### PR TITLE
fix: respect custom claude command for new sessions

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -440,8 +440,8 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 				// This handles the case where session was started but no message was sent
 				bashExportPrefix := i.buildBashExportPrefix()
 				return fmt.Sprintf(
-					`tmux set-environment CLAUDE_SESSION_ID "%s"; %sclaude --session-id "%s"%s`,
-					opts.ResumeSessionID, bashExportPrefix, opts.ResumeSessionID, extraFlags)
+					`tmux set-environment CLAUDE_SESSION_ID "%s"; %s%s --session-id "%s"%s`,
+					opts.ResumeSessionID, bashExportPrefix, claudeCmd, opts.ResumeSessionID, extraFlags)
 			}
 			// No session ID provided - use -r flag for interactive picker
 			return fmt.Sprintf(`%s%s -r%s`, configDirPrefix, claudeCmd, extraFlags)
@@ -453,10 +453,8 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 		// 3. Resumes that session interactively
 		// Fallback ensures Claude starts (without fork/restart support) rather than failing completely
 		//
-		// IMPORTANT: For capture-resume commands (which contain $(...) syntax), we MUST use
-		// "claude" binary + CLAUDE_CONFIG_DIR, NOT a custom command alias like "cdw".
-		// Reason: Commands with $(...) get wrapped in `bash -c` for fish compatibility (#47),
-		// and shell aliases are not available in non-interactive bash shells.
+		// NOTE: These commands get wrapped in `bash -c` for fish compatibility (#47),
+		// so shell aliases won't work — but real binaries/scripts are fine.
 		//
 		bashExportPrefix := i.buildBashExportPrefix()
 
@@ -466,8 +464,8 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 		baseCmd = fmt.Sprintf(
 			`session_id=$(uuidgen | tr '[:upper:]' '[:lower:]'); `+
 				`tmux set-environment CLAUDE_SESSION_ID "$session_id"; `+
-				`%sclaude --session-id "$session_id"%s`,
-			bashExportPrefix, extraFlags)
+				`%s%s --session-id "$session_id"%s`,
+			bashExportPrefix, claudeCmd, extraFlags)
 
 		// If message provided, append wait-and-send logic
 		if message != "" {
@@ -481,9 +479,9 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 					`(sleep 2; SESSION_NAME=$(tmux display-message -p '#S'); `+
 					`while ! tmux capture-pane -p -t "$SESSION_NAME" | tail -5 | grep -qE "^>"; do sleep 0.2; done; `+
 					`tmux send-keys -l -t "$SESSION_NAME" -- '%s' \\; send-keys -t "$SESSION_NAME" Enter) & `+
-					`%sclaude --session-id "$session_id"%s`,
+					`%s%s --session-id "$session_id"%s`,
 				escapedMsg,
-				bashExportPrefix, extraFlags)
+				bashExportPrefix, claudeCmd, extraFlags)
 		}
 
 		return baseCmd

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -409,10 +409,7 @@ func TestBuildClaudeCommand_ExplicitConfig(t *testing.T) {
 	}
 }
 
-// TestBuildClaudeCommand_CustomAlias tests that capture-resume commands always use
-// "claude" binary + CLAUDE_CONFIG_DIR, NOT the custom alias (aliases don't work in bash -c)
 func TestBuildClaudeCommand_CustomAlias(t *testing.T) {
-	// Create temp config with custom command
 	origHome := os.Getenv("HOME")
 	tmpDir := t.TempDir()
 	os.Setenv("HOME", tmpDir)
@@ -439,11 +436,8 @@ config_dir = "~/.claude-work"
 	inst := NewInstanceWithTool("test", "/tmp/test", "claude")
 	cmd := inst.buildClaudeCommand("claude")
 
-	// Should use "claude" binary (NOT "cdw" alias) for capture-resume commands
-	// Reason: Commands with $(...) get wrapped in `bash -c` for fish compatibility (#47),
-	// and shell aliases are not available in non-interactive bash shells
-	if strings.Contains(cmd, "cdw") {
-		t.Errorf("Should NOT use alias 'cdw' in capture-resume command (aliases don't work in bash -c), got: %s", cmd)
+	if !strings.Contains(cmd, "cdw") {
+		t.Errorf("Should use custom command 'cdw' from config, got: %s", cmd)
 	}
 
 	// Should include CLAUDE_CONFIG_DIR since config_dir is explicitly set


### PR DESCRIPTION
The [claude].command config (e.g., "cdw") was only used for session restarts/resumes. New sessions hardcoded "claude" in three places within buildClaudeCommandWithMessage(), causing subsequent new sessions to ignore the custom command.

Replace hardcoded "claude" with claudeCmd in all three new-session code paths: resume-with-session-ID, default new-session, and message-with-wait-and-send.