### PR TITLE
fix(web): apply browser dimensions to tmux window and PTY

### DIFF
--- a/internal/web/terminal_bridge.go
+++ b/internal/web/terminal_bridge.go
@@ -136,11 +136,18 @@ func (b *tmuxPTYBridge) Resize(cols, rows int) error {
 		return fmt.Errorf("invalid dimensions: cols=%d rows=%d", cols, rows)
 	}
 
-	// Do NOT call pty.Setsize here. Resizing the local PTY sends SIGWINCH to
-	// the tmux attach process, which causes the tmux server to recalculate the
-	// window size. Even with "ignore-size" on the attach client, this can race
-	// with the TUI client's dimensions. The web terminal should adapt to the
-	// size provided by the tmux session, not the other way around.
+	// Resize the tmux window so output reflows to match the web viewport.
+	cmd := tmuxCommand("resize-window", "-t", b.tmuxSession, "-x", fmt.Sprintf("%d", cols), "-y", fmt.Sprintf("%d", rows))
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("tmux resize-window: %w", err)
+	}
+
+	// Resize the local PTY so the tmux attach client doesn't clip output to its
+	// default 80x24 dimensions.
+	if err := pty.Setsize(b.ptmx, &pty.Winsize{Cols: uint16(cols), Rows: uint16(rows)}); err != nil {
+		return fmt.Errorf("pty setsize: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- `tmuxPTYBridge.Resize()` was a no-op, so the web client's xterm.js dimensions were silently dropped
- The bridge's PTY stayed at the default 80x24, and the tmux attach client clipped output to those dimensions, leaving most of the browser viewport empty
- Now `Resize()` runs `tmux resize-window` to reflow the session and `pty.Setsize` on the bridge PTY so the attach client picks up the new size

## Why the previous comment was wrong

The original comment warned that `pty.Setsize` would race with TUI client dimensions via SIGWINCH. In practice:

1. The bridge attaches with `-f ignore-size`, so this client is excluded from tmux's window-size negotiation
2. `tmux resize-window -x N -y M` sets the window directly, independent of attached client sizes
3. Without `pty.Setsize`, the tmux attach client process running through the bridge's PTY clips output to the PTY's dimensions (default 80x24), regardless of what the tmux window contains

The result was that even after manually running `tmux resize-window` from another terminal, the web view stayed clipped because the bridge's PTY was never resized.

## Test plan

- [x] Built locally with the patch and verified the web terminal now fills the browser viewport on session connect
- [x] Verified that resizing the browser window triggers a re-fit and reflow
- [ ] CI build / tests

Fixes #568