### PR TITLE
perf: launch sessions as initial tmux process (cherry-pick #389)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1910,7 +1910,7 @@ func (i *Instance) Start() error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed()
+	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
 	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
 
 	// Start the tmux session
@@ -2027,7 +2027,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed()
+	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
 	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
 
 	// Start the tmux session
@@ -4001,7 +4001,7 @@ func (i *Instance) Restart() error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed()
+	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
 	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
 
 	mcpLog.Debug("restart_starting_new_session", slog.String("command", command))

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -788,7 +788,12 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 	startWithInitialProcess := command != "" && s.RunCommandAsInitialProcess
 	args := []string{"new-session", "-d", "-s", s.Name, "-c", workDir}
 	if startWithInitialProcess {
-		args = append(args, command)
+		cmdToStart := command
+		if strings.Contains(command, "$(") || strings.Contains(command, "session_id=") {
+			escapedCmd := strings.ReplaceAll(command, "'", "'\"'\"'")
+			cmdToStart = fmt.Sprintf("bash -c '%s'", escapedCmd)
+		}
+		args = append(args, cmdToStart)
 	}
 
 	if !s.LaunchInUserScope {
@@ -1297,9 +1302,9 @@ func (s *Session) Start(command string) error {
 		workDir = os.Getenv("HOME")
 	}
 
-	// Create new tmux session in detached mode.
-	// Sandbox sessions launch command as the pane process for dead-pane restart.
-	// Non-sandbox sessions keep the legacy shell+send flow.
+	// Create new tmux session in detached mode with the command as the initial
+	// process. This avoids the slow shell-wait-sendkeys path (~2s pane ready poll).
+	// Commands containing bash-specific syntax are wrapped for fish compatibility.
 	launcher, args := s.startCommandSpec(workDir, command)
 	cmd := exec.Command(launcher, args...)
 	output, err := cmd.CombinedOutput()
@@ -1403,7 +1408,7 @@ func (s *Session) Start(command string) error {
 		}
 	}
 
-	// Legacy behavior for non-sandbox sessions: start shell first, then send command.
+	// Fallback: if RunCommandAsInitialProcess is false, send command via send-keys.
 	if command != "" && !s.RunCommandAsInitialProcess {
 		cmdToSend := command
 		// Commands containing bash-specific syntax must be wrapped for fish users.


### PR DESCRIPTION
## Summary
- For non-shell tools (claude, gemini, codex, etc.), pass the command directly to `tmux new-session` instead of polling for shell prompt readiness
- Eliminates ~1-2s of launch latency per session
- Shell sessions keep the legacy flow for status detection
- Commands with bash-specific syntax wrapped in `bash -c` for fish compatibility

Cherry-pick of #389 by @naps62, rebased onto current main.

## Test plan
- [ ] Verify claude/gemini/codex sessions launch without delay
- [ ] Verify shell sessions still work correctly
- [ ] Verify fish shell compatibility with bash-syntax commands