### PR TITLE
fix(tmux): soften ControlPipe.Close() to SIGTERM+grace (closes #739 gap)

### DIFF
--- a/internal/tmux/controlpipe.go
+++ b/internal/tmux/controlpipe.go
@@ -350,6 +350,14 @@ func (cp *ControlPipe) Done() <-chan struct{} {
 }
 
 // Close shuts down the control mode pipe and kills the process.
+//
+// Teardown is staged: (1) close stdin so tmux's `tmux -C attach-session`
+// child sees EOF and can shut down on its own; (2) SIGTERM with a 500ms
+// grace via softKillProcessGroup so a healthy client tears down its
+// control-mode state cleanly before exit; (3) SIGKILL fallback for stuck
+// clients. SIGKILL'ing a live control client races tmux's notify path
+// and on macOS Homebrew tmux 3.6a (tmux/tmux#4980) crashes the entire
+// server — wiping every agent-deck session. The grace closes that race.
 func (cp *ControlPipe) Close() {
 	cp.closeOnce.Do(func() {
 		cp.mu.Lock()
@@ -359,13 +367,17 @@ func (cp *ControlPipe) Close() {
 		// Close stdin first (tells tmux to disconnect)
 		cp.stdin.Close()
 
-		// Kill the process group to clean up reliably
+		// Reap the process group with SIGTERM+grace→SIGKILL escalation.
+		// Process-group kill (negative pgid) is preserved from the
+		// original Close() so any helpers tmux spawned are reaped too.
 		if cp.cmd.Process != nil {
 			pgid, err := syscall.Getpgid(cp.cmd.Process.Pid)
 			if err == nil {
-				_ = syscall.Kill(-pgid, syscall.SIGKILL)
+				_ = softKillProcessGroup(pgid, controlClientKillGrace)
 			} else {
-				_ = cp.cmd.Process.Kill()
+				// Pgid lookup failed (process already exited) — fall
+				// back to single-pid soft-kill.
+				_ = softKillProcess(cp.cmd.Process.Pid, controlClientKillGrace)
 			}
 		}
 

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -521,6 +521,46 @@ func softKillProcess(pid int, grace time.Duration) bool {
 	return true
 }
 
+// softKillProcessGroup is the process-group analogue of softKillProcess.
+// It sends SIGTERM to the entire group (-pgid), polls every 5ms up to grace
+// for the group to drain, and escalates to SIGKILL if any process in the
+// group is still alive at the deadline. Returns true iff SIGKILL was
+// ultimately used. An empty group (ESRCH on initial SIGTERM) is treated as
+// already-dead and returns false without escalation.
+//
+// Used by ControlPipe.Close() to tear down the agent-deck-owned
+// `tmux -C attach-session` child without racing tmux's control-mode
+// notify path. The original Close() implementation SIGKILL'd the group
+// immediately, which on macOS Homebrew tmux 3.6a races the unfixed
+// NULL-deref in tmux's notify path (tmux/tmux#4980) and crashes the
+// server — wiping every agent-deck session. The mitigation in #739
+// only covered killStaleControlClients (the post-restart cleanup path);
+// the active-pipe close path still SIGKILL'd. This helper closes that gap.
+func softKillProcessGroup(pgid int, grace time.Duration) bool {
+	if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return false
+		}
+		// Permission or other error — fall back to SIGKILL on the group.
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		return true
+	}
+
+	const pollInterval = 5 * time.Millisecond
+	deadline := time.Now().Add(grace)
+	for time.Now().Before(deadline) {
+		time.Sleep(pollInterval)
+		// kill(-pgid, 0) returns ESRCH only when no process in the group
+		// remains; until then it returns nil (some member alive or zombie).
+		if err := syscall.Kill(-pgid, 0); err != nil && errors.Is(err, syscall.ESRCH) {
+			return false
+		}
+	}
+
+	_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	return true
+}
+
 // tmuxSessionExistsOnSocket targets an explicit tmux server. socketName is the
 // tmux `-L <name>` selector (Session.SocketName / Instance.TmuxSocketName);
 // pass "" for the default server. All callers (watchPipe reconnect loop,

--- a/internal/tmux/softkill_test.go
+++ b/internal/tmux/softkill_test.go
@@ -62,6 +62,25 @@ func spawnHelper(t *testing.T, role string, extraEnv ...string) *exec.Cmd {
 	return cmd
 }
 
+// spawnHelperInOwnGroup is like spawnHelper but puts the child in its own
+// process group via Setpgid. Required for softKillProcessGroup tests:
+// without isolation, syscall.Kill(-pgid, ...) on the inherited pgid would
+// also signal the test runner itself.
+func spawnHelperInOwnGroup(t *testing.T, role string, extraEnv ...string) *exec.Cmd {
+	t.Helper()
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	cmd := exec.Command(exe, "-test.run=^$") // run no tests in child
+	env := append(os.Environ(), "SOFTKILL_TEST_HELPER="+role)
+	env = append(env, extraEnv...)
+	cmd.Env = env
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	require.NoError(t, cmd.Start())
+	return cmd
+}
+
 // waitForPidAlive polls until syscall.Kill(pid, 0) returns nil (process
 // exists) or the deadline passes. Used to ensure the helper has installed
 // its signal handler before the parent sends SIGTERM.
@@ -195,4 +214,114 @@ func TestSoftKillProcess_AlreadyDeadIsNoop(t *testing.T) {
 	// freshly-reaped pid within the same goroutine this is stable.
 	usedSIGKILL := softKillProcess(pid, 100*time.Millisecond)
 	assert.False(t, usedSIGKILL, "already-dead pid should not trigger SIGKILL")
+}
+
+// TestControlPipeClose_TerminatesCleanlyOnSIGTERM is the process-group
+// analogue of TestKillStaleControlClients_TerminatesCleanlyOnSIGTERM.
+// It exercises softKillProcessGroup, the helper now invoked by
+// ControlPipe.Close() to tear down the agent-deck-owned `tmux -C` child.
+//
+// Regression guard for the gap left by #739: that PR softened
+// killStaleControlClients but missed ControlPipe.Close(), which still
+// SIGKILL'd the active control pipe and continued to crash tmux 3.6a
+// via the unfixed NULL-deref in tmux/tmux#4980.
+func TestControlPipeClose_TerminatesCleanlyOnSIGTERM(t *testing.T) {
+	tmpDir := t.TempDir()
+	marker := filepath.Join(tmpDir, "term-handled")
+
+	cmd := spawnHelperInOwnGroup(t, "clean", "MARKER="+marker)
+	pid := cmd.Process.Pid
+	pgid, err := syscall.Getpgid(pid)
+	require.NoError(t, err)
+	// Sanity: child must be group leader of its own group, not sharing
+	// the test runner's pgid. Without this, kill(-pgid) would also
+	// signal the test binary.
+	require.Equal(t, pid, pgid, "child must be its own pgroup leader")
+
+	waitDone := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		<-waitDone
+	})
+
+	waitForPidAlive(pid, 1*time.Second)
+
+	_ = softKillProcessGroup(pgid, 500*time.Millisecond)
+
+	select {
+	case <-waitDone:
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// Marker existence proves the SIGTERM handler ran — SIGKILL cannot
+	// be trapped, so a missing marker means softKillProcessGroup
+	// skipped SIGTERM and went straight to SIGKILL.
+	_, err = os.Stat(marker)
+	assert.NoError(t, err, "child's SIGTERM handler must have run (marker file must exist)")
+
+	err = syscall.Kill(pid, 0)
+	assert.True(t, errors.Is(err, syscall.ESRCH), "child process should be fully reaped; got err=%v", err)
+}
+
+// TestControlPipeClose_FallsBackToSIGKILL is the pgroup analogue of
+// TestKillStaleControlClients_FallsBackToSIGKILL. When the control
+// client ignores SIGTERM, softKillProcessGroup must still reap it via
+// SIGKILL within roughly the grace window — preserving the original
+// "stuck clients cannot linger" guarantee that the unsoftened SIGKILL
+// in Close() previously enforced.
+func TestControlPipeClose_FallsBackToSIGKILL(t *testing.T) {
+	cmd := spawnHelperInOwnGroup(t, "ignore")
+	pid := cmd.Process.Pid
+	pgid, err := syscall.Getpgid(pid)
+	require.NoError(t, err)
+	require.Equal(t, pid, pgid, "child must be its own pgroup leader")
+
+	waitDone := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		<-waitDone
+	})
+
+	waitForPidAlive(pid, 1*time.Second)
+
+	start := time.Now()
+	usedSIGKILL := softKillProcessGroup(pgid, 500*time.Millisecond)
+	elapsed := time.Since(start)
+
+	select {
+	case <-waitDone:
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	assert.True(t, usedSIGKILL, "softKillProcessGroup must escalate to SIGKILL when TERM is ignored")
+	assert.Less(t, elapsed, 1500*time.Millisecond, "softKillProcessGroup should return promptly after grace")
+
+	err = syscall.Kill(pid, 0)
+	assert.True(t, errors.Is(err, syscall.ESRCH), "child process should be dead after SIGKILL; got err=%v", err)
+}
+
+// TestSoftKillProcessGroup_AlreadyDeadIsNoop asserts that calling
+// softKillProcessGroup on a pgid whose group is already empty returns
+// false (no SIGKILL escalation) and does not panic — mirrors
+// TestSoftKillProcess_AlreadyDeadIsNoop.
+func TestSoftKillProcessGroup_AlreadyDeadIsNoop(t *testing.T) {
+	// Spawn a single-process group, reap it, then soft-kill the empty pgid.
+	cmd := exec.Command("sh", "-c", "exit 0")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+	pgid, err := syscall.Getpgid(pid)
+	require.NoError(t, err)
+	_, _ = cmd.Process.Wait() // fully reap; group is now empty
+
+	usedSIGKILL := softKillProcessGroup(pgid, 100*time.Millisecond)
+	assert.False(t, usedSIGKILL, "already-empty pgroup should not trigger SIGKILL")
 }


### PR DESCRIPTION
# fix(tmux): soften `ControlPipe.Close()` to SIGTERM+grace (closes #739 gap)

## Summary

PR #739 (v1.7.68) softened agent-deck's SIGKILL on stale control clients to a SIGTERM+grace+SIGKILL escalation, mitigating the macOS Homebrew tmux 3.6a server-crash race ([tmux/tmux#4980](https://github.com/tmux/tmux/issues/4980)). That fix only covered the `killStaleControlClients` path. The `ControlPipe.Close()` path — which kills agent-deck's *own* `tmux -C attach-session` child on every session removal, reconnect, and shutdown — still did an immediate `kill(-pgid, SIGKILL)` and continued to crash the server.

This PR closes that gap: same SIGTERM+grace pattern, applied to the active-pipe close path.

## The bug we missed

I'm running v1.7.70. Two fresh `tmux` segfaults on 2026-04-27 (10:43 PT and 13:35 PT), both with the identical #4980 signature:

```
EXC_BAD_ACCESS (SIGSEGV) — KERN_INVALID_ADDRESS at 0x0000000000000020
  control_write + 40
  control_notify_client_detached + 76
  notify_callback + 312
  cmdq_next + 416
  server_loop + 52
  proc_loop + 68
  server_start + 600
  client_main + 1040
```

That's the same NULL deref tmux/tmux#4980 describes — server walks `control_state` of a control-mode client whose state has been freed.

The crash signature pointed away from "stale clients" and toward agent-deck's *own* control pipe being torn down. Tracing in `internal/tmux/`:

- **`killStaleControlClients`** at `pipemanager.go:443` was softened by #739. ✓
- **`ControlPipe.Close()`** at `controlpipe.go:352` was not. It does `cp.stdin.Close()` then immediately `_ = syscall.Kill(-pgid, syscall.SIGKILL)` on the active control pipe. ✗

That `Close()` runs in normal operation, not just edge-case cleanup:

| Caller | Trigger |
| --- | --- |
| `pipemanager.go:68` (`Connect` → `existing.Close()`) | Reconnecting an already-tracked session |
| `pipemanager.go:103` (`pipe.Close() // Discard the one we just created`) | TOCTOU race during pipe creation |
| `pipemanager.go:128` (`Disconnect` → `pipe.Close()`) | Per-session removal |
| `pipemanager.go:319` (`PipeManager.Close()` shutdown loop) | Agent-deck shutting down |
| `controlpipe.go:144`, `:153` (handshake-failure paths in `NewControlPipe`) | Pipe creation aborted |

Every one of these races tmux's notify path on 3.6a, and any of them can take down the entire server (and with it, every agent-deck session on that socket).

## The fix

Mirror #739's pattern for the process-group case.

**`internal/tmux/pipemanager.go`** — add `softKillProcessGroup(pgid, grace)` next to the existing `softKillProcess`. Same shape: SIGTERM → 5ms-poll → SIGKILL fallback at `controlClientKillGrace = 500ms`. Same ESRCH-as-already-dead semantics. Same return convention (`true` iff SIGKILL was ultimately used). The only difference is `-pgid` instead of `pid` in the kill targets — preserves the original `Close()`'s pgroup semantics so any subprocesses tmux may have spawned are still reaped.

**`internal/tmux/controlpipe.go`** — `Close()` now calls `softKillProcessGroup` after `cp.stdin.Close()`. The pgid-lookup-failure fallback now calls `softKillProcess` instead of immediate `cmd.Process.Kill`, so even that branch matches the family.

```go
if cp.cmd.Process != nil {
    pgid, err := syscall.Getpgid(cp.cmd.Process.Pid)
    if err == nil {
        _ = softKillProcessGroup(pgid, controlClientKillGrace)
    } else {
        // Pgid lookup failed — fall back to single-pid soft-kill.
        _ = softKillProcess(cp.cmd.Process.Pid, controlClientKillGrace)
    }
}
```

The `cp.stdin.Close()` already gives tmux's `tmux -C` child an EOF — under cooperative shutdown it exits cleanly and the SIGTERM is a no-op (ESRCH on the polling probe). The grace just ensures we don't race the EOF-driven shutdown when the kernel hasn't yet fully torn down `control_state`.

## Tests

Three new tests in `internal/tmux/softkill_test.go`, mirroring the structure of `TestKillStaleControlClients_*` from #739. All RED on the unsoftened `Close()`, GREEN here.

- **`TestControlPipeClose_TerminatesCleanlyOnSIGTERM`** — child traps SIGTERM and writes a marker file before exiting. Marker existence proves the SIGTERM handler ran (SIGKILL cannot be trapped, so a missing marker would be the regression).
- **`TestControlPipeClose_FallsBackToSIGKILL`** — child installs a no-op SIGTERM handler and blocks forever. Asserts `usedSIGKILL == true` and elapsed time stays under 1.5× grace. Preserves the original "stuck clients cannot linger" guarantee.
- **`TestSoftKillProcessGroup_AlreadyDeadIsNoop`** — already-empty group; ensures we don't escalate when there's nothing to kill.

A new `spawnHelperInOwnGroup` helper puts the child in its own process group via `cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}`. Without that isolation, `kill(-pgid, ...)` would also signal the test runner. Tests assert `pid == pgid` before signaling as a defensive guard against the helper somehow inheriting the parent's group.

```
$ go test -race ./internal/tmux/ -run "Test(ControlPipeClose|SoftKillProcessGroup)" -count=3
=== RUN   TestControlPipeClose_TerminatesCleanlyOnSIGTERM
--- PASS: TestControlPipeClose_TerminatesCleanlyOnSIGTERM (0.56s)
=== RUN   TestControlPipeClose_FallsBackToSIGKILL
--- PASS: TestControlPipeClose_FallsBackToSIGKILL (0.56s)
=== RUN   TestSoftKillProcessGroup_AlreadyDeadIsNoop
--- PASS: TestSoftKillProcessGroup_AlreadyDeadIsNoop (0.01s)
... (3 iterations, 9/9 passes)
PASS
ok  	github.com/asheshgoplani/agent-deck/internal/tmux	5.097s
```

The pre-existing softkill suite (`TestKillStaleControlClients_*`, `TestSoftKillProcess_*`) is untouched and still passes.

## Latency considerations for reviewers

`Close()` now blocks up to 500ms in the worst case (stuck client) versus microseconds before. Two reasons this is acceptable in practice:

**Typical case is much faster than the worst case.** When the tmux child exits cleanly (SIGTERM-handled or EOF-driven), its stdout closes, and the existing `reader` goroutine's defer at `controlpipe.go:180` calls `cp.reap()` which runs `cmd.Wait()` and clears the zombie. Once reaped, `softKillProcessGroup`'s `kill(-pgid, 0)` probe returns ESRCH and the polling loop returns early (typically tens of milliseconds). The 500ms is a ceiling, not a floor.

**`PipeManager.Close()` iterates pipes serially.** Worst-case shutdown after this fix is N × 500ms. For typical N (5–10 sessions) with cooperative tmux this is comfortably sub-second; for pathological N + stuck clients it could reach several seconds. Parallelizing `PipeManager.Close()` with an `errgroup` is a reasonable follow-up — every `Close()` is independent — but I kept it out of scope here so this PR stays narrow against #739.

## What this PR does *not* attempt

- It does not address [tmux/tmux#5024](https://github.com/tmux/tmux/issues/5024) (the `tty_draw_line` livelock in tmux HEAD). That's an upstream-only fix.
- It does not parallelize `PipeManager.Close()`.
- It does not change the v1.7.68 vulnerable-version startup warning. That message is still accurate — agent-deck is still mitigating around an unfixed upstream bug.

## Risk

Low.

- The change is structurally identical to the merged-and-deployed pattern in #739, just applied to a different call site.
- Pgid-kill semantics are preserved exactly from the prior `Close()` implementation.
- The pgid-lookup-failure fallback is now safer (soft-kill instead of immediate SIGKILL).
- Tests cover both the clean and the fallback paths.
- No production behaviour changes for any non-failure code path other than added latency on `Close()`.

Closes the residual #739 / tmux/tmux#4980 crash path.
