### PR TITLE
fix(tmux): recover stale default socket on session start

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -905,6 +906,103 @@ func sanitizeName(name string) string {
 	return re.ReplaceAllString(name, "-")
 }
 
+func shouldRecoverFromTmuxStartError(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "server exited unexpectedly") ||
+		strings.Contains(lower, "lost server")
+}
+
+func recoverFromStaleDefaultSocketIfNeeded(startErrOutput string) (bool, error) {
+	if !shouldRecoverFromTmuxStartError(startErrOutput) {
+		return false, nil
+	}
+
+	// If tmux can already answer list-sessions, don't touch any socket file.
+	if err := exec.Command("tmux", "list-sessions").Run(); err == nil {
+		return false, nil
+	}
+
+	for _, socketPath := range defaultTmuxSocketCandidates() {
+		info, err := os.Stat(socketPath)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		if isSocketAcceptingConnections(socketPath) {
+			continue
+		}
+
+		backupPath := fmt.Sprintf("%s.stale.%d", socketPath, time.Now().UnixNano())
+		if err := os.Rename(socketPath, backupPath); err != nil {
+			return false, fmt.Errorf("failed to quarantine stale tmux socket %s: %w", socketPath, err)
+		}
+
+		statusLog.Warn("tmux_stale_socket_recovered",
+			slog.String("socket", socketPath),
+			slog.String("backup", backupPath),
+		)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func defaultTmuxSocketCandidates() []string {
+	uid := os.Getuid()
+	if uid < 0 {
+		return nil
+	}
+
+	add := func(out []string, seen map[string]struct{}, p string) []string {
+		if p == "" {
+			return out
+		}
+		if _, ok := seen[p]; ok {
+			return out
+		}
+		seen[p] = struct{}{}
+		return append(out, p)
+	}
+
+	seen := make(map[string]struct{})
+	candidates := make([]string, 0, 5)
+	if tmuxPath := tmuxSocketPathFromEnv(); tmuxPath != "" {
+		candidates = add(candidates, seen, tmuxPath)
+	}
+
+	socketSuffix := filepath.Join(fmt.Sprintf("tmux-%d", uid), "default")
+	if tmuxTmp := os.Getenv("TMUX_TMPDIR"); tmuxTmp != "" {
+		candidates = add(candidates, seen, filepath.Join(tmuxTmp, socketSuffix))
+	}
+	candidates = add(candidates, seen, filepath.Join(os.TempDir(), socketSuffix))
+	candidates = add(candidates, seen, filepath.Join("/tmp", socketSuffix))
+	candidates = add(candidates, seen, filepath.Join("/private/tmp", socketSuffix))
+	return candidates
+}
+
+func tmuxSocketPathFromEnv() string {
+	raw := os.Getenv("TMUX")
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, ",")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[0]
+}
+
+func isSocketAcceptingConnections(socketPath string) bool {
+	conn, err := net.DialTimeout("unix", socketPath, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
 // Start creates and starts a tmux session.
 // By default, command is sent after session creation (legacy behavior).
 // When RunCommandAsInitialProcess is true, command is passed directly to tmux
@@ -944,6 +1042,19 @@ func (s *Session) Start(command string) error {
 	}
 	cmd := exec.Command("tmux", args...)
 	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if recovered, recoverErr := recoverFromStaleDefaultSocketIfNeeded(string(output)); recoverErr != nil {
+			statusLog.Warn("tmux_stale_socket_recovery_failed",
+				slog.String("session", s.Name),
+				slog.String("error", recoverErr.Error()),
+			)
+		} else if recovered {
+			statusLog.Warn("tmux_start_retry_after_socket_recovery",
+				slog.String("session", s.Name),
+			)
+			output, err = exec.Command("tmux", args...).CombinedOutput()
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("failed to create tmux session: %w (output: %s)", err, string(output))
 	}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -102,6 +103,65 @@ func TestSessionPrefix(t *testing.T) {
 	if SessionPrefix != "agentdeck_" {
 		t.Errorf("SessionPrefix = %s, want agentdeck_", SessionPrefix)
 	}
+}
+
+func TestShouldRecoverFromTmuxStartError(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "server exited unexpectedly",
+			output: "server exited unexpectedly",
+			want:   true,
+		},
+		{
+			name:   "lost server",
+			output: "lost server",
+			want:   true,
+		},
+		{
+			name:   "other tmux failure",
+			output: "duplicate session: foo",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldRecoverFromTmuxStartError(tt.output)
+			if got != tt.want {
+				t.Fatalf("shouldRecoverFromTmuxStartError(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultTmuxSocketCandidatesIncludesTmuxEnvPath(t *testing.T) {
+	t.Setenv("TMUX", "/private/tmp/tmux-501/default,1234,0")
+	candidates := defaultTmuxSocketCandidates()
+	assert.Contains(t, candidates, "/private/tmp/tmux-501/default")
+}
+
+func TestDefaultTmuxSocketCandidatesDedupe(t *testing.T) {
+	uid := os.Getuid()
+	if uid < 0 {
+		t.Skip("os.Getuid unavailable")
+	}
+
+	defaultPath := filepath.Join("/tmp", fmt.Sprintf("tmux-%d", uid), "default")
+	t.Setenv("TMUX", defaultPath+",999,0")
+	t.Setenv("TMUX_TMPDIR", "/tmp")
+
+	candidates := defaultTmuxSocketCandidates()
+	count := 0
+	for _, candidate := range candidates {
+		if candidate == defaultPath {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "expected default socket path to be deduplicated")
 }
 
 func TestPromptDetector(t *testing.T) {


### PR DESCRIPTION
## Summary
- detect tmux startup failures that indicate a dead/stale default socket (e.g. `server exited unexpectedly`)
- safely quarantine unreachable stale default socket candidates before retrying `tmux new-session`
- retry session creation once after successful socket recovery
- add unit tests for recovery trigger matching and socket-candidate selection/deduplication

## Why
On affected machines, Agent Deck session start failed with:
`failed to create tmux session: ... server exited unexpectedly`
caused by a stale default tmux socket file. This change auto-recovers instead of forcing manual cleanup.

## Validation
- `go test ./internal/tmux`
- `go test ./internal/session -run 'Test.*Tmux|Test.*Restart|Test.*Start'`
- `go test ./...` (known unrelated local failure in OpenCode integration tests due empty output from local `opencode session list`)
