### PR TITLE
feat(conductor): support Codex agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ See the [Docker Sandbox Guide](skills/agent-deck/references/sandbox.md) for the 
 
 ### Conductor
 
-Conductors are persistent Claude Code sessions that monitor and orchestrate all your other sessions. They watch for sessions that need help, auto-respond when confident, and escalate to you when they can't. Optionally connect **Telegram** and/or **Slack** for remote control.
+Conductors are persistent agent sessions that monitor and orchestrate all your other sessions. They watch for sessions that need help, auto-respond when confident, and escalate to you when they can't. Optionally connect **Telegram** and/or **Slack** for remote control.
 
 Create as many conductors as you need per profile:
 
@@ -175,7 +175,10 @@ agent-deck -p work conductor setup ops --description "Ops monitor"
 agent-deck -p work conductor setup infra --description "Infra watcher"
 agent-deck conductor setup personal --description "Personal project monitor"
 
-# Use a custom AI backend via environment variables
+# Run a conductor on Codex instead of Claude Code
+agent-deck -p work conductor setup review --agent codex --description "Codex reviewer"
+
+# Use a custom agent endpoint via environment variables
 agent-deck conductor setup glm-bot \
   -env ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic \
   -env ANTHROPIC_AUTH_TOKEN=<token> \
@@ -189,17 +192,20 @@ Each conductor gets its own directory, identity, and settings:
 
 ```
 ~/.agent-deck/conductor/
-├── CLAUDE.md           # Shared knowledge (CLI ref, protocols, rules)
+├── CLAUDE.md           # Shared knowledge for Claude conductors
+├── AGENTS.md           # Shared knowledge for Codex conductors
 ├── bridge.py           # Bridge daemon (Telegram/Slack, if configured)
 ├── ops/
 │   ├── CLAUDE.md       # Identity: "You are ops, a conductor for the work profile"
 │   ├── meta.json       # Config: name, profile, description, env vars
 │   ├── state.json      # Runtime state
 │   └── task-log.md     # Action log
-└── infra/
-    ├── CLAUDE.md
+└── review/
+    ├── AGENTS.md
     └── meta.json
 ```
+
+Claude conductors use `CLAUDE.md`. Codex conductors use `AGENTS.md`. Shared `POLICY.md` and `LEARNINGS.md` remain agent-neutral.
 
 **CLI commands:**
 
@@ -279,7 +285,7 @@ Agent Deck works with any terminal-based AI tool:
 | **Claude Code** | Full (status, MCP, fork, resume) |
 | **Gemini CLI** | Full (status, MCP, resume) |
 | **OpenCode** | Status detection, organization |
-| **Codex** | Status detection, organization |
+| **Codex** | Status detection, organization, conductor |
 | **Cursor** (terminal) | Status detection, organization |
 | **Custom tools** | Configurable via `[tools.*]` in config.toml |
 

--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -106,10 +106,13 @@ func parseConductorSetupArgs(fs *flag.FlagSet, args []string) (string, []string,
 // handleConductorSetup sets up a named conductor with directories, sessions, and optionally the Telegram bridge
 func handleConductorSetup(profile string, args []string) {
 	fs := flag.NewFlagSet("conductor setup", flag.ExitOnError)
-	noClearOnCompact := fs.Bool("no-clear-on-compact", false, "Allow normal compaction instead of /clear when context fills up")
+	agent := fs.String("agent", session.ConductorAgentClaude, "Conductor agent runtime (claude or codex)")
+	noClearOnCompact := fs.Bool("no-clear-on-compact", false, "Claude-only: allow normal compaction instead of /clear when context fills up")
 	description := fs.String("description", "", "Description for this conductor")
 	heartbeat := fs.Bool("heartbeat", false, "Enable heartbeat for this conductor (default)")
 	noHeartbeat := fs.Bool("no-heartbeat", false, "Disable heartbeat for this conductor")
+	instructionsMD := fs.String("instructions-md", "", "Custom instructions file for this conductor (agent-specific, e.g., ~/docs/conductor-ops.md)")
+	sharedInstructionsMD := fs.String("shared-instructions-md", "", "Custom shared instructions file for all conductors of this agent")
 	claudeMD := fs.String("claude-md", "", "Custom CLAUDE.md for this conductor (e.g., ~/docs/conductor-ryan.md)")
 	policyMD := fs.String("policy-md", "", "Custom POLICY.md for this conductor (e.g., ~/docs/my-policy.md)")
 	sharedClaudeMD := fs.String("shared-claude-md", "", "Custom path for shared CLAUDE.md (e.g., ~/docs/conductor-shared.md)")
@@ -122,29 +125,37 @@ func handleConductorSetup(profile string, args []string) {
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck [-p profile] conductor setup <name> [options]")
 		fmt.Println()
-		fmt.Println("Set up a named conductor: creates directory, CLAUDE.md, meta.json, and registers session.")
+		fmt.Println("Set up a named conductor: creates its directory, instructions file, meta.json, and session registration.")
 		fmt.Println("Multiple conductors can exist per profile.")
 		fmt.Println()
 		fmt.Println("Arguments:")
 		fmt.Println("  <name>    Conductor name (e.g., ryan, infra, monitor)")
 		fmt.Println()
 		fmt.Println("Options:")
+		fmt.Println("  -agent string")
+		fmt.Println("        Conductor agent runtime: claude or codex (default \"claude\")")
 		fmt.Println("  -description string")
 		fmt.Println("        Description for this conductor")
 		fmt.Println("  -heartbeat")
 		fmt.Println("        Enable heartbeat for this conductor (default)")
 		fmt.Println("  -no-heartbeat")
 		fmt.Println("        Disable heartbeat for this conductor")
+		fmt.Println("  -no-clear-on-compact")
+		fmt.Println("        Claude-only: allow normal compaction instead of /clear when context fills up")
 		fmt.Println()
 		fmt.Println("Conductor-specific files:")
+		fmt.Println("  -instructions-md string")
+		fmt.Println("        Custom instructions file for this conductor (agent-specific)")
 		fmt.Println("  -claude-md string")
-		fmt.Println("        Custom CLAUDE.md for this conductor (e.g., ~/docs/conductor-ryan.md)")
+		fmt.Println("        Deprecated Claude-only alias for -instructions-md")
 		fmt.Println("  -policy-md string")
 		fmt.Println("        Custom POLICY.md for this conductor (e.g., ~/docs/my-policy.md)")
 		fmt.Println()
 		fmt.Println("Shared files (all conductors):")
+		fmt.Println("  -shared-instructions-md string")
+		fmt.Println("        Custom shared instructions file for all conductors of this agent")
 		fmt.Println("  -shared-claude-md string")
-		fmt.Println("        Custom path for shared CLAUDE.md (e.g., ~/docs/conductor-shared.md)")
+		fmt.Println("        Deprecated Claude-only alias for -shared-instructions-md")
 		fmt.Println("  -shared-policy-md string")
 		fmt.Println("        Custom path for shared POLICY.md (e.g., ~/docs/conductor-policy.md)")
 		fmt.Println()
@@ -178,6 +189,31 @@ func handleConductorSetup(profile string, args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+	spec, err := session.GetConductorAgentSpec(*agent)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	if *instructionsMD != "" && *claudeMD != "" {
+		fmt.Fprintln(os.Stderr, "Error: use only one of -instructions-md or -claude-md")
+		os.Exit(1)
+	}
+	if *sharedInstructionsMD != "" && *sharedClaudeMD != "" {
+		fmt.Fprintln(os.Stderr, "Error: use only one of -shared-instructions-md or -shared-claude-md")
+		os.Exit(1)
+	}
+	resolvedInstructionsMD := *instructionsMD
+	if resolvedInstructionsMD == "" {
+		resolvedInstructionsMD = *claudeMD
+	}
+	resolvedSharedInstructionsMD := *sharedInstructionsMD
+	if resolvedSharedInstructionsMD == "" {
+		resolvedSharedInstructionsMD = *sharedClaudeMD
+	}
+	if spec.Agent != session.ConductorAgentClaude && (*claudeMD != "" || *sharedClaudeMD != "") {
+		fmt.Fprintln(os.Stderr, "Error: -claude-md and -shared-claude-md are only valid with --agent=claude")
+		os.Exit(1)
+	}
 	resolvedProfile := session.GetEffectiveProfile(profile)
 
 	// Auto-migrate legacy conductors
@@ -208,7 +244,7 @@ func handleConductorSetup(profile string, args []string) {
 		fmt.Println("Conductor Setup")
 		fmt.Println("===============")
 		fmt.Println()
-		fmt.Println("The conductor system lets you create named persistent Claude sessions that")
+		fmt.Printf("The conductor system lets you create named persistent %s conductor sessions that\n", spec.DisplayName)
 		fmt.Println("monitor and orchestrate all your agent-deck sessions.")
 		fmt.Println()
 
@@ -364,13 +400,13 @@ func handleConductorSetup(profile string, args []string) {
 		fmt.Println("[ok] Conductor config saved to config.toml")
 	}
 
-	// Step 3: Install/update shared CLAUDE.md
-	if err := session.InstallSharedClaudeMD(*sharedClaudeMD); err != nil {
-		fmt.Fprintf(os.Stderr, "Error installing shared CLAUDE.md: %v\n", err)
+	// Step 3: Install/update shared instructions file for the selected agent
+	if err := session.InstallSharedConductorInstructions(spec.Agent, resolvedSharedInstructionsMD); err != nil {
+		fmt.Fprintf(os.Stderr, "Error installing shared %s: %v\n", spec.InstructionsFileName, err)
 		os.Exit(1)
 	}
 	if !*jsonOutput {
-		fmt.Println("[ok] Shared CLAUDE.md installed/updated")
+		fmt.Printf("[ok] Shared %s installed/updated\n", spec.InstructionsFileName)
 	}
 
 	// Step 3b: Install/update shared POLICY.md
@@ -397,16 +433,19 @@ func handleConductorSetup(profile string, args []string) {
 	}
 
 	clearOnCompact := !*noClearOnCompact
+	if !spec.SupportsClearOnCompact {
+		clearOnCompact = false
+	}
 	var envMap map[string]string
 	if len(envFlags) > 0 {
 		envMap = map[string]string(envFlags)
 	}
-	if err := session.SetupConductor(name, resolvedProfile, heartbeatEnabled, clearOnCompact, *description, *claudeMD, *policyMD, envMap, *envFile); err != nil {
+	if err := session.SetupConductorWithAgent(name, resolvedProfile, spec.Agent, heartbeatEnabled, clearOnCompact, *description, resolvedInstructionsMD, *policyMD, envMap, *envFile); err != nil {
 		fmt.Fprintf(os.Stderr, "Error setting up conductor %s: %v\n", name, err)
 		os.Exit(1)
 	}
 	if !*jsonOutput {
-		fmt.Printf("  [ok] Directory, CLAUDE.md, and meta.json created\n")
+		fmt.Printf("  [ok] Directory, %s, and meta.json created\n", spec.InstructionsFileName)
 	}
 
 	// Step 5: Register session in the profile's storage
@@ -437,18 +476,26 @@ func handleConductorSetup(profile string, args []string) {
 	if existingID != "" {
 		sessionID = existingID
 		existed = true
+		for _, inst := range instances {
+			if inst.ID != existingID {
+				continue
+			}
+			inst.Tool = spec.Agent
+			inst.Command = spec.DefaultCommand
+			break
+		}
 		if !*jsonOutput {
-			fmt.Printf("  [ok] Session '%s' already registered (ID: %s)\n", sessionTitle, existingID[:8])
+			fmt.Printf("  [ok] Session '%s' already registered and synced to %s (ID: %s)\n", sessionTitle, spec.Agent, existingID[:8])
 		}
 	} else {
 		dir, _ := session.ConductorNameDir(name)
-		newInst := session.NewInstanceWithGroupAndTool(sessionTitle, dir, "conductor", "claude")
-		newInst.Command = "claude"
+		newInst := session.NewInstanceWithGroupAndTool(sessionTitle, dir, "conductor", spec.Agent)
+		newInst.Command = spec.DefaultCommand
 		instances = append(instances, newInst)
 
 		sessionID = newInst.ID
 		if !*jsonOutput {
-			fmt.Printf("  [ok] Session '%s' registered (ID: %s)\n", sessionTitle, newInst.ID[:8])
+			fmt.Printf("  [ok] Session '%s' registered as %s (ID: %s)\n", sessionTitle, spec.Agent, newInst.ID[:8])
 		}
 	}
 
@@ -528,6 +575,7 @@ func handleConductorSetup(profile string, args []string) {
 	if *jsonOutput {
 		data := map[string]any{
 			"success":                 true,
+			"agent":                   spec.Agent,
 			"name":                    name,
 			"profile":                 resolvedProfile,
 			"session":                 sessionID,
@@ -553,6 +601,7 @@ func handleConductorSetup(profile string, args []string) {
 	fmt.Println("Conductor setup complete!")
 	fmt.Println()
 	fmt.Printf("  Name:      %s\n", name)
+	fmt.Printf("  Agent:     %s\n", spec.Agent)
 	fmt.Printf("  Profile:   %s\n", resolvedProfile)
 	fmt.Printf("  Heartbeat: %v\n", heartbeatEnabled)
 	if *description != "" {
@@ -750,6 +799,7 @@ func handleConductorTeardown(_ string, args []string) {
 			_ = os.Remove(filepath.Join(condDir, "bridge.py"))
 			_ = os.Remove(filepath.Join(condDir, "bridge.log"))
 			_ = os.Remove(filepath.Join(condDir, "CLAUDE.md"))
+			_ = os.Remove(filepath.Join(condDir, "AGENTS.md"))
 			_ = os.Remove(filepath.Join(condDir, "POLICY.md"))
 			_ = os.Remove(filepath.Join(condDir, "LEARNINGS.md"))
 			_ = os.Remove(condDir) // Remove dir if empty
@@ -846,6 +896,7 @@ func handleConductorStatus(_ string, args []string) {
 
 	type conductorStatus struct {
 		Name        string `json:"name"`
+		Agent       string `json:"agent"`
 		Profile     string `json:"profile"`
 		DirExists   bool   `json:"dir_exists"`
 		SessionID   string `json:"session_id,omitempty"`
@@ -859,6 +910,7 @@ func handleConductorStatus(_ string, args []string) {
 	for _, meta := range conductors {
 		cs := conductorStatus{
 			Name:        meta.Name,
+			Agent:       meta.GetAgent(),
 			Profile:     meta.Profile,
 			DirExists:   session.IsConductorSetup(meta.Name),
 			Heartbeat:   meta.HeartbeatEnabled,
@@ -951,7 +1003,7 @@ func handleConductorStatus(_ string, args []string) {
 			desc = fmt.Sprintf("  %q", cs.Description)
 		}
 
-		fmt.Printf("  %s %s [%s] heartbeat:%s  (%s)%s\n", statusIcon, cs.Name, cs.Profile, hb, statusText, desc)
+		fmt.Printf("  %s %s [%s] agent:%s heartbeat:%s  (%s)%s\n", statusIcon, cs.Name, cs.Profile, cs.Agent, hb, statusText, desc)
 	}
 	fmt.Println()
 
@@ -1055,7 +1107,7 @@ func handleConductorList(profile string, args []string) {
 			desc = fmt.Sprintf("  %q", meta.Description)
 		}
 
-		fmt.Printf("  %-12s [%s]  heartbeat:%-3s  %-10s%s\n", meta.Name, meta.Profile, hb, statusText, desc)
+		fmt.Printf("  %-12s [%s]  agent:%-6s heartbeat:%-3s  %-10s%s\n", meta.Name, meta.Profile, meta.GetAgent(), hb, statusText, desc)
 	}
 	fmt.Println()
 }
@@ -1111,6 +1163,7 @@ func printConductorHelp() {
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  agent-deck -p work conductor setup ryan --description \"Ryan project\"")
+	fmt.Println("  agent-deck -p work conductor setup review --agent codex --description \"Codex reviewer\"")
 	fmt.Println("  agent-deck -p work conductor setup infra --no-heartbeat")
 	fmt.Println("  agent-deck conductor list")
 	fmt.Println("  agent-deck conductor status")

--- a/cmd/agent-deck/conductor_cmd_test.go
+++ b/cmd/agent-deck/conductor_cmd_test.go
@@ -8,10 +8,13 @@ import (
 
 func newConductorSetupFlagSet() *flag.FlagSet {
 	fs := flag.NewFlagSet("conductor setup", flag.ContinueOnError)
+	fs.String("agent", "claude", "")
 	fs.Bool("json", false, "")
 	fs.Bool("no-heartbeat", false, "")
 	fs.Bool("heartbeat", false, "")
 	fs.String("description", "", "")
+	fs.String("instructions-md", "", "")
+	fs.String("shared-instructions-md", "", "")
 	fs.String("shared-claude-md", "", "")
 	fs.String("claude-md", "", "")
 	return fs
@@ -26,6 +29,8 @@ func TestParseConductorSetupArgs(t *testing.T) {
 		wantDesc   string
 		wantJSON   bool
 		wantNoHB   bool
+		wantAgent  string
+		wantInstr  string
 		wantHasErr bool
 	}{
 		{
@@ -41,11 +46,19 @@ func TestParseConductorSetupArgs(t *testing.T) {
 			wantDesc: "Ops monitor",
 		},
 		{
-			name:     "bool flags and name",
-			args:     []string{"--json", "--no-heartbeat", "ops"},
-			wantName: "ops",
-			wantJSON: true,
-			wantNoHB: true,
+			name:      "bool flags and name",
+			args:      []string{"--json", "--no-heartbeat", "ops"},
+			wantName:  "ops",
+			wantJSON:  true,
+			wantNoHB:  true,
+			wantAgent: "claude",
+		},
+		{
+			name:      "agent and instructions flags",
+			args:      []string{"--agent", "codex", "--instructions-md", "~/docs/ops.md", "ops"},
+			wantName:  "ops",
+			wantAgent: "codex",
+			wantInstr: "~/docs/ops.md",
 		},
 		{
 			name:       "extra positional args",
@@ -81,6 +94,17 @@ func TestParseConductorSetupArgs(t *testing.T) {
 			}
 			if fs.Lookup("no-heartbeat").Value.String() == "true" != tt.wantNoHB {
 				t.Fatalf("no-heartbeat = %v, want %v", fs.Lookup("no-heartbeat").Value.String() == "true", tt.wantNoHB)
+			}
+			gotAgent := fs.Lookup("agent").Value.String()
+			if tt.wantAgent == "" {
+				tt.wantAgent = "claude"
+			}
+			if gotAgent != tt.wantAgent {
+				t.Fatalf("agent = %q, want %q", gotAgent, tt.wantAgent)
+			}
+			gotInstr := fs.Lookup("instructions-md").Value.String()
+			if gotInstr != tt.wantInstr {
+				t.Fatalf("instructions-md = %q, want %q", gotInstr, tt.wantInstr)
 			}
 		})
 	}

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -14,6 +14,37 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/platform"
 )
 
+const (
+	ConductorAgentClaude = "claude"
+	ConductorAgentCodex  = "codex"
+)
+
+// ConductorAgentSpec describes conductor-specific behavior for an agent runtime.
+type ConductorAgentSpec struct {
+	Agent                  string
+	DisplayName            string
+	DefaultCommand         string
+	InstructionsFileName   string
+	SupportsClearOnCompact bool
+}
+
+var conductorAgentSpecs = map[string]ConductorAgentSpec{
+	ConductorAgentClaude: {
+		Agent:                  ConductorAgentClaude,
+		DisplayName:            "Claude Code",
+		DefaultCommand:         "claude",
+		InstructionsFileName:   "CLAUDE.md",
+		SupportsClearOnCompact: true,
+	},
+	ConductorAgentCodex: {
+		Agent:                  ConductorAgentCodex,
+		DisplayName:            "Codex",
+		DefaultCommand:         "codex",
+		InstructionsFileName:   "AGENTS.md",
+		SupportsClearOnCompact: false,
+	},
+}
+
 // ConductorSettings defines conductor (meta-agent orchestration) configuration
 type ConductorSettings struct {
 	// Enabled activates the conductor system
@@ -93,6 +124,7 @@ type DiscordSettings struct {
 // ConductorMeta holds metadata for a named conductor instance
 type ConductorMeta struct {
 	Name              string `json:"name"`
+	Agent             string `json:"agent,omitempty"`
 	Profile           string `json:"profile"`
 	HeartbeatEnabled  bool   `json:"heartbeat_enabled"`
 	HeartbeatInterval int    `json:"heartbeat_interval"` // 0 = use global default
@@ -115,8 +147,23 @@ type ConductorMeta struct {
 	EnvFile string `json:"env_file,omitempty"`
 }
 
+// GetAgent returns the normalized conductor agent, defaulting to Claude.
+func (m *ConductorMeta) GetAgent() string {
+	if m == nil {
+		return ConductorAgentClaude
+	}
+	if _, err := GetConductorAgentSpec(m.Agent); err == nil {
+		return normalizeConductorAgent(m.Agent)
+	}
+	return ConductorAgentClaude
+}
+
 // GetClearOnCompact returns whether to block compaction and send /clear instead, defaulting to true
 func (m *ConductorMeta) GetClearOnCompact() bool {
+	spec, _ := GetConductorAgentSpec(m.GetAgent())
+	if !spec.SupportsClearOnCompact {
+		return false
+	}
 	if m.ClearOnCompact == nil {
 		return true
 	}
@@ -142,6 +189,48 @@ func (i *Instance) ConductorClearOnCompact() bool {
 		return true // can't load meta: enable by default
 	}
 	return meta.GetClearOnCompact()
+}
+
+func normalizeConductorAgent(agent string) string {
+	agent = strings.ToLower(strings.TrimSpace(agent))
+	if agent == "" {
+		return ConductorAgentClaude
+	}
+	return agent
+}
+
+// GetConductorAgentSpec returns the normalized spec for a supported conductor agent.
+func GetConductorAgentSpec(agent string) (ConductorAgentSpec, error) {
+	normalized := normalizeConductorAgent(agent)
+	spec, ok := conductorAgentSpecs[normalized]
+	if !ok {
+		return ConductorAgentSpec{}, fmt.Errorf("unsupported conductor agent %q (supported: %s, %s)", agent, ConductorAgentClaude, ConductorAgentCodex)
+	}
+	return spec, nil
+}
+
+func conductorInstructionsPath(name, agent string) (string, error) {
+	spec, err := GetConductorAgentSpec(agent)
+	if err != nil {
+		return "", err
+	}
+	dir, err := ConductorNameDir(name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, spec.InstructionsFileName), nil
+}
+
+func sharedConductorInstructionsPath(agent string) (string, error) {
+	spec, err := GetConductorAgentSpec(agent)
+	if err != nil {
+		return "", err
+	}
+	dir, err := ConductorDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, spec.InstructionsFileName), nil
 }
 
 // conductorNameRegex validates conductor names: starts with alphanumeric, then alphanumeric/._-
@@ -252,6 +341,7 @@ func LoadConductorMeta(name string) (*ConductorMeta, error) {
 	if meta.Name == "" {
 		meta.Name = name
 	}
+	meta.Agent = meta.GetAgent()
 	meta.Profile = normalizeConductorProfile(meta.Profile)
 	return &meta, nil
 }
@@ -263,6 +353,14 @@ func SaveConductorMeta(meta *ConductorMeta) error {
 	}
 	if meta.Name == "" {
 		return fmt.Errorf("conductor name cannot be empty")
+	}
+	spec, err := GetConductorAgentSpec(meta.Agent)
+	if err != nil {
+		return err
+	}
+	meta.Agent = spec.Agent
+	if !spec.SupportsClearOnCompact {
+		meta.ClearOnCompact = nil
 	}
 	meta.Profile = normalizeConductorProfile(meta.Profile)
 
@@ -306,20 +404,11 @@ func ListConductors() ([]ConductorMeta, error) {
 		if !entry.IsDir() {
 			continue
 		}
-		metaPath := filepath.Join(base, entry.Name(), "meta.json")
-		data, err := os.ReadFile(metaPath)
+		meta, err := LoadConductorMeta(entry.Name())
 		if err != nil {
-			continue // skip dirs without meta.json
-		}
-		var meta ConductorMeta
-		if err := json.Unmarshal(data, &meta); err != nil {
 			continue
 		}
-		if meta.Name == "" {
-			meta.Name = entry.Name()
-		}
-		meta.Profile = normalizeConductorProfile(meta.Profile)
-		conductors = append(conductors, meta)
+		conductors = append(conductors, *meta)
 	}
 	return conductors, nil
 }
@@ -339,8 +428,11 @@ func ListConductorsForProfile(profile string) ([]ConductorMeta, error) {
 	return filtered, nil
 }
 
-func renderConductorClaudeTemplate(baseTemplate, name, profile string) string {
+func renderConductorInstructionsTemplate(baseTemplate, name, profile string, spec ConductorAgentSpec) string {
 	content := strings.ReplaceAll(baseTemplate, "{NAME}", name)
+	content = strings.ReplaceAll(content, "{AGENT}", spec.Agent)
+	content = strings.ReplaceAll(content, "{AGENT_DISPLAY}", spec.DisplayName)
+	content = strings.ReplaceAll(content, "{INSTRUCTIONS_FILE}", spec.InstructionsFileName)
 	if profile == DefaultProfile {
 		// For default profile, show "default" in display text and omit -p flag in commands
 		content = strings.ReplaceAll(content, "{PROFILE}", "default")
@@ -352,16 +444,31 @@ func renderConductorClaudeTemplate(baseTemplate, name, profile string) string {
 	return content
 }
 
+func renderConductorClaudeTemplate(baseTemplate, name, profile string) string {
+	spec, _ := GetConductorAgentSpec(ConductorAgentClaude)
+	return renderConductorInstructionsTemplate(baseTemplate, name, profile, spec)
+}
+
 func matchesTemplateContent(actual, expected string) bool {
 	return strings.TrimSuffix(actual, "\n") == strings.TrimSuffix(expected, "\n")
 }
 
-// SetupConductor creates the conductor directory, per-conductor CLAUDE.md, and meta.json.
-// If customClaudeMD is provided, creates a symlink instead of writing the template.
+// SetupConductor creates a Claude conductor for backward compatibility.
+// New callers should prefer SetupConductorWithAgent.
+func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact bool, description string, customClaudeMD string, customPolicyMD string, env map[string]string, envFile string) error {
+	return SetupConductorWithAgent(name, profile, ConductorAgentClaude, heartbeatEnabled, clearOnCompact, description, customClaudeMD, customPolicyMD, env, envFile)
+}
+
+// SetupConductorWithAgent creates the conductor directory, agent-specific instructions file, and meta.json.
+// If customInstructionsMD is provided, creates a symlink instead of writing the template.
 // If customPolicyMD is provided, creates a per-conductor POLICY.md symlink (overrides the shared POLICY.md).
 // It does NOT register the session (that's done by the CLI handler which has access to storage).
-func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact bool, description string, customClaudeMD string, customPolicyMD string, env map[string]string, envFile string) error {
+func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool, clearOnCompact bool, description string, customInstructionsMD string, customPolicyMD string, env map[string]string, envFile string) error {
 	if err := ValidateConductorName(name); err != nil {
+		return err
+	}
+	spec, err := GetConductorAgentSpec(agent)
+	if err != nil {
 		return err
 	}
 	profile = normalizeConductorProfile(profile)
@@ -381,18 +488,27 @@ func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact 
 		return fmt.Errorf("failed to create conductor dir: %w", err)
 	}
 
-	targetPath := filepath.Join(dir, "CLAUDE.md")
+	targetPath := filepath.Join(dir, spec.InstructionsFileName)
 
-	if customClaudeMD != "" {
+	if customInstructionsMD != "" {
 		// Custom path provided - create symlink
-		if err := createSymlinkWithExpansion(targetPath, customClaudeMD); err != nil {
+		if err := createSymlinkWithExpansion(targetPath, customInstructionsMD); err != nil {
 			return err
 		}
 	} else if info, err := os.Lstat(targetPath); err != nil || info.Mode()&os.ModeSymlink == 0 {
 		// No custom path - write default template (but preserve existing symlink)
-		content := renderConductorClaudeTemplate(conductorPerNameClaudeMDTemplate, name, profile)
+		content := renderConductorInstructionsTemplate(conductorPerNameClaudeMDTemplate, name, profile, spec)
 		if err := os.WriteFile(targetPath, []byte(content), 0o644); err != nil {
-			return fmt.Errorf("failed to write CLAUDE.md: %w", err)
+			return fmt.Errorf("failed to write %s: %w", spec.InstructionsFileName, err)
+		}
+	}
+	for otherAgent, otherSpec := range conductorAgentSpecs {
+		if otherAgent == spec.Agent {
+			continue
+		}
+		stalePath := filepath.Join(dir, otherSpec.InstructionsFileName)
+		if err := os.Remove(stalePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove stale %s: %w", otherSpec.InstructionsFileName, err)
 		}
 	}
 
@@ -407,6 +523,7 @@ func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact 
 	// Write meta.json
 	meta := &ConductorMeta{
 		Name:             name,
+		Agent:            spec.Agent,
 		Profile:          profile,
 		HeartbeatEnabled: heartbeatEnabled,
 		Description:      description,
@@ -688,14 +805,14 @@ const conductorHeartbeatPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 </plist>
 `
 
-// SetupConductorProfile creates the conductor directory and CLAUDE.md for a profile.
+// SetupConductorProfile creates a default Claude conductor for a profile.
 // Deprecated: Use SetupConductor instead. Kept for backward compatibility.
 func SetupConductorProfile(profile string) error {
 	return SetupConductor(profile, profile, true, true, "", "", "", nil, "")
 }
 
 // createSymlinkWithExpansion creates a symlink from target to source, with ~ expansion and validation.
-// target: the symlink path (e.g., ~/.agent-deck/conductor/CLAUDE.md)
+// target: the generated instructions path (e.g., ~/.agent-deck/conductor/CLAUDE.md)
 // source: the user's custom file path (e.g., ~/my/custom.md)
 func createSymlinkWithExpansion(target, source string) error {
 	// Expand environment variables and ~ in source path
@@ -724,10 +841,13 @@ func createSymlinkWithExpansion(target, source string) error {
 	return nil
 }
 
-// InstallSharedClaudeMD writes the shared CLAUDE.md to the conductor base directory,
+// InstallSharedConductorInstructions writes the shared instructions file for the given conductor agent,
 // or creates a symlink if customPath is provided.
-// This contains CLI reference, protocols, and rules shared by all conductors.
-func InstallSharedClaudeMD(customPath string) error {
+func InstallSharedConductorInstructions(agent, customPath string) error {
+	spec, err := GetConductorAgentSpec(agent)
+	if err != nil {
+		return err
+	}
 	dir, err := ConductorDir()
 	if err != nil {
 		return err
@@ -735,7 +855,7 @@ func InstallSharedClaudeMD(customPath string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
-	targetPath := filepath.Join(dir, "CLAUDE.md")
+	targetPath := filepath.Join(dir, spec.InstructionsFileName)
 
 	if customPath != "" {
 		// Custom path provided - create symlink
@@ -746,10 +866,17 @@ func InstallSharedClaudeMD(customPath string) error {
 	if info, err := os.Lstat(targetPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return nil
 	}
-	if err := os.WriteFile(targetPath, []byte(conductorSharedClaudeMDTemplate), 0o644); err != nil {
-		return fmt.Errorf("failed to write shared CLAUDE.md: %w", err)
+	content := renderConductorInstructionsTemplate(conductorSharedClaudeMDTemplate, "", DefaultProfile, spec)
+	if err := os.WriteFile(targetPath, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("failed to write shared %s: %w", spec.InstructionsFileName, err)
 	}
 	return nil
+}
+
+// InstallSharedClaudeMD writes the shared CLAUDE.md to the conductor base directory.
+// Deprecated: use InstallSharedConductorInstructions with the Claude agent.
+func InstallSharedClaudeMD(customPath string) error {
+	return InstallSharedConductorInstructions(ConductorAgentClaude, customPath)
 }
 
 // InstallLearningsMD writes the default LEARNINGS.md to the conductor base directory.

--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -1,9 +1,10 @@
 package session
 
-// conductorSharedClaudeMDTemplate is the shared CLAUDE.md written to ~/.agent-deck/conductor/CLAUDE.md.
+// conductorSharedClaudeMDTemplate is the shared instructions file written to
+// ~/.agent-deck/conductor/<instructions-file> for the selected conductor agent.
 // It contains CLI reference, protocols, and formats shared by all conductors (mechanism).
 // Agent behavior (rules, auto-response policy) lives in POLICY.md, not here.
-// Claude Code walks up the directory tree, so per-conductor CLAUDE.md files inherit this automatically.
+// The active agent walks up the directory tree, so per-conductor instructions files inherit this automatically.
 const conductorSharedClaudeMDTemplate = `# Conductor: Shared Knowledge Base
 
 This file contains shared infrastructure knowledge (CLI reference, protocols, formats) for all conductor sessions.
@@ -35,10 +36,10 @@ Each conductor has its own identity in its subdirectory and its own policy in PO
 |---------|-------------|
 | ` + "`" + `agent-deck -p <PROFILE> session start <id_or_title>` + "`" + ` | Start a stopped session |
 | ` + "`" + `agent-deck -p <PROFILE> session stop <id_or_title>` + "`" + ` | Stop a running session |
-| ` + "`" + `agent-deck -p <PROFILE> session restart <id_or_title>` + "`" + ` | Restart (reloads MCPs for Claude) |
-| ` + "`" + `agent-deck -p <PROFILE> add <path> -t "Title" -c claude -g "group"` + "`" + ` | Create new Claude session |
-| ` + "`" + `agent-deck -p <PROFILE> launch <path> -t "Title" -c claude -g "group" -m "prompt"` + "`" + ` | Create + start + send initial prompt in one command (preferred for new task sessions) |
-| ` + "`" + `agent-deck -p <PROFILE> add <path> -t "Title" -c claude --worktree feature/branch -b` + "`" + ` | Create session with new worktree |
+| ` + "`" + `agent-deck -p <PROFILE> session restart <id_or_title>` + "`" + ` | Restart a managed session |
+| ` + "`" + `agent-deck -p <PROFILE> add <path> -t "Title" -c {AGENT} -g "group"` + "`" + ` | Create a new {AGENT_DISPLAY} session |
+| ` + "`" + `agent-deck -p <PROFILE> launch <path> -t "Title" -c {AGENT} -g "group" -m "prompt"` + "`" + ` | Create + start + send initial prompt in one command (preferred for new task sessions) |
+| ` + "`" + `agent-deck -p <PROFILE> add <path> -t "Title" -c {AGENT} --worktree feature/branch -b` + "`" + ` | Create a new {AGENT_DISPLAY} session with a worktree |
 
 ### Session Resolution
 Commands accept: **exact title**, **ID prefix** (e.g., first 4 chars), **path**, or **fuzzy match**.
@@ -47,8 +48,8 @@ Commands accept: **exact title**, **ID prefix** (e.g., first 4 chars), **path**,
 
 | Status | Meaning | Your Action |
 |--------|---------|-------------|
-| ` + "`" + `running` + "`" + ` (green) | Claude is actively processing | Do nothing. Wait. |
-| ` + "`" + `waiting` + "`" + ` (yellow) | Claude finished, needs input | Read output, decide: auto-respond or escalate |
+| ` + "`" + `running` + "`" + ` (green) | The conductor is actively processing | Do nothing. Wait. |
+| ` + "`" + `waiting` + "`" + ` (yellow) | The conductor finished and needs input | Read output, decide: auto-respond or escalate |
 | ` + "`" + `idle` + "`" + ` (gray) | Waiting, but user acknowledged | User knows about it. Skip unless asked. |
 | ` + "`" + `error` + "`" + ` (red) | Session crashed or missing | Try ` + "`" + `session restart` + "`" + `. If that fails, escalate. |
 
@@ -260,16 +261,18 @@ This file can be overridden per conductor by placing a POLICY.md in the conducto
 If you're not sure whether to auto-respond, **escalate**. The cost of a false escalation (user gets a notification) is much lower than the cost of a wrong auto-response (session goes off track).
 `
 
-// conductorPerNameClaudeMDTemplate is the per-conductor CLAUDE.md written to ~/.agent-deck/conductor/<name>/CLAUDE.md.
-// It contains only the conductor's identity. Shared knowledge is inherited from the parent directory's CLAUDE.md.
+// conductorPerNameClaudeMDTemplate is the per-conductor instructions file written to
+// ~/.agent-deck/conductor/<name>/<instructions-file>.
+// It contains only the conductor's identity. Shared knowledge is inherited from the parent directory's instructions file.
 // {NAME} and {PROFILE} placeholders are replaced at setup time.
 const conductorPerNameClaudeMDTemplate = `# Conductor: {NAME} ({PROFILE} profile)
 
-You are **{NAME}**, a conductor for the **{PROFILE}** profile.
+You are **{NAME}**, a conductor for the **{PROFILE}** profile running on **{AGENT_DISPLAY}**.
 
 ## Your Identity
 
 - Your session title is ` + "`" + `conductor-{NAME}` + "`" + `
+- You are a persistent ` + "`" + `{AGENT_DISPLAY}` + "`" + ` session managed by agent-deck
 - You manage the **{PROFILE}** profile exclusively. Always pass ` + "`" + `-p {PROFILE}` + "`" + ` to all CLI commands.
 - You live in ` + "`" + `~/.agent-deck/conductor/{NAME}/` + "`" + `
 - Maintain state in ` + "`" + `./state.json` + "`" + ` and log actions in ` + "`" + `./task-log.md` + "`" + `
@@ -293,7 +296,7 @@ When you first start (or after a restart):
 
 Your operating rules (auto-response policy, escalation guidelines, response style) are in ` + "`" + `./POLICY.md` + "`" + `.
 If ` + "`" + `./POLICY.md` + "`" + ` does not exist, use ` + "`" + `../POLICY.md` + "`" + ` instead.
-Read the policy file at the start of each interaction.
+Read the policy file at the start of each interaction. Your agent instructions live in ` + "`" + `{INSTRUCTIONS_FILE}` + "`" + `.
 `
 
 // conductorPerNameClaudeMDPreLearningsTemplate is the post-policy-split but pre-learnings per-conductor CLAUDE.md template.

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -747,6 +747,46 @@ func TestInstallSharedClaudeMD_CustomSymlinkCreatesConductorDir(t *testing.T) {
 	}
 }
 
+func TestInstallSharedConductorInstructions_CodexDefault(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	if err := InstallSharedConductorInstructions(ConductorAgentCodex, ""); err != nil {
+		t.Fatalf("InstallSharedConductorInstructions returned error: %v", err)
+	}
+
+	target := filepath.Join(tmpHome, ".agent-deck", "conductor", "AGENTS.md")
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("failed to read AGENTS.md: %v", err)
+	}
+	if !strings.Contains(string(content), "Codex") {
+		t.Fatal("AGENTS.md should mention Codex")
+	}
+	if !strings.Contains(string(content), "agent-deck -p <PROFILE> add <path> -t \"Title\" -c codex") {
+		t.Fatal("AGENTS.md should render codex session examples")
+	}
+}
+
+func TestInstallSharedConductorInstructions_AgentsCoexist(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	if err := InstallSharedConductorInstructions(ConductorAgentClaude, ""); err != nil {
+		t.Fatalf("InstallSharedConductorInstructions(claude) returned error: %v", err)
+	}
+	if err := InstallSharedConductorInstructions(ConductorAgentCodex, ""); err != nil {
+		t.Fatalf("InstallSharedConductorInstructions(codex) returned error: %v", err)
+	}
+
+	base := filepath.Join(tmpHome, ".agent-deck", "conductor")
+	for _, file := range []string{"CLAUDE.md", "AGENTS.md"} {
+		if _, err := os.Stat(filepath.Join(base, file)); err != nil {
+			t.Fatalf("%s should exist: %v", file, err)
+		}
+	}
+}
+
 func TestSetupConductor_DefaultTemplate(t *testing.T) {
 	name := "test-default"
 	profile := "default"
@@ -792,6 +832,64 @@ func TestSetupConductor_DefaultTemplate(t *testing.T) {
 	// Just verify basic fields exist
 	if meta.Name != name {
 		t.Errorf("expected name %q, got %q", name, meta.Name)
+	}
+	if meta.Agent != ConductorAgentClaude {
+		t.Errorf("expected agent %q, got %q", ConductorAgentClaude, meta.Agent)
+	}
+}
+
+func TestSetupConductorWithAgent_Codex(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "test-codex"
+	if err := SetupConductorWithAgent(name, "default", ConductorAgentCodex, true, true, "codex conductor", "", "", nil, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dir, _ := ConductorNameDir(name)
+	agentsPath := filepath.Join(dir, "AGENTS.md")
+	content, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("failed to read AGENTS.md: %v", err)
+	}
+	if !strings.Contains(string(content), "Codex") {
+		t.Fatal("AGENTS.md should mention Codex")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Fatal("CLAUDE.md should not be created for Codex conductor")
+	}
+
+	meta, err := LoadConductorMeta(name)
+	if err != nil {
+		t.Fatalf("failed to load meta: %v", err)
+	}
+	if meta.Agent != ConductorAgentCodex {
+		t.Fatalf("agent = %q, want %q", meta.Agent, ConductorAgentCodex)
+	}
+	if meta.GetClearOnCompact() {
+		t.Fatal("codex conductor should not enable clear_on_compact")
+	}
+}
+
+func TestSetupConductorWithAgent_RemovesStaleInstructionsFile(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "switch-agent"
+	if err := SetupConductor(name, "default", true, true, "", "", "", nil, ""); err != nil {
+		t.Fatalf("failed to create initial Claude conductor: %v", err)
+	}
+	if err := SetupConductorWithAgent(name, "default", ConductorAgentCodex, true, true, "", "", "", nil, ""); err != nil {
+		t.Fatalf("failed to switch conductor to Codex: %v", err)
+	}
+
+	dir, _ := ConductorNameDir(name)
+	if _, err := os.Stat(filepath.Join(dir, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Fatal("CLAUDE.md should be removed after switching conductor agent to Codex")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); err != nil {
+		t.Fatalf("AGENTS.md should exist after switching conductor agent to Codex: %v", err)
 	}
 }
 
@@ -903,6 +1001,30 @@ func TestLoadConductorMeta_EmptyProfileDefaultsToDefault(t *testing.T) {
 	}
 	if meta.Profile != DefaultProfile {
 		t.Fatalf("meta profile = %q, want %q", meta.Profile, DefaultProfile)
+	}
+}
+
+func TestLoadConductorMeta_EmptyAgentDefaultsToClaude(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "meta-empty-agent"
+	dir, _ := ConductorNameDir(name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create conductor dir: %v", err)
+	}
+
+	raw := `{"name":"meta-empty-agent","profile":"default","heartbeat_enabled":true,"created_at":"2026-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(raw), 0o644); err != nil {
+		t.Fatalf("failed to write meta.json: %v", err)
+	}
+
+	meta, err := LoadConductorMeta(name)
+	if err != nil {
+		t.Fatalf("LoadConductorMeta failed: %v", err)
+	}
+	if meta.Agent != ConductorAgentClaude {
+		t.Fatalf("meta agent = %q, want %q", meta.Agent, ConductorAgentClaude)
 	}
 }
 
@@ -1965,6 +2087,15 @@ func TestConductorClearOnCompact(t *testing.T) {
 
 	if inst.ConductorClearOnCompact() {
 		t.Error("should return false when clear_on_compact is explicitly disabled")
+	}
+
+	meta = ConductorMeta{Name: "main", Agent: ConductorAgentCodex, Profile: "default"}
+	data, _ = json.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(condDir, "meta.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if inst.ConductorClearOnCompact() {
+		t.Error("codex conductors should always disable clear_on_compact")
 	}
 
 	// Non-conductor title should return false (not a conductor-prefixed session)


### PR DESCRIPTION
## Summary
- add `conductor setup --agent` with a default Claude path and a new Codex conductor path
- generalize conductor instruction handling around `ConductorAgentSpec`, agent-specific instructions files, and agent-aware setup/list/status output
- keep the existing internal session `Tool` model unchanged while exposing `agent` in the conductor UX, docs, and regression tests

## Future-proofing
- shared and per-conductor instruction rendering now flow through a single spec abstraction so future agent additions like Gemini CLI stay localized to a new spec and template wiring

## Testing
- `go test ./cmd/agent-deck`
- `go test ./internal/session -run 'Test(InstallSharedConductorInstructions_CodexDefault|InstallSharedConductorInstructions_AgentsCoexist|SetupConductorWithAgent_Codex|SetupConductorWithAgent_RemovesStaleInstructionsFile|LoadConductorMeta_EmptyAgentDefaultsToClaude|ConductorClearOnCompact)$'`

## Notes
- `go test ./internal/session` still fails in existing lifecycle tests (`TestLifecycle_StoppedRestartedRunningError`, `TestStatusCycle_ShellSessionWithCommand`) unrelated to this change
