### PR TITLE
Fix #472: use Kitty keyboard pop instead of push mode 0

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -209,8 +209,6 @@ func GetConductorAgentSpec(agent string) (ConductorAgentSpec, error) {
 	return spec, nil
 }
 
-
-
 // conductorNameRegex validates conductor names: starts with alphanumeric, then alphanumeric/._-
 var conductorNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -25,12 +25,13 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// DisableKittyKeyboard writes the escape sequence that pushes keyboard mode 0
-// (legacy) on the Kitty keyboard protocol stack. After this call, Kitty-protocol-
-// aware terminals stop sending CSI u sequences and revert to legacy key
-// reporting. Terminals that do not support the protocol ignore the sequence.
+// DisableKittyKeyboard writes the escape sequence that pops the Kitty keyboard
+// protocol stack, restoring the previous keyboard mode. If nothing was on the
+// stack, this is a safe no-op. After this call, Kitty-protocol-aware terminals
+// stop sending CSI u sequences and revert to legacy key reporting. Terminals
+// that do not support the protocol ignore the sequence.
 func DisableKittyKeyboard(w io.Writer) {
-	_, _ = io.WriteString(w, "\x1b[>0u")
+	_, _ = io.WriteString(w, "\x1b[<u")
 }
 
 // RestoreKittyKeyboard writes the escape sequence that pops the keyboard mode

--- a/internal/ui/keyboard_compat_test.go
+++ b/internal/ui/keyboard_compat_test.go
@@ -109,7 +109,7 @@ func TestDisableKittyKeyboard(t *testing.T) {
 	var buf bytes.Buffer
 	DisableKittyKeyboard(&buf)
 	got := buf.String()
-	want := "\x1b[>0u"
+	want := "\x1b[<u"
 	if got != want {
 		t.Errorf("DisableKittyKeyboard wrote %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

- Changed `DisableKittyKeyboard` from `ESC[>0u` (push mode 0) to `ESC[<u` (pop) in `internal/ui/keyboard_compat.go`
- On Ghostty, pushing mode 0 onto the Kitty stack activates CSI u encoding, which Bubble Tea v1.3.10 can't parse, causing shifted keys (capitals) to be silently dropped
- Pop is safe: no-op if the stack is empty, restores previous state if something was pushed

Fixes #472