### PR TITLE
feat(worktree): configurable setup hook timeout via [worktree].setup_timeout_seconds (#724, v1.7.65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.65] - 2026-04-22
+
+### Added
+- **Configurable worktree-setup-hook timeout via `[worktree].setup_timeout_seconds`** ([#724](https://github.com/asheshgoplani/agent-deck/issues/724), reporter: @Clindbergh). The worktree setup script `.agent-deck/worktree-setup.sh` was previously capped at a hardcoded 60s, which is too tight for real-world setups that install dependencies and seed local databases — users were seeing timeouts on otherwise-healthy scripts. Fix introduces a new integer config knob `[worktree].setup_timeout_seconds` (default `60`, preserving prior behaviour for every existing install) that is loaded via the standard `LoadUserConfig` path and threaded through `git.RunWorktreeSetupScript` / `git.CreateWorktreeWithSetup` as an explicit `time.Duration` parameter. A non-positive value falls back to `git.DefaultWorktreeSetupTimeout` (60s), so a missing section, a missing field, a `0`, or a negative integer all behave identically to pre-v1.7.65 and cannot accidentally disable the guard. `WorktreeSettings.SetupTimeout()` is a value-receiver helper on the existing `session.WorktreeSettings` struct that returns the resolved `time.Duration`; it's what all five `CreateWorktreeWithSetup` call sites now pass (two in `internal/ui/home.go` for new-session and fork flows, one each in `cmd/agent-deck/launch_cmd.go`, `cmd/agent-deck/session_cmd.go`, `cmd/agent-deck/main.go`). The package-level `worktreeSetupTimeout` var in `internal/git/setup.go` is gone; all timeout control now flows through the function parameter, keeping the `git` package free of a `session` import. Effective wall-clock for a timed-out script is still `setup_timeout_seconds + cmd.WaitDelay` (5s) before SIGKILL — matches pre-v1.7.65 semantics. Tests: `TestWorktreeSettings_SetupTimeoutSeconds_ParsesFromTOML` (config round-trip), `TestWorktreeSettings_SetupTimeout_DefaultSixtySeconds` (zero-value backward compat), `TestWorktreeSettings_SetupTimeout_HonoursConfiguredValue` (positive value honoured) in `internal/session/worktree_setup_timeout_test.go`; `TestRunWorktreeSetupScript_HonoursCallerTimeout` in `internal/git/setup_timeout_arg_test.go` (a 1s caller timeout on a `sleep 300` script must fail in well under the legacy 60s default — proves the parameter is actually threaded, not just declared). Existing `TestRunWorktreeSetupScript_Timeout` rewritten to pass `1*time.Second` directly rather than mutating the now-deleted package var. Example config:
+  ```toml
+  [worktree]
+  setup_timeout_seconds = 300   # bump to 5 minutes for heavier setups
+  ```
+
 ## [1.7.62] - 2026-04-22
 
 ### Added

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -227,7 +227,7 @@ func handleLaunch(profile string, args []string) {
 				os.Exit(1)
 			}
 
-			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr)
+			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
 			if err != nil {
 				out.Error(fmt.Sprintf("failed to create worktree: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -36,7 +36,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.62" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.65" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (
@@ -1328,7 +1328,7 @@ func handleAdd(profile string, args []string) {
 
 			// Create worktree atomically (git handles existence checks).
 			// This avoids a TOCTOU race from separate check-then-create steps.
-			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr)
+			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
 			if err != nil {
 				if isWorktreeAlreadyExistsError(err) {
 					fmt.Fprintf(os.Stderr, "Error: worktree already exists at %s\n", worktreePath)

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -672,7 +672,7 @@ func handleSessionFork(profile string, args []string) {
 				os.Exit(1)
 			}
 
-			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr)
+			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
 			if err != nil {
 				out.Error(fmt.Sprintf("worktree creation failed: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)

--- a/internal/git/bare_repo_test.go
+++ b/internal/git/bare_repo_test.go
@@ -254,7 +254,7 @@ echo "bare-setup done"
 
 	newWorktreePath := filepath.Join(projectRoot, "worktree-feat")
 	var stdout, stderr bytes.Buffer
-	setupErr, err := CreateWorktreeWithSetup(projectRoot, newWorktreePath, "feature-bare-e2e", &stdout, &stderr)
+	setupErr, err := CreateWorktreeWithSetup(projectRoot, newWorktreePath, "feature-bare-e2e", &stdout, &stderr, 0)
 	if err != nil {
 		t.Fatalf("CreateWorktreeWithSetup failed: %v (stderr: %s)", err, stderr.String())
 	}

--- a/internal/git/setup.go
+++ b/internal/git/setup.go
@@ -20,14 +20,23 @@ func FindWorktreeSetupScript(repoDir string) string {
 	return ""
 }
 
-// worktreeSetupTimeout is the maximum time a setup script is allowed to run.
-var worktreeSetupTimeout = 60 * time.Second
+// DefaultWorktreeSetupTimeout is the fallback used when callers pass a
+// non-positive timeout. Kept in sync with session.DefaultWorktreeSetupTimeout
+// — duplicated here to avoid a session → git import cycle.
+const DefaultWorktreeSetupTimeout = 60 * time.Second
 
 // RunWorktreeSetupScript executes the setup script with AGENT_DECK_REPO_ROOT
 // and AGENT_DECK_WORKTREE_PATH environment variables set. Working directory
-// is set to worktreePath. Output is streamed to the provided writers.
-func RunWorktreeSetupScript(scriptPath, repoDir, worktreePath string, stdout, stderr io.Writer) error {
-	ctx, cancel := context.WithTimeout(context.Background(), worktreeSetupTimeout)
+// is set to worktreePath. Output is streamed to the provided writers. A
+// non-positive timeout falls back to DefaultWorktreeSetupTimeout so the
+// legacy 60s behaviour holds for any caller that has not adopted the new
+// [worktree].setup_timeout_seconds config knob (GH #724).
+func RunWorktreeSetupScript(scriptPath, repoDir, worktreePath string, stdout, stderr io.Writer, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = DefaultWorktreeSetupTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sh", "-e", scriptPath)
@@ -43,7 +52,7 @@ func RunWorktreeSetupScript(scriptPath, repoDir, worktreePath string, stdout, st
 	err := cmd.Run()
 
 	if ctx.Err() == context.DeadlineExceeded {
-		return fmt.Errorf("worktree setup script timed out after %s", worktreeSetupTimeout)
+		return fmt.Errorf("worktree setup script timed out after %s", timeout)
 	}
 	if err != nil {
 		return fmt.Errorf("worktree setup script failed: %w", err)
@@ -53,8 +62,9 @@ func RunWorktreeSetupScript(scriptPath, repoDir, worktreePath string, stdout, st
 
 // CreateWorktreeWithSetup creates a worktree and runs the setup script if present.
 // Setup script failure is non-fatal: the worktree is still valid.
-// Output is streamed to the provided writers.
-func CreateWorktreeWithSetup(repoDir, worktreePath, branchName string, stdout, stderr io.Writer) (setupErr error, err error) {
+// Output is streamed to the provided writers. A non-positive setupTimeout
+// falls back to DefaultWorktreeSetupTimeout.
+func CreateWorktreeWithSetup(repoDir, worktreePath, branchName string, stdout, stderr io.Writer, setupTimeout time.Duration) (setupErr error, err error) {
 	if err = CreateWorktree(repoDir, worktreePath, branchName); err != nil {
 		return nil, err
 	}
@@ -65,6 +75,6 @@ func CreateWorktreeWithSetup(repoDir, worktreePath, branchName string, stdout, s
 	}
 
 	fmt.Fprintln(stderr, "Running worktree setup script...")
-	setupErr = RunWorktreeSetupScript(scriptPath, repoDir, worktreePath, stdout, stderr)
+	setupErr = RunWorktreeSetupScript(scriptPath, repoDir, worktreePath, stdout, stderr, setupTimeout)
 	return setupErr, nil
 }

--- a/internal/git/setup_test.go
+++ b/internal/git/setup_test.go
@@ -59,7 +59,7 @@ echo "copying done"
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := RunWorktreeSetupScript(scriptPath, repoDir, worktreeDir, &stdout, &stderr)
+	err := RunWorktreeSetupScript(scriptPath, repoDir, worktreeDir, &stdout, &stderr, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v (stderr: %s)", err, stderr.String())
 	}
@@ -92,7 +92,7 @@ exit 1
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr)
+	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr, 0)
 	if err == nil {
 		t.Fatal("expected error from failing script")
 	}
@@ -104,11 +104,6 @@ exit 1
 func TestRunWorktreeSetupScript_Timeout(t *testing.T) {
 	worktreeDir := t.TempDir()
 
-	// Override timeout to 1s for test speed
-	orig := worktreeSetupTimeout
-	worktreeSetupTimeout = 1 * time.Second
-	t.Cleanup(func() { worktreeSetupTimeout = orig })
-
 	script := `#!/bin/sh
 sleep 300
 `
@@ -118,7 +113,7 @@ sleep 300
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr)
+	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr, 1*time.Second)
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -164,7 +159,7 @@ func TestCreateWorktreeWithSetup_NoScript(t *testing.T) {
 	worktreePath := filepath.Join(dir, ".worktrees", "test-branch")
 
 	var stdout, stderr bytes.Buffer
-	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "test-branch", &stdout, &stderr)
+	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "test-branch", &stdout, &stderr, 0)
 	if err != nil {
 		t.Fatalf("worktree creation failed: %v", err)
 	}
@@ -205,7 +200,7 @@ echo "setup done"
 
 	worktreePath := filepath.Join(dir, ".worktrees", "setup-branch")
 	var stdout, stderr bytes.Buffer
-	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "setup-branch", &stdout, &stderr)
+	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "setup-branch", &stdout, &stderr, 0)
 	if err != nil {
 		t.Fatalf("worktree creation failed: %v", err)
 	}
@@ -245,7 +240,7 @@ exit 1
 
 	worktreePath := filepath.Join(dir, ".worktrees", "fail-branch")
 	var stdout, stderr bytes.Buffer
-	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "fail-branch", &stdout, &stderr)
+	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "fail-branch", &stdout, &stderr, 0)
 
 	// Worktree creation should succeed
 	if err != nil {

--- a/internal/git/setup_timeout_arg_test.go
+++ b/internal/git/setup_timeout_arg_test.go
@@ -1,0 +1,44 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// T2: RunWorktreeSetupScript honours a caller-supplied timeout (threaded via
+// the new timeout parameter, not the historical package-level var). A 1s
+// timeout on a `sleep 300` script must fail in well under the legacy 60s
+// default.
+func TestRunWorktreeSetupScript_HonoursCallerTimeout(t *testing.T) {
+	worktreeDir := t.TempDir()
+
+	script := `#!/bin/sh
+sleep 300
+`
+	scriptPath := filepath.Join(t.TempDir(), "setup.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+
+	start := time.Now()
+	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr, 1*time.Second)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected 'timed out' in error, got: %v", err)
+	}
+	// Generous upper bound — catches a regression where the caller-supplied
+	// timeout is ignored and the 60s default is used.
+	if elapsed > 30*time.Second {
+		t.Errorf("RunWorktreeSetupScript took %v with a 1s timeout; caller timeout is not being threaded", elapsed)
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -825,6 +825,27 @@ type WorktreeSettings struct {
 	// Set to "" to disable auto-prefixing (just the session name).
 	// Default: "feature/" when not set.
 	BranchPrefix *string `toml:"branch_prefix"`
+
+	// SetupTimeoutSeconds caps how long .agent-deck/worktree-setup.sh may run.
+	// Raised via config.toml when the default is too tight for real setups
+	// (installing deps, seeding DBs, etc.) — see GH #724.
+	// Default: 60 when unset or non-positive.
+	SetupTimeoutSeconds int `toml:"setup_timeout_seconds"`
+}
+
+// DefaultWorktreeSetupTimeout is the fallback used when no explicit value is
+// configured. Kept small and visible so the git package can share it.
+const DefaultWorktreeSetupTimeout = 60 * time.Second
+
+// SetupTimeout returns the configured worktree-setup-script timeout as a
+// time.Duration, falling back to DefaultWorktreeSetupTimeout when the value
+// is unset or non-positive. Preserves backward compatibility for every
+// install that never sets [worktree].setup_timeout_seconds.
+func (w WorktreeSettings) SetupTimeout() time.Duration {
+	if w.SetupTimeoutSeconds <= 0 {
+		return DefaultWorktreeSetupTimeout
+	}
+	return time.Duration(w.SetupTimeoutSeconds) * time.Second
 }
 
 // Template returns the path template if set, or empty string if nil.

--- a/internal/session/worktree_setup_timeout_test.go
+++ b/internal/session/worktree_setup_timeout_test.go
@@ -1,0 +1,53 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+// T1: [worktree].setup_timeout_seconds parses into WorktreeSettings.SetupTimeoutSeconds.
+// Reporter @Clindbergh in GH #724: 60s hardcoded is too tight for install-deps + DB-setup
+// scripts, so users need a way to raise it via config.toml.
+func TestWorktreeSettings_SetupTimeoutSeconds_ParsesFromTOML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configContent := `
+[worktree]
+setup_timeout_seconds = 120
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var cfg UserConfig
+	if _, err := toml.DecodeFile(configPath, &cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got, want := cfg.Worktree.SetupTimeoutSeconds, 120; got != want {
+		t.Errorf("Worktree.SetupTimeoutSeconds = %d, want %d", got, want)
+	}
+}
+
+// T3: Default (zero-value) WorktreeSettings.SetupTimeout() returns 60s for
+// backward compatibility with every install that never set the new field.
+func TestWorktreeSettings_SetupTimeout_DefaultSixtySeconds(t *testing.T) {
+	var w WorktreeSettings // zero value: SetupTimeoutSeconds == 0
+
+	if got, want := w.SetupTimeout(), 60*time.Second; got != want {
+		t.Errorf("SetupTimeout() = %v, want %v (backward-compat default)", got, want)
+	}
+}
+
+// T3b: A positive SetupTimeoutSeconds is honoured.
+func TestWorktreeSettings_SetupTimeout_HonoursConfiguredValue(t *testing.T) {
+	w := WorktreeSettings{SetupTimeoutSeconds: 300}
+
+	if got, want := w.SetupTimeout(), 300*time.Second; got != want {
+		t.Errorf("SetupTimeout() = %v, want %v", got, want)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7661,7 +7661,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create parent directory: %w", err), tempID: tempID}
 				}
 				var setupBuf bytes.Buffer
-				setupErr, err := git.CreateWorktreeWithSetup(worktreeRepoRoot, worktreePath, worktreeBranch, &setupBuf, &setupBuf)
+				setupErr, err := git.CreateWorktreeWithSetup(worktreeRepoRoot, worktreePath, worktreeBranch, &setupBuf, &setupBuf, session.GetWorktreeSettings().SetupTimeout())
 				if err != nil {
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create worktree: %w", err), tempID: tempID}
 				}
@@ -8188,7 +8188,7 @@ func (h *Home) forkSessionCmdWithOptions(
 					return sessionForkedMsg{err: fmt.Errorf("failed to create directory: %w", err), sourceID: sourceID}
 				}
 				var setupBuf bytes.Buffer
-				setupErr, err := git.CreateWorktreeWithSetup(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch, &setupBuf, &setupBuf)
+				setupErr, err := git.CreateWorktreeWithSetup(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch, &setupBuf, &setupBuf, session.GetWorktreeSettings().SetupTimeout())
 				if err != nil {
 					return sessionForkedMsg{err: fmt.Errorf("worktree creation failed: %w", err), sourceID: sourceID}
 				}


### PR DESCRIPTION
## Summary

Closes #724. Reporter: @Clindbergh.

- New config knob **`[worktree].setup_timeout_seconds`** (int, default `60`) caps how long `.agent-deck/worktree-setup.sh` may run.
- Threaded as an explicit `time.Duration` parameter through `git.RunWorktreeSetupScript` / `git.CreateWorktreeWithSetup` — no package-level mutable state, no `git` → `session` import cycle.
- Non-positive / missing / zero / negative values all fall back to `DefaultWorktreeSetupTimeout` (60s) — **fully backward-compatible** for every install that never sets the knob.

## Why

@Clindbergh hit the hardcoded 60s cap on a worktree setup script that installs dependencies and seeds a local DB — both legitimate work that routinely exceeds a minute. Before this PR the only workaround was a fork.

Example after this PR:

```toml
[worktree]
setup_timeout_seconds = 300   # bump to 5 minutes for heavier setups
```

## Test plan

TDD — four new tests, all written red-first and watched fail for compile-missing-symbol reasons:

- [x] `TestWorktreeSettings_SetupTimeoutSeconds_ParsesFromTOML` — config round-trip
- [x] `TestWorktreeSettings_SetupTimeout_DefaultSixtySeconds` — zero-value backward compat
- [x] `TestWorktreeSettings_SetupTimeout_HonoursConfiguredValue` — positive path honoured
- [x] `TestRunWorktreeSetupScript_HonoursCallerTimeout` — a 1s caller timeout on a `sleep 300` script must fail in well under the legacy 60s default (proves the parameter is actually threaded, not just declared)
- [x] All existing `internal/git/setup_test.go` tests still pass after signature change (timeout=0 → 60s default path)
- [x] `go test ./internal/session/ ./internal/git/ -race -count=1` → all green
- [x] `go vet ./...` clean
- [x] lefthook pre-commit (fmt + vet) + pre-push (release-tests-yaml-lint + css-verify + build + lint + test, 72.6s) both green on this branch

## Scope

- 11 files touched, net ~160 LOC (mostly a long CHANGELOG entry).
- Five caller sites updated: `internal/ui/home.go` (new-session + fork), `cmd/agent-deck/launch_cmd.go`, `cmd/agent-deck/session_cmd.go`, `cmd/agent-deck/main.go`; plus `internal/git/bare_repo_test.go` for the new signature.
- No behaviour change for any install that doesn't explicitly set `setup_timeout_seconds`.

## Credit

Thanks to @Clindbergh for the clear repro and the concrete use case in #724.