### PR TITLE
feat: arrow-key browsing for path suggestions dropdown

### DIFF
--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -36,6 +36,13 @@ type ConfirmDialog struct {
 
 	remoteName string // Remote name for remote session confirmations.
 
+	// focusedButton tracks which button has arrow-key focus.
+	// 0 = confirm (left), 1 = cancel (right).
+	// For ConfirmQuitWithPool: 0 = keep, 1 = shutdown.
+	focusedButton int
+	// buttonCount is the number of selectable buttons for the current dialog.
+	buttonCount int
+
 	// Pending session creation data (for ConfirmCreateDirectory)
 	pendingSessionName       string
 	pendingSessionPath       string
@@ -58,6 +65,8 @@ func (c *ConfirmDialog) ShowDeleteSession(sessionID string, sessionName string, 
 	c.targetID = sessionID
 	c.targetName = sessionName
 	c.sandboxed = sandboxed
+	c.buttonCount = 2
+	c.focusedButton = 1 // default to Cancel
 }
 
 // ShowCloseSession shows confirmation for non-destructive session close.
@@ -67,6 +76,8 @@ func (c *ConfirmDialog) ShowCloseSession(sessionID string, sessionName string, s
 	c.targetID = sessionID
 	c.targetName = sessionName
 	c.sandboxed = sandboxed
+	c.buttonCount = 2
+	c.focusedButton = 1
 }
 
 // ShowDeleteRemoteSession shows confirmation for deleting a remote session.
@@ -76,6 +87,8 @@ func (c *ConfirmDialog) ShowDeleteRemoteSession(remoteName, sessionID, sessionNa
 	c.targetID = sessionID
 	c.targetName = sessionName
 	c.remoteName = remoteName
+	c.buttonCount = 2
+	c.focusedButton = 1
 }
 
 // ShowCloseRemoteSession shows confirmation for closing a remote session.
@@ -85,6 +98,8 @@ func (c *ConfirmDialog) ShowCloseRemoteSession(remoteName, sessionID, sessionNam
 	c.targetID = sessionID
 	c.targetName = sessionName
 	c.remoteName = remoteName
+	c.buttonCount = 2
+	c.focusedButton = 1
 }
 
 // ShowDeleteGroup shows confirmation for group deletion
@@ -93,6 +108,8 @@ func (c *ConfirmDialog) ShowDeleteGroup(groupPath, groupName string) {
 	c.confirmType = ConfirmDeleteGroup
 	c.targetID = groupPath
 	c.targetName = groupName
+	c.buttonCount = 2
+	c.focusedButton = 1
 }
 
 // ShowQuitWithPool shows confirmation for quitting with MCP pool running
@@ -102,6 +119,8 @@ func (c *ConfirmDialog) ShowQuitWithPool(mcpCount int) {
 	c.mcpCount = mcpCount
 	c.targetID = ""
 	c.targetName = ""
+	c.buttonCount = 2
+	c.focusedButton = 0 // default to "Keep running" (safe choice)
 }
 
 // ShowCreateDirectory shows confirmation for creating a missing directory.
@@ -125,6 +144,8 @@ func (c *ConfirmDialog) ShowCreateDirectory(
 	c.pendingToolOptionsJSON = toolOptionsJSON
 	c.pendingParentSessionID = parentSessionID
 	c.pendingParentProjectPath = parentProjectPath
+	c.buttonCount = 2
+	c.focusedButton = 1
 }
 
 // ShowInstallHooks shows confirmation for installing Claude Code hooks
@@ -133,6 +154,8 @@ func (c *ConfirmDialog) ShowInstallHooks() {
 	c.confirmType = ConfirmInstallHooks
 	c.targetID = ""
 	c.targetName = ""
+	c.buttonCount = 2
+	c.focusedButton = 1
 }
 
 // GetPendingSession returns the pending session creation data
@@ -175,9 +198,23 @@ func (c *ConfirmDialog) SetSize(width, height int) {
 	c.height = height
 }
 
-// Update handles key events
+// GetFocusedButton returns the currently focused button index.
+func (c *ConfirmDialog) GetFocusedButton() int {
+	return c.focusedButton
+}
+
+// Update handles key events for arrow-key navigation between buttons.
 func (c *ConfirmDialog) Update(msg tea.KeyMsg) (*ConfirmDialog, tea.Cmd) {
-	// Dialog handles y/n/enter/esc only
+	switch msg.String() {
+	case "left", "h":
+		if c.focusedButton > 0 {
+			c.focusedButton--
+		}
+	case "right", "l", "tab":
+		if c.focusedButton < c.buttonCount-1 {
+			c.focusedButton++
+		}
+	}
 	return c, nil
 }
 
@@ -197,6 +234,25 @@ func (c *ConfirmDialog) View() string {
 		Foreground(ColorTextDim).
 		MarginBottom(1)
 
+	// Focused buttons get filled background; unfocused get dim outline.
+	renderButton := func(label string, bg lipgloss.Color, focused bool) string {
+		if focused {
+			return lipgloss.NewStyle().
+				Foreground(ColorBg).
+				Background(bg).
+				Padding(0, 2).
+				Bold(true).
+				Render("▸ " + label)
+		}
+		return lipgloss.NewStyle().
+			Foreground(bg).
+			Padding(0, 2).
+			Bold(true).
+			Render("  " + label)
+	}
+
+	hintStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+
 	switch c.confirmType {
 	case ConfirmDeleteSession:
 		title = "⚠  Delete Session?"
@@ -207,23 +263,11 @@ func (c *ConfirmDialog) View() string {
 		}
 		details += "\n• Undo is available from the session list"
 		borderColor = ColorRed
-
-		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorRed).
-			Padding(0, 2).
-			Bold(true).
-			Render("y Delete")
-		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorAccent).
-			Padding(0, 2).
-			Bold(true).
-			Render("n Cancel")
-		escHint := lipgloss.NewStyle().
-			Foreground(ColorTextDim).
-			Render("(Esc to cancel)")
-		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonYes, "  ", buttonNo, "  ", escHint)
+		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
+			renderButton("Delete", ColorRed, c.focusedButton == 0), "  ",
+			renderButton("Cancel", ColorAccent, c.focusedButton == 1))
+		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
+			hintStyle.Render("y delete · n cancel · ←/→ navigate · Enter select · Esc"))
 
 	case ConfirmCloseSession:
 		title = "Close Session?"
@@ -233,162 +277,77 @@ func (c *ConfirmDialog) View() string {
 			details += "\n• The Docker container will be removed"
 		}
 		borderColor = ColorYellow
-
-		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorYellow).
-			Padding(0, 2).
-			Bold(true).
-			Render("y Close")
-		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorAccent).
-			Padding(0, 2).
-			Bold(true).
-			Render("n Cancel")
-		escHint := lipgloss.NewStyle().
-			Foreground(ColorTextDim).
-			Render("(Esc to cancel)")
-		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonYes, "  ", buttonNo, "  ", escHint)
+		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
+			renderButton("Close", ColorYellow, c.focusedButton == 0), "  ",
+			renderButton("Cancel", ColorAccent, c.focusedButton == 1))
+		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
+			hintStyle.Render("y close · n cancel · ←/→ navigate · Enter select · Esc"))
 
 	case ConfirmDeleteRemoteSession:
 		title = "⚠  Delete Remote Session?"
 		warning = fmt.Sprintf("This will permanently delete the remote session:\n\n  \"%s\" on %s", c.targetName, c.remoteName)
 		details = "• The remote tmux session will be terminated\n• Any running processes on the remote will be killed\n• Terminal history will be lost"
 		borderColor = ColorRed
-
-		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorRed).
-			Padding(0, 2).
-			Bold(true).
-			Render("y Delete")
-		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorAccent).
-			Padding(0, 2).
-			Bold(true).
-			Render("n Cancel")
-		escHint := lipgloss.NewStyle().
-			Foreground(ColorTextDim).
-			Render("(Esc to cancel)")
-		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonYes, "  ", buttonNo, "  ", escHint)
+		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
+			renderButton("Delete", ColorRed, c.focusedButton == 0), "  ",
+			renderButton("Cancel", ColorAccent, c.focusedButton == 1))
+		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
+			hintStyle.Render("y delete · n cancel · ←/→ navigate · Enter select · Esc"))
 
 	case ConfirmCloseRemoteSession:
 		title = "Close Remote Session?"
 		warning = fmt.Sprintf("This will close the running process for:\n\n  \"%s\" on %s", c.targetName, c.remoteName)
 		details = "• The remote tmux session will be terminated\n• Session metadata will be kept on the remote\n• You can restart later"
 		borderColor = ColorYellow
-
-		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorYellow).
-			Padding(0, 2).
-			Bold(true).
-			Render("y Close")
-		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorAccent).
-			Padding(0, 2).
-			Bold(true).
-			Render("n Cancel")
-		escHint := lipgloss.NewStyle().
-			Foreground(ColorTextDim).
-			Render("(Esc to cancel)")
-		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonYes, "  ", buttonNo, "  ", escHint)
+		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
+			renderButton("Close", ColorYellow, c.focusedButton == 0), "  ",
+			renderButton("Cancel", ColorAccent, c.focusedButton == 1))
+		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
+			hintStyle.Render("y close · n cancel · ←/→ navigate · Enter select · Esc"))
 
 	case ConfirmDeleteGroup:
 		title = "⚠  Delete Group?"
 		warning = fmt.Sprintf("This will delete the group:\n\n  \"%s\"", c.targetName)
 		details = "• All sessions will be MOVED to 'default' group\n• Sessions will NOT be killed\n• The group structure will be lost"
 		borderColor = ColorRed
-
-		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorRed).
-			Padding(0, 2).
-			Bold(true).
-			Render("y Delete")
-		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorAccent).
-			Padding(0, 2).
-			Bold(true).
-			Render("n Cancel")
-		escHint := lipgloss.NewStyle().
-			Foreground(ColorTextDim).
-			Render("(Esc to cancel)")
-		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonYes, "  ", buttonNo, "  ", escHint)
+		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
+			renderButton("Delete", ColorRed, c.focusedButton == 0), "  ",
+			renderButton("Cancel", ColorAccent, c.focusedButton == 1))
+		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
+			hintStyle.Render("y delete · n cancel · ←/→ navigate · Enter select · Esc"))
 
 	case ConfirmQuitWithPool:
 		title = "MCP Pool Running"
 		warning = fmt.Sprintf("%d MCP servers are running in the pool.", c.mcpCount)
 		details = "Keep them running for faster startup next time,\nor shut down to free resources."
 		borderColor = ColorAccent
-
-		// "Keep running" is the default (green), "Shut down" is secondary (red)
-		buttonKeep := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorGreen).
-			Padding(0, 2).
-			Bold(true).
-			Render("k Keep running")
-		buttonShutdown := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorRed).
-			Padding(0, 2).
-			Bold(true).
-			Render("s Shut down")
-		escHint := lipgloss.NewStyle().
-			Foreground(ColorTextDim).
-			Render("(Esc to cancel)")
-		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonKeep, "  ", buttonShutdown, "  ", escHint)
+		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
+			renderButton("Keep running", ColorGreen, c.focusedButton == 0), "  ",
+			renderButton("Shut down", ColorRed, c.focusedButton == 1))
+		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
+			hintStyle.Render("k keep · s shut down · ←/→ navigate · Enter select · Esc"))
 
 	case ConfirmCreateDirectory:
 		title = "📁  Directory Not Found"
 		warning = fmt.Sprintf("The path does not exist:\n\n  %s", c.targetName)
 		details = "Create this directory and start the session?"
 		borderColor = ColorAccent
-
-		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorGreen).
-			Padding(0, 2).
-			Bold(true).
-			Render("y Create")
-		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorRed).
-			Padding(0, 2).
-			Bold(true).
-			Render("n Cancel")
-		escHint := lipgloss.NewStyle().
-			Foreground(ColorTextDim).
-			Render("(Esc to cancel)")
-		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonYes, "  ", buttonNo, "  ", escHint)
+		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
+			renderButton("Create", ColorGreen, c.focusedButton == 0), "  ",
+			renderButton("Cancel", ColorRed, c.focusedButton == 1))
+		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
+			hintStyle.Render("y create · n cancel · ←/→ navigate · Enter select · Esc"))
 
 	case ConfirmInstallHooks:
 		title = "Claude Code Hooks"
 		warning = "Agent-deck can install Claude Code lifecycle hooks\nfor real-time status detection (instant green/yellow/gray)."
 		details = "This writes to your Claude settings.json (preserves existing settings).\nNew/restarted sessions will use hooks; existing sessions continue unchanged.\nYou can disable later with: hooks_enabled = false in config.toml"
 		borderColor = ColorAccent
-
-		buttonYes := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorGreen).
-			Padding(0, 2).
-			Bold(true).
-			Render("y Install")
-		buttonNo := lipgloss.NewStyle().
-			Foreground(ColorBg).
-			Background(ColorAccent).
-			Padding(0, 2).
-			Bold(true).
-			Render("n Skip")
-		escHint := lipgloss.NewStyle().
-			Foreground(ColorTextDim).
-			Render("(Esc to skip)")
-		buttons = lipgloss.JoinHorizontal(lipgloss.Center, buttonYes, "  ", buttonNo, "  ", escHint)
+		buttonRow := lipgloss.JoinHorizontal(lipgloss.Center,
+			renderButton("Install", ColorGreen, c.focusedButton == 0), "  ",
+			renderButton("Skip", ColorAccent, c.focusedButton == 1))
+		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
+			hintStyle.Render("y install · n skip · ←/→ navigate · Enter select · Esc"))
 	}
 
 	// Title style

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5838,6 +5838,9 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // handleConfirmDialogKey handles keys when confirmation dialog is visible
 func (h *Home) handleConfirmDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Let the dialog handle arrow/tab navigation first.
+	h.confirmDialog.Update(msg)
+
 	switch h.confirmDialog.GetConfirmType() {
 	case ConfirmQuitWithPool:
 		switch msg.String() {
@@ -5849,6 +5852,12 @@ func (h *Home) handleConfirmDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			h.confirmDialog.Hide()
 			h.isQuitting = true
 			return h, h.performQuit(true)
+		case "enter":
+			// Activate focused button: 0=keep, 1=shutdown
+			shutdown := h.confirmDialog.GetFocusedButton() == 1
+			h.confirmDialog.Hide()
+			h.isQuitting = true
+			return h, h.performQuit(shutdown)
 		case "esc":
 			h.confirmDialog.Hide()
 			h.isQuitting = false
@@ -5859,29 +5868,13 @@ func (h *Home) handleConfirmDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case ConfirmCreateDirectory:
 		switch msg.String() {
 		case "y", "Y":
-			name, path, command, groupPath, pendingToolOpts, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
-			h.confirmDialog.Hide()
-			if err := os.MkdirAll(path, 0o755); err != nil {
-				h.setError(fmt.Errorf("failed to create directory: %w", err))
-				return h, nil
+			return h, h.confirmCreateDirectory()
+		case "enter":
+			if h.confirmDialog.GetFocusedButton() == 0 {
+				return h, h.confirmCreateDirectory()
 			}
-			return h, h.createSessionInGroupWithWorktreeAndOptions(
-				name,
-				path,
-				command,
-				groupPath,
-				"",
-				"",
-				"",
-				false,
-				false,
-				pendingToolOpts,
-				false,
-				nil,
-				parentSessionID,
-				parentProjectPath,
-				"", // no placeholder — non-worktree sessions are fast
-			)
+			h.confirmDialog.Hide()
+			return h, nil
 		case "n", "N", "esc":
 			h.confirmDialog.Hide()
 			return h, nil
@@ -5891,88 +5884,138 @@ func (h *Home) handleConfirmDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case ConfirmInstallHooks:
 		switch msg.String() {
 		case "y", "Y":
-			h.confirmDialog.Hide()
-			h.pendingHooksPrompt = false
-			configDir := session.GetClaudeConfigDir()
-			if _, err := session.InjectClaudeHooks(configDir); err != nil {
-				uiLog.Warn("hook_install_failed", slog.String("error", err.Error()))
-			} else {
-				uiLog.Info("claude_hooks_installed", slog.String("config_dir", configDir))
+			return h, h.confirmInstallHooks()
+		case "enter":
+			if h.confirmDialog.GetFocusedButton() == 0 {
+				return h, h.confirmInstallHooks()
 			}
-			// Start the status file watcher
-			hookWatcher, err := session.NewStatusFileWatcher(nil)
-			if err != nil {
-				uiLog.Warn("hook_watcher_init_failed", slog.String("error", err.Error()))
-			} else {
-				h.hookWatcher = hookWatcher
-				go hookWatcher.Start()
-			}
-			// Remember user's choice
-			if db := statedb.GetGlobal(); db != nil {
-				_ = db.SetMeta("hooks_prompted", "accepted")
-			}
-			return h, nil
+			return h, h.declineInstallHooks()
 		case "n", "N", "esc":
-			h.confirmDialog.Hide()
-			h.pendingHooksPrompt = false
-			// Remember user declined
-			if db := statedb.GetGlobal(); db != nil {
-				_ = db.SetMeta("hooks_prompted", "declined")
-			}
-			return h, nil
+			return h, h.declineInstallHooks()
 		}
 		return h, nil
 
 	default:
-		// Handle delete confirmations (session/group)
+		// Handle delete/close confirmations (session/group/remote)
 		switch msg.String() {
 		case "y", "Y":
-			// User confirmed - perform the deletion
-			switch h.confirmDialog.GetConfirmType() {
-			case ConfirmDeleteSession:
-				sessionID := h.confirmDialog.GetTargetID()
-				if inst := h.getInstanceByID(sessionID); inst != nil {
-					h.confirmDialog.Hide()
-					return h, h.deleteSession(inst)
-				}
-			case ConfirmCloseSession:
-				sessionID := h.confirmDialog.GetTargetID()
-				if inst := h.getInstanceByID(sessionID); inst != nil {
-					h.confirmDialog.Hide()
-					return h, h.closeSession(inst)
-				}
-			case ConfirmDeleteGroup:
-				groupPath := h.confirmDialog.GetTargetID()
-				h.groupTree.DeleteGroup(groupPath)
-				h.instancesMu.Lock()
-				h.instances = h.groupTree.GetAllInstances()
-				h.instancesMu.Unlock()
-				h.rebuildFlatItems()
-				h.saveInstances()
-			case ConfirmDeleteRemoteSession:
-				sessionID := h.confirmDialog.GetTargetID()
-				remoteName := h.confirmDialog.GetRemoteName()
-				title := h.confirmDialog.targetName
-				h.confirmDialog.Hide()
-				return h, h.deleteRemoteSession(remoteName, sessionID, title)
-			case ConfirmCloseRemoteSession:
-				sessionID := h.confirmDialog.GetTargetID()
-				remoteName := h.confirmDialog.GetRemoteName()
-				title := h.confirmDialog.targetName
-				h.confirmDialog.Hide()
-				return h, h.closeRemoteSession(remoteName, sessionID, title)
+			return h, h.confirmAction()
+		case "enter":
+			if h.confirmDialog.GetFocusedButton() == 0 {
+				return h, h.confirmAction()
 			}
 			h.confirmDialog.Hide()
 			return h, nil
-
 		case "n", "N", "esc":
-			// User cancelled
 			h.confirmDialog.Hide()
 			return h, nil
 		}
 	}
 
 	return h, nil
+}
+
+// confirmAction executes the confirmed destructive action.
+func (h *Home) confirmAction() tea.Cmd {
+	switch h.confirmDialog.GetConfirmType() {
+	case ConfirmDeleteSession:
+		sessionID := h.confirmDialog.GetTargetID()
+		if inst := h.getInstanceByID(sessionID); inst != nil {
+			h.confirmDialog.Hide()
+			return h.deleteSession(inst)
+		}
+	case ConfirmCloseSession:
+		sessionID := h.confirmDialog.GetTargetID()
+		if inst := h.getInstanceByID(sessionID); inst != nil {
+			h.confirmDialog.Hide()
+			return h.closeSession(inst)
+		}
+	case ConfirmDeleteGroup:
+		groupPath := h.confirmDialog.GetTargetID()
+		h.groupTree.DeleteGroup(groupPath)
+		h.instancesMu.Lock()
+		h.instances = h.groupTree.GetAllInstances()
+		h.instancesMu.Unlock()
+		h.rebuildFlatItems()
+		h.saveInstances()
+	case ConfirmDeleteRemoteSession:
+		sessionID := h.confirmDialog.GetTargetID()
+		remoteName := h.confirmDialog.GetRemoteName()
+		title := h.confirmDialog.targetName
+		h.confirmDialog.Hide()
+		return h.deleteRemoteSession(remoteName, sessionID, title)
+	case ConfirmCloseRemoteSession:
+		sessionID := h.confirmDialog.GetTargetID()
+		remoteName := h.confirmDialog.GetRemoteName()
+		title := h.confirmDialog.targetName
+		h.confirmDialog.Hide()
+		return h.closeRemoteSession(remoteName, sessionID, title)
+	}
+	h.confirmDialog.Hide()
+	return nil
+}
+
+// confirmCreateDirectory handles the "yes" action for ConfirmCreateDirectory.
+func (h *Home) confirmCreateDirectory() tea.Cmd {
+	name, path, command, groupPath, pendingToolOpts, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
+	h.confirmDialog.Hide()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		h.setError(fmt.Errorf("failed to create directory: %w", err))
+		return nil
+	}
+	return h.createSessionInGroupWithWorktreeAndOptions(
+		name,
+		path,
+		command,
+		groupPath,
+		"",
+		"",
+		"",
+		false,
+		false,
+		pendingToolOpts,
+		false,
+		nil,
+		parentSessionID,
+		parentProjectPath,
+		"", // no placeholder — non-worktree sessions are fast
+	)
+}
+
+// confirmInstallHooks handles the "yes" action for ConfirmInstallHooks.
+func (h *Home) confirmInstallHooks() tea.Cmd {
+	h.confirmDialog.Hide()
+	h.pendingHooksPrompt = false
+	configDir := session.GetClaudeConfigDir()
+	if _, err := session.InjectClaudeHooks(configDir); err != nil {
+		uiLog.Warn("hook_install_failed", slog.String("error", err.Error()))
+	} else {
+		uiLog.Info("claude_hooks_installed", slog.String("config_dir", configDir))
+	}
+	// Start the status file watcher
+	hookWatcher, err := session.NewStatusFileWatcher(nil)
+	if err != nil {
+		uiLog.Warn("hook_watcher_init_failed", slog.String("error", err.Error()))
+	} else {
+		h.hookWatcher = hookWatcher
+		go hookWatcher.Start()
+	}
+	// Remember user's choice
+	if db := statedb.GetGlobal(); db != nil {
+		_ = db.SetMeta("hooks_prompted", "accepted")
+	}
+	return nil
+}
+
+// declineInstallHooks handles the "no" action for ConfirmInstallHooks.
+func (h *Home) declineInstallHooks() tea.Cmd {
+	h.confirmDialog.Hide()
+	h.pendingHooksPrompt = false
+	// Remember user declined
+	if db := statedb.GetGlobal(); db != nil {
+		_ = db.SetMeta("hooks_prompted", "declined")
+	}
+	return nil
 }
 
 // tryQuit checks if MCP pool is running and shows confirmation dialog, or quits directly

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1064,11 +1064,24 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.pathCycler.Reset()
 				d.filterPathSuggestions()
 				return d, nil // consume the key
-			case tea.KeyLeft, tea.KeyRight:
+			case tea.KeyRight:
+				// → enters the suggestions dropdown (if available).
+				if len(d.pathSuggestions) > 0 {
+					d.pathSoftSelected = false
+					d.suggestionsActive = true
+					d.suggestionNavigated = true
+					return d, nil
+				}
+				// No suggestions: just exit soft-select into edit mode.
+				d.pathSoftSelected = false
+				d.pathInput.Focus()
+			case tea.KeyLeft:
 				d.pathSoftSelected = false
 				d.pathInput.Focus() // exit soft-select, allow editing
 			}
-			// Tab, Enter, Esc, Ctrl+N, Ctrl+P, Up, Down fall through to existing handlers
+			// Tab, Enter, Esc, Ctrl+N, Ctrl+P, Up, Down fall through to existing handlers.
+			// Down specifically falls through to the normal "move to next field" handler
+			// so the user can keep navigating the form without entering the dropdown.
 		}
 
 		switch msg.String() {
@@ -1163,12 +1176,13 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case "down":
-			// Enter suggestions dropdown when pressing down on path field.
+			// Enter suggestions dropdown when pressing down on path field,
+			// but only when actively editing (not when soft-selected — ↓ should
+			// move to the next form field in that case).
 			isPathEditing := cur == focusPath || (cur == focusMultiRepo && d.multiRepoEditing)
-			if isPathEditing && len(d.pathSuggestions) > 0 {
+			if isPathEditing && !d.pathSoftSelected && len(d.pathSuggestions) > 0 {
 				d.suggestionsActive = true
 				d.suggestionNavigated = true
-				d.pathSoftSelected = false
 				d.pathInput.Blur()
 				return d, nil
 			}
@@ -1843,7 +1857,7 @@ func (d *NewDialog) View() string {
 	helpText := recentPrefix + "Tab next/accept │ ↑↓ navigate │ Enter create │ Esc cancel"
 	if cur == focusPath {
 		if d.pathSoftSelected {
-			helpText = "Type to replace │ ←→ to edit │ ^N/^P recent │ Tab next │ Esc cancel"
+			helpText = "Type to replace │ ← edit │ → browse suggestions │ Tab next │ Esc cancel"
 		} else {
 			helpText = "Tab autocomplete │ ↓ browse │ ^N/^P cycle │ Enter create │ Esc cancel"
 		}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -163,6 +163,7 @@ type NewDialog struct {
 	allPathSuggestions   []string // full unfiltered set of path suggestions.
 	pathSuggestionCursor int      // tracks selected suggestion in dropdown.
 	suggestionNavigated  bool     // tracks if user explicitly navigated suggestions.
+	suggestionsActive    bool     // true when arrow-key focus is inside the suggestions dropdown.
 	pathSoftSelected     bool     // true when path text is "soft selected" (ready to replace on type).
 	// Worktree support.
 	worktreeEnabled bool
@@ -323,6 +324,7 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.nameInput.Focus()
 	d.suggestionNavigated = false // reset on show
 	d.pathSuggestionCursor = 0    // reset cursor too
+	d.suggestionsActive = false
 	d.pathCycler.Reset()          // clear stale autocomplete matches from previous show
 	d.showRecentPicker = false    // reset recent picker
 	d.recentSessionCursor = 0
@@ -901,8 +903,9 @@ func (d *NewDialog) updateFocus() {
 	d.geminiOptions.Blur()
 	d.codexOptions.Blur()
 
-	// Manage soft-select: re-activate when entering path field with a value.
+	// Reset dropdown and soft-select state when focus changes.
 	d.pathSoftSelected = false
+	d.suggestionsActive = false
 	switch d.currentTarget() {
 	case focusName:
 		d.nameInput.Focus()
@@ -1010,6 +1013,36 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			d.recentSessionCursor = 0
 			d.previewRecentSession(d.recentSessions[0])
 			return d, nil
+		}
+
+		// Suggestions dropdown active: arrow keys navigate, space/enter select, left/esc exit.
+		if d.suggestionsActive && len(d.pathSuggestions) > 0 {
+			switch msg.String() {
+			case "down", "j":
+				d.pathSuggestionCursor = (d.pathSuggestionCursor + 1) % len(d.pathSuggestions)
+				d.suggestionNavigated = true
+				return d, nil
+			case "up", "k":
+				d.pathSuggestionCursor--
+				if d.pathSuggestionCursor < 0 {
+					d.pathSuggestionCursor = len(d.pathSuggestions) - 1
+				}
+				d.suggestionNavigated = true
+				return d, nil
+			case " ", "enter":
+				if d.pathSuggestionCursor < len(d.pathSuggestions) {
+					d.pathInput.SetValue(d.pathSuggestions[d.pathSuggestionCursor])
+					d.pathInput.SetCursor(len(d.pathInput.Value()))
+				}
+				d.suggestionsActive = false
+				d.pathInput.Focus()
+				return d, nil
+			case "left", "h", "esc":
+				d.suggestionsActive = false
+				d.pathInput.Focus()
+				return d, nil
+			}
+			return d, nil // consume all other keys while dropdown is active
 		}
 
 		// Soft-select interception for path field
@@ -1130,6 +1163,15 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case "down":
+			// Enter suggestions dropdown when pressing down on path field.
+			isPathEditing := cur == focusPath || (cur == focusMultiRepo && d.multiRepoEditing)
+			if isPathEditing && len(d.pathSuggestions) > 0 {
+				d.suggestionsActive = true
+				d.suggestionNavigated = true
+				d.pathSoftSelected = false
+				d.pathInput.Blur()
+				return d, nil
+			}
 			if cur == focusConductor {
 				total := len(d.conductorSessions) + 1 // +1 for "None"
 				if d.conductorCursor < total-1 {
@@ -1365,6 +1407,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 		d.pathInput, cmd = d.pathInput.Update(msg)
 		if d.pathInput.Value() != oldValue {
 			d.suggestionNavigated = false
+			d.suggestionsActive = false
 			d.pathSuggestionCursor = 0
 			d.pathCycler.Reset()
 			d.filterPathSuggestions()
@@ -1380,6 +1423,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			d.pathInput, cmd = d.pathInput.Update(msg)
 			if d.pathInput.Value() != oldValue {
 				d.suggestionNavigated = false
+				d.suggestionsActive = false
 				d.pathSuggestionCursor = 0
 				d.pathCycler.Reset()
 				d.filterPathSuggestions()
@@ -1801,7 +1845,7 @@ func (d *NewDialog) View() string {
 		if d.pathSoftSelected {
 			helpText = "Type to replace │ ←→ to edit │ ^N/^P recent │ Tab next │ Esc cancel"
 		} else {
-			helpText = "Tab autocomplete │ ^N/^P recent │ ↑↓ navigate │ Enter create │ Esc cancel"
+			helpText = "Tab autocomplete │ ↓ browse │ ^N/^P cycle │ Enter create │ Esc cancel"
 		}
 	} else if cur == focusBranch {
 		if d.branchPicker != nil && d.branchPicker.IsVisible() {
@@ -1933,19 +1977,32 @@ func (d *NewDialog) renderSuggestionsDropdown() string {
 
 	// Footer with keybinding hints
 	var footerText string
-	if len(d.pathSuggestions) < len(d.allPathSuggestions) {
-		footerText = fmt.Sprintf(" %d/%d matching │ ^N/^P cycle │ Tab accept ",
-			len(d.pathSuggestions), len(d.allPathSuggestions))
+	if d.suggestionsActive {
+		if len(d.pathSuggestions) < len(d.allPathSuggestions) {
+			footerText = fmt.Sprintf(" %d/%d matching │ ↑/↓ navigate │ Space select │ Esc back ",
+				len(d.pathSuggestions), len(d.allPathSuggestions))
+		} else {
+			footerText = " ↑/↓ navigate │ Space select │ Esc back "
+		}
 	} else {
-		footerText = " ^N/^P cycle │ Tab accept "
+		if len(d.pathSuggestions) < len(d.allPathSuggestions) {
+			footerText = fmt.Sprintf(" %d/%d matching │ ↓ browse │ ^N/^P cycle │ Tab accept ",
+				len(d.pathSuggestions), len(d.allPathSuggestions))
+		} else {
+			footerText = " ↓ browse │ ^N/^P cycle │ Tab accept "
+		}
 	}
 	b.WriteString("\n")
 	b.WriteString(lipgloss.NewStyle().Foreground(ColorBorder).Background(menuBg).Render(footerText))
 
-	// Wrap in a bordered menu box
+	// Wrap in a bordered menu box — accent border when actively browsing.
+	borderColor := ColorBorder
+	if d.suggestionsActive {
+		borderColor = ColorCyan
+	}
 	menuStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(ColorBorder).
+		BorderForeground(borderColor).
 		Background(menuBg).
 		Padding(0, 1)
 


### PR DESCRIPTION
## Summary
- When on the path field, pressing ↓ (editing mode) or → (soft-select mode) enters the suggestions dropdown for arrow-key browsing
- Inside the dropdown: ↑/↓ navigate, Space/Enter select, Left/Esc exit back to input
- Dropdown border highlights cyan when active, footer hint updates per mode
- When soft-selected (just landed on path): ↓ moves to the next form field as expected
- Ctrl+N/Ctrl+P still work as quick-cycle shortcuts from the path input

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/ui/` passes
- [ ] Manual: soft-selected path — → enters dropdown, ↓ moves to next field
- [ ] Manual: editing path — ↓ enters dropdown
- [ ] Manual: inside dropdown — ↑/↓ navigates, Space selects, Esc exits
- [ ] Manual: Ctrl+N/Ctrl+P still cycle suggestions from path input
- [ ] Manual: multi-repo editing — same dropdown behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)