### PR TITLE
fix: update tmux status bar when session is renamed

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3506,6 +3506,11 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				// Find and rename the session (O(1) lookup)
 				if inst := h.getInstanceByID(sessionID); inst != nil {
 					inst.Title = newName
+					// Update tmux status bar with new name
+					if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
+						tmuxSess.DisplayName = newName
+						tmuxSess.ConfigureStatusBar()
+					}
 				}
 				// Invalidate preview cache since title changed
 				h.invalidatePreviewCache(sessionID)


### PR DESCRIPTION
## Summary
- Fixed a bug where renaming a session with 'r' key only updated internal state but not the tmux status bar
- The status bar now immediately reflects the new session name after rename

## Test plan
- [x] Create a new session
- [x] Attach to the session and note the session name in bottom-right status bar
- [x] Detach and rename the session using 'r' key
- [x] Re-attach and verify the status bar shows the updated name

🤖 Generated with [Claude Code](https://claude.com/claude-code)