### PR TITLE
fix(hooks): emit allow decision for PermissionRequest in DSP-launched sessions

### DIFF
--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -131,6 +131,36 @@ func handleHookHandler() {
 	// Write cost event if this hook contains usage data
 	logCostDebug("hook event=%s instance=%s status=%s", payload.HookEventName, instanceID, status)
 	writeCostEvent(instanceID, data)
+
+	// PermissionRequest in DSP-launched, agent-deck-managed sessions: emit an
+	// explicit allow decision so headless / /remote-control contexts (which
+	// have no UI fallback) do not silently deny. DSP is the user-declared
+	// trust signal; the hook just makes that declaration consistent across
+	// interactive and non-interactive Claude UIs. Without this, a sync hook
+	// that exits with no decision falls through to Claude Code's default,
+	// which denies in UI-less contexts. Status-tracking behavior above is
+	// unchanged.
+	if payload.HookEventName == "PermissionRequest" && parentIsDSP() {
+		fmt.Println(`{"hookSpecificOutput":{"hookEventName":"PermissionRequest","permissionDecision":"allow"}}`)
+	}
+}
+
+// parentIsDSP reports whether the parent process (typically the claude binary)
+// was launched with --dangerously-skip-permissions. Returns true if the
+// AGENTDECK_DSP_MODE env var is explicitly set, or, on Linux/WSL, if the
+// parent's /proc/<ppid>/cmdline contains the DSP flag. Returns false on
+// non-Linux platforms unless AGENTDECK_DSP_MODE is set, since /proc is
+// unavailable; agent-deck launch paths can opt those platforms in via the
+// env var when needed.
+func parentIsDSP() bool {
+	if os.Getenv("AGENTDECK_DSP_MODE") == "1" {
+		return true
+	}
+	cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", os.Getppid()))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(cmdline), "--dangerously-skip-permissions")
 }
 
 // writeHookStatus writes a hook status file atomically for one instance.

--- a/cmd/agent-deck/hook_handler_test.go
+++ b/cmd/agent-deck/hook_handler_test.go
@@ -255,3 +255,25 @@ func TestIsTerminalHookEvent(t *testing.T) {
 		}
 	}
 }
+
+// TestParentIsDSP_EnvVarOverride verifies the explicit env-var path of the DSP
+// detection used by handleHookHandler to emit a PermissionRequest allow.
+// The env-var path is the cross-platform fallback when /proc is unavailable
+// (macOS) or when the launch site wants to declare DSP intent explicitly.
+func TestParentIsDSP_EnvVarOverride(t *testing.T) {
+	t.Setenv("AGENTDECK_DSP_MODE", "1")
+	if !parentIsDSP() {
+		t.Errorf("parentIsDSP() = false; expected true when AGENTDECK_DSP_MODE=1")
+	}
+}
+
+// TestParentIsDSP_NoOverrideNoFlag verifies that without the env var override
+// AND without --dangerously-skip-permissions in the parent's cmdline,
+// parentIsDSP returns false. The Go test runner is not launched with DSP, so
+// /proc/<ppid>/cmdline should not contain the flag in normal CI.
+func TestParentIsDSP_NoOverrideNoFlag(t *testing.T) {
+	t.Setenv("AGENTDECK_DSP_MODE", "")
+	if parentIsDSP() {
+		t.Skipf("parentIsDSP() returned true unexpectedly; the test runner's parent appears to have --dangerously-skip-permissions in its cmdline. Skipping the negative assertion.")
+	}
+}

--- a/internal/session/claude_hooks.go
+++ b/internal/session/claude_hooks.go
@@ -43,7 +43,12 @@ var hookEventConfigs = []struct {
 	{Event: "SessionStart", Async: true},
 	{Event: "UserPromptSubmit", Async: true},
 	{Event: "Stop", Async: true},
-	{Event: "PermissionRequest", Async: true},
+	// PermissionRequest is synchronous so the hook handler's stdout decision is
+	// consulted by Claude Code. In headless / /remote-control contexts an async
+	// hook with no UI fallback caused silent deny; the sync hook plus an
+	// emitted allow decision (when DSP is detected) closes that gap. Status
+	// tracking semantics are unchanged.
+	{Event: "PermissionRequest", Async: false},
 	{Event: "Notification", Matcher: "permission_prompt|elicitation_dialog", Async: true},
 	{Event: "SessionEnd", Async: true},
 	{Event: "PreCompact", Async: false},

--- a/internal/session/claude_hooks_test.go
+++ b/internal/session/claude_hooks_test.go
@@ -105,6 +105,49 @@ func TestPreCompactHookIsSynchronous(t *testing.T) {
 	}
 }
 
+// TestPermissionRequestHookIsSynchronous guards the fix for the headless /
+// /remote-control silent-deny: an async PermissionRequest hook with no UI
+// fallback was treated as a non-decision and Claude Code defaulted to deny.
+// Sync mode lets Claude Code consult the hook's stdout decision.
+func TestPermissionRequestHookIsSynchronous(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if _, err := InjectClaudeHooks(tmpDir); err != nil {
+		t.Fatalf("InjectClaudeHooks failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("Failed to read settings.json: %v", err)
+	}
+	var settings map[string]json.RawMessage
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("Failed to parse settings: %v", err)
+	}
+
+	var hooks map[string]json.RawMessage
+	if err := json.Unmarshal(settings["hooks"], &hooks); err != nil {
+		t.Fatalf("Failed to parse hooks: %v", err)
+	}
+
+	var matchers []claudeHookMatcher
+	if err := json.Unmarshal(hooks["PermissionRequest"], &matchers); err != nil {
+		t.Fatalf("Failed to parse PermissionRequest matchers: %v", err)
+	}
+
+	if len(matchers) == 0 || len(matchers[0].Hooks) == 0 {
+		t.Fatal("PermissionRequest has no hooks")
+	}
+
+	hook := matchers[0].Hooks[0]
+	if hook.Async {
+		t.Error("PermissionRequest hook must be synchronous (Async should be false) so Claude Code consults the hook's stdout decision")
+	}
+	if hook.Command != agentDeckHookCommand {
+		t.Errorf("PermissionRequest hook command = %q, want %q", hook.Command, agentDeckHookCommand)
+	}
+}
+
 func TestInjectClaudeHooks_PreservesExisting(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Closes a silent-deny gap that blocks agent-deck-managed Claude Code sessions from filesystem operations when invoked from \`/remote-control\` (and other headless / no-UI contexts).

Previously, agent-deck registered \`PermissionRequest\` as \`Async: true\`. The hook handler is a status tracker, not a permission decider; it writes \`~/.agent-deck/hooks/{instance}.json\` and exits 0 with no decision. In TUI sessions Claude Code's UI prompts the user. In \`/remote-control\` (no UI fallback), Claude Code treats the hook's silence as a non-decision and defaults to deny. Bash file system reads (\`ls /mnt/c/...\`) silently fail with no surfaced prompt.

This PR:

1. Flips PermissionRequest to \`Async: false\` so Claude Code consults the hook's stdout for a decision.
2. Adds an emission of \`{\"hookSpecificOutput\":{\"hookEventName\":\"PermissionRequest\",\"permissionDecision\":\"allow\"}}\` when the parent process was launched with \`--dangerously-skip-permissions\`. DSP is the user-declared trust signal; auto-allow is consistent with that declaration regardless of UI presence.
3. Detects DSP via either \`AGENTDECK_DSP_MODE=1\` env var (cross-platform) or \`/proc/<ppid>/cmdline\` (Linux/WSL).
4. Status-tracking semantics are unchanged. Non-DSP and non-agent-deck-managed sessions are unaffected.

## Test plan

- [x] \`go test ./internal/session/\` — passes (13.4s)
- [x] \`go test ./cmd/agent-deck/\` — passes (59.6s)
- [x] New test \`TestPermissionRequestHookIsSynchronous\` guards the Async: false registration so future regressions are caught
- [x] New test \`TestParentIsDSP_EnvVarOverride\` covers cross-platform env-var detection
- [x] New test \`TestParentIsDSP_NoOverrideNoFlag\` covers the negative case
- [x] **End-to-end manual verification from a /remote-control session**: \`agent-deck status\`, \`agent-deck list\`, \`ls /mnt/c/...\`, \`agent-deck session output\`, \`agent-deck session send\` all return cleanly. The previously-blocked FS read now returns directory entries.

## Behavior matrix

| Mode | DSP | Hook output | CC reaction |
|---|---|---|---|
| TUI + agent-deck | on | allow | allow (consistent with DSP server-side) |
| TUI + agent-deck | off | silent | CC default (UI prompt) |
| /remote-control + agent-deck | on | allow | allow (closes the silent-deny gap) |
| /remote-control + agent-deck | off | silent | CC default (may still deny; uncommon path) |
| Non-agent-deck CC session (no \`AGENTDECK_INSTANCE_ID\`) | n/a | hook returns silently | unchanged |

## Background

This was diagnosed and verified during 2026-04-28 work on /remote-control feature parity. The hook handler had been correctly suspected of "silently auto-denying file ops" in /remote-control; closer source review showed the handler is innocent (purely a status-tracker) and the silent-deny is Claude Code's default response to a synchronous-or-async \`PermissionRequest\` hook that exits 0 with no \`permissionDecision\` in a UI-less context. The fix changes both the registration (sync) and the handler (emit \`allow\` in DSP) to make the trust model honest across both interactive and non-interactive Claude UIs.

Considered but rejected: a /remote-control-aware bypass. No detection mechanism is currently exposed by Claude Code, and DSP is a more durable, user-controlled signal that also covers any future non-TUI invocation path (cron, CI, MCP-only).

## Followup, separate PR

\`hooksAlreadyInstalled\` in \`internal/session/claude_hooks.go\` only checks **presence** of the hook command, not whether the \`Async\` flag matches the current \`hookEventConfigs\` table. That means upgrading the agent-deck binary in place does not update existing settings.json hook entries; \`agent-deck hooks install\` no-ops with "already installed." Worth a follow-up PR to extend the check to verify \`Async\` (and \`Matcher\` where applicable) match the current config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)