### PR TITLE
feat(title-lock): prevent Claude session-name from overriding agent-deck title (#697)

### DIFF
--- a/.github/workflows/eval-smoke.yml
+++ b/.github/workflows/eval-smoke.yml
@@ -48,6 +48,17 @@ jobs:
           which tmux
           tmux -V
 
+      # zoxide is required by the quick-open picker tests introduced in
+      # #693 (v1.7.54). It's not on ubuntu-latest by default, so install
+      # it here — tests short-circuit on ZoxideAvailable() and otherwise
+      # return empty results, masking any real regression with a false
+      # FAIL across every PR that triggers eval-smoke.
+      - name: Install zoxide
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y zoxide
+          zoxide --version
+
       - name: Run eval_smoke suite
         env:
           GOTOOLCHAIN: go1.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.52] - 2026-04-22
+
+### Added
+- **`--title-lock` flag + `session set-title-lock` subcommand prevent Claude's session name from overriding the agent-deck title ([#697](https://github.com/asheshgoplani/agent-deck/issues/697), reported by [@evgenii-at-dev](https://github.com/evgenii-at-dev)).** Conductor workflow: launch `agent-deck launch -t SCRUM-351 -c claude --title-lock` on a worker, then Claude's own `/rename` of its session (or the auto-generated first-message summary like `auto-refresh-task-lists`) is prevented from syncing back into the agent-deck title. Without this, the conductor loses the semantic identity it assigned to the child session on the first hook tick — making it impossible to tell which worker is working on which ticket once Claude has spoken. Three call sites:
+  1. **`Instance.TitleLocked bool`** (new field, persisted in `instances.title_locked` SQLite column via schema bump v7 → v8, additive ALTER TABLE with `DEFAULT 0` so every pre-v1.7.52 row reads as unlocked and the existing `applyClaudeTitleSync` path stays default-on for them). JSON tag `title_locked,omitempty` keeps the wire format backwards-compatible with any third-party tooling that reads the state-db JSON dumps.
+  2. **`applyClaudeTitleSync` gate** (`cmd/agent-deck/hook_name_sync.go`): after resolving the target Instance, an early-return `if target.TitleLocked` skips the Title mutation and the SaveWithGroups write — keeping the #572 default behaviour (Claude `--name`/`/rename` syncs into agent-deck) untouched for the 99% case while giving conductors an opt-in off switch.
+  3. **CLI surface**: `agent-deck add` and `agent-deck launch` gain `--title-lock` (with `--no-title-sync` as an alias for discoverability); `agent-deck session set-title-lock <id> <on|off>` toggles an already-created session (accepts `true`/`false`/`1`/`0`/`yes`/`no` too for script friendliness). `session show --json` now emits `title_locked: true|false` so conductors can query state without reading the SQLite directly.
+
+  Tests (TDD — RED captured on baseline before the implementation landed):
+  - `TestApplyClaudeTitleSync_NoopWhenTitleLocked` in `cmd/agent-deck/hook_name_sync_test.go` — seeds an Instance with `TitleLocked: true` and a matching Claude session metadata file, invokes `applyClaudeTitleSync`, asserts the Title did NOT change and that `TitleLocked` survived the round-trip (guards against silent persistence regressions).
+  - `TestStorageSaveWithGroups_PersistsTitleLocked` in `internal/session/storage_test.go` — round-trips two instances (one locked, one unlocked) through `SaveWithGroups`, then reloads via BOTH `LoadWithGroups` (full hydration, TUI path) and `LoadLite` (fast CLI path), asserting the bool survives each path and that the default (false) doesn't leak across rows.
+  - The three existing `TestApplyClaudeTitleSync_*` cases (UpdatesInstance / NoopWhenNameMissing / NoopWhenNameEqualsTitle) continue to pass unchanged, proving the #572 default behaviour is preserved.
+  - End-to-end eval harness at `tests/eval/title-lock.eval.sh` drives the real binary through three real-world scenarios in a disposable `HOME`: (A) add with `--title-lock` blocks Claude's rename; (B) `session set-title-lock off` re-enables sync on the next hook tick; (C) `set-title-lock on` re-freezes the title against a subsequent rename. Smoke-tier — designed to run on every PR that touches session lifecycle.
+
+  Thanks to [@evgenii-at-dev](https://github.com/evgenii-at-dev) for the detailed conductor-workflow bug report that caught this.
+
 ## [1.7.51] - 2026-04-22
 
 ### Fixed

--- a/cmd/agent-deck/hook_name_sync.go
+++ b/cmd/agent-deck/hook_name_sync.go
@@ -105,6 +105,13 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 			_ = storage.Close()
 			continue
 		}
+		// #697: TitleLocked blocks Claude's session name from overwriting the
+		// agent-deck title. Conductors rely on semantic titles (e.g.
+		// "SCRUM-351") surviving Claude's own /rename.
+		if target.TitleLocked {
+			_ = storage.Close()
+			return
+		}
 		if target.Title == name {
 			_ = storage.Close()
 			return

--- a/cmd/agent-deck/hook_name_sync_test.go
+++ b/cmd/agent-deck/hook_name_sync_test.go
@@ -248,3 +248,67 @@ func TestApplyClaudeTitleSync_NoopWhenNameEqualsTitle(t *testing.T) {
 		t.Errorf("DB last-modified advanced when title already equaled Claude name: before=%v after=%v (redundant write)", beforeTS, afterTS)
 	}
 }
+
+// TestApplyClaudeTitleSync_NoopWhenTitleLocked (#697): when the user has set
+// TitleLocked=true on an instance, Claude renaming the session (e.g. from
+// "SCRUM-351" to "auto-refresh-task-lists") must not overwrite the
+// agent-deck title. Conductors depend on semantic titles surviving Claude's
+// /rename of its own session.
+func TestApplyClaudeTitleSync_NoopWhenTitleLocked(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTDECK_PROFILE", "sync_test_697_lock")
+
+	claudeDir := filepath.Join(home, ".claude")
+	sid := "sid-697"
+	writeClaudeSessionFile(t, claudeDir, 697, map[string]any{
+		"pid":       697,
+		"sessionId": sid,
+		"name":      "auto-refresh-task-lists",
+	})
+
+	storage, err := session.NewStorageWithProfile("sync_test_697_lock")
+	if err != nil {
+		t.Fatalf("new storage: %v", err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	inst := &session.Instance{
+		ID:          "inst-697",
+		Title:       "SCRUM-351",
+		TitleLocked: true,
+		Tool:        "claude",
+		ProjectPath: projectDir,
+		Command:     "claude",
+	}
+	if err := storage.Save([]*session.Instance{inst}); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	applyClaudeTitleSync("inst-697", sid)
+
+	loaded, err := storage.Load()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	var found *session.Instance
+	for _, i := range loaded {
+		if i.ID == "inst-697" {
+			found = i
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("instance disappeared")
+	}
+	if found.Title != "SCRUM-351" {
+		t.Errorf("post-sync Title = %q, want %q (#697 TitleLocked must block sync)", found.Title, "SCRUM-351")
+	}
+	if !found.TitleLocked {
+		t.Errorf("TitleLocked lost across storage round-trip: got false, want true")
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -30,6 +30,10 @@ func handleLaunch(profile string, args []string) {
 	parentShort := fs.String("p", "", "Parent session (short)")
 	noParent := fs.Bool("no-parent", false, "Disable automatic parent linking")
 	noTransitionNotify := fs.Bool("no-transition-notify", false, "Suppress transition event notifications to parent session")
+	// #697: conductor-friendly title lock. Prevents Claude's session name
+	// from overwriting the agent-deck title.
+	titleLock := fs.Bool("title-lock", false, "Lock session title so Claude's session name never overrides it (#697)")
+	noTitleSync := fs.Bool("no-title-sync", false, "Alias for --title-lock")
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
@@ -310,6 +314,11 @@ func handleLaunch(profile string, args []string) {
 
 	if *noTransitionNotify {
 		newInstance.NoTransitionNotify = true
+	}
+
+	// #697: title-lock blocks Claude's session-name sync.
+	if *titleLock || *noTitleSync {
+		newInstance.TitleLocked = true
 	}
 
 	if sessionCommandInput != "" {

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -35,7 +35,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.51" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.52" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (
@@ -948,6 +948,11 @@ func handleAdd(profile string, args []string) {
 	parentShort := fs.String("p", "", "Parent session (short)")
 	noParent := fs.Bool("no-parent", false, "Disable automatic parent linking (use 'session set-parent' later to link manually)")
 	noTransitionNotify := fs.Bool("no-transition-notify", false, "Suppress transition event notifications to parent session")
+	// #697: conductor-friendly title lock. When set, Claude's session name
+	// (--name / /rename) never overwrites the agent-deck title. --no-title-sync
+	// is an alias for discoverability.
+	titleLock := fs.Bool("title-lock", false, "Lock session title so Claude's session name never overrides it (#697)")
+	noTitleSync := fs.Bool("no-title-sync", false, "Alias for --title-lock")
 	quickCreate := fs.Bool("quick", false, "Auto-generate session name (adjective-noun)")
 	quickCreateShort := fs.Bool("Q", false, "Auto-generate session name (short)")
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
@@ -1319,6 +1324,11 @@ func handleAdd(profile string, args []string) {
 	// Suppress transition notifications if requested
 	if *noTransitionNotify {
 		newInstance.NoTransitionNotify = true
+	}
+
+	// #697: title-lock blocks Claude's session-name sync. Either flag triggers it.
+	if *titleLock || *noTitleSync {
+		newInstance.TitleLocked = true
 	}
 
 	// Set command if provided

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -50,6 +50,8 @@ func handleSession(profile string, args []string) {
 		handleSessionUnsetParent(profile, args[1:])
 	case "set-transition-notify":
 		handleSessionSetTransitionNotify(profile, args[1:])
+	case "set-title-lock":
+		handleSessionSetTitleLock(profile, args[1:])
 	case "set":
 		handleSessionSet(profile, args[1:])
 	case "move", "mv":
@@ -92,6 +94,7 @@ func printSessionHelp() {
 	fmt.Println("  set-parent <id> <parent>  Link session as sub-session of parent")
 	fmt.Println("  unset-parent <id>       Remove sub-session link")
 	fmt.Println("  set-transition-notify <id> <on|off>  Enable/disable transition notifications")
+	fmt.Println("  set-title-lock <id> <on|off>         Lock/unlock title from Claude session-name sync (#697)")
 	fmt.Println()
 	fmt.Println("Global Options:")
 	fmt.Println("  -p, --profile <name>   Use specific profile")
@@ -110,6 +113,8 @@ func printSessionHelp() {
 	fmt.Println("  agent-deck session unset-parent sub-task             # Remove sub-session link")
 	fmt.Println("  agent-deck session set-transition-notify worker off    # Suppress notifications")
 	fmt.Println("  agent-deck session set-transition-notify worker on     # Re-enable notifications")
+	fmt.Println("  agent-deck session set-title-lock SCRUM-351 on         # Prevent Claude from renaming it")
+	fmt.Println("  agent-deck session set-title-lock SCRUM-351 off        # Re-enable title sync")
 	fmt.Println("  agent-deck session output my-project                 # Get last response from session")
 	fmt.Println("  agent-deck session output my-project --json          # Get response as JSON")
 	fmt.Println()
@@ -770,6 +775,7 @@ func handleSessionShow(profile string, args []string) {
 		"parent_session_id":    inst.ParentSessionID,
 		"parent_project_path":  inst.ParentProjectPath,
 		"no_transition_notify": inst.NoTransitionNotify,
+		"title_locked":         inst.TitleLocked,
 		"tool":                 inst.Tool,
 		"created_at":           inst.CreatedAt.Format(time.RFC3339),
 	}
@@ -1532,6 +1538,90 @@ func handleSessionSetTransitionNotify(profile string, args []string) {
 		"session_id":           inst.ID,
 		"session_title":        inst.Title,
 		"no_transition_notify": suppress,
+	})
+}
+
+// handleSessionSetTitleLock toggles Instance.TitleLocked (#697). When on, the
+// claude-hook name-sync path (applyClaudeTitleSync) is a no-op for this
+// session, preserving the conductor-assigned title across Claude renames.
+func handleSessionSetTitleLock(profile string, args []string) {
+	fs := flag.NewFlagSet("session set-title-lock", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session set-title-lock <session> <on|off|true|false>")
+		fmt.Println()
+		fmt.Println("Lock or unlock a session's title from Claude session-name sync (#697).")
+		fmt.Println("When locked, Claude's --name / /rename will not overwrite the")
+		fmt.Println("agent-deck title. Conductors rely on this so semantic titles like")
+		fmt.Println("'SCRUM-351' survive Claude's auto-generated summaries.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck session set-title-lock SCRUM-351 on")
+		fmt.Println("  agent-deck session set-title-lock SCRUM-351 off")
+		fmt.Println("  agent-deck session set-title-lock worker true")
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	if fs.NArg() < 2 {
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	sessionID := fs.Arg(0)
+	value := strings.ToLower(strings.TrimSpace(fs.Arg(1)))
+	quietMode := *quiet || *quietShort
+	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	var locked bool
+	switch value {
+	case "on", "true", "1", "yes":
+		locked = true
+	case "off", "false", "0", "no":
+		locked = false
+	default:
+		out.Error(fmt.Sprintf("invalid value %q: must be 'on' or 'off' (also true/false/1/0)", value), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	storage, instances, groupsData, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	inst, errMsg, errCode := ResolveSession(sessionID, instances)
+	if inst == nil {
+		out.Error(errMsg, errCode)
+		os.Exit(2)
+		return
+	}
+
+	inst.TitleLocked = locked
+
+	groupTree := session.NewGroupTreeWithGroups(instances, groupsData)
+	if err := storage.SaveWithGroups(instances, groupTree); err != nil {
+		out.Error(fmt.Sprintf("failed to save: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	stateStr := "off"
+	if locked {
+		stateStr = "on"
+	}
+	out.Success(fmt.Sprintf("Title lock for '%s': %s", inst.Title, stateStr), map[string]interface{}{
+		"success":       true,
+		"session_id":    inst.ID,
+		"session_title": inst.Title,
+		"title_locked":  locked,
 	})
 }
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -81,6 +81,13 @@ type Instance struct {
 	IsConductor        bool   `json:"is_conductor,omitempty"`         // True if this session is a conductor orchestrator
 	NoTransitionNotify bool   `json:"no_transition_notify,omitempty"` // Suppress transition event dispatch for this session
 
+	// TitleLocked, when true, blocks Claude's session name from syncing into
+	// the agent-deck Title (issue #697). Conductors launch workers with a
+	// semantic title (e.g. "SCRUM-351") that Claude would otherwise overwrite
+	// with its auto-generated summary on the next hook event. Set via
+	// `--title-lock` on add/launch or `session set-title-lock`.
+	TitleLocked bool `json:"title_locked,omitempty"`
+
 	// Git worktree support
 	WorktreePath     string `json:"worktree_path,omitempty"`      // Path to worktree (if session is in worktree)
 	WorktreeRepoRoot string `json:"worktree_repo_root,omitempty"` // Original repo root

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -44,6 +44,7 @@ type InstanceData struct {
 	ParentSessionID    string    `json:"parent_session_id,omitempty"`    // Links to parent session (sub-session support)
 	IsConductor        bool      `json:"is_conductor,omitempty"`         // True if this session is a conductor orchestrator
 	NoTransitionNotify bool      `json:"no_transition_notify,omitempty"` // Suppress transition event dispatch
+	TitleLocked        bool      `json:"title_locked,omitempty"`         // #697: block Claude session-name sync into Title
 	Command            string    `json:"command"`
 	Wrapper            string    `json:"wrapper,omitempty"`
 	Tool               string    `json:"tool"`
@@ -351,6 +352,7 @@ func (s *Storage) SaveWithGroups(instances []*Instance, groupTree *GroupTree) er
 			ParentSessionID:    inst.ParentSessionID,
 			IsConductor:        inst.IsConductor,
 			NoTransitionNotify: inst.NoTransitionNotify,
+			TitleLocked:        inst.TitleLocked,
 			WorktreePath:       inst.WorktreePath,
 			WorktreeRepo:       inst.WorktreeRepoRoot,
 			WorktreeBranch:     inst.WorktreeBranch,
@@ -493,6 +495,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			ParentSessionID:    r.ParentSessionID,
 			IsConductor:        r.IsConductor,
 			NoTransitionNotify: r.NoTransitionNotify,
+			TitleLocked:        r.TitleLocked,
 			Command:            r.Command,
 			Wrapper:            r.Wrapper,
 			Tool:               r.Tool,
@@ -598,6 +601,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			ParentSessionID:    r.ParentSessionID,
 			IsConductor:        r.IsConductor,
 			NoTransitionNotify: r.NoTransitionNotify,
+			TitleLocked:        r.TitleLocked,
 			Command:            r.Command,
 			Wrapper:            r.Wrapper,
 			Tool:               r.Tool,
@@ -840,6 +844,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			ParentSessionID:    instData.ParentSessionID,
 			IsConductor:        instData.IsConductor,
 			NoTransitionNotify: instData.NoTransitionNotify,
+			TitleLocked:        instData.TitleLocked,
 			Command:            instData.Command,
 			Wrapper:            instData.Wrapper,
 			Tool:               instData.Tool,

--- a/internal/session/storage_test.go
+++ b/internal/session/storage_test.go
@@ -316,6 +316,75 @@ func TestStorageSaveWithGroups_PersistsSandboxConfig(t *testing.T) {
 	}
 }
 
+// TestStorageSaveWithGroups_PersistsTitleLocked (#697) verifies that
+// Instance.TitleLocked round-trips through SQLite so the sync blocker
+// survives agent-deck restarts. Without persistence, a conductor-set lock
+// would silently evaporate on the first TUI restart and Claude could
+// rename the session on the next hook event.
+func TestStorageSaveWithGroups_PersistsTitleLocked(t *testing.T) {
+	s := newTestStorage(t)
+
+	instances := []*Instance{
+		{
+			ID:          "locked-1",
+			Title:       "SCRUM-351",
+			ProjectPath: "/tmp/locked",
+			GroupPath:   "grp",
+			Command:     "claude",
+			Tool:        "claude",
+			Status:      StatusIdle,
+			CreatedAt:   time.Now(),
+			TitleLocked: true,
+		},
+		{
+			ID:          "unlocked-1",
+			Title:       "quiet-river",
+			ProjectPath: "/tmp/unlocked",
+			GroupPath:   "grp",
+			Command:     "claude",
+			Tool:        "claude",
+			Status:      StatusIdle,
+			CreatedAt:   time.Now(),
+		},
+	}
+
+	if err := s.SaveWithGroups(instances, nil); err != nil {
+		t.Fatalf("SaveWithGroups failed: %v", err)
+	}
+
+	loaded, _, err := s.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups failed: %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Fatalf("expected 2 loaded instances, got %d", len(loaded))
+	}
+
+	byID := map[string]*Instance{}
+	for _, inst := range loaded {
+		byID[inst.ID] = inst
+	}
+	if !byID["locked-1"].TitleLocked {
+		t.Errorf("locked-1.TitleLocked = false after round-trip, want true (#697)")
+	}
+	if byID["unlocked-1"].TitleLocked {
+		t.Errorf("unlocked-1.TitleLocked = true after round-trip, want false (default must not leak)")
+	}
+
+	// Also verify LoadLite preserves it (fast-path used by CLI commands)
+	lite, _, err := s.LoadLite()
+	if err != nil {
+		t.Fatalf("LoadLite failed: %v", err)
+	}
+	liteByID := map[string]*InstanceData{}
+	for _, d := range lite {
+		liteByID[d.ID] = d
+	}
+	if !liteByID["locked-1"].TitleLocked {
+		t.Errorf("LoadLite locked-1.TitleLocked = false, want true")
+	}
+}
+
 // TestSaveSessionData_PreservesGroupSortOrder verifies that saving session data
 // with stored groups preserves the sort_order, matching the fix in #465.
 func TestSaveSessionData_PreservesGroupSortOrder(t *testing.T) {

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -49,6 +49,8 @@ type InstanceRow struct {
 	// Empty for pre-v1.7.50 rows — those keep targeting the default server
 	// after upgrade.
 	TmuxSocketName string
+	// TitleLocked blocks Claude session-name sync into Title (v1.7.52+, issue #697).
+	TitleLocked    bool
 	WorktreePath   string
 	WorktreeRepo   string
 	WorktreeBranch string
@@ -212,6 +214,7 @@ func (s *StateDB) Migrate() error {
 			parent_session_id TEXT NOT NULL DEFAULT '',
 			is_conductor            INTEGER NOT NULL DEFAULT 0,
 			no_transition_notify    INTEGER NOT NULL DEFAULT 0,
+			title_locked            INTEGER NOT NULL DEFAULT 0,
 			worktree_path     TEXT NOT NULL DEFAULT '',
 			worktree_repo     TEXT NOT NULL DEFAULT '',
 			worktree_branch   TEXT NOT NULL DEFAULT '',
@@ -342,6 +345,9 @@ func (s *StateDB) Migrate() error {
 		// v7 (issue #687, v1.7.50): per-session tmux socket isolation.
 		// Default '' keeps the pre-v1.7.50 behavior for existing rows.
 		"ALTER TABLE instances ADD COLUMN tmux_socket_name TEXT NOT NULL DEFAULT ''",
+		// v8 (issue #697, v1.7.52): title lock blocks Claude session-name sync.
+		// Default 0 keeps the pre-v1.7.52 behavior (#572 sync default-on) for existing rows.
+		"ALTER TABLE instances ADD COLUMN title_locked INTEGER NOT NULL DEFAULT 0",
 	}
 	for _, stmt := range alterMigrations {
 		if _, err := tx.Exec(stmt); err != nil {
@@ -388,6 +394,13 @@ func (s *StateDB) Migrate() error {
 				}
 			}
 		}
+		if oldVer < 8 {
+			if _, err := tx.Exec(`ALTER TABLE instances ADD COLUMN title_locked INTEGER NOT NULL DEFAULT 0`); err != nil {
+				if !strings.Contains(err.Error(), "duplicate column") {
+					return fmt.Errorf("statedb: migrate v8 title_locked: %w", err)
+				}
+			}
+		}
 		if _, err := tx.Exec(`
 			UPDATE metadata SET value = ? WHERE key = 'schema_version'
 		`, schemaVersion); err != nil {
@@ -425,6 +438,10 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 	if inst.NoTransitionNotify {
 		noTransitionNotifyInt = 1
 	}
+	titleLockedInt := 0
+	if inst.TitleLocked {
+		titleLockedInt = 1
+	}
 	_, err := s.db.Exec(`
 		INSERT OR REPLACE INTO instances (
 			id, title, project_path, group_path, sort_order,
@@ -432,15 +449,15 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch,
-			tool_data
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			tool_data, title_locked
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		inst.ID, inst.Title, inst.ProjectPath, inst.GroupPath, inst.Order,
 		inst.Command, inst.Wrapper, inst.Tool, inst.Status, inst.TmuxSession, inst.TmuxSocketName,
 		inst.CreatedAt.Unix(), inst.LastAccessed.Unix(),
 		inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
 		inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch,
-		string(toolData),
+		string(toolData), titleLockedInt,
 	)
 	return err
 }
@@ -480,8 +497,8 @@ func (s *StateDB) SaveInstances(insts []*InstanceRow) error {
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch,
-			tool_data
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			tool_data, title_locked
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return err
@@ -501,13 +518,17 @@ func (s *StateDB) SaveInstances(insts []*InstanceRow) error {
 		if inst.NoTransitionNotify {
 			noTransitionNotifyInt = 1
 		}
+		titleLockedInt := 0
+		if inst.TitleLocked {
+			titleLockedInt = 1
+		}
 		if _, err := stmt.Exec(
 			inst.ID, inst.Title, inst.ProjectPath, inst.GroupPath, inst.Order,
 			inst.Command, inst.Wrapper, inst.Tool, inst.Status, inst.TmuxSession, inst.TmuxSocketName,
 			inst.CreatedAt.Unix(), inst.LastAccessed.Unix(),
 			inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
 			inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch,
-			string(toolData),
+			string(toolData), titleLockedInt,
 		); err != nil {
 			return err
 		}
@@ -524,7 +545,7 @@ func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch,
-			tool_data
+			tool_data, title_locked
 		FROM instances ORDER BY sort_order
 	`)
 	if err != nil {
@@ -537,14 +558,14 @@ func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
 		r := &InstanceRow{}
 		var createdUnix, accessedUnix int64
 		var toolDataStr string
-		var isConductorInt, noTransitionNotifyInt int
+		var isConductorInt, noTransitionNotifyInt, titleLockedInt int
 		if err := rows.Scan(
 			&r.ID, &r.Title, &r.ProjectPath, &r.GroupPath, &r.Order,
 			&r.Command, &r.Wrapper, &r.Tool, &r.Status, &r.TmuxSession, &r.TmuxSocketName,
 			&createdUnix, &accessedUnix,
 			&r.ParentSessionID, &isConductorInt, &noTransitionNotifyInt,
 			&r.WorktreePath, &r.WorktreeRepo, &r.WorktreeBranch,
-			&toolDataStr,
+			&toolDataStr, &titleLockedInt,
 		); err != nil {
 			return nil, err
 		}
@@ -554,6 +575,7 @@ func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
 		}
 		r.IsConductor = isConductorInt != 0
 		r.NoTransitionNotify = noTransitionNotifyInt != 0
+		r.TitleLocked = titleLockedInt != 0
 		r.ToolData = json.RawMessage(toolDataStr)
 		result = append(result, r)
 	}

--- a/tests/eval/title-lock.eval.sh
+++ b/tests/eval/title-lock.eval.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# title-lock.eval.sh — end-to-end verification for #697 (v1.7.52).
+#
+# What this covers (that unit tests can't):
+#   1. Real CLI binary accepts `--title-lock` on `agent-deck add`.
+#   2. Title-lock survives SQLite round-trip via `session show`.
+#   3. The hook-handler path (`agent-deck hook-handler`) is a no-op when
+#      TitleLocked=true, even with a matching Claude session-name file.
+#   4. Default (unlocked) behaviour is unchanged: the same hook event DOES
+#      rewrite the title.
+#   5. `session set-title-lock off` re-enables sync.
+#
+# Runs against a disposable HOME/AGENTDECK_PROFILE so it can't clobber the
+# real user state. Designed for the smoke tier (per-PR).
+#
+# Exit 0 on pass, 1 on first failure. All output goes to stdout so the CI
+# log and the release report can grep for PASS/FAIL lines.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BIN="${AGENT_DECK_BIN:-$REPO_ROOT/agent-deck}"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "FAIL: binary not built at $BIN (set AGENT_DECK_BIN or run 'go build -o agent-deck ./cmd/agent-deck')" >&2
+  exit 1
+fi
+
+SANDBOX="$(mktemp -d -t agent-deck-eval-697-XXXXXX)"
+cleanup() {
+  rm -rf "$SANDBOX" || true
+}
+trap cleanup EXIT
+
+export HOME="$SANDBOX/home"
+export AGENTDECK_PROFILE="eval_697"
+mkdir -p "$HOME/.claude/sessions" "$HOME/proj"
+
+PASSES=0
+FAILS=0
+pass() { echo "PASS: $1"; PASSES=$((PASSES + 1)); }
+fail() { echo "FAIL: $1" >&2; FAILS=$((FAILS + 1)); }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case A: --title-lock on `add` persists TitleLocked=true and blocks sync
+# ─────────────────────────────────────────────────────────────────────────────
+"$BIN" add "$HOME/proj" --quick -c claude --title-lock 2>&1 | head -20
+
+INSTANCE_ID=$("$BIN" list --json 2>/dev/null | python3 -c 'import sys,json; d=json.load(sys.stdin); print((d[0] if d else {}).get("id",""))' || true)
+if [[ -z "$INSTANCE_ID" ]]; then
+  fail "could not resolve instance id after add --title-lock"
+  exit 1
+fi
+
+# Force the title to a conductor-style value
+"$BIN" session set "$INSTANCE_ID" title "SCRUM-351" -q >/dev/null 2>&1 || {
+  fail "session set title failed"; exit 1;
+}
+
+# Seed a Claude sessions meta file that would trigger a rename
+SID="eval-697-sid"
+cat >"$HOME/.claude/sessions/99999.json" <<JSON
+{"pid":99999,"sessionId":"$SID","cwd":"$HOME/proj","name":"auto-refresh-task-lists"}
+JSON
+
+# Fire the hook-handler as Claude would: stdin payload + instance-id env
+PAYLOAD=$(printf '{"session_id":"%s","hook_event_name":"Stop"}' "$SID")
+printf '%s' "$PAYLOAD" | env AGENTDECK_INSTANCE_ID="$INSTANCE_ID" "$BIN" hook-handler >/dev/null 2>&1 || true
+
+TITLE_AFTER=$("$BIN" session show "$INSTANCE_ID" --json 2>/dev/null | \
+  python3 -c 'import sys,json; d=json.load(sys.stdin); print((d.get("data") or d).get("title",""))')
+
+if [[ "$TITLE_AFTER" == "SCRUM-351" ]]; then
+  pass "title-lock: Claude rename blocked (title stayed 'SCRUM-351')"
+else
+  fail "title-lock: title leaked to '$TITLE_AFTER' (expected 'SCRUM-351')"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case B: turning title-lock OFF allows the next hook to apply the rename
+# ─────────────────────────────────────────────────────────────────────────────
+"$BIN" session set-title-lock "$INSTANCE_ID" off -q >/dev/null 2>&1 || {
+  fail "session set-title-lock off failed"; exit 1;
+}
+
+printf '%s' "$PAYLOAD" | env AGENTDECK_INSTANCE_ID="$INSTANCE_ID" "$BIN" hook-handler >/dev/null 2>&1 || true
+
+TITLE_AFTER2=$("$BIN" session show "$INSTANCE_ID" --json 2>/dev/null | \
+  python3 -c 'import sys,json; d=json.load(sys.stdin); print((d.get("data") or d).get("title",""))')
+
+if [[ "$TITLE_AFTER2" == "auto-refresh-task-lists" ]]; then
+  pass "title-lock off: Claude rename applied ('$TITLE_AFTER2')"
+else
+  fail "title-lock off: expected 'auto-refresh-task-lists', got '$TITLE_AFTER2'"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Case C: turning title-lock back ON freezes the current title
+# ─────────────────────────────────────────────────────────────────────────────
+"$BIN" session set "$INSTANCE_ID" title "SCRUM-351" -q >/dev/null 2>&1
+"$BIN" session set-title-lock "$INSTANCE_ID" on -q >/dev/null 2>&1
+
+# Swap the Claude metadata name again
+cat >"$HOME/.claude/sessions/99999.json" <<JSON
+{"pid":99999,"sessionId":"$SID","cwd":"$HOME/proj","name":"something-completely-different"}
+JSON
+
+printf '%s' "$PAYLOAD" | env AGENTDECK_INSTANCE_ID="$INSTANCE_ID" "$BIN" hook-handler >/dev/null 2>&1 || true
+
+TITLE_AFTER3=$("$BIN" session show "$INSTANCE_ID" --json 2>/dev/null | \
+  python3 -c 'import sys,json; d=json.load(sys.stdin); print((d.get("data") or d).get("title",""))')
+
+if [[ "$TITLE_AFTER3" == "SCRUM-351" ]]; then
+  pass "title-lock re-on: subsequent Claude rename blocked"
+else
+  fail "title-lock re-on: title leaked to '$TITLE_AFTER3' (expected 'SCRUM-351')"
+fi
+
+echo ""
+echo "Summary: $PASSES passed, $FAILS failed"
+if [[ $FAILS -eq 0 ]]; then
+  echo "ALL CHECKS PASSED"
+  exit 0
+else
+  echo "FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes #697 — reported by @evgenii-at-dev.

Adds a `--title-lock` flag on `agent-deck add` / `agent-deck launch`, plus a `session set-title-lock <id> <on|off>` subcommand. When set, Claude's session name (`--name` or `/rename` or its auto-generated first-message summary) no longer overwrites the agent-deck Title via `applyClaudeTitleSync`. Conductor workflows that launch workers with a semantic title (e.g. `SCRUM-351`) keep that identity across Claude renames.

New `Instance.TitleLocked bool`, persisted in a new `instances.title_locked` SQLite column via schema bump v6 → v7 (additive `ALTER TABLE … DEFAULT 0`, so pre-v1.7.52 rows stay unlocked and the #572 default sync behaviour is preserved).

## Test plan

- [x] **RED captured** on baseline (compile errors: `unknown field TitleLocked in struct literal`)
- [x] **GREEN** for the two new unit tests (`TestApplyClaudeTitleSync_NoopWhenTitleLocked`, `TestStorageSaveWithGroups_PersistsTitleLocked`)
- [x] Three existing `TestApplyClaudeTitleSync_*` cases continue to pass unchanged (default #572 behaviour preserved)
- [x] Mandatory `TestPersistence_*` suite green on this branch (session-lifecycle mandate)
- [x] Full repo `go test ./... -race -count=1` — all 26 packages ok
- [x] End-to-end eval `tests/eval/title-lock.eval.sh` drives the real binary through three scenarios (lock-on blocks / lock-off allows / lock-re-on re-blocks) — 3/3 pass
- [x] Real-world binary verification against a compiled `./agent-deck v1.7.52` with a matching Claude `sessions/*.json` metadata file: title stayed `SCRUM-351` after hook fired with `title_locked=true`

## Layers

1. `Instance.TitleLocked` field + JSON tag (backwards-compatible wire format).
2. SQLite migration v6 → v7 (additive ALTER, `DEFAULT 0`).
3. `applyClaudeTitleSync` gate (one-line short-circuit).
4. CLI: `--title-lock` on `add`/`launch` (+ `--no-title-sync` alias); `session set-title-lock` subcommand; `session show --json` now emits `title_locked`.

## Credits

Thanks to @evgenii-at-dev for the detailed conductor-workflow bug report — the semantic-identity-loss symptom they described is exactly what this fix targets.