### PR TITLE
fix: detect Ctrl+Q in enhanced keyboard protocol encodings

### DIFF
--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -9,6 +9,9 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+	"golang.org/x/term"
 )
 
 // sshControlDir is the directory for SSH ControlMaster sockets.
@@ -66,14 +69,16 @@ func (r *SSHRunner) run(ctx context.Context, args ...string) ([]byte, error) {
 }
 
 // Attach connects interactively to a remote agent-deck session.
-// This connects stdin/stdout/stderr for full terminal interaction.
+// This manages the local terminal directly (rather than letting SSH do it)
+// so that Ctrl+Q can be intercepted regardless of the terminal's key
+// reporting mode (raw byte 0x11, xterm modifyOtherKeys, or kitty CSI u).
 func (r *SSHRunner) Attach(sessionID string) error {
 	_ = os.MkdirAll(sshControlDir, 0700)
 
 	remoteCmd := r.buildRemoteCommand("session", "attach", sessionID)
 
 	sshArgs := []string{
-		"-t",
+		"-tt", // force remote PTY even though local stdin is a pipe
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPath=" + sshControlDir + "/%r@%h:%p",
 		"-o", "ControlPersist=600",
@@ -82,12 +87,53 @@ func (r *SSHRunner) Attach(sessionID string) error {
 	}
 
 	cmd := exec.Command("ssh", sshArgs...)
-	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	return cmd.Run()
+	sshStdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return fmt.Errorf("failed to set raw mode: %w", err)
+	}
+	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start ssh: %w", err)
+	}
+
+	// Forward stdin to SSH, intercepting Ctrl+Q to detach
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			n, err := os.Stdin.Read(buf)
+			if err != nil {
+				break
+			}
+			data := buf[:n]
+
+			if idx := tmux.IndexCtrlQ(data); idx >= 0 {
+				if idx > 0 {
+					_, _ = sshStdin.Write(data[:idx])
+				}
+				_ = sshStdin.Close()
+				_ = cmd.Process.Kill()
+				return
+			}
+
+			if _, err := sshStdin.Write(data); err != nil {
+				break
+			}
+		}
+	}()
+
+	_ = cmd.Wait()
+	return nil
 }
+
 
 // RunCommand executes an arbitrary agent-deck command on the remote.
 func (r *SSHRunner) RunCommand(ctx context.Context, args ...string) ([]byte, error) {

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -19,6 +19,24 @@ import (
 	"golang.org/x/term"
 )
 
+// IndexCtrlQ returns the index of a Ctrl+Q sequence in data, or -1 if not found.
+// Handles three encodings:
+//   - Raw byte 0x11
+//   - xterm modifyOtherKeys: ESC[27;5;113~
+//   - CSI u (kitty keyboard protocol): ESC[113;5u
+func IndexCtrlQ(data []byte) int {
+	if idx := bytes.IndexByte(data, 17); idx >= 0 {
+		return idx
+	}
+	if idx := bytes.Index(data, []byte("\x1b[27;5;113~")); idx >= 0 {
+		return idx
+	}
+	if idx := bytes.Index(data, []byte("\x1b[113;5u")); idx >= 0 {
+		return idx
+	}
+	return -1
+}
+
 // Attach attaches to the tmux session with full PTY support
 // Ctrl+Q will detach and return to the caller
 func (s *Session) Attach(ctx context.Context) error {
@@ -134,9 +152,10 @@ func (s *Session) Attach(ctx context.Context) error {
 				continue
 			}
 
-			// Check for Ctrl+Q (ASCII 17) anywhere in the input chunk.
+			// Check for Ctrl+Q anywhere in the input chunk.
 			// Some terminals coalesce reads, so detach must not require a single-byte read.
-			if idx := bytes.IndexByte(buf[:n], 17); idx >= 0 {
+			// Handles raw byte 0x11, xterm modifyOtherKeys, and kitty CSI u encodings.
+			if idx := IndexCtrlQ(buf[:n]); idx >= 0 {
 				// Forward any bytes before Ctrl+Q, then detach.
 				if idx > 0 {
 					if _, err := ptmx.Write(buf[:idx]); err != nil {


### PR DESCRIPTION
Modern terminals with kitty keyboard protocol or xterm modifyOtherKeys encode Ctrl+Q as escape sequences (ESC[113;5u or ESC[27;5;113~) instead of raw byte 0x11. This broke detach in local sessions after the inner process enabled enhanced reporting, and in SSH remote sessions.

Extract IndexCtrlQ into a shared function in internal/tmux that handles all three encodings, and use it in both the local PTY attach and SSH attach paths.