### PR TITLE
fix(ui): reset Start query field on dialog open (#741)

### DIFF
--- a/internal/ui/claudeoptions.go
+++ b/internal/ui/claudeoptions.go
@@ -167,6 +167,13 @@ func (p *ClaudeOptionsPanel) SetStartQuery(query string) {
 	p.startQueryInput.SetValue(query)
 }
 
+// ResetStartQuery clears the start-query input. Called by NewDialog on each
+// open so the per-session StartupQuery (Instance.StartupQuery, json:"-") does
+// not leak across dialog invocations (#741).
+func (p *ClaudeOptionsPanel) ResetStartQuery() {
+	p.startQueryInput.SetValue("")
+}
+
 // IsFocused returns true if any element in the panel has focus
 func (p *ClaudeOptionsPanel) IsFocused() bool {
 	return p.focusIndex >= 0

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -336,6 +336,7 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	}
 	d.pathInput.Blur()
 	d.claudeOptions.Blur()
+	d.claudeOptions.ResetStartQuery() // #741: per-session query must not leak across openings
 	d.geminiOptions.Blur()
 	d.codexOptions.Blur()
 	if d.branchPicker != nil {

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -1573,3 +1573,38 @@ func TestNewDialog_GetClaudeStartQuery_ReturnsInputValue(t *testing.T) {
 		)
 	}
 }
+
+// TestNewDialog_StartQuery_ClearsBetweenOpenings is the RED regression for
+// #741 (@Clindbergh). Filed against v1.7.67 after #725 shipped the dedicated
+// "Start query" field: opening the new-session dialog a second time showed
+// the previous invocation's query instead of an empty field. The backend is
+// correct (Instance.StartupQuery is `json:"-"` so SQLite doesn't persist it);
+// the leak is purely at the TUI layer — ShowInGroup clears nameInput,
+// pathInput, branchInput, etc. but never resets claudeOptions.startQueryInput.
+// This test opens the dialog, sets a query, closes, re-opens, and asserts
+// the field is empty.
+func TestNewDialog_StartQuery_ClearsBetweenOpenings(t *testing.T) {
+	dialog := NewNewDialog()
+	dialog.Show()
+	dialog.commandCursor = 1 // claude
+	dialog.updateToolOptions()
+
+	dialog.claudeOptions.SetStartQuery("explain this repo")
+	if got := dialog.GetClaudeStartQuery(); got != "explain this repo" {
+		t.Fatalf("precondition: GetClaudeStartQuery() = %q, want %q", got, "explain this repo")
+	}
+
+	dialog.Hide()
+	dialog.Show()
+	dialog.commandCursor = 1
+	dialog.updateToolOptions()
+
+	if got := dialog.GetClaudeStartQuery(); got != "" {
+		t.Errorf(
+			"Start query must be empty on re-open; got %q. Per-session "+
+				"startup queries are ephemeral (Instance.StartupQuery is "+
+				"json:\"-\") and must not leak between dialog invocations.",
+			got,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #741 (@Clindbergh). The new-session dialog's dedicated "Start query" input (shipped in v1.7.67 via #725) retained its value between openings, so a second invocation prefilled with the previous session's query.

## Root cause

Backend was fine: `Instance.StartupQuery` is tagged `json:"-"` and isn't persisted. The leak was purely at the TUI layer — `NewDialog.ShowInGroup` resets `nameInput`, `pathInput`, `branchInput`, etc. but never touched the `startQueryInput` owned by `ClaudeOptionsPanel`. The `Blur()` call on the panel only drops focus; it doesn't clear text state.

## Fix

- Adds `ClaudeOptionsPanel.ResetStartQuery()` alongside the existing `SetStartQuery` accessor (`internal/ui/claudeoptions.go`).
- Calls it from `ShowInGroup` next to `claudeOptions.Blur()` — symmetric with focus-state reset (`internal/ui/newdialog.go`).

Scope intentionally minimal: `resumeIDInput` and `extraArgsInput` are untouched; #741 reports only the Start query field, and those other inputs may have different UX expectations.

## TDD trail

- `test(ui): RED for #741 — Start query field must clear between dialog openings` — regression test added first, verified to fail against unfixed code.
- `fix(ui): reset Start query field on dialog open (#741)` — minimal wire-up; test passes.

## Test plan

- [x] `go test ./internal/ui/ -run TestNewDialog_StartQuery_ClearsBetweenOpenings -v` — PASS
- [x] `go test ./internal/ui/... -race -count=1` — PASS (32.7s)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] lefthook pre-push (build + lint + test) — PASS
- [ ] Manual TUI: open new-session dialog, type a Start query, cancel, re-open — field should be empty