### PR TITLE
fix: clear scrollback buffer before session attach (#419)

### DIFF
--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -68,6 +68,17 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 		return fmt.Errorf("session %s does not exist", s.Name)
 	}
 
+	// Clear scrollback before attaching to prevent stale content from a
+	// previously-attached session bleeding into the new one (#419).
+	// 1. Clear tmux's internal pane scrollback history.
+	clearTarget := s.Name + ":"
+	clearCmd := exec.Command("tmux", "clear-history", "-t", clearTarget)
+	_ = clearCmd.Run()
+	// 2. Clear the outer terminal emulator's scrollback buffer.
+	//    \033[3J is the "Erase Saved Lines" escape (ED param 3) supported
+	//    by iTerm2, Terminal.app, Ghostty, and most modern emulators.
+	_, _ = os.Stdout.WriteString("\033[3J")
+
 	// Create context with cancel for detach
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
## Summary
- Clears tmux's internal pane scrollback (`tmux clear-history`) and the outer terminal emulator's scrollback buffer (`\033[3J`) before each session attach
- Prevents the "palimpsest" effect where scrolling up after switching sessions shows the previous session's output
- Mirrors the existing fix in `RespawnPane` (for #138) but covers the attach/switch code path

## Root Cause
When detaching from session A (Ctrl+Q) and selecting session B, tmux redraws the visible viewport correctly but the outer terminal emulator (iTerm2, Ghostty, etc.) retains session A's output in its scrollback buffer. The `\033[3J` escape sequence (Erase Saved Lines, ED param 3) clears the terminal's scrollback before the new session's content starts rendering.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./internal/tmux/...` passes (pre-existing tmux-server-dependent test excluded)
- [x] `go test -race ./internal/ui/...` passes
- [ ] Manual: start two sessions, attach to A, detach (Ctrl+Q), attach to B, scroll up in terminal. Scrollback should be clean (no session A content)

Closes #419