### PR TITLE
fix(codex): timeout-wrap the sessions tree walk to prevent indefinite hangs

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1356,6 +1356,38 @@ func getCodexHomeDir() string {
 	return filepath.Join(home, ".codex")
 }
 
+// runWithTimeout runs op in a goroutine and waits up to timeout for it to
+// complete. Returns true if op finished, false if it timed out. The
+// abandoned goroutine continues running until op returns naturally; its
+// effects on shared state after timeout are not consulted by callers, which
+// must check the return value before reading any variables op may have
+// written.
+//
+// Used to backstop FS operations under ~/.codex/sessions which can hang
+// indefinitely on a stuck FS layer (kernel D-state during readdir on the
+// WSL 9p path was observed on 2026-04-28; one thread held a dentry that
+// the FS layer never released, blocking every agent-deck CLI command that
+// transitively walked the codex sessions tree).
+func runWithTimeout(timeout time.Duration, op func()) bool {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		op()
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// codexWalkDirTimeout caps the recursive walk over $CODEX_HOME/sessions/ in
+// queryCodexSession. Healthy walks of a year's sessions complete in roughly
+// one second; the bound is generous so a slow disk does not false-negative
+// while still preventing indefinite hangs.
+const codexWalkDirTimeout = 5 * time.Second
+
 // queryCodexSession scans Codex sessions and returns the best candidate.
 // Selection strategy:
 //  1. Prefer sessions whose JSONL metadata matches this instance's project path.
@@ -1375,57 +1407,70 @@ func (i *Instance) queryCodexSession(excludeIDs map[string]bool, allowUnscoped b
 
 	normalizedProjectPath := normalizePath(i.ProjectPath)
 
-	err := filepath.WalkDir(sessionsDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil // Skip errors
-		}
+	var walkErr error
+	if !runWithTimeout(codexWalkDirTimeout, func() {
+		walkErr = filepath.WalkDir(sessionsDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil // Skip errors
+			}
 
-		if d.IsDir() || !strings.HasSuffix(d.Name(), ".jsonl") {
-			return nil
-		}
-
-		sessionID := uuidPattern.FindString(d.Name())
-		if sessionID == "" {
-			return nil
-		}
-		if excludeIDs != nil && excludeIDs[sessionID] {
-			return nil
-		}
-
-		info, err := d.Info()
-		if err != nil {
-			return nil
-		}
-
-		// Only consider sessions created after we started this instance.
-		if i.CodexStartedAt > 0 {
-			startTime := time.UnixMilli(i.CodexStartedAt)
-			if info.ModTime().Before(startTime) {
+			if d.IsDir() || !strings.HasSuffix(d.Name(), ".jsonl") {
 				return nil
 			}
-		}
 
-		matchesProject, hasProjectMetadata := codexSessionMatchesProject(path, normalizedProjectPath)
-		if matchesProject {
-			if bestScopedID == "" || info.ModTime().After(bestScopedTime) {
-				bestScopedID = sessionID
-				bestScopedTime = info.ModTime()
+			sessionID := uuidPattern.FindString(d.Name())
+			if sessionID == "" {
+				return nil
 			}
+			if excludeIDs != nil && excludeIDs[sessionID] {
+				return nil
+			}
+
+			info, err := d.Info()
+			if err != nil {
+				return nil
+			}
+
+			// Only consider sessions created after we started this instance.
+			if i.CodexStartedAt > 0 {
+				startTime := time.UnixMilli(i.CodexStartedAt)
+				if info.ModTime().Before(startTime) {
+					return nil
+				}
+			}
+
+			matchesProject, hasProjectMetadata := codexSessionMatchesProject(path, normalizedProjectPath)
+			if matchesProject {
+				if bestScopedID == "" || info.ModTime().After(bestScopedTime) {
+					bestScopedID = sessionID
+					bestScopedTime = info.ModTime()
+				}
+				return nil
+			}
+
+			// Use unscoped records only when bootstrapping and metadata is unavailable.
+			if allowUnscoped && !hasProjectMetadata {
+				if bestUnscopedID == "" || info.ModTime().After(bestUnscopedTime) {
+					bestUnscopedID = sessionID
+					bestUnscopedTime = info.ModTime()
+				}
+			}
+
 			return nil
-		}
-
-		// Use unscoped records only when bootstrapping and metadata is unavailable.
-		if allowUnscoped && !hasProjectMetadata {
-			if bestUnscopedID == "" || info.ModTime().After(bestUnscopedTime) {
-				bestUnscopedID = sessionID
-				bestUnscopedTime = info.ModTime()
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		sessionLog.Debug("codex_scan_error", slog.String("error", err.Error()))
+		})
+	}) {
+		// Walk did not complete in time. The most likely cause is a stuck FS
+		// layer (e.g., WSL kernel D-state). Return without consulting the
+		// best* variables since they may be partially populated; the caller
+		// retries with backoff so a transient stall self-heals.
+		sessionLog.Warn("codex_walkdir_timeout",
+			slog.String("instance_id", i.ID),
+			slog.String("sessions_dir", sessionsDir),
+			slog.Duration("timeout", codexWalkDirTimeout))
+		return ""
+	}
+	if walkErr != nil {
+		sessionLog.Debug("codex_scan_error", slog.String("error", walkErr.Error()))
 	}
 
 	if bestScopedID != "" {

--- a/internal/session/runtimeout_test.go
+++ b/internal/session/runtimeout_test.go
@@ -1,0 +1,71 @@
+package session
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRunWithTimeout_CompletesBeforeTimeout verifies the happy path: an op
+// that finishes quickly returns true, and its writes to captured state are
+// observable by the caller.
+func TestRunWithTimeout_CompletesBeforeTimeout(t *testing.T) {
+	var got int
+	completed := runWithTimeout(500*time.Millisecond, func() {
+		got = 42
+	})
+	if !completed {
+		t.Fatalf("runWithTimeout reported timeout for an instant op")
+	}
+	if got != 42 {
+		t.Errorf("captured state = %d, want 42", got)
+	}
+}
+
+// TestRunWithTimeout_TimesOut verifies the timeout path: an op that blocks
+// longer than the deadline returns false, and the caller is unblocked
+// promptly (within a small buffer over the configured timeout).
+func TestRunWithTimeout_TimesOut(t *testing.T) {
+	timeout := 50 * time.Millisecond
+	start := time.Now()
+	completed := runWithTimeout(timeout, func() {
+		time.Sleep(2 * time.Second) // far longer than the timeout
+	})
+	elapsed := time.Since(start)
+	if completed {
+		t.Fatalf("runWithTimeout reported completion for a long-blocking op")
+	}
+	// Allow generous slack: the select should fire near the timeout, but
+	// scheduler jitter on a busy CI host can add tens of ms. 500ms ceiling
+	// is comfortably below the op's 2s sleep, so this catches real
+	// regressions without being flaky.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("caller blocked for %v, expected return near %v", elapsed, timeout)
+	}
+}
+
+// TestRunWithTimeout_AbandonedGoroutineIsHarmless verifies the contract that
+// callers must not consult captured state after timeout. We trigger the
+// timeout path, the abandoned goroutine eventually writes to a shared
+// counter, and the test ends without panicking. The counter assertion is
+// secondary: it just confirms the goroutine kept running, which is
+// expected (we cannot kill goroutines from outside).
+func TestRunWithTimeout_AbandonedGoroutineIsHarmless(t *testing.T) {
+	var counter atomic.Int64
+	completed := runWithTimeout(20*time.Millisecond, func() {
+		time.Sleep(200 * time.Millisecond)
+		counter.Add(1)
+	})
+	if completed {
+		t.Fatalf("expected timeout, got completion")
+	}
+
+	// Wait long enough for the abandoned goroutine to finish on a healthy
+	// scheduler. If it never increments, that is also fine; the contract
+	// is just that the caller is not blocked and does not panic.
+	time.Sleep(400 * time.Millisecond)
+	final := counter.Load()
+	if final != 0 && final != 1 {
+		t.Errorf("counter = %d after abandoned goroutine; expected 0 or 1", final)
+	}
+}


### PR DESCRIPTION
## Summary

\`queryCodexSession\` recursively walks \`~/.codex/sessions\` via \`filepath.WalkDir\` to find resumable Codex sessions. When the underlying FS layer stalls (a WSL kernel D-state on a stuck dentry was observed on 2026-04-28; one thread held a fd whose dentry sat in \`d_alloc_parallel\`), the walk blocks indefinitely. Every \`agent-deck\` CLI command that transitively calls this function hangs along with it.

This PR wraps the \`WalkDir\` call in a 5s timeout via a small \`runWithTimeout\` helper. On timeout we log a warning and return empty without consulting partially populated state. The walk goroutine continues in the background until the FS clears.

## Test plan

- [x] \`go test ./internal/session/\` passes (full suite, 14s)
- [x] \`go test ./cmd/agent-deck/\` passes (full suite, 60s)
- [x] New tests cover the helper:
  - \`TestRunWithTimeout_CompletesBeforeTimeout\`
  - \`TestRunWithTimeout_TimesOut\`
  - \`TestRunWithTimeout_AbandonedGoroutineIsHarmless\`

## Background

This is a defensive resilience fix. The 2026-04-28 kernel-level WSL FS stall that surfaced this code path was cleared by \`wsl --shutdown\`, so the proximate cause is gone. But the agent-deck CLI should not be able to indefinitely block on any FS layer issue. This PR is the structural defense so a future stall (kernel, mount, fuse, etc.) cannot lock up CLI invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)