### PR TITLE
fix(session): avoid JSON marshal failure in session show for conductor sessions

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -692,12 +692,8 @@ func handleSessionShow(profile string, args []string) {
 		jsonData["can_fork"] = inst.CanFork()
 		jsonData["can_restart"] = inst.CanRestart()
 
-		if mcpInfo != nil && mcpInfo.HasAny() {
-			jsonData["mcps"] = map[string]interface{}{
-				"local":   mcpInfo.Local,
-				"global":  mcpInfo.Global,
-				"project": mcpInfo.Project,
-			}
+		if mcps := mcpInfoForJSON(mcpInfo); mcps != nil {
+			jsonData["mcps"] = mcps
 		}
 	}
 
@@ -771,6 +767,17 @@ func handleSessionShow(profile string, args []string) {
 	}
 
 	out.Print(sb.String(), jsonData)
+}
+
+func mcpInfoForJSON(mcpInfo *session.MCPInfo) map[string]interface{} {
+	if mcpInfo == nil || !mcpInfo.HasAny() {
+		return nil
+	}
+	return map[string]interface{}{
+		"local":   mcpInfo.Local(),
+		"global":  mcpInfo.Global,
+		"project": mcpInfo.Project,
+	}
 }
 
 // handleSessionSet updates a session property

--- a/cmd/agent-deck/session_cmd_test.go
+++ b/cmd/agent-deck/session_cmd_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestMCPInfoForJSON_NilOrEmpty(t *testing.T) {
+	if got := mcpInfoForJSON(nil); got != nil {
+		t.Fatalf("mcpInfoForJSON(nil) = %#v, want nil", got)
+	}
+
+	if got := mcpInfoForJSON(&session.MCPInfo{}); got != nil {
+		t.Fatalf("mcpInfoForJSON(empty) = %#v, want nil", got)
+	}
+}
+
+func TestMCPInfoForJSON_UsesSlicesAndIsMarshalable(t *testing.T) {
+	info := &session.MCPInfo{
+		Global:  []string{"global-a"},
+		Project: []string{"project-a"},
+		LocalMCPs: []session.LocalMCP{
+			{Name: "local-a", SourcePath: "/tmp"},
+		},
+	}
+
+	got := mcpInfoForJSON(info)
+	if got == nil {
+		t.Fatal("mcpInfoForJSON returned nil for populated MCP info")
+	}
+
+	local, ok := got["local"].([]string)
+	if !ok {
+		t.Fatalf("mcps.local type = %T, want []string", got["local"])
+	}
+	if len(local) != 1 || local[0] != "local-a" {
+		t.Fatalf("mcps.local = %#v, want []string{\"local-a\"}", local)
+	}
+
+	payload := map[string]interface{}{"mcps": got}
+	if _, err := json.Marshal(payload); err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #202.

## Problem
session show --json could fail with json: unsupported type: func() []string when MCP info is included for Claude/conductor sessions.

## Root cause
The JSON payload used mcpInfo.Local (method value) instead of calling mcpInfo.Local().

## Changes
- Add mcpInfoForJSON() helper in cmd/agent-deck/session_cmd.go
- Use mcpInfo.Local() (slice) for JSON payload
- Add regression tests in cmd/agent-deck/session_cmd_test.go to verify the payload is marshalable and typed correctly

## Validation
- go test ./cmd/agent-deck -run 'TestMCPInfoForJSON|TestWaitForCompletion'
- go test ./...
