### PR TITLE
fix(ui): force-delete worktrees on session deletion

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -257,8 +257,11 @@ func parseWorktreeList(output string) []Worktree {
 	return worktrees
 }
 
-// RemoveWorktree removes a worktree from the repository
-// If force is true, it will remove even if there are uncommitted changes
+// RemoveWorktree removes a worktree from the repository.
+// If force is true, it will remove even if there are uncommitted changes.
+// When force is true and git fails (e.g. "Directory not empty" due to
+// untracked files like node_modules), falls back to removing the directory
+// directly and pruning stale worktree references.
 func RemoveWorktree(repoDir, worktreePath string, force bool) error {
 	if !IsGitRepo(repoDir) {
 		return errors.New("not a git repository")
@@ -273,7 +276,16 @@ func RemoveWorktree(repoDir, worktreePath string, force bool) error {
 	cmd := exec.Command("git", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to remove worktree: %s: %w", strings.TrimSpace(string(output)), err)
+		if !force {
+			return fmt.Errorf("failed to remove worktree: %s: %w", strings.TrimSpace(string(output)), err)
+		}
+		// Force mode: git worktree remove --force can still fail when the
+		// directory contains untracked content. Fall back to deleting the
+		// directory and pruning the stale worktree reference.
+		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
+			return fmt.Errorf("failed to remove worktree directory: %w (git error: %s)", rmErr, strings.TrimSpace(string(output)))
+		}
+		return PruneWorktrees(repoDir)
 	}
 
 	return nil

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -33,6 +33,7 @@ type ConfirmDialog struct {
 	height      int
 	mcpCount    int  // Number of running MCPs (for quit confirmation)
 	sandboxed   bool // Whether the session uses a Docker sandbox.
+	worktree    bool // Whether the session has an associated git worktree.
 
 	remoteName string // Remote name for remote session confirmations.
 
@@ -59,12 +60,13 @@ func NewConfirmDialog() *ConfirmDialog {
 }
 
 // ShowDeleteSession shows confirmation for session deletion.
-func (c *ConfirmDialog) ShowDeleteSession(sessionID string, sessionName string, sandboxed bool) {
+func (c *ConfirmDialog) ShowDeleteSession(sessionID string, sessionName string, sandboxed, worktree bool) {
 	c.visible = true
 	c.confirmType = ConfirmDeleteSession
 	c.targetID = sessionID
 	c.targetName = sessionName
 	c.sandboxed = sandboxed
+	c.worktree = worktree
 	c.buttonCount = 2
 	c.focusedButton = 1 // default to Cancel
 }
@@ -258,6 +260,9 @@ func (c *ConfirmDialog) View() string {
 		title = "⚠  Delete Session?"
 		warning = fmt.Sprintf("This will permanently delete the session:\n\n  \"%s\"", c.targetName)
 		details = "• The tmux session will be terminated\n• Any running processes will be killed\n• Terminal history will be lost"
+		if c.worktree {
+			details += "\n• The git worktree directory will be removed"
+		}
 		if c.sandboxed {
 			details += "\n• The Docker container will be removed"
 		}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5721,7 +5721,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil {
-				h.confirmDialog.ShowDeleteSession(item.Session.ID, item.Session.Title, item.Session.IsSandboxed())
+				h.confirmDialog.ShowDeleteSession(item.Session.ID, item.Session.Title, item.Session.IsSandboxed(), item.Session.IsWorktree())
 			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
 				h.confirmDialog.ShowDeleteRemoteSession(item.RemoteName, item.RemoteSession.ID, item.RemoteSession.Title)
 			} else if item.Type == session.ItemTypeGroup && item.Path != session.DefaultGroupPath && item.Path != h.groupScope {
@@ -7519,8 +7519,12 @@ func (h *Home) deleteSession(inst *session.Instance) tea.Cmd {
 	return func() tea.Msg {
 		killErr := inst.Kill()
 		if isWorktree {
-			_ = git.RemoveWorktree(worktreeRepoRoot, worktreePath, false)
-			_ = git.PruneWorktrees(worktreeRepoRoot)
+			if err := git.RemoveWorktree(worktreeRepoRoot, worktreePath, true); err != nil {
+				uiLog.Warn("worktree_remove_err", slog.String("path", worktreePath), slog.String("err", err.Error()))
+			}
+			if err := git.PruneWorktrees(worktreeRepoRoot); err != nil {
+				uiLog.Warn("worktree_prune_err", slog.String("repo", worktreeRepoRoot), slog.String("err", err.Error()))
+			}
 		}
 		if isMultiRepo {
 			// Clean up multi-repo temp directory
@@ -7529,8 +7533,12 @@ func (h *Home) deleteSession(inst *session.Instance) tea.Cmd {
 			}
 			// Clean up per-repo worktrees
 			for _, wt := range multiRepoWorktrees {
-				_ = git.RemoveWorktree(wt.RepoRoot, wt.WorktreePath, false)
-				_ = git.PruneWorktrees(wt.RepoRoot)
+				if err := git.RemoveWorktree(wt.RepoRoot, wt.WorktreePath, true); err != nil {
+					uiLog.Warn("worktree_remove_err", slog.String("path", wt.WorktreePath), slog.String("err", err.Error()))
+				}
+				if err := git.PruneWorktrees(wt.RepoRoot); err != nil {
+					uiLog.Warn("worktree_prune_err", slog.String("repo", wt.RepoRoot), slog.String("err", err.Error()))
+				}
 			}
 		}
 		return sessionDeletedMsg{deletedID: id, killErr: killErr}


### PR DESCRIPTION
## Summary
- Use `--force` when removing git worktrees during session deletion, preventing orphaned worktree directories when sessions have uncommitted changes
- Fall back to `os.RemoveAll` + `git worktree prune` when `git worktree remove --force` still fails (e.g. untracked content like `node_modules` causes "Directory not empty")
- Log worktree removal errors via `uiLog.Warn()` instead of silently discarding them
- Update delete confirmation dialog to mention worktree cleanup for worktree sessions

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/git/...` passes
- [ ] Create a worktree session, make uncommitted changes, delete from UI — verify worktree directory is removed from disk
- [ ] Create a worktree session in a repo with `node_modules`, delete — verify fallback removes the directory
- [ ] Verify `git worktree list` no longer shows the deleted worktree
- [ ] Verify confirmation dialog shows "The git worktree directory will be removed" bullet for worktree sessions