### PR TITLE
fix: prevent UI freeze when tmux server is dead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ BUILD_DIR=./build
 VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS=-ldflags "-X main.Version=$(VERSION)"
 
+# Pin Go toolchain to 1.24.0 to prevent Go 1.25+ runtime regression on macOS
+export GOTOOLCHAIN=go1.24.0
+
 # Build the binary
 build:
 	go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/agent-deck
@@ -83,7 +86,7 @@ release-local:
 	echo "Version: $$CODE_VERSION"
 	@echo "=== Running tests ==="
 	go test -race ./...
-	@echo "=== Running GoReleaser (pinned to go1.24.0) ==="
-	GOTOOLCHAIN=go1.24.0 goreleaser release --clean
+	@echo "=== Running GoReleaser ==="
+	goreleaser release --clean
 	@echo "=== Release complete ==="
 	@echo "Verify: gh release view $$(git describe --tags --exact-match) --repo asheshgoplani/agent-deck"

--- a/internal/tmux/title_detection.go
+++ b/internal/tmux/title_detection.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -119,8 +120,10 @@ func RefreshPaneInfoCache() {
 		statusLog.Debug("pane_cache_subprocess_fallback")
 	}
 
-	// Subprocess fallback: list-panes -a
-	cmd := exec.Command("tmux", "list-panes", "-a", "-F", "#{session_name}\t#{pane_title}\t#{pane_current_command}\t#{pane_dead}\t#{window_index}\t#{pane_index}")
+	// Subprocess fallback: list-panes -a (3s timeout to prevent freeze when server is dead)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "tmux", "list-panes", "-a", "-F", "#{session_name}\t#{pane_title}\t#{pane_current_command}\t#{pane_dead}\t#{window_index}\t#{pane_index}")
 	output, err := cmd.Output()
 	if err != nil {
 		paneCacheMu.Lock()

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -104,6 +104,50 @@ var ErrCaptureTimeout = errors.New("capture-pane timed out")
 
 const SessionPrefix = "agentdeck_"
 
+// serverAlive tracks whether the tmux server is responsive.
+// When the server is dead, all subprocess calls take ~3s to fail.
+// This flag short-circuits expensive status loops to prevent UI freezes.
+var (
+	serverAliveMu   sync.RWMutex
+	serverAliveVal  = true
+	serverAliveTime time.Time
+)
+
+// IsServerAlive returns whether the tmux server was recently reachable.
+// Result is cached for 5 seconds to avoid redundant checks.
+func IsServerAlive() bool {
+	serverAliveMu.RLock()
+	if !serverAliveTime.IsZero() && time.Since(serverAliveTime) < 5*time.Second {
+		alive := serverAliveVal
+		serverAliveMu.RUnlock()
+		return alive
+	}
+	serverAliveMu.RUnlock()
+
+	// Quick probe: 1-second timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "tmux", "list-sessions", "-F", "#{session_name}").CombinedOutput()
+	alive := err == nil || (!strings.Contains(string(out), "server exited") &&
+		!strings.Contains(string(out), "lost server") &&
+		ctx.Err() != context.DeadlineExceeded)
+
+	// "no server running" with quick response is fine - server just has no sessions
+	if err != nil && strings.Contains(string(out), "no server running") {
+		alive = true
+	}
+
+	serverAliveMu.Lock()
+	serverAliveVal = alive
+	serverAliveTime = time.Now()
+	serverAliveMu.Unlock()
+
+	if !alive {
+		perfLog.Warn("tmux_server_dead")
+	}
+	return alive
+}
+
 // Session cache - reduces subprocess spawns from O(n) to O(1) per tick
 // Instead of calling `tmux has-session` and `tmux display-message` for each session,
 // we call `tmux list-sessions` ONCE and cache both existence and activity timestamps
@@ -144,8 +188,10 @@ func RefreshSessionCache() {
 		statusLog.Debug("refresh_cache_subprocess_fallback")
 	}
 
-	// Subprocess fallback: list-windows -a
-	cmd := exec.Command("tmux", "list-windows", "-a", "-F", "#{session_name}\t#{window_activity}\t#{window_index}\t#{window_name}")
+	// Subprocess fallback: list-windows -a (3s timeout to prevent freeze when server is dead)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "tmux", "list-windows", "-a", "-F", "#{session_name}\t#{window_activity}\t#{window_index}\t#{window_name}")
 	output, err := cmd.Output()
 	if err != nil {
 		sessionCacheMu.Lock()
@@ -974,7 +1020,9 @@ func generateShortID() string {
 
 // SetEnvironment sets an environment variable for this tmux session
 func (s *Session) SetEnvironment(key, value string) error {
-	cmd := exec.Command("tmux", "set-environment", "-t", s.Name, key, value)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "tmux", "set-environment", "-t", s.Name, key, value)
 	err := cmd.Run()
 	if err == nil {
 		// Invalidate cache entry so next GetEnvironment sees the new value
@@ -1016,7 +1064,9 @@ func (s *Session) GetEnvironment(key string) (string, error) {
 	}
 	s.envCacheMu.RUnlock()
 
-	cmd := exec.Command("tmux", "show-environment", "-t", s.Name, key)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "tmux", "show-environment", "-t", s.Name, key)
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("variable not found or session doesn't exist: %s", key)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2212,6 +2212,12 @@ func (h *Home) backgroundStatusUpdate() {
 		return
 	}
 
+	// Fast-fail: skip entire status loop when tmux server is dead.
+	// Without this, every subprocess call takes ~3s to fail, causing 30-50s UI freezes.
+	if !tmux.IsServerAlive() {
+		return
+	}
+
 	// Track this tick with the slow-op detector (warns if stuck >3s)
 	if sod := logging.SlowOps(); sod != nil {
 		opID := sod.Start("background_status_update")


### PR DESCRIPTION
## Summary
- When the tmux server crashes but leaves a stale socket (`/tmp/tmux-*/default`), every tmux subprocess call hangs for ~3s before failing. The background status worker makes dozens of these calls per tick across all sessions, causing **30-50s UI freezes**.
- Adds `IsServerAlive()` health check (1s probe, cached 5s) and short-circuits `backgroundStatusUpdate()` when the server is unreachable.
- Adds missing 3s timeouts to `GetEnvironment()`, `SetEnvironment()`, `RefreshSessionCache()`, and `RefreshPaneInfoCache()` subprocess fallbacks which previously had no timeout.
- Pins `GOTOOLCHAIN=go1.24.0` globally in the Makefile (was only applied to the `release-local` target).

## Test plan
- [x] `go test ./internal/tmux/...` passes
- [x] `go test ./internal/ui/...` passes (pre-existing `TestDialogPresetCommands` failure unrelated)
- [ ] Launch agent-deck with a dead tmux server (stale socket) — TUI should remain responsive
- [ ] Launch agent-deck with a healthy tmux server — status updates should work normally
- [ ] Verify `make build` uses Go 1.24.0 toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)