### PR TITLE
fix(ui): quick-create session resumes source session instead of starting fresh

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6527,7 +6527,21 @@ func (h *Home) quickCreateSession() tea.Cmd {
 		tool = sourceSession.Tool
 		command = sourceSession.Command
 		if len(sourceSession.ToolOptionsJSON) > 0 {
-			toolOptionsJSON = sourceSession.ToolOptionsJSON
+			// Inherit tool options but strip session-specific fields
+			// (resume_session_id, session_mode) so the new session starts
+			// fresh instead of resuming the source session's conversation.
+			var opts map[string]interface{}
+			if err := json.Unmarshal(sourceSession.ToolOptionsJSON, &opts); err == nil {
+				if inner, ok := opts["options"].(map[string]interface{}); ok {
+					delete(inner, "resume_session_id")
+					delete(inner, "session_mode")
+				}
+				if cleaned, err := json.Marshal(opts); err == nil {
+					toolOptionsJSON = cleaned
+				}
+			} else {
+				toolOptionsJSON = sourceSession.ToolOptionsJSON
+			}
 		}
 		if sourceSession.GeminiYoloMode != nil && *sourceSession.GeminiYoloMode {
 			geminiYoloMode = true
@@ -6552,7 +6566,20 @@ func (h *Home) quickCreateSession() tea.Cmd {
 			tool = mostRecent.Tool
 			command = mostRecent.Command
 			if len(mostRecent.ToolOptionsJSON) > 0 {
-				toolOptionsJSON = mostRecent.ToolOptionsJSON
+				// Strip session-specific fields so the new session starts
+				// fresh instead of resuming the most-recent session's conversation.
+				var opts map[string]interface{}
+				if err := json.Unmarshal(mostRecent.ToolOptionsJSON, &opts); err == nil {
+					if inner, ok := opts["options"].(map[string]interface{}); ok {
+						delete(inner, "resume_session_id")
+						delete(inner, "session_mode")
+					}
+					if cleaned, err := json.Marshal(opts); err == nil {
+						toolOptionsJSON = cleaned
+					}
+				} else {
+					toolOptionsJSON = mostRecent.ToolOptionsJSON
+				}
 			}
 			if mostRecent.GeminiYoloMode != nil && *mostRecent.GeminiYoloMode {
 				geminiYoloMode = true


### PR DESCRIPTION
## Problem

Pressing Shift+N (quick create) while the cursor is on an existing session creates a new session that immediately resumes the source session's conversation instead of starting fresh.

`quickCreateSession()` copies `ToolOptionsJSON` from the source session, which includes `resume_session_id` and `session_mode: "resume"`. The new session launches with the source session's resume flag.

## Fix

Strip session-specific fields (`resume_session_id`, `session_mode`) from inherited tool options while preserving other settings like `skip_permissions` and `use_happy`.

## Test plan
- [ ] Shift+N on an existing Claude session — new session starts fresh
- [ ] Shift+N inherits `skip_permissions` setting from source
- [ ] Shift+N on a Codex session — new session starts fresh