### PR TITLE
fix(termreply): whitelist DA/DSR through, swallow only outer-TUI replies (closes #731, #738)

### DIFF
--- a/internal/termreply/filter.go
+++ b/internal/termreply/filter.go
@@ -106,12 +106,19 @@ func (f *Filter) resetSequenceState() {
 	f.escapeSeenInDiscard = false
 }
 
-// Consume filters a chunk of bytes. When armed is true, terminal-generated
-// control replies are discarded. If a reply started in a previous chunk, it
-// continues to be discarded until it terminates even if armed is now false.
+// Consume filters a chunk of bytes. Escape-string replies (OSC/DCS/APC/PM/SOS)
+// are discarded unconditionally — they have no keyboard overlap, so a human
+// cannot produce them, and leaking them to the inner PTY has real-world
+// failure modes (see #731: iTerm2 XTVERSION DCS leaking as `TERM2 3.6.10n`
+// input into the wrapped agent). When armed is true, generic CSI replies are
+// ALSO discarded except for a small whitelist of keyboard-related CSI finals
+// (arrows/home/end/backtab/~ keys/kitty CSI u); when armed is false, CSI is
+// preserved so keyboard input is not corrupted outside the quarantine window.
+// If a reply started in a previous chunk, it continues to be discarded until
+// it terminates even if armed is now false.
 //
 // Terminal replies covered here:
-//   - escape-string families: OSC, DCS, APC, PM, SOS
+//   - escape-string families: OSC, DCS, APC, PM, SOS (always discarded)
 //   - CSI replies during the quarantine window, except for a small whitelist of
 //     user-input CSI finals (arrows/home/end/backtab/~ keys/kitty CSI u,
 //     mouse M/m)
@@ -174,7 +181,10 @@ func (f *Filter) Consume(src []byte, armed bool, final bool) []byte {
 		if f.pendingEsc {
 			f.pendingEsc = false
 			switch {
-			case armed && isEscapeStringIntroducer(b):
+			case isEscapeStringIntroducer(b):
+				// Escape-string replies (DCS/OSC/APC/PM/SOS) are never
+				// legitimate keyboard input — strip regardless of armed
+				// state to prevent terminal-response leaks like #731.
 				f.mode = filterModeDiscardEscapeString
 				continue
 			case b == controlSequenceIntroducerByte:

--- a/internal/termreply/filter.go
+++ b/internal/termreply/filter.go
@@ -26,6 +26,15 @@ const (
 	csiFinalKittyKeyByte      = 'u'
 	csiFinalMouseLegacyByte   = 'M' // X10/legacy mouse report + SGR mouse press
 	csiFinalMouseSGRFinalByte = 'm' // SGR mouse release
+
+	// CSI reply finals that tmux needs to see to negotiate terminal
+	// capabilities (modifyOtherKeys, extended-keys). Dropping these is what
+	// caused #738 (Shift+Enter collapsing to bare CR in iTerm2 default
+	// profile): without DA1/DA2 replies, tmux cannot engage the CSI u /
+	// modifyOtherKeys protocol with the host terminal.
+	csiFinalDeviceAttributesByte = 'c' // DA1 / DA2 reply
+	csiFinalDeviceStatusByte     = 'n' // DSR reply
+	csiFinalCursorPositionByte   = 'R' // DSR cursor position reply
 )
 
 type filterMode uint8
@@ -91,6 +100,25 @@ func isKeyboardCSIFinalByte(b byte) bool {
 	}
 }
 
+// isTmuxCapabilityReplyCSIFinalByte returns true for CSI final bytes that
+// carry DA/DSR replies tmux needs to negotiate terminal capabilities with the
+// host terminal. Per @Clean-Cole's root-cause analysis in #738, swallowing
+// these breaks modifyOtherKeys negotiation and collapses Shift+Enter to bare
+// CR in iTerm2 default profile. They must pass through to the wrapped tmux
+// client regardless of the armed flag. Unlike DCS/OSC/APC/PM/SOS (which are
+// purely outer-TUI capability responses and are unconditionally stripped),
+// these CSI replies are consumed by tmux itself.
+func isTmuxCapabilityReplyCSIFinalByte(b byte) bool {
+	switch b {
+	case csiFinalDeviceAttributesByte,
+		csiFinalDeviceStatusByte,
+		csiFinalCursorPositionByte:
+		return true
+	default:
+		return false
+	}
+}
+
 func flushSequence(out []byte, seq []byte) []byte {
 	return append(out, seq...)
 }
@@ -110,18 +138,21 @@ func (f *Filter) resetSequenceState() {
 // are discarded unconditionally — they have no keyboard overlap, so a human
 // cannot produce them, and leaking them to the inner PTY has real-world
 // failure modes (see #731: iTerm2 XTVERSION DCS leaking as `TERM2 3.6.10n`
-// input into the wrapped agent). When armed is true, generic CSI replies are
-// ALSO discarded except for a small whitelist of keyboard-related CSI finals
-// (arrows/home/end/backtab/~ keys/kitty CSI u); when armed is false, CSI is
-// preserved so keyboard input is not corrupted outside the quarantine window.
+// input into the wrapped agent).
+//
+// CSI sequences are handled by final-byte whitelist:
+//
+//   - Keyboard/mouse CSIs (arrows, Home/End, backtab, ~ keys, kitty CSI u,
+//     mouse M/m) always pass through so user input is never corrupted.
+//   - DA/DSR replies (final bytes c/n/R) always pass through so tmux can
+//     negotiate modifyOtherKeys with the host terminal (see #738: @Clean-Cole
+//     identified that swallowing DA1 collapsed Shift+Enter to bare CR in
+//     iTerm2 default profile).
+//   - Anything else is gated by armed: discarded during the quarantine
+//     window, preserved outside it.
+//
 // If a reply started in a previous chunk, it continues to be discarded until
 // it terminates even if armed is now false.
-//
-// Terminal replies covered here:
-//   - escape-string families: OSC, DCS, APC, PM, SOS (always discarded)
-//   - CSI replies during the quarantine window, except for a small whitelist of
-//     user-input CSI finals (arrows/home/end/backtab/~ keys/kitty CSI u,
-//     mouse M/m)
 //
 // If final is true, any incomplete pending escape/CSI/SS3 sequence is flushed as
 // literal input, while an incomplete discarded escape-string reply is dropped.
@@ -158,7 +189,12 @@ func (f *Filter) Consume(src []byte, armed bool, final bool) []byte {
 				continue
 			}
 
-			if armed && !isKeyboardCSIFinalByte(b) {
+			// DA/DSR replies (final bytes c/n/R) must always pass through so
+			// tmux can negotiate modifyOtherKeys with the host terminal (see
+			// #738 regression from @Clean-Cole). Keyboard CSIs pass through
+			// unconditionally too. Only non-whitelisted CSIs are gated by
+			// armed.
+			if armed && !isKeyboardCSIFinalByte(b) && !isTmuxCapabilityReplyCSIFinalByte(b) {
 				f.resetSequenceState()
 				continue
 			}

--- a/internal/termreply/filter_test.go
+++ b/internal/termreply/filter_test.go
@@ -18,11 +18,16 @@ func TestFilterDiscardsStringRepliesAcrossChunks(t *testing.T) {
 	require.False(t, f.Active())
 }
 
-func TestFilterDiscardsGenericCSIReplies(t *testing.T) {
+// TestFilterPassesDAReplyThrough: renamed from TestFilterDiscardsGenericCSIReplies.
+// The old behavior swallowed DA replies (final byte `c`), which broke tmux's
+// modifyOtherKeys negotiation in iTerm2 (#738). The new contract is: DA/DSR
+// replies always pass through to tmux; only outer-TUI-specific replies
+// (DCS/OSC/APC/PM/SOS) are unconditionally stripped.
+func TestFilterPassesDAReplyThrough(t *testing.T) {
 	var f Filter
 
-	got := f.Consume([]byte("\x1b[?1;2c"), true, false)
-	require.Empty(t, got)
+	input := []byte("\x1b[?1;2c")
+	require.Equal(t, input, f.Consume(input, true, false))
 	require.False(t, f.Active())
 }
 
@@ -92,5 +97,51 @@ func TestFilterDiscardsSplitDCSReplyWhenNotArmed(t *testing.T) {
 
 	got = f.Consume([]byte("3.6.10n\x1b\\rest"), false, false)
 	require.Equal(t, []byte("rest"), got)
+	require.False(t, f.Active())
+}
+
+// Regression for #738: Coleman (@Clean-Cole) reported that Shift+Enter collapsed
+// to bare CR inside attached Claude/Copilot sessions because the filter was
+// swallowing iTerm2's DA1 reply (`\x1b[?62;4c`). Without DA1 reaching tmux,
+// tmux cannot negotiate modifyOtherKeys with the host terminal. CSI replies
+// ending in `c` (DA/DA2), `n` (DSR), and `R` (cursor position) must pass
+// through to tmux even during the attach quarantine window.
+func TestFilterPassesDAReplyThroughEvenDuringQuarantine(t *testing.T) {
+	var f Filter
+
+	input := []byte("\x1b[?62;4c")
+	require.Equal(t, input, f.Consume(input, true, false))
+	require.False(t, f.Active())
+}
+
+func TestFilterPassesDA2ReplyThroughEvenDuringQuarantine(t *testing.T) {
+	var f Filter
+
+	input := []byte("\x1b[>0;95;0c")
+	require.Equal(t, input, f.Consume(input, true, false))
+	require.False(t, f.Active())
+}
+
+func TestFilterPassesDSRCursorReplyThroughEvenDuringQuarantine(t *testing.T) {
+	var f Filter
+
+	input := []byte("\x1b[12;34R")
+	require.Equal(t, input, f.Consume(input, true, false))
+	require.False(t, f.Active())
+}
+
+// Locks in that generic non-whitelisted CSI finals (e.g. arrow-like bytes
+// arriving as terminal replies, or other telemetry) continue to be discarded
+// while armed. The DA/DSR whitelist is a narrow carve-out, not a blanket
+// passthrough. Note: arrow finals (A/B/C/D) are already whitelisted as
+// keyboard input — this test uses a non-keyboard, non-reply CSI final to
+// exercise the discard path.
+func TestFilterDiscardsNonWhitelistedCSIWhenArmed(t *testing.T) {
+	var f Filter
+
+	// CSI ... J (ED, erase in display) is not a reply we want to pass and not
+	// keyboard input. It should still be discarded during quarantine.
+	got := f.Consume([]byte("\x1b[2J"), true, false)
+	require.Empty(t, got)
 	require.False(t, f.Active())
 }

--- a/internal/termreply/filter_test.go
+++ b/internal/termreply/filter_test.go
@@ -62,3 +62,35 @@ func TestFilterPreservesMouseCSIInput(t *testing.T) {
 		require.Equal(t, input, f.Consume(input, true, false))
 	})
 }
+
+// Regression for #731: iTerm2 XTVERSION DCS replies can arrive on stdin long
+// after the 2-second attach quarantine elapses (e.g. on window focus/resize).
+// Escape-string replies (DCS/OSC/APC/PM/SOS) have no keyboard overlap and must
+// be stripped regardless of the armed flag.
+func TestFilterDiscardsXTVERSIONReplyWhenNotArmed(t *testing.T) {
+	var f Filter
+
+	got := f.Consume([]byte("\x1bP>|iTerm2 3.6.10n\x1b\\j"), false, false)
+	require.Equal(t, []byte("j"), got)
+	require.False(t, f.Active())
+}
+
+func TestFilterDiscardsOSCReplyWhenNotArmed(t *testing.T) {
+	var f Filter
+
+	got := f.Consume([]byte("\x1b]11;rgb:d3d3/f5f5/f5f5\x07k"), false, false)
+	require.Equal(t, []byte("k"), got)
+	require.False(t, f.Active())
+}
+
+func TestFilterDiscardsSplitDCSReplyWhenNotArmed(t *testing.T) {
+	var f Filter
+
+	got := f.Consume([]byte("\x1bP>|iTerm2 "), false, false)
+	require.Empty(t, got)
+	require.True(t, f.Active())
+
+	got = f.Consume([]byte("3.6.10n\x1b\\rest"), false, false)
+	require.Equal(t, []byte("rest"), got)
+	require.False(t, f.Active())
+}

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -255,11 +255,15 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 			}
 
 			chunk := buf[:n]
-			if time.Since(startTime) < attachReplyQuarantine || replyFilter.Active() {
-				chunk = replyFilter.Consume(chunk, time.Since(startTime) < attachReplyQuarantine, false)
-				if len(chunk) == 0 {
-					continue
-				}
+			// Always run the reply filter: escape-string replies (DCS/OSC/etc.)
+			// can arrive long after the initial quarantine (e.g. iTerm2
+			// XTVERSION reply on window focus/resize — #731). `armed` stays
+			// gated to the quarantine window so generic CSI pass-through
+			// works for keyboard input outside it.
+			armed := time.Since(startTime) < attachReplyQuarantine
+			chunk = replyFilter.Consume(chunk, armed, false)
+			if len(chunk) == 0 {
+				continue
 			}
 
 			// Check for the detach key anywhere in the input chunk.

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -328,12 +328,15 @@ func (c *csiuReader) Read(p []byte) (int, error) {
 		n, err := c.src.Read(tmp)
 		if n > 0 {
 			chunk := tmp[:n]
-			if termreply.Active() || c.replyFilter.Active() {
-				chunk = c.replyFilter.Consume(chunk, termreply.Active(), false)
-			}
+			// Always run the reply filter. Escape-string families (DCS/OSC/
+			// APC/PM/SOS) are never keyboard input and can arrive outside
+			// any explicit quarantine window (e.g. iTerm2 XTVERSION reply on
+			// focus/resize — #731). `armed` stays tied to termreply.Active()
+			// so generic CSI pass-through works for keyboard input.
+			chunk = c.replyFilter.Consume(chunk, termreply.Active(), false)
 			c.inBuf = append(c.inBuf, chunk...)
 		}
-		if err == io.EOF && (termreply.Active() || c.replyFilter.Active()) {
+		if err == io.EOF {
 			c.inBuf = append(c.inBuf, c.replyFilter.Consume(nil, termreply.Active(), true)...)
 		}
 


### PR DESCRIPTION
## Summary

Fixes two related stdin-filter bugs in `internal/termreply.Filter`:

- **#731** (reporter: @marekaf): iTerm2's XTVERSION DCS reply (`\x1bP>|iTerm2 3.6.10n\x1b\\`) leaked as `TERM2 3.6.10n` into the wrapped agent when focus/resize events triggered capability replies *after* the 2-second attach quarantine elapsed.
- **#738** (reporter: @Clean-Cole): inside attached Claude/Copilot sessions on iTerm2 default profile, Shift+Enter collapsed to bare CR and submitted the prompt instead of inserting a newline. Coleman's hex-dump instrumentation on `internal/tmux/pty.go` proved that iTerm2's DA1 reply (`\x1b[?62;4c`) was being swallowed by the filter *before* tmux could see it — without DA1, tmux cannot negotiate `modifyOtherKeys` with the host terminal, so Shift+Enter stays bare `\r`.

The two bugs are in tension: the filter was doing two jobs (swallow outer-TUI replies to prevent inner-pane garbage + swallow tmux-bound replies) and couldn't distinguish them.

## Fix

CSI final-byte whitelist, aligned with Coleman's suggested direction:

- **DCS / OSC / APC / PM / SOS** — always stripped. These are outer-TUI capability responses (XTVERSION, OSC 10/11 color queries, etc.) that tmux never consumes. Unconditional strip fixes #731.
- **CSI final bytes `c`, `n`, `R`** — always pass through. DA1/DA2 (`c`), DSR (`n`), cursor-position (`R`) are the replies tmux needs to engage `modifyOtherKeys` / `extended-keys`. Unconditional passthrough fixes #738.
- **Keyboard/mouse CSI finals** (`A B C D F H Z ~ u M m`) — always pass through (existing behavior; preserves arrows, Home/End, kitty CSI u, mouse events).
- **Everything else** — gated by `armed` (quarantine window). Discarded during attach/detach transitions, preserved otherwise.

## Why not touch `allow-passthrough` or tmux config?

`allow-passthrough on` is inner→outer DCS (OSC 52 clipboard). The leak is outer→inner reply data; the correct boundary to fix is the stdin-to-PTY filter we already own.

## Test plan

- [x] `go test ./internal/termreply/... -race -count=1` — 11 tests including 3 new DA/DSR passthrough regressions and a non-whitelisted-CSI discard lock-in. RED without fix, GREEN with it.
- [x] `go test ./... -race -count=1 -timeout 300s` — full sweep clean, no new failures.
- [x] `go build ./...` clean via lefthook pre-push.
- [ ] Manual verification (for reviewer): iTerm2 default profile attach to a claude session, confirm (a) no `TERM2 3.6.10n` leak on focus/resize (#731) and (b) Shift+Enter inserts newline (#738).

No version bump on this PR — will be rolled into the v1.7.68 release PR along with any other changes.

Closes #731.
Closes #738.