### PR TITLE
fix: restore Kitty keyboard protocol during session attach (#445)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7348,6 +7348,13 @@ func (a attachCmd) Run() error {
 	// NOTE: Screen clearing is ONLY done in the tea.Exec callback (after Attach returns)
 	// Removing clear screen here prevents double-clearing which corrupts terminal state
 
+	// Re-enable Kitty keyboard protocol so the attached session (e.g. Claude
+	// Code) receives extended key sequences like Shift+Enter. The TUI pops
+	// the protocol at startup for Bubble Tea compatibility; push mode 1
+	// here and pop again on return.
+	EnableKittyKeyboard(os.Stdout)
+	defer DisableKittyKeyboard(os.Stdout)
+
 	ctx := context.Background()
 	return a.session.Attach(ctx, a.detachByte)
 }
@@ -7387,6 +7394,9 @@ type remoteCreateAndAttachCmd struct {
 }
 
 func (r remoteCreateAndAttachCmd) Run() error {
+	EnableKittyKeyboard(os.Stdout)
+	defer DisableKittyKeyboard(os.Stdout)
+
 	ctx := context.Background()
 	sessionID, err := r.runner.CreateSession(ctx)
 	if err != nil {
@@ -7407,6 +7417,9 @@ type attachWindowCmd struct {
 }
 
 func (a attachWindowCmd) Run() error {
+	EnableKittyKeyboard(os.Stdout)
+	defer DisableKittyKeyboard(os.Stdout)
+
 	ctx := context.Background()
 	return a.session.AttachWindow(ctx, a.windowIndex, a.detachByte)
 }
@@ -7440,6 +7453,9 @@ type remoteAttachCmd struct {
 }
 
 func (r remoteAttachCmd) Run() error {
+	EnableKittyKeyboard(os.Stdout)
+	defer DisableKittyKeyboard(os.Stdout)
+
 	return r.runner.Attach(r.sessionID)
 }
 

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -34,6 +34,16 @@ func DisableKittyKeyboard(w io.Writer) {
 	_, _ = io.WriteString(w, "\x1b[<u")
 }
 
+// EnableKittyKeyboard writes the escape sequence that pushes Kitty keyboard
+// mode 1 (disambiguate) onto the protocol stack. This re-enables extended key
+// reporting so that sequences like Shift+Enter are sent as CSI u codes.
+// Call this before attaching to a session that needs Kitty keyboard support
+// (e.g. Claude Code). Pair with DisableKittyKeyboard to pop the stack on
+// return.
+func EnableKittyKeyboard(w io.Writer) {
+	_, _ = io.WriteString(w, "\x1b[>1u")
+}
+
 // RestoreKittyKeyboard writes the escape sequence that pops the keyboard mode
 // stack, restoring the terminal to its previous keyboard mode. Call this when
 // the TUI exits so that the terminal returns to normal operation.

--- a/internal/ui/keyboard_compat_test.go
+++ b/internal/ui/keyboard_compat_test.go
@@ -115,6 +115,30 @@ func TestDisableKittyKeyboard(t *testing.T) {
 	}
 }
 
+// TestEnableKittyKeyboard tests that EnableKittyKeyboard pushes mode 1.
+func TestEnableKittyKeyboard(t *testing.T) {
+	var buf bytes.Buffer
+	EnableKittyKeyboard(&buf)
+	got := buf.String()
+	want := "\x1b[>1u"
+	if got != want {
+		t.Errorf("EnableKittyKeyboard wrote %q, want %q", got, want)
+	}
+}
+
+// TestKittyKeyboardPushPopBalance verifies that EnableKittyKeyboard (push mode 1)
+// followed by DisableKittyKeyboard (pop) produces balanced escape sequences.
+func TestKittyKeyboardPushPopBalance(t *testing.T) {
+	var buf bytes.Buffer
+	EnableKittyKeyboard(&buf)
+	DisableKittyKeyboard(&buf)
+	got := buf.String()
+	want := "\x1b[>1u\x1b[<u"
+	if got != want {
+		t.Errorf("push+pop sequence = %q, want %q", got, want)
+	}
+}
+
 // TestRestoreKittyKeyboard tests that RestoreKittyKeyboard writes the correct escape sequence.
 func TestRestoreKittyKeyboard(t *testing.T) {
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- Adds `EnableKittyKeyboard` (push mode 1, `\x1b[>1u`) to re-enable Kitty keyboard protocol before attaching to a session
- Calls `EnableKittyKeyboard` before and `DisableKittyKeyboard` (pop, `\x1b[<u`) after all four attach paths: `attachCmd`, `remoteCreateAndAttachCmd`, `attachWindowCmd`, `remoteAttachCmd`
- Push/pop is balanced: one push per attach, one pop per detach, no stack growth across attach/detach cycles

## Context
The TUI disables Kitty keyboard protocol at startup for Bubble Tea compatibility (PR #473 changed this to pop). When attaching to a session running Claude Code, the terminal was still in legacy mode, so extended key sequences like Shift+Enter (line break) were lost.

Supersedes #446, which needed rework after #473 changed the disable/restore semantics.

Fixes #445

## Test plan
- [x] `TestEnableKittyKeyboard`: verifies push mode 1 escape sequence (`\x1b[>1u`)
- [x] `TestKittyKeyboardPushPopBalance`: verifies Enable+Disable produces balanced push/pop sequence
- [x] Existing `TestDisableKittyKeyboard` and `TestRestoreKittyKeyboard` still pass
- [ ] Manual: attach to Claude Code session, verify Shift+Enter produces line break
- [ ] Manual: detach and verify TUI keyboard shortcuts still work (uppercase letters, etc.)