### PR TITLE
Fix #445: restore Kitty keyboard protocol during attach for Shift+Enter

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7081,6 +7081,12 @@ func (a attachCmd) Run() error {
 	// NOTE: Screen clearing is ONLY done in the tea.Exec callback (after Attach returns)
 	// Removing clear screen here prevents double-clearing which corrupts terminal state
 
+	// Restore Kitty keyboard protocol so the outer terminal sends extended key
+	// sequences (Shift+Enter, etc.) through to the tmux session. The TUI disables
+	// the protocol at startup for Bubble Tea compatibility; re-disable on return.
+	RestoreKittyKeyboard(os.Stdout)
+	defer DisableKittyKeyboard(os.Stdout)
+
 	ctx := context.Background()
 	return a.session.Attach(ctx, a.detachByte)
 }
@@ -7120,6 +7126,9 @@ type remoteCreateAndAttachCmd struct {
 }
 
 func (r remoteCreateAndAttachCmd) Run() error {
+	RestoreKittyKeyboard(os.Stdout)
+	defer DisableKittyKeyboard(os.Stdout)
+
 	ctx := context.Background()
 	sessionID, err := r.runner.CreateSession(ctx)
 	if err != nil {
@@ -7140,6 +7149,9 @@ type attachWindowCmd struct {
 }
 
 func (a attachWindowCmd) Run() error {
+	RestoreKittyKeyboard(os.Stdout)
+	defer DisableKittyKeyboard(os.Stdout)
+
 	ctx := context.Background()
 	return a.session.AttachWindow(ctx, a.windowIndex, a.detachByte)
 }
@@ -7173,6 +7185,9 @@ type remoteAttachCmd struct {
 }
 
 func (r remoteAttachCmd) Run() error {
+	RestoreKittyKeyboard(os.Stdout)
+	defer DisableKittyKeyboard(os.Stdout)
+
 	return r.runner.Attach(r.sessionID)
 }
 


### PR DESCRIPTION
## Summary
- Fixes Shift+Enter (line break) not working in some sessions when attaching via the TUI
- Root cause: `DisableKittyKeyboard` is called at TUI startup for Bubble Tea compatibility, but was never restored when attaching to tmux sessions, leaving the terminal in legacy keyboard mode
- Adds `RestoreKittyKeyboard`/`DisableKittyKeyboard` toggle around all 4 attach paths (local, window, remote create+attach, remote attach)

## Test plan
- [x] `go build` passes
- [x] `go vet` passes
- [x] `go fmt` clean
- [x] All unit tests pass (including keyboard_compat tests)
- [x] Full test suite passes via `make ci` (pre-push hook)
- [ ] Manual: attach to session from TUI, verify Shift+Enter produces line break in Claude Code
- [ ] Manual: detach and verify TUI keyboard shortcuts still work

Fixes #445