### PR TITLE
Fix #344: prevent shortcut keys from intercepting text input in new session dialog

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -785,6 +785,21 @@ func (d *NewDialog) updateFocus() {
 }
 
 // Update handles key messages.
+// isTextInputFocused returns true when a text input field is actively receiving
+// keystrokes. Single-letter shortcuts must be suppressed in this state.
+func (d *NewDialog) isTextInputFocused() bool {
+	switch d.currentTarget() {
+	case focusName, focusPath, focusBranch:
+		return true
+	case focusCommand:
+		return d.commandCursor == 0 // custom command input
+	case focusMultiRepo:
+		return d.multiRepoEditing
+	default:
+		return false
+	}
+}
+
 func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 	if !d.visible {
 		return d, nil
@@ -1030,7 +1045,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case "w":
-			if cur == focusCommand {
+			if cur == focusCommand && !d.isTextInputFocused() {
 				d.ToggleWorktree()
 				d.rebuildFocusTargets()
 				if d.worktreeEnabled {
@@ -1043,7 +1058,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case "s":
-			if cur == focusCommand {
+			if cur == focusCommand && !d.isTextInputFocused() {
 				d.ToggleSandbox()
 				if !d.sandboxEnabled {
 					d.inheritedExpanded = false
@@ -1053,7 +1068,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case "m":
-			if cur == focusCommand {
+			if cur == focusCommand && !d.isTextInputFocused() {
 				d.ToggleMultiRepo()
 				d.rebuildFocusTargets()
 				return d, nil
@@ -1102,14 +1117,16 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case "y":
-			selectedCmd := d.GetSelectedCommand()
-			if cur == focusCommand && (selectedCmd == "gemini" || selectedCmd == "codex") && d.toolOptions != nil {
-				d.toolOptions.Update(msg)
-				return d, nil
-			}
-			if cur == focusOptions && d.toolOptions != nil {
-				d.toolOptions.Update(msg)
-				return d, nil
+			if !d.isTextInputFocused() {
+				selectedCmd := d.GetSelectedCommand()
+				if cur == focusCommand && (selectedCmd == "gemini" || selectedCmd == "codex") && d.toolOptions != nil {
+					d.toolOptions.Update(msg)
+					return d, nil
+				}
+				if cur == focusOptions && d.toolOptions != nil {
+					d.toolOptions.Update(msg)
+					return d, nil
+				}
 			}
 
 		case " ":

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -619,6 +619,7 @@ func TestNewDialog_WorktreeToggle_ViaKeyPress(t *testing.T) {
 	dialog.Show()
 	dialog.sandboxEnabled = false
 	dialog.inheritedSettings = nil
+	dialog.commandCursor = 1 // preset command (not custom input)
 	dialog.rebuildFocusTargets()
 	dialog.focusIndex = 3 // Command field
 
@@ -640,6 +641,46 @@ func TestNewDialog_WorktreeToggle_ViaKeyPress(t *testing.T) {
 
 	if dialog.worktreeEnabled {
 		t.Error("Worktree should be disabled after pressing 'w' again")
+	}
+}
+
+func TestNewDialog_ShortcutsBlockedDuringTextInput(t *testing.T) {
+	dialog := NewNewDialog()
+	dialog.Show()
+	dialog.sandboxEnabled = false
+	dialog.inheritedSettings = nil
+	dialog.commandCursor = 0 // custom command input (text field active)
+	dialog.rebuildFocusTargets()
+
+	// Navigate to command field.
+	cmdIdx := dialog.indexOf(focusCommand)
+	dialog.focusIndex = cmdIdx
+	dialog.updateFocus()
+
+	// Press 's' — should NOT toggle sandbox when custom command input is focused.
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if dialog.sandboxEnabled {
+		t.Error("Pressing 's' on custom command input should type, not toggle sandbox")
+	}
+
+	// Press 'w' — should NOT toggle worktree.
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}})
+	if dialog.worktreeEnabled {
+		t.Error("Pressing 'w' on custom command input should type, not toggle worktree")
+	}
+
+	// Press 'm' — should NOT toggle multi-repo.
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	if dialog.multiRepoEnabled {
+		t.Error("Pressing 'm' on custom command input should type, not toggle multi-repo")
+	}
+
+	// Also verify shortcuts don't fire on name field.
+	dialog.focusIndex = 0 // focusName
+	dialog.updateFocus()
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if dialog.sandboxEnabled {
+		t.Error("Pressing 's' on name input should not toggle sandbox")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Added `isTextInputFocused()` helper that detects when a text input field (name, path, branch, or custom command) is actively receiving keystrokes
- Guarded all single-letter shortcut handlers (`s`, `w`, `m`, `y`) so they only fire when no text input is focused
- Added `TestNewDialog_ShortcutsBlockedDuringTextInput` test covering the fix

Fixes #344