### PR TITLE
feat(remote): add SSH port forwarding support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **SSH port forwarding for remote sessions** ([#792](https://github.com/asheshgoplani/agent-deck/issues/792)). Configure `-L`/`-R`/`-D` forwards per remote via `--forward` flag on `remote add` or the new `remote forward add/remove/list` subcommands. Forwards apply to all SSH connections (attach, command execution, session fetch).
+
 ## [1.7.72] - 2026-04-28
 
 Bundle of fixes and contributor PRs, hours after v1.7.71. Two external contributors merged this cycle: @tarekrached (twice), @oryaacov.

--- a/README.md
+++ b/README.md
@@ -585,6 +585,14 @@ agent-deck remote attach dev my-session
 # Keep remote binaries up to date
 agent-deck remote update          # all remotes
 agent-deck remote update dev      # specific remote
+
+# Port forwarding — access remote services locally
+agent-deck remote add dev user@dev-box --forward L:8444:localhost:8444
+
+# Manage port forwards on an existing remote
+agent-deck remote forward add dev L:3000:localhost:3000
+agent-deck remote forward list dev
+agent-deck remote forward remove dev L:8444:localhost:8444
 ```
 
 Remote configuration is stored under `[remotes]` in `~/.agent-deck/config.toml`. All `remote` subcommands support `--json` output for scripting. Run `agent-deck remote --help` for the full flag reference.

--- a/cmd/agent-deck/remote_cmd.go
+++ b/cmd/agent-deck/remote_cmd.go
@@ -36,6 +36,8 @@ func handleRemote(profile string, args []string) {
 		handleRemoteRename(args[1:])
 	case "update":
 		handleRemoteUpdate(args[1:])
+	case "forward", "fwd":
+		handleRemoteForward(args[1:])
 	default:
 		fmt.Printf("Unknown remote command: %s\n", args[0])
 		printRemoteUsage()
@@ -56,10 +58,12 @@ func printRemoteUsage() {
 	fmt.Println("  attach <name> <session>   Attach to a remote session")
 	fmt.Println("  rename <name> <session> <new-title>  Rename a remote session")
 	fmt.Println("  update [name]             Install/update agent-deck on remote(s)")
+	fmt.Println("  forward <sub> <name> ...  Manage port forwarding (add/remove/list)")
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  agent-deck remote add dev user@dev-box")
 	fmt.Println("  agent-deck remote add prod user@prod-server --agent-deck-path /usr/local/bin/agent-deck")
+	fmt.Println("  agent-deck remote add dev user@dev-box --forward L:8444:localhost:8444")
 	fmt.Println("  agent-deck remote list")
 	fmt.Println("  agent-deck remote sessions dev")
 	fmt.Println("  agent-deck remote attach dev my-session")
@@ -72,10 +76,21 @@ func isValidRemoteName(name string) bool {
 	return name != "" && !strings.ContainsAny(name, " /\\.:")
 }
 
+// portForwardFlags implements flag.Value for repeatable --forward flags.
+type portForwardFlags []string
+
+func (p *portForwardFlags) String() string { return strings.Join(*p, ",") }
+func (p *portForwardFlags) Set(val string) error {
+	*p = append(*p, val)
+	return nil
+}
+
 func handleRemoteAdd(args []string) {
 	fs := flag.NewFlagSet("remote add", flag.ExitOnError)
 	agentDeckPath := fs.String("agent-deck-path", "", "Path to agent-deck on the remote (default: agent-deck)")
 	remoteProfile := fs.String("profile", "", "Remote profile to use (default: default)")
+	var forwards portForwardFlags
+	fs.Var(&forwards, "forward", "Port forward rule (e.g., L:8444:localhost:8444). Can be repeated.")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck remote add <name> <user@host> [options]")
@@ -107,6 +122,17 @@ func handleRemoteAdd(args []string) {
 		os.Exit(1)
 	}
 
+	// Parse port forward flags
+	var portForwards []session.PortForward
+	for _, f := range forwards {
+		pf, err := session.ParsePortForwardFlag(f)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+		portForwards = append(portForwards, pf)
+	}
+
 	// Load existing config
 	config, err := session.LoadUserConfig()
 	if err != nil {
@@ -123,7 +149,8 @@ func handleRemoteAdd(args []string) {
 	}
 
 	rc := session.RemoteConfig{
-		Host: host,
+		Host:         host,
+		PortForwards: portForwards,
 	}
 	if *agentDeckPath != "" {
 		rc.AgentDeckPath = *agentDeckPath
@@ -220,10 +247,11 @@ func handleRemoteList(args []string) {
 
 	if *jsonOutput {
 		type remoteJSON struct {
-			Name          string `json:"name"`
-			Host          string `json:"host"`
-			AgentDeckPath string `json:"agent_deck_path"`
-			Profile       string `json:"profile"`
+			Name          string                `json:"name"`
+			Host          string                `json:"host"`
+			AgentDeckPath string                `json:"agent_deck_path"`
+			Profile       string                `json:"profile"`
+			PortForwards  []session.PortForward `json:"port_forwards,omitempty"`
 		}
 
 		var remotes []remoteJSON
@@ -233,6 +261,7 @@ func handleRemoteList(args []string) {
 				Host:          rc.Host,
 				AgentDeckPath: rc.GetAgentDeckPath(),
 				Profile:       rc.GetProfile(),
+				PortForwards:  rc.PortForwards,
 			})
 		}
 
@@ -245,10 +274,11 @@ func handleRemoteList(args []string) {
 		return
 	}
 
-	fmt.Printf("%-15s %-30s %-20s %s\n", "NAME", "HOST", "PATH", "PROFILE")
-	fmt.Println(strings.Repeat("-", 70))
+	fmt.Printf("%-15s %-30s %-20s %-10s %s\n", "NAME", "HOST", "PATH", "FORWARDS", "PROFILE")
+	fmt.Println(strings.Repeat("-", 80))
 	for name, rc := range config.Remotes {
-		fmt.Printf("%-15s %-30s %-20s %s\n", name, rc.Host, rc.GetAgentDeckPath(), rc.GetProfile())
+		fwdSummary := formatForwardSummary(rc.PortForwards)
+		fmt.Printf("%-15s %-30s %-20s %-10s %s\n", name, rc.Host, rc.GetAgentDeckPath(), fwdSummary, rc.GetProfile())
 	}
 	fmt.Printf("\nTotal: %d remotes\n", len(config.Remotes))
 }
@@ -602,6 +632,226 @@ func installOnRemote(runner *session.SSHRunner, ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// formatForwardSummary returns a compact summary like "2L 1R" for port forwards.
+func formatForwardSummary(forwards []session.PortForward) string {
+	if len(forwards) == 0 {
+		return "-"
+	}
+	counts := map[string]int{}
+	for _, pf := range forwards {
+		counts[pf.Direction]++
+	}
+	var parts []string
+	for _, dir := range []string{"L", "R", "D"} {
+		if c := counts[dir]; c > 0 {
+			parts = append(parts, fmt.Sprintf("%d%s", c, dir))
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func handleRemoteForward(args []string) {
+	if len(args) == 0 {
+		printRemoteForwardUsage()
+		return
+	}
+
+	switch args[0] {
+	case "list", "ls":
+		handleRemoteForwardList(args[1:])
+	case "add":
+		handleRemoteForwardAdd(args[1:])
+	case "remove", "rm":
+		handleRemoteForwardRemove(args[1:])
+	default:
+		fmt.Printf("Unknown forward command: %s\n", args[0])
+		printRemoteForwardUsage()
+		os.Exit(1)
+	}
+}
+
+func printRemoteForwardUsage() {
+	fmt.Println("Usage: agent-deck remote forward <command> <remote-name> [options]")
+	fmt.Println()
+	fmt.Println("Commands:")
+	fmt.Println("  list <name>                List configured port forwards")
+	fmt.Println("  add <name> <spec>...       Add port forward(s)")
+	fmt.Println("  remove <name> <spec>...    Remove port forward(s)")
+	fmt.Println()
+	fmt.Println("Spec format: D:spec where D is L (local), R (remote), or D (dynamic)")
+	fmt.Println()
+	fmt.Println("Examples:")
+	fmt.Println("  agent-deck remote forward list dev")
+	fmt.Println("  agent-deck remote forward add dev L:8444:localhost:8444")
+	fmt.Println("  agent-deck remote forward add dev L:3000:localhost:3000 R:9090:localhost:9090")
+	fmt.Println("  agent-deck remote forward remove dev L:8444:localhost:8444")
+}
+
+func handleRemoteForwardList(args []string) {
+	fs := flag.NewFlagSet("remote forward list", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	_ = fs.Parse(args)
+
+	remaining := fs.Args()
+	if len(remaining) < 1 {
+		fmt.Println("Usage: agent-deck remote forward list <remote-name> [--json]")
+		os.Exit(1)
+	}
+	name := remaining[0]
+
+	config, err := session.LoadUserConfig()
+	if err != nil {
+		fmt.Printf("Error: failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	rc, exists := config.Remotes[name]
+	if !exists {
+		fmt.Printf("Error: remote '%s' not found\n", name)
+		os.Exit(1)
+	}
+
+	if *jsonOutput {
+		output, err := json.MarshalIndent(rc.PortForwards, "", "  ")
+		if err != nil {
+			fmt.Printf("Error: failed to format JSON: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(output))
+		return
+	}
+
+	if len(rc.PortForwards) == 0 {
+		fmt.Printf("No port forwards configured for remote '%s'.\n", name)
+		return
+	}
+
+	fmt.Printf("Port forwards for remote '%s':\n\n", name)
+	fmt.Printf("  %-12s %s\n", "DIRECTION", "SPEC")
+	fmt.Printf("  %s\n", strings.Repeat("-", 40))
+	for _, pf := range rc.PortForwards {
+		var dirLabel string
+		switch pf.Direction {
+		case "L":
+			dirLabel = "local (-L)"
+		case "R":
+			dirLabel = "remote (-R)"
+		case "D":
+			dirLabel = "dynamic (-D)"
+		}
+		fmt.Printf("  %-12s %s\n", dirLabel, pf.Spec)
+	}
+	fmt.Printf("\nTotal: %d forward(s)\n", len(rc.PortForwards))
+}
+
+func handleRemoteForwardAdd(args []string) {
+	if len(args) < 2 {
+		fmt.Println("Usage: agent-deck remote forward add <remote-name> <spec>...")
+		fmt.Println("Example: agent-deck remote forward add dev L:8444:localhost:8444")
+		os.Exit(1)
+	}
+
+	name := args[0]
+	specs := args[1:]
+
+	config, err := session.LoadUserConfig()
+	if err != nil {
+		fmt.Printf("Error: failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	rc, exists := config.Remotes[name]
+	if !exists {
+		fmt.Printf("Error: remote '%s' not found\n", name)
+		os.Exit(1)
+	}
+
+	// Build set of existing forwards for dedup
+	existing := make(map[string]bool)
+	for _, pf := range rc.PortForwards {
+		existing[pf.Direction+":"+pf.Spec] = true
+	}
+
+	var added int
+	for _, s := range specs {
+		pf, err := session.ParsePortForwardFlag(s)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+		key := pf.Direction + ":" + pf.Spec
+		if existing[key] {
+			fmt.Printf("  Skipped (duplicate): %s\n", s)
+			continue
+		}
+		rc.PortForwards = append(rc.PortForwards, pf)
+		existing[key] = true
+		added++
+	}
+
+	config.Remotes[name] = rc
+	if err := session.SaveUserConfig(config); err != nil {
+		fmt.Printf("Error: failed to save config: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Added %d forward(s) to remote '%s' (%d total)\n", added, name, len(rc.PortForwards))
+}
+
+func handleRemoteForwardRemove(args []string) {
+	if len(args) < 2 {
+		fmt.Println("Usage: agent-deck remote forward remove <remote-name> <spec>...")
+		fmt.Println("Example: agent-deck remote forward remove dev L:8444:localhost:8444")
+		os.Exit(1)
+	}
+
+	name := args[0]
+	specs := args[1:]
+
+	config, err := session.LoadUserConfig()
+	if err != nil {
+		fmt.Printf("Error: failed to load config: %v\n", err)
+		os.Exit(1)
+	}
+
+	rc, exists := config.Remotes[name]
+	if !exists {
+		fmt.Printf("Error: remote '%s' not found\n", name)
+		os.Exit(1)
+	}
+
+	// Build set of specs to remove
+	toRemove := make(map[string]bool)
+	for _, s := range specs {
+		pf, err := session.ParsePortForwardFlag(s)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			os.Exit(1)
+		}
+		toRemove[pf.Direction+":"+pf.Spec] = true
+	}
+
+	var kept []session.PortForward
+	var removed int
+	for _, pf := range rc.PortForwards {
+		key := pf.Direction + ":" + pf.Spec
+		if toRemove[key] {
+			removed++
+		} else {
+			kept = append(kept, pf)
+		}
+	}
+
+	rc.PortForwards = kept
+	config.Remotes[name] = rc
+	if err := session.SaveUserConfig(config); err != nil {
+		fmt.Printf("Error: failed to save config: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Removed %d forward(s) from remote '%s' (%d remaining)\n", removed, name, len(rc.PortForwards))
 }
 
 // reorderRemoteArgs moves flags before positional args for Go's flag package.

--- a/cmd/agent-deck/remote_cmd_test.go
+++ b/cmd/agent-deck/remote_cmd_test.go
@@ -31,6 +31,40 @@ func TestIsValidRemoteName(t *testing.T) {
 	}
 }
 
+func TestPortForwardFlags_Set(t *testing.T) {
+	t.Parallel()
+	var flags portForwardFlags
+	if err := flags.Set("L:8444:localhost:8444"); err != nil {
+		t.Fatalf("Set() error: %v", err)
+	}
+	if err := flags.Set("R:3000:localhost:3000"); err != nil {
+		t.Fatalf("Set() error: %v", err)
+	}
+	if len(flags) != 2 {
+		t.Fatalf("expected 2 flags, got %d", len(flags))
+	}
+	if flags[0] != "L:8444:localhost:8444" {
+		t.Errorf("flags[0] = %q, want %q", flags[0], "L:8444:localhost:8444")
+	}
+	if flags[1] != "R:3000:localhost:3000" {
+		t.Errorf("flags[1] = %q, want %q", flags[1], "R:3000:localhost:3000")
+	}
+}
+
+func TestPortForwardFlags_String(t *testing.T) {
+	t.Parallel()
+	flags := portForwardFlags{"L:8080:localhost:8080", "D:1080"}
+	got := flags.String()
+	if got != "L:8080:localhost:8080,D:1080" {
+		t.Errorf("String() = %q, want %q", got, "L:8080:localhost:8080,D:1080")
+	}
+
+	var empty portForwardFlags
+	if s := empty.String(); s != "" {
+		t.Errorf("empty String() = %q, want %q", s, "")
+	}
+}
+
 func TestShouldProceedWithRemoteUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -30,9 +30,10 @@ const sshControlDir = "/tmp/agent-deck-ssh"
 
 // SSHRunner executes commands on a remote host via SSH.
 type SSHRunner struct {
-	Host          string // SSH destination (e.g., "user@host")
-	AgentDeckPath string // Remote agent-deck binary path
-	Profile       string // Remote profile name
+	Host          string        // SSH destination (e.g., "user@host")
+	AgentDeckPath string        // Remote agent-deck binary path
+	Profile       string        // Remote profile name
+	PortForwards  []PortForward // SSH port forwarding rules
 }
 
 // NewSSHRunner creates an SSHRunner from a RemoteConfig.
@@ -41,7 +42,27 @@ func NewSSHRunner(name string, rc RemoteConfig) *SSHRunner {
 		Host:          rc.Host,
 		AgentDeckPath: rc.GetAgentDeckPath(),
 		Profile:       rc.GetProfile(),
+		PortForwards:  rc.PortForwards,
 	}
+}
+
+// portForwardArgs returns the SSH flags for all configured port forwards.
+func (r *SSHRunner) portForwardArgs() []string {
+	if len(r.PortForwards) == 0 {
+		return nil
+	}
+	var args []string
+	for _, pf := range r.PortForwards {
+		switch pf.Direction {
+		case "L":
+			args = append(args, "-L", pf.Spec)
+		case "R":
+			args = append(args, "-R", pf.Spec)
+		case "D":
+			args = append(args, "-D", pf.Spec)
+		}
+	}
+	return args
 }
 
 // Run executes an agent-deck command on the remote host and returns stdout.
@@ -63,9 +84,9 @@ func (r *SSHRunner) run(ctx context.Context, args ...string) ([]byte, error) {
 		"-o", "ControlPersist=600",
 		"-o", "ConnectTimeout=10",
 		"-o", "BatchMode=yes",
-		r.Host,
-		remoteCmd,
 	}
+	sshArgs = append(sshArgs, r.portForwardArgs()...)
+	sshArgs = append(sshArgs, r.Host, remoteCmd)
 
 	cmd := exec.CommandContext(ctx, "ssh", sshArgs...)
 	var stdout, stderr bytes.Buffer
@@ -94,9 +115,9 @@ func (r *SSHRunner) Attach(sessionID string) error {
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPath=" + sshControlDir + "/%r@%h:%p",
 		"-o", "ControlPersist=600",
-		r.Host,
-		remoteCmd,
 	}
+	sshArgs = append(sshArgs, r.portForwardArgs()...)
+	sshArgs = append(sshArgs, r.Host, remoteCmd)
 
 	cmd := exec.Command("ssh", sshArgs...)
 
@@ -424,15 +445,16 @@ func (r *SSHRunner) DeployBinary(ctx context.Context, binaryData []byte) error {
 
 // sshBaseArgs returns common SSH args for running a raw command on the remote.
 func (r *SSHRunner) sshBaseArgs(remoteCmd string) []string {
-	return []string{
+	args := []string{
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPath=" + sshControlDir + "/%r@%h:%p",
 		"-o", "ControlPersist=600",
 		"-o", "ConnectTimeout=10",
 		"-o", "BatchMode=yes",
-		r.Host,
-		remoteCmd,
 	}
+	args = append(args, r.portForwardArgs()...)
+	args = append(args, r.Host, remoteCmd)
+	return args
 }
 
 // CreateSession creates and starts a new session on the remote, returning its ID.

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -72,6 +72,75 @@ func TestParseRemoteSessionOutput(t *testing.T) {
 	}
 }
 
+func TestPortForwardArgs_Empty(t *testing.T) {
+	runner := &SSHRunner{}
+	got := runner.portForwardArgs()
+	if got != nil {
+		t.Fatalf("expected nil for empty PortForwards, got %v", got)
+	}
+}
+
+func TestPortForwardArgs_AllDirections(t *testing.T) {
+	runner := &SSHRunner{
+		PortForwards: []PortForward{
+			{Direction: "L", Spec: "8444:localhost:8444"},
+			{Direction: "R", Spec: "3000:localhost:3000"},
+			{Direction: "D", Spec: "1080"},
+		},
+	}
+	got := runner.portForwardArgs()
+	want := []string{"-L", "8444:localhost:8444", "-R", "3000:localhost:3000", "-D", "1080"}
+	if len(got) != len(want) {
+		t.Fatalf("portForwardArgs() = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("portForwardArgs()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPortForwardArgs_Ordering(t *testing.T) {
+	runner := &SSHRunner{
+		PortForwards: []PortForward{
+			{Direction: "L", Spec: "1111:localhost:1111"},
+			{Direction: "L", Spec: "2222:localhost:2222"},
+			{Direction: "L", Spec: "3333:localhost:3333"},
+		},
+	}
+	got := runner.portForwardArgs()
+	want := []string{"-L", "1111:localhost:1111", "-L", "2222:localhost:2222", "-L", "3333:localhost:3333"}
+	if len(got) != len(want) {
+		t.Fatalf("portForwardArgs() = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("portForwardArgs()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestNewSSHRunner_CopiesPortForwards(t *testing.T) {
+	rc := RemoteConfig{
+		Host:    "user@host",
+		Profile: "dev",
+		PortForwards: []PortForward{
+			{Direction: "L", Spec: "8080:localhost:8080"},
+			{Direction: "D", Spec: "1080"},
+		},
+	}
+	runner := NewSSHRunner("test", rc)
+	if len(runner.PortForwards) != 2 {
+		t.Fatalf("expected 2 port forwards, got %d", len(runner.PortForwards))
+	}
+	if runner.PortForwards[0].Direction != "L" || runner.PortForwards[0].Spec != "8080:localhost:8080" {
+		t.Errorf("PortForwards[0] = %+v, want L:8080:localhost:8080", runner.PortForwards[0])
+	}
+	if runner.PortForwards[1].Direction != "D" || runner.PortForwards[1].Spec != "1080" {
+		t.Errorf("PortForwards[1] = %+v, want D:1080", runner.PortForwards[1])
+	}
+}
+
 func TestSSHRunnerBuildRemoteCommand_QuotesRemoteSessionOutputID(t *testing.T) {
 	runner := &SSHRunner{AgentDeckPath: "/usr/local/bin/agent-deck"}
 

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -195,6 +195,45 @@ type OpenClawSettings struct {
 	GroupName string `toml:"group_name"`
 }
 
+// PortForward describes a single SSH port-forwarding rule.
+type PortForward struct {
+	// Direction is "L" (local), "R" (remote), or "D" (dynamic/SOCKS).
+	Direction string `toml:"direction"`
+
+	// Spec is the forwarding specification passed to ssh -L/-R/-D.
+	// For L/R: "[bind_address:]port:host:hostport"
+	// For D:   "[bind_address:]port"
+	Spec string `toml:"spec"`
+}
+
+// ValidatePortForward checks that a PortForward has a valid direction and non-empty spec.
+func ValidatePortForward(pf PortForward) error {
+	switch pf.Direction {
+	case "L", "R", "D":
+	default:
+		return fmt.Errorf("invalid direction %q: must be L, R, or D", pf.Direction)
+	}
+	if pf.Spec == "" {
+		return fmt.Errorf("empty spec for %s forward", pf.Direction)
+	}
+	return nil
+}
+
+// ParsePortForwardFlag parses a CLI flag like "L:8444:localhost:8444" into a PortForward.
+// Accepts lowercase direction letters which are uppercased automatically.
+func ParsePortForwardFlag(s string) (PortForward, error) {
+	if len(s) < 3 || s[1] != ':' {
+		return PortForward{}, fmt.Errorf("invalid port forward %q: expected format D:spec (e.g., L:8444:localhost:8444)", s)
+	}
+	direction := strings.ToUpper(s[:1])
+	spec := s[2:]
+	pf := PortForward{Direction: direction, Spec: spec}
+	if err := ValidatePortForward(pf); err != nil {
+		return PortForward{}, err
+	}
+	return pf, nil
+}
+
 // RemoteConfig defines a remote agent-deck instance accessible via SSH.
 type RemoteConfig struct {
 	// Host is the SSH destination (e.g., "user@host" or "user@host:port")
@@ -205,6 +244,9 @@ type RemoteConfig struct {
 
 	// Profile is the remote profile to use (default: "default")
 	Profile string `toml:"profile"`
+
+	// PortForwards configures SSH port forwarding rules applied to all connections.
+	PortForwards []PortForward `toml:"port_forwards"`
 }
 
 // GetAgentDeckPath returns the agent-deck binary path, defaulting to "agent-deck".

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -1860,3 +1860,113 @@ transition_events = false
 		t.Error("GetTransitionEventsEnabled() should return false when explicitly false")
 	}
 }
+
+func TestValidatePortForward_Valid(t *testing.T) {
+	t.Parallel()
+	for _, dir := range []string{"L", "R", "D"} {
+		if err := ValidatePortForward(PortForward{Direction: dir, Spec: "8444:localhost:8444"}); err != nil {
+			t.Errorf("expected direction %q to be valid, got: %v", dir, err)
+		}
+	}
+}
+
+func TestValidatePortForward_InvalidDirection(t *testing.T) {
+	t.Parallel()
+	for _, dir := range []string{"X", "", "l", "local", "Z"} {
+		if err := ValidatePortForward(PortForward{Direction: dir, Spec: "8444:localhost:8444"}); err == nil {
+			t.Errorf("expected direction %q to be invalid", dir)
+		}
+	}
+}
+
+func TestValidatePortForward_EmptySpec(t *testing.T) {
+	t.Parallel()
+	if err := ValidatePortForward(PortForward{Direction: "L", Spec: ""}); err == nil {
+		t.Error("expected empty spec to be invalid")
+	}
+}
+
+func TestParsePortForwardFlag_Valid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		dir   string
+		spec  string
+	}{
+		{"L:8444:localhost:8444", "L", "8444:localhost:8444"},
+		{"R:3000:localhost:3000", "R", "3000:localhost:3000"},
+		{"D:1080", "D", "1080"},
+		{"l:8080:localhost:8080", "L", "8080:localhost:8080"},
+		{"r:9090:0.0.0.0:9090", "R", "9090:0.0.0.0:9090"},
+		{"d:1080", "D", "1080"},
+	}
+	for _, tc := range tests {
+		pf, err := ParsePortForwardFlag(tc.input)
+		if err != nil {
+			t.Errorf("ParsePortForwardFlag(%q) unexpected error: %v", tc.input, err)
+			continue
+		}
+		if pf.Direction != tc.dir {
+			t.Errorf("ParsePortForwardFlag(%q).Direction = %q, want %q", tc.input, pf.Direction, tc.dir)
+		}
+		if pf.Spec != tc.spec {
+			t.Errorf("ParsePortForwardFlag(%q).Spec = %q, want %q", tc.input, pf.Spec, tc.spec)
+		}
+	}
+}
+
+func TestParsePortForwardFlag_Invalid(t *testing.T) {
+	t.Parallel()
+	for _, input := range []string{"", "8444:localhost:8444", "X:1234", "LL:8080:localhost:8080", ":"} {
+		if _, err := ParsePortForwardFlag(input); err == nil {
+			t.Errorf("ParsePortForwardFlag(%q) expected error", input)
+		}
+	}
+}
+
+func TestRemoteConfig_PortForwards_TOML_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	input := `
+[remotes.dev]
+host = "user@dev-box"
+agent_deck_path = "agent-deck"
+profile = "default"
+
+[[remotes.dev.port_forwards]]
+direction = "L"
+spec = "8444:localhost:8444"
+
+[[remotes.dev.port_forwards]]
+direction = "R"
+spec = "3000:localhost:3000"
+
+[[remotes.dev.port_forwards]]
+direction = "D"
+spec = "1080"
+`
+
+	var config UserConfig
+	if _, err := toml.Decode(input, &config); err != nil {
+		t.Fatalf("Failed to decode TOML: %v", err)
+	}
+
+	rc, ok := config.Remotes["dev"]
+	if !ok {
+		t.Fatal("expected 'dev' remote in config")
+	}
+	if len(rc.PortForwards) != 3 {
+		t.Fatalf("expected 3 port forwards, got %d", len(rc.PortForwards))
+	}
+
+	expected := []PortForward{
+		{Direction: "L", Spec: "8444:localhost:8444"},
+		{Direction: "R", Spec: "3000:localhost:3000"},
+		{Direction: "D", Spec: "1080"},
+	}
+	for i, pf := range rc.PortForwards {
+		if pf.Direction != expected[i].Direction || pf.Spec != expected[i].Spec {
+			t.Errorf("port_forwards[%d] = %+v, want %+v", i, pf, expected[i])
+		}
+	}
+}

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -410,8 +410,56 @@ agent-deck remote add <name> <user@host> [options]
 |------|-------------|
 | `--agent-deck-path <path>` | Path to the agent-deck binary on the remote (default: `agent-deck`) |
 | `--profile <name>` | Remote profile to use (default: `default`) |
+| `--forward <spec>` | Port forward rule (e.g., `L:8444:localhost:8444`). Can be repeated. |
 
 Registers a remote instance. If agent-deck is not found on the remote, it is installed automatically. Remote names must be alphanumeric and may contain underscores or hyphens (no spaces, slashes, dots, or colons).
+
+### remote forward
+
+Manage SSH port forwarding rules for a remote. Forwards are applied to all SSH connections (attach, command execution, session fetch). Changes take effect on the next SSH connection.
+
+#### remote forward list
+
+```bash
+agent-deck remote forward list <remote-name> [--json]
+```
+
+Lists configured port forwards for a remote.
+
+#### remote forward add
+
+```bash
+agent-deck remote forward add <remote-name> <spec>...
+```
+
+Adds one or more port forwards. Duplicates are skipped automatically.
+
+#### remote forward remove
+
+```bash
+agent-deck remote forward remove <remote-name> <spec>...
+```
+
+Removes matching port forwards from the remote configuration.
+
+#### Port forward spec format
+
+The spec format is `D:spec` where `D` is the direction:
+
+| Direction | SSH Flag | Description |
+|-----------|----------|-------------|
+| `L` | `-L` | Local forwarding — access a remote service on a local port |
+| `R` | `-R` | Remote forwarding — expose a local service to the remote host |
+| `D` | `-D` | Dynamic (SOCKS) forwarding |
+
+Examples:
+
+```bash
+agent-deck remote forward add dev L:8444:localhost:8444
+agent-deck remote forward add dev R:3000:localhost:3000 D:1080
+agent-deck remote forward remove dev L:8444:localhost:8444
+agent-deck remote forward list dev --json
+```
 
 ### remote remove / rm
 
@@ -474,6 +522,12 @@ agent-deck remote attach dev my-session
 agent-deck remote rename dev my-session new-name
 agent-deck remote update          # update all remotes
 agent-deck remote update dev      # update specific remote
+
+# Port forwarding
+agent-deck remote add dev user@dev-box --forward L:8444:localhost:8444
+agent-deck remote forward add dev L:3000:localhost:3000
+agent-deck remote forward list dev
+agent-deck remote forward remove dev L:8444:localhost:8444
 ```
 
 ## Session Resolution

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -153,6 +153,30 @@ volume_ignores = []            # Directories to exclude from project mount
 | `environment` | array | `[]` | Host environment variable names to forward into containers. |
 | `volume_ignores` | array | `[]` | Directories to exclude from the project bind mount (e.g. `["node_modules", ".git"]`). |
 
+## [remotes] Section
+
+Named SSH remote agent-deck instances. Each remote is a sub-table keyed by name.
+
+```toml
+[remotes.dev]
+host = "user@dev-box"            # SSH destination (required)
+agent_deck_path = ""             # Path to agent-deck on remote (default: "agent-deck")
+profile = ""                     # Remote profile to use (default: "default")
+
+[[remotes.dev.port_forwards]]    # SSH port forwarding rules (optional, repeatable)
+direction = "L"                  # L (local), R (remote), or D (dynamic/SOCKS)
+spec = "8444:localhost:8444"     # Forwarding spec passed to ssh -L/-R/-D
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `host` | string | (required) | SSH destination (e.g. `"user@host"` or `"user@host:port"`). |
+| `agent_deck_path` | string | `"agent-deck"` | Path to the agent-deck binary on the remote. |
+| `profile` | string | `"default"` | Remote profile name. |
+| `port_forwards` | array of tables | `[]` | SSH port forwarding rules applied to all connections. |
+| `port_forwards.direction` | string | (required) | `"L"` (local `-L`), `"R"` (remote `-R`), or `"D"` (dynamic `-D`). |
+| `port_forwards.spec` | string | (required) | Forwarding spec (e.g. `"8444:localhost:8444"` or `"1080"`). |
+
 ## [logs] Section
 
 Session log file management.


### PR DESCRIPTION
## Summary

Adds native SSH port forwarding (`-L`/`-R`/`-D`) to remote sessions, closing #792.

- New `PortForward` type on `RemoteConfig` persisted as `[[remotes.<name>.port_forwards]]` in config.toml
- `SSHRunner.portForwardArgs()` injects flags into all three SSH call sites (`run`, `Attach`, `sshBaseArgs`); SCP is intentionally skipped
- `--forward` repeatable flag on `remote add`
- `remote forward add/remove/list` subcommands for managing forwards on existing remotes
- `remote list` now shows a FORWARDS column
- 11 new tests (validation, parsing, TOML round-trip, SSH args, CLI flags)

## Usage

### CLI

```bash
# Add a remote with port forwarding
agent-deck remote add dev user@dev-box --forward L:8444:localhost:8444

# Multiple forwards at once
agent-deck remote add staging user@staging-box \
  --forward L:8444:localhost:8444 \
  --forward L:3000:localhost:3000

# Manage forwards on an existing remote
agent-deck remote forward add dev R:9090:localhost:9090
agent-deck remote forward add dev D:1080
agent-deck remote forward list dev
agent-deck remote forward remove dev L:8444:localhost:8444

# See forwards summary in remote list
agent-deck remote list
# NAME    HOST              PATH          FORWARDS   PROFILE
# dev     user@dev-box      agent-deck    1L 1R 1D   default
```

### Configuration

Port forwards are stored in `~/.agent-deck/config.toml`:

```toml
[remotes.dev]
host = "user@dev-box"

[[remotes.dev.port_forwards]]
direction = "L"
spec = "8444:localhost:8444"

[[remotes.dev.port_forwards]]
direction = "R"
spec = "9090:localhost:9090"

[[remotes.dev.port_forwards]]
direction = "D"
spec = "1080"
```

Supported directions:

| Direction | SSH Flag | Use case |
|-----------|----------|----------|
| `L` | `-L` | Access a remote service on a local port |
| `R` | `-R` | Expose a local service to the remote host |
| `D` | `-D` | Dynamic SOCKS proxy |

Forwards apply automatically to all SSH connections (attach, command execution, session fetch).