### PR TITLE
fix(claude): Resume with empty ID opens picker instead of generating random UUID

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -308,7 +308,8 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 					`tmux set-environment CLAUDE_SESSION_ID "%s"; %sexec claude --session-id "%s"%s`,
 					opts.ResumeSessionID, bashExportPrefix, opts.ResumeSessionID, extraFlags)
 			}
-			// Fall through to default if no ID provided
+			// No session ID provided - use -r flag for interactive picker
+			return fmt.Sprintf(`%s%s -r%s`, configDirPrefix, claudeCmd, extraFlags)
 		}
 
 		// Default: new session with capture-resume pattern


### PR DESCRIPTION
## Summary

When selecting "Resume" session mode in the New Session dialog with an **empty session ID field**, the previous behavior was to fall through to default (new session), generating a random UUID with `uuidgen`.

**Expected:** Run `claude -r` which opens the interactive session picker
**Actual (before fix):** Generated random UUID and ran `claude --session-id <random-uuid>`

## Changes

- Modified `internal/session/instance.go` to return `claude -r` command when Resume mode is selected but no session ID is provided
- This allows users to select which session to resume from the Claude CLI picker

## Test

1. Open agent-deck TUI
2. Press `n` for New Session
3. Select `claude` as command
4. Select `Resume` for Session mode
5. Leave ID field empty
6. Press Enter

**Before:** Starts new session with random UUID
**After:** Opens `claude -r` interactive picker

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>