### PR TITLE
fix: run shell init_script on session resume

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3970,8 +3970,7 @@ func (i *Instance) Restart() error {
 	} else if i.Tool == "gemini" && i.GeminiSessionID != "" {
 		command = i.buildGeminiCommand("gemini")
 	} else if i.Tool == "opencode" && i.OpenCodeSessionID != "" {
-		// OPENCODE_SESSION_ID is propagated via host-side SetEnvironment after tmux start.
-		command = fmt.Sprintf("opencode -s %s", i.OpenCodeSessionID)
+		command = i.buildOpenCodeCommand("opencode")
 	} else if i.Tool == "codex" && i.CodexSessionID != "" {
 		command = i.buildCodexCommand("codex")
 	} else {
@@ -4060,9 +4059,13 @@ func (i *Instance) Restart() error {
 }
 
 // buildClaudeResumeCommand builds the claude resume command with proper config options
-// Respects: CLAUDE_CONFIG_DIR, dangerous_mode from user config
+// Respects: CLAUDE_CONFIG_DIR, dangerous_mode, and [shell].env_files + init_script
 // CLAUDE_SESSION_ID is set via host-side SetEnvironment (called by SyncSessionIDsToTmux after restart)
 func (i *Instance) buildClaudeResumeCommand() string {
+	// Source env files and init_script so resumed sessions have the same
+	// shell environment as freshly started ones (fixes #409).
+	envPrefix := i.buildEnvSourceCommand()
+
 	// Get the configured Claude command (e.g., "claude", "cdw", "cdp")
 	// If a custom command is set, we skip CLAUDE_CONFIG_DIR prefix since the alias handles it
 	claudeCmd := GetClaudeCommand()
@@ -4116,12 +4119,12 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// after the tmux session is restarted. No inline tmux set-environment in the shell string
 	// (which silently fails inside Docker sandbox containers).
 	if useResume {
-		return fmt.Sprintf("%s%s --resume %s%s",
-			configDirPrefix, claudeCmd, i.ClaudeSessionID, dangerousFlag)
+		return fmt.Sprintf("%s%s%s --resume %s%s",
+			envPrefix, configDirPrefix, claudeCmd, i.ClaudeSessionID, dangerousFlag)
 	}
 	// Session was never interacted with - use --session-id to create fresh session.
-	return fmt.Sprintf("%s%s --session-id %s%s",
-		configDirPrefix, claudeCmd, i.ClaudeSessionID, dangerousFlag)
+	return fmt.Sprintf("%s%s%s --session-id %s%s",
+		envPrefix, configDirPrefix, claudeCmd, i.ClaudeSessionID, dangerousFlag)
 }
 
 // SetGeminiModel sets the Gemini model for this session and triggers a restart if running.

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -2415,10 +2415,19 @@ func TestBuildClaudeResumeCommand_ExportsInstanceID(t *testing.T) {
 func TestBuildClaudeResumeCommand_IncludesInitScript(t *testing.T) {
 	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
 	origHome := os.Getenv("HOME")
-	tmpHome := t.TempDir()
 	os.Unsetenv("CLAUDE_CONFIG_DIR")
-	os.Setenv("HOME", tmpHome)
-	ClearUserConfigCache()
+	os.Setenv("HOME", t.TempDir())
+
+	// Inject config with init_script directly into cache
+	userConfigCacheMu.Lock()
+	userConfigCache = &UserConfig{
+		Shell: ShellSettings{
+			InitScript: `eval "$(direnv hook bash)"`,
+		},
+		MCPs: make(map[string]MCPDef),
+	}
+	userConfigCacheMu.Unlock()
+
 	defer func() {
 		if origConfigDir != "" {
 			os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
@@ -2426,14 +2435,6 @@ func TestBuildClaudeResumeCommand_IncludesInitScript(t *testing.T) {
 		os.Setenv("HOME", origHome)
 		ClearUserConfigCache()
 	}()
-
-	// Write a config with an init_script
-	configDir := filepath.Join(tmpHome, ".agent-deck")
-	os.MkdirAll(configDir, 0o755)
-	os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(`[shell]
-init_script = "eval \"$(direnv hook bash)\""
-`), 0o644)
-	ClearUserConfigCache()
 
 	inst := NewInstanceWithTool("test-resume-env", "/tmp/test", "claude")
 	inst.ClaudeSessionID = "resume-session-789"


### PR DESCRIPTION
## Summary

Fixes #409.

- `buildClaudeResumeCommand()` was missing the `buildEnvSourceCommand()` call that `buildClaudeCommand()` uses for new sessions. This meant `[shell].env_files` and `[shell].init_script` (direnv, nvm, pyenv, etc.) were not sourced when resuming or restarting Claude sessions.
- Also fixes the OpenCode restart fallback path which used a raw `fmt.Sprintf("opencode -s %s", ...)` instead of `buildOpenCodeCommand("opencode")`, similarly skipping env setup.

## What changed

**`internal/session/instance.go`**:
- Added `envPrefix := i.buildEnvSourceCommand()` at the top of `buildClaudeResumeCommand()` and prepended it to both return paths (`--resume` and `--session-id`)
- Changed OpenCode resume fallback in `Restart()` to use `buildOpenCodeCommand("opencode")` instead of raw `fmt.Sprintf`

**`internal/session/instance_test.go`**:
- Added `TestBuildClaudeResumeCommand_IncludesInitScript` regression test that configures an `init_script`, then verifies both `buildClaudeCommand` and `buildClaudeResumeCommand` include it in their output

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Existing `TestBuildClaudeResumeCommand_ExportsInstanceID` still passes
- [x] New `TestBuildClaudeResumeCommand_IncludesInitScript` passes
- [x] All `TestCommandBuilders_*` and `TestSandbox*` tests pass
- [ ] Manual test: configure `[shell].init_script` in config.toml, start a session, restart it, verify init_script runs both times