### PR TITLE
fix(ssh): clean up orphan remote session when start fails

### DIFF
--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -33,6 +33,9 @@ type SSHRunner struct {
 	Host          string // SSH destination (e.g., "user@host")
 	AgentDeckPath string // Remote agent-deck binary path
 	Profile       string // Remote profile name
+
+	// runFn lets tests stub out command execution. nil = real SSH.
+	runFn func(ctx context.Context, args ...string) ([]byte, error)
 }
 
 // NewSSHRunner creates an SSHRunner from a RemoteConfig.
@@ -53,6 +56,9 @@ func (r *SSHRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
 
 // run executes an agent-deck command on the remote host using the provided context directly.
 func (r *SSHRunner) run(ctx context.Context, args ...string) ([]byte, error) {
+	if r.runFn != nil {
+		return r.runFn(ctx, args...)
+	}
 	_ = os.MkdirAll(sshControlDir, 0700)
 
 	remoteCmd := r.buildRemoteCommand(args...)
@@ -461,6 +467,12 @@ func (r *SSHRunner) CreateSession(ctx context.Context) (string, error) {
 	startCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 	if _, err := r.run(startCtx, "session", "start", result.ID); err != nil {
+		// Compensate: the remote DB has the row but no tmux process. Best-effort
+		// delete with a fresh context so an upstream cancellation doesn't skip
+		// the cleanup. Surface the original start failure.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_ = r.DeleteSession(cleanupCtx, result.ID)
 		return "", fmt.Errorf("failed to start remote session: %w", err)
 	}
 

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -89,5 +91,74 @@ func TestSSHRunnerBuildRemoteCommand_QuotesRemoteSessionOutputID(t *testing.T) {
 				t.Fatalf("buildRemoteCommand mismatch\nwant: %s\ngot:  %s", want, got)
 			}
 		})
+	}
+}
+
+// TestSSHRunnerCreateSession_CleansOrphanOnStartFailure asserts that when the
+// remote `add` succeeds but the subsequent `session start` fails (tmux death,
+// network blip, timeout), CreateSession issues a compensating `remove` so the
+// remote DB doesn't accumulate orphan rows pointing at non-existent tmux.
+func TestSSHRunnerCreateSession_CleansOrphanOnStartFailure(t *testing.T) {
+	var calls [][]string
+	runner := &SSHRunner{
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			calls = append(calls, append([]string(nil), args...))
+			switch {
+			case len(args) > 0 && args[0] == "add":
+				return []byte(`{"id":"orphan-abc","title":"x"}`), nil
+			case len(args) >= 2 && args[0] == "session" && args[1] == "start":
+				return nil, errors.New("simulated tmux death")
+			case len(args) > 0 && args[0] == "remove":
+				return []byte(""), nil
+			}
+			return nil, errors.New("unexpected runner call")
+		},
+	}
+
+	_, err := runner.CreateSession(context.Background())
+	if err == nil {
+		t.Fatal("expected CreateSession to surface the start failure, got nil")
+	}
+
+	var sawRemove bool
+	for _, c := range calls {
+		if len(c) >= 2 && c[0] == "remove" && c[1] == "orphan-abc" {
+			sawRemove = true
+			break
+		}
+	}
+	if !sawRemove {
+		t.Fatalf("expected compensating remove call for orphan-abc; calls=%v", calls)
+	}
+}
+
+// TestSSHRunnerCreateSession_NoCleanupOnSuccess asserts the happy path doesn't
+// issue a spurious remove call when both add and session start succeed.
+func TestSSHRunnerCreateSession_NoCleanupOnSuccess(t *testing.T) {
+	var calls [][]string
+	runner := &SSHRunner{
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			calls = append(calls, append([]string(nil), args...))
+			switch {
+			case len(args) > 0 && args[0] == "add":
+				return []byte(`{"id":"good-abc","title":"x"}`), nil
+			case len(args) >= 2 && args[0] == "session" && args[1] == "start":
+				return []byte(""), nil
+			}
+			return nil, errors.New("unexpected runner call")
+		},
+	}
+
+	id, err := runner.CreateSession(context.Background())
+	if err != nil {
+		t.Fatalf("CreateSession unexpected error: %v", err)
+	}
+	if id != "good-abc" {
+		t.Fatalf("CreateSession id = %q, want good-abc", id)
+	}
+	for _, c := range calls {
+		if len(c) > 0 && c[0] == "remove" {
+			t.Fatalf("unexpected remove call on success path: %v", c)
+		}
 	}
 }


### PR DESCRIPTION
`SSHRunner.CreateSession` is two SSH calls: first `agent-deck add` (writes a row to the remote DB and returns the new ID), then `agent-deck session start <id>` (launches tmux). If `session start` fails — tmux death, network blip, the 20s timeout — the row stayed behind, and repeated retries piled up dead rows on the remote that had no easy path to cleanup.

This PR issues a best-effort `remove` (via the existing `DeleteSession`) on the start-failure path. The original start error is still surfaced to the caller; cleanup uses a fresh context with its own 10s timeout so an upstream cancellation doesn't skip it.

## Tests

`SSHRunner.run` had no injection point, so the two-step `CreateSession` flow wasn't unit-testable. Added a `runFn func(ctx, args...) ([]byte, error)` field on `SSHRunner`; `nil` means real SSH (production path is unchanged), tests stub it.

Two new tests in `internal/session/ssh_test.go`:
- `TestSSHRunnerCreateSession_CleansOrphanOnStartFailure` — `add` succeeds, `session start` errors → asserts a compensating `remove <id>` call fires.
- `TestSSHRunnerCreateSession_NoCleanupOnSuccess` — happy path → asserts no spurious `remove` call.

## Verification (manual)

```bash
# kill the remote tmux server mid-flight to force a session start failure
ssh remote 'tmux kill-server' &
# trigger the new-remote-session flow from the TUI
# pre-fix: ssh remote 'agent-deck list --json' shows a stopped orphan
# post-fix: orphan is gone, repeated failures stay clean
```
