### PR TITLE
fix(session): CLI commands read hook status files for accurate state

### DIFF
--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -201,6 +201,37 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 	}
 }
 
+// ReadHookStatusFile reads a hook status file from disk for a given instance ID.
+// This is the standalone equivalent of StatusFileWatcher.processFile, intended for
+// CLI commands that don't run a persistent filesystem watcher.
+func ReadHookStatusFile(instanceID string) *HookStatus {
+	if instanceID == "" {
+		return nil
+	}
+	filePath := filepath.Join(GetHooksDir(), instanceID+".json")
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+
+	var status struct {
+		Status    string `json:"status"`
+		SessionID string `json:"session_id"`
+		Event     string `json:"event"`
+		Timestamp int64  `json:"ts"`
+	}
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil
+	}
+
+	return &HookStatus{
+		Status:    status.Status,
+		SessionID: status.SessionID,
+		Event:     status.Event,
+		UpdatedAt: time.Unix(status.Timestamp, 0),
+	}
+}
+
 // GetHooksDir returns the path to the hooks status directory.
 func GetHooksDir() string {
 	home, err := os.UserHomeDir()

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2163,6 +2163,30 @@ func (i *Instance) UpdateStatus() error {
 		i.lastKnownActivity = currentTS
 	}
 
+	// COLD HOOK LOAD: CLI commands don't run StatusFileWatcher, so hookStatus
+	// is never populated via fsnotify. Read the hook file from disk once per
+	// UpdateStatus() call to give CLI the same hook fast path as the TUI.
+	if (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini") &&
+		i.hookStatus == "" {
+		if hs := ReadHookStatusFile(i.ID); hs != nil {
+			i.hookStatus = hs.Status
+			i.hookLastUpdate = hs.UpdatedAt
+			if hs.SessionID != "" {
+				i.hookSessionID = hs.SessionID
+			} else if sid := ReadHookSessionAnchor(i.ID); sid != "" {
+				i.hookSessionID = sid
+			}
+			// In the TUI, a running→waiting transition resets acknowledged via
+			// the "running" case in the hook fast path. CLI loads from SQLite
+			// (often "idle" with acknowledged=true) and never sees the "running"
+			// transition. Reset acknowledged here so fresh hook "waiting" status
+			// isn't downgraded to "idle" by the acknowledgment check below.
+			if hs.Status == "waiting" && i.tmuxSession != nil {
+				i.tmuxSession.ResetAcknowledged()
+			}
+		}
+	}
+
 	// HOOK FAST PATH: hook-based status for tools that emit lifecycle events.
 	// Freshness is tool- and state-specific (e.g. Codex running vs waiting).
 	// When this path is stale/missing, control naturally falls through to tmux
@@ -3536,6 +3560,11 @@ func (i *Instance) Restart() error {
 		}
 
 		mcpLog.Debug("respawn_pane_claude_succeeded")
+
+		// Persist .sid sidecar so hook events after restart can be correlated
+		// with this instance. Without this, the hook handler writes status files
+		// that UpdateHookStatus() can't resolve to a session.
+		WriteHookSessionAnchor(i.ID, i.ClaudeSessionID)
 
 		// Re-capture MCPs after restart (they may have changed since session started)
 		i.CaptureLoadedMCPs()


### PR DESCRIPTION
## Summary
- CLI commands (`list`, `status`) reported incorrect status for live sessions — `waiting` sessions appeared as `idle` because the CLI never ran `StatusFileWatcher`
- Adds `ReadHookStatusFile()` for one-shot hook file reads from disk, giving CLI the same hook fast path as the TUI
- Resets `acknowledged` flag on cold hook load so `waiting` isn't downgraded to `idle`
- Writes `.sid` sidecar in `Restart()` after `RespawnPane()` so post-restart hook events correlate with the instance

## Test plan
- [x] Built patched binary and compared against stock v0.25.1
- [x] With fresh hook files: patched binary correctly reports `waiting` sessions; stock reports `idle`
- [x] With no hook files: patched binary gracefully falls back to tmux polling (same as stock)
- [x] `go build ./internal/session/...` passes
- [ ] Verify TUI behavior is unchanged (cold hook load only fires when `hookStatus` is empty, which the TUI's fsnotify watcher always populates first)

Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)