### PR TITLE
Fix #468: reset multi-repo state when reopening new session dialog

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -225,6 +225,11 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string) {
 	d.branchInput.SetValue("")
 	d.branchAutoSet = false
 	d.branchPrefix = "feature/" // default; overridden below if config provides one.
+	// Reset multi-repo fields (ephemeral, never pre-filled).
+	d.multiRepoEnabled = false
+	d.multiRepoPaths = nil
+	d.multiRepoPathCursor = 0
+	d.multiRepoEditing = false
 	// Reset sandbox from global config default.
 	d.sandboxEnabled = false
 	d.inheritedExpanded = false
@@ -1339,7 +1344,7 @@ func (d *NewDialog) View() string {
 	if cur == focusCommand {
 		multiRepoLabel = "Multi-repo mode (m)"
 	}
-	content.WriteString(renderCheckboxLine(multiRepoLabel, d.multiRepoEnabled, cur == focusMultiRepo && !d.multiRepoEnabled))
+	content.WriteString(renderCheckboxLine(multiRepoLabel, d.multiRepoEnabled, cur == focusMultiRepo))
 
 	if d.multiRepoEnabled {
 		// Multi-repo path list replaces the single path field.

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -579,6 +579,29 @@ func TestNewDialog_ShowInGroup_ResetsWorktree(t *testing.T) {
 	}
 }
 
+func TestNewDialog_ShowInGroup_ResetsMultiRepo(t *testing.T) {
+	dialog := NewNewDialog()
+	dialog.multiRepoEnabled = true
+	dialog.multiRepoPaths = []string{"/path/a", "/path/b"}
+	dialog.multiRepoPathCursor = 1
+	dialog.multiRepoEditing = true
+
+	dialog.ShowInGroup("projects", "Projects", "")
+
+	if dialog.multiRepoEnabled {
+		t.Error("multiRepoEnabled should be reset to false on ShowInGroup")
+	}
+	if dialog.multiRepoPaths != nil {
+		t.Errorf("multiRepoPaths should be nil, got: %v", dialog.multiRepoPaths)
+	}
+	if dialog.multiRepoPathCursor != 0 {
+		t.Errorf("multiRepoPathCursor should be 0, got: %d", dialog.multiRepoPathCursor)
+	}
+	if dialog.multiRepoEditing {
+		t.Error("multiRepoEditing should be false on ShowInGroup")
+	}
+}
+
 func TestNewDialog_ShowInGroup_SetsDefaultPath(t *testing.T) {
 	dialog := NewNewDialog()
 


### PR DESCRIPTION
## Summary
- `ShowInGroup()` was missing multi-repo field resets (`multiRepoEnabled`, `multiRepoPaths`, `multiRepoPathCursor`, `multiRepoEditing`), causing multi-repo mode to persist across dialog reopens
- Fixed checkbox focus indicator to show as focused when multi-repo is enabled, making the space-to-uncheck discoverable

## Test plan
- [x] New test `TestNewDialog_ShowInGroup_ResetsMultiRepo` verifies all 4 fields are reset
- [x] All existing newdialog tests pass
- [x] Build and vet pass clean

Fixes #468