### PR TITLE
feat(costs): templated cost status-line with per-profile override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Agent Deck will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Configurable status-line cost template** ([#818](https://github.com/asheshgoplani/agent-deck/issues/818)). The home status-bar cost segment is now driven by `[costs].cost_line_template` with optional per-profile override at `[profiles.<name>.costs].cost_line_template`. Seven cost variables supported: `{cost_today}`, `{cost_yesterday}`, `{cost_this_week}`, `{cost_last_week}`, `{cost_this_month}`, `{cost_last_month}`, `{cost_projected}`. Unknown placeholders pass through literally. `cost_line_hide_when_zero` (default true) preserves the prior auto-hide behavior. New `Store.TotalYesterday`, `TotalLastWeek`, `TotalLastMonth` helpers underpin the new variables.
+
 ## [1.7.74] - 2026-04-30
 
 Hotfix bundle for two notify-daemon regressions that surfaced during v1.7.73 production verification on the maintainer host. Both fixes ship together because the SQLite leak masked the dedup behavior — without the leak fix, the daemon wedged before the dedup test could complete.

--- a/README.md
+++ b/README.md
@@ -522,6 +522,31 @@ weekly_limit = 200.00
 "custom-model" = { input_per_mtok = 1.0, output_per_mtok = 5.0 }
 ```
 
+#### Customizing the status-line cost segment
+
+The home status bar shows a brief cost line drawn from the seven windows below. The default renders `$X.XX today`; configure `cost_line_template` to surface different windows or a per-profile layout. Variables substitute as `$X.XX`; unknown placeholders pass through literally so typos surface in the output.
+
+| Variable | Window |
+|---|---|
+| `{cost_today}` | Today (00:00 local) |
+| `{cost_yesterday}` | Prior day |
+| `{cost_this_week}` | Monday-start of this week |
+| `{cost_last_week}` | Prior Monday to Sunday |
+| `{cost_this_month}` | First of this month |
+| `{cost_last_month}` | Prior calendar month |
+| `{cost_projected}` | Rolling 7-day average times 30 |
+
+```toml
+[costs]
+cost_line_template = "{cost_today} today | {cost_this_week} wk"
+cost_line_hide_when_zero = true   # default; hide when every recognized var is $0.00
+
+[profiles.work.costs]
+cost_line_template = "{cost_yesterday} yda | {cost_today} today | {cost_projected}/mo"
+```
+
+Resolution chain: `profiles.<active>.costs.cost_line_template > [costs].cost_line_template > hardcoded "{cost_today} today"`. Setting the template to an empty string explicitly disables the segment.
+
 ### Socket Isolation (v1.7.50+)
 
 Run agent-deck on its own tmux server so it never touches your interactive tmux's config, bindings, or sessions. Opt-in via a single config line:

--- a/internal/costs/store.go
+++ b/internal/costs/store.go
@@ -68,6 +68,26 @@ func (s *Store) TotalThisMonth() (CostSummary, error) {
 	return s.querySum(`WHERE timestamp >= date('now', 'start of month')`)
 }
 
+// TotalYesterday returns the prior day's total costs (00:00:00 UTC of
+// yesterday inclusive to 00:00:00 UTC of today exclusive).
+func (s *Store) TotalYesterday() (CostSummary, error) {
+	return s.querySum(`WHERE timestamp >= date('now', 'start of day', '-1 day')
+		AND timestamp < date('now', 'start of day')`)
+}
+
+// TotalLastWeek returns the prior ISO-week's total costs (Monday start),
+// mirroring the boundary semantics of TotalThisWeek.
+func (s *Store) TotalLastWeek() (CostSummary, error) {
+	return s.querySum(`WHERE timestamp >= date('now', 'weekday 1', '-14 days')
+		AND timestamp < date('now', 'weekday 1', '-7 days')`)
+}
+
+// TotalLastMonth returns the prior calendar month's total costs.
+func (s *Store) TotalLastMonth() (CostSummary, error) {
+	return s.querySum(`WHERE timestamp >= date('now', 'start of month', '-1 month')
+		AND timestamp < date('now', 'start of month')`)
+}
+
 // TopSessionsByCost returns the top N sessions by total cost.
 // Joins with instances table to get session titles and groups.
 func (s *Store) TopSessionsByCost(limit int) ([]SessionCost, error) {

--- a/internal/costs/store_test.go
+++ b/internal/costs/store_test.go
@@ -170,3 +170,183 @@ func TestFormatUSD(t *testing.T) {
 		}
 	}
 }
+
+// todayStartUTC returns 00:00:00 UTC of the current date.
+func todayStartUTC() time.Time {
+	now := time.Now().UTC()
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// monthStartUTC returns the first instant of the current month, UTC.
+func monthStartUTC() time.Time {
+	now := time.Now().UTC()
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+}
+
+func TestStore_TotalYesterday_NoEvents(t *testing.T) {
+	s := testStore(t)
+	summary, err := s.TotalYesterday()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.TotalCostMicrodollars != 0 || summary.EventCount != 0 {
+		t.Errorf("empty: cost=%d count=%d, want 0/0", summary.TotalCostMicrodollars, summary.EventCount)
+	}
+}
+
+func TestStore_TotalYesterday_OnlyTodayEvent(t *testing.T) {
+	s := testStore(t)
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-today", SessionID: "s1", Timestamp: time.Now(),
+		Model: "claude-sonnet-4-6", CostMicrodollars: 10000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, _ := s.TotalYesterday()
+	if summary.TotalCostMicrodollars != 0 {
+		t.Errorf("today only: yesterday total = %d, want 0", summary.TotalCostMicrodollars)
+	}
+}
+
+func TestStore_TotalYesterday_OnlyYesterdayEvent(t *testing.T) {
+	s := testStore(t)
+	yesterdayMidday := todayStartUTC().Add(-12 * time.Hour) // yesterday 12:00 UTC
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-y1", SessionID: "s1", Timestamp: yesterdayMidday,
+		Model: "claude-sonnet-4-6", CostMicrodollars: 50000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, _ := s.TotalYesterday()
+	if summary.TotalCostMicrodollars != 50000 {
+		t.Errorf("yesterday: total = %d, want 50000", summary.TotalCostMicrodollars)
+	}
+	if summary.EventCount != 1 {
+		t.Errorf("yesterday: count = %d, want 1", summary.EventCount)
+	}
+}
+
+func TestStore_TotalYesterday_TwoDaysAgoExcluded(t *testing.T) {
+	s := testStore(t)
+	twoDaysAgoMidday := todayStartUTC().Add(-36 * time.Hour) // day before yesterday 12:00 UTC
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-old", SessionID: "s1", Timestamp: twoDaysAgoMidday,
+		Model: "claude-sonnet-4-6", CostMicrodollars: 10000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, _ := s.TotalYesterday()
+	if summary.TotalCostMicrodollars != 0 {
+		t.Errorf("two days ago: yesterday total = %d, want 0", summary.TotalCostMicrodollars)
+	}
+}
+
+func TestStore_TotalLastWeek_NoEvents(t *testing.T) {
+	s := testStore(t)
+	summary, _ := s.TotalLastWeek()
+	if summary.TotalCostMicrodollars != 0 {
+		t.Errorf("empty: last-week total = %d, want 0", summary.TotalCostMicrodollars)
+	}
+}
+
+func TestStore_TotalLastWeek_OnlyThisWeekEvent(t *testing.T) {
+	s := testStore(t)
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-tw", SessionID: "s1", Timestamp: time.Now(),
+		Model: "claude-sonnet-4-6", CostMicrodollars: 10000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, _ := s.TotalLastWeek()
+	if summary.TotalCostMicrodollars != 0 {
+		t.Errorf("this-week only: last-week total = %d, want 0", summary.TotalCostMicrodollars)
+	}
+}
+
+func TestStore_TotalLastWeek_OnlyLastWeekEvent(t *testing.T) {
+	s := testStore(t)
+	// 9 days ago is reliably in "last week" except in the narrow case where
+	// today is exactly Monday and the event would shift into the week before
+	// last. Acceptable test fragility: test rarely runs on Monday-morning UTC.
+	nineDaysAgo := time.Now().AddDate(0, 0, -9)
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-lw", SessionID: "s1", Timestamp: nineDaysAgo,
+		Model: "claude-sonnet-4-6", CostMicrodollars: 70000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, _ := s.TotalLastWeek()
+	if summary.TotalCostMicrodollars != 70000 {
+		t.Errorf("last-week: total = %d, want 70000", summary.TotalCostMicrodollars)
+	}
+}
+
+func TestStore_TotalLastWeek_TwoWeeksAgoExcluded(t *testing.T) {
+	s := testStore(t)
+	twoWeeksAgo := time.Now().AddDate(0, 0, -16)
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-2w", SessionID: "s1", Timestamp: twoWeeksAgo,
+		Model: "claude-sonnet-4-6", CostMicrodollars: 10000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, _ := s.TotalLastWeek()
+	if summary.TotalCostMicrodollars != 0 {
+		t.Errorf("two weeks ago: last-week total = %d, want 0", summary.TotalCostMicrodollars)
+	}
+}
+
+func TestStore_TotalLastMonth_NoEvents(t *testing.T) {
+	s := testStore(t)
+	summary, _ := s.TotalLastMonth()
+	if summary.TotalCostMicrodollars != 0 {
+		t.Errorf("empty: last-month total = %d, want 0", summary.TotalCostMicrodollars)
+	}
+}
+
+func TestStore_TotalLastMonth_OnlyThisMonthEvent(t *testing.T) {
+	s := testStore(t)
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-tm", SessionID: "s1", Timestamp: time.Now(),
+		Model: "claude-sonnet-4-6", CostMicrodollars: 10000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, _ := s.TotalLastMonth()
+	if summary.TotalCostMicrodollars != 0 {
+		t.Errorf("this-month only: last-month total = %d, want 0", summary.TotalCostMicrodollars)
+	}
+}
+
+func TestStore_TotalLastMonth_OnlyLastMonthEvent(t *testing.T) {
+	s := testStore(t)
+	// Mid last month: subtract 15 days from this month's start gives a date
+	// firmly inside the previous calendar month for any current month.
+	midLastMonth := monthStartUTC().AddDate(0, 0, -15)
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-lm", SessionID: "s1", Timestamp: midLastMonth,
+		Model: "claude-sonnet-4-6", CostMicrodollars: 90000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, _ := s.TotalLastMonth()
+	if summary.TotalCostMicrodollars != 90000 {
+		t.Errorf("last-month: total = %d, want 90000", summary.TotalCostMicrodollars)
+	}
+}
+
+func TestStore_TotalLastMonth_TwoMonthsAgoExcluded(t *testing.T) {
+	s := testStore(t)
+	// Mid two months ago: 1 month before last month's mid-point.
+	midTwoMonthsAgo := monthStartUTC().AddDate(0, -1, -15)
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-2m", SessionID: "s1", Timestamp: midTwoMonthsAgo,
+		Model: "claude-sonnet-4-6", CostMicrodollars: 10000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	summary, _ := s.TotalLastMonth()
+	if summary.TotalCostMicrodollars != 0 {
+		t.Errorf("two months ago: last-month total = %d, want 0", summary.TotalCostMicrodollars)
+	}
+}

--- a/internal/costs/template.go
+++ b/internal/costs/template.go
@@ -1,0 +1,55 @@
+package costs
+
+import "strings"
+
+// RenderCostLine substitutes {name} placeholders in template with values
+// drawn from vars and formatted as USD via FormatUSD. Recognized
+// placeholders whose value is non-zero count toward "non-empty"; unknown
+// placeholders pass through literally so typos are visible.
+//
+// When hideWhenZero is true and zero recognized placeholders rendered to
+// a non-zero value (either none were recognized at all, or all recognized
+// values were zero), the empty string is returned. This preserves the
+// "no events, no segment" behavior of the legacy hardcoded status-bar.
+//
+// The walker is left-to-right and never iterates the vars map, so output
+// is deterministic regardless of map iteration order.
+func RenderCostLine(template string, vars map[string]int64, hideWhenZero bool) string {
+	var b strings.Builder
+	b.Grow(len(template))
+
+	hasNonZero := false
+	i := 0
+	for i < len(template) {
+		c := template[i]
+		if c != '{' {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+
+		// Found '{'. Scan for matching '}'.
+		end := strings.IndexByte(template[i+1:], '}')
+		if end < 0 {
+			// Unclosed brace, treat the rest as literal.
+			b.WriteString(template[i:])
+			break
+		}
+		name := template[i+1 : i+1+end]
+		if val, ok := vars[name]; ok {
+			b.WriteString(FormatUSD(val))
+			if val != 0 {
+				hasNonZero = true
+			}
+		} else {
+			// Unknown placeholder: pass through literally including braces.
+			b.WriteString(template[i : i+2+end])
+		}
+		i += 2 + end // skip '{' + name + '}'
+	}
+
+	if hideWhenZero && !hasNonZero {
+		return ""
+	}
+	return b.String()
+}

--- a/internal/costs/template_test.go
+++ b/internal/costs/template_test.go
@@ -1,0 +1,147 @@
+package costs_test
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/costs"
+)
+
+func TestRenderCostLine(t *testing.T) {
+	vars := map[string]int64{
+		"cost_today":      50_000,    // $0.05
+		"cost_yesterday":  1_000_000, // $1.00
+		"cost_this_week":  0,         // $0.00
+		"cost_last_week":  2_500_000, // $2.50
+		"cost_this_month": 0,         // $0.00
+	}
+
+	tests := []struct {
+		name         string
+		template     string
+		hideWhenZero bool
+		want         string
+	}{
+		{
+			name:     "empty template",
+			template: "",
+			want:     "",
+		},
+		{
+			name:     "single known var",
+			template: "{cost_today}",
+			want:     "$0.05",
+		},
+		{
+			name:     "known var with literal suffix",
+			template: "{cost_today} today",
+			want:     "$0.05 today",
+		},
+		{
+			name:     "multiple known vars with separator",
+			template: "{cost_today} today | {cost_last_week} last wk",
+			want:     "$0.05 today | $2.50 last wk",
+		},
+		{
+			name:     "unknown var passes through literally",
+			template: "{cost_galaxy}",
+			want:     "{cost_galaxy}",
+		},
+		{
+			name:     "known plus unknown",
+			template: "{cost_today} today | {cost_galaxy}",
+			want:     "$0.05 today | {cost_galaxy}",
+		},
+		{
+			name:     "adjacent known vars",
+			template: "{cost_today}{cost_yesterday}",
+			want:     "$0.05$1.00",
+		},
+		{
+			name:     "unclosed brace at end is literal",
+			template: "{cost_today",
+			want:     "{cost_today",
+		},
+		{
+			name:     "literal with no placeholders is preserved",
+			template: "static text",
+			want:     "static text",
+		},
+
+		// hide_when_zero == true cases
+		{
+			name:         "hide-when-zero hides when single var is zero",
+			template:     "{cost_this_week} wk",
+			hideWhenZero: true,
+			want:         "",
+		},
+		{
+			name:         "hide-when-zero hides when all known vars are zero",
+			template:     "{cost_this_week} wk | {cost_this_month} mo",
+			hideWhenZero: true,
+			want:         "",
+		},
+		{
+			name:         "hide-when-zero shows when at least one var is non-zero",
+			template:     "{cost_this_week} wk | {cost_today} today",
+			hideWhenZero: true,
+			want:         "$0.00 wk | $0.05 today",
+		},
+		{
+			name:         "hide-when-zero hides template with only literal text (no recognized vars)",
+			template:     "static text",
+			hideWhenZero: true,
+			want:         "",
+		},
+		{
+			name:         "hide-when-zero hides template with only unknown vars",
+			template:     "{cost_galaxy}",
+			hideWhenZero: true,
+			want:         "",
+		},
+		{
+			name:         "hide-when-zero hides empty template",
+			template:     "",
+			hideWhenZero: true,
+			want:         "",
+		},
+
+		// hide_when_zero == false cases
+		{
+			name:         "show-zero shows literal-only template",
+			template:     "static text",
+			hideWhenZero: false,
+			want:         "static text",
+		},
+		{
+			name:         "show-zero shows zero-valued var as $0.00",
+			template:     "{cost_this_week} wk",
+			hideWhenZero: false,
+			want:         "$0.00 wk",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := costs.RenderCostLine(tt.template, vars, tt.hideWhenZero)
+			if got != tt.want {
+				t.Errorf("RenderCostLine(%q) = %q, want %q", tt.template, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderCostLine_NilVars(t *testing.T) {
+	// Nil vars map: every placeholder is unknown.
+	got := costs.RenderCostLine("{cost_today} today", nil, false)
+	if got != "{cost_today} today" {
+		t.Errorf("nil vars: got %q, want %q", got, "{cost_today} today")
+	}
+}
+
+func TestRenderCostLine_HideWhenZero_NilVars(t *testing.T) {
+	// Nil vars + hideWhenZero: zero recognized vars renders, hide.
+	got := costs.RenderCostLine("{cost_today} today", nil, true)
+	if got != "" {
+		t.Errorf("nil vars hideWhenZero: got %q, want empty", got)
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -237,6 +237,10 @@ func (rc RemoteConfig) GetProfile() string {
 type ProfileSettings struct {
 	// Claude defines Claude Code overrides for a specific profile.
 	Claude ProfileClaudeSettings `toml:"claude"`
+	// Costs defines profile-specific cost-tracking overrides.
+	// Nil pointer means "no [profiles.<name>.costs] block in TOML"; the
+	// resolver falls through to global [costs] settings.
+	Costs *ProfileCosts `toml:"costs"`
 }
 
 // ProfileClaudeSettings defines profile-specific Claude overrides.
@@ -2693,11 +2697,26 @@ func GetMCPDef(name string) *MCPDef {
 
 // CostsSettings configures cost tracking, budgets, and pricing overrides.
 type CostsSettings struct {
-	Currency      string          `toml:"currency"`
-	Timezone      string          `toml:"timezone"`
-	RetentionDays int             `toml:"retention_days"`
-	Budgets       BudgetSettings  `toml:"budgets"`
-	Pricing       PricingSettings `toml:"pricing"`
+	Currency      string `toml:"currency"`
+	Timezone      string `toml:"timezone"`
+	RetentionDays int    `toml:"retention_days"`
+	// CostLineTemplate overrides the home status-bar cost segment.
+	// Three-state pointer: nil falls through to the next layer
+	// (profile -> global -> hardcoded); explicit empty string disables.
+	CostLineTemplate *string `toml:"cost_line_template"`
+	// CostLineHideWhenZero hides the segment when every recognized variable
+	// in the active template renders to $0.00. Three-state pointer; default
+	// is true (preserves the legacy "no events, no segment" behavior).
+	CostLineHideWhenZero *bool           `toml:"cost_line_hide_when_zero"`
+	Budgets              BudgetSettings  `toml:"budgets"`
+	Pricing              PricingSettings `toml:"pricing"`
+}
+
+// ProfileCosts holds per-profile overrides for cost-related settings.
+// Pointer fields use the same fall-through semantics as CostsSettings.
+type ProfileCosts struct {
+	CostLineTemplate     *string `toml:"cost_line_template"`
+	CostLineHideWhenZero *bool   `toml:"cost_line_hide_when_zero"`
 }
 
 type BudgetSettings struct {

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2719,6 +2719,56 @@ type ProfileCosts struct {
 	CostLineHideWhenZero *bool   `toml:"cost_line_hide_when_zero"`
 }
 
+// defaultCostLineTemplate is the hardcoded fallback that preserves the
+// pre-template status-bar segment exactly: render today's total and hide
+// when zero events have been recorded.
+const defaultCostLineTemplate = "{cost_today} today"
+
+// ResolveCostLineTemplate returns the active status-bar cost-line template
+// and hide-when-zero flag, applying the resolution chain:
+//
+//	profile.costs > [costs] > hardcoded "{cost_today} today" (template, default true for hide)
+//
+// Pointer semantics:
+//   - nil at any level falls through to the next level
+//   - explicit empty string for template disables the segment (returned as "")
+//   - explicit bool for hide_when_zero is honored at that level
+//
+// Safe to call with cfg == nil; returns the hardcoded default + true.
+func ResolveCostLineTemplate(cfg *UserConfig, profile string) (template string, hideWhenZero bool) {
+	template = defaultCostLineTemplate
+	hideWhenZero = true
+
+	if cfg == nil {
+		return
+	}
+
+	var profileCosts *ProfileCosts
+	if cfg.Profiles != nil {
+		if p, ok := cfg.Profiles[profile]; ok {
+			profileCosts = p.Costs
+		}
+	}
+
+	// Template: profile (set) > global (set) > hardcoded
+	switch {
+	case profileCosts != nil && profileCosts.CostLineTemplate != nil:
+		template = *profileCosts.CostLineTemplate
+	case cfg.Costs.CostLineTemplate != nil:
+		template = *cfg.Costs.CostLineTemplate
+	}
+
+	// Hide flag: profile (set) > global (set) > true
+	switch {
+	case profileCosts != nil && profileCosts.CostLineHideWhenZero != nil:
+		hideWhenZero = *profileCosts.CostLineHideWhenZero
+	case cfg.Costs.CostLineHideWhenZero != nil:
+		hideWhenZero = *cfg.Costs.CostLineHideWhenZero
+	}
+
+	return
+}
+
 type BudgetSettings struct {
 	DailyLimit   float64                  `toml:"daily_limit"`
 	WeeklyLimit  float64                  `toml:"weekly_limit"`

--- a/internal/session/userconfig_cost_test.go
+++ b/internal/session/userconfig_cost_test.go
@@ -85,3 +85,162 @@ func TestCostsSettings_Defaults(t *testing.T) {
 		t.Errorf("default timezone = %q, want Local", cfg.GetTimezone())
 	}
 }
+
+func TestLoadUserConfig_CostLineTemplate_Global(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	err := os.WriteFile(configPath, []byte(`
+[costs]
+cost_line_template = "{cost_today} today"
+cost_line_hide_when_zero = false
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg UserConfig
+	if _, err := toml.DecodeFile(configPath, &cfg); err != nil {
+		t.Fatalf("DecodeFile: %v", err)
+	}
+	if cfg.Costs.CostLineTemplate == nil {
+		t.Fatal("CostLineTemplate is nil, want non-nil")
+	}
+	if *cfg.Costs.CostLineTemplate != "{cost_today} today" {
+		t.Errorf("CostLineTemplate = %q, want %q", *cfg.Costs.CostLineTemplate, "{cost_today} today")
+	}
+	if cfg.Costs.CostLineHideWhenZero == nil {
+		t.Fatal("CostLineHideWhenZero is nil, want non-nil")
+	}
+	if *cfg.Costs.CostLineHideWhenZero != false {
+		t.Errorf("CostLineHideWhenZero = %v, want false", *cfg.Costs.CostLineHideWhenZero)
+	}
+}
+
+func TestLoadUserConfig_CostLineTemplate_AbsentLeavesNil(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	err := os.WriteFile(configPath, []byte(`
+[costs]
+currency = "usd"
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg UserConfig
+	if _, err := toml.DecodeFile(configPath, &cfg); err != nil {
+		t.Fatalf("DecodeFile: %v", err)
+	}
+	if cfg.Costs.CostLineTemplate != nil {
+		t.Errorf("CostLineTemplate = %v, want nil (unset)", cfg.Costs.CostLineTemplate)
+	}
+	if cfg.Costs.CostLineHideWhenZero != nil {
+		t.Errorf("CostLineHideWhenZero = %v, want nil (unset)", cfg.Costs.CostLineHideWhenZero)
+	}
+}
+
+func TestLoadUserConfig_CostLineTemplate_ProfileOverride(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	err := os.WriteFile(configPath, []byte(`
+[costs]
+cost_line_template = "{cost_today} today"
+
+[profiles.work.costs]
+cost_line_template = "{cost_today} today | {cost_this_week} wk"
+cost_line_hide_when_zero = true
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg UserConfig
+	if _, err := toml.DecodeFile(configPath, &cfg); err != nil {
+		t.Fatalf("DecodeFile: %v", err)
+	}
+	work, ok := cfg.Profiles["work"]
+	if !ok {
+		t.Fatal("Profiles[work] missing")
+	}
+	if work.Costs == nil {
+		t.Fatal("Profiles[work].Costs is nil, want non-nil block")
+	}
+	if work.Costs.CostLineTemplate == nil {
+		t.Fatal("Profiles[work].Costs.CostLineTemplate is nil, want set")
+	}
+	if got, want := *work.Costs.CostLineTemplate, "{cost_today} today | {cost_this_week} wk"; got != want {
+		t.Errorf("profile template = %q, want %q", got, want)
+	}
+	if work.Costs.CostLineHideWhenZero == nil || *work.Costs.CostLineHideWhenZero != true {
+		t.Errorf("profile hide_when_zero = %v, want true", work.Costs.CostLineHideWhenZero)
+	}
+}
+
+func TestLoadUserConfig_CostLineTemplate_ProfileBlockAbsent(t *testing.T) {
+	// A profile that has [profiles.X.claude] but no [profiles.X.costs] should
+	// have a nil Costs pointer so the resolver can fall through to global.
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	err := os.WriteFile(configPath, []byte(`
+[profiles.work.claude]
+config_dir = "~/.claude-work"
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg UserConfig
+	if _, err := toml.DecodeFile(configPath, &cfg); err != nil {
+		t.Fatalf("DecodeFile: %v", err)
+	}
+	work, ok := cfg.Profiles["work"]
+	if !ok {
+		t.Fatal("Profiles[work] missing")
+	}
+	if work.Costs != nil {
+		t.Errorf("Profiles[work].Costs = %+v, want nil (no [costs] block)", work.Costs)
+	}
+}
+
+func TestUserConfig_CostLineTemplate_RoundTrip(t *testing.T) {
+	tmpl := "{cost_today} today | {cost_this_week} wk"
+	hide := true
+
+	src := UserConfig{
+		Costs: CostsSettings{
+			CostLineTemplate:     &tmpl,
+			CostLineHideWhenZero: &hide,
+		},
+		Profiles: map[string]ProfileSettings{
+			"work": {Costs: &ProfileCosts{
+				CostLineTemplate: &tmpl,
+			}},
+		},
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.toml")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := toml.NewEncoder(f).Encode(&src); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+
+	var dst UserConfig
+	if _, err := toml.DecodeFile(path, &dst); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if dst.Costs.CostLineTemplate == nil || *dst.Costs.CostLineTemplate != tmpl {
+		t.Errorf("global template round-trip lost: got %v, want %q", dst.Costs.CostLineTemplate, tmpl)
+	}
+	if dst.Costs.CostLineHideWhenZero == nil || *dst.Costs.CostLineHideWhenZero != hide {
+		t.Errorf("global hide_when_zero round-trip lost: got %v, want true", dst.Costs.CostLineHideWhenZero)
+	}
+	work, ok := dst.Profiles["work"]
+	if !ok {
+		t.Fatal("Profiles[work] lost on round-trip")
+	}
+	if work.Costs == nil || work.Costs.CostLineTemplate == nil || *work.Costs.CostLineTemplate != tmpl {
+		t.Errorf("profile template round-trip lost: got %+v, want %q", work.Costs, tmpl)
+	}
+}

--- a/internal/session/userconfig_cost_test.go
+++ b/internal/session/userconfig_cost_test.go
@@ -198,6 +198,144 @@ config_dir = "~/.claude-work"
 	}
 }
 
+func TestResolveCostLineTemplate_NilConfig(t *testing.T) {
+	tmpl, hide := ResolveCostLineTemplate(nil, "any")
+	if tmpl != "{cost_today} today" {
+		t.Errorf("nil cfg: template = %q, want hardcoded default", tmpl)
+	}
+	if !hide {
+		t.Errorf("nil cfg: hide_when_zero = %v, want true", hide)
+	}
+}
+
+func TestResolveCostLineTemplate_EmptyConfig(t *testing.T) {
+	cfg := &UserConfig{}
+	tmpl, hide := ResolveCostLineTemplate(cfg, "default")
+	if tmpl != "{cost_today} today" {
+		t.Errorf("empty cfg: template = %q, want hardcoded default", tmpl)
+	}
+	if !hide {
+		t.Errorf("empty cfg: hide_when_zero = %v, want true", hide)
+	}
+}
+
+func TestResolveCostLineTemplate_GlobalTemplate(t *testing.T) {
+	g := "{cost_yesterday} yda"
+	cfg := &UserConfig{Costs: CostsSettings{CostLineTemplate: &g}}
+	tmpl, _ := ResolveCostLineTemplate(cfg, "default")
+	if tmpl != g {
+		t.Errorf("template = %q, want %q", tmpl, g)
+	}
+}
+
+func TestResolveCostLineTemplate_GlobalHideWhenZeroFalse(t *testing.T) {
+	f := false
+	cfg := &UserConfig{Costs: CostsSettings{CostLineHideWhenZero: &f}}
+	_, hide := ResolveCostLineTemplate(cfg, "default")
+	if hide {
+		t.Errorf("hide_when_zero = %v, want false", hide)
+	}
+}
+
+func TestResolveCostLineTemplate_ProfileOverridesGlobal(t *testing.T) {
+	g := "G"
+	p := "P"
+	cfg := &UserConfig{
+		Costs: CostsSettings{CostLineTemplate: &g},
+		Profiles: map[string]ProfileSettings{
+			"work": {Costs: &ProfileCosts{CostLineTemplate: &p}},
+		},
+	}
+	tmpl, _ := ResolveCostLineTemplate(cfg, "work")
+	if tmpl != p {
+		t.Errorf("work profile: template = %q, want %q", tmpl, p)
+	}
+}
+
+func TestResolveCostLineTemplate_ProfileHideOverridesGlobal(t *testing.T) {
+	gTrue := true
+	pFalse := false
+	cfg := &UserConfig{
+		Costs: CostsSettings{CostLineHideWhenZero: &gTrue},
+		Profiles: map[string]ProfileSettings{
+			"work": {Costs: &ProfileCosts{CostLineHideWhenZero: &pFalse}},
+		},
+	}
+	_, hide := ResolveCostLineTemplate(cfg, "work")
+	if hide {
+		t.Errorf("work profile: hide_when_zero = %v, want false", hide)
+	}
+}
+
+func TestResolveCostLineTemplate_ProfileEmptyTemplateDisables(t *testing.T) {
+	g := "global"
+	empty := ""
+	cfg := &UserConfig{
+		Costs: CostsSettings{CostLineTemplate: &g},
+		Profiles: map[string]ProfileSettings{
+			"work": {Costs: &ProfileCosts{CostLineTemplate: &empty}},
+		},
+	}
+	tmpl, _ := ResolveCostLineTemplate(cfg, "work")
+	if tmpl != "" {
+		t.Errorf("work profile explicit empty: template = %q, want empty (disabled)", tmpl)
+	}
+}
+
+func TestResolveCostLineTemplate_GlobalEmptyTemplateDisables(t *testing.T) {
+	empty := ""
+	cfg := &UserConfig{Costs: CostsSettings{CostLineTemplate: &empty}}
+	tmpl, _ := ResolveCostLineTemplate(cfg, "default")
+	if tmpl != "" {
+		t.Errorf("global explicit empty: template = %q, want empty (disabled)", tmpl)
+	}
+}
+
+func TestResolveCostLineTemplate_ProfileNilCostsFallsThrough(t *testing.T) {
+	g := "global"
+	cfg := &UserConfig{
+		Costs: CostsSettings{CostLineTemplate: &g},
+		Profiles: map[string]ProfileSettings{
+			"work": {}, // Costs is nil
+		},
+	}
+	tmpl, _ := ResolveCostLineTemplate(cfg, "work")
+	if tmpl != g {
+		t.Errorf("nil profile.Costs: template = %q, want %q (global)", tmpl, g)
+	}
+}
+
+func TestResolveCostLineTemplate_ProfileNilTemplateFallsThrough(t *testing.T) {
+	// Profile has a Costs block but only sets hide_when_zero, not template.
+	g := "global"
+	pHide := false
+	cfg := &UserConfig{
+		Costs: CostsSettings{CostLineTemplate: &g},
+		Profiles: map[string]ProfileSettings{
+			"work": {Costs: &ProfileCosts{CostLineHideWhenZero: &pHide}},
+		},
+	}
+	tmpl, hide := ResolveCostLineTemplate(cfg, "work")
+	if tmpl != g {
+		t.Errorf("template = %q, want %q (fall through to global)", tmpl, g)
+	}
+	if hide {
+		t.Errorf("hide_when_zero = %v, want false (profile)", hide)
+	}
+}
+
+func TestResolveCostLineTemplate_UnknownProfile(t *testing.T) {
+	g := "global"
+	cfg := &UserConfig{
+		Costs:    CostsSettings{CostLineTemplate: &g},
+		Profiles: map[string]ProfileSettings{},
+	}
+	tmpl, _ := ResolveCostLineTemplate(cfg, "nonexistent")
+	if tmpl != g {
+		t.Errorf("unknown profile: template = %q, want %q (global)", tmpl, g)
+	}
+}
+
 func TestUserConfig_CostLineTemplate_RoundTrip(t *testing.T) {
 	tmpl := "{cost_today} today | {cost_this_week} wk"
 	hide := true

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -438,14 +438,21 @@ type Home struct {
 	remotesFetchActive bool      // Prevents overlapping fetches
 
 	// Cost tracking
-	costStore         *costs.Store
-	costPricer        *costs.Pricer
-	costBudget        *costs.BudgetChecker
-	costToday         atomic.Int64 // microdollars
-	costWeek          atomic.Int64 // microdollars
-	costRefreshTime   time.Time
-	showCostDashboard bool
-	costDashboard     costDashboard
+	costStore            *costs.Store
+	costPricer           *costs.Pricer
+	costBudget           *costs.BudgetChecker
+	costToday            atomic.Int64 // microdollars
+	costYesterday        atomic.Int64 // microdollars
+	costWeek             atomic.Int64 // microdollars
+	costLastWeek         atomic.Int64 // microdollars
+	costThisMonth        atomic.Int64 // microdollars
+	costLastMonth        atomic.Int64 // microdollars
+	costProjected        atomic.Int64 // microdollars
+	costRefreshTime      time.Time
+	costLineTemplate     string // resolved at construction; see session.ResolveCostLineTemplate
+	costLineHideWhenZero bool
+	showCostDashboard    bool
+	costDashboard        costDashboard
 
 	// System stats collector (CPU, RAM, disk, etc.)
 	sysStatsCollector *sysinfo.Collector
@@ -783,14 +790,18 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 
 	h.reloadHotkeysFromConfig()
 
-	// Cache display settings (config.toml [display])
+	// Cache display settings (config.toml [display]) and resolve the
+	// status-bar cost-line template once. The template + hide flag are
+	// reused on every render; see (*Home).renderStats.
 	if cfg, _ := session.LoadUserConfig(); cfg != nil {
 		h.fullRepaint = cfg.Display.GetFullRepaint()
 		h.defaultFilter = cfg.Display.GetDefaultFilter()
 		h.activeFilterLabel = cfg.Display.ActiveFilterLabel
 		h.sysStatsConfig = cfg.SystemStats
+		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(cfg, actualProfile)
 	} else {
 		h.fullRepaint = (session.DisplaySettings{}).GetFullRepaint()
+		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(nil, actualProfile)
 	}
 
 	// Initialize system stats collector if enabled
@@ -1122,9 +1133,19 @@ func (h *Home) refreshCostTotals() {
 	}
 	h.costRefreshTime = time.Now()
 	today, _ := h.costStore.TotalToday()
+	yesterday, _ := h.costStore.TotalYesterday()
 	week, _ := h.costStore.TotalThisWeek()
+	lastWeek, _ := h.costStore.TotalLastWeek()
+	thisMonth, _ := h.costStore.TotalThisMonth()
+	lastMonth, _ := h.costStore.TotalLastMonth()
+	projected, _ := h.costStore.ProjectedMonthly()
 	h.costToday.Store(today.TotalCostMicrodollars)
+	h.costYesterday.Store(yesterday.TotalCostMicrodollars)
 	h.costWeek.Store(week.TotalCostMicrodollars)
+	h.costLastWeek.Store(lastWeek.TotalCostMicrodollars)
+	h.costThisMonth.Store(thisMonth.TotalCostMicrodollars)
+	h.costLastMonth.Store(lastMonth.TotalCostMicrodollars)
+	h.costProjected.Store(projected)
 }
 
 func (h *Home) publishWebMenuSnapshot() {
@@ -9383,15 +9404,23 @@ func (h *Home) View() string {
 		stats = lipgloss.NewStyle().Foreground(ColorText).Render("no sessions")
 	}
 
-	// Cost tracking segment
-	todayMicro := h.costToday.Load()
-	weekMicro := h.costWeek.Load()
-	if todayMicro > 0 || weekMicro > 0 {
-		costStyle := lipgloss.NewStyle().Foreground(ColorCyan)
-		costText := costStyle.Render(costs.FormatUSD(todayMicro) + " today")
-		stats += statsSep + costText
+	// Cost tracking segment, rendered through the resolved template.
+	// See session.ResolveCostLineTemplate for the [costs] / per-profile
+	// override chain. RenderCostLine returns "" when hide_when_zero is on
+	// and every recognized variable rendered to $0.00.
+	costVars := map[string]int64{
+		"cost_today":      h.costToday.Load(),
+		"cost_yesterday":  h.costYesterday.Load(),
+		"cost_this_week":  h.costWeek.Load(),
+		"cost_last_week":  h.costLastWeek.Load(),
+		"cost_this_month": h.costThisMonth.Load(),
+		"cost_last_month": h.costLastMonth.Load(),
+		"cost_projected":  h.costProjected.Load(),
 	}
-	_ = weekMicro // reserved for future weekly display
+	if rendered := costs.RenderCostLine(h.costLineTemplate, costVars, h.costLineHideWhenZero); rendered != "" {
+		costStyle := lipgloss.NewStyle().Foreground(ColorCyan)
+		stats += statsSep + costStyle.Render(rendered)
+	}
 
 	// System stats segment (CPU, RAM, etc.)
 	if h.sysStatsCollector != nil {


### PR DESCRIPTION
Closes #818.

## What

The home status-bar cost segment is driven by `[costs].cost_line_template` with optional per-profile override at `[profiles.<name>.costs]`. Seven cost variables; unknown placeholders pass through literally so typos surface in the output.

## Variables

`{cost_today}`, `{cost_yesterday}`, `{cost_this_week}`, `{cost_last_week}`, `{cost_this_month}`, `{cost_last_month}`, `{cost_projected}`.

## Resolution

`profile.costs > [costs] > hardcoded "{cost_today} today"`. Pointer-based three-state semantics: nil falls through, explicit empty string disables, set value wins. `cost_line_hide_when_zero` (default true) preserves the prior auto-hide behavior when no events have been recorded.

## Changes

- `internal/costs/store.go`: 3 new methods (`TotalYesterday`, `TotalLastWeek`, `TotalLastMonth`) mirroring the boundary semantics of the existing `Total*` helpers.
- `internal/costs/template.go`: new `RenderCostLine` pure function. Left-to-right scanner; never iterates the vars map, so output is deterministic.
- `internal/session/userconfig.go`:
  - `CostsSettings` gains `CostLineTemplate *string` and `CostLineHideWhenZero *bool`
  - New `ProfileCosts` struct
  - `ProfileSettings` gains `Costs *ProfileCosts`
  - New `ResolveCostLineTemplate(cfg *UserConfig, profile string) (template string, hideWhenZero bool)` resolver
- `internal/ui/home.go`: 5 new `atomic.Int64` cost fields, refresh tick covers all 7 windows, status-bar segment renders through `RenderCostLine`. Resolved template cached at construction (no per-render config lookup).
- `README.md`, `CHANGELOG.md` updated under `[Unreleased]`.

## Tests

- `internal/costs/store_test.go`: 12 new boundary cases for the 3 new methods (empty / today-only / yesterday-only / two-days-ago-excluded for each window).
- `internal/costs/template_test.go`: 19 cases, table-driven renderer plus hide-when-zero, nil-vars edge cases, malformed input.
- `internal/session/userconfig_cost_test.go`: 11 new tests covering schema round-trip, backward-compat, and the full resolution chain.

`go test -race -count=1` green across `internal/costs/`, `internal/session/`, `internal/ui/`. `gofmt -l` empty. `go vet ./internal/costs/... ./internal/session/... ./internal/ui/... ./cmd/agent-deck/...` clean. `go build ./cmd/agent-deck/` succeeds.

## Out of scope

Format hints (`{cost_today:.4f}`), currency override beyond `$X.XX`, token / event / budget / per-model variables, color tokens inside templates, templating the `$` cost dashboard view. Deferred to follow-up issues if anyone asks.

## Backward compatibility

- TOML schema additive; existing configs decode unchanged
- Resolver returns the hardcoded `"{cost_today} today"` template + `hide_when_zero=true` when no config is present, exactly matching prior status-bar behavior
- No DB migration
