### PR TITLE
Fix #564: allow Esc to dismiss setup wizard on welcome step

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4167,8 +4167,8 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if h.setupWizard.IsVisible() {
 			var cmd tea.Cmd
 			h.setupWizard, cmd = h.setupWizard.Update(msg)
-			// Check if user pressed Enter on final step
-			if msg.String() == "enter" && h.setupWizard.IsComplete() {
+			// Check if wizard completed (Enter on final step, or Esc on welcome to use defaults)
+			if h.setupWizard.IsComplete() {
 				// Save config and close wizard
 				config := h.setupWizard.GetConfig()
 				if err := session.SaveUserConfig(config); err != nil {

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -210,6 +210,11 @@ func (w *SetupWizard) Update(msg tea.Msg) (*SetupWizard, tea.Cmd) {
 			return w, nil
 
 		case "esc", "backspace":
+			if w.currentStep == stepWelcome {
+				// On welcome step, Esc means "use defaults and skip wizard"
+				w.complete = true
+				return w, nil
+			}
 			w.prevStep()
 			return w, nil
 

--- a/internal/ui/setup_wizard_test.go
+++ b/internal/ui/setup_wizard_test.go
@@ -293,6 +293,45 @@ func TestSetupWizard_ViewNonEmpty(t *testing.T) {
 	}
 }
 
+func TestSetupWizard_EscOnWelcomeCompletes(t *testing.T) {
+	wizard := NewSetupWizard()
+	wizard.Show()
+	wizard.SetSize(80, 24)
+
+	// Esc on welcome step should complete the wizard with defaults
+	wizard.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if !wizard.IsComplete() {
+		t.Error("Esc on welcome step should complete the wizard")
+	}
+
+	// Config should have sensible defaults
+	config := wizard.GetConfig()
+	if config.DefaultTool != "claude" {
+		t.Errorf("Default tool should be 'claude', got %q", config.DefaultTool)
+	}
+}
+
+func TestSetupWizard_EscOnNonWelcomeGoesBack(t *testing.T) {
+	wizard := NewSetupWizard()
+	wizard.Show()
+	wizard.SetSize(80, 24)
+
+	// Advance to tool selection
+	wizard.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if wizard.currentStep != 1 {
+		t.Fatalf("Expected step 1 after Enter, got %d", wizard.currentStep)
+	}
+
+	// Esc on tool selection should go back to welcome, not complete
+	wizard.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if wizard.currentStep != 0 {
+		t.Errorf("Esc on tool selection: got step %d, want 0", wizard.currentStep)
+	}
+	if wizard.IsComplete() {
+		t.Error("Esc on non-welcome step should not complete the wizard")
+	}
+}
+
 func TestSetupWizard_GetConfig_DefaultTheme(t *testing.T) {
 	wizard := NewSetupWizard()
 	config := wizard.GetConfig()


### PR DESCRIPTION
Fixes #564

## Summary
- The setup wizard welcome step displays "Press Esc to use defaults" but pressing Esc had no effect because `prevStep()` has no action for the first step
- Now pressing Esc on the welcome step completes the wizard with default configuration, matching the documented behavior
- On non-welcome steps, Esc still navigates back as before

## Changes
- `internal/ui/setup_wizard.go`: Added `stepWelcome` check in Esc handler to mark wizard complete
- `internal/ui/home.go`: Broadened completion check to trigger on any key that sets `IsComplete()`, not just Enter
- `internal/ui/setup_wizard_test.go`: Added two tests covering Esc behavior on welcome and non-welcome steps