### PR TITLE
feat: add window_style_override config option (cherry-pick #386)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1849,8 +1849,16 @@ func (i *Instance) loadCustomPatternsFromConfig() {
 // Returns nil if no overrides apply.
 func (i *Instance) buildTmuxOptionOverrides() map[string]string {
 	var overrides map[string]string
-	if tmuxCfg := GetTmuxSettings(); len(tmuxCfg.Options) > 0 {
+	tmuxCfg := GetTmuxSettings()
+	if len(tmuxCfg.Options) > 0 {
 		overrides = maps.Clone(tmuxCfg.Options)
+	}
+	if tmuxCfg.WindowStyleOverride != "" {
+		if overrides == nil {
+			overrides = make(map[string]string)
+		}
+		overrides["window-style"] = tmuxCfg.WindowStyleOverride
+		overrides["window-active-style"] = tmuxCfg.WindowStyleOverride
 	}
 	// Sandbox sessions need remain-on-exit so dead-pane detection works.
 	// Non-sandbox sessions use default tmux behaviour (pane closes on exit).

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -870,6 +870,14 @@ type TmuxSettings struct {
 	// scope is torn down. Default: false.
 	LaunchInUserScope bool `toml:"launch_in_user_scope"`
 
+	// WindowStyleOverride sets the tmux window-style (and window-active-style) for
+	// all sessions, overriding the theme default. Use "default" to let your terminal
+	// emulator's background show through instead of agent-deck's theme color.
+	// Empty string (default) means use the theme's built-in value.
+	// Takes precedence over the same keys in Options if both are set.
+	// Example: window_style_override = "default"
+	WindowStyleOverride string `toml:"window_style_override"`
+
 	// Options is a map of tmux option names to values.
 	// These are passed to `tmux set-option -t <session>` after defaults.
 	Options map[string]string `toml:"options"`
@@ -1774,6 +1782,9 @@ auto_cleanup = true
 # so they are not tied to the current login session scope (useful for SSH/tmux).
 # Default: false
 # launch_in_user_scope = true
+# window_style_override sets the tmux window-style for all sessions, overriding
+# the theme default. Use "default" to let your terminal's background show through.
+# window_style_override = "default"
 # Override tmux options applied to every session (applied after defaults)
 # Options matching agent-deck's managed keys (status, status-style,
 # status-left-length, status-right, status-right-length) will cause agent-deck

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1108,11 +1108,14 @@ func (s *Session) SetEnvironment(key, value string) error {
 
 func (s *Session) ApplyThemeOptions() error {
 	themeStyle := currentTmuxThemeStyle()
-	args := []string{
-		"set-option", "-t", s.Name, "window-style", themeStyle.windowStyle, ";",
-		"set-option", "-t", s.Name, "window-active-style", themeStyle.windowActiveStyle, ";",
-		"set-option", "-t", s.Name, "status-style", themeStyle.statusStyle,
+	var args []string
+	if _, ok := s.OptionOverrides["window-style"]; !ok {
+		args = append(args, "set-option", "-t", s.Name, "window-style", themeStyle.windowStyle, ";")
 	}
+	if _, ok := s.OptionOverrides["window-active-style"]; !ok {
+		args = append(args, "set-option", "-t", s.Name, "window-active-style", themeStyle.windowActiveStyle, ";")
+	}
+	args = append(args, "set-option", "-t", s.Name, "status-style", themeStyle.statusStyle)
 	if s.injectStatusLine {
 		args = append(args,
 			";", "set-option", "-t", s.Name, "status-right", s.themedStatusRight(themeStyle),
@@ -1352,16 +1355,22 @@ func (s *Session) Start(command string) error {
 	// via OptionOverrides to avoid changing behaviour for non-sandbox sessions.
 	themeStyle := currentTmuxThemeStyle()
 
-	_ = exec.Command("tmux",
-		"set-option", "-t", s.Name, "window-style", themeStyle.windowStyle, ";",
-		"set-option", "-t", s.Name, "window-active-style", themeStyle.windowActiveStyle, ";",
+	startArgs := make([]string, 0, 40)
+	if _, ok := s.OptionOverrides["window-style"]; !ok {
+		startArgs = append(startArgs, "set-option", "-t", s.Name, "window-style", themeStyle.windowStyle, ";")
+	}
+	if _, ok := s.OptionOverrides["window-active-style"]; !ok {
+		startArgs = append(startArgs, "set-option", "-t", s.Name, "window-active-style", themeStyle.windowActiveStyle, ";")
+	}
+	startArgs = append(startArgs,
 		"set-option", "-t", s.Name, "mouse", "on", ";",
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
 		"set-option", "-t", s.Name, "history-limit", "10000", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
 		"set", "-sq", "extended-keys", "on", ";",
-		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys").Run()
+		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys")
+	_ = exec.Command("tmux", startArgs...).Run()
 
 	// Bind Ctrl+Q to detach at the tmux level as fallback for terminals where
 	// XON/XOFF flow control intercepts the key before it reaches the PTY stdin


### PR DESCRIPTION
## Summary
- Adds `window_style_override` setting under `[tmux]` in config.toml
- Setting it to `"default"` lets the terminal's background show through (transparent terminal support)
- Refactors tmux option setup to conditionally skip window-style defaults when overrides are present

Cherry-pick of #386 by @daniel-shimon, rebased onto current main.

## Test plan
- [ ] Set `window_style_override = "default"` and verify terminal transparency works
- [ ] Verify default behavior unchanged without the setting
- [ ] Verify OptionOverrides still take precedence