### PR TITLE
feat(ui): add typeahead filtering to recent sessions picker

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -80,6 +80,8 @@ type NewDialog struct {
 	multiRepoEditing    bool     // True when editing a path entry.
 	// Recent sessions picker.
 	recentSessions      []*statedb.RecentSessionRow
+	recentFiltered      []*statedb.RecentSessionRow // filtered subset (nil = no filter active)
+	recentFilter        string                      // current typeahead filter text
 	recentSessionCursor int
 	showRecentPicker    bool
 	recentSnapshot      *dialogSnapshot // saved state to restore on Esc
@@ -306,8 +308,41 @@ func (d *NewDialog) IsRecentPickerOpen() bool {
 // SetRecentSessions sets the list of recently deleted session configs.
 func (d *NewDialog) SetRecentSessions(sessions []*statedb.RecentSessionRow) {
 	d.recentSessions = sessions
+	d.recentFiltered = nil
+	d.recentFilter = ""
 	d.recentSessionCursor = 0
 	d.showRecentPicker = false
+}
+
+// recentDisplayList returns the filtered list if a filter is active,
+// otherwise the full list.
+func (d *NewDialog) recentDisplayList() []*statedb.RecentSessionRow {
+	if d.recentFiltered != nil {
+		return d.recentFiltered
+	}
+	return d.recentSessions
+}
+
+// applyRecentFilter rebuilds the filtered list from the current filter text.
+// Matching is case-insensitive substring on title and project path.
+func (d *NewDialog) applyRecentFilter() {
+	if d.recentFilter == "" {
+		d.recentFiltered = nil
+		return
+	}
+	query := strings.ToLower(d.recentFilter)
+	filtered := make([]*statedb.RecentSessionRow, 0, len(d.recentSessions))
+	for _, rs := range d.recentSessions {
+		if strings.Contains(strings.ToLower(rs.Title), query) ||
+			strings.Contains(strings.ToLower(rs.ProjectPath), query) {
+			filtered = append(filtered, rs)
+		}
+	}
+	d.recentFiltered = filtered
+	// Clamp cursor to new list bounds.
+	if d.recentSessionCursor >= len(filtered) {
+		d.recentSessionCursor = 0
+	}
 }
 
 // saveSnapshot captures current form state so the picker can restore on cancel.
@@ -894,23 +929,32 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 	case tea.KeyMsg:
 		// Recent sessions picker handling
 		if d.showRecentPicker && len(d.recentSessions) > 0 {
+			displayList := d.recentDisplayList()
 			switch msg.String() {
 			case "ctrl+n", "down":
-				d.recentSessionCursor = (d.recentSessionCursor + 1) % len(d.recentSessions)
-				d.previewRecentSession(d.recentSessions[d.recentSessionCursor])
+				if len(displayList) > 0 {
+					d.recentSessionCursor = (d.recentSessionCursor + 1) % len(displayList)
+					d.previewRecentSession(displayList[d.recentSessionCursor])
+				}
 				return d, nil
 			case "ctrl+p", "up":
-				d.recentSessionCursor--
-				if d.recentSessionCursor < 0 {
-					d.recentSessionCursor = len(d.recentSessions) - 1
+				if len(displayList) > 0 {
+					d.recentSessionCursor--
+					if d.recentSessionCursor < 0 {
+						d.recentSessionCursor = len(displayList) - 1
+					}
+					d.previewRecentSession(displayList[d.recentSessionCursor])
 				}
-				d.previewRecentSession(d.recentSessions[d.recentSessionCursor])
 				return d, nil
 			case "enter":
-				// Fields already applied via preview — just close picker.
-				d.showRecentPicker = false
-				d.recentSnapshot = nil
-				d.pathSoftSelected = true
+				if len(displayList) > 0 {
+					// Fields already applied via preview — just close picker.
+					d.showRecentPicker = false
+					d.recentSnapshot = nil
+					d.recentFilter = ""
+					d.recentFiltered = nil
+					d.pathSoftSelected = true
+				}
 				return d, nil
 			case "esc", "ctrl+r":
 				// Cancel — restore original form state.
@@ -919,15 +963,39 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 					d.recentSnapshot = nil
 				}
 				d.showRecentPicker = false
+				d.recentFilter = ""
+				d.recentFiltered = nil
 				return d, nil
+			case "backspace":
+				// Remove last character from filter.
+				if len(d.recentFilter) > 0 {
+					d.recentFilter = d.recentFilter[:len(d.recentFilter)-1]
+					d.applyRecentFilter()
+					if len(d.recentDisplayList()) > 0 {
+						d.previewRecentSession(d.recentDisplayList()[d.recentSessionCursor])
+					}
+				}
+				return d, nil
+			default:
+				// Typeahead: printable runes filter the list.
+				if msg.Type == tea.KeyRunes {
+					d.recentFilter += string(msg.Runes)
+					d.applyRecentFilter()
+					if len(d.recentDisplayList()) > 0 {
+						d.previewRecentSession(d.recentDisplayList()[d.recentSessionCursor])
+					}
+					return d, nil
+				}
 			}
-			return d, nil // Consume all other keys while picker is open
+			return d, nil // Consume all other unhandled keys while picker is open
 		}
 
 		// Toggle recent sessions picker
 		if msg.String() == "ctrl+r" && len(d.recentSessions) > 0 {
 			d.recentSnapshot = d.saveSnapshot()
 			d.showRecentPicker = true
+			d.recentFilter = ""
+			d.recentFiltered = nil
 			d.recentSessionCursor = 0
 			d.previewRecentSession(d.recentSessions[0])
 			return d, nil
@@ -1348,65 +1416,104 @@ func (d *NewDialog) View() string {
 	content.WriteString(groupInfoStyle.Render("  in group: " + d.parentGroupName))
 	content.WriteString("\n")
 
-	// Recent sessions picker
+	// When recent picker is open, render it instead of the form fields.
 	if d.showRecentPicker && len(d.recentSessions) > 0 {
+		// Override title to show nested context
+		content.Reset()
+		pickerTitleStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
+		breadcrumbStyle := lipgloss.NewStyle().Foreground(ColorComment)
+		content.WriteString(pickerTitleStyle.Render("New Session") + breadcrumbStyle.Render(" → ") + pickerTitleStyle.Render("Recents"))
+		content.WriteString("\n")
+
 		pickerHeaderStyle := lipgloss.NewStyle().Foreground(ColorComment)
 		pickerSelectedStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
 		pickerItemStyle := lipgloss.NewStyle().Foreground(ColorComment)
+		filterStyle := lipgloss.NewStyle().Foreground(ColorGreen)
 
-		content.WriteString("\n")
-		content.WriteString(pickerHeaderStyle.Render(
-			fmt.Sprintf("─ Recent Sessions (%d) ─ ↑↓ navigate │ Enter apply │ Esc close ─", len(d.recentSessions)),
-		))
+		displayList := d.recentDisplayList()
 		content.WriteString("\n")
 
-		maxShow := 5
-		total := len(d.recentSessions)
-		startIdx := 0
-		endIdx := total
-		if total > maxShow {
-			startIdx = d.recentSessionCursor - maxShow/2
-			if startIdx < 0 {
-				startIdx = 0
-			}
-			endIdx = startIdx + maxShow
-			if endIdx > total {
-				endIdx = total
-				startIdx = endIdx - maxShow
-			}
+		// Filter prompt
+		content.WriteString(pickerHeaderStyle.Render("  Filter: "))
+		if d.recentFilter != "" {
+			content.WriteString(filterStyle.Render(d.recentFilter))
 		}
+		content.WriteString(pickerHeaderStyle.Render("▏"))
+		content.WriteString("\n\n")
 
-		if startIdx > 0 {
-			content.WriteString(pickerItemStyle.Render(fmt.Sprintf("    ↑ %d more above", startIdx)))
+		if len(displayList) == 0 {
+			content.WriteString(pickerItemStyle.Render("    no matches"))
 			content.WriteString("\n")
+		} else {
+			maxShow := 8
+			total := len(displayList)
+			startIdx := 0
+			endIdx := total
+			if total > maxShow {
+				startIdx = d.recentSessionCursor - maxShow/2
+				if startIdx < 0 {
+					startIdx = 0
+				}
+				endIdx = startIdx + maxShow
+				if endIdx > total {
+					endIdx = total
+					startIdx = endIdx - maxShow
+				}
+			}
+
+			if startIdx > 0 {
+				content.WriteString(pickerItemStyle.Render(fmt.Sprintf("    ↑ %d more above", startIdx)))
+				content.WriteString("\n")
+			}
+
+			for i := startIdx; i < endIdx; i++ {
+				rs := displayList[i]
+				shortPath := rs.ProjectPath
+				if home, err := os.UserHomeDir(); err == nil {
+					shortPath = strings.Replace(shortPath, home, "~", 1)
+				}
+				toolLabel := rs.Tool
+				if toolLabel == "" {
+					toolLabel = "shell"
+				}
+				entry := fmt.Sprintf("%s  (%s @ %s)", rs.Title, toolLabel, shortPath)
+
+				if i == d.recentSessionCursor {
+					content.WriteString(pickerSelectedStyle.Render("  ▶ " + entry))
+				} else {
+					content.WriteString(pickerItemStyle.Render("    " + entry))
+				}
+				content.WriteString("\n")
+			}
+
+			if endIdx < total {
+				content.WriteString(pickerItemStyle.Render(fmt.Sprintf("    ↓ %d more below", total-endIdx)))
+				content.WriteString("\n")
+			}
 		}
 
-		for i := startIdx; i < endIdx; i++ {
-			rs := d.recentSessions[i]
-			// Format: Name  (tool @ ~/shortened/path)
-			shortPath := rs.ProjectPath
-			if home, err := os.UserHomeDir(); err == nil {
-				shortPath = strings.Replace(shortPath, home, "~", 1)
-			}
-			toolLabel := rs.Tool
-			if toolLabel == "" {
-				toolLabel = "shell"
-			}
-			entry := fmt.Sprintf("%s  (%s @ %s)", rs.Title, toolLabel, shortPath)
-
-			if i == d.recentSessionCursor {
-				content.WriteString(pickerSelectedStyle.Render("  ▶ " + entry))
-			} else {
-				content.WriteString(pickerItemStyle.Render("    " + entry))
-			}
-			content.WriteString("\n")
+		// Picker-specific help text (replaces the normal form help)
+		content.WriteString("\n")
+		helpStyle := lipgloss.NewStyle().
+			Foreground(ColorComment).
+			MarginTop(1)
+		matchInfo := ""
+		if d.recentFilter != "" {
+			matchInfo = fmt.Sprintf("%d/%d │ ", len(displayList), len(d.recentSessions))
+		} else {
+			matchInfo = fmt.Sprintf("%d │ ", len(d.recentSessions))
 		}
+		content.WriteString(helpStyle.Render(matchInfo + "↑↓ navigate │ Enter apply │ Esc cancel"))
 
-		if endIdx < total {
-			content.WriteString(pickerItemStyle.Render(fmt.Sprintf("    ↓ %d more below", total-endIdx)))
-			content.WriteString("\n")
-		}
+		// Wrap in dialog box and return early
+		dialog := dialogStyle.Render(content.String())
+		return lipgloss.Place(
+			d.width, d.height,
+			lipgloss.Center, lipgloss.Center,
+			dialog,
+		)
 	}
+
 	content.WriteString("\n")
 
 	// Name input

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -1499,6 +1499,188 @@ func TestNewDialog_CtrlR_HintHiddenWhenNoRecents(t *testing.T) {
 	}
 }
 
+// TestNewDialog_RecentPicker_TypeaheadFilters verifies that typing in the
+// recent picker filters the list by session name.
+func TestNewDialog_RecentPicker_TypeaheadFilters(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(80, 40)
+	d.Show()
+
+	sessions := []*statedb.RecentSessionRow{
+		{Title: "alpha-project", ProjectPath: "/tmp/alpha", Tool: "claude"},
+		{Title: "beta-service", ProjectPath: "/tmp/beta", Tool: "claude"},
+		{Title: "gamma-api", ProjectPath: "/tmp/gamma", Tool: "gemini"},
+	}
+	d.SetRecentSessions(sessions)
+
+	// Open picker
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	if !d.showRecentPicker {
+		t.Fatal("picker should be open")
+	}
+
+	// Type "beta" to filter
+	for _, r := range "beta" {
+		d, _ = d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	if d.recentFilter != "beta" {
+		t.Errorf("recentFilter = %q, want %q", d.recentFilter, "beta")
+	}
+
+	displayList := d.recentDisplayList()
+	if len(displayList) != 1 {
+		t.Fatalf("expected 1 filtered result, got %d", len(displayList))
+	}
+	if displayList[0].Title != "beta-service" {
+		t.Errorf("filtered result = %q, want %q", displayList[0].Title, "beta-service")
+	}
+
+	// Preview should show the filtered result
+	if d.nameInput.Value() != "beta-service" {
+		t.Errorf("name = %q, want %q (should preview filtered result)", d.nameInput.Value(), "beta-service")
+	}
+}
+
+// TestNewDialog_RecentPicker_TypeaheadNoMatch shows "no matches" when filter
+// doesn't match anything, and Enter is a no-op.
+func TestNewDialog_RecentPicker_TypeaheadNoMatch(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(80, 40)
+	d.Show()
+
+	sessions := []*statedb.RecentSessionRow{
+		{Title: "alpha-project", ProjectPath: "/tmp/alpha", Tool: "claude"},
+	}
+	d.SetRecentSessions(sessions)
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+
+	// Type something that doesn't match
+	for _, r := range "zzz" {
+		d, _ = d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	if len(d.recentDisplayList()) != 0 {
+		t.Errorf("expected 0 filtered results, got %d", len(d.recentDisplayList()))
+	}
+
+	// View should show "no matches"
+	view := d.View()
+	if !strings.Contains(view, "no matches") {
+		t.Error("View should show 'no matches' when filter has no results")
+	}
+
+	// Enter should be a no-op (picker stays open)
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !d.showRecentPicker {
+		t.Error("Enter with no matches should not close the picker")
+	}
+}
+
+// TestNewDialog_RecentPicker_BackspaceRemovesFilter verifies backspace
+// progressively removes filter characters.
+func TestNewDialog_RecentPicker_BackspaceRemovesFilter(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(80, 40)
+	d.Show()
+
+	sessions := []*statedb.RecentSessionRow{
+		{Title: "alpha", ProjectPath: "/tmp/alpha", Tool: "claude"},
+		{Title: "beta", ProjectPath: "/tmp/beta", Tool: "claude"},
+	}
+	d.SetRecentSessions(sessions)
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+
+	// Type "al" — filters to "alpha"
+	for _, r := range "al" {
+		d, _ = d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	if len(d.recentDisplayList()) != 1 {
+		t.Fatalf("expected 1 result for 'al', got %d", len(d.recentDisplayList()))
+	}
+
+	// Backspace once — filter is "a", both match
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if d.recentFilter != "a" {
+		t.Errorf("filter = %q, want %q", d.recentFilter, "a")
+	}
+	if len(d.recentDisplayList()) != 2 {
+		t.Errorf("expected 2 results for 'a', got %d", len(d.recentDisplayList()))
+	}
+
+	// Backspace again — filter is empty, full list
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if d.recentFilter != "" {
+		t.Errorf("filter = %q, want empty", d.recentFilter)
+	}
+	if d.recentFiltered != nil {
+		t.Error("recentFiltered should be nil when filter is empty")
+	}
+}
+
+// TestNewDialog_RecentPicker_FilterMatchesPath verifies filtering also
+// matches on project path.
+func TestNewDialog_RecentPicker_FilterMatchesPath(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(80, 40)
+	d.Show()
+
+	sessions := []*statedb.RecentSessionRow{
+		{Title: "my-project", ProjectPath: "/home/user/special-repo", Tool: "claude"},
+		{Title: "other", ProjectPath: "/tmp/generic", Tool: "claude"},
+	}
+	d.SetRecentSessions(sessions)
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+
+	// Type "special" — matches path of first session
+	for _, r := range "special" {
+		d, _ = d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	displayList := d.recentDisplayList()
+	if len(displayList) != 1 {
+		t.Fatalf("expected 1 result for path match, got %d", len(displayList))
+	}
+	if displayList[0].Title != "my-project" {
+		t.Errorf("filtered result = %q, want %q", displayList[0].Title, "my-project")
+	}
+}
+
+// TestNewDialog_RecentPicker_EscClearsFilter verifies Esc cancels and
+// clears the filter state.
+func TestNewDialog_RecentPicker_EscClearsFilter(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(80, 40)
+	d.Show()
+
+	sessions := []*statedb.RecentSessionRow{
+		{Title: "test", ProjectPath: "/tmp/test", Tool: "claude"},
+	}
+	d.SetRecentSessions(sessions)
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+
+	for _, r := range "xyz" {
+		d, _ = d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	// Esc should close picker and clear filter
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if d.showRecentPicker {
+		t.Error("picker should be closed after Esc")
+	}
+	if d.recentFilter != "" {
+		t.Errorf("filter should be cleared after Esc, got %q", d.recentFilter)
+	}
+	if d.recentFiltered != nil {
+		t.Error("recentFiltered should be nil after Esc")
+	}
+}
+
 func TestNewDialog_BranchPrefix_Placeholder_Updated(t *testing.T) {
 	d := NewNewDialog()
 	d.branchPrefix = "fix/"


### PR DESCRIPTION
## Summary

I wanted to improve on the recent's functionality that you graciously merged a couple of weeks ago.  This update allows type-ahead style filtering and a new overlay so it doesn't impact the regular 'new' modal so much reducing confusion.

- Typing in the Ctrl+R recent sessions picker now filters by session name or project path (case-insensitive substring match)
- Backspace progressively removes filter characters
- Picker renders as an overlay replacing the form content, keeping dialog size consistent
- Title shows "New Session → Recents" to indicate nested context
- "no matches" displayed when filter has no results
- Enter is a no-op when no matches (prevents accidental empty selection)

## Implementation

- `recentFilter` string and `recentFiltered` slice track filter state
- `applyRecentFilter()` rebuilds the filtered list on each keystroke
- `recentDisplayList()` returns filtered or full list transparently — all navigation, preview, and rendering use this
- Filter state is cleared on both Esc (cancel) and Enter (confirm)
- Picker view returns early before form rendering, so the dialog body is replaced rather than expanded

## Test plan

- [x] `TestNewDialog_RecentPicker_TypeaheadFilters` — typing filters by name
- [x] `TestNewDialog_RecentPicker_TypeaheadNoMatch` — no matches shows message, Enter is no-op
- [x] `TestNewDialog_RecentPicker_BackspaceRemovesFilter` — backspace progressively widens results
- [x] `TestNewDialog_RecentPicker_FilterMatchesPath` — filtering also matches project path
- [x] `TestNewDialog_RecentPicker_EscClearsFilter` — Esc cancels and clears filter state
- [x] All 71 existing newdialog tests pass
- [x] Manual testing: dialog stays consistent size, preview updates on filter