### PR TITLE
feat(instances): enforce active limits, follow cwd sync, and quicktemp lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ Thumbs.db
 
 .worktrees
 agent-deck-test
+
+AGENTS.md

--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -65,6 +66,41 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func joinWarnings(parts ...string) string {
+	joined := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		joined = append(joined, part)
+	}
+	return strings.Join(joined, "; ")
+}
+
+func resolveQuickDefaultPathForCLI() string {
+	settings := session.GetInstanceSettings()
+	path := strings.TrimSpace(settings.GetQuickDefaultPath())
+	if path == "" {
+		return ""
+	}
+
+	if !filepath.IsAbs(path) {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return ""
+		}
+		path = absPath
+	}
+
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+
+	return filepath.Clean(path)
 }
 
 // resolveSessionCommand normalizes the user-provided --cmd/-c input.

--- a/cmd/agent-deck/cli_utils_test.go
+++ b/cmd/agent-deck/cli_utils_test.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"flag"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 func TestNormalizeArgs(t *testing.T) {
@@ -357,4 +361,73 @@ func TestResolveGroupSelection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func writeQuickDefaultPathConfigForTest(t *testing.T, value string) string {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	configDir := filepath.Join(homeDir, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("failed to create config directory: %v", err)
+	}
+
+	content := "[instances]\n"
+	if value != "" {
+		content += "quick_default_path = \"" + value + "\"\n"
+	}
+
+	configPath := filepath.Join(configDir, session.UserConfigFileName)
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	return homeDir
+}
+
+func TestJoinWarnings(t *testing.T) {
+	got := joinWarnings("  ", "limit reached", "", "  closing oldest  ")
+	want := "limit reached; closing oldest"
+	if got != want {
+		t.Fatalf("joinWarnings() = %q, want %q", got, want)
+	}
+
+	if got := joinWarnings("", "  "); got != "" {
+		t.Fatalf("joinWarnings empty = %q, want empty", got)
+	}
+}
+
+func TestResolveQuickDefaultPathForCLI(t *testing.T) {
+	t.Run("returns cleaned absolute existing directory", func(t *testing.T) {
+		targetDir := filepath.Join(t.TempDir(), "workspace")
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			t.Fatalf("failed to create target directory: %v", err)
+		}
+
+		homeDir := writeQuickDefaultPathConfigForTest(t, "~/"+filepath.Base(targetDir))
+		movedDir := filepath.Join(homeDir, filepath.Base(targetDir))
+		if err := os.Rename(targetDir, movedDir); err != nil {
+			t.Fatalf("failed to move target directory under HOME: %v", err)
+		}
+
+		got := resolveQuickDefaultPathForCLI()
+		want := filepath.Clean(movedDir)
+		if got != want {
+			t.Fatalf("resolveQuickDefaultPathForCLI() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns empty when configured path does not exist", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing-dir")
+		writeQuickDefaultPathConfigForTest(t, missing)
+
+		if got := resolveQuickDefaultPathForCLI(); got != "" {
+			t.Fatalf("resolveQuickDefaultPathForCLI() = %q, want empty", got)
+		}
+	})
 }

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -84,7 +84,17 @@ func handleLaunch(profile string, args []string) {
 
 	// Resolve path
 	path := strings.Trim(fs.Arg(0), "'\"")
-	if path == "" || path == "." {
+	if path == "" {
+		path = resolveQuickDefaultPathForCLI()
+		if path == "" {
+			var err error
+			path, err = os.Getwd()
+			if err != nil {
+				out.Error(fmt.Sprintf("failed to get current directory: %v", err), ErrCodeInvalidOperation)
+				os.Exit(1)
+			}
+		}
+	} else if path == "." {
 		var err error
 		path, err = os.Getwd()
 		if err != nil {
@@ -203,6 +213,15 @@ func handleLaunch(profile string, args []string) {
 	if err != nil {
 		out.Error(err.Error(), ErrCodeNotFound)
 		os.Exit(1)
+	}
+
+	limitWarning, limitErr := session.EnforceActiveSessionLimit(instances, "")
+	if limitErr != nil {
+		out.Error(fmt.Sprintf("cannot launch session: %v", limitErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	if limitWarning != "" && !*jsonOutput {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", limitWarning)
 	}
 
 	// Resolve parent session if specified
@@ -380,6 +399,9 @@ func handleLaunch(profile string, args []string) {
 	if initialMessage != "" {
 		jsonData["message"] = initialMessage
 		jsonData["message_pending"] = *noWait
+	}
+	if limitWarning != "" {
+		jsonData["warning"] = limitWarning
 	}
 	if len(mcpFlags) > 0 {
 		jsonData["mcps"] = mcpFlags

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -865,9 +865,13 @@ func handleAdd(profile string, args []string) {
 			}
 		}
 	} else {
-		// No explicit path provided: use group default path first, then cwd fallback.
+		// No explicit path provided: use group default path first,
+		// then quick default path, then cwd fallback.
 		if sessionGroup != "" {
 			path = groupTree.DefaultPathForGroup(sessionGroup)
+		}
+		if path == "" {
+			path = resolveQuickDefaultPathForCLI()
 		}
 		if path == "" {
 			path, err = os.Getwd()

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -177,6 +177,15 @@ func handleSessionStart(profile string, args []string) {
 		os.Exit(1)
 	}
 
+	limitWarning, limitErr := session.EnforceActiveSessionLimit(instances, inst.ID)
+	if limitErr != nil {
+		out.Error(fmt.Sprintf("cannot start session: %v", limitErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	if limitWarning != "" && !*jsonOutput {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", limitWarning)
+	}
+
 	// Start the session (with or without initial message)
 	if initialMessage != "" {
 		if err := inst.StartWithMessage(initialMessage); err != nil {
@@ -215,8 +224,14 @@ func handleSessionStart(profile string, args []string) {
 	if initialMessage != "" {
 		jsonData["message"] = initialMessage
 		jsonData["message_pending"] = false
+		if limitWarning != "" {
+			jsonData["warning"] = limitWarning
+		}
 		out.Success(fmt.Sprintf("Started session: %s (message sent)", inst.Title), jsonData)
 	} else {
+		if limitWarning != "" {
+			jsonData["warning"] = limitWarning
+		}
 		out.Success(fmt.Sprintf("Started session: %s", inst.Title), jsonData)
 	}
 }
@@ -331,12 +346,18 @@ func handleSessionRestart(profile string, args []string) {
 		return // unreachable, satisfies staticcheck SA5011
 	}
 
+	limitWarning, limitErr := session.EnforceActiveSessionLimit(instances, inst.ID)
+	if limitErr != nil {
+		out.Error(fmt.Sprintf("cannot restart session: %v", limitErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
 	// Restart the session
 	if err := inst.Restart(); err != nil {
 		out.Error(fmt.Sprintf("failed to restart session: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
-	warning := inst.ConsumeCodexRestartWarning()
+	warning := joinWarnings(limitWarning, inst.ConsumeCodexRestartWarning())
 	if warning != "" && !*jsonOutput {
 		fmt.Fprintf(os.Stderr, "Warning: %s\n", warning)
 	}
@@ -450,6 +471,15 @@ func handleSessionFork(profile string, args []string) {
 		os.Exit(1)
 	}
 
+	limitWarning, limitErr := session.EnforceActiveSessionLimit(instances, "")
+	if limitErr != nil {
+		out.Error(fmt.Sprintf("cannot fork session: %v", limitErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	if limitWarning != "" && !*jsonOutput {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", limitWarning)
+	}
+
 	// Default title if not provided
 	if forkTitle == "" {
 		forkTitle = inst.Title + "-fork"
@@ -554,14 +584,19 @@ func handleSessionFork(profile string, args []string) {
 	}
 
 	// Output success
+	jsonData := map[string]interface{}{
+		"success":   true,
+		"parent_id": inst.ID,
+		"new_id":    forkedInst.ID,
+		"new_title": forkedInst.Title,
+	}
+	if limitWarning != "" {
+		jsonData["warning"] = limitWarning
+	}
+
 	out.Success(
 		fmt.Sprintf("Forked session: %s -> %s (%s)", inst.Title, forkedInst.Title, TruncateID(forkedInst.ID)),
-		map[string]interface{}{
-			"success":   true,
-			"parent_id": inst.ID,
-			"new_id":    forkedInst.ID,
-			"new_title": forkedInst.Title,
-		},
+		jsonData,
 	)
 }
 

--- a/cmd/agent-deck/try_cmd.go
+++ b/cmd/agent-deck/try_cmd.go
@@ -120,7 +120,18 @@ func handleTry(profile string, args []string) {
 	for _, inst := range instances {
 		if inst.ProjectPath == exp.Path {
 			// Session exists - just start it if not running
+			limitWarning := ""
 			if !inst.Exists() {
+				var limitErr error
+				limitWarning, limitErr = session.EnforceActiveSessionLimit(instances, inst.ID)
+				if limitErr != nil {
+					out.Error(fmt.Sprintf("cannot start session: %v", limitErr), ErrCodeInvalidOperation)
+					os.Exit(1)
+				}
+				if limitWarning != "" && !*jsonOutput {
+					fmt.Fprintf(os.Stderr, "Warning: %s\n", limitWarning)
+				}
+
 				if err := inst.Start(); err != nil {
 					out.Error(fmt.Sprintf("starting session: %v", err), ErrCodeInvalidOperation)
 					os.Exit(1)
@@ -129,18 +140,32 @@ func handleTry(profile string, args []string) {
 				// Save updated state with session ID
 				_ = saveSessionData(storage, instances)
 			}
+
+			jsonData := map[string]interface{}{
+				"action":  "existing",
+				"session": inst.Title,
+				"id":      inst.ID[:8],
+				"path":    exp.Path,
+				"tool":    inst.Tool,
+			}
+			if limitWarning != "" {
+				jsonData["warning"] = limitWarning
+			}
 			out.Print(
 				fmt.Sprintf("Session: %s (%s)\nPath: %s\n", inst.Title, inst.ID[:8], exp.Path),
-				map[string]interface{}{
-					"action":  "existing",
-					"session": inst.Title,
-					"id":      inst.ID[:8],
-					"path":    exp.Path,
-					"tool":    inst.Tool,
-				},
+				jsonData,
 			)
 			return
 		}
+	}
+
+	limitWarning, limitErr := session.EnforceActiveSessionLimit(instances, "")
+	if limitErr != nil {
+		out.Error(fmt.Sprintf("cannot start session: %v", limitErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	if limitWarning != "" && !*jsonOutput {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", limitWarning)
 	}
 
 	// Create new session
@@ -176,16 +201,21 @@ func handleTry(profile string, args []string) {
 		action = "Found"
 	}
 
+	jsonData := map[string]interface{}{
+		"action":  strings.ToLower(action),
+		"name":    exp.Name,
+		"path":    exp.Path,
+		"session": newInst.Title,
+		"id":      newInst.ID[:8],
+		"tool":    selectedTool,
+	}
+	if limitWarning != "" {
+		jsonData["warning"] = limitWarning
+	}
+
 	out.Success(
 		fmt.Sprintf("%s experiment: %s", action, exp.Name),
-		map[string]interface{}{
-			"action":  strings.ToLower(action),
-			"name":    exp.Name,
-			"path":    exp.Path,
-			"session": newInst.Title,
-			"id":      newInst.ID[:8],
-			"tool":    selectedTool,
-		},
+		jsonData,
 	)
 }
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -134,6 +134,10 @@ type Instance struct {
 	// JSON structure: {"tool": "claude", "options": {...}}
 	ToolOptionsJSON json.RawMessage `json:"tool_options,omitempty"`
 
+	// AutoDeleteOnClose removes this session from agent-deck metadata when the
+	// underlying process exits or the session is explicitly closed.
+	AutoDeleteOnClose bool `json:"auto_delete_on_close,omitempty"`
+
 	tmuxSession *tmux.Session // Internal tmux session
 
 	// Hook-based status detection (set by StatusFileWatcher from Claude Code hooks)
@@ -254,6 +258,61 @@ func (inst *Instance) SetToolThreadSafe(t string) {
 // MarkAccessed updates the LastAccessedAt timestamp to now
 func (inst *Instance) MarkAccessed() {
 	inst.LastAccessedAt = time.Now()
+}
+
+// EnforceActiveSessionLimit applies [instances].max_active_sessions policy.
+//
+// excludeID lets callers ignore one session ID when needed.
+// Returns a non-empty warning when policy is "warn" or "close_oldest".
+func EnforceActiveSessionLimit(instances []*Instance, excludeID string) (string, error) {
+	settings := GetInstanceSettings()
+	maxActive := settings.GetMaxActiveSessions()
+	if maxActive <= 0 {
+		return "", nil
+	}
+
+	active := make([]*Instance, 0, len(instances))
+	for _, inst := range instances {
+		if inst == nil || inst.ID == excludeID {
+			continue
+		}
+		if inst.Exists() {
+			active = append(active, inst)
+		}
+	}
+
+	if len(active) < maxActive {
+		return "", nil
+	}
+
+	policy := settings.GetMaxActiveSessionsPolicy()
+	count := len(active)
+	baseMsg := fmt.Sprintf("max active sessions reached (%d/%d)", count, maxActive)
+
+	switch policy {
+	case MaxActiveSessionsPolicyDeny:
+		return "", fmt.Errorf("%s; policy=%s", baseMsg, MaxActiveSessionsPolicyDeny)
+
+	case MaxActiveSessionsPolicyCloseOldest:
+		sort.SliceStable(active, func(i, j int) bool {
+			if active[i].CreatedAt.Equal(active[j].CreatedAt) {
+				return active[i].ID < active[j].ID
+			}
+			return active[i].CreatedAt.Before(active[j].CreatedAt)
+		})
+
+		oldest := active[0]
+		if err := oldest.Kill(); err != nil {
+			return "", fmt.Errorf("%s; failed to close oldest session '%s': %w", baseMsg, oldest.Title, err)
+		}
+
+		return fmt.Sprintf("%s; closed oldest session '%s'", baseMsg, oldest.Title), nil
+
+	case MaxActiveSessionsPolicyWarn:
+		fallthrough
+	default:
+		return baseMsg + "; policy=warn (continuing)", nil
+	}
 }
 
 // GetLastActivityTime returns when the session was last active (content changed)

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -2623,3 +2623,114 @@ func TestInstance_SetAcknowledgedFromShared_WaitingApplied(t *testing.T) {
 
 // Tests for hasUnsentComposerPrompt and currentComposerPrompt moved to
 // internal/send/send_test.go as part of send verification consolidation.
+func writeInstanceLimitConfigForTest(t *testing.T, maxActive int, policy string) {
+	t.Helper()
+
+	origHome := os.Getenv("HOME")
+	homeDir := t.TempDir()
+	os.Setenv("HOME", homeDir)
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+	})
+
+	configDir := filepath.Join(homeDir, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("failed to create config directory: %v", err)
+	}
+
+	configPath := filepath.Join(configDir, UserConfigFileName)
+	content := fmt.Sprintf("[instances]\nmax_active_sessions = %d\nmax_active_sessions_policy = %q\n", maxActive, policy)
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+}
+
+func startActiveSessionForLimitTest(t *testing.T, title string) *Instance {
+	t.Helper()
+
+	inst := NewInstance(title, "/tmp")
+	if err := inst.Start(); err != nil {
+		t.Fatalf("failed to start session %q: %v", title, err)
+	}
+	t.Cleanup(func() {
+		_ = inst.Kill()
+	})
+
+	return inst
+}
+
+func TestEnforceActiveSessionLimitWarn(t *testing.T) {
+	skipIfNoTmuxServer(t)
+	writeInstanceLimitConfigForTest(t, 1, MaxActiveSessionsPolicyWarn)
+
+	inst := startActiveSessionForLimitTest(t, fmt.Sprintf("limit-warn-%d", time.Now().UnixNano()))
+
+	warning, err := EnforceActiveSessionLimit([]*Instance{inst}, "")
+	if err != nil {
+		t.Fatalf("EnforceActiveSessionLimit() returned error: %v", err)
+	}
+	if !strings.Contains(warning, "max active sessions reached (1/1)") {
+		t.Fatalf("warning %q missing limit context", warning)
+	}
+	if !strings.Contains(warning, "policy=warn") {
+		t.Fatalf("warning %q missing warn policy hint", warning)
+	}
+}
+
+func TestEnforceActiveSessionLimitDeny(t *testing.T) {
+	skipIfNoTmuxServer(t)
+	writeInstanceLimitConfigForTest(t, 1, MaxActiveSessionsPolicyDeny)
+
+	inst := startActiveSessionForLimitTest(t, fmt.Sprintf("limit-deny-%d", time.Now().UnixNano()))
+
+	warning, err := EnforceActiveSessionLimit([]*Instance{inst}, "")
+	if warning != "" {
+		t.Fatalf("warning = %q, want empty for deny policy", warning)
+	}
+	if err == nil {
+		t.Fatal("EnforceActiveSessionLimit() should error for deny policy")
+	}
+	if !strings.Contains(err.Error(), "policy=deny") {
+		t.Fatalf("deny error %q missing policy marker", err)
+	}
+}
+
+func TestEnforceActiveSessionLimitCloseOldest(t *testing.T) {
+	skipIfNoTmuxServer(t)
+	writeInstanceLimitConfigForTest(t, 1, MaxActiveSessionsPolicyCloseOldest)
+
+	oldestTitle := fmt.Sprintf("limit-oldest-%d", time.Now().UnixNano())
+	newerTitle := fmt.Sprintf("limit-newer-%d", time.Now().UnixNano())
+	oldest := startActiveSessionForLimitTest(t, oldestTitle)
+	time.Sleep(10 * time.Millisecond)
+	newer := startActiveSessionForLimitTest(t, newerTitle)
+
+	warning, err := EnforceActiveSessionLimit([]*Instance{oldest, newer}, "")
+	if err != nil {
+		t.Fatalf("EnforceActiveSessionLimit() returned error: %v", err)
+	}
+	if !strings.Contains(warning, "closed oldest session '") || !strings.Contains(warning, oldestTitle) {
+		t.Fatalf("warning %q should mention closed oldest session %q", warning, oldestTitle)
+	}
+	if !newer.Exists() {
+		t.Fatal("newer session should remain running after close_oldest policy")
+	}
+}
+
+func TestEnforceActiveSessionLimitExcludeID(t *testing.T) {
+	skipIfNoTmuxServer(t)
+	writeInstanceLimitConfigForTest(t, 1, MaxActiveSessionsPolicyDeny)
+
+	inst := startActiveSessionForLimitTest(t, fmt.Sprintf("limit-exclude-%d", time.Now().UnixNano()))
+
+	warning, err := EnforceActiveSessionLimit([]*Instance{inst}, inst.ID)
+	if err != nil {
+		t.Fatalf("EnforceActiveSessionLimit() with excludeID returned error: %v", err)
+	}
+	if warning != "" {
+		t.Fatalf("warning = %q, want empty when session is excluded", warning)
+	}
+}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -78,7 +78,8 @@ type InstanceData struct {
 	Notes        string `json:"notes,omitempty"`
 
 	// Tool-specific launch options (generic for all tools: claude, codex, etc.)
-	ToolOptionsJSON json.RawMessage `json:"tool_options,omitempty"`
+	ToolOptionsJSON   json.RawMessage `json:"tool_options,omitempty"`
+	AutoDeleteOnClose bool            `json:"auto_delete_on_close,omitempty"`
 
 	// MCP tracking (persisted for sync status display)
 	LoadedMCPNames []string `json:"loaded_mcp_names,omitempty"`
@@ -268,6 +269,7 @@ func (s *Storage) SaveWithGroups(instances []*Instance, groupTree *GroupTree) er
 			inst.LatestPrompt, inst.Notes, inst.LoadedMCPNames,
 			inst.ToolOptionsJSON,
 			inst.SSHHost, inst.SSHRemotePath,
+			inst.AutoDeleteOnClose,
 		)
 
 		rows[i] = &statedb.InstanceRow{
@@ -408,7 +410,8 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			codexSID, codexAt,
 			latestPrompt, notes, loadedMCPs,
 			toolOpts,
-			sshHost2, sshRemotePath2 := statedb.UnmarshalToolData(r.ToolData)
+			sshHost2, sshRemotePath2,
+			autoDeleteOnClose := statedb.UnmarshalToolData(r.ToolData)
 
 		instances[i] = &InstanceData{
 			ID:                 r.ID,
@@ -440,6 +443,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			LatestPrompt:       latestPrompt,
 			Notes:              notes,
 			ToolOptionsJSON:    toolOpts,
+			AutoDeleteOnClose:  autoDeleteOnClose,
 			LoadedMCPNames:     loadedMCPs,
 			SSHHost:            sshHost2,
 			SSHRemotePath:      sshRemotePath2,
@@ -494,7 +498,8 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			codexSID, codexAt,
 			latestPrompt, notes, loadedMCPs,
 			toolOpts,
-			sshHost, sshRemotePath := statedb.UnmarshalToolData(r.ToolData)
+			sshHost, sshRemotePath,
+			autoDeleteOnClose := statedb.UnmarshalToolData(r.ToolData)
 
 		data.Instances[i] = &InstanceData{
 			ID:                 r.ID,
@@ -526,6 +531,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			LatestPrompt:       latestPrompt,
 			Notes:              notes,
 			ToolOptionsJSON:    toolOpts,
+			AutoDeleteOnClose:  autoDeleteOnClose,
 			LoadedMCPNames:     loadedMCPs,
 			SSHHost:            sshHost,
 			SSHRemotePath:      sshRemotePath,

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -365,11 +365,38 @@ type InstanceSettings struct {
 	// When false, only one instance can run per profile
 	AllowMultiple *bool `toml:"allow_multiple"`
 
-	// FollowCwdOnAttach updates the session's ProjectPath from tmux pane_current_path
-	// after returning from attach, and persists the new path.
+	// FollowCwdOnAttach updates the session's ProjectPath from the last observed
+	// tmux pane_current_path.
+	//
+	// When enabled, agent-deck syncs path changes after attach returns and during
+	// background status polling while the session is running.
 	// Default: false
 	FollowCwdOnAttach *bool `toml:"follow_cwd_on_attach"`
+
+	// QuickDefaultPath is a default directory used by quick session creation when
+	// no session/group path context is available.
+	//
+	// Empty = fall back to current working directory behavior.
+	QuickDefaultPath string `toml:"quick_default_path"`
+
+	// MaxActiveSessions caps concurrently active sessions.
+	//
+	// 0 or less disables the limit.
+	MaxActiveSessions int `toml:"max_active_sessions"`
+
+	// MaxActiveSessionsPolicy determines behavior when opening a session beyond
+	// MaxActiveSessions.
+	//
+	// Valid values: "warn", "deny", "close_oldest".
+	// Default: "warn".
+	MaxActiveSessionsPolicy string `toml:"max_active_sessions_policy"`
 }
+
+const (
+	MaxActiveSessionsPolicyWarn        = "warn"
+	MaxActiveSessionsPolicyDeny        = "deny"
+	MaxActiveSessionsPolicyCloseOldest = "close_oldest"
+)
 
 // GetAllowMultiple returns whether multiple instances are allowed, defaulting to true
 func (i *InstanceSettings) GetAllowMultiple() bool {
@@ -385,6 +412,41 @@ func (i *InstanceSettings) GetFollowCwdOnAttach() bool {
 		return false
 	}
 	return *i.FollowCwdOnAttach
+}
+
+// GetQuickDefaultPath returns the configured quick-session default path.
+// Empty means no override.
+func (i *InstanceSettings) GetQuickDefaultPath() string {
+	path := strings.TrimSpace(i.QuickDefaultPath)
+	if path == "" {
+		return ""
+	}
+	return ExpandPath(path)
+}
+
+// GetMaxActiveSessions returns the configured active session limit.
+// 0 means unlimited.
+func (i *InstanceSettings) GetMaxActiveSessions() int {
+	if i.MaxActiveSessions <= 0 {
+		return 0
+	}
+	return i.MaxActiveSessions
+}
+
+// GetMaxActiveSessionsPolicy returns the configured limit policy,
+// normalized with defaults.
+func (i *InstanceSettings) GetMaxActiveSessionsPolicy() string {
+	policy := strings.TrimSpace(strings.ToLower(i.MaxActiveSessionsPolicy))
+	switch policy {
+	case MaxActiveSessionsPolicyDeny:
+		return MaxActiveSessionsPolicyDeny
+	case MaxActiveSessionsPolicyCloseOldest:
+		return MaxActiveSessionsPolicyCloseOldest
+	case "", MaxActiveSessionsPolicyWarn:
+		return MaxActiveSessionsPolicyWarn
+	default:
+		return MaxActiveSessionsPolicyWarn
+	}
 }
 
 // ShellSettings defines shell environment configuration for sessions
@@ -1586,9 +1648,17 @@ func CreateExampleConfig() error {
 # close_session = "D"
 # restart = "R"
 
-# Attach-return project path sync (optional)
+# Session behavior (optional)
 # [instances]
+# Keep project path synced with last observed tmux pane_current_path
 # follow_cwd_on_attach = true
+# Default directory for quick create when no group/session path context exists
+# quick_default_path = "~/src"
+# Maximum active sessions (0 = unlimited)
+# max_active_sessions = 5
+# What to do when trying to exceed max_active_sessions:
+# "warn" | "deny" | "close_oldest"
+# max_active_sessions_policy = "warn"
 
 # Preview notes/output split (optional)
 # [preview]

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -683,12 +683,63 @@ func TestInstanceSettingsFollowCwdOnAttach(t *testing.T) {
 	}
 }
 
+func TestInstanceSettingsQuickDefaultPath(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	homeDir := t.TempDir()
+	os.Setenv("HOME", homeDir)
+	defer os.Setenv("HOME", origHome)
+
+	settings := InstanceSettings{QuickDefaultPath: "  ~/projects/agent-deck  "}
+	want := filepath.Join(homeDir, "projects", "agent-deck")
+	if got := settings.GetQuickDefaultPath(); got != want {
+		t.Fatalf("GetQuickDefaultPath() = %q, want %q", got, want)
+	}
+
+	settings.QuickDefaultPath = "   "
+	if got := settings.GetQuickDefaultPath(); got != "" {
+		t.Fatalf("GetQuickDefaultPath() blank = %q, want empty", got)
+	}
+}
+
+func TestInstanceSettingsMaxActiveSessionsAndPolicy(t *testing.T) {
+	settings := InstanceSettings{}
+	if got := settings.GetMaxActiveSessions(); got != 0 {
+		t.Fatalf("GetMaxActiveSessions default = %d, want 0", got)
+	}
+	if got := settings.GetMaxActiveSessionsPolicy(); got != MaxActiveSessionsPolicyWarn {
+		t.Fatalf("GetMaxActiveSessionsPolicy default = %q, want %q", got, MaxActiveSessionsPolicyWarn)
+	}
+
+	settings.MaxActiveSessions = 3
+	if got := settings.GetMaxActiveSessions(); got != 3 {
+		t.Fatalf("GetMaxActiveSessions configured = %d, want 3", got)
+	}
+
+	settings.MaxActiveSessionsPolicy = "  CLOSE_OLDEST  "
+	if got := settings.GetMaxActiveSessionsPolicy(); got != MaxActiveSessionsPolicyCloseOldest {
+		t.Fatalf("GetMaxActiveSessionsPolicy close_oldest = %q, want %q", got, MaxActiveSessionsPolicyCloseOldest)
+	}
+
+	settings.MaxActiveSessionsPolicy = "deny"
+	if got := settings.GetMaxActiveSessionsPolicy(); got != MaxActiveSessionsPolicyDeny {
+		t.Fatalf("GetMaxActiveSessionsPolicy deny = %q, want %q", got, MaxActiveSessionsPolicyDeny)
+	}
+
+	settings.MaxActiveSessionsPolicy = "unsupported"
+	if got := settings.GetMaxActiveSessionsPolicy(); got != MaxActiveSessionsPolicyWarn {
+		t.Fatalf("GetMaxActiveSessionsPolicy invalid = %q, want %q", got, MaxActiveSessionsPolicyWarn)
+	}
+}
+
 func TestUserConfigParseFollowCwdOnAttach(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
 	content := `
 [instances]
 follow_cwd_on_attach = true
+quick_default_path = "~/projects"
+max_active_sessions = 4
+max_active_sessions_policy = "deny"
 `
 	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
 		t.Fatalf("Failed to write config file: %v", err)
@@ -701,6 +752,15 @@ follow_cwd_on_attach = true
 
 	if !config.Instances.GetFollowCwdOnAttach() {
 		t.Fatal("instances.follow_cwd_on_attach should parse as true")
+	}
+	if got := config.Instances.GetQuickDefaultPath(); got == "" {
+		t.Fatal("instances.quick_default_path should parse as non-empty")
+	}
+	if got := config.Instances.GetMaxActiveSessions(); got != 4 {
+		t.Fatalf("instances.max_active_sessions = %d, want 4", got)
+	}
+	if got := config.Instances.GetMaxActiveSessionsPolicy(); got != MaxActiveSessionsPolicyDeny {
+		t.Fatalf("instances.max_active_sessions_policy = %q, want %q", got, MaxActiveSessionsPolicyDeny)
 	}
 }
 

--- a/internal/statedb/migrate.go
+++ b/internal/statedb/migrate.go
@@ -48,10 +48,11 @@ type jsonInstanceData struct {
 	CodexSessionID  string    `json:"codex_session_id,omitempty"`
 	CodexDetectedAt time.Time `json:"codex_detected_at,omitempty"`
 
-	LatestPrompt    string          `json:"latest_prompt,omitempty"`
-	Notes           string          `json:"notes,omitempty"`
-	ToolOptionsJSON json.RawMessage `json:"tool_options,omitempty"`
-	LoadedMCPNames  []string        `json:"loaded_mcp_names,omitempty"`
+	LatestPrompt      string          `json:"latest_prompt,omitempty"`
+	Notes             string          `json:"notes,omitempty"`
+	ToolOptionsJSON   json.RawMessage `json:"tool_options,omitempty"`
+	LoadedMCPNames    []string        `json:"loaded_mcp_names,omitempty"`
+	AutoDeleteOnClose bool            `json:"auto_delete_on_close,omitempty"`
 }
 
 // jsonGroupData mirrors session.GroupData for migration.
@@ -81,6 +82,7 @@ type toolDataBlob struct {
 	ToolOptions        json.RawMessage `json:"tool_options,omitempty"`
 	SSHHost            string          `json:"ssh_host,omitempty"`
 	SSHRemotePath      string          `json:"ssh_remote_path,omitempty"`
+	AutoDeleteOnClose  bool            `json:"auto_delete_on_close,omitempty"`
 }
 
 // MigrateFromJSON reads a sessions.json file and inserts all data into the StateDB.
@@ -110,6 +112,7 @@ func MigrateFromJSON(jsonPath string, db *StateDB) (int, int, error) {
 			Notes:             inst.Notes,
 			LoadedMCPNames:    inst.LoadedMCPNames,
 			ToolOptions:       inst.ToolOptionsJSON,
+			AutoDeleteOnClose: inst.AutoDeleteOnClose,
 		}
 		if !inst.ClaudeDetectedAt.IsZero() {
 			td.ClaudeDetectedAt = inst.ClaudeDetectedAt.Unix()
@@ -186,6 +189,7 @@ func MarshalToolData(
 	latestPrompt string, notes string, loadedMCPNames []string,
 	toolOptionsJSON json.RawMessage,
 	sshHost string, sshRemotePath string,
+	autoDeleteOnClose bool,
 ) json.RawMessage {
 	td := toolDataBlob{
 		ClaudeSessionID:   claudeSessionID,
@@ -200,6 +204,7 @@ func MarshalToolData(
 		ToolOptions:       toolOptionsJSON,
 		SSHHost:           sshHost,
 		SSHRemotePath:     sshRemotePath,
+		AutoDeleteOnClose: autoDeleteOnClose,
 	}
 	if !claudeDetectedAt.IsZero() {
 		td.ClaudeDetectedAt = claudeDetectedAt.Unix()
@@ -228,6 +233,7 @@ func UnmarshalToolData(data json.RawMessage) (
 	latestPrompt string, notes string, loadedMCPNames []string,
 	toolOptionsJSON json.RawMessage,
 	sshHost string, sshRemotePath string,
+	autoDeleteOnClose bool,
 ) {
 	if len(data) == 0 {
 		return
@@ -260,5 +266,6 @@ func UnmarshalToolData(data json.RawMessage) (
 	toolOptionsJSON = td.ToolOptions
 	sshHost = td.SSHHost
 	sshRemotePath = td.SSHRemotePath
+	autoDeleteOnClose = td.AutoDeleteOnClose
 	return
 }

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -195,7 +195,7 @@ func (pm *PipeManager) RefreshAllActivities() (map[string]int64, map[string][]Wi
 }
 
 // RefreshAllPaneInfo sends a single list-panes command through any available
-// pipe to get pane titles and current commands for ALL sessions. This provides
+// pipe to get pane metadata for ALL sessions. This provides
 // the data needed for title-based state detection without subprocess spawns.
 // Also returns per-window tool detection data for enriching the window cache.
 func (pm *PipeManager) RefreshAllPaneInfo() (map[string]PaneInfo, map[string]map[int]string, error) {
@@ -213,7 +213,7 @@ func (pm *PipeManager) RefreshAllPaneInfo() (map[string]PaneInfo, map[string]map
 		return nil, nil, fmt.Errorf("no alive pipes available")
 	}
 
-	output, err := pipe.SendCommand(`list-panes -a -F "#{session_name}\t#{pane_title}\t#{pane_current_command}\t#{pane_dead}\t#{window_index}\t#{pane_index}"`)
+	output, err := pipe.SendCommand(`list-panes -a -F "#{session_name}\t#{pane_title}\t#{pane_current_command}\t#{pane_dead}\t#{pane_current_path}\t#{window_index}\t#{pane_index}"`)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list-panes via pipe: %w", err)
 	}
@@ -225,18 +225,18 @@ func (pm *PipeManager) RefreshAllPaneInfo() (map[string]PaneInfo, map[string]map
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "\t", 6)
-		if len(parts) != 6 {
+		parts := strings.SplitN(line, "\t", 7)
+		if len(parts) != 7 {
 			continue
 		}
 		name := parts[0]
 
 		// Collect tool info for the first pane of each window (handles any base-index).
-		windowKey := name + "\t" + parts[4]
+		windowKey := name + "\t" + parts[5]
 		if !seenWindowTool[windowKey] {
 			seenWindowTool[windowKey] = true
 			var winIdx int
-			_, _ = fmt.Sscanf(parts[4], "%d", &winIdx)
+			_, _ = fmt.Sscanf(parts[5], "%d", &winIdx)
 			tool := detectToolFromCommand(parts[2])
 			if tool == "" {
 				tool = detectToolFromCommand(parts[1])
@@ -255,6 +255,7 @@ func (pm *PipeManager) RefreshAllPaneInfo() (map[string]PaneInfo, map[string]map
 				Title:          parts[1],
 				CurrentCommand: parts[2],
 				Dead:           parts[3] == "1",
+				CurrentPath:    parts[4],
 			}
 		}
 	}

--- a/internal/tmux/title_detection.go
+++ b/internal/tmux/title_detection.go
@@ -20,11 +20,12 @@ const (
 	TitleStateDone                      // Done marker detected, fall through to prompt detection
 )
 
-// PaneInfo holds pane title and current command for a tmux session.
+// PaneInfo holds cached pane metadata for a tmux session.
 type PaneInfo struct {
 	Title          string
 	CurrentCommand string
 	Dead           bool
+	CurrentPath    string
 }
 
 // WindowInfo holds basic info about a tmux window within a session.
@@ -120,7 +121,7 @@ func RefreshPaneInfoCache() {
 	}
 
 	// Subprocess fallback: list-panes -a
-	cmd := exec.Command("tmux", "list-panes", "-a", "-F", "#{session_name}\t#{pane_title}\t#{pane_current_command}\t#{pane_dead}\t#{window_index}\t#{pane_index}")
+	cmd := exec.Command("tmux", "list-panes", "-a", "-F", "#{session_name}\t#{pane_title}\t#{pane_current_command}\t#{pane_dead}\t#{pane_current_path}\t#{window_index}\t#{pane_index}")
 	output, err := cmd.Output()
 	if err != nil {
 		paneCacheMu.Lock()
@@ -137,19 +138,19 @@ func RefreshPaneInfoCache() {
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "\t", 6)
-		if len(parts) != 6 {
+		parts := strings.SplitN(line, "\t", 7)
+		if len(parts) != 7 {
 			continue
 		}
 		name := parts[0]
 
 		// Collect tool info for the first pane of each window (handles any base-index).
 		// list-panes outputs panes sorted by window then pane index, so first hit = primary.
-		windowKey := name + "\t" + parts[4]
+		windowKey := name + "\t" + parts[5]
 		if !seenWindowTool[windowKey] {
 			seenWindowTool[windowKey] = true
 			var winIdx int
-			_, _ = fmt.Sscanf(parts[4], "%d", &winIdx)
+			_, _ = fmt.Sscanf(parts[5], "%d", &winIdx)
 			// Try pane_current_command first, then pane_title (Claude shows as "bash"
 			// in command but "Claude Code" in title via OSC escape sequences).
 			tool := detectToolFromCommand(parts[2])
@@ -171,6 +172,7 @@ func RefreshPaneInfoCache() {
 				Title:          parts[1],
 				CurrentCommand: parts[2],
 				Dead:           parts[3] == "1",
+				CurrentPath:    parts[4],
 			}
 		}
 	}

--- a/internal/tmux/title_detection_test.go
+++ b/internal/tmux/title_detection_test.go
@@ -136,6 +136,9 @@ func TestRefreshPaneInfoCache(t *testing.T) {
 	if info.CurrentCommand == "" {
 		t.Error("Expected non-empty CurrentCommand for test session")
 	}
+	if info.CurrentPath == "" {
+		t.Error("Expected non-empty CurrentPath for test session")
+	}
 
 	// Verify a non-existent session is not in cache
 	_, ok = GetCachedPaneInfo("nonexistent_session_xyz")

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -31,6 +31,7 @@ type ConfirmDialog struct {
 	height      int
 	mcpCount    int  // Number of running MCPs (for quit confirmation)
 	sandboxed   bool // Whether the session uses a Docker sandbox.
+	autoDelete  bool // Whether close removes session metadata too.
 
 	// Pending session creation data (for ConfirmCreateDirectory)
 	pendingSessionName      string
@@ -55,12 +56,13 @@ func (c *ConfirmDialog) ShowDeleteSession(sessionID string, sessionName string, 
 }
 
 // ShowCloseSession shows confirmation for non-destructive session close.
-func (c *ConfirmDialog) ShowCloseSession(sessionID string, sessionName string, sandboxed bool) {
+func (c *ConfirmDialog) ShowCloseSession(sessionID string, sessionName string, sandboxed bool, autoDelete bool) {
 	c.visible = true
 	c.confirmType = ConfirmCloseSession
 	c.targetID = sessionID
 	c.targetName = sessionName
 	c.sandboxed = sandboxed
+	c.autoDelete = autoDelete
 }
 
 // ShowDeleteGroup shows confirmation for group deletion
@@ -118,6 +120,7 @@ func (c *ConfirmDialog) Hide() {
 	c.targetID = ""
 	c.targetName = ""
 	c.sandboxed = false
+	c.autoDelete = false
 }
 
 // IsVisible returns whether the dialog is visible
@@ -194,7 +197,12 @@ func (c *ConfirmDialog) View() string {
 	case ConfirmCloseSession:
 		title = "Close Session?"
 		warning = fmt.Sprintf("This will close the running process for:\n\n  \"%s\"", c.targetName)
-		details = "• The tmux session will be terminated\n• Session metadata will be kept in the list\n• You can restart later from the session list"
+		details = "• The tmux session will be terminated"
+		if c.autoDelete {
+			details += "\n• Session metadata will be removed (temporary session)"
+		} else {
+			details += "\n• Session metadata will be kept in the list\n• You can restart later from the session list"
+		}
 		if c.sandboxed {
 			details += "\n• The Docker container will be removed"
 		}

--- a/internal/ui/confirm_dialog_test.go
+++ b/internal/ui/confirm_dialog_test.go
@@ -1,0 +1,28 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfirmDialogShowCloseSessionAutoDeleteDetails(t *testing.T) {
+	dialog := NewConfirmDialog()
+	dialog.SetSize(100, 30)
+	dialog.ShowCloseSession("sess-1", "Temporary Session", false, true)
+
+	view := dialog.View()
+	if !strings.Contains(view, "Session metadata will be removed") {
+		t.Fatalf("close dialog should mention metadata removal for temporary sessions, got %q", view)
+	}
+}
+
+func TestConfirmDialogShowCloseSessionKeepsMetadataDetails(t *testing.T) {
+	dialog := NewConfirmDialog()
+	dialog.SetSize(100, 30)
+	dialog.ShowCloseSession("sess-2", "Regular Session", false, false)
+
+	view := dialog.View()
+	if !strings.Contains(view, "Session metadata will be kept in the list") {
+		t.Fatalf("close dialog should mention preserved metadata for regular sessions, got %q", view)
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -170,7 +170,7 @@ func (h *HelpOverlay) View() string {
 		{
 			title: "SESSIONS",
 			items: [][2]string{
-				{newKeys, "New / quick create"},
+				{newKeys, "New / quicktemp (auto-delete)"},
 				{renameKey, "Rename session"},
 				{restartKey, "Restart session"},
 				{deleteKey, "Delete session"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -442,12 +442,14 @@ type loadSessionsMsg struct {
 type sessionCreatedMsg struct {
 	instance *session.Instance
 	err      error
+	warning  string
 }
 
 type sessionForkedMsg struct {
 	instance *session.Instance
 	sourceID string // ID of the source session that was forked (for cleanup)
 	err      error
+	warning  string
 }
 
 type refreshMsg struct{}
@@ -2010,6 +2012,60 @@ func (h *Home) getDefaultPathForGroup(groupPath string) string {
 	return p
 }
 
+func (h *Home) resolveQuickDefaultPath() string {
+	settings := session.GetInstanceSettings()
+	path := settings.GetQuickDefaultPath()
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+
+	if !filepath.IsAbs(path) {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return ""
+		}
+		path = absPath
+	}
+
+	if info, err := os.Stat(path); err != nil || !info.IsDir() {
+		return ""
+	}
+
+	return filepath.Clean(path)
+}
+
+func joinWarnings(parts ...string) string {
+	joined := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		joined = append(joined, part)
+	}
+	return strings.Join(joined, "; ")
+}
+
+func normalizeFollowedProjectPath(rawPath string) string {
+	path := strings.TrimSpace(rawPath)
+	if path == "" {
+		return ""
+	}
+
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(path) {
+		return ""
+	}
+
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+
+	return path
+}
+
 // statusWorker runs in a background goroutine with its own ticker
 // This ensures status updates continue even when TUI is paused (tea.Exec)
 func (h *Home) statusWorker() {
@@ -2117,6 +2173,8 @@ func (h *Home) backgroundStatusUpdate() {
 	instances := make([]*session.Instance, len(h.instances))
 	copy(instances, h.instances)
 	h.instancesMu.RUnlock()
+
+	h.syncProjectPathsFromPaneCache(instances)
 
 	// PERFORMANCE: Gradually configure unconfigured sessions in background
 	// Configure one session per tick to avoid blocking the status update
@@ -2871,6 +2929,10 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Use forceSave to bypass mtime check - new session creation MUST persist
 			h.forceSaveInstances()
 
+			if msg.warning != "" {
+				h.setError(fmt.Errorf("created '%s' (%s)", msg.instance.Title, msg.warning))
+			}
+
 			// Start fetching preview for the new session
 			return h, h.fetchPreview(msg.instance, msg.instance.ID, -1)
 		}
@@ -2938,6 +3000,10 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Use forceSave to bypass mtime check - forked session MUST persist
 			h.forceSaveInstances()
 
+			if msg.warning != "" {
+				h.setError(fmt.Errorf("forked '%s' (%s)", msg.instance.Title, msg.warning))
+			}
+
 			// Start fetching preview for the forked session
 			return h, h.fetchPreview(msg.instance, msg.instance.ID, -1)
 		}
@@ -2972,7 +3038,7 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.instancesMu.Unlock()
 
 		// Push to undo stack before removing from group tree
-		if deletedInstance != nil {
+		if deletedInstance != nil && !msg.skipUndo {
 			h.pushUndoStack(deletedInstance)
 			// Save to recent sessions for quick re-creation
 			if err := h.storage.SaveRecentSession(deletedInstance); err != nil {
@@ -3010,10 +3076,14 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Show undo hint (using setError as a transient message)
 		if deletedInstance != nil {
-			if undoKey := h.actionKey(hotkeyUndoDelete); undoKey != "" {
-				h.setError(fmt.Errorf("deleted '%s'. %s to undo", deletedInstance.Title, undoKey))
+			if msg.skipUndo {
+				h.setError(fmt.Errorf("removed temporary session '%s'", deletedInstance.Title))
 			} else {
-				h.setError(fmt.Errorf("deleted '%s'", deletedInstance.Title))
+				if undoKey := h.actionKey(hotkeyUndoDelete); undoKey != "" {
+					h.setError(fmt.Errorf("deleted '%s'. %s to undo", deletedInstance.Title, undoKey))
+				} else {
+					h.setError(fmt.Errorf("deleted '%s'", deletedInstance.Title))
+				}
 			}
 		}
 		return h, nil
@@ -3706,6 +3776,7 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Cache expires after 2 seconds to show live terminal updates without excessive fetching
 		const previewCacheTTL = 2 * time.Second
 		var previewCmd tea.Cmd
+		var autoDeleteCmd tea.Cmd
 		selectedInst, selectedKey, selectedWinIdx := h.selectedPreviewTarget()
 		if selectedInst != nil {
 			h.previewCacheMu.Lock()
@@ -3718,7 +3789,14 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			h.previewCacheMu.Unlock()
 		}
-		return h, tea.Batch(h.tick(), previewCmd, remoteFetchCmd)
+
+		if autoDeleteID := h.nextAutoDeleteSessionID(); autoDeleteID != "" {
+			autoDeleteCmd = func() tea.Msg {
+				return sessionDeletedMsg{deletedID: autoDeleteID, skipUndo: true}
+			}
+		}
+
+		return h, tea.Batch(h.tick(), previewCmd, remoteFetchCmd, autoDeleteCmd)
 
 	case globalSearchDebounceMsg, globalSearchResultsMsg:
 		// Route async global search messages to the global search component
@@ -4110,6 +4188,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			geminiYoloMode,
 			sandboxMode,
 			toolOptionsJSON,
+			false,
 		)
 
 	case "esc":
@@ -4869,11 +4948,11 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case "D":
-		// Close session process without deleting metadata from the list/storage.
+		// Close session process (or remove metadata too for temporary sessions).
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil {
-				h.confirmDialog.ShowCloseSession(item.Session.ID, item.Session.Title, item.Session.IsSandboxed())
+				h.confirmDialog.ShowCloseSession(item.Session.ID, item.Session.Title, item.Session.IsSandboxed(), item.Session.AutoDeleteOnClose)
 			}
 		}
 		return h, nil
@@ -5141,6 +5220,7 @@ func (h *Home) handleConfirmDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				false,
 				false,
 				pendingToolOpts,
+				false,
 			)
 		case "n", "N", "esc":
 			h.confirmDialog.Hide()
@@ -5824,10 +5904,21 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 	geminiYoloMode bool,
 	sandboxEnabled bool,
 	toolOptionsJSON json.RawMessage,
+	autoDeleteOnClose bool,
 ) tea.Cmd {
 	return func() tea.Msg {
 		// Check tmux availability before creating session
 		if err := tmux.IsTmuxAvailable(); err != nil {
+			return sessionCreatedMsg{err: fmt.Errorf("cannot create session: %w", err)}
+		}
+
+		h.instancesMu.RLock()
+		existing := make([]*session.Instance, len(h.instances))
+		copy(existing, h.instances)
+		h.instancesMu.RUnlock()
+
+		limitWarning, err := session.EnforceActiveSessionLimit(existing, "")
+		if err != nil {
 			return sessionCreatedMsg{err: fmt.Errorf("cannot create session: %w", err)}
 		}
 
@@ -5890,6 +5981,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 		if sandboxEnabled {
 			inst.Sandbox = session.NewSandboxConfig("")
 		}
+		inst.AutoDeleteOnClose = autoDeleteOnClose
 
 		uiLog.Info("session_create_starting",
 			slog.String("tool", inst.Tool),
@@ -5901,7 +5993,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			return sessionCreatedMsg{err: err}
 		}
 		uiLog.Info("session_create_succeeded", slog.String("id", inst.ID))
-		return sessionCreatedMsg{instance: inst}
+		return sessionCreatedMsg{instance: inst, warning: limitWarning}
 	}
 }
 
@@ -5995,6 +6087,9 @@ func (h *Home) quickCreateSession() tea.Cmd {
 
 	// Fallback for path
 	if projectPath == "" {
+		projectPath = h.resolveQuickDefaultPath()
+	}
+	if projectPath == "" {
 		var err error
 		projectPath, err = os.Getwd()
 		if err != nil {
@@ -6023,7 +6118,7 @@ func (h *Home) quickCreateSession() tea.Cmd {
 	return h.createSessionInGroupWithWorktreeAndOptions(
 		name, projectPath, command, groupPath,
 		"", "", "", // no worktree
-		geminiYoloMode, false, toolOptionsJSON,
+		geminiYoloMode, false, toolOptionsJSON, true,
 	)
 }
 
@@ -6086,6 +6181,16 @@ func (h *Home) forkSessionCmdWithOptions(
 			return sessionForkedMsg{err: fmt.Errorf("cannot fork session: %w", err), sourceID: sourceID}
 		}
 
+		h.instancesMu.RLock()
+		existing := make([]*session.Instance, len(h.instances))
+		copy(existing, h.instances)
+		h.instancesMu.RUnlock()
+
+		limitWarning, limitErr := session.EnforceActiveSessionLimit(existing, "")
+		if limitErr != nil {
+			return sessionForkedMsg{err: fmt.Errorf("cannot fork session: %w", limitErr), sourceID: sourceID}
+		}
+
 		if opts != nil && opts.WorktreePath != "" && opts.WorktreeRepoRoot != "" && opts.WorktreeBranch != "" {
 			// Worktree creation can be slow on large repos; keep it in async cmd path
 			// so the TUI remains responsive.
@@ -6124,7 +6229,7 @@ func (h *Home) forkSessionCmdWithOptions(
 			go inst.DetectOpenCodeSession()
 		}
 
-		return sessionForkedMsg{instance: inst, sourceID: sourceID}
+		return sessionForkedMsg{instance: inst, sourceID: sourceID, warning: limitWarning}
 	}
 }
 
@@ -6132,6 +6237,7 @@ func (h *Home) forkSessionCmdWithOptions(
 type sessionDeletedMsg struct {
 	deletedID string
 	killErr   error // Error from Kill() if any
+	skipUndo  bool
 }
 
 // sessionClosedMsg signals that a session process was closed without deleting metadata.
@@ -6149,6 +6255,10 @@ type sessionRestoredMsg struct {
 
 // deleteSession deletes a session
 func (h *Home) deleteSession(inst *session.Instance) tea.Cmd {
+	return h.deleteSessionWithOptions(inst, false)
+}
+
+func (h *Home) deleteSessionWithOptions(inst *session.Instance, skipUndo bool) tea.Cmd {
 	id := inst.ID
 	isWorktree := inst.IsWorktree()
 	worktreePath := inst.WorktreePath
@@ -6159,17 +6269,41 @@ func (h *Home) deleteSession(inst *session.Instance) tea.Cmd {
 			_ = git.RemoveWorktree(worktreeRepoRoot, worktreePath, false)
 			_ = git.PruneWorktrees(worktreeRepoRoot)
 		}
-		return sessionDeletedMsg{deletedID: id, killErr: killErr}
+		return sessionDeletedMsg{deletedID: id, killErr: killErr, skipUndo: skipUndo}
 	}
 }
 
-// closeSession stops a session process but keeps metadata in list/storage.
+// closeSession stops a session process.
+// Sessions marked AutoDeleteOnClose are removed from metadata as part of close.
 func (h *Home) closeSession(inst *session.Instance) tea.Cmd {
+	if inst.AutoDeleteOnClose {
+		return h.deleteSessionWithOptions(inst, true)
+	}
+
 	id := inst.ID
 	return func() tea.Msg {
 		killErr := inst.Kill()
 		return sessionClosedMsg{sessionID: id, killErr: killErr}
 	}
+}
+
+func (h *Home) nextAutoDeleteSessionID() string {
+	h.instancesMu.RLock()
+	defer h.instancesMu.RUnlock()
+
+	for _, inst := range h.instances {
+		if inst == nil || !inst.AutoDeleteOnClose {
+			continue
+		}
+		if h.hasActiveAnimation(inst.ID) {
+			continue
+		}
+		if !inst.Exists() {
+			return inst.ID
+		}
+	}
+
+	return ""
 }
 
 // sessionRestartedMsg signals that a session was restarted.
@@ -6208,12 +6342,24 @@ func (h *Home) restartSession(inst *session.Instance) tea.Cmd {
 			return sessionRestartedMsg{sessionID: id, err: err}
 		}
 
+		h.instancesMu.RLock()
+		existing := make([]*session.Instance, len(h.instances))
+		copy(existing, h.instances)
+		h.instancesMu.RUnlock()
+
+		limitWarning, limitErr := session.EnforceActiveSessionLimit(existing, id)
+		if limitErr != nil {
+			err := fmt.Errorf("cannot restart session: %w", limitErr)
+			mcpUILog.Debug("restart_session_result", slog.String("id", id), slog.Any("error", err))
+			return sessionRestartedMsg{sessionID: id, err: err}
+		}
+
 		err := current.Restart()
 		mcpUILog.Debug("restart_session_result", slog.String("id", id), slog.Any("error", err))
 		return sessionRestartedMsg{
 			sessionID: id,
 			err:       err,
-			warning:   current.ConsumeCodexRestartWarning(),
+			warning:   joinWarnings(limitWarning, current.ConsumeCodexRestartWarning()),
 		}
 	}
 }
@@ -6282,13 +6428,8 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 	})
 }
 
-func (h *Home) followAttachReturnCwd(msg statusUpdateMsg) {
-	if msg.attachedSessionID == "" {
-		return
-	}
-
-	workDir := strings.TrimSpace(msg.attachedWorkDir)
-	if workDir == "" {
+func (h *Home) syncProjectPathsFromPaneCache(instances []*session.Instance) {
+	if len(instances) == 0 {
 		return
 	}
 
@@ -6297,26 +6438,49 @@ func (h *Home) followAttachReturnCwd(msg statusUpdateMsg) {
 		return
 	}
 
-	workDir = filepath.Clean(workDir)
-	if !filepath.IsAbs(workDir) {
-		return
+	updatedAny := false
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		tmuxSess := inst.GetTmuxSession()
+		if tmuxSess == nil {
+			continue
+		}
+		paneInfo, ok := tmux.GetCachedPaneInfo(tmuxSess.Name)
+		if !ok {
+			continue
+		}
+		if h.applyObservedCwd(inst.ID, paneInfo.CurrentPath, "poll") {
+			updatedAny = true
+		}
 	}
 
-	info, err := os.Stat(workDir)
-	if err != nil || !info.IsDir() {
-		return
+	if updatedAny {
+		h.saveInstances()
+	}
+}
+
+func (h *Home) applyObservedCwd(sessionID, observedWorkDir, source string) bool {
+	if sessionID == "" {
+		return false
+	}
+
+	workDir := normalizeFollowedProjectPath(observedWorkDir)
+	if workDir == "" {
+		return false
 	}
 
 	h.instancesMu.RLock()
-	inst := h.instanceByID[msg.attachedSessionID]
+	inst := h.instanceByID[sessionID]
 	h.instancesMu.RUnlock()
 	if inst == nil {
-		return
+		return false
 	}
 
 	oldPath := strings.TrimSpace(inst.ProjectPath)
 	if oldPath == workDir {
-		return
+		return false
 	}
 
 	inst.ProjectPath = workDir
@@ -6324,14 +6488,27 @@ func (h *Home) followAttachReturnCwd(msg statusUpdateMsg) {
 		tmuxSess.WorkDir = workDir
 	}
 	h.invalidatePreviewCache(inst.ID)
-	h.saveInstances()
 
 	uiLog.Info(
-		"attach_follow_cwd_updated",
+		"follow_cwd_updated",
+		slog.String("source", source),
 		slog.String("session_id", inst.ID),
 		slog.String("old_path", oldPath),
 		slog.String("new_path", workDir),
 	)
+
+	return true
+}
+
+func (h *Home) followAttachReturnCwd(msg statusUpdateMsg) {
+	instanceSettings := session.GetInstanceSettings()
+	if !instanceSettings.GetFollowCwdOnAttach() {
+		return
+	}
+
+	if h.applyObservedCwd(msg.attachedSessionID, msg.attachedWorkDir, "attach_return") {
+		h.saveInstances()
+	}
 }
 
 // attachCmd implements tea.ExecCommand for custom PTY attach
@@ -7925,7 +8102,7 @@ func (h *Home) renderHelpBarFull() string {
 	if len(h.flatItems) == 0 {
 		contextTitle = "Empty"
 		if newQuickKey != "" {
-			primaryHints = append(primaryHints, h.helpKey(newQuickKey, "New/Quick"))
+			primaryHints = append(primaryHints, h.helpKey(newQuickKey, "New/Temp"))
 		}
 		if key := h.actionKey(hotkeyImport); key != "" {
 			primaryHints = append(primaryHints, h.helpKey(key, "Import"))
@@ -7939,7 +8116,7 @@ func (h *Home) renderHelpBarFull() string {
 			contextTitle = "Group"
 			primaryHints = append(primaryHints, h.helpKey("Tab", "Toggle"))
 			if newQuickKey != "" {
-				primaryHints = append(primaryHints, h.helpKey(newQuickKey, "New/Quick"))
+				primaryHints = append(primaryHints, h.helpKey(newQuickKey, "New/Temp"))
 			}
 			if groupKey != "" {
 				primaryHints = append(primaryHints, h.helpKey(groupKey, "Group"))
@@ -7954,7 +8131,7 @@ func (h *Home) renderHelpBarFull() string {
 			contextTitle = "Session"
 			primaryHints = append(primaryHints, h.helpKey("Enter", "Attach"))
 			if newQuickKey != "" {
-				primaryHints = append(primaryHints, h.helpKey(newQuickKey, "New/Quick"))
+				primaryHints = append(primaryHints, h.helpKey(newQuickKey, "New/Temp"))
 			}
 			if groupKey != "" {
 				primaryHints = append(primaryHints, h.helpKey(groupKey, "Group"))

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -1043,6 +1043,85 @@ func TestDeleteHotkeyRemapAndCloseUnbind(t *testing.T) {
 	}
 }
 
+func TestCloseSessionAutoDeleteReturnsDeleteMsg(t *testing.T) {
+	home := NewHome()
+	inst := session.NewInstance("auto-delete", t.TempDir())
+	inst.AutoDeleteOnClose = true
+
+	cmd := home.closeSession(inst)
+	if cmd == nil {
+		t.Fatal("closeSession should return a command")
+	}
+
+	msg := cmd()
+	deleted, ok := msg.(sessionDeletedMsg)
+	if !ok {
+		t.Fatalf("closeSession message type = %T, want sessionDeletedMsg", msg)
+	}
+	if deleted.deletedID != inst.ID {
+		t.Fatalf("deletedID = %q, want %q", deleted.deletedID, inst.ID)
+	}
+	if !deleted.skipUndo {
+		t.Fatal("auto-delete close should skip undo stack")
+	}
+}
+
+func TestNextAutoDeleteSessionID(t *testing.T) {
+	home := NewHome()
+
+	normal := session.NewInstance("normal", t.TempDir())
+	auto := session.NewInstance("temp", t.TempDir())
+	auto.AutoDeleteOnClose = true
+
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{normal, auto}
+	home.instanceByID[normal.ID] = normal
+	home.instanceByID[auto.ID] = auto
+	home.instancesMu.Unlock()
+
+	home.launchingSessions[auto.ID] = time.Now()
+	if got := home.nextAutoDeleteSessionID(); got != "" {
+		t.Fatalf("nextAutoDeleteSessionID() with active animation = %q, want empty", got)
+	}
+	delete(home.launchingSessions, auto.ID)
+
+	if got := home.nextAutoDeleteSessionID(); got != auto.ID {
+		t.Fatalf("nextAutoDeleteSessionID() = %q, want %q", got, auto.ID)
+	}
+}
+
+func TestSessionDeletedMsgSkipUndoSkipsUndoStack(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	inst := session.NewInstance("temporary-session", t.TempDir())
+	inst.AutoDeleteOnClose = true
+
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID[inst.ID] = inst
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+
+	model, _ := home.Update(sessionDeletedMsg{deletedID: inst.ID, skipUndo: true})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatal("Update should return *Home")
+	}
+
+	if len(h.undoStack) != 0 {
+		t.Fatalf("undoStack length = %d, want 0", len(h.undoStack))
+	}
+	if h.err == nil || !strings.Contains(h.err.Error(), "removed temporary session") {
+		t.Fatalf("expected temporary session removal message, got %v", h.err)
+	}
+	if got := h.getInstanceByID(inst.ID); got != nil {
+		t.Fatal("deleted temporary session should be removed from instance map")
+	}
+}
+
 func TestRenderHelpBarTiny(t *testing.T) {
 	home := NewHome()
 	home.width = 45 // Tiny mode (<50 cols)

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -32,10 +32,14 @@ const (
 	SettingShowOutput
 	SettingShowAnalytics
 	SettingMaintenanceEnabled
+	SettingFollowCwdOnAttach
+	SettingQuickDefaultPath
+	SettingMaxActiveSessions
+	SettingMaxActiveSessionsPolicy
 )
 
 // Total number of navigable settings.
-const settingsCount = 17
+const settingsCount = 21
 
 // SettingsPanel displays and edits user configuration
 type SettingsPanel struct {
@@ -65,6 +69,10 @@ type SettingsPanel struct {
 	showOutput          bool
 	showAnalytics       bool
 	maintenanceEnabled  bool
+	followCwdOnAttach   bool
+	quickDefaultPath    string
+	maxActiveSessions   int
+	maxActivePolicy     int // 0=warn, 1=deny, 2=close_oldest
 
 	// Text input state
 	editingText bool
@@ -93,6 +101,16 @@ var (
 var (
 	themeNames  = []string{"Dark", "Light", "System"}
 	themeValues = []string{"dark", "light", "system"}
+)
+
+// Active session limit policy names for radio selection.
+var (
+	limitPolicyNames  = []string{"Warn", "Deny", "CloseOldest"}
+	limitPolicyValues = []string{
+		session.MaxActiveSessionsPolicyWarn,
+		session.MaxActiveSessionsPolicyDeny,
+		session.MaxActiveSessionsPolicyCloseOldest,
+	}
 )
 
 // NewSettingsPanel creates a new settings panel
@@ -225,6 +243,19 @@ func (s *SettingsPanel) LoadConfig(config *session.UserConfig) {
 
 	// Maintenance settings.
 	s.maintenanceEnabled = config.Maintenance.Enabled
+
+	// Instance settings.
+	s.followCwdOnAttach = config.Instances.GetFollowCwdOnAttach()
+	s.quickDefaultPath = strings.TrimSpace(config.Instances.QuickDefaultPath)
+	s.maxActiveSessions = config.Instances.GetMaxActiveSessions()
+	s.maxActivePolicy = 0
+	policy := config.Instances.GetMaxActiveSessionsPolicy()
+	for i, val := range limitPolicyValues {
+		if val == policy {
+			s.maxActivePolicy = i
+			break
+		}
+	}
 }
 
 // GetConfig returns a UserConfig with current panel values
@@ -290,10 +321,26 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 		config.MCPPool = s.originalConfig.MCPPool
 		config.Docker = s.originalConfig.Docker
 		config.Profiles = s.originalConfig.Profiles
+		config.Instances = s.originalConfig.Instances
 		// Keep global Claude config when editing profile-specific override.
 		if s.claudeConfigIsScope {
 			config.Claude.ConfigDir = s.originalConfig.Claude.ConfigDir
 		}
+	}
+
+	// Instance settings.
+	followCwdOnAttach := s.followCwdOnAttach
+	config.Instances.FollowCwdOnAttach = &followCwdOnAttach
+	config.Instances.QuickDefaultPath = strings.TrimSpace(s.quickDefaultPath)
+	if s.maxActiveSessions < 0 {
+		config.Instances.MaxActiveSessions = 0
+	} else {
+		config.Instances.MaxActiveSessions = s.maxActiveSessions
+	}
+	if s.maxActivePolicy >= 0 && s.maxActivePolicy < len(limitPolicyValues) {
+		config.Instances.MaxActiveSessionsPolicy = limitPolicyValues[s.maxActivePolicy]
+	} else {
+		config.Instances.MaxActiveSessionsPolicy = session.MaxActiveSessionsPolicyWarn
 	}
 
 	// Apply profile-specific Claude override after original profile map is restored.
@@ -409,6 +456,20 @@ func (s *SettingsPanel) adjustValue(delta int) bool {
 			changed = true
 			s.needsRestart = true
 		}
+
+	case SettingMaxActiveSessions:
+		newVal := s.maxActiveSessions + delta
+		if newVal >= 0 {
+			s.maxActiveSessions = newVal
+			changed = true
+		}
+
+	case SettingMaxActiveSessionsPolicy:
+		newVal := s.maxActivePolicy + delta
+		if newVal >= 0 && newVal < len(limitPolicyNames) {
+			s.maxActivePolicy = newVal
+			changed = true
+		}
 	}
 
 	return changed
@@ -459,6 +520,10 @@ func (s *SettingsPanel) toggleValue() bool {
 	case SettingMaintenanceEnabled:
 		s.maintenanceEnabled = !s.maintenanceEnabled
 		return true
+
+	case SettingFollowCwdOnAttach:
+		s.followCwdOnAttach = !s.followCwdOnAttach
+		return true
 	}
 
 	return false
@@ -466,7 +531,8 @@ func (s *SettingsPanel) toggleValue() bool {
 
 // isTextSetting returns true if current setting uses text input
 func (s *SettingsPanel) isTextSetting() bool {
-	return SettingType(s.cursor) == SettingClaudeConfigDir
+	setting := SettingType(s.cursor)
+	return setting == SettingClaudeConfigDir || setting == SettingQuickDefaultPath
 }
 
 // startTextEdit begins text editing for current setting
@@ -474,6 +540,11 @@ func (s *SettingsPanel) startTextEdit() {
 	setting := SettingType(s.cursor)
 	if setting == SettingClaudeConfigDir {
 		s.textBuffer = s.claudeConfigDir
+		s.editingText = true
+		return
+	}
+	if setting == SettingQuickDefaultPath {
+		s.textBuffer = s.quickDefaultPath
 		s.editingText = true
 	}
 }
@@ -487,6 +558,9 @@ func (s *SettingsPanel) handleTextEdit(msg tea.KeyMsg) (*SettingsPanel, tea.Cmd,
 		// Save the text
 		if SettingType(s.cursor) == SettingClaudeConfigDir {
 			s.claudeConfigDir = s.textBuffer
+		}
+		if SettingType(s.cursor) == SettingQuickDefaultPath {
+			s.quickDefaultPath = s.textBuffer
 		}
 		s.editingText = false
 		return s, nil, true
@@ -722,12 +796,56 @@ func (s *SettingsPanel) View() string {
 	}
 	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
 
+	hotkeys := resolveHotkeys(session.GetHotkeyOverrides())
+
+	// INSTANCE BEHAVIOR
+	content.WriteString(sectionStyle.Render("INSTANCE BEHAVIOR"))
+	content.WriteString("\n")
+
+	line = s.renderCheckbox("Follow pane CWD on attach", s.followCwdOnAttach) + " - Sync session project path from tmux"
+	if s.cursor == int(SettingFollowCwdOnAttach) {
+		line = highlightStyle.Render(line)
+	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n")
+
+	line = "Quick default path: "
+	if s.editingText && s.cursor == int(SettingQuickDefaultPath) {
+		line += "[" + s.textBuffer + "|]"
+	} else if strings.TrimSpace(s.quickDefaultPath) == "" {
+		line += dimStyle.Render("(empty = current directory)")
+	} else {
+		line += s.quickDefaultPath
+	}
+	if s.cursor == int(SettingQuickDefaultPath) {
+		line = highlightStyle.Render(line)
+	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n")
+
+	line = s.renderNumber("Max active sessions:", s.maxActiveSessions, "(0 = unlimited)")
+	if s.cursor == int(SettingMaxActiveSessions) {
+		line = highlightStyle.Render(line)
+	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n")
+
+	line = "Limit policy: " + s.renderRadioGroup(limitPolicyNames, s.maxActivePolicy, s.cursor == int(SettingMaxActiveSessionsPolicy))
+	if s.cursor == int(SettingMaxActiveSessionsPolicy) {
+		line = highlightStyle.Render(line)
+	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n")
+
+	quickKey := actionHotkey(hotkeys, hotkeyQuickCreate)
+	quickHint := "  Quicktemp hotkey is unbound."
+	if quickKey != "" {
+		quickHint = fmt.Sprintf("  Press %s for quicktemp sessions (auto-delete on close).", quickKey)
+	}
+	content.WriteString(dimStyle.Render(quickHint))
+	content.WriteString("\n\n")
+
 	// MCP & TOOLS
 	content.WriteString(sectionStyle.Render("MCP SERVERS & CUSTOM TOOLS"))
 	content.WriteString("\n")
 	content.WriteString(dimStyle.Render("  Edit ~/.agent-deck/config.toml to configure MCPs and tools."))
 	content.WriteString("\n")
-	hotkeys := resolveHotkeys(session.GetHotkeyOverrides())
 	mcpKey := actionHotkey(hotkeys, hotkeyMCPManager)
 	mcpHint := "  MCP Manager hotkey is unbound."
 	if mcpKey != "" {
@@ -772,6 +890,10 @@ func (s *SettingsPanel) View() string {
 			34, // SettingShowOutput
 			35, // SettingShowAnalytics
 			38, // SettingMaintenanceEnabled
+			41, // SettingFollowCwdOnAttach
+			42, // SettingQuickDefaultPath
+			43, // SettingMaxActiveSessions
+			44, // SettingMaxActiveSessionsPolicy
 		}
 		cursorLine := cursorToLine[s.cursor]
 

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -151,6 +151,34 @@ func TestSettingsPanel_LoadConfig_ProfileClaudeOverride(t *testing.T) {
 	}
 }
 
+func TestSettingsPanel_LoadConfig_InstanceSettings(t *testing.T) {
+	follow := true
+	config := &session.UserConfig{
+		Instances: session.InstanceSettings{
+			FollowCwdOnAttach:       &follow,
+			QuickDefaultPath:        "~/workspace",
+			MaxActiveSessions:       7,
+			MaxActiveSessionsPolicy: session.MaxActiveSessionsPolicyCloseOldest,
+		},
+	}
+
+	panel := NewSettingsPanel()
+	panel.LoadConfig(config)
+
+	if !panel.followCwdOnAttach {
+		t.Fatal("followCwdOnAttach should be true after LoadConfig")
+	}
+	if panel.quickDefaultPath != "~/workspace" {
+		t.Fatalf("quickDefaultPath = %q, want %q", panel.quickDefaultPath, "~/workspace")
+	}
+	if panel.maxActiveSessions != 7 {
+		t.Fatalf("maxActiveSessions = %d, want 7", panel.maxActiveSessions)
+	}
+	if panel.maxActivePolicy != 2 {
+		t.Fatalf("maxActivePolicy = %d, want 2 (close_oldest)", panel.maxActivePolicy)
+	}
+}
+
 func TestSettingsPanel_LoadConfig_DefaultTool(t *testing.T) {
 	panel := NewSettingsPanel()
 
@@ -261,6 +289,33 @@ func TestSettingsPanel_GetConfig(t *testing.T) {
 	}
 	if config.GlobalSearch.RecentDays != 45 {
 		t.Errorf("RecentDays: got %d, want 45", config.GlobalSearch.RecentDays)
+	}
+}
+
+func TestSettingsPanel_GetConfig_InstanceSettings(t *testing.T) {
+	panel := NewSettingsPanel()
+	panel.followCwdOnAttach = true
+	panel.quickDefaultPath = "~/src"
+	panel.maxActiveSessions = 3
+	panel.maxActivePolicy = 1 // deny
+
+	config := panel.GetConfig()
+
+	if config.Instances.FollowCwdOnAttach == nil || !*config.Instances.FollowCwdOnAttach {
+		t.Fatal("FollowCwdOnAttach should be true in config")
+	}
+	if config.Instances.QuickDefaultPath != "~/src" {
+		t.Fatalf("QuickDefaultPath = %q, want %q", config.Instances.QuickDefaultPath, "~/src")
+	}
+	if config.Instances.MaxActiveSessions != 3 {
+		t.Fatalf("MaxActiveSessions = %d, want 3", config.Instances.MaxActiveSessions)
+	}
+	if config.Instances.MaxActiveSessionsPolicy != session.MaxActiveSessionsPolicyDeny {
+		t.Fatalf(
+			"MaxActiveSessionsPolicy = %q, want %q",
+			config.Instances.MaxActiveSessionsPolicy,
+			session.MaxActiveSessionsPolicyDeny,
+		)
 	}
 }
 
@@ -442,6 +497,73 @@ func TestSettingsPanel_Update_ToggleCheckbox(t *testing.T) {
 	}
 }
 
+func TestSettingsPanel_Update_InstanceSettingsControls(t *testing.T) {
+	panel := NewSettingsPanel()
+	panel.Show()
+
+	// Toggle follow CWD checkbox.
+	panel.cursor = int(SettingFollowCwdOnAttach)
+	initialFollow := panel.followCwdOnAttach
+	_, _, changed := panel.Update(tea.KeyMsg{Type: tea.KeySpace})
+	if !changed {
+		t.Fatal("follow CWD toggle should report changed=true")
+	}
+	if panel.followCwdOnAttach == initialFollow {
+		t.Fatal("follow CWD setting should toggle")
+	}
+
+	// Adjust max active sessions with arrow keys.
+	panel.cursor = int(SettingMaxActiveSessions)
+	panel.maxActiveSessions = 0
+	panel.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if panel.maxActiveSessions != 1 {
+		t.Fatalf("maxActiveSessions after right = %d, want 1", panel.maxActiveSessions)
+	}
+	panel.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if panel.maxActiveSessions != 0 {
+		t.Fatalf("maxActiveSessions after left = %d, want 0", panel.maxActiveSessions)
+	}
+
+	// Policy radio selection cycles with h/l.
+	panel.cursor = int(SettingMaxActiveSessionsPolicy)
+	panel.maxActivePolicy = 0
+	panel.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if panel.maxActivePolicy != 1 {
+		t.Fatalf("maxActivePolicy after right = %d, want 1", panel.maxActivePolicy)
+	}
+	panel.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if panel.maxActivePolicy != 2 {
+		t.Fatalf("maxActivePolicy after second right = %d, want 2", panel.maxActivePolicy)
+	}
+}
+
+func TestSettingsPanel_Update_QuickDefaultPathTextEdit(t *testing.T) {
+	panel := NewSettingsPanel()
+	panel.Show()
+	panel.cursor = int(SettingQuickDefaultPath)
+
+	// Start editing.
+	panel.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !panel.editingText {
+		t.Fatal("quick default path should enter text editing mode on Enter")
+	}
+
+	// Type a simple path and save.
+	panel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'~'}})
+	panel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	panel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	panel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	panel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	panel.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if panel.editingText {
+		t.Fatal("quick default path edit mode should exit on Enter")
+	}
+	if panel.quickDefaultPath == "" {
+		t.Fatal("quickDefaultPath should persist edited value")
+	}
+}
+
 func TestSettingsPanel_Update_RadioSelection(t *testing.T) {
 	panel := NewSettingsPanel()
 	panel.Show()
@@ -591,6 +713,9 @@ func TestSettingsPanel_View_Visible(t *testing.T) {
 		"UPDATES",
 		"LOGS",
 		"GLOBAL SEARCH",
+		"INSTANCE BEHAVIOR",
+		"Follow pane CWD on attach",
+		"Max active sessions",
 	}
 
 	for _, elem := range expectedElements {
@@ -865,5 +990,31 @@ func TestSettingsPanel_ViewShowsUnboundMCPHotkeyHint(t *testing.T) {
 	view := panel.View()
 	if !containsString(view, "MCP Manager hotkey is unbound.") {
 		t.Fatalf("settings view should show unbound MCP key hint, got %q", view)
+	}
+}
+
+func TestSettingsPanel_ViewUsesConfiguredQuicktempHotkeyHint(t *testing.T) {
+	setSettingsPanelHotkeyConfigForTest(t, "[hotkeys]\nquick_create = \"ctrl+n\"\n")
+
+	panel := NewSettingsPanel()
+	panel.SetSize(100, 80)
+	panel.Show()
+
+	view := panel.View()
+	if !containsString(view, "Press ctrl+n for quicktemp sessions") || !containsString(view, "auto-delete on") {
+		t.Fatalf("settings view should show configured quicktemp key hint, got %q", view)
+	}
+}
+
+func TestSettingsPanel_ViewShowsUnboundQuicktempHotkeyHint(t *testing.T) {
+	setSettingsPanelHotkeyConfigForTest(t, "[hotkeys]\nquick_create = \"\"\n")
+
+	panel := NewSettingsPanel()
+	panel.SetSize(100, 80)
+	panel.Show()
+
+	view := panel.View()
+	if !containsString(view, "Quicktemp hotkey is unbound.") {
+		t.Fatalf("settings view should show unbound quicktemp key hint, got %q", view)
 	}
 }


### PR DESCRIPTION
- **What changed**
  - Added `instances` config support for:
    - `follow_cwd_on_attach`
    - `quick_default_path`
    - `max_active_sessions`
    - `max_active_sessions_policy` (`warn|deny|close_oldest`)
  - Added `session.EnforceActiveSessionLimit(...)` and applied it in both TUI and CLI flows:
    - TUI create/fork/restart
    - CLI `launch`, `session start`, `session restart`, `session fork`, `try`
  - Added quick default path fallback in quick/no-path creation paths (TUI + CLI).
  - Completed quicktemp lifecycle:
    - `AutoDeleteOnClose` persisted in storage/migration data model
    - close/delete semantics updated so temporary sessions clean metadata automatically
    - periodic cleanup path handles already-dead temp sessions.
  - Added discoverability and UX updates:
    - richer close confirmation messaging for temporary sessions
    - help text updated for quicktemp behavior
    - settings panel now includes editable **INSTANCE BEHAVIOR** controls.

- **Why**
  - Makes session behavior predictable and configurable across both UI and CLI.
  - Prevents unbounded active-session growth with explicit policy handling.
  - Aligns quicktemp behavior with user expectation (temporary means auto-cleanup).
  - Reduces config friction by surfacing instance controls directly in Settings.

- **Behavior notes**
  - `follow_cwd_on_attach` now updates project path from tmux pane path after attach return and during polling.
  - `max_active_sessions`:
    - `warn`: proceed + warning
    - `deny`: block operation
    - `close_oldest`: kill oldest active session then continue.
  - `quick_default_path` is used when no group/session context path is available.
  - Temporary sessions (`AutoDeleteOnClose`) skip undo/recent-session restoration paths when auto-removed.

- **Tests**
  - Added/updated tests for:
    - instance settings parse/getters
    - active-session limit policies (warn/deny/close_oldest/exclude)
    - CLI warning composition + quick default path resolution
    - quicktemp close/delete behavior and skip-undo semantics
    - confirm dialog and settings panel coverage for new instance behavior controls.
  - Validation run:
    - `go test ./...` ✅

- **Config delta**

```yaml
config_delta:
  affordances:
    - add: "Editable instance behavior controls in Settings panel"
    - add: "Active-session policy enforcement in TUI and CLI flows"
    - add: "Quick default path fallback for no-context session creation"
    - modify: "Temporary session close semantics to auto-delete metadata"
  invariants:
    - add: "When active-session limit is configured, start/create/fork/restart obey configured policy"
    - strengthen: "Quicktemp sessions removed via auto-delete do not populate undo/recent lists"
    - strengthen: "Project path follow uses normalized absolute directory paths only"
  constraints:
    - add: "max_active_sessions <= 0 means unlimited"
    - add: "policy defaults to warn for empty/invalid values"
  rationale:
    - "Unify behavior across TUI and CLI to avoid policy bypass paths"
    - "Expose controls in UI so users do not need manual TOML edits"
  enforcement:
    - conformance: "internal/session/instance_test.go (policy tests)"
    - conformance: "internal/ui/home_test.go and internal/ui/settings_panel_test.go"
    - conformance: "cmd/agent-deck/cli_utils_test.go"
```