### PR TITLE
chore(release): v1.7.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.7.71] - 2026-04-28
+
+Single-issue hotfix-class release. One day after v1.7.70.
 
 ### Fixed
 

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -36,7 +36,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.70" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.71" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (


### PR DESCRIPTION
Single-issue hotfix-class release one day after v1.7.70.

## What's in

- **fix(session): set-parent no longer silently moves group (#786 / #787)** — `agent-deck session set-parent` previously rewrote child group to match parent's group while `unset-parent` only cleared parent_session_id, an asymmetric footgun that scrambled the TUI tree on retroactive relinks. Group now strictly preserved by default; `--inherit-group` opts back in. Locked in by 5 regression tests.

## Verification

- 5/5 new tests in cmd/agent-deck/setparent_group_test.go pass
- Full `go test ./... -race` green
- Live repro in clean profile confirmed group preserved post set-parent