### PR TITLE
fix(web,tmux): per-session window-size=largest + drop bridge resize-window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.81] - 2026-05-05
+
+Hotfix for a multi-client tmux size-negotiation bug that caused dot-filled void cells when the web UI and direct `tmux attach` clients were both connected to the same agent-deck session at different geometries.
+
+### Fixed
+
+- **Multi-client size mismatch ("dots in the window") between web UI and direct tmux clients.** Two contributing bugs combined: tmux's default `window-size latest` policy snapped the window to whichever client most recently sent input, and `(*tmuxPTYBridge).Resize` issued an explicit `tmux resize-window -x N -y M` on every browser FitAddon resize, which per `man tmux` implicitly flips the session option to `window-size=manual`. Together this dragged native attach clients (Ghostty, iTerm) to the web viewport's geometry and pinned them there. Fixed in two places: `internal/tmux/tmux.go` now sets `window-size=largest` (session) + `aggressive-resize=on` (window) per session at `Session.Start`, gated through the existing `[tmux] options` config-override mechanism so users can opt out; `internal/web/terminal_bridge.go` no longer issues `tmux resize-window` from `Resize` (the local `pty.Setsize` keeps xterm.js's grid correct), and the `-f ignore-size` flag was dropped from `tmuxAttachCommand` (no longer needed since the web client now participates in the `largest` arbitration alongside native clients). Smaller clients see clipped content rather than dragging the window. New integration test `TestSession_MultiClientSizePolicy_Integration` asserts both options are set after `Session.Start`. See tmux issue [#2594](https://github.com/tmux/tmux/issues/2594) for the upstream pattern.
+
 ## [1.7.80] - 2026-05-05
 
 WebUI overhaul Phase 1 + one small Claude-session UX fix.

--- a/internal/session/claude_hooks.go
+++ b/internal/session/claude_hooks.go
@@ -248,24 +248,6 @@ func hooksAlreadyInstalled(hooks map[string]json.RawMessage) bool {
 	return true
 }
 
-// eventHasAgentDeckHook checks if a hook event's matcher array contains our
-// hook command anywhere, regardless of Matcher or Async config. Kept for
-// callers that only need a presence check.
-func eventHasAgentDeckHook(raw json.RawMessage) bool {
-	var matchers []claudeHookMatcher
-	if err := json.Unmarshal(raw, &matchers); err != nil {
-		return false
-	}
-	for _, m := range matchers {
-		for _, h := range m.Hooks {
-			if strings.Contains(h.Command, agentDeckHookCommand) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // eventHasAgentDeckHookMatchingConfig checks both presence AND config match:
 // the agent-deck hook entry must live under a matcher block whose Matcher
 // field equals the expected value, and its Async flag must match.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1866,6 +1866,21 @@ func (s *Session) Start(command string) error {
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
 		"set", "-sq", "extended-keys", "on", ";",
 		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys")
+	// Multi-client size negotiation. Web's xterm.js connects via a tmux -C
+	// control client (controlpipe.go) at the same time as native `tmux attach`
+	// clients (Ghostty, iTerm). Default `window-size latest` makes the window
+	// flip to whichever client most recently sent input, so larger clients see
+	// dot-filled void cells and smaller clients clip. `largest` keeps the
+	// window sized to the biggest client; `aggressive-resize` only resizes
+	// windows that are actively viewed (avoids cross-window resize storms).
+	// See tmux(1) "window-size" / "aggressive-resize" and tmux issue #2594.
+	// Both are gated through OptionOverrides so users can opt out.
+	if _, ok := s.OptionOverrides["window-size"]; !ok {
+		startArgs = append(startArgs, ";", "set-option", "-t", s.Name, "window-size", "largest")
+	}
+	if _, ok := s.OptionOverrides["aggressive-resize"]; !ok {
+		startArgs = append(startArgs, ";", "set-window-option", "-t", s.Name, "aggressive-resize", "on")
+	}
 	_ = s.tmuxCmd(startArgs...).Run()
 
 	// Bind Ctrl+Q to detach at the tmux level as fallback for terminals where

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2449,6 +2449,34 @@ func TestSession_MouseMode_EnableMouseMode_Disabled_Integration(t *testing.T) {
 		"EnableMouseMode must respect SetMouse(false) and not re-enable mouse")
 }
 
+// TestSession_MultiClientSizePolicy_Integration verifies that on session
+// creation agent-deck pins window-size=largest (session option) and
+// aggressive-resize=on (window option). This is the fix for the dots-in-
+// window symptom that arose when web's xterm.js control client and a native
+// `tmux attach` client had different geometries — see tmux issue #2594.
+func TestSession_MultiClientSizePolicy_Integration(t *testing.T) {
+	if os.Getenv("AGENTDECK_TEST_PROFILE") == "" {
+		t.Skip("Skipping tmux integration test - no test profile")
+	}
+
+	s := NewSession("test-size-policy", t.TempDir())
+	s.InstanceID = "test-instance-size-policy"
+
+	err := s.Start("sleep 3600")
+	require.NoError(t, err)
+	defer func() { _ = s.Kill() }()
+
+	winSize, err := exec.Command("tmux", "show-options", "-t", s.Name, "-A", "-v", "window-size").Output()
+	require.NoError(t, err)
+	assert.Equal(t, "largest", strings.TrimSpace(string(winSize)),
+		"new sessions must pin window-size=largest so a smaller client cannot drag the window down (tmux #2594)")
+
+	aggResize, err := exec.Command("tmux", "show-options", "-w", "-t", s.Name+":0", "-A", "-v", "aggressive-resize").Output()
+	require.NoError(t, err)
+	assert.Equal(t, "on", strings.TrimSpace(string(aggResize)),
+		"new sessions must enable aggressive-resize so windows only resize when actively viewed")
+}
+
 // =============================================================================
 // Activity Monitoring Hook Tests (Task 3)
 // =============================================================================

--- a/internal/web/terminal_bridge.go
+++ b/internal/web/terminal_bridge.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -152,33 +151,26 @@ func (b *tmuxPTYBridge) Resize(cols, rows int) error {
 		return fmt.Errorf("bridge not initialized")
 	}
 
-	var firstErr error
-
-	// Step 1: Resize the local PTY master (per D-02: pty.Setsize first).
-	// This sends SIGWINCH to the tmux attach process. With ignore-size on the
-	// attach client, the tmux server will not auto-resize from this signal,
-	// but the PTY master's own TIOCGWINSZ is updated so xterm.js cell layout
-	// calculations are correct.
+	// Resize the local PTY master. This sends SIGWINCH to the tmux attach
+	// process. Because the attach client (see tmuxAttachCommand) is no longer
+	// flagged `-f ignore-size`, the tmux server now uses this client's PTY
+	// size as its declared geometry and re-arbitrates the window dimensions
+	// per the session's `window-size` policy (`largest` — set at Session.Start
+	// in internal/tmux/tmux.go). The previous `tmux resize-window` call here
+	// was removed because it implicitly flipped the session option to
+	// `window-size=manual` and pinned the window to the web viewport, which
+	// dragged native attached clients (Ghostty, iTerm) along with it. Letting
+	// tmux do the arbitration via `largest` keeps every client at the size of
+	// the biggest viewer; smaller clients see a clipped portion of the larger
+	// window content (no dot-filled void cells).
 	if err := pty.Setsize(b.ptmx, &pty.Winsize{
 		Rows: uint16(rows),
 		Cols: uint16(cols),
 	}); err != nil {
-		firstErr = fmt.Errorf("resize pty: %w", err)
+		return fmt.Errorf("resize pty: %w", err)
 	}
 
-	// Step 2: Tell the tmux server the new window dimensions (per D-01).
-	// Required because ignore-size prevents the server from adopting the
-	// attach client's PTY size automatically.
-	args := []string{
-		"resize-window", "-t", b.tmuxSession,
-		"-x", strconv.Itoa(cols),
-		"-y", strconv.Itoa(rows),
-	}
-	if output, err := tmuxCommand(b.tmuxSocketName, args...).CombinedOutput(); err != nil && firstErr == nil {
-		firstErr = fmt.Errorf("tmux resize-window: %w (output: %s)", err, strings.TrimSpace(string(output)))
-	}
-
-	return firstErr
+	return nil
 }
 
 func (b *tmuxPTYBridge) Close() {
@@ -259,8 +251,15 @@ func tmuxCommand(socketName string, args ...string) *exec.Cmd {
 }
 
 func tmuxAttachCommand(sessionName, socketName string) *exec.Cmd {
-	// Keep this web client from influencing other attached client sizes (for example, the local TUI).
-	return tmuxCommand(socketName, "attach-session", "-f", "ignore-size", "-t", sessionName)
+	// Web's attach is now a normal client whose PTY size participates in tmux's
+	// `window-size=largest` arbitration (set at Session.Start). Previously we
+	// passed `-f ignore-size` together with a manual `tmux resize-window` call
+	// in (*tmuxPTYBridge).Resize; the manual resize-window flipped the session
+	// option to `window-size=manual` and pinned the window to the web viewport
+	// for ALL attached clients (Ghostty, iTerm) — the dots-in-window symptom.
+	// With largest in effect, every client sees content sized to the biggest
+	// viewer; smaller clients see a clipped portion rather than dot-filled void.
+	return tmuxCommand(socketName, "attach-session", "-t", sessionName)
 }
 
 func tmuxSocketFromEnv() (string, bool) {

--- a/internal/web/terminal_bridge_integration_test.go
+++ b/internal/web/terminal_bridge_integration_test.go
@@ -68,7 +68,14 @@ func TestTmuxPTYBridgeResize(t *testing.T) {
 		t.Fatalf("failed to send resize message: %v", err)
 	}
 
-	// Poll for up to 2 seconds to handle async tmux propagation.
+	// The web bridge no longer issues a `tmux resize-window -x N -y M` call
+	// (that flipped session window-size to manual and dragged native clients —
+	// the dots-in-window bug). Instead the bridge only Setsizes the local PTY
+	// to the requested cols x rows, and tmux's window-size policy arbitrates
+	// across all attached clients. With one attach client at PTY 120x40 and
+	// tmux's default 1-row status bar, the resulting window content size is
+	// 120x39 (rows are reduced by the status bar height).
+	const wantSize = "120x39"
 	var got string
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
@@ -77,10 +84,10 @@ func TestTmuxPTYBridgeResize(t *testing.T) {
 			t.Fatalf("tmux display-message failed: %v", err)
 		}
 		got = strings.TrimSpace(string(out))
-		if got == "120x40" {
+		if got == wantSize {
 			return // PASS
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	t.Fatalf("tmux window size after Resize: got %q, want %q", got, "120x40")
+	t.Fatalf("tmux window size after Resize: got %q, want %q", got, wantSize)
 }

--- a/internal/web/terminal_bridge_test.go
+++ b/internal/web/terminal_bridge_test.go
@@ -6,12 +6,21 @@ import (
 	"testing"
 )
 
-func TestTmuxAttachCommandUsesIgnoreSizeFlag(t *testing.T) {
+// TestTmuxAttachCommand_NoIgnoreSize: the web's tmux attach must NOT pass
+// `-f ignore-size`. Earlier the bridge combined ignore-size with a manual
+// `tmux resize-window` call (since reverted) which had the side effect of
+// flipping the session option to `window-size=manual`, dragging the window
+// for ALL attached clients (Ghostty, iTerm) — the dots-in-window bug.
+// With ignore-size removed and resize-window dropped, the web client
+// participates in tmux's `window-size=largest` arbitration set at
+// Session.Start (internal/tmux/tmux.go), so every client sees content sized
+// to the biggest viewer.
+func TestTmuxAttachCommand_NoIgnoreSize(t *testing.T) {
 	t.Setenv("TMUX", "")
 
 	cmd := tmuxAttachCommand("sess-1", "")
 
-	wantArgs := []string{"tmux", "attach-session", "-f", "ignore-size", "-t", "sess-1"}
+	wantArgs := []string{"tmux", "attach-session", "-t", "sess-1"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("unexpected args: got %v want %v", cmd.Args, wantArgs)
 	}
@@ -22,7 +31,7 @@ func TestTmuxAttachCommandUsesSocketFromTMUXEnv(t *testing.T) {
 
 	cmd := tmuxAttachCommand("sess-2", "")
 
-	wantArgs := []string{"tmux", "-S", "/tmp/tmux-test.sock", "attach-session", "-f", "ignore-size", "-t", "sess-2"}
+	wantArgs := []string{"tmux", "-S", "/tmp/tmux-test.sock", "attach-session", "-t", "sess-2"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("unexpected args with TMUX env: got %v want %v", cmd.Args, wantArgs)
 	}
@@ -47,7 +56,7 @@ func TestTmuxAttachCommand_SocketNameOverridesEnv(t *testing.T) {
 
 	cmd := tmuxAttachCommand("agentdeck-foo", "agent-deck")
 
-	wantArgs := []string{"tmux", "-L", "agent-deck", "attach-session", "-f", "ignore-size", "-t", "agentdeck-foo"}
+	wantArgs := []string{"tmux", "-L", "agent-deck", "attach-session", "-t", "agentdeck-foo"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("socket name must take precedence over $TMUX env\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}
@@ -69,7 +78,7 @@ func TestTmuxAttachCommand_WhitespaceSocketNameFallsBackToEnv(t *testing.T) {
 
 	cmd := tmuxAttachCommand("sess-3", "   \t")
 
-	wantArgs := []string{"tmux", "-S", "/tmp/tmux-test.sock", "attach-session", "-f", "ignore-size", "-t", "sess-3"}
+	wantArgs := []string{"tmux", "-S", "/tmp/tmux-test.sock", "attach-session", "-t", "sess-3"}
 	if !reflect.DeepEqual(cmd.Args, wantArgs) {
 		t.Fatalf("whitespace-only socket name must fall through to legacy TMUX env\n got:  %v\n want: %v", cmd.Args, wantArgs)
 	}


### PR DESCRIPTION
## Summary

Hotfix for the multi-client tmux size-mismatch bug ("dots in the window") that surfaced when the web UI and direct \`tmux attach\` clients (Ghostty, iTerm) connected to the same agent-deck session at different geometries.

Two contributing bugs combined:

1. tmux's default \`window-size latest\` policy snapped the window to whichever client most recently sent input.
2. \`(*tmuxPTYBridge).Resize\` issued an explicit \`tmux resize-window -x N -y M\` on every browser FitAddon resize. Per \`man tmux\`, \`resize-window\` with explicit \`-x/-y\` implicitly sets the session's \`window-size\` option to \`manual\`, defeating both the \`largest\` policy and the \`-f ignore-size\` flag the bridge already carried. Net effect: every browser resize pinned the window to the web's viewport, dragging native attach clients to that geometry and producing dot-filled void cells in larger clients (or clipping in smaller ones).

## Fix

**\`internal/tmux/tmux.go\`** — set \`window-size=largest\` (session) and \`aggressive-resize=on\` (window) per session at \`Session.Start\`. Both gated through the existing \`OptionOverrides\` mechanism so users with \`[tmux] options\` in \`config.toml\` retain control.

**\`internal/web/terminal_bridge.go\`** — drop \`tmux resize-window\` from \`Resize\` (which silently flipped \`window-size=manual\`). The local \`pty.Setsize\` keeps xterm.js's grid correct. Drop \`-f ignore-size\` from \`tmuxAttachCommand\` (no longer needed; the web client now participates in the \`largest\` arbitration alongside native clients). Smaller clients see clipped content rather than dragging the window.

**\`internal/session/claude_hooks.go\`** — remove the dead \`eventHasAgentDeckHook\` function flagged by golangci-lint on every push. Replaced by \`eventHasAgentDeckHookMatchingConfig\`, no callers found.

## Test plan

- [x] New integration test \`TestSession_MultiClientSizePolicy_Integration\` asserts \`window-size=largest\` and \`aggressive-resize=on\` after \`Session.Start\`
- [x] Updated \`TestTmuxAttachCommand_NoIgnoreSize\` (renamed from \`TestTmuxAttachCommandUsesIgnoreSizeFlag\`) verifies the attach argv no longer carries \`-f ignore-size\`
- [x] \`TestTmuxPTYBridgeResize\` updated to expect tmux-arbitrated geometry instead of forced size
- [x] All \`internal/tmux\` and \`internal/web\` tests pass (one pre-existing failure \`TestSession_SetsUpActivityMonitoring\` confirmed on \`v1.7.80\` itself, unrelated)
- [x] \`go test -race -count=1 ./...\` passes (74 s)
- [x] \`golangci-lint run\` clean
- [x] \`go build\` clean
- [x] Empirically verified on a live session: 4 consecutive web resizes through the WebSocket bridge keep \`window-size=largest\` and let the window grow to the largest of all attached clients (vs. flipping to \`manual\` on first resize before the patch)

See \`tmux\` issue [tmux/tmux#2594](https://github.com/tmux/tmux/issues/2594) for the upstream pattern.

## Known follow-up (out of scope for this hotfix)

Status divergence between CLI (\`agent-deck list --json\`) and web (\`/api/sessions\`): \`waiting\` status is missing in web responses (sessions in \`waiting\` state are reported as \`error\` in the web). The existing \`TestParity_WebActionMatchesDirectMutator\` was designed to catch this class of drift but only fires lifecycle actions through HTTP — \`waiting\` is a runtime-derived state from activity timing that never surfaces in the synthetic test path. To be filed as a follow-up issue with a regression test that triggers the timing-derived \`waiting\` state.