### PR TITLE
fix: defer notify-daemon delivery when conductor is busy

### DIFF
--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	transitionDeliverySent    = "sent"
-	transitionDeliveryFailed  = "failed"
-	transitionDeliveryDropped = "dropped_no_target"
+	transitionDeliverySent     = "sent"
+	transitionDeliveryFailed   = "failed"
+	transitionDeliveryDropped  = "dropped_no_target"
+	transitionDeliveryDeferred = "deferred_target_busy"
 )
 
 type TransitionNotificationEvent struct {
@@ -112,7 +113,10 @@ func (n *TransitionNotifier) NotifyTransition(event TransitionNotificationEvent)
 	}
 
 	result := n.dispatch(event)
-	n.markNotified(result)
+	// Don't mark deferred events as notified so the next poll cycle retries delivery.
+	if result.DeliveryResult != transitionDeliveryDeferred {
+		n.markNotified(result)
+	}
 	n.logEvent(result)
 	return result
 }
@@ -143,6 +147,17 @@ func (n *TransitionNotifier) dispatch(event TransitionNotificationEvent) Transit
 	parent := resolveParentNotificationTarget(child, byID)
 	if parent == nil {
 		event.DeliveryResult = transitionDeliveryDropped
+		return event
+	}
+
+	// Defer delivery when the target session is busy (running) to avoid
+	// interrupting its in-progress response. The event will be retried on
+	// the next daemon poll cycle since deferred events are not marked as notified.
+	_ = parent.UpdateStatus()
+	if parent.GetStatusThreadSafe() == StatusRunning {
+		event.TargetSessionID = parent.ID
+		event.TargetKind = "parent"
+		event.DeliveryResult = transitionDeliveryDeferred
 		return event
 	}
 

--- a/internal/session/transition_notifier_test.go
+++ b/internal/session/transition_notifier_test.go
@@ -70,6 +70,46 @@ func TestResolveParentNotificationTargetReturnsParent(t *testing.T) {
 	}
 }
 
+func TestResolveParentNotificationTargetSelfLoop(t *testing.T) {
+	self := &Instance{ID: "self", Title: "task", ParentSessionID: "self"}
+	byID := map[string]*Instance{"self": self}
+	got := resolveParentNotificationTarget(self, byID)
+	if got != nil {
+		t.Fatalf("expected nil for self-referencing parent, got %#v", got)
+	}
+}
+
+func TestDeferredEventNotMarkedAsNotified(t *testing.T) {
+	n := &TransitionNotifier{
+		statePath: t.TempDir() + "/state.json",
+		logPath:   t.TempDir() + "/log.jsonl",
+		state: transitionNotifyState{
+			Records: map[string]transitionNotifyRecord{},
+		},
+	}
+
+	event := TransitionNotificationEvent{
+		ChildSessionID: "child1",
+		ChildTitle:     "task",
+		Profile:        "_test",
+		FromStatus:     "running",
+		ToStatus:       "waiting",
+		Timestamp:      time.Now(),
+		DeliveryResult: transitionDeliveryDeferred,
+	}
+
+	// Simulate what NotifyTransition does for a deferred event:
+	// deferred events skip markNotified so they can be retried.
+	if event.DeliveryResult != transitionDeliveryDeferred {
+		n.markNotified(event)
+	}
+
+	// The event should NOT be in the dedup records, so isDuplicate returns false.
+	if n.isDuplicate(event) {
+		t.Fatal("deferred event should not be treated as duplicate")
+	}
+}
+
 func TestTerminalHookTransitionCandidate(t *testing.T) {
 	now := time.Now()
 


### PR DESCRIPTION
## Summary

Fixes #387. The notify-daemon now checks whether the target (parent/conductor) session is currently `running` before delivering transition notifications via `tmux send-keys`.

- When the target is `running` (busy generating a response), delivery is **deferred** with result `deferred_target_busy`
- Deferred events are **not marked as notified**, so the next daemon poll cycle will retry delivery
- Once the target transitions to `waiting`/`idle`, the notification is delivered normally

## Changes

- **`transition_notifier.go`**: Added `transitionDeliveryDeferred` constant. In `dispatch()`, added status check (`parent.UpdateStatus()` + `GetStatusThreadSafe()`) before sending. In `NotifyTransition()`, deferred events skip `markNotified()` to allow retry.
- **`transition_notifier_test.go`**: Added `TestDeferredEventNotMarkedAsNotified` (verifies deferred events bypass dedup) and `TestResolveParentNotificationTargetSelfLoop` (edge case coverage).

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./internal/session/...` passes (all existing + 2 new tests)
- [ ] Manual: set up conductor + child, verify notification deferred while conductor is running, delivered when waiting