### PR TITLE
fix: use model-aware context window size for analytics percent

### DIFF
--- a/internal/session/analytics.go
+++ b/internal/session/analytics.go
@@ -29,6 +29,9 @@ type SessionAnalytics struct {
 	// Tool usage
 	ToolCalls []ToolCall `json:"tool_calls"`
 
+	// Model ID from the last assistant message (e.g. "claude-opus-4-6")
+	Model string `json:"model,omitempty"`
+
 	// Subagents
 	Subagents []SubagentInfo `json:"subagents"`
 
@@ -65,12 +68,43 @@ func (a *SessionAnalytics) TotalTokens() int {
 	return a.InputTokens + a.OutputTokens + a.CacheReadTokens + a.CacheWriteTokens
 }
 
+// modelContextWindow maps model ID prefixes to their context window sizes.
+// More specific prefixes must come first to ensure correct matching
+// (e.g. "claude-sonnet-4-6" before "claude-sonnet-4").
+var modelContextWindowPrefixes = []struct {
+	prefix string
+	size   int
+}{
+	// 4.6 models: 1M context
+	{"claude-opus-4-6", 1000000},
+	{"claude-sonnet-4-6", 1000000},
+	// 4.x models (non-4.6): 200k context
+	{"claude-opus-4", 200000},
+	{"claude-sonnet-4", 200000},
+	{"claude-haiku-4", 200000},
+	// 3.x models: 200k context
+	{"claude-3-5", 200000},
+	{"claude-3-opus", 200000},
+}
+
+// contextWindowForModel returns the context window size for a model ID.
+// Returns on first prefix match; entries are ordered most-specific first
+// (e.g. "claude-sonnet-4-6" before "claude-sonnet-4") to ensure correct resolution.
+func contextWindowForModel(model string) int {
+	for _, entry := range modelContextWindowPrefixes {
+		if len(model) >= len(entry.prefix) && model[:len(entry.prefix)] == entry.prefix {
+			return entry.size
+		}
+	}
+	return 200000 // Default Claude limit
+}
+
 // ContextPercent returns the percentage of context window used
 // Uses CurrentContextTokens (last turn's input + cache) for accurate context usage
-// modelLimit is the model's context window size (defaults to 200000 for Claude)
+// modelLimit is the model's context window size; if 0, it is inferred from the Model field
 func (a *SessionAnalytics) ContextPercent(modelLimit int) float64 {
 	if modelLimit == 0 {
-		modelLimit = 200000 // Default Claude limit
+		modelLimit = contextWindowForModel(a.Model)
 	}
 	return float64(a.CurrentContextTokens) / float64(modelLimit) * 100
 }
@@ -123,6 +157,7 @@ type jsonlEntry struct {
 			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 		} `json:"usage"`
+		Model   string `json:"model"`
 		Content []struct {
 			Type string `json:"type"`
 			Name string `json:"name"`
@@ -169,6 +204,11 @@ func ParseSessionJSONL(path string) (*SessionAnalytics, error) {
 			if entry.Timestamp.After(lastTime) {
 				lastTime = entry.Timestamp
 			}
+		}
+
+		// Track model ID (use last seen non-synthetic model)
+		if entry.Message.Model != "" && entry.Message.Model != "<synthetic>" {
+			analytics.Model = entry.Message.Model
 		}
 
 		// Accumulate tokens (cumulative totals for cost calculation)

--- a/internal/session/analytics_test.go
+++ b/internal/session/analytics_test.go
@@ -49,6 +49,31 @@ func TestSessionAnalytics_ContextPercent_DefaultLimit(t *testing.T) {
 	assert.InDelta(t, 10.0, analytics.ContextPercent(0), 0.01)
 }
 
+func TestSessionAnalytics_ContextPercent_OpusModel(t *testing.T) {
+	analytics := &SessionAnalytics{
+		CurrentContextTokens: 500000,
+		Model:                "claude-opus-4-6",
+	}
+
+	// 500000 / 1000000 (opus context window) * 100 = 50%
+	assert.InDelta(t, 50.0, analytics.ContextPercent(0), 0.01)
+}
+
+func TestContextWindowForModel(t *testing.T) {
+	// 4.6 models: 1M
+	assert.Equal(t, 1000000, contextWindowForModel("claude-opus-4-6"))
+	assert.Equal(t, 1000000, contextWindowForModel("claude-sonnet-4-6"))
+	// 4.x non-4.6 models: 200k
+	assert.Equal(t, 200000, contextWindowForModel("claude-opus-4-20250514"))
+	assert.Equal(t, 200000, contextWindowForModel("claude-sonnet-4-20250514"))
+	assert.Equal(t, 200000, contextWindowForModel("claude-haiku-4-5"))
+	// 3.x models: 200k
+	assert.Equal(t, 200000, contextWindowForModel("claude-3-5-sonnet"))
+	// Unknown/empty: 200k fallback
+	assert.Equal(t, 200000, contextWindowForModel("unknown-model"))
+	assert.Equal(t, 200000, contextWindowForModel(""))
+}
+
 func TestSessionAnalytics_ZeroTokens(t *testing.T) {
 	analytics := &SessionAnalytics{}
 


### PR DESCRIPTION
## Summary

- Context percentage in Session Analytics showed **100%** for Opus 4.6 and Sonnet 4.6 sessions when actual usage was ~20-50%
- Root cause: `ContextPercent()` in `analytics.go` hardcoded 200k as the default context window size, but 4.6 models have 1M context
- The Gemini path already correctly used 1M (line 166 in `analytics_panel.go`), but the Claude path passed `0` which fell back to 200k

## Changes

- Parse `message.model` from session JSONL into new `Model` field on `SessionAnalytics`
- Add ordered prefix-based model-to-context-window mapping:
  - `claude-opus-4-6`, `claude-sonnet-4-6` → 1M
  - `claude-opus-4`, `claude-sonnet-4`, `claude-haiku-4` → 200k
  - `claude-3-5`, `claude-3-opus` → 200k
  - Unknown → 200k fallback
- Longer prefixes match first so `claude-sonnet-4-6` resolves before `claude-sonnet-4`
- Filter out `<synthetic>` model entries from JSONL
- `ContextPercent(0)` now auto-detects the correct limit from the `Model` field

## Verified

```
Model: claude-opus-4-6
CurrentContextTokens: 206467
ContextPercent(0):      20.6%  ← fixed (auto-detected 1M)
ContextPercent(200000): 103.2% ← old behavior (capped to 100%)
```

## Test plan

- [x] Existing `TestSessionAnalytics_ContextPercent` tests pass
- [x] New `TestSessionAnalytics_ContextPercent_OpusModel` verifies Opus 4.6 → 50%
- [x] New `TestContextWindowForModel` covers all prefix variants
- [x] Verified against real session JSONL with Opus 4.6