### PR TITLE
fix: restore keyboard mode after session detach

### DIFF
--- a/internal/terminal/keyboard.go
+++ b/internal/terminal/keyboard.go
@@ -1,0 +1,24 @@
+// Package terminal provides shared terminal escape sequence helpers
+// used by both the TUI (ui) and PTY attach (tmux) packages.
+package terminal
+
+import "io"
+
+// DisableKittyKeyboard writes escape sequences that disable extended keyboard
+// protocols so that the terminal reverts to legacy key reporting:
+//
+//   - Kitty keyboard protocol: ESC[>0u pushes mode 0 (legacy) on the stack.
+//   - xterm modifyOtherKeys: ESC[>4;0m disables modifyOtherKeys mode.
+//
+// Terminals that do not support a protocol ignore the corresponding sequence.
+func DisableKittyKeyboard(w io.Writer) {
+	_, _ = io.WriteString(w, "\x1b[>0u")   // Disable Kitty protocol
+	_, _ = io.WriteString(w, "\x1b[>4;0m") // Disable xterm modifyOtherKeys
+}
+
+// RestoreKittyKeyboard writes escape sequences that restore the terminal to
+// its previous keyboard mode when the TUI exits.
+func RestoreKittyKeyboard(w io.Writer) {
+	_, _ = io.WriteString(w, "\x1b[<u")    // Pop Kitty protocol stack
+	_, _ = io.WriteString(w, "\x1b[>4;1m") // Restore modifyOtherKeys mode 1 (default)
+}

--- a/internal/terminal/keyboard_test.go
+++ b/internal/terminal/keyboard_test.go
@@ -1,0 +1,54 @@
+package terminal
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDisableKittyKeyboard(t *testing.T) {
+	var buf bytes.Buffer
+	DisableKittyKeyboard(&buf)
+	got := buf.String()
+	want := "\x1b[>0u\x1b[>4;0m"
+	if got != want {
+		t.Errorf("DisableKittyKeyboard wrote %q, want %q", got, want)
+	}
+}
+
+func TestRestoreKittyKeyboard(t *testing.T) {
+	var buf bytes.Buffer
+	RestoreKittyKeyboard(&buf)
+	got := buf.String()
+	want := "\x1b[<u\x1b[>4;1m"
+	if got != want {
+		t.Errorf("RestoreKittyKeyboard wrote %q, want %q", got, want)
+	}
+}
+
+// TestDisableKittyKeyboardIdempotent verifies calling disable twice produces
+// the same sequences (important for the detach-cleanup use case where disable
+// is called even if the terminal is already in legacy mode).
+func TestDisableKittyKeyboardIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	DisableKittyKeyboard(&buf)
+	DisableKittyKeyboard(&buf)
+	got := buf.String()
+	want := "\x1b[>0u\x1b[>4;0m\x1b[>0u\x1b[>4;0m"
+	if got != want {
+		t.Errorf("double DisableKittyKeyboard wrote %q, want %q", got, want)
+	}
+}
+
+// TestUIDelegatesMatchTerminalPackage verifies the escape sequences are
+// consistent — the ui package delegates to terminal, so calling disable
+// then restore should produce the expected combined output.
+func TestDisableRestoreRoundtrip(t *testing.T) {
+	var buf bytes.Buffer
+	DisableKittyKeyboard(&buf)
+	RestoreKittyKeyboard(&buf)
+	got := buf.String()
+	want := "\x1b[>0u\x1b[>4;0m\x1b[<u\x1b[>4;1m"
+	if got != want {
+		t.Errorf("disable+restore wrote %q, want %q", got, want)
+	}
+}

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/terminal"
 	"github.com/creack/pty"
 	"golang.org/x/term"
 )
@@ -234,6 +235,10 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 		}
 		// Reset OSC-8 hyperlink state + SGR attributes before Bubble Tea redraws.
 		_, _ = os.Stdout.WriteString(terminalStyleReset)
+		// Re-disable Kitty keyboard protocol — the attached session (or tools
+		// inside it like Claude Code) may have re-enabled it, leaving the
+		// outer terminal in CSI u mode where Bubble Tea can't parse shift keys.
+		terminal.DisableKittyKeyboard(os.Stdout)
 	}
 
 	// Wait for either detach key or command completion

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -22,29 +22,18 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/asheshgoplani/agent-deck/internal/terminal"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// DisableKittyKeyboard writes escape sequences that disable extended keyboard
-// protocols so that the terminal reverts to legacy key reporting:
-//
-//   - Kitty keyboard protocol: ESC[>0u pushes mode 0 (legacy) on the stack.
-//   - xterm modifyOtherKeys: ESC[>4;0m disables modifyOtherKeys mode.
-//
-// Terminals that do not support a protocol ignore the corresponding sequence.
-// Both must be disabled because tmux's "extended-keys on" option can activate
-// modifyOtherKeys on the outer terminal, and it may persist even after the
-// tmux option is turned off.
+// DisableKittyKeyboard delegates to terminal.DisableKittyKeyboard.
 func DisableKittyKeyboard(w io.Writer) {
-	_, _ = io.WriteString(w, "\x1b[>0u")   // Disable Kitty protocol
-	_, _ = io.WriteString(w, "\x1b[>4;0m") // Disable xterm modifyOtherKeys
+	terminal.DisableKittyKeyboard(w)
 }
 
-// RestoreKittyKeyboard writes escape sequences that restore the terminal to
-// its previous keyboard mode when the TUI exits.
+// RestoreKittyKeyboard delegates to terminal.RestoreKittyKeyboard.
 func RestoreKittyKeyboard(w io.Writer) {
-	_, _ = io.WriteString(w, "\x1b[<u")    // Pop Kitty protocol stack
-	_, _ = io.WriteString(w, "\x1b[>4;1m") // Restore modifyOtherKeys mode 1 (default)
+	terminal.RestoreKittyKeyboard(w)
 }
 
 // ParseCSIu parses a Kitty keyboard protocol (CSI u) escape sequence and


### PR DESCRIPTION
## Summary
- After detaching from a session (Ctrl+Q), shift-modified shortcuts (M, R, F, W, etc.) stopped working in the main TUI
- Root cause: tools inside the tmux session (e.g. Claude Code) enable the Kitty keyboard protocol, and detaching didn't reset it — leaving the outer terminal in CSI u mode that Bubble Tea can't parse
- Fix: re-send `DisableKittyKeyboard` after PTY cleanup so the terminal reverts to legacy key reporting before Bubble Tea resumes input

## Changes
- **`internal/terminal/keyboard.go`** — new shared package with `DisableKittyKeyboard` and `RestoreKittyKeyboard` (extracted to avoid import cycle between `ui` and `tmux`)
- **`internal/tmux/pty.go`** — call `terminal.DisableKittyKeyboard` in `cleanupAttach()` after style reset
- **`internal/ui/keyboard_compat.go`** — delegate to `internal/terminal` instead of inlining escape sequences

## Test plan
- [x] Launch agent-deck, attach to a Claude Code session, detach with Ctrl+Q
- [x] Verify Shift+M (Move), Shift+R (Restart), Shift+W (Worktree finish) all work after detach
- [x] Verified on Ghostty (macOS) — the terminal that triggered #382
- [x] All existing keyboard_compat tests pass

Fixes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)