### PR TITLE
fix(ui): refresh attached session status immediately on exit

### DIFF
--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -143,6 +143,13 @@ func (w *StatusFileWatcher) GetHookStatus(instanceID string) *HookStatus {
 	return w.statuses[instanceID]
 }
 
+// ClearHookStatus removes the cached hook status for an instance.
+func (w *StatusFileWatcher) ClearHookStatus(instanceID string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	delete(w.statuses, instanceID)
+}
+
 // loadExisting reads all current status files on startup.
 func (w *StatusFileWatcher) loadExisting() {
 	entries, err := os.ReadDir(w.hooksDir)

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3236,14 +3236,22 @@ func (i *Instance) GetHookStatus() (string, bool) {
 	return i.hookStatus, fresh
 }
 
-// ClearHookStatus resets the hook-based status, forcing the next UpdateStatus()
-// to fall through to polling. Used when the user manually overrides status (e.g., pressing 'u'
-// to unacknowledge after an Escape interrupt where the Stop hook didn't fire).
+// ClearHookStatus resets the hook-based status and removes the persisted hook
+// record, forcing the next UpdateStatus() to fall through to polling. Used
+// when the user manually overrides status (e.g., pressing 'u' to unacknowledge
+// after an Escape interrupt where the Stop hook didn't fire).
 func (i *Instance) ClearHookStatus() {
 	i.mu.Lock()
-	defer i.mu.Unlock()
 	i.hookStatus = ""
 	i.hookLastUpdate = time.Time{}
+	i.mu.Unlock()
+
+	if err := os.Remove(filepath.Join(GetHooksDir(), i.ID+".json")); err != nil && !os.IsNotExist(err) {
+		sessionLog.Debug("clear_hook_status_file_failed",
+			slog.String("instance", i.ID),
+			slog.String("error", err.Error()),
+		)
+	}
 }
 
 // ForceNextStatusCheck clears the idle polling optimization so the next

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -3149,6 +3149,38 @@ func TestInstance_UpdateHookStatus_Nil(t *testing.T) {
 	}
 }
 
+func TestInstance_ClearHookStatus_RemovesPersistedHookFile(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	inst := NewInstanceWithTool("test", "/tmp", "codex")
+	inst.ID = "clear-hook-file"
+
+	hooksDir := GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	hookPath := filepath.Join(hooksDir, inst.ID+".json")
+	if err := os.WriteFile(hookPath, []byte(`{"status":"running","event":"UserPromptSubmit","ts":1}`), 0o644); err != nil {
+		t.Fatalf("write hook file: %v", err)
+	}
+
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		Event:     "UserPromptSubmit",
+		UpdatedAt: time.Now(),
+	})
+
+	inst.ClearHookStatus()
+
+	if status, fresh := inst.GetHookStatus(); status != "" || fresh {
+		t.Fatalf("hook status = %q fresh=%v, want cleared", status, fresh)
+	}
+	if _, err := os.Stat(hookPath); !os.IsNotExist(err) {
+		t.Fatalf("hook file still exists or stat failed with unexpected error: %v", err)
+	}
+}
+
 func TestInstance_UpdateHookStatus_UsesAnchorWhenHookSessionIDMissing_Claude(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3223,6 +3223,9 @@ func (h *Home) refreshAttachedSessionStatus(sessionID string) {
 	// Force the attached session through the live tmux path before the list is
 	// redrawn so the status icon reflects a dead pane immediately.
 	inst.ClearHookStatus()
+	if h.hookWatcher != nil {
+		h.hookWatcher.ClearHookStatus(inst.ID)
+	}
 	inst.ForceNextStatusCheck()
 
 	if inst.GetTmuxSession() != nil {
@@ -4237,6 +4240,8 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.isAttaching.Store(false) // Atomic store for thread safety
 		now := time.Now()
 		h.beginAttachReturnGrace(now)
+		// Reconcile the attached session synchronously before the normal delayed
+		// refresh so an exited pane does not render as still running for a tick.
 		h.refreshAttachedSessionStatus(msg.attachedSessionID)
 
 		selectedBefore := h.captureSelectedItemIdentity()

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3206,6 +3206,51 @@ func (h *Home) triggerStatusUpdate() {
 	}
 }
 
+func (h *Home) refreshAttachedSessionStatus(sessionID string) {
+	if strings.TrimSpace(sessionID) == "" {
+		return
+	}
+
+	h.instancesMu.RLock()
+	inst := h.instanceByID[sessionID]
+	h.instancesMu.RUnlock()
+	if inst == nil {
+		return
+	}
+
+	// Attach return is the one moment where stale hook files are most visible:
+	// Claude/Codex may have exited via /q without writing a fresh "dead" hook.
+	// Force the attached session through the live tmux path before the list is
+	// redrawn so the status icon reflects a dead pane immediately.
+	inst.ClearHookStatus()
+	inst.ForceNextStatusCheck()
+
+	if inst.GetTmuxSession() != nil {
+		tmux.RefreshSessionCache()
+		tmux.RefreshPaneInfoCache()
+	}
+
+	oldStatus := inst.GetStatusThreadSafe()
+	_ = inst.UpdateStatus()
+	newStatus := inst.GetStatusThreadSafe()
+	if newStatus != oldStatus {
+		h.cachedStatusCounts.valid.Store(false)
+		h.publishCurrentSessionStates()
+		if db := statedb.GetGlobal(); db != nil {
+			_ = db.WriteStatus(inst.ID, string(newStatus), inst.GetToolThreadSafe())
+		}
+	}
+	h.refreshSessionRenderSnapshot(nil)
+}
+
+func (h *Home) publishCurrentSessionStates() {
+	h.instancesMu.RLock()
+	instances := make([]*session.Instance, len(h.instances))
+	copy(instances, h.instances)
+	h.instancesMu.RUnlock()
+	h.publishWebSessionStates(instances)
+}
+
 // processStatusUpdate implements round-robin status updates (Priority 1A + 1B)
 // Called by the background worker goroutine
 // Instead of updating ALL sessions every tick (which causes lag with 100+ sessions),
@@ -4192,6 +4237,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.isAttaching.Store(false) // Atomic store for thread safety
 		now := time.Now()
 		h.beginAttachReturnGrace(now)
+		h.refreshAttachedSessionStatus(msg.attachedSessionID)
 
 		selectedBefore := h.captureSelectedItemIdentity()
 		h.rebuildFlatItemsPreservingSelection(selectedBefore)
@@ -4251,7 +4297,8 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// resets mouse reporting), restore legacy keyboard reporting (tmux's
 		// extended-keys setting leaves Kitty/modifyOtherKeys on the outer terminal;
 		// see RestoreLegacyKeyboardCmd for the full rationale), and schedule a
-		// delayed refresh so the main menu reflects attach-return state changes.
+		// delayed repaint for any pane-title/content cache changes that settle just
+		// after tmux restores the outer client.
 		return h, tea.Batch(
 			tea.EnableMouseCellMotion,
 			RestoreLegacyKeyboardCmd(os.Stdout),
@@ -4261,7 +4308,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case attachReturnRefreshMsg:
 		selectedBefore := h.captureSelectedItemIdentity()
 		tmux.RefreshSessionCache()
+		tmux.RefreshPaneInfoCache()
 		h.rebuildFlatItemsPreservingSelection(selectedBefore)
+		h.refreshSessionRenderSnapshot(nil)
 		return h, nil
 
 	case previewDebounceMsg:

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2708,6 +2708,25 @@ func TestStatusUpdateMsg_PreservesSelectedSessionAcrossRebuild(t *testing.T) {
 	}
 }
 
+func TestStatusUpdateMsg_ReconcilesAttachedSessionBeforeRender(t *testing.T) {
+	h := newAttachReturnTestHome()
+	inst := session.NewInstanceWithGroup("exited", "/tmp/exited", "work")
+	inst.ID = "exited-session"
+	inst.CreatedAt = time.Now().Add(-2 * time.Second)
+	inst.Status = session.StatusRunning
+	setAttachReturnTestInstances(h, []*session.Instance{inst})
+
+	model, _ := h.Update(statusUpdateMsg{attachedSessionID: inst.ID})
+	home := model.(*Home)
+
+	if got := inst.GetStatusThreadSafe(); got != session.StatusError {
+		t.Fatalf("attached session status = %q, want %q", got, session.StatusError)
+	}
+	if got := home.getSessionRenderState(inst).status; got != session.StatusError {
+		t.Fatalf("render snapshot status = %q, want %q", got, session.StatusError)
+	}
+}
+
 func TestStatusUpdateMsg_FollowsNotificationSwitchSession(t *testing.T) {
 	h := newAttachReturnTestHome()
 	s1 := session.NewInstanceWithGroup("first", "/tmp/first", "work")

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2709,12 +2709,28 @@ func TestStatusUpdateMsg_PreservesSelectedSessionAcrossRebuild(t *testing.T) {
 }
 
 func TestStatusUpdateMsg_ReconcilesAttachedSessionBeforeRender(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
 	h := newAttachReturnTestHome()
-	inst := session.NewInstanceWithGroup("exited", "/tmp/exited", "work")
+	inst := session.NewInstanceWithGroupAndTool("exited", "/tmp/exited", "work", "codex")
 	inst.ID = "exited-session"
 	inst.CreatedAt = time.Now().Add(-2 * time.Second)
 	inst.Status = session.StatusRunning
 	setAttachReturnTestInstances(h, []*session.Instance{inst})
+
+	hooksDir := session.GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	hookPath := filepath.Join(hooksDir, inst.ID+".json")
+	hookBody := fmt.Sprintf(
+		`{"status":"running","session_id":"stale-session","event":"UserPromptSubmit","ts":%d}`,
+		time.Now().Unix(),
+	)
+	if err := os.WriteFile(hookPath, []byte(hookBody), 0o644); err != nil {
+		t.Fatalf("write stale hook: %v", err)
+	}
 
 	model, _ := h.Update(statusUpdateMsg{attachedSessionID: inst.ID})
 	home := model.(*Home)
@@ -2724,6 +2740,9 @@ func TestStatusUpdateMsg_ReconcilesAttachedSessionBeforeRender(t *testing.T) {
 	}
 	if got := home.getSessionRenderState(inst).status; got != session.StatusError {
 		t.Fatalf("render snapshot status = %q, want %q", got, session.StatusError)
+	}
+	if _, err := os.Stat(hookPath); !os.IsNotExist(err) {
+		t.Fatalf("stale hook file still exists or stat failed with unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
When I am exiting a session with "/q", agent-deck navigates to the list of sessions, but the session which I just closed, takes 2-3 seconds to be marked with "X". This PR addresses this.

- reconcile the just-attached session status synchronously when returning to the main UI
- clear stale hook fast-path state for that session before live tmux polling
- refresh delayed attach-return pane caches as a secondary repaint

## Tests
Manual test:
- Create new session, enter it, then close with "/q"
- agent-deck navigates to list of sessions, closed session is marked with "X"

Unit tests:
- rtk go test ./internal/ui