### PR TITLE
feat(remote): show SSH session output in remote preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ agent-deck-test
 
 # Tailwind brute-force diff gate scratch file (make css temp artifact)
 internal/web/static/.brute-tw.src.css
+/dist

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -261,6 +261,34 @@ func (r *SSHRunner) FetchSessions(ctx context.Context) ([]RemoteSessionInfo, err
 	return sessions, nil
 }
 
+type remoteSessionOutputJSON struct {
+	Content string `json:"content"`
+}
+
+func parseRemoteSessionOutput(output []byte) (string, error) {
+	trimmed := bytes.TrimSpace(output)
+	if len(trimmed) == 0 {
+		return "", nil
+	}
+
+	var parsed remoteSessionOutputJSON
+	if err := json.Unmarshal(trimmed, &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse remote session output: %w", err)
+	}
+
+	return parsed.Content, nil
+}
+
+// FetchSessionOutput retrieves the last response content for a remote session.
+func (r *SSHRunner) FetchSessionOutput(ctx context.Context, sessionID string) (string, error) {
+	output, err := r.Run(ctx, "session", "output", sessionID, "--json")
+	if err != nil {
+		return "", err
+	}
+
+	return parseRemoteSessionOutput(output)
+}
+
 // DetectPlatform returns the remote host's OS and architecture (e.g., "linux", "amd64").
 func (r *SSHRunner) DetectPlatform(ctx context.Context) (goos, goarch string, err error) {
 	_ = os.MkdirAll(sshControlDir, 0700)

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -27,3 +27,47 @@ func TestWrapForSSH_QuotesSSHHost(t *testing.T) {
 		t.Fatalf("expected wrapped SSH host to be single-quoted, got: %s", wrapped)
 	}
 }
+
+func TestParseRemoteSessionOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "valid json with content",
+			input: []byte(`{"content":"hello remote"}`),
+			want:  "hello remote",
+		},
+		{
+			name:  "empty payload",
+			input: []byte("   \n  "),
+			want:  "",
+		},
+		{
+			name:    "invalid json",
+			input:   []byte("not-json"),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseRemoteSessionOutput(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("content mismatch\nwant: %q\ngot:  %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -71,3 +71,23 @@ func TestParseRemoteSessionOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestSSHRunnerBuildRemoteCommand_QuotesRemoteSessionOutputID(t *testing.T) {
+	runner := &SSHRunner{AgentDeckPath: "/usr/local/bin/agent-deck"}
+
+	sessionIDs := []string{
+		"x; rm -rf /",
+		"$(whoami)",
+		`embedded'"quotes`,
+	}
+
+	for _, sessionID := range sessionIDs {
+		t.Run(sessionID, func(t *testing.T) {
+			got := runner.buildRemoteCommand("session", "output", sessionID, "--json")
+			want := "'/usr/local/bin/agent-deck' 'session' 'output' " + shellQuote(sessionID) + " '--json'"
+			if got != want {
+				t.Fatalf("buildRemoteCommand mismatch\nwant: %s\ngot:  %s", want, got)
+			}
+		})
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
@@ -2126,6 +2127,38 @@ func remotePreviewCacheKey(remoteName, sessionID string) string {
 	return fmt.Sprintf("remote:%s:%s", remoteName, sessionID)
 }
 
+const (
+	remotePreviewMaxLines = 200
+	remotePreviewMaxBytes = 16 * 1024
+)
+
+func truncateRemotePreviewContent(content string) string {
+	if content == "" {
+		return ""
+	}
+
+	lines := strings.Split(content, "\n")
+	if len(lines) > remotePreviewMaxLines {
+		lines = lines[len(lines)-remotePreviewMaxLines:]
+		content = strings.Join(lines, "\n")
+	}
+
+	if len(content) <= remotePreviewMaxBytes {
+		return content
+	}
+
+	trimmed := []byte(content)
+	trimmed = trimmed[len(trimmed)-remotePreviewMaxBytes:]
+	for len(trimmed) > 0 && !utf8.Valid(trimmed) {
+		trimmed = trimmed[1:]
+	}
+	if idx := bytes.IndexByte(trimmed, '\n'); idx >= 0 && idx < len(trimmed)-1 {
+		trimmed = trimmed[idx+1:]
+	}
+
+	return string(trimmed)
+}
+
 // fetchPreview returns a command that asynchronously fetches preview content.
 // windowIndex < 0 captures the session's primary pane; >= 0 captures a specific window.
 func (h *Home) fetchPreview(inst *session.Instance, key string, windowIndex int) tea.Cmd {
@@ -2195,6 +2228,7 @@ func (h *Home) fetchRemotePreview(remoteName, sessionID, key string) tea.Cmd {
 		defer cancel()
 
 		content, fetchErr := runner.FetchSessionOutput(ctx, sessionID)
+		content = truncateRemotePreviewContent(content)
 		return previewFetchedMsg{previewKey: key, content: content, err: fetchErr}
 	}
 }
@@ -10839,6 +10873,7 @@ func (h *Home) renderRemotePreview(item session.Item, width, height int) string 
 	b.WriteString(dimStyle.Render("Last response") + "\n")
 	b.WriteString(strings.Repeat("-", max(1, min(width-4, 40))))
 	b.WriteString("\n")
+	previewContent = truncateRemotePreviewContent(previewContent)
 	if hasPreview && strings.TrimSpace(previewContent) != "" {
 		b.WriteString(previewContent)
 		b.WriteString("\n\n")

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -247,8 +247,8 @@ type Home struct {
 	lastLoadMtime       time.Time  // File mtime when we last loaded (for external change detection)
 
 	// Preview cache (async fetching - View() must be pure, no blocking I/O)
-	previewCache      map[string]string    // sessionID -> cached preview content
-	previewCacheTime  map[string]time.Time // sessionID -> when cached (for expiration)
+	previewCache      map[string]string    // previewKey -> cached preview content
+	previewCacheTime  map[string]time.Time // previewKey -> when cached (for expiration)
 	previewCacheMu    sync.RWMutex         // Protects previewCache for thread-safety
 	previewFetchingID string               // ID currently being fetched (prevents duplicate fetches)
 
@@ -564,6 +564,7 @@ type previewDebounceMsg struct {
 	previewKey  string // cache key
 	sessionID   string // parent session ID (for instance lookup)
 	windowIndex int    // -1 for session, >= 0 for specific window
+	remoteName  string // remote name for remote session preview
 }
 
 // analyticsFetchedMsg is sent when async analytics parsing is complete
@@ -2121,6 +2122,10 @@ func previewCacheKey(sessionID string, windowIndex int) string {
 	return fmt.Sprintf("%s:%d", sessionID, windowIndex)
 }
 
+func remotePreviewCacheKey(remoteName, sessionID string) string {
+	return fmt.Sprintf("remote:%s:%s", remoteName, sessionID)
+}
+
 // fetchPreview returns a command that asynchronously fetches preview content.
 // windowIndex < 0 captures the session's primary pane; >= 0 captures a specific window.
 func (h *Home) fetchPreview(inst *session.Instance, key string, windowIndex int) tea.Cmd {
@@ -2159,6 +2164,41 @@ func (h *Home) fetchPreviewDebounced(sessionID string, windowIndex int) tea.Cmd 
 	}
 }
 
+func (h *Home) fetchRemotePreviewDebounced(remoteName, sessionID string) tea.Cmd {
+	const debounceDelay = 150 * time.Millisecond
+
+	key := remotePreviewCacheKey(remoteName, sessionID)
+	h.previewDebounceMu.Lock()
+	h.pendingPreviewKey = key
+	h.previewDebounceMu.Unlock()
+
+	return func() tea.Msg {
+		time.Sleep(debounceDelay)
+		return previewDebounceMsg{previewKey: key, sessionID: sessionID, windowIndex: -1, remoteName: remoteName}
+	}
+}
+
+func (h *Home) fetchRemotePreview(remoteName, sessionID, key string) tea.Cmd {
+	return func() tea.Msg {
+		config, err := session.LoadUserConfig()
+		if err != nil || config == nil || config.Remotes == nil {
+			return previewFetchedMsg{previewKey: key, err: fmt.Errorf("failed to load remote config")}
+		}
+
+		rc, ok := config.Remotes[remoteName]
+		if !ok {
+			return previewFetchedMsg{previewKey: key, err: fmt.Errorf("remote '%s' not found", remoteName)}
+		}
+
+		runner := session.NewSSHRunner(remoteName, rc)
+		ctx, cancel := context.WithTimeout(h.ctx, 15*time.Second)
+		defer cancel()
+
+		content, fetchErr := runner.FetchSessionOutput(ctx, sessionID)
+		return previewFetchedMsg{previewKey: key, content: content, err: fetchErr}
+	}
+}
+
 // selectedPreviewTarget returns the instance, cache key, and window index for the currently
 // selected flat item. windowIndex is -1 for session items.
 func (h *Home) selectedPreviewTarget() (*session.Instance, string, int) {
@@ -2182,12 +2222,32 @@ func (h *Home) selectedPreviewTarget() (*session.Instance, string, int) {
 	return nil, "", -1
 }
 
+func (h *Home) selectedRemotePreviewTarget() (string, string, string, bool) {
+	if h.cursor >= len(h.flatItems) {
+		return "", "", "", false
+	}
+	item := h.flatItems[h.cursor]
+	if item.Type != session.ItemTypeRemoteSession || item.RemoteSession == nil {
+		return "", "", "", false
+	}
+	if item.RemoteName == "" || item.RemoteSession.ID == "" {
+		return "", "", "", false
+	}
+
+	key := remotePreviewCacheKey(item.RemoteName, item.RemoteSession.ID)
+	return item.RemoteName, item.RemoteSession.ID, key, true
+}
+
 // fetchSelectedPreview debounces a preview fetch for the currently selected item.
 // Handles both session and window items transparently.
 func (h *Home) fetchSelectedPreview() tea.Cmd {
 	inst, _, winIdx := h.selectedPreviewTarget()
 	if inst == nil {
-		return nil
+		remoteName, remoteSessionID, _, ok := h.selectedRemotePreviewTarget()
+		if !ok {
+			return nil
+		}
+		return h.fetchRemotePreviewDebounced(remoteName, remoteSessionID)
 	}
 	return h.fetchPreviewDebounced(inst.ID, winIdx)
 }
@@ -3984,6 +4044,26 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return h, nil // Superseded by newer navigation
 		}
 
+		if msg.remoteName != "" {
+			var cmds []tea.Cmd
+
+			// Preview fetch
+			h.previewCacheMu.Lock()
+			needsPreviewFetch := h.previewFetchingID != msg.previewKey
+			if needsPreviewFetch {
+				h.previewFetchingID = msg.previewKey
+			}
+			h.previewCacheMu.Unlock()
+			if needsPreviewFetch {
+				cmds = append(cmds, h.fetchRemotePreview(msg.remoteName, msg.sessionID, msg.previewKey))
+			}
+
+			if len(cmds) > 0 {
+				return h, tea.Batch(cmds...)
+			}
+			return h, nil
+		}
+
 		// Find session and trigger actual fetch
 		h.instancesMu.RLock()
 		inst := h.instanceByID[msg.sessionID]
@@ -4082,13 +4162,14 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case previewFetchedMsg:
-		// Async preview content received - update cache with timestamp
+		// Async preview content received - always advance the TTL so failures
+		// and empty responses don't trigger a fetch on every tick.
 		// Protect both previewFetchingID and previewCache with the same mutex
 		h.previewCacheMu.Lock()
 		h.previewFetchingID = ""
+		h.previewCacheTime[msg.previewKey] = time.Now()
 		if msg.err == nil {
 			h.previewCache[msg.previewKey] = msg.content
-			h.previewCacheTime[msg.previewKey] = time.Now()
 		}
 		h.previewCacheMu.Unlock()
 		return h, nil
@@ -4377,8 +4458,10 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// which runs even when TUI is paused during tea.Exec
 
 		// Fetch preview for currently selected item (if stale/missing and not fetching)
-		// Cache expires after 2 seconds to show live terminal updates without excessive fetching
+		// Local previews use a short TTL for near-live terminal updates.
 		const previewCacheTTL = 2 * time.Second
+		// Remote previews use a longer TTL to avoid frequent SSH calls.
+		const remotePreviewCacheTTL = 10 * time.Second
 		var previewCmd tea.Cmd
 		selectedInst, selectedKey, selectedWinIdx := h.selectedPreviewTarget()
 		if selectedInst != nil {
@@ -4391,6 +4474,18 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				previewCmd = h.fetchPreview(selectedInst, selectedKey, selectedWinIdx)
 			}
 			h.previewCacheMu.Unlock()
+		} else {
+			remoteName, remoteSessionID, remoteKey, ok := h.selectedRemotePreviewTarget()
+			if ok {
+				h.previewCacheMu.Lock()
+				cachedTime, hasCached := h.previewCacheTime[remoteKey]
+				cacheExpired := !hasCached || time.Since(cachedTime) > remotePreviewCacheTTL
+				if cacheExpired && h.previewFetchingID != remoteKey {
+					h.previewFetchingID = remoteKey
+					previewCmd = h.fetchRemotePreview(remoteName, remoteSessionID, remoteKey)
+				}
+				h.previewCacheMu.Unlock()
+			}
 		}
 		cmds := []tea.Cmd{h.tick(), previewCmd, remoteFetchCmd}
 		if h.fullRepaint {
@@ -10734,6 +10829,30 @@ func (h *Home) renderRemotePreview(item session.Item, width, height int) string 
 		b.WriteString(dimStyle.Render("Group:   ") + rs.Group + "\n")
 	}
 	b.WriteString("\n")
+
+	pvKey := remotePreviewCacheKey(item.RemoteName, rs.ID)
+	h.previewCacheMu.RLock()
+	previewContent, hasPreview := h.previewCache[pvKey]
+	_, hasFetched := h.previewCacheTime[pvKey]
+	h.previewCacheMu.RUnlock()
+
+	b.WriteString(dimStyle.Render("Last response") + "\n")
+	b.WriteString(strings.Repeat("-", max(1, min(width-4, 40))))
+	b.WriteString("\n")
+	if hasPreview && strings.TrimSpace(previewContent) != "" {
+		b.WriteString(previewContent)
+		b.WriteString("\n\n")
+	} else if hasFetched {
+		b.WriteString(dimStyle.Render("No response available yet."))
+		b.WriteString("\n\n")
+	} else if rs.Status == "running" || rs.Status == "waiting" {
+		b.WriteString(dimStyle.Render("Fetching remote preview..."))
+		b.WriteString("\n\n")
+	} else {
+		b.WriteString(dimStyle.Render("No response available yet."))
+		b.WriteString("\n\n")
+	}
+
 	b.WriteString(dimStyle.Render("Press Enter to attach via SSH"))
 
 	return b.String()

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -1283,6 +1283,30 @@ func TestRemoteSelectionNOpensNewDialog(t *testing.T) {
 	}
 }
 
+func TestSelectedRemotePreviewTarget(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{ID: "remote-123", Title: "remote-session", RemoteName: "myserver"}
+	home.flatItems = []session.Item{{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "myserver"}}
+	home.cursor = 0
+
+	remoteName, sessionID, previewKey, ok := home.selectedRemotePreviewTarget()
+	if !ok {
+		t.Fatal("selectedRemotePreviewTarget should resolve remote selection")
+	}
+	if remoteName != "myserver" {
+		t.Fatalf("remoteName = %q, want %q", remoteName, "myserver")
+	}
+	if sessionID != "remote-123" {
+		t.Fatalf("sessionID = %q, want %q", sessionID, "remote-123")
+	}
+	if previewKey != "remote:myserver:remote-123" {
+		t.Fatalf("previewKey = %q, want %q", previewKey, "remote:myserver:remote-123")
+	}
+}
+
 func TestRemoteSelectionQuickCreateStillRunsRemoteCommand(t *testing.T) {
 	home := NewHome()
 	home.width = 100
@@ -1307,6 +1331,30 @@ func TestRemoteSelectionQuickCreateStillRunsRemoteCommand(t *testing.T) {
 	}
 }
 
+func TestRenderRemotePreviewIncludesCachedResponse(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID:     "remote-123",
+		Title:  "remote-session",
+		Status: "waiting",
+		Path:   "/srv/project",
+	}
+	item := session.Item{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "myserver"}
+
+	home.previewCache[remotePreviewCacheKey("myserver", "remote-123")] = "Remote answer"
+
+	rendered := home.renderRemotePreview(item, 80, 20)
+	if !strings.Contains(rendered, "Last response") {
+		t.Fatalf("rendered preview should include last response header, got: %q", rendered)
+	}
+	if !strings.Contains(rendered, "Remote answer") {
+		t.Fatalf("rendered preview should include cached remote response, got: %q", rendered)
+	}
+}
+
 func TestRemoteGroupSelectionNOpensNewDialog(t *testing.T) {
 	home := NewHome()
 	home.width = 100
@@ -1325,6 +1373,56 @@ func TestRemoteGroupSelectionNOpensNewDialog(t *testing.T) {
 	}
 	if !h.newDialog.IsVisible() {
 		t.Fatal("pressing n on remote group should open new session dialog")
+	}
+}
+
+func TestRenderRemotePreviewShowsEmptyStateAfterFetch(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID:     "remote-123",
+		Title:  "remote-session",
+		Status: "waiting",
+		Path:   "/srv/project",
+	}
+	item := session.Item{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "myserver"}
+	key := remotePreviewCacheKey("myserver", "remote-123")
+
+	home.previewCache[key] = ""
+	home.previewCacheTime[key] = time.Now()
+
+	rendered := home.renderRemotePreview(item, 80, 20)
+	if !strings.Contains(rendered, "No response available yet.") {
+		t.Fatalf("rendered preview should show empty-state copy after a fetch, got: %q", rendered)
+	}
+	if strings.Contains(rendered, "Fetching remote preview...") {
+		t.Fatalf("rendered preview should not keep showing the loading state after an empty fetch, got: %q", rendered)
+	}
+}
+
+func TestPreviewFetchedMsgUpdatesCacheTimeOnError(t *testing.T) {
+	home := NewHome()
+	key := remotePreviewCacheKey("myserver", "remote-123")
+	home.previewFetchingID = key
+	before := time.Now()
+
+	model, _ := home.Update(previewFetchedMsg{previewKey: key, err: fmt.Errorf("fetch failed")})
+	updated := model.(*Home)
+
+	if updated.previewFetchingID != "" {
+		t.Fatal("previewFetchingID should be cleared after fetch completion")
+	}
+	cacheTime, ok := updated.previewCacheTime[key]
+	if !ok {
+		t.Fatal("preview cache time should be recorded even when fetch fails")
+	}
+	if cacheTime.Before(before) {
+		t.Fatalf("preview cache time %v should be at or after %v", cacheTime, before)
+	}
+	if _, ok := updated.previewCache[key]; ok {
+		t.Fatal("preview content should not be cached when fetch fails")
 	}
 }
 

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -1402,6 +1402,61 @@ func TestRenderRemotePreviewShowsEmptyStateAfterFetch(t *testing.T) {
 	}
 }
 
+func TestRenderRemotePreviewTruncatesCachedResponseLines(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID:     "remote-123",
+		Title:  "remote-session",
+		Status: "running",
+		Path:   "/srv/project",
+	}
+	item := session.Item{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "myserver"}
+
+	lines := make([]string, 250)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line-%03d", i)
+	}
+	home.previewCache[remotePreviewCacheKey("myserver", "remote-123")] = strings.Join(lines, "\n")
+
+	rendered := home.renderRemotePreview(item, 80, 20)
+	if strings.Contains(rendered, "line-049") {
+		t.Fatalf("rendered preview should drop lines outside the retained tail, got: %q", rendered)
+	}
+	if !strings.Contains(rendered, "line-050") || !strings.Contains(rendered, "line-249") {
+		t.Fatalf("rendered preview should retain the last 200 lines, got: %q", rendered)
+	}
+}
+
+func TestRenderRemotePreviewTruncatesCachedResponseBytes(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID:     "remote-123",
+		Title:  "remote-session",
+		Status: "running",
+		Path:   "/srv/project",
+	}
+	item := session.Item{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "myserver"}
+
+	prefix := "TRUNCATE-ME"
+	tail := "KEEP-TAIL"
+	content := prefix + strings.Repeat("x", 20*1024) + tail
+	home.previewCache[remotePreviewCacheKey("myserver", "remote-123")] = content
+
+	rendered := home.renderRemotePreview(item, 80, 20)
+	if strings.Contains(rendered, prefix) {
+		t.Fatalf("rendered preview should drop content beyond the byte cap, got: %q", rendered)
+	}
+	if !strings.Contains(rendered, tail) {
+		t.Fatalf("rendered preview should keep the most recent content, got: %q", rendered)
+	}
+}
+
 func TestPreviewFetchedMsgUpdatesCacheTimeOnError(t *testing.T) {
 	home := NewHome()
 	key := remotePreviewCacheKey("myserver", "remote-123")


### PR DESCRIPTION
## Summary
- fetch the latest remote session output over SSH and render it in the remote preview pane so remote selections have useful context before attach
- cache remote previews with a longer TTL and treat failed or empty fetches as completed attempts, which avoids repeated SSH retries and fixes the stuck loading state for empty responses
- add SSH and UI regression tests covering remote preview fetching, empty-state rendering, and preview cache timestamp handling

## Testing
- `rtk go test ./internal/ui`
- `rtk go test ./...` *(still failing after rebasing onto `upstream/main` in existing tmux/session/integration tests, including `internal/tmux`, `internal/session`, `internal/integration`, and `internal/tuitest`)*