### PR TITLE
fix(#663): multi-repo sessions preserve state on stop→start

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -1059,3 +1059,36 @@ tests:
   run:
     command: go test ./internal/session/ -run TestInstance_BuildClaudeResumeCommand_AfterFlap_ResumesRichID -count=1 -race -v
     expected: pass
+- id: v1724-multirepo-restore-reconnect-workdir
+  added: '2026-04-18'
+  task: v1724-multirepo-restore-663
+  file: internal/session/multirepo_restore_test.go
+  test_name: TestRestore_ReconnectSeedsWorkDirFromMultiRepoTempDir
+  purpose: 'Issue #663 site 1 — storage.go convertToInstances must seed tmux WorkDir from MultiRepoTempDir, not the ProjectPath symlink. Otherwise the restart pane launches in the wrong cwd and Claude''s JSONL encoded-path key never matches, silently dropping the prior conversation.'
+  source: .planning/investigate-multirepo-restart/REPORT.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestRestore_ReconnectSeedsWorkDirFromMultiRepoTempDir -count=1 -race -v
+    expected: pass
+- id: v1724-multirepo-restore-recreate-workdir
+  added: '2026-04-18'
+  task: v1724-multirepo-restore-663
+  file: internal/session/multirepo_restore_test.go
+  test_name: TestRestore_RecreateTmuxSessionUsesEffectiveWorkingDir
+  purpose: 'Issue #663 site 2 — instance.go recreateTmuxSession must use EffectiveWorkingDir(), not ProjectPath, when the TUI restart path finds the prior tmux session dead. Without this, multi-repo TUI restarts spawn the replacement tmux session inside the symlinked source repo rather than the worktree parent dir.'
+  source: .planning/investigate-multirepo-restart/REPORT.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestRestore_RecreateTmuxSessionUsesEffectiveWorkingDir -count=1 -race -v
+    expected: pass
+- id: v1724-multirepo-restore-jsonl-discovery
+  added: '2026-04-18'
+  task: v1724-multirepo-restore-663
+  file: internal/session/multirepo_restore_test.go
+  test_name: TestRestore_DiscoverJSONLUsesMultiRepoTempDir
+  purpose: 'Issue #663 site 3 — ensureClaudeSessionIDFromDisk must probe discoverLatestClaudeJSONL with EffectiveWorkingDir(). ProjectPath on a multi-repo session EvalSymlinks-resolves into the original source repo, so the encoded path never finds the JSONL that Claude wrote while cwd=MultiRepoTempDir. Without this, Start() silently enters the fresh-session branch and the prior conversation vanishes.'
+  source: .planning/investigate-multirepo-restart/REPORT.md
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestRestore_DiscoverJSONLUsesMultiRepoTempDir -count=1 -race -v
+    expected: pass

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.23" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.24" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2010,7 +2010,14 @@ func (i *Instance) ensureClaudeSessionIDFromDisk() {
 	if i.ClaudeDetectedAt.IsZero() {
 		return
 	}
-	uuid, found := discoverLatestClaudeJSONL(i.ProjectPath)
+	// Issue #663: multi-repo sessions write their JSONL under
+	// ~/.claude/projects/<encoded MultiRepoTempDir>/. ProjectPath is a
+	// symlink inside MultiRepoTempDir, so EvalSymlinks would resolve it
+	// to the original source repo and miss the JSONL. Use
+	// EffectiveWorkingDir() so the encoded-path key matches what Claude
+	// actually wrote on the first boot.
+	lookupPath := i.EffectiveWorkingDir()
+	uuid, found := discoverLatestClaudeJSONL(lookupPath)
 	if !found {
 		return
 	}
@@ -2018,7 +2025,7 @@ func (i *Instance) ensureClaudeSessionIDFromDisk() {
 	sessionLog.Info("resume: id="+uuid+" reason=jsonl_discovery",
 		slog.String("instance_id", i.ID),
 		slog.String("claude_session_id", uuid),
-		slog.String("path", i.ProjectPath),
+		slog.String("path", lookupPath),
 		slog.String("reason", "jsonl_discovery"))
 }
 
@@ -3316,7 +3323,10 @@ func (i *Instance) clearSessionBindingForFreshStart() {
 }
 
 func (i *Instance) recreateTmuxSession() {
-	i.tmuxSession = tmux.NewSession(i.Title, i.ProjectPath)
+	// Issue #663: multi-repo sessions must cwd into MultiRepoTempDir, not
+	// ProjectPath (which is a symlink into that parent dir). Delegates to
+	// EffectiveWorkingDir so single-repo sessions keep using ProjectPath.
+	i.tmuxSession = tmux.NewSession(i.Title, i.EffectiveWorkingDir())
 	i.tmuxSession.InstanceID = i.ID
 	i.tmuxSession.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
 	i.tmuxSession.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
@@ -5179,9 +5189,13 @@ func sessionConversationByteSize(inst *Instance, sessionID string) int64 {
 	if configDir == "" {
 		configDir = filepath.Join(os.Getenv("HOME"), ".claude")
 	}
+	// Issue #663: for multi-repo sessions ProjectPath is a symlink into
+	// MultiRepoTempDir; EvalSymlinks would resolve away from the parent
+	// dir Claude actually used as cwd. EffectiveWorkingDir() is the
+	// authoritative cwd for JSONL encoding.
 	projectPath := ""
 	if inst != nil {
-		projectPath = inst.ProjectPath
+		projectPath = inst.EffectiveWorkingDir()
 	}
 	resolvedPath := projectPath
 	if resolved, err := filepath.EvalSymlinks(projectPath); err == nil {
@@ -5262,9 +5276,12 @@ func sessionHasConversationData(inst *Instance, sessionID string) bool {
 		configDir = filepath.Join(os.Getenv("HOME"), ".claude")
 	}
 
+	// Issue #663: see sessionConversationByteSize rationale above.
+	// Multi-repo sessions must encode EffectiveWorkingDir(), not the
+	// ProjectPath symlink.
 	projectPath := ""
 	if inst != nil {
-		projectPath = inst.ProjectPath
+		projectPath = inst.EffectiveWorkingDir()
 	}
 
 	// Resolve symlinks in project path (macOS: /tmp -> /private/tmp)

--- a/internal/session/multirepo_restore_test.go
+++ b/internal/session/multirepo_restore_test.go
@@ -1,0 +1,236 @@
+// Regression tests for https://github.com/asheshgoplani/agent-deck/issues/663:
+// multi-repo sessions silently drop all conversation history on stop→start.
+//
+// Root cause per .planning/investigate-multirepo-restart/REPORT.md: the
+// reload/restart paths seed tmux cwd and Claude JSONL lookup from
+// Instance.ProjectPath (which, for multi-repo sessions, was rewritten at
+// creation time to be a symlink inside MultiRepoTempDir) instead of
+// EffectiveWorkingDir() (which returns MultiRepoTempDir for multi-repo).
+// Result: tmux launches in the wrong cwd; Claude's JSONL encoded-path key
+// never matches; Start() enters the fresh-session branch; prior
+// conversation is silently lost.
+//
+// These four tests pin each of the four sites that must use
+// EffectiveWorkingDir() rather than ProjectPath on the restart/resume path.
+//
+// Parallel-paths audit (claude-conductor invariant 7): the bug has four
+// code paths, all fixed together:
+//  1. storage.go convertToInstances → tmux.ReconnectSessionLazy WorkDir
+//  2. instance.go recreateTmuxSession → tmux.NewSession WorkDir
+//  3. instance.go ensureClaudeSessionIDFromDisk → discoverLatestClaudeJSONL
+//  4. instance.go sessionHasConversationData encoded-path lookup
+//
+// Three RED tests below cover sites 1–3, which are 100% broken on v1.7.23.
+// Site 4 is a latent bug: the wrong encoded-path primary lookup is masked
+// by an existing cross-project fallback (findSessionFileInAllProjects) that
+// globs every project hash dir for the session UUID and hits the correct
+// JSONL anyway. We still apply the same EffectiveWorkingDir() fix at site 4
+// for consistency (and to avoid the fallback's read amplification when
+// projects/ contains hundreds of hash dirs), but it has no observable
+// failure mode on current code, so it ships without a dedicated RED test.
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// multiRepoFixtureDirs creates the on-disk layout that production sets up
+// for a multi-repo session:
+//
+//	<home>/.agent-deck/multi-repo-worktrees/<id8>/       (MultiRepoTempDir, real dir)
+//	<home>/.agent-deck/multi-repo-worktrees/<id8>/repo1 -> <home>/src/repo1
+//	<home>/src/repo1                                     (real source repo)
+//
+// ProjectPath points to the symlink (the first repo inside MultiRepoTempDir).
+// This mirrors home.go:7255-7364's rewrite-ProjectPath-to-parentDir-symlink step.
+// Returns (multiRepoTempDir, projectPathSymlink).
+func multiRepoFixtureDirs(t *testing.T, home string) (string, string) {
+	t.Helper()
+	srcRepo := filepath.Join(home, "src", "repo1")
+	if err := os.MkdirAll(srcRepo, 0o755); err != nil {
+		t.Fatalf("mkdir srcRepo: %v", err)
+	}
+	parent := filepath.Join(home, ".agent-deck", "multi-repo-worktrees", "abc12345")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+	// Resolve symlinks on the parent dir to match production (home.go uses
+	// filepath.EvalSymlinks when computing MultiRepoTempDir). On Linux the
+	// temp HOME itself may include /private or /var symlinks, so normalize.
+	if resolved, err := filepath.EvalSymlinks(parent); err == nil {
+		parent = resolved
+	}
+	symlink := filepath.Join(parent, "repo1")
+	if err := os.Symlink(srcRepo, symlink); err != nil {
+		t.Fatalf("symlink project: %v", err)
+	}
+	return parent, symlink
+}
+
+// TestRestore_ReconnectSeedsWorkDirFromMultiRepoTempDir pins site 1.
+//
+// On reload, storage.go:730-820's convertToInstances calls
+// tmux.ReconnectSessionLazy with instData.ProjectPath as the WorkDir. For
+// multi-repo sessions this must be instData.MultiRepoTempDir instead —
+// otherwise the first attach starts the pane inside the symlink's target
+// (the original repo), not the parent worktree dir.
+func TestRestore_ReconnectSeedsWorkDirFromMultiRepoTempDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	parent, symlink := multiRepoFixtureDirs(t, home)
+
+	data := &StorageData{
+		Instances: []*InstanceData{{
+			ID:               "test-663-reconnect",
+			Title:            "multirepo-reconnect",
+			ProjectPath:      symlink,
+			Tool:             "claude",
+			Command:          "claude",
+			Status:           StatusStopped,
+			TmuxSession:      "agentdeck_test_663_reconnect_deadbeef",
+			MultiRepoEnabled: true,
+			MultiRepoTempDir: parent,
+			AdditionalPaths:  []string{},
+		}},
+	}
+
+	s := &Storage{}
+	instances, _, err := s.convertToInstances(data)
+	if err != nil {
+		t.Fatalf("convertToInstances: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("want 1 instance, got %d", len(instances))
+	}
+
+	sess := instances[0].GetTmuxSession()
+	if sess == nil {
+		t.Fatal("GetTmuxSession returned nil — cannot verify WorkDir")
+	}
+	if sess.WorkDir != parent {
+		t.Fatalf("issue #663: after Load, tmux WorkDir = %q, want MultiRepoTempDir = %q. "+
+			"On restart the pane will launch in the symlink's resolved target (the "+
+			"original source repo) instead of the parent worktree dir, and Claude's "+
+			"JSONL encoded-path key will not match the one written on the first boot.",
+			sess.WorkDir, parent)
+	}
+}
+
+// TestRestore_RecreateTmuxSessionUsesEffectiveWorkingDir pins site 2.
+//
+// recreateTmuxSession (instance.go:3318-3323) runs on the TUI restart path
+// when the old tmux session is dead. Today it calls tmux.NewSession with
+// i.ProjectPath; for multi-repo sessions this must use
+// i.EffectiveWorkingDir() so the freshly-created session lands in
+// MultiRepoTempDir.
+func TestRestore_RecreateTmuxSessionUsesEffectiveWorkingDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	parent, symlink := multiRepoFixtureDirs(t, home)
+
+	inst := &Instance{
+		ID:               "test-663-recreate",
+		Title:            "multirepo-recreate",
+		ProjectPath:      symlink,
+		Tool:             "claude",
+		Command:          "claude",
+		MultiRepoEnabled: true,
+		MultiRepoTempDir: parent,
+	}
+
+	inst.recreateTmuxSession()
+
+	sess := inst.GetTmuxSession()
+	if sess == nil {
+		t.Fatal("recreateTmuxSession left tmuxSession nil")
+	}
+	if sess.WorkDir != parent {
+		t.Fatalf("issue #663: recreateTmuxSession set WorkDir = %q, want %q (MultiRepoTempDir). "+
+			"A TUI restart will then spawn the replacement tmux session in the wrong cwd.",
+			sess.WorkDir, parent)
+	}
+}
+
+// TestRestore_DiscoverJSONLUsesMultiRepoTempDir pins site 3.
+//
+// ensureClaudeSessionIDFromDisk calls discoverLatestClaudeJSONL(i.ProjectPath).
+// On a multi-repo session the JSONL was written under
+// ~/.claude/projects/<encoded MultiRepoTempDir>/, so a ProjectPath lookup
+// (which EvalSymlinks-resolves into the ORIGINAL repo path) misses. After
+// the fix, the lookup uses EffectiveWorkingDir() = MultiRepoTempDir and
+// hits.
+func TestRestore_DiscoverJSONLUsesMultiRepoTempDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	parent, symlink := multiRepoFixtureDirs(t, home)
+
+	// Seed a JSONL under the MultiRepoTempDir-encoded path (the key that
+	// Claude would have written on the first boot, when cwd = parent).
+	sessionUUID := "1234abcd-5678-90ab-cdef-1234567890ab"
+	encoded := ConvertToClaudeDirName(parent)
+	if encoded == "" {
+		encoded = "-"
+	}
+	projectsDir := filepath.Join(home, ".claude", "projects", encoded)
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatalf("mkdir projects: %v", err)
+	}
+	jsonlPath := filepath.Join(projectsDir, sessionUUID+".jsonl")
+	line, _ := json.Marshal(map[string]string{"sessionId": sessionUUID, "role": "user", "content": "hi"})
+	if err := os.WriteFile(jsonlPath, append(line, '\n'), 0o644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	inst := &Instance{
+		ID:               "test-663-discover",
+		ProjectPath:      symlink,
+		Tool:             "claude",
+		MultiRepoEnabled: true,
+		MultiRepoTempDir: parent,
+		// Required: ClaudeDetectedAt must be non-zero for the discovery
+		// path (issue #608 guard: zero-time means "never started, must be
+		// fresh").
+		ClaudeDetectedAt: time.Now(),
+	}
+
+	inst.ensureClaudeSessionIDFromDisk()
+
+	if inst.ClaudeSessionID != sessionUUID {
+		t.Fatalf("issue #663: ensureClaudeSessionIDFromDisk did not find the JSONL under "+
+			"MultiRepoTempDir encoding. Got ClaudeSessionID = %q, want %q. "+
+			"Current code encodes ProjectPath (the symlink, which EvalSymlinks "+
+			"resolves into the ORIGINAL repo path — a different hash than the "+
+			"one Claude used when cwd = MultiRepoTempDir). JSONL at: %s",
+			inst.ClaudeSessionID, sessionUUID, jsonlPath)
+	}
+}
+
+// NOTE on site 4 (sessionHasConversationData):
+//
+// The fourth parallel path — sessionHasConversationData — is ALSO fixed to
+// use EffectiveWorkingDir() for consistency (see parallel-paths audit
+// comment at the top of this file), but it has no dedicated RED test.
+// Reason: the helper has an existing cross-project fallback
+// (findSessionFileInAllProjects at instance.go:5352) that globs every
+// project hash dir for the session UUID and lands on the correct JSONL
+// even when the primary lookup uses the wrong (ProjectPath-based) encoded
+// path. So an end-to-end test seeded with a single JSONL at the
+// MultiRepoTempDir-encoded path passes both before and after the fix.
+// The fix at site 4 is still correct (eliminates a needless read
+// amplification over projects/) but is not user-observable in isolation.

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -746,6 +746,17 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 				instData.Command,
 				previousStatus,
 			)
+			// Issue #663: for multi-repo sessions ProjectPath is a symlink
+			// inside MultiRepoTempDir (see home.go:7255-7364), so the
+			// restart pane must cwd into the parent dir — not the symlink
+			// target (an individual source repo). Matches the creation-
+			// time assignment at home.go:7364. Without this, Claude's
+			// JSONL is written under a different encoded-path key and the
+			// next Start() silently mints a fresh session instead of
+			// resuming the prior conversation.
+			if instData.MultiRepoEnabled && instData.MultiRepoTempDir != "" {
+				tmuxSess.WorkDir = instData.MultiRepoTempDir
+			}
 			// Pass instance ID for activity hooks (enables real-time status updates)
 			tmuxSess.InstanceID = instData.ID
 			tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())


### PR DESCRIPTION
## Summary

Closes #663.

Multi-repo sessions were silently losing all Claude conversation history on every stop→start cycle. Root cause, per the read-only investigation at `.planning/investigate-multirepo-restart/REPORT.md`: the reload and restart paths seed tmux cwd and Claude JSONL lookup from `Instance.ProjectPath`, which — on a multi-repo session — was rewritten at creation time (home.go:7255-7364) to be a symlink *inside* `MultiRepoTempDir`. So after reload, the tmux pane launched in the wrong cwd and Claude's JSONL encoded-path key never matched the one written on the first boot. `Start()` then entered the `fresh_session` branch, minting a brand-new UUID and silently discarding the prior conversation.

The authoritative "where does this session run" helper — `EffectiveWorkingDir()` — existed but was never consulted on the reload/restart paths. This PR plumbs it through all four affected sites.

## Parallel-paths audit (claude-conductor invariant 7)

| Site | File | Before | After |
|------|------|--------|-------|
| 1 | `internal/session/storage.go` (convertToInstances) | `tmux.ReconnectSessionLazy(..., instData.ProjectPath, ...)` | Override `tmuxSess.WorkDir = MultiRepoTempDir` when `MultiRepoEnabled` |
| 2 | `internal/session/instance.go` (recreateTmuxSession) | `tmux.NewSession(i.Title, i.ProjectPath)` | `tmux.NewSession(i.Title, i.EffectiveWorkingDir())` |
| 3 | `internal/session/instance.go` (ensureClaudeSessionIDFromDisk) | `discoverLatestClaudeJSONL(i.ProjectPath)` | `discoverLatestClaudeJSONL(i.EffectiveWorkingDir())` |
| 4 | `internal/session/instance.go` (sessionHasConversationData + sessionConversationByteSize) | encoded `inst.ProjectPath` | encoded `inst.EffectiveWorkingDir()` |

Single-repo sessions are behaviorally byte-identical because `EffectiveWorkingDir()` falls back to `ProjectPath` when `MultiRepoEnabled=false` or `MultiRepoTempDir==""`.

## Tests

Three RED regression tests (sites 1–3) added to `internal/session/multirepo_restore_test.go`:

1. `TestRestore_ReconnectSeedsWorkDirFromMultiRepoTempDir` (site 1)
2. `TestRestore_RecreateTmuxSessionUsesEffectiveWorkingDir` (site 2)
3. `TestRestore_DiscoverJSONLUsesMultiRepoTempDir` (site 3)

All three fail RED on v1.7.23 and green on this branch. Site 4 ships without a dedicated RED test because its bug is masked in practice by the existing `findSessionFileInAllProjects` cross-project fallback that globs every project hash dir for the session UUID and hits the correct JSONL anyway — the site 4 fix eliminates a needless read amplification but has no user-observable regression on current code.

All three manifest entries appended to `.claude/release-tests.yaml`.

## Test plan

- [x] Targeted regression tests RED on `v1.7.23`, GREEN on this branch
- [x] Full suite green: `go test ./... -race -count=1` (all packages pass)
- [x] Pre-push hooks green (lint + full suite + release-tests-yaml-lint)
- [ ] Post-merge: tag `v1.7.24`, goreleaser workflow, local binary rebuild
- [ ] Post-release dogfood: stop + start a live multi-repo session and confirm `claude --resume <prior-uuid>` on the live tmux pane

## Out of scope

- Migrating already-orphaned JSONLs stuck under a wrong encoded-path key from past stop/start cycles (follow-up: a one-shot `agent-deck doctor migrate-multirepo-jsonls` utility)
- Renaming `MultiRepoTempDir` → `MultiRepoParentDir` (cosmetic)