### PR TITLE
feat: Show current task description inline for selected session

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9414,20 +9414,9 @@ func (h *Home) renderSessionItem(
 		windowChevron = chevronStyle.Render(chevronChar)
 	}
 
-	// Pane title suffix: show current task description inline (dim) only for the selected item.
-	// Cap length to avoid garbled mid-ANSI truncation by ensureExactWidth on narrow terminals.
-	paneTitleSuffix := ""
-	if selected && instState.paneTitle != "" {
-		pt := instState.paneTitle
-		if lipgloss.Width(pt) > 40 {
-			pt = ansi.Truncate(pt, 40, "…")
-		}
-		paneTitleSuffix = DimStyle.Render(" " + pt)
-	}
-
-	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [badges] [paneTitle]
+	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [badges]
 	row := fmt.Sprintf(
-		"%s%s%s%s%s %s%s%s%s%s%s%s%s",
+		"%s%s%s%s%s %s%s%s%s%s%s%s",
 		baseIndent,
 		selectionPrefix,
 		treeStyle.Render(treeConnector),
@@ -9440,8 +9429,22 @@ func (h *Home) renderSessionItem(
 		sandboxBadge,
 		multiRepoBadge,
 		sshBadge,
-		paneTitleSuffix,
 	)
+
+	// Append pane title filling remaining row space (only for the selected item).
+	// lipgloss.Width(row) accounts for indentation, tree connectors, and all badges,
+	// so deeply-nested sessions with many badges naturally get less pane title space.
+	if selected && instState.paneTitle != "" {
+		remaining := h.width - lipgloss.Width(row) - 2 // -2 for trailing margin
+		if remaining > 10 {
+			pt := instState.paneTitle
+			if lipgloss.Width(pt) > remaining {
+				pt = ansi.Truncate(pt, remaining, "…")
+			}
+			row += DimStyle.Render(" " + pt)
+		}
+	}
+
 	b.WriteString(row)
 	b.WriteString("\n")
 }

--- a/internal/ui/pane_title_test.go
+++ b/internal/ui/pane_title_test.go
@@ -1,6 +1,12 @@
 package ui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
 
 func TestCleanPaneTitle(t *testing.T) {
 	tests := []struct {
@@ -29,4 +35,81 @@ func TestCleanPaneTitle(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPaneTitleDynamicWidth verifies pane title fills available space without line breaks.
+func TestPaneTitleDynamicWidth(t *testing.T) {
+	// Mirrors the post-Sprintf logic in renderSessionItem.
+	renderPaneTitle := func(baseRowWidth, termWidth int, paneTitle string) string {
+		remaining := termWidth - baseRowWidth - 2
+		if remaining <= 10 {
+			return ""
+		}
+		pt := paneTitle
+		if lipgloss.Width(pt) > remaining {
+			pt = ansi.Truncate(pt, remaining, "…")
+		}
+		return DimStyle.Render(" " + pt)
+	}
+
+	t.Run("no line breaks in output", func(t *testing.T) {
+		result := renderPaneTitle(30, 120, "Fix the KPIs and run the full regression suite for all modules")
+		if strings.Contains(result, "\n") {
+			t.Error("pane title output contains newline")
+		}
+	})
+
+	t.Run("omitted when no space", func(t *testing.T) {
+		result := renderPaneTitle(78, 80, "Some task")
+		if result != "" {
+			t.Errorf("expected empty when no space, got %q", result)
+		}
+	})
+
+	t.Run("omitted when remaining too small", func(t *testing.T) {
+		result := renderPaneTitle(70, 80, "Some task")
+		if result != "" {
+			t.Errorf("expected empty when remaining < 10, got %q", result)
+		}
+	})
+
+	t.Run("shown when enough space", func(t *testing.T) {
+		result := renderPaneTitle(40, 120, "Fix the KPIs")
+		if result == "" {
+			t.Error("expected pane title to be shown with enough space")
+		}
+		if !strings.Contains(result, "Fix the KPIs") {
+			t.Errorf("expected result to contain pane title text, got %q", result)
+		}
+	})
+
+	t.Run("truncated for narrow terminal", func(t *testing.T) {
+		longTitle := "Implement the full authentication system with OAuth2"
+		result := renderPaneTitle(40, 60, longTitle)
+		if result == "" {
+			t.Error("expected pane title to be shown")
+		}
+		if strings.Contains(result, "OAuth2") {
+			t.Errorf("expected title to be truncated, but end is present: %q", result)
+		}
+	})
+
+	t.Run("wide terminal shows full title", func(t *testing.T) {
+		title := "Fix the KPIs and run tests"
+		result := renderPaneTitle(40, 200, title)
+		if !strings.Contains(result, title) {
+			t.Errorf("expected full title on wide terminal, got %q", result)
+		}
+	})
+
+	t.Run("deeply nested row leaves less space", func(t *testing.T) {
+		title := "A very long task description that should be truncated on nested items"
+		result := renderPaneTitle(70, 100, title)
+		if result == "" {
+			t.Error("expected pane title even for nested items")
+		}
+		if strings.Contains(result, "nested items") {
+			t.Errorf("expected truncation for nested row, got %q", result)
+		}
+	})
 }


### PR DESCRIPTION

## Summary
When a session is selected in the TUI list, display the Claude Code task description (from the tmux pane title) inline after the badges in dim text.
<img width="915" height="115" alt="TUI Subtitle Screenshot" src="https://github.com/user-attachments/assets/2a514afd-d201-4dde-a64b-e5a6716c710b" />

- Surfaces what each agent is working on without requiring attach
- Add paneTitle field to sessionRenderState, populated from existing tmux pane cache (no new subprocess calls)
- Strips spinner/done markers,  Filter generic titles ("Claude Code", "Gemini CLI", "Codex CLI"), caps at 40 visual chars
- ~~Cap at 40 visual chars to prevent ANSI truncation on narrow terminals~~
- Dynamically fills remaining row space (measures rendered row including indentation, tree connectors, and badges)
- Only rendered for the selected item to keep the list compact

## Test plan
  - [x] `go build ./...` passes
  - [x] `go vet ./...` passes
  - [x] `go fmt ./...` clean
  - [x] `golangci-lint run ./internal/ui/` — no issues
  - [x] 12 unit tests for `cleanPaneTitle` (new)
  - [x] 7 unit tests for dynamic width behavior (new)
  - [x] 248 existing UI tests still pass
  - [x] Manual: run agent-deck, select a session with an active Claude task, verify dim task text appears inline and adapts to terminal width