### PR TITLE
fix(conductor): prefer shell python for daemon generation

### DIFF
--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -992,6 +992,22 @@ func TestGenerateLaunchdPlist_IncludesAgentDeckDir(t *testing.T) {
 	}
 }
 
+func TestFindPython3_PrefersPathLookup(t *testing.T) {
+	tmpBin := t.TempDir()
+	pythonPath := filepath.Join(tmpBin, "python3")
+
+	if err := os.WriteFile(pythonPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("failed to create fake python3: %v", err)
+	}
+
+	t.Setenv("PATH", tmpBin)
+
+	got := findPython3()
+	if got != pythonPath {
+		t.Fatalf("findPython3() = %q, want %q", got, pythonPath)
+	}
+}
+
 func TestBuildDaemonPath(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Fixes #204.

## Problem
conductor daemon plist/systemd generation could select /opt/homebrew/bin/python3 before considering the active shell python, which breaks pyenv/asdf users and can hit PEP 668-managed Homebrew Python package constraints.

## Changes
- Update findPython3() to prefer exec.LookPath("python3") first (active shell resolution)
- Fallback to common absolute paths only if PATH lookup fails
- Add TestFindPython3_PrefersPathLookup to verify precedence

## Validation
- go test ./internal/session -run 'TestFindPython3_PrefersPathLookup|TestGenerateLaunchdPlist_IncludesAgentDeckDir|TestGenerateSystemdBridgeService_IncludesAgentDeckDir'
- go test ./...
