### PR TITLE
fix(termreply): restore mouse input + shrink post-detach quarantine to 500ms

### DIFF
--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -20,7 +20,10 @@ import (
 	"golang.org/x/term"
 )
 
-const sshAttachReplyQuarantine = 2 * time.Second
+// sshAttachReplyQuarantine matches attachReplyQuarantine in internal/tmux/pty.go.
+// Keep these in sync — they cover the same class of terminal-reply bursts on
+// their respective attach paths (local tmux vs SSH remote).
+const sshAttachReplyQuarantine = 500 * time.Millisecond
 
 // sshControlDir is the directory for SSH ControlMaster sockets.
 const sshControlDir = "/tmp/agent-deck-ssh"

--- a/internal/termreply/filter.go
+++ b/internal/termreply/filter.go
@@ -15,15 +15,17 @@ const (
 
 	stringTerminatorByte = '\\'
 
-	csiFinalArrowUpByte    = 'A'
-	csiFinalArrowDownByte  = 'B'
-	csiFinalArrowRightByte = 'C'
-	csiFinalArrowLeftByte  = 'D'
-	csiFinalEndByte        = 'F'
-	csiFinalHomeByte       = 'H'
-	csiFinalBacktabByte    = 'Z'
-	csiFinalTildeByte      = '~'
-	csiFinalKittyKeyByte   = 'u'
+	csiFinalArrowUpByte       = 'A'
+	csiFinalArrowDownByte     = 'B'
+	csiFinalArrowRightByte    = 'C'
+	csiFinalArrowLeftByte     = 'D'
+	csiFinalEndByte           = 'F'
+	csiFinalHomeByte          = 'H'
+	csiFinalBacktabByte       = 'Z'
+	csiFinalTildeByte         = '~'
+	csiFinalKittyKeyByte      = 'u'
+	csiFinalMouseLegacyByte   = 'M' // X10/legacy mouse report + SGR mouse press
+	csiFinalMouseSGRFinalByte = 'm' // SGR mouse release
 )
 
 type filterMode uint8
@@ -67,6 +69,9 @@ func isSequenceFinalByte(b byte) bool {
 	return b >= 0x40 && b <= 0x7e
 }
 
+// isKeyboardCSIFinalByte returns true for CSI final bytes that represent
+// user input (keyboard or mouse) rather than terminal replies. These are
+// preserved even when the filter is armed during the quarantine window.
 func isKeyboardCSIFinalByte(b byte) bool {
 	switch b {
 	case csiFinalArrowUpByte,
@@ -77,7 +82,9 @@ func isKeyboardCSIFinalByte(b byte) bool {
 		csiFinalHomeByte,
 		csiFinalBacktabByte,
 		csiFinalTildeByte,
-		csiFinalKittyKeyByte:
+		csiFinalKittyKeyByte,
+		csiFinalMouseLegacyByte,
+		csiFinalMouseSGRFinalByte:
 		return true
 	default:
 		return false
@@ -106,7 +113,8 @@ func (f *Filter) resetSequenceState() {
 // Terminal replies covered here:
 //   - escape-string families: OSC, DCS, APC, PM, SOS
 //   - CSI replies during the quarantine window, except for a small whitelist of
-//     keyboard-related CSI finals (arrows/home/end/backtab/~ keys/kitty CSI u)
+//     user-input CSI finals (arrows/home/end/backtab/~ keys/kitty CSI u,
+//     mouse M/m)
 //
 // If final is true, any incomplete pending escape/CSI/SS3 sequence is flushed as
 // literal input, while an incomplete discarded escape-string reply is dropped.

--- a/internal/termreply/filter_test.go
+++ b/internal/termreply/filter_test.go
@@ -38,7 +38,7 @@ func TestFilterPreservesKeyboardCSIAndSS3Input(t *testing.T) {
 
 // TestFilterPreservesMouseCSIInput verifies that mouse CSI sequences
 // ending in 'M' or 'm' pass through unchanged when armed. Without this,
-// mouse events are silently dropped during the 2s quarantine window,
+// mouse events are silently dropped during the attach quarantine window,
 // making the main-menu TUI feel frozen after detach.
 func TestFilterPreservesMouseCSIInput(t *testing.T) {
 	t.Run("legacy_mouse_press", func(t *testing.T) {

--- a/internal/termreply/filter_test.go
+++ b/internal/termreply/filter_test.go
@@ -35,3 +35,30 @@ func TestFilterPreservesKeyboardCSIAndSS3Input(t *testing.T) {
 	require.Equal(t, []byte("\x1bOA"), f.Consume([]byte("\x1bOA"), true, false))
 	require.False(t, f.Active())
 }
+
+// TestFilterPreservesMouseCSIInput verifies that mouse CSI sequences
+// ending in 'M' or 'm' pass through unchanged when armed. Without this,
+// mouse events are silently dropped during the 2s quarantine window,
+// making the main-menu TUI feel frozen after detach.
+func TestFilterPreservesMouseCSIInput(t *testing.T) {
+	t.Run("legacy_mouse_press", func(t *testing.T) {
+		var f Filter
+		// ESC [ M <button> <x> <y>  (X10/legacy format, 3 bytes after 'M')
+		input := []byte{0x1b, '[', 'M', ' ', '!', '"'}
+		require.Equal(t, input, f.Consume(input, true, false))
+	})
+
+	t.Run("sgr_mouse_press", func(t *testing.T) {
+		var f Filter
+		// ESC [ < 0 ; 10 ; 20 M
+		input := []byte("\x1b[<0;10;20M")
+		require.Equal(t, input, f.Consume(input, true, false))
+	})
+
+	t.Run("sgr_mouse_release", func(t *testing.T) {
+		var f Filter
+		// ESC [ < 0 ; 10 ; 20 m
+		input := []byte("\x1b[<0;10;20m")
+		require.Equal(t, input, f.Consume(input, true, false))
+	})
+}

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -21,7 +21,14 @@ import (
 )
 
 const attachOutputDrainTimeout = 250 * time.Millisecond
-const attachReplyQuarantine = 2 * time.Second
+
+// attachReplyQuarantine is how long after attach/detach we filter
+// terminal-generated control replies from stdin. Terminal capability
+// reply bursts (DA1/DA2, OSC color queries, etc.) empirically complete
+// within tens of milliseconds. 500ms gives comfortable margin while
+// being short enough that the TUI does not feel frozen on return from
+// an attached session.
+const attachReplyQuarantine = 500 * time.Millisecond
 
 // IndexDetachKey returns the index of a control-key sequence in data, or -1 if
 // not found. detachByte is the raw ASCII byte (e.g. 0x11 for Ctrl+Q).


### PR DESCRIPTION
## Summary

Fixes a ~2s UI freeze and dead mouse after Ctrl+Q detach from a session in v1.7.x. Two orthogonal, small changes bundled for related context; each is in its own commit so they can be merged independently.

## What was happening

After #588 landed the termreply filter, detaching from a tmux session armed the filter for **2 seconds** (`attachReplyQuarantine` in `internal/tmux/pty.go`). During that window the `isKeyboardCSIFinalByte` whitelist let through only keyboard CSI finals (`A/B/C/D/F/H/Z/~/u`). Mouse events are CSI sequences ending in `M` (X10/legacy + SGR press) or `m` (SGR release) — they were silently dropped. Users see the main-menu TUI as unresponsive to mouse clicks and wheel for 2 seconds. Keyboard can also swallow keystrokes that collide with in-flight OSC/DCS replies during that window.

Symptom matches closed issue #39 (UI freeze 2-11s after detach), but that issue's performance fixes (O(n) ANSI strip, session cache, grace-period suppression) are all still intact. This is a new, independent regression from #588's quarantine window.

## Changes

### Commit 1: `fix(termreply): allow mouse CSI finals during attach quarantine`

Add `'M'` and `'m'` to `isKeyboardCSIFinalByte`. Mouse events are user input, not terminal replies; terminal emulators don't send unsolicited mouse reports. Restores mouse immediately during the quarantine window.

### Commit 2: `fix(tmux): reduce reply quarantine from 2s to 500ms`

`attachReplyQuarantine` 2s → 500ms. Capability reply bursts (DA1/DA2, OSC color queries) empirically complete within tens of ms, so 2s was extremely conservative. 500ms is ~10-20× safety margin while short enough the TUI no longer feels frozen. Sibling `attachOutputDrainTimeout` on the attach side is 250ms.

### Commit 3: `fix(ssh): apply same quarantine reduction to SSH attach path`

`sshAttachReplyQuarantine` in `internal/session/ssh.go` had the same 2s value and the same user-visible behavior on the SSH detach path. Dropped to 500ms with a sync comment so the two constants stay paired.

## Test plan

- [x] `go test ./internal/termreply/... ./internal/tmux/... ./internal/session/...` — all pass
- [x] 3 new subtests verify mouse passthrough: legacy press, SGR press, SGR release
- [x] Manual smoke test: attach → Ctrl+Q → immediately scroll/click in session list — no freeze, mouse and keyboard both responsive

## Notes

- Happy to tune the 500ms if you had a specific slow-terminal case in mind when picking 2s — I don't have data that suggests 500ms is too tight, but defer to your judgment.
- The `isKeyboardCSIFinalByte` name is now slightly inaccurate (mouse included); left it to keep the diff minimal. Rename could be a follow-up.