### PR TITLE
feat: grant subagents access to parent's project directory via --add-dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ Thumbs.db
 .mcp.json
 .playwright-mcp/
 *.screenstudio/
+
+.worktrees

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -563,9 +563,9 @@ func handleAdd(profile string, args []string) {
 		newInstance = session.NewInstance(sessionTitle, path)
 	}
 
-	// Set parent if specified
+	// Set parent if specified (includes parent's project path for --add-dir access)
 	if parentInstance != nil {
-		newInstance.SetParent(parentInstance.ID)
+		newInstance.SetParentWithPath(parentInstance.ID, parentInstance.ProjectPath)
 	}
 
 	// Set command if provided

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1038,8 +1038,8 @@ func handleSessionSetParent(profile string, args []string) {
 		}
 	}
 
-	// Set parent and inherit group
-	inst.SetParent(parentInst.ID)
+	// Set parent (with project path for --add-dir access) and inherit group
+	inst.SetParentWithPath(parentInst.ID, parentInst.ProjectPath)
 	inst.GroupPath = parentInst.GroupPath
 
 	// Save


### PR DESCRIPTION
## Summary
- Adds `--add-dir` flag to subagent Claude commands, granting access to parent's project directory
- Useful for worktrees and other scenarios where subagents need access to the main project
- Stores parent project path in `ParentProjectPath` field via `SetParentWithPath()`

## Test plan
- [x] Unit tests for `buildClaudeCommand` with `--add-dir` flag
- [x] Verify standalone agents don't have `--add-dir`
- [x] Verify subagents with parent path get `--add-dir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)