### PR TITLE
fix(costs): correct Anthropic pricing data and add claude-opus-4-7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Outdated Anthropic pricing data for `claude-opus-4-6` and `claude-haiku-4-5`** ([#813](https://github.com/asheshgoplani/agent-deck/issues/813)). `claude-opus-4-6` was using legacy Opus 4 / 4.1 rates ($15 / $75 / $1.50 / $18.75); corrected to the current Opus 4.6 rates of $5 / $25 / $0.50 / $6.25. `claude-haiku-4-5` was at 80% of the published rates; corrected to $1 / $5 / $0.10 / $1.25. Source: https://docs.anthropic.com/en/docs/about-claude/pricing.
+
+- **Missing pricing for `claude-opus-4-7`** ([#813](https://github.com/asheshgoplani/agent-deck/issues/813)). Cost events for this model previously persisted with `cost_microdollars=0` because the pricer had no entry. Added at $5 / $25 / $0.50 / $6.25.
+
+### Added
+
+- **`agent-deck costs recompute`** ([#813](https://github.com/asheshgoplani/agent-deck/issues/813)). New CLI subcommand that recalculates `cost_microdollars` for every `cost_events` row using current pricing data (defaults plus user overrides). Idempotent. Rows whose `model` is unknown to the pricer are left untouched. Supports `--dry-run` for preview.
+
 ## [1.7.72] - 2026-04-28
 
 Bundle of fixes and contributor PRs, hours after v1.7.71. Two external contributors merged this cycle: @tarekrached (twice), @oryaacov.

--- a/README.md
+++ b/README.md
@@ -501,11 +501,12 @@ Agent Deck works with any terminal-based AI tool:
 Track token usage and costs across all your AI agent sessions in real-time.
 
 - **Automatic collection** — Claude Code hook integration reads transcript files on each turn. Gemini/Codex/MiniMax support via output parsing (untested)
-- **13 models priced** — Claude Opus/Sonnet/Haiku, Gemini Pro/Flash, GPT-4o/4.1, o3, o4-mini, MiniMax M2.7/M2.7-highspeed/M2.5/M2.5-highspeed with daily price refresh
+- **14 models priced** — Claude Opus 4.6/4.7, Sonnet 4.6, Haiku 4.5, Gemini Pro/Flash, GPT-4o/4.1, o3, o4-mini, MiniMax M2.7/M2.7-highspeed/M2.5/M2.5-highspeed with daily price refresh
 - **TUI dashboard** — press `$` to view today/week/month costs, top sessions, model breakdown
 - **Web dashboard** — `/costs` page with Chart.js charts, group drill-down, session detail views, SSE live updates
 - **Budget limits** — configurable daily/weekly/monthly/per-group/per-session limits with 80% warning and 100% hard stop (untested)
 - **Historical sync** — `agent-deck costs sync` backfills cost data from existing Claude transcript files
+- **Recompute costs** — `agent-deck costs recompute` recalculates `cost_microdollars` for every cost event using current pricing data. Useful after a pricing-data update to retroactively price events that landed at $0 because the model was missing from the pricer. Pass `--dry-run` to preview.
 - **Export** — CSV/JSON export from web dashboard
 
 ```toml

--- a/cmd/agent-deck/costs_cmd.go
+++ b/cmd/agent-deck/costs_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -8,9 +9,11 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
+const costsUsage = "Usage: agent-deck costs <sync|summary|recompute>"
+
 func handleCosts(profile string, args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "Usage: agent-deck costs <sync|summary>")
+		fmt.Fprintln(os.Stderr, costsUsage)
 		os.Exit(1)
 	}
 
@@ -19,9 +22,11 @@ func handleCosts(profile string, args []string) {
 		handleCostsSync(profile)
 	case "summary":
 		handleCostsSummary(profile)
+	case "recompute":
+		handleCostsRecompute(profile, args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown costs subcommand: %s\n", args[0])
-		fmt.Fprintln(os.Stderr, "Usage: agent-deck costs <sync|summary>")
+		fmt.Fprintln(os.Stderr, costsUsage)
 		os.Exit(1)
 	}
 }
@@ -136,5 +141,52 @@ func handleCostsSummary(profile string) {
 		for model, cost := range byModel {
 			fmt.Printf("  %-30s %s\n", model, costs.FormatUSD(cost))
 		}
+	}
+}
+
+func handleCostsRecompute(profile string, args []string) {
+	dryRun := false
+	for _, a := range args {
+		switch a {
+		case "--dry-run", "-n":
+			dryRun = true
+		case "-h", "--help":
+			fmt.Println("Usage: agent-deck costs recompute [--dry-run]")
+			fmt.Println("\nRecalculate cost_microdollars for every cost_events row using current")
+			fmt.Println("pricing data (defaults + user overrides). Rows whose model is unknown to")
+			fmt.Println("the pricer are left untouched. Idempotent.")
+			return
+		default:
+			fmt.Fprintf(os.Stderr, "Unknown flag: %s\n", a)
+			fmt.Fprintln(os.Stderr, "Usage: agent-deck costs recompute [--dry-run]")
+			os.Exit(1)
+		}
+	}
+
+	costStore, storage := openCostStore(profile)
+	defer storage.Close()
+	pricer := newPricerFromConfig()
+
+	if dryRun {
+		fmt.Println("Recomputing cost_events (dry-run, no rows will be modified)...")
+	} else {
+		fmt.Println("Recomputing cost_events...")
+	}
+
+	updated, skipped, err := costs.Recompute(context.Background(), costStore, pricer, dryRun)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\nResults:\n")
+	if dryRun {
+		fmt.Printf("  Would update: %d\n", updated)
+	} else {
+		fmt.Printf("  Updated:      %d\n", updated)
+	}
+	fmt.Printf("  Skipped:      %d (already correct or unknown model)\n", skipped)
+	if dryRun && updated > 0 {
+		fmt.Println("\nRe-run without --dry-run to apply changes.")
 	}
 }

--- a/internal/costs/fetcher.go
+++ b/internal/costs/fetcher.go
@@ -25,9 +25,11 @@ func (f *Fetcher) CacheAge() time.Duration {
 // Real HTML scraping is deferred — for now, writes hardcoded defaults.
 func (f *Fetcher) FetchAndCache() error {
 	defaults := map[string]pricingCacheModel{
+		// Anthropic rates: https://docs.anthropic.com/en/docs/about-claude/pricing
+		"claude-opus-4-7":   {InputPerMtok: 5.0, OutputPerMtok: 25.0, CacheReadPerMtok: 0.50, CacheWritePerMtok: 6.25},
+		"claude-opus-4-6":   {InputPerMtok: 5.0, OutputPerMtok: 25.0, CacheReadPerMtok: 0.50, CacheWritePerMtok: 6.25},
 		"claude-sonnet-4-6": {InputPerMtok: 3.0, OutputPerMtok: 15.0, CacheReadPerMtok: 0.30, CacheWritePerMtok: 3.75},
-		"claude-opus-4-6":   {InputPerMtok: 15.0, OutputPerMtok: 75.0, CacheReadPerMtok: 1.50, CacheWritePerMtok: 18.75},
-		"claude-haiku-4-5":  {InputPerMtok: 0.80, OutputPerMtok: 4.0, CacheReadPerMtok: 0.08, CacheWritePerMtok: 1.0},
+		"claude-haiku-4-5":  {InputPerMtok: 1.0, OutputPerMtok: 5.0, CacheReadPerMtok: 0.10, CacheWritePerMtok: 1.25},
 		"gemini-2.5-pro":    {InputPerMtok: 1.25, OutputPerMtok: 10.0},
 		"gemini-2.5-flash":  {InputPerMtok: 0.15, OutputPerMtok: 0.60},
 		"gpt-4o":            {InputPerMtok: 2.50, OutputPerMtok: 10.0},

--- a/internal/costs/pricing.go
+++ b/internal/costs/pricing.go
@@ -69,9 +69,11 @@ func priceFromUSD(input, output, cacheRead, cacheWrite float64) ModelPrice {
 func NewPricer(cfg PricerConfig) *Pricer {
 	p := &Pricer{
 		defaults: map[string]ModelPrice{
+			// Anthropic rates: https://docs.anthropic.com/en/docs/about-claude/pricing
+			"claude-opus-4-7":   priceFromUSD(5.0, 25.0, 0.50, 6.25),
+			"claude-opus-4-6":   priceFromUSD(5.0, 25.0, 0.50, 6.25),
 			"claude-sonnet-4-6": priceFromUSD(3.0, 15.0, 0.30, 3.75),
-			"claude-opus-4-6":   priceFromUSD(15.0, 75.0, 1.50, 18.75),
-			"claude-haiku-4-5":  priceFromUSD(0.80, 4.0, 0.08, 1.0),
+			"claude-haiku-4-5":  priceFromUSD(1.0, 5.0, 0.10, 1.25),
 			"gemini-2.5-pro":    priceFromUSD(1.25, 10.0, 0, 0),
 			"gemini-2.5-flash":  priceFromUSD(0.15, 0.60, 0, 0),
 			"gpt-4o":            priceFromUSD(2.50, 10.0, 0, 0),

--- a/internal/costs/pricing_test.go
+++ b/internal/costs/pricing_test.go
@@ -107,3 +107,36 @@ func TestPricerModelNormalization(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, int64(3_000_000), mp.InputPerMtokMicro)
 }
+
+// TestAnthropicPricing pins exact rates for every Anthropic model in defaults
+// against Anthropic's published rates. Source:
+// https://docs.anthropic.com/en/docs/about-claude/pricing
+// Cache-write column is the 5-minute TTL rate (the cache write rate the
+// pricing.json schema represents).
+func TestAnthropicPricing(t *testing.T) {
+	p := NewPricer(PricerConfig{})
+
+	tests := []struct {
+		model      string
+		input      int64
+		output     int64
+		cacheRead  int64
+		cacheWrite int64
+	}{
+		{"claude-opus-4-7", 5_000_000, 25_000_000, 500_000, 6_250_000},
+		{"claude-opus-4-6", 5_000_000, 25_000_000, 500_000, 6_250_000},
+		{"claude-sonnet-4-6", 3_000_000, 15_000_000, 300_000, 3_750_000},
+		{"claude-haiku-4-5", 1_000_000, 5_000_000, 100_000, 1_250_000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			mp, ok := p.GetPrice(tt.model)
+			require.True(t, ok, "model %s should have pricing", tt.model)
+			assert.Equal(t, tt.input, mp.InputPerMtokMicro, "input")
+			assert.Equal(t, tt.output, mp.OutputPerMtokMicro, "output")
+			assert.Equal(t, tt.cacheRead, mp.CacheReadPerMtokMicro, "cache_read")
+			assert.Equal(t, tt.cacheWrite, mp.CacheWritePerMtokMicro, "cache_write")
+		})
+	}
+}

--- a/internal/costs/recompute.go
+++ b/internal/costs/recompute.go
@@ -1,0 +1,70 @@
+package costs
+
+import (
+	"context"
+	"fmt"
+)
+
+// recomputeBatchSize controls how many cost_events are fetched and updated per
+// transaction during Recompute. 1000 is a balance between memory pressure and
+// transaction overhead on a personal-scale SQLite database.
+const recomputeBatchSize = 1000
+
+// Recompute walks every cost_events row in `store`, recalculates
+// cost_microdollars using `pricer`, and writes any differences back. It is
+// idempotent: a second run with no pricing data changes returns updated=0.
+//
+// Rows whose `model` is unknown to the pricer are left untouched and counted
+// as skipped (writing 0 over an existing positive cost would lose data).
+//
+// When dryRun is true no UPDATE is executed; the returned counts describe
+// what would change.
+func Recompute(ctx context.Context, store *Store, pricer *Pricer, dryRun bool) (updated, skipped int, err error) {
+	if store == nil {
+		return 0, 0, fmt.Errorf("recompute: store is nil")
+	}
+	if pricer == nil {
+		return 0, 0, fmt.Errorf("recompute: pricer is nil")
+	}
+
+	var afterRowID int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return updated, skipped, err
+		}
+
+		events, lastRowID, err := store.PageEventsAfter(afterRowID, recomputeBatchSize)
+		if err != nil {
+			return updated, skipped, fmt.Errorf("page events after rowid %d: %w", afterRowID, err)
+		}
+		if len(events) == 0 {
+			return updated, skipped, nil
+		}
+
+		batchUpdates := make(map[string]int64, len(events))
+		for _, ev := range events {
+			if _, ok := pricer.GetPrice(ev.Model); !ok {
+				skipped++
+				continue
+			}
+			recomputed := pricer.ComputeCost(ev.Model, ev.InputTokens, ev.OutputTokens, ev.CacheReadTokens, ev.CacheWriteTokens)
+			if recomputed == ev.CostMicrodollars {
+				skipped++
+				continue
+			}
+			batchUpdates[ev.ID] = recomputed
+			updated++
+		}
+
+		if !dryRun && len(batchUpdates) > 0 {
+			if err := store.ApplyCostUpdates(ctx, batchUpdates); err != nil {
+				return updated, skipped, fmt.Errorf("apply updates: %w", err)
+			}
+		}
+
+		afterRowID = lastRowID
+		if len(events) < recomputeBatchSize {
+			return updated, skipped, nil
+		}
+	}
+}

--- a/internal/costs/recompute_test.go
+++ b/internal/costs/recompute_test.go
@@ -1,0 +1,193 @@
+package costs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/costs"
+)
+
+// seedEvent inserts one cost_event row directly via WriteCostEvent.
+func seedEvent(t *testing.T, s *costs.Store, id, sessionID, model string, input, output, cacheRead, cacheWrite, cost int64) {
+	t.Helper()
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID:               id,
+		SessionID:        sessionID,
+		Timestamp:        time.Now(),
+		Model:            model,
+		InputTokens:      input,
+		OutputTokens:     output,
+		CacheReadTokens:  cacheRead,
+		CacheWriteTokens: cacheWrite,
+		CostMicrodollars: cost,
+	}); err != nil {
+		t.Fatalf("seed event %s: %v", id, err)
+	}
+}
+
+func TestRecompute_EmptyStore(t *testing.T) {
+	s := testStore(t)
+	updated, skipped, err := costs.Recompute(context.Background(), s, costs.NewPricer(costs.PricerConfig{}), false)
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if updated != 0 || skipped != 0 {
+		t.Errorf("empty store: got updated=%d skipped=%d, want 0/0", updated, skipped)
+	}
+}
+
+func TestRecompute_BackfillsZeroCostRows(t *testing.T) {
+	s := testStore(t)
+	// 1M input + 1M output on Opus 4.7 should cost $5 + $25 = $30 = 30,000,000 microdollars.
+	seedEvent(t, s, "evt-1", "sess-1", "claude-opus-4-7", 1_000_000, 1_000_000, 0, 0, 0)
+
+	updated, skipped, err := costs.Recompute(context.Background(), s, costs.NewPricer(costs.PricerConfig{}), false)
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if updated != 1 || skipped != 0 {
+		t.Errorf("got updated=%d skipped=%d, want 1/0", updated, skipped)
+	}
+
+	got, err := s.TotalBySession("sess-1")
+	if err != nil {
+		t.Fatalf("TotalBySession: %v", err)
+	}
+	if got.TotalCostMicrodollars != 30_000_000 {
+		t.Errorf("cost after recompute = %d, want 30000000", got.TotalCostMicrodollars)
+	}
+}
+
+func TestRecompute_SkipsAlreadyCorrectRows(t *testing.T) {
+	s := testStore(t)
+	// 1M input + 1M output on Sonnet 4.6 = $3 + $15 = $18 = 18,000,000.
+	seedEvent(t, s, "evt-1", "sess-1", "claude-sonnet-4-6", 1_000_000, 1_000_000, 0, 0, 18_000_000)
+
+	updated, skipped, err := costs.Recompute(context.Background(), s, costs.NewPricer(costs.PricerConfig{}), false)
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if updated != 0 || skipped != 1 {
+		t.Errorf("got updated=%d skipped=%d, want 0/1", updated, skipped)
+	}
+}
+
+func TestRecompute_LeavesUnknownModelRowsUntouched(t *testing.T) {
+	s := testStore(t)
+	// Unknown model with a positive cost: pricer cannot recompute, so we must
+	// leave the row alone rather than zero out the existing value.
+	seedEvent(t, s, "evt-unknown", "sess-1", "totally-made-up-model", 1_000_000, 0, 0, 0, 42_000)
+
+	updated, skipped, err := costs.Recompute(context.Background(), s, costs.NewPricer(costs.PricerConfig{}), false)
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if updated != 0 || skipped != 1 {
+		t.Errorf("got updated=%d skipped=%d, want 0/1", updated, skipped)
+	}
+
+	got, err := s.TotalBySession("sess-1")
+	if err != nil {
+		t.Fatalf("TotalBySession: %v", err)
+	}
+	if got.TotalCostMicrodollars != 42_000 {
+		t.Errorf("cost after recompute = %d, want 42000 (unchanged)", got.TotalCostMicrodollars)
+	}
+}
+
+func TestRecompute_DryRunDoesNotMutate(t *testing.T) {
+	s := testStore(t)
+	seedEvent(t, s, "evt-1", "sess-1", "claude-opus-4-7", 1_000_000, 1_000_000, 0, 0, 0)
+
+	updated, skipped, err := costs.Recompute(context.Background(), s, costs.NewPricer(costs.PricerConfig{}), true)
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if updated != 1 || skipped != 0 {
+		t.Errorf("dry-run counts: got updated=%d skipped=%d, want 1/0", updated, skipped)
+	}
+
+	got, err := s.TotalBySession("sess-1")
+	if err != nil {
+		t.Fatalf("TotalBySession: %v", err)
+	}
+	if got.TotalCostMicrodollars != 0 {
+		t.Errorf("dry-run mutated DB: cost = %d, want 0", got.TotalCostMicrodollars)
+	}
+}
+
+func TestRecompute_Idempotent(t *testing.T) {
+	s := testStore(t)
+	seedEvent(t, s, "evt-1", "sess-1", "claude-opus-4-7", 1_000_000, 1_000_000, 0, 0, 0)
+	pricer := costs.NewPricer(costs.PricerConfig{})
+
+	// First run: backfills 1 row.
+	if u, _, err := costs.Recompute(context.Background(), s, pricer, false); err != nil || u != 1 {
+		t.Fatalf("first run: updated=%d err=%v, want 1/nil", u, err)
+	}
+	// Second run: no further changes.
+	updated, skipped, err := costs.Recompute(context.Background(), s, pricer, false)
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if updated != 0 || skipped != 1 {
+		t.Errorf("second run: got updated=%d skipped=%d, want 0/1", updated, skipped)
+	}
+}
+
+func TestRecompute_MixedRows(t *testing.T) {
+	s := testStore(t)
+	// Zero-cost Opus 4.7 row: needs backfill to $30M.
+	seedEvent(t, s, "evt-1", "sess-1", "claude-opus-4-7", 1_000_000, 1_000_000, 0, 0, 0)
+	// Already-correct Sonnet 4.6 row.
+	seedEvent(t, s, "evt-2", "sess-1", "claude-sonnet-4-6", 1_000_000, 1_000_000, 0, 0, 18_000_000)
+	// Stale Opus 4.6 row at the old (3x too high) rate of $90M -- should be corrected to $30M.
+	seedEvent(t, s, "evt-3", "sess-1", "claude-opus-4-6", 1_000_000, 1_000_000, 0, 0, 90_000_000)
+	// Unknown model with non-zero cost: leave alone.
+	seedEvent(t, s, "evt-4", "sess-1", "totally-made-up-model", 1_000, 0, 0, 0, 1_234)
+
+	updated, skipped, err := costs.Recompute(context.Background(), s, costs.NewPricer(costs.PricerConfig{}), false)
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if updated != 2 || skipped != 2 {
+		t.Errorf("got updated=%d skipped=%d, want 2/2", updated, skipped)
+	}
+
+	got, err := s.TotalBySession("sess-1")
+	if err != nil {
+		t.Fatalf("TotalBySession: %v", err)
+	}
+	// $30M (opus-4-7 backfilled) + $18M (sonnet-4-6 unchanged) + $30M (opus-4-6 corrected) + $1234 (unknown, untouched)
+	want := int64(30_000_000 + 18_000_000 + 30_000_000 + 1_234)
+	if got.TotalCostMicrodollars != want {
+		t.Errorf("total cost = %d, want %d", got.TotalCostMicrodollars, want)
+	}
+}
+
+func TestRecompute_NilStore(t *testing.T) {
+	_, _, err := costs.Recompute(context.Background(), nil, costs.NewPricer(costs.PricerConfig{}), false)
+	if err == nil {
+		t.Fatal("expected error for nil store, got nil")
+	}
+}
+
+func TestRecompute_NilPricer(t *testing.T) {
+	s := testStore(t)
+	_, _, err := costs.Recompute(context.Background(), s, nil, false)
+	if err == nil {
+		t.Fatal("expected error for nil pricer, got nil")
+	}
+}
+
+func TestRecompute_CancelledContext(t *testing.T) {
+	s := testStore(t)
+	seedEvent(t, s, "evt-1", "sess-1", "claude-opus-4-7", 1_000_000, 1_000_000, 0, 0, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := costs.Recompute(ctx, s, costs.NewPricer(costs.PricerConfig{}), false)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+}

--- a/internal/costs/store.go
+++ b/internal/costs/store.go
@@ -1,6 +1,7 @@
 package costs
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
@@ -298,4 +299,71 @@ func repeatArg(n int) string {
 		s += ", ?"
 	}
 	return s
+}
+
+// PageEventsAfter returns up to `limit` cost_events with rowid > afterRowID,
+// ordered by rowid ascending, plus the rowid of the last returned row (or
+// afterRowID itself if no rows were returned). Use 0 as the initial
+// afterRowID. Cursor-based pagination is stable under concurrent inserts.
+func (s *Store) PageEventsAfter(afterRowID int64, limit int) ([]CostEvent, int64, error) {
+	rows, err := s.db.Query(`
+		SELECT rowid, id, session_id, timestamp, model,
+			input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+			cost_microdollars
+		FROM cost_events
+		WHERE rowid > ?
+		ORDER BY rowid ASC
+		LIMIT ?`, afterRowID, limit)
+	if err != nil {
+		return nil, afterRowID, err
+	}
+	defer rows.Close()
+
+	lastRowID := afterRowID
+	var result []CostEvent
+	for rows.Next() {
+		var (
+			rowid int64
+			ev    CostEvent
+			ts    string
+		)
+		if err := rows.Scan(
+			&rowid, &ev.ID, &ev.SessionID, &ts, &ev.Model,
+			&ev.InputTokens, &ev.OutputTokens, &ev.CacheReadTokens, &ev.CacheWriteTokens,
+			&ev.CostMicrodollars,
+		); err != nil {
+			return nil, afterRowID, err
+		}
+		ev.Timestamp, _ = time.Parse(time.RFC3339, ts)
+		lastRowID = rowid
+		result = append(result, ev)
+	}
+	return result, lastRowID, rows.Err()
+}
+
+// ApplyCostUpdates writes a batch of cost_microdollars updates within a single
+// transaction. The map key is cost_event id. Returns an error and rolls back
+// on any failure; on success commits and returns nil.
+func (s *Store) ApplyCostUpdates(ctx context.Context, updates map[string]int64) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx, `UPDATE cost_events SET cost_microdollars = ? WHERE id = ?`)
+	if err != nil {
+		return fmt.Errorf("prepare update: %w", err)
+	}
+	defer stmt.Close()
+
+	for id, value := range updates {
+		if _, err := stmt.ExecContext(ctx, value, id); err != nil {
+			return fmt.Errorf("update %s: %w", id, err)
+		}
+	}
+	return tx.Commit()
 }


### PR DESCRIPTION
Closes #813.

## Motivation

Three Anthropic models in the pricer had incorrect or missing data, causing visible mis-pricing of Claude cost events:

- `claude-opus-4-7` was missing entirely, so events for it persisted with `cost_microdollars=0` (1240+ rows on a real install).
- `claude-opus-4-6` was using legacy Opus 4 / 4.1 rates ($15 / $75 / $1.50 / $18.75), 3x the current Opus 4.6 rates.
- `claude-haiku-4-5` was at 80% of the published Haiku 4.5 rates.

Source for current rates: https://docs.anthropic.com/en/docs/about-claude/pricing.

## Changes

- **`fix(costs):` correct Anthropic rates and add 4-7** (`29e6b11`). Opus 4.6 corrected to $5/$25/$0.50/$6.25; Haiku 4.5 corrected to $1/$5/$0.10/$1.25; Opus 4.7 added at $5/$25/$0.50/$6.25. Both `pricing.go` defaults and `fetcher.go` `FetchAndCache` map updated. New table-driven `TestAnthropicPricing` pins exact rates.
- **`feat(costs):` `agent-deck costs recompute`** (`3d62111`). New CLI subcommand to backfill historical `cost_events` rows after pricing data changes. Iterates 1000-row pages by rowid, applies updates per batch in a single transaction. Idempotent. Rows whose `model` is unknown to the pricer are left untouched (writing 0 over a positive cost would lose data). Supports `--dry-run`. 10 unit tests against temp SQLite cover empty store, backfill, idempotency, dry-run, mixed rows, unknown models, nil args, and cancelled context.
- **`docs:`** (`b81f4e5`). New `[Unreleased]` CHANGELOG section. README cost-tracking section updated: 13 to 14 priced models, recompute documented alongside sync.

## User-facing impact note

After this lands, users running `agent-deck costs recompute` will see historical `claude-opus-4-6` cost values drop 3x and `claude-haiku-4-5` values rise 25%. Recompute is opt-in via CLI; no auto-migration on upgrade.

## Tests

- `internal/costs/`: `go test -race -count=1 ./internal/costs/` passes (including 4 new `TestAnthropicPricing` subtests and 10 new `TestRecompute_*` tests).
- `cmd/agent-deck/`: `go test -race -count=1 ./cmd/agent-deck/` passes.
- `gofmt -l` and `go vet ./internal/costs/ ./cmd/agent-deck/` clean.
- `go build ./cmd/agent-deck/` succeeds; `agent-deck costs` and `agent-deck costs recompute --help` show the new subcommand.

I did not run the full `go test ./...` to green because `internal/tmux/` and `internal/ui/` have pre-existing failures on macOS (long /tmp path exceeds unix socket name limit, `systemd-run` not present, UI snapshot tests for `zoxide_picker`). I confirmed these failures reproduce on `main` before my changes are applied.
