### PR TITLE
fix(git/setup): eliminate TOCTOU race in executable-bit dispatch

### DIFF
--- a/internal/git/bare_repo_test.go
+++ b/internal/git/bare_repo_test.go
@@ -207,7 +207,7 @@ func TestFindWorktreeSetupScript_BareRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := FindWorktreeSetupScript(projectRoot)
+	got, _ := FindWorktreeSetupScript(projectRoot)
 	if got != scriptPath {
 		t.Errorf("FindWorktreeSetupScript(%q) = %q, want %q", projectRoot, got, scriptPath)
 	}

--- a/internal/git/setup.go
+++ b/internal/git/setup.go
@@ -12,12 +12,14 @@ import (
 
 // FindWorktreeSetupScript returns the path to the worktree setup script
 // if one exists at <repoDir>/.agent-deck/worktree-setup.sh, or empty string.
-func FindWorktreeSetupScript(repoDir string) string {
+// The returned os.FileMode captures the file's permission bits at discovery
+// time, eliminating a TOCTOU race between finding and dispatching the script.
+func FindWorktreeSetupScript(repoDir string) (string, os.FileMode) {
 	p := filepath.Join(repoDir, ".agent-deck", "worktree-setup.sh")
-	if _, err := os.Stat(p); err == nil {
-		return p
+	if info, err := os.Stat(p); err == nil {
+		return p, info.Mode()
 	}
-	return ""
+	return "", 0
 }
 
 // RunWorktreeSetupScript executes the setup script with AGENT_DECK_REPO_ROOT
@@ -38,7 +40,7 @@ func FindWorktreeSetupScript(repoDir string) string {
 //
 // The session layer resolves the legacy 60s default before calling here;
 // callers that want bounded runs must pass a positive duration explicitly.
-func RunWorktreeSetupScript(scriptPath, repoDir, worktreePath string, stdout, stderr io.Writer, timeout time.Duration) error {
+func RunWorktreeSetupScript(scriptPath string, scriptMode os.FileMode, repoDir, worktreePath string, stdout, stderr io.Writer, timeout time.Duration) error {
 	var ctx context.Context
 	var cancel context.CancelFunc
 	if timeout > 0 {
@@ -48,7 +50,7 @@ func RunWorktreeSetupScript(scriptPath, repoDir, worktreePath string, stdout, st
 	}
 	defer cancel()
 
-	cmd := buildSetupCmd(ctx, scriptPath)
+	cmd := buildSetupCmd(ctx, scriptPath, scriptMode)
 	cmd.Dir = worktreePath
 	cmd.Env = append(os.Environ(),
 		"AGENT_DECK_REPO_ROOT="+repoDir,
@@ -72,8 +74,13 @@ func RunWorktreeSetupScript(scriptPath, repoDir, worktreePath string, stdout, st
 // buildSetupCmd picks how to invoke the setup script (#773). Executable
 // scripts run directly so the kernel honors their shebang line; legacy
 // non-executable scripts run via `sh -e <path>` for backwards compatibility.
-func buildSetupCmd(ctx context.Context, scriptPath string) *exec.Cmd {
-	if info, err := os.Stat(scriptPath); err == nil && info.Mode()&0o111 != 0 {
+//
+// The mode is passed from the caller (captured at discovery time) to avoid
+// a redundant os.Stat that is vulnerable to TOCTOU races — e.g. when
+// a concurrent `git rebase` on the main worktree momentarily removes the
+// file between FindWorktreeSetupScript and execution.
+func buildSetupCmd(ctx context.Context, scriptPath string, mode os.FileMode) *exec.Cmd {
+	if mode&0o111 != 0 {
 		return exec.CommandContext(ctx, scriptPath)
 	}
 	return exec.CommandContext(ctx, "sh", "-e", scriptPath)
@@ -95,14 +102,14 @@ func CreateWorktreeWithSetup(repoDir, worktreePath, branchName string, stdout, s
 		return nil, err
 	}
 
-	scriptPath := FindWorktreeSetupScript(repoDir)
+	scriptPath, scriptMode := FindWorktreeSetupScript(repoDir)
 	if scriptPath == "" {
 		return nil, nil
 	}
 
 	fmt.Fprintln(stderr, "Running worktree setup script...")
 	start := time.Now()
-	setupErr = RunWorktreeSetupScript(scriptPath, repoDir, worktreePath, stdout, stderr, setupTimeout)
+	setupErr = RunWorktreeSetupScript(scriptPath, scriptMode, repoDir, worktreePath, stdout, stderr, setupTimeout)
 	elapsed := time.Since(start).Round(100 * time.Millisecond)
 	if setupErr != nil {
 		fmt.Fprintf(stderr, "Worktree setup script failed after %s: %v\n", elapsed, setupErr)

--- a/internal/git/setup_shebang_test.go
+++ b/internal/git/setup_shebang_test.go
@@ -29,7 +29,7 @@ func TestRunWorktreeSetupScript_HonorsShebangWhenExecutable(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := RunWorktreeSetupScript(scriptPath, tmp, tmp, &stdout, &stderr, 5*time.Second)
+	err := RunWorktreeSetupScript(scriptPath, 0o755, tmp, tmp, &stdout, &stderr, 5*time.Second)
 	if err != nil {
 		t.Fatalf("expected success when shebang dispatches /bin/echo: %v\nstderr: %s", err, stderr.String())
 	}
@@ -54,7 +54,7 @@ func TestRunWorktreeSetupScript_FallsBackToShellWhenNotExecutable(t *testing.T) 
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := RunWorktreeSetupScript(scriptPath, tmp, tmp, &stdout, &stderr, 5*time.Second)
+	err := RunWorktreeSetupScript(scriptPath, 0o644, tmp, tmp, &stdout, &stderr, 5*time.Second)
 	if err != nil {
 		t.Fatalf("expected non-executable script to run via sh fallback: %v\nstderr: %s", err, stderr.String())
 	}

--- a/internal/git/setup_test.go
+++ b/internal/git/setup_test.go
@@ -13,7 +13,7 @@ import (
 func TestFindWorktreeSetupScript_NotPresent(t *testing.T) {
 	dir := t.TempDir()
 
-	result := FindWorktreeSetupScript(dir)
+	result, _ := FindWorktreeSetupScript(dir)
 	if result != "" {
 		t.Errorf("expected empty string, got %q", result)
 	}
@@ -32,9 +32,33 @@ func TestFindWorktreeSetupScript_Present(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := FindWorktreeSetupScript(dir)
+	result, mode := FindWorktreeSetupScript(dir)
 	if result != scriptPath {
 		t.Errorf("expected %q, got %q", scriptPath, result)
+	}
+	if mode&0o111 != 0 {
+		t.Errorf("expected non-executable mode, got %o", mode)
+	}
+}
+
+func TestFindWorktreeSetupScript_PresentExecutable(t *testing.T) {
+	dir := t.TempDir()
+
+	scriptDir := filepath.Join(dir, ".agent-deck")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(scriptDir, "worktree-setup.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/bash\necho hello\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, mode := FindWorktreeSetupScript(dir)
+	if result != scriptPath {
+		t.Errorf("expected %q, got %q", scriptPath, result)
+	}
+	if mode&0o111 == 0 {
+		t.Errorf("expected executable mode, got %o", mode)
 	}
 }
 
@@ -59,7 +83,7 @@ echo "copying done"
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := RunWorktreeSetupScript(scriptPath, repoDir, worktreeDir, &stdout, &stderr, 0)
+	err := RunWorktreeSetupScript(scriptPath, 0o644, repoDir, worktreeDir, &stdout, &stderr, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v (stderr: %s)", err, stderr.String())
 	}
@@ -92,7 +116,7 @@ exit 1
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr, 0)
+	err := RunWorktreeSetupScript(scriptPath, 0o644, t.TempDir(), worktreeDir, &stdout, &stderr, 0)
 	if err == nil {
 		t.Fatal("expected error from failing script")
 	}
@@ -113,7 +137,7 @@ sleep 300
 	}
 
 	var stdout, stderr bytes.Buffer
-	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr, 1*time.Second)
+	err := RunWorktreeSetupScript(scriptPath, 0o644, t.TempDir(), worktreeDir, &stdout, &stderr, 1*time.Second)
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}

--- a/internal/git/setup_timeout_arg_test.go
+++ b/internal/git/setup_timeout_arg_test.go
@@ -27,7 +27,7 @@ sleep 300
 	var stdout, stderr bytes.Buffer
 
 	start := time.Now()
-	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr, 1*time.Second)
+	err := RunWorktreeSetupScript(scriptPath, 0o644, t.TempDir(), worktreeDir, &stdout, &stderr, 1*time.Second)
 	elapsed := time.Since(start)
 
 	if err == nil {

--- a/internal/git/setup_unlimited_test.go
+++ b/internal/git/setup_unlimited_test.go
@@ -29,7 +29,7 @@ echo "done"
 
 	// timeout == 0 → unlimited (no context deadline).
 	start := time.Now()
-	err := RunWorktreeSetupScript(scriptPath, t.TempDir(), worktreeDir, &stdout, &stderr, 0)
+	err := RunWorktreeSetupScript(scriptPath, 0o644, t.TempDir(), worktreeDir, &stdout, &stderr, 0)
 	elapsed := time.Since(start)
 
 	if err != nil {


### PR DESCRIPTION
## Problem

`FindWorktreeSetupScript` and `buildSetupCmd` both call `os.Stat` on the same path independently. If the file's state changes between the two calls (e.g. a concurrent `git rebase` temporarily removing the file from the main worktree), `FindWorktreeSetupScript` succeeds but `buildSetupCmd` falls through to `sh -e`, ignoring the shebang line.

**Observed**: On WSL2 (Ubuntu 24.04, ext4), agent-deck v1.7.79 created a worktree while the main worktree was mid-rebase (`rebase (start): checkout origin/master` in reflog). The setup script's `#!/bin/bash` shebang was ignored and `sh -e` was used, causing `set -euo pipefail` to fail with:

```
/home/user/project/.agent-deck/worktree-setup.sh: 2: set: Illegal option -o pipefail
```

The file is `100755` in git and on disk — the race between the two independent `os.Stat` calls is the only explanation.

Debug log entry:
```json
{"time":"2026-05-05T10:05:51.890891494+02:00","level":"WARN","msg":"worktree_setup_script_failed","error":"worktree setup script failed: exit status 2","output":"Running worktree setup script...\n.../.agent-deck/worktree-setup.sh: 2: set: Illegal option -o pipefail\n"}
```

## Fix

Capture `os.FileMode` at discovery time in `FindWorktreeSetupScript` and thread it through `RunWorktreeSetupScript` → `buildSetupCmd`, removing the redundant stat.

## Breaking changes (internal only)

- `FindWorktreeSetupScript` now returns `(string, os.FileMode)` instead of `string`
- `RunWorktreeSetupScript` takes an additional `os.FileMode` parameter

Both are `internal/` functions — `CreateWorktreeWithSetup` (the public-facing API) is unchanged.

## Tests

All existing tests updated and passing (`go test ./internal/git/ -run "Setup|Shebang" -v -count=1`). Added `TestFindWorktreeSetupScript_PresentExecutable` to verify the mode is correctly captured.

## Environment

- Agent Deck v1.7.79
- WSL2, Ubuntu 24.04, kernel 6.6.87.2-microsoft-standard-WSL2
- ext4 filesystem, `core.filemode=true`