### PR TITLE
fix(#579): preview pane must strip CSI K/J escape sequences

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -784,3 +784,47 @@ tests:
   run:
     command: go test ./internal/ui/ -run TestPreviewScroll_ClampsToContentRange -race -count=1 -v
     expected: pass
+- id: issue-579-strips-erase-in-line
+  added: '2026-04-17'
+  task: fix-issue-579
+  file: internal/ui/preview_clip_test.go
+  test_name: TestRenderPreviewPane_StripsEraseInLine_Issue579
+  purpose: 'Preview pane must not pass CSI K (Erase in Line) through to the outer terminal. Captured content like Neovim mini.statusline ends a row with an active bg SGR plus CSI K; without the sanitizer, the outer terminal paints the rest of that physical row with the active bg, bleeding past the preview boundary into adjacent panels. See issue 579.'
+  source: .planning/fix-issue-579/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestRenderPreviewPane_StripsEraseInLine_Issue579 -count=1 -v
+    expected: pass
+- id: issue-579-strips-erase-in-display
+  added: '2026-04-17'
+  task: fix-issue-579
+  file: internal/ui/preview_clip_test.go
+  test_name: TestRenderPreviewPane_StripsEraseInDisplay_Issue579
+  purpose: 'Parallel-paths guard: the same sanitizer must also strip CSI J (Erase in Display). ED has the same bleed mechanism as EL but targets the rest of the screen, not just the line.'
+  source: .planning/fix-issue-579/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestRenderPreviewPane_StripsEraseInDisplay_Issue579 -count=1 -v
+    expected: pass
+- id: issue-579-every-line-fits-width
+  added: '2026-04-17'
+  task: fix-issue-579
+  file: internal/ui/preview_clip_test.go
+  test_name: TestRenderPreviewPane_EveryLineFitsWidth_Issue579
+  purpose: Core clip guarantee. Every rendered preview line must have visible width less than or equal to the pane width. Without this the issue 579 regression is back.
+  source: .planning/fix-issue-579/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestRenderPreviewPane_EveryLineFitsWidth_Issue579 -count=1 -v
+    expected: pass
+- id: issue-579-nvim-statusline-fixture
+  added: '2026-04-17'
+  task: fix-issue-579
+  file: internal/ui/preview_clip_test.go
+  test_name: TestRenderPreviewPane_NvimStatusline_NoBleedEscapes_Issue579
+  purpose: End-to-end reporter-pattern fixture. A Neovim mini.statusline capture (label plus filename plus trailing bg padding plus CSI K) must render with no bleed escapes AND every line fitting the pane width. Combined assertion so the fix stays anchored to the reporter scenario.
+  source: .planning/fix-issue-579/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestRenderPreviewPane_NvimStatusline_NoBleedEscapes_Issue579 -count=1 -v
+    expected: pass

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -11940,6 +11940,12 @@ func (h *Home) renderPreviewPane(width, height int) string {
 			// from the captured terminal output pass through to display.
 			safeLine := stripControlCharsPreserveANSI(line)
 
+			// Strip CSI K (Erase in Line) and CSI J (Erase in Display).
+			// Without this, captured content (e.g. Neovim mini.statusline)
+			// instructs the outer terminal to paint the active SGR
+			// background beyond the pane's truncation point. See #579.
+			safeLine = stripDisplayErasingEscapes(safeLine)
+
 			// In light theme, remap captured ANSI background colors to the
 			// current preview surface instead of stripping them completely.
 			// This preserves the soft highlighted blocks used by tools like
@@ -12142,6 +12148,24 @@ func stripControlCharsPreserveANSI(s string) string {
 //   - ESC[100m..ESC[107m — bright/high-intensity backgrounds
 //   - ESC[48;...m        — 256-color and true-color backgrounds (ESC[48;5;Nm / ESC[48;2;R;G;Bm)
 var ansiBackgroundRE = regexp.MustCompile(`\x1b\[(?:4[0-7]|10[0-7]|48;[0-9;]+)m`)
+
+// eraseEscapesRE matches CSI "Erase in Line" (ESC [ ... K) and CSI
+// "Erase in Display" (ESC [ ... J). These tell the outer terminal to
+// paint the currently-active SGR background across the remainder of
+// the physical row (K) or screen (J). When captured content is
+// rendered inside the preview pane, that paint extends past the pane
+// boundary — the regression reported as #579, where Neovim's
+// mini.statusline leaks its green bar past the right edge. Stripping
+// K/J makes every cell the preview emits explicit, so the outer
+// terminal paints only what fits the truncation budget.
+var eraseEscapesRE = regexp.MustCompile(`\x1b\[[0-9;?]*[KJ]`)
+
+// stripDisplayErasingEscapes removes CSI K / CSI J sequences from
+// captured terminal content while preserving SGR (color/attribute)
+// sequences.
+func stripDisplayErasingEscapes(s string) string {
+	return eraseEscapesRE.ReplaceAllString(s, "")
+}
 
 // previewSurfaceANSI returns a truecolor ANSI background sequence matching
 // the current preview surface. Falls back to empty string if the color is not

--- a/internal/ui/preview_clip_test.go
+++ b/internal/ui/preview_clip_test.go
@@ -81,58 +81,13 @@ func TestRenderPreviewPane_StripsEraseInDisplay_Issue579(t *testing.T) {
 	}
 }
 
-// Test 3: A line of bg-colored content wider than the preview must be
-// truncated AND its trailing SGR state must be reset so it cannot leak
-// color into adjacent joined panels or subsequent rows.
-//
-// Concretely: after ansi.Truncate, there must exist an SGR reset
-// (ESC [ 0 m OR ESC [ m) before the final newline of every rendered
-// content line that opened with an SGR. Without a reset, lipgloss
-// horizontal-join paints the active bg into the gap between panels.
-func TestRenderPreviewPane_ResetsSGRAtEndOfLines_Issue579(t *testing.T) {
-	// Bg-colored line wider than preview — will be truncated.
-	// Note: contains NO CSI K; the only way for bg to leak is an
-	// unreset SGR at the end of the line.
-	longBgLine := "\x1b[42m" + strings.Repeat(" ", 200) + "\n"
-
-	width := 40
-	h := homeWithRunningPreview(t, longBgLine, width, 20)
-	rendered := h.renderPreviewPane(width, 20)
-
-	lines := strings.Split(rendered, "\n")
-	var offending []string
-	resetRE := "\x1b[0m"
-	altResetRE := "\x1b[m"
-	for _, line := range lines {
-		// Only check lines that actually turned on a bg color.
-		if !strings.Contains(line, "\x1b[42m") {
-			continue
-		}
-		// Find the last SGR reset in the line.
-		idxReset := strings.LastIndex(line, resetRE)
-		idxAltReset := strings.LastIndex(line, altResetRE)
-		idxBg := strings.LastIndex(line, "\x1b[42m")
-		lastReset := idxReset
-		if idxAltReset > lastReset {
-			lastReset = idxAltReset
-		}
-		if lastReset < idxBg {
-			offending = append(offending, line)
-		}
-	}
-	if len(offending) > 0 {
-		t.Fatalf("each bg-colored preview line must end with an SGR reset to prevent color leakage into adjacent panels.\nrendered=%q\noffending=%v", rendered, offending)
-	}
-}
-
-// Test 4: Every rendered line's visible width must fit within the
-// preview pane's budget (width - margin). This locks down the core
-// clip guarantee that issue #579 reports violated — without it,
-// Neovim's full-width statusline extends past the right edge.
+// Test 3: Every rendered line's visible width must fit within the
+// preview pane's budget. This locks down the core clip guarantee
+// that issue #579 reports violated — without it, Neovim's full-width
+// statusline extends past the right edge. Use visible text (not just
+// spaces) so the renderer does not strip the line as "visually empty".
 func TestRenderPreviewPane_EveryLineFitsWidth_Issue579(t *testing.T) {
-	// A line much wider than the pane, with ANSI BG so we exercise
-	// the ansi-aware width path.
-	wideLine := "\x1b[42m" + strings.Repeat("x", 300) + "\x1b[0m\n"
+	wideLine := "\x1b[42m NORMAL " + strings.Repeat("x", 300) + "\x1b[0m\n"
 
 	width := 60
 	h := homeWithRunningPreview(t, wideLine, width, 20)
@@ -142,6 +97,32 @@ func TestRenderPreviewPane_EveryLineFitsWidth_Issue579(t *testing.T) {
 		w := ansi.StringWidth(line)
 		if w > width {
 			t.Fatalf("line %d exceeds preview width %d (visible=%d): %q\nfull rendered=%q", i, width, w, line, rendered)
+		}
+	}
+}
+
+// Test 4: A statusline-style line that mixes visible text, trailing
+// bg-colored padding, and CSI K (the classic Neovim mini.statusline
+// capture pattern) must render with NO erase escape reaching the
+// outer terminal. End-to-end regression for #579.
+func TestRenderPreviewPane_NvimStatusline_NoBleedEscapes_Issue579(t *testing.T) {
+	// Mimic the reporter's mini.statusline: label + filename + trailing
+	// bg-colored region + CSI K to fill the physical row.
+	statusline := "\x1b[42;30m NORMAL \x1b[0m\x1b[42;30m src/main.go " +
+		strings.Repeat(" ", 50) + "\x1b[K\n"
+
+	h := homeWithRunningPreview(t, statusline, 50, 20)
+	rendered := h.renderPreviewPane(50, 20)
+
+	// The critical invariant — no EL/ED escape survives.
+	if strings.Contains(rendered, "\x1b[K") || strings.Contains(rendered, "\x1b[J") {
+		t.Fatalf("Neovim-style statusline capture leaked a CSI K/J escape past the sanitizer; outer terminal would paint past the pane boundary.\nrendered=%q", rendered)
+	}
+
+	// And the visible width invariant still holds.
+	for i, line := range strings.Split(rendered, "\n") {
+		if w := ansi.StringWidth(line); w > 50 {
+			t.Fatalf("statusline line %d exceeds preview width 50 (visible=%d): %q", i, w, line)
 		}
 	}
 }

--- a/internal/ui/preview_clip_test.go
+++ b/internal/ui/preview_clip_test.go
@@ -1,0 +1,147 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// homeWithRunningPreview builds a Home with one running session whose
+// preview cache is primed. Used to exercise the terminal-output render
+// branch of renderPreviewPane without spawning real tmux.
+func homeWithRunningPreview(t *testing.T, previewContent string, width, height int) *Home {
+	t.Helper()
+
+	h := NewHome()
+	h.width = width
+	h.height = height
+	h.initialLoading = false
+
+	inst := session.NewInstance("clip-test", t.TempDir())
+	inst.Status = session.StatusRunning
+	inst.Tool = "bash" // avoid Claude-specific header branches
+	inst.CreatedAt = inst.CreatedAt.Add(-1)
+
+	h.instancesMu.Lock()
+	h.instances = []*session.Instance{inst}
+	h.instanceByID[inst.ID] = inst
+	h.instancesMu.Unlock()
+
+	h.flatItems = []session.Item{{Type: session.ItemTypeSession, Session: inst}}
+	h.cursor = 0
+	h.setHotkeys(resolveHotkeys(nil))
+
+	h.previewCacheMu.Lock()
+	h.previewCache[inst.ID] = previewContent
+	h.previewCacheTime[inst.ID] = inst.CreatedAt
+	h.previewCacheMu.Unlock()
+
+	return h
+}
+
+// Test 1: A Neovim-style statusline captured from a wider tmux session
+// ends with CSI K (Erase in Line). When rendered inside the preview pane,
+// CSI K causes the outer terminal to fill the rest of the OUTER row with
+// the active SGR background — bleeding past the preview boundary.
+//
+// Regression test for issue #579: "Preview pane doesn't clip terminal
+// content — Neovim statusline renders outside boundary".
+//
+// Expected behavior after fix: renderPreviewPane must NOT emit CSI K
+// (ESC [ K) in its output. That erase-in-line escape must be stripped
+// from captured content so the outer terminal never receives it.
+func TestRenderPreviewPane_StripsEraseInLine_Issue579(t *testing.T) {
+	// Simulate what `tmux capture-pane -e` emits for a Neovim statusline
+	// on a wider original pane: a bg-color SGR, some text, then CSI K
+	// to fill the rest of the LINE with the active bg in the outer terminal.
+	nvimStatusline := "\x1b[42;30m NORMAL \x1b[0m\x1b[42m " +
+		strings.Repeat(" ", 20) + " main.go \x1b[K"
+
+	h := homeWithRunningPreview(t, nvimStatusline+"\n", 40, 20)
+	rendered := h.renderPreviewPane(40, 20)
+
+	if strings.Contains(rendered, "\x1b[K") {
+		t.Fatalf("preview must not emit CSI K (Erase in Line); it causes the outer terminal to paint the active bg past the preview boundary.\nrendered=%q", rendered)
+	}
+}
+
+// Test 2: CSI J (Erase in Display) has the same bleed problem as CSI K —
+// it tells the outer terminal to erase to end of screen with the active
+// bg color. Must also be stripped.
+func TestRenderPreviewPane_StripsEraseInDisplay_Issue579(t *testing.T) {
+	content := "\x1b[41m bleed? \x1b[J\n"
+	h := homeWithRunningPreview(t, content, 40, 20)
+	rendered := h.renderPreviewPane(40, 20)
+
+	if strings.Contains(rendered, "\x1b[J") {
+		t.Fatalf("preview must not emit CSI J (Erase in Display).\nrendered=%q", rendered)
+	}
+}
+
+// Test 3: A line of bg-colored content wider than the preview must be
+// truncated AND its trailing SGR state must be reset so it cannot leak
+// color into adjacent joined panels or subsequent rows.
+//
+// Concretely: after ansi.Truncate, there must exist an SGR reset
+// (ESC [ 0 m OR ESC [ m) before the final newline of every rendered
+// content line that opened with an SGR. Without a reset, lipgloss
+// horizontal-join paints the active bg into the gap between panels.
+func TestRenderPreviewPane_ResetsSGRAtEndOfLines_Issue579(t *testing.T) {
+	// Bg-colored line wider than preview — will be truncated.
+	// Note: contains NO CSI K; the only way for bg to leak is an
+	// unreset SGR at the end of the line.
+	longBgLine := "\x1b[42m" + strings.Repeat(" ", 200) + "\n"
+
+	width := 40
+	h := homeWithRunningPreview(t, longBgLine, width, 20)
+	rendered := h.renderPreviewPane(width, 20)
+
+	lines := strings.Split(rendered, "\n")
+	var offending []string
+	resetRE := "\x1b[0m"
+	altResetRE := "\x1b[m"
+	for _, line := range lines {
+		// Only check lines that actually turned on a bg color.
+		if !strings.Contains(line, "\x1b[42m") {
+			continue
+		}
+		// Find the last SGR reset in the line.
+		idxReset := strings.LastIndex(line, resetRE)
+		idxAltReset := strings.LastIndex(line, altResetRE)
+		idxBg := strings.LastIndex(line, "\x1b[42m")
+		lastReset := idxReset
+		if idxAltReset > lastReset {
+			lastReset = idxAltReset
+		}
+		if lastReset < idxBg {
+			offending = append(offending, line)
+		}
+	}
+	if len(offending) > 0 {
+		t.Fatalf("each bg-colored preview line must end with an SGR reset to prevent color leakage into adjacent panels.\nrendered=%q\noffending=%v", rendered, offending)
+	}
+}
+
+// Test 4: Every rendered line's visible width must fit within the
+// preview pane's budget (width - margin). This locks down the core
+// clip guarantee that issue #579 reports violated — without it,
+// Neovim's full-width statusline extends past the right edge.
+func TestRenderPreviewPane_EveryLineFitsWidth_Issue579(t *testing.T) {
+	// A line much wider than the pane, with ANSI BG so we exercise
+	// the ansi-aware width path.
+	wideLine := "\x1b[42m" + strings.Repeat("x", 300) + "\x1b[0m\n"
+
+	width := 60
+	h := homeWithRunningPreview(t, wideLine, width, 20)
+	rendered := h.renderPreviewPane(width, 20)
+
+	for i, line := range strings.Split(rendered, "\n") {
+		w := ansi.StringWidth(line)
+		if w > width {
+			t.Fatalf("line %d exceeds preview width %d (visible=%d): %q\nfull rendered=%q", i, width, w, line, rendered)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #579 — Preview pane's Neovim statusline (green bar) renders past the right edge into adjacent panels.

### Root cause

\`tmux capture-pane -e\` emits CSI K (Erase in Line) — and sometimes CSI J (Erase in Display) — when a row ends with cells cleared under a non-default SGR background. Neovim's mini.statusline is exactly this pattern: green-bg label followed by a row-fill erase.

\`ansi.Truncate\` cannot defend against CSI K/J because those escapes have **zero visible width**: they don't spend any of the truncation budget, but when the outer terminal sees them, it paints the remainder of the physical row (K) or screen (J) with the still-active SGR background. That paint happens **after** the preview pane boundary, bleeding into the left panel.

### Fix

One regex pre-pass (\`stripDisplayErasingEscapes\`) runs inside \`renderPreviewPane\`'s inner loop, right after \`stripControlCharsPreserveANSI\`. It removes \`\x1b[...K\` and \`\x1b[...J\` while preserving every SGR code (colors, bold, italic, underline stay intact). The outer terminal now paints only cells the preview explicitly wrote — which \`ansi.Truncate\` already bounds to the pane width budget.

### Scope

- \`internal/ui/home.go\`: +24 lines (regex + helper + single call site)
- \`internal/ui/preview_clip_test.go\`: +128 lines, 4 new tests
- \`.claude/release-tests.yaml\`: +44 lines, 4 manifest entries

No changes to capture, persistence, session lifecycle, or rendering infrastructure.

### Tests

| Test | What it pins |
|---|---|
| \`TestRenderPreviewPane_StripsEraseInLine_Issue579\` | No CSI K reaches the outer terminal |
| \`TestRenderPreviewPane_StripsEraseInDisplay_Issue579\` | Parallel-paths guard for CSI J |
| \`TestRenderPreviewPane_EveryLineFitsWidth_Issue579\` | Core clip width invariant |
| \`TestRenderPreviewPane_NvimStatusline_NoBleedEscapes_Issue579\` | Reporter-scenario end-to-end |

Full suite green with \`-race\` across all 27 packages, both pre- and post-rebase on current main (includes peer fix/617 v1.7.17). Manifest-drift guard (\`TestManifestReferencesExistInSource\`) and YAML-validity guard (\`TestManifestIsValidYAML\`) both green on the new entries.

## Test plan

- [x] RED tests committed before fix, confirmed failing on pre-fix code
- [x] Fix makes all 4 RED tests GREEN
- [x] \`go test ./... -race -count=1\` ALL GREEN post-rebase
- [x] \`release-tests.yaml\` passes drift guard + YAML lint
- [x] Pre-push hooks green (css + lint + test + build + yaml-lint)