### PR TITLE
Fix #522: replace grep -o with grep -q and awk in heartbeat script

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -720,7 +720,7 @@ func buildDaemonPath(agentDeckPath string) string {
 }
 
 // conductorHeartbeatScript is the shell script that sends a heartbeat to a conductor session.
-// Uses grep instead of sed for JSON parsing to stay portable across GNU and BSD (macOS).
+// Uses grep -q and awk for JSON parsing to stay portable across GNU and BSD (macOS).
 const conductorHeartbeatScript = `#!/bin/bash
 # Heartbeat for conductor: {NAME} (profile: {PROFILE})
 # Sends a check-in message to the conductor session (non-blocking)
@@ -728,14 +728,13 @@ const conductorHeartbeatScript = `#!/bin/bash
 SESSION="conductor-{NAME}"
 PROFILE="{PROFILE}"
 
-# Check if conductor is enabled (grep -o works on both GNU and BSD)
-ENABLED=$(agent-deck -p "$PROFILE" conductor status --json 2>/dev/null | grep -o '"enabled"[[:space:]]*:[[:space:]]*true')
-if [ -z "$ENABLED" ]; then
+# Check if conductor is enabled (grep -q avoids quoting issues in subshells)
+if ! agent-deck -p "$PROFILE" conductor status --json 2>/dev/null | grep -q '"enabled".*true'; then
     exit 0
 fi
 
 # Only send if the session is running
-STATUS=$(agent-deck -p "$PROFILE" session show "$SESSION" --json 2>/dev/null | grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -o '"[^"]*"$' | tr -d '"')
+STATUS=$(agent-deck -p "$PROFILE" session show "$SESSION" --json 2>/dev/null | awk -F'"' '/"status"/{print $4; exit}')
 
 if [ "$STATUS" = "idle" ] || [ "$STATUS" = "waiting" ]; then
     agent-deck -p "$PROFILE" session send "$SESSION" "Heartbeat: Check sessions in your group ({NAME}). List any that are waiting, auto-respond where safe, and report what needs my attention." --no-wait -q

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -599,8 +599,8 @@ func TestBridgeTemplate_SendToConductorSupportsSingleCallWait(t *testing.T) {
 }
 
 func TestConductorHeartbeatScript_StatusParsingHandlesWhitespace(t *testing.T) {
-	if !strings.Contains(conductorHeartbeatScript, `"status"[[:space:]]*:[[:space:]]*"`) {
-		t.Fatal("heartbeat status parser should tolerate JSON whitespace around ':'")
+	if !strings.Contains(conductorHeartbeatScript, `"status"`) {
+		t.Fatal("heartbeat status parser should extract status field")
 	}
 	if !strings.Contains(conductorHeartbeatScript, `session send "$SESSION"`) {
 		t.Fatal("heartbeat script should send heartbeat messages")
@@ -2123,8 +2123,8 @@ func TestConductorHeartbeatScript_GroupScoped(t *testing.T) {
 	}
 
 	// The script must contain an enabled-config guard that queries conductor status
-	if !strings.Contains(conductorHeartbeatScript, "ENABLED") {
-		t.Fatal("heartbeat script must contain an ENABLED guard that checks conductor status before sending")
+	if !strings.Contains(conductorHeartbeatScript, "enabled") {
+		t.Fatal("heartbeat script must contain an enabled guard that checks conductor status before sending")
 	}
 	if !strings.Contains(conductorHeartbeatScript, "conductor status") {
 		t.Fatal("heartbeat script must query conductor status to determine if enabled")


### PR DESCRIPTION
## Summary

- Replaced `grep -o` (inside `$(...)` subshell) with `grep -q` for the enabled check, eliminating the `')` token that caused bash syntax errors on Linux
- Replaced chained `grep -o | head | grep -o | tr` pipeline for status extraction with a single `awk -F'"'` call
- The auto-migration (`MigrateConductorHeartbeatScripts`) will detect the stale script and overwrite it on next conductor command

Fixes #522