### PR TITLE
fix(scratch): gate worker-scratch CLAUDE_CONFIG_DIR on Telegram conductor presence (#759)

### DIFF
--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -37,6 +37,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // telegramPluginID is the Claude Code plugin id we force-disable in
@@ -44,13 +45,42 @@ import (
 // `telegramChannelPrefix` consumers in env.go / telegram_validator.go.
 const telegramPluginID = "telegram@claude-plugins-official"
 
+// hostHasTelegramConductor returns true when the user has actually
+// configured a Telegram conductor (a bot token is present in the
+// active user config). Issue #759: the worker-scratch indirection
+// (#732) is only load-bearing on hosts where a real Telegram bot
+// poller exists for a worker to race. On every other host the
+// indirection is pure collateral damage — it breaks per-group
+// config_dir account isolation because macOS Claude Code keys
+// OAuth credentials by the literal CLAUDE_CONFIG_DIR path, and the
+// scratch path is opaque (not the path Claude logged in under).
+//
+// Exposed as a package var so tests can override it without faking
+// the entire user-config cache.
+var hostHasTelegramConductor = func() bool {
+	cfg, err := LoadUserConfig()
+	if err != nil || cfg == nil {
+		return false
+	}
+	return strings.TrimSpace(cfg.Conductor.Telegram.Token) != ""
+}
+
 // NeedsWorkerScratchConfigDir returns true when a scratch CLAUDE_CONFIG_DIR
 // should be prepared for this instance at spawn time. The predicate
 // mirrors `telegramStateDirStripExpr` so both the env strip (TSD) and
 // the plugin disable (this scratch dir) fire for exactly the same
 // sessions — layered defense against the conductor-poller storm.
+//
+// Additionally gated on `hostHasTelegramConductor` per issue #759: the
+// scratch indirection only fires when a Telegram conductor is actually
+// configured on the host. Without that gate, every per-group
+// config_dir worker on every host gets its CLAUDE_CONFIG_DIR rewritten
+// to an opaque scratch path, breaking macOS account isolation.
 func (i *Instance) NeedsWorkerScratchConfigDir() bool {
-	return telegramStateDirStripExpr(i) != ""
+	if telegramStateDirStripExpr(i) == "" {
+		return false
+	}
+	return hostHasTelegramConductor()
 }
 
 // WorkerScratchDirRoot returns the path that holds every worker's

--- a/internal/session/worker_scratch_telegram_gate_test.go
+++ b/internal/session/worker_scratch_telegram_gate_test.go
@@ -1,0 +1,170 @@
+// Package session — gate tests for worker-scratch CLAUDE_CONFIG_DIR
+// (issue #759).
+//
+// v1.7.68 (PR #732, internal/session/worker_scratch.go) adds an
+// ephemeral CLAUDE_CONFIG_DIR for every non-conductor claude worker
+// to disable the Telegram plugin per-spawn. The fix is only
+// load-bearing on hosts that actually run a Telegram conductor — on
+// every other host, the indirection breaks per-group `config_dir`
+// account isolation: macOS Claude Code keys OAuth credentials by the
+// literal CLAUDE_CONFIG_DIR path, and the scratch path is opaque, so
+// Claude falls back to the default `~/.claude` account.
+//
+// These tests pin the predicate behaviour:
+//   - No Telegram conductor configured ⇒ NeedsWorkerScratchConfigDir == false
+//   - Telegram conductor configured     ⇒ NeedsWorkerScratchConfigDir == true
+//   - Conductor / channel-owner / non-claude short-circuits still win
+//     even when a Telegram conductor IS configured.
+
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeUserConfigForTest writes ~/.agent-deck/config.toml inside the
+// supplied home dir and clears the user-config cache so the next
+// LoadUserConfig() call sees the fresh contents. The HOME env var
+// MUST already point at home for the helper to take effect.
+func writeUserConfigForTest(t *testing.T, home, body string) {
+	t.Helper()
+	dir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir .agent-deck: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+}
+
+// TestNeedsWorkerScratchConfigDir_NoTelegramConductor_ReturnsFalse
+// pins the gate: a non-conductor claude worker on a host with no
+// Telegram conductor configured MUST NOT receive a scratch dir.
+// Without this gate the indirection silently rewrites
+// CLAUDE_CONFIG_DIR for every worker, defeating per-group config_dir
+// account isolation (issue #759).
+func TestNeedsWorkerScratchConfigDir_NoTelegramConductor_ReturnsFalse(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Per-group dir present, but [conductor.telegram] token is empty —
+	// the v1.7.68 indirection has nothing to protect against here.
+	writeUserConfigForTest(t, home, `
+[groups."personal".claude]
+config_dir = "~/.claude-personal"
+`)
+
+	inst := &Instance{
+		ID:    "00000000-0000-0000-0000-0000000000a1",
+		Tool:  "claude",
+		Title: "my-worker",
+	}
+
+	if got := inst.NeedsWorkerScratchConfigDir(); got {
+		t.Errorf("no Telegram conductor configured — NeedsWorkerScratchConfigDir must return false; got true")
+	}
+}
+
+// TestNeedsWorkerScratchConfigDir_WithTelegramConductor_ReturnsTrue
+// pins the inverse: when a Telegram conductor IS configured, the
+// predicate keeps firing for non-conductor claude workers — the
+// #732 fix continues to protect the conductor's bot token from a
+// duplicate poller.
+func TestNeedsWorkerScratchConfigDir_WithTelegramConductor_ReturnsTrue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeUserConfigForTest(t, home, `
+[conductor.telegram]
+token = "fake-bot-token"
+user_id = 1
+`)
+
+	inst := &Instance{
+		ID:    "00000000-0000-0000-0000-0000000000a2",
+		Tool:  "claude",
+		Title: "my-worker",
+	}
+
+	if got := inst.NeedsWorkerScratchConfigDir(); !got {
+		t.Errorf("Telegram conductor configured — NeedsWorkerScratchConfigDir must return true; got false")
+	}
+}
+
+// TestNeedsWorkerScratchConfigDir_ConductorShortCircuits_EvenWithTelegramToken
+// guards a regression vector: even when a Telegram conductor IS
+// configured (so the gate is OPEN), the conductor session itself
+// must NEVER be scratched — it is the legitimate bot owner.
+func TestNeedsWorkerScratchConfigDir_ConductorShortCircuits_EvenWithTelegramToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeUserConfigForTest(t, home, `
+[conductor.telegram]
+token = "fake-bot-token"
+user_id = 1
+`)
+
+	inst := &Instance{
+		ID:    "00000000-0000-0000-0000-0000000000a3",
+		Tool:  "claude",
+		Title: "conductor-personal",
+	}
+
+	if got := inst.NeedsWorkerScratchConfigDir(); got {
+		t.Errorf("conductor session must keep ambient profile even when telegram conductor configured; got scratch=true")
+	}
+}
+
+// TestPerGroupConfig_NoScratchWhenNoTelegramConductor is the
+// integration-level mirror of #759: end-to-end on a host with
+// per-group config_dir and no Telegram conductor, the spawn command
+// builder must export the per-group dir verbatim, not a scratch
+// path. Locked under the TestPerGroupConfig_* mandate in CLAUDE.md.
+func TestPerGroupConfig_NoScratchWhenNoTelegramConductor(t *testing.T) {
+	home := t.TempDir()
+	origHome := os.Getenv("HOME")
+	origClaudeDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origClaudeDir != "" {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", origClaudeDir)
+		} else {
+			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+		}
+		ClearUserConfigCache()
+	})
+	_ = os.Setenv("HOME", home)
+	_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+
+	writeUserConfigForTest(t, home, `
+[groups."personal".claude]
+config_dir = "~/.claude-personal"
+`)
+
+	// Per-group dir must exist so the source-profile mirror has a
+	// base — matches real-world setups where the user has actually
+	// logged in to a Claude account under this dir.
+	if err := os.MkdirAll(filepath.Join(home, ".claude-personal"), 0o755); err != nil {
+		t.Fatalf("mkdir personal: %v", err)
+	}
+
+	inst := NewInstanceWithGroupAndTool("worker", "/tmp/p", "personal", "claude")
+	inst.prepareWorkerScratchConfigDirForSpawn()
+
+	if inst.WorkerScratchConfigDir != "" {
+		t.Errorf("no telegram conductor configured — scratch dir must not be created; got %q", inst.WorkerScratchConfigDir)
+	}
+
+	cmd := inst.buildClaudeCommand("claude")
+	wantDir := filepath.Join(home, ".claude-personal")
+	wantInline := "CLAUDE_CONFIG_DIR=" + wantDir
+	if !strings.Contains(cmd, wantInline) {
+		t.Errorf("spawn must export per-group config_dir verbatim; want contains %q\n  got: %s", wantInline, cmd)
+	}
+	if strings.Contains(cmd, "worker-scratch") {
+		t.Errorf("spawn must not reference worker-scratch path when no telegram conductor; got: %s", cmd)
+	}
+}

--- a/internal/session/worker_scratch_test.go
+++ b/internal/session/worker_scratch_test.go
@@ -29,6 +29,19 @@ import (
 	"testing"
 )
 
+// withTelegramConductorPresent forces the host-conductor gate to
+// return true for the duration of the test. Issue #759 narrowed
+// `NeedsWorkerScratchConfigDir` to additionally require an active
+// Telegram conductor; the existing scratch-dir invariants below
+// pre-date that gate and exercise the dir's content/path properties
+// in isolation, so they short-circuit the gate via this seam.
+func withTelegramConductorPresent(t *testing.T) {
+	t.Helper()
+	orig := hostHasTelegramConductor
+	hostHasTelegramConductor = func() bool { return true }
+	t.Cleanup(func() { hostHasTelegramConductor = orig })
+}
+
 // A non-conductor claude session (title does not start with "conductor-",
 // no telegram channel) MUST receive a scratch CLAUDE_CONFIG_DIR that:
 //   - is a distinct directory from the source profile
@@ -37,6 +50,7 @@ import (
 //   - preserves other enabled plugins
 //   - makes the rest of the profile reachable (via symlink)
 func TestEnsureWorkerScratchConfigDir_DisablesTelegramPlugin(t *testing.T) {
+	withTelegramConductorPresent(t)
 	source := t.TempDir()
 	srcSettings := `{"enabledPlugins":{"telegram@claude-plugins-official":true,"superpowers@claude-plugins-official":true}}`
 	if err := os.WriteFile(filepath.Join(source, "settings.json"), []byte(srcSettings), 0o644); err != nil {
@@ -107,6 +121,7 @@ func TestEnsureWorkerScratchConfigDir_DisablesTelegramPlugin(t *testing.T) {
 // scratch dir — the conductor is the legitimate telegram poller owner.
 // Returning "" signals the caller to use the ambient profile.
 func TestEnsureWorkerScratchConfigDir_ConductorKeepsAmbientProfile(t *testing.T) {
+	withTelegramConductorPresent(t)
 	source := t.TempDir()
 	_ = os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{"telegram@claude-plugins-official":true}}`), 0o644)
 
@@ -125,6 +140,7 @@ func TestEnsureWorkerScratchConfigDir_ConductorKeepsAmbientProfile(t *testing.T)
 // explicit, opted-in telegram bot owner and MUST keep the ambient
 // profile — isolating it would break its own bot.
 func TestEnsureWorkerScratchConfigDir_ChannelOwnerKeepsAmbientProfile(t *testing.T) {
+	withTelegramConductorPresent(t)
 	source := t.TempDir()
 	_ = os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{"telegram@claude-plugins-official":true}}`), 0o644)
 
@@ -148,6 +164,7 @@ func TestEnsureWorkerScratchConfigDir_ChannelOwnerKeepsAmbientProfile(t *testing
 // scratch dir — TELEGRAM_STATE_DIR is a Claude Code plugin concept
 // and other tools have no interaction with it.
 func TestEnsureWorkerScratchConfigDir_NonClaudeToolSkipped(t *testing.T) {
+	withTelegramConductorPresent(t)
 	source := t.TempDir()
 	_ = os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{"telegram@claude-plugins-official":true}}`), 0o644)
 
@@ -166,6 +183,7 @@ func TestEnsureWorkerScratchConfigDir_NonClaudeToolSkipped(t *testing.T) {
 // have telegram flipped on behind its back by a concurrent conductor
 // setup. The scratch settings.json always pins it false.
 func TestEnsureWorkerScratchConfigDir_TelegramAbsentStillPinsDisabled(t *testing.T) {
+	withTelegramConductorPresent(t)
 	source := t.TempDir()
 	_ = os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{"superpowers@claude-plugins-official":true}}`), 0o644)
 
@@ -191,6 +209,7 @@ func TestEnsureWorkerScratchConfigDir_TelegramAbsentStillPinsDisabled(t *testing
 // load-bearing wire: without it, the plugin still loads the ambient
 // profile's settings.json and reads the conductor's bot token.
 func TestBuildClaudeCommand_UsesWorkerScratchConfigDir(t *testing.T) {
+	withTelegramConductorPresent(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	profile := filepath.Join(home, ".claude")


### PR DESCRIPTION
## Summary

- Fixes #759. The v1.7.68 worker-scratch indirection (#732) currently fires for every non-conductor claude worker. On hosts with no Telegram conductor it's pure collateral damage: macOS Claude Code keys OAuth credentials by the literal CLAUDE_CONFIG_DIR path, so rewriting the per-group `config_dir` to an opaque `~/.agent-deck/worker-scratch/<id>/` path silently breaks per-group account isolation — sessions fall back to the default `~/.claude` account.
- Narrows `NeedsWorkerScratchConfigDir` (`internal/session/worker_scratch.go:52`) to additionally require an active Telegram conductor (non-empty `[conductor.telegram] token` in the user config). Hosts without one exit the predicate early and the spawn command exports the per-group `config_dir` verbatim. Hosts with one keep the original #732 protection unchanged.
- The new gate is exposed as a `var hostHasTelegramConductor` seam so tests can pin both branches without faking the user-config cache.

## Root cause

`NeedsWorkerScratchConfigDir` previously delegated entirely to `telegramStateDirStripExpr` (`internal/session/env.go:363`), which returns non-empty for any non-conductor / non-channel-owner claude worker. It never checked whether the host actually had any Telegram setup at all. The 409-Conflict storm that motivated #732 only happens when a real Telegram bot poller exists for the worker to race; on a Telegram-free host the indirection costs us account isolation and gives us nothing.

Verified locally: with the fix, \`\$CLAUDE_CONFIG_DIR\` inside a \`--group personal\` session resolves to \`~/.claude-personal\` again instead of a \`worker-scratch\` path, and the right Claude account banner is back.

## Behavior matrix

| State | Pre-PR | This PR |
| --- | --- | --- |
| No Telegram conductor configured, claude worker | scratch dir created → CLAUDE_CONFIG_DIR rewritten | no scratch → per-group dir reaches the spawn shell |
| Telegram conductor configured, claude worker | scratch dir created (#732) | scratch dir created (#732, unchanged) |
| Telegram conductor configured, conductor session itself | no scratch (short-circuits) | no scratch (short-circuits, unchanged) |
| Telegram conductor configured, explicit \`plugin:telegram@...\` channel owner | no scratch (short-circuits) | no scratch (short-circuits, unchanged) |
| Non-claude tool (codex, gemini, copilot) | no scratch | no scratch |

## Tests

New (added to \`internal/session/worker_scratch_telegram_gate_test.go\`):

- \`TestNeedsWorkerScratchConfigDir_NoTelegramConductor_ReturnsFalse\` — predicate returns false on a host with no Telegram conductor, even for a non-conductor claude worker.
- \`TestNeedsWorkerScratchConfigDir_WithTelegramConductor_ReturnsTrue\` — predicate keeps firing when a Telegram conductor IS configured.
- \`TestNeedsWorkerScratchConfigDir_ConductorShortCircuits_EvenWithTelegramToken\` — conductor sessions still keep ambient profile when the gate is open.
- \`TestPerGroupConfig_NoScratchWhenNoTelegramConductor\` — integration: \`prepareWorkerScratchConfigDirForSpawn\` + \`buildClaudeCommand\` end-to-end. Spawn must export \`CLAUDE_CONFIG_DIR=<group-dir>\`, must not reference \`worker-scratch\`. Lands under the \`TestPerGroupConfig_*\` mandate per \`CLAUDE.md\`.

Existing scratch tests (\`TestEnsureWorkerScratchConfigDir_*\`, \`TestBuildClaudeCommand_UsesWorkerScratchConfigDir\`) gain a \`withTelegramConductorPresent(t)\` seam call at the top so they keep exercising scratch-dir invariants in isolation rather than silently passing through the new gate.

## Test plan

- [x] \`GOTOOLCHAIN=go1.24.0 go test ./internal/session/ -run \"WorkerScratch|TestNeedsWorkerScratchConfigDir|TestPerGroupConfig|TestEnsureWorkerScratchConfigDir|TestBuildClaudeCommand_UsesWorkerScratchConfigDir\" -race -count=1\` — green
- [x] \`GOTOOLCHAIN=go1.24.0 go vet ./internal/session/... ./cmd/agent-deck/...\` — clean
- [x] \`GOTOOLCHAIN=go1.24.0 go build ./...\` — clean
- [x] Stash the fix, re-run \`TestPerGroupConfig_NoScratchWhenNoTelegramConductor\` — RED with the original #759 symptom (\`CLAUDE_CONFIG_DIR=...worker-scratch/<id>\` instead of the per-group dir). Restoring the fix turns it GREEN. Confirms the gate test catches the regression vector.
- [x] End-to-end on macOS with two per-group \`config_dir\`s (\`~/.claude-personal\`, \`~/.claude-consensys\`), no Telegram conductor: per-group accounts resolve correctly inside the spawned Claude session.
- [ ] \`bash scripts/verify-session-persistence.sh\` — Linux+systemd only per \`CLAUDE.md\`; not run on the author's macOS host. Reviewer with a Linux runner welcome to gate.
- [ ] \`TestPersistence_*\` with \`-race\` — pre-existing macOS tmux socket path-length issue; same suite fails on bare \`main\` for the same environmental reason. Not a regression introduced by this PR.

## Notes for reviewers

- The seam is a package-level \`var\` so tests can override without faking \`LoadUserConfig\`. If you'd prefer dependency injection on \`Instance\` instead, happy to refactor.
- A second-best fix considered and rejected: symlink \`settings.json\` instead of copying it when telegram is already disabled in the source profile. Doesn't help — the OAuth-keying issue is the path itself, not the file content.
- The default-config path through \`LoadUserConfig()\` (no \`~/.agent-deck/config.toml\`) returns an empty \`Conductor.Telegram.Token\`, so first-launch users get the safer "no scratch" branch — matching their pre-1.7.68 experience.