### PR TITLE
perf: hoist compiled regexps to package level

### DIFF
--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -16,6 +16,9 @@ import (
 // Claude Code replaces all such characters with hyphens in project directory names
 var claudeDirNameRegex = regexp.MustCompile(`[^a-zA-Z0-9-]`)
 
+// uuidSessionFileRegex matches UUID-format JSONL session filenames.
+var uuidSessionFileRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$`)
+
 // ConvertToClaudeDirName converts a filesystem path to Claude's directory naming format.
 // Claude Code replaces all non-alphanumeric characters (except hyphens) with hyphens.
 // Example: /Users/master/Code cloud/!Project → -Users-master-Code-cloud--Project
@@ -351,8 +354,8 @@ func findActiveSessionIDExcluding(configDir, projectPath string, excludeIDs map[
 		return ""
 	}
 
-	// UUID pattern for session files
-	uuidPattern := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$`)
+	// UUID pattern for session files (compiled once at package level)
+	uuidPattern := uuidSessionFileRegex
 
 	var mostRecent string
 	var mostRecentTime time.Time

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -898,11 +898,13 @@ func (s *Session) InvalidateEnvCache() {
 	s.envCacheMu.Unlock()
 }
 
+// sanitizeNameRe matches characters not allowed in tmux session names.
+var sanitizeNameRe = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
+
 // sanitizeName converts a display name to a valid tmux session name
 func sanitizeName(name string) string {
 	// Replace spaces and special characters with hyphens
-	re := regexp.MustCompile(`[^a-zA-Z0-9-]+`)
-	return re.ReplaceAllString(name, "-")
+	return sanitizeNameRe.ReplaceAllString(name, "-")
 }
 
 // Start creates and starts a tmux session.


### PR DESCRIPTION
Two `regexp.MustCompile` calls that live inside functions are moved to package-level variables so they compile once at init instead of on every call.

**Changes**

- `internal/tmux/tmux.go` – `sanitizeName()` compiled its pattern on every invocation.
- `internal/session/claude.go` – `findActiveSessionIDExcluding()` compiled a UUID pattern on every invocation.

Both are now package-level `var` declarations, consistent with the existing `claudeDirNameRegex` in the same file.