### PR TITLE
fix(codex): gate `resume <sid>` on rollout-file existence (#756)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1011,12 +1011,50 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 		command = "codex"
 	}
 
+	// Issue #756: Gate `codex resume <sid>` on rollout-file existence.
+	// If Codex died before flushing its rollout JSONL (tmux crash, kill -9
+	// in the SessionStart→first-flush window), the captured session_id is
+	// permanently unresumable. Without this check the bridge appends
+	// `resume <stale-uuid>` on every restart and Codex exits immediately,
+	// flipping the session back to error in an infinite loop. Drop the
+	// stale ID, clear the .sid sidecar so the next hook tick rebinds
+	// cleanly, and spawn fresh.
+	if i.CodexSessionID != "" && !codexRolloutExists(i.CodexSessionID) {
+		sessionLog.Warn("codex_resume_stale_sid_dropped",
+			slog.String("instance_id", i.ID),
+			slog.String("title", i.Title),
+			slog.String("sid", i.CodexSessionID),
+			slog.String("codex_home", getCodexHomeDir()))
+		i.CodexSessionID = ""
+		i.CodexDetectedAt = time.Time{}
+		ClearHookSessionAnchor(i.ID)
+	}
+
 	if i.CodexSessionID != "" {
 		return envPrefix + fmt.Sprintf("%s%s resume %s",
 			command, yoloFlag, i.CodexSessionID)
 	}
 
 	return envPrefix + command + yoloFlag
+}
+
+// codexRolloutExists reports whether Codex has flushed a rollout JSONL for
+// the given session ID under $CODEX_HOME/sessions. Used by buildCodexCommand
+// to gate `codex resume <sid>` on a real on-disk rollout file (Issue #756).
+//
+// Codex layout: $CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+func codexRolloutExists(sessionID string) bool {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return false
+	}
+	pattern := filepath.Join(getCodexHomeDir(), "sessions", "*", "*", "*",
+		"rollout-*-"+sessionID+".jsonl")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return false
+	}
+	return len(matches) > 0
 }
 
 // detectOpenCodeSessionAsync detects the OpenCode session ID after startup

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1425,9 +1425,145 @@ func TestBuildCodexCommand_CustomWrapperPreservesToolIdentity(t *testing.T) {
 	}
 
 	inst.CodexSessionID = "019d1af6-c425-7791-8fd1-38c0fc43062c"
+	// Issue #756: buildCodexCommand now gates `resume` on rollout existence.
+	// Plant a rollout file under HOME/.codex so the resume branch is exercised.
+	writeFakeCodexRollout(t, filepath.Join(tmpDir, ".codex"), inst.CodexSessionID)
 	cmd = inst.buildCodexCommand(inst.Command)
 	if !strings.Contains(cmd, "codex-wrapper resume 019d1af6-c425-7791-8fd1-38c0fc43062c") {
 		t.Fatalf("buildCodexCommand should resume through the custom wrapper, got %q", cmd)
+	}
+}
+
+// writeFakeCodexRollout creates an empty rollout JSONL under
+// codexHome/sessions/YYYY/MM/DD/ matching the layout buildCodexCommand
+// globs against (Issue #756).
+func writeFakeCodexRollout(t *testing.T, codexHome, sessionID string) string {
+	t.Helper()
+	dir := filepath.Join(codexHome, "sessions", "2026", "04", "24")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, "rollout-2026-04-24T17-00-00-"+sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write rollout: %v", err)
+	}
+	return path
+}
+
+// TestBuildCodexCommand_DropsResumeWhenRolloutMissing verifies that a stale
+// CodexSessionID with no on-disk rollout (the death-loop signature from
+// Issue #756) gets dropped: the emitted command starts a fresh codex run
+// instead of `codex resume <stale-uuid>`, and the in-memory + .sid state
+// is cleared so the next save persists the cleanup.
+func TestBuildCodexCommand_DropsResumeWhenRolloutMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+	originalCodexHome := os.Getenv("CODEX_HOME")
+	os.Unsetenv("CODEX_HOME")
+	defer func() {
+		if originalCodexHome != "" {
+			_ = os.Setenv("CODEX_HOME", originalCodexHome)
+		}
+	}()
+	ClearUserConfigCache()
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".agent-deck", "hooks"), 0o700); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+
+	inst := NewInstanceWithTool("stale", "/tmp/stale", "codex")
+	staleID := "deadbeef-1111-2222-3333-444455556666"
+	inst.CodexSessionID = staleID
+	inst.CodexDetectedAt = time.Now()
+	WriteHookSessionAnchor(inst.ID, staleID)
+
+	// Sessions dir exists but no rollout matches staleID — the death-loop signature.
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".codex", "sessions", "2026", "04", "24"), 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+
+	cmd := inst.buildCodexCommand(inst.Command)
+	if strings.Contains(cmd, "resume "+staleID) {
+		t.Fatalf("expected resume to be dropped for stale sid, got %q", cmd)
+	}
+	if strings.Contains(cmd, " resume ") {
+		t.Fatalf("expected no resume token at all, got %q", cmd)
+	}
+	if inst.CodexSessionID != "" {
+		t.Fatalf("CodexSessionID should be cleared after stale-sid drop, got %q", inst.CodexSessionID)
+	}
+	if !inst.CodexDetectedAt.IsZero() {
+		t.Fatalf("CodexDetectedAt should be zeroed after stale-sid drop, got %v", inst.CodexDetectedAt)
+	}
+	if got := ReadHookSessionAnchor(inst.ID); got != "" {
+		t.Fatalf(".sid anchor should be cleared after stale-sid drop, got %q", got)
+	}
+}
+
+// TestBuildCodexCommand_KeepsResumeWhenRolloutExists is the happy-path
+// regression guard for Issue #756: a CodexSessionID with a real on-disk
+// rollout must still emit `codex resume <uuid>`.
+func TestBuildCodexCommand_KeepsResumeWhenRolloutExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+	originalCodexHome := os.Getenv("CODEX_HOME")
+	os.Unsetenv("CODEX_HOME")
+	defer func() {
+		if originalCodexHome != "" {
+			_ = os.Setenv("CODEX_HOME", originalCodexHome)
+		}
+	}()
+	ClearUserConfigCache()
+
+	inst := NewInstanceWithTool("live", "/tmp/live", "codex")
+	liveID := "01234567-89ab-cdef-0123-456789abcdef"
+	inst.CodexSessionID = liveID
+	writeFakeCodexRollout(t, filepath.Join(tmpDir, ".codex"), liveID)
+
+	cmd := inst.buildCodexCommand(inst.Command)
+	if !strings.Contains(cmd, "resume "+liveID) {
+		t.Fatalf("expected resume %s in command, got %q", liveID, cmd)
+	}
+	if inst.CodexSessionID != liveID {
+		t.Fatalf("CodexSessionID should be preserved when rollout exists, got %q", inst.CodexSessionID)
+	}
+}
+
+// TestBuildCodexCommand_RespectsCodexHomeForRolloutCheck verifies the
+// rollout glob honors $CODEX_HOME (Issue #756). Primary execs run with
+// CODEX_HOME=~/.codex-acct1; the gate must look there, not at ~/.codex.
+func TestBuildCodexCommand_RespectsCodexHomeForRolloutCheck(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+	codexHome := filepath.Join(tmpDir, ".codex-acct1")
+	originalCodexHome := os.Getenv("CODEX_HOME")
+	os.Setenv("CODEX_HOME", codexHome)
+	defer func() {
+		if originalCodexHome != "" {
+			_ = os.Setenv("CODEX_HOME", originalCodexHome)
+		} else {
+			_ = os.Unsetenv("CODEX_HOME")
+		}
+	}()
+	ClearUserConfigCache()
+
+	inst := NewInstanceWithTool("acct1", "/tmp/acct1", "codex")
+	id := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	inst.CodexSessionID = id
+
+	// Plant the rollout under ~/.codex-acct1, NOT ~/.codex. With the gate
+	// reading CODEX_HOME via getCodexHomeDir(), this must resume.
+	writeFakeCodexRollout(t, codexHome, id)
+
+	cmd := inst.buildCodexCommand(inst.Command)
+	if !strings.Contains(cmd, "resume "+id) {
+		t.Fatalf("expected resume under CODEX_HOME=%s, got %q", codexHome, cmd)
 	}
 }
 


### PR DESCRIPTION
Closes #756.

## Summary

When a Codex process dies before its session rollout JSONL is flushed (observed real-world cause: tmux 3.4 server segfault, but any `kill -9` in the SessionStart→first-flush window does it), the captured `session_id` becomes permanently unresumable. agent-deck's spawn path keeps appending `codex resume <stale-uuid>` on every restart, Codex exits immediately, and the session flips back to `error` in an infinite loop until both `instances.tool_data.codex_session_id` and `~/.agent-deck/hooks/<id>.sid` are wiped by hand. In the wild this stranded 5 of 54 sessions after a single tmux 3.4 segfault.

## What changed

`buildCodexCommand` (`internal/session/instance.go`) now globs `$CODEX_HOME/sessions/*/*/*/rollout-*-<sid>.jsonl` before adding the `resume` argv. When no rollout matches:
- log `codex_resume_stale_sid_dropped` with `instance_id`, `title`, `sid`, `codex_home`
- clear `i.CodexSessionID` and `i.CodexDetectedAt` (so the next save persists the cleanup to `tool_data`)
- clear the `.sid` sidecar via the existing `ClearHookSessionAnchor` helper

The next spawn starts fresh; the loop self-heals on the first restart instead of needing operator surgery.

The rollout layout, regex, and `CODEX_HOME` resolution were all already in this codebase (`codexSessionIDPathPatternRE`, `getCodexHomeDir`); this patch just consults them at the spawn-decision point.

## Tests

`internal/session/instance_test.go`:
- `TestBuildCodexCommand_DropsResumeWhenRolloutMissing` — the bug scenario: sessions dir present, no matching rollout → resume dropped, in-memory state cleared, .sid cleared.
- `TestBuildCodexCommand_KeepsResumeWhenRolloutExists` — happy-path regression guard.
- `TestBuildCodexCommand_RespectsCodexHomeForRolloutCheck` — glob honors `CODEX_HOME` (relevant for multi-account setups using `CODEX_HOME=~/.codex-acctN` wrappers).
- Existing `TestBuildCodexCommand_CustomWrapperPreservesToolIdentity` updated to plant a rollout file before asserting the resume branch (the assertion didn't change, just made consistent with the new gate).

## Verification

- `go test ./internal/session/...` ✅
- `go test ./cmd/agent-deck/...` ✅
- `go vet ./...` ✅

(Local fleet smoke test against a live Codex instance was deliberately skipped to avoid touching production sessions; the unit tests cover the rollout-existence gate deterministically.)

## Out of scope

Reacting to a Codex `SessionEnd:dead` notify event by clearing `tool_data` proactively. `mapCodexNotifyToStatus` does not currently recognize a terminal event for Codex (no `SessionEnd`/`session.closed` mapping), so there's no signal to act on from the notify side. The spawn-side gate is self-sufficient — every restart is now idempotent against stale state, regardless of how it got stale. If a future Codex notify version starts emitting a terminal event, hooking that into `ClearHookSessionAnchor` + a DB update would be a small follow-up.

## Operator workaround (for users on older versions)

```sh
ID=<instance_id>
TITLE=<title>
rm -f ~/.agent-deck/hooks/${ID}.sid ~/.agent-deck/hooks/${ID}.json
sqlite3 ~/.agent-deck/profiles/default/state.db \
    "UPDATE instances SET tool_data='{}' WHERE id='${ID}'"
agent-deck -p default session restart "${TITLE}"
```