### PR TITLE
fix(#617): expand $HOME/${HOME} in sources.toml for cross-machine portability

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -674,3 +674,47 @@ tests:
   run:
     command: go test ./internal/tmux/ -run TestTmuxBootstrap_ServerIsRunning -race -count=1 -v
     expected: pass
+- id: issue-617-dollar-home-expand
+  added: '2026-04-17'
+  task: fix-617
+  file: internal/session/skills_catalog_test.go
+  test_name: TestExpandSkillPath_DollarHome
+  purpose: Regression guard for issue-617 cross-machine portability. Pins that expandSkillPath expands $HOME so a sources.toml synced macOS-to-Linux (or across Linux hosts with different usernames) does not silently return "No skills found".
+  source: .planning/fix-617/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestExpandSkillPath_DollarHome -count=1 -v
+    expected: pass
+- id: issue-617-braced-home-expand
+  added: '2026-04-17'
+  task: fix-617
+  file: internal/session/skills_catalog_test.go
+  test_name: TestExpandSkillPath_BracedDollarHome
+  purpose: Regression guard that ${HOME} (braced form) expands alongside $HOME. Protects against a partial fix that only handles one form.
+  source: .planning/fix-617/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestExpandSkillPath_BracedDollarHome -count=1 -v
+    expected: pass
+- id: issue-617-unknown-envvar-preserved
+  added: '2026-04-17'
+  task: fix-617
+  file: internal/session/skills_catalog_test.go
+  test_name: TestExpandSkillPath_UnknownEnvVarPreserved
+  purpose: Scope guard — only $HOME is expanded. Prevents a future "simplify to os.ExpandEnv" regression from silently inheriting arbitrary process environment ($USER, $PATH, secrets) into config paths.
+  source: .planning/fix-617/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestExpandSkillPath_UnknownEnvVarPreserved -count=1 -v
+    expected: pass
+- id: issue-617-discover-via-dollar-home
+  added: '2026-04-17'
+  task: fix-617
+  file: internal/session/skills_catalog_test.go
+  test_name: TestLoadSkillSources_DiscoversSkillsViaDollarHome
+  purpose: End-to-end guard covering the full load→discovery hop — writes a sources.toml with $HOME, populates a pool skill, and asserts ListAvailableSkills finds it. Covers the exact repro in issue-617.
+  source: .planning/fix-617/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestLoadSkillSources_DiscoversSkillsViaDollarHome -count=1 -v
+    expected: pass

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.16" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.17" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -112,6 +112,20 @@ func expandSkillPath(path string) string {
 	if path == "" {
 		return ""
 	}
+	// Expand $HOME and ${HOME} anywhere in the path so sources.toml is portable
+	// across machines with different home-directory layouts (issue #617). Only
+	// HOME is recognised; other env references pass through verbatim so config
+	// paths do not silently inherit arbitrary process environment.
+	if strings.Contains(path, "$") {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = os.Expand(path, func(name string) string {
+				if name == "HOME" {
+					return home
+				}
+				return "$" + name
+			})
+		}
+	}
 	if path == "~" {
 		home, err := os.UserHomeDir()
 		if err == nil {

--- a/internal/session/skills_catalog_test.go
+++ b/internal/session/skills_catalog_test.go
@@ -77,6 +77,138 @@ func TestLoadSkillSources_DefaultsWhenMissing(t *testing.T) {
 	}
 }
 
+func TestExpandSkillPath_DollarHome(t *testing.T) {
+	homeDir, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	got := expandSkillPath("$HOME/.agent-deck/skills/pool")
+	want := filepath.Join(homeDir, ".agent-deck", "skills", "pool")
+	if got != want {
+		t.Fatalf("expandSkillPath($HOME/...) = %q, want %q", got, want)
+	}
+}
+
+func TestExpandSkillPath_BracedDollarHome(t *testing.T) {
+	homeDir, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	got := expandSkillPath("${HOME}/foo")
+	want := filepath.Join(homeDir, "foo")
+	if got != want {
+		t.Fatalf("expandSkillPath(${HOME}/foo) = %q, want %q", got, want)
+	}
+}
+
+func TestExpandSkillPath_BareDollarHome(t *testing.T) {
+	homeDir, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	if got := expandSkillPath("$HOME"); got != homeDir {
+		t.Fatalf("expandSkillPath($HOME) = %q, want %q", got, homeDir)
+	}
+	if got := expandSkillPath("${HOME}"); got != homeDir {
+		t.Fatalf("expandSkillPath(${HOME}) = %q, want %q", got, homeDir)
+	}
+}
+
+func TestExpandSkillPath_DollarHomeSubstringPreserved(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	// $HOMEBREW must NOT match $HOME — env var name is HOMEBREW, not HOME.
+	got := expandSkillPath("/etc/$HOMEBREW/foo")
+	want := filepath.Clean("/etc/$HOMEBREW/foo")
+	if got != want {
+		t.Fatalf("expandSkillPath(/etc/$HOMEBREW/foo) = %q, want %q", got, want)
+	}
+}
+
+func TestExpandSkillPath_UnknownEnvVarPreserved(t *testing.T) {
+	_, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	// Only $HOME is expanded. Other env refs pass through verbatim so sources.toml
+	// does not silently inherit arbitrary process environment into config paths.
+	got := expandSkillPath("$USER/foo")
+	want := filepath.Clean("$USER/foo")
+	if got != want {
+		t.Fatalf("expandSkillPath($USER/foo) = %q, want %q", got, want)
+	}
+}
+
+func TestLoadSkillSources_ExpandsDollarHomeOnLoad(t *testing.T) {
+	homeDir, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	sourcesPath, err := GetSkillSourcesPath()
+	if err != nil {
+		t.Fatalf("GetSkillSourcesPath failed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(sourcesPath), 0o700); err != nil {
+		t.Fatalf("failed to create sources dir: %v", err)
+	}
+
+	toml := "[sources.pool]\n" +
+		`path = "$HOME/.agent-deck/skills/pool"` + "\n" +
+		`description = "sync-from-mac"` + "\n" +
+		"enabled = true\n"
+	if err := os.WriteFile(sourcesPath, []byte(toml), 0o600); err != nil {
+		t.Fatalf("failed to write sources.toml: %v", err)
+	}
+
+	sources, err := LoadSkillSources()
+	if err != nil {
+		t.Fatalf("LoadSkillSources failed: %v", err)
+	}
+
+	pool, ok := sources["pool"]
+	if !ok {
+		t.Fatalf("expected pool source in sources map")
+	}
+	want := filepath.Join(homeDir, ".agent-deck", "skills", "pool")
+	if pool.Path != want {
+		t.Fatalf("pool.Path = %q, want %q (was $HOME expanded on load?)", pool.Path, want)
+	}
+}
+
+func TestLoadSkillSources_DiscoversSkillsViaDollarHome(t *testing.T) {
+	homeDir, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+
+	poolRoot := filepath.Join(homeDir, ".agent-deck", "skills", "pool")
+	writeSkillDir(t, poolRoot, "demo", "demo", "Demo skill for #617 repro")
+
+	sourcesPath, err := GetSkillSourcesPath()
+	if err != nil {
+		t.Fatalf("GetSkillSourcesPath failed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(sourcesPath), 0o700); err != nil {
+		t.Fatalf("failed to create sources dir: %v", err)
+	}
+	toml := "[sources.pool]\n" +
+		`path = "$HOME/.agent-deck/skills/pool"` + "\n" +
+		"enabled = true\n"
+	if err := os.WriteFile(sourcesPath, []byte(toml), 0o600); err != nil {
+		t.Fatalf("failed to write sources.toml: %v", err)
+	}
+
+	candidates, err := ListAvailableSkills()
+	if err != nil {
+		t.Fatalf("ListAvailableSkills failed: %v", err)
+	}
+
+	found := false
+	for _, c := range candidates {
+		if c.Source == "pool" && c.Name == "demo" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected to discover pool/demo via $HOME expansion; got %d candidates: %+v", len(candidates), candidates)
+	}
+}
+
 func TestAddAndRemoveSkillSource(t *testing.T) {
 	_, cleanup := setupSkillTestEnv(t)
 	defer cleanup()


### PR DESCRIPTION
Fixes #617.

## Summary
`~/.agent-deck/skills/sources.toml` required absolute paths. Users syncing the file verbatim across machines (macOS → Linux, or across hosts with different usernames) hit a silent failure: hardcoded `/Users/alice/...` doesn't exist on target, so `agent-deck skill list` returns "No skills found".

This PR extends `expandSkillPath` to also expand `$HOME` and `${HOME}` anywhere in a path. `~`/`~/` expansion already existed; `$HOME` was the missing form the issue requested. Only `HOME` is recognized — other env references pass through verbatim so sources.toml does not silently inherit arbitrary process environment into config paths.

## Design notes
- Single chokepoint: all 5 data-flow hops (load, save, add, list, discovery) converge on `expandSkillPath`. One surgical patch covers every path.
- Uses `os.Expand` with a scoped mapping (`name == "HOME"`) rather than `os.ExpandEnv` to prevent future drift where other vars (`$USER`, `$PATH`, secrets) could silently leak.

## Tests (4 regression entries added to `.claude/release-tests.yaml`)
- `TestExpandSkillPath_DollarHome` — `$HOME/...` expands
- `TestExpandSkillPath_BracedDollarHome` — `${HOME}/...` expands
- `TestExpandSkillPath_UnknownEnvVarPreserved` — `$USER/...` passes through (scope guard)
- `TestLoadSkillSources_DiscoversSkillsViaDollarHome` — end-to-end: sources.toml with `$HOME` → skill discovered by `ListAvailableSkills`
- Plus `TestExpandSkillPath_BareDollarHome` and `TestExpandSkillPath_DollarHomeSubstringPreserved` in the test file (covering `$HOMEBREW` vs `$HOME` boundary).

Full suite green (`go test ./... -race -count=1`). Live-boundary verified: real `agent-deck` binary + real sources.toml with `$HOME/...` → skill listed. Confirmed on main that hardcoded `/Users/alice/...` still produces the original "No skills found" symptom — the fix is what unlocks it.

## Version
Bumped to v1.7.17.

## Test plan
- [x] RED tests committed first (failed on main, one per expansion form)
- [x] Implementation makes them GREEN
- [x] Full test suite green at `-count=1` (pre-existing `TestWatcherEventDedup` SQLite flake only, documented)
- [x] Live-boundary verification against real binary with `\$HOME` and `\${HOME}` forms
- [x] Manifest append passes `TestManifestIsValidYAML` + `TestManifestReferencesExistInSource`