### PR TITLE
feat(mcp): add manage_mcp_json config flag to disable .mcp.json writes

### DIFF
--- a/internal/session/mcp_catalog.go
+++ b/internal/session/mcp_catalog.go
@@ -143,6 +143,11 @@ func readExistingLocalMCPServers(mcpFile string) map[string]json.RawMessage {
 // WriteMCPJsonFromConfig writes enabled MCPs from config.toml to project's .mcp.json
 // It preserves any existing entries not managed by agent-deck (not defined in config.toml)
 func WriteMCPJsonFromConfig(projectPath string, enabledNames []string) error {
+	if !GetManageMCPJson() {
+		mcpCatLog.Debug("mcp_json_management_disabled", slog.String("path", projectPath))
+		return nil
+	}
+
 	mcpFile := filepath.Join(projectPath, ".mcp.json")
 	availableMCPs := GetAvailableMCPs()
 	pool := GetGlobalPool() // Get pool instance (may be nil)

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -37,6 +37,12 @@ type UserConfig struct {
 	// Valid values: "local" (default), "global", "user"
 	MCPDefaultScope string `toml:"mcp_default_scope"`
 
+	// ManageMCPJson controls whether agent-deck writes to .mcp.json in project directories.
+	// Set to false to prevent agent-deck from touching any .mcp.json files, which is useful
+	// when you manage that file manually or via another tool.
+	// Default: true (nil = true)
+	ManageMCPJson *bool `toml:"manage_mcp_json"`
+
 	// MCPs defines available MCP servers for the MCP Manager
 	// These can be attached/detached per-project via the MCP Manager (M key)
 	MCPs map[string]MCPDef `toml:"mcps"`
@@ -1405,6 +1411,11 @@ auto_cleanup = true
 # "user" writes to ~/.claude.json (all profiles)
 # mcp_default_scope = "local"
 
+# Disable ALL .mcp.json management (default: true)
+# Set to false if you manage .mcp.json manually or via another tool and don't
+# want agent-deck to touch it. LOCAL-scope MCP changes will be silently skipped.
+# manage_mcp_json = false
+
 # Tmux session settings
 # Controls how agent-deck configures tmux sessions
 # [tmux]
@@ -1594,6 +1605,19 @@ func GetMCPDefaultScope() string {
 	default:
 		return "local"
 	}
+}
+
+// GetManageMCPJson returns whether agent-deck should write to .mcp.json files.
+// Defaults to true when unset.
+func GetManageMCPJson() bool {
+	config, err := LoadUserConfig()
+	if err != nil || config == nil {
+		return true
+	}
+	if config.ManageMCPJson == nil {
+		return true
+	}
+	return *config.ManageMCPJson
 }
 
 // GetMCPDef returns a specific MCP definition by name

--- a/internal/ui/mcp_dialog.go
+++ b/internal/ui/mcp_dialog.go
@@ -733,7 +733,11 @@ func (m *MCPDialog) View() string {
 	} else {
 		switch m.scope {
 		case MCPScopeLocal:
-			scopeDesc = DimStyle.Render("Writes to: .mcp.json (this project only)")
+			if !session.GetManageMCPJson() {
+				scopeDesc = lipgloss.NewStyle().Foreground(ColorYellow).Render("⚠ .mcp.json management disabled (manage_mcp_json = false in config.toml)")
+			} else {
+				scopeDesc = DimStyle.Render("Writes to: .mcp.json (this project only)")
+			}
 		case MCPScopeGlobal:
 			scopeDesc = DimStyle.Render("Writes to: Claude config (profile-specific)")
 		case MCPScopeUser:


### PR DESCRIPTION
Introduces a new `manage_mcp_json` boolean in config.toml (default: true) that completely disables agent-deck writing to .mcp.json files. When set to false, WriteMCPJsonFromConfig is a no-op at all call sites (MCP dialog, mcp attach/detach CLI, session startup).

The MCP Manager dialog now shows a yellow warning when LOCAL scope is active but .mcp.json management has been disabled, so users know why changes won't be persisted.

Useful for projects where .mcp.json is managed manually or by another tool, and any agent-deck rewrite (even harmless reformatting) would cause spurious git diffs.