### PR TITLE
fix: anchor BusyRegexp to line start to prevent welcome banner false positive

### DIFF
--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -41,7 +41,7 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 	case "claude":
 		return &RawPatterns{
 			BusyPatterns: []string{
-				`re:[✳✽✶✻✢·]\s*.+…`,   // PRIMARY: spinner + ellipsis (Claude 2.1.25+) — · included because ellipsis requirement prevents false positives from separator usage
+				`re:(?m)^[✳✽✶✻✢·]\s*.+…`, // PRIMARY: spinner + ellipsis (Claude 2.1.25+) — anchored to line start to prevent mid-line · in welcome banner from false-positiving
 				"ctrl+c to interrupt", // SECONDARY: explicit busy text (current Claude)
 				"esc to interrupt",    // FALLBACK: older Claude Code versions
 			},

--- a/internal/tmux/status_fixes_test.go
+++ b/internal/tmux/status_fixes_test.go
@@ -607,7 +607,7 @@ func TestClaudeCode2125_ActiveDetection(t *testing.T) {
 		{
 			name:     "active - · spinner with ellipsis",
 			content:  "· Sublimating… (39s · ↓ 1.8k tokens)",
-			wantBusy: true, // BusyRegexp catches · with ellipsis as active work
+			wantBusy: true, // BusyRegexp catches · at line start with ellipsis as active work
 		},
 		{
 			name:     "active - ✶ spinner with ellipsis",
@@ -653,7 +653,7 @@ func TestClaudeCode2125_ActiveDetection(t *testing.T) {
 		{
 			name:     "active - multi-word task with ·",
 			content:  "· Installing package dependencies… (45s · ↑ 312 tokens)",
-			wantBusy: true, // BusyRegexp catches · with ellipsis as active work
+			wantBusy: true, // BusyRegexp catches · at line start with ellipsis as active work
 		},
 		{
 			name: "active - multi-word with surrounding content",
@@ -746,7 +746,7 @@ func TestClaudeCode2125_SpinnerActiveRegex(t *testing.T) {
 		{"✢ channelling…", true},
 		{"✶ Fixing Scanner Buffer Overflow…", true},  // multi-word task name
 		{"✻ Adding mcp-proxy subcommand…", true},     // multi-word with excluded spinner
-		{"· Installing package dependencies…", true}, // multi-word with excluded spinner
+		{"· Installing package dependencies…", true}, // multi-word with · at line start
 		{"✳ Running tests and building…", true},      // multi-word
 		{"✻ worked for 54s", false},                  // done state, no ellipsis
 		{"✻ churned for 47s", false},                 // done state, no ellipsis
@@ -1256,7 +1256,7 @@ func TestBusyPatternRegex_CatchesMidDotAndAsterisk(t *testing.T) {
 		want    bool
 	}{
 		{
-			name: "middot active (not in findSpinnerInContent set)",
+			name: "middot active at line start (not in findSpinnerInContent set, caught by BusyRegexp)",
 			content: `some output
 · Kneading… (9m 22s · ↓ 14.1k tokens · thought for 36s)
 ──────────────────

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2579,7 +2579,8 @@ var (
 	// Claude Code 2.1.25+ active spinner: symbol + unicode ellipsis (U+2026)
 	// Matches: "✳ Gusting…", "✻ Adding mcp-proxy subcommand…" (single or multi-word)
 	// Does NOT match done state: "✻ Worked for 54s" (no ellipsis)
-	claudeSpinnerActivePattern = regexp.MustCompile(`[·✳✽✶✻✢]\s*.+…`)
+	// Anchored to line start to prevent mid-line · in welcome banner from false-positiving
+	claudeSpinnerActivePattern = regexp.MustCompile(`(?m)^[·✳✽✶✻✢]\s*.+…`)
 
 	// Matches whimsical thinking words with timing info (e.g., "⠋ Flibbertigibbeting... (25s · 340 tokens)")
 	// Requires spinner prefix to avoid matching normal English words like "processing" or "computing"


### PR DESCRIPTION
The regex `[✳✽✶✻✢·]\s*.+…` false-positived on the Claude welcome banner "Opus 4.6 is here · $50 free extra usage · Try fast mode or use i…" because the mid-line `·` matched the char class and terminal-truncated `…` matched the end. This caused waitForAgentReady to never see "waiting", making `session send` timeout after 80s.

Fix: add `(?m)^` anchor so the spinner char must appear at line start. Real busy lines like `· Installing…` start with the spinner; the banner has `·` mid-line as a separator.