### PR TITLE
feat(tmux): vulnerable-version startup warning + docs note on socket isolation scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,8 @@ With this set, every agent-deck session is spawned as `tmux -L agent-deck …` �
 
 **Default behavior unchanged.** Leave `socket_name` unset (the default) and agent-deck behaves exactly like v1.7.46: it uses your default tmux server. This is a pure opt-in.
 
+**What socket isolation does not cover.** `socket_name` isolates agent-deck from *other* tmux servers on the host — a `tmux kill-server` in your shell, a stray `set-option -g` from your personal config, or an interactive session competing for the same socket. It does **not** harden agent-deck's own tmux server against bugs inside tmux itself. If agent-deck's internal session churn trips a tmux bug (for example, a control-mode race in older tmux builds), that failure happens on the isolated socket just as it would on the default one. The isolation boundary is "other tmux instances," not "all possible tmux crashes." Keep your tmux up to date alongside agent-deck.
+
 **Per-session override.** The `agent-deck add` and `agent-deck launch` commands both accept `--tmux-socket <name>` to override the installation-wide default for one session:
 
 ```bash

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -217,6 +217,11 @@ func main() {
 	// the installation-wide fallback for callers without a session handle.
 	tmux.SetDefaultSocketName(session.GetTmuxSettings().GetSocketName())
 
+	// Nudge macOS users whose tmux predates the upstream fix for the
+	// control-mode NULL-deref (tmux #4980, issue #737). Once per process,
+	// no-op on non-macOS, suppressible via AGENTDECK_SUPPRESS_TMUX_WARNING.
+	tmux.WarnIfVulnerableTmux()
+
 	var webEnabled bool
 	var webArgs []string
 

--- a/internal/tmux/tmux_exec_lint_test.go
+++ b/internal/tmux/tmux_exec_lint_test.go
@@ -62,6 +62,11 @@ func TestNoRawTmuxExec_OutsideAllowlist(t *testing.T) {
 		"internal/tmux/tmux.go": {
 			{"tmux", "-V"},
 		},
+		// `tmux -V` again: the startup vulnerable-version warning
+		// (S14 / issue #737) reads the binary's version. No server contact.
+		"internal/tmux/version_warning.go": {
+			{"tmux", "-V"},
+		},
 
 		// The CLI "who am I" helpers read $TMUX env to identify the
 		// current tmux session. tmux auto-routes via TMUX env when no -L

--- a/internal/tmux/version_warning.go
+++ b/internal/tmux/version_warning.go
@@ -1,0 +1,131 @@
+package tmux
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// VersionProbe returns the raw output of `tmux -V`, e.g. "tmux 3.6a".
+type VersionProbe func() (string, error)
+
+var versionWarningOnce sync.Once
+
+// WarnIfVulnerableTmux prints a one-time stderr warning when the host tmux
+// is known-vulnerable to the CONTROL_SHOULD_NOTIFY_CLIENT NULL-deref
+// (tmux #4980, stability row S14, issue #737). No-op on non-macOS, no-op
+// when AGENTDECK_SUPPRESS_TMUX_WARNING=1/true. Safe to call from main()
+// unconditionally; gated by sync.Once so repeat invocations are free.
+func WarnIfVulnerableTmux() {
+	checkAndWarnTmuxVersion(defaultTmuxVersionProbe, os.Stderr, runtime.GOOS, os.Getenv("AGENTDECK_SUPPRESS_TMUX_WARNING"))
+}
+
+// ResetVersionWarningOnceForTest clears the sync.Once so tests can exercise
+// the repeat-call path. Not for production use.
+func ResetVersionWarningOnceForTest() {
+	versionWarningOnce = sync.Once{}
+}
+
+func checkAndWarnTmuxVersion(probe VersionProbe, w io.Writer, goos, suppress string) {
+	versionWarningOnce.Do(func() {
+		doCheckAndWarnTmuxVersion(probe, w, goos, suppress)
+	})
+}
+
+func doCheckAndWarnTmuxVersion(probe VersionProbe, w io.Writer, goos, suppress string) {
+	if goos != "darwin" {
+		return
+	}
+	if suppress == "1" || suppress == "true" {
+		return
+	}
+	raw, err := probe()
+	if err != nil {
+		return
+	}
+	ver := parseTmuxVersion(raw)
+	if ver == "" || !isVulnerableTmuxVersion(ver) {
+		return
+	}
+	fmt.Fprintf(w,
+		"agent-deck: heads-up — your tmux (%s) has an unfixed control-mode NULL deref (tmux #4980) that can crash the server. "+
+			"We apply a SIGTERM+grace mitigation in v1.7.68+, but a patched tmux from Homebrew will close the window entirely. "+
+			"Set AGENTDECK_SUPPRESS_TMUX_WARNING=1 to silence.\n",
+		ver)
+}
+
+func defaultTmuxVersionProbe() (string, error) {
+	out, err := exec.Command("tmux", "-V").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+var tmuxVersionRE = regexp.MustCompile(`^tmux\s+(\S+)`)
+
+func parseTmuxVersion(raw string) string {
+	m := tmuxVersionRE.FindStringSubmatch(strings.TrimSpace(raw))
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// isVulnerableTmuxVersion reports whether the given tmux version is <= 3.6a.
+// Upstream fix commits (881bec95, e5a2a25f, 31c93c48) landed on master after
+// the 3.6a release and have not been tagged yet. Returns false for master/next
+// (assumed patched) and for anything unparseable (don't warn on the unknown).
+func isVulnerableTmuxVersion(ver string) bool {
+	if ver == "" || ver == "master" || ver == "next" {
+		return false
+	}
+	major, minor, letter, ok := splitTmuxVersion(ver)
+	if !ok {
+		return false
+	}
+	if major < 3 {
+		return true
+	}
+	if major > 3 {
+		return false
+	}
+	if minor < 6 {
+		return true
+	}
+	if minor > 6 {
+		return false
+	}
+	// major.minor == 3.6: bare "3.6" and "3.6a" are vulnerable; "3.6b"+ assumed patched.
+	return letter <= "a"
+}
+
+func splitTmuxVersion(ver string) (major, minor int, letter string, ok bool) {
+	parts := strings.SplitN(ver, ".", 2)
+	if len(parts) != 2 {
+		return 0, 0, "", false
+	}
+	m, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, "", false
+	}
+	tail := parts[1]
+	i := 0
+	for i < len(tail) && tail[i] >= '0' && tail[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return 0, 0, "", false
+	}
+	n, err := strconv.Atoi(tail[:i])
+	if err != nil {
+		return 0, 0, "", false
+	}
+	return m, n, strings.ToLower(tail[i:]), true
+}

--- a/internal/tmux/version_warning_test.go
+++ b/internal/tmux/version_warning_test.go
@@ -1,0 +1,126 @@
+package tmux
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestIsVulnerableTmuxVersion(t *testing.T) {
+	cases := []struct {
+		ver        string
+		vulnerable bool
+	}{
+		{"3.6a", true},
+		{"3.6", true},
+		{"3.5a", true},
+		{"3.4", true},
+		{"2.8", true},
+		{"3.6b", false},
+		{"3.7", false},
+		{"4.0", false},
+		{"master", false},
+		{"next", false},
+		{"", false},
+		{"garbage", false},
+	}
+	for _, c := range cases {
+		got := isVulnerableTmuxVersion(c.ver)
+		if got != c.vulnerable {
+			t.Errorf("isVulnerableTmuxVersion(%q) = %v, want %v", c.ver, got, c.vulnerable)
+		}
+	}
+}
+
+func TestParseTmuxVersion(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"tmux 3.6a", "3.6a"},
+		{"tmux 3.6a\n", "3.6a"},
+		{"tmux 3.5\n", "3.5"},
+		{"tmux master", "master"},
+		{"tmux next-3.7", "next-3.7"},
+		{"", ""},
+		{"not tmux", ""},
+	}
+	for _, c := range cases {
+		got := parseTmuxVersion(c.raw)
+		if got != c.want {
+			t.Errorf("parseTmuxVersion(%q) = %q, want %q", c.raw, got, c.want)
+		}
+	}
+}
+
+func TestDoCheckAndWarnTmuxVersion_WarnsOnVulnerableDarwin(t *testing.T) {
+	var buf bytes.Buffer
+	probe := func() (string, error) { return "tmux 3.6a", nil }
+	doCheckAndWarnTmuxVersion(probe, &buf, "darwin", "")
+	out := buf.String()
+	if !strings.Contains(out, "3.6a") {
+		t.Errorf("expected warning to contain version 3.6a, got: %q", out)
+	}
+	if !strings.Contains(out, "tmux") {
+		t.Errorf("expected warning to mention tmux, got: %q", out)
+	}
+	if !strings.Contains(out, "AGENTDECK_SUPPRESS_TMUX_WARNING") {
+		t.Errorf("expected warning to mention suppression env var, got: %q", out)
+	}
+}
+
+func TestDoCheckAndWarnTmuxVersion_SilentOnPatched(t *testing.T) {
+	var buf bytes.Buffer
+	probe := func() (string, error) { return "tmux 3.6b", nil }
+	doCheckAndWarnTmuxVersion(probe, &buf, "darwin", "")
+	if buf.Len() != 0 {
+		t.Errorf("expected no output on patched tmux, got: %q", buf.String())
+	}
+}
+
+func TestDoCheckAndWarnTmuxVersion_SilentOnLinux(t *testing.T) {
+	var buf bytes.Buffer
+	probe := func() (string, error) { return "tmux 3.6a", nil }
+	doCheckAndWarnTmuxVersion(probe, &buf, "linux", "")
+	if buf.Len() != 0 {
+		t.Errorf("expected no output on linux even if vulnerable version, got: %q", buf.String())
+	}
+}
+
+func TestDoCheckAndWarnTmuxVersion_SuppressEnv(t *testing.T) {
+	for _, v := range []string{"1", "true"} {
+		var buf bytes.Buffer
+		probe := func() (string, error) { return "tmux 3.6a", nil }
+		doCheckAndWarnTmuxVersion(probe, &buf, "darwin", v)
+		if buf.Len() != 0 {
+			t.Errorf("expected suppression via %q, got output: %q", v, buf.String())
+		}
+	}
+}
+
+func TestDoCheckAndWarnTmuxVersion_SilentOnProbeError(t *testing.T) {
+	var buf bytes.Buffer
+	probe := func() (string, error) { return "", assertAnyErr{} }
+	doCheckAndWarnTmuxVersion(probe, &buf, "darwin", "")
+	if buf.Len() != 0 {
+		t.Errorf("expected no output when probe errors, got: %q", buf.String())
+	}
+}
+
+type assertAnyErr struct{}
+
+func (assertAnyErr) Error() string { return "probe failed" }
+
+func TestCheckAndWarnTmuxVersion_PrintsAtMostOnce(t *testing.T) {
+	ResetVersionWarningOnceForTest()
+	var buf bytes.Buffer
+	probe := func() (string, error) { return "tmux 3.6a", nil }
+	checkAndWarnTmuxVersion(probe, &buf, "darwin", "")
+	checkAndWarnTmuxVersion(probe, &buf, "darwin", "")
+	checkAndWarnTmuxVersion(probe, &buf, "darwin", "")
+	out := buf.String()
+	count := strings.Count(out, "agent-deck:")
+	if count != 1 {
+		t.Errorf("expected exactly 1 warning line, got %d. Output: %q", count, out)
+	}
+}


### PR DESCRIPTION
## Summary

Two small follow-ups against the S14 work shipped in v1.7.68 (#737).

**Part A — startup warning for vulnerable tmux.** v1.7.68 landed a client-side SIGTERM+grace mitigation for the tmux control-mode NULL-deref (tmux #4980), but all released tmux builds through 3.6a remain structurally vulnerable; the fix commits (`881bec95`, `e5a2a25f`, `31c93c48`) sit on upstream master with no release tag. This PR adds a one-line stderr nudge at agent-deck startup so macOS users know to upgrade once Homebrew ships a patched tmux. No-op on non-macOS (Linux users can trivially build tmux from master), emitted once per process, suppressible via `AGENTDECK_SUPPRESS_TMUX_WARNING=1`.

**Part B — README note on socket-isolation scope.** `[tmux].socket_name` (#687 / #707 / #718) isolates agent-deck from *other* tmux servers on the host. It does not harden agent-deck's own tmux server against bugs inside tmux itself. The README's socket-isolation section now calls this out so readers don't assume the feature covers more than it does.

## Approach

- TDD for Part A: RED test (`internal/tmux/version_warning_test.go`) landed before the implementation. Covers version parsing, the vulnerable-predicate truth table (including bare `3.6` vs `3.6a` vs `3.6b`, plus `master` / `next`), darwin gating, suppression env var, probe-error no-op, and the `sync.Once` at-most-once contract via an injected seam.
- Implementation seam: `doCheckAndWarnTmuxVersion` takes a `VersionProbe`, writer, GOOS, and suppression string so the logic is testable without `os.Exec`/`os.Stderr`/`runtime.GOOS` coupling. `checkAndWarnTmuxVersion` wraps it with `sync.Once`. Production entry point is `tmux.WarnIfVulnerableTmux()`, called once in `cmd/agent-deck/main.go` right after `tmux.SetDefaultSocketName`.
- Allowlisted the new `tmux -V` site via the existing `TestNoRawTmuxExec_OutsideAllowlist` guard — it's a binary version check and never touches a tmux server.

## Test plan

- [x] `GOTOOLCHAIN=go1.24.0 go test ./internal/tmux/ -race -count=1` green (including the new tests and the raw-exec lint guard).
- [x] `GOTOOLCHAIN=go1.24.0 go build ./...` green.
- [x] Pre-commit lefthook (fmt-check, vet) green; pre-push (build, lint, test) green.
- [ ] Manual: on macOS with `tmux 3.6a`, run `agent-deck list` and confirm the warning appears exactly once; re-run with `AGENTDECK_SUPPRESS_TMUX_WARNING=1` and confirm it disappears; on Linux confirm no output regardless of version.

## Out of scope

- No version bump, no CHANGELOG entry (this is a low-risk follow-up to a shipped release).
- No tagging, no release.