### PR TITLE
fix(tmux): restore Ctrl+Z suspend/resume inside attached sessions

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -554,6 +554,9 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 
 		// Pre-generate UUID in Go to avoid shell uuidgen (may be absent in Docker sandbox).
 		// CLAUDE_SESSION_ID is also propagated via host-side SetEnvironment after tmux start.
+		// Use `exec` before the final claude invocation so that when this compound
+		// command is wrapped in `bash -c` (for fish compatibility), exec replaces
+		// the bash process with claude, enabling proper job control (Ctrl+Z suspend / fg resume).
 		sessionUUID := generateUUID()
 		i.ClaudeSessionID = sessionUUID
 
@@ -561,7 +564,7 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 		// Use pre-generated literal UUID with --session-id flag.
 		// CLAUDE_SESSION_ID is propagated via host-side SetEnvironment after tmux start.
 		baseCmd = fmt.Sprintf(
-			`%s%s --session-id "%s"%s`,
+			`%sexec %s --session-id "%s"%s`,
 			bashExportPrefix, claudeCmd, sessionUUID, extraFlags)
 
 		// If message provided, append wait-and-send logic in background.
@@ -569,11 +572,13 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 			// Escape single quotes in message for bash
 			escapedMsg := strings.ReplaceAll(message, "'", "'\"'\"'")
 
+			// The background subshell runs independently; exec replaces
+			// the current shell with claude for proper job control.
 			baseCmd = fmt.Sprintf(
 				`(sleep 2; SESSION_NAME=$(tmux display-message -p '#S'); `+
 					`while ! tmux capture-pane -p -t "$SESSION_NAME" | tail -5 | grep -qE "^>"; do sleep 0.2; done; `+
 					`tmux send-keys -l -t "$SESSION_NAME" -- '%s' \; send-keys -t "$SESSION_NAME" Enter) & `+
-					`%s%s --session-id "%s"%s`,
+					`%sexec %s --session-id "%s"%s`,
 				escapedMsg,
 				bashExportPrefix, claudeCmd, sessionUUID, extraFlags)
 		}
@@ -4255,11 +4260,14 @@ func (i *Instance) buildClaudeForkCommandForTarget(target *Instance, opts *Claud
 
 	// Pre-generate UUID for forked session to avoid shell uuidgen dependency.
 	// CLAUDE_SESSION_ID is propagated via host-side SetEnvironment after tmux start.
+	// Use `exec` before claude so that when this compound command is wrapped
+	// in `bash -c` (for fish compatibility), claude replaces the bash process,
+	// enabling proper job control (Ctrl+Z suspend / fg resume).
 	forkUUID := generateUUID()
 	target.ClaudeSessionID = forkUUID
 	cmd := fmt.Sprintf(
 		`cd '%s' && `+
-			`%sclaude --session-id "%s" --resume %s --fork-session%s`,
+			`%sexec claude --session-id "%s" --resume %s --fork-session%s`,
 		workDir,
 		bashExportPrefix, forkUUID, i.ClaudeSessionID, extraFlags)
 	cmd, err := i.applyWrapper(cmd)
@@ -4950,7 +4958,11 @@ func (i *Instance) prepareCommand(cmd string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	if wrapped != "" {
+	// Only disable Ctrl+Z suspend for sandboxed sessions where the command
+	// runs as the pane's initial process (no interactive shell for job control).
+	// Non-sandbox sessions use send-keys into an interactive shell, so Ctrl+Z
+	// naturally suspends the process and the user can `fg` to resume.
+	if wrapped != "" && i.IsSandboxed() {
 		wrapped = wrapIgnoreSuspend(wrapped)
 	}
 	return wrapped, containerName, nil

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -40,6 +40,14 @@ func (s *Session) Attach(ctx context.Context) error {
 	}
 	defer ptmx.Close()
 
+	// Set the PTY to raw mode so all bytes pass through transparently.
+	// Without this, the PTY's default terminal settings (ISIG enabled)
+	// interpret Ctrl+Z as SUSP and send SIGTSTP to the tmux attach process,
+	// causing it to exit and returning the user to the session list.
+	if _, err := term.MakeRaw(int(ptmx.Fd())); err != nil {
+		return fmt.Errorf("failed to set pty raw mode: %w", err)
+	}
+
 	// Save original terminal state and set raw mode
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {


### PR DESCRIPTION
## Summary

Ctrl+Z (suspend) has been broken inside agent-deck tmux sessions, leaving users in an unrecoverable frozen terminal state where control characters echo as raw text (`^Z^Z^Z^Z`). Only Ctrl+Q (detach) still worked. This PR fixes two independent root causes:

### Problem 1: PTY line discipline suspending the tmux client

The PTY master fd connecting agent-deck to `tmux attach-session` had default terminal settings with `ISIG` enabled. When the user pressed Ctrl+Z, the PTY's line discipline interpreted byte `0x1A` as `SUSP` and delivered `SIGTSTP` to the tmux attach process — suspending the tmux client. This left the user in a frozen limbo state: no process was actively reading input, so further control characters were simply echoed as text. Only Ctrl+Q escaped because it is intercepted in the stdin-reader goroutine *before* bytes reach the PTY.

**Fix:** Set the PTY master to raw mode (`term.MakeRaw`) immediately after creation, so all bytes pass through transparently to tmux. This is safe because:
- The PTY master fd is fully isolated from `os.Stdin`/`os.Stdout` and Bubble Tea's terminal state
- tmux expects to receive raw bytes and routes control characters to panes internally
- The existing Ctrl+Q interception in the stdin-reader goroutine is unaffected (it operates before bytes reach the PTY)

### Problem 2: Non-interactive `bash -c` wrapper breaking job control

Compound session commands (containing `$()` subshells for UUID generation) are wrapped in `bash -c '...'` for fish shell compatibility. This non-interactive bash shell has no job control. When Claude Code handled Ctrl+Z internally by sending `SIGTSTP` to itself, the `bash -c` parent couldn't handle the stopped child — leaving the pane in a broken state.

Additionally, `wrapIgnoreSuspend` wrapped *every* command in `bash -c 'stty susp undef; ...'`, which disabled the terminal's ability to generate `SIGTSTP` from Ctrl+Z.

**Fix (two parts):**
- Add `exec` before the final `claude` invocation in compound commands. This replaces the `bash -c` process with claude, making it a direct child of the interactive shell where job control works naturally (Ctrl+Z → `[1]+ Stopped` → shell prompt → `fg` to resume).
- Only apply `wrapIgnoreSuspend` for sandboxed sessions, where the command runs as the pane's initial process with no interactive shell for job control. Non-sandbox sessions launch via `send-keys` into the user's interactive shell, so standard job control works without intervention.

## Test plan
- [x] Create a new non-sandbox Claude session, attach, press Ctrl+Z — Claude should suspend and show a shell prompt
- [x] Type `fg` — Claude should resume normally
- [x] Ctrl+Q still detaches back to the session list
- [x] Ctrl+C inside an attached session passes through to the running process (not intercepted by the PTY)
- [ ] Sandboxed sessions still function correctly (wrapIgnoreSuspend still applied)
- [ ] Fork and new-session-with-message flows work correctly with the `exec` prefix
- [ ] Fish shell users can still create/resume sessions (bash -c wrapping still applied)