### PR TITLE
fix(hooks): detect and update stale Async config on reinstall

### DIFF
--- a/internal/session/claude_hooks.go
+++ b/internal/session/claude_hooks.go
@@ -220,21 +220,32 @@ func CheckClaudeHooksInstalled(configDir string) bool {
 	return hooksAlreadyInstalled(existingHooks)
 }
 
-// hooksAlreadyInstalled checks if all required agent-deck hooks are present.
+// hooksAlreadyInstalled checks if all required agent-deck hooks are present
+// AND their config (Matcher and Async flag) matches the current
+// hookEventConfigs table. Returns false on any drift so a subsequent
+// InjectClaudeHooks call will merge the current config in.
+//
+// Pre-2026-04-29 this only checked presence, which let stale Async flags
+// from older binary versions linger across upgrades. The PermissionRequest
+// async-true to async-false flip in the /remote-control parity fix
+// surfaced the bug: settings.json kept the old flag because hooks install
+// no-opped on "already installed."
 func hooksAlreadyInstalled(hooks map[string]json.RawMessage) bool {
 	for _, cfg := range hookEventConfigs {
 		raw, ok := hooks[cfg.Event]
 		if !ok {
 			return false
 		}
-		if !eventHasAgentDeckHook(raw) {
+		if !eventHasAgentDeckHookMatchingConfig(raw, cfg.Matcher, cfg.Async) {
 			return false
 		}
 	}
 	return true
 }
 
-// eventHasAgentDeckHook checks if a hook event's matcher array contains our hook.
+// eventHasAgentDeckHook checks if a hook event's matcher array contains our
+// hook command anywhere, regardless of Matcher or Async config. Kept for
+// callers that only need a presence check.
 func eventHasAgentDeckHook(raw json.RawMessage) bool {
 	var matchers []claudeHookMatcher
 	if err := json.Unmarshal(raw, &matchers); err != nil {
@@ -244,6 +255,27 @@ func eventHasAgentDeckHook(raw json.RawMessage) bool {
 		for _, h := range m.Hooks {
 			if strings.Contains(h.Command, agentDeckHookCommand) {
 				return true
+			}
+		}
+	}
+	return false
+}
+
+// eventHasAgentDeckHookMatchingConfig checks both presence AND config match:
+// the agent-deck hook entry must live under a matcher block whose Matcher
+// field equals the expected value, and its Async flag must match.
+func eventHasAgentDeckHookMatchingConfig(raw json.RawMessage, expectedMatcher string, expectedAsync bool) bool {
+	var matchers []claudeHookMatcher
+	if err := json.Unmarshal(raw, &matchers); err != nil {
+		return false
+	}
+	for _, m := range matchers {
+		if m.Matcher != expectedMatcher {
+			continue
+		}
+		for _, h := range m.Hooks {
+			if strings.Contains(h.Command, agentDeckHookCommand) {
+				return h.Async == expectedAsync
 			}
 		}
 	}
@@ -264,10 +296,14 @@ func mergeHookEvent(existing json.RawMessage, matcher string, async bool) json.R
 	// Check if we already have a matcher entry with our hook
 	for i, m := range matchers {
 		if m.Matcher == matcher {
-			// Check if our hook is already in this matcher
-			for _, h := range m.Hooks {
+			// Update our existing entry to the current config (Async/Type),
+			// or append if it is missing. In-place update covers the
+			// binary-upgrade case where the hookEventConfigs table changes
+			// (e.g., flipping Async from true to false) and the persisted
+			// settings.json must drift to follow.
+			for j, h := range m.Hooks {
 				if strings.Contains(h.Command, agentDeckHookCommand) {
-					// Already present
+					matchers[i].Hooks[j] = agentDeckHook(async)
 					result, _ := json.Marshal(matchers)
 					return result
 				}

--- a/internal/session/claude_hooks_test.go
+++ b/internal/session/claude_hooks_test.go
@@ -381,3 +381,100 @@ func TestNotificationMatcher(t *testing.T) {
 		t.Errorf("Notification matcher = %q, want %q", matchers[0].Matcher, "permission_prompt|elicitation_dialog")
 	}
 }
+
+// TestHooksAlreadyInstalled_DetectsAsyncDrift guards the binary-upgrade
+// case: settings.json may have an agent-deck hook with stale Async config
+// from a previous version. hooksAlreadyInstalled must return false so
+// InjectClaudeHooks rewrites the entry to match the current config.
+func TestHooksAlreadyInstalled_DetectsAsyncDrift(t *testing.T) {
+	// Build a hooks map that has every required event but with PermissionRequest
+	// stuck at Async=true (the pre-2026-04-29 config). The current code wants
+	// Async=false. This must register as drift.
+	staleHooks := map[string]json.RawMessage{}
+	for _, cfg := range hookEventConfigs {
+		stale := claudeHookMatcher{
+			Matcher: cfg.Matcher,
+			Hooks:   []claudeHookEntry{{Type: "command", Command: agentDeckHookCommand, Async: true}},
+		}
+		raw, _ := json.Marshal([]claudeHookMatcher{stale})
+		staleHooks[cfg.Event] = raw
+	}
+
+	if hooksAlreadyInstalled(staleHooks) {
+		t.Errorf("hooksAlreadyInstalled returned true on stale Async; expected false to trigger reinstall")
+	}
+}
+
+// TestInjectClaudeHooks_UpdatesStaleAsync verifies the integration: a
+// settings.json that already contains the agent-deck PermissionRequest hook
+// but with the old Async=true gets rewritten to Async=false on the next
+// InjectClaudeHooks call.
+func TestInjectClaudeHooks_UpdatesStaleAsync(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Hand-craft a settings.json mimicking the post-mitigation pre-fix
+	// state: PermissionRequest present with Async=true (stale).
+	stalePermissionRequest := []claudeHookMatcher{
+		{Hooks: []claudeHookEntry{{Type: "command", Command: agentDeckHookCommand, Async: true}}},
+	}
+	staleRaw, _ := json.Marshal(stalePermissionRequest)
+	hooks := map[string]json.RawMessage{"PermissionRequest": staleRaw}
+
+	// Add the rest of the events with whatever Async flags hookEventConfigs
+	// expects so only PermissionRequest is the drift point.
+	for _, cfg := range hookEventConfigs {
+		if cfg.Event == "PermissionRequest" {
+			continue
+		}
+		entry := claudeHookMatcher{
+			Matcher: cfg.Matcher,
+			Hooks:   []claudeHookEntry{{Type: "command", Command: agentDeckHookCommand, Async: cfg.Async}},
+		}
+		raw, _ := json.Marshal([]claudeHookMatcher{entry})
+		hooks[cfg.Event] = raw
+	}
+
+	settings := map[string]json.RawMessage{}
+	hooksRaw, _ := json.Marshal(hooks)
+	settings["hooks"] = hooksRaw
+	data, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(filepath.Join(tmpDir, "settings.json"), data, 0644); err != nil {
+		t.Fatalf("Failed to seed settings.json: %v", err)
+	}
+
+	// Run InjectClaudeHooks; it should detect drift and rewrite.
+	installed, err := InjectClaudeHooks(tmpDir)
+	if err != nil {
+		t.Fatalf("InjectClaudeHooks failed: %v", err)
+	}
+	if !installed {
+		t.Errorf("InjectClaudeHooks returned installed=false; expected true because stale Async should trigger reinstall")
+	}
+
+	// Verify the post-write Async flag is now false.
+	postData, err := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("Failed to read settings.json after reinstall: %v", err)
+	}
+	var postSettings map[string]json.RawMessage
+	if err := json.Unmarshal(postData, &postSettings); err != nil {
+		t.Fatalf("Failed to parse settings: %v", err)
+	}
+	var postHooks map[string]json.RawMessage
+	if err := json.Unmarshal(postSettings["hooks"], &postHooks); err != nil {
+		t.Fatalf("Failed to parse hooks: %v", err)
+	}
+	var postPR []claudeHookMatcher
+	if err := json.Unmarshal(postHooks["PermissionRequest"], &postPR); err != nil {
+		t.Fatalf("Failed to parse PermissionRequest: %v", err)
+	}
+	if len(postPR) == 0 || len(postPR[0].Hooks) == 0 {
+		t.Fatal("PermissionRequest has no hooks after reinstall")
+	}
+	if postPR[0].Hooks[0].Async {
+		t.Errorf("Post-reinstall PermissionRequest still has Async=true; expected false")
+	}
+	if postPR[0].Hooks[0].Command != agentDeckHookCommand {
+		t.Errorf("Post-reinstall command = %q, want %q", postPR[0].Hooks[0].Command, agentDeckHookCommand)
+	}
+}


### PR DESCRIPTION
Followup to #808. hooksAlreadyInstalled now verifies the Async and Matcher fields of each agent-deck hook entry against hookEventConfigs (not just command presence). mergeHookEvent updates in place when our entry exists. Closes the binary-upgrade gap where a Async config change cannot propagate to existing settings.json files because hooks install no-ops with 'already installed.' Tests added. See commit message for full background.