### PR TITLE
fix(makefile): update air module path to air-verse/air

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,8 @@ clean:
 
 # Development with auto-reload
 dev:
-	@which air > /dev/null || go install github.com/cosmtrek/air@latest
-	air
+	@which air > /dev/null || go install github.com/air-verse/air@latest
+	$(shell go env GOPATH)/bin/air
 
 # Run tests (with race detector)
 test:


### PR DESCRIPTION
## Summary

The `cosmtrek/air` module was renamed to `air-verse/air` some time ago. The old import path still resolves today (GitHub redirects), but a fresh `go install github.com/cosmtrek/air@latest` prints a deprecation warning and the name will eventually stop working.

While here, also invoke the binary via `$(shell go env GOPATH)/bin/air` so `make dev` works on setups where `$GOPATH/bin` isn't on `PATH` (common in CI images and fresh dev environments — the preceding `which air` check can pass because `go install` just put it there, but the plain `air` invocation then fails to find it without a shell rehash).

## Why

- Forward-compatibility: get ahead of the eventual removal of the deprecated path.
- Removes a deprecation warning on first `make dev`.
- Makes `make dev` work on environments where `$GOPATH/bin` isn't on `PATH`.

## Test plan

- [x] `make dev` triggers the install path when `air` is absent and starts correctly.
- [x] Re-running `make dev` with air already installed launches it via the explicit path.
- [x] No other Makefile targets reference `air`.