### PR TITLE
feat(conductor): queue messages when conductor is busy, deliver with reply callback

### DIFF
--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -780,8 +780,9 @@ def create_telegram_bot(config: dict):
     bot = Bot(token=config["telegram"]["token"])
     dp = Dispatcher()
     authorized_user = config["telegram"]["user_id"]
-    profiles = config["profiles"]
-    default_profile = profiles[0]
+    profiles = get_unique_profiles()
+    default_conductor = get_default_conductor()
+    default_profile = default_conductor["profile"] if default_conductor else (profiles[0] if profiles else "default")
     bot_info = {"username": ""}
 
     async def ensure_bot_info(bot_instance: Bot):

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
 """
-Conductor Bridge: Telegram <-> Agent-Deck conductor sessions (multi-profile).
+Conductor Bridge: Telegram & Slack <-> Agent-Deck conductor sessions (multi-conductor).
 
 A thin bridge that:
-  A) Forwards Telegram messages -> conductor session (via agent-deck CLI)
-  B) Forwards conductor responses -> Telegram
+  A) Forwards Telegram/Slack messages -> conductor session (via agent-deck CLI)
+  B) Forwards conductor responses -> Telegram/Slack
   C) Runs a periodic heartbeat to trigger conductor status checks
 
-Supports multiple profiles: each profile gets its own conductor session.
-The bridge aggregates status across all profiles.
+Discovers conductors dynamically from meta.json files in ~/.agent-deck/conductor/*/
+Each conductor has its own name, profile, and heartbeat settings.
 
-Dependencies: pip3 install aiogram toml
+Dependencies: pip3 install toml aiogram slack-bolt slack-sdk
+  - aiogram is only needed if Telegram is configured
+  - slack-bolt/slack-sdk are only needed if Slack is configured
 """
 
 import asyncio
@@ -24,8 +26,24 @@ import time
 from pathlib import Path
 
 import toml
-from aiogram import Bot, Dispatcher, types
-from aiogram.filters import Command, CommandStart
+
+# Conditional imports for Telegram
+try:
+    from aiogram import Bot, Dispatcher, types
+    from aiogram.filters import Command, CommandStart
+    HAS_AIOGRAM = True
+except ImportError:
+    HAS_AIOGRAM = False
+
+# Conditional imports for Slack
+try:
+    from slack_bolt.async_app import AsyncApp
+    from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
+    from slack_bolt.authorization import AuthorizeResult
+    from slack_sdk.web.async_client import AsyncWebClient
+    HAS_SLACK = True
+except ImportError:
+    HAS_SLACK = False
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -36,6 +54,9 @@ CONFIG_PATH = AGENT_DECK_DIR / "config.toml"
 CONDUCTOR_DIR = AGENT_DECK_DIR / "conductor"
 # Telegram message length limit
 TG_MAX_LENGTH = 4096
+
+# Slack message length limit
+SLACK_MAX_LENGTH = 40000
 
 # How long to wait for conductor to respond (seconds)
 RESPONSE_TIMEOUT = 300
@@ -60,7 +81,11 @@ log = logging.getLogger("conductor-bridge")
 
 
 def load_config() -> dict:
-    """Load [conductor] section from config.toml."""
+    """Load [conductor] section from config.toml.
+
+    Returns a dict with nested 'telegram' and 'slack' sub-dicts,
+    each with a 'configured' flag.
+    """
     if not CONFIG_PATH.exists():
         log.error("Config not found: %s", CONFIG_PATH)
         sys.exit(1)
@@ -72,30 +97,79 @@ def load_config() -> dict:
         log.error("[conductor] section missing or not enabled in config.toml")
         sys.exit(1)
 
+    # Telegram config
     tg = conductor_cfg.get("telegram", {})
-    token = tg.get("token", "")
-    user_id = tg.get("user_id", 0)
+    tg_token = tg.get("token", "")
+    tg_user_id = tg.get("user_id", 0)
+    tg_configured = bool(tg_token and tg_user_id)
 
-    if not token:
-        log.error("conductor.telegram.token not set in config.toml")
-        sys.exit(1)
-    if not user_id:
-        log.error("conductor.telegram.user_id not set in config.toml")
-        sys.exit(1)
+    # Slack config
+    sl = conductor_cfg.get("slack", {})
+    sl_bot_token = sl.get("bot_token", "")
+    sl_app_token = sl.get("app_token", "")
+    sl_channel_id = sl.get("channel_id", "")
+    sl_listen_mode = sl.get("listen_mode", "mentions")  # "mentions" or "all"
+    sl_allowed_users = sl.get("allowed_user_ids", [])  # List of authorized Slack user IDs
+    sl_configured = bool(sl_bot_token and sl_app_token and sl_channel_id)
 
-    profiles = conductor_cfg.get("profiles", ["default"])
+    if not tg_configured and not sl_configured:
+        log.error(
+            "Neither Telegram nor Slack configured in config.toml. "
+            "Set [conductor.telegram] or [conductor.slack]."
+        )
+        sys.exit(1)
 
     return {
-        "token": token,
-        "user_id": int(user_id),
+        "telegram": {
+            "token": tg_token,
+            "user_id": int(tg_user_id) if tg_user_id else 0,
+            "configured": tg_configured,
+        },
+        "slack": {
+            "bot_token": sl_bot_token,
+            "app_token": sl_app_token,
+            "channel_id": sl_channel_id,
+            "listen_mode": sl_listen_mode,
+            "allowed_user_ids": sl_allowed_users,
+            "configured": sl_configured,
+        },
         "heartbeat_interval": conductor_cfg.get("heartbeat_interval", 15),
-        "profiles": profiles,
     }
 
 
-def conductor_session_title(profile: str) -> str:
-    """Return the conductor session title for a given profile."""
-    return f"conductor-{profile}"
+def discover_conductors() -> list[dict]:
+    """Discover all conductors by scanning meta.json files."""
+    conductors = []
+    if not CONDUCTOR_DIR.exists():
+        return conductors
+    for entry in CONDUCTOR_DIR.iterdir():
+        if entry.is_dir():
+            meta_path = entry / "meta.json"
+            if meta_path.exists():
+                try:
+                    with open(meta_path) as f:
+                        conductors.append(json.load(f))
+                except (json.JSONDecodeError, IOError) as e:
+                    log.warning("Failed to read %s: %s", meta_path, e)
+    return conductors
+
+
+def conductor_session_title(name: str) -> str:
+    """Return the conductor session title for a given conductor name."""
+    return f"conductor-{name}"
+
+
+def get_conductor_names() -> list[str]:
+    """Get list of all conductor names."""
+    return [c["name"] for c in discover_conductors()]
+
+
+def get_unique_profiles() -> list[str]:
+    """Get unique profile names from all conductors."""
+    profiles = set()
+    for c in discover_conductors():
+        profiles.add(c.get("profile", "default"))
+    return sorted(profiles)
 
 
 # ---------------------------------------------------------------------------
@@ -131,7 +205,7 @@ def run_cli(
 def get_session_status(session: str, profile: str | None = None) -> str:
     """Get the status of a session (running/waiting/idle/error)."""
     result = run_cli(
-        "session", "show", session, "--json", profile=profile, timeout=30
+        "session", "show", "--json", session, profile=profile, timeout=30
     )
     if result.returncode != 0:
         return "error"
@@ -162,27 +236,152 @@ def send_to_conductor(
     """Send a message to the conductor session.
 
     Returns (success, response_text). When wait_for_reply=False, response_text is "".
+
+    When wait_for_reply=False and the conductor is busy (running/active/starting),
+    the message is queued in-memory and delivered automatically once the conductor
+    returns to idle/waiting state (see _drain_queue). This prevents message loss
+    during long-running tool calls.
     """
-    if wait_for_reply:
-        # Single-call flow: send + wait + print raw response.
-        # Avoids extra status/output polling round-trips.
-        result = run_cli(
-            "session", "send", session, message,
-            "--wait", "--timeout", f"{response_timeout}s", "-q",
-            profile=profile,
-            timeout=max(response_timeout+30, 60),
-        )
-    else:
+    if not wait_for_reply:
+        # For non-blocking sends (user messages), check if conductor is busy
+        # and queue instead of dropping.
+        status = get_session_status(session, profile=profile)
+        if status in ("running", "active", "starting"):
+            log.info(
+                "Conductor %s is busy (%s), queueing message", session, status,
+            )
+            _enqueue_message(session, message, profile)
+            return True, ""  # queued, not failed
+
         result = run_cli(
             "session", "send", session, message, "--no-wait",
             profile=profile, timeout=30,
         )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            # If the conductor became busy between the status check and the send,
+            # queue instead of dropping.
+            if "timeout" in stderr.lower() or "not ready" in stderr.lower():
+                log.info(
+                    "Conductor %s became busy during send, queueing message",
+                    session,
+                )
+                _enqueue_message(session, message, profile)
+                return True, ""
+            log.error("Failed to send to conductor: %s", stderr)
+            return False, ""
+        return True, ""
+
+    # wait_for_reply=True: single-call flow used by heartbeats.
+    # Send + wait + capture raw response. Avoids extra polling round-trips.
+    result = run_cli(
+        "session", "send", session, message,
+        "--wait", "--timeout", f"{response_timeout}s", "-q",
+        profile=profile,
+        timeout=max(response_timeout + 30, 60),
+    )
     if result.returncode != 0:
         log.error(
             "Failed to send to conductor: %s", result.stderr.strip()
         )
         return False, ""
     return True, result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Message queue for busy conductors
+# ---------------------------------------------------------------------------
+
+# In-memory queue: {session_title: [(message, profile), ...]}
+_message_queue: dict[str, list[tuple[str, str | None]]] = {}
+_queue_lock = asyncio.Lock()
+_drain_task: asyncio.Task | None = None
+
+
+def _enqueue_message(session: str, message: str, profile: str | None) -> None:
+    """Add a message to the in-memory queue for a busy conductor."""
+    if session not in _message_queue:
+        _message_queue[session] = []
+    _message_queue[session].append((message, profile))
+    log.info(
+        "Queued message for %s (queue depth: %d)",
+        session, len(_message_queue[session]),
+    )
+    _ensure_drain_task()
+
+
+def _ensure_drain_task() -> None:
+    """Start the background drain task if it's not already running."""
+    global _drain_task
+    if _drain_task is None or _drain_task.done():
+        _drain_task = asyncio.ensure_future(_drain_queue())
+
+
+async def _drain_queue() -> None:
+    """Background loop that delivers queued messages once conductors are ready.
+
+    Polls every 5s. For each conductor with queued messages, checks its
+    status and delivers the oldest message when it becomes idle/waiting.
+    Stops when the queue is empty.
+    """
+    log.info("Queue drain task started")
+    while True:
+        await asyncio.sleep(5)
+
+        if not _message_queue:
+            log.info("Queue drain task finished (queue empty)")
+            return
+
+        # Snapshot keys to avoid mutation during iteration
+        sessions = list(_message_queue.keys())
+        for session in sessions:
+            items = _message_queue.get(session)
+            if not items:
+                _message_queue.pop(session, None)
+                continue
+
+            message, profile = items[0]
+            status = get_session_status(session, profile=profile)
+
+            if status in ("running", "active", "starting"):
+                continue  # still busy, try next cycle
+
+            if status == "error":
+                log.error(
+                    "Conductor %s in error state, dropping %d queued message(s)",
+                    session, len(items),
+                )
+                _message_queue.pop(session, None)
+                continue
+
+            # Conductor is ready — deliver the message
+            log.info(
+                "Conductor %s is %s, delivering queued message (%d remaining)",
+                session, status, len(items) - 1,
+            )
+            result = run_cli(
+                "session", "send", session, message,
+                profile=profile, timeout=120,
+            )
+            if result.returncode == 0:
+                items.pop(0)
+                if not items:
+                    _message_queue.pop(session, None)
+            else:
+                stderr = result.stderr.strip()
+                if "timeout" in stderr.lower() or "not ready" in stderr.lower():
+                    log.info(
+                        "Conductor %s busy again during drain, will retry",
+                        session,
+                    )
+                else:
+                    log.error(
+                        "Failed to deliver queued message to %s: %s — dropping",
+                        session, stderr,
+                    )
+                    items.pop(0)
+                    if not items:
+                        _message_queue.pop(session, None)
 
 
 def get_status_summary(profile: str | None = None) -> dict:
@@ -233,15 +432,14 @@ def get_sessions_list_all(profiles: list[str]) -> list[tuple[str, dict]]:
     return all_sessions
 
 
-def ensure_conductor_running(profile: str) -> bool:
-    """Ensure the conductor session for a profile exists and is running."""
-    session_title = conductor_session_title(profile)
+def ensure_conductor_running(name: str, profile: str) -> bool:
+    """Ensure the conductor session exists and is running."""
+    session_title = conductor_session_title(name)
     status = get_session_status(session_title, profile=profile)
 
     if status == "error":
         log.info(
-            "Conductor session for %s not running, attempting to start...",
-            profile,
+            "Conductor %s not running, attempting to start...", name,
         )
         # Try starting first (session might exist but be stopped)
         result = run_cli(
@@ -249,20 +447,20 @@ def ensure_conductor_running(profile: str) -> bool:
         )
         if result.returncode != 0:
             # Session might not exist, try creating it
-            log.info("Creating conductor session for %s...", profile)
-            session_path = str(CONDUCTOR_DIR / profile)
+            log.info("Creating conductor session for %s...", name)
+            session_path = str(CONDUCTOR_DIR / name)
             result = run_cli(
                 "add", session_path,
                 "-t", session_title,
                 "-c", "claude",
-                "-g", "infra",
+                "-g", "conductor",
                 profile=profile,
                 timeout=60,
             )
             if result.returncode != 0:
                 log.error(
-                    "Failed to create conductor for %s: %s",
-                    profile,
+                    "Failed to create conductor %s: %s",
+                    name,
                     result.stderr.strip(),
                 )
                 return False
@@ -279,14 +477,6 @@ def ensure_conductor_running(profile: str) -> bool:
         )
 
     return True
-
-
-def ensure_all_conductors_running(profiles: list[str]) -> dict[str, bool]:
-    """Ensure conductor sessions are running for all profiles."""
-    results = {}
-    for profile in profiles:
-        results[profile] = ensure_conductor_running(profile)
-    return results
 
 
 # ---------------------------------------------------------------------------
@@ -390,28 +580,18 @@ def invoke_hook(
 # ---------------------------------------------------------------------------
 
 
-def parse_profile_prefix(text: str, profiles: list[str]) -> tuple[str | None, str]:
-    """Parse profile prefix from user message.
+def parse_conductor_prefix(text: str, conductor_names: list[str]) -> tuple[str | None, str]:
+    """Parse conductor name prefix from user message.
 
     Supports formats:
-      /p <profile> <message>
-      <profile>: <message>
+      <name>: <message>
 
-    Returns (profile_or_None, cleaned_message).
+    Returns (name_or_None, cleaned_message).
     """
-    # Check /p <profile> <message>
-    if text.startswith("/p "):
-        parts = text[3:].strip().split(None, 1)
-        if len(parts) >= 2 and parts[0] in profiles:
-            return parts[0], parts[1]
-        if len(parts) == 1 and parts[0] in profiles:
-            return parts[0], ""
-
-    # Check <profile>: <message>
-    for profile in profiles:
-        prefix = f"{profile}:"
+    for name in conductor_names:
+        prefix = f"{name}:"
         if text.startswith(prefix):
-            return profile, text[len(prefix):].strip()
+            return name, text[len(prefix):].strip()
 
     return None, text
 
@@ -422,7 +602,7 @@ def parse_profile_prefix(text: str, profiles: list[str]) -> tuple[str | None, st
 
 
 def split_message(text: str, max_len: int = TG_MAX_LENGTH) -> list[str]:
-    """Split a long message into chunks that fit Telegram's limit."""
+    """Split a long message into chunks that fit the platform limit."""
     if len(text) <= max_len:
         return [text]
 
@@ -476,9 +656,18 @@ def md_to_tg_html(text: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
-    """Create and configure the Telegram bot."""
-    bot = Bot(token=config["token"])
+def create_telegram_bot(config: dict):
+    """Create and configure the Telegram bot.
+
+    Returns (bot, dp) or None if Telegram is not configured or aiogram is not available.
+    """
+    if not HAS_AIOGRAM:
+        log.warning("aiogram not installed, skipping Telegram bot")
+        return None
+    if not config["telegram"]["configured"]:
+        return None
+
+    bot = Bot(token=config["telegram"]["token"])
     dp = Dispatcher()
     authorized_user = config["user_id"]
     profiles = config["profiles"]
@@ -536,19 +725,22 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
     async def cmd_start(message: types.Message):
         if not is_authorized(message):
             return
-        profile_list = ", ".join(profiles)
+        conductors = discover_conductors()
+        names = [c["name"] for c in conductors]
+        default = names[0] if names else "none"
         await message.answer(
             "Conductor bridge active.\n"
-            f"Profiles: {profile_list}\n"
+            f"Conductors: {', '.join(names) if names else 'none'}\n"
             "Commands: /status /sessions /help /restart\n"
-            f"Route to profile: /p <profile> <message> or <profile>: <message>\n"
-            f"Default profile: {default_profile}"
+            f"Route to conductor: <name>: <message>\n"
+            f"Default conductor: {default}"
         )
 
     @dp.message(Command("status"))
     async def cmd_status(message: types.Message):
         if not is_authorized(message):
             return
+        profiles = get_unique_profiles()
         agg = get_status_summary_all(profiles)
         totals = agg["totals"]
 
@@ -576,6 +768,7 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
     async def cmd_sessions(message: types.Message):
         if not is_authorized(message):
             return
+        profiles = get_unique_profiles()
         all_sessions = get_sessions_list_all(profiles)
         if not all_sessions:
             await message.answer("No sessions found.")
@@ -602,16 +795,17 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
     async def cmd_help(message: types.Message):
         if not is_authorized(message):
             return
-        profile_list = ", ".join(profiles)
+        conductors = discover_conductors()
+        names = [c["name"] for c in conductors]
         await message.answer(
             "Conductor Commands:\n"
             "/status    - Aggregated status across all profiles\n"
             "/sessions  - List all sessions (all profiles)\n"
-            "/restart   - Restart a conductor (default or specify profile)\n"
+            "/restart   - Restart a conductor (specify name)\n"
             "/help      - This message\n\n"
-            f"Profiles: {profile_list}\n"
-            f"Route: /p <profile> <message> or <profile>: <message>\n"
-            f"Default: messages go to {default_profile} conductor"
+            f"Conductors: {', '.join(names) if names else 'none'}\n"
+            f"Route: <name>: <message>\n"
+            f"Default: messages go to first conductor"
         )
 
     @dp.message(Command("restart"))
@@ -619,24 +813,35 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
         if not is_authorized(message):
             return
 
-        # Parse optional profile argument: /restart work
+        # Parse optional conductor name: /restart ryan
         text = message.text.strip()
         parts = text.split(None, 1)
-        target_profile = default_profile
-        if len(parts) > 1 and parts[1] in profiles:
-            target_profile = parts[1]
+        conductor_names = get_conductor_names()
 
-        session_title = conductor_session_title(target_profile)
+        target = None
+        if len(parts) > 1 and parts[1] in conductor_names:
+            for c in discover_conductors():
+                if c["name"] == parts[1]:
+                    target = c
+                    break
+        if target is None:
+            target = get_default_conductor()
+
+        if target is None:
+            await message.answer("No conductors found.")
+            return
+
+        session_title = conductor_session_title(target["name"])
         await message.answer(
-            f"Restarting conductor for [{target_profile}]..."
+            f"Restarting conductor {target['name']}..."
         )
         result = run_cli(
             "session", "restart", session_title,
-            profile=target_profile, timeout=60,
+            profile=target["profile"], timeout=60,
         )
         if result.returncode == 0:
             await message.answer(
-                f"Conductor [{target_profile}] restarted."
+                f"Conductor {target['name']} restarted."
             )
         else:
             await message.answer(
@@ -663,10 +868,22 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
         target_profile, cleaned_msg = parse_profile_prefix(text, profiles)
         if target_profile is None:
             target_profile = default_profile
+
         if not cleaned_msg:
             cleaned_msg = text
 
-        session_title = conductor_session_title(target_profile)
+        # Find conductor for this profile
+        all_conductors = discover_conductors()
+        target_conductor = next(
+            (c for c in all_conductors if c["profile"] == target_profile), None
+        )
+        if target_conductor is None:
+            await message.answer(
+                f"[No conductor configured for profile {target_profile}. Run: agent-deck conductor setup]"
+            )
+            return
+
+        session_title = conductor_session_title(target_conductor["name"])
 
         # Run pre-message hook (can transform or gate the message)
         hook_result = invoke_hook(target_profile, "pre-message", {
@@ -683,16 +900,38 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
                 cleaned_msg = stdout
 
         # Ensure conductor is running for this profile
-        if not ensure_conductor_running(target_profile):
+        if not ensure_conductor_running(target_conductor["name"], target_profile):
             await message.answer(
                 f"[Could not start conductor for {target_profile}. Check agent-deck.]"
             )
             return
 
-        # Send to conductor
-        log.info(
-            "User message -> [%s]: %s", target_profile, cleaned_msg[:100]
-        )
+        profile_tag = f"[{target_profile}] " if len(profiles) > 1 else ""
+
+        # Check if conductor is busy; queue the message instead of blocking
+        conductor_status = get_session_status(session_title, profile=target_profile)
+        was_busy = conductor_status in ("running", "active", "starting")
+
+        log.info("User message -> [%s]: %s", target_profile, cleaned_msg[:100])
+
+        if was_busy:
+            ok, _ = send_to_conductor(
+                session_title,
+                cleaned_msg,
+                profile=target_profile,
+                wait_for_reply=False,
+            )
+            if not ok:
+                await message.answer(
+                    f"[Failed to send message to conductor [{target_profile}].]"
+                )
+                return
+            await message.answer(
+                f"{profile_tag}⏳ Conductor busy — message queued, will deliver when ready."
+            )
+            return
+
+        # Conductor is free — send and wait for reply synchronously
         ok, response = send_to_conductor(
             session_title,
             cleaned_msg,
@@ -707,9 +946,6 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
             return
 
         # Response is returned directly by `session send --wait`.
-        profile_tag = (
-            f"[{target_profile}] " if len(profiles) > 1 else ""
-        )
         await message.answer(f"{profile_tag}...")  # typing indicator
         log.info("Conductor [%s] response: %s", target_profile, response[:100])
 
@@ -728,6 +964,329 @@ def create_bot(config: dict) -> tuple[Bot, Dispatcher]:
         })
 
     return bot, dp
+
+
+# ---------------------------------------------------------------------------
+# Slack app setup
+# ---------------------------------------------------------------------------
+
+
+def create_slack_app(config: dict):
+    """Create and configure the Slack app with Socket Mode.
+
+    Returns (app, channel_id) or None if Slack is not configured or slack-bolt is not available.
+    """
+    if not HAS_SLACK:
+        log.warning("slack-bolt not installed, skipping Slack app")
+        return None
+    if not config["slack"]["configured"]:
+        return None
+
+    bot_token = config["slack"]["bot_token"]
+    channel_id = config["slack"]["channel_id"]
+
+    # Cache auth.test() result to avoid calling it on every event.
+    # The default SingleTeamAuthorization middleware calls auth.test()
+    # per-event until it succeeds; if the Slack API is slow after a
+    # Socket Mode reconnect, this causes cascading TimeoutErrors.
+    _auth_cache: dict = {}
+    _auth_lock = asyncio.Lock()
+
+    async def _cached_authorize(**kwargs):
+        async with _auth_lock:
+            if "result" in _auth_cache:
+                return _auth_cache["result"]
+            client = AsyncWebClient(token=bot_token, timeout=30)
+            for attempt in range(3):
+                try:
+                    resp = await client.auth_test()
+                    _auth_cache["result"] = AuthorizeResult(
+                        enterprise_id=resp.get("enterprise_id"),
+                        team_id=resp.get("team_id"),
+                        bot_user_id=resp.get("user_id"),
+                        bot_id=resp.get("bot_id"),
+                        bot_token=bot_token,
+                    )
+                    return _auth_cache["result"]
+                except Exception as e:
+                    log.warning("Slack auth.test attempt %d/3 failed: %s", attempt + 1, e)
+                    if attempt < 2:
+                        await asyncio.sleep(2 ** attempt)
+            raise RuntimeError("Slack auth.test failed after 3 attempts")
+
+    app = AsyncApp(token=bot_token, authorize=_cached_authorize)
+    listen_mode = config["slack"].get("listen_mode", "mentions")
+
+    # Authorization setup
+    allowed_users = config["slack"]["allowed_user_ids"]
+
+    def is_slack_authorized(user_id: str) -> bool:
+        """Check if Slack user is authorized to use the bot.
+
+        If allowed_user_ids is empty, allow all users (backward compatible).
+        Otherwise, only allow users in the list.
+        """
+        if not allowed_users:  # Empty list = no restrictions
+            return True
+        if user_id not in allowed_users:
+            log.warning("Unauthorized Slack message from user %s", user_id)
+            return False
+        return True
+
+    def get_default_conductor() -> dict | None:
+        """Get the first conductor (default target for messages)."""
+        conductors = discover_conductors()
+        return conductors[0] if conductors else None
+
+    async def _safe_say(say, **kwargs):
+        """Wrapper around say() that catches network/API errors."""
+        try:
+            await say(**kwargs)
+        except Exception as e:
+            log.error("Slack say() failed: %s", e)
+
+    async def _handle_slack_text(text: str, say, thread_ts: str = None):
+        """Shared handler for Slack messages and mentions."""
+        conductor_names = get_conductor_names()
+        conductors = discover_conductors()
+
+        target_name, cleaned_msg = parse_conductor_prefix(text, conductor_names)
+
+        target = None
+        if target_name:
+            for c in conductors:
+                if c["name"] == target_name:
+                    target = c
+                    break
+        if target is None:
+            target = get_default_conductor()
+        if target is None:
+            await _safe_say(
+                say,
+                text="[No conductors configured. Run: agent-deck conductor setup <name>]",
+                thread_ts=thread_ts,
+            )
+            return
+
+        if not cleaned_msg:
+            cleaned_msg = text
+
+        session_title = conductor_session_title(target["name"])
+        profile = target["profile"]
+
+        if not ensure_conductor_running(target["name"], profile):
+            await _safe_say(
+                say,
+                text=f"[Could not start conductor {target['name']}. Check agent-deck.]",
+                thread_ts=thread_ts,
+            )
+            return
+
+        # Check if conductor is busy before sending
+        conductor_status = get_session_status(session_title, profile=profile)
+        was_busy = conductor_status in ("running", "active", "starting")
+
+        log.info("Slack message -> [%s]: %s", target["name"], cleaned_msg[:100])
+        if not send_to_conductor(session_title, cleaned_msg, profile=profile):
+            await _safe_say(
+                say,
+                text=f"[Failed to send message to conductor {target['name']}.]",
+                thread_ts=thread_ts,
+            )
+            return
+
+        name_tag = f"[{target['name']}] " if len(conductors) > 1 else ""
+
+        if was_busy:
+            await _safe_say(
+                say,
+                text=f"{name_tag}⏳ Conductor busy — message queued, will deliver when ready.",
+                thread_ts=thread_ts,
+            )
+            return
+
+        await _safe_say(say, text=f"{name_tag}...", thread_ts=thread_ts)
+
+        response = await wait_for_response(session_title, profile=profile)
+        log.info("Conductor [%s] response: %s", target["name"], response[:100])
+
+        for chunk in split_message(response, max_len=SLACK_MAX_LENGTH):
+            prefixed = f"{name_tag}{chunk}" if name_tag else chunk
+            await _safe_say(say, text=prefixed, thread_ts=thread_ts)
+
+    @app.event("message")
+    async def handle_slack_message(event, say):
+        """Handle messages in the configured channel.
+
+        Only active when listen_mode is "all". Ignored in "mentions" mode.
+        """
+        if listen_mode != "all":
+            return
+        # Ignore bot messages
+        if event.get("bot_id") or event.get("subtype"):
+            return
+        # Only listen in configured channel
+        if event.get("channel") != channel_id:
+            return
+
+        # Authorization check
+        user_id = event.get("user", "")
+        if not is_slack_authorized(user_id):
+            return
+
+        text = event.get("text", "").strip()
+        if not text:
+            return
+        await _handle_slack_text(
+            text, say,
+            thread_ts=event.get("thread_ts") or event.get("ts"),
+        )
+
+    @app.event("app_mention")
+    async def handle_slack_mention(event, say):
+        """Handle @bot mentions in any channel the bot is in. Always active."""
+
+        # Authorization check
+        user_id = event.get("user", "")
+        if not is_slack_authorized(user_id):
+            return
+
+        text = event.get("text", "")
+        # Strip the bot mention (e.g., "<@U01234> message" -> "message")
+        text = re.sub(r"<@[A-Z0-9]+>\s*", "", text).strip()
+        if not text:
+            return
+        thread_ts = event.get("thread_ts") or event.get("ts")
+        await _handle_slack_text(
+            text, say,
+            thread_ts=thread_ts,
+        )
+
+    @app.command("/ad-status")
+    async def slack_cmd_status(ack, respond, command):
+        """Handle /ad-status slash command."""
+        await ack()
+
+        # Authorization check
+        user_id = command.get("user_id", "")
+        if not is_slack_authorized(user_id):
+            await respond("⛔ Unauthorized. Contact your administrator.")
+            return
+
+        profiles = get_unique_profiles()
+        agg = get_status_summary_all(profiles)
+        totals = agg["totals"]
+
+        lines = [
+            f"Total: {totals['total']} sessions",
+            f"  Running: {totals['running']}",
+            f"  Waiting: {totals['waiting']}",
+            f"  Idle: {totals['idle']}",
+            f"  Error: {totals['error']}",
+        ]
+
+        if len(profiles) > 1:
+            lines.append("")
+            for profile in profiles:
+                p = agg["per_profile"][profile]
+                lines.append(
+                    f"[{profile}] {p['total']}s "
+                    f"({p['running']}R {p['waiting']}W {p['idle']}I {p['error']}E)"
+                )
+
+        await respond("\n".join(lines))
+
+    @app.command("/ad-sessions")
+    async def slack_cmd_sessions(ack, respond, command):
+        """Handle /ad-sessions slash command."""
+        await ack()
+
+        # Authorization check
+        user_id = command.get("user_id", "")
+        if not is_slack_authorized(user_id):
+            await respond("⛔ Unauthorized. Contact your administrator.")
+            return
+
+        profiles = get_unique_profiles()
+        all_sessions = get_sessions_list_all(profiles)
+        if not all_sessions:
+            await respond("No sessions found.")
+            return
+
+        lines = []
+        for profile, s in all_sessions:
+            title = s.get("title", "untitled")
+            status = s.get("status", "unknown")
+            tool = s.get("tool", "")
+            prefix = f"[{profile}] " if len(profiles) > 1 else ""
+            lines.append(f"  {prefix}{title} ({tool}) - {status}")
+
+        await respond("\n".join(lines))
+
+    @app.command("/ad-restart")
+    async def slack_cmd_restart(ack, respond, command):
+        """Handle /ad-restart slash command."""
+        await ack()
+
+        # Authorization check
+        user_id = command.get("user_id", "")
+        if not is_slack_authorized(user_id):
+            await respond("⛔ Unauthorized. Contact your administrator.")
+            return
+
+        target_name = command.get("text", "").strip()
+        conductor_names = get_conductor_names()
+
+        target = None
+        if target_name and target_name in conductor_names:
+            for c in discover_conductors():
+                if c["name"] == target_name:
+                    target = c
+                    break
+        if target is None:
+            target = get_default_conductor()
+
+        if target is None:
+            await respond("No conductors found.")
+            return
+
+        session_title = conductor_session_title(target["name"])
+        await respond(f"Restarting conductor {target['name']}...")
+        result = run_cli(
+            "session", "restart", session_title,
+            profile=target["profile"], timeout=60,
+        )
+        if result.returncode == 0:
+            await respond(f"Conductor {target['name']} restarted.")
+        else:
+            await respond(f"Restart failed: {result.stderr.strip()}")
+
+    @app.command("/ad-help")
+    async def slack_cmd_help(ack, respond, command):
+        """Handle /ad-help slash command."""
+        await ack()
+
+        # Authorization check
+        user_id = command.get("user_id", "")
+        if not is_slack_authorized(user_id):
+            await respond("⛔ Unauthorized. Contact your administrator.")
+            return
+
+        conductors = discover_conductors()
+        names = [c["name"] for c in conductors]
+        await respond(
+            "Conductor Commands:\n"
+            "/ad-status    - Aggregated status across all profiles\n"
+            "/ad-sessions  - List all sessions (all profiles)\n"
+            "/ad-restart   - Restart a conductor (specify name)\n"
+            "/ad-help      - This message\n\n"
+            f"Conductors: {', '.join(names) if names else 'none'}\n"
+            f"Route: <name>: <message>\n"
+            f"Default: messages go to first conductor"
+        )
+
+    log.info("Slack app initialized (Socket Mode, channel=%s)", channel_id)
+    return app, channel_id
 
 
 # ---------------------------------------------------------------------------
@@ -756,10 +1315,10 @@ def _os_heartbeat_daemon_installed() -> bool:
     return False
 
 
-async def heartbeat_loop(bot: Bot, config: dict):
-    """Periodic heartbeat: check status across all profiles and trigger conductors."""
-    interval_minutes = config["heartbeat_interval"]
-    if interval_minutes <= 0:
+async def heartbeat_loop(config: dict, telegram_bot=None, slack_app=None, slack_channel_id=None):
+    """Periodic heartbeat: check status for each conductor and trigger checks."""
+    global_interval = config["heartbeat_interval"]
+    if global_interval <= 0:
         log.info("Heartbeat disabled (interval=0)")
         return
 
@@ -767,24 +1326,28 @@ async def heartbeat_loop(bot: Bot, config: dict):
         log.info("OS heartbeat daemon detected, bridge heartbeat loop disabled (avoiding double-trigger)")
         return
 
-    interval_seconds = interval_minutes * 60
-    profiles = config["profiles"]
-    authorized_user = config["user_id"]
+    interval_seconds = global_interval * 60
+    tg_user_id = config["telegram"]["user_id"] if config["telegram"]["configured"] else None
 
-    log.info(
-        "Heartbeat loop started (every %d minutes, %d profiles)",
-        interval_minutes,
-        len(profiles),
-    )
+    log.info("Heartbeat loop started (global interval: %d minutes)", global_interval)
 
     while True:
         await asyncio.sleep(interval_seconds)
 
-        for profile in profiles:
+        conductors = discover_conductors()
+        for conductor in conductors:
             try:
-                session_title = conductor_session_title(profile)
+                name = conductor["name"]
+                profile = conductor["profile"]
 
-                # Get current status for this profile
+                # Skip conductors with heartbeat disabled
+                if not conductor.get("heartbeat_enabled", True):
+                    log.debug("Heartbeat skipped for %s (disabled)", name)
+                    continue
+
+                session_title = conductor_session_title(name)
+
+                # Get current status for this conductor's profile
                 summary = get_status_summary(profile)
                 waiting = summary.get("waiting", 0)
                 running = summary.get("running", 0)
@@ -792,8 +1355,8 @@ async def heartbeat_loop(bot: Bot, config: dict):
                 error = summary.get("error", 0)
 
                 log.info(
-                    "Heartbeat [%s]: %d waiting, %d running, %d idle, %d error",
-                    profile, waiting, running, idle, error,
+                    "Heartbeat [%s/%s]: %d waiting, %d running, %d idle, %d error",
+                    name, profile, waiting, running, idle, error,
                 )
 
                 # Only trigger conductor if there are waiting or error sessions
@@ -808,8 +1371,8 @@ async def heartbeat_loop(bot: Bot, config: dict):
                     s_title = s.get("title", "untitled")
                     s_status = s.get("status", "")
                     s_path = s.get("path", "")
-                    # Skip the conductor itself
-                    if s_title == session_title:
+                    # Skip conductor sessions
+                    if s_title.startswith("conductor-"):
                         continue
                     if s_status == "waiting":
                         waiting_details.append(
@@ -821,7 +1384,7 @@ async def heartbeat_loop(bot: Bot, config: dict):
                         )
 
                 parts = [
-                    f"[HEARTBEAT] [{profile}] Status: {waiting} waiting, "
+                    f"[HEARTBEAT] [{name}] Status: {waiting} waiting, "
                     f"{running} running, {idle} idle, {error} error."
                 ]
                 if waiting_details:
@@ -835,6 +1398,7 @@ async def heartbeat_loop(bot: Bot, config: dict):
                 # Append HEARTBEAT_RULES.md (per-profile, then global fallback)
                 rules_text = None
                 for rules_path in [
+                    CONDUCTOR_DIR / name / "HEARTBEAT_RULES.md",
                     CONDUCTOR_DIR / profile / "HEARTBEAT_RULES.md",
                     CONDUCTOR_DIR / "HEARTBEAT_RULES.md",
                 ]:
@@ -876,10 +1440,22 @@ async def heartbeat_loop(bot: Bot, config: dict):
                         heartbeat_msg = stdout
 
                 # Ensure conductor is running for this profile
-                if not ensure_conductor_running(profile):
+                if not ensure_conductor_running(name, profile):
                     log.error(
                         "Heartbeat [%s]: conductor not running, skipping",
-                        profile,
+                        name,
+                    )
+                    continue
+
+                # Check if conductor is busy — skip heartbeat if so
+                # (heartbeats are periodic; no point queueing them)
+                conductor_status = get_session_status(
+                    session_title, profile=profile
+                )
+                if conductor_status in ("running", "active", "starting"):
+                    log.info(
+                        "Heartbeat [%s]: conductor busy (%s), skipping this cycle",
+                        name, conductor_status,
                     )
                     continue
 
@@ -894,36 +1470,50 @@ async def heartbeat_loop(bot: Bot, config: dict):
                 if not ok:
                     log.error(
                         "Heartbeat [%s]: failed to send to conductor",
-                        profile,
+                        name,
                     )
                     continue
 
                 # Response is returned directly by `session send --wait`.
                 log.info(
                     "Heartbeat [%s] response: %s",
-                    profile, response[:200],
+                    name, response[:200],
                 )
 
-                # If conductor flagged items needing attention, notify via Telegram
+                # If conductor flagged items needing attention, notify via Telegram and Slack
                 has_alerts = "NEED:" in response
                 if has_alerts:
-                    try:
-                        prefix = (
-                            f"[{profile}] " if len(profiles) > 1 else ""
-                        )
-                        alert_html = md_to_tg_html(
-                            f"{prefix}Conductor alert:\n{response}"
-                        )
-                        for chunk in split_message(alert_html):
-                            await bot.send_message(
-                                authorized_user,
-                                chunk,
-                                parse_mode="HTML",
+                    all_conductors = discover_conductors()
+                    prefix = (
+                        f"[{name}] " if len(all_conductors) > 1 else ""
+                    )
+                    alert_text = f"{prefix}Conductor alert:\n{response}"
+
+                    # Notify via Telegram (with HTML formatting)
+                    if telegram_bot and tg_user_id:
+                        try:
+                            alert_html = md_to_tg_html(alert_text)
+                            for chunk in split_message(alert_html):
+                                await telegram_bot.send_message(
+                                    tg_user_id,
+                                    chunk,
+                                    parse_mode="HTML",
+                                )
+                        except Exception as e:
+                            log.error(
+                                "Failed to send Telegram notification: %s", e
                             )
-                    except Exception as e:
-                        log.error(
-                            "Failed to send Telegram notification: %s", e
-                        )
+
+                    # Notify via Slack
+                    if slack_app and slack_channel_id:
+                        try:
+                            await slack_app.client.chat_postMessage(
+                                channel=slack_channel_id, text=alert_text,
+                            )
+                        except Exception as e:
+                            log.error(
+                                "Failed to send Slack notification: %s", e
+                            )
 
                 # Run post-heartbeat hook (non-gating)
                 invoke_hook(profile, "post-heartbeat", {
@@ -933,7 +1523,7 @@ async def heartbeat_loop(bot: Bot, config: dict):
                 })
 
             except Exception as e:
-                log.error("Heartbeat [%s] error: %s", profile, e)
+                log.error("Heartbeat [%s] error: %s", conductor.get("name", "?"), e)
 
 
 # ---------------------------------------------------------------------------
@@ -945,24 +1535,85 @@ async def main():
     log.info("Loading config from %s", CONFIG_PATH)
     config = load_config()
 
+    conductors = discover_conductors()
+    conductor_names = [c["name"] for c in conductors]
+
+    # Verify at least one integration is configured and available
+    tg_ok = config["telegram"]["configured"] and HAS_AIOGRAM
+    sl_ok = config["slack"]["configured"] and HAS_SLACK
+
+    if not tg_ok and not sl_ok:
+        if config["telegram"]["configured"] and not HAS_AIOGRAM:
+            log.error("Telegram configured but aiogram not installed. pip install aiogram")
+        if config["slack"]["configured"] and not HAS_SLACK:
+            log.error("Slack configured but slack-bolt not installed. pip install slack-bolt slack-sdk")
+        if not config["telegram"]["configured"] and not config["slack"]["configured"]:
+            log.error("Neither Telegram nor Slack configured. Exiting.")
+        sys.exit(1)
+
+    platforms = []
+    if tg_ok:
+        platforms.append("Telegram")
+    if sl_ok:
+        platforms.append("Slack")
+
     log.info(
-        "Starting conductor bridge (user_id=%d, heartbeat=%dm, profiles=%s)",
-        config["user_id"],
+        "Starting conductor bridge (platforms=%s, heartbeat=%dm, conductors=%s)",
+        "+".join(platforms),
         config["heartbeat_interval"],
-        ", ".join(config["profiles"]),
+        ", ".join(conductor_names) if conductor_names else "none",
     )
 
-    bot, dp = create_bot(config)
+    # Create Telegram bot
+    telegram_bot, telegram_dp = None, None
+    if tg_ok:
+        result = create_telegram_bot(config)
+        if result:
+            telegram_bot, telegram_dp = result
+            log.info("Telegram bot initialized (user_id=%d)", config["telegram"]["user_id"])
 
-    # Run heartbeat in background
-    heartbeat_task = asyncio.create_task(heartbeat_loop(bot, config))
+    # Create Slack app
+    slack_app, slack_handler, slack_channel_id = None, None, None
+    if sl_ok:
+        result = create_slack_app(config)
+        if result:
+            slack_app, slack_channel_id = result
+            slack_handler = AsyncSocketModeHandler(slack_app, config["slack"]["app_token"])
+
+    # Pre-start all conductors so they're warm when messages arrive
+    for c in conductors:
+        if ensure_conductor_running(c["name"], c["profile"]):
+            log.info("Conductor %s is running", c["name"])
+        else:
+            log.warning("Failed to pre-start conductor %s", c["name"])
+
+    # Start heartbeat (shared, notifies both platforms)
+    heartbeat_task = asyncio.create_task(
+        heartbeat_loop(
+            config,
+            telegram_bot=telegram_bot,
+            slack_app=slack_app,
+            slack_channel_id=slack_channel_id,
+        )
+    )
+
+    # Run both concurrently
+    tasks = [heartbeat_task]
+    if telegram_dp and telegram_bot:
+        tasks.append(asyncio.create_task(telegram_dp.start_polling(telegram_bot)))
+        log.info("Telegram bot polling started")
+    if slack_handler:
+        tasks.append(asyncio.create_task(slack_handler.start_async()))
+        log.info("Slack Socket Mode handler started")
 
     try:
-        log.info("Telegram bot polling started")
-        await dp.start_polling(bot)
+        await asyncio.gather(*tasks)
     finally:
         heartbeat_task.cancel()
-        await bot.session.close()
+        if telegram_bot:
+            await telegram_bot.session.close()
+        if slack_handler:
+            await slack_handler.close_async()
 
 
 if __name__ == "__main__":

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -218,7 +218,7 @@ def run_cli(
 def get_session_status(session: str, profile: str | None = None) -> str:
     """Get the status of a session (running/waiting/idle/error)."""
     result = run_cli(
-        "session", "show", "--json", session, profile=profile, timeout=30
+        "session", "show", session, "--json", profile=profile, timeout=30
     )
     if result.returncode != 0:
         return "unknown"  # transient CLI failure — not the same as conductor broken

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -243,6 +243,10 @@ def get_session_output(session: str, profile: str | None = None) -> str:
     return result.stdout.strip()
 
 
+# Async callable type for reply notifications: (response_text: str) -> None
+ReplyCallback = Callable[[str], Coroutine[Any, Any, None]]
+
+
 def send_to_conductor(
     session: str,
     message: str,
@@ -320,9 +324,6 @@ def send_to_conductor(
 # ---------------------------------------------------------------------------
 # Message queue for busy conductors
 # ---------------------------------------------------------------------------
-
-# Async callable type for reply notifications: (response_text: str) -> None
-ReplyCallback = Callable[[str], Coroutine[Any, Any, None]]
 
 # Per-session max depth — prevents unbounded memory growth when conductor is stuck.
 MAX_QUEUE_DEPTH = 20

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -200,16 +200,28 @@ def run_cli(
     cmd += list(args)
     log.debug("CLI: %s", " ".join(cmd))
     try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout
+        # Use Popen + communicate(timeout=) so we have the proc object available
+        # when TimeoutExpired fires — subprocess.run() does NOT set exc.proc.
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,  # own process group → killpg kills grandchildren too
         )
-        return result
-    except subprocess.TimeoutExpired as exc:
-        log.warning("CLI timeout: %s", " ".join(cmd))
-        if exc.proc:
-            exc.proc.kill()
-            exc.proc.communicate()
-        return subprocess.CompletedProcess(cmd, 1, "", "timeout")
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+            return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+        except subprocess.TimeoutExpired:
+            log.warning("CLI timeout: %s", " ".join(cmd))
+            try:
+                # Kill the entire process group so grandchildren (e.g. tmux send-keys)
+                # don't survive as orphans and jam the pane's input queue.
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                proc.kill()  # fallback: kill direct child only
+            proc.communicate()
+            return subprocess.CompletedProcess(cmd, 1, "", "timeout")
     except FileNotFoundError:
         log.error("agent-deck not found in PATH")
         return subprocess.CompletedProcess(cmd, 1, "", "not found")
@@ -1618,8 +1630,10 @@ async def heartbeat_loop(config: dict, telegram_bot=None, slack_app=None, slack_
 
                 # Check if conductor is busy — skip heartbeat if so
                 # (heartbeats are periodic; no point queueing them)
-                conductor_status = get_session_status(
-                    session_title, profile=profile
+                loop = asyncio.get_running_loop()
+                conductor_status = await loop.run_in_executor(
+                    None,
+                    functools.partial(get_session_status, session_title, profile=profile),
                 )
                 if conductor_status in ("running", "active", "starting"):
                     log.info(
@@ -1628,13 +1642,19 @@ async def heartbeat_loop(config: dict, telegram_bot=None, slack_app=None, slack_
                     )
                     continue
 
-                # Send heartbeat to conductor
-                ok, response = send_to_conductor(
-                    session_title,
-                    heartbeat_msg,
-                    profile=profile,
-                    wait_for_reply=True,
-                    response_timeout=RESPONSE_TIMEOUT,
+                # Send heartbeat to conductor (wrapped in executor — blocks up to
+                # RESPONSE_TIMEOUT seconds and must not freeze the event loop)
+                loop = asyncio.get_running_loop()
+                ok, response = await loop.run_in_executor(
+                    None,
+                    functools.partial(
+                        send_to_conductor,
+                        session_title,
+                        heartbeat_msg,
+                        profile=profile,
+                        wait_for_reply=True,
+                        response_timeout=RESPONSE_TIMEOUT,
+                    ),
                 )
                 if not ok:
                     log.error(

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -16,6 +16,7 @@ Dependencies: pip3 install toml aiogram slack-bolt slack-sdk
 """
 
 import asyncio
+import functools
 import json
 import logging
 import os
@@ -164,6 +165,12 @@ def get_conductor_names() -> list[str]:
     return [c["name"] for c in discover_conductors()]
 
 
+def get_default_conductor() -> dict | None:
+    """Get the first conductor (default target for messages)."""
+    conductors = discover_conductors()
+    return conductors[0] if conductors else None
+
+
 def get_unique_profiles() -> list[str]:
     """Get unique profile names from all conductors."""
     profiles = set()
@@ -232,6 +239,7 @@ def send_to_conductor(
     profile: str | None = None,
     wait_for_reply: bool = False,
     response_timeout: int = RESPONSE_TIMEOUT,
+    reply_callback=None,
 ) -> tuple[bool, str]:
     """Send a message to the conductor session.
 
@@ -239,8 +247,8 @@ def send_to_conductor(
 
     When wait_for_reply=False and the conductor is busy (running/active/starting),
     the message is queued in-memory and delivered automatically once the conductor
-    returns to idle/waiting state (see _drain_queue). This prevents message loss
-    during long-running tool calls.
+    returns to idle/waiting state (see _drain_queue). reply_callback, if provided,
+    is an async callable(response_text: str) invoked after drain delivery.
     """
     if not wait_for_reply:
         # For non-blocking sends (user messages), check if conductor is busy
@@ -250,7 +258,7 @@ def send_to_conductor(
             log.info(
                 "Conductor %s is busy (%s), queueing message", session, status,
             )
-            _enqueue_message(session, message, profile)
+            _enqueue_message(session, message, profile, reply_callback)
             return True, ""  # queued, not failed
 
         result = run_cli(
@@ -266,7 +274,7 @@ def send_to_conductor(
                     "Conductor %s became busy during send, queueing message",
                     session,
                 )
-                _enqueue_message(session, message, profile)
+                _enqueue_message(session, message, profile, reply_callback)
                 return True, ""
             log.error("Failed to send to conductor: %s", stderr)
             return False, ""
@@ -292,17 +300,27 @@ def send_to_conductor(
 # Message queue for busy conductors
 # ---------------------------------------------------------------------------
 
-# In-memory queue: {session_title: [(message, profile), ...]}
-_message_queue: dict[str, list[tuple[str, str | None]]] = {}
-_queue_lock = asyncio.Lock()
+# In-memory queue: {session_title: [(message, profile, reply_callback), ...]}
+# reply_callback is an optional async callable(response_text: str) that notifies
+# the originating user when the queued message is eventually delivered.
+_message_queue: dict[str, list[tuple[str, str | None, object]]] = {}
 _drain_task: asyncio.Task | None = None
 
 
-def _enqueue_message(session: str, message: str, profile: str | None) -> None:
-    """Add a message to the in-memory queue for a busy conductor."""
+def _enqueue_message(
+    session: str,
+    message: str,
+    profile: str | None,
+    reply_callback=None,
+) -> None:
+    """Add a message to the in-memory queue for a busy conductor.
+
+    reply_callback, if provided, is an async callable(response_text: str) that
+    will be invoked once the message is delivered and the conductor replies.
+    """
     if session not in _message_queue:
         _message_queue[session] = []
-    _message_queue[session].append((message, profile))
+    _message_queue[session].append((message, profile, reply_callback))
     log.info(
         "Queued message for %s (queue depth: %d)",
         session, len(_message_queue[session]),
@@ -314,7 +332,7 @@ def _ensure_drain_task() -> None:
     """Start the background drain task if it's not already running."""
     global _drain_task
     if _drain_task is None or _drain_task.done():
-        _drain_task = asyncio.ensure_future(_drain_queue())
+        _drain_task = asyncio.create_task(_drain_queue())
 
 
 async def _drain_queue() -> None:
@@ -340,8 +358,12 @@ async def _drain_queue() -> None:
                 _message_queue.pop(session, None)
                 continue
 
-            message, profile = items[0]
-            status = get_session_status(session, profile=profile)
+            message, profile, reply_callback = items[0]
+            loop = asyncio.get_event_loop()
+            status = await loop.run_in_executor(
+                None,
+                functools.partial(get_session_status, session, profile=profile),
+            )
 
             if status in ("running", "active", "starting"):
                 continue  # still busy, try next cycle
@@ -351,22 +373,42 @@ async def _drain_queue() -> None:
                     "Conductor %s in error state, dropping %d queued message(s)",
                     session, len(items),
                 )
-                _message_queue.pop(session, None)
+                dropped = _message_queue.pop(session, [])
+                for _msg, _prof, cb in dropped:
+                    if cb is not None:
+                        try:
+                            await cb(
+                                "[Queued message could not be delivered — conductor error.]"
+                            )
+                        except Exception as e:
+                            log.error("reply_callback error for %s: %s", session, e)
                 continue
 
-            # Conductor is ready — deliver the message
+            # Conductor is ready — deliver the message and wait for the response
             log.info(
                 "Conductor %s is %s, delivering queued message (%d remaining)",
                 session, status, len(items) - 1,
             )
-            result = run_cli(
-                "session", "send", session, message,
-                profile=profile, timeout=120,
+            result = await loop.run_in_executor(
+                None,
+                functools.partial(
+                    run_cli,
+                    "session", "send", session, message,
+                    "--wait", "--timeout", f"{RESPONSE_TIMEOUT}s", "-q",
+                    profile=profile,
+                    timeout=max(RESPONSE_TIMEOUT + 30, 60),
+                ),
             )
             if result.returncode == 0:
                 items.pop(0)
                 if not items:
                     _message_queue.pop(session, None)
+                if reply_callback is not None:
+                    try:
+                        text = result.stdout.strip() or "[No output from conductor.]"
+                        await reply_callback(text)
+                    except Exception as e:
+                        log.error("reply_callback error for %s: %s", session, e)
             else:
                 stderr = result.stderr.strip()
                 if "timeout" in stderr.lower() or "not ready" in stderr.lower():
@@ -382,6 +424,13 @@ async def _drain_queue() -> None:
                     items.pop(0)
                     if not items:
                         _message_queue.pop(session, None)
+                    if reply_callback is not None:
+                        try:
+                            await reply_callback(
+                                "[Queued message could not be delivered — conductor error.]"
+                            )
+                        except Exception as e:
+                            log.error("reply_callback error for %s: %s", session, e)
 
 
 def get_status_summary(profile: str | None = None) -> dict:
@@ -669,7 +718,7 @@ def create_telegram_bot(config: dict):
 
     bot = Bot(token=config["telegram"]["token"])
     dp = Dispatcher()
-    authorized_user = config["user_id"]
+    authorized_user = config["telegram"]["user_id"]
     profiles = config["profiles"]
     default_profile = profiles[0]
     bot_info = {"username": ""}
@@ -915,11 +964,22 @@ def create_telegram_bot(config: dict):
         log.info("User message -> [%s]: %s", target_profile, cleaned_msg[:100])
 
         if was_busy:
+            tg_bot = message.bot
+            tg_chat_id = message.chat.id
+            profile_tag_captured = profile_tag
+
+            async def _tg_reply(response_text: str):
+                header = f"{profile_tag_captured}Queued response:\n" if profile_tag_captured else "Queued response:\n"
+                html = md_to_tg_html(f"{header}{response_text}")
+                for chunk in split_message(html):
+                    await tg_bot.send_message(tg_chat_id, chunk, parse_mode="HTML")
+
             ok, _ = send_to_conductor(
                 session_title,
                 cleaned_msg,
                 profile=target_profile,
                 wait_for_reply=False,
+                reply_callback=_tg_reply,
             )
             if not ok:
                 await message.answer(
@@ -927,11 +987,12 @@ def create_telegram_bot(config: dict):
                 )
                 return
             await message.answer(
-                f"{profile_tag}⏳ Conductor busy — message queued, will deliver when ready."
+                f"{profile_tag}⏳ Conductor busy — message queued, will reply here when done."
             )
             return
 
         # Conductor is free — send and wait for reply synchronously
+        await message.answer(f"{profile_tag}⏳")  # typing indicator (sent before blocking)
         ok, response = send_to_conductor(
             session_title,
             cleaned_msg,
@@ -945,8 +1006,6 @@ def create_telegram_bot(config: dict):
             )
             return
 
-        # Response is returned directly by `session send --wait`.
-        await message.answer(f"{profile_tag}...")  # typing indicator
         log.info("Conductor [%s] response: %s", target_profile, response[:100])
 
         # Convert to HTML first, then split to respect post-conversion length
@@ -1033,11 +1092,6 @@ def create_slack_app(config: dict):
             return False
         return True
 
-    def get_default_conductor() -> dict | None:
-        """Get the first conductor (default target for messages)."""
-        conductors = discover_conductors()
-        return conductors[0] if conductors else None
-
     async def _safe_say(say, **kwargs):
         """Wrapper around say() that catches network/API errors."""
         try:
@@ -1087,7 +1141,41 @@ def create_slack_app(config: dict):
         was_busy = conductor_status in ("running", "active", "starting")
 
         log.info("Slack message -> [%s]: %s", target["name"], cleaned_msg[:100])
-        if not send_to_conductor(session_title, cleaned_msg, profile=profile):
+
+        name_tag = f"[{target['name']}] " if len(conductors) > 1 else ""
+
+        if was_busy:
+            name_tag_captured = name_tag
+
+            async def _slack_reply(response_text: str):
+                for chunk in split_message(response_text, max_len=SLACK_MAX_LENGTH):
+                    prefixed = f"{name_tag_captured}{chunk}" if name_tag_captured else chunk
+                    await _safe_say(say, text=prefixed, thread_ts=thread_ts)
+
+            ok, _ = send_to_conductor(
+                session_title, cleaned_msg, profile=profile,
+                wait_for_reply=False, reply_callback=_slack_reply,
+            )
+            if not ok:
+                await _safe_say(
+                    say,
+                    text=f"[Failed to send message to conductor {target['name']}.]",
+                    thread_ts=thread_ts,
+                )
+                return
+            await _safe_say(
+                say,
+                text=f"{name_tag}⏳ Conductor busy — message queued, will reply here when done.",
+                thread_ts=thread_ts,
+            )
+            return
+
+        await _safe_say(say, text=f"{name_tag}⏳", thread_ts=thread_ts)  # sent before blocking
+        ok, response = send_to_conductor(
+            session_title, cleaned_msg, profile=profile,
+            wait_for_reply=True, response_timeout=RESPONSE_TIMEOUT,
+        )
+        if not ok:
             await _safe_say(
                 say,
                 text=f"[Failed to send message to conductor {target['name']}.]",
@@ -1095,19 +1183,6 @@ def create_slack_app(config: dict):
             )
             return
 
-        name_tag = f"[{target['name']}] " if len(conductors) > 1 else ""
-
-        if was_busy:
-            await _safe_say(
-                say,
-                text=f"{name_tag}⏳ Conductor busy — message queued, will deliver when ready.",
-                thread_ts=thread_ts,
-            )
-            return
-
-        await _safe_say(say, text=f"{name_tag}...", thread_ts=thread_ts)
-
-        response = await wait_for_response(session_title, profile=profile)
         log.info("Conductor [%s] response: %s", target["name"], response[:100])
 
         for chunk in split_message(response, max_len=SLACK_MAX_LENGTH):

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -216,7 +216,11 @@ def run_cli(
 
 
 def get_session_status(session: str, profile: str | None = None) -> str:
-    """Get the status of a session (running/waiting/idle/error)."""
+    """Get the status of a session (running/waiting/idle/error/unknown).
+
+    Returns "unknown" on CLI failure or parse error — callers should treat
+    this as a transient condition and retry rather than dropping state.
+    """
     result = run_cli(
         "session", "show", session, "--json", profile=profile, timeout=30
     )

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -24,7 +24,10 @@ import re
 import subprocess
 import sys
 import time
+from collections import deque
+from collections.abc import Coroutine
 from pathlib import Path
+from typing import Any, Callable
 
 import toml
 
@@ -201,8 +204,11 @@ def run_cli(
             cmd, capture_output=True, text=True, timeout=timeout
         )
         return result
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as exc:
         log.warning("CLI timeout: %s", " ".join(cmd))
+        if exc.proc:
+            exc.proc.kill()
+            exc.proc.communicate()
         return subprocess.CompletedProcess(cmd, 1, "", "timeout")
     except FileNotFoundError:
         log.error("agent-deck not found in PATH")
@@ -215,12 +221,12 @@ def get_session_status(session: str, profile: str | None = None) -> str:
         "session", "show", "--json", session, profile=profile, timeout=30
     )
     if result.returncode != 0:
-        return "error"
+        return "unknown"  # transient CLI failure — not the same as conductor broken
     try:
         data = json.loads(result.stdout)
-        return data.get("status", "error")
+        return data.get("status", "unknown")
     except (json.JSONDecodeError, KeyError):
-        return "error"
+        return "unknown"
 
 
 def get_session_output(session: str, profile: str | None = None) -> str:
@@ -239,7 +245,8 @@ def send_to_conductor(
     profile: str | None = None,
     wait_for_reply: bool = False,
     response_timeout: int = RESPONSE_TIMEOUT,
-    reply_callback=None,
+    reply_callback: ReplyCallback | None = None,
+    force_queue: bool = False,
 ) -> tuple[bool, str]:
     """Send a message to the conductor session.
 
@@ -249,8 +256,18 @@ def send_to_conductor(
     the message is queued in-memory and delivered automatically once the conductor
     returns to idle/waiting state (see _drain_queue). reply_callback, if provided,
     is an async callable(response_text: str) invoked after drain delivery.
+
+    force_queue=True skips the internal status check and enqueues immediately.
+    Use this when the caller already knows the conductor is busy to avoid a
+    redundant blocking subprocess call.
     """
     if not wait_for_reply:
+        # force_queue: caller already confirmed conductor is busy — skip status check.
+        if force_queue:
+            log.info("Conductor %s: force-queueing message", session)
+            _enqueue_message(session, message, profile, reply_callback)
+            return True, ""
+
         # For non-blocking sends (user messages), check if conductor is busy
         # and queue instead of dropping.
         status = get_session_status(session, profile=profile)
@@ -300,10 +317,16 @@ def send_to_conductor(
 # Message queue for busy conductors
 # ---------------------------------------------------------------------------
 
-# In-memory queue: {session_title: [(message, profile, reply_callback), ...]}
-# reply_callback is an optional async callable(response_text: str) that notifies
-# the originating user when the queued message is eventually delivered.
-_message_queue: dict[str, list[tuple[str, str | None, object]]] = {}
+# Async callable type for reply notifications: (response_text: str) -> None
+ReplyCallback = Callable[[str], Coroutine[Any, Any, None]]
+
+# Per-session max depth — prevents unbounded memory growth when conductor is stuck.
+MAX_QUEUE_DEPTH = 20
+
+# In-memory queue: {session_title: deque[(message, profile, reply_callback), ...]}
+# reply_callback is an optional ReplyCallback that notifies the originating user
+# when the queued message is eventually delivered.
+_message_queue: dict[str, deque[tuple[str, str | None, ReplyCallback | None]]] = {}
 _drain_task: asyncio.Task | None = None
 
 
@@ -311,28 +334,57 @@ def _enqueue_message(
     session: str,
     message: str,
     profile: str | None,
-    reply_callback=None,
+    reply_callback: ReplyCallback | None = None,
 ) -> None:
     """Add a message to the in-memory queue for a busy conductor.
 
-    reply_callback, if provided, is an async callable(response_text: str) that
-    will be invoked once the message is delivered and the conductor replies.
+    Enforces MAX_QUEUE_DEPTH by dropping the oldest item when full.
+    reply_callback, if provided, is invoked once the message is delivered.
     """
     if session not in _message_queue:
-        _message_queue[session] = []
-    _message_queue[session].append((message, profile, reply_callback))
-    log.info(
-        "Queued message for %s (queue depth: %d)",
-        session, len(_message_queue[session]),
-    )
+        _message_queue[session] = deque()
+    queue = _message_queue[session]
+    if len(queue) >= MAX_QUEUE_DEPTH:
+        log.warning(
+            "Queue full for %s (depth=%d), dropping oldest message",
+            session, MAX_QUEUE_DEPTH,
+        )
+        queue.popleft()  # drop oldest; no loop ref available for callback here
+    queue.append((message, profile, reply_callback))
+    log.info("Queued message for %s (queue depth: %d)", session, len(queue))
     _ensure_drain_task()
+
+
+async def _fire_callback(cb: ReplyCallback, text: str) -> None:
+    """Invoke a reply_callback safely, decoupled from the drain loop."""
+    try:
+        await cb(text)
+    except Exception as e:
+        log.error("reply_callback error: %s", e)
 
 
 def _ensure_drain_task() -> None:
     """Start the background drain task if it's not already running."""
     global _drain_task
+    if _drain_task is not None and _drain_task.done() and not _drain_task.cancelled():
+        exc = _drain_task.exception()
+        if exc:
+            log.error("Drain task crashed: %s", exc, exc_info=exc)
     if _drain_task is None or _drain_task.done():
-        _drain_task = asyncio.create_task(_drain_queue())
+        _drain_task = asyncio.get_running_loop().create_task(_drain_queue_supervised())
+
+
+async def _drain_queue_supervised() -> None:
+    """Supervisor wrapper: restarts _drain_queue on unexpected crash."""
+    while True:
+        try:
+            await _drain_queue()
+            return  # normal exit: queue is empty
+        except asyncio.CancelledError:
+            raise  # propagate shutdown cancellation
+        except Exception:
+            log.exception("Drain task crashed unexpectedly, restarting in 5s")
+            await asyncio.sleep(5)
 
 
 async def _drain_queue() -> None:
@@ -346,10 +398,6 @@ async def _drain_queue() -> None:
     while True:
         await asyncio.sleep(5)
 
-        if not _message_queue:
-            log.info("Queue drain task finished (queue empty)")
-            return
-
         # Snapshot keys to avoid mutation during iteration
         sessions = list(_message_queue.keys())
         for session in sessions:
@@ -359,36 +407,31 @@ async def _drain_queue() -> None:
                 continue
 
             message, profile, reply_callback = items[0]
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             status = await loop.run_in_executor(
                 None,
                 functools.partial(get_session_status, session, profile=profile),
             )
 
-            if status in ("running", "active", "starting"):
-                continue  # still busy, try next cycle
+            # Still busy or transient CLI failure — retry next cycle
+            if status in ("running", "active", "starting", "unknown"):
+                continue
 
             if status == "error":
                 log.error(
                     "Conductor %s in error state, dropping %d queued message(s)",
                     session, len(items),
                 )
-                dropped = _message_queue.pop(session, [])
+                dropped = _message_queue.pop(session, deque())
                 for _msg, _prof, cb in dropped:
                     if cb is not None:
-                        try:
-                            await cb(
-                                "[Queued message could not be delivered — conductor error.]"
-                            )
-                        except Exception as e:
-                            log.error("reply_callback error for %s: %s", session, e)
+                        loop.create_task(_fire_callback(
+                            cb,
+                            "[Queued message could not be delivered — conductor is in error state.]",
+                        ))
                 continue
 
             # Conductor is ready — deliver the message and wait for the response
-            log.info(
-                "Conductor %s is %s, delivering queued message (%d remaining)",
-                session, status, len(items) - 1,
-            )
             result = await loop.run_in_executor(
                 None,
                 functools.partial(
@@ -400,15 +443,17 @@ async def _drain_queue() -> None:
                 ),
             )
             if result.returncode == 0:
-                items.pop(0)
-                if not items:
+                items.popleft()
+                remaining = len(items)
+                if not remaining:
                     _message_queue.pop(session, None)
+                log.info(
+                    "Conductor %s delivered queued message (%d remaining)",
+                    session, remaining,
+                )
                 if reply_callback is not None:
-                    try:
-                        text = result.stdout.strip() or "[No output from conductor.]"
-                        await reply_callback(text)
-                    except Exception as e:
-                        log.error("reply_callback error for %s: %s", session, e)
+                    text = result.stdout.strip() or "[No output from conductor.]"
+                    loop.create_task(_fire_callback(reply_callback, text))
             else:
                 stderr = result.stderr.strip()
                 if "timeout" in stderr.lower() or "not ready" in stderr.lower():
@@ -421,16 +466,19 @@ async def _drain_queue() -> None:
                         "Failed to deliver queued message to %s: %s — dropping",
                         session, stderr,
                     )
-                    items.pop(0)
+                    items.popleft()
                     if not items:
                         _message_queue.pop(session, None)
                     if reply_callback is not None:
-                        try:
-                            await reply_callback(
-                                "[Queued message could not be delivered — conductor error.]"
-                            )
-                        except Exception as e:
-                            log.error("reply_callback error for %s: %s", session, e)
+                        loop.create_task(_fire_callback(
+                            reply_callback,
+                            f"[Queued message could not be delivered — send failed: {stderr[:100]}]",
+                        ))
+
+        # Exit check AFTER the session loop — avoids missing items enqueued during drain
+        if not _message_queue:
+            log.info("Queue drain task finished (queue empty)")
+            return
 
 
 def get_status_summary(profile: str | None = None) -> dict:
@@ -481,30 +529,36 @@ def get_sessions_list_all(profiles: list[str]) -> list[tuple[str, dict]]:
     return all_sessions
 
 
-def ensure_conductor_running(name: str, profile: str) -> bool:
+async def ensure_conductor_running(name: str, profile: str) -> bool:
     """Ensure the conductor session exists and is running."""
     session_title = conductor_session_title(name)
-    status = get_session_status(session_title, profile=profile)
+    loop = asyncio.get_running_loop()
+    status = await loop.run_in_executor(
+        None, functools.partial(get_session_status, session_title, profile=profile)
+    )
 
-    if status == "error":
-        log.info(
-            "Conductor %s not running, attempting to start...", name,
-        )
+    if status not in ("waiting", "running", "idle", "active", "starting"):
+        log.info("Conductor %s not running (status=%s), attempting to start...", name, status)
         # Try starting first (session might exist but be stopped)
-        result = run_cli(
-            "session", "start", session_title, profile=profile, timeout=60
+        result = await loop.run_in_executor(
+            None, functools.partial(
+                run_cli, "session", "start", session_title, profile=profile, timeout=60
+            )
         )
         if result.returncode != 0:
             # Session might not exist, try creating it
             log.info("Creating conductor session for %s...", name)
             session_path = str(CONDUCTOR_DIR / name)
-            result = run_cli(
-                "add", session_path,
-                "-t", session_title,
-                "-c", "claude",
-                "-g", "conductor",
-                profile=profile,
-                timeout=60,
+            result = await loop.run_in_executor(
+                None, functools.partial(
+                    run_cli,
+                    "add", session_path,
+                    "-t", session_title,
+                    "-c", "claude",
+                    "-g", "conductor",
+                    profile=profile,
+                    timeout=60,
+                )
             )
             if result.returncode != 0:
                 log.error(
@@ -514,16 +568,18 @@ def ensure_conductor_running(name: str, profile: str) -> bool:
                 )
                 return False
             # Start the newly created session
-            run_cli(
-                "session", "start", session_title,
-                profile=profile, timeout=60,
+            await loop.run_in_executor(
+                None, functools.partial(
+                    run_cli, "session", "start", session_title, profile=profile, timeout=60
+                )
             )
 
-        # Wait a moment for the session to initialize
-        time.sleep(5)
-        return (
-            get_session_status(session_title, profile=profile) != "error"
+        # Wait a moment for the session to initialize (non-blocking)
+        await asyncio.sleep(5)
+        final_status = await loop.run_in_executor(
+            None, functools.partial(get_session_status, session_title, profile=profile)
         )
+        return final_status not in ("error", "unknown")
 
     return True
 
@@ -949,7 +1005,7 @@ def create_telegram_bot(config: dict):
                 cleaned_msg = stdout
 
         # Ensure conductor is running for this profile
-        if not ensure_conductor_running(target_conductor["name"], target_profile):
+        if not await ensure_conductor_running(target_conductor["name"], target_profile):
             await message.answer(
                 f"[Could not start conductor for {target_profile}. Check agent-deck.]"
             )
@@ -957,8 +1013,11 @@ def create_telegram_bot(config: dict):
 
         profile_tag = f"[{target_profile}] " if len(profiles) > 1 else ""
 
-        # Check if conductor is busy; queue the message instead of blocking
-        conductor_status = get_session_status(session_title, profile=target_profile)
+        # Check if conductor is busy — non-blocking via executor
+        loop = asyncio.get_running_loop()
+        conductor_status = await loop.run_in_executor(
+            None, functools.partial(get_session_status, session_title, profile=target_profile)
+        )
         was_busy = conductor_status in ("running", "active", "starting")
 
         log.info("User message -> [%s]: %s", target_profile, cleaned_msg[:100])
@@ -967,9 +1026,16 @@ def create_telegram_bot(config: dict):
             tg_bot = message.bot
             tg_chat_id = message.chat.id
             profile_tag_captured = profile_tag
+            enqueued_at = time.monotonic()
 
             async def _tg_reply(response_text: str):
-                header = f"{profile_tag_captured}Queued response:\n" if profile_tag_captured else "Queued response:\n"
+                elapsed = int(time.monotonic() - enqueued_at)
+                waited = f"{elapsed // 60}m {elapsed % 60}s" if elapsed >= 60 else f"{elapsed}s"
+                header = (
+                    f"{profile_tag_captured}Queued response (waited {waited}):\n"
+                    if profile_tag_captured
+                    else f"Queued response (waited {waited}):\n"
+                )
                 html = md_to_tg_html(f"{header}{response_text}")
                 for chunk in split_message(html):
                     await tg_bot.send_message(tg_chat_id, chunk, parse_mode="HTML")
@@ -980,6 +1046,7 @@ def create_telegram_bot(config: dict):
                 profile=target_profile,
                 wait_for_reply=False,
                 reply_callback=_tg_reply,
+                force_queue=True,
             )
             if not ok:
                 await message.answer(
@@ -991,14 +1058,18 @@ def create_telegram_bot(config: dict):
             )
             return
 
-        # Conductor is free — send and wait for reply synchronously
-        await message.answer(f"{profile_tag}⏳")  # typing indicator (sent before blocking)
-        ok, response = send_to_conductor(
-            session_title,
-            cleaned_msg,
-            profile=target_profile,
-            wait_for_reply=True,
-            response_timeout=RESPONSE_TIMEOUT,
+        # Conductor is free — send and wait for reply (non-blocking via executor)
+        await message.answer(f"{profile_tag}⏳")  # typing indicator before blocking
+        ok, response = await loop.run_in_executor(
+            None,
+            functools.partial(
+                send_to_conductor,
+                session_title,
+                cleaned_msg,
+                profile=target_profile,
+                wait_for_reply=True,
+                response_timeout=RESPONSE_TIMEOUT,
+            ),
         )
         if not ok:
             await message.answer(
@@ -1128,7 +1199,7 @@ def create_slack_app(config: dict):
         session_title = conductor_session_title(target["name"])
         profile = target["profile"]
 
-        if not ensure_conductor_running(target["name"], profile):
+        if not await ensure_conductor_running(target["name"], profile):
             await _safe_say(
                 say,
                 text=f"[Could not start conductor {target['name']}. Check agent-deck.]",
@@ -1136,8 +1207,11 @@ def create_slack_app(config: dict):
             )
             return
 
-        # Check if conductor is busy before sending
-        conductor_status = get_session_status(session_title, profile=profile)
+        # Check if conductor is busy — non-blocking via executor
+        loop = asyncio.get_running_loop()
+        conductor_status = await loop.run_in_executor(
+            None, functools.partial(get_session_status, session_title, profile=profile)
+        )
         was_busy = conductor_status in ("running", "active", "starting")
 
         log.info("Slack message -> [%s]: %s", target["name"], cleaned_msg[:100])
@@ -1146,15 +1220,25 @@ def create_slack_app(config: dict):
 
         if was_busy:
             name_tag_captured = name_tag
+            enqueued_at = time.monotonic()
 
             async def _slack_reply(response_text: str):
-                for chunk in split_message(response_text, max_len=SLACK_MAX_LENGTH):
-                    prefixed = f"{name_tag_captured}{chunk}" if name_tag_captured else chunk
-                    await _safe_say(say, text=prefixed, thread_ts=thread_ts)
+                elapsed = int(time.monotonic() - enqueued_at)
+                waited = f"{elapsed // 60}m {elapsed % 60}s" if elapsed >= 60 else f"{elapsed}s"
+                header = (
+                    f"{name_tag_captured}Queued response (waited {waited}):\n"
+                    if name_tag_captured
+                    else f"Queued response (waited {waited}):\n"
+                )
+                chunks = split_message(response_text, max_len=SLACK_MAX_LENGTH)
+                for i, chunk in enumerate(chunks):
+                    text = f"{header}{chunk}" if i == 0 else chunk
+                    await _safe_say(say, text=text, thread_ts=thread_ts)
 
             ok, _ = send_to_conductor(
                 session_title, cleaned_msg, profile=profile,
                 wait_for_reply=False, reply_callback=_slack_reply,
+                force_queue=True,
             )
             if not ok:
                 await _safe_say(
@@ -1170,10 +1254,14 @@ def create_slack_app(config: dict):
             )
             return
 
-        await _safe_say(say, text=f"{name_tag}⏳", thread_ts=thread_ts)  # sent before blocking
-        ok, response = send_to_conductor(
-            session_title, cleaned_msg, profile=profile,
-            wait_for_reply=True, response_timeout=RESPONSE_TIMEOUT,
+        await _safe_say(say, text=f"{name_tag}⏳", thread_ts=thread_ts)  # before blocking
+        ok, response = await loop.run_in_executor(
+            None,
+            functools.partial(
+                send_to_conductor,
+                session_title, cleaned_msg, profile=profile,
+                wait_for_reply=True, response_timeout=RESPONSE_TIMEOUT,
+            ),
         )
         if not ok:
             await _safe_say(
@@ -1515,7 +1603,7 @@ async def heartbeat_loop(config: dict, telegram_bot=None, slack_app=None, slack_
                         heartbeat_msg = stdout
 
                 # Ensure conductor is running for this profile
-                if not ensure_conductor_running(name, profile):
+                if not await ensure_conductor_running(name, profile):
                     log.error(
                         "Heartbeat [%s]: conductor not running, skipping",
                         name,
@@ -1657,7 +1745,7 @@ async def main():
 
     # Pre-start all conductors so they're warm when messages arrive
     for c in conductors:
-        if ensure_conductor_running(c["name"], c["profile"]):
+        if await ensure_conductor_running(c["name"], c["profile"]):
             log.info("Conductor %s is running", c["name"])
         else:
             log.warning("Failed to pre-start conductor %s", c["name"])


### PR DESCRIPTION
## Summary

- **Queue instead of drop**: when a conductor session is `running`/`active`/`starting`, messages are held in an in-memory queue (`_message_queue`) and delivered once the conductor becomes free
- **Reply callback**: a per-message async closure (`ReplyCallback`) is stored with each queued item and invoked via fire-and-forget task after drain delivery — the deferred response is pushed back to the user in the same Telegram chat / Slack thread
- **Event loop safety**: all blocking `subprocess.run` calls in async handlers are wrapped in `run_in_executor`; `ensure_conductor_running` is now `async` with `await asyncio.sleep` instead of `time.sleep`
- **Queue robustness**: `MAX_QUEUE_DEPTH=20` per session, `deque`/`popleft()` (O(1)), drain task supervisor with crash recovery, `get_running_loop()` throughout, `force_queue` param to skip redundant status checks, `get_session_status` returns `"unknown"` on CLI failure (not `"error"`) to prevent premature queue drops
- **UX**: both Telegram and Slack deferred replies show `"Queued response (waited Xs):"` prefix with elapsed wait time; orphaned subprocesses killed on `TimeoutExpired`; differentiated error messages for error-state drop vs send failure

## Commits

1. `09217e6` — core queue infrastructure: `_message_queue`, `_enqueue_message`, `_drain_queue`, `_ensure_drain_task`; `was_busy` detection in Telegram and Slack handlers
2. `8a0172b` — post-rebase bug fixes: Slack tuple check, `wait_for_response` NameError, `reply_callback` threading, `run_in_executor` for drain, `create_task` over deprecated `ensure_future`, `get_default_conductor` promotion, typing indicators before blocking sends
3. `69d3ae1` — robustness pass: all MUST FIX + QUICK WIN items from 4-reviewer audit (async handlers, drain supervisor, `deque`, `MAX_QUEUE_DEPTH`, `force_queue`, `get_running_loop`, orphan subprocess kill, "Queued response" prefix on Slack, elapsed time in deferred replies)

## Test plan

- [ ] Send a message via Telegram while conductor is busy → expect `"⏳ Conductor busy — message queued, will reply here when done."`; when conductor finishes, expect follow-up `"Queued response (waited Xs):\n<response>"`
- [ ] Same flow via Slack — same prefix and threading behaviour
- [ ] Send multiple messages while busy → all delivered in order; each gets its own callback
- [ ] Kill conductor mid-queue → expect `"[Queued message could not be delivered — conductor is in error state.]"` per queued item
- [ ] Restart bridge while queue has items → messages lost (in-memory, expected); no crash or hang
- [ ] `python3 -c "import ast; ast.parse(open('conductor/bridge.py').read()); print('OK')"`