### PR TITLE
fix: explicit conductor/group TOML beats CLAUDE_CONFIG_DIR env var (v1.7.6)

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -172,3 +172,72 @@ tests:
     command: go test ./cmd/agent-deck/ -run TestSessionShowJSONIncludesChannels -count=1
       -timeout 90s -v
     expected: pass
+- id: fix-config-dir-priority-group-beats-env
+  added: '2026-04-17'
+  task: fix-config-dir-priority
+  file: internal/session/conductorconfig_test.go
+  test_name: TestConductorConfig_GroupBeatsEnv
+  purpose: "[groups.<g>.claude].config_dir wins over CLAUDE_CONFIG_DIR env var \u2014\
+    \ explicit TOML override is more specific than shell-wide default (2026-04-17\
+    \ priority-inversion fix)."
+  source: user-report-2026-04-17
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestConductorConfig_GroupBeatsEnv -count=1
+      -v
+    expected: pass
+- id: fix-config-dir-priority-conductor-beats-env
+  added: '2026-04-17'
+  task: fix-config-dir-priority
+  file: internal/session/conductorconfig_test.go
+  test_name: TestConductorConfig_PrecedenceConductorBeatsEnv
+  purpose: "[conductors.<n>.claude].config_dir wins over CLAUDE_CONFIG_DIR env var\
+    \ \u2014 flipped from old TestConductorConfig_PrecedenceEnvBeatsConductor which\
+    \ codified the buggy env-first order."
+  source: user-report-2026-04-17
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestConductorConfig_PrecedenceConductorBeatsEnv
+      -count=1 -v
+    expected: pass
+- id: fix-config-dir-priority-env-still-beats-profile
+  added: '2026-04-17'
+  task: fix-config-dir-priority
+  file: internal/session/conductorconfig_test.go
+  test_name: TestConductorConfig_EnvBeatsProfile
+  purpose: "Regression guard: env var STILL beats [profiles.<p>.claude].config_dir.\
+    \ Profile is shell-wide-ish and less specific than env; must stay below env in\
+    \ the new priority order."
+  source: user-report-2026-04-17
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestConductorConfig_EnvBeatsProfile
+      -count=1 -v
+    expected: pass
+- id: fix-config-dir-priority-env-still-beats-global
+  added: '2026-04-17'
+  task: fix-config-dir-priority
+  file: internal/session/conductorconfig_test.go
+  test_name: TestConductorConfig_EnvBeatsGlobal
+  purpose: 'Regression guard: env var STILL beats [claude].config_dir top-level global.
+    Global is shell-wide fallback; env remains stronger.'
+  source: user-report-2026-04-17
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestConductorConfig_EnvBeatsGlobal -count=1
+      -v
+    expected: pass
+- id: fix-config-dir-priority-source-label-group
+  added: '2026-04-17'
+  task: fix-config-dir-priority
+  file: internal/session/conductorconfig_test.go
+  test_name: TestConductorConfig_SourceLabelGroupWhenGroupBeatsEnv
+  purpose: "GetClaudeConfigDirSourceForInstance must return source=\"group\" when\
+    \ group TOML beats env \u2014 parallel-paths audit for the (path, source) getter\
+    \ alongside the primary resolver."
+  source: user-report-2026-04-17
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestConductorConfig_SourceLabelGroupWhenGroupBeatsEnv
+      -count=1 -v
+    expected: pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.6] - 2026-04-17
+
+### Fixed
+- **Priority inversion on `CLAUDE_CONFIG_DIR`**: explicit `[conductors.<name>.claude]` and `[groups."<name>".claude]` TOML overrides now beat the shell-wide `CLAUDE_CONFIG_DIR` env var. Previously, developer shells that exported `CLAUDE_CONFIG_DIR` via profile aliases (`cdp`/`cdw`) silently shadowed every per-conductor/per-group override — making config.toml overrides unreliable for the exact users most likely to use them. Profile/global fallbacks remain weaker than env (they're shell-wide too). Scope: `GetClaudeConfigDirForInstance`, `GetClaudeConfigDirSourceForInstance`, `IsClaudeConfigDirExplicitForInstance` in `internal/session/claude.go`. Group-less variants unchanged.
+- **Web terminal `TestTmuxPTYBridgeResize` -race flake**: added `ptmxMu sync.RWMutex` protecting the PTY file handle against concurrent Close/Resize. Previously intermittent on GH Actions release runs (v1.7.4, v1.7.5).
+
 ## [1.5.4] - 2026-04-16
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.5" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.6" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -340,29 +340,34 @@ func conductorNameFromInstance(inst *Instance) string {
 	return name
 }
 
-// GetClaudeConfigDirForInstance returns the Claude config directory,
-// extending GetClaudeConfigDirForGroup with a [conductors.<name>] branch
-// that sits between the env-var check and the group check.
+// GetClaudeConfigDirForInstance returns the Claude config directory for
+// this Instance. Per-instance TOML overrides (conductor, group) beat the
+// shell-wide CLAUDE_CONFIG_DIR env var; less-specific config (profile,
+// global) falls to env and below.
 //
 // Priority (most-specific → least-specific):
 //
-//  1. CLAUDE_CONFIG_DIR env var
-//  2. [conductors.<name>.claude].config_dir — NEW (CFG-08), consulted only when
+//  1. [conductors.<name>.claude].config_dir — consulted only when
 //     Instance.Title starts with "conductor-"
-//  3. [groups."<group>".claude].config_dir   — PR #578 (CFG-01)
+//  2. [groups."<group>".claude].config_dir
+//  3. CLAUDE_CONFIG_DIR env var
 //  4. [profiles.<profile>.claude].config_dir
 //  5. [claude].config_dir
 //  6. ~/.claude
 //
+// Why conductor/group beat env (fix-config-dir-priority, 2026-04-17):
+// developer shells commonly export CLAUDE_CONFIG_DIR via aliases (cdp,
+// cdw) to select a profile. When the user then writes an explicit
+// [conductors.foo.claude] or [groups.bar.claude] block in config.toml,
+// that TOML block is scoped to exactly that conductor/group and is
+// semantically MORE specific than a shell-wide default. The old
+// env-first order silently shadowed every TOML override. Profile/global
+// remain beaten by env because they're shell-wide too (less specific
+// than env in intent).
+//
 // Callers pass the *Instance; conductor name is derived via
-// conductorNameFromInstance. Backward compat: non-conductor sessions
-// (Title without "conductor-" prefix) resolve identically to
-// GetClaudeConfigDirForGroup(inst.GroupPath).
+// conductorNameFromInstance.
 func GetClaudeConfigDirForInstance(inst *Instance) string {
-	if envDir := os.Getenv("CLAUDE_CONFIG_DIR"); envDir != "" {
-		return ExpandPath(envDir)
-	}
-
 	userConfig, _ := LoadUserConfig()
 	if userConfig != nil {
 		if name := conductorNameFromInstance(inst); name != "" {
@@ -377,6 +382,13 @@ func GetClaudeConfigDirForInstance(inst *Instance) string {
 		if groupDir := userConfig.GetGroupClaudeConfigDir(groupPath); groupDir != "" {
 			return groupDir
 		}
+	}
+
+	if envDir := os.Getenv("CLAUDE_CONFIG_DIR"); envDir != "" {
+		return ExpandPath(envDir)
+	}
+
+	if userConfig != nil {
 		profile := GetEffectiveProfile("")
 		if profileDir := userConfig.GetProfileClaudeConfigDir(profile); profileDir != "" {
 			return profileDir
@@ -391,14 +403,11 @@ func GetClaudeConfigDirForInstance(inst *Instance) string {
 }
 
 // GetClaudeConfigDirSourceForInstance returns the resolved path and the
-// priority-level label. Extends GetClaudeConfigDirSourceForGroup with a
-// "conductor" branch. Keep in sync with GetClaudeConfigDirForInstance —
+// priority-level label. Keep in sync with GetClaudeConfigDirForInstance —
 // both functions must change together if the priority chain ever changes.
+// Source labels: "conductor", "group", "env", "profile", "global",
+// "default".
 func GetClaudeConfigDirSourceForInstance(inst *Instance) (path, source string) {
-	if envDir := os.Getenv("CLAUDE_CONFIG_DIR"); envDir != "" {
-		return ExpandPath(envDir), "env"
-	}
-
 	userConfig, _ := LoadUserConfig()
 	if userConfig != nil {
 		if name := conductorNameFromInstance(inst); name != "" {
@@ -413,6 +422,13 @@ func GetClaudeConfigDirSourceForInstance(inst *Instance) (path, source string) {
 		if groupDir := userConfig.GetGroupClaudeConfigDir(groupPath); groupDir != "" {
 			return groupDir, "group"
 		}
+	}
+
+	if envDir := os.Getenv("CLAUDE_CONFIG_DIR"); envDir != "" {
+		return ExpandPath(envDir), "env"
+	}
+
+	if userConfig != nil {
 		profile := GetEffectiveProfile("")
 		if profileDir := userConfig.GetProfileClaudeConfigDir(profile); profileDir != "" {
 			return profileDir, "profile"
@@ -426,13 +442,11 @@ func GetClaudeConfigDirSourceForInstance(inst *Instance) (path, source string) {
 	return filepath.Join(home, ".claude"), "default"
 }
 
-// IsClaudeConfigDirExplicitForInstance mirrors IsClaudeConfigDirExplicitForGroup
-// with the conductor-block branch. Returns true if ANY priority level sets a
-// config dir for this Instance.
+// IsClaudeConfigDirExplicitForInstance returns true if ANY priority level
+// sets a config dir for this Instance. The priority CHAIN is the same as
+// GetClaudeConfigDirForInstance but the boolean is order-insensitive —
+// explicit is explicit regardless of which layer wins.
 func IsClaudeConfigDirExplicitForInstance(inst *Instance) bool {
-	if os.Getenv("CLAUDE_CONFIG_DIR") != "" {
-		return true
-	}
 	userConfig, _ := LoadUserConfig()
 	if userConfig != nil {
 		if name := conductorNameFromInstance(inst); name != "" {
@@ -447,6 +461,11 @@ func IsClaudeConfigDirExplicitForInstance(inst *Instance) bool {
 		if userConfig.GetGroupClaudeConfigDir(groupPath) != "" {
 			return true
 		}
+	}
+	if os.Getenv("CLAUDE_CONFIG_DIR") != "" {
+		return true
+	}
+	if userConfig != nil {
 		profile := GetEffectiveProfile("")
 		if userConfig.GetProfileClaudeConfigDir(profile) != "" {
 			return true

--- a/internal/session/conductorconfig_test.go
+++ b/internal/session/conductorconfig_test.go
@@ -123,22 +123,111 @@ config_dir = "/tmp/group-loses"
 	}
 }
 
-// TestConductorConfig_PrecedenceEnvBeatsConductor locks CFG-11 test 3:
-// the CLAUDE_CONFIG_DIR env var beats a [conductors.<name>.claude] override.
-func TestConductorConfig_PrecedenceEnvBeatsConductor(t *testing.T) {
+// TestConductorConfig_PrecedenceConductorBeatsEnv codifies the CORRECTED
+// priority (fix-config-dir-priority, 2026-04-17): an explicit
+// [conductors.<name>.claude].config_dir TOML override beats a shell-wide
+// CLAUDE_CONFIG_DIR export.
+//
+// This test REPLACES an earlier TestConductorConfig_PrecedenceEnvBeatsConductor
+// that codified the INCORRECT env-first behavior. That priority was wrong
+// because developer shells often export CLAUDE_CONFIG_DIR via aliases
+// (cdp, cdw) to select a profile, and that export shadowed every explicit
+// per-conductor TOML block the user wrote — making config.toml overrides
+// silently useless. The TOML block is scoped to this conductor; the env
+// var is a shell-wide default. More specific wins.
+func TestConductorConfig_PrecedenceConductorBeatsEnv(t *testing.T) {
 	tmpHome := setupConductorTest(t)
-	_ = os.Setenv("CLAUDE_CONFIG_DIR", "/tmp/env-wins")
+	_ = os.Setenv("CLAUDE_CONFIG_DIR", "/tmp/env-loses")
 	// setupConductorTest's t.Cleanup already restores CLAUDE_CONFIG_DIR.
 
 	writeConductorConfig(t, tmpHome, `
 [conductors.foo.claude]
-config_dir = "/tmp/conductor-loses"
+config_dir = "/tmp/conductor-wins"
 `)
 
 	inst := NewInstanceWithGroupAndTool("conductor-foo", tmpHome, "conductor", "claude")
 	got := GetClaudeConfigDirForInstance(inst)
+	if got != "/tmp/conductor-wins" {
+		t.Errorf("GetClaudeConfigDirForInstance: conductor TOML must beat env; got=%q want=%q", got, "/tmp/conductor-wins")
+	}
+}
+
+// TestConductorConfig_GroupBeatsEnv codifies the CORRECTED priority for
+// group-level TOML overrides. An explicit [groups."<group>".claude].config_dir
+// beats a shell-wide CLAUDE_CONFIG_DIR export.
+//
+// Regression protection: a user with cdp/cdw aliases that export
+// CLAUDE_CONFIG_DIR must still be able to use [groups.innotrade.claude]
+// to force a different dir for that group's sessions.
+func TestConductorConfig_GroupBeatsEnv(t *testing.T) {
+	tmpHome := setupConductorTest(t)
+	_ = os.Setenv("CLAUDE_CONFIG_DIR", "/tmp/env-loses")
+	writeConductorConfig(t, tmpHome, `
+[groups."innotrade".claude]
+config_dir = "/tmp/group-wins"
+`)
+
+	inst := NewInstanceWithGroupAndTool("some-session", tmpHome, "innotrade", "claude")
+	got := GetClaudeConfigDirForInstance(inst)
+	if got != "/tmp/group-wins" {
+		t.Errorf("GetClaudeConfigDirForInstance: group TOML must beat env; got=%q want=%q", got, "/tmp/group-wins")
+	}
+}
+
+// TestConductorConfig_EnvBeatsProfile locks the remaining correct behavior:
+// env still beats profile. Profile is less specific than env (targets a
+// profile, not a session), so env > profile stays.
+func TestConductorConfig_EnvBeatsProfile(t *testing.T) {
+	tmpHome := setupConductorTest(t)
+	_ = os.Setenv("CLAUDE_CONFIG_DIR", "/tmp/env-wins")
+	_ = os.Setenv("AGENTDECK_PROFILE", "personal")
+	writeConductorConfig(t, tmpHome, `
+[profiles.personal.claude]
+config_dir = "/tmp/profile-loses"
+`)
+
+	inst := NewInstanceWithGroupAndTool("plain", tmpHome, "", "claude")
+	got := GetClaudeConfigDirForInstance(inst)
 	if got != "/tmp/env-wins" {
-		t.Errorf("GetClaudeConfigDirForInstance with CLAUDE_CONFIG_DIR set = %q, want %q", got, "/tmp/env-wins")
+		t.Errorf("GetClaudeConfigDirForInstance: env must beat profile; got=%q want=%q", got, "/tmp/env-wins")
+	}
+}
+
+// TestConductorConfig_EnvBeatsGlobal locks env > [claude] global fallback.
+// Global is shell-wide too, but less intentional than CLAUDE_CONFIG_DIR.
+func TestConductorConfig_EnvBeatsGlobal(t *testing.T) {
+	tmpHome := setupConductorTest(t)
+	_ = os.Setenv("CLAUDE_CONFIG_DIR", "/tmp/env-wins")
+	writeConductorConfig(t, tmpHome, `
+[claude]
+config_dir = "/tmp/global-loses"
+`)
+
+	inst := NewInstanceWithGroupAndTool("plain", tmpHome, "", "claude")
+	got := GetClaudeConfigDirForInstance(inst)
+	if got != "/tmp/env-wins" {
+		t.Errorf("GetClaudeConfigDirForInstance: env must beat global; got=%q want=%q", got, "/tmp/env-wins")
+	}
+}
+
+// TestConductorConfig_SourceLabelGroupWhenGroupBeatsEnv mirrors the
+// priority swap into the (path, source) getter. With group set AND env
+// set, source must be "group", not "env".
+func TestConductorConfig_SourceLabelGroupWhenGroupBeatsEnv(t *testing.T) {
+	tmpHome := setupConductorTest(t)
+	_ = os.Setenv("CLAUDE_CONFIG_DIR", "/tmp/env-value")
+	writeConductorConfig(t, tmpHome, `
+[groups."innotrade".claude]
+config_dir = "/tmp/group-value"
+`)
+
+	inst := NewInstanceWithGroupAndTool("some-session", tmpHome, "innotrade", "claude")
+	path, source := GetClaudeConfigDirSourceForInstance(inst)
+	if source != "group" {
+		t.Errorf("source label = %q, want %q (group beats env)", source, "group")
+	}
+	if path != "/tmp/group-value" {
+		t.Errorf("path = %q, want %q", path, "/tmp/group-value")
 	}
 }
 

--- a/internal/web/terminal_bridge.go
+++ b/internal/web/terminal_bridge.go
@@ -46,8 +46,15 @@ type tmuxPTYBridge struct {
 	sessionID   string
 	writer      *wsConnWriter
 
-	cmd  *exec.Cmd
-	ptmx *os.File
+	cmd *exec.Cmd
+
+	// ptmxMu guards ptmx against a concurrent Close/Resize race. Close
+	// closes the PTY file and nils the pointer under the write lock;
+	// Resize reads under the read lock so Setsize cannot hit a freshly
+	// closed fd. Observed as an intermittent TestTmuxPTYBridgeResize
+	// -race failure on CI (v1.7.4, v1.7.5 release workflows).
+	ptmxMu sync.RWMutex
+	ptmx   *os.File
 
 	closeOnce sync.Once
 	done      chan struct{}
@@ -130,11 +137,17 @@ func (b *tmuxPTYBridge) WriteInput(data string) error {
 }
 
 func (b *tmuxPTYBridge) Resize(cols, rows int) error {
-	if b == nil || b.ptmx == nil {
+	if b == nil {
 		return fmt.Errorf("bridge not initialized")
 	}
 	if cols <= 0 || rows <= 0 {
 		return fmt.Errorf("invalid dimensions: cols=%d rows=%d", cols, rows)
+	}
+
+	b.ptmxMu.RLock()
+	defer b.ptmxMu.RUnlock()
+	if b.ptmx == nil {
+		return fmt.Errorf("bridge not initialized")
 	}
 
 	var firstErr error
@@ -171,9 +184,12 @@ func (b *tmuxPTYBridge) Close() {
 		return
 	}
 	b.closeOnce.Do(func() {
+		b.ptmxMu.Lock()
 		if b.ptmx != nil {
 			_ = b.ptmx.Close()
+			b.ptmx = nil
 		}
+		b.ptmxMu.Unlock()
 		if b.cmd != nil && b.cmd.Process != nil {
 			pgid, err := syscall.Getpgid(b.cmd.Process.Pid)
 			if err == nil {


### PR DESCRIPTION
## Summary

Fixes a priority inversion where developer shells exporting `CLAUDE_CONFIG_DIR` (via profile aliases like `cdp`/`cdw`) silently shadowed every explicit `[conductors.<name>.claude]` and `[groups.<name>.claude]` TOML override — making config.toml overrides unreliable for the exact users most likely to write them.

Also fixes the `TestTmuxPTYBridgeResize -race` flake that blocked v1.7.4 and v1.7.5 release-workflow asset uploads on GH Actions.

## Priority change (Instance-variant only)

| # | Before (buggy) | After (fixed) |
|---|---|---|
| 1 | `CLAUDE_CONFIG_DIR` env | `[conductors.<n>.claude].config_dir` |
| 2 | `[conductors.<n>.claude]` | `[groups.<g>.claude].config_dir` |
| 3 | `[groups.<g>.claude]` | `CLAUDE_CONFIG_DIR` env |
| 4 | `[profiles.<p>.claude]` | `[profiles.<p>.claude].config_dir` |
| 5 | `[claude]` (global) | `[claude]` (global) |
| 6 | `~/.claude` | `~/.claude` |

Rationale: per-conductor/per-group TOML is semantically MORE specific than a shell-wide env var. Profile/global stay weaker than env (they're shell-wide too).

## Scope

- `internal/session/claude.go` — `GetClaudeConfigDirForInstance`, `GetClaudeConfigDirSourceForInstance`, `IsClaudeConfigDirExplicitForInstance` (keep-in-sync invariant held)
- `GetClaudeConfigDirForGroup` (no Instance context) **unchanged** — without an Instance, env is still the strongest signal.
- `internal/web/terminal_bridge.go` — adds `ptmxMu sync.RWMutex` for Close/Resize safety (orthogonal race fix required for CI to publish release assets).

## Tests (all in `.claude/release-tests.yaml`)

- `TestConductorConfig_PrecedenceConductorBeatsEnv` (flipped from old buggy `...EnvBeatsConductor`)
- `TestConductorConfig_GroupBeatsEnv` (new regression guard)
- `TestConductorConfig_EnvBeatsProfile` (env still beats profile)
- `TestConductorConfig_EnvBeatsGlobal` (env still beats global)
- `TestConductorConfig_SourceLabelGroupWhenGroupBeatsEnv` (parallel-paths audit)

## Live-boundary verification

With `CLAUDE_CONFIG_DIR=/tmp/env-wrong` exported and `-g <group>` + `[groups.<group>.claude].config_dir = "~/.claude-<profile>"` in config.toml, the resulting tmux `pane_start_command` now exports `CLAUDE_CONFIG_DIR=$HOME/.claude-<profile>` (group wins), not `/tmp/env-wrong`.

## Test plan
- [x] Failing tests committed first, confirmed RED on base
- [x] Implementation turns all new tests GREEN
- [x] Full `go test ./... -race -count=1` clean
- [x] `TestTmuxPTYBridgeResize -race -count=20` passes locally
- [x] `/tmp/tmux-1000/default` mtime unchanged through test run (session isolation fix from v1.7.5 live)
- [x] Live tmux pane_start_command shows correct `CLAUDE_CONFIG_DIR`

Committed by Ashesh Goplani
