### PR TITLE
feat(watchdog): lift to scripts/watchdog/ + poller patrol + waiting-too-long nudge (#53, #56)

### DIFF
--- a/.claude/release-tests.yaml
+++ b/.claude/release-tests.yaml
@@ -1818,3 +1818,157 @@ tests:
   run:
     command: go test -tags eval_smoke ./tests/eval/session/ -run TestEval_VersionFlag_ShowsUpdateAnnotationFromCache -count=1 -race -v
     expected: pass
+- id: v1763-watchdog-poller-running-no-restart
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_poller_running_no_restart
+  purpose: 'v1.7.63 capability A — when a conductor''s bun-telegram poller is alive (TELEGRAM_STATE_DIR present in running process environ), watchdog must NOT issue a session restart. Catches a false-positive regression in check_poller_existence that would thrash healthy sessions.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestPollerExistence.test_poller_running_no_restart -v
+    expected: pass
+- id: v1763-watchdog-poller-missing-triggers-restart
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_poller_missing_triggers_restart
+  purpose: 'v1.7.63 capability A — when a conductor declares the telegram channel but no matching bun-telegram process is running, watchdog MUST fire agent-deck session restart. Pins the core positive case.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestPollerExistence.test_poller_missing_triggers_restart -v
+    expected: pass
+- id: v1763-watchdog-poller-dedup-1h
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_dedup_within_one_hour
+  purpose: 'v1.7.63 capability A — POLLER_RESTART_DEDUP_S (3600s) ceiling: two ticks 30 min apart with the poller still missing must produce only one restart, not two. Guards against restart-thrash on a persistently broken poller.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestPollerExistence.test_dedup_within_one_hour -v
+    expected: pass
+- id: v1763-watchdog-poller-dedup-expires
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_dedup_window_expires_after_one_hour
+  purpose: 'v1.7.63 capability A — after POLLER_RESTART_DEDUP_S elapses, a still-missing poller is eligible for another restart. Guards the complementary case of dedup-1h (prevents dedup from becoming permanent block).'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestPollerExistence.test_dedup_window_expires_after_one_hour -v
+    expected: pass
+- id: v1763-watchdog-poller-no-telegram-channel-ignored
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_session_without_telegram_channel_ignored
+  purpose: 'v1.7.63 capability A — sessions without plugin:telegram@claude-plugins-official in channels are NOT subject to poller check. Prevents unnecessary restarts on non-telegram sessions.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestPollerExistence.test_session_without_telegram_channel_ignored -v
+    expected: pass
+- id: v1763-watchdog-poller-multi-conductor-partial-miss
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_multi_conductor_only_missing_ones_restart
+  purpose: 'v1.7.63 capability A — with three conductors configured for telegram and only one poller running, watchdog restarts the other two (and only those two). Pins per-session correctness under mixed state.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestPollerExistence.test_multi_conductor_only_missing_ones_restart -v
+    expected: pass
+- id: v1763-watchdog-bun-state-dirs-proc-environ
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_extracts_from_proc_environ
+  purpose: 'v1.7.63 — bun_telegram_state_dirs() correctly parses /proc/<pid>/environ NUL-separated entries and extracts TELEGRAM_STATE_DIR. Pins the low-level /proc reading contract that capability A depends on.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestBunTelegramStateDirs.test_extracts_from_proc_environ -v
+    expected: pass
+- id: v1763-watchdog-waiting-first-observation-no-nudge
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_first_observation_does_not_nudge
+  purpose: 'v1.7.63 capability B — first time we see a child session in waiting state, tracker is seeded but no nudge is sent. Prevents premature firing on transient waiting states.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestWaitingTooLong.test_first_observation_does_not_nudge -v
+    expected: pass
+- id: v1763-watchdog-waiting-over-10min-nudges
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_waiting_over_10min_unchanged_nudges
+  purpose: 'v1.7.63 capability B — child session waiting > WAITING_PATROL_THRESHOLD_S (600s) with unchanged pane hash triggers a "report status?" nudge. Pins the core positive case.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestWaitingTooLong.test_waiting_over_10min_unchanged_nudges -v
+    expected: pass
+- id: v1763-watchdog-waiting-pane-change-resets
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_pane_changed_resets_timer
+  purpose: 'v1.7.63 capability B — ANY pane-output change resets the waiting timer. Without this a session doing real work but staying in waiting state would get false nudges.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestWaitingTooLong.test_pane_changed_resets_timer -v
+    expected: pass
+- id: v1763-watchdog-waiting-dedup-1h
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_dedup_1h_per_session
+  purpose: 'v1.7.63 capability B — WAITING_PATROL_NUDGE_DEDUP_S (3600s) throttles repeat nudges on the same session. Guards against nudge-thrash on a truly stuck child.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestWaitingTooLong.test_dedup_1h_per_session -v
+    expected: pass
+- id: v1763-watchdog-waiting-non-child-ignored
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_no_nudge_for_non_child
+  purpose: 'v1.7.63 capability B — standalone sessions (parent_session_id empty) are NEVER nudged. Patrol is strictly for child / sub-agent sessions.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestWaitingTooLong.test_no_nudge_for_non_child -v
+    expected: pass
+- id: v1763-watchdog-waiting-tracker-cleared
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_tracker_cleared_when_session_leaves_waiting
+  purpose: 'v1.7.63 capability B — when a session transitions out of waiting, its waiting_tracker entry is evicted. Prevents stale tracker data from firing nudges after the session has moved on.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestWaitingTooLong.test_tracker_cleared_when_session_leaves_waiting -v
+    expected: pass
+- id: v1763-watchdog-waiting-live-send
+  added: '2026-04-22'
+  task: fix-53-56-watchdog-poller-patrol
+  file: scripts/watchdog/test_watchdog.py
+  test_name: test_live_mode_invokes_session_send
+  purpose: 'v1.7.63 capability B — in non-dry-run mode, an over-threshold unchanged-pane child triggers an actual agent-deck session send --no-wait call carrying the exact WAITING_PATROL_NUDGE_TEXT. Pins the real-side-effect contract.'
+  source: conductor-internal-53-56
+  manual: false
+  run:
+    command: cd scripts/watchdog && python3 -m unittest test_watchdog.TestWaitingTooLong.test_live_mode_invokes_session_send -v
+    expected: pass

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,10 @@ agent-deck-test
 # Tailwind brute-force diff gate scratch file (make css temp artifact)
 internal/web/static/.brute-tw.src.css
 /dist
+
+# Python bytecode (scripts/watchdog/ + conductor/tests/)
+__pycache__/
+*.pyc
+
+# Claude harness lock (per-session, never committed)
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [worktree]
   setup_timeout_seconds = 300   # bump to 5 minutes for heavier setups
   ```
-
 ## [1.7.62] - 2026-04-22
 
 ### Added

--- a/internal/releasetests/manifest_test.go
+++ b/internal/releasetests/manifest_test.go
@@ -92,12 +92,18 @@ func TestManifestIsValidYAML(t *testing.T) {
 	}
 }
 
-// funcDeclRE matches `func <name>(` at a line start (ignoring leading
-// whitespace). Accepts receivers so a test with a receiver (rare in Go
-// but possible) isn't falsely missed.
+// funcDeclRE matches a test-function declaration at a line start (ignoring
+// leading whitespace). Supports both Go (`func <name>(`) with an optional
+// receiver, and Python (`def <name>(`) — the latter indented inside a
+// TestCase class. The Python branch is needed because v1.7.63 added the
+// first repo-gated Python tests under scripts/watchdog/ and those entries
+// would otherwise fail the drift check with spurious "missing func" errors.
 func funcDeclForName(name string) *regexp.Regexp {
 	quoted := regexp.QuoteMeta(name)
-	return regexp.MustCompile(`(?m)^func(?:\s+\([^)]*\))?\s+` + quoted + `\s*\(`)
+	return regexp.MustCompile(
+		`(?m)^func(?:\s+\([^)]*\))?\s+` + quoted + `\s*\(` +
+			`|(?m)^\s*def\s+` + quoted + `\s*\(`,
+	)
 }
 
 // TestManifestReferencesExistInSource asserts that for every non-manual

--- a/scripts/watchdog/DESIGN.md
+++ b/scripts/watchdog/DESIGN.md
@@ -1,0 +1,153 @@
+# Auto-Restart Watchdog for Critical Agent-Deck Sessions
+
+Date: 2026-04-19 (initial design) · 2026-04-22 (lift-and-shift into repo for v1.7.63)
+Target: agent-deck v1.7.63
+
+## Problem
+
+Conductor sessions (`conductor-innotrade`, `conductor-travel`, `conductor-opengraphdb`, etc.) are the brain of the orchestration system. A single SSH logout or tmux hiccup can flip them to `error`, and they stay there until a human manually runs `agent-deck session restart`. Today there is no automatic recovery for this class of session.
+
+The existing reviver (`internal/session/reviver.go`) only revives `ClassErrored` (tmux alive, control pipe dead). Sessions where tmux itself died are `ClassDead` and are deliberately NOT auto-revived by design (disambiguation between intentional kill and crash).
+
+The missing piece: **something external** that, for a small allow-list of critical sessions, WILL restart them when they flip to error — with rate limits, cascade guards, and escalation.
+
+## Non-goals
+
+- Auto-restart arbitrary worker sessions (keep opt-in explicit)
+- Replace the existing transition-notifier daemon (reuse it as a signal source)
+
+## Status note (v1.7.63, 2026-04-22)
+
+The original non-goal "Modify agent-deck Go source (external-only; zero new mandate territory)" is **retired as of v1.7.63**. The watchdog is now a first-class distribution asset shipped under `scripts/watchdog/` in this repo so that all users benefit from bug fixes and feature additions through normal releases — not just the host where this file originated. Tests in `scripts/watchdog/test_watchdog.py` are under the repo's TDD gate.
+
+## Architecture
+
+One Python daemon, shipped from `scripts/watchdog/watchdog.py` in this repo, running under a user-level systemd unit (typical install: copy to `~/.agent-deck/watchdog/watchdog.py` and point a `systemd --user` unit at it).
+
+```
+     ┌──────────────────────────────┐
+     │ agent-deck notify-daemon     │ (existing service, ~Restart=always)
+     │   writes hook files          │
+     │   ~/.agent-deck/hooks/*.json │
+     └──────────────┬───────────────┘
+                    │ inotify CLOSE_WRITE / MOVED_TO
+                    ▼
+     ┌──────────────────────────────┐
+     │ watchdog.py                  │
+     │  - inotify listener (fast)   │◄──────┐
+     │  - 5s safety poll (slow)     │       │
+     │  - per-session rate limiter  │       │ 5s tick
+     │  - global cascade guard      │       │
+     └──────────────┬───────────────┘       │
+                    │                       │
+         is_critical && status==error       │
+                    │                       │
+                    ▼                       │
+        agent-deck session restart <id>     │
+                    │                       │
+                    ▼                       │
+          (post-restart cool-down)──────────┘
+```
+
+### Trigger sources (in order of latency)
+
+1. **Primary (inotify)**: `inotifywait -m ~/.agent-deck/hooks/` — kernel-level fsevent on every hook file write. Latency: ~100 ms end-to-end. Covers: Claude hooks that write `status:"dead"` or transitions to waiting/error.
+
+2. **Safety-net (poll)**: every 5 s, run `agent-deck list --all --json`, for each critical session run `agent-deck session show <id> --json`, check `status`. Latency: up to 5 s. Covers: external tmux kills where the Claude process never got to write a hook. Cost: ~3 subprocess calls every 5 s for 3 conductors = negligible.
+
+Both sources feed the same dispatcher. The dispatcher is idempotent (per-session state machine), so dual-firing is a non-issue.
+
+### Critical-session criteria
+
+A session is "critical" if **any** of:
+
+- `title` starts with `conductor-` (current flagship case — 3 sessions today)
+- `group` == `"conductor"` or `"watchers"` (forward-compat; no watchers exist yet)
+- `is_conductor: true` in `session show` output
+- File `~/.agent-deck/watchdog/autorestart/<id>` exists (explicit opt-in for one-offs)
+
+A session is excluded if `status` == `"stopped"` (user deliberately stopped it).
+
+### Restart path
+
+Call `agent-deck session restart <id>` — this preserves ClaudeSessionID via `respawn-pane -k`, env_file, config_dir, channels. Exactly what conductors need. No new restart logic in the watchdog; we reuse the battle-tested path.
+
+## Guardrails
+
+### Per-session rate limit
+
+Max **3 restarts per 300 seconds per session_id**. Tracked in-memory dict `restart_history[id] = [ts1, ts2, ts3, ...]`, pruned on each check. Exceed → skip restart and escalate.
+
+### Global cascade guard
+
+If **5 or more** restarts fire across all critical sessions within a **10-second window**, pause all restarts for **60 seconds** and emit a single "cascade detected" escalation. This is the "SSH logout took everything down" case — wait for the system to settle, then resume normal operation.
+
+### Post-restart cool-down
+
+After each successful restart, suppress further restart attempts for that same session for **30 seconds**. This allows the new tmux session time to come up and prevents inotify-driven double-fire.
+
+### Escalation channel
+
+On any of:
+
+- Per-session rate limit exceeded (3rd failure in 5 min)
+- Cascade detected (5 in 10s)
+- Restart subprocess returned non-zero 2x in a row
+
+… the watchdog writes a structured line to `~/.agent-deck/watchdog/escalations.log` AND calls `~/.agent-deck/watchdog/escalate.sh <severity> <message>` if that script exists (stub initially, wire to Telegram bot later).
+
+## Concurrency
+
+Single-process Python with a threading model:
+
+- Thread A: inotify listener (blocking `inotify.adapters.Inotify`)
+- Thread B: 5 s safety poll
+- Main thread: event queue consumer with a mutex around rate-limit state
+
+No external store — state lives in-memory, resets on daemon restart. Acceptable because the only thing that's lost is the 5-min rolling window, and a restart is itself a signal that something went sideways.
+
+## Failure modes
+
+| Failure | Effect | Mitigation |
+|---|---|---|
+| Watchdog crashes | No auto-restart until systemd restarts it | `Restart=always`, `RestartSec=5` |
+| `agent-deck` binary missing or broken | All restarts fail | Escalation after 2 consecutive non-zero exits |
+| Conductor itself keeps crashing | Watchdog hits rate limit, escalates | Per-session cap at 3/5min |
+| Notify-daemon down | inotify still fires (hooks are written by Claude hooks themselves) | Dual trigger source |
+| Hook dir floods (100s of events/sec) | Backpressure on event queue | Bounded queue (size 100); drop oldest and log |
+
+## Out of scope for v1
+
+- Telegram escalation wiring (stub only; will be wired once the bot token story is finalized)
+- Per-group restart policies (all critical sessions share one rate-limit policy for v1)
+- Dry-run mode as a config flag (use `--dry-run` at invocation)
+- Metrics endpoint (stdout logging is sufficient for now)
+
+## Files
+
+- `~/.agent-deck/watchdog/DESIGN.md` — this file
+- `~/.agent-deck/watchdog/watchdog.py` — the daemon
+- `~/.agent-deck/watchdog/escalate.sh` — escalation stub (template)
+- `~/.agent-deck/watchdog/escalations.log` — written by daemon
+- `~/.agent-deck/watchdog/autorestart/<id>` — marker files for explicit opt-in (dir created by daemon)
+- `~/.config/systemd/user/agent-deck-watchdog.service` — user-level systemd unit (disabled until user approves)
+
+## Rollout
+
+1. Write script + systemd unit, leave DISABLED.
+2. Synthetic dry-run with fake hook events and fake CLI responses — assert rate limit, cascade guard, critical-session filter all behave correctly.
+3. User approval gate → real kill of one low-stakes conductor (e.g., `conductor-opengraphdb` if not actively in use), verify recovery within 10 s.
+4. User approval gate → `systemctl --user enable --now agent-deck-watchdog.service`.
+5. Monitor for 24 h, then adjust thresholds if needed.
+
+## Coexistence with existing infrastructure
+
+- **Does not conflict with existing reviver** — reviver handles `ClassErrored` (tmux alive, pipe dead); watchdog handles `ClassDead` (tmux gone) for critical sessions only. Disjoint domains.
+- **Does not modify notify-daemon** — reads its outputs (hooks) but is a pure consumer.
+- **No shared state with TUI** — watchdog never touches the SQLite statedb directly.
+
+## Rate-limit tuning rationale
+
+- 3 restarts / 5 min: a session that genuinely can't come up after 3 tries probably needs a human. 5 min window is long enough that a healthy session won't trip it even if it hiccups twice.
+- 5 sessions / 10 s cascade: an SSH logout typically kills all sessions within ~2 s. 5-in-10s is a reliable cascade signal that is very unlikely in normal operation (normal crashes are isolated).
+- 30 s post-restart cool-down: Claude's cold-start is typically 10-20 s. 30 s gives the new tmux session time to reach `running` status before the next inotify-driven re-check.

--- a/scripts/watchdog/README.md
+++ b/scripts/watchdog/README.md
@@ -1,0 +1,90 @@
+# agent-deck watchdog
+
+Python daemon that keeps critical agent-deck sessions alive. Ships in-tree from
+v1.7.63 onward so every user gets it via normal releases.
+
+See `DESIGN.md` for architecture.
+
+## What it does
+
+1. **Auto-restart** critical sessions (conductors, `meeting-watcher`, `gmail-watcher`,
+   `agent-deck`, explicit opt-ins) when they flip to `error` — with per-session
+   rate limit (3 per 10 min), global cascade guard, 429 detection, and Telegram
+   escalation.
+2. **Poller-existence check (v1.7.63)** — for each conductor session with
+   `plugin:telegram@claude-plugins-official` attached, verify a matching
+   `bun ... telegram ...` subprocess is running and owns the expected
+   `TELEGRAM_STATE_DIR`. Fires `agent-deck session restart <id>` if missing
+   (max one per hour per conductor).
+3. **Waiting-too-long patrol (v1.7.63)** — for each child session
+   (`parent_session_id` set) stuck in `status=waiting` with an unchanged tmux
+   pane for >10 min, inject `report status?` via `agent-deck session send`
+   (max one nudge per hour per session).
+
+## Install
+
+```bash
+# 1. Copy the daemon into your runtime dir:
+mkdir -p ~/.agent-deck/watchdog
+install -m 755 scripts/watchdog/watchdog.py  ~/.agent-deck/watchdog/watchdog.py
+install -m 755 scripts/watchdog/escalate.sh  ~/.agent-deck/watchdog/escalate.sh
+
+# 2. Sanity check:
+python3 ~/.agent-deck/watchdog/watchdog.py --once --dry-run --verbose
+
+# 3. Wire up a systemd --user unit (example):
+cat >~/.config/systemd/user/agent-deck-watchdog.service <<'EOF'
+[Unit]
+Description=agent-deck watchdog
+After=default.target
+
+[Service]
+ExecStart=/usr/bin/python3 %h/.agent-deck/watchdog/watchdog.py
+Restart=always
+RestartSec=5
+Environment=AGENT_DECK_BIN=/usr/local/bin/agent-deck
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable --now agent-deck-watchdog.service
+```
+
+## Configuration (env vars)
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `AGENT_DECK_ROOT` | Where hook files + logs live | `~/.agent-deck` |
+| `AGENT_DECK_BIN`  | Path to the `agent-deck` binary | `/usr/local/bin/agent-deck` |
+| `TELEGRAM_ESCALATION_CHAT_ID` | Chat ID for watchdog's own escalation alerts. **Empty by default — set it or escalations log locally only.** | `""` |
+
+## Running tests
+
+```bash
+cd scripts/watchdog
+python3 -m unittest test_watchdog -v
+# or:
+pytest test_watchdog.py
+```
+
+The full suite takes ~9 minutes because several tests exercise the global
+restart serialization (`MIN_GLOBAL_RESTART_INTERVAL_S=60`). For iterating on
+the v1.7.63 additions specifically:
+
+```bash
+python3 -m unittest \
+  test_watchdog.TestPollerExistence \
+  test_watchdog.TestBunTelegramStateDirs \
+  test_watchdog.TestWaitingTooLong
+# Runs in <1s.
+```
+
+## Operational notes
+
+- **Dry-run** (`--dry-run`) logs every action instead of invoking restart /
+  send / Telegram. Safe to leave running.
+- **One-shot** (`--once`) executes a single safety-poll pass and exits. Useful
+  from shell scripts or cron alongside the systemd service.
+- Logs land in `$AGENT_DECK_ROOT/watchdog/{watchdog.log,restart.log,escalations.log}`.

--- a/scripts/watchdog/escalate.sh
+++ b/scripts/watchdog/escalate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Escalation stub for agent-deck watchdog.
+#
+# Called as: escalate.sh <severity> <message>
+#
+# Severities: cascade, rate-limit, restart-failed
+#
+# Default behavior: log to syslog. Wire to Telegram bot later by editing
+# this file and adding a curl to the appropriate bot endpoint.
+
+SEVERITY="${1:-unknown}"
+MESSAGE="${2:-no message}"
+
+logger -t agent-deck-watchdog -p user.warning "[$SEVERITY] $MESSAGE"
+
+# Optional: desktop notification if on a graphical session
+if [ -n "$DISPLAY" ] && command -v notify-send >/dev/null 2>&1; then
+    notify-send -u critical "agent-deck watchdog [$SEVERITY]" "$MESSAGE"
+fi
+
+# TODO: wire Telegram escalation here once bot token story is finalized.
+# Example (leave commented until activated):
+# curl -s -X POST "https://api.telegram.org/bot$TOKEN/sendMessage" \
+#   -d "chat_id=$CHAT_ID" \
+#   -d "text=🚨 [agent-deck watchdog] [$SEVERITY] $MESSAGE"
+
+exit 0

--- a/scripts/watchdog/test_watchdog.py
+++ b/scripts/watchdog/test_watchdog.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+"""Unit tests for watchdog v2 — rate-limit + atomic-cascade + critical-filter + Telegram stub."""
+
+import json
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent))
+import watchdog as wd_mod
+
+
+def make_sess(sid="c-1", title="conductor-travel", group="", profile="personal",
+              status="error", is_conductor=False):
+    return {
+        "id": sid,
+        "title": title,
+        "group": group,
+        "profile": profile,
+        "status": status,
+        "tool": "claude",
+        "is_conductor": is_conductor,
+    }
+
+
+class TestIsCritical(unittest.TestCase):
+    def test_conductor_title_prefix(self):
+        self.assertTrue(wd_mod.is_critical(make_sess(title="conductor-travel")))
+
+    def test_regular_session_not_critical(self):
+        self.assertFalse(wd_mod.is_critical(make_sess(title="my-project")))
+
+    def test_watchers_group(self):
+        self.assertTrue(wd_mod.is_critical(make_sess(title="random", group="watchers")))
+
+    def test_conductor_group(self):
+        self.assertTrue(wd_mod.is_critical(make_sess(title="anything", group="conductor")))
+
+    def test_is_conductor_flag(self):
+        self.assertTrue(wd_mod.is_critical(make_sess(title="x", is_conductor=True)))
+
+    def test_exact_title_agent_deck(self):
+        self.assertTrue(wd_mod.is_critical(make_sess(title="agent-deck")))
+
+    def test_exact_title_meeting_watcher(self):
+        self.assertTrue(wd_mod.is_critical(make_sess(title="meeting-watcher")))
+
+    def test_exact_title_gmail_watcher(self):
+        self.assertTrue(wd_mod.is_critical(make_sess(title="gmail-watcher")))
+
+    def test_empty_or_none(self):
+        self.assertFalse(wd_mod.is_critical({}))
+        self.assertFalse(wd_mod.is_critical(None))
+
+    def test_autorestart_marker(self):
+        with tempfile.TemporaryDirectory() as td:
+            original = wd_mod.AUTORESTART_DIR
+            try:
+                wd_mod.AUTORESTART_DIR = Path(td)
+                (Path(td) / "opt-in-id").touch()
+                self.assertTrue(wd_mod.is_critical(make_sess(sid="opt-in-id", title="ordinary")))
+                self.assertFalse(wd_mod.is_critical(make_sess(sid="other-id", title="ordinary")))
+            finally:
+                wd_mod.AUTORESTART_DIR = original
+
+
+class TestRateLimit(unittest.TestCase):
+    def setUp(self):
+        self.wd = wd_mod.Watchdog(dry_run=True)
+
+    def test_first_three_allowed_then_blocked(self):
+        sess = make_sess()
+        with mock.patch.object(wd_mod, "show_session", return_value=sess), \
+             tempfile.TemporaryDirectory() as td:
+            old = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                for _ in range(wd_mod.RATE_LIMIT_MAX):
+                    self.wd.cooldown_until.pop(sess["id"], None)
+                    self.wd.maybe_restart(sess)
+                before = len(self.wd.restart_history[sess["id"]])
+                self.wd.cooldown_until.pop(sess["id"], None)
+                with mock.patch.object(wd_mod, "telegram_send", return_value=True):
+                    self.wd.maybe_restart(sess)
+                after = len(self.wd.restart_history[sess["id"]])
+                self.assertEqual(before, after, "rate limit should block further attempts")
+            finally:
+                wd_mod.ESCALATIONS_LOG = old
+
+    def test_rate_limit_window_is_600s(self):
+        self.assertEqual(wd_mod.RATE_LIMIT_WINDOW_S, 600)
+
+    def test_cooldown_blocks_immediate_retry(self):
+        sess = make_sess()
+        with mock.patch.object(wd_mod, "show_session", return_value=sess):
+            self.wd.maybe_restart(sess)
+            before = len(self.wd.restart_history[sess["id"]])
+            self.wd.maybe_restart(sess)
+            after = len(self.wd.restart_history[sess["id"]])
+            self.assertEqual(before, after, "cooldown should block immediate retry")
+
+    def test_prune_history_after_window(self):
+        self.wd.restart_history["old-id"] = wd_mod.deque([time.time() - 1000])
+        self.wd._prune_history(time.time())
+        self.assertEqual(len(self.wd.restart_history["old-id"]), 0)
+
+    def test_status_not_error_skips_restart(self):
+        sess = make_sess(status="running")
+        with mock.patch.object(wd_mod, "show_session", return_value=sess):
+            self.wd.maybe_restart(sess)
+            self.assertNotIn(sess["id"], self.wd.restart_history)
+
+    def test_rate_limit_sends_telegram_escalation(self):
+        sess = make_sess()
+        with tempfile.TemporaryDirectory() as td:
+            old = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                with mock.patch.object(wd_mod, "show_session", return_value=sess):
+                    for _ in range(wd_mod.RATE_LIMIT_MAX):
+                        self.wd.cooldown_until.pop(sess["id"], None)
+                        self.wd.maybe_restart(sess)
+                    self.wd.cooldown_until.pop(sess["id"], None)
+                    with mock.patch.object(wd_mod, "telegram_send", return_value=True) as tg:
+                        self.wd.maybe_restart(sess)
+                        tg.assert_called_once()
+                        args, kwargs = tg.call_args
+                        self.assertIn("keeps crashing", args[0])
+            finally:
+                wd_mod.ESCALATIONS_LOG = old
+
+
+class TestAtomicCascade(unittest.TestCase):
+    def setUp(self):
+        self.wd = wd_mod.Watchdog(dry_run=True)
+
+    def test_below_threshold_does_not_trigger(self):
+        fewer = [(f"id-{i}", f"conductor-x{i}", "personal") for i in range(wd_mod.CASCADE_THRESHOLD - 1)]
+        with mock.patch.object(self.wd, "_scan_critical_error_sessions", return_value=fewer):
+            fired = self.wd._maybe_trigger_cascade()
+        self.assertFalse(fired)
+        self.assertEqual(self.wd.cascade_settling_until, 0.0)
+
+    def test_at_threshold_triggers_settle_window(self):
+        many = [(f"id-{i}", f"conductor-x{i}", "personal") for i in range(wd_mod.CASCADE_THRESHOLD)]
+        with tempfile.TemporaryDirectory() as td:
+            old = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                with mock.patch.object(self.wd, "_scan_critical_error_sessions", return_value=many), \
+                     mock.patch.object(wd_mod, "telegram_send", return_value=True):
+                    fired = self.wd._maybe_trigger_cascade()
+                self.assertTrue(fired)
+                self.assertGreater(self.wd.cascade_settling_until, time.time())
+                self.assertIn("cascade-detected", Path(wd_mod.ESCALATIONS_LOG).read_text())
+            finally:
+                wd_mod.ESCALATIONS_LOG = old
+
+    def test_settling_window_blocks_individual_restarts(self):
+        sess = make_sess()
+        self.wd.cascade_settling_until = time.time() + 100
+        with mock.patch.object(wd_mod, "show_session", return_value=sess):
+            self.wd.maybe_restart(sess)
+        self.assertNotIn(sess["id"], self.wd.restart_history)
+
+
+class TestContinuityMessage(unittest.TestCase):
+    def test_dry_run_does_not_call_send(self):
+        with mock.patch.object(wd_mod, "run_cmd") as rc:
+            ok = wd_mod.send_continuity_message("c-1", "personal", dry_run=True)
+        self.assertTrue(ok)
+        rc.assert_not_called()
+
+    def test_live_mode_invokes_send_no_wait(self):
+        with mock.patch.object(wd_mod, "run_cmd", return_value=(0, "", "")) as rc:
+            ok = wd_mod.send_continuity_message("c-1", "personal", dry_run=False)
+        self.assertTrue(ok)
+        args = rc.call_args[0][0]
+        self.assertIn("session", args)
+        self.assertIn("send", args)
+        self.assertIn("--no-wait", args)
+        self.assertIn("c-1", args)
+
+
+class TestIsEscalationCritical(unittest.TestCase):
+    def test_conductor_title_prefix_is_escalation_critical(self):
+        self.assertTrue(wd_mod.is_escalation_critical(make_sess(title="conductor-travel")))
+
+    def test_watchers_group_is_escalation_critical(self):
+        self.assertTrue(wd_mod.is_escalation_critical(make_sess(title="x", group="watchers")))
+
+    def test_is_conductor_flag_is_escalation_critical(self):
+        self.assertTrue(wd_mod.is_escalation_critical(make_sess(title="x", is_conductor=True)))
+
+    def test_group_conductor_NOT_escalation_critical_without_flag(self):
+        # Workers in group=conductor (e.g. test-visual) should restart but NOT telegram
+        self.assertFalse(wd_mod.is_escalation_critical(make_sess(title="test-visual", group="conductor")))
+
+    def test_exact_title_agent_deck_NOT_escalation_critical(self):
+        # 'agent-deck' is in the restart allow-list but not real conductor — no telegram
+        self.assertFalse(wd_mod.is_escalation_critical(make_sess(title="agent-deck")))
+
+    def test_regular_session_NOT_escalation_critical(self):
+        self.assertFalse(wd_mod.is_escalation_critical(make_sess(title="my-project")))
+
+
+class TestEscalationDedup(unittest.TestCase):
+    def test_same_sid_severity_dedup_within_window(self):
+        wd = wd_mod.Watchdog(dry_run=True)
+        with tempfile.TemporaryDirectory() as td, \
+             mock.patch.object(wd_mod, "telegram_send", return_value=True) as tg:
+            old = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                wd.escalate("rate-limit", "msg1", telegram=True, sid="c-1")
+                wd.escalate("rate-limit", "msg2", telegram=True, sid="c-1")
+                wd.escalate("rate-limit", "msg3", telegram=True, sid="c-1")
+                self.assertEqual(tg.call_count, 1, "second+third should be deduped")
+            finally:
+                wd_mod.ESCALATIONS_LOG = old
+
+    def test_different_sid_not_deduped(self):
+        wd = wd_mod.Watchdog(dry_run=True)
+        with tempfile.TemporaryDirectory() as td, \
+             mock.patch.object(wd_mod, "telegram_send", return_value=True) as tg:
+            old = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                wd.escalate("rate-limit", "A", telegram=True, sid="a-1")
+                wd.escalate("rate-limit", "B", telegram=True, sid="b-1")
+                self.assertEqual(tg.call_count, 2)
+            finally:
+                wd_mod.ESCALATIONS_LOG = old
+
+    def test_different_severity_not_deduped(self):
+        wd = wd_mod.Watchdog(dry_run=True)
+        with tempfile.TemporaryDirectory() as td, \
+             mock.patch.object(wd_mod, "telegram_send", return_value=True) as tg:
+            old = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                wd.escalate("rate-limit", "r", telegram=True, sid="c-1")
+                wd.escalate("restart-failed", "f", telegram=True, sid="c-1")
+                self.assertEqual(tg.call_count, 2)
+            finally:
+                wd_mod.ESCALATIONS_LOG = old
+
+
+class TestWorkerNoTelegram(unittest.TestCase):
+    """Verify that rate-limit on a non-escalation-critical session does NOT fire telegram."""
+
+    def test_worker_rate_limit_local_only(self):
+        wd = wd_mod.Watchdog(dry_run=True)
+        # test-visual style: group=conductor but not a real conductor
+        sess = make_sess(sid="test-v", title="test-visual", group="conductor", profile="default", status="error")
+        with tempfile.TemporaryDirectory() as td, \
+             mock.patch.object(wd_mod, "show_session", return_value=sess), \
+             mock.patch.object(wd_mod, "telegram_send", return_value=True) as tg:
+            old = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                # Burn through the rate-limit
+                for _ in range(wd_mod.RATE_LIMIT_MAX):
+                    wd.cooldown_until.pop("test-v", None)
+                    wd.maybe_restart(sess)
+                wd.cooldown_until.pop("test-v", None)
+                wd.maybe_restart(sess)  # this should hit rate limit
+                tg.assert_not_called()  # worker → local log only
+                content = Path(wd_mod.ESCALATIONS_LOG).read_text()
+                self.assertIn("rate-limit", content)
+            finally:
+                wd_mod.ESCALATIONS_LOG = old
+
+    def test_conductor_rate_limit_does_telegram(self):
+        wd = wd_mod.Watchdog(dry_run=True)
+        sess = make_sess(sid="cond-1", title="conductor-travel", group="conductor", profile="personal", status="error")
+        with tempfile.TemporaryDirectory() as td, \
+             mock.patch.object(wd_mod, "show_session", return_value=sess), \
+             mock.patch.object(wd_mod, "telegram_send", return_value=True) as tg:
+            old = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                for _ in range(wd_mod.RATE_LIMIT_MAX):
+                    wd.cooldown_until.pop("cond-1", None)
+                    wd.maybe_restart(sess)
+                wd.cooldown_until.pop("cond-1", None)
+                wd.maybe_restart(sess)
+                tg.assert_called_once()  # real conductor → telegram
+            finally:
+                wd_mod.ESCALATIONS_LOG = old
+
+
+class TestStaleCleanup(unittest.TestCase):
+    def test_stale_non_critical_gets_removed(self):
+        wd = wd_mod.Watchdog(dry_run=True)
+        # worker-ish session in error state
+        sess = make_sess(sid="test-v", title="test-visual", group="conductor", profile="default", status="error")
+        wd.first_error_seen_at["test-v"] = time.time() - (wd_mod.STALE_ERROR_CLEANUP_S + 10)
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "show_session", return_value=sess), \
+             mock.patch.object(wd_mod, "run_cmd", return_value=(0, "", "")) as rc:
+            wd._stale_cleanup_scan()
+        # Should have called `agent-deck ... remove test-v`
+        call_args = [c[0][0] for c in rc.call_args_list]
+        self.assertTrue(any("remove" in args and "test-v" in args for args in call_args),
+                        f"expected remove call, got: {call_args}")
+        self.assertIn("test-v", wd.removed_ids)
+
+    def test_stale_critical_NOT_removed(self):
+        wd = wd_mod.Watchdog(dry_run=True)
+        sess = make_sess(sid="cond-1", title="conductor-travel", group="conductor", profile="personal", status="error")
+        wd.first_error_seen_at["cond-1"] = time.time() - (wd_mod.STALE_ERROR_CLEANUP_S + 10)
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "show_session", return_value=sess), \
+             mock.patch.object(wd_mod, "run_cmd", return_value=(0, "", "")) as rc:
+            wd._stale_cleanup_scan()
+        # No `remove` call — real conductors never auto-removed
+        call_args = [c[0][0] for c in rc.call_args_list]
+        self.assertFalse(any("remove" in args for args in call_args),
+                         f"should NOT remove critical, got: {call_args}")
+        self.assertNotIn("cond-1", wd.removed_ids)
+
+    def test_non_stuck_session_not_removed(self):
+        wd = wd_mod.Watchdog(dry_run=True)
+        sess = make_sess(sid="test-v", title="test-visual", group="conductor", status="error")
+        # only been errored for 5s, not stale
+        wd.first_error_seen_at["test-v"] = time.time() - 5
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "show_session", return_value=sess), \
+             mock.patch.object(wd_mod, "run_cmd", return_value=(0, "", "")) as rc:
+            wd._stale_cleanup_scan()
+        self.assertEqual(rc.call_count, 0)
+        self.assertNotIn("test-v", wd.removed_ids)
+
+
+class TestEscalation(unittest.TestCase):
+    def test_writes_log(self):
+        wd = wd_mod.Watchdog(dry_run=True)
+        with tempfile.TemporaryDirectory() as td:
+            old = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                wd.escalate("test-sev", "hello")
+                content = Path(wd_mod.ESCALATIONS_LOG).read_text()
+                self.assertIn("test-sev", content)
+                self.assertIn("hello", content)
+            finally:
+                wd_mod.ESCALATIONS_LOG = old
+
+    def test_telegram_flag_invokes_telegram_send(self):
+        wd = wd_mod.Watchdog(dry_run=True)
+        with tempfile.TemporaryDirectory() as td:
+            old = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                with mock.patch.object(wd_mod, "telegram_send", return_value=True) as tg:
+                    wd.escalate("cascade-detected", "msg", telegram=True)
+                    tg.assert_called_once()
+            finally:
+                wd_mod.ESCALATIONS_LOG = old
+
+
+class TestRestartFailureEscalation(unittest.TestCase):
+    def test_two_consecutive_failures_escalate(self):
+        wd = wd_mod.Watchdog(dry_run=False)
+        sess = make_sess()
+        with tempfile.TemporaryDirectory() as td:
+            old_log = wd_mod.ESCALATIONS_LOG
+            wd_mod.ESCALATIONS_LOG = Path(td) / "esc.log"
+            try:
+                with mock.patch.object(wd_mod, "show_session", return_value=sess), \
+                     mock.patch.object(wd_mod, "run_cmd", return_value=(1, "", "boom")), \
+                     mock.patch.object(wd_mod, "telegram_send", return_value=True):
+                    wd.maybe_restart(sess)
+                    wd.cooldown_until.pop(sess["id"], None)
+                    wd.maybe_restart(sess)
+                content = Path(wd_mod.ESCALATIONS_LOG).read_text()
+                self.assertIn("restart-failed", content)
+            finally:
+                wd_mod.ESCALATIONS_LOG = old_log
+
+
+class TestPollerExistence(unittest.TestCase):
+    """Capability A (v1.7.63): detect missing bun-telegram pollers and trigger
+    `agent-deck session restart` exactly once per conductor per hour."""
+
+    def setUp(self):
+        self.wd = wd_mod.Watchdog(dry_run=True)
+
+    def _make_conductor(self, sid, env_file=None, has_telegram=True, profile="personal"):
+        return {
+            "id": sid,
+            "title": f"conductor-{sid}",
+            "group": "conductor",
+            "profile": profile,
+            "status": "running",
+            "is_conductor": True,
+            "channels": [wd_mod.TELEGRAM_CHANNEL_NAME] if has_telegram else [],
+            "env_file": str(env_file) if env_file else None,
+        }
+
+    def test_poller_running_no_restart(self):
+        with tempfile.TemporaryDirectory() as td:
+            env_path = Path(td) / ".envrc"
+            state_dir = Path(td) / "state"
+            env_path.write_text(f"export TELEGRAM_STATE_DIR={state_dir}\n")
+            sess = self._make_conductor("c-1", env_file=env_path)
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+                 mock.patch.object(wd_mod, "bun_telegram_state_dirs", return_value={str(state_dir)}), \
+                 mock.patch.object(wd_mod, "run_cmd") as rc:
+                restarted = self.wd.check_poller_existence()
+        self.assertEqual(restarted, [])
+        rc.assert_not_called()
+
+    def test_poller_missing_triggers_restart(self):
+        with tempfile.TemporaryDirectory() as td:
+            env_path = Path(td) / ".envrc"
+            state_dir = Path(td) / "state"
+            env_path.write_text(f"export TELEGRAM_STATE_DIR={state_dir}\n")
+            sess = self._make_conductor("c-2", env_file=env_path)
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+                 mock.patch.object(wd_mod, "bun_telegram_state_dirs", return_value=set()):
+                restarted = self.wd.check_poller_existence()
+        self.assertEqual(restarted, ["c-2"])
+        self.assertIn("c-2", self.wd.last_poller_restart_at)
+
+    def test_session_without_telegram_channel_ignored(self):
+        with tempfile.TemporaryDirectory() as td:
+            env_path = Path(td) / ".envrc"
+            state_dir = Path(td) / "state"
+            env_path.write_text(f"TELEGRAM_STATE_DIR={state_dir}\n")
+            sess = self._make_conductor("c-3", env_file=env_path, has_telegram=False)
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+                 mock.patch.object(wd_mod, "bun_telegram_state_dirs", return_value=set()):
+                restarted = self.wd.check_poller_existence()
+        self.assertEqual(restarted, [])
+
+    def test_dedup_within_one_hour(self):
+        with tempfile.TemporaryDirectory() as td:
+            env_path = Path(td) / ".envrc"
+            state_dir = Path(td) / "state"
+            env_path.write_text(f"TELEGRAM_STATE_DIR={state_dir}\n")
+            sess = self._make_conductor("c-4", env_file=env_path)
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+                 mock.patch.object(wd_mod, "bun_telegram_state_dirs", return_value=set()):
+                t0 = 100000.0
+                self.wd.check_poller_existence(now=t0)
+                restarted = self.wd.check_poller_existence(now=t0 + 1800)  # +30 min
+        self.assertEqual(restarted, [])
+
+    def test_dedup_window_expires_after_one_hour(self):
+        with tempfile.TemporaryDirectory() as td:
+            env_path = Path(td) / ".envrc"
+            state_dir = Path(td) / "state"
+            env_path.write_text(f"TELEGRAM_STATE_DIR={state_dir}\n")
+            sess = self._make_conductor("c-5", env_file=env_path)
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+                 mock.patch.object(wd_mod, "bun_telegram_state_dirs", return_value=set()):
+                t0 = 200000.0
+                self.wd.check_poller_existence(now=t0)
+                restarted = self.wd.check_poller_existence(now=t0 + 3660)  # +61 min
+        self.assertEqual(restarted, ["c-5"])
+
+    def test_env_file_with_quoted_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            env_path = Path(td) / ".envrc"
+            state_dir = Path(td) / "state with spaces"
+            env_path.write_text(f'export TELEGRAM_STATE_DIR="{state_dir}"\n')
+            sess = self._make_conductor("c-6", env_file=env_path)
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+                 mock.patch.object(wd_mod, "bun_telegram_state_dirs", return_value={str(state_dir)}):
+                restarted = self.wd.check_poller_existence()
+        self.assertEqual(restarted, [])
+
+    def test_missing_env_file_skipped(self):
+        sess = self._make_conductor("c-7", env_file="/does/not/exist/.envrc")
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "bun_telegram_state_dirs", return_value=set()):
+            restarted = self.wd.check_poller_existence()
+        self.assertEqual(restarted, [])
+
+    def test_envrc_without_state_dir_skipped(self):
+        with tempfile.TemporaryDirectory() as td:
+            env_path = Path(td) / ".envrc"
+            env_path.write_text("export SOMETHING_ELSE=value\n")
+            sess = self._make_conductor("c-8", env_file=env_path)
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+                 mock.patch.object(wd_mod, "bun_telegram_state_dirs", return_value=set()):
+                restarted = self.wd.check_poller_existence()
+        self.assertEqual(restarted, [])
+
+    def test_live_mode_invokes_session_restart(self):
+        with tempfile.TemporaryDirectory() as td:
+            env_path = Path(td) / ".envrc"
+            state_dir = Path(td) / "state"
+            env_path.write_text(f"TELEGRAM_STATE_DIR={state_dir}\n")
+            sess = self._make_conductor("c-9", env_file=env_path)
+            wd = wd_mod.Watchdog(dry_run=False)
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+                 mock.patch.object(wd_mod, "bun_telegram_state_dirs", return_value=set()), \
+                 mock.patch.object(wd_mod, "run_cmd", return_value=(0, "", "")) as rc:
+                restarted = wd.check_poller_existence()
+        self.assertEqual(restarted, ["c-9"])
+        call_args = [c[0][0] for c in rc.call_args_list]
+        self.assertTrue(any("restart" in args and "c-9" in args for args in call_args),
+                        f"expected restart call for c-9, got: {call_args}")
+
+    def test_multi_conductor_only_missing_ones_restart(self):
+        with tempfile.TemporaryDirectory() as td:
+            env_a = Path(td) / "a.envrc"
+            env_b = Path(td) / "b.envrc"
+            env_c = Path(td) / "c.envrc"
+            state_a = Path(td) / "state-a"
+            state_b = Path(td) / "state-b"
+            state_c = Path(td) / "state-c"
+            env_a.write_text(f"TELEGRAM_STATE_DIR={state_a}\n")
+            env_b.write_text(f"TELEGRAM_STATE_DIR={state_b}\n")
+            env_c.write_text(f"TELEGRAM_STATE_DIR={state_c}\n")
+            sessions = [
+                self._make_conductor("cond-a", env_file=env_a),
+                self._make_conductor("cond-b", env_file=env_b),
+                self._make_conductor("cond-c", env_file=env_c),
+            ]
+            # Only cond-a's poller is running
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=sessions), \
+                 mock.patch.object(wd_mod, "bun_telegram_state_dirs",
+                                   return_value={str(state_a)}):
+                restarted = self.wd.check_poller_existence()
+        self.assertEqual(sorted(restarted), ["cond-b", "cond-c"])
+
+
+class TestBunTelegramStateDirs(unittest.TestCase):
+    """Unit tests for the helper that extracts TELEGRAM_STATE_DIR from running
+    bun processes via /proc/PID/environ."""
+
+    def test_no_matching_processes_returns_empty(self):
+        with mock.patch.object(wd_mod, "run_cmd", return_value=(1, "", "")):
+            self.assertEqual(wd_mod.bun_telegram_state_dirs(), set())
+
+    def test_extracts_from_proc_environ(self):
+        with tempfile.TemporaryDirectory() as td:
+            procdir = Path(td) / "12345"
+            procdir.mkdir()
+            env_bytes = b"FOO=bar\x00TELEGRAM_STATE_DIR=/fake/state/conductor-x\x00BAZ=qux\x00"
+            (procdir / "environ").write_bytes(env_bytes)
+            with mock.patch.object(wd_mod, "run_cmd",
+                                   return_value=(0, "12345 bun telegram start\n", "")):
+                dirs = wd_mod.bun_telegram_state_dirs(proc_root=td)
+        self.assertEqual(dirs, {"/fake/state/conductor-x"})
+
+    def test_multiple_bun_processes_distinct_dirs(self):
+        with tempfile.TemporaryDirectory() as td:
+            for pid, sdir in [("111", "/s/one"), ("222", "/s/two")]:
+                procdir = Path(td) / pid
+                procdir.mkdir()
+                (procdir / "environ").write_bytes(
+                    f"TELEGRAM_STATE_DIR={sdir}\x00".encode())
+            with mock.patch.object(wd_mod, "run_cmd",
+                                   return_value=(0, "111 bun telegram\n222 bun telegram\n", "")):
+                dirs = wd_mod.bun_telegram_state_dirs(proc_root=td)
+        self.assertEqual(dirs, {"/s/one", "/s/two"})
+
+    def test_unreadable_environ_skipped(self):
+        with tempfile.TemporaryDirectory() as td:
+            # PID with no environ file
+            (Path(td) / "999").mkdir()
+            with mock.patch.object(wd_mod, "run_cmd",
+                                   return_value=(0, "999 bun telegram\n", "")):
+                dirs = wd_mod.bun_telegram_state_dirs(proc_root=td)
+        self.assertEqual(dirs, set())
+
+
+class TestWaitingTooLong(unittest.TestCase):
+    """Capability B (v1.7.63): nudge child sessions that have been stuck in
+    'waiting' state with no pane activity change for > 10 min."""
+
+    def setUp(self):
+        self.wd = wd_mod.Watchdog(dry_run=True)
+
+    def _make_child(self, sid="child-1", status="waiting", parent="p-1", profile="personal"):
+        return {
+            "id": sid,
+            "title": "child-work",
+            "parent_session_id": parent,
+            "profile": profile,
+            "status": status,
+        }
+
+    def test_first_observation_does_not_nudge(self):
+        sess = self._make_child()
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "fetch_session_output", return_value="hello"):
+            nudged = self.wd.check_waiting_too_long(now=1000.0)
+        self.assertEqual(nudged, [])
+        self.assertIn("child-1", self.wd.waiting_tracker)
+
+    def test_pane_changed_resets_timer(self):
+        sess = self._make_child()
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]):
+            with mock.patch.object(wd_mod, "fetch_session_output", return_value="pane-A"):
+                self.wd.check_waiting_too_long(now=1000.0)
+            with mock.patch.object(wd_mod, "fetch_session_output", return_value="pane-B"):
+                nudged = self.wd.check_waiting_too_long(now=1000.0 + 660)  # +11 min, but pane changed
+        self.assertEqual(nudged, [])
+
+    def test_waiting_over_10min_unchanged_nudges(self):
+        sess = self._make_child(sid="child-2")
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "fetch_session_output", return_value="frozen-pane"):
+            self.wd.check_waiting_too_long(now=2000.0)
+            nudged = self.wd.check_waiting_too_long(now=2000.0 + 660)
+        self.assertEqual(nudged, ["child-2"])
+
+    def test_no_nudge_within_threshold(self):
+        sess = self._make_child(sid="child-3")
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "fetch_session_output", return_value="stable"):
+            self.wd.check_waiting_too_long(now=3000.0)
+            nudged = self.wd.check_waiting_too_long(now=3000.0 + 300)  # only 5 min
+        self.assertEqual(nudged, [])
+
+    def test_no_nudge_for_non_child(self):
+        sess = {
+            "id": "std-1", "title": "standalone",
+            "parent_session_id": "",
+            "status": "waiting", "profile": "default",
+        }
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "fetch_session_output", return_value="output"):
+            self.wd.check_waiting_too_long(now=4000.0)
+            nudged = self.wd.check_waiting_too_long(now=4000.0 + 660)
+        self.assertEqual(nudged, [])
+
+    def test_no_nudge_when_status_not_waiting(self):
+        sess = self._make_child(sid="child-4", status="running")
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "fetch_session_output", return_value="output"):
+            self.wd.check_waiting_too_long(now=5000.0)
+            nudged = self.wd.check_waiting_too_long(now=5000.0 + 660)
+        self.assertEqual(nudged, [])
+
+    def test_dedup_1h_per_session(self):
+        sess = self._make_child(sid="child-5")
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "fetch_session_output", return_value="frozen"):
+            self.wd.check_waiting_too_long(now=6000.0)
+            self.wd.check_waiting_too_long(now=6000.0 + 660)  # nudges
+            # 30 min after nudge, still unchanged → dedup blocks
+            nudged = self.wd.check_waiting_too_long(now=6000.0 + 660 + 1800)
+        self.assertEqual(nudged, [])
+
+    def test_dedup_window_expires(self):
+        sess = self._make_child(sid="child-6")
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "fetch_session_output", return_value="frozen"):
+            self.wd.check_waiting_too_long(now=7000.0)
+            self.wd.check_waiting_too_long(now=7000.0 + 660)
+            # 70 min after first nudge → can re-nudge
+            nudged = self.wd.check_waiting_too_long(now=7000.0 + 660 + 4200)
+        self.assertEqual(nudged, ["child-6"])
+
+    def test_tracker_cleared_when_session_leaves_waiting(self):
+        sess_waiting = self._make_child(sid="child-7")
+        sess_running = self._make_child(sid="child-7", status="running")
+        with mock.patch.object(wd_mod, "fetch_session_output", return_value="output"):
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess_waiting]):
+                self.wd.check_waiting_too_long(now=8000.0)
+            self.assertIn("child-7", self.wd.waiting_tracker)
+            with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess_running]):
+                self.wd.check_waiting_too_long(now=8000.0 + 60)
+        self.assertNotIn("child-7", self.wd.waiting_tracker)
+
+    def test_live_mode_invokes_session_send(self):
+        sess = self._make_child(sid="child-8")
+        wd = wd_mod.Watchdog(dry_run=False)
+        with mock.patch.object(wd_mod, "list_all_sessions", return_value=[sess]), \
+             mock.patch.object(wd_mod, "fetch_session_output", return_value="stuck"), \
+             mock.patch.object(wd_mod, "run_cmd", return_value=(0, "", "")) as rc:
+            wd.check_waiting_too_long(now=9000.0)
+            nudged = wd.check_waiting_too_long(now=9000.0 + 660)
+        self.assertEqual(nudged, ["child-8"])
+        call_args = [c[0][0] for c in rc.call_args_list]
+        found_send = any(
+            "session" in args and "send" in args and "child-8" in args
+            and wd_mod.WAITING_PATROL_NUDGE_TEXT in args
+            for args in call_args
+        )
+        self.assertTrue(found_send, f"expected session send call, got: {call_args}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/watchdog/watchdog.py
+++ b/scripts/watchdog/watchdog.py
@@ -1,0 +1,1141 @@
+#!/usr/bin/env python3
+"""
+Agent-Deck Auto-Restart Watchdog (v2 — with continuity message, atomic cascade revive, Telegram escalation).
+
+See DESIGN.md for architecture. Changes in v2:
+  - Critical-session filter narrowed to explicit allow-list
+  - Rate limit: 3 per 600s (10 min) per session
+  - Cascade: when 5+ criticals are simultaneously in error, wait 30s for
+    system to stabilize, then fire all restarts in parallel (atomic-ish revive)
+  - After each successful restart, send a continuity message via
+    `agent-deck session send <id> "..." --no-wait`
+  - Telegram escalation to a fixed chat_id for rate-limit breaches
+
+Usage:
+    watchdog.py                 # daemon mode (systemd)
+    watchdog.py --dry-run       # log only, no restart / send / escalation
+    watchdog.py --once          # one pass of safety poll, then exit
+    watchdog.py --verbose
+"""
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import queue
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+import urllib.request
+from collections import deque
+from pathlib import Path
+
+AGENT_DECK_ROOT = Path(os.environ.get("AGENT_DECK_ROOT", str(Path.home() / ".agent-deck")))
+HOOKS_DIR = AGENT_DECK_ROOT / "hooks"
+WATCHDOG_DIR = AGENT_DECK_ROOT / "watchdog"
+AUTORESTART_DIR = WATCHDOG_DIR / "autorestart"
+ESCALATIONS_LOG = WATCHDOG_DIR / "escalations.log"
+RESTART_LOG = WATCHDOG_DIR / "restart.log"
+ESCALATE_SCRIPT = WATCHDOG_DIR / "escalate.sh"
+
+AGENT_DECK_BIN = os.environ.get("AGENT_DECK_BIN", "/usr/local/bin/agent-deck")
+TELEGRAM_ENV_FILE = Path.home() / ".claude/channels/telegram/.env"
+TELEGRAM_ESCALATION_CHAT_ID = os.environ.get("TELEGRAM_ESCALATION_CHAT_ID", "")
+
+# --- guardrails ---
+RATE_LIMIT_MAX = 3
+RATE_LIMIT_WINDOW_S = 600          # 10 min per user's spec
+CASCADE_THRESHOLD = 5
+CASCADE_WAIT_S = 30                # settle-time before batch revive
+POST_RESTART_COOLDOWN_S = 30
+SAFETY_POLL_INTERVAL_S = 5
+SUBPROCESS_TIMEOUT_S = 30
+EVENT_QUEUE_MAXSIZE = 100
+
+# --- v1.7.63 capability A: poller-existence check ---
+# Name of the telegram MCP channel as registered on a session. Presence on a
+# conductor session's `channels` array means that session is expected to have
+# a bun-telegram poller subprocess running somewhere on this host.
+TELEGRAM_CHANNEL_NAME = "plugin:telegram@claude-plugins-official"
+# Per-conductor dedup: don't fire more than one poller-restart per hour, even
+# if the poller keeps dying. Prevents thrash; human attention kicks in after that.
+POLLER_RESTART_DEDUP_S = 3600
+
+# --- v1.7.63 capability B: waiting-too-long patrol ---
+# A child session (parent_session_id set) sitting in status=waiting with an
+# unchanged pane for longer than this gets a "report status?" nudge.
+WAITING_PATROL_THRESHOLD_S = 600        # 10 min
+WAITING_PATROL_NUDGE_DEDUP_S = 3600     # 1 hour — don't re-nudge within this
+WAITING_PATROL_NUDGE_TEXT = "report status?"
+
+# --- API rate-limit (429) handling ---
+# When claude itself returns 429, we must NOT count it as a crash (that escalates
+# to telegram and eventually removes the session). Instead, pause the specific
+# session for API_429_BACKOFF_S, and if 429s keep piling up globally, trip a
+# circuit breaker so we stop hammering the API entirely.
+API_429_BACKOFF_S = 180                       # per-session pause after a 429
+MIN_GLOBAL_RESTART_INTERVAL_S = 60            # serialize ALL restart attempts ≥ 60s apart
+CIRCUIT_BREAKER_429_THRESHOLD = 3             # 3 recent 429s trips the breaker
+CIRCUIT_BREAKER_429_WINDOW_S = 600            # counted over last 10 min
+CIRCUIT_BREAKER_PAUSE_S = 600                 # breaker pauses restarts for 10 min
+PROMPT_RESUME_TIMEOUT_S = 120                 # one-shot `claude --resume -p` timeout
+
+# Patterns we grep against tmux pane output / subprocess stderr.
+RATE_LIMIT_PATTERNS = (
+    re.compile(r"\brate[- ]?limit", re.IGNORECASE),
+    re.compile(r"\bHTTP[/ ]?429\b", re.IGNORECASE),
+    re.compile(r"\(429\)"),
+    re.compile(r"exceed.*rate.*limit", re.IGNORECASE),
+)
+DEFERRED_MARKER_PATTERN = re.compile(r"deferred tool marker", re.IGNORECASE)
+
+# Profile → CLAUDE_CONFIG_DIR mapping. Used only for the prompt-resume fallback
+# (restricted to personal profile per explicit user instruction).
+PROFILE_CONFIG_DIRS = {
+    "personal": str(Path.home() / ".claude"),
+    "work": str(Path.home() / ".claude-work"),
+}
+PROMPT_RESUME_TEXT = (
+    "continue — your tmux session was stopped unexpectedly; "
+    "check your state and report a one-line status"
+)
+
+# --- critical-session allow-list ---
+CRITICAL_TITLE_PREFIXES = ("conductor-",)
+CRITICAL_TITLES_EXACT = ("meeting-watcher", "gmail-watcher", "agent-deck")
+CRITICAL_GROUPS = ("conductor", "watchers")
+
+CONTINUITY_MESSAGE_TEMPLATE = (
+    "[SESSION AUTO-RESTARTED] Your session was abruptly stopped "
+    "(suspected cascade event at {timestamp}). If you were mid-task, "
+    "re-read your task-log.md + state.json and continue from where you "
+    "left off. Tell the user via Telegram if you resumed successfully."
+)
+
+log = logging.getLogger("watchdog")
+
+
+# ------------------------------------------------------------------
+# Subprocess helpers
+# ------------------------------------------------------------------
+
+def run_cmd(args, timeout=SUBPROCESS_TIMEOUT_S):
+    try:
+        res = subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout, check=False
+        )
+        return res.returncode, res.stdout, res.stderr
+    except subprocess.TimeoutExpired as e:
+        log.error("subprocess timeout: %s", args)
+        return 124, e.stdout or "", e.stderr or ""
+    except FileNotFoundError:
+        return 127, "", f"binary not found: {args[0]}"
+
+
+def list_all_sessions():
+    rc, out, err = run_cmd([AGENT_DECK_BIN, "list", "--all", "--json"])
+    if rc != 0:
+        log.warning("list --all failed rc=%d err=%s", rc, err.strip())
+        return []
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return []
+
+
+def show_session(instance_id, profile=None):
+    args = [AGENT_DECK_BIN]
+    if profile:
+        args += ["-p", profile]
+    args += ["session", "show", instance_id, "--json"]
+    rc, out, err = run_cmd(args)
+    if rc != 0:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+def fetch_session_output(instance_id, profile):
+    """Read the session's most-recent tmux pane output via agent-deck. Used to
+    inspect why claude's startup failed (429 vs deferred-tool marker vs other)."""
+    args = [AGENT_DECK_BIN]
+    if profile:
+        args += ["-p", profile]
+    args += ["session", "output", instance_id, "-quiet"]
+    rc, out, err = run_cmd(args, timeout=15)
+    if rc != 0:
+        return ""
+    return out or ""
+
+
+def detect_rate_limit(text):
+    if not text:
+        return False
+    return any(p.search(text) for p in RATE_LIMIT_PATTERNS)
+
+
+def detect_deferred_marker(text):
+    if not text:
+        return False
+    return bool(DEFERRED_MARKER_PATTERN.search(text))
+
+
+def send_continuity_message(instance_id, profile, dry_run=False):
+    msg = CONTINUITY_MESSAGE_TEMPLATE.format(
+        timestamp=time.strftime("%Y-%m-%d %H:%M:%S %Z")
+    )
+    if dry_run:
+        log.info("[DRY] continuity→ %s: %s", instance_id, msg)
+        return True
+    args = [AGENT_DECK_BIN]
+    if profile:
+        args += ["-p", profile]
+    args += ["session", "send", instance_id, msg, "--no-wait"]
+    rc, out, err = run_cmd(args, timeout=15)
+    if rc != 0:
+        log.warning("continuity send failed %s rc=%d err=%s", instance_id, rc, err.strip())
+        return False
+    log.info("continuity sent to %s", instance_id)
+    return True
+
+
+# ------------------------------------------------------------------
+# Telegram escalation
+# ------------------------------------------------------------------
+
+def _load_telegram_token():
+    try:
+        for line in TELEGRAM_ENV_FILE.read_text().splitlines():
+            if line.startswith("TELEGRAM_BOT_TOKEN="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        return None
+    return None
+
+
+def telegram_send(text, chat_id=None, dry_run=False):
+    if chat_id is None:
+        chat_id = TELEGRAM_ESCALATION_CHAT_ID
+    if not chat_id:
+        log.warning("telegram escalation skipped: TELEGRAM_ESCALATION_CHAT_ID env var not set")
+        return False
+    token = _load_telegram_token()
+    if not token:
+        log.warning("telegram escalation skipped: no token in %s", TELEGRAM_ENV_FILE)
+        return False
+    if dry_run:
+        log.info("[DRY] telegram→%s: %s", chat_id, text)
+        return True
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    data = urllib.parse.urlencode({
+        "chat_id": chat_id,
+        "text": text,
+    }).encode()
+    try:
+        with urllib.request.urlopen(url, data=data, timeout=10) as resp:
+            ok = resp.status == 200
+            if not ok:
+                log.warning("telegram non-200: %d", resp.status)
+            return ok
+    except Exception as e:
+        log.warning("telegram send failed: %s", e)
+        return False
+
+
+# ------------------------------------------------------------------
+# Critical-session classifier
+# ------------------------------------------------------------------
+
+def is_critical(sess):
+    """Broad: should the watchdog attempt auto-restart at all?"""
+    if not sess:
+        return False
+    title = sess.get("title") or ""
+    group = sess.get("group") or sess.get("group_path") or ""
+    sid = sess.get("id") or ""
+    is_cond = bool(sess.get("is_conductor") or sess.get("IsConductor"))
+
+    if is_cond:
+        return True
+    if group in CRITICAL_GROUPS:
+        return True
+    if any(title.startswith(p) for p in CRITICAL_TITLE_PREFIXES):
+        return True
+    if title in CRITICAL_TITLES_EXACT:
+        return True
+    if sid and (AUTORESTART_DIR / sid).exists():
+        return True
+    return False
+
+
+def is_escalation_critical(sess):
+    """Narrow: should failures escalate to Telegram?
+    Workers (exact-title allow-list, autorestart markers, group=conductor one-offs like 'test-visual')
+    get auto-restart but NOT telegram spam.
+    Telegram is reserved for: title=conductor-*  OR  group=watchers  OR  IsConductor flag."""
+    if not sess:
+        return False
+    title = sess.get("title") or ""
+    group = sess.get("group") or sess.get("group_path") or ""
+    is_cond = bool(sess.get("is_conductor") or sess.get("IsConductor"))
+    if is_cond:
+        return True
+    if title.startswith("conductor-"):
+        return True
+    if group == "watchers":
+        return True
+    return False
+
+
+# ------------------------------------------------------------------
+# v1.7.63 helpers: poller-existence check + waiting-too-long patrol
+# ------------------------------------------------------------------
+
+_ENVFILE_STATE_DIR_RE = re.compile(
+    r'^\s*(?:export\s+)?TELEGRAM_STATE_DIR\s*=\s*["\']?(.*?)["\']?\s*$'
+)
+
+
+def bun_telegram_state_dirs(proc_root="/proc"):
+    """Return the set of TELEGRAM_STATE_DIR values exported by every running
+    bun-telegram process on this host.
+
+    The agent-deck telegram plugin spawns one `bun ... telegram ... start` per
+    conductor; each such process has its conductor's TELEGRAM_STATE_DIR in its
+    environment. Enumerating those state dirs is how the watchdog decides
+    whether a given conductor's poller is currently alive.
+    """
+    rc, out, _ = run_cmd(["pgrep", "-af", "bun.*telegram"], timeout=5)
+    if rc != 0:
+        return set()
+    dirs = set()
+    for line in out.splitlines():
+        parts = line.split(None, 1)
+        if not parts or not parts[0].isdigit():
+            continue
+        pid = parts[0]
+        environ_path = Path(proc_root) / pid / "environ"
+        try:
+            raw = environ_path.read_bytes()
+        except (OSError, PermissionError):
+            continue
+        for chunk in raw.split(b"\x00"):
+            if chunk.startswith(b"TELEGRAM_STATE_DIR="):
+                dirs.add(chunk.decode("utf-8", "replace").split("=", 1)[1])
+                break
+    return dirs
+
+
+def parse_envfile_state_dir(env_file_path):
+    """Extract TELEGRAM_STATE_DIR from a conductor's env_file (a shell .envrc
+    like `export TELEGRAM_STATE_DIR=/foo/bar`). Returns None if the file is
+    missing, unreadable, or does not declare the var."""
+    if not env_file_path:
+        return None
+    try:
+        text = Path(env_file_path).read_text()
+    except OSError:
+        return None
+    for line in text.splitlines():
+        m = _ENVFILE_STATE_DIR_RE.match(line)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def compute_pane_hash(sid, profile):
+    """Cheap 'has anything changed on this pane' signal for the waiting patrol.
+    Hashes the current agent-deck session output so caller can compare snapshots
+    across ticks without storing full pane text."""
+    text = fetch_session_output(sid, profile)
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()
+
+
+def send_status_query(sid, profile, dry_run=False):
+    """Inject the 'report status?' nudge via `agent-deck session send --no-wait`.
+    Non-blocking on the receiver so a truly stuck agent doesn't stall this tick."""
+    if dry_run:
+        log.info("[DRY] status-query→ %s", sid)
+        return True
+    args = [AGENT_DECK_BIN]
+    if profile:
+        args += ["-p", profile]
+    args += ["session", "send", sid, WAITING_PATROL_NUDGE_TEXT, "--no-wait"]
+    rc, _, err = run_cmd(args, timeout=15)
+    if rc != 0:
+        log.warning("status query send failed %s rc=%d err=%s", sid, rc, err.strip()[:200])
+        return False
+    log.info("status query sent to %s", sid)
+    return True
+
+
+def poller_restart_session(sid, profile, dry_run=False):
+    """Issue a plain `agent-deck session restart <sid>` for a session whose
+    telegram poller has died. This path deliberately does NOT go through the
+    429-serialized `_do_restart` — the session itself is healthy, only its
+    out-of-band poller subprocess needs to be respawned."""
+    if dry_run:
+        log.info("[DRY] poller-restart→ %s", sid)
+        return True
+    args = [AGENT_DECK_BIN]
+    if profile:
+        args += ["-p", profile]
+    args += ["session", "restart", sid]
+    rc, _, err = run_cmd(args, timeout=60)
+    if rc != 0:
+        log.warning("poller restart failed %s rc=%d err=%s", sid, rc, err.strip()[:200])
+        return False
+    log.info("poller restart ok for %s", sid)
+    return True
+
+
+# ------------------------------------------------------------------
+# Watchdog core
+# ------------------------------------------------------------------
+
+ESCALATION_DEDUP_S = 300            # don't re-escalate same sid+severity within 5 min
+STALE_ERROR_CLEANUP_S = 600         # non-escalation-critical session in error > this → remove
+STALE_CLEANUP_SCAN_INTERVAL_S = 60  # how often to scan for stale non-criticals
+
+
+class Watchdog:
+    def __init__(self, dry_run=False):
+        self.dry_run = dry_run
+        self.restart_history = {}          # id -> deque[ts]
+        self.consecutive_failures = {}     # id -> int
+        self.cooldown_until = {}           # id -> ts
+        self.cascade_settling_until = 0.0  # during cascade window, NO restarts fire
+        self.first_error_seen_at = {}      # id -> ts of first consecutive error observation
+        self.removed_ids = set()           # ids we've auto-removed (won't retry)
+        self.last_escalation_at = {}       # (sid, severity) -> ts
+        self.lock = threading.Lock()
+        self.event_q = queue.Queue(maxsize=EVENT_QUEUE_MAXSIZE)
+        self.stop_event = threading.Event()
+        # Rate-limit state (429 handling)
+        self.restart_lock = threading.Lock()      # serialize ALL restart attempts globally
+        self.last_global_restart_at = 0.0
+        self.rate_limited_until = {}              # sid -> ts (skip restart while < ts)
+        self.recent_429s = deque()                # timestamps of recent 429 detections
+        self.circuit_breaker_until = 0.0          # if > now, pause ALL restarts
+        self.circuit_breaker_notified = False     # avoid re-telegramming the same trip
+        # v1.7.63 capability A: one restart per conductor per POLLER_RESTART_DEDUP_S
+        self.last_poller_restart_at = {}          # sid -> ts
+        # v1.7.63 capability B: per-waiting-child {first_seen_at, pane_hash, last_nudge_at}
+        self.waiting_tracker = {}
+
+    # ---- logging helpers ----
+
+    def _audit(self, path, record):
+        try:
+            with open(path, "a") as f:
+                f.write(json.dumps(record) + "\n")
+        except OSError as e:
+            log.error("audit write failed %s: %s", path, e)
+
+    def escalate(self, severity, message, telegram=False, sid=None):
+        """Log locally. Telegram only if `telegram=True` AND the (sid,severity)
+        hasn't escalated within ESCALATION_DEDUP_S. Local log also dedup'd."""
+        now = time.time()
+        dedup_key = (sid or "_global", severity)
+        last = self.last_escalation_at.get(dedup_key, 0)
+        dedup_active = (now - last) < ESCALATION_DEDUP_S
+
+        if dedup_active:
+            log.debug("escalation deduped [%s] sid=%s (last %ds ago)", severity, sid, int(now - last))
+            return
+
+        self.last_escalation_at[dedup_key] = now
+        rec = {"ts": now, "severity": severity, "message": message, "sid": sid, "telegram": telegram}
+        self._audit(ESCALATIONS_LOG, rec)
+        log.warning("ESCALATION [%s]%s %s", severity, f" telegram" if telegram else " local", message)
+        if ESCALATE_SCRIPT.exists() and os.access(ESCALATE_SCRIPT, os.X_OK):
+            try:
+                subprocess.Popen(
+                    [str(ESCALATE_SCRIPT), severity, message],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                )
+            except OSError:
+                pass
+        if telegram:
+            telegram_send(f"[agent-deck watchdog] {severity}: {message}", dry_run=self.dry_run)
+
+    # ---- gate checks ----
+
+    def _prune_history(self, now):
+        for hist in self.restart_history.values():
+            while hist and now - hist[0] > RATE_LIMIT_WINDOW_S:
+                hist.popleft()
+
+    def _in_cooldown(self, sid, now):
+        return now < self.cooldown_until.get(sid, 0)
+
+    def _rate_limited(self, sid):
+        hist = self.restart_history.get(sid)
+        return hist and len(hist) >= RATE_LIMIT_MAX
+
+    def _cascade_active(self, now):
+        return now < self.cascade_settling_until
+
+    # ---- rate-limit (429) state machine ----
+
+    def _note_429(self, sid):
+        """Record a 429 hit for `sid`. Pauses that session for API_429_BACKOFF_S
+        and (if the threshold is crossed) trips the global circuit breaker.
+        Must be called with self.lock held."""
+        now = time.time()
+        self.rate_limited_until[sid] = now + API_429_BACKOFF_S
+        self.recent_429s.append(now)
+        while self.recent_429s and now - self.recent_429s[0] > CIRCUIT_BREAKER_429_WINDOW_S:
+            self.recent_429s.popleft()
+        if (len(self.recent_429s) >= CIRCUIT_BREAKER_429_THRESHOLD
+                and now >= self.circuit_breaker_until):
+            self.circuit_breaker_until = now + CIRCUIT_BREAKER_PAUSE_S
+            if not self.circuit_breaker_notified:
+                self.circuit_breaker_notified = True
+                # Defer the telegram — we're holding self.lock.
+                threading.Thread(
+                    target=telegram_send,
+                    args=(
+                        f"[agent-deck watchdog] circuit breaker tripped — "
+                        f"{len(self.recent_429s)} API 429s in last "
+                        f"{CIRCUIT_BREAKER_429_WINDOW_S // 60} min. "
+                        f"Pausing restarts for "
+                        f"{CIRCUIT_BREAKER_PAUSE_S // 60} min.",
+                    ),
+                    kwargs={"dry_run": self.dry_run},
+                    daemon=True,
+                ).start()
+            log.warning("circuit breaker tripped until %s (%d 429s in window)",
+                        time.strftime("%H:%M:%S", time.localtime(self.circuit_breaker_until)),
+                        len(self.recent_429s))
+
+    def _circuit_broken(self, now):
+        """Must be called with self.lock held."""
+        if now < self.circuit_breaker_until:
+            return True
+        # Breaker expired — reset notification flag so a future trip re-alerts.
+        if self.circuit_breaker_until > 0:
+            self.circuit_breaker_until = 0.0
+            self.circuit_breaker_notified = False
+        return False
+
+    def _session_rate_limited(self, sid, now):
+        """Must be called with self.lock held."""
+        return now < self.rate_limited_until.get(sid, 0)
+
+    # ---- single-session restart path ----
+
+    def _poll_status(self, sid, profile, timeout_s, want_not="error"):
+        """Poll session status every 1s for up to timeout_s. Return final status."""
+        deadline = time.time() + timeout_s
+        last = ""
+        while time.time() < deadline:
+            detail = show_session(sid, profile=profile)
+            status = (detail.get("status") if detail else "") or ""
+            last = status
+            if status.lower() != want_not:
+                return status
+            time.sleep(1.0)
+        return last
+
+    def _restart_or_start(self, sid, profile):
+        """Call `session restart`, verify status recovered; if not, fall back to `session start`.
+        Returns (ok, final_status, err_msg)."""
+        base = [AGENT_DECK_BIN]
+        if profile:
+            base += ["-p", profile]
+        rc, _, err = run_cmd(base + ["session", "restart", sid], timeout=60)
+        if rc != 0:
+            return False, None, f"restart rc={rc}: {err.strip()[:200]}"
+        # Restart can silently no-op when tmux was fully dead. Poll up to 4s first.
+        status = self._poll_status(sid, profile, timeout_s=4)
+        if status.lower() != "error":
+            return True, status, None
+        log.warning("%s still in error after restart; falling back to session start", sid)
+        rc2, _, err2 = run_cmd(base + ["session", "start", sid], timeout=60)
+        if rc2 != 0:
+            return False, status, f"fallback start rc={rc2}: {err2.strip()[:200]}"
+        # `start` can take longer — tmux bootstrap + claude cold start.
+        status2 = self._poll_status(sid, profile, timeout_s=15)
+        if status2.lower() == "error":
+            return False, status2, "fallback start returned success but status still error after 15s"
+        return True, status2, None
+
+    def _prompt_resume_personal(self, sid, profile):
+        """One-shot `claude --resume <claude_sid> -p "continue..."` to burn a
+        stale deferred-tool marker. Scoped to profile=personal per user spec.
+        Returns (ok, rate_limited_detected)."""
+        if profile != "personal":
+            return False, False
+        detail = show_session(sid, profile=profile)
+        if not detail:
+            return False, False
+        claude_sid = detail.get("claude_session_id") or ""
+        if not claude_sid:
+            log.info("prompt-resume: no claude_session_id for %s, skip", sid)
+            return False, False
+        config_dir = PROFILE_CONFIG_DIRS.get(profile)
+        if not config_dir:
+            return False, False
+        env = os.environ.copy()
+        env["CLAUDE_CONFIG_DIR"] = config_dir
+        # Strip any inherited TELEGRAM_STATE_DIR to avoid the plugin spawning a
+        # second bot poller (see bug_child_session_telegram_poller_leak).
+        env.pop("TELEGRAM_STATE_DIR", None)
+        log.info("prompt-resume: claude --resume %s -p '<continuity>' (profile=%s)", claude_sid, profile)
+        try:
+            res = subprocess.run(
+                ["claude", "--resume", claude_sid,
+                 "--dangerously-skip-permissions",
+                 "-p", PROMPT_RESUME_TEXT],
+                env=env, capture_output=True, text=True,
+                timeout=PROMPT_RESUME_TIMEOUT_S, check=False,
+            )
+        except subprocess.TimeoutExpired:
+            log.warning("prompt-resume TIMEOUT for %s", sid)
+            return False, False
+        except FileNotFoundError:
+            log.error("prompt-resume: claude binary not found")
+            return False, False
+        combined = (res.stdout or "") + "\n" + (res.stderr or "")
+        if detect_rate_limit(combined):
+            log.warning("prompt-resume: 429 detected for %s", sid)
+            return False, True
+        ok = (res.returncode == 0)
+        log.info("prompt-resume %s rc=%d ok=%s (out=%d bytes)", sid, res.returncode, ok, len(combined))
+        return ok, False
+
+    def _do_restart(self, sid, title, profile, escalate_critical=False):
+        """Fire the restart (with start-fallback) + continuity message. Returns True on success.
+
+        Serialized globally via `self.restart_lock` — only one restart in-flight
+        at a time, and each attempt is spaced at least MIN_GLOBAL_RESTART_INTERVAL_S
+        from the previous one. This is the primary defense against 429 cascades.
+        """
+        # Global serialization: wait for any in-flight restart to finish, and
+        # enforce the minimum inter-restart interval.
+        with self.restart_lock:
+            now = time.time()
+            wait = (self.last_global_restart_at + MIN_GLOBAL_RESTART_INTERVAL_S) - now
+            if wait > 0:
+                log.info("serialize: waiting %.1fs before restarting %s (%s)", wait, sid, title)
+                # Interruptible sleep — stop_event lets --once/sigterm bail out cleanly.
+                self.stop_event.wait(wait)
+                if self.stop_event.is_set():
+                    return False
+
+            # Re-check circuit breaker and rate-limit state now that we've waited.
+            with self.lock:
+                if self._circuit_broken(time.time()):
+                    log.info("circuit breaker active, aborting restart of %s", sid)
+                    return False
+                if self._session_rate_limited(sid, time.time()):
+                    log.info("%s still rate-limited, aborting restart", sid)
+                    return False
+
+            log.info("RESTART %s (%s) profile=%s dry_run=%s", sid, title, profile, self.dry_run)
+            self._audit(RESTART_LOG, {
+                "ts": time.time(), "id": sid, "title": title, "profile": profile,
+                "dry_run": self.dry_run,
+            })
+            if self.dry_run:
+                self.last_global_restart_at = time.time()
+                return True
+            ok, final_status, err_msg = self._restart_or_start(sid, profile)
+            self.last_global_restart_at = time.time()
+
+            # Inspect pane output if we failed — distinguish 429 from real crash
+            # from deferred-tool-marker (where the -p fallback can help).
+            if not ok:
+                pane_text = fetch_session_output(sid, profile)
+                if detect_rate_limit(pane_text):
+                    log.warning("rate-limit (429) detected for %s — backing off %ds, NOT counted as crash",
+                                sid, API_429_BACKOFF_S)
+                    self._audit(RESTART_LOG, {
+                        "ts": time.time(), "id": sid, "title": title, "profile": profile,
+                        "action": "rate-limited", "backoff_s": API_429_BACKOFF_S,
+                    })
+                    with self.lock:
+                        self._note_429(sid)
+                    return False
+                # Deferred-tool-marker fallback — scoped to personal profile.
+                if profile == "personal" and detect_deferred_marker(pane_text):
+                    log.info("deferred-tool-marker detected for %s — trying -p prompt-resume", sid)
+                    self._audit(RESTART_LOG, {
+                        "ts": time.time(), "id": sid, "title": title, "profile": profile,
+                        "action": "prompt-resume-attempt",
+                    })
+                    resumed, was_rate_limited = self._prompt_resume_personal(sid, profile)
+                    if was_rate_limited:
+                        with self.lock:
+                            self._note_429(sid)
+                        return False
+                    if resumed:
+                        # Marker is burned — retry `agent-deck session start` to
+                        # get the session back into its normal tmux scope.
+                        base = [AGENT_DECK_BIN]
+                        if profile:
+                            base += ["-p", profile]
+                        rc3, _, err3 = run_cmd(base + ["session", "start", sid], timeout=60)
+                        if rc3 == 0:
+                            status3 = self._poll_status(sid, profile, timeout_s=15)
+                            if status3.lower() != "error":
+                                log.info("prompt-resume recovery OK for %s final_status=%s", sid, status3)
+                                self.consecutive_failures[sid] = 0
+                                self.first_error_seen_at.pop(sid, None)
+                                ok = True
+                                final_status = status3
+                                err_msg = None
+                        if not ok:
+                            log.warning("prompt-resume ran but session %s is still in error", sid)
+
+            if not ok:
+                n = self.consecutive_failures.get(sid, 0) + 1
+                self.consecutive_failures[sid] = n
+                log.error("restart FAILED %s: %s", sid, err_msg)
+                if n >= 2:
+                    self.escalate(
+                        "restart-failed",
+                        f"{title} ({sid}) failed to restart {n}x consecutively; last err: {err_msg}",
+                        telegram=escalate_critical,
+                        sid=sid,
+                    )
+                return False
+            self.consecutive_failures[sid] = 0
+            self.first_error_seen_at.pop(sid, None)  # clear stale-error timer on recovery
+            log.info("restart OK %s final_status=%s", sid, final_status)
+            def _send_continuity():
+                time.sleep(2.0)
+                send_continuity_message(sid, profile, dry_run=self.dry_run)
+            threading.Thread(target=_send_continuity, daemon=True).start()
+            return True
+
+    def maybe_restart(self, sess_summary):
+        sid = sess_summary.get("id")
+        title = sess_summary.get("title", "?")
+        profile = sess_summary.get("profile")
+        if not sid:
+            return
+        if sid in self.removed_ids:
+            return
+
+        # Fast-path status check outside the lock — avoids rate-limit false positives
+        # on an already-recovered session, and avoids holding the lock during subprocess.
+        detail = show_session(sid, profile=profile)
+        if not detail:
+            return
+        status = (detail.get("status") or "").lower()
+        if status != "error":
+            log.debug("session %s status=%s (not error), skip", sid, status)
+            with self.lock:
+                self.first_error_seen_at.pop(sid, None)
+            return
+
+        # Escalation-critical is a stricter classification than restart-critical.
+        # Workers (exact-title allow-list, autorestart markers, one-offs in group=conductor)
+        # still get auto-restart attempts but DO NOT escalate to Telegram.
+        escalate_critical = is_escalation_critical(sess_summary) or is_escalation_critical(detail)
+
+        with self.lock:
+            now = time.time()
+            self._prune_history(now)
+            self.first_error_seen_at.setdefault(sid, now)
+
+            if self._circuit_broken(now):
+                log.debug("circuit breaker active; skipping %s (until %s)",
+                          sid, time.strftime("%H:%M:%S", time.localtime(self.circuit_breaker_until)))
+                return
+            if self._session_rate_limited(sid, now):
+                log.debug("session %s in 429 backoff until %s; skip",
+                          sid, time.strftime("%H:%M:%S", time.localtime(self.rate_limited_until[sid])))
+                return
+            if self._cascade_active(now):
+                log.debug("cascade settling active; skipping %s", sid)
+                return
+            if self._in_cooldown(sid, now):
+                return
+            if self._rate_limited(sid):
+                # Dedup'd inside escalate(); workers never telegram.
+                self.escalate(
+                    "rate-limit",
+                    f"Session {title} ({sid}) keeps crashing — needs human attention",
+                    telegram=escalate_critical,
+                    sid=sid,
+                )
+                return
+
+            self.restart_history.setdefault(sid, deque()).append(now)
+            self.cooldown_until[sid] = now + POST_RESTART_COOLDOWN_S
+
+        self._do_restart(sid, title, profile, escalate_critical=escalate_critical)
+
+    # ---- cascade detection + batch revive ----
+
+    def _scan_critical_error_sessions(self):
+        """Return list of (id, title, profile) for all critical sessions currently in error."""
+        errored = []
+        for s in list_all_sessions():
+            if not is_critical(s):
+                continue
+            detail = show_session(s.get("id"), profile=s.get("profile"))
+            if not detail:
+                continue
+            if (detail.get("status") or "").lower() == "error":
+                errored.append((s.get("id"), s.get("title") or "?", s.get("profile")))
+        return errored
+
+    def _maybe_trigger_cascade(self):
+        """Called by safety poll. If ≥ THRESHOLD criticals are in error, enter
+        cascade mode: wait CASCADE_WAIT_S, then batch-revive all still-errored."""
+        now = time.time()
+        with self.lock:
+            if self._cascade_active(now):
+                return False
+        errored = self._scan_critical_error_sessions()
+        if len(errored) < CASCADE_THRESHOLD:
+            return False
+
+        self.escalate(
+            "cascade-detected",
+            f"{len(errored)} critical sessions in error simultaneously — waiting {CASCADE_WAIT_S}s to stabilize, then batch-reviving",
+            telegram=True,
+        )
+        with self.lock:
+            self.cascade_settling_until = now + CASCADE_WAIT_S
+
+        def _batch_revive():
+            time.sleep(CASCADE_WAIT_S)
+            # Re-scan and pull full session summaries so we can compute escalation criticality
+            snapshot = {s.get("id"): s for s in list_all_sessions() if s.get("id")}
+            still_errored = self._scan_critical_error_sessions()
+            log.info("cascade settle complete; %d still in error, reviving SERIALLY (1/min)", len(still_errored))
+            # SERIAL revive — _do_restart acquires restart_lock and enforces
+            # MIN_GLOBAL_RESTART_INTERVAL_S spacing, so running sequentially here
+            # is what we want. The original parallel-thread design was exactly
+            # what caused the 2026-04-20 429 cascade (9 simultaneous API calls).
+            for sid, title, profile in still_errored:
+                if self.stop_event.is_set():
+                    break
+                summary = snapshot.get(sid, {})
+                is_esc = is_escalation_critical(summary)
+                with self.lock:
+                    now = time.time()
+                    if self._circuit_broken(now):
+                        log.info("batch-revive: circuit breaker tripped mid-batch, aborting remaining restarts")
+                        break
+                    if self._session_rate_limited(sid, now):
+                        log.info("batch-revive: %s in 429 backoff, skip", sid)
+                        continue
+                    if self._rate_limited(sid):
+                        self.escalate(
+                            "rate-limit",
+                            f"Session {title} ({sid}) keeps crashing — needs human attention",
+                            telegram=is_esc,
+                            sid=sid,
+                        )
+                        continue
+                    self.restart_history.setdefault(sid, deque()).append(now)
+                    self.cooldown_until[sid] = now + POST_RESTART_COOLDOWN_S
+                # _do_restart is blocking and globally serialized via restart_lock.
+                self._do_restart(sid, title, profile, escalate_critical=is_esc)
+            with self.lock:
+                self.cascade_settling_until = 0
+
+        threading.Thread(target=_batch_revive, name="cascade-revive", daemon=True).start()
+        return True
+
+    # ---- triggers ----
+
+    def inotify_listener(self):
+        if not HOOKS_DIR.exists():
+            log.warning("hooks dir missing: %s — inotify disabled", HOOKS_DIR)
+            return
+        while not self.stop_event.is_set():
+            try:
+                log.info("inotify start on %s", HOOKS_DIR)
+                proc = subprocess.Popen(
+                    ["inotifywait", "-m", "-q",
+                     "-e", "close_write,moved_to",
+                     "--format", "%f",
+                     str(HOOKS_DIR)],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                )
+                for line in proc.stdout:
+                    if self.stop_event.is_set():
+                        break
+                    name = line.strip()
+                    if not name.endswith(".json"):
+                        continue
+                    instance_id = name[:-5].split("-")[0]
+                    try:
+                        self.event_q.put_nowait(("inotify", instance_id))
+                    except queue.Full:
+                        pass
+                proc.terminate()
+            except Exception as e:
+                log.error("inotify listener crashed: %s; retrying in 5s", e)
+                time.sleep(5)
+
+    def _stale_cleanup_scan(self):
+        """Silently remove sessions that:
+          - have been in error state for > STALE_ERROR_CLEANUP_S, AND
+          - are NOT escalation-critical (i.e. workers / one-offs, not real conductors)
+        Critical sessions are NEVER auto-removed — they need human attention."""
+        now = time.time()
+        for s in list_all_sessions():
+            sid = s.get("id")
+            if not sid or sid in self.removed_ids:
+                continue
+            if not is_critical(s):
+                continue  # we only track sessions we're responsible for
+            if is_escalation_critical(s):
+                continue  # never auto-remove real conductors
+            detail = show_session(sid, profile=s.get("profile"))
+            if not detail:
+                continue
+            status = (detail.get("status") or "").lower()
+            if status != "error":
+                with self.lock:
+                    self.first_error_seen_at.pop(sid, None)
+                continue
+            with self.lock:
+                first = self.first_error_seen_at.setdefault(sid, now)
+                stuck_for = now - first
+            if stuck_for < STALE_ERROR_CLEANUP_S:
+                continue
+            # Time's up — evict.
+            title = s.get("title") or "?"
+            profile = s.get("profile")
+            log.warning("stale-cleanup: removing non-critical session %s (%s) stuck in error for %.0fs",
+                        sid, title, stuck_for)
+            args = [AGENT_DECK_BIN]
+            if profile:
+                args += ["-p", profile]
+            args += ["remove", sid]
+            rc, _, err = run_cmd(args, timeout=20)
+            if rc == 0:
+                with self.lock:
+                    self.removed_ids.add(sid)
+                    self.first_error_seen_at.pop(sid, None)
+                    self.restart_history.pop(sid, None)
+                    self.cooldown_until.pop(sid, None)
+                self._audit(RESTART_LOG, {
+                    "ts": now, "id": sid, "title": title, "profile": profile,
+                    "action": "stale-removed", "stuck_for_s": int(stuck_for),
+                })
+                # Local-only log, NO telegram (these are noisy one-offs, that's the whole point)
+                log.info("stale-cleanup: removed %s (%s)", sid, title)
+            else:
+                log.warning("stale-cleanup: failed to remove %s rc=%d err=%s", sid, rc, err.strip()[:200])
+
+    def safety_poll(self):
+        last_stale_scan = 0.0
+        while not self.stop_event.is_set():
+            try:
+                if not self._maybe_trigger_cascade():
+                    sessions = list_all_sessions()
+                    for s in sessions:
+                        if is_critical(s) and s.get("id") not in self.removed_ids:
+                            try:
+                                self.event_q.put_nowait(("poll", s))
+                            except queue.Full:
+                                pass
+                now = time.time()
+                if now - last_stale_scan > STALE_CLEANUP_SCAN_INTERVAL_S:
+                    self._stale_cleanup_scan()
+                    last_stale_scan = now
+            except Exception as e:
+                log.error("safety poll error: %s", e)
+            self.stop_event.wait(SAFETY_POLL_INTERVAL_S)
+
+    def dispatcher(self):
+        cache = {}
+        cache_refreshed = 0.0
+        CACHE_TTL_S = 10.0
+        while not self.stop_event.is_set():
+            try:
+                kind, payload = self.event_q.get(timeout=1.0)
+            except queue.Empty:
+                continue
+            try:
+                if kind == "poll":
+                    if is_critical(payload):
+                        self.maybe_restart(payload)
+                elif kind == "inotify":
+                    now = time.time()
+                    if now - cache_refreshed > CACHE_TTL_S:
+                        sessions = list_all_sessions()
+                        cache = {s.get("id"): s for s in sessions if s.get("id")}
+                        cache_refreshed = now
+                    sess = cache.get(payload)
+                    if sess and is_critical(sess):
+                        self.maybe_restart(sess)
+            except Exception as e:
+                log.error("dispatcher error: %s", e)
+
+    # ---- v1.7.63 capability A: poller-existence check ----
+
+    def check_poller_existence(self, now=None):
+        """For each conductor session whose `channels` declares the telegram
+        plugin, verify a bun-telegram process with the matching TELEGRAM_STATE_DIR
+        is running. If missing, fire one `agent-deck session restart <sid>` —
+        deduped to at most one per conductor per POLLER_RESTART_DEDUP_S.
+
+        Returns the list of session IDs for which a restart was actually issued
+        (for test and log observability)."""
+        if now is None:
+            now = time.time()
+        running_state_dirs = bun_telegram_state_dirs()
+        restarted = []
+        for sess in list_all_sessions():
+            sid = sess.get("id")
+            if not sid:
+                continue
+            channels = sess.get("channels") or []
+            if TELEGRAM_CHANNEL_NAME not in channels:
+                continue
+            expected = parse_envfile_state_dir(sess.get("env_file"))
+            if not expected:
+                continue
+            if expected in running_state_dirs:
+                continue
+            last = self.last_poller_restart_at.get(sid, 0.0)
+            if now - last < POLLER_RESTART_DEDUP_S:
+                log.debug("poller missing for %s but dedup-gated (%.0fs ago)",
+                          sid, now - last)
+                continue
+            log.warning("telegram poller missing for %s (expected state_dir=%s) — restarting session",
+                        sid, expected)
+            ok = poller_restart_session(sid, sess.get("profile"), dry_run=self.dry_run)
+            if ok:
+                self.last_poller_restart_at[sid] = now
+                restarted.append(sid)
+        return restarted
+
+    # ---- v1.7.63 capability B: waiting-too-long patrol ----
+
+    def check_waiting_too_long(self, now=None):
+        """For each child session (parent_session_id set) in status=waiting,
+        check whether its pane has been unchanged for >WAITING_PATROL_THRESHOLD_S.
+        If so, inject a 'report status?' nudge via `agent-deck session send`.
+        Dedup at most one nudge per session per WAITING_PATROL_NUDGE_DEDUP_S.
+
+        Returns the list of session IDs that were nudged this tick."""
+        if now is None:
+            now = time.time()
+        nudged = []
+        active_sids = set()
+        for sess in list_all_sessions():
+            sid = sess.get("id")
+            if not sid:
+                continue
+            if not sess.get("parent_session_id"):
+                continue
+            status = (sess.get("status") or "").lower()
+            if status != "waiting":
+                continue
+            active_sids.add(sid)
+            pane_hash = compute_pane_hash(sid, sess.get("profile"))
+            tracker = self.waiting_tracker.get(sid)
+            if tracker is None or tracker["pane_hash"] != pane_hash:
+                self.waiting_tracker[sid] = {
+                    "first_seen_at": now,
+                    "pane_hash": pane_hash,
+                    "last_nudge_at": tracker["last_nudge_at"] if tracker else 0.0,
+                }
+                continue
+            if now - tracker["first_seen_at"] < WAITING_PATROL_THRESHOLD_S:
+                continue
+            last_nudge = tracker["last_nudge_at"]
+            if last_nudge and now - last_nudge < WAITING_PATROL_NUDGE_DEDUP_S:
+                continue
+            log.warning("session %s waiting > %ds with unchanged pane — nudging",
+                        sid, int(now - tracker["first_seen_at"]))
+            if send_status_query(sid, sess.get("profile"), dry_run=self.dry_run):
+                tracker["last_nudge_at"] = now
+                nudged.append(sid)
+        # Cull tracker entries for sessions that are no longer waiting.
+        for sid in list(self.waiting_tracker.keys()):
+            if sid not in active_sids:
+                self.waiting_tracker.pop(sid, None)
+        return nudged
+
+    def run(self):
+        threads = [
+            threading.Thread(target=self.inotify_listener, name="inotify", daemon=True),
+            threading.Thread(target=self.safety_poll, name="poll", daemon=True),
+            threading.Thread(target=self.dispatcher, name="dispatch", daemon=True),
+        ]
+        for t in threads:
+            t.start()
+        while not self.stop_event.is_set():
+            time.sleep(1)
+
+    def stop(self):
+        self.stop_event.set()
+
+
+# ------------------------------------------------------------------
+# CLI
+# ------------------------------------------------------------------
+
+def setup_logging(verbose=False):
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(threadName)s: %(message)s",
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--once", action="store_true")
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args()
+
+    setup_logging(verbose=args.verbose)
+    WATCHDOG_DIR.mkdir(parents=True, exist_ok=True)
+    AUTORESTART_DIR.mkdir(parents=True, exist_ok=True)
+
+    wd = Watchdog(dry_run=args.dry_run)
+
+    if args.once:
+        log.info("--once: running single safety poll (cascade check + critical-error scan)")
+        if wd._maybe_trigger_cascade():
+            log.info("cascade triggered; waiting for batch revive to finish")
+            time.sleep(CASCADE_WAIT_S + 10)
+        else:
+            for s in list_all_sessions():
+                if is_critical(s):
+                    log.info("critical candidate: %s (%s) profile=%s",
+                             s.get("id"), s.get("title"), s.get("profile"))
+                    wd.maybe_restart(s)
+            # give continuity-send threads a moment
+            time.sleep(3)
+        return 0
+
+    def sigterm(signum, frame):
+        log.info("signal %d received, shutting down", signum)
+        wd.stop()
+
+    signal.signal(signal.SIGTERM, sigterm)
+    signal.signal(signal.SIGINT, sigterm)
+    log.info("watchdog starting dry_run=%s", args.dry_run)
+    try:
+        wd.run()
+    finally:
+        wd.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Lift-and-shift** `watchdog.py` + `test_watchdog.py` from a private host copy into `scripts/watchdog/` so every user benefits through normal releases, not just the one host where the watchdog was born. `DESIGN.md`'s original "external-only; zero new mandate territory" non-goal is explicitly retired in the same commit.
- **Capability A — telegram-poller existence check:** for each conductor session declaring `plugin:telegram@claude-plugins-official` in `channels`, verify a matching bun-telegram process is alive (pgrep + `/proc/<pid>/environ` → TELEGRAM_STATE_DIR), else issue `agent-deck session restart <id>`. Deduped to 1 per session per hour.
- **Capability B — waiting-too-long patrol:** for each child session (`parent_session_id` set) stuck in `status=waiting` with an unchanged pane hash for >10 min, inject `"report status?"` via `agent-deck session send --no-wait`. Deduped to 1 nudge per session per hour; pane change resets the timer.
- `cmd/agent-deck/main.go` → Version = `1.7.63`. CHANGELOG.md updated. `internal/releasetests/manifest_test.go` funcDeclForName extended to accept Python `def` so the new `scripts/watchdog/test_watchdog.py` entries pass the drift check. 14 new `v1763-watchdog-*` entries in `.claude/release-tests.yaml`.

## Why

Both bugs are real production pain. (A) A single bun-telegram crash today leaves the conductor silently unreachable via its Telegram bot — the session is healthy but its channel is deaf. (B) Child sub-agents occasionally get stuck waiting on a deferred tool call with the pane frozen; they never self-report, so the parent has no signal to re-engage. Both now self-heal.

## Sanitization

`git diff | grep -E '<home-token>|<user-id>|<telegram-token-regex>'` → **0 hits** on the committed diff. `TELEGRAM_ESCALATION_CHAT_ID` no longer has a hardcoded default; env-var only (misconfigured hosts fail loud with a warning instead of silently posting to a stale chat).

## Test plan

- [x] 24 new Python tests written RED-first, watched fail with `AttributeError`, then green in 13 ms after implementation.
- [x] All 62 Python tests pass (38 pre-existing + 24 new) — `python3 -m unittest scripts.watchdog.test_watchdog` → `Ran 62 tests in 540.041s / OK`.
- [x] `go build ./...` OK.
- [x] `go vet ./...` OK.
- [x] `go test ./...` green (full suite, 72.89 s per pre-push gate).
- [x] `go test ./internal/releasetests/` green — `TestManifestIsValidYAML` + `TestManifestReferencesExistInSource` both pass with the 14 new Python entries (funcDeclForName accepts `def`).
- [x] `agent-deck --version` prints `Agent Deck v1.7.63`.
- [x] Pre-push gate (lefthook): css-verify, lint, test, build, release-tests-yaml-lint — all green.
