### PR TITLE
fix(git): Fix tests when running on a machine with init.defaultBranch set

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -13,7 +13,7 @@ func createTestRepo(t *testing.T, dir string) {
 	t.Helper()
 
 	// Initialize git repo
-	cmd := exec.Command("git", "init")
+	cmd := exec.Command("git", "-c", "init.defaultBranch=main", "init")
 	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init git repo: %v", err)


### PR DESCRIPTION
Tests fail when running with `init.defaultBranch` set to something like "trunk" in the global config.

Set the value explicitly when initializing a test repository, to isolate tests from global git config.