### PR TITLE
fix(groups): reorder swaps with same-parent sibling, not slice neighbor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Session reorder (`K` / `J`, `Shift+Up` / `Shift+Down`) required multiple key presses to produce a visible move when sub-sessions of different parents were interleaved in a group.** `MoveSessionUp` / `MoveSessionDown` swapped with the immediate slice neighbor, but the render path re-buckets sub-sessions under their parents, so a swap with a non-sibling produced zero visible change. Fixed by walking the slice for the previous/next session with the same `ParentSessionID` (top-level peers treat each other as siblings, sub-sessions reorder among same-parent siblings only). One key press now always produces a visible move when one is possible. Tests in `internal/session/groups_test.go` cover the interleaving case, the first-sibling no-op, and the top-level-skips-subs case.
+
 ## [1.7.78] - 2026-05-01
 
 P0 hotfix for a data-loss bug in submodule worktree handling.

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -557,38 +557,63 @@ func (t *GroupTree) MoveGroupDown(path string) {
 	}
 }
 
-// MoveSessionUp moves a session up within its group
+// MoveSessionUp moves a session up among its visual siblings: top-level
+// sessions (empty ParentSessionID) reorder among other top-level sessions
+// in the same group; sub-sessions reorder among other sub-sessions of the
+// same parent. Non-siblings interleaved in the flat slice are skipped, so
+// a single call always produces a visible change when one is possible.
 func (t *GroupTree) MoveSessionUp(inst *Instance) {
 	group, exists := t.Groups[inst.GroupPath]
 	if !exists {
 		return
 	}
 
+	currentIdx, prevSiblingIdx := -1, -1
 	for i, s := range group.Sessions {
-		if s.ID == inst.ID && i > 0 {
-			group.Sessions[i], group.Sessions[i-1] = group.Sessions[i-1], group.Sessions[i]
+		if s.ID == inst.ID {
+			currentIdx = i
 			break
 		}
+		if s.ParentSessionID == inst.ParentSessionID {
+			prevSiblingIdx = i
+		}
 	}
+	if currentIdx < 0 || prevSiblingIdx < 0 {
+		return
+	}
+	group.Sessions[currentIdx], group.Sessions[prevSiblingIdx] = group.Sessions[prevSiblingIdx], group.Sessions[currentIdx]
+
 	// Normalize Order for all sessions in group
 	for i, s := range group.Sessions {
 		s.Order = i
 	}
 }
 
-// MoveSessionDown moves a session down within its group
+// MoveSessionDown moves a session down among its visual siblings.
+// See MoveSessionUp for the sibling-aware semantics; this is the symmetric
+// case that swaps with the next same-parent session in the slice.
 func (t *GroupTree) MoveSessionDown(inst *Instance) {
 	group, exists := t.Groups[inst.GroupPath]
 	if !exists {
 		return
 	}
 
+	currentIdx, nextSiblingIdx := -1, -1
 	for i, s := range group.Sessions {
-		if s.ID == inst.ID && i < len(group.Sessions)-1 {
-			group.Sessions[i], group.Sessions[i+1] = group.Sessions[i+1], group.Sessions[i]
+		if s.ID == inst.ID {
+			currentIdx = i
+			continue
+		}
+		if currentIdx >= 0 && s.ParentSessionID == inst.ParentSessionID {
+			nextSiblingIdx = i
 			break
 		}
 	}
+	if currentIdx < 0 || nextSiblingIdx < 0 {
+		return
+	}
+	group.Sessions[currentIdx], group.Sessions[nextSiblingIdx] = group.Sessions[nextSiblingIdx], group.Sessions[currentIdx]
+
 	// Normalize Order for all sessions in group
 	for i, s := range group.Sessions {
 		s.Order = i

--- a/internal/session/groups_test.go
+++ b/internal/session/groups_test.go
@@ -1307,6 +1307,152 @@ func TestMoveSessionDownOrder(t *testing.T) {
 	}
 }
 
+// childrenOf returns IDs of sub-sessions whose ParentSessionID matches parentID,
+// in the order they appear in the group's flat session slice. Mirrors the
+// rendering path's bucketing in groups.go::Items().
+func childrenOf(group *Group, parentID string) []string {
+	var ids []string
+	for _, s := range group.Sessions {
+		if s.ParentSessionID == parentID {
+			ids = append(ids, s.ID)
+		}
+	}
+	return ids
+}
+
+// TestMoveSessionUp_SubSessionSkipsNonSiblings documents the bug fix:
+// when sub-sessions of different parents are interleaved in the flat
+// group.Sessions slice, MoveSessionUp on a sub-session must swap with
+// the previous SAME-parent sibling, not with the immediately-preceding
+// non-sibling. Otherwise a single key press produces no visible change
+// and the user has to press the reorder key multiple times.
+func TestMoveSessionUp_SubSessionSkipsNonSiblings(t *testing.T) {
+	instances := []*Instance{
+		{ID: "p1", Title: "parent1", GroupPath: "test"},
+		{ID: "s1a", Title: "child1a", GroupPath: "test", ParentSessionID: "p1"},
+		{ID: "p2", Title: "parent2", GroupPath: "test"},
+		{ID: "s1b", Title: "child1b", GroupPath: "test", ParentSessionID: "p1"},
+	}
+	tree := NewGroupTree(instances)
+	group := tree.Groups["test"]
+
+	var s1b *Instance
+	for _, s := range group.Sessions {
+		if s.ID == "s1b" {
+			s1b = s
+			break
+		}
+	}
+
+	tree.MoveSessionUp(s1b)
+
+	// After one move, the visual children-of-p1 order should be [s1b, s1a].
+	got := childrenOf(group, "p1")
+	want := []string{"s1b", "s1a"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("children of p1 after MoveSessionUp(s1b) = %v, want %v", got, want)
+	}
+}
+
+func TestMoveSessionDown_SubSessionSkipsNonSiblings(t *testing.T) {
+	instances := []*Instance{
+		{ID: "p1", Title: "parent1", GroupPath: "test"},
+		{ID: "s1a", Title: "child1a", GroupPath: "test", ParentSessionID: "p1"},
+		{ID: "p2", Title: "parent2", GroupPath: "test"},
+		{ID: "s1b", Title: "child1b", GroupPath: "test", ParentSessionID: "p1"},
+	}
+	tree := NewGroupTree(instances)
+	group := tree.Groups["test"]
+
+	var s1a *Instance
+	for _, s := range group.Sessions {
+		if s.ID == "s1a" {
+			s1a = s
+			break
+		}
+	}
+
+	tree.MoveSessionDown(s1a)
+
+	got := childrenOf(group, "p1")
+	want := []string{"s1b", "s1a"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("children of p1 after MoveSessionDown(s1a) = %v, want %v", got, want)
+	}
+}
+
+// TestMoveSessionUp_SubSessionAtFirstSiblingNoOp guards against the
+// pre-fix behavior of swapping a sub-session with its immediately-preceding
+// element when that element is NOT a sibling (e.g. the parent itself).
+// The first sub-session under a parent must stay in place when moved up.
+func TestMoveSessionUp_SubSessionAtFirstSiblingNoOp(t *testing.T) {
+	instances := []*Instance{
+		{ID: "p1", Title: "parent1", GroupPath: "test"},
+		{ID: "s1a", Title: "child1a", GroupPath: "test", ParentSessionID: "p1"},
+		{ID: "s1b", Title: "child1b", GroupPath: "test", ParentSessionID: "p1"},
+	}
+	tree := NewGroupTree(instances)
+	group := tree.Groups["test"]
+
+	var s1a *Instance
+	for _, s := range group.Sessions {
+		if s.ID == "s1a" {
+			s1a = s
+			break
+		}
+	}
+
+	before := []string{}
+	for _, s := range group.Sessions {
+		before = append(before, s.ID)
+	}
+
+	tree.MoveSessionUp(s1a)
+
+	after := []string{}
+	for _, s := range group.Sessions {
+		after = append(after, s.ID)
+	}
+
+	for i := range before {
+		if before[i] != after[i] {
+			t.Errorf("expected no-op when first child has no previous sibling; got %v -> %v", before, after)
+			break
+		}
+	}
+}
+
+// TestMoveSessionUp_TopLevelSkipsSubSessions: a top-level session moved up
+// should swap with the previous TOP-LEVEL session, skipping any sub-sessions
+// belonging to another parent that happen to be between them in the slice.
+func TestMoveSessionUp_TopLevelSkipsSubSessions(t *testing.T) {
+	instances := []*Instance{
+		{ID: "p1", Title: "parent1", GroupPath: "test"},
+		{ID: "s1a", Title: "child1a", GroupPath: "test", ParentSessionID: "p1"},
+		{ID: "p2", Title: "parent2", GroupPath: "test"},
+	}
+	tree := NewGroupTree(instances)
+	group := tree.Groups["test"]
+
+	var p2 *Instance
+	for _, s := range group.Sessions {
+		if s.ID == "p2" {
+			p2 = s
+			break
+		}
+	}
+
+	tree.MoveSessionUp(p2)
+
+	// Top-level peers (sessions with empty ParentSessionID) order should
+	// now be [p2, p1].
+	got := childrenOf(group, "")
+	want := []string{"p2", "p1"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("top-level order after MoveSessionUp(p2) = %v, want %v", got, want)
+	}
+}
+
 func TestSessionOrderPersistence(t *testing.T) {
 	// Simulate sessions with Order values (as if saved after reorder)
 	instances := []*Instance{


### PR DESCRIPTION
## Problem

`K` / `J` (and `Shift+Up` / `Shift+Down`) reorder a session within its group. When a group contains sub-sessions of multiple parents interleaved in `group.Sessions`, a single key press often produces zero visible change. Users have to press the reorder key multiple times until the iteration finally moves the cursor past a real sibling.

Concrete repro (using slice order to model what's stored):

```
group.Sessions = [parentA, subA1, parentB, subB1, subA2]
```

Visually agent-deck renders:
```
parentA
  subA1
  subA2
parentB
  subB1
```

User selects `subA2` and presses `K` to move it up. Expected: `subA2` and `subA1` swap, visible result is `parentA → [subA2, subA1]`. Actual:

1. `MoveSessionUp(subA2)` finds it at index 4 and swaps with index 3 (`subB1`, a non-sibling). Slice becomes `[parentA, subA1, parentB, subA2, subB1]`.
2. The render re-buckets sub-sessions under `parentA`: still `[subA1, subA2]`. **No visible change.**
3. User presses `K` again. Now swap with index 2 (`parentB`). Slice becomes `[parentA, subA1, subA2, parentB, subB1]`. Visual under parentA: still `[subA1, subA2]`.
4. User presses `K` a third time. Now swap with index 1 (`subA1`). Slice becomes `[parentA, subA2, subA1, parentB, subB1]`. Visual under parentA: `[subA2, subA1]`. **Finally moved.**

## Fix

Walk the slice for the previous (resp. next) session with the same `ParentSessionID`, skipping non-siblings. Top-level peers (empty `ParentSessionID`) reorder among other top-level peers; sub-sessions reorder among same-parent siblings only.

`internal/session/groups.go::MoveSessionUp` / `MoveSessionDown` rewritten with this logic. ~25 lines net change.

A subtle pre-fix side effect of the bug worth calling out: when a sub-session was already at the first position among its siblings (e.g. `subA1` in `[parentA, subA1, ...]`), pressing `K` would silently swap it with `parentA` in the underlying slice. The render still showed the same visual order so the user saw nothing, but the slice was now `[subA1, parentA, ...]`. The new behavior treats this case as a no-op, which is the correct intent.

## Tests

- `TestMoveSessionUp_SubSessionSkipsNonSiblings` — RED before fix, GREEN after. Single press swaps `s1b` past a non-sibling `p2` to reach `s1a`.
- `TestMoveSessionDown_SubSessionSkipsNonSiblings` — symmetric.
- `TestMoveSessionUp_SubSessionAtFirstSiblingNoOp` — guards against the silent parent-swap regression described above.
- `TestMoveSessionUp_TopLevelSkipsSubSessions` — top-level peers reorder past unrelated sub-sessions in between.

Existing `TestMoveSessionUpOrder` / `TestMoveSessionDownOrder` (all-top-level case) still pass.

`go test -race -count=1 ./internal/session/...` clean for the reorder tests. `gofmt`/`vet`/`go build ./cmd/agent-deck/` all clean.

## Out of scope (follow-up)

A larger hierarchy-navigation feature is in design (Tab/Shift+Tab indent/outdent + a session-picker dialog for arbitrary parent change). I'll file that separately as an issue first since it has UX choices worth confirming. This PR is the bug fix only.
