### PR TITLE
Fix light-theme Codex rendering in live tmux sessions and improve preview background handling

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -21,8 +21,10 @@ import (
 
 	"golang.org/x/sync/singleflight"
 
+	"github.com/BurntSushi/toml"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/platform"
+	dark "github.com/thiagokokada/dark-mode-go"
 )
 
 var (
@@ -30,6 +32,70 @@ var (
 	respawnLog = logging.ForComponent(logging.CompSession)
 	mcpLog     = logging.ForComponent(logging.CompMCP)
 )
+
+type tmuxThemeStyle struct {
+	windowStyle       string
+	windowActiveStyle string
+	statusStyle       string
+	hintColor         string
+}
+
+func resolvedAgentDeckTheme() string {
+	type cfg struct {
+		Theme string `toml:"theme"`
+	}
+	home, err := os.UserHomeDir()
+	if err == nil {
+		var c cfg
+		if _, err := toml.DecodeFile(filepath.Join(home, ".agent-deck", "config.toml"), &c); err == nil {
+			switch c.Theme {
+			case "light", "dark":
+				return c.Theme
+			case "system", "":
+				// fall through to OS detection
+			default:
+				return "dark"
+			}
+		}
+	}
+	isDark, err := dark.IsDarkMode()
+	if err != nil {
+		return "dark"
+	}
+	if isDark {
+		return "dark"
+	}
+	return "light"
+}
+
+func currentTmuxThemeStyle() tmuxThemeStyle {
+	if resolvedAgentDeckTheme() == "light" {
+		return tmuxThemeStyle{
+			// Light terminals can still inherit a dark-looking tmux window background
+			// when we leave window-style at "default". Use an explicit neutral light
+			// background so the attached client sees and renders against a light pane.
+			windowStyle:       "bg=#f9f9f9",
+			windowActiveStyle: "bg=#f9f9f9",
+			statusStyle:       "bg=#e9e9ec,fg=#343b58",
+			hintColor:         "#6a6d7c",
+		}
+	}
+	return tmuxThemeStyle{
+		// Preserve the historical dark behavior unless a light theme is active.
+		windowStyle:       "default",
+		windowActiveStyle: "default",
+		statusStyle:       "bg=#1a1b26,fg=#a9b1d6",
+		hintColor:         "#565f89",
+	}
+}
+
+func (s *Session) themedStatusRight(themeStyle tmuxThemeStyle) string {
+	folderName := filepath.Base(s.WorkDir)
+	if folderName == "" || folderName == "." {
+		folderName = "~"
+	}
+	return fmt.Sprintf("#[fg=%s]ctrl+q detach#[default] │ 📁 %s | %s ", themeStyle.hintColor, s.DisplayName, folderName)
+}
 
 // ErrCaptureTimeout is returned when CapturePane exceeds its timeout.
 // Callers should preserve previous state rather than transitioning to error/inactive.
@@ -917,6 +983,21 @@ func (s *Session) SetEnvironment(key, value string) error {
 	return err
 }
 
+func (s *Session) ApplyThemeOptions() error {
+	themeStyle := currentTmuxThemeStyle()
+	args := []string{
+		"set-option", "-t", s.Name, "window-style", themeStyle.windowStyle, ";",
+		"set-option", "-t", s.Name, "window-active-style", themeStyle.windowActiveStyle, ";",
+		"set-option", "-t", s.Name, "status-style", themeStyle.statusStyle,
+	}
+	if s.injectStatusLine {
+		args = append(args,
+			";", "set-option", "-t", s.Name, "status-right", s.themedStatusRight(themeStyle),
+		)
+	}
+	return exec.Command("tmux", args...).Run()
+}
+
 // GetEnvironment gets an environment variable from this tmux session.
 // Uses a 30-second cache to avoid spawning tmux show-environment subprocesses
 // on every poll cycle. Call InvalidateEnvCache() after SetEnvironment to clear.
@@ -1142,9 +1223,11 @@ func (s *Session) Start(command string) error {
 	//
 	// Note: remain-on-exit is NOT set here — it is only enabled for sandbox sessions
 	// via OptionOverrides to avoid changing behaviour for non-sandbox sessions.
+	themeStyle := currentTmuxThemeStyle()
+
 	_ = exec.Command("tmux",
-		"set-option", "-t", s.Name, "window-style", "default", ";",
-		"set-option", "-t", s.Name, "window-active-style", "default", ";",
+		"set-option", "-t", s.Name, "window-style", themeStyle.windowStyle, ";",
+		"set-option", "-t", s.Name, "window-active-style", themeStyle.windowActiveStyle, ";",
 		"set-option", "-t", s.Name, "mouse", "on", ";",
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
@@ -1269,16 +1352,8 @@ func (s *Session) ConfigureStatusBar() {
 	if !s.injectStatusLine {
 		return
 	}
-
-	// Get short folder name from WorkDir
-	folderName := filepath.Base(s.WorkDir)
-	if folderName == "" || folderName == "." {
-		folderName = "~"
-	}
-
-	// Right side: detach hint + session title with folder path
-	// The hint uses subtle gray (#565f89) so it doesn't compete with session info
-	rightStatus := fmt.Sprintf("#[fg=#565f89]ctrl+q detach#[default] │ 📁 %s | %s ", s.DisplayName, folderName)
+	themeStyle := currentTmuxThemeStyle()
+	rightStatus := s.themedStatusRight(themeStyle)
 
 	// PERFORMANCE: Batch all 5 status bar options into single subprocess call
 	// Uses tmux command chaining with \; separator (73% reduction in subprocess calls)
@@ -1286,7 +1361,7 @@ func (s *Session) ConfigureStatusBar() {
 	// After: 1 exec.Command call = 1 subprocess spawn
 	cmd := exec.Command("tmux",
 		"set-option", "-t", s.Name, "status", "on", ";",
-		"set-option", "-t", s.Name, "status-style", "bg=#1a1b26,fg=#a9b1d6", ";",
+		"set-option", "-t", s.Name, "status-style", themeStyle.statusStyle, ";",
 		"set-option", "-t", s.Name, "status-left-length", "120", ";",
 		"set-option", "-t", s.Name, "status-right", rightStatus, ";",
 		"set-option", "-t", s.Name, "status-right-length", "80")

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1493,6 +1494,7 @@ func (h *Home) propagateThemeToSessions() {
 		for _, inst := range instances {
 			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil && tmuxSess.Exists() {
 				_ = tmuxSess.SetEnvironment("COLORFGBG", colorfgbg)
+				_ = tmuxSess.ApplyThemeOptions()
 			}
 		}
 	}()
@@ -10324,12 +10326,12 @@ func (h *Home) renderPreviewPane(width, height int) string {
 			// from the captured terminal output pass through to display.
 			safeLine := stripControlCharsPreserveANSI(line)
 
-			// In light theme, remove background color ANSI sequences that
-			// cause dark background bands to bleed through (e.g., tool output
-			// uses ESC[40m..ESC[47m which remain dark on a light background).
-			// Foreground colors and text formatting are preserved.
+			// In light theme, remap captured ANSI background colors to the
+			// current preview surface instead of stripping them completely.
+			// This preserves the soft highlighted blocks used by tools like
+			// Codex without letting dark background bands bleed through.
 			if isLightTheme {
-				safeLine = stripANSIBackground(safeLine)
+				safeLine = remapANSIBackground(safeLine, previewSurfaceANSI())
 			}
 
 			// Check if visually empty (strip ANSI for this check)
@@ -10525,15 +10527,40 @@ func stripControlCharsPreserveANSI(s string) string {
 //   - ESC[40m..ESC[47m  — standard 8-color backgrounds
 //   - ESC[100m..ESC[107m — bright/high-intensity backgrounds
 //   - ESC[48;...m        — 256-color and true-color backgrounds (ESC[48;5;Nm / ESC[48;2;R;G;Bm)
-//   - ESC[49m            — default background reset
-var ansiBackgroundRE = regexp.MustCompile(`\x1b\[(?:4[0-7]|10[0-7]|48;[0-9;]+|49)m`)
+var ansiBackgroundRE = regexp.MustCompile(`\x1b\[(?:4[0-7]|10[0-7]|48;[0-9;]+)m`)
 
-// stripANSIBackground removes ANSI background color sequences from a line
-// while preserving all other ANSI sequences (foreground colors, bold, italic,
-// underline). Used in light theme to prevent dark background bleed-through
-// from captured tmux pane output.
-func stripANSIBackground(s string) string {
-	return ansiBackgroundRE.ReplaceAllString(s, "")
+// previewSurfaceANSI returns a truecolor ANSI background sequence matching
+// the current preview surface. Falls back to empty string if the color is not
+// a hex RGB value.
+func previewSurfaceANSI() string {
+	hex := strings.TrimPrefix(string(ColorSurface), "#")
+	if len(hex) != 6 {
+		return ""
+	}
+	r, err := strconv.ParseUint(hex[0:2], 16, 8)
+	if err != nil {
+		return ""
+	}
+	g, err := strconv.ParseUint(hex[2:4], 16, 8)
+	if err != nil {
+		return ""
+	}
+	b, err := strconv.ParseUint(hex[4:6], 16, 8)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("\x1b[48;2;%d;%d;%dm", r, g, b)
+}
+
+// remapANSIBackground replaces ANSI background color sequences with the
+// provided replacement while preserving all other ANSI sequences (foreground
+// colors, bold, italic, underline). Used in light theme so captured terminal
+// output keeps soft highlighted regions instead of dropping them entirely.
+func remapANSIBackground(s, replacement string) string {
+	if replacement == "" {
+		return ansiBackgroundRE.ReplaceAllString(s, "")
+	}
+	return ansiBackgroundRE.ReplaceAllString(s, replacement)
 }
 
 // truncatePath shortens a path to fit within maxLen display width


### PR DESCRIPTION
## Summary

This PR follows up on [#322](https://github.com/asheshgoplani/agent-deck/issues/322)

`v0.26.0` improved the preview pane by removing dark background bleed, but it did not fully fix the original light-theme rendering problem for Codex sessions.

In particular, the main live attached session could still render with a dark input/background bar in light theme.

This change makes the rendering more correct in practice by addressing both layers:

1. **Live attached tmux session**
   - apply theme-aware tmux styles for light theme
   - avoid relying on `window-style/window-active-style=default` in light mode

2. **Preview pane**
   - instead of stripping all ANSI backgrounds in light theme, remap explicit background colors to the current light preview surface
   - this preserves soft highlighted blocks better than full stripping

## What was still broken in `v0.26.0`

`v0.26.0` fixed the preview bleed part of `#322`, but the live interactive Codex session in light theme was still reproducibly wrong.

In my testing:
- `Ghostty + codex` rendered correctly in light theme
- `agent-deck` preview was improved in `v0.26.0`
- but the live attached session still showed the dark/black input bar

So `#322` was only partially addressed there.

## Root cause

The main issue was not just Codex theme detection.

The larger problem was that tmux session styling in light mode still effectively behaved like a dark/default pane background during live attach, which caused the Codex input area to render incorrectly.

For preview, the `v0.26.0` approach removed background ANSI completely. That avoided black bands, but also removed the softer highlighted background behavior that looks closer to native Codex rendering.

## Changes in this PR

### Live session fix
- make tmux session styling theme-aware
- for light theme, set explicit light `window-style` / `window-active-style`
- keep dark behavior conservative
- also update existing sessions when theme propagation runs

### Preview improvement
- replace the current light-theme “strip all ANSI background” behavior
- remap explicit ANSI background colors to the current preview surface color instead
- do **not** remap/reset `49m`, to avoid background bleed across adjacent lines

## Result

With this change, the issue is more or less closed in practice:

- live Codex sessions in light theme render correctly
- preview no longer shows dark bleed
- preview also preserves soft highlighted regions better than the `v0.26.0` strip-only behavior

## Notes

This should work correctly, but it still deserves testing in different setups before assuming it is universally correct.

The fix is designed to be conservative for dark mode and explicit only where light mode was still broken.
