### PR TITLE
feat(tmux,v1721): launch_as=service auto-restart on tmux death (#656)

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -828,3 +828,102 @@ tests:
   run:
     command: go test ./internal/ui/ -run TestRenderPreviewPane_NvimStatusline_NoBleedEscapes_Issue579 -count=1 -v
     expected: pass
+- id: v1721-launch-as-service-argv-shape
+  added: '2026-04-18'
+  task: v1721-scope-to-service
+  file: internal/tmux/tmux_launch_as_test.go
+  test_name: TestStartCommandSpec_LaunchAs_Service_UsesServiceForm
+  purpose: 'Pins the exact systemd-run argv for LaunchAs=service — Type=forking, Restart=on-failure, KillMode=control-group, NO --scope, NO --collect. Missing any of these silently defeats the auto-restart guarantee.'
+  source: .planning/v1721-scope-to-service/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestStartCommandSpec_LaunchAs_Service_UsesServiceForm -count=1 -v
+    expected: pass
+- id: v1721-launch-as-scope-backcompat
+  added: '2026-04-18'
+  task: v1721-scope-to-service
+  file: internal/tmux/tmux_launch_as_test.go
+  test_name: TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm
+  purpose: 'Backward-compatibility lifeline. Users who set launch_as="scope" must get the exact PR #467 argv shape. Guards against a future service-mode refactor silently mutating scope-mode semantics.'
+  source: .planning/v1721-scope-to-service/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm -count=1 -v
+    expected: pass
+- id: v1721-launch-as-empty-legacy-respect
+  added: '2026-04-18'
+  task: v1721-scope-to-service
+  file: internal/tmux/tmux_launch_as_test.go
+  test_name: TestStartCommandSpec_LaunchAs_Empty_RespectsLegacyLaunchInUserScope
+  purpose: 'Zero-behavior-change contract for v1.7.20 users. Unset launch_as must defer fully to LaunchInUserScope — NO accidental switch to service mode, NO accidental switch to direct.'
+  source: .planning/v1721-scope-to-service/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestStartCommandSpec_LaunchAs_Empty_RespectsLegacyLaunchInUserScope -count=1 -v
+    expected: pass
+- id: v1721-launch-as-invalid-fallback
+  added: '2026-04-18'
+  task: v1721-scope-to-service
+  file: internal/tmux/tmux_launch_as_test.go
+  test_name: TestStartCommandSpec_LaunchAs_Invalid_FallsBackToLegacy
+  purpose: 'Typo protection. A misspelled launch_as value must NOT silently opt the user into service mode — must fall through to LaunchInUserScope with a one-line warning log.'
+  source: .planning/v1721-scope-to-service/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestStartCommandSpec_LaunchAs_Invalid_FallsBackToLegacy -count=1 -v
+    expected: pass
+- id: v1721-fallback-service-to-scope
+  added: '2026-04-18'
+  task: v1721-scope-to-service
+  file: internal/tmux/tmux_service_fallback_test.go
+  test_name: TestStart_Service_WhenServiceFails_FallbackToScope
+  purpose: 'Three-tier fallback chain — when service-mode systemd-run fails (rare; e.g. transient-unit Restart= rejected on very old systemd), fall back to scope-mode before falling to direct tmux. Preserves PR #467 isolation even when service mode is broken.'
+  source: .planning/v1721-scope-to-service/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestStart_Service_WhenServiceFails_FallbackToScope -count=1 -timeout 60s -v
+    expected: pass
+- id: v1721-fallback-all-three-wraps-error
+  added: '2026-04-18'
+  task: v1721-scope-to-service
+  file: internal/tmux/tmux_service_fallback_test.go
+  test_name: TestStart_Service_AllThreePathsFail_ErrorIncludesAllThree
+  purpose: 'Observability. When all three tiers fail the error must list every diagnostic so operators can grep one log to find which tier broke.'
+  source: .planning/v1721-scope-to-service/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestStart_Service_AllThreePathsFail_ErrorIncludesAllThree -count=1 -v
+    expected: pass
+- id: v1721-service-restarts-on-sigkill
+  added: '2026-04-18'
+  task: v1721-scope-to-service
+  file: internal/tmux/tmux_service_integration_test.go
+  test_name: TestTmuxService_RestartsOnUnexpectedKill
+  purpose: 'Headline live-boundary empirical guarantee — the whole point of v1.7.21. Spawn tmux via the exact argv startCommandSpec emits, SIGKILL the daemon, observe systemd bring it back via Restart=on-failure within ~10s. Requires systemd-user; skips cleanly elsewhere.'
+  source: .planning/v1721-scope-to-service/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestTmuxService_RestartsOnUnexpectedKill -count=1 -timeout 60s -v
+    expected: pass
+- id: v1721-service-clean-stop
+  added: '2026-04-18'
+  task: v1721-scope-to-service
+  file: internal/tmux/tmux_service_integration_test.go
+  test_name: TestTmuxService_ExplicitStopDoesNotTriggerRestart
+  purpose: 'Removal semantics. systemctl --user stop must be a CLEAN stop — Restart=on-failure must NOT fire. This guarantees `agent-deck remove` is truly terminal and not papered over by auto-restart.'
+  source: .planning/v1721-scope-to-service/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestTmuxService_ExplicitStopDoesNotTriggerRestart -count=1 -timeout 60s -v
+    expected: pass
+- id: v1721-tmux-settings-get-launch-as
+  added: '2026-04-18'
+  task: v1721-scope-to-service
+  file: internal/session/userconfig_launch_as_test.go
+  test_name: TestTmuxSettings_GetLaunchAs_UnknownValueReturnsEmpty
+  purpose: 'Config parse guard. An unknown launch_as value in config.toml must return "" from GetLaunchAs so the legacy LaunchInUserScope code path kicks in — never a random spawn path.'
+  source: .planning/v1721-scope-to-service/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestTmuxSettings_GetLaunchAs_UnknownValueReturnsEmpty -count=1 -v
+    expected: pass

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1766,6 +1766,14 @@ func handleRemove(profile string, args []string) {
 		}
 	}
 
+	// v1.7.21+: if this session was spawned via LaunchAs=service, the
+	// transient systemd-user service unit survives a plain `tmux
+	// kill-server` (Restart=on-failure would respawn it). Best-effort
+	// stop + reset-failed the unit here so `agent-deck remove` is truly
+	// terminal. No-op on non-service-mode sessions and on non-systemd
+	// hosts.
+	_ = inst.StopServiceUnit()
+
 	// Clean up worktree directory if this is a worktree session
 	if inst.IsWorktree() {
 		if err := git.RemoveWorktree(inst.WorktreeRepoRoot, inst.WorktreePath, false); err != nil {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2096,6 +2096,7 @@ func (i *Instance) Start() error {
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
 	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
 	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
+	i.tmuxSession.LaunchAs = GetTmuxSettings().GetLaunchAs()
 
 	// Start the tmux session
 	if err := i.tmuxSession.Start(command); err != nil {
@@ -2248,6 +2249,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
 	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
 	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
+	i.tmuxSession.LaunchAs = GetTmuxSettings().GetLaunchAs()
 
 	// Start the tmux session
 	if err := i.tmuxSession.Start(command); err != nil {
@@ -3999,6 +4001,21 @@ func parseGenericOutput(content, tool string) (*ResponseOutput, error) {
 	}, nil
 }
 
+// StopServiceUnit best-effort stops + resets-failed the transient
+// systemd-user service unit associated with this instance's tmux
+// server (if LaunchAs=service was used). Intended for the remove/delete
+// code path ONLY — NOT for restart, which needs the unit to persist so
+// it can re-spawn tmux.
+//
+// No-ops on non-systemd hosts. Returns nil when the unit doesn't exist
+// or was never started (best-effort semantics per v1.7.21 spec).
+func (i *Instance) StopServiceUnit() error {
+	if i.tmuxSession == nil {
+		return nil
+	}
+	return tmux.StopServiceUnit(i.tmuxSession.Name)
+}
+
 // Kill terminates the tmux session and cleans up sandbox container if present.
 func (i *Instance) Kill() error {
 	// Kill tmux session first, but always continue to container cleanup.
@@ -4331,6 +4348,7 @@ func (i *Instance) Restart() error {
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
 	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
 	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
+	i.tmuxSession.LaunchAs = GetTmuxSettings().GetLaunchAs()
 
 	mcpLog.Debug("restart_starting_new_session", slog.String("command", command))
 

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1013,6 +1013,27 @@ type TmuxSettings struct {
 	// "field absent" from "explicit false".
 	LaunchInUserScope *bool `toml:"launch_in_user_scope"`
 
+	// LaunchAs selects the spawn form for new tmux servers (v1.7.21+).
+	// Valid values (case-insensitive, whitespace-trimmed):
+	//   "scope"   — systemd-run --user --scope (PR #467 legacy behavior)
+	//   "service" — systemd-run --user --unit <NAME>.service with
+	//               Type=forking + Restart=on-failure. Adds auto-restart
+	//               if the tmux daemon dies unexpectedly (OOM, SIGKILL,
+	//               kernel signal). Opt-in defense-in-depth.
+	//   "direct"  — plain `tmux new-session` (no systemd isolation).
+	//   "auto"    — service where systemd-user manager is available,
+	//               else direct.
+	//   ""        — unset (default): defer to LaunchInUserScope.
+	//
+	// LaunchAs, when non-empty and valid, takes precedence over
+	// LaunchInUserScope. Unknown values are ignored (fall through to
+	// LaunchInUserScope) so a config typo doesn't silently opt the user
+	// onto an unintended spawn path.
+	//
+	// This is additive — v1.7.20 users get zero behavior change until
+	// they explicitly set launch_as.
+	LaunchAs *string `toml:"launch_as"`
+
 	// WindowStyleOverride sets the tmux window-style (and window-active-style) for
 	// all sessions, overriding the theme default. Use "default" to let your terminal
 	// emulator's background show through instead of agent-deck's theme color.
@@ -1050,6 +1071,23 @@ func (t TmuxSettings) GetLaunchInUserScope() bool {
 		return *t.LaunchInUserScope
 	}
 	return isSystemdUserScopeAvailable()
+}
+
+// GetLaunchAs returns the canonicalised launch mode string parsed from
+// config.toml's [tmux].launch_as key. Returns "" if the field is unset
+// or contains an unknown value (in which case downstream callers fall
+// back to LaunchInUserScope). v1.7.21+.
+func (t TmuxSettings) GetLaunchAs() string {
+	if t.LaunchAs == nil {
+		return ""
+	}
+	v := strings.ToLower(strings.TrimSpace(*t.LaunchAs))
+	switch v {
+	case "scope", "service", "direct", "auto":
+		return v
+	default:
+		return ""
+	}
 }
 
 // systemdUserScopeAvailable caches the result of probing whether

--- a/internal/session/userconfig_launch_as_test.go
+++ b/internal/session/userconfig_launch_as_test.go
@@ -1,0 +1,112 @@
+// Tests for TmuxSettings.LaunchAs + GetLaunchAs (v1.7.21 defense-in-depth).
+//
+// LaunchAs is the new config-driven spawn-mode selector that agent-deck
+// passes through to tmux.Session. These tests pin:
+//   - toml decodes [tmux].launch_as = "..." into TmuxSettings.LaunchAs
+//   - GetLaunchAs normalizes case + trims whitespace
+//   - Unknown values return "" (defer to legacy LaunchInUserScope)
+//   - nil pointer (absent field) returns "" — zero-behavior-change guarantee
+//
+// See .planning/v1721-scope-to-service/PLAN.md.
+package session
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTmuxSettings_GetLaunchAs_Unset returns empty string so
+// downstream resolveLaunchMode falls through to LaunchInUserScope
+// (the zero-behavior-change contract for v1.7.20 users).
+func TestTmuxSettings_GetLaunchAs_Unset(t *testing.T) {
+	s := TmuxSettings{}
+	assert.Equal(t, "", s.GetLaunchAs(), "unset launch_as must return empty string")
+}
+
+// TestTmuxSettings_GetLaunchAs_ValidValues ensures each documented
+// value round-trips through GetLaunchAs unchanged (lowercase canonical).
+func TestTmuxSettings_GetLaunchAs_ValidValues(t *testing.T) {
+	for _, v := range []string{"scope", "service", "direct", "auto"} {
+		t.Run(v, func(t *testing.T) {
+			val := v
+			s := TmuxSettings{LaunchAs: &val}
+			assert.Equal(t, v, s.GetLaunchAs())
+		})
+	}
+}
+
+// TestTmuxSettings_GetLaunchAs_CaseInsensitive ensures "Service" and
+// "SERVICE" and " service " all normalize to "service" so config typos
+// don't silently opt the user out of the feature they requested.
+func TestTmuxSettings_GetLaunchAs_CaseInsensitive(t *testing.T) {
+	cases := map[string]string{
+		"Service":   "service",
+		"SERVICE":   "service",
+		" service ": "service",
+		"\tSCOPE\n": "scope",
+		"Auto":      "auto",
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			v := input
+			s := TmuxSettings{LaunchAs: &v}
+			assert.Equal(t, want, s.GetLaunchAs())
+		})
+	}
+}
+
+// TestTmuxSettings_GetLaunchAs_UnknownValueReturnsEmpty protects users
+// from typos. A misspelling like "servise" must NOT put them on a
+// random spawn path — it returns "" so downstream resolveLaunchMode
+// uses legacy LaunchInUserScope behavior.
+func TestTmuxSettings_GetLaunchAs_UnknownValueReturnsEmpty(t *testing.T) {
+	for _, bad := range []string{"servise", "foo", "scope-ish", "SERVIC", "bin"} {
+		t.Run(bad, func(t *testing.T) {
+			v := bad
+			s := TmuxSettings{LaunchAs: &v}
+			assert.Equal(t, "", s.GetLaunchAs(),
+				"unknown value %q must return empty so legacy fallback kicks in", bad)
+		})
+	}
+}
+
+// TestTmuxSettings_LaunchAs_TomlRoundTrip exercises the toml decode
+// path explicitly, because that's the one that runs at agent-deck
+// startup. A regression that breaks toml tagging would silently make
+// the new config key inert.
+func TestTmuxSettings_LaunchAs_TomlRoundTrip(t *testing.T) {
+	doc := `
+[tmux]
+launch_as = "service"
+`
+	var cfg struct {
+		Tmux TmuxSettings `toml:"tmux"`
+	}
+	_, err := toml.Decode(doc, &cfg)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Tmux.LaunchAs, "launch_as must decode into a non-nil pointer")
+	assert.Equal(t, "service", *cfg.Tmux.LaunchAs)
+	assert.Equal(t, "service", cfg.Tmux.GetLaunchAs())
+}
+
+// TestTmuxSettings_LaunchAs_TomlAbsent ensures that leaving the field
+// out of config.toml leaves the pointer nil (the "unset" sentinel
+// GetLaunchAs consults). A regression where toml synthesizes an empty
+// string would confuse downstream logic that distinguishes "absent"
+// from "explicit empty" — we never want that distinction to drift.
+func TestTmuxSettings_LaunchAs_TomlAbsent(t *testing.T) {
+	doc := `
+[tmux]
+inject_status_line = true
+`
+	var cfg struct {
+		Tmux TmuxSettings `toml:"tmux"`
+	}
+	_, err := toml.Decode(doc, &cfg)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.Tmux.LaunchAs, "absent launch_as must leave the pointer nil")
+	assert.Equal(t, "", cfg.Tmux.GetLaunchAs())
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -744,6 +744,15 @@ type Session struct {
 	// login session scope.
 	LaunchInUserScope bool
 
+	// LaunchAs overrides the spawn form (v1.7.21+). Valid values:
+	// "scope", "service", "direct", "auto", or "" (defer to
+	// LaunchInUserScope). "service" uses systemd-run --user --unit
+	// <NAME>.service with Type=forking + Restart=on-failure so tmux
+	// auto-restarts on OOM / SIGKILL / unexpected death. Unknown values
+	// fall through to LaunchInUserScope behavior — populated by callers
+	// from TmuxSettings.GetLaunchAs which already canonicalises.
+	LaunchAs string
+
 	// Custom patterns for generic tool support
 	customToolName       string
 	customBusyPatterns   []string
@@ -832,37 +841,195 @@ const (
 	bashCPrefix = "bash -c '"
 )
 
+// LaunchMode enumerates the resolved spawn form used by startCommandSpec.
+// The string values are stable and used in logs + fallback diagnostics.
+const (
+	launchModeDirect  = "direct"
+	launchModeScope   = "scope"
+	launchModeService = "service"
+)
+
+// resolveLaunchMode returns one of launchModeDirect / launchModeScope /
+// launchModeService based on LaunchAs (primary) and LaunchInUserScope
+// (legacy fallback for empty LaunchAs). Unknown LaunchAs values fall
+// through to the legacy LaunchInUserScope path — callers populate
+// LaunchAs from TmuxSettings.GetLaunchAs which already canonicalises.
+func (s *Session) resolveLaunchMode() string {
+	switch strings.ToLower(strings.TrimSpace(s.LaunchAs)) {
+	case "service":
+		return launchModeService
+	case "scope":
+		return launchModeScope
+	case "direct":
+		return launchModeDirect
+	case "auto":
+		// Prefer service when systemd-user-manager is available;
+		// otherwise fall through to direct. isSystemdUserScopeAvailable
+		// already probes `systemd-run --user --version` which is
+		// exactly the precondition for the service spawn too.
+		if isSystemdUserScopeAvailable() {
+			return launchModeService
+		}
+		return launchModeDirect
+	case "":
+		if s.LaunchInUserScope {
+			return launchModeScope
+		}
+		return launchModeDirect
+	default:
+		// Unknown value — log once, fall through to legacy. Valid
+		// values are enforced upstream in TmuxSettings.GetLaunchAs, so
+		// reaching this branch means a caller populated LaunchAs from
+		// somewhere other than GetLaunchAs (e.g. a test).
+		statusLog.Warn("tmux_launch_as_invalid",
+			slog.String("value", s.LaunchAs),
+			slog.String("resolved", "legacy"))
+		if s.LaunchInUserScope {
+			return launchModeScope
+		}
+		return launchModeDirect
+	}
+}
+
+// isSystemdUserScopeAvailable probes whether `systemd-run --user` is
+// operational. Defined in internal/session/userconfig.go — we avoid
+// import cycles by taking the probe result via a swappable seam. Tests
+// can override this via the systemdUserRunProbe variable below.
+var systemdUserRunProbe = func() bool {
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		return false
+	}
+	return exec.Command("systemd-run", "--user", "--version").Run() == nil
+}
+
+func isSystemdUserScopeAvailable() bool {
+	return systemdUserRunProbe()
+}
+
 func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 	startWithInitialProcess := command != "" && s.RunCommandAsInitialProcess
-	args := []string{"new-session", "-d", "-s", s.Name, "-c", workDir}
+	tmuxArgs := []string{"new-session", "-d", "-s", s.Name, "-c", workDir}
 	if startWithInitialProcess {
 		// Keep commands under bash for fish/zsh compatibility, but avoid
 		// double-wrapping payloads that are already `bash -c '…'`.
 		// wrapIgnoreSuspend() already returns that shape; re-wrapping it can
 		// corrupt quoting for nested payloads like docker exec bash -c ... .
 		if isBashCWrapped(command) {
-			args = append(args, command)
+			tmuxArgs = append(tmuxArgs, command)
 		} else {
-			args = append(args, bashCWrap(command))
+			tmuxArgs = append(tmuxArgs, bashCWrap(command))
 		}
 	}
 
-	if !s.LaunchInUserScope {
-		return "tmux", args
-	}
+	unitBase := "agentdeck-tmux-" + sanitizeSystemdUnitComponent(s.Name)
 
-	unitName := "agentdeck-tmux-" + sanitizeSystemdUnitComponent(s.Name)
-	scopeArgs := []string{"--user", "--scope", "--quiet", "--collect", "--unit", unitName, "tmux"}
-	scopeArgs = append(scopeArgs, args...)
-	return "systemd-run", scopeArgs
+	switch s.resolveLaunchMode() {
+	case launchModeService:
+		// Type=forking is the ONLY viable type for tmux: tmux new-session
+		// -d daemonizes, so Type=simple would see ExecStart exit 0 and
+		// mark the service inactive immediately, defeating Restart=.
+		// Empirically validated in the v1.7.21 pre-check
+		// (see .planning/v1721-scope-to-service/PLAN.md): Type=forking +
+		// kill -9 tmux → NRestarts=1 within 4s; Type=simple → NRestarts=0.
+		//
+		// We DO NOT use --collect here: --collect unloads the unit once
+		// inactive, which would race with Restart= semantics.
+		svcArgs := []string{
+			"--user", "--unit", unitBase + ".service", "--quiet",
+			"--property=Type=forking",
+			"--property=Restart=on-failure",
+			"--property=RestartSec=5s",
+			"--property=StartLimitBurst=10",
+			"--property=StartLimitIntervalSec=60",
+			"--property=KillMode=control-group",
+			"--property=TimeoutStopSec=15s",
+			"tmux",
+		}
+		svcArgs = append(svcArgs, tmuxArgs...)
+		return "systemd-run", svcArgs
+
+	case launchModeScope:
+		// Legacy PR #467 shape — unchanged so existing users opting out
+		// of service mode with launch_as="scope" get identical semantics.
+		scopeArgs := []string{
+			"--user", "--scope", "--quiet", "--collect", "--unit", unitBase, "tmux",
+		}
+		scopeArgs = append(scopeArgs, tmuxArgs...)
+		return "systemd-run", scopeArgs
+
+	default:
+		return "tmux", tmuxArgs
+	}
 }
 
-// stripSystemdRunPrefix removes the leading systemd-run --user --scope wrap
-// from args produced by startCommandSpec when LaunchInUserScope is true,
-// returning the bare tmux args. Returns args unchanged if the shape doesn't
-// match — defensive against future startCommandSpec changes.
+// buildScopeArgsFromTmuxArgs reconstructs scope-mode systemd-run argv
+// from the bare tmux args. Used by the three-tier fallback in Start()
+// when service-mode spawn fails and we retry with scope mode before
+// falling all the way back to direct tmux.
+func buildScopeArgsFromTmuxArgs(sessionName string, tmuxArgs []string) []string {
+	unitBase := "agentdeck-tmux-" + sanitizeSystemdUnitComponent(sessionName)
+	scopeArgs := []string{"--user", "--scope", "--quiet", "--collect", "--unit", unitBase, "tmux"}
+	return append(scopeArgs, tmuxArgs...)
+}
+
+// wasServiceModeArgs detects whether systemd-run args produced by
+// startCommandSpec are for service mode (contains --unit X.service).
+// Used by the fallback chain to pick human-readable diagnostic labels
+// and decide whether to attempt the scope-mode retry tier.
+func wasServiceModeArgs(args []string) bool {
+	for i, a := range args {
+		if a == "--unit" && i+1 < len(args) && strings.HasSuffix(args[i+1], ".service") {
+			return true
+		}
+	}
+	return false
+}
+
+// wasScopeModeArgs detects whether systemd-run args are for scope mode
+// (contains --scope). Symmetric helper used by the fallback chain.
+func wasScopeModeArgs(args []string) bool {
+	for _, a := range args {
+		if a == "--scope" {
+			return true
+		}
+	}
+	return false
+}
+
+// StopServiceUnit best-effort stops + resets-failed the transient
+// user-level service for the given session name. Called by
+// agent-deck remove on service-mode sessions to guarantee the unit
+// does not Restart=on-failure its way back into existence after
+// removal. Errors are returned but callers typically log-and-continue.
 //
-// Expected shape (matches startCommandSpec above):
+// Returns nil on non-systemd hosts (no-op), on already-stopped units,
+// and on hosts where systemctl is missing — removal must not block on
+// systemd availability.
+//
+// The unit name derivation mirrors startCommandSpec's service branch:
+// "agentdeck-tmux-" + sanitized(sessionName) + ".service".
+func StopServiceUnit(sessionName string) error {
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return nil // no systemctl → nothing to stop
+	}
+	unit := "agentdeck-tmux-" + sanitizeSystemdUnitComponent(sessionName) + ".service"
+	// `stop` returns non-zero if the unit was never started; that's a
+	// no-op for our purposes — swallow and continue to reset-failed.
+	_ = execCommand("systemctl", "--user", "stop", unit).Run()
+	_ = execCommand("systemctl", "--user", "reset-failed", unit).Run()
+	return nil
+}
+
+// stripSystemdRunPrefix removes the leading systemd-run flags from args
+// produced by startCommandSpec (either scope-mode or service-mode form)
+// and returns the bare tmux args. Scans for the first bare "tmux" token
+// which, in both shapes, is the command argument to systemd-run —
+// everything after it is tmux argv.
+//
+// Returns args unchanged if no "tmux" token is found (shape mismatch),
+// preserving the defensive-against-refactors behavior of the original.
+//
+// Scope-mode shape (PR #467):
 //
 //	[0]   "--user"
 //	[1]   "--scope"
@@ -872,9 +1039,24 @@ func (s *Session) startCommandSpec(workDir, command string) (string, []string) {
 //	[5]   "<unit name>"
 //	[6]   "tmux"
 //	[7..] tmux args
+//
+// Service-mode shape (v1.7.21+):
+//
+//	[0]   "--user"
+//	[1]   "--unit"
+//	[2]   "<unit name>.service"
+//	[3]   "--quiet"
+//	[4..10] "--property=..." (variable count)
+//	[11]  "tmux"
+//	[12..] tmux args
+//
+// A "--property=..." value never equals "tmux" as a whole arg (they are
+// single KEY=VALUE tokens), so the scan is unambiguous.
 func stripSystemdRunPrefix(args []string) []string {
-	if len(args) >= 7 && args[6] == "tmux" {
-		return args[7:]
+	for i, a := range args {
+		if a == "tmux" {
+			return args[i+1:]
+		}
 	}
 	return args
 }
@@ -1456,22 +1638,79 @@ func (s *Session) Start(command string) error {
 	if err != nil && launcher == "systemd-run" {
 		// systemd-run detection said yes but invocation failed (e.g. dbus
 		// down, lingering disabled, broken user manager). Log a structured
-		// warning and retry ONCE with the direct tmux launcher so session
-		// creation is never blocked. If the direct retry also fails, wrap
-		// both diagnostics in the returned error so operators can see why
-		// isolation was attempted and how the fallback broke.
+		// warning and retry with softer wrap forms so session creation is
+		// never blocked.
+		//
+		// Three-tier fallback chain (v1.7.21):
+		//  1. Originally requested form (service or scope) — already failed above
+		//  2. If originally service: try scope-mode systemd-run
+		//  3. Direct tmux (no systemd wrap)
+		//
+		// Each failed tier is logged and its error collected. If all three
+		// fail the returned error carries all three diagnostics so operators
+		// can triage via a single log grep.
 		statusLog.Warn("tmux_systemd_run_fallback",
 			slog.String("session", s.Name),
 			slog.String("error", err.Error()),
 			slog.String("output", string(output)))
-		directArgs := stripSystemdRunPrefix(args)
-		retryOutput, retryErr := execCommand("tmux", directArgs...).CombinedOutput()
-		if retryErr == nil {
-			output = retryOutput
-			err = nil
-		} else {
-			return fmt.Errorf("failed to create tmux session: systemd-run path: %w (output: %s); direct retry: %v (output: %s)",
-				err, string(output), retryErr, string(retryOutput))
+
+		initialErr := err
+		initialOutput := output
+		initialLabel := "systemd-run path"
+		if wasServiceModeArgs(args) {
+			initialLabel = "service path"
+		} else if wasScopeModeArgs(args) {
+			initialLabel = "scope path"
+		}
+
+		tmuxArgs := stripSystemdRunPrefix(args)
+
+		// Tier 2: if the first attempt was service-mode, try scope-mode
+		// as an intermediate step BEFORE falling all the way to direct.
+		// This matters when the user manager supports scopes but
+		// services fail (e.g. transient-unit restart-property constraints
+		// on very old systemd).
+		var scopeErr error
+		var scopeOutput []byte
+		triedScope := false
+		if wasServiceModeArgs(args) {
+			scopeRetryArgs := buildScopeArgsFromTmuxArgs(s.Name, tmuxArgs)
+			scopeOutput, scopeErr = execCommand("systemd-run", scopeRetryArgs...).CombinedOutput()
+			triedScope = true
+			if scopeErr == nil {
+				output = scopeOutput
+				err = nil
+			} else {
+				statusLog.Warn("tmux_systemd_run_scope_fallback_failed",
+					slog.String("session", s.Name),
+					slog.String("error", scopeErr.Error()),
+					slog.String("output", string(scopeOutput)))
+			}
+		}
+
+		// Tier 3: direct tmux. Only attempted if we're still in an error
+		// state after tier 2 (or if tier 2 was skipped because the
+		// initial attempt was scope-mode, in which case it's the next
+		// tier down).
+		if err != nil {
+			retryOutput, retryErr := execCommand("tmux", tmuxArgs...).CombinedOutput()
+			if retryErr == nil {
+				output = retryOutput
+				err = nil
+			} else {
+				// All tiers failed — compose a single error that lists
+				// every diagnostic.
+				if triedScope {
+					return fmt.Errorf(
+						"failed to create tmux session: %s: %w (output: %s); scope path: %v (output: %s); direct retry: %v (output: %s)",
+						initialLabel, initialErr, string(initialOutput),
+						scopeErr, string(scopeOutput),
+						retryErr, string(retryOutput))
+				}
+				return fmt.Errorf(
+					"failed to create tmux session: systemd-run path: %w (output: %s); direct retry: %v (output: %s)",
+					initialErr, string(initialOutput), retryErr, string(retryOutput))
+			}
 		}
 	}
 	if err != nil {

--- a/internal/tmux/tmux_launch_as_test.go
+++ b/internal/tmux/tmux_launch_as_test.go
@@ -1,0 +1,211 @@
+// Tests for Session.LaunchAs (v1.7.21 defense-in-depth).
+//
+// LaunchAs is the new config-driven spawn-mode selector that sits ABOVE
+// LaunchInUserScope. Values: "scope" | "service" | "direct" | "auto" | "".
+// Empty preserves legacy LaunchInUserScope behavior so existing users on
+// v1.7.20 get zero behavior change until they opt in.
+//
+// These tests pin the invariants of startCommandSpec(): exact argv shape
+// for each mode, case-insensitivity, whitespace-tolerance, invalid-value
+// fallback, and regression guard on the legacy scope argv shape.
+//
+// See .planning/v1721-scope-to-service/PLAN.md for the full data-flow
+// trace and scope boundaries.
+package tmux
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartCommandSpec_LaunchAs_Service_UsesServiceForm pins the argv
+// shape for service mode. Restart=on-failure and Type=forking are the
+// two properties whose absence would silently defeat the entire feature
+// (Type=simple was the pre-v1.7.21 pre-check failure mode: service marks
+// itself inactive the moment tmux daemonizes, NRestarts stays 0 forever).
+func TestStartCommandSpec_LaunchAs_Service_UsesServiceForm(t *testing.T) {
+	s := &Session{
+		Name:     "agentdeck_test-service_1234abcd",
+		WorkDir:  "/tmp/project",
+		LaunchAs: "service",
+	}
+
+	launcher, args := s.startCommandSpec("/tmp/project", "")
+	require.Equal(t, "systemd-run", launcher, "service mode must spawn via systemd-run")
+
+	joined := strings.Join(args, " ")
+	assert.Contains(t, joined, "--user", "service invocation must be --user scoped")
+	assert.Contains(t, joined, "--unit agentdeck-tmux-agentdeck-test-service-1234abcd.service",
+		"service mode unit name must carry .service suffix so systemd treats it as a service not a scope")
+	assert.Contains(t, joined, "--property=Type=forking",
+		"Type=forking is the ONLY Type= that survives tmux daemonization — Type=simple would mark the service dead immediately")
+	assert.Contains(t, joined, "--property=Restart=on-failure",
+		"Restart=on-failure is the entire point of v1.7.21 — its absence silently breaks the feature")
+	assert.Contains(t, joined, "--property=RestartSec=")
+	assert.Contains(t, joined, "--property=KillMode=control-group",
+		"KillMode=control-group ensures systemctl stop kills tmux cleanly via cgroup")
+
+	assert.NotContains(t, joined, "--scope",
+		"service mode MUST NOT include --scope (would conflict and produce an invalid unit)")
+	assert.NotContains(t, joined, "--collect",
+		"--collect removes the unit when inactive — breaks Restart=on-failure reattach")
+
+	// The tmux args shape after the systemd-run prefix must match the scope
+	// form's tmux args shape exactly. We use stripSystemdRunPrefix to verify.
+	tmuxArgs := stripSystemdRunPrefix(args)
+	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-service_1234abcd", "-c", "/tmp/project"}, tmuxArgs)
+}
+
+// TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm explicitly pins the
+// SCOPE-MODE argv (legacy PR #467 shape) so a refactor to service mode
+// can't silently break users who set LaunchAs="scope" to keep the old
+// behavior. This is the backward-compat lifeline.
+func TestStartCommandSpec_LaunchAs_Scope_UsesScopeForm(t *testing.T) {
+	s := &Session{
+		Name:     "agentdeck_test-scope_1234abcd",
+		WorkDir:  "/tmp/project",
+		LaunchAs: "scope",
+	}
+
+	launcher, args := s.startCommandSpec("/tmp/project", "")
+	require.Equal(t, "systemd-run", launcher)
+	require.GreaterOrEqual(t, len(args), 8)
+	assert.Equal(t, []string{"--user", "--scope", "--quiet", "--collect", "--unit"}, args[:5])
+	assert.Equal(t, "agentdeck-tmux-agentdeck-test-scope-1234abcd", args[5])
+	assert.Equal(t, "tmux", args[6])
+
+	joined := strings.Join(args, " ")
+	assert.NotContains(t, joined, "--property=Type=forking",
+		"scope mode must not contain service-only properties")
+	assert.NotContains(t, joined, "--property=Restart=",
+		"Restart= is invalid on scopes (systemd rejects)")
+}
+
+// TestStartCommandSpec_LaunchAs_Direct_UsesDirectTmux pins that an
+// explicit LaunchAs="direct" forces direct tmux EVEN IF
+// LaunchInUserScope=true. This is the "opt out of isolation" path for
+// users on hosts where systemd-run misbehaves.
+func TestStartCommandSpec_LaunchAs_Direct_UsesDirectTmux(t *testing.T) {
+	s := &Session{
+		Name:              "agentdeck_test-direct_1234abcd",
+		WorkDir:           "/tmp/project",
+		LaunchAs:          "direct",
+		LaunchInUserScope: true, // explicit override must WIN
+	}
+
+	launcher, args := s.startCommandSpec("/tmp/project", "")
+	assert.Equal(t, "tmux", launcher, "LaunchAs=direct must override LaunchInUserScope=true")
+	assert.Equal(t, []string{"new-session", "-d", "-s", "agentdeck_test-direct_1234abcd", "-c", "/tmp/project"}, args)
+}
+
+// TestStartCommandSpec_LaunchAs_Empty_RespectsLegacyLaunchInUserScope
+// is the zero-behavior-change guarantee for v1.7.20 users who don't set
+// launch_as in config.toml. Empty string = defer to the pre-existing
+// LaunchInUserScope flag.
+func TestStartCommandSpec_LaunchAs_Empty_RespectsLegacyLaunchInUserScope(t *testing.T) {
+	t.Run("empty + LaunchInUserScope=true → scope form (legacy PR #467)", func(t *testing.T) {
+		s := &Session{
+			Name:              "agentdeck_test-empty-scope_1234abcd",
+			WorkDir:           "/tmp/project",
+			LaunchInUserScope: true,
+			// LaunchAs intentionally unset
+		}
+		launcher, args := s.startCommandSpec("/tmp/project", "")
+		assert.Equal(t, "systemd-run", launcher)
+		assert.Contains(t, strings.Join(args, " "), "--scope")
+	})
+
+	t.Run("empty + LaunchInUserScope=false → direct", func(t *testing.T) {
+		s := &Session{
+			Name:              "agentdeck_test-empty-direct_1234abcd",
+			WorkDir:           "/tmp/project",
+			LaunchInUserScope: false,
+		}
+		launcher, _ := s.startCommandSpec("/tmp/project", "")
+		assert.Equal(t, "tmux", launcher)
+	})
+}
+
+// TestStartCommandSpec_LaunchAs_Invalid_FallsBackToLegacy asserts an
+// unknown string does NOT panic and does NOT silently pick service — it
+// falls back to the LaunchInUserScope-driven legacy behavior. A typo in
+// config.toml must not put a user on an unintended spawn path.
+func TestStartCommandSpec_LaunchAs_Invalid_FallsBackToLegacy(t *testing.T) {
+	s := &Session{
+		Name:              "agentdeck_test-invalid_1234abcd",
+		WorkDir:           "/tmp/project",
+		LaunchAs:          "typo-gibberish",
+		LaunchInUserScope: true,
+	}
+
+	launcher, args := s.startCommandSpec("/tmp/project", "")
+	assert.Equal(t, "systemd-run", launcher)
+	joined := strings.Join(args, " ")
+	assert.Contains(t, joined, "--scope", "invalid LaunchAs value must not accidentally select service mode")
+	assert.NotContains(t, joined, "--property=Type=forking")
+}
+
+// TestStartCommandSpec_LaunchAs_CaseInsensitive guards against config
+// typos where the user writes "Service" or "SERVICE". These must still
+// resolve to the service mode, not silently fall through to legacy.
+func TestStartCommandSpec_LaunchAs_CaseInsensitive(t *testing.T) {
+	for _, variant := range []string{"service", "Service", "SERVICE", " service ", "service\t"} {
+		t.Run(variant, func(t *testing.T) {
+			s := &Session{
+				Name:     "agentdeck_test-ci_1234abcd",
+				WorkDir:  "/tmp/project",
+				LaunchAs: variant,
+			}
+			launcher, args := s.startCommandSpec("/tmp/project", "")
+			assert.Equal(t, "systemd-run", launcher, "case/whitespace variant %q must still resolve to service", variant)
+			assert.Contains(t, strings.Join(args, " "), "--property=Type=forking")
+		})
+	}
+}
+
+// TestStartCommandSpec_LaunchAs_ServiceWithInitialProcess pins that the
+// RunCommandAsInitialProcess path (sandbox sessions, custom claude
+// commands) composes correctly with service mode. Failure here means
+// sandbox sessions silently lose their auto-restart guarantee.
+func TestStartCommandSpec_LaunchAs_ServiceWithInitialProcess(t *testing.T) {
+	s := &Session{
+		Name:                       "agentdeck_test-svcinit_1234abcd",
+		WorkDir:                    "/tmp/project",
+		LaunchAs:                   "service",
+		RunCommandAsInitialProcess: true,
+	}
+	launcher, args := s.startCommandSpec("/tmp/project", "claude --resume xyz")
+
+	require.Equal(t, "systemd-run", launcher)
+	tmuxArgs := stripSystemdRunPrefix(args)
+	// Last element must be the bash-wrapped command
+	require.NotEmpty(t, tmuxArgs)
+	last := tmuxArgs[len(tmuxArgs)-1]
+	assert.True(t, strings.HasPrefix(last, "bash -c '"), "initial process must be bash-wrapped")
+	assert.Contains(t, last, "claude --resume xyz")
+}
+
+// TestStripSystemdRunPrefix_RecoversTmuxArgsFromServiceForm is the
+// regression guard for stripSystemdRunPrefix when it's fed SERVICE-mode
+// argv (which has ~12 leading elements vs scope's 7). Adding a property
+// to the service spawn must not break fallback-to-direct-tmux.
+func TestStripSystemdRunPrefix_RecoversTmuxArgsFromServiceForm(t *testing.T) {
+	in := []string{
+		"--user", "--unit", "agentdeck-tmux-foo.service", "--quiet",
+		"--property=Type=forking",
+		"--property=Restart=on-failure",
+		"--property=RestartSec=5s",
+		"--property=StartLimitBurst=10",
+		"--property=StartLimitIntervalSec=60",
+		"--property=KillMode=control-group",
+		"--property=TimeoutStopSec=15s",
+		"tmux",
+		"new-session", "-d", "-s", "name",
+	}
+	want := []string{"new-session", "-d", "-s", "name"}
+	got := stripSystemdRunPrefix(in)
+	assert.Equal(t, want, got)
+}

--- a/internal/tmux/tmux_service_fallback_test.go
+++ b/internal/tmux/tmux_service_fallback_test.go
@@ -1,0 +1,170 @@
+// Tests for the three-tier fallback chain on service-mode spawn
+// (v1.7.21). Service systemd-run fails → scope systemd-run attempted
+// → direct tmux attempted. Any tier succeeding short-circuits; all
+// tiers failing wraps ALL THREE diagnostics so operators can triage.
+//
+// Uses the same execCommand swappable-seam + failOnLauncher helpers
+// as tmux_fallback_test.go so failures are injected at the process
+// boundary without touching host PATH or systemd state.
+package tmux
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStart_Service_SuccessPath: service spawn works first time, no
+// scope/direct retries attempted. Negative guard: execCommand counter
+// asserts exactly one systemd-run invocation.
+func TestStart_Service_SuccessPath(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("no tmux binary available: %v", err)
+	}
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		t.Skipf("no systemd-run available: %v", err)
+	}
+
+	original := execCommand
+	var calls []string
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		calls = append(calls, name)
+		return exec.Command(name, arg...)
+	}
+	t.Cleanup(func() { execCommand = original })
+
+	displayName := "test-svcok-" + randomServerSuffix(t)
+	s := NewSession(displayName, "/tmp")
+	s.LaunchAs = "service"
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "kill-session", "-t", s.Name).Run()
+		// Also best-effort stop the service unit in case
+		unitName := "agentdeck-tmux-" + sanitizeSystemdUnitComponent(s.Name) + ".service"
+		_ = exec.Command("systemctl", "--user", "stop", unitName).Run()
+		_ = exec.Command("systemctl", "--user", "reset-failed", unitName).Run()
+	})
+
+	if err := s.Start(""); err != nil {
+		t.Fatalf("service-mode spawn failed unexpectedly: %v", err)
+	}
+
+	// Successful service spawn must invoke systemd-run exactly once on success
+	// (tmux binary probes from inside tmux itself don't go through execCommand).
+	var systemdRunCalls int
+	for _, c := range calls {
+		if c == "systemd-run" {
+			systemdRunCalls++
+		}
+	}
+	assert.Equal(t, 1, systemdRunCalls, "service success path must NOT retry; got %d systemd-run invocations", systemdRunCalls)
+}
+
+// TestStart_Service_WhenServiceFails_FallbackToScope: first systemd-run
+// (service) returns non-zero; fallback tries systemd-run (scope);
+// fallback succeeds; session ready.
+//
+// Simulation: inject a mock that returns exit-1 ONLY when the argv
+// contains "--unit *.service" (i.e. service form), pass-through for the
+// scope form and direct tmux.
+func TestStart_Service_WhenServiceFails_FallbackToScope(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("no tmux binary available: %v", err)
+	}
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		t.Skipf("no systemd-run available: %v", err)
+	}
+
+	original := execCommand
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		if name == "systemd-run" && containsServiceUnitFlag(arg) {
+			return exec.Command("false")
+		}
+		return exec.Command(name, arg...)
+	}
+	t.Cleanup(func() { execCommand = original })
+
+	buf := captureStatusLog(t)
+
+	displayName := "test-svcfallscope-" + randomServerSuffix(t)
+	s := NewSession(displayName, "/tmp")
+	s.LaunchAs = "service"
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", s.Name).Run() })
+
+	if err := s.Start(""); err != nil {
+		t.Fatalf("expected fallback from service → scope to recover, got error: %v\nlog: %s", err, buf.String())
+	}
+
+	logs := buf.String()
+	assert.Contains(t, logs, "tmux_systemd_run_fallback",
+		"service→scope fallback must emit a structured log for observability")
+}
+
+// TestStart_Service_WhenAllSystemdFail_FallbackToDirect: service AND
+// scope both fail; direct tmux succeeds; session ready.
+func TestStart_Service_WhenAllSystemdFail_FallbackToDirect(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("no tmux binary available: %v", err)
+	}
+
+	original := execCommand
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		if name == "systemd-run" {
+			return exec.Command("false") // fail on BOTH service AND scope
+		}
+		return exec.Command(name, arg...)
+	}
+	t.Cleanup(func() { execCommand = original })
+
+	displayName := "test-svcfallall-" + randomServerSuffix(t)
+	s := NewSession(displayName, "/tmp")
+	s.LaunchAs = "service"
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", s.Name).Run() })
+
+	if err := s.Start(""); err != nil {
+		t.Fatalf("expected fallback service→scope→direct to recover, got: %v", err)
+	}
+}
+
+// TestStart_Service_AllThreePathsFail_ErrorIncludesAllThree: when
+// every tier fails, the returned error must contain all three
+// diagnostics so operators can triage in one log grep.
+func TestStart_Service_AllThreePathsFail_ErrorIncludesAllThree(t *testing.T) {
+	original := execCommand
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		if name == "systemd-run" || name == "tmux" {
+			return exec.Command("false")
+		}
+		return exec.Command(name, arg...)
+	}
+	t.Cleanup(func() { execCommand = original })
+
+	displayName := "test-svcallfail-" + randomServerSuffix(t)
+	s := NewSession(displayName, "/tmp")
+	s.LaunchAs = "service"
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", s.Name).Run() })
+
+	err := s.Start("")
+	require.Error(t, err, "all three paths fail — Start must surface an error")
+	msg := err.Error()
+	assert.Contains(t, msg, "service path:",
+		"operators must see the service-tier failure to diagnose dbus/manager issues")
+	assert.Contains(t, msg, "scope path:",
+		"operators must see the scope-tier failure to diagnose permission/linger issues")
+	assert.Contains(t, msg, "direct retry:",
+		"operators must see the direct-tmux failure to diagnose host-tmux issues")
+}
+
+// containsServiceUnitFlag scans argv for a "--unit X.service" pair. Used
+// by the mock above to distinguish service-form systemd-run from
+// scope-form at inject time.
+func containsServiceUnitFlag(args []string) bool {
+	for i, a := range args {
+		if a == "--unit" && i+1 < len(args) && strings.HasSuffix(args[i+1], ".service") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tmux/tmux_service_integration_test.go
+++ b/internal/tmux/tmux_service_integration_test.go
@@ -1,0 +1,238 @@
+// Integration tests for the service-mode systemd invocation shape
+// produced by startCommandSpec (v1.7.21). These tests validate the REAL
+// systemd mechanism: spawn tmux as a transient service with the exact
+// properties startCommandSpec emits, then exercise Restart=on-failure
+// (kill -9) and clean-stop semantics.
+//
+// These tests deliberately do NOT go through Session.Start to avoid the
+// default-tmux-socket sharing issue: production sessions share one
+// daemon on the user's default socket and let the FIRST scope/service
+// wrap anchor the daemon's cgroup; in tests we can't rely on there
+// being no pre-existing server, so we use `-L <uniqueName>` to create
+// a fresh isolated server per test. The unit tests in
+// tmux_launch_as_test.go pin the argv shape separately — these tests
+// ensure that argv shape actually delivers the advertised semantics on
+// a real systemd host.
+//
+// These tests require systemd-user + systemctl and skip on any other
+// platform (macOS, non-systemd Linux).
+//
+// Safety: every transient unit name gets a random 8-char suffix; every
+// tmux server gets a unique -L name. Cleanup runs `systemctl --user
+// stop` + `reset-failed` + `tmux -L NAME kill-server`, so a failed
+// test cannot leak units or daemons.
+package tmux
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func requireSystemdUserRun(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		t.Skipf("systemd-run not available: %v", err)
+	}
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		t.Skipf("systemctl not available: %v", err)
+	}
+	if err := exec.Command("systemd-run", "--user", "--version").Run(); err != nil {
+		t.Skipf("systemd-run --user not operational: %v", err)
+	}
+	if err := exec.Command("systemctl", "--user", "is-active", "default.target").Run(); err != nil {
+		// User manager not active — common on CI. Skip.
+		t.Skipf("systemd --user manager not active: %v", err)
+	}
+}
+
+// spawnServiceModeTmux executes the exact systemd-run invocation shape
+// produced by startCommandSpec's service branch, but inserts -L so the
+// spawned tmux creates a fresh isolated server instead of attaching to
+// any pre-existing default-socket daemon. Returns the unit name so
+// tests can poll systemctl show / issue systemctl stop on it.
+func spawnServiceModeTmux(t *testing.T, tmuxLName, tmuxSessName string) (unit string, err error) {
+	t.Helper()
+	unit = "agentdeck-tmux-v1721svcit-" + randomServerSuffix(t) + ".service"
+	args := []string{
+		"--user", "--unit", unit, "--quiet",
+		"--property=Type=forking",
+		"--property=Restart=on-failure",
+		"--property=RestartSec=2s", // shorter than production 5s for test speed
+		"--property=StartLimitBurst=10",
+		"--property=StartLimitIntervalSec=60",
+		"--property=KillMode=control-group",
+		"--property=TimeoutStopSec=15s",
+		// -L creates a test-isolated tmux socket so no default-socket server
+		// is contacted; this is the single necessary deviation from
+		// startCommandSpec's production argv for tests to be reliable.
+		"tmux", "-L", tmuxLName,
+		"new-session", "-d", "-s", tmuxSessName, "-c", "/tmp",
+		"bash", "-c", "exec sleep 600",
+	}
+	out, err := exec.Command("systemd-run", args...).CombinedOutput()
+	if err != nil {
+		return unit, fmt.Errorf("systemd-run: %w (output: %s)", err, string(out))
+	}
+	return unit, nil
+}
+
+// TestTmuxService_RestartsOnUnexpectedKill: with the argv shape
+// startCommandSpec emits, a SIGKILL on the tmux daemon must trigger
+// systemd's Restart=on-failure within ~10s. This is the headline
+// v1.7.21 guarantee — if this test fails, the service-mode argv has a
+// property bug.
+func TestTmuxService_RestartsOnUnexpectedKill(t *testing.T) {
+	requireSystemdUserRun(t)
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("tmux not available: %v", err)
+	}
+
+	tmuxLName := "v1721-svcit-" + randomServerSuffix(t)
+	tmuxSessName := "svcrestart"
+	unit, err := spawnServiceModeTmux(t, tmuxLName, tmuxSessName)
+	require.NoError(t, err, "service spawn must succeed on a systemd-user host")
+
+	t.Cleanup(func() {
+		_ = exec.Command("systemctl", "--user", "stop", unit).Run()
+		_ = exec.Command("systemctl", "--user", "reset-failed", unit).Run()
+		_ = exec.Command("tmux", "-L", tmuxLName, "kill-server").Run()
+	})
+
+	initialPID := waitForServicePID(t, unit, 5*time.Second)
+	require.NotZero(t, initialPID, "tmux daemon PID must be visible via systemctl show within 5s (unit=%s)", unit)
+
+	// SIGKILL — simulates OOM, kernel signal, or bug-induced crash.
+	require.NoError(t, syscall.Kill(initialPID, syscall.SIGKILL),
+		"kill -9 must succeed to meaningfully exercise Restart=on-failure")
+
+	// Poll for restart. RestartSec=2s + Type=forking fork detection ~ a few
+	// hundred ms → the new PID should appear within ~8s on a sane host.
+	deadline := time.Now().Add(15 * time.Second)
+	var newPID int
+	var restarts int
+	for time.Now().Before(deadline) {
+		time.Sleep(500 * time.Millisecond)
+		newPID = readServicePID(unit)
+		restarts = readServiceNRestarts(unit)
+		if newPID != 0 && newPID != initialPID && restarts >= 1 {
+			break
+		}
+	}
+
+	require.NotZero(t, newPID,
+		"expected a new tmux daemon PID after kill -9 + 15s wait, got 0 — Restart=on-failure did not fire")
+	require.NotEqual(t, initialPID, newPID,
+		"expected new tmux PID to differ from killed one; Restart did not actually respawn")
+	require.GreaterOrEqual(t, restarts, 1,
+		"NRestarts must be >=1 after SIGKILL; got %d", restarts)
+}
+
+// TestTmuxService_ExplicitStopDoesNotTriggerRestart: `systemctl --user
+// stop` on the service unit must be CLEAN — Restart=on-failure must NOT
+// fire. This is what guarantees `agent-deck remove` is truly terminal
+// and that a stopped service stays stopped.
+func TestTmuxService_ExplicitStopDoesNotTriggerRestart(t *testing.T) {
+	requireSystemdUserRun(t)
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("tmux not available: %v", err)
+	}
+
+	tmuxLName := "v1721-svcitstop-" + randomServerSuffix(t)
+	tmuxSessName := "svcstop"
+	unit, err := spawnServiceModeTmux(t, tmuxLName, tmuxSessName)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = exec.Command("systemctl", "--user", "stop", unit).Run()
+		_ = exec.Command("systemctl", "--user", "reset-failed", unit).Run()
+		_ = exec.Command("tmux", "-L", tmuxLName, "kill-server").Run()
+	})
+
+	pid := waitForServicePID(t, unit, 5*time.Second)
+	require.NotZero(t, pid)
+
+	require.NoError(t, exec.Command("systemctl", "--user", "stop", unit).Run(),
+		"systemctl --user stop must succeed on an active unit")
+	_ = exec.Command("systemctl", "--user", "reset-failed", unit).Run()
+
+	// Give systemd a beat to finalize; then assert no new PID re-appears
+	// within a 4s window. Restart=on-failure must NOT fire on clean stop.
+	time.Sleep(4 * time.Second)
+	after := readServicePID(unit)
+	require.Zero(t, after,
+		"expected tmux daemon to stay dead after systemctl stop; got PID %d", after)
+}
+
+// TestStopServiceUnit_HandlesMissingSystemd: on hosts without systemctl
+// the helper must return nil (no-op) so `agent-deck remove` on a
+// non-systemd host doesn't spew errors.
+func TestStopServiceUnit_HandlesMissingSystemd(t *testing.T) {
+	// We can't easily remove systemctl from PATH in a test without
+	// mutating global state. Instead, call StopServiceUnit with a
+	// name that will never match an existing unit and verify it
+	// returns nil (best-effort semantics).
+	err := StopServiceUnit("does-not-exist-" + randomServerSuffix(t))
+	require.NoError(t, err, "StopServiceUnit must never return an error — it's best-effort cleanup")
+}
+
+// waitForServicePID polls systemctl show until MainPID becomes non-zero
+// or the timeout elapses. Returns 0 on timeout.
+func waitForServicePID(t *testing.T, unitName string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pid := readServicePID(unitName); pid != 0 {
+			return pid
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return 0
+}
+
+// readServicePID extracts MainPID from `systemctl --user show`. Returns
+// 0 on any error or if the PID is not alive (stale).
+func readServicePID(unitName string) int {
+	out, err := exec.Command("systemctl", "--user", "show", unitName, "-p", "MainPID").Output()
+	if err != nil {
+		return 0
+	}
+	line := strings.TrimSpace(string(out))
+	const prefix = "MainPID="
+	if !strings.HasPrefix(line, prefix) {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(line, prefix))
+	if err != nil || n == 0 {
+		return 0
+	}
+	// Signal 0 is the kernel permission+existence check with no delivery.
+	if err := syscall.Kill(n, 0); err != nil {
+		return 0
+	}
+	return n
+}
+
+// readServiceNRestarts extracts NRestarts from `systemctl --user show`.
+func readServiceNRestarts(unitName string) int {
+	out, err := exec.Command("systemctl", "--user", "show", unitName, "-p", "NRestarts").Output()
+	if err != nil {
+		return 0
+	}
+	line := strings.TrimSpace(string(out))
+	const prefix = "NRestarts="
+	if !strings.HasPrefix(line, prefix) {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimPrefix(line, prefix))
+	if err != nil {
+		return 0
+	}
+	return n
+}


### PR DESCRIPTION
Closes #656.

## Summary

Opt-in `launch_as = "service"` config that wraps new tmux servers in a transient systemd-user service with `Type=forking` + `Restart=on-failure`, so the tmux daemon auto-restarts on unexpected death (OOM, SIGKILL, kernel signal, crash). Defense-in-depth, **not** a cascade fix — see #656 for the honest framing and the empirical investigation that disproved the phantom cascade mechanism.

## What changed

- `[tmux].launch_as` config option (values: `scope` | `service` | `direct` | `auto` | unset). Default unset = defer to legacy `launch_in_user_scope` = **zero behavior change** for v1.7.20 users.
- Three-tier fallback when service is requested: service systemd-run → scope systemd-run → direct tmux (all three diagnostics wrapped in the error if every tier fails).
- `tmux.StopServiceUnit` helper + `Instance.StopServiceUnit`; called from `handleRemove` so the service unit can't auto-restart itself after `agent-deck remove`.
- `stripSystemdRunPrefix` generalised to scan for the `tmux` token so it works for BOTH argv shapes (scope and service).

## Why `Type=forking` is the only viable Type

Empirically validated before any production code was written:

| Type | `kill -9` tmux | NRestarts | Result |
|---|---|---|---|
| `simple` | yes | 0 | service dead; tmux daemonizes → ExecStart exits 0 immediately → Restart= never fires |
| `forking` | yes | 1 | service alive; new tmux PID in ~3s ✅ |

## Test plan

- [x] 7 unit tests in `internal/tmux/tmux_launch_as_test.go` pin the argv shape for each mode
- [x] 4 fallback tests in `internal/tmux/tmux_service_fallback_test.go` exercise success + every fallback tier
- [x] 3 integration tests in `internal/tmux/tmux_service_integration_test.go` empirically validate Restart on kill -9 and clean-stop (gated by `requireSystemdUserRun`; skips on macOS / non-systemd CI)
- [x] 5 unit tests in `internal/session/userconfig_launch_as_test.go` pin toml decode + GetLaunchAs normalisation
- [x] **5× live-boundary**: `TestTmuxService_RestartsOnUnexpectedKill` 5/5 pass (2.47–2.93s per run); `TestTmuxService_ExplicitStopDoesNotTriggerRestart` 5/5 pass (4.11–4.37s per run)
- [x] `go test -run TestPersistence_ ./internal/session/... -race -count=1` → all 8 pass
- [x] `go test ./internal/feedback/... ./internal/ui/... ./cmd/agent-deck/... -run "Feedback|Sender_" -race -count=1` → all 23 pass
- [x] `go test ./internal/watcher/... -race -count=1 -timeout 120s` → pass
- [x] **Full suite** `go test ./... -race -timeout 600s` → all packages ok, **zero regressions**
- [x] `stat -c '%y' /tmp/tmux-1000/default` unchanged before/after full suite (test isolation intact per repo 2026-04-17 incident mandate)
- [x] 9 entries appended to `.claude/release-tests.yaml`, each run-command verified
- [x] pre-commit (fmt + vet) and pre-push (full suite, lint, release-tests-yaml-lint, build) hooks passed

## Out of scope (tracked for follow-up)

- Control-client (`tmux -C attach-session`) supervision — pipe client's systemd placement is a separate architectural question. v1.7.8 reviver already recovers pipe-death; structural fix deserves its own design cycle.
- Flipping default to `auto` — reserved for a later patch after soak time.

## Rollback

Users flip `launch_as = "scope"` (or unset) in `config.toml` + restart agent-deck — back to PR #467 semantics. No schema / storage changes to unwind.