### PR TITLE
Fix #361: make detach key configurable via hotkeys

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/send"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
+	"github.com/asheshgoplani/agent-deck/internal/ui"
 )
 
 // handleSession dispatches session subcommands
@@ -579,13 +580,16 @@ func handleSessionFork(profile string, args []string) {
 
 // handleSessionAttach attaches to a session interactively
 func handleSessionAttach(profile string, args []string) {
+	detachByte := ui.ResolvedDetachByte(session.GetHotkeyOverrides())
+	detachLabel := ui.DetachByteLabel(detachByte)
+
 	fs := flag.NewFlagSet("session attach", flag.ExitOnError)
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session attach <id|title>")
 		fmt.Println()
 		fmt.Println("Attach to a session interactively.")
-		fmt.Println("Press Ctrl+Q to detach.")
+		fmt.Printf("Press %s to detach.\n", detachLabel)
 	}
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
@@ -628,7 +632,7 @@ func handleSessionAttach(profile string, args []string) {
 	// Create context for attach
 	ctx := context.Background()
 
-	if err := tmuxSession.Attach(ctx); err != nil {
+	if err := tmuxSession.Attach(ctx, detachByte); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to attach: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -19,32 +19,55 @@ import (
 	"golang.org/x/term"
 )
 
-// IndexCtrlQ returns the index of a Ctrl+Q sequence in data, or -1 if not found.
+// IndexDetachKey returns the index of a control-key sequence in data, or -1 if
+// not found. detachByte is the raw ASCII byte (e.g. 0x11 for Ctrl+Q).
 // Handles three encodings:
-//   - Raw byte 0x11
-//   - xterm modifyOtherKeys: ESC[27;5;113~
-//   - CSI u (kitty keyboard protocol): ESC[113;5u
-func IndexCtrlQ(data []byte) int {
-	if idx := bytes.IndexByte(data, 17); idx >= 0 {
+//   - Raw byte
+//   - xterm modifyOtherKeys: ESC[27;5;{keyCode}~
+//   - CSI u (kitty keyboard protocol): ESC[{keyCode};5u
+func IndexDetachKey(data []byte, detachByte byte) int {
+	if idx := bytes.IndexByte(data, detachByte); idx >= 0 {
 		return idx
 	}
-	if idx := bytes.Index(data, []byte("\x1b[27;5;113~")); idx >= 0 {
-		return idx
+	var keyCode byte
+	if detachByte >= 1 && detachByte <= 26 {
+		keyCode = detachByte + 96
+	} else if detachByte >= 28 && detachByte <= 31 {
+		keyCode = detachByte + 64
 	}
-	if idx := bytes.Index(data, []byte("\x1b[113;5u")); idx >= 0 {
-		return idx
+	if keyCode > 0 {
+		modSeq := fmt.Sprintf("\x1b[27;5;%d~", keyCode)
+		if idx := bytes.Index(data, []byte(modSeq)); idx >= 0 {
+			return idx
+		}
+		csiSeq := fmt.Sprintf("\x1b[%d;5u", keyCode)
+		if idx := bytes.Index(data, []byte(csiSeq)); idx >= 0 {
+			return idx
+		}
 	}
 	return -1
 }
 
-// Attach attaches to the tmux session with full PTY support
-// Ctrl+Q will detach and return to the caller
-func (s *Session) Attach(ctx context.Context) error {
+// IndexCtrlQ returns the index of a Ctrl+Q sequence in data, or -1 if not found.
+// This is a convenience wrapper around IndexDetachKey with the default Ctrl+Q byte.
+func IndexCtrlQ(data []byte) int {
+	return IndexDetachKey(data, 17)
+}
+
+// Attach attaches to the tmux session with full PTY support.
+// The detach key (default Ctrl+Q) will detach and return to the caller.
+// An optional detachByte overrides the default detach key (0x11 = Ctrl+Q).
+func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
+	detach := byte(17)
+	if len(detachByte) > 0 && detachByte[0] != 0 {
+		detach = detachByte[0]
+	}
+
 	if !s.Exists() {
 		return fmt.Errorf("session %s does not exist", s.Name)
 	}
 
-	// Create context with cancel for Ctrl+Q detach
+	// Create context with cancel for detach key
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -107,7 +130,7 @@ func (s *Session) Attach(ctx context.Context) error {
 	// Initial resize
 	sigwinch <- syscall.SIGWINCH
 
-	// Channel to signal detach via Ctrl+Q
+	// Channel to signal detach via configured detach key
 	detachCh := make(chan struct{})
 
 	// Channel for I/O errors (buffered to prevent goroutine leaks)
@@ -135,7 +158,7 @@ func (s *Session) Attach(ctx context.Context) error {
 		}
 	}()
 
-	// Goroutine 2: Read stdin, intercept Ctrl+Q (ASCII 17), forward rest to PTY
+	// Goroutine 2: Read stdin, intercept detach key, forward rest to PTY
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -160,11 +183,11 @@ func (s *Session) Attach(ctx context.Context) error {
 				continue
 			}
 
-			// Check for Ctrl+Q anywhere in the input chunk.
+			// Check for the detach key anywhere in the input chunk.
 			// Some terminals coalesce reads, so detach must not require a single-byte read.
-			// Handles raw byte 0x11, xterm modifyOtherKeys, and kitty CSI u encodings.
-			if idx := IndexCtrlQ(buf[:n]); idx >= 0 {
-				// Forward any bytes before Ctrl+Q, then detach.
+			// Handles raw byte, xterm modifyOtherKeys, and kitty CSI u encodings.
+			if idx := IndexDetachKey(buf[:n], detach); idx >= 0 {
+				// Forward any bytes before the detach key, then detach.
 				if idx > 0 {
 					if _, err := ptmx.Write(buf[:idx]); err != nil {
 						select {
@@ -213,11 +236,11 @@ func (s *Session) Attach(ctx context.Context) error {
 		_, _ = os.Stdout.WriteString(terminalStyleReset)
 	}
 
-	// Wait for either detach (Ctrl+Q) or command completion
+	// Wait for either detach key or command completion
 	var attachErr error
 	select {
 	case <-detachCh:
-		// User pressed Ctrl+Q, detach gracefully
+		// User pressed detach key, detach gracefully
 		attachErr = nil
 	case err := <-cmdDone:
 		if err != nil {
@@ -231,7 +254,7 @@ func (s *Session) Attach(ctx context.Context) error {
 			} else {
 				attachErr = err
 			}
-			// Context cancelled is normal (from Ctrl+Q)
+			// Context cancelled is normal (from detach key)
 			if ctx.Err() != nil {
 				attachErr = nil
 			}
@@ -248,7 +271,8 @@ func (s *Session) Attach(ctx context.Context) error {
 
 // AttachWindow attaches to a specific window within this tmux session.
 // Selects the target window first, then uses the standard Attach flow.
-func (s *Session) AttachWindow(ctx context.Context, windowIndex int) error {
+// An optional detachByte overrides the default detach key.
+func (s *Session) AttachWindow(ctx context.Context, windowIndex int, detachByte ...byte) error {
 	if !s.Exists() {
 		return fmt.Errorf("session %s does not exist", s.Name)
 	}
@@ -259,7 +283,7 @@ func (s *Session) AttachWindow(ctx context.Context, windowIndex int) error {
 		return fmt.Errorf("failed to select window %s: %w", target, err)
 	}
 
-	return s.Attach(ctx)
+	return s.Attach(ctx, detachByte...)
 }
 
 // Resize changes the terminal size of the tmux session

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -415,6 +415,10 @@ func (h *Home) reloadHotkeysFromConfig() {
 	h.setHotkeys(resolveHotkeys(session.GetHotkeyOverrides()))
 }
 
+func (h *Home) detachByte() byte {
+	return ResolvedDetachByte(session.GetHotkeyOverrides())
+}
+
 func (h *Home) setHotkeys(bindings map[string]string) {
 	if bindings == nil {
 		bindings = resolveHotkeys(nil)
@@ -4830,7 +4834,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						}
 
 						h.isAttaching.Store(true)
-						return h, tea.Exec(attachWindowCmd{session: tmuxSess, windowIndex: item.WindowIndex}, func(err error) tea.Msg {
+						return h, tea.Exec(attachWindowCmd{session: tmuxSess, windowIndex: item.WindowIndex, detachByte: h.detachByte()}, func(err error) tea.Msg {
 							h.isAttaching.Store(false)
 							parentInst.MarkAccessed()
 							return statusUpdateMsg{}
@@ -5139,7 +5143,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			termSession := &tmux.Session{Name: tmuxName}
 			h.isAttaching.Store(true)
-			return h, tea.Exec(attachCmd{session: termSession}, func(err error) tea.Msg {
+			return h, tea.Exec(attachCmd{session: termSession, detachByte: h.detachByte()}, func(err error) tea.Msg {
 				h.isAttaching.Store(false)
 				return statusUpdateMsg{}
 			})
@@ -6990,7 +6994,7 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 	// On return, immediately update all session statuses (don't reload from storage
 	// which would lose the tmux session state)
 	h.isAttaching.Store(true) // Prevent View() output only during actual attach transition
-	return tea.Exec(attachCmd{session: tmuxSess}, func(err error) tea.Msg {
+	return tea.Exec(attachCmd{session: tmuxSess, detachByte: h.detachByte()}, func(err error) tea.Msg {
 		// CRITICAL: Set isAttaching to false BEFORE returning the message
 		// This prevents a race condition where View() could be called with
 		// isAttaching=true before Update() processes statusUpdateMsg,
@@ -7069,7 +7073,8 @@ func (h *Home) followAttachReturnCwd(msg statusUpdateMsg) {
 
 // attachCmd implements tea.ExecCommand for custom PTY attach
 type attachCmd struct {
-	session *tmux.Session
+	session    *tmux.Session
+	detachByte byte
 }
 
 func (a attachCmd) Run() error {
@@ -7077,7 +7082,7 @@ func (a attachCmd) Run() error {
 	// Removing clear screen here prevents double-clearing which corrupts terminal state
 
 	ctx := context.Background()
-	return a.session.Attach(ctx)
+	return a.session.Attach(ctx, a.detachByte)
 }
 
 func (a attachCmd) SetStdin(r io.Reader)  {}
@@ -7131,11 +7136,12 @@ func (r remoteCreateAndAttachCmd) SetStderr(writer io.Writer) {}
 type attachWindowCmd struct {
 	session     *tmux.Session
 	windowIndex int
+	detachByte  byte
 }
 
 func (a attachWindowCmd) Run() error {
 	ctx := context.Background()
-	return a.session.AttachWindow(ctx, a.windowIndex)
+	return a.session.AttachWindow(ctx, a.windowIndex, a.detachByte)
 }
 
 func (a attachWindowCmd) SetStdin(r io.Reader)  {}

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -34,6 +34,7 @@ const (
 	hotkeySettings        = "settings"
 	hotkeyImport          = "import"
 	hotkeyReload          = "reload"
+	hotkeyDetach          = "detach"
 )
 
 var hotkeyActionOrder = []string{
@@ -64,6 +65,7 @@ var hotkeyActionOrder = []string{
 	hotkeySettings,
 	hotkeyImport,
 	hotkeyReload,
+	hotkeyDetach,
 }
 
 var defaultHotkeyBindings = map[string]string{
@@ -94,6 +96,7 @@ var defaultHotkeyBindings = map[string]string{
 	hotkeySettings:        "S",
 	hotkeyImport:          "i",
 	hotkeyReload:          "ctrl+r",
+	hotkeyDetach:          "ctrl+q",
 }
 
 var hotkeyActionDefaultTriggers = map[string][]string{
@@ -313,4 +316,57 @@ func joinHotkeyLabels(keys ...string) string {
 		}
 	}
 	return strings.Join(filtered, "/")
+}
+
+// DetachByteFromBinding converts a hotkey binding string (e.g. "ctrl+q") to the
+// corresponding ASCII byte used by the PTY attach loop. Returns 0x11 (Ctrl+Q) as
+// the default when the binding cannot be mapped.
+func DetachByteFromBinding(binding string) byte {
+	binding = strings.ToLower(strings.TrimSpace(binding))
+	if !strings.HasPrefix(binding, "ctrl+") {
+		return 17 // default Ctrl+Q
+	}
+	ch := binding[len("ctrl+"):]
+	if len(ch) == 1 && ch[0] >= 'a' && ch[0] <= 'z' {
+		return ch[0] - 'a' + 1
+	}
+	switch ch {
+	case "\\":
+		return 0x1C
+	case "]":
+		return 0x1D
+	case "^":
+		return 0x1E
+	case "_":
+		return 0x1F
+	}
+	return 17 // default Ctrl+Q
+}
+
+// DetachByteLabel returns a human-readable label for a detach byte (e.g. "Ctrl+Q").
+func DetachByteLabel(b byte) string {
+	if b >= 1 && b <= 26 {
+		return "Ctrl+" + string(rune('A'+b-1))
+	}
+	switch b {
+	case 0x1C:
+		return "Ctrl+\\"
+	case 0x1D:
+		return "Ctrl+]"
+	case 0x1E:
+		return "Ctrl+^"
+	case 0x1F:
+		return "Ctrl+_"
+	}
+	return "Ctrl+Q"
+}
+
+// ResolvedDetachByte returns the detach byte for the current hotkey configuration.
+func ResolvedDetachByte(overrides map[string]string) byte {
+	bindings := resolveHotkeys(overrides)
+	key := actionHotkey(bindings, hotkeyDetach)
+	if key == "" {
+		return 17 // default Ctrl+Q
+	}
+	return DetachByteFromBinding(key)
 }

--- a/internal/ui/hotkeys_test.go
+++ b/internal/ui/hotkeys_test.go
@@ -93,6 +93,89 @@ func TestHotkeyAliasesShiftAndSymbols(t *testing.T) {
 	}
 }
 
+func TestDetachByteFromBinding(t *testing.T) {
+	tests := []struct {
+		binding string
+		want    byte
+	}{
+		{"ctrl+q", 17},     // 'q' - 'a' + 1 = 17
+		{"ctrl+a", 1},      // 'a' - 'a' + 1 = 1
+		{"ctrl+z", 26},     // 'z' - 'a' + 1 = 26
+		{"ctrl+b", 2},      // 'b' - 'a' + 1 = 2
+		{"Ctrl+Q", 17},     // case insensitive
+		{"  ctrl+q  ", 17}, // whitespace trimmed
+		{"ctrl+\\", 0x1C},
+		{"ctrl+]", 0x1D},
+		{"ctrl+^", 0x1E},
+		{"ctrl+_", 0x1F},
+		{"q", 17},       // non-ctrl binding defaults to Ctrl+Q
+		{"", 17},        // empty defaults to Ctrl+Q
+		{"shift+q", 17}, // non-ctrl prefix defaults to Ctrl+Q
+		{"ctrl+1", 17},  // non-letter defaults to Ctrl+Q
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.binding, func(t *testing.T) {
+			if got := DetachByteFromBinding(tt.binding); got != tt.want {
+				t.Errorf("DetachByteFromBinding(%q) = %d, want %d", tt.binding, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetachByteLabel(t *testing.T) {
+	tests := []struct {
+		b    byte
+		want string
+	}{
+		{17, "Ctrl+Q"},
+		{1, "Ctrl+A"},
+		{26, "Ctrl+Z"},
+		{2, "Ctrl+B"},
+		{0x1C, "Ctrl+\\"},
+		{0x1D, "Ctrl+]"},
+		{0x1E, "Ctrl+^"},
+		{0x1F, "Ctrl+_"},
+		{0, "Ctrl+Q"},  // out of range defaults
+		{27, "Ctrl+Q"}, // ESC byte, not in letter range
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := DetachByteLabel(tt.b); got != tt.want {
+				t.Errorf("DetachByteLabel(%d) = %q, want %q", tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvedDetachByte(t *testing.T) {
+	// Default (no overrides) should be Ctrl+Q
+	if got := ResolvedDetachByte(nil); got != 17 {
+		t.Fatalf("ResolvedDetachByte(nil) = %d, want 17", got)
+	}
+
+	// Override detach to ctrl+b
+	if got := ResolvedDetachByte(map[string]string{"detach": "ctrl+b"}); got != 2 {
+		t.Fatalf("ResolvedDetachByte(ctrl+b) = %d, want 2", got)
+	}
+
+	// Override detach to ctrl+a
+	if got := ResolvedDetachByte(map[string]string{"detach": "ctrl+a"}); got != 1 {
+		t.Fatalf("ResolvedDetachByte(ctrl+a) = %d, want 1", got)
+	}
+
+	// Unrelated overrides should not affect detach
+	if got := ResolvedDetachByte(map[string]string{"quit": "x"}); got != 17 {
+		t.Fatalf("ResolvedDetachByte with unrelated override = %d, want 17", got)
+	}
+
+	// Unbinding detach (empty string) should default to Ctrl+Q
+	if got := ResolvedDetachByte(map[string]string{"detach": ""}); got != 17 {
+		t.Fatalf("ResolvedDetachByte with empty override = %d, want 17", got)
+	}
+}
+
 func TestNormalizeMainKeyWithConfiguredHotkeys(t *testing.T) {
 	h := NewHome()
 	h.setHotkeys(resolveHotkeys(map[string]string{


### PR DESCRIPTION
## Summary
- Adds `detach` action to the existing `[hotkeys]` config system, defaulting to `ctrl+q`
- Generalizes `IndexCtrlQ` into `IndexDetachKey` that works with any control-key byte (raw + xterm modifyOtherKeys + kitty CSI u encodings)
- Threads the configured detach byte through `Attach`/`AttachWindow` from TUI and CLI callers (variadic parameter, fully backward compatible)

Users whose terminals intercept Ctrl+Q (XON/XOFF flow control in iTerm2, Zellij multiplexer, etc.) can now remap to any `ctrl+` key in `~/.agent-deck/config.toml`:

```toml
[hotkeys]
detach = "ctrl+]"
```

Fixes #361

## Test plan
- [x] All existing `IndexCtrlQ` tests pass (wrapper over `IndexDetachKey`)
- [x] New `TestIndexDetachKey` with 16 cases (different keys, encodings, prefixes)
- [x] New `TestDetachByteFromBinding` with 14 cases
- [x] New `TestDetachByteLabel` with 10 cases
- [x] New `TestResolvedDetachByte` with 5 cases
- [x] `golangci-lint run` passes
- [x] Full `go test -race ./...` passes