### PR TITLE
Fix #350: detect Codex › prompt marker in ready detection

### DIFF
--- a/internal/tmux/detector.go
+++ b/internal/tmux/detector.go
@@ -70,8 +70,16 @@ func (d *PromptDetector) HasPrompt(content string) bool {
 			strings.Contains(lower, "ctrl+c to interrupt") {
 			return false
 		}
-		return strings.Contains(content, "codex>") ||
-			strings.Contains(content, "Continue?")
+		// Direct prompt strings
+		if strings.Contains(content, "codex>") ||
+			strings.Contains(content, "Continue?") ||
+			strings.Contains(content, "How can I help") {
+			return true
+		}
+		// Codex uses › (U+203A) as its prompt marker, similar to Claude's ❯.
+		// The prompt appears as "› suggestion text" near the bottom of the pane
+		// with a status bar (model · path · branch · usage) below it.
+		return d.hasCodexPromptMarker(content)
 
 	default:
 		// Generic shell - check for common prompts
@@ -321,6 +329,34 @@ func (d *PromptDetector) hasClaudePrompt(content string) bool {
 		}
 	}
 
+	return false
+}
+
+// hasCodexPromptMarker detects the › (U+203A) prompt marker used by Codex CLI.
+// Codex renders its prompt as:
+//
+//	› Run /review on my current changes
+//	  gpt-5.4 · ~/path/to/project · branch · 100% left · 0% used
+//
+// The marker appears at (or near) the start of a line in the last few lines.
+func (d *PromptDetector) hasCodexPromptMarker(content string) bool {
+	lines := strings.Split(content, "\n")
+	// Check last 10 non-empty lines (prompt may not be the very last line
+	// due to the status bar below it).
+	var lastLines []string
+	for i := len(lines) - 1; i >= 0 && len(lastLines) < 10; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line != "" {
+			lastLines = append(lastLines, line)
+		}
+	}
+	for _, line := range lastLines {
+		clean := strings.TrimSpace(StripANSI(line))
+		if clean == "›" || clean == "› " ||
+			strings.HasPrefix(clean, "› ") {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -78,7 +78,7 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 				"esc to interrupt",
 				"press esc to interrupt",
 			},
-			PromptPatterns: []string{"How can I help", "codex>", "Continue?"},
+			PromptPatterns: []string{"How can I help", "codex>", "Continue?", `re:(?m)^\s*›\s`},
 		}
 	case "pi":
 		return &RawPatterns{

--- a/internal/tmux/patterns_test.go
+++ b/internal/tmux/patterns_test.go
@@ -89,6 +89,41 @@ func TestDefaultRawPatterns_Codex(t *testing.T) {
 	}
 }
 
+func TestDefaultRawPatterns_Codex_PromptRegex(t *testing.T) {
+	raw := DefaultRawPatterns("codex")
+	if raw == nil {
+		t.Fatal("expected non-nil for codex")
+	}
+	resolved, err := CompilePatterns(raw)
+	if err != nil {
+		t.Fatalf("unexpected compile error: %v", err)
+	}
+
+	// The › regex should match Codex's actual prompt format
+	tests := []struct {
+		content string
+		want    bool
+	}{
+		{"› Run /review on my current changes", true},
+		{"  › ", true},
+		{"› ", true},
+		{"some output without marker", false},
+		{"codex>", false}, // matched by string pattern, not regex
+	}
+	for _, tt := range tests {
+		matched := false
+		for _, re := range resolved.PromptRegexps {
+			if re.MatchString(tt.content) {
+				matched = true
+				break
+			}
+		}
+		if matched != tt.want {
+			t.Errorf("codex prompt regex on %q = %v, want %v", tt.content, matched, tt.want)
+		}
+	}
+}
+
 func TestDefaultRawPatterns_Pi(t *testing.T) {
 	raw := DefaultRawPatterns("pi")
 	if raw == nil {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -279,9 +279,15 @@ func TestPromptDetector(t *testing.T) {
 	}{
 		{"codex>", true},
 		{"Continue?", true},
-		{"How can I help today?", false}, // plain prose should not trigger by itself
-		{"some output >", false},         // generic trailing '>' should not be treated as Codex prompt
-		{"esc to interrupt", false},      // busy indicator, not prompt
+		{"How can I help today?", true},               // initial Codex prompt (#350)
+		{"some output >", false},                      // generic trailing '>' should not be treated as Codex prompt
+		{"esc to interrupt", false},                   // busy indicator, not prompt
+		{"› Run /review on my current changes", true}, // Codex › prompt marker (#350)
+		{"›", true},                                   // bare › prompt marker (#350)
+		{"  › ", true},                                // › with surrounding whitespace (#350)
+		{"› Run /review\n\n  gpt-5.4 · ~/proj · main · 100% left · 0% used", true}, // full Codex prompt with status bar (#350)
+		{"ctrl+c to interrupt\n› Run /review on my current changes", false},        // busy overrides › prompt (#350)
+		{"Processing files...\nesc to interrupt\n› previous suggestion", false},    // busy overrides › prompt (#350)
 	}
 
 	for _, tt := range codexTests {


### PR DESCRIPTION
## Summary
- Codex CLI uses `›` (U+203A) as its prompt marker, but agent-deck only looked for `"codex>"` and `"Continue?"`, causing `session send` and `launch-subagent.sh` to always timeout with "agent not ready after 80 seconds"
- Added `›` prompt marker detection in both `PromptDetector.HasPrompt()` (used by `waitForAgentReady`) and the compiled regex patterns (used by `GetStatus()`)
- Added `"How can I help"` to the detector (was already in `patterns.go` but missing from `detector.go`)

## Test plan
- [x] Added test cases for `›` prompt marker in `tmux_test.go` (bare, with suggestion text, with status bar, busy override)
- [x] Added regex compilation test in `patterns_test.go`
- [x] All existing Codex prompt detection tests still pass
- [x] `go test -race ./internal/tmux/... ./internal/send/... ./cmd/agent-deck/...` all pass
- [ ] Manual: `agent-deck session send` to a running Codex session

Fixes #350