### PR TITLE
fix: prevent Codex session ID contamination and Ctrl+Q swallowing in nested tmux

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1686,6 +1686,15 @@ func (i *Instance) updateCodexSession(excludeIDs map[string]bool, forceProbe boo
 		return missingProbeDep
 	}
 
+	// When we already have a session ID and the process probe didn't find a
+	// running process, add our current ID to the exclude set so the disk scan
+	// won't reassign it to another instance that shares the same project path.
+	// The disk scan should only discover *new* sessions (e.g. after /new rotation),
+	// not re-discover the same ID we already own.
+	if i.CodexSessionID != "" && excludeIDs != nil {
+		excludeIDs[i.CodexSessionID] = true
+	}
+
 	if sessionID := i.queryCodexSession(excludeIDs, allowUnscoped); sessionID != "" {
 		changed := sessionID != i.CodexSessionID
 		if sessionID != i.CodexSessionID {
@@ -2497,10 +2506,11 @@ func (i *Instance) UpdateStatus() error {
 
 			// Update Codex session tracking (non-blocking, best-effort)
 			if i.Tool == "codex" {
-				var exclude map[string]bool
-				if i.CodexSessionID == "" {
-					exclude = i.collectOtherCodexSessionIDs()
-				}
+				// Always collect other instances' session IDs to prevent the
+				// disk scan from assigning a session that belongs to another
+				// instance. Without this, instances that share the same
+				// project_path can all claim the same Codex session file.
+				exclude := i.collectOtherCodexSessionIDs()
 				i.UpdateCodexSession(exclude)
 			}
 		}
@@ -3884,13 +3894,16 @@ func (i *Instance) Restart() error {
 		return nil
 	}
 
-	// For Codex: ALWAYS update session to get the most recent one
-	// Krudony fix: don't skip when we already have an ID - the user may have started a NEW session
-	if i.Tool == "codex" {
+	// For Codex: try to update session ID, but only if we don't already have one.
+	// When we already have a known session ID (from the database), trust it —
+	// the disk scan can return a wrong ID when multiple instances share the same
+	// project_path. The process probe is authoritative but only works when the
+	// process is running, which it isn't during a restart.
+	if i.Tool == "codex" && i.CodexSessionID == "" {
 		i.mu.Lock()
 		i.pendingCodexRestartWarning = ""
 		i.mu.Unlock()
-		if missingDep := i.updateCodexSession(nil, true); missingDep != "" {
+		if missingDep := i.updateCodexSession(i.collectOtherCodexSessionIDs(), true); missingDep != "" {
 			i.mu.Lock()
 			i.pendingCodexRestartWarning = codexProbeMissingWarning(missingDep)
 			i.mu.Unlock()

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1246,9 +1246,12 @@ func (s *Session) Start(command string) error {
 	// Bind Ctrl+Q to detach at the tmux level as fallback for terminals where
 	// XON/XOFF flow control intercepts the key before it reaches the PTY stdin
 	// reader (e.g. iTerm2 on macOS). Only binds on agentdeck-managed sessions.
+	// Uses a prefix match so all agentdeck sessions are covered, and forwards
+	// the key to the pane when the condition fails (e.g. when agent-deck runs
+	// inside an outer tmux session where session_name is "main").
 	_ = exec.Command("tmux", "bind-key", "-n", "-T", "root", "C-q",
-		"if-shell", fmt.Sprintf("[ \"#{session_name}\" = \"%s\" ]", s.Name),
-		"detach-client", "").Run()
+		"if-shell", "echo '#{session_name}' | grep -q '^agentdeck_'",
+		"detach-client", "send-keys C-q").Run()
 
 	// Apply user-specified tmux option overrides from config (after defaults).
 	// These are batched into a single call when multiple overrides are present.


### PR DESCRIPTION
## Summary

- **Codex session ID contamination**: When multiple instances share the same `project_path` (e.g. `~/`), the disk-based session scanner assigns the most recently modified `.jsonl` file to whichever instance scans first. This causes sessions to point to wrong Codex conversations — e.g. selecting "Amazon" opens the "Gmail filters" session.
- **Ctrl+Q not working in nested tmux**: The `bind-key -T root C-q` uses an exact session name match. When agent-deck runs inside an outer tmux (where `session_name` is "main"), the condition fails and the empty else clause silently swallows the key.

## Changes

### Session ID contamination (`internal/session/instance.go`)
- **Background worker**: Always collect other instances' session IDs before disk scanning (previously skipped when `CodexSessionID` was non-empty)
- **Disk scan self-exclusion**: Add the instance's own current ID to the exclude set so the scan only discovers genuinely new sessions (e.g. `/new` rotation), not re-claims existing IDs
- **Restart path**: Only run disk scan when no session ID exists — trust the DB-stored ID for restart/resume instead of overwriting it with a potentially wrong scan result

### Ctrl+Q bind-key (`internal/tmux/tmux.go`)
- Use `grep -q '^agentdeck_'` prefix match instead of exact session name
- Forward `send-keys C-q` on mismatch instead of empty else clause (swallowing)

## Reproduction

1. Create 2+ Codex sessions with the same `project_path` (e.g. `~/`)
2. Wait for background worker to run disk scan
3. Both sessions end up with the same `codex_session_id` in the database
4. Restarting either session resumes the wrong Codex conversation

For Ctrl+Q: run agent-deck inside a tmux session (e.g. auto-started from `.zshrc`) — Ctrl+Q does nothing.

## Test plan

- [ ] Create multiple Codex sessions with the same project path, verify they maintain separate session IDs
- [ ] Restart a session and verify it resumes the correct Codex conversation
- [ ] Run agent-deck inside an outer tmux session, verify Ctrl+Q detaches
- [ ] Run agent-deck directly (no outer tmux), verify Ctrl+Q still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)