### PR TITLE
fix: permission prompt shows as idle when previously acknowledged

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -148,6 +148,7 @@ type Instance struct {
 
 	// Hook-based status detection (set by StatusFileWatcher from Claude Code hooks)
 	hookStatus     string    // running, idle, waiting, dead (empty = no hook data)
+	hookEvent      string    // Hook event name that caused the last status (e.g. "PermissionRequest")
 	hookSessionID  string    // Session ID from hook payload
 	hookLastUpdate time.Time // When hook status was last received
 
@@ -2317,6 +2318,7 @@ func (i *Instance) UpdateStatus() error {
 	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini") {
 		if hs := readHookStatusFile(i.ID); hs != nil {
 			i.hookStatus = hs.Status
+			i.hookEvent = hs.Event
 			i.hookLastUpdate = hs.UpdatedAt
 			i.hookSessionID = hs.SessionID
 			// Reset stale acknowledged flag from ReconnectSessionLazy.
@@ -2356,7 +2358,8 @@ func (i *Instance) UpdateStatus() error {
 			} else {
 				// Check acknowledgment: orange (waiting) vs gray (idle)
 				// Acknowledge() is called when user attaches to a session.
-				// ResetAcknowledged() is called by u key or when new activity occurs.
+				// ResetAcknowledged() is called by UpdateHookStatus on any new
+				// waiting event, and by the u key / new activity.
 				if i.tmuxSession != nil && i.tmuxSession.IsAcknowledged() {
 					i.Status = StatusIdle
 				} else {
@@ -2568,8 +2571,25 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
+	// Detect whether this is genuinely new data (newer timestamp than last seen).
+	// Only reset acknowledgment on new events — not on re-application of the same
+	// stale hook file, which would undo the user's intentional acknowledge.
+	isNewEvent := status.UpdatedAt.After(i.hookLastUpdate)
+
 	i.hookStatus = status.Status
+	i.hookEvent = status.Event
 	i.hookLastUpdate = status.UpdatedAt
+
+	// Permission-type events are always attention-needed, even if the user
+	// previously acknowledged this session. A mid-task permission block is new
+	// activity that the user must respond to — unlike Stop (task complete) which
+	// can stay grey if already seen.
+	// Handles both PermissionRequest events and Notification/permission_prompt.
+	if isNewEvent && status.Status == "waiting" && i.tmuxSession != nil {
+		if status.Event == "PermissionRequest" || status.Event == "Notification" {
+			i.tmuxSession.ResetAcknowledged()
+		}
+	}
 
 	// Resolve session ID from hook payload first, then sidecar anchor.
 	sessionID := strings.TrimSpace(status.SessionID)

--- a/internal/session/lifecycle_regression_test.go
+++ b/internal/session/lifecycle_regression_test.go
@@ -347,3 +347,82 @@ func TestThreadSafeAccessors_Concurrent(t *testing.T) {
 func killTmuxSession(name string) error {
 	return exec.Command("tmux", "kill-session", "-t", name).Run()
 }
+
+// TestPermissionRequestResetsAcknowledged verifies that a PermissionRequest hook
+// event always causes the session to show as waiting (orange), even if the user
+// previously acknowledged the session while it was running.
+//
+// Regression test: before the fix, a previously-acknowledged session would show
+// as idle (grey) when Claude hit a permission prompt mid-task.
+func TestPermissionRequestResetsAcknowledged(t *testing.T) {
+	tmpDir := t.TempDir()
+	hooksDir := filepath.Join(tmpDir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0755))
+
+	// Simulate the hook event sequence:
+	// 1. UserPromptSubmit → running
+	// 2. User attaches (Acknowledge)
+	// 3. PermissionRequest → waiting  ← should be orange despite acknowledgment
+
+	watcher := &StatusFileWatcher{
+		hooksDir: hooksDir,
+		statuses: make(map[string]*HookStatus),
+	}
+
+	instanceID := "test-permission-ack"
+
+	writeHookFile := func(hooksDir, instanceID, status, event string) {
+		payload := map[string]any{
+			"status": status,
+			"event":  event,
+			"ts":     time.Now().Unix(),
+		}
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+		path := filepath.Join(hooksDir, instanceID+".json")
+		require.NoError(t, os.WriteFile(path, data, 0644))
+		watcher.processFile(path)
+	}
+
+	// Step 1: running
+	writeHookFile(hooksDir, instanceID, "running", "UserPromptSubmit")
+	hs := watcher.GetHookStatus(instanceID)
+	require.NotNil(t, hs)
+	assert.Equal(t, "running", hs.Status)
+	assert.Equal(t, "UserPromptSubmit", hs.Event)
+
+	// Step 2: PermissionRequest → waiting
+	writeHookFile(hooksDir, instanceID, "waiting", "PermissionRequest")
+	hs = watcher.GetHookStatus(instanceID)
+	require.NotNil(t, hs)
+	assert.Equal(t, "waiting", hs.Status)
+	assert.Equal(t, "PermissionRequest", hs.Event, "Event field must be preserved for PermissionRequest")
+}
+
+// TestHookEventFieldPropagated verifies that the Event field from a hook status
+// file is correctly propagated into the HookStatus struct by the watcher.
+func TestHookEventFieldPropagated(t *testing.T) {
+	tmpDir := t.TempDir()
+	hooksDir := filepath.Join(tmpDir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0755))
+
+	watcher := &StatusFileWatcher{
+		hooksDir: hooksDir,
+		statuses: make(map[string]*HookStatus),
+	}
+
+	payload := map[string]any{
+		"status": "waiting",
+		"event":  "PermissionRequest",
+		"ts":     time.Now().Unix(),
+	}
+	data, _ := json.Marshal(payload)
+	path := filepath.Join(hooksDir, "inst-xyz.json")
+	require.NoError(t, os.WriteFile(path, data, 0644))
+	watcher.processFile(path)
+
+	hs := watcher.GetHookStatus("inst-xyz")
+	require.NotNil(t, hs)
+	assert.Equal(t, "PermissionRequest", hs.Event)
+	assert.Equal(t, "waiting", hs.Status)
+}

--- a/internal/tmux/detector.go
+++ b/internal/tmux/detector.go
@@ -196,10 +196,13 @@ func (d *PromptDetector) hasClaudePrompt(content string) bool {
 		"Allow this MCP server",
 		// Tool permission prompts
 		"Run this command?",
+		"Do you want to proceed?",
 		"Execute this?",
 		"Action Required",
 		"Waiting for user confirmation",
 		"Allow execution of",
+		// Numbered menu footer (present in all Claude Code permission dialogs)
+		"Esc to cancel",
 		// AskUserQuestion / interactive question UI
 		// Claude Code renders selection options with these indicators
 		"Use arrow keys to navigate",

--- a/internal/tmux/patterns_test.go
+++ b/internal/tmux/patterns_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"strings"
 	"testing"
+	"fmt"
 )
 
 func TestDefaultRawPatterns_Claude(t *testing.T) {
@@ -452,4 +453,95 @@ func TestSpinnerRuneSet(t *testing.T) {
 	if !hasDone {
 		t.Error("missing ✻ from normalization set")
 	}
+}
+
+// TestClaudePromptDetector_NumberedMenuPermission verifies that the Claude
+// prompt detector correctly identifies the numbered-menu permission dialog
+// (e.g. "Do you want to proceed? > 1. Yes / 2. No") as a waiting state.
+// Regression test for the grey/idle bug reported in agent-deck.
+func TestClaudePromptDetector_NumberedMenuPermission(t *testing.T) {
+	detector := NewPromptDetector("claude")
+
+	// Exact content captured from the screenshot showing the bug
+	numberedMenuContent := `find /Users/ben.sgro/Work/k8s-configs/expanded -name "*.yaml" | wc -l
+Running…
+Bash(# Check the gcp:staging and gcp:production configs...)
+Running…
++111 more tool uses (ctrl+o to expand)
+(ctrl+b ctrl+b (twice) to run in background)
+
+Bash command
+
+  # Count files in expanded to see if it's stale/orphaned configs
+  find /Users/ben.sgro/Work/k8s-configs/expanded -name "*.yaml" | wc -l
+  Count expanded config files
+
+Command contains quote characters inside a # comment which can desync quote tracking
+
+Do you want to proceed?
+> 1.  Yes
+  2.  No
+
+Esc to cancel · Tab to amend · ctrl+e to explain`
+
+	if !detector.HasPrompt(numberedMenuContent) {
+		t.Error("should detect 'Do you want to proceed?' numbered menu as waiting")
+	}
+
+	// Also verify "Esc to cancel" alone is sufficient as a catch-all
+	escCancelContent := `Some tool output here
+Running some bash command
+
+Esc to cancel · Tab to amend · ctrl+e to explain`
+
+	if !detector.HasPrompt(escCancelContent) {
+		t.Error("should detect 'Esc to cancel' footer as waiting")
+	}
+
+	// Verify busy state is NOT incorrectly detected as waiting
+	busyContent := `Hullaballooing… (12s · ↓ 1234 tokens)
+ctrl+c to interrupt`
+
+	if detector.HasPrompt(busyContent) {
+		t.Error("busy state should NOT be detected as waiting")
+	}
+}
+
+// TestClaudePromptDetector_PermissionDialogVariants checks several known
+// permission dialog formats to ensure none are missed.
+func TestClaudePromptDetector_PermissionDialogVariants(t *testing.T) {
+	detector := NewPromptDetector("claude")
+
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "Do you want to proceed",
+			content: "Do you want to proceed?\n> 1.  Yes\n  2.  No\n\nEsc to cancel · Tab to amend",
+		},
+		{
+			name:    "Esc to cancel footer only",
+			content: "some output\nEsc to cancel · Tab to amend · ctrl+e to explain",
+		},
+		{
+			name:    "legacy box-drawing dialog",
+			content: "│ Do you want to run this command?\n│ Yes\n│ No",
+		},
+		{
+			name:    "Yes allow once",
+			content: "Run bash?\nYes, allow once\nNo",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !detector.HasPrompt(tc.content) {
+				t.Errorf("should detect as waiting: %s", tc.name)
+			}
+		})
+	}
+
+	// Suppress unused import
+	_ = fmt.Sprintf
 }


### PR DESCRIPTION
## Summary
Cherry-pick of the fix from #427 (by @mr-sk) onto a clean main base.

- `UpdateHookStatus` now calls `ResetAcknowledged()` when a new `PermissionRequest` or `Notification` hook event sets status to "waiting", so acknowledgment from a prior attach cannot suppress the orange indicator
- Tmux pane detector now recognizes the numbered-menu permission dialog format ("Do you want to proceed?", "Esc to cancel")
- Includes regression tests for both fixes

Original-PR: #427
Original-Author: @mr-sk

## Test plan
- [x] `go build ./...` passes
- [x] New tests pass: `TestPermissionRequestResetsAcknowledged`, `TestHookEventFieldPropagated`
- [x] Tmux detector tests pass: `TestClaudePromptDetector_NumberedMenuPermission`, `TestClaudePromptDetector_PermissionDialogVariants`