### PR TITLE
fix(tmux): don't wipe pane scrollback on attach

### DIFF
--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -68,15 +68,17 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 		return fmt.Errorf("session %s does not exist", s.Name)
 	}
 
-	// Clear scrollback before attaching to prevent stale content from a
-	// previously-attached session bleeding into the new one (#419).
-	// 1. Clear tmux's internal pane scrollback history.
-	clearTarget := s.Name + ":"
-	clearCmd := exec.Command("tmux", "clear-history", "-t", clearTarget)
-	_ = clearCmd.Run()
-	// 2. Clear the outer terminal emulator's scrollback buffer.
-	//    \033[3J is the "Erase Saved Lines" escape (ED param 3) supported
-	//    by iTerm2, Terminal.app, Ghostty, and most modern emulators.
+	// Clear the outer terminal emulator's scrollback before attaching so
+	// the previously-attached session's output does not linger in the
+	// outer terminal's scrollback buffer (#419). \033[3J is the "Erase
+	// Saved Lines" escape (ED param 3) supported by iTerm2, Terminal.app,
+	// Ghostty, and most modern emulators.
+	//
+	// Do NOT call `tmux clear-history` here. tmux pane histories are
+	// per-pane, so session A's history is never in session B's pane —
+	// clearing on attach fixes no bleed, and it wipes the attached pane's
+	// own scrollback, which breaks mouse-wheel navigation in copy-mode
+	// (the scroll indicator shows [0/0]).
 	_, _ = os.Stdout.WriteString("\033[3J")
 
 	// Create context with cancel for detach


### PR DESCRIPTION
## Summary

- Drop the `tmux clear-history` call from `Session.Attach`; keep the `\033[3J` escape.
- Restores mouse-wheel scrolling and vi copy-mode navigation in attached sessions (regressed since v1.3.1 / #505).
- Does **not** reopen #419 — the cross-session bleed fix lives entirely in the `\033[3J` line, which is preserved.

## Background

#505 fixed #419 (cross-session scrollback bleed) by clearing scrollback before each attach. Since then, users have reported that mouse-wheel scrolling in an attached session shows `[0/0]` (tmux copy-mode's "0 lines / 0 total" indicator) and doesn't move. Affected versions: **v1.3.1, v1.3.2, v1.3.3, v1.3.4, v1.4.0** (verified by diffing `internal/tmux/pty.go` at each release tag).

## Root cause

`internal/tmux/pty.go`, `Session.Attach`:

```go
clearTarget := s.Name + ":"
clearCmd := exec.Command("tmux", "clear-history", "-t", clearTarget)
_ = clearCmd.Run()
_, _ = os.Stdout.WriteString("\033[3J")
```

#505 correctly identified the #419 bug as outer-terminal-emulator scrollback leakage:

> "the outer terminal emulator… retains session A's output in its scrollback buffer"

`\033[3J` (Erase Saved Lines, ED param 3) is exactly the right fix for that — it tells iTerm2/Terminal.app/Ghostty/etc. to wipe their own scrollback. That line stays.

The extra `tmux clear-history` call does not serve #419's goal:

- **tmux pane histories are per-pane.** Session A's output never ends up in session B's pane history buffer — tmux redraws B's viewport from B's own state. So clearing B's history on attach fixes no bleed.
- **It does destroy B's own scrollback**, which is what breaks mouse-wheel navigation. Enter copy-mode via mouse wheel → `[0/0]` because history was just wiped.

The PR description in #505 notes it "mirrors the existing fix in `RespawnPane`" (for #138), but the semantics differ:

- `RespawnPane` *replaces* a pane's process. The old process's scrollback is stale — clear it.
- `Attach` *joins* a live pane. The scrollback is exactly what the user wants to scroll through.

## Reproduction (on current main)

1. `agent-deck add -c claude .` (or any command that produces output)
2. Attach and let output accumulate
3. Detach (Ctrl+Q)
4. Re-attach the same session
5. Mouse-wheel up → yellow `[0/0]` indicator top-right, cursor inverts to copy-mode block, no content scrolls

After this patch, step 5 scrolls through the pane's history as expected.

## Test plan

- [x] `grep -n "clearTarget\|clearCmd" internal/tmux/pty.go` — no remaining refs
- [x] `os/exec` import still used elsewhere in the file (8 other call sites) — no unused-import
- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `go test -race ./internal/tmux/...`
- [ ] Manual: repro steps above — scroll works after attach
- [ ] Manual: verify #419 stays fixed — detach from A, attach to B, outer terminal scrollback is clean (no A content)

(Unchecked items require a Go toolchain; the committer doesn't have one locally. The diff is a 3-line deletion + comment rewrite, no new code introduced, and the remaining `\033[3J` line is exactly what the #419 PR description says is the correct fix. Build/vet should be a no-op.)

## Notes

If you'd prefer a belt-and-suspenders approach that keeps `clear-history` behind a toggle (e.g. only clear on *switch* between different sessions, not on re-attach to the same one), happy to iterate. The minimal fix felt right because the clear-history call doesn't actually address the stated bleed vector.