### PR TITLE
feat(#391): render per-session Color tint in TUI rows (v1.7.30)

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -1543,3 +1543,36 @@ tests:
   run:
     command: go test ./cmd/agent-deck/ -run TestSessionSearch_NoMatches -count=1 -race -v
     expected: pass
+- id: v1730-issue391-hex-color-rendered
+  added: '2026-04-19'
+  task: v1730-issue-391
+  file: internal/ui/issue391_tui_test.go
+  test_name: TestIssue391_SessionRow_HexColorRenderedAsForeground
+  purpose: 'Issue #391 — renderSessionItem applies Instance.Color as title foreground when set to a #RRGGBB truecolor hex. Pins the render contract so a future refactor of titleStyle cannot silently drop the tint overlay (the exact failure mode from v1.7.27–v1.7.29 where the field round-tripped through storage but never reached the render layer).'
+  source: github-issue-391
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestIssue391_SessionRow_HexColorRenderedAsForeground -count=1 -race -v
+    expected: pass
+- id: v1730-issue391-ansi-color-rendered
+  added: '2026-04-19'
+  task: v1730-issue-391
+  file: internal/ui/issue391_tui_test.go
+  test_name: TestIssue391_SessionRow_ANSIIndexColorRendered
+  purpose: 'Issue #391 — renderSessionItem handles the second accepted color format from isValidSessionColor: a 0..255 ANSI 256-palette index emits the `38;5;<idx>` foreground escape. Guards against a future "truecolor-hex only" regression that would silently reject valid CLI input.'
+  source: github-issue-391
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestIssue391_SessionRow_ANSIIndexColorRendered -count=1 -race -v
+    expected: pass
+- id: v1730-issue391-empty-color-untinted
+  added: '2026-04-19'
+  task: v1730-issue-391
+  file: internal/ui/issue391_tui_test.go
+  test_name: TestIssue391_SessionRow_EmptyColorLeavesRowUntinted
+  purpose: 'Issue #391 — the fall-through invariant: Color="" must leave the row untinted. Guards against a future refactor that turns the opt-in tint into a mandatory one, which would change rendering for every user who never set a color.'
+  source: github-issue-391
+  manual: false
+  run:
+    command: go test ./internal/ui/ -run TestIssue391_SessionRow_EmptyColorLeavesRowUntinted -count=1 -race -v
+    expected: pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.30] - 2026-04-19
+
+### Fixed
+- **Per-session color tint now actually renders in the TUI** (issue [#391](https://github.com/asheshgoplani/agent-deck/issues/391)): PR #650 (v1.7.27) added the `Instance.Color` field, TOML validation, CLI plumbing (`agent-deck session set <id> color '#FF0000'`), SQLite persistence, and `list --json` exposure — but the TUI dashboard never consumed the field, so users setting a color saw it round-trip through storage yet every row kept the default palette. `renderSessionItem` now overrides the title foreground with `lipgloss.Color(Instance.Color)` when the field is non-empty, preserving the bold/underline weight cues that distinguish Running/Waiting/Error states for colorblind users. Empty `Color` is the default and leaves rendering byte-identical to v1.7.29 (fully opt-in). Accepts both accepted formats from `isValidSessionColor`: `#RRGGBB` truecolor hex and `0..255` ANSI 256-palette index. Tests: `TestIssue391_SessionRow_{HexColorRenderedAsForeground,ANSIIndexColorRendered,EmptyColorLeavesRowUntinted}` in `internal/ui/issue391_tui_test.go` (Seam A, per `internal/ui/TUI_TESTS.md`).
+
 ## [1.7.29] - 2026-04-19
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.29" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.30" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10597,6 +10597,17 @@ func (h *Home) renderSessionItem(
 		titleStyle = SessionTitleDefault
 	}
 
+	// Issue #391: per-session color tint. When the user has set
+	// Instance.Color (validated CLI-side in isValidSessionColor), override
+	// the title foreground with that color. Bold/underline from the
+	// status-based style above is preserved — only the hue changes, so
+	// colorblind accessibility via weight still works. Empty Color is the
+	// default and leaves titleStyle untouched (zero behavior change for
+	// users who haven't opted in).
+	if inst.Color != "" {
+		titleStyle = titleStyle.Foreground(lipgloss.Color(inst.Color))
+	}
+
 	// Tool badge with brand-specific color
 	// Claude=orange, Gemini=purple, Codex=cyan, Aider=red
 	toolStyle := GetToolStyle(instTool)

--- a/internal/ui/issue391_tui_test.go
+++ b/internal/ui/issue391_tui_test.go
@@ -1,0 +1,152 @@
+package ui
+
+// Issue #391 — per-session color tint rendered in the TUI row.
+//
+// PR #650 (shipped in v1.7.27) added the Instance.Color field, TOML
+// validation, CLI plumbing, SQLite persistence, and `list --json`
+// exposure. The field was plumbed end-to-end but NOT rendered: a user
+// running `agent-deck session set <id> color '#FF0000'` saw the value
+// round-trip through persistence yet the TUI dashboard still drew every
+// session row in the default palette.
+//
+// This file pins the render contract at Seam A (model-level, see
+// internal/ui/TUI_TESTS.md). When Instance.Color is a valid lipgloss
+// color spec, renderSessionItem MUST emit an ANSI escape for that
+// foreground in the row's title. When Color is empty, rendering must
+// remain byte-identical to the v1.7.29 baseline.
+//
+// Seam choice: Seam A over Seam B because the only observable here is
+// the output of a single render function on a single row. No teatest
+// runtime needed; no tmux needed. Fastest seam that catches the bug.
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// forceTrueColorProfileOnce guarantees the lipgloss global profile is
+// TrueColor for any test in this file. Go tests don't run under a TTY,
+// so lipgloss' auto-detect falls back to Ascii and strips every escape —
+// which would make an "assert ANSI escape present" check vacuous.
+var forceTrueColorProfileOnce sync.Once
+
+func forceTrueColorProfile() {
+	forceTrueColorProfileOnce.Do(func() {
+		lipgloss.SetColorProfile(termenv.TrueColor)
+	})
+}
+
+// renderSingleSessionRow drives the minimal inputs required for
+// renderSessionItem in isolation. It deliberately avoids newSeamATestHome
+// (which wires every dialog pointer) because renderSessionItem only
+// reads width + style globals + the snapshot map. Keeping the helper
+// narrow makes the assertion below easy to reason about.
+func renderSingleSessionRow(t *testing.T, inst *session.Instance) string {
+	t.Helper()
+	forceTrueColorProfile()
+
+	h := &Home{width: 140}
+	item := session.Item{
+		Type:          session.ItemTypeSession,
+		Session:       inst,
+		Level:         1,
+		Path:          "test",
+		IsLastInGroup: true,
+	}
+	snapshot := map[string]sessionRenderState{
+		inst.ID: {
+			status:    session.StatusRunning,
+			tool:      "claude",
+			paneTitle: "",
+		},
+	}
+
+	var b strings.Builder
+	h.renderSessionItem(&b, item, false, snapshot)
+	return b.String()
+}
+
+// TestIssue391_SessionRow_HexColorRenderedAsForeground is the primary
+// regression pin. A session with Color="#FF0000" must cause the row
+// output to include the truecolor ANSI escape `38;2;255;0;0` (lipgloss'
+// encoding for red foreground under TrueColor profile).
+//
+// Failure mode on v1.7.29 (pre-fix): the row contains no red escape —
+// only the default title-style foreground — because renderSessionItem
+// ignores Instance.Color entirely.
+//
+// This test does NOT assert on byte-exact output because surrounding
+// escape sequences (status icon, tool badge, tree connectors) share the
+// row. It asserts only on the presence of the expected foreground
+// sequence — the load-bearing signal for "the tint made it to output."
+func TestIssue391_SessionRow_HexColorRenderedAsForeground(t *testing.T) {
+	inst := &session.Instance{
+		ID:    "sess-red",
+		Title: "red-session",
+		Color: "#FF0000",
+	}
+
+	row := renderSingleSessionRow(t, inst)
+
+	// TrueColor hex "#FF0000" → lipgloss renders as `\x1b[38;2;255;0;0m`.
+	// We check for the decimal triple embedded in the row, not the full
+	// escape, so we survive future SGR-combining changes in lipgloss.
+	const wantFgSig = "38;2;255;0;0"
+	if !strings.Contains(row, wantFgSig) {
+		t.Fatalf("issue #391 regression: session row for Color=%q did not contain the truecolor foreground escape %q. "+
+			"Got raw row: %q. "+
+			"This means renderSessionItem is not applying Instance.Color to the title — the field round-trips through "+
+			"persistence but never reaches the render layer.",
+			inst.Color, wantFgSig, row)
+	}
+}
+
+// TestIssue391_SessionRow_ANSIIndexColorRendered pins the second
+// accepted color format from isValidSessionColor: a decimal 0..255 ANSI
+// palette index. Under TrueColor profile, lipgloss emits `38;5;<idx>` for
+// ANSI256-palette colors.
+func TestIssue391_SessionRow_ANSIIndexColorRendered(t *testing.T) {
+	inst := &session.Instance{
+		ID:    "sess-ansi",
+		Title: "ansi-session",
+		Color: "196", // bright red in the 256-palette
+	}
+
+	row := renderSingleSessionRow(t, inst)
+
+	const wantFgSig = "38;5;196"
+	if !strings.Contains(row, wantFgSig) {
+		t.Fatalf("issue #391 regression: session row for Color=%q did not contain the 256-palette foreground escape %q. "+
+			"Got raw row: %q.",
+			inst.Color, wantFgSig, row)
+	}
+}
+
+// TestIssue391_SessionRow_EmptyColorLeavesRowUntinted guards the
+// fall-through invariant: when Instance.Color is "", the render output
+// must be byte-identical to the pre-#391 baseline. We can't compare
+// against a frozen fixture (too brittle across style tweaks), but we
+// CAN prove the red signature doesn't appear by accident — i.e. the
+// tint is opt-in and invisible to users who don't set it.
+func TestIssue391_SessionRow_EmptyColorLeavesRowUntinted(t *testing.T) {
+	inst := &session.Instance{
+		ID:    "sess-default",
+		Title: "default-session",
+		Color: "",
+	}
+
+	row := renderSingleSessionRow(t, inst)
+
+	// If this fires, something leaked a red tint into the default path.
+	// The default palette has no 255,0,0 foreground; seeing it means a
+	// regression that turned the opt-in tint into a mandatory one.
+	if strings.Contains(row, "38;2;255;0;0") {
+		t.Fatalf("issue #391 regression: session row with Color=\"\" unexpectedly contains a red truecolor escape. "+
+			"The tint must be fully opt-in. Got: %q", row)
+	}
+}


### PR DESCRIPTION
## Summary

Ships the TUI render half of issue #391. PR #650 (shipped in v1.7.27) added the `Instance.Color` field end-to-end — TOML validation, CLI `session set <id> color '#FF0000'`, SQLite persistence, and `list --json` exposure — but `renderSessionItem` never consumed the field. Users setting a color saw it round-trip through storage yet every row kept the default palette. Issue #391 stayed open for three releases as a result.

`renderSessionItem` now overrides `titleStyle.Foreground` with `lipgloss.Color(inst.Color)` when set, preserving the bold/underline weight cues that distinguish Running/Waiting/Error states (critical for colorblind users). Empty `Color` leaves rendering byte-identical to v1.7.29 — fully opt-in, zero change for users who haven't set one.

Both CLI-validated formats work:
- `"#RRGGBB"` (truecolor hex) → `38;2;R;G;B` foreground escape
- `"0".."255"` (ANSI 256-palette index) → `38;5;<idx>` foreground escape

## Test plan

- [x] Seam A (per `internal/ui/TUI_TESTS.md`) tests in `internal/ui/issue391_tui_test.go`:
  - `TestIssue391_SessionRow_HexColorRenderedAsForeground` — confirmed RED on `main` before fix; GREEN on this branch.
  - `TestIssue391_SessionRow_ANSIIndexColorRendered` — confirmed RED on `main` before fix; GREEN on this branch.
  - `TestIssue391_SessionRow_EmptyColorLeavesRowUntinted` — opt-in invariant guard.
- [x] `go test ./... -race -count=1` — all 27 packages green.
- [x] Pre-push hook ran full suite — passed.
- [x] New tests appended to `.claude/release-tests.yaml` as IDs `v1730-issue391-{hex,ansi,empty}-color-*`; YAML lint passes; manifest source-drift guard in `internal/releasetests/` passes.
- [x] `CHANGELOG.md` updated under `[1.7.30] - 2026-04-19`.
- [x] `cmd/agent-deck/main.go` `Version` bumped 1.7.29 → 1.7.30.

Closes #391.