### PR TITLE
perf(ui): smooth attach-return main menu refresh

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -104,6 +104,11 @@ const (
 	// clearOnCompactCooldown - minimum time between /clear sends for the same session
 	// Prevents repeated /clear if context fills up again quickly
 	clearOnCompactCooldown = 60 * time.Second
+
+	// attach-return grace periods keep the main menu responsive right after tea.Exec returns.
+	attachReturnHotDuration  = 1200 * time.Millisecond
+	attachReturnRefreshDelay = 350 * time.Millisecond
+	attachReturnPreviewGrace = 1500 * time.Millisecond
 )
 
 // UI spacing constants (2-char grid system)
@@ -450,6 +455,13 @@ type uiState struct {
 	StatusFilter    string `json:"status_filter,omitempty"`
 }
 
+type selectedItemIdentity struct {
+	groupPath       string
+	sessionID       string
+	windowSessionID string
+	windowIndex     int
+}
+
 func (h *Home) reloadHotkeysFromConfig() {
 	h.setHotkeys(resolveHotkeys(session.GetHotkeyOverrides()))
 }
@@ -530,6 +542,8 @@ type statusUpdateMsg struct {
 	attachedSessionID string // Session that just returned from attach (if local attach)
 	attachedWorkDir   string // pane_current_path captured after attach returns
 } // Triggers immediate status update without reloading
+
+type attachReturnRefreshMsg struct{}
 
 // storageChangedMsg signals that state.db was modified externally
 type storageChangedMsg struct{}
@@ -1221,6 +1235,63 @@ func (h *Home) moveCursorToGroup(path string) {
 			return
 		}
 	}
+}
+
+func (h *Home) captureSelectedItemIdentity() selectedItemIdentity {
+	if h.cursor < 0 || h.cursor >= len(h.flatItems) {
+		return selectedItemIdentity{windowIndex: -1}
+	}
+
+	item := h.flatItems[h.cursor]
+	identity := selectedItemIdentity{windowIndex: -1}
+	switch item.Type {
+	case session.ItemTypeGroup:
+		identity.groupPath = item.Path
+	case session.ItemTypeSession:
+		if item.Session != nil {
+			identity.sessionID = item.Session.ID
+		}
+	case session.ItemTypeWindow:
+		identity.windowSessionID = item.WindowSessionID
+		identity.windowIndex = item.WindowIndex
+	}
+	return identity
+}
+
+func (h *Home) restoreSelectedItemIdentity(identity selectedItemIdentity) bool {
+	for i, item := range h.flatItems {
+		switch {
+		case identity.windowSessionID != "" && item.Type == session.ItemTypeWindow && item.WindowSessionID == identity.windowSessionID && item.WindowIndex == identity.windowIndex:
+			h.cursor = i
+			return true
+		case identity.sessionID != "" && item.Type == session.ItemTypeSession && item.Session != nil && item.Session.ID == identity.sessionID:
+			h.cursor = i
+			return true
+		case identity.groupPath != "" && item.Type == session.ItemTypeGroup && item.Path == identity.groupPath:
+			h.cursor = i
+			return true
+		}
+	}
+
+	if identity.windowSessionID != "" {
+		for i, item := range h.flatItems {
+			if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.ID == identity.windowSessionID {
+				h.cursor = i
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (h *Home) rebuildFlatItemsPreservingSelection(identity selectedItemIdentity) {
+	h.rebuildFlatItems()
+	if !h.restoreSelectedItemIdentity(identity) && len(h.flatItems) > 0 {
+		h.cursor = min(h.cursor, len(h.flatItems)-1)
+		h.cursor = max(h.cursor, 0)
+	}
+	h.syncViewport()
 }
 
 // rebuildFlatItems rebuilds the flattened view from group tree
@@ -2395,6 +2466,17 @@ func (h *Home) markNavigationActivity() {
 	h.lastNavigationTime = now
 	h.isNavigating = true
 	h.navigationHotUntil.Store(now.Add(900 * time.Millisecond).UnixNano())
+}
+
+func (h *Home) beginAttachReturnGrace(now time.Time) {
+	h.lastAttachReturn = now
+	h.lastNavigationTime = now
+	h.isNavigating = true
+	h.navigationHotUntil.Store(now.Add(attachReturnHotDuration).UnixNano())
+}
+
+func (h *Home) shouldSuppressPreviewRefresh(now time.Time) bool {
+	return !h.lastAttachReturn.IsZero() && now.Sub(h.lastAttachReturn) < attachReturnPreviewGrace
 }
 
 // getInstanceByID returns the instance with the given ID using O(1) map lookup
@@ -3898,17 +3980,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case statusUpdateMsg:
 		// Clear attach flag - we've returned from the attached session
 		h.isAttaching.Store(false) // Atomic store for thread safety
-		h.lastAttachReturn = time.Now()
+		now := time.Now()
+		h.beginAttachReturnGrace(now)
 
-		// Refresh window cache and rebuild flat items to reflect window changes
-		// (user may have opened/closed tmux windows while attached)
-		tmux.RefreshSessionCache()
-		h.rebuildFlatItems()
-
-		// Trigger status update on attach return to reflect current state
-		// Acknowledgment was already done on attach (if session was waiting),
-		// so this just refreshes the display with current busy indicator state.
-		h.triggerStatusUpdate()
+		selectedBefore := h.captureSelectedItemIdentity()
+		h.rebuildFlatItemsPreservingSelection(selectedBefore)
 
 		// Cursor sync: if user switched sessions via notification bar during attach,
 		// move cursor to the session they were last viewing
@@ -3962,13 +4038,21 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// We'll let the next tickMsg handle background save if needed.
 
 		// Re-enable mouse mode after returning from tea.Exec (tmux detach-client
-		// resets mouse reporting) and restore legacy keyboard reporting (tmux's
+		// resets mouse reporting), restore legacy keyboard reporting (tmux's
 		// extended-keys setting leaves Kitty/modifyOtherKeys on the outer terminal;
-		// see RestoreLegacyKeyboardCmd for the full rationale).
+		// see RestoreLegacyKeyboardCmd for the full rationale), and schedule a
+		// delayed refresh so the main menu reflects attach-return state changes.
 		return h, tea.Batch(
 			tea.EnableMouseCellMotion,
 			RestoreLegacyKeyboardCmd(os.Stdout),
+			tea.Tick(attachReturnRefreshDelay, func(time.Time) tea.Msg { return attachReturnRefreshMsg{} }),
 		)
+
+	case attachReturnRefreshMsg:
+		selectedBefore := h.captureSelectedItemIdentity()
+		tmux.RefreshSessionCache()
+		h.rebuildFlatItemsPreservingSelection(selectedBefore)
+		return h, nil
 
 	case previewDebounceMsg:
 		// PERFORMANCE: Debounce period elapsed - check if this fetch is still relevant
@@ -4381,7 +4465,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		const previewCacheTTL = 2 * time.Second
 		var previewCmd tea.Cmd
 		selectedInst, selectedKey, selectedWinIdx := h.selectedPreviewTarget()
-		if selectedInst != nil {
+		if selectedInst != nil && !h.shouldSuppressPreviewRefresh(time.Now()) {
 			h.previewCacheMu.Lock()
 			cachedTime, hasCached := h.previewCacheTime[selectedKey]
 			cacheExpired := !hasCached || time.Since(cachedTime) > previewCacheTTL

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2488,3 +2488,91 @@ func TestScopedGroupPaths(t *testing.T) {
 		}
 	}
 }
+
+func TestStatusUpdateMsg_PreservesSelectedSessionAcrossRebuild(t *testing.T) {
+	h := newAttachReturnTestHome()
+	s1 := session.NewInstanceWithGroup("first", "/tmp/first", "work")
+	s1.ID = "s1"
+	s2 := session.NewInstanceWithGroup("second", "/tmp/second", "work")
+	s2.ID = "s2"
+	setAttachReturnTestInstances(h, []*session.Instance{s1, s2})
+
+	h.groupTree = session.NewGroupTree([]*session.Instance{s2, s1})
+
+	model, _ := h.Update(statusUpdateMsg{})
+	home := model.(*Home)
+
+	if got := selectedSessionID(home); got != s2.ID {
+		t.Fatalf("selected session = %q, want %q", got, s2.ID)
+	}
+}
+
+func TestStatusUpdateMsg_FollowsNotificationSwitchSession(t *testing.T) {
+	h := newAttachReturnTestHome()
+	s1 := session.NewInstanceWithGroup("first", "/tmp/first", "work")
+	s1.ID = "s1"
+	s2 := session.NewInstanceWithGroup("second", "/tmp/second", "work")
+	s2.ID = "s2"
+	setAttachReturnTestInstances(h, []*session.Instance{s1, s2})
+
+	h.lastNotifSwitchID = s1.ID
+	h.groupTree = session.NewGroupTree([]*session.Instance{s2, s1})
+
+	model, _ := h.Update(statusUpdateMsg{})
+	home := model.(*Home)
+
+	if got := selectedSessionID(home); got != s1.ID {
+		t.Fatalf("selected session = %q, want switched session %q", got, s1.ID)
+	}
+	if home.lastNotifSwitchID != "" {
+		t.Fatalf("lastNotifSwitchID = %q, want cleared", home.lastNotifSwitchID)
+	}
+}
+
+func TestAttachReturnGraceSuppressesPreviewRefresh(t *testing.T) {
+	h := NewHome()
+	now := time.Now()
+	h.beginAttachReturnGrace(now)
+
+	if !h.shouldSuppressPreviewRefresh(now.Add(attachReturnPreviewGrace / 2)) {
+		t.Fatal("expected preview refresh suppression during attach-return grace period")
+	}
+	if h.shouldSuppressPreviewRefresh(now.Add(attachReturnPreviewGrace + 100*time.Millisecond)) {
+		t.Fatal("expected preview refresh suppression to expire after grace period")
+	}
+	if hotUntil := time.Unix(0, h.navigationHotUntil.Load()); !hotUntil.After(now) {
+		t.Fatal("expected navigation hot window after attach return")
+	}
+}
+
+func newAttachReturnTestHome() *Home {
+	h := NewHome()
+	h.width = 100
+	h.height = 30
+	h.initialLoading = false
+	return h
+}
+
+func setAttachReturnTestInstances(h *Home, instances []*session.Instance) {
+	h.instancesMu.Lock()
+	h.instances = instances
+	h.instanceByID = make(map[string]*session.Instance, len(instances))
+	for _, inst := range instances {
+		h.instanceByID[inst.ID] = inst
+	}
+	h.instancesMu.Unlock()
+	h.groupTree = session.NewGroupTree(instances)
+	h.rebuildFlatItems()
+	h.moveCursorToSession(instances[len(instances)-1].ID)
+}
+
+func selectedSessionID(h *Home) string {
+	if h.cursor < 0 || h.cursor >= len(h.flatItems) {
+		return ""
+	}
+	item := h.flatItems[h.cursor]
+	if item.Type == session.ItemTypeSession && item.Session != nil {
+		return item.Session.ID
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- preserve the selected session or window across attach-return list rebuilds so the preview target stays stable when returning to the main menu
- defer the tmux cache refresh and suppress immediate preview refreshes after `tea.Exec` returns to avoid the burst of work that made the menu feel frozen
- add focused UI regressions for attach-return selection restore, notification-bar switching, and preview grace handling

## Testing
- `go test ./internal/ui`
- `make test` *(currently fails in existing unrelated suites under `internal/integration`, `internal/session`, `internal/tmux`, and `internal/tuitest` on this branch)*