### PR TITLE
feat(worktree): add configurable branch_prefix to WorktreeSettings

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -560,6 +560,12 @@ type WorktreeSettings struct {
 	// Unknown variables like {foo} are left as-is in the path.
 	// If set, overrides DefaultLocation.
 	PathTemplate *string `toml:"path_template"`
+
+	// BranchPrefix is the prefix for auto-generated branch names when creating
+	// worktree sessions. For example, "feature/" produces "feature/my-session".
+	// Set to "" to disable auto-prefixing (just the session name).
+	// Default: "feature/" when not set.
+	BranchPrefix *string `toml:"branch_prefix"`
 }
 
 // Template returns the path template if set, or empty string if nil.
@@ -568,6 +574,14 @@ func (w *WorktreeSettings) Template() string {
 		return ""
 	}
 	return *w.PathTemplate
+}
+
+// Prefix returns the branch prefix if set, or "feature/" if nil.
+func (w *WorktreeSettings) Prefix() string {
+	if w.BranchPrefix == nil {
+		return "feature/"
+	}
+	return *w.BranchPrefix
 }
 
 // GlobalSearchSettings defines global conversation search configuration

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -376,6 +376,54 @@ func TestGetWorktreeSettings_FromConfig(t *testing.T) {
 	}
 }
 
+func TestWorktreeSettings_Prefix_Default(t *testing.T) {
+	settings := WorktreeSettings{}
+	if got := settings.Prefix(); got != "feature/" {
+		t.Errorf("Prefix() with nil BranchPrefix: got %q, want %q", got, "feature/")
+	}
+}
+
+func TestWorktreeSettings_Prefix_Custom(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	settings := WorktreeSettings{BranchPrefix: strPtr("dev/")}
+	if got := settings.Prefix(); got != "dev/" {
+		t.Errorf("Prefix() with custom BranchPrefix: got %q, want %q", got, "dev/")
+	}
+}
+
+func TestWorktreeSettings_Prefix_Empty(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	settings := WorktreeSettings{BranchPrefix: strPtr("")}
+	if got := settings.Prefix(); got != "" {
+		t.Errorf("Prefix() with empty BranchPrefix: got %q, want %q", got, "")
+	}
+}
+
+func TestGetWorktreeSettings_BranchPrefix(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	// Create config with custom branch_prefix
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	_ = os.MkdirAll(agentDeckDir, 0700)
+	strPtr := func(s string) *string { return &s }
+	config := &UserConfig{
+		Worktree: WorktreeSettings{
+			BranchPrefix: strPtr("custom/"),
+		},
+	}
+	_ = SaveUserConfig(config)
+	ClearUserConfigCache()
+
+	settings := GetWorktreeSettings()
+	if got := settings.Prefix(); got != "custom/" {
+		t.Errorf("GetWorktreeSettings Prefix(): got %q, want %q", got, "custom/")
+	}
+}
+
 // ============================================================================
 // Preview Settings Tests
 // ============================================================================

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -61,7 +61,8 @@ type NewDialog struct {
 	// Worktree support.
 	worktreeEnabled bool
 	branchInput     textinput.Model
-	branchAutoSet   bool // true if branch was auto-derived from session name.
+	branchAutoSet   bool   // true if branch was auto-derived from session name.
+	branchPrefix    string // configured prefix for auto-generated branch names.
 	// Docker sandbox support.
 	sandboxEnabled    bool
 	inheritedExpanded bool             // whether the inherited settings section is expanded.
@@ -180,6 +181,7 @@ func NewNewDialog() *NewDialog {
 		parentGroupPath: "default",
 		parentGroupName: "default",
 		worktreeEnabled: false,
+		branchPrefix:    "feature/",
 	}
 	dlg.updateToolOptions() // Also calls rebuildFocusTargets.
 	return dlg
@@ -213,6 +215,7 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string) {
 	d.worktreeEnabled = false
 	d.branchInput.SetValue("")
 	d.branchAutoSet = false
+	d.branchPrefix = "feature/" // default; overridden below if config provides one.
 	// Reset sandbox from global config default.
 	d.sandboxEnabled = false
 	d.inheritedExpanded = false
@@ -236,7 +239,9 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string) {
 		d.claudeOptions.SetDefaults(userConfig)
 		d.sandboxEnabled = userConfig.Docker.DefaultEnabled
 		d.inheritedSettings = buildInheritedSettings(userConfig.Docker)
+		d.branchPrefix = userConfig.Worktree.Prefix()
 	}
+	d.branchInput.Placeholder = d.branchPrefix + "branch-name"
 	d.rebuildFocusTargets()
 }
 
@@ -469,14 +474,14 @@ func (d *NewDialog) ToggleWorktree() {
 	d.rebuildFocusTargets()
 }
 
-// autoBranchFromName sets the branch input to "feature/<session-name>" if the
+// autoBranchFromName sets the branch input to "<prefix><session-name>" if the
 // name field is non-empty and the branch hasn't been manually edited.
 func (d *NewDialog) autoBranchFromName() {
 	name := strings.TrimSpace(d.nameInput.Value())
 	if name == "" {
 		return
 	}
-	branch := "feature/" + name
+	branch := d.branchPrefix + name
 	d.branchInput.SetValue(branch)
 	d.branchAutoSet = true
 }

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -1192,3 +1192,53 @@ func TestNewDialog_FilterPaths_EmptyInput(t *testing.T) {
 		t.Errorf("expected all 3 suggestions for empty input, got %d", len(d.pathSuggestions))
 	}
 }
+
+func TestNewDialog_BranchPrefix_Default(t *testing.T) {
+	d := NewNewDialog()
+	if d.branchPrefix != "feature/" {
+		t.Errorf("expected branchPrefix %q from constructor, got %q", "feature/", d.branchPrefix)
+	}
+}
+
+func TestNewDialog_BranchPrefix_Custom_AutoPopulates(t *testing.T) {
+	d := NewNewDialog()
+	d.branchPrefix = "dev/"
+	d.nameInput.SetValue("my-session")
+	d.autoBranchFromName()
+
+	if got := d.branchInput.Value(); got != "dev/my-session" {
+		t.Errorf("expected branch %q, got %q", "dev/my-session", got)
+	}
+}
+
+func TestNewDialog_BranchPrefix_Empty_NoPrefix(t *testing.T) {
+	d := NewNewDialog()
+	d.branchPrefix = ""
+	d.nameInput.SetValue("my-session")
+	d.autoBranchFromName()
+
+	if got := d.branchInput.Value(); got != "my-session" {
+		t.Errorf("expected branch %q, got %q", "my-session", got)
+	}
+}
+
+func TestNewDialog_BranchPrefix_Placeholder_Updated(t *testing.T) {
+	d := NewNewDialog()
+	d.branchPrefix = "fix/"
+	d.branchInput.Placeholder = d.branchPrefix + "branch-name"
+
+	if d.branchInput.Placeholder != "fix/branch-name" {
+		t.Errorf("expected placeholder %q, got %q", "fix/branch-name", d.branchInput.Placeholder)
+	}
+}
+
+func TestNewDialog_ToggleWorktree_CustomPrefix(t *testing.T) {
+	d := NewNewDialog()
+	d.branchPrefix = "dev/"
+	d.nameInput.SetValue("cool-feature")
+	d.ToggleWorktree()
+
+	if got := d.branchInput.Value(); got != "dev/cool-feature" {
+		t.Errorf("expected branch %q, got %q", "dev/cool-feature", got)
+	}
+}


### PR DESCRIPTION
Add a branch_prefix option to [worktree] config section so users can customize the auto-populated branch prefix when creating new sessions with worktrees. Previously hardcoded to "feature/".

