### PR TITLE
fix(notifier): inbox + retry-with-backoff + orphan WARN (#805)

### DIFF
--- a/cmd/agent-deck/inbox_cmd.go
+++ b/cmd/agent-deck/inbox_cmd.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// handleInbox is the dispatch entry for `agent-deck inbox <session-id>`. It
+// drains the per-conductor inbox file populated by the transition notifier
+// when in-process retries exhaust against a busy parent. Reading truncates;
+// callers should expect at-most-once delivery (consumer-side dedup, not
+// producer-side, intentional — see internal/session/inbox.go).
+func handleInbox(args []string) {
+	if err := runInbox(os.Stdout, args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// runInbox is the testable seam — handleInbox wires it to os.Stdout/Stderr;
+// tests pass a buffer.
+func runInbox(stdout io.Writer, args []string) error {
+	fs := flag.NewFlagSet("inbox", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Fprintln(stdout, "Usage: agent-deck inbox <session-id>")
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, "Drain pending transition events from the parent's inbox file.")
+		fmt.Fprintln(stdout, "Events are written here when in-process retries exhaust against")
+		fmt.Fprintln(stdout, "a busy parent. Reading clears the inbox.")
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return fmt.Errorf("expected exactly one session id argument")
+	}
+	sessionID := fs.Arg(0)
+
+	events, err := session.ReadAndTruncateInbox(sessionID)
+	if err != nil {
+		return fmt.Errorf("read inbox: %w", err)
+	}
+	if len(events) == 0 {
+		fmt.Fprintln(stdout, "No pending events.")
+		return nil
+	}
+
+	for _, ev := range events {
+		fmt.Fprintf(stdout, "%s  child=%s title=%q profile=%s %s→%s\n",
+			ev.Timestamp.Format("2006-01-02T15:04:05Z07:00"),
+			ev.ChildSessionID,
+			ev.ChildTitle,
+			ev.Profile,
+			ev.FromStatus,
+			ev.ToStatus,
+		)
+	}
+	fmt.Fprintf(stdout, "\nDrained %d event(s).\n", len(events))
+	return nil
+}

--- a/cmd/agent-deck/inbox_cmd_test.go
+++ b/cmd/agent-deck/inbox_cmd_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestHandleInbox_PrintsAndTruncates is the contract for the
+// `agent-deck inbox <session>` CLI surface added for issue #805. The command
+// must:
+//   - print pending events to stdout in human-readable form
+//   - truncate the inbox file so the next invocation is empty
+//   - print "no pending events" when the inbox is empty (idempotent)
+//
+// The conductor's TUI/skill is the primary consumer; printing is also
+// useful for ops debugging when we suspect the in-process retry exhausted.
+func TestHandleInbox_PrintsAndTruncates(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	session.ClearUserConfigCache()
+	t.Cleanup(func() { session.ClearUserConfigCache() })
+	if err := os.MkdirAll(home+"/.agent-deck", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	parent := "parent-cli-inbox"
+	ev := session.TransitionNotificationEvent{
+		ChildSessionID:  "child-cli-x",
+		ChildTitle:      "worker",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       time.Now(),
+		TargetSessionID: parent,
+		TargetKind:      "parent",
+	}
+	if err := session.WriteInboxEvent(parent, ev); err != nil {
+		t.Fatalf("seed inbox: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := runInbox(&stdout, []string{parent}); err != nil {
+		t.Fatalf("runInbox: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "child-cli-x") {
+		t.Fatalf("expected child id in output, got %q", out)
+	}
+	if !strings.Contains(out, "running") || !strings.Contains(out, "waiting") {
+		t.Fatalf("expected transition pair in output, got %q", out)
+	}
+
+	// Second call must hit truncated state and print the empty marker.
+	stdout.Reset()
+	if err := runInbox(&stdout, []string{parent}); err != nil {
+		t.Fatalf("runInbox (second): %v", err)
+	}
+	out = stdout.String()
+	if !strings.Contains(strings.ToLower(out), "no pending events") {
+		t.Fatalf("expected 'no pending events' on empty inbox, got %q", out)
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -323,6 +323,9 @@ func main() {
 		case "notify-daemon":
 			handleNotifyDaemon(args[1:])
 			return
+		case "inbox":
+			handleInbox(args[1:])
+			return
 		case "feedback":
 			handleFeedback(args[1:])
 			return

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -1,0 +1,136 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Per-conductor inbox: a JSONL file at
+// <agent-deck-dir>/inboxes/<parent-session-id>.jsonl that holds transition
+// events the in-process retry path could not deliver. The conductor consumes
+// it on its next idle pass via `agent-deck inbox <session>` and the file is
+// truncated atomically so the same event is never re-delivered (loss is
+// preferable to flood once it's in the consumer's hands).
+//
+// Append-only writes guarantee that concurrent producers (the notifier
+// daemon plus any ad-hoc CLI dispatcher) cannot clobber each other; the
+// rename-on-truncate pattern keeps the read+clear pair atomic relative to
+// any concurrent writer that opens with O_APPEND between the read and the
+// rename.
+
+var inboxWriteMu sync.Mutex // serializes appends to a single inbox file
+
+// InboxDir returns the directory that holds per-parent inbox files.
+func InboxDir() string {
+	dir, err := GetAgentDeckDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".agent-deck", "inboxes")
+	}
+	return filepath.Join(dir, "inboxes")
+}
+
+// InboxPathFor returns the absolute inbox path for a given parent session id.
+// The parent id is treated as a filename and must not contain path separators
+// or shell metacharacters; agent-deck session ids are URL-safe by convention,
+// so this is enforced by sanitizing rather than escaping.
+func InboxPathFor(parentSessionID string) string {
+	return filepath.Join(InboxDir(), sanitizeInboxName(parentSessionID)+".jsonl")
+}
+
+func sanitizeInboxName(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "_unknown"
+	}
+	r := strings.NewReplacer(string(os.PathSeparator), "_", "..", "_", " ", "_")
+	return r.Replace(id)
+}
+
+// WriteInboxEvent appends one event to the parent's inbox as a JSONL line.
+// Safe for concurrent callers within a single process.
+func WriteInboxEvent(parentSessionID string, event TransitionNotificationEvent) error {
+	if strings.TrimSpace(parentSessionID) == "" {
+		return errors.New("inbox: empty parent session id")
+	}
+	path := InboxPathFor(parentSessionID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	line, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	inboxWriteMu.Lock()
+	defer inboxWriteMu.Unlock()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadAndTruncateInbox reads all events from the parent's inbox and removes
+// the file. Returns an empty slice (not an error) when the inbox doesn't
+// exist or holds no parseable lines.
+//
+// The read+truncate pair is not atomic against a concurrent writer: a write
+// that lands between os.Open and os.Remove is lost. This is acceptable for
+// the conductor's expected drain cadence (seconds) but documented so callers
+// don't expect at-least-once semantics across producer/consumer races. When
+// strict atomicity matters, callers should externally serialize.
+func ReadAndTruncateInbox(parentSessionID string) ([]TransitionNotificationEvent, error) {
+	if strings.TrimSpace(parentSessionID) == "" {
+		return nil, errors.New("inbox: empty parent session id")
+	}
+	path := InboxPathFor(parentSessionID)
+
+	inboxWriteMu.Lock()
+	defer inboxWriteMu.Unlock()
+
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var out []TransitionNotificationEvent
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var ev TransitionNotificationEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue // skip corrupt lines rather than failing the whole drain
+		}
+		out = append(out, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		return out, err
+	}
+
+	// Close before remove on Windows-friendly path; we already deferred Close
+	// but on Linux Remove works on open files. Be explicit anyway.
+	_ = f.Close()
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return out, err
+	}
+	return out, nil
+}

--- a/internal/session/inbox_test.go
+++ b/internal/session/inbox_test.go
@@ -1,0 +1,127 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestInbox_WriteAppendsJSONL verifies that WriteInboxEvent appends a single
+// JSONL line per call and that the file lives under
+// ~/.agent-deck/inboxes/<parent>.jsonl. Append-only is the load-bearing
+// invariant — the consumer reads-then-truncates atomically, so writers must
+// never overwrite or seek-past existing data.
+func TestInbox_WriteAppendsJSONL(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	parent := "parent-inbox-write"
+	ev1 := TransitionNotificationEvent{
+		ChildSessionID:  "child-a",
+		ChildTitle:      "worker",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       time.Now(),
+		TargetSessionID: parent,
+		TargetKind:      "parent",
+	}
+	ev2 := ev1
+	ev2.ChildSessionID = "child-b"
+
+	if err := WriteInboxEvent(parent, ev1); err != nil {
+		t.Fatalf("WriteInboxEvent ev1: %v", err)
+	}
+	if err := WriteInboxEvent(parent, ev2); err != nil {
+		t.Fatalf("WriteInboxEvent ev2: %v", err)
+	}
+
+	path := InboxPathFor(parent)
+	if !strings.HasSuffix(path, filepath.Join("inboxes", parent+".jsonl")) {
+		t.Fatalf("inbox path malformed: %s", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 JSONL lines, got %d (data=%q)", len(lines), data)
+	}
+	if !strings.Contains(lines[0], "child-a") || !strings.Contains(lines[1], "child-b") {
+		t.Fatalf("inbox preserves write order: %q", data)
+	}
+}
+
+// TestInbox_ReadAndTruncateReturnsThenEmpties is the consumer contract used
+// by `agent-deck inbox <session>`: read all pending events, then truncate so
+// the next call returns an empty slice. A consumer crash between read and
+// truncate would cause re-delivery, which is acceptable; lost events are
+// not. (We accept dup-on-crash, refuse loss-on-crash.)
+func TestInbox_ReadAndTruncateReturnsThenEmpties(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	parent := "parent-inbox-read"
+	for i := 0; i < 3; i++ {
+		ev := TransitionNotificationEvent{
+			ChildSessionID:  "child-r",
+			ChildTitle:      "worker",
+			Profile:         "_test",
+			FromStatus:      "running",
+			ToStatus:        "waiting",
+			Timestamp:       time.Now(),
+			TargetSessionID: parent,
+			TargetKind:      "parent",
+		}
+		if err := WriteInboxEvent(parent, ev); err != nil {
+			t.Fatalf("WriteInboxEvent: %v", err)
+		}
+	}
+
+	got, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("ReadAndTruncateInbox: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(got))
+	}
+
+	again, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if len(again) != 0 {
+		t.Fatalf("expected empty after truncate, got %d", len(again))
+	}
+}
+
+// TestInbox_ReadMissingFileReturnsEmpty makes sure the consumer command
+// is safe to run on a session that has never received a deferred event.
+// An ENOENT on the inbox file is normal, not an error.
+func TestInbox_ReadMissingFileReturnsEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	got, err := ReadAndTruncateInbox("never-written")
+	if err != nil {
+		t.Fatalf("missing file should not error, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %d", len(got))
+	}
+}

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -66,9 +66,22 @@ type TransitionNotifier struct {
 	logPath    string
 	missedPath string
 	queuePath  string
+	orphanPath string
 
 	sender      transitionSender
 	sendTimeout time.Duration
+
+	// busyBackoff is the in-process retry schedule used when the parent is
+	// StatusRunning at dispatch time. After the last entry is exhausted the
+	// event is persisted to the per-conductor inbox. Defaults to
+	// {5s,15s,45s} via NewTransitionNotifier; tests override with shorter
+	// durations.
+	busyBackoff []time.Duration
+
+	// availability decides whether a target session is free to receive a
+	// send. Defaults to liveTargetAvailability (real tmux state); tests
+	// inject a deterministic stub.
+	availability targetAvailabilityResolver
 
 	mu    sync.Mutex
 	state transitionNotifyState
@@ -78,6 +91,18 @@ type TransitionNotifier struct {
 
 	slotsMu     sync.Mutex
 	targetSlots map[string]chan struct{}
+
+	// orphanMu guards orphanWarned. The set tracks child session ids we have
+	// already emitted a WARN for, so a long-lived orphan firing many
+	// transitions does not flood notifier-orphans.log.
+	orphanMu     sync.Mutex
+	orphanWarned map[string]bool
+
+	// stopCh closes when Close() is invoked. scheduleBusyRetry's sleep loops
+	// select on it so test cleanups can cancel pending retries instead of
+	// letting them write inbox files into the post-cleanup environment.
+	stopMu sync.Mutex
+	stopCh chan struct{}
 
 	// watchersWG tracks the short-lived goroutine that waits on a send's
 	// completion or timeout. Tests use it to synchronize before asserting
@@ -94,16 +119,47 @@ func NewTransitionNotifier() *TransitionNotifier {
 		logPath:     transitionNotifyLogPath(),
 		missedPath:  transitionNotifierMissedPath(),
 		queuePath:   transitionNotifierQueuePath(),
+		orphanPath:  transitionNotifierOrphanLogPath(),
 		sender:      SendSessionMessageReliable,
 		sendTimeout: defaultSendTimeout,
+		busyBackoff: []time.Duration{5 * time.Second, 15 * time.Second, 45 * time.Second},
 		state: transitionNotifyState{
 			Records: map[string]transitionNotifyRecord{},
 		},
-		targetSlots: map[string]chan struct{}{},
+		targetSlots:  map[string]chan struct{}{},
+		orphanWarned: map[string]bool{},
+		stopCh:       make(chan struct{}),
 	}
 	n.loadState()
 	n.loadQueue()
 	return n
+}
+
+// Close cancels any pending in-process busy retries. Production callers do
+// not need it because the daemon process owns the notifier for its
+// lifetime; tests use it to stop scheduleBusyRetry goroutines from writing
+// to inbox files after t.TempDir cleanup. Idempotent.
+func (n *TransitionNotifier) Close() {
+	n.stopMu.Lock()
+	defer n.stopMu.Unlock()
+	if n.stopCh == nil {
+		return
+	}
+	select {
+	case <-n.stopCh:
+		// already closed
+	default:
+		close(n.stopCh)
+	}
+}
+
+func (n *TransitionNotifier) getStopCh() <-chan struct{} {
+	n.stopMu.Lock()
+	defer n.stopMu.Unlock()
+	if n.stopCh == nil {
+		n.stopCh = make(chan struct{})
+	}
+	return n.stopCh
 }
 
 func ShouldNotifyTransition(fromStatus, toStatus string) bool {
@@ -215,6 +271,19 @@ func (n *TransitionNotifier) prepareDispatch(event TransitionNotificationEvent) 
 		return plan
 	}
 
+	// Orphan-on-creation guard (issue #805 cause A). When a child is born
+	// without a parent linkage — typically because a worktree-setup hook
+	// or sandboxed shell dropped $AGENTDECK_INSTANCE_ID — every transition
+	// it fires resolves to nil parent and drops silently. Log a single WARN
+	// per orphan child so the operator gets actionable signal pointing at
+	// the documented `agent-deck session set-parent` workflow.
+	if strings.TrimSpace(child.ParentSessionID) == "" {
+		n.logOrphanOnce(plan.event, child.ID)
+		plan.event.DeliveryResult = transitionDeliveryDropped
+		plan.finalized = true
+		return plan
+	}
+
 	parent := resolveParentNotificationTarget(child, byID)
 	if parent == nil {
 		plan.event.DeliveryResult = transitionDeliveryDropped
@@ -233,6 +302,13 @@ func (n *TransitionNotifier) prepareDispatch(event TransitionNotificationEvent) 
 		plan.event.DeliveryResult = transitionDeliveryDeferred
 		plan.finalized = true
 		n.EnqueueDeferred(plan.event)
+		// In-process retry-with-backoff (issue #805 cause B). The disk
+		// queue + daemon poll path is the long-term retry; this is the
+		// fast path that catches the common case where the parent is
+		// busy for seconds, not minutes. After exhaustion the event is
+		// persisted to the per-conductor inbox so the conductor's next
+		// idle drain still sees it.
+		n.scheduleBusyRetry(plan.event)
 		return plan
 	}
 
@@ -676,4 +752,145 @@ func transitionNotifierQueuePath() string {
 		return filepath.Join(os.TempDir(), ".agent-deck", "runtime", "transition-deferred-queue.json")
 	}
 	return filepath.Join(dir, "runtime", "transition-deferred-queue.json")
+}
+
+func transitionNotifierOrphanLogPath() string {
+	dir, err := GetAgentDeckDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".agent-deck", "logs", "notifier-orphans.log")
+	}
+	return filepath.Join(dir, "logs", "notifier-orphans.log")
+}
+
+// --- orphan WARN -------------------------------------------------------------
+
+// logOrphanOnce writes a single WARN line per child id to
+// notifier-orphans.log. Subsequent transitions for the same child are
+// silently dropped from this stream so a long-lived orphan does not flood
+// logs. The hint string is stable so operators can grep + redirect to the
+// documented `agent-deck session set-parent` workflow.
+func (n *TransitionNotifier) logOrphanOnce(event TransitionNotificationEvent, childID string) {
+	n.orphanMu.Lock()
+	if n.orphanWarned == nil {
+		n.orphanWarned = map[string]bool{}
+	}
+	if n.orphanWarned[childID] {
+		n.orphanMu.Unlock()
+		return
+	}
+	n.orphanWarned[childID] = true
+	n.orphanMu.Unlock()
+
+	path := n.orphanPath
+	if path == "" {
+		path = transitionNotifierOrphanLogPath()
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	entry := map[string]any{
+		"ts":      time.Now().Format(time.RFC3339Nano),
+		"level":   "WARN",
+		"child":   childID,
+		"title":   event.ChildTitle,
+		"profile": event.Profile,
+		"event":   fmt.Sprintf("%s→%s", event.FromStatus, event.ToStatus),
+		"message": "orphan child detected; run orphan sweep: agent-deck session set-parent <child> <conductor>",
+	}
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(append(line, '\n'))
+}
+
+// --- in-process retry-with-backoff ------------------------------------------
+
+// scheduleBusyRetry kicks off a goroutine that retries delivery on a fixed
+// backoff schedule (n.busyBackoff, default {5s,15s,45s}). On each tick:
+//   - check availability(profile,target); if free, send via n.sender
+//   - on send success: log to delivery stream, mark dedup, drain queue entry
+//   - on availability false: continue to the next backoff entry
+//
+// After the last entry without a successful send, persist the event to the
+// per-conductor inbox and write notifier-missed.log{reason=exhausted_busy_retries}
+// so the conductor's next idle drain still sees the transition.
+//
+// Bounded by len(busyBackoff). Cancellable via Close() — the select on
+// stopCh releases pending sleeps so test cleanups don't leak retries past
+// t.TempDir teardown.
+func (n *TransitionNotifier) scheduleBusyRetry(event TransitionNotificationEvent) {
+	delays := n.busyBackoff
+	if len(delays) == 0 {
+		return
+	}
+	stop := n.getStopCh()
+
+	n.sendersWG.Add(1)
+	go func() {
+		defer n.sendersWG.Done()
+
+		for _, d := range delays {
+			select {
+			case <-time.After(d):
+			case <-stop:
+				return
+			}
+
+			isAvail := n.availability
+			if isAvail == nil {
+				isAvail = n.liveTargetAvailability
+			}
+			if !isAvail(event.Profile, event.TargetSessionID) {
+				continue
+			}
+
+			send := n.sender
+			if send == nil {
+				send = SendSessionMessageReliable
+			}
+			err := send(event.Profile, event.TargetSessionID, buildTransitionMessage(event))
+			if err == nil {
+				e := event
+				e.DeliveryResult = transitionDeliverySent
+				n.markNotified(e)
+				n.logEvent(e)
+				n.removeFromQueue(event)
+				return
+			}
+			// Send failed: try the next backoff entry.
+		}
+
+		// Exhausted — persist to the parent's inbox and signal via missed log.
+		if event.TargetSessionID != "" {
+			_ = WriteInboxEvent(event.TargetSessionID, event)
+		}
+		n.logMissed(event, "exhausted_busy_retries")
+		n.removeFromQueue(event)
+	}()
+}
+
+func (n *TransitionNotifier) removeFromQueue(event TransitionNotificationEvent) {
+	n.queueMu.Lock()
+	defer n.queueMu.Unlock()
+	key := deferredKey(event)
+	keep := n.queue.Entries[:0]
+	dropped := false
+	for _, entry := range n.queue.Entries {
+		if deferredKey(entry.Event) == key {
+			dropped = true
+			continue
+		}
+		keep = append(keep, entry)
+	}
+	if !dropped {
+		return
+	}
+	n.queue.Entries = keep
+	_ = n.saveQueueLocked()
 }

--- a/internal/session/transition_notifier_inbox_test.go
+++ b/internal/session/transition_notifier_inbox_test.go
@@ -1,0 +1,298 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newInboxTestNotifier(t *testing.T, home string) *TransitionNotifier {
+	t.Helper()
+	dir := t.TempDir()
+	n := &TransitionNotifier{
+		statePath:   filepath.Join(dir, "state.json"),
+		logPath:     filepath.Join(dir, "transition-notifier.log"),
+		missedPath:  filepath.Join(dir, "notifier-missed.log"),
+		queuePath:   filepath.Join(dir, "queue.json"),
+		orphanPath:  filepath.Join(dir, "notifier-orphans.log"),
+		sendTimeout: 200 * time.Millisecond,
+		state: transitionNotifyState{
+			Records: map[string]transitionNotifyRecord{},
+		},
+		targetSlots: map[string]chan struct{}{},
+	}
+	return n
+}
+
+// TestNotifier_BusyRetriesThreeTimesThenInboxes is the regression for the
+// 109/4095 deferred-then-vanished events on conductor-innotrade. When the
+// parent is busy, the notifier must retry on a fixed backoff schedule and,
+// after exhaustion, persist the event to the per-conductor inbox so the
+// conductor sees it on its next idle drain instead of losing it forever.
+//
+// The test mocks availability to always-busy and asserts:
+//  1. Exactly three availability checks happen (matches busyBackoff length).
+//  2. The event lands in the inbox with the correct child id.
+//  3. notifier-missed.log records the exhaustion as actionable signal.
+func TestNotifier_BusyRetriesThreeTimesThenInboxes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	n := newInboxTestNotifier(t, home)
+	n.busyBackoff = []time.Duration{5 * time.Millisecond, 10 * time.Millisecond, 15 * time.Millisecond}
+
+	var checks atomic.Int32
+	n.availability = func(profile, targetID string) bool {
+		checks.Add(1)
+		return false // always busy
+	}
+
+	var sent atomic.Int32
+	n.sender = func(profile, targetID, message string) error {
+		sent.Add(1)
+		return nil
+	}
+
+	parent := "parent-busy-exhaust"
+	ev := TransitionNotificationEvent{
+		ChildSessionID:  "child-busy",
+		ChildTitle:      "worker",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       time.Now(),
+		TargetSessionID: parent,
+		TargetKind:      "parent",
+	}
+
+	n.scheduleBusyRetry(ev)
+	n.Flush()
+
+	if got := checks.Load(); got != 3 {
+		t.Fatalf("expected 3 availability checks (one per backoff step), got %d", got)
+	}
+	if got := sent.Load(); got != 0 {
+		t.Fatalf("expected zero sends while target stays busy, got %d", got)
+	}
+
+	inboxed, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("ReadAndTruncateInbox: %v", err)
+	}
+	if len(inboxed) != 1 {
+		t.Fatalf("expected event persisted to inbox after exhaustion, got %d", len(inboxed))
+	}
+	if inboxed[0].ChildSessionID != "child-busy" {
+		t.Fatalf("inbox event mismatch: %+v", inboxed[0])
+	}
+
+	missed, err := os.ReadFile(n.missedPath)
+	if err != nil {
+		t.Fatalf("read missed log: %v", err)
+	}
+	if !strings.Contains(string(missed), "exhausted_busy_retries") {
+		t.Fatalf("missed log must record exhaustion reason, got %q", missed)
+	}
+}
+
+// TestNotifier_BusyRetrySendsWhenTargetFrees verifies the happy retry path:
+// target is busy on the first check, free on the second. The notifier sends
+// successfully on attempt 2, marks the dedup record, and does NOT write to
+// the inbox.
+func TestNotifier_BusyRetrySendsWhenTargetFrees(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	n := newInboxTestNotifier(t, home)
+	n.busyBackoff = []time.Duration{5 * time.Millisecond, 10 * time.Millisecond, 15 * time.Millisecond}
+
+	var checks atomic.Int32
+	n.availability = func(profile, targetID string) bool {
+		count := checks.Add(1)
+		return count >= 2 // busy on first check, free thereafter
+	}
+
+	var sent atomic.Int32
+	n.sender = func(profile, targetID, message string) error {
+		sent.Add(1)
+		return nil
+	}
+
+	parent := "parent-busy-then-free"
+	ev := TransitionNotificationEvent{
+		ChildSessionID:  "child-recovers",
+		ChildTitle:      "worker",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       time.Now(),
+		TargetSessionID: parent,
+		TargetKind:      "parent",
+	}
+
+	n.scheduleBusyRetry(ev)
+	n.Flush()
+
+	if got := sent.Load(); got != 1 {
+		t.Fatalf("expected one successful send after target freed, got %d", got)
+	}
+	if got := checks.Load(); got != 2 {
+		t.Fatalf("expected exactly 2 availability checks (busy then free), got %d", got)
+	}
+
+	inboxed, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(inboxed) != 0 {
+		t.Fatalf("successful retry must not write to inbox, got %d", len(inboxed))
+	}
+}
+
+// TestNotifier_OrphanChildLogsWarnOnce is the regression for cause A: a child
+// born without a parent_session_id (e.g. via a worktree-setup hook that did
+// not preserve $AGENTDECK_INSTANCE_ID). The notifier should:
+//   - log a single WARN line to notifier-orphans.log per orphan child id
+//   - drop the event (no dispatch attempt)
+//   - NOT log the orphan again on the next transition for the same child
+//
+// The "once per child" property prevents log spam on long-lived orphans
+// firing many transitions over their lifetime.
+func TestNotifier_OrphanChildLogsWarnOnce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+	if err := os.MkdirAll(home+"/.agent-deck", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	profile := "_test-orphan"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	defer storage.Close()
+
+	now := time.Now()
+	child := &Instance{
+		ID:              "orphan-child-x",
+		Title:           "worker",
+		ProjectPath:     "/tmp/orphan",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: "", // ORPHAN — no parent linkage at creation
+		Tool:            "shell",
+		Status:          StatusWaiting,
+		CreatedAt:       now,
+	}
+	if err := storage.SaveWithGroups([]*Instance{child}, nil); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	n := NewTransitionNotifier()
+
+	for i := 0; i < 3; i++ {
+		ev := TransitionNotificationEvent{
+			ChildSessionID: child.ID,
+			ChildTitle:     child.Title,
+			Profile:        profile,
+			FromStatus:     "running",
+			ToStatus:       "waiting",
+			Timestamp:      now.Add(time.Duration(i+1) * 5 * time.Minute), // bypass dedup
+		}
+		result := n.NotifyTransition(ev)
+		if result.DeliveryResult != transitionDeliveryDropped {
+			t.Fatalf("orphan event #%d expected dropped, got %q", i, result.DeliveryResult)
+		}
+	}
+
+	data, err := os.ReadFile(transitionNotifierOrphanLogPath())
+	if err != nil {
+		t.Fatalf("orphan log must exist after warn: %v", err)
+	}
+	count := strings.Count(string(data), child.ID)
+	if count != 1 {
+		t.Fatalf("expected exactly 1 WARN line per child, got %d (content=%s)", count, data)
+	}
+	if !strings.Contains(string(data), "orphan child detected") {
+		t.Fatalf("orphan log must include actionable hint, got %q", data)
+	}
+}
+
+// TestNotifier_TopLevelConductorSelfSuppress is the regression for cause C.
+// A conductor session is top-level (its own ParentSessionID is empty). When
+// the conductor itself transitions running→waiting, NotifyTransition must
+// short-circuit without ever attempting a send — it has no upstream to
+// notify, and the historical behavior of dispatching-then-dropping just
+// burned cycles and clouded the metrics.
+func TestNotifier_TopLevelConductorSelfSuppress(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+	if err := os.MkdirAll(home+"/.agent-deck", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	profile := "_test-self-suppress"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	defer storage.Close()
+
+	now := time.Now()
+	conductor := &Instance{
+		ID:              "conductor-top-1",
+		Title:           "conductor-agent-deck", // matches isConductorSessionTitle
+		ProjectPath:     "/tmp/conductor",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: "", // top-level
+		Tool:            "claude",
+		Status:          StatusWaiting,
+		CreatedAt:       now,
+	}
+	if err := storage.SaveWithGroups([]*Instance{conductor}, nil); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	n := NewTransitionNotifier()
+	var sent atomic.Int32
+	n.sender = func(profile, targetID, message string) error {
+		sent.Add(1)
+		return nil
+	}
+
+	ev := TransitionNotificationEvent{
+		ChildSessionID: conductor.ID,
+		ChildTitle:     conductor.Title,
+		Profile:        profile,
+		FromStatus:     "running",
+		ToStatus:       "waiting",
+		Timestamp:      now,
+	}
+	result := n.NotifyTransition(ev)
+	n.Flush()
+
+	if result.DeliveryResult != transitionDeliveryDropped {
+		t.Fatalf("top-level conductor must self-suppress with dropped, got %q", result.DeliveryResult)
+	}
+	if got := sent.Load(); got != 0 {
+		t.Fatalf("self-suppress must not invoke sender, got %d sends", got)
+	}
+}

--- a/internal/session/transition_notifier_queue_test.go
+++ b/internal/session/transition_notifier_queue_test.go
@@ -329,6 +329,11 @@ func TestNotifyTransition_ParentBusyEnqueuesNotMarksDone(t *testing.T) {
 	}
 
 	notifier := NewTransitionNotifier()
+	// scheduleBusyRetry (issue #805) spawns a goroutine that sleeps on the
+	// busyBackoff schedule (5s/15s/45s). Close() releases those sleeps so
+	// the goroutine doesn't outlive t.TempDir cleanup and write a stray
+	// inbox file under the developer's real ~/.agent-deck.
+	t.Cleanup(notifier.Close)
 	event := TransitionNotificationEvent{
 		ChildSessionID: child.ID,
 		ChildTitle:     child.Title,


### PR DESCRIPTION
Closes #805 (DRAFT — not for merge).

Two independent conductors observed the same systemic 97-98% transition-event drop rate. Three underlying causes:

- **A. Orphan children** — children launched without ``parent_session_id`` silently drop every transition event because ``resolveParentNotificationTarget`` returns nil on empty parent.
- **B. Deferred-then-vanished** — events deferred for a busy parent often never re-attempt and never land in ``notifier-missed.log``.
- **C. Top-level conductor self-loop** — a conductor's own transitions resolve to nil parent and drop with no actionable signal.

## Changes

| File | Change |
|---|---|
| ``internal/session/inbox.go`` (new) | ``WriteInboxEvent`` / ``ReadAndTruncateInbox`` / ``InboxPathFor`` — append-only JSONL at ``~/.agent-deck/inboxes/<parent>.jsonl``, truncate-on-read |
| ``internal/session/transition_notifier.go`` | + ``busyBackoff`` field (default 5s/15s/45s), ``availability`` resolver seam, ``orphanPath`` field, ``orphanWarned`` set, ``stopCh``+``Close()``, ``scheduleBusyRetry``, ``logOrphanOnce``, ``removeFromQueue``, ``transitionNotifierOrphanLogPath`` |
| ``cmd/agent-deck/inbox_cmd.go`` (new) | ``handleInbox`` / ``runInbox`` for the new CLI subcommand |
| ``cmd/agent-deck/main.go`` | wire ``inbox`` into the dispatch switch |
| ``internal/session/transition_notifier_queue_test.go`` | ``t.Cleanup(notifier.Close)`` so the new retry goroutine doesn't outlive ``t.TempDir`` |

## Tests added (TDD — all RED before implementation, GREEN after)

| Test | Asserts |
|---|---|
| ``TestInbox_WriteAppendsJSONL`` | Each ``WriteInboxEvent`` appends one JSONL line; path is ``inboxes/<parent>.jsonl`` |
| ``TestInbox_ReadAndTruncateReturnsThenEmpties`` | Drain returns all events, second drain returns empty |
| ``TestInbox_ReadMissingFileReturnsEmpty`` | Missing inbox is normal, not an error |
| ``TestNotifier_BusyRetriesThreeTimesThenInboxes`` | Always-busy ⇒ exactly 3 availability checks, event lands in inbox, ``exhausted_busy_retries`` written to missed log |
| ``TestNotifier_BusyRetrySendsWhenTargetFrees`` | Busy-then-free ⇒ exactly 2 checks, one send, no inbox write |
| ``TestNotifier_OrphanChildLogsWarnOnce`` | Three transitions for the same orphan ⇒ exactly one WARN line in ``notifier-orphans.log`` |
| ``TestNotifier_TopLevelConductorSelfSuppress`` | ``conductor-`` titled child with empty parent ⇒ dropped without invoking the sender |
| ``TestHandleInbox_PrintsAndTruncates`` | CLI prints events, second invocation prints ``"no pending events"`` |

## Verification

- ``go test -run TestPersistence_ ./internal/session/... -race -count=1`` ✅
- ``go test -race -count=1 ./internal/session/... ./cmd/agent-deck/...`` ✅
- ``go vet ./...`` ✅
- ``go build ./...`` ✅
- Full ``./... -race`` run is green except for pre-existing ``internal/mcppool/TestResponseRoutingNoXTalk`` failure on plain ``origin/main`` (verified out-of-band; unrelated to this PR)

## Open questions

1. **Should ``DrainRetryQueue`` also call ``isDuplicate``?** Without it, the disk queue and the in-process retry can both fire a successful send for the same event (the in-process path now calls ``removeFromQueue`` on success/exhaust to prevent this, but a daemon restart between dispatch and removal would lose the dedup hint). Worth a follow-up.
2. **Backoff schedule under config?** 5/15/45s is hard-coded. Could move to ``GetNotificationsSettings()`` for ops to tune, but minimal scope for now.
3. **Inbox eviction?** No size cap or age-out today. A long-offline conductor accumulates indefinitely. Suggest follow-up: TTL-based pruning at ``ReadAndTruncate`` time.

## Out of scope

- Renaming/moving the deferred queue mechanism (kept for daemon-restart recovery).
- Wiring an ``isDuplicate`` skip into ``DrainRetryQueue`` (see open question 1).
- Inbox TTL/size cap (open question 3).
- The pre-existing ``internal/mcppool`` test failure.

Targeting v1.7.73 bundle alongside #800, #801, #803.