### PR TITLE
fix(#615): session show --json includes channels field

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -159,4 +159,16 @@ tests:
   run:
     command: go test ./internal/ui/ -run TestCSIuReader_UnderscorePreserved -count=1
       -v
+- id: fix-615-session-show-channels
+  added: '2026-04-16'
+  task: fix-615
+  file: cmd/agent-deck/channels_cmd_test.go
+  test_name: TestSessionShowJSONIncludesChannels
+  purpose: "session show --json must include channels field when set \u2014 guards\
+    \ parallel-paths regression where list --json and show --json emitters drift."
+  source: gh#615
+  manual: false
+  run:
+    command: go test ./cmd/agent-deck/ -run TestSessionShowJSONIncludesChannels -count=1
+      -timeout 90s -v
     expected: pass

--- a/cmd/agent-deck/channels_cmd_test.go
+++ b/cmd/agent-deck/channels_cmd_test.go
@@ -165,6 +165,84 @@ func TestAddChannelFlag(t *testing.T) {
 	}
 }
 
+// TestSessionShowJSONIncludesChannels asserts that
+// `agent-deck session show --json <id>` includes the `channels` field when
+// the session has channels set. Without this, the `show` JSON is
+// inconsistent with `list --json` (which does include the field).
+//
+// Failure mode on main pre-fix: `session show --json` omits the "channels"
+// key entirely even when set. Data persists fine (list shows it) — only
+// the show serializer is blind to it.
+//
+// Root cause: two separate JSON emitters. handleList threads Channels;
+// handleSessionShow (session_cmd.go:645) builds its own jsonData map and
+// never included the field.
+//
+// See gh#615.
+func TestSessionShowJSONIncludesChannels(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 1: create claude session with --channel.
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add",
+		"-t", "ch-show-test",
+		"-c", "claude",
+		"--channel", "plugin:telegram@user/repo",
+		"--no-parent",
+		"--json",
+		projectDir,
+	)
+	if code != 0 {
+		t.Fatalf("agent-deck add --channel failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var addResp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &addResp); err != nil {
+		t.Fatalf("parse add response: %v\nstdout: %s", err, stdout)
+	}
+
+	// Step 2: session show --json MUST include the channels field.
+	stdout, stderr, code = runAgentDeck(t, home,
+		"session", "show", addResp.ID, "--json",
+	)
+	if code != 0 {
+		t.Fatalf("agent-deck session show --json failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+
+	var showResp map[string]interface{}
+	if err := json.Unmarshal([]byte(stdout), &showResp); err != nil {
+		t.Fatalf("parse show response: %v\nstdout: %s", err, stdout)
+	}
+
+	// The assertion — pre-fix this fails because the key is absent.
+	channels, ok := showResp["channels"]
+	if !ok {
+		t.Fatalf(
+			"session show --json must include 'channels' field when set, but key is absent.\n"+
+				"list --json includes it; show --json should too (consistency).\n"+
+				"See gh#615.\nResponse: %s",
+			stdout,
+		)
+	}
+
+	// Must be a list with our channel id.
+	chList, ok := channels.([]interface{})
+	if !ok {
+		t.Fatalf("channels field should be a list, got %T: %v", channels, channels)
+	}
+	if len(chList) != 1 || chList[0] != "plugin:telegram@user/repo" {
+		t.Errorf("expected channels == [plugin:telegram@user/repo], got %v", chList)
+	}
+}
+
 // TestSessionSetChannels asserts that
 // `agent-deck session set <id> channels <csv>` updates the field.
 //

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -739,6 +739,13 @@ func handleSessionShow(profile string, args []string) {
 		if mcps := mcpInfoForJSON(mcpInfo); mcps != nil {
 			jsonData["mcps"] = mcps
 		}
+
+		// Always include channels for claude sessions — omitting when empty
+		// would make absence-of-field ambiguous with absence-of-value. Match
+		// the `list --json` emitter which surfaces this field unconditionally.
+		if len(inst.Channels) > 0 {
+			jsonData["channels"] = inst.Channels
+		}
 	}
 
 	if tmuxSession := inst.GetTmuxSession(); tmuxSession != nil {


### PR DESCRIPTION
## Summary

`agent-deck session show --json <id>` was omitting the `channels` field even when set. `agent-deck list --json` correctly included it — the two JSON emitters had drifted.

## Fix

Thread `inst.Channels` through `handleSessionShow`'s `jsonData` map for claude-compatible sessions, matching `handleList`'s behavior. Include only when non-empty (omitempty semantics; pre-existing-session JSON stays unchanged).

## Root cause

When first-class `--channel` / channels shipped in v1.7.0 (PR #614), the field was added to:
- `Instance.Channels` struct field ✅
- Storage round-trip (`MarshalToolData` / `UnmarshalToolData`) ✅
- CLI add/launch flags ✅
- `session set <id> channels` ✅
- `list --json` output ✅
- `session show --json` output ❌ ← missed

Classic parallel-paths gap: two emitters that should stay in lockstep drifted when one got a new field. Exactly the class of bug the updated `claude-conductor` skill's invariant 7 (parallel-paths audit) was designed to catch in future features.

## Test

`TestSessionShowJSONIncludesChannels` (added to `cmd/agent-deck/channels_cmd_test.go`) — creates a claude session with `--channel plugin:telegram@user/repo`, runs `session show --json`, asserts the `channels` key is present with the expected list. Fails pre-fix (key absent); passes post-fix.

Added to `.claude/release-tests.yaml` for permanent pre-release guard.

## Impact

Low user impact (display bug only — data was never lost). High integrity value (fixes JSON output contract consistency, which downstream automation may depend on).

Closes #615.