### PR TITLE
fix(ui): preserve cursor in path field's soft-select render (#765)

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1618,10 +1618,18 @@ func (d *NewDialog) View() string {
 		content.WriteString("\n")
 		content.WriteString("  ")
 		if cur == focusPath && d.pathSoftSelected && d.pathInput.Value() != "" {
-			selectedStyle := lipgloss.NewStyle().
+			// Soft-select highlight: render the textinput's own View() (which
+			// includes Bubble Tea's blinking cursor) with TextStyle set to
+			// reverse colors. The previous static-string render dropped the
+			// cursor entirely, leaving users editing blind (#765). Saving and
+			// restoring the prior TextStyle keeps this branch's mutation local
+			// to the soft-select case.
+			savedTextStyle := d.pathInput.TextStyle
+			d.pathInput.TextStyle = lipgloss.NewStyle().
 				Background(ColorAccent).
 				Foreground(ColorBg)
-			content.WriteString(selectedStyle.Render(d.pathInput.Value()))
+			content.WriteString(d.pathInput.View())
+			d.pathInput.TextStyle = savedTextStyle
 		} else {
 			content.WriteString(d.pathInput.View())
 		}


### PR DESCRIPTION
## Summary

@xuan-w reported (#765) that the New Session dialog's path field renders without a visible cursor when soft-selected, leaving users editing blind.

Root cause was in `internal/ui/newdialog.go` line 1620 — the soft-select branch replaced `d.pathInput.View()` with a static lipgloss-styled render of `d.pathInput.Value()`. Bubble Tea's textinput cursor logic lives inside `View()`, so the static replacement dropped the cursor indicator entirely.

## Fix

Keep using `d.pathInput.View()` (preserves Bubble Tea's cursor blinking) and apply the reverse-color highlight via the textinput's own `TextStyle` field. Save and restore `TextStyle` inline so the mutation is scope-local and other render paths are byte-for-byte unaffected.

## Test plan

- `go build ./...` clean
- `go test ./internal/ui/ -race -count=1` GREEN (30s) — existing UI tests don't snapshot the path field's exact bytes; behavioural nav/edit assertions are unchanged
- Pre-commit hooks (fmt + vet) pass

Manual verification deferred — the issue is purely visual and the existing test surface doesn't have a render-snapshot harness for textinput. Reporter is invited to retest on next release.

Closes #765.