### PR TITLE
feat: add [tmux] config section for session options

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -215,11 +215,20 @@ func (inst *Instance) ClearParent() {
 	inst.ParentProjectPath = ""
 }
 
+// applyTmuxConfig applies user's tmux configuration to a tmux session.
+// This is called when creating new instances to ensure config is applied before Start().
+func applyTmuxConfig(tmuxSess *tmux.Session) {
+	tmuxSess.TmuxConfig = tmux.TmuxConfig(GetTmuxSettings())
+}
+
 // NewInstance creates a new session instance
 func NewInstance(title, projectPath string) *Instance {
 	id := generateID()
 	tmuxSess := tmux.NewSession(title, projectPath)
 	tmuxSess.InstanceID = id // Pass instance ID for activity hooks
+
+	// Apply user's tmux configuration
+	applyTmuxConfig(tmuxSess)
 
 	return &Instance{
 		ID:          id,
@@ -245,6 +254,9 @@ func NewInstanceWithTool(title, projectPath, tool string) *Instance {
 	id := generateID()
 	tmuxSess := tmux.NewSession(title, projectPath)
 	tmuxSess.InstanceID = id // Pass instance ID for activity hooks
+
+	// Apply user's tmux configuration
+	applyTmuxConfig(tmuxSess)
 
 	inst := &Instance{
 		ID:          id,
@@ -2459,6 +2471,9 @@ func (i *Instance) Restart() error {
 	// Fallback: recreate tmux session (for dead sessions or unknown ID)
 	i.tmuxSession = tmux.NewSession(i.Title, i.ProjectPath)
 	i.tmuxSession.InstanceID = i.ID // Pass instance ID for activity hooks
+
+	// Apply user's tmux configuration
+	applyTmuxConfig(i.tmuxSession)
 
 	var command string
 	if i.Tool == "claude" && i.ClaudeSessionID != "" {

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -83,6 +83,9 @@ type UserConfig struct {
 
 	// Status defines session status detection settings
 	Status StatusSettings `toml:"status"`
+
+	// Tmux defines tmux session configuration
+	Tmux TmuxSettings `toml:"tmux"`
 }
 
 // MCPPoolSettings defines HTTP MCP pool configuration
@@ -417,6 +420,11 @@ type CodexSettings struct {
 	// Default: false
 	YoloMode bool `toml:"yolo_mode"`
 }
+
+// TmuxSettings defines tmux session configuration as a map of option name to value.
+// Keys use tmux's native hyphenated names (e.g., "history-limit", "escape-time").
+// Common options: mouse, history-limit, escape-time, set-clipboard, allow-passthrough.
+type TmuxSettings map[string]string
 
 // WorktreeSettings contains git worktree preferences.
 type WorktreeSettings struct {
@@ -983,6 +991,30 @@ func GetWorktreeSettings() WorktreeSettings {
 	return settings
 }
 
+// GetTmuxSettings returns tmux settings with defaults applied.
+// Defaults: mouse=on, history-limit=10000, escape-time=10, set-clipboard=on, allow-passthrough=on.
+func GetTmuxSettings() TmuxSettings {
+	defaults := TmuxSettings{
+		"mouse":            "on",
+		"history-limit":    "10000",
+		"escape-time":      "10",
+		"set-clipboard":    "on",
+		"allow-passthrough": "on",
+	}
+
+	config, err := LoadUserConfig()
+	if err != nil || config == nil {
+		return defaults
+	}
+
+	// Merge user settings over defaults
+	for key, value := range config.Tmux {
+		defaults[key] = value
+	}
+
+	return defaults
+}
+
 // GetUpdateSettings returns update settings with defaults applied
 func GetUpdateSettings() UpdateSettings {
 	config, err := LoadUserConfig()
@@ -1217,6 +1249,17 @@ max_size_mb = 10
 max_lines = 10000
 # Remove log files for sessions that no longer exist (default: true)
 remove_orphans = true
+
+# Tmux session configuration
+# Set any tmux option using its native name (hyphens, not underscores)
+# [tmux]
+# mouse = "on"               # Mouse support (default: on)
+# history-limit = "10000"    # Scrollback buffer (default: 10000)
+# escape-time = "10"         # Escape timeout in ms (default: 10, lower = faster Vim)
+# set-clipboard = "on"       # OSC 52 clipboard (default: on)
+# allow-passthrough = "on"   # OSC 8 hyperlinks (default: on, requires tmux 3.2+)
+# focus-events = "on"        # Any other tmux option works too
+# default-terminal = "tmux-256color"
 
 # Update settings
 # Controls automatic update checking and installation

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -937,6 +937,7 @@ All options for `~/.agent-deck/config.toml`.
 - [Top-Level](#top-level)
 - [[claude] Section](#claude-section)
 - [[logs] Section](#logs-section)
+- [[tmux] Section](#tmux-section)
 - [[updates] Section](#updates-section)
 - [[global_search] Section](#global_search-section)
 - [[mcp_pool] Section](#mcp_pool-section)
@@ -982,6 +983,30 @@ remove_orphans = true   # Delete logs for removed sessions
 | `remove_orphans` | bool | `true` | Clean up logs for deleted sessions. |
 
 **Logs location:** `~/.agent-deck/logs/agentdeck_<session>_<id>.log`
+
+## [tmux] Section
+
+Tmux session configuration. Set any tmux option using its native hyphenated name.
+
+```toml
+[tmux]
+mouse = "on"               # Mouse support (default: on)
+history-limit = "10000"    # Scrollback buffer (default: 10000)
+escape-time = "10"         # Escape timeout in ms (default: 10)
+set-clipboard = "on"       # OSC 52 clipboard (default: on)
+allow-passthrough = "on"   # OSC 8 hyperlinks (default: on)
+focus-events = "on"        # Any tmux option works
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `mouse` | `"on"` | Mouse support: `"on"` or `"off"`. |
+| `history-limit` | `"10000"` | Scrollback buffer size in lines. |
+| `escape-time` | `"10"` | Escape timeout in ms. Lower = faster Vim. |
+| `set-clipboard` | `"on"` | Clipboard: `"on"`, `"off"`, or `"external"`. |
+| `allow-passthrough` | `"on"` | Escape passthrough for hyperlinks. Requires tmux 3.2+. |
+
+Any valid tmux option can be set here.
 
 ## [updates] Section
 
@@ -1188,6 +1213,10 @@ dangerous_mode = true
 max_size_mb = 10
 max_lines = 10000
 remove_orphans = true
+
+[tmux]
+history-limit = "50000"
+escape-time = "0"
 
 [updates]
 check_enabled = true

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -8,6 +8,7 @@ All options for `~/.agent-deck/config.toml`.
 - [[claude] Section](#claude-section)
 - [[codex] Section](#codex-section)
 - [[logs] Section](#logs-section)
+- [[tmux] Section](#tmux-section)
 - [[updates] Section](#updates-section)
 - [[global_search] Section](#global_search-section)
 - [[mcp_pool] Section](#mcp_pool-section)
@@ -66,6 +67,30 @@ remove_orphans = true   # Delete logs for removed sessions
 | `remove_orphans` | bool | `true` | Clean up logs for deleted sessions. |
 
 **Logs location:** `~/.agent-deck/logs/agentdeck_<session>_<id>.log`
+
+## [tmux] Section
+
+Tmux session configuration. Set any tmux option using its native hyphenated name.
+
+```toml
+[tmux]
+mouse = "on"               # Mouse support (default: on)
+history-limit = "10000"    # Scrollback buffer (default: 10000)
+escape-time = "10"         # Escape timeout in ms (default: 10)
+set-clipboard = "on"       # OSC 52 clipboard (default: on)
+allow-passthrough = "on"   # OSC 8 hyperlinks (default: on)
+focus-events = "on"        # Any tmux option works
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `mouse` | `"on"` | Mouse support: `"on"` or `"off"`. |
+| `history-limit` | `"10000"` | Scrollback buffer size in lines. |
+| `escape-time` | `"10"` | Escape timeout in ms. Lower = faster Vim. |
+| `set-clipboard` | `"on"` | Clipboard: `"on"`, `"off"`, or `"external"`. |
+| `allow-passthrough` | `"on"` | Escape passthrough for hyperlinks. Requires tmux 3.2+. |
+
+Any valid tmux option can be set here. Use `tmux show-options` to see available options.
 
 ## [updates] Section
 
@@ -275,6 +300,10 @@ yolo_mode = false
 max_size_mb = 10
 max_lines = 10000
 remove_orphans = true
+
+[tmux]
+history-limit = "50000"
+escape-time = "0"
 
 [updates]
 check_enabled = true


### PR DESCRIPTION
Add configurable tmux options via config.toml [tmux] section. Uses tmux's native hyphenated option names as a flat map.

Defaults: mouse=on, history-limit=10000, escape-time=10, set-clipboard=on, allow-passthrough=on.

Any valid tmux option can be set, e.g.:
[tmux]
history-limit = "50000"
escape-time = "0"
focus-events = "on"

Closes #150 