### PR TITLE
fix(tui): add copilot to TUI session creation preset list and createSessionTool

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8088,6 +8088,8 @@ func createSessionTool(command string) (string, string) {
 		tool = "opencode"
 	case "pi":
 		tool = "pi"
+	case "copilot":
+		tool = "copilot"
 	default:
 		if toolDef := session.GetToolDef(command); toolDef != nil {
 			tool = command

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -92,6 +92,16 @@ func TestCreateSessionTool_Pi(t *testing.T) {
 	}
 }
 
+// TUI session creation must produce Tool="copilot" rather than
+// Tool="shell" with Command="copilot", matching the tmux/userconfig
+// wiring already present since v1.7.26.
+func TestCreateSessionTool_Copilot(t *testing.T) {
+	tool, command := createSessionTool("copilot")
+	if tool != "copilot" || command != "copilot" {
+		t.Fatalf("createSessionTool(\"copilot\") = (%q, %q), want (\"copilot\", \"copilot\")", tool, command)
+	}
+}
+
 func TestHomeInit(t *testing.T) {
 	home := NewHome()
 	cmd := home.Init()

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -216,7 +216,7 @@ type dialogSnapshot struct {
 // buildPresetCommands returns the list of commands for the picker,
 // including any custom tools from config.toml.
 func buildPresetCommands() []string {
-	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi"}
+	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -55,8 +55,8 @@ func TestDialogSetSize(t *testing.T) {
 func TestDialogPresetCommands(t *testing.T) {
 	d := NewNewDialog()
 
-	// Should have shell (empty), claude, gemini, opencode, codex, pi
-	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi"}
+	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot
+	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot"}
 
 	if len(d.presetCommands) != len(expectedCommands) {
 		t.Errorf("Expected %d preset commands, got %d", len(expectedCommands), len(d.presetCommands))


### PR DESCRIPTION
## Problem

`copilot` was added as a first-class built-in tool in v1.7.26 (closes #556), but two call sites in the TUI creation flow were never updated — identical to the oversight that affected `pi` (fixed in v1.7.32, PR #674).

**Symptoms:**
- The New Session dialog pill-selector has no `copilot` option
- Typing `copilot` in the free-form command input creates a **shell** session instead of a Copilot session (because `createSessionTool()` had no `copilot` case, `GetToolDef` returned nil, and it fell back to `("shell", "copilot")`)

## Fix

Two source changes, mirroring exactly how `pi` was fixed:

1. **`internal/ui/newdialog.go`** — append `"copilot"` to `buildPresetCommands()`'s preset slice so it appears in the pill selector for both New Session and Edit Session dialogs
2. **`internal/ui/home.go`** — add `case "copilot": tool = "copilot"` to `createSessionTool()` so the free-form input is correctly resolved

## Tests

- Updated `TestDialogPresetCommands` to expect `copilot` in the preset list
- Added `TestCreateSessionTool_Copilot` (mirrors `TestCreateSessionTool_Pi`)
- All existing tests pass

## Related

- Tracking issue: #556
- Analogous fix: PR #674 (pi in v1.7.32)