### PR TITLE
fix(session): restart respects per-conductor/group config_dir override

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -241,3 +241,35 @@ tests:
     command: go test ./internal/session/ -run TestConductorConfig_SourceLabelGroupWhenGroupBeatsEnv
       -count=1 -v
     expected: pass
+- id: fix-restart-custom-config-dir-respects-per-instance
+  added: '2026-04-17'
+  task: fix-restart-custom-config-dir
+  file: internal/session/conductorconfig_test.go
+  test_name: TestSessionHasConversationData_RespectsPerInstanceConfigDir
+  purpose: sessionHasConversationData must consult per-instance Claude config dir
+    (GetClaudeConfigDirForInstance) so conductors/groups with config_dir overrides
+    detect their own JSONL history on restart. Pre-fix, the global GetClaudeConfigDir()
+    was used, causing restart to mis-route to --session-id (Claude rejects as already-in-use)
+    and the tmux pane to die.
+  source: user-report-2026-04-17-conductor-innotrade
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestSessionHasConversationData_RespectsPerInstanceConfigDir
+      -count=1 -v
+    expected: pass
+- id: fix-restart-custom-config-dir-resume-flag
+  added: '2026-04-17'
+  task: fix-restart-custom-config-dir
+  file: internal/session/conductorconfig_test.go
+  test_name: TestBuildClaudeResumeCommand_UsesResumeWhenPerInstanceHistoryExists
+  purpose: End-to-end live-boundary pin — when JSONL exists only under the per-instance
+    config dir, buildClaudeResumeCommand (output becomes tmux pane_start_command
+    verbatim) emits --resume <uuid>, NOT --session-id. Guards against the v1.7.6
+    regression where restart forked a fresh conversation because sessionHasConversationData
+    ignored conductor/group config_dir overrides.
+  source: user-report-2026-04-17-conductor-innotrade
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestBuildClaudeResumeCommand_UsesResumeWhenPerInstanceHistoryExists
+      -count=1 -v
+    expected: pass

--- a/internal/session/conductorconfig_test.go
+++ b/internal/session/conductorconfig_test.go
@@ -385,3 +385,102 @@ config_dir = "/tmp/group-for-non-conductor"
 		t.Errorf("non-conductor Instance path = %q, want %q", gpath, "/tmp/group-for-non-conductor")
 	}
 }
+
+// TestSessionHasConversationData_RespectsPerInstanceConfigDir pins the bug
+// that v1.7.7 fixes: sessionHasConversationData must consult the PER-INSTANCE
+// Claude config dir (derived from [conductors.<name>.claude].config_dir and
+// friends), not the process-wide GetClaudeConfigDir(). Before the fix, a
+// conductor with a config_dir override would fail to detect its own JSONL
+// history on restart, causing buildClaudeResumeCommand to emit --session-id
+// (which Claude rejects as already-in-use), and the pane would crash.
+//
+// Data-flow covered: GetClaudeConfigDirForInstance → sessionHasConversationData
+// → buildClaudeResumeCommand. This test pins the FIRST hop; Test 2 below
+// pins the second.
+func TestSessionHasConversationData_RespectsPerInstanceConfigDir(t *testing.T) {
+	tmpHome := setupConductorTest(t)
+
+	// Conductor config dir override — this is the scenario that broke on
+	// 2026-04-17: [conductors.innotrade.claude].config_dir = "~/.claude-work".
+	altConfigDir := filepath.Join(tmpHome, ".claude-work")
+	writeConductorConfig(t, tmpHome, fmt.Sprintf(`
+[conductors.foo.claude]
+config_dir = %q
+`, altConfigDir))
+
+	// Seed a JSONL with "sessionId" under the PER-INSTANCE config dir only.
+	// If the lookup falls back to GetClaudeConfigDir() (global ~/.claude),
+	// it won't find anything (tmpHome/.claude doesn't exist) and returns false.
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	encoded := ConvertToClaudeDirName(projectPath)
+	projectsDir := filepath.Join(altConfigDir, "projects", encoded)
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatalf("mkdir projects dir: %v", err)
+	}
+	sessionID := "d4bdd524-210c-47f9-a505-9bc49969e278"
+	jsonl := filepath.Join(projectsDir, sessionID+".jsonl")
+	body := `{"type":"user","sessionId":"` + sessionID + `","text":"hi"}` + "\n"
+	if err := os.WriteFile(jsonl, []byte(body), 0o600); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	inst := NewInstanceWithGroupAndTool("conductor-foo", projectPath, "conductor", "claude")
+
+	// Sanity check: priority chain resolves to the override.
+	if got := GetClaudeConfigDirForInstance(inst); got != altConfigDir {
+		t.Fatalf("precondition failed: GetClaudeConfigDirForInstance = %q, want %q", got, altConfigDir)
+	}
+
+	if !sessionHasConversationData(inst, sessionID) {
+		t.Errorf("sessionHasConversationData(inst, %q) = false; want true — per-instance config_dir %q has live JSONL at %q",
+			sessionID, altConfigDir, jsonl)
+	}
+}
+
+// TestBuildClaudeResumeCommand_UsesResumeWhenPerInstanceHistoryExists is the
+// integration-ish pin for the FULL data-flow: JSONL exists only under the
+// per-instance config dir, and buildClaudeResumeCommand must choose --resume,
+// not --session-id. Before the fix, the command contained --session-id, which
+// Claude rejects with "Error: Session ID is already in use" and the tmux pane
+// dies.
+func TestBuildClaudeResumeCommand_UsesResumeWhenPerInstanceHistoryExists(t *testing.T) {
+	tmpHome := setupConductorTest(t)
+	altConfigDir := filepath.Join(tmpHome, ".claude-work")
+	writeConductorConfig(t, tmpHome, fmt.Sprintf(`
+[conductors.foo.claude]
+config_dir = %q
+`, altConfigDir))
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	encoded := ConvertToClaudeDirName(projectPath)
+	projectsDir := filepath.Join(altConfigDir, "projects", encoded)
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatalf("mkdir projects dir: %v", err)
+	}
+	sessionID := "d4bdd524-210c-47f9-a505-9bc49969e278"
+	jsonl := filepath.Join(projectsDir, sessionID+".jsonl")
+	body := `{"type":"user","sessionId":"` + sessionID + `","text":"hi"}` + "\n"
+	if err := os.WriteFile(jsonl, []byte(body), 0o600); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	inst := NewInstanceWithGroupAndTool("conductor-foo", projectPath, "conductor", "claude")
+	inst.ClaudeSessionID = sessionID
+
+	cmd := inst.buildClaudeResumeCommand()
+
+	resumeFlag := "--resume " + sessionID
+	sessionIDFlag := "--session-id " + sessionID
+	if !strings.Contains(cmd, resumeFlag) {
+		t.Errorf("buildClaudeResumeCommand missing %q; got %q", resumeFlag, cmd)
+	}
+	if strings.Contains(cmd, sessionIDFlag) {
+		t.Errorf("buildClaudeResumeCommand must NOT contain %q when history exists at per-instance config_dir; got %q", sessionIDFlag, cmd)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -541,7 +541,7 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 			// Resume specific session by ID
 			if opts.ResumeSessionID != "" {
 				// Check if session has actual conversation data
-				if sessionHasConversationData(opts.ResumeSessionID, i.ProjectPath) {
+				if sessionHasConversationData(i, opts.ResumeSessionID) {
 					// Session has conversation history - use normal --resume
 					return fmt.Sprintf(`%s%s --resume %s%s`,
 						configDirPrefix, claudeCmd, opts.ResumeSessionID, extraFlags)
@@ -2732,8 +2732,8 @@ func (i *Instance) UpdateClaudeSession(excludeIDs map[string]bool) {
 			rejected := false
 			// Quality gate: don't adopt a zombie ID from tmux env when current has real data
 			if i.ClaudeSessionID != "" {
-				currentHasData := sessionHasConversationData(i.ClaudeSessionID, i.ProjectPath)
-				candidateHasData := sessionHasConversationData(sessionID, i.ProjectPath)
+				currentHasData := sessionHasConversationData(i, i.ClaudeSessionID)
+				candidateHasData := sessionHasConversationData(i, sessionID)
 				if currentHasData && !candidateHasData {
 					sessionLog.Debug("claude_session_tmux_rejected_zombie",
 						slog.String("current_id", i.ClaudeSessionID),
@@ -2841,7 +2841,7 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		}
 		// Quality gate: only accept if the hook session has conversation data,
 		// OR if the current session ID is empty (first detection).
-		if i.ClaudeSessionID == "" || sessionHasConversationData(sessionID, i.ProjectPath) {
+		if i.ClaudeSessionID == "" || sessionHasConversationData(i, sessionID) {
 			action := "bind"
 			if i.ClaudeSessionID != "" {
 				action = "rebind"
@@ -4372,7 +4372,7 @@ func (i *Instance) buildClaudeResumeCommand() string {
 
 	// Check if session has actual conversation data
 	// If not, use --session-id instead of --resume to avoid "No conversation found" error
-	useResume := sessionHasConversationData(i.ClaudeSessionID, i.ProjectPath)
+	useResume := sessionHasConversationData(i, i.ClaudeSessionID)
 	sessionLog.Debug(
 		"session_data_build_resume",
 		slog.String("session_id", i.ClaudeSessionID),
@@ -5020,6 +5020,16 @@ func geminiSessionHasConversationData(sessionID, projectPath string) bool {
 // sessionHasConversationData checks if a Claude session file contains actual
 // conversation data (has "sessionId" field in records).
 //
+// Uses the PER-INSTANCE Claude config dir (via GetClaudeConfigDirForInstance)
+// so sessions with [conductors.<name>.claude].config_dir or
+// [groups."<group>".claude].config_dir overrides detect their own JSONL
+// history correctly. Prior versions (≤v1.7.6) consulted the process-wide
+// GetClaudeConfigDir(), which silently ignored per-instance overrides and
+// caused restart-with-history to mis-route to --session-id (Claude rejects
+// that as "already in use") instead of --resume. Passing inst == nil
+// degrades to the global lookup, preserving legacy call sites without an
+// Instance.
+//
 // Returns true if:
 // - File has any "sessionId" field (user interacted with session)
 // - Error reading file (safe fallback - don't risk losing sessions)
@@ -5027,12 +5037,22 @@ func geminiSessionHasConversationData(sessionID, projectPath string) bool {
 // Returns false if:
 // - File doesn't exist (nothing to resume, use --session-id)
 // - File exists but has zero "sessionId" occurrences (never interacted)
-func sessionHasConversationData(sessionID string, projectPath string) bool {
+func sessionHasConversationData(inst *Instance, sessionID string) bool {
 	// Build the session file path
 	// Format: {config_dir}/projects/{encoded_path}/{sessionID}.jsonl
-	configDir := GetClaudeConfigDir()
+	var configDir string
+	if inst != nil {
+		configDir = GetClaudeConfigDirForInstance(inst)
+	} else {
+		configDir = GetClaudeConfigDir()
+	}
 	if configDir == "" {
 		configDir = filepath.Join(os.Getenv("HOME"), ".claude")
+	}
+
+	projectPath := ""
+	if inst != nil {
+		projectPath = inst.ProjectPath
 	}
 
 	// Resolve symlinks in project path (macOS: /tmp -> /private/tmp)
@@ -5054,7 +5074,7 @@ func sessionHasConversationData(sessionID string, projectPath string) bool {
 	if _, err := os.Stat(sessionFile); os.IsNotExist(err) {
 		// File doesn't exist at expected location - try cross-project search
 		// This handles path hash mismatches (e.g., session created from different directory)
-		if fallbackPath := findSessionFileInAllProjects(sessionID); fallbackPath != "" {
+		if fallbackPath := findSessionFileInAllProjects(inst, sessionID); fallbackPath != "" {
 			sessionLog.Debug("session_data_cross_project_found", slog.String("path", fallbackPath))
 			sessionFile = fallbackPath
 		} else {
@@ -5114,12 +5134,20 @@ func sessionHasConversationData(sessionID string, projectPath string) bool {
 // This handles path hash mismatches when agent-deck runs from a different directory
 // than where the Claude session was originally created.
 // Returns the full path to the session file, or empty string if not found.
-func findSessionFileInAllProjects(sessionID string) string {
+// Uses the PER-INSTANCE config dir (via GetClaudeConfigDirForInstance) when
+// inst is non-nil so sessions with conductor/group config_dir overrides find
+// their own JSONLs. Passing inst == nil degrades to the global lookup.
+func findSessionFileInAllProjects(inst *Instance, sessionID string) string {
 	if sessionID == "" {
 		return ""
 	}
 
-	configDir := GetClaudeConfigDir()
+	var configDir string
+	if inst != nil {
+		configDir = GetClaudeConfigDirForInstance(inst)
+	} else {
+		configDir = GetClaudeConfigDir()
+	}
 	if configDir == "" {
 		configDir = filepath.Join(os.Getenv("HOME"), ".claude")
 	}

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -2104,6 +2104,13 @@ func TestSessionHasConversationData(t *testing.T) {
 	ClearUserConfigCache()
 	defer ClearUserConfigCache()
 
+	// Build an Instance pointing at the test project. No conductor/group
+	// config override is set, so GetClaudeConfigDirForInstance(inst) falls
+	// through to the CLAUDE_CONFIG_DIR env var above — preserving the
+	// original semantics of this legacy test.
+	inst := NewInstance("legacy-has-data", projectPath)
+	inst.Tool = "claude"
+
 	t.Run("file with sessionId returns true", func(t *testing.T) {
 		sessionID := "has-session-id"
 		filePath := filepath.Join(projectsDir, sessionID+".jsonl")
@@ -2112,7 +2119,7 @@ func TestSessionHasConversationData(t *testing.T) {
 {"type":"user","sessionId":"has-session-id","text":"hello"}`
 		_ = os.WriteFile(filePath, []byte(content), 0o644)
 
-		if !sessionHasConversationData(sessionID, projectPath) {
+		if !sessionHasConversationData(inst, sessionID) {
 			t.Error("Expected true for file with sessionId")
 		}
 	})
@@ -2124,13 +2131,13 @@ func TestSessionHasConversationData(t *testing.T) {
 {"type":"summary","leafUuid":"def"}`
 		_ = os.WriteFile(filePath, []byte(content), 0o644)
 
-		if sessionHasConversationData(sessionID, projectPath) {
+		if sessionHasConversationData(inst, sessionID) {
 			t.Error("Expected false for file without sessionId")
 		}
 	})
 
 	t.Run("missing file returns false (use --session-id)", func(t *testing.T) {
-		if sessionHasConversationData("nonexistent-file", projectPath) {
+		if sessionHasConversationData(inst, "nonexistent-file") {
 			t.Error("Expected false for missing file (nothing to resume)")
 		}
 	})


### PR DESCRIPTION
## Problem

Sessions with a `[conductors.<name>.claude].config_dir` (or `[groups."<group>".claude].config_dir`) override — e.g. a client conductor pointing at `~/.claude-<profile>` — could not be restarted. Every restart forked a fresh conversation and the tmux pane died with:

```
Error: Session ID <uuid> is already in use.
```

## Root cause

`sessionHasConversationData` (and its fallback `findSessionFileInAllProjects`) at `internal/session/instance.go:5030` and `:5117` used the process-wide `GetClaudeConfigDir()` to locate the session JSONL. Per-instance TOML overrides were ignored. With history stored at `~/.claude-<profile>/projects/<encoded>/<uuid>.jsonl`, the function looked under `~/.claude/projects/...` (empty), concluded "no history", and `buildClaudeResumeCommand` chose `--session-id <uuid>` instead of `--resume <uuid>`. Claude rejected the duplicate ID.

This is the same bug class as v1.5.2 REQ-7 (conductor history loss) but at a different hop in the data-flow: v1.5.2 fixed the ClaudeSessionID capture path for custom-command sessions; this fixes the config-dir lookup inside the resume-vs-session-id decision.

## Fix

Thread `*Instance` through both functions so they use `GetClaudeConfigDirForInstance` (the same per-instance resolver already in use by `buildClaudeCommandWithMessage` and `buildClaudeResumeCommand` for the `CLAUDE_CONFIG_DIR=` prefix). `nil` Instance still falls back to the global lookup, preserving every legacy caller.

All 4 in-package call sites and 3 legacy unit-test call sites updated.

## Tests (appended to `.claude/release-tests.yaml`)

- `TestSessionHasConversationData_RespectsPerInstanceConfigDir` — seeds JSONL only under `~/.claude-<profile>` and asserts detection returns `true`.
- `TestBuildClaudeResumeCommand_UsesResumeWhenPerInstanceHistoryExists` — live-boundary pin: the command that becomes tmux `pane_start_command` must contain `--resume <uuid>`, never `--session-id <uuid>`, when the per-instance JSONL exists.

Both tests fail on `main` (compile error — old 2-string signature), pass after the fix.

## Verification

- `go test ./internal/session/... -race -count=1` → ok (10.488s)
- `go test ./... -race -count=1` → all 25 packages ok
- Tmux socket mtime `/tmp/tmux-1000/default` unchanged end-to-end (09:28:01.741806757 before and after).
- Live-boundary on this host with `/tmp/agent-deck-fix` (v1.7.7-pre): the session-ID quality gate at `instance.go:2735-2736` now correctly REJECTS zombie hook candidates because it sees the real JSONL under the override dir. Pre-fix it would have accepted the zombie and lost history.

## Out of scope

- `mcp_catalog.go` / `skills_catalog.go` — those use `GetClaudeConfigDir()` for per-user assets (skills/MCPs), different semantics, not this bug.
- Refactoring other callers — only touched what this bug required.

Committed by Ashesh Goplani
