### PR TITLE
fix(tmux): restrict 'esc to interrupt' busy detection to status bar lines

### DIFF
--- a/internal/tmux/status_fixes_test.go
+++ b/internal/tmux/status_fixes_test.go
@@ -471,6 +471,105 @@ func TestClaudeCodeBusyPatterns(t *testing.T) {
 }
 
 // =============================================================================
+// VALIDATION 4.1: "esc to interrupt" Only Matched in Status Bar Lines
+// =============================================================================
+// Bug: conductor output containing "esc to interrupt" in prose (e.g.
+// "I is processing (esc to interrupt = running)") caused the session to be
+// detected as busy/running even when Claude was waiting at the ❯ prompt.
+// Fix: interrupt patterns are now only checked against the last 3 lines of
+// the pane (the status bar area), not the full 25-line window.
+
+func TestEscToInterruptOnlyMatchedInStatusBar(t *testing.T) {
+	// separatorLine is the horizontal rule Claude Code draws above/below the prompt.
+	const separatorLine = "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
+
+	tests := []struct {
+		name     string
+		content  string
+		wantBusy bool
+	}{
+		{
+			// Real busy: "esc to interrupt" appears in the last status-bar line,
+			// together with the bypass-permissions affordance.
+			name: "busy - esc to interrupt in status bar with bypass permissions",
+			content: `Some previous output
+
+` + separatorLine + `
+❯
+` + separatorLine + `
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt                9% until auto-compact`,
+			wantBusy: true,
+		},
+		{
+			// Real busy: bare "esc to interrupt" on its own as last status-bar line
+			// (older Claude Code versions).
+			name: "busy - esc to interrupt alone in status bar",
+			content: `Working on your request...
+` + separatorLine + `
+❯
+` + separatorLine + `
+esc to interrupt`,
+			wantBusy: true,
+		},
+		{
+			// Real busy: accept-edits variant.
+			name: "busy - esc to interrupt in accept edits status bar",
+			content: `Editing file...
+
+` + separatorLine + `
+❯
+` + separatorLine + `
+  ⏵⏵ accept edits on (shift+tab to cycle) · esc to interrupt                      9% until auto-compact`,
+			wantBusy: true,
+		},
+		{
+			// False positive regression: conductor prose output containing
+			// "esc to interrupt" with parentheses is far above the status bar.
+			// Before the fix this triggered busy detection.
+			name: "not busy - conductor prose mentioning esc to interrupt with parens",
+			content: `● I is processing (esc to interrupt = running). Verified.
+
+  ⚡ 2
+
+  · A    review loop BLA-840 (@assessor)
+  · B    running     BLA-838 billing tests
+  NEED: D stuck 4+ heartbeats.
+
+✻ Brewed for 2m 12s · 2 shells still running
+
+` + separatorLine + `
+❯
+` + separatorLine + `
+  ⏵⏵ bypass permissions on · 2 shells · ↓ to manage`,
+			wantBusy: false,
+		},
+		{
+			// Another prose variant: model output quoting the phrase.
+			name: "not busy - model output quoting esc to interrupt in body",
+			content: `To interrupt a running task, press (esc to interrupt) in the terminal.
+
+✻ Conjured for 1m 22s
+
+` + separatorLine + `
+❯
+` + separatorLine,
+			wantBusy: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// detectedTool must be set so Claude string patterns ("esc to interrupt") are loaded.
+			sess := &Session{DisplayName: "test-" + tt.name, detectedTool: "claude"}
+			got := sess.hasBusyIndicator(tt.content)
+			if got != tt.wantBusy {
+				t.Errorf("hasBusyIndicator() = %v, want %v\nContent:\n%s", got, tt.wantBusy, tt.content)
+			}
+		})
+	}
+}
+
+// =============================================================================
 // VALIDATION 5.0: thinkingPattern Requires Spinner Prefix
 // =============================================================================
 // Fix: thinkingPattern now requires a braille spinner character prefix

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2850,13 +2850,17 @@ func (s *Session) hasBusyIndicatorResolved(content string) bool {
 			}
 		}
 		lowerContent := strings.ToLower(recentContent)
+		// "esc to interrupt" always appears in the last 1-2 status bar lines of the
+		// pane. Limiting to 3 lines prevents matching model-generated prose output
+		// that happens to contain the phrase (e.g. conductor status reports).
+		statusBarLines := lastNLines(content, 3)
 		for _, str := range patterns.BusyStrings {
 			lowerStr := strings.ToLower(str)
 			if !strings.Contains(lowerContent, lowerStr) {
 				continue
 			}
 			if strings.Contains(lowerStr, "interrupt") &&
-				!hasInterruptBusyContext(recentLines, lowerStr, spinnerChars) {
+				!hasInterruptBusyContext(statusBarLines, lowerStr, spinnerChars) {
 				statusLog.Debug("busy_string_ignored_no_context",
 					slog.String("session", shortName),
 					slog.String("pattern", str))


### PR DESCRIPTION
## Problem

Sessions were incorrectly detected as `running` (busy) when their pane output contained the phrase `esc to interrupt` anywhere in the body text — not just in Claude Code's actual status bar.

A concrete example: a conductor session that had finished responding and was waiting at the `❯` prompt showed as `running` because its own output included a line like:

```
● I is processing (esc to interrupt = running). Verified.
```

This caused the heartbeat to skip the conductor (only sends when status is `idle` or `waiting`), so heartbeats silently stopped firing.

## Root Cause

`hasBusyIndicatorResolved` checked for `"esc to interrupt"` across the last **25 lines** of pane content, so prose far above the status bar could trigger the pattern.

## Fix

Claude Code's status bar always lives **below the last horizontal separator** (`────`). The layout is:

```
────────────────────────  (first separator)
❯                         (prompt area)
────────────────────────  (last separator)
  ⏵⏵ bypass permissions on · esc to interrupt · ctrl+t to show tasks   ← status bar
```

Two new helpers scope the check to the right region:

- **`isHorizontalSeparator(line)`** — matches lines made entirely of U+2500 box-drawing dashes (`─`), 8+ runes wide. ASCII hyphens are intentionally excluded (they appear in prose/markdown).
- **`linesAfterLastSeparator(content)`** — finds the last separator and returns everything below it. If the separator is the final line (idle pane), returns lines between the last two separators. Falls back to `lastNLines(content, 3)` when no separator is present.

The `hasInterruptBusyContext` call now receives `linesAfterLastSeparator(content)` instead of `lastNLines(content, 3)`, making the boundary structural rather than a fixed line count. This is robust even when the status bar wraps onto 2–3 lines on narrow panes.

## Tests

- **`TestEscToInterruptOnlyMatchedInStatusBar`** — 5 cases covering real status bar variants (busy) and conductor prose output (not busy)
- **`TestLinesAfterLastSeparator`** — 4 unit tests for the new helper: standard layout, separator-as-last-line, no separator fallback, trailing blank line stripping
- **`TestEscToInterruptSeparatorBased`** — 2 end-to-end cases using the exact pane layout reported in the bug, verified via `hasBusyIndicator`