### PR TITLE
fix(git): resolve submodule paths to worktree, not gitdir

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -68,6 +68,55 @@ func gitCommonDirAbs(dir string) (string, error) {
 	return commonDir, nil
 }
 
+// resolveWorktreeToToplevel returns the actual working tree for path via
+// `git rev-parse --show-toplevel`. No-op for a regular working tree; for a
+// submodule's gitdir (which `git worktree list --porcelain` reports as the
+// worktree path for the main checkout) it returns the real working tree.
+// Falls back to path on any git failure.
+func resolveWorktreeToToplevel(path string) string {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		return path
+	}
+	top := strings.TrimSpace(string(out))
+	if top == "" {
+		return path
+	}
+	return top
+}
+
+// isGitDir reports whether dir is a git directory (bare repo, a .git folder,
+// .git/modules/<sub>, .git/worktrees/<wt>) rather than a real working tree.
+// Used as a deletion-safety check before os.RemoveAll.
+//
+// Detection is path-structural plus IsBareRepo. `git rev-parse --show-toplevel`
+// is unusable here: it errors out from inside .git/ and .git/worktrees/ (no
+// working tree), AND it returns false-negative for a submodule gitdir under
+// .git/modules/ (because that gitdir's core.worktree config makes git treat
+// the submodule's working tree as the toplevel). Both classes are caught
+// structurally instead.
+//
+// Non-git paths and orphaned worktree directories at user-chosen locations
+// (the case exercised by TestRemoveWorktree's force-fallback path) are NOT
+// flagged — they are legitimate os.RemoveAll targets.
+func isGitDir(dir string) bool {
+	if IsBareRepo(dir) {
+		return true
+	}
+	clean := filepath.Clean(dir)
+	if filepath.Base(clean) == ".git" {
+		return true
+	}
+	parts := strings.Split(clean, string(filepath.Separator))
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i] == ".git" && (parts[i+1] == "modules" || parts[i+1] == "worktrees") {
+			return true
+		}
+	}
+	return false
+}
+
 // findNestedBareRepo returns the path to a bare git repository nested under
 // dir, if one exists. The conventional layout from issue #715 places it at
 // "<projectRoot>/.bare"; this helper first probes that path, then scans
@@ -355,6 +404,14 @@ func parseWorktreeList(output string) []Worktree {
 		worktrees = append(worktrees, current)
 	}
 
+	// `git worktree list --porcelain` reports the gitdir (not the working
+	// tree) for a plain submodule's main checkout — normalize it back.
+	for i := range worktrees {
+		if !worktrees[i].Bare {
+			worktrees[i].Path = resolveWorktreeToToplevel(worktrees[i].Path)
+		}
+	}
+
 	return worktrees
 }
 
@@ -384,6 +441,14 @@ func RemoveWorktree(repoDir, worktreePath string, force bool) error {
 		// Force mode: git worktree remove --force can still fail when the
 		// directory contains untracked content. Fall back to deleting the
 		// directory and pruning the stale worktree reference.
+		//
+		// Refuse if the path is a git directory (bare repo, .git/modules/<sub>,
+		// .git/worktrees/<wt>). A pre-fix bug stored a submodule gitdir as
+		// WorktreePath; without this guard, session deletion destroyed the
+		// submodule's git history.
+		if isGitDir(worktreePath) {
+			return fmt.Errorf("refusing to remove %q: path is a git directory, not a working tree (likely a stale session row from before the submodule path-normalization fix)", worktreePath)
+		}
 		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
 			return fmt.Errorf("failed to remove worktree directory: %w (git error: %s)", rmErr, strings.TrimSpace(string(output)))
 		}

--- a/internal/git/submodule_test.go
+++ b/internal/git/submodule_test.go
@@ -1,0 +1,190 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// createSubmoduleLayout builds a superproject containing one initialized submodule.
+//
+//	super/
+//	├── .git/
+//	│   └── modules/erp/      ← submodule gitdir; agent-deck must NOT treat as a worktree
+//	├── erp/                  ← submodule working tree (the path agent-deck should store)
+//	└── README.md
+//
+// Returns (superprojectRoot, submoduleWorkingTree). A local file:// remote backs the
+// submodule so no network is required.
+func createSubmoduleLayout(t *testing.T) (super, submodule string) {
+	t.Helper()
+
+	run := func(dir string, args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = testutil.CleanGitEnv(os.Environ())
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git -C %s %s: %v (stderr: %s)", dir, strings.Join(args, " "), err, stderr.String())
+		}
+	}
+
+	parent := t.TempDir()
+	remote := filepath.Join(parent, "remote")
+	if err := os.Mkdir(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(remote, "-c", "init.defaultBranch=main", "init")
+	run(remote, "config", "user.email", "test@test.com")
+	run(remote, "config", "user.name", "Test User")
+	run(remote, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(remote, "README.md"), []byte("# erp\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(remote, "add", ".")
+	run(remote, "commit", "-m", "init")
+
+	super = filepath.Join(parent, "super")
+	if err := os.Mkdir(super, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(super, "-c", "init.defaultBranch=main", "init")
+	run(super, "config", "user.email", "test@test.com")
+	run(super, "config", "user.name", "Test User")
+	run(super, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(super, "README.md"), []byte("# super\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(super, "add", ".")
+	run(super, "commit", "-m", "init")
+
+	// Modern git refuses file:// submodule fetches without protocol.file.allow=always.
+	run(super, "-c", "protocol.file.allow=always", "submodule", "add", remote, "erp")
+	run(super, "commit", "-m", "add erp submodule")
+
+	submodule = filepath.Join(super, "erp")
+	return super, submodule
+}
+
+// TestListWorktrees_SubmoduleReturnsWorkingTreeNotGitdir is the regression test
+// for the path-normalization bug: `git worktree list --porcelain` from inside a
+// submodule reports the submodule's gitdir (`<super>/.git/modules/<name>`) as
+// the worktree path, not the actual working tree. parseWorktreeList must
+// normalize that back to the working tree, otherwise downstream code stores
+// the gitdir as ProjectPath / worktree cwd.
+func TestListWorktrees_SubmoduleReturnsWorkingTreeNotGitdir(t *testing.T) {
+	_, submodule := createSubmoduleLayout(t)
+
+	wts, err := ListWorktrees(submodule)
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if len(wts) == 0 {
+		t.Fatal("expected at least one worktree entry from a submodule")
+	}
+
+	expected, _ := filepath.EvalSymlinks(submodule)
+	got, _ := filepath.EvalSymlinks(wts[0].Path)
+	if got != expected {
+		t.Errorf("worktree path = %q, want %q (must NOT be the gitdir)", wts[0].Path, expected)
+	}
+	if strings.Contains(wts[0].Path, string(filepath.Separator)+".git"+string(filepath.Separator)+"modules"+string(filepath.Separator)) {
+		t.Errorf("worktree path %q still points at the submodule gitdir", wts[0].Path)
+	}
+}
+
+// TestGetWorktreeForBranch_SubmoduleReturnsWorkingTree exercises the helper
+// that the agent-deck worktree-reuse flow consults
+// (cmd/agent-deck/main.go:1319, launch_cmd.go:216, internal/ui/home.go:7897).
+// Returning the gitdir here is what caused the wrong ProjectPath / cwd / data
+// loss on session deletion.
+func TestGetWorktreeForBranch_SubmoduleReturnsWorkingTree(t *testing.T) {
+	_, submodule := createSubmoduleLayout(t)
+
+	branch, err := GetCurrentBranch(submodule)
+	if err != nil {
+		t.Fatalf("GetCurrentBranch: %v", err)
+	}
+
+	got, err := GetWorktreeForBranch(submodule, branch)
+	if err != nil {
+		t.Fatalf("GetWorktreeForBranch: %v", err)
+	}
+
+	expected, _ := filepath.EvalSymlinks(submodule)
+	resolved, _ := filepath.EvalSymlinks(got)
+	if resolved != expected {
+		t.Errorf("GetWorktreeForBranch(%q, %q) = %q, want %q",
+			submodule, branch, resolved, expected)
+	}
+}
+
+// TestRemoveWorktree_RefusesToDeleteSubmoduleGitdir is the data-loss regression
+// gate. A session created before the path-normalization fix may have its
+// WorktreePath persisted as the submodule's gitdir. When the user deletes that
+// session, RemoveWorktree(force=true) used to fall back to os.RemoveAll on the
+// gitdir, destroying the submodule's git history. The defensive guard must
+// surface an error instead.
+func TestRemoveWorktree_RefusesToDeleteSubmoduleGitdir(t *testing.T) {
+	super, submodule := createSubmoduleLayout(t)
+	gitdir := filepath.Join(super, ".git", "modules", "erp")
+
+	if _, err := os.Stat(gitdir); err != nil {
+		t.Fatalf("gitdir should exist before RemoveWorktree (fixture bug?): %v", err)
+	}
+
+	// Mirror the call shape from internal/ui/home.go:8562 and
+	// cmd/agent-deck/session_remove_cmd.go:177 — repoRoot = submodule worktree,
+	// worktreePath = (mistakenly) the gitdir, force = true.
+	err := RemoveWorktree(submodule, gitdir, true)
+	if err == nil {
+		t.Fatal("RemoveWorktree(force=true) on a gitdir must return an error, not silently delete")
+	}
+
+	if _, err := os.Stat(gitdir); err != nil {
+		t.Fatalf("gitdir was destroyed by RemoveWorktree (data-loss regression): %v", err)
+	}
+}
+
+// TestRemoveWorktree_RefusesToDeleteRepoGitFolder covers the broader class of
+// gitdir-shaped paths that could end up on stale or buggy WorktreePath values:
+// the repo's own .git folder and the .git/worktrees/<wt> admin dir. Neither
+// case can be detected by `git rev-parse --show-toplevel` (the command errors
+// out from inside both), so isGitDir uses path structure.
+func TestRemoveWorktree_RefusesToDeleteRepoGitFolder(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+
+	wtPath := filepath.Join(t.TempDir(), "wt-feat")
+	if err := CreateWorktree(dir, wtPath, "feat"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"repo .git folder", filepath.Join(dir, ".git")},
+		{".git/worktrees admin dir", filepath.Join(dir, ".git", "worktrees", "wt-feat")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := os.Stat(tc.path); err != nil {
+				t.Fatalf("%s should exist before RemoveWorktree (fixture bug?): %v", tc.path, err)
+			}
+			err := RemoveWorktree(dir, tc.path, true)
+			if err == nil {
+				t.Fatalf("RemoveWorktree(force=true) on %q must error, not delete git internals", tc.path)
+			}
+			if _, err := os.Stat(tc.path); err != nil {
+				t.Fatalf("%q was destroyed by RemoveWorktree (data-loss regression): %v", tc.path, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> ⚠️ **Data-loss bug**: deleting a session whose path was auto-resolved to a submodule's gitdir destroys `<superproject>/.git/modules/<name>` with no confirmation. Reproduced in user's environment.

## Bug

`git worktree list --porcelain` from inside a plain submodule reports the **gitdir** (`<super>/.git/modules/<name>`) as the worktree path for the main checkout, not the actual `<super>/<name>` working tree. Empirically:

```text
$ git -C <submodule> worktree list --porcelain
worktree /path/to/super/.git/modules/<name>     ← gitdir, wrong
HEAD <sha>
branch refs/heads/<branch>

$ git -C <gitdir> rev-parse --show-toplevel
/path/to/super/<name>                            ← actual working tree
```

Three flows turn that gitdir into `Instance.ProjectPath` and the tmux `-c` cwd:
- `cmd/agent-deck/main.go` (`agent-deck add -w`)
- `cmd/agent-deck/launch_cmd.go` (`agent-deck launch -w`)
- `internal/ui/home.go` (TUI new-session with worktree enabled)

(Plus fork variants in `cmd/agent-deck/session_cmd.go` and `internal/ui/home.go` worktree-fork branches — all consume the same `GetWorktreeForBranch` helper and are fixed transparently by the change below.)

Sessions thus created drop the user inside the gitdir, where source files don't exist. **Worse**, deleting the session via the TUI or `session remove --force` calls `RemoveWorktree(force=true)`, whose force-fallback at the end of the function calls `os.RemoveAll(worktreePath)` — destroying the submodule's git history.

## Reproduction

1. Init a superproject with a submodule (`git submodule add <remote> erp`).
2. TUI new-session pointing at the submodule worktree, enable the worktree checkbox, pick the branch already checked out in the submodule (e.g. `main`).
3. Confirm. Attach to the session — `pwd` shows `<super>/.git/modules/erp` instead of `<super>/erp`.
4. Delete the session in the TUI. The submodule's gitdir is gone.

## Fix

Two parts in `internal/git/git.go`:

1. **Prevention** — `parseWorktreeList` normalizes each non-bare entry through `git rev-parse --show-toplevel` (post-loop pass). The flag returns the working tree even when invoked from inside a gitdir, so all three call sites (and any future caller of `ListWorktrees` / `GetWorktreeForBranch`) get the actual worktree path.

2. **Defense-in-depth** — `RemoveWorktree` refuses the `os.RemoveAll` fallback when the target path is structurally a git directory: the helper `isGitDir` flags `.git` basename, paths under `.git/modules/<sub>` or `.git/worktrees/<wt>`, and bare repos. This catches stale session rows that were persisted before Part 1 — they now error on delete instead of nuking git internals.

Note on detection: `--show-toplevel` was rejected for `isGitDir` because (a) it errors out from inside `.git/` and `.git/worktrees/` (no working tree) and (b) it returns a *false negative* for a submodule gitdir under `.git/modules/` (because that gitdir's `core.worktree` config makes git treat the submodule's working tree as the toplevel). Path-structural detection covers all three cases. `--is-inside-git-dir` was rejected for the same `core.worktree` false-negative reason.

## Tests

New file `internal/git/submodule_test.go` (4 tests, 6 sub-tests):
- `TestListWorktrees_SubmoduleReturnsWorkingTreeNotGitdir` — Part 1 invariant
- `TestGetWorktreeForBranch_SubmoduleReturnsWorkingTree` — same invariant at the consumed-helper layer
- `TestRemoveWorktree_RefusesToDeleteSubmoduleGitdir` — data-loss regression gate (the user's actual scenario)
- `TestRemoveWorktree_RefusesToDeleteRepoGitFolder` — covers bare `.git/` and `.git/worktrees/<wt>` (additional gitdir-shaped paths a stale `WorktreePath` could hold)

The existing force-fallback test (`TestRemoveWorktree/force falls back to direct removal when git refuses`) continues to pass — it operates on an orphaned worktree at a user path (`<temp>/wtA`), which is structurally NOT a git directory and remains a legitimate `os.RemoveAll` target.

## Out-of-scope follow-up (not fixed in this PR)

In the TUI fork-with-worktree reuse branch at `internal/ui/home.go:8441`, when an existing worktree is reused, `opts.WorktreePath` is updated but `opts.WorkDir` is not. `CreateForkedInstanceWithOptions` (`internal/session/instance.go:5108`) uses `opts.WorkDir` for the new session's `ProjectPath`, so fork-with-reused-worktree sessions still get the *originally generated* (uncreated) path as their cwd. This is a pre-existing, non-submodule bug in the fork flow. Flagging here for awareness — happy to file a separate PR if useful.

## Local verification

```bash
GOTOOLCHAIN=go1.24.0 go test -race -count=1 ./internal/git/...
# 166 passed, 1 pre-existing (unrelated /bin/echo shebang test in this NixOS env)
GOTOOLCHAIN=go1.24.0 gofmt -l ./internal/git/git.go ./internal/git/submodule_test.go
# clean
GOTOOLCHAIN=go1.24.0 golangci-lint run ./internal/git/...
# clean
```