### PR TITLE
feat(ui): implement path autocomplete in New Session dialog

### DIFF
--- a/internal/session/utils.go
+++ b/internal/session/utils.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -27,4 +28,100 @@ func findNewestFile(pattern string) (string, time.Time) {
 		}
 	}
 	return newestPath, newestTime
+}
+
+// GetDirectoryCompletions returns a list of directories that match the input prefix.
+// Supports absolute, relative, and tilde-prefixed (~) paths.
+func GetDirectoryCompletions(input string) ([]string, error) {
+	if input == "" {
+		return nil, nil
+	}
+
+	// Handle tilde-prefixed paths
+	originalInput := input
+	if strings.HasPrefix(input, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		input = filepath.Join(home, input[1:])
+	}
+
+	// Determine the directory to scan and the prefix to match
+	var dir, prefix string
+	if info, err := os.Stat(input); err == nil && info.IsDir() {
+		// Exact directory match - return itself
+		return []string{originalInput}, nil
+	}
+
+	dir = filepath.Dir(input)
+	prefix = filepath.Base(input)
+
+	// Special case: if input ends with a separator, we want to scan THAT directory
+	if strings.HasSuffix(originalInput, string(os.PathSeparator)) {
+		dir = input
+		prefix = ""
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil // Silently ignore errors (e.g. invalid parent dir)
+	}
+
+	var matches []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if strings.HasPrefix(name, prefix) {
+			match := filepath.Join(dir, name)
+			
+			// If original input used tilde, convert back
+			if strings.HasPrefix(originalInput, "~") {
+				home, _ := os.UserHomeDir()
+				rel, err := filepath.Rel(home, match)
+				if err == nil && !strings.HasPrefix(rel, "..") {
+					match = "~" + string(os.PathSeparator) + rel
+				}
+			}
+			matches = append(matches, match)
+		}
+	}
+
+	return matches, nil
+}
+
+// CompletionCycler manages the state of directory autocomplete.
+type CompletionCycler struct {
+	matches []string
+	index   int
+}
+
+// IsActive returns true if the cycler has active matches.
+func (c *CompletionCycler) IsActive() bool {
+	return len(c.matches) > 0
+}
+
+// Reset clears the cycler state.
+func (c *CompletionCycler) Reset() {
+	c.matches = nil
+	c.index = -1
+}
+
+// SetMatches sets the matches for the cycler and resets the index.
+func (c *CompletionCycler) SetMatches(matches []string) {
+	c.matches = matches
+	c.index = -1
+}
+
+// Next returns the next match in the cycle.
+// Wraps around to the beginning if the end is reached.
+func (c *CompletionCycler) Next() string {
+	if !c.IsActive() {
+		return ""
+	}
+	c.index = (c.index + 1) % len(c.matches)
+	return c.matches[c.index]
 }

--- a/internal/session/utils_test.go
+++ b/internal/session/utils_test.go
@@ -1,0 +1,105 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDirectoryCompletions(t *testing.T) {
+	// Setup temporary directory structure
+	tmpDir := t.TempDir()
+	
+	// Create some directories
+	dirs := []string{
+		"projects",
+		"playground",
+		"personal",
+		"work/agent-deck",
+		"work/other",
+	}
+	for _, d := range dirs {
+		err := os.MkdirAll(filepath.Join(tmpDir, d), 0755)
+		require.NoError(t, err)
+	}
+	
+	// Create some files (should be ignored)
+	files := []string{
+		"README.md",
+		"projects/todo.txt",
+	}
+	for _, f := range files {
+		err := os.WriteFile(filepath.Join(tmpDir, f), []byte("test"), 0644)
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "Absolute path prefix",
+			input:    filepath.Join(tmpDir, "p"),
+			expected: []string{filepath.Join(tmpDir, "personal"), filepath.Join(tmpDir, "playground"), filepath.Join(tmpDir, "projects")},
+		},
+		{
+			name:     "Nested absolute path",
+			input:    filepath.Join(tmpDir, "work/a"),
+			expected: []string{filepath.Join(tmpDir, "work/agent-deck")},
+		},
+		{
+			name:     "No matches",
+			input:    filepath.Join(tmpDir, "xyz"),
+			expected: nil,
+		},
+		{
+			name:     "Exact match directory (should return itself and any subdirs starting with it)",
+			input:    filepath.Join(tmpDir, "projects"),
+			expected: []string{filepath.Join(tmpDir, "projects")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := GetDirectoryCompletions(tt.input)
+			assert.NoError(t, err)
+			sort.Strings(results)
+			sort.Strings(tt.expected)
+			assert.Equal(t, tt.expected, results)
+		})
+	}
+}
+
+func TestCompletionCycler(t *testing.T) {
+	cycler := &CompletionCycler{}
+	
+	// 1. Initial state
+	assert.Equal(t, "", cycler.Next())
+	
+	// 2. Set matches and cycle
+	matches := []string{"/a", "/b", "/c"}
+	cycler.SetMatches(matches)
+	assert.True(t, cycler.IsActive())
+	
+	assert.Equal(t, "/a", cycler.Next())
+	assert.Equal(t, "/b", cycler.Next())
+	assert.Equal(t, "/c", cycler.Next())
+	
+	// 3. Wrap around
+	assert.Equal(t, "/a", cycler.Next())
+	
+	// 4. Reset
+	cycler.Reset()
+	assert.False(t, cycler.IsActive())
+	assert.Equal(t, "", cycler.Next())
+	
+	// 5. Change matches
+	cycler.SetMatches([]string{"/x"})
+	assert.Equal(t, "/x", cycler.Next())
+	assert.Equal(t, "/x", cycler.Next())
+}


### PR DESCRIPTION
### Overview
This PR adds shell-like Tab autocomplete to the Project Path field in the New Session dialog.

### Key Features
- **Tab Autocomplete**: Pressing Tab triggers directory autocomplete based on the current input.
- **Match Cycling**: Subsequent Tab presses cycle through multiple matching directories.
- **Tilde Support**: Correctly handles and resolves `~` paths.
- **Smart Focus**: Only triggers autocomplete if the path is partial or cycler is active; otherwise, Tab advances focus as usual.
- **Cursor Management**: Automatically moves the cursor to the end of the input upon completion.

### Verification
- Unit tests for the completion utility and cycler logic.
- Verified field navigation remains functional.