### PR TITLE
feat: add custom environment variables for conductor sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ agent-deck -p work conductor setup ops --description "Ops monitor"
 # Add more conductors to the same profile (no prompts)
 agent-deck -p work conductor setup infra --description "Infra watcher"
 agent-deck conductor setup personal --description "Personal project monitor"
+
+# Use a custom AI backend via environment variables
+agent-deck conductor setup glm-bot \
+  -env ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic \
+  -env ANTHROPIC_AUTH_TOKEN=<token> \
+  -env ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5
+
+# Or use an env file
+agent-deck conductor setup glm-bot -env-file ~/.conductor.env
 ```
 
 Each conductor gets its own directory, identity, and settings:
@@ -184,7 +193,7 @@ Each conductor gets its own directory, identity, and settings:
 ├── bridge.py           # Bridge daemon (Telegram/Slack, if configured)
 ├── ops/
 │   ├── CLAUDE.md       # Identity: "You are ops, a conductor for the work profile"
-│   ├── meta.json       # Config: name, profile, description
+│   ├── meta.json       # Config: name, profile, description, env vars
 │   ├── state.json      # Runtime state
 │   └── task-log.md     # Action log
 └── infra/

--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -14,6 +14,19 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
+// envVarFlags implements flag.Value for repeatable -env KEY=VALUE flags
+type envVarFlags map[string]string
+
+func (e *envVarFlags) String() string { return "" }
+func (e *envVarFlags) Set(val string) error {
+	parts := strings.SplitN(val, "=", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		return fmt.Errorf("invalid env format %q, expected KEY=VALUE", val)
+	}
+	(*e)[parts[0]] = parts[1]
+	return nil
+}
+
 // handleConductor dispatches conductor subcommands
 func handleConductor(profile string, args []string) {
 	if len(args) == 0 {
@@ -101,6 +114,9 @@ func handleConductorSetup(profile string, args []string) {
 	policyMD := fs.String("policy-md", "", "Custom POLICY.md for this conductor (e.g., ~/docs/my-policy.md)")
 	sharedClaudeMD := fs.String("shared-claude-md", "", "Custom path for shared CLAUDE.md (e.g., ~/docs/conductor-shared.md)")
 	sharedPolicyMD := fs.String("shared-policy-md", "", "Custom path for shared POLICY.md (e.g., ~/docs/conductor-policy.md)")
+	envFile := fs.String("env-file", "", "Path to .env file to source before conductor starts (e.g., ~/.conductor.env)")
+	envFlags := make(envVarFlags)
+	fs.Var(&envFlags, "env", "Environment variable in KEY=VALUE format (can be repeated)")
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 
 	fs.Usage = func() {
@@ -131,6 +147,12 @@ func handleConductorSetup(profile string, args []string) {
 		fmt.Println("        Custom path for shared CLAUDE.md (e.g., ~/docs/conductor-shared.md)")
 		fmt.Println("  -shared-policy-md string")
 		fmt.Println("        Custom path for shared POLICY.md (e.g., ~/docs/conductor-policy.md)")
+		fmt.Println()
+		fmt.Println("Environment:")
+		fmt.Println("  -env KEY=VALUE")
+		fmt.Println("        Environment variable for the conductor session (can be repeated)")
+		fmt.Println("  -env-file string")
+		fmt.Println("        Path to .env file to source before conductor starts")
 		fmt.Println()
 		fmt.Println("Output:")
 		fmt.Println("  -json")
@@ -375,7 +397,11 @@ func handleConductorSetup(profile string, args []string) {
 	}
 
 	clearOnCompact := !*noClearOnCompact
-	if err := session.SetupConductor(name, resolvedProfile, heartbeatEnabled, clearOnCompact, *description, *claudeMD, *policyMD); err != nil {
+	var envMap map[string]string
+	if len(envFlags) > 0 {
+		envMap = map[string]string(envFlags)
+	}
+	if err := session.SetupConductor(name, resolvedProfile, heartbeatEnabled, clearOnCompact, *description, *claudeMD, *policyMD, envMap, *envFile); err != nil {
 		fmt.Fprintf(os.Stderr, "Error setting up conductor %s: %v\n", name, err)
 		os.Exit(1)
 	}

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -105,6 +105,14 @@ type ConductorMeta struct {
 	// relying on CLAUDE.md and conductor state for continuity.
 	// Default: true (nil = use default true via GetClearOnCompact)
 	ClearOnCompact *bool `json:"clear_on_compact,omitempty"`
+
+	// Env holds inline environment variables for the conductor session.
+	// These are exported before the conductor command launches.
+	Env map[string]string `json:"env,omitempty"`
+
+	// EnvFile is a path to a .env file to source before the conductor command.
+	// Supports ~ and $VAR expansion.
+	EnvFile string `json:"env_file,omitempty"`
 }
 
 // GetClearOnCompact returns whether to block compaction and send /clear instead, defaulting to true
@@ -270,7 +278,11 @@ func SaveConductorMeta(meta *ConductorMeta) error {
 		return fmt.Errorf("failed to marshal meta.json: %w", err)
 	}
 	metaPath := filepath.Join(dir, "meta.json")
-	if err := os.WriteFile(metaPath, data, 0o644); err != nil {
+	perm := os.FileMode(0o644)
+	if len(meta.Env) > 0 || meta.EnvFile != "" {
+		perm = 0o600 // restrict access when env vars contain secrets
+	}
+	if err := os.WriteFile(metaPath, data, perm); err != nil {
 		return fmt.Errorf("failed to write meta.json: %w", err)
 	}
 	return nil
@@ -348,7 +360,7 @@ func matchesTemplateContent(actual, expected string) bool {
 // If customClaudeMD is provided, creates a symlink instead of writing the template.
 // If customPolicyMD is provided, creates a per-conductor POLICY.md symlink (overrides the shared POLICY.md).
 // It does NOT register the session (that's done by the CLI handler which has access to storage).
-func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact bool, description string, customClaudeMD string, customPolicyMD string) error {
+func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact bool, description string, customClaudeMD string, customPolicyMD string, env map[string]string, envFile string) error {
 	if err := ValidateConductorName(name); err != nil {
 		return err
 	}
@@ -399,6 +411,8 @@ func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact 
 		HeartbeatEnabled: heartbeatEnabled,
 		Description:      description,
 		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+		Env:              env,
+		EnvFile:          envFile,
 	}
 	if !clearOnCompact {
 		meta.ClearOnCompact = &clearOnCompact
@@ -677,7 +691,7 @@ const conductorHeartbeatPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 // SetupConductorProfile creates the conductor directory and CLAUDE.md for a profile.
 // Deprecated: Use SetupConductor instead. Kept for backward compatibility.
 func SetupConductorProfile(profile string) error {
-	return SetupConductor(profile, profile, true, true, "", "", "")
+	return SetupConductor(profile, profile, true, true, "", "", "", nil, "")
 }
 
 // createSymlinkWithExpansion creates a symlink from target to source, with ~ expansion and validation.

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -756,7 +756,7 @@ func TestSetupConductor_DefaultTemplate(t *testing.T) {
 	defer os.RemoveAll(filepath.Join(homeDir, ".agent-deck", "conductor", name))
 
 	// Setup without custom path (uses default template)
-	err := SetupConductor(name, profile, true, true, "test description", "", "")
+	err := SetupConductor(name, profile, true, true, "test description", "", "", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -812,7 +812,7 @@ func TestSetupConductor_CustomSymlink(t *testing.T) {
 	defer os.RemoveAll(filepath.Join(homeDir, ".agent-deck", "conductor", name))
 
 	// Setup with custom path (creates symlink)
-	err := SetupConductor(name, profile, true, true, "test description", customPath, "")
+	err := SetupConductor(name, profile, true, true, "test description", customPath, "", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -842,7 +842,7 @@ func TestSetupConductor_EmptyProfileNormalizesToDefault(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	name := "default-profile-conductor"
-	if err := SetupConductor(name, "", true, true, "", "", ""); err != nil {
+	if err := SetupConductor(name, "", true, true, "", "", "", nil, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -869,11 +869,11 @@ func TestSetupConductor_ProfileConflict(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	name := "profile-conflict"
-	if err := SetupConductor(name, "work", true, true, "", "", ""); err != nil {
+	if err := SetupConductor(name, "work", true, true, "", "", "", nil, ""); err != nil {
 		t.Fatalf("first setup failed: %v", err)
 	}
 
-	err := SetupConductor(name, "personal", true, true, "", "", "")
+	err := SetupConductor(name, "personal", true, true, "", "", "", nil, "")
 	if err == nil {
 		t.Fatal("expected conflict error when reusing conductor name across profiles")
 	}
@@ -1244,7 +1244,7 @@ func TestSetupConductor_PolicyOverride(t *testing.T) {
 	defer os.RemoveAll(filepath.Join(homeDir, ".agent-deck", "conductor", name))
 
 	// Setup with custom policy path (creates per-conductor symlink)
-	err := SetupConductor(name, profile, true, true, "test description", "", customPolicyPath)
+	err := SetupConductor(name, profile, true, true, "test description", "", customPolicyPath, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1423,7 +1423,7 @@ func TestSetupConductorCreatesLearnings(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	name := "learnings-test"
-	if err := SetupConductor(name, "default", true, true, "", "", ""); err != nil {
+	if err := SetupConductor(name, "default", true, true, "", "", "", nil, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1448,7 +1448,7 @@ func TestSetupConductorPreservesExistingLearnings(t *testing.T) {
 
 	name := "learnings-preserve"
 	// First setup creates the file
-	if err := SetupConductor(name, "default", true, true, "", "", ""); err != nil {
+	if err := SetupConductor(name, "default", true, true, "", "", "", nil, ""); err != nil {
 		t.Fatalf("first setup failed: %v", err)
 	}
 
@@ -1461,7 +1461,7 @@ func TestSetupConductorPreservesExistingLearnings(t *testing.T) {
 	}
 
 	// Re-running setup should NOT overwrite
-	if err := SetupConductor(name, "default", true, true, "", "", ""); err != nil {
+	if err := SetupConductor(name, "default", true, true, "", "", "", nil, ""); err != nil {
 		t.Fatalf("second setup failed: %v", err)
 	}
 
@@ -2082,5 +2082,68 @@ func TestBridgeTemplate_SafeSayConvertsMarkdown(t *testing.T) {
 	// The conversion must be conditional on "text" being in kwargs.
 	if !strings.Contains(template, `if "text" in kwargs:`) {
 		t.Error("_safe_say should guard _markdown_to_slack call with 'if \"text\" in kwargs:'")
+	}
+}
+
+func TestSetupConductor_WithEnvVars(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "test-env-conductor"
+	env := map[string]string{
+		"ANTHROPIC_BASE_URL":  "https://api.z.ai/api/anthropic",
+		"ANTHROPIC_AUTH_TOKEN": "test-token",
+	}
+	err := SetupConductor(name, "default", true, true, "env test", "", "", env, "~/.conductor.env")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	meta, err := LoadConductorMeta(name)
+	if err != nil {
+		t.Fatalf("failed to load meta: %v", err)
+	}
+
+	if len(meta.Env) != 2 {
+		t.Errorf("expected 2 env vars, got %d", len(meta.Env))
+	}
+	if meta.Env["ANTHROPIC_BASE_URL"] != "https://api.z.ai/api/anthropic" {
+		t.Errorf("unexpected ANTHROPIC_BASE_URL: %s", meta.Env["ANTHROPIC_BASE_URL"])
+	}
+	if meta.EnvFile != "~/.conductor.env" {
+		t.Errorf("unexpected env_file: %s", meta.EnvFile)
+	}
+
+	// Verify restricted file permissions when env vars present
+	dir, _ := ConductorNameDir(name)
+	info, err := os.Stat(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatalf("failed to stat meta.json: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected 0600 permissions for meta.json with env vars, got %o", info.Mode().Perm())
+	}
+}
+
+func TestSetupConductor_WithoutEnvVars(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "test-no-env-conductor"
+	err := SetupConductor(name, "default", true, true, "", "", "", nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	meta, err := LoadConductorMeta(name)
+	if err != nil {
+		t.Fatalf("failed to load meta: %v", err)
+	}
+
+	if meta.Env != nil {
+		t.Errorf("expected nil env, got %v", meta.Env)
+	}
+	if meta.EnvFile != "" {
+		t.Errorf("expected empty env_file, got %s", meta.EnvFile)
 	}
 }

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -15,7 +16,8 @@ import (
 //  2. Global [shell].env_files (in order)
 //  3. [shell].init_script (for direnv, nvm, etc.)
 //  4. Tool-specific env_file ([claude].env_file, [gemini].env_file, [tools.X].env_file)
-//  5. Inline env vars from [tools.X].env (highest priority)
+//  5. Inline env vars from [tools.X].env
+//  6. Conductor-specific env from meta.json (highest priority, overrides tool env)
 func (i *Instance) buildEnvSourceCommand() string {
 	var sources []string
 
@@ -60,9 +62,14 @@ func (i *Instance) buildEnvSourceCommand() string {
 		sources = append(sources, buildSourceCmd(resolved, ignoreMissing))
 	}
 
-	// 5. Inline env vars from [tools.X].env (highest priority)
+	// 5. Inline env vars from [tools.X].env
 	if inlineEnv := i.getToolInlineEnv(); inlineEnv != "" {
 		sources = append(sources, inlineEnv)
+	}
+
+	// 6. Conductor-specific env (highest priority, overrides tool env)
+	if conductorEnv := i.getConductorEnv(ignoreMissing); conductorEnv != "" {
+		sources = append(sources, conductorEnv)
 	}
 
 	if len(sources) == 0 {
@@ -241,4 +248,63 @@ func (i *Instance) getToolEnvFile() string {
 		}
 	}
 	return ""
+}
+
+// getConductorEnv returns shell export commands for conductor-specific env vars.
+// Checks if this session is a conductor (title starts with "conductor-") and loads
+// env and env_file from the conductor's meta.json.
+func (i *Instance) getConductorEnv(ignoreMissing bool) string {
+	name := strings.TrimPrefix(i.Title, "conductor-")
+	if name == "" || name == i.Title {
+		return "" // not a conductor session
+	}
+	meta, err := LoadConductorMeta(name)
+	if err != nil {
+		sessionLog.Warn("conductor_env_load_failed",
+			slog.String("conductor", name),
+			slog.String("error", err.Error()))
+		return ""
+	}
+
+	var parts []string
+
+	// Conductor env_file
+	if meta.EnvFile != "" {
+		resolved := resolvePath(meta.EnvFile, i.ProjectPath)
+		parts = append(parts, buildSourceCmd(resolved, ignoreMissing))
+	}
+
+	// Conductor inline env vars
+	if len(meta.Env) > 0 {
+		keys := make([]string, 0, len(meta.Env))
+		for k := range meta.Env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if !isValidEnvKey(k) {
+				continue // skip invalid env var names
+			}
+			parts = append(parts, fmt.Sprintf("export %s='%s'", k, strings.ReplaceAll(meta.Env[k], "'", "'\\''")))
+		}
+	}
+
+	return strings.Join(parts, " && ")
+}
+
+// isValidEnvKey checks that a string is a valid environment variable name.
+func isValidEnvKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i, c := range key {
+		if c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' || c == '_' {
+			continue
+		}
+		if i > 0 && c >= '0' && c <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/session/env_test.go
+++ b/internal/session/env_test.go
@@ -414,3 +414,66 @@ func TestShellSettings_GetIgnoreMissingEnvFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestGetConductorEnv(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "env-order-test"
+	env := map[string]string{
+		"MY_API_KEY": "conductor-value",
+		"DEBUG":      "true",
+	}
+	if err := SetupConductor(name, "default", true, true, "", "", "", env, ""); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	inst := &Instance{
+		Title:       "conductor-" + name,
+		Tool:        "claude",
+		ProjectPath: tmpHome,
+	}
+
+	result := inst.getConductorEnv(true)
+	if result == "" {
+		t.Fatal("getConductorEnv returned empty string for conductor with env vars")
+	}
+	if !strings.Contains(result, "export DEBUG='true'") {
+		t.Errorf("expected DEBUG export, got: %s", result)
+	}
+	if !strings.Contains(result, "export MY_API_KEY='conductor-value'") {
+		t.Errorf("expected MY_API_KEY export, got: %s", result)
+	}
+
+	// Verify ordering: DEBUG before MY_API_KEY (sorted)
+	debugIdx := strings.Index(result, "DEBUG")
+	apiIdx := strings.Index(result, "MY_API_KEY")
+	if debugIdx > apiIdx {
+		t.Error("env vars should be sorted alphabetically")
+	}
+}
+
+func TestGetConductorEnv_NonConductorSession(t *testing.T) {
+	inst := &Instance{
+		Title: "main",
+		Tool:  "claude",
+	}
+	if result := inst.getConductorEnv(true); result != "" {
+		t.Errorf("non-conductor session should return empty, got: %s", result)
+	}
+}
+
+func TestIsValidEnvKey(t *testing.T) {
+	valid := []string{"HOME", "MY_VAR", "_private", "A", "API_KEY_123"}
+	for _, k := range valid {
+		if !isValidEnvKey(k) {
+			t.Errorf("expected %q to be valid", k)
+		}
+	}
+	invalid := []string{"", "123BAD", "HAS SPACE", "key=val", "semi;colon", "a'b"}
+	for _, k := range invalid {
+		if isValidEnvKey(k) {
+			t.Errorf("expected %q to be invalid", k)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `-env KEY=VALUE` (repeatable) and `-env-file` flags to `conductor setup`, enabling conductors to run with custom environment variables. This matches the existing env support already available for custom tools via `[tools.X].env`.

Closes #256

## Changes

- **`internal/session/conductor.go`**: Add `Env map[string]string` and `EnvFile string` fields to `ConductorMeta`, update `SetupConductor()` signature
- **`internal/session/env.go`**: Add `getConductorEnv()` — detects conductor sessions by title prefix, loads `meta.json`, and builds export commands. Applied as step 6 in `buildEnvSourceCommand()` (highest priority, overrides tool env)
- **`cmd/agent-deck/conductor_cmd.go`**: Add `-env` and `-env-file` flags with `envVarFlags` type for repeatable KEY=VALUE parsing, update help text
- **`internal/session/conductor_test.go`**: Update existing test calls + add `TestSetupConductor_WithEnvVars` and `TestSetupConductor_WithoutEnvVars`

## Usage

```bash
# Setup conductor with Z.ai GLM backend (the original issue's use case)
agent-deck conductor setup mybot \
  -env ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic \
  -env ANTHROPIC_AUTH_TOKEN=<token> \
  -env ANTHROPIC_DEFAULT_SONNET_MODEL=glm-4.7 \
  -env ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5

# Or with an env file
agent-deck conductor setup mybot -env-file ~/.conductor.env
```

Env vars are stored in `meta.json` and exported before the conductor command launches via the existing `buildEnvSourceCommand()` pipeline.

## Test plan

- [x] `TestSetupConductor_WithEnvVars` — verifies env vars and env_file are stored in meta.json
- [x] `TestSetupConductor_WithoutEnvVars` — verifies nil env when none provided
- [x] All 15 existing conductor tests pass (no regressions)
- [x] Manual test: `conductor setup` with `-env` flags correctly writes to meta.json
- [ ] End-to-end test with actual alternative backend not performed (requires third-party API key). The env sourcing path (`buildEnvSourceCommand` → `getConductorEnv`) follows the same proven pattern used by custom tools.

## Note on pre-existing test failures

`TestLifecycle_StoppedRestartedRunningError` and `TestStatusCycle_ShellSessionWithCommand` fail on `main` as well — they are flaky tmux timing tests unrelated to this change.