### PR TITLE
Fix default worktree location fallback

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1380,7 +1380,7 @@ func GetWorktreeSettings() WorktreeSettings {
 	config, err := LoadUserConfig()
 	if err != nil || config == nil {
 		return WorktreeSettings{
-			DefaultLocation: "subdirectory",
+			DefaultLocation: "sibling",
 			AutoCleanup:     true,
 		}
 	}
@@ -1388,7 +1388,7 @@ func GetWorktreeSettings() WorktreeSettings {
 	settings := config.Worktree
 
 	if settings.DefaultLocation == "" {
-		settings.DefaultLocation = "subdirectory"
+		settings.DefaultLocation = "sibling"
 	}
 	// AutoCleanup defaults to true (Go zero value is false)
 	// We detect if section was not present by checking if DefaultLocation is empty

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -411,11 +411,40 @@ func TestGetWorktreeSettings(t *testing.T) {
 	ClearUserConfigCache()
 
 	settings := GetWorktreeSettings()
-	if settings.DefaultLocation != "subdirectory" {
-		t.Errorf("GetWorktreeSettings DefaultLocation: got %q, want %q", settings.DefaultLocation, "subdirectory")
+	if settings.DefaultLocation != "sibling" {
+		t.Errorf("GetWorktreeSettings DefaultLocation: got %q, want %q", settings.DefaultLocation, "sibling")
 	}
 	if !settings.AutoCleanup {
 		t.Error("GetWorktreeSettings AutoCleanup: should default to true")
+	}
+}
+
+func TestGetWorktreeSettings_UsesSiblingWhenLocationUnsetInConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("Failed to create agent-deck dir: %v", err)
+	}
+
+	configPath := filepath.Join(agentDeckDir, "config.toml")
+	configContent := "[worktree]\nauto_cleanup = true\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	ClearUserConfigCache()
+
+	settings := GetWorktreeSettings()
+	if settings.DefaultLocation != "sibling" {
+		t.Errorf("GetWorktreeSettings DefaultLocation: got %q, want %q", settings.DefaultLocation, "sibling")
+	}
+	if !settings.AutoCleanup {
+		t.Error("GetWorktreeSettings AutoCleanup: should remain true from config")
 	}
 }
 


### PR DESCRIPTION
## Summary
- make the default worktree location fallback to `sibling`
- keep empty location semantics aligned with `sibling`
- add coverage for config files that omit `default_location`

## Testing
- go test ./internal/session -run 'TestGetWorktreeSettings|TestGetWorktreeSettings_FromConfig|TestGetWorktreeSettings_UsesSiblingWhenLocationUnsetInConfig'
- go test ./internal/git -run 'TestGenerateWorktreePath|TestWorktreePath'