### PR TITLE
fix: _markdown_to_slack crashes on bullet list regex

### DIFF
--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -1395,7 +1395,7 @@ def create_slack_app(config: dict):
         # Links [text](url) -> <url|text>
         text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", text)
         # Bullet lists: - item or * item -> bullet char item
-        text = re.sub(r"^(\s*)[-*]\s+", r"\1\u2022 ", text, flags=re.MULTILINE)
+        text = re.sub(r"^(\s*)[-*]\s+", "\\1\u2022 ", text, flags=re.MULTILINE)
 
         # Restore inline code.
         for i, code in enumerate(inline_codes):

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -2191,6 +2191,13 @@ func TestBridgeTemplate_ContainsMarkdownToSlackConverter(t *testing.T) {
 		t.Error("template should contain bullet list regex ^(\\s*)[-*]\\s+")
 	}
 
+	// Regression: bullet replacement must NOT use r"..." prefix (#408).
+	// r"\1\u2022 " passes \u literally to re.sub, which crashes with "bad escape \u".
+	// The correct form is "\\1\u2022 " (non-raw string so \u2022 becomes the bullet char).
+	if strings.Contains(template, `r"\1\u2022 "`) {
+		t.Error("bullet replacement must not use raw string r\"\\1\\u2022 \" (causes re.error: bad escape \\u); use \"\\\\1\\u2022 \" instead (#408)")
+	}
+
 	// Code block protection.
 	if !strings.Contains(template, "code_blocks = []") {
 		t.Error("template should contain code block protection list")


### PR DESCRIPTION
## Summary

- Fix `re.error: bad escape \u` crash in `_markdown_to_slack` when converting bullet lists to Slack mrkdwn format
- Drop raw string prefix (`r"..."`) on the replacement so Python interprets `\u2022` as the Unicode bullet character instead of passing literal `\u` to `re.sub`
- Add regression test to prevent reintroduction

## Root Cause

The replacement string `r"\1\u2022 "` used a raw string prefix. In Python raw strings, `\u` is not interpreted as a Unicode escape, so `re.sub` received the literal backslash-u sequence and raised `re.error: bad escape \u at position 2`.

The fix changes it to `"\\1\u2022 "` (non-raw string) where `\\1` is the regex backreference and `\u2022` is the bullet character.

## Test plan

- [x] Verified old code crashes: `re.sub(r"^(\s*)[-*]\s+", r"\1\u2022 ", "- hello", flags=re.MULTILINE)` raises `re.error`
- [x] Verified fix works: `re.sub(r"^(\s*)[-*]\s+", "\\1\u2022 ", "- hello\n  - nested\n* star", flags=re.MULTILINE)` produces `• hello\n  • nested\n• star`
- [x] Regression test added in `conductor_test.go` to detect raw string usage

Closes #408