### PR TITLE
fix: bridge.py Python 3.9 compat (type union syntax)

### DIFF
--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -13,6 +13,8 @@ The bridge aggregates status across all profiles.
 Dependencies: pip3 install aiogram toml
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging


### PR DESCRIPTION
## Summary
- Adds `from __future__ import annotations` to `conductor/bridge.py` to fix crashes on macOS default Python 3.9.6
- The file uses Python 3.10+ type union syntax (`str | None`) and lowercase generics (`list[str]`, `dict[str, ...]`) which cause `TypeError` at import time on Python 3.9
- PEP 563 lazy evaluation makes all annotations strings, so they're never evaluated at runtime

Fixes #412

## Test plan
- [ ] Verify `python3.9 -c "import ast; ast.parse(open('conductor/bridge.py').read())"` passes
- [ ] Verify bridge starts without crash on macOS with `/usr/bin/python3` (3.9.6)
- [ ] Verify bridge still works on Python 3.10+ (no regression)