### PR TITLE
feat(worktree): reuse existing branches and add fzf picker

### DIFF
--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -36,8 +36,8 @@ func handleLaunch(profile string, args []string) {
 	// Worktree flags
 	worktreeBranch := fs.String("w", "", "Create session in git worktree for branch")
 	worktreeBranchLong := fs.String("worktree", "", "Create session in git worktree for branch")
-	newBranch := fs.Bool("b", false, "Create new branch (use with --worktree)")
-	newBranchLong := fs.Bool("new-branch", false, "Create new branch")
+	newBranch := fs.Bool("b", false, "Create new branch if needed (reuse existing branch when present)")
+	newBranchLong := fs.Bool("new-branch", false, "Create new branch if needed (reuse existing branch when present)")
 	worktreeLocation := fs.String("location", "", "Worktree location: sibling, subdirectory, or custom path")
 
 	// MCP flag
@@ -129,7 +129,7 @@ func handleLaunch(profile string, args []string) {
 	if *worktreeBranchLong != "" {
 		wtBranch = *worktreeBranchLong
 	}
-	createNewBranch := *newBranch || *newBranchLong
+	_ = *newBranch || *newBranchLong
 
 	// Validate --resume-session requires Claude
 	if *resumeSession != "" {
@@ -156,12 +156,6 @@ func handleLaunch(profile string, args []string) {
 
 		if err := git.ValidateBranchName(wtBranch); err != nil {
 			out.Error(fmt.Sprintf("invalid branch name: %v", err), ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
-
-		branchExists := git.BranchExists(repoRoot, wtBranch)
-		if createNewBranch && branchExists {
-			out.Error(fmt.Sprintf("branch '%s' already exists (remove -b flag to use existing branch)", wtBranch), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
 

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -815,8 +815,8 @@ func handleAdd(profile string, args []string) {
 	// Worktree flags
 	worktreeBranch := fs.String("w", "", "Create session in git worktree for branch")
 	worktreeBranchLong := fs.String("worktree", "", "Create session in git worktree for branch")
-	newBranch := fs.Bool("b", false, "Create new branch (use with --worktree)")
-	newBranchLong := fs.Bool("new-branch", false, "Create new branch")
+	newBranch := fs.Bool("b", false, "Create new branch if needed (reuse existing branch when present)")
+	newBranchLong := fs.Bool("new-branch", false, "Create new branch if needed (reuse existing branch when present)")
 	worktreeLocation := fs.String("location", "", "Worktree location: sibling, subdirectory, or custom path")
 
 	// MCP flag - can be specified multiple times
@@ -895,7 +895,7 @@ func handleAdd(profile string, args []string) {
 	if *worktreeBranchLong != "" {
 		wtBranch = *worktreeBranchLong
 	}
-	createNewBranch := *newBranch || *newBranchLong
+	_ = *newBranch || *newBranchLong
 
 	// Merge short and long flags
 	sessionTitle := mergeFlags(*title, *titleShort)
@@ -1032,17 +1032,6 @@ func handleAdd(profile string, args []string) {
 		// Pre-validate branch name for better error messages
 		if err := git.ValidateBranchName(wtBranch); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: invalid branch name: %v\n", err)
-			os.Exit(1)
-		}
-
-		// Check -b flag logic: if -b is passed, branch must NOT exist (user wants new branch)
-		branchExists := git.BranchExists(repoRoot, wtBranch)
-		if createNewBranch && branchExists {
-			fmt.Fprintf(
-				os.Stderr,
-				"Error: branch '%s' already exists (remove -b flag to use existing branch)\n",
-				wtBranch,
-			)
 			os.Exit(1)
 		}
 

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -383,8 +383,8 @@ func handleSessionFork(profile string, args []string) {
 	groupShort := fs.String("g", "", "Group for forked session (short)")
 	worktreeBranch := fs.String("w", "", "Create fork in git worktree for branch")
 	worktreeBranchLong := fs.String("worktree", "", "Create fork in git worktree for branch")
-	newBranch := fs.Bool("b", false, "Create new branch (use with --worktree)")
-	newBranchLong := fs.Bool("new-branch", false, "Create new branch")
+	newBranch := fs.Bool("b", false, "Create new branch if needed (reuse existing branch when present)")
+	newBranchLong := fs.Bool("new-branch", false, "Create new branch if needed (reuse existing branch when present)")
 	sandbox := fs.Bool("sandbox", false, "Run forked session in Docker sandbox")
 	sandboxImage := fs.String("sandbox-image", "", "Docker image for sandbox (overrides config default)")
 
@@ -472,7 +472,7 @@ func handleSessionFork(profile string, args []string) {
 	if *worktreeBranchLong != "" {
 		wtBranch = *worktreeBranchLong
 	}
-	createNewBranch := *newBranch || *newBranchLong
+	_ = *newBranch || *newBranchLong
 
 	// Handle worktree creation
 	var opts *session.ClaudeOptions
@@ -487,8 +487,8 @@ func handleSessionFork(profile string, args []string) {
 			os.Exit(1)
 		}
 
-		if !createNewBranch && !git.BranchExists(repoRoot, wtBranch) {
-			out.Error(fmt.Sprintf("branch '%s' does not exist (use -b to create)", wtBranch), ErrCodeInvalidOperation)
+		if err := git.ValidateBranchName(wtBranch); err != nil {
+			out.Error(fmt.Sprintf("invalid branch name: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -54,6 +55,26 @@ func BranchExists(repoDir, branchName string) bool {
 	cmd := exec.Command("git", "-C", repoDir, "show-ref", "--verify", "--quiet", "refs/heads/"+branchName)
 	err := cmd.Run()
 	return err == nil
+}
+
+func remoteBranchExists(repoDir, remoteName, branchName string) bool {
+	cmd := exec.Command("git", "-C", repoDir, "show-ref", "--verify", "--quiet", "refs/remotes/"+remoteName+"/"+branchName)
+	err := cmd.Run()
+	return err == nil
+}
+
+type worktreeBranchMode int
+
+const (
+	worktreeBranchNew worktreeBranchMode = iota
+	worktreeBranchLocal
+	worktreeBranchRemote
+)
+
+type worktreeBranchResolution struct {
+	Branch string
+	Mode   worktreeBranchMode
+	Remote string
 }
 
 // ValidateBranchName validates that a branch name follows git's naming rules
@@ -151,13 +172,22 @@ func CreateWorktree(repoDir, worktreePath, branchName string) error {
 		return errors.New("not a git repository")
 	}
 
-	var cmd *exec.Cmd
+	resolution, err := resolveWorktreeBranch(repoDir, branchName)
+	if err != nil {
+		return err
+	}
 
-	if BranchExists(repoDir, branchName) {
-		// Use existing branch
+	var cmd *exec.Cmd
+	switch resolution.Mode {
+	case worktreeBranchLocal:
+		// Reuse an existing local branch.
 		cmd = exec.Command("git", "-C", repoDir, "worktree", "add", worktreePath, branchName)
-	} else {
-		// Create new branch with -b flag
+	case worktreeBranchRemote:
+		// Create a local tracking branch from the default remote.
+		remoteRef := resolution.Remote + "/" + branchName
+		cmd = exec.Command("git", "-C", repoDir, "worktree", "add", "--track", "-b", branchName, worktreePath, remoteRef)
+	default:
+		// Create a new local branch.
 		cmd = exec.Command("git", "-C", repoDir, "worktree", "add", "-b", branchName, worktreePath)
 	}
 
@@ -358,6 +388,150 @@ func SanitizeBranchName(name string) string {
 	sanitized = strings.Trim(sanitized, "-")
 
 	return sanitized
+}
+
+func resolveWorktreeBranch(repoDir, branchName string) (worktreeBranchResolution, error) {
+	if !IsGitRepo(repoDir) {
+		return worktreeBranchResolution{}, errors.New("not a git repository")
+	}
+
+	resolution := worktreeBranchResolution{
+		Branch: branchName,
+		Mode:   worktreeBranchNew,
+	}
+
+	if BranchExists(repoDir, branchName) {
+		resolution.Mode = worktreeBranchLocal
+		return resolution, nil
+	}
+
+	defaultRemote, err := getDefaultRemote(repoDir)
+	if err == nil && defaultRemote != "" && remoteBranchExists(repoDir, defaultRemote, branchName) {
+		resolution.Mode = worktreeBranchRemote
+		resolution.Remote = defaultRemote
+	}
+
+	return resolution, nil
+}
+
+func getDefaultRemote(repoDir string) (string, error) {
+	remotes, err := listRemotes(repoDir)
+	if err != nil {
+		return "", err
+	}
+	if len(remotes) == 0 {
+		return "", errors.New("no git remotes configured")
+	}
+
+	currentBranch, err := GetCurrentBranch(repoDir)
+	if err == nil && currentBranch != "" && currentBranch != "HEAD" {
+		cmd := exec.Command("git", "-C", repoDir, "config", "--get", "branch."+currentBranch+".remote")
+		output, err := cmd.Output()
+		if err == nil {
+			remote := strings.TrimSpace(string(output))
+			if remote != "" {
+				return remote, nil
+			}
+		}
+	}
+
+	for _, remote := range remotes {
+		if remote == "origin" {
+			return remote, nil
+		}
+	}
+
+	if len(remotes) == 1 {
+		return remotes[0], nil
+	}
+
+	return "", fmt.Errorf("could not determine default remote from %d remotes", len(remotes))
+}
+
+func listRemotes(repoDir string) ([]string, error) {
+	cmd := exec.Command("git", "-C", repoDir, "remote")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list remotes: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	var remotes []string
+	for _, line := range lines {
+		remote := strings.TrimSpace(line)
+		if remote != "" {
+			remotes = append(remotes, remote)
+		}
+	}
+	return remotes, nil
+}
+
+func listRefShortNames(repoDir string, refs ...string) ([]string, error) {
+	args := []string{"-C", repoDir, "for-each-ref", "--format=%(refname:short)"}
+	args = append(args, refs...)
+	cmd := exec.Command("git", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list refs: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	var names []string
+	for _, line := range lines {
+		name := strings.TrimSpace(line)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// ListBranchCandidates returns unique branch names from local branches and the
+// default remote, normalized to plain branch names without a remote prefix.
+func ListBranchCandidates(repoDir string) ([]string, error) {
+	if !IsGitRepo(repoDir) {
+		return nil, errors.New("not a git repository")
+	}
+
+	repoRoot, err := GetWorktreeBaseRoot(repoDir)
+	if err == nil && repoRoot != "" {
+		repoDir = repoRoot
+	}
+
+	branches, err := listRefShortNames(repoDir, "refs/heads")
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(branches))
+	for _, branch := range branches {
+		seen[branch] = struct{}{}
+	}
+
+	if defaultRemote, err := getDefaultRemote(repoDir); err == nil && defaultRemote != "" {
+		remoteBranches, err := listRefShortNames(repoDir, "refs/remotes/"+defaultRemote)
+		if err != nil {
+			return nil, err
+		}
+		prefix := defaultRemote + "/"
+		for _, branch := range remoteBranches {
+			if branch == defaultRemote+"/HEAD" {
+				continue
+			}
+			branch = strings.TrimPrefix(branch, prefix)
+			if branch == "" {
+				continue
+			}
+			seen[branch] = struct{}{}
+		}
+	}
+
+	branches = branches[:0]
+	for branch := range seen {
+		branches = append(branches, branch)
+	}
+	sort.Strings(branches)
+	return branches, nil
 }
 
 // HasUncommittedChanges checks if the repository at dir has uncommitted changes

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -61,6 +61,17 @@ func createBranch(t *testing.T, dir, branchName string) {
 	}
 }
 
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, strings.TrimSpace(string(output)))
+	}
+	return strings.TrimSpace(string(output))
+}
+
 func TestIsGitRepo(t *testing.T) {
 	t.Run("returns true for git repo", func(t *testing.T) {
 		dir := t.TempDir()
@@ -491,6 +502,45 @@ func TestCreateWorktree(t *testing.T) {
 		}
 	})
 
+	t.Run("creates worktree from default remote branch", func(t *testing.T) {
+		dir := t.TempDir()
+		createTestRepo(t, dir)
+
+		remoteDir := filepath.Join(t.TempDir(), "origin.git")
+		if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+			t.Fatalf("failed to create remote dir: %v", err)
+		}
+		runGit(t, remoteDir, "init", "--bare")
+		runGit(t, dir, "remote", "add", "origin", remoteDir)
+		runGit(t, dir, "push", "-u", "origin", "main")
+		runGit(t, dir, "checkout", "-b", "remote-only")
+		runGit(t, dir, "push", "-u", "origin", "remote-only")
+		runGit(t, dir, "checkout", "main")
+		runGit(t, dir, "branch", "-D", "remote-only")
+
+		worktreePath := filepath.Join(t.TempDir(), "worktree")
+		if err := CreateWorktree(dir, worktreePath, "remote-only"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !BranchExists(dir, "remote-only") {
+			t.Fatal("expected CreateWorktree to create a local tracking branch")
+		}
+
+		branch, err := GetCurrentBranch(worktreePath)
+		if err != nil {
+			t.Fatalf("failed to get branch: %v", err)
+		}
+		if branch != "remote-only" {
+			t.Fatalf("expected remote-only branch, got %s", branch)
+		}
+
+		upstream := runGit(t, worktreePath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+		if upstream != "origin/remote-only" {
+			t.Fatalf("expected upstream origin/remote-only, got %s", upstream)
+		}
+	})
+
 	t.Run("returns error for invalid branch name", func(t *testing.T) {
 		dir := t.TempDir()
 		createTestRepo(t, dir)
@@ -512,6 +562,75 @@ func TestCreateWorktree(t *testing.T) {
 			t.Error("expected error for non-git directory")
 		}
 	})
+}
+
+func TestResolveWorktreeBranch(t *testing.T) {
+	t.Run("prefers local branch over default remote branch", func(t *testing.T) {
+		dir := t.TempDir()
+		createTestRepo(t, dir)
+
+		remoteDir := filepath.Join(t.TempDir(), "origin.git")
+		if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+			t.Fatalf("failed to create remote dir: %v", err)
+		}
+		runGit(t, remoteDir, "init", "--bare")
+		runGit(t, dir, "remote", "add", "origin", remoteDir)
+		runGit(t, dir, "push", "-u", "origin", "main")
+		runGit(t, dir, "checkout", "-b", "shared-branch")
+		runGit(t, dir, "push", "-u", "origin", "shared-branch")
+		runGit(t, dir, "checkout", "main")
+
+		resolution, err := resolveWorktreeBranch(dir, "shared-branch")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resolution.Mode != worktreeBranchLocal {
+			t.Fatalf("expected local branch resolution, got mode %d", resolution.Mode)
+		}
+		if resolution.Remote != "" {
+			t.Fatalf("expected no remote for local resolution, got %q", resolution.Remote)
+		}
+	})
+}
+
+func TestListBranchCandidates(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+
+	remoteDir := filepath.Join(t.TempDir(), "origin.git")
+	if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+		t.Fatalf("failed to create remote dir: %v", err)
+	}
+	runGit(t, remoteDir, "init", "--bare")
+	runGit(t, dir, "remote", "add", "origin", remoteDir)
+	runGit(t, dir, "push", "-u", "origin", "main")
+	runGit(t, dir, "checkout", "-b", "feature/local-only")
+	runGit(t, dir, "checkout", "main")
+	runGit(t, dir, "checkout", "-b", "feature/remote-only")
+	runGit(t, dir, "push", "-u", "origin", "feature/remote-only")
+	runGit(t, dir, "checkout", "main")
+	runGit(t, dir, "branch", "-D", "feature/remote-only")
+
+	branches, err := ListBranchCandidates(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !containsString(branches, "feature/local-only") {
+		t.Fatalf("expected local branch in candidates: %v", branches)
+	}
+	if !containsString(branches, "feature/remote-only") {
+		t.Fatalf("expected remote-only branch in candidates: %v", branches)
+	}
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestListWorktrees(t *testing.T) {

--- a/internal/ui/branch_picker.go
+++ b/internal/ui/branch_picker.go
@@ -1,0 +1,116 @@
+package ui
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+var openBranchPicker = branchPickerCmd
+
+type branchPickerResultMsg struct {
+	branch   string
+	canceled bool
+	err      error
+}
+
+func branchPickerCmd(projectPath string) tea.Cmd {
+	selected := ""
+	canceled := false
+
+	cmd := &branchPickerExecCmd{
+		projectPath: projectPath,
+		selected:    &selected,
+		canceled:    &canceled,
+	}
+
+	return tea.Exec(cmd, func(err error) tea.Msg {
+		return branchPickerResultMsg{
+			branch:   selected,
+			canceled: canceled,
+			err:      err,
+		}
+	})
+}
+
+type branchPickerExecCmd struct {
+	projectPath string
+	selected    *string
+	canceled    *bool
+	stdin       io.Reader
+	stdout      io.Writer
+	stderr      io.Writer
+}
+
+func (c *branchPickerExecCmd) Run() error {
+	if _, err := exec.LookPath("fzf"); err != nil {
+		return errors.New("fzf not found; install fzf or type branch manually")
+	}
+
+	projectPath := session.ExpandPath(strings.Trim(strings.TrimSpace(c.projectPath), "'\""))
+	if projectPath == "" {
+		return errors.New("project path is empty")
+	}
+
+	repoRoot, err := git.GetWorktreeBaseRoot(projectPath)
+	if err != nil {
+		return errors.New("path is not a git repository")
+	}
+
+	branches, err := git.ListBranchCandidates(repoRoot)
+	if err != nil {
+		return err
+	}
+	if len(branches) == 0 {
+		return errors.New("no branches found in repository")
+	}
+
+	var output bytes.Buffer
+	fzf := exec.Command("fzf", "--prompt", "Branch> ", "--height", "40%", "--reverse")
+	fzf.Stdin = strings.NewReader(strings.Join(branches, "\n") + "\n")
+	fzf.Stdout = &output
+	if c.stderr != nil {
+		fzf.Stderr = c.stderr
+	} else {
+		fzf.Stderr = os.Stderr
+	}
+
+	if err := fzf.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			switch exitErr.ExitCode() {
+			case 1, 130:
+				if c.canceled != nil {
+					*c.canceled = true
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("fzf failed: %w", err)
+	}
+
+	selected := strings.TrimSpace(output.String())
+	if selected == "" {
+		if c.canceled != nil {
+			*c.canceled = true
+		}
+		return nil
+	}
+	if c.selected != nil {
+		*c.selected = selected
+	}
+	return nil
+}
+
+func (c *branchPickerExecCmd) SetStdin(r io.Reader)  { c.stdin = r }
+func (c *branchPickerExecCmd) SetStdout(w io.Writer) { c.stdout = w }
+func (c *branchPickerExecCmd) SetStderr(w io.Writer) { c.stderr = w }

--- a/internal/ui/forkdialog.go
+++ b/internal/ui/forkdialog.go
@@ -186,6 +186,23 @@ func (d *ForkDialog) ClearError() {
 	d.validationErr = ""
 }
 
+func (d *ForkDialog) applyBranchPickerResult(msg branchPickerResultMsg) {
+	if msg.err != nil {
+		d.SetError(msg.err.Error())
+		return
+	}
+	if msg.canceled {
+		return
+	}
+	if msg.branch == "" {
+		return
+	}
+
+	d.branchInput.SetValue(msg.branch)
+	d.branchInput.SetCursor(len(msg.branch))
+	d.ClearError()
+}
+
 // Update handles input events
 func (d *ForkDialog) Update(msg tea.Msg) (*ForkDialog, tea.Cmd) {
 	if !d.visible {
@@ -195,6 +212,10 @@ func (d *ForkDialog) Update(msg tea.Msg) (*ForkDialog, tea.Cmd) {
 	optStart := d.optionsStartIndex()
 
 	switch msg := msg.(type) {
+	case branchPickerResultMsg:
+		d.applyBranchPickerResult(msg)
+		return d, nil
+
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "tab", "down":
@@ -255,6 +276,11 @@ func (d *ForkDialog) Update(msg tea.Msg) (*ForkDialog, tea.Cmd) {
 					d.updateFocus()
 				}
 				return d, nil
+			}
+
+		case "ctrl+f":
+			if d.focusIndex == 2 && d.worktreeEnabled {
+				return d, openBranchPicker(d.projectPath)
 			}
 
 		case "s":
@@ -414,6 +440,11 @@ func (d *ForkDialog) View() string {
 		errLine = "\n" + errStyle.Render("  ⚠ "+d.validationErr) + "\n"
 	}
 
+	helpText := "Enter create │ Esc cancel │ Tab next │ s sandbox │ Space toggle"
+	if d.focusIndex == 2 && d.worktreeEnabled {
+		helpText = "^F fzf pick │ Enter create │ Esc cancel │ Tab next"
+	}
+
 	content := titleStyle.Render("Fork Session") + "\n\n" +
 		nameLabel + "\n" +
 		"  " + d.nameInput.View() + "\n\n" +
@@ -424,7 +455,7 @@ func (d *ForkDialog) View() string {
 		d.optionsPanel.View() +
 		errLine + "\n" +
 		lipgloss.NewStyle().Foreground(ColorComment).
-			Render("Enter create │ Esc cancel │ Tab next │ s sandbox │ Space toggle")
+			Render(helpText)
 
 	dialog := boxStyle.Render(content)
 

--- a/internal/ui/forkdialog_test.go
+++ b/internal/ui/forkdialog_test.go
@@ -1,8 +1,11 @@
 package ui
 
 import (
+	"os"
 	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestNewForkDialog(t *testing.T) {
@@ -173,5 +176,54 @@ func TestForkDialog_Show_ClearsError(t *testing.T) {
 
 	if d.validationErr != "" {
 		t.Error("Show() should clear validationErr")
+	}
+}
+
+func TestForkDialog_CtrlFBranchPickerAppliesSelection(t *testing.T) {
+	d := NewForkDialog()
+	d.Show("Test", "/tmp/project", "group")
+	d.worktreeEnabled = true
+	d.focusIndex = 2
+	d.updateFocus()
+
+	origPicker := openBranchPicker
+	defer func() { openBranchPicker = origPicker }()
+
+	called := false
+	openBranchPicker = func(path string) tea.Cmd {
+		called = true
+		if path != "/tmp/project" {
+			t.Fatalf("picker path = %q, want %q", path, "/tmp/project")
+		}
+		return func() tea.Msg {
+			return branchPickerResultMsg{branch: "fork/picked"}
+		}
+	}
+
+	var cmd tea.Cmd
+	d, cmd = d.Update(tea.KeyMsg{Type: tea.KeyCtrlF})
+	if !called {
+		t.Fatal("expected ctrl+f to open branch picker")
+	}
+	if cmd == nil {
+		t.Fatal("expected ctrl+f to return a branch picker command")
+	}
+
+	d, _ = d.Update(cmd())
+	if got := d.branchInput.Value(); got != "fork/picked" {
+		t.Fatalf("branch = %q, want %q", got, "fork/picked")
+	}
+}
+
+func TestForkDialog_BranchPickerErrorIsShown(t *testing.T) {
+	d := NewForkDialog()
+	d.Show("Test", "/tmp/project", "group")
+	d.worktreeEnabled = true
+	d.focusIndex = 2
+	d.updateFocus()
+
+	d, _ = d.Update(branchPickerResultMsg{err: os.ErrNotExist})
+	if !strings.Contains(d.validationErr, os.ErrNotExist.Error()) {
+		t.Fatalf("expected picker error in validationErr, got %q", d.validationErr)
 	}
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2988,6 +2988,19 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
+	case branchPickerResultMsg:
+		if h.newDialog.IsVisible() {
+			var cmd tea.Cmd
+			h.newDialog, cmd = h.newDialog.Update(msg)
+			return h, cmd
+		}
+		if h.forkDialog.IsVisible() {
+			var cmd tea.Cmd
+			h.forkDialog, cmd = h.forkDialog.Update(msg)
+			return h, cmd
+		}
+		return h, nil
+
 	case sessionCreatedMsg:
 		// Handle reload scenario: session was already started in tmux, we MUST save it to JSON
 		// even during reload, otherwise the session becomes orphaned (exists in tmux but not in storage)

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -800,6 +800,36 @@ func (d *NewDialog) isTextInputFocused() bool {
 	}
 }
 
+func (d *NewDialog) worktreePickerPath() string {
+	if d.multiRepoEnabled {
+		for _, path := range d.multiRepoPaths {
+			path = strings.Trim(strings.TrimSpace(path), "'\"")
+			if path != "" {
+				return path
+			}
+		}
+	}
+	return strings.Trim(strings.TrimSpace(d.pathInput.Value()), "'\"")
+}
+
+func (d *NewDialog) applyBranchPickerResult(msg branchPickerResultMsg) {
+	if msg.err != nil {
+		d.SetError(msg.err.Error())
+		return
+	}
+	if msg.canceled {
+		return
+	}
+	if msg.branch == "" {
+		return
+	}
+
+	d.branchInput.SetValue(msg.branch)
+	d.branchInput.SetCursor(len(msg.branch))
+	d.branchAutoSet = false
+	d.ClearError()
+}
+
 func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 	if !d.visible {
 		return d, nil
@@ -810,6 +840,10 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 	cur := d.currentTarget()
 
 	switch msg := msg.(type) {
+	case branchPickerResultMsg:
+		d.applyBranchPickerResult(msg)
+		return d, nil
+
 	case tea.KeyMsg:
 		// Recent sessions picker handling
 		if d.showRecentPicker && len(d.recentSessions) > 0 {
@@ -952,6 +986,11 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				}
 				d.suggestionNavigated = true
 				return d, nil
+			}
+
+		case "ctrl+f":
+			if cur == focusBranch {
+				return d, openBranchPicker(d.worktreePickerPath())
 			}
 
 		case "down":
@@ -1672,6 +1711,8 @@ func (d *NewDialog) View() string {
 		} else {
 			helpText = "Tab autocomplete │ ^N/^P recent │ ↑↓ navigate │ Enter create │ Esc cancel"
 		}
+	} else if cur == focusBranch {
+		helpText = "^F fzf pick │ Tab next │ Enter create │ Esc cancel"
 	} else if cur == focusCommand {
 		selectedCmd := d.GetSelectedCommand()
 		if selectedCmd == "gemini" || selectedCmd == "codex" {

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -994,6 +994,61 @@ func TestNewDialog_ShowInGroup_ResetsBranchAutoSet(t *testing.T) {
 	}
 }
 
+func TestNewDialog_CtrlFBranchPickerAppliesSelection(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+	d.pathInput.SetValue("/tmp/project")
+	d.ToggleWorktree()
+	d.rebuildFocusTargets()
+	d.focusIndex = d.indexOf(focusBranch)
+	d.updateFocus()
+
+	origPicker := openBranchPicker
+	defer func() { openBranchPicker = origPicker }()
+
+	called := false
+	openBranchPicker = func(path string) tea.Cmd {
+		called = true
+		if path != "/tmp/project" {
+			t.Fatalf("picker path = %q, want %q", path, "/tmp/project")
+		}
+		return func() tea.Msg {
+			return branchPickerResultMsg{branch: "feature/picked"}
+		}
+	}
+
+	var cmd tea.Cmd
+	d, cmd = d.Update(tea.KeyMsg{Type: tea.KeyCtrlF})
+	if !called {
+		t.Fatal("expected ctrl+f to open branch picker")
+	}
+	if cmd == nil {
+		t.Fatal("expected ctrl+f to return a branch picker command")
+	}
+
+	d, _ = d.Update(cmd())
+	if got := d.branchInput.Value(); got != "feature/picked" {
+		t.Fatalf("branch = %q, want %q", got, "feature/picked")
+	}
+	if d.validationErr != "" {
+		t.Fatalf("expected no validation error, got %q", d.validationErr)
+	}
+}
+
+func TestNewDialog_BranchPickerErrorIsShown(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+	d.ToggleWorktree()
+	d.rebuildFocusTargets()
+	d.focusIndex = d.indexOf(focusBranch)
+	d.updateFocus()
+
+	d, _ = d.Update(branchPickerResultMsg{err: os.ErrNotExist})
+	if !strings.Contains(d.validationErr, os.ErrNotExist.Error()) {
+		t.Fatalf("expected picker error in validationErr, got %q", d.validationErr)
+	}
+}
+
 // ===== Soft-Select Tests =====
 
 func TestNewDialog_SoftSelect_InitialState(t *testing.T) {


### PR DESCRIPTION
## Summary
- reuse existing local branches and default-remote branches when creating worktrees
- stop erroring when -b/--new-branch is passed for an existing branch and keep CLI/TUI behavior aligned
- add Ctrl+F fzf branch picking in new/fork worktree dialogs with tests for remote branch reuse and picker flows