### PR TITLE
fix(ui): align selection arrow for sub-sessions

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9295,10 +9295,13 @@ func (h *Home) renderSessionItem(
 		status = statusStyle.Render(statusIcon)
 		// Tree connector also gets selection styling
 		treeStyle = TreeConnectorSelStyle
-		// Rebuild baseIndent with selection styling for sub-sessions
-		if item.IsSubSession && !item.ParentIsLastInGroup {
+		// Rebuild baseIndent with selection arrow for sub-sessions
+		// Replace the │ (or empty space) with ▶ so the arrow doesn't squeeze
+		// between tree connector characters (e.g. " │▶├─" → " ▶ ├─")
+		if item.IsSubSession {
 			groupIndent := strings.Repeat(treeEmpty, max(0, item.Level-2))
-			baseIndent = groupIndent + " " + treeStyle.Render("│")
+			baseIndent = groupIndent + SessionSelectionPrefix.Render(" ▶")
+			selectionPrefix = " "
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fix selection arrow rendering for sub-sessions in the session list
- The arrow was squeezed between tree connector characters (e.g. " │▶├─") instead of replacing the connector (" ▶ ├─")
- Also removes the `ParentIsLastInGroup` gate so the arrow shows for all selected sub-sessions