### PR TITLE
fix(tmux): check COLORFGBG before OS appearance for theme detection

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1357,6 +1357,22 @@ func ResolveTheme() string {
 	if theme != "system" {
 		return theme
 	}
+	// Check the terminal's own declaration before asking the OS.
+	// COLORFGBG is set by iTerm2 and other terminals; format is "fg;bg"
+	// where bg < 8 means a dark background. This catches the common case
+	// where macOS is in light mode but the terminal profile is dark.
+	if colorfgbg := os.Getenv("COLORFGBG"); colorfgbg != "" {
+		if idx := strings.LastIndex(colorfgbg, ";"); idx >= 0 {
+			var bg int
+			if _, err := fmt.Sscanf(colorfgbg[idx+1:], "%d", &bg); err == nil {
+				if bg < 8 {
+					return "dark"
+				}
+				return "light"
+			}
+		}
+	}
+
 	isDark, err := dark.IsDarkMode()
 	if err != nil {
 		return "dark"

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -349,6 +349,44 @@ func TestGetTheme_Light(t *testing.T) {
 	}
 }
 
+func TestResolveTheme_COLORFGBGOverridesOS(t *testing.T) {
+	// Setup: explicit "system" theme so ResolveTheme falls through to
+	// auto-detection where COLORFGBG should be checked.
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	_ = os.MkdirAll(agentDeckDir, 0700)
+	config := &UserConfig{Theme: "system"}
+	_ = SaveUserConfig(config)
+
+	tests := []struct {
+		name      string
+		colorfgbg string
+		want      string
+	}{
+		{"dark terminal (bg=0)", "15;0", "dark"},
+		{"dark terminal (bg=1)", "15;1", "dark"},
+		{"light terminal (bg=15)", "0;15", "light"},
+		{"light terminal (bg=8)", "0;8", "light"},
+		{"three-part dark", "12;7;0", "dark"},
+		{"three-part light", "12;7;15", "light"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("COLORFGBG", tt.colorfgbg)
+			ClearUserConfigCache()
+
+			got := ResolveTheme()
+			if got != tt.want {
+				t.Errorf("ResolveTheme() with COLORFGBG=%q: got %q, want %q", tt.colorfgbg, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWorktreeConfig(t *testing.T) {
 	// Create temp config with worktree settings
 	tmpDir := t.TempDir()

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -59,6 +59,22 @@ func resolvedAgentDeckTheme() string {
 			}
 		}
 	}
+	// Check the terminal's own declaration before asking the OS.
+	// COLORFGBG is set by iTerm2 and other terminals; format is "fg;bg"
+	// where bg < 8 means a dark background. This catches the common case
+	// where macOS is in light mode but the terminal profile is dark.
+	if colorfgbg := os.Getenv("COLORFGBG"); colorfgbg != "" {
+		if idx := strings.LastIndex(colorfgbg, ";"); idx >= 0 {
+			var bg int
+			if _, err := fmt.Sscanf(colorfgbg[idx+1:], "%d", &bg); err == nil {
+				if bg < 8 {
+					return "dark"
+				}
+				return "light"
+			}
+		}
+	}
+
 	isDark, err := dark.IsDarkMode()
 	if err != nil {
 		return "dark"

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2711,3 +2711,48 @@ func TestStartCommandSpec_UserScope(t *testing.T) {
 	assert.Equal(t, "agentdeck-tmux-agentdeck-test-session-1234abcd", args[5])
 	assert.Equal(t, []string{"tmux", "new-session", "-d", "-s", "agentdeck_test-session_1234abcd", "-c", "/tmp/project"}, args[6:])
 }
+
+func TestResolvedAgentDeckTheme_COLORFGBG(t *testing.T) {
+	// Use temp HOME with no config so we fall through to auto-detection.
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	tests := []struct {
+		name      string
+		colorfgbg string
+		want      string
+	}{
+		{"dark terminal bg=0", "15;0", "dark"},
+		{"dark terminal bg=1", "15;1", "dark"},
+		{"light terminal bg=15", "0;15", "light"},
+		{"light terminal bg=8", "0;8", "light"},
+		{"three-part dark", "12;7;0", "dark"},
+		{"three-part light", "12;7;15", "light"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("COLORFGBG", tt.colorfgbg)
+			got := resolvedAgentDeckTheme()
+			assert.Equal(t, tt.want, got, "COLORFGBG=%q", tt.colorfgbg)
+		})
+	}
+}
+
+func TestResolvedAgentDeckTheme_ExplicitConfigOverridesCOLORFGBG(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	// Write explicit dark config
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	require.NoError(t, os.MkdirAll(agentDeckDir, 0700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(agentDeckDir, "config.toml"),
+		[]byte("theme = \"dark\"\n"), 0600,
+	))
+
+	// Even though COLORFGBG says light, explicit config wins
+	t.Setenv("COLORFGBG", "0;15")
+	got := resolvedAgentDeckTheme()
+	assert.Equal(t, "dark", got, "explicit config should override COLORFGBG")
+}


### PR DESCRIPTION
## Summary
Cherry-pick of the fix from #426 (by @beaufour) onto a clean main base.

- When theme is auto-detected, check terminal's `COLORFGBG` env var before falling back to macOS `dark.IsDarkMode()`
- Fixes white tmux backgrounds when macOS is in light mode but terminal profile is dark (common with iTerm2)
- `COLORFGBG` format is `fg;bg` where bg < 8 means dark background
- Applied in both `session/userconfig.go` (ResolveTheme) and `tmux/tmux.go` (resolvedAgentDeckTheme)
- Includes comprehensive tests for both code paths

Original-PR: #426
Original-Author: @beaufour

## Test plan
- [x] `go build ./...` passes
- [x] Tests pass: `TestResolveTheme_COLORFGBGOverridesOS`, `TestResolvedAgentDeckTheme_COLORFGBG`, `TestResolvedAgentDeckTheme_ExplicitConfigOverridesCOLORFGBG`