### PR TITLE
fix(test): TestTmuxPTYBridgeResize sets window-size=largest on test session

### DIFF
--- a/internal/web/terminal_bridge_integration_test.go
+++ b/internal/web/terminal_bridge_integration_test.go
@@ -24,6 +24,14 @@ func TestTmuxPTYBridgeResize(t *testing.T) {
 		_ = exec.Command("tmux", "kill-session", "-t", sessionName).Run()
 	}()
 
+	// Match what Session.Start does in production — without these options,
+	// tmux defaults to window-size=latest which doesn't reliably re-arbitrate
+	// to the bridge's attach client size on CI's headless tmux. Production
+	// session creation always sets these (see internal/tmux/tmux.go); the
+	// test's manual `tmux new-session` bypassed that path.
+	_ = exec.Command("tmux", "set-option", "-t", sessionName, "window-size", "largest").Run()
+	_ = exec.Command("tmux", "set-window-option", "-t", sessionName, "aggressive-resize", "on").Run()
+
 	srv := NewServer(Config{
 		ListenAddr: "127.0.0.1:0",
 		Profile:    "work",


### PR DESCRIPTION
Fixes the CI test failure that blocked v1.7.81 release. The test created its tmux session manually without the window-size=largest option that production code sets at Session.Start, causing tmux's default 'latest' policy to behave differently on CI's headless environment.

Surfaced when v1.7.81 release pipeline failed: https://github.com/asheshgoplani/agent-deck/actions/runs/25395639116

Verified locally: `go test -run TestTmuxPTYBridgeResize ./internal/web/` passes.