### PR TITLE
fix(session): guard session restart against fresh tmux scope destruction (#30, v1.7.39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.39] - 2026-04-20
+
+### Fixed
+- **`agent-deck session restart` no longer destroys a just-created tmux scope** ([#30](https://github.com/asheshgoplani/agent-deck/issues/30)): a watchdog double-fire pattern — stop → manual `session start` → watchdog-queued `session restart` on the now-alive session — previously caused `Restart()` to tear down the fresh tmux/systemd scope regardless of current session state. Reproduced 2026-04-20 at 08:13:05 during the phase-5 resilience test against the v1.7.38 watchdog. Fix: a freshness guard in the CLI handler skips `inst.Restart()` (no-op) when the session is already healthy (`running`/`waiting`/`idle`/`starting`) AND was started within the last 60 seconds. A new persisted `Instance.LastStartedAt` JSON field carries the start stamp across CLI invocations so the guard works for the short-lived `agent-deck` process. A new `--force` flag bypasses the guard for users who genuinely want to recycle a healthy session. Scope is deliberately narrow: the check lives only in `handleSessionRestart` — `Instance.Restart()`, `Instance.RestartFresh()`, TUI restart paths, and the watchdog Python helper are unchanged. Tests: `TestShouldSkipRestart_FreshHealthy`, `TestShouldSkipRestart_StaleHealthy`, `TestShouldSkipRestart_ErrorStatus`, `TestShouldSkipRestart_StoppedStatus`, `TestShouldSkipRestart_Force`, `TestShouldSkipRestart_UnknownStartTime`, `TestShouldSkipRestart_ExactBoundary`, `TestStart_RecordsLastStartedAt` in `internal/session/restart_guard_test.go`.
+
 ## [1.7.38] - 2026-04-19
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -33,7 +33,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.38" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.39" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -316,11 +316,17 @@ func handleSessionRestart(profile string, args []string) {
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	force := fs.Bool("force", false, "Restart even if the session is already healthy and fresh (bypasses issue #30 guard)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session restart <id|title> [options]")
 		fmt.Println()
 		fmt.Println("Restart a session. For Claude sessions, this reloads MCPs.")
+		fmt.Println()
+		fmt.Println("By default, a restart is skipped (no-op) when the session is already")
+		fmt.Println("healthy (running/waiting/idle/starting) and was started within the last")
+		fmt.Println("60 seconds. This prevents watchdog double-fires from destroying a")
+		fmt.Println("just-created tmux scope (issue #30). Use --force to restart anyway.")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -352,11 +358,30 @@ func handleSessionRestart(profile string, args []string) {
 		return // unreachable, satisfies staticcheck SA5011
 	}
 
+	// Issue #30: freshness guard. Skip the restart (keep the current tmux
+	// scope intact) when the session is healthy and was started very
+	// recently. A watchdog racing `start` → `restart` on the same session
+	// must not tear down the fresh scope.
+	if skip, reason := session.ShouldSkipRestart(inst, time.Now(), *force); skip {
+		data := map[string]interface{}{
+			"success": true,
+			"skipped": true,
+			"reason":  reason,
+			"id":      inst.ID,
+			"title":   inst.Title,
+		}
+		out.Success(fmt.Sprintf("Skipped restart of %s: %s", inst.Title, reason), data)
+		return
+	}
+
 	// Restart the session
 	if err := inst.Restart(); err != nil {
 		out.Error(fmt.Sprintf("failed to restart session: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
+	// Stamp the persisted freshness marker so subsequent watchdog ticks see
+	// this session as "just started" and skip (issue #30).
+	inst.LastStartedAt = time.Now()
 	warning := inst.ConsumeCodexRestartWarning()
 	if warning != "" && !*jsonOutput {
 		fmt.Fprintf(os.Stderr, "Warning: %s\n", warning)

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -99,6 +99,14 @@ type Instance struct {
 	CreatedAt      time.Time `json:"created_at"`
 	LastAccessedAt time.Time `json:"last_accessed_at,omitempty"` // When user last attached
 
+	// LastStartedAt is the wall-clock time of the most recent successful
+	// Start() / StartWithMessage() / Restart() call. Persisted so short-lived
+	// CLI invocations can see it across processes (issue #30): a restart
+	// queued seconds after a start must detect the session is already fresh
+	// and skip the teardown. Zero value means "unknown" (old record or
+	// never started) and callers MUST NOT treat zero as "just now".
+	LastStartedAt time.Time `json:"last_started_at,omitempty"`
+
 	// Claude Code integration
 	ClaudeSessionID  string    `json:"claude_session_id,omitempty"`
 	ClaudeDetectedAt time.Time `json:"claude_detected_at,omitempty"`
@@ -2166,6 +2174,7 @@ func (i *Instance) Start() error {
 
 	// Record start time for grace period (prevents error flash during tmux startup)
 	i.lastStartTime = time.Now()
+	i.markStarted() // persisted stamp (issue #30 — cross-process freshness guard)
 
 	// New sessions start as STARTING - shows they're initializing
 	// After 5s grace period, status will be properly detected from tmux
@@ -2311,6 +2320,7 @@ func (i *Instance) StartWithMessage(message string) error {
 
 	// Record start time for grace period (prevents error flash during tmux startup)
 	i.lastStartTime = time.Now()
+	i.markStarted() // persisted stamp (issue #30 — cross-process freshness guard)
 
 	// New sessions start as STARTING
 	i.Status = StatusStarting

--- a/internal/session/restart_guard.go
+++ b/internal/session/restart_guard.go
@@ -1,0 +1,61 @@
+package session
+
+import (
+	"fmt"
+	"time"
+)
+
+// restartFreshnessWindow is the grace period during which a healthy session
+// that was just started is considered "too fresh to restart". Issue #30: the
+// watchdog previously queued a redundant `session restart` seconds after a
+// manual `session start`, and the restart tore down the just-created tmux
+// scope. 60 seconds covers typical watchdog tick + queue latency without
+// meaningfully blocking legitimate rapid recycles.
+const restartFreshnessWindow = 60 * time.Second
+
+// ShouldSkipRestart decides whether `agent-deck session restart` should
+// short-circuit instead of calling Instance.Restart().
+//
+// Returns skip=true (with a human-readable reason) when the session is in a
+// healthy state AND was started within restartFreshnessWindow. The force
+// parameter (wired to the CLI --force flag) bypasses the guard.
+//
+// A zero LastStartedAt is treated as "unknown" — we always permit the
+// restart so users can recover legacy records.
+func ShouldSkipRestart(inst *Instance, now time.Time, force bool) (bool, string) {
+	if inst == nil || force {
+		return false, ""
+	}
+	if inst.LastStartedAt.IsZero() {
+		return false, ""
+	}
+	if !isHealthyForFreshnessGuard(inst.Status) {
+		return false, ""
+	}
+	age := now.Sub(inst.LastStartedAt)
+	if age >= restartFreshnessWindow {
+		return false, ""
+	}
+	return true, fmt.Sprintf(
+		"session is %s and was started %s ago (within %s freshness window); use --force to restart anyway",
+		inst.Status, age.Round(time.Second), restartFreshnessWindow,
+	)
+}
+
+// isHealthyForFreshnessGuard reports whether the status indicates the session
+// is alive enough that a restart would be destructive.
+func isHealthyForFreshnessGuard(s Status) bool {
+	switch s {
+	case StatusRunning, StatusWaiting, StatusIdle, StatusStarting:
+		return true
+	default:
+		return false
+	}
+}
+
+// markStarted stamps LastStartedAt with the current wall-clock time. It is
+// the single source of truth for the persisted start timestamp so tests and
+// callers don't drift.
+func (i *Instance) markStarted() {
+	i.LastStartedAt = time.Now()
+}

--- a/internal/session/restart_guard_test.go
+++ b/internal/session/restart_guard_test.go
@@ -1,0 +1,126 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// TestShouldSkipRestart_FreshHealthy reproduces issue #30: a session that was
+// just started (healthy + fresh) must NOT be restarted, because the watchdog
+// sometimes queues a redundant `session restart` right after a `session start`
+// and the restart would tear down the just-created tmux/scope.
+func TestShouldSkipRestart_FreshHealthy(t *testing.T) {
+	now := time.Now()
+	healthyStates := []Status{StatusRunning, StatusWaiting, StatusIdle, StatusStarting}
+	for _, st := range healthyStates {
+		inst := &Instance{
+			Status:        st,
+			LastStartedAt: now.Add(-30 * time.Second), // 30s ago, within freshness window
+		}
+		skip, reason := ShouldSkipRestart(inst, now, false)
+		if !skip {
+			t.Errorf("status=%s fresh: want skip=true, got skip=false", st)
+		}
+		if reason == "" {
+			t.Errorf("status=%s fresh: want non-empty reason, got empty", st)
+		}
+	}
+}
+
+// TestShouldSkipRestart_StaleHealthy — a healthy session that's been running
+// for a while (past the freshness window) is a legitimate restart target.
+func TestShouldSkipRestart_StaleHealthy(t *testing.T) {
+	now := time.Now()
+	inst := &Instance{
+		Status:        StatusRunning,
+		LastStartedAt: now.Add(-5 * time.Minute),
+	}
+	skip, _ := ShouldSkipRestart(inst, now, false)
+	if skip {
+		t.Errorf("stale healthy session: want skip=false, got skip=true")
+	}
+}
+
+// TestShouldSkipRestart_ErrorStatus — restarts on errored sessions always proceed.
+func TestShouldSkipRestart_ErrorStatus(t *testing.T) {
+	now := time.Now()
+	inst := &Instance{
+		Status:        StatusError,
+		LastStartedAt: now.Add(-5 * time.Second), // fresh, but errored
+	}
+	skip, _ := ShouldSkipRestart(inst, now, false)
+	if skip {
+		t.Errorf("error status: want skip=false, got skip=true")
+	}
+}
+
+// TestShouldSkipRestart_StoppedStatus — restarts on stopped sessions always proceed.
+func TestShouldSkipRestart_StoppedStatus(t *testing.T) {
+	now := time.Now()
+	inst := &Instance{
+		Status:        StatusStopped,
+		LastStartedAt: now.Add(-5 * time.Second),
+	}
+	skip, _ := ShouldSkipRestart(inst, now, false)
+	if skip {
+		t.Errorf("stopped status: want skip=false, got skip=true")
+	}
+}
+
+// TestShouldSkipRestart_Force — --force bypasses the freshness guard.
+func TestShouldSkipRestart_Force(t *testing.T) {
+	now := time.Now()
+	inst := &Instance{
+		Status:        StatusRunning,
+		LastStartedAt: now.Add(-10 * time.Second),
+	}
+	skip, _ := ShouldSkipRestart(inst, now, true)
+	if skip {
+		t.Errorf("force=true: want skip=false, got skip=true")
+	}
+}
+
+// TestShouldSkipRestart_UnknownStartTime — if LastStartedAt is zero (e.g. old
+// session persisted before this field existed), proceed with the restart.
+// Otherwise users could never recover such sessions via `session restart`.
+func TestShouldSkipRestart_UnknownStartTime(t *testing.T) {
+	now := time.Now()
+	inst := &Instance{
+		Status:        StatusRunning,
+		LastStartedAt: time.Time{}, // zero value
+	}
+	skip, _ := ShouldSkipRestart(inst, now, false)
+	if skip {
+		t.Errorf("zero LastStartedAt: want skip=false, got skip=true")
+	}
+}
+
+// TestShouldSkipRestart_ExactBoundary — at exactly 60s the session is no
+// longer considered fresh.
+func TestShouldSkipRestart_ExactBoundary(t *testing.T) {
+	now := time.Now()
+	inst := &Instance{
+		Status:        StatusRunning,
+		LastStartedAt: now.Add(-restartFreshnessWindow),
+	}
+	skip, _ := ShouldSkipRestart(inst, now, false)
+	if skip {
+		t.Errorf("at freshness boundary: want skip=false, got skip=true")
+	}
+}
+
+// TestStart_RecordsLastStartedAt — the Instance.Start() code path must stamp
+// LastStartedAt so a subsequent restart can consult it. Without this wiring
+// the guard is a no-op and the #30 regression returns.
+func TestStart_RecordsLastStartedAt(t *testing.T) {
+	inst := &Instance{
+		LastStartedAt: time.Time{},
+	}
+	before := time.Now()
+	inst.markStarted() // helper encapsulating the LastStartedAt stamp
+	after := time.Now()
+
+	if inst.LastStartedAt.Before(before) || inst.LastStartedAt.After(after) {
+		t.Fatalf("LastStartedAt=%v, want between %v and %v", inst.LastStartedAt, before, after)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes [#30](https://github.com/asheshgoplani/agent-deck/issues/30): `agent-deck session restart` destroys a just-created tmux scope when the watchdog queues a redundant restart seconds after a manual `session start`.
- Adds a freshness guard in the CLI handler: skip `Restart()` as a no-op when the session is already healthy (`running`/`waiting`/`idle`/`starting`) AND was started within the last 60 seconds.
- New persisted `Instance.LastStartedAt` JSON field carries the start stamp across short-lived CLI invocations.
- New `--force` flag bypasses the guard for legitimate rapid recycles.
- Ships as v1.7.39.

## Reproduction
Reproduced 2026-04-20 at 08:13:05 during the phase-5 resilience test against the v1.7.38 watchdog: stop → manual `session start` (fresh tmux scope created, session becomes `waiting`/`running`) → watchdog queues `session restart` on the now-alive session → `Restart()` tore down the fresh scope regardless of current state.

## Scope
Deliberately narrow — only the `agent-deck session restart` CLI handler consults the guard. `Instance.Restart()`, `Instance.RestartFresh()`, TUI restart paths, and the watchdog Python helper are unchanged.

## TDD
RED → GREEN → REFACTOR. Failing tests written first in `internal/session/restart_guard_test.go`, then the pure `ShouldSkipRestart` helper + `Instance.LastStartedAt` field + CLI wiring added to turn them green.

8 new tests:
- `TestShouldSkipRestart_FreshHealthy` (covers all 4 healthy statuses)
- `TestShouldSkipRestart_StaleHealthy`
- `TestShouldSkipRestart_ErrorStatus`
- `TestShouldSkipRestart_StoppedStatus`
- `TestShouldSkipRestart_Force`
- `TestShouldSkipRestart_UnknownStartTime`
- `TestShouldSkipRestart_ExactBoundary`
- `TestStart_RecordsLastStartedAt`

## Test plan
- [x] `GOTOOLCHAIN=go1.24.0 go test ./internal/session/ -run 'TestShouldSkipRestart|TestStart_RecordsLastStartedAt' -race -count=1` — 8/8 pass
- [x] `GOTOOLCHAIN=go1.24.0 go test -run TestPersistence_ ./internal/session/... -race -count=1` — mandated persistence suite passes
- [x] `GOTOOLCHAIN=go1.24.0 go test ./internal/feedback/... ./internal/ui/... ./cmd/agent-deck/... -run "Feedback|Sender_" -race -count=1` — mandated feedback suite passes
- [x] `GOTOOLCHAIN=go1.24.0 go test ./... -race -count=1 -timeout 600s` — full repo suite green
- [x] `agent-deck session restart --help` — docs describe guard + `--force`
- [ ] Manual verification on Linux+systemd host (phase-5 watchdog rerun) — pending post-release