### PR TITLE
fix(ui): buffer lone ESC at chunk boundary for SS3 detection

### DIFF
--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -377,8 +377,13 @@ func (c *csiuReader) translate(final bool) []byte {
 			continue
 		}
 
-		// Preserve a lone ESC as-is to avoid hanging standalone escape.
+		// Lone ESC at buffer end: if mid-stream, buffer it for the next Read so
+		// SS3 (ESC OH / ESC OF) can be detected when the next byte arrives. On
+		// final flush we pass it through to avoid hanging a standalone escape.
 		if i+1 >= len(c.inBuf) {
+			if !final {
+				break
+			}
 			out = append(out, c.inBuf[i])
 			i++
 			continue


### PR DESCRIPTION
Hotfix for the v1.7.76 release CI failure. The csiuReader.translate function emitted a lone ESC at the buffer boundary unconditionally, breaking SS3 sequence detection when ESC and the following 'OH' arrived in separate Read() chunks.

## Root cause

`csiuReader.translate` had this for lone ESC at end-of-buffer:
\`\`\`go
if i+1 >= len(c.inBuf) {
    out = append(out, c.inBuf[i])
    i++
    continue
}
\`\`\`

It always emitted the ESC. Once flushed, the next chunk's `OH` was treated as plain bytes and the SS3 → CSI Home rewrite never ran.

## Fix

Mirrors the existing ESC-O-at-buffer-end pattern (lines 391-396): when not final, buffer the lone ESC and wait for the next chunk; on final flush emit ESC as-is to avoid hanging a standalone escape.

## Verification

- `TestCSIuReader_SS3HomeEnd_ChunkedRead/SS3_Home_split_between_ESC_and_OH` now passes (was the failing case in v1.7.76 release CI)
- All other CSIuReader tests still pass
- `go test ./internal/ui/ -race -count=1` green

Caught in v1.7.76 release CI. v1.7.76 tag exists but no binaries were published due to the test failure; will retag as v1.7.77 once this lands.

Committed by Ashesh Goplani