### PR TITLE
fix(config): Preserve worktree settings when editing config

### DIFF
--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -367,6 +367,7 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 		config.Preview.NotesOutputSplit = s.originalConfig.Preview.NotesOutputSplit
 		config.Preview.Analytics = s.originalConfig.Preview.Analytics
 		config.Profiles = s.originalConfig.Profiles
+		config.Worktree = s.originalConfig.Worktree
 		// Keep global Claude config when editing profile-specific override.
 		if s.claudeConfigIsScope {
 			config.Claude.ConfigDir = s.originalConfig.Claude.ConfigDir


### PR DESCRIPTION
The `worktree` config section is not in the Settings panel, but wasn't being copied from the original config. The result was that `default_location` and `auto_cleanup` would be set to `""` and `false` every time settings were saved.

Explicitly copy Worktree from the original config to the new to preserve the values.