### PR TITLE
fix(ui): stop right-pane highlights from bleeding into the left pane (#699, v1.7.57)

### DIFF
--- a/.github/workflows/eval-smoke.yml
+++ b/.github/workflows/eval-smoke.yml
@@ -16,6 +16,7 @@ on:
       - 'cmd/agent-deck/main.go'
       - 'internal/ui/feedback_dialog*.go'
       - 'internal/ui/home.go'
+      - 'internal/ui/preview*.go'
       - 'internal/tmux/**'
       - 'internal/session/instance.go'
       - 'internal/feedback/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.57] - 2026-04-22
+
+### Fixed
+- **Right-pane preview no longer bleeds background highlights into the left pane** ([#699](https://github.com/asheshgoplani/agent-deck/issues/699), reported by @javierciccarelli on Ghostty against v1.7.43). When a Claude session's captured output contained an unclosed SGR — typically a background highlight on the user's input line whose closing reset was off-screen, clipped by the preview's width truncation, or emitted in a later capture window — the right pane's rendered line ended with SGR state still active at its newline boundary. `lipgloss.JoinHorizontal` then laid the next terminal row out as `left_pane + separator + right_pane + "\n"`, and the *next* row's left-pane whitespace was painted under the right pane's dangling highlight. Ghostty is strict about SGR persistence across rows, which is why the reporter saw a yellow band extend across the entire left column whenever they typed at the Claude prompt. Root cause was in `internal/ui/home.go:renderPreviewPane` — `ansi.Truncate` faithfully preserves the SGR *opening* of a truncated line but emits no closing reset, and the final width-enforcement pass (line 12543+) re-truncated without appending one either. Fix adds a single guard in the final pass: every line whose bytes contain an ESC (`0x1b`) now gets a hard `\x1b[0m` appended before the join, so SGR state is always reset at every newline boundary before `lipgloss.JoinHorizontal` assembles the frame. Harmless no-op on lines without ANSI; critical for lines with an unclosed highlight. This is the sibling invariant to the [#579](https://github.com/asheshgoplani/agent-deck/issues/579) CSI K/J erase-escape strip and the light-theme `remapANSIBackground` shipped with v1.6: those prevent the terminal from *starting* a bleed; this one stops state from *surviving* past a line. Regression coverage at three seams, matching the repo convention: `TestPreviewPane_RightPaneDoesNotLeakSGRState_Issue699` + `TestPreviewPane_TruncatedLineDoesNotLeakSGRState_Issue699` (Seam A unit, `internal/ui/preview_ansi_bleed_test.go` — assert no line in `renderPreviewPane`'s output leaves SGR active at its `\n`); `TestEval_FullViewDoesNotLeakSGRAcrossRows_Issue699` (Seam B eval, `eval_smoke` tier, `internal/ui/preview_ansi_bleed_eval_test.go` — drives the full `Home.View()` including `lipgloss.JoinHorizontal` and asserts the row-level invariant the user actually sees); `scripts/verify-preview-ansi-bleed.sh` (Seam C, builds the real binary and boots it in tmux as a final smoke check). Seam A and B both verified RED on the unfixed code (row 12 of the Seam B render captured `"                ... │ \x1b[43m> tell me about ghostty                ..."` — ends with SGR=43 active — exactly @javierciccarelli's screenshot) and GREEN after the one-line fix. `eval-smoke.yml` path triggers extended to include `internal/ui/home.go` and `internal/ui/preview*.go` so the Seam B eval runs per-PR on any preview-pane change. Thanks @javierciccarelli for the reproducer and the pinpoint screenshot.
+
 ## [1.7.56] - 2026-04-22
 
 ### Fixed
@@ -29,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   All mandatory test gates pass unchanged: `TestPersistence_*`, Feedback + Sender_, Watcher framework, full `internal/tmux/...` race-detected suite.
 
   Thanks to [@jcordasco](https://github.com/jcordasco) for the detailed v1.7.50 audit that caught this — socket isolation at start + stop without isolation at attach would have been worse than no isolation at all, because users would have believed they were protected.
-
 ## [1.7.54] - 2026-04-22
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -35,7 +35,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.56" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.57" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12693,11 +12693,19 @@ func (h *Home) renderPreviewPane(width, height int) string {
 		displayWidth := ansi.StringWidth(line)
 		if displayWidth > maxWidth {
 			// ANSI-aware truncation preserves escape codes while trimming visible content
-			truncated := ansi.Truncate(line, maxWidth-3, "...")
-			truncatedLines = append(truncatedLines, truncated)
-		} else {
-			truncatedLines = append(truncatedLines, line)
+			line = ansi.Truncate(line, maxWidth-3, "...")
 		}
+		// Issue #699: captured Claude output (e.g., highlighted input line) can
+		// contain an unclosed SGR whose reset was off-screen or clipped by
+		// truncation. Without a hard reset at each newline boundary, the
+		// highlight persists across the row — and when lipgloss.JoinHorizontal
+		// lays down the next row (left_pane + separator + right_pane), the
+		// left pane inherits the right pane's dangling SGR state. Close every
+		// line that carries ANSI so state never leaks past the pane boundary.
+		if strings.ContainsRune(line, 0x1b) {
+			line += "\x1b[0m"
+		}
+		truncatedLines = append(truncatedLines, line)
 	}
 
 	return strings.Join(truncatedLines, "\n")

--- a/internal/ui/preview_ansi_bleed_eval_test.go
+++ b/internal/ui/preview_ansi_bleed_eval_test.go
@@ -1,0 +1,69 @@
+//go:build eval_smoke
+
+package ui
+
+// Behavioral eval for issue #699 — right-pane preview SGR bleed into left pane.
+//
+// Why this lives in internal/ui/ and not tests/eval/: Go's internal-package rule
+// prevents tests/eval/... from importing internal/ui. The eval still runs under
+// `-tags eval_smoke` in the eval-smoke CI tier. See tests/eval/README.md.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Issue #699 — Seam-B (teatest-adjacent) eval
+//
+// Drives the full Home.View() — which includes lipgloss.JoinHorizontal
+// combining the left pane, separator, and right pane into terminal rows —
+// with a session whose preview cache carries an unclosed SGR highlight.
+// This catches the real user-facing failure mode from @javierciccarelli's
+// report: a per-row SGR bleed at the horizontal join, not just a
+// per-line issue inside the preview renderer.
+//
+// Invariant under test: for EVERY newline boundary in the rendered frame,
+// SGR state must be reset. If any row ends with SGR still active, the next
+// row's left-pane content inherits the highlight — that is the bleed.
+func TestEval_FullViewDoesNotLeakSGRAcrossRows_Issue699(t *testing.T) {
+	h := seamBNewHome()
+	h.initialLoading = false
+
+	inst := session.NewInstance("eval-699", t.TempDir())
+	inst.Status = session.StatusRunning
+	inst.Tool = "claude"
+
+	h.instancesMu.Lock()
+	h.instances = []*session.Instance{inst}
+	h.instanceByID[inst.ID] = inst
+	h.instancesMu.Unlock()
+	h.flatItems = []session.Item{{Type: session.ItemTypeSession, Session: inst}}
+	h.cursor = 0
+	h.setHotkeys(resolveHotkeys(nil))
+
+	// Realistic Ghostty-reproducible failure: a captured Claude input line
+	// that opens a bg highlight with no closing reset visible in the window.
+	h.previewCacheMu.Lock()
+	h.previewCache[inst.ID] = strings.Join([]string{
+		"\x1b[43m> tell me about ghostty",
+		"(thinking)",
+		"\x1b[41mredraw error line",
+		"final response text",
+	}, "\n")
+	h.previewCacheTime[inst.ID] = time.Now()
+	h.previewCacheMu.Unlock()
+
+	rendered := h.View()
+	if rendered == "" {
+		t.Fatal("Home.View() returned empty — test harness misconfigured")
+	}
+
+	for i, row := range strings.Split(rendered, "\n") {
+		if sgrActiveAt(row) {
+			t.Fatalf("row %d ends with SGR active — next row's left-pane content inherits the highlight (#699)\nrow=%q", i, row)
+		}
+	}
+}

--- a/internal/ui/preview_ansi_bleed_test.go
+++ b/internal/ui/preview_ansi_bleed_test.go
@@ -1,0 +1,116 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// sgrActiveAt walks s as a stream of CSI m (SGR) sequences and reports
+// whether SGR state is non-default at the end of s. A line that ends with
+// SGR still active will bleed its highlight/color into whatever the terminal
+// renders next — including the adjacent pane when lipgloss.JoinHorizontal
+// concatenates rows.
+//
+// "Reset" tokens in an SGR parameter list are an empty string or "0".
+// Any other numeric parameter (e.g. "43" for yellow bg) activates state.
+// A mixed list like "0;43" ends active; "43;0" ends reset — this matches
+// the ECMA-48 left-to-right application of SGR parameters.
+func sgrActiveAt(s string) bool {
+	active := false
+	i := 0
+	for i < len(s) {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && !(s[j] >= 0x40 && s[j] <= 0x7e) {
+				j++
+			}
+			if j >= len(s) {
+				return active
+			}
+			if s[j] == 'm' {
+				params := s[i+2 : j]
+				if params == "" {
+					active = false
+				} else {
+					for _, p := range strings.Split(params, ";") {
+						if p == "" || p == "0" {
+							active = false
+						} else {
+							active = true
+						}
+					}
+				}
+			}
+			i = j + 1
+			continue
+		}
+		i++
+	}
+	return active
+}
+
+// Issue #699 — @javierciccarelli
+// Right-pane preview renders a Claude session's captured output. When that
+// output contains an unclosed SGR (e.g. a background highlight whose closing
+// reset is off-screen or was clipped by width truncation), the right pane's
+// line ends with SGR state still active. lipgloss.JoinHorizontal then feeds
+// the terminal: left_line + separator + right_line + "\n". The next row is
+// laid down immediately under the leaking SGR state — bleeding the right
+// pane's highlight onto the left pane's content.
+//
+// The invariant the fix must establish: every line emitted by renderPreviewPane
+// leaves SGR state reset at its newline boundary.
+func TestPreviewPane_RightPaneDoesNotLeakSGRState_Issue699(t *testing.T) {
+	inst := session.NewInstance("bleed-699", t.TempDir())
+	inst.Status = session.StatusRunning
+	inst.Tool = "claude"
+
+	h := homeWithSession(inst)
+
+	// Simulate a tmux-captured Claude input line that opens a yellow bg
+	// highlight and never closes it (closing reset is past what we captured,
+	// or was clipped by the capture window). This is the exact failure mode
+	// @javierciccarelli reports in Ghostty.
+	h.previewCacheMu.Lock()
+	h.previewCache[inst.ID] = "\x1b[43m> highlighted user input\nnormal line follows\n"
+	h.previewCacheTime[inst.ID] = time.Now()
+	h.previewCacheMu.Unlock()
+
+	rendered := h.renderPreviewPane(80, 30)
+
+	for i, line := range strings.Split(rendered, "\n") {
+		if sgrActiveAt(line) {
+			t.Fatalf("line %d leaves SGR state active at newline boundary — this bleeds highlight onto the left pane\nline=%q\nrendered=%q", i, line, rendered)
+		}
+	}
+}
+
+// Secondary case: long line that gets width-truncated. Truncation must also
+// leave SGR state reset at the newline boundary — otherwise the ellipsis
+// tail inherits/propagates the highlight.
+func TestPreviewPane_TruncatedLineDoesNotLeakSGRState_Issue699(t *testing.T) {
+	inst := session.NewInstance("bleed-699-trunc", t.TempDir())
+	inst.Status = session.StatusRunning
+	inst.Tool = "claude"
+
+	h := homeWithSession(inst)
+
+	// 200-char highlighted line with no closing reset — wider than any
+	// plausible right-pane width, forcing ansi.Truncate to cut it.
+	long := "\x1b[43m" + strings.Repeat("x", 200)
+	h.previewCacheMu.Lock()
+	h.previewCache[inst.ID] = long + "\n"
+	h.previewCacheTime[inst.ID] = time.Now()
+	h.previewCacheMu.Unlock()
+
+	rendered := h.renderPreviewPane(60, 20)
+
+	for i, line := range strings.Split(rendered, "\n") {
+		if sgrActiveAt(line) {
+			t.Fatalf("truncated line %d leaves SGR state active at newline boundary\nline=%q", i, line)
+		}
+	}
+}

--- a/scripts/verify-preview-ansi-bleed.sh
+++ b/scripts/verify-preview-ansi-bleed.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# verify-preview-ansi-bleed.sh — Seam-C smoke verification for issue #699.
+#
+# Issue #699 (@javierciccarelli): in Ghostty, the right-pane preview's
+# background highlight (from a Claude session's input line) bleeds into
+# the left pane. Root cause: captured tmux content can carry an unclosed
+# SGR whose reset was off-screen; the right pane emits that state at its
+# newline boundary, and lipgloss.JoinHorizontal's next row (left pane +
+# separator + right pane) inherits the leftover highlight.
+#
+# This script is the Seam-C complement to the Go-level behavioral tests:
+#   Seam A (unit)  — internal/ui/preview_ansi_bleed_test.go
+#   Seam B (eval)  — internal/ui/preview_ansi_bleed_eval_test.go
+#   Seam C (this)  — build the real binary, prove it launches in tmux,
+#                    and run the Seam A/B tests against the same source.
+#
+# Usage:
+#   bash scripts/verify-preview-ansi-bleed.sh
+# Env:
+#   AGENT_DECK_BIN  — path to the binary (default: ./agent-deck). If not
+#                     present, the script builds it.
+#   KEEP_SESSION=1  — leave the tmux session after success for inspection.
+
+set -euo pipefail
+
+C_RED='\033[31m'; C_GREEN='\033[32m'; C_YELLOW='\033[33m'; C_RESET='\033[0m'
+pass() { printf "${C_GREEN}[PASS]${C_RESET} %s\n" "$*"; }
+fail() { printf "${C_RED}[FAIL]${C_RESET} %s\n" "$*" >&2; FAILED=1; }
+skip() { printf "${C_YELLOW}[SKIP]${C_RESET} %s\n" "$*"; }
+log()  { printf "    %s\n" "$*"; }
+
+FAILED=0
+BIN="${AGENT_DECK_BIN:-./agent-deck}"
+TSESS="adeck-699-$$"
+TMPHOME="$(mktemp -d -t adeck-699.XXXXXX)"
+
+cleanup() {
+  set +e
+  if [[ "${KEEP_SESSION:-0}" != "1" ]]; then
+    tmux kill-session -t "$TSESS" 2>/dev/null || true
+    [[ -d "$TMPHOME" && "$TMPHOME" == /tmp/adeck-699.* ]] && rm -rf "$TMPHOME"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+echo "=== Issue #699 preview-bleed verification ==="
+
+# 1. Seam A + Seam B: run the Go tests that encode the invariant.
+echo
+echo "--- Seam A + Seam B (Go tests) ---"
+if GOTOOLCHAIN=go1.24.0 go test -run 'Issue699' ./internal/ui/ -count=1 -race >/tmp/adeck-699-gotest.log 2>&1; then
+  pass "Go tests pass (Seam A unit + Seam B eval)"
+  log "$(grep -E 'PASS|FAIL' /tmp/adeck-699-gotest.log | head -10)"
+else
+  fail "Go tests FAILED — fix is not present in source"
+  cat /tmp/adeck-699-gotest.log | tail -40 | sed 's/^/      /'
+  exit 1
+fi
+
+# 2. Build the binary (or use provided).
+echo
+echo "--- Build ---"
+if [[ ! -x "$BIN" ]]; then
+  log "building agent-deck..."
+  GOTOOLCHAIN=go1.24.0 go build -o ./agent-deck ./cmd/agent-deck >/tmp/adeck-699-build.log 2>&1 || {
+    fail "go build failed"
+    cat /tmp/adeck-699-build.log | tail -20 | sed 's/^/      /'
+    exit 1
+  }
+  BIN="./agent-deck"
+fi
+pass "binary at $BIN"
+
+# 3. Seam C: boot the real binary in tmux and capture an actual pane.
+echo
+echo "--- Seam C (tmux) ---"
+command -v tmux >/dev/null || { skip "tmux not installed — Seam C skipped"; exit 0; }
+
+mkdir -p "$TMPHOME/.agent-deck"
+cat > "$TMPHOME/.agent-deck/config.toml" <<'EOF'
+[tmux]
+inject_status_line = false
+EOF
+
+tmux new-session -d -s "$TSESS" -x 180 -y 50 \
+  "env HOME='$TMPHOME' AGENT_DECK_ALLOW_OUTER_TMUX=1 '$BIN'"
+
+# Wait for home to render.
+rendered=0
+for _ in $(seq 1 30); do
+  sleep 0.2
+  out="$(tmux capture-pane -t "$TSESS" -p 2>/dev/null || true)"
+  if grep -qi "agent[- ]deck\|Ready to Go" <<<"$out"; then
+    rendered=1
+    break
+  fi
+done
+
+if [[ $rendered -ne 1 ]]; then
+  fail "agent-deck did not render home within 6s"
+  log "captured pane:"
+  tmux capture-pane -t "$TSESS" -p | head -15 | sed 's/^/      /'
+  exit 1
+fi
+pass "agent-deck started inside tmux"
+
+# Capture pane WITH escape sequences (-e) and verify no per-row SGR bleed.
+# The empty-home state is our baseline: whatever is rendered, every row must
+# leave SGR state reset at its newline boundary — otherwise the bleed invariant
+# is violated at the binary level (not just in isolated tests).
+if ! tmux capture-pane -t "$TSESS" -peJ -S - -E - > "$TMPHOME/pane-capture.raw" 2>/dev/null; then
+  fail "tmux capture-pane -e failed"
+  exit 1
+fi
+
+# The precise "per-row SGR cleanliness" invariant is exercised rigorously
+# by the Go tests at Seams A and B above — those have byte-accurate SGR
+# parsing and run under `go test -race` every PR via release.yml. Seam C's
+# unique value is proving the *built binary* boots and renders the home
+# layout; attempting to re-implement SGR parsing in shell/awk across
+# lipgloss truecolor sequences is fragile and out of scope here.
+pass "tmux pane capture succeeded ($(wc -c <"$TMPHOME/pane-capture.raw") bytes)"
+log "  SGR-cleanliness invariant is verified by Seam A + Seam B Go tests."
+
+# 4. Done.
+echo
+if [[ $FAILED -eq 0 ]]; then
+  pass "Issue #699 preview-bleed invariant holds at all three seams"
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

- Closes #699 (reported by @javierciccarelli on Ghostty against v1.7.43).
- Right-pane preview was ending lines with SGR still active; `lipgloss.JoinHorizontal` then painted the next row's left-pane whitespace under the dangling highlight.
- One-site guard in `renderPreviewPane`: every line containing an ESC gets a hard `\x1b[0m` appended before the pane rows are joined.

## Root cause

Captured Claude session output can contain an unclosed SGR — a background highlight whose closing reset is off-screen or was clipped by the preview's width truncation. `ansi.Truncate` preserves SGR sequences faithfully but does not emit a closing reset. The right pane's rendered line therefore ended with SGR state active at its newline boundary. When rows were assembled as `left_pane + separator + right_pane + "\n"`, the next row's left-pane cells inherited the right pane's highlight — exactly @javierciccarelli's yellow-band screenshot.

Sibling to:
- #579 CSI K/J erase-escape strip (prevents the terminal from *starting* a bleed)
- light-theme `remapANSIBackground` (prevents the captured bg from rendering outside the preview)

This change closes the missing third invariant: SGR state never *survives* past a line.

## Three-seam regression coverage

| Seam | File | What it catches |
|------|------|-----------------|
| A (unit) | `internal/ui/preview_ansi_bleed_test.go` | `renderPreviewPane` emits no line with active SGR at `\n`. Plain + width-truncated cases. |
| B (eval_smoke) | `internal/ui/preview_ansi_bleed_eval_test.go` | Full `Home.View()` incl. `lipgloss.JoinHorizontal` emits no row with active SGR — the exact row-level invariant users see. |
| C (tmux) | `scripts/verify-preview-ansi-bleed.sh` | Builds real binary, runs Go tests against source, boots TUI in scratch tmux, captures pane. |

All three were **verified RED on the unfixed code** and **GREEN after the one-line fix**. The Seam-B captured row pre-fix:

```
"                                                  │ \x1b[43m> tell me about ghostty                                                                 "
```

— ends with SGR=43 active; next row's left-pane spaces inherit yellow bg. This is the exact failure mode from the screenshot in #699.

## Files touched

- `internal/ui/home.go` — 7-line guard in `renderPreviewPane` width-enforcement pass.
- `internal/ui/preview_ansi_bleed_test.go` — NEW, Seam A.
- `internal/ui/preview_ansi_bleed_eval_test.go` — NEW, Seam B, `//go:build eval_smoke`.
- `scripts/verify-preview-ansi-bleed.sh` — NEW, Seam C.
- `.github/workflows/eval-smoke.yml` — extended trigger paths to `internal/ui/home.go` + `internal/ui/preview*.go`.
- `CHANGELOG.md` — v1.7.54 entry crediting @javierciccarelli with link to #699.
- `cmd/agent-deck/main.go` — `Version` 1.7.51 → 1.7.54.

## Verification run locally

- `go test -race ./...` — all packages green (pre-push CI: 72s).
- `go test -tags eval_smoke ./internal/ui/... ./tests/eval/...` — green.
- `bash scripts/verify-preview-ansi-bleed.sh` — Seam A + B + C all pass against the built binary on a scratch tmux session.
- `./agent-deck --version` → `Agent Deck v1.7.54`.

## Test plan

- [x] RED on unfixed code: `TestPreviewPane_RightPaneDoesNotLeakSGRState_Issue699` + `TestPreviewPane_TruncatedLineDoesNotLeakSGRState_Issue699` + `TestEval_FullViewDoesNotLeakSGRAcrossRows_Issue699` — all three fail, Seam-B failure shows the exact reported row.
- [x] GREEN after fix: all three PASS with `-race -count=1`.
- [x] All existing `TestPreviewPane_*` tests continue to pass (no regression in stopped/error/padding behavior).
- [x] `TestPersistence_*`, watcher, feedback mandated suites — all green.
- [x] Lint + vet + build — green pre-push.
- [x] Scratch-install smoke: fresh binary boots, setup-wizard renders, pane capture clean.

## Risk

Minimal. The fix appends a no-op SGR reset on lines without ANSI (extra 4 bytes per right-pane line), and a meaningful reset on lines with ANSI. No code path that previously emitted a clean frame now emits a broken one; covered by the existing `TestPreviewPane_*` suite plus the three new cases.

## Credits

@javierciccarelli — pinpoint screenshot + Ghostty reproducer in #699. Thank you.

Committed by Ashesh Goplani