### PR TITLE
fix(tmux): only enable extended-keys when outer terminal supports CSI u

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1230,18 +1230,26 @@ func (s *Session) Start(command string) error {
 	// via OptionOverrides to avoid changing behaviour for non-sandbox sessions.
 	themeStyle := currentTmuxThemeStyle()
 
-	_ = exec.Command("tmux",
+	optArgs := []string{
 		"set-option", "-t", s.Name, "window-style", themeStyle.windowStyle, ";",
 		"set-option", "-t", s.Name, "window-active-style", themeStyle.windowActiveStyle, ";",
 		"set-option", "-t", s.Name, "mouse", "on", ";",
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
 		"set-option", "-t", s.Name, "history-limit", "10000", ";",
-		"set-option", "-t", s.Name, "escape-time", "10", ";",
-		"set-option", "-t", s.Name, "-q", "extended-keys", "on").Run()
+		"set-option", "-t", s.Name, "escape-time", "10",
+	}
+	if outerTerminalSupportsExtKeys() {
+		optArgs = append(optArgs, ";", "set-option", "-t", s.Name, "-q", "extended-keys", "on")
+	}
+	_ = exec.Command("tmux", optArgs...).Run()
 
 	// Idempotent: only append terminal-features if not already present
-	ensureTerminalFeatures("hyperlinks", "extkeys")
+	features := []string{"hyperlinks"}
+	if outerTerminalSupportsExtKeys() {
+		features = append(features, "extkeys")
+	}
+	ensureTerminalFeatures(features...)
 
 	// Bind Ctrl+Q to detach at the tmux level as fallback for terminals where
 	// XON/XOFF flow control intercepts the key before it reaches the PTY stdin
@@ -1410,6 +1418,32 @@ func (s *Session) ConfigureStatusBar() {
 	_ = exec.Command("tmux", args...).Run()
 }
 
+// outerTerminalSupportsExtKeys reports whether the terminal emulator that
+// launched tmux is known to support the CSI u / kitty keyboard protocol.
+// When this returns false, enabling tmux extended-keys will cause Shift+key
+// and other modified key combos to be silently dropped by the terminal.
+func outerTerminalSupportsExtKeys() bool {
+	term := os.Getenv("TERM")
+	termProgram := os.Getenv("TERM_PROGRAM")
+
+	// Known CSI u / kitty keyboard protocol supporters
+	switch {
+	case strings.Contains(term, "ghostty"):
+		// Real Ghostty supports it, but cmux also sets TERM=xterm-ghostty
+		// while not supporting the protocol. Check TERM_PROGRAM to distinguish.
+		return termProgram == "ghostty"
+	case strings.Contains(term, "kitty"):
+		return true
+	case strings.Contains(term, "wezterm"):
+		return true
+	case termProgram == "ghostty", termProgram == "kitty", termProgram == "WezTerm":
+		return true
+	}
+	// Foot, Contour, Rio, and other CSI u terminals can be added here.
+	// Default to off — breaking Shift+key is worse than missing extended key reports.
+	return false
+}
+
 // ensureTerminalFeatures appends terminal features only if not already present.
 // This prevents the terminal-features list from growing on every session start (#366).
 func ensureTerminalFeatures(features ...string) {
@@ -1474,18 +1508,25 @@ func (s *Session) EnableMouseMode() error {
 	// - escape-time 10: Fast Vim/editor responsiveness (default 500ms is too slow)
 	//
 	// Uses -q flag where supported to silently ignore on older tmux versions
-	enhanceCmd := exec.Command("tmux",
+	enhanceArgs := []string{
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
 		"set-option", "-t", s.Name, "history-limit", "10000", ";",
-		"set-option", "-t", s.Name, "escape-time", "10", ";",
-		"set-option", "-t", s.Name, "-q", "extended-keys", "on")
+		"set-option", "-t", s.Name, "escape-time", "10",
+	}
+	if outerTerminalSupportsExtKeys() {
+		enhanceArgs = append(enhanceArgs, ";", "set-option", "-t", s.Name, "-q", "extended-keys", "on")
+	}
 	// Ignore errors - all these are non-fatal enhancements
 	// Older tmux versions may not support some options
-	_ = enhanceCmd.Run()
+	_ = exec.Command("tmux", enhanceArgs...).Run()
 
 	// Idempotent: only append terminal-features if not already present
-	ensureTerminalFeatures("hyperlinks", "extkeys")
+	enhanceFeatures := []string{"hyperlinks"}
+	if outerTerminalSupportsExtKeys() {
+		enhanceFeatures = append(enhanceFeatures, "extkeys")
+	}
+	ensureTerminalFeatures(enhanceFeatures...)
 
 	return nil
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2685,3 +2685,35 @@ func TestBuildStatusBarArgs_InjectDisabled(t *testing.T) {
 	args := s.buildStatusBarArgs()
 	assert.Nil(t, args, "args should be nil when injectStatusLine is false")
 }
+
+func TestOuterTerminalSupportsExtKeys(t *testing.T) {
+	tests := []struct {
+		name        string
+		term        string
+		termProgram string
+		want        bool
+	}{
+		{"ghostty terminal", "xterm-ghostty", "ghostty", true},
+		{"cmux using ghostty term", "xterm-ghostty", "cmux", false},
+		{"cmux using ghostty term no program", "xterm-ghostty", "", false},
+		{"kitty terminal", "xterm-kitty", "kitty", true},
+		{"kitty term only", "xterm-kitty", "", true},
+		{"wezterm terminal", "wezterm", "WezTerm", true},
+		{"wezterm term only", "wezterm", "", true},
+		{"plain xterm", "xterm-256color", "", false},
+		{"tmux term", "tmux-256color", "", false},
+		{"screen term", "screen-256color", "", false},
+		{"unknown terminal", "alacritty", "", false},
+		{"ghostty via TERM_PROGRAM only", "xterm-256color", "ghostty", true},
+		{"kitty via TERM_PROGRAM only", "xterm-256color", "kitty", true},
+		{"WezTerm via TERM_PROGRAM only", "xterm-256color", "WezTerm", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TERM", tc.term)
+			t.Setenv("TERM_PROGRAM", tc.termProgram)
+			got := outerTerminalSupportsExtKeys()
+			assert.Equal(t, tc.want, got, "outerTerminalSupportsExtKeys() for TERM=%q TERM_PROGRAM=%q", tc.term, tc.termProgram)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #417

agent-deck unconditionally enables tmux `extended-keys on`, which breaks Shift+key combos in terminals that don't support the CSI u / kitty keyboard protocol (cmux, Alacritty, Terminal.app, etc.).

- Add `outerTerminalSupportsExtKeys()` that checks `TERM` and `TERM_PROGRAM` to detect CSI u-capable terminals (Ghostty, kitty, WezTerm)
- cmux sets `TERM=xterm-ghostty` without supporting CSI u — we check `TERM_PROGRAM` to distinguish real Ghostty
- Only enable `extended-keys on` and append `extkeys` to `terminal-features` when the outer terminal supports it
- Default to off — breaking Shift+key is worse than missing extended key reports
- Both call sites updated (session creation in `Start` and `StartQuick`)

## Test plan

- [x] `TestOuterTerminalSupportsExtKeys` — 14 cases covering Ghostty, cmux-as-ghostty, kitty, WezTerm, plain xterm, tmux, screen, unknown terminals, and TERM_PROGRAM-only detection
- [x] Full build passes (`go build ./...`)
- [ ] Manual: Shift+R works in agent-deck TUI inside cmux after this change
- [ ] Manual: Shift+R still works in Ghostty (extended-keys enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)