### PR TITLE
Jujutsu support

### DIFF
--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 // handleLaunch combines add + start + optional send into a single command.
@@ -171,18 +172,14 @@ func handleLaunch(profile string, args []string) {
 	}
 
 	// Handle worktree creation
-	var worktreePath, worktreeRepoRoot string
+	var worktreePath, worktreeRepoRoot, worktreeType string
 	if wtBranch != "" {
-		if !git.IsGitRepoOrBareProjectRoot(path) {
-			out.Error(fmt.Sprintf("%s is not a git repository", path), ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
-
-		repoRoot, err := git.GetWorktreeBaseRoot(path)
+		backend, err := detectAndCreateBackend(path)
 		if err != nil {
-			out.Error(fmt.Sprintf("failed to get repo root: %v", err), ErrCodeInvalidOperation)
+			out.Error(fmt.Sprintf("%v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
+		worktreeType = string(backend.Type())
 
 		// Apply configured branch prefix before validation/existence checks
 		wtSettings := session.GetWorktreeSettings()
@@ -193,7 +190,7 @@ func handleLaunch(profile string, args []string) {
 			os.Exit(1)
 		}
 
-		branchExists := git.BranchExists(repoRoot, wtBranch)
+		branchExists := backend.BranchExists(wtBranch)
 		if createNewBranch && branchExists {
 			out.Error(fmt.Sprintf("branch '%s' already exists (remove -b flag to use existing branch)", wtBranch), ErrCodeInvalidOperation)
 			os.Exit(1)
@@ -204,16 +201,15 @@ func handleLaunch(profile string, args []string) {
 			location = *worktreeLocation
 		}
 
-		worktreePath = git.WorktreePath(git.WorktreePathOptions{
+		worktreePath = backend.WorktreePath(vcs.WorktreePathOptions{
 			Branch:    wtBranch,
 			Location:  location,
-			RepoDir:   repoRoot,
 			SessionID: git.GeneratePathID(),
 			Template:  wtSettings.Template(),
 		})
 
 		// Check for an existing worktree for this branch before creating a new one
-		if existingPath, err := git.GetWorktreeForBranch(repoRoot, wtBranch); err == nil && existingPath != "" {
+		if existingPath, err := backend.GetWorktreeForBranch(wtBranch); err == nil && existingPath != "" {
 			fmt.Fprintf(os.Stderr, "Reusing existing worktree at %s for branch %s\n", existingPath, wtBranch)
 			worktreePath = existingPath
 		} else {
@@ -227,7 +223,7 @@ func handleLaunch(profile string, args []string) {
 				os.Exit(1)
 			}
 
-			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+			setupErr, err := git.CreateWorktreeWithSetup(backend, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
 			if err != nil {
 				out.Error(fmt.Sprintf("failed to create worktree: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)
@@ -237,7 +233,7 @@ func handleLaunch(profile string, args []string) {
 			}
 		}
 
-		worktreeRepoRoot = repoRoot
+		worktreeRepoRoot = backend.RepoDir()
 		path = worktreePath
 	}
 
@@ -352,6 +348,7 @@ func handleLaunch(profile string, args []string) {
 		newInstance.WorktreePath = worktreePath
 		newInstance.WorktreeRepoRoot = worktreeRepoRoot
 		newInstance.WorktreeBranch = wtBranch
+		newInstance.WorktreeType = worktreeType
 	}
 
 	if *resumeSession != "" {

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 	"github.com/asheshgoplani/agent-deck/internal/ui"
 	"github.com/asheshgoplani/agent-deck/internal/update"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
@@ -1264,20 +1265,14 @@ func handleAdd(profile string, args []string) {
 	}
 
 	// Handle worktree creation
-	var worktreePath, worktreeRepoRoot string
+	var worktreePath, worktreeRepoRoot, worktreeType string
 	if wtBranch != "" {
-		// Validate path is a git repo (or a bare-repo project root with nested .bare/)
-		if !git.IsGitRepoOrBareProjectRoot(path) {
-			fmt.Fprintf(os.Stderr, "Error: %s is not a git repository\n", path)
-			os.Exit(1)
-		}
-
-		// Get repo root (resolve through worktrees to prevent nesting)
-		repoRoot, err := git.GetWorktreeBaseRoot(path)
+		backend, err := detectAndCreateBackend(path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: failed to get repo root: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
+		worktreeType = string(backend.Type())
 
 		// Determine worktree settings and apply configured branch prefix
 		// (e.g., "$USER/" -> "dani.fernandez/") before validation/existence checks
@@ -1291,7 +1286,7 @@ func handleAdd(profile string, args []string) {
 		}
 
 		// Check -b flag logic: if -b is passed, branch must NOT exist (user wants new branch)
-		branchExists := git.BranchExists(repoRoot, wtBranch)
+		branchExists := backend.BranchExists(wtBranch)
 		if createNewBranch && branchExists {
 			fmt.Fprintf(
 				os.Stderr,
@@ -1307,16 +1302,15 @@ func handleAdd(profile string, args []string) {
 		}
 
 		// Generate worktree path
-		worktreePath = git.WorktreePath(git.WorktreePathOptions{
+		worktreePath = backend.WorktreePath(vcs.WorktreePathOptions{
 			Branch:    wtBranch,
 			Location:  location,
-			RepoDir:   repoRoot,
 			SessionID: git.GeneratePathID(),
 			Template:  wtSettings.Template(),
 		})
 
 		// Check for an existing worktree for this branch before creating a new one
-		if existingPath, err := git.GetWorktreeForBranch(repoRoot, wtBranch); err == nil && existingPath != "" {
+		if existingPath, err := backend.GetWorktreeForBranch(wtBranch); err == nil && existingPath != "" {
 			fmt.Fprintf(os.Stderr, "Reusing existing worktree at %s for branch %s\n", existingPath, wtBranch)
 			worktreePath = existingPath
 		} else {
@@ -1328,7 +1322,7 @@ func handleAdd(profile string, args []string) {
 
 			// Create worktree atomically (git handles existence checks).
 			// This avoids a TOCTOU race from separate check-then-create steps.
-			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+			setupErr, err := git.CreateWorktreeWithSetup(backend, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
 			if err != nil {
 				if isWorktreeAlreadyExistsError(err) {
 					fmt.Fprintf(os.Stderr, "Error: worktree already exists at %s\n", worktreePath)
@@ -1344,7 +1338,7 @@ func handleAdd(profile string, args []string) {
 
 			fmt.Printf("Created worktree at: %s\n", worktreePath)
 		}
-		worktreeRepoRoot = repoRoot
+		worktreeRepoRoot = backend.RepoDir()
 		// Update path to point to worktree so session uses worktree as working directory
 		path = worktreePath
 	}
@@ -1442,6 +1436,7 @@ func handleAdd(profile string, args []string) {
 		newInstance.WorktreePath = worktreePath
 		newInstance.WorktreeRepoRoot = worktreeRepoRoot
 		newInstance.WorktreeBranch = wtBranch
+		newInstance.WorktreeType = worktreeType
 	}
 
 	// Apply sandbox config if requested.
@@ -1914,12 +1909,16 @@ func handleRemove(profile string, args []string) {
 
 	// Clean up worktree directory if this is a worktree session
 	if inst.IsWorktree() {
-		if err := git.RemoveWorktree(inst.WorktreeRepoRoot, inst.WorktreePath, false); err != nil {
-			if !*jsonOutput {
-				fmt.Printf("Warning: failed to remove worktree: %v\n", err)
+		if wtBackend, err := inst.Backend(); err == nil {
+			if err := wtBackend.RemoveWorktree(inst.WorktreePath, false); err != nil {
+				if !*jsonOutput {
+					fmt.Printf("Warning: failed to remove worktree: %v\n", err)
+				}
 			}
+			_ = wtBackend.PruneWorktrees()
+		} else if !*jsonOutput {
+			fmt.Printf("Warning: failed to initialize VCS for worktree cleanup: %v\n", err)
 		}
-		_ = git.PruneWorktrees(inst.WorktreeRepoRoot)
 	}
 
 	// Direct SQL DELETE first to prevent resurrection by concurrent TUI force saves.

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 	"github.com/asheshgoplani/agent-deck/internal/ui"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 // handleSession dispatches session subcommands
@@ -630,39 +631,37 @@ func handleSessionFork(profile string, args []string) {
 
 	// Handle worktree creation
 	var opts *session.ClaudeOptions
+	var worktreeType string
 	if wtBranch != "" {
-		if !git.IsGitRepoOrBareProjectRoot(inst.ProjectPath) {
-			out.Error("session path is not a git repository", ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
-		repoRoot, err := git.GetWorktreeBaseRoot(inst.ProjectPath)
+		backend, err := detectAndCreateBackend(inst.ProjectPath)
 		if err != nil {
-			out.Error(fmt.Sprintf("failed to get repo root: %v", err), ErrCodeInvalidOperation)
+			out.Error(fmt.Sprintf("%v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
+		worktreeType = string(backend.Type())
 
 		// Apply configured branch prefix before validation/existence checks
 		wtSettings := session.GetWorktreeSettings()
 		wtBranch = wtSettings.ApplyBranchPrefix(wtBranch)
 
-		if !createNewBranch && !git.BranchExists(repoRoot, wtBranch) {
+		if !createNewBranch && !backend.BranchExists(wtBranch) {
 			out.Error(fmt.Sprintf("branch '%s' does not exist (use -b to create)", wtBranch), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
 
-		worktreePath := git.WorktreePath(git.WorktreePathOptions{
+		worktreePath := backend.WorktreePath(vcs.WorktreePathOptions{
 			Branch:    wtBranch,
 			Location:  wtSettings.DefaultLocation,
-			RepoDir:   repoRoot,
 			SessionID: git.GeneratePathID(),
 			Template:  wtSettings.Template(),
 		})
 
 		// Check for an existing worktree for this branch before creating a new one
-		if existingPath, err := git.GetWorktreeForBranch(repoRoot, wtBranch); err == nil && existingPath != "" {
+		if existingPath, err := backend.GetWorktreeForBranch(wtBranch); err == nil && existingPath != "" {
 			fmt.Fprintf(os.Stderr, "Reusing existing worktree at %s for branch %s\n", existingPath, wtBranch)
 			worktreePath = existingPath
 		} else {
+
 			if _, statErr := os.Stat(worktreePath); statErr == nil {
 				out.Error(fmt.Sprintf("worktree path already exists: %s", worktreePath), ErrCodeInvalidOperation)
 				os.Exit(1)
@@ -673,7 +672,7 @@ func handleSessionFork(profile string, args []string) {
 				os.Exit(1)
 			}
 
-			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+			setupErr, err := git.CreateWorktreeWithSetup(backend, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
 			if err != nil {
 				out.Error(fmt.Sprintf("worktree creation failed: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)
@@ -687,7 +686,7 @@ func handleSessionFork(profile string, args []string) {
 		opts = session.NewClaudeOptions(userConfig)
 		opts.WorkDir = worktreePath
 		opts.WorktreePath = worktreePath
-		opts.WorktreeRepoRoot = repoRoot
+		opts.WorktreeRepoRoot = backend.RepoDir()
 		opts.WorktreeBranch = wtBranch
 	}
 
@@ -696,6 +695,10 @@ func handleSessionFork(profile string, args []string) {
 	if err != nil {
 		out.Error(fmt.Sprintf("failed to create fork: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
+	}
+
+	if worktreeType != "" {
+		forkedInst.WorktreeType = worktreeType
 	}
 
 	// Apply sandbox config if requested.

--- a/cmd/agent-deck/session_remove_cmd.go
+++ b/cmd/agent-deck/session_remove_cmd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
@@ -174,10 +173,12 @@ func removeAllErrored(
 func pruneSessionWorktree(inst *session.Instance) {
 	_ = inst.KillAndWait()
 	if inst.IsWorktree() {
-		if err := git.RemoveWorktree(inst.WorktreeRepoRoot, inst.WorktreePath, true); err != nil {
-			fmt.Fprintf(os.Stderr, "warn: worktree remove failed for %s: %v\n", inst.ID, err)
+		if backend, err := detectAndCreateBackend(inst.WorktreeRepoRoot); err == nil {
+			if err := backend.RemoveWorktree(inst.WorktreePath, true); err != nil {
+				fmt.Fprintf(os.Stderr, "warn: worktree remove failed for %s: %v\n", inst.ID, err)
+			}
+			_ = backend.PruneWorktrees()
 		}
-		_ = git.PruneWorktrees(inst.WorktreeRepoRoot)
 	}
 }
 

--- a/cmd/agent-deck/vcs_helper.go
+++ b/cmd/agent-deck/vcs_helper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/jujutsu"
 	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
@@ -12,7 +13,11 @@ import (
 // string to store on the session Instance.
 func detectAndCreateBackend(dir string) (vcs.Backend, error) {
 	var b vcs.Backend
-	b, err := git.NewGitBackend(dir)
+	b, err := jujutsu.NewJJBackend(dir)
+	if err == nil {
+		return b, nil
+	}
+	b, err = git.NewGitBackend(dir)
 	if err == nil {
 		return b, nil
 	}

--- a/cmd/agent-deck/vcs_helper.go
+++ b/cmd/agent-deck/vcs_helper.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
+)
+
+// detectAndCreateBackend detects the VCS type for the given directory and
+// creates the appropriate backend. Returns the backend and the WorktreeType
+// string to store on the session Instance.
+func detectAndCreateBackend(dir string) (vcs.Backend, error) {
+	var b vcs.Backend
+	b, err := git.NewGitBackend(dir)
+	if err == nil {
+		return b, nil
+	}
+	return nil, fmt.Errorf("failed to initialize backend: %w", err)
+}

--- a/cmd/agent-deck/worktree_cmd.go
+++ b/cmd/agent-deck/worktree_cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 // handleWorktree dispatches worktree subcommands
@@ -91,22 +92,14 @@ func handleWorktreeList(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Check if in a git repo (or a bare-repo project root)
-	if !git.IsGitRepoOrBareProjectRoot(cwd) {
-		out.Error("not in a git repository", ErrCodeInvalidOperation)
-		os.Exit(1)
-	}
-
-	// Get repo root (resolve through worktrees to prevent nesting; also
-	// handles bare-repo project roots by returning the parent of .bare/).
-	repoRoot, err := git.GetWorktreeBaseRoot(cwd)
+	backend, err := detectAndCreateBackend(cwd)
 	if err != nil {
-		out.Error(fmt.Sprintf("failed to get repo root: %v", err), ErrCodeInvalidOperation)
+		out.Error(fmt.Sprintf("%v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
 
 	// List worktrees
-	worktrees, err := git.ListWorktrees(repoRoot)
+	worktrees, err := backend.ListWorktrees()
 	if err != nil {
 		out.Error(fmt.Sprintf("failed to list worktrees: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
@@ -161,7 +154,7 @@ func handleWorktreeList(profile string, args []string) {
 
 	if *jsonOutput {
 		out.Print("", map[string]interface{}{
-			"repo_root": repoRoot,
+			"repo_root": backend.RepoDir(),
 			"worktrees": results,
 			"count":     len(results),
 		})
@@ -174,7 +167,7 @@ func handleWorktreeList(profile string, args []string) {
 		return
 	}
 
-	fmt.Printf("Repository: %s\n\n", FormatPath(repoRoot))
+	fmt.Printf("Repository: %s\n\n", FormatPath(backend.RepoDir()))
 	fmt.Printf("%-40s  %-20s  %-10s  %s\n", "PATH", "BRANCH", "TYPE", "SESSION")
 	fmt.Printf("%-40s  %-20s  %-10s  %s\n", strings.Repeat("-", 40), strings.Repeat("-", 20), strings.Repeat("-", 10), strings.Repeat("-", 20))
 
@@ -329,31 +322,29 @@ func handleWorktreeCleanup(profile string, args []string) {
 	}
 
 	// Find orphaned worktrees (exist but no session points to them)
-	var orphanedWorktrees []git.Worktree
-	var repoRoot string
+	var orphanedWorktrees []vcs.Worktree
+	var cleanupBackend vcs.Backend
 
-	if git.IsGitRepoOrBareProjectRoot(cwd) {
-		repoRoot, err = git.GetWorktreeBaseRoot(cwd)
-		if err == nil {
-			worktrees, err := git.ListWorktrees(repoRoot)
-			if err == nil {
-				// Build set of paths that sessions use
-				sessionPaths := make(map[string]bool)
-				for _, inst := range instances {
-					sessionPaths[inst.ProjectPath] = true
-					if inst.WorktreePath != "" {
-						sessionPaths[inst.WorktreePath] = true
-					}
+	if cleanupB, bErr := detectAndCreateBackend(cwd); bErr == nil {
+		cleanupBackend = cleanupB
+		worktrees, wErr := cleanupBackend.ListWorktrees()
+		if wErr == nil {
+			// Build set of paths that sessions use
+			sessionPaths := make(map[string]bool)
+			for _, inst := range instances {
+				sessionPaths[inst.ProjectPath] = true
+				if inst.WorktreePath != "" {
+					sessionPaths[inst.WorktreePath] = true
 				}
+			}
 
-				// Check each worktree (skip the first one which is usually the main repo)
-				for i, wt := range worktrees {
-					if i == 0 {
-						continue // Skip main repo
-					}
-					if !sessionPaths[wt.Path] {
-						orphanedWorktrees = append(orphanedWorktrees, wt)
-					}
+			// Check each worktree (skip the first one which is usually the main repo)
+			for i, wt := range worktrees {
+				if i == 0 {
+					continue // Skip main repo
+				}
+				if !sessionPaths[wt.Path] {
+					orphanedWorktrees = append(orphanedWorktrees, wt)
 				}
 			}
 		}
@@ -470,7 +461,11 @@ func handleWorktreeCleanup(profile string, args []string) {
 	// Remove orphaned worktrees
 	removedWorktrees := 0
 	for _, wt := range orphanedWorktrees {
-		if err := git.RemoveWorktree(repoRoot, wt.Path, false); err != nil {
+		if cleanupBackend == nil {
+			fmt.Fprintf(os.Stderr, "Warning: no VCS backend for worktree removal\n")
+			break
+		}
+		if err := cleanupBackend.RemoveWorktree(wt.Path, false); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to remove worktree %s: %v\n", wt.Path, err)
 			continue
 		}
@@ -548,7 +543,13 @@ func handleWorktreeFinish(profile string, args []string) {
 	worktreePath := inst.WorktreePath
 	worktreeBranch := inst.WorktreeBranch
 
-	// Check for uncommitted changes
+	finishBackend, err := inst.Backend()
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to initialize VCS: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	// Check for uncommitted changes (uses worktree path, not repoDir — stays standalone)
 	if !*force {
 		dirty, err := git.HasUncommittedChanges(worktreePath)
 		if err != nil {
@@ -570,7 +571,7 @@ func handleWorktreeFinish(profile string, args []string) {
 	// Determine target branch
 	targetBranch := *into
 	if targetBranch == "" && !*noMerge {
-		targetBranch, err = git.GetDefaultBranch(repoRoot)
+		targetBranch, err = finishBackend.GetDefaultBranch()
 		if err != nil {
 			out.Error(fmt.Sprintf("could not determine target branch: %v\nUse --into <branch> to specify", err), ErrCodeInvalidOperation)
 			os.Exit(1)
@@ -624,7 +625,7 @@ func handleWorktreeFinish(profile string, args []string) {
 		}
 
 		// Merge the worktree branch
-		if err := git.MergeBranch(repoRoot, worktreeBranch); err != nil {
+		if err := finishBackend.MergeBranch(worktreeBranch); err != nil {
 			// Abort the merge to leave things clean
 			abortCmd := exec.Command("git", "-C", repoRoot, "merge", "--abort")
 			_ = abortCmd.Run()
@@ -637,18 +638,18 @@ func handleWorktreeFinish(profile string, args []string) {
 	// Step 2: Remove worktree
 	if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
 		fmt.Printf("Removing worktree at %s...\n", FormatPath(worktreePath))
-		if err := git.RemoveWorktree(repoRoot, worktreePath, *force); err != nil {
+		if err := finishBackend.RemoveWorktree(worktreePath, *force); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to remove worktree: %v\n", err)
 		} else {
 			fmt.Printf("  %s Worktree removed\n", successSymbol)
 		}
 	}
-	_ = git.PruneWorktrees(repoRoot)
+	_ = finishBackend.PruneWorktrees()
 
 	// Step 3: Delete branch (if not --keep-branch)
 	if !*keepBranch {
 		fmt.Printf("Deleting branch %s...\n", worktreeBranch)
-		if err := git.DeleteBranch(repoRoot, worktreeBranch, *force); err != nil {
+		if err := finishBackend.DeleteBranch(worktreeBranch, *force); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to delete branch: %v\n", err)
 		} else {
 			fmt.Printf("  %s Branch deleted\n", successSymbol)

--- a/internal/git/bare_repo_test.go
+++ b/internal/git/bare_repo_test.go
@@ -121,8 +121,12 @@ func TestIsBareRepoWorktree_FalseForNormalWorktree(t *testing.T) {
 	dir := t.TempDir()
 	createTestRepo(t, dir)
 
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
 	wtPath := filepath.Join(t.TempDir(), "regular-wt")
-	if err := CreateWorktree(dir, wtPath, "feature-regular"); err != nil {
+	if err := backend.CreateWorktree(wtPath, "feature-regular"); err != nil {
 		t.Fatalf("failed to create worktree: %v", err)
 	}
 
@@ -220,8 +224,12 @@ func TestFindWorktreeSetupScript_BareRepo(t *testing.T) {
 func TestCreateWorktree_FromBareProjectRoot(t *testing.T) {
 	projectRoot, _, _ := createBareRepoLayout(t, "worktree1")
 
+	backend, err := NewGitBackend(projectRoot)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
 	newWorktreePath := filepath.Join(projectRoot, "worktree-new")
-	if err := CreateWorktree(projectRoot, newWorktreePath, "feature-new"); err != nil {
+	if err := backend.CreateWorktree(newWorktreePath, "feature-new"); err != nil {
 		t.Fatalf("CreateWorktree(projectRoot=%q) failed: %v", projectRoot, err)
 	}
 
@@ -252,9 +260,13 @@ echo "bare-setup done"
 		t.Fatal(err)
 	}
 
+	bareBackend, err := NewGitBackend(projectRoot)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
 	newWorktreePath := filepath.Join(projectRoot, "worktree-feat")
 	var stdout, stderr bytes.Buffer
-	setupErr, err := CreateWorktreeWithSetup(projectRoot, newWorktreePath, "feature-bare-e2e", &stdout, &stderr, 0)
+	setupErr, err := CreateWorktreeWithSetup(bareBackend, newWorktreePath, "feature-bare-e2e", &stdout, &stderr, 0)
 	if err != nil {
 		t.Fatalf("CreateWorktreeWithSetup failed: %v (stderr: %s)", err, stderr.String())
 	}
@@ -281,7 +293,11 @@ echo "bare-setup done"
 func TestListWorktrees_BareRepo(t *testing.T) {
 	projectRoot, _, _ := createBareRepoLayout(t, "worktree1", "worktree2", "worktree3")
 
-	wts, err := ListWorktrees(projectRoot)
+	backend, err := NewGitBackend(projectRoot)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
+	wts, err := backend.ListWorktrees()
 	if err != nil {
 		t.Fatalf("ListWorktrees(projectRoot) failed: %v", err)
 	}
@@ -310,16 +326,20 @@ func TestListWorktrees_BareRepo(t *testing.T) {
 func TestBranchExists_FromBareProjectRoot(t *testing.T) {
 	projectRoot, _, _ := createBareRepoLayout(t, "worktree1", "worktree2")
 
+	backend, err := NewGitBackend(projectRoot)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
 	// main branch (from the seed commit) should exist.
-	if !BranchExists(projectRoot, "main") {
+	if !backend.BranchExists("main") {
 		t.Errorf("BranchExists(%q, main) = false; want true", projectRoot)
 	}
 	// feature-worktree2 branch was auto-created by the fixture.
-	if !BranchExists(projectRoot, "feature-worktree2") {
+	if !backend.BranchExists("feature-worktree2") {
 		t.Errorf("BranchExists(%q, feature-worktree2) = false; want true", projectRoot)
 	}
 	// Non-existent branches should report false, not error out.
-	if BranchExists(projectRoot, "never-existed") {
+	if backend.BranchExists("never-existed") {
 		t.Errorf("BranchExists(%q, never-existed) = true; want false", projectRoot)
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -11,16 +11,59 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 var consecutiveDashesRe = regexp.MustCompile(`-+`)
 
-// Worktree represents a git worktree
-type Worktree struct {
-	Path   string // Filesystem path to the worktree
-	Branch string // Branch name checked out in this worktree
-	Commit string // HEAD commit SHA
-	Bare   bool   // Whether this is the bare repository
+// GitBackend encapsulates a repository directory and provides methods that
+// implement the vcs.Backend interface. Construct via NewGitBackend.
+//
+// repoDir is the git-invocable directory (suitable for git -C). For normal
+// repos and worktrees this equals the project root. For bare-repo project
+// roots (contain a nested .bare/) it is the .bare/ directory itself.
+// projectRoot is the user-visible project root returned by RepoDir().
+type GitBackend struct {
+	repoDir     string // git-invocable dir (for git -C invocations)
+	projectRoot string // project root (for RepoDir(), setup scripts, etc.)
+}
+
+// Compile-time check that *GitBackend satisfies vcs.Backend.
+var _ vcs.Backend = (*GitBackend)(nil)
+
+// NewGitBackend validates dir is a git repository (or bare-repo project root),
+// resolves through worktrees to prevent nesting, and returns a GitBackend.
+func NewGitBackend(dir string) (*GitBackend, error) {
+	if !IsGitRepoOrBareProjectRoot(dir) {
+		return nil, fmt.Errorf("not a git repository: %s", dir)
+	}
+	root, err := GetWorktreeBaseRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	return &GitBackend{
+		repoDir:     resolveGitInvocationDir(root),
+		projectRoot: root,
+	}, nil
+}
+
+func (g *GitBackend) Type() vcs.Type { return vcs.TypeGit }
+
+// RepoDir returns the project root directory of the repository.
+// For normal repos this is the repo root. For bare-repo layouts it is the
+// parent of the .bare/ directory.
+func (g *GitBackend) RepoDir() string { return g.projectRoot }
+
+// WorktreePath generates a worktree path using the backend's project root.
+func (g *GitBackend) WorktreePath(opts vcs.WorktreePathOptions) string {
+	return WorktreePath(WorktreePathOptions{
+		Branch:    opts.Branch,
+		Location:  opts.Location,
+		RepoDir:   g.projectRoot,
+		SessionID: opts.SessionID,
+		Template:  opts.Template,
+	})
 }
 
 // IsGitRepo checks if the given directory is inside a git repository
@@ -183,9 +226,9 @@ func GetRepoRoot(dir string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// GetCurrentBranch returns the current branch name for the repository at dir
-func GetCurrentBranch(dir string) (string, error) {
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
+// GetCurrentBranch returns the current branch name.
+func (g *GitBackend) GetCurrentBranch() (string, error) {
+	cmd := exec.Command("git", "-C", g.repoDir, "rev-parse", "--abbrev-ref", "HEAD")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current branch: %w", err)
@@ -193,10 +236,9 @@ func GetCurrentBranch(dir string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// BranchExists checks if a branch exists in the repository
-func BranchExists(repoDir, branchName string) bool {
-	repoDir = resolveGitInvocationDir(repoDir)
-	cmd := exec.Command("git", "-C", repoDir, "show-ref", "--verify", "--quiet", "refs/heads/"+branchName)
+// BranchExists checks if a branch exists in the repository.
+func (g *GitBackend) BranchExists(branchName string) bool {
+	cmd := exec.Command("git", "-C", g.repoDir, "show-ref", "--verify", "--quiet", "refs/heads/"+branchName)
 	err := cmd.Run()
 	return err == nil
 }
@@ -304,24 +346,19 @@ func GenerateWorktreePath(repoDir, branchName, location string) string {
 	}
 }
 
-// CreateWorktree creates a new git worktree at worktreePath for the given branch
-// If the branch doesn't exist, it will be created
-func CreateWorktree(repoDir, worktreePath, branchName string) error {
-	// Validate branch name first
+// CreateWorktree creates a new git worktree.
+// If the branch doesn't exist, it will be created.
+func (g *GitBackend) CreateWorktree(worktreePath, branchName string) error {
+
 	if err := ValidateBranchName(branchName); err != nil {
 		return fmt.Errorf("invalid branch name: %w", err)
 	}
 
-	// Transparently resolve a bare-repo project root (no .git, but contains
-	// a nested bare repo like .bare/) to the underlying git dir.
-	repoDir = resolveGitInvocationDir(repoDir)
-
-	// Check if it's a git repo
-	if !IsGitRepo(repoDir) {
+	if !IsGitRepo(g.repoDir) {
 		return errors.New("not a git repository")
 	}
 
-	resolution, err := resolveWorktreeBranch(repoDir, branchName)
+	resolution, err := g.resolveWorktreeBranch(branchName)
 	if err != nil {
 		return err
 	}
@@ -329,15 +366,15 @@ func CreateWorktree(repoDir, worktreePath, branchName string) error {
 	var cmd *exec.Cmd
 	switch resolution.Mode {
 	case worktreeBranchLocal:
-		// Reuse an existing local branch.
-		cmd = exec.Command("git", "-C", repoDir, "worktree", "add", worktreePath, branchName)
+		// Use existing branch
+		cmd = exec.Command("git", "-C", g.repoDir, "worktree", "add", worktreePath, branchName)
 	case worktreeBranchRemote:
 		// Create a local tracking branch from the default remote.
 		remoteRef := resolution.Remote + "/" + branchName
-		cmd = exec.Command("git", "-C", repoDir, "worktree", "add", "--track", "-b", branchName, worktreePath, remoteRef)
+		cmd = exec.Command("git", "-C", g.repoDir, "worktree", "add", "--track", "-b", branchName, worktreePath, remoteRef)
 	default:
-		// Create a new local branch.
-		cmd = exec.Command("git", "-C", repoDir, "worktree", "add", "-b", branchName, worktreePath)
+		// Create new branch with -b flag
+		cmd = exec.Command("git", "-C", g.repoDir, "worktree", "add", "-b", branchName, worktreePath)
 	}
 
 	output, err := cmd.CombinedOutput()
@@ -348,14 +385,13 @@ func CreateWorktree(repoDir, worktreePath, branchName string) error {
 	return nil
 }
 
-// ListWorktrees returns all worktrees for the repository at repoDir
-func ListWorktrees(repoDir string) ([]Worktree, error) {
-	repoDir = resolveGitInvocationDir(repoDir)
-	if !IsGitRepo(repoDir) {
+// ListWorktrees returns all worktrees for the repository.
+func (g *GitBackend) ListWorktrees() ([]vcs.Worktree, error) {
+	if !IsGitRepo(g.repoDir) {
 		return nil, errors.New("not a git repository")
 	}
 
-	cmd := exec.Command("git", "-C", repoDir, "worktree", "list", "--porcelain")
+	cmd := exec.Command("git", "-C", g.repoDir, "worktree", "list", "--porcelain")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list worktrees: %w", err)
@@ -365,9 +401,9 @@ func ListWorktrees(repoDir string) ([]Worktree, error) {
 }
 
 // parseWorktreeList parses the output of `git worktree list --porcelain`
-func parseWorktreeList(output string) []Worktree {
-	var worktrees []Worktree
-	var current Worktree
+func parseWorktreeList(output string) []vcs.Worktree {
+	var worktrees []vcs.Worktree
+	var current vcs.Worktree
 
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	for scanner.Scan() {
@@ -378,7 +414,7 @@ func parseWorktreeList(output string) []Worktree {
 			if current.Path != "" {
 				worktrees = append(worktrees, current)
 			}
-			current = Worktree{}
+			current = vcs.Worktree{}
 			continue
 		}
 
@@ -420,13 +456,12 @@ func parseWorktreeList(output string) []Worktree {
 // When force is true and git fails (e.g. "Directory not empty" due to
 // untracked files like node_modules), falls back to removing the directory
 // directly and pruning stale worktree references.
-func RemoveWorktree(repoDir, worktreePath string, force bool) error {
-	repoDir = resolveGitInvocationDir(repoDir)
-	if !IsGitRepo(repoDir) {
+func (g *GitBackend) RemoveWorktree(worktreePath string, force bool) error {
+	if !IsGitRepo(g.repoDir) {
 		return errors.New("not a git repository")
 	}
 
-	args := []string{"-C", repoDir, "worktree", "remove"}
+	args := []string{"-C", g.repoDir, "worktree", "remove"}
 	if force {
 		args = append(args, "--force")
 	}
@@ -452,15 +487,15 @@ func RemoveWorktree(repoDir, worktreePath string, force bool) error {
 		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
 			return fmt.Errorf("failed to remove worktree directory: %w (git error: %s)", rmErr, strings.TrimSpace(string(output)))
 		}
-		return PruneWorktrees(repoDir)
+		return g.PruneWorktrees()
 	}
 
 	return nil
 }
 
-// GetWorktreeForBranch returns the worktree path for a given branch, if any
-func GetWorktreeForBranch(repoDir, branchName string) (string, error) {
-	worktrees, err := ListWorktrees(repoDir)
+// GetWorktreeForBranch returns the worktree path for a given branch, if any.
+func (g *GitBackend) GetWorktreeForBranch(branchName string) (string, error) {
+	worktrees, err := g.ListWorktrees()
 	if err != nil {
 		return "", err
 	}
@@ -593,8 +628,8 @@ func SanitizeBranchName(name string) string {
 	return sanitized
 }
 
-func resolveWorktreeBranch(repoDir, branchName string) (worktreeBranchResolution, error) {
-	if !IsGitRepo(repoDir) {
+func (g *GitBackend) resolveWorktreeBranch(branchName string) (worktreeBranchResolution, error) {
+	if !IsGitRepo(g.repoDir) {
 		return worktreeBranchResolution{}, errors.New("not a git repository")
 	}
 
@@ -603,21 +638,22 @@ func resolveWorktreeBranch(repoDir, branchName string) (worktreeBranchResolution
 		Mode:   worktreeBranchNew,
 	}
 
-	if BranchExists(repoDir, branchName) {
+	if g.BranchExists(branchName) {
 		resolution.Mode = worktreeBranchLocal
 		return resolution, nil
 	}
 
-	defaultRemote, err := getDefaultRemote(repoDir)
-	if err == nil && defaultRemote != "" && remoteBranchExists(repoDir, defaultRemote, branchName) {
+	defaultRemote, err := g.getDefaultRemote()
+	if err == nil && defaultRemote != "" && remoteBranchExists(g.repoDir, defaultRemote, branchName) {
 		resolution.Mode = worktreeBranchRemote
 		resolution.Remote = defaultRemote
 	}
 
 	return resolution, nil
 }
-func getDefaultRemote(repoDir string) (string, error) {
-	remotes, err := listRemotes(repoDir)
+
+func (g *GitBackend) getDefaultRemote() (string, error) {
+	remotes, err := listRemotes(g.repoDir)
 	if err != nil {
 		return "", err
 	}
@@ -625,9 +661,9 @@ func getDefaultRemote(repoDir string) (string, error) {
 		return "", errors.New("no git remotes configured")
 	}
 
-	currentBranch, err := GetCurrentBranch(repoDir)
+	currentBranch, err := g.GetCurrentBranch()
 	if err == nil && currentBranch != "" && currentBranch != "HEAD" {
-		cmd := exec.Command("git", "-C", repoDir, "config", "--get", "branch."+currentBranch+".remote")
+		cmd := exec.Command("git", "-C", g.repoDir, "config", "--get", "branch."+currentBranch+".remote")
 		output, err := cmd.Output()
 		if err == nil {
 			remote := strings.TrimSpace(string(output))
@@ -690,15 +726,13 @@ func listRefShortNames(repoDir string, refs ...string) ([]string, error) {
 
 // ListBranchCandidates returns unique branch names from local branches and the
 // default remote, normalized to plain branch names without a remote prefix.
-func ListBranchCandidates(repoDir string) ([]string, error) {
-	repoDir = resolveGitInvocationDir(repoDir)
-	if !IsGitRepo(repoDir) {
-		return nil, errors.New("not a git repository")
-	}
-
+func (g *GitBackend) ListBranchCandidates() ([]string, error) {
+	repoDir := g.repoDir
 	repoRoot, err := GetWorktreeBaseRoot(repoDir)
 	if err == nil && repoRoot != "" {
-		repoDir = repoRoot
+		// Re-resolve: GetWorktreeBaseRoot may return a project root that needs
+		// resolution for git invocations (e.g. bare-repo project roots).
+		repoDir = resolveGitInvocationDir(repoRoot)
 	}
 
 	branches, err := listRefShortNames(repoDir, "refs/heads")
@@ -750,10 +784,10 @@ func HasUncommittedChanges(dir string) (bool, error) {
 	return strings.TrimSpace(string(output)) != "", nil
 }
 
-// GetDefaultBranch returns the default branch name (e.g. "main" or "master") for the repo
-func GetDefaultBranch(repoDir string) (string, error) {
+// GetDefaultBranch returns the default branch name (e.g. "main" or "master").
+func (g *GitBackend) GetDefaultBranch() (string, error) {
 	// Try symbolic-ref first (works when remote HEAD is set)
-	cmd := exec.Command("git", "-C", repoDir, "symbolic-ref", "refs/remotes/origin/HEAD")
+	cmd := exec.Command("git", "-C", g.repoDir, "symbolic-ref", "refs/remotes/origin/HEAD")
 	output, err := cmd.Output()
 	if err == nil {
 		ref := strings.TrimSpace(string(output))
@@ -764,19 +798,19 @@ func GetDefaultBranch(repoDir string) (string, error) {
 	}
 
 	// Fallback: check for common default branch names
-	if BranchExists(repoDir, "main") {
+	if g.BranchExists("main") {
 		return "main", nil
 	}
-	if BranchExists(repoDir, "master") {
+	if g.BranchExists("master") {
 		return "master", nil
 	}
 
 	return "", errors.New("could not determine default branch (no origin/HEAD, no main or master branch)")
 }
 
-// MergeBranch merges the given branch into the current branch of the repository
-func MergeBranch(repoDir, branchName string) error {
-	cmd := exec.Command("git", "-C", repoDir, "merge", branchName)
+// MergeBranch merges the given branch into the current branch.
+func (g *GitBackend) MergeBranch(branchName string) error {
+	cmd := exec.Command("git", "-C", g.repoDir, "merge", branchName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("merge failed: %s: %w", strings.TrimSpace(string(output)), err)
@@ -785,12 +819,12 @@ func MergeBranch(repoDir, branchName string) error {
 }
 
 // DeleteBranch deletes a local branch. If force is true, uses -D (force delete).
-func DeleteBranch(repoDir, branchName string, force bool) error {
+func (g *GitBackend) DeleteBranch(branchName string, force bool) error {
 	flag := "-d"
 	if force {
 		flag = "-D"
 	}
-	cmd := exec.Command("git", "-C", repoDir, "branch", flag, branchName)
+	cmd := exec.Command("git", "-C", g.repoDir, "branch", flag, branchName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to delete branch: %s: %w", strings.TrimSpace(string(output)), err)
@@ -798,9 +832,9 @@ func DeleteBranch(repoDir, branchName string, force bool) error {
 	return nil
 }
 
-// PruneWorktrees removes stale worktree references
-func PruneWorktrees(repoDir string) error {
-	cmd := exec.Command("git", "-C", repoDir, "worktree", "prune")
+// PruneWorktrees removes stale worktree references.
+func (g *GitBackend) PruneWorktrees() error {
+	cmd := exec.Command("git", "-C", g.repoDir, "worktree", "prune")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to prune worktrees: %s: %w", strings.TrimSpace(string(output)), err)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 // Helper function to create a git repo for testing
@@ -59,6 +61,28 @@ func createBranch(t *testing.T, dir, branchName string) {
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to create branch %s: %v", branchName, err)
 	}
+}
+
+// Helper to create a test repo and return a GitBackend for it
+func newTestBackend(t *testing.T, dir string) *GitBackend {
+	t.Helper()
+	createTestRepo(t, dir)
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
+	return backend
+}
+
+// getCurrentBranch is a test helper that gets current branch using raw git commands
+func getCurrentBranch(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("failed to get current branch: %v", err)
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func runGit(t *testing.T, dir string, args ...string) string {
@@ -162,17 +186,16 @@ func TestGetRepoRoot(t *testing.T) {
 	})
 }
 
-func TestGetCurrentBranch(t *testing.T) {
+func TestGitBackend_GetCurrentBranch_Extended(t *testing.T) {
 	t.Run("returns main/master for new repo", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
-		branch, err := GetCurrentBranch(dir)
+		branch, err := backend.GetCurrentBranch()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		// Could be main or master depending on git config
 		if branch != "main" && branch != "master" {
 			t.Errorf("expected main or master, got %s", branch)
 		}
@@ -180,7 +203,7 @@ func TestGetCurrentBranch(t *testing.T) {
 
 	t.Run("returns correct branch after checkout", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 		createBranch(t, dir, "feature-branch")
 
 		cmd := exec.Command("git", "checkout", "feature-branch")
@@ -189,7 +212,7 @@ func TestGetCurrentBranch(t *testing.T) {
 			t.Fatalf("failed to checkout branch: %v", err)
 		}
 
-		branch, err := GetCurrentBranch(dir)
+		branch, err := backend.GetCurrentBranch()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -198,42 +221,25 @@ func TestGetCurrentBranch(t *testing.T) {
 			t.Errorf("expected feature-branch, got %s", branch)
 		}
 	})
-
-	t.Run("returns error for non-git directory", func(t *testing.T) {
-		dir := t.TempDir()
-
-		_, err := GetCurrentBranch(dir)
-		if err == nil {
-			t.Error("expected error for non-git directory")
-		}
-	})
 }
 
-func TestBranchExists(t *testing.T) {
+func TestGitBackend_BranchExists_Extended(t *testing.T) {
 	t.Run("returns true for existing branch", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 		createBranch(t, dir, "existing-branch")
 
-		if !BranchExists(dir, "existing-branch") {
+		if !backend.BranchExists("existing-branch") {
 			t.Error("expected BranchExists to return true for existing branch")
 		}
 	})
 
 	t.Run("returns false for non-existing branch", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
-		if BranchExists(dir, "nonexistent-branch") {
+		if backend.BranchExists("nonexistent-branch") {
 			t.Error("expected BranchExists to return false for non-existing branch")
-		}
-	})
-
-	t.Run("returns false for non-git directory", func(t *testing.T) {
-		dir := t.TempDir()
-
-		if BranchExists(dir, "any-branch") {
-			t.Error("expected BranchExists to return false for non-git directory")
 		}
 	})
 }
@@ -448,29 +454,24 @@ func TestGenerateWorktreePath(t *testing.T) {
 	})
 }
 
-func TestCreateWorktree(t *testing.T) {
+func TestGitBackend_CreateWorktree(t *testing.T) {
 	t.Run("creates worktree with existing branch", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 		createBranch(t, dir, "existing-branch")
 
 		worktreePath := filepath.Join(t.TempDir(), "worktree")
 
-		err := CreateWorktree(dir, worktreePath, "existing-branch")
+		err := backend.CreateWorktree(worktreePath, "existing-branch")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		// Verify worktree was created
 		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
 			t.Error("worktree directory was not created")
 		}
 
-		// Verify it's on the correct branch
-		branch, err := GetCurrentBranch(worktreePath)
-		if err != nil {
-			t.Fatalf("failed to get branch: %v", err)
-		}
+		branch := getCurrentBranch(t, worktreePath)
 		if branch != "existing-branch" {
 			t.Errorf("expected branch existing-branch, got %s", branch)
 		}
@@ -478,49 +479,110 @@ func TestCreateWorktree(t *testing.T) {
 
 	t.Run("creates worktree with new branch", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		worktreePath := filepath.Join(t.TempDir(), "worktree")
 
-		err := CreateWorktree(dir, worktreePath, "new-branch")
+		err := backend.CreateWorktree(worktreePath, "new-branch")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		// Verify worktree was created
 		if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
 			t.Error("worktree directory was not created")
 		}
 
-		// Verify it's on the new branch
-		branch, err := GetCurrentBranch(worktreePath)
-		if err != nil {
-			t.Fatalf("failed to get branch: %v", err)
-		}
+		branch := getCurrentBranch(t, worktreePath)
 		if branch != "new-branch" {
 			t.Errorf("expected branch new-branch, got %s", branch)
 		}
 	})
 
-	t.Run("returns error for invalid branch name", func(t *testing.T) {
+	t.Run("creates worktree from default remote branch", func(t *testing.T) {
 		dir := t.TempDir()
 		createTestRepo(t, dir)
 
+		remoteDir := filepath.Join(t.TempDir(), "origin.git")
+		if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+			t.Fatalf("failed to create remote dir: %v", err)
+		}
+		runGit(t, remoteDir, "init", "--bare")
+		runGit(t, dir, "remote", "add", "origin", remoteDir)
+		runGit(t, dir, "push", "-u", "origin", "main")
+		runGit(t, dir, "checkout", "-b", "remote-only")
+		runGit(t, dir, "push", "-u", "origin", "remote-only")
+		runGit(t, dir, "checkout", "main")
+		runGit(t, dir, "branch", "-D", "remote-only")
+
+		backend, err := NewGitBackend(dir)
+		if err != nil {
+			t.Fatalf("failed to create GitBackend: %v", err)
+		}
+
+		worktreePath := filepath.Join(t.TempDir(), "worktree")
+		if err := backend.CreateWorktree(worktreePath, "remote-only"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !backend.BranchExists("remote-only") {
+			t.Fatal("expected CreateWorktree to create a local tracking branch")
+		}
+
+		// Check the worktree's HEAD directly: NewGitBackend resolves to the main
+		// repo root, so GetCurrentBranch() would report the main repo's branch.
+		branch := runGit(t, worktreePath, "rev-parse", "--abbrev-ref", "HEAD")
+		if branch != "remote-only" {
+			t.Fatalf("expected remote-only branch, got %s", branch)
+		}
+
+		upstream := runGit(t, worktreePath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+		if upstream != "origin/remote-only" {
+			t.Fatalf("expected upstream origin/remote-only, got %s", upstream)
+		}
+	})
+
+	t.Run("returns error for invalid branch name", func(t *testing.T) {
+		dir := t.TempDir()
+		backend := newTestBackend(t, dir)
+
 		worktreePath := filepath.Join(t.TempDir(), "worktree")
 
-		err := CreateWorktree(dir, worktreePath, "invalid..branch")
+		err := backend.CreateWorktree(worktreePath, "invalid..branch")
 		if err == nil {
 			t.Error("expected error for invalid branch name")
 		}
 	})
+}
 
-	t.Run("returns error for non-git directory", func(t *testing.T) {
+func TestResolveWorktreeBranch(t *testing.T) {
+	t.Run("prefers local branch over default remote branch", func(t *testing.T) {
 		dir := t.TempDir()
-		worktreePath := filepath.Join(t.TempDir(), "worktree")
+		createTestRepo(t, dir)
 
-		err := CreateWorktree(dir, worktreePath, "branch")
-		if err == nil {
-			t.Error("expected error for non-git directory")
+		remoteDir := filepath.Join(t.TempDir(), "origin.git")
+		if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+			t.Fatalf("failed to create remote dir: %v", err)
+		}
+		runGit(t, remoteDir, "init", "--bare")
+		runGit(t, dir, "remote", "add", "origin", remoteDir)
+		runGit(t, dir, "push", "-u", "origin", "main")
+		runGit(t, dir, "checkout", "-b", "shared-branch")
+		runGit(t, dir, "push", "-u", "origin", "shared-branch")
+		runGit(t, dir, "checkout", "main")
+
+		backend, err := NewGitBackend(dir)
+		if err != nil {
+			t.Fatalf("failed to create GitBackend: %v", err)
+		}
+		resolution, err := backend.resolveWorktreeBranch("shared-branch")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resolution.Mode != worktreeBranchLocal {
+			t.Fatalf("expected local branch resolution, got mode %d", resolution.Mode)
+		}
+		if resolution.Remote != "" {
+			t.Fatalf("expected no remote for local resolution, got %q", resolution.Remote)
 		}
 	})
 }
@@ -554,7 +616,11 @@ func TestListBranchCandidates(t *testing.T) {
 	runGit(t, dir, "checkout", "main")
 	runGit(t, dir, "branch", "-D", "feature/fork-remote")
 
-	branches, err := ListBranchCandidates(dir)
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
+	branches, err := backend.ListBranchCandidates()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -579,28 +645,25 @@ func containsString(items []string, want string) bool {
 	return false
 }
 
-func TestListWorktrees(t *testing.T) {
+func TestGitBackend_ListWorktrees(t *testing.T) {
 	t.Run("lists worktrees in repo", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
-		// Create a worktree
 		worktreePath := filepath.Join(t.TempDir(), "worktree")
-		if err := CreateWorktree(dir, worktreePath, "feature-branch"); err != nil {
+		if err := backend.CreateWorktree(worktreePath, "feature-branch"); err != nil {
 			t.Fatalf("failed to create worktree: %v", err)
 		}
 
-		worktrees, err := ListWorktrees(dir)
+		worktrees, err := backend.ListWorktrees()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		// Should have at least 2 worktrees (main + feature)
 		if len(worktrees) < 2 {
 			t.Errorf("expected at least 2 worktrees, got %d", len(worktrees))
 		}
 
-		// Find the feature worktree
 		var found bool
 		for _, wt := range worktrees {
 			resolvedPath, _ := filepath.EvalSymlinks(wt.Path)
@@ -616,34 +679,24 @@ func TestListWorktrees(t *testing.T) {
 			t.Error("feature worktree not found in list")
 		}
 	})
-
-	t.Run("returns error for non-git directory", func(t *testing.T) {
-		dir := t.TempDir()
-
-		_, err := ListWorktrees(dir)
-		if err == nil {
-			t.Error("expected error for non-git directory")
-		}
-	})
 }
 
-func TestRemoveWorktree(t *testing.T) {
+func TestGitBackend_RemoveWorktree(t *testing.T) {
 	t.Run("removes worktree", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		worktreePath := filepath.Join(t.TempDir(), "worktree")
-		if err := CreateWorktree(dir, worktreePath, "feature-branch"); err != nil {
+		if err := backend.CreateWorktree(worktreePath, "feature-branch"); err != nil {
 			t.Fatalf("failed to create worktree: %v", err)
 		}
 
-		err := RemoveWorktree(dir, worktreePath, false)
+		err := backend.RemoveWorktree(worktreePath, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		// Verify worktree was removed from list
-		worktrees, err := ListWorktrees(dir)
+		worktrees, err := backend.ListWorktrees()
 		if err != nil {
 			t.Fatalf("failed to list worktrees: %v", err)
 		}
@@ -659,20 +712,19 @@ func TestRemoveWorktree(t *testing.T) {
 
 	t.Run("force removes worktree with changes", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		worktreePath := filepath.Join(t.TempDir(), "worktree")
-		if err := CreateWorktree(dir, worktreePath, "feature-branch"); err != nil {
+		if err := backend.CreateWorktree(worktreePath, "feature-branch"); err != nil {
 			t.Fatalf("failed to create worktree: %v", err)
 		}
 
-		// Make uncommitted changes
 		testFile := filepath.Join(worktreePath, "newfile.txt")
 		if err := os.WriteFile(testFile, []byte("test content"), 0644); err != nil {
 			t.Fatalf("failed to create test file: %v", err)
 		}
 
-		err := RemoveWorktree(dir, worktreePath, true)
+		err := backend.RemoveWorktree(worktreePath, true)
 		if err != nil {
 			t.Fatalf("unexpected error with force: %v", err)
 		}
@@ -680,9 +732,9 @@ func TestRemoveWorktree(t *testing.T) {
 
 	t.Run("returns error for non-existent worktree", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
-		err := RemoveWorktree(dir, "/nonexistent/worktree", false)
+		err := backend.RemoveWorktree("/nonexistent/worktree", false)
 		if err == nil {
 			t.Error("expected error for non-existent worktree")
 		}
@@ -693,14 +745,14 @@ func TestRemoveWorktree(t *testing.T) {
 	// RemoveWorktree must fall back to os.RemoveAll + PruneWorktrees.
 	t.Run("force falls back to direct removal when git refuses", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		// wtA: target of RemoveWorktree. Deleting its admin metadata under
 		// <repoDir>/.git/worktrees/<name>/ makes `git worktree remove --force`
 		// exit non-zero ("is not a working tree"). The worktree directory
 		// itself stays on disk, so the fallback's os.RemoveAll has real work.
 		wtA := filepath.Join(t.TempDir(), "wtA")
-		if err := CreateWorktree(dir, wtA, "feature-a"); err != nil {
+		if err := backend.CreateWorktree(wtA, "feature-a"); err != nil {
 			t.Fatalf("create wtA: %v", err)
 		}
 		if err := os.RemoveAll(filepath.Join(dir, ".git", "worktrees", filepath.Base(wtA))); err != nil {
@@ -711,14 +763,14 @@ func TestRemoveWorktree(t *testing.T) {
 		// Gives PruneWorktrees real work so a future refactor that drops
 		// the prune call would fail this test.
 		wtB := filepath.Join(t.TempDir(), "wtB")
-		if err := CreateWorktree(dir, wtB, "feature-b"); err != nil {
+		if err := backend.CreateWorktree(wtB, "feature-b"); err != nil {
 			t.Fatalf("create wtB: %v", err)
 		}
 		if err := os.RemoveAll(wtB); err != nil {
 			t.Fatalf("remove wtB dir: %v", err)
 		}
 
-		if err := RemoveWorktree(dir, wtA, true); err != nil {
+		if err := backend.RemoveWorktree(wtA, true); err != nil {
 			t.Fatalf("RemoveWorktree(force=true) should succeed via fallback: %v", err)
 		}
 
@@ -729,7 +781,7 @@ func TestRemoveWorktree(t *testing.T) {
 
 		// PruneWorktrees ran: wtB's dangling admin entry is swept, leaving
 		// only the main repo worktree.
-		worktrees, err := ListWorktrees(dir)
+		worktrees, err := backend.ListWorktrees()
 		if err != nil {
 			t.Fatalf("list worktrees: %v", err)
 		}
@@ -741,7 +793,7 @@ func TestRemoveWorktree(t *testing.T) {
 
 func TestWorktreeStruct(t *testing.T) {
 	t.Run("worktree has expected fields", func(t *testing.T) {
-		wt := Worktree{
+		wt := vcs.Worktree{
 			Path:   "/path/to/worktree",
 			Branch: "feature-branch",
 			Commit: "abc123",
@@ -764,36 +816,27 @@ func TestWorktreeStruct(t *testing.T) {
 }
 
 func TestIntegration_WorktreeLifecycle(t *testing.T) {
-	// Full lifecycle test: create repo -> create worktree -> list -> remove
 	dir := t.TempDir()
-	createTestRepo(t, dir)
+	backend := newTestBackend(t, dir)
 
-	// Verify initial state
 	if !IsGitRepo(dir) {
 		t.Fatal("test repo is not a git repo")
 	}
 
-	root, err := GetRepoRoot(dir)
-	if err != nil {
-		t.Fatalf("failed to get repo root: %v", err)
-	}
-
-	branch, err := GetCurrentBranch(dir)
+	branch, err := backend.GetCurrentBranch()
 	if err != nil {
 		t.Fatalf("failed to get current branch: %v", err)
 	}
 	t.Logf("Initial branch: %s", branch)
 
-	// Create worktree
-	worktreePath := GenerateWorktreePath(root, "feature-test", "sibling")
+	worktreePath := GenerateWorktreePath(backend.RepoDir(), "feature-test", "sibling")
 	t.Logf("Creating worktree at: %s", worktreePath)
 
-	if err := CreateWorktree(root, worktreePath, "feature-test"); err != nil {
+	if err := backend.CreateWorktree(worktreePath, "feature-test"); err != nil {
 		t.Fatalf("failed to create worktree: %v", err)
 	}
 
-	// List and verify
-	worktrees, err := ListWorktrees(root)
+	worktrees, err := backend.ListWorktrees()
 	if err != nil {
 		t.Fatalf("failed to list worktrees: %v", err)
 	}
@@ -802,18 +845,15 @@ func TestIntegration_WorktreeLifecycle(t *testing.T) {
 		t.Errorf("expected 2 worktrees, got %d", len(worktrees))
 	}
 
-	// Verify branch exists now
-	if !BranchExists(root, "feature-test") {
+	if !backend.BranchExists("feature-test") {
 		t.Error("feature-test branch should exist after worktree creation")
 	}
 
-	// Remove worktree
-	if err := RemoveWorktree(root, worktreePath, false); err != nil {
+	if err := backend.RemoveWorktree(worktreePath, false); err != nil {
 		t.Fatalf("failed to remove worktree: %v", err)
 	}
 
-	// Verify removal
-	worktrees, err = ListWorktrees(root)
+	worktrees, err = backend.ListWorktrees()
 	if err != nil {
 		t.Fatalf("failed to list worktrees after removal: %v", err)
 	}
@@ -822,7 +862,6 @@ func TestIntegration_WorktreeLifecycle(t *testing.T) {
 		t.Errorf("expected 1 worktree after removal, got %d", len(worktrees))
 	}
 
-	// Cleanup - remove the worktree directory if it still exists
 	os.RemoveAll(worktreePath)
 }
 
@@ -895,9 +934,9 @@ func TestHasUncommittedChanges(t *testing.T) {
 func TestGetDefaultBranch(t *testing.T) {
 	t.Run("detects main branch", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
-		branch, err := GetDefaultBranch(dir)
+		branch, err := backend.GetDefaultBranch()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -909,17 +948,17 @@ func TestGetDefaultBranch(t *testing.T) {
 
 	t.Run("returns error when no default branch exists", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		// Rename the default branch to something non-standard
-		currentBranch, _ := GetCurrentBranch(dir)
-		cmd := exec.Command("git", "branch", "-m", currentBranch, "develop")
+		curBranch := getCurrentBranch(t, dir)
+		cmd := exec.Command("git", "branch", "-m", curBranch, "develop")
 		cmd.Dir = dir
 		if err := cmd.Run(); err != nil {
 			t.Fatalf("failed to rename branch: %v", err)
 		}
 
-		_, err := GetDefaultBranch(dir)
+		_, err := backend.GetDefaultBranch()
 		if err == nil {
 			t.Error("expected error when no main/master branch exists")
 		}
@@ -929,22 +968,22 @@ func TestGetDefaultBranch(t *testing.T) {
 func TestDeleteBranch(t *testing.T) {
 	t.Run("deletes merged branch", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 		createBranch(t, dir, "to-delete")
 
-		err := DeleteBranch(dir, "to-delete", false)
+		err := backend.DeleteBranch("to-delete", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if BranchExists(dir, "to-delete") {
+		if backend.BranchExists("to-delete") {
 			t.Error("branch should have been deleted")
 		}
 	})
 
 	t.Run("force deletes unmerged branch", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		// Create branch with a unique commit
 		cmd := exec.Command("git", "checkout", "-b", "unmerged-branch")
@@ -963,9 +1002,8 @@ func TestDeleteBranch(t *testing.T) {
 		_ = cmd.Run()
 
 		// Switch back to default branch
-		defaultBranch, _ := GetCurrentBranch(dir)
-		if defaultBranch == "unmerged-branch" {
-			// Need to get the original branch name
+		curBranch := getCurrentBranch(t, dir)
+		if curBranch == "unmerged-branch" {
 			cmd = exec.Command("git", "checkout", "-")
 			cmd.Dir = dir
 			if err := cmd.Run(); err != nil {
@@ -974,18 +1012,18 @@ func TestDeleteBranch(t *testing.T) {
 		}
 
 		// Regular delete should fail
-		err := DeleteBranch(dir, "unmerged-branch", false)
+		err := backend.DeleteBranch("unmerged-branch", false)
 		if err == nil {
 			t.Error("expected error deleting unmerged branch without force")
 		}
 
 		// Force delete should succeed
-		err = DeleteBranch(dir, "unmerged-branch", true)
+		err = backend.DeleteBranch("unmerged-branch", true)
 		if err != nil {
 			t.Fatalf("unexpected error with force delete: %v", err)
 		}
 
-		if BranchExists(dir, "unmerged-branch") {
+		if backend.BranchExists("unmerged-branch") {
 			t.Error("branch should have been force-deleted")
 		}
 	})
@@ -994,7 +1032,7 @@ func TestDeleteBranch(t *testing.T) {
 func TestMergeBranch(t *testing.T) {
 	t.Run("fast-forward merge succeeds", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		// Create feature branch with a commit
 		cmd := exec.Command("git", "checkout", "-b", "feature-merge")
@@ -1020,7 +1058,7 @@ func TestMergeBranch(t *testing.T) {
 		}
 
 		// Merge feature branch
-		err := MergeBranch(dir, "feature-merge")
+		err := backend.MergeBranch("feature-merge")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1035,10 +1073,10 @@ func TestMergeBranch(t *testing.T) {
 func TestPruneWorktrees(t *testing.T) {
 	t.Run("prune after manually removing worktree dir", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		worktreePath := filepath.Join(t.TempDir(), "worktree")
-		if err := CreateWorktree(dir, worktreePath, "prune-test"); err != nil {
+		if err := backend.CreateWorktree(worktreePath, "prune-test"); err != nil {
 			t.Fatalf("failed to create worktree: %v", err)
 		}
 
@@ -1046,13 +1084,13 @@ func TestPruneWorktrees(t *testing.T) {
 		os.RemoveAll(worktreePath)
 
 		// Prune should clean up the stale reference
-		err := PruneWorktrees(dir)
+		err := backend.PruneWorktrees()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
 		// After pruning, listing worktrees should show only the main one
-		worktrees, err := ListWorktrees(dir)
+		worktrees, err := backend.ListWorktrees()
 		if err != nil {
 			t.Fatalf("failed to list worktrees: %v", err)
 		}
@@ -1074,10 +1112,10 @@ func TestIsWorktree(t *testing.T) {
 
 	t.Run("returns true for worktree", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		worktreePath := filepath.Join(t.TempDir(), "wt")
-		if err := CreateWorktree(dir, worktreePath, "feature-wt"); err != nil {
+		if err := backend.CreateWorktree(worktreePath, "feature-wt"); err != nil {
 			t.Fatalf("failed to create worktree: %v", err)
 		}
 
@@ -1097,10 +1135,10 @@ func TestIsWorktree(t *testing.T) {
 func TestGetMainWorktreePath(t *testing.T) {
 	t.Run("returns main repo from worktree", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		worktreePath := filepath.Join(t.TempDir(), "wt")
-		if err := CreateWorktree(dir, worktreePath, "feature-main"); err != nil {
+		if err := backend.CreateWorktree(worktreePath, "feature-main"); err != nil {
 			t.Fatalf("failed to create worktree: %v", err)
 		}
 
@@ -1155,10 +1193,10 @@ func TestGetWorktreeBaseRoot(t *testing.T) {
 
 	t.Run("returns main repo root from worktree", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		worktreePath := filepath.Join(t.TempDir(), "wt")
-		if err := CreateWorktree(dir, worktreePath, "feature-base"); err != nil {
+		if err := backend.CreateWorktree(worktreePath, "feature-base"); err != nil {
 			t.Fatalf("failed to create worktree: %v", err)
 		}
 
@@ -1177,10 +1215,10 @@ func TestGetWorktreeBaseRoot(t *testing.T) {
 
 	t.Run("returns main repo root from worktree subdirectory", func(t *testing.T) {
 		dir := t.TempDir()
-		createTestRepo(t, dir)
+		backend := newTestBackend(t, dir)
 
 		worktreePath := filepath.Join(t.TempDir(), "wt")
-		if err := CreateWorktree(dir, worktreePath, "feature-sub"); err != nil {
+		if err := backend.CreateWorktree(worktreePath, "feature-sub"); err != nil {
 			t.Fatalf("failed to create worktree: %v", err)
 		}
 
@@ -1216,11 +1254,11 @@ func TestIntegration_WorktreeNesting(t *testing.T) {
 	// When creating a worktree from within another worktree, the new worktree
 	// should be a sibling (relative to the main repo), not nested inside the first.
 	dir := t.TempDir()
-	createTestRepo(t, dir)
+	backend := newTestBackend(t, dir)
 
 	// Create first worktree (simulates Session A)
 	wt1Path := filepath.Join(dir, ".worktrees", "feature-a")
-	if err := CreateWorktree(dir, wt1Path, "feature-a"); err != nil {
+	if err := backend.CreateWorktree(wt1Path, "feature-a"); err != nil {
 		t.Fatalf("failed to create first worktree: %v", err)
 	}
 
@@ -1239,7 +1277,7 @@ func TestIntegration_WorktreeNesting(t *testing.T) {
 
 	// Create second worktree using the resolved base root (simulates Session B fork)
 	wt2Path := GenerateWorktreePath(baseRoot, "feature-b", "subdirectory")
-	if err := CreateWorktree(baseRoot, wt2Path, "feature-b"); err != nil {
+	if err := backend.CreateWorktree(wt2Path, "feature-b"); err != nil {
 		t.Fatalf("failed to create second worktree: %v", err)
 	}
 
@@ -1269,4 +1307,226 @@ func TestIntegration_WorktreeNesting(t *testing.T) {
 	}
 	t.Logf("Correct path:  %s", actualWt2)
 	t.Logf("Wrong path:    %s (would have been nested)", wrongWt2)
+}
+
+// --- GitBackend tests ---
+
+func TestNewGitBackend(t *testing.T) {
+	t.Run("succeeds for git repo", func(t *testing.T) {
+		dir := t.TempDir()
+		createTestRepo(t, dir)
+
+		backend, err := NewGitBackend(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedRoot, _ := filepath.EvalSymlinks(dir)
+		actualRoot, _ := filepath.EvalSymlinks(backend.RepoDir())
+		if actualRoot != expectedRoot {
+			t.Errorf("expected repo dir %s, got %s", expectedRoot, actualRoot)
+		}
+	})
+
+	t.Run("resolves through worktree", func(t *testing.T) {
+		dir := t.TempDir()
+		backend := newTestBackend(t, dir)
+
+		wtPath := filepath.Join(t.TempDir(), "wt")
+		if err := backend.CreateWorktree(wtPath, "feature-backend"); err != nil {
+			t.Fatalf("failed to create worktree: %v", err)
+		}
+
+		backend, err := NewGitBackend(wtPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedRoot, _ := filepath.EvalSymlinks(dir)
+		actualRoot, _ := filepath.EvalSymlinks(backend.RepoDir())
+		if actualRoot != expectedRoot {
+			t.Errorf("expected main repo root %s, got %s", expectedRoot, actualRoot)
+		}
+	})
+
+	t.Run("returns error for non-git directory", func(t *testing.T) {
+		dir := t.TempDir()
+
+		_, err := NewGitBackend(dir)
+		if err == nil {
+			t.Error("expected error for non-git directory")
+		}
+	})
+}
+
+func TestGitBackend_BranchExists(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	createBranch(t, dir, "exists")
+
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !backend.BranchExists("exists") {
+		t.Error("expected BranchExists to return true")
+	}
+	if backend.BranchExists("nope") {
+		t.Error("expected BranchExists to return false")
+	}
+}
+
+func TestGitBackend_GetCurrentBranch(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	branch, err := backend.GetCurrentBranch()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch != "main" && branch != "master" {
+		t.Errorf("expected main or master, got %s", branch)
+	}
+}
+
+func TestGitBackend_GetDefaultBranch(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	branch, err := backend.GetDefaultBranch()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch != "main" && branch != "master" {
+		t.Errorf("expected main or master, got %s", branch)
+	}
+}
+
+func TestGitBackend_WorktreeLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Create worktree
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	if err := backend.CreateWorktree(wtPath, "feature-lifecycle"); err != nil {
+		t.Fatalf("failed to create worktree: %v", err)
+	}
+
+	// List worktrees
+	worktrees, err := backend.ListWorktrees()
+	if err != nil {
+		t.Fatalf("failed to list worktrees: %v", err)
+	}
+	if len(worktrees) < 2 {
+		t.Errorf("expected at least 2 worktrees, got %d", len(worktrees))
+	}
+
+	// GetWorktreeForBranch
+	foundPath, err := backend.GetWorktreeForBranch("feature-lifecycle")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resolvedFound, _ := filepath.EvalSymlinks(foundPath)
+	resolvedExpected, _ := filepath.EvalSymlinks(wtPath)
+	if resolvedFound != resolvedExpected {
+		t.Errorf("expected worktree path %s, got %s", resolvedExpected, resolvedFound)
+	}
+
+	// Remove worktree
+	if err := backend.RemoveWorktree(wtPath, false); err != nil {
+		t.Fatalf("failed to remove worktree: %v", err)
+	}
+
+	// Prune
+	if err := backend.PruneWorktrees(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify removal
+	worktrees, err = backend.ListWorktrees()
+	if err != nil {
+		t.Fatalf("failed to list after removal: %v", err)
+	}
+	if len(worktrees) != 1 {
+		t.Errorf("expected 1 worktree after removal, got %d", len(worktrees))
+	}
+}
+
+func TestGitBackend_MergeAndDeleteBranch(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Create branch with commit
+	cmd := exec.Command("git", "checkout", "-b", "merge-test")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to create branch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "merge.txt"), []byte("merge"), 0644); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "commit", "-m", "merge commit")
+	cmd.Dir = dir
+	_ = cmd.Run()
+
+	// Switch back
+	cmd = exec.Command("git", "checkout", "-")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to checkout: %v", err)
+	}
+
+	// Merge
+	if err := backend.MergeBranch("merge-test"); err != nil {
+		t.Fatalf("merge failed: %v", err)
+	}
+
+	// Delete
+	if err := backend.DeleteBranch("merge-test", false); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+
+	if backend.BranchExists("merge-test") {
+		t.Error("branch should have been deleted")
+	}
+}
+
+func TestGitBackend_ImplementsVCSBackend(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Use through the interface to verify it satisfies vcs.Backend
+	var b vcs.Backend = backend
+	if b.RepoDir() == "" {
+		t.Error("expected non-empty RepoDir")
+	}
 }

--- a/internal/git/setup.go
+++ b/internal/git/setup.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 // FindWorktreeSetupScript returns the path to the worktree setup script
@@ -86,10 +88,10 @@ func buildSetupCmd(ctx context.Context, scriptPath string, mode os.FileMode) *ex
 	return exec.CommandContext(ctx, "sh", "-e", scriptPath)
 }
 
-// CreateWorktreeWithSetup creates a worktree and runs the setup script if present.
-// Setup script failure is non-fatal: the worktree is still valid.
-// Output is streamed to the provided writers. A non-positive setupTimeout
-// means "no deadline" — see RunWorktreeSetupScript for the full semantic.
+// CreateWorktreeWithSetup creates a worktree via the given backend and runs the
+// setup script if present. Setup script failure is non-fatal: the worktree is
+// still valid. Output is streamed to the provided writers. A non-positive
+// setupTimeout means "no deadline" — see RunWorktreeSetupScript for the full semantic.
 //
 // User-visible progress (#768): the start preamble, an explicit completion
 // line on success, and an explicit failure line on error are written to
@@ -97,11 +99,12 @@ func buildSetupCmd(ctx context.Context, scriptPath string, mode os.FileMode) *ex
 // for later display) can show the user what happened. Without these,
 // users couldn't tell whether the script had run, finished, or finished
 // cleanly before claude started.
-func CreateWorktreeWithSetup(repoDir, worktreePath, branchName string, stdout, stderr io.Writer, setupTimeout time.Duration) (setupErr error, err error) {
-	if err = CreateWorktree(repoDir, worktreePath, branchName); err != nil {
+func CreateWorktreeWithSetup(backend vcs.Backend, worktreePath, branchName string, stdout, stderr io.Writer, setupTimeout time.Duration) (setupErr error, err error) {
+	if err = backend.CreateWorktree(worktreePath, branchName); err != nil {
 		return nil, err
 	}
 
+	repoDir := backend.RepoDir()
 	scriptPath, scriptMode := FindWorktreeSetupScript(repoDir)
 	if scriptPath == "" {
 		return nil, nil

--- a/internal/git/setup_progress_test.go
+++ b/internal/git/setup_progress_test.go
@@ -29,9 +29,14 @@ func TestCreateWorktreeWithSetup_ProgressMessages_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
+
 	worktreePath := filepath.Join(dir, ".worktrees", "progress-ok")
 	var stdout, stderr bytes.Buffer
-	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "progress-ok", &stdout, &stderr, 0)
+	setupErr, err := CreateWorktreeWithSetup(backend, worktreePath, "progress-ok", &stdout, &stderr, 0)
 	if err != nil {
 		t.Fatalf("worktree creation failed: %v", err)
 	}
@@ -61,9 +66,14 @@ func TestCreateWorktreeWithSetup_ProgressMessages_Failure(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
+
 	worktreePath := filepath.Join(dir, ".worktrees", "progress-fail")
 	var stdout, stderr bytes.Buffer
-	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "progress-fail", &stdout, &stderr, 0)
+	setupErr, err := CreateWorktreeWithSetup(backend, worktreePath, "progress-fail", &stdout, &stderr, 0)
 	if err != nil {
 		t.Fatalf("worktree creation should succeed even when setup fails: %v", err)
 	}

--- a/internal/git/setup_test.go
+++ b/internal/git/setup_test.go
@@ -182,8 +182,13 @@ func TestCreateWorktreeWithSetup_NoScript(t *testing.T) {
 	createTestRepoForSetup(t, dir)
 	worktreePath := filepath.Join(dir, ".worktrees", "test-branch")
 
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
+
 	var stdout, stderr bytes.Buffer
-	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "test-branch", &stdout, &stderr, 0)
+	setupErr, err := CreateWorktreeWithSetup(backend, worktreePath, "test-branch", &stdout, &stderr, 0)
 	if err != nil {
 		t.Fatalf("worktree creation failed: %v", err)
 	}
@@ -222,9 +227,14 @@ echo "setup done"
 		t.Fatal(err)
 	}
 
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
+
 	worktreePath := filepath.Join(dir, ".worktrees", "setup-branch")
 	var stdout, stderr bytes.Buffer
-	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "setup-branch", &stdout, &stderr, 0)
+	setupErr, err := CreateWorktreeWithSetup(backend, worktreePath, "setup-branch", &stdout, &stderr, 0)
 	if err != nil {
 		t.Fatalf("worktree creation failed: %v", err)
 	}
@@ -262,9 +272,14 @@ exit 1
 		t.Fatal(err)
 	}
 
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("failed to create GitBackend: %v", err)
+	}
+
 	worktreePath := filepath.Join(dir, ".worktrees", "fail-branch")
 	var stdout, stderr bytes.Buffer
-	setupErr, err := CreateWorktreeWithSetup(dir, worktreePath, "fail-branch", &stdout, &stderr, 0)
+	setupErr, err := CreateWorktreeWithSetup(backend, worktreePath, "fail-branch", &stdout, &stderr, 0)
 
 	// Worktree creation should succeed
 	if err != nil {

--- a/internal/git/submodule_test.go
+++ b/internal/git/submodule_test.go
@@ -81,7 +81,11 @@ func createSubmoduleLayout(t *testing.T) (super, submodule string) {
 func TestListWorktrees_SubmoduleReturnsWorkingTreeNotGitdir(t *testing.T) {
 	_, submodule := createSubmoduleLayout(t)
 
-	wts, err := ListWorktrees(submodule)
+	backend, err := NewGitBackend(submodule)
+	if err != nil {
+		t.Fatalf("NewGitBackend: %v", err)
+	}
+	wts, err := backend.ListWorktrees()
 	if err != nil {
 		t.Fatalf("ListWorktrees: %v", err)
 	}
@@ -107,12 +111,16 @@ func TestListWorktrees_SubmoduleReturnsWorkingTreeNotGitdir(t *testing.T) {
 func TestGetWorktreeForBranch_SubmoduleReturnsWorkingTree(t *testing.T) {
 	_, submodule := createSubmoduleLayout(t)
 
-	branch, err := GetCurrentBranch(submodule)
+	backend, err := NewGitBackend(submodule)
+	if err != nil {
+		t.Fatalf("NewGitBackend: %v", err)
+	}
+	branch, err := backend.GetCurrentBranch()
 	if err != nil {
 		t.Fatalf("GetCurrentBranch: %v", err)
 	}
 
-	got, err := GetWorktreeForBranch(submodule, branch)
+	got, err := backend.GetWorktreeForBranch(branch)
 	if err != nil {
 		t.Fatalf("GetWorktreeForBranch: %v", err)
 	}
@@ -142,7 +150,11 @@ func TestRemoveWorktree_RefusesToDeleteSubmoduleGitdir(t *testing.T) {
 	// Mirror the call shape from internal/ui/home.go:8562 and
 	// cmd/agent-deck/session_remove_cmd.go:177 — repoRoot = submodule worktree,
 	// worktreePath = (mistakenly) the gitdir, force = true.
-	err := RemoveWorktree(submodule, gitdir, true)
+	backend, err := NewGitBackend(submodule)
+	if err != nil {
+		t.Fatalf("NewGitBackend: %v", err)
+	}
+	err = backend.RemoveWorktree(gitdir, true)
 	if err == nil {
 		t.Fatal("RemoveWorktree(force=true) on a gitdir must return an error, not silently delete")
 	}
@@ -161,8 +173,13 @@ func TestRemoveWorktree_RefusesToDeleteRepoGitFolder(t *testing.T) {
 	dir := t.TempDir()
 	createTestRepo(t, dir)
 
+	backend, err := NewGitBackend(dir)
+	if err != nil {
+		t.Fatalf("NewGitBackend: %v", err)
+	}
+
 	wtPath := filepath.Join(t.TempDir(), "wt-feat")
-	if err := CreateWorktree(dir, wtPath, "feat"); err != nil {
+	if err := backend.CreateWorktree(wtPath, "feat"); err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
 
@@ -178,7 +195,7 @@ func TestRemoveWorktree_RefusesToDeleteRepoGitFolder(t *testing.T) {
 			if _, err := os.Stat(tc.path); err != nil {
 				t.Fatalf("%s should exist before RemoveWorktree (fixture bug?): %v", tc.path, err)
 			}
-			err := RemoveWorktree(dir, tc.path, true)
+			err := backend.RemoveWorktree(tc.path, true)
 			if err == nil {
 				t.Fatalf("RemoveWorktree(force=true) on %q must error, not delete git internals", tc.path)
 			}

--- a/internal/git/template_test.go
+++ b/internal/git/template_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -446,6 +447,44 @@ func TestWorktreePath(t *testing.T) {
 		})
 		// Falls back to GenerateWorktreePath.
 		expected := "..-feature-branch"
+		require.Equal(t, expected, result)
+	})
+}
+
+func TestGitBackend_WorktreePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses template via backend", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		createTestRepo(t, dir)
+
+		backend, err := NewGitBackend(dir)
+		require.NoError(t, err)
+
+		result := backend.WorktreePath(vcs.WorktreePathOptions{
+			Branch:    "feature-branch",
+			Location:  "sibling",
+			SessionID: "a1b2c3d4",
+			Template:  "{repo-root}/.worktrees/{branch}",
+		})
+		expected := filepath.Join(backend.RepoDir(), ".worktrees", "feature-branch")
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("falls back to location without template", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		createTestRepo(t, dir)
+
+		backend, err := NewGitBackend(dir)
+		require.NoError(t, err)
+
+		result := backend.WorktreePath(vcs.WorktreePathOptions{
+			Branch:   "feature-branch",
+			Location: "sibling",
+		})
+		expected := backend.RepoDir() + "-feature-branch"
 		require.Equal(t, expected, result)
 	})
 }

--- a/internal/jujutsu/jujutsu.go
+++ b/internal/jujutsu/jujutsu.go
@@ -1,0 +1,338 @@
+// Package jujutsu provides jj (Jujutsu) VCS operations for agent-deck.
+// It mirrors the internal/git package pattern with package-level functions
+// that execute jj CLI commands.
+package jujutsu
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
+)
+
+type JJBackend struct {
+	repoDir string
+}
+
+// Compile-time check that *JJBackend satisfies vcs.Backend.
+var _ vcs.Backend = (*JJBackend)(nil)
+
+func NewJJBackend(dir string) (*JJBackend, error) {
+	if !IsJJRepo(dir) {
+		return nil, fmt.Errorf("not a jujutsu repository: %s", dir)
+	}
+	root, err := GetWorktreeBaseRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	return &JJBackend{root}, nil
+}
+
+func (g *JJBackend) Type() vcs.Type { return vcs.TypeJujutsu }
+
+// RepoDir returns the root directory of the repository.
+func (b *JJBackend) RepoDir() string { return b.repoDir }
+
+// WorktreePath generates a workspace path using the backend's repoDir.
+// Delegates to the shared template logic in the git package (VCS-agnostic).
+func (b *JJBackend) WorktreePath(opts vcs.WorktreePathOptions) string {
+	return git.WorktreePath(git.WorktreePathOptions{
+		Branch:    opts.Branch,
+		Location:  opts.Location,
+		RepoDir:   b.repoDir,
+		SessionID: opts.SessionID,
+		Template:  opts.Template,
+	})
+}
+
+// IsJJRepo checks if the given directory is inside a jj repository by running
+// `jj root`. Returns false if jj is not installed or the directory is not a jj repo.
+func IsJJRepo(dir string) bool {
+	if _, err := exec.LookPath("jj"); err != nil {
+		return false
+	}
+	cmd := exec.Command("jj", "root", "-R", dir, "--ignore-working-copy")
+	return cmd.Run() == nil
+}
+
+// GetRepoRoot returns the root directory of the jj repository.
+func GetRepoRoot(dir string) (string, error) {
+	cmd := exec.Command("jj", "root", "-R", dir, "--ignore-working-copy")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("not a jj repository: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// GetCurrentBranch returns the first bookmark of the current working-copy change.
+func (b *JJBackend) GetCurrentBranch() (string, error) {
+	cmd := exec.Command("jj", "log", "-r", "@", "--no-graph", "-T", "bookmarks", "-R", b.repoDir, "--ignore-working-copy")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current bookmark: %w", err)
+	}
+	raw := strings.TrimSpace(string(output))
+	if raw == "" {
+		return "", nil
+	}
+	// jj may return multiple bookmarks separated by spaces; take the first
+	parts := strings.Fields(raw)
+	// jj appends a '*' to bookmarks that have local changes; strip it
+	return strings.TrimRight(parts[0], "*"), nil
+}
+
+// BranchExists checks if a bookmark exists in the repository.
+func (b *JJBackend) BranchExists(branchName string) bool {
+	cmd := exec.Command("jj", "bookmark", "list", "--name", branchName, "-R", b.repoDir, "--ignore-working-copy")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) != ""
+}
+
+// Workspace represents a jj workspace parsed from `jj workspace list`.
+type Workspace struct {
+	Name string
+	Path string
+}
+
+// ListWorktrees returns all workspaces for the repository.
+func (b *JJBackend) ListWorktrees() ([]vcs.Worktree, error) {
+	cmd := exec.Command("jj", "workspace", "list", "-R", b.repoDir, "-T", "name ++ ':' ++ target.commit_id() ++ \"\\n\"", "--ignore-working-copy")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workspaces: %w", err)
+	}
+	return parseWorkspacesList(string(output))
+}
+
+func parseWorkspacesList(output string) ([]vcs.Worktree, error) {
+	var workspaces []vcs.Worktree
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		// Format: "name: rest..."
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		commitId := strings.TrimSpace(parts[1])
+		workspaces = append(workspaces, vcs.Worktree{
+			Branch: name,
+			Commit: commitId,
+		})
+	}
+	return workspaces, nil
+}
+
+// getWorkspacePath returns the filesystem path for a named workspace.
+// It resolves the path from the repo root's .jj/working-copy stores.
+func getWorkspacePath(repoDir, workspaceName string) (string, error) {
+	if workspaceName == "default" {
+		return GetRepoRoot(repoDir)
+	}
+
+	cmd := exec.Command("jj", "workspace", "root", "--name", workspaceName, "--ignore-working-copy")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get workspace path: %w", err)
+	}
+	return string(output), nil
+}
+
+// IsDefaultWorkspace returns true if the given directory is the default workspace.
+func IsDefaultWorkspace(dir string) (bool, error) {
+	root, err := GetRepoRoot(dir)
+	if err != nil {
+		return false, err
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return false, err
+	}
+	return absDir == root, nil
+}
+
+// IsWorktree checks if the directory is a non-default jj workspace.
+func IsWorktree(dir string) bool {
+	isDefault, err := IsDefaultWorkspace(dir)
+	if err != nil {
+		return false
+	}
+	return !isDefault
+}
+
+// GetWorktreeBaseRoot returns the default workspace path (equivalent to main worktree in git).
+func GetWorktreeBaseRoot(dir string) (string, error) {
+	return GetRepoRoot(dir)
+}
+
+// CreateWorkspace creates a new jj workspace at the given path.
+func (b *JJBackend) CreateWorktree(workspacePath, branchName string) error {
+	// Derive workspace name from the path
+	wsName := workspaceNameFromPath(workspacePath)
+
+	cmd := exec.Command("jj", "workspace", "add", "--name", wsName, workspacePath, "-R", b.repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create workspace: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+
+	// Create/set bookmark on the new workspace's working copy
+	if branchName != "" {
+		if b.BranchExists(branchName) {
+			// Set existing bookmark to point to the new workspace's working copy
+			cmd = exec.Command("jj", "bookmark", "set", branchName, "-r", "@", "-R", workspacePath)
+		} else {
+			// Create new bookmark
+			cmd = exec.Command("jj", "bookmark", "create", branchName, "-r", "@", "-R", workspacePath)
+		}
+		output, err = cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to set bookmark: %s: %w", strings.TrimSpace(string(output)), err)
+		}
+	}
+
+	return nil
+}
+
+// RemoveWorktree forgets a workspace and optionally removes its directory.
+func (b *JJBackend) RemoveWorktree(workspacePath string, force bool) error {
+	wsName := workspaceNameFromPath(workspacePath)
+
+	cmd := exec.Command("jj", "workspace", "forget", wsName, "-R", b.repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to forget workspace: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+
+	// jj workspace forget doesn't remove the directory, so we do it ourselves
+	if err := os.RemoveAll(workspacePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove workspace directory: %w", err)
+	}
+
+	return nil
+}
+
+// PruneWorktrees removes workspace entries whose directories no longer exist.
+func (b *JJBackend) PruneWorktrees() error {
+	workspaces, err := b.ListWorktrees()
+	if err != nil {
+		return err
+	}
+	for _, ws := range workspaces {
+		if ws.Path == "default" {
+			continue
+		}
+		path, pathErr := getWorkspacePath(b.repoDir, ws.Branch)
+		if pathErr != nil {
+			continue
+		}
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			cmd := exec.Command("jj", "workspace", "forget", ws.Branch, "-R", b.repoDir)
+			_ = cmd.Run()
+		}
+	}
+	return nil
+}
+
+// HasUncommittedChanges checks if the working copy has uncommitted changes.
+func (b *JJBackend) HasUncommittedChanges() (bool, error) {
+	cmd := exec.Command("jj", "diff", "--stat", "-R", b.repoDir, "--ignore-working-copy")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("failed to check jj diff: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return strings.TrimSpace(string(output)) != "", nil
+}
+
+// GetDefaultBranch returns the default branch name (checks for main/master bookmarks).
+func (b *JJBackend) GetDefaultBranch() (string, error) {
+	if b.BranchExists("main") {
+		return "main", nil
+	}
+	if b.BranchExists("master") {
+		return "master", nil
+	}
+	return "", errors.New("could not determine default branch (no main or master bookmark)")
+}
+
+// MergeBranch creates a merge change combining the current change with the given bookmark.
+func (b *JJBackend) MergeBranch(branchName string) error {
+	cmd := exec.Command("jj", "new", "@", branchName, "-R", b.repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("merge failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// DeleteBranch deletes a bookmark.
+func (b *JJBackend) DeleteBranch(branchName string, force bool) error {
+	cmd := exec.Command("jj", "bookmark", "delete", branchName, "-R", b.repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to delete bookmark: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// CheckoutBranch moves the working copy to a new change based on the given bookmark.
+func (b *JJBackend) CheckoutBranch(branchName string) error {
+	cmd := exec.Command("jj", "new", branchName, "-R", b.repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to checkout %s: %s: %w", branchName, strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// AbortMerge undoes the last operation (equivalent to aborting a merge).
+func AbortMerge(repoDir string) error {
+	cmd := exec.Command("jj", "undo", "-R", repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to undo: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// GetMainWorktreePath returns the path to the default workspace.
+func GetMainWorktreePath(dir string) (string, error) {
+	return GetRepoRoot(dir)
+}
+
+// workspaceNameFromPath generates a workspace name from a filesystem path.
+func workspaceNameFromPath(path string) string {
+	name := filepath.Base(path)
+	// Replace characters that might be problematic in workspace names
+	name = strings.ReplaceAll(name, " ", "-")
+	return name
+}
+
+func (b *JJBackend) GetWorktreeForBranch(branchName string) (string, error) {
+	worktrees, err := b.ListWorktrees()
+	if err != nil {
+		return "", err
+	}
+
+	for _, wt := range worktrees {
+		if wt.Branch == branchName {
+			return wt.Path, nil
+		}
+	}
+
+	return "", nil
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -285,6 +285,11 @@ type Instance struct {
 	// Set by MCP dialog Apply() to avoid race condition where Apply writes
 	// config then Restart immediately overwrites it with different pool state
 	SkipMCPRegenerate bool `json:"-"` // Don't persist, transient flag
+
+	// lastVCSCheck tracks when we last verified the on-disk VCS type matches
+	// WorktreeType. After deserializing instances from disk the stored type
+	// may be stale (e.g. a repo was converted from git to jujutsu).
+	lastVCSCheck time.Time
 }
 
 // SandboxConfig holds per-session Docker sandbox settings.
@@ -479,6 +484,50 @@ func (inst *Instance) Backend() (vcs.Backend, error) {
 		return jujutsu.NewJJBackend(inst.WorktreePath)
 	}
 	return nil, fmt.Errorf("Unrecognized VCS type: %s", inst.WorktreeType)
+}
+
+// vcsCheckInterval controls how often reconcileWorktreeType re-probes the
+// on-disk VCS type. The check spawns subprocesses (jj root / git rev-parse)
+// so we avoid running it on every status tick.
+const vcsCheckInterval = 10 * time.Minute
+
+// reconcileWorktreeType checks the actual VCS type on disk and updates
+// WorktreeType if it doesn't match. This handles the case where an instance
+// was deserialized from disk but the underlying repo has changed VCS type
+// (e.g. converted from git to jujutsu or vice-versa). Must be called with
+// inst.mu held.
+func (inst *Instance) reconcileWorktreeType() {
+	if inst.WorktreePath == "" {
+		return
+	}
+	if !inst.lastVCSCheck.IsZero() && time.Since(inst.lastVCSCheck) < vcsCheckInterval {
+		return
+	}
+	inst.lastVCSCheck = time.Now()
+
+	var detected string
+	if _, err := jujutsu.NewJJBackend(inst.WorktreePath); err == nil {
+		detected = string(WorktreeTypeJujutsu)
+	} else if _, err := git.NewGitBackend(inst.WorktreePath); err == nil {
+		detected = string(WorktreeTypeGit)
+	} else {
+		// Neither VCS detected; leave WorktreeType as-is.
+		return
+	}
+
+	stored := inst.WorktreeType
+	if stored == "" {
+		stored = string(WorktreeTypeGit) // default
+	}
+	if detected != stored {
+		sessionLog.Info("worktree_type_reconciled",
+			slog.String("id", inst.ID),
+			slog.String("old", stored),
+			slog.String("new", detected),
+			slog.String("path", inst.WorktreePath),
+		)
+		inst.WorktreeType = detected
+	}
 }
 
 // IsWorktree returns true if this session is running in a git worktree
@@ -2807,6 +2856,10 @@ func hookFastPathFreshnessForTool(tool, hookStatus string) time.Duration {
 func (i *Instance) UpdateStatus() error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
+
+	// On the first status check after deserialization, verify the on-disk VCS
+	// type matches the stored WorktreeType and correct it if needed.
+	i.reconcileWorktreeType()
 
 	// Short grace period for tmux initialization (not Claude startup)
 	// Use lastStartTime for accuracy on restarts, fallback to CreatedAt

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/asheshgoplani/agent-deck/internal/docker"
 	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/jujutsu"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/send"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
@@ -74,7 +75,8 @@ const (
 type WorktreeType string
 
 const (
-	WorktreeTypeGit WorktreeType = "git"
+	WorktreeTypeGit     WorktreeType = "git"
+	WorktreeTypeJujutsu WorktreeType = "jujutsu"
 )
 
 // Instance represents a single agent/shell session
@@ -100,7 +102,7 @@ type Instance struct {
 	WorktreePath     string `json:"worktree_path,omitempty"`      // Path to worktree (if session is in worktree)
 	WorktreeRepoRoot string `json:"worktree_repo_root,omitempty"` // Original repo root
 	WorktreeBranch   string `json:"worktree_branch,omitempty"`    // Branch name in worktree
-	WorktreeType     string `json:"worktree_type,omitempty"`      // "git" or "" (auto-detect)
+	WorktreeType     string `json:"worktree_type,omitempty"`      // "git", "jujutsu", or "" (auto-detect)
 
 	// Multi-repo support
 	MultiRepoEnabled   bool                `json:"multi_repo_enabled,omitempty"`
@@ -473,6 +475,8 @@ func (inst *Instance) Backend() (vcs.Backend, error) {
 	switch inst.WorktreeType {
 	case string(WorktreeTypeGit), "":
 		return git.NewGitBackend(inst.WorktreePath)
+	case string(WorktreeTypeJujutsu):
+		return jujutsu.NewJJBackend(inst.WorktreePath)
 	}
 	return nil, fmt.Errorf("Unrecognized VCS type: %s", inst.WorktreeType)
 }

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -26,9 +26,11 @@ import (
 	"al.essio.dev/pkg/shellescape"
 
 	"github.com/asheshgoplani/agent-deck/internal/docker"
+	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/send"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 var (
@@ -69,6 +71,12 @@ const (
 	codexProbeMissingSentinel = "__AGENT_DECK_MISSING_TOOL__"
 )
 
+type WorktreeType string
+
+const (
+	WorktreeTypeGit WorktreeType = "git"
+)
+
 // Instance represents a single agent/shell session
 type Instance struct {
 	ID                 string `json:"id"`
@@ -92,6 +100,7 @@ type Instance struct {
 	WorktreePath     string `json:"worktree_path,omitempty"`      // Path to worktree (if session is in worktree)
 	WorktreeRepoRoot string `json:"worktree_repo_root,omitempty"` // Original repo root
 	WorktreeBranch   string `json:"worktree_branch,omitempty"`    // Branch name in worktree
+	WorktreeType     string `json:"worktree_type,omitempty"`      // "git" or "" (auto-detect)
 
 	// Multi-repo support
 	MultiRepoEnabled   bool                `json:"multi_repo_enabled,omitempty"`
@@ -457,6 +466,15 @@ func (inst *Instance) GetWaitingSince() time.Time {
 // IsSubSession returns true if this session has a parent
 func (inst *Instance) IsSubSession() bool {
 	return inst.ParentSessionID != ""
+}
+
+// Backend returns the backend for this instance
+func (inst *Instance) Backend() (vcs.Backend, error) {
+	switch inst.WorktreeType {
+	case string(WorktreeTypeGit), "":
+		return git.NewGitBackend(inst.WorktreePath)
+	}
+	return nil, fmt.Errorf("Unrecognized VCS type: %s", inst.WorktreeType)
 }
 
 // IsWorktree returns true if this session is running in a git worktree

--- a/internal/ui/branch_picker.go
+++ b/internal/ui/branch_picker.go
@@ -35,12 +35,12 @@ func branchCandidatesForPath(projectPath string) ([]string, error) {
 		return nil, errors.New("project path is empty")
 	}
 
-	repoRoot, err := git.GetWorktreeBaseRoot(projectPath)
+	backend, err := git.NewGitBackend(projectPath)
 	if err != nil {
 		return nil, errors.New("path is not a git repository")
 	}
 
-	branches, err := git.ListBranchCandidates(repoRoot)
+	branches, err := backend.ListBranchCandidates()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ui/forkdialog.go
+++ b/internal/ui/forkdialog.go
@@ -11,7 +11,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/jujutsu"
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 // ForkDialog handles the fork session dialog
@@ -31,6 +33,8 @@ type ForkDialog struct {
 	branchInput     textinput.Model
 	branchPicker    *BranchPickerDialog
 	isGitRepo       bool
+	isJJRepo        bool
+	vcsTypeCursor   int // 0 = Git, 1 = Jujutsu.
 	// Docker sandbox support
 	sandboxEnabled bool
 
@@ -114,6 +118,13 @@ func (d *ForkDialog) Show(originalName, projectPath, groupPath string, conductor
 	d.worktreeEnabled = false
 	d.sandboxEnabled = false
 	d.isGitRepo = git.IsGitRepo(projectPath)
+	d.isJJRepo = jujutsu.IsJJRepo(projectPath)
+	// Default VCS type: prefer jujutsu when both available.
+	if d.isJJRepo {
+		d.vcsTypeCursor = 1
+	} else {
+		d.vcsTypeCursor = 0
+	}
 
 	// Conductor parent selector
 	d.conductorSessions = conductors
@@ -166,12 +177,31 @@ func (d *ForkDialog) GetValues() (name, group string) {
 }
 
 // GetValuesWithWorktree returns all values including worktree settings
-func (d *ForkDialog) GetValuesWithWorktree() (name, group, branch string, worktreeEnabled bool) {
+func (d *ForkDialog) GetValuesWithWorktree() (name, group, branch string, worktreeEnabled bool, vcsType vcs.Type) {
 	name = d.nameInput.Value()
 	group = d.groupInput.Value()
 	branch = strings.TrimSpace(d.branchInput.Value())
 	worktreeEnabled = d.worktreeEnabled
+	vcsType = d.GetSelectedVCSType()
 	return
+}
+
+// GetSelectedVCSType returns the VCS type selected in the dialog.
+func (d *ForkDialog) GetSelectedVCSType() vcs.Type {
+	if d.vcsTypeCursor == 1 {
+		return vcs.TypeJujutsu
+	}
+	return vcs.TypeGit
+}
+
+// cycleVCSType moves the VCS type cursor by delta, skipping unavailable options.
+func (d *ForkDialog) cycleVCSType(delta int) {
+	next := (d.vcsTypeCursor + delta + 2) % 2
+	if next == 0 && d.isGitRepo {
+		d.vcsTypeCursor = 0
+	} else if next == 1 && d.isJJRepo {
+		d.vcsTypeCursor = 1
+	}
 }
 
 // GetOptions returns the current Claude options
@@ -369,8 +399,8 @@ func (d *ForkDialog) Update(msg tea.Msg) (*ForkDialog, tea.Cmd) {
 			}
 
 		case "w":
-			// Toggle worktree when on group field (only if git repo).
-			if d.focusIndex == 1 && d.isGitRepo {
+			// Toggle worktree when on group field (only if VCS repo).
+			if d.focusIndex == 1 && (d.isGitRepo || d.isJJRepo) {
 				d.ToggleWorktree()
 				if d.worktreeEnabled {
 					d.focusIndex = 2
@@ -547,9 +577,9 @@ func (d *ForkDialog) View() string {
 		conductorSection += "\n"
 	}
 
-	// Worktree checkbox and branch input (only for git repos)
+	// Worktree checkbox and branch input (only for VCS repos)
 	worktreeSection := ""
-	if d.isGitRepo {
+	if d.isGitRepo || d.isJJRepo {
 		checkboxStyle := lipgloss.NewStyle().Foreground(ColorText)
 		checkboxActiveStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
 
@@ -558,15 +588,59 @@ func (d *ForkDialog) View() string {
 			checkbox = "[x]"
 		}
 
+		// When only one VCS is available, show its type inline on the checkbox.
+		wtLabel := "Create in worktree"
 		if d.focusIndex == 1 {
-			worktreeSection += checkboxActiveStyle.Render(fmt.Sprintf("  %s Create in worktree (press w)", checkbox))
+			wtLabel = "Create in worktree (press w)"
+		}
+		if d.isGitRepo != d.isJJRepo {
+			vcsName := "Git"
+			if d.isJJRepo {
+				vcsName = "Jujutsu"
+			}
+			dimStyle := lipgloss.NewStyle().Foreground(ColorComment)
+			wtLabel += " " + dimStyle.Render("("+vcsName+")")
+		}
+
+		if d.focusIndex == 1 {
+			worktreeSection += checkboxActiveStyle.Render(fmt.Sprintf("  %s %s", checkbox, wtLabel))
 		} else {
-			worktreeSection += checkboxStyle.Render(fmt.Sprintf("  %s Create in worktree", checkbox))
+			worktreeSection += checkboxStyle.Render(fmt.Sprintf("  %s %s", checkbox, wtLabel))
 		}
 		worktreeSection += "\n"
 
-		// Branch input (only visible when worktree is enabled)
+		// VCS type picker (only when worktree is enabled and both VCS available)
 		if d.worktreeEnabled {
+			if d.isGitRepo && d.isJJRepo {
+				worktreeSection += "\n"
+				worktreeSection += labelStyle.Render("  VCS Type:") + "\n  "
+				vcsOptions := []struct {
+					label string
+					idx   int
+				}{
+					{"Git", 0},
+					{"Jujutsu", 1},
+				}
+				var vcsPills []string
+				for _, opt := range vcsOptions {
+					var pillStyle lipgloss.Style
+					if opt.idx == d.vcsTypeCursor {
+						pillStyle = lipgloss.NewStyle().
+							Foreground(ColorBg).
+							Background(ColorAccent).
+							Bold(true).
+							Padding(0, 2)
+					} else {
+						pillStyle = lipgloss.NewStyle().
+							Foreground(ColorTextDim).
+							Background(ColorSurface).
+							Padding(0, 2)
+					}
+					vcsPills = append(vcsPills, pillStyle.Render(opt.label))
+				}
+				worktreeSection += lipgloss.JoinHorizontal(lipgloss.Left, vcsPills...) + "\n"
+			}
+
 			worktreeSection += "\n"
 			if d.focusIndex == 2 {
 				worktreeSection += activeLabelStyle.Render("▶ Branch:")

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -31,12 +31,14 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/costs"
 	"github.com/asheshgoplani/agent-deck/internal/feedback"
 	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/jujutsu"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/asheshgoplani/agent-deck/internal/sysinfo"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 	"github.com/asheshgoplani/agent-deck/internal/update"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 	"github.com/asheshgoplani/agent-deck/internal/watcher"
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
@@ -7903,6 +7905,19 @@ func (h *Home) loadUIState() {
 	h.pendingCursorRestore = &state
 }
 
+// detectVCSBackend detects the VCS type for the given directory and creates the
+// appropriate backend. It tries jujutsu first (since jj repos also contain a git
+// store that would match git detection), then falls back to git.
+func detectVCSBackend(dir string) (vcs.Backend, error) {
+	if b, err := jujutsu.NewJJBackend(dir); err == nil {
+		return b, nil
+	}
+	if b, err := git.NewGitBackend(dir); err == nil {
+		return b, nil
+	}
+	return nil, fmt.Errorf("no supported VCS found in %s", dir)
+}
+
 // createSessionInGroupWithWorktreeAndOptions creates a new session with full options including YOLO mode, sandbox, and tool options.
 func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 	name, path, command, groupPath, worktreePath, worktreeRepoRoot, worktreeBranch string,
@@ -7926,9 +7941,9 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			// Single-repo worktree: create here. Multi-repo worktrees are handled below.
 			//
 			// Check for an existing worktree for this branch before creating a new one.
-			wtBackend, err := git.NewGitBackend(worktreeRepoRoot)
+			wtBackend, err := detectVCSBackend(worktreeRepoRoot)
 			if err != nil {
-				return sessionCreatedMsg{err: fmt.Errorf("failed to initialize git: %w", err)}
+				return sessionCreatedMsg{err: fmt.Errorf("failed to initialize VCS backend: %w", err)}
 			}
 			if existingPath, err := wtBackend.GetWorktreeForBranch(worktreeBranch); err == nil && existingPath != "" {
 				uiLog.Info("worktree_reuse", slog.String("branch", worktreeBranch), slog.String("path", existingPath))
@@ -7964,6 +7979,12 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			inst.WorktreePath = worktreePath
 			inst.WorktreeRepoRoot = worktreeRepoRoot
 			inst.WorktreeBranch = worktreeBranch
+
+			worktreeType := vcs.TypeGit
+			if jujutsu.IsJJRepo(worktreeRepoRoot) {
+				worktreeType = vcs.TypeJujutsu
+			}
+			inst.WorktreeType = string(worktreeType)
 		}
 
 		applyCreateSessionToolOverrides(inst, tool, geminiYoloMode)
@@ -8022,8 +8043,14 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 					// path too (#742). Without this, a .bare layout
 					// silently fell through to os.Symlink below,
 					// skipping worktree creation AND the setup hook.
-					if git.IsGitRepoOrBareProjectRoot(p) {
-						repoRoot, rootErr := git.GetWorktreeBaseRoot(p)
+					if jujutsu.IsJJRepo(p) || git.IsGitRepoOrBareProjectRoot(p) {
+						var repoRoot string
+						var rootErr error
+						if jujutsu.IsJJRepo(p) {
+							repoRoot, rootErr = jujutsu.GetWorktreeBaseRoot(p)
+						} else {
+							repoRoot, rootErr = git.GetWorktreeBaseRoot(p)
+						}
 						if rootErr != nil {
 							uiLog.Warn("multi_repo_worktree_skip", slog.String("path", p), slog.String("error", rootErr.Error()))
 							// Copy path as-is into the parent dir via symlink
@@ -8035,7 +8062,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 							}
 							continue
 						}
-						mrBackend, mrErr := git.NewGitBackend(repoRoot)
+						mrBackend, mrErr := detectVCSBackend(repoRoot)
 						if mrErr != nil {
 							uiLog.Warn("multi_repo_worktree_create_fail", slog.String("path", p), slog.String("error", mrErr.Error()))
 							_ = os.Symlink(p, wtPath)
@@ -8483,9 +8510,9 @@ func (h *Home) forkSessionCmdWithOptions(
 			// so the TUI remains responsive.
 			//
 			// Check for an existing worktree for this branch before creating a new one.
-			forkWtBackend, err := git.NewGitBackend(opts.WorktreeRepoRoot)
+			forkWtBackend, err := detectVCSBackend(opts.WorktreeRepoRoot)
 			if err != nil {
-				return sessionForkedMsg{err: fmt.Errorf("failed to initialize git: %w", err), sourceID: sourceID}
+				return sessionForkedMsg{err: fmt.Errorf("failed to initialize VCS backend: %w", err), sourceID: sourceID}
 			}
 			if existingPath, err := forkWtBackend.GetWorktreeForBranch(opts.WorktreeBranch); err == nil && existingPath != "" {
 				uiLog.Info("worktree_reuse", slog.String("branch", opts.WorktreeBranch), slog.String("path", existingPath))

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12242,14 +12242,32 @@ func (h *Home) renderPreviewPane(width, height int) string {
 		Background(ColorCyan).
 		Padding(0, 1).
 		Render(selected.GroupPath)
+	vcsBadgeText := string(vcs.TypeGit)
+	if selected.WorktreeType != "" {
+		vcsBadgeText = string(selected.WorktreeType)
+	}
+	vcsBadge := lipgloss.NewStyle().
+		Foreground(ColorBg).
+		Background(ColorOrange).
+		Padding(0, 1).
+		Render(vcsBadgeText)
 	b.WriteString(toolBadge)
 	b.WriteString(" ")
 	b.WriteString(groupBadge)
+	b.WriteString(" ")
+	b.WriteString(vcsBadge)
 	b.WriteString("\n")
 
 	// Worktree info section (for sessions running in git worktrees)
 	if selected.IsWorktree() {
-		wtHeader := renderSectionDivider("Worktree", width-4)
+		var sectionHeader string
+		switch selected.WorktreeType {
+		case string(vcs.TypeGit), "":
+			sectionHeader = "Git Worktree"
+		case string(vcs.TypeJujutsu):
+			sectionHeader = "Jujutsu Workspace"
+		}
+		wtHeader := renderSectionDivider(sectionHeader, width-4)
 		b.WriteString(wtHeader)
 		b.WriteString("\n")
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5171,25 +5171,31 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 		// Get values including worktree settings.
-		name, path, command, branchName, worktreeEnabled := h.newDialog.GetValuesWithWorktree()
+		name, path, command, branchName, worktreeEnabled, selectedVCSType := h.newDialog.GetValuesWithWorktree()
 		groupPath := h.newDialog.GetSelectedGroup()
 		claudeOpts := h.newDialog.GetClaudeOptions() // Get Claude options if applicable.
 
 		// Resolve worktree target if enabled; actual worktree creation runs in async command.
 		var worktreePath, worktreeRepoRoot string
 		if worktreeEnabled && branchName != "" {
-			wtBackend, err := git.NewGitBackend(path)
+			var wtBackend vcs.Backend
+			var err error
+			switch selectedVCSType {
+			case vcs.TypeJujutsu:
+				wtBackend, err = jujutsu.NewJJBackend(path)
+			default:
+				wtBackend, err = git.NewGitBackend(path)
+			}
 			if err != nil {
-				h.newDialog.SetError(fmt.Sprintf("Failed to initialize git: %v", err))
+				h.newDialog.SetError(fmt.Sprintf("Failed to initialize %s: %v", selectedVCSType, err))
 				return h, nil
 			}
 
 			// Generate worktree path using configured location/template
 			wtSettings := session.GetWorktreeSettings()
-			worktreePath = git.WorktreePath(git.WorktreePathOptions{
+			worktreePath = wtBackend.WorktreePath(vcs.WorktreePathOptions{
 				Branch:    branchName,
 				Location:  wtSettings.DefaultLocation,
-				RepoDir:   wtBackend.RepoDir(),
 				SessionID: git.GeneratePathID(),
 				Template:  wtSettings.Template(),
 			})
@@ -7625,7 +7631,7 @@ func (h *Home) handleForkDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 		// Get fork parameters from dialog including worktree settings
-		title, groupPath, branchName, worktreeEnabled := h.forkDialog.GetValuesWithWorktree()
+		title, groupPath, branchName, worktreeEnabled, selectedVCSType := h.forkDialog.GetValuesWithWorktree()
 		opts := h.forkDialog.GetOptions()
 		h.clearError() // Clear any previous error
 
@@ -7637,17 +7643,23 @@ func (h *Home) handleForkDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 				// Resolve worktree target if enabled; actual creation runs in async command.
 				if worktreeEnabled && branchName != "" {
-					forkBackend, forkErr := git.NewGitBackend(source.ProjectPath)
+					var forkBackend vcs.Backend
+					var forkErr error
+					switch selectedVCSType {
+					case vcs.TypeJujutsu:
+						forkBackend, forkErr = jujutsu.NewJJBackend(source.ProjectPath)
+					default:
+						forkBackend, forkErr = git.NewGitBackend(source.ProjectPath)
+					}
 					if forkErr != nil {
-						h.forkDialog.SetError(fmt.Sprintf("Failed to initialize git: %v", forkErr))
+						h.forkDialog.SetError(fmt.Sprintf("Failed to initialize %s: %v", selectedVCSType, forkErr))
 						return h, nil
 					}
 
 					wtSettings := session.GetWorktreeSettings()
-					worktreePath := git.WorktreePath(git.WorktreePathOptions{
+					worktreePath := forkBackend.WorktreePath(vcs.WorktreePathOptions{
 						Branch:    branchName,
 						Location:  wtSettings.DefaultLocation,
-						RepoDir:   forkBackend.RepoDir(),
 						SessionID: git.GeneratePathID(),
 						Template:  wtSettings.Template(),
 					})

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5176,19 +5176,9 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Resolve worktree target if enabled; actual worktree creation runs in async command.
 		var worktreePath, worktreeRepoRoot string
 		if worktreeEnabled && branchName != "" {
-			// Validate path is a git repo OR a bare-repo project root (#742 /
-			// #715): IsGitRepoOrBareProjectRoot accepts a directory that
-			// contains a nested .bare/ even though the directory itself has
-			// no .git. Downstream GetWorktreeBaseRoot + CreateWorktreeWithSetup
-			// handle both layouts transparently.
-			if !git.IsGitRepoOrBareProjectRoot(path) {
-				h.newDialog.SetError("Path is not a git repository")
-				return h, nil
-			}
-
-			repoRoot, err := git.GetWorktreeBaseRoot(path)
+			wtBackend, err := git.NewGitBackend(path)
 			if err != nil {
-				h.newDialog.SetError(fmt.Sprintf("Failed to get repo root: %v", err))
+				h.newDialog.SetError(fmt.Sprintf("Failed to initialize git: %v", err))
 				return h, nil
 			}
 
@@ -5197,13 +5187,13 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			worktreePath = git.WorktreePath(git.WorktreePathOptions{
 				Branch:    branchName,
 				Location:  wtSettings.DefaultLocation,
-				RepoDir:   repoRoot,
+				RepoDir:   wtBackend.RepoDir(),
 				SessionID: git.GeneratePathID(),
 				Template:  wtSettings.Template(),
 			})
 
 			// Store repo root for later use
-			worktreeRepoRoot = repoRoot
+			worktreeRepoRoot = wtBackend.RepoDir()
 		}
 
 		// Build generic toolOptionsJSON from tool-specific options
@@ -6131,8 +6121,10 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 				// Determine default target branch
 				defaultBranch := "main"
-				if detected, err := git.GetDefaultBranch(inst.WorktreeRepoRoot); err == nil {
-					defaultBranch = detected
+				if wtb, bErr := inst.Backend(); bErr == nil {
+					if detected, dErr := wtb.GetDefaultBranch(); dErr == nil {
+						defaultBranch = detected
+					}
 				}
 				h.worktreeFinishDialog.SetSize(h.width, h.height)
 				h.worktreeFinishDialog.Show(inst.ID, inst.Title, inst.WorktreeBranch, inst.WorktreeRepoRoot, inst.WorktreePath, defaultBranch)
@@ -7643,15 +7635,9 @@ func (h *Home) handleForkDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 				// Resolve worktree target if enabled; actual creation runs in async command.
 				if worktreeEnabled && branchName != "" {
-					// Bare-repo project roots must pass — same contract as
-					// the new-session path (#742).
-					if !git.IsGitRepoOrBareProjectRoot(source.ProjectPath) {
-						h.forkDialog.SetError("Path is not a git repository")
-						return h, nil
-					}
-					repoRoot, err := git.GetWorktreeBaseRoot(source.ProjectPath)
-					if err != nil {
-						h.forkDialog.SetError(fmt.Sprintf("Failed to get repo root: %v", err))
+					forkBackend, forkErr := git.NewGitBackend(source.ProjectPath)
+					if forkErr != nil {
+						h.forkDialog.SetError(fmt.Sprintf("Failed to initialize git: %v", forkErr))
 						return h, nil
 					}
 
@@ -7659,7 +7645,7 @@ func (h *Home) handleForkDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					worktreePath := git.WorktreePath(git.WorktreePathOptions{
 						Branch:    branchName,
 						Location:  wtSettings.DefaultLocation,
-						RepoDir:   repoRoot,
+						RepoDir:   forkBackend.RepoDir(),
 						SessionID: git.GeneratePathID(),
 						Template:  wtSettings.Template(),
 					})
@@ -7669,7 +7655,7 @@ func (h *Home) handleForkDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 					opts.WorkDir = worktreePath
 					opts.WorktreePath = worktreePath
-					opts.WorktreeRepoRoot = repoRoot
+					opts.WorktreeRepoRoot = forkBackend.RepoDir()
 					opts.WorktreeBranch = branchName
 				}
 
@@ -7940,7 +7926,11 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			// Single-repo worktree: create here. Multi-repo worktrees are handled below.
 			//
 			// Check for an existing worktree for this branch before creating a new one.
-			if existingPath, err := git.GetWorktreeForBranch(worktreeRepoRoot, worktreeBranch); err == nil && existingPath != "" {
+			wtBackend, err := git.NewGitBackend(worktreeRepoRoot)
+			if err != nil {
+				return sessionCreatedMsg{err: fmt.Errorf("failed to initialize git: %w", err)}
+			}
+			if existingPath, err := wtBackend.GetWorktreeForBranch(worktreeBranch); err == nil && existingPath != "" {
 				uiLog.Info("worktree_reuse", slog.String("branch", worktreeBranch), slog.String("path", existingPath))
 				worktreePath = existingPath
 			} else {
@@ -7948,7 +7938,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create parent directory: %w", err), tempID: tempID}
 				}
 				var setupBuf bytes.Buffer
-				setupErr, err := git.CreateWorktreeWithSetup(worktreeRepoRoot, worktreePath, worktreeBranch, &setupBuf, &setupBuf, session.GetWorktreeSettings().SetupTimeout())
+				setupErr, err := git.CreateWorktreeWithSetup(wtBackend, worktreePath, worktreeBranch, &setupBuf, &setupBuf, session.GetWorktreeSettings().SetupTimeout())
 				if err != nil {
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create worktree: %w", err), tempID: tempID}
 				}
@@ -8045,7 +8035,18 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 							}
 							continue
 						}
-						if err := git.CreateWorktree(repoRoot, wtPath, worktreeBranch); err != nil {
+						mrBackend, mrErr := git.NewGitBackend(repoRoot)
+						if mrErr != nil {
+							uiLog.Warn("multi_repo_worktree_create_fail", slog.String("path", p), slog.String("error", mrErr.Error()))
+							_ = os.Symlink(p, wtPath)
+							if i == 0 {
+								newProjectPath = wtPath
+							} else {
+								newAdditionalPaths = append(newAdditionalPaths, wtPath)
+							}
+							continue
+						}
+						if err := mrBackend.CreateWorktree(wtPath, worktreeBranch); err != nil {
 							uiLog.Warn("multi_repo_worktree_create_fail", slog.String("path", p), slog.String("error", err.Error()))
 							_ = os.Symlink(p, wtPath)
 							if i == 0 {
@@ -8482,7 +8483,11 @@ func (h *Home) forkSessionCmdWithOptions(
 			// so the TUI remains responsive.
 			//
 			// Check for an existing worktree for this branch before creating a new one.
-			if existingPath, err := git.GetWorktreeForBranch(opts.WorktreeRepoRoot, opts.WorktreeBranch); err == nil && existingPath != "" {
+			forkWtBackend, err := git.NewGitBackend(opts.WorktreeRepoRoot)
+			if err != nil {
+				return sessionForkedMsg{err: fmt.Errorf("failed to initialize git: %w", err), sourceID: sourceID}
+			}
+			if existingPath, err := forkWtBackend.GetWorktreeForBranch(opts.WorktreeBranch); err == nil && existingPath != "" {
 				uiLog.Info("worktree_reuse", slog.String("branch", opts.WorktreeBranch), slog.String("path", existingPath))
 				opts.WorktreePath = existingPath
 			} else {
@@ -8490,7 +8495,7 @@ func (h *Home) forkSessionCmdWithOptions(
 					return sessionForkedMsg{err: fmt.Errorf("failed to create directory: %w", err), sourceID: sourceID}
 				}
 				var setupBuf bytes.Buffer
-				setupErr, err := git.CreateWorktreeWithSetup(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch, &setupBuf, &setupBuf, session.GetWorktreeSettings().SetupTimeout())
+				setupErr, err := git.CreateWorktreeWithSetup(forkWtBackend, opts.WorktreePath, opts.WorktreeBranch, &setupBuf, &setupBuf, session.GetWorktreeSettings().SetupTimeout())
 				if err != nil {
 					return sessionForkedMsg{err: fmt.Errorf("worktree creation failed: %w", err), sourceID: sourceID}
 				}
@@ -8598,18 +8603,19 @@ func (h *Home) deleteSession(inst *session.Instance) tea.Cmd {
 	id := inst.ID
 	isWorktree := inst.IsWorktree()
 	worktreePath := inst.WorktreePath
-	worktreeRepoRoot := inst.WorktreeRepoRoot
 	isMultiRepo := inst.IsMultiRepo()
 	multiRepoTempDir := inst.MultiRepoTempDir
 	multiRepoWorktrees := inst.MultiRepoWorktrees
 	return func() tea.Msg {
 		killErr := inst.Kill()
 		if isWorktree {
-			if err := git.RemoveWorktree(worktreeRepoRoot, worktreePath, true); err != nil {
-				uiLog.Warn("worktree_remove_err", slog.String("path", worktreePath), slog.String("err", err.Error()))
-			}
-			if err := git.PruneWorktrees(worktreeRepoRoot); err != nil {
-				uiLog.Warn("worktree_prune_err", slog.String("repo", worktreeRepoRoot), slog.String("err", err.Error()))
+			if delBackend, bErr := inst.Backend(); bErr == nil {
+				if err := delBackend.RemoveWorktree(worktreePath, true); err != nil {
+					uiLog.Warn("worktree_remove_err", slog.String("path", worktreePath), slog.String("err", err.Error()))
+				}
+				if err := delBackend.PruneWorktrees(); err != nil {
+					uiLog.Warn("worktree_prune_err", slog.String("path", worktreePath), slog.String("err", err.Error()))
+				}
 			}
 		}
 		if isMultiRepo {
@@ -8619,11 +8625,13 @@ func (h *Home) deleteSession(inst *session.Instance) tea.Cmd {
 			}
 			// Clean up per-repo worktrees
 			for _, wt := range multiRepoWorktrees {
-				if err := git.RemoveWorktree(wt.RepoRoot, wt.WorktreePath, true); err != nil {
-					uiLog.Warn("worktree_remove_err", slog.String("path", wt.WorktreePath), slog.String("err", err.Error()))
-				}
-				if err := git.PruneWorktrees(wt.RepoRoot); err != nil {
-					uiLog.Warn("worktree_prune_err", slog.String("repo", wt.RepoRoot), slog.String("err", err.Error()))
+				if wtCleanBackend, wtErr := git.NewGitBackend(wt.RepoRoot); wtErr == nil {
+					if err := wtCleanBackend.RemoveWorktree(wt.WorktreePath, true); err != nil {
+						uiLog.Warn("worktree_remove_err", slog.String("path", wt.WorktreePath), slog.String("err", err.Error()))
+					}
+					if err := wtCleanBackend.PruneWorktrees(); err != nil {
+						uiLog.Warn("worktree_prune_err", slog.String("repo", wt.RepoRoot), slog.String("err", err.Error()))
+					}
 				}
 			}
 		}
@@ -13783,6 +13791,14 @@ func (h *Home) finishWorktree(inst *session.Instance, sessionID, sessionTitle, b
 	return func() tea.Msg {
 		merged := false
 
+		finBackend, bErr := inst.Backend()
+		if bErr != nil {
+			return worktreeFinishResultMsg{
+				sessionID: sessionID, sessionTitle: sessionTitle,
+				err: fmt.Errorf("failed to initialize VCS: %v", bErr),
+			}
+		}
+
 		// Step 1: Merge (if requested)
 		if mergeEnabled {
 			// Checkout target branch in main repo
@@ -13796,7 +13812,7 @@ func (h *Home) finishWorktree(inst *session.Instance, sessionID, sessionTitle, b
 			}
 
 			// Merge the worktree branch
-			if err := git.MergeBranch(repoRoot, branchName); err != nil {
+			if err := finBackend.MergeBranch(branchName); err != nil {
 				// Abort the merge to leave things clean
 				abortCmd := exec.Command("git", "-C", repoRoot, "merge", "--abort")
 				_ = abortCmd.Run()
@@ -13810,14 +13826,14 @@ func (h *Home) finishWorktree(inst *session.Instance, sessionID, sessionTitle, b
 
 		// Step 2: Remove worktree
 		if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
-			_ = git.RemoveWorktree(repoRoot, worktreePath, false)
+			_ = finBackend.RemoveWorktree(worktreePath, false)
 		}
-		_ = git.PruneWorktrees(repoRoot)
+		_ = finBackend.PruneWorktrees()
 
 		// Step 3: Delete branch (if not keeping)
 		if !keepBranch {
 			// Use force delete if we merged (branch is fully merged), regular delete otherwise
-			_ = git.DeleteBranch(repoRoot, branchName, merged)
+			_ = finBackend.DeleteBranch(branchName, merged)
 		}
 
 		// Step 4: Kill tmux session

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -12,8 +12,10 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/jujutsu"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 // overlayDropdown paints `overlay` on top of `base` starting at the given
@@ -127,6 +129,7 @@ const (
 	focusPath                  // project path input (hidden when multi-repo enabled).
 	focusCommand               // tool/command picker.
 	focusWorktree              // worktree checkbox.
+	focusVCSType               // VCS type picker (git/jujutsu, conditional — only when worktree enabled).
 	focusSandbox               // sandbox checkbox.
 	focusConductor             // conducting parent dropdown (conditional — only when conductors exist).
 	focusMultiRepo             // multi-repo toggle (transforms path into list when enabled).
@@ -172,6 +175,12 @@ type NewDialog struct {
 	branchAutoSet   bool   // true if branch was auto-derived from session name.
 	branchPrefix    string // configured prefix for auto-generated branch names.
 	branchPicker    *BranchPickerDialog
+	// VCS type selector (only active when worktree is enabled).
+	vcsTypeCursor   int    // 0 = Git, 1 = Jujutsu.
+	vcsGitAvailable bool   // whether git is available for the current path.
+	vcsJJAvailable  bool   // whether jujutsu is available for the current path.
+	vcsDetected     bool   // whether detection has run for the current path.
+	vcsDetectedPath string // path that was last detected (to avoid re-detection).
 	// Docker sandbox support.
 	sandboxEnabled    bool
 	inheritedExpanded bool             // whether the inherited settings section is expanded.
@@ -205,6 +214,7 @@ type dialogSnapshot struct {
 	worktreeEnabled  bool
 	branch           string
 	branchAutoSet    bool
+	vcsTypeCursor    int
 	claudeOptions    *session.ClaudeOptions
 	geminiYolo       bool
 	codexYolo        bool
@@ -358,6 +368,11 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.multiRepoPaths = nil
 	d.multiRepoPathCursor = 0
 	d.multiRepoEditing = false
+	d.vcsDetected = false
+	d.vcsDetectedPath = ""
+	d.vcsGitAvailable = false
+	d.vcsJJAvailable = false
+	d.vcsTypeCursor = 0
 	// Reset sandbox from global config default.
 	d.sandboxEnabled = false
 	d.inheritedExpanded = false
@@ -507,6 +522,7 @@ func (d *NewDialog) saveSnapshot() *dialogSnapshot {
 		worktreeEnabled:  d.worktreeEnabled,
 		branch:           d.branchInput.Value(),
 		branchAutoSet:    d.branchAutoSet,
+		vcsTypeCursor:    d.vcsTypeCursor,
 		claudeOptions:    claudeOpts,
 		geminiYolo:       d.geminiOptions.GetYoloMode(),
 		codexYolo:        d.codexOptions.GetYoloMode(),
@@ -526,6 +542,7 @@ func (d *NewDialog) restoreSnapshot(s *dialogSnapshot) {
 	d.worktreeEnabled = s.worktreeEnabled
 	d.branchInput.SetValue(s.branch)
 	d.branchAutoSet = s.branchAutoSet
+	d.vcsTypeCursor = s.vcsTypeCursor
 	if s.claudeOptions != nil {
 		d.claudeOptions.SetFromOptions(s.claudeOptions)
 	}
@@ -601,6 +618,11 @@ func (d *NewDialog) previewRecentSession(rs *statedb.RecentSessionRow) {
 	d.worktreeEnabled = false
 	d.branchInput.SetValue("")
 	d.branchAutoSet = false
+	d.vcsDetected = false
+	d.vcsDetectedPath = ""
+	d.vcsGitAvailable = false
+	d.vcsJJAvailable = false
+	d.vcsTypeCursor = 0
 
 	// Reset multi-repo (ephemeral, never pre-filled)
 	d.multiRepoEnabled = false
@@ -676,13 +698,53 @@ func (d *NewDialog) GetValues() (name, path, command string) {
 }
 
 // ToggleWorktree toggles the worktree checkbox.
-// When enabling, auto-populates the branch name from the session name.
+// When enabling, auto-populates the branch name from the session name and detects VCS.
 func (d *NewDialog) ToggleWorktree() {
 	d.worktreeEnabled = !d.worktreeEnabled
 	if d.worktreeEnabled {
 		d.autoBranchFromName()
+		d.detectVCSForPath()
 	}
 	d.rebuildFocusTargets()
+}
+
+// detectVCSForPath detects which VCS backends are available for the current path
+// and sets the default VCS type cursor accordingly.
+func (d *NewDialog) detectVCSForPath() {
+	_, path, _ := d.GetValues()
+	if path == d.vcsDetectedPath && d.vcsDetected {
+		return // already detected for this path
+	}
+	d.vcsDetectedPath = path
+	d.vcsDetected = true
+	d.vcsGitAvailable = git.IsGitRepo(path)
+	d.vcsJJAvailable = jujutsu.IsJJRepo(path)
+
+	// Set default: prefer jujutsu when both are available.
+	if d.vcsJJAvailable {
+		d.vcsTypeCursor = 1 // Jujutsu
+	} else {
+		d.vcsTypeCursor = 0 // Git
+	}
+}
+
+// GetSelectedVCSType returns the VCS type selected in the dialog.
+func (d *NewDialog) GetSelectedVCSType() vcs.Type {
+	if d.vcsTypeCursor == 1 {
+		return vcs.TypeJujutsu
+	}
+	return vcs.TypeGit
+}
+
+// cycleVCSType moves the VCS type cursor by delta, skipping unavailable options.
+func (d *NewDialog) cycleVCSType(delta int) {
+	next := (d.vcsTypeCursor + delta + 2) % 2
+	// Only move if the target is available.
+	if next == 0 && d.vcsGitAvailable {
+		d.vcsTypeCursor = 0
+	} else if next == 1 && d.vcsJJAvailable {
+		d.vcsTypeCursor = 1
+	}
 }
 
 // autoBranchFromName sets the branch input to "<prefix><session-name>" if the
@@ -703,10 +765,11 @@ func (d *NewDialog) IsWorktreeEnabled() bool {
 }
 
 // GetValuesWithWorktree returns all values including worktree settings
-func (d *NewDialog) GetValuesWithWorktree() (name, path, command, branch string, worktreeEnabled bool) {
+func (d *NewDialog) GetValuesWithWorktree() (name, path, command, branch string, worktreeEnabled bool, vcsType vcs.Type) {
 	name, path, command = d.GetValues()
 	branch = strings.TrimSpace(d.branchInput.Value())
 	worktreeEnabled = d.worktreeEnabled
+	vcsType = d.GetSelectedVCSType()
 	return
 }
 
@@ -927,6 +990,9 @@ func (d *NewDialog) rebuildFocusTargets() {
 	if len(d.conductorSessions) > 0 {
 		targets = append(targets, focusConductor)
 	}
+	if d.worktreeEnabled && d.vcsGitAvailable && d.vcsJJAvailable {
+		targets = append(targets, focusVCSType)
+	}
 	if d.sandboxEnabled && len(d.inheritedSettings) > 0 {
 		targets = append(targets, focusInherited)
 	}
@@ -990,8 +1056,8 @@ func (d *NewDialog) updateFocus() {
 		if d.commandCursor == 0 { // shell.
 			d.commandInput.Focus()
 		}
-	case focusWorktree, focusSandbox, focusConductor, focusInherited:
-		// Checkbox/toggle rows and conductor dropdown — no text input to focus.
+	case focusWorktree, focusVCSType, focusSandbox, focusConductor, focusInherited:
+		// Checkbox/toggle/picker rows and conductor dropdown — no text input to focus.
 	case focusBranch:
 		d.branchInput.Focus()
 	case focusOptions:
@@ -1329,6 +1395,10 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.updateFocus()
 				return d, nil
 			}
+			if cur == focusVCSType {
+				d.cycleVCSType(-1)
+				return d, nil
+			}
 			if cur == focusOptions && d.toolOptions != nil {
 				return d, d.toolOptions.Update(msg)
 			}
@@ -1338,6 +1408,10 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.commandCursor = (d.commandCursor + 1) % len(d.presetCommands)
 				d.updateToolOptions()
 				d.updateFocus()
+				return d, nil
+			}
+			if cur == focusVCSType {
+				d.cycleVCSType(1)
 				return d, nil
 			}
 			if cur == focusOptions && d.toolOptions != nil {
@@ -1430,6 +1504,10 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 
 		case " ":
+			if cur == focusVCSType {
+				d.cycleVCSType(1)
+				return d, nil
+			}
 			if cur == focusWorktree {
 				d.ToggleWorktree()
 				d.rebuildFocusTargets()
@@ -1482,6 +1560,8 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			d.pathSuggestionCursor = 0
 			d.pathCycler.Reset()
 			d.filterPathSuggestions()
+			// Invalidate VCS detection so it re-runs when worktree is toggled.
+			d.vcsDetected = false
 		}
 	case focusCommand:
 		if d.commandCursor == 0 {
@@ -1786,11 +1866,59 @@ func (d *NewDialog) View() string {
 	}
 
 	// Worktree checkbox — individually focusable.
+	// Lazily detect VCS so the label can show the type even before toggling.
+	d.detectVCSForPath()
 	worktreeLabel := "Create in worktree"
 	if cur == focusCommand {
 		worktreeLabel = "Create in worktree (w)"
 	}
+	// When only one VCS is available, show its type inline on the checkbox.
+	if d.vcsDetected && (d.vcsGitAvailable != d.vcsJJAvailable) {
+		vcsName := "Git"
+		if d.vcsJJAvailable {
+			vcsName = "Jujutsu"
+		}
+		dimStyle := lipgloss.NewStyle().Foreground(ColorComment)
+		worktreeLabel += " " + dimStyle.Render("("+vcsName+")")
+	}
 	content.WriteString(renderCheckboxLine(worktreeLabel, d.worktreeEnabled, cur == focusWorktree))
+
+	// VCS type picker (only when worktree is enabled and both VCS are available).
+	if d.worktreeEnabled && d.vcsGitAvailable && d.vcsJJAvailable {
+		vcsActive := cur == focusVCSType
+		if vcsActive {
+			content.WriteString(activeLabelStyle.Render("▶ VCS Type:"))
+		} else {
+			content.WriteString(labelStyle.Render("  VCS Type:"))
+		}
+		content.WriteString("\n  ")
+		vcsOptions := []struct {
+			label string
+			idx   int
+		}{
+			{"Git", 0},
+			{"Jujutsu", 1},
+		}
+		var vcsPills []string
+		for _, opt := range vcsOptions {
+			var pillStyle lipgloss.Style
+			if opt.idx == d.vcsTypeCursor {
+				pillStyle = lipgloss.NewStyle().
+					Foreground(ColorBg).
+					Background(ColorAccent).
+					Bold(true).
+					Padding(0, 2)
+			} else {
+				pillStyle = lipgloss.NewStyle().
+					Foreground(ColorTextDim).
+					Background(ColorSurface).
+					Padding(0, 2)
+			}
+			vcsPills = append(vcsPills, pillStyle.Render(opt.label))
+		}
+		content.WriteString(lipgloss.JoinHorizontal(lipgloss.Left, vcsPills...))
+		content.WriteString("\n")
+	}
 
 	// Docker sandbox checkbox — individually focusable.
 	sandboxLabel := "Run in Docker sandbox"
@@ -1942,6 +2070,8 @@ func (d *NewDialog) View() string {
 		}
 	} else if cur == focusConductor {
 		helpText = "↑↓ select parent │ Tab next │ Enter create │ Esc cancel"
+	} else if cur == focusVCSType {
+		helpText = "←→ select │ Space toggle │ ↑↓ navigate │ Enter create │ Esc cancel"
 	} else if cur == focusWorktree || cur == focusSandbox {
 		helpText = "Space toggle │ ↑↓ navigate │ Enter create │ Esc cancel"
 	} else if cur == focusInherited {

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -477,7 +477,7 @@ func TestNewDialog_GetValuesWithWorktree(t *testing.T) {
 	dialog.nameInput.SetValue("test-session")
 	dialog.pathInput.SetValue("/tmp/project")
 
-	name, path, command, branch, enabled := dialog.GetValuesWithWorktree()
+	name, path, command, branch, enabled, _ := dialog.GetValuesWithWorktree()
 
 	if !enabled {
 		t.Error("worktreeEnabled should be true")
@@ -500,7 +500,7 @@ func TestNewDialog_GetValuesWithWorktree_Disabled(t *testing.T) {
 	dialog.worktreeEnabled = false
 	dialog.branchInput.SetValue("feature/test")
 
-	_, _, _, branch, enabled := dialog.GetValuesWithWorktree()
+	_, _, _, branch, enabled, _ := dialog.GetValuesWithWorktree()
 
 	if enabled {
 		t.Error("worktreeEnabled should be false")

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -21,7 +21,8 @@ type WorktreePathOptions struct {
 type Type string
 
 const (
-	TypeGit Type = "git"
+	TypeGit     Type = "git"
+	TypeJujutsu Type = "jujutsu"
 )
 
 // Backend abstracts version control operations scoped to a repository.

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -1,0 +1,48 @@
+// Package vcs defines a version control system abstraction layer.
+package vcs
+
+// Worktree represents a VCS worktree.
+type Worktree struct {
+	Path   string // Filesystem path to the worktree
+	Branch string // Branch name checked out in this worktree
+	Commit string // HEAD commit SHA
+	Bare   bool   // Whether this is the bare repository
+}
+
+// WorktreePathOptions configures worktree path generation for a Backend.
+// Unlike git.WorktreePathOptions, it omits RepoDir because the backend supplies it.
+type WorktreePathOptions struct {
+	Branch    string
+	Location  string
+	SessionID string
+	Template  string
+}
+
+type Type string
+
+const (
+	TypeGit Type = "git"
+)
+
+// Backend abstracts version control operations scoped to a repository.
+type Backend interface {
+	Type() Type
+
+	// RepoDir returns the root directory of the repository.
+	RepoDir() string
+
+	// Branch operations
+	BranchExists(branchName string) bool
+	GetCurrentBranch() (string, error)
+	GetDefaultBranch() (string, error)
+	DeleteBranch(branchName string, force bool) error
+	MergeBranch(branchName string) error
+
+	// Worktree operations
+	WorktreePath(opts WorktreePathOptions) string
+	CreateWorktree(worktreePath, branchName string) error
+	ListWorktrees() ([]Worktree, error)
+	RemoveWorktree(worktreePath string, force bool) error
+	GetWorktreeForBranch(branchName string) (string, error)
+	PruneWorktrees() error
+}


### PR DESCRIPTION
Adds support for Jujutsu repositories. Jujutsu (jj) is a git-compatible version control system. It has the concept of "workspaces" which are analogous to git worktrees.

Jujutsu repositories can be colocated with git repositories (the .jj directory is a sibiling of the .git directory it uses as its backing storage), so a directory may be both a Git repository and a jj repository. If so, prefer the jj repository.

- Add a vcs.Backend interface that is implemented by both git.GitBackend and jujutsu.JJBackend.
- When creating a worktree, prefer instead to create a Jujutsu workspace with jj workspace if in a jj repository. The user can select "git" instead if they'd prefer for some reason to create a git worktree even though the main repo is jj.
- Display in the preview window whether it is a Git Worktree or a Jujutsu Workspace, as a new tag next to the agent and group tags.

This is a reopening of #302. I've been using this for several weeks without noticing any egregious bugs.