### PR TITLE
Fix clipboard paste handling in WSL2+Chrome environments

### DIFF
--- a/internal/web/static/app/TerminalPanel.js
+++ b/internal/web/static/app/TerminalPanel.js
@@ -235,6 +235,26 @@ export function TerminalPanel() {
       })
     }
 
+    // WSL2+Chrome paste fix: xterm.js 6.0's default paste path can fail and
+    // destroy the system clipboard when focus is not on .xterm-helper-textarea.
+    // Capture the paste on the container first, read clipboardData directly,
+    // and forward through the same path as terminal.onData.
+    if (!mobile) {
+      container.addEventListener('paste', (event) => {
+        if (readOnlySignal.value) return
+        if (!ctx.ws || ctx.ws.readyState !== WebSocket.OPEN || !ctx.terminalAttached) return
+        const cd = event.clipboardData
+        if (!cd) return
+        let text = cd.getData('text/plain')
+        if (!text) return
+        // Normalize CRLF/CR to LF; shells expect LF, bare CR re-runs input.
+        text = text.replace(/\r\n?/g, '\n')
+        event.preventDefault()
+        event.stopPropagation()
+        ctx.ws.send(JSON.stringify({ type: 'input', data: text }))
+      }, { capture: true, signal: controller.signal })
+    }
+
     // Prevent mobile soft keyboard by blocking touch-focus on the hidden textarea
     if (mobile) {
       container.addEventListener('touchstart', (e) => { e.preventDefault() }, {


### PR DESCRIPTION
## Summary
This change adds a workaround for a clipboard handling issue in xterm.js 6.0 when running in WSL2 with Chrome. The default paste behavior can fail and corrupt the system clipboard when focus is not on the hidden textarea element.

## Key Changes
- Added a capture-phase paste event listener on the terminal container that intercepts paste events before xterm.js processes them
- Directly reads clipboard data and forwards it through the same WebSocket path as normal terminal input
- Normalizes line endings (CRLF/CR → LF) to match shell expectations
- Prevents default paste behavior and event propagation to avoid xterm.js's problematic paste handling
- Only applies the fix on non-mobile devices to avoid interfering with mobile keyboard handling

## Implementation Details
- The listener checks for necessary preconditions: read-only mode, WebSocket connection state, and terminal attachment status
- Uses `capture: true` to intercept the paste event before it reaches xterm.js
- Properly cleans up the event listener using the abort controller signal
- Maintains compatibility with existing mobile-specific touch handling

https://claude.ai/code/session_011HM93T64mzVi5rebMizVZC