### PR TITLE
feat: quick session creation with hovered-session inheritance (#161)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4681,19 +4681,74 @@ func (h *Home) quickForkSession(source *session.Instance) tea.Cmd {
 }
 
 // quickCreateSession creates a session instantly with auto-generated name and smart defaults.
-// Defaults are inherited from the most recent session in the current group.
+// When the cursor is on a session, it inherits that session's path and tool settings
+// (duplicate-like behavior per community feedback). When on a group header, it uses
+// the group's default path and most recently created session's settings.
 func (h *Home) quickCreateSession() tea.Cmd {
-	// Resolve group from cursor position
-	groupPath := h.getCurrentGroupPath()
+	groupPath := ""
+	var sourceSession *session.Instance
+
+	// Determine context from cursor position
+	if h.cursor >= 0 && h.cursor < len(h.flatItems) {
+		item := h.flatItems[h.cursor]
+		if item.Type == session.ItemTypeSession && item.Session != nil {
+			sourceSession = item.Session
+			groupPath = item.Session.GroupPath
+		} else if item.Type == session.ItemTypeGroup && item.Group != nil {
+			groupPath = item.Group.Path
+		}
+	}
 	if groupPath == "" {
 		groupPath = session.DefaultGroupPath
 	}
 
-	// Resolve path: group default → most recent session in group → cwd
-	projectPath := h.getDefaultPathForGroup(groupPath)
-	if projectPath == "" {
-		projectPath = h.mostRecentPathInGroup(groupPath)
+	projectPath := ""
+	tool := ""
+	command := ""
+	var toolOptionsJSON json.RawMessage
+	geminiYoloMode := false
+
+	if sourceSession != nil {
+		// Cursor on a session: inherit from THAT session (duplicate-like)
+		projectPath = sourceSession.ProjectPath
+		tool = sourceSession.Tool
+		command = sourceSession.Command
+		if len(sourceSession.ToolOptionsJSON) > 0 {
+			toolOptionsJSON = sourceSession.ToolOptionsJSON
+		}
+		if sourceSession.GeminiYoloMode != nil && *sourceSession.GeminiYoloMode {
+			geminiYoloMode = true
+		}
+	} else {
+		// Cursor on a group header: use group defaults + most recent session
+		projectPath = h.getDefaultPathForGroup(groupPath)
+		if projectPath == "" {
+			projectPath = h.mostRecentPathInGroup(groupPath)
+		}
+
+		h.instancesMu.RLock()
+		var mostRecent *session.Instance
+		for _, inst := range h.instances {
+			if inst.GroupPath == groupPath {
+				if mostRecent == nil || inst.CreatedAt.After(mostRecent.CreatedAt) {
+					mostRecent = inst
+				}
+			}
+		}
+		if mostRecent != nil {
+			tool = mostRecent.Tool
+			command = mostRecent.Command
+			if len(mostRecent.ToolOptionsJSON) > 0 {
+				toolOptionsJSON = mostRecent.ToolOptionsJSON
+			}
+			if mostRecent.GeminiYoloMode != nil && *mostRecent.GeminiYoloMode {
+				geminiYoloMode = true
+			}
+		}
+		h.instancesMu.RUnlock()
 	}
+
+	// Fallback for path
 	if projectPath == "" {
 		var err error
 		projectPath, err = os.Getwd()
@@ -4704,41 +4759,13 @@ func (h *Home) quickCreateSession() tea.Cmd {
 		}
 	}
 
-	// Resolve tool + options from most recent session in group
-	tool := ""
-	command := ""
-	var toolOptionsJSON json.RawMessage
-	geminiYoloMode := false
-
-	h.instancesMu.RLock()
-	var mostRecent *session.Instance
-	for _, inst := range h.instances {
-		if inst.GroupPath == groupPath {
-			if mostRecent == nil || inst.CreatedAt.After(mostRecent.CreatedAt) {
-				mostRecent = inst
-			}
-		}
-	}
-	if mostRecent != nil {
-		tool = mostRecent.Tool
-		command = mostRecent.Command
-		if len(mostRecent.ToolOptionsJSON) > 0 {
-			toolOptionsJSON = mostRecent.ToolOptionsJSON
-		}
-		if mostRecent.GeminiYoloMode != nil && *mostRecent.GeminiYoloMode {
-			geminiYoloMode = true
-		}
-	}
-	h.instancesMu.RUnlock()
-
-	// Fall back to user's configured default tool
+	// Fallback for tool
 	if tool == "" {
 		tool = session.GetDefaultTool()
 	}
 	if tool == "" {
 		tool = "claude"
 	}
-	// Ensure command matches tool if not inherited
 	if command == "" {
 		command = tool
 	}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -735,3 +735,45 @@ func TestNewDialog_ShowInGroup_ClearsError(t *testing.T) {
 		t.Error("ShowInGroup should clear validationErr")
 	}
 }
+
+// ===== Worktree Branch Auto-Matching Tests =====
+
+func TestNewDialog_ToggleWorktree_AutoPopulatesBranch(t *testing.T) {
+	d := NewNewDialog()
+	d.nameInput.SetValue("amber-falcon")
+
+	// Toggling worktree ON should auto-populate branch from session name
+	d.ToggleWorktree()
+
+	if !d.worktreeEnabled {
+		t.Fatal("worktreeEnabled should be true after toggle")
+	}
+	if d.branchInput.Value() != "feature/amber-falcon" {
+		t.Errorf("branch = %q, want %q", d.branchInput.Value(), "feature/amber-falcon")
+	}
+	if !d.branchAutoSet {
+		t.Error("branchAutoSet should be true after auto-population")
+	}
+}
+
+func TestNewDialog_ToggleWorktree_EmptyName_NoBranch(t *testing.T) {
+	d := NewNewDialog()
+	// Name is empty
+
+	d.ToggleWorktree()
+
+	if d.branchInput.Value() != "" {
+		t.Errorf("branch should be empty when name is empty, got %q", d.branchInput.Value())
+	}
+}
+
+func TestNewDialog_ShowInGroup_ResetsBranchAutoSet(t *testing.T) {
+	d := NewNewDialog()
+	d.branchAutoSet = true
+
+	d.ShowInGroup("projects", "Projects", "")
+
+	if d.branchAutoSet {
+		t.Error("branchAutoSet should be reset to false on ShowInGroup")
+	}
+}


### PR DESCRIPTION
## Summary
- Shift+N on a session now inherits that session's path, tool, and options (acts like duplicate)
- Shift+N on a group header still uses group defaults
- Worktree branch auto-populates as feature/<session-name> when toggling worktree on
- Manual branch edits disable auto-derivation

Closes #161

## Test plan
- [x] go test ./... passes (all 13 packages)
- [x] Shift+N on session inherits path/tool/options
- [x] Shift+N on group uses group defaults
- [x] Worktree branch auto-derives from name
- [x] Manual branch edit disables auto-derivation