### PR TITLE
fix: analytics path encoding to match Claude Code naming convention

### DIFF
--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -12,6 +12,17 @@ import (
 	"time"
 )
 
+// claudeDirNameRegex matches any character that's not alphanumeric or hyphen
+// Claude Code replaces all such characters with hyphens in project directory names
+var claudeDirNameRegex = regexp.MustCompile(`[^a-zA-Z0-9-]`)
+
+// ConvertToClaudeDirName converts a filesystem path to Claude's directory naming format.
+// Claude Code replaces all non-alphanumeric characters (except hyphens) with hyphens.
+// Example: /Users/master/Code cloud/!Project → -Users-master-Code-cloud--Project
+func ConvertToClaudeDirName(path string) string {
+	return claudeDirNameRegex.ReplaceAllString(path, "-")
+}
+
 // ClaudeProject represents a project entry in Claude's config
 type ClaudeProject struct {
 	LastSessionId string `json:"lastSessionId"`
@@ -301,8 +312,9 @@ func GetClaudeSessionID(projectPath string) (string, error) {
 // This finds the CURRENTLY RUNNING session, not the last completed one
 func findActiveSessionID(configDir, projectPath string) string {
 	// Convert project path to Claude's directory format
-	// /Users/ashesh/claude-deck -> -Users-ashesh-claude-deck
-	projectDirName := strings.ReplaceAll(projectPath, "/", "-")
+	// Claude replaces ALL non-alphanumeric chars (spaces, !, etc.) with hyphens
+	// /Users/master/Code cloud/!Project -> -Users-master-Code-cloud--Project
+	projectDirName := ConvertToClaudeDirName(projectPath)
 	projectDir := filepath.Join(configDir, "projects", projectDirName)
 
 	// Check if project directory exists

--- a/internal/session/claude_test.go
+++ b/internal/session/claude_test.go
@@ -428,3 +428,61 @@ func TestClearMCPCache_ClearsParentDirectories(t *testing.T) {
 		t.Error("parent directory cache should be cleared but wasn't")
 	}
 }
+
+func TestConvertToClaudeDirName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple path",
+			input:    "/Users/test/project",
+			expected: "-Users-test-project",
+		},
+		{
+			name:     "path with space",
+			input:    "/Users/test/My Project",
+			expected: "-Users-test-My-Project",
+		},
+		{
+			name:     "path with exclamation mark",
+			input:    "/Users/test/!Contributions",
+			expected: "-Users-test--Contributions",
+		},
+		{
+			name:     "path with multiple special chars",
+			input:    "/Users/test/Code cloud/!Dir",
+			expected: "-Users-test-Code-cloud--Dir",
+		},
+		{
+			name:     "real world example",
+			input:    "/Users/master/Dropbox/LLM x AWST/project",
+			expected: "-Users-master-Dropbox-LLM-x-AWST-project",
+		},
+		{
+			name:     "path with dots",
+			input:    "/Users/test/.hidden/file.txt",
+			expected: "-Users-test--hidden-file-txt",
+		},
+		{
+			name:     "path with parentheses",
+			input:    "/Users/test/(backup)/data",
+			expected: "-Users-test--backup--data",
+		},
+		{
+			name:     "preserves existing hyphens",
+			input:    "/Users/test/my-project-name",
+			expected: "-Users-test-my-project-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertToClaudeDirName(tt.input)
+			if got != tt.expected {
+				t.Errorf("ConvertToClaudeDirName(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -965,8 +965,9 @@ func (i *Instance) GetJSONLPath() string {
 	}
 
 	// Convert project path to Claude's directory format
-	// /Users/ashesh/claude-deck -> -Users-ashesh-claude-deck
-	projectDirName := strings.ReplaceAll(resolvedPath, "/", "-")
+	// Claude replaces ALL non-alphanumeric chars (spaces, !, etc.) with hyphens
+	// /Users/master/Code cloud/!Project -> -Users-master-Code-cloud--Project
+	projectDirName := ConvertToClaudeDirName(resolvedPath)
 	projectDir := filepath.Join(configDir, "projects", projectDirName)
 
 	// Build the JSONL file path
@@ -996,8 +997,9 @@ func (i *Instance) getClaudeLastResponse() (*ResponseOutput, error) {
 	}
 
 	// Convert project path to Claude's directory format
-	// /Users/ashesh/claude-deck -> -Users-ashesh-claude-deck
-	projectDirName := strings.ReplaceAll(resolvedPath, "/", "-")
+	// Claude replaces ALL non-alphanumeric chars (spaces, !, etc.) with hyphens
+	// /Users/master/Code cloud/!Project -> -Users-master-Code-cloud--Project
+	projectDirName := ConvertToClaudeDirName(resolvedPath)
 	projectDir := filepath.Join(configDir, "projects", projectDirName)
 
 	// Use stored session ID directly

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1399,7 +1399,7 @@ func TestInstance_GetJSONLPath(t *testing.T) {
 
 		// Create mock Claude config structure using the RESOLVED path
 		claudeDir := filepath.Join(tempDir, ".claude")
-		projectDirName := strings.ReplaceAll(resolvedPath, "/", "-")
+		projectDirName := ConvertToClaudeDirName(resolvedPath)
 		claudeProjectDir := filepath.Join(claudeDir, "projects", projectDirName)
 		if err := os.MkdirAll(claudeProjectDir, 0755); err != nil {
 			t.Fatalf("Failed to create claude project dir: %v", err)


### PR DESCRIPTION
## Summary
- Fix path encoding mismatch causing Analytics to show "Loading..." forever for projects with spaces or special characters in path
- Add `ConvertToClaudeDirName()` helper function using regex `[^a-zA-Z0-9-]`
- Update `GetJSONLPath()`, `getClaudeLastResponse()`, `findActiveSessionID()` to use the new helper
- Add comprehensive tests (8 test cases)

## Test plan
- [x] Run `go test ./internal/session/... -run "TestConvertToClaudeDirName" -v` - all 8 tests pass
- [x] Run full session package tests - all pass
- [x] Build succeeds

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)