### PR TITLE
Fix #332: add CI release workflow to prevent empty releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+# Automated release via GoReleaser when a version tag is pushed.
+# Replaces the manual `make release-local` step that was previously
+# required after tagging, preventing empty releases (see #332).
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Validate tag matches code version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          CODE=$(grep 'const Version' cmd/agent-deck/main.go | sed 's/.*"\(.*\)".*/\1/')
+          if [ "$TAG" != "$CODE" ]; then
+            echo "ERROR: Tag v$TAG does not match code Version $CODE"
+            exit 1
+          fi
+          echo "Version: $CODE"
+
+      - name: Run tests
+        run: go test -race ./...
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/install.sh
+++ b/install.sh
@@ -469,12 +469,27 @@ if ! curl -fsSL "$DOWNLOAD_URL" -o "$TMP_DIR/agent-deck.tar.gz"; then
     echo -e "${RED}Error: Download failed${NC}"
     echo "URL: $DOWNLOAD_URL"
     echo ""
-    echo "This could mean:"
-    echo "  - The version doesn't exist"
-    echo "  - The release hasn't been published yet"
-    echo "  - Network issues"
+
+    # Check if the release exists but has no assets (common when GoReleaser didn't run)
+    ASSET_COUNT=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/tags/${VERSION}" 2>/dev/null | grep -c '"browser_download_url"' || true)
+    if [[ "$ASSET_COUNT" -eq 0 ]]; then
+        echo "The release ${VERSION} exists but has no downloadable binaries."
+        echo "This usually means the release build hasn't completed yet."
+    else
+        echo "This could mean:"
+        echo "  - The version doesn't exist"
+        echo "  - Network issues"
+    fi
     echo ""
-    echo "Try building from source instead:"
+
+    # Suggest Homebrew first if available (most reliable)
+    if [[ "$OS" == "darwin" ]] && command -v brew &> /dev/null; then
+        echo "Install via Homebrew instead (recommended):"
+        echo "  brew install asheshgoplani/tap/agent-deck"
+        echo ""
+    fi
+
+    echo "Or build from source:"
     echo "  git clone https://github.com/${REPO}.git"
     echo "  cd agent-deck && make install"
     exit 1


### PR DESCRIPTION
## Summary
- Added `.github/workflows/release.yml` that triggers GoReleaser on tag push, preventing releases with no binaries
- Improved `install.sh` error handling to detect "release exists but no assets" and suggest Homebrew as fallback
- Root cause: v0.26.0 was tagged but `make release-local` was never run, leaving 0 assets on the release

## Note
The existing v0.26.0 release still needs its assets uploaded. After merging this PR, either:
1. Delete and re-tag v0.26.0 to trigger the new workflow, or
2. Run `make release-local` manually one last time

The `HOMEBREW_TAP_GITHUB_TOKEN` secret must be added to the repository settings for the Homebrew tap update to work in CI.

Fixes #332

## Test plan
- [x] `make ci` passes (lint + test + build)
- [ ] Verify workflow triggers on next tag push
- [ ] Verify install.sh shows improved error for empty releases