### PR TITLE
fix(#535): Wire CSI u keyboard reader into Bubble Tea input pipeline

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -595,8 +595,10 @@ func main() {
 	ui.DisableKittyKeyboard(os.Stdout)
 	defer ui.RestoreKittyKeyboard(os.Stdout)
 
+	input := ui.NewCSIuReader(os.Stdin)
 	p := tea.NewProgram(
 		homeModel,
+		tea.WithInput(input),
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(),
 	)


### PR DESCRIPTION
Fixes #535

On terminals using the CSI u (Kitty) keyboard protocol, Shift+letter keys and uppercase text input were silently dropped because Bubble Tea v1.3.10 doesn't parse Kitty keyboard sequences natively. The translation layer (`NewCSIuReader` in `keyboard_compat.go`) already existed but was never wired into the program's input pipeline.

This wraps `os.Stdin` with `NewCSIuReader` and passes it via `tea.WithInput()` when creating the Bubble Tea program, so CSI u sequences are translated to legacy bytes before Bubble Tea sees them.