### PR TITLE
Fix #533: respect user history-limit, stop clearing scrollback on restart

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -394,6 +394,7 @@ func NewInstance(title, projectPath string) *Instance {
 	tmuxSess := tmux.NewSession(title, projectPath)
 	tmuxSess.InstanceID = id // Pass instance ID for activity hooks
 	tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+	tmuxSess.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
 
 	return &Instance{
 		ID:          id,
@@ -420,6 +421,7 @@ func NewInstanceWithTool(title, projectPath, tool string) *Instance {
 	tmuxSess := tmux.NewSession(title, projectPath)
 	tmuxSess.InstanceID = id // Pass instance ID for activity hooks
 	tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+	tmuxSess.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
 
 	inst := &Instance{
 		ID:          id,
@@ -3963,6 +3965,7 @@ func (i *Instance) Restart() error {
 	i.tmuxSession = tmux.NewSession(i.Title, i.ProjectPath)
 	i.tmuxSession.InstanceID = i.ID // Pass instance ID for activity hooks
 	i.tmuxSession.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+	i.tmuxSession.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
 
 	var command string
 	if IsClaudeCompatible(i.Tool) && i.ClaudeSessionID != "" {

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -732,6 +732,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			// Pass instance ID for activity hooks (enables real-time status updates)
 			tmuxSess.InstanceID = instData.ID
 			tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+			tmuxSess.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
 			// Note: EnableMouseMode and ConfigureStatusBar are deferred to EnsureConfigured()
 			// Called automatically when user attaches to session
 		}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -883,6 +883,12 @@ type TmuxSettings struct {
 	// Example: window_style_override = "default"
 	WindowStyleOverride string `toml:"window_style_override"`
 
+	// ClearOnRestart clears the tmux scrollback buffer when a session is
+	// restarted (respawn-pane). When false (default), the previous session's
+	// output is preserved in scrollback. When true, scrollback is wiped so
+	// the new session starts with a clean buffer.
+	ClearOnRestart bool `toml:"clear_on_restart"`
+
 	// Options is a map of tmux option names to values.
 	// These are passed to `tmux set-option -t <session>` after defaults.
 	Options map[string]string `toml:"options"`
@@ -1820,7 +1826,11 @@ auto_cleanup = true
 # window_style_override sets the tmux window-style for all sessions, overriding
 # the theme default. Use "default" to let your terminal's background show through.
 # window_style_override = "default"
-# Override tmux options applied to every session (applied after defaults)
+# clear_on_restart clears the tmux scrollback buffer when a session is restarted.
+# When false (default), previous output is preserved. When true, scrollback is wiped.
+# clear_on_restart = true
+# Override tmux options applied to every session (applied after defaults).
+# agent-deck does NOT set history-limit by default, so your tmux.conf value is used.
 # Options matching agent-deck's managed keys (status, status-style,
 # status-left-length, status-right, status-right-length) will cause agent-deck
 # to skip its default for that key, letting your value take full effect.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -744,6 +744,11 @@ type Session struct {
 	// When false, the status bar configuration is skipped entirely.
 	// Default: true (set via SetInjectStatusLine from user config)
 	injectStatusLine bool
+
+	// clearOnRestart controls whether RespawnPane clears the scrollback buffer.
+	// When false (default), previous session output is preserved.
+	// Set via SetClearOnRestart from user config.
+	clearOnRestart bool
 }
 
 type envCacheEntry struct {
@@ -896,6 +901,14 @@ func (s *Session) SetInjectStatusLine(inject bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.injectStatusLine = inject
+}
+
+// SetClearOnRestart controls whether RespawnPane clears the scrollback buffer.
+// When false (default), previous output is preserved on restart.
+func (s *Session) SetClearOnRestart(clear bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clearOnRestart = clear
 }
 
 // LogFile returns the path to this session's log file
@@ -1346,8 +1359,10 @@ func (s *Session) Start(command string) error {
 	// - mouse on: Mouse scrolling, text selection, pane resizing
 	// - allow-passthrough on: OSC 8 hyperlinks, OSC 52 clipboard (tmux 3.2+, -q for older)
 	// - set-clipboard on: Clipboard integration (Warp, iTerm2, kitty, etc.)
-	// - history-limit 10000: Large scrollback for AI agent output
 	// - escape-time 10: Fast Vim/editor responsiveness (default 500ms is too slow)
+	//
+	// Note: history-limit is NOT set here — the user's tmux.conf value is respected.
+	// Users can override via [tmux] options = { "history-limit" = "50000" } in config.toml.
 	// - extended-keys on: Forward Shift+Enter and other modified keys to apps (tmux 3.2+)
 	// - terminal-features hyperlinks+extkeys: Track hyperlinks and enable extended key reporting (tmux 3.4+, server-wide)
 	//
@@ -1366,7 +1381,6 @@ func (s *Session) Start(command string) error {
 		"set-option", "-t", s.Name, "mouse", "on", ";",
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
-		"set-option", "-t", s.Name, "history-limit", "10000", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
 		"set", "-sq", "extended-keys", "on", ";",
 		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys")
@@ -1546,7 +1560,6 @@ func (s *Session) ConfigureStatusBar() {
 // - mouse on: Mouse wheel scrolling, text selection, pane resizing
 // - set-clipboard on: OSC 52 clipboard integration (works with modern terminals)
 // - allow-passthrough on: OSC 8 hyperlinks, advanced escape sequences (tmux 3.2+)
-// - history-limit 10000: Large scrollback buffer for AI agent output
 // - escape-time 10: Fast Vim/editor responsiveness (default 500ms is too slow)
 //
 // Terminal compatibility:
@@ -1574,14 +1587,12 @@ func (s *Session) EnableMouseMode() error {
 	// - allow-passthrough on: OSC 8 hyperlinks, advanced escape sequences (tmux 3.2+)
 	// - extended-keys on: Forward Shift+Enter and other modified keys to apps (tmux 3.2+)
 	// - terminal-features hyperlinks+extkeys: Track hyperlinks and enable extended key reporting (tmux 3.4+)
-	// - history-limit 10000: Large scrollback for AI agent output
 	// - escape-time 10: Fast Vim/editor responsiveness (default 500ms is too slow)
 	//
 	// Uses -q flag where supported to silently ignore on older tmux versions
 	enhanceCmd := exec.Command("tmux",
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
-		"set-option", "-t", s.Name, "history-limit", "10000", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
 		"set", "-sq", "extended-keys", "on", ";",
 		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys")
@@ -1774,18 +1785,21 @@ func (s *Session) RespawnPane(command string) error {
 		respawnLog.Info("pre_respawn_process_tree", slog.Any("pids", oldPIDs))
 	}
 
-	// Clear scrollback buffer BEFORE respawn to prevent stale content
-	// from previous conversation appearing when user attaches (#138).
-	clearTarget := s.Name + ":"
-	clearCmd := exec.Command("tmux", "clear-history", "-t", clearTarget)
-	if clearOut, clearErr := clearCmd.CombinedOutput(); clearErr != nil {
-		respawnLog.Debug(
-			"clear_history_failed",
-			slog.String("error", clearErr.Error()),
-			slog.String("output", string(clearOut)),
-		)
-	} else {
-		respawnLog.Info("cleared_scrollback", slog.String("session", s.Name))
+	// Optionally clear scrollback buffer BEFORE respawn.
+	// Disabled by default to preserve the user's scroll history.
+	// Enable with [tmux] clear_on_restart = true in config.toml.
+	if s.clearOnRestart {
+		clearTarget := s.Name + ":"
+		clearCmd := exec.Command("tmux", "clear-history", "-t", clearTarget)
+		if clearOut, clearErr := clearCmd.CombinedOutput(); clearErr != nil {
+			respawnLog.Debug(
+				"clear_history_failed",
+				slog.String("error", clearErr.Error()),
+				slog.String("output", string(clearOut)),
+			)
+		} else {
+			respawnLog.Info("cleared_scrollback", slog.String("session", s.Name))
+		}
 	}
 
 	// Build respawn-pane command


### PR DESCRIPTION
Fixes #533

## Summary
- Remove hardcoded `history-limit 10000` from `Start()` and `EnableMouseMode()` so the user's `tmux.conf` setting (e.g. `set -g history-limit 50000`) is respected
- Make `clear-history` on restart opt-in via `[tmux] clear_on_restart = true` in config.toml (default: false, preserving scrollback)

## Changes
- `internal/tmux/tmux.go`: Remove `history-limit 10000` from both session startup and mouse mode enhancement. Add `clearOnRestart` field + setter. Gate `clear-history` in `RespawnPane()` behind the new flag.
- `internal/session/userconfig.go`: Add `ClearOnRestart` field to `TmuxSettings`, update config template with documentation.
- `internal/session/instance.go` + `storage.go`: Wire `ClearOnRestart` config into tmux sessions at all creation points.

## Config
Users who want the old clear-on-restart behavior can opt in:
```toml
[tmux]
clear_on_restart = true
```

Users who want to set a specific history-limit via agent-deck (rather than tmux.conf) can use the existing options map:
```toml
[tmux]
options = { "history-limit" = "50000" }
```