### PR TITLE
fix(#574): route mouse wheel over preview pane to scroll session output

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -729,3 +729,58 @@ tests:
   run:
     command: go test ./cmd/agent-deck/ -run TestOuterTmuxGuard -count=1 -v
     expected: pass
+- id: fix-574-mouse-wheel-scrolls-preview
+  added: '2026-04-17'
+  task: fix-574
+  file: internal/ui/preview_scroll_test.go
+  test_name: TestPreviewScroll_MouseWheel_OverPreviewPane_IncrementsOffset
+  purpose: Wheel events over the preview region in dual layout scroll preview content (previewScrollOffset++) and DO NOT move the session list cursor (#574).
+  source: gh-issue-574
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestPreviewScroll_MouseWheel_OverPreviewPane_IncrementsOffset -race -count=1 -v
+    expected: pass
+- id: fix-574-wheel-over-list-resets-preview-offset
+  added: '2026-04-17'
+  task: fix-574
+  file: internal/ui/preview_scroll_test.go
+  test_name: TestPreviewScroll_MouseWheel_OverList_MovesCursor_ResetsOffset
+  purpose: Wheel events over the list region move the cursor AND reset any stale preview-scroll offset, so the new session opens at its tail (#574).
+  source: gh-issue-574
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestPreviewScroll_MouseWheel_OverList_MovesCursor_ResetsOffset -race -count=1 -v
+    expected: pass
+- id: fix-574-render-applies-offset
+  added: '2026-04-17'
+  task: fix-574
+  file: internal/ui/preview_scroll_test.go
+  test_name: TestPreviewScroll_Render_AppliesOffset
+  purpose: renderPreviewPane slides the visible window up by previewScrollOffset lines so older output becomes visible (#574).
+  source: gh-issue-574
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestPreviewScroll_Render_AppliesOffset -race -count=1 -v
+    expected: pass
+- id: fix-574-cursor-move-resets-offset
+  added: '2026-04-17'
+  task: fix-574
+  file: internal/ui/preview_scroll_test.go
+  test_name: TestPreviewScroll_CursorMove_ResetsOffset
+  purpose: Keyboard cursor movement (j/k/arrows/ctrl-u/d/b/f) resets the preview scroll offset so a newly-selected session opens at its tail (#574).
+  source: gh-issue-574
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestPreviewScroll_CursorMove_ResetsOffset -race -count=1 -v
+    expected: pass
+- id: fix-574-clamps-offset-to-bounds
+  added: '2026-04-17'
+  task: fix-574
+  file: internal/ui/preview_scroll_test.go
+  test_name: TestPreviewScroll_ClampsToContentRange
+  purpose: Absurd previewScrollOffset values (huge, negative) are clamped to the valid range in renderPreviewPane so the state can never go out of bounds (#574).
+  source: gh-issue-574
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestPreviewScroll_ClampsToContentRange -race -count=1 -v
+    expected: pass

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -229,20 +229,21 @@ type Home struct {
 	analyticsCacheTime     map[string]time.Time                       // TTL cache: sessionID -> cache timestamp
 
 	// State
-	cursor         int            // Selected item index in flatItems
-	viewOffset     int            // First visible item index (for scrolling)
-	isAttaching    atomic.Bool    // Prevents View() output during attach (fixes Bubble Tea Issue #431) - atomic for thread safety
-	statusFilter   session.Status // Filter sessions by status ("" = all, or specific status)
-	groupScope     string         // Limit TUI to a specific group path ("" = all groups)
-	previewMode    PreviewMode    // What to show in preview pane (both, output-only, analytics-only)
-	err            error
-	errTime        time.Time  // When error occurred (for auto-dismiss)
-	isReloading    bool       // Visual feedback during auto-reload
-	initialLoading bool       // True until first loadSessionsMsg received (shows splash screen)
-	isQuitting     bool       // True when user pressed q, shows quitting splash
-	reloadVersion  uint64     // Incremented on each reload to prevent stale background saves
-	reloadMu       sync.Mutex // Protects reloadVersion, isReloading, and lastLoadMtime for thread-safe access
-	lastLoadMtime  time.Time  // File mtime when we last loaded (for external change detection)
+	cursor              int            // Selected item index in flatItems
+	viewOffset          int            // First visible item index (for scrolling)
+	previewScrollOffset int            // Lines scrolled up from tail in the preview pane (#574). 0 = tail (default). Reset on cursor move.
+	isAttaching         atomic.Bool    // Prevents View() output during attach (fixes Bubble Tea Issue #431) - atomic for thread safety
+	statusFilter        session.Status // Filter sessions by status ("" = all, or specific status)
+	groupScope          string         // Limit TUI to a specific group path ("" = all groups)
+	previewMode         PreviewMode    // What to show in preview pane (both, output-only, analytics-only)
+	err                 error
+	errTime             time.Time  // When error occurred (for auto-dismiss)
+	isReloading         bool       // Visual feedback during auto-reload
+	initialLoading      bool       // True until first loadSessionsMsg received (shows splash screen)
+	isQuitting          bool       // True when user pressed q, shows quitting splash
+	reloadVersion       uint64     // Incremented on each reload to prevent stale background saves
+	reloadMu            sync.Mutex // Protects reloadVersion, isReloading, and lastLoadMtime for thread-safe access
+	lastLoadMtime       time.Time  // File mtime when we last loaded (for external change detection)
 
 	// Preview cache (async fetching - View() must be pure, no blocking I/O)
 	previewCache      map[string]string    // sessionID -> cached preview content
@@ -3131,10 +3132,30 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if h.newDialog.IsVisible() || h.forkDialog.IsVisible() {
 				return h, nil
 			}
-			// Main session list scroll
+			// Preview pane scroll (#574): when the wheel event lands in the
+			// preview region of the dual layout, scroll preview content
+			// instead of moving the list cursor. Other layouts keep the
+			// legacy list-scroll behaviour because they have no dedicated
+			// preview click-target (single = no preview; stacked = same-
+			// width column where Y-based routing is ambiguous enough to
+			// leave as list-scroll).
+			if h.getLayoutMode() == LayoutModeDual {
+				leftWidth := int(float64(h.width) * 0.35)
+				if msg.X >= leftWidth {
+					if msg.Button == tea.MouseButtonWheelUp {
+						h.previewScrollOffset++
+					} else if h.previewScrollOffset > 0 {
+						h.previewScrollOffset--
+					}
+					return h, nil
+				}
+			}
+			// Main session list scroll (cursor movement also resets any
+			// stale preview offset so the new session starts at its tail).
 			if msg.Button == tea.MouseButtonWheelUp {
 				if h.cursor > 0 {
 					h.cursor--
+					h.previewScrollOffset = 0
 					h.syncViewport()
 					h.markNavigationActivity()
 					return h, h.fetchSelectedPreview()
@@ -3142,6 +3163,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				if h.cursor < len(h.flatItems)-1 {
 					h.cursor++
+					h.previewScrollOffset = 0
 					h.syncViewport()
 					h.markNavigationActivity()
 					return h, h.fetchSelectedPreview()
@@ -5091,6 +5113,7 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 		// Single click: select item
 		h.cursor = itemIndex
+		h.previewScrollOffset = 0
 		h.syncViewport()
 		return h, h.markNavigationAndFetchPreview()
 	}
@@ -5180,6 +5203,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "up", "k":
 		if h.cursor > 0 {
 			h.cursor--
+			h.previewScrollOffset = 0
 			h.syncViewport()
 			h.markNavigationActivity()
 			// PERFORMANCE: Debounced preview fetch - waits 150ms for navigation to settle
@@ -5191,6 +5215,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "down", "j":
 		if h.cursor < len(h.flatItems)-1 {
 			h.cursor++
+			h.previewScrollOffset = 0
 			h.syncViewport()
 			h.markNavigationActivity()
 			// PERFORMANCE: Debounced preview fetch - waits 150ms for navigation to settle
@@ -5209,6 +5234,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < 0 {
 			h.cursor = 0
 		}
+		h.previewScrollOffset = 0
 		h.syncViewport()
 		h.markNavigationActivity()
 		return h, h.fetchSelectedPreview()
@@ -5225,6 +5251,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < 0 {
 			h.cursor = 0
 		}
+		h.previewScrollOffset = 0
 		h.syncViewport()
 		h.markNavigationActivity()
 		return h, h.fetchSelectedPreview()
@@ -5238,6 +5265,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < 0 {
 			h.cursor = 0
 		}
+		h.previewScrollOffset = 0
 		h.syncViewport()
 		h.markNavigationActivity()
 		return h, h.fetchSelectedPreview()
@@ -5254,6 +5282,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < 0 {
 			h.cursor = 0
 		}
+		h.previewScrollOffset = 0
 		h.syncViewport()
 		h.markNavigationActivity()
 		return h, h.fetchSelectedPreview()
@@ -11850,15 +11879,40 @@ func (h *Home) renderPreviewPane(width, height int) string {
 		// Track if we're truncating from the top (for indicator)
 		truncatedFromTop := len(lines) > maxLines
 		truncatedCount := 0
+		scrolledBelow := 0
 		if truncatedFromTop {
-			// Reserve one line for the truncation indicator
+			// Reserve one line for the "⋮ N more above" indicator
 			maxLines--
 			if maxLines < 1 {
 				maxLines = 1
 			}
-			truncatedCount = len(lines) - maxLines
-			lines = lines[len(lines)-maxLines:]
+			// #574: slide the visible window up by previewScrollOffset lines
+			// so the user can see older output instead of the tail. Clamp
+			// the offset to the valid range so arbitrary values don't go
+			// out of bounds or below zero.
+			maxOffset := len(lines) - maxLines
+			if maxOffset < 0 {
+				maxOffset = 0
+			}
+			if h.previewScrollOffset > maxOffset {
+				h.previewScrollOffset = maxOffset
+			}
+			if h.previewScrollOffset < 0 {
+				h.previewScrollOffset = 0
+			}
+			endIdx := len(lines) - h.previewScrollOffset
+			startIdx := endIdx - maxLines
+			if startIdx < 0 {
+				startIdx = 0
+			}
+			truncatedCount = startIdx
+			scrolledBelow = len(lines) - endIdx
+			lines = lines[startIdx:endIdx]
+		} else {
+			// Content fits without truncation — offset has no effect, keep state consistent.
+			h.previewScrollOffset = 0
 		}
+		_ = scrolledBelow // reserved for a future "⋮ N below" indicator; offset clamp already prevents stale state
 
 		maxWidth := width - 4
 		if maxWidth < 10 {

--- a/internal/ui/preview_scroll_test.go
+++ b/internal/ui/preview_scroll_test.go
@@ -1,0 +1,207 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// previewScrollSessionWithLines returns a session instance whose preview cache
+// is seeded with N numbered lines ("line-0"..."line-(N-1)"), and a *Home
+// configured for dual layout so mouse-wheel routing has a preview region.
+func previewScrollSessionWithLines(t *testing.T, width, height, numLines int) (*Home, *session.Instance) {
+	t.Helper()
+	inst := session.NewInstance("scroll-target", t.TempDir())
+	inst.Status = session.StatusRunning
+
+	lines := make([]string, numLines)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line-%d", i)
+	}
+	content := strings.Join(lines, "\n")
+
+	h := NewHome()
+	h.width = width
+	h.height = height
+	h.initialLoading = false
+
+	h.instancesMu.Lock()
+	h.instances = []*session.Instance{inst}
+	h.instanceByID[inst.ID] = inst
+	h.instancesMu.Unlock()
+
+	h.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: inst},
+	}
+	h.cursor = 0
+	h.lastClickIndex = -1
+	h.setHotkeys(resolveHotkeys(nil))
+
+	h.previewCacheMu.Lock()
+	h.previewCache[inst.ID] = content
+	h.previewCacheMu.Unlock()
+
+	return h, inst
+}
+
+// Test 1: Mouse wheel over the preview pane region (dual layout) increments
+// previewScrollOffset and does NOT move the session list cursor.
+func TestPreviewScroll_MouseWheel_OverPreviewPane_IncrementsOffset(t *testing.T) {
+	h, _ := previewScrollSessionWithLines(t, 120, 40, 50)
+
+	// width=120, dual layout threshold is >=80, leftWidth = int(120*0.35) = 42.
+	// X=100 is well inside the preview region.
+	msg := tea.MouseMsg{X: 100, Y: 10, Button: tea.MouseButtonWheelUp}
+	model, _ := h.Update(msg)
+	h = model.(*Home)
+
+	if h.previewScrollOffset != 1 {
+		t.Fatalf("WheelUp over preview: previewScrollOffset=%d, want 1", h.previewScrollOffset)
+	}
+	if h.cursor != 0 {
+		t.Fatalf("WheelUp over preview: cursor=%d, want 0 (cursor should not move)", h.cursor)
+	}
+}
+
+// Test 2: Mouse wheel over the list region (dual layout) moves the session
+// list cursor and resets any preview scroll offset.
+func TestPreviewScroll_MouseWheel_OverList_MovesCursor_ResetsOffset(t *testing.T) {
+	h, _ := previewScrollSessionWithLines(t, 120, 40, 50)
+
+	// Add a second session so there's somewhere to move the cursor to.
+	inst2 := session.NewInstance("other", t.TempDir())
+	inst2.Status = session.StatusRunning
+	h.instancesMu.Lock()
+	h.instances = append(h.instances, inst2)
+	h.instanceByID[inst2.ID] = inst2
+	h.instancesMu.Unlock()
+	h.flatItems = append(h.flatItems, session.Item{Type: session.ItemTypeSession, Session: inst2})
+
+	// Pre-seed a non-zero preview offset; wheel-over-list should reset it.
+	h.previewScrollOffset = 5
+
+	// X=10 is inside the list region (leftWidth=42).
+	msg := tea.MouseMsg{X: 10, Y: 10, Button: tea.MouseButtonWheelDown}
+	model, _ := h.Update(msg)
+	h = model.(*Home)
+
+	if h.cursor != 1 {
+		t.Fatalf("WheelDown over list: cursor=%d, want 1", h.cursor)
+	}
+	if h.previewScrollOffset != 0 {
+		t.Fatalf("WheelDown over list: previewScrollOffset=%d, want 0 (should reset on cursor move)", h.previewScrollOffset)
+	}
+}
+
+// Test 3: renderPreviewPane applies previewScrollOffset when slicing the
+// captured content — offset=0 shows tail, offset>0 reveals older lines.
+func TestPreviewScroll_Render_AppliesOffset(t *testing.T) {
+	const numLines = 50
+	h, _ := previewScrollSessionWithLines(t, 120, 40, numLines)
+
+	// offset=0: must include the tail line.
+	h.previewScrollOffset = 0
+	tailRender := h.renderPreviewPane(78, 20)
+	if !strings.Contains(tailRender, fmt.Sprintf("line-%d", numLines-1)) {
+		t.Fatalf("offset=0 render: expected tail line %q present, got:\n%s", fmt.Sprintf("line-%d", numLines-1), tailRender)
+	}
+
+	// offset=10: tail line must disappear, and a line 10 positions earlier
+	// must appear.
+	h.previewScrollOffset = 10
+	scrolledRender := h.renderPreviewPane(78, 20)
+	if strings.Contains(scrolledRender, fmt.Sprintf("line-%d", numLines-1)) {
+		t.Fatalf("offset=10 render: tail line %q should NOT be visible, got:\n%s", fmt.Sprintf("line-%d", numLines-1), scrolledRender)
+	}
+	earlierLine := fmt.Sprintf("line-%d", numLines-1-10)
+	if !strings.Contains(scrolledRender, earlierLine) {
+		t.Fatalf("offset=10 render: expected earlier line %q visible, got:\n%s", earlierLine, scrolledRender)
+	}
+}
+
+// Test 4: Cursor movement via keyboard (down/j) resets the preview scroll
+// offset — otherwise the new session's preview would open at a stale offset.
+func TestPreviewScroll_CursorMove_ResetsOffset(t *testing.T) {
+	h, _ := previewScrollSessionWithLines(t, 120, 40, 50)
+
+	inst2 := session.NewInstance("second", t.TempDir())
+	inst2.Status = session.StatusRunning
+	h.instancesMu.Lock()
+	h.instances = append(h.instances, inst2)
+	h.instanceByID[inst2.ID] = inst2
+	h.instancesMu.Unlock()
+	h.flatItems = append(h.flatItems, session.Item{Type: session.ItemTypeSession, Session: inst2})
+
+	h.previewScrollOffset = 7
+
+	model, _ := h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	h = model.(*Home)
+
+	if h.cursor != 1 {
+		t.Fatalf("after 'j': cursor=%d, want 1", h.cursor)
+	}
+	if h.previewScrollOffset != 0 {
+		t.Fatalf("after 'j': previewScrollOffset=%d, want 0 (should reset on cursor move)", h.previewScrollOffset)
+	}
+}
+
+// Test 5: Render clamps previewScrollOffset to the valid content range and
+// does not panic on absurd values.
+func TestPreviewScroll_ClampsToContentRange(t *testing.T) {
+	h, _ := previewScrollSessionWithLines(t, 120, 40, 20)
+
+	// Over-large offset must clamp during render. We don't assert the exact
+	// clamped value (depends on header lines + maxLines), only that the
+	// render succeeds AND shows the top of content (line-0) AND the clamped
+	// offset is not absurd.
+	h.previewScrollOffset = 9999
+	rendered := h.renderPreviewPane(78, 20)
+	if !strings.Contains(rendered, "line-0") {
+		t.Fatalf("offset=9999 should clamp so top-of-content (line-0) is visible, got:\n%s", rendered)
+	}
+	if h.previewScrollOffset >= 9999 {
+		t.Fatalf("previewScrollOffset was not clamped after render: still %d", h.previewScrollOffset)
+	}
+	if h.previewScrollOffset < 0 {
+		t.Fatalf("previewScrollOffset became negative: %d", h.previewScrollOffset)
+	}
+
+	// WheelDown (decrement) past zero must clamp at 0.
+	h.previewScrollOffset = 0
+	msg := tea.MouseMsg{X: 100, Y: 10, Button: tea.MouseButtonWheelDown}
+	model, _ := h.Update(msg)
+	h = model.(*Home)
+	if h.previewScrollOffset < 0 {
+		t.Fatalf("WheelDown from 0: previewScrollOffset=%d, want 0 (no negative)", h.previewScrollOffset)
+	}
+}
+
+// Test 6: In single/stacked layout modes the mouse-wheel-over-preview route
+// does NOT apply (there's either no preview or the region detection differs).
+// In single mode the wheel must keep list-scroll semantics for all X values.
+func TestPreviewScroll_SingleLayoutMode_WheelMovesCursor(t *testing.T) {
+	// width=45 → LayoutModeSingle (<50).
+	h, _ := previewScrollSessionWithLines(t, 45, 40, 50)
+
+	inst2 := session.NewInstance("second", t.TempDir())
+	inst2.Status = session.StatusRunning
+	h.instancesMu.Lock()
+	h.instances = append(h.instances, inst2)
+	h.instanceByID[inst2.ID] = inst2
+	h.instancesMu.Unlock()
+	h.flatItems = append(h.flatItems, session.Item{Type: session.ItemTypeSession, Session: inst2})
+
+	msg := tea.MouseMsg{X: 30, Y: 10, Button: tea.MouseButtonWheelDown}
+	model, _ := h.Update(msg)
+	h = model.(*Home)
+
+	if h.cursor != 1 {
+		t.Fatalf("single-layout WheelDown: cursor=%d, want 1 (should move cursor since no preview region)", h.cursor)
+	}
+	if h.previewScrollOffset != 0 {
+		t.Fatalf("single-layout WheelDown: previewScrollOffset=%d, want 0 (no preview scroll in single layout)", h.previewScrollOffset)
+	}
+}


### PR DESCRIPTION
Closes #574.

## Problem
Reporter expected the preview pane scrollbar to let them scroll session output. In the current code the preview pane tails the last N lines with no scroll concept at all — there is no way to view older output regardless of which UI element you click. The original triage reclassified this as a feature request; this PR ships the minimal implementation.

## Fix
In dual layout, mouse-wheel events landing in the preview region (X >= 35% of window width) now increment / decrement a new `previewScrollOffset` instead of moving the session list cursor. `renderPreviewPane` slides the visible window up by that offset so older captured output becomes visible.

- Cursor movement (arrow keys, j/k, ctrl-u/d/b/f, single-click, wheel-over-list) resets the offset so a freshly-selected session opens at its tail.
- Offset is clamped to the valid range on every render — absurd values never go out of bounds or negative.
- Single and stacked layouts keep list-scroll semantics (no preview region to hit).

## Tests — 6 new, all green
- `TestPreviewScroll_MouseWheel_OverPreviewPane_IncrementsOffset`
- `TestPreviewScroll_MouseWheel_OverList_MovesCursor_ResetsOffset`
- `TestPreviewScroll_Render_AppliesOffset`
- `TestPreviewScroll_CursorMove_ResetsOffset`
- `TestPreviewScroll_ClampsToContentRange`
- `TestPreviewScroll_SingleLayoutMode_WheelMovesCursor`

Regression guard: existing mouse-click + preview-pane test suite (13 tests) still passes. Full suite `go test ./... -race -count=1` across 27 packages all green, both pre- and post-rebase on `origin/main`.

## Release-tests.yaml
5 new manifest entries for the new regression guards. Manifest drift test (`TestManifestReferencesExistInSource`, added in v1.7.16) confirms each entry resolves to a real `(file, test_name)` pair.

## Scope
- `internal/ui/home.go` (+72/-18) — field, mouse routing, render slicing, cursor-reset
- `internal/ui/preview_scroll_test.go` (new, 207 lines)
- `.claude/release-tests.yaml` (+55)

Committed by Ashesh Goplani.