### PR TITLE
Add happy wrapper support for Claude and Codex

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -481,16 +481,21 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 		return baseCommand
 	}
 
-	// Get the configured Claude command (e.g., "claude", "cdw", "cdp")
-	// If a custom command is set, we skip CLAUDE_CONFIG_DIR prefix since the alias handles it
-	claudeCmd := GetClaudeCommand()
-	hasCustomCommand := claudeCmd != "claude"
+	// Get options - either from instance or create defaults from config
+	opts := i.GetClaudeOptions()
+	if opts == nil {
+		// Fall back to config defaults
+		userConfig, _ := LoadUserConfig()
+		opts = NewClaudeOptions(userConfig)
+	}
+
+	claudeCmd, hasCustomCommand := resolveClaudeLaunchCommand(opts)
 
 	// Check if CLAUDE_CONFIG_DIR is explicitly configured (env var or config.toml)
 	// If NOT explicit, we don't set it in the command - let the shell's environment handle it.
 	// This is critical for WSL and other environments where users have CLAUDE_CONFIG_DIR
 	// set in their .bashrc/.zshrc - we should NOT override that with a default path.
-	// Also skip if using a custom command (alias handles config dir)
+	// Also skip if using a custom command alias (alias handles config dir).
 	configDirPrefix := ""
 	if !hasCustomCommand && IsClaudeConfigDirExplicit() {
 		configDir := GetClaudeConfigDir()
@@ -501,14 +506,6 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 	// can identify which agent-deck session they belong to.
 	instanceIDPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s ", i.ID)
 	configDirPrefix = instanceIDPrefix + configDirPrefix
-
-	// Get options - either from instance or create defaults from config
-	opts := i.GetClaudeOptions()
-	if opts == nil {
-		// Fall back to config defaults
-		userConfig, _ := LoadUserConfig()
-		opts = NewClaudeOptions(userConfig)
-	}
 
 	// If baseCommand is just "claude", build the appropriate command
 	if baseCommand == "claude" {
@@ -588,6 +585,32 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 
 	// For custom commands (e.g., fork commands), return as-is
 	return baseCommand
+}
+
+func resolveClaudeLaunchCommand(opts *ClaudeOptions) (cmd string, hasCustomCommand bool) {
+	if opts == nil {
+		userConfig, _ := LoadUserConfig()
+		opts = NewClaudeOptions(userConfig)
+	}
+
+	configuredCmd := GetClaudeCommand()
+	if configuredCmd == "" {
+		configuredCmd = "claude"
+	}
+
+	hasCustomCommand = configuredCmd != "claude"
+	if hasCustomCommand {
+		return configuredCmd, true
+	}
+
+	if opts != nil {
+		if opts.UseHappy {
+			return "happy", false
+		}
+		return configuredCmd, false
+	}
+
+	return configuredCmd, false
 }
 
 // buildBashExportPrefix builds the export prefix used in bash -c commands.
@@ -784,8 +807,8 @@ func (i *Instance) DetectOpenCodeSession() {
 	i.detectOpenCodeSessionAsync()
 }
 
-// buildCodexCommand builds the command for OpenAI Codex CLI
-// resolveCodexYoloFlag returns " --yolo" if yolo mode is enabled (per-session override > global config), or "".
+// resolveCodexYoloFlag returns " --yolo" if yolo mode is enabled
+// (per-session override > global config), or "".
 func (i *Instance) resolveCodexYoloFlag() string {
 	opts := i.GetCodexOptions()
 	if opts != nil && opts.YoloMode != nil {
@@ -803,6 +826,17 @@ func (i *Instance) resolveCodexYoloFlag() string {
 	return ""
 }
 
+func (i *Instance) resolveCodexUseHappy() bool {
+	opts := i.GetCodexOptions()
+	if opts != nil && opts.UseHappy != nil {
+		return *opts.UseHappy
+	}
+	if config, err := LoadUserConfig(); err == nil && config != nil {
+		return config.Codex.UseHappy
+	}
+	return false
+}
+
 // Codex stores sessions in ~/.codex/sessions/YYYY/MM/DD/*.jsonl
 // Resume: codex resume <session-id> or codex resume --last
 // Also sources .env files from [shell].env_files
@@ -817,18 +851,22 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	envPrefix += agentdeckEnvPrefix
 
 	yoloFlag := i.resolveCodexYoloFlag()
+	codexCmd := "codex"
+	if i.resolveCodexUseHappy() {
+		codexCmd = "happy codex"
+	}
 
 	// If baseCommand is just "codex", handle specially
 	if baseCommand == "codex" {
 		// If we already have a session ID, use resume.
 		// CODEX_SESSION_ID is propagated via host-side SetEnvironment after tmux start.
 		if i.CodexSessionID != "" {
-			return envPrefix + fmt.Sprintf("codex%s resume %s",
-				yoloFlag, i.CodexSessionID)
+			return envPrefix + fmt.Sprintf("%s%s resume %s",
+				codexCmd, yoloFlag, i.CodexSessionID)
 		}
 
 		// Start Codex fresh - session ID will be captured async after startup
-		return envPrefix + "codex" + yoloFlag
+		return envPrefix + codexCmd + yoloFlag
 	}
 
 	// For custom commands (e.g., resume commands), preserve env propagation.
@@ -4050,14 +4088,19 @@ func (i *Instance) Restart() error {
 	return nil
 }
 
-// buildClaudeResumeCommand builds the claude resume command with proper config options
-// Respects: CLAUDE_CONFIG_DIR, dangerous_mode from user config
+// buildClaudeResumeCommand builds the Claude resume command with proper config options.
+// Respects: CLAUDE_CONFIG_DIR, use_happy, and dangerous_mode from user/session config.
 // CLAUDE_SESSION_ID is set via host-side SetEnvironment (called by SyncSessionIDsToTmux after restart)
 func (i *Instance) buildClaudeResumeCommand() string {
-	// Get the configured Claude command (e.g., "claude", "cdw", "cdp")
-	// If a custom command is set, we skip CLAUDE_CONFIG_DIR prefix since the alias handles it
-	claudeCmd := GetClaudeCommand()
-	hasCustomCommand := claudeCmd != "claude"
+	opts := i.GetClaudeOptions()
+	if opts == nil {
+		userConfig, _ := LoadUserConfig()
+		opts = NewClaudeOptions(userConfig)
+	}
+
+	// Get the configured Claude command (e.g., "claude", "cdw", "happy")
+	// If a custom command alias is set, we skip CLAUDE_CONFIG_DIR prefix since the alias handles it.
+	claudeCmd, hasCustomCommand := resolveClaudeLaunchCommand(opts)
 
 	// Check if CLAUDE_CONFIG_DIR is explicitly configured
 	// If NOT explicit, don't set it - let the shell's environment handle it
@@ -4072,13 +4115,6 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// can identify which agent-deck session they belong to.
 	instanceIDPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s ", i.ID)
 	configDirPrefix = instanceIDPrefix + configDirPrefix
-
-	// Get per-session permission settings (falls back to config if not persisted)
-	opts := i.GetClaudeOptions()
-	if opts == nil {
-		userConfig, _ := LoadUserConfig()
-		opts = NewClaudeOptions(userConfig)
-	}
 	dangerousMode := opts.SkipPermissions
 	allowDangerousMode := opts.AllowSkipPermissions
 
@@ -4244,7 +4280,8 @@ func (i *Instance) buildClaudeForkCommandForTarget(target *Instance, opts *Claud
 	workDir := target.ProjectPath
 
 	// IMPORTANT: For capture-resume commands (which contain $(...) syntax), we MUST use
-	// "claude" binary + explicit env exports, NOT a custom command alias like "cdw".
+	// the default launch binary ("claude" or "happy") + explicit env exports, NOT a
+	// custom command alias like "cdw".
 	// Reason: Commands with $(...) get wrapped in `bash -c` for fish compatibility (#47),
 	// and shell aliases are not available in non-interactive bash shells.
 	bashExportPrefix := target.buildBashExportPrefix()
@@ -4253,6 +4290,11 @@ func (i *Instance) buildClaudeForkCommandForTarget(target *Instance, opts *Claud
 	if opts == nil {
 		userConfig, _ := LoadUserConfig()
 		opts = NewClaudeOptions(userConfig)
+	}
+
+	claudeCmd, hasCustomCommand := resolveClaudeLaunchCommand(opts)
+	if hasCustomCommand {
+		claudeCmd = "claude"
 	}
 
 	// Build extra flags from options (for fork, we use ToArgsForFork which excludes session mode)
@@ -4267,9 +4309,9 @@ func (i *Instance) buildClaudeForkCommandForTarget(target *Instance, opts *Claud
 	target.ClaudeSessionID = forkUUID
 	cmd := fmt.Sprintf(
 		`cd '%s' && `+
-			`%sexec claude --session-id "%s" --resume %s --fork-session%s`,
+			`%sexec %s --session-id "%s" --resume %s --fork-session%s`,
 		workDir,
-		bashExportPrefix, forkUUID, i.ClaudeSessionID, extraFlags)
+		bashExportPrefix, claudeCmd, forkUUID, i.ClaudeSessionID, extraFlags)
 	cmd, err := i.applyWrapper(cmd)
 	if err != nil {
 		return "", err

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -504,6 +504,106 @@ config_dir = "~/.claude-work"
 	}
 }
 
+func TestBuildClaudeCommand_UseHappy(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	configContent := `[claude]
+use_happy = true
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	ClearUserConfigCache()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	}()
+
+	inst := NewInstanceWithTool("happy-claude", "/tmp/test", "claude")
+	cmd := inst.buildClaudeCommand("claude")
+
+	if !strings.Contains(cmd, "exec happy --session-id") {
+		t.Errorf("Should launch Claude via happy when use_happy=true, got: %s", cmd)
+	}
+}
+
+func TestBuildClaudeCommand_CustomAliasWinsOverHappy(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	configContent := `[claude]
+command = "cdw"
+use_happy = true
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	ClearUserConfigCache()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	}()
+
+	inst := NewInstanceWithTool("alias-claude", "/tmp/test", "claude")
+	cmd := inst.buildClaudeCommand("claude")
+
+	if !strings.Contains(cmd, "cdw") {
+		t.Errorf("Should use custom Claude command when configured, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "exec happy") {
+		t.Errorf("Custom Claude command should win over happy, got: %s", cmd)
+	}
+}
+
+func TestBuildClaudeCommand_PerSessionUseHappyOverride(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	configContent := `[claude]
+use_happy = true
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	ClearUserConfigCache()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	}()
+
+	inst := NewInstanceWithTool("plain-claude", "/tmp/test", "claude")
+	if err := inst.SetClaudeOptions(&ClaudeOptions{SessionMode: "new", UseHappy: false}); err != nil {
+		t.Fatalf("SetClaudeOptions failed: %v", err)
+	}
+
+	cmd := inst.buildClaudeCommand("claude")
+	if strings.Contains(cmd, "exec happy") {
+		t.Errorf("Per-session UseHappy=false should override global config, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "exec claude --session-id") {
+		t.Errorf("Expected plain claude command when per-session UseHappy=false, got: %s", cmd)
+	}
+}
+
 // TestBuildClaudeCommand_SubagentAddDir tests that subagents get --add-dir
 // for access to parent's project directory (for worktrees, etc.)
 func TestBuildClaudeCommand_SubagentAddDir(t *testing.T) {
@@ -2316,6 +2416,147 @@ func TestBuildClaudeCommand_ExportsInstanceID(t *testing.T) {
 	expectedPrefix := "AGENTDECK_INSTANCE_ID=" + inst.ID
 	if !strings.Contains(cmd, expectedPrefix) {
 		t.Errorf("Command should contain %q, got: %s", expectedPrefix, cmd)
+	}
+}
+
+func TestBuildCodexCommand_UseHappy(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	configContent := `[codex]
+use_happy = true
+yolo_mode = true
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	ClearUserConfigCache()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	}()
+
+	inst := NewInstanceWithTool("happy-codex", "/tmp/test", "codex")
+	cmd := inst.buildCodexCommand("codex")
+
+	if !strings.Contains(cmd, "happy codex --yolo") {
+		t.Errorf("Should launch Codex via happy with yolo flag, got: %s", cmd)
+	}
+}
+
+func TestBuildCodexCommand_PerSessionUseHappyOverride(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	configContent := `[codex]
+use_happy = true
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	ClearUserConfigCache()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	}()
+
+	inst := NewInstanceWithTool("plain-codex", "/tmp/test", "codex")
+	inst.CodexSessionID = "codex-session-123"
+	if err := inst.SetCodexOptions(&CodexOptions{
+		YoloMode: boolPtr(true),
+		UseHappy: boolPtr(false),
+	}); err != nil {
+		t.Fatalf("SetCodexOptions failed: %v", err)
+	}
+
+	cmd := inst.buildCodexCommand("codex")
+
+	if strings.Contains(cmd, "happy codex") {
+		t.Errorf("Per-session UseHappy=false should override global config, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "codex --yolo resume codex-session-123") {
+		t.Errorf("Expected plain codex resume command with yolo, got: %s", cmd)
+	}
+}
+
+func TestBuildClaudeResumeCommand_UseHappy(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	configContent := `[claude]
+use_happy = true
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	ClearUserConfigCache()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	}()
+
+	inst := NewInstanceWithTool("resume-happy", "/tmp/test", "claude")
+	inst.ClaudeSessionID = "resume-session-123"
+	inst.ClaudeDetectedAt = time.Now()
+
+	cmd := inst.buildClaudeResumeCommand()
+	if !strings.Contains(cmd, "happy --session-id resume-session-123") &&
+		!strings.Contains(cmd, "happy --resume resume-session-123") {
+		t.Errorf("Resume command should use happy when configured, got: %s", cmd)
+	}
+}
+
+func TestBuildClaudeForkCommandForTarget_UseHappy(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	tmpDir := t.TempDir()
+	os.Setenv("HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	configContent := `[claude]
+use_happy = true
+`
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	ClearUserConfigCache()
+	defer func() {
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	}()
+
+	parent := NewInstanceWithTool("parent", "/tmp/test", "claude")
+	parent.ClaudeSessionID = "parent-session-123"
+	parent.ClaudeDetectedAt = time.Now()
+	target := NewInstanceWithTool("fork", "/tmp/test", "claude")
+
+	cmd, err := parent.buildClaudeForkCommandForTarget(target, nil)
+	if err != nil {
+		t.Fatalf("buildClaudeForkCommandForTarget failed: %v", err)
+	}
+	if !strings.Contains(cmd, "exec happy --session-id") {
+		t.Errorf("Fork command should use happy when configured, got: %s", cmd)
 	}
 }
 

--- a/internal/session/tooloptions.go
+++ b/internal/session/tooloptions.go
@@ -20,6 +20,8 @@ type ClaudeOptions struct {
 	SessionMode string `json:"session_mode,omitempty"`
 	// ResumeSessionID is the session ID for -r flag (only when SessionMode="resume")
 	ResumeSessionID string `json:"resume_session_id,omitempty"`
+	// UseHappy launches Claude via the happy wrapper
+	UseHappy bool `json:"use_happy,omitempty"`
 	// SkipPermissions adds --dangerously-skip-permissions flag
 	SkipPermissions bool `json:"skip_permissions,omitempty"`
 	// AllowSkipPermissions adds --allow-dangerously-skip-permissions flag
@@ -99,6 +101,7 @@ func NewClaudeOptions(config *UserConfig) *ClaudeOptions {
 		SessionMode: "new",
 	}
 	if config != nil {
+		opts.UseHappy = config.Claude.UseHappy
 		opts.SkipPermissions = config.Claude.GetDangerousMode()
 		opts.AllowSkipPermissions = config.Claude.AllowDangerousMode
 	}
@@ -110,6 +113,9 @@ type CodexOptions struct {
 	// YoloMode enables --yolo flag (bypass approvals and sandbox)
 	// nil = inherit from global config, true/false = explicit override
 	YoloMode *bool `json:"yolo_mode,omitempty"`
+	// UseHappy launches Codex via "happy codex"
+	// nil = inherit from global config, true/false = explicit override
+	UseHappy *bool `json:"use_happy,omitempty"`
 }
 
 // ToolName returns "codex"
@@ -132,6 +138,10 @@ func NewCodexOptions(config *UserConfig) *CodexOptions {
 	if config != nil && config.Codex.YoloMode {
 		yolo := true
 		opts.YoloMode = &yolo
+	}
+	if config != nil && config.Codex.UseHappy {
+		useHappy := true
+		opts.UseHappy = &useHappy
 	}
 	return opts
 }

--- a/internal/session/tooloptions_test.go
+++ b/internal/session/tooloptions_test.go
@@ -192,6 +192,7 @@ func TestNewClaudeOptions_WithConfig(t *testing.T) {
 	config := &UserConfig{
 		Claude: ClaudeSettings{
 			DangerousMode: &dangerousModeBool,
+			UseHappy:      true,
 		},
 	}
 
@@ -202,6 +203,9 @@ func TestNewClaudeOptions_WithConfig(t *testing.T) {
 	}
 	if !opts.SkipPermissions {
 		t.Error("expected SkipPermissions=true when config.DangerousMode=true")
+	}
+	if !opts.UseHappy {
+		t.Error("expected UseHappy=true when config.Claude.UseHappy=true")
 	}
 }
 
@@ -216,6 +220,9 @@ func TestNewClaudeOptions_NilConfig(t *testing.T) {
 	}
 	if opts.AllowSkipPermissions {
 		t.Error("expected AllowSkipPermissions=false when config is nil")
+	}
+	if opts.UseHappy {
+		t.Error("expected UseHappy=false when config is nil")
 	}
 }
 
@@ -302,6 +309,7 @@ func TestUnmarshalClaudeOptions(t *testing.T) {
 	opts := &ClaudeOptions{
 		SessionMode:     "resume",
 		ResumeSessionID: "test-session-123",
+		UseHappy:        true,
 		SkipPermissions: true,
 		UseChrome:       true,
 		UseTeammateMode: true,
@@ -326,6 +334,9 @@ func TestUnmarshalClaudeOptions(t *testing.T) {
 	}
 	if !result.SkipPermissions {
 		t.Error("expected SkipPermissions=true")
+	}
+	if !result.UseHappy {
+		t.Error("expected UseHappy=true")
 	}
 	if !result.UseChrome {
 		t.Error("expected UseChrome=true")
@@ -413,22 +424,28 @@ func TestCodexOptions_ToArgs(t *testing.T) {
 }
 
 func TestNewCodexOptions_WithConfig(t *testing.T) {
-	// Global yolo=true
+	// Global yolo=true, use_happy=true
 	config := &UserConfig{
-		Codex: CodexSettings{YoloMode: true},
+		Codex: CodexSettings{YoloMode: true, UseHappy: true},
 	}
 	opts := NewCodexOptions(config)
 	if opts.YoloMode == nil || !*opts.YoloMode {
 		t.Error("expected YoloMode=true when config.Codex.YoloMode=true")
 	}
+	if opts.UseHappy == nil || !*opts.UseHappy {
+		t.Error("expected UseHappy=true when config.Codex.UseHappy=true")
+	}
 
-	// Global yolo=false
+	// Global yolo=false, use_happy=false
 	config2 := &UserConfig{
-		Codex: CodexSettings{YoloMode: false},
+		Codex: CodexSettings{YoloMode: false, UseHappy: false},
 	}
 	opts2 := NewCodexOptions(config2)
 	if opts2.YoloMode != nil {
 		t.Errorf("expected YoloMode=nil when config.Codex.YoloMode=false, got %v", *opts2.YoloMode)
+	}
+	if opts2.UseHappy != nil {
+		t.Errorf("expected UseHappy=nil when config.Codex.UseHappy=false, got %v", *opts2.UseHappy)
 	}
 }
 
@@ -437,10 +454,13 @@ func TestNewCodexOptions_NilConfig(t *testing.T) {
 	if opts.YoloMode != nil {
 		t.Errorf("expected YoloMode=nil when config is nil, got %v", *opts.YoloMode)
 	}
+	if opts.UseHappy != nil {
+		t.Errorf("expected UseHappy=nil when config is nil, got %v", *opts.UseHappy)
+	}
 }
 
 func TestCodexOptions_MarshalUnmarshal(t *testing.T) {
-	original := &CodexOptions{YoloMode: boolPtr(true)}
+	original := &CodexOptions{YoloMode: boolPtr(true), UseHappy: boolPtr(true)}
 
 	data, err := MarshalToolOptions(original)
 	if err != nil {
@@ -454,6 +474,9 @@ func TestCodexOptions_MarshalUnmarshal(t *testing.T) {
 
 	if restored.YoloMode == nil || !*restored.YoloMode {
 		t.Error("expected YoloMode=true after roundtrip")
+	}
+	if restored.UseHappy == nil || !*restored.UseHappy {
+		t.Error("expected UseHappy=true after roundtrip")
 	}
 }
 
@@ -482,7 +505,7 @@ func TestUnmarshalCodexOptions_WrongTool(t *testing.T) {
 }
 
 func TestCodexOptions_RoundTrip_NilYolo(t *testing.T) {
-	original := &CodexOptions{YoloMode: nil}
+	original := &CodexOptions{YoloMode: nil, UseHappy: nil}
 
 	data, err := MarshalToolOptions(original)
 	if err != nil {
@@ -496,6 +519,9 @@ func TestCodexOptions_RoundTrip_NilYolo(t *testing.T) {
 
 	if restored.YoloMode != nil {
 		t.Errorf("expected YoloMode=nil after roundtrip, got %v", *restored.YoloMode)
+	}
+	if restored.UseHappy != nil {
+		t.Errorf("expected UseHappy=nil after roundtrip, got %v", *restored.UseHappy)
 	}
 }
 

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -528,6 +528,11 @@ type ClaudeSettings struct {
 	// This allows using shell aliases that set CLAUDE_CONFIG_DIR automatically
 	Command string `toml:"command"`
 
+	// UseHappy launches Claude via the happy wrapper by default.
+	// Ignored when Command is set to a custom alias or command.
+	// Default: false
+	UseHappy bool `toml:"use_happy"`
+
 	// ConfigDir is the path to Claude's config directory
 	// Default: ~/.claude (or CLAUDE_CONFIG_DIR env var)
 	ConfigDir string `toml:"config_dir"`
@@ -622,6 +627,10 @@ type CodexSettings struct {
 	// YoloMode enables --yolo flag for Codex sessions (bypass approvals and sandbox)
 	// Default: false
 	YoloMode bool `toml:"yolo_mode"`
+
+	// UseHappy launches Codex via "happy codex" by default.
+	// Default: false
+	UseHappy bool `toml:"use_happy"`
 }
 
 // WorktreeSettings contains git worktree preferences.
@@ -1648,6 +1657,8 @@ func CreateExampleConfig() error {
 # config_dir = "~/.claude-work"
 # Enable --dangerously-skip-permissions by default (default: false)
 # dangerous_mode = true
+# Launch Claude via happy by default (default: false)
+# use_happy = true
 
 # Gemini CLI integration
 # [gemini]
@@ -1665,6 +1676,8 @@ func CreateExampleConfig() error {
 # [codex]
 # Enable --yolo (bypass approvals and sandbox) by default (default: false)
 # yolo_mode = true
+# Launch Codex via happy by default (default: false)
+# use_happy = true
 
 # Log file management
 # Agent-deck logs session output to ~/.agent-deck/logs/ for status detection

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -14,6 +14,7 @@ func TestUserConfig_ClaudeConfigDir(t *testing.T) {
 	configContent := `
 [claude]
 config_dir = "~/.claude-work"
+use_happy = true
 
 [tools.test]
 command = "test"
@@ -32,6 +33,9 @@ command = "test"
 
 	if config.Claude.ConfigDir != "~/.claude-work" {
 		t.Errorf("Claude.ConfigDir = %s, want ~/.claude-work", config.Claude.ConfigDir)
+	}
+	if !config.Claude.UseHappy {
+		t.Error("Claude.UseHappy should be true")
 	}
 }
 
@@ -92,6 +96,34 @@ command = "test"
 
 	if config.Claude.ConfigDir != "" {
 		t.Errorf("Claude.ConfigDir = %s, want empty string", config.Claude.ConfigDir)
+	}
+	if config.Claude.UseHappy {
+		t.Error("Claude.UseHappy should default to false")
+	}
+}
+
+func TestUserConfig_CodexUseHappy(t *testing.T) {
+	tmpDir := t.TempDir()
+	configContent := `
+[codex]
+yolo_mode = true
+use_happy = true
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	var config UserConfig
+	if _, err := toml.DecodeFile(configPath, &config); err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+
+	if !config.Codex.YoloMode {
+		t.Error("Codex.YoloMode should be true")
+	}
+	if !config.Codex.UseHappy {
+		t.Error("Codex.UseHappy should be true")
 	}
 }
 

--- a/internal/ui/claudeoptions.go
+++ b/internal/ui/claudeoptions.go
@@ -15,6 +15,7 @@ type ClaudeOptionsPanel struct {
 	// Resume session ID input (only for mode=resume)
 	resumeIDInput textinput.Model
 	// Checkbox states
+	useHappy             bool
 	skipPermissions      bool
 	allowSkipPermissions bool
 	useChrome            bool
@@ -30,8 +31,10 @@ type ClaudeOptionsPanel struct {
 // Focus indices for NewDialog mode:
 // 0: Session mode (radio)
 // 1: Resume ID input (only when mode=resume)
-// 2: Skip permissions checkbox
-// 3: Chrome checkbox
+// 2: Use happy checkbox
+// 3: Skip permissions checkbox
+// 4: Chrome checkbox
+// 5: Teammate checkbox
 
 // Focus indices for ForkDialog mode:
 // 0: Skip permissions checkbox
@@ -48,7 +51,7 @@ func NewClaudeOptionsPanel() *ClaudeOptionsPanel {
 		sessionMode:   0, // new
 		resumeIDInput: resumeInput,
 		isForkMode:    false,
-		focusCount:    5, // Will adjust dynamically
+		focusCount:    6, // Will adjust dynamically
 	}
 }
 
@@ -65,6 +68,7 @@ func NewClaudeOptionsPanelForFork() *ClaudeOptionsPanel {
 // SetDefaults applies default values from config
 func (p *ClaudeOptionsPanel) SetDefaults(config *session.UserConfig) {
 	if config != nil {
+		p.useHappy = config.Claude.UseHappy
 		p.skipPermissions = config.Claude.GetDangerousMode()
 		p.allowSkipPermissions = config.Claude.AllowDangerousMode
 	}
@@ -84,6 +88,7 @@ func (p *ClaudeOptionsPanel) SetFromOptions(opts *session.ClaudeOptions) {
 	default:
 		p.sessionMode = 0
 	}
+	p.useHappy = opts.UseHappy
 	p.skipPermissions = opts.SkipPermissions
 	p.allowSkipPermissions = opts.AllowSkipPermissions
 	p.useChrome = opts.UseChrome
@@ -117,6 +122,7 @@ func (p *ClaudeOptionsPanel) AtTop() bool {
 // GetOptions returns current options as ClaudeOptions
 func (p *ClaudeOptionsPanel) GetOptions() *session.ClaudeOptions {
 	opts := &session.ClaudeOptions{
+		UseHappy:             p.useHappy,
 		SkipPermissions:      p.skipPermissions,
 		AllowSkipPermissions: p.allowSkipPermissions,
 		UseChrome:            p.useChrome,
@@ -219,6 +225,8 @@ func (p *ClaudeOptionsPanel) handleSpaceKey() {
 		case "sessionMode":
 			// Cycle through modes on space
 			p.sessionMode = (p.sessionMode + 1) % 3
+		case "useHappy":
+			p.useHappy = !p.useHappy
 		case "skipPermissions":
 			p.skipPermissions = !p.skipPermissions
 		case "chrome":
@@ -253,16 +261,20 @@ func (p *ClaudeOptionsPanel) getFocusType() string {
 			}
 			idx-- // Adjust for missing resume input
 		}
-		// 2: skip permissions
+		// 2: use happy
 		if idx == 1 {
+			return "useHappy"
+		}
+		// 3: skip permissions
+		if idx == 2 {
 			return "skipPermissions"
 		}
-		// 3: chrome
-		if idx == 2 {
+		// 4: chrome
+		if idx == 3 {
 			return "chrome"
 		}
-		// 4: teammate mode
-		if idx == 3 {
+		// 5: teammate mode
+		if idx == 4 {
 			return "teammateMode"
 		}
 	}
@@ -275,7 +287,7 @@ func (p *ClaudeOptionsPanel) getFocusCount() int {
 		return 3 // skip, chrome, teammate
 	}
 
-	count := 4 // session mode, skip, chrome, teammate
+	count := 5 // session mode, use happy, skip, chrome, teammate
 	if p.sessionMode == 2 {
 		count++ // resume input
 	}
@@ -350,6 +362,10 @@ func (p *ClaudeOptionsPanel) viewNewMode(labelStyle, activeStyle, dimStyle, head
 		}
 		focusIdx++
 	}
+
+	// Use happy checkbox
+	content += renderCheckboxLine("Use happy wrapper", p.useHappy, p.focusIndex == focusIdx)
+	focusIdx++
 
 	// Skip permissions checkbox
 	content += renderCheckboxLine("Skip permissions", p.skipPermissions, p.focusIndex == focusIdx)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4311,9 +4311,9 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if command == "claude" && claudeOpts != nil {
 			toolOptionsJSON, _ = session.MarshalToolOptions(claudeOpts)
 		} else if command == "codex" {
-			yolo := h.newDialog.GetCodexYoloMode()
-			codexOpts := &session.CodexOptions{YoloMode: &yolo}
-			toolOptionsJSON, _ = session.MarshalToolOptions(codexOpts)
+			if codexOpts := h.newDialog.GetCodexOptions(); codexOpts != nil {
+				toolOptionsJSON, _ = session.MarshalToolOptions(codexOpts)
+			}
 		}
 
 		// Only non-worktree sessions may need interactive "create directory" confirmation.

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -97,6 +97,7 @@ type dialogSnapshot struct {
 	claudeOptions    *session.ClaudeOptions
 	geminiYolo       bool
 	codexYolo        bool
+	codexUseHappy    bool
 	multiRepoEnabled bool
 	multiRepoPaths   []string
 }
@@ -181,8 +182,8 @@ func NewNewDialog() *NewDialog {
 		commandInput:    commandInput,
 		branchInput:     branchInput,
 		claudeOptions:   NewClaudeOptionsPanel(),
-		geminiOptions:   NewYoloOptionsPanel("Gemini", "YOLO mode - auto-approve all"),
-		codexOptions:    NewYoloOptionsPanel("Codex", "YOLO mode - bypass approvals and sandbox"),
+		geminiOptions:   NewYoloOptionsPanel("Gemini", "YOLO mode - auto-approve all", false),
+		codexOptions:    NewYoloOptionsPanel("Codex", "YOLO mode - bypass approvals and sandbox", true),
 		focusIndex:      0,
 		visible:         false,
 		presetCommands:  buildPresetCommands(),
@@ -241,10 +242,10 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string) {
 	d.pathSoftSelected = true // activate soft-select for pre-filled path.
 	// Initialize tool options from global config.
 	d.geminiOptions.SetDefaults(false)
-	d.codexOptions.SetDefaults(false)
+	d.codexOptions.SetDefaults(false, false)
 	if userConfig, err := session.LoadUserConfig(); err == nil && userConfig != nil {
 		d.geminiOptions.SetDefaults(userConfig.Gemini.YoloMode)
-		d.codexOptions.SetDefaults(userConfig.Codex.YoloMode)
+		d.codexOptions.SetDefaults(userConfig.Codex.YoloMode, userConfig.Codex.UseHappy)
 		d.claudeOptions.SetDefaults(userConfig)
 		d.sandboxEnabled = userConfig.Docker.DefaultEnabled
 		d.inheritedSettings = buildInheritedSettings(userConfig.Docker)
@@ -326,6 +327,7 @@ func (d *NewDialog) saveSnapshot() *dialogSnapshot {
 		claudeOptions:    claudeOpts,
 		geminiYolo:       d.geminiOptions.GetYoloMode(),
 		codexYolo:        d.codexOptions.GetYoloMode(),
+		codexUseHappy:    d.codexOptions.GetUseHappy(),
 		multiRepoEnabled: d.multiRepoEnabled,
 		multiRepoPaths:   append([]string{}, d.multiRepoPaths...),
 	}
@@ -345,7 +347,7 @@ func (d *NewDialog) restoreSnapshot(s *dialogSnapshot) {
 		d.claudeOptions.SetFromOptions(s.claudeOptions)
 	}
 	d.geminiOptions.SetDefaults(s.geminiYolo)
-	d.codexOptions.SetDefaults(s.codexYolo)
+	d.codexOptions.SetDefaults(s.codexYolo, s.codexUseHappy)
 	d.multiRepoEnabled = s.multiRepoEnabled
 	d.multiRepoPaths = append([]string{}, s.multiRepoPaths...)
 	d.multiRepoPathCursor = 0
@@ -402,8 +404,18 @@ func (d *NewDialog) previewRecentSession(rs *statedb.RecentSessionRow) {
 			var wrapper session.ToolOptionsWrapper
 			if err := json.Unmarshal(rs.ToolOptions, &wrapper); err == nil && wrapper.Tool == "codex" {
 				var opts session.CodexOptions
-				if err := json.Unmarshal(wrapper.Options, &opts); err == nil && opts.YoloMode != nil {
-					d.codexOptions.SetDefaults(*opts.YoloMode)
+				if err := json.Unmarshal(wrapper.Options, &opts); err == nil {
+					yoloMode := d.codexOptions.GetYoloMode()
+					if opts.YoloMode != nil {
+						yoloMode = *opts.YoloMode
+					}
+					useHappy := d.codexOptions.GetUseHappy()
+					if opts.UseHappy != nil {
+						useHappy = *opts.UseHappy
+					}
+					if opts.YoloMode != nil || opts.UseHappy != nil {
+						d.codexOptions.SetDefaults(yoloMode, useHappy)
+					}
 				}
 			}
 		}
@@ -528,6 +540,19 @@ func (d *NewDialog) IsGeminiYoloMode() bool {
 // GetCodexYoloMode returns the Codex YOLO mode state
 func (d *NewDialog) GetCodexYoloMode() bool {
 	return d.codexOptions.GetYoloMode()
+}
+
+// GetCodexOptions returns the Codex-specific options (only relevant if command is "codex")
+func (d *NewDialog) GetCodexOptions() *session.CodexOptions {
+	if d.GetSelectedCommand() != "codex" {
+		return nil
+	}
+	yoloMode := d.codexOptions.GetYoloMode()
+	useHappy := d.codexOptions.GetUseHappy()
+	return &session.CodexOptions{
+		YoloMode: &yoloMode,
+		UseHappy: &useHappy,
+	}
 }
 
 // IsSandboxEnabled returns whether Docker sandbox mode is enabled.

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -379,6 +379,7 @@ func TestNewDialog_RestoreSnapshot_RestoresToolOptionsAndCommandInput(t *testing
 	originalClaude := &session.ClaudeOptions{
 		SessionMode:          "resume",
 		ResumeSessionID:      "abc123",
+		UseHappy:             true,
 		SkipPermissions:      true,
 		AllowSkipPermissions: false,
 		UseChrome:            true,
@@ -390,7 +391,7 @@ func TestNewDialog_RestoreSnapshot_RestoresToolOptionsAndCommandInput(t *testing
 	d.commandInput.SetValue("echo original")
 	d.claudeOptions.SetFromOptions(originalClaude)
 	d.geminiOptions.SetDefaults(true)
-	d.codexOptions.SetDefaults(true)
+	d.codexOptions.SetDefaults(true, true)
 
 	snapshot := d.saveSnapshot()
 
@@ -401,7 +402,7 @@ func TestNewDialog_RestoreSnapshot_RestoresToolOptionsAndCommandInput(t *testing
 	d.commandInput.SetValue("echo mutated")
 	d.claudeOptions.SetFromOptions(&session.ClaudeOptions{SessionMode: "new"})
 	d.geminiOptions.SetDefaults(false)
-	d.codexOptions.SetDefaults(false)
+	d.codexOptions.SetDefaults(false, false)
 
 	d.restoreSnapshot(snapshot)
 
@@ -426,7 +427,7 @@ func TestNewDialog_RestoreSnapshot_RestoresToolOptionsAndCommandInput(t *testing
 		t.Fatalf("restored Claude session mode/id = %q/%q, want resume/abc123",
 			restoredClaude.SessionMode, restoredClaude.ResumeSessionID)
 	}
-	if !restoredClaude.SkipPermissions || !restoredClaude.UseChrome || !restoredClaude.UseTeammateMode {
+	if !restoredClaude.UseHappy || !restoredClaude.SkipPermissions || !restoredClaude.UseChrome || !restoredClaude.UseTeammateMode {
 		t.Fatalf("restored Claude toggles incorrect: %+v", restoredClaude)
 	}
 	if !d.geminiOptions.GetYoloMode() {
@@ -434,6 +435,27 @@ func TestNewDialog_RestoreSnapshot_RestoresToolOptionsAndCommandInput(t *testing
 	}
 	if !d.codexOptions.GetYoloMode() {
 		t.Fatal("codex yolo mode was not restored")
+	}
+	if !d.codexOptions.GetUseHappy() {
+		t.Fatal("codex happy mode was not restored")
+	}
+}
+
+func TestNewDialog_GetCodexOptions(t *testing.T) {
+	d := NewNewDialog()
+	d.commandCursor = 4 // codex
+	d.updateToolOptions()
+	d.codexOptions.SetDefaults(true, true)
+
+	opts := d.GetCodexOptions()
+	if opts == nil {
+		t.Fatal("GetCodexOptions returned nil")
+	}
+	if opts.YoloMode == nil || !*opts.YoloMode {
+		t.Fatalf("expected YoloMode=true, got %+v", opts)
+	}
+	if opts.UseHappy == nil || !*opts.UseHappy {
+		t.Fatalf("expected UseHappy=true, got %+v", opts)
 	}
 }
 

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -20,7 +20,9 @@ const (
 	SettingDefaultTool
 	SettingDangerousMode
 	SettingClaudeConfigDir
+	SettingClaudeUseHappy
 	SettingGeminiYoloMode
+	SettingCodexUseHappy
 	SettingCodexYoloMode
 	SettingCheckForUpdates
 	SettingAutoUpdate
@@ -36,7 +38,7 @@ const (
 )
 
 // Total number of navigable settings.
-const settingsCount = 17
+const settingsCount = 19
 
 // SettingsPanel displays and edits user configuration
 type SettingsPanel struct {
@@ -57,7 +59,9 @@ type SettingsPanel struct {
 	dangerousMode       bool
 	claudeConfigDir     string
 	claudeConfigIsScope bool // true = profile override, false = global [claude]
+	claudeUseHappy      bool
 	geminiYoloMode      bool
+	codexUseHappy       bool
 	codexYoloMode       bool
 	checkForUpdates     bool
 	autoUpdate          bool
@@ -202,6 +206,7 @@ func (s *SettingsPanel) LoadConfig(config *session.UserConfig) {
 	s.dangerousMode = config.Claude.GetDangerousMode()
 	s.claudeConfigDir = config.Claude.ConfigDir
 	s.claudeConfigIsScope = false
+	s.claudeUseHappy = config.Claude.UseHappy
 	if s.profile != "" && config.Profiles != nil {
 		if profileCfg, ok := config.Profiles[s.profile]; ok && profileCfg.Claude.ConfigDir != "" {
 			s.claudeConfigDir = profileCfg.Claude.ConfigDir
@@ -213,6 +218,7 @@ func (s *SettingsPanel) LoadConfig(config *session.UserConfig) {
 	s.geminiYoloMode = config.Gemini.YoloMode
 
 	// Codex settings
+	s.codexUseHappy = config.Codex.UseHappy
 	s.codexYoloMode = config.Codex.YoloMode
 
 	// Update settings
@@ -290,6 +296,17 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 		MCPs:        make(map[string]session.MCPDef),
 	}
 
+	if s.originalConfig != nil {
+		config.Claude = s.originalConfig.Claude
+		config.Gemini = s.originalConfig.Gemini
+		config.Codex = s.originalConfig.Codex
+		config.Updates = s.originalConfig.Updates
+		config.Logs = s.originalConfig.Logs
+		config.GlobalSearch = s.originalConfig.GlobalSearch
+		config.Preview = s.originalConfig.Preview
+		config.Maintenance = s.originalConfig.Maintenance
+	}
+
 	// Theme
 	if s.selectedTheme < len(themeValues) {
 		config.Theme = themeValues[s.selectedTheme]
@@ -303,6 +320,7 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 	// Claude settings
 	dangerousModeVal := s.dangerousMode
 	config.Claude.DangerousMode = &dangerousModeVal
+	config.Claude.UseHappy = s.claudeUseHappy
 	if !s.claudeConfigIsScope {
 		config.Claude.ConfigDir = s.claudeConfigDir
 	}
@@ -311,6 +329,7 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 	config.Gemini.YoloMode = s.geminiYoloMode
 
 	// Codex settings
+	config.Codex.UseHappy = s.codexUseHappy
 	config.Codex.YoloMode = s.codexYoloMode
 
 	// Update settings
@@ -481,8 +500,16 @@ func (s *SettingsPanel) toggleValue() bool {
 		s.dangerousMode = !s.dangerousMode
 		return true
 
+	case SettingClaudeUseHappy:
+		s.claudeUseHappy = !s.claudeUseHappy
+		return true
+
 	case SettingGeminiYoloMode:
 		s.geminiYoloMode = !s.geminiYoloMode
+		return true
+
+	case SettingCodexUseHappy:
+		s.codexUseHappy = !s.codexUseHappy
 		return true
 
 	case SettingCodexYoloMode:
@@ -664,6 +691,12 @@ func (s *SettingsPanel) View() string {
 	if s.cursor == int(SettingClaudeConfigDir) {
 		line = highlightStyle.Render(line)
 	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n")
+
+	line = s.renderCheckbox("Use happy wrapper", s.claudeUseHappy) + " - Launch Claude via happy"
+	if s.cursor == int(SettingClaudeUseHappy) {
+		line = highlightStyle.Render(line)
+	}
 	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
 
 	// GEMINI
@@ -680,6 +713,12 @@ func (s *SettingsPanel) View() string {
 	// CODEX
 	content.WriteString(sectionStyle.Render("CODEX"))
 	content.WriteString("\n")
+
+	line = s.renderCheckbox("Use happy wrapper", s.codexUseHappy) + " - Launch Codex via happy"
+	if s.cursor == int(SettingCodexUseHappy) {
+		line = highlightStyle.Render(line)
+	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n")
 
 	// YOLO mode checkbox
 	line = s.renderCheckbox("YOLO mode", s.codexYoloMode) + " - Bypass approvals and sandbox"
@@ -817,19 +856,21 @@ func (s *SettingsPanel) View() string {
 			7,  // SettingDefaultTool
 			11, // SettingDangerousMode
 			12, // SettingClaudeConfigDir
-			15, // SettingGeminiYoloMode
-			18, // SettingCodexYoloMode
-			21, // SettingCheckForUpdates
-			22, // SettingAutoUpdate
-			25, // SettingLogMaxSize
-			25, // SettingLogMaxLines (shares line with LogMaxSize)
-			26, // SettingRemoveOrphans
-			29, // SettingGlobalSearchEnabled
-			30, // SettingSearchTier
-			31, // SettingRecentDays
-			34, // SettingShowOutput
-			35, // SettingShowAnalytics
-			38, // SettingMaintenanceEnabled
+			13, // SettingClaudeUseHappy
+			16, // SettingGeminiYoloMode
+			19, // SettingCodexUseHappy
+			20, // SettingCodexYoloMode
+			23, // SettingCheckForUpdates
+			24, // SettingAutoUpdate
+			27, // SettingLogMaxSize
+			27, // SettingLogMaxLines (shares line with LogMaxSize)
+			28, // SettingRemoveOrphans
+			31, // SettingGlobalSearchEnabled
+			32, // SettingSearchTier
+			33, // SettingRecentDays
+			36, // SettingShowOutput
+			37, // SettingShowAnalytics
+			40, // SettingMaintenanceEnabled
 		}
 		cursorLine := cursorToLine[s.cursor]
 

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -68,6 +68,11 @@ func TestSettingsPanel_LoadConfig(t *testing.T) {
 		Claude: session.ClaudeSettings{
 			DangerousMode: &dangerousModeBool,
 			ConfigDir:     "~/.claude-work",
+			UseHappy:      true,
+		},
+		Codex: session.CodexSettings{
+			UseHappy: true,
+			YoloMode: true,
 		},
 		Updates: session.UpdateSettings{
 			CheckEnabled: false,
@@ -95,6 +100,15 @@ func TestSettingsPanel_LoadConfig(t *testing.T) {
 	}
 	if panel.claudeConfigDir != "~/.claude-work" {
 		t.Errorf("claudeConfigDir: got %q, want %q", panel.claudeConfigDir, "~/.claude-work")
+	}
+	if !panel.claudeUseHappy {
+		t.Error("claudeUseHappy should be true")
+	}
+	if !panel.codexUseHappy {
+		t.Error("codexUseHappy should be true")
+	}
+	if !panel.codexYoloMode {
+		t.Error("codexYoloMode should be true")
 	}
 	if panel.checkForUpdates {
 		t.Error("checkForUpdates should be false")
@@ -247,6 +261,9 @@ func TestSettingsPanel_GetConfig(t *testing.T) {
 	panel.selectedTool = 2 // opencode
 	panel.dangerousMode = true
 	panel.claudeConfigDir = "~/.claude-custom"
+	panel.claudeUseHappy = true
+	panel.codexUseHappy = true
+	panel.codexYoloMode = true
 	panel.checkForUpdates = false
 	panel.autoUpdate = true
 	panel.logMaxSizeMB = 15
@@ -266,6 +283,15 @@ func TestSettingsPanel_GetConfig(t *testing.T) {
 	}
 	if config.Claude.ConfigDir != "~/.claude-custom" {
 		t.Errorf("ConfigDir: got %q, want %q", config.Claude.ConfigDir, "~/.claude-custom")
+	}
+	if !config.Claude.UseHappy {
+		t.Error("Claude.UseHappy should be true")
+	}
+	if !config.Codex.UseHappy {
+		t.Error("Codex.UseHappy should be true")
+	}
+	if !config.Codex.YoloMode {
+		t.Error("Codex.YoloMode should be true")
 	}
 	if config.Updates.CheckEnabled {
 		t.Error("CheckEnabled should be false")
@@ -486,6 +512,29 @@ func TestSettingsPanel_Update_ToggleCheckbox(t *testing.T) {
 	}
 }
 
+func TestSettingsPanel_Update_ToggleHappyCheckboxes(t *testing.T) {
+	panel := NewSettingsPanel()
+	panel.Show()
+
+	panel.cursor = int(SettingClaudeUseHappy)
+	_, _, changed := panel.Update(tea.KeyMsg{Type: tea.KeySpace})
+	if !changed {
+		t.Fatal("Claude use_happy toggle should report a change")
+	}
+	if !panel.claudeUseHappy {
+		t.Fatal("claudeUseHappy should toggle on")
+	}
+
+	panel.cursor = int(SettingCodexUseHappy)
+	_, _, changed = panel.Update(tea.KeyMsg{Type: tea.KeySpace})
+	if !changed {
+		t.Fatal("Codex use_happy toggle should report a change")
+	}
+	if !panel.codexUseHappy {
+		t.Fatal("codexUseHappy should toggle on")
+	}
+}
+
 func TestSettingsPanel_Update_RadioSelection(t *testing.T) {
 	panel := NewSettingsPanel()
 	panel.Show()
@@ -632,6 +681,7 @@ func TestSettingsPanel_View_Visible(t *testing.T) {
 		"Gemini",
 		"CLAUDE",
 		"Dangerous mode",
+		"Use happy wrapper",
 		"UPDATES",
 		"LOGS",
 		"GLOBAL SEARCH",

--- a/internal/ui/yolooptions.go
+++ b/internal/ui/yolooptions.go
@@ -8,33 +8,44 @@ import (
 // YoloOptionsPanel is a UI panel for YOLO/dangerous mode options.
 // Used for Gemini and Codex in NewDialog, matching ClaudeOptionsPanel's visual style.
 type YoloOptionsPanel struct {
-	toolName string // "Gemini" or "Codex"
-	label    string // Checkbox label text
-	yoloMode bool
-	focused  bool
+	toolName   string // "Gemini" or "Codex"
+	label      string // Checkbox label text
+	yoloMode   bool
+	useHappy   bool
+	showHappy  bool
+	focusIndex int
+	focused    bool
 }
 
-// NewYoloOptionsPanel creates a new options panel for a tool with a single YOLO checkbox.
-func NewYoloOptionsPanel(toolName, label string) *YoloOptionsPanel {
+// NewYoloOptionsPanel creates a new options panel for a tool with a YOLO checkbox
+// and an optional happy checkbox.
+func NewYoloOptionsPanel(toolName, label string, showHappy bool) *YoloOptionsPanel {
 	return &YoloOptionsPanel{
-		toolName: toolName,
-		label:    label,
+		toolName:  toolName,
+		label:     label,
+		showHappy: showHappy,
 	}
 }
 
 // SetDefaults applies default value from config.
-func (p *YoloOptionsPanel) SetDefaults(yoloMode bool) {
+func (p *YoloOptionsPanel) SetDefaults(yoloMode bool, useHappy ...bool) {
 	p.yoloMode = yoloMode
+	p.useHappy = false
+	if len(useHappy) > 0 {
+		p.useHappy = useHappy[0]
+	}
 }
 
 // Focus sets focus to this panel.
 func (p *YoloOptionsPanel) Focus() {
 	p.focused = true
+	p.focusIndex = 0
 }
 
 // Blur removes focus from this panel.
 func (p *YoloOptionsPanel) Blur() {
 	p.focused = false
+	p.focusIndex = -1
 }
 
 // IsFocused returns true if the panel has focus.
@@ -47,9 +58,14 @@ func (p *YoloOptionsPanel) GetYoloMode() bool {
 	return p.yoloMode
 }
 
-// AtTop returns true (single element, always at top).
+// GetUseHappy returns the current happy state.
+func (p *YoloOptionsPanel) GetUseHappy() bool {
+	return p.useHappy
+}
+
+// AtTop returns true when focus is on the first checkbox.
 func (p *YoloOptionsPanel) AtTop() bool {
-	return true
+	return p.focusIndex <= 0
 }
 
 // Update handles key events.
@@ -57,7 +73,24 @@ func (p *YoloOptionsPanel) Update(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case " ", "y":
+		case "down", "tab":
+			if p.showHappy && p.focusIndex < 1 {
+				p.focusIndex++
+			}
+			return nil
+		case "up", "shift+tab":
+			if p.showHappy && p.focusIndex > 0 {
+				p.focusIndex--
+			}
+			return nil
+		case " ":
+			if p.showHappy && p.focusIndex == 0 {
+				p.useHappy = !p.useHappy
+				return nil
+			}
+			p.yoloMode = !p.yoloMode
+			return nil
+		case "y":
 			p.yoloMode = !p.yoloMode
 			return nil
 		}
@@ -71,6 +104,13 @@ func (p *YoloOptionsPanel) View() string {
 
 	var content string
 	content += headerStyle.Render("─ "+p.toolName+" Options ─") + "\n"
-	content += renderCheckboxLine(p.label, p.yoloMode, p.focused)
+	if p.showHappy {
+		content += renderCheckboxLine("Use happy wrapper", p.useHappy, p.focused && p.focusIndex == 0)
+	}
+	yoloFocusIndex := 0
+	if p.showHappy {
+		yoloFocusIndex = 1
+	}
+	content += renderCheckboxLine(p.label, p.yoloMode, p.focused && p.focusIndex == yoloFocusIndex)
 	return content
 }

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -57,6 +57,7 @@ Claude Code integration settings.
 ```toml
 [claude]
 config_dir = "~/.claude"           # Path to Claude config directory
+use_happy = false                  # Launch Claude via happy
 dangerous_mode = true              # Enable --dangerously-skip-permissions
 allow_dangerous_mode = false       # Enable --allow-dangerously-skip-permissions
 env_file = "~/.claude.env"         # .env file specific to Claude sessions
@@ -69,6 +70,7 @@ config_dir = "~/.claude-work"      # Optional override for profile "work"
 |-----|------|---------|-------------|
 | `config_dir` | string | `~/.claude` | Claude config directory. Override with `CLAUDE_CONFIG_DIR` env. |
 | `profiles.<name>.claude.config_dir` | string | none | Profile-specific Claude config directory. Takes precedence over `[claude].config_dir` when that profile is active. |
+| `use_happy` | bool | `false` | Launch built-in Claude sessions via `happy`. Ignored when `[claude].command` is set to a custom alias/command. |
 | `dangerous_mode` | bool | `false` | Adds `--dangerously-skip-permissions`. Forces bypass on. Takes precedence over `allow_dangerous_mode`. |
 | `allow_dangerous_mode` | bool | `false` | Adds `--allow-dangerously-skip-permissions`. Unlocks bypass as an option without activating it. Ignored when `dangerous_mode` is true. |
 | `env_file` | string | `""` | A .env file sourced for Claude sessions only. Sourced after global `[shell].env_files`. See [Path Resolution](#path-resolution). |
@@ -117,11 +119,13 @@ Codex CLI integration settings.
 ```toml
 [codex]
 yolo_mode = true   # Enable --yolo (bypass approvals and sandbox)
+use_happy = false  # Launch Codex via happy codex
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `yolo_mode` | bool | `false` | Maps to `codex --yolo` (`--dangerously-bypass-approvals-and-sandbox`). Can be overridden per-session. |
+| `use_happy` | bool | `false` | Launch built-in Codex sessions via `happy codex`. Can be overridden per-session. |
 
 ## [docker] Section
 
@@ -412,6 +416,7 @@ ignore_missing_env_files = true
 
 [claude]
 config_dir = "~/.claude"
+use_happy = false
 dangerous_mode = true
 env_file = "~/.claude.env"
 
@@ -420,6 +425,7 @@ config_dir = "~/.claude-work"
 
 [codex]
 yolo_mode = false
+use_happy = false
 
 [docker]
 default_enabled = false


### PR DESCRIPTION
## Summary
- add per-session and default `use_happy` support for built-in Claude and Codex sessions
- expose `Use happy wrapper` toggles in the new-session dialog and Settings panel
- update command building, persistence, docs, and tests for Claude/Codex happy launch paths

## Testing
- `go test ./internal/ui`
- `go test ./internal/session -run 'Test(BuildClaude(Command_(UseHappy|CustomAliasWinsOverHappy|PerSessionUseHappyOverride)|ResumeCommand_UseHappy|ForkCommandForTarget_UseHappy)|BuildCodexCommand_(UseHappy|PerSessionUseHappyOverride)|NewClaudeOptions_WithConfig|NewCodexOptions_WithConfig|UserConfig_(ClaudeConfigDir|CodexUseHappy)|UnmarshalClaudeOptions|CodexOptions_MarshalUnmarshal|CreateForkedInstance_SessionIDPattern|ForkCommandNoUuidgen)'`
- `go test ./cmd/agent-deck -run 'TestApplyCLIYoloOverride|TestParseCommand'`

## Notes
- `go test ./internal/session` still has unrelated pre-existing failures in `TestLifecycle_StoppedRestartedRunningError` and `TestStatusCycle_ShellSessionWithCommand` (status remains `starting`).