### PR TITLE
fix: prevent --no-wait from re-sending message (#479)

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1397,8 +1397,9 @@ func handleSessionSend(profile string, args []string) {
 	// default mode: full retry budget after readiness check.
 	if *noWait {
 		if err := sendWithRetryTarget(tmuxSess, message, false, sendRetryOptions{
-			maxRetries: 8,
-			checkDelay: 150 * time.Millisecond,
+			maxRetries:     8,
+			checkDelay:     150 * time.Millisecond,
+			maxFullResends: -1, // no-wait: message already delivered, never re-send
 		}); err != nil {
 			out.Error(fmt.Sprintf("failed to send message: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
@@ -1478,8 +1479,9 @@ type sendRetryTarget interface {
 }
 
 type sendRetryOptions struct {
-	maxRetries int
-	checkDelay time.Duration
+	maxRetries     int
+	checkDelay     time.Duration
+	maxFullResends int // >0 overrides default (3); <0 disables Ctrl+C-then-resend; 0 uses default
 }
 
 func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool, opts sendRetryOptions) error {
@@ -1515,7 +1517,12 @@ func sendWithRetryTarget(target sendRetryTarget, message string, skipVerify bool
 	// with no activity and no unsent prompt, assume the message was lost
 	// during TUI init and re-send the full message.
 	const fullResendThreshold = 8
-	const maxFullResends = 3
+	maxFullResends := 3 // default
+	if opts.maxFullResends > 0 {
+		maxFullResends = opts.maxFullResends
+	} else if opts.maxFullResends < 0 {
+		maxFullResends = 0
+	}
 	waitingNoMarkerChecks := 0
 	waitingNoActivityChecks := 0
 	activeChecks := 0

--- a/cmd/agent-deck/session_send_test.go
+++ b/cmd/agent-deck/session_send_test.go
@@ -459,6 +459,39 @@ func TestSendWithRetryTarget_FullResendMaxLimit(t *testing.T) {
 	}
 }
 
+func TestSendWithRetryTarget_NoWaitDoesNotResend(t *testing.T) {
+	// Regression test for issue #479: --no-wait sends message twice.
+	// When maxFullResends is negative (disabled), the verification loop
+	// must never Ctrl+C + re-send even if the session stays in "waiting"
+	// past the fullResendThreshold window.
+	n := 12
+	statuses := make([]string, n)
+	panes := make([]string, n)
+	for i := range statuses {
+		statuses[i] = "waiting"
+		panes[i] = ""
+	}
+	mock := &mockSendRetryTarget{
+		statuses: statuses,
+		panes:    panes,
+	}
+	err := sendWithRetryTarget(mock, "hello", false, sendRetryOptions{
+		maxRetries:     n,
+		checkDelay:     0,
+		maxFullResends: -1, // disabled, as used by --no-wait
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&mock.sendCtrlCCalls); got != 0 {
+		t.Fatalf("expected 0 SendCtrlC calls (resend disabled), got %d", got)
+	}
+	// Only the initial send, no resends
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
+		t.Fatalf("expected 1 SendKeysAndEnter call (initial only), got %d", got)
+	}
+}
+
 // skipIfNoTmuxServer skips the test if tmux is not available or not running.
 func skipIfNoTmuxServer(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
## Summary

- Fixes `session send --no-wait` delivering the message twice when the session hasn't transitioned to "active" within the fullResendThreshold window (8 × 150ms = 1.2s)
- Adds `maxFullResends` field to `sendRetryOptions` so `--no-wait` can disable the Ctrl+C-then-resend path while keeping Enter-nudge verification intact
- Default (wait) mode behavior is unchanged: zero-value `maxFullResends` still uses the default of 3

## Root Cause

The `--no-wait` path called `sendWithRetryTarget` with `maxRetries: 8` and `checkDelay: 150ms`. Since readiness waiting was skipped, the session stayed in "waiting" state. After 8 consecutive waiting checks, `waitingNoActivityChecks >= fullResendThreshold` triggered a `SendCtrlC()` + `SendKeysAndEnter()`, duplicating the already-delivered message.

## Test plan

- [x] New test `TestSendWithRetryTarget_NoWaitDoesNotResend` verifies zero Ctrl+C calls and exactly 1 SendKeysAndEnter when `maxFullResends: -1`
- [x] Existing `TestSendWithRetryTarget_FullResendAfterMessageLost` still passes (default resend behavior preserved)
- [x] Existing `TestSendWithRetryTarget_FullResendMaxLimit` still passes (cap at 3 resends preserved)
- [x] All 14 SendWithRetryTarget tests pass with `-race`
- [x] `go vet` clean

Closes #479