### PR TITLE
fix: make scrollback clearing on attach opt-in via config

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -883,6 +883,15 @@ type TmuxSettings struct {
 	// Example: window_style_override = "default"
 	WindowStyleOverride string `toml:"window_style_override"`
 
+	// ClearScrollbackOnAttach controls whether the tmux pane scrollback and
+	// terminal emulator saved-lines buffer are cleared each time you attach
+	// to a session. When true, output from a previously-attached session is
+	// erased so it does not bleed into the new one. When false (default),
+	// scrollback is preserved, allowing you to scroll up through earlier
+	// output after detaching and re-attaching.
+	// Default: false
+	ClearScrollbackOnAttach bool `toml:"clear_scrollback_on_attach"`
+
 	// Options is a map of tmux option names to values.
 	// These are passed to `tmux set-option -t <session>` after defaults.
 	Options map[string]string `toml:"options"`

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -15,6 +15,9 @@ import (
 	"syscall"
 	"time"
 
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
 	"github.com/creack/pty"
 	"golang.org/x/term"
 )
@@ -68,16 +71,16 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 		return fmt.Errorf("session %s does not exist", s.Name)
 	}
 
-	// Clear scrollback before attaching to prevent stale content from a
-	// previously-attached session bleeding into the new one (#419).
-	// 1. Clear tmux's internal pane scrollback history.
-	clearTarget := s.Name + ":"
-	clearCmd := exec.Command("tmux", "clear-history", "-t", clearTarget)
-	_ = clearCmd.Run()
-	// 2. Clear the outer terminal emulator's scrollback buffer.
-	//    \033[3J is the "Erase Saved Lines" escape (ED param 3) supported
-	//    by iTerm2, Terminal.app, Ghostty, and most modern emulators.
-	_, _ = os.Stdout.WriteString("\033[3J")
+	// Optionally clear scrollback before attaching to prevent stale content
+	// from a previously-attached session bleeding into the new one (#419).
+	// Disabled by default so users keep their scroll history.
+	// Enable via [tmux] clear_scrollback_on_attach = true in config.toml.
+	if shouldClearScrollback() {
+		clearTarget := s.Name + ":"
+		clearCmd := exec.Command("tmux", "clear-history", "-t", clearTarget)
+		_ = clearCmd.Run()
+		_, _ = os.Stdout.WriteString("\033[3J")
+	}
 
 	// Create context with cancel for detach
 	ctx, cancel := context.WithCancel(ctx)
@@ -385,4 +388,23 @@ func (s *Session) StreamOutput(ctx context.Context, w io.Writer) error {
 		}
 		return nil
 	}
+}
+
+// shouldClearScrollback reads the user config to check if scrollback clearing
+// is enabled. Returns false on any error (safe default: preserve scrollback).
+func shouldClearScrollback() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	configPath := filepath.Join(home, ".agent-deck", "config.toml")
+	var cfg struct {
+		Tmux struct {
+			ClearScrollbackOnAttach bool `toml:"clear_scrollback_on_attach"`
+		} `toml:"tmux"`
+	}
+	if _, err := toml.DecodeFile(configPath, &cfg); err != nil {
+		return false
+	}
+	return cfg.Tmux.ClearScrollbackOnAttach
 }

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -208,6 +208,21 @@ active_filter_label = "Open"      # Label for the active filter pill (default: "
 | `default_filter` | string | `""` | Status filter applied on TUI startup. `"active"` hides error/stopped sessions. Auto-clears if no sessions match. |
 | `active_filter_label` | string | `"Open"` | Label shown on the filter pill when active filter is engaged (e.g., "Active", "Live", "Open"). |
 
+## [tmux] Section
+
+Tmux session behavior.
+
+```toml
+[tmux]
+inject_status_line = true         # Inject agent-deck status line into tmux
+clear_scrollback_on_attach = false # Clear scrollback buffer when attaching to a session
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `inject_status_line` | bool | `true` | Inject custom status line into tmux sessions. Set `false` to keep your own tmux status config. |
+| `clear_scrollback_on_attach` | bool | `false` | Clear tmux pane scrollback and terminal saved-lines buffer on each attach. Prevents cross-session output bleed but destroys scroll history. |
+
 ## [global_search] Section
 
 Search across all Claude conversations.


### PR DESCRIPTION
## Summary

- Makes the scrollback clearing introduced in #505 / 3da70e0 **opt-in** instead of always-on
- Adds `[tmux] clear_scrollback_on_attach` config option (default: `false`)
- Preserves tmux scroll history by default — users who experience cross-session output bleed can enable clearing

## Context

The unconditional `tmux clear-history` + `\033[3J` on every attach (#419) destroys scroll history, making it impossible to scroll back through session output after detaching with Ctrl+Q and re-attaching. Users who frequently switch between sessions lose all scrollback every time.

## Changes

- `internal/tmux/pty.go`: Scrollback clearing now gated behind `shouldClearScrollback()` which reads `~/.agent-deck/config.toml`
- `internal/session/userconfig.go`: Added `ClearScrollbackOnAttach` field to `TmuxSettings`
- `skills/agent-deck/references/config-reference.md`: Added `[tmux]` section documenting the new option

## Test plan

- [ ] Verify scrollback is preserved after Ctrl+Q detach and re-attach (default behavior)
- [ ] Verify `clear_scrollback_on_attach = true` in config.toml restores the clearing behavior
- [ ] Verify no cross-session bleed with clearing enabled