### PR TITLE
feat(claude): add --extra-arg CLI flag and TUI field for custom claude CLI tokens

### DIFF
--- a/cmd/agent-deck/extraargs_cmd_test.go
+++ b/cmd/agent-deck/extraargs_cmd_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAddExtraArgFlag asserts that `agent-deck add --extra-arg <token>`
+// is parsed (repeatable) and the args persist on the new session.
+//
+// Failure mode on main:
+//
+//	flag provided but not defined: -extra-arg
+//	(exit 2 from flag.NewFlagSet ExitOnError)
+func TestAddExtraArgFlag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add",
+		"-t", "ea-add-test",
+		"-c", "claude",
+		"--extra-arg", "--agent",
+		"--extra-arg", "my-agent",
+		"--no-parent",
+		"--json",
+		projectDir,
+	)
+	if code != 0 {
+		t.Fatalf(
+			"agent-deck add --extra-arg failed (exit %d) — feature missing\n"+
+				"stdout: %s\nstderr: %s",
+			code, stdout, stderr,
+		)
+	}
+
+	listJSON := readSessionsJSON(t, home)
+
+	if !strings.Contains(listJSON, "--agent") {
+		t.Errorf("persisted sessions missing --agent token; got:\n%s", listJSON)
+	}
+	if !strings.Contains(listJSON, "my-agent") {
+		t.Errorf("persisted sessions missing my-agent value; got:\n%s", listJSON)
+	}
+}
+
+// TestSessionSetExtraArgs asserts that
+// `agent-deck session set <id> extra-args <space-separated>` updates the field.
+func TestSessionSetExtraArgs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add",
+		"-t", "ea-set-test",
+		"-c", "claude",
+		"--no-parent",
+		"--json",
+		projectDir,
+	)
+	if code != 0 {
+		t.Fatalf("agent-deck add failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var addResp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &addResp); err != nil {
+		t.Fatalf("parse add response: %v\nstdout: %s", err, stdout)
+	}
+	if addResp.ID == "" {
+		t.Fatalf("add returned empty id; stdout: %s", stdout)
+	}
+
+	// Use `--` terminator so Go's flag package leaves --model alone.
+	stdout, stderr, code = runAgentDeck(t, home,
+		"session", "set", "--json", addResp.ID, "extra-args",
+		"--", "--model", "opus",
+	)
+	if code != 0 {
+		t.Fatalf(
+			"agent-deck session set <id> extra-args failed (exit %d) — feature missing\n"+
+				"stdout: %s\nstderr: %s",
+			code, stdout, stderr,
+		)
+	}
+
+	listJSON := readSessionsJSON(t, home)
+	if !strings.Contains(listJSON, "--model") {
+		t.Errorf("session set extra-args did not persist --model; list output:\n%s", listJSON)
+	}
+	if !strings.Contains(listJSON, "opus") {
+		t.Errorf("session set extra-args did not persist opus; list output:\n%s", listJSON)
+	}
+
+	// Clear via empty-string value: `extra-args ""` must reset the list.
+	_, stderr, code = runAgentDeck(t, home,
+		"session", "set", "--json", addResp.ID, "extra-args", "",
+	)
+	if code != 0 {
+		t.Fatalf("clear extra-args failed (exit %d)\nstderr: %s", code, stderr)
+	}
+	listJSON = readSessionsJSON(t, home)
+	if strings.Contains(listJSON, "--model") || strings.Contains(listJSON, "opus") {
+		t.Errorf("clear via \"\" did not reset extra-args; list output:\n%s", listJSON)
+	}
+
+	// Empty tokens mixed with real ones must be dropped (avoid emitting
+	// literal '' to claude). `extra-args -- "" --model "" opus` → [--model, opus].
+	_, stderr, code = runAgentDeck(t, home,
+		"session", "set", "--json", addResp.ID, "extra-args",
+		"--", "", "--model", "", "opus",
+	)
+	if code != 0 {
+		t.Fatalf("extra-args with mixed empty tokens failed (exit %d)\nstderr: %s", code, stderr)
+	}
+	listJSON = readSessionsJSON(t, home)
+	if !strings.Contains(listJSON, "--model") || !strings.Contains(listJSON, "opus") {
+		t.Errorf("real tokens missing after mixed-empty set; list output:\n%s", listJSON)
+	}
+	// Ensure JSON array does not contain an empty-string element.
+	var listResp []struct {
+		ID        string   `json:"id"`
+		ExtraArgs []string `json:"extra_args"`
+	}
+	if err := json.Unmarshal([]byte(listJSON), &listResp); err != nil {
+		t.Fatalf("parse list JSON: %v", err)
+	}
+	var match *struct {
+		ID        string   `json:"id"`
+		ExtraArgs []string `json:"extra_args"`
+	}
+	for i := range listResp {
+		if listResp[i].ID == addResp.ID {
+			match = &listResp[i]
+			break
+		}
+	}
+	if match == nil {
+		t.Fatalf("session %s not found in list", addResp.ID)
+	}
+	for _, tok := range match.ExtraArgs {
+		if tok == "" {
+			t.Errorf("empty token leaked into persisted ExtraArgs: %v", match.ExtraArgs)
+		}
+	}
+	if len(match.ExtraArgs) != 2 {
+		t.Errorf("expected exactly 2 tokens after empty-strip, got %v", match.ExtraArgs)
+	}
+}
+
+// TestExtraArgsOnlyForClaude asserts the tool-restriction contract, same
+// shape as TestChannelsOnlyForClaude in channels_cmd_test.go:246.
+//
+// On main the field is universally rejected. Positive+negative arms are
+// required to prevent a false-PASS where the generic rejection trivially
+// satisfies a unilateral negative test.
+func TestExtraArgsOnlyForClaude(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	claudeProj := filepath.Join(home, "claude-proj")
+	shellProj := filepath.Join(home, "shell-proj")
+	for _, p := range []string{claudeProj, shellProj} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Positive control: claude session accepts extra-args.
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add", "-t", "ea-claude-ok", "-c", "claude", "--no-parent", "--json", claudeProj,
+	)
+	if code != 0 {
+		t.Fatalf("add claude failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var claudeResp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &claudeResp); err != nil {
+		t.Fatalf("parse claude add response: %v\nstdout: %s", err, stdout)
+	}
+
+	stdout, stderr, code = runAgentDeck(t, home,
+		"session", "set", "--json", claudeResp.ID, "extra-args",
+		"--", "--model", "opus",
+	)
+	if code != 0 {
+		t.Fatalf(
+			"positive control failed: setting extra-args on CLAUDE session "+
+				"should succeed (exit %d)\nstdout: %s\nstderr: %s",
+			code, stdout, stderr,
+		)
+	}
+
+	// Negative control: shell session rejects extra-args with a tool-specific message.
+	stdout, stderr, code = runAgentDeck(t, home,
+		"add", "-t", "ea-shell-reject", "-c", "bash", "--no-parent", "--json", shellProj,
+	)
+	if code != 0 {
+		t.Fatalf("add shell failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var shellResp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &shellResp); err != nil {
+		t.Fatalf("parse shell add response: %v\nstdout: %s", err, stdout)
+	}
+
+	stdout, stderr, code = runAgentDeck(t, home,
+		"session", "set", "--json", shellResp.ID, "extra-args",
+		"--", "--model", "opus",
+	)
+	if code == 0 {
+		t.Fatalf(
+			"negative control failed: extra-args on non-claude session must be rejected\n"+
+				"stdout: %s\nstderr: %s",
+			stdout, stderr,
+		)
+	}
+	combined := strings.ToLower(stdout + stderr)
+	if strings.Contains(combined, "invalid field") {
+		t.Errorf(
+			"shell-session error should be a tool-restriction message, "+
+				"NOT a generic 'invalid field'; got:\nstdout: %s\nstderr: %s",
+			stdout, stderr,
+		)
+	}
+	mustMentionTool := strings.Contains(combined, "claude") &&
+		(strings.Contains(combined, "only") ||
+			strings.Contains(combined, "supported") ||
+			strings.Contains(combined, "requires"))
+	if !mustMentionTool {
+		t.Errorf(
+			"shell-session error must mention claude AND a restriction word "+
+				"(only/supported/requires); got:\nstdout: %s\nstderr: %s",
+			stdout, stderr,
+		)
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -56,6 +56,16 @@ func handleLaunch(profile string, args []string) {
 		return nil
 	})
 
+	// Extra claude CLI tokens - repeatable; mirrors handleAdd's --extra-arg.
+	// Each invocation contributes one already-tokenised arg; feeds
+	// Instance.ExtraArgs which buildClaudeExtraFlags shellescapes and appends.
+	// Persisted plaintext in state.db — do NOT pass secrets like API keys.
+	var extraArgFlags []string
+	fs.Func("extra-arg", "Extra claude CLI token (can specify multiple times); requires -c claude; persisted plaintext — no secrets", func(s string) error {
+		extraArgFlags = append(extraArgFlags, s)
+		return nil
+	})
+
 	// Resume session flag
 	resumeSession := fs.String("resume-session", "", "Claude session ID to resume")
 
@@ -294,6 +304,15 @@ func handleLaunch(profile string, args []string) {
 			os.Exit(1)
 		}
 		newInstance.Channels = channelFlags
+	}
+
+	// Apply --extra-arg flags (claude only; mirror of handleAdd).
+	if len(extraArgFlags) > 0 {
+		if newInstance.Tool != "claude" {
+			out.Error("--extra-arg only supported for claude sessions (use -c claude); claude is the only tool whose builder appends user extra args", ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		newInstance.ExtraArgs = extraArgFlags
 	}
 
 	if sessionWrapperResolved != "" {

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -737,10 +737,11 @@ func reorderArgsForFlagParsing(args []string) []string {
 		"-c": true, "--cmd": true,
 		"-m": true, "--message": true,
 		"-p": true, "--parent": true,
-		"--mcp":     true,
-		"--channel": true,
-		"--wrapper": true,
-		"-w":        true, "--worktree": true,
+		"--mcp":       true,
+		"--channel":   true,
+		"--extra-arg": true,
+		"--wrapper":   true,
+		"-w":          true, "--worktree": true,
 		"--location":       true,
 		"--resume-session": true,
 		"--sandbox-image":  true,
@@ -928,6 +929,17 @@ func handleAdd(profile string, args []string) {
 	var channelFlags []string
 	fs.Func("channel", "Plugin channel id (can specify multiple times); requires -c claude", func(s string) error {
 		channelFlags = append(channelFlags, s)
+		return nil
+	})
+
+	// Extra claude CLI tokens - repeatable; each invocation is one already-
+	// tokenised arg (e.g. --extra-arg --agent --extra-arg reviewer).
+	// Persisted on Instance.ExtraArgs (plaintext — do NOT pass secrets) and
+	// appended verbatim to every claude Start/Restart/Fork command via
+	// buildClaudeExtraFlags.
+	var extraArgFlags []string
+	fs.Func("extra-arg", "Extra claude CLI token (can specify multiple times); requires -c claude; persisted plaintext — no secrets", func(s string) error {
+		extraArgFlags = append(extraArgFlags, s)
 		return nil
 	})
 
@@ -1256,6 +1268,16 @@ func handleAdd(profile string, args []string) {
 		newInstance.Channels = channelFlags
 	}
 
+	// Apply --extra-arg flags (claude only for now — these are passed to the
+	// claude binary via buildClaudeExtraFlags; other tools have their own builders).
+	if len(extraArgFlags) > 0 {
+		if newInstance.Tool != "claude" {
+			fmt.Println("Error: --extra-arg only supported for claude sessions (use -c claude); claude is the only tool whose builder appends user extra args")
+			os.Exit(1)
+		}
+		newInstance.ExtraArgs = extraArgFlags
+	}
+
 	// Set wrapper if provided
 	if sessionWrapperResolved != "" {
 		newInstance.Wrapper = sessionWrapperResolved
@@ -1501,6 +1523,7 @@ func handleList(profile string, args []string) {
 			SSHHost       string    `json:"ssh_host,omitempty"`
 			SSHRemotePath string    `json:"ssh_remote_path,omitempty"`
 			Channels      []string  `json:"channels,omitempty"`
+			ExtraArgs     []string  `json:"extra_args,omitempty"`
 		}
 		// Warm tmux pane-title cache + load hook statuses so the CLI
 		// reports the same Status the TUI and /api/menu do (issue #610).
@@ -1521,6 +1544,7 @@ func handleList(profile string, args []string) {
 				SSHHost:       inst.SSHHost,
 				SSHRemotePath: inst.SSHRemotePath,
 				Channels:      inst.Channels,
+				ExtraArgs:     inst.ExtraArgs,
 			}
 			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
 				sj.TmuxSession = tmuxSess.Name

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -856,6 +856,7 @@ func handleSessionSet(profile string, args []string) {
 		fmt.Println("  tool               Tool type (claude, gemini, shell, etc.)")
 		fmt.Println("  wrapper            Wrapper command (use {command} to include tool command)")
 		fmt.Println("  channels           Comma-separated plugin channel ids (claude only)")
+		fmt.Println("  extra-args         Extra claude CLI tokens (claude only; use `-- --flag value` for tokens starting with -; persisted plaintext — no secrets)")
 		fmt.Println("  claude-session-id  Claude conversation ID")
 		fmt.Println("  gemini-session-id  Gemini conversation ID")
 		fmt.Println()
@@ -881,6 +882,11 @@ func handleSessionSet(profile string, args []string) {
 	identifier := fs.Arg(0)
 	field := fs.Arg(1)
 	value := fs.Arg(2)
+	// For extra-args: accept an arbitrary number of positional tokens after
+	// the field name. Use `--` terminator so Go's flag package leaves tokens
+	// starting with `-` alone, e.g.:
+	//   agent-deck session set <id> extra-args -- --model opus
+	extraArgTokens := fs.Args()[2:]
 	quietMode := *quiet || *quietShort
 	out := NewCLIOutput(*jsonOutput, quietMode)
 
@@ -892,6 +898,7 @@ func handleSessionSet(profile string, args []string) {
 		"tool":              true,
 		"wrapper":           true,
 		"channels":          true,
+		"extra-args":        true,
 		"claude-session-id": true,
 		"gemini-session-id": true,
 	}
@@ -899,7 +906,7 @@ func handleSessionSet(profile string, args []string) {
 	if !validFields[field] {
 		out.Error(
 			fmt.Sprintf(
-				"invalid field: %s\nValid fields: title, path, command, tool, wrapper, channels, claude-session-id, gemini-session-id",
+				"invalid field: %s\nValid fields: title, path, command, tool, wrapper, channels, extra-args, claude-session-id, gemini-session-id",
 				field,
 			),
 			ErrCodeInvalidOperation,
@@ -964,6 +971,36 @@ func handleSessionSet(profile string, args []string) {
 			}
 		}
 		inst.Channels = parsed
+	case "extra-args":
+		// extra-args are passed to the claude binary by buildClaudeExtraFlags;
+		// only meaningful for claude sessions. Every positional arg after the
+		// field name is treated as one already-tokenised extra arg. Use `--`
+		// so Go's flag package leaves tokens starting with `-` alone:
+		//   agent-deck session set <id> extra-args -- --model opus
+		// Empty string clears all extra args. Empty tokens mixed with real
+		// ones are dropped (avoid emitting literal `''` to claude).
+		//
+		// Note: extra-args persist in state.db as plaintext. Do NOT pass
+		// secrets like API keys via --extra-arg.
+		if inst.Tool != "claude" {
+			out.Error(
+				fmt.Sprintf("extra-args only supported for claude sessions (this session's tool is %q); claude is the only tool whose builder appends user extra args", inst.Tool),
+				ErrCodeInvalidOperation,
+			)
+			os.Exit(1)
+		}
+		oldValue = strings.Join(inst.ExtraArgs, " ")
+		cleaned := make([]string, 0, len(extraArgTokens))
+		for _, tok := range extraArgTokens {
+			if tok != "" {
+				cleaned = append(cleaned, tok)
+			}
+		}
+		if len(cleaned) == 0 {
+			inst.ExtraArgs = nil
+		} else {
+			inst.ExtraArgs = cleaned
+		}
 	case "claude-session-id":
 		oldValue = inst.ClaudeSessionID
 		inst.ClaudeSessionID = value

--- a/internal/session/extraargs_test.go
+++ b/internal/session/extraargs_test.go
@@ -1,0 +1,231 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// extraArgsTestEnv isolates the test from the host's CLAUDE_CONFIG_DIR / HOME
+// so buildClaudeCommand resolves deterministically. Mirrors the pattern in
+// channelsTestEnv at channels_test.go:14.
+func extraArgsTestEnv(t *testing.T) {
+	t.Helper()
+	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	origHome := os.Getenv("HOME")
+	os.Unsetenv("CLAUDE_CONFIG_DIR")
+	os.Setenv("HOME", t.TempDir())
+	ClearUserConfigCache()
+	t.Cleanup(func() {
+		if origConfigDir != "" {
+			os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
+		} else {
+			os.Unsetenv("CLAUDE_CONFIG_DIR")
+		}
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	})
+}
+
+// setExtraArgsField uses reflection so this test file compiles cleanly on
+// main (where Instance.ExtraArgs does not yet exist). Identical probe pattern
+// to setChannelsField in channels_test.go:39.
+func setExtraArgsField(t *testing.T, inst *Instance, args []string) {
+	t.Helper()
+	val := reflect.ValueOf(inst).Elem()
+	field := val.FieldByName("ExtraArgs")
+	if !field.IsValid() {
+		t.Fatalf(
+			"Instance.ExtraArgs field does not exist; required for first-class " +
+				"--extra-arg CLI support. Add `ExtraArgs []string " +
+				"`json:\"extra_args,omitempty\"`` to the Instance struct " +
+				"in internal/session/instance.go next to Channels.",
+		)
+	}
+	if field.Kind() != reflect.Slice || field.Type().Elem().Kind() != reflect.String {
+		t.Fatalf(
+			"Instance.ExtraArgs has wrong type %s; want []string",
+			field.Type().String(),
+		)
+	}
+	field.Set(reflect.ValueOf(args))
+}
+
+// TestStartCommandAppendsExtraArgs asserts that Instance.ExtraArgs tokens
+// appear in the built start command. This is the core contract for passing
+// arbitrary claude CLI flags (e.g. --agent, --model) to claude sessions.
+func TestStartCommandAppendsExtraArgs(t *testing.T) {
+	extraArgsTestEnv(t)
+
+	inst := NewInstanceWithTool("ea-start", t.TempDir(), "claude")
+	setExtraArgsField(t, inst, []string{"--agent", "my-agent"})
+
+	cmd := inst.buildClaudeCommand("claude")
+
+	if !strings.Contains(cmd, "--agent") {
+		t.Fatalf("built claude command missing --agent token, got:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, "my-agent") {
+		t.Errorf("built claude command missing my-agent value, got:\n%s", cmd)
+	}
+}
+
+// TestStartCommandOmitsExtraArgsWhenEmpty asserts no extra flags are
+// emitted when ExtraArgs is empty (avoids leading/trailing garbage).
+func TestStartCommandOmitsExtraArgsWhenEmpty(t *testing.T) {
+	extraArgsTestEnv(t)
+
+	inst := NewInstanceWithTool("ea-empty", t.TempDir(), "claude")
+	val := reflect.ValueOf(inst).Elem()
+	if !val.FieldByName("ExtraArgs").IsValid() {
+		t.Fatalf("Instance.ExtraArgs field does not exist")
+	}
+	cmd := inst.buildClaudeCommand("claude")
+
+	// The builder should produce a clean command with no double spaces or
+	// trailing residue that would indicate a stray empty-flag emission.
+	if strings.Contains(cmd, "  ") {
+		t.Errorf("empty ExtraArgs produced double-space in command, got:\n%s", cmd)
+	}
+}
+
+// TestExtraArgsRestartPersist asserts extra args survive a JSON round-trip
+// through Storage. Mirrors TestChannelsRestartPersist at channels_test.go:118.
+func TestExtraArgsRestartPersist(t *testing.T) {
+	extraArgsTestEnv(t)
+
+	inst := NewInstanceWithTool("ea-restart", t.TempDir(), "claude")
+	args := []string{"--model", "opus", "--thinking-level", "high"}
+	setExtraArgsField(t, inst, args)
+
+	data, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatalf("json.Marshal(inst): %v", err)
+	}
+
+	if !strings.Contains(string(data), `"extra_args":`) {
+		t.Errorf(
+			"marshalled instance missing \"extra_args\" json tag; got:\n%s",
+			string(data),
+		)
+	}
+
+	revived := &Instance{}
+	if err := json.Unmarshal(data, revived); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	revivedField := reflect.ValueOf(revived).Elem().FieldByName("ExtraArgs")
+	if !revivedField.IsValid() {
+		t.Fatalf("revived Instance has no ExtraArgs field after unmarshal")
+	}
+	got := revivedField.Interface().([]string)
+	if len(got) != len(args) {
+		t.Fatalf("revived ExtraArgs = %v, want %v", got, args)
+	}
+	for i, want := range args {
+		if got[i] != want {
+			t.Fatalf("revived ExtraArgs[%d] = %q, want %q", i, got[i], want)
+		}
+	}
+
+	cmd := revived.buildClaudeCommand("claude")
+	if !strings.Contains(cmd, "--model") || !strings.Contains(cmd, "opus") {
+		t.Errorf("command from revived instance missing extra args, got:\n%s", cmd)
+	}
+}
+
+// TestResumeCommandAppendsExtraArgs is the phase-5 loopback guard, mirror
+// of TestResumeCommandAppendsChannels at channels_test.go:182. Any flag that
+// flows through buildClaudeExtraFlags must also survive a restart.
+func TestResumeCommandAppendsExtraArgs(t *testing.T) {
+	extraArgsTestEnv(t)
+
+	inst := NewInstanceWithTool("ea-resume", t.TempDir(), "claude")
+	inst.ClaudeSessionID = "00000000-0000-0000-0000-000000000000"
+	setExtraArgsField(t, inst, []string{"--agent", "reviewer"})
+
+	cmd := inst.buildClaudeResumeCommand()
+
+	if !strings.Contains(cmd, "--agent") || !strings.Contains(cmd, "reviewer") {
+		t.Fatalf(
+			"buildClaudeResumeCommand dropped --agent/reviewer on restart path; "+
+				"this is the phase-5 loopback bug. got:\n%s",
+			cmd,
+		)
+	}
+}
+
+// TestExtraArgsAndChannelsCoexist asserts that both flag families are
+// emitted together and do not clobber each other. Channels come first
+// (so --channels appears before user tokens), and user tokens are last
+// so they can override claude's own defaults (claude uses last-wins).
+func TestExtraArgsAndChannelsCoexist(t *testing.T) {
+	extraArgsTestEnv(t)
+
+	inst := NewInstanceWithTool("ea-and-ch", t.TempDir(), "claude")
+	inst.Channels = []string{"plugin:telegram@acme/bot"}
+	setExtraArgsField(t, inst, []string{"--agent", "reviewer"})
+
+	cmd := inst.buildClaudeCommand("claude")
+
+	chanIdx := strings.Index(cmd, "--channels")
+	agentIdx := strings.Index(cmd, "--agent")
+	if chanIdx < 0 || agentIdx < 0 {
+		t.Fatalf("missing --channels or --agent in command:\n%s", cmd)
+	}
+	if chanIdx > agentIdx {
+		t.Errorf("expected --channels to appear BEFORE --agent (last-wins), got:\n%s", cmd)
+	}
+}
+
+// TestExtraArgsShellInjectionSafe asserts that shell metacharacters in
+// tokens are quoted so they do not execute. This is the injection-surface
+// guard the Define→Develop debate gate flagged as HIGH severity.
+func TestExtraArgsShellInjectionSafe(t *testing.T) {
+	extraArgsTestEnv(t)
+
+	inst := NewInstanceWithTool("ea-inject", t.TempDir(), "claude")
+	// Tokens that would be dangerous if not quoted: $(...) and backticks
+	// would execute in bash -c context.
+	setExtraArgsField(t, inst, []string{"--name", "$(rm -rf /)", "--other", "`touch /tmp/pwn`"})
+
+	cmd := inst.buildClaudeCommand("claude")
+
+	// Raw $() or `` must NOT appear unquoted. shellescape wraps in single
+	// quotes, which prevent expansion.
+	if strings.Contains(cmd, " $(rm -rf /)") || strings.Contains(cmd, " `touch /tmp/pwn`") {
+		t.Fatalf(
+			"shell metacharacters were not quoted — command injection surface; got:\n%s",
+			cmd,
+		)
+	}
+}
+
+// TestExtraArgsShellQuotesTokensWithSpaces asserts that tokens containing
+// shell metacharacters (spaces, quotes) are re-quoted on emission so
+// `bash -c` does NOT re-split them. Without this, `--claude-args "foo bar"`
+// would be re-tokenised into `foo` and `bar` by the shell wrapper.
+func TestExtraArgsShellQuotesTokensWithSpaces(t *testing.T) {
+	extraArgsTestEnv(t)
+
+	inst := NewInstanceWithTool("ea-quote", t.TempDir(), "claude")
+	setExtraArgsField(t, inst, []string{"--name", "agent with spaces"})
+
+	cmd := inst.buildClaudeCommand("claude")
+
+	// The multi-word value must be emitted as a single shell token, not
+	// "agent with spaces" raw. Accept either single-quoted ('agent with spaces')
+	// or double-quoted ("agent with spaces") forms; both survive bash -c.
+	hasQuoted := strings.Contains(cmd, `'agent with spaces'`) ||
+		strings.Contains(cmd, `"agent with spaces"`)
+	if !hasQuoted {
+		t.Fatalf(
+			"token with spaces was not shell-quoted on emission; "+
+				"bash -c will re-split it. Use shellescape.Quote on each token. got:\n%s",
+			cmd,
+		)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	"al.essio.dev/pkg/shellescape"
+
 	"github.com/asheshgoplani/agent-deck/internal/docker"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/send"
@@ -152,6 +154,12 @@ type Instance struct {
 	// no inbound delivery) which silently drops Telegram/Discord/Slack
 	// messages on conductor restart.
 	Channels []string `json:"channels,omitempty"`
+
+	// ExtraArgs are user-supplied claude CLI tokens appended verbatim to every
+	// start/resume/fork command (e.g. ["--agent","reviewer","--model","opus"]).
+	// Each token is shellescape-quoted on emission so values with spaces
+	// survive the bash -c wrapper.
+	ExtraArgs []string `json:"extra_args,omitempty"`
 
 	// ToolOptions stores tool-specific launch options (Claude, Codex, Gemini, etc.)
 	// JSON structure: {"tool": "claude", "options": {...}}
@@ -690,6 +698,14 @@ func (i *Instance) buildClaudeExtraFlags(opts *ClaudeOptions) string {
 	// on every Start/Restart/resume because every command-build flows here.
 	if len(i.Channels) > 0 {
 		flags = append(flags, fmt.Sprintf("--channels %s", strings.Join(i.Channels, ",")))
+	}
+
+	// User-supplied extra args: each token is shellescape-quoted before
+	// re-emission so values with spaces survive the `bash -c` wrapper
+	// without being re-tokenized. Appended last so user flags can override
+	// defaults claude accepts in last-wins ordering.
+	for _, tok := range i.ExtraArgs {
+		flags = append(flags, shellescape.Quote(tok))
 	}
 
 	if len(flags) == 0 {

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -87,6 +87,10 @@ type InstanceData struct {
 	// Plugin channels (persisted for --channels CLI flag on Claude restart)
 	Channels []string `json:"channels,omitempty"`
 
+	// User-supplied claude CLI tokens, appended to every start/resume/fork
+	// command. Persisted so restarts preserve custom flags like --agent/--model.
+	ExtraArgs []string `json:"extra_args,omitempty"`
+
 	// Sandbox support
 	Sandbox          *SandboxConfig `json:"sandbox,omitempty"`
 	SandboxContainer string         `json:"sandbox_container,omitempty"`
@@ -303,6 +307,7 @@ func (s *Storage) SaveWithGroups(instances []*Instance, groupTree *GroupTree) er
 			inst.MultiRepoEnabled, inst.AdditionalPaths,
 			inst.MultiRepoTempDir, mrWorktrees,
 			inst.Channels,
+			inst.ExtraArgs,
 		)
 
 		rows[i] = &statedb.InstanceRow{
@@ -448,7 +453,8 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			sshHost2, sshRemotePath2,
 			mrEnabled2, addPaths2,
 			mrTempDir2, mrWorktrees2,
-			channels2 := statedb.UnmarshalToolData(r.ToolData)
+			channels2,
+			extraArgs2 := statedb.UnmarshalToolData(r.ToolData)
 		sandboxCfg := decodeSandboxConfig(sandboxJSON)
 
 		instances[i] = &InstanceData{
@@ -492,6 +498,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			MultiRepoTempDir:   mrTempDir2,
 			MultiRepoWorktrees: mrWorktrees2,
 			Channels:           channels2,
+			ExtraArgs:          extraArgs2,
 		}
 	}
 
@@ -547,7 +554,8 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			sshHost, sshRemotePath,
 			mrEnabled, addPaths,
 			mrTempDir, mrWorktrees,
-			channels := statedb.UnmarshalToolData(r.ToolData)
+			channels,
+			extraArgs := statedb.UnmarshalToolData(r.ToolData)
 		sandboxCfg := decodeSandboxConfig(sandboxJSON)
 
 		data.Instances[i] = &InstanceData{
@@ -591,6 +599,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			MultiRepoTempDir:   mrTempDir,
 			MultiRepoWorktrees: mrWorktrees,
 			Channels:           channels,
+			ExtraArgs:          extraArgs,
 		}
 	}
 
@@ -788,6 +797,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			Notes:              instData.Notes,
 			LoadedMCPNames:     instData.LoadedMCPNames,
 			Channels:           instData.Channels,
+			ExtraArgs:          instData.ExtraArgs,
 			Sandbox:            instData.Sandbox,
 			SandboxContainer:   instData.SandboxContainer,
 			SSHHost:            instData.SSHHost,

--- a/internal/statedb/migrate.go
+++ b/internal/statedb/migrate.go
@@ -53,6 +53,7 @@ type jsonInstanceData struct {
 	ToolOptionsJSON  json.RawMessage `json:"tool_options,omitempty"`
 	LoadedMCPNames   []string        `json:"loaded_mcp_names,omitempty"`
 	Channels         []string        `json:"channels,omitempty"`
+	ExtraArgs        []string        `json:"extra_args,omitempty"`
 	Sandbox          json.RawMessage `json:"sandbox,omitempty"`
 	SandboxContainer string          `json:"sandbox_container,omitempty"`
 }
@@ -82,6 +83,7 @@ type toolDataBlob struct {
 	Notes              string          `json:"notes,omitempty"`
 	LoadedMCPNames     []string        `json:"loaded_mcp_names,omitempty"`
 	Channels           []string        `json:"channels,omitempty"`
+	ExtraArgs          []string        `json:"extra_args,omitempty"`
 	ToolOptions        json.RawMessage `json:"tool_options,omitempty"`
 	Sandbox            json.RawMessage `json:"sandbox,omitempty"`
 	SandboxContainer   string          `json:"sandbox_container,omitempty"`
@@ -219,6 +221,7 @@ func MarshalToolData(
 	multiRepoEnabled bool, additionalPaths []string,
 	multiRepoTempDir string, multiRepoWorktrees []MultiRepoWorktreeData,
 	channels []string,
+	extraArgs []string,
 ) json.RawMessage {
 	td := toolDataBlob{
 		ClaudeSessionID:   claudeSessionID,
@@ -231,6 +234,7 @@ func MarshalToolData(
 		Notes:             notes,
 		LoadedMCPNames:    loadedMCPNames,
 		Channels:          channels,
+		ExtraArgs:         extraArgs,
 		ToolOptions:       toolOptionsJSON,
 		Sandbox:           sandboxJSON,
 		SandboxContainer:  sandboxContainer,
@@ -274,6 +278,7 @@ func UnmarshalToolData(data json.RawMessage) (
 	multiRepoEnabled bool, additionalPaths []string,
 	multiRepoTempDir string, multiRepoWorktrees []MultiRepoWorktreeData,
 	channels []string,
+	extraArgs []string,
 ) {
 	if len(data) == 0 {
 		return
@@ -304,6 +309,7 @@ func UnmarshalToolData(data json.RawMessage) (
 	notes = td.Notes
 	loadedMCPNames = td.LoadedMCPNames
 	channels = td.Channels
+	extraArgs = td.ExtraArgs
 	toolOptionsJSON = td.ToolOptions
 	sandboxJSON = td.Sandbox
 	sandboxContainer = td.SandboxContainer

--- a/internal/statedb/multirepo_test.go
+++ b/internal/statedb/multirepo_test.go
@@ -24,10 +24,11 @@ func TestMarshalUnmarshalToolData_MultiRepo(t *testing.T) {
 		true, []string{"/path/additional1", "/path/additional2"}, // multi-repo
 		"/tmp/agent-deck-sessions/abc", worktrees,
 		nil, // channels
+		nil, // extra_args
 	)
 
 	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
-		mrEnabled, addPaths, mrTempDir, mrWorktrees, _ := UnmarshalToolData(data)
+		mrEnabled, addPaths, mrTempDir, mrWorktrees, _, _ := UnmarshalToolData(data)
 
 	assert.True(t, mrEnabled)
 	assert.Equal(t, []string{"/path/additional1", "/path/additional2"}, addPaths)
@@ -50,10 +51,11 @@ func TestMarshalUnmarshalToolData_NoMultiRepo(t *testing.T) {
 		"", "",
 		false, nil, "", nil,
 		nil, // channels
+		nil, // extra_args
 	)
 
 	claudeSID, _, _, _, _, _, _, _, _, _, prompt, notes, mcps, _, _, _, _, _,
-		mrEnabled, addPaths, mrTempDir, mrWorktrees, _ := UnmarshalToolData(data)
+		mrEnabled, addPaths, mrTempDir, mrWorktrees, _, _ := UnmarshalToolData(data)
 
 	assert.Equal(t, "claude-123", claudeSID)
 	assert.Equal(t, "prompt", prompt)

--- a/internal/ui/claudeoptions.go
+++ b/internal/ui/claudeoptions.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"strings"
+
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -14,6 +16,9 @@ type ClaudeOptionsPanel struct {
 	sessionMode int
 	// Resume session ID input (only for mode=resume)
 	resumeIDInput textinput.Model
+	// Extra claude CLI tokens (space-separated in input; persisted as []string).
+	// NewDialog only — fork inherits parent's ExtraArgs implicitly via builder.
+	extraArgsInput textinput.Model
 	// Checkbox states
 	skipPermissions      bool
 	allowSkipPermissions bool
@@ -45,21 +50,28 @@ func NewClaudeOptionsPanel() *ClaudeOptionsPanel {
 	resumeInput.CharLimit = 64
 	resumeInput.Width = 30
 
+	extraArgsInput := textinput.New()
+	extraArgsInput.Placeholder = "--agent reviewer --model opus"
+	extraArgsInput.CharLimit = 512
+	extraArgsInput.Width = 44
+
 	return &ClaudeOptionsPanel{
-		sessionMode:   0, // new
-		resumeIDInput: resumeInput,
-		isForkMode:    false,
-		focusCount:    5, // Will adjust dynamically
+		sessionMode:    0, // new
+		resumeIDInput:  resumeInput,
+		extraArgsInput: extraArgsInput,
+		isForkMode:     false,
+		focusCount:     6, // session, skip, auto, chrome, teammate, extra-args
 	}
 }
 
 // NewClaudeOptionsPanelForFork creates a panel for ForkDialog (fewer options)
 func NewClaudeOptionsPanelForFork() *ClaudeOptionsPanel {
 	return &ClaudeOptionsPanel{
-		sessionMode:   0,
-		resumeIDInput: textinput.New(), // Not used in fork mode
-		isForkMode:    true,
-		focusCount:    3, // skip, chrome, teammate
+		sessionMode:    0,
+		resumeIDInput:  textinput.New(), // Not used in fork mode
+		extraArgsInput: textinput.New(), // Not used in fork mode
+		isForkMode:     true,
+		focusCount:     3, // skip, chrome, teammate
 	}
 }
 
@@ -105,6 +117,27 @@ func (p *ClaudeOptionsPanel) Focus() {
 func (p *ClaudeOptionsPanel) Blur() {
 	p.focusIndex = -1
 	p.resumeIDInput.Blur()
+	p.extraArgsInput.Blur()
+}
+
+// GetExtraArgs returns the parsed extra-args tokens (whitespace-split, empties dropped).
+// Callers assign the result to Instance.ExtraArgs. Tokens with embedded spaces
+// cannot be expressed through this input — use CLI `--extra-arg` for that.
+func (p *ClaudeOptionsPanel) GetExtraArgs() []string {
+	raw := strings.TrimSpace(p.extraArgsInput.Value())
+	if raw == "" {
+		return nil
+	}
+	tokens := strings.Fields(raw)
+	if len(tokens) == 0 {
+		return nil
+	}
+	return tokens
+}
+
+// SetExtraArgs pre-fills the input from a persisted slice.
+func (p *ClaudeOptionsPanel) SetExtraArgs(tokens []string) {
+	p.extraArgsInput.SetValue(strings.Join(tokens, " "))
 }
 
 // IsFocused returns true if any element in the panel has focus
@@ -173,7 +206,7 @@ func (p *ClaudeOptionsPanel) Update(msg tea.Msg) tea.Cmd {
 
 		case " ":
 			// Don't intercept space when focused on a text input
-			if p.isResumeInputFocused() {
+			if p.isResumeInputFocused() || p.isExtraArgsInputFocused() {
 				break // Let it fall through to text input handling
 			}
 			// Toggle checkbox or radio at current focus
@@ -200,6 +233,11 @@ func (p *ClaudeOptionsPanel) Update(msg tea.Msg) tea.Cmd {
 	if p.isResumeInputFocused() {
 		var cmd tea.Cmd
 		p.resumeIDInput, cmd = p.resumeIDInput.Update(msg)
+		return cmd
+	}
+	if p.isExtraArgsInputFocused() {
+		var cmd tea.Cmd
+		p.extraArgsInput, cmd = p.extraArgsInput.Update(msg)
 		return cmd
 	}
 
@@ -279,6 +317,10 @@ func (p *ClaudeOptionsPanel) getFocusType() string {
 		if idx == 4 {
 			return "teammateMode"
 		}
+		// 6: extra-args input
+		if idx == 5 {
+			return "extraArgsInput"
+		}
 	}
 	return ""
 }
@@ -289,7 +331,7 @@ func (p *ClaudeOptionsPanel) getFocusCount() int {
 		return 4 // skip, auto, chrome, teammate
 	}
 
-	count := 5 // session mode, skip, auto, chrome, teammate
+	count := 6 // session mode, skip, auto, chrome, teammate, extra-args
 	if p.sessionMode == 2 {
 		count++ // resume input
 	}
@@ -301,12 +343,30 @@ func (p *ClaudeOptionsPanel) isResumeInputFocused() bool {
 	return !p.isForkMode && p.sessionMode == 2 && p.focusIndex == 1
 }
 
+// isExtraArgsInputFocused returns true if extra-args input is focused.
+// Last focusable element in NewDialog mode — index shifts by +1 when
+// resume mode is active (resume ID input adds a row).
+func (p *ClaudeOptionsPanel) isExtraArgsInputFocused() bool {
+	if p.isForkMode {
+		return false
+	}
+	want := 5 // default: session(0) + skip(1) + auto(2) + chrome(3) + teammate(4) + extraArgs(5)
+	if p.sessionMode == 2 {
+		want = 6 // resume input inserts between session and skip
+	}
+	return p.focusIndex == want
+}
+
 // updateInputFocus updates which text input has focus
 func (p *ClaudeOptionsPanel) updateInputFocus() {
 	p.resumeIDInput.Blur()
+	p.extraArgsInput.Blur()
 
 	if p.isResumeInputFocused() {
 		p.resumeIDInput.Focus()
+	}
+	if p.isExtraArgsInputFocused() {
+		p.extraArgsInput.Focus()
 	}
 }
 
@@ -386,6 +446,14 @@ func (p *ClaudeOptionsPanel) viewNewMode(labelStyle, activeStyle, dimStyle, head
 
 	// Teammate mode checkbox
 	content += renderCheckboxLine("Teammate mode", p.useTeammateMode, p.focusIndex == focusIdx)
+	focusIdx++
+
+	// Extra args input (free-form space-separated claude CLI tokens).
+	if p.focusIndex == focusIdx {
+		content += activeStyle.Render("  ▶ Extra args: ") + p.extraArgsInput.View() + "\n"
+	} else {
+		content += "    Extra args: " + p.extraArgsInput.View() + "\n"
+	}
 
 	return content
 }

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -50,6 +50,7 @@ type ConfirmDialog struct {
 	pendingSessionCommand    string
 	pendingSessionGroupPath  string
 	pendingToolOptionsJSON   json.RawMessage // Generic tool options (claude, codex, etc.)
+	pendingClaudeExtraArgs   []string        // User-supplied claude CLI tokens
 	pendingParentSessionID   string
 	pendingParentProjectPath string
 }
@@ -132,6 +133,7 @@ func (c *ConfirmDialog) ShowCreateDirectory(
 	command string,
 	groupPath string,
 	toolOptionsJSON json.RawMessage,
+	claudeExtraArgs []string,
 	parentSessionID string,
 	parentProjectPath string,
 ) {
@@ -144,6 +146,7 @@ func (c *ConfirmDialog) ShowCreateDirectory(
 	c.pendingSessionCommand = command
 	c.pendingSessionGroupPath = groupPath
 	c.pendingToolOptionsJSON = toolOptionsJSON
+	c.pendingClaudeExtraArgs = claudeExtraArgs
 	c.pendingParentSessionID = parentSessionID
 	c.pendingParentProjectPath = parentProjectPath
 	c.buttonCount = 2
@@ -161,8 +164,8 @@ func (c *ConfirmDialog) ShowInstallHooks() {
 }
 
 // GetPendingSession returns the pending session creation data
-func (c *ConfirmDialog) GetPendingSession() (name, path, command, groupPath string, toolOptionsJSON json.RawMessage, parentSessionID, parentProjectPath string) {
-	return c.pendingSessionName, c.pendingSessionPath, c.pendingSessionCommand, c.pendingSessionGroupPath, c.pendingToolOptionsJSON, c.pendingParentSessionID, c.pendingParentProjectPath
+func (c *ConfirmDialog) GetPendingSession() (name, path, command, groupPath string, toolOptionsJSON json.RawMessage, claudeExtraArgs []string, parentSessionID, parentProjectPath string) {
+	return c.pendingSessionName, c.pendingSessionPath, c.pendingSessionCommand, c.pendingSessionGroupPath, c.pendingToolOptionsJSON, c.pendingClaudeExtraArgs, c.pendingParentSessionID, c.pendingParentProjectPath
 }
 
 // Hide hides the dialog.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4770,8 +4770,10 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		// Build generic toolOptionsJSON from tool-specific options
 		var toolOptionsJSON json.RawMessage
+		var claudeExtraArgs []string
 		if command == "claude" && claudeOpts != nil {
 			toolOptionsJSON, _ = session.MarshalToolOptions(claudeOpts)
+			claudeExtraArgs = h.newDialog.GetClaudeExtraArgs()
 		} else if command == "codex" {
 			yolo := h.newDialog.GetCodexYoloMode()
 			codexOpts := &session.CodexOptions{YoloMode: &yolo}
@@ -4785,7 +4787,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if !worktreeEnabled {
 			if _, err := os.Stat(path); os.IsNotExist(err) {
 				h.newDialog.Hide()
-				h.confirmDialog.ShowCreateDirectory(path, name, command, groupPath, toolOptionsJSON, parentSessionID, parentProjectPath)
+				h.confirmDialog.ShowCreateDirectory(path, name, command, groupPath, toolOptionsJSON, claudeExtraArgs, parentSessionID, parentProjectPath)
 				return h, nil
 			}
 		}
@@ -4836,6 +4838,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			geminiYoloMode,
 			sandboxMode,
 			toolOptionsJSON,
+			claudeExtraArgs,
 			multiRepoEnabled,
 			additionalPaths,
 			parentSessionID,
@@ -6236,7 +6239,7 @@ func (h *Home) confirmAction() tea.Cmd {
 
 // confirmCreateDirectory handles the "yes" action for ConfirmCreateDirectory.
 func (h *Home) confirmCreateDirectory() tea.Cmd {
-	name, path, command, groupPath, pendingToolOpts, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
+	name, path, command, groupPath, pendingToolOpts, pendingExtraArgs, parentSessionID, parentProjectPath := h.confirmDialog.GetPendingSession()
 	h.confirmDialog.Hide()
 	if err := os.MkdirAll(path, 0o755); err != nil {
 		h.setError(fmt.Errorf("failed to create directory: %w", err))
@@ -6253,6 +6256,7 @@ func (h *Home) confirmCreateDirectory() tea.Cmd {
 		false,
 		false,
 		pendingToolOpts,
+		pendingExtraArgs,
 		false,
 		nil,
 		parentSessionID,
@@ -7024,6 +7028,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 	geminiYoloMode bool,
 	sandboxEnabled bool,
 	toolOptionsJSON json.RawMessage,
+	claudeExtraArgs []string,
 	multiRepoEnabled bool,
 	additionalPaths []string,
 	parentSessionID, parentProjectPath string,
@@ -7099,6 +7104,11 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 		// Apply generic tool options (claude, codex, etc.)
 		if len(toolOptionsJSON) > 0 {
 			inst.ToolOptionsJSON = toolOptionsJSON
+		}
+
+		// Apply claude extra CLI tokens (claude-only, ignored for other tools).
+		if tool == "claude" && len(claudeExtraArgs) > 0 {
+			inst.ExtraArgs = claudeExtraArgs
 		}
 
 		// Apply sandbox config.
@@ -7355,6 +7365,7 @@ func (h *Home) quickCreateSession() tea.Cmd {
 		name, projectPath, command, groupPath,
 		"", "", "", // no worktree
 		geminiYoloMode, false, toolOptionsJSON,
+		nil,        // no extra claude args (recent-session path)
 		false, nil, // no multi-repo
 		"", "", // no parent
 		"", // no placeholder

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -755,6 +755,16 @@ func (d *NewDialog) GetClaudeOptions() *session.ClaudeOptions {
 	return d.claudeOptions.GetOptions()
 }
 
+// GetClaudeExtraArgs returns the user-supplied claude CLI tokens from the
+// options panel. Returns nil for non-claude tools. Tokens are whitespace-split;
+// for values with embedded spaces, use `ad-fork add --extra-arg`.
+func (d *NewDialog) GetClaudeExtraArgs() []string {
+	if !d.isClaudeSelected() {
+		return nil
+	}
+	return d.claudeOptions.GetExtraArgs()
+}
+
 // isClaudeSelected returns true if the selected command is Claude or a claude-compatible custom tool
 func (d *NewDialog) isClaudeSelected() bool {
 	if d.commandCursor < 0 || d.commandCursor >= len(d.presetCommands) {


### PR DESCRIPTION
## Summary

- Adds `Instance.ExtraArgs []string` — arbitrary tokens forwarded to the `claude` binary on every Start/Restart/Fork (e.g. `--agent reviewer`, `--model opus`, `--thinking-level high`).
- Tokens pass through `shellescape.Quote` on emission so `bash -c` does not re-tokenise or expand shell metacharacters (`$()`, backticks, `;`, `|` etc. are persisted/emitted as literals).
- Surfaces: repeatable `--extra-arg` on `agent-deck add` / `agent-deck launch`, `session set <id> extra-args -- <tokens…>` (uses `--` terminator for `-` prefixed tokens), and a new free-form "Extra args" textinput in the TUI `ClaudeOptionsPanel`.

## Motivation

Users increasingly want to pin a specific sub-agent, model, or thinking-level per session without editing global Claude config. Today this is impossible through `agent-deck` — the only per-session overrides are the typed `ClaudeOptions` (skip-perms, chrome, teammate, resume, etc.) and channels.

## Approach

Mirrors the existing `--channels` pattern 1:1:
- Field on `Instance` (`internal/session/instance.go`), not `ClaudeOptions`, so a future generic extension to codex/gemini builders stays open.
- Persistence reuses the existing `tool_data` JSON blob — no SQL migration.
- Flag emission flows through the single choke-point `buildClaudeExtraFlags`, already shared by start/resume/fork command builders.
- Claude-only guard at all three CLI entry points plus in `session set`, with explicit tool-restriction error messages.

## Security

- Every token is `shellescape.Quote`'d before join (covered by `TestExtraArgsShellInjectionSafe`).
- Help text and `session set` usage document the plaintext-in-`state.db` exposure and warn against passing secrets (e.g. `--api-key`).

## Tests

10 new tests, all green:

**Unit (`internal/session/extraargs_test.go`)**
- [x] `TestStartCommandAppendsExtraArgs`
- [x] `TestStartCommandOmitsExtraArgsWhenEmpty`
- [x] `TestExtraArgsRestartPersist` (JSON round-trip + post-restart command)
- [x] `TestResumeCommandAppendsExtraArgs` (phase-5 loopback guard)
- [x] `TestExtraArgsAndChannelsCoexist` (ordering contract)
- [x] `TestExtraArgsShellInjectionSafe` (`$(...)` + backticks)
- [x] `TestExtraArgsShellQuotesTokensWithSpaces`

**Subprocess CLI (`cmd/agent-deck/extraargs_cmd_test.go`)**
- [x] `TestAddExtraArgFlag` (repeatable flag on `add`)
- [x] `TestSessionSetExtraArgs` (+ empty-strip + `\"\"` clear)
- [x] `TestExtraArgsOnlyForClaude` (positive + negative tool guard)

Existing `--channels` regression suite + CLAUDE.md mandated suites (feedback, watcher) all remain green.

## Known follow-ups (terminal debt, same state as `--channels`)

- Fork does not inherit parent's `ExtraArgs` on forked-session restart (same bug as `Channels`; proposed single follow-up ticket for both).
- `MarshalToolData` signature now 25 positional args (pre-existing smell; struct-based refactor deserves its own PR).
- No TUI edit-existing-session flow — user must recreate or use `session set` CLI.

## Scope

- `agent-deck-fork` Medium feature; mirrors `--channels` pattern verbatim, no changes to persistence schema, no changes to any tool builder other than claude, no new runtime dependencies (`shellescape` already vendored).