### PR TITLE
fix: preserve session scrollback on attach instead of clearing it

### DIFF
--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -68,16 +68,23 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 		return fmt.Errorf("session %s does not exist", s.Name)
 	}
 
-	// Clear scrollback before attaching to prevent stale content from a
-	// previously-attached session bleeding into the new one (#419).
-	// 1. Clear tmux's internal pane scrollback history.
-	clearTarget := s.Name + ":"
-	clearCmd := exec.Command("tmux", "clear-history", "-t", clearTarget)
-	_ = clearCmd.Run()
+	// Restore this session's scrollback into the terminal emulator's buffer
+	// so the user can scroll up through the correct session's history.
+	// This also fixes #419 (cross-session scrollback bleed) because we
+	// clear the emulator buffer first, then replay the target session's
+	// own history — so scrolling up always shows the right content.
+	//
+	// 1. Capture this session's scrollback from tmux's internal buffer.
+	history, _ := s.CaptureFullHistory()
 	// 2. Clear the outer terminal emulator's scrollback buffer.
 	//    \033[3J is the "Erase Saved Lines" escape (ED param 3) supported
 	//    by iTerm2, Terminal.app, Ghostty, and most modern emulators.
 	_, _ = os.Stdout.WriteString("\033[3J")
+	// 3. Replay the captured history to stdout, populating the emulator's
+	//    scrollback with this session's content before we attach.
+	if len(history) > 0 {
+		_, _ = os.Stdout.WriteString(history)
+	}
 
 	// Create context with cancel for detach
 	ctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
## Summary

- Fixes #419 — attaching to a session previously cleared all scrollback history, preventing users from scrolling up through the session's output
- Replaces the destructive `clear-history` approach with a **capture-and-replay** strategy: capture the target session's scrollback from tmux, clear the terminal emulator's buffer, then replay the captured history before attaching
- This still prevents cross-session scrollback bleed (the original #419 fix goal) while preserving the correct session's own history

## How it works

1. **Capture**: `tmux capture-pane -p -e -S -2000` grabs the target session's scrollback (last 2000 lines, with ANSI escapes for color preservation)
2. **Clear**: `\033[3J` (Erase Saved Lines / ED param 3) clears the terminal emulator's scrollback buffer so stale content from a previously-attached session is removed
3. **Replay**: The captured history is written to stdout, populating the emulator's scrollback with the correct session's content before `tmux attach` takes over

## Terminal compatibility

The `\033[3J` escape sequence is supported by all major modern terminal emulators:

| Terminal | Supported |
|---|---|
| iTerm2 | Yes |
| Terminal.app | Yes (macOS 10.12+) |
| Ghostty | Yes |
| Alacritty | Yes |
| Kitty | Yes |
| WezTerm | Yes |
| GNOME Terminal (VTE 0.52+) | Yes |
| Konsole (20.04+) | Yes |
| Windows Terminal | Yes |
| xterm | Partial (newer builds) |

For terminals that don't support `\033[3J` (e.g. nested tmux/screen, very old xterm), the behavior degrades gracefully — the history replay still works correctly, but stale content from a previous session may remain above it in the scrollback.

## Test plan

- [x] Manually tested on iTerm2: attach to session, scroll up, confirm correct session history is shown
- [x] Verify scrollback content is correct after switching between multiple sessions
- [x] Verify no scrollback bleed from previously-attached sessions
- [ ] Test with Ghostty / Alacritty / Terminal.app if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)