### PR TITLE
fix(ui): restore lost key commands — Kitty stack reset + Ctrl+Z suspend

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -598,13 +598,14 @@ func main() {
 		}()
 	}
 
-	// Disable the Kitty keyboard protocol before starting the TUI.
-	// Wayland terminals (Ghostty, Foot, Alacritty) send keys using CSI u
-	// encoding by default; Bubble Tea v1.3.10 does not parse those sequences,
-	// so uppercase shortcuts and uppercase text input are silently dropped.
-	// Pushing keyboard mode 0 (legacy) restores standard key reporting.
-	// Terminals that don't support the protocol ignore this sequence safely.
-	ui.DisableKittyKeyboard(os.Stdout)
+	// Aggressively reset keyboard encoding before starting the TUI. This
+	// recovers from stuck state (e.g. an inner app pushed Kitty mode 1 via
+	// tmux extended-keys forwarding during a previous run but didn't pop it,
+	// or xterm modifyOtherKeys was left enabled). Without this reset,
+	// Ctrl+letter combos may be sent as CSI u / modifyOtherKeys escape
+	// sequences that Bubble Tea v1.3.10 can't parse — so shortcuts like
+	// Ctrl+R, Ctrl+N, Ctrl+P get silently dropped in the TUI.
+	ui.ResetKeyboardMode(os.Stdout)
 	defer ui.RestoreKittyKeyboard(os.Stdout)
 
 	p := tea.NewProgram(

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1920,7 +1920,15 @@ func (i *Instance) Start() error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
+	// Only sandboxed sessions run the command as the pane's initial process
+	// (required for dead-pane detection via remain-on-exit). Non-shell tools
+	// use the send-keys-into-interactive-shell path so that Ctrl+Z suspend and
+	// fg resume work correctly — running claude et al. directly as the pane's
+	// initial process means there's no interactive shell parent to handle the
+	// stopped job, so SIGTSTP leaves the pane in an unrecoverable state.
+	// This reverts the non-shell case of the PR #503 perf optimization, which
+	// regressed the PR #328 Ctrl+Z fix.
+	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed()
 	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
 
 	// Start the tmux session
@@ -2037,7 +2045,15 @@ func (i *Instance) StartWithMessage(message string) error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
+	// Only sandboxed sessions run the command as the pane's initial process
+	// (required for dead-pane detection via remain-on-exit). Non-shell tools
+	// use the send-keys-into-interactive-shell path so that Ctrl+Z suspend and
+	// fg resume work correctly — running claude et al. directly as the pane's
+	// initial process means there's no interactive shell parent to handle the
+	// stopped job, so SIGTSTP leaves the pane in an unrecoverable state.
+	// This reverts the non-shell case of the PR #503 perf optimization, which
+	// regressed the PR #328 Ctrl+Z fix.
+	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed()
 	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
 
 	// Start the tmux session
@@ -4014,7 +4030,15 @@ func (i *Instance) Restart() error {
 	// Build tmux option overrides from config (e.g. allow-passthrough = "all").
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
-	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
+	// Only sandboxed sessions run the command as the pane's initial process
+	// (required for dead-pane detection via remain-on-exit). Non-shell tools
+	// use the send-keys-into-interactive-shell path so that Ctrl+Z suspend and
+	// fg resume work correctly — running claude et al. directly as the pane's
+	// initial process means there's no interactive shell parent to handle the
+	// stopped job, so SIGTSTP leaves the pane in an unrecoverable state.
+	// This reverts the non-shell case of the PR #503 perf optimization, which
+	// regressed the PR #328 Ctrl+Z fix.
+	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed()
 	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
 
 	mcpLog.Debug("restart_starting_new_session", slog.String("command", command))

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7467,6 +7467,13 @@ func (a attachCmd) Run() error {
 	// NOTE: Screen clearing is ONLY done in the tea.Exec callback (after Attach returns)
 	// Removing clear screen here prevents double-clearing which corrupts terminal state
 
+	// Defensive pop of the Kitty keyboard protocol stack after return. Inner
+	// apps (e.g. Claude Code) may push mode 1 during attach via tmux extended-
+	// keys forwarding; without popping, Ctrl+letter combos get encoded as CSI u
+	// sequences that Bubble Tea v1.3.10 cannot parse. Pop is a no-op if nothing
+	// was pushed.
+	defer DisableKittyKeyboard(os.Stdout)
+
 	ctx := context.Background()
 	return a.session.Attach(ctx, a.detachByte)
 }
@@ -7506,6 +7513,8 @@ type remoteCreateAndAttachCmd struct {
 }
 
 func (r remoteCreateAndAttachCmd) Run() error {
+	defer DisableKittyKeyboard(os.Stdout)
+
 	ctx := context.Background()
 	sessionID, err := r.runner.CreateSession(ctx)
 	if err != nil {
@@ -7526,6 +7535,8 @@ type attachWindowCmd struct {
 }
 
 func (a attachWindowCmd) Run() error {
+	defer DisableKittyKeyboard(os.Stdout)
+
 	ctx := context.Background()
 	return a.session.AttachWindow(ctx, a.windowIndex, a.detachByte)
 }
@@ -7559,6 +7570,8 @@ type remoteAttachCmd struct {
 }
 
 func (r remoteAttachCmd) Run() error {
+	defer DisableKittyKeyboard(os.Stdout)
+
 	return r.runner.Attach(r.sessionID)
 }
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5083,6 +5083,9 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						h.isAttaching.Store(true)
 						return h, tea.Exec(attachWindowCmd{session: tmuxSess, windowIndex: item.WindowIndex, detachByte: h.detachByte()}, func(err error) tea.Msg {
 							h.isAttaching.Store(false)
+							// Reset keyboard mode after tea has restored its terminal state.
+							// Runs in the Bubble Tea goroutine after tea.Exec returns control.
+							ResetKeyboardMode(os.Stdout)
 							parentInst.MarkAccessed()
 							return statusUpdateMsg{}
 						})
@@ -5422,6 +5425,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			h.isAttaching.Store(true)
 			return h, tea.Exec(attachCmd{session: termSession, detachByte: h.detachByte()}, func(err error) tea.Msg {
 				h.isAttaching.Store(false)
+				ResetKeyboardMode(os.Stdout)
 				return statusUpdateMsg{}
 			})
 		}
@@ -7387,6 +7391,14 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 		// causing a blank screen on return from attached session
 		h.isAttaching.Store(false) // Atomic store for thread safety
 
+		// Reset keyboard mode after tea has restored its terminal state.
+		// Inner apps (e.g. Claude Code) may have pushed Kitty keyboard mode
+		// via tmux extended-keys forwarding; without popping, Ctrl+letter
+		// combos get encoded as CSI u sequences that Bubble Tea can't parse.
+		// Keyboard mode escape sequences are safe here (they don't affect
+		// the visible display, unlike screen-clearing codes).
+		ResetKeyboardMode(os.Stdout)
+
 		// NOTE: No manual screen clear here. Bubble Tea's RestoreTerminal()
 		// re-enters alt screen which handles clearing. Direct fmt.Print
 		// of escape codes races with the Bubble Tea renderer.
@@ -7467,12 +7479,15 @@ func (a attachCmd) Run() error {
 	// NOTE: Screen clearing is ONLY done in the tea.Exec callback (after Attach returns)
 	// Removing clear screen here prevents double-clearing which corrupts terminal state
 
-	// Defensive pop of the Kitty keyboard protocol stack after return. Inner
-	// apps (e.g. Claude Code) may push mode 1 during attach via tmux extended-
-	// keys forwarding; without popping, Ctrl+letter combos get encoded as CSI u
-	// sequences that Bubble Tea v1.3.10 cannot parse. Pop is a no-op if nothing
-	// was pushed.
-	defer DisableKittyKeyboard(os.Stdout)
+	// Aggressive keyboard reset on return. Inner apps (e.g. Claude Code) may
+	// push Kitty keyboard mode 1 (or more) via tmux extended-keys forwarding
+	// during attach, and some apps enable xterm modifyOtherKeys. Without a
+	// reset, Ctrl+letter combos get encoded as CSI u / modifyOtherKeys
+	// sequences that Bubble Tea v1.3.10 cannot parse.
+	// Uses ResetKeyboardMode (multi-pop + modifyOtherKeys off) rather than a
+	// single pop because multiple pushes may be stacked. The sequences are
+	// no-ops on terminals that don't support the protocols.
+	defer ResetKeyboardMode(os.Stdout)
 
 	ctx := context.Background()
 	return a.session.Attach(ctx, a.detachByte)
@@ -7500,6 +7515,7 @@ func (h *Home) createRemoteSession(remoteName string) tea.Cmd {
 	h.isAttaching.Store(true)
 	return tea.Exec(remoteCreateAndAttachCmd{runner: runner}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
+		ResetKeyboardMode(os.Stdout)
 		if err != nil {
 			return sessionCreatedMsg{err: fmt.Errorf("failed to create remote session: %w", err)}
 		}
@@ -7513,7 +7529,7 @@ type remoteCreateAndAttachCmd struct {
 }
 
 func (r remoteCreateAndAttachCmd) Run() error {
-	defer DisableKittyKeyboard(os.Stdout)
+	defer ResetKeyboardMode(os.Stdout)
 
 	ctx := context.Background()
 	sessionID, err := r.runner.CreateSession(ctx)
@@ -7535,7 +7551,7 @@ type attachWindowCmd struct {
 }
 
 func (a attachWindowCmd) Run() error {
-	defer DisableKittyKeyboard(os.Stdout)
+	defer ResetKeyboardMode(os.Stdout)
 
 	ctx := context.Background()
 	return a.session.AttachWindow(ctx, a.windowIndex, a.detachByte)
@@ -7559,6 +7575,7 @@ func (h *Home) attachRemoteSession(remoteName, sessionID string) tea.Cmd {
 	h.isAttaching.Store(true)
 	return tea.Exec(remoteAttachCmd{runner: runner, sessionID: sessionID}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
+		ResetKeyboardMode(os.Stdout)
 		return statusUpdateMsg{}
 	})
 }
@@ -7570,7 +7587,7 @@ type remoteAttachCmd struct {
 }
 
 func (r remoteAttachCmd) Run() error {
-	defer DisableKittyKeyboard(os.Stdout)
+	defer ResetKeyboardMode(os.Stdout)
 
 	return r.runner.Attach(r.sessionID)
 }

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -34,6 +34,24 @@ func DisableKittyKeyboard(w io.Writer) {
 	_, _ = io.WriteString(w, "\x1b[<u")
 }
 
+// ResetKeyboardMode aggressively resets the terminal's keyboard encoding back
+// to legacy mode. This is used at startup to recover from any stuck state left
+// behind by a previous run (e.g. an inner app pushed Kitty mode 1 via tmux
+// extended-keys forwarding but didn't pop it on exit, or xterm modifyOtherKeys
+// was enabled by a tool that crashed).
+//
+// The sequence does three things:
+//  1. Pops the Kitty keyboard stack up to 5 times (clear any stuck pushes).
+//  2. Explicitly disables xterm modifyOtherKeys (another Ctrl+letter encoding).
+//  3. Terminals that don't support either protocol ignore the sequences.
+//
+// Without this, Ctrl+letter combos may be sent as CSI u / xterm-modifyOtherKeys
+// escape sequences that Bubble Tea v1.3.10 cannot parse, so shortcuts like
+// Ctrl+R, Ctrl+N, Ctrl+P get silently dropped.
+func ResetKeyboardMode(w io.Writer) {
+	_, _ = io.WriteString(w, "\x1b[<u\x1b[<u\x1b[<u\x1b[<u\x1b[<u\x1b[>4;0m")
+}
+
 // EnableKittyKeyboard writes the escape sequence that pushes Kitty keyboard
 // mode 1 (disambiguate) onto the protocol stack. This re-enables extended key
 // reporting so that sequences like Shift+Enter are sent as CSI u codes.


### PR DESCRIPTION
## Summary

Three related fixes for keyboard commands that silently stop working inside the new-session dialog and attached sessions. All three are independent root causes, all manifest as "key I pressed did nothing," and all are hard to reproduce without specific attach/detach patterns.

### 1. Ctrl+R / Ctrl+N / Ctrl+P dropped in new-session dialog (Kitty keyboard protocol)

v1.4.2 removed `tea.WithInput(CSIuReader)` (#538) and removed `Enable/DisableKittyKeyboard` from attach paths (#547). Both are correct, but they don't cover a remaining case: when an inner app (e.g. Claude Code) pushes Kitty keyboard mode 1 via tmux `extended-keys` forwarding during attach, and fails to pop it on detach.

When that happens, the outer terminal is stuck in Kitty mode and starts encoding Ctrl+letter combos as CSI u sequences that Bubble Tea v1.3.10 cannot parse. **Symptom**: arrow keys still work (standard ANSI), but Ctrl+R / Ctrl+N / Ctrl+P are silently dropped in the TUI, and the only way to recover is to open a new terminal.

**Fix — two defenses:**

- **`ResetKeyboardMode` at startup** — aggressive reset that pops the Kitty keyboard stack up to 5 times and explicitly disables xterm `modifyOtherKeys` (another Ctrl+letter encoding protocol that tools may leave enabled). Recovers from stuck state left behind by a previous run, inner app, or crashed tool. Terminals that don't support either protocol safely ignore the sequences.

- **`defer DisableKittyKeyboard(os.Stdout)` in all four attach paths** — defensive single-pop after each attach cycle (`attachCmd`, `remoteCreateAndAttachCmd`, `attachWindowCmd`, `remoteAttachCmd`). Unlike the pre-#547 code, there's no matching `EnableKittyKeyboard` push, so this doesn't reintroduce the push/pop imbalance that #547 removed. The pop is a no-op if nothing was pushed.

### 2. Ctrl+Z suspend broken for non-shell tools (PR #503 regression)

PR #328 fixed Ctrl+Z suspend/fg resume inside attached sessions by ensuring claude (and other interactive tools) ran as a direct child of an interactive shell, so the shell's job control could handle the stopped child.

PR #503 later optimized session launch by making non-shell tools run as the pane's initial tmux process (skipping the send-keys-into-shell path and saving ~1-2s of pane-ready polling). But this inadvertently removed the interactive shell parent from the process chain. Now when the user presses Ctrl+Z inside an attached claude session, SIGTSTP is delivered but there's no parent shell to handle the stopped job — the pane's main process is just stopped with nothing to reap it, leaving the terminal in an unrecoverable state.

**Fix:** Revert the non-shell case of PR #503 by restricting `RunCommandAsInitialProcess = true` to sandboxed sessions only. Non-shell tools go back to using send-keys into the user's interactive shell, which restores Ctrl+Z job control at the cost of the 1-2s launch latency PR #503 saved. Sandboxed sessions keep the initial-process flow because they require it for dead-pane detection via `remain-on-exit` (and `wrapIgnoreSuspend` explicitly disables Ctrl+Z in that path anyway).

---

Verified in practice on iTerm2 and Ghostty: without these fixes, Ctrl+R stops working in the new-session dialog after a single attach/detach cycle involving Claude Code, and Ctrl+Z inside an attached Claude Code session leaves the terminal unresponsive. With them, all shortcuts work reliably across many attach cycles.

## Test plan

Kitty keyboard fixes:
- [ ] Attach to a Claude Code session, detach, open new-session dialog (`n`), verify Ctrl+R opens the recent picker
- [ ] Repeat attach/detach several times, verify Ctrl+R / Ctrl+N / Ctrl+P remain responsive
- [ ] Start agent-deck in a terminal that already has stuck Kitty mode, verify TUI keys work immediately
- [ ] Verify Shift+Enter still works inside attached Claude Code sessions (extended-keys forwarding not disrupted)

Ctrl+Z suspend:
- [ ] Create and attach to a Claude Code session, press Ctrl+Z, verify claude suspends and the interactive shell prompt returns
- [ ] Run `fg` in the shell, verify claude resumes correctly
- [ ] Verify sandboxed sessions still launch correctly (they keep the initial-process flow)
- [ ] Verify non-shell sessions (claude, gemini, codex, opencode, custom tools) still launch correctly