### PR TITLE
fix: session output returns stale cache after /clear

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3055,28 +3055,28 @@ func (i *Instance) GetLastResponse() (*ResponseOutput, error) {
 // 4. Fallback to terminal parsing.
 // 5. If still unavailable, return an empty response (no error).
 func (i *Instance) GetLastResponseBestEffort() (*ResponseOutput, error) {
+	// For Claude sessions, ensure session ID is current before reading.
+	// After /clear, a new session UUID exists on disk but the stored ID
+	// still points to the old (pre-clear) conversation file — which still
+	// exists and would succeed, returning stale content.
+	if IsClaudeCompatible(i.Tool) {
+		if sessionID := i.GetSessionIDFromTmux(); sessionID != "" && sessionID != i.ClaudeSessionID {
+			i.ClaudeSessionID = sessionID
+			i.ClaudeDetectedAt = time.Now()
+		}
+		i.syncClaudeSessionFromDisk()
+	}
+
 	resp, err := i.GetLastResponse()
 	if err == nil {
 		return resp, nil
 	}
 
-	// Claude-specific recovery path
-	if IsClaudeCompatible(i.Tool) {
-		// Refresh from tmux env (fast path)
-		if sessionID := i.GetSessionIDFromTmux(); sessionID != "" {
-			i.ClaudeSessionID = sessionID
-			i.ClaudeDetectedAt = time.Now()
-			if recovered, recoverErr := i.getClaudeLastResponse(); recoverErr == nil {
-				return recovered, nil
-			}
-		}
-
-		// Fallback: detect latest session on disk (handles startup race / stale ID)
-		i.syncClaudeSessionFromDisk()
-		if i.ClaudeSessionID != "" {
-			if recovered, recoverErr := i.getClaudeLastResponse(); recoverErr == nil {
-				return recovered, nil
-			}
+	// Claude-specific recovery path (session ID already synced above; retry
+	// only helps if the initial read had a transient error like a truncated file)
+	if IsClaudeCompatible(i.Tool) && i.ClaudeSessionID != "" {
+		if recovered, recoverErr := i.getClaudeLastResponse(); recoverErr == nil {
+			return recovered, nil
 		}
 	}
 

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -2024,6 +2024,57 @@ func TestInstance_GetLastResponseBestEffort_ClaudeNoSessionID(t *testing.T) {
 	}
 }
 
+func TestGetLastResponseBestEffort_ReturnsNewSessionAfterClear(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := "/test/clear-project"
+	encodedPath := ConvertToClaudeDirName(projectPath)
+	projectsDir := filepath.Join(tmpDir, "projects", encodedPath)
+	_ = os.MkdirAll(projectsDir, 0o755)
+
+	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	os.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+	defer os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
+	ClearUserConfigCache()
+	defer ClearUserConfigCache()
+
+	oldSessionID := "aaaa0000-0000-0000-0000-000000000001"
+	newSessionID := "bbbb0000-0000-0000-0000-000000000002"
+
+	oldContent := `{"type":"user","sessionId":"` + oldSessionID + `","message":{"role":"user","content":"hello"},"timestamp":"2026-01-01T00:00:00Z"}
+{"type":"assistant","sessionId":"` + oldSessionID + `","message":{"role":"assistant","content":"Old stale response"},"timestamp":"2026-01-01T00:00:01Z"}`
+	newContent := `{"type":"user","sessionId":"` + newSessionID + `","message":{"role":"user","content":"new task"},"timestamp":"2026-01-01T00:01:00Z"}
+{"type":"assistant","sessionId":"` + newSessionID + `","message":{"role":"assistant","content":"Fresh response after clear"},"timestamp":"2026-01-01T00:01:01Z"}`
+
+	oldFile := filepath.Join(projectsDir, oldSessionID+".jsonl")
+	newFile := filepath.Join(projectsDir, newSessionID+".jsonl")
+	_ = os.WriteFile(oldFile, []byte(oldContent), 0o644)
+	_ = os.WriteFile(newFile, []byte(newContent), 0o644)
+
+	// Make old file older, new file recent
+	oldTime := time.Now().Add(-10 * time.Minute)
+	_ = os.Chtimes(oldFile, oldTime, oldTime)
+
+	inst := NewInstance("clear-test", projectPath)
+	inst.Tool = "claude"
+	inst.ClaudeSessionID = oldSessionID
+	inst.tmuxSession = nil
+
+	resp, err := inst.GetLastResponseBestEffort()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Content != "Fresh response after clear" {
+		t.Errorf("got %q, want %q (stale cache not invalidated after /clear)",
+			resp.Content, "Fresh response after clear")
+	}
+	if inst.ClaudeSessionID != newSessionID {
+		t.Errorf("ClaudeSessionID = %q, want %q", inst.ClaudeSessionID, newSessionID)
+	}
+}
+
 func TestSessionHasConversationData(t *testing.T) {
 	// Create temp directory structure
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Hi, thanks for the great application. I'm submitting some stuff I changed locally, in case you want it upstream. (PR 2/3)

## Summary

- `session output` returned the pre-`/clear` response because `GetLastResponseBestEffort()` read from the old JSONL file (which still exists on disk) before checking whether a newer session file was available
- Move session ID sync (tmux env + disk scan via `syncClaudeSessionFromDisk`) to run **before** the first read attempt, not as a fallback after failure

## Root cause

After `/clear`, Claude Code creates a new session UUID on disk. The stored `ClaudeSessionID` still pointed to the old file. `getClaudeLastResponse()` read the old file successfully, so the recovery paths (`syncClaudeSessionFromDisk`) never executed.

## Test plan

- [x] New test `TestGetLastResponseBestEffort_ReturnsNewSessionAfterClear`: sets up old + new JSONL files, points `ClaudeSessionID` at the old one, verifies `GetLastResponseBestEffort` returns the new content
- [x] Manual: run `/clear` on a waiting session, let it complete a new task, verify `agent-deck session output <session> -q` returns the new response