### PR TITLE
feat: add Open status filter (%) to hide error/stopped sessions

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -968,6 +968,34 @@ type DisplaySettings struct {
 	// Can also be enabled via AGENTDECK_REPAINT=full env var.
 	// Default: false
 	FullRepaint bool `toml:"full_repaint"`
+
+	// DefaultFilter sets the initial status filter when the TUI opens.
+	// Valid values: "" (all, default), "active" (hides error/stopped),
+	// "running", "waiting", "idle", "error".
+	// If set to "active" and no non-error sessions exist, falls back to showing all.
+	DefaultFilter string `toml:"default_filter"`
+
+	// ActiveFilterLabel sets the label shown on the filter pill when the active
+	// filter is engaged. Default: "Open". Examples: "Active", "Live", "Open".
+	ActiveFilterLabel string `toml:"active_filter_label"`
+}
+
+// ValidDefaultFilters lists acceptable values for DefaultFilter.
+var ValidDefaultFilters = map[string]bool{
+	"":        true,
+	"active":  true,
+	"running": true,
+	"waiting": true,
+	"idle":    true,
+	"error":   true,
+}
+
+// GetDefaultFilter returns the validated default_filter value, falling back to "" on invalid input.
+func (d DisplaySettings) GetDefaultFilter() string {
+	if ValidDefaultFilters[d.DefaultFilter] {
+		return d.DefaultFilter
+	}
+	return ""
 }
 
 // GetFullRepaint returns whether full-repaint mode is active, checking

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -215,6 +215,7 @@ func (h *HelpOverlay) View() string {
 			title: "SEARCH & FILTER",
 			items: [][2]string{
 				{searchKey, "Open search"},
+				{FilterKeyActive, "Filter open (hide errors)"},
 				{"/waiting", "Filter waiting"},
 				{"/running", "Filter running"},
 				{"/idle", "Filter idle"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -128,6 +128,14 @@ const (
 	minTerminalHeight = 12 // Reduced from 20 - supports smaller screens
 )
 
+// FilterKeyActive is the keyboard shortcut for the "open" status filter
+// (shows all sessions except error/stopped). Change this constant to rebind.
+const FilterKeyActive = "%"
+
+// FilterModeActive is the filter value for "open" sessions: excludes error/stopped.
+// This is NOT a session status (never assigned to a session), just a filter mode.
+const FilterModeActive session.Status = "active"
+
 // Mouse interaction thresholds
 const doubleClickThreshold = 500 * time.Millisecond
 
@@ -362,7 +370,9 @@ type Home struct {
 
 	// Full repaint mode: issue tea.ClearScreen every tick to avoid
 	// incremental redraw drift in terminals with unicode grapheme widths
-	fullRepaint bool
+	fullRepaint       bool
+	defaultFilter     string // from config.toml [display] default_filter
+	activeFilterLabel string // from config.toml [display] active_filter_label
 
 	// Performance observability (debug mode only, zero cost when off)
 	debugMode          bool         // true when AGENTDECK_DEBUG=1, enables perf overlay
@@ -731,9 +741,11 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 
 	h.reloadHotkeysFromConfig()
 
-	// Cache full-repaint setting (config.toml [display] full_repaint or AGENTDECK_REPAINT=full)
+	// Cache display settings (config.toml [display])
 	if cfg, _ := session.LoadUserConfig(); cfg != nil {
 		h.fullRepaint = cfg.Display.GetFullRepaint()
+		h.defaultFilter = cfg.Display.GetDefaultFilter()
+		h.activeFilterLabel = cfg.Display.ActiveFilterLabel
 		h.sysStatsConfig = cfg.SystemStats
 	} else {
 		h.fullRepaint = (session.DisplaySettings{}).GetFullRepaint()
@@ -750,6 +762,12 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 
 	// Restore persisted UI state (preview mode, status filter, cursor position)
 	h.loadUIState()
+
+	// Apply default_filter from config if no filter was restored from persisted state.
+	// Auto-clears if no sessions match (handled in rebuildFlatItems).
+	if h.statusFilter == "" && h.defaultFilter != "" {
+		h.statusFilter = session.Status(h.defaultFilter)
+	}
 
 	tmuxSettings := session.GetTmuxSettings()
 	h.manageTmuxNotifications = tmuxSettings.GetInjectStatusLine()
@@ -1163,7 +1181,7 @@ func (h *Home) rebuildFlatItems() {
 		groupsWithMatches := make(map[string]bool)
 		for _, item := range allItems {
 			if item.Type == session.ItemTypeSession && item.Session != nil {
-				if item.Session.Status == h.statusFilter {
+				if matchesStatusFilter(h.statusFilter, item.Session.Status) {
 					// Mark this session's group and all parent groups as having matches
 					groupsWithMatches[item.Path] = true
 					// Also mark parent paths
@@ -1186,7 +1204,7 @@ func (h *Home) rebuildFlatItems() {
 				}
 			} else if item.Type == session.ItemTypeSession && item.Session != nil {
 				// Keep session if it matches the filter
-				if item.Session.Status == h.statusFilter {
+				if matchesStatusFilter(h.statusFilter, item.Session.Status) {
 					filtered = append(filtered, item)
 				}
 			}
@@ -5716,6 +5734,16 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		h.rebuildFlatItems()
 		return h, nil
+
+	case FilterKeyActive, "shift+5":
+		// Filter to open sessions (excludes error/stopped)
+		if h.statusFilter == FilterModeActive {
+			h.statusFilter = "" // Toggle off
+		} else {
+			h.statusFilter = FilterModeActive
+		}
+		h.rebuildFlatItems()
+		return h, nil
 	}
 
 	return h, nil
@@ -7554,12 +7582,24 @@ func (h *Home) renderFilterBar() string {
 	// Build pills
 	var pills []string
 
-	// "All" pill
-	allLabel := "All"
-	if h.statusFilter == "" {
-		pills = append(pills, activePillStyle.Render(allLabel))
+	// "All" / "Open" pill
+	isActive := h.statusFilter == FilterModeActive
+	activeLabel := h.activeFilterLabel
+	if activeLabel == "" {
+		activeLabel = "Open"
+	}
+	// "All" is shorter than "Open" — pad with a trailing space outside the pill
+	// so toggling doesn't shift the bar, without extending the highlight.
+	allPad := ""
+	if len(activeLabel) > len("All") {
+		allPad = " "
+	}
+	if isActive {
+		pills = append(pills, activePillStyle.Render(activeLabel))
+	} else if h.statusFilter == "" {
+		pills = append(pills, activePillStyle.Render("All")+allPad)
 	} else {
-		pills = append(pills, inactivePillStyle.Render(allLabel))
+		pills = append(pills, inactivePillStyle.Render("All")+allPad)
 	}
 
 	// Running pill (green when active, dim if 0)
@@ -7596,7 +7636,7 @@ func (h *Home) renderFilterBar() string {
 		pills = append(pills, dimPillStyle.Render(waitingLabel))
 	}
 
-	// Idle pill (gray when active)
+	// Idle pill (gray when selected, dimmed when active filter hides it)
 	idleLabel := fmt.Sprintf("○ %d", idle)
 	if h.statusFilter == session.StatusIdle {
 		pills = append(pills, lipgloss.NewStyle().
@@ -7604,16 +7644,16 @@ func (h *Home) renderFilterBar() string {
 			Background(ColorTextDim).
 			Bold(true).
 			Padding(0, 1).Render(idleLabel))
-	} else if idle > 0 {
+	} else if idle == 0 {
+		pills = append(pills, dimPillStyle.Render(idleLabel))
+	} else {
 		pills = append(pills, lipgloss.NewStyle().
 			Foreground(ColorText).
 			Background(ColorSurface).
 			Padding(0, 1).Render(idleLabel))
-	} else {
-		pills = append(pills, dimPillStyle.Render(idleLabel))
 	}
 
-	// Error pill (red when active)
+	// Error pill (red when selected, dimmed when active filter hides it)
 	if errored > 0 || h.statusFilter == session.StatusError {
 		errorLabel := fmt.Sprintf("✕ %d", errored)
 		if h.statusFilter == session.StatusError {
@@ -7622,6 +7662,8 @@ func (h *Home) renderFilterBar() string {
 				Background(ColorRed).
 				Bold(true).
 				Padding(0, 1).Render(errorLabel))
+		} else if isActive {
+			pills = append(pills, dimPillStyle.Render(errorLabel))
 		} else if errored > 0 {
 			pills = append(pills, lipgloss.NewStyle().
 				Foreground(ColorRed).
@@ -7630,9 +7672,8 @@ func (h *Home) renderFilterBar() string {
 		}
 	}
 
-	// Hint for keyboard shortcuts (shift+number to filter, 0 to clear)
-	hintStyle := lipgloss.NewStyle().Foreground(ColorComment).Faint(true)
-	hint := hintStyle.Render("  !@#$ filter • 0 all")
+	// Hint for keyboard shortcuts (cached — content is static)
+	hint := cachedFilterBarHint()
 
 	// Join pills with spaces (leading space replaces Padding)
 	filterRow := " " + strings.Join(pills, " ") + hint
@@ -12116,4 +12157,28 @@ func renderBar(percent float64, width int) string {
 	emptyStyle := lipgloss.NewStyle().Foreground(ColorBorder)
 
 	return filledStyle.Render(strings.Repeat("█", filled)) + emptyStyle.Render(strings.Repeat("░", empty))
+}
+
+// matchesStatusFilter returns true if the given session status matches the
+// current filter. For FilterModeActive, everything except error/stopped matches
+// (including StatusStarting — sessions being launched count as active).
+func matchesStatusFilter(filter, status session.Status) bool {
+	if filter == FilterModeActive {
+		return status != session.StatusError && status != session.StatusStopped
+	}
+	return status == filter
+}
+
+// cachedFilterBarHint returns the static filter bar hint string.
+// Cached after first call since the content never changes after theme init.
+var _cachedFilterBarHint string
+
+func cachedFilterBarHint() string {
+	if _cachedFilterBarHint == "" {
+		_cachedFilterBarHint = lipgloss.NewStyle().
+			Foreground(ColorComment).
+			Faint(true).
+			Render("  !@#$ filter • 0 all • " + FilterKeyActive + " open")
+	}
+	return _cachedFilterBarHint
 }

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2145,3 +2145,30 @@ func TestRebuildFlatItemsKeepsValidStatusFilter(t *testing.T) {
 		t.Errorf("expected 1 session in flatItems with error filter, got %d", sessionCount)
 	}
 }
+
+func TestMatchesStatusFilter(t *testing.T) {
+	tests := []struct {
+		filter session.Status
+		status session.Status
+		want   bool
+	}{
+		// Active filter: excludes error and stopped only
+		{FilterModeActive, session.StatusRunning, true},
+		{FilterModeActive, session.StatusWaiting, true},
+		{FilterModeActive, session.StatusIdle, true},
+		{FilterModeActive, session.StatusStarting, true},
+		{FilterModeActive, session.StatusError, false},
+		{FilterModeActive, session.StatusStopped, false},
+		// Concrete status filters: exact match
+		{session.StatusRunning, session.StatusRunning, true},
+		{session.StatusRunning, session.StatusWaiting, false},
+		{session.StatusError, session.StatusError, true},
+		{session.StatusError, session.StatusStopped, false},
+	}
+	for _, tt := range tests {
+		got := matchesStatusFilter(tt.filter, tt.status)
+		if got != tt.want {
+			t.Errorf("matchesStatusFilter(%q, %q) = %v, want %v", tt.filter, tt.status, got, tt.want)
+		}
+	}
+}

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -11,6 +11,7 @@ All options for `~/.agent-deck/config.toml`.
 - [[docker] Section](#docker-section)
 - [[logs] Section](#logs-section)
 - [[updates] Section](#updates-section)
+- [[display] Section](#display-section)
 - [[global_search] Section](#global_search-section)
 - [Skills Registry (Outside config.toml)](#skills-registry-outside-configtoml)
 - [[mcp_pool] Section](#mcp_pool-section)
@@ -189,6 +190,23 @@ notify_in_cli = true          # Show in CLI commands
 | `check_enabled` | bool | `true` | Enable startup update checks. |
 | `check_interval_hours` | int | `24` | Hours between checks. |
 | `notify_in_cli` | bool | `true` | Show updates in CLI (not just TUI). |
+
+## [display] Section
+
+Rendering and display settings.
+
+```toml
+[display]
+full_repaint = false              # Force full screen clear every render (for terminals with grapheme issues)
+default_filter = "active"         # Initial status filter: "", "active", "running", "waiting", "idle", "error"
+active_filter_label = "Open"      # Label for the active filter pill (default: "Open")
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `full_repaint` | bool | `false` | Force full redraws (fix for Ghostty 1.3+ drift). Also via `AGENTDECK_REPAINT=full`. |
+| `default_filter` | string | `""` | Status filter applied on TUI startup. `"active"` hides error/stopped sessions. Auto-clears if no sessions match. |
+| `active_filter_label` | string | `"Open"` | Label shown on the filter pill when active filter is engaged (e.g., "Active", "Live", "Open"). |
 
 ## [global_search] Section
 


### PR DESCRIPTION
## Summary

- Press `%` to toggle an "Open" filter that hides error/stopped sessions in the TUI
- Adds `default_filter` and `active_filter_label` config options under `[display]` section
- Config validation with fallback to "all" on invalid `default_filter` values
- Uses `FilterModeActive` constant instead of adding to `Status` enum (clean separation of filter logic from session state)
- Cached filter bar hint for performance
- Filter bar dims error/idle pills when "Open" filter is active

Closes #491

## Changes from original PR #491
- No pane title display code (already merged in #474)
- No `StatusActive` on the `Status` enum; uses separate `FilterModeActive` constant
- Added `GetDefaultFilter()` with validation map for safe config handling

## Test plan
- [x] `go test ./internal/ui/` passes (including new `TestMatchesStatusFilter`)
- [x] `go build ./...` compiles cleanly
- [ ] Manual: press `%` in TUI to toggle Open filter, verify error/stopped sessions hidden
- [ ] Manual: set `default_filter = "active"` in config.toml, verify TUI opens with filter applied
- [ ] Manual: set invalid `default_filter = "bogus"`, verify fallback to showing all