### PR TITLE
test(git): regression test for RemoveWorktree force-fallback

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -687,6 +687,56 @@ func TestRemoveWorktree(t *testing.T) {
 			t.Error("expected error for non-existent worktree")
 		}
 	})
+
+	// Regression test for the force-fallback path added in cd46219.
+	// When force=true and `git worktree remove --force` still fails,
+	// RemoveWorktree must fall back to os.RemoveAll + PruneWorktrees.
+	t.Run("force falls back to direct removal when git refuses", func(t *testing.T) {
+		dir := t.TempDir()
+		createTestRepo(t, dir)
+
+		// wtA: target of RemoveWorktree. Deleting its admin metadata under
+		// <repoDir>/.git/worktrees/<name>/ makes `git worktree remove --force`
+		// exit non-zero ("is not a working tree"). The worktree directory
+		// itself stays on disk, so the fallback's os.RemoveAll has real work.
+		wtA := filepath.Join(t.TempDir(), "wtA")
+		if err := CreateWorktree(dir, wtA, "feature-a"); err != nil {
+			t.Fatalf("create wtA: %v", err)
+		}
+		if err := os.RemoveAll(filepath.Join(dir, ".git", "worktrees", filepath.Base(wtA))); err != nil {
+			t.Fatalf("deregister wtA: %v", err)
+		}
+
+		// wtB: directory manually removed, admin entry left dangling.
+		// Gives PruneWorktrees real work so a future refactor that drops
+		// the prune call would fail this test.
+		wtB := filepath.Join(t.TempDir(), "wtB")
+		if err := CreateWorktree(dir, wtB, "feature-b"); err != nil {
+			t.Fatalf("create wtB: %v", err)
+		}
+		if err := os.RemoveAll(wtB); err != nil {
+			t.Fatalf("remove wtB dir: %v", err)
+		}
+
+		if err := RemoveWorktree(dir, wtA, true); err != nil {
+			t.Fatalf("RemoveWorktree(force=true) should succeed via fallback: %v", err)
+		}
+
+		// os.RemoveAll ran: wtA is gone on disk.
+		if _, err := os.Stat(wtA); !os.IsNotExist(err) {
+			t.Errorf("wtA should be removed, stat err=%v", err)
+		}
+
+		// PruneWorktrees ran: wtB's dangling admin entry is swept, leaving
+		// only the main repo worktree.
+		worktrees, err := ListWorktrees(dir)
+		if err != nil {
+			t.Fatalf("list worktrees: %v", err)
+		}
+		if len(worktrees) != 1 {
+			t.Errorf("expected 1 worktree (main only) after prune, got %d: %+v", len(worktrees), worktrees)
+		}
+	})
 }
 
 func TestWorktreeStruct(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a regression test for the `os.RemoveAll` + `PruneWorktrees` fallback in `RemoveWorktree` introduced in cd46219 (PR #606). That fallback shipped without test coverage; this subtest closes the gap.

## How the test triggers the fallback

- Creates worktree `wtA` and then deletes its admin metadata under `<repoDir>/.git/worktrees/<name>/`. `git worktree remove --force wtA` exits non-zero with `'... wtA' is not a working tree`, forcing the fallback branch.
- The worktree directory itself stays on disk, so `os.RemoveAll(worktreePath)` has real work.
- A second worktree `wtB` has its directory removed but its admin entry left dangling. After the fallback runs, `ListWorktrees(dir)` is expected to contain only the main repo — if a future refactor drops the `PruneWorktrees` call, `wtB`'s dangling admin entry survives and the test fails.

Note on the alternative I tried first: nesting a `.git` directory inside the worktree (to simulate node_modules) does NOT make `git worktree remove --force` fail on git 2.50.1; git happily deletes nested `.git` dirs with `--force`, which would silently skip the fallback and produce a false-green test. The admin-metadata trigger is portable and failure-deterministic.

## Verification

- `go test ./internal/git/ -run TestRemoveWorktree -race -count=1 -v` — all four subtests pass, including the new `force_falls_back_to_direct_removal_when_git_refuses`.
- Mutation sanity check: temporarily removed the `os.RemoveAll` + `PruneWorktrees` block in `internal/git/git.go`. The new subtest failed with `'... wtA' is not a working tree: exit status 128`, proving it actually exercises the fallback. Restored before committing (production code byte-identical to current main).

No production code changes in this PR — test-only.

## Test plan

- [x] `go test ./internal/git/ -run TestRemoveWorktree -race -count=1` passes
- [x] Mutation-disable the fallback → new subtest fails as expected
- [x] Full `internal/git/` package test run is green with `-race`