### PR TITLE
perf: hoist regexp.MustCompile to package-level vars to avoid recompilation

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 )
 
+var consecutiveDashesRe = regexp.MustCompile(`-+`)
+
 // Worktree represents a git worktree
 type Worktree struct {
 	Path   string // Filesystem path to the worktree
@@ -350,8 +352,7 @@ func SanitizeBranchName(name string) string {
 	}
 
 	// Remove consecutive dashes
-	re := regexp.MustCompile(`-+`)
-	sanitized = re.ReplaceAllString(sanitized, "-")
+	sanitized = consecutiveDashesRe.ReplaceAllString(sanitized, "-")
 
 	// Remove leading/trailing dashes
 	sanitized = strings.Trim(sanitized, "-")

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -32,6 +32,9 @@ var (
 	sessionLog                  = logging.ForComponent(logging.CompSession)
 	mcpLog                      = logging.ForComponent(logging.CompMCP)
 	codexSessionIDPathPatternRE = regexp.MustCompile(`/.codex/sessions/\S*/rollout-\S*-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl`)
+	uuidPatternRE               = regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+	geminiPromptRE              = regexp.MustCompile(`^(>|>>>|\$|❯|➜|gemini>)\s*$`)
+	shellPromptRE               = regexp.MustCompile(`^[\s]*(>|>>>|\$|❯|➜|#|%)\s*$`)
 )
 
 // Status represents the current state of a session
@@ -1005,7 +1008,7 @@ func (i *Instance) queryCodexSession(excludeIDs map[string]bool, allowUnscoped b
 		return ""
 	}
 
-	uuidPattern := regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+	uuidPattern := uuidPatternRE
 
 	var bestScopedID string
 	var bestScopedTime time.Time
@@ -3468,7 +3471,7 @@ func parseGeminiOutput(content string) (*ResponseOutput, error) {
 
 		// Detect prompt line (end of response when reading backwards)
 		// Common prompts: "> ", ">>> ", "$", "❯", "➜"
-		isPrompt := regexp.MustCompile(`^(>|>>>|\$|❯|➜|gemini>)\s*$`).MatchString(trimmed)
+		isPrompt := geminiPromptRE.MatchString(trimmed)
 
 		if isPrompt && inResponse {
 			// We've found the start of the response block
@@ -3514,7 +3517,7 @@ func parseGenericOutput(content, tool string) (*ResponseOutput, error) {
 	// before a prompt character
 	var responseLines []string
 	inResponse := false
-	promptPattern := regexp.MustCompile(`^[\s]*(>|>>>|\$|❯|➜|#|%)\s*$`)
+	promptPattern := shellPromptRE
 
 	for idx := len(lines) - 1; idx >= 0; idx-- {
 		line := lines[idx]


### PR DESCRIPTION
## Summary

- Hoist 4 `regexp.MustCompile` calls from function bodies to package-level `var` declarations to avoid redundant recompilation on every invocation

## Background

In Go, `regexp.MustCompile` parses and compiles a regular expression pattern each time it is called. When placed inside a function body, this compilation cost is paid on every function call — even though the pattern is a constant that never changes. The idiomatic Go approach is to compile such patterns once at package initialization time by declaring them as package-level variables.

## Changes

| File | Pattern | Context |
|------|---------|---------|
| `internal/git/git.go` | `-+` (consecutive dashes) | `SanitizeBranchName()` — called during branch creation |
| `internal/session/instance.go` | UUID pattern | `queryCodexSession()` — called during session lookup |
| `internal/session/instance.go` | Gemini prompt pattern | `parseGeminiOutput()` — used inside a loop iterating over output lines |
| `internal/session/instance.go` | Shell prompt pattern | `parseGenericOutput()` — used inside a loop iterating over output lines |

## Impact

- **Zero behavior change** — all regex patterns remain identical
- Eliminates per-call compilation overhead, especially for the two prompt-detection patterns that run inside loops processing potentially large output buffers
- Follows the same convention already used elsewhere in the codebase (e.g., `codexSessionIDPathPatternRE`, `sanitizeNameRe`, `consecutiveDashes`)

## Test plan

- [x] `go vet ./internal/git/ ./internal/session/` passes with no errors
- [ ] Existing unit tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)