### PR TITLE
Fix #315: extend yolo mode toggle to Codex sessions

### DIFF
--- a/cmd/agent-deck/add_test.go
+++ b/cmd/agent-deck/add_test.go
@@ -7,34 +7,42 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-func TestApplyGeminiCLIYoloOverride(t *testing.T) {
+func TestApplyCLIYoloOverride(t *testing.T) {
 	t.Run("enabled for gemini sets override", func(t *testing.T) {
 		inst := session.NewInstanceWithTool("gemini-test", "/tmp/test", "gemini")
-		if err := applyGeminiCLIYoloOverride(inst, true); err != nil {
-			t.Fatalf("applyGeminiCLIYoloOverride() error = %v", err)
+		if err := applyCLIYoloOverride(inst, true); err != nil {
+			t.Fatalf("applyCLIYoloOverride() error = %v", err)
 		}
 		if inst.GeminiYoloMode == nil || !*inst.GeminiYoloMode {
 			t.Fatalf("GeminiYoloMode = %v, want true override", inst.GeminiYoloMode)
 		}
 	})
 
+	t.Run("enabled for codex sets override", func(t *testing.T) {
+		inst := session.NewInstanceWithTool("codex-test", "/tmp/test", "codex")
+		if err := applyCLIYoloOverride(inst, true); err != nil {
+			t.Fatalf("applyCLIYoloOverride() error = %v", err)
+		}
+		opts := inst.GetCodexOptions()
+		if opts == nil || opts.YoloMode == nil || !*opts.YoloMode {
+			t.Fatalf("CodexOptions.YoloMode = %v, want true override", opts)
+		}
+	})
+
 	t.Run("disabled is a no-op", func(t *testing.T) {
 		inst := session.NewInstanceWithTool("gemini-test", "/tmp/test", "gemini")
-		if err := applyGeminiCLIYoloOverride(inst, false); err != nil {
-			t.Fatalf("applyGeminiCLIYoloOverride() error = %v", err)
+		if err := applyCLIYoloOverride(inst, false); err != nil {
+			t.Fatalf("applyCLIYoloOverride() error = %v", err)
 		}
 		if inst.GeminiYoloMode != nil {
 			t.Fatalf("GeminiYoloMode = %v, want nil when flag is not set", inst.GeminiYoloMode)
 		}
 	})
 
-	t.Run("non-gemini returns error", func(t *testing.T) {
+	t.Run("non-gemini-codex returns error", func(t *testing.T) {
 		inst := session.NewInstanceWithTool("claude-test", "/tmp/test", "claude")
-		if err := applyGeminiCLIYoloOverride(inst, true); err == nil {
-			t.Fatal("applyGeminiCLIYoloOverride() error = nil, want non-nil")
-		}
-		if inst.GeminiYoloMode != nil {
-			t.Fatalf("GeminiYoloMode = %v, want nil for non-gemini sessions", inst.GeminiYoloMode)
+		if err := applyCLIYoloOverride(inst, true); err == nil {
+			t.Fatal("applyCLIYoloOverride() error = nil, want non-nil")
 		}
 	})
 }

--- a/cmd/agent-deck/gemini_yolo.go
+++ b/cmd/agent-deck/gemini_yolo.go
@@ -6,13 +6,25 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-func applyGeminiCLIYoloOverride(inst *session.Instance, enabled bool) error {
+func applyCLIYoloOverride(inst *session.Instance, enabled bool) error {
 	if !enabled || inst == nil {
 		return nil
 	}
-	if inst.Tool != "gemini" {
-		return fmt.Errorf("--yolo only works with Gemini sessions (-c gemini)")
+	switch inst.Tool {
+	case "gemini":
+		inst.SetGeminiYoloMode(true)
+	case "codex":
+		yolo := true
+		opts := inst.GetCodexOptions()
+		if opts == nil {
+			opts = &session.CodexOptions{}
+		}
+		opts.YoloMode = &yolo
+		if err := inst.SetCodexOptions(opts); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("--yolo only works with Gemini or Codex sessions")
 	}
-	inst.SetGeminiYoloMode(true)
 	return nil
 }

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -723,8 +723,8 @@ func handleAdd(profile string, args []string) {
 
 	// Resume session flag
 	resumeSession := fs.String("resume-session", "", "Claude session ID to resume (skips new session creation)")
-	yoloMode := fs.Bool("yolo", false, "Enable Gemini YOLO mode for this session")
-	geminiYoloMode := fs.Bool("gemini-yolo", false, "Enable Gemini YOLO mode for this session")
+	yoloMode := fs.Bool("yolo", false, "Enable YOLO mode for Gemini or Codex sessions")
+	geminiYoloMode := fs.Bool("gemini-yolo", false, "Enable YOLO mode (alias for --yolo)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck add [path] [options]")
@@ -1059,7 +1059,7 @@ func handleAdd(profile string, args []string) {
 		}
 	}
 
-	if err := applyGeminiCLIYoloOverride(newInstance, *yoloMode || *geminiYoloMode); err != nil {
+	if err := applyCLIYoloOverride(newInstance, *yoloMode || *geminiYoloMode); err != nil {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -121,7 +121,7 @@ func handleSessionStart(profile string, args []string) {
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
 	message := fs.String("message", "", "Initial message to send once agent is ready")
 	messageShort := fs.String("m", "", "Initial message to send once agent is ready (short)")
-	yoloMode := fs.Bool("yolo", false, "Enable Gemini YOLO mode when starting the session")
+	yoloMode := fs.Bool("yolo", false, "Enable YOLO mode when starting Gemini or Codex sessions")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session start <id|title> [options]")
@@ -172,7 +172,7 @@ func handleSessionStart(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	if err := applyGeminiCLIYoloOverride(inst, *yoloMode); err != nil {
+	if err := applyCLIYoloOverride(inst, *yoloMode); err != nil {
 		out.Error(err.Error(), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4915,31 +4915,55 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case "y":
-		// Toggle Gemini YOLO mode (requires restart)
+		// Toggle YOLO mode for Gemini or Codex sessions (requires restart)
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
-			if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.Tool == "gemini" {
+			if item.Type == session.ItemTypeSession && item.Session != nil {
 				inst := item.Session
-				// Determine current YOLO state
-				currentYolo := false
-				if inst.GeminiYoloMode != nil {
-					currentYolo = *inst.GeminiYoloMode
-				} else {
-					// Fall back to global config
-					userConfig, _ := session.LoadUserConfig()
-					if userConfig != nil {
-						currentYolo = userConfig.Gemini.YoloMode
+				toggled := false
+
+				switch inst.Tool {
+				case "gemini":
+					currentYolo := false
+					if inst.GeminiYoloMode != nil {
+						currentYolo = *inst.GeminiYoloMode
+					} else {
+						userConfig, _ := session.LoadUserConfig()
+						if userConfig != nil {
+							currentYolo = userConfig.Gemini.YoloMode
+						}
 					}
+					newYolo := !currentYolo
+					inst.GeminiYoloMode = &newYolo
+					toggled = true
+
+				case "codex":
+					currentYolo := false
+					opts := inst.GetCodexOptions()
+					if opts != nil && opts.YoloMode != nil {
+						currentYolo = *opts.YoloMode
+					} else {
+						userConfig, _ := session.LoadUserConfig()
+						if userConfig != nil {
+							currentYolo = userConfig.Codex.YoloMode
+						}
+					}
+					newYolo := !currentYolo
+					if opts == nil {
+						opts = &session.CodexOptions{}
+					}
+					opts.YoloMode = &newYolo
+					_ = inst.SetCodexOptions(opts)
+					toggled = true
 				}
-				// Toggle: set per-session override to opposite of current
-				newYolo := !currentYolo
-				inst.GeminiYoloMode = &newYolo
-				h.saveInstances()
-				// If session is running, it needs restart to apply
-				if inst.GetStatusThreadSafe() == session.StatusRunning ||
-					inst.GetStatusThreadSafe() == session.StatusWaiting {
-					h.resumingSessions[inst.ID] = time.Now()
-					return h, h.restartSession(inst)
+
+				if toggled {
+					h.saveInstances()
+					if inst.GetStatusThreadSafe() == session.StatusRunning ||
+						inst.GetStatusThreadSafe() == session.StatusWaiting {
+						h.resumingSessions[inst.ID] = time.Now()
+						return h, h.restartSession(inst)
+					}
 				}
 			}
 		}
@@ -8491,9 +8515,17 @@ func (h *Home) renderSessionItem(
 	title := titleStyle.Render(inst.Title)
 	tool := toolStyle.Render(" " + instTool)
 
-	// YOLO badge for Gemini sessions with YOLO mode enabled
+	// YOLO badge for Gemini/Codex sessions with YOLO mode enabled
 	yoloBadge := ""
+	showYolo := false
 	if instTool == "gemini" && inst.GeminiYoloMode != nil && *inst.GeminiYoloMode {
+		showYolo = true
+	} else if instTool == "codex" {
+		if opts := inst.GetCodexOptions(); opts != nil && opts.YoloMode != nil && *opts.YoloMode {
+			showYolo = true
+		}
+	}
+	if showYolo {
 		yoloStyle := lipgloss.NewStyle().Foreground(ColorYellow).Bold(true)
 		if selected {
 			yoloStyle = SessionStatusSelStyle

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -6,33 +6,33 @@ import (
 )
 
 const (
-	hotkeyQuit             = "quit"
-	hotkeyNewSession       = "new_session"
-	hotkeyQuickCreate      = "quick_create"
-	hotkeyRename           = "rename"
-	hotkeyRestart          = "restart"
-	hotkeyDelete           = "delete"
-	hotkeyCloseSession     = "close_session"
-	hotkeyUndoDelete       = "undo_delete"
-	hotkeyMoveToGroup      = "move_to_group"
-	hotkeyMCPManager       = "mcp_manager"
-	hotkeySkillsManager    = "skills_manager"
-	hotkeyTogglePreview    = "toggle_preview"
-	hotkeyMarkUnread       = "mark_unread"
-	hotkeyToggleGeminiYolo = "toggle_gemini_yolo"
-	hotkeyQuickFork        = "quick_fork"
-	hotkeyForkWithOptions  = "fork_with_options"
-	hotkeyCopyOutput       = "copy_output"
-	hotkeySendOutput       = "send_output"
-	hotkeyExecShell        = "exec_shell"
-	hotkeyEditNotes        = "edit_notes"
-	hotkeyWorktreeFinish   = "worktree_finish"
-	hotkeyCreateGroup      = "create_group"
-	hotkeySearch           = "search"
-	hotkeyHelp             = "help"
-	hotkeySettings         = "settings"
-	hotkeyImport           = "import"
-	hotkeyReload           = "reload"
+	hotkeyQuit            = "quit"
+	hotkeyNewSession      = "new_session"
+	hotkeyQuickCreate     = "quick_create"
+	hotkeyRename          = "rename"
+	hotkeyRestart         = "restart"
+	hotkeyDelete          = "delete"
+	hotkeyCloseSession    = "close_session"
+	hotkeyUndoDelete      = "undo_delete"
+	hotkeyMoveToGroup     = "move_to_group"
+	hotkeyMCPManager      = "mcp_manager"
+	hotkeySkillsManager   = "skills_manager"
+	hotkeyTogglePreview   = "toggle_preview"
+	hotkeyMarkUnread      = "mark_unread"
+	hotkeyToggleYolo      = "toggle_yolo"
+	hotkeyQuickFork       = "quick_fork"
+	hotkeyForkWithOptions = "fork_with_options"
+	hotkeyCopyOutput      = "copy_output"
+	hotkeySendOutput      = "send_output"
+	hotkeyExecShell       = "exec_shell"
+	hotkeyEditNotes       = "edit_notes"
+	hotkeyWorktreeFinish  = "worktree_finish"
+	hotkeyCreateGroup     = "create_group"
+	hotkeySearch          = "search"
+	hotkeyHelp            = "help"
+	hotkeySettings        = "settings"
+	hotkeyImport          = "import"
+	hotkeyReload          = "reload"
 )
 
 var hotkeyActionOrder = []string{
@@ -49,7 +49,7 @@ var hotkeyActionOrder = []string{
 	hotkeySkillsManager,
 	hotkeyTogglePreview,
 	hotkeyMarkUnread,
-	hotkeyToggleGeminiYolo,
+	hotkeyToggleYolo,
 	hotkeyQuickFork,
 	hotkeyForkWithOptions,
 	hotkeyCopyOutput,
@@ -66,33 +66,33 @@ var hotkeyActionOrder = []string{
 }
 
 var defaultHotkeyBindings = map[string]string{
-	hotkeyQuit:             "q",
-	hotkeyNewSession:       "n",
-	hotkeyQuickCreate:      "N",
-	hotkeyRename:           "r",
-	hotkeyRestart:          "R",
-	hotkeyDelete:           "d",
-	hotkeyCloseSession:     "D",
-	hotkeyUndoDelete:       "ctrl+z",
-	hotkeyMoveToGroup:      "M",
-	hotkeyMCPManager:       "m",
-	hotkeySkillsManager:    "s",
-	hotkeyTogglePreview:    "v",
-	hotkeyMarkUnread:       "u",
-	hotkeyToggleGeminiYolo: "y",
-	hotkeyQuickFork:        "f",
-	hotkeyForkWithOptions:  "F",
-	hotkeyCopyOutput:       "c",
-	hotkeySendOutput:       "x",
-	hotkeyExecShell:        "E",
-	hotkeyEditNotes:        "e",
-	hotkeyWorktreeFinish:   "W",
-	hotkeyCreateGroup:      "g",
-	hotkeySearch:           "/",
-	hotkeyHelp:             "?",
-	hotkeySettings:         "S",
-	hotkeyImport:           "i",
-	hotkeyReload:           "ctrl+r",
+	hotkeyQuit:            "q",
+	hotkeyNewSession:      "n",
+	hotkeyQuickCreate:     "N",
+	hotkeyRename:          "r",
+	hotkeyRestart:         "R",
+	hotkeyDelete:          "d",
+	hotkeyCloseSession:    "D",
+	hotkeyUndoDelete:      "ctrl+z",
+	hotkeyMoveToGroup:     "M",
+	hotkeyMCPManager:      "m",
+	hotkeySkillsManager:   "s",
+	hotkeyTogglePreview:   "v",
+	hotkeyMarkUnread:      "u",
+	hotkeyToggleYolo:      "y",
+	hotkeyQuickFork:       "f",
+	hotkeyForkWithOptions: "F",
+	hotkeyCopyOutput:      "c",
+	hotkeySendOutput:      "x",
+	hotkeyExecShell:       "E",
+	hotkeyEditNotes:       "e",
+	hotkeyWorktreeFinish:  "W",
+	hotkeyCreateGroup:     "g",
+	hotkeySearch:          "/",
+	hotkeyHelp:            "?",
+	hotkeySettings:        "S",
+	hotkeyImport:          "i",
+	hotkeyReload:          "ctrl+r",
 }
 
 var hotkeyActionDefaultTriggers = map[string][]string{
@@ -100,6 +100,11 @@ var hotkeyActionDefaultTriggers = map[string][]string{
 	hotkeyForkWithOptions: {"F", "shift+f"},
 	hotkeyMoveToGroup:     {"M", "shift+m"},
 	hotkeyWorktreeFinish:  {"W", "shift+w"},
+}
+
+// renamedHotkeys maps old action names to new names for backward compatibility.
+var renamedHotkeys = map[string]string{
+	"toggle_gemini_yolo": hotkeyToggleYolo,
 }
 
 func resolveHotkeys(overrides map[string]string) map[string]string {
@@ -110,6 +115,10 @@ func resolveHotkeys(overrides map[string]string) map[string]string {
 
 	for action, key := range overrides {
 		normalizedAction := strings.TrimSpace(strings.ToLower(action))
+		// Migrate renamed hotkey actions
+		if newName, ok := renamedHotkeys[normalizedAction]; ok {
+			normalizedAction = newName
+		}
 		if _, ok := defaultHotkeyBindings[normalizedAction]; !ok {
 			continue
 		}


### PR DESCRIPTION
## Summary
- The `y` hotkey now toggles YOLO mode for both **Gemini** and **Codex** sessions (previously Gemini-only)
- The `--yolo` CLI flag in `agent-deck add` and `agent-deck session start` now works with `-c codex`
- The `[YOLO]` badge in the session list shows for Codex sessions with YOLO mode enabled
- Hotkey action renamed from `toggle_gemini_yolo` to `toggle_yolo` with backward compatibility for existing configs

## Test plan
- [x] All existing tests pass (cmd, ui, session packages)
- [x] New test case for Codex YOLO override via CLI
- [x] Pre-push hooks pass (lint + test + build)

Fixes #315