### PR TITLE
fix(newdialog): skip single-letter shortcuts when text input is focused

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -692,6 +692,19 @@ func (d *NewDialog) currentTarget() focusTarget {
 	return d.focusTargets[d.focusIndex]
 }
 
+// isTextInputFocused returns true when a text input field is actively receiving keystrokes.
+func (d *NewDialog) isTextInputFocused() bool {
+	cur := d.currentTarget()
+	switch cur {
+	case focusName, focusPath, focusBranch:
+		return true
+	case focusCommand:
+		return d.commandCursor == 0
+	default:
+		return false
+	}
+}
+
 // indexOf returns the index of target in focusTargets, or -1 if absent.
 func (d *NewDialog) indexOf(target focusTarget) int {
 	for i, t := range d.focusTargets {
@@ -1030,7 +1043,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case "w":
-			if cur == focusCommand {
+			if cur == focusCommand && !d.isTextInputFocused() {
 				d.ToggleWorktree()
 				d.rebuildFocusTargets()
 				if d.worktreeEnabled {
@@ -1043,7 +1056,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case "s":
-			if cur == focusCommand {
+			if cur == focusCommand && !d.isTextInputFocused() {
 				d.ToggleSandbox()
 				if !d.sandboxEnabled {
 					d.inheritedExpanded = false
@@ -1053,7 +1066,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case "m":
-			if cur == focusCommand {
+			if cur == focusCommand && !d.isTextInputFocused() {
 				d.ToggleMultiRepo()
 				d.rebuildFocusTargets()
 				return d, nil
@@ -1103,7 +1116,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 
 		case "y":
 			selectedCmd := d.GetSelectedCommand()
-			if cur == focusCommand && (selectedCmd == "gemini" || selectedCmd == "codex") && d.toolOptions != nil {
+			if cur == focusCommand && !d.isTextInputFocused() && (selectedCmd == "gemini" || selectedCmd == "codex") && d.toolOptions != nil {
 				d.toolOptions.Update(msg)
 				return d, nil
 			}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -621,6 +621,7 @@ func TestNewDialog_WorktreeToggle_ViaKeyPress(t *testing.T) {
 	dialog.inheritedSettings = nil
 	dialog.rebuildFocusTargets()
 	dialog.focusIndex = 3 // Command field
+	dialog.commandCursor = 1 // Preset command (not custom/shell text input)
 
 	// Press 'w' to toggle worktree.
 	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}})
@@ -636,6 +637,7 @@ func TestNewDialog_WorktreeToggle_ViaKeyPress(t *testing.T) {
 
 	// Press 'w' again to disable (need to be on command field).
 	dialog.focusIndex = 3
+	dialog.commandCursor = 1 // Preset command (not custom/shell text input)
 	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}})
 
 	if dialog.worktreeEnabled {
@@ -1240,5 +1242,47 @@ func TestNewDialog_ToggleWorktree_CustomPrefix(t *testing.T) {
 
 	if got := d.branchInput.Value(); got != "dev/cool-feature" {
 		t.Errorf("expected branch %q, got %q", "dev/cool-feature", got)
+	}
+}
+
+func TestNewDialog_ShortcutsSkippedWhenTextInputFocused(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+	d.visible = true
+	d.rebuildFocusTargets()
+
+	// Focus on the Name field (a text input).
+	d.focusIndex = d.indexOf(focusName)
+
+	// Record initial toggle states.
+	sandbox := d.sandboxEnabled
+	worktree := d.worktreeEnabled
+	multiRepo := d.multiRepoEnabled
+
+	// Send shortcut keys while Name is focused — they should be ignored.
+	for _, key := range []string{"s", "w", "m", "y"} {
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
+		d.Update(msg)
+	}
+
+	if d.sandboxEnabled != sandbox {
+		t.Error("sandbox toggled while Name text input was focused")
+	}
+	if d.worktreeEnabled != worktree {
+		t.Error("worktree toggled while Name text input was focused")
+	}
+	if d.multiRepoEnabled != multiRepo {
+		t.Error("multi-repo toggled while Name text input was focused")
+	}
+
+	// Now focus on Command field with a preset command (not custom/shell).
+	cmdIdx := d.indexOf(focusCommand)
+	d.focusIndex = cmdIdx
+	d.commandCursor = 1 // preset command, not custom input
+
+	sandbox = d.sandboxEnabled
+	d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")})
+	if d.sandboxEnabled == sandbox {
+		t.Error("sandbox should toggle when command field is focused on a preset (non-text-input)")
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes #344 — single-letter shortcuts (`s`, `w`, `m`, `y`) were intercepting keystrokes in text input fields (Name, Path, Custom command) on the New Session form, preventing users from typing those letters
- Adds `isTextInputFocused()` helper to detect when a text input is actively receiving keystrokes
- Guards all four shortcut handlers so they only fire when no text input has focus

## Details

The `Update` method in `newdialog.go` matched shortcut keys and returned early before the text input `.Update(msg)` calls could run. The fix adds a check: when `focusName`, `focusPath`, or `focusBranch` is active, or when `focusCommand` with `commandCursor == 0` (custom command input), shortcuts are skipped and the keystroke falls through to the text input handler.

## Test plan

- [x] Added `TestNewDialog_ShortcutsSkippedWhenTextInputFocused` — verifies shortcuts are ignored on text inputs but still work on preset command selections
- [x] Fixed `TestNewDialog_WorktreeToggle_ViaKeyPress` to set `commandCursor = 1` so it correctly tests the shortcut on a non-text-input field
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)