### PR TITLE
fix: append ANSI reset to preview pane lines to prevent style bleed

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10932,13 +10932,16 @@ func (h *Home) renderPreviewPane(width, height int) string {
 	for _, line := range lines {
 		// Use ANSI-aware width measurement to handle lines with escape codes
 		displayWidth := ansi.StringWidth(line)
+		var finalLine string
 		if displayWidth > maxWidth {
 			// ANSI-aware truncation preserves escape codes while trimming visible content
-			truncated := ansi.Truncate(line, maxWidth-3, "...")
-			truncatedLines = append(truncatedLines, truncated)
+			finalLine = ansi.Truncate(line, maxWidth-3, "...")
 		} else {
-			truncatedLines = append(truncatedLines, line)
+			finalLine = line
 		}
+		
+		// Append ANSI reset to prevent terminal styling from bleeding into adjacent UI.
+		truncatedLines = append(truncatedLines, finalLine+"\x1b[0m")
 	}
 
 	return strings.Join(truncatedLines, "\n")


### PR DESCRIPTION
## Summary
- Lines with ANSI escape codes (background colors, reverse video) in the preview pane could bleed their styling into lipgloss padding and adjacent dashboard panels
- Appends an ANSI reset sequence (`\x1b[0m`) to each line in `renderPreviewPane` to ensure terminal styling is always contained

## Test plan
- [ ] Open agent-deck dashboard with sessions that produce colored/styled output
- [ ] Verify preview pane no longer bleeds background colors or reverse video into surrounding panels
- [ ] Confirm normal (unstyled) output still renders correctly