### PR TITLE
Fix #374: resolve $ key conflict between cost dashboard and error filter

### DIFF
--- a/internal/ui/cost_dashboard.go
+++ b/internal/ui/cost_dashboard.go
@@ -100,7 +100,7 @@ func (d costDashboard) View() string {
 
 	// Help
 	helpStyle := lipgloss.NewStyle().Foreground(ColorComment)
-	b.WriteString("  " + helpStyle.Render("Press q or $ to return"))
+	b.WriteString("  " + helpStyle.Render("Press q or C to return"))
 
 	return b.String()
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4071,7 +4071,7 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if h.showCostDashboard {
 			keyStr := msg.String()
-			if keyStr == "q" || keyStr == "$" || keyStr == "esc" {
+			if keyStr == "q" || keyStr == "C" || keyStr == "esc" {
 				h.showCostDashboard = false
 				return h, nil
 			}


### PR DESCRIPTION
## Summary
- Changed cost dashboard close key from `$` to `C` (matching its open key) in `home.go`
- Updated help text in `cost_dashboard.go` from "Press q or $" to "Press q or C"
- `$` now correctly toggles the error filter without being intercepted by the cost dashboard

Fixes #374