### PR TITLE
feat(ui): add PgUp/PgDn/Home/End to session list (#815 rebased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Terminal navigation keys in session list.** Session list now accepts `Home` / `End` (jump to first / last item) and `PgUp` / `PgDn` (half-page aliases of existing `Ctrl+U` / `Ctrl+D`). Fills a gap where no single-key jump-to-bottom existed, since `G` opens global search. `Home` / `End` also scroll the help overlay. Follows the same side-effect contract as the pagination handlers (preview scroll reset, navigation-activity mark, debounced preview fetch).
+
+### Fixed
+
+- **Home/End keys in TUI now work for iTerm2 over direct SSH.** iTerm2's default macOS profile emits Home/End as SS3 application-mode sequences (`ESC OH` / `ESC OF`) on direct SSH (no intermediate tmux or screen). Bubble Tea's decoder covers the xterm, vt220, and urxvt Home/End variants but not SS3 — `csiuReader.translate` now rewrites `ESC OH` to `ESC [H` and `ESC OF` to `ESC [F` before bytes reach Bubble Tea. All other `ESC O*` sequences pass through unchanged. Verified unchanged for iTerm2 → SSH → Screen (already emitted vt220 `ESC [1~` / `ESC [4~`).
+
 ## [1.7.75] - 2026-04-30
 
 Community quality-of-life bundle. Four contributor PRs landing the day after the v1.7.74 hotfix: regression fix for web mutations broken since v1.7.71, an SSH start-failure cleanup compensation, an `add` ergonomics fix for SSH-piped paths, and a configurable cost status-line. All four were dual-reviewed (Claude + Codex peer reviewer) before merge — first run of the dual-model review pipeline.
@@ -60,6 +68,26 @@ Resilience pass. Nine community-and-internal PRs addressing real user-impacting 
 - **Bare ESC keypress lost in tmux attach quarantine; ESC followed by arrow arrived as Alt+Up** (thanks @amkopyt for [PR #812](https://github.com/asheshgoplani/agent-deck/pull/812)). `internal/termreply/filter.go` set `pendingEsc = true` on ESC and emitted nothing, waiting for the next byte to disambiguate CSI / SS3 / OSC. Real keyboard ESC has no follow-up byte, so the press stayed buffered indefinitely and later concatenated with the next keystroke's encoding. User-visible symptoms in Claude Code: bare ESC (interrupt) didn't fire, ESC ESC (jump-to-previous-message) didn't work, arrow keys appeared to reset the input. Fix flushes the lone ESC after a short timeout so it reaches the inner agent.
 
 - **Outdated Anthropic pricing data + missing entry for `claude-opus-4-7`** (thanks @AdamiecRadek for [issue #813](https://github.com/asheshgoplani/agent-deck/issues/813) → [PR #814](https://github.com/asheshgoplani/agent-deck/pull/814)). `claude-opus-4-6` was using legacy Opus 4 / 4.1 rates (3× the actual current rate, over-attributing every Opus 4.6 token), `claude-haiku-4-5` was at 80% of the published rates, and `claude-opus-4-7` was missing entirely (1240+ cost-event rows in the wild persisted at $0). Cost dashboard accuracy was wrong in both directions. Fix corrects all three plus adds a new `agent-deck costs recompute` CLI subcommand that recalculates `cost_microdollars` for every `cost_events` row using current pricing data (idempotent; supports `--dry-run`).
+### Added
+
+- **Terminal navigation keys in session list.** Session list now accepts
+  `Home` / `End` (jump to first / last item) and `PgUp` / `PgDn` (half-page
+  aliases of existing `Ctrl+U` / `Ctrl+D`). Fills a gap where no single-key
+  jump-to-bottom existed, since `G` opens global search. `Home` / `End` also
+  scroll the help overlay. Follows the same side-effect contract as the
+  pagination handlers (preview scroll reset, navigation-activity mark,
+  debounced preview fetch).
+
+### Fixed
+
+- **Home/End keys in TUI now work for iTerm2 over direct SSH.** iTerm2's
+  default macOS profile emits Home/End as SS3 application-mode sequences
+  (`ESC OH` / `ESC OF`) on direct SSH (no intermediate tmux or screen).
+  Bubble Tea's decoder covers the xterm, vt220, and urxvt Home/End
+  variants but not SS3 — `csiuReader.translate` now rewrites `ESC OH` to
+  `ESC [H` and `ESC OF` to `ESC [F` before bytes reach Bubble Tea. All
+  other `ESC O*` sequences pass through unchanged. Verified unchanged
+  for iTerm2 → SSH → Screen (already emitted vt220 `ESC [1~` / `ESC [4~`).
 
 ## [1.7.72] - 2026-04-28
 

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -103,6 +103,12 @@ func (h *HelpOverlay) Update(msg tea.Msg) (*HelpOverlay, tea.Cmd) {
 				h.scrollOffset = 0
 			}
 			return h, nil
+		case "home":
+			h.scrollOffset = 0
+			return h, nil
+		case "end":
+			h.scrollOffset = 9999 // Will be clamped in View()
+			return h, nil
 		case "g":
 			h.scrollOffset = 0
 			return h, nil
@@ -168,7 +174,9 @@ func (h *HelpOverlay) View() string {
 				{"j / Down", "Move down"},
 				{"k / Up", "Move up"},
 				{"Ctrl+u/d", "Half page up/down"},
+				{"PgUp / PgDn", "Half page up/down"},
 				{"Ctrl+f/b", "Full page up/down"},
+				{"Home / End", "Jump to first / last item"},
 				{"gg / G", "Jump to top / global search"},
 				{"h / Left", "Collapse / parent"},
 				{"l / Right", "Expand / toggle"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5647,7 +5647,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 		// Vi-style pagination (#38) - half/full page scrolling
-	case "ctrl+u": // Half page up
+	case "ctrl+u", "pgup": // Half page up
 		pageSize := h.getVisibleHeight() / 2
 		if pageSize < 1 {
 			pageSize = 1
@@ -5661,7 +5661,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.markNavigationActivity()
 		return h, h.fetchSelectedPreview()
 
-	case "ctrl+d": // Half page down
+	case "ctrl+d", "pgdown": // Half page down
 		pageSize := h.getVisibleHeight() / 2
 		if pageSize < 1 {
 			pageSize = 1
@@ -5701,6 +5701,23 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor >= len(h.flatItems) {
 			h.cursor = len(h.flatItems) - 1
 		}
+		if h.cursor < 0 {
+			h.cursor = 0
+		}
+		h.previewScrollOffset = 0
+		h.syncViewport()
+		h.markNavigationActivity()
+		return h, h.fetchSelectedPreview()
+
+	case "home": // Jump to first item
+		h.cursor = 0
+		h.previewScrollOffset = 0
+		h.syncViewport()
+		h.markNavigationActivity()
+		return h, h.fetchSelectedPreview()
+
+	case "end": // Jump to last item
+		h.cursor = len(h.flatItems) - 1
 		if h.cursor < 0 {
 			h.cursor = 0
 		}

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2864,3 +2864,82 @@ func TestRegression743_NOnRemoteGroup_QuickCreatesNoDialog(t *testing.T) {
 		t.Fatal("pressing n on a remote group must NOT open the local new-session dialog")
 	}
 }
+
+// TestHome_TerminalNavigationKeys verifies the PgUp/PgDn/Home/End bindings
+// added alongside the existing vi-style pagination (#38). PgUp/PgDn are
+// half-page aliases of Ctrl+U/Ctrl+D; Home/End jump to the first/last item
+// (End fills the gap where no single-key jump-to-bottom existed, since G
+// opens global search).
+func TestHome_TerminalNavigationKeys(t *testing.T) {
+	// Build a 100-item list so pagination + absolute jumps have room to move.
+	items := make([]session.Item, 100)
+	for i := range items {
+		items[i] = session.Item{
+			Type:    session.ItemTypeSession,
+			Session: &session.Instance{ID: fmt.Sprintf("s%d", i), Title: fmt.Sprintf("S%d", i)},
+			Level:   0,
+		}
+	}
+
+	const width, height = 100, 30
+
+	// Compute half-page from the actual getVisibleHeight so the test
+	// stays correct if the viewport formula changes.
+	h0 := newTestHomeWithItems(width, height, items)
+	halfPage := h0.getVisibleHeight() / 2
+	if halfPage < 1 {
+		halfPage = 1
+	}
+	last := len(items) - 1
+
+	tests := []struct {
+		name        string
+		key         tea.KeyMsg
+		startCursor int
+		wantCursor  int
+	}{
+		{"PgUp from middle", tea.KeyMsg{Type: tea.KeyPgUp}, 50, 50 - halfPage},
+		{"PgUp clamps at top", tea.KeyMsg{Type: tea.KeyPgUp}, 0, 0},
+		{"PgDown from middle", tea.KeyMsg{Type: tea.KeyPgDown}, 10, 10 + halfPage},
+		{"PgDown clamps at bottom", tea.KeyMsg{Type: tea.KeyPgDown}, last, last},
+		{"Home from middle", tea.KeyMsg{Type: tea.KeyHome}, 50, 0},
+		{"Home at top no-op", tea.KeyMsg{Type: tea.KeyHome}, 0, 0},
+		{"End from middle", tea.KeyMsg{Type: tea.KeyEnd}, 5, last},
+		{"End at bottom no-op", tea.KeyMsg{Type: tea.KeyEnd}, last, last},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHomeWithItems(width, height, items)
+			h.cursor = tc.startCursor
+			h.previewScrollOffset = 42 // non-zero to verify reset contract
+			updated, _ := h.Update(tc.key)
+			got := updated.(*Home).cursor
+			if got != tc.wantCursor {
+				t.Fatalf("cursor = %d, want %d (halfPage=%d)", got, tc.wantCursor, halfPage)
+			}
+			if updated.(*Home).previewScrollOffset != 0 {
+				t.Fatalf("previewScrollOffset = %d, want 0 (nav handlers must reset)",
+					updated.(*Home).previewScrollOffset)
+			}
+		})
+	}
+
+	t.Run("End on empty list does not crash", func(t *testing.T) {
+		h := newTestHomeWithItems(width, height, nil)
+		updated, _ := h.Update(tea.KeyMsg{Type: tea.KeyEnd})
+		got := updated.(*Home).cursor
+		if got != 0 {
+			t.Fatalf("cursor = %d, want 0 on empty list", got)
+		}
+	})
+
+	t.Run("Home on empty list does not crash", func(t *testing.T) {
+		h := newTestHomeWithItems(width, height, nil)
+		updated, _ := h.Update(tea.KeyMsg{Type: tea.KeyHome})
+		got := updated.(*Home).cursor
+		if got != 0 {
+			t.Fatalf("cursor = %d, want 0 on empty list", got)
+		}
+	})
+}

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -383,6 +383,39 @@ func (c *csiuReader) translate(final bool) []byte {
 			i++
 			continue
 		}
+
+		// SS3 (ESC O) handling: rewrite ESC OH / ESC OF to ESC [H / ESC [F
+		// so Bubble Tea's escSeq table recognizes Home/End. Terminals that
+		// emit application-mode (DECKPAM) SS3 sequences for Home/End include
+		// iTerm2's default macOS profile over direct SSH. Other SS3 sequences
+		// (arrows ESC OA-D, function keys ESC OP-S) are already in Bubble
+		// Tea's escSeq table and must pass through unchanged.
+		if c.inBuf[i+1] == 'O' {
+			if i+2 >= len(c.inBuf) {
+				if !final {
+					break // buffer ESC O, wait for third byte
+				}
+				// final: pass through ESC O as-is.
+				out = append(out, c.inBuf[i:i+2]...)
+				i += 2
+				continue
+			}
+			switch c.inBuf[i+2] {
+			case 'H':
+				out = append(out, 0x1b, '[', 'H')
+				i += 3
+				continue
+			case 'F':
+				out = append(out, 0x1b, '[', 'F')
+				i += 3
+				continue
+			}
+			// Other ESC O* sequence — Bubble Tea handles natively.
+			out = append(out, c.inBuf[i:i+3]...)
+			i += 3
+			continue
+		}
+
 		if c.inBuf[i+1] != '[' {
 			out = append(out, c.inBuf[i])
 			i++

--- a/internal/ui/keyboard_compat_test.go
+++ b/internal/ui/keyboard_compat_test.go
@@ -681,3 +681,98 @@ func TestRestoreLegacyKeyboardCmd(t *testing.T) {
 		t.Errorf("cmd() wrote %q to writer, want %q (Kitty pop sequence)", got, want)
 	}
 }
+
+// TestCSIuReader_SS3HomeEnd covers the SS3 application-mode Home/End rewrite.
+// iTerm2's default macOS profile emits Home/End as ESC OH / ESC OF (SS3),
+// which Bubble Tea v1.3.10's escSeq table does not decode. The csiuReader
+// rewrites only these two sequences to their CSI equivalents ESC [H / ESC [F.
+// All other SS3 sequences (arrows ESC OA-D, F1-F4 ESC OP-S) must pass through
+// unchanged because Bubble Tea handles them natively.
+func TestCSIuReader_SS3HomeEnd(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"SS3 Home rewrites to CSI H", "\x1bOH", "\x1b[H"},
+		{"SS3 End rewrites to CSI F", "\x1bOF", "\x1b[F"},
+		{"SS3 up arrow passes through", "\x1bOA", "\x1bOA"},
+		{"SS3 down arrow passes through", "\x1bOB", "\x1bOB"},
+		{"SS3 right arrow passes through", "\x1bOC", "\x1bOC"},
+		{"SS3 left arrow passes through", "\x1bOD", "\x1bOD"},
+		{"SS3 F1 passes through", "\x1bOP", "\x1bOP"},
+		{"SS3 F2 passes through", "\x1bOQ", "\x1bOQ"},
+		{"SS3 F3 passes through", "\x1bOR", "\x1bOR"},
+		{"SS3 F4 passes through", "\x1bOS", "\x1bOS"},
+		{"mixed: legacy byte, SS3 Home, SS3 End, legacy byte",
+			"j\x1bOH\x1bOFq", "j\x1b[H\x1b[Fq"},
+		{"SS3 Home followed by CSI PgUp (known-working)",
+			"\x1bOH\x1b[5~", "\x1b[H\x1b[5~"},
+		{"SS3 Home next to non-SS3 ESC (bare ESC preserved)",
+			"\x1bOH\x1bq", "\x1b[H\x1bq"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewCSIuReader(bytes.NewReader([]byte(tt.input)))
+			out, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll error: %v", err)
+			}
+			if string(out) != tt.want {
+				t.Errorf("CSIuReader(%q) = %q, want %q", tt.input, string(out), tt.want)
+			}
+		})
+	}
+}
+
+// TestCSIuReader_SS3HomeEnd_ChunkedRead verifies that an SS3 Home/End sequence
+// split across two Read() calls (e.g. ESC O arrives in chunk 1, H in chunk 2)
+// is still rewritten correctly. The translator must buffer the partial ESC O
+// until the third byte is available.
+func TestCSIuReader_SS3HomeEnd_ChunkedRead(t *testing.T) {
+	tests := []struct {
+		name   string
+		chunks [][]byte
+		want   string
+	}{
+		{
+			"SS3 Home split between ESC O and H",
+			[][]byte{[]byte("\x1bO"), []byte("H")},
+			"\x1b[H",
+		},
+		{
+			"SS3 End split between ESC O and F",
+			[][]byte{[]byte("\x1bO"), []byte("F")},
+			"\x1b[F",
+		},
+		{
+			"SS3 Home split between ESC and OH",
+			[][]byte{[]byte("\x1b"), []byte("OH")},
+			"\x1b[H",
+		},
+		{
+			"SS3 passthrough (F1) split between ESC O and P",
+			[][]byte{[]byte("\x1bO"), []byte("P")},
+			"\x1bOP",
+		},
+		{
+			"mixed stream with SS3 Home at chunk boundary",
+			[][]byte{[]byte("j\x1bO"), []byte("Hq")},
+			"j\x1b[Hq",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewCSIuReader(&chunkedReader{chunks: tt.chunks})
+			out, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll error: %v", err)
+			}
+			if string(out) != tt.want {
+				t.Errorf("chunked CSIuReader = %q, want %q", string(out), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Rebased version of @strofimovsky's PR #815 onto current main. Authorship preserved (commit author: Sergey Trofimovsky); CHANGELOG entries placed under [Unreleased].

This is the same change as #815 with a CHANGELOG conflict resolved against the v1.7.74/75 entries that landed after #815 was filed. Closes #815.

Original review: dual-review (Claude verdict SAFE_TO_MERGE / LOW risk; codex peer skipped due to sub-of-sub spawn limit).

Committed by Ashesh Goplani