### PR TITLE
fix(settings): preserve [tmux] config block on TUI save (#710, v1.7.51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.51] - 2026-04-22
+
+### Fixed
+- **Settings TUI no longer drops the `[tmux]` config block on save** ([#710](https://github.com/asheshgoplani/agent-deck/issues/710), reported on v1.7.50). Pressing `S` in the TUI, toggling any setting, and saving was silently zeroing the entire `[tmux]` table on disk — `inject_status_line`, `launch_in_user_scope`, `detach_key`, `socket_name` (v1.7.50), and `options` were all gone after the next reload. Root cause: `SettingsPanel.GetConfig` reconstructs the to-be-saved `UserConfig` from the panel's visible widget state and pass-through-copies every section it doesn't render (MCPs, Tools, Profiles, Worktree, …) from `originalConfig`, but `Tmux` had been omitted from that copy block. Same class of bug as [#584](https://github.com/asheshgoplani/agent-deck/pull/584) (Worktree) and the structural reason we couldn't reproduce the original [#687](https://github.com/asheshgoplani/agent-deck/issues/687) `inject_status_line` report by editing `config.toml` directly — the reporter was hitting the Settings TUI save path, not the loader. Fix is one line: `config.Tmux = s.originalConfig.Tmux` added to the preservation block in `internal/ui/settings_panel.go`. Coverage gap closed by two new tests: `TestSettingsPanel_Tmux_GetConfigPreservesHiddenFields` (unit, mirrors the existing Worktree guard) asserts `GetConfig()` round-trips `InjectStatusLine`, `LaunchInUserScope`, and `DetachKey` from `originalConfig`; `TestEval_SettingsTUI_SavePreservesTmux` (eval_smoke tier in `internal/ui/settings_panel_eval_test.go`) drives the full `LoadUserConfig → SettingsPanel.LoadConfig → GetConfig → SaveUserConfig → re-read TOML` round-trip against a scratch `$HOME` to prove `[tmux]` survives a real save with a non-tmux setting changed (theme dark → light). Both tests were verified RED on the unfixed code and GREEN after the one-line fix. Thanks to @jcordasco for the exact diagnosis and suggested fix in #710.
+
 ## [1.7.50] - 2026-04-21
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -35,7 +35,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.50" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.51" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -442,6 +442,11 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 		config.Preview.Analytics = s.originalConfig.Preview.Analytics
 		config.Profiles = s.originalConfig.Profiles
 		config.Worktree = s.originalConfig.Worktree
+		// Tmux settings (#710): preserve [tmux] table — Settings TUI does not
+		// expose these fields, so without this copy the entire [tmux] block
+		// (inject_status_line, launch_in_user_scope, detach_key, options …)
+		// vanishes on save. Same class of bug as #584 (Worktree).
+		config.Tmux = s.originalConfig.Tmux
 		// Keep global Claude config when editing profile-specific override.
 		if s.claudeConfigIsScope {
 			config.Claude.ConfigDir = s.originalConfig.Claude.ConfigDir

--- a/internal/ui/settings_panel_eval_test.go
+++ b/internal/ui/settings_panel_eval_test.go
@@ -1,0 +1,113 @@
+//go:build eval_smoke
+
+package ui
+
+// Behavioral eval for the Settings TUI save path (issue #710).
+//
+// Why this lives in internal/ui/ and not tests/eval/: Go's internal-package
+// rule prevents tests/eval/... from importing internal/ui. The eval is still
+// part of the eval_smoke tier — it runs only under `-tags eval_smoke`. See
+// tests/eval/README.md.
+//
+// Motivation: #710 (and the original report half of #687) — the Settings TUI
+// silently dropped the entire [tmux] config table on save because
+// SettingsPanel.GetConfig forgot to copy `config.Tmux` from originalConfig.
+// Unit tests on GetConfig caught the in-memory regression after the fact;
+// this eval guards the user-observable claim end-to-end: "open settings,
+// change something unrelated, save → my [tmux] block is still on disk."
+//
+// We could not catch this earlier because no test exercised the full
+// LoadUserConfig → SettingsPanel → GetConfig → SaveUserConfig → re-read
+// round-trip. That coverage gap is what this file closes.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestEval_SettingsTUI_SavePreservesTmux is the guard for #710 at the
+// save-round-trip layer. It writes a config.toml with a [tmux] block to a
+// scratch HOME, loads it through the Settings panel exactly as the TUI
+// would, mutates a NON-tmux field (theme), calls SaveUserConfig with the
+// panel's GetConfig() output, and then re-parses config.toml from disk to
+// assert the tmux block is intact.
+//
+// Without the #710 fix, the final reload returns zero-valued TmuxSettings
+// and the assertions below fail with "InjectStatusLine = nil".
+func TestEval_SettingsTUI_SavePreservesTmux(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	configDir := filepath.Join(homeDir, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	// Seed a config.toml with [tmux] populated. These three fields cover
+	// all three Tmux struct member shapes: *bool, *bool, string.
+	seedTOML := `# Agent Deck Configuration
+theme = "dark"
+
+[tmux]
+inject_status_line = false
+launch_in_user_scope = true
+detach_key = "C-q"
+`
+	configPath := filepath.Join(configDir, session.UserConfigFileName)
+	if err := os.WriteFile(configPath, []byte(seedTOML), 0o600); err != nil {
+		t.Fatalf("seed config.toml: %v", err)
+	}
+
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	// Replay the TUI flow: load existing config into the panel, change a
+	// non-tmux field (theme), then ask the panel for the to-be-saved config.
+	loaded, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	if loaded.Tmux.InjectStatusLine == nil || *loaded.Tmux.InjectStatusLine != false {
+		t.Fatalf("seed sanity: loaded inject_status_line = %v, want false ptr", loaded.Tmux.InjectStatusLine)
+	}
+
+	// Mirror what SettingsPanel.Show() does at runtime: LoadConfig populates
+	// the visible widget state, originalConfig retains the full snapshot for
+	// pass-through preservation in GetConfig.
+	panel := NewSettingsPanel()
+	panel.LoadConfig(loaded)
+	panel.originalConfig = loaded
+	panel.selectedTheme = 1 // toggle dark → light, a non-tmux change
+
+	saved := panel.GetConfig()
+	if err := session.SaveUserConfig(saved); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	// Re-read from disk to mimic the next agent-deck launch. Clear the
+	// in-process cache first so we hit the file rather than a stale handle.
+	session.ClearUserConfigCache()
+	reloaded, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("reload after save: %v", err)
+	}
+
+	if reloaded.Theme != "light" {
+		t.Fatalf("non-tmux change lost: Theme = %q, want %q", reloaded.Theme, "light")
+	}
+	if reloaded.Tmux.InjectStatusLine == nil {
+		t.Fatalf("Tmux.InjectStatusLine dropped on save (#710 regression). The Settings TUI save path is silently zeroing the [tmux] table again — re-add `config.Tmux = s.originalConfig.Tmux` in SettingsPanel.GetConfig.")
+	}
+	if *reloaded.Tmux.InjectStatusLine != false {
+		t.Fatalf("Tmux.InjectStatusLine flipped: got %v, want false", *reloaded.Tmux.InjectStatusLine)
+	}
+	if reloaded.Tmux.LaunchInUserScope == nil || *reloaded.Tmux.LaunchInUserScope != true {
+		t.Fatalf("Tmux.LaunchInUserScope dropped: got %v", reloaded.Tmux.LaunchInUserScope)
+	}
+	if reloaded.Tmux.DetachKey != "C-q" {
+		t.Fatalf("Tmux.DetachKey dropped: got %q, want %q", reloaded.Tmux.DetachKey, "C-q")
+	}
+}

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -936,6 +936,40 @@ func TestSettingsPanel_Worktree_GetConfigPreservesHiddenFields(t *testing.T) {
 	}
 }
 
+// TestSettingsPanel_Tmux_GetConfigPreservesHiddenFields guards #710.
+// The Settings TUI does not expose [tmux] fields, so GetConfig() must copy
+// them through from originalConfig — same as MCPs/Tools/Worktree. Before the
+// fix, saving from the TUI silently dropped the entire [tmux] table, which
+// also explained the original #687 inject_status_line report we couldn't
+// reproduce by editing config.toml directly.
+func TestSettingsPanel_Tmux_GetConfigPreservesHiddenFields(t *testing.T) {
+	panel := NewSettingsPanel()
+
+	injectFalse := false
+	launchScopeTrue := true
+	original := &session.UserConfig{
+		Tmux: session.TmuxSettings{
+			InjectStatusLine:  &injectFalse,
+			LaunchInUserScope: &launchScopeTrue,
+			DetachKey:         "C-q",
+		},
+	}
+	panel.LoadConfig(original)
+	panel.originalConfig = original
+
+	config := panel.GetConfig()
+
+	if config.Tmux.InjectStatusLine == nil || *config.Tmux.InjectStatusLine != false {
+		t.Fatalf("Tmux.InjectStatusLine should be preserved as false, got %v", config.Tmux.InjectStatusLine)
+	}
+	if config.Tmux.LaunchInUserScope == nil || *config.Tmux.LaunchInUserScope != true {
+		t.Fatalf("Tmux.LaunchInUserScope should be preserved as true, got %v", config.Tmux.LaunchInUserScope)
+	}
+	if config.Tmux.DetachKey != "C-q" {
+		t.Fatalf("Tmux.DetachKey = %q, want %q", config.Tmux.DetachKey, "C-q")
+	}
+}
+
 func TestSettingsPanel_PreviewSettings_ViewContains(t *testing.T) {
 	panel := NewSettingsPanel()
 	panel.SetSize(80, 50)


### PR DESCRIPTION
## Summary

- Fixes **#710** (Settings TUI drops `[tmux]` settings on save). One-line preservation in `SettingsPanel.GetConfig`, mirroring the existing Worktree/Profiles/MCP pass-through.
- Same class of bug as #584 (Worktree). Also explains the original #687 `inject_status_line` report we couldn't reproduce by editing `config.toml` directly — the reporter was hitting the Settings TUI save path, which we weren't covering.
- Bumps to **v1.7.51**.

## Root cause

`internal/ui/settings_panel.go` `GetConfig()` reconstructs the to-be-saved `UserConfig` from the panel's visible widget state, then pass-through-copies every section it doesn't render from `originalConfig`. `Tmux` was missing from that copy block:

```go
config.Profiles = s.originalConfig.Profiles
config.Worktree = s.originalConfig.Worktree   // #584 fix
// ← no `config.Tmux = s.originalConfig.Tmux`
```

So pressing `S` → toggle anything → save silently zeroed the entire `[tmux]` table on disk: `inject_status_line`, `launch_in_user_scope`, `detach_key`, `socket_name` (added v1.7.50), and `options`.

## Fix

One line, mirroring Worktree:

```go
config.Tmux = s.originalConfig.Tmux
```

## Tests (TDD)

Both new tests verified RED on the unfixed code, GREEN after the one-line fix:

| Test | Layer | What it guards |
|---|---|---|
| `TestSettingsPanel_Tmux_GetConfigPreservesHiddenFields` | unit (`internal/ui/settings_panel_test.go`) | `GetConfig()` round-trips `InjectStatusLine`, `LaunchInUserScope`, `DetachKey` from `originalConfig`. Mirrors the existing Worktree guard. |
| `TestEval_SettingsTUI_SavePreservesTmux` | eval_smoke (`internal/ui/settings_panel_eval_test.go`) | Full `LoadUserConfig → SettingsPanel.LoadConfig → GetConfig → SaveUserConfig → re-read TOML` round-trip against a scratch `$HOME`. Proves `[tmux]` survives a real save while a non-tmux setting (theme dark→light) is changed. **This closes the coverage gap that let the bug ship.** |

## Test plan

- [x] `go test ./internal/ui/... -race -count=1` — green (30s)
- [x] `go test -tags eval_smoke ./internal/ui/... ./internal/session/... ./tests/eval/... -race -count=1` — green
- [x] Sabotage check: removed the fix → both new tests fail with the expected diagnostic; restored fix → both pass
- [x] `go build` clean, `--version` reports `Agent Deck v1.7.51`

Reported by @jcordasco. Closes #710.