### PR TITLE
feat(worktree): add configurable default checkbox state (cherry-pick #384)

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -639,6 +639,11 @@ type WorktreeSettings struct {
 	// AutoCleanup: remove worktree when session is deleted
 	AutoCleanup bool `toml:"auto_cleanup"`
 
+	// DefaultEnabled controls whether worktree creation is pre-selected in
+	// new-session and fork dialogs by default.
+	// Default: false
+	DefaultEnabled bool `toml:"default_enabled"`
+
 	// DefaultLocation: "sibling" (next to repo), "subdirectory" (inside .worktrees/),
 	// or a custom path (e.g., "~/worktrees") creating <path>/<repo_name>/<branch>
 	DefaultLocation string `toml:"default_location"`
@@ -1750,6 +1755,8 @@ default_tool = "claude"
 [worktree]
 # Where to create worktrees: "sibling" (next to repo) or "subdirectory" (inside repo)
 default_location = "sibling"
+# Pre-check "Create in worktree" in new-session and fork dialogs (default: false)
+# default_enabled = true
 # Automatically remove worktree when session is deleted
 auto_cleanup = true
 # Custom path template (overrides default_location if set)

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -393,6 +393,7 @@ func TestWorktreeConfig(t *testing.T) {
 	configContent := `
 [worktree]
 default_location = "subdirectory"
+default_enabled = true
 auto_cleanup = false
 `
 	configPath := filepath.Join(tmpDir, "config.toml")
@@ -409,6 +410,9 @@ auto_cleanup = false
 
 	if config.Worktree.DefaultLocation != "subdirectory" {
 		t.Errorf("Expected DefaultLocation 'subdirectory', got %q", config.Worktree.DefaultLocation)
+	}
+	if !config.Worktree.DefaultEnabled {
+		t.Error("Expected DefaultEnabled to be true")
 	}
 	if config.Worktree.AutoCleanup {
 		t.Error("Expected AutoCleanup to be false")
@@ -470,6 +474,7 @@ func TestGetWorktreeSettings_FromConfig(t *testing.T) {
 	config := &UserConfig{
 		Worktree: WorktreeSettings{
 			DefaultLocation: "subdirectory",
+			DefaultEnabled:  true,
 			AutoCleanup:     false,
 		},
 	}
@@ -479,6 +484,9 @@ func TestGetWorktreeSettings_FromConfig(t *testing.T) {
 	settings := GetWorktreeSettings()
 	if settings.DefaultLocation != "subdirectory" {
 		t.Errorf("GetWorktreeSettings DefaultLocation: got %q, want %q", settings.DefaultLocation, "subdirectory")
+	}
+	if !settings.DefaultEnabled {
+		t.Error("GetWorktreeSettings DefaultEnabled: should be true from config")
 	}
 	if settings.AutoCleanup {
 		t.Error("GetWorktreeSettings AutoCleanup: should be false from config")

--- a/internal/ui/forkdialog.go
+++ b/internal/ui/forkdialog.go
@@ -105,7 +105,7 @@ func (d *ForkDialog) Show(originalName, projectPath, groupPath string, conductor
 	d.branchInput.Blur()
 	d.optionsPanel.Blur()
 
-	// Reset worktree fields.
+	// Reset worktree fields from global config defaults.
 	d.worktreeEnabled = false
 	d.sandboxEnabled = false
 	d.isGitRepo = git.IsGitRepo(projectPath)
@@ -129,6 +129,7 @@ func (d *ForkDialog) Show(originalName, projectPath, groupPath string, conductor
 	if config, err := session.LoadUserConfig(); err == nil {
 		d.optionsPanel.SetDefaults(config)
 		d.sandboxEnabled = config.Docker.DefaultEnabled
+		d.worktreeEnabled = config.Worktree.DefaultEnabled
 	}
 }
 

--- a/internal/ui/forkdialog_test.go
+++ b/internal/ui/forkdialog_test.go
@@ -1,8 +1,12 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 func TestNewForkDialog(t *testing.T) {
@@ -29,6 +33,33 @@ func TestForkDialog_Show(t *testing.T) {
 	}
 	if group != "group/path" {
 		t.Errorf("Group = %s, want 'group/path'", group)
+	}
+}
+
+func TestForkDialog_Show_UsesConfiguredWorktreeDefault(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	session.ClearUserConfigCache()
+	defer session.ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Worktree: session.WorktreeSettings{DefaultEnabled: true},
+	}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	session.ClearUserConfigCache()
+
+	d := NewForkDialog()
+	d.Show("Original Session", "/path/to/project", "group/path", nil, "")
+
+	if !d.worktreeEnabled {
+		t.Error("worktreeEnabled should default to true from config on Show")
 	}
 }
 

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -338,7 +338,7 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.codexOptions.Blur()
 	// Keep commandCursor at previously set default (don't reset to 0)
 	d.updateToolOptions()
-	// Reset worktree fields.
+	// Reset worktree fields from global config defaults.
 	d.worktreeEnabled = false
 	d.branchInput.SetValue("")
 	d.branchAutoSet = false
@@ -370,6 +370,7 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 		d.codexOptions.SetDefaults(userConfig.Codex.YoloMode)
 		d.claudeOptions.SetDefaults(userConfig)
 		d.sandboxEnabled = userConfig.Docker.DefaultEnabled
+		d.worktreeEnabled = userConfig.Worktree.DefaultEnabled
 		d.inheritedSettings = buildInheritedSettings(userConfig.Docker)
 		d.branchPrefix = userConfig.Worktree.Prefix()
 	}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -599,6 +600,33 @@ func TestNewDialog_ShowInGroup_ResetsMultiRepo(t *testing.T) {
 	}
 	if dialog.multiRepoEditing {
 		t.Error("multiRepoEditing should be false on ShowInGroup")
+	}
+}
+
+func TestNewDialog_ShowInGroup_UsesConfiguredWorktreeDefault(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	session.ClearUserConfigCache()
+	defer session.ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Worktree: session.WorktreeSettings{DefaultEnabled: true},
+	}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	session.ClearUserConfigCache()
+
+	dialog := NewNewDialog()
+	dialog.ShowInGroup("projects", "Projects", "", nil, "")
+
+	if !dialog.worktreeEnabled {
+		t.Error("worktreeEnabled should default to true from config on ShowInGroup")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `default_enabled` setting under `[worktree]` in config.toml
- When true, worktree checkbox is pre-selected in new session and fork dialogs
- Includes tests for both NewDialog and ForkDialog

Cherry-pick of #384 by @qzchenwl, rebased onto current main.

## Test plan
- [ ] Set `default_enabled = true` under `[worktree]`, verify checkbox pre-selected
- [ ] Verify default behavior unchanged without the setting
- [ ] Tests pass: `go test -race -run 'WorktreeDefault' ./internal/ui/...`