### PR TITLE
fix(tui): clear stale status filter when no sessions match

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1141,7 +1141,17 @@ func (h *Home) rebuildFlatItems() {
 				}
 			}
 		}
-		h.flatItems = filtered
+
+		// If the persisted status filter results in an empty list but sessions
+		// exist, clear the filter so sessions remain visible. This prevents a
+		// stale filter (e.g. "error") from hiding all sessions after the
+		// matching sessions are removed.
+		if len(filtered) == 0 && len(allItems) > 0 {
+			h.statusFilter = ""
+			h.flatItems = allItems
+		} else {
+			h.flatItems = filtered
+		}
 	} else {
 		h.flatItems = allItems
 	}


### PR DESCRIPTION
Had a fun time debugging this one. After upgrading to 0.26.3, my TUI showed "No Sessions Yet" even though sessions clearly existed (header bar had the correct count).

Turns out `loadUIState()` restores the persisted status filter on startup. If the sessions that matched that filter got removed in the meantime, `rebuildFlatItems()` filters everything out and you end up with an empty list. The header counts are fine because they read from `h.instances` directly, not from `flatItems`.

In my case I had 18 sessions in error state (tmux server wasnt running), removed them all with `ad rm`, created new ones, and the TUI just showed nothing. The old "error" filter was still saved in the sqlite metadata and kept hiding everything.

The fix just clears the status filter when it would produce an empty result but sessions are actually there.

### repro steps

1. have sessions in some status (e.g. error)
2. filter to that status (gets persisted to ui_state metadata)
3. remove all those sessions
4. add new sessions with a different status
5. restart AD, session list is empty

### workaround

quit AD, then run:
```
sqlite3 ~/.agent-deck/profiles/default/state.db \
  "UPDATE metadata SET value='{\"preview_mode\":0,\"status_filter\":\"\"}' WHERE key='ui_state';"
```