### PR TITLE
fix(conductor): add Discord typing indicator and async executor

### DIFF
--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -1639,13 +1639,18 @@ def create_discord_bot(config: dict):
             "Discord message -> [%s]: %s",
             target["name"], cleaned_msg[:100],
         )
-        ok, response = send_to_conductor(
-            session_title,
-            cleaned_msg,
-            profile=profile,
-            wait_for_reply=True,
-            response_timeout=RESPONSE_TIMEOUT,
-        )
+        async with message.channel.typing():
+            loop = asyncio.get_event_loop()
+            ok, response = await loop.run_in_executor(
+                None,
+                lambda: send_to_conductor(
+                    session_title,
+                    cleaned_msg,
+                    profile=profile,
+                    wait_for_reply=True,
+                    response_timeout=RESPONSE_TIMEOUT,
+                ),
+            )
         if not ok:
             await message.channel.send(
                 f"[Failed to send message to conductor {target['name']}.]",

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -1825,6 +1825,16 @@ func TestBridgeTemplate_DiscordInMain(t *testing.T) {
 	}
 }
 
+func TestBridgeTemplate_DiscordTypingIndicator(t *testing.T) {
+	template := conductorBridgePy
+	if !strings.Contains(template, "async with message.channel.typing():") {
+		t.Error("Discord on_message should show typing indicator while waiting for conductor response")
+	}
+	if !strings.Contains(template, "run_in_executor") {
+		t.Error("Discord on_message should offload blocking send_to_conductor to thread executor")
+	}
+}
+
 func TestConductorClearOnCompact(t *testing.T) {
 	// Override HOME so LoadConductorMeta reads from our temp dir
 	tmpHome := t.TempDir()


### PR DESCRIPTION
## Summary

Follow-up to #267 / #268 — the Discord `on_message` handler was missing a typing indicator and called `send_to_conductor()` synchronously on the event loop.

This caused two issues:
1. **No visual feedback** — the user sees nothing in Discord while waiting for the conductor response (up to 5 minutes)
2. **Event loop blocked** — discord.py can't respond to gateway heartbeat pings during the wait, risking disconnection

## Changes

- Wrap `send_to_conductor` in `async with message.channel.typing():` — shows "Bot is typing..." indicator
- Offload blocking subprocess call to thread pool via `run_in_executor()` — keeps the event loop responsive
- Add test for typing indicator and executor patterns

<img width="257" height="81" alt="Screenshot From 2026-03-03 12-40-18" src="https://github.com/user-attachments/assets/15a8976f-9f5c-4fba-8c1b-feef4b5cb0e8" />


## Test plan

- [x] `go build` succeeds
- [x] All Discord template tests pass
- [x] Tested locally — typing indicator visible in Discord channel