### PR TITLE
fix(ui): align confirm dialog border

### DIFF
--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -155,7 +155,7 @@ func (c *ConfirmDialog) View() string {
 
 	switch c.confirmType {
 	case ConfirmDeleteSession:
-		title = "⚠️  Delete Session?"
+		title = "⚠  Delete Session?"
 		warning = fmt.Sprintf("This will permanently delete the session:\n\n  \"%s\"", c.targetName)
 		details = "• The tmux session will be terminated\n• Any running processes will be killed\n• Terminal history will be lost"
 		if c.sandboxed {
@@ -182,7 +182,7 @@ func (c *ConfirmDialog) View() string {
 		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonYes, "  ", buttonNo, "  ", escHint)
 
 	case ConfirmDeleteGroup:
-		title = "⚠️  Delete Group?"
+		title = "⚠  Delete Group?"
 		warning = fmt.Sprintf("This will delete the group:\n\n  \"%s\"", c.targetName)
 		details = "• All sessions will be MOVED to 'default' group\n• Sessions will NOT be killed\n• The group structure will be lost"
 		borderColor = ColorRed


### PR DESCRIPTION
## Summary

<img width="1392" height="902" alt="CleanShot-2026-02-26-oSrGSPwK" src="https://github.com/user-attachments/assets/997b880f-ba4f-4bcb-87f3-2df00b25dfa4" />

- Fix misaligned right border on the delete session/group confirmation dialogs
- Root cause: `⚠️` (U+26A0 + U+FE0F) renders as 2 cells in the terminal but `go-runewidth` measures it as 1, causing lipgloss to over-pad the title line by 1 character
- Fix: drop the VS16 variation selector so the glyph uses text presentation with consistent 1-cell width — still renders as `⚠` with the red foreground color from the existing style

<img width="1308" height="912" alt="CleanShot-2026-02-26-WraiOmrh" src="https://github.com/user-attachments/assets/ccb84d8e-7401-4ace-9fc5-0ec43c61dfbe" />


## Test plan

- [x] Delete session confirm dialog — right border now aligns correctly
- [x] Delete group confirm dialog — same fix applied