### PR TITLE
fix(#658): telegram conductor poller stability (v1.7.22)

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -927,3 +927,69 @@ tests:
   run:
     command: go test ./internal/session/ -run TestTmuxSettings_GetLaunchAs_UnknownValueReturnsEmpty -count=1 -v
     expected: pass
+- id: v1722-telegram-global-disabled-no-warning
+  added: '2026-04-18'
+  task: v1722-telegram-poller-stability
+  file: internal/session/telegram_validator_test.go
+  test_name: TestTelegramValidator_GlobalDisabled_NoWarning
+  purpose: 'Silent path — when the profile is configured correctly the validator emits zero warnings, keeping logs clean. Locks the no-noise baseline so future guards do not accidentally warn on the supported topology.'
+  source: .planning/fix-v1722-telegram-poller-stability/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestTelegramValidator_GlobalDisabled_NoWarning -count=1 -v
+    expected: pass
+- id: v1722-telegram-global-enabled-warn-antipattern
+  added: '2026-04-18'
+  task: v1722-telegram-poller-stability
+  file: internal/session/telegram_validator_test.go
+  test_name: TestTelegramValidator_GlobalEnabled_OrdinarySession_WarnAntiPattern
+  purpose: 'Root-cause A — detect the profile-wide enablement of telegram@claude-plugins-official in settings.json, the anti-pattern that leaks a bun poller to every claude subprocess.'
+  source: .planning/fix-v1722-telegram-poller-stability/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestTelegramValidator_GlobalEnabled_OrdinarySession_WarnAntiPattern -count=1 -v
+    expected: pass
+- id: v1722-telegram-double-load
+  added: '2026-04-18'
+  task: v1722-telegram-poller-stability
+  file: internal/session/telegram_validator_test.go
+  test_name: TestTelegramValidator_GlobalEnabled_ConductorSession_WarnDoubleLoad
+  purpose: 'Root-cause B — detect the combined global+channels configuration that makes the plugin load twice in one claude process, producing Telegram 409 Conflict.'
+  source: .planning/fix-v1722-telegram-poller-stability/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestTelegramValidator_GlobalEnabled_ConductorSession_WarnDoubleLoad -count=1 -v
+    expected: pass
+- id: v1722-telegram-wrapper-deprecated
+  added: '2026-04-18'
+  task: v1722-telegram-poller-stability
+  file: internal/session/telegram_validator_test.go
+  test_name: TestTelegramValidator_WrapperStateDir_AntiPattern
+  purpose: 'Root-cause C — detect the wrapper-injected TELEGRAM_STATE_DIR anti-pattern and recommend the canonical env_file mechanism. Wrapper fails silently on the fresh-start path due to bash -c argv splitting.'
+  source: .planning/fix-v1722-telegram-poller-stability/PLAN.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestTelegramValidator_WrapperStateDir_AntiPattern -count=1 -v
+    expected: pass
+- id: v1722-telegram-settings-reader
+  added: '2026-04-18'
+  task: v1722-telegram-poller-stability
+  file: cmd/agent-deck/conductor_cmd_telegram_test.go
+  test_name: TestReadTelegramGloballyEnabled_TrueWhenSettingsHasIt
+  purpose: 'CLI helper parses Claude Code settings.json defensively — missing file and missing key both map to false (safe baseline), explicit true surfaces the anti-pattern.'
+  source: .planning/fix-v1722-telegram-poller-stability/PLAN.md
+  manual: false
+  run:
+    command: go test ./cmd/agent-deck/ -run TestReadTelegramGloballyEnabled_ -count=1 -v
+    expected: pass
+- id: v1722-telegram-warn-formatting
+  added: '2026-04-18'
+  task: v1722-telegram-poller-stability
+  file: cmd/agent-deck/conductor_cmd_telegram_test.go
+  test_name: TestConductorSetup_WarnsOnGlobalTelegramEnabled
+  purpose: 'End-to-end CLI surface — the human-facing warning text includes the ⚠ prefix, the GLOBAL_ANTIPATTERN code or label, and the exact settings.json key so users can find and fix the setting.'
+  source: .planning/fix-v1722-telegram-poller-stability/PLAN.md
+  manual: false
+  run:
+    command: go test ./cmd/agent-deck/ -run "TestConductorSetup_WarnsOnGlobalTelegramEnabled|TestConductorSetup_RecommendsEnvFileOverWrapper|TestEmitTelegramWarnings_CleanConfig_Silent" -count=1 -v
+    expected: pass

--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ Both Telegram and Slack can run simultaneously — the bridge daemon handles bot
 
 **Heartbeat-driven monitoring**: heartbeats still run on the configured interval (default 15 minutes) as a secondary safety net. If a conductor response includes `NEED:`, the bridge forwards that alert to Telegram and/or Slack.
 
+**Telegram conductor topology (v1.7.22+)**: each conductor bot must own exactly one channel-owning session. Activate telegram per-session via `--channels plugin:telegram@claude-plugins-official` and inject `TELEGRAM_STATE_DIR` via `[conductors.<name>.claude].env_file` in `~/.agent-deck/config.toml`. Do NOT set `enabledPlugins."telegram@claude-plugins-official"=true` in a profile's `settings.json` — that leaks a poller to every claude session under the profile. agent-deck emits warnings (`GLOBAL_ANTIPATTERN`, `DOUBLE_LOAD`, `WRAPPER_DEPRECATED`) when it detects these setups. Full guidance: [Telegram conductor topology](skills/agent-deck/SKILL.md#telegram-conductor-topology-v1722).
+
 **Permission prompts during automation**: if a conductor keeps pausing on permission requests, set `[claude].allow_dangerous_mode = true` (or `dangerous_mode = true`) in `~/.agent-deck/config.toml`, then run `agent-deck session restart conductor-<name>`. See [Troubleshooting](skills/agent-deck/references/troubleshooting.md#conductor-keeps-asking-for-permissions).
 
 **Legacy external watcher scripts**: optional only. `~/.agent-deck/events/` is not required for notification routing.

--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -242,19 +242,14 @@ func handleConductorSetup(profile string, args []string) {
 	// v1.7.22: warn on the "global telegram enabled in profile settings.json"
 	// anti-pattern that silently leaks pollers to every claude session under
 	// this profile. We detect but do not auto-mutate settings.json (#658).
-	{
-		cfgDir := ""
-		if config != nil {
-			cfgDir = config.GetProfileClaudeConfigDir(resolvedProfile)
-		}
-		if cfgDir == "" {
-			cfgDir = session.GetClaudeConfigDirForGroup("")
-		}
-		if globalTelegramEnabled, _ := readTelegramGloballyEnabled(cfgDir); globalTelegramEnabled {
-			emitTelegramWarnings(os.Stderr, session.TelegramValidatorInput{
-				GlobalEnabled: true,
-			})
-		}
+	cfgDir := config.GetProfileClaudeConfigDir(resolvedProfile)
+	if cfgDir == "" {
+		cfgDir = session.GetClaudeConfigDirForGroup("")
+	}
+	if globalTelegramEnabled, _ := readTelegramGloballyEnabled(cfgDir); globalTelegramEnabled {
+		emitTelegramWarnings(os.Stderr, session.TelegramValidatorInput{
+			GlobalEnabled: true,
+		})
 	}
 
 	// Step 2: If conductor system not enabled, run first-time setup

--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -239,6 +239,24 @@ func handleConductorSetup(profile string, args []string) {
 	slackConfigured := settings.Slack.BotToken != ""
 	discordConfigured := settings.Discord.BotToken != ""
 
+	// v1.7.22: warn on the "global telegram enabled in profile settings.json"
+	// anti-pattern that silently leaks pollers to every claude session under
+	// this profile. We detect but do not auto-mutate settings.json (#658).
+	{
+		cfgDir := ""
+		if config != nil {
+			cfgDir = config.GetProfileClaudeConfigDir(resolvedProfile)
+		}
+		if cfgDir == "" {
+			cfgDir = session.GetClaudeConfigDirForGroup("")
+		}
+		if globalTelegramEnabled, _ := readTelegramGloballyEnabled(cfgDir); globalTelegramEnabled {
+			emitTelegramWarnings(os.Stderr, session.TelegramValidatorInput{
+				GlobalEnabled: true,
+			})
+		}
+	}
+
 	// Step 2: If conductor system not enabled, run first-time setup
 	if !settings.Enabled {
 		fmt.Println("Conductor Setup")

--- a/cmd/agent-deck/conductor_cmd_telegram.go
+++ b/cmd/agent-deck/conductor_cmd_telegram.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"io"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Conductor telegram-topology CLI glue (fix v1.7.22, issue #658).
+//
+// readTelegramGloballyEnabled inspects a Claude Code profile's settings.json
+// and reports whether "telegram@claude-plugins-official" is enabled as a
+// profile-wide plugin (the root-cause-A anti-pattern). Missing file and
+// missing key both map to false.
+//
+// emitTelegramWarnings runs the validator and writes human-facing warnings
+// to w. Silent on a clean configuration.
+//
+// Stubs during RED phase (Phase 3 TDD) — real logic lands in Phase 5.
+
+func readTelegramGloballyEnabled(configDir string) (bool, error) {
+	return false, nil
+}
+
+func emitTelegramWarnings(w io.Writer, in session.TelegramValidatorInput) {
+	// stub: no output until Phase 5
+	_ = w
+	_ = in
+}

--- a/cmd/agent-deck/conductor_cmd_telegram.go
+++ b/cmd/agent-deck/conductor_cmd_telegram.go
@@ -1,29 +1,48 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 // Conductor telegram-topology CLI glue (fix v1.7.22, issue #658).
-//
-// readTelegramGloballyEnabled inspects a Claude Code profile's settings.json
-// and reports whether "telegram@claude-plugins-official" is enabled as a
-// profile-wide plugin (the root-cause-A anti-pattern). Missing file and
-// missing key both map to false.
-//
-// emitTelegramWarnings runs the validator and writes human-facing warnings
-// to w. Silent on a clean configuration.
-//
-// Stubs during RED phase (Phase 3 TDD) — real logic lands in Phase 5.
 
+// telegramPluginKey is the settings.json key Claude Code uses for this
+// plugin. Matches skills/agent-deck/SKILL.md "Telegram conductor topology".
+const telegramPluginKey = "telegram@claude-plugins-official"
+
+// readTelegramGloballyEnabled inspects settings.json in the given Claude
+// Code profile directory (e.g. ~/.claude or ~/.claude-work) and reports
+// whether the telegram plugin is globally enabled. Missing file and missing
+// key both map to (false, nil) — absence is the safe baseline.
 func readTelegramGloballyEnabled(configDir string) (bool, error) {
-	return false, nil
+	path := filepath.Join(configDir, "settings.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	var parsed struct {
+		EnabledPlugins map[string]bool `json:"enabledPlugins"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return parsed.EnabledPlugins[telegramPluginKey], nil
 }
 
+// emitTelegramWarnings runs the validator and writes human-facing warnings
+// to w. Silent on a clean configuration.
 func emitTelegramWarnings(w io.Writer, in session.TelegramValidatorInput) {
-	// stub: no output until Phase 5
-	_ = w
-	_ = in
+	warnings := session.ValidateTelegramTopology(in)
+	for _, warn := range warnings {
+		fmt.Fprintf(w, "⚠  %s: %s\n", warn.Code, warn.Message)
+	}
 }

--- a/cmd/agent-deck/conductor_cmd_telegram_test.go
+++ b/cmd/agent-deck/conductor_cmd_telegram_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// CLI-level telegram topology tests (fix v1.7.22, Closes #658).
+//
+// These exercise the CLI glue: reading enabledPlugins from Claude Code's
+// settings.json, feeding the validator, and formatting warnings on stderr.
+
+func TestReadTelegramGloballyEnabled_TrueWhenSettingsHasIt(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+      "enabledPlugins": {
+        "telegram@claude-plugins-official": true,
+        "watcher@claude-plugins-official": true
+      }
+    }`
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(settings), 0644); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+	got, err := readTelegramGloballyEnabled(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got {
+		t.Fatalf("expected true, got false")
+	}
+}
+
+func TestReadTelegramGloballyEnabled_FalseWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	// no settings.json at all — must not error.
+	got, err := readTelegramGloballyEnabled(dir)
+	if err != nil {
+		t.Fatalf("missing settings.json must not error, got: %v", err)
+	}
+	if got {
+		t.Fatalf("missing settings.json must be treated as disabled")
+	}
+}
+
+func TestReadTelegramGloballyEnabled_FalseWhenExplicitlyDisabled(t *testing.T) {
+	dir := t.TempDir()
+	settings := `{
+      "enabledPlugins": {
+        "telegram@claude-plugins-official": false
+      }
+    }`
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(settings), 0644); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+	got, err := readTelegramGloballyEnabled(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Fatalf("expected false when explicitly disabled")
+	}
+}
+
+func TestConductorSetup_WarnsOnGlobalTelegramEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	in := session.TelegramValidatorInput{
+		GlobalEnabled:   true,
+		SessionChannels: nil,
+		SessionWrapper:  "",
+	}
+	emitTelegramWarnings(&buf, in)
+
+	out := buf.String()
+	if !strings.Contains(out, "⚠") {
+		t.Errorf("warning output should be prefixed with ⚠, got: %s", out)
+	}
+	if !strings.Contains(out, "GLOBAL_ANTIPATTERN") && !strings.Contains(strings.ToLower(out), "anti-pattern") {
+		t.Errorf("output should surface the GLOBAL_ANTIPATTERN code or anti-pattern label, got: %s", out)
+	}
+	if !strings.Contains(out, "enabledPlugins") {
+		t.Errorf("output should reference enabledPlugins so users can find the setting, got: %s", out)
+	}
+}
+
+func TestConductorSetup_RecommendsEnvFileOverWrapper(t *testing.T) {
+	var buf bytes.Buffer
+	in := session.TelegramValidatorInput{
+		GlobalEnabled: false,
+		SessionChannels: []string{
+			"plugin:telegram@claude-plugins-official",
+		},
+		SessionWrapper: "TELEGRAM_STATE_DIR=/home/me/.claude/channels/telegram {command}",
+	}
+	emitTelegramWarnings(&buf, in)
+
+	out := buf.String()
+	if !strings.Contains(out, "env_file") {
+		t.Errorf("recommendation must reference env_file, got: %s", out)
+	}
+	if !strings.Contains(out, "WRAPPER_DEPRECATED") && !strings.Contains(strings.ToLower(out), "wrapper") {
+		t.Errorf("output should surface wrapper-deprecated concern, got: %s", out)
+	}
+}
+
+// Silent path: nothing to warn about → emitter writes nothing (clean logs).
+func TestEmitTelegramWarnings_CleanConfig_Silent(t *testing.T) {
+	var buf bytes.Buffer
+	in := session.TelegramValidatorInput{
+		GlobalEnabled:   false,
+		SessionChannels: []string{"plugin:telegram@claude-plugins-official"},
+		SessionWrapper:  "",
+	}
+	emitTelegramWarnings(&buf, in)
+	if buf.Len() != 0 {
+		t.Errorf("clean config must produce no output, got: %q", buf.String())
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1035,6 +1035,19 @@ func handleSessionSet(profile string, args []string) {
 		"old_value": oldValue,
 		"new_value": value,
 	})
+
+	// v1.7.22: emit telegram topology warnings whenever the signals the
+	// validator cares about change (wrapper or channels). The silent-path
+	// case writes nothing — see ValidateTelegramTopology (#658).
+	if field == "wrapper" || field == "channels" {
+		cfgDir := session.GetClaudeConfigDirForGroup(inst.GroupPath)
+		globalTelegramEnabled, _ := readTelegramGloballyEnabled(cfgDir)
+		emitTelegramWarnings(os.Stderr, session.TelegramValidatorInput{
+			GlobalEnabled:   globalTelegramEnabled,
+			SessionChannels: inst.Channels,
+			SessionWrapper:  inst.Wrapper,
+		})
+	}
 }
 
 // loadSessionData loads storage and session data for a profile

--- a/conductor/conductor-claude.md
+++ b/conductor/conductor-claude.md
@@ -208,3 +208,20 @@ When you first start (or after a restart):
 - The bridge sends with `session send --wait -q` and waits in a single CLI call. Reply promptly.
 - Your own session can be restarted by the bridge if it detects you're in an error state.
 - Keep state.json small (no large output dumps). Store summaries, not full text.
+
+## Telegram Topology (v1.7.22+)
+
+Each conductor that owns a Telegram bot must follow this topology, or pollers leak and the bot stops responding with 409 Conflict after a few hours:
+
+- **Activate per-session only**: set `channels = ["plugin:telegram@claude-plugins-official"]` on this conductor's agent-deck record (via `agent-deck session set <conductor> channels ...`).
+- **Inject `TELEGRAM_STATE_DIR` via `env_file`**: in `~/.agent-deck/config.toml`, set `[conductors.{PROFILE}.claude].env_file = "~/.agent-deck/conductor/{PROFILE}/.envrc"` (and a matching `[groups.{PROFILE}.claude]` block). The `.envrc` file contains a single line: `export TELEGRAM_STATE_DIR=<profile-state-dir>`. Never use a session wrapper (`agent-deck session set <conductor> wrapper "TELEGRAM_STATE_DIR=... {command}"`) — it works on resume but silently fails on fresh-start.
+- **Keep global telegram disabled**: `enabledPlugins."telegram@claude-plugins-official"` must be absent or `false` in this profile's `settings.json`. If it is `true`, every claude child session loads the plugin, and the conductor loads it twice.
+- **Preflight checklist before expecting messages to flow**:
+  1. `channels` persisted on this session (check with `agent-deck -p {PROFILE} list --json | jq ...`).
+  2. `env_file` present and readable, containing `export TELEGRAM_STATE_DIR=...`.
+  3. Plugin enabled in this profile: `CLAUDE_CONFIG_DIR=<profile-dir> claude plugin list` shows `telegram@claude-plugins-official` as installed.
+  4. No stray pollers: `pgrep -af 'bun.*telegram' | wc -l` equals the number of conductor bots (one per token).
+- **Debug checklist when bot goes silent**:
+  1. `curl https://api.telegram.org/bot<TOKEN>/getMe` → `ok:true`.
+  2. `pgrep -af 'bun.*telegram.*start'` — one PID per conductor; verify each has a distinct `TELEGRAM_STATE_DIR` in `/proc/<pid>/environ`.
+  3. Look for `⚠  GLOBAL_ANTIPATTERN` / `DOUBLE_LOAD` / `WRAPPER_DEPRECATED` lines in recent agent-deck command output — these are the leading indicators.

--- a/internal/session/telegram_validator.go
+++ b/internal/session/telegram_validator.go
@@ -1,0 +1,45 @@
+package session
+
+// Telegram-topology validator.
+//
+// Surfaces three anti-patterns that cause telegram poller leaks and 409
+// Conflict lockouts across conductor hosts (see fix v1.7.22, issue #658):
+//   GLOBAL_ANTIPATTERN — enabledPlugins."telegram@claude-plugins-official"=true
+//                        in a profile settings.json makes every claude
+//                        session load the plugin.
+//   DOUBLE_LOAD        — global + --channels on the same session makes the
+//                        plugin load twice in one process → 409.
+//   WRAPPER_DEPRECATED — TELEGRAM_STATE_DIR injected via session wrapper is
+//                        unreliable on the fresh-start path. Use
+//                        [conductors.<name>.claude].env_file instead.
+//
+// Pure and side-effect-free. CLI layer owns I/O (reading settings.json) and
+// presentation (formatting warnings on stderr).
+
+// TelegramValidatorInput captures the three signals the validator inspects.
+type TelegramValidatorInput struct {
+	// GlobalEnabled is the value of
+	// enabledPlugins."telegram@claude-plugins-official" in the relevant
+	// profile's settings.json, or false if that file or key is absent.
+	GlobalEnabled bool
+
+	// SessionChannels is the list of channels the session is launched with
+	// (Instance.Channels). Empty for ordinary child sessions.
+	SessionChannels []string
+
+	// SessionWrapper is the wrapper template for the session (may be empty).
+	SessionWrapper string
+}
+
+// TelegramWarning is one emission from the validator.
+type TelegramWarning struct {
+	Code    string // GLOBAL_ANTIPATTERN | DOUBLE_LOAD | WRAPPER_DEPRECATED
+	Message string
+}
+
+// ValidateTelegramTopology returns zero or more warnings for the given
+// session configuration. Stub during RED phase (Phase 3 TDD) — real logic
+// lands in Phase 5.
+func ValidateTelegramTopology(in TelegramValidatorInput) []TelegramWarning {
+	return nil
+}

--- a/internal/session/telegram_validator.go
+++ b/internal/session/telegram_validator.go
@@ -1,20 +1,29 @@
 package session
 
+import "strings"
+
 // Telegram-topology validator.
 //
 // Surfaces three anti-patterns that cause telegram poller leaks and 409
-// Conflict lockouts across conductor hosts (see fix v1.7.22, issue #658):
-//   GLOBAL_ANTIPATTERN — enabledPlugins."telegram@claude-plugins-official"=true
-//                        in a profile settings.json makes every claude
-//                        session load the plugin.
-//   DOUBLE_LOAD        — global + --channels on the same session makes the
-//                        plugin load twice in one process → 409.
-//   WRAPPER_DEPRECATED — TELEGRAM_STATE_DIR injected via session wrapper is
-//                        unreliable on the fresh-start path. Use
-//                        [conductors.<name>.claude].env_file instead.
+// Conflict lockouts across conductor hosts (fix v1.7.22, issue #658):
+//
+//	GLOBAL_ANTIPATTERN — enabledPlugins."telegram@claude-plugins-official"=true
+//	                     in a profile settings.json makes every claude
+//	                     session load the plugin.
+//	DOUBLE_LOAD        — global + --channels on the same session makes the
+//	                     plugin load twice in one process → 409.
+//	WRAPPER_DEPRECATED — TELEGRAM_STATE_DIR injected via session wrapper is
+//	                     unreliable on the fresh-start path. Use
+//	                     [conductors.<name>.claude].env_file instead.
 //
 // Pure and side-effect-free. CLI layer owns I/O (reading settings.json) and
 // presentation (formatting warnings on stderr).
+
+// telegramChannelPrefix matches channel ids like
+// "plugin:telegram@claude-plugins-official" or any other
+// "plugin:telegram@<owner>/<repo>" variant. We match by prefix so forks and
+// repo renames still trigger the guard.
+const telegramChannelPrefix = "plugin:telegram@"
 
 // TelegramValidatorInput captures the three signals the validator inspects.
 type TelegramValidatorInput struct {
@@ -38,8 +47,38 @@ type TelegramWarning struct {
 }
 
 // ValidateTelegramTopology returns zero or more warnings for the given
-// session configuration. Stub during RED phase (Phase 3 TDD) — real logic
-// lands in Phase 5.
+// session configuration. Ordering is stable: GLOBAL_ANTIPATTERN,
+// DOUBLE_LOAD, WRAPPER_DEPRECATED.
 func ValidateTelegramTopology(in TelegramValidatorInput) []TelegramWarning {
-	return nil
+	hasTelegramChannel := false
+	for _, ch := range in.SessionChannels {
+		if strings.HasPrefix(ch, telegramChannelPrefix) {
+			hasTelegramChannel = true
+			break
+		}
+	}
+
+	var out []TelegramWarning
+
+	if in.GlobalEnabled {
+		out = append(out, TelegramWarning{
+			Code:    "GLOBAL_ANTIPATTERN",
+			Message: `enabledPlugins."telegram@claude-plugins-official"=true in the profile settings.json is an anti-pattern for conductor hosts. Every claude session launched under this profile will start a telegram poller — including child agents spawned by the conductor. Disable the global flag and activate telegram per-session via --channels instead.`,
+		})
+		if hasTelegramChannel {
+			out = append(out, TelegramWarning{
+				Code:    "DOUBLE_LOAD",
+				Message: `Global telegram enablement AND --channels telegram@... on the same session: the plugin is loaded twice in one claude process. Two bun pollers race for the same bot token and Telegram rejects one with 409 Conflict. The supported topology is one channel-owning session per bot token with the global flag disabled (see skills/agent-deck SKILL.md "Telegram conductor topology").`,
+			})
+		}
+	}
+
+	if hasTelegramChannel && strings.Contains(in.SessionWrapper, "TELEGRAM_STATE_DIR=") {
+		out = append(out, TelegramWarning{
+			Code:    "WRAPPER_DEPRECATED",
+			Message: `The session wrapper injects TELEGRAM_STATE_DIR. This path is deprecated because bash -c argv splitting makes it unreliable on the fresh-start path (claude without --resume). Inject the variable via [conductors.<name>.claude].env_file in ~/.agent-deck/config.toml — it is sourced deterministically on both fresh and resume spawns.`,
+		})
+	}
+
+	return out
 }

--- a/internal/session/telegram_validator_test.go
+++ b/internal/session/telegram_validator_test.go
@@ -1,0 +1,141 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// Telegram-topology validator tests (fix v1.7.22, Closes #658).
+//
+// These tests enforce the Codex-approved three-root-cause fix:
+//   A. Global enablement of telegram@claude-plugins-official in profile
+//      settings.json → per-session poller leak.
+//   B. Global enablement + --channels on the same session → plugin loaded
+//      twice in one claude process → dueling bun pollers → Telegram 409.
+//   C. wrapper-based TELEGRAM_STATE_DIR injection is silently unreliable on
+//      the fresh-start path; env_file is the canonical mechanism.
+//
+// The validator is pure (no I/O) and takes the three inputs as struct fields.
+// CLI layer is responsible for reading settings.json and feeding GlobalEnabled.
+
+func TestTelegramValidator_GlobalDisabled_NoWarning(t *testing.T) {
+	in := TelegramValidatorInput{
+		GlobalEnabled: false,
+		SessionChannels: []string{
+			"plugin:telegram@claude-plugins-official",
+			"plugin:slack@claude-plugins-official",
+		},
+		SessionWrapper: "ENV=foo {command}",
+	}
+	got := ValidateTelegramTopology(in)
+	if len(got) != 0 {
+		t.Fatalf("GlobalEnabled=false must produce zero warnings, got %d: %+v", len(got), got)
+	}
+}
+
+func TestTelegramValidator_GlobalEnabled_OrdinarySession_WarnAntiPattern(t *testing.T) {
+	in := TelegramValidatorInput{
+		GlobalEnabled:   true,
+		SessionChannels: nil, // ordinary child session, no telegram channel
+		SessionWrapper:  "",
+	}
+	got := ValidateTelegramTopology(in)
+
+	var antipattern *TelegramWarning
+	for i := range got {
+		if got[i].Code == "GLOBAL_ANTIPATTERN" {
+			antipattern = &got[i]
+			break
+		}
+	}
+	if antipattern == nil {
+		t.Fatalf("expected GLOBAL_ANTIPATTERN warning, got %+v", got)
+	}
+	if !strings.Contains(antipattern.Message, "enabledPlugins") {
+		t.Errorf("GLOBAL_ANTIPATTERN message must reference enabledPlugins, got: %s", antipattern.Message)
+	}
+	if !strings.Contains(strings.ToLower(antipattern.Message), "telegram") {
+		t.Errorf("GLOBAL_ANTIPATTERN message must reference telegram, got: %s", antipattern.Message)
+	}
+	// Must NOT emit DOUBLE_LOAD when session has no telegram channel.
+	for _, w := range got {
+		if w.Code == "DOUBLE_LOAD" {
+			t.Errorf("ordinary session must not receive DOUBLE_LOAD warning, got: %+v", w)
+		}
+	}
+}
+
+func TestTelegramValidator_GlobalEnabled_ConductorSession_WarnDoubleLoad(t *testing.T) {
+	in := TelegramValidatorInput{
+		GlobalEnabled: true,
+		SessionChannels: []string{
+			"plugin:telegram@claude-plugins-official",
+		},
+		SessionWrapper: "",
+	}
+	got := ValidateTelegramTopology(in)
+
+	codes := map[string]bool{}
+	var doubleLoad *TelegramWarning
+	for i := range got {
+		codes[got[i].Code] = true
+		if got[i].Code == "DOUBLE_LOAD" {
+			doubleLoad = &got[i]
+		}
+	}
+	if !codes["GLOBAL_ANTIPATTERN"] {
+		t.Errorf("expected GLOBAL_ANTIPATTERN, got codes %+v", codes)
+	}
+	if doubleLoad == nil {
+		t.Fatalf("expected DOUBLE_LOAD warning, got %+v", got)
+	}
+	msg := strings.ToLower(doubleLoad.Message)
+	// message should explain the actual failure mode
+	if !strings.Contains(msg, "twice") && !strings.Contains(msg, "duplicate") {
+		t.Errorf("DOUBLE_LOAD message should explain plugin loaded twice, got: %s", doubleLoad.Message)
+	}
+	if !strings.Contains(msg, "409") && !strings.Contains(msg, "conflict") {
+		t.Errorf("DOUBLE_LOAD message should reference 409/Conflict, got: %s", doubleLoad.Message)
+	}
+}
+
+func TestTelegramValidator_WrapperStateDir_AntiPattern(t *testing.T) {
+	in := TelegramValidatorInput{
+		GlobalEnabled: false,
+		SessionChannels: []string{
+			"plugin:telegram@claude-plugins-official",
+		},
+		SessionWrapper: "TELEGRAM_STATE_DIR=/home/me/.claude/channels/telegram {command}",
+	}
+	got := ValidateTelegramTopology(in)
+
+	var w *TelegramWarning
+	for i := range got {
+		if got[i].Code == "WRAPPER_DEPRECATED" {
+			w = &got[i]
+			break
+		}
+	}
+	if w == nil {
+		t.Fatalf("expected WRAPPER_DEPRECATED warning, got %+v", got)
+	}
+	if !strings.Contains(w.Message, "env_file") {
+		t.Errorf("WRAPPER_DEPRECATED message must recommend env_file, got: %s", w.Message)
+	}
+}
+
+// Sanity: wrapper with TELEGRAM_STATE_DIR on a session without telegram
+// channel is NOT a v1.7.22-relevant antipattern (nothing to poll). Don't warn.
+func TestTelegramValidator_WrapperStateDir_NoTelegramChannel_NoWarning(t *testing.T) {
+	in := TelegramValidatorInput{
+		GlobalEnabled:   false,
+		SessionChannels: nil,
+		SessionWrapper:  "TELEGRAM_STATE_DIR=/tmp/x {command}",
+	}
+	got := ValidateTelegramTopology(in)
+	for _, w := range got {
+		if w.Code == "WRAPPER_DEPRECATED" {
+			t.Errorf("no telegram channel: must not emit WRAPPER_DEPRECATED, got %+v", w)
+		}
+	}
+}

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -457,6 +457,38 @@ Telegram's Bot API `getUpdates` is single-consumer per bot token. If N Claude se
 
 **Debug:** `pgrep -af "bun.*telegram" | wc -l` should return 1. Anything higher means a race. Kill extras: `pkill -f "bun.*telegram"` then restart only the intended session.
 
+### Telegram conductor topology (v1.7.22+)
+
+**Supported topology — enforce this on every conductor host:**
+
+- Telegram is activated **per-session** via `--channels plugin:telegram@claude-plugins-official`. This is the only supported activation path for a conductor bot.
+- `TELEGRAM_STATE_DIR` is injected **exclusively** via `[conductors.<name>.claude].env_file` in `~/.agent-deck/config.toml`. The env file sources deterministically on both fresh-start and `--resume` spawns.
+- One bot token = one channel-owning session. Never share tokens between sessions.
+- `enabledPlugins."telegram@claude-plugins-official"` in the profile `settings.json` must be **absent or false**. Global enablement makes every claude subprocess (including child agents) load the plugin.
+
+**Codified anti-patterns — agent-deck v1.7.22 emits warnings for these:**
+
+| Anti-pattern | Code | Why it breaks |
+|---|---|---|
+| `enabledPlugins."telegram@claude-plugins-official" = true` in profile settings | `GLOBAL_ANTIPATTERN` | Every claude process loads the plugin, including every child agent the conductor spawns. Each one starts a `bun telegram` poller. |
+| Global enablement **AND** `--channels plugin:telegram@...` on the same session | `DOUBLE_LOAD` | The plugin loads twice in one claude process. Two bun pollers race on one bot token and Telegram rejects with 409 Conflict. |
+| `session set wrapper "TELEGRAM_STATE_DIR=... {command}"` | `WRAPPER_DEPRECATED` | Works on the resume path; silently fails on fresh-start due to `bash -c` argv splitting. The env var never reaches claude, so the plugin falls back to the default state dir and two conductors collide. Use `env_file` instead. |
+| Relying on `.mcp.json` telegram entries for inbound delivery | — | `.mcp.json` loads the plugin as an MCP server (tool-use only). Inbound message → conversation-turn delivery requires `--channels`. |
+| Using the same bot token for multiple concurrent sessions | — | `getUpdates` is single-consumer per token. |
+| Assuming an empty `TELEGRAM_STATE_DIR` is fine | — | The plugin falls back to `~/.claude/channels/telegram/`; any DM approval there leaks across unrelated conductors. |
+
+**Verifying steady state (conductor host):**
+
+```bash
+pgrep -af 'bun.*telegram' | grep -v grep | wc -l   # expect: exactly one per conductor bot
+for PID in $(pgrep -f 'bun.*telegram.*start'); do
+  echo "PID=$PID TSD=$(tr '\0' '\n' < /proc/$PID/environ | grep ^TELEGRAM_STATE_DIR= | cut -d= -f2-)"
+done
+# Each PID must show a distinct TELEGRAM_STATE_DIR; collisions indicate env_file is not being sourced.
+```
+
+**When agent-deck emits a `⚠  GLOBAL_ANTIPATTERN` / `DOUBLE_LOAD` / `WRAPPER_DEPRECATED` warning**, the problem is in your topology, not in agent-deck. Fix the profile settings or the conductor env_file; the warning is a leading indicator of the 409-Conflict symptom that follows minutes-to-hours later.
+
 ## References
 
 - [cli-reference.md](references/cli-reference.md) - Complete CLI command reference


### PR DESCRIPTION
Closes #658.

## Summary

Three stacked root causes were silently making `bun telegram` pollers race across conductor hosts and triggering Telegram `409 Conflict` lockouts after a few hours. Fix was designed with Codex review and lands the minimal patch + permanent test-gate for each:

- **A. Global enablement** — `enabledPlugins.\"telegram@claude-plugins-official\" = true` in a profile `settings.json` made every `claude` subprocess (including every child agent spawned by the conductor) start its own poller. Agent-deck now **warns** on detection — it does not auto-mutate settings.
- **B. Double-load in one process** — global enablement **and** `--channels plugin:telegram@...` on the same session loaded the plugin twice in one `claude` process. Two bun pollers on one bot token = 409. Agent-deck now emits a stronger `DOUBLE_LOAD` warning explaining the mechanism.
- **C. Wrapper-shape bug** — `agent-deck session set wrapper \"TELEGRAM_STATE_DIR=... {command}\"` works on `claude --resume` but silently fails on fresh-start (bash -c argv splitting). Fallback to the default state dir lets unrelated conductors collide. Fix codifies `[conductors.<name>.claude].env_file` as the only supported injection path and deprecates the wrapper route with a `WRAPPER_DEPRECATED` warning.

The existing `enabledPlugins: false` + `--channels` topology is unchanged; clean configurations emit zero warnings.

## What changed

- `internal/session/telegram_validator.go` (NEW) — pure, side-effect-free topology validator emitting stable-ordered warnings (`GLOBAL_ANTIPATTERN`, `DOUBLE_LOAD`, `WRAPPER_DEPRECATED`).
- `cmd/agent-deck/conductor_cmd_telegram.go` (NEW) — `readTelegramGloballyEnabled()` (defensive JSON parse of Claude Code `settings.json`) + `emitTelegramWarnings()` formatter.
- `cmd/agent-deck/conductor_cmd.go` — hook in `handleConductorSetup` (fires once per setup invocation).
- `cmd/agent-deck/session_cmd.go` — hook in `handleSessionSet` for `wrapper` and `channels` field changes.
- `skills/agent-deck/SKILL.md` — new \"Telegram conductor topology (v1.7.22+)\" subsection codifying supported topology + anti-pattern table.
- `conductor/conductor-claude.md` — runbook addendum with preflight + debug checklists.
- `README.md` — short v1.7.22 pointer.
- `.claude/release-tests.yaml` — 6 new manifest entries gating the validator contract.

## Test plan

- [x] Eight mandatory `TestPersistence_*` tests green (`go test -run TestPersistence_ ./internal/session/... -race -count=1`).
- [x] `TestPerGroupConfig_*` suite green.
- [x] Feedback suite green (`-run \"Feedback|Sender_\"`).
- [x] Watcher suite green (`./internal/watcher/... -race -count=1 -timeout 120s` + `./cmd/agent-deck/... -run Watcher`).
- [x] Full suite green: `go test -race -count=1 ./...` (all 27 packages pass).
- [x] Nine v1.7.22 validator tests green (5 unit + 6 CLI) — all RED → GREEN under TDD.
- [x] Live-boundary 5-case matrix exercised against the built binary (clean / ordinary / global-only / global+channels / wrapper): warnings fire exactly as designed.

## Release discipline

- Branched from `main` at v1.7.21 (a6d5773). No cross-contamination with v1.7.21 launch_as work.
- Zero regressions.
- No `--no-verify` used on source-modifying commits.
- Docs + SKILL.md + manifest + tests land atomically with the fix per Watcher-framework-style sync mandate (REQ-WF-7 spirit).

Post-merge: version bump to v1.7.22 on main, then release cut.