### PR TITLE
chore: bump version to v0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.2] - 2026-03-03
+
+### Fixed
+
+- Recover automatically when tmux startup fails due to a stale/unreachable default socket by quarantining the stale socket and retrying session creation once. This prevents `failed to create tmux session ... server exited unexpectedly` startup failures.
+
 ## [0.20.1] - 2026-03-03
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-const Version = "0.20.1"
+const Version = "0.20.2"
 
 // Table column widths for list command output
 const (


### PR DESCRIPTION
## Summary
- add CHANGELOG entry for v0.20.2
- bump cmd/agent-deck/main.go Version to 0.20.2

## Release Notes
- fixes session startup failures caused by stale/unreachable default tmux sockets by recovering and retrying once
