### PR TITLE
feat(session): add lifecycle event log for session ID transitions

### DIFF
--- a/internal/session/session_id_event_log.go
+++ b/internal/session/session_id_event_log.go
@@ -1,0 +1,68 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// SessionIDLifecycleEvent captures every session-ID bind/rebind/reject decision.
+// Events are appended as JSONL for postmortem debugging.
+type SessionIDLifecycleEvent struct {
+	InstanceID string `json:"instance_id"`
+	Tool       string `json:"tool"`
+	Action     string `json:"action"` // bind | rebind | reject | scan_disabled
+	Source     string `json:"source"` // tmux_env | hook_payload | hook_anchor | disk_scan
+	OldID      string `json:"old_id,omitempty"`
+	NewID      string `json:"new_id,omitempty"`
+	Candidate  string `json:"candidate,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+	HookEvent  string `json:"hook_event,omitempty"`
+	Timestamp  int64  `json:"ts"`
+}
+
+var sessionIDLifecycleLogMu sync.Mutex
+
+// GetSessionIDLifecycleLogPath returns ~/.agent-deck/logs/session-id-lifecycle.jsonl.
+func GetSessionIDLifecycleLogPath() string {
+	agentDeckDir, err := GetAgentDeckDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".agent-deck", "logs", "session-id-lifecycle.jsonl")
+	}
+	return filepath.Join(agentDeckDir, "logs", "session-id-lifecycle.jsonl")
+}
+
+// WriteSessionIDLifecycleEvent appends a single JSONL event.
+func WriteSessionIDLifecycleEvent(event SessionIDLifecycleEvent) error {
+	if event.Timestamp == 0 {
+		event.Timestamp = time.Now().Unix()
+	}
+
+	logPath := GetSessionIDLifecycleLogPath()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+		return fmt.Errorf("create lifecycle log dir: %w", err)
+	}
+
+	line, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal lifecycle event: %w", err)
+	}
+	line = append(line, '\n')
+
+	sessionIDLifecycleLogMu.Lock()
+	defer sessionIDLifecycleLogMu.Unlock()
+
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open lifecycle log: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(line); err != nil {
+		return fmt.Errorf("write lifecycle event: %w", err)
+	}
+	return nil
+}

--- a/internal/session/session_id_event_log_test.go
+++ b/internal/session/session_id_event_log_test.go
@@ -1,0 +1,59 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWriteSessionIDLifecycleEvent_AppendsJSONL(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	first := SessionIDLifecycleEvent{
+		InstanceID: "inst-1",
+		Tool:       "claude",
+		Action:     "bind",
+		Source:     "tmux_env",
+		NewID:      "session-a",
+	}
+	second := SessionIDLifecycleEvent{
+		InstanceID: "inst-1",
+		Tool:       "claude",
+		Action:     "rebind",
+		Source:     "hook_payload",
+		OldID:      "session-a",
+		NewID:      "session-b",
+	}
+
+	if err := WriteSessionIDLifecycleEvent(first); err != nil {
+		t.Fatalf("WriteSessionIDLifecycleEvent(first) error: %v", err)
+	}
+	if err := WriteSessionIDLifecycleEvent(second); err != nil {
+		t.Fatalf("WriteSessionIDLifecycleEvent(second) error: %v", err)
+	}
+
+	data, err := os.ReadFile(GetSessionIDLifecycleLogPath())
+	if err != nil {
+		t.Fatalf("read lifecycle log: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("line count = %d, want 2", len(lines))
+	}
+
+	var gotFirst, gotSecond SessionIDLifecycleEvent
+	if err := json.Unmarshal([]byte(lines[0]), &gotFirst); err != nil {
+		t.Fatalf("unmarshal first line: %v", err)
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &gotSecond); err != nil {
+		t.Fatalf("unmarshal second line: %v", err)
+	}
+	if gotFirst.Action != "bind" || gotSecond.Action != "rebind" {
+		t.Fatalf("actions = %q/%q, want bind/rebind", gotFirst.Action, gotSecond.Action)
+	}
+	if gotFirst.Timestamp == 0 || gotSecond.Timestamp == 0 {
+		t.Fatal("timestamps should be auto-populated")
+	}
+}


### PR DESCRIPTION
## Summary
- Add a JSONL event log that records every session ID bind, rebind, and reject decision
- Each event captures timestamp, old/new IDs, source (hook_payload vs hook_anchor), and reason
- Log file: `~/.agent-deck/logs/session-id-lifecycle.jsonl`
- Observability-only -- no behavior changes
- Provides the audit infrastructure used by #490 to trace session ID contamination bugs described in #423