### PR TITLE
git: add collision-safe worktree template branch variable

### DIFF
--- a/internal/git/template.go
+++ b/internal/git/template.go
@@ -3,6 +3,7 @@ package git
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -29,10 +30,11 @@ var consecutiveDashes = regexp.MustCompile(`-{2,}`)
 
 // templateVars holds values for template substitution.
 type templateVars struct {
-	branch    string
-	repoName  string
-	repoRoot  string
-	sessionID string
+	branch        string
+	branchEscaped string
+	repoName      string
+	repoRoot      string
+	sessionID     string
 }
 
 // WorktreePathOptions configures worktree path generation.
@@ -53,6 +55,14 @@ func sanitizeBranchForPath(branch string) string {
 	return strings.Trim(result, "-")
 }
 
+// escapeBranchForPath returns a reversible path-safe branch representation.
+// Unlike sanitizeBranchForPath, this avoids collisions:
+// - feature/foo    -> feature%2Ffoo
+// - feature-foo    -> feature-foo
+func escapeBranchForPath(branch string) string {
+	return url.PathEscape(branch)
+}
+
 // resolveTemplate expands a path template with the given variables.
 // Returns the resolved absolute path.
 //
@@ -68,6 +78,7 @@ func resolveTemplate(template string, vars templateVars) string {
 		"{repo-name}", vars.repoName,
 		"{repo-root}", vars.repoRoot,
 		"{branch}", sanitizedBranch,
+		"{branch-escaped}", vars.branchEscaped,
 		"{session-id}", vars.sessionID,
 	)
 	resolved := replacer.Replace(template)
@@ -81,7 +92,11 @@ func resolveTemplate(template string, vars templateVars) string {
 }
 
 // WorktreePath generates a worktree path. If opts.Template is set, it expands
-// the template with variables {repo-name}, {repo-root}, {branch}, {session-id}.
+// the template with variables:
+//   - {repo-name}, {repo-root}, {session-id}
+//   - {branch}: sanitized (human-friendly, may collide)
+//   - {branch-escaped}: URL-escaped (collision-resistant, reversible)
+//
 // Unknown variables like {foo} are left as-is in the resolved path.
 // Falls back to location-based strategy using opts.Location when template is
 // empty or RepoDir is invalid.
@@ -94,10 +109,11 @@ func WorktreePath(opts WorktreePathOptions) string {
 	}
 
 	vars := templateVars{
-		branch:    opts.Branch,
-		repoName:  repoName,
-		repoRoot:  opts.RepoDir,
-		sessionID: opts.SessionID,
+		branch:        opts.Branch,
+		branchEscaped: escapeBranchForPath(opts.Branch),
+		repoName:      repoName,
+		repoRoot:      opts.RepoDir,
+		sessionID:     opts.SessionID,
 	}
 	return resolveTemplate(opts.Template, vars)
 }

--- a/internal/git/template_test.go
+++ b/internal/git/template_test.go
@@ -148,6 +148,46 @@ func TestSanitizeBranchForPath(t *testing.T) {
 	}
 }
 
+func TestEscapeBranchForPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "branch with slash stays distinct",
+			input:    "feature/new-thing",
+			expected: "feature%2Fnew-thing",
+		},
+		{
+			name:     "branch with dash remains literal",
+			input:    "feature-new-thing",
+			expected: "feature-new-thing",
+		},
+		{
+			name:     "percent is escaped",
+			input:    "feature%2Fnew-thing",
+			expected: "feature%252Fnew-thing",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := escapeBranchForPath(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+
+	// Collision regression check for the reported branch pair.
+	require.NotEqual(t,
+		escapeBranchForPath("feature/foo"),
+		escapeBranchForPath("feature-foo"),
+	)
+}
+
 func TestResolveTemplate(t *testing.T) {
 	t.Parallel()
 
@@ -216,12 +256,25 @@ func TestResolveTemplate(t *testing.T) {
 			name:     "branch with slash gets sanitized",
 			template: "{repo-root}/.worktrees/{branch}",
 			vars: templateVars{
-				branch:    "feature/new-thing",
-				repoName:  "my-project",
-				repoRoot:  "/Users/me/src/my-project",
-				sessionID: "a1b2c3d4",
+				branch:        "feature/new-thing",
+				branchEscaped: "feature%2Fnew-thing",
+				repoName:      "my-project",
+				repoRoot:      "/Users/me/src/my-project",
+				sessionID:     "a1b2c3d4",
 			},
 			expected: "/Users/me/src/my-project/.worktrees/feature-new-thing",
+		},
+		{
+			name:     "escaped branch variable avoids collisions",
+			template: "{repo-root}/wt/{branch-escaped}",
+			vars: templateVars{
+				branch:        "feature/foo",
+				branchEscaped: "feature%2Ffoo",
+				repoName:      "my-project",
+				repoRoot:      "/Users/me/src/my-project",
+				sessionID:     "a1b2c3d4",
+			},
+			expected: "/Users/me/src/my-project/wt/feature%2Ffoo",
 		},
 		{
 			name:     "all variables used",

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -553,7 +553,10 @@ type WorktreeSettings struct {
 	DefaultLocation string `toml:"default_location"`
 
 	// PathTemplate: custom path template for worktree location.
-	// Variables: {repo-name}, {repo-root}, {branch}, {session-id}
+	// Variables:
+	//   {repo-name}, {repo-root}, {session-id}
+	//   {branch}         -> sanitized (human-friendly, may collide)
+	//   {branch-escaped} -> URL-escaped (collision-resistant, reversible)
 	// Unknown variables like {foo} are left as-is in the path.
 	// If set, overrides DefaultLocation.
 	PathTemplate *string `toml:"path_template"`
@@ -1492,7 +1495,10 @@ default_location = "sibling"
 # Automatically remove worktree when session is deleted
 auto_cleanup = true
 # Custom path template (overrides default_location if set)
-# Variables: {repo-name}, {repo-root}, {branch}, {session-id}
+# Variables:
+#   {repo-name}, {repo-root}, {session-id}
+#   {branch}         -> sanitized (human-friendly, may collide)
+#   {branch-escaped} -> URL-escaped (collision-resistant, reversible)
 # path_template = "../worktrees/{repo-name}/{branch}"
 
 # Default scope for MCP operations: "local", "global", or "user"


### PR DESCRIPTION
Problem:
- Path templates that use {branch} are based on a sanitized branch string.
- Distinct branch names like `feature/foo` and `feature-foo` can map to the same directory name (`feature-foo`)

Approach:
- Keep existing {branch} behavior for backwards compatibility.
- Add a new template variable, `{branch-escaped}`, that uses a reversible URL-escaped branch representation to avoid collisions.

Changes:
- internal/git/template.go: added escapeBranchForPath() and support for {branch-escaped} during template expansion.
- internal/git/template_test.go: added tests for escaped branch behavior and a regression asserting feature/foo != feature-foo.
- internal/session/userconfig.go: documented the new variable and clarified tradeoffs between {branch} and {branch-escaped}.
- Breaking/Schema/API impact: none (backward-compatible additive template variable).

Validation:
- go test ./internal/git -run 'TestSanitizeBranchForPath|TestEscapeBranchForPath|TestResolveTemplate|TestWorktreePath|TestGenerateWorktreePath'
- go test ./internal/session -run 'TestGetWorktreeSettings|TestLoadUserConfig'