### PR TITLE
fix(add): expand ~ and $VAR in positional path arg

### DIFF
--- a/cmd/agent-deck/add_test.go
+++ b/cmd/agent-deck/add_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -523,5 +525,45 @@ func TestResolveGroupPathForAdd_ByNameAndNormalizedPath(t *testing.T) {
 
 	if got := resolveGroupPathForAdd(tree, "my team"); got != "my-team" {
 		t.Fatalf("Expected normalized selector to resolve to my-team, got %q", got)
+	}
+}
+
+// TestResolveAddPath covers the path-arg resolver used by `agent-deck add`.
+// Regression: prior to the fix, `~` was passed through filepath.Abs and resolved
+// to <cwd>/~, breaking remote SSH-driven adds where the shell preserves a
+// literal tilde. ExpandPath handles ~, ~/foo, $HOME, and ${VAR}.
+func TestResolveAddPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"dot uses cwd", ".", cwd},
+		{"bare tilde expands to home", "~", home},
+		{"tilde with subdir", "~/projects/foo", filepath.Join(home, "projects/foo")},
+		{"HOME env var", "$HOME", home},
+		{"HOME env var with subdir", "$HOME/bar", filepath.Join(home, "bar")},
+		{"absolute path passes through", "/tmp/abs", "/tmp/abs"},
+		{"relative resolves against cwd", "rel/sub", filepath.Join(cwd, "rel/sub")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveAddPath(tt.in)
+			if err != nil {
+				t.Fatalf("resolveAddPath(%q) error = %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveAddPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -131,6 +132,17 @@ func resolveGroupSelection(currentGroup, parentGroup string, explicitGroupProvid
 		return currentGroup
 	}
 	return parentGroup
+}
+
+// resolveAddPath resolves the user-provided positional path arg for `agent-deck add`.
+// Handles ".", "~", "~/foo", "$VAR/foo", and relative/absolute paths uniformly.
+// session.ExpandPath runs first so a literal tilde from a non-expanding shell
+// (e.g. SSH-driven invocation) reaches a real home directory before Abs.
+func resolveAddPath(rawPathArg string) (string, error) {
+	if rawPathArg == "." {
+		return os.Getwd()
+	}
+	return filepath.Abs(session.ExpandPath(rawPathArg))
 }
 
 // CLIOutput handles consistent output formatting across all CLI commands

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1219,18 +1219,10 @@ func handleAdd(profile string, args []string) {
 	}
 
 	if explicitPathProvided {
-		if rawPathArg == "." {
-			path, err = os.Getwd()
-			if err != nil {
-				fmt.Printf("Error: failed to get current directory: %v\n", err)
-				os.Exit(1)
-			}
-		} else {
-			path, err = filepath.Abs(rawPathArg)
-			if err != nil {
-				fmt.Printf("Error: failed to resolve path: %v\n", err)
-				os.Exit(1)
-			}
+		path, err = resolveAddPath(rawPathArg)
+		if err != nil {
+			fmt.Printf("Error: failed to resolve path: %v\n", err)
+			os.Exit(1)
 		}
 	} else {
 		// No explicit path provided: use group default path first, then cwd fallback.


### PR DESCRIPTION
Fixes #820.

`agent-deck add ~` failed with `path does not exist: <cwd>/~` because `filepath.Abs` treats `~` as a literal directory name. Locally this was masked by callers pre-expanding the path; over SSH the literal tilde reaches `add` unexpanded and dies.

This wraps the positional path arg through `session.ExpandPath` before `Abs` so the CLI behaves like every other path-accepting tool. The `.` shortcut still goes through `os.Getwd`. The resolution is extracted into `resolveAddPath` for unit tests.

## Scope

This is **one of several possible approaches** to fixing #820, picked because it's the smallest change that resolves the reported behaviour. The issue lists the alternatives:

1. **(this PR)** Wrap the positional arg in `add` through `session.ExpandPath`.
2. Share a single resolver across every path-accepting CLI subcommand.
3. Push expansion further down into the storage / Instance path-normalisation layer.
4. Reject literal `~` with a clearer error instead of expanding.

If 2 or 3 is preferred, happy to redo. The fix is intentionally local so it's easy to revert/replace.

## Verification

Pre-fix:

```
$ agent-deck add --quick --json -c claude '~'
Error: path does not exist: /Users/dmitry/~
```

Post-fix:

```
$ agent-deck add --quick --json -c claude '~'
{ "path": "/Users/dmitry", ... }
```

New table-driven test in `cmd/agent-deck/add_test.go` covers `.`, `~`, `~/foo`, `$HOME`, `$HOME/bar`, absolute paths, and relative paths.
