### PR TITLE
fix(tmux): restore original status-left on notification clear

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3271,7 +3271,8 @@ func ClearStatusLeft(sessionName string) error {
 // instead of unsetting it, which would fall back to tmux's built-in default "[#{session_name}]".
 var savedStatusLeft struct {
 	sync.Once
-	value string
+	value    string
+	captured bool
 }
 
 // captureOriginalStatusLeft reads and stores the current global status-left value.
@@ -3280,6 +3281,7 @@ func captureOriginalStatusLeft() {
 	out, err := exec.Command("tmux", "show-option", "-gv", "status-left").Output()
 	if err == nil {
 		savedStatusLeft.value = strings.TrimRight(string(out), "\n")
+		savedStatusLeft.captured = true
 	}
 }
 
@@ -3299,7 +3301,7 @@ func SetStatusLeftGlobal(text string) error {
 // (e.g., tmux-oasis) is preserved. Falls back to unsetting the option only if
 // no original value was captured.
 func ClearStatusLeftGlobal() error {
-	if savedStatusLeft.value != "" {
+	if savedStatusLeft.captured {
 		escaped := strings.ReplaceAll(savedStatusLeft.value, "'", "'\\''")
 		return exec.Command("tmux", "set-option", "-g", "status-left", escaped).Run()
 	}


### PR DESCRIPTION
## Summary

- Fixes `ClearStatusLeftGlobal` destroying user's tmux theme/plugin `status-left` value (e.g., tmux-oasis, catppuccin) by restoring the original value instead of unsetting it with `-gu`
- Captures the original `status-left` on first `SetStatusLeftGlobal` call using `sync.Once` so it survives multiple set/clear cycles
- Falls back to the original unset behavior if no value was captured (safe default)

## Problem

When the notification bar clears (e.g., no waiting sessions), `ClearStatusLeftGlobal` ran `tmux set-option -gu status-left`, which unsets the global option entirely. This causes tmux to fall back to its built-in default `[#{session_name}]`, destroying whatever the user's theme plugin had set (e.g., Oasis's `#{E:@oasis_module_mode}#{E:@oasis_module_session}`).

## Test plan

- [x] Existing `TestSetStatusLeft` and `TestClearStatusLeft` pass
- [x] Full `go test ./internal/tmux/` passes
- [x] Manual verification: set → clear cycle correctly restores Oasis theme value
- [ ] Verify with catppuccin or other tmux theme plugins