### PR TITLE
fix(tmux): split flushDetachInput by platform to fix macOS build

### DIFF
--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/asheshgoplani/agent-deck/internal/termreply"
 	"github.com/creack/pty"
-	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 )
 
@@ -71,10 +70,6 @@ func waitForAttachOutputDrain(outputDone <-chan struct{}, timeout time.Duration)
 	case <-timer.C:
 		return false, time.Since(start)
 	}
-}
-
-func flushDetachInput(fd int) error {
-	return unix.IoctlSetInt(fd, unix.TCFLSH, unix.TCIFLUSH)
 }
 
 // Attach attaches to the tmux session with full PTY support.

--- a/internal/tmux/pty_flush_darwin.go
+++ b/internal/tmux/pty_flush_darwin.go
@@ -1,0 +1,16 @@
+//go:build darwin
+
+package tmux
+
+import "golang.org/x/sys/unix"
+
+// FREAD from <sys/fcntl.h>; not re-exported by golang.org/x/sys/unix
+// on darwin. Stable value across BSD-derived systems.
+const darwinFREAD = 0x1
+
+// Darwin's ioctl for flushing tty queues is TIOCFLUSH; the second
+// argument selects which queue. FREAD flushes input — equivalent to
+// Linux's TCFLSH + TCIFLUSH.
+func flushDetachInput(fd int) error {
+	return unix.IoctlSetInt(fd, unix.TIOCFLUSH, darwinFREAD)
+}

--- a/internal/tmux/pty_flush_linux.go
+++ b/internal/tmux/pty_flush_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package tmux
+
+import "golang.org/x/sys/unix"
+
+func flushDetachInput(fd int) error {
+	return unix.IoctlSetInt(fd, unix.TCFLSH, unix.TCIFLUSH)
+}


### PR DESCRIPTION
## Summary

The `flushDetachInput` helper added in #588 (119c55d) uses `unix.TCFLSH`, which only exists on Linux. As of v1.7.4 the project no longer builds on darwin:

```
internal/tmux/pty.go:77:35: undefined: unix.TCFLSH
```

Split the helper into two platform-specific files:

- `internal/tmux/pty_flush_linux.go` — unchanged Linux impl (`TCFLSH` + `TCIFLUSH`).
- `internal/tmux/pty_flush_darwin.go` — darwin equivalent (`TIOCFLUSH` + `FREAD`).

Darwin's `TIOCFLUSH` ioctl selects which tty queue to flush via its second argument; passing `FREAD` (`0x1`) flushes the input queue — semantically identical to Linux's `TCFLSH` + `TCIFLUSH`. Since `golang.org/x/sys/unix` doesn't re-export `FREAD` on darwin, the constant is defined locally with its stable BSD value from `<sys/fcntl.h>`.

## Why

Without this, `make build` fails out of the box on macOS. The preceding build tag on `pty.go` (`//go:build !windows`) suggests cross-Unix support was intended.

## Test plan

- [x] `make build` succeeds on darwin (arm64).
- [x] `go build ./...` succeeds on darwin.
- [x] No test-case rewrites needed; the existing `internal/tmux` unit tests that don't require systemd still pass.
- [ ] Linux CI continues to pass (no code-path change on Linux — same `TCFLSH` + `TCIFLUSH` pair, just moved into `pty_flush_linux.go`).