### PR TITLE
feat(ui): add zoxide-backed quick-open picker

### DIFF
--- a/internal/session/zoxide.go
+++ b/internal/session/zoxide.go
@@ -1,0 +1,48 @@
+package session
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+)
+
+// ZoxideAvailable reports whether the zoxide binary is reachable on PATH.
+func ZoxideAvailable() bool {
+	_, err := exec.LookPath("zoxide")
+	return err == nil
+}
+
+// ZoxideQuery returns matching directory paths from zoxide's database, ordered
+// by frecency. An empty query returns the full list. Returns an empty slice
+// (not an error) when zoxide has no matches for the query.
+func ZoxideQuery(ctx context.Context, query string) ([]string, error) {
+	args := []string{"query", "--list"}
+	if q := strings.TrimSpace(query); q != "" {
+		args = append(args, q)
+	}
+	cmd := exec.CommandContext(ctx, "zoxide", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && ee.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return parseZoxideOutput(out), nil
+}
+
+func parseZoxideOutput(out []byte) []string {
+	var paths []string
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths
+}

--- a/internal/session/zoxide_test.go
+++ b/internal/session/zoxide_test.go
@@ -1,0 +1,27 @@
+package session
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseZoxideOutput_StripsBlankAndWhitespace(t *testing.T) {
+
+	raw := []byte("/Users/me/proj-a\n\n  /Users/me/proj-b  \n\t\n/Users/me/proj-c\n")
+
+	got := parseZoxideOutput(raw)
+
+	want := []string{"/Users/me/proj-a", "/Users/me/proj-b", "/Users/me/proj-c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseZoxideOutput = %v, want %v", got, want)
+	}
+}
+
+func TestParseZoxideOutput_EmptyInput(t *testing.T) {
+
+	got := parseZoxideOutput(nil)
+
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -210,6 +210,7 @@ type Home struct {
 	sessionPickerDialog  *SessionPickerDialog  // For sending output to another session
 	worktreeFinishDialog *WorktreeFinishDialog // For finishing worktree sessions (merge + cleanup)
 	feedbackDialog       *FeedbackDialog       // For in-app feedback popup (Phase 2)
+	zoxidePicker         *ZoxidePicker         // Quick-open picker backed by the zoxide DB
 	feedbackState        *feedback.State       // Loaded at first show, avoids repeated disk I/O
 	feedbackSender       *feedback.Sender      // Sender constructed once in NewHome (Phase 3, per D-05)
 	watcherPanel         *WatcherPanel         // For showing watcher status and events
@@ -726,6 +727,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		sessionPickerDialog:  NewSessionPickerDialog(),
 		worktreeFinishDialog: NewWorktreeFinishDialog(),
 		feedbackDialog:       NewFeedbackDialog(),
+		zoxidePicker:         NewZoxidePicker(),
 		feedbackSender:       feedback.NewSender(),
 		watcherPanel:         NewWatcherPanel(),
 		cursor:               0,
@@ -4754,6 +4756,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.feedbackDialog = d
 			return h, cmd
 		}
+		if h.zoxidePicker.IsVisible() {
+			return h.handleZoxidePickerKey(msg)
+		}
 
 		if h.showCostDashboard {
 			keyStr := msg.String()
@@ -5280,7 +5285,8 @@ func (h *Home) hasModalVisible() bool {
 		h.newDialog.IsVisible() || h.groupDialog.IsVisible() || h.forkDialog.IsVisible() ||
 		h.confirmDialog.IsVisible() || h.mcpDialog.IsVisible() || h.skillDialog.IsVisible() ||
 		h.geminiModelDialog.IsVisible() || h.sessionPickerDialog.IsVisible() ||
-		h.worktreeFinishDialog.IsVisible() || h.editPathsDialog.IsVisible()
+		h.worktreeFinishDialog.IsVisible() || h.editPathsDialog.IsVisible() ||
+		h.zoxidePicker.IsVisible()
 }
 
 // markNavigationAndFetchPreview sets navigation tracking state and returns a debounced preview command
@@ -6081,6 +6087,11 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		// Quick create: auto-generated name, smart defaults from group context
 		return h, h.quickCreateSession()
+
+	case "z":
+		h.zoxidePicker.SetSize(h.width, h.height)
+		h.zoxidePicker.Show()
+		return h, nil
 
 	case "d":
 		// Show confirmation dialog before deletion (prevents accidental deletion)
@@ -7802,6 +7813,83 @@ func (h *Home) quickCreateSession() tea.Cmd {
 	)
 }
 
+// deriveSessionNameFromPath returns the trailing directory of projectPath as a
+// session title. Falls back to a generated name for paths that have no
+// meaningful basename (empty, root, or relative `.`).
+func deriveSessionNameFromPath(projectPath string) string {
+	base := filepath.Base(strings.TrimSpace(projectPath))
+	if base == "" || base == "." || base == "/" {
+		return session.GenerateSessionName()
+	}
+	return base
+}
+
+// ensureUniqueSessionTitle appends a numeric suffix if the preferred title
+// collides with an existing instance. Dedup is global rather than per-group
+// so the zoxide flow doesn't depend on post-hoc group derivation.
+func ensureUniqueSessionTitle(preferred string, instances []*session.Instance) string {
+	used := make(map[string]bool, len(instances))
+	for _, inst := range instances {
+		used[inst.Title] = true
+	}
+	if !used[preferred] {
+		return preferred
+	}
+	for i := 2; i < 1000; i++ {
+		candidate := fmt.Sprintf("%s-%d", preferred, i)
+		if !used[candidate] {
+			return candidate
+		}
+	}
+	return fmt.Sprintf("%s-%d", preferred, time.Now().Unix())
+}
+
+func (h *Home) handleZoxidePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		h.zoxidePicker.Hide()
+		return h, nil
+	case "enter":
+		selected := h.zoxidePicker.Selected()
+		h.zoxidePicker.Hide()
+		if selected == "" {
+			return h, nil
+		}
+		return h, h.quickCreateSessionAt(selected)
+	default:
+		h.zoxidePicker, _ = h.zoxidePicker.Update(msg)
+		return h, nil
+	}
+}
+
+// quickCreateSessionAt creates a session rooted at the given path with an
+// auto-generated name and the user's configured default tool, bypassing
+// cursor-context tool inheritance so the zoxide flow always lands on the
+// user's chosen default (Claude, unless overridden in config.toml).
+func (h *Home) quickCreateSessionAt(projectPath string) tea.Cmd {
+	tool := session.GetDefaultTool()
+	if tool == "" {
+		tool = "claude"
+	}
+	command := tool
+
+	preferred := deriveSessionNameFromPath(projectPath)
+	h.instancesMu.RLock()
+	name := ensureUniqueSessionTitle(preferred, h.instances)
+	h.instancesMu.RUnlock()
+
+	return h.createSessionInGroupWithWorktreeAndOptions(
+		name, projectPath, command,
+		"",         // empty group → creator derives from path via extractGroupPath
+		"", "", "", // no worktree
+		false, false, nil,
+		nil, // no extra claude args
+		false, nil,
+		"", "",
+		"",
+	)
+}
+
 // suggestConductorParent returns the ID of the most contextually relevant conductor
 // based on the current cursor position: the cursor session itself if it's a conductor,
 // or the conductor pointed to by its ParentSessionID.
@@ -8788,6 +8876,9 @@ func (h *Home) View() string {
 	}
 	if h.feedbackDialog.IsVisible() {
 		return h.feedbackDialog.View()
+	}
+	if h.zoxidePicker.IsVisible() {
+		return h.zoxidePicker.View()
 	}
 	if h.showCostDashboard {
 		return h.costDashboard.View()

--- a/internal/ui/tui_eval_seam_a_test.go
+++ b/internal/ui/tui_eval_seam_a_test.go
@@ -107,6 +107,7 @@ func newSeamATestHome() *Home {
 		sessionPickerDialog:  NewSessionPickerDialog(),
 		worktreeFinishDialog: NewWorktreeFinishDialog(),
 		feedbackDialog:       NewFeedbackDialog(),
+		zoxidePicker:         NewZoxidePicker(),
 		globalSearch:         NewGlobalSearch(),
 		watcherPanel:         NewWatcherPanel(),
 		notesEditor:          newNotesEditor(),

--- a/internal/ui/tui_eval_seam_b_test.go
+++ b/internal/ui/tui_eval_seam_b_test.go
@@ -158,6 +158,7 @@ func seamBNewHome() *Home {
 		sessionPickerDialog:  NewSessionPickerDialog(),
 		worktreeFinishDialog: NewWorktreeFinishDialog(),
 		feedbackDialog:       NewFeedbackDialog(),
+		zoxidePicker:         NewZoxidePicker(),
 		globalSearch:         NewGlobalSearch(),
 		watcherPanel:         NewWatcherPanel(),
 		notesEditor:          newNotesEditor(),

--- a/internal/ui/zoxide_picker.go
+++ b/internal/ui/zoxide_picker.go
@@ -1,0 +1,240 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+const (
+	maxZoxideResultsShown = 10
+	zoxideQueryTimeout    = 500 * time.Millisecond
+)
+
+// zoxideQueryFunc looks up matching paths from the zoxide database for the
+// given query. Injected via the picker for deterministic tests.
+type zoxideQueryFunc func(query string) ([]string, error)
+
+// ZoxidePicker is a minimal overlay that fuzzy-matches directories via zoxide
+// and returns the selected path for quick session creation.
+type ZoxidePicker struct {
+	visible    bool
+	queryInput textinput.Model
+	results    []string
+	cursor     int
+	width      int
+	height     int
+	errMsg     string
+	unavail    bool // zoxide not installed; results disabled
+	queryFn    zoxideQueryFunc
+}
+
+// NewZoxidePicker constructs a picker wired to the real zoxide binary.
+func NewZoxidePicker() *ZoxidePicker {
+	return newZoxidePickerWithQueryFn(defaultZoxideQuery)
+}
+
+func newZoxidePickerWithQueryFn(fn zoxideQueryFunc) *ZoxidePicker {
+	ti := textinput.New()
+	ti.Placeholder = "fragment of a path you've visited"
+	ti.CharLimit = 256
+	ti.Width = 40
+	return &ZoxidePicker{
+		queryInput: ti,
+		queryFn:    fn,
+	}
+}
+
+func defaultZoxideQuery(query string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), zoxideQueryTimeout)
+	defer cancel()
+	return session.ZoxideQuery(ctx, query)
+}
+
+// Show opens the picker. If zoxide is missing the picker still renders but
+// displays an install hint and disables selection.
+func (z *ZoxidePicker) Show() {
+	z.visible = true
+	z.errMsg = ""
+	z.cursor = 0
+	z.queryInput.SetValue("")
+	z.queryInput.CursorEnd()
+	z.queryInput.Focus()
+
+	if !session.ZoxideAvailable() {
+		z.unavail = true
+		z.results = nil
+		return
+	}
+	z.unavail = false
+	z.refreshResults()
+}
+
+// Hide closes the picker.
+func (z *ZoxidePicker) Hide() {
+	z.visible = false
+	z.queryInput.Blur()
+}
+
+// IsVisible reports whether the picker is currently shown.
+func (z *ZoxidePicker) IsVisible() bool { return z.visible }
+
+// Selected returns the highlighted path, or empty if nothing is selectable.
+func (z *ZoxidePicker) Selected() string {
+	if z.cursor < 0 || z.cursor >= len(z.results) {
+		return ""
+	}
+	return z.results[z.cursor]
+}
+
+// SetSize updates the dialog viewport for centering.
+func (z *ZoxidePicker) SetSize(width, height int) {
+	z.width = width
+	z.height = height
+}
+
+// Update processes a key event and refreshes results when the query changes.
+func (z *ZoxidePicker) Update(msg tea.KeyMsg) (*ZoxidePicker, tea.Cmd) {
+	switch msg.String() {
+	case "up", "ctrl+p":
+		if z.cursor > 0 {
+			z.cursor--
+		}
+		return z, nil
+	case "down", "ctrl+n":
+		if z.cursor < len(z.results)-1 {
+			z.cursor++
+		}
+		return z, nil
+	}
+
+	prev := z.queryInput.Value()
+	var cmd tea.Cmd
+	z.queryInput, cmd = z.queryInput.Update(msg)
+	if z.queryInput.Value() != prev && !z.unavail {
+		z.refreshResults()
+	}
+	return z, cmd
+}
+
+func (z *ZoxidePicker) refreshResults() {
+	results, err := z.queryFn(z.queryInput.Value())
+	if err != nil {
+		z.errMsg = err.Error()
+		z.results = nil
+		z.cursor = 0
+		return
+	}
+	z.errMsg = ""
+	z.results = results
+	if z.cursor >= len(z.results) {
+		z.cursor = 0
+	}
+}
+
+// View renders the overlay, centered in the viewport.
+func (z *ZoxidePicker) View() string {
+	if !z.visible {
+		return ""
+	}
+
+	title := DialogTitleStyle.Render("Quick Open (zoxide)")
+	body := z.queryInput.View()
+
+	var listBlock string
+	switch {
+	case z.unavail:
+		listBlock = lipgloss.NewStyle().
+			Foreground(ColorRed).
+			Render("zoxide not found on PATH\ninstall: brew install zoxide")
+	case z.errMsg != "":
+		listBlock = lipgloss.NewStyle().
+			Foreground(ColorRed).
+			Render("⚠ " + z.errMsg)
+	case len(z.results) == 0:
+		listBlock = lipgloss.NewStyle().
+			Foreground(ColorTextDim).
+			Render("(no matches)")
+	default:
+		listBlock = z.renderResults()
+	}
+
+	hintStyle := lipgloss.NewStyle().Foreground(ColorComment)
+	hint := hintStyle.Render("↑/↓ navigate │ Enter open │ Esc cancel")
+
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		title,
+		"",
+		body,
+		"",
+		listBlock,
+		"",
+		hint,
+	)
+
+	dialog := DialogBoxStyle.
+		Width(z.dialogWidth()).
+		Render(content)
+
+	return lipgloss.Place(
+		z.width,
+		z.height,
+		lipgloss.Center,
+		lipgloss.Center,
+		dialog,
+	)
+}
+
+func (z *ZoxidePicker) renderResults() string {
+	shown := z.results
+	if len(shown) > maxZoxideResultsShown {
+		shown = shown[:maxZoxideResultsShown]
+	}
+	rowStyle := lipgloss.NewStyle().Foreground(ColorText).Padding(0, 1)
+	selStyle := lipgloss.NewStyle().
+		Foreground(ColorBg).
+		Background(ColorAccent).
+		Bold(true).
+		Padding(0, 1)
+
+	home, _ := os.UserHomeDir()
+	rows := make([]string, 0, len(shown)+1)
+	for i, p := range shown {
+		display := p
+		if home != "" && strings.HasPrefix(p, home) {
+			display = "~" + strings.TrimPrefix(p, home)
+		}
+		if i == z.cursor {
+			rows = append(rows, selStyle.Render(display))
+		} else {
+			rows = append(rows, rowStyle.Render(display))
+		}
+	}
+	if extra := len(z.results) - len(shown); extra > 0 {
+		rows = append(rows, lipgloss.NewStyle().
+			Foreground(ColorTextDim).
+			Render(fmt.Sprintf("  (+%d more — refine query)", extra)))
+	}
+	return strings.Join(rows, "\n")
+}
+
+func (z *ZoxidePicker) dialogWidth() int {
+	const preferred = 70
+	if z.width > 0 && z.width < preferred+10 {
+		w := z.width - 10
+		if w < 40 {
+			w = 40
+		}
+		return w
+	}
+	return preferred
+}

--- a/internal/ui/zoxide_picker_home_test.go
+++ b/internal/ui/zoxide_picker_home_test.go
@@ -1,0 +1,113 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestDeriveSessionNameFromPath_UsesBase(t *testing.T) {
+
+	got := deriveSessionNameFromPath("/Users/me/projects/goat")
+
+	if got != "goat" {
+		t.Fatalf("deriveSessionNameFromPath = %q, want goat", got)
+	}
+}
+
+func TestDeriveSessionNameFromPath_TrailingSlashStripped(t *testing.T) {
+
+	got := deriveSessionNameFromPath("/Users/me/projects/goat/")
+
+	if got != "goat" {
+		t.Fatalf("deriveSessionNameFromPath = %q, want goat", got)
+	}
+}
+
+func TestDeriveSessionNameFromPath_EmptyFallsBackToGenerated(t *testing.T) {
+
+	got := deriveSessionNameFromPath("")
+
+	if got == "" || strings.ContainsAny(got, "/.") {
+		t.Fatalf("expected a generated fallback name, got %q", got)
+	}
+}
+
+func TestEnsureUniqueSessionTitle_NoCollision(t *testing.T) {
+	instances := []*session.Instance{{Title: "existing"}}
+
+	got := ensureUniqueSessionTitle("goat", instances)
+
+	if got != "goat" {
+		t.Fatalf("ensureUniqueSessionTitle = %q, want goat", got)
+	}
+}
+
+func TestEnsureUniqueSessionTitle_SuffixesOnCollision(t *testing.T) {
+	instances := []*session.Instance{
+		{Title: "goat"},
+		{Title: "goat-2"},
+	}
+
+	got := ensureUniqueSessionTitle("goat", instances)
+
+	if got != "goat-3" {
+		t.Fatalf("ensureUniqueSessionTitle = %q, want goat-3", got)
+	}
+}
+
+func TestHome_ZoxidePickerInitialized(t *testing.T) {
+	home := NewHome()
+
+	if home.zoxidePicker == nil {
+		t.Fatal("zoxidePicker should be initialized")
+	}
+	if home.zoxidePicker.IsVisible() {
+		t.Fatal("zoxidePicker should start hidden")
+	}
+}
+
+func TestHome_ZPressOpensPicker(t *testing.T) {
+	home := NewHome()
+
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("expected *Home, got %T", model)
+	}
+	if !h.zoxidePicker.IsVisible() {
+		t.Fatal("expected picker to be visible after pressing z")
+	}
+}
+
+func TestHome_ZoxidePickerEscClosesWithoutCreating(t *testing.T) {
+	home := NewHome()
+	home.zoxidePicker = newZoxidePickerWithQueryFn(stubQueryFn([]string{"/some/path"}, nil))
+	home.zoxidePicker.Show()
+
+	model, _ := home.handleZoxidePickerKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	h := model.(*Home)
+	if h.zoxidePicker.IsVisible() {
+		t.Fatal("expected picker hidden after esc")
+	}
+}
+
+func TestHome_HasModalVisibleIncludesPicker(t *testing.T) {
+	home := NewHome()
+	home.initialLoading = false // clear the splash so the picker bit is what we observe
+
+	if home.hasModalVisible() {
+		t.Fatal("expected no modals visible before showing picker")
+	}
+
+	home.zoxidePicker.Show()
+
+	if !home.hasModalVisible() {
+		t.Fatal("hasModalVisible should be true while picker is open")
+	}
+}

--- a/internal/ui/zoxide_picker_test.go
+++ b/internal/ui/zoxide_picker_test.go
@@ -1,0 +1,119 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func stubQueryFn(paths []string, err error) zoxideQueryFunc {
+	return func(string) ([]string, error) {
+		return paths, err
+	}
+}
+
+func feedRune(t *testing.T, z *ZoxidePicker, r rune) {
+	t.Helper()
+	z, _ = z.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	_ = z
+}
+
+func TestZoxidePicker_ShowPopulatesResults(t *testing.T) {
+
+	paths := []string{"/home/me/a", "/home/me/b"}
+	z := newZoxidePickerWithQueryFn(stubQueryFn(paths, nil))
+
+	z.Show()
+
+	if !z.IsVisible() {
+		t.Fatal("expected picker to be visible")
+	}
+	if got := z.Selected(); got != "/home/me/a" {
+		t.Fatalf("Selected() = %q, want /home/me/a", got)
+	}
+}
+
+func TestZoxidePicker_TypingRefreshesResults(t *testing.T) {
+	calls := 0
+	fn := func(q string) ([]string, error) {
+		calls++
+		if q == "" {
+			return []string{"/first/path"}, nil
+		}
+		return []string{"/queried/" + q}, nil
+	}
+	z := newZoxidePickerWithQueryFn(fn)
+	z.Show()
+	preTypingCalls := calls
+
+	feedRune(t, z, 'x')
+
+	if calls != preTypingCalls+1 {
+		t.Fatalf("expected one refresh per keystroke, got %d (was %d)", calls, preTypingCalls)
+	}
+	if got := z.Selected(); got != "/queried/x" {
+		t.Fatalf("Selected() = %q, want /queried/x", got)
+	}
+}
+
+func TestZoxidePicker_CursorNavClamped(t *testing.T) {
+	z := newZoxidePickerWithQueryFn(stubQueryFn([]string{"/a", "/b", "/c"}, nil))
+	z.Show()
+
+	z, _ = z.Update(tea.KeyMsg{Type: tea.KeyDown})
+	z, _ = z.Update(tea.KeyMsg{Type: tea.KeyDown})
+	z, _ = z.Update(tea.KeyMsg{Type: tea.KeyDown}) // past end
+	if got := z.Selected(); got != "/c" {
+		t.Fatalf("after 3 downs Selected() = %q, want /c", got)
+	}
+
+	z, _ = z.Update(tea.KeyMsg{Type: tea.KeyUp})
+	z, _ = z.Update(tea.KeyMsg{Type: tea.KeyUp})
+	z, _ = z.Update(tea.KeyMsg{Type: tea.KeyUp}) // past start
+	if got := z.Selected(); got != "/a" {
+		t.Fatalf("after 3 ups Selected() = %q, want /a", got)
+	}
+}
+
+func TestZoxidePicker_QueryErrorSurfaced(t *testing.T) {
+	z := newZoxidePickerWithQueryFn(stubQueryFn(nil, errors.New("boom")))
+
+	z.Show()
+
+	if z.Selected() != "" {
+		t.Fatalf("expected no selection on error, got %q", z.Selected())
+	}
+	view := z.View()
+	if view == "" {
+		t.Fatal("expected non-empty view on error")
+	}
+}
+
+func TestZoxidePicker_HideClearsVisibility(t *testing.T) {
+	z := newZoxidePickerWithQueryFn(stubQueryFn([]string{"/x"}, nil))
+	z.Show()
+
+	z.Hide()
+
+	if z.IsVisible() {
+		t.Fatal("expected picker hidden")
+	}
+	if z.View() != "" {
+		t.Fatal("hidden picker should render empty")
+	}
+}
+
+func TestZoxidePicker_NoResultsShowsHint(t *testing.T) {
+	z := newZoxidePickerWithQueryFn(stubQueryFn(nil, nil))
+	z.SetSize(120, 40)
+
+	z.Show()
+
+	if z.Selected() != "" {
+		t.Fatalf("expected no selection with empty results, got %q", z.Selected())
+	}
+	if z.View() == "" {
+		t.Fatal("expected non-empty view even with no results")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `z` hotkey on the home view that opens a fuzzy directory picker backed by [zoxide](https://github.com/ajeitler/zoxide). Goal: collapse the "new Claude session in directory X" workflow to one keystroke → a few characters → Enter, with no name prompt, no path prompt, no tool prompt.

The picker reads from `zoxide query --list [query]` live as you type, so you get frecency-ranked directories you've actually visited. Enter launches Claude rooted at the selected path.

## Design decisions

- **Session title derived from the path.** Selecting `/Users/me/projects/goat` yields a session titled `goat`. Collisions get `-2`, `-3`, … Degenerate paths (empty, `.`, `/`) fall back to `GenerateSessionName()` so no session ever lands with a blank or `/` title.
- **Tool always = `default_tool` config (or `claude`).** The zoxide flow deliberately skips cursor-context / most-recent-in-group inheritance that `Shift+N` uses. The whole point is a deterministic one-keystroke workflow — inheritance would make the outcome depend on cursor state.
- **Group derived from the path**, via the existing `extractGroupPath` fallthrough in `createSessionInGroupWithWorktreeAndOptions` (empty `groupPath` → `NewInstanceWithTool` → `extractGroupPath(projectPath)`). No new exports needed.
- **Degrades gracefully when zoxide is missing.** The picker opens and shows an install hint instead of silently no-oping.

## Changes

- `internal/session/zoxide.go` + test — `ZoxideAvailable()` / `ZoxideQuery(ctx, query)`; exit code 1 (no match) treated as empty result, not an error.
- `internal/ui/zoxide_picker.go` + test — `ZoxidePicker` bubbletea overlay with single input + live dropdown; `zoxideQueryFunc` is injectable for deterministic tests.
- `internal/ui/home.go` — wires the picker: `z` key handler, `quickCreateSessionAt(path)` helper, `hasModalVisible()` + view render switch, Home struct field + constructor init. Adds `deriveSessionNameFromPath` and `ensureUniqueSessionTitle` helpers.
- `internal/ui/tui_eval_seam_{a,b}_test.go` — seed `zoxidePicker` in the minimal test fixtures so Home key-dispatch seam tests don't nil-deref.

## Test plan

- [x] `go test -race -count=1 ./internal/session/... ./internal/ui/...` — all new and existing tests pass
- [x] `go test -race -count=1 ./cmd/agent-deck/... ./internal/feedback/... ./internal/watcher/...` — mandated suites pass
- [x] `go test -race -count=1 $(go list ./... | grep -v /internal/session$)` — remaining packages pass
- [x] `gofmt -l` clean; `go vet ./...` clean; `go build -o /dev/null ./cmd/agent-deck/` clean
- [x] Manual: zoxide installed → picker opens on `z`, typing filters, Enter launches Claude in the selected dir with the directory's basename as the title, `Esc` cancels
- [x] Manual: zoxide absent (`PATH` override) → picker still opens, shows the install hint, no crash

Known unrelated failures on this macOS host: `TestPersistence_*` and `TestTmuxBootstrap_*` fail with "error connecting to ... (File name too long)" — macOS tmp-path Unix-socket limit, reproduces unmodified on `main`. Not caused by this change.

## Notes

- New hotkey `z` is a raw `case "z":` in `handleMainKey`, not registered in `defaultHotkeyBindings`. Matches the existing pattern for free keys like `n`/`N`/`d`. If we want remap support later, promote it to a `hotkeyZoxidePicker` action — intentionally deferred.
- Picker queries zoxide synchronously (no debouncing). Zoxide's local DB returns in single-digit ms; keeping it sync avoids async race conditions in the dropdown state.