### PR TITLE
fix(ui): remove redundant preview pane suppression during navigation

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9158,12 +9158,6 @@ func (h *Home) renderPreviewPane(width, height int) string {
 		pvKey = previewCacheKey(selected.ID, item.WindowIndex)
 	}
 
-	// Attach-return fast path: prioritize immediate list navigation and defer preview work.
-	if !h.lastAttachReturn.IsZero() && time.Since(h.lastAttachReturn) < 900*time.Millisecond {
-		quickStyle := lipgloss.NewStyle().Foreground(ColorText).Italic(true)
-		return quickStyle.Render("Returned from session... refreshing preview")
-	}
-
 	// Session info header box
 	statusIcon := "○"
 	statusColor := ColorTextDim


### PR DESCRIPTION
## Summary

PR #284 introduced render-level gates that suppress the preview pane during navigation, showing placeholder text ("Preview paused while navigating..." / "Moving... preview updating") instead of actual content. While intended to improve performance for users with many concurrent agents, this creates **self-induced lag of up to 2 seconds** after a single keypress — even when cached preview content is already available and ready to display.

### The problem

Three layers of navigation suppression were stacked:

1. **`fetchPreviewDebounced` (150ms delay)** - Debounces tmux `capture-pane` subprocess spawning during rapid j/k scrolling. Correct and sufficient.

2. **`shouldDeferPreviewPane` / `renderDeferredPreview`** - Blanks the entire preview pane whenever `isNavigating` is true. The `isNavigating` flag is only cleared by a tick that fires every **2 seconds**, so a single keypress can hide already-cached content for up to 2 full seconds.

3. **`navigationHotUntil` gate inside `renderPreviewPane`** - Shows "Moving... preview updating" for 900ms after any keypress, again suppressing cached content.

4. **`lastAttachReturn` gate inside `renderPreviewPane`** - Shows "Returned from session... refreshing preview" for 900ms after detaching from a session, suppressing cached content that is ready to display immediately.

Layers 2, 3 and 4 are redundant with layer 1. The expensive operation (tmux subprocess) is already debounced at 150ms. Rendering cached content from a map lookup is cheap and should never be deferred.

### The fix

- Remove `shouldDeferPreviewPane()` and `renderDeferredPreview()` functions and their two callsites
- Remove the `navigationHotUntil` render gate inside `renderPreviewPane()`
- Preserve `navigationHotUntil` for background worker throttling (lines 2098, 2527) where it remains appropriate
- The 150ms fetch debounce remains as the sole - and sufficient - throttling mechanism

**Result:** -36 lines, +2 lines. Preview pane now renders instantly using cached content, with no perceptible delay on navigation.

## Test plan

- [x] Navigate sessions with j/k - preview should update instantly, no placeholder text
- [x] Rapid-scroll through many sessions - should remain responsive, no subprocess spam
- [x] Verify with multiple concurrent running agents that status updates still work
- [x] Attach/detach from sessions (enter/ctrl+q) - preview should restore on return