### PR TITLE
Fix #325: correct CLI status reporting for live sessions

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2163,6 +2163,22 @@ func (i *Instance) UpdateStatus() error {
 		i.lastKnownActivity = currentTS
 	}
 
+	// COLD LOAD: CLI doesn't run StatusFileWatcher, so hookStatus is always empty.
+	// Read the hook file from disk once to give CLI the same fast path as the TUI.
+	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini") {
+		if hs := readHookStatusFile(i.ID); hs != nil {
+			i.hookStatus = hs.Status
+			i.hookLastUpdate = hs.UpdatedAt
+			i.hookSessionID = hs.SessionID
+			// Reset stale acknowledged flag from ReconnectSessionLazy.
+			// Without this, sessions loaded from SQLite with previousStatus="idle"
+			// would report idle even when the hook file says waiting/running.
+			if i.tmuxSession != nil && (hs.Status == "running" || hs.Status == "waiting") {
+				i.tmuxSession.ResetAcknowledged()
+			}
+		}
+	}
+
 	// HOOK FAST PATH: hook-based status for tools that emit lifecycle events.
 	// Freshness is tool- and state-specific (e.g. Codex running vs waiting).
 	// When this path is stale/missing, control naturally falls through to tmux
@@ -3537,6 +3553,9 @@ func (i *Instance) Restart() error {
 
 		mcpLog.Debug("respawn_pane_claude_succeeded")
 
+		// Persist .sid sidecar so hook events after restart can be correlated
+		WriteHookSessionAnchor(i.ID, i.ClaudeSessionID)
+
 		// Re-capture MCPs after restart (they may have changed since session started)
 		i.CaptureLoadedMCPs()
 
@@ -3568,6 +3587,10 @@ func (i *Instance) Restart() error {
 		}
 
 		sessionLog.Info("restart_gemini_respawn_succeeded")
+
+		// Persist .sid sidecar so hook events after restart can be correlated
+		WriteHookSessionAnchor(i.ID, i.GeminiSessionID)
+
 		i.Status = StatusWaiting
 		return nil
 	}
@@ -3612,6 +3635,12 @@ func (i *Instance) Restart() error {
 		}
 
 		sessionLog.Info("restart_opencode_respawn_succeeded")
+
+		// Persist .sid sidecar so hook events after restart can be correlated
+		if i.OpenCodeSessionID != "" {
+			WriteHookSessionAnchor(i.ID, i.OpenCodeSessionID)
+		}
+
 		i.Status = StatusWaiting
 		return nil
 	}
@@ -3664,6 +3693,10 @@ func (i *Instance) Restart() error {
 		}
 
 		sessionLog.Info("restart_codex_respawn_succeeded")
+
+		// Persist .sid sidecar so hook events after restart can be correlated
+		WriteHookSessionAnchor(i.ID, i.CodexSessionID)
+
 		i.Status = StatusWaiting
 		return nil
 	}

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -2716,5 +2716,106 @@ func TestInstance_SetAcknowledgedFromShared_WaitingApplied(t *testing.T) {
 	}
 }
 
+// TestUpdateStatus_ColdLoadHookFile verifies that UpdateStatus reads hook status
+// from disk when hookStatus is empty (CLI path without StatusFileWatcher).
+func TestUpdateStatus_ColdLoadHookFile(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	inst := NewInstanceWithTool("cold-load-test", "/tmp/test", "claude")
+
+	// Write a hook status file to disk
+	hooksDir := GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	hookData := fmt.Sprintf(`{"status":"waiting","session_id":"cold-sess-1","event":"Stop","ts":%d}`, time.Now().Unix())
+	hookPath := filepath.Join(hooksDir, inst.ID+".json")
+	if err := os.WriteFile(hookPath, []byte(hookData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify hookStatus starts empty
+	if inst.hookStatus != "" {
+		t.Fatalf("hookStatus should start empty, got %q", inst.hookStatus)
+	}
+
+	// Call UpdateStatus — it will fail early because tmux session doesn't exist,
+	// but the cold load fires before the tmux-exists check only if we've passed
+	// the tmuxSession nil check. Instead, verify readHookStatusFile directly.
+	hs := readHookStatusFile(inst.ID)
+	if hs == nil {
+		t.Fatal("readHookStatusFile returned nil, expected hook status from disk")
+	}
+	if hs.Status != "waiting" {
+		t.Errorf("hook status = %q, want waiting", hs.Status)
+	}
+	if hs.SessionID != "cold-sess-1" {
+		t.Errorf("hook session ID = %q, want cold-sess-1", hs.SessionID)
+	}
+}
+
+// TestUpdateStatus_ColdLoadResetsAcknowledged verifies that cold-loading a
+// "waiting" hook status resets the stale acknowledged flag from ReconnectSessionLazy.
+func TestUpdateStatus_ColdLoadResetsAcknowledged(t *testing.T) {
+	skipIfNoTmuxServer(t)
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	inst := NewInstanceWithTool("cold-ack-test", tmpHome, "claude")
+
+	// Create a real tmux session so UpdateStatus gets past the Exists() check
+	if err := inst.tmuxSession.Start("sleep 3600"); err != nil {
+		t.Fatalf("failed to start tmux session: %v", err)
+	}
+	defer func() { _ = inst.tmuxSession.Kill() }()
+
+	// Simulate what ReconnectSessionLazy does for previousStatus="idle"
+	inst.tmuxSession.Acknowledge()
+	if !inst.tmuxSession.IsAcknowledged() {
+		t.Fatal("precondition: acknowledged should be true after Acknowledge()")
+	}
+
+	// Write a hook status file showing "waiting"
+	hooksDir := GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	hookData := fmt.Sprintf(`{"status":"waiting","session_id":"sess-1","event":"Stop","ts":%d}`, time.Now().Unix())
+	if err := os.WriteFile(filepath.Join(hooksDir, inst.ID+".json"), []byte(hookData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for grace period to pass (1.5s)
+	time.Sleep(2 * time.Second)
+
+	// hookStatus is empty, so cold load should fire and reset acknowledged
+	inst.hookStatus = ""
+	_ = inst.UpdateStatus()
+
+	// After cold load with "waiting" status, acknowledged should be reset
+	if inst.tmuxSession.IsAcknowledged() {
+		t.Error("acknowledged should be false after cold-loading 'waiting' hook status")
+	}
+}
+
+// TestWriteHookSessionAnchor_InRestart verifies that WriteHookSessionAnchor
+// creates a .sid file with the correct session ID content.
+func TestWriteHookSessionAnchor_InRestart(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	instanceID := "restart-sid-test"
+	sessionID := "restart-session-abc123"
+
+	WriteHookSessionAnchor(instanceID, sessionID)
+
+	got := ReadHookSessionAnchor(instanceID)
+	if got != sessionID {
+		t.Errorf("ReadHookSessionAnchor = %q, want %q", got, sessionID)
+	}
+}
+
 // Tests for hasUnsentComposerPrompt and currentComposerPrompt moved to
 // internal/send/send_test.go as part of send verification consolidation.


### PR DESCRIPTION
Fixes #325

## Summary

- **Cold-load hook status from disk in `UpdateStatus()`**: When `hookStatus` is empty (CLI path without `StatusFileWatcher`), reads the `.json` hook file once to give CLI the same hook fast path as the TUI
- **Reset stale acknowledged flag during cold load**: `ReconnectSessionLazy` sets `acknowledged=true` for `previousStatus="idle"`, causing sessions that transitioned idle→waiting to remain stuck as idle in CLI output
- **Write `.sid` sidecar in `Restart()`**: After successful `RespawnPane()` for Claude, Gemini, Codex, and OpenCode, persists the session ID anchor so hook events after restart can be correlated with the instance

## Test plan

- [x] `TestUpdateStatus_ColdLoadHookFile` — verifies `readHookStatusFile` reads hook status from disk
- [x] `TestUpdateStatus_ColdLoadResetsAcknowledged` — verifies cold-loading "waiting" status resets stale acknowledged flag (requires tmux)
- [x] `TestWriteHookSessionAnchor_InRestart` — verifies `.sid` file is written correctly
- [x] Full test suite passes (`make ci` — all 19 packages green)