### PR TITLE
Claude --allow-dangerously-skip-permissions config

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -381,17 +381,22 @@ type ClaudeSettings struct {
 	// Power users typically want this enabled for faster iteration
 	DangerousMode *bool `toml:"dangerous_mode"`
 
+	// AllowDangerousMode enables --allow-dangerously-skip-permissions flag
+	// This unlocks bypass as an option without activating it by default.
+	// Ignored when dangerous_mode is true (the stronger flag takes precedence).
+	// Default: false
+	AllowDangerousMode bool `toml:"allow_dangerous_mode"`
+
 	// EnvFile is a .env file specific to Claude sessions
 	// Sourced AFTER global [shell].env_files
 	// Path can be absolute, ~ for home, or relative to session working directory
 	EnvFile string `toml:"env_file"`
 }
 
-// GetDangerousMode returns whether dangerous mode is enabled, defaulting to true
-// This provides a safe getter that handles the nil case (config not set)
+// GetDangerousMode returns whether dangerous mode is enabled, defaulting to false
 func (c *ClaudeSettings) GetDangerousMode() bool {
 	if c.DangerousMode == nil {
-		return true // Default: ON for power users
+		return false
 	}
 	return *c.DangerousMode
 }

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -572,6 +572,39 @@ max_shown = 8
 	}
 }
 
+func TestClaudeSettings_AllowDangerousMode_TOML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configContent := `
+[claude]
+dangerous_mode = false
+allow_dangerous_mode = true
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	var config UserConfig
+	_, err := toml.DecodeFile(configPath, &config)
+	if err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+
+	if config.Claude.GetDangerousMode() {
+		t.Error("Expected dangerous_mode false")
+	}
+	if !config.Claude.AllowDangerousMode {
+		t.Error("Expected allow_dangerous_mode true")
+	}
+}
+
+func TestClaudeSettings_AllowDangerousMode_Default(t *testing.T) {
+	var config UserConfig
+	if config.Claude.AllowDangerousMode {
+		t.Error("allow_dangerous_mode should default to false")
+	}
+}
+
 func TestGetNotificationsSettings_PartialConfig(t *testing.T) {
 	// Test that missing fields get defaults
 	tempDir := t.TempDir()

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3024,11 +3024,13 @@ func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd
 		inst := session.NewInstanceWithGroupAndTool(title, projectPath, h.getCurrentGroupPath(), "claude")
 		inst.ClaudeSessionID = result.SessionID
 
-		// Build resume command with config dir and dangerous mode
+		// Build resume command with config dir and permission flags
 		userConfig, _ := session.LoadUserConfig()
 		dangerousMode := false
+		allowDangerousMode := false
 		if userConfig != nil {
 			dangerousMode = userConfig.Claude.GetDangerousMode()
+			allowDangerousMode = userConfig.Claude.AllowDangerousMode
 		}
 
 		// Build command - only set CLAUDE_CONFIG_DIR if explicitly configured
@@ -3044,6 +3046,8 @@ func (h *Home) createSessionFromGlobalSearch(result *GlobalSearchResult) tea.Cmd
 		cmdBuilder.WriteString(result.SessionID)
 		if dangerousMode {
 			cmdBuilder.WriteString(" --dangerously-skip-permissions")
+		} else if allowDangerousMode {
+			cmdBuilder.WriteString(" --allow-dangerously-skip-permissions")
 		}
 		inst.Command = cmdBuilder.String()
 

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -26,14 +26,16 @@ Claude Code integration settings.
 
 ```toml
 [claude]
-config_dir = "~/.claude-work"   # Path to Claude config directory
-dangerous_mode = true           # Enable --dangerously-skip-permissions
+config_dir = "~/.claude-work"      # Path to Claude config directory
+dangerous_mode = true              # Enable --dangerously-skip-permissions
+allow_dangerous_mode = false       # Enable --allow-dangerously-skip-permissions
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `config_dir` | string | `~/.claude` | Claude config directory. Override with `CLAUDE_CONFIG_DIR` env. |
-| `dangerous_mode` | bool | `false` | Skip Claude permission dialogs. Required for automation. |
+| `dangerous_mode` | bool | `false` | Adds `--dangerously-skip-permissions`. Forces bypass on. Takes precedence over `allow_dangerous_mode`. |
+| `allow_dangerous_mode` | bool | `false` | Adds `--allow-dangerously-skip-permissions`. Unlocks bypass as an option without activating it. Ignored when `dangerous_mode` is true. |
 
 ## [codex] Section
 


### PR DESCRIPTION
Hi!
I'm using claude with yolo mode enabled but not set by default.
I noticed its not possible with the current agent-deck configuration.

This pr allows for more fine-grained control via `allow_dangerous_mode`.

Also I noticed there's a mismatch between the default value of `dangerous_mode` in the wizard and in code when the value is missing from the config, so I fixed that as well.

Let me know what you think @asheshgoplani and thanks for this awesome project!