### PR TITLE
feat: add MiniMax as cost tracking provider (#428)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,8 @@ Agent Deck works with any terminal-based AI tool:
 
 Track token usage and costs across all your AI agent sessions in real-time.
 
-- **Automatic collection** — Claude Code hook integration reads transcript files on each turn. Gemini/Codex support via output parsing (untested)
-- **9 models priced** — Claude Opus/Sonnet/Haiku, Gemini Pro/Flash, GPT-4o/4.1, o3, o4-mini with daily price refresh
+- **Automatic collection** — Claude Code hook integration reads transcript files on each turn. Gemini/Codex/MiniMax support via output parsing (untested)
+- **13 models priced** — Claude Opus/Sonnet/Haiku, Gemini Pro/Flash, GPT-4o/4.1, o3, o4-mini, MiniMax M2.7/M2.7-highspeed/M2.5/M2.5-highspeed with daily price refresh
 - **TUI dashboard** — press `$` to view today/week/month costs, top sessions, model breakdown
 - **Web dashboard** — `/costs` page with Chart.js charts, group drill-down, session detail views, SSE live updates
 - **Budget limits** — configurable daily/weekly/monthly/per-group/per-session limits with 80% warning and 100% hard stop (untested)

--- a/internal/costs/collector.go
+++ b/internal/costs/collector.go
@@ -26,6 +26,7 @@ func NewCollector(pricer *Pricer) *Collector {
 			&ClaudeHookParser{pricer: pricer},
 			&GeminiOutputParser{pricer: pricer},
 			&OpenAIOutputParser{pricer: pricer},
+			&MiniMaxOutputParser{pricer: pricer},
 		},
 		pricer: pricer,
 	}

--- a/internal/costs/parser_minimax.go
+++ b/internal/costs/parser_minimax.go
@@ -1,0 +1,39 @@
+package costs
+
+import (
+	"regexp"
+)
+
+// minimaxTokenRe matches MiniMax CLI output in the format:
+//
+//	MiniMax usage: 1,234 input tokens, 567 output tokens (MiniMax-M2.7)
+var minimaxTokenRe = regexp.MustCompile(
+	`MiniMax usage:\s*([\d,]+)\s*input tokens?,\s*([\d,]+)\s*output tokens?\s*\(([^)]+)\)`,
+)
+
+// MiniMaxOutputParser parses MiniMax CLI/tool token usage output.
+type MiniMaxOutputParser struct {
+	pricer *Pricer
+}
+
+func (p *MiniMaxOutputParser) Name() string { return "minimax" }
+
+func (p *MiniMaxOutputParser) CanParse(toolType string) bool {
+	return toolType == "minimax"
+}
+
+func (p *MiniMaxOutputParser) Parse(input string) ([]CostEvent, error) {
+	m := minimaxTokenRe.FindStringSubmatch(input)
+	if m == nil {
+		return nil, nil
+	}
+	inputTokens := parseCommaInt(m[1])
+	outputTokens := parseCommaInt(m[2])
+	model := m[3]
+	ev := CostEvent{
+		Model:        model,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+	}
+	return []CostEvent{ev}, nil
+}

--- a/internal/costs/parser_minimax_integration_test.go
+++ b/internal/costs/parser_minimax_integration_test.go
@@ -1,0 +1,59 @@
+package costs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Integration tests verify the full cost pipeline for MiniMax models:
+// output parsing → token extraction → pricing lookup → cost computation.
+
+func TestMiniMaxEndToEnd_M27(t *testing.T) {
+	pricer := NewPricer(PricerConfig{})
+	collector := NewCollector(pricer)
+
+	input := "MiniMax usage: 500,000 input tokens, 100,000 output tokens (MiniMax-M2.7)"
+	events, err := collector.Collect("minimax", "integration-m27", input)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	ev := events[0]
+	assert.Equal(t, "integration-m27", ev.SessionID)
+	assert.Equal(t, "MiniMax-M2.7", ev.Model)
+	assert.Equal(t, int64(500_000), ev.InputTokens)
+	assert.Equal(t, int64(100_000), ev.OutputTokens)
+	// 500K input at $0.70/Mtok = $0.35 = 350,000 microdollars
+	// 100K output at $2.80/Mtok = $0.28 = 280,000 microdollars
+	// Total = 630,000 microdollars
+	assert.Equal(t, int64(630_000), ev.CostMicrodollars)
+}
+
+func TestMiniMaxEndToEnd_M25Highspeed(t *testing.T) {
+	pricer := NewPricer(PricerConfig{})
+	collector := NewCollector(pricer)
+
+	input := "MiniMax usage: 1,000,000 input tokens, 500,000 output tokens (MiniMax-M2.5-highspeed)"
+	events, err := collector.Collect("minimax", "integration-m25hs", input)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	ev := events[0]
+	assert.Equal(t, "MiniMax-M2.5-highspeed", ev.Model)
+	// 1M input at $0.15/Mtok = $0.15 = 150,000 microdollars
+	// 500K output at $0.60/Mtok = $0.30 = 300,000 microdollars
+	// Total = 450,000 microdollars
+	assert.Equal(t, int64(450_000), ev.CostMicrodollars)
+}
+
+func TestMiniMaxEndToEnd_UnknownTool(t *testing.T) {
+	pricer := NewPricer(PricerConfig{})
+	collector := NewCollector(pricer)
+
+	// MiniMax output sent via an unknown tool type should not be parsed by any parser
+	input := "MiniMax usage: 1,000 input tokens, 500 output tokens (MiniMax-M2.7)"
+	events, err := collector.Collect("unknown-tool", "session-wrong-tool", input)
+	require.NoError(t, err)
+	assert.Nil(t, events)
+}

--- a/internal/costs/parser_test.go
+++ b/internal/costs/parser_test.go
@@ -72,6 +72,66 @@ func TestOpenAIParser(t *testing.T) {
 	assert.Equal(t, "gpt-4.1", events[0].Model)
 }
 
+func TestMiniMaxParser(t *testing.T) {
+	pricer := NewPricer(PricerConfig{})
+	parser := &MiniMaxOutputParser{pricer: pricer}
+
+	events, err := parser.Parse("MiniMax usage: 3,456 input tokens, 1,234 output tokens (MiniMax-M2.7)")
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	assert.Equal(t, int64(3456), events[0].InputTokens)
+	assert.Equal(t, int64(1234), events[0].OutputTokens)
+	assert.Equal(t, "MiniMax-M2.7", events[0].Model)
+}
+
+func TestMiniMaxParser_Highspeed(t *testing.T) {
+	pricer := NewPricer(PricerConfig{})
+	parser := &MiniMaxOutputParser{pricer: pricer}
+
+	events, err := parser.Parse("MiniMax usage: 10000 input tokens, 5000 output tokens (MiniMax-M2.5-highspeed)")
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	assert.Equal(t, int64(10000), events[0].InputTokens)
+	assert.Equal(t, int64(5000), events[0].OutputTokens)
+	assert.Equal(t, "MiniMax-M2.5-highspeed", events[0].Model)
+}
+
+func TestMiniMaxParser_SingleToken(t *testing.T) {
+	pricer := NewPricer(PricerConfig{})
+	parser := &MiniMaxOutputParser{pricer: pricer}
+
+	events, err := parser.Parse("MiniMax usage: 1 input token, 1 output token (MiniMax-M2.5)")
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	assert.Equal(t, int64(1), events[0].InputTokens)
+	assert.Equal(t, int64(1), events[0].OutputTokens)
+	assert.Equal(t, "MiniMax-M2.5", events[0].Model)
+}
+
+func TestMiniMaxParser_NoMatch(t *testing.T) {
+	pricer := NewPricer(PricerConfig{})
+	parser := &MiniMaxOutputParser{pricer: pricer}
+
+	events, err := parser.Parse("no minimax usage info here")
+	require.NoError(t, err)
+	assert.Empty(t, events)
+}
+
+func TestMiniMaxParser_CanParse(t *testing.T) {
+	parser := &MiniMaxOutputParser{}
+	assert.True(t, parser.CanParse("minimax"))
+	assert.False(t, parser.CanParse("claude"))
+	assert.False(t, parser.CanParse("gemini"))
+}
+
+func TestMiniMaxParser_Name(t *testing.T) {
+	parser := &MiniMaxOutputParser{}
+	assert.Equal(t, "minimax", parser.Name())
+}
+
 func TestCollector(t *testing.T) {
 	pricer := NewPricer(PricerConfig{})
 	collector := NewCollector(pricer)
@@ -85,6 +145,23 @@ func TestCollector(t *testing.T) {
 	ev := events[0]
 	assert.Equal(t, "session-123", ev.SessionID)
 	assert.Equal(t, "claude-sonnet-4-6", ev.Model)
+	assert.NotEmpty(t, ev.ID)
+	assert.Greater(t, ev.CostMicrodollars, int64(0))
+}
+
+func TestCollectorMiniMax(t *testing.T) {
+	pricer := NewPricer(PricerConfig{})
+	collector := NewCollector(pricer)
+
+	input := "MiniMax usage: 2,000 input tokens, 1,000 output tokens (MiniMax-M2.7)"
+
+	events, err := collector.Collect("minimax", "session-456", input)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	ev := events[0]
+	assert.Equal(t, "session-456", ev.SessionID)
+	assert.Equal(t, "MiniMax-M2.7", ev.Model)
 	assert.NotEmpty(t, ev.ID)
 	assert.Greater(t, ev.CostMicrodollars, int64(0))
 }

--- a/internal/costs/pricing.go
+++ b/internal/costs/pricing.go
@@ -78,6 +78,11 @@ func NewPricer(cfg PricerConfig) *Pricer {
 			"gpt-4.1":           priceFromUSD(2.0, 8.0, 0, 0),
 			"o3":                priceFromUSD(2.0, 8.0, 0, 0),
 			"o4-mini":           priceFromUSD(1.10, 4.40, 0, 0),
+			// MiniMax models (https://www.minimaxi.com/en/pricing)
+			"MiniMax-M2.7":           priceFromUSD(0.70, 2.80, 0, 0),
+			"MiniMax-M2.7-highspeed": priceFromUSD(0.35, 1.40, 0, 0),
+			"MiniMax-M2.5":           priceFromUSD(0.50, 2.00, 0, 0),
+			"MiniMax-M2.5-highspeed": priceFromUSD(0.15, 0.60, 0, 0),
 		},
 		cached:    make(map[string]ModelPrice),
 		overrides: make(map[string]ModelPrice),

--- a/internal/costs/pricing_test.go
+++ b/internal/costs/pricing_test.go
@@ -71,6 +71,36 @@ func TestPricerUserOverride(t *testing.T) {
 	assert.Equal(t, int64(99_000_000), mp.OutputPerMtokMicro)
 }
 
+func TestMiniMaxPricing(t *testing.T) {
+	p := NewPricer(PricerConfig{})
+
+	tests := []struct {
+		model string
+		input int64
+		output int64
+	}{
+		{"MiniMax-M2.7", 700_000, 2_800_000},
+		{"MiniMax-M2.7-highspeed", 350_000, 1_400_000},
+		{"MiniMax-M2.5", 500_000, 2_000_000},
+		{"MiniMax-M2.5-highspeed", 150_000, 600_000},
+	}
+
+	for _, tt := range tests {
+		mp, ok := p.GetPrice(tt.model)
+		assert.True(t, ok, "model %s should have pricing", tt.model)
+		assert.Equal(t, tt.input, mp.InputPerMtokMicro, "model %s input pricing", tt.model)
+		assert.Equal(t, tt.output, mp.OutputPerMtokMicro, "model %s output pricing", tt.model)
+	}
+}
+
+func TestMiniMaxComputeCost(t *testing.T) {
+	p := NewPricer(PricerConfig{})
+	// MiniMax-M2.7: input=$0.70/Mtok, output=$2.80/Mtok
+	// 1M input = $0.70, 1M output = $2.80 → total $3.50 = 3,500,000 microdollars
+	cost := p.ComputeCost("MiniMax-M2.7", 1_000_000, 1_000_000, 0, 0)
+	assert.Equal(t, int64(3_500_000), cost)
+}
+
 func TestPricerModelNormalization(t *testing.T) {
 	p := NewPricer(PricerConfig{})
 	mp, ok := p.GetPrice("claude-sonnet-4-6-20260301")

--- a/internal/session/analytics.go
+++ b/internal/session/analytics.go
@@ -85,6 +85,10 @@ var modelContextWindowPrefixes = []struct {
 	// 3.x models: 200k context
 	{"claude-3-5", 200000},
 	{"claude-3-opus", 200000},
+	// MiniMax models
+	{"MiniMax-M2.7", 1000000},       // 1M context
+	{"MiniMax-M2.5-highspeed", 204000}, // 204K context (must precede M2.5)
+	{"MiniMax-M2.5", 204000},        // 204K context
 }
 
 // contextWindowForModel returns the context window size for a model ID.
@@ -123,6 +127,11 @@ var modelPricing = map[string]ModelPricing{
 	"claude-opus-4-20250514":   {Input: 15.0, Output: 75.0, CacheRead: 1.50, CacheWrite: 18.75},
 	"claude-3-5-sonnet":        {Input: 3.0, Output: 15.0, CacheRead: 0.30, CacheWrite: 3.75},
 	"claude-3-5-haiku":         {Input: 0.80, Output: 4.0, CacheRead: 0.08, CacheWrite: 1.0},
+	// MiniMax models
+	"MiniMax-M2.7":           {Input: 0.70, Output: 2.80},
+	"MiniMax-M2.7-highspeed": {Input: 0.35, Output: 1.40},
+	"MiniMax-M2.5":           {Input: 0.50, Output: 2.00},
+	"MiniMax-M2.5-highspeed": {Input: 0.15, Output: 0.60},
 	// Default fallback uses Sonnet pricing
 	"default": {Input: 3.0, Output: 15.0, CacheRead: 0.30, CacheWrite: 3.75},
 }


### PR DESCRIPTION
Cherry-picked from PR #428 (octo-patch). Original PR had stale v0.27.0-era commits causing conflicts; only the feature commit is included.

Changes:
- Add MiniMax cost tracking provider with M2.7/M2.5 model pricing
- New parser_minimax.go for MiniMax log format
- Integration tests for MiniMax parsing