### PR TITLE
remove flicker when navigating sidebar

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9148,10 +9148,10 @@ func (h *Home) renderGroupItem(
 		}
 	}
 
-	// Hotkey indicator (subtle, only for root groups, hidden when selected)
+	// Hotkey indicator (subtle, only for root groups)
 	// Uses pre-computed RootGroupNum from rebuildFlatItems() - O(1) lookup instead of O(n) loop
 	hotkeyStr := ""
-	if item.Level == 0 && !selected {
+	if item.Level == 0 {
 		if item.RootGroupNum >= 1 && item.RootGroupNum <= 9 {
 			hotkeyStr = GroupHotkeyStyle.Render(fmt.Sprintf("%d·", item.RootGroupNum))
 		}


### PR DESCRIPTION
remove the 1-char shift that happens when navigating the sidebar, due to the number disappearing when hovering a session

this is a UI annoyance only