### PR TITLE
Reduce tmux parsing

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -55,6 +55,11 @@ const (
 	// At 2s: 2-5 CapturePane() calls/sec = minimal CPU overhead
 	tickInterval = 2 * time.Second
 
+	// logOutputDebounce limits how often a single session can trigger
+	// UpdateStatus() from tmux %output events.
+	// A higher value avoids expensive status parsing loops for very chatty sessions
+	logOutputDebounce = 2 * time.Second
+
 	// Launch animation minimum durations.
 	// Claude/Gemini get longer feedback because startup UI is richer and may settle asynchronously.
 	minLaunchAnimationDurationDefault = 500 * time.Millisecond
@@ -610,7 +615,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 			if inst.GetTmuxSession() != nil && inst.GetTmuxSession().Name == sessionName {
 				h.logActivityMu.Lock()
 				lastUpdate := h.lastLogActivity[inst.ID]
-				if time.Since(lastUpdate) < 500*time.Millisecond {
+				if time.Since(lastUpdate) < logOutputDebounce {
 					h.logActivityMu.Unlock()
 					break
 				}


### PR DESCRIPTION
I have multi-second lag when doing simple things like pressing `j` and `k` on the agent-deck TUI even when there is no very little load on my CPU and IO under specific conditions and I've maxed out IO niceness and niceness specifically for the agent-deck pids (and tmux pids). This only happens when codex runs [the lean mcp server](https://github.com/oOo0oOo/lean-lsp-mcp), and immediately stops when codex pauses for user input. The (codex guided) solution was this change to parse that session less. It seems to have fixed my issue.

I don't have great advice for reproducing other than checking out a really large lean repo (say, mathlib), installing the mcp server, and running claude or codex to do something with it (exploration is likely enough). It's still a bit jumpy, but on the order of "barely noticable" rather than "unusablely laggy"