### PR TITLE
fix(ui): quick-create strips resume fields so new sessions start fresh

### DIFF
--- a/internal/session/tooloptions.go
+++ b/internal/session/tooloptions.go
@@ -282,6 +282,35 @@ func UnmarshalOpenCodeOptions(data json.RawMessage) (*OpenCodeOptions, error) {
 	return &opts, nil
 }
 
+// StripResumeFields removes session-specific fields (resume_session_id,
+// session_mode) from serialized ToolOptionsJSON so that a new session
+// inheriting another session's settings starts fresh instead of resuming
+// the source conversation.  Other options (skip_permissions, etc.) are
+// preserved.  Returns the input unchanged when it is nil/empty or when
+// unmarshalling fails.
+func StripResumeFields(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+
+	var wrapper struct {
+		Tool    string         `json:"tool"`
+		Options map[string]any `json:"options"`
+	}
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		return raw
+	}
+
+	delete(wrapper.Options, "resume_session_id")
+	delete(wrapper.Options, "session_mode")
+
+	cleaned, err := json.Marshal(wrapper)
+	if err != nil {
+		return raw
+	}
+	return cleaned
+}
+
 // UnmarshalClaudeOptions deserializes ClaudeOptions from JSON wrapper
 func UnmarshalClaudeOptions(data json.RawMessage) (*ClaudeOptions, error) {
 	if len(data) == 0 {

--- a/internal/session/tooloptions_test.go
+++ b/internal/session/tooloptions_test.go
@@ -774,6 +774,89 @@ func TestUnmarshalOpenCodeOptions_WrongTool(t *testing.T) {
 	}
 }
 
+func TestStripResumeFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          json.RawMessage
+		wantSessionID  string
+		wantMode       string
+		wantSkipPerms  bool
+		wantPassthrough bool // true = expect input returned unchanged
+	}{
+		{
+			name:            "nil input",
+			input:           nil,
+			wantPassthrough: true,
+		},
+		{
+			name:            "empty input",
+			input:           json.RawMessage{},
+			wantPassthrough: true,
+		},
+		{
+			name: "strips resume fields, preserves skip_permissions",
+			input: mustMarshalToolOptions(&ClaudeOptions{
+				SessionMode:     "resume",
+				ResumeSessionID: "abc-123",
+				SkipPermissions: true,
+			}),
+			wantSessionID: "",
+			wantMode:      "",
+			wantSkipPerms: true,
+		},
+		{
+			name: "no resume fields present",
+			input: mustMarshalToolOptions(&ClaudeOptions{
+				SkipPermissions: true,
+				UseChrome:       true,
+			}),
+			wantSessionID: "",
+			wantMode:      "",
+			wantSkipPerms: true,
+		},
+		{
+			name:            "invalid JSON returns input unchanged",
+			input:           json.RawMessage(`{not valid`),
+			wantPassthrough: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripResumeFields(tt.input)
+
+			if tt.wantPassthrough {
+				if string(got) != string(tt.input) {
+					t.Errorf("expected passthrough, got %s", got)
+				}
+				return
+			}
+
+			opts, err := UnmarshalClaudeOptions(got)
+			if err != nil {
+				t.Fatalf("UnmarshalClaudeOptions failed: %v", err)
+			}
+			if opts.ResumeSessionID != tt.wantSessionID {
+				t.Errorf("ResumeSessionID = %q, want %q", opts.ResumeSessionID, tt.wantSessionID)
+			}
+			if opts.SessionMode != tt.wantMode {
+				t.Errorf("SessionMode = %q, want %q", opts.SessionMode, tt.wantMode)
+			}
+			if opts.SkipPermissions != tt.wantSkipPerms {
+				t.Errorf("SkipPermissions = %v, want %v", opts.SkipPermissions, tt.wantSkipPerms)
+			}
+		})
+	}
+}
+
+func mustMarshalToolOptions(opts ToolOptions) json.RawMessage {
+	data, err := MarshalToolOptions(opts)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
 func TestClaudeOptions_RoundTrip(t *testing.T) {
 	// Test complete round-trip serialization
 	original := &ClaudeOptions{

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6735,7 +6735,7 @@ func (h *Home) quickCreateSession() tea.Cmd {
 		tool = sourceSession.Tool
 		command = sourceSession.Command
 		if len(sourceSession.ToolOptionsJSON) > 0 {
-			toolOptionsJSON = sourceSession.ToolOptionsJSON
+			toolOptionsJSON = session.StripResumeFields(sourceSession.ToolOptionsJSON)
 		}
 		if sourceSession.GeminiYoloMode != nil && *sourceSession.GeminiYoloMode {
 			geminiYoloMode = true
@@ -6760,7 +6760,7 @@ func (h *Home) quickCreateSession() tea.Cmd {
 			tool = mostRecent.Tool
 			command = mostRecent.Command
 			if len(mostRecent.ToolOptionsJSON) > 0 {
-				toolOptionsJSON = mostRecent.ToolOptionsJSON
+				toolOptionsJSON = session.StripResumeFields(mostRecent.ToolOptionsJSON)
 			}
 			if mostRecent.GeminiYoloMode != nil && *mostRecent.GeminiYoloMode {
 				geminiYoloMode = true


### PR DESCRIPTION
## Summary

- Extracts `StripResumeFields()` helper in `internal/session/tooloptions.go` that removes `resume_session_id` and `session_mode` from serialized `ToolOptionsJSON`
- Calls the helper in both inheritance paths of `quickCreateSession()` (cursor-on-session and most-recent-in-group)
- Adds table-driven unit tests covering: resume fields stripped, other options preserved, nil/empty/invalid input passthrough

Supersedes #424 (same fix, but deduplicates the repeated code block into a reusable helper).

Closes #424

## Test plan

- [x] `go test -race -v -run TestStripResumeFields ./internal/session/...` passes
- [x] `go build ./...` passes
- [ ] Shift+N on a resumed Claude session creates a fresh session (not a resume)
- [ ] Shift+N inherits `skip_permissions` from source
- [ ] Shift+N on a group header with recent resumed session starts fresh