### PR TITLE
feat: add top-level rename command with validation

### DIFF
--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -387,10 +387,10 @@ func TestSlackSettings_AllowedUserIDs(t *testing.T) {
 func TestSlackSettings_UserIDFormat(t *testing.T) {
 	// Verify that typical Slack user ID formats are handled correctly
 	userIDs := []string{
-		"U01234ABCDE",  // Standard user ID
-		"U05678FGHIJ",  // Another standard ID
-		"W12345",       // Workspace user ID
-		"USLACKBOT",    // SlackBot ID
+		"U01234ABCDE", // Standard user ID
+		"U05678FGHIJ", // Another standard ID
+		"W12345",      // Workspace user ID
+		"USLACKBOT",   // SlackBot ID
 	}
 
 	settings := SlackSettings{
@@ -481,9 +481,9 @@ func TestBridgeTemplate_ContainsSlackAuthorization(t *testing.T) {
 
 	// Check for authorization checks in handlers
 	authCheckPatterns := []string{
-		"user_id = event.get(\"user\", \"\")",           // message/mention handlers
-		"user_id = command.get(\"user_id\", \"\")",      // slash command handlers
-		"if not is_slack_authorized(user_id):",         // authorization check
+		"user_id = event.get(\"user\", \"\")",                            // message/mention handlers
+		"user_id = command.get(\"user_id\", \"\")",                       // slash command handlers
+		"if not is_slack_authorized(user_id):",                           // authorization check
 		"await respond(\"⛔ Unauthorized. Contact your administrator.\")", // slash command error
 	}
 


### PR DESCRIPTION
Adds `agent-deck rename <id|title> <new-title>` (with `mv` alias) as a discoverable alternative to `agent-deck session set <id> title <value>`. Includes --json/--quiet flags and live tmux status bar sync.

## Improvements over #172

- **Add duplicate title validation**: Prevents renaming to a title that already exists at the same path (allows renaming to same title)
- **Fix error code**: Use `ErrCodeInvalidOperation` (not `ErrCodeNotFound`) for missing argument validation
- **Add comprehensive test coverage**: `TestIsDuplicateSession` verifies duplicate detection, path normalization, and edge cases

## Testing

```bash
go test ./... && go build ./cmd/agent-deck/
```

All tests pass ✅

---

Co-authored-by: nlenepveu <nlenepveu@users.noreply.github.com>