### PR TITLE
fix: always bash-c wrap commands when wrapper is configured

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1802,6 +1802,18 @@ func (i *Instance) applyWrapper(command string) (string, error) {
 	return wrapper, nil
 }
 
+// hasEffectiveWrapper returns true if the instance has a wrapper configured,
+// either directly on the instance or via the tool definition in config.toml.
+func (i *Instance) hasEffectiveWrapper() bool {
+	if i.Wrapper != "" {
+		return true
+	}
+	if toolDef := GetToolDef(i.Tool); toolDef != nil && toolDef.Wrapper != "" {
+		return true
+	}
+	return false
+}
+
 // loadCustomPatternsFromConfig loads detection patterns from built-in defaults + config.toml
 // overrides, and sets them on the tmux session for status detection and tool auto-detection.
 // Works for ALL tools: built-in (claude, gemini, opencode, codex) and custom.
@@ -4906,6 +4918,16 @@ func (i *Instance) wrapForSandbox(command string) (string, string, error) {
 // All code paths that launch or respawn a tmux pane should use this instead of calling
 // applyWrapper/wrapForSandbox/wrapIgnoreSuspend individually.
 func (i *Instance) prepareCommand(cmd string) (string, string, error) {
+	// Always pre-wrap in bash -c when a wrapper is configured. Wrappers use
+	// execvp() which cannot interpret shell syntax, so without this any
+	// metacharacter in cmd (inline env vars, &&, $(), etc.) would be passed
+	// as literal argv. Wrapping unconditionally is both safe and simpler than
+	// trying to detect which commands need it.
+	if i.hasEffectiveWrapper() {
+		escaped := strings.ReplaceAll(cmd, "'", "'\"'\"'")
+		cmd = fmt.Sprintf("bash -c '%s'", escaped)
+	}
+
 	wrapped, err := i.applyWrapper(cmd)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
## Summary
Cherry-pick of the fix from #431 (by @borng) onto a clean main base.

- When a wrapper is set in config.toml (e.g. `wrapper = "direnv exec ."`), wrappers use `execvp()` which cannot interpret shell syntax
- Inline env var prefixes like `AGENTDECK_INSTANCE_ID=xxx` get passed as literal argv instead of being interpreted by the shell
- Fix: always pre-wrap in `bash -c` when any wrapper is configured, before passing the command to `applyWrapper`

Original-PR: #431
Original-Author: @borng

## Test plan
- [x] `go build ./...` passes
- [x] No new tests (logic change in `prepareCommand` path)