### PR TITLE
feat(ui): keep branch picker inside tui (cherry-pick #379)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -358,6 +359,126 @@ func SanitizeBranchName(name string) string {
 	sanitized = strings.Trim(sanitized, "-")
 
 	return sanitized
+}
+
+func getDefaultRemote(repoDir string) (string, error) {
+	remotes, err := listRemotes(repoDir)
+	if err != nil {
+		return "", err
+	}
+	if len(remotes) == 0 {
+		return "", errors.New("no git remotes configured")
+	}
+
+	currentBranch, err := GetCurrentBranch(repoDir)
+	if err == nil && currentBranch != "" && currentBranch != "HEAD" {
+		cmd := exec.Command("git", "-C", repoDir, "config", "--get", "branch."+currentBranch+".remote")
+		output, err := cmd.Output()
+		if err == nil {
+			remote := strings.TrimSpace(string(output))
+			if remote != "" {
+				return remote, nil
+			}
+		}
+	}
+
+	for _, remote := range remotes {
+		if remote == "origin" {
+			return remote, nil
+		}
+	}
+
+	if len(remotes) == 1 {
+		return remotes[0], nil
+	}
+
+	return "", fmt.Errorf("could not determine default remote from %d remotes", len(remotes))
+}
+
+func listRemotes(repoDir string) ([]string, error) {
+	cmd := exec.Command("git", "-C", repoDir, "remote")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list remotes: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	var remotes []string
+	for _, line := range lines {
+		remote := strings.TrimSpace(line)
+		if remote != "" {
+			remotes = append(remotes, remote)
+		}
+	}
+	return remotes, nil
+}
+
+func listRefShortNames(repoDir string, refs ...string) ([]string, error) {
+	args := []string{"-C", repoDir, "for-each-ref", "--format=%(refname:short)"}
+	args = append(args, refs...)
+	cmd := exec.Command("git", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list refs: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	var names []string
+	for _, line := range lines {
+		name := strings.TrimSpace(line)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// ListBranchCandidates returns unique branch names from local branches and all
+// configured remotes. Local branches use plain names; remote branches keep
+// their remote prefix (for example "origin/main").
+func ListBranchCandidates(repoDir string) ([]string, error) {
+	if !IsGitRepo(repoDir) {
+		return nil, errors.New("not a git repository")
+	}
+
+	repoRoot, err := GetWorktreeBaseRoot(repoDir)
+	if err == nil && repoRoot != "" {
+		repoDir = repoRoot
+	}
+
+	branches, err := listRefShortNames(repoDir, "refs/heads")
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(branches))
+	for _, branch := range branches {
+		seen[branch] = struct{}{}
+	}
+
+	remotes, err := listRemotes(repoDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, remote := range remotes {
+		remoteBranches, err := listRefShortNames(repoDir, "refs/remotes/"+remote)
+		if err != nil {
+			return nil, err
+		}
+		for _, branch := range remoteBranches {
+			if branch == remote || branch == remote+"/HEAD" {
+				continue
+			}
+			seen[branch] = struct{}{}
+		}
+	}
+
+	branches = branches[:0]
+	for branch := range seen {
+		branches = append(branches, branch)
+	}
+	sort.Strings(branches)
+	return branches, nil
 }
 
 // HasUncommittedChanges checks if the repository at dir has uncommitted changes

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -61,6 +61,18 @@ func createBranch(t *testing.T, dir, branchName string) {
 	}
 }
 
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, strings.TrimSpace(string(output)))
+	}
+	return strings.TrimSpace(string(output))
+}
+
 func TestIsGitRepo(t *testing.T) {
 	t.Run("returns true for git repo", func(t *testing.T) {
 		dir := t.TempDir()
@@ -512,6 +524,60 @@ func TestCreateWorktree(t *testing.T) {
 			t.Error("expected error for non-git directory")
 		}
 	})
+}
+
+func TestListBranchCandidates(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+
+	remoteDir := filepath.Join(t.TempDir(), "origin.git")
+	if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+		t.Fatalf("failed to create remote dir: %v", err)
+	}
+	runGit(t, remoteDir, "init", "--bare")
+	runGit(t, dir, "remote", "add", "origin", remoteDir)
+	runGit(t, dir, "push", "-u", "origin", "main")
+	runGit(t, dir, "checkout", "-b", "feature/local-only")
+	runGit(t, dir, "checkout", "main")
+	runGit(t, dir, "checkout", "-b", "feature/remote-only")
+	runGit(t, dir, "push", "-u", "origin", "feature/remote-only")
+	runGit(t, dir, "checkout", "main")
+	runGit(t, dir, "branch", "-D", "feature/remote-only")
+
+	secondRemoteDir := filepath.Join(t.TempDir(), "qzchenwl.git")
+	if err := os.MkdirAll(secondRemoteDir, 0o755); err != nil {
+		t.Fatalf("failed to create second remote dir: %v", err)
+	}
+	runGit(t, secondRemoteDir, "init", "--bare")
+	runGit(t, dir, "remote", "add", "qzchenwl", secondRemoteDir)
+	runGit(t, dir, "checkout", "-b", "feature/fork-remote")
+	runGit(t, dir, "push", "-u", "qzchenwl", "feature/fork-remote")
+	runGit(t, dir, "checkout", "main")
+	runGit(t, dir, "branch", "-D", "feature/fork-remote")
+
+	branches, err := ListBranchCandidates(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !containsString(branches, "feature/local-only") {
+		t.Fatalf("expected local branch in candidates: %v", branches)
+	}
+	if !containsString(branches, "origin/feature/remote-only") {
+		t.Fatalf("expected origin remote-only branch in candidates: %v", branches)
+	}
+	if !containsString(branches, "qzchenwl/feature/fork-remote") {
+		t.Fatalf("expected second remote branch in candidates: %v", branches)
+	}
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestListWorktrees(t *testing.T) {

--- a/internal/ui/branch_picker.go
+++ b/internal/ui/branch_picker.go
@@ -1,0 +1,237 @@
+package ui
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+var loadBranchCandidates = branchCandidatesForPath
+
+// branchPickerResultMsg is kept for compatibility with existing dialog message handling.
+type branchPickerResultMsg struct {
+	branch   string
+	canceled bool
+	err      error
+}
+
+// BranchPickerDialog is an in-TUI branch picker with inline filtering.
+type BranchPickerDialog struct {
+	visible     bool
+	width       int
+	height      int
+	allBranches []string
+	branches    []string
+	cursor      int
+	offset      int
+}
+
+func NewBranchPickerDialog() *BranchPickerDialog {
+	return &BranchPickerDialog{}
+}
+
+func branchCandidatesForPath(projectPath string) ([]string, error) {
+	projectPath = session.ExpandPath(strings.Trim(strings.TrimSpace(projectPath), "'\""))
+	if projectPath == "" {
+		return nil, errors.New("project path is empty")
+	}
+
+	repoRoot, err := git.GetWorktreeBaseRoot(projectPath)
+	if err != nil {
+		return nil, errors.New("path is not a git repository")
+	}
+
+	branches, err := git.ListBranchCandidates(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	if len(branches) == 0 {
+		return nil, errors.New("no branches found in repository")
+	}
+
+	return branches, nil
+}
+
+func (d *BranchPickerDialog) SetSize(width, height int) {
+	d.width = width
+	d.height = height
+}
+
+func (d *BranchPickerDialog) IsVisible() bool {
+	return d.visible
+}
+
+func (d *BranchPickerDialog) Hide() {
+	d.visible = false
+	d.allBranches = nil
+	d.branches = nil
+	d.cursor = 0
+	d.offset = 0
+}
+
+func (d *BranchPickerDialog) Show(projectPath, query string) error {
+	branches, err := loadBranchCandidates(projectPath)
+	if err != nil {
+		return err
+	}
+
+	d.visible = true
+	d.allBranches = branches
+	d.cursor = 0
+	d.offset = 0
+	d.SetQuery(query)
+	return nil
+}
+
+func (d *BranchPickerDialog) SetQuery(query string) {
+	d.filter(query)
+}
+
+func (d *BranchPickerDialog) filter(query string) {
+	query = strings.ToLower(strings.TrimSpace(query))
+	d.branches = d.branches[:0]
+	for _, branch := range d.allBranches {
+		if query == "" || strings.Contains(strings.ToLower(branch), query) {
+			d.branches = append(d.branches, branch)
+		}
+	}
+	if len(d.branches) == 0 {
+		d.cursor = 0
+		d.offset = 0
+		return
+	}
+	if d.cursor >= len(d.branches) {
+		d.cursor = len(d.branches) - 1
+	}
+	if d.cursor < 0 {
+		d.cursor = 0
+	}
+	d.ensureCursorVisible()
+}
+
+func (d *BranchPickerDialog) maxVisibleRows() int {
+	if d.height <= 0 {
+		return 6
+	}
+	rows := d.height / 4
+	if rows < 4 {
+		rows = 4
+	}
+	if rows > 8 {
+		rows = 8
+	}
+	return rows
+}
+
+func (d *BranchPickerDialog) ensureCursorVisible() {
+	rows := d.maxVisibleRows()
+	if d.cursor < d.offset {
+		d.offset = d.cursor
+	}
+	if d.cursor >= d.offset+rows {
+		d.offset = d.cursor - rows + 1
+	}
+	if d.offset < 0 {
+		d.offset = 0
+	}
+	maxOffset := len(d.branches) - rows
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if d.offset > maxOffset {
+		d.offset = maxOffset
+	}
+}
+
+// Update handles list navigation keys. Text entry should remain in the parent input.
+func (d *BranchPickerDialog) Update(msg tea.KeyMsg) (string, bool) {
+	if !d.visible {
+		return "", false
+	}
+
+	switch msg.String() {
+	case "esc":
+		d.Hide()
+		return "", true
+	case "enter":
+		if len(d.branches) == 0 {
+			return "", true
+		}
+		selected := d.branches[d.cursor]
+		d.Hide()
+		return selected, true
+	case "up", "ctrl+k", "ctrl+p":
+		if len(d.branches) > 0 && d.cursor > 0 {
+			d.cursor--
+			d.ensureCursorVisible()
+		}
+		return "", true
+	case "down", "ctrl+j", "ctrl+n":
+		if len(d.branches) > 0 && d.cursor < len(d.branches)-1 {
+			d.cursor++
+			d.ensureCursorVisible()
+		}
+		return "", true
+	}
+
+	return "", false
+}
+
+func (d *BranchPickerDialog) View() string {
+	if !d.visible {
+		return ""
+	}
+
+	labelStyle := lipgloss.NewStyle().
+		Foreground(ColorComment)
+	selectedStyle := lipgloss.NewStyle().
+		Foreground(ColorCyan).
+		Bold(true)
+	itemStyle := lipgloss.NewStyle().
+		Foreground(ColorComment)
+
+	var body strings.Builder
+	total := len(d.branches)
+	rows := d.maxVisibleRows()
+	startIdx := d.offset
+	endIdx := startIdx + rows
+	if endIdx > total {
+		endIdx = total
+	}
+
+	body.WriteString(labelStyle.Render("─ branches (↑↓/Enter/Esc) ─"))
+	body.WriteString("\n")
+
+	if total == 0 {
+		body.WriteString(labelStyle.Render("    No matching branches"))
+		return body.String()
+	}
+
+	if startIdx > 0 {
+		body.WriteString(labelStyle.Render(fmt.Sprintf("    ↑ %d more above", startIdx)))
+		body.WriteString("\n")
+	}
+
+	for i := startIdx; i < endIdx; i++ {
+		prefix := "    "
+		style := itemStyle
+		if i == d.cursor {
+			prefix = "  ▶ "
+			style = selectedStyle
+		}
+		body.WriteString(style.Render(prefix + d.branches[i]))
+		body.WriteString("\n")
+	}
+
+	if endIdx < total {
+		body.WriteString(labelStyle.Render(fmt.Sprintf("    ↓ %d more below", total-endIdx)))
+	}
+
+	return body.String()
+}

--- a/internal/ui/forkdialog.go
+++ b/internal/ui/forkdialog.go
@@ -29,6 +29,7 @@ type ForkDialog struct {
 	// Worktree support
 	worktreeEnabled bool
 	branchInput     textinput.Model
+	branchPicker    *BranchPickerDialog
 	isGitRepo       bool
 	// Docker sandbox support
 	sandboxEnabled bool
@@ -59,6 +60,7 @@ func NewForkDialog() *ForkDialog {
 		nameInput:    nameInput,
 		groupInput:   groupInput,
 		branchInput:  branchInput,
+		branchPicker: NewBranchPickerDialog(),
 		optionsPanel: NewClaudeOptionsPanelForFork(),
 	}
 }
@@ -103,6 +105,9 @@ func (d *ForkDialog) Show(originalName, projectPath, groupPath string, conductor
 	d.nameInput.Focus()
 	d.groupInput.Blur()
 	d.branchInput.Blur()
+	if d.branchPicker != nil {
+		d.branchPicker.Hide()
+	}
 	d.optionsPanel.Blur()
 
 	// Reset worktree fields from global config defaults.
@@ -139,12 +144,20 @@ func (d *ForkDialog) Hide() {
 	d.nameInput.Blur()
 	d.groupInput.Blur()
 	d.branchInput.Blur()
+	if d.branchPicker != nil {
+		d.branchPicker.Hide()
+	}
 	d.optionsPanel.Blur()
 }
 
 // IsVisible returns whether the dialog is visible
 func (d *ForkDialog) IsVisible() bool {
 	return d.visible
+}
+
+// IsBranchPickerOpen returns whether the inline branch result list is visible.
+func (d *ForkDialog) IsBranchPickerOpen() bool {
+	return d.branchPicker != nil && d.branchPicker.IsVisible()
 }
 
 // GetValues returns the current input values
@@ -170,6 +183,9 @@ func (d *ForkDialog) GetOptions() *session.ClaudeOptions {
 func (d *ForkDialog) SetSize(width, height int) {
 	d.width = width
 	d.height = height
+	if d.branchPicker != nil {
+		d.branchPicker.SetSize(width, height)
+	}
 }
 
 // ToggleWorktree toggles the worktree checkbox
@@ -246,6 +262,20 @@ func (d *ForkDialog) Update(msg tea.Msg) (*ForkDialog, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if d.branchPicker != nil && d.branchPicker.IsVisible() {
+			if selected, handled := d.branchPicker.Update(msg); handled {
+				if d.branchPicker == nil || !d.branchPicker.IsVisible() {
+					d.branchInput.Focus()
+				}
+				if selected != "" {
+					d.branchInput.SetValue(selected)
+					d.branchInput.SetCursor(len(selected))
+					d.ClearError()
+				}
+				return d, nil
+			}
+		}
+
 		switch msg.String() {
 		case "tab", "down":
 			cIdx := d.conductorFocusIndex()
@@ -349,6 +379,21 @@ func (d *ForkDialog) Update(msg tea.Msg) (*ForkDialog, tea.Cmd) {
 				return d, nil
 			}
 
+		case "ctrl+f":
+			if d.focusIndex == 2 && d.worktreeEnabled {
+				if d.branchPicker == nil {
+					d.branchPicker = NewBranchPickerDialog()
+				}
+				d.branchPicker.SetSize(d.width, d.height)
+				if err := d.branchPicker.Show(d.projectPath, d.branchInput.Value()); err != nil {
+					d.SetError(err.Error())
+				} else {
+					d.ClearError()
+					d.branchInput.Focus()
+				}
+				return d, nil
+			}
+
 		case "s":
 			// Toggle sandbox when on group field.
 			if d.focusIndex == 1 {
@@ -373,7 +418,11 @@ func (d *ForkDialog) Update(msg tea.Msg) (*ForkDialog, tea.Cmd) {
 		d.groupInput, cmd = d.groupInput.Update(msg)
 	case 2:
 		if d.worktreeEnabled {
+			oldBranch := d.branchInput.Value()
 			d.branchInput, cmd = d.branchInput.Update(msg)
+			if d.branchInput.Value() != oldBranch && d.branchPicker != nil && d.branchPicker.IsVisible() {
+				d.branchPicker.SetQuery(d.branchInput.Value())
+			}
 		} else {
 			cmd = d.optionsPanel.Update(msg)
 		}
@@ -526,6 +575,9 @@ func (d *ForkDialog) View() string {
 			}
 			worktreeSection += "\n"
 			worktreeSection += "  " + d.branchInput.View() + "\n"
+			if d.branchPicker != nil && d.branchPicker.IsVisible() {
+				worktreeSection += "  " + strings.ReplaceAll(d.branchPicker.View(), "\n", "\n  ") + "\n"
+			}
 		}
 	}
 
@@ -551,6 +603,15 @@ func (d *ForkDialog) View() string {
 		errLine = "\n" + errStyle.Render("  ⚠ "+d.validationErr) + "\n"
 	}
 
+	helpText := "Enter create │ Esc cancel │ Tab next │ s sandbox │ Space toggle"
+	if d.focusIndex == 2 && d.worktreeEnabled {
+		if d.branchPicker != nil && d.branchPicker.IsVisible() {
+			helpText = "Type filter │ ↑↓ navigate │ Enter select │ Esc close"
+		} else {
+			helpText = "^F branch search │ Enter create │ Esc cancel │ Tab next"
+		}
+	}
+
 	content := titleStyle.Render("Fork Session") + "\n\n" +
 		nameLabel + "\n" +
 		"  " + d.nameInput.View() + "\n\n" +
@@ -562,7 +623,7 @@ func (d *ForkDialog) View() string {
 		d.optionsPanel.View() +
 		errLine + "\n" +
 		lipgloss.NewStyle().Foreground(ColorComment).
-			Render("Enter create │ Esc cancel │ Tab next │ s sandbox │ Space toggle")
+			Render(helpText)
 
 	dialog := boxStyle.Render(content)
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4384,6 +4384,13 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.newDialog, cmd = h.newDialog.Update(msg)
 		return h, cmd
 	}
+	// When branch search results are visible, let the dialog consume Enter/Esc/navigation
+	// before the outer dialog-level handlers create/cancel the session.
+	if h.newDialog.IsBranchPickerOpen() {
+		var cmd tea.Cmd
+		h.newDialog, cmd = h.newDialog.Update(msg)
+		return h, cmd
+	}
 
 	switch msg.String() {
 	case "enter":
@@ -6161,6 +6168,12 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // handleForkDialogKey handles keyboard input for the fork dialog
 func (h *Home) handleForkDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if h.forkDialog.IsBranchPickerOpen() {
+		var cmd tea.Cmd
+		h.forkDialog, cmd = h.forkDialog.Update(msg)
+		return h, cmd
+	}
+
 	switch msg.String() {
 	case "enter":
 		// Validate before proceeding

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -169,6 +169,7 @@ type NewDialog struct {
 	branchInput     textinput.Model
 	branchAutoSet   bool   // true if branch was auto-derived from session name.
 	branchPrefix    string // configured prefix for auto-generated branch names.
+	branchPicker    *BranchPickerDialog
 	// Docker sandbox support.
 	sandboxEnabled    bool
 	inheritedExpanded bool             // whether the inherited settings section is expanded.
@@ -289,6 +290,7 @@ func NewNewDialog() *NewDialog {
 		pathInput:       pathInput,
 		commandInput:    commandInput,
 		branchInput:     branchInput,
+		branchPicker:    NewBranchPickerDialog(),
 		claudeOptions:   NewClaudeOptionsPanel(),
 		geminiOptions:   NewYoloOptionsPanel("Gemini", "YOLO mode - auto-approve all"),
 		codexOptions:    NewYoloOptionsPanel("Codex", "YOLO mode - bypass approvals and sandbox"),
@@ -336,6 +338,9 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.claudeOptions.Blur()
 	d.geminiOptions.Blur()
 	d.codexOptions.Blur()
+	if d.branchPicker != nil {
+		d.branchPicker.Hide()
+	}
 	// Keep commandCursor at previously set default (don't reset to 0)
 	d.updateToolOptions()
 	// Reset worktree fields from global config defaults.
@@ -409,6 +414,9 @@ func (d *NewDialog) GetSelectedGroup() string {
 func (d *NewDialog) SetSize(width, height int) {
 	d.width = width
 	d.height = height
+	if d.branchPicker != nil {
+		d.branchPicker.SetSize(width, height)
+	}
 }
 
 // SetPathSuggestions sets the available path suggestions for autocomplete
@@ -421,6 +429,11 @@ func (d *NewDialog) SetPathSuggestions(paths []string) {
 // IsRecentPickerOpen returns whether the recent sessions picker is visible.
 func (d *NewDialog) IsRecentPickerOpen() bool {
 	return d.showRecentPicker && len(d.recentSessions) > 0
+}
+
+// IsBranchPickerOpen returns whether the inline branch result list is visible.
+func (d *NewDialog) IsBranchPickerOpen() bool {
+	return d.branchPicker != nil && d.branchPicker.IsVisible()
 }
 
 // SetRecentSessions sets the list of recently deleted session configs.
@@ -578,6 +591,9 @@ func (d *NewDialog) Show() {
 // Hide hides the dialog
 func (d *NewDialog) Hide() {
 	d.visible = false
+	if d.branchPicker != nil {
+		d.branchPicker.Hide()
+	}
 }
 
 // IsVisible returns whether the dialog is visible
@@ -940,6 +956,21 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if d.branchPicker != nil && d.branchPicker.IsVisible() {
+			if selected, handled := d.branchPicker.Update(msg); handled {
+				if d.branchPicker == nil || !d.branchPicker.IsVisible() {
+					d.branchInput.Focus()
+				}
+				if selected != "" {
+					d.branchInput.SetValue(selected)
+					d.branchInput.SetCursor(len(selected))
+					d.branchAutoSet = false
+					d.ClearError()
+				}
+				return d, nil
+			}
+		}
+
 		// Recent sessions picker handling
 		if d.showRecentPicker && len(d.recentSessions) > 0 {
 			switch msg.String() {
@@ -1080,6 +1111,21 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 					d.pathSuggestionCursor = len(d.pathSuggestions) - 1
 				}
 				d.suggestionNavigated = true
+				return d, nil
+			}
+
+		case "ctrl+f":
+			if cur == focusBranch {
+				if d.branchPicker == nil {
+					d.branchPicker = NewBranchPickerDialog()
+				}
+				d.branchPicker.SetSize(d.width, d.height)
+				if err := d.branchPicker.Show(strings.Trim(strings.TrimSpace(d.pathInput.Value()), "'\""), d.branchInput.Value()); err != nil {
+					d.SetError(err.Error())
+				} else {
+					d.ClearError()
+					d.branchInput.Focus()
+				}
 				return d, nil
 			}
 
@@ -1346,6 +1392,9 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 		d.branchInput, cmd = d.branchInput.Update(msg)
 		if d.branchInput.Value() != oldBranch {
 			d.branchAutoSet = false
+			if d.branchPicker != nil && d.branchPicker.IsVisible() {
+				d.branchPicker.SetQuery(d.branchInput.Value())
+			}
 		}
 	case focusOptions:
 		if d.toolOptions != nil {
@@ -1717,6 +1766,11 @@ func (d *NewDialog) View() string {
 		content.WriteString("  ")
 		content.WriteString(d.branchInput.View())
 		content.WriteString("\n")
+		if d.branchPicker != nil && d.branchPicker.IsVisible() {
+			content.WriteString("  ")
+			content.WriteString(strings.ReplaceAll(d.branchPicker.View(), "\n", "\n  "))
+			content.WriteString("\n")
+		}
 	}
 
 	// Tool options panel
@@ -1748,6 +1802,12 @@ func (d *NewDialog) View() string {
 			helpText = "Type to replace │ ←→ to edit │ ^N/^P recent │ Tab next │ Esc cancel"
 		} else {
 			helpText = "Tab autocomplete │ ^N/^P recent │ ↑↓ navigate │ Enter create │ Esc cancel"
+		}
+	} else if cur == focusBranch {
+		if d.branchPicker != nil && d.branchPicker.IsVisible() {
+			helpText = "Type filter │ ↑↓ navigate │ Enter select │ Esc close"
+		} else {
+			helpText = "^F branch search │ Tab next │ Enter create │ Esc cancel"
 		}
 	} else if cur == focusCommand {
 		selectedCmd := d.GetSelectedCommand()


### PR DESCRIPTION
## Summary
- Replaces external fzf dependency with native in-TUI branch picker
- Lists all local and remote branches with fuzzy filtering
- Keyboard navigation: up/down, Enter to select, Esc to close
- Integrates into both new session and fork dialogs
- Adds git helpers for listing branch candidates across all remotes

Cherry-pick of #379 by @qzchenwl, rebased onto current main. Adapted to current codebase (removed dependency on unmerged PR #370 functions).

## Test plan
- [ ] Press Ctrl+F on branch field in new session dialog, verify picker appears
- [ ] Type to filter branches, verify fuzzy matching works
- [ ] Select a branch with Enter, verify it populates the input
- [ ] Press Esc to close picker without selecting
- [ ] Tests pass: `go test -race -run 'BranchPicker|BranchCandidates' ./internal/...`