### PR TITLE
Fix #531: remove clear-history on attach that wiped pane scrollback

### DIFF
--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -68,15 +68,15 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 		return fmt.Errorf("session %s does not exist", s.Name)
 	}
 
-	// Clear scrollback before attaching to prevent stale content from a
-	// previously-attached session bleeding into the new one (#419).
-	// 1. Clear tmux's internal pane scrollback history.
-	clearTarget := s.Name + ":"
-	clearCmd := exec.Command("tmux", "clear-history", "-t", clearTarget)
-	_ = clearCmd.Run()
-	// 2. Clear the outer terminal emulator's scrollback buffer.
-	//    \033[3J is the "Erase Saved Lines" escape (ED param 3) supported
-	//    by iTerm2, Terminal.app, Ghostty, and most modern emulators.
+	// Clear the outer terminal emulator's scrollback buffer to prevent
+	// stale content from a previously-attached session bleeding into the
+	// new one (#419). \033[3J is the "Erase Saved Lines" escape (ED param 3)
+	// supported by iTerm2, Terminal.app, Ghostty, and most modern emulators.
+	//
+	// Note: We intentionally do NOT call `tmux clear-history` here. tmux pane
+	// histories are per-pane, so session A's output never appears in session B's
+	// scrollback. Clearing pane history on attach destroys the user's scrollback
+	// and breaks mouse-wheel / copy-mode navigation (#531).
 	_, _ = os.Stdout.WriteString("\033[3J")
 
 	// Create context with cancel for detach


### PR DESCRIPTION
Fixes #531

## Summary

- Removed the `tmux clear-history` call from `Session.Attach` in `internal/tmux/pty.go`
- This call was introduced by #505 to fix cross-session bleed (#419), but tmux pane histories are per-pane so it never served that purpose
- It destroyed the attached pane's own scrollback, causing mouse-wheel scroll to show `[0/0]` in copy-mode
- The `\033[3J` escape sequence (which correctly clears the outer terminal emulator's scrollback) is preserved

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./internal/tmux/...` passes
- [x] Pre-existing `TestSmoke_TUIRenders` failure confirmed on main (unrelated)
- [ ] Manual: attach to session with accumulated output, detach, re-attach, mouse-wheel up should scroll normally