### PR TITLE
fix: don't flag shell terminals as waiting

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1639,7 +1639,11 @@ func (i *Instance) UpdateStatus() error {
 	case "active":
 		i.Status = StatusRunning
 	case "waiting":
-		i.Status = StatusWaiting
+		if i.Tool == "shell" {
+			i.Status = StatusIdle
+		} else {
+			i.Status = StatusWaiting
+		}
 	case "idle":
 		i.Status = StatusIdle
 	case "starting":


### PR DESCRIPTION
## Summary

- Shell terminals at their prompt show as orange ◐ (waiting), creating false positives when scanning sessions for ones needing attention
- Remap shell "waiting" → idle so they show as gray ○ instead
- Single conditional added to `UpdateStatus()` in `internal/session/instance.go`

## Details

A shell at its prompt is idle by definition — there's no agent output to review. This change makes shell terminals use `StatusIdle` (gray ○) instead of `StatusWaiting` (orange ◐) when at their prompt. They're also automatically excluded from the notification bar since `SyncFromInstances()` only tracks `StatusWaiting`.

| Scenario | Before | After |
|----------|--------|-------|
| Shell at prompt | Orange ◐ | Gray ○ |
| Shell running command | Green ● | Green ● |
| Agent finished task | Orange ◐ | Orange ◐ |

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` all tests pass
- [x] Manual: shell terminal shows gray ○ at prompt, green ● when running a command
