### PR TITLE
fix: detect 'Action Required' and other Claude permission prompts

### DIFF
--- a/internal/tmux/detector.go
+++ b/internal/tmux/detector.go
@@ -162,6 +162,9 @@ func (d *PromptDetector) hasClaudePrompt(content string) bool {
 		// Tool permission prompts
 		"Run this command?",
 		"Execute this?",
+		"Action Required",
+		"Waiting for user confirmation",
+		"Allow execution of",
 	}
 	for _, prompt := range permissionPrompts {
 		if strings.Contains(content, prompt) {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -111,6 +111,9 @@ func TestPromptDetector(t *testing.T) {
 		{"No, and tell Claude what to do differently", true},
 		{"Yes, allow once", true},
 		{"❯ Yes", true},
+		{"Action Required", true},
+		{"Waiting for user confirmation", true},
+		{"Allow execution of: 'npm'?", true},
 		// Input prompt (--dangerously-skip-permissions mode)
 		{">", true},
 		{"> ", true},


### PR DESCRIPTION
### Overview
This PR fixes a bug where Claude Code sessions showing an "Action Required" dialog (or other permission prompts) were incorrectly identified as **running** (●) instead of **waiting** (◐).

### Changes
- Updated `hasClaudePrompt` in `internal/tmux/detector.go` to include patterns like "Action Required", "Waiting for user confirmation", and "Allow execution of".
- Added regression tests in `internal/tmux/tmux_test.go` to cover these cases.

### Verification
- Passed unit tests for `PromptDetector`.
- Manual verification confirms that the TUI status indicator now correctly reflects the waiting state during permission prompts.