### PR TITLE
fix(termreply): flush lone ESC outside attach quarantine

### DIFF
--- a/internal/termreply/filter.go
+++ b/internal/termreply/filter.go
@@ -259,6 +259,18 @@ func (f *Filter) Consume(src []byte, armed bool, final bool) []byte {
 		}
 		f.pendingEsc = false
 		f.resetSequenceState()
+		return out
+	}
+
+	// Outside the post-attach quarantine, a trailing ESC is almost always a
+	// lone keyboard press: terminals write reply sequences atomically, so a
+	// chunk-split exactly between ESC and its introducer is vanishingly rare
+	// on a tty fd. Flushing eagerly preserves bare-ESC and ESC-ESC bindings
+	// that would otherwise sit forever in pendingEsc waiting for a follow-up
+	// byte that never comes. Armed = keep buffering for cross-chunk replies.
+	if f.pendingEsc && !armed {
+		out = append(out, escapeByte)
+		f.pendingEsc = false
 	}
 
 	return out

--- a/internal/termreply/filter_test.go
+++ b/internal/termreply/filter_test.go
@@ -192,3 +192,174 @@ func TestRegression744_FilterPassesShiftLetterCSIUWhileArmed(t *testing.T) {
 		})
 	}
 }
+
+// A lone ESC keypress (and ESC-ESC for jump-to-prev-message) must reach the
+// inner agent outside the quarantine. Previously pendingEsc held ESC forever
+// waiting for a follow-up byte that never comes for keyboard ESC.
+func TestFilterFlushesLoneEscWhenNotArmed(t *testing.T) {
+	t.Run("single_esc_passes_through", func(t *testing.T) {
+		var f Filter
+		got := f.Consume([]byte{0x1b}, false, false)
+		require.Equal(t, []byte{0x1b}, got)
+		require.False(t, f.Active())
+	})
+
+	t.Run("double_esc_passes_through", func(t *testing.T) {
+		var f Filter
+		got := f.Consume([]byte{0x1b, 0x1b}, false, false)
+		require.Equal(t, []byte{0x1b, 0x1b}, got)
+		require.False(t, f.Active())
+	})
+
+	t.Run("triple_esc_passes_through", func(t *testing.T) {
+		var f Filter
+		got := f.Consume([]byte{0x1b, 0x1b, 0x1b}, false, false)
+		require.Equal(t, []byte{0x1b, 0x1b, 0x1b}, got)
+		require.False(t, f.Active())
+	})
+
+	// Without the flush, a held ESC concatenates with the next read's
+	// arrow into ESC ESC[A — interpreted as Alt/Meta+Up by most TUI
+	// parsers ("up arrow resets the dialog" symptom).
+	t.Run("lone_esc_then_arrow_in_next_chunk", func(t *testing.T) {
+		var f Filter
+		first := f.Consume([]byte{0x1b}, false, false)
+		require.Equal(t, []byte{0x1b}, first)
+		require.False(t, f.Active())
+
+		next := f.Consume([]byte("\x1b[A"), false, false)
+		require.Equal(t, []byte("\x1b[A"), next)
+		require.False(t, f.Active())
+	})
+}
+
+// Pins the quarantine carve-out: while armed, trailing ESC is still buffered
+// across chunks so DCS/OSC reply parsing keeps working.
+func TestFilterStillBuffersTrailingEscWhenArmed(t *testing.T) {
+	var f Filter
+	got := f.Consume([]byte{0x1b}, true, false)
+	require.Empty(t, got)
+	require.True(t, f.Active())
+
+	got = f.Consume([]byte("]11;rgb:d3d3/f5f5/f5f5\x07j"), true, false)
+	require.Equal(t, []byte("j"), got)
+	require.False(t, f.Active())
+}
+
+// Alt+letter (iTerm2 "Esc+" Option, vim Meta bindings) hits the default
+// pendingEsc branch which emits ESC+byte unchanged.
+func TestFilterPassesAltLetterThrough(t *testing.T) {
+	cases := []struct {
+		name string
+		seq  []byte
+	}{
+		{"alt_a", []byte{0x1b, 'a'}},
+		{"alt_z", []byte{0x1b, 'z'}},
+		{"alt_period", []byte{0x1b, '.'}},
+		{"alt_digit", []byte{0x1b, '7'}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+"/not_armed", func(t *testing.T) {
+			var f Filter
+			got := f.Consume(tc.seq, false, false)
+			require.Equal(t, tc.seq, got)
+			require.False(t, f.Active())
+		})
+		t.Run(tc.name+"/armed", func(t *testing.T) {
+			var f Filter
+			got := f.Consume(tc.seq, true, false)
+			require.Equal(t, tc.seq, got)
+			require.False(t, f.Active())
+		})
+	}
+}
+
+// F1-F4 use SS3 (ESC O P/Q/R/S); F5-F12 use CSI ~ (ESC [ 15 ~ etc.). SS3 has
+// no final-byte gating; tilde is in isKeyboardCSIFinalByte. Both pass armed.
+func TestFilterPassesFunctionKeysThrough(t *testing.T) {
+	cases := []struct {
+		name string
+		seq  []byte
+	}{
+		{"f1_ss3", []byte("\x1bOP")},
+		{"f2_ss3", []byte("\x1bOQ")},
+		{"f3_ss3", []byte("\x1bOR")},
+		{"f4_ss3", []byte("\x1bOS")},
+		{"f5_csi_tilde", []byte("\x1b[15~")},
+		{"f6_csi_tilde", []byte("\x1b[17~")},
+		{"f10_csi_tilde", []byte("\x1b[21~")},
+		{"f12_csi_tilde", []byte("\x1b[24~")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+"/not_armed", func(t *testing.T) {
+			var f Filter
+			got := f.Consume(tc.seq, false, false)
+			require.Equal(t, tc.seq, got)
+			require.False(t, f.Active())
+		})
+		t.Run(tc.name+"/armed", func(t *testing.T) {
+			var f Filter
+			got := f.Consume(tc.seq, true, false)
+			require.Equal(t, tc.seq, got)
+			require.False(t, f.Active())
+		})
+	}
+}
+
+// Focus-in (CSI I) and focus-out (CSI O) are non-keyboard, non-DA/DSR CSI:
+// dropped while armed, passed through unarmed. Pins both branches so a
+// future change to the gate doesn't silently swap them.
+func TestFilterFocusEventBehavior(t *testing.T) {
+	cases := []struct {
+		name string
+		seq  []byte
+	}{
+		{"focus_in", []byte("\x1b[I")},
+		{"focus_out", []byte("\x1b[O")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+"/not_armed_passes", func(t *testing.T) {
+			var f Filter
+			got := f.Consume(tc.seq, false, false)
+			require.Equal(t, tc.seq, got)
+			require.False(t, f.Active())
+		})
+		t.Run(tc.name+"/armed_dropped", func(t *testing.T) {
+			var f Filter
+			got := f.Consume(tc.seq, true, false)
+			require.Empty(t, got)
+			require.False(t, f.Active())
+		})
+	}
+}
+
+// Known tradeoff: when armed=false and an OSC/DCS reply fragments exactly
+// between ESC and its introducer, the eager flush emits ESC and the body
+// arrives next read as literal text. Vanishingly rare on a local tty fd
+// (terminals write replies atomically); theoretically possible over SSH.
+// Pre-fix behavior buffered every keyboard ESC indefinitely — strictly
+// worse for the >99% case. A future timeout-based Flush() would close
+// this window; update this test to assert suppression then.
+func TestFilterCrossChunkSplitAfterEscWhenNotArmed_KnownLimitation(t *testing.T) {
+	var f Filter
+
+	got := f.Consume([]byte{'x', 0x1b}, false, false)
+	require.Equal(t, []byte{'x', 0x1b}, got)
+	require.False(t, f.Active())
+
+	got = f.Consume([]byte("]11;rgb:d3d3/f5f5/f5f5\x07after"), false, false)
+	require.Equal(t, []byte("]11;rgb:d3d3/f5f5/f5f5\x07after"), got)
+}
+
+// Symmetric: the same split while armed stays fully suppressed end-to-end.
+func TestFilterCrossChunkSplitAfterEscWhenArmed_StillSuppressed(t *testing.T) {
+	var f Filter
+
+	got := f.Consume([]byte{'x', 0x1b}, true, false)
+	require.Equal(t, []byte{'x'}, got)
+	require.True(t, f.Active())
+
+	got = f.Consume([]byte("]11;rgb:d3d3/f5f5/f5f5\x07after"), true, false)
+	require.Equal(t, []byte("after"), got)
+	require.False(t, f.Active())
+}


### PR DESCRIPTION
## Summary

Inside a tmux attach a lone ESC keypress never reached the inner agent, and ESC followed by an arrow key arrived at the inner agent as Alt/Meta+Up. User-visible symptoms reported in `agent-deck` sessions running Claude Code:

- Bare ESC (interrupt) didn't fire
- ESC ESC for jump-to-previous-message didn't work
- Arrow keys appeared to reset the input

## Root cause

`internal/termreply/filter.go` runs on every stdin Read during `Session.Attach` (`internal/tmux/pty.go:272`). On ESC it sets `pendingEsc = true` and emits nothing, waiting for the next byte to disambiguate CSI / SS3 / OSC. Keyboard ESC has no follow-up byte, so the press stayed buffered indefinitely and later concatenated with the next keystroke's encoding — for example, a subsequent up-arrow `\x1b[A` arrived at the inner agent as `\x1b\x1b[A` (Alt+Up), and a lone ESC was never delivered at all.

Regression entered with #119c55d3 (v1.7.50) and remained through later termreply hardening (#708, #731, #738, #744). Pre-#119c55d3 behavior in `pty.go` was a 50ms timeout that only filtered chunks starting with ESC during the first 50ms of attach.

## Fix

At end of `Filter.Consume`, when `armed=false && !final && pendingEsc=true`, flush the buffered ESC and clear the flag. Inside the 500ms post-attach quarantine (`armed=true`) buffering is preserved so cross-chunk DCS/OSC reply parsing keeps working (#731).

```go
if f.pendingEsc && !armed {
    out = append(out, escapeByte)
    f.pendingEsc = false
}
```

## Tradeoff

Documented in `TestFilterCrossChunkSplitAfterEscWhenNotArmed_KnownLimitation`: when `armed=false` and an OSC/DCS reply fragments exactly between its leading ESC and the introducer byte, the eager flush emits the ESC and the body arrives next read as literal text. Vanishingly rare on a local tty fd because terminals write replies atomically, theoretically possible over SSH. The pre-fix behavior of buffering every keyboard ESC indefinitely is strictly worse for the >99% case.

A future timeout-based `Filter.Flush()` (called by the I/O loop after ~50ms of inactivity, mirroring xterm's standard ESC disambiguation) would close this window without giving up the safety; left as follow-up.

## Test plan

- [x] `GOTOOLCHAIN=go1.24.0 go test ./internal/termreply/... -race -count=1` — green
- [x] `GOTOOLCHAIN=go1.24.0 go test ./internal/ui/... -run \"TestFilter|CSIuReader|Keyboard\" -race -count=1` — green (same Filter is used by `csiuReader` in `internal/ui/keyboard_compat.go` for the outer Bubble Tea TUI)
- [x] `GOTOOLCHAIN=go1.24.0 go vet ./internal/termreply/... ./internal/tmux/... ./internal/ui/...` — clean
- [x] `GOTOOLCHAIN=go1.24.0 go build ./...` — clean
- [x] Manual test with `make build && ./build/ad-fork` attached to a Claude Code session — bare ESC, ESC ESC, and arrow-key history navigation behave correctly

### Tests added

- `TestFilterFlushesLoneEscWhenNotArmed` — single/double/triple ESC and ESC-then-arrow across chunks
- `TestFilterStillBuffersTrailingEscWhenArmed` — pins the quarantine carve-out
- `TestFilterPassesAltLetterThrough` — Alt+letter (`ESC a`, etc.) in both modes
- `TestFilterPassesFunctionKeysThrough` — F1-F4 (SS3) and F5-F12 (CSI ~) in both modes
- `TestFilterFocusEventBehavior` — focus-in/out: passes unarmed, dropped armed
- `TestFilterCrossChunkSplitAfterEscWhenNotArmed_KnownLimitation` — documents the leak window
- `TestFilterCrossChunkSplitAfterEscWhenArmed_StillSuppressed` — pins quarantine end-to-end suppression

### Non-regressions verified by existing tests in this package

- `#731` XTVERSION DCS leak via OSC/DCS replies
- `#738` DA1/DSR pass-through for tmux modifyOtherKeys (Shift+Enter through tmux)
- `#708` mouse CSI sequences
- `#744` Shift+letter CSI u while armed