### PR TITLE
feat(conductor): externalize heartbeat instructions into HEARTBEAT_RULES.md

### DIFF
--- a/conductor/HEARTBEAT_RULES.md
+++ b/conductor/HEARTBEAT_RULES.md
@@ -1,0 +1,1 @@
+Check if any need auto-response or user attention.

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -621,11 +621,7 @@ async def heartbeat_loop(bot: Bot, config: dict):
                     parts.append(
                         f"Error sessions: {', '.join(error_details)}."
                     )
-                parts.append(
-                    "Check if any need auto-response or user attention."
-                )
-
-                # Inject HEARTBEAT_RULES.md if present (per-profile, then global)
+                # Append HEARTBEAT_RULES.md (per-profile, then global fallback)
                 rules_text = None
                 for rules_path in [
                     CONDUCTOR_DIR / profile / "HEARTBEAT_RULES.md",
@@ -639,6 +635,10 @@ async def heartbeat_loop(bot: Bot, config: dict):
                         break
                 if rules_text:
                     parts.append(f"\n\n{rules_text}")
+                else:
+                    parts.append(
+                        "Check if any need auto-response or user attention."
+                    )
 
                 heartbeat_msg = " ".join(parts)
 

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -625,6 +625,21 @@ async def heartbeat_loop(bot: Bot, config: dict):
                     "Check if any need auto-response or user attention."
                 )
 
+                # Inject HEARTBEAT_RULES.md if present (per-profile, then global)
+                rules_text = None
+                for rules_path in [
+                    CONDUCTOR_DIR / profile / "HEARTBEAT_RULES.md",
+                    CONDUCTOR_DIR / "HEARTBEAT_RULES.md",
+                ]:
+                    if rules_path.exists():
+                        try:
+                            rules_text = rules_path.read_text().strip()
+                        except Exception as e:
+                            log.warning("Failed to read %s: %s", rules_path, e)
+                        break
+                if rules_text:
+                    parts.append(f"\n\n{rules_text}")
+
                 heartbeat_msg = " ".join(parts)
 
                 # Ensure conductor is running for this profile

--- a/conductor/setup.sh
+++ b/conductor/setup.sh
@@ -44,6 +44,10 @@ cp "${SCRIPT_DIR}/bridge.py" "${CONDUCTOR_DIR}/bridge.py"
 chmod +x "${CONDUCTOR_DIR}/bridge.py"
 ok "bridge.py installed"
 
+# Copy default heartbeat rules (profiles can override with their own)
+cp "${SCRIPT_DIR}/HEARTBEAT_RULES.md" "${CONDUCTOR_DIR}/HEARTBEAT_RULES.md"
+ok "HEARTBEAT_RULES.md installed (default)"
+
 # --------------------------------------------------------------------------
 # Step 2: Install Python dependencies
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

In long-running conductor sessions, policy rules defined in `POLICY.md` or the system prompt can lose effectiveness — whether due to context compaction, a saturated context window, or simply being too far back in the conversation history. This means critical guardrails (e.g. never merge PRs without human approval) can be silently ignored.

The fix: inject key rules into every heartbeat message, so the conductor sees them at every cycle regardless of context state.

## Summary

Moves the heartbeat instruction text from a hardcoded string in `bridge.py` into an external `HEARTBEAT_RULES.md` file, allowing per-profile customization without code changes.

## Changes

- **bridge.py**: Reads `HEARTBEAT_RULES.md` (per-profile first, then global fallback) instead of a hardcoded instruction string. Falls back to the original message if no file is found.
- **HEARTBEAT_RULES.md**: Default template shipped with the repo (identical to the previous hardcoded text).
- **setup.sh**: Installs the default `HEARTBEAT_RULES.md` alongside `bridge.py` during conductor setup.

## How it works

Resolution order:
1. `~/.agent-deck/conductor/<profile>/HEARTBEAT_RULES.md` (per-profile override)
2. `~/.agent-deck/conductor/HEARTBEAT_RULES.md` (global default)
3. Hardcoded fallback (if no file exists)

This lets operators inject persistent rules into heartbeat messages — useful for policies that must survive context saturation or compaction.