### PR TITLE
fix(config): Preserve worktree settings when editing config

### DIFF
--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -441,6 +441,7 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 		config.Docker = s.originalConfig.Docker
 		config.Preview.Analytics = s.originalConfig.Preview.Analytics
 		config.Profiles = s.originalConfig.Profiles
+		config.Worktree = s.originalConfig.Worktree
 		// Keep global Claude config when editing profile-specific override.
 		if s.claudeConfigIsScope {
 			config.Claude.ConfigDir = s.originalConfig.Claude.ConfigDir

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -900,6 +900,42 @@ func TestSettingsPanel_PreviewSettings_GetConfigPreservesHiddenFields(t *testing
 	}
 }
 
+func TestSettingsPanel_Worktree_GetConfigPreservesHiddenFields(t *testing.T) {
+	panel := NewSettingsPanel()
+
+	branchPrefix := "dev/"
+	pathTemplate := "~/worktrees/{repo-name}/{branch}"
+	original := &session.UserConfig{
+		Worktree: session.WorktreeSettings{
+			AutoCleanup:     true,
+			DefaultEnabled:  true,
+			DefaultLocation: "sibling",
+			PathTemplate:    &pathTemplate,
+			BranchPrefix:    &branchPrefix,
+		},
+	}
+	panel.LoadConfig(original)
+	panel.originalConfig = original
+
+	config := panel.GetConfig()
+
+	if !config.Worktree.AutoCleanup {
+		t.Fatal("Worktree.AutoCleanup should be preserved")
+	}
+	if !config.Worktree.DefaultEnabled {
+		t.Fatal("Worktree.DefaultEnabled should be preserved")
+	}
+	if config.Worktree.DefaultLocation != "sibling" {
+		t.Fatalf("Worktree.DefaultLocation = %q, want %q", config.Worktree.DefaultLocation, "sibling")
+	}
+	if config.Worktree.PathTemplate == nil || *config.Worktree.PathTemplate != pathTemplate {
+		t.Fatalf("Worktree.PathTemplate should be preserved, got %v", config.Worktree.PathTemplate)
+	}
+	if config.Worktree.BranchPrefix == nil || *config.Worktree.BranchPrefix != branchPrefix {
+		t.Fatalf("Worktree.BranchPrefix should be preserved, got %v", config.Worktree.BranchPrefix)
+	}
+}
+
 func TestSettingsPanel_PreviewSettings_ViewContains(t *testing.T) {
 	panel := NewSettingsPanel()
 	panel.SetSize(80, 50)


### PR DESCRIPTION
The `worktree` config section is not in the Settings panel, but wasn't being copied from the original config. The result was that `default_location` would be set to `""` every time settings were saved.

Explicitly copy Worktree from the original config to the new to preserve the values.

This is a second copy of #388, as I think that PR got reverted in v0.27.3.