### PR TITLE
fix: resolve Python 3.13 re.sub PatternError in bridge.py

### DIFF
--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -1361,7 +1361,7 @@ def create_slack_app(config: dict):
         # Links [text](url) -> <url|text>
         text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", text)
         # Bullet lists: - item or * item -> bullet char item
-        text = re.sub(r"^(\s*)[-*]\s+", r"\1\u2022 ", text, flags=re.MULTILINE)
+        text = re.sub(r"^(\s*)[-*]\s+", "\\1\u2022 ", text, flags=re.MULTILINE)
 
         # Restore inline code.
         for i, code in enumerate(inline_codes):


### PR DESCRIPTION
## Summary

- Fix `re.PatternError: bad escape \u at position 2` when running the conductor bridge with Python 3.13+
- Change raw string `r"\1\u2022 "` to regular string `"\\1\u2022 "` in `_markdown_to_slack()` replacement pattern

## Problem

Python 3.13 promoted the `DeprecationWarning` for invalid escape sequences in `re.sub()` replacement strings to a hard `re.PatternError`. The raw string `r"\1\u2022 "` contains `\u` which is not a valid regex escape, causing the bridge to crash on every message:

```
re.PatternError: bad escape \u at position 2
```

This prevents the Slack bridge from sending any responses back to the channel.

## Fix

Replace the raw string with a regular string so that:
- `\\1` is interpreted as the regex backreference `\1`
- `\u2022` is interpreted as the Unicode bullet character `•` by Python

## Test plan

- [x] Verified on Python 3.13.12 — bridge processes messages and sends responses to Slack without errors
- [x] The replacement still produces the correct bullet character (`•`) in Slack output