### PR TITLE
fix(#618): iTerm2 OSC 1337 ClearScrollback on attach and detach

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -668,3 +668,47 @@ tests:
     command: go test ./internal/session/ -run TestInstance_RefreshLiveSessionIDs_NoOpWhenTmuxSessionNil
       -race -count=1 -v
     expected: pass
+- id: issue-618-iterm-clearscrollback-constant
+  added: '2026-04-17'
+  task: fix-issue-618
+  file: internal/tmux/pty_test.go
+  test_name: TestITermClearScrollback_ConstantContents
+  purpose: Guard the iTerm2-specific OSC 1337 ClearScrollback constant. If the
+    constant drifts (typo, wrong terminator, accidental deletion), iTerm2 3.6.x
+    users regress to cross-session scrollback bleedover (#618 = regression of #419).
+  source: .planning/fix-issue-618/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestITermClearScrollback_ConstantContents
+      -race -count=1 -v
+    expected: pass
+- id: issue-618-emit-scrollback-clear-both-escapes
+  added: '2026-04-17'
+  task: fix-issue-618
+  file: internal/tmux/pty_test.go
+  test_name: TestEmitScrollbackClear_IncludesBothEscapes
+  purpose: Parallel-paths guard. Both Attach() entry and cleanupAttach() on
+    detach route through emitScrollbackClear(); this test asserts the helper
+    emits BOTH the generic CSI 3 J escape AND the iTerm2-specific OSC 1337
+    ClearScrollback escape in the correct order (CSI first, OSC second).
+    Prevents silent drift between the two boundaries.
+  source: .planning/fix-issue-618/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestEmitScrollbackClear_IncludesBothEscapes
+      -race -count=1 -v
+    expected: pass
+- id: issue-618-cleanup-attach-emits-iterm-osc1337
+  added: '2026-04-17'
+  task: fix-issue-618
+  file: internal/tmux/pty_test.go
+  test_name: TestCleanupAttach_EmitsITermClearScrollback
+  purpose: Live-boundary regression. Detach path (Ctrl+Q) must emit OSC 1337
+    ClearScrollback on stdout so iTerm2 3.6.x actually clears its scrollback
+    (#618). TTY-gated — skips on CI without a terminal.
+  source: .planning/fix-issue-618/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestCleanupAttach_EmitsITermClearScrollback
+      -race -count=1 -v
+    expected: pass

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -72,6 +72,35 @@ func waitForAttachOutputDrain(outputDone <-chan struct{}, timeout time.Duration)
 	}
 }
 
+// Scrollback-clear escape sequences. See emitScrollbackClear below for the
+// full rationale on why iTerm2 3.6.x requires the OSC 1337 supplement (#618).
+const (
+	// clearScrollbackCSI is CSI 3 J — "Erase Saved Lines". Honored by Terminal.app,
+	// WezTerm, Alacritty, Ghostty, Kitty, xterm, and older iTerm2 builds.
+	clearScrollbackCSI = "\x1b[3J"
+	// itermClearScrollback is OSC 1337 ; ClearScrollback BEL — iTerm2-specific.
+	// Required by iTerm2 3.6.x when "Save lines to scrollback in alternate screen
+	// mode" is OFF (#618). Other terminals parse the OSC payload and discard it
+	// safely — adding this escape is strictly additive, no regression risk.
+	itermClearScrollback = "\x1b]1337;ClearScrollback\a"
+)
+
+// emitScrollbackClear writes escape sequences to clear the host terminal's
+// scrollback buffer. Both the generic CSI 3 J escape AND the iTerm2-specific
+// OSC 1337 ClearScrollback escape are emitted, in that order:
+//
+//   - CSI first — broadly-compatible, terminals that honor it short-circuit.
+//   - OSC second — belt-and-suspenders for iTerm2 3.6.x where CSI alone is
+//     insufficient when alt-screen-scrollback-save is disabled (#618 regression
+//     of #419).
+//
+// Both Attach() entry and cleanupAttach() (exit) route through this helper so
+// the two boundaries cannot silently drift apart (parallel-paths invariant).
+func emitScrollbackClear(w io.Writer) {
+	_, _ = io.WriteString(w, clearScrollbackCSI)
+	_, _ = io.WriteString(w, itermClearScrollback)
+}
+
 // Attach attaches to the tmux session with full PTY support.
 // The configured detach key (default Ctrl+Q) will detach and return to the caller.
 // Pass an optional detachByte to override the default (0x11 / Ctrl+Q).
@@ -87,14 +116,16 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 
 	// Clear the outer terminal emulator's scrollback buffer to prevent
 	// stale content from a previously-attached session bleeding into the
-	// new one (#419). \033[3J is the "Erase Saved Lines" escape (ED param 3)
-	// supported by iTerm2, Terminal.app, Ghostty, and most modern emulators.
+	// new one (#419, #618). emitScrollbackClear writes both the generic
+	// CSI 3 J escape AND the iTerm2-specific OSC 1337 ClearScrollback escape —
+	// the latter is required for iTerm2 3.6.x where CSI alone is insufficient
+	// when alt-screen-scrollback-save is disabled (#618 regression of #419).
 	//
 	// Note: We intentionally do NOT call `tmux clear-history` here. tmux pane
 	// histories are per-pane, so session A's output never appears in session B's
 	// scrollback. Clearing pane history on attach destroys the user's scrollback
 	// and breaks mouse-wheel / copy-mode navigation (#531).
-	_, _ = os.Stdout.WriteString("\033[3J")
+	emitScrollbackClear(os.Stdout)
 
 	// Create context with cancel for detach
 	ctx, cancel := context.WithCancel(ctx)
@@ -175,7 +206,6 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 
 	startTime := time.Now()
 	const terminalStyleReset = "\x1b]8;;\x1b\\\x1b[0m\x1b[24m\x1b[39m\x1b[49m"
-	const clearScrollback = "\033[3J"
 	outputDone := make(chan struct{})
 
 	// Goroutine 1: Copy PTY output to stdout
@@ -284,8 +314,10 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 		}
 		// Clear host terminal scrollback before returning to TUI.
 		// The on-attach clear at the top of Attach() covers the "next attach" direction;
-		// this covers the "on detach" direction for belt-and-suspenders coverage (#419).
-		_, _ = os.Stdout.WriteString(clearScrollback)
+		// this covers the "on detach" direction for belt-and-suspenders coverage
+		// (#419, #618). emitScrollbackClear emits CSI 3 J + iTerm2-specific OSC 1337
+		// ClearScrollback — both boundaries route through one helper so they cannot drift.
+		emitScrollbackClear(os.Stdout)
 		// Reset OSC-8 hyperlink state + SGR attributes before Bubble Tea redraws.
 		_, _ = os.Stdout.WriteString(terminalStyleReset)
 	}

--- a/internal/tmux/pty_test.go
+++ b/internal/tmux/pty_test.go
@@ -340,3 +340,82 @@ func TestCleanupAttach_ScrollbackClearBeforeStyleReset(t *testing.T) {
 	require.Less(t, scrollIdx, styleIdx,
 		"\\033[3J (scrollback clear) must appear BEFORE terminalStyleReset (per D-04); captured: %q", captured)
 }
+
+// TestITermClearScrollback_ConstantContents asserts the iTerm2-specific OSC 1337
+// ClearScrollback escape constant is defined correctly (#618).
+func TestITermClearScrollback_ConstantContents(t *testing.T) {
+	require.Equal(t, "\x1b]1337;ClearScrollback\a", itermClearScrollback,
+		"itermClearScrollback constant must be the exact OSC 1337 ClearScrollback sequence with BEL terminator")
+}
+
+// TestEmitScrollbackClear_IncludesBothEscapes asserts the emitScrollbackClear
+// helper writes BOTH the generic CSI 3 J escape AND the iTerm2-specific
+// OSC 1337 ClearScrollback escape, in order (CSI first, OSC second).
+// Parallel-paths guarantee for #618 regression of #419.
+func TestEmitScrollbackClear_IncludesBothEscapes(t *testing.T) {
+	var buf bytes.Buffer
+	emitScrollbackClear(&buf)
+
+	csiIdx := bytes.Index(buf.Bytes(), []byte("\x1b[3J"))
+	oscIdx := bytes.Index(buf.Bytes(), []byte("\x1b]1337;ClearScrollback\a"))
+
+	require.NotEqual(t, -1, csiIdx,
+		"emitScrollbackClear must emit \\033[3J (CSI 3 J); captured: %q", buf.String())
+	require.NotEqual(t, -1, oscIdx,
+		"emitScrollbackClear must emit \\033]1337;ClearScrollback\\a (OSC 1337) for iTerm2 3.6.x (#618); captured: %q", buf.String())
+	require.Less(t, csiIdx, oscIdx,
+		"\\033[3J (CSI) must be emitted BEFORE \\033]1337;ClearScrollback\\a (OSC 1337); captured: %q", buf.String())
+}
+
+// TestCleanupAttach_EmitsITermClearScrollback verifies that cleanupAttach()
+// emits the iTerm2-specific OSC 1337 ClearScrollback escape on detach (#618).
+func TestCleanupAttach_EmitsITermClearScrollback(t *testing.T) {
+	skipIfNoTmuxServer(t)
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		t.Skip("stdin is not a terminal (CI/pipe environment); skipping PTY attach test")
+	}
+
+	name := SessionPrefix + "ptytest-itermscroll-" + fmt.Sprintf("%d", time.Now().UnixNano()%100000)
+	require.NoError(t,
+		exec.Command("tmux", "new-session", "-d", "-s", name, "bash").Run(),
+		"failed to create test session %s", name,
+	)
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", name).Run() })
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	oldStdout := os.Stdout
+	os.Stdout = w
+
+	sess := &Session{Name: name}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	attachDone := make(chan error, 1)
+	go func() { attachDone <- sess.Attach(ctx, 0x11) }()
+
+	time.Sleep(300 * time.Millisecond)
+	require.NoError(t,
+		exec.Command("tmux", "send-keys", "-t", name, "C-q", "").Run(),
+		"failed to send detach key",
+	)
+
+	select {
+	case attachErr := <-attachDone:
+		os.Stdout = oldStdout
+		w.Close()
+		require.NoError(t, attachErr, "Attach returned error after detach")
+	case <-time.After(4 * time.Second):
+		cancel()
+		os.Stdout = oldStdout
+		w.Close()
+		t.Fatal("Attach did not return after detach key was sent")
+	}
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	captured := buf.String()
+	require.Contains(t, captured, "\x1b]1337;ClearScrollback\a",
+		"cleanupAttach() must emit \\033]1337;ClearScrollback\\a (OSC 1337) to clear iTerm2 3.6.x scrollback on detach (#618)")
+}


### PR DESCRIPTION
## Summary

Fixes cross-session scrollback bleedover on iTerm2 3.6.x — a regression of #419.

**Problem:** iTerm2 3.6.x with "Save lines to scrollback in alternate screen mode" OFF does not honor the generic `\033[3J` (CSI 3 J) escape sufficiently to clear its scrollback when agent-deck switches between sessions. Prior-session output remains visible on scroll-up, breaking core multi-session UX (reported by @godlen4332 in #609 / #618).

**Fix:** Emit the iTerm2-specific OSC 1337 `ClearScrollback` escape (`\x1b]1337;ClearScrollback\a`) alongside the existing CSI 3 J at both attach entry (`Attach()`) and detach cleanup (`cleanupAttach()`). Both call sites now route through a single helper `emitScrollbackClear(io.Writer)` so the two boundaries cannot silently drift — the exact parallel-paths pattern that caused #618 to regress #419.

Other terminals parse unknown OSC payloads and discard them safely, so adding the OSC 1337 escape is strictly additive. No regression risk for WezTerm, Alacritty, Ghostty, Kitty, Terminal.app, xterm.

## Changes

- `internal/tmux/pty.go` — package-level `clearScrollbackCSI` + `itermClearScrollback` constants, new `emitScrollbackClear(w io.Writer)` helper, 2 call sites updated (attach entry, cleanupAttach).
- `internal/tmux/pty_test.go` — 3 new tests (2 CI-safe, 1 TTY-gated).
- `.claude/release-tests.yaml` — 3 regression manifest entries.

## Tests

- `TestITermClearScrollback_ConstantContents` — constant shape guard (CI-safe).
- `TestEmitScrollbackClear_IncludesBothEscapes` — helper writes both CSI + OSC 1337 in order (CI-safe). **This is the parallel-paths regression guard.**
- `TestCleanupAttach_EmitsITermClearScrollback` — live-boundary assertion on stdout bytes after real tmux detach (TTY-gated).

All three confirmed RED on main (compile errors against the new symbols), GREEN after the fix. 5/5 race runs all green.

## Test plan

- [x] Write failing tests (TDD RED) before the fix
- [x] Confirm tests fail on main
- [x] Implement fix — minimal scope, helper factored for parallel-paths discipline
- [x] Full tmux package tests pass with `-race -count=1`
- [x] Live-boundary verify x5 (all GREEN)
- [x] Append three regression entries to `.claude/release-tests.yaml` and verify each runs
- [ ] iTerm2 end-user confirmation by original reporter (follow-up after release)

Closes #618