### PR TITLE
feat(cli): add group reorder command

### DIFF
--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -28,6 +28,8 @@ func handleGroup(profile string, args []string) {
 		handleGroupDelete(profile, args[1:])
 	case "move", "mv":
 		handleGroupMove(profile, args[1:])
+	case "reorder", "sort":
+		handleGroupReorder(profile, args[1:])
 	case "help", "--help", "-h":
 		printGroupHelp()
 		return
@@ -49,6 +51,7 @@ func printGroupHelp() {
 	fmt.Println("  update <name>     Update group settings")
 	fmt.Println("  delete <name>     Delete a group")
 	fmt.Println("  move <id> <group> Move session to a different group")
+	fmt.Println("  reorder <name>    Reorder a group (--up, --down, --position N)")
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  agent-deck group list")
@@ -59,6 +62,9 @@ func printGroupHelp() {
 	fmt.Println("  agent-deck group delete work --force")
 	fmt.Println("  agent-deck group move my-project work/frontend")
 	fmt.Println("  agent-deck group move my-project \"\"          # Move to root")
+	fmt.Println("  agent-deck group reorder mobile --up")
+	fmt.Println("  agent-deck group reorder mobile --down")
+	fmt.Println("  agent-deck group reorder mobile --position 0")
 }
 
 // handleGroupList lists all groups with session counts and status
@@ -745,6 +751,189 @@ func handleGroupMove(profile string, args []string) {
 	})
 }
 
+// handleGroupReorder changes a group's position among its siblings
+func handleGroupReorder(profile string, args []string) {
+	fs := flag.NewFlagSet("group reorder", flag.ExitOnError)
+	up := fs.Bool("up", false, "Move group up one position")
+	upShort := fs.Bool("u", false, "Move group up one position (short)")
+	down := fs.Bool("down", false, "Move group down one position")
+	downShort := fs.Bool("d", false, "Move group down one position (short)")
+	position := fs.Int("position", -1, "Move group to specific position (0-indexed)")
+	positionShort := fs.Int("p", -1, "Move group to specific position (short)")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck group reorder <name> [options]")
+		fmt.Println()
+		fmt.Println("Reorder a group among its siblings.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck group reorder mobile --up")
+		fmt.Println("  agent-deck group reorder mobile --down")
+		fmt.Println("  agent-deck group reorder mobile --position 0")
+	}
+
+	args = reorderGroupArgs(args)
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	out := NewCLIOutput(*jsonOutput, *quiet || *quietShort)
+
+	name := fs.Arg(0)
+	if name == "" {
+		out.Error("group name is required", ErrCodeNotFound)
+		fmt.Println("Usage: agent-deck group reorder <name> [--up|--down|--position N]")
+		os.Exit(1)
+	}
+
+	moveUp := *up || *upShort
+	moveDown := *down || *downShort
+	posSet := *position >= 0
+	posShortSet := *positionShort >= 0
+	if posSet && posShortSet {
+		out.Error("specify only one of --position or -p", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	pos := *position
+	if posShortSet {
+		pos = *positionShort
+	}
+
+	// Validate: exactly one direction
+	dirCount := 0
+	if moveUp {
+		dirCount++
+	}
+	if moveDown {
+		dirCount++
+	}
+	if pos >= 0 {
+		dirCount++
+	}
+	if dirCount == 0 {
+		out.Error("specify one of --up, --down, or --position", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	if dirCount > 1 {
+		out.Error("specify only one of --up, --down, or --position", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	// Load storage
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to initialize storage: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	instances, groups, err := storage.LoadWithGroups()
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to load sessions: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+
+	// Find group by path or name
+	groupPath := normalizeGroupPath(name)
+	_, exists := groupTree.Groups[groupPath]
+	if !exists {
+		for path, g := range groupTree.Groups {
+			if strings.EqualFold(g.Name, name) {
+				groupPath = path
+				exists = true
+				break
+			}
+		}
+	}
+	if !exists {
+		out.Error(fmt.Sprintf("group '%s' not found", name), ErrCodeNotFound)
+		os.Exit(2)
+	}
+
+	// Compute current sibling position
+	siblingIndex, siblings := groupSiblingPosition(groupTree, groupPath)
+
+	fromPos := siblingIndex
+
+	if moveUp {
+		groupTree.MoveGroupUp(groupPath)
+	} else if moveDown {
+		groupTree.MoveGroupDown(groupPath)
+	} else {
+		// --position: move to target position among siblings
+		targetPos := pos
+		if targetPos >= len(siblings) {
+			targetPos = len(siblings) - 1
+		}
+		if targetPos < 0 {
+			targetPos = 0
+		}
+		// Re-check position after each move to handle interleaved children
+		for {
+			cur, _ := groupSiblingPosition(groupTree, groupPath)
+			if cur == targetPos {
+				break
+			}
+			if cur > targetPos {
+				groupTree.MoveGroupUp(groupPath)
+			} else {
+				groupTree.MoveGroupDown(groupPath)
+			}
+			// Detect no-op to avoid infinite loop (e.g., blocked by non-sibling)
+			newCur, _ := groupSiblingPosition(groupTree, groupPath)
+			if newCur == cur {
+				break
+			}
+		}
+	}
+
+	// Compute new position
+	toPos, _ := groupSiblingPosition(groupTree, groupPath)
+
+	// Save
+	if err := storage.SaveWithGroups(groupTree.GetAllInstances(), groupTree); err != nil {
+		out.Error(fmt.Sprintf("failed to save: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	out.Success(fmt.Sprintf("Reordered group '%s': position %d → %d", name, fromPos, toPos), map[string]interface{}{
+		"success":       true,
+		"name":          name,
+		"path":          groupPath,
+		"from_position": fromPos,
+		"to_position":   toPos,
+	})
+}
+
+// groupSiblingPosition returns the 0-indexed position of a group among its siblings and the sibling paths
+func groupSiblingPosition(groupTree *session.GroupTree, groupPath string) (int, []string) {
+	parentPath := getParentGroupPath(groupPath)
+	level := session.GetGroupLevel(groupPath)
+
+	var siblings []string
+	for _, g := range groupTree.GroupList {
+		gParent := getParentGroupPath(g.Path)
+		if gParent == parentPath && session.GetGroupLevel(g.Path) == level {
+			siblings = append(siblings, g.Path)
+		}
+	}
+
+	for i, s := range siblings {
+		if s == groupPath {
+			return i, siblings
+		}
+	}
+	return -1, siblings
+}
+
 // getParentGroupPath returns the parent path of a group path
 func getParentGroupPath(path string) string {
 	if idx := strings.LastIndex(path, "/"); idx != -1 {
@@ -786,6 +975,8 @@ func reorderGroupArgs(args []string) []string {
 	valueFlags := map[string]bool{
 		"--parent":       true,
 		"--default-path": true,
+		"--position":     true,
+		"-p":             true,
 	}
 
 	var flags []string

--- a/cmd/agent-deck/group_cmd_test.go
+++ b/cmd/agent-deck/group_cmd_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// helper: create storage, add N root groups, return (storage, instances, groupTree).
+// Each call overwrites the _test profile, so tests are independent when run sequentially.
+func setupGroupsForReorder(t *testing.T, names ...string) *session.Storage {
+	t.Helper()
+	storage, err := session.NewStorageWithProfile("_test")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+
+	instances := []*session.Instance{}
+	groupTree := session.NewGroupTreeWithGroups(instances, nil)
+
+	for _, name := range names {
+		groupTree.CreateGroup(name)
+	}
+
+	if err := storage.SaveWithGroups(instances, groupTree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	return storage
+}
+
+// helper: reload groups from storage and return ordered paths (excluding default group)
+func reloadGroupPaths(t *testing.T, storage *session.Storage) []string {
+	t.Helper()
+	_, groups, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+
+	instances := []*session.Instance{}
+	tree := session.NewGroupTreeWithGroups(instances, groups)
+
+	var paths []string
+	for _, g := range tree.GroupList {
+		if g.Path == session.DefaultGroupPath {
+			continue
+		}
+		paths = append(paths, g.Path)
+	}
+	return paths
+}
+
+func TestGroupReorderUp(t *testing.T) {
+	storage := setupGroupsForReorder(t, "Alpha", "Beta", "Gamma")
+
+	// Move beta up — should swap with alpha
+	handleGroupReorder("_test", []string{"beta", "--up"})
+
+	paths := reloadGroupPaths(t, storage)
+	if len(paths) < 3 {
+		t.Fatalf("expected 3 groups, got %d", len(paths))
+	}
+	if paths[0] != "beta" || paths[1] != "alpha" || paths[2] != "gamma" {
+		t.Errorf("expected [beta alpha gamma], got %v", paths)
+	}
+}
+
+func TestGroupReorderDown(t *testing.T) {
+	storage := setupGroupsForReorder(t, "Alpha", "Beta", "Gamma")
+
+	// Move beta down — should swap with gamma
+	handleGroupReorder("_test", []string{"beta", "--down"})
+
+	paths := reloadGroupPaths(t, storage)
+	if len(paths) < 3 {
+		t.Fatalf("expected 3 groups, got %d", len(paths))
+	}
+	if paths[0] != "alpha" || paths[1] != "gamma" || paths[2] != "beta" {
+		t.Errorf("expected [alpha gamma beta], got %v", paths)
+	}
+}
+
+func TestGroupReorderPosition(t *testing.T) {
+	storage := setupGroupsForReorder(t, "Alpha", "Beta", "Gamma")
+
+	// Move gamma to position 0
+	handleGroupReorder("_test", []string{"gamma", "--position", "0"})
+
+	paths := reloadGroupPaths(t, storage)
+	if len(paths) < 3 {
+		t.Fatalf("expected 3 groups, got %d", len(paths))
+	}
+	if paths[0] != "gamma" || paths[1] != "alpha" || paths[2] != "beta" {
+		t.Errorf("expected [gamma alpha beta], got %v", paths)
+	}
+}
+
+func TestGroupReorderAlreadyAtTop(t *testing.T) {
+	storage := setupGroupsForReorder(t, "Alpha", "Beta", "Gamma")
+
+	// Move alpha up — already first, should be no-op
+	handleGroupReorder("_test", []string{"alpha", "--up"})
+
+	paths := reloadGroupPaths(t, storage)
+	if len(paths) < 3 {
+		t.Fatalf("expected 3 groups, got %d", len(paths))
+	}
+	if paths[0] != "alpha" || paths[1] != "beta" || paths[2] != "gamma" {
+		t.Errorf("expected [alpha beta gamma], got %v", paths)
+	}
+}
+
+func TestGroupReorderAlreadyAtBottom(t *testing.T) {
+	storage := setupGroupsForReorder(t, "Alpha", "Beta", "Gamma")
+
+	// Move gamma down — already last, should be no-op
+	handleGroupReorder("_test", []string{"gamma", "--down"})
+
+	paths := reloadGroupPaths(t, storage)
+	if len(paths) < 3 {
+		t.Fatalf("expected 3 groups, got %d", len(paths))
+	}
+	if paths[0] != "alpha" || paths[1] != "beta" || paths[2] != "gamma" {
+		t.Errorf("expected [alpha beta gamma], got %v", paths)
+	}
+}
+
+func TestGroupReorderPositionClamp(t *testing.T) {
+	storage := setupGroupsForReorder(t, "Alpha", "Beta", "Gamma")
+
+	// Move alpha to position 99 (should clamp to last)
+	handleGroupReorder("_test", []string{"alpha", "--position", "99"})
+
+	paths := reloadGroupPaths(t, storage)
+	if len(paths) < 3 {
+		t.Fatalf("expected 3 groups, got %d", len(paths))
+	}
+	if paths[0] != "beta" || paths[1] != "gamma" || paths[2] != "alpha" {
+		t.Errorf("expected [beta gamma alpha], got %v", paths)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `agent-deck group reorder <name>` CLI subcommand with `--up`/`-u`, `--down`/`-d`, and `--position N`/`-p N` flags
- Wires existing model-layer `MoveGroupUp`/`MoveGroupDown` (already used by TUI) into the CLI, enabling automation and quick terminal usage
- Includes 6 tests covering up, down, absolute position, boundary no-ops, and clamping

## Test plan
- [x] `go test ./cmd/agent-deck/ -run TestGroupReorder -v -count=2` — all 6 tests pass across 2 iterations
- [x] `make fmt` — no formatting changes needed
- [x] `make build && ./build/agent-deck group reorder <name> --up` — manual verification
- [x] `./build/agent-deck group reorder <name> --position 0` — absolute positioning works
- [x] `./build/agent-deck group help` — help text includes reorder command and examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)