### PR TITLE
feat(tui): add fresh session restart command

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3048,6 +3048,56 @@ func (i *Instance) SyncSessionIDsToTmux() {
 	}
 }
 
+func (i *Instance) clearSessionBindingForFreshStart() {
+	if IsClaudeCompatible(i.Tool) {
+		i.ClaudeSessionID = ""
+		i.ClaudeDetectedAt = time.Time{}
+	}
+
+	if i.Tool == "gemini" {
+		i.GeminiSessionID = ""
+		i.GeminiDetectedAt = time.Time{}
+	}
+
+	if i.Tool == "opencode" {
+		i.OpenCodeSessionID = ""
+		i.OpenCodeDetectedAt = time.Time{}
+		i.OpenCodeStartedAt = 0
+		i.lastOpenCodeScanAt = time.Time{}
+	}
+
+	if i.Tool == "codex" {
+		i.CodexSessionID = ""
+		i.CodexDetectedAt = time.Time{}
+		i.CodexStartedAt = 0
+		i.lastCodexScanAt = time.Time{}
+		i.mu.Lock()
+		i.pendingCodexRestartWarning = ""
+		i.mu.Unlock()
+	}
+}
+
+func (i *Instance) recreateTmuxSession() {
+	i.tmuxSession = tmux.NewSession(i.Title, i.ProjectPath)
+	i.tmuxSession.InstanceID = i.ID
+	i.tmuxSession.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+	i.tmuxSession.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
+}
+
+func (i *Instance) prepareRestartMCPConfig() {
+	// Clear flag immediately to prevent it staying set if restart fails.
+	skipRegen := i.SkipMCPRegenerate
+	i.SkipMCPRegenerate = false
+
+	if IsClaudeCompatible(i.Tool) && !skipRegen {
+		if err := i.regenerateMCPConfig(); err != nil {
+			mcpLog.Warn("mcp_config_regen_failed", slog.String("error", err.Error()))
+		}
+	} else if skipRegen {
+		mcpLog.Debug("mcp_regen_skipped", slog.String("reason", "flag_set_by_apply"))
+	}
+}
+
 // SyncSessionIDsFromTmux reads tool session IDs from the tmux environment
 // into the Instance struct. This is the reverse of SyncSessionIDsToTmux.
 // Used in the stop path to capture IDs that may not have been saved during
@@ -3769,20 +3819,9 @@ func (i *Instance) Restart() error {
 		slog.Bool("tmux_exists", i.tmuxSession != nil && i.tmuxSession.Exists()),
 	)
 
-	// Clear flag immediately to prevent it staying set if restart fails
-	skipRegen := i.SkipMCPRegenerate
-	i.SkipMCPRegenerate = false
-
-	// Regenerate .mcp.json before restart to use socket pool if available
-	// Skip if MCP dialog just wrote the config (avoids race condition)
-	if IsClaudeCompatible(i.Tool) && !skipRegen {
-		if err := i.regenerateMCPConfig(); err != nil {
-			mcpLog.Warn("mcp_config_regen_failed", slog.String("error", err.Error()))
-			// Continue with restart - Claude will use existing .mcp.json or defaults
-		}
-	} else if skipRegen {
-		mcpLog.Debug("mcp_regen_skipped", slog.String("reason", "flag_set_by_apply"))
-	}
+	// Regenerate .mcp.json before restart to use socket pool if available.
+	// Skip if MCP dialog just wrote the config (avoids race condition).
+	i.prepareRestartMCPConfig()
 
 	// If Claude session with known ID AND tmux session exists, use respawn-pane.
 	if IsClaudeCompatible(i.Tool) && i.ClaudeSessionID != "" && i.tmuxSession != nil && i.tmuxSession.Exists() {
@@ -4009,10 +4048,7 @@ func (i *Instance) Restart() error {
 	}
 
 	// Fallback: recreate tmux session (for dead sessions or unknown ID)
-	i.tmuxSession = tmux.NewSession(i.Title, i.ProjectPath)
-	i.tmuxSession.InstanceID = i.ID // Pass instance ID for activity hooks
-	i.tmuxSession.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
-	i.tmuxSession.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
+	i.recreateTmuxSession()
 
 	var command string
 	if IsClaudeCompatible(i.Tool) && i.ClaudeSessionID != "" {
@@ -4103,6 +4139,30 @@ func (i *Instance) Restart() error {
 		i.Status = StatusWaiting
 	} else {
 		i.Status = StatusIdle
+	}
+
+	return nil
+}
+
+// RestartFresh restarts the current tool without resuming the existing tool session.
+// This recreates the tmux session and clears the stored tool session binding first,
+// so the next start gets a brand-new tool session ID.
+func (i *Instance) RestartFresh() error {
+	i.prepareRestartMCPConfig()
+
+	i.clearSessionBindingForFreshStart()
+
+	if i.tmuxSession != nil && i.tmuxSession.Exists() {
+		if killErr := i.tmuxSession.Kill(); killErr != nil {
+			mcpLog.Warn("restart_fresh_kill_old_session_failed", slog.String("error", killErr.Error()))
+		}
+	}
+
+	i.recreateTmuxSession()
+
+	if err := i.Start(); err != nil {
+		i.Status = StatusError
+		return fmt.Errorf("failed to restart session fresh: %w", err)
 	}
 
 	return nil
@@ -4241,6 +4301,24 @@ func (i *Instance) CanRestart() bool {
 
 	// Other sessions: only if dead or error
 	return i.Status == StatusError || i.tmuxSession == nil || !i.tmuxSession.Exists()
+}
+
+// CanRestartFresh returns true when the session has a known tool session binding
+// that can be intentionally discarded to start with a new session ID.
+func (i *Instance) CanRestartFresh() bool {
+	if IsClaudeCompatible(i.Tool) {
+		return i.ClaudeSessionID != ""
+	}
+	if i.Tool == "gemini" {
+		return i.GeminiSessionID != ""
+	}
+	if i.Tool == "opencode" {
+		return i.OpenCodeSessionID != ""
+	}
+	if i.Tool == "codex" {
+		return i.CodexSessionID != ""
+	}
+	return i.CanRestartGeneric()
 }
 
 // CanFork returns true if this session can be forked

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1584,6 +1584,97 @@ func TestInstance_CanFork_OpenCode(t *testing.T) {
 	}
 }
 
+func TestInstance_CanRestartFresh(t *testing.T) {
+	tests := []struct {
+		name string
+		inst *Instance
+		want bool
+	}{
+		{
+			name: "claude with session ID",
+			inst: &Instance{Tool: "claude", ClaudeSessionID: "claude-session-1"},
+			want: true,
+		},
+		{
+			name: "claude without session ID",
+			inst: &Instance{Tool: "claude"},
+			want: false,
+		},
+		{
+			name: "gemini with session ID",
+			inst: &Instance{Tool: "gemini", GeminiSessionID: "gemini-session-1"},
+			want: true,
+		},
+		{
+			name: "opencode with session ID",
+			inst: &Instance{Tool: "opencode", OpenCodeSessionID: "ses_123"},
+			want: true,
+		},
+		{
+			name: "codex with session ID",
+			inst: &Instance{Tool: "codex", CodexSessionID: "codex-session-1"},
+			want: true,
+		},
+		{
+			name: "shell never offers fresh restart",
+			inst: &Instance{Tool: "shell"},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.inst.CanRestartFresh(); got != tt.want {
+				t.Fatalf("CanRestartFresh() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstance_ClearSessionBindingForFreshStart(t *testing.T) {
+	inst := &Instance{
+		Tool:               "opencode",
+		ClaudeSessionID:    "claude-session-1",
+		GeminiSessionID:    "gemini-session-1",
+		OpenCodeSessionID:  "ses_123",
+		CodexSessionID:     "codex-session-1",
+		OpenCodeStartedAt:  123,
+		CodexStartedAt:     456,
+		OpenCodeDetectedAt: time.Now(),
+		CodexDetectedAt:    time.Now(),
+	}
+
+	inst.clearSessionBindingForFreshStart()
+
+	if inst.OpenCodeSessionID != "" {
+		t.Fatalf("OpenCodeSessionID = %q, want empty", inst.OpenCodeSessionID)
+	}
+	if inst.OpenCodeStartedAt != 0 {
+		t.Fatalf("OpenCodeStartedAt = %d, want 0", inst.OpenCodeStartedAt)
+	}
+	if !inst.OpenCodeDetectedAt.IsZero() {
+		t.Fatal("OpenCodeDetectedAt should be cleared")
+	}
+	if inst.ClaudeSessionID != "claude-session-1" {
+		t.Fatalf("ClaudeSessionID should be untouched for opencode, got %q", inst.ClaudeSessionID)
+	}
+	if inst.GeminiSessionID != "gemini-session-1" {
+		t.Fatalf("GeminiSessionID should be untouched for opencode, got %q", inst.GeminiSessionID)
+	}
+	if inst.CodexSessionID != "codex-session-1" {
+		t.Fatalf("CodexSessionID should be untouched for opencode, got %q", inst.CodexSessionID)
+	}
+
+	claude := &Instance{Tool: "claude", ClaudeSessionID: "claude-session-2", ClaudeDetectedAt: time.Now()}
+	claude.clearSessionBindingForFreshStart()
+	if claude.ClaudeSessionID != "" {
+		t.Fatalf("ClaudeSessionID = %q, want empty", claude.ClaudeSessionID)
+	}
+	if !claude.ClaudeDetectedAt.IsZero() {
+		t.Fatal("ClaudeDetectedAt should be cleared")
+	}
+}
+
 func TestInstance_ForkOpenCode(t *testing.T) {
 	inst := NewInstanceWithTool("test", "/tmp/test", "opencode")
 

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -136,6 +136,7 @@ func (h *HelpOverlay) View() string {
 	deleteKey := h.key(hotkeyDelete, "d")
 	closeKey := h.key(hotkeyCloseSession, "D")
 	restartKey := h.key(hotkeyRestart, "Shift+R")
+	restartFreshKey := h.key(hotkeyRestartFresh, "Shift+T")
 	renameKey := h.key(hotkeyRename, "r")
 	moveKey := h.key(hotkeyMoveToGroup, "M")
 	mcpKey := h.key(hotkeyMCPManager, "m")
@@ -179,6 +180,7 @@ func (h *HelpOverlay) View() string {
 				{newKeys, "New / quick create"},
 				{renameKey, "Rename session"},
 				{restartKey, "Restart session"},
+				{restartFreshKey, "Restart with new session ID"},
 				{deleteKey, "Delete session"},
 				{closeKey, "Close session process"},
 				{undoKey, "Undo delete"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3606,7 +3606,11 @@ func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			// Restart failed - clear resuming animation immediately so user can retry.
 			delete(h.resumingSessions, msg.sessionID)
-			h.setError(fmt.Errorf("failed to restart session: %w", msg.err))
+			if msg.fresh {
+				h.setError(fmt.Errorf("failed to restart session fresh: %w", msg.err))
+			} else {
+				h.setError(fmt.Errorf("failed to restart session: %w", msg.err))
+			}
 		} else {
 			// Find the instance and refresh its MCP state (O(1) lookup)
 			if inst := h.getInstanceByID(msg.sessionID); inst != nil {
@@ -5822,6 +5826,23 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
+	case "T":
+		// Restart session fresh (discard current tool session binding first)
+		if h.cursor < len(h.flatItems) {
+			item := h.flatItems[h.cursor]
+			if item.Type == session.ItemTypeSession && item.Session != nil {
+				if h.hasActiveAnimation(item.Session.ID) {
+					h.setError(fmt.Errorf("session is starting, please wait..."))
+					return h, nil
+				}
+				if item.Session.CanRestartFresh() {
+					h.resumingSessions[item.Session.ID] = time.Now()
+					return h, h.restartSessionFresh(item.Session)
+				}
+			}
+		}
+		return h, nil
+
 	case "c":
 		// Copy last AI response to system clipboard
 		if h.cursor < len(h.flatItems) {
@@ -7491,6 +7512,7 @@ type sessionRestartedMsg struct {
 	sessionID string
 	err       error
 	warning   string
+	fresh     bool
 }
 
 // mcpRestartedMsg signals that an MCP-triggered restart completed and should auto-attach
@@ -7528,6 +7550,38 @@ func (h *Home) restartSession(inst *session.Instance) tea.Cmd {
 			sessionID: id,
 			err:       err,
 			warning:   current.ConsumeCodexRestartWarning(),
+		}
+	}
+}
+
+// restartSessionFresh restarts a session without resuming the previous tool session.
+func (h *Home) restartSessionFresh(inst *session.Instance) tea.Cmd {
+	id := inst.ID
+	mcpUILog.Debug(
+		"restart_session_fresh_called",
+		slog.String("id", inst.ID),
+		slog.String("title", inst.Title),
+		slog.String("tool", inst.Tool),
+	)
+	return func() tea.Msg {
+		mcpUILog.Debug("restart_session_fresh_executing", slog.String("id", id))
+
+		h.instancesMu.RLock()
+		current := h.instanceByID[id]
+		h.instancesMu.RUnlock()
+		if current == nil {
+			err := fmt.Errorf("session no longer exists")
+			mcpUILog.Debug("restart_session_fresh_result", slog.String("id", id), slog.Any("error", err))
+			return sessionRestartedMsg{sessionID: id, err: err, fresh: true}
+		}
+
+		err := current.RestartFresh()
+		mcpUILog.Debug("restart_session_fresh_result", slog.String("id", id), slog.Any("error", err))
+		return sessionRestartedMsg{
+			sessionID: id,
+			err:       err,
+			warning:   current.ConsumeCodexRestartWarning(),
+			fresh:     true,
 		}
 	}
 }
@@ -9176,6 +9230,7 @@ func (h *Home) renderHelpBarMinimal() string {
 	importKey := h.actionKey(hotkeyImport)
 	groupKey := h.actionKey(hotkeyCreateGroup)
 	restartKey := h.actionKey(hotkeyRestart)
+	restartFreshKey := h.actionKey(hotkeyRestartFresh)
 	forkKey := h.actionKey(hotkeyQuickFork)
 	mcpKey := h.actionKey(hotkeyMCPManager)
 	skillsKey := h.actionKey(hotkeySkillsManager)
@@ -9197,6 +9252,12 @@ func (h *Home) renderHelpBarMinimal() string {
 			contextKeys = renderKeys("⏎", newKey, quickKey, groupKey)
 		} else {
 			contextKeys = renderKeys("⏎", newKey, quickKey, restartKey)
+			if item.Session != nil && item.Session.CanRestartFresh() {
+				freshRendered := renderKeys(restartFreshKey)
+				if freshRendered != "" {
+					contextKeys += " " + freshRendered
+				}
+			}
 			if item.Session != nil && item.Session.CanFork() {
 				forkRendered := renderKeys(forkKey)
 				if forkRendered != "" {
@@ -9269,6 +9330,7 @@ func (h *Home) renderHelpBarCompact() string {
 	sepStyle := lipgloss.NewStyle().Foreground(ColorBorder)
 	sep := sepStyle.Render(" │ ")
 	newQuickKey := joinHotkeyLabels(h.actionKey(hotkeyNewSession), h.actionKey(hotkeyQuickCreate))
+	restartFreshKey := h.actionKey(hotkeyRestartFresh)
 
 	// Abbreviated key+short desc
 	var contextHints []string
@@ -9293,6 +9355,9 @@ func (h *Home) renderHelpBarCompact() string {
 			}
 			if key := h.actionKey(hotkeyRestart); key != "" {
 				contextHints = append(contextHints, h.helpKeyShort(key, "Restart"))
+			}
+			if item.Session != nil && item.Session.CanRestartFresh() && restartFreshKey != "" {
+				contextHints = append(contextHints, h.helpKeyShort(restartFreshKey, "Fresh"))
 			}
 			if item.Session != nil && item.Session.CanFork() {
 				if key := h.actionKey(hotkeyQuickFork); key != "" {
@@ -9405,6 +9470,7 @@ func (h *Home) renderHelpBarFull() string {
 	newQuickKey := joinHotkeyLabels(h.actionKey(hotkeyNewSession), h.actionKey(hotkeyQuickCreate))
 	renameKey := h.actionKey(hotkeyRename)
 	restartKey := h.actionKey(hotkeyRestart)
+	restartFreshKey := h.actionKey(hotkeyRestartFresh)
 	deleteKey := h.actionKey(hotkeyDelete)
 	closeKey := h.actionKey(hotkeyCloseSession)
 	groupKey := h.actionKey(hotkeyCreateGroup)
@@ -9466,6 +9532,9 @@ func (h *Home) renderHelpBarFull() string {
 			}
 			if restartKey != "" {
 				primaryHints = append(primaryHints, h.helpKey(restartKey, "Restart"))
+			}
+			if item.Session != nil && item.Session.CanRestartFresh() && restartFreshKey != "" {
+				primaryHints = append(primaryHints, h.helpKey(restartFreshKey, "Restart Fresh"))
 			}
 			// Only show fork hints if session has a valid Claude session ID
 			if item.Session != nil && item.Session.CanFork() {
@@ -11341,6 +11410,16 @@ func (h *Home) renderPreviewPane(width, height int) string {
 					b.WriteString("\n")
 				}
 			}
+			if selected.CanRestartFresh() {
+				if restartFreshKey := h.actionKey(hotkeyRestartFresh); restartFreshKey != "" {
+					hintStyle := lipgloss.NewStyle().Foreground(ColorText).Italic(true)
+					keyStyle := lipgloss.NewStyle().Foreground(ColorAccent).Bold(true)
+					b.WriteString(hintStyle.Render("Fresh:   "))
+					b.WriteString(keyStyle.Render(restartFreshKey))
+					b.WriteString(hintStyle.Render(" restart with a new session ID"))
+					b.WriteString("\n")
+				}
+			}
 		}
 	}
 
@@ -11391,6 +11470,14 @@ func (h *Home) renderPreviewPane(width, height int) string {
 			b.WriteString(keyStyle.Render(restartKey))
 			b.WriteString(dimStyle.Render(" Resume  - restart with session resume"))
 			b.WriteString("\n")
+		}
+		if selected.CanRestartFresh() {
+			if restartFreshKey := h.actionKey(hotkeyRestartFresh); restartFreshKey != "" {
+				b.WriteString("  ")
+				b.WriteString(keyStyle.Render(restartFreshKey))
+				b.WriteString(dimStyle.Render(" Fresh   - restart with a new session ID"))
+				b.WriteString("\n")
+			}
 		}
 		if deleteKey := h.actionKey(hotkeyDelete); deleteKey != "" {
 			b.WriteString("  ")
@@ -11448,6 +11535,14 @@ func (h *Home) renderPreviewPane(width, height int) string {
 			b.WriteString(keyStyle.Render(restartKey))
 			b.WriteString(dimStyle.Render(" Start   - create and start tmux session"))
 			b.WriteString("\n")
+		}
+		if selected.CanRestartFresh() {
+			if restartFreshKey := h.actionKey(hotkeyRestartFresh); restartFreshKey != "" {
+				b.WriteString("  ")
+				b.WriteString(keyStyle.Render(restartFreshKey))
+				b.WriteString(dimStyle.Render(" Fresh   - start without resuming the prior session"))
+				b.WriteString("\n")
+			}
 		}
 		if deleteKey := h.actionKey(hotkeyDelete); deleteKey != "" {
 			b.WriteString("  ")

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -1327,6 +1327,27 @@ func TestRenderHelpBarMinimalWithSession(t *testing.T) {
 	}
 }
 
+func TestRenderHelpBarMinimalWithFreshRestartableSession(t *testing.T) {
+	home := NewHome()
+	home.width = 55
+	home.height = 30
+
+	testSession := &session.Instance{
+		ID:              "test-456",
+		Title:           "Fresh Restart Session",
+		Tool:            "claude",
+		ClaudeSessionID: "session-xyz",
+	}
+	home.flatItems = []session.Item{{Type: session.ItemTypeSession, Session: testSession}}
+	home.cursor = 0
+
+	result := home.renderHelpBar()
+
+	if !strings.Contains(result, "T") {
+		t.Error("Minimal help bar should contain T key for fresh restart")
+	}
+}
+
 func TestRenderHelpBarCompact(t *testing.T) {
 	home := NewHome()
 	home.width = 85 // Compact mode (70-99)
@@ -2055,6 +2076,28 @@ func TestRestartSessionCmdSessionMissingReturnsError(t *testing.T) {
 
 	// Build command with a valid instance, then simulate reload/delete before cmd runs.
 	cmd := home.restartSession(inst)
+	home.instancesMu.Lock()
+	delete(home.instanceByID, inst.ID)
+	home.instancesMu.Unlock()
+
+	msg := cmd()
+	restarted, ok := msg.(sessionRestartedMsg)
+	if !ok {
+		t.Fatalf("expected sessionRestartedMsg, got %T", msg)
+	}
+	if restarted.err == nil {
+		t.Fatal("expected error when session no longer exists")
+	}
+	if !strings.Contains(restarted.err.Error(), "session no longer exists") {
+		t.Fatalf("unexpected error: %v", restarted.err)
+	}
+}
+
+func TestRestartSessionFreshCmdSessionMissingReturnsError(t *testing.T) {
+	home := NewHome()
+	inst := session.NewInstance("restart-fresh-test", "/tmp/project")
+
+	cmd := home.restartSessionFresh(inst)
 	home.instancesMu.Lock()
 	delete(home.instanceByID, inst.ID)
 	home.instancesMu.Unlock()

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -13,6 +13,7 @@ const (
 	hotkeyQuickCreate     = "quick_create"
 	hotkeyRename          = "rename"
 	hotkeyRestart         = "restart"
+	hotkeyRestartFresh    = "restart_fresh"
 	hotkeyDelete          = "delete"
 	hotkeyCloseSession    = "close_session"
 	hotkeyUndoDelete      = "undo_delete"
@@ -45,6 +46,7 @@ var hotkeyActionOrder = []string{
 	hotkeyQuickCreate,
 	hotkeyRename,
 	hotkeyRestart,
+	hotkeyRestartFresh,
 	hotkeyDelete,
 	hotkeyCloseSession,
 	hotkeyUndoDelete,
@@ -77,6 +79,7 @@ var defaultHotkeyBindings = map[string]string{
 	hotkeyQuickCreate:     "N",
 	hotkeyRename:          "r",
 	hotkeyRestart:         "R",
+	hotkeyRestartFresh:    "T",
 	hotkeyDelete:          "d",
 	hotkeyCloseSession:    "D",
 	hotkeyUndoDelete:      "ctrl+z",

--- a/internal/ui/hotkeys_test.go
+++ b/internal/ui/hotkeys_test.go
@@ -20,6 +20,10 @@ func TestResolveHotkeysOverridesAndUnbinds(t *testing.T) {
 	if got := bindings[hotkeyRestart]; got != defaultHotkeyBindings[hotkeyRestart] {
 		t.Fatalf("restart binding = %q, want %q", got, defaultHotkeyBindings[hotkeyRestart])
 	}
+
+	if got := bindings[hotkeyRestartFresh]; got != defaultHotkeyBindings[hotkeyRestartFresh] {
+		t.Fatalf("restart_fresh binding = %q, want %q", got, defaultHotkeyBindings[hotkeyRestartFresh])
+	}
 }
 
 func TestResolveHotkeysPrefersCanonicalNameOverLegacyRename(t *testing.T) {

--- a/internal/ui/keyboard_compat_test.go
+++ b/internal/ui/keyboard_compat_test.go
@@ -377,11 +377,11 @@ func TestCSIuReaderModifyOtherKeysMixed(t *testing.T) {
 // tea.WithInput(NewCSIuReader(os.Stdin)) wiring.
 func TestCSIuReaderAllShiftHotkeys(t *testing.T) {
 	// Every uppercase hotkey defined in defaultHotkeyBindings:
-	//   N=quick_create, R=restart, D=close_session, M=move_to_group,
+	//   N=quick_create, R=restart, T=restart_fresh, D=close_session, M=move_to_group,
 	//   F=fork_with_options, E=exec_shell, W=worktree_finish, S=settings,
 	//   G=global_search, K=move_up, J=move_down, C=cost_dashboard
 	hotkeys := map[rune]int{
-		'N': 110, 'R': 114, 'D': 100, 'M': 109,
+		'N': 110, 'R': 114, 'T': 116, 'D': 100, 'M': 109,
 		'F': 102, 'E': 101, 'W': 119, 'S': 115,
 		'G': 103, 'K': 107, 'J': 106, 'C': 99,
 	}


### PR DESCRIPTION
## Summary
- add a separate `T` hotkey and TUI help copy to restart the highlighted local session with a fresh tool session ID
- keep the existing `R` restart flow unchanged so resume-based restarts still work as before
- clear stored session bindings before fresh restart and cover the new behavior with session and UI tests

## Testing
- `make fmt`
- `TMPDIR=\"$PWD/.tmp/go-tmp\" GOCACHE=\"$PWD/.tmp/go-cache\" go test ./internal/session -run 'TestInstance_(CanRestartFresh|ClearSessionBindingForFreshStart)$'`
- `TMPDIR=\"$PWD/.tmp/go-tmp\" GOCACHE=\"$PWD/.tmp/go-cache\" go test ./internal/ui -run 'TestRenderHelpBarMinimalWithFreshRestartableSession|TestRestartSessionFreshCmdSessionMissingReturnsError|TestResolveHotkeysOverridesAndUnbinds|TestCSIuReaderAllShiftHotkeys'`
- `make test` was attempted but the environment's `/tmp` tmpfs was full, so the full suite could not complete in this workspace

## Notes
- no documentation changes were needed because this is a TUI-only command addition