### PR TITLE
feat(launch): verify claude consumed -m prompt (v1.7.66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.66] - 2026-04-22
+
+### Fixed
+- **`agent-deck launch -m "<prompt>" --no-wait` now verifies claude actually consumed the initial prompt** (internal task `54-launch-verify-prompt`). On cold starts, claude's welcome screen occasionally ate the first `Enter`, leaving the `-m` prompt typed-but-not-submitted in the composer. The session sat in `status=waiting` forever with the message visible at `❯` but no assistant response ever started. Root cause: the launch path's post-start verification budget was **1.2s** (`sendRetryOptions{maxRetries: 8, checkDelay: 150ms}` in `cmd/agent-deck/launch_cmd.go`), far too short to observe and recover from the welcome-screen race on a fresh claude+MCPs cold start. Fix: after the existing `sendWithRetryTarget` pass, a new `verifyPromptConsumedAfterLaunch` helper polls the pane for up to **10s** (`250ms` interval). "Consumed" = composer rendered AND the `-m` message is no longer visible in the input line (`send.HasCurrentComposerPrompt && !send.HasUnsentComposerPrompt`). If still unconsumed after the first window, it retries `send-keys` exactly once; if the second window also shows the prompt unconsumed, it writes a warning to `os.Stderr` and returns without failing the launch (best-effort, preserving `--no-wait` spirit). Five unit tests in `cmd/agent-deck/launch_verify_prompt_test.go` cover: consumed-first-poll path (no retry, no warning), unsent-then-consumed-after-retry path (exactly 1 retry, no warning), unsent-both-windows path (1 retry + warning), welcome-screen-no-composer path (no false "consumed" when the composer hasn't rendered yet), and wall-time budget enforcement. All five use synthetic pane strings only, per the sanitization rule. The existing `sendWithRetryTarget` call is unchanged — the new helper is a second verification layer, not a replacement. **Numbering note:** originally drafted as v1.7.64; renumbered forward through the v1.7.63/64/65 queue shift (fix-53-56 + #724 worktree-timeout landed ahead).
+
 ## [1.7.65] - 2026-04-22
 
 ### Added

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -422,8 +422,13 @@ func handleLaunch(profile string, args []string) {
 
 	// Send message only for --no-wait mode.
 	// Non --no-wait mode already sent via StartWithMessage above.
-	// Even in no-wait mode, run a short send-verification loop so Enter-loss
+	// Even in no-wait mode, run a send-verification loop so Enter-loss
 	// races don't silently drop the initial prompt.
+	//
+	// v1.7.64 (internal task "54-launch-verify-prompt"): after the initial
+	// sendWithRetryTarget pass, run verifyPromptConsumedAfterLaunch to catch
+	// the welcome-screen race where claude eats the first Enter. 10s budget
+	// per window + single retry + stderr warning on persistent no-op.
 	if initialMessage != "" && *noWait {
 		tmuxSess := newInstance.GetTmuxSession()
 		if tmuxSess != nil {
@@ -434,6 +439,11 @@ func handleLaunch(profile string, args []string) {
 				out.Error(fmt.Sprintf("failed to send initial message: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)
 			}
+			verifyPromptConsumedAfterLaunch(
+				tmuxSess, initialMessage,
+				10*time.Second, 250*time.Millisecond,
+				os.Stderr,
+			)
 		}
 	}
 

--- a/cmd/agent-deck/launch_verify_prompt.go
+++ b/cmd/agent-deck/launch_verify_prompt.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/send"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// verifyPromptConsumedAfterLaunch observes whether claude actually consumed
+// the -m prompt after `agent-deck launch -m "..." --no-wait`.
+//
+// Bug (v1.7.64): the initial tmux send-keys + Enter occasionally races
+// claude's welcome-screen Enter handler, leaving the prompt typed in the
+// composer but never submitted. Session then sits in "waiting" forever. The
+// pre-existing launch path only granted 1.2s of verification (8×150ms),
+// which is far too short to observe and recover from that race on cold
+// starts with MCPs.
+//
+// Semantics:
+//  1. Poll the pane for up to maxWait. "Consumed" = composer rendered AND
+//     the message text is no longer visible in the input line.
+//  2. If still unconsumed, retry send-keys exactly once.
+//  3. Poll again for up to maxWait.
+//  4. If still unconsumed, emit a warning to `warn` and return.
+//
+// Never returns an error — this is best-effort verification layered on top
+// of the existing --no-wait contract.
+func verifyPromptConsumedAfterLaunch(
+	target sendRetryTarget,
+	message string,
+	maxWait, pollInterval time.Duration,
+	warn io.Writer,
+) {
+	if pollPromptConsumed(target, message, maxWait, pollInterval) {
+		return
+	}
+	_ = target.SendKeysAndEnter(message)
+	if pollPromptConsumed(target, message, maxWait, pollInterval) {
+		return
+	}
+	if warn != nil {
+		fmt.Fprintln(warn, "warning: launch prompt may not have been consumed by claude after retry; session may still be on the welcome screen")
+	}
+}
+
+// pollPromptConsumed returns true once the pane shows a rendered composer
+// whose input line no longer contains the message — i.e., Enter was
+// accepted. Returns false on timeout. Capture errors are treated as "not
+// yet consumed" so we keep polling until the budget expires.
+func pollPromptConsumed(target sendRetryTarget, message string, maxWait, pollInterval time.Duration) bool {
+	if pollInterval <= 0 {
+		pollInterval = 100 * time.Millisecond
+	}
+	deadline := time.Now().Add(maxWait)
+	for {
+		if raw, err := target.CapturePaneFresh(); err == nil {
+			content := tmux.StripANSI(raw)
+			if send.HasCurrentComposerPrompt(content) && !send.HasUnsentComposerPrompt(content, message) {
+				return true
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		remaining := time.Until(deadline)
+		sleep := pollInterval
+		if remaining < sleep {
+			sleep = remaining
+		}
+		if sleep > 0 {
+			time.Sleep(sleep)
+		}
+	}
+}

--- a/cmd/agent-deck/launch_verify_prompt_test.go
+++ b/cmd/agent-deck/launch_verify_prompt_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Tests for verifyPromptConsumedAfterLaunch — the v1.7.64 fix for:
+//
+//   agent-deck launch -m "prompt" --no-wait
+//
+// where claude at the welcome screen occasionally eats the initial Enter and
+// leaves the prompt typed-but-not-submitted. Existing 1.2s verify budget on
+// the launch path (launch_cmd.go:403-414) was too short to observe and
+// recover from this race on cold starts.
+//
+// Contract (per internal task spec, April 2026):
+//   1. After initial send-keys with -m, poll the pane for up to maxWait.
+//      "Consumed" = composer has rendered AND the message text is no longer
+//      visible in the composer input line.
+//   2. If still unconsumed after the first poll window, retry send-keys
+//      exactly once.
+//   3. Poll again for up to maxWait.
+//   4. If still unconsumed, emit a stderr-style warning to the injected
+//      writer and return (best-effort — do NOT fail the launch).
+//
+// All pane strings below are synthetic (no captured user data) per the
+// sanitization rule.
+
+const (
+	// paneConsumed: composer rendered, input line empty → message was
+	// submitted and claude is now at a clean prompt. This is the success
+	// shape we poll for.
+	paneConsumed = "some output above\n" +
+		"─────────────────────────\n" +
+		"❯\n" +
+		"─────────────────────────\n"
+
+	// paneUnsent: composer rendered with message still typed in the input
+	// line → Enter was never accepted.
+	paneUnsentTemplate = "welcome to claude\n" +
+		"─────────────────────────\n" +
+		"❯ %s\n" +
+		"─────────────────────────\n"
+
+	// paneWelcomeNoComposer: pre-TUI, no composer region visible at all →
+	// must NOT be classified as consumed (prompt could still be pending).
+	paneWelcomeNoComposer = "Claude is loading...\n"
+)
+
+func paneUnsent(msg string) string {
+	return strings.Replace(paneUnsentTemplate, "%s", msg, 1)
+}
+
+func TestVerifyPromptConsumedAfterLaunch_ConsumedFirstPoll_NoRetry_NoWarning(t *testing.T) {
+	// First capture already shows an empty composer → consumed on first poll.
+	// No retry send-keys should fire. No warning.
+	mock := &mockSendRetryTarget{
+		panes: []string{paneConsumed},
+	}
+	var warn bytes.Buffer
+
+	verifyPromptConsumedAfterLaunch(mock, "do the thing", 50*time.Millisecond, time.Millisecond, &warn)
+
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 0 {
+		t.Fatalf("SendKeysAndEnter retry count: got %d, want 0 (prompt already consumed)", got)
+	}
+	if warn.Len() != 0 {
+		t.Fatalf("unexpected warning written: %q", warn.String())
+	}
+}
+
+func TestVerifyPromptConsumedAfterLaunch_UnsentFirstWindow_RetryThenConsumed_OneRetry_NoWarning(t *testing.T) {
+	// Pane shows prompt typed-but-unconsumed through the entire first poll
+	// window, then after the retry send-keys it shows the consumed shape.
+	// Expect exactly one SendKeysAndEnter retry and no warning.
+	msg := "explain this code"
+	mock := &mockSendRetryTarget{
+		panes: []string{
+			paneUnsent(msg), paneUnsent(msg), paneUnsent(msg), paneUnsent(msg),
+			paneUnsent(msg), paneUnsent(msg), paneUnsent(msg), paneUnsent(msg),
+			paneUnsent(msg), paneUnsent(msg), paneUnsent(msg), paneUnsent(msg),
+			// After the retry kicks in, subsequent captures show consumed.
+			paneConsumed, paneConsumed, paneConsumed,
+		},
+	}
+	var warn bytes.Buffer
+
+	verifyPromptConsumedAfterLaunch(mock, msg, 20*time.Millisecond, 2*time.Millisecond, &warn)
+
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
+		t.Fatalf("SendKeysAndEnter retry count: got %d, want exactly 1", got)
+	}
+	if warn.Len() != 0 {
+		t.Fatalf("unexpected warning after successful retry: %q", warn.String())
+	}
+}
+
+func TestVerifyPromptConsumedAfterLaunch_UnsentBothWindows_OneRetry_WarningEmitted(t *testing.T) {
+	// Pane always shows prompt unconsumed. Expect: exactly one retry
+	// send-keys + warning written to the injected writer + non-fatal return.
+	msg := "launch stuck prompt"
+	mock := &mockSendRetryTarget{
+		panes: []string{paneUnsent(msg)}, // mock stays on last pane indefinitely
+	}
+	var warn bytes.Buffer
+
+	verifyPromptConsumedAfterLaunch(mock, msg, 10*time.Millisecond, time.Millisecond, &warn)
+
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
+		t.Fatalf("SendKeysAndEnter retry count: got %d, want exactly 1", got)
+	}
+	if warn.Len() == 0 {
+		t.Fatalf("expected warning on second no-op, got empty stderr writer")
+	}
+	if !strings.Contains(strings.ToLower(warn.String()), "prompt") {
+		t.Fatalf("warning should mention the prompt; got %q", warn.String())
+	}
+}
+
+func TestVerifyPromptConsumedAfterLaunch_WelcomeScreenNoComposer_NotConsumed_TriggersRetry(t *testing.T) {
+	// No composer has rendered yet (welcome/loading screen). "Not unsent"
+	// must NOT mean "consumed" — we require the composer to be present AND
+	// empty. So this scenario should fall through to retry + warning, not
+	// short-circuit as success.
+	mock := &mockSendRetryTarget{
+		panes: []string{paneWelcomeNoComposer},
+	}
+	var warn bytes.Buffer
+
+	verifyPromptConsumedAfterLaunch(mock, "ignored", 5*time.Millisecond, time.Millisecond, &warn)
+
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
+		t.Fatalf("expected retry when composer never rendered; SendKeysAndEnter calls=%d want=1", got)
+	}
+	if warn.Len() == 0 {
+		t.Fatalf("expected warning when composer never rendered")
+	}
+}
+
+func TestVerifyPromptConsumedAfterLaunch_RespectsWallTimeBudget(t *testing.T) {
+	// Poll windows must honour maxWait. With a 30ms budget per window and
+	// an always-unsent pane, total wall time should be bounded by roughly
+	// 2*maxWait + retry overhead. Anything approaching the production 10s
+	// default inside a test means the budget enforcement is broken.
+	msg := "budget guard"
+	mock := &mockSendRetryTarget{
+		panes: []string{paneUnsent(msg)},
+	}
+	var warn bytes.Buffer
+
+	start := time.Now()
+	verifyPromptConsumedAfterLaunch(mock, msg, 30*time.Millisecond, time.Millisecond, &warn)
+	elapsed := time.Since(start)
+
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("verify took %v, expected <500ms with 30ms budgets (unbounded poll bug)", elapsed)
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -36,7 +36,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.65" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.66" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (


### PR DESCRIPTION
## Summary
- Adds `verifyPromptConsumedAfterLaunch` helper: after `launch -m <prompt> --no-wait` fires send-keys, polls the pane for up to 10s to confirm claude actually consumed the prompt (composer rendered + message no longer visible in input line).
- If unconsumed after first window, retries send-keys exactly once and polls another 10s. If still unconsumed, emits a stderr warning and returns non-blocking.
- Existing `sendWithRetryTarget` call is unchanged — new helper is a strictly additive second verification layer.
- Fixes the welcome-screen Enter-loss race where `agent-deck launch -m "..." --no-wait` sometimes left sessions stuck at `status=waiting` with the prompt typed in the composer forever.

## Why now
Conductor workflows that fan out `agent-deck launch -m` for child sessions stall whenever the 1.2s post-start verify budget (`maxRetries:8, checkDelay:150ms`) misses the race on a cold claude + MCP boot. 10s × 2 windows + one explicit retry covers the observed failure mode without regressing the fast path.

## Test plan
- [x] `go test ./cmd/agent-deck/ -race -count=1` — 56s, PASS (includes 5 new `TestVerifyPromptConsumedAfterLaunch_*` cases with synthetic panes)
- [x] `go test -run TestPersistence_ ./internal/session/... -race -count=1` — PASS
- [x] `go test ./internal/feedback/... ./internal/ui/... -run "Feedback|Sender_" -race -count=1` — PASS
- [x] `go test ./internal/watcher/... -race -count=1` — PASS
- [x] Pre-push lefthook: fmt-check + vet + full test + lint + build — PASS
- [ ] Manual: `agent-deck launch -m "write one line: OK" --no-wait` on a cold claude session, verify stderr warning only appears when the session actually stalls