### PR TITLE
chore(release): v1.7.81

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -36,7 +36,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.7.80" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.7.81" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (


### PR DESCRIPTION
Release PR for v1.7.81 hotfix.

Includes:
- #866 fix(web,tmux): per-session window-size=largest + drop bridge resize-window — eliminates dot-filled void cells between web UI and direct tmux clients at different geometries

CHANGELOG entry added in #866. This PR bumps the local Version constant to 1.7.81.