### PR TITLE
Fix #342: enable extended-keys for Shift+Enter in tmux sessions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -551,7 +551,7 @@ configure_tmux() {
     local TMUX_CONF="$HOME/.tmux.conf"
     local MARKER="# agent-deck configuration"
     local VERSION_MARKER="# agent-deck-tmux-config-version:"
-    local CURRENT_VERSION="2"  # Bump this when config changes
+    local CURRENT_VERSION="3"  # Bump this when config changes
     local NEEDS_UPDATE=false
     local HAS_CONFIG=false
 
@@ -571,6 +571,7 @@ configure_tmux() {
             fi
             echo ""
             echo -e "${BLUE}What's new in this update:${NC}"
+            echo "  • Added extended-keys for Shift+Enter support (tmux 3.2+)"
             echo "  • Fixed mouse scrolling issues on WSL"
             echo "  • Added auto-enter copy-mode on scroll up"
             echo "  • Added explicit scroll bindings for copy-mode"
@@ -667,6 +668,9 @@ set -ag terminal-overrides \",*256col*:Tc\"
 # Performance
 set -sg escape-time 0
 set -g history-limit 50000
+
+# Extended keys: forward Shift+Enter and other modified keys to apps (tmux 3.2+)
+set -s extended-keys on
 
 # Mouse support (scroll + drag-to-copy)
 set -g mouse on

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1223,6 +1223,7 @@ func (s *Session) Start(command string) error {
 	// - set-clipboard on: Clipboard integration (Warp, iTerm2, kitty, etc.)
 	// - history-limit 10000: Large scrollback for AI agent output
 	// - escape-time 10: Fast Vim/editor responsiveness (default 500ms is too slow)
+	// - extended-keys on: Forward Shift+Enter and other modified keys to apps (tmux 3.2+)
 	// - terminal-features hyperlinks: Track hyperlinks like colors (tmux 3.4+, server-wide)
 	//
 	// Note: remain-on-exit is NOT set here — it is only enabled for sandbox sessions
@@ -1237,6 +1238,7 @@ func (s *Session) Start(command string) error {
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
 		"set-option", "-t", s.Name, "history-limit", "10000", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
+		"set", "-sq", "extended-keys", "on", ";",
 		"set", "-asq", "terminal-features", ",*:hyperlinks").Run()
 
 	// Apply user-specified tmux option overrides from config (after defaults).
@@ -1405,6 +1407,7 @@ func (s *Session) EnableMouseMode() error {
 	// Enhancements included:
 	// - set-clipboard on: OSC 52 clipboard integration (Warp, iTerm2, kitty, etc.)
 	// - allow-passthrough on: OSC 8 hyperlinks, advanced escape sequences (tmux 3.2+)
+	// - extended-keys on: Forward Shift+Enter and other modified keys to apps (tmux 3.2+)
 	// - terminal-features hyperlinks: Track hyperlinks like colors (tmux 3.4+)
 	// - history-limit 10000: Large scrollback for AI agent output
 	// - escape-time 10: Fast Vim/editor responsiveness (default 500ms is too slow)
@@ -1415,6 +1418,7 @@ func (s *Session) EnableMouseMode() error {
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
 		"set-option", "-t", s.Name, "history-limit", "10000", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
+		"set", "-sq", "extended-keys", "on", ";",
 		"set", "-asq", "terminal-features", ",*:hyperlinks")
 	// Ignore errors - all these are non-fatal enhancements
 	// Older tmux versions may not support some options


### PR DESCRIPTION
## Summary
- Added `set -sq extended-keys on` (tmux 3.2+ server option) to both session creation and lazy configuration paths in `internal/tmux/tmux.go`
- Updated `install.sh` tmux config template (v2 -> v3) to include `extended-keys on` for users who configure via the installer
- Uses `-sq` flags (server option + quiet) so older tmux versions that don't support `extended-keys` silently ignore it

## Root cause
tmux drops Shift+Enter (and other modified key sequences) by default. The `extended-keys on` server option tells tmux to forward these sequences to applications running inside panes when they request it.

## Test plan
- [x] `make ci` passes (lint + test + build)
- [ ] Manual: create session, attach, verify Shift+Enter produces newline in Claude Code
- [ ] Manual: verify no regression on older tmux (<3.2) where option is silently ignored

Fixes #342