### PR TITLE
fix(#560): warn when TUI is launched inside a non-agentdeck tmux session

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -718,3 +718,14 @@ tests:
   run:
     command: go test ./internal/session/ -run TestLoadSkillSources_DiscoversSkillsViaDollarHome -count=1 -v
     expected: pass
+- id: fix-560-outer-tmux-guard
+  added: '2026-04-17'
+  task: fix-560-tmux-detach-guidance
+  file: cmd/agent-deck/main_test.go
+  test_name: TestOuterTmuxGuard
+  purpose: Guards issue-560 regressions — warns-and-exits when TUI is launched inside a non-agentdeck tmux session without AGENT_DECK_ALLOW_OUTER_TMUX=1. Covers three subcases (no-optin blocks, optin passes, no-tmux passes) + defensive narrow-match on opt-in value.
+  source: gh#560
+  manual: false
+  run:
+    command: go test ./cmd/agent-deck/ -run TestOuterTmuxGuard -count=1 -v
+    expected: pass

--- a/.planning/fix-560/PLAN.md
+++ b/.planning/fix-560/PLAN.md
@@ -1,0 +1,118 @@
+# PLAN — fix #560: Having issues detaching within Tmux
+
+## Problem summary
+
+Issue reporter (shorea) ran `agent-deck` inside an existing tmux session and
+got surprising detach behavior. Community contributor DieracDelta correctly
+answered that agent-deck is designed to be run OUTSIDE tmux. The TUI already
+blocks launch inside an *agent-deck-managed* tmux session (`isNestedSession()`
+check in `main.go:313`), but there is NO guidance for users who launch
+agent-deck inside a *generic* (non-agentdeck) tmux session — it just boots the
+TUI, and then Ctrl+Q detach lands them back in the outer tmux instead of
+returning them to a clean shell, which is confusing.
+
+## Reproducer
+
+```bash
+tmux new -s myouter
+# inside tmux:
+agent-deck
+# → TUI boots with no warning, no indication that detach semantics will be
+#   surprising. Ctrl+Q from an attached session returns to TUI; quitting the
+#   TUI returns to the outer tmux, not a clean shell.
+```
+
+## Data-flow trace (parallel paths audit)
+
+Startup code path for `agent-deck` (no args, TUI launch):
+
+1. `cmd/agent-deck/main.go:main()` — line 186
+2. → `extractProfileFlag(os.Args[1:])` — splits profile flag from args
+3. → subcommand dispatch (if args[0] matches a known command, handled and returns)
+4. → `reviveOnStartup(profile)` — background reviver
+5. → **`isNestedSession()` guard** — blocks launch inside agentdeck-managed tmux
+   - In-scope: this guard handles `agentdeck_*` tmux sessions ONLY
+   - **MISSING**: guard for *generic* tmux sessions (TMUX env set, but not agentdeck-managed) ← THIS IS THE FIX
+6. → `ui.SetVersion`, theme init, `promptForUpdate()`, `ensureTmuxInPath()`, TUI launch
+
+**Parallel paths considered (and why we only touch the TUI path):**
+- CLI subcommands (`agent-deck add`, `session start`, `mcp attach`, …) — MUST keep working inside tmux. The reporter's confusion is ONLY about the interactive TUI. CLI already works fine in nested contexts and we must not regress that.
+- `agent-deck session current` (session_cmd.go:2069) — REQUIRES TMUX to be set. Keep as-is.
+- `ResolveSessionOrCurrent` fallback (session_cmd.go:686) — USES TMUX for auto-detect. Keep as-is.
+- `GetCurrentSessionID` (cli_utils.go:280) — USES TMUX to detect agentdeck session. Keep as-is.
+
+Only ONE code path changes: the TUI launch path in `main.go`, immediately after
+the existing `isNestedSession()` guard. Adding a second guard for the
+generic-tmux case preserves all CLI behaviour.
+
+## Fix design
+
+Add a function `isOuterTmuxWithoutOptIn() bool` to `main.go`:
+
+```go
+// isOuterTmuxWithoutOptIn reports true when the user is launching the
+// interactive TUI from inside a NON-agentdeck tmux session without the
+// opt-in env var set. See issue #560.
+func isOuterTmuxWithoutOptIn() bool {
+    if os.Getenv("TMUX") == "" {
+        return false // not in tmux, OK
+    }
+    if isNestedSession() {
+        return false // agentdeck-managed, handled by the nested guard above
+    }
+    if os.Getenv("AGENT_DECK_ALLOW_OUTER_TMUX") == "1" {
+        return false // user opted in
+    }
+    return true
+}
+```
+
+Call it in `main()` immediately after the `isNestedSession()` block. On hit,
+print an explanatory message (same style as the existing nested guard) and
+`os.Exit(1)`. The message must:
+1. State clearly that agent-deck manages its own tmux sessions
+2. Explain that nesting causes detach confusion
+3. Offer the opt-in env var for users who insist
+4. Point at the CLI subcommand pattern for users who just want to run one command
+
+## Failing tests (RED first)
+
+File: `cmd/agent-deck/main_test.go` — append the following three tests:
+
+1. `TestOuterTmuxGuard_OuterTmuxNoOptIn` — `TMUX` set to a non-agentdeck value,
+   `AGENT_DECK_ALLOW_OUTER_TMUX` unset → expect `isOuterTmuxWithoutOptIn()` to
+   return `true`.
+2. `TestOuterTmuxGuard_OuterTmuxWithOptIn` — `TMUX` set, opt-in env set to
+   `"1"` → expect `false`.
+3. `TestOuterTmuxGuard_NoTmux` — `TMUX` unset → expect `false`.
+
+All three will fail to COMPILE on current main because `isOuterTmuxWithoutOptIn`
+does not exist. That's the RED signal.
+
+## Scope boundaries
+
+**May change:**
+- `cmd/agent-deck/main.go` — add `isOuterTmuxWithoutOptIn()` helper + call site after the nested guard
+- `cmd/agent-deck/main_test.go` — add the three tests above
+- `.claude/release-tests.yaml` — append new regression entries in phase 8a
+
+**MUST NOT change:**
+- `internal/tmux/**` — unrelated
+- `internal/session/**` — unrelated
+- `cmd/agent-deck/session_cmd.go` — CLI subcommands must stay working inside tmux
+- `cmd/agent-deck/cli_utils.go` — `GetCurrentSessionID` logic must stay
+- Any watcher / feedback / persistence / per-group paths
+
+## Live-boundary verification (phase 7)
+
+1. Start a generic tmux session (not agentdeck): `tmux new-session -d -s outer560 'sleep 600'`
+2. Exec agent-deck binary inside that tmux pane: expect startup exit with
+   non-zero status and the explanatory message on stderr.
+3. Set `AGENT_DECK_ALLOW_OUTER_TMUX=1` and rerun: expect TUI boots normally
+   (user opted in).
+4. Exit tmux; run `agent-deck --version`: expect normal version output
+   (guard only fires on TUI launch, not on CLI subcommands).
+5. Inside the same outer tmux, run `agent-deck list`: expect normal list
+   output (CLI subcommand unaffected by the guard).
+
+All five boundary checks must pass.

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -324,6 +324,27 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Block TUI launch inside a *generic* (non-agentdeck) tmux session (#560).
+	// Detach semantics get confusing when nested: Ctrl+Q returns to the outer
+	// tmux instead of a clean shell. CLI subcommands still work inside tmux —
+	// this guard only fires on the interactive TUI path.
+	if isOuterTmuxWithoutOptIn() {
+		fmt.Fprintln(os.Stderr, "Error: The agent-deck TUI is designed to run OUTSIDE of tmux.")
+		fmt.Fprintln(os.Stderr, "You are inside a tmux session, so Ctrl+Q detach and nested")
+		fmt.Fprintln(os.Stderr, "tmux behavior will be surprising. agent-deck manages its own")
+		fmt.Fprintln(os.Stderr, "tmux sessions internally.")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Options:")
+		fmt.Fprintln(os.Stderr, "  • Detach from tmux (Ctrl+B d) and run agent-deck from a clean shell.")
+		fmt.Fprintln(os.Stderr, "  • Run CLI subcommands — they work fine inside tmux:")
+		fmt.Fprintln(os.Stderr, "      agent-deck list                    # List sessions")
+		fmt.Fprintln(os.Stderr, "      agent-deck add /path -t \"Title\"  # Add a new session")
+		fmt.Fprintln(os.Stderr, "      agent-deck session start <id>      # Start a session")
+		fmt.Fprintln(os.Stderr, "  • If you really want to run the TUI anyway, set:")
+		fmt.Fprintln(os.Stderr, "      AGENT_DECK_ALLOW_OUTER_TMUX=1 agent-deck")
+		os.Exit(1)
+	}
+
 	// Set version for UI update checking
 	ui.SetVersion(Version)
 
@@ -2977,6 +2998,25 @@ func handleUninstall(args []string) {
 // Uses GetCurrentSessionID() which checks if the current tmux session name matches agentdeck_*.
 func isNestedSession() bool {
 	return GetCurrentSessionID() != ""
+}
+
+// isOuterTmuxWithoutOptIn reports true when the user is launching the
+// interactive TUI from inside a NON-agentdeck tmux session without the
+// AGENT_DECK_ALLOW_OUTER_TMUX=1 opt-in. See issue #560: nesting the TUI
+// inside an outer tmux leads to confusing detach semantics (Ctrl+Q returns
+// to the outer tmux, not a clean shell). The guard fires only on the TUI
+// path — CLI subcommands remain usable inside tmux.
+func isOuterTmuxWithoutOptIn() bool {
+	if os.Getenv("TMUX") == "" {
+		return false
+	}
+	if isNestedSession() {
+		return false
+	}
+	if os.Getenv("AGENT_DECK_ALLOW_OUTER_TMUX") == "1" {
+		return false
+	}
+	return true
 }
 
 // ensureTmuxInPath checks that tmux is reachable. If exec.LookPath fails

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -108,6 +108,62 @@ func TestNestedSessionAllowsCLICommands(t *testing.T) {
 	})
 }
 
+// TestOuterTmuxGuard verifies the generic-tmux TUI guard added for issue #560.
+// When a user runs the interactive TUI inside a non-agentdeck tmux session,
+// detach semantics get surprising (Ctrl+Q returns to the outer tmux). The
+// guard warns and exits unless the user opts in via AGENT_DECK_ALLOW_OUTER_TMUX=1.
+func TestOuterTmuxGuard(t *testing.T) {
+	// Setup: snapshot env, restore on exit
+	origTmux := os.Getenv("TMUX")
+	origOptIn := os.Getenv("AGENT_DECK_ALLOW_OUTER_TMUX")
+	t.Cleanup(func() {
+		if origTmux == "" {
+			os.Unsetenv("TMUX")
+		} else {
+			os.Setenv("TMUX", origTmux)
+		}
+		if origOptIn == "" {
+			os.Unsetenv("AGENT_DECK_ALLOW_OUTER_TMUX")
+		} else {
+			os.Setenv("AGENT_DECK_ALLOW_OUTER_TMUX", origOptIn)
+		}
+	})
+
+	t.Run("outer_tmux_no_optin_blocks", func(t *testing.T) {
+		os.Setenv("TMUX", "/tmp/tmux-501/default,12345,0")
+		os.Unsetenv("AGENT_DECK_ALLOW_OUTER_TMUX")
+		if !isOuterTmuxWithoutOptIn() {
+			t.Error("expected guard to fire when TMUX set and no opt-in")
+		}
+	})
+
+	t.Run("outer_tmux_with_optin_passes", func(t *testing.T) {
+		os.Setenv("TMUX", "/tmp/tmux-501/default,12345,0")
+		os.Setenv("AGENT_DECK_ALLOW_OUTER_TMUX", "1")
+		if isOuterTmuxWithoutOptIn() {
+			t.Error("expected guard NOT to fire when opt-in env is set")
+		}
+	})
+
+	t.Run("no_tmux_passes", func(t *testing.T) {
+		os.Unsetenv("TMUX")
+		os.Unsetenv("AGENT_DECK_ALLOW_OUTER_TMUX")
+		if isOuterTmuxWithoutOptIn() {
+			t.Error("expected guard NOT to fire when TMUX is unset")
+		}
+	})
+
+	t.Run("optin_non_1_value_still_blocks", func(t *testing.T) {
+		// Only "1" is the accepted opt-in value — defensively narrow so typos
+		// like "true"/"yes" don't silently bypass the guard.
+		os.Setenv("TMUX", "/tmp/tmux-501/default,12345,0")
+		os.Setenv("AGENT_DECK_ALLOW_OUTER_TMUX", "true")
+		if !isOuterTmuxWithoutOptIn() {
+			t.Error("expected guard to fire when opt-in is not exactly \"1\"")
+		}
+	})
+}
+
 func TestExtractGroupFlag(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary

Issue #560 reporter (shorea) ran `agent-deck` inside an existing tmux session and got confusing detach behavior. The existing `isNestedSession()` guard only handles *agentdeck-managed* tmux; generic outer tmux was undetected, so the TUI booted silently and Ctrl+Q returned users to the outer tmux instead of a clean shell.

This PR adds a second guard — `isOuterTmuxWithoutOptIn()` — that fires right after the nested-session guard in `main()` and emits a clear explanation with three escape hatches:

1. Detach tmux (Ctrl+B d) and run agent-deck from a clean shell.
2. Use CLI subcommands — they work fine inside tmux.
3. Opt in via `AGENT_DECK_ALLOW_OUTER_TMUX=1` for users who insist.

## Scope

- `cmd/agent-deck/main.go` — new helper + call site after nested guard
- `cmd/agent-deck/main_test.go` — `TestOuterTmuxGuard` with 4 subcases
- `.claude/release-tests.yaml` — new regression entry

CLI subcommands remain usable inside tmux — the guard only fires on the interactive TUI launch path.

## Test plan

- [x] Targeted: `go test ./cmd/agent-deck/ -run TestOuterTmuxGuard -count=1 -v` — 4/4 pass
- [x] Full suite: `go test ./... -race -count=1 -timeout 600s` — 27/27 packages pass
- [x] Manifest drift: `TestManifestReferencesExistInSource` passes
- [x] YAML valid: `yaml.safe_load` succeeds (65 tests)
- [x] Live-boundary 5/5:
  - TMUX + no opt-in → guard fires with clear message, exit 1
  - TMUX + opt-in → guard bypassed
  - `list --json` inside TMUX → works
  - `--version` inside TMUX → works
  - No TMUX + CLI → works
- [x] Post-rebase anti-deletion check: no peer test functions removed

Closes #560.