### PR TITLE
fix(test): isolate tmux socket — prevent 'go test ./...' from killing live user sessions

### DIFF
--- a/cmd/agent-deck/testmain_test.go
+++ b/cmd/agent-deck/testmain_test.go
@@ -17,6 +17,14 @@ func TestMain(m *testing.M) {
 	// commands operate on their temp repos instead of the real repository.
 	testutil.UnsetGitRepoEnv()
 
+	// Isolate the tmux socket. Without this, cmd-level tests spawn tmux
+	// sessions on the user's default socket and destabilize live agent-deck
+	// sessions. 2026-04-17 incident: go test ./... killed every session in
+	// the personal profile when tests ran on a live host.
+	// See internal/testutil/tmuxenv.go for the full postmortem.
+	cleanupTmux := testutil.IsolateTmuxSocket()
+	defer cleanupTmux()
+
 	// Force _test profile for all tests in this package
 	os.Setenv("AGENTDECK_PROFILE", "_test")
 

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -27,6 +27,14 @@ func TestMain(m *testing.M) {
 	// commands operate on their temp repos instead of the real repository.
 	testutil.UnsetGitRepoEnv()
 
+	// Isolate the tmux socket. Without this, tests spawn tmux sessions on the
+	// user's default socket and destabilize live agent-deck sessions.
+	// 2026-04-17 incident: go test ./... killed every session in the personal
+	// profile when a maintainer ran tests during PR review.
+	// See internal/testutil/tmuxenv.go for the full postmortem.
+	cleanupTmux := testutil.IsolateTmuxSocket()
+	defer cleanupTmux()
+
 	// Force test profile to prevent production data corruption
 	// See CLAUDE.md: "2025-12-11 Incident: Tests with AGENTDECK_PROFILE=work overwrote ALL 36 production sessions"
 	os.Setenv("AGENTDECK_PROFILE", "_test")

--- a/internal/testutil/tmuxenv.go
+++ b/internal/testutil/tmuxenv.go
@@ -1,0 +1,55 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+)
+
+// IsolateTmuxSocket points TMUX_TMPDIR at a unique temp directory for this
+// test process, so that `tmux new-session`, `tmux list-sessions`, and
+// `tmux kill-session` commands spawned by the test suite all operate on an
+// isolated tmux socket — NOT the user's default `/tmp/tmux-<uid>/default`.
+//
+// Why this matters:
+//
+// Before this helper existed, `go test ./...` on a host with active
+// agent-deck sessions (a conductor running, user sessions in flight)
+// caused cascading session death. The test suite creates and kills tmux
+// sessions as part of normal test fixture setup/teardown. Without socket
+// isolation, those operations hit the user's real tmux server:
+//
+//   - New sessions pile up in the user's server, polluting `tmux ls`
+//     output for the duration of the test run.
+//   - The cleanup paths in various tests (kill-session patterns,
+//     post-TestMain cleanup) can kill or destabilize the user's tmux
+//     server, taking down every user session with it.
+//   - Incident on 2026-04-17: a maintainer ran `go test ./...` during
+//     PR review; every user session in the personal profile went to
+//     error state within 24 minutes as the shared tmux server died.
+//
+// Call this from every package-level `TestMain` that touches tmux:
+//
+//	func TestMain(m *testing.M) {
+//	    cleanup := testutil.IsolateTmuxSocket()
+//	    defer cleanup()
+//	    os.Exit(m.Run())
+//	}
+//
+// Returns a cleanup function that removes the temp directory.
+func IsolateTmuxSocket() func() {
+	dir, err := os.MkdirTemp("", "agent-deck-test-tmux-")
+	if err != nil {
+		// If we can't isolate, we still want tests to run — but we
+		// REALLY don't want them on the default socket.
+		// Fall back to a well-known test path that won't collide.
+		dir = fmt.Sprintf("/tmp/agent-deck-test-tmux-fallback-%d", os.Getpid())
+		_ = os.MkdirAll(dir, 0o700)
+	}
+	_ = os.Setenv("TMUX_TMPDIR", dir)
+	return func() {
+		// Best-effort cleanup. Stale tmux sockets in the temp dir are
+		// harmless — kernel removes them when the binding tmux server
+		// exits, and `go test` process exit will release any we spawned.
+		_ = os.RemoveAll(dir)
+	}
+}

--- a/internal/testutil/tmuxenv_test.go
+++ b/internal/testutil/tmuxenv_test.go
@@ -1,0 +1,77 @@
+package testutil
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestIsolateTmuxSocket verifies that the helper sets TMUX_TMPDIR to an
+// isolated directory that is NOT the user's default /tmp/tmux-<uid>/ path,
+// and that cleanup removes the directory.
+func TestIsolateTmuxSocket(t *testing.T) {
+	// Save and restore the env var around this test.
+	orig, had := os.LookupEnv("TMUX_TMPDIR")
+	defer func() {
+		if had {
+			os.Setenv("TMUX_TMPDIR", orig)
+		} else {
+			os.Unsetenv("TMUX_TMPDIR")
+		}
+	}()
+
+	cleanup := IsolateTmuxSocket()
+
+	// After call, TMUX_TMPDIR must be set.
+	dir := os.Getenv("TMUX_TMPDIR")
+	if dir == "" {
+		t.Fatal("IsolateTmuxSocket did not set TMUX_TMPDIR")
+	}
+
+	// CRITICAL: must NOT be the default /tmp/tmux-<uid> location that the
+	// user's real sessions use. That's the whole point of this helper.
+	defaultDefault := "/tmp"
+	if dir == defaultDefault {
+		t.Errorf("IsolateTmuxSocket left TMUX_TMPDIR=%q (the default tmux dir) — this would NOT isolate from user sessions", dir)
+	}
+	if strings.HasPrefix(dir, "/tmp/tmux-") {
+		t.Errorf("IsolateTmuxSocket set TMUX_TMPDIR=%q which is the user's real tmux dir pattern", dir)
+	}
+
+	// The directory should exist.
+	if stat, err := os.Stat(dir); err != nil || !stat.IsDir() {
+		t.Errorf("isolated temp dir %q does not exist or is not a directory: %v", dir, err)
+	}
+
+	// Cleanup removes the directory.
+	cleanup()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("cleanup did not remove %q (stat err=%v)", dir, err)
+	}
+}
+
+// TestIsolateTmuxSocket_UniquePerCall ensures repeated calls return
+// different directories — so parallel test binaries don't collide.
+func TestIsolateTmuxSocket_UniquePerCall(t *testing.T) {
+	// Save and restore
+	orig, had := os.LookupEnv("TMUX_TMPDIR")
+	defer func() {
+		if had {
+			os.Setenv("TMUX_TMPDIR", orig)
+		} else {
+			os.Unsetenv("TMUX_TMPDIR")
+		}
+	}()
+
+	c1 := IsolateTmuxSocket()
+	dir1 := os.Getenv("TMUX_TMPDIR")
+	c1()
+
+	c2 := IsolateTmuxSocket()
+	dir2 := os.Getenv("TMUX_TMPDIR")
+	c2()
+
+	if dir1 == dir2 {
+		t.Errorf("expected unique dirs per call, both got %q", dir1)
+	}
+}

--- a/internal/tmux/testmain_test.go
+++ b/internal/tmux/testmain_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
 )
 
 // skipIfNoTmuxServer skips the test if tmux binary is missing or server isn't running.
@@ -24,6 +26,15 @@ func skipIfNoTmuxServer(t *testing.T) {
 // accidental modification of production data.
 // CRITICAL: This was missing and caused test data to overwrite production sessions!
 func TestMain(m *testing.M) {
+	// Isolate the tmux socket. Without this, `tmux new-session` / `list-sessions` /
+	// `kill-session` calls in test setup & cleanup hit the user's default
+	// /tmp/tmux-<uid>/default socket — destabilizing their live sessions.
+	// 2026-04-17 incident: go test ./... killed every session in the personal
+	// profile when a maintainer ran tests during PR review.
+	// See internal/testutil/tmuxenv.go for the full postmortem.
+	cleanupTmux := testutil.IsolateTmuxSocket()
+	defer cleanupTmux()
+
 	// Force _test profile for all tests in this package
 	os.Setenv("AGENTDECK_PROFILE", "_test")
 


### PR DESCRIPTION
Closes #622.

## Summary

Adds `testutil.IsolateTmuxSocket()` helper that points `TMUX_TMPDIR` at a per-test-process temp directory. Wires it into every package-level `TestMain` that touches tmux. Result: `go test ./...` is now safe to run on a live agent-deck host without destabilizing user sessions.

## Context — 2026-04-17 incident

Full postmortem in the companion issue (#622) and in the docstring of `internal/testutil/tmuxenv.go`. TL;DR: a maintainer ran `go test ./...` during PR review; within 24 minutes every session in the user's personal profile was in `error` state because the shared tmux server destabilized as tests created/killed sessions on the default socket.

## Files changed

- `internal/testutil/tmuxenv.go` — **NEW** helper `IsolateTmuxSocket()`
- `internal/testutil/tmuxenv_test.go` — **NEW** unit tests (2 cases)
- `internal/tmux/testmain_test.go` — wire helper into TestMain
- `internal/session/testmain_test.go` — wire helper into TestMain
- `cmd/agent-deck/testmain_test.go` — wire helper into TestMain

## Test plan

- `go test ./internal/testutil/` — PASS locally (2 tests: isolation check + uniqueness)
- Cannot locally run `go test ./...` for obvious reasons (we'd be testing by reproducing the bug). CI will verify nothing breaks.
- Post-merge verification: a maintainer running `go test ./...` on a live host should see zero session deaths. That is the true acceptance criterion.

## Design choices

- **Helper in `internal/testutil`** — already contains `UnsetGitRepoEnv()` with similar "protect the developer's environment from test side-effects" intent. Natural home.
- **`TMUX_TMPDIR` (not `tmux -L`)** — setting the env var once in `TestMain` covers EVERY subsequent `exec.Command(\"tmux\", ...)` in the test process automatically, without having to touch each test fixture. Using `-L` per-invocation would require hundreds of call-site changes.
- **Returns a cleanup func** — tests get best-effort temp dir removal on teardown. Stale sockets in the temp dir are harmless; kernel cleans them up when tmux servers exit.
- **Docstring records the incident** — future maintainers reading this code will know why it exists and what it prevents. Follows the repo's existing pattern of `// See CLAUDE.md: '2025-12-11 Incident: ...'` comments in the testmain files.

## Backward compatibility

Pure additive. Tests that already used `-L` isolation (e.g., `session_persistence_test.go`) are unaffected — they set their own sockets inside isolated test funcs. CI runners have no live agent-deck sessions, so their previous default-socket behavior happened to work; they now get isolation too as a side benefit.