### PR TITLE
fix(analytics): add claude-opus-4-7 to 1M context-window prefix table (#836)

### DIFF
--- a/internal/session/analytics.go
+++ b/internal/session/analytics.go
@@ -75,10 +75,12 @@ var modelContextWindowPrefixes = []struct {
 	prefix string
 	size   int
 }{
+	// 4.7 models: 1M context (must precede 4.x fallback)
+	{"claude-opus-4-7", 1000000},
 	// 4.6 models: 1M context
 	{"claude-opus-4-6", 1000000},
 	{"claude-sonnet-4-6", 1000000},
-	// 4.x models (non-4.6): 200k context
+	// 4.x models (non-4.6/4.7): 200k context
 	{"claude-opus-4", 200000},
 	{"claude-sonnet-4", 200000},
 	{"claude-haiku-4", 200000},

--- a/internal/session/analytics_test.go
+++ b/internal/session/analytics_test.go
@@ -60,10 +60,13 @@ func TestSessionAnalytics_ContextPercent_OpusModel(t *testing.T) {
 }
 
 func TestContextWindowForModel(t *testing.T) {
+	// 4.7 models: 1M (must match before 4.x fallback)
+	assert.Equal(t, 1000000, contextWindowForModel("claude-opus-4-7"))
+	assert.Equal(t, 1000000, contextWindowForModel("claude-opus-4-7-20260101"))
 	// 4.6 models: 1M
 	assert.Equal(t, 1000000, contextWindowForModel("claude-opus-4-6"))
 	assert.Equal(t, 1000000, contextWindowForModel("claude-sonnet-4-6"))
-	// 4.x non-4.6 models: 200k
+	// 4.x non-4.6/4.7 models: 200k
 	assert.Equal(t, 200000, contextWindowForModel("claude-opus-4-20250514"))
 	assert.Equal(t, 200000, contextWindowForModel("claude-sonnet-4-20250514"))
 	assert.Equal(t, 200000, contextWindowForModel("claude-haiku-4-5"))


### PR DESCRIPTION
Diagnosed by @AdamiecRadek in #836. The Session Analytics "Context [bar] N%" gauge rendered ~5x too high for `claude-opus-4-7` because the model→context-window prefix table in `internal/session/analytics.go` was missing the 4-7 entry, falling through to the 200K default. Concrete user impact: 145K used → bar read 72.6% instead of the correct 14.5%.

## Fix

Adds `{"claude-opus-4-7", 1000000}` entry placed BEFORE the 4.x fallback in the prefix table (table walk is order-sensitive), and extends `TestContextWindowForModel` with two 4-7 cases (bare model name + dated suffix) to lock the regression.

`claude-sonnet-4-7` not added per the reporter's note: Anthropic's published model list shows the latest Sonnet is 4.6.

## Out of scope (per reporter)

- Centralizing context-window data alongside the pricing registry in `internal/costs/pricing.go` (deferred).
- Hardcoded 1M for Gemini at `analytics_panel.go:166` (different model family, separate concern).

## Verification

- `go test ./internal/session/ -run TestContextWindowForModel -count=1` ✅
- `go build ./...` clean

Closes #836

Committed by Ashesh Goplani