### PR TITLE
fix(web): enable web mutations via config.toml and wire missing mutator (#781)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -691,7 +691,7 @@ func main() {
 		liveMenuData := web.NewMemoryMenuData(fallbackMenuData)
 		homeModel.SetWebMenuData(liveMenuData)
 
-		server, err := buildWebServer(effectiveProfile, webArgs, liveMenuData)
+		server, err := buildWebServer(effectiveProfile, webArgs, liveMenuData, ui.NewWebMutator(homeModel))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: web server setup failed: %v\n", err)
 			os.Exit(1)

--- a/cmd/agent-deck/web_cmd.go
+++ b/cmd/agent-deck/web_cmd.go
@@ -12,7 +12,12 @@ import (
 
 // buildWebServer parses web-specific flags and returns a ready-to-start server.
 // The caller is responsible for calling server.Start() and server.Shutdown().
-func buildWebServer(profile string, args []string, menuData web.MenuDataLoader) (*web.Server, error) {
+//
+// mutator is wired via Server.SetMutator. Pass nil only in tests that don't
+// exercise mutation handlers — production callers MUST pass a real mutator
+// or every POST/PATCH/DELETE will 503 with NOT_IMPLEMENTED. See
+// TestBuildWebServer_WiresMutator for the regression guard on this contract.
+func buildWebServer(profile string, args []string, menuData web.MenuDataLoader, mutator web.SessionMutator) (*web.Server, error) {
 	fs := flag.NewFlagSet("web", flag.ContinueOnError)
 	listenAddr := fs.String("listen", "127.0.0.1:8420", "Listen address for web server")
 	readOnly := fs.Bool("read-only", false, "Run in read-only mode (input disabled)")
@@ -76,6 +81,7 @@ func buildWebServer(profile string, args []string, menuData web.MenuDataLoader) 
 		ListenAddr:          *listenAddr,
 		Profile:             effectiveProfile,
 		ReadOnly:            *readOnly,
+		WebMutations:        resolveMutationsEnabled(*readOnly),
 		Token:               *token,
 		MenuData:            menuData,
 		PushVAPIDPublicKey:  resolvedPushPublic,
@@ -84,5 +90,19 @@ func buildWebServer(profile string, args []string, menuData web.MenuDataLoader) 
 		PushTestInterval:    *pushTestEvery,
 	})
 
+	if mutator != nil {
+		server.SetMutator(mutator)
+	}
+
 	return server, nil
+}
+
+// resolveMutationsEnabled applies precedence: --read-only forces mutations off;
+// otherwise the value comes from config.toml `[web].mutations_enabled`, which
+// defaults to true when unset.
+func resolveMutationsEnabled(readOnly bool) bool {
+	if readOnly {
+		return false
+	}
+	return session.GetWebMutationsEnabled()
 }

--- a/cmd/agent-deck/web_cmd_test.go
+++ b/cmd/agent-deck/web_cmd_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/ui"
+	"github.com/asheshgoplani/agent-deck/internal/web"
+)
+
+// noopMutator implements web.SessionMutator with stubs that never run. It's
+// only used to verify that buildWebServer wires whatever is passed in.
+type noopMutator struct{}
+
+func (noopMutator) CreateSession(string, string, string, string) (string, error) {
+	return "", nil
+}
+func (noopMutator) StartSession(string) error            { return nil }
+func (noopMutator) StopSession(string) error             { return nil }
+func (noopMutator) RestartSession(string) error          { return nil }
+func (noopMutator) DeleteSession(string) error           { return nil }
+func (noopMutator) ForkSession(string) (string, error)   { return "", nil }
+func (noopMutator) CreateGroup(string, string) (string, error) {
+	return "", nil
+}
+func (noopMutator) RenameGroup(string, string) error { return nil }
+func (noopMutator) DeleteGroup(string) error         { return nil }
+
+// Compile-time guard that ui.WebMutator continues to satisfy
+// web.SessionMutator. Catches accidental signature drift between the two
+// packages — the kind of break that would otherwise only surface at runtime.
+var _ web.SessionMutator = (*ui.WebMutator)(nil)
+
+// withTempHomeAndConfig is the same fixture used by internal/session tests:
+// point HOME at a temp dir, optionally write config.toml, and clear the
+// session.LoadUserConfig cache. Restores HOME and clears the cache on cleanup.
+func withTempHomeAndConfig(t *testing.T, contents string) {
+	t.Helper()
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	t.Cleanup(func() {
+		os.Setenv("HOME", originalHome)
+		session.ClearUserConfigCache()
+	})
+	session.ClearUserConfigCache()
+
+	if contents != "" {
+		agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+		if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDeckDir, "config.toml"), []byte(contents), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+}
+
+func TestResolveMutations_DefaultsToTrue(t *testing.T) {
+	withTempHomeAndConfig(t, "")
+	if !resolveMutationsEnabled(false) {
+		t.Errorf("resolveMutationsEnabled(false) = false, want true with empty config")
+	}
+}
+
+func TestResolveMutations_TOMLDisables(t *testing.T) {
+	withTempHomeAndConfig(t, `
+[web]
+mutations_enabled = false
+`)
+	if resolveMutationsEnabled(false) {
+		t.Errorf("resolveMutationsEnabled(false) = true, want false when TOML disables mutations")
+	}
+}
+
+func TestResolveMutations_ReadOnlyForcesOff(t *testing.T) {
+	withTempHomeAndConfig(t, `
+[web]
+mutations_enabled = true
+`)
+	if resolveMutationsEnabled(true) {
+		t.Errorf("resolveMutationsEnabled(true) = true, want false (--read-only must override TOML true)")
+	}
+}
+
+func TestResolveMutations_ReadOnlyAndTOMLFalse(t *testing.T) {
+	withTempHomeAndConfig(t, `
+[web]
+mutations_enabled = false
+`)
+	if resolveMutationsEnabled(true) {
+		t.Errorf("resolveMutationsEnabled(true) = true, want false when both are off")
+	}
+}
+
+// TestBuildWebServer_WiresMutator is a regression guard for the bootstrap-side
+// of the v1.7.71 "web mutations are disabled / mutations not available" bug.
+//
+// Prior to the fix, cmd/agent-deck/main.go built the web server but never
+// called server.SetMutator. The unit-test suite passed because every handler
+// test injects a fakeMutator directly; the integration was never exercised.
+// At runtime every POST/PATCH/DELETE returned 503 NOT_IMPLEMENTED.
+//
+// This test locks the contract: buildWebServer MUST forward whatever
+// mutator the caller passes to the returned Server, so that deleting the
+// SetMutator call in main.go fails CI rather than silently shipping.
+func TestBuildWebServer_WiresMutator(t *testing.T) {
+	withTempHomeAndConfig(t, "")
+
+	server, err := buildWebServer("test-profile", []string{"--listen", "127.0.0.1:0"}, nil, noopMutator{})
+	if err != nil {
+		t.Fatalf("buildWebServer: %v", err)
+	}
+	if !server.HasMutator() {
+		t.Fatal("buildWebServer returned a Server with no mutator wired — main.go's POST/PATCH/DELETE handlers will 503 NOT_IMPLEMENTED at runtime")
+	}
+}
+
+// TestBuildWebServer_NilMutator_StaysUnwired verifies the test-only escape
+// hatch: passing nil leaves HasMutator() false. Documents that production
+// callers must pass a real mutator; the nil branch exists for tests that
+// don't exercise mutations.
+func TestBuildWebServer_NilMutator_StaysUnwired(t *testing.T) {
+	withTempHomeAndConfig(t, "")
+
+	server, err := buildWebServer("test-profile", []string{"--listen", "127.0.0.1:0"}, nil, nil)
+	if err != nil {
+		t.Fatalf("buildWebServer: %v", err)
+	}
+	if server.HasMutator() {
+		t.Fatal("buildWebServer wired a mutator when nil was passed — nil should be a no-op for the test escape hatch")
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -166,6 +166,16 @@ type UserConfig struct {
 	// writes directly to the host terminal (iTerm2 badge, etc), distinct
 	// from anything tmux draws. Empty/absent uses defaults; see TerminalSettings.
 	Terminal TerminalSettings `toml:"terminal"`
+
+	// Web defines `agent-deck web` HTTP server settings.
+	Web WebSettings `toml:"web"`
+}
+
+// WebSettings configures the `agent-deck web` HTTP server.
+type WebSettings struct {
+	// MutationsEnabled controls whether POST/PATCH/DELETE endpoints accept
+	// requests. nil (omitted) defaults to true. Forced off by --read-only.
+	MutationsEnabled *bool `toml:"mutations_enabled"`
 }
 
 // FeedbackSettings controls the in-product feedback prompts.
@@ -1883,6 +1893,17 @@ func GetDefaultTool() string {
 		return ""
 	}
 	return config.DefaultTool
+}
+
+// GetWebMutationsEnabled returns whether `agent-deck web` should accept
+// mutating HTTP requests (POST/PATCH/DELETE). Defaults to true when the
+// `[web].mutations_enabled` key is omitted from config.toml.
+func GetWebMutationsEnabled() bool {
+	config, err := LoadUserConfig()
+	if err != nil || config == nil || config.Web.MutationsEnabled == nil {
+		return true
+	}
+	return *config.Web.MutationsEnabled
 }
 
 // GetHotkeyOverrides returns user-configured hotkey overrides from config.toml.

--- a/internal/session/userconfig_web_test.go
+++ b/internal/session/userconfig_web_test.go
@@ -1,0 +1,71 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withTempHomeAndConfig sets HOME to a temp dir, writes the given config.toml
+// contents (or no file when contents is empty), clears the user-config cache,
+// and registers cleanup that restores HOME and clears the cache again. It
+// returns the temp dir for tests that need to inspect the path.
+func withTempHomeAndConfig(t *testing.T, contents string) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	t.Cleanup(func() {
+		os.Setenv("HOME", originalHome)
+		ClearUserConfigCache()
+	})
+	ClearUserConfigCache()
+
+	if contents != "" {
+		agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+		if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(agentDeckDir, "config.toml"), []byte(contents), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+	return tempDir
+}
+
+func TestWebSettings_DefaultsTrueWhenAbsent(t *testing.T) {
+	withTempHomeAndConfig(t, `
+[claude]
+config_dir = "~/.claude"
+`)
+	if !GetWebMutationsEnabled() {
+		t.Errorf("GetWebMutationsEnabled() = false, want true when [web] is absent")
+	}
+}
+
+func TestWebSettings_DefaultsTrueWhenNoConfigFile(t *testing.T) {
+	withTempHomeAndConfig(t, "")
+	if !GetWebMutationsEnabled() {
+		t.Errorf("GetWebMutationsEnabled() = false, want true when config.toml is missing")
+	}
+}
+
+func TestWebSettings_ExplicitTrue(t *testing.T) {
+	withTempHomeAndConfig(t, `
+[web]
+mutations_enabled = true
+`)
+	if !GetWebMutationsEnabled() {
+		t.Errorf("GetWebMutationsEnabled() = false, want true when explicitly enabled")
+	}
+}
+
+func TestWebSettings_ExplicitFalse(t *testing.T) {
+	withTempHomeAndConfig(t, `
+[web]
+mutations_enabled = false
+`)
+	if GetWebMutationsEnabled() {
+		t.Errorf("GetWebMutationsEnabled() = true, want false when explicitly disabled")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -272,6 +272,14 @@ func (s *Server) SetMutator(m SessionMutator) {
 	s.mutator = m
 }
 
+// HasMutator reports whether a SessionMutator has been wired. Mutating
+// endpoints (POST/PATCH/DELETE) return 503 NOT_IMPLEMENTED when this is
+// false, even if WebMutations is true. Exposed for regression tests on the
+// `agent-deck web` bootstrap path.
+func (s *Server) HasMutator() bool {
+	return s.mutator != nil
+}
+
 func (s *Server) notifyMenuChanged() {
 	s.menuSubscribersMu.Lock()
 	for ch := range s.menuSubscribers {


### PR DESCRIPTION
## Summary

Fixes #781. `agent-deck web` could not perform any mutation (create group, create/start/stop session, etc.) since the web app redesign in #519. Two independent bugs combined:

1. **`Config.WebMutations` defaulted to false** because `cmd/agent-deck/web_cmd.go` never set it. Result: every `POST/PATCH/DELETE` returned **403 `web mutations are disabled`** out of the box, with no user-accessible toggle.
2. **`main.go` never called `server.SetMutator(...)`**, so `s.mutator == nil` and every handler short-circuited with **503 `NOT_IMPLEMENTED` ("mutations not available")** even after the first gate was bypassed.

The unit-test suite was structurally blind to bug #2: every handler test injects `fakeMutator` directly into the `Server` struct, so the bootstrap path from `main.go` has zero coverage. `cmd/agent-deck-test-server` (the Playwright e2e harness) also never called `SetMutator`.

## What changed

- **New `[web].mutations_enabled` key in `config.toml`.** Defaults to `true` when omitted; `--read-only` forces it off regardless. Backed by a `WebSettings` struct on `UserConfig` and a `session.GetWebMutationsEnabled()` getter following the existing TOML domain-table pattern (mirrors `FeedbackSettings`, `UpdateSettings`, etc.).
- **`buildWebServer` now takes a `web.SessionMutator`** and wires it itself, so `main.go`'s `ui.NewWebMutator(homeModel)` flows through one parameter. The standalone `server.SetMutator` call has been removed.
- **New `Server.HasMutator() bool`** getter exposed solely so the bootstrap wiring can be regression-tested.

Default-on rationale: PR #519 introduced the gate with no documented rationale (no comments, no `CHANGELOG.md` entry, no RFC). `--read-only` already covers the "kill mutations for this invocation" use case, and treating the false default as an unintended regression restores pre-#519 behavior. Users who want a read-only-data-only HTTP API can opt in by setting `mutations_enabled = false`.

## Example config

```toml
[web]
# Enable mutating endpoints (POST/PATCH/DELETE) in `agent-deck web`.
# Default: true. Set to false to expose a read-data-only HTTP API.
# Note: --read-only on the CLI forces this off regardless of this setting.
mutations_enabled = true
```

## Tests

New regression coverage (all six pass):

- `TestBuildWebServer_WiresMutator` — fails loudly if the `SetMutator` wiring is ever removed from `buildWebServer`. Verified by sabotaging the line during development; test failed with the exact diagnostic.
- `TestBuildWebServer_NilMutator_StaysUnwired` — documents the test-only nil escape hatch.
- `TestResolveMutations_{DefaultsToTrue,TOMLDisables,ReadOnlyForcesOff,ReadOnlyAndTOMLFalse}` — pin precedence: `--read-only` > TOML > default-true.
- `TestWebSettings_{DefaultsTrueWhenAbsent,DefaultsTrueWhenNoConfigFile,ExplicitTrue,ExplicitFalse}` — TOML decode coverage.
- Compile-time guard `var _ web.SessionMutator = (*ui.WebMutator)(nil)` catches future signature drift between the interface in `internal/web` and the impl in `internal/ui`.

Existing handler-level tests for the 403 (`WebMutations: false`) and 503 (`mutator == nil`) paths are unchanged.

Mandatory CLAUDE.md gates pass:

```
go test -run TestPersistence_ ./internal/session/... -race -count=1   # ok
go test ./internal/web/... -race -count=1                              # ok
go test ./cmd/agent-deck/... -race -count=1                            # ok
```

## Test plan

- [x] `make build`
- [x] `go test ./cmd/agent-deck/... ./internal/web/... -race -count=1`
- [x] `go test -run TestPersistence_ ./internal/session/... -race -count=1`
- [x] Manual smoke: `./build/agent-deck -p web-mutations-test web --listen 127.0.0.1:8421` — `POST /api/groups` returns 201; `/healthz` reports `webMutations: true`.
- [x] Manual smoke: `--read-only` flag still 403s mutations.
- [x] Manual smoke: `[web].mutations_enabled = false` in `config.toml` 403s mutations.
- [ ] Reviewer to confirm `webMutations: false` UX in the SPA (mutation controls hide gracefully).
- [ ] Reviewer judgment: should the per-profile override `[profiles.<name>.web]` follow up in a separate PR? Out of scope here.

## Risks / follow-ups

- The `agent-deck-test-server` e2e harness still hardcodes `WebMutations: true` — intentional, since its job is to provide a known-mutable server independent of the developer's `config.toml`. No change.
- This PR does not add an `eval` case under `tests/eval/`. The `TestBuildWebServer_WiresMutator` regression guard catches the structural regression at unit-test speed; a behavioral eval that boots the binary and exercises `POST /api/groups` end-to-end would be a stronger net but is a follow-up — happy to add it on request.
- Per-profile override (`UserConfig.Profiles[name].Web`) is a plausible future ask but out of scope.