### PR TITLE
fix(tui): correct cursor tracking for group reorder K/J

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4938,14 +4938,24 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			switch item.Type {
 			case session.ItemTypeGroup:
 				h.groupTree.MoveGroupUp(item.Path)
+				h.rebuildFlatItems()
+				// Track cursor to the group's new position (it may have jumped
+				// over multiple flat items if the sibling above was expanded).
+				for i, fi := range h.flatItems {
+					if fi.Type == session.ItemTypeGroup && fi.Path == item.Path {
+						h.cursor = i
+						break
+					}
+				}
+				h.saveGroupState()
 			case session.ItemTypeSession:
 				h.groupTree.MoveSessionUp(item.Session)
+				h.rebuildFlatItems()
+				if h.cursor > 0 {
+					h.cursor--
+				}
+				h.saveInstances()
 			}
-			h.rebuildFlatItems()
-			if h.cursor > 0 {
-				h.cursor--
-			}
-			h.saveInstances()
 		}
 		return h, nil
 
@@ -4956,14 +4966,24 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			switch item.Type {
 			case session.ItemTypeGroup:
 				h.groupTree.MoveGroupDown(item.Path)
+				h.rebuildFlatItems()
+				// Track cursor to the group's new position (it may have jumped
+				// over multiple flat items if the sibling below was expanded).
+				for i, fi := range h.flatItems {
+					if fi.Type == session.ItemTypeGroup && fi.Path == item.Path {
+						h.cursor = i
+						break
+					}
+				}
+				h.saveGroupState()
 			case session.ItemTypeSession:
 				h.groupTree.MoveSessionDown(item.Session)
+				h.rebuildFlatItems()
+				if h.cursor < len(h.flatItems)-1 {
+					h.cursor++
+				}
+				h.saveInstances()
 			}
-			h.rebuildFlatItems()
-			if h.cursor < len(h.flatItems)-1 {
-				h.cursor++
-			}
-			h.saveInstances()
 		}
 		return h, nil
 


### PR DESCRIPTION
## Summary
- Fixes cursor tracking when reordering groups with K/J (Shift+Up/Down) in the TUI
- Previously the cursor moved by a fixed +/-1 offset after group reorder, which was incorrect when the adjacent group had expanded sessions (the group header jumps over multiple flat items when groups swap)
- Now searches for the moved group's actual position in the rebuilt flat list, keeping the cursor on the correct group
- Switches group reorder persistence to `saveGroupState()` (lightweight, no Touch trigger) instead of `saveInstances()`, since only group Order values change

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/session/ -run MoveGroup -v` passes
- [ ] Manual: create 2+ groups with sessions, use K/J to reorder groups, verify cursor follows the group header correctly
- [ ] Manual: restart TUI after reordering groups, verify order is persisted

Fixes #398