### PR TITLE
fix: clean up stale tmux watchers and prevent duplicate sessions

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1936,6 +1936,9 @@ func (i *Instance) Start() error {
 	// inside Docker sandbox containers that have no access to the host tmux socket.
 	if i.ClaudeSessionID != "" {
 		_ = i.tmuxSession.SetEnvironment("CLAUDE_SESSION_ID", i.ClaudeSessionID)
+		// Kill any other agentdeck tmux session with the same Claude session ID
+		// to prevent duplicates running `claude --resume` with the same conversation (#596).
+		tmux.KillSessionsWithEnvValue("CLAUDE_SESSION_ID", i.ClaudeSessionID, i.tmuxSession.Name)
 	}
 	if i.GeminiSessionID != "" {
 		_ = i.tmuxSession.SetEnvironment("GEMINI_SESSION_ID", i.GeminiSessionID)
@@ -4084,6 +4087,12 @@ func (i *Instance) Restart() error {
 	// This covers Restart() which uses buildClaudeResumeCommand() and similar
 	// builders that no longer embed "tmux set-environment" in the shell string.
 	i.SyncSessionIDsToTmux()
+
+	// Kill any other agentdeck tmux session with the same Claude session ID
+	// to prevent duplicates running `claude --resume` with the same conversation (#596).
+	if i.ClaudeSessionID != "" {
+		tmux.KillSessionsWithEnvValue("CLAUDE_SESSION_ID", i.ClaudeSessionID, i.tmuxSession.Name)
+	}
 
 	// Re-capture MCPs after restart
 	i.CaptureLoadedMCPs()

--- a/internal/tmux/controlpipe_test.go
+++ b/internal/tmux/controlpipe_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
 	"sync"
@@ -275,6 +276,69 @@ func TestPipeManager_GlobalSingleton(t *testing.T) {
 
 	SetPipeManager(nil)
 	assert.Nil(t, GetPipeManager())
+}
+
+func TestKillStaleControlClients(t *testing.T) {
+	name := createTestSession(t, "stale-ctrl")
+
+	// Use NewControlPipe to create a proper control-mode client that we know works,
+	// then simulate it being "stale" by tracking its PID before killing it via our function.
+	stalePipe, err := NewControlPipe(name)
+	require.NoError(t, err)
+	stalePID := stalePipe.cmd.Process.Pid
+	t.Cleanup(func() { stalePipe.Close() })
+
+	// Verify the control client is registered
+	require.Eventually(t, func() bool {
+		out, _ := exec.Command("tmux", "list-clients", "-t", name, "-F", "#{client_control_mode} #{client_pid}").Output()
+		return strings.Contains(string(out), fmt.Sprintf("1 %d", stalePID))
+	}, 3*time.Second, 100*time.Millisecond, "control client should register")
+
+	// Kill stale clients — this should kill the pipe's process
+	killStaleControlClients(name)
+
+	// Verify the control client is no longer listed by tmux
+	require.Eventually(t, func() bool {
+		out, _ := exec.Command("tmux", "list-clients", "-t", name, "-F", "#{client_control_mode} #{client_pid}").Output()
+		return !strings.Contains(string(out), fmt.Sprintf("1 %d", stalePID))
+	}, 2*time.Second, 100*time.Millisecond, "stale control client should be gone from tmux client list")
+}
+
+func TestPipeManager_ConnectCleansStaleClients(t *testing.T) {
+	name := createTestSession(t, "pm-stale")
+
+	// Create a stale control pipe (simulates orphan from previous TUI)
+	stalePipe, err := NewControlPipe(name)
+	require.NoError(t, err)
+	stalePID := stalePipe.cmd.Process.Pid
+	t.Cleanup(func() { stalePipe.Close() })
+
+	// Verify stale client is registered
+	require.Eventually(t, func() bool {
+		out, _ := exec.Command("tmux", "list-clients", "-t", name, "-F", "#{client_control_mode} #{client_pid}").Output()
+		return strings.Contains(string(out), fmt.Sprintf("1 %d", stalePID))
+	}, 3*time.Second, 100*time.Millisecond)
+
+	// Connect via PipeManager — should kill stale client and create a new one
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pm := NewPipeManager(ctx, nil)
+	defer pm.Close()
+
+	require.NoError(t, pm.Connect(name))
+	assert.True(t, pm.IsConnected(name))
+
+	// Stale client should be gone
+	out, _ := exec.Command("tmux", "list-clients", "-t", name, "-F", "#{client_control_mode} #{client_pid}").Output()
+	assert.NotContains(t, string(out), fmt.Sprintf("1 %d", stalePID), "stale client should have been killed by Connect")
+}
+
+func TestKillStaleControlClients_PreservesOwnProcess(t *testing.T) {
+	name := createTestSession(t, "own-proc")
+
+	// killStaleControlClients should not kill our own PID
+	// (this is mostly a safety check — our PID is never a tmux control client)
+	killStaleControlClients(name) // should not panic or kill us
 }
 
 // --- Helpers ---

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -427,6 +427,9 @@ func (pm *PipeManager) watchPipe(sessionName string, pipe *ControlPipe) {
 // are not owned by the current process. These accumulate when the TUI is killed
 // without clean shutdown and restarted — the old `tmux -C attach-session`
 // processes survive because they run in their own process group (#595).
+//
+// Expected to find stale clients after: agent-deck crash/SIGKILL, OOM kill,
+// or any exit that bypasses PipeManager.Close() (which normally tears them down).
 func killStaleControlClients(sessionName string) {
 	myPID := os.Getpid()
 

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -79,6 +80,11 @@ func (pm *PipeManager) Connect(sessionName string) error {
 		delete(pm.reconnecting, sessionName)
 		pm.reconnectMu.Unlock()
 	}()
+
+	// Kill stale control-mode clients left over from previous TUI instances.
+	// Without this, each TUI reconnect accumulates orphan `tmux -C attach-session`
+	// processes that are never cleaned up (#595).
+	killStaleControlClients(sessionName)
 
 	// Create new pipe (outside lock since it spawns a process)
 	pipe, err := NewControlPipe(sessionName)
@@ -415,6 +421,46 @@ func (pm *PipeManager) watchPipe(sessionName string, pipe *ControlPipe) {
 	pm.mu.Lock()
 	delete(pm.pipes, sessionName)
 	pm.mu.Unlock()
+}
+
+// killStaleControlClients kills control-mode clients attached to a session that
+// are not owned by the current process. These accumulate when the TUI is killed
+// without clean shutdown and restarted — the old `tmux -C attach-session`
+// processes survive because they run in their own process group (#595).
+func killStaleControlClients(sessionName string) {
+	myPID := os.Getpid()
+
+	out, err := exec.Command(
+		"tmux", "list-clients", "-t", sessionName,
+		"-F", "#{client_control_mode} #{client_pid}",
+	).Output()
+	if err != nil {
+		return // session may not exist or no clients attached
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 || parts[0] != "1" {
+			continue // not a control-mode client
+		}
+		var pid int
+		if _, err := fmt.Sscanf(parts[1], "%d", &pid); err != nil || pid == 0 {
+			continue
+		}
+		if pid == myPID {
+			continue // don't kill our own process
+		}
+		// Kill the stale control-mode client process
+		if proc, err := os.FindProcess(pid); err == nil {
+			_ = proc.Kill()
+			pipeLog.Debug("killed_stale_control_client",
+				slog.String("session", sessionName),
+				slog.Int("pid", pid))
+		}
+	}
 }
 
 // tmuxSessionExists checks if a tmux session exists (lightweight subprocess).

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1117,6 +1117,46 @@ func (s *Session) IsConfigured() bool {
 	return s.configured
 }
 
+// KillSessionsWithEnvValue kills agentdeck tmux sessions that have the given
+// environment variable set to the given value, excluding the session named
+// `excludeName`. This prevents duplicate tmux sessions running the same Claude
+// conversation (#596).
+func KillSessionsWithEnvValue(envKey, envValue, excludeName string) {
+	if envValue == "" {
+		return
+	}
+
+	out, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		return
+	}
+
+	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if name == "" || name == excludeName {
+			continue
+		}
+		if !strings.HasPrefix(name, SessionPrefix) {
+			continue
+		}
+		val, err := exec.Command("tmux", "show-environment", "-t", name, envKey).Output()
+		if err != nil {
+			continue
+		}
+		// Output format: "KEY=value\n"
+		line := strings.TrimSpace(string(val))
+		if idx := strings.IndexByte(line, '='); idx >= 0 {
+			if line[idx+1:] == envValue {
+				statusLog.Warn("killing_duplicate_session",
+					slog.String("session", name),
+					slog.String("env_key", envKey),
+					slog.String("env_value", envValue),
+					slog.String("kept", excludeName))
+				_ = exec.Command("tmux", "kill-session", "-t", name).Run()
+			}
+		}
+	}
+}
+
 // generateShortID generates a short random ID for uniqueness
 func generateShortID() string {
 	b := make([]byte, 4)

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2942,3 +2942,41 @@ func TestResolvedAgentDeckTheme_ExplicitConfigOverridesCOLORFGBG(t *testing.T) {
 	got := resolvedAgentDeckTheme()
 	assert.Equal(t, "dark", got, "explicit config should override COLORFGBG")
 }
+
+func TestKillSessionsWithEnvValue(t *testing.T) {
+	skipIfNoTmuxServer(t)
+
+	// Create two sessions with the same CLAUDE_SESSION_ID env var
+	sess1 := createTestSession(t, "dedup-keep")
+	sess2 := createTestSession(t, "dedup-kill")
+
+	testID := "test-dedup-" + generateShortID()
+	require.NoError(t, exec.Command("tmux", "set-environment", "-t", sess1, "CLAUDE_SESSION_ID", testID).Run())
+	require.NoError(t, exec.Command("tmux", "set-environment", "-t", sess2, "CLAUDE_SESSION_ID", testID).Run())
+
+	// Kill duplicates, excluding sess1
+	KillSessionsWithEnvValue("CLAUDE_SESSION_ID", testID, sess1)
+
+	// sess1 should still exist
+	assert.NoError(t, exec.Command("tmux", "has-session", "-t", sess1).Run(), "kept session should still exist")
+
+	// sess2 should be killed
+	assert.Error(t, exec.Command("tmux", "has-session", "-t", sess2).Run(), "duplicate session should have been killed")
+}
+
+func TestKillSessionsWithEnvValue_EmptyID(t *testing.T) {
+	// Should be a no-op when envValue is empty
+	KillSessionsWithEnvValue("CLAUDE_SESSION_ID", "", "anything")
+}
+
+func TestKillSessionsWithEnvValue_NoMatch(t *testing.T) {
+	skipIfNoTmuxServer(t)
+
+	sess := createTestSession(t, "dedup-nomatch")
+	require.NoError(t, exec.Command("tmux", "set-environment", "-t", sess, "CLAUDE_SESSION_ID", "unique-id-xyz").Run())
+
+	// Should not kill anything when looking for a different ID
+	KillSessionsWithEnvValue("CLAUDE_SESSION_ID", "nonexistent-id", "")
+
+	assert.NoError(t, exec.Command("tmux", "has-session", "-t", sess).Run(), "session should not be killed")
+}


### PR DESCRIPTION
## Summary

- **#595**: Kill orphaned `tmux -C attach-session` control-mode clients before spawning new ones in `PipeManager.Connect()`. Previously, each TUI reconnect accumulated watchers because old processes survived in their own process group. New `killStaleControlClients()` uses `tmux list-clients` to find and kill stale control-mode processes.
- **#596**: Kill any existing agentdeck tmux session with the same `CLAUDE_SESSION_ID` before starting a new one, in both `Instance.Start()` and `Restart()` paths. New `KillSessionsWithEnvValue()` scans agentdeck tmux sessions for matching env vars and kills duplicates.

Fixes #595
Fixes #596

## Test plan

- [x] `TestKillStaleControlClients` — spawns a real control-mode client, kills it, verifies removal from tmux client list
- [x] `TestPipeManager_ConnectCleansStaleClients` — verifies `Connect()` cleans stale clients before creating new ones
- [x] `TestKillStaleControlClients_PreservesOwnProcess` — safety check that we don't kill ourselves
- [x] `TestKillSessionsWithEnvValue` — creates two sessions with same CLAUDE_SESSION_ID, kills duplicate, verifies correct one survives
- [x] `TestKillSessionsWithEnvValue_EmptyID` — no-op on empty ID
- [x] `TestKillSessionsWithEnvValue_NoMatch` — doesn't kill sessions with different IDs
- [x] Full `go build ./...` passes
- [x] All new tests pass, no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)