### PR TITLE
feat(conductor): split policy from shared CLAUDE with safe migration

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -42,13 +42,22 @@ func handleConductor(profile string, args []string) {
 
 // runAutoMigration runs legacy conductor migration and prints results
 func runAutoMigration(jsonOutput bool) {
-	migrated, err := session.MigrateLegacyConductors()
+	migratedLegacy, err := session.MigrateLegacyConductors()
 	if err != nil && !jsonOutput {
 		fmt.Fprintf(os.Stderr, "Warning: migration check failed: %v\n", err)
 	}
+
+	migratedPolicy, err := session.MigrateConductorPolicySplit()
+	if err != nil && !jsonOutput {
+		fmt.Fprintf(os.Stderr, "Warning: policy migration check failed: %v\n", err)
+	}
+
 	if !jsonOutput {
-		for _, name := range migrated {
+		for _, name := range migratedLegacy {
 			fmt.Printf("  [migrated] Legacy conductor: %s\n", name)
+		}
+		for _, name := range migratedPolicy {
+			fmt.Printf("  [migrated] Updated policy split: %s\n", name)
 		}
 	}
 }

--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -213,6 +213,34 @@ If ` + "`" + `./POLICY.md` + "`" + ` does not exist, use ` + "`" + `../POLICY.md
 Read the policy file at the start of each interaction.
 `
 
+// conductorPerNameClaudeMDLegacyTemplate is the pre-policy-split per-conductor CLAUDE.md template.
+// It is kept only for migration matching and should not be used for new writes.
+const conductorPerNameClaudeMDLegacyTemplate = `# Conductor: {NAME} ({PROFILE} profile)
+
+You are **{NAME}**, a conductor for the **{PROFILE}** profile.
+
+## Your Identity
+
+- Your session title is ` + "`" + `conductor-{NAME}` + "`" + `
+- You manage the **{PROFILE}** profile exclusively. Always pass ` + "`" + `-p {PROFILE}` + "`" + ` to all CLI commands.
+- You live in ` + "`" + `~/.agent-deck/conductor/{NAME}/` + "`" + `
+- Maintain state in ` + "`" + `./state.json` + "`" + ` and log actions in ` + "`" + `./task-log.md` + "`" + `
+- The bridge (Telegram/Slack) sends you messages from the user and forwards your responses back
+- You receive periodic ` + "`" + `[HEARTBEAT]` + "`" + ` messages with system status
+- Other conductors may exist for different purposes. You only manage sessions in your profile.
+
+## Startup Checklist
+
+When you first start (or after a restart):
+
+1. Read ` + "`" + `./state.json` + "`" + ` if it exists (restore context)
+2. Run ` + "`" + `agent-deck -p {PROFILE} status --json` + "`" + ` to get the current state
+3. Run ` + "`" + `agent-deck -p {PROFILE} list --json` + "`" + ` to know what sessions exist
+4. Log startup in ` + "`" + `./task-log.md` + "`" + `
+5. If any sessions are in error state, try to restart them
+6. Reply: "Conductor {NAME} ({PROFILE}) online. N sessions tracked (X running, Y waiting)."
+`
+
 // conductorBridgePy is the Python bridge script that connects Telegram and/or Slack to conductor sessions.
 // This is embedded so the binary is self-contained.
 // Updated for multi-conductor: discovers conductors from meta.json files on disk.


### PR DESCRIPTION
Supersedes #200 because I could not push fixes to the fork branch from this environment (GitHub returned 403 on fork push).

Includes all changes from #200 plus a migration safety fix:
- auto-migrate legacy generated per-conductor CLAUDE.md files to the new POLICY.md-aware template
- preserve custom CLAUDE.md files and symlinked CLAUDE.md files
- run this migration from conductor setup auto-migration path
- add regression tests covering migration + preservation behavior

Validation:
- go test ./...
- pre-push hooks: build, lint, test all passed