### PR TITLE
feat: add custom wrapper command support for sessions

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -492,6 +492,7 @@ func handleAdd(profile string, args []string) {
 	groupShort := fs.String("g", "", "Group path (short)")
 	command := fs.String("cmd", "", "Command to run (e.g., 'claude', 'opencode')")
 	commandShort := fs.String("c", "", "Command to run (short)")
+	wrapper := fs.String("wrapper", "", "Wrapper command (use {command} to include tool command, e.g., 'nvim +\"terminal {command}\"')")
 	parent := fs.String("parent", "", "Parent session (creates sub-session, inherits group)")
 	parentShort := fs.String("p", "", "Parent session (short)")
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
@@ -531,6 +532,7 @@ func handleAdd(profile string, args []string) {
 		fmt.Println("  agent-deck -p work add               # Add to 'work' profile")
 		fmt.Println("  agent-deck add -t \"Sub-task\" --parent \"Main Project\"  # Create sub-session")
 		fmt.Println("  agent-deck add -t \"Research\" -c claude --mcp memory --mcp sequential-thinking /tmp/x")
+		fmt.Println("  agent-deck add -c opencode --wrapper \"nvim +'terminal {command}' +'startinsert'\" .")
 		fmt.Println()
 		fmt.Println("Worktree Examples:")
 		fmt.Println("  agent-deck add -w feature/login .    # Create worktree for existing branch")
@@ -728,6 +730,11 @@ func handleAdd(profile string, args []string) {
 		} else {
 			newInstance.Command = sessionCommand
 		}
+	}
+
+	// Set wrapper if provided
+	if *wrapper != "" {
+		newInstance.Wrapper = *wrapper
 	}
 
 	// Set worktree fields if created

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -101,6 +101,7 @@ func printSessionHelp() {
 	fmt.Println("  path               Project path")
 	fmt.Println("  command            Command to run")
 	fmt.Println("  tool               Tool type (claude, gemini, shell, etc.)")
+	fmt.Println("  wrapper            Wrapper command (use {command} to include tool command)")
 	fmt.Println("  claude-session-id  Claude conversation ID (for fork/resume)")
 	fmt.Println("  gemini-session-id  Gemini conversation ID (for resume)")
 	fmt.Println()
@@ -108,6 +109,7 @@ func printSessionHelp() {
 	fmt.Println("  agent-deck session set my-project title \"New Title\"")
 	fmt.Println("  agent-deck session set my-project claude-session-id \"abc123-def456\"")
 	fmt.Println("  agent-deck session set my-project tool claude")
+	fmt.Println("  agent-deck session set my-project wrapper \"nvim +'terminal {command}'\"")
 }
 
 // handleSessionStart starts a session's tmux process
@@ -773,6 +775,7 @@ func handleSessionSet(profile string, args []string) {
 		fmt.Println("  path               Project path")
 		fmt.Println("  command            Command to run")
 		fmt.Println("  tool               Tool type (claude, gemini, shell, etc.)")
+		fmt.Println("  wrapper            Wrapper command (use {command} to include tool command)")
 		fmt.Println("  claude-session-id  Claude conversation ID")
 		fmt.Println("  gemini-session-id  Gemini conversation ID")
 		fmt.Println()
@@ -783,6 +786,7 @@ func handleSessionSet(profile string, args []string) {
 		fmt.Println("  agent-deck session set my-project title \"New Title\"")
 		fmt.Println("  agent-deck session set my-project claude-session-id \"abc123-def456\"")
 		fmt.Println("  agent-deck session set my-project path /new/path/to/project")
+		fmt.Println("  agent-deck session set my-project wrapper \"nvim +'terminal {command}'\"")
 	}
 
 	if err := fs.Parse(args); err != nil {
@@ -806,12 +810,13 @@ func handleSessionSet(profile string, args []string) {
 		"path":               true,
 		"command":            true,
 		"tool":               true,
+		"wrapper":            true,
 		"claude-session-id":  true,
 		"gemini-session-id":  true,
 	}
 
 	if !validFields[field] {
-		out.Error(fmt.Sprintf("invalid field: %s\nValid fields: title, path, command, tool, claude-session-id, gemini-session-id", field), ErrCodeInvalidOperation)
+		out.Error(fmt.Sprintf("invalid field: %s\nValid fields: title, path, command, tool, wrapper, claude-session-id, gemini-session-id", field), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
 
@@ -851,6 +856,9 @@ func handleSessionSet(profile string, args []string) {
 	case "tool":
 		oldValue = inst.Tool
 		inst.Tool = value
+	case "wrapper":
+		oldValue = inst.Wrapper
+		inst.Wrapper = value
 	case "claude-session-id":
 		oldValue = inst.ClaudeSessionID
 		inst.ClaudeSessionID = value

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -65,6 +65,7 @@ type InstanceData struct {
 	Order           int       `json:"order"`
 	ParentSessionID string    `json:"parent_session_id,omitempty"` // Links to parent session (sub-session support)
 	Command         string    `json:"command"`
+	Wrapper         string    `json:"wrapper,omitempty"`
 	Tool            string    `json:"tool"`
 	Status          Status    `json:"status"`
 	CreatedAt       time.Time `json:"created_at"`
@@ -220,6 +221,7 @@ func (s *Storage) SaveWithGroups(instances []*Instance, groupTree *GroupTree) er
 			Order:              inst.Order,
 			ParentSessionID:    inst.ParentSessionID,
 			Command:            inst.Command,
+			Wrapper:            inst.Wrapper,
 			Tool:               inst.Tool,
 			Status:             inst.Status,
 			CreatedAt:          inst.CreatedAt,
@@ -558,6 +560,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			Order:              instData.Order,
 			ParentSessionID:    instData.ParentSessionID,
 			Command:            instData.Command,
+			Wrapper:            instData.Wrapper,
 			Tool:               instData.Tool,
 			Status:             instData.Status,
 			CreatedAt:          instData.CreatedAt,

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -404,6 +404,11 @@ type ToolDef struct {
 	// Command is the shell command to run
 	Command string `toml:"command"`
 
+	// Wrapper is an optional command that wraps the tool command.
+	// Use {command} placeholder to include the tool command, or omit it to replace the command.
+	// Example: wrapper = "nvim +'terminal {command}' +'startinsert'"
+	Wrapper string `toml:"wrapper"`
+
 	// Icon is the emoji/symbol to display
 	Icon string `toml:"icon"`
 


### PR DESCRIPTION
## Summary

Related to #131 - extends wrapper support with consistent application across all session methods.

- Add Wrapper field to ToolDef (config.toml) and Instance (per-session)
- Add `applyWrapper()` helper to centralize wrapper logic
- Apply wrapper in `Start()`, `StartWithMessage()`, `Restart()` (all paths), and `ForkWithOptions()`
- Make `{command}` placeholder optional - if omitted, wrapper fully replaces the tool command

## Use Cases

**1. Wrap tool in terminal emulator:**
```toml
[tools.opencode]
command = "opencode"
wrapper = "nvim +'terminal {command}' +'startinsert'"
```

**2. Editor-driven flow (nvim plugin manages tool):**
```toml
[tools.opencode]
command = "opencode"
wrapper = "nvim +'lua require(\"opencode\").toggle()'"
```

## Changes

- Add `applyWrapper()` helper to centralize wrapper logic
- Apply wrapper in `Start()`, `StartWithMessage()`, `Restart()` (all paths), and `ForkWithOptions()`
- Update help text to reflect optional `{command}`

## Testing

Tested locally by updating `~/.agent-deck/config.toml` with the configurations shown above and verifying:
- New sessions start with wrapper applied
- Restart preserves wrapper behavior
- Editor-driven flow (without `{command}`) works correctly