### PR TITLE
fix(add): eliminate worktree TOCTOU race

### DIFF
--- a/cmd/agent-deck/add_test.go
+++ b/cmd/agent-deck/add_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -189,6 +190,44 @@ func TestIsDuplicateSession_MultipleExistingSessions(t *testing.T) {
 	}
 	if existing != nil {
 		t.Errorf("Expected nil existing instance for non-duplicate")
+	}
+}
+
+func TestIsWorktreeAlreadyExistsError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "git path exists error",
+			err:  errors.New("failed to create worktree: fatal: '/tmp/repo-feature' already exists"),
+			want: true,
+		},
+		{
+			name: "case insensitive match",
+			err:  errors.New("FAILED: ALREADY EXISTS"),
+			want: true,
+		},
+		{
+			name: "different git failure",
+			err:  errors.New("failed to create worktree: fatal: invalid reference: bad-branch"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isWorktreeAlreadyExistsError(tt.err)
+			if got != tt.want {
+				t.Errorf("isWorktreeAlreadyExistsError() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -610,6 +610,16 @@ func generateUniqueTitle(instances []*session.Instance, baseTitle, path string) 
 	return fmt.Sprintf("%s (%d)", baseTitle, time.Now().Unix())
 }
 
+// isWorktreeAlreadyExistsError detects whether git worktree creation failed because
+// the destination path already exists. This preserves friendly UX while avoiding
+// TOCTOU race windows from separate filesystem pre-checks.
+func isWorktreeAlreadyExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "already exists")
+}
+
 func resolveAutoParentInstance(instances []*session.Instance) *session.Instance {
 	candidates := []string{
 		strings.TrimSpace(os.Getenv("AGENT_DECK_SESSION_ID")),
@@ -906,15 +916,14 @@ func handleAdd(profile string, args []string) {
 			os.Exit(1)
 		}
 
-		// Check if worktree already exists
-		if _, err := os.Stat(worktreePath); err == nil {
-			fmt.Fprintf(os.Stderr, "Error: worktree already exists at %s\n", worktreePath)
-			fmt.Fprintf(os.Stderr, "Tip: Use 'agent-deck add %s' to add the existing worktree\n", worktreePath)
-			os.Exit(1)
-		}
-
-		// Create worktree
+		// Create worktree atomically (git handles existence checks).
+		// This avoids a TOCTOU race from separate check-then-create steps.
 		if err := git.CreateWorktree(repoRoot, worktreePath, wtBranch); err != nil {
+			if isWorktreeAlreadyExistsError(err) {
+				fmt.Fprintf(os.Stderr, "Error: worktree already exists at %s\n", worktreePath)
+				fmt.Fprintf(os.Stderr, "Tip: Use 'agent-deck add %s' to add the existing worktree\n", worktreePath)
+				os.Exit(1)
+			}
 			fmt.Fprintf(os.Stderr, "Error: failed to create worktree: %v\n", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary
- remove the pre-flight path existence check before worktree creation
- rely on atomic git worktree add behavior for existence detection
- preserve friendly UX by mapping "already exists" failures to the existing help text
- add unit coverage for isWorktreeAlreadyExistsError

## Why
The old check-then-create flow had a TOCTOU race window under concurrent agent-deck add --worktree usage.

## Validation
- go test ./cmd/agent-deck -run 'TestIsWorktreeAlreadyExistsError|TestIsDuplicateSession|TestGenerateUniqueTitle' -count=1
- go test ./... -count=1

Fixes #222
