### PR TITLE
fix(feedback): stream prompts to os.Stdout — #679 follow-up hotfix v1.7.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.36] - 2026-04-19
+
+### Fixed
+- **`agent-deck feedback` prompts now print interactively to stdout instead of being buffered until the whole flow returns** (#679 follow-up, reported by @rgarlik after testing v1.7.35): the v1.7.35 fix for #679 added an explicit disclosure block and `Post this? [y/N]` confirm — but the disclosure was rendered into a `strings.Builder` that was only flushed to `os.Stdout` *after* `handleFeedbackWithSender` returned. Users typed `Rating`, `Comment`, and the confirm answer at a blank cursor, and the disclosure they were supposed to read before consenting was never visible while they were being asked to consent. The same buffering predated #679 (the `Sent! Thanks` path had it too) — #679 just made it impossible to ignore. Fix: `handleFeedbackWithSender` signature gains `in io.Reader` before the writer; `handleFeedback` now wires `os.Stdin`/`os.Stdout` directly, so every `fmt.Fprint(w, ...)` reaches the terminal immediately. Test gap closed by `TestFeedback_PromptPrintsBeforeStdinBlocks` in `cmd/agent-deck/feedback_cmd_test.go`: pairs `io.Pipe` for both stdin and stdout, spawns the handler in a goroutine, reads from the out pipe and asserts "Rating" arrives before sending anything to the in pipe, and times out at 2s if the function buffered. The legacy #679 tests continue to use `strings.Builder` for convenience — that type silently buffers, which is exactly the class of test gap that hid this regression; a follow-up issue tracks adding similar pipe-based smoke tests to every interactive subcommand.
+
 ## [1.7.35] - 2026-04-19
 
 This is a **consolidated batch release**. It ships three new fixes (#678, #680, #679) together with the two previously-unreleased `chore(release)` rebuilds that landed on `main` but were never tagged: the PR #655 custom-tool `compatible_with` work (previously slated for v1.7.33) and the PR #580 transition-notify toggle (previously slated for v1.7.34). There are no standalone v1.7.33 or v1.7.34 releases — everything is collapsed into v1.7.35 to avoid tag gaps and user confusion.

--- a/cmd/agent-deck/feedback_cmd.go
+++ b/cmd/agent-deck/feedback_cmd.go
@@ -28,22 +28,21 @@ var ghUserLogin = func() string {
 }
 
 // handleFeedback is the public dispatch entry point for the "agent-deck feedback" subcommand.
-// It delegates to handleFeedbackWithSender with the real stdin and a real Sender.
+// It delegates to handleFeedbackWithSender wired to real stdin/stdout so prompts print
+// interactively as they are emitted (see #679 follow-up: a previous strings.Builder wrapper
+// hid every prompt until after the function returned, leaving users typing at a blank cursor).
 func handleFeedback(args []string) {
-	var stdout strings.Builder
-	if err := handleFeedbackWithSender(args, Version, feedback.NewSender(), &stdout); err != nil {
+	if err := handleFeedbackWithSender(args, Version, feedback.NewSender(), os.Stdin, os.Stdout); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	// Print buffered output to real stdout
-	fmt.Print(stdout.String())
 }
 
 // handleFeedbackWithSender is the testable core: it reads a rating and optional comment
-// from os.Stdin, records the state, and calls sender.Send().
+// from in, records the state, and calls sender.Send(). Prompts are written to w as they
+// are emitted (no buffering — see #679 follow-up).
 // The sender parameter is injected so tests can provide a mock.
-// Output is written to w (use &strings.Builder for tests, os.Stdout for production).
-func handleFeedbackWithSender(args []string, version string, sender *feedback.Sender, w io.Writer) error {
+func handleFeedbackWithSender(args []string, version string, sender *feedback.Sender, in io.Reader, w io.Writer) error {
 	for _, a := range args {
 		if a == "-h" || a == "--help" {
 			printFeedbackHelp(w)
@@ -51,7 +50,7 @@ func handleFeedbackWithSender(args []string, version string, sender *feedback.Se
 		}
 	}
 
-	reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(in)
 
 	fmt.Fprint(w, "Rating (1-5, n=never-again, q=quit): ")
 

--- a/cmd/agent-deck/feedback_cmd_test.go
+++ b/cmd/agent-deck/feedback_cmd_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/feedback"
 )
@@ -79,6 +81,73 @@ func withFeedbackLogin(t *testing.T, login string) func() {
 }
 
 // ──────────────────────────────────────────────────────────────────
+// #679 follow-up: prompts must print to out BEFORE stdin blocks, so
+// an interactive user actually sees the question at the cursor. The
+// legacy tests above use a strings.Builder writer — that type buffers
+// silently, hiding any output-ordering bug. This test pairs io.Pipes
+// for BOTH stdin and stdout so the ordering is observable: we read
+// from out first (which blocks until the function writes "Rating"),
+// THEN send "q" to stdin to let the goroutine exit cleanly. If the
+// function buffered its output (the v1.7.35 bug), outR.Read would
+// never return and the test would time out.
+// ──────────────────────────────────────────────────────────────────
+func TestFeedback_PromptPrintsBeforeStdinBlocks(t *testing.T) {
+	defer withFeedbackLogin(t, "octocat")()
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	m := newFeedbackMocks()
+	done := make(chan error, 1)
+	go func() {
+		err := handleFeedbackWithSender([]string{}, "1.7.36", m.sender, inR, outW)
+		_ = outW.Close()
+		done <- err
+	}()
+
+	// Read from out — must return with "Rating" text before we write
+	// anything to inW. If production code buffers output, this Read
+	// blocks until the function returns, which is after stdin reads.
+	buf := make([]byte, 256)
+	readDone := make(chan struct{})
+	var n int
+	var readErr error
+	go func() {
+		n, readErr = outR.Read(buf)
+		close(readDone)
+	}()
+
+	select {
+	case <-readDone:
+		// fall through
+	case <-time.After(2 * time.Second):
+		t.Fatal("Rating prompt did not reach out pipe within 2s — output is buffered")
+	}
+	if readErr != nil {
+		t.Fatalf("read from out pipe: %v", readErr)
+	}
+	if !strings.Contains(string(buf[:n]), "Rating") {
+		t.Errorf("first out-pipe read must contain 'Rating' prompt; got %q", string(buf[:n]))
+	}
+
+	// Drain any further output so the writer-goroutine can make progress.
+	go func() { _, _ = io.Copy(io.Discard, outR) }()
+
+	// Release stdin with "q" so the function returns.
+	_, _ = inW.Write([]byte("q\n"))
+	_ = inW.Close()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("handleFeedbackWithSender returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleFeedbackWithSender did not return within 2s after stdin close")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────
 // #679 test matrix (a) — rating + comment + 'n' on confirm prompt.
 // GhCmd NOT called, state IS saved, stdout contains 'Not posted.'
 // ──────────────────────────────────────────────────────────────────
@@ -89,7 +158,7 @@ func TestIssue679_ConfirmN_DoesNotPost(t *testing.T) {
 	m := newFeedbackMocks()
 	var stdout strings.Builder
 
-	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, &stdout); err != nil {
+	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, os.Stdin, &stdout); err != nil {
 		t.Fatalf("handleFeedbackWithSender returned error: %v", err)
 	}
 	if m.ghCalled {
@@ -119,7 +188,7 @@ func TestIssue679_ConfirmY_GhSuccess_Posts(t *testing.T) {
 	m := newFeedbackMocks()
 	var stdout strings.Builder
 
-	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, &stdout); err != nil {
+	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, os.Stdin, &stdout); err != nil {
 		t.Fatalf("handleFeedbackWithSender returned error: %v", err)
 	}
 	if !m.ghCalled {
@@ -161,7 +230,7 @@ func TestIssue679_ConfirmY_GhFailure_NoFallback(t *testing.T) {
 	m.ghFailErr = errors.New("gh: authentication required")
 	var stdout strings.Builder
 
-	err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, &stdout)
+	err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, os.Stdin, &stdout)
 	if err == nil {
 		t.Fatal("handleFeedbackWithSender must return an error when gh fails (non-zero exit)")
 	}
@@ -193,7 +262,7 @@ func TestIssue679_EmptyConfirm_DefaultNo(t *testing.T) {
 	m := newFeedbackMocks()
 	var stdout strings.Builder
 
-	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, &stdout); err != nil {
+	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, os.Stdin, &stdout); err != nil {
 		t.Fatalf("handleFeedbackWithSender returned error: %v", err)
 	}
 	if m.ghCalled {
@@ -214,7 +283,7 @@ func TestIssue679_Confirm_UppercaseY(t *testing.T) {
 	m := newFeedbackMocks()
 	var stdout strings.Builder
 
-	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, &stdout); err != nil {
+	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, os.Stdin, &stdout); err != nil {
 		t.Fatalf("handleFeedbackWithSender returned error: %v", err)
 	}
 	if !m.ghCalled {
@@ -232,7 +301,7 @@ func TestIssue679_Confirm_WhitespaceY(t *testing.T) {
 	m := newFeedbackMocks()
 	var stdout strings.Builder
 
-	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, &stdout); err != nil {
+	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, os.Stdin, &stdout); err != nil {
 		t.Fatalf("handleFeedbackWithSender returned error: %v", err)
 	}
 	if !m.ghCalled {
@@ -253,7 +322,7 @@ func TestIssue679_Disclosure_PreviewMatchesFormatComment(t *testing.T) {
 	m := newFeedbackMocks()
 	var stdout strings.Builder
 
-	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, &stdout); err != nil {
+	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, os.Stdin, &stdout); err != nil {
 		t.Fatalf("handleFeedbackWithSender returned error: %v", err)
 	}
 	body := feedback.FormatComment("1.7.35", 2, runtime.GOOS, runtime.GOARCH, comment)
@@ -275,7 +344,7 @@ func TestIssue679_Disclosure_ShowsLogin(t *testing.T) {
 
 	m := newFeedbackMocks()
 	var stdout strings.Builder
-	_ = handleFeedbackWithSender([]string{}, "1.7.35", m.sender, &stdout)
+	_ = handleFeedbackWithSender([]string{}, "1.7.35", m.sender, os.Stdin, &stdout)
 
 	out := stdout.String()
 	if !strings.Contains(out, "@octocat") {
@@ -301,7 +370,7 @@ func TestIssue679_Disclosure_LoginFallback(t *testing.T) {
 
 	m := newFeedbackMocks()
 	var stdout strings.Builder
-	_ = handleFeedbackWithSender([]string{}, "1.7.35", m.sender, &stdout)
+	_ = handleFeedbackWithSender([]string{}, "1.7.35", m.sender, os.Stdin, &stdout)
 
 	out := stdout.String()
 	if !strings.Contains(out, "your GitHub account") {
@@ -321,7 +390,7 @@ func TestIssue679_OptOut_Unchanged(t *testing.T) {
 
 	m := newFeedbackMocks()
 	var stdout strings.Builder
-	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, &stdout); err != nil {
+	if err := handleFeedbackWithSender([]string{}, "1.7.35", m.sender, os.Stdin, &stdout); err != nil {
 		t.Fatalf("handleFeedbackWithSender returned error: %v", err)
 	}
 	if m.ghCalled {

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -33,7 +33,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.35" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.36" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (


### PR DESCRIPTION
## Summary

Closes the critical UX gap in v1.7.35: the #679 disclosure was shipped but hidden from view due to output-buffering in `handleFeedback`. This is a hotfix — minimal scope, restores visible prompts, adds a pipe-based test that would catch this class of regression.

## The bug

`handleFeedback` wrapped every prompt, the disclosure block, and the `Post this? [y/N]` confirm in a `strings.Builder` that only flushed to `os.Stdout` after `handleFeedbackWithSender` returned. Users typed the rating, the comment, and their y/N answer at a **blank cursor**, and the disclosure they were supposed to read *before* consenting was never visible *while* they were being asked to consent.

The buffering predated #679 too (the legacy `Sent! Thanks` message had it), but #679's disclosure block is what made it impossible to ignore.

## The fix

- `handleFeedbackWithSender` signature gains `in io.Reader` before the writer.
- `handleFeedback` wires `os.Stdin` / `os.Stdout` directly — no more `strings.Builder` wrapper.
- Every `fmt.Fprint(w, …)` now reaches the terminal at the moment it is written.

## Why tests didn't catch it

The existing #679 test matrix passes a `*strings.Builder` to the handler. That type silently buffers everything, so any write-before-read ordering bug is invisible from the test's perspective.

New test: `TestFeedback_PromptPrintsBeforeStdinBlocks` in `cmd/agent-deck/feedback_cmd_test.go` pairs `io.Pipe` for both stdin and stdout, spawns the handler in a goroutine, reads from the out pipe and asserts `"Rating"` arrives **before** anything is written to the in pipe. Times out at 2 s if buffering is reintroduced. A follow-up issue tracks adding similar pipe-based smoke tests to every interactive subcommand.

## Test plan

- [x] `go test -race -count=1 ./...` green locally.
- [x] Manual smoke: `go build -o /tmp/adeck-test ./cmd/agent-deck && /tmp/adeck-test feedback < /dev/null` prints the `Rating (1-5, n=never-again, q=quit):` prompt **before** exiting — confirmed.
- [x] Manual smoke: `printf "q\n" | /tmp/adeck-test feedback` prints prompt, then `Cancelled.`, exit 0 — confirmed.
- [x] Binary reports `Agent Deck v1.7.36`.
- [ ] CI green (visual-regression pre-existing flake is acceptable per v1.7.35 precedent — escalate anything else).

## Scope

- Touches only `cmd/agent-deck/feedback_cmd.go`, its test file, `cmd/agent-deck/main.go` (version bump), and `CHANGELOG.md`.
- TUI feedback dialog (`internal/ui/feedback_dialog.go`) is unchanged.
- No schema, no CLI flags, no new dependencies.

## References

- Original issue: #679
- v1.7.35 release notes added the disclosure block that this hotfix makes visible.