### PR TITLE
fix: restore opencode status detection regression

### DIFF
--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -55,8 +55,16 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 		}
 	case "opencode":
 		return &RawPatterns{
-			BusyPatterns:   []string{"esc interrupt"},
-			PromptPatterns: []string{"Ask anything"},
+			BusyPatterns: []string{
+				"esc interrupt",
+				"esc to exit",
+				"thinking...",
+				"generating...",
+				"building tool call...",
+				"waiting for tool response...",
+			},
+			PromptPatterns: []string{"Ask anything", "press enter to send"},
+			SpinnerChars:   []string{"█", "▓", "▒", "░"},
 		}
 	case "codex":
 		return &RawPatterns{

--- a/internal/tmux/patterns_test.go
+++ b/internal/tmux/patterns_test.go
@@ -59,6 +59,23 @@ func TestDefaultRawPatterns_Gemini(t *testing.T) {
 	}
 }
 
+func TestDefaultRawPatterns_OpenCode(t *testing.T) {
+	raw := DefaultRawPatterns("opencode")
+	if raw == nil {
+		t.Fatal("expected non-nil for opencode")
+	}
+
+	if len(raw.BusyPatterns) == 0 {
+		t.Error("opencode should have busy patterns")
+	}
+	if len(raw.PromptPatterns) == 0 {
+		t.Error("opencode should have prompt patterns")
+	}
+	if len(raw.SpinnerChars) == 0 {
+		t.Error("opencode should define spinner chars")
+	}
+}
+
 func TestDefaultRawPatterns_Codex(t *testing.T) {
 	raw := DefaultRawPatterns("codex")
 	if raw == nil {


### PR DESCRIPTION
## Summary
- restore OpenCode default busy patterns to include real processing signals (esc hints + task text)
- add OpenCode pulse spinner characters to default status detection
- add regression tests for OpenCode defaults and busy detection behavior

## Validation
- go test ./internal/tmux -count=1
- go test ./internal/session -run 'OpenCode|Opencode|opencode' -count=1
- go test ./... -count=1

Fixes #242