### PR TITLE
feat(#556): GitHub Copilot CLI first-class tool support (v1.7.26)

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -1257,3 +1257,80 @@ tests:
   run:
     command: go test ./internal/ui/ -run TestIssue666_GlobalSearchImport_EndToEnd_PreservesGroupAcrossReload -count=1 -race -v
     expected: pass
+- id: v1726-issue556-copilot-options-toargs
+  added: '2026-04-18'
+  task: v1726-issue556-copilot-cli
+  file: internal/session/copilot_test.go
+  test_name: TestCopilotOptions_ToArgs
+  purpose: 'Issue #556 — CopilotOptions.ToArgs emits the right flag shape for each session mode (new → no args, resume → --resume, resume with ID → --resume <id>). This is the contract that buildCopilotCommand wiring will consume as the feature extends.'
+  source: github-issue-556
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestCopilotOptions_ToArgs -count=1 -race -v
+    expected: pass
+- id: v1726-issue556-copilot-marshal-roundtrip
+  added: '2026-04-18'
+  task: v1726-issue556-copilot-cli
+  file: internal/session/copilot_test.go
+  test_name: TestCopilotOptions_MarshalUnmarshalRoundtrip
+  purpose: 'Issue #556 — CopilotOptions survives JSON roundtrip through the ToolOptionsWrapper envelope (tool="copilot"). Guards against persistence regression when the storage layer serialises tool options.'
+  source: github-issue-556
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestCopilotOptions_MarshalUnmarshalRoundtrip -count=1 -race -v
+    expected: pass
+- id: v1726-issue556-copilot-not-claude-compatible
+  added: '2026-04-18'
+  task: v1726-issue556-copilot-cli
+  file: internal/session/copilot_test.go
+  test_name: TestIsClaudeCompatible_CopilotNotCompatible
+  purpose: 'Issue #556 — Copilot is its own tool, not a Claude wrapper. IsClaudeCompatible("copilot") must be false so Claude-only surfaces (--channels, --extra-arg, skill injection, MCP hooks) stay off. Critical negative guard preventing Claude-path accidents.'
+  source: github-issue-556
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestIsClaudeCompatible_CopilotNotCompatible -count=1 -race -v
+    expected: pass
+- id: v1726-issue556-copilot-custom-names-excludes-builtin
+  added: '2026-04-18'
+  task: v1726-issue556-copilot-cli
+  file: internal/session/copilot_test.go
+  test_name: TestGetCustomToolNames_CopilotIsBuiltin
+  purpose: 'Issue #556 — if a user defines [tools.copilot] in config.toml the built-in copilot handler must take precedence. GetCustomToolNames must exclude "copilot" from the custom list so the detection / icon / pattern path routes through the built-in branch.'
+  source: github-issue-556
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestGetCustomToolNames_CopilotIsBuiltin -count=1 -race -v
+    expected: pass
+- id: v1726-issue556-copilot-tmux-detect
+  added: '2026-04-18'
+  task: v1726-issue556-copilot-cli
+  file: internal/tmux/copilot_test.go
+  test_name: TestDetectToolFromCommand_Copilot
+  purpose: 'Issue #556 — tmux-layer detection identifies "copilot" from bare binary, flagged invocations, npx @github/copilot form, and uppercase variants. Fires from pipemanager + title_detection so the TUI and status refresh agree on tool identity.'
+  source: github-issue-556
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestDetectToolFromCommand_Copilot -count=1 -race -v
+    expected: pass
+- id: v1726-issue556-copilot-patterns
+  added: '2026-04-18'
+  task: v1726-issue556-copilot-cli
+  file: internal/tmux/copilot_test.go
+  test_name: TestDefaultRawPatterns_Copilot
+  purpose: 'Issue #556 — DefaultRawPatterns("copilot") returns non-nil busy + prompt pattern sets, wiring copilot into the same status detection pipeline as claude/gemini/codex. Without this patch the session would have no busy/idle semantics in the TUI.'
+  source: github-issue-556
+  manual: false
+  run:
+    command: go test ./internal/tmux/ -run TestDefaultRawPatterns_Copilot -count=1 -race -v
+    expected: pass
+- id: v1726-issue556-copilot-cli-detect
+  added: '2026-04-18'
+  task: v1726-issue556-copilot-cli
+  file: cmd/agent-deck/copilot_detect_test.go
+  test_name: TestDetectTool_Copilot
+  purpose: 'Issue #556 — `agent-deck add -c copilot .` must resolve to Tool="copilot" instead of the shell fallback. Covers bare / flagged / uppercase invocations routed through the CLI-layer detectTool helper in main.go.'
+  source: github-issue-556
+  manual: false
+  run:
+    command: go test ./cmd/agent-deck/ -run TestDetectTool_Copilot -count=1 -race -v
+    expected: pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.26] - 2026-04-18
+
+### Added
+- **GitHub Copilot CLI support** (issue [#556](https://github.com/asheshgoplani/agent-deck/issues/556)): Agent Deck now recognises the standalone `copilot` binary from `@github/copilot` (GA 2026-02-25) as a first-class tool identity alongside `claude`, `gemini`, `codex`, and `opencode`. `agent-deck add -c copilot .` lands on `Tool="copilot"` instead of the generic `shell` fallback, so sessions get the right status detection, the right icon (🐙), and the right per-tool config path. A new `[copilot]` TOML block (`env_file` for now) gives users a home for future knobs without schema churn. The `CopilotOptions` envelope mirrors the existing Claude/OpenCode shape (`SessionMode` + `ResumeSessionID`) and emits `--resume` (picker) or `--resume <id>` (direct). `IsClaudeCompatible("copilot")` is deliberately **false** — Copilot is not a Claude wrapper, so Claude-only surfaces (`--channels`, `--extra-arg`, skill injection, MCP hook paths) stay off. This ships the foundation; deeper hook-based session-id capture (analogous to `internal/session/gemini.go` analytics) will land as a follow-up once Copilot CLI's on-disk session format stabilises. Tests: `TestCopilotOptions_{ToolName,ToArgs,MarshalUnmarshalRoundtrip}`, `TestNewCopilotOptions_{Defaults,WithConfig}`, `TestUnmarshalCopilotOptions_WrongTool`, `TestIsClaudeCompatible_CopilotNotCompatible`, `TestGetToolIcon_Copilot`, `TestGetCustomToolNames_CopilotIsBuiltin`, `TestNewInstanceWithTool_Copilot` in `internal/session/copilot_test.go`; `TestDetectToolFromCommand_Copilot`, `TestDefaultRawPatterns_Copilot` in `internal/tmux/copilot_test.go`; `TestDetectTool_Copilot` in `cmd/agent-deck/copilot_detect_test.go`.
+
 ## [1.7.25] - 2026-04-18
 
 ### Added

--- a/cmd/agent-deck/copilot_detect_test.go
+++ b/cmd/agent-deck/copilot_detect_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+// Issue #556: `agent-deck add -c copilot .` must set Instance.Tool = "copilot"
+// instead of falling back to "shell". This is the CLI-layer detection (not
+// tmux's detectToolFromCommand) — it lives in main.go.
+
+func TestDetectTool_Copilot(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"bare", "copilot", "copilot"},
+		{"with flags", "copilot --resume", "copilot"},
+		{"uppercase", "Copilot", "copilot"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got != tt.want {
+				t.Errorf("detectTool(%q) = %q, want %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.25" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.26" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2702,6 +2702,8 @@ func detectTool(cmd string) string {
 		return "gemini"
 	case strings.Contains(cmd, "codex"):
 		return "codex"
+	case strings.Contains(cmd, "copilot"):
+		return "copilot"
 	case strings.Contains(cmd, "cursor"):
 		return "cursor"
 	default:

--- a/internal/session/copilot_test.go
+++ b/internal/session/copilot_test.go
@@ -1,0 +1,168 @@
+package session
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// Issue #556: GitHub Copilot CLI support.
+// These tests define the Tool="copilot" contract: options marshalling,
+// ToArgs for new/resume, factory from config, and the basic identity gates
+// (icon, IsClaudeCompatible, builtin-name filter).
+//
+// Model: https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli
+// Binary: `copilot` (npm @github/copilot), interactive REPL with --resume
+// picker for prior sessions.
+
+func TestCopilotOptions_ToolName(t *testing.T) {
+	opts := &CopilotOptions{}
+	if got := opts.ToolName(); got != "copilot" {
+		t.Errorf("CopilotOptions.ToolName() = %q, want %q", got, "copilot")
+	}
+}
+
+func TestCopilotOptions_ToArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     CopilotOptions
+		expected []string
+	}{
+		{
+			name:     "default new session - no args",
+			opts:     CopilotOptions{SessionMode: "new"},
+			expected: nil,
+		},
+		{
+			name:     "empty session mode - no args",
+			opts:     CopilotOptions{},
+			expected: nil,
+		},
+		{
+			name:     "resume without id - picker mode",
+			opts:     CopilotOptions{SessionMode: "resume"},
+			expected: []string{"--resume"},
+		},
+		{
+			name:     "resume with id",
+			opts:     CopilotOptions{SessionMode: "resume", ResumeSessionID: "abc123"},
+			expected: []string{"--resume", "abc123"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.opts.ToArgs()
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("ToArgs() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewCopilotOptions_Defaults(t *testing.T) {
+	opts := NewCopilotOptions(nil)
+	if opts == nil {
+		t.Fatal("NewCopilotOptions(nil) returned nil")
+	}
+	if opts.SessionMode != "new" {
+		t.Errorf("default SessionMode = %q, want %q", opts.SessionMode, "new")
+	}
+}
+
+func TestNewCopilotOptions_WithConfig(t *testing.T) {
+	cfg := &UserConfig{
+		Copilot: CopilotSettings{EnvFile: "/tmp/copilot.env"},
+	}
+	opts := NewCopilotOptions(cfg)
+	if opts == nil {
+		t.Fatal("NewCopilotOptions returned nil")
+	}
+	if opts.SessionMode != "new" {
+		t.Errorf("SessionMode = %q, want %q", opts.SessionMode, "new")
+	}
+}
+
+func TestCopilotOptions_MarshalUnmarshalRoundtrip(t *testing.T) {
+	orig := &CopilotOptions{SessionMode: "resume", ResumeSessionID: "sess-42"}
+
+	data, err := MarshalToolOptions(orig)
+	if err != nil {
+		t.Fatalf("MarshalToolOptions: %v", err)
+	}
+
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		t.Fatalf("unmarshal wrapper: %v", err)
+	}
+	if wrapper.Tool != "copilot" {
+		t.Errorf("wrapper.Tool = %q, want %q", wrapper.Tool, "copilot")
+	}
+
+	got, err := UnmarshalCopilotOptions(data)
+	if err != nil {
+		t.Fatalf("UnmarshalCopilotOptions: %v", err)
+	}
+	if got == nil {
+		t.Fatal("UnmarshalCopilotOptions returned nil")
+	}
+	if got.SessionMode != "resume" || got.ResumeSessionID != "sess-42" {
+		t.Errorf("roundtrip mismatch: %+v", got)
+	}
+}
+
+func TestUnmarshalCopilotOptions_WrongTool(t *testing.T) {
+	raw := json.RawMessage(`{"tool":"codex","options":{}}`)
+	got, err := UnmarshalCopilotOptions(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalCopilotOptions: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for wrong tool, got %+v", got)
+	}
+}
+
+func TestIsClaudeCompatible_CopilotNotCompatible(t *testing.T) {
+	if IsClaudeCompatible("copilot") {
+		t.Error("IsClaudeCompatible(\"copilot\") must be false")
+	}
+}
+
+func TestGetToolIcon_Copilot(t *testing.T) {
+	icon := GetToolIcon("copilot")
+	if icon == "" {
+		t.Error("GetToolIcon(\"copilot\") returned empty")
+	}
+	if icon == GetToolIcon("shell") {
+		t.Errorf("GetToolIcon(\"copilot\") = %q equals shell fallback (want a distinct icon)", icon)
+	}
+}
+
+func TestGetCustomToolNames_CopilotIsBuiltin(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+
+	userConfigCache = &UserConfig{
+		Tools: map[string]ToolDef{
+			"copilot":    {Command: "copilot"},
+			"my-wrapper": {Command: "claude"},
+		},
+	}
+
+	names := GetCustomToolNames()
+	for _, n := range names {
+		if n == "copilot" {
+			t.Errorf("GetCustomToolNames() returned %q as custom; copilot is built-in", n)
+		}
+	}
+}
+
+func TestNewInstanceWithTool_Copilot(t *testing.T) {
+	inst := NewInstanceWithTool("copilot-test", "/tmp/copilot-test-proj", "copilot")
+	if inst == nil {
+		t.Fatal("NewInstanceWithTool returned nil")
+	}
+	if inst.Tool != "copilot" {
+		t.Errorf("inst.Tool = %q, want %q", inst.Tool, "copilot")
+	}
+}

--- a/internal/session/tooloptions.go
+++ b/internal/session/tooloptions.go
@@ -282,6 +282,69 @@ func UnmarshalOpenCodeOptions(data json.RawMessage) (*OpenCodeOptions, error) {
 	return &opts, nil
 }
 
+// CopilotOptions holds launch options for GitHub Copilot CLI sessions
+// (the standalone `copilot` binary from @github/copilot, not the older
+// `gh copilot` extension).
+type CopilotOptions struct {
+	// SessionMode: "new" (default) or "resume" (--resume).
+	// When "resume" and ResumeSessionID is empty, Copilot CLI shows its
+	// session picker; when set, agent-deck passes the ID through as
+	// --resume <id>.
+	SessionMode string `json:"session_mode,omitempty"`
+	// ResumeSessionID is the Copilot session ID for --resume (only used
+	// when SessionMode == "resume").
+	ResumeSessionID string `json:"resume_session_id,omitempty"`
+}
+
+// ToolName returns "copilot"
+func (o *CopilotOptions) ToolName() string {
+	return "copilot"
+}
+
+// ToArgs returns command-line arguments based on options
+func (o *CopilotOptions) ToArgs() []string {
+	var args []string
+	if o.SessionMode == "resume" {
+		args = append(args, "--resume")
+		if o.ResumeSessionID != "" {
+			args = append(args, o.ResumeSessionID)
+		}
+	}
+	return args
+}
+
+// NewCopilotOptions creates CopilotOptions with defaults from config
+func NewCopilotOptions(config *UserConfig) *CopilotOptions {
+	opts := &CopilotOptions{SessionMode: "new"}
+	// No config-sourced defaults today; the struct exists so future
+	// settings (e.g., default model, auto-approve) have a home.
+	_ = config
+	return opts
+}
+
+// UnmarshalCopilotOptions deserializes CopilotOptions from JSON wrapper
+func UnmarshalCopilotOptions(data json.RawMessage) (*CopilotOptions, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, err
+	}
+
+	if wrapper.Tool != "copilot" {
+		return nil, nil
+	}
+
+	var opts CopilotOptions
+	if err := json.Unmarshal(wrapper.Options, &opts); err != nil {
+		return nil, err
+	}
+
+	return &opts, nil
+}
+
 // StripResumeFields removes session-specific fields (resume_session_id,
 // session_mode) from serialized ToolOptionsJSON so that a new session
 // inheriting another session's settings starts fresh instead of resuming

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -91,6 +91,9 @@ type UserConfig struct {
 	// Codex defines Codex CLI integration settings
 	Codex CodexSettings `toml:"codex"`
 
+	// Copilot defines GitHub Copilot CLI integration settings (Issue #556)
+	Copilot CopilotSettings `toml:"copilot"`
+
 	// Worktree defines git worktree preferences
 	Worktree WorktreeSettings `toml:"worktree"`
 
@@ -753,6 +756,15 @@ type CodexSettings struct {
 	// YoloMode enables --yolo flag for Codex sessions (bypass approvals and sandbox)
 	// Default: false
 	YoloMode bool `toml:"yolo_mode"`
+}
+
+// CopilotSettings defines GitHub Copilot CLI configuration (Issue #556).
+// Binary: `copilot` from @github/copilot (GA 2026-02-25).
+// Doc: https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli
+type CopilotSettings struct {
+	// EnvFile is a .env file specific to Copilot sessions (sourced before
+	// the `copilot` command runs, like [gemini].env_file). Optional.
+	EnvFile string `toml:"env_file"`
 }
 
 // WorktreeSettings contains git worktree preferences.
@@ -1587,7 +1599,7 @@ func GetCustomToolNames() []string {
 
 	builtins := map[string]bool{
 		"claude": true, "gemini": true, "opencode": true,
-		"codex": true, "pi": true, "shell": true, "cursor": true, "aider": true,
+		"codex": true, "copilot": true, "pi": true, "shell": true, "cursor": true, "aider": true,
 	}
 
 	var names []string
@@ -1620,6 +1632,8 @@ func GetToolIcon(toolName string) string {
 		return "🌐"
 	case "codex":
 		return "💻"
+	case "copilot":
+		return "🐙"
 	case "pi":
 		return "π"
 	case "cursor":

--- a/internal/tmux/copilot_test.go
+++ b/internal/tmux/copilot_test.go
@@ -1,0 +1,39 @@
+package tmux
+
+import "testing"
+
+// Issue #556: tmux-layer detection + pattern defaults for GitHub Copilot CLI.
+
+func TestDetectToolFromCommand_Copilot(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"bare copilot", "copilot", "copilot"},
+		{"copilot with resume flag", "copilot --resume", "copilot"},
+		{"copilot via npx", "npx @github/copilot", "copilot"},
+		{"uppercase binary", "COPILOT", "copilot"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromCommand(tt.command); got != tt.want {
+				t.Fatalf("detectToolFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultRawPatterns_Copilot(t *testing.T) {
+	raw := DefaultRawPatterns("copilot")
+	if raw == nil {
+		t.Fatal("expected non-nil RawPatterns for copilot")
+	}
+	if len(raw.BusyPatterns) == 0 {
+		t.Error("copilot should have busy patterns")
+	}
+	if len(raw.PromptPatterns) == 0 {
+		t.Error("copilot should have prompt patterns")
+	}
+}

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -88,6 +88,22 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 			},
 			PromptPatterns: []string{`re:(?m)^\s*pi>\s*`},
 		}
+	case "copilot":
+		// GitHub Copilot CLI (the standalone `copilot` binary, Issue #556).
+		// Busy/prompt strings are conservative; can be tuned via user config
+		// overrides once more real-world transcripts are collected.
+		return &RawPatterns{
+			BusyPatterns: []string{
+				"esc to interrupt",
+				"ctrl+c to interrupt",
+				"thinking",
+			},
+			PromptPatterns: []string{
+				"How can I help",
+				`re:(?m)^\s*copilot>\s*`,
+				`re:(?m)^\s*›\s`,
+			},
+		}
 	case "shell":
 		return &RawPatterns{
 			PromptPatterns: []string{"$ ", "# ", "% "},

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -512,7 +512,7 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "pi"}
+var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "pi"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"claude": {
@@ -532,6 +532,13 @@ var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"codex": {
 		regexp.MustCompile(`(?i)codex`),
 		regexp.MustCompile(`(?i)openai`),
+	},
+	"copilot": {
+		// GitHub Copilot CLI (the `copilot` binary from @github/copilot,
+		// NOT the older `gh copilot` shell-suggestion extension). Issue #556.
+		regexp.MustCompile(`(?i)\bgithub\s+copilot\b`),
+		regexp.MustCompile(`(?i)\bcopilot\s+cli\b`),
+		regexp.MustCompile(`(?i)^copilot>\s*`),
 	},
 	"pi": {
 		regexp.MustCompile(`(?mi)^\s*pi>\s*`),
@@ -558,6 +565,8 @@ func detectToolFromCommand(command string) string {
 			return "opencode"
 		case "codex":
 			return "codex"
+		case "copilot":
+			return "copilot"
 		case "pi":
 			return "pi"
 		}
@@ -572,6 +581,8 @@ func detectToolFromCommand(command string) string {
 		return "opencode"
 	case strings.Contains(cmdLower, "codex"):
 		return "codex"
+	case strings.Contains(cmdLower, "copilot") || strings.Contains(cmdLower, "@github/copilot"):
+		return "copilot"
 	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
 		return "pi"
 	default:


### PR DESCRIPTION
Closes #556.

## Summary
- Promotes the standalone `copilot` binary (`@github/copilot`, GA 2026-02-25) from a shell-fallback session to a first-class agent-deck tool alongside `claude`, `gemini`, `codex`, and `opencode`.
- Adds `CopilotOptions{SessionMode, ResumeSessionID}` (emits `--resume` picker or `--resume <id>`), `CopilotSettings{EnvFile}` TOML block, 🐙 icon, tmux command + content detection, CLI-layer `detectTool` recognition, and the built-in-name gate so user-defined `[tools.copilot]` can't shadow the built-in.
- `IsClaudeCompatible("copilot")` stays **false** deliberately — Copilot is not a Claude wrapper, so Claude-only surfaces (`--channels`, `--extra-arg`, skill injection, MCP hook paths) correctly stay off.
- Ships the foundation; deeper hook-based session-id capture (analogous to `internal/session/gemini.go` analytics) will land as a follow-up once Copilot CLI's on-disk session format stabilises.

## Scope per issue thread
Ashesh asked the reporter which Copilot surface they wanted. The concrete scope from that conversation:

- Tool detection so `agent-deck add -c copilot .` lands on `Tool="copilot"` instead of `shell` ✅
- `--session-id` / `--resume` equivalents ✅ (via `CopilotOptions`)
- Per-tool config (`[copilot]` block in `config.toml`) ✅

## Test plan
- [x] `go test ./... -race -count=1` (full suite locally, clean except for pre-existing `TestWatcherEventDedup` SQLITE_BUSY flake in `internal/statedb` — passes in isolation 3x, unrelated to this PR).
- [x] Persistence mandate gate: `go test -run TestPersistence_ ./internal/session/... -race -count=1` passes.
- [x] Feedback mandate gate: `Feedback|Sender_` tests pass.
- [x] Watcher mandate: `internal/watcher/...` passes; `cmd/agent-deck/... -run Watcher` passes.
- [x] Release tests yaml-lint: 7 new `v1726-issue556-*` entries validated by pre-push `release-tests-yaml-lint`.
- [x] 10 copilot-specific tests pass (`TestCopilotOptions_*`, `TestNewCopilotOptions_*`, `TestUnmarshal*`, `TestIsClaudeCompatible_CopilotNotCompatible`, `TestGetToolIcon_Copilot`, `TestGetCustomToolNames_CopilotIsBuiltin`, `TestNewInstanceWithTool_Copilot`, `TestDetectToolFromCommand_Copilot`, `TestDefaultRawPatterns_Copilot`, `TestDetectTool_Copilot`).
- [ ] Smoke-test on macOS: `agent-deck add -c copilot ~/scratch` → session spawns with `copilot` binary, TUI shows 🐙 + correct tool identity, `--resume` flag passes through.

## Risk / reversibility
Low. No existing tool's behavior changes. Copilot is inserted as a parallel case in detection/pattern/icon switches; nothing is rewritten. Revert = revert these two commits. The `IsClaudeCompatible` gate is explicitly false, so no claude-specific path accidentally fires for copilot sessions.

Committed by Ashesh Goplani