### PR TITLE
feat: add Open status filter to hide error/stopped sessions

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -48,6 +48,7 @@ const (
 	StatusError    Status = "error"
 	StatusStarting Status = "starting" // Session is being created (tmux initializing)
 	StatusStopped  Status = "stopped"  // Session intentionally stopped by user (not crashed)
+	StatusActive   Status = "active"   // Pseudo-status for filter: excludes error/stopped (never assigned to a session)
 )
 
 const wrapperPlaceholder = "{command}"

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -933,6 +933,16 @@ type DisplaySettings struct {
 	// Can also be enabled via AGENTDECK_REPAINT=full env var.
 	// Default: false
 	FullRepaint bool `toml:"full_repaint"`
+
+	// DefaultFilter sets the initial status filter when the TUI opens.
+	// Valid values: "" (all, default), "active" (hides error/stopped),
+	// "running", "waiting", "idle", "error".
+	// If set to "active" and no non-error sessions exist, falls back to showing all.
+	DefaultFilter string `toml:"default_filter"`
+
+	// ActiveFilterLabel sets the label shown on the filter pill when the active
+	// filter is engaged. Default: "Open". Examples: "Active", "Live", "Open".
+	ActiveFilterLabel string `toml:"active_filter_label"`
 }
 
 // GetFullRepaint returns whether full-repaint mode is active, checking

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -215,6 +215,7 @@ func (h *HelpOverlay) View() string {
 			title: "SEARCH & FILTER",
 			items: [][2]string{
 				{searchKey, "Open search"},
+				{FilterKeyActive, "Filter open (hide errors)"},
 				{"/waiting", "Filter waiting"},
 				{"/running", "Filter running"},
 				{"/idle", "Filter idle"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2028,8 +2028,29 @@ func (h *Home) getSelectedSession() *session.Instance {
 }
 
 type sessionRenderState struct {
-	status session.Status
-	tool   string
+	status    session.Status
+	tool      string
+	paneTitle string // Current task description from tmux pane title (stripped of spinner/done markers)
+}
+
+// cleanPaneTitle strips spinner/done marker characters from a tmux pane title
+// and returns the task description. Returns "" for default/generic titles.
+func cleanPaneTitle(title string) string {
+	if title == "" {
+		return ""
+	}
+	// Strip known spinner/done markers, plus any Braille chars (U+2800-28FF)
+	// that Claude Code may use as spinner frames beyond the canonical set.
+	cleaned := tmux.StripSpinnerRunes(title)
+	cleaned = strings.TrimLeftFunc(cleaned, func(r rune) bool {
+		return r >= 0x2800 && r <= 0x28FF
+	})
+	cleaned = strings.TrimSpace(cleaned)
+	switch cleaned {
+	case "", "Claude Code", "Gemini CLI", "Codex CLI":
+		return ""
+	}
+	return cleaned
 }
 
 func (h *Home) getSessionRenderSnapshot() map[string]sessionRenderState {
@@ -2054,10 +2075,17 @@ func (h *Home) refreshSessionRenderSnapshot(instances []*session.Instance) {
 		if inst == nil {
 			continue
 		}
-		snap[inst.ID] = sessionRenderState{
+		state := sessionRenderState{
 			status: inst.GetStatusThreadSafe(),
 			tool:   inst.GetToolThreadSafe(),
 		}
+		// Look up pane title from the already-refreshed tmux cache.
+		if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
+			if paneInfo, ok := tmux.GetCachedPaneInfo(tmuxSess.Name); ok {
+				state.paneTitle = cleanPaneTitle(paneInfo.Title)
+			}
+		}
+		snap[inst.ID] = state
 	}
 	h.sessionRenderSnapshot.Store(snap)
 }
@@ -9386,9 +9414,20 @@ func (h *Home) renderSessionItem(
 		windowChevron = chevronStyle.Render(chevronChar)
 	}
 
-	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [yolo] [worktree] [sandbox] [multi-repo] [ssh]
+	// Pane title suffix: show current task description inline (dim) only for the selected item.
+	// Cap length to avoid garbled mid-ANSI truncation by ensureExactWidth on narrow terminals.
+	paneTitleSuffix := ""
+	if selected && instState.paneTitle != "" {
+		pt := instState.paneTitle
+		if lipgloss.Width(pt) > 40 {
+			pt = ansi.Truncate(pt, 40, "…")
+		}
+		paneTitleSuffix = DimStyle.Render(" " + pt)
+	}
+
+	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [badges] [paneTitle]
 	row := fmt.Sprintf(
-		"%s%s%s%s%s %s%s%s%s%s%s%s",
+		"%s%s%s%s%s %s%s%s%s%s%s%s%s",
 		baseIndent,
 		selectionPrefix,
 		treeStyle.Render(treeConnector),
@@ -9401,6 +9440,7 @@ func (h *Home) renderSessionItem(
 		sandboxBadge,
 		multiRepoBadge,
 		sshBadge,
+		paneTitleSuffix,
 	)
 	b.WriteString(row)
 	b.WriteString("\n")

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9414,20 +9414,9 @@ func (h *Home) renderSessionItem(
 		windowChevron = chevronStyle.Render(chevronChar)
 	}
 
-	// Pane title suffix: show current task description inline (dim) only for the selected item.
-	// Cap length to avoid garbled mid-ANSI truncation by ensureExactWidth on narrow terminals.
-	paneTitleSuffix := ""
-	if selected && instState.paneTitle != "" {
-		pt := instState.paneTitle
-		if lipgloss.Width(pt) > 40 {
-			pt = ansi.Truncate(pt, 40, "…")
-		}
-		paneTitleSuffix = DimStyle.Render(" " + pt)
-	}
-
-	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [badges] [paneTitle]
+	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [badges]
 	row := fmt.Sprintf(
-		"%s%s%s%s%s %s%s%s%s%s%s%s%s",
+		"%s%s%s%s%s %s%s%s%s%s%s%s",
 		baseIndent,
 		selectionPrefix,
 		treeStyle.Render(treeConnector),
@@ -9440,8 +9429,22 @@ func (h *Home) renderSessionItem(
 		sandboxBadge,
 		multiRepoBadge,
 		sshBadge,
-		paneTitleSuffix,
 	)
+
+	// Append pane title filling remaining row space (only for the selected item).
+	// lipgloss.Width(row) accounts for indentation, tree connectors, and all badges,
+	// so deeply-nested sessions with many badges naturally get less pane title space.
+	if selected && instState.paneTitle != "" {
+		remaining := h.width - lipgloss.Width(row) - 2 // -2 for trailing margin
+		if remaining > 10 {
+			pt := instState.paneTitle
+			if lipgloss.Width(pt) > remaining {
+				pt = ansi.Truncate(pt, remaining, "…")
+			}
+			row += DimStyle.Render(" " + pt)
+		}
+	}
+
 	b.WriteString(row)
 	b.WriteString("\n")
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -122,6 +122,10 @@ const (
 	LayoutModeDual    = "dual"    // 80+ cols: side-by-side
 )
 
+// FilterKeyActive is the keyboard shortcut for the "open" status filter
+// (shows all sessions except error/stopped). Change this constant to rebind.
+const FilterKeyActive = "%"
+
 // PreviewMode defines what to show in the preview pane
 type PreviewMode int
 
@@ -338,7 +342,9 @@ type Home struct {
 
 	// Full repaint mode: issue tea.ClearScreen every tick to avoid
 	// incremental redraw drift in terminals with unicode grapheme widths
-	fullRepaint bool
+	fullRepaint       bool
+	defaultFilter     string // from config.toml [display] default_filter
+	activeFilterLabel string // from config.toml [display] active_filter_label
 
 	// Performance observability (debug mode only, zero cost when off)
 	debugMode          bool         // true when AGENTDECK_DEBUG=1, enables perf overlay
@@ -701,9 +707,11 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 
 	h.reloadHotkeysFromConfig()
 
-	// Cache full-repaint setting (config.toml [display] full_repaint or AGENTDECK_REPAINT=full)
+	// Cache display settings (config.toml [display])
 	if cfg, _ := session.LoadUserConfig(); cfg != nil {
 		h.fullRepaint = cfg.Display.GetFullRepaint()
+		h.defaultFilter = cfg.Display.DefaultFilter
+		h.activeFilterLabel = cfg.Display.ActiveFilterLabel
 	} else {
 		h.fullRepaint = (session.DisplaySettings{}).GetFullRepaint()
 	}
@@ -714,6 +722,12 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 
 	// Restore persisted UI state (preview mode, status filter, cursor position)
 	h.loadUIState()
+
+	// Apply default_filter from config if no filter was restored from persisted state.
+	// Auto-clears if no sessions match (handled in rebuildFlatItems).
+	if h.statusFilter == "" && h.defaultFilter != "" {
+		h.statusFilter = session.Status(h.defaultFilter)
+	}
 
 	tmuxSettings := session.GetTmuxSettings()
 	h.manageTmuxNotifications = tmuxSettings.GetInjectStatusLine()
@@ -1117,7 +1131,7 @@ func (h *Home) rebuildFlatItems() {
 		groupsWithMatches := make(map[string]bool)
 		for _, item := range allItems {
 			if item.Type == session.ItemTypeSession && item.Session != nil {
-				if item.Session.Status == h.statusFilter {
+				if matchesStatusFilter(h.statusFilter, item.Session.Status) {
 					// Mark this session's group and all parent groups as having matches
 					groupsWithMatches[item.Path] = true
 					// Also mark parent paths
@@ -1140,7 +1154,7 @@ func (h *Home) rebuildFlatItems() {
 				}
 			} else if item.Type == session.ItemTypeSession && item.Session != nil {
 				// Keep session if it matches the filter
-				if item.Session.Status == h.statusFilter {
+				if matchesStatusFilter(h.statusFilter, item.Session.Status) {
 					filtered = append(filtered, item)
 				}
 			}
@@ -5561,6 +5575,16 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.rebuildFlatItems()
 		return h, nil
+
+	case FilterKeyActive, "shift+5":
+		// Filter to open sessions (excludes error/stopped)
+		if h.statusFilter == session.StatusActive {
+			h.statusFilter = "" // Toggle off
+		} else {
+			h.statusFilter = session.StatusActive
+		}
+		h.rebuildFlatItems()
+		return h, nil
 	}
 
 	return h, nil
@@ -7299,12 +7323,24 @@ func (h *Home) renderFilterBar() string {
 	// Build pills
 	var pills []string
 
-	// "All" pill
-	allLabel := "All"
-	if h.statusFilter == "" {
-		pills = append(pills, activePillStyle.Render(allLabel))
+	// "All" / "Open" pill
+	isActive := h.statusFilter == session.StatusActive
+	activeLabel := h.activeFilterLabel
+	if activeLabel == "" {
+		activeLabel = "Open"
+	}
+	// "All" is shorter than "Open" — pad with a trailing space outside the pill
+	// so toggling doesn't shift the bar, without extending the highlight.
+	allPad := ""
+	if len(activeLabel) > len("All") {
+		allPad = " "
+	}
+	if isActive {
+		pills = append(pills, activePillStyle.Render(activeLabel))
+	} else if h.statusFilter == "" {
+		pills = append(pills, activePillStyle.Render("All")+allPad)
 	} else {
-		pills = append(pills, inactivePillStyle.Render(allLabel))
+		pills = append(pills, inactivePillStyle.Render("All")+allPad)
 	}
 
 	// Running pill (green when active, dim if 0)
@@ -7341,7 +7377,7 @@ func (h *Home) renderFilterBar() string {
 		pills = append(pills, dimPillStyle.Render(waitingLabel))
 	}
 
-	// Idle pill (gray when active)
+	// Idle pill (gray when selected, dimmed when active filter hides it)
 	idleLabel := fmt.Sprintf("○ %d", idle)
 	if h.statusFilter == session.StatusIdle {
 		pills = append(pills, lipgloss.NewStyle().
@@ -7349,16 +7385,16 @@ func (h *Home) renderFilterBar() string {
 			Background(ColorTextDim).
 			Bold(true).
 			Padding(0, 1).Render(idleLabel))
-	} else if idle > 0 {
+	} else if idle == 0 {
+		pills = append(pills, dimPillStyle.Render(idleLabel))
+	} else {
 		pills = append(pills, lipgloss.NewStyle().
 			Foreground(ColorText).
 			Background(ColorSurface).
 			Padding(0, 1).Render(idleLabel))
-	} else {
-		pills = append(pills, dimPillStyle.Render(idleLabel))
 	}
 
-	// Error pill (red when active)
+	// Error pill (red when selected, dimmed when active filter hides it)
 	if errored > 0 || h.statusFilter == session.StatusError {
 		errorLabel := fmt.Sprintf("✕ %d", errored)
 		if h.statusFilter == session.StatusError {
@@ -7367,6 +7403,8 @@ func (h *Home) renderFilterBar() string {
 				Background(ColorRed).
 				Bold(true).
 				Padding(0, 1).Render(errorLabel))
+		} else if isActive {
+			pills = append(pills, dimPillStyle.Render(errorLabel))
 		} else if errored > 0 {
 			pills = append(pills, lipgloss.NewStyle().
 				Foreground(ColorRed).
@@ -7375,9 +7413,8 @@ func (h *Home) renderFilterBar() string {
 		}
 	}
 
-	// Hint for keyboard shortcuts (shift+number to filter, 0 to clear)
-	hintStyle := lipgloss.NewStyle().Foreground(ColorComment).Faint(true)
-	hint := hintStyle.Render("  !@#$ filter • 0 all")
+	// Hint for keyboard shortcuts (cached — content is static)
+	hint := cachedFilterBarHint()
 
 	// Join pills with spaces (leading space replaces Padding)
 	filterRow := " " + strings.Join(pills, " ") + hint
@@ -11651,4 +11688,30 @@ func getSessionContent(inst *session.Instance) (string, error) {
 	}
 
 	return content, nil
+}
+
+// matchesStatusFilter returns true if the given session status matches the
+// current filter. For StatusActive, everything except error/stopped matches
+// (including StatusStarting — sessions being launched count as active).
+// See also isLiveSessionStatus in session/transition_notifier.go which uses
+// a positive enumeration for a different purpose (notification transitions).
+func matchesStatusFilter(filter, status session.Status) bool {
+	if filter == session.StatusActive {
+		return status != session.StatusError && status != session.StatusStopped
+	}
+	return status == filter
+}
+
+// cachedFilterBarHint returns the static filter bar hint string.
+// Cached after first call since the content never changes after theme init.
+var _cachedFilterBarHint string
+
+func cachedFilterBarHint() string {
+	if _cachedFilterBarHint == "" {
+		_cachedFilterBarHint = lipgloss.NewStyle().
+			Foreground(ColorComment).
+			Faint(true).
+			Render("  !@#$ filter • 0 all • " + FilterKeyActive + " open")
+	}
+	return _cachedFilterBarHint
 }

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2098,3 +2098,30 @@ func TestRebuildFlatItemsKeepsValidStatusFilter(t *testing.T) {
 		t.Errorf("expected 1 session in flatItems with error filter, got %d", sessionCount)
 	}
 }
+
+func TestMatchesStatusFilter(t *testing.T) {
+	tests := []struct {
+		filter session.Status
+		status session.Status
+		want   bool
+	}{
+		// Active filter: excludes error and stopped only
+		{session.StatusActive, session.StatusRunning, true},
+		{session.StatusActive, session.StatusWaiting, true},
+		{session.StatusActive, session.StatusIdle, true},
+		{session.StatusActive, session.StatusStarting, true},
+		{session.StatusActive, session.StatusError, false},
+		{session.StatusActive, session.StatusStopped, false},
+		// Concrete status filters: exact match
+		{session.StatusRunning, session.StatusRunning, true},
+		{session.StatusRunning, session.StatusWaiting, false},
+		{session.StatusError, session.StatusError, true},
+		{session.StatusError, session.StatusStopped, false},
+	}
+	for _, tt := range tests {
+		got := matchesStatusFilter(tt.filter, tt.status)
+		if got != tt.want {
+			t.Errorf("matchesStatusFilter(%q, %q) = %v, want %v", tt.filter, tt.status, got, tt.want)
+		}
+	}
+}

--- a/internal/ui/pane_title_test.go
+++ b/internal/ui/pane_title_test.go
@@ -1,0 +1,32 @@
+package ui
+
+import "testing"
+
+func TestCleanPaneTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"generic claude", "✳ Claude Code", ""},
+		{"generic gemini", "✳ Gemini CLI", ""},
+		{"generic codex", "✳ Codex CLI", ""},
+		{"braille spinner with task", "⠐ Fix the KPIs (Branch)", "Fix the KPIs (Branch)"},
+		{"done marker with task", "✳ Run and verify session tests", "Run and verify session tests"},
+		{"multiple markers", "✳✻ Some task", "Some task"},
+		{"just markers", "✳✻✽", ""},
+		{"no markers", "Hello world", "Hello world"},
+		{"hostname only", "29fa91017da8", "29fa91017da8"},
+		{"braille only", "⠐ Claude Code", ""},
+		{"whitespace after strip", "✳  Spaced task ", "Spaced task"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanPaneTitle(tt.input)
+			if got != tt.want {
+				t.Errorf("cleanPaneTitle(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/pane_title_test.go
+++ b/internal/ui/pane_title_test.go
@@ -1,6 +1,12 @@
 package ui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
 
 func TestCleanPaneTitle(t *testing.T) {
 	tests := []struct {
@@ -29,4 +35,81 @@ func TestCleanPaneTitle(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPaneTitleDynamicWidth verifies pane title fills available space without line breaks.
+func TestPaneTitleDynamicWidth(t *testing.T) {
+	// Mirrors the post-Sprintf logic in renderSessionItem.
+	renderPaneTitle := func(baseRowWidth, termWidth int, paneTitle string) string {
+		remaining := termWidth - baseRowWidth - 2
+		if remaining <= 10 {
+			return ""
+		}
+		pt := paneTitle
+		if lipgloss.Width(pt) > remaining {
+			pt = ansi.Truncate(pt, remaining, "…")
+		}
+		return DimStyle.Render(" " + pt)
+	}
+
+	t.Run("no line breaks in output", func(t *testing.T) {
+		result := renderPaneTitle(30, 120, "Fix the KPIs and run the full regression suite for all modules")
+		if strings.Contains(result, "\n") {
+			t.Error("pane title output contains newline")
+		}
+	})
+
+	t.Run("omitted when no space", func(t *testing.T) {
+		result := renderPaneTitle(78, 80, "Some task")
+		if result != "" {
+			t.Errorf("expected empty when no space, got %q", result)
+		}
+	})
+
+	t.Run("omitted when remaining too small", func(t *testing.T) {
+		result := renderPaneTitle(70, 80, "Some task")
+		if result != "" {
+			t.Errorf("expected empty when remaining < 10, got %q", result)
+		}
+	})
+
+	t.Run("shown when enough space", func(t *testing.T) {
+		result := renderPaneTitle(40, 120, "Fix the KPIs")
+		if result == "" {
+			t.Error("expected pane title to be shown with enough space")
+		}
+		if !strings.Contains(result, "Fix the KPIs") {
+			t.Errorf("expected result to contain pane title text, got %q", result)
+		}
+	})
+
+	t.Run("truncated for narrow terminal", func(t *testing.T) {
+		longTitle := "Implement the full authentication system with OAuth2"
+		result := renderPaneTitle(40, 60, longTitle)
+		if result == "" {
+			t.Error("expected pane title to be shown")
+		}
+		if strings.Contains(result, "OAuth2") {
+			t.Errorf("expected title to be truncated, but end is present: %q", result)
+		}
+	})
+
+	t.Run("wide terminal shows full title", func(t *testing.T) {
+		title := "Fix the KPIs and run tests"
+		result := renderPaneTitle(40, 200, title)
+		if !strings.Contains(result, title) {
+			t.Errorf("expected full title on wide terminal, got %q", result)
+		}
+	})
+
+	t.Run("deeply nested row leaves less space", func(t *testing.T) {
+		title := "A very long task description that should be truncated on nested items"
+		result := renderPaneTitle(70, 100, title)
+		if result == "" {
+			t.Error("expected pane title even for nested items")
+		}
+		if strings.Contains(result, "nested items") {
+			t.Errorf("expected truncation for nested row, got %q", result)
+		}
+	})
 }

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -11,6 +11,7 @@ All options for `~/.agent-deck/config.toml`.
 - [[docker] Section](#docker-section)
 - [[logs] Section](#logs-section)
 - [[updates] Section](#updates-section)
+- [[display] Section](#display-section)
 - [[global_search] Section](#global_search-section)
 - [Skills Registry (Outside config.toml)](#skills-registry-outside-configtoml)
 - [[mcp_pool] Section](#mcp_pool-section)
@@ -187,6 +188,23 @@ notify_in_cli = true          # Show in CLI commands
 | `check_enabled` | bool | `true` | Enable startup update checks. |
 | `check_interval_hours` | int | `24` | Hours between checks. |
 | `notify_in_cli` | bool | `true` | Show updates in CLI (not just TUI). |
+
+## [display] Section
+
+Rendering and display settings.
+
+```toml
+[display]
+full_repaint = false              # Force full screen clear every render (for terminals with grapheme issues)
+default_filter = "active"         # Initial status filter: "", "active", "running", "waiting", "idle", "error"
+active_filter_label = "Open"      # Label for the active filter pill (default: "Open")
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `full_repaint` | bool | `false` | Force full redraws (fix for Ghostty 1.3+ drift). Also via `AGENTDECK_REPAINT=full`. |
+| `default_filter` | string | `""` | Status filter applied on TUI startup. `"active"` hides error/stopped sessions. Auto-clears if no sessions match. |
+| `active_filter_label` | string | `"Open"` | Label shown on the filter pill when active filter is engaged (e.g., "Active", "Live", "Open"). |
 
 ## [global_search] Section
 


### PR DESCRIPTION
## Summary
  - Adds % hotkey to toggle an Open filter that hides error/stopped sessions
  - Adds [display] default_filter config option to auto-apply on TUI startup
  - Adds [display] active_filter_label config option to customize the pill label

<img width="608" height="87" alt="image" src="https://github.com/user-attachments/assets/f48c83c5-1f36-4644-a942-9e99c7d9b9b1" />

<img width="606" height="84" alt="image" src="https://github.com/user-attachments/assets/db7842ec-6fca-46ab-b26d-600651a8647f" />

  ## Changes
  - FilterKeyActive constant for easy rebinding
  - matchesStatusFilter() helper with table-driven test (10 cases)
  - Filter bar pill toggles between All and Open, dims error pill when active
  - Cached static hint string to avoid per-frame allocation
  - Config reference docs updated with [display] section

  ## Test plan
  - [x] All existing tests pass (1325 tests across ui + session packages)
  - [x] New TestMatchesStatusFilter covers all 6 status values
  - [x] go vet and gofmt clean
  - [x] Manual: press % to toggle filter, verify pill changes and sessions filter correctly
  - [x] Manual: set default_filter = active in config.toml, restart TUI, verify filter auto-applies
  - [x] Manual: set active_filter_label = Live in config.toml, verify custom label appears