### PR TITLE
fix(statedb): preserve tool_data extras across save cycles

### DIFF
--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -430,6 +430,14 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 		toolData = json.RawMessage("{}")
 	}
 
+	// Preserve any tool_data keys not modeled by the typed schema (e.g.,
+	// manually-set clear_on_compact). Without this merge, every
+	// INSERT OR REPLACE silently drops user-managed extras.
+	var existingToolData []byte
+	if err := s.db.QueryRow("SELECT tool_data FROM instances WHERE id = ?", inst.ID).Scan(&existingToolData); err == nil {
+		toolData = MergeToolDataExtras(json.RawMessage(existingToolData), toolData)
+	}
+
 	isConductorInt := 0
 	if inst.IsConductor {
 		isConductorInt = 1
@@ -466,6 +474,43 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 // It also removes any rows from the database that are not in the provided list,
 // ensuring deleted sessions don't reappear on reload.
 func (s *StateDB) SaveInstances(insts []*InstanceRow) error {
+	// Pre-fetch existing tool_data per instance ID so we can preserve any
+	// keys not modeled by the typed schema (e.g., manually-set
+	// clear_on_compact). Without this merge, every INSERT OR REPLACE
+	// silently drops user-managed extras. One batch SELECT instead of N
+	// individual reads.
+	//
+	// IMPORTANT: this read runs OUTSIDE the write transaction below.
+	// In SQLite WAL mode, beginning a transaction with a read and then
+	// trying to upgrade to a write fails with SQLITE_BUSY (rather than
+	// waiting on busy_timeout) when another connection is currently
+	// writing. Pre-reading on the raw DB handle avoids the upgrade path.
+	// There is a tiny race window where a concurrent writer could modify
+	// extras between this read and our commit; we accept it because
+	// extras keys are rarely-mutated user-managed flags and the worst-case
+	// outcome is one stale-overlay save, recoverable on next save.
+	existingToolData := make(map[string]json.RawMessage, len(insts))
+	if len(insts) > 0 {
+		placeholders := make([]string, len(insts))
+		args := make([]any, len(insts))
+		for i, inst := range insts {
+			placeholders[i] = "?"
+			args[i] = inst.ID
+		}
+		query := "SELECT id, tool_data FROM instances WHERE id IN (" + strings.Join(placeholders, ",") + ")"
+		rows, queryErr := s.db.Query(query, args...)
+		if queryErr == nil {
+			for rows.Next() {
+				var id string
+				var td []byte
+				if scanErr := rows.Scan(&id, &td); scanErr == nil {
+					existingToolData[id] = json.RawMessage(td)
+				}
+			}
+			_ = rows.Close()
+		}
+	}
+
 	tx, err := s.db.Begin()
 	if err != nil {
 		return err
@@ -509,6 +554,9 @@ func (s *StateDB) SaveInstances(insts []*InstanceRow) error {
 		toolData := inst.ToolData
 		if len(toolData) == 0 {
 			toolData = json.RawMessage("{}")
+		}
+		if existing, ok := existingToolData[inst.ID]; ok {
+			toolData = MergeToolDataExtras(existing, toolData)
 		}
 		isConductorInt := 0
 		if inst.IsConductor {

--- a/internal/statedb/tool_data_extras.go
+++ b/internal/statedb/tool_data_extras.go
@@ -1,0 +1,94 @@
+package statedb
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+)
+
+// MergeToolDataExtras preserves any keys in oldToolData that are not part of
+// agent-deck's typed tool_data schema (the toolDataBlob fields in this
+// package) and that are not already present in newToolData. It returns the
+// merged JSON to write back to the instances table.
+//
+// Why this exists: agent-deck's save path (SaveInstances) builds a fresh
+// tool_data blob from typed Instance fields and INSERT OR REPLACEs the row
+// wholesale. Any externally-written keys not modeled by toolDataBlob are
+// silently dropped on every save cycle. The user-set `clear_on_compact`
+// flag is the canonical example: it has no agent-deck CLI surface, so it
+// is set by direct SQLite UPDATE; without this merge, it survives at most
+// until the next session lifecycle event.
+//
+// The function is conservative: typed-known keys are not touched (the new
+// blob's value wins, including absence-by-omitempty), and new explicitly
+// setting a key wins over the old value (no silent override of intended
+// updates). Only keys that are completely unknown to the typed schema AND
+// absent from the new blob are carried forward.
+func MergeToolDataExtras(oldToolData, newToolData json.RawMessage) json.RawMessage {
+	if len(oldToolData) == 0 {
+		return newToolData
+	}
+	if len(newToolData) == 0 {
+		newToolData = json.RawMessage("{}")
+	}
+
+	var oldMap map[string]json.RawMessage
+	if err := json.Unmarshal(oldToolData, &oldMap); err != nil {
+		return newToolData // old is corrupt; cannot merge
+	}
+	if len(oldMap) == 0 {
+		return newToolData
+	}
+
+	var newMap map[string]json.RawMessage
+	if err := json.Unmarshal(newToolData, &newMap); err != nil {
+		return newToolData // new is corrupt; nothing to merge into
+	}
+	if newMap == nil {
+		newMap = make(map[string]json.RawMessage)
+	}
+
+	known := toolDataKnownKeys()
+	merged := false
+	for k, v := range oldMap {
+		if known[k] {
+			continue // typed schema is authoritative
+		}
+		if _, exists := newMap[k]; exists {
+			continue // new explicitly set this key
+		}
+		newMap[k] = v
+		merged = true
+	}
+
+	if !merged {
+		return newToolData
+	}
+	out, err := json.Marshal(newMap)
+	if err != nil {
+		return newToolData
+	}
+	return out
+}
+
+// toolDataKnownKeys returns the set of JSON keys that toolDataBlob explicitly
+// models. Used by MergeToolDataExtras to distinguish agent-deck's
+// authoritative schema from externally-managed extras.
+func toolDataKnownKeys() map[string]bool {
+	t := reflect.TypeOf(toolDataBlob{})
+	keys := make(map[string]bool, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		if comma := strings.Index(tag, ","); comma >= 0 {
+			tag = tag[:comma]
+		}
+		if tag != "" {
+			keys[tag] = true
+		}
+	}
+	return keys
+}

--- a/internal/statedb/tool_data_extras_test.go
+++ b/internal/statedb/tool_data_extras_test.go
@@ -1,0 +1,231 @@
+package statedb
+
+import (
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMergeToolDataExtras_PreservesUnknownKeys(t *testing.T) {
+	old := json.RawMessage(`{"claude_session_id":"abc","clear_on_compact":false}`)
+	new_ := json.RawMessage(`{"claude_session_id":"def"}`)
+
+	merged := MergeToolDataExtras(old, new_)
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(merged, &got); err != nil {
+		t.Fatalf("merged JSON does not parse: %v", err)
+	}
+
+	// Typed key: new wins.
+	if string(got["claude_session_id"]) != `"def"` {
+		t.Errorf("claude_session_id = %s, want \"def\"", got["claude_session_id"])
+	}
+	// Unknown key: preserved from old.
+	if string(got["clear_on_compact"]) != `false` {
+		t.Errorf("clear_on_compact = %s, want false (preserved from old)", got["clear_on_compact"])
+	}
+}
+
+func TestMergeToolDataExtras_NewExplicitWinsOverOldUnknown(t *testing.T) {
+	old := json.RawMessage(`{"some_unknown_key":"v1"}`)
+	new_ := json.RawMessage(`{"some_unknown_key":"v2"}`)
+
+	merged := MergeToolDataExtras(old, new_)
+
+	var got map[string]json.RawMessage
+	_ = json.Unmarshal(merged, &got)
+	if string(got["some_unknown_key"]) != `"v2"` {
+		t.Errorf("some_unknown_key = %s, want \"v2\" (new explicit wins)", got["some_unknown_key"])
+	}
+}
+
+func TestMergeToolDataExtras_TypedKeyAbsenceRespected(t *testing.T) {
+	// When the new tool_data omits a typed key (e.g., omitempty zero-value),
+	// the merge must NOT carry the old value forward. The typed schema is
+	// authoritative for typed fields. This protects intentional clears.
+	old := json.RawMessage(`{"claude_session_id":"abc"}`)
+	new_ := json.RawMessage(`{}`)
+
+	merged := MergeToolDataExtras(old, new_)
+
+	var got map[string]json.RawMessage
+	_ = json.Unmarshal(merged, &got)
+	if _, present := got["claude_session_id"]; present {
+		t.Errorf("claude_session_id should be absent in merged when new omits it; got %s", got["claude_session_id"])
+	}
+}
+
+func TestMergeToolDataExtras_EmptyOld(t *testing.T) {
+	new_ := json.RawMessage(`{"claude_session_id":"abc"}`)
+	merged := MergeToolDataExtras(nil, new_)
+	if string(merged) != string(new_) {
+		t.Errorf("empty old should pass through new; got %s, want %s", merged, new_)
+	}
+}
+
+func TestMergeToolDataExtras_CorruptOldFallsThrough(t *testing.T) {
+	old := json.RawMessage(`not json`)
+	new_ := json.RawMessage(`{"claude_session_id":"abc"}`)
+	merged := MergeToolDataExtras(old, new_)
+	if string(merged) != string(new_) {
+		t.Errorf("corrupt old should fall through to new; got %s", merged)
+	}
+}
+
+func TestToolDataKnownKeys_IncludesCoreFields(t *testing.T) {
+	keys := toolDataKnownKeys()
+	for _, expected := range []string{
+		"claude_session_id",
+		"codex_session_id",
+		"latest_prompt",
+		"color",
+	} {
+		if !keys[expected] {
+			t.Errorf("toolDataKnownKeys missing expected typed key %q", expected)
+		}
+	}
+}
+
+// TestSaveInstance_PreservesClearOnCompactExtra is the regression test for
+// the bug surfaced 2026-04-29: a manually-written tool_data extra
+// (clear_on_compact) was being silently dropped on every SaveInstance
+// because INSERT OR REPLACE wholesale-replaced the row's tool_data with
+// the typed-only blob.
+func TestSaveInstance_PreservesClearOnCompactExtra(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+
+	id := "test-instance-1"
+	now := time.Now()
+	row := &InstanceRow{
+		ID:           id,
+		Title:        "test",
+		Status:       "running",
+		Tool:         "claude",
+		CreatedAt:    now,
+		LastAccessed: now,
+		GroupPath:    "default",
+		ToolData:     json.RawMessage(`{"claude_session_id":"abc"}`),
+	}
+	if err := db.SaveInstance(row); err != nil {
+		t.Fatalf("first SaveInstance failed: %v", err)
+	}
+
+	// Simulate a manual SQLite write adding clear_on_compact (the user's
+	// canonical method per standing convention).
+	if _, err := db.DB().Exec(
+		`UPDATE instances SET tool_data = json_set(tool_data, '$.clear_on_compact', json('false')) WHERE id = ?`,
+		id,
+	); err != nil {
+		t.Fatalf("manual update failed: %v", err)
+	}
+
+	// Verify the manual write landed.
+	var afterManual sql.NullString
+	if err := db.DB().QueryRow("SELECT tool_data FROM instances WHERE id = ?", id).Scan(&afterManual); err != nil {
+		t.Fatalf("read after manual update: %v", err)
+	}
+	if !afterManual.Valid {
+		t.Fatal("tool_data is null after manual update")
+	}
+	var afterManualMap map[string]json.RawMessage
+	_ = json.Unmarshal([]byte(afterManual.String), &afterManualMap)
+	if string(afterManualMap["clear_on_compact"]) != "false" {
+		t.Fatalf("manual write did not land: tool_data=%s", afterManual.String)
+	}
+
+	// Now agent-deck saves the row again with a typed-only blob (e.g., a
+	// new claude_session_id from a fresh detection). Pre-fix this would
+	// wipe clear_on_compact; post-fix it must be preserved.
+	row.ToolData = json.RawMessage(`{"claude_session_id":"def"}`)
+	if err := db.SaveInstance(row); err != nil {
+		t.Fatalf("second SaveInstance failed: %v", err)
+	}
+
+	var afterReSave sql.NullString
+	if err := db.DB().QueryRow("SELECT tool_data FROM instances WHERE id = ?", id).Scan(&afterReSave); err != nil {
+		t.Fatalf("read after re-save: %v", err)
+	}
+	var afterReSaveMap map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(afterReSave.String), &afterReSaveMap); err != nil {
+		t.Fatalf("parse re-save tool_data: %v", err)
+	}
+	if string(afterReSaveMap["claude_session_id"]) != `"def"` {
+		t.Errorf("typed update lost: claude_session_id = %s", afterReSaveMap["claude_session_id"])
+	}
+	if v, ok := afterReSaveMap["clear_on_compact"]; !ok || string(v) != "false" {
+		t.Errorf("regression: clear_on_compact wiped on re-save (got %q, present=%v)", v, ok)
+	}
+}
+
+// TestSaveInstances_PreservesClearOnCompactExtra is the batch-save analog
+// of TestSaveInstance_PreservesClearOnCompactExtra. SaveInstances has its
+// own separate code path (transaction, INSERT OR REPLACE per row) that
+// must independently preserve unknown tool_data keys.
+func TestSaveInstances_PreservesClearOnCompactExtra(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer db.Close()
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+
+	now := time.Now()
+	a := &InstanceRow{
+		ID: "a", Title: "a", Status: "running", Tool: "claude",
+		CreatedAt: now, LastAccessed: now, GroupPath: "default",
+		ToolData: json.RawMessage(`{"claude_session_id":"a-v1"}`),
+	}
+	b := &InstanceRow{
+		ID: "b", Title: "b", Status: "running", Tool: "codex",
+		CreatedAt: now, LastAccessed: now, GroupPath: "default",
+		ToolData: json.RawMessage(`{"codex_session_id":"b-v1"}`),
+	}
+	if err := db.SaveInstances([]*InstanceRow{a, b}); err != nil {
+		t.Fatalf("first SaveInstances failed: %v", err)
+	}
+
+	// Manual writes adding extras to both rows.
+	for _, id := range []string{"a", "b"} {
+		if _, err := db.DB().Exec(
+			`UPDATE instances SET tool_data = json_set(tool_data, '$.clear_on_compact', json('false')) WHERE id = ?`,
+			id,
+		); err != nil {
+			t.Fatalf("manual update %s: %v", id, err)
+		}
+	}
+
+	// Re-save with typed-only blobs.
+	a.ToolData = json.RawMessage(`{"claude_session_id":"a-v2"}`)
+	b.ToolData = json.RawMessage(`{"codex_session_id":"b-v2"}`)
+	if err := db.SaveInstances([]*InstanceRow{a, b}); err != nil {
+		t.Fatalf("second SaveInstances failed: %v", err)
+	}
+
+	for _, id := range []string{"a", "b"} {
+		var raw sql.NullString
+		if err := db.DB().QueryRow("SELECT tool_data FROM instances WHERE id = ?", id).Scan(&raw); err != nil {
+			t.Fatalf("read after re-save %s: %v", id, err)
+		}
+		var m map[string]json.RawMessage
+		_ = json.Unmarshal([]byte(raw.String), &m)
+		if v, ok := m["clear_on_compact"]; !ok || string(v) != "false" {
+			t.Errorf("regression on %s: clear_on_compact wiped on batch re-save (got %q, present=%v)", id, v, ok)
+		}
+	}
+}


### PR DESCRIPTION
Fixes silent-wipe of manually-set tool_data keys (canonical case: `clear_on_compact`, which has no CLI surface and is set via direct SQLite UPDATE per harness convention). Surfaced 2026-04-29 by hub-orch sessions firing /clear-on-compact again after the SQLite write had been applied earlier; agent-deck save path INSERT OR REPLACEs tool_data wholesale from the typed schema, dropping any keys not modeled by toolDataBlob.

Fix preserves unknown keys via a read-before-write merge in SaveInstance and SaveInstances. Pre-fetch happens outside the write transaction in the batch path to avoid SQLite WAL upgrade-from-read-to-write contention with concurrent writers (which manifests as SQLITE_BUSY rather than waiting on busy_timeout). Typed schema remains authoritative; only keys NOT modeled by toolDataBlob and NOT explicitly present in the new blob are carried forward.

Tests: unit coverage on the merge logic, regression tests reproducing the bug pattern, plus the pre-existing TestConcurrentStorageWrites continues to pass across 5 consecutive runs.