### PR TITLE
fix: use portable grep instead of GNU sed in heartbeat.sh

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -719,7 +719,8 @@ func buildDaemonPath(agentDeckPath string) string {
 	return strings.Join(ordered, ":")
 }
 
-// conductorHeartbeatScript is the shell script that sends a heartbeat to a conductor session
+// conductorHeartbeatScript is the shell script that sends a heartbeat to a conductor session.
+// Uses grep instead of sed for JSON parsing to stay portable across GNU and BSD (macOS).
 const conductorHeartbeatScript = `#!/bin/bash
 # Heartbeat for conductor: {NAME} (profile: {PROFILE})
 # Sends a check-in message to the conductor session (non-blocking)
@@ -727,14 +728,14 @@ const conductorHeartbeatScript = `#!/bin/bash
 SESSION="conductor-{NAME}"
 PROFILE="{PROFILE}"
 
-# Check if conductor is enabled
-ENABLED=$(agent-deck -p "$PROFILE" conductor status --json 2>/dev/null | tr -d '\n' | sed -n 's/.*"enabled"[[:space:]]*:[[:space:]]*\(true\|false\).*/\1/p')
-if [ "$ENABLED" != "true" ]; then
+# Check if conductor is enabled (grep -o works on both GNU and BSD)
+ENABLED=$(agent-deck -p "$PROFILE" conductor status --json 2>/dev/null | grep -o '"enabled"[[:space:]]*:[[:space:]]*true')
+if [ -z "$ENABLED" ]; then
     exit 0
 fi
 
 # Only send if the session is running
-STATUS=$(agent-deck -p "$PROFILE" session show "$SESSION" --json 2>/dev/null | tr -d '\n' | sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+STATUS=$(agent-deck -p "$PROFILE" session show "$SESSION" --json 2>/dev/null | grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -o '"[^"]*"$' | tr -d '"')
 
 if [ "$STATUS" = "idle" ] || [ "$STATUS" = "waiting" ]; then
     agent-deck -p "$PROFILE" session send "$SESSION" "Heartbeat: Check sessions in your group ({NAME}). List any that are waiting, auto-respond where safe, and report what needs my attention." --no-wait -q
@@ -1261,10 +1262,18 @@ func LaunchdPlistPath() (string, error) {
 }
 
 // findPython3 resolves python3 for daemon configs.
-// Prefer the current PATH (so pyenv/asdf-selected interpreters win),
-// then fall back to common absolute locations for non-interactive environments.
+// Prefer the conductor venv (has required deps like toml), then the current
+// PATH (so pyenv/asdf-selected interpreters win), then common absolute paths.
 func findPython3() string {
-	// Respect the user's current shell environment first.
+	// Prefer the conductor venv python which has bridge dependencies installed.
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		venvPython := filepath.Join(homeDir, ".agent-deck", "conductor", "venv", "bin", "python3")
+		if _, err := os.Stat(venvPython); err == nil {
+			return venvPython
+		}
+	}
+
+	// Respect the user's current shell environment.
 	if p, err := exec.LookPath("python3"); err == nil {
 		if abs, absErr := filepath.Abs(p); absErr == nil {
 			return abs


### PR DESCRIPTION
## Summary

- Replace GNU `sed` alternation syntax (`\(true\|false\)`) in the heartbeat script with `grep -o`, which works on both BSD (macOS) and GNU `sed`. This fixes the heartbeat silently never firing on macOS.
- Fix `findPython3()` to prefer the conductor venv python (`~/.agent-deck/conductor/venv/bin/python3`) over system python, so bridge dependencies like `toml` are available when the bridge plist launches.

Closes #425

## What was wrong

The `ENABLED` extraction in `conductorHeartbeatScript` used `\|` alternation in a basic regex group, which is a GNU extension. On macOS BSD sed, this pattern never matches, so `ENABLED` is always empty and the script exits at the `!= "true"` check. The heartbeat never fires.

Additionally, `findPython3()` resolved to system python (e.g. `/opt/homebrew/bin/python3`) rather than the conductor venv, causing `ModuleNotFoundError: No module named 'toml'` on bridge startup.

## Changes

**`internal/session/conductor.go`:**
1. `conductorHeartbeatScript`: Replace `sed` JSON parsing with `grep -o` for both `ENABLED` and `STATUS` extraction
2. `findPython3()`: Check `~/.agent-deck/conductor/venv/bin/python3` first before falling back to PATH/common locations

## Test plan

- [x] Build passes (`go build ./...`)
- [x] Shell command extraction verified: `grep -o` produces correct output for `ENABLED` (matches `"enabled": true`, empty for false) and `STATUS` (extracts `idle`, `waiting`, `running`, etc.)
- [x] All existing test assertions still hold (status whitespace tolerance, session send, no-wait flag, ENABLED guard, conductor status query, NAME reference, group scoping)
- [ ] Verify on macOS: `bash heartbeat.sh` with a running conductor should correctly detect enabled state and send heartbeat