### PR TITLE
feat: group-scoped TUI via --group/-g flag

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -441,8 +441,31 @@ func main() {
 		}()
 	}
 
+	// Extract --group / -g flag here (TUI-only path; subcommands consume their own -g)
+	var groupScope string
+	groupScope, args = extractGroupFlag(args)
+
 	// Start TUI with the specified profile
 	homeModel := ui.NewHomeWithProfileAndMode(profile)
+	// Apply group scope if specified via --group / -g flag
+	if groupScope != "" {
+		normalizedGroup := normalizeGroupPath(groupScope)
+		// Validate group exists by loading current sessions
+		if storage, err := session.NewStorageWithProfile(profile); err == nil {
+			if _, groups, err := storage.LoadWithGroups(); err == nil {
+				groupTree := session.NewGroupTreeWithGroups(nil, groups)
+				if _, exists := groupTree.Groups[normalizedGroup]; !exists {
+					fmt.Fprintf(os.Stderr, "Error: group '%s' not found\n", groupScope)
+					os.Exit(2)
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "Warning: could not verify group '%s' (storage error)\n", groupScope)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "Warning: could not verify group '%s' (storage error)\n", groupScope)
+		}
+		homeModel.SetGroupScope(normalizedGroup)
+	}
 
 	// ═══════════════════════════════════════════════════════════════════
 	// Cost Tracking Initialization
@@ -622,6 +645,40 @@ func extractProfileFlag(args []string) (string, []string) {
 	}
 
 	return profile, remaining
+}
+
+// extractGroupFlag extracts -g or --group from args, returning the group path and remaining args.
+// This only applies to the TUI launch path; subcommands like add/launch have their own -g flag.
+func extractGroupFlag(args []string) (string, []string) {
+	var group string
+	var remaining []string
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		// Check for -g=value or --group=value
+		if strings.HasPrefix(arg, "-g=") {
+			group = strings.TrimPrefix(arg, "-g=")
+			continue
+		}
+		if strings.HasPrefix(arg, "--group=") {
+			group = strings.TrimPrefix(arg, "--group=")
+			continue
+		}
+
+		// Check for -g value or --group value
+		if arg == "-g" || arg == "--group" {
+			if i+1 < len(args) {
+				group = args[i+1]
+				i++ // Skip the value
+				continue
+			}
+		}
+
+		remaining = append(remaining, arg)
+	}
+
+	return group, remaining
 }
 
 // reorderArgsForFlagParsing moves the path argument to the end of args
@@ -2273,10 +2330,11 @@ func printHelp() {
 	fmt.Printf("Agent Deck v%s\n", Version)
 	fmt.Println("Terminal session manager for AI coding agents")
 	fmt.Println()
-	fmt.Println("Usage: agent-deck [-p profile] [command]")
+	fmt.Println("Usage: agent-deck [-p profile] [-g group] [command]")
 	fmt.Println()
 	fmt.Println("Global Options:")
 	fmt.Println("  -p, --profile <name>   Use specific profile (default: 'default')")
+	fmt.Println("  -g, --group <name>     Launch TUI scoped to a specific group")
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  (none)           Start the TUI")

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -107,6 +107,103 @@ func TestNestedSessionAllowsCLICommands(t *testing.T) {
 	})
 }
 
+func TestExtractGroupFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		wantGroup     string
+		wantRemaining []string
+	}{
+		{
+			name:          "no flag",
+			args:          []string{"list"},
+			wantGroup:     "",
+			wantRemaining: []string{"list"},
+		},
+		{
+			name:          "--group=work equals form",
+			args:          []string{"--group=work"},
+			wantGroup:     "work",
+			wantRemaining: nil,
+		},
+		{
+			name:          "--group work space form",
+			args:          []string{"--group", "work"},
+			wantGroup:     "work",
+			wantRemaining: nil,
+		},
+		{
+			name:          "-g work short form",
+			args:          []string{"-g", "work"},
+			wantGroup:     "work",
+			wantRemaining: nil,
+		},
+		{
+			name:          "-g=work short equals form",
+			args:          []string{"-g=work"},
+			wantGroup:     "work",
+			wantRemaining: nil,
+		},
+		{
+			name:          "combined with -p",
+			args:          []string{"-p", "myprofile", "-g", "work"},
+			wantGroup:     "work",
+			wantRemaining: []string{"-p", "myprofile"},
+		},
+		{
+			name:          "subgroup path",
+			args:          []string{"--group", "clients/acme"},
+			wantGroup:     "clients/acme",
+			wantRemaining: nil,
+		},
+		{
+			name:          "group flag before subcommand",
+			args:          []string{"-g", "work", "list"},
+			wantGroup:     "work",
+			wantRemaining: []string{"list"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotGroup, gotRemaining := extractGroupFlag(tt.args)
+			if gotGroup != tt.wantGroup {
+				t.Errorf("group: got %q, want %q", gotGroup, tt.wantGroup)
+			}
+			if len(gotRemaining) != len(tt.wantRemaining) {
+				t.Errorf("remaining length: got %d (%v), want %d (%v)", len(gotRemaining), gotRemaining, len(tt.wantRemaining), tt.wantRemaining)
+				return
+			}
+			for i, arg := range gotRemaining {
+				if arg != tt.wantRemaining[i] {
+					t.Errorf("remaining[%d]: got %q, want %q", i, arg, tt.wantRemaining[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGroupScopeValidation(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"work", "work"},
+		{"Work", "work"},
+		{"My Projects", "my-projects"},
+		{"work/frontend", "work/frontend"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeGroupPath(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeGroupPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsDuplicateSession(t *testing.T) {
 	instances := []*session.Instance{
 		{ID: "abc123", Title: "Test Session", ProjectPath: "/home/user/project"},

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -232,6 +232,13 @@ func (h *HelpOverlay) View() string {
 				{helpKey, "This help"},
 			},
 		},
+		{
+			title: "STARTUP FLAGS",
+			items: [][2]string{
+				{"--group <name>", "Launch scoped to a group"},
+				{"--profile <name>", "Use specific profile"},
+			},
+		},
 	}
 
 	for i := range sections {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -236,6 +236,7 @@ type Home struct {
 	viewOffset     int            // First visible item index (for scrolling)
 	isAttaching    atomic.Bool    // Prevents View() output during attach (fixes Bubble Tea Issue #431) - atomic for thread safety
 	statusFilter   session.Status // Filter sessions by status ("" = all, or specific status)
+	groupScope     string         // Limit TUI to a specific group path ("" = all groups)
 	previewMode    PreviewMode    // What to show in preview pane (both, output-only, analytics-only)
 	err            error
 	errTime        time.Time  // When error occurred (for auto-dismiss)
@@ -979,6 +980,49 @@ func (h *Home) SetCostBudget(budget *costs.BudgetChecker) {
 	h.costBudget = budget
 }
 
+// SetGroupScope limits the TUI to sessions within the given group path.
+// The path is normalized: lowercased and spaces replaced with hyphens.
+func (h *Home) SetGroupScope(path string) {
+	h.groupScope = strings.ToLower(strings.ReplaceAll(path, " ", "-"))
+}
+
+// isInGroupScope returns true if the given path is within the active group scope.
+// Returns true for all paths when no scope is set.
+func (h *Home) isInGroupScope(path string) bool {
+	if h.groupScope == "" {
+		return true
+	}
+	return path == h.groupScope || strings.HasPrefix(path, h.groupScope+"/")
+}
+
+// scopedGroupPaths returns group paths filtered to the active scope.
+// Returns all paths when no scope is set.
+func (h *Home) scopedGroupPaths() []string {
+	allPaths := h.groupTree.GetGroupPaths()
+	if h.groupScope == "" {
+		return allPaths
+	}
+	var scoped []string
+	for _, p := range allPaths {
+		if h.isInGroupScope(p) {
+			scoped = append(scoped, p)
+		}
+	}
+	return scoped
+}
+
+// groupScopeDisplayName returns the human-readable name for the active group scope.
+// Falls back to the raw scope path if the group is not found in the tree.
+func (h *Home) groupScopeDisplayName() string {
+	if h.groupScope == "" {
+		return ""
+	}
+	if group, exists := h.groupTree.Groups[h.groupScope]; exists {
+		return group.Name
+	}
+	return h.groupScope
+}
+
 // refreshCostTotals updates cached cost totals from the store.
 // Throttled to run at most every 10 seconds.
 func (h *Home) refreshCostTotals() {
@@ -1218,6 +1262,17 @@ func (h *Home) rebuildFlatItems() {
 		}
 	} else {
 		h.flatItems = allItems
+	}
+
+	// Apply group scope filter (composes with status filter above)
+	if h.groupScope != "" {
+		scoped := make([]session.Item, 0, len(h.flatItems))
+		for _, item := range h.flatItems {
+			if h.isInGroupScope(item.Path) {
+				scoped = append(scoped, item)
+			}
+		}
+		h.flatItems = scoped
 	}
 
 	// Inject window items after sessions that have 2+ windows
@@ -5222,7 +5277,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession {
-				h.groupDialog.ShowMove(h.groupTree.GetGroupPaths())
+				h.groupDialog.ShowMove(h.scopedGroupPaths())
 			}
 		}
 		return h, nil
@@ -5274,7 +5329,19 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// - Group header: defaults to subgroup, Tab toggles to root
 		// - Grouped session: defaults to root, Tab toggles to subgroup
 		// - Ungrouped item: root only, no toggle
-		if h.cursor < len(h.flatItems) {
+		if h.groupScope != "" {
+			// Scoped mode: create subgroups under scope root or its children
+			if h.cursor < len(h.flatItems) {
+				item := h.flatItems[h.cursor]
+				if item.Type == session.ItemTypeGroup {
+					h.groupDialog.ShowCreateSubgroup(item.Group.Path, item.Group.Name)
+				} else {
+					h.groupDialog.ShowCreateSubgroup(h.groupScope, h.groupScopeDisplayName())
+				}
+			} else {
+				h.groupDialog.ShowCreateSubgroup(h.groupScope, h.groupScopeDisplayName())
+			}
+		} else if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeGroup {
 				// On group header: default to subgroup mode
@@ -5424,6 +5491,13 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Auto-select parent group from current cursor position
 		groupPath := session.DefaultGroupPath
 		groupName := session.DefaultGroupName
+		if h.groupScope != "" {
+			// Scoped mode: default to scope root
+			groupPath = h.groupScope
+			if group, exists := h.groupTree.Groups[h.groupScope]; exists {
+				groupName = group.Name
+			}
+		}
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			switch item.Type {
@@ -5463,8 +5537,10 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				h.confirmDialog.ShowDeleteSession(item.Session.ID, item.Session.Title, item.Session.IsSandboxed())
 			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
 				h.confirmDialog.ShowDeleteRemoteSession(item.RemoteName, item.RemoteSession.ID, item.RemoteSession.Title)
-			} else if item.Type == session.ItemTypeGroup && item.Path != session.DefaultGroupPath {
+			} else if item.Type == session.ItemTypeGroup && item.Path != session.DefaultGroupPath && item.Path != h.groupScope {
 				h.confirmDialog.ShowDeleteGroup(item.Path, item.Group.Name)
+			} else if item.Type == session.ItemTypeGroup && item.Path == h.groupScope {
+				h.setError(fmt.Errorf("cannot delete the scoped root group"))
 			}
 		}
 		return h, nil
@@ -6748,7 +6824,11 @@ func (h *Home) quickCreateSession() tea.Cmd {
 		}
 	}
 	if groupPath == "" {
-		groupPath = session.DefaultGroupPath
+		if h.groupScope != "" {
+			groupPath = h.groupScope
+		} else {
+			groupPath = session.DefaultGroupPath
+		}
 	}
 
 	projectPath := ""
@@ -7809,6 +7889,12 @@ func (h *Home) View() string {
 			Foreground(ColorCyan).
 			Bold(true)
 		titleText = "Agent Deck " + profileStyle.Render("["+h.profile+"]")
+	}
+	if h.groupScope != "" {
+		scopeStyle := lipgloss.NewStyle().
+			Foreground(ColorPurple).
+			Bold(true)
+		titleText += " " + scopeStyle.Render("["+h.groupScopeDisplayName()+"]")
 	}
 	title := titleStyle.Render(titleText)
 
@@ -9270,6 +9356,25 @@ func (h *Home) renderSessionList(width, height int) string {
 			contentHeight = 5
 		}
 
+		// Group-scoped empty state
+		if h.groupScope != "" {
+			hints := []string{}
+			if key := h.actionKey(hotkeyNewSession); key != "" {
+				hints = append(hints, fmt.Sprintf("Press %s to create a session", key))
+			}
+			emptyContent := renderEmptyStateResponsive(EmptyStateConfig{
+				Icon:     "⬡",
+				Title:    "No sessions in " + h.groupScopeDisplayName(),
+				Subtitle: "This group is empty",
+				Hints:    hints,
+			}, contentWidth, contentHeight)
+
+			return lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(ColorBorder).
+				Render(emptyContent)
+		}
+
 		hints := make([]string, 0, 3)
 		if key := h.actionKey(hotkeyNewSession); key != "" {
 			hints = append(hints, fmt.Sprintf("Press %s to create a new session", key))
@@ -10369,6 +10474,15 @@ func (h *Home) renderPreviewPane(width, height int) string {
 	if len(h.flatItems) == 0 || h.cursor >= len(h.flatItems) {
 		// Show different message when there are no sessions vs just no selection
 		if len(h.flatItems) == 0 {
+			// Group-scoped empty preview
+			if h.groupScope != "" {
+				return renderEmptyStateResponsive(EmptyStateConfig{
+					Icon:     "✦",
+					Title:    h.groupScopeDisplayName(),
+					Subtitle: "Group scope active",
+					Hints:    []string{"Only sessions in this group are shown"},
+				}, width, height)
+			}
 			hints := make([]string, 0, 2)
 			if key := h.actionKey(hotkeyNewSession); key != "" {
 				hints = append(hints, fmt.Sprintf("Press %s to create your first session", key))

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2172,3 +2172,180 @@ func TestMatchesStatusFilter(t *testing.T) {
 		}
 	}
 }
+
+func TestSetGroupScope(t *testing.T) {
+	home := NewHome()
+
+	// Default is empty
+	if home.groupScope != "" {
+		t.Errorf("expected empty groupScope by default, got %q", home.groupScope)
+	}
+
+	// Set a group scope
+	home.SetGroupScope("work")
+	if home.groupScope != "work" {
+		t.Errorf("expected groupScope %q, got %q", "work", home.groupScope)
+	}
+
+	// Overwrite with another value
+	home.SetGroupScope("clients/acme")
+	if home.groupScope != "clients/acme" {
+		t.Errorf("expected groupScope %q, got %q", "clients/acme", home.groupScope)
+	}
+}
+
+func TestGroupScopeNormalization(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"work", "work"},
+		{"Work", "work"},
+		{"My Group", "my-group"},
+		{"MY GROUP", "my-group"},
+		{"clients/Acme Corp", "clients/acme-corp"},
+		{"already-normalized", "already-normalized"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			home := NewHome()
+			home.SetGroupScope(tt.input)
+			if home.groupScope != tt.want {
+				t.Errorf("SetGroupScope(%q): got %q, want %q", tt.input, home.groupScope, tt.want)
+			}
+		})
+	}
+}
+
+func TestRebuildFlatItemsGroupScope(t *testing.T) {
+	h := &Home{}
+	h.groupScope = "work"
+
+	instances := []*session.Instance{
+		session.NewInstanceWithGroup("s1", "/tmp/p1", "work"),
+		session.NewInstanceWithGroup("s2", "/tmp/p2", "work/frontend"),
+		session.NewInstanceWithGroup("s3", "/tmp/p3", "personal"),
+	}
+	h.groupTree = session.NewGroupTree(instances)
+	h.windowsCollapsed = make(map[string]bool)
+
+	h.rebuildFlatItems()
+
+	for _, item := range h.flatItems {
+		if item.Type == session.ItemTypeSession && item.Session != nil {
+			if item.Session.GroupPath == "personal" {
+				t.Errorf("found session in 'personal' group, expected only work and children")
+			}
+		}
+		if item.Type == session.ItemTypeGroup && item.Path == "personal" {
+			t.Errorf("found 'personal' group header, expected only work and children")
+		}
+	}
+
+	found := map[string]bool{}
+	for _, item := range h.flatItems {
+		if item.Type == session.ItemTypeSession && item.Session != nil {
+			found[item.Session.Title] = true
+		}
+	}
+	if !found["s1"] {
+		t.Error("missing session s1 (work group)")
+	}
+	if !found["s2"] {
+		t.Error("missing session s2 (work/frontend group)")
+	}
+}
+
+func TestRebuildFlatItemsGroupScopeComposesWithStatusFilter(t *testing.T) {
+	h := &Home{}
+	h.groupScope = "work"
+	h.statusFilter = session.StatusRunning
+
+	instances := []*session.Instance{
+		session.NewInstanceWithGroup("running-work", "/tmp/p1", "work"),
+		session.NewInstanceWithGroup("idle-work", "/tmp/p2", "work"),
+		session.NewInstanceWithGroup("running-personal", "/tmp/p3", "personal"),
+	}
+	instances[0].Status = session.StatusRunning
+	instances[1].Status = session.StatusIdle
+	instances[2].Status = session.StatusRunning
+
+	h.groupTree = session.NewGroupTree(instances)
+	h.windowsCollapsed = make(map[string]bool)
+
+	h.rebuildFlatItems()
+
+	for _, item := range h.flatItems {
+		if item.Type == session.ItemTypeSession && item.Session != nil {
+			if item.Session.GroupPath == "personal" {
+				t.Errorf("found personal session, expected only work group")
+			}
+			if item.Session.Status != session.StatusRunning {
+				t.Errorf("found non-running session %q, expected only running", item.Session.Title)
+			}
+		}
+	}
+}
+
+func TestIsInGroupScope(t *testing.T) {
+	h := &Home{}
+
+	// No scope set: everything is in scope
+	if !h.isInGroupScope("anything") {
+		t.Error("expected all paths in scope when groupScope is empty")
+	}
+
+	h.groupScope = "work"
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"work", true},
+		{"work/frontend", true},
+		{"work/frontend/react", true},
+		{"personal", false},
+		{"worker", false}, // should NOT match (not a child)
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := h.isInGroupScope(tt.path); got != tt.want {
+				t.Errorf("isInGroupScope(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScopedGroupPaths(t *testing.T) {
+	h := &Home{}
+	instances := []*session.Instance{
+		session.NewInstanceWithGroup("s1", "/tmp/p1", "work"),
+		session.NewInstanceWithGroup("s2", "/tmp/p2", "work/frontend"),
+		session.NewInstanceWithGroup("s3", "/tmp/p3", "personal"),
+	}
+	h.groupTree = session.NewGroupTree(instances)
+
+	// No scope: returns all paths
+	allPaths := h.scopedGroupPaths()
+	if len(allPaths) < 3 {
+		t.Errorf("expected at least 3 group paths without scope, got %d", len(allPaths))
+	}
+
+	// With scope: returns only work and children
+	h.groupScope = "work"
+	scopedPaths := h.scopedGroupPaths()
+	for _, p := range scopedPaths {
+		if !h.isInGroupScope(p) {
+			t.Errorf("scopedGroupPaths returned %q which is not in scope", p)
+		}
+	}
+	// Verify personal is excluded
+	for _, p := range scopedPaths {
+		if p == "personal" {
+			t.Error("scopedGroupPaths should not include 'personal' when scoped to 'work'")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--group` / `-g` CLI flag to launch the TUI scoped to a specific group, showing only sessions in that group and its children
- Validates group existence at startup (exits with code 2 if not found)
- Scopes hotkey handlers: `n` (new session defaults to scope root), `g` (create subgroup within scope), `M` (move targets filtered to scope), `d` (prevents deleting scope root)
- Shows purple `[groupname]` indicator in title bar and custom empty state when group has no sessions
- Adds STARTUP FLAGS section to help overlay

Closes #475

## Test plan
- [x] `TestExtractGroupFlag` covers all flag forms (-g, --group, equals, space, combined with -p)
- [x] `TestGroupScopeValidation` verifies normalizeGroupPath
- [x] `TestSetGroupScope` and `TestGroupScopeNormalization` verify setter behavior
- [x] `TestRebuildFlatItemsGroupScope` verifies filtering excludes out-of-scope items
- [x] `TestRebuildFlatItemsGroupScopeComposesWithStatusFilter` verifies both filters compose
- [x] `TestIsInGroupScope` verifies path matching (exact, children, non-children)
- [x] `TestScopedGroupPaths` verifies group path filtering
- [x] `go test ./...` passes (pre-existing tmux failures unrelated)
- [x] `go vet ./...` clean