### PR TITLE
fix(#610): CLI status parity — warm tmux cache before UpdateStatus

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -345,3 +345,33 @@ tests:
     command: go test ./cmd/agent-deck/ -run TestRevive_CLI_AllFlag_TriggersReviver
       -race -count=1 -v
     expected: pass
+- id: issue-610-cli-parity-spinner
+  added: '2026-04-17'
+  task: fix-issue-610
+  file: internal/session/instance_cli_parity_test.go
+  test_name: TestUpdateStatus_CLIParity_SpinnerTitle_StaleHook
+  purpose: CLI cold path with a 3-minute-old hook file and a braille-spinner pane
+    title must report StatusRunning. Regression guard for #610 — without
+    RefreshInstancesForCLIStatus the title fast-path cache is never populated so
+    the CLI fell back to idle/waiting while TUI/web said running.
+  source: .planning/fix-issue-610/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestUpdateStatus_CLIParity_SpinnerTitle_StaleHook
+      -race -count=1 -v
+    expected: pass
+- id: issue-610-cli-vs-tui-parity
+  added: '2026-04-17'
+  task: fix-issue-610
+  file: internal/session/instance_cli_parity_test.go
+  test_name: TestUpdateStatus_CLIvsTUIParity_SameTmuxState
+  purpose: Direct parity assertion — CLI path (RefreshInstancesForCLIStatus +
+    UpdateStatus) and TUI path (RefreshPaneInfoCache + UpdateHookStatus +
+    UpdateStatus) must produce identical Status for the same underlying tmux
+    session. Script automation via list --json sees what the TUI shows.
+  source: .planning/fix-issue-610/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestUpdateStatus_CLIvsTUIParity_SameTmuxState
+      -race -count=1 -v
+    expected: pass

--- a/.planning/fix-issue-610/PLAN.md
+++ b/.planning/fix-issue-610/PLAN.md
@@ -1,0 +1,277 @@
+# Fix issue #610 — CLI status parity with TUI / web API
+
+## (a) Problem summary
+
+`agent-deck list --json` and `agent-deck session show <id> --json` report
+incorrect status (typically `idle` or `waiting`) for sessions that the TUI
+and the web API at `/api/menu` correctly report as `running`.
+
+Scripts that automate agent-deck via CLI JSON output make wrong decisions
+because their view of the world disagrees with the user's view in the TUI.
+
+## (b) Exact reproducer
+
+Requires a live tmux server and a Claude session doing a long tool call
+(e.g. a multi-minute `bash -c` or a file read that spans >2 minutes).
+
+```bash
+# 1. Start a long-running session via agent-deck
+agent-deck add -t repro610 -c claude ~/some/project
+agent-deck session attach repro610
+
+# 2. Inside Claude, kick off a long tool call (>2 min). Example:
+#    "Read this 500MB log file and summarize everything."
+#    The pane title acquires a braille spinner (⠋/⠙/⠹/⠸/⠼/⠴/⠦/⠧/⠇/⠏).
+
+# 3. Detach from the session (C-b d) or leave it running in another pane.
+
+# 4. In a second shell, wait >2 minutes so the stored "running" hook event
+#    ages out of the 2-minute fast-path window (hookFastPathWindow).
+sleep 130
+
+# 5. Poll each surface. All three SHOULD say "running".
+agent-deck list --json                     | jq '.[] | select(.id=="<ID>") | .status'
+agent-deck session show <ID> --json         | jq .status
+curl -s http://localhost:8080/api/menu     | jq '.. | .status? // empty' | head
+
+# Observed on main:
+#   list --json     → "idle" or "waiting"
+#   session show    → "idle" or "waiting"
+#   /api/menu       → "running"      ← parity break
+```
+
+The same reproducer works without an actual Claude process by setting a
+braille character on the pane title with:
+`tmux select-pane -t <tmux-session> -T "⠋ Working"` — used by the unit
+tests in `internal/session/instance_cli_parity_test.go`.
+
+## (c) Data-flow trace
+
+### TUI — `internal/ui/home.go :: Home.backgroundStatusUpdate` (line ~2497)
+```
+tick →
+  tmux.RefreshExistingSessions()               # tmux.go
+  tmux.RefreshPaneInfoCache()                  # title_detection.go:110  ★ warms pane-title cache
+  for each inst:
+    hookWatcher.GetHookStatus(inst.ID)         # hook_watcher.go
+    inst.UpdateHookStatus(hs)                  # instance.go:2798
+  parallel for each inst:
+    inst.UpdateStatus()                        # instance.go:2476
+      → hookFastPathWindow check (2m)
+      → tmuxSession.GetStatus()                # tmux.go:2296
+          → GetCachedPaneInfo(name)            # title_detection.go:191   ★ cache HIT
+          → AnalyzePaneTitle(title,_)          # title_detection.go:212
+            → braille → TitleStateWorking
+          → return "active"
+      → inst.Status = StatusRunning
+```
+
+### Web API — `GET /api/menu` → `internal/web/handlers_menu.go::handleMenu` (line 26)
+```
+GET /api/menu →
+  s.menuData.LoadMenuSnapshot()                # either MemoryMenuData or SessionDataService
+
+SessionDataService.LoadMenuSnapshot (session_data_service.go:126)
+  → s.refreshStatuses(instances)                # line 210
+      → tmux.RefreshExistingSessions()
+      → tmux.RefreshPaneInfoCache()            ★ warms pane-title cache (same as TUI)
+      → defaultLoadHookStatuses()               # reads hook JSON from disk
+      → inst.UpdateHookStatus(hs)
+      → inst.ForceNextStatusCheck() (for Claude without hook)
+      → inst.UpdateStatus()                     # title fast-path HIT
+```
+
+MemoryMenuData (web-mode) reads the last snapshot published by the web
+server's background refresher — which in turn runs through
+`refreshStatuses` on every tick. So the pane-title cache is always warm
+inside the web server's process memory.
+
+### CLI — `agent-deck list --json` — `cmd/agent-deck/main.go :: handleList` (line 1438)
+```
+main → handleList →
+  storage.LoadInstances()                       # cold load from sessions.json
+  for each inst: inst.UpdateStatus()            # line 1501  ← NO pre-warm
+      → UpdateStatus reads hook file cold (instance.go:2545-2558)
+      → hookFastPathWindow check → STALE (>2m) → fall through
+      → tmuxSession.GetStatus() (tmux.go:2296)
+          → GetCachedPaneInfo(name)             # title_detection.go:191
+            → cache was NEVER populated by this process → MISS
+          → fall through to window-activity + content scan
+          → first call, stateTracker nil → CapturePane → hasBusyIndicator
+            - "sleep 3600" pane has no "esc to interrupt" → not busy
+            - no prompt indicator → not waiting
+          → falls to "Restored session" block (tmux.go:2514)
+            - previousStatus "idle" → StatusIdle
+            - else                    → StatusWaiting
+      → inst.Status = StatusIdle / StatusWaiting   ★ wrong
+```
+
+### CLI — `agent-deck session show <id> --json` — `cmd/agent-deck/session_cmd.go :: handleShow` (line 711)
+
+Same shape as `handleList`: a single `inst.UpdateStatus()` with no
+pre-warm of `tmux.RefreshPaneInfoCache()` and no explicit hook-file load
+beyond what `UpdateStatus` does cold internally.
+
+### Divergence point
+
+| Step                         | TUI | Web | CLI list | CLI show |
+|------------------------------|-----|-----|----------|----------|
+| `tmux.RefreshPaneInfoCache`  | ✔   | ✔   | **✘**    | **✘**    |
+| Fresh hook statuses loaded   | ✔   | ✔   | cold (UpdateStatus only) | cold |
+| `ForceNextStatusCheck`       | n/a | ✔   | ✘        | ✘        |
+| `inst.UpdateStatus()`        | ✔   | ✔   | ✔        | ✔        |
+
+The CLI skips the only step that reliably surfaces "working" state during
+long tool calls — the pane-title cache refresh.
+
+Authoritative sources examined:
+- `internal/tmux/tmux.go:2296` `GetStatus`
+- `internal/tmux/tmux.go:2326` title fast-path reads `GetCachedPaneInfo`
+- `internal/tmux/title_detection.go:110` `RefreshPaneInfoCache` (populates cache)
+- `internal/tmux/title_detection.go:191` `GetCachedPaneInfo` (4 s staleness)
+- `internal/tmux/title_detection.go:212` `AnalyzePaneTitle` (braille → working)
+- `internal/session/instance.go:2474` `UpdateStatus` (hook fast-path gate)
+- `internal/session/instance.go:2545` cold-load hook read
+- `internal/session/instance.go:56` `hookFastPathWindow = 2 * time.Minute`
+- `internal/ui/home.go:2526` TUI calls `RefreshPaneInfoCache`
+- `internal/web/session_data_service.go:213` web calls `RefreshPaneInfoCache`
+- `cmd/agent-deck/main.go:1501` CLI list path — no pre-warm
+- `cmd/agent-deck/session_cmd.go:711` CLI show path — no pre-warm
+
+## (d) Failing test cases (committed)
+
+File: `internal/session/instance_cli_parity_test.go`
+
+1. `TestUpdateStatus_CLIParity_SpinnerTitle_StaleHook`
+   - Creates a real tmux session (`sleep 3600` as the pane process).
+   - Writes a 3-minute-old `running` hook file under HOME/.agent-deck/hooks
+     so the hook fast-path is stale (mirrors Claude's long tool calls).
+   - Sets pane title to `"⠋ Working on refactor"` via `tmux select-pane -T`.
+   - Sleeps past the 1.5 s grace window.
+   - Calls `RefreshInstancesForCLIStatus([]*Instance{inst})` — the helper
+     the fix must introduce, analogous to `refreshStatuses` in the web
+     package and `backgroundStatusUpdate` in the UI package.
+   - Asserts `inst.GetStatusThreadSafe() == StatusRunning`.
+
+2. `TestUpdateStatus_CLIvsTUIParity_SameTmuxState`
+   - Builds one tmux session and two `*Instance` wrappers pointing at it
+     (mirrors the real split: TUI and CLI are different OS processes
+     loading the same `sessions.json`).
+   - Runs the TUI path (`tmux.RefreshPaneInfoCache` + `UpdateHookStatus` +
+     `UpdateStatus`) and the CLI path (`RefreshInstancesForCLIStatus` +
+     `UpdateStatus`) against the same tmux state.
+   - Asserts both report the same `Status`, and that it is `StatusRunning`
+     (sanity oracle).
+
+Current failure mode (`go test ./internal/session/ -run
+TestUpdateStatus_CLIParity`):
+
+```
+internal/session/instance_cli_parity_test.go:111:2:
+    undefined: RefreshInstancesForCLIStatus
+internal/session/instance_cli_parity_test.go:171:2:
+    undefined: RefreshInstancesForCLIStatus
+FAIL	github.com/asheshgoplani/agent-deck/internal/session [build failed]
+```
+
+i.e. compilation fails because the fix's public helper does not exist yet
+— the mandated TDD red.
+
+## (e) Implementation sketch
+
+### Option 1 (recommended) — introduce `session.RefreshInstancesForCLIStatus(instances []*Instance)`
+
+New file `internal/session/cli_status_refresh.go`:
+
+```go
+package session
+
+import "github.com/asheshgoplani/agent-deck/internal/tmux"
+
+// RefreshInstancesForCLIStatus warms the shared tmux caches and loads
+// on-disk hook statuses into the given instances. It is the CLI analogue
+// of SessionDataService.refreshStatuses (internal/web) and
+// Home.backgroundStatusUpdate (internal/ui). Call this before looping
+// inst.UpdateStatus() in any CLI emitter — without it the title fast-path
+// in tmux.GetStatus cannot fire because the pane-info cache is process-
+// local and the CLI never populates it otherwise. Regression: issue #610.
+func RefreshInstancesForCLIStatus(instances []*Instance) {
+	if len(instances) == 0 {
+		return
+	}
+	tmux.RefreshExistingSessions()
+	tmux.RefreshPaneInfoCache()
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		if IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" {
+			if hs := readHookStatusFile(inst.ID); hs != nil {
+				inst.UpdateHookStatus(hs)
+			}
+		}
+	}
+}
+```
+
+CLI call sites (single-line insertions):
+
+- `cmd/agent-deck/main.go` `handleList`, immediately above the
+  `for i, inst := range instances { _ = inst.UpdateStatus() ...` loop
+  (line ~1499).
+- `cmd/agent-deck/session_cmd.go` `handleShow`, immediately above
+  `_ = inst.UpdateStatus()` (line ~710).
+- Anywhere else in `cmd/agent-deck` that emits JSON and loops
+  `UpdateStatus` without pre-warm — audit other JSON emitters in
+  `session_cmd.go` (`handleStatus`, etc.) and apply the same pattern.
+
+### Option 2 — widen `hookFastPathWindow` for `running`
+
+Set a separate `hookRunningFastPathWindow = 10 * time.Minute` so long
+tool calls stay "running" via the hook fast-path. Downsides:
+- Still wrong when the hook was never written (new session, CLI-only
+  interaction, hooks disabled).
+- Hides a stale dead session as `running` for 10 minutes.
+- Does not address the parity gap structurally — TUI and web already
+  warm the cache, CLI still would not.
+
+### Option 3 — have `UpdateStatus` auto-refresh the cache when it is stale
+
+Cheap per-instance but `tmux.RefreshPaneInfoCache` is a
+`list-panes -a` subprocess — running it once per Instance per tick is
+wasteful and undoes the "once per tick" contract documented at
+`title_detection.go:108`.
+
+**Chosen:** Option 1. Smallest surface, reuses existing web and TUI
+patterns, testable at package boundary.
+
+## (f) Scope boundaries
+
+**MAY edit (within fix/issue-610-cli-status-parity):**
+- `internal/session/cli_status_refresh.go` (new file) — helper landing spot.
+- `internal/session/instance_cli_parity_test.go` (new) — failing tests.
+- `cmd/agent-deck/main.go` — call `RefreshInstancesForCLIStatus` in
+  `handleList` and `handleListAllProfiles` JSON branches.
+- `cmd/agent-deck/session_cmd.go` — call the helper in `handleShow` (and
+  any sibling JSON emitters touching `UpdateStatus`).
+- `CHANGELOG.md` — one-line entry under Unreleased.
+- `.planning/fix-issue-610/**` — planning artifacts (this file).
+
+**MUST NOT edit without an RFC:**
+- `internal/tmux/**` — adding refresh calls, changing cache TTL, adding
+  new exported state. Regression risk on the eight persistence tests
+  plus the watcher suite per `CLAUDE.md`.
+- `internal/session/instance.go` — the hot `UpdateStatus` path. No widened
+  hookFastPathWindow, no per-call `RefreshPaneInfoCache`, no new branches
+  that could destabilise the `TestPersistence_*` suite.
+- `internal/ui/**`, `internal/web/**` — already correct; do not touch.
+- `internal/watcher/**` — unrelated, protected by mandate.
+- Any `--no-verify` commits on source-modifying changes (CLAUDE.md).
+
+**Verification before marking done:**
+- `GOTOOLCHAIN=go1.24.0 go test ./internal/session/... -race -count=1`
+- `GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/... -race -count=1`
+- `GOTOOLCHAIN=go1.24.0 go test -run TestPersistence_ ./internal/session/... -race -count=1`
+- Manual spot-check: set up a live Claude session; confirm
+  `list --json | jq '.[].status'`, `session show <id> --json | jq .status`,
+  and `/api/menu` all report `running` during a >2-minute tool call.

--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -924,6 +924,9 @@ func handleConductorStatus(_ string, args []string) {
 		if err == nil {
 			instances, _, err := storage.LoadWithGroups()
 			if err == nil {
+				// Warm tmux + hook caches before UpdateStatus so we match
+				// what the TUI and /api/menu show (issue #610).
+				session.RefreshInstancesForCLIStatus(instances)
 				for _, inst := range instances {
 					if inst.Title == sessionTitle {
 						cs.SessionID = inst.ID
@@ -1079,6 +1082,9 @@ func handleConductorList(profile string, args []string) {
 		if err == nil {
 			instances, _, err := storage.LoadWithGroups()
 			if err == nil {
+				// Warm tmux + hook caches before UpdateStatus so conductor
+				// list matches the TUI and /api/menu view (issue #610).
+				session.RefreshInstancesForCLIStatus(instances)
 				found := false
 				for _, inst := range instances {
 					if inst.Title == sessionTitle {

--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -102,6 +102,12 @@ func handleGroupList(profile string, args []string) {
 		os.Exit(1)
 	}
 
+	// Warm tmux pane-title cache + load hook statuses once up-front so
+	// the per-status counts below match the TUI and /api/menu view
+	// (issue #610). Without this the nested UpdateStatus calls each run
+	// with a cold cache and miss the Claude "working" spinner.
+	session.RefreshInstancesForCLIStatus(instances)
+
 	// Build group tree
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
 

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1502,6 +1502,9 @@ func handleList(profile string, args []string) {
 			SSHRemotePath string    `json:"ssh_remote_path,omitempty"`
 			Channels      []string  `json:"channels,omitempty"`
 		}
+		// Warm tmux pane-title cache + load hook statuses so the CLI
+		// reports the same Status the TUI and /api/menu do (issue #610).
+		session.RefreshInstancesForCLIStatus(instances)
 		sessions := make([]sessionJSON, len(instances))
 		for i, inst := range instances {
 			_ = inst.UpdateStatus()
@@ -1858,6 +1861,9 @@ type statusCounts struct {
 
 // countByStatus counts sessions by their status
 func countByStatus(instances []*session.Instance) statusCounts {
+	// Warm tmux pane-title cache + load hook statuses so `status`/`status --json`
+	// reports the same counts the TUI and /api/menu do (issue #610).
+	session.RefreshInstancesForCLIStatus(instances)
 	var counts statusCounts
 	for _, inst := range instances {
 		_ = inst.UpdateStatus() // Refresh status from tmux

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -710,6 +710,9 @@ func handleSessionShow(profile string, args []string) {
 		}
 	}
 
+	// Warm tmux pane-title cache + load hook status so `session show --json`
+	// reports the same Status the TUI and /api/menu do (issue #610).
+	session.RefreshInstancesForCLIStatus([]*session.Instance{inst})
 	// Update status
 	_ = inst.UpdateStatus()
 

--- a/internal/session/cli_status_refresh.go
+++ b/internal/session/cli_status_refresh.go
@@ -1,15 +1,41 @@
 package session
 
+import "github.com/asheshgoplani/agent-deck/internal/tmux"
+
 // RefreshInstancesForCLIStatus is the CLI analogue of
 // SessionDataService.refreshStatuses (internal/web) and
 // Home.backgroundStatusUpdate (internal/ui). CLI JSON emitters must call
 // it before iterating inst.UpdateStatus() so the tmux pane-title cache is
-// warm and on-disk hook statuses are loaded — without this step the
-// title fast-path in tmux.GetStatus cannot fire (issue #610).
+// warm and on-disk hook statuses are loaded — without this step the title
+// fast-path in tmux.GetStatus cannot fire and long-running Claude sessions
+// get reported as idle/waiting instead of running (issue #610).
 //
-// TDD stub: the real implementation is pending as part of fix/issue-610.
-// Until then this is a no-op, which keeps go vet/build green while the
-// regression tests in instance_cli_parity_test.go stay red.
+// Symmetry with the other two surfaces:
+//   - internal/ui/home.go:backgroundStatusUpdate
+//   - internal/web/session_data_service.go:refreshStatuses
 func RefreshInstancesForCLIStatus(instances []*Instance) {
-	_ = instances
+	if len(instances) == 0 {
+		return
+	}
+	// Warm the shared tmux caches so the title fast-path in GetStatus can
+	// read pane titles (braille spinner while Claude is working) without
+	// hitting a subprocess per instance.
+	tmux.RefreshExistingSessions()
+	tmux.RefreshPaneInfoCache()
+
+	// Cold-load hook status files for every tool that emits lifecycle
+	// events. The CLI is a fresh OS process with no StatusFileWatcher
+	// running; without this the "running" event written by Claude's
+	// UserPromptSubmit hook never reaches UpdateStatus's fast-path window.
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		if !IsClaudeCompatible(inst.Tool) && inst.Tool != "codex" && inst.Tool != "gemini" {
+			continue
+		}
+		if hs := readHookStatusFile(inst.ID); hs != nil {
+			inst.UpdateHookStatus(hs)
+		}
+	}
 }

--- a/internal/session/cli_status_refresh.go
+++ b/internal/session/cli_status_refresh.go
@@ -1,0 +1,15 @@
+package session
+
+// RefreshInstancesForCLIStatus is the CLI analogue of
+// SessionDataService.refreshStatuses (internal/web) and
+// Home.backgroundStatusUpdate (internal/ui). CLI JSON emitters must call
+// it before iterating inst.UpdateStatus() so the tmux pane-title cache is
+// warm and on-disk hook statuses are loaded — without this step the
+// title fast-path in tmux.GetStatus cannot fire (issue #610).
+//
+// TDD stub: the real implementation is pending as part of fix/issue-610.
+// Until then this is a no-op, which keeps go vet/build green while the
+// regression tests in instance_cli_parity_test.go stay red.
+func RefreshInstancesForCLIStatus(instances []*Instance) {
+	_ = instances
+}

--- a/internal/session/instance_cli_parity_test.go
+++ b/internal/session/instance_cli_parity_test.go
@@ -1,0 +1,228 @@
+package session
+
+// Failing tests for issue #610: `agent-deck list --json` and
+// `agent-deck session show <id> --json` report wrong status (idle/waiting)
+// for sessions that the TUI and web API /api/menu correctly report as
+// running.
+//
+// Root cause trace (see .planning/fix-issue-610/PLAN.md for the full
+// data-flow analysis):
+//
+//   TUI   backgroundStatusUpdate → tmux.RefreshPaneInfoCache()
+//                                → hookWatcher.GetHookStatus + UpdateHookStatus
+//                                → inst.UpdateStatus()           ← title fast-path hits
+//   Web   SessionDataService.refreshStatuses → tmux.RefreshPaneInfoCache()
+//                                → defaultLoadHookStatuses + UpdateHookStatus
+//                                → inst.UpdateStatus()           ← title fast-path hits
+//   CLI   handleList / handleShow → inst.UpdateStatus()          ← cache cold, hook stale
+//
+// When Claude is mid-tool-execution the only reliable running-state signal
+// is the braille spinner embedded in the pane title (set by Claude Code via
+// OSC sequences). The TUI/web populate the pane-title cache before each
+// UpdateStatus tick; the CLI never does. As a result the CLI's GetStatus
+// falls through the title fast path, the hook fast path is stale (>2min,
+// because Claude only emits "running" on UserPromptSubmit), and content-scan
+// on the bottom of the pane misses the busy indicator for long tool calls.
+//
+// Fix surface: introduce session.RefreshInstancesForCLIStatus(instances)
+// — the CLI analogue of SessionDataService.refreshStatuses — and call it
+// from handleList and the session-show JSON emitter before the UpdateStatus
+// loop. Until that helper exists this file fails to compile, which is the
+// intended red state for TDD.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// writeHookFile writes a hook status file under the test-scoped HOME so
+// readHookStatusFile picks it up via GetHooksDir().
+func writeHookFile(t *testing.T, instanceID, status string, tsSecondsAgo int) {
+	t.Helper()
+	hooksDir := GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	ts := time.Now().Add(-time.Duration(tsSecondsAgo) * time.Second).Unix()
+	body := fmt.Sprintf(
+		`{"status":%q,"session_id":"sess-610","event":"UserPromptSubmit","ts":%d}`,
+		status, ts,
+	)
+	path := filepath.Join(hooksDir, instanceID+".json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+}
+
+// setPaneTitle injects a pane title via `tmux select-pane -T`. Claude Code
+// normally does this with OSC escape sequences while it is actively working;
+// the tests fake the same state.
+func setPaneTitle(t *testing.T, tmuxSession, title string) {
+	t.Helper()
+	cmd := exec.Command("tmux", "select-pane", "-t", tmuxSession, "-T", title)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("select-pane -T %q: %v\n%s", title, err, out)
+	}
+}
+
+// TestUpdateStatus_CLIParity_SpinnerTitle_StaleHook reproduces the core
+// symptom of issue #610: when the hook fast path is stale and the pane
+// title carries a braille spinner (Claude "working" signal), the CLI cold
+// path must still report StatusRunning.
+//
+// Required behavior after fix:
+//
+//	RefreshInstancesForCLIStatus(instances) warms the title cache (and loads
+//	hook files from disk) so the subsequent UpdateStatus sees the spinner
+//	via the title fast-path — identical to what the TUI and web already do.
+func TestUpdateStatus_CLIParity_SpinnerTitle_StaleHook(t *testing.T) {
+	skipIfNoTmuxServer(t)
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	inst := NewInstanceWithTool("issue610-spinner", tmpHome, "claude")
+	if err := inst.tmuxSession.Start("sleep 3600"); err != nil {
+		t.Fatalf("tmux start: %v", err)
+	}
+	defer func() { _ = inst.tmuxSession.Kill() }()
+
+	// Stale running hook (3 minutes old, past the 2-minute fast-path window).
+	// Matches real-world behavior: Claude only emits "running" on
+	// UserPromptSubmit, so a long-running tool call leaves the hook stale.
+	writeHookFile(t, inst.ID, "running", 180)
+
+	// Simulate Claude's OSC title sequence while working.
+	setPaneTitle(t, inst.tmuxSession.Name, "⠋ Working on refactor")
+
+	// Past the 1.5-second grace period inside UpdateStatus.
+	time.Sleep(2 * time.Second)
+
+	// CLI entry point: the fix must expose a helper that parallels
+	// SessionDataService.refreshStatuses and Home.backgroundStatusUpdate,
+	// and handleList / session-show must call it before the UpdateStatus
+	// loop. Until then this symbol does not exist and the file will not
+	// compile — the intended TDD red.
+	RefreshInstancesForCLIStatus([]*Instance{inst})
+
+	if err := inst.UpdateStatus(); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+	if got := inst.GetStatusThreadSafe(); got != StatusRunning {
+		t.Errorf(
+			"issue #610: CLI cold path reported %q, want %q. "+
+				"Pane title carries a braille spinner; TUI and web API report "+
+				"\"running\" for this exact state.",
+			got, StatusRunning,
+		)
+	}
+}
+
+// TestUpdateStatus_CLIvsTUIParity_SameTmuxState verifies that the CLI and
+// TUI paths produce the same Status for a session in the same underlying
+// tmux state. Direct parity assertion: scripts that consume `list --json`
+// must see the same answer the TUI shows on screen.
+//
+// Both entry points run against a single tmux session:
+//   - TUI path:   tmux.RefreshPaneInfoCache + UpdateHookStatus + UpdateStatus
+//   - CLI path:   RefreshInstancesForCLIStatus + UpdateStatus
+//
+// On main the CLI path has no equivalent to RefreshPaneInfoCache, so even
+// once the helper exists the two must produce identical output for the
+// same pane state. The fix lands green only when CLI output == TUI output.
+func TestUpdateStatus_CLIvsTUIParity_SameTmuxState(t *testing.T) {
+	skipIfNoTmuxServer(t)
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// Shared tmux state: create the session once. Two Instance wrappers
+	// point at the same tmux session name, mirroring the real world where
+	// the TUI and CLI are separate processes loading the same sessions.json.
+	base := NewInstanceWithTool("issue610-parity", tmpHome, "claude")
+	if err := base.tmuxSession.Start("sleep 3600"); err != nil {
+		t.Fatalf("tmux start: %v", err)
+	}
+	defer func() { _ = base.tmuxSession.Kill() }()
+
+	writeHookFile(t, base.ID, "running", 180)
+	setPaneTitle(t, base.tmuxSession.Name, "⠴ Running tool")
+	time.Sleep(2 * time.Second)
+
+	tuiInst := reloadInstanceForParityTest(base)
+	cliInst := reloadInstanceForParityTest(base)
+
+	// Run CLI path FIRST so the tmux pane-info cache is cold — mirrors a
+	// real agent-deck list invocation where the CLI is a fresh OS process
+	// with its own (empty) tmux package globals. If the TUI path ran first
+	// in this binary it would warm the package-level cache and mask the
+	// parity gap.
+	//
+	// --- CLI path (handleList / session show --json) ---
+	RefreshInstancesForCLIStatus([]*Instance{cliInst})
+	if err := cliInst.UpdateStatus(); err != nil {
+		t.Fatalf("CLI UpdateStatus: %v", err)
+	}
+	cliStatus := cliInst.GetStatusThreadSafe()
+
+	// --- TUI path (internal/ui/home.go:backgroundStatusUpdate) ---
+	tmux.RefreshPaneInfoCache()
+	if hs := readHookStatusFile(tuiInst.ID); hs != nil {
+		tuiInst.UpdateHookStatus(hs)
+	}
+	if err := tuiInst.UpdateStatus(); err != nil {
+		t.Fatalf("TUI UpdateStatus: %v", err)
+	}
+	tuiStatus := tuiInst.GetStatusThreadSafe()
+
+	if tuiStatus != StatusRunning {
+		// Sanity: if the TUI path itself does not report Running on this
+		// setup, the test oracle is wrong — bail before trusting the parity
+		// check.
+		t.Fatalf(
+			"test oracle broken: TUI path did not report running for a "+
+				"spinner-title session; got %q. Check tmux.RefreshPaneInfoCache "+
+				"and the AnalyzePaneTitle contract before blaming CLI parity.",
+			tuiStatus,
+		)
+	}
+
+	if cliStatus != tuiStatus {
+		t.Errorf(
+			"issue #610 parity break: TUI path=%q, CLI path=%q for the same "+
+				"tmux state. list --json must match /api/menu.",
+			tuiStatus, cliStatus,
+		)
+	}
+}
+
+// reloadInstanceForParityTest constructs a second Instance wrapper pointing
+// at the same underlying tmux session as base — simulates what
+// ReconnectSessionLazy does across process boundaries (TUI vs CLI as
+// separate OS processes reading the same sessions.json).
+func reloadInstanceForParityTest(base *Instance) *Instance {
+	reloaded := &Instance{
+		ID:          base.ID,
+		Title:       base.Title,
+		ProjectPath: base.ProjectPath,
+		GroupPath:   base.GroupPath,
+		Tool:        base.Tool,
+		Status:      StatusIdle,
+		CreatedAt:   time.Now().Add(-10 * time.Second), // past grace window
+	}
+	reloaded.tmuxSession = tmux.ReconnectSessionLazy(
+		base.tmuxSession.Name,
+		base.Title,
+		base.ProjectPath,
+		"claude",
+		"idle",
+	)
+	reloaded.tmuxSession.InstanceID = base.ID
+	return reloaded
+}


### PR DESCRIPTION
## Summary

CLI JSON emitters (`list --json`, `session show --json`, `status --json`, `group list --json`, `conductor status/list`) reported `idle`/`waiting` for sessions that the TUI and `/api/menu` showed as `running`. Root cause: the CLI never called `tmux.RefreshPaneInfoCache` before its `UpdateStatus` loop, so `GetStatus`'s title fast-path missed the braille spinner Claude sets during long tool calls.

Introduces `session.RefreshInstancesForCLIStatus(instances)` — the CLI analogue of `SessionDataService.refreshStatuses` (internal/web) and `Home.backgroundStatusUpdate` (internal/ui). Wires it into every CLI emitter that previously called `UpdateStatus()` cold.

**Parallel-paths audit:** every `UpdateStatus()` call site in `cmd/agent-deck/` now pre-warms:
- `main.go`  handleList JSON branch
- `main.go`  countByStatus (status / status --json)
- `session_cmd.go`  handleShow
- `conductor_cmd.go`  conductor status / list
- `group_cmd.go`  handleGroupList (JSON + table)

## Tests

Two new regression tests in `internal/session/instance_cli_parity_test.go`:
1. `TestUpdateStatus_CLIParity_SpinnerTitle_StaleHook` — CLI cold path with stale hook + braille-spinner title must report `StatusRunning`.
2. `TestUpdateStatus_CLIvsTUIParity_SameTmuxState` — CLI path output MUST equal TUI path output for the same tmux state.

## Test plan

- [x] Targeted parity tests PASS (morning verify session, tmux-visible host)
- [x] Full suite shows no new regressions vs main (only pre-existing `TestStatusEventWatcher_*` fsnotify flakes, reproduced on `main`)
- [x] Rebased cleanly onto main after v1.7.5–v1.7.8 cascade releases
- [ ] CI green (or triage matches pre-existing flake signatures)

Closes #610

Refs: PLAN.md data-flow trace in `.planning/fix-issue-610/PLAN.md`