### PR TITLE
feat(update): support installing a specific version

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2374,8 +2374,9 @@ func handleUpdateToSpecificVersion(requested string, checkOnly bool) {
 	}
 
 	drainStdin()
+	defaultYes := cmp <= 0
 	prompt := fmt.Sprintf("\nInstall v%s now? [Y/n] ", targetVersion)
-	if cmp > 0 {
+	if !defaultYes {
 		prompt = fmt.Sprintf("\nDowngrade to v%s now? [y/N] ", targetVersion)
 	}
 	fmt.Print(prompt)
@@ -2383,12 +2384,7 @@ func handleUpdateToSpecificVersion(requested string, checkOnly bool) {
 	response, _ := reader.ReadString('\n')
 	response = strings.TrimSpace(strings.ToLower(response))
 
-	confirmed := false
-	if cmp > 0 {
-		confirmed = response == "y" || response == "yes"
-	} else {
-		confirmed = response == "" || response == "y" || response == "yes"
-	}
+	confirmed := response == "y" || response == "yes" || (defaultYes && response == "")
 	if !confirmed {
 		fmt.Println("Update cancelled.")
 		return

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2206,6 +2206,7 @@ func handleProfileSetDefault(out *CLIOutput, name string) {
 func handleUpdate(args []string) {
 	fs := flag.NewFlagSet("update", flag.ExitOnError)
 	checkOnly := fs.Bool("check", false, "Only check for updates, don't install")
+	targetVersion := fs.String("version", "", "Install a specific released version (e.g. 1.7.3); may be a downgrade")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck update [options]")
@@ -2216,12 +2217,18 @@ func handleUpdate(args []string) {
 		fs.PrintDefaults()
 		fmt.Println()
 		fmt.Println("Examples:")
-		fmt.Println("  agent-deck update           # Check and install if available")
-		fmt.Println("  agent-deck update --check   # Only check, don't install")
+		fmt.Println("  agent-deck update              # Check and install latest if available")
+		fmt.Println("  agent-deck update --check      # Only check, don't install")
+		fmt.Println("  agent-deck update --version 1.7.3  # Install a specific version (may downgrade)")
 	}
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)
+	}
+
+	if strings.TrimSpace(*targetVersion) != "" {
+		handleUpdateToSpecificVersion(*targetVersion, *checkOnly)
+		return
 	}
 
 	fmt.Printf("Agent Deck v%s\n", Version)
@@ -2311,6 +2318,95 @@ func handleUpdate(args []string) {
 
 	// Offer to update remotes
 	updateRemotesAfterLocalUpdate(info.LatestVersion)
+}
+
+// handleUpdateToSpecificVersion installs a user-specified release version.
+// Unlike the default update flow, this bypasses the "is this newer?" check so
+// callers can reinstall or downgrade to a prior release on purpose.
+func handleUpdateToSpecificVersion(requested string, checkOnly bool) {
+	fmt.Printf("Agent Deck v%s\n", Version)
+
+	normalized := update.NormalizeReleaseTag(requested)
+	if normalized == "" {
+		fmt.Println("Error: --version requires a non-empty version (e.g. 1.7.3)")
+		os.Exit(1)
+	}
+	targetVersion := strings.TrimPrefix(normalized, "v")
+
+	installPath, homebrewUpgradeCmd, homebrewManaged, hbErr := update.DetectHomebrewManagedInstall()
+	if hbErr != nil {
+		homebrewManaged = false
+	}
+	if homebrewManaged {
+		fmt.Printf("\nHomebrew-managed install detected at %s\n", installPath)
+		fmt.Printf("Pinning to a specific version is not supported via this command.\n")
+		fmt.Printf("Use Homebrew directly, or run `%s` for the latest.\n", homebrewUpgradeCmd)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Fetching release %s...\n", normalized)
+	release, err := update.FetchReleaseByTag(normalized)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	downloadURL := update.GetAssetURLForPlatform(release, runtime.GOOS, runtime.GOARCH)
+	if downloadURL == "" {
+		fmt.Printf("Error: release %s has no binary for %s/%s\n", normalized, runtime.GOOS, runtime.GOARCH)
+		os.Exit(1)
+	}
+
+	cmp := update.CompareVersions(Version, targetVersion)
+	switch {
+	case cmp == 0:
+		fmt.Printf("\n↻ Reinstalling v%s (current = requested)\n", targetVersion)
+	case cmp < 0:
+		fmt.Printf("\n⬆ Installing v%s → v%s\n", Version, targetVersion)
+	default:
+		fmt.Printf("\n⬇ Downgrading v%s → v%s\n", Version, targetVersion)
+	}
+	fmt.Printf("  Release: %s\n", release.HTMLURL)
+
+	if checkOnly {
+		fmt.Println("\nRun without --check to install.")
+		return
+	}
+
+	drainStdin()
+	prompt := fmt.Sprintf("\nInstall v%s now? [Y/n] ", targetVersion)
+	if cmp > 0 {
+		prompt = fmt.Sprintf("\nDowngrade to v%s now? [y/N] ", targetVersion)
+	}
+	fmt.Print(prompt)
+	reader := bufio.NewReader(os.Stdin)
+	response, _ := reader.ReadString('\n')
+	response = strings.TrimSpace(strings.ToLower(response))
+
+	confirmed := false
+	if cmp > 0 {
+		confirmed = response == "y" || response == "yes"
+	} else {
+		confirmed = response == "" || response == "y" || response == "yes"
+	}
+	if !confirmed {
+		fmt.Println("Update cancelled.")
+		return
+	}
+
+	fmt.Println()
+	if err := update.PerformUpdate(downloadURL); err != nil {
+		fmt.Printf("Error installing v%s: %v\n", targetVersion, err)
+		os.Exit(1)
+	}
+
+	if err := update.UpdateBridgePy(); err != nil {
+		fmt.Printf("Warning: Failed to update bridge.py: %v\n", err)
+		fmt.Println("  You can manually refresh it with: agent-deck conductor setup <name>")
+	}
+
+	fmt.Printf("\n✓ Installed v%s\n", targetVersion)
+	fmt.Println("  Restart agent-deck to use this version.")
 }
 
 func runHomebrewUpgradeWithRefresh(homebrewUpgradeCmd string) error {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -32,6 +32,9 @@ const (
 // checkInterval stores the configurable interval (set via SetCheckInterval)
 var checkInterval = DefaultCheckInterval
 
+// apiBaseURL is the base URL for GitHub API calls. Overridable in tests.
+var apiBaseURL = "https://api.github.com"
+
 // SetCheckInterval sets the update check interval from config
 func SetCheckInterval(hours int) {
 	if hours > 0 {
@@ -125,7 +128,7 @@ func saveCache(cache *UpdateCache) error {
 
 // fetchLatestRelease fetches the latest release from GitHub
 func fetchLatestRelease() (*Release, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", GitHubRepo)
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", apiBaseURL, GitHubRepo)
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(url)
@@ -169,6 +172,51 @@ func GetAssetURLForPlatform(release *Release, goos, goarch string) string {
 // FetchLatestRelease fetches the latest release from GitHub (exported for remote update).
 func FetchLatestRelease() (*Release, error) {
 	return fetchLatestRelease()
+}
+
+// NormalizeReleaseTag ensures a version string is prefixed with "v" so it matches
+// GitHub release tags (e.g., "1.7.4" -> "v1.7.4", "v1.7.4" -> "v1.7.4").
+func NormalizeReleaseTag(version string) string {
+	trimmed := strings.TrimSpace(version)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "v") || strings.HasPrefix(trimmed, "V") {
+		return "v" + strings.TrimPrefix(strings.TrimPrefix(trimmed, "v"), "V")
+	}
+	return "v" + trimmed
+}
+
+// FetchReleaseByTag fetches a specific release from GitHub by its tag.
+// The tag may be supplied with or without the leading "v".
+func FetchReleaseByTag(tag string) (*Release, error) {
+	normalized := NormalizeReleaseTag(tag)
+	if normalized == "" {
+		return nil, fmt.Errorf("empty release tag")
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/releases/tags/%s", apiBaseURL, GitHubRepo, normalized)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch release %s: %w", normalized, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("release %s not found on GitHub", normalized)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned status %d for release %s", resp.StatusCode, normalized)
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to parse release %s: %w", normalized, err)
+	}
+
+	return &release, nil
 }
 
 // DownloadAndExtractBinary downloads a release tarball and returns the binary bytes.

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -177,12 +177,9 @@ func FetchLatestRelease() (*Release, error) {
 // NormalizeReleaseTag ensures a version string is prefixed with "v" so it matches
 // GitHub release tags (e.g., "1.7.4" -> "v1.7.4", "v1.7.4" -> "v1.7.4").
 func NormalizeReleaseTag(version string) string {
-	trimmed := strings.TrimSpace(version)
+	trimmed := strings.TrimLeft(strings.TrimSpace(version), "vV")
 	if trimmed == "" {
 		return ""
-	}
-	if strings.HasPrefix(trimmed, "v") || strings.HasPrefix(trimmed, "V") {
-		return "v" + strings.TrimPrefix(strings.TrimPrefix(trimmed, "v"), "V")
 	}
 	return "v" + trimmed
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -213,44 +213,27 @@ func TestNormalizeReleaseTag(t *testing.T) {
 }
 
 func TestFetchReleaseByTag(t *testing.T) {
+	rel := Release{
+		TagName: "v1.7.4",
+		Name:    "v1.7.4",
+		HTMLURL: "https://example/releases/v1.7.4",
+		Assets: []Asset{{
+			Name:               "agent-deck_1.7.4_darwin_arm64.tar.gz",
+			BrowserDownloadURL: "https://example/download/agent-deck_1.7.4_darwin_arm64.tar.gz",
+			Size:               123,
+		}},
+	}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
-		// path shape: /repos/{owner}/{repo}/releases/tags/{tag}
-		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
-		if len(parts) != 5 || parts[3] != "tags" {
-			http.NotFound(w, r)
-			return
-		}
-		tag := parts[4]
-		if tag != "v1.7.4" {
-			http.NotFound(w, r)
-			return
-		}
-		rel := Release{
-			TagName: "v1.7.4",
-			Name:    "v1.7.4",
-			HTMLURL: "https://example/releases/v1.7.4",
-			Assets: []Asset{
-				{
-					Name:               "agent-deck_1.7.4_darwin_arm64.tar.gz",
-					BrowserDownloadURL: "https://example/download/agent-deck_1.7.4_darwin_arm64.tar.gz",
-					Size:               123,
-				},
-			},
-		}
+	mux.HandleFunc("GET /repos/"+GitHubRepo+"/releases/tags/v1.7.4", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(rel)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	origRepo := GitHubRepo
 	origURL := apiBaseURL
 	apiBaseURL = srv.URL
-	t.Cleanup(func() {
-		apiBaseURL = origURL
-		_ = origRepo
-	})
+	t.Cleanup(func() { apiBaseURL = origURL })
 
 	t.Run("accepts plain semver", func(t *testing.T) {
 		rel, err := FetchReleaseByTag("1.7.4")

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,6 +1,9 @@
 package update
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -187,6 +190,93 @@ func TestUpdateBridgePy_UsesEmbeddedTemplateAndBacksUpExistingFile(t *testing.T)
 	require.NoError(t, err)
 	assert.True(t, strings.Contains(string(newContent), "Conductor Bridge: Telegram & Slack"),
 		"bridge.py should be refreshed from the embedded multi-platform template")
+}
+
+func TestNormalizeReleaseTag(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"whitespace", "  ", ""},
+		{"plain semver", "1.7.4", "v1.7.4"},
+		{"already prefixed", "v1.7.4", "v1.7.4"},
+		{"uppercase prefix", "V1.7.4", "v1.7.4"},
+		{"surrounding whitespace", "  1.7.4  ", "v1.7.4"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NormalizeReleaseTag(tt.input))
+		})
+	}
+}
+
+func TestFetchReleaseByTag(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		// path shape: /repos/{owner}/{repo}/releases/tags/{tag}
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		if len(parts) != 5 || parts[3] != "tags" {
+			http.NotFound(w, r)
+			return
+		}
+		tag := parts[4]
+		if tag != "v1.7.4" {
+			http.NotFound(w, r)
+			return
+		}
+		rel := Release{
+			TagName: "v1.7.4",
+			Name:    "v1.7.4",
+			HTMLURL: "https://example/releases/v1.7.4",
+			Assets: []Asset{
+				{
+					Name:               "agent-deck_1.7.4_darwin_arm64.tar.gz",
+					BrowserDownloadURL: "https://example/download/agent-deck_1.7.4_darwin_arm64.tar.gz",
+					Size:               123,
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rel)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	origRepo := GitHubRepo
+	origURL := apiBaseURL
+	apiBaseURL = srv.URL
+	t.Cleanup(func() {
+		apiBaseURL = origURL
+		_ = origRepo
+	})
+
+	t.Run("accepts plain semver", func(t *testing.T) {
+		rel, err := FetchReleaseByTag("1.7.4")
+		require.NoError(t, err)
+		require.NotNil(t, rel)
+		assert.Equal(t, "v1.7.4", rel.TagName)
+		assert.Equal(t, "https://example/download/agent-deck_1.7.4_darwin_arm64.tar.gz",
+			GetAssetURLForPlatform(rel, "darwin", "arm64"))
+	})
+
+	t.Run("accepts prefixed tag", func(t *testing.T) {
+		rel, err := FetchReleaseByTag("v1.7.4")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.7.4", rel.TagName)
+	})
+
+	t.Run("missing tag", func(t *testing.T) {
+		_, err := FetchReleaseByTag("99.0.0")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("empty tag", func(t *testing.T) {
+		_, err := FetchReleaseByTag("  ")
+		require.Error(t, err)
+	})
 }
 
 func TestHomebrewUpgradeHint(t *testing.T) {


### PR DESCRIPTION
Add `agent-deck update --version <X.Y.Z>` to install a pinned GitHub release instead of always pulling the latest. The flag accepts either `1.7.3` or `v1.7.3`, fetches the release by tag, and installs the asset matching the current platform. Direct and Homebrew-managed installs are distinguished — Homebrew pinning is refused with a pointer to `brew` tooling.

- new `update.NormalizeReleaseTag` and `update.FetchReleaseByTag` helpers
- `--version` bypasses the "is this newer?" gate so reinstall and downgrade work; downgrade requires an explicit `y` confirmation
- factored the GitHub API base URL into a package var so the new HTTP paths are covered by tests via httptest