### PR TITLE
feat(tmux): add [tmux].mouse config option (closes #730)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -470,6 +470,7 @@ func NewInstance(title, projectPath string) *Instance {
 	tmuxSess.SocketName = socket
 	tmuxSess.InstanceID = id // Pass instance ID for activity hooks
 	tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+	tmuxSess.SetMouse(GetTmuxSettings().GetMouse())
 	tmuxSess.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
 
 	return &Instance{
@@ -500,6 +501,7 @@ func NewInstanceWithTool(title, projectPath, tool string) *Instance {
 	tmuxSess.SocketName = socket
 	tmuxSess.InstanceID = id // Pass instance ID for activity hooks
 	tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+	tmuxSess.SetMouse(GetTmuxSettings().GetMouse())
 	tmuxSess.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
 
 	inst := &Instance{
@@ -3425,6 +3427,7 @@ func (i *Instance) recreateTmuxSession() {
 	i.tmuxSession.SocketName = i.TmuxSocketName
 	i.tmuxSession.InstanceID = i.ID
 	i.tmuxSession.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+	i.tmuxSession.SetMouse(GetTmuxSettings().GetMouse())
 	i.tmuxSession.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
 }
 

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -805,6 +805,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			// Pass instance ID for activity hooks (enables real-time status updates)
 			tmuxSess.InstanceID = instData.ID
 			tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
+			tmuxSess.SetMouse(GetTmuxSettings().GetMouse())
 			tmuxSess.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
 			// Note: EnableMouseMode and ConfigureStatusBar are deferred to EnsureConfigured()
 			// Called automatically when user attaches to session

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1070,6 +1070,15 @@ type TmuxSettings struct {
 	// Default: true (nil = use default true)
 	InjectStatusLine *bool `toml:"inject_status_line"`
 
+	// Mouse controls whether agent-deck enables tmux mouse mode on new
+	// sessions. When false, tmux `mouse on` is never set, so the terminal
+	// emulator keeps raw control of mouse events — required by the VS Code
+	// Linux integrated terminal to let users click-drag to select text
+	// (issue #730). Affects both the inline set-option during session
+	// creation and the separate EnableMouseMode() path used on reconnect.
+	// Default: true (nil = use default true, preserves pre-#730 behavior)
+	Mouse *bool `toml:"mouse"`
+
 	// LaunchInUserScope starts new tmux servers via `systemd-run --user --scope`
 	// so the tmux server lives under the user's systemd manager instead of the
 	// current login session scope. This keeps tmux alive when an SSH session
@@ -1172,6 +1181,16 @@ func (t TmuxSettings) GetInjectStatusLine() bool {
 // Instance creation — sees the same sanitised value.
 func (t TmuxSettings) GetSocketName() string {
 	return strings.TrimSpace(t.SocketName)
+}
+
+// GetMouse returns whether tmux mouse mode should be enabled, defaulting to
+// true. Issue #730: users on VS Code's Linux integrated terminal need mouse
+// OFF so the terminal can handle click-drag selection natively.
+func (t TmuxSettings) GetMouse() bool {
+	if t.Mouse == nil {
+		return true
+	}
+	return *t.Mouse
 }
 
 // GetLaunchInUserScope returns whether new tmux servers should be launched
@@ -2318,6 +2337,12 @@ auto_cleanup = true
 # agent-deck stops mutating the global tmux notification bar / number key bindings
 # Default: true (agent-deck injects its own status bar with session info)
 # inject_status_line = false
+# mouse controls whether agent-deck enables tmux mouse mode.
+# Set this to false if your terminal (e.g. VS Code's Linux integrated terminal)
+# interprets mouse events at the terminal layer and you want click-drag text
+# selection to bypass tmux entirely. Issue #730.
+# Default: true (tmux mouse mode is enabled — scrolling, pane resize, selection in tmux)
+# mouse = false
 # launch_in_user_scope starts new tmux servers with systemd-run --user --scope
 # so they survive when the current login session is torn down (e.g. SSH logout).
 # Default: true on Linux+systemd hosts where 'systemd-run --user --version'

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -1309,6 +1309,83 @@ inject_status_line = true
 	}
 }
 
+func TestGetTmuxSettings_Mouse_Default(t *testing.T) {
+	// Default (no config) should return true — preserves pre-#730 behavior
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	_ = os.MkdirAll(agentDeckDir, 0700)
+
+	configPath := filepath.Join(agentDeckDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(""), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+	ClearUserConfigCache()
+
+	settings := GetTmuxSettings()
+	if !settings.GetMouse() {
+		t.Error("GetMouse should default to true when not set")
+	}
+}
+
+func TestGetTmuxSettings_Mouse_False(t *testing.T) {
+	// Explicit false disables tmux mouse capture so VS Code Linux terminal
+	// can select text natively (issue #730).
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	_ = os.MkdirAll(agentDeckDir, 0700)
+
+	configPath := filepath.Join(agentDeckDir, "config.toml")
+	configContent := `
+[tmux]
+mouse = false
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+	ClearUserConfigCache()
+
+	settings := GetTmuxSettings()
+	if settings.GetMouse() {
+		t.Error("GetMouse should be false when set to false")
+	}
+}
+
+func TestGetTmuxSettings_Mouse_True(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	_ = os.MkdirAll(agentDeckDir, 0700)
+
+	configPath := filepath.Join(agentDeckDir, "config.toml")
+	configContent := `
+[tmux]
+mouse = true
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+	ClearUserConfigCache()
+
+	settings := GetTmuxSettings()
+	if !settings.GetMouse() {
+		t.Error("GetMouse should be true when set to true")
+	}
+}
+
 func TestGetTmuxSettings_LaunchInUserScope_Default(t *testing.T) {
 	tempDir := t.TempDir()
 	originalHome := os.Getenv("HOME")

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -815,6 +815,13 @@ type Session struct {
 	// Default: true (set via SetInjectStatusLine from user config)
 	injectStatusLine bool
 
+	// mouse controls whether tmux `mouse on` is set during session creation
+	// and by EnableMouseMode. When false, tmux never captures mouse events so
+	// the terminal emulator keeps them — fixes VS Code Linux integrated
+	// terminal click-drag selection (issue #730).
+	// Default: true (set via SetMouse from user config)
+	mouse bool
+
 	// clearOnRestart controls whether RespawnPane clears the scrollback buffer.
 	// When false (default), previous session output is preserved.
 	// Set via SetClearOnRestart from user config.
@@ -1199,6 +1206,25 @@ func (s *Session) SetInjectStatusLine(inject bool) {
 	s.injectStatusLine = inject
 }
 
+// SetMouse controls whether tmux mouse mode is enabled for this session.
+// When false, the inline `mouse on` set-option during Start is skipped AND
+// EnableMouseMode becomes a no-op — required for VS Code Linux integrated
+// terminal click-drag selection (issue #730).
+func (s *Session) SetMouse(enabled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mouse = enabled
+}
+
+// GetMouse reports whether tmux mouse mode is currently enabled for this
+// session. Used by tests and by the Start / EnableMouseMode code paths to
+// decide whether to set `mouse on`.
+func (s *Session) GetMouse() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mouse
+}
+
 // SetClearOnRestart controls whether RespawnPane clears the scrollback buffer.
 // When false (default), previous output is preserved on restart.
 func (s *Session) SetClearOnRestart(clear bool) {
@@ -1241,6 +1267,7 @@ func NewSession(name, workDir string) *Session {
 		lastStableStatus: "waiting",
 		toolDetectExpiry: 30 * time.Second, // Re-detect tool every 30 seconds
 		injectStatusLine: true,             // Default: inject status bar
+		mouse:            true,             // Default: mouse on (#730 opt-out)
 		// stateTracker and promptDetector will be created lazily on first status check
 	}
 }
@@ -1262,6 +1289,7 @@ func ReconnectSession(tmuxName, displayName, workDir, command string) *Session {
 		lastStableStatus: "waiting",
 		toolDetectExpiry: 30 * time.Second,
 		injectStatusLine: true,  // Default: inject status bar
+		mouse:            true,  // Default: mouse on (#730 opt-out)
 		configured:       false, // Will be set to true after configuration
 		// stateTracker and promptDetector will be created lazily on first status check
 	}
@@ -1330,6 +1358,7 @@ func ReconnectSessionLazy(tmuxName, displayName, workDir, command string, previo
 		lastStableStatus: "waiting",
 		toolDetectExpiry: 30 * time.Second,
 		injectStatusLine: true,  // Default: inject status bar
+		mouse:            true,  // Default: mouse on (#730 opt-out)
 		configured:       false, // Explicitly mark as not configured
 	}
 
@@ -1795,8 +1824,13 @@ func (s *Session) Start(command string) error {
 	if _, ok := s.OptionOverrides["window-active-style"]; !ok {
 		startArgs = append(startArgs, "set-option", "-t", s.Name, "window-active-style", themeStyle.windowActiveStyle, ";")
 	}
+	// #730: users opt out of mouse capture via [tmux].mouse = false so
+	// terminals like VS Code Linux can do native click-drag selection.
+	if s.mouse {
+		startArgs = append(startArgs,
+			"set-option", "-t", s.Name, "mouse", "on", ";")
+	}
 	startArgs = append(startArgs,
-		"set-option", "-t", s.Name, "mouse", "on", ";",
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
@@ -2025,11 +2059,16 @@ func (s *Session) ConfigureStatusBar() {
 // Note: With mouse mode on, hold Shift while selecting to use native terminal selection
 // instead of tmux's selection (useful for copying to system clipboard in some terminals)
 func (s *Session) EnableMouseMode() error {
-	// CRITICAL: Mouse mode must succeed - keep as separate call for error handling
-	// This is the only essential feature; all others are enhancements
-	mouseCmd := s.tmuxCmd("set-option", "-t", s.Name, "mouse", "on")
-	if err := mouseCmd.Run(); err != nil {
-		return err
+	// #730: when the user opted out via [tmux].mouse = false, skip the mouse
+	// set-option entirely so terminals like VS Code Linux keep click-drag
+	// selection. Enhancements below are unaffected.
+	if s.mouse {
+		// CRITICAL: Mouse mode must succeed - keep as separate call for error handling
+		// This is the only essential feature; all others are enhancements
+		mouseCmd := s.tmuxCmd("set-option", "-t", s.Name, "mouse", "on")
+		if err := mouseCmd.Run(); err != nil {
+			return err
+		}
 	}
 
 	// PERFORMANCE: Batch all non-fatal enhancements into single subprocess call

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -99,6 +99,33 @@ func TestSession_InjectStatusLine_ReconnectSession(t *testing.T) {
 	sess.ConfigureStatusBar() // Should be no-op, no error
 }
 
+func TestSession_Mouse_Default(t *testing.T) {
+	// NewSession should default mouse to true (preserves pre-#730 behavior).
+	sess := NewSession("test-mouse-default", "/tmp")
+	if !sess.GetMouse() {
+		t.Error("NewSession should default mouse to true")
+	}
+}
+
+func TestSession_SetMouse(t *testing.T) {
+	sess := NewSession("test-mouse-setter", "/tmp")
+	sess.SetMouse(false)
+	if sess.GetMouse() {
+		t.Error("SetMouse(false) should disable mouse")
+	}
+	sess.SetMouse(true)
+	if !sess.GetMouse() {
+		t.Error("SetMouse(true) should re-enable mouse")
+	}
+}
+
+func TestSession_Mouse_ReconnectLazy_DefaultTrue(t *testing.T) {
+	sess := ReconnectSessionLazy("test_sess_mouse", "Test", "/tmp", "echo hi", "waiting")
+	if !sess.GetMouse() {
+		t.Error("ReconnectSessionLazy should default mouse to true")
+	}
+}
+
 func TestSessionPrefix(t *testing.T) {
 	if SessionPrefix != "agentdeck_" {
 		t.Errorf("SessionPrefix = %s, want agentdeck_", SessionPrefix)
@@ -2343,6 +2370,80 @@ func TestSession_SendCommand(t *testing.T) {
 	if !strings.Contains(content, "hello") {
 		t.Errorf("Expected 'hello' in output, got: %s", content)
 	}
+}
+
+// =============================================================================
+// Mouse Mode Config Gate Integration Tests (#730)
+// =============================================================================
+
+// TestSession_MouseMode_DefaultIsOn_Integration verifies pre-#730 behavior:
+// when no config is set, a new session has tmux `mouse` option = "on".
+func TestSession_MouseMode_DefaultIsOn_Integration(t *testing.T) {
+	if os.Getenv("AGENTDECK_TEST_PROFILE") == "" {
+		t.Skip("Skipping tmux integration test - no test profile")
+	}
+
+	s := NewSession("test-mouse-default-on", t.TempDir())
+	s.InstanceID = "test-instance-mouse-on"
+
+	err := s.Start("sleep 3600")
+	require.NoError(t, err)
+	defer func() { _ = s.Kill() }()
+
+	out, err := exec.Command("tmux", "show-options", "-t", s.Name, "-v", "mouse").Output()
+	require.NoError(t, err)
+	assert.Equal(t, "on", strings.TrimSpace(string(out)),
+		"default mouse mode should be 'on' (preserves pre-#730 behavior)")
+}
+
+// TestSession_MouseMode_Disabled_Integration verifies that when SetMouse(false)
+// is called before Start, the inline mouse-on set-option at tmux.go:~1762 is
+// skipped, and the resulting tmux session leaves `mouse` at the tmux default
+// ("off"). Regression guard for issue #730 — VS Code Linux integrated terminal
+// relies on tmux NOT capturing mouse events so the terminal can select text.
+func TestSession_MouseMode_Disabled_Integration(t *testing.T) {
+	if os.Getenv("AGENTDECK_TEST_PROFILE") == "" {
+		t.Skip("Skipping tmux integration test - no test profile")
+	}
+
+	s := NewSession("test-mouse-disabled", t.TempDir())
+	s.InstanceID = "test-instance-mouse-off"
+	s.SetMouse(false)
+
+	err := s.Start("sleep 3600")
+	require.NoError(t, err)
+	defer func() { _ = s.Kill() }()
+
+	out, err := exec.Command("tmux", "show-options", "-t", s.Name, "-v", "mouse").Output()
+	require.NoError(t, err)
+	assert.Equal(t, "off", strings.TrimSpace(string(out)),
+		"mouse option must stay 'off' when SetMouse(false) was called before Start (issue #730)")
+}
+
+// TestSession_MouseMode_EnableMouseMode_Disabled_Integration verifies that
+// EnableMouseMode (called from EnsureConfigured on reconnect) is ALSO gated.
+// This is the second call site that #730 fix must close.
+func TestSession_MouseMode_EnableMouseMode_Disabled_Integration(t *testing.T) {
+	if os.Getenv("AGENTDECK_TEST_PROFILE") == "" {
+		t.Skip("Skipping tmux integration test - no test profile")
+	}
+
+	s := NewSession("test-mouse-enable-off", t.TempDir())
+	s.InstanceID = "test-instance-mouse-enable-off"
+	s.SetMouse(false)
+
+	err := s.Start("sleep 3600")
+	require.NoError(t, err)
+	defer func() { _ = s.Kill() }()
+
+	// Simulate the EnsureConfigured path by calling EnableMouseMode directly.
+	// Should be a no-op when mouse is disabled.
+	_ = s.EnableMouseMode()
+
+	out, err := exec.Command("tmux", "show-options", "-t", s.Name, "-v", "mouse").Output()
+	require.NoError(t, err)
+	assert.Equal(t, "off", strings.TrimSpace(string(out)),
+		"EnableMouseMode must respect SetMouse(false) and not re-enable mouse")
 }
 
 // =============================================================================

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2390,10 +2390,10 @@ func TestSession_MouseMode_DefaultIsOn_Integration(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = s.Kill() }()
 
-	out, err := exec.Command("tmux", "show-options", "-t", s.Name, "-v", "mouse").Output()
+	out, err := exec.Command("tmux", "show-options", "-t", s.Name, "-A", "-v", "mouse").Output()
 	require.NoError(t, err)
 	assert.Equal(t, "on", strings.TrimSpace(string(out)),
-		"default mouse mode should be 'on' (preserves pre-#730 behavior)")
+		"default mouse mode should resolve to 'on' (preserves pre-#730 behavior)")
 }
 
 // TestSession_MouseMode_Disabled_Integration verifies that when SetMouse(false)
@@ -2414,10 +2414,13 @@ func TestSession_MouseMode_Disabled_Integration(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = s.Kill() }()
 
-	out, err := exec.Command("tmux", "show-options", "-t", s.Name, "-v", "mouse").Output()
+	// -A resolves inheritance and returns the effective value. Without -A,
+	// an unset-at-session option returns empty string even if the default
+	// (or a global override) would resolve to "off".
+	out, err := exec.Command("tmux", "show-options", "-t", s.Name, "-A", "-v", "mouse").Output()
 	require.NoError(t, err)
 	assert.Equal(t, "off", strings.TrimSpace(string(out)),
-		"mouse option must stay 'off' when SetMouse(false) was called before Start (issue #730)")
+		"mouse option must resolve to 'off' when SetMouse(false) was called before Start (issue #730)")
 }
 
 // TestSession_MouseMode_EnableMouseMode_Disabled_Integration verifies that
@@ -2440,7 +2443,7 @@ func TestSession_MouseMode_EnableMouseMode_Disabled_Integration(t *testing.T) {
 	// Should be a no-op when mouse is disabled.
 	_ = s.EnableMouseMode()
 
-	out, err := exec.Command("tmux", "show-options", "-t", s.Name, "-v", "mouse").Output()
+	out, err := exec.Command("tmux", "show-options", "-t", s.Name, "-A", "-v", "mouse").Output()
 	require.NoError(t, err)
 	assert.Equal(t, "off", strings.TrimSpace(string(out)),
 		"EnableMouseMode must respect SetMouse(false) and not re-enable mouse")


### PR DESCRIPTION
## Summary
- Adds `[tmux].mouse` (bool, default `true`) so users can opt out of tmux mouse capture.
- When `mouse = false`, agent-deck never runs `set-option mouse on` — both the inline call during session create and the separate `EnableMouseMode()` path used on reconnect/attach are gated on the new flag.
- Fixes VS Code Linux integrated terminal click-drag text selection (reported by @sghiassy on #730). Other tmux enhancements (`allow-passthrough`, `set-clipboard`, `escape-time`, `extended-keys`, `terminal-features`) are unchanged.

Implementation mirrors the existing `inject_status_line` `*bool` pattern end-to-end — same nil-defaults-to-true semantic, same threading at all four `SetInjectStatusLine` call sites (`NewInstance`, `NewInstanceWithTool`, `recreateTmuxSession`, `storage.Load`), same config doc style.

Config example:
```toml
[tmux]
mouse = false
```

## Test plan
TDD: RED commit lands compile-failing tests first, GREEN commit wires the fix.

- [x] `go test ./internal/session/ -run GetTmuxSettings_Mouse -race` (3 unit tests: default, explicit-false, explicit-true)
- [x] `go test ./internal/tmux/ -run TestSession_Mouse -race` (3 unit tests: default, setter/getter, ReconnectSessionLazy default)
- [x] `AGENTDECK_TEST_PROFILE=_test go test ./internal/tmux/ -run TestSession_MouseMode -race` (3 integration tests against real tmux):
  - `TestSession_MouseMode_DefaultIsOn_Integration` — pre-#730 behavior preserved (`show-options -A -v mouse` → `on`)
  - `TestSession_MouseMode_Disabled_Integration` — gates the inline start-args set-option (→ `off`)
  - `TestSession_MouseMode_EnableMouseMode_Disabled_Integration` — gates the reconnect-path `EnableMouseMode` (→ `off`)
- [x] `go test -run TestPersistence_ ./internal/session/... -race -count=1` (mandatory per CLAUDE.md)
- [x] `go test ./...` full sweep — all packages green except `TestSession_SetsUpActivityMonitoring`, which was verified to fail on pristine `main` too (same `tmux show-options -v` returns empty for unset-at-session semantic as the issue my integration tests hit; unrelated pre-existing flake).

Closes #730.