### PR TITLE
feat: Add ability to use custom paths for CLAUDE.md in conductors

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -60,6 +60,8 @@ func handleConductorSetup(profile string, args []string) {
 	noHeartbeat := fs.Bool("no-heartbeat", false, "Disable heartbeat for this conductor")
 	heartbeat := fs.Bool("heartbeat", false, "Enable heartbeat for this conductor (default)")
 	description := fs.String("description", "", "Description for this conductor")
+	sharedClaudeMD := fs.String("shared-claude-md", "", "Custom path for shared CLAUDE.md (e.g., ~/docs/conductor-shared.md)")
+	claudeMD := fs.String("claude-md", "", "Custom path for this conductor's CLAUDE.md (e.g., ~/docs/conductor-ryan.md)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck [-p profile] conductor setup <name> [options]")
@@ -230,7 +232,7 @@ func handleConductorSetup(profile string, args []string) {
 	}
 
 	// Step 3: Install/update shared CLAUDE.md
-	if err := session.InstallSharedClaudeMD(); err != nil {
+	if err := session.InstallSharedClaudeMD(*sharedClaudeMD); err != nil {
 		fmt.Fprintf(os.Stderr, "Error installing shared CLAUDE.md: %v\n", err)
 		os.Exit(1)
 	}
@@ -243,7 +245,7 @@ func handleConductorSetup(profile string, args []string) {
 		fmt.Printf("\nSetting up conductor: %s (profile: %s)\n", name, profile)
 	}
 
-	if err := session.SetupConductor(name, profile, heartbeatEnabled, *description); err != nil {
+	if err := session.SetupConductor(name, profile, heartbeatEnabled, *description, *claudeMD); err != nil {
 		fmt.Fprintf(os.Stderr, "Error setting up conductor %s: %v\n", name, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Use symlinks that point from the conductor directory to the user's file. This enable to use persist these CLAUDE.md in usual user's git repositories.

Changes:
- Add createSymlinkWithExpansion() helper with ~ expansion and validation
- SetupConductor with --claude-md creates a symlink instead of writing content
- InstallSharedClaudeMD with --shared-claude-md creates a symlink
- Preserve existing symlinks on re-run without --claude-md flag

Usage:
  agent-deck conductor setup my-conductor --claude-md ~/docs/conductor.md