### PR TITLE
fix(ui): resolve duplicate group names when moving sessions

### DIFF
--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -28,7 +28,7 @@ type GroupDialog struct {
 	height        int
 	groupPath     string   // Current group being edited (for rename) or parent path (for create subgroup)
 	parentName    string   // Display name of parent group (for subgroup creation)
-	groupNames    []string // Available groups (for move)
+	groupPaths    []string // Available target group paths (for move)
 	selected      int      // Selected group index (for move)
 	sessionID     string   // Session ID being renamed (for rename session)
 	validationErr string   // Inline validation error displayed inside the dialog
@@ -47,7 +47,7 @@ func NewGroupDialog() *GroupDialog {
 
 	return &GroupDialog{
 		nameInput:  ti,
-		groupNames: []string{},
+		groupPaths: []string{},
 	}
 }
 
@@ -146,12 +146,12 @@ func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 	g.nameInput.Focus()
 }
 
-// ShowMove shows the dialog for moving a session to a group
-func (g *GroupDialog) ShowMove(groups []string) {
+// ShowMove shows the dialog for moving a session to a group path.
+func (g *GroupDialog) ShowMove(groupPaths []string) {
 	g.visible = true
 	g.mode = GroupDialogMove
 	g.validationErr = ""
-	g.groupNames = groups
+	g.groupPaths = groupPaths
 	g.selected = 0
 }
 
@@ -249,8 +249,8 @@ func (g *GroupDialog) HasParent() bool {
 
 // GetSelectedGroup returns the selected group for move mode
 func (g *GroupDialog) GetSelectedGroup() string {
-	if g.selected >= 0 && g.selected < len(g.groupNames) {
-		return g.groupNames[g.selected]
+	if g.selected >= 0 && g.selected < len(g.groupPaths) {
+		return g.groupPaths[g.selected]
 	}
 	return ""
 }
@@ -270,7 +270,7 @@ func (g *GroupDialog) Update(msg tea.KeyMsg) (*GroupDialog, tea.Cmd) {
 				g.selected--
 			}
 		case "down", "j":
-			if g.selected < len(g.groupNames)-1 {
+			if g.selected < len(g.groupPaths)-1 {
 				g.selected++
 			}
 		}
@@ -333,19 +333,19 @@ func (g *GroupDialog) View() string {
 	case GroupDialogMove:
 		title = "Move to Group"
 		var items []string
-		for i, name := range g.groupNames {
+		for i, groupPath := range g.groupPaths {
 			if i == g.selected {
 				items = append(items, lipgloss.NewStyle().
 					Foreground(ColorBg).
 					Background(ColorAccent).
 					Bold(true).
 					Padding(0, 1).
-					Render(name))
+					Render(groupPath))
 			} else {
 				items = append(items, lipgloss.NewStyle().
 					Foreground(ColorText).
 					Padding(0, 1).
-					Render(name))
+					Render(groupPath))
 			}
 		}
 		content = strings.Join(items, "\n")

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3943,7 +3943,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession {
-				h.groupDialog.ShowMove(h.groupTree.GetGroupNames())
+				h.groupDialog.ShowMove(h.groupTree.GetGroupPaths())
 			}
 		}
 		return h, nil
@@ -4662,22 +4662,16 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				h.saveInstances()
 			}
 		case GroupDialogMove:
-			groupName := h.groupDialog.GetSelectedGroup()
-			if groupName != "" && h.cursor < len(h.flatItems) {
+			targetGroupPath := h.groupDialog.GetSelectedGroup()
+			if targetGroupPath != "" && h.cursor < len(h.flatItems) {
 				item := h.flatItems[h.cursor]
 				if item.Type == session.ItemTypeSession {
-					// Find the group path from name
-					for _, g := range h.groupTree.GroupList {
-						if g.Name == groupName {
-							h.groupTree.MoveSessionToGroup(item.Session, g.Path)
-							h.instancesMu.Lock()
-							h.instances = h.groupTree.GetAllInstances()
-							h.instancesMu.Unlock()
-							h.rebuildFlatItems()
-							h.saveInstances()
-							break
-						}
-					}
+					h.groupTree.MoveSessionToGroup(item.Session, targetGroupPath)
+					h.instancesMu.Lock()
+					h.instances = h.groupTree.GetAllInstances()
+					h.instancesMu.Unlock()
+					h.rebuildFlatItems()
+					h.saveInstances()
 				}
 			}
 		case GroupDialogRenameSession:


### PR DESCRIPTION
## Summary
- fix TUI session move flow to use canonical group paths instead of display names
- prevent duplicate-name ambiguity (e.g. `work/frontend` and `play/frontend`) when selecting a move target
- update move dialog list to show unique group paths and apply selected path directly
- add regression test covering duplicate group names

## Testing
- go test ./internal/ui -run 'TestHomeMoveSessionWithDuplicateGroupNamesUsesSelectedPath|TestHomeUpdateNewDialog|TestHomeRenameSessionComplete'
- go test ./...

Fixes #221
