### PR TITLE
Fix #525: detect tmux in well-known paths when not in PATH

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -324,11 +325,22 @@ func main() {
 		return
 	}
 
-	// Check if tmux is available
-	if _, err := exec.LookPath("tmux"); err != nil {
-		fmt.Println("Error: tmux not found in PATH")
-		fmt.Println("\nAgent Deck requires tmux. Install with:")
-		fmt.Println("  brew install tmux")
+	// Check if tmux is available (with fallback path search)
+	if err := ensureTmuxInPath(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: tmux not found")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Agent Deck requires tmux. Install with:")
+		switch runtime.GOOS {
+		case "darwin":
+			fmt.Fprintln(os.Stderr, "  brew install tmux")
+		case "linux":
+			fmt.Fprintln(os.Stderr, "  sudo apt install tmux    # Debian/Ubuntu")
+			fmt.Fprintln(os.Stderr, "  sudo dnf install tmux    # Fedora/RHEL")
+			fmt.Fprintln(os.Stderr, "  sudo pacman -S tmux      # Arch")
+		default:
+			fmt.Fprintln(os.Stderr, "  See: https://github.com/tmux/tmux/wiki/Installing")
+		}
+		fmt.Fprintf(os.Stderr, "\nSearched PATH: %s\n", os.Getenv("PATH"))
 		os.Exit(1)
 	}
 
@@ -2908,6 +2920,41 @@ func handleUninstall(args []string) {
 // Uses GetCurrentSessionID() which checks if the current tmux session name matches agentdeck_*.
 func isNestedSession() bool {
 	return GetCurrentSessionID() != ""
+}
+
+// ensureTmuxInPath checks that tmux is reachable. If exec.LookPath fails
+// (common when the Go binary inherits a minimal PATH from a desktop launcher,
+// systemd unit, or non-login shell), it probes well-known installation
+// directories. When tmux is found via fallback, the containing directory is
+// prepended to PATH so every subsequent exec.Command("tmux", …) succeeds.
+func ensureTmuxInPath() error {
+	if _, err := exec.LookPath("tmux"); err == nil {
+		return nil
+	}
+
+	// Well-known paths where tmux is commonly installed.
+	fallbacks := []string{
+		"/usr/bin/tmux",
+		"/usr/local/bin/tmux",
+		"/opt/homebrew/bin/tmux",
+		"/home/linuxbrew/.linuxbrew/bin/tmux",
+		"/snap/bin/tmux",
+	}
+
+	for _, p := range fallbacks {
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		// Must be a regular file (or symlink target) with at least one execute bit.
+		if info.Mode().IsRegular() && info.Mode()&0111 != 0 {
+			dir := filepath.Dir(p)
+			_ = os.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			return nil
+		}
+	}
+
+	return fmt.Errorf("tmux not found in PATH or common locations")
 }
 
 // formatSize formats bytes into human-readable size

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -273,4 +274,80 @@ func TestIsDuplicateSession(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEnsureTmuxInPath(t *testing.T) {
+	// ensureTmuxInPath should succeed when tmux is genuinely installed.
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not available")
+	}
+
+	t.Run("found_via_LookPath", func(t *testing.T) {
+		if err := ensureTmuxInPath(); err != nil {
+			t.Fatalf("ensureTmuxInPath() failed: %v", err)
+		}
+	})
+
+	t.Run("found_via_fallback", func(t *testing.T) {
+		// Discover the real tmux path so we can verify the fallback finds it.
+		realPath, err := exec.LookPath("tmux")
+		if err != nil {
+			t.Skip("tmux not in PATH")
+		}
+
+		// Strip PATH down to something that definitely does NOT contain tmux,
+		// then let ensureTmuxInPath try the fallback paths.
+		origPath := os.Getenv("PATH")
+		os.Setenv("PATH", "/nonexistent-dir-for-test")
+		defer os.Setenv("PATH", origPath)
+
+		err = ensureTmuxInPath()
+		if err != nil {
+			// Only fail if the real tmux lived in one of the fallback dirs.
+			dir := filepath.Dir(realPath)
+			wellKnown := []string{
+				"/usr/bin",
+				"/usr/local/bin",
+				"/opt/homebrew/bin",
+				"/home/linuxbrew/.linuxbrew/bin",
+				"/snap/bin",
+			}
+			for _, d := range wellKnown {
+				if d == dir {
+					t.Fatalf("ensureTmuxInPath() should have found tmux at %s via fallback", realPath)
+				}
+			}
+			t.Skipf("tmux at %s is not in a well-known fallback dir; fallback correctly failed", realPath)
+		}
+
+		// Verify that PATH was updated so LookPath now succeeds.
+		if _, err := exec.LookPath("tmux"); err != nil {
+			t.Fatalf("after ensureTmuxInPath(), exec.LookPath still fails: %v", err)
+		}
+	})
+
+	t.Run("not_found_anywhere", func(t *testing.T) {
+		origPath := os.Getenv("PATH")
+		os.Setenv("PATH", "/nonexistent-dir-for-test")
+		defer os.Setenv("PATH", origPath)
+
+		// Temporarily check: if tmux is in a well-known path, this test can't
+		// assert failure. Only run the assertion when no well-known path exists.
+		wellKnown := []string{
+			"/usr/bin/tmux",
+			"/usr/local/bin/tmux",
+			"/opt/homebrew/bin/tmux",
+			"/home/linuxbrew/.linuxbrew/bin/tmux",
+			"/snap/bin/tmux",
+		}
+		for _, p := range wellKnown {
+			if _, err := os.Stat(p); err == nil {
+				t.Skipf("tmux exists at well-known path %s; cannot test not-found case", p)
+			}
+		}
+
+		if err := ensureTmuxInPath(); err == nil {
+			t.Fatal("ensureTmuxInPath() should have failed when tmux is not installed")
+		}
+	})
 }


### PR DESCRIPTION
Fixes #525

## Summary
- When `exec.LookPath("tmux")` fails (common with minimal PATH from desktop launchers, non-login shells, or systemd units), agent-deck now probes well-known installation directories (`/usr/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, linuxbrew, `/snap/bin`)
- If found via fallback, the directory is prepended to `$PATH` so all downstream `exec.Command("tmux", ...)` calls work
- Error message now shows OS-specific install instructions (apt/dnf/pacman for Linux, brew for macOS) and the PATH that was searched

## Test plan
- [x] `TestEnsureTmuxInPath/found_via_LookPath` passes
- [x] `TestEnsureTmuxInPath/found_via_fallback` passes (strips PATH, verifies fallback finds tmux)
- [x] `go vet ./...` clean
- [x] `go build` succeeds