### PR TITLE
fix(conductor): stamp real profile name in heartbeat.sh message text

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -349,13 +349,10 @@ func InstallHeartbeatScript(name, profile string) error {
 	profile = normalizeConductorProfile(profile)
 
 	script := strings.ReplaceAll(conductorHeartbeatScript, "{NAME}", name)
+	script = strings.ReplaceAll(script, "{PROFILE}", profile)
 	if profile == DefaultProfile {
 		// For default profile, omit -p flag entirely
-		script = strings.ReplaceAll(script, "{PROFILE}", "default")
 		script = strings.ReplaceAll(script, `-p "$PROFILE" `, "")
-		script = strings.ReplaceAll(script, `$PROFILE profile`, "default profile")
-	} else {
-		script = strings.ReplaceAll(script, "{PROFILE}", profile)
 	}
 	scriptPath := filepath.Join(dir, "heartbeat.sh")
 	return os.WriteFile(scriptPath, []byte(script), 0o755)
@@ -468,7 +465,7 @@ PROFILE="{PROFILE}"
 STATUS=$(agent-deck -p "$PROFILE" session show "$SESSION" --json 2>/dev/null | tr -d '\n' | sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
 if [ "$STATUS" = "idle" ] || [ "$STATUS" = "waiting" ]; then
-    agent-deck -p "$PROFILE" session send "$SESSION" "Heartbeat: Check all sessions in the $PROFILE profile. List any waiting sessions, auto-respond where safe, and report what needs my attention."
+    agent-deck -p "$PROFILE" session send "$SESSION" "Heartbeat: Check all sessions in the {PROFILE} profile. List any waiting sessions, auto-respond where safe, and report what needs my attention."
 fi
 `
 


### PR DESCRIPTION
## Summary

- The heartbeat script template used `$PROFILE` (a shell variable) inside the message string, so the **generated** `heartbeat.sh` file showed the literal text `$PROFILE profile` instead of the actual profile name (e.g. `testprofile profile`).
- For the default profile a special post-processing step replaced `$PROFILE profile` → `default profile`, creating an inconsistency between default and non-default profiles.
- `CLAUDE.md` was already stamping the real profile name via `{PROFILE}` — this fix brings `heartbeat.sh` message text into line with the same approach.

**Before (non-default profile `testprofile`):**
```bash
agent-deck -p "$PROFILE" session send "$SESSION" "Heartbeat: Check all sessions in the $PROFILE profile. ..."
```

**After:**
```bash
agent-deck -p "$PROFILE" session send "$SESSION" "Heartbeat: Check all sessions in the testprofile profile. ..."
```

## Changes

- `conductorHeartbeatScript` template: replaced `$PROFILE` with `{PROFILE}` placeholder in the message body so it is stamped at generation time.
- `InstallHeartbeatScript`: unified the replacement — `{PROFILE}` is now replaced first for all profiles; only the `-p "$PROFILE"` flag removal is conditional on the default profile. The now-redundant `$PROFILE profile` → `default profile` string replacement is removed.

## Test plan

- [ ] Build: `go build -o /tmp/agent-deck-test ./cmd/agent-deck`
- [ ] `agent-deck-test profile create testprofile && agent-deck-test -p testprofile conductor setup testconductor`
- [ ] Verify `~/.agent-deck/conductor/testconductor/CLAUDE.md` says `testprofile profile` (not `default`)
- [ ] Verify `~/.agent-deck/conductor/testconductor/heartbeat.sh` message says `testprofile profile` (not `$PROFILE profile`)
- [ ] Verify default profile still works: `-p` flag omitted from script, message says `default profile`
- [ ] All existing conductor tests pass: `go test ./internal/session/ -run TestSetupConductor`
- [ ] Teardown: `agent-deck-test conductor teardown testconductor --remove`

🤖 Generated with [Claude Code](https://claude.com/claude-code)