### PR TITLE
fix(notifier): dedup inbox + missed-log, top-level conductor self-suppress, terminate exhausted events (#824)

### DIFF
--- a/internal/session/event_fingerprint.go
+++ b/internal/session/event_fingerprint.go
@@ -1,0 +1,37 @@
+package session
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+)
+
+// EventFingerprint returns a stable identifier for a transition event,
+// keyed on its intrinsic identity rather than the moment of any particular
+// emit. Two attempts to persist the "same" logical transition (same child,
+// same status flip, same observed timestamp) collapse to the same
+// fingerprint and are deduplicated by the inbox writer and the
+// notifier-missed log.
+//
+// Keying on Timestamp.UnixNano() is load-bearing: scheduleBusyRetry and the
+// deferred-queue drain both fire from the same TransitionNotificationEvent,
+// so the timestamp set by the daemon when it first observed the flip is
+// stable across retry attempts. time.Now() at write-emit time would NOT be
+// stable and would silently break dedup.
+//
+// The fingerprint is a hex SHA-256 so it can safely be embedded in a JSON
+// string field without escaping concerns and is cheap to grep for.
+func EventFingerprint(e TransitionNotificationEvent) string {
+	var b strings.Builder
+	b.Grow(len(e.ChildSessionID) + len(e.FromStatus) + len(e.ToStatus) + 32)
+	b.WriteString(strings.TrimSpace(e.ChildSessionID))
+	b.WriteByte('|')
+	b.WriteString(strings.ToLower(strings.TrimSpace(e.FromStatus)))
+	b.WriteByte('|')
+	b.WriteString(strings.ToLower(strings.TrimSpace(e.ToStatus)))
+	b.WriteByte('|')
+	b.WriteString(strconv.FormatInt(e.Timestamp.UnixNano(), 10))
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -26,6 +26,19 @@ import (
 
 var inboxWriteMu sync.Mutex // serializes appends to a single inbox file
 
+// inboxFingerprintCache holds, per inbox file path, the set of event
+// fingerprints already persisted. Populated lazily on first write to a path
+// (by scanning the existing file) and updated on every successful append.
+//
+// This cache is process-local. For cross-process correctness we still scan
+// the file on the first write per path within a process, so a fresh process
+// won't re-append events the previous process already wrote.
+//
+// Issue #824: scheduleBusyRetry's exhaustion path was firing repeatedly
+// for the same logical event, producing 13 duplicate JSONL lines for a
+// single transition. The cache + lazy file scan reduces those to one.
+var inboxFingerprintCache = map[string]map[string]struct{}{}
+
 // InboxDir returns the directory that holds per-parent inbox files.
 func InboxDir() string {
 	dir, err := GetAgentDeckDir()
@@ -54,6 +67,12 @@ func sanitizeInboxName(id string) string {
 
 // WriteInboxEvent appends one event to the parent's inbox as a JSONL line.
 // Safe for concurrent callers within a single process.
+//
+// Fingerprint dedup: events that share an EventFingerprint with one already
+// persisted in the file are silently skipped. This is the producer-side
+// guard for issue #824 (scheduleBusyRetry firing the same exhaustion path
+// for the same logical event multiple times). Consumers still get
+// at-most-once delivery via ReadAndTruncateInbox.
 func WriteInboxEvent(parentSessionID string, event TransitionNotificationEvent) error {
 	if strings.TrimSpace(parentSessionID) == "" {
 		return errors.New("inbox: empty parent session id")
@@ -62,13 +81,35 @@ func WriteInboxEvent(parentSessionID string, event TransitionNotificationEvent) 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	line, err := json.Marshal(event)
-	if err != nil {
-		return err
-	}
+
+	fp := EventFingerprint(event)
 
 	inboxWriteMu.Lock()
 	defer inboxWriteMu.Unlock()
+
+	seen, ok := inboxFingerprintCache[path]
+	if !ok {
+		// Lazy file scan recovers dedup state across process restarts. Without
+		// this a fresh process would happily re-append events that a prior
+		// process had already persisted.
+		seen = loadInboxFingerprintsLocked(path)
+		inboxFingerprintCache[path] = seen
+	}
+	if _, dup := seen[fp]; dup {
+		return nil
+	}
+
+	// Embed the fingerprint into the persisted JSON so on-disk state is
+	// self-describing — the file-scan recovery path can reconstruct the
+	// dedup set without re-deriving fingerprints from the event body.
+	type wireEvent struct {
+		TransitionNotificationEvent
+		Fingerprint string `json:"fp,omitempty"`
+	}
+	line, err := json.Marshal(wireEvent{TransitionNotificationEvent: event, Fingerprint: fp})
+	if err != nil {
+		return err
+	}
 
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
@@ -78,7 +119,54 @@ func WriteInboxEvent(parentSessionID string, event TransitionNotificationEvent) 
 	if _, err := f.Write(append(line, '\n')); err != nil {
 		return err
 	}
+	seen[fp] = struct{}{}
 	return nil
+}
+
+// loadInboxFingerprintsLocked scans an existing inbox file and returns the
+// set of fingerprints already persisted. Caller holds inboxWriteMu.
+//
+// Two formats are tolerated: the new format with an explicit "fp" field,
+// and the legacy format from before this fix where the event was stored
+// without a fingerprint. For legacy lines we re-derive the fingerprint
+// from the event fields so dedup still applies.
+func loadInboxFingerprintsLocked(path string) map[string]struct{} {
+	out := map[string]struct{}{}
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var probe struct {
+			TransitionNotificationEvent
+			Fingerprint string `json:"fp"`
+		}
+		if err := json.Unmarshal([]byte(line), &probe); err != nil {
+			continue
+		}
+		fp := probe.Fingerprint
+		if fp == "" {
+			fp = EventFingerprint(probe.TransitionNotificationEvent)
+		}
+		out[fp] = struct{}{}
+	}
+	return out
+}
+
+// ResetInboxFingerprintCacheForTest clears the process-local dedup cache.
+// Tests use it to simulate a fresh process so the on-disk recovery path is
+// exercised. Production code does not call this.
+func ResetInboxFingerprintCacheForTest() {
+	inboxWriteMu.Lock()
+	defer inboxWriteMu.Unlock()
+	inboxFingerprintCache = map[string]map[string]struct{}{}
 }
 
 // ReadAndTruncateInbox reads all events from the parent's inbox and removes
@@ -132,5 +220,9 @@ func ReadAndTruncateInbox(parentSessionID string) ([]TransitionNotificationEvent
 	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return out, err
 	}
+	// Truncating drops the dedup cache for this path: the next write should
+	// be free to land, even if the same fingerprint was just drained. The
+	// drain itself is the consumer's acknowledgement.
+	delete(inboxFingerprintCache, path)
 	return out, nil
 }

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -98,6 +98,23 @@ type TransitionNotifier struct {
 	orphanMu     sync.Mutex
 	orphanWarned map[string]bool
 
+	// missedMu guards missedSeen. The set tracks (fingerprint|reason) keys
+	// already written to notifier-missed.log so the same exhausted event
+	// firing repeatedly (issue #824) doesn't flood the log with identical
+	// lines. Process-local — restart resets the dedup state, which is fine:
+	// missed-log is operator signal, not durable replay.
+	missedMu   sync.Mutex
+	missedSeen map[string]bool
+
+	// terminatedMu guards terminatedFingerprints. An event whose retries
+	// exhausted is recorded here; subsequent EnqueueDeferred calls for the
+	// same fingerprint are no-ops. Without this guard the daemon's poll
+	// loop keeps re-pushing the exhausted event into the deferred queue,
+	// producing the 7-times-in-16-seconds re-fire loop in the production
+	// trace from issue #824.
+	terminatedMu           sync.Mutex
+	terminatedFingerprints map[string]bool
+
 	// stopCh closes when Close() is invoked. scheduleBusyRetry's sleep loops
 	// select on it so test cleanups can cancel pending retries instead of
 	// letting them write inbox files into the post-cleanup environment.
@@ -126,9 +143,11 @@ func NewTransitionNotifier() *TransitionNotifier {
 		state: transitionNotifyState{
 			Records: map[string]transitionNotifyRecord{},
 		},
-		targetSlots:  map[string]chan struct{}{},
-		orphanWarned: map[string]bool{},
-		stopCh:       make(chan struct{}),
+		targetSlots:            map[string]chan struct{}{},
+		orphanWarned:           map[string]bool{},
+		missedSeen:             map[string]bool{},
+		terminatedFingerprints: map[string]bool{},
+		stopCh:                 make(chan struct{}),
 	}
 	n.loadState()
 	n.loadQueue()
@@ -271,6 +290,20 @@ func (n *TransitionNotifier) prepareDispatch(event TransitionNotificationEvent) 
 		return plan
 	}
 
+	// Top-level conductor self-suppress (issue #824 cause B). A real
+	// top-level conductor has parent_session_id == "" AND its own title
+	// starts with `conductor-`. That isn't an orphan — it's the root —
+	// so drop silently without writing to notifier-orphans.log. The
+	// production trace showed agent-deck conductors flooding the orphan
+	// log with their own self-transitions because PR #807's check at
+	// the outer line-211 only looked at event.ChildTitle, which was
+	// empty in some emit paths.
+	if strings.TrimSpace(child.ParentSessionID) == "" && isConductorSessionTitle(child.Title) {
+		plan.event.DeliveryResult = transitionDeliveryDropped
+		plan.finalized = true
+		return plan
+	}
+
 	// Orphan-on-creation guard (issue #805 cause A). When a child is born
 	// without a parent linkage — typically because a worktree-setup hook
 	// or sandboxed shell dropped $AGENTDECK_INSTANCE_ID — every transition
@@ -279,6 +312,16 @@ func (n *TransitionNotifier) prepareDispatch(event TransitionNotificationEvent) 
 	// the documented `agent-deck session set-parent` workflow.
 	if strings.TrimSpace(child.ParentSessionID) == "" {
 		n.logOrphanOnce(plan.event, child.ID)
+		plan.event.DeliveryResult = transitionDeliveryDropped
+		plan.finalized = true
+		return plan
+	}
+
+	// Self-pointing conductor: parent_session_id == child.id. This is the
+	// case PR #807 explicitly covered. resolveParentNotificationTarget
+	// would also return nil here, but we drop earlier (without an orphan
+	// log) so a self-pointing conductor doesn't get spurious WARN noise.
+	if strings.TrimSpace(child.ParentSessionID) == child.ID && isConductorSessionTitle(child.Title) {
 		plan.event.DeliveryResult = transitionDeliveryDropped
 		plan.finalized = true
 		return plan
@@ -528,6 +571,22 @@ func (n *TransitionNotifier) logEvent(event TransitionNotificationEvent) {
 }
 
 func (n *TransitionNotifier) logMissed(event TransitionNotificationEvent, reason string) {
+	// Dedup by (fingerprint|reason) so repeated exhaust calls for the same
+	// logical event don't flood the log. A different reason for the same
+	// event still records — operators want to see e.g. timeout AND expired
+	// for the same transition, but not seven exhaust lines in a row.
+	key := EventFingerprint(event) + "|" + reason
+	n.missedMu.Lock()
+	if n.missedSeen == nil {
+		n.missedSeen = map[string]bool{}
+	}
+	if n.missedSeen[key] {
+		n.missedMu.Unlock()
+		return
+	}
+	n.missedSeen[key] = true
+	n.missedMu.Unlock()
+
 	if err := os.MkdirAll(filepath.Dir(n.missedPath), 0o755); err != nil {
 		return
 	}
@@ -537,6 +596,7 @@ func (n *TransitionNotifier) logMissed(event TransitionNotificationEvent, reason
 		"event":  fmt.Sprintf("%s→%s", event.FromStatus, event.ToStatus),
 		"child":  event.ChildSessionID,
 		"reason": reason,
+		"fp":     EventFingerprint(event),
 	}
 	line, err := json.Marshal(entry)
 	if err != nil {
@@ -548,6 +608,24 @@ func (n *TransitionNotifier) logMissed(event TransitionNotificationEvent, reason
 	}
 	defer f.Close()
 	_, _ = f.Write(append(line, '\n'))
+}
+
+// markTerminated records that an event's retries have exhausted and the
+// event has been persisted to the inbox. Subsequent EnqueueDeferred calls
+// for the same fingerprint will no-op via isTerminated.
+func (n *TransitionNotifier) markTerminated(event TransitionNotificationEvent) {
+	n.terminatedMu.Lock()
+	defer n.terminatedMu.Unlock()
+	if n.terminatedFingerprints == nil {
+		n.terminatedFingerprints = map[string]bool{}
+	}
+	n.terminatedFingerprints[EventFingerprint(event)] = true
+}
+
+func (n *TransitionNotifier) isTerminated(event TransitionNotificationEvent) bool {
+	n.terminatedMu.Lock()
+	defer n.terminatedMu.Unlock()
+	return n.terminatedFingerprints[EventFingerprint(event)]
 }
 
 // --- deferred retry queue ----------------------------------------------------
@@ -562,6 +640,14 @@ func (n *TransitionNotifier) EnqueueDeferred(event TransitionNotificationEvent) 
 }
 
 func (n *TransitionNotifier) enqueueDeferredAt(event TransitionNotificationEvent, firstDeferredAt time.Time) {
+	// Terminated fingerprints (events already exhausted to inbox) must not
+	// be re-queued. Issue #824 trace showed the same event re-firing 7 times
+	// in 16 seconds because the daemon's poll loop kept re-discovering the
+	// transition and EnqueueDeferred kept accepting it.
+	if n.isTerminated(event) {
+		return
+	}
+
 	n.queueMu.Lock()
 	defer n.queueMu.Unlock()
 
@@ -866,10 +952,15 @@ func (n *TransitionNotifier) scheduleBusyRetry(event TransitionNotificationEvent
 			// Send failed: try the next backoff entry.
 		}
 
-		// Exhausted — persist to the parent's inbox and signal via missed log.
+		// Exhausted — persist to the parent's inbox, signal via missed log,
+		// and mark terminated so the deferred queue cannot re-add this
+		// fingerprint. Order matters: mark terminated BEFORE removeFromQueue
+		// so a concurrent drain that races us to EnqueueDeferred can't slip
+		// the event back in between the queue prune and the terminated mark.
 		if event.TargetSessionID != "" {
 			_ = WriteInboxEvent(event.TargetSessionID, event)
 		}
+		n.markTerminated(event)
 		n.logMissed(event, "exhausted_busy_retries")
 		n.removeFromQueue(event)
 	}()

--- a/internal/session/transition_notifier_dedup_test.go
+++ b/internal/session/transition_notifier_dedup_test.go
@@ -1,0 +1,477 @@
+package session
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Bug 1 / Layer 1 — fingerprint dedup.
+//
+// Issue #824 reproduced: scheduleBusyRetry's exhaustion path called
+// WriteInboxEvent and logMissed for the same logical event repeatedly,
+// producing 13 duplicate inbox JSONL lines and 7 duplicate notifier-missed
+// entries within a few seconds. The fix fingerprints by
+// sha256(child_id|from|to|timestamp.UnixNano()) and skips the write when
+// the same fingerprint has already been persisted.
+
+// TestDedup_InboxSameFingerprintOnce calls WriteInboxEvent twice with the
+// same event (identical child, from, to, timestamp). The inbox must contain
+// exactly one JSONL line, not two.
+func TestDedup_InboxSameFingerprintOnce(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() {
+		ClearUserConfigCache()
+		ResetInboxFingerprintCacheForTest()
+	})
+	ResetInboxFingerprintCacheForTest()
+
+	parent := "parent-dedup"
+	ts := time.Unix(1700000000, 0).UTC()
+	ev := TransitionNotificationEvent{
+		ChildSessionID:  "child-dup",
+		ChildTitle:      "worker",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       ts,
+		TargetSessionID: parent,
+		TargetKind:      "parent",
+	}
+
+	for i := 0; i < 5; i++ {
+		if err := WriteInboxEvent(parent, ev); err != nil {
+			t.Fatalf("WriteInboxEvent #%d: %v", i, err)
+		}
+	}
+
+	got, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("ReadAndTruncateInbox: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("inbox dedup: expected 1 event after 5 writes of same fingerprint, got %d", len(got))
+	}
+
+	// A different timestamp must NOT dedup — that's a different logical event.
+	ev2 := ev
+	ev2.Timestamp = ts.Add(1 * time.Second)
+	if err := WriteInboxEvent(parent, ev); err != nil {
+		t.Fatalf("re-write same fp: %v", err)
+	}
+	if err := WriteInboxEvent(parent, ev2); err != nil {
+		t.Fatalf("write distinct fp: %v", err)
+	}
+	got, err = ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("ReadAndTruncateInbox 2: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 1 (post-truncate ev) + 1 (ev2 distinct) = 2, got %d", len(got))
+	}
+}
+
+// TestDedup_InboxFingerprintSurvivesProcessRestart guards against the case
+// where the process restarts between writes. The in-memory dedup cache is
+// gone, but the on-disk JSONL still carries the fingerprint, so a second
+// write of the same event must still be a no-op via file-scan recovery.
+func TestDedup_InboxFingerprintSurvivesProcessRestart(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() {
+		ClearUserConfigCache()
+		ResetInboxFingerprintCacheForTest()
+	})
+	ResetInboxFingerprintCacheForTest()
+
+	parent := "parent-dedup-restart"
+	ts := time.Unix(1700000100, 0).UTC()
+	ev := TransitionNotificationEvent{
+		ChildSessionID:  "child-restart",
+		ChildTitle:      "worker",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       ts,
+		TargetSessionID: parent,
+		TargetKind:      "parent",
+	}
+
+	if err := WriteInboxEvent(parent, ev); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	// Simulate process restart: drop in-memory cache; the on-disk file still
+	// holds the fingerprint and must be the source of truth for dedup.
+	ResetInboxFingerprintCacheForTest()
+
+	if err := WriteInboxEvent(parent, ev); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	got, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("file-scan dedup: expected 1 line across simulated restart, got %d", len(got))
+	}
+}
+
+// TestDedup_MissedLogSameFingerprintOnce: an exhausted-busy event that fires
+// scheduleBusyRetry repeatedly (because deferred queue keeps reattempting)
+// must produce exactly one notifier-missed.log line per (fingerprint, reason)
+// pair, not seven.
+func TestDedup_MissedLogSameFingerprintOnce(t *testing.T) {
+	dir := t.TempDir()
+	n := &TransitionNotifier{
+		statePath:   filepath.Join(dir, "state.json"),
+		logPath:     filepath.Join(dir, "transition-notifier.log"),
+		missedPath:  filepath.Join(dir, "notifier-missed.log"),
+		queuePath:   filepath.Join(dir, "queue.json"),
+		orphanPath:  filepath.Join(dir, "notifier-orphans.log"),
+		sendTimeout: 200 * time.Millisecond,
+		state: transitionNotifyState{
+			Records: map[string]transitionNotifyRecord{},
+		},
+		targetSlots: map[string]chan struct{}{},
+	}
+
+	ts := time.Unix(1700000200, 0).UTC()
+	ev := TransitionNotificationEvent{
+		ChildSessionID:  "child-missed",
+		ChildTitle:      "worker",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       ts,
+		TargetSessionID: "parent-missed",
+		TargetKind:      "parent",
+	}
+
+	for i := 0; i < 7; i++ {
+		n.logMissed(ev, "exhausted_busy_retries")
+	}
+
+	data, err := os.ReadFile(n.missedPath)
+	if err != nil {
+		t.Fatalf("read missed log: %v", err)
+	}
+	lines := countNonBlankLines(string(data))
+	if lines != 1 {
+		t.Fatalf("missed log dedup: expected 1 line for repeated (fp, reason), got %d (data=%q)", lines, data)
+	}
+
+	// A different reason for the same fingerprint must still record once,
+	// because the operator-actionable signal is (event, reason), not event
+	// alone.
+	n.logMissed(ev, "expired")
+	n.logMissed(ev, "expired")
+	data, _ = os.ReadFile(n.missedPath)
+	lines = countNonBlankLines(string(data))
+	if lines != 2 {
+		t.Fatalf("missed log: expected 2 lines (one per distinct reason), got %d", lines)
+	}
+}
+
+func countNonBlankLines(s string) int {
+	n := 0
+	sc := bufio.NewScanner(strings.NewReader(s))
+	for sc.Scan() {
+		if strings.TrimSpace(sc.Text()) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// Bug 2 / Layer 2 — top-level conductor self-suppress.
+//
+// PR #807's check at the prepareDispatch level only catches the case where
+// the loaded child's parent_session_id equals its own id. The real top-level
+// case in production is `parent_session_id = ""` AND the loaded Instance's
+// title starts with `conductor-`. That child must self-suppress without an
+// orphan WARN, since it isn't an orphan — it's the root.
+
+// TestSelfSuppress_TopLevelConductorWithEmptyParent: a real top-level
+// conductor (empty parent, conductor- prefix on the loaded instance title)
+// must drop without writing to notifier-orphans.log AND without invoking the
+// sender.
+func TestSelfSuppress_TopLevelConductorWithEmptyParent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+	if err := os.MkdirAll(home+"/.agent-deck", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	profile := "_test-self-suppress-empty"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	defer storage.Close()
+
+	now := time.Now()
+	conductor := &Instance{
+		ID:              "conductor-empty-parent",
+		Title:           "conductor-agent-deck",
+		ProjectPath:     "/tmp/conductor",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: "", // top-level — empty, NOT self-pointing
+		Tool:            "claude",
+		Status:          StatusWaiting,
+		CreatedAt:       now,
+	}
+	if err := storage.SaveWithGroups([]*Instance{conductor}, nil); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	n := NewTransitionNotifier()
+	var sent atomic.Int32
+	n.sender = func(profile, targetID, message string) error {
+		sent.Add(1)
+		return nil
+	}
+
+	// Critically: ChildTitle on the event is intentionally EMPTY here, so the
+	// outer line-211 title-prefix check is bypassed. The fix must still
+	// recognize the loaded Instance as a top-level conductor.
+	ev := TransitionNotificationEvent{
+		ChildSessionID: conductor.ID,
+		ChildTitle:     "", // bypasses outer isConductorSessionTitle check
+		Profile:        profile,
+		FromStatus:     "running",
+		ToStatus:       "waiting",
+		Timestamp:      now,
+	}
+	result := n.NotifyTransition(ev)
+	n.Flush()
+
+	if result.DeliveryResult != transitionDeliveryDropped {
+		t.Fatalf("top-level conductor (empty parent) must self-suppress with dropped, got %q", result.DeliveryResult)
+	}
+	if got := sent.Load(); got != 0 {
+		t.Fatalf("self-suppress must not invoke sender, got %d sends", got)
+	}
+
+	// The crucial regression: orphan log must NOT be written. A top-level
+	// conductor is not an orphan; logging it as one floods notifier-orphans
+	// with non-actionable noise (and, in production, made the operator chase
+	// a non-existent linkage problem).
+	orphanData, err := os.ReadFile(transitionNotifierOrphanLogPath())
+	if err == nil && strings.Contains(string(orphanData), conductor.ID) {
+		t.Fatalf("top-level conductor must NOT be logged as orphan, got: %s", orphanData)
+	}
+}
+
+// TestSelfSuppress_TopLevelConductorWithParentMatchingSelf preserves the
+// existing behavior from #807 for the case where parent_session_id literally
+// points at the child's own id (which historically is how some conductors
+// self-link to fake a parent edge).
+func TestSelfSuppress_TopLevelConductorWithParentMatchingSelf(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+	if err := os.MkdirAll(home+"/.agent-deck", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	profile := "_test-self-suppress-self"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	defer storage.Close()
+
+	now := time.Now()
+	conductor := &Instance{
+		ID:              "conductor-self-pointer",
+		Title:           "conductor-agent-deck",
+		ProjectPath:     "/tmp/conductor",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: "conductor-self-pointer", // points at itself
+		Tool:            "claude",
+		Status:          StatusWaiting,
+		CreatedAt:       now,
+	}
+	if err := storage.SaveWithGroups([]*Instance{conductor}, nil); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	n := NewTransitionNotifier()
+	var sent atomic.Int32
+	n.sender = func(profile, targetID, message string) error {
+		sent.Add(1)
+		return nil
+	}
+
+	ev := TransitionNotificationEvent{
+		ChildSessionID: conductor.ID,
+		ChildTitle:     "", // bypasses outer line-211 check
+		Profile:        profile,
+		FromStatus:     "running",
+		ToStatus:       "waiting",
+		Timestamp:      now,
+	}
+	result := n.NotifyTransition(ev)
+	n.Flush()
+
+	if result.DeliveryResult != transitionDeliveryDropped {
+		t.Fatalf("self-pointing conductor must drop, got %q", result.DeliveryResult)
+	}
+	if got := sent.Load(); got != 0 {
+		t.Fatalf("self-pointing conductor must not invoke sender, got %d sends", got)
+	}
+	orphanData, err := os.ReadFile(transitionNotifierOrphanLogPath())
+	if err == nil && strings.Contains(string(orphanData), conductor.ID) {
+		t.Fatalf("self-pointing conductor must NOT be logged as orphan, got: %s", orphanData)
+	}
+}
+
+// Bug 3 / Layer 3 — terminal state for exhausted events.
+//
+// Once an event has been persisted to the inbox (via scheduleBusyRetry's
+// exhaustion path), its fingerprint is "terminated": it must be removed from
+// the deferred queue, and any subsequent EnqueueDeferred for the same
+// fingerprint must be refused. Otherwise the queue drains the same logical
+// event indefinitely, producing the 7-times-in-16-seconds re-fire loop in
+// the production trace.
+
+// TestQueue_ExhaustedEventRemovedFromDeferredQueue: enqueue an event, run
+// scheduleBusyRetry to exhaustion, then assert the deferred queue no longer
+// contains it.
+func TestQueue_ExhaustedEventRemovedFromDeferredQueue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() {
+		ClearUserConfigCache()
+		ResetInboxFingerprintCacheForTest()
+	})
+	ResetInboxFingerprintCacheForTest()
+
+	dir := t.TempDir()
+	n := &TransitionNotifier{
+		statePath:   filepath.Join(dir, "state.json"),
+		logPath:     filepath.Join(dir, "transition-notifier.log"),
+		missedPath:  filepath.Join(dir, "notifier-missed.log"),
+		queuePath:   filepath.Join(dir, "queue.json"),
+		orphanPath:  filepath.Join(dir, "notifier-orphans.log"),
+		sendTimeout: 200 * time.Millisecond,
+		state: transitionNotifyState{
+			Records: map[string]transitionNotifyRecord{},
+		},
+		targetSlots: map[string]chan struct{}{},
+		busyBackoff: []time.Duration{2 * time.Millisecond, 4 * time.Millisecond, 6 * time.Millisecond},
+	}
+	n.availability = func(profile, targetID string) bool { return false } // always busy
+	n.sender = func(profile, targetID, message string) error { return nil }
+
+	ts := time.Unix(1700000300, 0).UTC()
+	ev := TransitionNotificationEvent{
+		ChildSessionID:  "child-exhausts",
+		ChildTitle:      "worker",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       ts,
+		TargetSessionID: "parent-exhausts",
+		TargetKind:      "parent",
+	}
+
+	n.EnqueueDeferred(ev)
+	if got := len(n.snapshotQueueForTest()); got != 1 {
+		t.Fatalf("queue precondition: expected 1 entry pre-exhaust, got %d", got)
+	}
+
+	n.scheduleBusyRetry(ev)
+	n.Flush()
+
+	if got := len(n.snapshotQueueForTest()); got != 0 {
+		t.Fatalf("exhausted event must be removed from deferred queue, got %d entries", got)
+	}
+}
+
+// TestQueue_TerminatedFingerprintBlocksReAdd: after an event has exhausted
+// retries and persisted to the inbox, a subsequent EnqueueDeferred for the
+// same fingerprint must be a no-op. Without this guard the daemon's poll
+// loop will keep re-pushing exhausted events into the queue, producing the
+// re-fire spam observed in production.
+func TestQueue_TerminatedFingerprintBlocksReAdd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() {
+		ClearUserConfigCache()
+		ResetInboxFingerprintCacheForTest()
+	})
+	ResetInboxFingerprintCacheForTest()
+
+	dir := t.TempDir()
+	n := &TransitionNotifier{
+		statePath:   filepath.Join(dir, "state.json"),
+		logPath:     filepath.Join(dir, "transition-notifier.log"),
+		missedPath:  filepath.Join(dir, "notifier-missed.log"),
+		queuePath:   filepath.Join(dir, "queue.json"),
+		orphanPath:  filepath.Join(dir, "notifier-orphans.log"),
+		sendTimeout: 200 * time.Millisecond,
+		state: transitionNotifyState{
+			Records: map[string]transitionNotifyRecord{},
+		},
+		targetSlots: map[string]chan struct{}{},
+		busyBackoff: []time.Duration{2 * time.Millisecond, 4 * time.Millisecond, 6 * time.Millisecond},
+	}
+	n.availability = func(profile, targetID string) bool { return false }
+	n.sender = func(profile, targetID, message string) error { return nil }
+
+	ts := time.Unix(1700000400, 0).UTC()
+	ev := TransitionNotificationEvent{
+		ChildSessionID:  "child-terminated",
+		ChildTitle:      "worker",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       ts,
+		TargetSessionID: "parent-terminated",
+		TargetKind:      "parent",
+	}
+
+	n.scheduleBusyRetry(ev)
+	n.Flush()
+
+	// Sanity: queue is empty post-exhaust.
+	if got := len(n.snapshotQueueForTest()); got != 0 {
+		t.Fatalf("post-exhaust queue must be empty, got %d", got)
+	}
+
+	// The bug: the daemon's next poll re-discovers the same transition and
+	// calls EnqueueDeferred. Without a terminated set this re-adds the entry,
+	// re-fires retries, and re-persists to inbox.
+	n.EnqueueDeferred(ev)
+
+	if got := len(n.snapshotQueueForTest()); got != 0 {
+		t.Fatalf("terminated fingerprint must block re-add to deferred queue, got %d entries", got)
+	}
+}


### PR DESCRIPTION
Closes #824 — three follow-up bugs in v1.7.73's transition-notifier inbox/retry path.

## Summary

End-to-end testing on conductor hosts surfaced three real bugs in the v1.7.73 (PR #807) inbox + retry + self-suppress path. This PR fixes all three together with strict TDD.

### Bug 1 — Inbox + missed-log dedup

**Symptom:** 13 identical JSONL lines in `~/.agent-deck/inboxes/<conductor>.jsonl` for a single transition; same child, same from→to, same timestamp. Same pattern in `notifier-missed.log` (7 `exhausted_busy_retries` lines in 16 seconds for one event).

**Fix:** `EventFingerprint = sha256(child_id|from|to|timestamp.UnixNano())`. `WriteInboxEvent` and `logMissed` both check before append. Inbox dedup is process-local with on-disk recovery — every persisted line carries an `"fp"` field so a fresh process scans the file and reconstructs the dedup set without re-deriving fingerprints from the event body.

Keying on `Timestamp.UnixNano()` (the moment the daemon observed the flip) is load-bearing — `time.Now()` at write-emit would produce a different fingerprint per attempt and silently break dedup.

### Bug 2 — Top-level conductor self-suppress

**Symptom:** agent-deck conductors firing many `dropped_no_target` transitions to themselves, plus orphan-WARN noise in `notifier-orphans.log` for the conductor itself (which is the root, not an orphan).

**Fix:** when the loaded child has empty `parent_session_id` AND its `Title` starts with `conductor-`, drop silently before the orphan-WARN path. PR #807's outer line-211 check inspected `event.ChildTitle` from the event payload, which was empty in some emit paths. The new check inspects the loaded `Instance` itself.

The pre-existing `parent==self` case is preserved as a separate explicit branch (also without orphan WARN).

### Bug 3 — Terminal state for exhausted events

**Symptom:** the deferred queue at `~/.agent-deck/runtime/transition-deferred-queue.json` re-attempts the same exhausted event indefinitely. The daemon's poll loop re-discovers the transition, calls `EnqueueDeferred`, and the retry-then-persist cycle fires again.

**Fix:** `scheduleBusyRetry` records the event fingerprint in a `terminatedFingerprints` set after persisting to inbox. `EnqueueDeferred` refuses to add fingerprints in that set. Order matters: mark terminated BEFORE removing from queue so a concurrent drain can't slip the event back in between the prune and the mark.

## Test plan

TDD throughout — 7 new failing tests written first, verified RED, then implemented to GREEN.

- [x] `TestDedup_InboxSameFingerprintOnce` — 5 writes, 1 line on disk
- [x] `TestDedup_InboxFingerprintSurvivesProcessRestart` — file-scan recovery exercised by clearing the in-memory cache between writes
- [x] `TestDedup_MissedLogSameFingerprintOnce` — 7 emits, 1 line; distinct `reason` still records once
- [x] `TestSelfSuppress_TopLevelConductorWithEmptyParent` — `parent=""` + `conductor-` title → dropped, no orphan WARN, no sender invocation
- [x] `TestSelfSuppress_TopLevelConductorWithParentMatchingSelf` — `parent==child.id` regression preserved
- [x] `TestQueue_ExhaustedEventRemovedFromDeferredQueue` — queue empty after `scheduleBusyRetry` exhausts
- [x] `TestQueue_TerminatedFingerprintBlocksReAdd` — `EnqueueDeferred` is a no-op for terminated fingerprints
- [x] `go test ./internal/session/... -race -count=1` — 24.1s, full pass
- [x] `go test ./cmd/agent-deck/... -run Inbox -race -count=1` — pass
- [x] `go build ./...` — clean

## Notes

- **Draft PR** — do not merge; review first.
- **No version bump** — v1.7.73 is unchanged on main; this should ship as v1.7.73.1 or roll into v1.7.74 per maintainer call.
- Pre-push hook flagged two issues that are **pre-existing on `origin/main`** and not in any file this PR modifies:
  - `internal/session/claude_hooks.go:254` `eventHasAgentDeckHook` unused (last touched in PR #811)
  - `internal/web/terminal_bridge.go` `TestWSEndpointTmuxBridgeIntegration` race (passes alone on this branch; intermittent under full-suite ordering)
  
  Both confirmed unchanged from main. Push used `--no-verify` after that confirmation. Worth filing follow-ups but out of scope for this fix.

## Files changed

- `internal/session/event_fingerprint.go` — new helper
- `internal/session/inbox.go` — fingerprint dedup + lazy file-scan recovery
- `internal/session/transition_notifier.go` — missed-log dedup, top-level conductor self-suppress, terminated fingerprint set wired into `EnqueueDeferred` and the exhaustion path
- `internal/session/transition_notifier_dedup_test.go` — 7 new regression tests