### PR TITLE
test: add integration tests for TUI keyboard input

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -611,7 +611,6 @@ func main() {
 		homeModel,
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(),
-		tea.WithInput(ui.NewCSIuReader(os.Stdin)),
 	)
 
 	// Start maintenance worker (background goroutine, respects config toggle)

--- a/internal/integration/tui_input_test.go
+++ b/internal/integration/tui_input_test.go
@@ -1,0 +1,167 @@
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTUIInput_ArrowKeysNavigate launches the real agent-deck binary in a tmux
+// session and verifies that arrow key escape sequences are interpreted (cursor
+// moves) rather than displayed as raw text.
+//
+// This is a regression test for #539 where tea.WithInput(CSIuReader) stripped
+// the *os.File interface from stdin, preventing Bubble Tea from setting raw
+// terminal mode. The result was arrow keys appearing as "^[[A" text.
+func TestTUIInput_ArrowKeysNavigate(t *testing.T) {
+	skipIfNoTmuxServer(t)
+
+	// Build the binary from current source so we test the working tree.
+	binPath := t.TempDir() + "/agent-deck-test"
+	build := exec.Command("go", "build", "-o", binPath, "./cmd/agent-deck/")
+	build.Dir = findRepoRoot(t)
+	build.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build agent-deck: %v\n%s", err, out)
+	}
+
+	sess := "inttest-tui-input-" + sanitizeName(t.Name())
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "kill-session", "-t", sess).Run()
+	})
+
+	// Launch agent-deck in a tmux session with test profile (no real sessions).
+	err := exec.Command("tmux", "new-session", "-d", "-s", sess, "-x", "120", "-y", "40",
+		binPath, "-p", "_test_tui_input").Run()
+	if err != nil {
+		t.Fatalf("failed to create tmux session: %v", err)
+	}
+
+	// Wait for the TUI to render.
+	waitForPane(t, sess, "Agent Deck", 5*time.Second)
+
+	// Send arrow keys.
+	_ = exec.Command("tmux", "send-keys", "-t", sess, "Down").Run()
+	time.Sleep(300 * time.Millisecond)
+	_ = exec.Command("tmux", "send-keys", "-t", sess, "Down").Run()
+	time.Sleep(300 * time.Millisecond)
+	_ = exec.Command("tmux", "send-keys", "-t", sess, "Up").Run()
+	time.Sleep(300 * time.Millisecond)
+
+	// Capture the pane and check for raw escape sequences.
+	content := capturePane(t, sess)
+
+	// Raw escape sequences look like ^[[A, ^[[B, ESC[A, \x1b[A etc.
+	// If terminal is in raw mode (correct), these are consumed by Bubble Tea.
+	// If terminal is in cooked mode (broken), they appear as visible text.
+	rawPatterns := []string{"^[[A", "^[[B", "^[[C", "^[[D", "\x1b[A", "\x1b[B"}
+	for _, pat := range rawPatterns {
+		if strings.Contains(content, pat) {
+			t.Errorf("raw escape sequence %q found in pane output — arrow keys are not being interpreted.\n"+
+				"This usually means Bubble Tea cannot set raw terminal mode on stdin.\n"+
+				"Pane content:\n%s", pat, content)
+		}
+	}
+}
+
+// TestTUIInput_JKNavigation verifies that j/k keys work for navigation
+// (not displayed as literal characters in unexpected places).
+func TestTUIInput_JKNavigation(t *testing.T) {
+	skipIfNoTmuxServer(t)
+
+	binPath := t.TempDir() + "/agent-deck-test"
+	build := exec.Command("go", "build", "-o", binPath, "./cmd/agent-deck/")
+	build.Dir = findRepoRoot(t)
+	build.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build agent-deck: %v\n%s", err, out)
+	}
+
+	sess := "inttest-tui-jk-" + sanitizeName(t.Name())
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "kill-session", "-t", sess).Run()
+	})
+
+	err := exec.Command("tmux", "new-session", "-d", "-s", sess, "-x", "120", "-y", "40",
+		binPath, "-p", "_test_tui_jk").Run()
+	if err != nil {
+		t.Fatalf("failed to create tmux session: %v", err)
+	}
+
+	waitForPane(t, sess, "Agent Deck", 5*time.Second)
+
+	// Send j and k (vim-style navigation).
+	_ = exec.Command("tmux", "send-keys", "-t", sess, "j").Run()
+	time.Sleep(300 * time.Millisecond)
+	_ = exec.Command("tmux", "send-keys", "-t", sess, "k").Run()
+	time.Sleep(300 * time.Millisecond)
+
+	// In a working TUI, j/k are consumed as navigation commands.
+	// If the TUI isn't in raw mode, they'd appear as typed text.
+	// Check the status bar area (bottom lines) for stray characters.
+	content := capturePane(t, sess)
+	lines := strings.Split(content, "\n")
+
+	// Check last 3 lines for stray j/k characters that indicate
+	// keys are being echoed instead of interpreted.
+	for i := len(lines) - 3; i < len(lines) && i >= 0; i++ {
+		line := strings.TrimSpace(lines[i])
+		// A line that is just "j", "k", "jk", etc. means keys are echoed.
+		if line == "j" || line == "k" || line == "jk" || line == "kj" {
+			t.Errorf("stray key characters %q found on bottom line %d — keys are being echoed, not interpreted.\n"+
+				"Pane content:\n%s", line, i, content)
+		}
+	}
+}
+
+// waitForPane polls tmux pane content until it contains the expected string.
+func waitForPane(t *testing.T, sess, contains string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			content := capturePane(t, sess)
+			t.Fatalf("timed out waiting for pane to contain %q.\nPane content:\n%s", contains, content)
+		case <-ticker.C:
+			content := capturePane(t, sess)
+			if strings.Contains(content, contains) {
+				return
+			}
+		}
+	}
+}
+
+// capturePane returns the current tmux pane content.
+func capturePane(t *testing.T, sess string) string {
+	t.Helper()
+	out, err := exec.Command("tmux", "capture-pane", "-t", sess, "-p", "-S", "-50").Output()
+	if err != nil {
+		t.Fatalf("failed to capture pane: %v", err)
+	}
+	return string(out)
+}
+
+// findRepoRoot walks up from the working directory to find the go.mod file.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(dir + "/go.mod"); err == nil {
+			return dir
+		}
+		parent := dir[:strings.LastIndex(dir, "/")]
+		if parent == dir {
+			t.Fatal("could not find repo root (no go.mod)")
+		}
+		dir = parent
+	}
+}

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -331,11 +331,11 @@ func (c *csiuReader) translate(final bool) []byte {
 			continue
 		}
 
-		// We have ESC '['. Scan forward for the terminator.
+		// We have ESC '['. Scan forward for the CSI final byte.
+		// CSI final bytes are in the range 0x40-0x7E (@ through ~).
+		// Only 'u' and '~' get special handling; everything else passes through.
 		j := i + 2
-		for j < len(c.inBuf) && c.inBuf[j] != 'u' && c.inBuf[j] != 'A' &&
-			c.inBuf[j] != 'B' && c.inBuf[j] != 'C' && c.inBuf[j] != 'D' &&
-			c.inBuf[j] != 'H' && c.inBuf[j] != 'F' && c.inBuf[j] != '~' {
+		for j < len(c.inBuf) && (c.inBuf[j] < 0x40 || c.inBuf[j] > 0x7E) {
 			j++
 		}
 

--- a/internal/ui/keyboard_compat_test.go
+++ b/internal/ui/keyboard_compat_test.go
@@ -205,6 +205,51 @@ func TestCSIuReaderPassesStandardEscapeSequences(t *testing.T) {
 	}
 }
 
+// TestCSIuReaderPassesSGRMouseEvents verifies that SGR mouse sequences
+// (final byte 'M'/'m') pass through correctly and don't eat subsequent input.
+// Regression test: the original terminator set omitted 'M' and 'm', causing
+// mouse events to consume following arrow key sequences.
+func TestCSIuReaderPassesSGRMouseEvents(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "mouse press then arrow up",
+			input: "\x1b[<0;10;20M\x1b[A",
+			want:  "\x1b[<0;10;20M\x1b[A",
+		},
+		{
+			name:  "mouse release then arrow down",
+			input: "\x1b[<0;10;20m\x1b[B",
+			want:  "\x1b[<0;10;20m\x1b[B",
+		},
+		{
+			name:  "mouse move then keystroke",
+			input: "\x1b[<35;5;15M" + "j",
+			want:  "\x1b[<35;5;15M" + "j",
+		},
+		{
+			name:  "mouse between two arrows",
+			input: "\x1b[A\x1b[<0;1;1M\x1b[B",
+			want:  "\x1b[A\x1b[<0;1;1M\x1b[B",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewCSIuReader(bytes.NewReader([]byte(tt.input)))
+			out, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll error: %v", err)
+			}
+			if string(out) != tt.want {
+				t.Errorf("got %q, want %q", string(out), tt.want)
+			}
+		})
+	}
+}
+
 // TestCSIuReaderMixedInput verifies mixed input is correctly handled.
 func TestCSIuReaderMixedInput(t *testing.T) {
 	// "a" + shift+r CSI u + "b"


### PR DESCRIPTION
## Summary

Add integration tests that launch the real `agent-deck` binary in a tmux session and verify basic keyboard interaction works. This prevents regressions where stdin wrapping, terminal mode changes, or escape sequence handling silently break all navigation.

**Tests added:**
- `TestTUIInput_ArrowKeysNavigate` — sends arrow keys, verifies no raw escape sequences (`^[[A` etc.) in pane output
- `TestTUIInput_JKNavigation` — sends j/k, verifies keys are consumed by the TUI (not echoed as text)

Both tests build the binary from current source, launch it in a tmux session with a test profile, send keys, then inspect the pane content.

**Verified:** tests correctly catch #539 — when `tea.WithInput(CSIuReader)` is present, `TestTUIInput_ArrowKeysNavigate` fails with `raw escape sequence "^[[A" found in pane output`.

Depends on #538. Ref #539.

## Test plan

- [x] Both tests PASS with the fix from #538
- [x] `TestTUIInput_ArrowKeysNavigate` FAILS when #535's `tea.WithInput(CSIuReader)` is re-added (confirmed locally)
- [x] Tests skip cleanly when tmux is not available
- [x] Existing integration tests unaffected