### PR TITLE
fix: update COLORFGBG on OS theme change so sessions get correct colors

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4043,6 +4043,16 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.dark {
 			theme = "dark"
 		}
+		// Update COLORFGBG in our process environment so that all downstream
+		// code (ResolveTheme, ThemeColorFGBG, themeEnvExport, currentTmuxThemeStyle)
+		// sees the correct theme. Without this, the stale COLORFGBG inherited
+		// from the parent terminal at launch time takes precedence over the OS
+		// dark mode change, causing sessions to stay in the wrong color scheme.
+		if msg.dark {
+			os.Setenv("COLORFGBG", "15;0")
+		} else {
+			os.Setenv("COLORFGBG", "0;15")
+		}
 		InitTheme(theme)
 		h.propagateThemeToSessions()
 		// IMPORTANT: Re-issue listener to keep watching for theme changes.


### PR DESCRIPTION
Fixes sessions staying in the wrong color scheme after toggling macOS dark/light mode.

**Root cause:** `COLORFGBG` env var inherited from iTerm2 at launch is frozen for the process lifetime. `ResolveTheme()` checks it before `dark.IsDarkMode()`, so the stale value wins. This causes `propagateThemeToSessions()` and `themeEnvExport()` (for new sessions) to propagate the wrong theme.

**Fix:** Update `COLORFGBG` in the process environment when `systemThemeMsg` arrives, before propagating to sessions. One-line change in the `systemThemeMsg` handler in `internal/ui/home.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)