### PR TITLE
feat(ui): terminal navigation keys (PgUp/PgDn/Home/End)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Terminal navigation keys in session list.** Session list now accepts
+  `Home` / `End` (jump to first / last item) and `PgUp` / `PgDn` (half-page
+  aliases of existing `Ctrl+U` / `Ctrl+D`). Fills a gap where no single-key
+  jump-to-bottom existed, since `G` opens global search. `Home` / `End` also
+  scroll the help overlay. Follows the same side-effect contract as the
+  pagination handlers (preview scroll reset, navigation-activity mark,
+  debounced preview fetch).
+
+### Fixed
+
+- **Home/End keys in TUI now work for iTerm2 over direct SSH.** iTerm2's
+  default macOS profile emits Home/End as SS3 application-mode sequences
+  (`ESC OH` / `ESC OF`) on direct SSH (no intermediate tmux or screen).
+  Bubble Tea's decoder covers the xterm, vt220, and urxvt Home/End
+  variants but not SS3 — `csiuReader.translate` now rewrites `ESC OH` to
+  `ESC [H` and `ESC OF` to `ESC [F` before bytes reach Bubble Tea. All
+  other `ESC O*` sequences pass through unchanged. Verified unchanged
+  for iTerm2 → SSH → Screen (already emitted vt220 `ESC [1~` / `ESC [4~`).
+
 ## [1.7.72] - 2026-04-28
 
 Bundle of fixes and contributor PRs, hours after v1.7.71. Two external contributors merged this cycle: @tarekrached (twice), @oryaacov.

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -103,6 +103,12 @@ func (h *HelpOverlay) Update(msg tea.Msg) (*HelpOverlay, tea.Cmd) {
 				h.scrollOffset = 0
 			}
 			return h, nil
+		case "home":
+			h.scrollOffset = 0
+			return h, nil
+		case "end":
+			h.scrollOffset = 9999 // Will be clamped in View()
+			return h, nil
 		case "g":
 			h.scrollOffset = 0
 			return h, nil
@@ -168,7 +174,9 @@ func (h *HelpOverlay) View() string {
 				{"j / Down", "Move down"},
 				{"k / Up", "Move up"},
 				{"Ctrl+u/d", "Half page up/down"},
+				{"PgUp / PgDn", "Half page up/down"},
 				{"Ctrl+f/b", "Full page up/down"},
+				{"Home / End", "Jump to first / last item"},
 				{"gg / G", "Jump to top / global search"},
 				{"h / Left", "Collapse / parent"},
 				{"l / Right", "Expand / toggle"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5626,7 +5626,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 		// Vi-style pagination (#38) - half/full page scrolling
-	case "ctrl+u": // Half page up
+	case "ctrl+u", "pgup": // Half page up
 		pageSize := h.getVisibleHeight() / 2
 		if pageSize < 1 {
 			pageSize = 1
@@ -5640,7 +5640,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.markNavigationActivity()
 		return h, h.fetchSelectedPreview()
 
-	case "ctrl+d": // Half page down
+	case "ctrl+d", "pgdown": // Half page down
 		pageSize := h.getVisibleHeight() / 2
 		if pageSize < 1 {
 			pageSize = 1
@@ -5680,6 +5680,23 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor >= len(h.flatItems) {
 			h.cursor = len(h.flatItems) - 1
 		}
+		if h.cursor < 0 {
+			h.cursor = 0
+		}
+		h.previewScrollOffset = 0
+		h.syncViewport()
+		h.markNavigationActivity()
+		return h, h.fetchSelectedPreview()
+
+	case "home": // Jump to first item
+		h.cursor = 0
+		h.previewScrollOffset = 0
+		h.syncViewport()
+		h.markNavigationActivity()
+		return h, h.fetchSelectedPreview()
+
+	case "end": // Jump to last item
+		h.cursor = len(h.flatItems) - 1
 		if h.cursor < 0 {
 			h.cursor = 0
 		}

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2854,3 +2854,82 @@ func TestRegression743_NOnRemoteGroup_QuickCreatesNoDialog(t *testing.T) {
 		t.Fatal("pressing n on a remote group must NOT open the local new-session dialog")
 	}
 }
+
+// TestHome_TerminalNavigationKeys verifies the PgUp/PgDn/Home/End bindings
+// added alongside the existing vi-style pagination (#38). PgUp/PgDn are
+// half-page aliases of Ctrl+U/Ctrl+D; Home/End jump to the first/last item
+// (End fills the gap where no single-key jump-to-bottom existed, since G
+// opens global search).
+func TestHome_TerminalNavigationKeys(t *testing.T) {
+	// Build a 100-item list so pagination + absolute jumps have room to move.
+	items := make([]session.Item, 100)
+	for i := range items {
+		items[i] = session.Item{
+			Type:    session.ItemTypeSession,
+			Session: &session.Instance{ID: fmt.Sprintf("s%d", i), Title: fmt.Sprintf("S%d", i)},
+			Level:   0,
+		}
+	}
+
+	const width, height = 100, 30
+
+	// Compute half-page from the actual getVisibleHeight so the test
+	// stays correct if the viewport formula changes.
+	h0 := newTestHomeWithItems(width, height, items)
+	halfPage := h0.getVisibleHeight() / 2
+	if halfPage < 1 {
+		halfPage = 1
+	}
+	last := len(items) - 1
+
+	tests := []struct {
+		name        string
+		key         tea.KeyMsg
+		startCursor int
+		wantCursor  int
+	}{
+		{"PgUp from middle", tea.KeyMsg{Type: tea.KeyPgUp}, 50, 50 - halfPage},
+		{"PgUp clamps at top", tea.KeyMsg{Type: tea.KeyPgUp}, 0, 0},
+		{"PgDown from middle", tea.KeyMsg{Type: tea.KeyPgDown}, 10, 10 + halfPage},
+		{"PgDown clamps at bottom", tea.KeyMsg{Type: tea.KeyPgDown}, last, last},
+		{"Home from middle", tea.KeyMsg{Type: tea.KeyHome}, 50, 0},
+		{"Home at top no-op", tea.KeyMsg{Type: tea.KeyHome}, 0, 0},
+		{"End from middle", tea.KeyMsg{Type: tea.KeyEnd}, 5, last},
+		{"End at bottom no-op", tea.KeyMsg{Type: tea.KeyEnd}, last, last},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHomeWithItems(width, height, items)
+			h.cursor = tc.startCursor
+			h.previewScrollOffset = 42 // non-zero to verify reset contract
+			updated, _ := h.Update(tc.key)
+			got := updated.(*Home).cursor
+			if got != tc.wantCursor {
+				t.Fatalf("cursor = %d, want %d (halfPage=%d)", got, tc.wantCursor, halfPage)
+			}
+			if updated.(*Home).previewScrollOffset != 0 {
+				t.Fatalf("previewScrollOffset = %d, want 0 (nav handlers must reset)",
+					updated.(*Home).previewScrollOffset)
+			}
+		})
+	}
+
+	t.Run("End on empty list does not crash", func(t *testing.T) {
+		h := newTestHomeWithItems(width, height, nil)
+		updated, _ := h.Update(tea.KeyMsg{Type: tea.KeyEnd})
+		got := updated.(*Home).cursor
+		if got != 0 {
+			t.Fatalf("cursor = %d, want 0 on empty list", got)
+		}
+	})
+
+	t.Run("Home on empty list does not crash", func(t *testing.T) {
+		h := newTestHomeWithItems(width, height, nil)
+		updated, _ := h.Update(tea.KeyMsg{Type: tea.KeyHome})
+		got := updated.(*Home).cursor
+		if got != 0 {
+			t.Fatalf("cursor = %d, want 0 on empty list", got)
+		}
+	})
+}

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -383,6 +383,39 @@ func (c *csiuReader) translate(final bool) []byte {
 			i++
 			continue
 		}
+
+		// SS3 (ESC O) handling: rewrite ESC OH / ESC OF to ESC [H / ESC [F
+		// so Bubble Tea's escSeq table recognizes Home/End. Terminals that
+		// emit application-mode (DECKPAM) SS3 sequences for Home/End include
+		// iTerm2's default macOS profile over direct SSH. Other SS3 sequences
+		// (arrows ESC OA-D, function keys ESC OP-S) are already in Bubble
+		// Tea's escSeq table and must pass through unchanged.
+		if c.inBuf[i+1] == 'O' {
+			if i+2 >= len(c.inBuf) {
+				if !final {
+					break // buffer ESC O, wait for third byte
+				}
+				// final: pass through ESC O as-is.
+				out = append(out, c.inBuf[i:i+2]...)
+				i += 2
+				continue
+			}
+			switch c.inBuf[i+2] {
+			case 'H':
+				out = append(out, 0x1b, '[', 'H')
+				i += 3
+				continue
+			case 'F':
+				out = append(out, 0x1b, '[', 'F')
+				i += 3
+				continue
+			}
+			// Other ESC O* sequence — Bubble Tea handles natively.
+			out = append(out, c.inBuf[i:i+3]...)
+			i += 3
+			continue
+		}
+
 		if c.inBuf[i+1] != '[' {
 			out = append(out, c.inBuf[i])
 			i++

--- a/internal/ui/keyboard_compat_test.go
+++ b/internal/ui/keyboard_compat_test.go
@@ -681,3 +681,98 @@ func TestRestoreLegacyKeyboardCmd(t *testing.T) {
 		t.Errorf("cmd() wrote %q to writer, want %q (Kitty pop sequence)", got, want)
 	}
 }
+
+// TestCSIuReader_SS3HomeEnd covers the SS3 application-mode Home/End rewrite.
+// iTerm2's default macOS profile emits Home/End as ESC OH / ESC OF (SS3),
+// which Bubble Tea v1.3.10's escSeq table does not decode. The csiuReader
+// rewrites only these two sequences to their CSI equivalents ESC [H / ESC [F.
+// All other SS3 sequences (arrows ESC OA-D, F1-F4 ESC OP-S) must pass through
+// unchanged because Bubble Tea handles them natively.
+func TestCSIuReader_SS3HomeEnd(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"SS3 Home rewrites to CSI H", "\x1bOH", "\x1b[H"},
+		{"SS3 End rewrites to CSI F", "\x1bOF", "\x1b[F"},
+		{"SS3 up arrow passes through", "\x1bOA", "\x1bOA"},
+		{"SS3 down arrow passes through", "\x1bOB", "\x1bOB"},
+		{"SS3 right arrow passes through", "\x1bOC", "\x1bOC"},
+		{"SS3 left arrow passes through", "\x1bOD", "\x1bOD"},
+		{"SS3 F1 passes through", "\x1bOP", "\x1bOP"},
+		{"SS3 F2 passes through", "\x1bOQ", "\x1bOQ"},
+		{"SS3 F3 passes through", "\x1bOR", "\x1bOR"},
+		{"SS3 F4 passes through", "\x1bOS", "\x1bOS"},
+		{"mixed: legacy byte, SS3 Home, SS3 End, legacy byte",
+			"j\x1bOH\x1bOFq", "j\x1b[H\x1b[Fq"},
+		{"SS3 Home followed by CSI PgUp (known-working)",
+			"\x1bOH\x1b[5~", "\x1b[H\x1b[5~"},
+		{"SS3 Home next to non-SS3 ESC (bare ESC preserved)",
+			"\x1bOH\x1bq", "\x1b[H\x1bq"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewCSIuReader(bytes.NewReader([]byte(tt.input)))
+			out, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll error: %v", err)
+			}
+			if string(out) != tt.want {
+				t.Errorf("CSIuReader(%q) = %q, want %q", tt.input, string(out), tt.want)
+			}
+		})
+	}
+}
+
+// TestCSIuReader_SS3HomeEnd_ChunkedRead verifies that an SS3 Home/End sequence
+// split across two Read() calls (e.g. ESC O arrives in chunk 1, H in chunk 2)
+// is still rewritten correctly. The translator must buffer the partial ESC O
+// until the third byte is available.
+func TestCSIuReader_SS3HomeEnd_ChunkedRead(t *testing.T) {
+	tests := []struct {
+		name   string
+		chunks [][]byte
+		want   string
+	}{
+		{
+			"SS3 Home split between ESC O and H",
+			[][]byte{[]byte("\x1bO"), []byte("H")},
+			"\x1b[H",
+		},
+		{
+			"SS3 End split between ESC O and F",
+			[][]byte{[]byte("\x1bO"), []byte("F")},
+			"\x1b[F",
+		},
+		{
+			"SS3 Home split between ESC and OH",
+			[][]byte{[]byte("\x1b"), []byte("OH")},
+			"\x1b[H",
+		},
+		{
+			"SS3 passthrough (F1) split between ESC O and P",
+			[][]byte{[]byte("\x1bO"), []byte("P")},
+			"\x1bOP",
+		},
+		{
+			"mixed stream with SS3 Home at chunk boundary",
+			[][]byte{[]byte("j\x1bO"), []byte("Hq")},
+			"j\x1b[Hq",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewCSIuReader(&chunkedReader{chunks: tt.chunks})
+			out, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll error: %v", err)
+			}
+			if string(out) != tt.want {
+				t.Errorf("chunked CSIuReader = %q, want %q", string(out), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two related changes:

1. **Adds `PgUp`, `PgDn`, `Home`, `End` to the session list** as half-page / absolute-jump navigation. Completes the keyboard-pagination family added by vi-style scrolling in #38 (`Ctrl+U/D/F/B`, `gg/G`).
2. **Fixes an SS3 input decoder gap** that hid the new `Home`/`End` bindings from iTerm2 users on direct SSH (no tmux/screen between terminal and agent-deck).

Before this PR there was no single-key jump-to-bottom on the session list, because `G` was claimed by global search in #38. `End` fills that gap.

## Motivation

- Muscle memory: users coming from other TUIs (file managers, log viewers, pagers) expect `PgUp/PgDn/Home/End` to work.
- Discoverability: vi-style pagination (`Ctrl+U/D/F/B` + `gg`) is the current primary, but users who don't know vi were unable to page.
- iTerm2 default macOS profile emits Home/End as SS3 (`ESC OH`/`ESC OF`) — Bubble Tea v1.3.10's escSeq table doesn't decode these two variants, so the new handlers silently did nothing for a common user setup until the SS3 rewrite.

## Changes

### Commit 1 — keybindings (`feat(ui)`)

- `internal/ui/home.go` — `pgup`/`pgdown` added as aliases of `Ctrl+U`/`Ctrl+D` cases; new `case "home":` and `case "end":` handlers inserted before `case "G":`. All four follow the existing pagination side-effect contract (preview-scroll reset, navigation-activity mark, debounced preview fetch).
- `internal/ui/help.go` — NAVIGATION legend gets two new rows (`PgUp / PgDn`, `Home / End`); help overlay also accepts Home/End to scroll to top/bottom, mirroring existing `g`/`G`.
- `internal/ui/home_test.go` — `TestHome_TerminalNavigationKeys`: 8 cursor-position subtests (middle, clamps, no-op-at-boundary) plus 2 empty-list no-panic guards, with half-page size computed dynamically from `getVisibleHeight()`.
- `CHANGELOG.md` — new `[Unreleased]` section with `### Added` (this commit) and `### Fixed` (commit 2) bullets.

### Commit 2 — SS3 compat (`fix(ui)`)

- `internal/ui/keyboard_compat.go` — `csiuReader.translate` now rewrites `\x1bOH` → `\x1b[H` and `\x1bOF` → `\x1b[F`. All other `\x1bO*` sequences (arrows, F1–F4) pass through unchanged — Bubble Tea handles them.
- `internal/ui/keyboard_compat_test.go` — `TestCSIuReader_SS3HomeEnd` (13 cases) and `TestCSIuReader_SS3HomeEnd_ChunkedRead` (5 cases covering `\x1bO`-at-buffer-boundary buffering).

## Testing

- `go test ./internal/ui/... -race -count=1 -run "CSIuReader|TerminalNav"` — all new tests pass.
- `go test -tags eval_smoke -race -count=1 -timeout 3m ./tests/eval/... ./internal/ui/...` — eval tests pass (`tests/eval/feedback`, `tests/eval/session`).
- `go build ./...` — clean.
- Manual smoke in iTerm2 → direct SSH → remote tmux → agent-deck: `Home` jumps to first session, `End` to last, `PgUp/PgDn` paginate, help overlay `Home/End` scroll correctly.
- Manual smoke in iTerm2 → SSH → Screen → agent-deck: unchanged behavior (vt220 `\x1b[1~`/`\x1b[4~` already in Bubble Tea's escSeq table).

## Eval harness

No new eval case required. Cursor movement from `KeyMsg` is structurally expressible in Go unit tests (the new unit test demonstrates this). No tmux state mutation, interactive prompt, or disclosure step.

## Risk

- SS3 rewrite is narrow: two 3-byte sequences rewritten; every other SS3 sequence takes the passthrough branch. Bubble Tea's native handling of F1-F4 and SS3 arrows is unaffected.
- Keybindings are pure additions — existing `Ctrl+U/D/F/B`, `gg`, `G`, `j/k`, `Shift+K/J` reorder unchanged.
- Bubble Tea's `ESC [H` → `"home"` xterm decoding is assumed stable; no agent-deck-side eval case guards against its regression because the translator is covered at the byte level and the decoder is Bubble Tea's owned surface (see `key.go:425,435` in `bubbletea@v1.3.10`). If that decoder ever changes, unit tests go green but users break — file an eval case if desired.

## Related

Extends #38 (vi-style pagination). Does not close it — that feature already shipped in v0.8.41 and users asked only for vi keys.