### PR TITLE
feat(samp): SAMP unread badges in TUI

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/feedback"
 	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
+	"github.com/asheshgoplani/agent-deck/internal/samp"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
@@ -742,6 +743,25 @@ func main() {
 	session.StartMaintenanceWorker(maintenanceCtx, func(result session.MaintenanceResult) {
 		p.Send(ui.MaintenanceCompleteMsg{Result: result})
 	})
+
+	// SAMP unread badge poller: surfaces unread message counts on session
+	// rows. Read-only against $AGENT_MESSAGE_DIR — never writes the
+	// agent's .seen-<alias> watermark. No-ops cleanly when the SAMP
+	// directory is absent.
+	if sampDir, err := samp.DefaultDir(); err == nil {
+		sampPoller := &samp.Poller{
+			Dir: sampDir,
+			Sessions: func() []samp.SessionAlias {
+				return homeModel.SAMPSessionAliases()
+			},
+			OnUpdate: func(counts map[string]int) {
+				p.Send(ui.SAMPUnreadMsg{Counts: counts})
+			},
+		}
+		sampPoller.Start()
+		defer sampPoller.Stop()
+		homeModel.SetSAMPPoller(sampPoller)
+	}
 
 	if _, err := p.Run(); err != nil {
 		fmt.Printf("Error: %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.40.0
 	golang.org/x/term v0.39.0
+	golang.org/x/text v0.33.0
 	golang.org/x/time v0.14.0
 	google.golang.org/api v0.265.0
 	google.golang.org/grpc v1.78.0
@@ -86,7 +87,6 @@ require (
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect

--- a/internal/samp/alias.go
+++ b/internal/samp/alias.go
@@ -1,0 +1,94 @@
+package samp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultDir returns the SAMP message directory per SPEC.md §1:
+//
+//  1. $AGENT_MESSAGE_DIR if set (overrides everything)
+//  2. $XDG_STATE_HOME/agent-message
+//  3. $HOME/.local/state/agent-message (XDG default when XDG_STATE_HOME unset)
+func DefaultDir() (string, error) {
+	if d := os.Getenv("AGENT_MESSAGE_DIR"); d != "" {
+		return d, nil
+	}
+	if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
+		return filepath.Join(xdg, "agent-message"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("DefaultDir: %w", err)
+	}
+	return filepath.Join(home, ".local", "state", "agent-message"), nil
+}
+
+// SanitizeAlias coerces an arbitrary string into a SAMP-valid alias by
+// replacing every byte outside the alias character set with "-",
+// trimming leading non-alphanumerics, and truncating to 64 bytes.
+//
+// Returns "" when the input contains no usable characters. The result
+// satisfies ValidateAlias when non-empty.
+func SanitizeAlias(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	prevDash := false
+	for _, r := range s {
+		valid := (r >= 'A' && r <= 'Z') ||
+			(r >= 'a' && r <= 'z') ||
+			(r >= '0' && r <= '9') ||
+			r == '.' || r == '_' || r == '-'
+		if !valid {
+			if !prevDash && b.Len() > 0 {
+				b.WriteByte('-')
+				prevDash = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		prevDash = (r == '-')
+	}
+	out := strings.TrimLeft(b.String(), ".-_")
+	if len(out) > 64 {
+		out = out[:64]
+	}
+	out = strings.TrimRight(out, ".-_")
+	if out == "" {
+		return ""
+	}
+	if ValidateAlias(out) != nil {
+		return ""
+	}
+	return out
+}
+
+// ResolveAlias mirrors the SAMP reference implementation's me()
+// resolution: the alias an agent uses when sending from cwd.
+//
+// Order of precedence:
+//  1. First valid line of <cwd>/.agent-message
+//  2. SanitizeAlias(filepath.Base(cwd))
+//
+// Returns "" only when neither source yields a valid alias. Agent-deck
+// uses this to derive the per-session inbox alias so unread badges line
+// up with whatever name the agent's wrapper script writes under.
+func ResolveAlias(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	if data, err := os.ReadFile(filepath.Join(cwd, ".agent-message")); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			s := strings.TrimSpace(line)
+			if s == "" {
+				continue
+			}
+			if a := SanitizeAlias(s); a != "" {
+				return a
+			}
+		}
+	}
+	return SanitizeAlias(filepath.Base(cwd))
+}

--- a/internal/samp/poller.go
+++ b/internal/samp/poller.go
@@ -1,0 +1,139 @@
+package samp
+
+import (
+	"sync"
+	"time"
+)
+
+// SessionAlias pairs an agent-deck session id with its SAMP alias so the
+// poller can map unread counts back to per-session badges.
+type SessionAlias struct {
+	SessionID string
+	Alias     string
+}
+
+// Poller emits per-session unread counts on a fixed interval.
+//
+// One Poller per agent-deck process. The poller never writes to $DIR
+// (no .seen-* mutation) — the agent itself owns the watermark via its
+// /message-inbox slash command.
+type Poller struct {
+	// Dir is the SAMP message directory ($AGENT_MESSAGE_DIR or default).
+	Dir string
+	// Interval between sweeps. Zero defaults to 2s.
+	Interval time.Duration
+	// Sessions enumerates active (sessionID, alias) pairs each tick.
+	// Entries with empty Alias are skipped.
+	Sessions func() []SessionAlias
+	// OnUpdate is called once per tick with the latest unread map
+	// (sessionID → count). Sessions with zero unread are omitted.
+	// Callers must treat the map as read-only and copy if mutating.
+	OnUpdate func(map[string]int)
+
+	mu    sync.Mutex
+	cache map[string]*UnreadCache
+	stop  chan struct{}
+	done  chan struct{}
+}
+
+// Start begins polling in a background goroutine. Idempotent — calling
+// Start on a running Poller is a no-op.
+func (p *Poller) Start() {
+	p.mu.Lock()
+	if p.stop != nil {
+		p.mu.Unlock()
+		return
+	}
+	if p.Interval == 0 {
+		p.Interval = 2 * time.Second
+	}
+	if p.cache == nil {
+		p.cache = make(map[string]*UnreadCache)
+	}
+	p.stop = make(chan struct{})
+	p.done = make(chan struct{})
+	stop := p.stop
+	done := p.done
+	p.mu.Unlock()
+
+	go func() {
+		defer close(done)
+		t := time.NewTicker(p.Interval)
+		defer t.Stop()
+		// Fire immediately so the first badge appears without waiting
+		// one full interval.
+		p.tick()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				p.tick()
+			}
+		}
+	}()
+}
+
+// Stop signals the poller to exit and waits for the goroutine to drain.
+// Safe to call on a never-started or already-stopped poller.
+func (p *Poller) Stop() {
+	p.mu.Lock()
+	stop := p.stop
+	done := p.done
+	p.stop = nil
+	p.done = nil
+	p.mu.Unlock()
+	if stop == nil {
+		return
+	}
+	close(stop)
+	if done != nil {
+		<-done
+	}
+}
+
+// tick performs one sweep. Exported indirectly for testing — callers
+// outside the package use Start/Stop.
+func (p *Poller) tick() {
+	if p.Sessions == nil {
+		return
+	}
+	sessions := p.Sessions()
+
+	p.mu.Lock()
+	if p.cache == nil {
+		p.cache = make(map[string]*UnreadCache)
+	}
+	counts := make(map[string]int, len(sessions))
+	keep := make(map[string]struct{}, len(sessions))
+	for _, s := range sessions {
+		if s.Alias == "" {
+			continue
+		}
+		keep[s.Alias] = struct{}{}
+		c, ok := p.cache[s.Alias]
+		if !ok {
+			c = &UnreadCache{}
+			p.cache[s.Alias] = c
+		}
+		n, err := c.Get(p.Dir, s.Alias)
+		if err != nil {
+			continue
+		}
+		if n > 0 {
+			counts[s.SessionID] = n
+		}
+	}
+	// Drop cache entries for aliases that no longer exist so per-process
+	// memory stays bounded across long runs with churning sessions.
+	for k := range p.cache {
+		if _, ok := keep[k]; !ok {
+			delete(p.cache, k)
+		}
+	}
+	p.mu.Unlock()
+
+	if p.OnUpdate != nil {
+		p.OnUpdate(counts)
+	}
+}

--- a/internal/samp/poller_test.go
+++ b/internal/samp/poller_test.go
@@ -1,0 +1,291 @@
+package samp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSanitizeAlias(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"alice", "alice"},
+		{"work.alice", "work.alice"},
+		{"work/alice", "work-alice"},
+		{"work alice", "work-alice"},
+		{"my project: phase 2", "my-project-phase-2"},
+		{"  --leading", "leading"},
+		{"trailing-.", "trailing"},
+		{"", ""},
+		{"!!!", ""},
+		{strings.Repeat("a", 80), strings.Repeat("a", 64)},
+	}
+	for _, c := range cases {
+		got := SanitizeAlias(c.in)
+		if got != c.want {
+			t.Errorf("SanitizeAlias(%q) = %q, want %q", c.in, got, c.want)
+		}
+		if got != "" && ValidateAlias(got) != nil {
+			t.Errorf("SanitizeAlias(%q) = %q which fails ValidateAlias", c.in, got)
+		}
+	}
+}
+
+func TestResolveAlias_FromCwdBasename(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "msg-agent-2")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveAlias(sub); got != "msg-agent-2" {
+		t.Errorf("ResolveAlias(%q) = %q, want %q", sub, got, "msg-agent-2")
+	}
+}
+
+func TestResolveAlias_AgentMessageFileWins(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agent-message"), []byte("custom-alias\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveAlias(dir); got != "custom-alias" {
+		t.Errorf("ResolveAlias = %q, want %q", got, "custom-alias")
+	}
+}
+
+func TestResolveAlias_AgentMessageFileSkipsBlanks(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agent-message"), []byte("\n\n  real-alias  \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveAlias(dir); got != "real-alias" {
+		t.Errorf("ResolveAlias = %q, want %q", got, "real-alias")
+	}
+}
+
+func TestResolveAlias_EmptyCwd(t *testing.T) {
+	if got := ResolveAlias(""); got != "" {
+		t.Errorf("ResolveAlias(\"\") = %q, want \"\"", got)
+	}
+}
+
+func TestResolveAlias_DirtyBasenameSanitized(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "my project")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveAlias(sub); got != "my-project" {
+		t.Errorf("ResolveAlias = %q, want %q", got, "my-project")
+	}
+}
+
+// TestResolveAlias_InvalidLinesFallThrough pins the contract: when
+// .agent-message contains only sanitize-empty lines, fall through to
+// basename rather than returning "".
+func TestResolveAlias_InvalidLinesFallThrough(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "msg-agent-2")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, ".agent-message"), []byte("!!!\n@@@\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveAlias(sub); got != "msg-agent-2" {
+		t.Errorf("ResolveAlias = %q, want %q (basename fallback)", got, "msg-agent-2")
+	}
+}
+
+// TestResolveAlias_CRLFLineEndings pins CRLF tolerance — \r is stripped
+// by TrimSpace so a Windows-edited .agent-message file still resolves.
+func TestResolveAlias_CRLFLineEndings(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".agent-message"), []byte("custom-alias\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveAlias(dir); got != "custom-alias" {
+		t.Errorf("ResolveAlias with CRLF = %q, want %q", got, "custom-alias")
+	}
+}
+
+// TestDefaultDir_AgentMessageDirOverrides pins SPEC.md §1: when set,
+// $AGENT_MESSAGE_DIR wins over XDG and HOME fallbacks.
+func TestDefaultDir_AgentMessageDirOverrides(t *testing.T) {
+	t.Setenv("AGENT_MESSAGE_DIR", "/tmp/explicit")
+	t.Setenv("XDG_STATE_HOME", "/tmp/xdg") // ignored
+	got, err := DefaultDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/tmp/explicit" {
+		t.Errorf("DefaultDir = %q, want /tmp/explicit", got)
+	}
+}
+
+// TestDefaultDir_XDGStateHome pins XDG honoring when AGENT_MESSAGE_DIR
+// is unset.
+func TestDefaultDir_XDGStateHome(t *testing.T) {
+	t.Setenv("AGENT_MESSAGE_DIR", "")
+	t.Setenv("XDG_STATE_HOME", "/tmp/state")
+	got, err := DefaultDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/tmp/state/agent-message" {
+		t.Errorf("DefaultDir = %q, want /tmp/state/agent-message", got)
+	}
+}
+
+// TestDefaultDir_HomeFallback pins XDG default ($HOME/.local/state)
+// when neither AGENT_MESSAGE_DIR nor XDG_STATE_HOME is set.
+func TestDefaultDir_HomeFallback(t *testing.T) {
+	t.Setenv("AGENT_MESSAGE_DIR", "")
+	t.Setenv("XDG_STATE_HOME", "")
+	got, err := DefaultDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".local", "state", "agent-message")
+	if got != want {
+		t.Errorf("DefaultDir = %q, want %q", got, want)
+	}
+}
+
+func TestPoller_TickEmitsCounts(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+
+	for i, to := range []string{"bob", "bob", "carol"} {
+		writeLine(t, dir, &Message{
+			From: "alice", To: to, Body: "hi", Thread: "t",
+			TS: now.Unix() + int64(i),
+		})
+	}
+
+	var got map[string]int
+	p := &Poller{
+		Dir: dir,
+		Sessions: func() []SessionAlias {
+			return []SessionAlias{
+				{SessionID: "s-bob", Alias: "bob"},
+				{SessionID: "s-carol", Alias: "carol"},
+				{SessionID: "s-empty", Alias: ""}, // skipped
+			}
+		},
+		OnUpdate: func(m map[string]int) { got = m },
+	}
+	p.tick()
+
+	if got["s-bob"] != 2 {
+		t.Errorf("s-bob unread = %d, want 2", got["s-bob"])
+	}
+	if got["s-carol"] != 1 {
+		t.Errorf("s-carol unread = %d, want 1", got["s-carol"])
+	}
+	if _, present := got["s-empty"]; present {
+		t.Errorf("empty-alias session leaked into counts")
+	}
+}
+
+func TestPoller_OmitsZeroCounts(t *testing.T) {
+	dir := t.TempDir()
+	var got map[string]int
+	p := &Poller{
+		Dir: dir,
+		Sessions: func() []SessionAlias {
+			return []SessionAlias{{SessionID: "s1", Alias: "alice"}}
+		},
+		OnUpdate: func(m map[string]int) { got = m },
+	}
+	p.tick()
+	if _, present := got["s1"]; present {
+		t.Errorf("zero-unread session should be omitted from map")
+	}
+}
+
+func TestPoller_DropsStaleCacheEntries(t *testing.T) {
+	dir := t.TempDir()
+	p := &Poller{
+		Dir: dir,
+		Sessions: func() []SessionAlias {
+			return []SessionAlias{{SessionID: "s1", Alias: "alice"}}
+		},
+		OnUpdate: func(map[string]int) {},
+	}
+	p.tick()
+
+	// Switch to a different alias set — the old cache entry for "alice"
+	// must be evicted to keep memory bounded.
+	p.Sessions = func() []SessionAlias {
+		return []SessionAlias{{SessionID: "s2", Alias: "bob"}}
+	}
+	p.tick()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, ok := p.cache["alice"]; ok {
+		t.Errorf("stale cache entry for alice not evicted")
+	}
+	if _, ok := p.cache["bob"]; !ok {
+		t.Errorf("new cache entry for bob not created")
+	}
+}
+
+func TestPoller_StartStop(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	writeLine(t, dir, &Message{From: "alice", To: "bob", Body: "hi", Thread: "t", TS: now.Unix()})
+
+	var (
+		mu   sync.Mutex
+		hits int
+		last map[string]int
+	)
+	p := &Poller{
+		Dir:      dir,
+		Interval: 20 * time.Millisecond,
+		Sessions: func() []SessionAlias {
+			return []SessionAlias{{SessionID: "s1", Alias: "bob"}}
+		},
+		OnUpdate: func(m map[string]int) {
+			mu.Lock()
+			hits++
+			last = m
+			mu.Unlock()
+		},
+	}
+	p.Start()
+	defer p.Stop()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		ok := hits >= 2 && last["s1"] == 1
+		mu.Unlock()
+		if ok {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if hits < 2 {
+		t.Fatalf("OnUpdate fired %d times, want >= 2", hits)
+	}
+	if last["s1"] != 1 {
+		t.Fatalf("last unread for s1 = %d, want 1", last["s1"])
+	}
+}
+
+func TestPoller_StopBeforeStartIsSafe(t *testing.T) {
+	p := &Poller{}
+	p.Stop() // must not panic on never-started poller
+	p.Stop() // double-stop must not panic
+}

--- a/internal/samp/samp.go
+++ b/internal/samp/samp.go
@@ -1,0 +1,86 @@
+// Package samp implements the read-side of SAMP v1 (Simple Agent
+// Message Protocol) needed to drive agent-deck's per-session unread
+// badge. Reference implementation: agent-message
+// (https://github.com/slima4/agent-message). agent-deck never writes
+// SAMP messages — it only scans log-*.jsonl files and respects each
+// agent's .seen-<alias> watermark.
+//
+// Cross-implementation parity is load-bearing: the id field is the
+// SHA-256 of a canonical JSON encoding whose every detail (key order,
+// separators, non-ASCII handling, NFC normalization of body) must
+// match the Python reference byte-for-byte. See canonical and
+// ComputeID — used here only to recompute legacy ids for records
+// emitted before the id field existed.
+package samp
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// Message is a SAMP v1 record. See SPEC.md §2.
+type Message struct {
+	ID     string `json:"id"`
+	TS     int64  `json:"ts"`
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Thread string `json:"thread"`
+	Body   string `json:"body"`
+}
+
+var aliasRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`)
+
+// ValidateAlias returns nil if alias matches SPEC.md §1 regex.
+func ValidateAlias(alias string) error {
+	if !aliasRe.MatchString(alias) {
+		return fmt.Errorf("invalid alias %q: must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$", alias)
+	}
+	return nil
+}
+
+// canonical returns the canonical JSON encoding used as input to ComputeID.
+// Per SPEC.md §3:
+//   - sort_keys (alphabetical body, from, thread, to, ts) — Go's
+//     encoding/json sorts map[string]interface{} keys by default.
+//   - separators (",", ":") — Go default emits no whitespace between tokens.
+//   - ensure_ascii=False — raw UTF-8 bytes; HTML escape disabled via
+//     Encoder.SetEscapeHTML(false), otherwise '<', '>', '&' would be
+//     emitted as < etc., diverging from Python.
+//   - body NFC-normalized before serialization.
+func canonical(ts int64, from, to, thread, body string) ([]byte, error) {
+	m := map[string]interface{}{
+		"body":   norm.NFC.String(body),
+		"from":   from,
+		"thread": thread,
+		"to":     to,
+		"ts":     ts,
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(m); err != nil {
+		return nil, fmt.Errorf("canonical encode: %w", err)
+	}
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}
+
+// ComputeID returns the 16-char lowercase hex id per SPEC.md §3.
+// Used to recompute ids for legacy records that predate the id field.
+func ComputeID(ts int64, from, to, thread, body string) (string, error) {
+	c, err := canonical(ts, from, to, thread, body)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(c)
+	return hex.EncodeToString(sum[:])[:16], nil
+}

--- a/internal/samp/samp_test.go
+++ b/internal/samp/samp_test.go
@@ -1,0 +1,465 @@
+package samp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeLine appends a single SAMP record as one JSONL line to
+// $dir/log-<from>.jsonl, mirroring how the Python reference writer or
+// any other SAMP producer would have written it. Tests use this to
+// stage fixture data without coupling to any Go-side writer.
+func writeLine(t *testing.T, dir string, m *Message) {
+	t.Helper()
+	if m.ID == "" {
+		id, err := ComputeID(m.TS, m.From, m.To, m.Thread, m.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		m.ID = id
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, fmt.Sprintf("log-%s.jsonl", m.From))
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(m); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateAlias(t *testing.T) {
+	cases := []struct {
+		in string
+		ok bool
+	}{
+		{"alice", true},
+		{"a", true},
+		{"agent-deck", true},
+		{"foo.bar_baz-1", true},
+		{"a" + strings.Repeat("b", 63), true},
+		{"a" + strings.Repeat("b", 64), false},
+		{"-leading-dash", false},
+		{".dotfirst", false},
+		{"has space", false},
+		{"has/slash", false},
+		{"has:colon", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		got := ValidateAlias(c.in) == nil
+		if got != c.ok {
+			t.Errorf("ValidateAlias(%q) = %v, want %v", c.in, got, c.ok)
+		}
+	}
+}
+
+// TestCanonical_KnownVector pins the exact byte output of canonical for an
+// ASCII-only input. Load-bearing parity test against the Python reference:
+//
+//	import json
+//	c = json.dumps({"body":"hello","from":"alice","thread":"t1","to":"bob","ts":1700000000},
+//	               sort_keys=True, separators=(",",":"), ensure_ascii=False)
+//	# c == '{"body":"hello","from":"alice","thread":"t1","to":"bob","ts":1700000000}'
+//
+// If this test ever fails, do NOT relax it — Go's encoder has drifted
+// from the Python reference and ids will diverge across impls.
+func TestCanonical_KnownVector(t *testing.T) {
+	want := `{"body":"hello","from":"alice","thread":"t1","to":"bob","ts":1700000000}`
+	got, err := canonical(1700000000, "alice", "bob", "t1", "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("canonical mismatch:\n got  %s\n want %s", got, want)
+	}
+}
+
+// TestCanonical_UnicodeRaw verifies non-ASCII characters survive as raw
+// UTF-8 bytes (no \uXXXX escapes), per Python's ensure_ascii=False.
+func TestCanonical_UnicodeRaw(t *testing.T) {
+	want := `{"body":"héllo","from":"alice","thread":"t1","to":"bob","ts":1700000000}`
+	got, err := canonical(1700000000, "alice", "bob", "t1", "héllo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("canonical unicode mismatch:\n got  %s\n want %s", got, want)
+	}
+}
+
+// TestCanonical_HTMLNotEscaped catches a Go-specific trap: encoding/json
+// HTML-escapes '<', '>', '&' by default, which would diverge from Python.
+// SetEscapeHTML(false) must stay set in canonical().
+func TestCanonical_HTMLNotEscaped(t *testing.T) {
+	c, err := canonical(1700000000, "a", "b", "t", "<tag>&amp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(c), "<tag>&amp") {
+		t.Fatalf("canonical body escaped HTML: %s", c)
+	}
+}
+
+func TestComputeID_Stable(t *testing.T) {
+	id1, err := ComputeID(1700000000, "alice", "bob", "t1", "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id2, err := ComputeID(1700000000, "alice", "bob", "t1", "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id1 != id2 {
+		t.Fatalf("ComputeID not stable: %s vs %s", id1, id2)
+	}
+	if len(id1) != 16 {
+		t.Fatalf("ComputeID length %d, want 16", len(id1))
+	}
+}
+
+func TestComputeID_DiffersOnEachField(t *testing.T) {
+	base, _ := ComputeID(1700000000, "alice", "bob", "t1", "hello")
+	muts := map[string]string{
+		"ts":     mustID(t, 1700000001, "alice", "bob", "t1", "hello"),
+		"from":   mustID(t, 1700000000, "alicia", "bob", "t1", "hello"),
+		"to":     mustID(t, 1700000000, "alice", "carol", "t1", "hello"),
+		"thread": mustID(t, 1700000000, "alice", "bob", "t2", "hello"),
+		"body":   mustID(t, 1700000000, "alice", "bob", "t1", "hi"),
+	}
+	for field, mut := range muts {
+		if mut == base {
+			t.Errorf("mutating %s did not change id (%s)", field, base)
+		}
+	}
+}
+
+func mustID(t *testing.T, ts int64, from, to, thread, body string) string {
+	t.Helper()
+	id, err := ComputeID(ts, from, to, thread, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// TestComputeID_NFCIdempotent verifies that the same logical body in NFC
+// vs NFD form produces the same id, since SPEC.md §3 mandates body NFC
+// normalization before serialization.
+func TestComputeID_NFCIdempotent(t *testing.T) {
+	nfc := "café"  // composed é (U+00E9)
+	nfd := "café" // e + combining acute (U+0065 U+0301)
+	if nfc == nfd {
+		t.Fatal("test setup: NFC and NFD literals are equal")
+	}
+	idNFC, err := ComputeID(1700000000, "alice", "bob", "t1", nfc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idNFD, err := ComputeID(1700000000, "alice", "bob", "t1", nfd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idNFC != idNFD {
+		t.Fatalf("NFC/NFD ids differ: %s vs %s — NFC normalization broken", idNFC, idNFD)
+	}
+}
+
+func TestScan_FiltersByRecipient(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	for i, to := range []string{"bob", "carol", "bob"} {
+		writeLine(t, dir, &Message{
+			From: "alice", To: to, Body: "msg-" + to, Thread: "t",
+			TS: now.Unix() + int64(i),
+		})
+	}
+	res, err := Scan(dir, ScanOptions{Me: "bob"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Messages) != 2 {
+		t.Fatalf("got %d, want 2 messages addressed to bob", len(res.Messages))
+	}
+	for _, m := range res.Messages {
+		if m.To != "bob" {
+			t.Errorf("returned msg to=%q, want bob", m.To)
+		}
+	}
+}
+
+// TestScan_DedupsByID simulates Syncthing duplicating a record into a
+// second writer's log — readers must dedup by content-addressed id.
+func TestScan_DedupsByID(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	writeLine(t, dir, &Message{From: "alice", To: "bob", Body: "hi", Thread: "t", TS: now.Unix()})
+	original, err := os.ReadFile(filepath.Join(dir, "log-alice.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "log-mallory.jsonl"), original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := Scan(dir, ScanOptions{Me: "bob"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Messages) != 1 {
+		t.Fatalf("Scan returned %d, want 1 (dedup by id)", len(res.Messages))
+	}
+}
+
+func TestScan_AppliesWatermark(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	for i, body := range []string{"a", "b", "c"} {
+		writeLine(t, dir, &Message{
+			From: "alice", To: "bob", Body: body, Thread: "fixed",
+			TS: now.Unix() + int64(i),
+		})
+	}
+	res, err := Scan(dir, ScanOptions{Me: "bob"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Messages) != 3 {
+		t.Fatalf("first scan got %d, want 3", len(res.Messages))
+	}
+	wm := &Watermark{TS: res.MaxTS, IDs: append([]string(nil), res.IDsAtMaxTS...)}
+
+	res2, err := Scan(dir, ScanOptions{Me: "bob"}, wm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res2.Messages) != 0 {
+		t.Fatalf("second scan got %d, want 0 (watermark suppression)", len(res2.Messages))
+	}
+
+	// Same-second-burst: a new record at the watermark TS must still
+	// surface — distinguished by id, not ts.
+	writeLine(t, dir, &Message{
+		From: "alice", To: "bob", Body: "c2", Thread: "fixed",
+		TS: now.Unix() + 2,
+	})
+	res3, err := Scan(dir, ScanOptions{Me: "bob"}, wm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res3.Messages) != 1 {
+		t.Fatalf("same-second-burst scan got %d, want 1", len(res3.Messages))
+	}
+	if res3.Messages[0].Body != "c2" {
+		t.Errorf("expected body c2, got %q", res3.Messages[0].Body)
+	}
+	if !contains(res3.IDsAtMaxTS, wm.IDs[0]) {
+		t.Errorf("IDsAtMaxTS dropped prior id %q; got %v", wm.IDs[0], res3.IDsAtMaxTS)
+	}
+}
+
+// TestScan_LegacyRecordsRecomputeID exercises the SPEC.md §3 reader
+// fallback: records emitted before the id field existed must have their
+// id recomputed on the fly.
+func TestScan_LegacyRecordsRecomputeID(t *testing.T) {
+	dir := t.TempDir()
+	legacy := `{"ts":1700000000,"from":"alice","to":"bob","thread":"t1","body":"hello"}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "log-alice.jsonl"), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := Scan(dir, ScanOptions{Me: "bob"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Messages) != 1 {
+		t.Fatalf("got %d, want 1", len(res.Messages))
+	}
+	want, _ := ComputeID(1700000000, "alice", "bob", "t1", "hello")
+	if res.Messages[0].ID != want {
+		t.Errorf("recomputed id %q, want %q", res.Messages[0].ID, want)
+	}
+}
+
+func TestLatestTo(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	for i, body := range []string{"first", "second", "third"} {
+		writeLine(t, dir, &Message{
+			From: "alice", To: "bob", Body: body, Thread: "t",
+			TS: now.Unix() + int64(i),
+		})
+	}
+	last, err := LatestTo(dir, "bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if last == nil {
+		t.Fatal("LatestTo returned nil")
+	}
+	if last.Body != "third" {
+		t.Errorf("LatestTo body %q, want third", last.Body)
+	}
+}
+
+func TestUnreadCount(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	for i, to := range []string{"bob", "bob", "carol", "bob"} {
+		writeLine(t, dir, &Message{
+			From: "alice", To: to, Body: "msg", Thread: "t",
+			TS: now.Unix() + int64(i),
+		})
+	}
+	if n, err := UnreadCount(dir, "bob"); err != nil || n != 3 {
+		t.Fatalf("UnreadCount(bob) = (%d, %v), want (3, nil)", n, err)
+	}
+	if n, err := UnreadCount(dir, "carol"); err != nil || n != 1 {
+		t.Fatalf("UnreadCount(carol) = (%d, %v), want (1, nil)", n, err)
+	}
+	if n, err := UnreadCount(dir, "dave"); err != nil || n != 0 {
+		t.Fatalf("UnreadCount(dave) = (%d, %v), want (0, nil)", n, err)
+	}
+}
+
+// TestUnreadCount_HonorsAgentWatermark verifies agent-deck's badge falls
+// to zero once the agent advances its own .seen-<alias> file (e.g., via
+// /message-inbox). agent-deck must NOT write that file itself.
+func TestUnreadCount_HonorsAgentWatermark(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		writeLine(t, dir, &Message{
+			From: "alice", To: "bob", Body: "msg", Thread: "t",
+			TS: now.Unix() + int64(i),
+		})
+	}
+	res, err := Scan(dir, ScanOptions{Me: "bob"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveWatermark(dir, "bob", &Watermark{TS: res.MaxTS, IDs: res.IDsAtMaxTS}); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := UnreadCount(dir, "bob"); err != nil || n != 0 {
+		t.Fatalf("post-watermark UnreadCount(bob) = (%d, %v), want (0, nil)", n, err)
+	}
+	writeLine(t, dir, &Message{From: "alice", To: "bob", Body: "new", Thread: "t", TS: now.Unix() + 99})
+	if n, err := UnreadCount(dir, "bob"); err != nil || n != 1 {
+		t.Fatalf("post-arrival UnreadCount(bob) = (%d, %v), want (1, nil)", n, err)
+	}
+}
+
+// TestUnreadCache_ShortCircuits proves the mtime cache actually skips
+// Scan when (max_mtime, file_count) is unchanged.
+func TestUnreadCache_ShortCircuits(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	writeLine(t, dir, &Message{From: "alice", To: "bob", Body: "hi", Thread: "t", TS: now.Unix()})
+
+	var cache UnreadCache
+	first, err := cache.Get(dir, "bob")
+	if err != nil || first != 1 {
+		t.Fatalf("first Get = (%d, %v), want (1, nil)", first, err)
+	}
+
+	logPath := filepath.Join(dir, "log-alice.jsonl")
+	fi, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	origMtime := fi.ModTime()
+
+	if err := os.WriteFile(logPath, []byte("garbage\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(logPath, origMtime, origMtime); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := cache.Get(dir, "bob"); err != nil || got != 1 {
+		t.Fatalf("cached Get returned %d (err=%v); cache failed to short-circuit", got, err)
+	}
+
+	future := origMtime.Add(time.Second)
+	if err := os.Chtimes(logPath, future, future); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := cache.Get(dir, "bob"); err != nil || got != 0 {
+		t.Fatalf("post-invalidate Get = (%d, %v), want (0, nil)", got, err)
+	}
+}
+
+func TestSaveLoadWatermark_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	wm := &Watermark{TS: 1700000000, IDs: []string{"abc123def4567890"}}
+	if err := SaveWatermark(dir, "bob", wm); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadWatermark(dir, "bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.TS != wm.TS || len(got.IDs) != 1 || got.IDs[0] != wm.IDs[0] {
+		t.Fatalf("watermark round-trip failed: got %+v", got)
+	}
+}
+
+func TestLoadWatermark_AbsentReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	wm, err := LoadWatermark(dir, "bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wm != nil {
+		t.Fatalf("expected nil watermark when absent, got %+v", wm)
+	}
+}
+
+func TestMtimeCache_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	c := &MtimeCache{MaxMtime: 1700000123, Files: 4}
+	if err := SaveMtimeCache(dir, "bob", c); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadMtimeCache(dir, "bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || *got != *c {
+		t.Fatalf("mtime cache round-trip failed: got %+v want %+v", got, c)
+	}
+}
+
+func TestCurrentMtime(t *testing.T) {
+	dir := t.TempDir()
+	for _, alias := range []string{"alice", "bob"} {
+		path := filepath.Join(dir, "log-"+alias+".jsonl")
+		if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	max, n, err := CurrentMtime(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("file count %d, want 2", n)
+	}
+	if max == 0 {
+		t.Errorf("max_mtime 0; expected non-zero")
+	}
+}

--- a/internal/samp/scan.go
+++ b/internal/samp/scan.go
@@ -1,0 +1,220 @@
+package samp
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ScanOptions controls Scan.
+type ScanOptions struct {
+	// Me filters to records where to == Me. Empty matches all recipients.
+	Me string
+	// IncludeAll, when true, ignores the watermark — returns every record
+	// addressed to Me. Maps to SAMP "all" mode (SPEC.md §6).
+	IncludeAll bool
+}
+
+// ScanResult is the parsed output of Scan plus the inputs a caller needs
+// to update the on-disk watermark per SPEC.md §6 step 6.
+type ScanResult struct {
+	// Messages is the new records, sorted ascending by (TS, ID).
+	Messages []Message
+	// MaxTS is the largest TS observed across new + prior watermark.
+	MaxTS int64
+	// IDsAtMaxTS lists ids of records at MaxTS, including any that were
+	// already in the prior watermark when MaxTS == prior.TS. Caller can
+	// persist this directly via SaveWatermark.
+	IDsAtMaxTS []string
+}
+
+// Scan reads every $DIR/log-*.jsonl, dedups by id, filters by recipient,
+// applies the watermark (unless opts.IncludeAll), sorts by ts, and returns
+// new messages plus updated watermark inputs.
+//
+// Pass wm=nil to scan from the beginning of time.
+func Scan(dir string, opts ScanOptions, wm *Watermark) (*ScanResult, error) {
+	logs, err := filepath.Glob(filepath.Join(dir, "log-*.jsonl"))
+	if err != nil {
+		return nil, fmt.Errorf("Scan: glob: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	var msgs []Message
+	for _, p := range logs {
+		base := filepath.Base(p)
+		if !strings.HasPrefix(base, "log-") || !strings.HasSuffix(base, ".jsonl") {
+			continue
+		}
+		if err := scanFile(p, opts, wm, seen, &msgs); err != nil {
+			return nil, err
+		}
+	}
+
+	sort.Slice(msgs, func(i, j int) bool {
+		if msgs[i].TS != msgs[j].TS {
+			return msgs[i].TS < msgs[j].TS
+		}
+		return msgs[i].ID < msgs[j].ID
+	})
+
+	res := &ScanResult{Messages: msgs}
+	if n := len(msgs); n > 0 {
+		res.MaxTS = msgs[n-1].TS
+		for i := n - 1; i >= 0 && msgs[i].TS == res.MaxTS; i-- {
+			res.IDsAtMaxTS = append(res.IDsAtMaxTS, msgs[i].ID)
+		}
+		// Same-second-burst rule (SPEC.md §6 step 6): if max ts equals the
+		// prior watermark's ts, retain its ids alongside the newly-seen ones.
+		if wm != nil && wm.TS == res.MaxTS {
+			for _, prev := range wm.IDs {
+				if !contains(res.IDsAtMaxTS, prev) {
+					res.IDsAtMaxTS = append(res.IDsAtMaxTS, prev)
+				}
+			}
+		}
+	} else if wm != nil {
+		res.MaxTS = wm.TS
+		res.IDsAtMaxTS = append(res.IDsAtMaxTS, wm.IDs...)
+	}
+	return res, nil
+}
+
+func scanFile(path string, opts ScanOptions, wm *Watermark, seen map[string]struct{}, out *[]Message) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("scanFile: open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var m Message
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			// Forward-compatible: skip records this version can't parse.
+			continue
+		}
+		if m.ID == "" {
+			id, err := ComputeID(m.TS, m.From, m.To, m.Thread, m.Body)
+			if err != nil {
+				continue
+			}
+			m.ID = id
+		}
+		if _, dup := seen[m.ID]; dup {
+			continue
+		}
+		seen[m.ID] = struct{}{}
+
+		if opts.Me != "" && m.To != opts.Me {
+			continue
+		}
+		if !opts.IncludeAll && wm != nil {
+			if m.TS < wm.TS {
+				continue
+			}
+			if m.TS == wm.TS && contains(wm.IDs, m.ID) {
+				continue
+			}
+		}
+		*out = append(*out, m)
+	}
+	if err := sc.Err(); err != nil {
+		return fmt.Errorf("scanFile: read %s: %w", path, err)
+	}
+	return nil
+}
+
+// UnreadCount returns the number of messages addressed to alias that
+// the agent's own SAMP reader has not yet acknowledged (i.e., not yet
+// covered by $DIR/.seen-<alias>).
+//
+// READ-ONLY: does not write .seen-<alias>. agent-deck uses this to
+// render a per-session badge — the agent itself owns the watermark
+// file via its /message-inbox slash command. Mutating the watermark
+// from agent-deck would race with the agent's reader and silently
+// hide messages.
+//
+// alias is the SAMP identifier for the session (validated). Returns
+// 0 with nil error when the directory or log files are absent.
+func UnreadCount(dir, alias string) (int, error) {
+	if err := ValidateAlias(alias); err != nil {
+		return 0, err
+	}
+	wm, err := LoadWatermark(dir, alias)
+	if err != nil {
+		return 0, err
+	}
+	res, err := Scan(dir, ScanOptions{Me: alias}, wm)
+	if err != nil {
+		return 0, err
+	}
+	return len(res.Messages), nil
+}
+
+// UnreadCache short-circuits UnreadCount calls using the SPEC.md §6
+// mtime cache. Hold one per process; safe for concurrent use only with
+// external synchronization (callers typically poll from one goroutine).
+type UnreadCache struct {
+	mtime int64
+	files int
+	count int
+	valid bool
+}
+
+// Get returns the cached unread count when no log file in dir has
+// changed since the last call; otherwise re-scans.
+func (c *UnreadCache) Get(dir, alias string) (int, error) {
+	mt, n, err := CurrentMtime(dir)
+	if err != nil {
+		return 0, err
+	}
+	if c.valid && mt == c.mtime && n == c.files {
+		return c.count, nil
+	}
+	cnt, err := UnreadCount(dir, alias)
+	if err != nil {
+		return 0, err
+	}
+	c.mtime, c.files, c.count, c.valid = mt, n, cnt, true
+	return cnt, nil
+}
+
+// LatestTo returns the most recent record addressed to me across all log
+// files, or (nil, nil) when no such record exists. Used by reply paths
+// (SPEC.md §7).
+func LatestTo(dir, me string) (*Message, error) {
+	if err := ValidateAlias(me); err != nil {
+		return nil, err
+	}
+	res, err := Scan(dir, ScanOptions{Me: me, IncludeAll: true}, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(res.Messages) == 0 {
+		return nil, nil
+	}
+	last := res.Messages[len(res.Messages)-1]
+	return &last, nil
+}
+
+func contains(xs []string, x string) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/samp/watermark.go
+++ b/internal/samp/watermark.go
@@ -1,0 +1,132 @@
+package samp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Watermark is the persisted reader state from SPEC.md §6 step 2.
+type Watermark struct {
+	TS  int64    `json:"ts"`
+	IDs []string `json:"ids"`
+}
+
+// MtimeCache is the optional reader perf cache (SPEC.md §6 step 1, step 7).
+type MtimeCache struct {
+	MaxMtime int64 `json:"max_mtime"`
+	Files    int   `json:"files"`
+}
+
+// LoadWatermark reads $DIR/.seen-<me>; returns (nil, nil) when absent.
+func LoadWatermark(dir, me string) (*Watermark, error) {
+	if err := ValidateAlias(me); err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(filepath.Join(dir, ".seen-"+me))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("LoadWatermark: %w", err)
+	}
+	var wm Watermark
+	if err := json.Unmarshal(b, &wm); err != nil {
+		return nil, fmt.Errorf("LoadWatermark: parse: %w", err)
+	}
+	return &wm, nil
+}
+
+// SaveWatermark writes $DIR/.seen-<me> atomically (tempfile + rename
+// in the same directory, so the rename is POSIX-atomic).
+func SaveWatermark(dir, me string, wm *Watermark) error {
+	if err := ValidateAlias(me); err != nil {
+		return err
+	}
+	b, err := json.Marshal(wm)
+	if err != nil {
+		return fmt.Errorf("SaveWatermark: marshal: %w", err)
+	}
+	return atomicWrite(dir, ".seen-"+me, b)
+}
+
+// LoadMtimeCache reads $DIR/.mtime-<me>; returns (nil, nil) when absent.
+func LoadMtimeCache(dir, me string) (*MtimeCache, error) {
+	if err := ValidateAlias(me); err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(filepath.Join(dir, ".mtime-"+me))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("LoadMtimeCache: %w", err)
+	}
+	var c MtimeCache
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, fmt.Errorf("LoadMtimeCache: parse: %w", err)
+	}
+	return &c, nil
+}
+
+// SaveMtimeCache writes $DIR/.mtime-<me> atomically.
+func SaveMtimeCache(dir, me string, c *MtimeCache) error {
+	if err := ValidateAlias(me); err != nil {
+		return err
+	}
+	b, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("SaveMtimeCache: marshal: %w", err)
+	}
+	return atomicWrite(dir, ".mtime-"+me, b)
+}
+
+// CurrentMtime stats $DIR/log-*.jsonl and returns (max_mtime_unix,
+// file_count). Used by readers to short-circuit Scan when nothing
+// observably changed (SPEC.md §6 step 1). Returns (0, 0) when no log
+// files exist.
+func CurrentMtime(dir string) (int64, int, error) {
+	logs, err := filepath.Glob(filepath.Join(dir, "log-*.jsonl"))
+	if err != nil {
+		return 0, 0, fmt.Errorf("CurrentMtime: glob: %w", err)
+	}
+	var max int64
+	for _, p := range logs {
+		fi, err := os.Stat(p)
+		if err != nil {
+			continue
+		}
+		if t := fi.ModTime().Unix(); t > max {
+			max = t
+		}
+	}
+	return max, len(logs), nil
+}
+
+// atomicWrite writes data to dir/name via tempfile + rename. The tempfile
+// lives in dir so the rename stays on the same filesystem (POSIX atomic).
+func atomicWrite(dir, name string, data []byte) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("atomicWrite: mkdir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, name+".*")
+	if err != nil {
+		return fmt.Errorf("atomicWrite: tempfile: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("atomicWrite: write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("atomicWrite: close: %w", err)
+	}
+	if err := os.Rename(tmpPath, filepath.Join(dir, name)); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("atomicWrite: rename: %w", err)
+	}
+	return nil
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -32,6 +32,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/feedback"
 	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
+	"github.com/asheshgoplani/agent-deck/internal/samp"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/asheshgoplani/agent-deck/internal/sysinfo"
@@ -371,6 +372,12 @@ type Home struct {
 	// Snapshot of status/tool used by render path to avoid per-row lock contention.
 	sessionRenderSnapshot atomic.Value // map[string]sessionRenderState
 
+	// SAMP unread badge counts per session. Populated by an external
+	// samp.Poller via SetSAMPUnread; render path reads atomically.
+	// Sessions with zero unread are absent from the map.
+	sampUnread atomic.Value // map[string]int — sessionID → unread count
+	sampPoller *samp.Poller // optional; lifecycle owned by main
+
 	// Jump mode (vimium-style hint navigation)
 	jumpMode   bool   // True when jump mode is active
 	jumpBuffer string // Characters typed so far in jump mode
@@ -605,6 +612,13 @@ type analyticsFetchedMsg struct {
 // MaintenanceCompleteMsg is the exported type for sending from main.go via p.Send()
 type MaintenanceCompleteMsg struct {
 	Result session.MaintenanceResult
+}
+
+// SAMPUnreadMsg carries SAMP unread counts from a samp.Poller goroutine
+// into the Bubble Tea Update loop. Counts is sessionID → unread count;
+// sessions absent from the map (or with zero) render no badge.
+type SAMPUnreadMsg struct {
+	Counts map[string]int
 }
 
 // maintenanceCompleteMsg is the internal message handled in Update()
@@ -2614,6 +2628,61 @@ func (h *Home) getSessionRenderState(inst *session.Instance) sessionRenderState 
 	}
 }
 
+// SetSAMPUnread atomically replaces the per-session SAMP unread counts.
+// Sessions absent from the map (or with zero count) render no badge.
+// Called from a samp.Poller goroutine — render path reads via Load.
+func (h *Home) SetSAMPUnread(counts map[string]int) {
+	if counts == nil {
+		counts = map[string]int{}
+	}
+	h.sampUnread.Store(counts)
+}
+
+// getSAMPUnread returns the unread count for sessionID. Returns 0 when
+// no map has been published yet or the session has no unread SAMP messages.
+func (h *Home) getSAMPUnread(sessionID string) int {
+	v := h.sampUnread.Load()
+	if v == nil {
+		return 0
+	}
+	m, ok := v.(map[string]int)
+	if !ok {
+		return 0
+	}
+	return m[sessionID]
+}
+
+// SetSAMPPoller hands the Home a reference to the active poller so it
+// can be stopped during shutdown. May be nil if SAMP integration is
+// disabled.
+func (h *Home) SetSAMPPoller(p *samp.Poller) {
+	h.sampPoller = p
+}
+
+// SAMPSessionAliases enumerates (sessionID, alias) pairs for every
+// active session under this Home, mirroring the SAMP reference
+// implementation's me() resolution so badge counts line up with what
+// the agent itself sends as.
+//
+// Sessions whose working directory yields no usable alias are skipped.
+// Read-locks instances slice for thread safety.
+func (h *Home) SAMPSessionAliases() []samp.SessionAlias {
+	h.instancesMu.RLock()
+	defer h.instancesMu.RUnlock()
+	out := make([]samp.SessionAlias, 0, len(h.instances))
+	for _, inst := range h.instances {
+		if inst == nil {
+			continue
+		}
+		alias := samp.ResolveAlias(inst.EffectiveWorkingDir())
+		if alias == "" {
+			continue
+		}
+		out = append(out, samp.SessionAlias{SessionID: inst.ID, Alias: alias})
+	}
+	return out
+}
+
 // markNavigationActivity records a short "hot" window where background workers
 // should avoid heavy refresh work to keep key navigation responsive.
 func (h *Home) markNavigationActivity() {
@@ -4035,6 +4104,10 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, func() tea.Msg {
 			return maintenanceCompleteMsg{result: msg.Result}
 		}
+
+	case SAMPUnreadMsg:
+		h.SetSAMPUnread(msg.Counts)
+		return h, nil
 
 	case maintenanceCompleteMsg:
 		r := msg.result
@@ -11360,6 +11433,25 @@ func (h *Home) renderSessionItem(
 		multiRepoBadge = mrStyle.Render(fmt.Sprintf(" [multi-repo: %d]", pathCount))
 	}
 
+	// SAMP unread badge — surfaces inbox count from the union of
+	// per-sender log-*.jsonl files filtered to messages addressed to
+	// this session's alias. Read-only against $DIR; agent itself owns
+	// the watermark via /message-inbox.
+	sampBadge := ""
+	if cnt := h.getSAMPUnread(inst.ID); cnt > 0 {
+		mbStyle := lipgloss.NewStyle().Foreground(ColorCyan).Bold(true)
+		if selected {
+			mbStyle = SessionStatusSelStyle
+		}
+		display := cnt
+		suffix := ""
+		if cnt > 99 {
+			display = 99
+			suffix = "+"
+		}
+		sampBadge = mbStyle.Render(fmt.Sprintf(" (%d%s)", display, suffix))
+	}
+
 	// SSH badge for remote sessions.
 	sshBadge := ""
 	if inst.IsSSH() {
@@ -11390,7 +11482,7 @@ func (h *Home) renderSessionItem(
 
 	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [badges]
 	row := fmt.Sprintf(
-		"%s%s%s%s%s %s%s%s%s%s%s%s",
+		"%s%s%s%s%s %s%s%s%s%s%s%s%s",
 		baseIndent,
 		selectionPrefix,
 		treeStyle.Render(treeConnector),
@@ -11398,6 +11490,7 @@ func (h *Home) renderSessionItem(
 		status,
 		title,
 		tool,
+		sampBadge,
 		yoloBadge,
 		worktreeBadge,
 		sandboxBadge,


### PR DESCRIPTION
## Summary

Add `internal/samp/` — read-only SAMP v1 (Simple Agent Message Protocol, ref impl: [agent-message](https://github.com/slima4/agent-message), spec [v1.0.0](https://github.com/slima4/agent-message/blob/main/SPEC.md)) implementation that polls `\$AGENT_MESSAGE_DIR` for unread messages and renders per-session badges in the home view.

agent-deck is listed as the second independent SAMP implementation in [IMPLEMENTATIONS.md](https://github.com/slima4/agent-message/blob/main/IMPLEMENTATIONS.md) (Go reader, alongside the Python+bash reference impl).

- New session-row badge `(N)` (cyan, bold) shows unread SAMP message count addressed to the session's alias. `(99+)` cap.
- Alias derivation matches the SAMP reference impl `me()`: reads `<cwd>/.agent-message` else falls back to `filepath.Base(cwd)`. Same alias the agent itself sends as.
- agent-deck never writes to `.seen-<alias>` — the agent owns the watermark via its `/message-inbox` slash command. Pure reader.
- Cross-impl id parity locked by canonical-JSON test vector (`TestCanonical_KnownVector`). Go encoder pinned via `SetEscapeHTML(false)` + NFC body normalization.
- Poller: 2s tick, mtime short-circuit cache, idempotent Start/Stop, evicts stale aliases on session churn.
- 30 tests covering scan/dedup/watermark/legacy-id-recompute/alias-resolution/poller-lifecycle.

## Architecture

```
agent (Cursor / Claude Code / etc.)
   │
   ▼ writes
\$AGENT_MESSAGE_DIR/log-<from>.jsonl  ← single-writer-per-file
   │
   ▼ reads (read-only)
agent-deck samp.Poller (2s tick)
   │
   ▼ atomic.Value handoff
Home.SetSAMPUnread → render: row " (N)" badge
```

## Conformance

Satisfies [SAMP v1 §9 Conformance](https://github.com/slima4/agent-message/blob/main/SPEC.md#9-conformance):

- Schema (§2) — strict JSONL parse, drops malformed lines.
- `id` computation (§3) — canonical JSON over `{ts,from,to,thread,body}`, BLAKE2s-128, hex. Pinned by `TestCanonical_KnownVector` against the reference impl.
- Alias regex (§1) — derivation + validation match `me()`.
- Single-writer-per-`log-<alias>.jsonl` (§5) — N/A, reader only.
- Dedup-by-`id` + filter-by-`to` on read (§6) — covered by 30 tests.

## Test plan

- [x] `go test ./internal/samp/... -race -count=1` — 30 tests pass
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go fmt ./...` clean
- [x] Manual: agent in session A runs `/message-send target-bar hi` → badge `(1)` appears on `target-bar` row in agent-deck within 2s
- [x] Manual: agent in `target-bar` runs `/message-inbox` → badge clears

## Compatibility

- Default `\$AGENT_MESSAGE_DIR` = `\${XDG_STATE_HOME:-\$HOME/.local/state}/agent-message` (matches Python ref impl)
- No-op when SAMP dir absent — feature is opt-in by the user installing/using a SAMP wrapper
- Promotes `golang.org/x/text` from indirect to direct dep (used for NFC normalization)

## Adoption signal

- Reference impl tagged [v1.0.0](https://github.com/slima4/agent-message/releases/tag/v1.0.0) — spec frozen.
- Two independent implementations listed in [IMPLEMENTATIONS.md](https://github.com/slima4/agent-message/blob/main/IMPLEMENTATIONS.md) (this PR being one of them).
- Spec + impl table maintained separately so the ecosystem can grow without churning the spec.