### PR TITLE
fix: expose tmux_session in JSON API output

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1373,6 +1373,7 @@ func handleList(profile string, args []string) {
 			Tool          string    `json:"tool"`
 			Command       string    `json:"command,omitempty"`
 			Status        string    `json:"status"`
+			TmuxSession   string    `json:"tmux_session,omitempty"`
 			Profile       string    `json:"profile"`
 			CreatedAt     time.Time `json:"created_at"`
 			SSHHost       string    `json:"ssh_host,omitempty"`
@@ -1381,7 +1382,7 @@ func handleList(profile string, args []string) {
 		sessions := make([]sessionJSON, len(instances))
 		for i, inst := range instances {
 			_ = inst.UpdateStatus()
-			sessions[i] = sessionJSON{
+			sj := sessionJSON{
 				ID:            inst.ID,
 				Title:         inst.Title,
 				Path:          inst.ProjectPath,
@@ -1394,6 +1395,10 @@ func handleList(profile string, args []string) {
 				SSHHost:       inst.SSHHost,
 				SSHRemotePath: inst.SSHRemotePath,
 			}
+			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
+				sj.TmuxSession = tmuxSess.Name
+			}
+			sessions[i] = sj
 		}
 		output, err := json.MarshalIndent(sessions, "", "  ")
 		if err != nil {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -737,11 +737,8 @@ func handleSessionShow(profile string, args []string) {
 		}
 	}
 
-	if inst.Exists() {
-		tmuxSession := inst.GetTmuxSession()
-		if tmuxSession != nil {
-			jsonData["tmux_session"] = tmuxSession.Name
-		}
+	if tmuxSession := inst.GetTmuxSession(); tmuxSession != nil {
+		jsonData["tmux_session"] = tmuxSession.Name
 	}
 
 	// Build human-readable output
@@ -1897,6 +1894,10 @@ func handleSessionCurrent(profileArg string, args []string) {
 		"id":      instData.ID,
 		"path":    instData.ProjectPath,
 		"status":  status,
+	}
+
+	if instData.TmuxSession != "" {
+		jsonData["tmux_session"] = instData.TmuxSession
 	}
 
 	if instData.GroupPath != "" {


### PR DESCRIPTION
## Summary

- Add `tmux_session` field to `list --json` output struct
- Remove `inst.Exists()` gate from `session show --json` so stopped/error sessions still report their tmux name
- Add `tmux_session` field to `session current --json` output

Fixes #455

## Test plan

- [x] `agent-deck list --json` returns `tmux_session` for all sessions with a persisted tmux name
- [x] `agent-deck session show <id> --json` returns `tmux_session` for both running and stopped sessions
- [x] `agent-deck session current --json` returns `tmux_session` for the current session
- [x] Cross-referenced JSON output against live `tmux list-sessions` — mapping is correct
- [x] Existing `cmd/agent-deck` tests pass