### PR TITLE
fix(session): release i.mu across opencode CLI subprocess

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1230,16 +1230,36 @@ func findBestOpenCodeSession(sessions []openCodeSessionMetadata, projectPath, cu
 // queryOpenCodeSession queries OpenCode CLI for sessions matching our project
 // directory. Unbound instances adopt the most recently updated session, while
 // already-bound instances keep their current ID as long as it still exists.
+//
+// Bounded wall-clock cost:
+//   - 5s context deadline for the subprocess itself.
+//   - WaitDelay=500ms so cmd.Output() returns after the context fires even if
+//     an opencode grandchild keeps stdout pipes open (Go 1.20+).
+//
+// 5s is the ceiling for cold opencode CLI on large session stores; on slower
+// machines this still usually succeeds, and on genuine hangs we log a Warn
+// and lastOpenCodeScanAt schedules the next retry 15s later.
 func (i *Instance) queryOpenCodeSession() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	// Run: opencode session list --format json
-	cmd := exec.Command("opencode", "session", "list", "--format", "json")
+	cmd := exec.CommandContext(ctx, "opencode", "session", "list", "--format", "json")
 	cmd.Dir = i.ProjectPath
+	cmd.WaitDelay = 500 * time.Millisecond
 
 	sessionLog.Debug("opencode_query_sessions", slog.String("dir", i.ProjectPath))
 
 	output, err := cmd.Output()
 	if err != nil {
-		sessionLog.Debug("opencode_query_failed", slog.String("error", err.Error()))
+		if ctx.Err() == context.DeadlineExceeded {
+			sessionLog.Warn("opencode_query_timeout",
+				slog.String("dir", i.ProjectPath),
+				slog.String("instance_id", i.ID),
+			)
+		} else {
+			sessionLog.Debug("opencode_query_failed", slog.String("error", err.Error()))
+		}
 		return ""
 	}
 
@@ -2945,9 +2965,15 @@ func (i *Instance) UpdateStatus() error {
 				i.UpdateCodexSession(exclude)
 			}
 
-			// Update OpenCode session tracking (non-blocking, best-effort)
+			// Update OpenCode session tracking (non-blocking, best-effort).
+			// The opencode CLI subprocess can take seconds and must not run
+			// under i.mu or it starves render-path RLocks and freezes the TUI.
+			// updateOpenCodeSession manages its own locking internally — we
+			// drop i.mu here and reacquire after it returns.
 			if i.Tool == "opencode" {
+				i.mu.Unlock()
 				i.UpdateOpenCodeSession()
+				i.mu.Lock()
 			}
 		}
 	}
@@ -3223,19 +3249,30 @@ func (i *Instance) UpdateOpenCodeSession() {
 	i.updateOpenCodeSession(false)
 }
 
+// updateOpenCodeSession self-manages i.mu: state reads/writes happen under the
+// lock but the queryOpenCodeSession subprocess runs outside it, so a slow
+// opencode CLI cannot starve render-path RLocks on this instance.
+//
+// Contract: callers MUST NOT hold i.mu when invoking this function.
 func (i *Instance) updateOpenCodeSession(force bool) {
 	if i.Tool != "opencode" {
 		return
 	}
 
+	i.mu.Lock()
 	now := time.Now()
 	if !force && !i.lastOpenCodeScanAt.IsZero() && now.Sub(i.lastOpenCodeScanAt) < opencodeRotationScanInterval {
+		i.mu.Unlock()
 		return
 	}
 	i.lastOpenCodeScanAt = now
+	i.mu.Unlock()
 
 	candidate := i.queryOpenCodeSession()
+
+	i.mu.Lock()
 	i.applyOpenCodeSessionCandidate(candidate)
+	i.mu.Unlock()
 }
 
 func (i *Instance) applyOpenCodeSessionCandidate(candidate string) bool {

--- a/internal/session/opencode_lock_test.go
+++ b/internal/session/opencode_lock_test.go
@@ -1,0 +1,157 @@
+package session
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestUpdateOpenCodeSession_DoesNotHoldLockAcrossSubprocess is half of the
+// regression guard for the TUI-freeze bug: it verifies that calling
+// updateOpenCodeSession() does not hold i.mu across the opencode CLI
+// subprocess. If a future maintainer adds `i.mu.Lock(); defer i.mu.Unlock()`
+// inside updateOpenCodeSession (the most natural way to reintroduce the bug),
+// this test fails.
+//
+// It does NOT verify that UpdateStatus's call site drops i.mu around the call;
+// see TestUpdateStatus_DropsLockAroundOpencode (source assertion) for that.
+func TestUpdateOpenCodeSession_DoesNotHoldLockAcrossSubprocess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub not portable to windows")
+	}
+
+	stubDir := t.TempDir()
+	stubPath := filepath.Join(stubDir, "opencode")
+	startedFile := filepath.Join(stubDir, "started")
+	script := "#!/usr/bin/env bash\n" +
+		"touch " + startedFile + "\n" +
+		"sleep 0.6\n" +
+		"echo '[]'\n"
+	if err := os.WriteFile(stubPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	inst := &Instance{
+		ID:          "test-instance",
+		Tool:        "opencode",
+		ProjectPath: t.TempDir(),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		inst.updateOpenCodeSession(true)
+		close(done)
+	}()
+
+	// Wait up to 2s for the stub to actually enter. File signal is more
+	// reliable than a time.Sleep for this handshake.
+	waitDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(waitDeadline) {
+		if _, err := os.Stat(startedFile); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := os.Stat(startedFile); err != nil {
+		<-done
+		t.Fatalf("opencode stub never ran (PATH issue?): %v", err)
+	}
+
+	// If updateOpenCodeSession holds i.mu (write lock) across the
+	// subprocess, TryLock fails here.
+	if !inst.mu.TryLock() {
+		<-done
+		t.Fatal("i.mu is held while the opencode subprocess is running; " +
+			"updateOpenCodeSession must release i.mu across the subprocess.")
+	}
+	inst.mu.Unlock()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("updateOpenCodeSession did not return within 5s")
+	}
+}
+
+// TestUpdateStatus_DropsLockAroundOpencode is the other half of the regression
+// guard: it parses the UpdateStatus source and asserts that the
+// `if i.Tool == "opencode"` branch releases and reacquires i.mu around the
+// UpdateOpenCodeSession() call. Without this, even a correct callee can be
+// starved by a caller that holds the lock.
+//
+// This is a source-level test because standing up a realistic tmux session
+// that reaches the metadata-sync block at UpdateStatus:~2950 requires
+// bypassing a 2-minute startup window and a content-based status detector —
+// neither is reasonable in a unit test.
+func TestUpdateStatus_DropsLockAroundOpencode(t *testing.T) {
+	src, err := os.ReadFile("instance.go")
+	if err != nil {
+		t.Fatalf("read instance.go: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "instance.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse instance.go: %v", err)
+	}
+
+	var updateStatus *ast.FuncDecl
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "UpdateStatus" {
+			continue
+		}
+		if fn.Recv == nil || len(fn.Recv.List) == 0 {
+			continue
+		}
+		updateStatus = fn
+		break
+	}
+	if updateStatus == nil {
+		t.Fatal("UpdateStatus function not declared in instance.go")
+	}
+
+	// Serialize the function body and scan for the required pattern.
+	// Extract the raw source range of the function body.
+	start := fset.Position(updateStatus.Body.Pos()).Offset
+	end := fset.Position(updateStatus.Body.End()).Offset
+	body := string(src[start:end])
+
+	// Anchor the search on the UpdateOpenCodeSession call and look for
+	// i.mu.Unlock() immediately before it and i.mu.Lock() immediately
+	// after it, within a small window. Substring-based so it is robust
+	// to whitespace or comment changes.
+	const window = 120 // chars
+	callIdx := strings.Index(body, "i.UpdateOpenCodeSession()")
+	if callIdx == -1 {
+		t.Fatal("UpdateStatus does not call i.UpdateOpenCodeSession() at all")
+	}
+
+	beforeStart := callIdx - window
+	if beforeStart < 0 {
+		beforeStart = 0
+	}
+	before := body[beforeStart:callIdx]
+	if !strings.Contains(before, "i.mu.Unlock()") {
+		t.Fatalf("UpdateStatus does not call i.mu.Unlock() within %d chars before i.UpdateOpenCodeSession() — "+
+			"freeze regression: i.mu is held across the opencode subprocess.\nContext:\n%s", window, before)
+	}
+
+	afterStart := callIdx + len("i.UpdateOpenCodeSession()")
+	afterEnd := afterStart + window
+	if afterEnd > len(body) {
+		afterEnd = len(body)
+	}
+	after := body[afterStart:afterEnd]
+	if !strings.Contains(after, "i.mu.Lock()") {
+		t.Fatalf("UpdateStatus does not reacquire i.mu.Lock() within %d chars after i.UpdateOpenCodeSession() — "+
+			"freeze regression.\nContext:\n%s", window, after)
+	}
+}


### PR DESCRIPTION
## Summary
- `UpdateStatus` held `i.mu.Lock()` across the `opencode session list` subprocess. On large session stores the subprocess takes multiple seconds; the write-preferring `sync.RWMutex` starved render-path RLocks and froze the TUI for 10-15 s during navigation over active opencode sessions.
- Release `i.mu` around the call; `updateOpenCodeSession` self-manages its locking (subprocess runs unlocked, state reads/writes under lock).
- Bound the subprocess with a 5 s context deadline plus `cmd.WaitDelay = 500 ms` so a Node-style child that holds stdout open does not extend `cmd.Output()` past the context.

## Evidence
Reproduced with an automated 60-second navigation harness against a workload of 28 opencode sessions:

| Metric | Before | After |
|---|---|---|
| `slow_meta_sync.lock_held` (opencode) | 5–7 s per event | **0 ms** across 21/21 events |
| `slow_meta_sync.duration` | 6.0–7.5 s | 2.0–6.5 s (subprocess still slow, but unlocked) |
| Bubble Tea main goroutine during freeze | blocked (inferred from symptom) | `[select]` in event loop (confirmed via `/debug/pprof/goroutine`) |

## Regression tests
Two complementary guards; each empirically verified to fail when its half of the fix is reverted:

- **`TestUpdateOpenCodeSession_DoesNotHoldLockAcrossSubprocess`** — runtime. Stubs `opencode` with a shell script that signals via a file, spawns `updateOpenCodeSession` in a goroutine, asserts `TryLock` succeeds while the subprocess is sleeping. Uses a file-signal handshake rather than `time.Sleep` for deterministic CI.
- **`TestUpdateStatus_DropsLockAroundOpencode`** — source-level (`go/ast` + substring scan). Asserts the `i.mu.Unlock() → i.UpdateOpenCodeSession() → i.mu.Lock()` pattern exists in `UpdateStatus`, catching regressions that a callee-only test cannot.

`go test -race ./internal/session -short` — clean (32 s). Regression tests pass 10/10 under repeated runs.

## Scope: other AI agents need separate fixes
The underlying anti-pattern is endemic to the active-only metadata-sync block in `UpdateStatus` (`instance.go` ~2927-2970): `UpdateClaudeSession`, `UpdateCodexSession`, and `UpdateGeminiSession` are all invoked under `i.mu.Lock()`. Each can exhibit the same freeze symptom under a different workload:

- **Codex** is the worst remaining offender: `collectOtherCodexSessionIDs` runs N × `tmux show-environment` (3 s timeout each), and `queryCodexSessionFromProcessFiles` invokes untimed `ps`, `pgrep`, `lsof`, and `docker exec` subprocesses. Under load this can hold `i.mu` for tens of seconds.
- **Gemini** reads and JSON-parses every `~/.gemini/tmp/<hash>/chats/session-*.json` on each poll; source comments note these can reach 40 MB+.
- **Claude** calls `GetSessionIDFromTmux` (3 s timeout) plus bounded disk scans; lower severity but same pattern.

**This PR intentionally scopes to opencode** because that's what the reproduction harness confirmed. The Codex and Gemini branches should be addressed in follow-up PRs, ideally using the same release-and-reacquire pattern (or a centralised version that releases around the entire metadata-sync block). The Codex probe subprocesses should also gain `context.WithTimeout` regardless.

## Related
- #193 — closed, same class of bug for Codex; fixed in v0.19.5 via rate-limiting the disk scan. This PR addresses the opencode variant with a different approach (lock release), which is more resilient than rate-limiting because it decouples subprocess latency from UI responsiveness.
- #39 — closed, earlier similar UI-freeze symptom after detach; different root cause.

## Known follow-ups (not blocking)
- `applyOpenCodeSessionCandidate` → `setOpenCodeSession` → `tmux SetEnvironment` still runs under the re-acquired lock (~3 s tail on a rebind). Same pattern applies.
- Stale-candidate race: a concurrent `RestartFresh` can clear `OpenCodeSessionID` during the ≤5 s unlocked window, and the subsequent apply can rebind a stale ID. A binding-generation counter would resolve it.
- `queryOpenCodeSession` reads `i.ProjectPath` / `i.OpenCodeSessionID` without a lock; pre-existing race class widened from µs to ≤5 s.

## Test plan
- `go test -race ./internal/session -short` ✅
- Both regression tests empirically confirmed to fail on broken code and pass on fixed code ✅
- 10× stability runs of each regression test: all pass