### PR TITLE
fix(tmux): wait for shell prompt before send-keys to prevent race condition

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -942,6 +942,13 @@ func (s *Session) Start(command string) error {
 
 	// Send the command to the session
 	if command != "" {
+		// Wait for shell to be ready before sending the command.
+		// Without this, send-keys arrives before shells with slow initialization
+		// (zsh + Oh My Zsh, fish + plugins, bash + large .bashrc) finish loading,
+		// causing the command to be silently lost.
+		// See: https://github.com/anthropics/claude-code/issues/23513
+		s.WaitForShellPrompt(3 * time.Second)
+
 		cmdToSend := command
 		// IMPORTANT: Commands containing bash-specific syntax (like `session_id=$(...)`)
 		// must be wrapped in `bash -c` for fish shell compatibility (#47).


### PR DESCRIPTION
## Problem

On macOS with zsh + Oh My Zsh (and other shells with slow initialization), newly created sessions
often fail to start the agent. The `send-keys` command arrives before the shell finishes
initializing, causing the agent command to be silently lost. The tmux pane shows the command text
echoed on screen followed by a bare shell prompt — the agent never starts.

This is **intermittent** — it depends on shell initialization time vs. send-keys timing:
- Cold start (first session after boot): ~0.5-1.5s shell init → almost always fails
- Warm start (cached): ~0.25s shell init → sometimes succeeds

### What the user sees

**Agent Deck TUI**: Status shows "Not connected", output shows command text + shell prompt.

**tmux pane (raw)**:
```
── 0: zsh ──
bash -c 'session_id=$(uuidgen | tr '"'"'[:upper:]'"'"'
'"'"'[:lower:]'"'"'); tmux set-environment CLAUDE_SESSION_ID
"$session_id"; export AGENTDECK_INSTANCE_ID=XXXXX;
claude --session-id "$session_id" --dangerously-skip-permissions'
➜  my-project
```
The command was echoed to screen but never executed by the shell.
The shell prompt (`➜`) appeared immediately — the agent never started.

### Evidence from debug log

```
17:12:36  pipe_connected                                    # tmux session created
17:12:38  last_line="bash -c 'session_id=$(uuidgen..."      # command text visible in pane
17:12:40  last_line="➜  my-project"                         # shell prompt appeared (2s later)
17:13:06  last_line="➜  my-project"                         # still at shell prompt, agent never started
```

The `CLAUDE_SESSION_ID` environment variable was never set in the tmux session, confirming that
`tmux set-environment` (part of the command) was never executed — the entire `bash -c` block
was silently discarded.

## Root Cause

In `Session.Start()` (`internal/tmux/tmux.go`), the current flow is:

```
Line 892:  tmux new-session -d -s <name> -c <workDir>   ← creates shell (returns immediately)
Line 914:  set-option (batched session configuration)
Line 941:  ConfigureStatusBar()
Line 954:  SendKeysAndEnter("bash -c '... claude ...'")  ← fires immediately, 0ms after creation
```

There is **no delay or readiness check** between session creation and command sending.
When the shell (zsh, fish, bash) is still initializing — loading `.zshrc`, Oh My Zsh plugins,
completions (`compinit`), etc. — the `send-keys` keystrokes arrive during initialization and
are silently discarded or echoed without execution.

This is the same root cause as [anthropics/claude-code#23513](https://github.com/anthropics/claude-code/issues/23513).

## Changes

- Add `s.WaitForShellPrompt(3 * time.Second)` call before `SendKeysAndEnter()` in `Session.Start()`
- This uses the **existing** `WaitForShellPrompt()` method (line 2848) which polls for common
  shell prompts (`$`, `#`, `%`, `❯`, `➜`) at 100ms intervals
- Returns as soon as the prompt is detected (typically 0.3-0.6s), no unnecessary delay
- 3-second timeout is generous enough for slow shells while keeping fast shells snappy

### Why `WaitForShellPrompt()` over alternatives

| Approach | Pros | Cons |
|---|---|---|
| **`WaitForShellPrompt()` (chosen)** | Adaptive, uses existing code, returns early | Depends on prompt pattern matching |
| `tmux new-session "command"` | No race condition at all | Command becomes pane's init process — pane closes when agent exits, breaking restart flow |
| `time.Sleep(1s)` | Simple | Fixed delay, too slow for fast shells, too short for slow ones |

## Validation

- `go build ./...` — passes
- `go vet ./internal/tmux/` — passes
- `make fmt` — no changes needed
- `make lint` — no new warnings (existing 72 warnings are pre-existing upstream issues)
- Related tests pass:
  ```
  AGENTDECK_TEST_PROFILE=1 go test ./internal/tmux/ \
    -run "TestSession_SendCtrlC|TestSession_SendCommand" -v
  ```
- **Manual testing**: Replaced the installed binary on macOS (arm64) + zsh + Oh My Zsh.
  Sessions now reliably start the agent instead of dropping to shell prompt.

## Environment

- Agent Deck: v0.19.13
- macOS (arm64)
- tmux 3.6a
- zsh 5.9 + Oh My Zsh (with plugins: colorize, autojump, zsh-autosuggestions, etc.)
- Shell init time: ~0.5s cold / ~0.25s warm (`time zsh -i -c exit`)