### PR TITLE
fix: prevent worktree-within-worktree nesting when forking sessions

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -672,8 +672,8 @@ func handleAdd(profile string, args []string) {
 			os.Exit(1)
 		}
 
-		// Get repo root
-		repoRoot, err := git.GetRepoRoot(path)
+		// Get repo root (resolve through worktrees to prevent nesting)
+		repoRoot, err := git.GetWorktreeBaseRoot(path)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to get repo root: %v\n", err)
 			os.Exit(1)

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -457,7 +457,7 @@ func handleSessionFork(profile string, args []string) {
 			out.Error("session path is not a git repository", ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
-		repoRoot, err := git.GetRepoRoot(inst.ProjectPath)
+		repoRoot, err := git.GetWorktreeBaseRoot(inst.ProjectPath)
 		if err != nil {
 			out.Error(fmt.Sprintf("failed to get repo root: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)

--- a/cmd/agent-deck/worktree_cmd.go
+++ b/cmd/agent-deck/worktree_cmd.go
@@ -97,8 +97,8 @@ func handleWorktreeList(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Get repo root
-	repoRoot, err := git.GetRepoRoot(cwd)
+	// Get repo root (resolve through worktrees to prevent nesting)
+	repoRoot, err := git.GetWorktreeBaseRoot(cwd)
 	if err != nil {
 		out.Error(fmt.Sprintf("failed to get repo root: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
@@ -332,7 +332,7 @@ func handleWorktreeCleanup(profile string, args []string) {
 	var repoRoot string
 
 	if git.IsGitRepo(cwd) {
-		repoRoot, err = git.GetRepoRoot(cwd)
+		repoRoot, err = git.GetWorktreeBaseRoot(cwd)
 		if err == nil {
 			worktrees, err := git.ListWorktrees(repoRoot)
 			if err == nil {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3391,7 +3391,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return h, nil
 			}
 
-			repoRoot, err := git.GetRepoRoot(path)
+			repoRoot, err := git.GetWorktreeBaseRoot(path)
 			if err != nil {
 				h.newDialog.SetError(fmt.Sprintf("Failed to get repo root: %v", err))
 				return h, nil
@@ -4531,7 +4531,7 @@ func (h *Home) handleForkDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						h.forkDialog.SetError("Path is not a git repository")
 						return h, nil
 					}
-					repoRoot, err := git.GetRepoRoot(source.ProjectPath)
+					repoRoot, err := git.GetWorktreeBaseRoot(source.ProjectPath)
 					if err != nil {
 						h.forkDialog.SetError(fmt.Sprintf("Failed to get repo root: %v", err))
 						return h, nil


### PR DESCRIPTION
## Summary
- Add `GetWorktreeBaseRoot()` function that resolves through worktrees via `--git-common-dir` to find the true main repo root
- Fix `GetMainWorktreePath()` to handle relative paths from `--git-common-dir`
- Replace `GetRepoRoot()` with `GetWorktreeBaseRoot()` at all 6 worktree creation call sites (CLI add, CLI fork, worktree list, worktree cleanup, TUI new session, TUI fork session)

## Problem
When forking a session that already uses a worktree (e.g., `/repo/.worktrees/feature-a`), `GetRepoRoot()` returns the worktree's own root instead of the main repo root. This causes the new worktree to nest inside the first one: `/repo/.worktrees/feature-a/.worktrees/feature-b` instead of `/repo/.worktrees/feature-b`.

## Test plan
- [x] `TestIsWorktree` — false for main repo, true for worktree, false for non-git
- [x] `TestGetMainWorktreePath` — returns main repo from worktree, handles relative paths
- [x] `TestGetWorktreeBaseRoot` — main repo, worktree, worktree subdirectory, non-git error
- [x] `TestIntegration_WorktreeNesting` — creates worktree from within another worktree, verifies no nesting
- [x] All existing tests pass (`go test ./...`)
- [x] `go build ./cmd/agent-deck` compiles cleanly