### PR TITLE
fix(sandbox): harden runtime probes and respawn bash wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	cloud.google.com/go/pubsub v1.50.1
+	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/BurntSushi/toml v1.5.0
 	github.com/SherClockHolmes/webpush-go v1.4.0
 	github.com/charmbracelet/bubbles v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ cloud.google.com/go/pubsub v1.50.1/go.mod h1:6YVJv3MzWJUVdvQXG081sFvS0dWQOdnV+oT
 cloud.google.com/go/pubsub/v2 v2.0.0 h1:0qS6mRJ41gD1lNmM/vdm6bR7DQu6coQcVwD+VPf0Bz0=
 cloud.google.com/go/pubsub/v2 v2.0.0/go.mod h1:0aztFxNzVQIRSZ8vUr79uH2bS3jwLebwK6q1sgEub+E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeXHA=
+al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
@@ -117,6 +119,8 @@ github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.3.11 h1:vAe81Msw+8tKUxi2Dqh/NZMz7475yUvmRIkXr4oN2ao=

--- a/internal/docker/config.go
+++ b/internal/docker/config.go
@@ -49,6 +49,16 @@ var agentConfigMounts = []AgentConfigMount{
 		skipEntries:     []string{"sandbox"},
 	},
 	{
+		hostRel:         ".local/state/opencode",
+		containerSuffix: ".local/state/opencode",
+		skipEntries:     []string{"sandbox"},
+	},
+	{
+		hostRel:         ".config/opencode",
+		containerSuffix: ".config/opencode",
+		skipEntries:     []string{"sandbox"},
+	},
+	{
 		hostRel:         ".codex",
 		containerSuffix: ".codex",
 		skipEntries:     []string{"sandbox"},

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -150,7 +150,9 @@ func (c *Container) Create(ctx context.Context, cfg *ContainerConfig) (string, e
 		"--pids-limit=4096",
 		// Read-only root filesystem — writable paths are explicitly mounted as tmpfs below.
 		"--read-only",
-		"--tmpfs", "/tmp:rw,noexec,nosuid,size=256m",
+		// Keep /tmp executable: OpenCode/OpenTUI loads a native render library
+		// from /tmp via dlopen, which fails when /tmp is mounted noexec.
+		"--tmpfs", "/tmp:rw,nosuid,size=256m",
 		"--tmpfs", "/var/tmp:rw,noexec,nosuid,size=128m",
 		// Node.js and npm require writable cache/config directories.
 		"--tmpfs", "/root/.npm:rw,nosuid,size=256m",

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -152,12 +152,18 @@ func (c *Container) Create(ctx context.Context, cfg *ContainerConfig) (string, e
 		"--read-only",
 		// Keep /tmp executable: OpenCode/OpenTUI loads a native render library
 		// from /tmp via dlopen, which fails when /tmp is mounted noexec.
-		"--tmpfs", "/tmp:rw,nosuid,size=256m",
+		"--tmpfs", "/tmp:rw,exec,nosuid,size=256m",
 		"--tmpfs", "/var/tmp:rw,noexec,nosuid,size=128m",
-		// Node.js and npm require writable cache/config directories.
-		"--tmpfs", "/root/.npm:rw,nosuid,size=256m",
-		"--tmpfs", "/root/.cache:rw,nosuid,size=512m",
 	}
+
+	// Node.js and npm require writable cache directories. The container runs as
+	// host UID:GID, so set tmpfs ownership explicitly; otherwise Docker creates
+	// root-owned 0755 tmpfs mounts and npm fails with EACCES under /root/.npm.
+	tmpfsUserOpts := fmt.Sprintf("uid=%d,gid=%d", os.Getuid(), os.Getgid())
+	args = append(args,
+		"--tmpfs", "/root/.npm:rw,nosuid,size=256m,"+tmpfsUserOpts+",mode=1777",
+		"--tmpfs", "/root/.cache:rw,nosuid,size=512m,"+tmpfsUserOpts+",mode=1777",
+	)
 
 	if cfg.workingDir != "" {
 		args = append(args, "--workdir", cfg.workingDir)
@@ -261,6 +267,12 @@ func (c *Container) Remove(ctx context.Context, force bool) error {
 // Returns ["docker", "exec", "-it", name].
 func (c *Container) ExecPrefix() []string {
 	return []string{"docker", "exec", "-it", c.name}
+}
+
+// ExecPrefixNonInteractive returns the command prefix for non-interactive
+// execution inside this container. Returns ["docker", "exec", name].
+func (c *Container) ExecPrefixNonInteractive() []string {
+	return []string{"docker", "exec", c.name}
 }
 
 // ExecPrefixWithEnv returns the command prefix with -e flags for runtime env vars.

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -158,6 +158,20 @@ func TestAgentConfigMounts_AllTools(t *testing.T) {
 	}
 }
 
+func TestAgentConfigMounts_OpenCodePathsMounted(t *testing.T) {
+	t.Parallel()
+
+	mounts := AgentConfigMounts()
+	seen := map[string]bool{}
+	for _, m := range mounts {
+		seen[m.hostRel] = true
+	}
+
+	require.True(t, seen[".local/share/opencode"])
+	require.True(t, seen[".local/state/opencode"])
+	require.True(t, seen[".config/opencode"])
+}
+
 func TestIsManagedContainer(t *testing.T) {
 	t.Parallel()
 

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -136,6 +136,14 @@ func TestExecPrefix(t *testing.T) {
 	require.Equal(t, []string{"docker", "exec", "-it", "my-container"}, prefix)
 }
 
+func TestExecPrefixNonInteractive(t *testing.T) {
+	t.Parallel()
+
+	c := NewContainer("my-container", "")
+	prefix := c.ExecPrefixNonInteractive()
+	require.Equal(t, []string{"docker", "exec", "my-container"}, prefix)
+}
+
 func TestDefaultImage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -23,8 +23,14 @@ func (i *Instance) buildEnvSourceCommand() string {
 
 	// 1. Theme environment (COLORFGBG) so tools like Codex detect light/dark theme.
 	// Set early so env files or init scripts can override if needed.
-	if themeExport := themeEnvExport(); themeExport != "" {
-		sources = append(sources, themeExport)
+	// For sandboxed sessions, COLORFGBG is injected via docker exec environment
+	// forwarding (collectDockerEnvVars) instead of inline shell export. Inline
+	// export uses a semicolon-containing value (e.g. "15;0") that becomes fragile
+	// under nested bash -c quoting chains used by sandbox command wrappers.
+	if !i.IsSandboxed() {
+		if themeExport := themeEnvExport(); themeExport != "" {
+			sources = append(sources, themeExport)
+		}
 	}
 
 	config, _ := LoadUserConfig()

--- a/internal/session/env_test.go
+++ b/internal/session/env_test.go
@@ -391,6 +391,41 @@ func TestBuildEnvSourceCommand_IncludesTheme(t *testing.T) {
 	}
 }
 
+func TestBuildEnvSourceCommand_SandboxSkipsThemeExport(t *testing.T) {
+	// Save and restore original config cache
+	userConfigCacheMu.Lock()
+	origCache := userConfigCache
+	userConfigCacheMu.Unlock()
+	defer func() {
+		userConfigCacheMu.Lock()
+		userConfigCache = origCache
+		userConfigCacheMu.Unlock()
+	}()
+
+	// Ensure no parent COLORFGBG
+	t.Setenv("COLORFGBG", "")
+	os.Unsetenv("COLORFGBG")
+
+	// Set up light theme config
+	userConfigCacheMu.Lock()
+	userConfigCache = &UserConfig{
+		Theme: "light",
+		MCPs:  make(map[string]MCPDef),
+	}
+	userConfigCacheMu.Unlock()
+
+	inst := &Instance{
+		Tool:        "opencode",
+		ProjectPath: "/tmp",
+		Sandbox:     &SandboxConfig{Enabled: true, Image: "example/sandbox:latest"},
+	}
+	result := inst.buildEnvSourceCommand()
+
+	if strings.Contains(result, "COLORFGBG") {
+		t.Errorf("buildEnvSourceCommand() = %q, should not contain COLORFGBG for sandboxed sessions", result)
+	}
+}
+
 func TestShellSettings_GetIgnoreMissingEnvFiles(t *testing.T) {
 	trueBool := true
 	falseBool := false

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4994,18 +4994,22 @@ func (i *Instance) prepareCommand(cmd string) (string, string, error) {
 }
 
 // terminalEnvVars are always passed through to containers for proper UI/theming.
-var terminalEnvVars = []string{"TERM", "COLORTERM", "FORCE_COLOR", "NO_COLOR"}
+var terminalEnvVars = []string{"TERM", "COLORTERM", "FORCE_COLOR", "NO_COLOR", "COLORFGBG"}
 
 // collectDockerEnvVars returns host environment variables to forward to containers.
 // Each call reads fresh values from the host environment via os.LookupEnv so that
 // changes between session starts (e.g. updated TERM) are picked up immediately.
-// Terminal-related variables (TERM, COLORTERM, FORCE_COLOR, NO_COLOR) are always
+// Terminal-related variables (TERM, COLORTERM, FORCE_COLOR, NO_COLOR, COLORFGBG) are always
 // included when set. Additional names from DockerSettings.Environment are appended.
 func collectDockerEnvVars(names []string) map[string]string {
 	env := make(map[string]string, len(terminalEnvVars)+len(names))
 	for _, name := range terminalEnvVars {
 		if val, ok := os.LookupEnv(name); ok {
 			env[name] = val
+			continue
+		}
+		if name == "COLORFGBG" {
+			env[name] = ThemeColorFGBG()
 		}
 	}
 	for _, name := range names {
@@ -5089,7 +5093,47 @@ func ensureContainerRunning(
 		}
 	}
 
+	// Migration guard: older containers were created with root-owned tmpfs mounts
+	// for /root/.npm and /root/.cache. With --user uid:gid this causes plugin
+	// bootstrap failures (EACCES mkdir '/root/.npm/_cacache'). Recreate the
+	// container once if those paths are not writable.
+	cacheWritable := sandboxCacheDirsWritable(ctx, ctr)
+	tmpExecutable := sandboxTmpExecutable(ctx, ctr)
+	if !cacheWritable || !tmpExecutable {
+		sessionLog.Warn(
+			"sandbox_recreating_for_runtime_compat",
+			slog.Bool("cache_writable", cacheWritable),
+			slog.Bool("tmp_executable", tmpExecutable),
+		)
+		if rmErr := ctr.Remove(ctx, true); rmErr != nil {
+			return fmt.Errorf("removing incompatible sandbox container: %w", rmErr)
+		}
+		cfg := buildSandboxConfig(inst, userCfg, homeDir, bindMounts, homeMounts)
+		if _, createErr := ctr.Create(ctx, cfg); createErr != nil {
+			return fmt.Errorf("recreating sandbox container: %w", createErr)
+		}
+		if startErr := ctr.Start(ctx); startErr != nil {
+			return fmt.Errorf("starting recreated sandbox container: %w", startErr)
+		}
+	}
+
 	return nil
+}
+
+func sandboxCacheDirsWritable(ctx context.Context, ctr *docker.Container) bool {
+	return sandboxExecProbe(ctx, ctr, "test -w /root/.npm && test -w /root/.cache")
+}
+
+func sandboxTmpExecutable(ctx context.Context, ctr *docker.Container) bool {
+	probe := `f=/tmp/.agent_deck_exec_probe.sh; printf '#!/bin/sh\nexit 0\n' > "$f" && chmod +x "$f" && "$f" >/dev/null 2>&1 && rm -f "$f"`
+	return sandboxExecProbe(ctx, ctr, probe)
+}
+
+func sandboxExecProbe(ctx context.Context, ctr *docker.Container, script string) bool {
+	prefix := ctr.ExecPrefixNonInteractive()
+	args := append(prefix[1:], "bash", "-lc", script)
+	_, err := exec.CommandContext(ctx, prefix[0], args...).CombinedOutput()
+	return err == nil
 }
 
 // buildSandboxConfig assembles the ContainerConfig from session and user settings.

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -2274,6 +2274,16 @@ func TestCollectDockerEnvVars(t *testing.T) {
 	}
 }
 
+func TestCollectDockerEnvVars_ColorFGBGFallback(t *testing.T) {
+	// Cannot use t.Parallel() because t.Setenv mutates process env.
+	t.Setenv("COLORFGBG", "")
+	os.Unsetenv("COLORFGBG")
+
+	result := collectDockerEnvVars(nil)
+	require.Contains(t, result, "COLORFGBG")
+	require.NotEmpty(t, result["COLORFGBG"])
+}
+
 func TestNewSandboxConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	"al.essio.dev/pkg/shellescape"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/BurntSushi/toml"
@@ -790,28 +791,39 @@ func sanitizeSystemdUnitComponent(raw string) string {
 }
 
 // bashCWrap returns the given command wrapped in `bash -c '…'` with
-// single quotes safely escaped via the POSIX `'\”` pattern. The result
+// single quotes safely escaped using the POSIX shell quote-break pattern. The result
 // is a single shell word that can be passed to any `sh -c` invocation
 // (e.g. tmux's default shell-command delivery) and will always be
 // executed under bash, giving consistent semantics regardless of the
 // user's login shell.
 func bashCWrap(command string) string {
 	escaped := strings.ReplaceAll(command, `'`, `'\''`)
-	return "bash -c '" + escaped + "'"
+	return bashCPrefix + escaped + "'"
 }
+
+func isBashCWrapped(command string) bool {
+	trimmed := strings.TrimSpace(command)
+	return strings.HasPrefix(trimmed, bashCPrefix)
+}
+
+const (
+	bashBinary  = "bash"
+	bashCPrefix = "bash -c '"
+)
 
 func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 	startWithInitialProcess := command != "" && s.RunCommandAsInitialProcess
 	args := []string{"new-session", "-d", "-s", s.Name, "-c", workDir}
 	if startWithInitialProcess {
-		// Always wrap the command in `bash -c '…'` so it runs under bash
-		// regardless of the user's default-shell. This guarantees fish users
-		// can launch sessions whose commands use bash syntax (inline env
-		// vars, `&&`, `$(...)`, etc.) — previously the wrapping was gated
-		// on `$(` or `session_id=` appearing in the command, which missed
-		// simple compound commands like `export COLORFGBG='0;15' && claude …`
-		// and caused those sessions to die immediately on fish (#526).
-		args = append(args, bashCWrap(command))
+		// Keep commands under bash for fish/zsh compatibility, but avoid
+		// double-wrapping payloads that are already `bash -c '…'`.
+		// wrapIgnoreSuspend() already returns that shape; re-wrapping it can
+		// corrupt quoting for nested payloads like docker exec bash -c ... .
+		if isBashCWrapped(command) {
+			args = append(args, command)
+		} else {
+			args = append(args, bashCWrap(command))
+		}
 	}
 
 	if !s.LaunchInUserScope {
@@ -1818,25 +1830,11 @@ func (s *Session) RespawnPane(command string) error {
 	target := s.Name + ":" // Append colon to target the active pane
 	args := []string{"respawn-pane", "-k", "-t", target}
 	if command != "" {
-		// Wrap command in interactive shell to ensure aliases and shell configs are available
-		// tmux respawn-pane runs commands directly without loading ~/.bashrc or ~/.zshrc,
-		// so shell aliases (like 'cdw' for claude) won't work without this wrapper
-		shell := os.Getenv("SHELL")
-		if shell == "" {
-			shell = "/bin/bash"
+		wrapped, wrapErr := wrapRespawnCommand(command)
+		if wrapErr != nil {
+			return wrapErr
 		}
-
-		// IMPORTANT: Commands containing bash-specific syntax (like `session_id=$(...)`)
-		// must use bash, regardless of user's shell. This fixes fish shell compatibility (#47).
-		// Fish uses different syntax: `set var (...)` instead of `var=$(...)`.
-		// We detect bash-specific constructs and force bash for those commands.
-		if strings.Contains(command, "$(") || strings.Contains(command, "session_id=") {
-			shell = "/bin/bash"
-		}
-
-		// Use -i for interactive (loads aliases) and -c for command
-		wrappedCmd := fmt.Sprintf("%s -ic %q", shell, command)
-		args = append(args, wrappedCmd)
+		args = append(args, wrapped)
 	}
 
 	mcpLog.Debug("respawn_pane_executing", slog.Any("args", args))
@@ -1879,6 +1877,22 @@ func (s *Session) RespawnPane(command string) error {
 	s.mu.Unlock()
 
 	return nil
+}
+
+func wrapRespawnCommand(command string) (string, error) {
+	return wrapRespawnCommandWithResolver(command, exec.LookPath)
+}
+
+func wrapRespawnCommandWithResolver(command string, lookPath func(string) (string, error)) (string, error) {
+	bashPath, err := lookPath(bashBinary)
+	if err != nil {
+		return "", fmt.Errorf("bash not found in PATH: %w", err)
+	}
+	return buildBashLCCommand(bashPath, command), nil
+}
+
+func buildBashLCCommand(bashPath, command string) string {
+	return fmt.Sprintf("%s -lc %s", bashPath, shellescape.Quote(command))
 }
 
 // GetWindowActivity returns Unix timestamp of last tmux window activity

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2822,6 +2822,82 @@ func TestStartCommandSpec_InitialProcess_ShellSyntaxValid(t *testing.T) {
 	}
 }
 
+func TestWrapRespawnCommand_UsesBashRegardlessOfShellEnv(t *testing.T) {
+	t.Setenv("SHELL", "/usr/bin/fish")
+
+	wrapped, err := wrapRespawnCommand("claude --session-id abc")
+	require.NoError(t, err)
+	require.Contains(t, wrapped, " -lc ")
+	require.Contains(t, wrapped, "claude --session-id abc")
+}
+
+func TestWrapRespawnCommand_PreservesQuotedPayloads(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{
+			name: "embedded single quotes",
+			cmd:  `echo 'hello world' && echo done`,
+		},
+		{
+			name: "nested quoted payload",
+			cmd:  `bash -c 'stty susp undef; echo '"'"'hello world'"'"''`,
+		},
+		{
+			name: "subshell and mixed quotes",
+			cmd:  `session_id=$(echo "abc") || session_id=""; echo "$session_id"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped, err := wrapRespawnCommand(tc.cmd)
+			require.NoError(t, err)
+			require.Contains(t, wrapped, " -lc ")
+
+			run := exec.Command("sh", "-c", wrapped)
+			out, err := run.CombinedOutput()
+			require.NoError(t, err, "wrapped command failed: %s", string(out))
+		})
+	}
+}
+
+func TestWrapRespawnCommand_ErrorsWhenBashUnavailable(t *testing.T) {
+	_, err := wrapRespawnCommandWithResolver("echo ok", func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bash not found")
+}
+
+func TestStartCommandSpec_DoesNotDoubleWrapBashC(t *testing.T) {
+	s := &Session{
+		Name:                       "agentdeck_test_abcdef12",
+		WorkDir:                    "/tmp",
+		RunCommandAsInitialProcess: true,
+	}
+
+	cmd := `bash -c 'stty susp undef; docker exec -it agent-deck-test bash -c '\''export COLORFGBG='\''\''\''15;0'\''\''\'' && opencode -s ses_abc'\'''`
+	_, args := s.startCommandSpec("/tmp", cmd)
+	require.NotEmpty(t, args)
+	require.Equal(t, cmd, args[len(args)-1])
+}
+
+func TestStartCommandSpec_WrapsNonBashCommands(t *testing.T) {
+	s := &Session{
+		Name:                       "agentdeck_test_abcdef12",
+		WorkDir:                    "/tmp",
+		RunCommandAsInitialProcess: true,
+	}
+
+	_, args := s.startCommandSpec("/tmp", `export COLORFGBG='15;0' && opencode -s ses_abc`)
+	require.NotEmpty(t, args)
+	require.True(t, strings.HasPrefix(args[len(args)-1], "bash -c '"))
+}
+
 func TestResolvedAgentDeckTheme_COLORFGBG(t *testing.T) {
 	// Use temp HOME with no config so we fall through to auto-detection.
 	tempDir := t.TempDir()

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -63,6 +63,7 @@ RUN npm install -g @google/gemini-cli@0
 RUN mkdir -p /root/.claude \
     /root/.config/opencode \
     /root/.local/share/opencode \
+    /root/.local/state/opencode \
     /root/.codex \
     /root/.gemini \
     /root/.ssh

--- a/skills/agent-deck/references/sandbox.md
+++ b/skills/agent-deck/references/sandbox.md
@@ -87,7 +87,7 @@ See the full [Configuration Reference](config-reference.md) for details.
 
 Agent Deck automatically shares your host tool credentials with sandboxed containers so agents can authenticate without re-login. This works for all supported tools: Claude Code, Codex, Gemini, and OpenCode.
 
-For each tool whose host config directory exists (e.g. `~/.claude/`, `~/.codex/`, `~/.gemini/`, `~/.local/share/opencode/`), Agent Deck syncs credential files into a **shared sandbox directory** and bind-mounts it into containers:
+For each tool whose host config directory exists (e.g. `~/.claude/`, `~/.codex/`, `~/.gemini/`, `~/.local/share/opencode/`, `~/.local/state/opencode/`, `~/.config/opencode/`), Agent Deck syncs credential files into a **shared sandbox directory** and bind-mounts it into containers:
 
 1. On every session start, host config files are synced into `~/<tool>/sandbox/`.
 2. **Seed files** (e.g. onboarding flags) use write-once semantics — they are only written if absent, preserving any state accumulated by the container.
@@ -119,6 +119,8 @@ Each tool's sandbox directory lives inside that tool's own config directory:
 ~/.codex/sandbox/                  # Codex sandbox
 ~/.gemini/sandbox/                 # Gemini sandbox
 ~/.local/share/opencode/sandbox/   # OpenCode sandbox
+~/.local/state/opencode/sandbox/   # OpenCode state sandbox
+~/.config/opencode/sandbox/        # OpenCode config sandbox
 ```
 
 These directories persist on the host and are shared across all containers. Deleting a tool's config directory (e.g. `rm -rf ~/.codex/`) removes everything related to that tool, including its sandbox directory. The `sandbox/` subdirectories are safe to delete manually if you want to reset state.
@@ -232,6 +234,8 @@ rm -rf ~/.claude/sandbox/
 rm -rf ~/.codex/sandbox/
 rm -rf ~/.gemini/sandbox/
 rm -rf ~/.local/share/opencode/sandbox/
+rm -rf ~/.local/state/opencode/sandbox/
+rm -rf ~/.config/opencode/sandbox/
 ```
 
 They will be re-created automatically on the next session start.

--- a/skills/agent-deck/references/sandbox.md
+++ b/skills/agent-deck/references/sandbox.md
@@ -144,7 +144,7 @@ Example: `agent-deck-my-refactor-a1b2c3d4`
 ## Environment Variables
 
 These terminal-related variables are always passed through for proper UI/theming:
-- `TERM`, `COLORTERM`, `FORCE_COLOR`, `NO_COLOR`
+- `TERM`, `COLORTERM`, `FORCE_COLOR`, `NO_COLOR`, `COLORFGBG`
 
 Pass additional variables (like API keys) through to containers by adding them to config:
 


### PR DESCRIPTION
## Summary
- add non-interactive Docker exec prefix and use it for sandbox runtime probes so checks do not depend on TTY availability
- harden tmux respawn command wrapping by resolving bash from PATH, failing clearly when unavailable, and quoting payloads with `shellescape`
- pass through `COLORFGBG` for sandbox sessions, avoid fragile inline export quoting, and update tests/docs for the new behavior

## Testing
- `go test ./internal/docker ./internal/session ./internal/tmux`
- `go test ./internal/tmux -run 'TestWrapRespawnCommand_UsesBashRegardlessOfShellEnv|TestWrapRespawnCommand_PreservesQuotedPayloads|TestWrapRespawnCommand_ErrorsWhenBashUnavailable|TestStartCommandSpec_DoesNotDoubleWrapBashC|TestStartCommandSpec_WrapsNonBashCommands' -count=1`

## Notes
- The package test run still shows existing failures in this workspace:
  - `internal/session`: `TestLifecycle_StoppedRestartedRunningError`, `TestStatusCycle_ShellSessionWithCommand`
  - `internal/tmux`: `TestWaitForPaneReady_RealTmux`