### PR TITLE
fix: initialize branchAutoSet when worktree default_enabled is true in ShowInGroup

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -376,6 +376,9 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 		d.claudeOptions.SetDefaults(userConfig)
 		d.sandboxEnabled = userConfig.Docker.DefaultEnabled
 		d.worktreeEnabled = userConfig.Worktree.DefaultEnabled
+		if d.worktreeEnabled {
+			d.branchAutoSet = true
+		}
 		d.inheritedSettings = buildInheritedSettings(userConfig.Docker)
 		d.branchPrefix = userConfig.Worktree.Prefix()
 	}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -1045,6 +1045,69 @@ func TestNewDialog_ShowInGroup_ResetsBranchAutoSet(t *testing.T) {
 	}
 }
 
+func TestNewDialog_ShowInGroup_DefaultWorktree_SetsBranchAutoSet(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	session.ClearUserConfigCache()
+	defer session.ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Worktree: session.WorktreeSettings{DefaultEnabled: true},
+	}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	session.ClearUserConfigCache()
+
+	d := NewNewDialog()
+	d.ShowInGroup("projects", "Projects", "", nil, "")
+
+	if !d.worktreeEnabled {
+		t.Fatal("worktreeEnabled should be true from config default")
+	}
+	if !d.branchAutoSet {
+		t.Error("branchAutoSet should be true when worktree is enabled by config default")
+	}
+}
+
+func TestNewDialog_ShowInGroup_DefaultWorktree_AutoPopulatesBranchFromName(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	session.ClearUserConfigCache()
+	defer session.ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Worktree: session.WorktreeSettings{DefaultEnabled: true},
+	}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	session.ClearUserConfigCache()
+
+	d := NewNewDialog()
+	d.ShowInGroup("projects", "Projects", "", nil, "")
+	d.nameInput.SetValue("amber-falcon")
+
+	// Simulate the name-change handler: it calls autoBranchFromName() only when branchAutoSet is true.
+	if d.worktreeEnabled && d.branchAutoSet {
+		d.autoBranchFromName()
+	}
+
+	if got := d.branchInput.Value(); got != "feature/amber-falcon" {
+		t.Errorf("branch = %q, want %q; branch should auto-populate when worktree is default-enabled", got, "feature/amber-falcon")
+	}
+}
+
 // ===== Soft-Select Tests =====
 
 func TestNewDialog_SoftSelect_InitialState(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes asheshgoplani/agent-deck#561

When `[worktree] default_enabled = true` is set in `~/.agent-deck/config.toml`, the New Session dialog opens with the worktree checkbox already checked — but the branch input was not auto-populated as the user typed the session name.

## Root Cause

In `internal/ui/newdialog.go`, `ShowInGroup()` resets `branchAutoSet = false` before applying config defaults. The name-change handler guards on `branchAutoSet` being `true`:

```go
if d.worktreeEnabled && d.branchAutoSet && d.nameInput.Value() != oldName {
    d.autoBranchFromName()
}
```

Since `branchAutoSet` was `false`, the sync never fired when the dialog started with worktree enabled via the config default.

## Fix

In `ShowInGroup()`, after applying the config default for worktree, set `branchAutoSet = true` when `worktreeEnabled` is `true`. This mirrors exactly what `ToggleWorktree()` does when the user manually enables the checkbox:

```go
d.worktreeEnabled = userConfig.Worktree.DefaultEnabled
if d.worktreeEnabled {
    d.branchAutoSet = true
}
```

## Tests

Added two regression tests that fail before the fix and pass after it:
- `TestNewDialog_ShowInGroup_DefaultWorktree_SetsBranchAutoSet` — asserts `branchAutoSet` is `true` when config has `default_enabled = true`
- `TestNewDialog_ShowInGroup_DefaultWorktree_AutoPopulatesBranchFromName` — asserts branch auto-populates from session name when worktree is default-enabled

All existing tests continue to pass.