### PR TITLE
feat: separate conductor mechanism from policy (CLAUDE.md + POLICY.md)

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -68,12 +68,14 @@ func parseConductorSetupArgs(fs *flag.FlagSet, args []string) (string, []string,
 // handleConductorSetup sets up a named conductor with directories, sessions, and optionally the Telegram bridge
 func handleConductorSetup(profile string, args []string) {
 	fs := flag.NewFlagSet("conductor setup", flag.ExitOnError)
-	jsonOutput := fs.Bool("json", false, "Output as JSON")
-	noHeartbeat := fs.Bool("no-heartbeat", false, "Disable heartbeat for this conductor")
-	heartbeat := fs.Bool("heartbeat", false, "Enable heartbeat for this conductor (default)")
 	description := fs.String("description", "", "Description for this conductor")
+	heartbeat := fs.Bool("heartbeat", false, "Enable heartbeat for this conductor (default)")
+	noHeartbeat := fs.Bool("no-heartbeat", false, "Disable heartbeat for this conductor")
+	claudeMD := fs.String("claude-md", "", "Custom CLAUDE.md for this conductor (e.g., ~/docs/conductor-ryan.md)")
+	policyMD := fs.String("policy-md", "", "Custom POLICY.md for this conductor (e.g., ~/docs/my-policy.md)")
 	sharedClaudeMD := fs.String("shared-claude-md", "", "Custom path for shared CLAUDE.md (e.g., ~/docs/conductor-shared.md)")
-	claudeMD := fs.String("claude-md", "", "Custom path for this conductor's CLAUDE.md (e.g., ~/docs/conductor-ryan.md)")
+	sharedPolicyMD := fs.String("shared-policy-md", "", "Custom path for shared POLICY.md (e.g., ~/docs/conductor-policy.md)")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck [-p profile] conductor setup <name> [options]")
@@ -85,7 +87,28 @@ func handleConductorSetup(profile string, args []string) {
 		fmt.Println("  <name>    Conductor name (e.g., ryan, infra, monitor)")
 		fmt.Println()
 		fmt.Println("Options:")
-		fs.PrintDefaults()
+		fmt.Println("  -description string")
+		fmt.Println("        Description for this conductor")
+		fmt.Println("  -heartbeat")
+		fmt.Println("        Enable heartbeat for this conductor (default)")
+		fmt.Println("  -no-heartbeat")
+		fmt.Println("        Disable heartbeat for this conductor")
+		fmt.Println()
+		fmt.Println("Conductor-specific files:")
+		fmt.Println("  -claude-md string")
+		fmt.Println("        Custom CLAUDE.md for this conductor (e.g., ~/docs/conductor-ryan.md)")
+		fmt.Println("  -policy-md string")
+		fmt.Println("        Custom POLICY.md for this conductor (e.g., ~/docs/my-policy.md)")
+		fmt.Println()
+		fmt.Println("Shared files (all conductors):")
+		fmt.Println("  -shared-claude-md string")
+		fmt.Println("        Custom path for shared CLAUDE.md (e.g., ~/docs/conductor-shared.md)")
+		fmt.Println("  -shared-policy-md string")
+		fmt.Println("        Custom path for shared POLICY.md (e.g., ~/docs/conductor-policy.md)")
+		fmt.Println()
+		fmt.Println("Output:")
+		fmt.Println("  -json")
+		fmt.Println("        Output as JSON")
 	}
 
 	name, extras, err := parseConductorSetupArgs(fs, args)
@@ -245,12 +268,21 @@ func handleConductorSetup(profile string, args []string) {
 		fmt.Println("[ok] Shared CLAUDE.md installed/updated")
 	}
 
+	// Step 3b: Install/update shared POLICY.md
+	if err := session.InstallPolicyMD(*sharedPolicyMD); err != nil {
+		fmt.Fprintf(os.Stderr, "Error installing POLICY.md: %v\n", err)
+		os.Exit(1)
+	}
+	if !*jsonOutput {
+		fmt.Println("[ok] Shared POLICY.md installed/updated")
+	}
+
 	// Step 4: Set up the named conductor
 	if !*jsonOutput {
 		fmt.Printf("\nSetting up conductor: %s (profile: %s)\n", name, resolvedProfile)
 	}
 
-	if err := session.SetupConductor(name, resolvedProfile, heartbeatEnabled, *description, *claudeMD); err != nil {
+	if err := session.SetupConductor(name, resolvedProfile, heartbeatEnabled, *description, *claudeMD, *policyMD); err != nil {
 		fmt.Fprintf(os.Stderr, "Error setting up conductor %s: %v\n", name, err)
 		os.Exit(1)
 	}
@@ -563,6 +595,7 @@ func handleConductorTeardown(_ string, args []string) {
 			_ = os.Remove(filepath.Join(condDir, "bridge.py"))
 			_ = os.Remove(filepath.Join(condDir, "bridge.log"))
 			_ = os.Remove(filepath.Join(condDir, "CLAUDE.md"))
+			_ = os.Remove(filepath.Join(condDir, "POLICY.md"))
 			_ = os.Remove(condDir) // Remove dir if empty
 		}
 	}


### PR DESCRIPTION
## Problem

The shared `CLAUDE.md` mixes two concerns:
- **Mechanism**: how the conductor works (CLI reference, protocols, bridge format, state management)
- **Policy**: how the conductor should behave (auto-response rules, escalation guidelines, response style)

This makes it impossible to customize agent behavior per project or per conductor without also duplicating all the infrastructure knowledge. A user who wants a more aggressive auto-response policy or project-specific escalation rules has to fork the entire CLAUDE.md.

## Solution

Split into two files with clear responsibilities:

| File | Contains | Overridable via |
|------|----------|----------------|
| `CLAUDE.md` (shared) | CLI reference, protocols, bridge format, state mgmt | `--shared-claude-md` |
| `POLICY.md` (shared) | Core rules, auto-response guidelines, escalation | `--shared-policy-md` |
| `<name>/CLAUDE.md` | Conductor identity, startup checklist | `--claude-md` |
| `<name>/POLICY.md` | Per-conductor policy override (symlink) | `--policy-md` |

The per-conductor CLAUDE.md now tells the conductor: "Read `./POLICY.md`, falling back to `../POLICY.md`". This means:
- Default behavior: all conductors share the same policy from the parent directory
- Per-conductor override: pass `--policy-md ~/my-project/policy.md` at setup to symlink a custom policy
- Per-project override: pass `--shared-policy-md` to replace the default policy for all conductors

```
~/.agent-deck/conductor/
  CLAUDE.md              ← mechanism (shared, inherited by all conductors)
  POLICY.md              ← default policy (shared, overridable)
  ryan/
    CLAUDE.md            ← identity + references POLICY.md
    POLICY.md            ← (optional) symlink to custom policy via --policy-md
    meta.json
```

## Migration

**No automatic migration needed.** Existing conductors keep working — their old combined CLAUDE.md still contains both mechanism and policy inline.

To migrate an existing conductor, re-run `conductor setup <name>`. This:
1. Rewrites the shared CLAUDE.md (mechanism only)
2. Creates the new shared POLICY.md (default policy)
3. Rewrites the per-conductor CLAUDE.md (now references POLICY.md)

Symlinked files (from `--claude-md` or `--shared-claude-md`) are preserved and not overwritten.

## Changes

- **conductor_templates.go**: Moved Core Rules + Auto-Response Guidelines from shared CLAUDE.md into new `conductorPolicyTemplate`. Per-conductor template now references POLICY.md.
- **conductor.go**: Added `InstallPolicyMD()`, extended `SetupConductor()` with `customPolicyMD` param.
- **conductor_cmd.go**: Added `--policy-md` and `--shared-policy-md` flags. Reordered help into logical groups.
- **conductor_test.go**: Tests for policy install (default + symlink), per-conductor override, and negative tests verifying CLAUDE.md no longer contains policy content.

## Test plan

- [x] `TestInstallPolicyMD_Default` — default template written correctly
- [x] `TestInstallPolicyMD_CustomSymlink` — custom path creates symlink
- [x] `TestSetupConductor_PolicyOverride` — per-conductor POLICY.md symlink
- [x] `TestInstallSharedClaudeMD_Default` — verifies policy content removed from CLAUDE.md
- [x] `TestSetupConductor_DefaultTemplate` — per-conductor CLAUDE.md references POLICY.md
- [x] All existing conductor tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)