### PR TITLE
feat(tmux): native iTerm2 badge sync on attach + rename

### DIFF
--- a/cmd/agent-deck/hook_name_sync.go
+++ b/cmd/agent-deck/hook_name_sync.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
 
 // claudeSessionMetaFile is the subset of ~/.claude/sessions/<PID>.json that
@@ -121,6 +122,13 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 		groupTree := session.NewGroupTreeWithGroups(instances, groups)
 		_ = storage.SaveWithGroups(instances, groupTree)
 		_ = storage.Close()
+
+		// If the user is attached to this session in iTerm2, push the
+		// badge through tmux DCS passthrough — agent-deck's own attach
+		// emits only fire on attach/detach, not on mid-attach renames.
+		// Silent no-op outside iTerm2, when the feature is disabled,
+		// or when this hook subprocess has no controlling tty.
+		tmux.EmitITermBadgeViaTty(name, session.GetTerminalSettings().GetITermBadge())
 		return
 	}
 }

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -495,6 +495,7 @@ func NewInstance(title, projectPath string) *Instance {
 	tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
 	tmuxSess.SetMouse(GetTmuxSettings().GetMouse())
 	tmuxSess.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
+	tmuxSess.SetTerminalChromeEnabled(GetTerminalSettings().GetITermBadge())
 
 	return &Instance{
 		ID:             id,
@@ -526,6 +527,7 @@ func NewInstanceWithTool(title, projectPath, tool string) *Instance {
 	tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
 	tmuxSess.SetMouse(GetTmuxSettings().GetMouse())
 	tmuxSess.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
+	tmuxSess.SetTerminalChromeEnabled(GetTerminalSettings().GetITermBadge())
 
 	inst := &Instance{
 		ID:             id,
@@ -3549,6 +3551,7 @@ func (i *Instance) recreateTmuxSession() {
 	i.tmuxSession.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
 	i.tmuxSession.SetMouse(GetTmuxSettings().GetMouse())
 	i.tmuxSession.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
+	i.tmuxSession.SetTerminalChromeEnabled(GetTerminalSettings().GetITermBadge())
 }
 
 func (i *Instance) prepareRestartMCPConfig() {

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -807,6 +807,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			tmuxSess.SetInjectStatusLine(GetTmuxSettings().GetInjectStatusLine())
 			tmuxSess.SetMouse(GetTmuxSettings().GetMouse())
 			tmuxSess.SetClearOnRestart(GetTmuxSettings().ClearOnRestart)
+			tmuxSess.SetTerminalChromeEnabled(GetTerminalSettings().GetITermBadge())
 			// Note: EnableMouseMode and ConfigureStatusBar are deferred to EnsureConfigured()
 			// Called automatically when user attaches to session
 		}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -161,6 +161,11 @@ type UserConfig struct {
 	// Mirrors the opt-out in ~/.agent-deck/feedback-state.json so it is visible
 	// to the user and editable without running `agent-deck feedback`.
 	Feedback FeedbackSettings `toml:"feedback"`
+
+	// Terminal defines outer-terminal chrome settings — sequences agent-deck
+	// writes directly to the host terminal (iTerm2 badge, etc), distinct
+	// from anything tmux draws. Empty/absent uses defaults; see TerminalSettings.
+	Terminal TerminalSettings `toml:"terminal"`
 }
 
 // FeedbackSettings controls the in-product feedback prompts.
@@ -2160,6 +2165,55 @@ func GetTmuxSettings() TmuxSettings {
 	return config.Tmux
 }
 
+// TerminalSettings controls outer-terminal chrome agent-deck writes directly
+// to the host terminal (bypassing tmux). These settings affect what the
+// terminal emulator displays — currently only iTerm2's badge.
+//
+// Example config.toml:
+//
+//	[terminal]
+//	iterm_badge = true
+type TerminalSettings struct {
+	// ITermBadge controls whether agent-deck sets the iTerm2 badge to the
+	// attached session's title for the duration of the attach, and refreshes
+	// it when Claude renames the session mid-attach. No-op outside iTerm2.
+	//
+	// AGENTDECK_ITERM_BADGE env var overrides this in either direction
+	// (=1/true/yes/on force on, =0/false/no/off force off; unset defers to
+	// this config). Caveat: env reliably reaches the attach/detach path
+	// (agent-deck reads its own env directly) but the rename-while-attached
+	// path runs in a hook subprocess spawned through agent-deck → tmux →
+	// Claude → hook, and Claude may filter custom env vars. For consistent
+	// behavior on both paths, prefer this config setting — every process
+	// re-reads it from disk, so propagation is independent of the spawn
+	// chain.
+	//
+	// Default: false (opt-in). Most users have their own iTerm2 badge scheme
+	// (e.g. host/cwd via shell PROMPT_COMMAND), so silently overwriting it on
+	// every attach is too presumptuous a default. Users who want the
+	// per-session badge set this to true explicitly.
+	ITermBadge *bool `toml:"iterm_badge"`
+}
+
+// GetITermBadge returns whether the iTerm2 badge integration is enabled,
+// defaulting to false (opt-in). Mirrors the GetInjectStatusLine pattern but
+// with the inverse default — see ITermBadge field doc for rationale.
+func (t TerminalSettings) GetITermBadge() bool {
+	if t.ITermBadge == nil {
+		return false
+	}
+	return *t.ITermBadge
+}
+
+// GetTerminalSettings returns terminal-chrome settings from config.
+func GetTerminalSettings() TerminalSettings {
+	config, err := LoadUserConfig()
+	if err != nil || config == nil {
+		return TerminalSettings{}
+	}
+	return config.Terminal
+}
+
 // GetInstanceSettings returns instance behavior settings
 func GetInstanceSettings() InstanceSettings {
 	config, err := LoadUserConfig()
@@ -2389,6 +2443,21 @@ auto_cleanup = true
 # options = { "allow-passthrough" = "all", "history-limit" = "50000" }
 # Example: keep agent-deck notifications but use a 2-line status bar
 # options = { "status" = "2" }
+
+# Outer-terminal chrome (sequences agent-deck writes to the host terminal,
+# bypassing tmux). Currently controls the iTerm2 badge; future window-title
+# integrations will live in the same section.
+# [terminal]
+# iterm_badge sets the iTerm2 badge to the attached session's title for the
+# duration of the attach (cleared on detach), and refreshes it when Claude
+# renames the session mid-attach. Opt-in because most users already drive
+# the badge from their shell prompt. No-op outside iTerm2.
+# Override at runtime: AGENTDECK_ITERM_BADGE=1 forces on, =0 forces off.
+# Caveat: the env var reliably reaches the attach/detach path but is
+# unreliable for rename-while-attached (Claude may filter env vars when
+# spawning hook subprocesses). Prefer this config setting for both paths.
+# Default: false
+# iterm_badge = true
 
 # ============================================================================
 # MCP Server Definitions

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -1309,6 +1309,83 @@ inject_status_line = true
 	}
 }
 
+func TestGetTerminalSettings_ITermBadge_Default(t *testing.T) {
+	// Default (no config) should return false — opt-in. Most users drive
+	// the iTerm2 badge from their shell prompt, so silently overwriting it
+	// every attach is too presumptuous a default.
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	_ = os.MkdirAll(agentDeckDir, 0700)
+
+	configPath := filepath.Join(agentDeckDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(""), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+	ClearUserConfigCache()
+
+	settings := GetTerminalSettings()
+	if settings.GetITermBadge() {
+		t.Error("GetITermBadge should default to false (opt-in) when not set")
+	}
+}
+
+func TestGetTerminalSettings_ITermBadge_False(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	_ = os.MkdirAll(agentDeckDir, 0700)
+
+	configPath := filepath.Join(agentDeckDir, "config.toml")
+	configContent := `
+[terminal]
+iterm_badge = false
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+	ClearUserConfigCache()
+
+	settings := GetTerminalSettings()
+	if settings.GetITermBadge() {
+		t.Error("GetITermBadge should be false when set to false")
+	}
+}
+
+func TestGetTerminalSettings_ITermBadge_True(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	_ = os.MkdirAll(agentDeckDir, 0700)
+
+	configPath := filepath.Join(agentDeckDir, "config.toml")
+	configContent := `
+[terminal]
+iterm_badge = true
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+	ClearUserConfigCache()
+
+	settings := GetTerminalSettings()
+	if !settings.GetITermBadge() {
+		t.Error("GetITermBadge should be true when set to true")
+	}
+}
+
 func TestGetTmuxSettings_Mouse_Default(t *testing.T) {
 	// Default (no config) should return true — preserves pre-#730 behavior
 	tempDir := t.TempDir()

--- a/internal/tmux/chrome.go
+++ b/internal/tmux/chrome.go
@@ -79,15 +79,14 @@ func formatITermBadgeOSC(title string) string {
 // passthrough envelope so the OSC reaches the outer terminal even when
 // emitted from inside a tmux pane (e.g. a Claude rename hook subprocess).
 //
-// Tmux DCS form: `ESC P tmux ; <inner with each ESC doubled> ESC \`. The
-// inner OSC carries one ESC (its own opener), which we double to ESC ESC
-// per tmux passthrough rules. Works regardless of whether the pane has
-// `allow-passthrough` on — the DCS envelope is the older, universally-
-// supported mechanism.
+// Tmux DCS form: `ESC P tmux ; <inner with each ESC doubled> ESC \`. We
+// take the inner OSC straight from formatITermBadgeOSC (single source of
+// truth — the constants only live there) and ESC-double it. Works
+// regardless of whether the pane has `allow-passthrough` on — the DCS
+// envelope is the older, universally-supported mechanism.
 func formatITermBadgeOSCViaTmux(title string) string {
-	encoded := base64.StdEncoding.EncodeToString([]byte(title))
-	// ESC P tmux ; ESC ESC ]1337;SetBadgeFormat=<b64> BEL ESC \
-	return "\x1bPtmux;\x1b\x1b]1337;SetBadgeFormat=" + encoded + "\x07\x1b\\"
+	inner := strings.ReplaceAll(formatITermBadgeOSC(title), "\x1b", "\x1b\x1b")
+	return "\x1bPtmux;" + inner + "\x1b\\"
 }
 
 // emitITermBadge writes the iTerm2 SetBadgeFormat OSC directly to w. Used

--- a/internal/tmux/chrome.go
+++ b/internal/tmux/chrome.go
@@ -1,0 +1,188 @@
+//go:build !windows
+
+package tmux
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// Terminal-chrome escape sequences. Agent-deck owns the outer terminal's
+// tty between tea.Exec attach/detach boundaries, so it can write iTerm2-
+// specific OSC sequences directly to os.Stdout — exactly the same pattern
+// used by emitScrollbackClear for #618.
+//
+// This replaces the external poller in tarek-eq-scripts/hooks/iterm-badge-sync.sh,
+// which had to walk pgrep → ppid → tty to find this same fd from outside
+// the agent-deck process.
+const (
+	// itermBadgeOSCPrefix opens an OSC 1337 SetBadgeFormat sequence.
+	// Format per iTerm2 docs: ESC ]1337;SetBadgeFormat=<base64> BEL.
+	// An empty base64 payload clears the badge.
+	itermBadgeOSCPrefix     = "\x1b]1337;SetBadgeFormat="
+	itermBadgeOSCTerminator = "\a"
+)
+
+// iTerm2Active returns true when agent-deck is running inside an iTerm2
+// terminal. Checks both TERM_PROGRAM (set on local launches) and
+// LC_TERMINAL (auto-propagated over ssh when iTerm2's
+// "Set locale variables automatically" option is on, which is the default).
+// The bash hook used LC_TERMINAL because it's the most-propagating signal;
+// keeping that fallback here preserves parity for SSH'd-in agent-deck.
+func iTerm2Active() bool {
+	if DetectTerminal() == "iterm2" {
+		return true
+	}
+	return os.Getenv("LC_TERMINAL") == "iTerm2"
+}
+
+// iTermBadgeEffective resolves whether the iTerm2 badge feature should
+// emit, given the config-sourced default. Mirrors the AGENTDECK_REPAINT
+// precedent: a single env var named after the config key carries override
+// semantics in its value (no awkward NO_ prefix).
+//
+// Tri-state precedence:
+//   - AGENTDECK_ITERM_BADGE=1|true|yes|on   → force on, regardless of config.
+//   - AGENTDECK_ITERM_BADGE=0|false|no|off  → force off, regardless of config.
+//   - unset, empty, or unrecognised value   → defer to configEnabled.
+//
+// Garbage values intentionally fall through to config rather than failing
+// closed; users who typo the env var still get their persistent setting.
+func iTermBadgeEffective(configEnabled bool) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("AGENTDECK_ITERM_BADGE"))) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	}
+	return configEnabled
+}
+
+// formatITermBadgeOSC returns the iTerm2 OSC 1337 SetBadgeFormat sequence
+// for the given title (base64-encoded per iTerm2's wire format). An empty
+// title produces the no-payload form, which iTerm2 interprets as "clear
+// the badge".
+//
+// Pure formatter — no env / config / terminal-detection logic so it stays
+// trivial to test. Both the direct-stdout (Attach) and via-tty (rename
+// hook) emit paths share this byte sequence as their single source of truth.
+func formatITermBadgeOSC(title string) string {
+	encoded := base64.StdEncoding.EncodeToString([]byte(title))
+	return itermBadgeOSCPrefix + encoded + itermBadgeOSCTerminator
+}
+
+// formatITermBadgeOSCViaTmux wraps formatITermBadgeOSC in a tmux DCS
+// passthrough envelope so the OSC reaches the outer terminal even when
+// emitted from inside a tmux pane (e.g. a Claude rename hook subprocess).
+//
+// Tmux DCS form: `ESC P tmux ; <inner with each ESC doubled> ESC \`. The
+// inner OSC carries one ESC (its own opener), which we double to ESC ESC
+// per tmux passthrough rules. Works regardless of whether the pane has
+// `allow-passthrough` on — the DCS envelope is the older, universally-
+// supported mechanism.
+func formatITermBadgeOSCViaTmux(title string) string {
+	encoded := base64.StdEncoding.EncodeToString([]byte(title))
+	// ESC P tmux ; ESC ESC ]1337;SetBadgeFormat=<b64> BEL ESC \
+	return "\x1bPtmux;\x1b\x1b]1337;SetBadgeFormat=" + encoded + "\x07\x1b\\"
+}
+
+// emitITermBadge writes the iTerm2 SetBadgeFormat OSC directly to w. Used
+// on the Attach lifecycle boundary, where agent-deck owns the outer iTerm2
+// tty (no tmux between us and the terminal), so a raw OSC suffices.
+//
+// Two gates, both must permit the emit:
+//   - iTerm2Active() — terminal detection (TERM_PROGRAM or LC_TERMINAL).
+//   - iTermBadgeEffective(configEnabled) — env-var-or-config decision.
+func emitITermBadge(w io.Writer, title string, configEnabled bool) {
+	if !iTerm2Active() || !iTermBadgeEffective(configEnabled) {
+		return
+	}
+	_, _ = io.WriteString(w, formatITermBadgeOSC(title))
+}
+
+// EmitITermBadgeViaTty writes the SetBadgeFormat OSC to /dev/tty wrapped
+// in a tmux DCS passthrough envelope. Used by Claude rename-hook
+// subprocesses that run inside a tmux pane: their stdout is owned by the
+// hook protocol (writing OSC there would corrupt the response), but their
+// controlling tty is the tmux pane's pty, so a wrapped OSC routes through
+// tmux out to iTerm2 — this is what closes the gap when Claude renames
+// the session mid-attach.
+//
+// Silent no-op when:
+//   - not iTerm2 (or env / config disabled)
+//   - the process has no controlling tty (e.g. detached daemon)
+//   - the user isn't attached to this pane in iTerm2 (tmux buffers the
+//     pane output but iTerm2 never sees it — fine, the next attach emit
+//     in pty.go will catch up)
+//
+// Debug: set AGENTDECK_ITERM_BADGE_DEBUG=1 to log decisions to
+// /tmp/agent-deck-iterm-badge.log (timestamp, gate values, /dev/tty open
+// result). Useful for diagnosing the multi-process chain Claude → hook
+// subprocess → /dev/tty → tmux → iTerm2.
+func EmitITermBadgeViaTty(title string, configEnabled bool) {
+	dbg := emitITermBadgeDebugger()
+	defer dbg.flush()
+
+	dbg.logf("EmitITermBadgeViaTty title=%q configEnabled=%v", title, configEnabled)
+	dbg.logf("  TERM_PROGRAM=%q LC_TERMINAL=%q ITERM_SESSION_ID=%q",
+		os.Getenv("TERM_PROGRAM"), os.Getenv("LC_TERMINAL"), os.Getenv("ITERM_SESSION_ID"))
+	dbg.logf("  AGENTDECK_ITERM_BADGE=%q", os.Getenv("AGENTDECK_ITERM_BADGE"))
+
+	if !iTerm2Active() {
+		dbg.logf("  decision: skip (iTerm2Active=false)")
+		return
+	}
+	if !iTermBadgeEffective(configEnabled) {
+		dbg.logf("  decision: skip (iTermBadgeEffective=false)")
+		return
+	}
+
+	tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+	if err != nil {
+		dbg.logf("  decision: skip (open /dev/tty failed: %v)", err)
+		return
+	}
+	defer tty.Close()
+	payload := formatITermBadgeOSCViaTmux(title)
+	n, werr := io.WriteString(tty, payload)
+	dbg.logf("  decision: wrote %d/%d bytes to /dev/tty err=%v", n, len(payload), werr)
+}
+
+// emitITermBadgeDebugger returns a debug helper that no-ops unless
+// AGENTDECK_ITERM_BADGE_DEBUG=1 is set. Output goes to a per-user file in
+// /tmp so the multi-process chain (agent-deck, tmux server, Claude, hook
+// subprocess) all write to one log the user can `tail -f`.
+func emitITermBadgeDebugger() *iTermBadgeDebugLog {
+	if os.Getenv("AGENTDECK_ITERM_BADGE_DEBUG") != "1" {
+		return &iTermBadgeDebugLog{}
+	}
+	path := fmt.Sprintf("/tmp/agent-deck-iterm-badge-%d.log", os.Getuid())
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return &iTermBadgeDebugLog{}
+	}
+	return &iTermBadgeDebugLog{f: f, pid: os.Getpid()}
+}
+
+type iTermBadgeDebugLog struct {
+	f   *os.File
+	pid int
+}
+
+func (d *iTermBadgeDebugLog) logf(format string, args ...any) {
+	if d.f == nil {
+		return
+	}
+	fmt.Fprintf(d.f, "%s pid=%d "+format+"\n",
+		append([]any{time.Now().Format("15:04:05.000"), d.pid}, args...)...)
+}
+
+func (d *iTermBadgeDebugLog) flush() {
+	if d.f != nil {
+		_ = d.f.Close()
+	}
+}

--- a/internal/tmux/chrome_test.go
+++ b/internal/tmux/chrome_test.go
@@ -1,0 +1,302 @@
+//go:build !windows
+
+package tmux
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/term"
+)
+
+// TestEmitITermBadge_EncodesTitleBase64 asserts that the helper produces
+// exactly the OSC 1337 SetBadgeFormat sequence iTerm2 expects: the literal
+// prefix, the base64-encoded title bytes, and a BEL terminator.
+func TestEmitITermBadge_EncodesTitleBase64(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	var buf bytes.Buffer
+	emitITermBadge(&buf, "myapp", true)
+
+	want := "\x1b]1337;SetBadgeFormat=" + base64.StdEncoding.EncodeToString([]byte("myapp")) + "\a"
+	require.Equal(t, want, buf.String(),
+		"emitITermBadge must write OSC 1337;SetBadgeFormat=<base64(title)>BEL")
+}
+
+// TestEmitITermBadge_EmptyTitleClears asserts that an empty title produces
+// the badge-clear form (empty base64 payload), which iTerm2 interprets as
+// "remove the badge" — used on detach to leave the terminal in a clean state.
+func TestEmitITermBadge_EmptyTitleClears(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	var buf bytes.Buffer
+	emitITermBadge(&buf, "", true)
+
+	require.Equal(t, "\x1b]1337;SetBadgeFormat=\a", buf.String(),
+		"empty title must emit the no-payload form to clear the badge")
+}
+
+// TestEmitITermBadge_NoOpOutsideITerm2 ensures we don't write iTerm2-specific
+// escape sequences to terminals that won't parse them — they would otherwise
+// appear as literal garbage in the user's terminal output.
+func TestEmitITermBadge_NoOpOutsideITerm2(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
+	t.Setenv("ITERM_SESSION_ID", "")
+	t.Setenv("LC_TERMINAL", "")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	var buf bytes.Buffer
+	emitITermBadge(&buf, "anything", true)
+
+	require.Empty(t, buf.Bytes(),
+		"emitITermBadge must not write anything when not running inside iTerm2; got %q", buf.String())
+}
+
+// TestEmitITermBadge_HonorsLCTerminal verifies the SSH-friendly fallback:
+// when only LC_TERMINAL=iTerm2 is set (TERM_PROGRAM does not propagate over
+// ssh), we still detect iTerm2 and emit the badge. Mirrors the gate the
+// external bash hook in tarek-eq-scripts uses.
+func TestEmitITermBadge_HonorsLCTerminal(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("ITERM_SESSION_ID", "")
+	t.Setenv("LC_TERMINAL", "iTerm2")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	var buf bytes.Buffer
+	emitITermBadge(&buf, "remote", true)
+
+	require.NotEmpty(t, buf.Bytes(),
+		"emitITermBadge must honor LC_TERMINAL=iTerm2 (SSH propagation path)")
+}
+
+// TestEmitITermBadge_ConfigDisabledSuppressesEmit covers the
+// [terminal].iterm_badge=false config default. With the env var unset,
+// configEnabled=false must suppress the OSC write — that's the whole
+// point of the opt-in default for users who run their own badge scheme.
+func TestEmitITermBadge_ConfigDisabledSuppressesEmit(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	var buf bytes.Buffer
+	emitITermBadge(&buf, "myapp", false)
+
+	require.Empty(t, buf.Bytes(),
+		"configEnabled=false must suppress chrome emits even on iTerm2; got %q", buf.String())
+}
+
+// TestEmitITermBadge_EnvForceEnableOverridesConfigOff pins the "ad-hoc
+// enable trumps persistent off" direction: config defaults the badge to
+// off, but AGENTDECK_ITERM_BADGE=1 forces it on for this run. Each truthy
+// value variant is asserted because the helper accepts a small set.
+func TestEmitITermBadge_EnvForceEnableOverridesConfigOff(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+
+	for _, v := range []string{"1", "true", "TRUE", "yes", "on"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("AGENTDECK_ITERM_BADGE", v)
+
+			var buf bytes.Buffer
+			emitITermBadge(&buf, "myapp", false) // config off, env says on
+
+			require.NotEmpty(t, buf.Bytes(),
+				"AGENTDECK_ITERM_BADGE=%q must force-enable when config is off", v)
+		})
+	}
+}
+
+// TestEmitITermBadge_EnvForceDisableOverridesConfigOn pins the "ad-hoc
+// disable trumps persistent on" direction: config has badge on, but
+// AGENTDECK_ITERM_BADGE=0 forces it off for this run. Each falsy value
+// variant is asserted because the helper accepts a small set.
+func TestEmitITermBadge_EnvForceDisableOverridesConfigOn(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+
+	for _, v := range []string{"0", "false", "FALSE", "no", "off"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv("AGENTDECK_ITERM_BADGE", v)
+
+			var buf bytes.Buffer
+			emitITermBadge(&buf, "myapp", true) // config on, env says off
+
+			require.Empty(t, buf.Bytes(),
+				"AGENTDECK_ITERM_BADGE=%q must force-disable when config is on; got %q",
+				v, buf.String())
+		})
+	}
+}
+
+// TestEmitITermBadge_EnvGarbageDefersToConfig pins fail-open: a typo or
+// otherwise unrecognised env value must not silently flip the user's
+// persistent setting. Garbage falls through to configEnabled.
+func TestEmitITermBadge_EnvGarbageDefersToConfig(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "maybe")
+
+	var bufOff bytes.Buffer
+	emitITermBadge(&bufOff, "myapp", false)
+	require.Empty(t, bufOff.Bytes(),
+		"garbage env value with config off must remain off (not silently force-on); got %q", bufOff.String())
+
+	var bufOn bytes.Buffer
+	emitITermBadge(&bufOn, "myapp", true)
+	require.NotEmpty(t, bufOn.Bytes(),
+		"garbage env value with config on must remain on (not silently force-off)")
+}
+
+// TestFormatITermBadgeOSC_RoundTrip pins the on-the-wire byte format. Both
+// emit paths (direct stdout in Attach, /dev/tty in the rename hook) share
+// this string, so a regression here breaks both.
+func TestFormatITermBadgeOSC_RoundTrip(t *testing.T) {
+	require.Equal(t,
+		"\x1b]1337;SetBadgeFormat="+base64.StdEncoding.EncodeToString([]byte("myapp"))+"\a",
+		formatITermBadgeOSC("myapp"),
+		"formatITermBadgeOSC must produce ESC ]1337;SetBadgeFormat=<b64>BEL")
+
+	require.Equal(t, "\x1b]1337;SetBadgeFormat=\a", formatITermBadgeOSC(""),
+		"empty title must produce the badge-clear form (no payload)")
+}
+
+// TestFormatITermBadgeOSCViaTmux_DCSEnvelope pins the tmux DCS passthrough
+// wrapping rule: the inner OSC's lone ESC is doubled (\x1b\x1b) so tmux
+// strips one and forwards the other. ESC P tmux ; ... ESC \ delimits.
+// Without this exact shape the rename-hook badge update silently disappears
+// inside tmux instead of reaching iTerm2.
+func TestFormatITermBadgeOSCViaTmux_DCSEnvelope(t *testing.T) {
+	got := formatITermBadgeOSCViaTmux("myapp")
+
+	want := "\x1bPtmux;\x1b\x1b]1337;SetBadgeFormat=" +
+		base64.StdEncoding.EncodeToString([]byte("myapp")) +
+		"\x07\x1b\\"
+	require.Equal(t, want, got,
+		"DCS-wrapped form must be ESC P tmux ; ESC ESC <OSC inner> ESC \\")
+
+	require.True(t, strings.HasPrefix(got, "\x1bPtmux;"),
+		"must open with the DCS tmux prefix")
+	require.True(t, strings.HasSuffix(got, "\x1b\\"),
+		"must close with the ST terminator (ESC \\)")
+}
+
+// TestEmitITermBadgeViaTty_NoOpOutsideITerm2 ensures the rename-hook helper
+// is safe to call from any terminal — outside iTerm2 we must not even
+// attempt to open /dev/tty (which would still succeed and write garbage
+// into the user's pane that the wrong terminal can't parse).
+func TestEmitITermBadgeViaTty_NoOpOutsideITerm2(t *testing.T) {
+	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
+	t.Setenv("ITERM_SESSION_ID", "")
+	t.Setenv("LC_TERMINAL", "")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	// Cannot meaningfully assert on /dev/tty contents from a unit test, but
+	// we can confirm the function returns without panicking and consults
+	// the gate first. iTerm2Active is the early-return barrier; if it's
+	// honored, no /dev/tty open attempt happens.
+	require.NotPanics(t, func() {
+		EmitITermBadgeViaTty("anything", true)
+	}, "EmitITermBadgeViaTty must be a silent no-op outside iTerm2")
+}
+
+// TestSession_SetTerminalChromeEnabled pins the setter contract: a fresh
+// Session built via NewSession defaults to disabled (opt-in), and
+// SetTerminalChromeEnabled flips the bit returned by the read accessor.
+// Mirrors TestSession_SetInjectStatusLine but with the inverse default —
+// the iTerm2 badge is opt-in because most users already drive their badge
+// from their shell prompt.
+func TestSession_SetTerminalChromeEnabled(t *testing.T) {
+	sess := NewSession("test", "/tmp")
+	require.False(t, sess.terminalChromeIsEnabled(),
+		"NewSession must default terminalChromeEnabled=false (opt-in)")
+
+	sess.SetTerminalChromeEnabled(true)
+	require.True(t, sess.terminalChromeIsEnabled(),
+		"SetTerminalChromeEnabled(true) must flip the bit")
+
+	sess.SetTerminalChromeEnabled(false)
+	require.False(t, sess.terminalChromeIsEnabled(),
+		"SetTerminalChromeEnabled(false) must restore the bit")
+}
+
+// TestAttach_EmitsITermBadgeOnEntry is the structural counterpart of the
+// existing #618 scrollback test: pipe os.Stdout, drive Attach + detach, and
+// assert that the SetBadgeFormat OSC for the session's DisplayName landed on
+// the iTerm2 tty before the user saw any tmux output. This is what closes
+// the loop on the external `iterm-badge-sync.sh` poller.
+func TestAttach_EmitsITermBadgeOnEntry(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		t.Skip("stdin is not a terminal (CI/pipe environment); skipping PTY attach test")
+	}
+
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	name := SessionPrefix + "ptytest-itermbadge-" + fmt.Sprintf("%d", time.Now().UnixNano()%100000)
+	require.NoError(t,
+		exec.Command("tmux", "new-session", "-d", "-s", name, "bash").Run(),
+		"failed to create test session %s", name,
+	)
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", name).Run() })
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	oldStdout := os.Stdout
+	os.Stdout = w
+
+	const displayTitle = "badge-eval-fixture"
+	// Direct struct literal bypasses NewSession, so terminalChromeEnabled
+	// would otherwise default to the zero value (false) — which is also
+	// the constructor / upstream-config default now that the feature is
+	// opt-in. Set true here to mirror what an opted-in user's session
+	// looks like at attach time.
+	sess := &Session{Name: name, DisplayName: displayTitle, terminalChromeEnabled: true}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	attachDone := make(chan error, 1)
+	go func() { attachDone <- sess.Attach(ctx, 0x11) }()
+
+	time.Sleep(300 * time.Millisecond)
+	require.NoError(t,
+		exec.Command("tmux", "send-keys", "-t", name, "C-q", "").Run(),
+		"failed to send detach key",
+	)
+
+	select {
+	case attachErr := <-attachDone:
+		os.Stdout = oldStdout
+		w.Close()
+		require.NoError(t, attachErr, "Attach returned error after detach")
+	case <-time.After(4 * time.Second):
+		cancel()
+		os.Stdout = oldStdout
+		w.Close()
+		t.Fatal("Attach did not return after detach key was sent")
+	}
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	captured := buf.String()
+
+	wantSet := "\x1b]1337;SetBadgeFormat=" + base64.StdEncoding.EncodeToString([]byte(displayTitle)) + "\a"
+	require.Contains(t, captured, wantSet,
+		"Attach() must emit OSC 1337;SetBadgeFormat=<base64(DisplayName)>BEL on entry; captured: %q", captured)
+
+	wantClear := "\x1b]1337;SetBadgeFormat=\a"
+	require.Contains(t, captured, wantClear,
+		"cleanupAttach() must emit OSC 1337;SetBadgeFormat=BEL (empty payload) to clear the badge on detach; captured: %q", captured)
+
+	setIdx := bytes.Index(buf.Bytes(), []byte(wantSet))
+	clearIdx := bytes.LastIndex(buf.Bytes(), []byte(wantClear))
+	require.Less(t, setIdx, clearIdx,
+		"badge SET must precede badge CLEAR within a single Attach lifecycle; set=%d clear=%d", setIdx, clearIdx)
+}

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -134,6 +134,15 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 	// and breaks mouse-wheel / copy-mode navigation (#531).
 	emitScrollbackClear(os.Stdout)
 
+	// Set the iTerm2 badge to the session's display title for the duration
+	// of the attach. Agent-deck owns the outer iTerm2 tty here (no tmux
+	// between us and the terminal), so a direct OSC write reaches iTerm2.
+	// Replaces the external pgrep/ppid/tty-walk in iterm-badge-sync.sh.
+	// Opt-in: no-op outside iTerm2, when [terminal].iterm_badge=false in
+	// user config (the default), or when AGENTDECK_ITERM_BADGE=0 forces
+	// it off at runtime. AGENTDECK_ITERM_BADGE=1 ad-hoc enables.
+	emitITermBadge(os.Stdout, s.DisplayName, s.terminalChromeIsEnabled())
+
 	// Create context with cancel for detach
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -332,6 +341,10 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 		// (#419, #618). emitScrollbackClear emits CSI 3 J + iTerm2-specific OSC 1337
 		// ClearScrollback — both boundaries route through one helper so they cannot drift.
 		emitScrollbackClear(os.Stdout)
+		// Clear the iTerm2 badge so the home view doesn't keep showing the
+		// detached session's title. Symmetric with the on-entry emit above —
+		// both boundaries route through emitITermBadge so they cannot drift.
+		emitITermBadge(os.Stdout, "", s.terminalChromeIsEnabled())
 		// Reset OSC-8 hyperlink state + SGR attributes before Bubble Tea redraws.
 		_, _ = os.Stdout.WriteString(terminalStyleReset)
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -826,6 +826,13 @@ type Session struct {
 	// When false (default), previous session output is preserved.
 	// Set via SetClearOnRestart from user config.
 	clearOnRestart bool
+
+	// terminalChromeEnabled controls whether Attach emits outer-terminal
+	// chrome sequences (currently the iTerm2 badge) on attach/detach.
+	// Default: false (opt-in via [terminal].iterm_badge in user config; set
+	// here through SetTerminalChromeEnabled). AGENTDECK_ITERM_BADGE=0|1
+	// overrides this at runtime in either direction; see chrome.go.
+	terminalChromeEnabled bool
 }
 
 type envCacheEntry struct {
@@ -1206,6 +1213,26 @@ func (s *Session) SetInjectStatusLine(inject bool) {
 	s.injectStatusLine = inject
 }
 
+// SetTerminalChromeEnabled controls whether Attach emits outer-terminal
+// chrome (currently the iTerm2 badge) on attach/detach. Mirrors the
+// SetInjectStatusLine plumbing pattern: callers in internal/session read
+// `[terminal].iterm_badge` from user config and forward it here.
+// AGENTDECK_ITERM_BADGE overrides this at runtime; see chrome.go.
+func (s *Session) SetTerminalChromeEnabled(enabled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.terminalChromeEnabled = enabled
+}
+
+// terminalChromeIsEnabled is the read-side accessor used by Attach. Locked
+// read so a concurrent Set call cannot publish a torn bool — same shape as
+// the other Session getters.
+func (s *Session) terminalChromeIsEnabled() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.terminalChromeEnabled
+}
+
 // SetMouse controls whether tmux mouse mode is enabled for this session.
 // When false, the inline `mouse on` set-option during Start is skipped AND
 // EnableMouseMode becomes a no-op — required for VS Code Linux integrated
@@ -1265,9 +1292,10 @@ func NewSession(name, workDir string) *Session {
 		Created:          time.Now(),
 		startupAt:        time.Now(),
 		lastStableStatus: "waiting",
-		toolDetectExpiry: 30 * time.Second, // Re-detect tool every 30 seconds
-		injectStatusLine: true,             // Default: inject status bar
-		mouse:            true,             // Default: mouse on (#730 opt-out)
+		toolDetectExpiry:      30 * time.Second, // Re-detect tool every 30 seconds
+		injectStatusLine:      true,             // Default: inject status bar
+		mouse:                 true,             // Default: mouse on (#730 opt-out)
+		terminalChromeEnabled: false, // Default: opt-in (set true via [terminal].iterm_badge)
 		// stateTracker and promptDetector will be created lazily on first status check
 	}
 }
@@ -1287,10 +1315,11 @@ func ReconnectSession(tmuxName, displayName, workDir, command string) *Session {
 		Created:          time.Now(), // Approximate - we don't persist this
 		startupAt:        time.Time{},
 		lastStableStatus: "waiting",
-		toolDetectExpiry: 30 * time.Second,
-		injectStatusLine: true,  // Default: inject status bar
-		mouse:            true,  // Default: mouse on (#730 opt-out)
-		configured:       false, // Will be set to true after configuration
+		toolDetectExpiry:      30 * time.Second,
+		injectStatusLine:      true,  // Default: inject status bar
+		mouse:                 true,  // Default: mouse on (#730 opt-out)
+		terminalChromeEnabled: false, // Default: opt-in (set true via [terminal].iterm_badge)
+		configured:            false, // Will be set to true after configuration
 		// stateTracker and promptDetector will be created lazily on first status check
 	}
 
@@ -1356,10 +1385,11 @@ func ReconnectSessionLazy(tmuxName, displayName, workDir, command string, previo
 		Created:          time.Now(), // Approximate - we don't persist this
 		startupAt:        time.Time{},
 		lastStableStatus: "waiting",
-		toolDetectExpiry: 30 * time.Second,
-		injectStatusLine: true,  // Default: inject status bar
-		mouse:            true,  // Default: mouse on (#730 opt-out)
-		configured:       false, // Explicitly mark as not configured
+		toolDetectExpiry:      30 * time.Second,
+		injectStatusLine:      true,  // Default: inject status bar
+		mouse:                 true,  // Default: mouse on (#730 opt-out)
+		terminalChromeEnabled: false, // Default: opt-in (set true via [terminal].iterm_badge)
+		configured:            false, // Explicitly mark as not configured
 	}
 
 	// Restore state tracker based on previous status (without running tmux commands)

--- a/tests/eval/session/badge_test.go
+++ b/tests/eval/session/badge_test.go
@@ -1,0 +1,133 @@
+//go:build eval_smoke
+
+// Package session — eval coverage for the iTerm2 badge integration. The
+// `Attach` lifecycle emits OSC 1337 SetBadgeFormat directly to os.Stdout
+// (which is the iTerm2 tty under normal use). The unit-level integration
+// test in internal/tmux/chrome_test.go skips when stdin isn't a terminal,
+// which is always the case under `go test`. PTY-spawning the binary here
+// gives Attach() a real terminal so the OSC bytes land in our captured
+// stream — exactly the gap the eval harness exists to close (RFC §7
+// Bug 3, mirroring the inject_status_line case).
+package session_test
+
+import (
+	"encoding/base64"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/tests/eval/harness"
+)
+
+// TestEval_Session_ITermBadge_RealAttach drives `agent-deck session attach`
+// under a real PTY and asserts that the SetBadgeFormat OSC for the
+// session's title is written to stdout on attach entry, and the empty
+// (clear) form is written on detach. Catches regressions where the call
+// to emitITermBadge in pty.Attach is removed or reordered — a class of
+// breakage the existing pure-Go tests cannot structurally detect because
+// they exercise the helper in isolation, not the lifecycle wiring.
+func TestEval_Session_ITermBadge_RealAttach(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not on PATH")
+	}
+
+	sb := harness.NewSandbox(t)
+	sb.InstallTmuxShim(t)
+
+	workDir := filepath.Join(sb.Home, "project")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+
+	// Enable the feature via config — the env-var path doesn't reliably
+	// propagate through every process boundary, but config is read from
+	// disk in every spawn. Match the wiring users are documented to use.
+	cfgDir := filepath.Join(sb.Home, ".agent-deck")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent-deck config dir: %v", err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("[terminal]\niterm_badge = true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Register a shell session so we don't need claude on PATH. Title
+	// "badge" is what we'll assert the SetBadgeFormat payload encodes.
+	runBin(t, sb, "add", "-c", "bash", "-t", "badge", "-g", "evalgrp", workDir)
+	runBin(t, sb, "session", "start", "badge")
+
+	// Wait for the agentdeck_* session to register on tmux.
+	deadline := time.Now().Add(5 * time.Second)
+	registered := false
+	for time.Now().Before(deadline) {
+		out, err := sb.TmuxTry("list-sessions", "-F", "#{session_name}")
+		if err == nil {
+			for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+				if strings.HasPrefix(line, "agentdeck_") {
+					registered = true
+					break
+				}
+			}
+		}
+		if registered {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !registered {
+		out, _ := sb.TmuxTry("list-sessions")
+		t.Fatalf("no agentdeck_* session appeared within 5s.\ntmux list-sessions: %s", out)
+	}
+
+	// Cleanup the session even on failure.
+	t.Cleanup(func() { _, _ = runBinTry(sb, "session", "stop", "badge") })
+
+	// PTY-spawn the attach. TERM_PROGRAM=iTerm.app turns on the badge
+	// emit gate. TERM=dumb (harness default) is intentional: under it,
+	// the inner tmux attach process exits immediately with "terminal does
+	// not support clear", which drives agent-deck's Attach() through its
+	// full on-entry-then-cleanupAttach lifecycle in a single short-lived
+	// spawn. We do not need to actually run an interactive session — we
+	// just need both OSC emit boundaries to fire so we can assert on them.
+	p := sb.SpawnWithEnv(
+		[]string{"TERM_PROGRAM=iTerm.app"},
+		"session", "attach", "badge",
+	)
+	defer p.Close()
+
+	// Wait for the binary to exit naturally. Under TERM=dumb the inner
+	// tmux attach exits with "terminal does not support clear", but
+	// agent-deck's Attach normalises that into a clean exit (the cmdDone
+	// branch treats exit codes 0/1 as detach equivalents). Both emit
+	// sites fire before and after, which is what we're testing. A 10s
+	// ceiling is generous for what's typically a sub-second flow.
+	p.ExpectExit(0, 10*time.Second)
+
+	captured := p.Output()
+
+	// Set-on-entry: SetBadgeFormat=<base64("badge")> + BEL.
+	wantSet := "\x1b]1337;SetBadgeFormat=" +
+		base64.StdEncoding.EncodeToString([]byte("badge")) + "\a"
+	if !strings.Contains(captured, wantSet) {
+		t.Fatalf("attach did not emit SetBadgeFormat OSC for session title 'badge'.\n"+
+			"want substring: %q\ncaptured (escaped): %q",
+			wantSet, captured)
+	}
+
+	// Clear-on-detach: empty payload form.
+	wantClear := "\x1b]1337;SetBadgeFormat=\a"
+	clearIdx := strings.LastIndex(captured, wantClear)
+	setIdx := strings.Index(captured, wantSet)
+	if clearIdx < 0 {
+		t.Fatalf("detach did not emit badge-clear OSC.\nwant substring: %q\ncaptured (escaped): %q",
+			wantClear, captured)
+	}
+	if clearIdx <= setIdx {
+		t.Fatalf("badge SET must precede badge CLEAR within a single Attach lifecycle.\n"+
+			"set-idx=%d clear-idx=%d\ncaptured (escaped): %q",
+			setIdx, clearIdx, captured)
+	}
+}


### PR DESCRIPTION
_This has been helpful for telling agent-deck sessions apart when several are running in different iTerm2 windows — the badge gives each window a persistent label visible in the window switcher without having to peek at the tmux status bar._

_Started life as a Claude statusline hook on my laptop that polled `agent-deck session current --json` and walked `pgrep → ppid → tty` to find agent-deck's iTerm2 fd from outside the process — fragile, throttled, and cache-stale. Agent-deck is the process that owns the iTerm2 tty, so folding it in-tree collapses all that ceremony into a direct `os.Stdout` write at the same boundary `emitScrollbackClear` already uses._

## Summary

Sets iTerm2's [badge](https://iterm2.com/documentation-badges.html) to the attached session's title for the duration of the attach, refreshes it when Claude renames the session mid-attach, and clears it on detach. Opt-in via `[terminal].iterm_badge`, defaults to `false`.

## Two emit paths, one source of truth

Agent-deck owns the outer iTerm2 tty between `tea.Exec` attach/detach boundaries, so the on-attach / on-detach badge writes go straight to `os.Stdout` — the same pattern `emitScrollbackClear` already uses for #618. The mid-attach rename case runs in a different process: Claude invokes `agent-deck hook-handler` as a subprocess inside the tmux pane, which has no direct line to the iTerm2 tty. That path wraps the same OSC in a tmux DCS passthrough envelope and writes it to `/dev/tty`, which routes through the running tmux server out to iTerm2 (works regardless of `allow-passthrough` setting). Both formatters share `formatITermBadgeOSC` so the OSC prefix/terminator constants only live in one place — no parallel-paths drift.

## Three independent gates

1. **Terminal detection** — `TERM_PROGRAM=iTerm.app`, `ITERM_SESSION_ID`, or `LC_TERMINAL=iTerm2` (the SSH-friendly fallback iTerm2 propagates by default).
2. **`[terminal].iterm_badge` config** — default `false`. Most users drive their iTerm2 badge from a shell prompt (host/cwd via `PROMPT_COMMAND`); silent-overwrite-on-every-attach is too presumptuous a default.
3. **`AGENTDECK_ITERM_BADGE` env override** — tri-state, follows the `AGENTDECK_REPAINT` precedent (value carries polarity, no awkward `NO_` prefix). `1|true|yes|on` force on; `0|false|no|off` force off; unset or unrecognised value defers to config.

The env-var caveat is documented inline: it reaches the attach/detach path reliably (one hop from your shell to agent-deck) but the rename path runs in a Claude hook subprocess where Claude may filter custom env vars, so the config setting is the recommended gate for both paths.

## Debug

`AGENTDECK_ITERM_BADGE_DEBUG=1` logs gate decisions to a per-uid file in `/tmp` so the multi-process passthrough chain (agent-deck → tmux → Claude → hook subprocess) can be observed end-to-end. Cheap insurance for the kind of thing that goes wrong silently across process boundaries.

## Plumbing

`Session.terminalChromeEnabled` (default `false` at all three constructors) is set by callers in `internal/session` next to the existing `SetInjectStatusLine` sites. Mirrors the established `inject_status_line` plumbing pattern.

## Tests

14 unit tests in `internal/tmux/chrome_test.go`: OSC byte format, tmux DCS wrapping, env tri-state precedence (truthy/falsy variants and garbage-defers-to-config), `LC_TERMINAL` SSH fallback, no-op outside iTerm2, `EmitITermBadgeViaTty` early-return, `Session.SetTerminalChromeEnabled` setter contract. 3 unit tests in `internal/session/userconfig_test.go` for config defaults and round-trip. 1 attach-lifecycle integration test mirroring `TestCleanupAttach_EmitsITermClearScrollback` (#618), which skips without a TTY.

The eval-smoke case in `tests/eval/session/badge_test.go` closes that CI gap: it PTY-spawns `agent-deck session attach`, drives the full Attach lifecycle under a real terminal, and asserts both the SET (base64-encoded title) and CLEAR (empty payload) OSC bytes are emitted and ordered. Negative-control verified locally — commenting out the on-entry emit in `pty.go` causes the eval to fail.

## Test plan

- [ ] `GOTOOLCHAIN=go1.24.0 go test ./internal/tmux/... -race -count=1` (race-clean)
- [ ] `GOTOOLCHAIN=go1.24.0 go test -tags eval_smoke ./tests/eval/session/...` (new badge eval passes)
- [ ] `GOTOOLCHAIN=go1.24.0 go test -run TestPersistence_ ./internal/session/... -race -count=1` (session-persistence mandate)
- [ ] Manual smoke in iTerm2: enable via `[terminal] iterm_badge = true`, attach to a Claude session — badge mirrors title; detach — badge clears; `/rename foo` mid-attach — badge updates.
