### PR TITLE
feat(telegram-bot): enhance bot message handling with username management and mention stripping

### DIFF
--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -359,6 +360,14 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
     authorized_user = config["user_id"]
     profiles = config["profiles"]
     default_profile = profiles[0]
+    bot_info = {"username": ""}
+
+    async def ensure_bot_info(bot_instance: Bot):
+        """Lazy-init bot username on first message."""
+        if not bot_info["username"]:
+            me = await bot_instance.get_me()
+            bot_info["username"] = me.username.lower()
+            log.info("Bot username: @%s", bot_info["username"])
 
     def is_authorized(message: types.Message) -> bool:
         """Check if message is from the authorized user."""
@@ -368,6 +377,37 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
             )
             return False
         return True
+
+    def is_bot_addressed(message: types.Message) -> bool:
+        """Check if message is directed at the bot (mention or reply in groups)."""
+        if message.chat.type == "private":
+            return True
+        # Reply to the bot's own message
+        if message.reply_to_message and message.reply_to_message.from_user:
+            reply_username = message.reply_to_message.from_user.username
+            if reply_username and reply_username.lower() == bot_info["username"]:
+                return True
+        # @mention in message entities
+        if message.entities and message.text:
+            for entity in message.entities:
+                if entity.type == "mention":
+                    mentioned = message.text[
+                        entity.offset : entity.offset + entity.length
+                    ].lower()
+                    if mentioned == f"@{bot_info['username']}":
+                        return True
+        return False
+
+    def strip_bot_mention(text: str) -> str:
+        """Remove @botusername from message text."""
+        if not bot_info["username"]:
+            return text
+        return re.sub(
+            rf"@{re.escape(bot_info['username'])}\b",
+            "",
+            text,
+            flags=re.IGNORECASE,
+        ).strip()
 
     @dp.message(CommandStart())
     async def cmd_start(message: types.Message):
@@ -487,15 +527,21 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
             return
         if not message.text:
             return
+        await ensure_bot_info(message.bot)
+        if not is_bot_addressed(message):
+            return
+
+        # Strip @botname mention from group messages
+        text = strip_bot_mention(message.text)
+        if not text:
+            return
 
         # Determine target profile from message prefix
-        target_profile, cleaned_msg = parse_profile_prefix(
-            message.text, profiles
-        )
+        target_profile, cleaned_msg = parse_profile_prefix(text, profiles)
         if target_profile is None:
             target_profile = default_profile
         if not cleaned_msg:
-            cleaned_msg = message.text
+            cleaned_msg = text
 
         session_title = conductor_session_title(target_profile)
 

--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -802,6 +802,14 @@ def create_telegram_bot(config: dict):
     bot = Bot(token=config["telegram"]["token"])
     dp = Dispatcher()
     authorized_user = config["telegram"]["user_id"]
+    bot_info = {"username": ""}
+
+    async def ensure_bot_info(bot_instance: Bot):
+        """Lazy-init bot username on first message."""
+        if not bot_info["username"]:
+            me = await bot_instance.get_me()
+            bot_info["username"] = me.username.lower()
+            log.info("Bot username: @%s", bot_info["username"])
 
     def is_authorized(message: types.Message) -> bool:
         """Check if message is from the authorized user."""
@@ -811,6 +819,37 @@ def create_telegram_bot(config: dict):
             )
             return False
         return True
+
+    def is_bot_addressed(message: types.Message) -> bool:
+        """Check if message is directed at the bot (mention or reply in groups)."""
+        if message.chat.type == "private":
+            return True
+        # Reply to the bot's own message
+        if message.reply_to_message and message.reply_to_message.from_user:
+            reply_username = message.reply_to_message.from_user.username
+            if reply_username and reply_username.lower() == bot_info["username"]:
+                return True
+        # @mention in message entities
+        if message.entities and message.text:
+            for entity in message.entities:
+                if entity.type == "mention":
+                    mentioned = message.text[
+                        entity.offset : entity.offset + entity.length
+                    ].lower()
+                    if mentioned == f"@{bot_info['username']}":
+                        return True
+        return False
+
+    def strip_bot_mention(text: str) -> str:
+        """Remove @botusername from message text."""
+        if not bot_info["username"]:
+            return text
+        return re.sub(
+            rf"@{re.escape(bot_info['username'])}\b",
+            "",
+            text,
+            flags=re.IGNORECASE,
+        ).strip()
 
     def get_default_conductor() -> dict | None:
         """Get the first conductor (default target for messages)."""
@@ -951,13 +990,21 @@ def create_telegram_bot(config: dict):
             return
         if not message.text:
             return
+        await ensure_bot_info(message.bot)
+        if not is_bot_addressed(message):
+            return
+
+        # Strip @botname mention from group messages
+        text = strip_bot_mention(message.text)
+        if not text:
+            return
 
         conductor_names = get_conductor_names()
         conductors = discover_conductors()
 
         # Determine target conductor from message prefix
         target_name, cleaned_msg = parse_conductor_prefix(
-            message.text, conductor_names
+            text, conductor_names
         )
 
         target = None
@@ -973,7 +1020,7 @@ def create_telegram_bot(config: dict):
             return
 
         if not cleaned_msg:
-            cleaned_msg = message.text
+            cleaned_msg = text
 
         session_title = conductor_session_title(target["name"])
         profile = target["profile"]


### PR DESCRIPTION
feat(telegram-bot): enhance bot message handling with username management and mention stripping
This pull request enhances the Telegram bot's group chat handling by ensuring the bot only responds when directly addressed, either via mention or reply, and by stripping its mention from incoming messages before further processing. These changes improve the bot's behavior in group chats, preventing it from responding to irrelevant messages and ensuring cleaner message parsing. The updates are applied to both the main Python implementation (`conductor/bridge.py`) and the Go template (`internal/session/conductor_templates.go`).

**Improved group chat handling:**

* Added `is_bot_addressed` function to ensure the bot only responds to messages that mention it or are replies to its messages in group chats. [[1]](diffhunk://#diff-02c42af0355f59c9a581a996170ac1a4eac94989210ac8fdd54d7c03efcc91b2R381-R411) [[2]](diffhunk://#diff-31c4552bc1f86295acd2d1b663f17c58223b634ba226574ac46e78b92b268106R823-R853)
* Introduced `strip_bot_mention` function to remove the bot's username from the start of messages, ensuring cleaner command parsing in group contexts. [[1]](diffhunk://#diff-02c42af0355f59c9a581a996170ac1a4eac94989210ac8fdd54d7c03efcc91b2R381-R411) [[2]](diffhunk://#diff-31c4552bc1f86295acd2d1b663f17c58223b634ba226574ac46e78b92b268106R823-R853)
* Updated message handler logic to check if the bot is addressed and to strip mentions before processing, preventing unintended responses and improving message parsing. [[1]](diffhunk://#diff-02c42af0355f59c9a581a996170ac1a4eac94989210ac8fdd54d7c03efcc91b2R530-R544) [[2]](diffhunk://#diff-31c4552bc1f86295acd2d1b663f17c58223b634ba226574ac46e78b92b268106R993-R1007) [[3]](diffhunk://#diff-31c4552bc1f86295acd2d1b663f17c58223b634ba226574ac46e78b92b268106L976-R1023)

**Bot username management:**

* Added `ensure_bot_info` async function to lazily fetch and cache the bot's username on the first message, supporting accurate mention detection. [[1]](diffhunk://#diff-02c42af0355f59c9a581a996170ac1a4eac94989210ac8fdd54d7c03efcc91b2R363-R370) [[2]](diffhunk://#diff-31c4552bc1f86295acd2d1b663f17c58223b634ba226574ac46e78b92b268106R805-R812)

**Dependency update:**

* Imported the `re` module to support regular expression operations for mention stripping.