### PR TITLE
fix(opencode): preserve existing session binding

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -58,6 +58,7 @@ const (
 	codexHookWaitingFastPathWindow = 2 * time.Minute
 	codexBootstrapScanInterval     = 2 * time.Second
 	codexRotationScanInterval      = 30 * time.Second
+	opencodeRotationScanInterval   = 15 * time.Second
 	// codexProbeScanInterval rate-limits process-file probing to avoid
 	// repeated /proc and lsof scans on every status tick.
 	codexProbeScanInterval    = 2 * time.Second
@@ -108,6 +109,7 @@ type Instance struct {
 	OpenCodeSessionID  string    `json:"opencode_session_id,omitempty"`
 	OpenCodeDetectedAt time.Time `json:"opencode_detected_at,omitempty"`
 	OpenCodeStartedAt  int64     `json:"-"` // Unix millis when we started OpenCode (for session matching, not persisted)
+	lastOpenCodeScanAt time.Time // Rate-limits expensive `opencode session list` scans
 
 	// Codex CLI integration
 	CodexSessionID   string    `json:"codex_session_id,omitempty"`
@@ -927,9 +929,55 @@ func (i *Instance) setOpenCodeSession(sessionID string) {
 	}
 }
 
-// queryOpenCodeSession queries OpenCode CLI for session matching our project directory
-// OpenCode automatically resumes the most recent session for a directory, so we
-// simply find the most recently updated session matching our project path.
+type openCodeSessionMetadata struct {
+	ID        string `json:"id"`
+	Directory string `json:"directory"`
+	Path      string `json:"path"`
+	Created   int64  `json:"created"`
+	Updated   int64  `json:"updated"`
+}
+
+// findBestOpenCodeSession keeps an existing binding if that session still exists
+// for the project. Otherwise it falls back to the most recently updated match.
+func findBestOpenCodeSession(sessions []openCodeSessionMetadata, projectPath, currentID string) string {
+	normalizedProjectPath := normalizePath(projectPath)
+
+	var bestMatch string
+	var bestMatchTime int64
+
+	for _, sess := range sessions {
+		sessDir := sess.Directory
+		if sessDir == "" {
+			sessDir = sess.Path
+		}
+
+		if sessDir == "" || normalizePath(sessDir) != normalizedProjectPath {
+			continue
+		}
+
+		// Multiple OpenCode tabs can share a project path. A newer sibling session
+		// is not enough evidence to steal this instance's existing binding.
+		if currentID != "" && sess.ID == currentID {
+			return currentID
+		}
+
+		updatedAt := sess.Updated
+		if updatedAt == 0 {
+			updatedAt = sess.Created
+		}
+
+		if bestMatch == "" || updatedAt > bestMatchTime {
+			bestMatch = sess.ID
+			bestMatchTime = updatedAt
+		}
+	}
+
+	return bestMatch
+}
+
+// queryOpenCodeSession queries OpenCode CLI for sessions matching our project
+// directory. Unbound instances adopt the most recently updated session, while
+// already-bound instances keep their current ID as long as it still exists.
 func (i *Instance) queryOpenCodeSession() string {
 	// Run: opencode session list --format json
 	cmd := exec.Command("opencode", "session", "list", "--format", "json")
@@ -947,13 +995,7 @@ func (i *Instance) queryOpenCodeSession() string {
 
 	// Parse JSON response
 	// Expected format: array of session objects with id, directory, created, updated fields
-	var sessions []struct {
-		ID        string `json:"id"`
-		Directory string `json:"directory"`
-		Path      string `json:"path"`    // Some versions use path instead of directory
-		Created   int64  `json:"created"` // Unix timestamp (milliseconds)
-		Updated   int64  `json:"updated"` // Unix timestamp (milliseconds) - when last active
-	}
+	var sessions []openCodeSessionMetadata
 
 	if err := json.Unmarshal(output, &sessions); err != nil {
 		sessionLog.Debug("opencode_parse_failed", slog.String("error", err.Error()))
@@ -962,58 +1004,12 @@ func (i *Instance) queryOpenCodeSession() string {
 
 	sessionLog.Debug("opencode_parsed_sessions", slog.Int("count", len(sessions)))
 
-	// Find the most recently updated session matching our project path
-	// OpenCode auto-resumes the most recent session when you run `opencode` in a directory,
-	// so we track that same session (no startTime check needed)
-	projectPath := i.ProjectPath
-
-	var bestMatch string
-	var bestMatchTime int64
-
-	for _, sess := range sessions {
-		// Check directory match (normalize paths)
-		sessDir := sess.Directory
-		if sessDir == "" {
-			sessDir = sess.Path
-		}
-
-		normalizedSessDir := normalizePath(sessDir)
-		normalizedProjectPath := normalizePath(projectPath)
-
-		sessionLog.Debug(
-			"opencode_session_compare",
-			slog.String("session_id", sess.ID),
-			slog.String("sess_dir", sessDir),
-			slog.String("project_path", projectPath),
-			slog.Int64("created", sess.Created),
-			slog.Int64("updated", sess.Updated),
-		)
-
-		// Normalize both paths for comparison
-		if sessDir == "" || normalizedSessDir != normalizedProjectPath {
-			sessionLog.Debug("opencode_session_dir_mismatch", slog.String("session_id", sess.ID))
-			continue
-		}
-
-		// Pick the most recently updated session for this directory
-		updatedAt := sess.Updated
-		if updatedAt == 0 {
-			updatedAt = sess.Created // Fallback to created if updated not available
-		}
-
-		sessionLog.Debug(
-			"opencode_session_dir_match",
-			slog.String("session_id", sess.ID),
-			slog.Int64("updated", updatedAt),
-		)
-
-		if bestMatch == "" || updatedAt > bestMatchTime {
-			bestMatch = sess.ID
-			bestMatchTime = updatedAt
-		}
-	}
-
-	sessionLog.Debug("opencode_best_match", slog.String("session_id", bestMatch), slog.Int64("updated", bestMatchTime))
+	bestMatch := findBestOpenCodeSession(sessions, i.ProjectPath, i.OpenCodeSessionID)
+	sessionLog.Debug(
+		"opencode_best_match",
+		slog.String("session_id", bestMatch),
+		slog.String("current_id", i.OpenCodeSessionID),
+	)
 	return bestMatch
 }
 
@@ -2505,6 +2501,11 @@ func (i *Instance) UpdateStatus() error {
 				exclude := i.collectOtherCodexSessionIDs()
 				i.UpdateCodexSession(exclude)
 			}
+
+			// Update OpenCode session tracking (non-blocking, best-effort)
+			if i.Tool == "opencode" {
+				i.UpdateOpenCodeSession()
+			}
 		}
 	}
 
@@ -2767,6 +2768,49 @@ func (i *Instance) UpdateGeminiSession(excludeIDs map[string]bool) {
 	i.syncGeminiSessionFromDisk()
 	i.updateGeminiAnalytics()
 	i.updateGeminiLatestPrompt()
+}
+
+// UpdateOpenCodeSession refreshes the OpenCode session ID from OpenCode CLI
+// state without stealing a different tab's session from the same project.
+func (i *Instance) UpdateOpenCodeSession() {
+	i.updateOpenCodeSession(false)
+}
+
+func (i *Instance) updateOpenCodeSession(force bool) {
+	if i.Tool != "opencode" {
+		return
+	}
+
+	now := time.Now()
+	if !force && !i.lastOpenCodeScanAt.IsZero() && now.Sub(i.lastOpenCodeScanAt) < opencodeRotationScanInterval {
+		return
+	}
+	i.lastOpenCodeScanAt = now
+
+	candidate := i.queryOpenCodeSession()
+	i.applyOpenCodeSessionCandidate(candidate)
+}
+
+func (i *Instance) applyOpenCodeSessionCandidate(candidate string) bool {
+	if candidate == "" {
+		return false
+	}
+
+	if candidate == i.OpenCodeSessionID {
+		if i.OpenCodeDetectedAt.IsZero() {
+			i.OpenCodeDetectedAt = time.Now()
+		}
+		return false
+	}
+
+	sessionLog.Debug(
+		"opencode_session_rebind",
+		slog.String("old_id", i.OpenCodeSessionID),
+		slog.String("new_id", candidate),
+	)
+
+	i.setOpenCodeSession(candidate)
+	return true
 }
 
 // syncGeminiSessionFromTmux reads session ID and YOLO mode from tmux environment (authoritative source).
@@ -3805,6 +3849,9 @@ func (i *Instance) Restart() error {
 
 	// If OpenCode session AND tmux session exists, use respawn-pane
 	if i.Tool == "opencode" && i.tmuxSession != nil && i.tmuxSession.Exists() {
+		// Refresh from OpenCode state before deciding the resume target.
+		i.updateOpenCodeSession(true)
+
 		// Try to get session ID from tmux environment if not already set
 		// (async detection stores it there but Instance might not have been saved)
 		if i.OpenCodeSessionID == "" {

--- a/internal/session/opencode_test.go
+++ b/internal/session/opencode_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 // TestOpenCodeSessionMatching tests the session matching logic for OpenCode
@@ -38,35 +39,39 @@ func TestOpenCodeSessionMatching(t *testing.T) {
 	tests := []struct {
 		name        string
 		projectPath string
-		startTime   int64
+		currentID   string
 		wantID      string
 		wantMatch   bool
 	}{
 		{
 			name:        "Finds most recent session for matching directory",
 			projectPath: "/Users/ashesh/claude-deck",
-			startTime:   1768982150000, // After OLD, before NEW updated
-			wantID:      "ses_NEW001",  // Should pick the most recently updated one
+			wantID:      "ses_NEW001", // Should pick the most recently updated one
 			wantMatch:   true,
 		},
 		{
-			name:        "Picks most recent even when startTime is very recent",
+			name:        "Keeps existing session when it still belongs to project",
 			projectPath: "/Users/ashesh/claude-deck",
-			startTime:   1768982500000, // After all sessions
-			wantID:      "ses_NEW001",  // Should still pick most recent for directory
+			currentID:   "ses_OLD001",
+			wantID:      "ses_OLD001",
 			wantMatch:   true,
 		},
 		{
 			name:        "Ignores sessions from different directories",
 			projectPath: "/Users/ashesh/other-project",
-			startTime:   1768982000000,
 			wantID:      "ses_OTHER001", // Only session matching this directory
+			wantMatch:   true,
+		},
+		{
+			name:        "Falls back to most recent when existing session is missing",
+			projectPath: "/Users/ashesh/claude-deck",
+			currentID:   "ses_MISSING001",
+			wantID:      "ses_NEW001",
 			wantMatch:   true,
 		},
 		{
 			name:        "No match for unknown directory",
 			projectPath: "/Users/ashesh/nonexistent",
-			startTime:   1768982000000,
 			wantID:      "",
 			wantMatch:   false,
 		},
@@ -75,20 +80,14 @@ func TestOpenCodeSessionMatching(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Parse mock sessions
-			var sessions []struct {
-				ID        string `json:"id"`
-				Directory string `json:"directory"`
-				Path      string `json:"path"`
-				Created   int64  `json:"created"`
-				Updated   int64  `json:"updated"`
-			}
+			var sessions []openCodeSessionMetadata
 
 			if err := json.Unmarshal([]byte(mockSessionsJSON), &sessions); err != nil {
 				t.Fatalf("Failed to parse mock sessions: %v", err)
 			}
 
 			// Apply the matching logic (same as queryOpenCodeSession but testable)
-			gotID := findBestOpenCodeSession(sessions, tt.projectPath)
+			gotID := findBestOpenCodeSession(sessions, tt.projectPath, tt.currentID)
 
 			if tt.wantMatch {
 				if gotID != tt.wantID {
@@ -101,49 +100,6 @@ func TestOpenCodeSessionMatching(t *testing.T) {
 			}
 		})
 	}
-}
-
-// findBestOpenCodeSession is a testable version of the session matching logic
-// This should match the algorithm used in queryOpenCodeSession()
-func findBestOpenCodeSession(sessions []struct {
-	ID        string `json:"id"`
-	Directory string `json:"directory"`
-	Path      string `json:"path"`
-	Created   int64  `json:"created"`
-	Updated   int64  `json:"updated"`
-}, projectPath string) string {
-	var bestMatch string
-	var bestMatchTime int64
-
-	for _, sess := range sessions {
-		// Check directory match (normalize paths)
-		sessDir := sess.Directory
-		if sessDir == "" {
-			sessDir = sess.Path
-		}
-
-		normalizedSessDir := normalizePath(sessDir)
-		normalizedProjectPath := normalizePath(projectPath)
-
-		if sessDir == "" || normalizedSessDir != normalizedProjectPath {
-			continue
-		}
-
-		// Pick the most recently updated session for this directory
-		// OpenCode automatically resumes the most recent session,
-		// so we should track that same session
-		updatedAt := sess.Updated
-		if updatedAt == 0 {
-			updatedAt = sess.Created
-		}
-
-		if bestMatch == "" || updatedAt > bestMatchTime {
-			bestMatch = sess.ID
-			bestMatchTime = updatedAt
-		}
-	}
-
-	return bestMatch
 }
 
 // TestOpenCodeBuildCommand tests the command building for OpenCode sessions
@@ -213,4 +169,73 @@ func findSubstring(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestApplyOpenCodeSessionCandidate_BindsWhenEmpty(t *testing.T) {
+	inst := &Instance{Tool: "opencode"}
+
+	changed := inst.applyOpenCodeSessionCandidate("ses_NEW001")
+
+	if !changed {
+		t.Fatal("expected change when binding first OpenCode session ID")
+	}
+	if inst.OpenCodeSessionID != "ses_NEW001" {
+		t.Fatalf("OpenCodeSessionID = %q, want %q", inst.OpenCodeSessionID, "ses_NEW001")
+	}
+	if inst.OpenCodeDetectedAt.IsZero() {
+		t.Fatal("OpenCodeDetectedAt should be set when binding OpenCode session ID")
+	}
+}
+
+func TestApplyOpenCodeSessionCandidate_RebindsWhenDifferent(t *testing.T) {
+	inst := &Instance{
+		Tool:              "opencode",
+		OpenCodeSessionID: "ses_OLD001",
+		OpenCodeDetectedAt: time.Now().Add(
+			-1 * time.Hour,
+		),
+	}
+
+	changed := inst.applyOpenCodeSessionCandidate("ses_NEW001")
+
+	if !changed {
+		t.Fatal("expected change when OpenCode session rotates")
+	}
+	if inst.OpenCodeSessionID != "ses_NEW001" {
+		t.Fatalf("OpenCodeSessionID = %q, want %q", inst.OpenCodeSessionID, "ses_NEW001")
+	}
+}
+
+func TestApplyOpenCodeSessionCandidate_NoChangeWhenSame(t *testing.T) {
+	detectedAt := time.Now().Add(-5 * time.Minute)
+	inst := &Instance{
+		Tool:               "opencode",
+		OpenCodeSessionID:  "ses_SAME001",
+		OpenCodeDetectedAt: detectedAt,
+	}
+
+	changed := inst.applyOpenCodeSessionCandidate("ses_SAME001")
+
+	if changed {
+		t.Fatal("expected no change when candidate matches current OpenCode session ID")
+	}
+	if inst.OpenCodeSessionID != "ses_SAME001" {
+		t.Fatalf("OpenCodeSessionID = %q, want %q", inst.OpenCodeSessionID, "ses_SAME001")
+	}
+	if !inst.OpenCodeDetectedAt.Equal(detectedAt) {
+		t.Fatal("OpenCodeDetectedAt should remain unchanged when candidate matches current ID")
+	}
+}
+
+func TestApplyOpenCodeSessionCandidate_IgnoresEmptyCandidate(t *testing.T) {
+	inst := &Instance{Tool: "opencode", OpenCodeSessionID: "ses_EXISTING001"}
+
+	changed := inst.applyOpenCodeSessionCandidate("")
+
+	if changed {
+		t.Fatal("expected no change when OpenCode candidate is empty")
+	}
+	if inst.OpenCodeSessionID != "ses_EXISTING001" {
+		t.Fatalf("OpenCodeSessionID = %q, want %q", inst.OpenCodeSessionID, "ses_EXISTING001")
+	}
 }


### PR DESCRIPTION
## Summary
- preserve an instance's existing OpenCode session binding when multiple tabs share the same project path
- only fall back to the most recently updated project session when the instance is unbound or its recorded session no longer exists
- add regression coverage for retained bindings and missing-session fallback during refresh and restart

## Testing
- `go test ./internal/session -run 'TestOpenCode'`
- `make lint` *(currently fails on existing errcheck violations in unrelated files such as `internal/clipboard/clipboard.go` and `internal/costs/store.go`)*
- `make test` *(currently fails on existing unrelated suites including `internal/integration`, `internal/session`, `internal/tmux`, and `internal/tuitest`)*