### PR TITLE
test(notifier): gate slow senders on release channel (unblocks v1.7.45 release)

### DIFF
--- a/internal/session/transition_notifier_async_test.go
+++ b/internal/session/transition_notifier_async_test.go
@@ -87,9 +87,14 @@ func TestAsyncDispatch_SlowTargetDoesNotBlockFastTarget(t *testing.T) {
 	n := newAsyncTestNotifier(t)
 
 	fastDone := make(chan struct{})
+	releaseSlow := make(chan struct{})
+	// releaseSlow gates the slow sender so the test can end deterministically
+	// instead of leaving a time.Sleep goroutine alive past t.TempDir cleanup;
+	// CI hit "directory not empty" when the leaked sender wrote logs into a
+	// directory that the framework was mid-delete of.
 	n.sender = func(profile, targetID, message string) error {
 		if targetID == "slow" {
-			time.Sleep(10 * time.Second)
+			<-releaseSlow
 			return nil
 		}
 		close(fastDone)
@@ -121,8 +126,14 @@ func TestAsyncDispatch_SlowTargetDoesNotBlockFastTarget(t *testing.T) {
 	case <-fastDone:
 		// success: fast target fired while slow target is still blocked
 	case <-time.After(500 * time.Millisecond):
+		close(releaseSlow)
+		n.Flush()
 		t.Fatalf("fast target did not run within 500ms; slow target head-of-line blocking regressed")
 	}
+
+	// Let the slow sender finish and wait for it so t.TempDir cleanup is safe.
+	close(releaseSlow)
+	n.Flush()
 }
 
 // TestAsyncDispatch_SendTimeoutWritesMissedLog covers the 30s timeout knob
@@ -133,8 +144,13 @@ func TestAsyncDispatch_SlowTargetDoesNotBlockFastTarget(t *testing.T) {
 func TestAsyncDispatch_SendTimeoutWritesMissedLog(t *testing.T) {
 	n := newAsyncTestNotifier(t)
 
+	release := make(chan struct{})
+	// Sender parks on a channel so (1) it definitely outlives the 200ms
+	// sendTimeout, triggering the watcher's timeout branch, and (2) we can
+	// drain it before t.TempDir cleanup to avoid leaking a goroutine that
+	// would race the directory removal.
 	n.sender = func(profile, targetID, message string) error {
-		time.Sleep(2 * time.Second)
+		<-release
 		return nil
 	}
 
@@ -151,6 +167,10 @@ func TestAsyncDispatch_SendTimeoutWritesMissedLog(t *testing.T) {
 
 	n.dispatchAsync("hang-target", "msg", event)
 	n.waitWatchers()
+	defer func() {
+		close(release)
+		n.Flush()
+	}()
 
 	entries := readMissedLines(t, n.missedPath)
 	if len(entries) != 1 {


### PR DESCRIPTION
## Why

The v1.7.45 release workflow failed on its test step:

\`\`\`
--- FAIL: TestAsyncDispatch_SlowTargetDoesNotBlockFastTarget
    testing.go:1267: TempDir RemoveAll cleanup: unlinkat ...: directory not empty
\`\`\`

Two tests in \`transition_notifier_async_test.go\` parked their fake sender in long sleeps (10s, 2s) so the watcher could observe a stalled/timeout target. The test assertions ran fast and the function returned, but the parked sender goroutines survived and eventually wrote into \`t.TempDir\` *during* the framework's cleanup → race → CI fail.

## Fix

Both tests now park the sender on an unbuffered \`release\` channel that the test explicitly closes after its assertions, followed by \`n.Flush()\` to wait on the sender WaitGroup. \`logEvent\` writes land inside \`Flush()\`'s window, well before \`t.TempDir\` starts its cleanup.

No assertion semantics change:
- Slow test still proves the fast sender completes while the slow one is blocked.
- Timeout test still parks the sender indefinitely past the 200ms \`sendTimeout\`, so the watcher's timeout branch still fires and writes \`notifier-missed.log\`.

## Verification

- \`go test -run 'TestAsync|TestQueue' ./internal/session/... -race -count=5\` → all 60 runs pass
- \`go test ./... -race -count=1\` → all 26 packages green
- Pre-push CI: fmt-check, vet, golangci-lint, full test, build, release-tests-yaml-lint all green

## After merge

Need to delete and re-push the v1.7.45 tag at the new \`main\` HEAD so the release workflow re-triggers.

## Test plan
- [x] tests pass locally (race, 5x)
- [x] pre-push gates pass
- [ ] CI re-run after merge verifies release binary build