### PR TITLE
release: bump to v1.7.54 to re-ship title-lock (#697) + select flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.54] - 2026-04-22
+
+### Added
+- **Title-lock re-ship** ([#697](https://github.com/asheshgoplani/agent-deck/issues/697), reported by [@evgenii-at-dev](https://github.com/evgenii-at-dev)). The title-lock feature itself landed in main via PR [#714](https://github.com/asheshgoplani/agent-deck/pull/714) under the v1.7.52 CHANGELOG heading, but its release workflow and the follow-up v1.7.53 release both hit a pre-existing CI gap (`ubuntu-latest` ships without zoxide; the #693 quick-open picker tests short-circuit on `ZoxideAvailable()` and false-fail `go test ./...`). PR [#716](https://github.com/asheshgoplani/agent-deck/pull/716) added `apt-get install -y zoxide` to both `eval-smoke.yml` and `release.yml`. This release re-ships the v1.7.52 and v1.7.53 features as v1.7.54 so the title-lock fix (and the #709 `--select` flag that briefly tagged as v1.7.53 without artifacts) actually reach binary releases. **No source-code changes for the title-lock feature between v1.7.52 and v1.7.54** — the PR [#714](https://github.com/asheshgoplani/agent-deck/pull/714) commit is unchanged on main; only the release infrastructure around it was fixed. See the "[1.7.52]" entry below for the full feature description and the TDD evidence.
+- **No-op for the #709 `--select` behaviour** — see the "[1.7.53]" entry below; re-shipped identically.
+
+### Fixed
+- **Release workflow infrastructure gap unblocked** ([#716](https://github.com/asheshgoplani/agent-deck/pull/716)): `release.yml` and `eval-smoke.yml` now install zoxide before running `go test ./...`. Without this every release tag between v1.7.52 and v1.7.54 failed its goreleaser step, leaving orphan tags with no binaries. Future releases on `ubuntu-latest` are unblocked.
+
 ## [1.7.53] - 2026-04-22
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -35,7 +35,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.53" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.54" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (


### PR DESCRIPTION
## Summary

Re-ship the v1.7.52 (#697 title-lock, PR #714) and v1.7.53 (#709 `--select` flag) features under v1.7.54 so they actually produce binary releases. Both prior tags are orphan tags — the release workflow aborted in `go test ./...` because `ubuntu-latest` ships without zoxide and #693's picker tests short-circuit + false-fail on `ZoxideAvailable() == false`.

PR #716 fixed the CI infrastructure in `eval-smoke.yml` and `release.yml`. This PR is the minimum-viable bump that gets the two features out the door under fresh artifacts.

**No product-code changes.** Only:
- `cmd/agent-deck/main.go`: `Version = "1.7.53" → "1.7.54"`
- `CHANGELOG.md`: `[1.7.54]` entry documenting the re-ship reason and pointing to the original `[1.7.52]` and `[1.7.53]` entries for the actual feature evidence.

## Test plan

- [x] Build clean
- [x] Targeted tests green: `TestApplyClaudeTitleSync_NoopWhenTitleLocked`, `TestStorageSaveWithGroups_PersistsTitleLocked`, `TestPersistence_*`
- [ ] After merge: tag v1.7.54, push tag, goreleaser produces artifacts, release is live

## Context

Runs that hit the zoxide gap:
- v1.7.52: https://github.com/asheshgoplani/agent-deck/actions/runs/24761914048
- v1.7.53: https://github.com/asheshgoplani/agent-deck/actions/runs/24762231900