### PR TITLE
fix(bridge): remove FileHandler to prevent duplicate log lines

### DIFF
--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -34,8 +34,6 @@ from aiogram.filters import Command, CommandStart
 AGENT_DECK_DIR = Path.home() / ".agent-deck"
 CONFIG_PATH = AGENT_DECK_DIR / "config.toml"
 CONDUCTOR_DIR = AGENT_DECK_DIR / "conductor"
-LOG_PATH = CONDUCTOR_DIR / "bridge.log"
-
 # Telegram message length limit
 TG_MAX_LENGTH = 4096
 
@@ -50,7 +48,6 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
-        logging.FileHandler(LOG_PATH, encoding="utf-8"),
         logging.StreamHandler(sys.stdout),
     ],
 )


### PR DESCRIPTION
## Summary
- Remove `logging.FileHandler` from bridge.py — when running under launchd, the plist already redirects stdout/stderr to `bridge.log`, so the FileHandler was causing every log line to appear twice
- Remove unused `LOG_PATH` constant (no longer referenced after the fix)

## Context
The bridge is typically run as a launchd daemon with stdout/stderr redirected to a log file via the plist configuration. The `logging.basicConfig` was configured with **both** a `FileHandler` (writing directly to `bridge.log`) and a `StreamHandler` (writing to stdout). Since launchd captures stdout to the same `bridge.log`, every log entry was written twice.

The fix keeps only the `StreamHandler`, which is the correct approach — let the process manager handle log file persistence.

## Test plan
- [ ] Run bridge under launchd and verify log lines appear only once in `bridge.log`
- [ ] Run bridge directly (`python3 bridge.py`) and verify logs appear on stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)