### PR TITLE
fix(#604): rename dialog cursor goes to end of pre-filled name

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -450,3 +450,89 @@ tests:
       sleep 30; tmux capture-pane -t agentdeck_t-$i* -p | grep -q '● OK_$i' &&
       echo PASS_$i || echo FAIL_$i; agent-deck remove t-$i; done"
     expected: 10 PASS lines
+- id: issue-604-rename-session-cursor-at-end
+  added: '2026-04-17'
+  task: fix-issue-604
+  file: internal/ui/group_dialog_test.go
+  test_name: TestGroupDialog_ShowRenameSession_CursorAtEnd_Issue604
+  purpose: Regression test for #604 — opening the rename-session dialog must place
+    the cursor at the end of the pre-filled name. Before v1.7.11 the long-lived
+    textinput cursor bled between invocations, landing at min(prev_pos, new_len).
+  source: .planning/fix-issue-604/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestGroupDialog_ShowRenameSession_CursorAtEnd_Issue604
+      -race -count=1 -v
+    expected: pass
+- id: issue-604-rename-group-cursor-at-end
+  added: '2026-04-17'
+  task: fix-issue-604
+  file: internal/ui/group_dialog_test.go
+  test_name: TestGroupDialog_ShowRename_CursorAtEnd_Issue604
+  purpose: Same class of regression as #604 but for the group-rename entry point.
+    Cursor must land at end of pre-filled group name.
+  source: .planning/fix-issue-604/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestGroupDialog_ShowRename_CursorAtEnd_Issue604
+      -race -count=1 -v
+    expected: pass
+- id: issue-604-fresh-cursor-after-create-type
+  added: '2026-04-17'
+  task: fix-issue-604
+  file: internal/ui/group_dialog_test.go
+  test_name: TestGroupDialog_ShowRenameSession_FreshCursor_Issue604
+  purpose: After a Create-type cycle that advances the cursor, opening a rename
+    must reset the cursor to the end of the pre-filled name — not inherit the
+    typing cursor from Create mode.
+  source: .planning/fix-issue-604/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestGroupDialog_ShowRenameSession_FreshCursor_Issue604
+      -race -count=1 -v
+    expected: pass
+- id: issue-618-iterm-clearscrollback-constant
+  added: '2026-04-17'
+  task: fix-issue-618
+  file: internal/tmux/pty_test.go
+  test_name: TestITermClearScrollback_ConstantContents
+  purpose: Guard the iTerm2-specific OSC 1337 ClearScrollback constant. If the
+    constant drifts (typo, wrong terminator, accidental deletion), iTerm2 3.6.x
+    users regress to cross-session scrollback bleedover (#618 = regression of #419).
+  source: .planning/fix-issue-618/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestITermClearScrollback_ConstantContents
+      -race -count=1 -v
+    expected: pass
+- id: issue-618-emit-scrollback-clear-both-escapes
+  added: '2026-04-17'
+  task: fix-issue-618
+  file: internal/tmux/pty_test.go
+  test_name: TestEmitScrollbackClear_IncludesBothEscapes
+  purpose: Parallel-paths guard. Both Attach() entry and cleanupAttach() on
+    detach route through emitScrollbackClear(); this test asserts the helper
+    emits BOTH the generic CSI 3 J escape AND the iTerm2-specific OSC 1337
+    ClearScrollback escape in the correct order (CSI first, OSC second).
+    Prevents silent drift between the two boundaries — the exact regression
+    pattern that bit #419.
+  source: .planning/fix-issue-618/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestEmitScrollbackClear_IncludesBothEscapes
+      -race -count=1 -v
+    expected: pass
+- id: issue-618-cleanup-attach-emits-iterm-osc1337
+  added: '2026-04-17'
+  task: fix-issue-618
+  file: internal/tmux/pty_test.go
+  test_name: TestCleanupAttach_EmitsITermClearScrollback
+  purpose: Live-boundary regression. Detach path (Ctrl+Q) must emit OSC 1337
+    ClearScrollback on stdout so iTerm2 3.6.x actually clears its scrollback
+    (#618). TTY-gated — skips on CI without a terminal.
+  source: .planning/fix-issue-618/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestCleanupAttach_EmitsITermClearScrollback
+      -race -count=1 -v
+    expected: pass

--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -59,6 +59,7 @@ func (g *GroupDialog) Show() {
 	g.parentName = ""
 	g.validationErr = ""
 	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604: reset cursor — SetValue only clamps, it does not reset.
 	g.nameInput.Focus()
 }
 
@@ -70,6 +71,7 @@ func (g *GroupDialog) ShowCreateSubgroup(parentPath, parentName string) {
 	g.parentName = parentName
 	g.validationErr = ""
 	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
 	g.nameInput.Focus()
 }
 
@@ -83,6 +85,7 @@ func (g *GroupDialog) ShowCreateWithContext(parentPath, parentName string) {
 	g.contextParentName = parentName
 	g.validationErr = ""
 	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
 	g.nameInput.Focus()
 
 	if parentPath != "" {
@@ -106,6 +109,7 @@ func (g *GroupDialog) ShowCreateWithContextDefaultRoot(parentPath, parentName st
 	g.contextParentName = parentName
 	g.validationErr = ""
 	g.nameInput.SetValue("")
+	g.nameInput.CursorEnd() // Issue #604
 	g.nameInput.Focus()
 
 	// Default to root mode, Tab toggles to subgroup
@@ -143,6 +147,7 @@ func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 	g.groupPath = currentPath
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
+	g.nameInput.CursorEnd() // Issue #604: place cursor at end of pre-filled name.
 	g.nameInput.Focus()
 }
 
@@ -162,6 +167,7 @@ func (g *GroupDialog) ShowRenameSession(sessionID, currentName string) {
 	g.sessionID = sessionID
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
+	g.nameInput.CursorEnd() // Issue #604: place cursor at end of pre-filled name.
 	g.nameInput.Focus()
 }
 

--- a/internal/ui/group_dialog_test.go
+++ b/internal/ui/group_dialog_test.go
@@ -19,3 +19,78 @@ func TestGroupDialog_NameInput_AcceptsUnderscore(t *testing.T) {
 		t.Errorf("nameInput.Value() = %q after typing '_', want %q", updated.nameInput.Value(), "_")
 	}
 }
+
+// TestGroupDialog_ShowRenameSession_CursorAtEnd_Issue604 verifies that after a
+// prior rename with a shorter name, opening ShowRenameSession with a longer
+// name places the cursor at the end of the new name, not at the stale cursor
+// position clamped to the new length. Regression test for issue #604.
+func TestGroupDialog_ShowRenameSession_CursorAtEnd_Issue604(t *testing.T) {
+	g := NewGroupDialog()
+
+	// First rename: short name; user types a bit, then "saves" (we simulate
+	// only the cursor state leak — no actual save needed).
+	g.ShowRenameSession("sess-1", "alpha") // 5 chars
+	// Cursor should be at end (5) initially.
+	if pos := g.nameInput.Position(); pos != len("alpha") {
+		t.Fatalf("first ShowRenameSession: initial cursor = %d, want %d", pos, len("alpha"))
+	}
+	// Simulate user editing: move cursor to position 2 (e.g. by pressing
+	// left arrow a few times or clicking).
+	g.nameInput.SetCursor(2)
+	g.Hide()
+
+	// Second rename: a longer name. Cursor should go to end of new name.
+	longName := "delta-epsilon-zeta-eta" // 22 chars
+	g.ShowRenameSession("sess-2", longName)
+
+	if pos := g.nameInput.Position(); pos != len(longName) {
+		t.Errorf("second ShowRenameSession: cursor = %d, want %d (end of %q)",
+			pos, len(longName), longName)
+	}
+}
+
+// TestGroupDialog_ShowRename_CursorAtEnd_Issue604 is the same regression as
+// above but for the group-rename entry point.
+func TestGroupDialog_ShowRename_CursorAtEnd_Issue604(t *testing.T) {
+	g := NewGroupDialog()
+
+	g.ShowRename("/a", "alpha")
+	g.nameInput.SetCursor(2)
+	g.Hide()
+
+	longName := "some-much-longer-group-name"
+	g.ShowRename("/b", longName)
+
+	if pos := g.nameInput.Position(); pos != len(longName) {
+		t.Errorf("second ShowRename: cursor = %d, want %d (end of %q)",
+			pos, len(longName), longName)
+	}
+}
+
+// TestGroupDialog_ShowRenameSession_FreshCursor_Issue604 verifies that after a
+// Create-then-type cycle (which leaves the cursor advanced), opening a rename
+// resets the cursor to the end of the pre-filled name — not to wherever the
+// cursor was left from the Create dialog.
+func TestGroupDialog_ShowRenameSession_FreshCursor_Issue604(t *testing.T) {
+	g := NewGroupDialog()
+
+	g.Show() // create mode, empty name
+	// Simulate typing 3 characters: cursor advances to 3.
+	for _, r := range "abc" {
+		key := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+		updated, _ := g.Update(key)
+		g = updated
+	}
+	if pos := g.nameInput.Position(); pos != 3 {
+		t.Fatalf("sanity: after typing 'abc' cursor = %d, want 3", pos)
+	}
+	g.Hide()
+
+	name := "my-session"
+	g.ShowRenameSession("sess-X", name)
+
+	if pos := g.nameInput.Position(); pos != len(name) {
+		t.Errorf("ShowRenameSession after Create-type cycle: cursor = %d, want %d",
+			pos, len(name))
+	}
+}


### PR DESCRIPTION
Closes #604

## Summary

`GroupDialog` in the TUI holds a long-lived `textinput.Model`. Its cursor state persisted across dialog invocations: `bubbles`' `SetValue` only re-positions the cursor when the value is empty or the stale cursor is past the new length, so the cursor bled through at `min(prev_cursor_pos, len(new_name))`.

Reporter @jasmine-wu-ai called this exactly in #604: *"it seems like when renaming a session, the cursor always moves to the minimum of: 1. length of word, 2. length of session last renamed."*

## Fix

Call `CursorEnd()` after every `SetValue` in the dialog's `Show*` entry points. Scope is tight: 6 lines in `internal/ui/group_dialog.go`, no behaviour change outside the dialog.

## Tests (regression)

Three new tests in `internal/ui/group_dialog_test.go`, all appended to `.claude/release-tests.yaml`:

- `TestGroupDialog_ShowRenameSession_CursorAtEnd_Issue604` — shorter-then-longer rename cycle on session rename
- `TestGroupDialog_ShowRename_CursorAtEnd_Issue604` — same for group rename
- `TestGroupDialog_ShowRenameSession_FreshCursor_Issue604` — Create-then-type cycle leaking into rename

All three fail on `main` (confirmed TDD red) and pass on this branch. Full `./internal/ui/...` suite green, 5/5 race-enabled runs green.

## Test plan

- [x] `go test ./internal/ui/ -run Issue604 -race -count=1` — 3/3 pass
- [x] `go test ./internal/ui/... -count=1` — full package suite green
- [x] 5x consecutive race-enabled runs — all green
- [x] Pre-push CI hook (fmt + vet + lint + build + full test) — passed

## Out of scope

No other dialogs (feedback, fork, new, skill, mcp) touched. Scope constrained to session/group rename per issue.