### PR TITLE
fix(bridge): kill full process group on CLI timeout to prevent orphaned subprocesses

### DIFF
--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -117,11 +118,20 @@ def run_cli(
     log.debug("CLI: %s", " ".join(cmd))
     try:
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout
+            cmd, capture_output=True, text=True, timeout=timeout,
+            start_new_session=True,  # own process group → killpg kills grandchildren too
         )
         return result
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as exc:
         log.warning("CLI timeout: %s", " ".join(cmd))
+        if exc.proc:
+            try:
+                # Kill the entire process group so grandchildren (e.g. tmux send-keys)
+                # don't survive as orphans and jam the pane's input queue.
+                os.killpg(os.getpgid(exc.proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                exc.proc.kill()  # fallback: kill direct child only
+            exc.proc.communicate()
         return subprocess.CompletedProcess(cmd, 1, "", "timeout")
     except FileNotFoundError:
         log.error("agent-deck not found in PATH")

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -117,22 +117,28 @@ def run_cli(
     cmd += list(args)
     log.debug("CLI: %s", " ".join(cmd))
     try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout,
+        # Use Popen + communicate(timeout=) so we have the proc object available
+        # when TimeoutExpired fires — subprocess.run() does NOT set exc.proc.
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
             start_new_session=True,  # own process group → killpg kills grandchildren too
         )
-        return result
-    except subprocess.TimeoutExpired as exc:
-        log.warning("CLI timeout: %s", " ".join(cmd))
-        if exc.proc:
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+            return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+        except subprocess.TimeoutExpired:
+            log.warning("CLI timeout: %s", " ".join(cmd))
             try:
                 # Kill the entire process group so grandchildren (e.g. tmux send-keys)
                 # don't survive as orphans and jam the pane's input queue.
-                os.killpg(os.getpgid(exc.proc.pid), signal.SIGKILL)
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             except (ProcessLookupError, PermissionError):
-                exc.proc.kill()  # fallback: kill direct child only
-            exc.proc.communicate()
-        return subprocess.CompletedProcess(cmd, 1, "", "timeout")
+                proc.kill()  # fallback: kill direct child only
+            proc.communicate()
+            return subprocess.CompletedProcess(cmd, 1, "", "timeout")
     except FileNotFoundError:
         log.error("agent-deck not found in PATH")
         return subprocess.CompletedProcess(cmd, 1, "", "not found")


### PR DESCRIPTION
## Problem

When `run_cli` times out, it kills the `agent-deck` process — but any grandchild processes spawned by `agent-deck` (most notably `tmux send-keys -l`) survive as orphans. SIGKILL does not propagate to children in a different process group.

These orphans continue feeding characters into the tmux pane's PTY input buffer. On a narrow PTY the buffer fills and subsequent `tmux send-keys` calls from the next heartbeat or user message block indefinitely, effectively freezing the conductor until manually killed.

**Observed failure mode:** Bridge and systemd heartbeat both stuck in `tmux send-keys -l` for 2+ days, conductor unreachable, no Telegram/Slack responses.

## Fix

- `start_new_session=True` on `subprocess.run` puts `agent-deck` in its own process group, isolated from the bridge
- `os.killpg(os.getpgid(proc.pid), signal.SIGKILL)` on `TimeoutExpired` kills the entire group including all grandchildren
- Fallback to `proc.kill()` if the process group is already gone (race condition)

## Test plan

- [ ] Manually verify: send a message that causes `session send --wait` to time out → confirm no `tmux send-keys` orphan survives (`ps aux | grep send-keys`)
- [ ] Subsequent sends to the same pane complete normally after a timeout