### PR TITLE
feat(openclaw): Ed25519 device auth for full scoped gateway access

### DIFF
--- a/cmd/agent-deck/openclaw_cmd.go
+++ b/cmd/agent-deck/openclaw_cmd.go
@@ -32,6 +32,8 @@ func handleOpenClaw(profile string, args []string) {
 		handleOpenClawList(args[1:])
 	case "send":
 		handleOpenClawSend(args[1:])
+	case "pair":
+		handleOpenClawPair(args[1:])
 	case "help", "--help", "-h":
 		printOpenClawHelp()
 	default:
@@ -51,6 +53,7 @@ func printOpenClawHelp() {
 	fmt.Println("  status         Show gateway health and agent summary")
 	fmt.Println("  list           List agents from gateway")
 	fmt.Println("  send           Send a message to an agent")
+	fmt.Println("  pair           Pair this device with the gateway (required for full access)")
 	fmt.Println("  help           Show this help")
 	fmt.Println()
 	fmt.Println("Aliases: openclaw, oc")
@@ -443,6 +446,129 @@ func resolveAgentName(agent openclaw.AgentSummary) string {
 		return agent.Name
 	}
 	return agent.ID
+}
+
+// --- pair ---
+
+func handleOpenClawPair(args []string) {
+	fs := flag.NewFlagSet("openclaw pair", flag.ExitOnError)
+	showID := fs.Bool("id", false, "Show device ID only")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+
+	identity, err := openclaw.LoadOrCreateIdentity()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create device identity: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *showID {
+		fmt.Println(identity.DeviceID)
+		return
+	}
+
+	// Check if already paired
+	tokens, _ := openclaw.LoadDeviceTokens()
+	if tokens != nil && tokens.DeviceID == identity.DeviceID {
+		if ref, ok := tokens.Tokens["operator"]; ok && ref.Token != "" {
+			fmt.Printf("Device already paired (id: %s...%s)\n", identity.DeviceID[:8], identity.DeviceID[len(identity.DeviceID)-8:])
+			fmt.Println("Testing connection with device auth...")
+
+			cfg := loadOpenClawConfig()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			client := openclaw.NewClient(cfg.GatewayURL, cfg.Password)
+			if err := client.Connect(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "Connection failed: %v\n", err)
+				fmt.Println("Try: agent-deck openclaw pair --force to re-pair")
+				os.Exit(1)
+			}
+			defer client.Close()
+
+			hello := client.Hello()
+			if hello.Auth != nil && len(hello.Auth.Scopes) > 0 {
+				fmt.Printf("Scopes: %s\n", strings.Join(hello.Auth.Scopes, ", "))
+				fmt.Println("Device pairing is working.")
+			} else {
+				fmt.Println("Connected but no scopes granted. Try re-pairing.")
+			}
+			return
+		}
+	}
+
+	cfg := loadOpenClawConfig()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client := openclaw.NewClient(cfg.GatewayURL, cfg.Password)
+	if err := client.Connect(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to connect: %v\n", err)
+		os.Exit(1)
+	}
+	defer client.Close()
+
+	rawPub, _ := openclaw.RawPublicKeyBase64URL(identity.PublicKeyPEM)
+
+	pairParams := map[string]any{
+		"deviceId":     identity.DeviceID,
+		"publicKey":    rawPub,
+		"displayName":  fmt.Sprintf("Agent Deck (%s)", "darwin"),
+		"platform":     "darwin",
+		"deviceFamily": "mac",
+		"clientId":     "gateway-client",
+		"clientMode":   "backend",
+		"role":         "operator",
+		"roles":        []string{"operator"},
+		"scopes":       []string{"operator.admin", "operator.read", "operator.write", "operator.approvals", "operator.pairing"},
+		"silent":       false,
+	}
+
+	fmt.Printf("Device ID: %s\n", identity.DeviceID)
+	fmt.Println("Requesting pairing...")
+
+	payload, err := client.Request(ctx, "device.pair.request", pairParams)
+	if err != nil {
+		if strings.Contains(err.Error(), "already paired") {
+			fmt.Println("Device is already paired with the gateway.")
+			return
+		}
+		fmt.Fprintf(os.Stderr, "Pairing request failed: %v\n", err)
+		fmt.Println()
+		fmt.Println("Approve this device on the gateway:")
+		fmt.Printf("  ssh openclaw \"openclaw device approve %s\"\n", identity.DeviceID[:12])
+		os.Exit(1)
+	}
+
+	var pairResult struct {
+		RequestID string `json:"requestId"`
+		Device    *struct {
+			DeviceID string `json:"deviceId"`
+			Tokens   map[string]struct {
+				Token  string   `json:"token"`
+				Role   string   `json:"role"`
+				Scopes []string `json:"scopes"`
+			} `json:"tokens"`
+		} `json:"device"`
+	}
+	if err := json.Unmarshal(payload, &pairResult); err == nil && pairResult.Device != nil && pairResult.Device.Tokens != nil {
+		for role, tokenInfo := range pairResult.Device.Tokens {
+			_ = openclaw.SaveDeviceToken(identity.DeviceID, role, tokenInfo.Token, tokenInfo.Scopes)
+		}
+		fmt.Println("Paired successfully!")
+		return
+	}
+
+	fmt.Println()
+	fmt.Println("Pairing request sent. Approve on the gateway:")
+	if pairResult.RequestID != "" {
+		fmt.Printf("  ssh openclaw \"openclaw device approve %s\"\n", pairResult.RequestID)
+	} else {
+		fmt.Printf("  ssh openclaw \"openclaw device approve %s\"\n", identity.DeviceID[:12])
+	}
+	fmt.Println()
+	fmt.Println("After approving, run: agent-deck openclaw status")
 }
 
 func formatDuration(d time.Duration) string {

--- a/internal/openclaw/client.go
+++ b/internal/openclaw/client.go
@@ -97,10 +97,8 @@ func (c *Client) Connect(ctx context.Context) error {
 		return fmt.Errorf("challenge: %w", err)
 	}
 
-	_ = challenge // nonce received but not used in password auth
-
-	// Step 2: Send connect request
-	helloOk, err := c.sendConnect(ctx)
+	// Step 2: Send connect request with device identity
+	helloOk, err := c.sendConnect(ctx, challenge.Nonce)
 	if err != nil {
 		conn.Close()
 		return fmt.Errorf("connect: %w", err)
@@ -109,10 +107,25 @@ func (c *Client) Connect(ctx context.Context) error {
 	c.hello = helloOk
 	c.backoff = initialBackoff // reset on successful connect
 
+	// Persist device token if the gateway issued one
+	if helloOk.Auth != nil && helloOk.Auth.DeviceToken != "" {
+		if identity, err := LoadOrCreateIdentity(); err == nil {
+			_ = SaveDeviceToken(identity.DeviceID, helloOk.Auth.Role, helloOk.Auth.DeviceToken, helloOk.Auth.Scopes)
+		}
+	}
+
+	authRole := ""
+	var authScopes []string
+	if helloOk.Auth != nil {
+		authRole = helloOk.Auth.Role
+		authScopes = helloOk.Auth.Scopes
+	}
 	clientLog.Info("connected",
 		slog.String("server_version", helloOk.Server.Version),
 		slog.String("conn_id", helloOk.Server.ConnID),
 		slog.Int("protocol", helloOk.Protocol),
+		slog.String("auth_role", authRole),
+		slog.Any("auth_scopes", authScopes),
 	)
 
 	// Start read loop
@@ -320,27 +333,52 @@ func (c *Client) waitForChallenge(ctx context.Context) (*ChallengePayload, error
 	return &challenge, nil
 }
 
-func (c *Client) sendConnect(ctx context.Context) (*HelloOk, error) {
+func (c *Client) sendConnect(ctx context.Context, nonce string) (*HelloOk, error) {
+	scopes := []string{"operator.admin", "operator.read", "operator.write", "operator.approvals", "operator.pairing"}
+
+	params := ConnectParams{
+		MinProtocol: ProtocolVersion,
+		MaxProtocol: ProtocolVersion,
+		Client: ClientInfo{
+			ID:       clientID,
+			Version:  clientVersion,
+			Platform: runtime.GOOS,
+			Mode:     clientMode,
+		},
+		Role:   "operator",
+		Scopes: scopes,
+		Auth: &ConnectAuth{
+			Token:    c.password,
+			Password: c.password,
+		},
+	}
+
+	// Attach device identity if available (enables full scoped access)
+	identity, err := LoadOrCreateIdentity()
+	if err != nil {
+		clientLog.Warn("device_identity_unavailable", slog.String("error", err.Error()))
+	} else {
+		device, err := BuildDeviceConnect(identity, nonce, scopes, runtime.GOOS, "", c.password)
+		if err != nil {
+			clientLog.Warn("device_connect_build_failed", slog.String("error", err.Error()))
+		} else {
+			params.Device = device
+			// Include device token in auth if we have one
+			tokens, err := LoadDeviceTokens()
+			if err == nil && tokens.DeviceID == identity.DeviceID {
+				if ref, ok := tokens.Tokens["operator"]; ok {
+					params.Auth.DeviceToken = ref.Token
+				}
+			}
+		}
+	}
+
 	id := uuid.New().String()
 	frame := RequestFrame{
 		Type:   FrameTypeRequest,
 		ID:     id,
 		Method: "connect",
-		Params: ConnectParams{
-			MinProtocol: ProtocolVersion,
-			MaxProtocol: ProtocolVersion,
-			Client: ClientInfo{
-				ID:       clientID,
-				Version:  clientVersion,
-				Platform: runtime.GOOS,
-				Mode:     clientMode,
-			},
-			Role:   "operator",
-			Scopes: []string{"operator.admin"},
-			Auth: &ConnectAuth{
-				Password: c.password,
-			},
-		},
+		Params: params,
 	}
 
 	if err := c.writeJSON(frame); err != nil {

--- a/internal/openclaw/device.go
+++ b/internal/openclaw/device.go
@@ -1,0 +1,291 @@
+package openclaw
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DeviceIdentity holds the Ed25519 keypair and derived device ID.
+type DeviceIdentity struct {
+	Version       int    `json:"version"`
+	DeviceID      string `json:"deviceId"`
+	PublicKeyPEM  string `json:"publicKeyPem"`
+	PrivateKeyPEM string `json:"privateKeyPem"`
+	CreatedAtMs   int64  `json:"createdAtMs"`
+}
+
+// DeviceTokenStore persists device tokens received from pairing.
+type DeviceTokenStore struct {
+	Version  int                       `json:"version"`
+	DeviceID string                    `json:"deviceId"`
+	Tokens   map[string]DeviceTokenRef `json:"tokens"`
+}
+
+// DeviceTokenRef is a stored token for a specific role.
+type DeviceTokenRef struct {
+	Token       string `json:"token"`
+	Role        string `json:"role"`
+	Scopes      []string `json:"scopes"`
+	UpdatedAtMs int64  `json:"updatedAtMs"`
+}
+
+// DeviceConnect is the device identity field sent in the connect request.
+type DeviceConnect struct {
+	ID        string `json:"id"`
+	PublicKey string `json:"publicKey"`
+	Signature string `json:"signature"`
+	SignedAt  int64  `json:"signedAt"`
+	Nonce     string `json:"nonce"`
+}
+
+// DeviceDir returns the directory for device identity files.
+func DeviceDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".agent-deck", "openclaw")
+}
+
+// LoadOrCreateIdentity loads an existing device identity or generates a new one.
+func LoadOrCreateIdentity() (*DeviceIdentity, error) {
+	dir := DeviceDir()
+	path := filepath.Join(dir, "device.json")
+
+	data, err := os.ReadFile(path)
+	if err == nil {
+		var id DeviceIdentity
+		if err := json.Unmarshal(data, &id); err == nil && id.Version == 1 {
+			// Verify deviceId matches public key
+			derived, err := deriveDeviceID(id.PublicKeyPEM)
+			if err == nil && derived == id.DeviceID {
+				return &id, nil
+			}
+			// Fix stale deviceId
+			id.DeviceID = derived
+			_ = saveIdentity(&id)
+			return &id, nil
+		}
+	}
+
+	// Generate new identity
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ed25519 key: %w", err)
+	}
+
+	pubPEM, err := marshalPublicKeyPEM(pub)
+	if err != nil {
+		return nil, err
+	}
+	privPEM, err := marshalPrivateKeyPEM(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	deviceID, err := deriveDeviceID(pubPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	identity := &DeviceIdentity{
+		Version:       1,
+		DeviceID:      deviceID,
+		PublicKeyPEM:  pubPEM,
+		PrivateKeyPEM: privPEM,
+		CreatedAtMs:   time.Now().UnixMilli(),
+	}
+
+	if err := saveIdentity(identity); err != nil {
+		return nil, err
+	}
+
+	return identity, nil
+}
+
+// LoadDeviceTokens loads stored device tokens.
+func LoadDeviceTokens() (*DeviceTokenStore, error) {
+	path := filepath.Join(DeviceDir(), "device-auth.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var store DeviceTokenStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, err
+	}
+	return &store, nil
+}
+
+// SaveDeviceToken stores a device token for a role.
+func SaveDeviceToken(deviceID, role, token string, scopes []string) error {
+	store := &DeviceTokenStore{
+		Version:  1,
+		DeviceID: deviceID,
+		Tokens:   make(map[string]DeviceTokenRef),
+	}
+
+	// Load existing
+	existing, err := LoadDeviceTokens()
+	if err == nil && existing.DeviceID == deviceID {
+		store = existing
+	}
+
+	store.Tokens[role] = DeviceTokenRef{
+		Token:       token,
+		Role:        role,
+		Scopes:      scopes,
+		UpdatedAtMs: time.Now().UnixMilli(),
+	}
+
+	dir := DeviceDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "device-auth.json"), data, 0600)
+}
+
+// BuildDeviceConnect creates the device field for the connect request.
+// platform and deviceFamily must match the values sent in ClientInfo.
+// authToken is the gateway auth token (from connectParams.auth.token), used in the signature.
+// scopes must be in the exact order sent in ConnectParams.Scopes.
+func BuildDeviceConnect(identity *DeviceIdentity, nonce string, scopes []string, platform, deviceFamily, authToken string) (*DeviceConnect, error) {
+	signedAt := time.Now().UnixMilli()
+
+	rawPub, err := RawPublicKeyBase64URL(identity.PublicKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("encode public key: %w", err)
+	}
+
+	// The "token" in the payload is the gateway auth token (resolveSignatureToken
+	// returns auth.token ?? auth.deviceToken ?? auth.bootstrapToken).
+	signatureToken := authToken
+
+	// Build v3 payload — must match server-side reconstruction exactly.
+	// Server uses normalizeDeviceMetadataForAuth() which lowercases and trims.
+
+	normPlatform := strings.ToLower(strings.TrimSpace(platform))
+	normDeviceFamily := strings.ToLower(strings.TrimSpace(deviceFamily))
+
+	payload := strings.Join([]string{
+		"v3",
+		identity.DeviceID,
+		clientID,
+		clientMode,
+		"operator",
+		strings.Join(scopes, ","),
+		fmt.Sprintf("%d", signedAt),
+		signatureToken,
+		nonce,
+		normPlatform,
+		normDeviceFamily,
+	}, "|")
+
+	signature, err := signPayload(identity.PrivateKeyPEM, payload)
+	if err != nil {
+		return nil, fmt.Errorf("sign payload: %w", err)
+	}
+
+	return &DeviceConnect{
+		ID:        identity.DeviceID,
+		PublicKey: rawPub,
+		Signature: signature,
+		SignedAt:  signedAt,
+		Nonce:     nonce,
+	}, nil
+}
+
+// --- internal helpers ---
+
+func deriveDeviceID(publicKeyPEM string) (string, error) {
+	raw, err := rawPublicKeyBytes(publicKeyPEM)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256(raw)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+func rawPublicKeyBytes(publicKeyPEM string) ([]byte, error) {
+	block, _ := pem.Decode([]byte(publicKeyPEM))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse public key: %w", err)
+	}
+	edPub, ok := pub.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not an ed25519 public key")
+	}
+	return []byte(edPub), nil
+}
+
+// RawPublicKeyBase64URL returns the raw 32-byte Ed25519 public key as base64url.
+func RawPublicKeyBase64URL(publicKeyPEM string) (string, error) {
+	raw, err := rawPublicKeyBytes(publicKeyPEM)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func signPayload(privateKeyPEM, payload string) (string, error) {
+	block, _ := pem.Decode([]byte(privateKeyPEM))
+	if block == nil {
+		return "", fmt.Errorf("failed to decode private key PEM")
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("parse private key: %w", err)
+	}
+	edKey, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		return "", fmt.Errorf("not an ed25519 private key")
+	}
+	sig := ed25519.Sign(edKey, []byte(payload))
+	return base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+func marshalPublicKeyPEM(pub ed25519.PublicKey) (string, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", fmt.Errorf("marshal public key: %w", err)
+	}
+	block := &pem.Block{Type: "PUBLIC KEY", Bytes: der}
+	return string(pem.EncodeToMemory(block)), nil
+}
+
+func marshalPrivateKeyPEM(priv ed25519.PrivateKey) (string, error) {
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return "", fmt.Errorf("marshal private key: %w", err)
+	}
+	block := &pem.Block{Type: "PRIVATE KEY", Bytes: der}
+	return string(pem.EncodeToMemory(block)), nil
+}
+
+func saveIdentity(identity *DeviceIdentity) error {
+	dir := DeviceDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("create device dir: %w", err)
+	}
+	data, err := json.MarshalIndent(identity, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "device.json"), data, 0600)
+}

--- a/internal/openclaw/types.go
+++ b/internal/openclaw/types.go
@@ -76,15 +76,16 @@ type ChallengePayload struct {
 
 // ConnectParams are sent in the "connect" request.
 type ConnectParams struct {
-	MinProtocol int          `json:"minProtocol"`
-	MaxProtocol int          `json:"maxProtocol"`
-	Client      ClientInfo   `json:"client"`
-	Caps        []string     `json:"caps,omitempty"`
-	Role        string       `json:"role,omitempty"`
-	Scopes      []string     `json:"scopes,omitempty"`
-	Auth        *ConnectAuth `json:"auth,omitempty"`
-	Locale      string       `json:"locale,omitempty"`
-	UserAgent   string       `json:"userAgent,omitempty"`
+	MinProtocol int            `json:"minProtocol"`
+	MaxProtocol int            `json:"maxProtocol"`
+	Client      ClientInfo     `json:"client"`
+	Caps        []string       `json:"caps,omitempty"`
+	Role        string         `json:"role,omitempty"`
+	Scopes      []string       `json:"scopes,omitempty"`
+	Auth        *ConnectAuth   `json:"auth,omitempty"`
+	Device      *DeviceConnect `json:"device,omitempty"`
+	Locale      string         `json:"locale,omitempty"`
+	UserAgent   string         `json:"userAgent,omitempty"`
 }
 
 // ClientInfo identifies this client to the gateway.


### PR DESCRIPTION
## Summary
- Adds Ed25519 device identity and pairing flow for OpenClaw gateway authentication
- New `agent-deck openclaw pair` command for device registration
- Replaces simple password auth with scoped token-based auth using device keypairs
- Stores device tokens locally for persistent authentication

## Test plan
- [ ] Run `agent-deck openclaw pair`, verify device identity is created
- [ ] Test `agent-deck openclaw pair --id` shows device ID
- [ ] Verify gateway connection with device auth after pairing
- [ ] Test re-pairing and token refresh flows

🤖 Generated with [Claude Code](https://claude.ai/code)