### PR TITLE
fix(group): preserve group name case in group move command

### DIFF
--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -707,9 +707,8 @@ func handleGroupMove(profile string, args []string) {
 
 	// Normalize target group
 	// Handle special cases for moving to root/default group
-	targetGroupPath := normalizeGroupPath(targetGroup)
 	if targetGroup == "root" || targetGroup == "" {
-		targetGroupPath = session.DefaultGroupPath
+		targetGroup = session.DefaultGroupPath
 	}
 
 	// Store original group for output
@@ -721,11 +720,32 @@ func handleGroupMove(profile string, args []string) {
 	// Build group tree
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
 
-	// Check if target group exists (unless moving to default)
-	if targetGroupPath != session.DefaultGroupPath && targetGroupPath != "" {
-		if _, exists := groupTree.Groups[targetGroupPath]; !exists {
-			// Create the group
-			groupTree.CreateGroup(targetGroupPath)
+	// Try to match an existing group by exact name first, then case-insensitive
+	targetGroupPath := targetGroup
+	if targetGroup != session.DefaultGroupPath {
+		matched := false
+		for path := range groupTree.Groups {
+			if path == targetGroup {
+				targetGroupPath = path
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			// Case-insensitive match against existing groups
+			targetLower := strings.ToLower(targetGroup)
+			for path := range groupTree.Groups {
+				if strings.ToLower(path) == targetLower {
+					targetGroupPath = path
+					matched = true
+					break
+				}
+			}
+		}
+		if !matched {
+			// No existing group found - CreateGroup normalizes the path
+			created := groupTree.CreateGroup(targetGroupPath)
+			targetGroupPath = created.Path
 		}
 	}
 


### PR DESCRIPTION
## Summary
- When moving a session to a group, match existing groups case-insensitively before creating a new one
- Use the normalized path returned by `CreateGroup` instead of raw user input, preventing duplicate groups

**Reproduction:**
1. Create a group "my-project"
2. Run `agent-deck group move <session> "My-Project"` (different case)
3. A second group "My-Project" is created instead of reusing the existing one