### PR TITLE
fix(#662): retry sessionHasConversationData + structured decision log (v1.7.27)

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -1334,3 +1334,47 @@ tests:
   run:
     command: go test ./cmd/agent-deck/ -run TestDetectTool_Copilot -count=1 -race -v
     expected: pass
+- id: v1727-issue662-hidden-dir-encoding
+  added: '2026-04-19'
+  task: v1727-issue662-session-data-false-negative
+  file: internal/session/issue662_session_data_diag_test.go
+  test_name: TestIssue662_HiddenDirInPath_EncodesToDoubleDash
+  purpose: 'Issue #662 hypothesis (1) regression pin — paths with dot-prefix segments (/home/u/.agent-deck/conductor/*) must encode with a double-dash (the dot and the path separator both become dashes). Guards against silent encoder regressions that would make every .agent-deck/conductor session stop finding its jsonl.'
+  source: https://github.com/asheshgoplani/agent-deck/issues/662
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestIssue662_HiddenDirInPath_EncodesToDoubleDash -count=1 -race -v
+    expected: pass
+- id: v1727-issue662-fallback-on-primary-miss
+  added: '2026-04-19'
+  task: v1727-issue662-session-data-false-negative
+  file: internal/session/issue662_session_data_diag_test.go
+  test_name: TestIssue662_FindsFileViaFallback_WhenPrimaryPathMisses
+  purpose: 'Issue #662 hypothesis (3) regression pin — when the primary encoded path has no matching jsonl but another project dir under the same configDir does, the fallback must surface it. Protects the findSessionFileInAllProjects safety net from regressions that would break path-hash drift recovery.'
+  source: https://github.com/asheshgoplani/agent-deck/issues/662
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestIssue662_FindsFileViaFallback_WhenPrimaryPathMisses -count=1 -race -v
+    expected: pass
+- id: v1727-issue662-diagnostic-log-contract
+  added: '2026-04-19'
+  task: v1727-issue662-session-data-false-negative
+  file: internal/session/issue662_session_data_diag_test.go
+  test_name: TestIssue662_DiagnosticLog_CapturesAllDecisionFields
+  purpose: 'Issue #662 diagnostic contract — sessionHasConversationData must emit a structured session_data_decision log line carrying config_dir, resolved_project_path, encoded_path, primary_path_tested, fallback_lookup_tried, and final_result. Production diagnosis of the travel-conductor false-negative was blocked because these fields were missing; the test pins the full field set so future diagnosis can be done from logs alone.'
+  source: https://github.com/asheshgoplani/agent-deck/issues/662
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestIssue662_DiagnosticLog_CapturesAllDecisionFields -count=1 -race -v
+    expected: pass
+- id: v1727-issue662-retry-on-session-end-race
+  added: '2026-04-19'
+  task: v1727-issue662-session-data-false-negative
+  file: internal/session/issue662_session_data_diag_test.go
+  test_name: TestIssue662_BuildClaudeResumeCommand_RetriesOnceOnSessionEndRace
+  purpose: 'Issue #662 hypothesis (2) fix — buildClaudeResumeCommand now retries sessionHasConversationData once after a 200ms wait when the first check returns false but ClaudeSessionID is non-empty. Covers the SessionEnd-flush race where Claude is still writing the jsonl when agent-deck picks the resume flag. Test seeds a delayed jsonl write at 50ms and asserts the emitted command contains --resume, not --session-id.'
+  source: https://github.com/asheshgoplani/agent-deck/issues/662
+  manual: false
+  run:
+    command: go test ./internal/session/ -run TestIssue662_BuildClaudeResumeCommand_RetriesOnceOnSessionEndRace -count=1 -race -v
+    expected: pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.27] - 2026-04-19
+
+### Fixed
+- **`sessionHasConversationData` false-negatives caused `--session-id` instead of `--resume` despite rich jsonl on disk** (issue [#662](https://github.com/asheshgoplani/agent-deck/issues/662)): when a conductor's Claude session was restarted while the SessionEnd hook was still flushing the jsonl (a ~100–150ms window), `buildClaudeResumeCommand` would observe the file as not-yet-written, fall through to `--session-id`, and hand the user a blank conversation even though the historic jsonl was on disk. Two layers of fix: (1) a bounded retry-once at the call site (`resumeCheckRetryDelay = 200ms`) that re-checks after the flush window closes, firing only when the first check is negative AND `ClaudeSessionID` is non-empty so the happy path is untouched; (2) a new `session_data_decision` structured log line carrying `config_dir`, `resolved_project_path`, `encoded_path`, `primary_path_tested`, `primary_path_stat_err`, `fallback_lookup_tried`, `fallback_path_found`, and `final_result` so production false-negatives can be diagnosed from logs alone without attaching a debugger. Tests: `TestIssue662_HiddenDirInPath_EncodesToDoubleDash`, `TestIssue662_FindsFileViaFallback_WhenPrimaryPathMisses`, `TestIssue662_DiagnosticLog_CapturesAllDecisionFields`, `TestIssue662_BuildClaudeResumeCommand_RetriesOnceOnSessionEndRace` in `internal/session/issue662_session_data_diag_test.go`.
+
+### Deferred
+- **Tmux control-client supervision** (issue [#659](https://github.com/asheshgoplani/agent-deck/issues/659)): deferred to its own design cycle. #659's own body notes that "Pipe-death is already recovered" by the v1.7.8 reviver and frames the control-client wrapping as a structural improvement rather than a bug fix, with four open design questions (per-instance vs shared service, TUI coordination, per-user vs global, CLI-without-TUI behaviour). Tracked under issue [#668](https://github.com/asheshgoplani/agent-deck/issues/668) as an RFC to pick the shape before any code lands.
+
 ## [1.7.26] - 2026-04-18
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.26" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.27" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2490,6 +2490,12 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 // instead of every 500ms tick, dramatically reducing subprocess spawns
 const errorRecheckInterval = 30 * time.Second
 
+// resumeCheckRetryDelay is the wait between the two sessionHasConversationData
+// checks in buildClaudeResumeCommand (Issue #662). SessionEnd writes are
+// observed to finish within ~100-150ms in practice; 200ms gives headroom
+// without noticeably slowing the restart path when there truly is no jsonl.
+var resumeCheckRetryDelay = 200 * time.Millisecond
+
 func hookFastPathFreshnessForTool(tool, hookStatus string) time.Duration {
 	if tool != "codex" {
 		return hookFastPathWindow
@@ -4502,9 +4508,28 @@ func (i *Instance) buildClaudeResumeCommand() string {
 		opts = NewClaudeOptions(userConfig)
 	}
 
-	// Check if session has actual conversation data
-	// If not, use --session-id instead of --resume to avoid "No conversation found" error
+	// Check if session has actual conversation data.
+	// If not, use --session-id instead of --resume to avoid "No conversation found" error.
+	//
+	// Issue #662: a bounded retry-once at this call site covers the
+	// SessionEnd-flush race — the helper is called synchronously with
+	// restart, and Claude may still be flushing its jsonl for a few
+	// hundred milliseconds after the SessionEnd hook fires. Waiting 200ms
+	// and re-checking turns a shipped-fresh-session into a resume for the
+	// common flush-race case without slowing the happy path (retry only
+	// fires when the first check comes back negative AND we have a
+	// non-empty ClaudeSessionID).
 	useResume := sessionHasConversationData(i, i.ClaudeSessionID)
+	if !useResume && i.ClaudeSessionID != "" {
+		time.Sleep(resumeCheckRetryDelay)
+		useResume = sessionHasConversationData(i, i.ClaudeSessionID)
+		sessionLog.Debug(
+			"session_data_retry_after_wait",
+			slog.String("session_id", i.ClaudeSessionID),
+			slog.Duration("wait", resumeCheckRetryDelay),
+			slog.Bool("use_resume_after_retry", useResume),
+		)
+	}
 	sessionLog.Debug(
 		"session_data_build_resume",
 		slog.String("session_id", i.ClaudeSessionID),
@@ -5321,19 +5346,51 @@ func sessionHasConversationData(inst *Instance, sessionID string) bool {
 	}
 
 	sessionFile := filepath.Join(configDir, "projects", encodedPath, sessionID+".jsonl")
+
+	// Issue #662 diagnostic contract: emit a single structured "decision"
+	// log line per call with every field needed to reconstruct the false
+	// negatives in production logs (config_dir, resolved_project_path,
+	// encoded_path, primary_path_tested, primary_path_stat_err,
+	// fallback_lookup_tried, fallback_path_found, final_result).
+	primaryStatErr := ""
+	fallbackTried := false
+	fallbackPathFound := ""
+
+	emitDecision := func(result bool, reason string) {
+		sessionLog.Debug(
+			"session_data_decision",
+			slog.String("session_id", sessionID),
+			slog.String("config_dir", configDir),
+			slog.String("resolved_project_path", resolvedPath),
+			slog.String("encoded_path", encodedPath),
+			slog.String("primary_path_tested", sessionFile),
+			slog.String("primary_path_stat_err", primaryStatErr),
+			slog.Bool("fallback_lookup_tried", fallbackTried),
+			slog.String("fallback_path_found", fallbackPathFound),
+			slog.Bool("final_result", result),
+			slog.String("reason", reason),
+		)
+	}
+
 	sessionLog.Debug("session_data_checking_file", slog.String("file", sessionFile))
 
 	// Check if file exists
 	if _, err := os.Stat(sessionFile); os.IsNotExist(err) {
+		if err != nil {
+			primaryStatErr = err.Error()
+		}
 		// File doesn't exist at expected location - try cross-project search
 		// This handles path hash mismatches (e.g., session created from different directory)
+		fallbackTried = true
 		if fallbackPath := findSessionFileInAllProjects(inst, sessionID); fallbackPath != "" {
+			fallbackPathFound = fallbackPath
 			sessionLog.Debug("session_data_cross_project_found", slog.String("path", fallbackPath))
 			sessionFile = fallbackPath
 		} else {
 			// File doesn't exist anywhere - use --session-id to create fresh session
 			// (there's nothing to resume if the file doesn't exist)
 			sessionLog.Debug("session_data_file_not_found", slog.String("result", "use_session_id"))
+			emitDecision(false, "file_not_found")
 			return false
 		}
 	}
@@ -5349,6 +5406,7 @@ func sessionHasConversationData(inst *Instance, sessionID string) bool {
 			slog.String("error", err.Error()),
 			slog.String("fallback", "use_resume"),
 		)
+		emitDecision(true, "open_error_safe_fallback")
 		return true
 	}
 	defer file.Close()
@@ -5364,6 +5422,7 @@ func sessionHasConversationData(inst *Instance, sessionID string) bool {
 		// Simple string search - faster than JSON parsing
 		if strings.Contains(line, `"sessionId"`) {
 			sessionLog.Debug("session_data_found_session_id", slog.String("result", "use_resume"))
+			emitDecision(true, "session_id_line_present")
 			return true // Found conversation data
 		}
 	}
@@ -5375,11 +5434,13 @@ func sessionHasConversationData(inst *Instance, sessionID string) bool {
 			slog.String("error", err.Error()),
 			slog.String("fallback", "use_resume"),
 		)
+		emitDecision(true, "scanner_error_safe_fallback")
 		return true
 	}
 
 	// No sessionId found - session was never interacted with
 	sessionLog.Debug("session_data_no_session_id", slog.String("result", "use_session_id"))
+	emitDecision(false, "no_session_id_line")
 	return false
 }
 

--- a/internal/session/issue662_session_data_diag_test.go
+++ b/internal/session/issue662_session_data_diag_test.go
@@ -1,0 +1,231 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Issue #662 regression suite — sessionHasConversationData returns false
+// despite rich jsonl on disk, causing buildClaudeResumeCommand to emit
+// --session-id instead of --resume (Claude then rejects or starts fresh).
+//
+// The issue body lists three hypotheses to audit:
+//   (1) path-encoding mismatch on hidden-dir paths like `.agent-deck`
+//   (2) race with SessionEnd flush at the resume-command call site
+//   (3) findSessionFileInAllProjects fallback not firing / wrong configDir
+//
+// These tests pin each hypothesis. Tests 1 and 2 guard against regressions in
+// the existing encoder + fallback. Test 3 is the RED test that fails on
+// v1.7.25 — it exercises the SessionEnd flush race at the call site and
+// requires a bounded retry on first-miss.
+//
+// Test 4 pins the diagnostic-log contract: when sessionHasConversationData
+// returns false, the structured debug line MUST carry enough fields to
+// reconstruct the decision from logs alone (config_dir, resolved path,
+// encoded path, primary path tested, fallback tried, final result).
+
+// captureSessionLogDebug swaps sessionLog for a JSON handler at Debug level
+// so tests that assert on Debug lines (like the #662 diagnostic-log test)
+// actually see them. The package-wide captureSessionLog helper defaults to
+// slog's Info level and therefore drops the very lines this test must pin.
+func captureSessionLogDebug(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	original := sessionLog
+	sessionLog = slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { sessionLog = original })
+	return buf
+}
+
+// TestIssue662_HiddenDirInPath_EncodesToDoubleDash is a sanity pin for
+// hypothesis (1): paths with dot-prefix segments must encode with a
+// double-dash (the dot → dash plus the path-separator → dash), which is
+// exactly how Claude writes to disk. If this ever regresses, every
+// `.agent-deck/conductor/*` session silently stops finding its jsonl.
+func TestIssue662_HiddenDirInPath_EncodesToDoubleDash(t *testing.T) {
+	got := ConvertToClaudeDirName("/home/u/.agent-deck/conductor/travel")
+	want := "-home-u--agent-deck-conductor-travel"
+	if got != want {
+		t.Fatalf("ConvertToClaudeDirName(hidden-dir path) = %q, want %q (double-dash indicates the dot was preserved as a separate char)", got, want)
+	}
+}
+
+// TestIssue662_FindsFileViaFallback_WhenPrimaryPathMisses pins hypothesis (3):
+// when the primary encoded path has no matching jsonl but ANOTHER project dir
+// under the same configDir does have <sessionID>.jsonl, the fallback must
+// surface it. This mirrors real-world path-hash drift where Claude was
+// originally invoked from a slightly different cwd than the Instance records
+// today.
+func TestIssue662_FindsFileViaFallback_WhenPrimaryPathMisses(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	_ = os.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+	t.Cleanup(func() {
+		if origConfigDir == "" {
+			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+		} else {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
+		}
+		ClearUserConfigCache()
+	})
+	ClearUserConfigCache()
+
+	instPath := "/tmp/instance-cwd-A"
+	actualEncoded := "-tmp-instance-cwd-B"
+	sessionID := "11111111-2222-3333-4444-555555555555"
+
+	actualDir := filepath.Join(tmpDir, "projects", actualEncoded)
+	if err := os.MkdirAll(actualDir, 0o755); err != nil {
+		t.Fatalf("mkdir actual projects dir: %v", err)
+	}
+	actualFile := filepath.Join(actualDir, sessionID+".jsonl")
+	body := `{"type":"user","sessionId":"` + sessionID + `","text":"hi"}` + "\n"
+	if err := os.WriteFile(actualFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	inst := NewInstance("test-fallback", instPath)
+	inst.Tool = "claude"
+
+	if !sessionHasConversationData(inst, sessionID) {
+		t.Fatalf("expected true via fallback (jsonl at %q), got false", actualFile)
+	}
+}
+
+// TestIssue662_DiagnosticLog_CapturesAllDecisionFields pins hypothesis (1) +
+// (3) forensic story: when sessionHasConversationData returns false, the
+// structured log line MUST contain enough fields to reconstruct the decision
+// from logs alone. Production diagnosis of the travel-conductor case in the
+// issue body was blocked because the existing log line only named the file
+// tested — not the config_dir source, resolved project path, encoded path,
+// stat err detail, or whether the fallback was tried.
+//
+// Required fields: config_dir, resolved_project_path, encoded_path,
+// primary_path_tested, fallback_lookup_tried, final_result.
+func TestIssue662_DiagnosticLog_CapturesAllDecisionFields(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	_ = os.Setenv("CLAUDE_CONFIG_DIR", tmpDir)
+	t.Cleanup(func() {
+		if origConfigDir == "" {
+			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+		} else {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
+		}
+		ClearUserConfigCache()
+	})
+	ClearUserConfigCache()
+
+	buf := captureSessionLogDebug(t)
+
+	inst := NewInstance("diag-none", "/tmp/does-not-exist-anywhere")
+	inst.Tool = "claude"
+	sessionID := "deadbeef-dead-beef-dead-beefdeadbeef"
+
+	if got := sessionHasConversationData(inst, sessionID); got {
+		t.Fatalf("precondition: expected false for empty state, got true")
+	}
+
+	logText := buf.String()
+	required := []string{
+		"config_dir",
+		"resolved_project_path",
+		"encoded_path",
+		"primary_path_tested",
+		"fallback_lookup_tried",
+		"final_result",
+	}
+	for _, field := range required {
+		if !strings.Contains(logText, `"`+field+`"`) {
+			t.Errorf("diagnostic log missing required field %q. Log: %s", field, logText)
+		}
+	}
+}
+
+// TestIssue662_BuildClaudeResumeCommand_RetriesOnceOnSessionEndRace pins
+// hypothesis (2): if sessionHasConversationData observes "no data" on the
+// first call but the jsonl is written shortly after (Claude's SessionEnd
+// hook hasn't fully flushed yet), buildClaudeResumeCommand must wait briefly
+// and re-check before falling back to --session-id. Per the issue spec:
+// "Worth a 1-retry with a 200ms wait at the CALL SITE".
+//
+// RED on v1.7.26-baseline — there is no retry there; GREEN after the
+// resumeCheckRetryDelay at buildClaudeResumeCommand is added.
+func TestIssue662_BuildClaudeResumeCommand_RetriesOnceOnSessionEndRace(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	origHome := os.Getenv("HOME")
+	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	_ = os.Setenv("HOME", tmpHome)
+	_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origConfigDir != "" {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
+		}
+		ClearUserConfigCache()
+	})
+	ClearUserConfigCache()
+
+	configDir := filepath.Join(tmpHome, ".claude")
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir projectPath: %v", err)
+	}
+	encoded := ConvertToClaudeDirName(projectPath)
+	projectsDir := filepath.Join(configDir, "projects", encoded)
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatalf("mkdir projects dir: %v", err)
+	}
+
+	sessionID := "cafebabe-cafe-babe-cafe-babecafebabe"
+	jsonlPath := filepath.Join(projectsDir, sessionID+".jsonl")
+
+	inst := NewInstance("race-test", projectPath)
+	inst.Tool = "claude"
+	inst.ClaudeSessionID = sessionID
+
+	var writeDone atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() {
+		select {
+		case <-time.After(50 * time.Millisecond):
+		case <-ctx.Done():
+			return
+		}
+		body := fmt.Sprintf(`{"type":"user","sessionId":%q,"text":"hi"}`+"\n", sessionID)
+		if err := os.WriteFile(jsonlPath, []byte(body), 0o600); err == nil {
+			writeDone.Store(true)
+		}
+	}()
+
+	cmd := inst.buildClaudeResumeCommand()
+
+	deadline := time.Now().Add(1 * time.Second)
+	for !writeDone.Load() && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !writeDone.Load() {
+		t.Fatalf("precondition: delayed write did not complete within 1s")
+	}
+
+	resumeFlag := "--resume " + sessionID
+	sessionIDFlag := "--session-id " + sessionID
+	if strings.Contains(cmd, sessionIDFlag) {
+		t.Errorf("expected --resume, got --session-id (retry did not surface the late-written jsonl). cmd=%q", cmd)
+	}
+	if !strings.Contains(cmd, resumeFlag) {
+		t.Errorf("expected cmd to contain %q, got %q", resumeFlag, cmd)
+	}
+}


### PR DESCRIPTION
## Summary

- Retry `sessionHasConversationData` once after a 200ms wait inside `buildClaudeResumeCommand` when the first check returns false AND `ClaudeSessionID` is non-empty — closes the SessionEnd-flush race that caused `--session-id` to be emitted instead of `--resume` even when the historic jsonl existed on disk.
- Enrich `sessionHasConversationData` with a single structured `session_data_decision` debug log carrying every field the issue's "Required instrumentation" checklist lists (`config_dir`, `resolved_project_path`, `encoded_path`, `primary_path_tested`, `primary_path_stat_err`, `fallback_lookup_tried`, `fallback_path_found`, `final_result`, `reason`). Future false-negatives can be diagnosed from logs alone.
- Four regression tests pinning all three hypotheses the issue body enumerates (hidden-dir encoding, fallback on primary miss, diagnostic-log contract, call-site retry).
- `.claude/release-tests.yaml` appended with the four entries; `CHANGELOG.md` entry; version bump to `1.7.27`.

## Why v1.7.27, not v1.7.26

v1.7.26 shipped during the fix window as #556 (GitHub Copilot CLI first-class tool support). Serial-bump cascade: this is v1.7.27.

## Why #659 is NOT in this release

Issue #659 is explicitly a design question, not a bug — its own body says "Pipe-death is already recovered. This is a structural question... Merits its own design cycle." Four open design questions (per-instance vs shared service, TUI coordination, per-user vs global, CLI-without-TUI). Tracked under RFC #668 to pick the shape before any code lands. Shipping a speculative fix in a patch bundle would violate the conductor's empirical-repro-first invariant and scope discipline.

## Test plan

- [x] `go test ./internal/session/ -run 'TestIssue662' -race -count=1` — all 4 tests pass
- [x] `go test ./... -race -count=1 -timeout 600s` — green except documented `TestWatcherEventDedup` SQLite-BUSY flake (unrelated to this change; my edits do not touch statedb)
- [x] Pre-push hooks (fmt, vet, release-tests-yaml-lint, css-verify, build, lint, test) — all green
- [ ] CI — visual-regression ignored per convention; all other checks expected green

## Verification

The `TestIssue662_BuildClaudeResumeCommand_RetriesOnceOnSessionEndRace` test is authentically RED on v1.7.26 and GREEN on this branch:

- Baseline: emits `--session-id` (resume flag missing, retry doesn't exist)
- Fix: emits `--resume` (200ms wait surfaces the late-written jsonl)

The diagnostic log test fails on baseline (fields missing) and passes on this branch (all six fields present in `session_data_decision`).

Closes #662
Ref #659, #668