### PR TITLE
fix: align session name input CharLimit with validation limit

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -43,7 +43,7 @@ func NewNewDialog() *NewDialog {
 	nameInput := textinput.New()
 	nameInput.Placeholder = "session-name"
 	nameInput.Focus()
-	nameInput.CharLimit = 100
+	nameInput.CharLimit = 50
 	nameInput.Width = 40
 
 	// Create path input


### PR DESCRIPTION
## Summary
- Fixed mismatch between `nameInput.CharLimit` (100) and `Validate()` limit (50)
- Users could paste long strings from clipboard but Enter would silently fail
- Now both limits are aligned at 50, truncating input at paste time

## Problem
When creating/renaming a session:
1. User pastes a long name from clipboard (e.g., 80 characters)
2. Text appears in full (CharLimit was 100)
3. User presses Enter
4. Nothing happens because `Validate()` rejects names > 50 characters

## Solution
Set `nameInput.CharLimit = 50` to match the validation limit, so clipboard paste is automatically truncated.

## Test plan
- [x] Build passes
- [x] Existing tests pass
- [ ] Manual test: paste long string in session name field, verify truncation at 50 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)