### PR TITLE
fix: detect Pi as a first-class tool in CLI and TUI session creation

### DIFF
--- a/cmd/agent-deck/copilot_detect_test.go
+++ b/cmd/agent-deck/copilot_detect_test.go
@@ -24,3 +24,22 @@ func TestDetectTool_Copilot(t *testing.T) {
 		})
 	}
 }
+
+func TestDetectTool_Pi(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"bare", "pi", "pi"},
+		{"with flags", "pi --profile dev", "pi"},
+		{"uppercase", "Pi", "pi"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got != tt.want {
+				t.Errorf("detectTool(%q) = %q, want %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2702,6 +2702,8 @@ func detectTool(cmd string) string {
 		return "gemini"
 	case strings.Contains(cmd, "codex"):
 		return "codex"
+	case hasCommandToken(cmd, "pi"):
+		return "pi"
 	case strings.Contains(cmd, "copilot"):
 		return "copilot"
 	case strings.Contains(cmd, "cursor"):
@@ -2709,6 +2711,15 @@ func detectTool(cmd string) string {
 	default:
 		return "shell"
 	}
+}
+
+func hasCommandToken(cmd, want string) bool {
+	for _, token := range strings.Fields(strings.ToLower(cmd)) {
+		if token == want {
+			return true
+		}
+	}
+	return false
 }
 
 // handleUninstall removes agent-deck from the system

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7320,26 +7320,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			path = worktreePath
 		}
 
-		tool := "shell"
-		switch command {
-		case "claude":
-			tool = "claude"
-		case "gemini":
-			tool = "gemini"
-		case "aider":
-			tool = "aider"
-		case "codex":
-			tool = "codex"
-		case "opencode":
-			tool = "opencode"
-		default:
-			// Check custom tools: tool identity stays as the custom name (e.g. "glm")
-			// so config lookup works, but command resolves to the actual binary (e.g. "claude")
-			if toolDef := session.GetToolDef(command); toolDef != nil {
-				tool = command
-				command = toolDef.Command
-			}
-		}
+		tool, command := createSessionTool(command)
 
 		var inst *session.Instance
 		if groupPath != "" {
@@ -7498,6 +7479,32 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 		uiLog.Info("session_create_succeeded", slog.String("id", inst.ID))
 		return sessionCreatedMsg{instance: inst, tempID: tempID}
 	}
+}
+
+func createSessionTool(command string) (string, string) {
+	tool := "shell"
+	switch command {
+	case "claude":
+		tool = "claude"
+	case "gemini":
+		tool = "gemini"
+	case "aider":
+		tool = "aider"
+	case "codex":
+		tool = "codex"
+	case "opencode":
+		tool = "opencode"
+	case "pi":
+		tool = "pi"
+	default:
+		// Check custom tools: tool identity stays as the custom name (e.g. "glm")
+		// so config lookup works, but command resolves to the actual binary (e.g. "claude")
+		if toolDef := session.GetToolDef(command); toolDef != nil {
+			tool = command
+			command = toolDef.Command
+		}
+	}
+	return tool, command
 }
 
 func applyCreateSessionToolOverrides(inst *session.Instance, tool string, geminiYoloMode bool) {

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -82,6 +82,16 @@ func TestApplyCreateSessionToolOverrides_NonGeminiNoop(t *testing.T) {
 	}
 }
 
+func TestCreateSessionTool_Pi(t *testing.T) {
+	tool, command := createSessionTool("pi")
+	if tool != "pi" {
+		t.Fatalf("tool = %q, want %q", tool, "pi")
+	}
+	if command != "pi" {
+		t.Fatalf("command = %q, want %q", command, "pi")
+	}
+}
+
 func TestHomeInit(t *testing.T) {
 	home := NewHome()
 	cmd := home.Init()


### PR DESCRIPTION
## Summary

Pi is already exposed in agent-deck as a built-in session command, but new Pi sessions created through both the CLI (`add -c pi`) and the TUI new-session flow were being stored as `Tool="shell"` with `Command="pi"`.

This PR fixes that built-in tool detection gap so Pi sessions are persisted as `Tool="pi"` in both creation paths.

Preserved behavior:
- custom commands still fall back to `shell`
- no session lifecycle or skill behavior changes
- no config format changes

## Scope discipline

In scope:
- CLI tool detection for `pi`
- TUI new-session tool mapping for `pi`
- regression tests for both paths

Out of scope:
- Pi skills
- Pi reload/restart behavior
- Pi wrapper/custom-command detection
- any broader multi-runtime feature work

## Test plan

- [x] `go test ./cmd/agent-deck/... ./internal/ui/... -run 'DetectTool|CreateSessionTool|Pi' -count=1`
- [x] manual verification: new Pi session persists with `Tool: pi`

