### PR TITLE
Add set_session_name config to pass session title to Claude

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -683,6 +683,11 @@ func (i *Instance) buildClaudeExtraFlags(opts *ClaudeOptions) string {
 		if opts.UseTeammateMode {
 			flags = append(flags, "--teammate-mode tmux")
 		}
+		// --name surfaces the agent-deck session Title inside the Claude
+		// TUI/terminal title bar. shellQuote handles spaces/quotes safely.
+		if opts.SetSessionName && strings.TrimSpace(i.Title) != "" {
+			flags = append(flags, fmt.Sprintf("--name %s", shellQuote(i.Title)))
+		}
 	}
 
 	// Plugin channels: subscribe the claude session to inbound messages from

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -2367,6 +2367,116 @@ func TestBuildClaudeExtraFlags_NilOpts(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeExtraFlags_NameIncludesTitle(t *testing.T) {
+	inst := &Instance{Tool: "claude", Title: "my session"}
+	opts := &ClaudeOptions{SetSessionName: true}
+	flags := inst.buildClaudeExtraFlags(opts)
+
+	if !strings.Contains(flags, "--name 'my session'") {
+		t.Errorf("expected --name 'my session', got %q", flags)
+	}
+}
+
+func TestBuildClaudeExtraFlags_NameOmittedWhenDisabled(t *testing.T) {
+	inst := &Instance{Tool: "claude", Title: "whatever"}
+	opts := &ClaudeOptions{SetSessionName: false}
+	flags := inst.buildClaudeExtraFlags(opts)
+
+	if strings.Contains(flags, "--name") {
+		t.Errorf("SetSessionName=false should omit --name, got %q", flags)
+	}
+}
+
+func TestBuildClaudeExtraFlags_NameOmittedWhenEmptyTitle(t *testing.T) {
+	inst := &Instance{Tool: "claude", Title: ""}
+	opts := &ClaudeOptions{SetSessionName: true}
+	flags := inst.buildClaudeExtraFlags(opts)
+
+	if strings.Contains(flags, "--name") {
+		t.Errorf("empty Title should omit --name, got %q", flags)
+	}
+
+	// Whitespace-only should also be treated as empty
+	inst.Title = "   "
+	flags = inst.buildClaudeExtraFlags(opts)
+	if strings.Contains(flags, "--name") {
+		t.Errorf("whitespace-only Title should omit --name, got %q", flags)
+	}
+}
+
+func TestBuildClaudeExtraFlags_NameEscapesQuotes(t *testing.T) {
+	inst := &Instance{Tool: "claude", Title: "a'b"}
+	opts := &ClaudeOptions{SetSessionName: true}
+	flags := inst.buildClaudeExtraFlags(opts)
+
+	// shellQuote wraps in single quotes and escapes embedded ' as '\''
+	want := `--name 'a'\''b'`
+	if !strings.Contains(flags, want) {
+		t.Errorf("expected %q in flags, got %q", want, flags)
+	}
+}
+
+func TestBuildClaudeExtraFlags_NameNotAddedWithNilOpts(t *testing.T) {
+	inst := &Instance{Tool: "claude", Title: "titled"}
+	flags := inst.buildClaudeExtraFlags(nil)
+
+	// With nil opts, SetSessionName defaults to false (zero value), so no --name
+	if strings.Contains(flags, "--name") {
+		t.Errorf("nil opts should not emit --name, got %q", flags)
+	}
+}
+
+// TestBuildClaudeCommand_IncludesName verifies that, under default config
+// (set_session_name unset == true), the command string passes the Title
+// through as --name.
+func TestBuildClaudeCommand_IncludesName(t *testing.T) {
+	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	origHome := os.Getenv("HOME")
+	os.Unsetenv("CLAUDE_CONFIG_DIR")
+	os.Setenv("HOME", t.TempDir())
+	ClearUserConfigCache()
+	defer func() {
+		if origConfigDir != "" {
+			os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
+		}
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	}()
+
+	inst := NewInstanceWithTool("probe-42", "/tmp/test", "claude")
+	cmd := inst.buildClaudeCommand("claude")
+
+	if !strings.Contains(cmd, "--name 'probe-42'") {
+		t.Errorf("expected --name 'probe-42' in command, got: %s", cmd)
+	}
+}
+
+// TestBuildClaudeCommand_ConfigOptOutDropsName verifies that users can opt
+// out via [claude].set_session_name = false in user config.
+func TestBuildClaudeCommand_ConfigOptOutDropsName(t *testing.T) {
+	inst := NewInstanceWithTool("probe-42", "/tmp/test", "claude")
+
+	setSessionNameFalse := false
+	userConfigCacheMu.Lock()
+	userConfigCache = &UserConfig{
+		Claude: ClaudeSettings{
+			SetSessionName: &setSessionNameFalse,
+		},
+	}
+	userConfigCacheMu.Unlock()
+	defer func() {
+		userConfigCacheMu.Lock()
+		userConfigCache = nil
+		userConfigCacheMu.Unlock()
+	}()
+
+	cmd := inst.buildClaudeCommand("claude")
+
+	if strings.Contains(cmd, "--name") {
+		t.Errorf("set_session_name=false should omit --name, got: %s", cmd)
+	}
+}
+
 // TestBuildClaudeCommand_ExportsInstanceID verifies that AGENTDECK_INSTANCE_ID
 // is included in the command string for Claude sessions.
 func TestBuildClaudeCommand_ExportsInstanceID(t *testing.T) {

--- a/internal/session/tooloptions.go
+++ b/internal/session/tooloptions.go
@@ -33,6 +33,10 @@ type ClaudeOptions struct {
 	UseChrome bool `json:"use_chrome,omitempty"`
 	// UseTeammateMode adds --teammate-mode tmux flag
 	UseTeammateMode bool `json:"use_teammate_mode,omitempty"`
+	// SetSessionName adds `--name <Instance.Title>` so the session title
+	// shows up in the Claude TUI/terminal title bar. Populated from
+	// ClaudeSettings.GetSetSessionName() (default true).
+	SetSessionName bool `json:"set_session_name,omitempty"`
 
 	// Transient fields for worktree fork (not persisted)
 	WorkDir          string `json:"-"`
@@ -110,6 +114,7 @@ func NewClaudeOptions(config *UserConfig) *ClaudeOptions {
 		opts.SkipPermissions = config.Claude.GetDangerousMode()
 		opts.AutoMode = config.Claude.AutoMode
 		opts.AllowSkipPermissions = config.Claude.AllowDangerousMode
+		opts.SetSessionName = config.Claude.GetSetSessionName()
 	}
 	return opts
 }

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -605,6 +605,13 @@ type ClaudeSettings struct {
 	// Power users typically want this enabled for faster iteration
 	DangerousMode *bool `toml:"dangerous_mode"`
 
+	// SetSessionName controls whether agent-deck passes the session Title
+	// to Claude via `--name <title>`. When enabled, the Title shows up in
+	// Claude's terminal title bar and TUI prompt bar so users can tell which
+	// agent-deck session they are attached to from inside the Claude TUI.
+	// Default: true (nil = true). Set to false to opt out.
+	SetSessionName *bool `toml:"set_session_name"`
+
 	// AllowDangerousMode enables --allow-dangerously-skip-permissions flag
 	// This unlocks bypass as an option without activating it by default.
 	// Ignored when dangerous_mode is true (the stronger flag takes precedence).
@@ -704,6 +711,15 @@ func (c *ClaudeSettings) GetDangerousMode() bool {
 		return true
 	}
 	return *c.DangerousMode
+}
+
+// GetSetSessionName returns whether to pass Instance.Title as `--name` to
+// claude, defaulting to true when unset.
+func (c *ClaudeSettings) GetSetSessionName() bool {
+	if c.SetSessionName == nil {
+		return true
+	}
+	return *c.SetSessionName
 }
 
 // GetHooksEnabled returns whether Claude Code hooks are enabled, defaulting to true

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -315,6 +315,52 @@ func TestSaveUserConfig(t *testing.T) {
 	}
 }
 
+func TestClaudeSettings_SetSessionName_DefaultsTrue(t *testing.T) {
+	var s ClaudeSettings
+	if !s.GetSetSessionName() {
+		t.Error("GetSetSessionName should default to true when unset")
+	}
+
+	vTrue := true
+	s.SetSessionName = &vTrue
+	if !s.GetSetSessionName() {
+		t.Error("GetSetSessionName should be true when set to true")
+	}
+
+	vFalse := false
+	s.SetSessionName = &vFalse
+	if s.GetSetSessionName() {
+		t.Error("GetSetSessionName should be false when set to false")
+	}
+}
+
+func TestClaudeSettings_SetSessionName_Roundtrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	configContent := `
+[claude]
+set_session_name = false
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	var config UserConfig
+	if _, err := toml.DecodeFile(configPath, &config); err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+
+	if config.Claude.SetSessionName == nil {
+		t.Fatal("SetSessionName should have been decoded (non-nil)")
+	}
+	if *config.Claude.SetSessionName != false {
+		t.Errorf("SetSessionName = %v, want false", *config.Claude.SetSessionName)
+	}
+	if config.Claude.GetSetSessionName() {
+		t.Error("GetSetSessionName should return false after roundtrip")
+	}
+}
+
 func TestGetTheme_Default(t *testing.T) {
 	// Setup: use temp directory with no config
 	tempDir := t.TempDir()


### PR DESCRIPTION
## Summary
This change adds support for passing the agent-deck session title to Claude via the `--name` flag, allowing the session name to appear in Claude's terminal title bar and TUI prompt. This feature is controlled by a new `set_session_name` configuration option that defaults to true.

## Key Changes

- **New config option**: Added `SetSessionName` field to `ClaudeSettings` in `userconfig.go` with a getter that defaults to true when unset
- **Claude command building**: Modified `buildClaudeExtraFlags()` in `instance.go` to append `--name <title>` when `SetSessionName` is enabled and the title is non-empty
- **Options propagation**: Added `SetSessionName` field to `ClaudeOptions` struct and populated it from config in `NewClaudeOptions()`
- **Comprehensive tests**: Added 8 new test cases covering:
  - Basic name inclusion when enabled
  - Name omission when disabled or title is empty/whitespace
  - Proper shell quoting of special characters (e.g., single quotes)
  - Nil options handling
  - Integration with config file parsing and roundtrip serialization
  - End-to-end command building with and without config opt-out

## Implementation Details

- The session title is safely passed through `shellQuote()` to handle spaces and special characters
- Empty or whitespace-only titles are treated as "no title" and the flag is omitted
- The feature defaults to enabled (true) for better UX, but users can opt out via `[claude].set_session_name = false` in their config
- The implementation follows existing patterns for optional boolean config settings using pointer-to-bool with a getter method

https://claude.ai/code/session_01KB3Y2D7yPGxprNDfEAQ2Ri