### PR TITLE
feat: enrich Slack bridge messages with sender and channel context

### DIFF
--- a/conductor/conductor-claude.md
+++ b/conductor/conductor-claude.md
@@ -173,13 +173,13 @@ For any other text, treat it as a conversational message from the user. They mig
 When messages arrive from Slack, the bridge tags them with sender and channel context:
 
 ```
-[from:alice] [channel:#bugs] the login button is broken
-[from:bob] [dm] can you check the API?
-[from:charlie] [channel:#feature-requests] add dark mode support
+[from:alice (U12345)] [channel:#bugs (C67890)] the login button is broken
+[from:bob (U11111)] [dm] can you check the API?
+[from:charlie (U22222)] [channel:#feature-requests (C33333)] add dark mode support
 ```
 
-- `[from:<name>]` — The Slack display name of the sender
-- `[channel:#<name>]` — The Slack channel the message came from
+- `[from:<name> (<user_id>)]` — The Slack display name and stable user ID of the sender
+- `[channel:#<name> (<channel_id>)]` — The Slack channel name and stable channel ID
 - `[dm]` — The message was sent via direct message
 
 Use these tags to:
@@ -187,7 +187,7 @@ Use these tags to:
 - **Route by channel** — messages from #bugs are likely bug reports, #ideas are feature requests
 - **Include sender context in escalations** — e.g., "NEED: @alice (#bugs): login button broken"
 
-If the bridge cannot resolve a name, the raw Slack ID appears instead (e.g., `[from:U12345]`, `[channel:C99999]`).
+If the bridge cannot resolve a name (temporary API failure), the raw Slack ID appears alone (e.g., `[from:U12345 (U12345)]`, `[channel:C99999]`). Failed lookups are retried automatically after 5 minutes.
 
 ## Startup Checklist
 

--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -163,13 +163,13 @@ For any other text, treat it as a conversational message from the user. They mig
 When messages arrive from Slack, the bridge tags them with sender and channel context:
 
 ` + "```" + `
-[from:alice] [channel:#bugs] the login button is broken
-[from:bob] [dm] can you check the API?
-[from:charlie] [channel:#feature-requests] add dark mode support
+[from:alice (U12345)] [channel:#bugs (C67890)] the login button is broken
+[from:bob (U11111)] [dm] can you check the API?
+[from:charlie (U22222)] [channel:#feature-requests (C33333)] add dark mode support
 ` + "```" + `
 
-- ` + "`" + `[from:<name>]` + "`" + ` — The Slack display name of the sender
-- ` + "`" + `[channel:#<name>]` + "`" + ` — The Slack channel the message came from
+- ` + "`" + `[from:<name> (<user_id>)]` + "`" + ` — The Slack display name and stable user ID of the sender
+- ` + "`" + `[channel:#<name> (<channel_id>)]` + "`" + ` — The Slack channel name and stable channel ID
 - ` + "`" + `[dm]` + "`" + ` — The message was sent via direct message
 
 Use these tags to:
@@ -177,7 +177,7 @@ Use these tags to:
 - **Route by channel** — messages from #bugs are likely bug reports, #ideas are feature requests
 - **Include sender context in escalations** — e.g., "NEED: @alice (#bugs): login button broken"
 
-If the bridge cannot resolve a name, the raw Slack ID appears instead (e.g., ` + "`" + `[from:U12345]` + "`" + `, ` + "`" + `[channel:C99999]` + "`" + `).
+If the bridge cannot resolve a name (temporary API failure), the raw Slack ID appears alone (e.g., ` + "`" + `[from:U12345 (U12345)]` + "`" + `, ` + "`" + `[channel:C99999]` + "`" + `). Failed lookups are retried automatically after 5 minutes.
 
 ## Important Notes
 
@@ -1133,31 +1133,46 @@ def create_slack_app(config: dict):
         return True
 
     # Caches for Slack user/channel name resolution.
-    _user_cache: dict[str, str] = {}
-    _channel_cache: dict[str, str] = {}
+    # Entries: (value: str, expires_at: float | None).
+    # Successful lookups never expire; failures expire after 5 minutes.
+    _NEGATIVE_TTL = 300  # seconds
+    _user_cache: dict[str, tuple[str, float | None]] = {}
+    _channel_cache: dict[str, tuple[str, float | None]] = {}
+
+    def _cache_get(cache: dict, key: str) -> str | None:
+        entry = cache.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if expires_at is not None and time.monotonic() > expires_at:
+            del cache[key]
+            return None
+        return value
 
     async def resolve_slack_username(user_id: str) -> str:
         """Resolve a Slack user ID to a display name, with caching."""
-        if user_id in _user_cache:
-            return _user_cache[user_id]
+        cached = _cache_get(_user_cache, user_id)
+        if cached is not None:
+            return cached
         try:
             resp = await app.client.users_info(user=user_id)
             profile = resp["user"]["profile"]
             name = profile.get("display_name") or profile.get("real_name") or user_id
-            _user_cache[user_id] = name
+            _user_cache[user_id] = (name, None)
             return name
         except Exception as e:
             log.warning("Failed to resolve Slack user %s: %s", user_id, e)
-            _user_cache[user_id] = user_id
+            _user_cache[user_id] = (user_id, time.monotonic() + _NEGATIVE_TTL)
             return user_id
 
     async def resolve_slack_channel(event_channel: str) -> str:
         """Resolve a Slack channel ID to a context tag.
 
-        Returns '[channel:#name]' for channels or '[dm]' for direct messages.
+        Returns '[channel:#name (ID)]' for channels or '[dm]' for DMs.
         """
-        if event_channel in _channel_cache:
-            return _channel_cache[event_channel]
+        cached = _cache_get(_channel_cache, event_channel)
+        if cached is not None:
+            return cached
         try:
             resp = await app.client.conversations_info(channel=event_channel)
             ch = resp["channel"]
@@ -1165,13 +1180,13 @@ def create_slack_app(config: dict):
                 tag = "[dm]"
             else:
                 name = ch.get("name", event_channel)
-                tag = f"[channel:#{name}]"
-            _channel_cache[event_channel] = tag
+                tag = f"[channel:#{name} ({event_channel})]"
+            _channel_cache[event_channel] = (tag, None)
             return tag
         except Exception as e:
             log.warning("Failed to resolve Slack channel %s: %s", event_channel, e)
             tag = f"[channel:{event_channel}]"
-            _channel_cache[event_channel] = tag
+            _channel_cache[event_channel] = (tag, time.monotonic() + _NEGATIVE_TTL)
             return tag
 
     def get_default_conductor() -> dict | None:
@@ -1217,10 +1232,17 @@ def create_slack_app(config: dict):
 
         # Enrich message with sender and channel context for the conductor.
         prefix_parts = []
-        if user_id:
+        if user_id and event_channel:
+            username, channel_tag = await asyncio.gather(
+                resolve_slack_username(user_id),
+                resolve_slack_channel(event_channel),
+            )
+            prefix_parts.append(f"[from:{username} ({user_id})]")
+            prefix_parts.append(channel_tag)
+        elif user_id:
             username = await resolve_slack_username(user_id)
-            prefix_parts.append(f"[from:{username}]")
-        if event_channel:
+            prefix_parts.append(f"[from:{username} ({user_id})]")
+        elif event_channel:
             channel_tag = await resolve_slack_channel(event_channel)
             prefix_parts.append(channel_tag)
         if prefix_parts:

--- a/internal/session/test_slack_message_enrichment.py
+++ b/internal/session/test_slack_message_enrichment.py
@@ -3,38 +3,52 @@
 Test suite for Slack message enrichment in conductor bridge.
 
 Tests the resolve_slack_username(), resolve_slack_channel(), and message
-enrichment logic that tags messages with [from:username] and [channel:#name]
-before relaying to the conductor.
+enrichment logic that tags messages with [from:username (ID)] and
+[channel:#name (ID)] before relaying to the conductor.
 """
 
+import time
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 import logging
 
 
 log = logging.getLogger(__name__)
+
+_NEGATIVE_TTL = 300  # mirrors bridge constant
 
 
 class TestResolveSlackUsername(unittest.IsolatedAsyncioTestCase):
     """Test Slack user ID to display name resolution."""
 
     def setUp(self):
-        self._user_cache: dict[str, str] = {}
+        self._user_cache: dict[str, tuple[str, float | None]] = {}
         self.mock_client = MagicMock()
+
+    def _cache_get(self, cache, key):
+        entry = cache.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if expires_at is not None and time.monotonic() > expires_at:
+            del cache[key]
+            return None
+        return value
 
     async def resolve_slack_username(self, user_id: str) -> str:
         """Mirror of the bridge's resolve_slack_username with injected client."""
-        if user_id in self._user_cache:
-            return self._user_cache[user_id]
+        cached = self._cache_get(self._user_cache, user_id)
+        if cached is not None:
+            return cached
         try:
             resp = await self.mock_client.users_info(user=user_id)
             profile = resp["user"]["profile"]
             name = profile.get("display_name") or profile.get("real_name") or user_id
-            self._user_cache[user_id] = name
+            self._user_cache[user_id] = (name, None)
             return name
         except Exception as e:
             log.warning("Failed to resolve Slack user %s: %s", user_id, e)
-            self._user_cache[user_id] = user_id
+            self._user_cache[user_id] = (user_id, time.monotonic() + _NEGATIVE_TTL)
             return user_id
 
     async def test_resolves_display_name(self):
@@ -62,8 +76,8 @@ class TestResolveSlackUsername(unittest.IsolatedAsyncioTestCase):
         result = await self.resolve_slack_username("UNONAME")
         self.assertEqual(result, "UNONAME")
 
-    async def test_caches_result(self):
-        """Should only call Slack API once per user ID."""
+    async def test_caches_successful_result(self):
+        """Should only call Slack API once per user ID on success."""
         self.mock_client.users_info = AsyncMock(return_value={
             "user": {"profile": {"display_name": "cached-user", "real_name": ""}}
         })
@@ -72,17 +86,34 @@ class TestResolveSlackUsername(unittest.IsolatedAsyncioTestCase):
         self.mock_client.users_info.assert_awaited_once()
 
     async def test_api_failure_falls_back_to_user_id(self):
-        """Should return raw user ID and cache it on API failure."""
+        """Should return raw user ID on API failure."""
         self.mock_client.users_info = AsyncMock(side_effect=Exception("timeout"))
         result = await self.resolve_slack_username("UFAILED")
         self.assertEqual(result, "UFAILED")
-        self.assertEqual(self._user_cache["UFAILED"], "UFAILED")
 
-    async def test_api_failure_is_cached(self):
-        """After a failure, subsequent calls should not retry the API."""
+    async def test_negative_cache_is_temporary(self):
+        """Failed lookups should be retried after TTL expires."""
+        self.mock_client.users_info = AsyncMock(side_effect=Exception("timeout"))
+        await self.resolve_slack_username("UFAILED")
+        self.mock_client.users_info.assert_awaited_once()
+
+        # Simulate TTL expiry by backdating the cache entry.
+        self._user_cache["UFAILED"] = ("UFAILED", time.monotonic() - 1)
+
+        # Now it should retry and succeed.
+        self.mock_client.users_info = AsyncMock(return_value={
+            "user": {"profile": {"display_name": "recovered", "real_name": ""}}
+        })
+        result = await self.resolve_slack_username("UFAILED")
+        self.assertEqual(result, "recovered")
+        self.mock_client.users_info.assert_awaited_once()
+
+    async def test_negative_cache_suppresses_retry_within_ttl(self):
+        """Failed lookups should NOT retry within TTL window."""
         self.mock_client.users_info = AsyncMock(side_effect=Exception("timeout"))
         await self.resolve_slack_username("UFAILED")
         await self.resolve_slack_username("UFAILED")
+        # Only one API call despite two resolve attempts.
         self.mock_client.users_info.assert_awaited_once()
 
 
@@ -90,13 +121,24 @@ class TestResolveSlackChannel(unittest.IsolatedAsyncioTestCase):
     """Test Slack channel ID to context tag resolution."""
 
     def setUp(self):
-        self._channel_cache: dict[str, str] = {}
+        self._channel_cache: dict[str, tuple[str, float | None]] = {}
         self.mock_client = MagicMock()
+
+    def _cache_get(self, cache, key):
+        entry = cache.get(key)
+        if entry is None:
+            return None
+        value, expires_at = entry
+        if expires_at is not None and time.monotonic() > expires_at:
+            del cache[key]
+            return None
+        return value
 
     async def resolve_slack_channel(self, event_channel: str) -> str:
         """Mirror of the bridge's resolve_slack_channel with injected client."""
-        if event_channel in self._channel_cache:
-            return self._channel_cache[event_channel]
+        cached = self._cache_get(self._channel_cache, event_channel)
+        if cached is not None:
+            return cached
         try:
             resp = await self.mock_client.conversations_info(channel=event_channel)
             ch = resp["channel"]
@@ -104,22 +146,22 @@ class TestResolveSlackChannel(unittest.IsolatedAsyncioTestCase):
                 tag = "[dm]"
             else:
                 name = ch.get("name", event_channel)
-                tag = f"[channel:#{name}]"
-            self._channel_cache[event_channel] = tag
+                tag = f"[channel:#{name} ({event_channel})]"
+            self._channel_cache[event_channel] = (tag, None)
             return tag
         except Exception as e:
             log.warning("Failed to resolve Slack channel %s: %s", event_channel, e)
             tag = f"[channel:{event_channel}]"
-            self._channel_cache[event_channel] = tag
+            self._channel_cache[event_channel] = (tag, time.monotonic() + _NEGATIVE_TTL)
             return tag
 
-    async def test_resolves_public_channel(self):
-        """Should return [channel:#name] for public channels."""
+    async def test_resolves_public_channel_with_id(self):
+        """Should return [channel:#name (ID)] for public channels."""
         self.mock_client.conversations_info = AsyncMock(return_value={
             "channel": {"name": "bugs", "is_im": False}
         })
         result = await self.resolve_slack_channel("C12345")
-        self.assertEqual(result, "[channel:#bugs]")
+        self.assertEqual(result, "[channel:#bugs (C12345)]")
 
     async def test_resolves_dm(self):
         """Should return [dm] for direct messages."""
@@ -147,37 +189,56 @@ class TestResolveSlackChannel(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, "[channel:CBAD]")
 
     async def test_missing_name_falls_back_to_id(self):
-        """Should use channel ID if name field is missing."""
+        """Should use channel ID in name position if name field is missing."""
         self.mock_client.conversations_info = AsyncMock(return_value={
             "channel": {"is_im": False}
         })
         result = await self.resolve_slack_channel("CNONAME")
-        self.assertEqual(result, "[channel:#CNONAME]")
+        self.assertEqual(result, "[channel:#CNONAME (CNONAME)]")
+
+    async def test_negative_cache_expires(self):
+        """Failed channel lookups should be retried after TTL."""
+        self.mock_client.conversations_info = AsyncMock(
+            side_effect=Exception("timeout")
+        )
+        await self.resolve_slack_channel("CBAD")
+
+        # Expire the negative cache entry.
+        self._channel_cache["CBAD"] = ("[channel:CBAD]", time.monotonic() - 1)
+
+        self.mock_client.conversations_info = AsyncMock(return_value={
+            "channel": {"name": "recovered-channel", "is_im": False}
+        })
+        result = await self.resolve_slack_channel("CBAD")
+        self.assertEqual(result, "[channel:#recovered-channel (CBAD)]")
 
 
 class TestMessageEnrichment(unittest.TestCase):
     """Test the full message enrichment format."""
 
     def test_full_enrichment(self):
-        """Message with both user and channel tags."""
-        prefix_parts = ["[from:alice]", "[channel:#bugs]"]
+        """Message with both user and channel tags including stable IDs."""
+        prefix_parts = ["[from:alice (U12345)]", "[channel:#bugs (C67890)]"]
         cleaned_msg = "the login button is broken"
         result = " ".join(prefix_parts) + " " + cleaned_msg
-        self.assertEqual(result, "[from:alice] [channel:#bugs] the login button is broken")
+        self.assertEqual(
+            result,
+            "[from:alice (U12345)] [channel:#bugs (C67890)] the login button is broken",
+        )
 
     def test_dm_enrichment(self):
         """Message from a DM should use [dm] tag."""
-        prefix_parts = ["[from:bob]", "[dm]"]
+        prefix_parts = ["[from:bob (U11111)]", "[dm]"]
         cleaned_msg = "can you check the API?"
         result = " ".join(prefix_parts) + " " + cleaned_msg
-        self.assertEqual(result, "[from:bob] [dm] can you check the API?")
+        self.assertEqual(result, "[from:bob (U11111)] [dm] can you check the API?")
 
     def test_user_only(self):
-        """Message with user but no channel (shouldn't happen, but safe)."""
-        prefix_parts = ["[from:charlie]"]
+        """Message with user but no channel."""
+        prefix_parts = ["[from:charlie (U22222)]"]
         cleaned_msg = "hello"
         result = " ".join(prefix_parts) + " " + cleaned_msg
-        self.assertEqual(result, "[from:charlie] hello")
+        self.assertEqual(result, "[from:charlie (U22222)] hello")
 
     def test_no_enrichment(self):
         """No prefix when both user_id and channel are None."""
@@ -190,18 +251,20 @@ class TestMessageEnrichment(unittest.TestCase):
         self.assertEqual(result, "raw message")
 
     def test_fallback_user_id_in_tag(self):
-        """When username resolution fails, raw user ID appears in tag."""
-        prefix_parts = ["[from:U12345]", "[channel:#bugs]"]
+        """When username resolution fails, raw user ID appears as both name and ID."""
+        prefix_parts = ["[from:U12345 (U12345)]", "[channel:#bugs (C67890)]"]
         cleaned_msg = "test"
         result = " ".join(prefix_parts) + " " + cleaned_msg
-        self.assertEqual(result, "[from:U12345] [channel:#bugs] test")
+        self.assertEqual(
+            result, "[from:U12345 (U12345)] [channel:#bugs (C67890)] test"
+        )
 
     def test_fallback_channel_id_in_tag(self):
         """When channel resolution fails, raw channel ID appears in tag."""
-        prefix_parts = ["[from:alice]", "[channel:C99999]"]
+        prefix_parts = ["[from:alice (U12345)]", "[channel:C99999]"]
         cleaned_msg = "test"
         result = " ".join(prefix_parts) + " " + cleaned_msg
-        self.assertEqual(result, "[from:alice] [channel:C99999] test")
+        self.assertEqual(result, "[from:alice (U12345)] [channel:C99999] test")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose
- I want to have a "safe" way for a Slack conductor to ingest requests, bug reports etc but for it to not mistake all messages as messages coming from me, I needed to relay this user meta data.

## Summary

- The Slack bridge now tags every relayed message with `[from:username (USER_ID)]` and `[channel:#name (CHANNEL_ID)]` (or `[dm]`) before sending to the conductor
- Resolvers use `users_info` and `conversations_info` Slack APIs with in-memory caching
- Successful lookups cached permanently; failed lookups cached for 5 minutes then retried (prevents transient API hiccups from permanently degrading UX)
- User + channel resolved concurrently via `asyncio.gather()` on cache miss
- Conductor CLAUDE.md updated to document the new message format, routing use cases, and fallback behavior

**Example enriched messages:**
```
[from:alice (U12345)] [channel:#bugs (C67890)] the login button is broken
[from:bob (U11111)] [dm] can you check the API?
```

## Files changed

- `internal/session/conductor_templates.go` — Resolver functions, enrichment logic in `_handle_slack_text()`, handler updates
- `conductor/conductor-claude.md` — Document new message format spec for conductors
- `internal/session/test_slack_message_enrichment.py` — 19 unit tests (resolution, caching, TTL expiry, format)

## Test plan

- [x] 19 Python unit tests pass (`python3 internal/session/test_slack_message_enrichment.py`)
- [x] Go build passes (`go build ./internal/session/ ./cmd/agent-deck/`)
- [ ] Manual test with live Slack workspace (bridge sends enriched messages to conductor)