### PR TITLE
fix(tmux): set extended-keys per-session to avoid breaking dashboard Ctrl shortcuts

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1238,7 +1238,7 @@ func (s *Session) Start(command string) error {
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
 		"set-option", "-t", s.Name, "history-limit", "10000", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
-		"set", "-sq", "extended-keys", "on", ";",
+		"set-option", "-t", s.Name, "-q", "extended-keys", "on", ";",
 		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys").Run()
 
 	// Bind Ctrl+Q to detach at the tmux level as fallback for terminals where
@@ -1452,7 +1452,7 @@ func (s *Session) EnableMouseMode() error {
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
 		"set-option", "-t", s.Name, "history-limit", "10000", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
-		"set", "-sq", "extended-keys", "on", ";",
+		"set-option", "-t", s.Name, "-q", "extended-keys", "on", ";",
 		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys")
 	// Ignore errors - all these are non-fatal enhancements
 	// Older tmux versions may not support some options

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -25,19 +25,26 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// DisableKittyKeyboard writes the escape sequence that pushes keyboard mode 0
-// (legacy) on the Kitty keyboard protocol stack. After this call, Kitty-protocol-
-// aware terminals stop sending CSI u sequences and revert to legacy key
-// reporting. Terminals that do not support the protocol ignore the sequence.
+// DisableKittyKeyboard writes escape sequences that disable extended keyboard
+// protocols so that the terminal reverts to legacy key reporting:
+//
+//   - Kitty keyboard protocol: ESC[>0u pushes mode 0 (legacy) on the stack.
+//   - xterm modifyOtherKeys: ESC[>4;0m disables modifyOtherKeys mode.
+//
+// Terminals that do not support a protocol ignore the corresponding sequence.
+// Both must be disabled because tmux's "extended-keys on" option can activate
+// modifyOtherKeys on the outer terminal, and it may persist even after the
+// tmux option is turned off.
 func DisableKittyKeyboard(w io.Writer) {
-	_, _ = io.WriteString(w, "\x1b[>0u")
+	_, _ = io.WriteString(w, "\x1b[>0u")   // Disable Kitty protocol
+	_, _ = io.WriteString(w, "\x1b[>4;0m") // Disable xterm modifyOtherKeys
 }
 
-// RestoreKittyKeyboard writes the escape sequence that pops the keyboard mode
-// stack, restoring the terminal to its previous keyboard mode. Call this when
-// the TUI exits so that the terminal returns to normal operation.
+// RestoreKittyKeyboard writes escape sequences that restore the terminal to
+// its previous keyboard mode when the TUI exits.
 func RestoreKittyKeyboard(w io.Writer) {
-	_, _ = io.WriteString(w, "\x1b[<u")
+	_, _ = io.WriteString(w, "\x1b[<u")    // Pop Kitty protocol stack
+	_, _ = io.WriteString(w, "\x1b[>4;1m") // Restore modifyOtherKeys mode 1 (default)
 }
 
 // ParseCSIu parses a Kitty keyboard protocol (CSI u) escape sequence and

--- a/internal/ui/keyboard_compat_test.go
+++ b/internal/ui/keyboard_compat_test.go
@@ -104,23 +104,23 @@ func TestParseCSIuCtrlA(t *testing.T) {
 	}
 }
 
-// TestDisableKittyKeyboard tests that DisableKittyKeyboard writes the correct escape sequence.
+// TestDisableKittyKeyboard tests that DisableKittyKeyboard writes the correct escape sequences.
 func TestDisableKittyKeyboard(t *testing.T) {
 	var buf bytes.Buffer
 	DisableKittyKeyboard(&buf)
 	got := buf.String()
-	want := "\x1b[>0u"
+	want := "\x1b[>0u\x1b[>4;0m"
 	if got != want {
 		t.Errorf("DisableKittyKeyboard wrote %q, want %q", got, want)
 	}
 }
 
-// TestRestoreKittyKeyboard tests that RestoreKittyKeyboard writes the correct escape sequence.
+// TestRestoreKittyKeyboard tests that RestoreKittyKeyboard writes the correct escape sequences.
 func TestRestoreKittyKeyboard(t *testing.T) {
 	var buf bytes.Buffer
 	RestoreKittyKeyboard(&buf)
 	got := buf.String()
-	want := "\x1b[<u"
+	want := "\x1b[<u\x1b[>4;1m"
 	if got != want {
 		t.Errorf("RestoreKittyKeyboard wrote %q, want %q", got, want)
 	}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -1263,6 +1263,64 @@ func TestNewDialog_BranchPrefix_Empty_NoPrefix(t *testing.T) {
 	}
 }
 
+// TestNewDialog_CtrlR_OpensRecentPicker verifies that Ctrl+R opens the recent
+// sessions picker when recent sessions are available.
+func TestNewDialog_CtrlR_OpensRecentPicker(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(80, 40)
+	d.Show()
+
+	// Set up recent sessions
+	sessions := []*statedb.RecentSessionRow{
+		{Title: "session-1", ProjectPath: "/tmp/one", Tool: "claude"},
+		{Title: "session-2", ProjectPath: "/tmp/two", Tool: "claude"},
+	}
+	d.SetRecentSessions(sessions)
+
+	if len(d.recentSessions) != 2 {
+		t.Fatalf("expected 2 recent sessions, got %d", len(d.recentSessions))
+	}
+
+	// Verify ^R hint appears in the view
+	view := d.View()
+	if !strings.Contains(view, "^R recent") {
+		t.Error("View should contain '^R recent' hint when recent sessions exist")
+	}
+
+	// Verify picker is not open yet
+	if d.showRecentPicker {
+		t.Fatal("recent picker should not be open before Ctrl+R")
+	}
+
+	// Send Ctrl+R
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+
+	if !d.showRecentPicker {
+		t.Error("Ctrl+R should open the recent sessions picker")
+	}
+	if d.recentSessionCursor != 0 {
+		t.Errorf("recentSessionCursor = %d, want 0", d.recentSessionCursor)
+	}
+	// First session should be previewed
+	if d.nameInput.Value() != "session-1" {
+		t.Errorf("name = %q, want %q (first session should be previewed)", d.nameInput.Value(), "session-1")
+	}
+}
+
+// TestNewDialog_CtrlR_HintHiddenWhenNoRecents verifies the hint is absent
+// when there are no recent sessions.
+func TestNewDialog_CtrlR_HintHiddenWhenNoRecents(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(80, 40)
+	d.Show()
+
+	// No recent sessions set
+	view := d.View()
+	if strings.Contains(view, "^R recent") {
+		t.Error("View should NOT contain '^R recent' hint when no recent sessions exist")
+	}
+}
+
 func TestNewDialog_BranchPrefix_Placeholder_Updated(t *testing.T) {
 	d := NewNewDialog()
 	d.branchPrefix = "fix/"


### PR DESCRIPTION
## Summary

- **tmux.go**: Changed `set -sq extended-keys on` (server-wide) to `set-option -t <session> -q extended-keys on` (per-session) at both call sites (`Start()` and `EnableMouseMode()`)
- **keyboard_compat.go**: Added xterm modifyOtherKeys disable sequence (`ESC[>4;0m`) on TUI startup as defense-in-depth, alongside the existing Kitty protocol disable
- **Tests**: Updated `DisableKittyKeyboard`/`RestoreKittyKeyboard` tests, added Ctrl+R recent picker tests

## Problem

The `extended-keys on` option introduced in b427418 (#342) was set with `-s` (server-wide), which caused tmux to activate xterm modifyOtherKeys mode on the outer terminal (iTerm2, etc.). This mode persists even after the tmux option is turned off, causing modified keys like Ctrl+R to be sent as escape sequences (`\x1b[27;5;114~`) instead of legacy bytes (`0x12`). Bubble Tea v1.3.10 cannot parse these sequences, breaking:

- Ctrl+R recent sessions picker in the new session dialog
- Potentially all other Ctrl-key shortcuts in the dashboard

## Root Cause

`set -sq extended-keys on` is a **server-level** setting that affects all sessions on the tmux server, including the dashboard's terminal. When any child session starts, tmux negotiates modifyOtherKeys mode 2 with the outer terminal — and this terminal state persists independently of tmux's own setting.

## Fix

1. Scope `extended-keys` per-session so only child sessions (where Shift+Enter is needed) get it, not the dashboard
2. Send `\x1b[>4;0m` on TUI startup to reset the terminal in case it was previously poisoned

## Test plan

- [x] Existing tmux tests pass
- [x] `TestDisableKittyKeyboard` / `TestRestoreKittyKeyboard` updated and pass
- [x] New `TestNewDialog_CtrlR_OpensRecentPicker` / `TestNewDialog_CtrlR_HintHiddenWhenNoRecents` pass
- [ ] Manual: Ctrl+R opens recent sessions picker in new session dialog
- [ ] Manual: Shift+Enter still works inside attached Claude Code sessions