### PR TITLE
fix: remove CSIuReader from tea.WithInput — breaks terminal raw mode

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -611,7 +611,6 @@ func main() {
 		homeModel,
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(),
-		tea.WithInput(ui.NewCSIuReader(os.Stdin)),
 	)
 
 	// Start maintenance worker (background goroutine, respects config toggle)

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -331,11 +331,11 @@ func (c *csiuReader) translate(final bool) []byte {
 			continue
 		}
 
-		// We have ESC '['. Scan forward for the terminator.
+		// We have ESC '['. Scan forward for the CSI final byte.
+		// CSI final bytes are in the range 0x40-0x7E (@ through ~).
+		// Only 'u' and '~' get special handling; everything else passes through.
 		j := i + 2
-		for j < len(c.inBuf) && c.inBuf[j] != 'u' && c.inBuf[j] != 'A' &&
-			c.inBuf[j] != 'B' && c.inBuf[j] != 'C' && c.inBuf[j] != 'D' &&
-			c.inBuf[j] != 'H' && c.inBuf[j] != 'F' && c.inBuf[j] != '~' {
+		for j < len(c.inBuf) && (c.inBuf[j] < 0x40 || c.inBuf[j] > 0x7E) {
 			j++
 		}
 

--- a/internal/ui/keyboard_compat_test.go
+++ b/internal/ui/keyboard_compat_test.go
@@ -205,6 +205,51 @@ func TestCSIuReaderPassesStandardEscapeSequences(t *testing.T) {
 	}
 }
 
+// TestCSIuReaderPassesSGRMouseEvents verifies that SGR mouse sequences
+// (final byte 'M'/'m') pass through correctly and don't eat subsequent input.
+// Regression test: the original terminator set omitted 'M' and 'm', causing
+// mouse events to consume following arrow key sequences.
+func TestCSIuReaderPassesSGRMouseEvents(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "mouse press then arrow up",
+			input: "\x1b[<0;10;20M\x1b[A",
+			want:  "\x1b[<0;10;20M\x1b[A",
+		},
+		{
+			name:  "mouse release then arrow down",
+			input: "\x1b[<0;10;20m\x1b[B",
+			want:  "\x1b[<0;10;20m\x1b[B",
+		},
+		{
+			name:  "mouse move then keystroke",
+			input: "\x1b[<35;5;15M" + "j",
+			want:  "\x1b[<35;5;15M" + "j",
+		},
+		{
+			name:  "mouse between two arrows",
+			input: "\x1b[A\x1b[<0;1;1M\x1b[B",
+			want:  "\x1b[A\x1b[<0;1;1M\x1b[B",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewCSIuReader(bytes.NewReader([]byte(tt.input)))
+			out, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll error: %v", err)
+			}
+			if string(out) != tt.want {
+				t.Errorf("got %q, want %q", string(out), tt.want)
+			}
+		})
+	}
+}
+
 // TestCSIuReaderMixedInput verifies mixed input is correctly handled.
 func TestCSIuReaderMixedInput(t *testing.T) {
 	// "a" + shift+r CSI u + "b"


### PR DESCRIPTION
## Summary

`tea.WithInput(ui.NewCSIuReader(os.Stdin))` (added in #535) wraps stdin with a plain `io.Reader`, stripping the `*os.File` interface. Bubble Tea needs the file descriptor to set raw terminal mode. Without it, the terminal stays in cooked mode: escape sequences are processed by the terminal driver instead of reaching the app. Arrow keys, mouse events, and all CSI sequences appear as raw text.

**Fix:** remove the `tea.WithInput(CSIuReader)` line entirely. The existing `DisableKittyKeyboard`/`RestoreKittyKeyboard` escape sequences already handle Kitty protocol terminals. The CSIuReader approach cannot work at the `io.Reader` level.

Also fixes the CSIuReader's internal terminator set to use the standard CSI final byte range (`0x40`-`0x7E`) instead of a hardcoded subset that missed SGR mouse terminators (`M`/`m`). This makes the code correct if reused as a `tea.KeyMsg` translator in `Update()`.

Reverts the one-line change from #535.

Fixes #539

## Test plan

- [x] Arrow keys work in tmux + xterm (verified locally)
- [x] `TestCSIuReaderPassesSGRMouseEvents` — regression test for the terminator fix
- [x] All 19 existing CSIuReader tests pass