### PR TITLE
fix: use Kitty keyboard mode 0 instead of mode 1 to avoid ESC as 27u

### DIFF
--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -34,14 +34,13 @@ func DisableKittyKeyboard(w io.Writer) {
 	_, _ = io.WriteString(w, "\x1b[<u")
 }
 
-// EnableKittyKeyboard writes the escape sequence that pushes Kitty keyboard
-// mode 1 (disambiguate) onto the protocol stack. This re-enables extended key
-// reporting so that sequences like Shift+Enter are sent as CSI u codes.
-// Call this before attaching to a session that needs Kitty keyboard support
-// (e.g. Claude Code). Pair with DisableKittyKeyboard to pop the stack on
-// return.
+// EnableKittyKeyboard pushes Kitty keyboard protocol onto the stack so that
+// the attached session receives extended key sequences like Shift+Enter.
+// Uses flags=0 (no disambiguation) to avoid encoding plain ESC as CSI 27u,
+// which breaks applications that expect a bare \x1b.
+// Pair with DisableKittyKeyboard to pop the stack on return.
 func EnableKittyKeyboard(w io.Writer) {
-	_, _ = io.WriteString(w, "\x1b[>1u")
+	_, _ = io.WriteString(w, "\x1b[>0u")
 }
 
 // RestoreKittyKeyboard writes the escape sequence that pops the keyboard mode

--- a/internal/ui/keyboard_compat_test.go
+++ b/internal/ui/keyboard_compat_test.go
@@ -130,25 +130,25 @@ func TestDisableKittyKeyboard(t *testing.T) {
 	}
 }
 
-// TestEnableKittyKeyboard tests that EnableKittyKeyboard pushes mode 1.
+// TestEnableKittyKeyboard tests that EnableKittyKeyboard pushes mode 0.
 func TestEnableKittyKeyboard(t *testing.T) {
 	var buf bytes.Buffer
 	EnableKittyKeyboard(&buf)
 	got := buf.String()
-	want := "\x1b[>1u"
+	want := "\x1b[>0u"
 	if got != want {
 		t.Errorf("EnableKittyKeyboard wrote %q, want %q", got, want)
 	}
 }
 
-// TestKittyKeyboardPushPopBalance verifies that EnableKittyKeyboard (push mode 1)
+// TestKittyKeyboardPushPopBalance verifies that EnableKittyKeyboard (push mode 0)
 // followed by DisableKittyKeyboard (pop) produces balanced escape sequences.
 func TestKittyKeyboardPushPopBalance(t *testing.T) {
 	var buf bytes.Buffer
 	EnableKittyKeyboard(&buf)
 	DisableKittyKeyboard(&buf)
 	got := buf.String()
-	want := "\x1b[>1u\x1b[<u"
+	want := "\x1b[>0u\x1b[<u"
 	if got != want {
 		t.Errorf("push+pop sequence = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary
- `EnableKittyKeyboard` was pushing mode 1 (disambiguate), which encodes plain ESC as `CSI 27u`. Applications like Claude Code that expect a bare `\x1b` for the escape key see the literal text `27u` instead.
- Changed to mode 0, which still pushes the Kitty protocol onto the stack (enabling Shift+Enter and other extended sequences) without the disambiguation flag that re-encodes ESC.

## Test plan
- [x] Existing `TestEnableKittyKeyboard` and `TestKittyKeyboardPushPopBalance` updated and passing
- [x] Manually verified: attach to Claude Code session, press ESC — sends proper escape instead of `27u`
- [x] Manually verified: Shift+Enter still works in attached Claude Code session

Fixes the regression introduced in #510.