### PR TITLE
add support for compatible custom tools (`compatible_with`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Custom tools can set `compatible_with = "claude"` or `"codex"` to reuse built-in compatibility behavior when the command is a wrapper.
+
 ## [1.7.13] - 2026-04-17
 
 ### Fixed

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -872,7 +872,7 @@ func (i *Instance) resolveCodexYoloFlag() string {
 // Resume: codex resume <session-id> or codex resume --last
 // Also sources .env files from [shell].env_files
 func (i *Instance) buildCodexCommand(baseCommand string) string {
-	if i.Tool != "codex" {
+	if !IsCodexCompatible(i.Tool) {
 		return baseCommand
 	}
 
@@ -883,21 +883,17 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 
 	yoloFlag := i.resolveCodexYoloFlag()
 
-	// If baseCommand is just "codex", handle specially
-	if baseCommand == "codex" {
-		// If we already have a session ID, use resume.
-		// CODEX_SESSION_ID is propagated via host-side SetEnvironment after tmux start.
-		if i.CodexSessionID != "" {
-			return envPrefix + fmt.Sprintf("codex%s resume %s",
-				yoloFlag, i.CodexSessionID)
-		}
-
-		// Start Codex fresh - session ID will be captured async after startup
-		return envPrefix + "codex" + yoloFlag
+	command := strings.TrimSpace(baseCommand)
+	if command == "" {
+		command = "codex"
 	}
 
-	// For custom commands (e.g., resume commands), preserve env propagation.
-	return envPrefix + baseCommand
+	if i.CodexSessionID != "" {
+		return envPrefix + fmt.Sprintf("%s%s resume %s",
+			command, yoloFlag, i.CodexSessionID)
+	}
+
+	return envPrefix + command + yoloFlag
 }
 
 // detectOpenCodeSessionAsync detects the OpenCode session ID after startup
@@ -1704,7 +1700,7 @@ func (i *Instance) UpdateCodexSession(excludeIDs map[string]bool) {
 // updateCodexSession refreshes Codex session ID from env/process-files/disk.
 // Returns missing dependency name when probe prerequisites are unavailable.
 func (i *Instance) updateCodexSession(excludeIDs map[string]bool, forceProbe bool) string {
-	if i.Tool != "codex" {
+	if !IsCodexCompatible(i.Tool) {
 		return ""
 	}
 
@@ -2072,7 +2068,7 @@ func (i *Instance) Start() error {
 		command = i.buildOpenCodeCommand(i.Command)
 		// Record start time for session ID detection (Unix millis)
 		i.OpenCodeStartedAt = time.Now().UnixMilli()
-	case i.Tool == "codex":
+	case IsCodexCompatible(i.Tool):
 		command = i.buildCodexCommand(i.Command)
 		// Record start time for session ID detection (Unix millis)
 		i.CodexStartedAt = time.Now().UnixMilli()
@@ -2174,7 +2170,7 @@ func (i *Instance) Start() error {
 
 	// Start async session ID detection for Codex
 	// This runs in background and captures the session ID once Codex creates it
-	if i.Tool == "codex" {
+	if IsCodexCompatible(i.Tool) {
 		go i.detectCodexSessionAsync()
 	}
 
@@ -2226,7 +2222,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	case i.Tool == "opencode":
 		command = i.buildOpenCodeCommand(i.Command)
 		i.OpenCodeStartedAt = time.Now().UnixMilli()
-	case i.Tool == "codex":
+	case IsCodexCompatible(i.Tool):
 		command = i.buildCodexCommand(i.Command)
 		i.CodexStartedAt = time.Now().UnixMilli()
 	default:
@@ -2312,7 +2308,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	if i.Tool == "opencode" {
 		go i.detectOpenCodeSessionAsync()
 	}
-	if i.Tool == "codex" {
+	if IsCodexCompatible(i.Tool) {
 		go i.detectCodexSessionAsync()
 	}
 
@@ -2383,7 +2379,7 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 			}
 			// Gate Codex sends on prompt readiness: wait for "codex>" or
 			// "Continue?" to be visible before considering the agent ready.
-			if i.Tool == "codex" {
+			if IsCodexCompatible(i.Tool) {
 				if rawContent, captureErr := i.tmuxSession.CapturePaneFresh(); captureErr == nil {
 					content := tmux.StripANSI(rawContent)
 					detector := tmux.NewPromptDetector("codex")
@@ -2481,7 +2477,7 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 const errorRecheckInterval = 30 * time.Second
 
 func hookFastPathFreshnessForTool(tool, hookStatus string) time.Duration {
-	if tool != "codex" {
+	if !IsCodexCompatible(tool) {
 		return hookFastPathWindow
 	}
 
@@ -2586,7 +2582,7 @@ func (i *Instance) UpdateStatus() error {
 	// Freshness is tool- and state-specific (e.g. Codex running vs waiting).
 	// When this path is stale/missing, control naturally falls through to tmux
 	// polling and tool-specific session sync (tmux env/process-files/disk).
-	if (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini") &&
+	if (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini") &&
 		i.hookStatus != "" &&
 		time.Since(i.hookLastUpdate) < hookFastPathFreshnessForTool(i.Tool, i.hookStatus) {
 		switch i.hookStatus {
@@ -2599,7 +2595,7 @@ func (i *Instance) UpdateStatus() error {
 				i.tmuxSession.ResetAcknowledged()
 			}
 		case "waiting":
-			if i.Tool == "codex" {
+			if IsCodexCompatible(i.Tool) {
 				// Codex completion should surface as attention-needed.
 				// Keep this as waiting and let tmux settle to idle if the user
 				// has acknowledged and no new activity appears.
@@ -2628,7 +2624,7 @@ func (i *Instance) UpdateStatus() error {
 					i.ClaudeSessionID = i.hookSessionID
 					i.ClaudeDetectedAt = time.Now()
 				}
-			case i.Tool == "codex":
+			case IsCodexCompatible(i.Tool):
 				if i.hookSessionID != i.CodexSessionID {
 					i.CodexSessionID = i.hookSessionID
 					i.CodexDetectedAt = time.Now()
@@ -2673,19 +2669,22 @@ func (i *Instance) UpdateStatus() error {
 		i.Status = StatusError
 	}
 
-	// Update tool detection dynamically (enables fork when Claude starts).
-	// Only override for built-in tools — custom tools (openclaw, etc.) must not be
-	// clobbered by the fallback "shell" detection from content sniffing.
+	// Update tool detection dynamically (enables fork when wrapped tools start).
+	// Only built-in tool identities are rewritten here. Custom tools like
+	// "my-codex" should keep their configured identity even when tmux correctly
+	// detects the wrapped CLI as Codex.
 	if detectedTool := i.tmuxSession.DetectTool(); detectedTool != "" {
-		switch detectedTool {
-		case "claude", "gemini", "opencode", "codex":
-			i.Tool = detectedTool
-		case "shell":
-			// Only override if current tool is also a built-in (or already shell).
-			// Custom tools should keep their configured identity.
-			switch i.Tool {
-			case "", "shell", "claude", "gemini", "opencode", "codex":
+		if !isBuiltinToolName(i.Tool) && GetToolDef(i.Tool) != nil {
+			// Preserve configured custom tool names.
+		} else {
+			switch detectedTool {
+			case "claude", "gemini", "opencode", "codex":
 				i.Tool = detectedTool
+			case "shell":
+				switch i.Tool {
+				case "", "shell", "claude", "gemini", "opencode", "codex":
+					i.Tool = detectedTool
+				}
 			}
 		}
 	}
@@ -2696,16 +2695,16 @@ func (i *Instance) UpdateStatus() error {
 	if i.Status == StatusRunning || i.Status == StatusWaiting {
 		interval := 2 * time.Second
 		// Bootstrap unknown IDs faster for newly-started sessions.
-		switch i.Tool {
-		case "claude":
+		switch {
+		case IsClaudeCompatible(i.Tool):
 			if i.ClaudeSessionID == "" {
 				interval = 500 * time.Millisecond
 			}
-		case "gemini":
+		case i.Tool == "gemini":
 			if i.GeminiSessionID == "" {
 				interval = 500 * time.Millisecond
 			}
-		case "codex":
+		case IsCodexCompatible(i.Tool):
 			if i.CodexSessionID == "" {
 				interval = 500 * time.Millisecond
 			}
@@ -2722,7 +2721,7 @@ func (i *Instance) UpdateStatus() error {
 			}
 
 			// Update Codex session tracking (non-blocking, best-effort)
-			if i.Tool == "codex" {
+			if IsCodexCompatible(i.Tool) {
 				// Always collect other instances' session IDs to prevent the
 				// disk scan from assigning a session that belongs to another
 				// instance. Without this, instances that share the same
@@ -2899,7 +2898,7 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 			}
 		}
 		i.bindClaudeSessionFromHook(sessionID, hookSource, status.Event, "rebind")
-	case i.Tool == "codex":
+	case IsCodexCompatible(i.Tool):
 		if sessionID == i.CodexSessionID {
 			return
 		}
@@ -3896,10 +3895,10 @@ func (i *Instance) getTerminalLastResponse() (*ResponseOutput, error) {
 	}
 
 	// Parse based on tool type
-	switch i.Tool {
-	case "gemini":
+	switch {
+	case i.Tool == "gemini":
 		return parseGeminiOutput(content)
-	case "codex":
+	case IsCodexCompatible(i.Tool):
 		return parseCodexOutput(content)
 	default:
 		return parseGenericOutput(content, i.Tool)
@@ -4207,7 +4206,7 @@ func (i *Instance) Restart() error {
 	// the disk scan can return a wrong ID when multiple instances share the same
 	// project_path. The process probe is authoritative but only works when the
 	// process is running, which it isn't during a restart.
-	if i.Tool == "codex" && i.CodexSessionID == "" {
+	if IsCodexCompatible(i.Tool) && i.CodexSessionID == "" {
 		i.mu.Lock()
 		i.pendingCodexRestartWarning = ""
 		i.mu.Unlock()
@@ -4220,7 +4219,7 @@ func (i *Instance) Restart() error {
 	}
 
 	// If Codex session AND tmux session exists, use respawn-pane
-	if i.Tool == "codex" && i.tmuxSession != nil && i.tmuxSession.Exists() {
+	if IsCodexCompatible(i.Tool) && i.tmuxSession != nil && i.tmuxSession.Exists() {
 		// Try to get session ID from tmux environment if not already set
 		if i.CodexSessionID == "" {
 			if envID, err := i.tmuxSession.GetEnvironment("CODEX_SESSION_ID"); err == nil && envID != "" {
@@ -4233,7 +4232,7 @@ func (i *Instance) Restart() error {
 		if i.CodexSessionID == "" {
 			i.CodexStartedAt = time.Now().UnixMilli()
 		}
-		resumeCmd, containerName, err := i.prepareCommand(i.buildCodexCommand("codex"))
+		resumeCmd, containerName, err := i.prepareCommand(i.buildCodexCommand(i.Command))
 		if err != nil {
 			return err
 		}
@@ -4320,8 +4319,8 @@ func (i *Instance) Restart() error {
 		command = i.buildGeminiCommand("gemini")
 	} else if i.Tool == "opencode" && i.OpenCodeSessionID != "" {
 		command = i.buildOpenCodeCommand("opencode")
-	} else if i.Tool == "codex" && i.CodexSessionID != "" {
-		command = i.buildCodexCommand("codex")
+	} else if IsCodexCompatible(i.Tool) && i.CodexSessionID != "" {
+		command = i.buildCodexCommand(i.Command)
 	} else {
 		// Route to appropriate command builder based on tool
 		switch {
@@ -4333,7 +4332,7 @@ func (i *Instance) Restart() error {
 			command = i.buildOpenCodeCommand(i.Command)
 			// Record start time for async session ID detection
 			i.OpenCodeStartedAt = time.Now().UnixMilli()
-		case i.Tool == "codex":
+		case IsCodexCompatible(i.Tool):
 			command = i.buildCodexCommand(i.Command)
 			// Record start time for async session ID detection
 			i.CodexStartedAt = time.Now().UnixMilli()
@@ -4406,7 +4405,7 @@ func (i *Instance) Restart() error {
 	}
 
 	// Start async session ID detection for Codex (if no ID yet)
-	if i.Tool == "codex" && i.CodexSessionID == "" {
+	if IsCodexCompatible(i.Tool) && i.CodexSessionID == "" {
 		go i.detectCodexSessionAsync()
 	}
 
@@ -4573,13 +4572,13 @@ func (i *Instance) CanRestart() bool {
 	}
 
 	// Codex sessions with known session ID can always be restarted
-	if i.Tool == "codex" && i.CodexSessionID != "" {
+	if IsCodexCompatible(i.Tool) && i.CodexSessionID != "" {
 		return true
 	}
 
 	// Codex sessions without ID can still restart (will start fresh)
 	// This allows restart even before session ID is detected
-	if i.Tool == "codex" {
+	if IsCodexCompatible(i.Tool) {
 		return true
 	}
 

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1388,6 +1388,85 @@ func TestBuildGeminiCommand(t *testing.T) {
 	}
 }
 
+func TestBuildCodexCommand_CustomWrapperPreservesToolIdentity(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", agentDeckDir, err)
+	}
+
+	cfg := &UserConfig{
+		Tools: map[string]ToolDef{
+			"my-codex": {
+				Command:        "codex-wrapper",
+				CompatibleWith: "codex",
+			},
+		},
+	}
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	ClearUserConfigCache()
+
+	inst := NewInstanceWithTool("test", "/tmp/test", "my-codex")
+	inst.Command = "codex-wrapper"
+
+	cmd := inst.buildCodexCommand(inst.Command)
+	if !strings.Contains(cmd, `AGENTDECK_TOOL=my-codex`) {
+		t.Fatalf("buildCodexCommand should preserve custom tool identity, got %q", cmd)
+	}
+	if !strings.Contains(cmd, "codex-wrapper") {
+		t.Fatalf("buildCodexCommand should use the custom command, got %q", cmd)
+	}
+
+	inst.CodexSessionID = "019d1af6-c425-7791-8fd1-38c0fc43062c"
+	cmd = inst.buildCodexCommand(inst.Command)
+	if !strings.Contains(cmd, "codex-wrapper resume 019d1af6-c425-7791-8fd1-38c0fc43062c") {
+		t.Fatalf("buildCodexCommand should resume through the custom wrapper, got %q", cmd)
+	}
+}
+
+func TestCanRestart_CustomCodexWrapperWithKnownID(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", agentDeckDir, err)
+	}
+
+	cfg := &UserConfig{
+		Tools: map[string]ToolDef{
+			"my-codex": {
+				Command:        "codex-wrapper",
+				CompatibleWith: "codex",
+			},
+		},
+	}
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	ClearUserConfigCache()
+
+	inst := NewInstanceWithTool("test", "/tmp/test", "my-codex")
+	if !inst.CanRestart() {
+		t.Fatal("custom Codex wrapper should be restartable even before session ID detection")
+	}
+
+	inst.CodexSessionID = "019d1af6-c425-7791-8fd1-38c0fc43062c"
+	if !inst.CanRestart() {
+		t.Fatal("custom Codex wrapper should be restartable with a known session ID")
+	}
+}
+
 func TestInstance_GetMCPInfo_Gemini(t *testing.T) {
 	inst := NewInstanceWithTool("test", "/tmp/test", "gemini")
 

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -842,6 +842,12 @@ type ToolDef struct {
 	// Command is the shell command to run
 	Command string `toml:"command"`
 
+	// CompatibleWith opts this tool into compatibility behavior for a built-in
+	// tool even when the configured command is a wrapper script rather than the
+	// literal executable name. Supported values currently include "claude" and
+	// "codex".
+	CompatibleWith string `toml:"compatible_with"`
+
 	// Wrapper is an optional command that wraps the tool command.
 	// Use {command} placeholder to include the tool command, or omit it to replace the command.
 	// Example: wrapper = "nvim +'terminal {command}' +'startinsert'"
@@ -1497,12 +1503,34 @@ func IsClaudeCompatible(toolName string) bool {
 		return true
 	}
 	if def := GetToolDef(toolName); def != nil {
-		return isClaudeCommand(def.Command)
+		return strings.EqualFold(strings.TrimSpace(def.CompatibleWith), "claude") || isClaudeCommand(def.Command)
+	}
+	return false
+}
+
+// IsCodexCompatible returns true if the tool is "codex" or a custom tool
+// whose underlying command is "codex". Use this for capability gates
+// where custom tools wrapping Codex should get full Codex functionality
+// without losing their configured tool identity.
+func IsCodexCompatible(toolName string) bool {
+	if toolName == "codex" {
+		return true
+	}
+	if def := GetToolDef(toolName); def != nil {
+		return strings.EqualFold(strings.TrimSpace(def.CompatibleWith), "codex") || isCodexCommand(def.Command)
 	}
 	return false
 }
 
 func isClaudeCommand(command string) bool {
+	return isCommand(command, "claude")
+}
+
+func isCodexCommand(command string) bool {
+	return isCommand(command, "codex")
+}
+
+func isCommand(command, wantBase string) bool {
 	fields := strings.Fields(strings.TrimSpace(command))
 	if len(fields) == 0 {
 		return false
@@ -1523,7 +1551,7 @@ func isClaudeCommand(command string) bool {
 	base := filepath.Base(cmdToken)
 	base = strings.TrimSuffix(base, ".exe")
 	base = strings.TrimSuffix(base, ".EXE")
-	return strings.EqualFold(base, "claude")
+	return strings.EqualFold(base, wantBase)
 }
 
 func isShellEnvAssignment(token string) bool {
@@ -1573,14 +1601,9 @@ func GetCustomToolNames() []string {
 		return nil
 	}
 
-	builtins := map[string]bool{
-		"claude": true, "gemini": true, "opencode": true,
-		"codex": true, "pi": true, "shell": true, "cursor": true, "aider": true,
-	}
-
 	var names []string
 	for name := range config.Tools {
-		if !builtins[name] {
+		if !isBuiltinToolName(name) {
 			names = append(names, name)
 		}
 	}
@@ -1589,6 +1612,15 @@ func GetCustomToolNames() []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+func isBuiltinToolName(toolName string) bool {
+	switch toolName {
+	case "claude", "gemini", "opencode", "codex", "pi", "shell", "cursor", "aider":
+		return true
+	default:
+		return false
+	}
 }
 
 // GetToolIcon returns the icon for a tool (custom or built-in)
@@ -2243,6 +2275,7 @@ auto_cleanup = true
 # Each tool can have:
 #   command      - The shell command to run
 #   icon         - Emoji/symbol shown in the UI
+#   compatible_with - Built-in compatibility to mirror ("claude" or "codex")
 #   busy_patterns - Strings that indicate the tool is processing
 
 # Example: Add a custom AI tool
@@ -2264,6 +2297,12 @@ auto_cleanup = true
 # dangerous_mode = true
 # dangerous_flag = "--dangerously-skip-permissions"
 # env = { ANTHROPIC_BASE_URL = "https://api.example.com/v4", API_KEY = "your-key" }
+
+# Example: Custom Codex wrapper that should restart and detect status like Codex
+# [tools.my-codex]
+# command = "codex-wrapper"
+# compatible_with = "codex"
+# icon = "C"
 
 # ============================================================================
 # Status Detection Pattern Overrides (Advanced)

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -211,6 +212,10 @@ func TestIsClaudeCompatible_CustomToolCommands(t *testing.T) {
 			"claude_env": {
 				Command: "ANTHROPIC_BASE_URL=https://example.com claude --continue",
 			},
+			"claude_wrapper": {
+				Command:        "claude-wrapper",
+				CompatibleWith: "claude",
+			},
 			"other": {
 				Command: "codex --model gpt-5",
 			},
@@ -231,8 +236,84 @@ func TestIsClaudeCompatible_CustomToolCommands(t *testing.T) {
 	if !IsClaudeCompatible("claude_env") {
 		t.Fatal("custom tool with env-prefixed Claude command should be Claude-compatible")
 	}
+	if !IsClaudeCompatible("claude_wrapper") {
+		t.Fatal("custom tool with compatible_with=claude should be Claude-compatible")
+	}
 	if IsClaudeCompatible("other") {
 		t.Fatal("non-Claude custom tool should not be Claude-compatible")
+	}
+}
+
+func TestIsCodexCompatible_CustomToolCommands(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", agentDeckDir, err)
+	}
+
+	cfg := &UserConfig{
+		Tools: map[string]ToolDef{
+			"my_codex_wrapper": {
+				Command:        "codex-wrapper",
+				CompatibleWith: "codex",
+			},
+			"my_codex_exact": {
+				Command: "CODEX_HOME=/tmp/codex codex --model gpt-5",
+			},
+			"other": {
+				Command: "codex-wrapper",
+			},
+		},
+	}
+
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	ClearUserConfigCache()
+
+	if !IsCodexCompatible("codex") {
+		t.Fatal("built-in codex should be Codex-compatible")
+	}
+	if !IsCodexCompatible("my_codex_wrapper") {
+		t.Fatal("custom tool with compatible_with=codex should be Codex-compatible")
+	}
+	if !IsCodexCompatible("my_codex_exact") {
+		t.Fatal("custom tool with env-prefixed exact codex command should be Codex-compatible")
+	}
+	if IsCodexCompatible("other") {
+		t.Fatal("wrapper without compatible_with should not be Codex-compatible")
+	}
+}
+
+func TestCreateExampleConfigDocumentsCompatibleWith(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+
+	if err := CreateExampleConfig(); err != nil {
+		t.Fatalf("CreateExampleConfig: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, ".agent-deck", "config.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", configPath, err)
+	}
+	config := string(data)
+
+	for _, want := range []string{
+		`compatible_with - Built-in compatibility to mirror ("claude" or "codex")`,
+		`compatible_with = "codex"`,
+	} {
+		if !strings.Contains(config, want) {
+			t.Fatalf("example config missing %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
Replacement PR for https://github.com/asheshgoplani/agent-deck/pull/550.

Current status after re-check on 2026-04-19:

- Latest `main` is `8ba3f01` (`v1.7.34` release commit).
- The `compatible_with` work from this PR is already present on `main` in the v1.7.33 changeloged release.
- The PR branch `pr/replacement-f0f4013` has been force-updated to `8ba3f01` so it is no longer stale or carrying a duplicate conflict-prone commit.
- `git diff origin/main..HEAD~1` is empty locally after rebasing, so there is no remaining replacement diff to merge.
