### PR TITLE
fix(ui): keep new session on n for remote selections

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5428,14 +5428,6 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case "n":
-		// Check if cursor is on a remote group/session — create on remote instead
-		if h.cursor >= 0 && h.cursor < len(h.flatItems) {
-			item := h.flatItems[h.cursor]
-			if item.Type == session.ItemTypeRemoteGroup || item.Type == session.ItemTypeRemoteSession {
-				return h, h.createRemoteSession(item.RemoteName)
-			}
-		}
-
 		// Collect unique project paths sorted by most recently accessed
 		type pathInfo struct {
 			path           string

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -1232,6 +1232,73 @@ func TestRemoteRestartReturnsRemoteCommand(t *testing.T) {
 	_ = h
 }
 
+func TestRemoteSelectionNOpensNewDialog(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{ID: "remote-123", Title: "remote-session", RemoteName: "myserver"}
+	home.flatItems = []session.Item{{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "myserver"}}
+	home.cursor = 0
+
+	model, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatal("handleMainKey should return *Home")
+	}
+	if cmd != nil {
+		t.Fatal("pressing n on remote selection should not execute remote attach command")
+	}
+	if !h.newDialog.IsVisible() {
+		t.Fatal("pressing n on remote selection should open new session dialog")
+	}
+}
+
+func TestRemoteSelectionQuickCreateStillRunsRemoteCommand(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{ID: "remote-123", Title: "remote-session", RemoteName: "myserver"}
+	home.flatItems = []session.Item{{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "myserver"}}
+	home.cursor = 0
+
+	_, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+	if cmd == nil {
+		t.Fatal("pressing N on remote selection should return remote create command")
+	}
+
+	msg := cmd()
+	createMsg, ok := msg.(sessionCreatedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want sessionCreatedMsg", msg)
+	}
+	if createMsg.err == nil {
+		t.Fatal("expected error when remote config is unavailable")
+	}
+}
+
+func TestRemoteGroupSelectionNOpensNewDialog(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	home.flatItems = []session.Item{{Type: session.ItemTypeRemoteGroup, RemoteName: "myserver", Path: "remotes/myserver"}}
+	home.cursor = 0
+
+	model, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatal("handleMainKey should return *Home")
+	}
+	if cmd != nil {
+		t.Fatal("pressing n on remote group should not execute remote attach command")
+	}
+	if !h.newDialog.IsVisible() {
+		t.Fatal("pressing n on remote group should open new session dialog")
+	}
+}
+
 func TestRenderHelpBarTiny(t *testing.T) {
 	home := NewHome()
 	home.width = 45 // Tiny mode (<50 cols)


### PR DESCRIPTION
## Summary
- Remove remote-specific behavior from the `n` hotkey so `n` always opens the New Session dialog.
- Keep remote quick-create behavior on `N` when a remote group/session is selected.
- Add regression tests covering `n` and `N` behavior for remote selections.