### PR TITLE
feat: smart heartbeat with state-diffing

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -439,12 +439,16 @@ func handleConductorSetup(profile string, args []string) {
 	// Step 6: Install heartbeat timer (if heartbeat enabled)
 	if heartbeatEnabled {
 		interval := settings.GetHeartbeatInterval()
-		if err := session.InstallHeartbeatScript(name, resolvedProfile); err != nil {
+		if err := session.InstallHeartbeatScript(name, resolvedProfile, settings.HeartbeatSmart); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to install heartbeat script: %v\n", err)
 		} else if err := session.InstallHeartbeatDaemon(name, resolvedProfile, interval); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to install heartbeat daemon: %v\n", err)
 		} else if !*jsonOutput {
-			fmt.Printf("  [ok] Heartbeat timer installed (every %d min)\n", interval)
+			mode := ""
+			if settings.HeartbeatSmart {
+				mode = ", smart"
+			}
+			fmt.Printf("  [ok] Heartbeat timer installed (every %d min%s)\n", interval, mode)
 		}
 	}
 

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -23,6 +23,11 @@ type ConductorSettings struct {
 	// Default: 15
 	HeartbeatInterval int `toml:"heartbeat_interval"`
 
+	// HeartbeatSmart enables state-diffing for heartbeat: the heartbeat script
+	// only sends a check-in when session states have changed since the last run.
+	// Default: false (every timer tick sends a heartbeat)
+	HeartbeatSmart bool `toml:"heartbeat_smart"`
+
 	// Profiles is the list of agent-deck profiles to manage
 	// Kept for backward compat but ignored after migration to meta.json-based discovery
 	Profiles []string `toml:"profiles"`
@@ -406,14 +411,23 @@ func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact 
 
 // InstallHeartbeatScript writes the heartbeat.sh script for a conductor.
 // This is a standalone heartbeat that works without Telegram.
-func InstallHeartbeatScript(name, profile string) error {
+// If smart is true, installs the state-diffing variant that only fires on changes.
+func InstallHeartbeatScript(name, profile string, smart ...bool) error {
 	dir, err := ConductorNameDir(name)
 	if err != nil {
 		return err
 	}
 	profile = normalizeConductorProfile(profile)
 
-	script := strings.ReplaceAll(conductorHeartbeatScript, "{NAME}", name)
+	useSmart := len(smart) > 0 && smart[0]
+	var template string
+	if useSmart {
+		template = conductorSmartHeartbeatScript
+	} else {
+		template = conductorHeartbeatScript
+	}
+
+	script := strings.ReplaceAll(template, "{NAME}", name)
 	script = strings.ReplaceAll(script, "{PROFILE}", profile)
 	if profile == DefaultProfile {
 		// For default profile, omit -p flag entirely
@@ -607,6 +621,41 @@ SESSION="conductor-{NAME}"
 PROFILE="{PROFILE}"
 
 # Only send if the session is running
+STATUS=$(agent-deck -p "$PROFILE" session show "$SESSION" --json 2>/dev/null | tr -d '\n' | sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+if [ "$STATUS" = "idle" ] || [ "$STATUS" = "waiting" ]; then
+    agent-deck -p "$PROFILE" session send "$SESSION" "Heartbeat: Check all sessions in the {PROFILE} profile. List any waiting sessions, auto-respond where safe, and report what needs my attention." --no-wait -q
+fi
+`
+
+// conductorSmartHeartbeatScript wraps the heartbeat with state-diffing.
+// It snapshots session states and only forwards to the real heartbeat logic
+// when something has changed since the last run.
+const conductorSmartHeartbeatScript = `#!/bin/bash
+# Smart heartbeat for conductor: {NAME} (profile: {PROFILE})
+# Only sends a check-in when session states have changed since the last run.
+
+SESSION="conductor-{NAME}"
+PROFILE="{PROFILE}"
+STATE_DIR=$(dirname "$0")
+STATE_FILE="$STATE_DIR/.heartbeat-state"
+
+# Snapshot current state: sorted "title:status" pairs (exclude this conductor)
+CURRENT=$(agent-deck -p "$PROFILE" list --json 2>/dev/null | tr -d '\n' | sed 's/},{/}\n{/g' | sed -n 's/.*"title"[[:space:]]*:[[:space:]]*"\([^"]*\)".*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1:\2/p' | grep -v "^conductor-{NAME}:" | sort)
+
+PREVIOUS=""
+if [ -f "$STATE_FILE" ]; then
+    PREVIOUS=$(cat "$STATE_FILE")
+fi
+
+if [ "$CURRENT" = "$PREVIOUS" ]; then
+    exit 0
+fi
+
+# State changed — save and run the heartbeat
+echo "$CURRENT" > "$STATE_FILE"
+
+# Only send if the conductor session is running
 STATUS=$(agent-deck -p "$PROFILE" session show "$SESSION" --json 2>/dev/null | tr -d '\n' | sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
 if [ "$STATUS" = "idle" ] || [ "$STATUS" = "waiting" ]; then
@@ -998,11 +1047,14 @@ func MigrateConductorLearnings() ([]string, error) {
 
 // MigrateConductorHeartbeatScripts refreshes managed heartbeat scripts to the
 // current template without touching custom user-authored scripts.
+// It respects the heartbeat_smart global setting when choosing which template to use.
 func MigrateConductorHeartbeatScripts() ([]string, error) {
 	conductors, err := ListConductors()
 	if err != nil {
 		return nil, err
 	}
+
+	settings := GetConductorSettings()
 
 	var migrated []string
 	for _, meta := range conductors {
@@ -1012,7 +1064,11 @@ func MigrateConductorHeartbeatScripts() ([]string, error) {
 		}
 
 		scriptPath := filepath.Join(dir, "heartbeat.sh")
-		expected := strings.ReplaceAll(conductorHeartbeatScript, "{NAME}", meta.Name)
+		template := conductorHeartbeatScript
+		if settings.HeartbeatSmart {
+			template = conductorSmartHeartbeatScript
+		}
+		expected := strings.ReplaceAll(template, "{NAME}", meta.Name)
 		expected = strings.ReplaceAll(expected, "{PROFILE}", normalizeConductorProfile(meta.Profile))
 		if normalizeConductorProfile(meta.Profile) == DefaultProfile {
 			expected = strings.ReplaceAll(expected, `-p "$PROFILE" `, "")
@@ -1029,7 +1085,8 @@ func MigrateConductorHeartbeatScripts() ([]string, error) {
 		}
 
 		existingStr := string(existing)
-		managedScript := strings.Contains(existingStr, "# Heartbeat for conductor:") &&
+		managedScript := (strings.Contains(existingStr, "# Heartbeat for conductor:") ||
+			strings.Contains(existingStr, "# Smart heartbeat for conductor:")) &&
 			strings.Contains(existingStr, `SESSION="conductor-`)
 		if !managedScript {
 			continue

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -1875,3 +1875,153 @@ func TestConductorClearOnCompact(t *testing.T) {
 		t.Error("non-conductor-prefixed title should return false")
 	}
 }
+
+// --- Smart heartbeat tests ---
+
+func TestSmartHeartbeatScriptTemplate(t *testing.T) {
+	// Verify the smart heartbeat template has the expected structure
+	if !strings.Contains(conductorSmartHeartbeatScript, "# Smart heartbeat for conductor:") {
+		t.Error("smart heartbeat script should contain identifying comment")
+	}
+	if !strings.Contains(conductorSmartHeartbeatScript, "STATE_FILE=") {
+		t.Error("smart heartbeat script should reference a state file")
+	}
+	if !strings.Contains(conductorSmartHeartbeatScript, "exit 0") {
+		t.Error("smart heartbeat script should exit early when states match")
+	}
+	if !strings.Contains(conductorSmartHeartbeatScript, "{NAME}") {
+		t.Error("smart heartbeat script should contain {NAME} placeholder")
+	}
+	if !strings.Contains(conductorSmartHeartbeatScript, "{PROFILE}") {
+		t.Error("smart heartbeat script should contain {PROFILE} placeholder")
+	}
+}
+
+func TestInstallHeartbeatScript_Standard(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a fake conductor dir structure
+	name := "test-std"
+	condDir := filepath.Join(tmpDir, name)
+	if err := os.MkdirAll(condDir, 0o755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	// Write script directly using the template (simulating InstallHeartbeatScript without real home dir)
+	script := strings.ReplaceAll(conductorHeartbeatScript, "{NAME}", name)
+	script = strings.ReplaceAll(script, "{PROFILE}", "default")
+	script = strings.ReplaceAll(script, `-p "$PROFILE" `, "")
+	scriptPath := filepath.Join(condDir, "heartbeat.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write script: %v", err)
+	}
+
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to read script: %v", err)
+	}
+
+	// Standard script should NOT contain smart heartbeat markers
+	if strings.Contains(string(content), "Smart heartbeat") {
+		t.Error("standard heartbeat script should not contain smart heartbeat markers")
+	}
+	if strings.Contains(string(content), "STATE_FILE") {
+		t.Error("standard heartbeat script should not contain STATE_FILE")
+	}
+	if !strings.Contains(string(content), "# Heartbeat for conductor: "+name) {
+		t.Error("standard script should contain conductor name in comment")
+	}
+}
+
+func TestInstallHeartbeatScript_Smart(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a fake conductor dir structure
+	name := "test-smart"
+	condDir := filepath.Join(tmpDir, name)
+	if err := os.MkdirAll(condDir, 0o755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	// Write smart script directly using the template
+	script := strings.ReplaceAll(conductorSmartHeartbeatScript, "{NAME}", name)
+	script = strings.ReplaceAll(script, "{PROFILE}", "work")
+	scriptPath := filepath.Join(condDir, "heartbeat.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write script: %v", err)
+	}
+
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("failed to read script: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Smart script should contain state-diffing logic
+	if !strings.Contains(contentStr, "# Smart heartbeat for conductor: "+name) {
+		t.Error("smart script should contain conductor name in comment")
+	}
+	if !strings.Contains(contentStr, "STATE_FILE=") {
+		t.Error("smart script should reference STATE_FILE")
+	}
+	if !strings.Contains(contentStr, ".heartbeat-state") {
+		t.Error("smart script should use .heartbeat-state file")
+	}
+	if !strings.Contains(contentStr, `grep -v "^conductor-`+name+`:"`) {
+		t.Error("smart script should exclude own conductor from state snapshot")
+	}
+	// Should still have the actual heartbeat send logic
+	if !strings.Contains(contentStr, "session send") {
+		t.Error("smart script should still send heartbeat message when state changes")
+	}
+	// Profile flag should be present for non-default profiles
+	if !strings.Contains(contentStr, `-p "$PROFILE"`) {
+		t.Error("smart script for non-default profile should contain -p flag")
+	}
+}
+
+func TestSmartHeartbeatScript_DefaultProfileOmitsFlag(t *testing.T) {
+	script := strings.ReplaceAll(conductorSmartHeartbeatScript, "{NAME}", "test")
+	script = strings.ReplaceAll(script, "{PROFILE}", DefaultProfile)
+	script = strings.ReplaceAll(script, `-p "$PROFILE" `, "")
+
+	if strings.Contains(script, `-p "$PROFILE"`) {
+		t.Error("smart heartbeat for default profile should not contain -p flag")
+	}
+}
+
+func TestHeartbeatSmartConfigDefault(t *testing.T) {
+	settings := ConductorSettings{}
+	if settings.HeartbeatSmart {
+		t.Error("HeartbeatSmart should default to false")
+	}
+}
+
+func TestManagedScriptDetection_Smart(t *testing.T) {
+	// Verify that the smart script comment is detectable as a managed script
+	script := strings.ReplaceAll(conductorSmartHeartbeatScript, "{NAME}", "test")
+	script = strings.ReplaceAll(script, "{PROFILE}", "default")
+
+	isManaged := (strings.Contains(script, "# Heartbeat for conductor:") ||
+		strings.Contains(script, "# Smart heartbeat for conductor:")) &&
+		strings.Contains(script, `SESSION="conductor-`)
+
+	if !isManaged {
+		t.Error("smart heartbeat script should be detectable as a managed script")
+	}
+}
+
+func TestManagedScriptDetection_Standard(t *testing.T) {
+	// Verify the standard script is still detectable
+	script := strings.ReplaceAll(conductorHeartbeatScript, "{NAME}", "test")
+	script = strings.ReplaceAll(script, "{PROFILE}", "default")
+
+	isManaged := (strings.Contains(script, "# Heartbeat for conductor:") ||
+		strings.Contains(script, "# Smart heartbeat for conductor:")) &&
+		strings.Contains(script, `SESSION="conductor-`)
+
+	if !isManaged {
+		t.Error("standard heartbeat script should be detectable as a managed script")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `heartbeat_smart` config option to `[conductor]` settings that makes heartbeat scripts compare session states before firing
- When enabled, heartbeat only wakes the conductor when session states have actually changed, avoiding redundant check-ins when everything is stable
- Includes migration support: `MigrateConductorHeartbeatScripts` respects the setting and can upgrade/downgrade existing scripts

## How it works

The smart heartbeat script snapshots all session `title:status` pairs (excluding the conductor itself), compares against the previous snapshot stored in `.heartbeat-state`, and only proceeds with the heartbeat send if something changed.

## Config

```toml
[conductor]
heartbeat_smart = true  # default: false
```

## Test plan

- [x] 7 new unit tests covering template content, managed script detection, config defaults, profile flag handling
- [x] All existing conductor tests pass
- [x] Full binary builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)