### PR TITLE
docs: scrub host-private paths and add user-facing guides for conductor/watchdog/skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ __pycache__/
 
 # Claude harness lock (per-session, never committed)
 .claude/scheduled_tasks.lock
+
+# Internal planning / scratch (design docs, phase plans) — private to maintainer host
+.planning/

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -19,8 +19,8 @@ progress:
 ## Project Reference
 
 **Project:** Agent Deck
-**Repository:** /home/ashesh-goplani/agent-deck
-**Worktree:** /home/ashesh-goplani/agent-deck/.worktrees/watcher-completion
+**Repository:** <repo-root>
+**Worktree:** <repo-root>/.worktrees/watcher-completion
 **Branch:** feat/watcher-completion (off main after v1.5.4 merges locally)
 **Current version:** v1.5.4 (local hotfix series, unpushed)
 **Target version:** v1.6.0

--- a/.planning/phases/01-custom-command-injection-core-regression-tests/01-01-PLAN.md
+++ b/.planning/phases/01-custom-command-injection-core-regression-tests/01-01-PLAN.md
@@ -56,8 +56,8 @@ Output: New file `internal/session/pergroupconfig_test.go` with four tests. ~3-l
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/per-group-claude-config/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/per-group-claude-config/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/01-persistence-test-scaffolding-red/01-PLAN.md
+++ b/.planning/phases/01-persistence-test-scaffolding-red/01-PLAN.md
@@ -46,8 +46,8 @@ Output: A compilable Go test file with helpers + 2 tests. Subsequent plans will 
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/01-persistence-test-scaffolding-red/02-PLAN.md
+++ b/.planning/phases/01-persistence-test-scaffolding-red/02-PLAN.md
@@ -46,8 +46,8 @@ Output: Same test file, now containing 4 of the 8 tests. `go vet` still passes. 
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/01-persistence-test-scaffolding-red/03-PLAN.md
+++ b/.planning/phases/01-persistence-test-scaffolding-red/03-PLAN.md
@@ -53,8 +53,8 @@ Output: The test file contains all 8 `TestPersistence_*` tests. Full suite run o
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/01-persistence-test-scaffolding-red/03-SUMMARY.md
+++ b/.planning/phases/01-persistence-test-scaffolding-red/03-SUMMARY.md
@@ -118,7 +118,7 @@ Plan metadata commit: pending (orchestrator will make the final doc commit with 
 
 **2. [Rule 3 — Blocking] CLAUDE_CONFIG_DIR env-var poisons sessionHasConversationData**
 - **Found during:** Task 2 after fix 1 (TEST-06/07 captured argv correctly; TEST-05 showed `--session-id` instead of expected `--resume`)
-- **Issue:** After capturing argv, TEST-05 showed Restart() correctly routed through `buildClaudeResumeCommand()` but the function emitted `--session-id` — meaning `sessionHasConversationData()` returned false. Debug trace revealed `GetClaudeConfigDir()` returned `/home/ashesh-goplani/.claude` (the executor user's real home) instead of the isolated HOME's `.claude/`. Root cause: `CLAUDE_CONFIG_DIR=/home/ashesh-goplani/.claude` is pre-set in the executor's environment, and `GetClaudeConfigDir()` at claude.go:234 short-circuits to that env var.
+- **Issue:** After capturing argv, TEST-05 showed Restart() correctly routed through `buildClaudeResumeCommand()` but the function emitted `--session-id` — meaning `sessionHasConversationData()` returned false. Debug trace revealed `GetClaudeConfigDir()` returned `~/.claude` (the executor user's real home) instead of the isolated HOME's `.claude/`. Root cause: `CLAUDE_CONFIG_DIR=~/.claude` is pre-set in the executor's environment, and `GetClaudeConfigDir()` at claude.go:234 short-circuits to that env var.
 - **Fix:** `t.Setenv("CLAUDE_CONFIG_DIR", "")` inside `setupStubClaudeOnPATH`. `GetClaudeConfigDir()` checks `envDir != ""` so empty-string-set is equivalent to unset; falls through to `filepath.Join(os.UserHomeDir(), ".claude")` under the isolated HOME.
 - **Files modified:** same file (same commit)
 - **Commit:** `e1c9333`

--- a/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-01-PLAN.md
+++ b/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-01-PLAN.md
@@ -42,8 +42,8 @@ Output: One new function in `userconfig.go`, one cache var, one reset function, 
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/.claude/get-shit-done/templates/summary.md
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-02-PLAN.md
+++ b/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-02-PLAN.md
@@ -48,8 +48,8 @@ Output: one struct field type change, one rewritten getter (4 lines → ~7 lines
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/.claude/get-shit-done/templates/summary.md
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-03-PLAN.md
+++ b/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-03-PLAN.md
@@ -42,8 +42,8 @@ Output: One new exported function `LogCgroupIsolationDecision()` plus a `sync.On
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/.claude/get-shit-done/templates/summary.md
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-04-PLAN.md
+++ b/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-04-PLAN.md
@@ -44,8 +44,8 @@ Output: a small (~15 line) addition to the failure handler in `internal/tmux/tmu
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/.claude/get-shit-done/templates/summary.md
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-05-PLAN.md
+++ b/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-05-PLAN.md
@@ -40,8 +40,8 @@ Output: One small comment-only edit to `internal/session/userconfig.go`, one ful
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/.claude/get-shit-done/templates/summary.md
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-05-SUMMARY.md
+++ b/.planning/phases/02-cgroup-isolation-default-req-1-fix/02-05-SUMMARY.md
@@ -244,10 +244,10 @@ No `agentdeck-tmux-*.scope` units are currently active on this host. Rationale c
 
 ```
 $ ls -la ~/.agent-deck/logs/
-drwxr-xr-x  3 ashesh-goplani ashesh-goplani   4096 Apr  6 06:36 .
-drwxr-xr-x 17 ashesh-goplani ashesh-goplani   4096 Apr 14 11:37 ..
-drwxr-xr-x  2 ashesh-goplani ashesh-goplani   4096 Apr  6 09:46 mcppool
--rw-r--r--  1 ashesh-goplani ashesh-goplani 274087 Apr 14 13:38 session-id-lifecycle.jsonl
+drwxr-xr-x  3 <user> <user>   4096 Apr  6 06:36 .
+drwxr-xr-x 17 <user> <user>   4096 Apr 14 11:37 ..
+drwxr-xr-x  2 <user> <user>   4096 Apr  6 09:46 mcppool
+-rw-r--r--  1 <user> <user> 274087 Apr 14 13:38 session-id-lifecycle.jsonl
 
 $ grep 'tmux cgroup isolation' ~/.agent-deck/logs/*.log
 (no *.log file present yet — will be created on next CLI invocation that emits via logging.ForComponent)

--- a/.planning/phases/02-env-file-source-semantics-observability-conductor-e2e/02-01-PLAN.md
+++ b/.planning/phases/02-env-file-source-semantics-observability-conductor-e2e/02-01-PLAN.md
@@ -84,8 +84,8 @@ Output:
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/per-group-claude-config/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/per-group-claude-config/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>
@@ -395,7 +395,7 @@ From internal/session/pergroupconfig_test.go (existing — do not modify tests 1
     Do NOT add Claude attribution. Do NOT use `--no-verify`. If lefthook (gofmt + go vet) fails, fix the underlying issue and re-stage.
   </action>
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config && gofmt -l internal/session/pergroupconfig_test.go && go vet ./internal/session/... && grep -c "^func TestPerGroupConfig_" internal/session/pergroupconfig_test.go</automated>
+    <automated>cd <repo-root>/.worktrees/per-group-claude-config && gofmt -l internal/session/pergroupconfig_test.go && go vet ./internal/session/... && grep -c "^func TestPerGroupConfig_" internal/session/pergroupconfig_test.go</automated>
   </verify>
   <done>
     - `internal/session/pergroupconfig_test.go` compiles (`go vet` exits 0).
@@ -507,7 +507,7 @@ From internal/session/pergroupconfig_test.go (existing — do not modify tests 1
     Do NOT use `--no-verify`. Do NOT add Claude attribution.
   </action>
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config && go test ./internal/session/... -run TestPerGroupConfig_ -race -count=1 -v 2>&1 | tee /tmp/pergroupconfig-envfile-green.log && grep -cE "^--- PASS: TestPerGroupConfig_" /tmp/pergroupconfig-envfile-green.log</automated>
+    <automated>cd <repo-root>/.worktrees/per-group-claude-config && go test ./internal/session/... -run TestPerGroupConfig_ -race -count=1 -v 2>&1 | tee /tmp/pergroupconfig-envfile-green.log && grep -cE "^--- PASS: TestPerGroupConfig_" /tmp/pergroupconfig-envfile-green.log</automated>
   </verify>
   <done>
     - `/tmp/pergroupconfig-envfile-red.log` exists and captures the RED state. Expected: assertion B failed (`CFG-03 gap at instance.go:598`).

--- a/.planning/phases/02-env-file-source-semantics-observability-conductor-e2e/02-02-PLAN.md
+++ b/.planning/phases/02-env-file-source-semantics-observability-conductor-e2e/02-02-PLAN.md
@@ -92,8 +92,8 @@ Output:
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/per-group-claude-config/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/per-group-claude-config/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>
@@ -626,7 +626,7 @@ Test patterns to reuse (from existing pergroupconfig_test.go tests 1/2 and plan 
     Do NOT add Claude attribution. Do NOT use `--no-verify`.
   </action>
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config && gofmt -l internal/session/pergroupconfig_test.go internal/session/claude.go internal/session/instance.go && go vet ./internal/session/... && grep -c "^func TestPerGroupConfig_" internal/session/pergroupconfig_test.go && go test -run 'TestPerGroupConfig_ClaudeConfigDirSourceLabel|TestPerGroupConfig_ClaudeConfigResolutionLogFormat|TestPerGroupConfig_ConductorRestartPreservesConfigDir' ./internal/session/... -race -count=1 2>&1 | tee /tmp/pergroupconfig-plan2-red.log; grep -cE "^--- FAIL: TestPerGroupConfig_(ClaudeConfigDirSourceLabel|ClaudeConfigResolutionLogFormat)" /tmp/pergroupconfig-plan2-red.log</automated>
+    <automated>cd <repo-root>/.worktrees/per-group-claude-config && gofmt -l internal/session/pergroupconfig_test.go internal/session/claude.go internal/session/instance.go && go vet ./internal/session/... && grep -c "^func TestPerGroupConfig_" internal/session/pergroupconfig_test.go && go test -run 'TestPerGroupConfig_ClaudeConfigDirSourceLabel|TestPerGroupConfig_ClaudeConfigResolutionLogFormat|TestPerGroupConfig_ConductorRestartPreservesConfigDir' ./internal/session/... -race -count=1 2>&1 | tee /tmp/pergroupconfig-plan2-red.log; grep -cE "^--- FAIL: TestPerGroupConfig_(ClaudeConfigDirSourceLabel|ClaudeConfigResolutionLogFormat)" /tmp/pergroupconfig-plan2-red.log</automated>
   </verify>
   <done>
     - `internal/session/pergroupconfig_test.go` now contains 8 `TestPerGroupConfig_*` functions (`grep -c "^func TestPerGroupConfig_"` returns 8: tests 1/2/3/4/6 from prior phases plus 5, SourceLabel, LogFormat).
@@ -825,7 +825,7 @@ Test patterns to reuse (from existing pergroupconfig_test.go tests 1/2 and plan 
     Do NOT add Claude attribution. Do NOT use `--no-verify`.
   </action>
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config && gofmt -l internal/session/claude.go internal/session/instance.go && go vet ./internal/session/... && go test ./internal/session/... -run TestPerGroupConfig_ -race -count=1 -v 2>&1 | tee /tmp/pergroupconfig-plan2-green.log && grep -cE "^--- PASS: TestPerGroupConfig_" /tmp/pergroupconfig-plan2-green.log && grep -cE 'i\.logClaudeConfigResolution\(\)' internal/session/instance.go && grep -c '"claude config resolution"' internal/session/instance.go</automated>
+    <automated>cd <repo-root>/.worktrees/per-group-claude-config && gofmt -l internal/session/claude.go internal/session/instance.go && go vet ./internal/session/... && go test ./internal/session/... -run TestPerGroupConfig_ -race -count=1 -v 2>&1 | tee /tmp/pergroupconfig-plan2-green.log && grep -cE "^--- PASS: TestPerGroupConfig_" /tmp/pergroupconfig-plan2-green.log && grep -cE 'i\.logClaudeConfigResolution\(\)' internal/session/instance.go && grep -c '"claude config resolution"' internal/session/instance.go</automated>
   </verify>
   <done>
     - `GetClaudeConfigDirSourceForGroup` in `internal/session/claude.go` is no longer a stub; body mirrors the priority chain at L246 and returns the source label at each branch.

--- a/.planning/phases/03-docs-and-mandate/03-02-SUMMARY.md
+++ b/.planning/phases/03-docs-and-mandate/03-02-SUMMARY.md
@@ -71,7 +71,7 @@ Each task was committed atomically:
 
 ## Files Created/Modified
 
-- `/home/ashesh-goplani/agent-deck/.worktrees/feedback-closeout/CLAUDE.md` - New repo-local mandate file: mandatory feedback test coverage (23 tests, sweep command, trigger paths, D_PLACEHOLDER blocker) and --no-verify ban with incident evidence
+- `<repo-root>/.worktrees/feedback-closeout/CLAUDE.md` - New repo-local mandate file: mandatory feedback test coverage (23 tests, sweep command, trigger paths, D_PLACEHOLDER blocker) and --no-verify ban with incident evidence
 
 ## Decisions Made
 
@@ -85,7 +85,7 @@ Each task was committed atomically:
 **1. [Rule 3 - Blocking] Removed CLAUDE.md from .git/info/exclude**
 - **Found during:** Task 4 (staging CLAUDE.md for commit)
 - **Issue:** `CLAUDE.md` was listed in `.git/info/exclude` (parent repo's local exclude), causing git to silently ignore the new file as untracked
-- **Fix:** Removed the `CLAUDE.md` line from `/home/ashesh-goplani/agent-deck/.git/info/exclude` using Python (Edit tool was denied for `.git/info/exclude`)
+- **Fix:** Removed the `CLAUDE.md` line from `<repo-root>/.git/info/exclude` using Python (Edit tool was denied for `.git/info/exclude`)
 - **Files modified:** `.git/info/exclude` (not committed — local git metadata)
 - **Verification:** `git status --short CLAUDE.md` returned `?? CLAUDE.md` after the fix
 - **Committed in:** Not committed (local git metadata file)

--- a/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-01-PLAN.md
+++ b/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-01-PLAN.md
@@ -37,8 +37,8 @@ Output: Updated `internal/session/session_persistence_test.go` with one new func
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-01-SUMMARY.md
+++ b/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-01-SUMMARY.md
@@ -98,7 +98,7 @@ None. The plan executed exactly as written. Insertion point was the one the plan
 
 ## Self-Check: PASSED
 
-- Test function exists at line 958 of `/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/internal/session/session_persistence_test.go` — verified by grep.
+- Test function exists at line 958 of `<repo-root>/.worktrees/session-persistence/internal/session/session_persistence_test.go` — verified by grep.
 - Commit `be20eff` exists on branch `fix/session-persistence` — verified by `git log --oneline -1`.
 - Build passes, target test runs with the documented failure, full suite unchanged — all verified.
 

--- a/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-02-PLAN.md
+++ b/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-02-PLAN.md
@@ -42,8 +42,8 @@ Note: `autonomous: false` because the test requires `requireTmux()` — on hosts
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-02-SUMMARY.md
+++ b/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-02-SUMMARY.md
@@ -110,7 +110,7 @@ Otherwise the plan executed exactly as written. Insertion point was the one the 
 
 ## Self-Check: PASSED
 
-- Test function exists at line ~1003 of `/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/internal/session/session_persistence_test.go` — verified by grep (`func TestPersistence_SessionIDFallbackWhenJSONLMissing` → 1 match).
+- Test function exists at line ~1003 of `<repo-root>/.worktrees/session-persistence/internal/session/session_persistence_test.go` — verified by grep (`func TestPersistence_SessionIDFallbackWhenJSONLMissing` → 1 match).
 - Commit `dc7388f` exists on branch `fix/session-persistence` — verified by `git log --oneline -2`.
 - Build passes, target test runs with the documented RED failure mode, full suite otherwise unchanged — all verified.
 

--- a/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-03-PLAN.md
+++ b/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-03-PLAN.md
@@ -55,8 +55,8 @@ Autonomous: false — the executor must run the full `TestPersistence_*` suite a
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-04-PLAN.md
+++ b/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-04-PLAN.md
@@ -61,8 +61,8 @@ Autonomous: false — the observability line's exact substrings are contractual.
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-05-PLAN.md
+++ b/.planning/phases/03-resume-on-start-and-error-recovery-req-2-fix/03-05-PLAN.md
@@ -47,8 +47,8 @@ Autonomous: false — final phase sign-off requires human verification that all 
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/03-visual-harness-documentation-attribution-commit/03-01-PLAN.md
+++ b/.planning/phases/03-visual-harness-documentation-attribution-commit/03-01-PLAN.md
@@ -44,8 +44,8 @@ Output: One executable bash script with `chmod +x`, one successful run captured 
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/per-group-claude-config/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/per-group-claude-config/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/03-visual-harness-documentation-attribution-commit/03-02-PLAN.md
+++ b/.planning/phases/03-visual-harness-documentation-attribution-commit/03-02-PLAN.md
@@ -60,8 +60,8 @@ Output: Three doc commits (README / CLAUDE.md / CHANGELOG), each carrying `Base 
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/per-group-claude-config/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/per-group-claude-config/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/03-visual-harness-documentation-attribution-commit/03-CONTEXT.md
+++ b/.planning/phases/03-visual-harness-documentation-attribution-commit/03-CONTEXT.md
@@ -81,7 +81,7 @@ Ship the human-watchable verification harness that proves per-group `CLAUDE_CONF
 
 ### CFG-06 — repo-root CLAUDE.md one-liner (P0, locked) {#claude_md_handling}
 
-- **File:** `CLAUDE.md` at the worktree root (`/home/ashesh-goplani/agent-deck/.worktrees/per-group-claude-config/CLAUDE.md`).
+- **File:** `CLAUDE.md` at the worktree root (`<repo-root>/.worktrees/per-group-claude-config/CLAUDE.md`).
 - **Tracking status:** `CLAUDE.md` was removed from tracking in commit `5013940 chore: remove CLAUDE.md from tracking (keep local)`. It is NOT in the Git index on `main` or on this branch. The worktree currently has no CLAUDE.md file. It is also not in `.gitignore` — it is simply untracked.
 - **Planner decision:** Choose ONE of the following three paths and commit it explicitly:
   - **Path A (resurrect):** `git show <last-tracked-commit>:CLAUDE.md > CLAUDE.md`, then add the one-line entry under the session-persistence mandate block, then commit with `git add -f CLAUDE.md` (since it may still be path-ignored — verify first).
@@ -173,7 +173,7 @@ Every commit message trailer: `Committed by Ashesh Goplani`. No Claude attributi
 - `cmd/agent-deck/group_cmd.go` — `group create|delete` commands for the harness's group setup/teardown.
 
 ### Repo-root rules
-- `/home/ashesh-goplani/agent-deck/CLAUDE.md` (NOT in this worktree; lives in the main-branch checkout) — reference copy if Path A (resurrect) is chosen. Do NOT rely on it being present inside this worktree's checkout.
+- `<repo-root>/CLAUDE.md` (NOT in this worktree; lives in the main-branch checkout) — reference copy if Path A (resurrect) is chosen. Do NOT rely on it being present inside this worktree's checkout.
 - Global `~/.claude/CLAUDE.md` / `~/.claude-work/CLAUDE.md` — user-level mandates (no `rm`, no Claude attribution). Enforced by the planner/executor agents directly; already honored in Phase 1 + 2.
 
 ### Phase 1 + 2 commits (attribution precedent)

--- a/.planning/phases/03-visual-harness-documentation-attribution-commit/03-VERIFICATION.md
+++ b/.planning/phases/03-visual-harness-documentation-attribution-commit/03-VERIFICATION.md
@@ -7,7 +7,7 @@ overrides_applied: 1
 overrides:
   - must_have: "Harness uses `agent-deck session send` AND `agent-deck session output` call sites"
     reason: "Script uses /proc/<pane_pid>/environ (Linux kernel env snapshot) instead of session-send/output round-trip. Approved at Task 2 checkpoint by Ashesh Goplani with rationale: /proc reads the exact tmux-spawn environment directly — strictly tighter assertion than a session-send round-trip that goes through the agent-ready gate (80s timeout). Deviation recorded in 03-01-SUMMARY.md key-decisions."
-    accepted_by: "ashesh-goplani"
+    accepted_by: "<user>"
     accepted_at: "2026-04-15T20:18:10Z"
 human_verification:
   - test: "Review --no-verify usage on planning doc commit 911c0e7"
@@ -63,7 +63,7 @@ None. All requirements in scope for this phase are fully implemented.
 
 | From | To | Via | Status | Details |
 |------|----|-----|--------|---------|
-| `scripts/verify-per-group-claude-config.sh` | `agent-deck session send/output` | bash subprocess | PASSED (override) | Script uses `/proc/<pane_pid>/environ` instead — approved deviation. session start/stop/show/remove ARE present; the assertion method is different but tighter. Override: accepted by ashesh-goplani on 2026-04-15T20:18:10Z |
+| `scripts/verify-per-group-claude-config.sh` | `agent-deck session send/output` | bash subprocess | PASSED (override) | Script uses `/proc/<pane_pid>/environ` instead — approved deviation. session start/stop/show/remove ARE present; the assertion method is different but tighter. Override: accepted by <user> on 2026-04-15T20:18:10Z |
 | `scripts/verify-per-group-claude-config.sh` | `~/.agent-deck/config.toml` | backup-restore via trap EXIT INT TERM | VERIFIED | `trap cleanup EXIT INT TERM` at line 107; `cp "$BACKUP_FILE" "$CONFIG_FILE"` in cleanup function; `trash "$BACKUP_FILE"` for temp files |
 | `README.md` | `scripts/verify-per-group-claude-config.sh` | markdown reference in subsection body | VERIFIED | `grep -q 'scripts/verify-per-group-claude-config.sh' README.md` exits 0 |
 | `CLAUDE.md` | `internal/session/pergroupconfig_test.go` | one-line reference to TestPerGroupConfig_* suite | VERIFIED | `grep -c "TestPerGroupConfig_" CLAUDE.md` = 1; backtick-wrapped suite name at line 50 |

--- a/.planning/phases/04-conductor-schema-docs-refresh-mandate-clarification/04-01-PLAN.md
+++ b/.planning/phases/04-conductor-schema-docs-refresh-mandate-clarification/04-01-PLAN.md
@@ -67,8 +67,8 @@ Output:
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.claude/plugins/cache/gsd@ad3bab3fea6f/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.claude/plugins/cache/gsd@ad3bab3fea6f/get-shit-done/templates/summary.md
+@<repo-root>/.claude/plugins/cache/gsd@ad3bab3fea6f/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.claude/plugins/cache/gsd@ad3bab3fea6f/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>
@@ -821,7 +821,7 @@ go vet ./internal/session/... && go build ./...
 ```
 Both must exit 0.
 
-**Step 4e — Write `04-01-SUMMARY.md`** at `.planning/phases/04-conductor-schema-docs-refresh-mandate-clarification/04-01-SUMMARY.md` using the template at @/home/ashesh-goplani/agent-deck/.claude/plugins/cache/gsd@ad3bab3fea6f/get-shit-done/templates/summary.md. Include:
+**Step 4e — Write `04-01-SUMMARY.md`** at `.planning/phases/04-conductor-schema-docs-refresh-mandate-clarification/04-01-SUMMARY.md` using the template at @<repo-root>/.claude/plugins/cache/gsd@ad3bab3fea6f/get-shit-done/templates/summary.md. Include:
 - Commits shipped in this plan (hashes + subjects) — enumerated list
 - CFG-11 test pass log excerpt (PASS count)
 - CFG-08 closure status

--- a/.planning/phases/04-conductor-schema-docs-refresh-mandate-clarification/04-02-PLAN.md
+++ b/.planning/phases/04-conductor-schema-docs-refresh-mandate-clarification/04-02-PLAN.md
@@ -73,8 +73,8 @@ All three commits sign `Committed by Ashesh Goplani`, reference issue #602 in at
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.claude/plugins/cache/gsd@ad3bab3fea6f/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.claude/plugins/cache/gsd@ad3bab3fea6f/get-shit-done/templates/summary.md
+@<repo-root>/.claude/plugins/cache/gsd@ad3bab3fea6f/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.claude/plugins/cache/gsd@ad3bab3fea6f/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/04-conductor-schema-docs-refresh-mandate-clarification/SKILL_MD_DIFF.md
+++ b/.planning/phases/04-conductor-schema-docs-refresh-mandate-clarification/SKILL_MD_DIFF.md
@@ -6,7 +6,7 @@ repo-visible audit trail required for CFG-09 closure.
 
 ## Canonical plugin-cache SKILL.md
 
-**Path resolved:** `/home/ashesh-goplani/.claude/plugins/cache/agent-deck/agent-deck/12c0a65dfb13/skills/agent-deck/SKILL.md`
+**Path resolved:** `~/.claude/plugins/cache/agent-deck/agent-deck/12c0a65dfb13/skills/agent-deck/SKILL.md`
 
 **Status:** applied
 
@@ -14,7 +14,7 @@ repo-visible audit trail required for CFG-09 closure.
 
 ```diff
 --- /tmp/skill.canonical.before.md	2026-04-16 00:11:24.911461994 +0200
-+++ /home/ashesh-goplani/.claude/plugins/cache/agent-deck/agent-deck/12c0a65dfb13/skills/agent-deck/SKILL.md	2026-04-16 00:12:14.455170358 +0200
++++ ~/.claude/plugins/cache/agent-deck/agent-deck/12c0a65dfb13/skills/agent-deck/SKILL.md	2026-04-16 00:12:14.455170358 +0200
 @@ -281,6 +281,22 @@
 
  See [config-reference.md](references/config-reference.md) for all options.
@@ -44,7 +44,7 @@ repo-visible audit trail required for CFG-09 closure.
 
 ```
 $ grep -n "\[conductors\..*\.claude\]\|Per-conductor\|issues/602" \
-    /home/ashesh-goplani/.claude/plugins/cache/agent-deck/agent-deck/12c0a65dfb13/skills/agent-deck/SKILL.md
+    ~/.claude/plugins/cache/agent-deck/agent-deck/12c0a65dfb13/skills/agent-deck/SKILL.md
 ```
 
 All three substrings (`[conductors.<name>.claude]`, `Per-conductor Claude config`, `issues/602`) are present.

--- a/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-01-PLAN.md
+++ b/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-01-PLAN.md
@@ -52,8 +52,8 @@ Output: Two new files under `scripts/`. No production code changes. No changes t
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-01-SUMMARY.md
+++ b/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-01-SUMMARY.md
@@ -119,7 +119,7 @@ Classified as a plan-intent-preserving fix, not a Rule-N auto-fix: the plan expl
 
 ## Issues Encountered
 
-- The Write tool initially placed files in a different worktree path (`/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/...`) because the prompt's `files_to_read` block used that path. Resolved by removing the stray directory via `trash` and writing to the correct worktree (`/home/ashesh-goplani/agent-deck/.claude/worktrees/agent-ab2e9834/...`). No files from the wrong worktree were committed.
+- The Write tool initially placed files in a different worktree path (`<repo-root>/.worktrees/session-persistence/...`) because the prompt's `files_to_read` block used that path. Resolved by removing the stray directory via `trash` and writing to the correct worktree (`<repo-root>/.claude/worktrees/agent-ab2e9834/...`). No files from the wrong worktree were committed.
 
 ## Threat Surface
 

--- a/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-02-PLAN.md
+++ b/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-02-PLAN.md
@@ -49,8 +49,8 @@ Output: Edits to `CLAUDE.md` (only if audit finds gaps) and `CHANGELOG.md` (alwa
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-03-PLAN.md
+++ b/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-03-PLAN.md
@@ -42,8 +42,8 @@ Output: One new file under `.github/workflows/`. No other changes.
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-04-PLAN.md
+++ b/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-04-PLAN.md
@@ -47,8 +47,8 @@ Output: `04-VERIFY.md` (new) and `.planning/STATE.md` (edited). Both committed.
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-CONTEXT.md
+++ b/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-CONTEXT.md
@@ -12,7 +12,7 @@ This is the FINAL phase of v1.5.2. It does NOT change session-persistence behavi
 Three deliverables, in priority order:
 
 1. **`scripts/verify-session-persistence.sh`** — a human-watchable end-to-end verification script that exercises real systemd login-session teardown on Linux (not mocked) and exits non-zero if any scenario fails.
-2. **CLAUDE.md mandate verification + DOC-05** — the "Session persistence: mandatory test coverage" section at `/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/CLAUDE.md:5` already exists (drafted at commit a262c6d). Verify it covers DOC-01..04 verbatim, patch any gaps. Then add the one-line v1.5.2 mention to `CHANGELOG.md` (DOC-05).
+2. **CLAUDE.md mandate verification + DOC-05** — the "Session persistence: mandatory test coverage" section at `<repo-root>/.worktrees/session-persistence/CLAUDE.md:5` already exists (drafted at commit a262c6d). Verify it covers DOC-01..04 verbatim, patch any gaps. Then add the one-line v1.5.2 mention to `CHANGELOG.md` (DOC-05).
 3. **CI wiring** — add a GitHub Actions workflow (or extend an existing one) that runs `go test -run TestPersistence_ ./internal/session/... -race -count=1` AND `bash scripts/verify-session-persistence.sh` on every PR touching the mandated paths. Red of either blocks the PR (SCRIPT-07).
 
 OUT OF SCOPE: changing `launch_in_user_scope` semantics, touching `internal/tmux/**` or `internal/session/instance.go` behavior, any new tests beyond what the script drives (the eight `TestPersistence_*` tests already exist). OBS sanity (mentioned in user brief) is a **read-only** log check inside the script, not new log emission work — OBS-01/02/03 are Phase 2/3 deliverables.

--- a/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-VERIFY.md
+++ b/.planning/phases/04-verification-harness-docs-and-ci-wiring/04-VERIFY.md
@@ -2,7 +2,7 @@
 
 # Phase 04 — verification run
 
-**Date:** 2026-04-15 (conductor host `ashesh-goplani-CELSIUS-M7010power`)
+**Date:** 2026-04-15 (conductor host `<user>-CELSIUS-M7010power`)
 **Script:** scripts/verify-session-persistence.sh @ `a680197` (commit `a680197ea2747984c6ee1def247b06b90f92cd22`)
 **Binary:** `./bin/agent-deck` built from HEAD `a680197` immediately prior to the run and placed on `$PATH` via `export PATH="$PWD/bin:$PATH"`
 **Exit code:** 0
@@ -21,17 +21,17 @@ On this host, Scenario 1 SKIPs because the live tmux daemon (PID 1752166) predat
 ## Host
 
 ```
-Linux ashesh-goplani-CELSIUS-M7010power 6.17.0-19-generic #19~24.04.2-Ubuntu SMP PREEMPT_DYNAMIC Fri Mar  6 23:08:46 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
+Linux <user>-CELSIUS-M7010power 6.17.0-19-generic #19~24.04.2-Ubuntu SMP PREEMPT_DYNAMIC Fri Mar  6 23:08:46 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
 ```
 
 ```
 systemctl --user show-environment (first 10 lines):
-HOME=/home/ashesh-goplani
+HOME=~
 LANG=en_US.UTF-8
-LOGNAME=ashesh-goplani
+LOGNAME=<user>
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin
 SHELL=/bin/bash
-USER=ashesh-goplani
+USER=<user>
 XDG_RUNTIME_DIR=/run/user/1000
 GTK_MODULES=gail:atk-bridge
 QT_ACCESSIBILITY=1
@@ -39,9 +39,9 @@ XDG_DATA_DIRS=/usr/share/ubuntu:/usr/share/gnome:/usr/local/share/:/usr/share/:/
 ```
 
 ```
-loginctl show-user ashesh-goplani:
+loginctl show-user <user>:
 UID=1000
-Name=ashesh-goplani
+Name=<user>
 State=active
 Linger=yes
 ```
@@ -49,7 +49,7 @@ Linger=yes
 ```
 PATH ordering (agent-deck is the freshly-built local binary):
 $ command -v agent-deck
-/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/bin/agent-deck
+<repo-root>/.worktrees/session-persistence/bin/agent-deck
 
 $ command -v tmux
 /usr/bin/tmux
@@ -61,7 +61,7 @@ $ command -v systemd-run
 ## Script output (full stdout+stderr, ANSI-stripped)
 
 ```
-    claude: /home/ashesh-goplani/.nvm/versions/node/v22.20.0/bin/claude (real)
+    claude: ~/.nvm/versions/node/v22.20.0/bin/claude (real)
 ==========================================================
 verify-session-persistence.sh — v1.5.2 persistence harness
 ==========================================================
@@ -87,10 +87,10 @@ Each scenario ends with one [PASS], [FAIL], or [SKIP] line.
 [PASS] [2] tmux pid 1752166 survived login-session teardown (cgroup isolation works)
     creating session: verify-persist-4142851-s3
     restarting session: agent-deck session start verify-persist-4142851-s3
-    captured claude argv: "bash -c 'export COLORFGBG='\\''15;0'\\'' && AGENTDECK_INSTANCE_ID=2ee9d76f-1776233540 CLAUDE_CONFIG_DIR=/home/ashesh-goplani/.claude claude --session-id 4d228b20-a927-483c-ba19-8c9ed0d877b3 --dangerously-skip-permissions'"
+    captured claude argv: "bash -c 'export COLORFGBG='\\''15;0'\\'' && AGENTDECK_INSTANCE_ID=2ee9d76f-1776233540 CLAUDE_CONFIG_DIR=~/.claude claude --session-id 4d228b20-a927-483c-ba19-8c9ed0d877b3 --dangerously-skip-permissions'"
 [PASS] [3] restart spawned claude with --resume or --session-id
     creating fresh session: verify-persist-4142851-s4
-    captured claude argv: "bash -c 'export COLORFGBG='\\''15;0'\\'' && export AGENTDECK_INSTANCE_ID=341ec3a0-1776233546; export CLAUDE_CONFIG_DIR=/home/ashesh-goplani/.claude; exec claude --session-id \"6f5fe9dc-b27a-486f-9df7-b168d58589ca\" --dangerously-skip-permissions'"
+    captured claude argv: "bash -c 'export COLORFGBG='\\''15;0'\\'' && export AGENTDECK_INSTANCE_ID=341ec3a0-1776233546; export CLAUDE_CONFIG_DIR=~/.claude; exec claude --session-id \"6f5fe9dc-b27a-486f-9df7-b168d58589ca\" --dangerously-skip-permissions'"
 [PASS] [4] fresh session uses --session-id without --resume
 OVERALL: PASS
 ```

--- a/.planning/phases/05-custom-command-jsonl-resume/05-01-PLAN.md
+++ b/.planning/phases/05-custom-command-jsonl-resume/05-01-PLAN.md
@@ -42,8 +42,8 @@ Output: one atomic commit appending ONE new `func TestPersistence_CustomCommandR
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>
@@ -262,7 +262,7 @@ Committed by Ashesh Goplani
 NO Claude attribution, NO push, NO tag, NO PR.
   </action>
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/session-persistence && go vet ./internal/session/... && go test -run TestPersistence_CustomCommandResumesFromLatestJSONL ./internal/session/... -count=1 -timeout=60s; test $? -eq 1</automated>
+    <automated>cd <repo-root>/.worktrees/session-persistence && go vet ./internal/session/... && go test -run TestPersistence_CustomCommandResumesFromLatestJSONL ./internal/session/... -count=1 -timeout=60s; test $? -eq 1</automated>
   </verify>
   <acceptance_criteria>
     - `grep -q "func TestPersistence_CustomCommandResumesFromLatestJSONL" internal/session/session_persistence_test.go` exits 0

--- a/.planning/phases/05-custom-command-jsonl-resume/05-02-PLAN.md
+++ b/.planning/phases/05-custom-command-jsonl-resume/05-02-PLAN.md
@@ -60,8 +60,8 @@ OR a single commit if the executor judges it clearer. Both patterns are acceptab
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>
@@ -278,7 +278,7 @@ Committed by Ashesh Goplani
 OR defer the commit until after Task 2 (single combined commit). Executor's choice; both are atomic-enough for this scope.
   </action>
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/session-persistence && go vet ./internal/session/... && go build ./internal/session/...</automated>
+    <automated>cd <repo-root>/.worktrees/session-persistence && go vet ./internal/session/... && go build ./internal/session/...</automated>
   </verify>
   <acceptance_criteria>
     - `grep -q "^func discoverLatestClaudeJSONL(projectPath string) (string, bool)" internal/session/claude.go` exits 0
@@ -423,7 +423,7 @@ Committed by Ashesh Goplani
 ```
   </action>
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/session-persistence && go vet ./internal/session/... && go test -run TestPersistence_CustomCommandResumesFromLatestJSONL ./internal/session/... -count=1 -timeout=60s && go test -run TestPersistence_ ./internal/session/... -race -count=1 -timeout=300s</antry></automated>
+    <automated>cd <repo-root>/.worktrees/session-persistence && go vet ./internal/session/... && go test -run TestPersistence_CustomCommandResumesFromLatestJSONL ./internal/session/... -count=1 -timeout=60s && go test -run TestPersistence_ ./internal/session/... -race -count=1 -timeout=300s</antry></automated>
   </verify>
   <acceptance_criteria>
     - `grep -q "^func (i \*Instance) ensureClaudeSessionIDFromDisk" internal/session/instance.go` exits 0

--- a/.planning/phases/05-custom-command-jsonl-resume/05-03-PLAN.md
+++ b/.planning/phases/05-custom-command-jsonl-resume/05-03-PLAN.md
@@ -40,8 +40,8 @@ Output: ONE atomic commit appending `TestPersistence_DiscoverLatestClaudeJSONL_U
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/session-persistence/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>
@@ -212,7 +212,7 @@ Committed by Ashesh Goplani
 ```
   </action>
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/session-persistence && go test -run TestPersistence_DiscoverLatestClaudeJSONL_Unit ./internal/session/... -count=1 -timeout=30s && go test -run TestPersistence_ ./internal/session/... -race -count=1 -timeout=300s</antry></automated>
+    <automated>cd <repo-root>/.worktrees/session-persistence && go test -run TestPersistence_DiscoverLatestClaudeJSONL_Unit ./internal/session/... -count=1 -timeout=30s && go test -run TestPersistence_ ./internal/session/... -race -count=1 -timeout=300s</antry></automated>
   </verify>
   <acceptance_criteria>
     - `grep -q "^func TestPersistence_DiscoverLatestClaudeJSONL_Unit" internal/session/session_persistence_test.go` exits 0

--- a/.planning/phases/05-custom-command-jsonl-resume/05-CONTEXT.md
+++ b/.planning/phases/05-custom-command-jsonl-resume/05-CONTEXT.md
@@ -104,7 +104,7 @@ Phase 5 closes spec REQ-7 and REQUIREMENTS entries PERSIST-11, PERSIST-12, PERSI
 
 - Test fixture for TEST-09: create two temp JSONLs with `os.Chtimes` setting mtimes 10s apart, assert newer wins. Use `t.TempDir()` for isolation; clean up is automatic.
 - JSONL content minimum: the file need not contain valid JSON for discovery — the helper only reads the filename. (`sessionHasConversationData` checks content; `discoverLatestClaudeJSONL` does not.)
-- Conductor reproduction path: `ProjectPath` on the conductor instance is `/home/ashesh-goplani/.agent-deck/conductor/agent-deck`; `ConvertToClaudeDirName` produces `-home-ashesh-goplani--agent-deck-conductor-agent-deck` which matches the on-disk directory the user confirmed has ~10 JSONLs.
+- Conductor reproduction path: `ProjectPath` on the conductor instance is `~/.agent-deck/conductor/agent-deck`; `ConvertToClaudeDirName` produces `-home-<user>--agent-deck-conductor-agent-deck` which matches the on-disk directory the user confirmed has ~10 JSONLs.
 - Persistence test: after calling `Start()` (or the helper that it uses), reload the instance from storage (JSON file under `~/.agent-deck/<profile>/instances/<id>.json` or whatever the storage manager uses) and assert `ClaudeSessionID` is populated. This is what PERSIST-12 requires and is the most likely Dimension-8 failure if the planner forgets to call save.
 
 </specifics>

--- a/.planning/phases/19-verification-docs-phases-14-15/19-01-PLAN.md
+++ b/.planning/phases/19-verification-docs-phases-14-15/19-01-PLAN.md
@@ -71,8 +71,8 @@ No code changes. This is a pure docs-backfill plan.
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/watcher-completion/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/watcher-completion/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/watcher-completion/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/watcher-completion/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/19-verification-docs-phases-14-15/19-02-PLAN.md
+++ b/.planning/phases/19-verification-docs-phases-14-15/19-02-PLAN.md
@@ -89,8 +89,8 @@ No code changes.
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/watcher-completion/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/watcher-completion/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/watcher-completion/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/watcher-completion/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>

--- a/.planning/phases/20-health-alerts-bridge/20-01-PLAN.md
+++ b/.planning/phases/20-health-alerts-bridge/20-01-PLAN.md
@@ -68,9 +68,9 @@ Output: one new source file (`health_bridge.go`), one new test file (`health_bri
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/watcher-completion/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/watcher-completion/.claude/get-shit-done/templates/summary.md
-@/home/ashesh-goplani/agent-deck/.worktrees/watcher-completion/.claude/get-shit-done/references/tdd.md
+@<repo-root>/.worktrees/watcher-completion/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/watcher-completion/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/watcher-completion/.claude/get-shit-done/references/tdd.md
 </execution_context>
 
 <context>

--- a/.planning/phases/21-watcher-folder-hierarchy/21-01-PLAN.md
+++ b/.planning/phases/21-watcher-folder-hierarchy/21-01-PLAN.md
@@ -91,8 +91,8 @@ Output: 3 new source files (layout.go, state.go, event_log.go), 1 new test file 
 </objective>
 
 <execution_context>
-@/home/ashesh-goplani/agent-deck/.worktrees/watcher-completion/.claude/get-shit-done/workflows/execute-plan.md
-@/home/ashesh-goplani/agent-deck/.worktrees/watcher-completion/.claude/get-shit-done/templates/summary.md
+@<repo-root>/.worktrees/watcher-completion/.claude/get-shit-done/workflows/execute-plan.md
+@<repo-root>/.worktrees/watcher-completion/.claude/get-shit-done/templates/summary.md
 </execution_context>
 
 <context>
@@ -472,7 +472,7 @@ Committed by Ashesh Goplani
   </action>
 
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/watcher-completion && GOTOOLCHAIN=go1.24.0 go build ./internal/watcher/... && ! GOTOOLCHAIN=go1.24.0 go test ./internal/watcher/ -run TestLayout -race -count=1 -timeout 30s</automated>
+    <automated>cd <repo-root>/.worktrees/watcher-completion && GOTOOLCHAIN=go1.24.0 go build ./internal/watcher/... && ! GOTOOLCHAIN=go1.24.0 go test ./internal/watcher/ -run TestLayout -race -count=1 -timeout 30s</automated>
   </verify>
 
   <acceptance_criteria>
@@ -923,7 +923,7 @@ Committed by Ashesh Goplani
   </action>
 
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/watcher-completion && GOTOOLCHAIN=go1.24.0 go test ./internal/watcher/ -run TestLayout -race -count=1 -timeout 30s && GOTOOLCHAIN=go1.24.0 go test ./internal/watcher/... -race -count=1 -timeout 120s</automated>
+    <automated>cd <repo-root>/.worktrees/watcher-completion && GOTOOLCHAIN=go1.24.0 go test ./internal/watcher/ -run TestLayout -race -count=1 -timeout 30s && GOTOOLCHAIN=go1.24.0 go test ./internal/watcher/... -race -count=1 -timeout 120s</automated>
   </verify>
 
   <acceptance_criteria>
@@ -1033,7 +1033,7 @@ Committed by Ashesh Goplani
   </action>
 
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/watcher-completion && test -s assets/watcher-templates/CLAUDE.md && test -s assets/watcher-templates/POLICY.md && test -s assets/watcher-templates/LEARNINGS.md && test -s internal/watcher/assets/watcher-templates/CLAUDE.md && test -s internal/watcher/assets/watcher-templates/POLICY.md && test -s internal/watcher/assets/watcher-templates/LEARNINGS.md && GOTOOLCHAIN=go1.24.0 go test ./internal/watcher/ -run TestLayout_FreshInstallCreatesLayout -race -count=1 -timeout 30s</automated>
+    <automated>cd <repo-root>/.worktrees/watcher-completion && test -s assets/watcher-templates/CLAUDE.md && test -s assets/watcher-templates/POLICY.md && test -s assets/watcher-templates/LEARNINGS.md && test -s internal/watcher/assets/watcher-templates/CLAUDE.md && test -s internal/watcher/assets/watcher-templates/POLICY.md && test -s internal/watcher/assets/watcher-templates/LEARNINGS.md && GOTOOLCHAIN=go1.24.0 go test ./internal/watcher/ -run TestLayout_FreshInstallCreatesLayout -race -count=1 -timeout 30s</automated>
   </verify>
 
   <acceptance_criteria>
@@ -1264,7 +1264,7 @@ Committed by Ashesh Goplani
   </action>
 
   <verify>
-    <automated>cd /home/ashesh-goplani/agent-deck/.worktrees/watcher-completion && GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/ -run TestWatcherList_JSON_ExposesStateFields -race -count=1 -timeout 30s && GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/... -race -count=1 -timeout 120s</automated>
+    <automated>cd <repo-root>/.worktrees/watcher-completion && GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/ -run TestWatcherList_JSON_ExposesStateFields -race -count=1 -timeout 30s && GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/... -race -count=1 -timeout 120s</automated>
   </verify>
 
   <acceptance_criteria>

--- a/.planning/phases/21-watcher-folder-hierarchy/21-PATTERNS.md
+++ b/.planning/phases/21-watcher-folder-hierarchy/21-PATTERNS.md
@@ -649,7 +649,7 @@ All files have in-repo analogs. The weakest match is `event_log.go` (no direct O
 - CLI `list --json` extension reuses `HealthTracker.Check()` (`internal/watcher/health.go:148`) for the `health_status` field — no parallel classifier.
 
 ### File Created
-`/home/ashesh-goplani/agent-deck/.worktrees/watcher-completion/.planning/phases/21-watcher-folder-hierarchy/21-PATTERNS.md`
+`<repo-root>/.worktrees/watcher-completion/.planning/phases/21-watcher-folder-hierarchy/21-PATTERNS.md`
 
 ### Ready for Planning
 Pattern mapping complete. Planner can reference analog file:line ranges + verbatim excerpts when writing PLAN.md task actions.

--- a/README.md
+++ b/README.md
@@ -672,6 +672,16 @@ See [TUI Reference](skills/agent-deck/references/tui-reference.md) for all short
 
 ## Documentation
 
+**User guides** — start here if you are new:
+
+| Guide | What's Inside |
+|-------|---------------|
+| [Conductor](docs/CONDUCTOR.md) | What a conductor is, quickstart, channel pairing, state files, multi-conductor setups |
+| [Skills](docs/SKILLS.md) | User-level vs pool skills, authoring, attach/detach, when to use which tier |
+| [Watchdog](docs/WATCHDOG.md) | Optional Python daemon that auto-restarts critical sessions and nudges stuck children |
+
+**References** — drill into specifics:
+
 | Guide | What's Inside |
 |-------|---------------|
 | [CLI Reference](skills/agent-deck/references/cli-reference.md) | Commands, flags, scripting examples |

--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ See [TUI Reference](skills/agent-deck/references/tui-reference.md) for all short
 | [Conductor](docs/CONDUCTOR.md) | What a conductor is, quickstart, channel pairing, state files, multi-conductor setups |
 | [Skills](docs/SKILLS.md) | User-level vs pool skills, authoring, attach/detach, when to use which tier |
 | [Watchdog](docs/WATCHDOG.md) | Optional Python daemon that auto-restarts critical sessions and nudges stuck children |
+| [Watchers](docs/WATCHERS.md) | Event-forwarding framework: doorbell model, built-in adapters, custom watchers, gotchas |
 
 **References** — drill into specifics:
 

--- a/docs/CONDUCTOR.md
+++ b/docs/CONDUCTOR.md
@@ -1,0 +1,243 @@
+# Conductor: a persistent orchestrator for your agent-deck sessions
+
+A **conductor** is one long-lived Claude Code session whose whole job is to supervise other sessions. You do not code in it. You do not read files with it. You talk to it (from your terminal, from Telegram, from Slack, from anywhere you have a bot) and it delegates the work to child sessions, watches what they do, and reports back.
+
+If you have ever run `claude` directly, closed the terminal, and come back to find the session gone, you already understand half the problem a conductor solves. The other half is that even while your `claude` is alive, it is bound to your keyboard: you cannot ask it for status from your phone, you cannot hand off to a colleague, you cannot fan out three investigations in parallel and reconvene.
+
+A conductor is the foreman on a jobsite. You send instructions to the foreman. The foreman assigns them to workers (child sessions in agent-deck). You do not need to stand next to each worker; you just need to know the foreman is reachable.
+
+## What a conductor actually is
+
+Under the hood, a conductor is:
+
+- A `claude` process pinned inside a named tmux session managed by agent-deck.
+- A directory at `~/.agent-deck/conductor/<name>/` that holds its instructions, policy, learnings, state, and task log.
+- An agent-deck session record (`agent-deck list` will show it) with `is_conductor: true`.
+- Optionally, one or more channels attached (Telegram today, more planned) so you can talk to it remotely.
+- Optionally, a heartbeat daemon that pings the conductor on a schedule, keeping it honest about idle-while-work-is-pending states.
+
+Everything else (which models it uses, which policy it follows, how it splits work) is configured through the files in its directory. Those files are the contract.
+
+## Why you would want one
+
+- **It survives your terminal.** Close iTerm, reboot, come back a day later. The tmux session is still there, the Claude process is still there, the conductor knows where it left off.
+- **It is reachable from anywhere.** Pair a Telegram bot once. From then on, any message to that bot reaches the conductor, and the conductor's replies come back to your chat.
+- **It delegates.** Instead of one Claude doing everything serially, the conductor spawns child sessions per project or per investigation, points them at the right worktree, and monitors their output.
+- **It keeps an audit trail.** Every action the conductor takes gets appended to `task-log.md`. Every pattern it learns, successes and failures both, goes into `LEARNINGS.md`. You can read both with any editor.
+- **It self-polices.** The `POLICY.md` file tells it what to auto-respond to and what to escalate to you. Routine requests get handled. Anything ambiguous or destructive gets thrown back at you via the channel.
+
+## Quickstart (about ten minutes)
+
+Requirements: agent-deck installed, a project path in mind, and (optional) a Telegram bot token.
+
+### 1. Create the conductor
+
+```bash
+agent-deck conductor setup my-conductor --description "Supervises work in ~/projects/foo"
+```
+
+This creates:
+
+```
+~/.agent-deck/conductor/my-conductor/
+├── CLAUDE.md          # per-conductor startup checklist (auto-generated)
+├── POLICY.md          # symlink to shared policy, or a per-conductor copy
+├── LEARNINGS.md       # patterns that worked or failed (starts empty)
+├── state.json         # persistent state across compactions (conductor writes this)
+└── task-log.md        # append-only log of what the conductor did (conductor writes this)
+```
+
+It also registers a session in agent-deck's registry and prints the session ID.
+
+### 2. Start it
+
+```bash
+agent-deck session start my-conductor
+```
+
+The tmux session spins up, Claude boots inside it, reads `CLAUDE.md` on start, and is now alive and waiting for its first instruction.
+
+To send something to it from your shell:
+
+```bash
+agent-deck session send my-conductor "status?"
+agent-deck session output my-conductor
+```
+
+### 3. Attach a Telegram channel (optional but recommended)
+
+Attaching a channel is what makes the conductor reachable remotely.
+
+**3a. Create a bot.** Open Telegram, message `@BotFather`, run `/newbot`, answer the two prompts, save the token it gives you. Token format is `{digits}:{alphanumeric}`.
+
+**3b. Find your chat ID.** Send any message to your new bot, then open `https://api.telegram.org/bot{YOUR_BOT_TOKEN}/getUpdates` in a browser. The `chat.id` in the response is `{YOUR_CHAT_ID}`.
+
+**3c. Make sure the telegram plugin is installed but not globally enabled.** You want the plugin's code on disk so agent-deck can activate it per-session. You do **not** want `enabledPlugins."telegram@claude-plugins-official" = true` in any profile's `settings.json`: that flag leaks a poller to every Claude session under the profile, and agent-deck will warn about it (`GLOBAL_ANTIPATTERN`, `DOUBLE_LOAD`). Check the flag with `jq '.enabledPlugins' "$CLAUDE_CONFIG_DIR/settings.json"` and remove the entry if it is there. The plugin gets activated per-session via the `channels` field in step 3f; step 3e injects the state dir.
+
+**3d. Pick a state directory for this bot.** One directory per bot. Never share across conductors.
+
+```bash
+mkdir -p ~/.agent-deck/channels/telegram-my-conductor
+echo "{YOUR_BOT_TOKEN}" > ~/.agent-deck/channels/telegram-my-conductor/.env
+chmod 600 ~/.agent-deck/channels/telegram-my-conductor/.env
+```
+
+**3e. Wire the env in `~/.agent-deck/config.toml`.** The conductor needs `TELEGRAM_STATE_DIR` set at launch. The clean way is an `env_file`:
+
+```toml
+[conductors.my-conductor.claude]
+config_dir = "~/.claude"
+env_file   = "~/.agent-deck/conductor/my-conductor/.envrc"
+
+# If you use groups:
+[groups.my-conductor.claude]
+config_dir = "~/.claude"
+env_file   = "~/.agent-deck/conductor/my-conductor/.envrc"
+```
+
+Then write the envrc:
+
+```bash
+echo 'export TELEGRAM_STATE_DIR=~/.agent-deck/channels/telegram-my-conductor' \
+  > ~/.agent-deck/conductor/my-conductor/.envrc
+```
+
+**3f. Attach the channel to the conductor session.**
+
+```bash
+agent-deck session set my-conductor channels plugin:telegram@claude-plugins-official
+```
+
+**3g. Restart the session so the channel comes up.**
+
+```bash
+agent-deck session restart my-conductor
+```
+
+**3h. Verify.**
+
+```bash
+# A single bun telegram process should be running, owning your state dir:
+pgrep -af 'bun.*telegram' | grep telegram-my-conductor
+
+# The bot responds to /getMe:
+curl -s "https://api.telegram.org/bot{YOUR_BOT_TOKEN}/getMe" | jq .ok
+# -> true
+```
+
+Send a message to the bot in Telegram. The conductor should receive it within a few seconds.
+
+## State files: what each is for
+
+Everything lives under `~/.agent-deck/conductor/<name>/`.
+
+### `CLAUDE.md`
+
+The startup checklist Claude reads on every session start or resume. Generated by `conductor setup` from a template, customizable with `--instructions-md`. Tells the conductor what its scope is, what agents live in its group, and what the reading order of the other files is.
+
+### `POLICY.md`
+
+The auto-response contract. Reads something like: "Messages that match pattern X → auto-respond with Y. Messages that ask for Z → escalate to the user with `NEED: ...`." The shared default is installed into the conductor base dir; `--policy-md` on `conductor setup` overrides it per conductor. You own this file; edit it directly when you want the conductor to behave differently.
+
+### `LEARNINGS.md`
+
+Append-only notes on what worked and what did not. The conductor is instructed to consult this at session start and write a new entry whenever a pattern stabilizes: either "this approach works reliably, keep doing it" or "this approach failed for reason X, avoid it". Over time this becomes your conductor's institutional memory.
+
+### `state.json`
+
+The conductor's own working memory across Claude compactions. Small JSON file. Per the template instructions, it holds summaries of each child session's state, the current top-level goal, and any handoff notes. The conductor reads it at the start of every interaction and updates it after every action. You almost never need to read or edit it yourself; when you do, `jq` over it is fine.
+
+### `task-log.md`
+
+Append-only timeline of what the conductor did and why. Useful for audits, for catching drift, and for writing post-incident reports. Format is freeform markdown; each entry is timestamped.
+
+## Heartbeat protocol
+
+If you enabled heartbeat at setup (it is enabled by default), agent-deck installs a `systemd --user` timer (Linux) or launchd agent (macOS) that pings the conductor on a schedule. Each ping is a simple message like:
+
+```
+[HEARTBEAT]
+```
+
+The conductor is instructed to respond with either:
+
+```
+[STATUS] {one-line summary of current state}
+```
+
+when everything is on track, or:
+
+```
+NEED: {question or decision point}
+```
+
+when it is blocked and wants to escalate. If a Telegram channel is attached, `NEED:` lines are forwarded to your chat; `[STATUS]` lines log to the task log and are only surfaced if you ask.
+
+Why bother? The heartbeat prevents a failure mode where a conductor appears healthy (tmux alive, Claude alive) but has silently drifted: it thinks it is waiting on you, you think it is waiting on a worker, nothing moves for hours. The heartbeat forces a periodic self-report.
+
+To disable heartbeat for a conductor:
+
+```bash
+agent-deck conductor setup my-conductor --no-heartbeat
+```
+
+## Running multiple conductors
+
+A typical setup: one conductor per logical scope. Work conductor, personal conductor, each customer, each repo, whatever axis you cut on.
+
+Rules for multi-conductor hosts:
+
+1. **One bot per conductor, never shared.** Share-a-bot leaks messages between scopes. Always pair a dedicated bot to each conductor.
+2. **One state directory per bot.** Every `TELEGRAM_STATE_DIR` is distinct. Two conductors pointing at the same state dir race each other for every inbound message.
+3. **Check for poller collisions.** After starting all conductors, `pgrep -af 'bun.*telegram' | wc -l` should equal the number of conductors with a telegram channel attached. If it is lower, one is not running; if it is higher, something is double-spawning.
+
+### A shortcut: worker-child isolation (v1.7.40+)
+
+In older agent-deck versions, a conductor that spawned a child session via `agent-deck launch` could accidentally inherit the parent's `TELEGRAM_STATE_DIR`, spawning a phantom poller inside the child. v1.7.40 fixed this structurally by giving every `launch` child an ephemeral scratch `CLAUDE_CONFIG_DIR` so the plugin does not get re-activated.
+
+Practical upshot: you can let your conductor spawn children liberally; the pollers stay pinned to the conductor itself.
+
+## Common gotchas
+
+**Plugin globally enabled by accident.** The opposite of the old trap: setting `enabledPlugins."telegram@claude-plugins-official" = true` in a profile's `settings.json` does *not* help, and actively leaks a poller to every Claude session under that profile. agent-deck warns about it (`GLOBAL_ANTIPATTERN`, `DOUBLE_LOAD`). The plugin code needs to be installed (`claude plugin add telegram@claude-plugins-official`) but disabled at the profile level; per-session activation happens through the session's `channels` field.
+
+**Tokens in git.** Never. Not in your conductor CLAUDE.md, not in a script you commit, not in the envrc if that envrc is under version control. The tokens live in the channel state directory only, chmod 600. If a token lands in git, revoke it via BotFather immediately; the bot token cannot be rotated in-place.
+
+**Wrapper-based env injection.** Older guides suggested `session set <id> wrapper "env FOO=bar {command}"`. This does not persist across `agent-deck session restart` or `claude --resume` and will occasionally flip your conductor to `error`. Use `[conductors.<name>.claude].env_file` in `config.toml` instead.
+
+**Blanket kills during debug.** Do not `pkill -f 'bun.*telegram'` or `tmux kill-server` on a host with a live conductor. The first destroys all pollers across every conductor at once; the second destroys every agent-deck tmux session simultaneously. If you need to restart one poller, prefer `agent-deck session restart <conductor>`.
+
+**Profile mismatch on setup.** If you run `conductor setup` under the wrong profile (`CLAUDE_CONFIG_DIR` pointing somewhere unintended), the conductor's config_dir resolution may later fail, and the session flips to `error` on resume. `agent-deck conductor teardown <name> --remove` is the clean-slate reset; you can run it and set up fresh without losing anything outside the conductor dir.
+
+## Lifecycle commands
+
+```bash
+# Create
+agent-deck conductor setup <name> [--description "..."] [--agent claude|codex] \
+    [--heartbeat|--no-heartbeat] [--instructions-md path] [--policy-md path]
+
+# Observe
+agent-deck conductor list
+agent-deck conductor status            # all conductors
+agent-deck conductor status <name>     # one conductor
+
+# Operate
+agent-deck session start <name>
+agent-deck session stop <name>
+agent-deck session restart <name>
+agent-deck session send <name> "message"
+agent-deck session output <name>
+
+# Tear down
+agent-deck conductor teardown <name>              # stop, keep files
+agent-deck conductor teardown <name> --remove     # stop and delete dir
+agent-deck conductor teardown --all --remove      # nuke every conductor on this host
+```
+
+The `--remove` flag is destructive: it deletes `~/.agent-deck/conductor/<name>/`. Your `LEARNINGS.md` and `task-log.md` go with it. Snapshot them first if they matter.
+
+## Where to go next
+
+- [SKILLS.md](SKILLS.md): conductors lean on skills heavily; how the two-tier skill system works.
+- [WATCHDOG.md](WATCHDOG.md): optional ops script that keeps a flaky conductor alive by auto-restarting it and catching stuck children.
+- [SESSION-PERSISTENCE-SPEC.md](SESSION-PERSISTENCE-SPEC.md): the underlying session-persistence rules conductors inherit.

--- a/docs/SESSION-PERSISTENCE-SPEC.md
+++ b/docs/SESSION-PERSISTENCE-SPEC.md
@@ -84,7 +84,7 @@ Each test MUST be independently runnable (`go test -run TestPersistence_<name> .
 
 ### REQ-4: Documentation as enforcement (P0)
 
-**Rule:** The repo's `CLAUDE.md` (at `/home/ashesh-goplani/agent-deck/CLAUDE.md`) contains a section titled "Session persistence: mandatory test coverage" that:
+**Rule:** The repo's `CLAUDE.md` (at `<repo-root>/CLAUDE.md`) contains a section titled "Session persistence: mandatory test coverage" that:
 
 - Lists the eight tests above by name.
 - Declares that any PR modifying files in `internal/tmux/`, `internal/session/instance.go`, `internal/session/userconfig.go`, or the `session start`/`session restart` command handlers MUST have passing runs of the full `TestPersistence_*` suite, and the PR description MUST include the test output or a CI run link.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,0 +1,152 @@
+# Skills: on-demand capabilities for agent-deck sessions
+
+Skills are packaged instructions that a Claude Code session can load to gain new capabilities. Each skill is a single directory with a `SKILL.md` file and optional scripts, references, and assets alongside. When Claude reads a `SKILL.md`, its instructions enter the current context and stay active until the session ends or the context is compacted away.
+
+agent-deck uses skills in two tiers. Understanding when to use which is the whole point of this doc.
+
+## The two tiers
+
+### User skills: always present
+
+**Where they live.** `~/.claude/skills/` (default profile) or `~/.claude-work/skills/` (work profile, if you use one), and inside `CLAUDE_PLUGIN_ROOT` directories for installed plugins.
+
+**How they load.** Every `claude` session, on every start and every resume, scans these locations and registers every skill it finds. The skills' descriptions (but not their full bodies) go into context so the model knows they exist and can invoke them when relevant.
+
+**Cost.** Constant, per session. Every skill in these directories costs you some tokens on every startup, whether you use it or not. Ten small skills is fine; a hundred large ones will eat noticeable context.
+
+**When to use.** Capabilities you need in 95%+ of your sessions. Examples: code simplification rules, commit hygiene, a universally-needed project-conventions skill. Anything you always want at hand.
+
+### Pool skills: loaded on demand
+
+**Where they live.** `<AGENT_DECK_ROOT>/skills/pool/` (typically `~/.agent-deck/skills/pool/`). Flat directory, one subfolder per skill. Not auto-discovered by Claude Code.
+
+**How they load.** Manually. Either:
+
+- From the terminal by attaching to a session: `agent-deck skill attach <session> <skill-name>` (the project-level attach workflow).
+- From inside a running Claude session by reading the file directly: `Read <AGENT_DECK_ROOT>/skills/pool/<skill-name>/SKILL.md`. Once read, the contents are in context.
+
+**Cost.** Zero when not loaded. When loaded, only for the lifetime of that session's context window.
+
+**When to use.** Capabilities that are project-specific, experimental, rarely-needed, or heavy (long references, big asset lists). A WordPress migration skill you use twice a quarter; a customer-specific worklog skill; a research playbook that is 1500 lines of instructions. Keep them in the pool and pay the cost only when you need them.
+
+### The rule of thumb
+
+Put a skill in user-level directories if you will use it in almost every session. Put it in the pool otherwise. In practice, `code-simplifier` is user-level; `ryan-worklog` and `ard-worklog` sit in the pool.
+
+## Invoking skills
+
+Inside Claude Code, an auto-loaded skill is invoked with a slash command that matches its directory name:
+
+```
+/skill-name
+```
+
+Claude sees the slash, matches it against the registered skill set, and (typically) loads the full `SKILL.md` body into context before the next turn.
+
+A pool skill that you have not auto-loaded is invoked by a direct read:
+
+```
+Read ~/.agent-deck/skills/pool/skill-name/SKILL.md
+```
+
+From that point in the conversation, its instructions are active. Skills "detach" naturally when the conversation ends or is compacted; there is no explicit detach command.
+
+### From agent-deck's CLI
+
+If you are running agent-deck, you can attach and detach skills at the project level without being inside the session:
+
+```bash
+# List what is discoverable.
+agent-deck skill list
+
+# Show what is currently attached to a session's project.
+agent-deck skill attached my-project
+
+# Attach a skill. The --source flag picks where to resolve from (pool, user, team, etc.).
+agent-deck skill attach my-project ryan-worklog --source pool --restart
+
+# Detach.
+agent-deck skill detach my-project ryan-worklog
+```
+
+Attach writes the skill's materialized form into the project's `.claude/skills/` directory and updates `.agent-deck/skills.toml` so the state survives session restarts.
+
+## Authoring a skill
+
+The canonical path: use Anthropic's own `example-skills:skill-creator` skill. It has a bootstrap script (`init_skill.py`) that scaffolds a correctly-shaped SKILL.md, a `package_skill.py` helper for distribution, and lint rules that match what Claude Code expects.
+
+### Directory shape
+
+```
+skill-name/
+├── SKILL.md          # required
+├── scripts/          # optional: executables the skill wants to run
+├── references/       # optional: long docs the skill wants to cite
+└── assets/           # optional: images, templates, fixtures
+```
+
+### SKILL.md frontmatter
+
+```yaml
+---
+name: skill-name
+description: |
+  One to three sentences describing WHAT this skill does and, more importantly,
+  WHEN Claude should use it. The description is what Claude sees to decide
+  relevance, so be specific about trigger conditions: "use when X", "applies
+  to Y", "do not use for Z".
+---
+```
+
+The `name` field must match the directory name. The `description` is what gets loaded into every session that auto-discovers the skill, so keep it tight but explicit: a vague description means the skill never fires when it should, or worse, fires when it should not.
+
+### SKILL.md body
+
+The body is markdown. Claude reads it only when the skill is invoked. There is no hard size limit, but keep it focused: a skill that tries to teach everything teaches nothing.
+
+Common structure:
+
+1. A one-paragraph restatement of purpose.
+2. Concrete triggers: "use this when the user says X" or "use after completing Y".
+3. The procedure: ordered steps, with file paths and command examples.
+4. Constraints: what NOT to do, what to escalate.
+5. Pointers to the references/ and scripts/ subdirs for detail.
+
+## agent-deck's own shipped skills
+
+The repo ships a small set of skills inside `skills/`:
+
+- `skills/agent-deck/SKILL.md`: the canonical orchestration skill. Covers session lifecycle, MCP attach/detach, groups, profiles, worktree sessions, and sub-agent launching. Every installation gets a curl-one-liner in the README that drops it straight into `~/.claude/skills/agent-deck/`.
+- `skills/watcher-creator/`: guides the creation of watcher processes under the watcher framework.
+- `skills/session-share/`: helpers for exporting and importing sessions between developers.
+
+These are shipped as reference implementations: you can read them to understand how a well-shaped skill is written.
+
+## When to prefer user-level vs pool
+
+Use **user-level** when:
+
+- You use the skill in almost every session (>90% of the time).
+- The skill is small enough that loading its description on every start is negligible.
+- The skill represents universal rules (style, commit hygiene, TDD gates).
+
+Use **pool** when:
+
+- The skill is scoped to one project, one customer, or one workflow.
+- The skill is experimental and you want to invoke it consciously.
+- The skill is large (long references, many procedures) and loading its description everywhere would be wasteful.
+- You are iterating on the skill's wording and want to control when it is active.
+
+A skill can start in the pool, prove itself useful, and get promoted to user-level with a symlink. Going the other way (demoting a user skill to the pool) is equally easy: move the directory, leave a note for your future self.
+
+## Caveats
+
+- **Pool skills do not auto-discover.** If you add a skill to the pool and expect `/skill-name` to work without attaching it first, it will not. You either attach it via `agent-deck skill attach` or `Read` it explicitly.
+- **Skills are text, not code.** They persuade, they do not compile. A skill that says "always run the tests" only works if the model actually runs the tests. Write skills that are easy to follow and include command examples the model can copy verbatim.
+- **SKILL.md frontmatter drift.** If you rename a skill's directory, update the `name` field. Mismatches cause quiet registration failures that look like "Claude knows the skill but will not invoke it".
+- **Context budget on startup.** Every auto-discovered skill contributes to context on every session start. If startup feels heavy, list `~/.claude/skills/` and consider which of them really belong in the pool.
+
+## Related docs
+
+- [CONDUCTOR.md](CONDUCTOR.md): conductors lean heavily on skills for policy and routines.
+- [WATCHDOG.md](WATCHDOG.md): the watchdog itself has no skill, but conductors it restarts typically do.

--- a/docs/WATCHDOG.md
+++ b/docs/WATCHDOG.md
@@ -1,0 +1,214 @@
+# Watchdog: auto-restart critical sessions and nudge stuck children
+
+The watchdog is an optional Python daemon that sits alongside agent-deck and keeps critical sessions alive. You do not need it to use agent-deck. You will want it the first time a conductor flips to `error` while you are asleep, or the first time a child session sits frozen on an unseen prompt for an hour.
+
+It is not a replacement for the in-tree session reviver (`internal/session/reviver.go`). The reviver handles dead control pipes for sessions whose tmux is still alive. The watchdog handles three classes of failure the reviver intentionally does not:
+
+1. A critical session that died outright (tmux gone too) and that you have pre-declared should auto-restart.
+2. A Telegram bot poller that has disappeared while the conductor it belongs to is otherwise healthy: a "deaf conductor".
+3. A child session that has been sitting in `waiting` with an unchanged tmux pane for longer than any child should.
+
+If any of those sound familiar, read on.
+
+## What ships in the repo
+
+Since v1.7.63 the watchdog is a first-class artefact living at `scripts/watchdog/` in this repository. Previous versions only existed in a maintainer's private `~/.agent-deck/watchdog/` directory; the in-tree version is identical, sanitized, test-gated, and upgraded through normal agent-deck releases.
+
+```
+scripts/watchdog/
+├── watchdog.py          # the daemon (single file, ~1100 lines of Python)
+├── test_watchdog.py     # 62-test suite; TDD-gated
+├── escalate.sh          # fires a Telegram message when the daemon wants to alert you
+├── DESIGN.md            # full architecture, guardrails, decision log
+└── README.md            # install + operational quickstart
+```
+
+No Go compilation required. Python 3.10 or newer, no third-party packages beyond the standard library.
+
+## What the watchdog does
+
+### Capability 1: auto-restart critical sessions
+
+For a small allow-list of "critical" sessions, the watchdog will run `agent-deck session restart <id>` automatically whenever one flips to `error`. A session counts as critical if any of:
+
+- its `title` starts with `conductor-`,
+- its `group` is `"conductor"` or `"watchers"`,
+- `is_conductor: true` in its session record,
+- or you have touched an opt-in flag file at `~/.agent-deck/watchdog/autorestart/<id>`.
+
+Every restart is bounded by guardrails:
+
+- **Per-session rate limit.** At most three restarts per session per 300 seconds. Hitting the limit escalates to Telegram (if configured) and logs locally.
+- **Global cascade guard.** At most one restart across all sessions every 60 seconds. Prevents a bad release from restart-looping the whole host.
+- **429 detection.** If a restart output contains "rate limit" or "429", the watchdog backs off and escalates rather than burning quota.
+- **Post-restart cool-down.** A just-restarted session is ignored for 60 seconds so the reviver and watchdog do not double-fire (issue #30 is also guarded on the Go side).
+
+Sessions whose status is `stopped` are excluded: "stopped" means you deliberately stopped it, so auto-restart would fight the user.
+
+### Capability 2: Telegram poller liveness (v1.7.63)
+
+For every conductor session with `plugin:telegram@claude-plugins-official` in its channels list, the watchdog verifies a `bun ... telegram ...` subprocess is running and owns the expected `TELEGRAM_STATE_DIR`. The state dir is read from the conductor's `env_file` in `config.toml`.
+
+If a conductor has the channel attached but no bun process owns its state dir, the watchdog fires `agent-deck session restart <id>`. Dedupe window: one restart per hour per conductor.
+
+This catches the "deaf conductor" failure: tmux is alive, Claude is alive, you can `session send` to it just fine, but messages to the Telegram bot go nowhere because the plugin's poller died quietly and nothing in the existing stack notices.
+
+### Capability 3: waiting-too-long patrol (v1.7.63)
+
+For every child session (one with `parent_session_id` set), the watchdog takes a SHA-256 hash of its tmux pane output every safety-poll tick. If the session sits in `status=waiting` with an unchanged pane hash for longer than 10 minutes, the watchdog injects a gentle `report status?` nudge via `agent-deck session send --no-wait`. Dedupe: one nudge per hour per session.
+
+Pane change resets the timer. A status change (e.g. `waiting` → `running`) evicts the tracker entry entirely.
+
+This catches the other quiet failure mode: a child that finished its work, asked the user a yes-or-no question via Claude, and now sits invisibly in `waiting` status because no one is looking at its pane. The nudge makes the child speak up in its output, which the conductor or its watcher will pick up.
+
+## What the watchdog will not do
+
+- Create sessions. It only operates on sessions agent-deck already knows about.
+- Merge PRs, push code, trigger deploys. It is a session-health tool; authorization boundaries are kept narrow on purpose.
+- Restart itself. The systemd/launchd unit owns that.
+- Guess the user's intent on ambiguous state. When rate-limited or confused, it escalates rather than retrying.
+- Touch arbitrary worker sessions. Auto-restart is opt-in: either the session declares itself (conductor title, group, `is_conductor`) or you flag it explicitly.
+
+## Installation
+
+### Linux (systemd --user)
+
+```bash
+# 1. Stage the daemon under your runtime root.
+mkdir -p ~/.agent-deck/watchdog
+install -m 755 scripts/watchdog/watchdog.py ~/.agent-deck/watchdog/watchdog.py
+install -m 755 scripts/watchdog/escalate.sh ~/.agent-deck/watchdog/escalate.sh
+
+# 2. Dry-run to sanity-check the install.
+python3 ~/.agent-deck/watchdog/watchdog.py --once --dry-run --verbose
+
+# 3. Install the user-level systemd unit.
+cat > ~/.config/systemd/user/agent-deck-watchdog.service <<'EOF'
+[Unit]
+Description=agent-deck watchdog
+After=default.target
+
+[Service]
+ExecStart=/usr/bin/python3 %h/.agent-deck/watchdog/watchdog.py
+Restart=always
+RestartSec=5
+Environment=AGENT_DECK_BIN=/usr/local/bin/agent-deck
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable --now agent-deck-watchdog.service
+
+# 4. Check it came up.
+systemctl --user status agent-deck-watchdog.service
+journalctl --user -u agent-deck-watchdog -n 50
+```
+
+Linger needs to be enabled if you want the watchdog to run while you are logged out: `sudo loginctl enable-linger $USER`.
+
+### macOS (launchd)
+
+```bash
+mkdir -p ~/.agent-deck/watchdog
+install -m 755 scripts/watchdog/watchdog.py ~/.agent-deck/watchdog/watchdog.py
+install -m 755 scripts/watchdog/escalate.sh ~/.agent-deck/watchdog/escalate.sh
+
+cat > ~/Library/LaunchAgents/com.agentdeck.watchdog.plist <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>                <string>com.agentdeck.watchdog</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/python3</string>
+    <string>/Users/YOUR_USER/.agent-deck/watchdog/watchdog.py</string>
+  </array>
+  <key>RunAtLoad</key>            <true/>
+  <key>KeepAlive</key>            <true/>
+  <key>StandardOutPath</key>      <string>/tmp/agent-deck-watchdog.stdout.log</string>
+  <key>StandardErrorPath</key>    <string>/tmp/agent-deck-watchdog.stderr.log</string>
+</dict>
+</plist>
+EOF
+
+launchctl load -w ~/Library/LaunchAgents/com.agentdeck.watchdog.plist
+```
+
+### Cron fallback
+
+If neither systemd nor launchd is available, a cron entry running the watchdog in `--once` mode every minute is a reasonable degradation:
+
+```
+* * * * * /usr/bin/python3 $HOME/.agent-deck/watchdog/watchdog.py --once >> $HOME/.agent-deck/watchdog/cron.log 2>&1
+```
+
+You lose the inotify fast-path (a restart then takes up to 60 s instead of ~100 ms), but all three capabilities still function.
+
+## Configuration
+
+All configuration is through environment variables. There is no config file.
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `AGENT_DECK_ROOT` | Where hooks, logs, and watchdog state live. | `~/.agent-deck` |
+| `AGENT_DECK_BIN` | Path to the `agent-deck` binary. Set this explicitly if the watchdog runs outside your login `$PATH`. | `/usr/local/bin/agent-deck` |
+| `AGENT_DECK_PROFILE` | The profile to use for `agent-deck list` / `session show` / `session restart`. | `default` |
+| `TELEGRAM_ESCALATION_CHAT_ID` | Chat ID the watchdog sends its own alerts to (rate-limit hits, 429s, escalations). **Empty by default: without it, escalations only log locally.** | `""` |
+| `POLLER_RESTART_DEDUP_S` | Dedupe window for poller-liveness restarts. | `3600` |
+| `WAITING_PATROL_THRESHOLD_S` | How long a child must sit in `waiting` with unchanged pane before a nudge. | `600` |
+| `WAITING_PATROL_NUDGE_DEDUP_S` | Dedupe window for waiting-too-long nudges. | `3600` |
+| `MIN_GLOBAL_RESTART_INTERVAL_S` | Global cascade guard. Do not lower. | `60` |
+
+Full detail, including internal constants and why they are what they are, is in `scripts/watchdog/DESIGN.md` alongside the daemon.
+
+## Expected output
+
+In normal operation the watchdog is silent. The service runs, the logs grow slowly, nothing happens because nothing needs to happen.
+
+When something fires, log lines land in `$AGENT_DECK_ROOT/watchdog/`:
+
+- `watchdog.log`: general runtime events (safety-poll ticks in verbose mode, state transitions, dedupe decisions).
+- `restart.log`: every restart attempt, with the decision path (which capability triggered, which session, why).
+- `escalations.log`: entries for each Telegram escalation, whether it was sent or rate-limited.
+
+If you configured `TELEGRAM_ESCALATION_CHAT_ID`, rate-limit hits and repeated-failure escalations go to that chat in addition to logging.
+
+## Running the tests
+
+The watchdog has its own TDD gate.
+
+```bash
+cd scripts/watchdog
+python3 -m unittest test_watchdog -v
+```
+
+The full 62-test suite takes about nine minutes because several tests exercise the global restart serialization. When iterating on the v1.7.63 additions only:
+
+```bash
+python3 -m unittest \
+  test_watchdog.TestPollerExistence \
+  test_watchdog.TestBunTelegramStateDirs \
+  test_watchdog.TestWaitingTooLong
+# Runs in under a second.
+```
+
+Any change to `scripts/watchdog/watchdog.py` or its helpers needs the full suite green before it lands.
+
+## Troubleshooting
+
+**The service is running but nothing happens when I kill a conductor.** Check that the conductor meets the critical-session criteria (title prefix, group, `is_conductor`, or opt-in flag). If not, the watchdog ignores it by design.
+
+**Restarts fire in a loop.** The per-session rate limit should prevent this. If it does not, set `--verbose --dry-run` on the daemon and watch a cycle: either the dedupe is miscomputing (file a bug), or the root cause is a consistently-broken session that needs a real fix, not auto-restart.
+
+**The poller-existence check keeps firing.** The most common cause is that `enabledPlugins.telegram@claude-plugins-official` is not `true` in the profile's `settings.json`, so the bun poller never starts in the first place. Restarting the conductor does not help. Enable the plugin under the right `CLAUDE_CONFIG_DIR` and the restart will stick.
+
+**Waiting-too-long patrol is noisy.** Either the child sessions genuinely are stuck (the watchdog is doing its job: fix the root cause), or your workload has naturally long idle periods and 10 minutes is too short. Raise `WAITING_PATROL_THRESHOLD_S` in the systemd unit's `Environment=` lines.
+
+## Related docs
+
+- [CONDUCTOR.md](CONDUCTOR.md): the sessions the watchdog primarily protects.
+- `scripts/watchdog/DESIGN.md`: architecture, guardrails, decision log. Read this before modifying the daemon.
+- `scripts/watchdog/README.md`: operational quickstart that lives next to the daemon.

--- a/docs/WATCHERS.md
+++ b/docs/WATCHERS.md
@@ -1,0 +1,195 @@
+# Watchers: lean triggers from the outside world into your conductors
+
+A watcher is the thing that rings the doorbell. It does not carry the package inside; it just rings. When a GitHub issue gets filed, when a Slack message arrives, when your phone fires an ntfy push, when your gmail-watcher script notices a new label — a watcher's only job is to drop a short, normalized trigger onto a conductor session so the conductor can decide what to do next.
+
+This doc explains the watcher framework that ships in `internal/watcher/`, the philosophy behind it, and how to extend it with your own custom sources.
+
+## The doorbell model
+
+A conductor is an expensive, context-heavy Claude session. Every token you hand it at wake-up time is a token it cannot spend on actual work. So the rule is:
+
+**Forward the bell, not the package.**
+
+- ❌ Forwarding the full email body, the entire meeting transcript, the complete webhook payload. Floods context. Costs tokens. Makes the conductor's log unreadable.
+- ✅ Forwarding `[github:pr_opened:asheshgoplani/agent-deck#740]` and letting the conductor call `gh pr view 740` itself if (and only if) it decides the event is worth acting on.
+
+A good trigger is:
+
+- **Short.** Convention: ≤200 characters. If you need more, you are smuggling data that the conductor should fetch live.
+- **Structured.** `[source:type:identifier] optional hint`. The conductor's prompt can pattern-match on it. `[gmail:new:label=agent-deck] 3 unread` is a good trigger; `New email from bob@example.com titled "hey"` is not.
+- **Self-contained enough to ignore.** The conductor reads the trigger, and if it does not care, it moves on. It should never need to fetch state just to decide whether a trigger is relevant.
+
+Why this matters: conductors run for weeks. A conductor that auto-fetches every trigger's full payload will hit its context limit and start compacting away real work to make room for email bodies. A conductor that treats triggers as doorbells and fetches live state on demand stays lean indefinitely.
+
+## What ships in the repo
+
+The framework lives at `internal/watcher/`:
+
+```
+internal/watcher/
+├── adapter.go         # WatcherAdapter interface, AdapterConfig, normalized Event struct
+├── engine.go          # Runs adapters, dispatches events to router + event_log
+├── event_log.go       # SQLite-backed dedupe (INSERT OR IGNORE on (name, event_id))
+├── health_bridge.go   # Cross-links watcher health with the session reviver
+├── layout.go          # ~/.agent-deck/watcher/<name>/ folder layout (REQ-WF-6)
+├── router.go          # Maps events → target conductor/group via clients.json
+├── state.go           # Per-watcher state.json (last seen, failure counts)
+├── webhook.go         # Generic HTTP webhook adapter
+├── github.go          # GitHub webhook adapter (HMAC-SHA256 verified)
+├── ntfy.go            # ntfy.sh push-notification topic adapter
+├── slack.go           # Slack-over-ntfy bridge adapter
+├── gmail.go           # Gmail IMAP adapter (scaffold; see gmail_test.go)
+├── triage.go          # Triage subprocess lifecycle (reaper, zombie gate)
+└── assets/            # Skills + templates embedded into the binary
+```
+
+Subcommands live in `cmd/agent-deck/watcher_cmd.go`; the TUI watcher panel is at `internal/ui/watcher_panel.go` (press `w`).
+
+Every adapter implements the same small interface (`internal/watcher/adapter.go`):
+
+```go
+type WatcherAdapter interface {
+    Setup(ctx context.Context, config AdapterConfig) error
+    Listen(ctx context.Context, events chan<- Event) error
+    Teardown() error
+    HealthCheck() error
+}
+```
+
+`Listen` is the only method that does real work: it blocks, normalizes whatever raw payload the source sends, and pushes `Event` structs onto the channel. The engine handles dedupe, routing, event log writes, and health accounting. Adapters stay tiny.
+
+## Built-in adapter types
+
+Four adapters are wired into the CLI today. All four embody the doorbell model — the event fields they forward are small and structured.
+
+| Type | What it listens for | Required flag | Transport |
+|------|---------------------|---------------|-----------|
+| `webhook` | Any service that can fire an HTTP POST | `--port <int>` | Local HTTP listener |
+| `github` | GitHub repo events (issues, PRs, pushes) | `--secret <hmac-secret>` | HTTPS webhook + HMAC-SHA256 verify |
+| `ntfy` | [ntfy.sh](https://ntfy.sh) topics (phone → conductor) | `--topic <name>` | Persistent SSE subscription |
+| `slack` | Slack messages via a Cloudflare Worker bridge into an ntfy topic | `--topic <name>` | Slack → CF Worker → ntfy → watcher |
+
+A fifth adapter (`gmail`) is scaffolded in `gmail.go` but not exposed through `watcher create` at the time of this writing. If you need gmail right now, the supported path is an external polling script (see "Custom external watchers" below) rather than enabling the internal adapter.
+
+## CLI surface
+
+Verified against `agent-deck watcher --help`:
+
+```
+agent-deck watcher create <type> --name <name> [options]
+agent-deck watcher start <name>
+agent-deck watcher stop <name>
+agent-deck watcher list [--json]
+agent-deck watcher status <name> [--json]
+agent-deck watcher test <name>
+agent-deck watcher routes [--json]
+agent-deck watcher import <path>
+agent-deck watcher install-skill <skill-name>
+```
+
+The usual loop:
+
+```bash
+# Create the watcher (writes ~/.agent-deck/watcher/<name>/ with watcher.toml + state.json).
+agent-deck watcher create github --name gh-alerts --secret "$GITHUB_WEBHOOK_SECRET"
+
+# Activate it (picked up by the engine on the next tick).
+agent-deck watcher start gh-alerts
+
+# Confirm: list shows status + events/hour; status shows recent events.
+agent-deck watcher list
+agent-deck watcher status gh-alerts
+
+# Smoke-test without waiting for a real event.
+agent-deck watcher test gh-alerts
+```
+
+`agent-deck watcher routes` prints the currently-loaded routing rules across every watcher, so you can double-check which conductor or group owns which event types.
+
+Conversational setup is also supported: `agent-deck watcher install-skill watcher-creator` drops a Claude Code skill into `~/.agent-deck/skills/pool/`, and inside an agent-deck Claude session you can then ask *"Use the watcher-creator skill to set up a GitHub watcher"*. The skill walks through adapter choice, required settings, and emits the exact `watcher create` command.
+
+## Routing: how an event finds a conductor
+
+Each watcher gets its own directory at `~/.agent-deck/watcher/<name>/` with (REQ-WF-6):
+
+```
+~/.agent-deck/watcher/<name>/
+├── watcher.toml     # adapter type + [source] settings
+├── clients.json     # routing rules: event type → target conductor/group
+├── state.json       # last-seen cursor, consecutive-failure counter, health
+└── events.log       # append-only dedupe-resolved event log (mirrored into SQLite)
+```
+
+`clients.json` is where you decide *which* conductor wakes up for *which* event. Edit it by hand, or let `watcher create` prompt you for defaults. `agent-deck watcher routes` is the authoritative read-out.
+
+Dedupe is SQL-level: `INSERT OR IGNORE INTO watcher_events (watcher_name, event_id, ...)`. Retries from the sender (GitHub re-fires when its delivery times out, ntfy replays when the subscriber reconnects) cannot double-fire a conductor. Turning this off requires an RFC.
+
+## Security guarantees
+
+- **GitHub adapter verifies HMAC-SHA256** on every webhook. Missing or invalid signature → event dropped, counter incremented, nothing forwarded. Removing this check requires an RFC (`CLAUDE.md` "Watcher structural changes requiring RFC").
+- **ntfy adapter** relies on topic secrecy. Use a long random topic name; anyone who knows it can publish to it.
+- **webhook adapter** binds to localhost by default; exposing it to the public internet is on you (use a reverse proxy + auth header).
+- **slack adapter** rides on top of the ntfy adapter, so it inherits ntfy's topic-secrecy threat model plus whatever you put in front of your Cloudflare Worker.
+
+## Custom external watchers
+
+The in-repo framework covers HTTP-receivable sources. For sources that require polling — IMAP inboxes, calendar APIs, a CI that only exposes a status page, a custom SaaS — the cleanest pattern today is an **external polling script** that forwards triggers via `agent-deck session send`.
+
+The pattern:
+
+1. **Poll.** A small script (Python, bash, Go — whatever fits) queries the source on a schedule. systemd timers or launchd work well; so does a plain `while true; do ...; sleep 60; done` under agent-deck itself.
+2. **Dedupe locally.** Track "last seen" in a state file (`~/.agent-deck/events/<name>.last`, a SQLite file, whatever). Do not rely on the conductor to filter duplicates — that is context pressure you can avoid.
+3. **Forward lean.** Emit the bell, not the package:
+   ```bash
+   agent-deck session send <conductor-name> "[gmail:new:label=agent-deck] 3 unread" --no-wait
+   ```
+   `--no-wait` matters: if the conductor is unreachable, you want the script to log-and-move-on rather than block until timeout.
+4. **Test the silent-failure path.** A watcher that cannot reach its conductor is worse than useless, because nobody notices. Emit a metric or log line on every successful send, and page yourself if the send count drops to zero.
+
+Two informal examples of this pattern, both maintainer-side rather than in this repo:
+
+- **gmail-watcher** — polls an IMAP label, fires `[gmail:new:...]` triggers.
+- **meeting-watcher** — polls Google Calendar, fires `[calendar:starting:<event>]` triggers ~5 minutes before meetings.
+
+Neither ships in agent-deck because both are tied to a specific identity's credentials. The pattern above is what you are copying, not the scripts themselves.
+
+## Writing a first-class in-repo adapter
+
+If your source *can* be wired through the built-in engine (it exposes webhooks, a push channel, or a long-lived stream), it is worth adding a real adapter. You get dedupe, health, the TUI panel, and the event log for free.
+
+Drop a new file into `internal/watcher/` that implements `WatcherAdapter`, register it in `engine.go`, teach `watcher_cmd.go` about the new `--type`. Then — non-negotiable per `CLAUDE.md`:
+
+```bash
+go test ./internal/watcher/... -race -count=1 -timeout 120s
+go test ./cmd/agent-deck/... -run "Watcher" -race -count=1
+bash scripts/verify-watcher-framework.sh
+```
+
+Any change under `internal/watcher/**`, `cmd/agent-deck/watcher_cmd*.go`, `internal/ui/watcher_panel.go`, or `internal/statedb/statedb.go` (watcher rows) is test-gated. `TestSkillDriftCheck_WatcherCreator` additionally enforces that embedded skills + README + CHANGELOG stay in sync with the layout (REQ-WF-7).
+
+## Common gotchas
+
+- **Forwarding verbose content.** Breaks the doorbell model. Every extra kilobyte costs tokens on every conductor turn until the context compacts. If your trigger is >200 chars you are probably smuggling data.
+- **No local dedupe in a polling script.** Some sources re-deliver on retry (IMAP on reconnect, cron re-runs, flaky networks). Without a state file you will fire the same trigger again and again, and the conductor will eventually start ignoring you — or, worse, act on stale signals.
+- **Forgetting `--no-wait` in a polling script.** `session send` blocks until the session acknowledges. A wedged conductor then wedges every watcher that forwards to it. Use `--no-wait` unless you genuinely need the ack.
+- **Leaking host-private topic names into shared configs.** `ntfy` topic secrecy is your only auth. Do not commit topic names into tracked files; keep them in `~/.agent-deck/watcher/<name>/watcher.toml`.
+- **Standing up a new adapter without updating embedded skills.** `TestSkillDriftCheck_WatcherCreator` will fail the build. Fix the assets alongside the code.
+- **Assuming the event log is for debugging only.** It is the dedupe source of truth. Hand-editing `events.log` or deleting SQLite rows can cause the next real event to fire twice.
+
+## Interaction with conductors
+
+A conductor that receives a trigger is responsible for everything that happens next:
+
+1. Parse the trigger (`[source:type:identifier]` is a stable format).
+2. Decide whether it cares. Many triggers are ignored. That is healthy.
+3. If relevant, fetch live state (`gh pr view`, `curl`, `slack api`, whatever the source exposes).
+4. Act — or delegate to a child session — or escalate to the user via the conductor's channel.
+
+The watcher does not know which of these happens. That is the separation of concerns that makes the whole thing scale.
+
+## Related docs
+
+- [CONDUCTOR.md](CONDUCTOR.md) — what the watcher is ringing the doorbell *for*.
+- [WATCHDOG.md](WATCHDOG.md) — keeps the conductor alive so the doorbell gets answered.
+- [SKILLS.md](SKILLS.md) — `watcher-creator` is a pool skill; this doc explains the two tiers and how to install skills.
+- `internal/watcher/` — the code. Start at `adapter.go` and `engine.go` to understand the data flow.


### PR DESCRIPTION
## Summary

Two-part docs pass. No code, test, CHANGELOG, or version changes.

### Part A: scrubbed host-private absolute paths

Every \`/home/<user>/\` prefix and bare \`<user>\` token in git-tracked markdown is replaced with a neutral placeholder so public readers never see the maintainer's host paths or login name.

Replacements applied in this order (most-specific first):

| Pattern | Replacement |
|---|---|
| \`/home/<user>/agent-deck\` | \`<repo-root>\` |
| \`/home/<user>/.agent-deck\` | \`~/.agent-deck\` |
| \`/home/<user>/.claude\` | \`~/.claude\` |
| \`/home/<user>/.nvm\` | \`~/.nvm\` |
| \`/home/<user>\` (catch-all) | \`~\` |
| bare \`<user>\` (ls/LOGNAME/USER/hostname) | \`<user>\` |

Scope: \`docs/**/*.md\` and \`.planning/**/*.md\`. Source code, Go files, tests, public GitHub URLs (\`github.com/asheshgoplani/...\`), and the \`asheshgoplani\` GitHub handle are intentionally untouched (public, legit).

Files scrubbed (46 total, all .md):

- \`docs/SESSION-PERSISTENCE-SPEC.md\` -- REQ-4 rule block referenced the repo CLAUDE.md by absolute path.
- \`.planning/STATE.md\` -- top-of-file Repository/Worktree block.
- \`.planning/phases/**/*.md\` (44 files) -- execute-plan/summary.md @-include paths, shell-captured \`cd <abs>\` commands, \`ls -la\` output blocks, hostname/USER/LOGNAME env dumps.
- \`.planning/phases/04-verification-harness-docs-and-ci-wiring/04-VERIFY.md\` -- \`loginctl show-user\`, \`uname -a\`, and systemd show-environment output with embedded username.
- \`.planning/phases/03-visual-harness-documentation-attribution-commit/03-VERIFICATION.md\` -- \`accepted_by:\` authorship field and override attestation.

No token patterns (\`\\b[0-9]{9,10}:[A-Za-z0-9_-]{35}\\b\`) were found; no \`<user-id>\` chat IDs leaked.

Final sanitize scan:
\`\`\`
$ git grep -nE '<home-token>|<user-id>|\b[0-9]{9,10}:[A-Za-z0-9_-]{35}\b' -- '*.md'
(empty)
\`\`\`

### Part B: three new user-facing guides + README index

Added under \`docs/\`:

- **\`docs/CONDUCTOR.md\`** (244 lines): what a conductor is, ~10-min quickstart including Telegram bot pairing with placeholders only (\`{YOUR_BOT_TOKEN}\`, \`{YOUR_CHAT_ID}\`), state file tour (\`CLAUDE.md\`, \`POLICY.md\`, \`LEARNINGS.md\`, \`state.json\`, \`task-log.md\`), heartbeat protocol, multi-conductor hygiene, gotchas (plugin-global anti-pattern, tokens-in-git, wrapper env injection, blanket kills, profile mismatch), full lifecycle command cheat sheet.
- **\`docs/WATCHDOG.md\`** (215 lines): optional Python daemon at \`scripts/watchdog/\`, its three capabilities (critical auto-restart, Telegram poller liveness check, waiting-too-long patrol), systemd + launchd + cron install paths, env-var config table, what it will NOT do, troubleshooting.
- **\`docs/SKILLS.md\`** (152 lines): two-tier model (user-level vs pool), where each lives, cost and load semantics, invocation paths (slash command vs Read vs \`agent-deck skill attach\`), authoring (frontmatter, body structure, canonical \`example-skills:skill-creator\`), agent-deck's own shipped skills, decision rule for user vs pool, caveats.

README.md now has a **User guides** table at the top of the Documentation section linking all three, placed above the existing references tables.

### Known scope note

\`docs/WATCHDOG.md\` references \`scripts/watchdog/\` which ships from v1.7.63 in PR #736 (currently on \`feature/fix/727-timeout-zero-unlimited\`). The guide describes that shipped behavior based on the canonical \`scripts/watchdog/README.md\` and \`DESIGN.md\` in that commit. Once #736 lands on main, the guide's internal references become live. No link in this PR points at a file that does not exist in this branch.

## CLI verification

Every CLI example in the new guides was verified against \`agent-deck --help\`, \`agent-deck conductor --help\`, \`agent-deck session --help\`, \`agent-deck skill --help\`. Subcommands used: \`conductor setup/teardown/list/status\`, \`session start/stop/restart/send/output/show/set\`, \`skill list/attached/attach/detach\`. No invented commands.

One early draft of CONDUCTOR.md step 3c advised \`claude plugin enable telegram@claude-plugins-official\` at the profile level; this was caught and rewritten before commit because the repo README actively warns against it (\`GLOBAL_ANTIPATTERN\`, \`DOUBLE_LOAD\`). The final guide directs readers to install the plugin but leave it profile-disabled, and activates it per-session via the \`channels\` field.

## Test plan

- [ ] Sanitize scan stays empty: \`git grep -nE '<home-token>|<user-id>|\b[0-9]{9,10}:[A-Za-z0-9_-]{35}\b' -- '*.md'\`
- [ ] \`docs/CONDUCTOR.md\`, \`docs/WATCHDOG.md\`, \`docs/SKILLS.md\` render on GitHub.
- [ ] README.md Documentation section shows new User guides table.
- [ ] All internal \`[FOO](SIBLING.md)\` links between the three new files resolve.
- [ ] The placeholder \`{YOUR_BOT_TOKEN}\` / \`{YOUR_CHAT_ID}\` appear exactly in the step-3 code blocks and nowhere else (no real tokens leak).

---

## Follow-up commit: WATCHERS.md + .planning/ ignore rule

A third commit was added on this branch after initial review.

### A. `.gitignore`: `.planning/`

`.planning/` was scrubbed in Part A of this PR, but the directory is design/planning scratch that should not accumulate in a public repo going forward. Added a rule so future additions are ignored:

```
# Internal planning / scratch (design docs, phase plans) — private to maintainer host
.planning/
```

**Note**: `git rm -r --cached .planning/` was **not** done here — existing scrubbed files stay in git history. Only future additions are ignored. Fully ripping `.planning/` out of the repo is a separate, larger PR.

Verification:
```
$ git check-ignore -v .planning/README.md
.gitignore:63:.planning/	.planning/README.md
```

### B. `docs/WATCHERS.md` (new, 195 lines)

User-facing guide to the event-forwarding framework under `internal/watcher/`. Covers:

- The **doorbell model**: forward the bell, not the package. Trigger convention `[source:type:identifier]` ≤200 chars; conductor fetches live state on demand.
- The `WatcherAdapter` interface and what ships in `internal/watcher/` (adapter/engine/event_log/router/state plus the four adapters).
- The four built-in adapter types (`webhook`, `github`, `ntfy`, `slack`) with required flags and transport details. A `gmail` adapter is scaffolded but not wired into `watcher create` yet; doc notes this.
- CLI surface verified against `agent-deck watcher --help`: `create`, `start`, `stop`, `list`, `status`, `test`, `routes`, `import`, `install-skill`.
- Routing via `~/.agent-deck/watcher/<name>/clients.json`, SQLite-level dedupe (`INSERT OR IGNORE on (watcher_name, event_id)`), and HMAC-SHA256 on GitHub webhooks — all test-gated per `CLAUDE.md`.
- External polling-script pattern for sources that cannot webhook (IMAP, calendar, custom SaaS): `agent-deck session send <conductor> "[source:type:ctx]" --no-wait`. `gmail-watcher` and `meeting-watcher` mentioned as informal examples — no host-private links.
- Common gotchas (verbose forwarding, no local dedupe, missing `--no-wait`, leaking topic names, skill drift, hand-editing the event log).

### C. README.md

Added a fourth row to the User guides table linking `docs/WATCHERS.md`.

### Verification

- `git grep -nE '<home-token>|<user-id>|\b[0-9]{9,10}:[A-Za-z0-9_-]{35}\b' -- '*.md'` — still empty.
- All CLI subcommands in `docs/WATCHERS.md` exist under `agent-deck watcher --help`.
- Full pre-push test suite green (`lefthook pre-push`: release-tests-yaml-lint, css-verify, lint, build, test — including `./internal/watcher/...`).

