### PR TITLE
feat: add CLI multi-repo support, configurable base dir, and session add-path

### DIFF
--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -47,6 +47,13 @@ func handleLaunch(profile string, args []string) {
 		return nil
 	})
 
+	// Multi-repo flag
+	var addPaths []string
+	fs.Func("add-path", "Additional repo path for multi-repo session (repeatable)", func(s string) error {
+		addPaths = append(addPaths, s)
+		return nil
+	})
+
 	// Resume session flag
 	resumeSession := fs.String("resume-session", "", "Claude session ID to resume")
 
@@ -70,6 +77,7 @@ func handleLaunch(profile string, args []string) {
 		fmt.Println("  agent-deck launch . -c claude -m \"Fix bug\" --no-wait")
 		fmt.Println("  agent-deck launch . -c \"codex --dangerously-bypass-approvals-and-sandbox\"")
 		fmt.Println("  agent-deck launch . -g ard --no-parent -c claude -m \"Run review\"")
+		fmt.Println("  agent-deck launch . -c claude --add-path /path/to/repo2 --add-path /path/to/repo3")
 	}
 
 	// Reorder args: move path to end so flags are parsed correctly
@@ -140,9 +148,9 @@ func handleLaunch(profile string, args []string) {
 		}
 	}
 
-	// Handle worktree creation
+	// Handle worktree creation (single-repo only; multi-repo delegates to SetupMultiRepo below)
 	var worktreePath, worktreeRepoRoot string
-	if wtBranch != "" {
+	if wtBranch != "" && len(addPaths) == 0 {
 		if !git.IsGitRepo(path) {
 			out.Error(fmt.Sprintf("%s is not a git repository", path), ErrCodeInvalidOperation)
 			os.Exit(1)
@@ -284,6 +292,44 @@ func handleLaunch(profile string, args []string) {
 		newInstance.WorktreeBranch = wtBranch
 	}
 
+	if len(addPaths) > 0 {
+		// Resolve, validate, and collect additional paths
+		resolvedPaths := make([]string, 0, len(addPaths))
+		for _, p := range addPaths {
+			abs, err := filepath.Abs(session.ExpandPath(p))
+			if err != nil {
+				out.Error(fmt.Sprintf("failed to resolve --add-path %s: %v", p, err), ErrCodeInvalidOperation)
+				os.Exit(1)
+			}
+			info, err := os.Stat(abs)
+			if err != nil {
+				out.Error(fmt.Sprintf("--add-path %s does not exist", abs), ErrCodeInvalidOperation)
+				os.Exit(1)
+			}
+			if !info.IsDir() {
+				out.Error(fmt.Sprintf("--add-path %s is not a directory", abs), ErrCodeInvalidOperation)
+				os.Exit(1)
+			}
+			resolvedPaths = append(resolvedPaths, abs)
+		}
+		// Honour -b in multi-repo mode: fail fast if branch already exists in any repo
+		if createNewBranch && wtBranch != "" {
+			allPaths := append([]string{path}, resolvedPaths...)
+			for _, p := range allPaths {
+				if repoRoot, err := git.GetWorktreeBaseRoot(p); err == nil {
+					if git.BranchExists(repoRoot, wtBranch) {
+						out.Error(fmt.Sprintf("branch '%s' already exists in %s (remove -b to reuse it)", wtBranch, p), ErrCodeInvalidOperation)
+						os.Exit(1)
+					}
+				}
+			}
+		}
+		if err := session.SetupMultiRepo(newInstance, resolvedPaths, wtBranch, session.GetMultiRepoBaseDir()); err != nil {
+			out.Error(fmt.Sprintf("failed to set up multi-repo session: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+	}
+
 	if *resumeSession != "" {
 		newInstance.ClaudeSessionID = *resumeSession
 		newInstance.ClaudeDetectedAt = time.Now()
@@ -400,6 +446,10 @@ func handleLaunch(profile string, args []string) {
 	if worktreePath != "" {
 		jsonData["worktree_path"] = worktreePath
 		jsonData["worktree_branch"] = wtBranch
+	}
+	if newInstance.IsMultiRepo() {
+		jsonData["multi_repo"] = true
+		jsonData["multi_repo_paths"] = newInstance.AllProjectPaths()
 	}
 
 	msg := fmt.Sprintf("Launched session: %s", newInstance.Title)

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -699,9 +699,10 @@ func reorderArgsForFlagParsing(args []string) []string {
 		"-c": true, "--cmd": true,
 		"-m": true, "--message": true,
 		"-p": true, "--parent": true,
-		"--mcp":     true,
-		"--wrapper": true,
-		"-w":        true, "--worktree": true,
+		"--mcp":      true,
+		"--add-path": true,
+		"--wrapper":  true,
+		"-w":         true, "--worktree": true,
 		"--location":       true,
 		"--resume-session": true,
 		"--sandbox-image":  true,
@@ -883,6 +884,13 @@ func handleAdd(profile string, args []string) {
 		return nil
 	})
 
+	// Multi-repo flag
+	var addPaths []string
+	fs.Func("add-path", "Additional repo path for multi-repo session (repeatable)", func(s string) error {
+		addPaths = append(addPaths, s)
+		return nil
+	})
+
 	// Sandbox flags
 	sandbox := fs.Bool("sandbox", false, "Run session in Docker sandbox")
 	sandboxImage := fs.String("sandbox-image", "", "Docker image for sandbox (overrides config default)")
@@ -926,6 +934,10 @@ func handleAdd(profile string, args []string) {
 		fmt.Println("  agent-deck add -w feature/login .    # Create worktree for existing branch")
 		fmt.Println("  agent-deck add -w feature/new -b .   # Create worktree with new branch")
 		fmt.Println("  agent-deck add --worktree fix/bug-123 --new-branch /path/to/repo")
+		fmt.Println()
+		fmt.Println("Multi-Repo Examples:")
+		fmt.Println("  agent-deck add . --add-path /path/to/repo2 --add-path /path/to/repo3")
+		fmt.Println("  agent-deck add . -w feature/my-branch --add-path /path/to/repo2")
 		fmt.Println()
 		fmt.Println("SSH Examples:")
 		fmt.Println("  agent-deck add --ssh user@host --remote-path ~/project -c claude")
@@ -1070,9 +1082,9 @@ func handleAdd(profile string, args []string) {
 		}
 	}
 
-	// Handle worktree creation
+	// Handle worktree creation (single-repo only; multi-repo delegates to SetupMultiRepo below)
 	var worktreePath, worktreeRepoRoot string
-	if wtBranch != "" {
+	if wtBranch != "" && len(addPaths) == 0 {
 		// Validate path is a git repo
 		if !git.IsGitRepo(path) {
 			fmt.Fprintf(os.Stderr, "Error: %s is not a git repository\n", path)
@@ -1205,6 +1217,44 @@ func handleAdd(profile string, args []string) {
 		newInstance.WorktreePath = worktreePath
 		newInstance.WorktreeRepoRoot = worktreeRepoRoot
 		newInstance.WorktreeBranch = wtBranch
+	}
+
+	// Set up multi-repo if additional paths were provided
+	if len(addPaths) > 0 {
+		resolvedPaths := make([]string, 0, len(addPaths))
+		for _, p := range addPaths {
+			abs, err := filepath.Abs(session.ExpandPath(p))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: failed to resolve --add-path %s: %v\n", p, err)
+				os.Exit(1)
+			}
+			info, err := os.Stat(abs)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: --add-path %s does not exist\n", abs)
+				os.Exit(1)
+			}
+			if !info.IsDir() {
+				fmt.Fprintf(os.Stderr, "Error: --add-path %s is not a directory\n", abs)
+				os.Exit(1)
+			}
+			resolvedPaths = append(resolvedPaths, abs)
+		}
+		// Honour -b in multi-repo mode: fail fast if branch already exists in any repo
+		if createNewBranch && wtBranch != "" {
+			allPaths := append([]string{path}, resolvedPaths...)
+			for _, p := range allPaths {
+				if repoRoot, err := git.GetWorktreeBaseRoot(p); err == nil {
+					if git.BranchExists(repoRoot, wtBranch) {
+						fmt.Fprintf(os.Stderr, "Error: branch '%s' already exists in %s (remove -b to reuse it)\n", wtBranch, p)
+						os.Exit(1)
+					}
+				}
+			}
+		}
+		if err := session.SetupMultiRepo(newInstance, resolvedPaths, wtBranch, session.GetMultiRepoBaseDir()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to set up multi-repo session: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// Apply sandbox config if requested.
@@ -1355,6 +1405,17 @@ func handleAdd(profile string, args []string) {
 		jsonData["worktree_path"] = worktreePath
 		jsonData["worktree_branch"] = wtBranch
 		jsonData["worktree_repo_root"] = worktreeRepoRoot
+	}
+	if newInstance.IsMultiRepo() {
+		jsonData["multi_repo"] = true
+		jsonData["multi_repo_paths"] = newInstance.AllProjectPaths()
+		humanLines = append(humanLines[:len(humanLines)-3],
+			fmt.Sprintf("  Multi-repo: %d paths", len(newInstance.AllProjectPaths())),
+		)
+		humanLines = append(humanLines, "", "Next steps:",
+			fmt.Sprintf("  agent-deck session start %s   # Start the session", sessionTitle),
+			"  agent-deck                         # Open TUI and press Enter to attach",
+		)
 	}
 	if *resumeSession != "" {
 		jsonData["resume_session"] = *resumeSession

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -274,3 +274,87 @@ func TestIsDuplicateSession(t *testing.T) {
 		})
 	}
 }
+
+func TestReorderArgsForFlagParsing_AddPath(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "add-path value not treated as positional",
+			args: []string{".", "--add-path", "/other/repo", "-c", "claude"},
+			want: []string{"--add-path", "/other/repo", "-c", "claude", "."},
+		},
+		{
+			name: "multiple add-path flags",
+			args: []string{".", "--add-path", "/repo1", "--add-path", "/repo2"},
+			want: []string{"--add-path", "/repo1", "--add-path", "/repo2", "."},
+		},
+		{
+			name: "add-path with worktree branch",
+			args: []string{".", "--add-path", "/other/repo", "-w", "feature/branch", "-b"},
+			want: []string{"--add-path", "/other/repo", "-w", "feature/branch", "-b", "."},
+		},
+		{
+			name: "no add-path flag",
+			args: []string{".", "-c", "claude"},
+			want: []string{"-c", "claude", "."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reorderArgsForFlagParsing(tt.args)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len=%d (%v), want len=%d (%v)", len(got), got, len(tt.want), tt.want)
+			}
+			for i, arg := range got {
+				if arg != tt.want[i] {
+					t.Errorf("[%d]: got %q, want %q", i, arg, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestAddPathValidation(t *testing.T) {
+	// Validate that ExpandPath + Abs + Stat pattern works for --add-path values
+	t.Run("tilde expansion", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skip("cannot get home dir")
+		}
+		expanded := session.ExpandPath("~/")
+		if expanded != home && expanded != home+"/" {
+			t.Errorf("ExpandPath(~/): got %q, want %q", expanded, home)
+		}
+	})
+
+	t.Run("nonexistent path fails stat", func(t *testing.T) {
+		_, err := os.Stat("/tmp/agent-deck-test-nonexistent-path-xyz")
+		if err == nil {
+			t.Skip("path unexpectedly exists")
+		}
+		if !os.IsNotExist(err) {
+			t.Errorf("expected IsNotExist error, got %v", err)
+		}
+	})
+
+	t.Run("file path rejected as not-a-dir", func(t *testing.T) {
+		f, err := os.CreateTemp("", "agent-deck-test-*.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(f.Name())
+		f.Close()
+
+		info, err := os.Stat(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.IsDir() {
+			t.Error("expected file to not be a directory")
+		}
+	})
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -106,12 +106,14 @@ func printSessionHelp() {
 	fmt.Println("  wrapper            Wrapper command (use {command} to include tool command)")
 	fmt.Println("  claude-session-id  Claude conversation ID (for fork/resume)")
 	fmt.Println("  gemini-session-id  Gemini conversation ID (for resume)")
+	fmt.Println("  add-path           Add a repository to a multi-repo session")
 	fmt.Println()
 	fmt.Println("Set examples:")
 	fmt.Println("  agent-deck session set my-project title \"New Title\"")
 	fmt.Println("  agent-deck session set my-project claude-session-id \"abc123-def456\"")
 	fmt.Println("  agent-deck session set my-project tool claude")
 	fmt.Println("  agent-deck session set my-project wrapper \"nvim +'terminal {command}'\"")
+	fmt.Println("  agent-deck session set my-project add-path /path/to/another-repo")
 }
 
 // handleSessionStart starts a session's tmux process
@@ -841,6 +843,7 @@ func handleSessionSet(profile string, args []string) {
 		fmt.Println("  wrapper            Wrapper command (use {command} to include tool command)")
 		fmt.Println("  claude-session-id  Claude conversation ID")
 		fmt.Println("  gemini-session-id  Gemini conversation ID")
+		fmt.Println("  add-path           Add a repository to a multi-repo session")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -876,12 +879,13 @@ func handleSessionSet(profile string, args []string) {
 		"wrapper":           true,
 		"claude-session-id": true,
 		"gemini-session-id": true,
+		"add-path":          true,
 	}
 
 	if !validFields[field] {
 		out.Error(
 			fmt.Sprintf(
-				"invalid field: %s\nValid fields: title, path, command, tool, wrapper, claude-session-id, gemini-session-id",
+				"invalid field: %s\nValid fields: title, path, command, tool, wrapper, claude-session-id, gemini-session-id, add-path",
 				field,
 			),
 			ErrCodeInvalidOperation,
@@ -944,6 +948,26 @@ func handleSessionSet(profile string, args []string) {
 		if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil && tmuxSess.Exists() {
 			_ = exec.Command("tmux", "set-environment", "-t", tmuxSess.Name, "GEMINI_SESSION_ID", value).Run()
 		}
+	case "add-path":
+		createdPath, err := session.AddPathToMultiRepo(inst, value)
+		if err != nil {
+			out.Error(fmt.Sprintf("failed to add path: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		groupTree := session.NewGroupTreeWithGroups(instances, groupsData)
+		if err := storage.SaveWithGroups(instances, groupTree); err != nil {
+			out.Error(fmt.Sprintf("failed to save: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		out.Success(fmt.Sprintf("Added %s -> %s", value, createdPath), map[string]interface{}{
+			"success":      true,
+			"id":           inst.ID,
+			"title":        inst.Title,
+			"field":        field,
+			"added_path":   value,
+			"created_path": createdPath,
+		})
+		return
 	}
 
 	// Save

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3960,7 +3960,7 @@ func (i *Instance) Restart() error {
 	}
 
 	// Fallback: recreate tmux session (for dead sessions or unknown ID)
-	i.tmuxSession = tmux.NewSession(i.Title, i.ProjectPath)
+	i.tmuxSession = tmux.NewSession(i.Title, i.EffectiveWorkingDir())
 	i.tmuxSession.InstanceID = i.ID // Pass instance ID for activity hooks
 	i.tmuxSession.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
 

--- a/internal/session/multirepo_setup.go
+++ b/internal/session/multirepo_setup.go
@@ -1,0 +1,179 @@
+package session
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+)
+
+// SetupMultiRepo configures inst for a multi-repo session by creating a parent
+// directory with either git worktrees (when worktreeBranch is set) or symlinks
+// (otherwise) for each repo path.
+//
+// baseDir is the parent directory under which session dirs are created.
+// If empty, defaults to ~/.agent-deck/multi-repo-worktrees.
+//
+// The function mutates inst: sets MultiRepoEnabled, MultiRepoTempDir,
+// MultiRepoWorktrees, ProjectPath, AdditionalPaths, and the tmux WorkDir.
+func SetupMultiRepo(inst *Instance, additionalPaths []string, worktreeBranch, baseDir string) error {
+	if len(additionalPaths) == 0 {
+		return nil
+	}
+
+	inst.MultiRepoEnabled = true
+	inst.AdditionalPaths = additionalPaths
+	allPaths := inst.AllProjectPaths()
+
+	if baseDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+		baseDir = filepath.Join(home, ".agent-deck", "multi-repo-worktrees")
+	}
+
+	var parentDir string
+	if worktreeBranch != "" {
+		sanitized := strings.ReplaceAll(worktreeBranch, "/", "-")
+		sanitized = strings.ReplaceAll(sanitized, " ", "-")
+		parentDir = filepath.Join(baseDir, fmt.Sprintf("%s-%s", sanitized, inst.ID[:8]))
+	} else {
+		parentDir = filepath.Join(baseDir, inst.ID[:8])
+	}
+
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create multi-repo dir: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(parentDir); err == nil {
+		parentDir = resolved
+	}
+	inst.MultiRepoTempDir = parentDir
+
+	dirnames := DeduplicateDirnames(allPaths)
+	var newProjectPath string
+	var newAdditionalPaths []string
+
+	for i, p := range allPaths {
+		targetPath := filepath.Join(parentDir, dirnames[i])
+
+		if worktreeBranch != "" {
+			if git.IsGitRepo(p) {
+				repoRoot, err := git.GetWorktreeBaseRoot(p)
+				if err != nil {
+					slog.Warn("multirepo_worktree_skip",
+						slog.String("path", p),
+						slog.String("error", err.Error()))
+					_ = os.Symlink(p, targetPath)
+				} else if err := git.CreateWorktree(repoRoot, targetPath, worktreeBranch); err != nil {
+					slog.Warn("multirepo_worktree_create_fail",
+						slog.String("path", p),
+						slog.String("error", err.Error()))
+					_ = os.Symlink(p, targetPath)
+				} else {
+					inst.MultiRepoWorktrees = append(inst.MultiRepoWorktrees, MultiRepoWorktree{
+						OriginalPath: p,
+						WorktreePath: targetPath,
+						RepoRoot:     repoRoot,
+						Branch:       worktreeBranch,
+					})
+				}
+			} else {
+				_ = os.Symlink(p, targetPath)
+			}
+		} else {
+			_ = os.Symlink(p, targetPath)
+		}
+
+		if i == 0 {
+			newProjectPath = targetPath
+		} else {
+			newAdditionalPaths = append(newAdditionalPaths, targetPath)
+		}
+	}
+
+	inst.ProjectPath = newProjectPath
+	inst.AdditionalPaths = newAdditionalPaths
+
+	if inst.GetTmuxSession() != nil {
+		inst.GetTmuxSession().WorkDir = inst.MultiRepoTempDir
+	}
+
+	return nil
+}
+
+// AddPathToMultiRepo adds a new repository to an existing multi-repo session.
+// Creates a symlink (or git worktree if the session was created with worktrees)
+// in the session's MultiRepoTempDir and appends the new path to AdditionalPaths.
+// Returns the path of the created symlink/worktree inside the parent dir.
+func AddPathToMultiRepo(inst *Instance, newPath string) (string, error) {
+	// Auto-initialize multi-repo if not already enabled.
+	// Use the parent of the current ProjectPath as the workspace root —
+	// useful when worktrees were already set up manually on disk.
+	if !inst.MultiRepoEnabled || inst.MultiRepoTempDir == "" {
+		parentDir := filepath.Dir(inst.ProjectPath)
+		if parentDir == "" || parentDir == "." {
+			return "", fmt.Errorf("session is not a multi-repo session; create it with --add-path")
+		}
+		inst.MultiRepoEnabled = true
+		inst.MultiRepoTempDir = parentDir
+	}
+
+	abs, err := filepath.Abs(ExpandPath(newPath))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path: %w", err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		return "", fmt.Errorf("path does not exist: %s", abs)
+	}
+
+	// If session was created with worktrees, create a worktree for the new path too
+	var worktreeBranch string
+	if len(inst.MultiRepoWorktrees) > 0 {
+		worktreeBranch = inst.MultiRepoWorktrees[0].Branch
+	}
+
+	// Find a unique name inside the parent dir
+	candidate := filepath.Base(abs)
+	targetPath := filepath.Join(inst.MultiRepoTempDir, candidate)
+	for i := 1; ; i++ {
+		if _, err := os.Stat(targetPath); os.IsNotExist(err) {
+			break
+		}
+		targetPath = filepath.Join(inst.MultiRepoTempDir, fmt.Sprintf("%s-%d", candidate, i))
+	}
+
+	if worktreeBranch != "" && git.IsGitRepo(abs) {
+		repoRoot, err := git.GetWorktreeBaseRoot(abs)
+		if err == nil {
+			if err := git.CreateWorktree(repoRoot, targetPath, worktreeBranch); err == nil {
+				inst.MultiRepoWorktrees = append(inst.MultiRepoWorktrees, MultiRepoWorktree{
+					OriginalPath: abs,
+					WorktreePath: targetPath,
+					RepoRoot:     repoRoot,
+					Branch:       worktreeBranch,
+				})
+				inst.AdditionalPaths = append(inst.AdditionalPaths, targetPath)
+				return targetPath, nil
+			}
+			slog.Warn("multirepo_add_worktree_fail",
+				slog.String("path", abs),
+				slog.String("error", err.Error()),
+				slog.String("fallback", "symlink"))
+		}
+	}
+
+	// Fallback: symlink. If the path is already directly inside the parent dir, use it as-is.
+	if filepath.Dir(abs) == inst.MultiRepoTempDir {
+		inst.AdditionalPaths = append(inst.AdditionalPaths, abs)
+		return abs, nil
+	}
+	if err := os.Symlink(abs, targetPath); err != nil {
+		return "", fmt.Errorf("failed to create symlink in %s: %w", inst.MultiRepoTempDir, err)
+	}
+	inst.AdditionalPaths = append(inst.AdditionalPaths, targetPath)
+	return targetPath, nil
+}

--- a/internal/session/multirepo_test.go
+++ b/internal/session/multirepo_test.go
@@ -61,6 +61,86 @@ func TestCleanupMultiRepoTempDir(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestAddPathToMultiRepo(t *testing.T) {
+	// Create a temp parent dir (simulating MultiRepoTempDir)
+	parentDir := t.TempDir()
+	// Create a temp repo dir to add
+	repoDir := t.TempDir()
+
+	inst := &Instance{
+		ID:               "abc12345",
+		MultiRepoEnabled: true,
+		MultiRepoTempDir: parentDir,
+		ProjectPath:      filepath.Join(parentDir, "existing-repo"),
+		AdditionalPaths:  []string{},
+	}
+
+	createdPath, err := AddPathToMultiRepo(inst, repoDir)
+	require.NoError(t, err)
+
+	// Should have created a symlink inside parentDir
+	assert.Equal(t, filepath.Join(parentDir, filepath.Base(repoDir)), createdPath)
+	link, err := os.Readlink(createdPath)
+	require.NoError(t, err)
+	assert.Equal(t, repoDir, link)
+
+	// AdditionalPaths should be updated
+	assert.Contains(t, inst.AdditionalPaths, createdPath)
+}
+
+func TestAddPathToMultiRepo_NameConflict(t *testing.T) {
+	parentDir := t.TempDir()
+	repoDir := t.TempDir()
+	repoName := filepath.Base(repoDir)
+
+	inst := &Instance{
+		ID:               "abc12345",
+		MultiRepoEnabled: true,
+		MultiRepoTempDir: parentDir,
+	}
+
+	// Pre-create a conflicting entry
+	conflictPath := filepath.Join(parentDir, repoName)
+	require.NoError(t, os.MkdirAll(conflictPath, 0o755))
+
+	createdPath, err := AddPathToMultiRepo(inst, repoDir)
+	require.NoError(t, err)
+
+	// Should have used -1 suffix to avoid conflict
+	assert.Equal(t, filepath.Join(parentDir, repoName+"-1"), createdPath)
+}
+
+func TestAddPathToMultiRepo_AutoInit(t *testing.T) {
+	// Session not yet multi-repo — parent dir inferred from ProjectPath
+	parentDir := t.TempDir()
+	repoDir := t.TempDir()
+	existingRepo := filepath.Join(parentDir, "gateway-services")
+	require.NoError(t, os.MkdirAll(existingRepo, 0o755))
+
+	inst := &Instance{
+		ID:          "abc12345",
+		ProjectPath: existingRepo,
+	}
+
+	createdPath, err := AddPathToMultiRepo(inst, repoDir)
+	require.NoError(t, err)
+
+	assert.True(t, inst.MultiRepoEnabled)
+	assert.Equal(t, parentDir, inst.MultiRepoTempDir)
+	assert.Equal(t, filepath.Join(parentDir, filepath.Base(repoDir)), createdPath)
+	assert.Contains(t, inst.AdditionalPaths, createdPath)
+}
+
+func TestAddPathToMultiRepo_NotMultiRepo(t *testing.T) {
+	// Relative/empty ProjectPath — cannot infer parent
+	inst := &Instance{ProjectPath: "relative"}
+	repoDir := t.TempDir()
+	_, err := AddPathToMultiRepo(inst, repoDir)
+	// Should succeed by auto-init (parent of "relative" is ".")
+	// Actually "." is filtered, so it errors
+	assert.Error(t, err)
+}
+
 func TestDeduplicateDirnames(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -722,10 +722,15 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			// Convert Status enum to string for tmux package
 			// This restores the exact status across app restarts
 			previousStatus := statusToString(instData.Status)
+			// Multi-repo sessions use the parent dir as working dir, not ProjectPath
+			reconnectWorkDir := instData.ProjectPath
+			if instData.MultiRepoEnabled && instData.MultiRepoTempDir != "" {
+				reconnectWorkDir = instData.MultiRepoTempDir
+			}
 			tmuxSess = tmux.ReconnectSessionLazy(
 				instData.TmuxSession,
 				instData.Title,
-				instData.ProjectPath,
+				reconnectWorkDir,
 				instData.Command,
 				previousStatus,
 			)

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -662,6 +662,11 @@ type WorktreeSettings struct {
 	// Set to "" to disable auto-prefixing (just the session name).
 	// Default: "feature/" when not set.
 	BranchPrefix *string `toml:"branch_prefix"`
+
+	// MultiRepoBaseDir overrides the default base directory used when creating
+	// multi-repo session symlink/worktree directories.
+	// Default: ~/.agent-deck/multi-repo-worktrees
+	MultiRepoBaseDir string `toml:"multi_repo_base_dir"`
 }
 
 // Template returns the path template if set, or empty string if nil.
@@ -678,6 +683,21 @@ func (w *WorktreeSettings) Prefix() string {
 		return "feature/"
 	}
 	return *w.BranchPrefix
+}
+
+// MultiRepoBase returns the effective base directory for multi-repo sessions.
+// Expands a leading ~/ to the user home directory.
+// Returns ~/.agent-deck/multi-repo-worktrees if not configured.
+func (w *WorktreeSettings) MultiRepoBase() string {
+	if w.MultiRepoBaseDir != "" {
+		if strings.HasPrefix(w.MultiRepoBaseDir, "~/") {
+			home, _ := os.UserHomeDir()
+			return filepath.Join(home, w.MultiRepoBaseDir[2:])
+		}
+		return w.MultiRepoBaseDir
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".agent-deck", "multi-repo-worktrees")
 }
 
 // GlobalSearchSettings defines global conversation search configuration
@@ -1478,6 +1498,16 @@ func GetWorktreeSettings() WorktreeSettings {
 	return settings
 }
 
+// GetMultiRepoBaseDir returns the configured base directory for multi-repo sessions.
+func GetMultiRepoBaseDir() string {
+	config, err := LoadUserConfig()
+	if err != nil || config == nil {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, ".agent-deck", "multi-repo-worktrees")
+	}
+	return config.Worktree.MultiRepoBase()
+}
+
 // GetUpdateSettings returns update settings with defaults applied
 func GetUpdateSettings() UpdateSettings {
 	config, err := LoadUserConfig()
@@ -1793,6 +1823,8 @@ auto_cleanup = true
 #   {branch}         -> sanitized (human-friendly, may collide)
 #   {branch-escaped} -> URL-escaped (collision-resistant, reversible)
 # path_template = "../worktrees/{repo-name}/{branch}"
+# Base directory for multi-repo session symlink/worktree dirs (default: ~/.agent-deck/multi-repo-worktrees)
+# multi_repo_base_dir = "~/my-workspaces/multi-repo"
 
 # Default scope for MCP operations: "local", "global", or "user"
 # "local" writes to .mcp.json (project-only, default)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6672,110 +6672,8 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 
 		// Apply multi-repo config.
 		if multiRepoEnabled && len(additionalPaths) > 0 {
-			inst.MultiRepoEnabled = true
-			inst.AdditionalPaths = additionalPaths
-			allPaths := inst.AllProjectPaths()
-
-			if worktreeBranch != "" {
-				// Multi-repo + worktree: create a persistent parent dir with all worktrees inside.
-				// Layout: ~/.agent-deck/multi-repo-worktrees/<branch>-<id>/<repo-name>/
-				home, _ := os.UserHomeDir()
-				sanitizedBranch := strings.ReplaceAll(worktreeBranch, "/", "-")
-				sanitizedBranch = strings.ReplaceAll(sanitizedBranch, " ", "-")
-				parentDir := filepath.Join(home, ".agent-deck", "multi-repo-worktrees",
-					fmt.Sprintf("%s-%s", sanitizedBranch, inst.ID[:8]))
-				if mkErr := os.MkdirAll(parentDir, 0o755); mkErr != nil {
-					return sessionCreatedMsg{err: fmt.Errorf("failed to create multi-repo worktree dir: %w", mkErr), tempID: tempID}
-				}
-				if resolved, evalErr := filepath.EvalSymlinks(parentDir); evalErr == nil {
-					parentDir = resolved
-				}
-				inst.MultiRepoTempDir = parentDir
-
-				// Create worktrees inside parentDir, named after each repo
-				dirnames := session.DeduplicateDirnames(allPaths)
-				var newProjectPath string
-				var newAdditionalPaths []string
-				for i, p := range allPaths {
-					wtPath := filepath.Join(parentDir, dirnames[i])
-					if git.IsGitRepo(p) {
-						repoRoot, rootErr := git.GetWorktreeBaseRoot(p)
-						if rootErr != nil {
-							uiLog.Warn("multi_repo_worktree_skip", slog.String("path", p), slog.String("error", rootErr.Error()))
-							// Copy path as-is into the parent dir via symlink
-							_ = os.Symlink(p, wtPath)
-							if i == 0 {
-								newProjectPath = wtPath
-							} else {
-								newAdditionalPaths = append(newAdditionalPaths, wtPath)
-							}
-							continue
-						}
-						if err := git.CreateWorktree(repoRoot, wtPath, worktreeBranch); err != nil {
-							uiLog.Warn("multi_repo_worktree_create_fail", slog.String("path", p), slog.String("error", err.Error()))
-							_ = os.Symlink(p, wtPath)
-							if i == 0 {
-								newProjectPath = wtPath
-							} else {
-								newAdditionalPaths = append(newAdditionalPaths, wtPath)
-							}
-							continue
-						}
-						inst.MultiRepoWorktrees = append(inst.MultiRepoWorktrees, session.MultiRepoWorktree{
-							OriginalPath: p,
-							WorktreePath: wtPath,
-							RepoRoot:     repoRoot,
-							Branch:       worktreeBranch,
-						})
-						if i == 0 {
-							newProjectPath = wtPath
-						} else {
-							newAdditionalPaths = append(newAdditionalPaths, wtPath)
-						}
-					} else {
-						// Non-git paths: symlink into parent dir
-						_ = os.Symlink(p, wtPath)
-						if i == 0 {
-							newProjectPath = wtPath
-						} else {
-							newAdditionalPaths = append(newAdditionalPaths, wtPath)
-						}
-					}
-				}
-				inst.ProjectPath = newProjectPath
-				inst.AdditionalPaths = newAdditionalPaths
-			} else {
-				// Multi-repo without worktree: create a persistent parent dir with symlinks.
-				home, _ := os.UserHomeDir()
-				parentDir := filepath.Join(home, ".agent-deck", "multi-repo-worktrees", inst.ID[:8])
-				if mkErr := os.MkdirAll(parentDir, 0o755); mkErr != nil {
-					return sessionCreatedMsg{err: fmt.Errorf("failed to create multi-repo dir: %w", mkErr), tempID: tempID}
-				}
-				if resolved, evalErr := filepath.EvalSymlinks(parentDir); evalErr == nil {
-					parentDir = resolved
-				}
-				inst.MultiRepoTempDir = parentDir
-
-				// Create symlinks for all paths
-				dirnames := session.DeduplicateDirnames(allPaths)
-				var newProjectPath string
-				var newAdditionalPaths []string
-				for i, p := range allPaths {
-					linkPath := filepath.Join(parentDir, dirnames[i])
-					_ = os.Symlink(p, linkPath)
-					if i == 0 {
-						newProjectPath = linkPath
-					} else {
-						newAdditionalPaths = append(newAdditionalPaths, linkPath)
-					}
-				}
-				inst.ProjectPath = newProjectPath
-				inst.AdditionalPaths = newAdditionalPaths
-			}
-
-			// Update tmux session working directory to the parent dir
-			if inst.GetTmuxSession() != nil {
-				inst.GetTmuxSession().WorkDir = inst.MultiRepoTempDir
+			if err := session.SetupMultiRepo(inst, additionalPaths, worktreeBranch, session.GetMultiRepoBaseDir()); err != nil {
+				return sessionCreatedMsg{err: err}
 			}
 		}
 
@@ -7082,8 +6980,7 @@ func (h *Home) forkSessionCmdWithOptions(
 				inst.MultiRepoWorktrees = append([]session.MultiRepoWorktree{}, source.MultiRepoWorktrees...)
 			}
 			// Create a new persistent dir for the fork with symlinks to shared worktrees
-			home, _ := os.UserHomeDir()
-			parentDir := filepath.Join(home, ".agent-deck", "multi-repo-worktrees", inst.ID[:8])
+			parentDir := filepath.Join(session.GetMultiRepoBaseDir(), inst.ID[:8])
 			if mkErr := os.MkdirAll(parentDir, 0o755); mkErr != nil {
 				return sessionForkedMsg{err: fmt.Errorf("failed to create multi-repo dir: %w", mkErr), sourceID: sourceID}
 			}

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -21,7 +21,6 @@ package ui
 import (
 	"bytes"
 	"io"
-	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -41,14 +40,7 @@ func DisableKittyKeyboard(w io.Writer) {
 // Call this before attaching to a session that needs Kitty keyboard support
 // (e.g. Claude Code). Pair with DisableKittyKeyboard to pop the stack on
 // return.
-//
-// No-op when running inside tmux: tmux does not forward Kitty protocol
-// sequences correctly and enabling it causes ESC to be received as literal
-// "27u" by inner processes.
 func EnableKittyKeyboard(w io.Writer) {
-	if os.Getenv("TMUX") != "" {
-		return
-	}
 	_, _ = io.WriteString(w, "\x1b[>1u")
 }
 

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -21,6 +21,7 @@ package ui
 import (
 	"bytes"
 	"io"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -40,7 +41,14 @@ func DisableKittyKeyboard(w io.Writer) {
 // Call this before attaching to a session that needs Kitty keyboard support
 // (e.g. Claude Code). Pair with DisableKittyKeyboard to pop the stack on
 // return.
+//
+// No-op when running inside tmux: tmux does not forward Kitty protocol
+// sequences correctly and enabling it causes ESC to be received as literal
+// "27u" by inner processes.
 func EnableKittyKeyboard(w io.Writer) {
+	if os.Getenv("TMUX") != "" {
+		return
+	}
 	_, _ = io.WriteString(w, "\x1b[>1u")
 }
 


### PR DESCRIPTION
## What changed

- **`--add-path` flag** on both `add` and `launch` commands — repeatable, creates multi-repo sessions from CLI:
  ```
  agent-deck add . --add-path /path/to/repo2 --add-path /path/to/repo3
  agent-deck launch . -c claude --add-path /path/to/repo2 -w feature/branch -b
  ```
- **Extracted `session.SetupMultiRepo()`** — multi-repo setup logic from `home.go` is now in `internal/session/multirepo_setup.go`, shared by TUI and CLI
- **`multi_repo_base_dir` config option** in `[worktree]` section of `config.toml` — overrides the default `~/.agent-deck/multi-repo-worktrees/`
- **`session set <id> add-path <path>`** — add a repo to an existing multi-repo session (creates worktree or symlink; auto-initializes single-repo sessions)
- **`-b` flag wired in multi-repo mode** — validates branch doesn't already exist across all repos before setup
- **`--add-path` path validation** — `os.Stat` + dir check upfront before calling `SetupMultiRepo`
- **Fix `reorderArgsForFlagParsing`** — `--add-path` was missing from `valueFlags`, causing its value to be consumed as a flag name
- **Fix single-repo worktree skip** — single-repo worktree block now skipped when `--add-path` is present
- **Fix `EffectiveWorkingDir` for tmux WorkDir** — used on session load (`ReconnectSessionLazy`) and restart

## Addresses review feedback from #435
- `-b` flag now validated in multi-repo path (not dead code)
- Path validation added for `--add-path` (exists, is directory)
- Tests added for `reorderArgsForFlagParsing` with `--add-path` and path validation

🤖 Generated with [Claude Code](https://claude.com/code)