### PR TITLE
feat(bridge): add Telegram voice message support via OpenAI Whisper

### DIFF
--- a/conductor/voice_transcriber.py
+++ b/conductor/voice_transcriber.py
@@ -1,0 +1,76 @@
+"""
+Voice message transcription for the conductor bridge.
+
+Downloads Telegram voice messages (.ogg) and transcribes them
+using the OpenAI Whisper API. Falls back gracefully when the
+API key is missing or the transcription fails.
+
+Dependencies: pip3 install openai
+"""
+
+import logging
+import tempfile
+from pathlib import Path
+
+log = logging.getLogger("conductor-bridge")
+
+try:
+    from openai import OpenAI
+
+    HAS_OPENAI = True
+except ImportError:
+    HAS_OPENAI = False
+
+
+def is_available(config: dict) -> bool:
+    """Check whether voice transcription is configured and usable."""
+    voice_cfg = config.get("voice", {})
+    if not voice_cfg.get("enabled", False):
+        return False
+    if not HAS_OPENAI:
+        log.warning("Voice enabled but 'openai' package not installed. pip3 install openai")
+        return False
+    if not voice_cfg.get("openai_api_key"):
+        log.warning("Voice enabled but conductor.telegram.voice.openai_api_key not set")
+        return False
+    return True
+
+
+async def transcribe_voice(bot, voice_file_id: str, config: dict) -> str | None:
+    """Download a Telegram voice message and transcribe it via Whisper.
+
+    Returns the transcribed text, or None on failure.
+    """
+    voice_cfg = config.get("voice", {})
+    api_key = voice_cfg.get("openai_api_key", "")
+    model = voice_cfg.get("model", "whisper-1")
+
+    if not api_key:
+        return None
+
+    tmp_path: Path | None = None
+    try:
+        file = await bot.get_file(voice_file_id)
+        tmp_path = Path(tempfile.mktemp(suffix=".ogg"))
+        await bot.download_file(file.file_path, destination=str(tmp_path))
+
+        log.info("Voice file downloaded (%d bytes), transcribing with %s", tmp_path.stat().st_size, model)
+
+        client = OpenAI(api_key=api_key)
+        with open(tmp_path, "rb") as audio_file:
+            transcript = client.audio.transcriptions.create(
+                model=model,
+                file=audio_file,
+            )
+
+        text = transcript.text.strip()
+        log.info("Transcription result (%d chars): %s", len(text), text[:100])
+        return text if text else None
+
+    except Exception as e:
+        log.error("Voice transcription failed: %s", e)
+        return None
+
+    finally:
+        if tmp_path and tmp_path.exists():
+            tmp_path.unlink()


### PR DESCRIPTION
## Summary

- Telegram voice messages are now transcribed via the OpenAI Whisper API and forwarded to the conductor as text
- New `voice_transcriber.py` module handles download + transcription with graceful fallback
- The bridge echoes back `[Heard: ...]` so the user can verify the transcription before the conductor processes it

## Configuration

Add to `~/.agent-deck/config.toml`:

```toml
[conductor.telegram.voice]
enabled = true
openai_api_key = "sk-..."   # or set OPENAI_API_KEY env var
model = "whisper-1"          # optional, defaults to whisper-1
```

## How it works

1. User sends a voice message in Telegram
2. Bridge detects `message.voice` and downloads the `.ogg` file
3. File is sent to OpenAI Whisper API for transcription
4. Transcribed text is echoed back: `[Heard: check the stripe session]`
5. Text is forwarded to the conductor via the existing `send_to_conductor` pipeline
6. Conductor response is sent back to Telegram as usual

## Dependencies

- `openai` Python package (`pip3 install openai`)
- Gracefully degrades: if `openai` is not installed or voice is not enabled, voice messages are silently ignored (same as current behavior)

## Test plan

- [ ] Send a voice message with voice enabled + valid API key -> transcription echoed + forwarded to conductor
- [ ] Send a voice message with voice disabled -> silently ignored
- [ ] Send a voice message with voice enabled but no API key -> warning logged, message ignored
- [ ] Send a voice message with voice enabled but `openai` not installed -> warning logged, message ignored
- [ ] `/help` command shows voice status (on/off)
- [ ] Text messages continue to work exactly as before


Made with [Cursor](https://cursor.com)