### PR TITLE
feat(v1.7.29): group change (#447) + session search (#483)

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -1477,3 +1477,69 @@ tests:
   run:
     command: go test ./internal/session/ -run TestIssue662_BuildClaudeResumeCommand_RetriesOnceOnSessionEndRace -count=1 -race -v
     expected: pass
+- id: v1729-issue447-movegroupto-tree
+  added: '2026-04-18'
+  task: v1729-issues-447-483
+  file: internal/session/groups_reorganize_test.go
+  test_name: TestMoveGroupTo_WithSubgroups
+  purpose: 'Issue #447 — GroupTree.MoveGroupTo reparents a group and rewrites every subgroup path (and session GroupPath) in one pass.'
+  source: github-issue-447
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestMoveGroupTo_WithSubgroups -count=1 -race -v
+    expected: pass
+- id: v1729-issue447-movegroupto-circular
+  added: '2026-04-18'
+  task: v1729-issues-447-483
+  file: internal/session/groups_reorganize_test.go
+  test_name: TestMoveGroupTo_Circular
+  purpose: 'Issue #447 — MoveGroupTo refuses circular moves (dest == source or a descendant) and leaves the tree intact.'
+  source: github-issue-447
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestMoveGroupTo_Circular -count=1 -race -v
+    expected: pass
+- id: v1729-issue447-group-change-cli-e2e
+  added: '2026-04-18'
+  task: v1729-issues-447-483
+  file: cmd/agent-deck/group_change_test.go
+  test_name: TestGroupChange_RootToSubgroup
+  purpose: 'Issue #447 — end-to-end CLI: group change reparents a group and the change survives SaveWithGroups + reload.'
+  source: github-issue-447
+  manual: false
+  run:
+    command: go test ./cmd/agent-deck/ -run TestGroupChange_RootToSubgroup -count=1 -race -v
+    expected: pass
+- id: v1729-issue447-group-change-rejects-circular
+  added: '2026-04-18'
+  task: v1729-issues-447-483
+  file: cmd/agent-deck/group_change_test.go
+  test_name: TestGroupChange_RejectsCircular
+  purpose: 'Issue #447 — CLI refuses circular moves with a non-zero exit and a diagnostic that names the reason.'
+  source: github-issue-447
+  manual: false
+  run:
+    command: go test ./cmd/agent-deck/ -run TestGroupChange_RejectsCircular -count=1 -race -v
+    expected: pass
+- id: v1729-issue483-session-search-content
+  added: '2026-04-18'
+  task: v1729-issues-447-483
+  file: cmd/agent-deck/session_search_test.go
+  test_name: TestSessionSearch_FindsMessageContent
+  purpose: 'Issue #483 — `agent-deck session search` matches on JSONL message content (not titles) and returns session_id + snippet + cwd. Locks the JSON output shape.'
+  source: github-issue-483
+  manual: false
+  run:
+    command: go test ./cmd/agent-deck/ -run TestSessionSearch_FindsMessageContent -count=1 -race -v
+    expected: pass
+- id: v1729-issue483-session-search-no-matches
+  added: '2026-04-18'
+  task: v1729-issues-447-483
+  file: cmd/agent-deck/session_search_test.go
+  test_name: TestSessionSearch_NoMatches
+  purpose: 'Issue #483 — exit 0 + empty results array when no sessions match; keeps `search | jq` pipelines clean.'
+  source: github-issue-483
+  manual: false
+  run:
+    command: go test ./cmd/agent-deck/ -run TestSessionSearch_NoMatches -count=1 -race -v
+    expected: pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.29] - 2026-04-19
+
+### Added
+- **`agent-deck group change <source> [<dest>]` — reparent an entire group subtree** (issue [#447](https://github.com/asheshgoplani/agent-deck/issues/447)): groups can now be moved as a unit, taking all their subgroups and sessions along. `group change personal/project1 work` places `project1` (and everything beneath it) under `work`, rewriting every descendant path in one atomic persist. Passing an empty destination (`group change work/project1 ""` or simply omitting it) promotes the group back to root level. The new `GroupTree.MoveGroupTo(source, destParent)` engine refuses circular moves (dest == source or a descendant of source), collisions at the target path, and moving the protected default group. Tests: `TestMoveGroupTo_{ToRoot,ToOtherParent,WithSubgroups,DestMissing,Circular,NoOpSameParent,Collision,SourceMissing,DefaultGroupForbidden}` in `internal/session/groups_reorganize_test.go`; `TestGroupChange_{RootToSubgroup,MoveToRoot,RejectsCircular}` end-to-end CLI in `cmd/agent-deck/group_change_test.go`. TUI group-move dialog is intentionally deferred to a follow-up — the CLI is the minimum shippable surface for the feature.
+- **`agent-deck session search <query>` — full-content search across Claude sessions** (issue [#483](https://github.com/asheshgoplani/agent-deck/issues/483)): the global-search index that powers the TUI's (currently-disabled) `G` overlay is now exposed as a first-class CLI so users can grep their conversation history from scripts and one-liners. Returns matching `SessionID`, `cwd`, and a 60-char snippet around the first match; `--json` emits a machine-readable shape with `{query, results, count}`. Flags: `--limit N` (default 20), `--days N` (default 30 — searches files modified in the last N days; `0` = all), `--tier {instant|balanced|auto}` (default auto — switches based on corpus size). Honours `CLAUDE_CONFIG_DIR` so per-profile `cdp` / `cdw` setups search the right tree. Test isolation fix (strip `CLAUDE_CONFIG_DIR=` from subprocess env in `runAgentDeck`) prevents CLI test suites from leaking into the developer's real `~/.claude`. Tests: `TestSessionSearch_{FindsMessageContent,EmptyQuery,NoMatches}` in `cmd/agent-deck/session_search_test.go`.
+
 ## [1.7.28] - 2026-04-19
 
 ### Added

--- a/cmd/agent-deck/channels_cmd_test.go
+++ b/cmd/agent-deck/channels_cmd_test.go
@@ -69,6 +69,12 @@ func runAgentDeck(
 		if strings.HasPrefix(kv, "HOME=") {
 			continue
 		}
+		// Strip CLAUDE_CONFIG_DIR so the test's isolated HOME/.claude is the
+		// effective Claude config dir — otherwise session search leaks into
+		// the developer's real ~/.claude/projects tree. Added for #483.
+		if strings.HasPrefix(kv, "CLAUDE_CONFIG_DIR=") {
+			continue
+		}
 		env = append(env, kv)
 	}
 	env = append(env,

--- a/cmd/agent-deck/group_change_test.go
+++ b/cmd/agent-deck/group_change_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGroupChange_RootToSubgroup exercises issue #447 via the CLI boundary.
+// Creates two sessions (one in groupA, one in groupB), then changes groupA
+// to become a subgroup of groupB. The session originally in groupA must
+// land under the new path groupB/groupA.
+func TestGroupChange_RootToSubgroup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a session in group "alpha".
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add", "-t", "sess-alpha", "-c", "claude", "-g", "alpha",
+		"--no-parent", "--json", projectDir,
+	)
+	if code != 0 {
+		t.Fatalf("add alpha failed (%d)\n%s\n%s", code, stdout, stderr)
+	}
+	var alphaResp struct{ ID string }
+	if err := json.Unmarshal([]byte(stdout), &alphaResp); err != nil {
+		t.Fatalf("unmarshal alpha: %v\n%s", err, stdout)
+	}
+
+	// Create a session in group "beta".
+	stdout, stderr, code = runAgentDeck(t, home,
+		"add", "-t", "sess-beta", "-c", "claude", "-g", "beta",
+		"--no-parent", "--json", projectDir,
+	)
+	if code != 0 {
+		t.Fatalf("add beta failed (%d)\n%s\n%s", code, stdout, stderr)
+	}
+
+	// Change alpha to be a subgroup of beta.
+	stdout, stderr, code = runAgentDeck(t, home, "group", "change", "alpha", "beta", "--json")
+	if code != 0 {
+		t.Fatalf("group change failed (%d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+
+	// Verify alpha session is now at path beta/alpha.
+	stdout, stderr, code = runAgentDeck(t, home, "session", "show", alphaResp.ID, "--json")
+	if code != 0 {
+		t.Fatalf("session show failed (%d)\n%s\n%s", code, stdout, stderr)
+	}
+	var showResp struct {
+		GroupPath string `json:"group"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &showResp); err != nil {
+		t.Fatalf("unmarshal show: %v\n%s", err, stdout)
+	}
+	if showResp.GroupPath != "beta/alpha" {
+		t.Fatalf("group_path = %q, want %q", showResp.GroupPath, "beta/alpha")
+	}
+
+	// Verify "group list" shows beta with alpha as a subgroup.
+	stdout, _, code = runAgentDeck(t, home, "group", "list", "--json")
+	if code != 0 {
+		t.Fatalf("group list failed (%d)\n%s", code, stdout)
+	}
+	if !strings.Contains(stdout, "beta/alpha") {
+		t.Errorf("expected 'beta/alpha' in group list output, got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, `"alpha"`) && !strings.Contains(stdout, "beta/alpha") {
+		t.Errorf("root-level 'alpha' should no longer exist")
+	}
+}
+
+// TestGroupChange_MoveToRoot verifies the "no dest" form moves a subgroup
+// back to root level.
+func TestGroupChange_MoveToRoot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a session inside parent/child.
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add", "-t", "nested", "-c", "claude", "-g", "parent/child",
+		"--no-parent", "--json", projectDir,
+	)
+	if code != 0 {
+		t.Fatalf("add nested failed (%d)\n%s\n%s", code, stdout, stderr)
+	}
+	var resp struct{ ID string }
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Move parent/child to root (no dest arg).
+	stdout, stderr, code = runAgentDeck(t, home, "group", "change", "parent/child", "--json")
+	if code != 0 {
+		t.Fatalf("group change to root failed (%d)\n%s\n%s", code, stdout, stderr)
+	}
+
+	// Verify the session's group_path is now just "child".
+	stdout, _, code = runAgentDeck(t, home, "session", "show", resp.ID, "--json")
+	if code != 0 {
+		t.Fatalf("session show failed (%d)\n%s", code, stdout)
+	}
+	var show struct {
+		GroupPath string `json:"group"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &show); err != nil {
+		t.Fatalf("unmarshal show: %v", err)
+	}
+	if show.GroupPath != "child" {
+		t.Fatalf("group_path = %q, want %q", show.GroupPath, "child")
+	}
+}
+
+// TestGroupChange_RejectsCircular ensures the CLI refuses circular moves.
+func TestGroupChange_RejectsCircular(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, code := runAgentDeck(t, home,
+		"add", "-t", "nested", "-c", "claude", "-g", "a/b",
+		"--no-parent", "--json", projectDir,
+	)
+	if code != 0 {
+		t.Fatalf("setup failed (%d)", code)
+	}
+
+	// Attempt to move 'a' under its own descendant 'a/b' — must fail.
+	_, stderr, code := runAgentDeck(t, home, "group", "change", "a", "a/b")
+	if code == 0 {
+		t.Fatal("expected non-zero exit for circular move")
+	}
+	if !strings.Contains(strings.ToLower(stderr), "circular") &&
+		!strings.Contains(strings.ToLower(stderr), "descendant") &&
+		!strings.Contains(strings.ToLower(stderr), "itself") {
+		t.Errorf("stderr should mention the circular/descendant reason, got: %s", stderr)
+	}
+}

--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -28,6 +28,8 @@ func handleGroup(profile string, args []string) {
 		handleGroupDelete(profile, args[1:])
 	case "move", "mv":
 		handleGroupMove(profile, args[1:])
+	case "change", "reparent":
+		handleGroupChange(profile, args[1:])
 	case "reorder", "sort":
 		handleGroupReorder(profile, args[1:])
 	case "help", "--help", "-h":
@@ -51,6 +53,7 @@ func printGroupHelp() {
 	fmt.Println("  update <name>     Update group settings")
 	fmt.Println("  delete <name>     Delete a group")
 	fmt.Println("  move <id> <group> Move session to a different group")
+	fmt.Println("  change <group> [<dest>] Reparent a group (empty dest = move to root)")
 	fmt.Println("  reorder <name>    Reorder a group (--up, --down, --position N)")
 	fmt.Println()
 	fmt.Println("Examples:")
@@ -62,6 +65,8 @@ func printGroupHelp() {
 	fmt.Println("  agent-deck group delete work --force")
 	fmt.Println("  agent-deck group move my-project work/frontend")
 	fmt.Println("  agent-deck group move my-project \"\"          # Move to root")
+	fmt.Println("  agent-deck group change project1 work         # Move group 'project1' under 'work'")
+	fmt.Println("  agent-deck group change work/project1          # Move 'work/project1' to root")
 	fmt.Println("  agent-deck group reorder mobile --up")
 	fmt.Println("  agent-deck group reorder mobile --down")
 	fmt.Println("  agent-deck group reorder mobile --position 0")
@@ -1027,4 +1032,136 @@ func reorderGroupArgs(args []string) []string {
 
 	// Return flags first, then positional args
 	return append(flags, positional...)
+}
+
+// handleGroupChange implements issue #447: reparent an entire group (and its
+// subgroups + sessions) under a new parent, or promote it to root when dest
+// is omitted/empty. Reuses GroupTree.MoveGroupTo for the in-memory mutation
+// and persists via storage.SaveAll.
+func handleGroupChange(profile string, args []string) {
+	fs := flag.NewFlagSet("group change", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck group change <source> [<dest>]")
+		fmt.Println()
+		fmt.Println("Reparent a group (and its subgroups/sessions) under <dest>.")
+		fmt.Println("Omit <dest> or pass \"\" / root to promote the group to root.")
+		fmt.Println()
+		fmt.Println("Arguments:")
+		fmt.Println("  <source>   Full path of the group to move (e.g. personal/project1)")
+		fmt.Println("  <dest>     Target parent path (empty = root)")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck group change project1 work")
+		fmt.Println("  agent-deck group change personal/project1 work")
+		fmt.Println("  agent-deck group change work/project1              # Move to root")
+		fmt.Println("  agent-deck group change work/project1 \"\"          # Move to root")
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	out := NewCLIOutput(*jsonOutput, *quiet || *quietShort)
+
+	source := fs.Arg(0)
+	if source == "" {
+		out.Error("source group path is required", ErrCodeNotFound)
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	dest := ""
+	if fs.NArg() >= 2 {
+		dest = fs.Arg(1)
+	}
+	// Normalize "root" / "/" to empty string (root level).
+	if dest == "root" || dest == "/" {
+		dest = ""
+	}
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to initialize storage: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	instances, groups, err := storage.LoadWithGroups()
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to load sessions: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+
+	// Resolve source path (exact or case-insensitive).
+	sourcePath := source
+	if _, ok := groupTree.Groups[sourcePath]; !ok {
+		low := strings.ToLower(sourcePath)
+		matched := false
+		for path := range groupTree.Groups {
+			if strings.ToLower(path) == low {
+				sourcePath = path
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			out.Error(fmt.Sprintf("source group %q not found", source), ErrCodeNotFound)
+			os.Exit(2)
+		}
+	}
+
+	// Resolve dest path if non-empty (exact or case-insensitive).
+	destPath := dest
+	if destPath != "" {
+		if _, ok := groupTree.Groups[destPath]; !ok {
+			low := strings.ToLower(destPath)
+			matched := false
+			for path := range groupTree.Groups {
+				if strings.ToLower(path) == low {
+					destPath = path
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				out.Error(fmt.Sprintf("destination group %q not found", dest), ErrCodeNotFound)
+				os.Exit(2)
+			}
+		}
+	}
+
+	if err := groupTree.MoveGroupTo(sourcePath, destPath); err != nil {
+		// Distinguish circular errors for a friendlier exit message.
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	// Compute the new path for output.
+	baseName := sourcePath
+	if idx := strings.LastIndex(sourcePath, "/"); idx >= 0 {
+		baseName = sourcePath[idx+1:]
+	}
+	newPath := baseName
+	if destPath != "" {
+		newPath = destPath + "/" + baseName
+	}
+
+	// Persist.
+	if err := storage.SaveWithGroups(groupTree.GetAllInstances(), groupTree); err != nil {
+		out.Error(fmt.Sprintf("failed to save: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	out.Success(fmt.Sprintf("Moved group %q to %q", sourcePath, newPath), map[string]interface{}{
+		"from": sourcePath,
+		"to":   newPath,
+	})
 }

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.28" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.29" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -55,6 +55,8 @@ func handleSession(profile string, args []string) {
 		handleSessionSend(profile, args[1:])
 	case "output":
 		handleSessionOutput(profile, args[1:])
+	case "search":
+		handleSessionSearch(profile, args[1:])
 	case "help", "--help", "-h":
 		printSessionHelp()
 	default:
@@ -83,6 +85,7 @@ func printSessionHelp() {
 	fmt.Println("  move <id> <path>        Move session to a new path (migrates Claude history)")
 	fmt.Println("  send <id> <message>     Send a message to a running session")
 	fmt.Println("  output <id>             Get the last response from a session")
+	fmt.Println("  search <query>          Search message content across Claude sessions")
 	fmt.Println("  set-parent <id> <parent>  Link session as sub-session of parent")
 	fmt.Println("  unset-parent <id>       Remove sub-session link")
 	fmt.Println()
@@ -2311,4 +2314,130 @@ func isValidSessionColor(v string) bool {
 		n = n*10 + int(c-'0')
 	}
 	return n >= 0 && n <= 255
+}
+
+// handleSessionSearch implements issue #483 — search across Claude session
+// message content (not just titles). Wraps the internal global-search index
+// behind a CLI surface so users can find past prompts / responses without
+// dropping into the TUI.
+func handleSessionSearch(profile string, args []string) {
+	_ = profile // reserved: future per-profile claudeDir lookup
+	fs := flag.NewFlagSet("session search", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	limit := fs.Int("limit", 20, "Maximum number of results to return")
+	recentDays := fs.Int("days", 30, "Only search sessions modified within the last N days (0 = all)")
+	tierFlag := fs.String("tier", "auto", "Index tier: instant, balanced, auto")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session search <query> [options]")
+		fmt.Println()
+		fmt.Println("Search message content across all Claude sessions.")
+		fmt.Println()
+		fmt.Println("Arguments:")
+		fmt.Println("  <query>   Free-text query (case-insensitive substring match)")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck session search \"MCP server\"")
+		fmt.Println("  agent-deck session search authentication --json")
+		fmt.Println("  agent-deck session search \"database migration\" --limit 5")
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	out := NewCLIOutput(*jsonOutput, *quiet || *quietShort)
+
+	query := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	if query == "" {
+		out.Error("query is required", ErrCodeNotFound)
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	claudeDir := session.GetClaudeConfigDir()
+	cfg := session.GlobalSearchSettings{
+		Enabled:        true,
+		Tier:           *tierFlag,
+		MemoryLimitMB:  100,
+		RecentDays:     *recentDays,
+		IndexRateLimit: 200,
+	}
+	index, err := session.NewGlobalSearchIndex(claudeDir, cfg)
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to initialize search index: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+	if index == nil {
+		out.Error("search index is disabled", ErrCodeNotFound)
+		os.Exit(1)
+	}
+	defer index.Close()
+
+	// Wait for the background initialLoad to finish. The fs.Size-based tier
+	// detector returns immediately; content population is async. Poll up to
+	// ~3s — enough for most ~.claude/projects but bounded for CLI latency.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !index.IsLoading() {
+			break
+		}
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	results := index.Search(query)
+	if *limit > 0 && len(results) > *limit {
+		results = results[:*limit]
+	}
+
+	type hitJSON struct {
+		SessionID string `json:"session_id"`
+		Snippet   string `json:"snippet"`
+		CWD       string `json:"cwd"`
+		Summary   string `json:"summary,omitempty"`
+		FilePath  string `json:"file_path,omitempty"`
+	}
+
+	hits := make([]hitJSON, 0, len(results))
+	for _, r := range results {
+		if r == nil || r.Entry == nil {
+			continue
+		}
+		hits = append(hits, hitJSON{
+			SessionID: r.Entry.SessionID,
+			Snippet:   r.Snippet,
+			CWD:       r.Entry.CWD,
+			Summary:   r.Entry.Summary,
+			FilePath:  r.Entry.FilePath,
+		})
+	}
+
+	if *jsonOutput {
+		out.Success("", map[string]interface{}{
+			"query":   query,
+			"results": hits,
+			"count":   len(hits),
+		})
+		return
+	}
+
+	if len(hits) == 0 {
+		fmt.Printf("No sessions matched %q\n", query)
+		return
+	}
+	fmt.Printf("Found %d match(es) for %q:\n", len(hits), query)
+	for i, h := range hits {
+		fmt.Printf("%d. %s\n", i+1, h.SessionID)
+		if h.CWD != "" {
+			fmt.Printf("   cwd: %s\n", h.CWD)
+		}
+		if h.Snippet != "" {
+			fmt.Printf("   %s\n", h.Snippet)
+		}
+	}
 }

--- a/cmd/agent-deck/session_search_test.go
+++ b/cmd/agent-deck/session_search_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSessionSearch_FindsMessageContent exercises issue #483 via the CLI.
+// Seeds the isolated HOME with a Claude projects directory containing JSONL
+// files that agent-deck's global-search index will discover, then invokes
+// `session search <query>` and expects matching sessions + snippets.
+func TestSessionSearch_FindsMessageContent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+
+	// Seed ~/.claude/projects/<proj>/<uuid>.jsonl — the index walks this tree.
+	projectDir := filepath.Join(home, ".claude", "projects", "-Users-test-project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jsonl := `{"sessionId":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","type":"user","message":{"role":"user","content":"implement MCP server for observability metrics"},"cwd":"/Users/test/project"}
+{"sessionId":"a1b2c3d4-e5f6-7890-abcd-ef1234567890","type":"assistant","message":{"role":"assistant","content":"I'll scaffold an MCP server that exposes Prometheus-style metrics."}}`
+	if err := os.WriteFile(
+		filepath.Join(projectDir, "a1b2c3d4-e5f6-7890-abcd-ef1234567890.jsonl"),
+		[]byte(jsonl), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Control session that must NOT match.
+	jsonl2 := `{"sessionId":"b2c3d4e5-f6a7-8901-bcde-f23456789012","type":"user","message":{"role":"user","content":"refactor the login widget styles"},"cwd":"/Users/test/project"}`
+	if err := os.WriteFile(
+		filepath.Join(projectDir, "b2c3d4e5-f6a7-8901-bcde-f23456789012.jsonl"),
+		[]byte(jsonl2), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Invoke `session search observability --json`.
+	stdout, stderr, code := runAgentDeck(t, home, "session", "search", "observability", "--json")
+	if code != 0 {
+		t.Fatalf("session search failed (%d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+
+	// Expected JSON: {"query":"observability","results":[{"session_id":...,"snippet":...,"cwd":...}]}
+	var resp struct {
+		Query   string `json:"query"`
+		Results []struct {
+			SessionID string `json:"session_id"`
+			Snippet   string `json:"snippet"`
+			CWD       string `json:"cwd"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v\nstdout: %s", err, stdout)
+	}
+	if resp.Query != "observability" {
+		t.Errorf("query = %q, want %q", resp.Query, "observability")
+	}
+	if len(resp.Results) != 1 {
+		t.Fatalf("want 1 result, got %d: %+v", len(resp.Results), resp.Results)
+	}
+	r := resp.Results[0]
+	if r.SessionID != "a1b2c3d4-e5f6-7890-abcd-ef1234567890" {
+		t.Errorf("session_id = %q, want the matching UUID", r.SessionID)
+	}
+	if !strings.Contains(strings.ToLower(r.Snippet), "observability") {
+		t.Errorf("snippet %q should contain the query term", r.Snippet)
+	}
+	if r.CWD != "/Users/test/project" {
+		t.Errorf("cwd = %q, want %q", r.CWD, "/Users/test/project")
+	}
+}
+
+// TestSessionSearch_EmptyQuery requires a query argument.
+func TestSessionSearch_EmptyQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+
+	_, stderr, code := runAgentDeck(t, home, "session", "search")
+	if code == 0 {
+		t.Fatal("expected non-zero exit for empty query")
+	}
+	if !strings.Contains(strings.ToLower(stderr), "query") &&
+		!strings.Contains(strings.ToLower(stderr), "usage") {
+		t.Errorf("stderr should mention query / usage, got: %s", stderr)
+	}
+}
+
+// TestSessionSearch_NoMatches returns an empty results array, exit 0.
+func TestSessionSearch_NoMatches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, ".claude", "projects", "-Users-test-project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Empty projects directory — the index will come up with zero entries.
+
+	stdout, stderr, code := runAgentDeck(t, home, "session", "search", "xyzzy-no-match", "--json")
+	if code != 0 {
+		t.Fatalf("session search no-matches failed (%d)\nstderr: %s", code, stderr)
+	}
+	var resp struct {
+		Query   string        `json:"query"`
+		Results []interface{} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, stdout)
+	}
+	if len(resp.Results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(resp.Results))
+	}
+}

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -791,6 +792,92 @@ func (t *GroupTree) RenameGroup(oldPath, newName string) {
 	t.Expanded[newPath] = group.Expanded
 
 	t.rebuildGroupList()
+}
+
+// MoveGroupTo reparents a group (and its entire subtree) under destParentPath.
+// An empty destParentPath promotes the group to root level. Returns an error
+// for: unknown source, source == DefaultGroupPath, unknown destParent,
+// destParent == source or its descendant (circular), or a collision at the
+// target path. Same-parent call is a no-op.
+//
+// This is the engine behind the #447 "group change" CLI / TUI.
+func (t *GroupTree) MoveGroupTo(sourcePath, destParentPath string) error {
+	if sourcePath == "" {
+		return fmt.Errorf("source group path is required")
+	}
+	if sourcePath == DefaultGroupPath {
+		return fmt.Errorf("the default group %q cannot be moved", DefaultGroupPath)
+	}
+
+	src, ok := t.Groups[sourcePath]
+	if !ok {
+		return fmt.Errorf("source group %q does not exist", sourcePath)
+	}
+
+	if destParentPath != "" {
+		if _, ok := t.Groups[destParentPath]; !ok {
+			return fmt.Errorf("destination parent group %q does not exist", destParentPath)
+		}
+	}
+
+	if destParentPath == sourcePath ||
+		strings.HasPrefix(destParentPath, sourcePath+"/") {
+		return fmt.Errorf("cannot move %q under itself or its descendant %q", sourcePath, destParentPath)
+	}
+
+	baseName := sourcePath
+	if idx := strings.LastIndex(sourcePath, "/"); idx >= 0 {
+		baseName = sourcePath[idx+1:]
+	}
+	currentParent := getParentPath(sourcePath)
+	if currentParent == destParentPath {
+		return nil
+	}
+
+	newPath := baseName
+	if destParentPath != "" {
+		newPath = destParentPath + "/" + baseName
+	}
+	if _, collide := t.Groups[newPath]; collide {
+		return fmt.Errorf("target path %q already exists", newPath)
+	}
+
+	subgroupsToRewrite := make(map[string]*Group)
+	for path, g := range t.Groups {
+		if strings.HasPrefix(path, sourcePath+"/") {
+			newSubPath := newPath + path[len(sourcePath):]
+			if _, collide := t.Groups[newSubPath]; collide {
+				return fmt.Errorf("target subpath %q already exists", newSubPath)
+			}
+			for _, sess := range g.Sessions {
+				sess.GroupPath = newSubPath
+			}
+			g.Path = newSubPath
+			subgroupsToRewrite[path] = g
+		}
+	}
+
+	for _, sess := range src.Sessions {
+		sess.GroupPath = newPath
+	}
+	src.Path = newPath
+
+	delete(t.Groups, sourcePath)
+	t.Groups[newPath] = src
+	expanded := t.Expanded[sourcePath]
+	delete(t.Expanded, sourcePath)
+	t.Expanded[newPath] = expanded
+
+	for oldSubPath, g := range subgroupsToRewrite {
+		delete(t.Groups, oldSubPath)
+		t.Groups[g.Path] = g
+		e := t.Expanded[oldSubPath]
+		delete(t.Expanded, oldSubPath)
+		t.Expanded[g.Path] = e
+	}
+
+	t.rebuildGroupList()
+	return nil
 }
 
 // DeleteGroup deletes a group, all its subgroups, and moves all sessions to default

--- a/internal/session/groups_reorganize_test.go
+++ b/internal/session/groups_reorganize_test.go
@@ -1,0 +1,175 @@
+package session
+
+import "testing"
+
+// Tests for issue #447 — MoveGroupTo reparents a group under a new parent
+// (or to root when destParentPath == "").
+
+// TestMoveGroupTo_ToRoot moves a nested group to root and verifies paths.
+func TestMoveGroupTo_ToRoot(t *testing.T) {
+	tree := NewGroupTree([]*Instance{})
+	tree.CreateGroup("Parent")
+	tree.CreateSubgroup("Parent", "Child")
+
+	sess := &Instance{ID: "s1", GroupPath: "Parent/Child"}
+	tree.Groups["Parent/Child"].Sessions = []*Instance{sess}
+
+	if err := tree.MoveGroupTo("Parent/Child", ""); err != nil {
+		t.Fatalf("MoveGroupTo returned error: %v", err)
+	}
+
+	if tree.Groups["Parent/Child"] != nil {
+		t.Error("old path Parent/Child should no longer exist")
+	}
+	child := tree.Groups["Child"]
+	if child == nil {
+		t.Fatal("expected group at new path 'Child'")
+	}
+	if child.Path != "Child" {
+		t.Errorf("group.Path = %q, want %q", child.Path, "Child")
+	}
+	if sess.GroupPath != "Child" {
+		t.Errorf("session GroupPath = %q, want %q", sess.GroupPath, "Child")
+	}
+	if tree.Groups["Parent"] == nil {
+		t.Error("parent group Parent should still exist")
+	}
+}
+
+// TestMoveGroupTo_ToOtherParent moves one root group to become a subgroup of another.
+func TestMoveGroupTo_ToOtherParent(t *testing.T) {
+	tree := NewGroupTree([]*Instance{})
+	tree.CreateGroup("personal")
+	tree.CreateSubgroup("personal", "project1")
+	tree.CreateGroup("work")
+
+	sess := &Instance{ID: "s1", GroupPath: "personal/project1"}
+	tree.Groups["personal/project1"].Sessions = []*Instance{sess}
+
+	if err := tree.MoveGroupTo("personal/project1", "work"); err != nil {
+		t.Fatalf("MoveGroupTo returned error: %v", err)
+	}
+
+	if tree.Groups["personal/project1"] != nil {
+		t.Error("old path personal/project1 should not exist")
+	}
+	moved := tree.Groups["work/project1"]
+	if moved == nil {
+		t.Fatal("expected group at new path 'work/project1'")
+	}
+	if moved.Path != "work/project1" {
+		t.Errorf("group.Path = %q, want %q", moved.Path, "work/project1")
+	}
+	if sess.GroupPath != "work/project1" {
+		t.Errorf("session GroupPath = %q, want %q", sess.GroupPath, "work/project1")
+	}
+	if tree.Groups["personal"] == nil {
+		t.Error("personal group should still exist (empty, but present)")
+	}
+}
+
+// TestMoveGroupTo_WithSubgroups verifies that subgroups and their sessions
+// follow the moved group and all get their paths rewritten.
+func TestMoveGroupTo_WithSubgroups(t *testing.T) {
+	tree := NewGroupTree([]*Instance{})
+	tree.CreateGroup("personal")
+	tree.CreateSubgroup("personal", "project1")
+	tree.CreateSubgroup("personal/project1", "backend")
+	tree.CreateGroup("work")
+
+	sA := &Instance{ID: "a", GroupPath: "personal/project1"}
+	sB := &Instance{ID: "b", GroupPath: "personal/project1/backend"}
+	tree.Groups["personal/project1"].Sessions = []*Instance{sA}
+	tree.Groups["personal/project1/backend"].Sessions = []*Instance{sB}
+
+	if err := tree.MoveGroupTo("personal/project1", "work"); err != nil {
+		t.Fatalf("MoveGroupTo returned error: %v", err)
+	}
+
+	if tree.Groups["personal/project1"] != nil || tree.Groups["personal/project1/backend"] != nil {
+		t.Error("old subgroup paths should be gone")
+	}
+	if tree.Groups["work/project1"] == nil || tree.Groups["work/project1/backend"] == nil {
+		t.Fatal("new subgroup paths should exist")
+	}
+	if sA.GroupPath != "work/project1" {
+		t.Errorf("session A GroupPath = %q, want %q", sA.GroupPath, "work/project1")
+	}
+	if sB.GroupPath != "work/project1/backend" {
+		t.Errorf("session B GroupPath = %q, want %q", sB.GroupPath, "work/project1/backend")
+	}
+}
+
+// TestMoveGroupTo_DestMissing returns an error when destination parent doesn't exist
+// (and is not root/empty).
+func TestMoveGroupTo_DestMissing(t *testing.T) {
+	tree := NewGroupTree([]*Instance{})
+	tree.CreateGroup("personal")
+
+	if err := tree.MoveGroupTo("personal", "nonexistent"); err == nil {
+		t.Error("expected error when destination parent doesn't exist")
+	}
+}
+
+// TestMoveGroupTo_Circular refuses to move a group under itself or a descendant.
+func TestMoveGroupTo_Circular(t *testing.T) {
+	tree := NewGroupTree([]*Instance{})
+	tree.CreateGroup("a")
+	tree.CreateSubgroup("a", "b")
+	tree.CreateSubgroup("a/b", "c")
+
+	if err := tree.MoveGroupTo("a", "a/b"); err == nil {
+		t.Error("expected error moving 'a' under its own descendant 'a/b'")
+	}
+	if err := tree.MoveGroupTo("a", "a"); err == nil {
+		t.Error("expected error moving 'a' under itself")
+	}
+	if tree.Groups["a"] == nil || tree.Groups["a/b"] == nil || tree.Groups["a/b/c"] == nil {
+		t.Error("original structure should be intact after rejected circular move")
+	}
+}
+
+// TestMoveGroupTo_NoOpSameParent is a no-op when source already under destParent.
+func TestMoveGroupTo_NoOpSameParent(t *testing.T) {
+	tree := NewGroupTree([]*Instance{})
+	tree.CreateGroup("work")
+	tree.CreateSubgroup("work", "alpha")
+
+	if err := tree.MoveGroupTo("work/alpha", "work"); err != nil {
+		t.Fatalf("MoveGroupTo returned error on same-parent no-op: %v", err)
+	}
+	if tree.Groups["work/alpha"] == nil {
+		t.Error("group should still be at work/alpha after no-op")
+	}
+}
+
+// TestMoveGroupTo_Collision returns an error when destination already has a group
+// with the same base name.
+func TestMoveGroupTo_Collision(t *testing.T) {
+	tree := NewGroupTree([]*Instance{})
+	tree.CreateGroup("personal")
+	tree.CreateSubgroup("personal", "alpha")
+	tree.CreateGroup("work")
+	tree.CreateSubgroup("work", "alpha")
+
+	if err := tree.MoveGroupTo("personal/alpha", "work"); err == nil {
+		t.Error("expected collision error moving alpha where work/alpha already exists")
+	}
+}
+
+// TestMoveGroupTo_SourceMissing returns an error for unknown source.
+func TestMoveGroupTo_SourceMissing(t *testing.T) {
+	tree := NewGroupTree([]*Instance{})
+	if err := tree.MoveGroupTo("nonexistent", ""); err == nil {
+		t.Error("expected error when source doesn't exist")
+	}
+}
+
+// TestMoveGroupTo_DefaultGroupForbidden forbids moving the default group.
+func TestMoveGroupTo_DefaultGroupForbidden(t *testing.T) {
+	tree := NewGroupTree([]*Instance{})
+	tree.CreateGroup("work")
+	if err := tree.MoveGroupTo(DefaultGroupPath, "work"); err == nil {
+		t.Error("expected error moving the default group")
+	}
+}


### PR DESCRIPTION
## Summary

Ships two accepted feature enhancements as **v1.8.0**:

- **#447** — `agent-deck group change <source> [<dest>]`: reparent an entire group subtree (sessions and all subgroups follow) under a new parent, or to root when `<dest>` is empty. Refuses circular moves, target-path collisions, unknown dest, and moves of the protected default group.
- **#483** — `agent-deck session search <query>`: surface the global-search index (which already indexes full JSONL content) as a first-class CLI. Returns `{session_id, snippet, cwd}` with `--limit`, `--days`, `--tier` flags. Honours `CLAUDE_CONFIG_DIR` for per-profile (`cdp`/`cdw`) searches.

TUI move-group dialog for #447 is intentionally deferred — the CLI is the minimum shippable surface, the underlying `GroupTree.MoveGroupTo` engine is TUI-ready.

## Scope discipline

- Zero behavior change for users who don't invoke the new subcommands.
- No refactoring of adjacent code.
- Side-fix (in scope): `runAgentDeck` test helper strips `CLAUDE_CONFIG_DIR=` from subprocess env so search tests can't leak into the developer's real `~/.claude/projects`.

## Tests (11 new)

**MoveGroupTo engine (9):**
- \`TestMoveGroupTo_{ToRoot,ToOtherParent,WithSubgroups,DestMissing,Circular,NoOpSameParent,Collision,SourceMissing,DefaultGroupForbidden}\` in \`internal/session/groups_reorganize_test.go\`

**\`group change\` CLI e2e (3):**
- \`TestGroupChange_{RootToSubgroup,MoveToRoot,RejectsCircular}\` in \`cmd/agent-deck/group_change_test.go\`

**\`session search\` CLI e2e (3):**
- \`TestSessionSearch_{FindsMessageContent,EmptyQuery,NoMatches}\` in \`cmd/agent-deck/session_search_test.go\`

**Release manifest:** 6 entries appended to \`.claude/release-tests.yaml\`. Each was executed before commit to prevent the manifest-source-drift class of shipped regression.

## Test plan

- [x] New tests RED before implementation, GREEN after
- [x] \`go test ./internal/session/... ./cmd/agent-deck/... -race -count=1\` — all green
- [x] All 6 release-tests.yaml entries run independently — all green
- [x] \`fmt-check\` + \`vet\` pre-commit hooks pass
- [ ] CI passes on this PR
- [ ] User merges + tags v1.8.0

🔗 Closes #447, closes #483