### PR TITLE
fix: avoid false claude detection for shell sessions

### DIFF
--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -426,6 +426,64 @@ func TestDetectTool(t *testing.T) {
 	}
 }
 
+func TestDetectToolFromCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{name: "claude", command: "claude", want: "claude"},
+		{name: "gemini", command: "gemini --yolo", want: "gemini"},
+		{name: "opencode", command: "open-code --continue", want: "opencode"},
+		{name: "codex", command: "codex --dangerously-bypass-approvals-and-sandbox", want: "codex"},
+		{name: "shell command", command: "npm run dev", want: ""},
+		{name: "empty", command: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromCommand(tt.command); got != tt.want {
+				t.Fatalf("detectToolFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromContentClaudeRegression(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name: "path containing claude should stay shell",
+			content: `user@host:/Users/test/claude-deck$ 
+$ `,
+			want: "shell",
+		},
+		{
+			name: "claude banner detects claude",
+			content: `Welcome to Claude Code!
+Do you trust the files in this folder?`,
+			want: "claude",
+		},
+		{
+			name: "claude permission prompt detects claude",
+			content: `No, and tell Claude what to do differently
+Yes, allow once`,
+			want: "claude",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromContent(tt.content); got != tt.want {
+				t.Fatalf("detectToolFromContent(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestReconnectSession(t *testing.T) {
 	// Test that ReconnectSession properly initializes all fields
 	sess := ReconnectSession("agentdeck_test_abc123", "test", "/tmp", "claude")


### PR DESCRIPTION
## Summary
- tighten content-based Claude detection to avoid matching plain shell text like `claude-deck`
- keep command-based detection intact and centralize command/content detection logic
- add regression coverage for shell-path false positives and valid Claude prompt detection

## Testing
- go test ./internal/tmux -run 'TestDetectTool|TestDetectToolFromCommand|TestDetectToolFromContentClaudeRegression'
- go test ./...

Fixes #219
