### PR TITLE
fix(worktree): expand ~ in path_template to home directory

### DIFF
--- a/internal/git/template.go
+++ b/internal/git/template.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -82,6 +83,17 @@ func resolveTemplate(template string, vars templateVars) string {
 		"{session-id}", vars.sessionID,
 	)
 	resolved := replacer.Replace(template)
+
+	// Expand ~ to the user's home directory.
+	if strings.HasPrefix(resolved, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			resolved = filepath.Join(home, resolved[2:])
+		}
+	} else if resolved == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			resolved = home
+		}
+	}
 
 	// Handle relative paths - resolve relative to repo root.
 	if !filepath.IsAbs(resolved) {

--- a/internal/git/template_test.go
+++ b/internal/git/template_test.go
@@ -1,12 +1,21 @@
 package git
 
 import (
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func mustUserHomeDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	return home
+}
 
 func TestSanitizeBranchForPath(t *testing.T) {
 	t.Parallel()
@@ -308,6 +317,17 @@ func TestResolveTemplate(t *testing.T) {
 				sessionID: "a1b2c3d4",
 			},
 			expected: "/tmp/feature",
+		},
+		{
+			name:     "tilde expands to home directory",
+			template: "~/.agent-deck/worktrees/{repo-name}/{branch}",
+			vars: templateVars{
+				branch:    "feature-branch",
+				repoName:  "my-project",
+				repoRoot:  "/Users/me/src/my-project",
+				sessionID: "a1b2c3d4",
+			},
+			expected: filepath.Join(mustUserHomeDir(), ".agent-deck/worktrees/my-project/feature-branch"),
 		},
 	}
 


### PR DESCRIPTION
## Summary

`path_template` in `[worktree]` config does not expand `~` to the user's home directory, unlike `default_location` which does. This causes worktrees to be created as relative paths from the project root, resulting in paths like `/home/user/project/~/.agent-deck/worktrees/...`.

This adds `~` expansion in `resolveTemplate` (consistent with `GenerateWorktreePath`) so that `path_template = "~/.agent-deck/worktrees/{repo-name}/{branch}"` resolves correctly.

## Test plan

- [x] Added test case for tilde expansion in `TestResolveTemplate`
- [x] All existing template tests continue to pass

🤖 Generated with Claude Code