### PR TITLE
feat(worktree): add setup script support for post-creation automation (#432)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,23 @@ default_location = "subdirectory"  # "sibling" (default), "subdirectory", or a c
 
 `sibling` creates worktrees next to the repo (`repo-branch`). `subdirectory` creates them inside it (`repo/.worktrees/branch`). A custom path like `~/worktrees` or `/tmp/worktrees` creates repo-namespaced worktrees at `<path>/<repo_name>/<branch>`. The `--location` flag overrides the config per session.
 
+#### Worktree Setup Script
+
+Gitignored files (`.env`, `.mcp.json`, etc.) aren't copied into new worktrees. To automate this, create a setup script at `.agent-deck/worktree-setup.sh` in your repo. Agent-deck runs it automatically after creating a worktree.
+
+```sh
+#!/bin/sh
+for f in .env .env.local .mcp.json; do
+    [ -f "$AGENT_DECK_REPO_ROOT/$f" ] && cp "$AGENT_DECK_REPO_ROOT/$f" "$AGENT_DECK_WORKTREE_PATH/$f"
+done
+```
+
+The script receives two environment variables:
+- `AGENT_DECK_REPO_ROOT` — path to the main repository
+- `AGENT_DECK_WORKTREE_PATH` — path to the new worktree
+
+The script runs via `sh -e` with a 60-second timeout. If it fails, the worktree is still created — you'll see a warning but the session proceeds normally.
+
 ### Docker Sandbox
 
 Run sessions inside isolated Docker containers. The project directory is bind-mounted read-write, so agents work on your code while the rest of the system stays protected.

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -194,9 +194,13 @@ func handleLaunch(profile string, args []string) {
 				os.Exit(1)
 			}
 
-			if err := git.CreateWorktree(repoRoot, worktreePath, wtBranch); err != nil {
+			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr)
+			if err != nil {
 				out.Error(fmt.Sprintf("failed to create worktree: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)
+			}
+			if setupErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: worktree setup script failed: %v\n", setupErr)
 			}
 		}
 

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1075,7 +1075,8 @@ func handleAdd(profile string, args []string) {
 
 			// Create worktree atomically (git handles existence checks).
 			// This avoids a TOCTOU race from separate check-then-create steps.
-			if err := git.CreateWorktree(repoRoot, worktreePath, wtBranch); err != nil {
+			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr)
+			if err != nil {
 				if isWorktreeAlreadyExistsError(err) {
 					fmt.Fprintf(os.Stderr, "Error: worktree already exists at %s\n", worktreePath)
 					fmt.Fprintf(os.Stderr, "Tip: Use 'agent-deck add %s' to add the existing worktree\n", worktreePath)
@@ -1083,6 +1084,9 @@ func handleAdd(profile string, args []string) {
 				}
 				fmt.Fprintf(os.Stderr, "Error: failed to create worktree: %v\n", err)
 				os.Exit(1)
+			}
+			if setupErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: worktree setup script failed: %v\n", setupErr)
 			}
 
 			fmt.Printf("Created worktree at: %s\n", worktreePath)

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -516,9 +516,13 @@ func handleSessionFork(profile string, args []string) {
 				os.Exit(1)
 			}
 
-			if err := git.CreateWorktree(repoRoot, worktreePath, wtBranch); err != nil {
+			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr)
+			if err != nil {
 				out.Error(fmt.Sprintf("worktree creation failed: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)
+			}
+			if setupErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: worktree setup script failed: %v\n", setupErr)
 			}
 		}
 

--- a/internal/git/setup.go
+++ b/internal/git/setup.go
@@ -1,0 +1,70 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// FindWorktreeSetupScript returns the path to the worktree setup script
+// if one exists at <repoDir>/.agent-deck/worktree-setup.sh, or empty string.
+func FindWorktreeSetupScript(repoDir string) string {
+	p := filepath.Join(repoDir, ".agent-deck", "worktree-setup.sh")
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	return ""
+}
+
+// worktreeSetupTimeout is the maximum time a setup script is allowed to run.
+var worktreeSetupTimeout = 60 * time.Second
+
+// RunWorktreeSetupScript executes the setup script with AGENT_DECK_REPO_ROOT
+// and AGENT_DECK_WORKTREE_PATH environment variables set. Working directory
+// is set to worktreePath. Output is streamed to the provided writers.
+func RunWorktreeSetupScript(scriptPath, repoDir, worktreePath string, stdout, stderr io.Writer) error {
+	ctx, cancel := context.WithTimeout(context.Background(), worktreeSetupTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-e", scriptPath)
+	cmd.Dir = worktreePath
+	cmd.Env = append(os.Environ(),
+		"AGENT_DECK_REPO_ROOT="+repoDir,
+		"AGENT_DECK_WORKTREE_PATH="+worktreePath,
+	)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.WaitDelay = 5 * time.Second
+
+	err := cmd.Run()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("worktree setup script timed out after %s", worktreeSetupTimeout)
+	}
+	if err != nil {
+		return fmt.Errorf("worktree setup script failed: %w", err)
+	}
+	return nil
+}
+
+// CreateWorktreeWithSetup creates a worktree and runs the setup script if present.
+// Setup script failure is non-fatal: the worktree is still valid.
+// Output is streamed to the provided writers.
+func CreateWorktreeWithSetup(repoDir, worktreePath, branchName string, stdout, stderr io.Writer) (setupErr error, err error) {
+	if err = CreateWorktree(repoDir, worktreePath, branchName); err != nil {
+		return nil, err
+	}
+
+	scriptPath := FindWorktreeSetupScript(repoDir)
+	if scriptPath == "" {
+		return nil, nil
+	}
+
+	fmt.Fprintln(stderr, "Running worktree setup script...")
+	setupErr = RunWorktreeSetupScript(scriptPath, repoDir, worktreePath, stdout, stderr)
+	return setupErr, nil
+}

--- a/internal/git/setup_test.go
+++ b/internal/git/setup_test.go
@@ -1,0 +1,267 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFindWorktreeSetupScript_NotPresent(t *testing.T) {
+	dir := t.TempDir()
+
+	result := FindWorktreeSetupScript(dir)
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+}
+
+func TestFindWorktreeSetupScript_Present(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create .agent-deck/worktree-setup.sh
+	scriptDir := filepath.Join(dir, ".agent-deck")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(scriptDir, "worktree-setup.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := FindWorktreeSetupScript(dir)
+	if result != scriptPath {
+		t.Errorf("expected %q, got %q", scriptPath, result)
+	}
+}
+
+func TestRunWorktreeSetupScript_Success(t *testing.T) {
+	repoDir := t.TempDir()
+	worktreeDir := t.TempDir()
+
+	// Create a file in repoDir that the script will copy
+	testFile := filepath.Join(repoDir, ".mcp.json")
+	if err := os.WriteFile(testFile, []byte(`{"test": true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Script copies .mcp.json using env vars
+	script := `#!/bin/sh
+cp "$AGENT_DECK_REPO_ROOT/.mcp.json" "$AGENT_DECK_WORKTREE_PATH/.mcp.json"
+echo "copying done"
+`
+	scriptPath := filepath.Join(t.TempDir(), "setup.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := RunWorktreeSetupScript(scriptPath, repoDir, worktreeDir, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v (stderr: %s)", err, stderr.String())
+	}
+
+	// Verify file was copied
+	copied, err := os.ReadFile(filepath.Join(worktreeDir, ".mcp.json"))
+	if err != nil {
+		t.Fatalf("expected .mcp.json to be copied: %v", err)
+	}
+	if string(copied) != `{"test": true}` {
+		t.Errorf("unexpected content: %s", copied)
+	}
+
+	// Verify output was streamed to stdout
+	if !strings.Contains(stdout.String(), "copying done") {
+		t.Errorf("expected stdout to contain 'copying done', got %q", stdout.String())
+	}
+}
+
+func TestRunWorktreeSetupScript_Failure(t *testing.T) {
+	worktreeDir := t.TempDir()
+
+	script := `#!/bin/sh
+echo "something went wrong" >&2
+exit 1
+`
+	scriptPath := filepath.Join(t.TempDir(), "setup.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error from failing script")
+	}
+	if !strings.Contains(stderr.String(), "something went wrong") {
+		t.Errorf("expected stderr to contain error message, got: %q", stderr.String())
+	}
+}
+
+func TestRunWorktreeSetupScript_Timeout(t *testing.T) {
+	worktreeDir := t.TempDir()
+
+	// Override timeout to 1s for test speed
+	orig := worktreeSetupTimeout
+	worktreeSetupTimeout = 1 * time.Second
+	t.Cleanup(func() { worktreeSetupTimeout = orig })
+
+	script := `#!/bin/sh
+sleep 300
+`
+	scriptPath := filepath.Join(t.TempDir(), "setup.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected timeout error, got: %v", err)
+	}
+}
+
+// createTestRepoForSetup creates a git repo with an initial commit.
+// Uses the same pattern as createTestRepo in git_test.go but avoids
+// name collision since both are in the same package.
+func createTestRepoForSetup(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test User"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git %s failed: %v", args[0], err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command("git", "commit", "-m", "init")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateWorktreeWithSetup_NoScript(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepoForSetup(t, dir)
+	worktreePath := filepath.Join(dir, ".worktrees", "test-branch")
+
+	var stdout, stderr bytes.Buffer
+	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "test-branch", &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("worktree creation failed: %v", err)
+	}
+	if setupErr != nil {
+		t.Errorf("unexpected setup error: %v", setupErr)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("expected no output, got %q", stdout.String())
+	}
+
+	// Verify worktree was created
+	if _, err := os.Stat(filepath.Join(worktreePath, "README.md")); err != nil {
+		t.Error("worktree directory should contain README.md")
+	}
+}
+
+func TestCreateWorktreeWithSetup_WithScript(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepoForSetup(t, dir)
+
+	// Create a config file to copy
+	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(`{"ok":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create setup script
+	scriptDir := filepath.Join(dir, ".agent-deck")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := `#!/bin/sh
+cp "$AGENT_DECK_REPO_ROOT/.mcp.json" "$AGENT_DECK_WORKTREE_PATH/.mcp.json"
+echo "setup done"
+`
+	if err := os.WriteFile(filepath.Join(scriptDir, "worktree-setup.sh"), []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	worktreePath := filepath.Join(dir, ".worktrees", "setup-branch")
+	var stdout, stderr bytes.Buffer
+	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "setup-branch", &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("worktree creation failed: %v", err)
+	}
+	if setupErr != nil {
+		t.Errorf("unexpected setup error: %v", setupErr)
+	}
+	if !strings.Contains(stdout.String(), "setup done") {
+		t.Errorf("expected stdout to contain 'setup done', got %q", stdout.String())
+	}
+
+	// Verify file was copied
+	data, err := os.ReadFile(filepath.Join(worktreePath, ".mcp.json"))
+	if err != nil {
+		t.Fatalf("expected .mcp.json to be copied: %v", err)
+	}
+	if string(data) != `{"ok":true}` {
+		t.Errorf("unexpected content: %s", data)
+	}
+}
+
+func TestCreateWorktreeWithSetup_SetupFails(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepoForSetup(t, dir)
+
+	// Create a failing setup script
+	scriptDir := filepath.Join(dir, ".agent-deck")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := `#!/bin/sh
+echo "fail" >&2
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(scriptDir, "worktree-setup.sh"), []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	worktreePath := filepath.Join(dir, ".worktrees", "fail-branch")
+	var stdout, stderr bytes.Buffer
+	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "fail-branch", &stdout, &stderr)
+
+	// Worktree creation should succeed
+	if err != nil {
+		t.Fatalf("worktree creation should succeed: %v", err)
+	}
+
+	// Setup should fail (non-fatal)
+	if setupErr == nil {
+		t.Error("expected setup error from failing script")
+	}
+	if !strings.Contains(stderr.String(), "fail") {
+		t.Errorf("expected stderr to contain 'fail', got %q", stderr.String())
+	}
+
+	// Worktree should still be valid
+	if _, err := os.Stat(filepath.Join(worktreePath, "README.md")); err != nil {
+		t.Error("worktree should still exist after setup failure")
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -6385,8 +6386,13 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 				if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create parent directory: %w", err)}
 				}
-				if err := git.CreateWorktree(worktreeRepoRoot, worktreePath, worktreeBranch); err != nil {
+				var setupBuf bytes.Buffer
+				setupErr, err := git.CreateWorktreeWithSetup(worktreeRepoRoot, worktreePath, worktreeBranch, &setupBuf, &setupBuf)
+				if err != nil {
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create worktree: %w", err)}
+				}
+				if setupErr != nil {
+					uiLog.Warn("worktree_setup_script_failed", slog.String("error", setupErr.Error()), slog.String("output", setupBuf.String()))
 				}
 			}
 			path = worktreePath
@@ -6809,8 +6815,13 @@ func (h *Home) forkSessionCmdWithOptions(
 				if err := os.MkdirAll(filepath.Dir(opts.WorktreePath), 0o755); err != nil {
 					return sessionForkedMsg{err: fmt.Errorf("failed to create directory: %w", err), sourceID: sourceID}
 				}
-				if err := git.CreateWorktree(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch); err != nil {
+				var setupBuf bytes.Buffer
+				setupErr, err := git.CreateWorktreeWithSetup(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch, &setupBuf, &setupBuf)
+				if err != nil {
 					return sessionForkedMsg{err: fmt.Errorf("worktree creation failed: %w", err), sourceID: sourceID}
+				}
+				if setupErr != nil {
+					uiLog.Warn("worktree_setup_script_failed", slog.String("error", setupErr.Error()), slog.String("output", setupBuf.String()))
 				}
 			}
 		}


### PR DESCRIPTION
Cherry-picked from PR #432 (Clarity-89). Original PR had stale v0.27.0-era commits causing conflicts; only the feature commit is included.

Changes:
- Add setup script support for worktree post-creation automation
- New internal/git/setup.go with setup script execution
- CLI integration for worktree setup commands
- Tests for setup script functionality