### PR TITLE
Fix #363: auto-clear status filter when it matches no sessions

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -209,30 +209,6 @@ func GetConductorAgentSpec(agent string) (ConductorAgentSpec, error) {
 	return spec, nil
 }
 
-func conductorInstructionsPath(name, agent string) (string, error) {
-	spec, err := GetConductorAgentSpec(agent)
-	if err != nil {
-		return "", err
-	}
-	dir, err := ConductorNameDir(name)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, spec.InstructionsFileName), nil
-}
-
-func sharedConductorInstructionsPath(agent string) (string, error) {
-	spec, err := GetConductorAgentSpec(agent)
-	if err != nil {
-		return "", err
-	}
-	dir, err := ConductorDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, spec.InstructionsFileName), nil
-}
-
 // conductorNameRegex validates conductor names: starts with alphanumeric, then alphanumeric/._-
 var conductorNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -134,7 +134,6 @@ func (r *SSHRunner) Attach(sessionID string) error {
 	return nil
 }
 
-
 // RunCommand executes an arbitrary agent-deck command on the remote.
 func (r *SSHRunner) RunCommand(ctx context.Context, args ...string) ([]byte, error) {
 	return r.Run(ctx, args...)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1141,7 +1141,13 @@ func (h *Home) rebuildFlatItems() {
 				}
 			}
 		}
-		h.flatItems = filtered
+		// Auto-clear filter if it matches nothing but sessions exist
+		if len(filtered) == 0 && len(allItems) > 0 {
+			h.statusFilter = ""
+			h.flatItems = allItems
+		} else {
+			h.flatItems = filtered
+		}
 	} else {
 		h.flatItems = allItems
 	}

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2024,3 +2024,77 @@ func TestRestartSessionCmdSessionMissingReturnsError(t *testing.T) {
 		t.Fatalf("unexpected error: %v", restarted.err)
 	}
 }
+
+func TestRebuildFlatItemsAutoClearsEmptyStatusFilter(t *testing.T) {
+	home := NewHome()
+	home.initialLoading = false
+
+	// Create sessions that are all "running"
+	inst1 := &session.Instance{ID: "s1", Title: "Session 1", Tool: "claude", Status: session.StatusRunning}
+	inst2 := &session.Instance{ID: "s2", Title: "Session 2", Tool: "claude", Status: session.StatusRunning}
+
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst1, inst2}
+	home.instanceByID[inst1.ID] = inst1
+	home.instanceByID[inst2.ID] = inst2
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+
+	// Set a filter for a status that no session has
+	home.statusFilter = session.StatusError
+
+	home.rebuildFlatItems()
+
+	// Filter should have been auto-cleared since no sessions match "error"
+	if home.statusFilter != "" {
+		t.Errorf("statusFilter should be auto-cleared when filter matches nothing, got %q", home.statusFilter)
+	}
+
+	// All sessions should be visible
+	sessionCount := 0
+	for _, item := range home.flatItems {
+		if item.Type == session.ItemTypeSession {
+			sessionCount++
+		}
+	}
+	if sessionCount != 2 {
+		t.Errorf("expected 2 sessions in flatItems after auto-clear, got %d", sessionCount)
+	}
+}
+
+func TestRebuildFlatItemsKeepsValidStatusFilter(t *testing.T) {
+	home := NewHome()
+	home.initialLoading = false
+
+	// Create sessions with mixed statuses
+	inst1 := &session.Instance{ID: "s1", Title: "Session 1", Tool: "claude", Status: session.StatusRunning}
+	inst2 := &session.Instance{ID: "s2", Title: "Session 2", Tool: "claude", Status: session.StatusError}
+
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst1, inst2}
+	home.instanceByID[inst1.ID] = inst1
+	home.instanceByID[inst2.ID] = inst2
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+
+	// Filter for error - one session matches
+	home.statusFilter = session.StatusError
+
+	home.rebuildFlatItems()
+
+	// Filter should remain because it matches a session
+	if home.statusFilter != session.StatusError {
+		t.Errorf("statusFilter should remain %q when sessions match, got %q", session.StatusError, home.statusFilter)
+	}
+
+	// Only the error session should be visible
+	sessionCount := 0
+	for _, item := range home.flatItems {
+		if item.Type == session.ItemTypeSession {
+			sessionCount++
+		}
+	}
+	if sessionCount != 1 {
+		t.Errorf("expected 1 session in flatItems with error filter, got %d", sessionCount)
+	}
+}


### PR DESCRIPTION
## Summary

- Auto-clears the persisted status filter in `rebuildFlatItems()` when filtering produces an empty list but sessions actually exist
- Prevents the "No Sessions Yet" empty state after removing all sessions that matched the active filter
- Also removes unused `conductorInstructionsPath`/`sharedConductorInstructionsPath` functions flagged by linter

## Test plan

- [x] `TestRebuildFlatItemsAutoClearsEmptyStatusFilter` - verifies filter is cleared and all sessions shown
- [x] `TestRebuildFlatItemsKeepsValidStatusFilter` - verifies filter persists when sessions match
- [x] Full CI passes (`make ci`)

Fixes #363