### PR TITLE
feat: Ctrl+T split terminal while attached

### DIFF
--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -55,6 +55,37 @@ func IndexCtrlQ(data []byte) int {
 	return IndexDetachKey(data, 17)
 }
 
+// splitKeyByte is the raw ASCII byte for Ctrl+T (0x14).
+const splitKeyByte = 0x14
+
+// stripSplitKey removes the first Ctrl+T sequence from data (raw byte or
+// escape-sequence encoding) and returns the remaining bytes and true.
+// Returns the original data and false if no Ctrl+T was found.
+func stripSplitKey(data []byte) ([]byte, bool) {
+	// Try raw byte first.
+	if idx := bytes.IndexByte(data, splitKeyByte); idx >= 0 {
+		out := make([]byte, 0, len(data)-1)
+		out = append(out, data[:idx]...)
+		out = append(out, data[idx+1:]...)
+		return out, true
+	}
+	// Derive keyCode for escape sequence matching (Ctrl+T = 0x14 -> 't' = 116).
+	keyCode := splitKeyByte + 96
+	for _, seq := range []string{
+		fmt.Sprintf("\x1b[27;5;%d~", keyCode),
+		fmt.Sprintf("\x1b[%d;5u", keyCode),
+	} {
+		seqBytes := []byte(seq)
+		if idx := bytes.Index(data, seqBytes); idx >= 0 {
+			out := make([]byte, 0, len(data)-len(seqBytes))
+			out = append(out, data[:idx]...)
+			out = append(out, data[idx+len(seqBytes):]...)
+			return out, true
+		}
+	}
+	return data, false
+}
+
 // Attach attaches to the tmux session with full PTY support.
 // The configured detach key (default Ctrl+Q) will detach and return to the caller.
 // Pass an optional detachByte to override the default (0x11 / Ctrl+Q).
@@ -212,6 +243,16 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 				close(detachCh)
 				cancel()
 				return
+			}
+
+			// Check for Ctrl+T (split terminal). Strip the key sequence
+			// from the buffer, open a split pane, and forward remaining bytes.
+			if remaining, found := stripSplitKey(buf[:n]); found {
+				if len(remaining) > 0 {
+					_, _ = ptmx.Write(remaining)
+				}
+				_ = s.SplitPane(s.WorkDir)
+				continue
 			}
 
 			// Forward other input to tmux PTY

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -4081,6 +4081,16 @@ func GetActiveSession() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// SplitPane opens a vertical split (side-by-side) in the session's current
+// window, starting a shell in the given working directory.
+func (s *Session) SplitPane(workDir string) error {
+	args := []string{"split-window", "-h", "-t", s.Name}
+	if workDir != "" {
+		args = append(args, "-c", workDir)
+	}
+	return exec.Command("tmux", args...).Run()
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 
 // DiscoverAllTmuxSessions returns all tmux sessions (including non-Agent Deck ones)


### PR DESCRIPTION
## Summary
- Pressing Ctrl+T while attached to a session opens a vertical split pane with a shell in the session's working directory
- Focus between panes via mouse click, Ctrl+B arrow, or Ctrl+arrow keys
- Ctrl+T is intercepted in the PTY stdin reader (same mechanism as the detach key) and stripped from input so it never reaches the underlying tool
- Handles raw byte, xterm modifyOtherKeys, and kitty CSI u encodings

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/ui/` passes
- [ ] Manual: attach to a Claude session, press Ctrl+T — split pane opens on the right
- [ ] Manual: split pane starts in the session's project directory
- [ ] Manual: click or Ctrl+B arrow to switch focus between panes
- [ ] Manual: Ctrl+T does not leak into Claude's input
- [ ] Manual: detach (Ctrl+Q) still works after splitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)