### PR TITLE
feat: add top-level rename command

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -202,6 +202,9 @@ func main() {
 		case "remove", "rm":
 			handleRemove(profile, args[1:])
 			return
+		case "rename", "mv":
+			handleRename(profile, args[1:])
+			return
 		case "status":
 			handleStatus(profile, args[1:])
 			return
@@ -1271,6 +1274,77 @@ func handleRemove(profile string, args []string) {
 	)
 }
 
+func handleRename(profile string, args []string) {
+	fs := flag.NewFlagSet("rename", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck rename <id|title> <new-title>")
+		fmt.Println()
+		fmt.Println("Rename a session by ID or title.")
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck rename abc12345 \"New Name\"")
+		fmt.Println("  agent-deck rename \"Old Name\" \"New Name\"")
+		fmt.Println("  agent-deck -p work rename abc12345 \"New Name\"   # Rename in 'work' profile")
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	quietMode := *quiet || *quietShort
+	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	identifier := fs.Arg(0)
+	newTitle := fs.Arg(1)
+	if identifier == "" || newTitle == "" {
+		out.Error("session ID/title and new title are required", ErrCodeNotFound)
+		if !*jsonOutput {
+			fs.Usage()
+		}
+		os.Exit(1)
+	}
+
+	storage, instances, groups, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	inst, errMsg, errCode := ResolveSession(identifier, instances)
+	if inst == nil {
+		out.Error(fmt.Sprintf("%s (profile '%s')", errMsg, storage.Profile()), errCode)
+		if errCode == ErrCodeNotFound {
+			os.Exit(2)
+		}
+		os.Exit(1)
+	}
+
+	oldTitle := inst.Title
+	inst.Title = newTitle
+	inst.SyncTmuxDisplayName()
+
+	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+	if err := storage.SaveWithGroups(instances, groupTree); err != nil {
+		out.Error(fmt.Sprintf("failed to save: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	out.Success(
+		fmt.Sprintf("Renamed session: %q → %q (profile '%s')", oldTitle, newTitle, storage.Profile()),
+		map[string]interface{}{
+			"success":   true,
+			"id":        inst.ID,
+			"old_title": oldTitle,
+			"new_title": newTitle,
+			"profile":   storage.Profile(),
+		},
+	)
+}
+
 // statusCounts holds session counts by status
 type statusCounts struct {
 	running int
@@ -1718,6 +1792,7 @@ func printHelp() {
 	fmt.Println("  try <name>       Quick experiment (create/find dated folder + session)")
 	fmt.Println("  list, ls         List all sessions")
 	fmt.Println("  remove, rm       Remove a session")
+	fmt.Println("  rename, mv       Rename a session")
 	fmt.Println("  status           Show session status summary")
 	fmt.Println("  session          Manage session lifecycle")
 	fmt.Println("  mcp              Manage MCP servers")


### PR DESCRIPTION
## Motivation

AI agents need a discoverable way to rename sessions. The existing `agent-deck session set <id> title <value>` works but is buried and hard for agents to find. A top-level `agent-deck rename` mirrors `agent-deck remove` and is self-documenting:

```bash
agent-deck rename "A - placeholder contrast" "A - free"
```

## Summary
- Adds `agent-deck rename <id|title> <new-title>` as a discoverable top-level command for renaming sessions
- Includes `mv` alias, `--json`/`--quiet` flags, and live tmux status bar sync via `SyncTmuxDisplayName()`
- Follows the existing `handleRemove` pattern with shared `ResolveSession`, `loadSessionData`, and `CLIOutput` utilities

## Test plan
- [x] `go build ./cmd/agent-deck/` — compiles
- [x] `go vet ./cmd/agent-deck/` — no warnings
- [x] `go test ./cmd/agent-deck/...` — existing tests pass
- [ ] Manual: `agent-deck rename <session> "New Name"` — verify title changes
- [ ] Manual: `agent-deck rename <session> "New Name" --json` — verify JSON output
- [ ] Manual: `agent-deck mv <session> "New Name"` — verify alias works

🤖 Generated with [Claude Code](https://claude.com/claude-code)