### PR TITLE
Fix #535: wire CSIuReader into tea.NewProgram input pipeline

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -599,6 +599,7 @@ func main() {
 		homeModel,
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(),
+		tea.WithInput(ui.NewCSIuReader(os.Stdin)),
 	)
 
 	// Start maintenance worker (background goroutine, respects config toggle)


### PR DESCRIPTION
## Summary

- Wires the existing `NewCSIuReader` into `tea.NewProgram` via `tea.WithInput()` so CSI u / Kitty keyboard protocol sequences are translated to legacy bytes before Bubble Tea processes them
- Fixes Shift+letter keys being silently dropped on terminals (e.g. Ghostty) that ignore `DisableKittyKeyboard` and continue sending CSI u sequences

## What changed

One line added to `cmd/agent-deck/main.go:602`:
```go
tea.WithInput(ui.NewCSIuReader(os.Stdin)),
```

The reader (`internal/ui/keyboard_compat.go`) was already fully implemented and tested but never connected to the program's input.

## Test plan

- [x] Build compiles cleanly
- [x] All 30+ CSI u reader tests pass (`go test -race ./internal/ui/ -run TestCSIu`)
- [x] Full `internal/ui` test suite passes
- [ ] Manual: Ghostty terminal — Shift+R triggers restart, Shift+S opens settings
- [ ] Manual: Rename dialog produces uppercase letters

Fixes #535