### PR TITLE
Fix #546: remove EnableKittyKeyboard from attach paths

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -50,7 +50,7 @@ func SetVersion(v string) {
 // a worktree + session is being created asynchronously.
 // It is NOT a real session.Instance — it is excluded from save, polling, and search.
 type CreatingSession struct {
-	ID        string    // Temporary ID for tracking
+	ID        string // Temporary ID for tracking
 	Title     string
 	Tool      string
 	GroupPath string
@@ -317,12 +317,12 @@ type Home struct {
 	updateInfo *update.UpdateInfo
 
 	// Launching animation state (for newly created sessions)
-	launchingSessions  map[string]time.Time // sessionID -> creation time
-	resumingSessions   map[string]time.Time // sessionID -> resume time (for restart/resume)
-	mcpLoadingSessions map[string]time.Time // sessionID -> MCP reload time
-	forkingSessions    map[string]time.Time          // sessionID -> fork start time (fork in progress)
-	creatingSessions   map[string]*CreatingSession   // tempID -> placeholder for worktree creation in progress
-	animationFrame     int                           // Current frame for spinner animation
+	launchingSessions  map[string]time.Time        // sessionID -> creation time
+	resumingSessions   map[string]time.Time        // sessionID -> resume time (for restart/resume)
+	mcpLoadingSessions map[string]time.Time        // sessionID -> MCP reload time
+	forkingSessions    map[string]time.Time        // sessionID -> fork start time (fork in progress)
+	creatingSessions   map[string]*CreatingSession // tempID -> placeholder for worktree creation in progress
+	animationFrame     int                         // Current frame for spinner animation
 
 	// Context for cleanup
 	ctx    context.Context
@@ -7467,13 +7467,6 @@ func (a attachCmd) Run() error {
 	// NOTE: Screen clearing is ONLY done in the tea.Exec callback (after Attach returns)
 	// Removing clear screen here prevents double-clearing which corrupts terminal state
 
-	// Re-enable Kitty keyboard protocol so the attached session (e.g. Claude
-	// Code) receives extended key sequences like Shift+Enter. The TUI pops
-	// the protocol at startup for Bubble Tea compatibility; push mode 1
-	// here and pop again on return.
-	EnableKittyKeyboard(os.Stdout)
-	defer DisableKittyKeyboard(os.Stdout)
-
 	ctx := context.Background()
 	return a.session.Attach(ctx, a.detachByte)
 }
@@ -7513,9 +7506,6 @@ type remoteCreateAndAttachCmd struct {
 }
 
 func (r remoteCreateAndAttachCmd) Run() error {
-	EnableKittyKeyboard(os.Stdout)
-	defer DisableKittyKeyboard(os.Stdout)
-
 	ctx := context.Background()
 	sessionID, err := r.runner.CreateSession(ctx)
 	if err != nil {
@@ -7536,9 +7526,6 @@ type attachWindowCmd struct {
 }
 
 func (a attachWindowCmd) Run() error {
-	EnableKittyKeyboard(os.Stdout)
-	defer DisableKittyKeyboard(os.Stdout)
-
 	ctx := context.Background()
 	return a.session.AttachWindow(ctx, a.windowIndex, a.detachByte)
 }
@@ -7572,9 +7559,6 @@ type remoteAttachCmd struct {
 }
 
 func (r remoteAttachCmd) Run() error {
-	EnableKittyKeyboard(os.Stdout)
-	defer DisableKittyKeyboard(os.Stdout)
-
 	return r.runner.Attach(r.sessionID)
 }
 
@@ -11063,7 +11047,7 @@ func (h *Home) renderPreviewPane(width, height int) string {
 	showAnalytics := config != nil && config.GetShowAnalytics() &&
 		(session.IsClaudeCompatible(selected.Tool) || selected.Tool == "gemini")
 	showOutput := config == nil || config.GetShowOutput() // Default to true if config fails
-	showNotes := config != nil && config.GetShowNotes() // Default to false if config fails
+	showNotes := config != nil && config.GetShowNotes()   // Default to false if config fails
 	notesOutputSplit := 0.33
 	if config != nil {
 		notesOutputSplit = config.Preview.GetNotesOutputSplit()


### PR DESCRIPTION
## Summary
- Removes `EnableKittyKeyboard(os.Stdout)` / `defer DisableKittyKeyboard(os.Stdout)` from all four attach paths (`attachCmd`, `remoteCreateAndAttachCmd`, `attachWindowCmd`, `remoteAttachCmd`)
- Restores pre-v1.4.0 behavior where no kitty keyboard protocol manipulation occurred during tmux attach
- Fixes arrow keys being broken on Ghostty and other kitty-protocol terminals

## Test plan
- [x] Build passes (`go build ./...`)
- [x] `internal/ui` tests pass
- [ ] Manual: attach to a session on Ghostty, verify arrow keys work
- [ ] Manual: verify Shift+Enter still works via tmux `extended-keys` setting

Fixes #546