### PR TITLE
Fix Restart() adopting wrong .jsonl when tmux session is dead

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3728,8 +3728,11 @@ func (i *Instance) Restart() error {
 		mcpLog.Debug("mcp_regen_skipped", slog.String("reason", "flag_set_by_apply"))
 	}
 
-	// Sync Claude session from disk before restart to pick up /clear session changes
-	if IsClaudeCompatible(i.Tool) {
+	// Sync Claude session from disk before restart to pick up /clear session changes.
+	// Only do this when the tmux session is alive — a dead session can't have run /clear,
+	// and scanning disk without a live tmux session risks adopting another session's .jsonl
+	// because collectOtherClaudeSessionIDs() only excludes IDs from live tmux sessions.
+	if IsClaudeCompatible(i.Tool) && i.tmuxSession != nil && i.tmuxSession.Exists() {
 		i.syncClaudeSessionFromDisk()
 	}
 


### PR DESCRIPTION
## Summary

- When `Restart()` is called on a dead session (tmux gone), `syncClaudeSessionFromDisk()` scans `~/.claude/projects/<project>/` for the most recently modified `.jsonl` file
- `collectOtherClaudeSessionIDs()` builds an exclusion list from **live** tmux sessions only — so a recently-killed session's `.jsonl` is not excluded
- This causes the restarting session to adopt a completely different conversation's `.jsonl` file

## Fix

Guard `syncClaudeSessionFromDisk()` so it only runs when the tmux session is alive. A dead session cannot have run `/clear` (the only reason for the disk scan), so skipping is always safe.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./internal/session/...` passes
- [ ] Kill a tmux session for project X, then restart another session for the same project — verify it keeps its own `.jsonl` instead of adopting the dead session's file