### PR TITLE
ci(release): install zoxide to unblock v1.7.52 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,15 @@ jobs:
           fi
           echo "Version: $CODE"
 
+      # zoxide backs the quick-open picker tests (#693, v1.7.54). Not on
+      # ubuntu-latest by default; install here so `go test ./...` doesn't
+      # false-fail on the non-title-lock zoxide_picker_test suite.
+      - name: Install zoxide
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y zoxide
+          zoxide --version
+
       - name: Run tests
         run: go test -race ./...
 


### PR DESCRIPTION
## Summary

Release workflow for v1.7.52 failed in `go test ./...` because
`ubuntu-latest` ships without zoxide and #693's `zoxide_picker_test.go`
tests short-circuit on `ZoxideAvailable() == false`. Matches the
eval-smoke.yml fix that landed in #714.

Run that hit this: https://github.com/asheshgoplani/agent-deck/actions/runs/24761914048

## Test plan

- [x] Same 2-line install recipe we already validated in eval-smoke.yml (green after fix)
- [ ] After merge: delete + re-push v1.7.52 tag to retrigger goreleaser

## Blocking

v1.7.52 tag is live but has no release artifacts. Merging this unblocks every future release tag too.