### PR TITLE
fix(analytics): add claude-opus-4-7 to context-window prefix table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Session Analytics context bar showed wrong percentage for `claude-opus-4-7`** ([#836](https://github.com/asheshgoplani/agent-deck/issues/836)). The model→context-window prefix table in `internal/session/analytics.go` had no entry for `claude-opus-4-7`, so `contextWindowForModel` fell through to the 200k default. The Session Analytics panel called `ContextPercent(0)` and rendered ~5x the actual context usage (e.g. 72.6% instead of 14.5% for ~145K tokens used). Fix adds `claude-opus-4-7` at 1,000,000 to the prefix table.
+
 ## [1.7.75] - 2026-04-30
 
 Community quality-of-life bundle. Four contributor PRs landing the day after the v1.7.74 hotfix: regression fix for web mutations broken since v1.7.71, an SSH start-failure cleanup compensation, an `add` ergonomics fix for SSH-piped paths, and a configurable cost status-line. All four were dual-reviewed (Claude + Codex peer reviewer) before merge — first run of the dual-model review pipeline.

--- a/internal/session/analytics.go
+++ b/internal/session/analytics.go
@@ -75,10 +75,12 @@ var modelContextWindowPrefixes = []struct {
 	prefix string
 	size   int
 }{
+	// 4.7 models: 1M context (Opus 4.7 launched at 1M default)
+	{"claude-opus-4-7", 1000000},
 	// 4.6 models: 1M context
 	{"claude-opus-4-6", 1000000},
 	{"claude-sonnet-4-6", 1000000},
-	// 4.x models (non-4.6): 200k context
+	// 4.x models (non-4.6/4.7): 200k context
 	{"claude-opus-4", 200000},
 	{"claude-sonnet-4", 200000},
 	{"claude-haiku-4", 200000},

--- a/internal/session/analytics_test.go
+++ b/internal/session/analytics_test.go
@@ -59,11 +59,25 @@ func TestSessionAnalytics_ContextPercent_OpusModel(t *testing.T) {
 	assert.InDelta(t, 50.0, analytics.ContextPercent(0), 0.01)
 }
 
+func TestSessionAnalytics_ContextPercent_Opus47Model(t *testing.T) {
+	analytics := &SessionAnalytics{
+		CurrentContextTokens: 145200,
+		Model:                "claude-opus-4-7",
+	}
+
+	// Opus 4.7 launched at 1M context default. 145200 / 1000000 * 100 = 14.52%.
+	// Without the prefix-table entry this falls back to 200k and reports 72.6%.
+	assert.InDelta(t, 14.52, analytics.ContextPercent(0), 0.01)
+}
+
 func TestContextWindowForModel(t *testing.T) {
+	// 4.7 models: 1M
+	assert.Equal(t, 1000000, contextWindowForModel("claude-opus-4-7"))
+	assert.Equal(t, 1000000, contextWindowForModel("claude-opus-4-7-20260301"))
 	// 4.6 models: 1M
 	assert.Equal(t, 1000000, contextWindowForModel("claude-opus-4-6"))
 	assert.Equal(t, 1000000, contextWindowForModel("claude-sonnet-4-6"))
-	// 4.x non-4.6 models: 200k
+	// 4.x non-4.6/4.7 models: 200k
 	assert.Equal(t, 200000, contextWindowForModel("claude-opus-4-20250514"))
 	assert.Equal(t, 200000, contextWindowForModel("claude-sonnet-4-20250514"))
 	assert.Equal(t, 200000, contextWindowForModel("claude-haiku-4-5"))


### PR DESCRIPTION
Closes #836.

## What

`internal/session/analytics.go`'s model→context-window prefix table is missing `claude-opus-4-7`. The Session Analytics panel calls `ContextPercent(0)`, the inference falls through to the 200k default, and the bar renders ~5x too high (e.g. 72.6% instead of 14.5% for ~145K tokens used). The status-bar `Ctx: N%` readout (parsed from Claude's own status line) was unaffected and showed the correct 1M-denominator value, which is how the discrepancy surfaced.

## Fix

Adds `{"claude-opus-4-7", 1000000}` to `modelContextWindowPrefixes`, placed before the `claude-opus-4` 200k fallback so prefix matching resolves correctly for both bare `claude-opus-4-7` and date-suffixed variants like `claude-opus-4-7-20260301`.

`claude-sonnet-4-7` is intentionally not added: per Anthropic's published model list, Sonnet's latest is 4.6.

## Tests

- `TestContextWindowForModel` extended with two assertions for `claude-opus-4-7` and the date-suffixed variant.
- New `TestSessionAnalytics_ContextPercent_Opus47Model` verifies the panel-side math (145200 / 1,000,000 = 14.52%), RED before fix (returned 72.6 against 200k), GREEN after.

`go test -race -count=1` clean across `internal/session/`. `gofmt -l`, `go vet`, `go build ./cmd/agent-deck/` all clean.

## Out of scope

- Hardcoded 1M for Gemini at `analytics_panel.go:166` (different model family, separate concern).
- Centralizing the context-window registry alongside `internal/costs/pricing.go`, deferred follow-up if a third missing-model bug appears.
