### PR TITLE
fix(ui): make % filter exclude-set configurable + highlight active-filter hint

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1455,6 +1455,43 @@ type DisplaySettings struct {
 	// ActiveFilterLabel sets the label shown on the filter pill when the active
 	// filter is engaged. Default: "Open". Examples: "Active", "Live", "Open".
 	ActiveFilterLabel string `toml:"active_filter_label"`
+
+	// ActiveFilterExcludes is the list of session statuses that the % "Open"
+	// filter hides. Default: ["error", "stopped"] — matches the original
+	// upstream behavior. Set to ["error"] to keep stopped/closed sessions
+	// visible while still hiding errors, or extend with "idle" for an
+	// aggressive "show only running/waiting" definition. Unknown statuses
+	// are dropped silently; if all entries are unknown the default applies.
+	// Valid statuses: "running", "waiting", "idle", "error", "starting",
+	// "stopped".
+	ActiveFilterExcludes []string `toml:"active_filter_excludes"`
+}
+
+// GetActiveFilterExcludes returns the resolved set of statuses the % filter
+// should hide. Default {error, stopped} matches the original upstream
+// hardcoded behavior; opt into ["error"] to keep stopped sessions visible.
+// Unknown values are dropped; an empty resolved set falls back to the default.
+func (d DisplaySettings) GetActiveFilterExcludes() map[Status]bool {
+	defaults := func() map[Status]bool {
+		return map[Status]bool{StatusError: true, StatusStopped: true}
+	}
+	if len(d.ActiveFilterExcludes) == 0 {
+		return defaults()
+	}
+	valid := map[Status]bool{
+		StatusRunning: true, StatusWaiting: true, StatusIdle: true,
+		StatusError: true, StatusStarting: true, StatusStopped: true,
+	}
+	out := make(map[Status]bool, len(d.ActiveFilterExcludes))
+	for _, s := range d.ActiveFilterExcludes {
+		if st := Status(s); valid[st] {
+			out[st] = true
+		}
+	}
+	if len(out) == 0 {
+		return defaults()
+	}
+	return out
 }
 
 // ValidDefaultFilters lists acceptable values for DefaultFilter.

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -1900,3 +1900,77 @@ transition_events = false
 		t.Error("GetTransitionEventsEnabled() should return false when explicitly false")
 	}
 }
+
+// TestGetActiveFilterExcludes verifies the % filter's exclude-set resolution:
+// the default ({error, stopped}) matches the original upstream hardcoded
+// behavior so existing users see no behavior change unless they opt in.
+// Setting active_filter_excludes = ["error"] is the documented way to keep
+// stopped/closed sessions visible — the regression fix for users who found
+// the upstream default too aggressive.
+func TestGetActiveFilterExcludes(t *testing.T) {
+	defaultSet := map[Status]bool{StatusError: true, StatusStopped: true}
+
+	tests := []struct {
+		name string
+		in   []string
+		want map[Status]bool
+	}{
+		{"nil falls back to default (error + stopped)", nil, defaultSet},
+		{"empty list falls back to default", []string{}, defaultSet},
+		{"opt-in: error only (keeps stopped visible)",
+			[]string{"error"},
+			map[Status]bool{StatusError: true}},
+		{"all valid: error + stopped (matches default explicitly)",
+			[]string{"error", "stopped"},
+			map[Status]bool{StatusError: true, StatusStopped: true}},
+		{"all valid: aggressive exclude includes idle",
+			[]string{"error", "stopped", "idle"},
+			map[Status]bool{StatusError: true, StatusStopped: true, StatusIdle: true}},
+		{"unknown values dropped silently, valid kept",
+			[]string{"error", "bogus"},
+			map[Status]bool{StatusError: true}},
+		{"all unknown falls back to default",
+			[]string{"bogus", "garbage"},
+			defaultSet},
+		{"duplicates collapse",
+			[]string{"error", "error", "stopped"},
+			map[Status]bool{StatusError: true, StatusStopped: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := DisplaySettings{ActiveFilterExcludes: tt.in}
+			got := d.GetActiveFilterExcludes()
+			if len(got) != len(tt.want) {
+				t.Fatalf("GetActiveFilterExcludes(%v) size = %d, want %d (got=%v)",
+					tt.in, len(got), len(tt.want), got)
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("GetActiveFilterExcludes(%v)[%q] = %v, want %v",
+						tt.in, k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+// TestGetActiveFilterExcludes_TomlRoundtrip verifies the TOML tag wires up
+// correctly and survives marshal/unmarshal.
+func TestGetActiveFilterExcludes_TomlRoundtrip(t *testing.T) {
+	const cfg = `
+[display]
+active_filter_excludes = ["error", "stopped"]
+`
+	var c UserConfig
+	if _, err := toml.Decode(cfg, &c); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := c.Display.GetActiveFilterExcludes()
+	if !got[StatusError] || !got[StatusStopped] {
+		t.Errorf("expected {error,stopped} excluded, got %v", got)
+	}
+	if got[StatusRunning] {
+		t.Errorf("running should not be excluded, got %v", got)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9251,8 +9251,7 @@ func (h *Home) renderFilterBar() string {
 		}
 	}
 
-	// Hint for keyboard shortcuts (cached — content is static)
-	hint := cachedFilterBarHint()
+	hint := h.renderFilterBarHint()
 
 	// Join pills with spaces (leading space replaces Padding)
 	filterRow := " " + strings.Join(pills, " ") + hint
@@ -13991,16 +13990,28 @@ func (h *Home) matchesStatusFilter(filter, status session.Status) bool {
 	return status == filter
 }
 
-// cachedFilterBarHint returns the static filter bar hint string.
-// Cached after first call since the content never changes after theme init.
-var _cachedFilterBarHint string
+// renderFilterBarHint renders the filter-bar keyboard-shortcut hint with the
+// shortcut character of the currently-engaged filter highlighted (subtle shade
+// brighter than the surrounding faint hint text).
+func (h *Home) renderFilterBarHint() string {
+	dim := lipgloss.NewStyle().Foreground(ColorComment).Faint(true)
+	hi := lipgloss.NewStyle().Foreground(ColorTextDim) // same hue, no Faint
 
-func cachedFilterBarHint() string {
-	if _cachedFilterBarHint == "" {
-		_cachedFilterBarHint = lipgloss.NewStyle().
-			Foreground(ColorComment).
-			Faint(true).
-			Render("  !@#$ filter • 0 all • " + FilterKeyActive + " open")
+	mark := func(c string, on bool) string {
+		if on {
+			return hi.Render(c)
+		}
+		return dim.Render(c)
 	}
-	return _cachedFilterBarHint
+
+	return dim.Render("  ") +
+		mark("!", h.statusFilter == session.StatusRunning) +
+		mark("@", h.statusFilter == session.StatusWaiting) +
+		mark("#", h.statusFilter == session.StatusIdle) +
+		mark("$", h.statusFilter == session.StatusError) +
+		dim.Render(" filter • ") +
+		mark("0", h.statusFilter == "") +
+		dim.Render(" all • ") +
+		mark(FilterKeyActive, h.statusFilter == FilterModeActive) +
+		dim.Render(" open")
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -130,8 +130,10 @@ const (
 // (shows all sessions except error/stopped). Change this constant to rebind.
 const FilterKeyActive = "%"
 
-// FilterModeActive is the filter value for "open" sessions: excludes error/stopped.
-// This is NOT a session status (never assigned to a session), just a filter mode.
+// FilterModeActive is the filter value for "open" sessions: excludes the
+// configured set of statuses (see DisplaySettings.ActiveFilterExcludes; default
+// {error}). This is NOT a session status (never assigned to a session), just a
+// filter mode.
 const FilterModeActive session.Status = "active"
 
 // Mouse interaction thresholds
@@ -384,9 +386,10 @@ type Home struct {
 
 	// Full repaint mode: issue tea.ClearScreen every tick to avoid
 	// incremental redraw drift in terminals with unicode grapheme widths
-	fullRepaint       bool
-	defaultFilter     string // from config.toml [display] default_filter
-	activeFilterLabel string // from config.toml [display] active_filter_label
+	fullRepaint          bool
+	defaultFilter        string                  // from config.toml [display] default_filter
+	activeFilterLabel    string                  // from config.toml [display] active_filter_label
+	activeFilterExcludes map[session.Status]bool // from config.toml [display] active_filter_excludes; default {error}
 
 	// Performance observability (debug mode only, zero cost when off)
 	debugMode          bool         // true when AGENTDECK_DEBUG=1, enables perf overlay
@@ -797,10 +800,12 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.fullRepaint = cfg.Display.GetFullRepaint()
 		h.defaultFilter = cfg.Display.GetDefaultFilter()
 		h.activeFilterLabel = cfg.Display.ActiveFilterLabel
+		h.activeFilterExcludes = cfg.Display.GetActiveFilterExcludes()
 		h.sysStatsConfig = cfg.SystemStats
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(cfg, actualProfile)
 	} else {
 		h.fullRepaint = (session.DisplaySettings{}).GetFullRepaint()
+		h.activeFilterExcludes = (session.DisplaySettings{}).GetActiveFilterExcludes()
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(nil, actualProfile)
 	}
 
@@ -1391,7 +1396,7 @@ func (h *Home) rebuildFlatItems() {
 		groupsWithMatches := make(map[string]bool)
 		for _, item := range allItems {
 			if item.Type == session.ItemTypeSession && item.Session != nil {
-				if matchesStatusFilter(h.statusFilter, item.Session.Status) {
+				if h.matchesStatusFilter(h.statusFilter, item.Session.Status) {
 					// Mark this session's group and all parent groups as having matches
 					groupsWithMatches[item.Path] = true
 					// Also mark parent paths
@@ -1414,7 +1419,7 @@ func (h *Home) rebuildFlatItems() {
 				}
 			} else if item.Type == session.ItemTypeSession && item.Session != nil {
 				// Keep session if it matches the filter
-				if matchesStatusFilter(h.statusFilter, item.Session.Status) {
+				if h.matchesStatusFilter(h.statusFilter, item.Session.Status) {
 					filtered = append(filtered, item)
 				}
 			}
@@ -9174,7 +9179,6 @@ func (h *Home) renderFilterBar() string {
 		pills = append(pills, inactivePillStyle.Render("All")+allPad)
 	}
 
-	// Running pill (green when active, dim if 0)
 	runningLabel := fmt.Sprintf("● %d", running)
 	if h.statusFilter == session.StatusRunning {
 		pills = append(pills, lipgloss.NewStyle().
@@ -9182,6 +9186,8 @@ func (h *Home) renderFilterBar() string {
 			Background(ColorGreen).
 			Bold(true).
 			Padding(0, 1).Render(runningLabel))
+	} else if isActive && h.activeFilterExcludes[session.StatusRunning] {
+		pills = append(pills, dimPillStyle.Render(runningLabel))
 	} else if running > 0 {
 		pills = append(pills, lipgloss.NewStyle().
 			Foreground(ColorGreen).
@@ -9191,7 +9197,6 @@ func (h *Home) renderFilterBar() string {
 		pills = append(pills, dimPillStyle.Render(runningLabel))
 	}
 
-	// Waiting pill (yellow when active)
 	waitingLabel := fmt.Sprintf("◐ %d", waiting)
 	if h.statusFilter == session.StatusWaiting {
 		pills = append(pills, lipgloss.NewStyle().
@@ -9199,6 +9204,8 @@ func (h *Home) renderFilterBar() string {
 			Background(ColorYellow).
 			Bold(true).
 			Padding(0, 1).Render(waitingLabel))
+	} else if isActive && h.activeFilterExcludes[session.StatusWaiting] {
+		pills = append(pills, dimPillStyle.Render(waitingLabel))
 	} else if waiting > 0 {
 		pills = append(pills, lipgloss.NewStyle().
 			Foreground(ColorYellow).
@@ -9208,7 +9215,6 @@ func (h *Home) renderFilterBar() string {
 		pills = append(pills, dimPillStyle.Render(waitingLabel))
 	}
 
-	// Idle pill (gray when selected, dimmed when active filter hides it)
 	idleLabel := fmt.Sprintf("○ %d", idle)
 	if h.statusFilter == session.StatusIdle {
 		pills = append(pills, lipgloss.NewStyle().
@@ -9216,6 +9222,8 @@ func (h *Home) renderFilterBar() string {
 			Background(ColorTextDim).
 			Bold(true).
 			Padding(0, 1).Render(idleLabel))
+	} else if isActive && h.activeFilterExcludes[session.StatusIdle] {
+		pills = append(pills, dimPillStyle.Render(idleLabel))
 	} else if idle == 0 {
 		pills = append(pills, dimPillStyle.Render(idleLabel))
 	} else {
@@ -9225,7 +9233,6 @@ func (h *Home) renderFilterBar() string {
 			Padding(0, 1).Render(idleLabel))
 	}
 
-	// Error pill (red when selected, dimmed when active filter hides it)
 	if errored > 0 || h.statusFilter == session.StatusError {
 		errorLabel := fmt.Sprintf("✕ %d", errored)
 		if h.statusFilter == session.StatusError {
@@ -9234,7 +9241,7 @@ func (h *Home) renderFilterBar() string {
 				Background(ColorRed).
 				Bold(true).
 				Padding(0, 1).Render(errorLabel))
-		} else if isActive {
+		} else if isActive && h.activeFilterExcludes[session.StatusError] {
 			pills = append(pills, dimPillStyle.Render(errorLabel))
 		} else if errored > 0 {
 			pills = append(pills, lipgloss.NewStyle().
@@ -13974,12 +13981,12 @@ func renderBar(percent float64, width int) string {
 	return filledStyle.Render(strings.Repeat("█", filled)) + emptyStyle.Render(strings.Repeat("░", empty))
 }
 
-// matchesStatusFilter returns true if the given session status matches the
-// current filter. For FilterModeActive, everything except error/stopped matches
-// (including StatusStarting — sessions being launched count as active).
-func matchesStatusFilter(filter, status session.Status) bool {
+// matchesStatusFilter reports whether status passes the current filter.
+// FilterModeActive consults [display].active_filter_excludes; concrete
+// filters require exact match.
+func (h *Home) matchesStatusFilter(filter, status session.Status) bool {
 	if filter == FilterModeActive {
-		return status != session.StatusError && status != session.StatusStopped
+		return !h.activeFilterExcludes[status]
 	}
 	return status == filter
 }

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2487,29 +2487,57 @@ func TestRebuildFlatItemsKeepsValidStatusFilter(t *testing.T) {
 }
 
 func TestMatchesStatusFilter(t *testing.T) {
+	// Default matches upstream's original hardcoded behavior so existing
+	// users see no change unless they opt into a narrower exclude-set.
+	defaultExcludes := map[session.Status]bool{
+		session.StatusError:   true,
+		session.StatusStopped: true,
+	}
+	errorOnly := map[session.Status]bool{session.StatusError: true}
+	excludeNothing := map[session.Status]bool{}
+
 	tests := []struct {
-		filter session.Status
-		status session.Status
-		want   bool
+		name     string
+		filter   session.Status
+		status   session.Status
+		excludes map[session.Status]bool
+		want     bool
 	}{
-		// Active filter: excludes error and stopped only
-		{FilterModeActive, session.StatusRunning, true},
-		{FilterModeActive, session.StatusWaiting, true},
-		{FilterModeActive, session.StatusIdle, true},
-		{FilterModeActive, session.StatusStarting, true},
-		{FilterModeActive, session.StatusError, false},
-		{FilterModeActive, session.StatusStopped, false},
-		// Concrete status filters: exact match
-		{session.StatusRunning, session.StatusRunning, true},
-		{session.StatusRunning, session.StatusWaiting, false},
-		{session.StatusError, session.StatusError, true},
-		{session.StatusError, session.StatusStopped, false},
+		// Default exclude-set ({error, stopped}): % hides both, matching
+		// upstream's prior hardcoded behavior exactly.
+		{"default-running", FilterModeActive, session.StatusRunning, defaultExcludes, true},
+		{"default-waiting", FilterModeActive, session.StatusWaiting, defaultExcludes, true},
+		{"default-idle", FilterModeActive, session.StatusIdle, defaultExcludes, true},
+		{"default-starting", FilterModeActive, session.StatusStarting, defaultExcludes, true},
+		{"default-error-hidden", FilterModeActive, session.StatusError, defaultExcludes, false},
+		{"default-stopped-hidden", FilterModeActive, session.StatusStopped, defaultExcludes, false},
+
+		// Opt-in via active_filter_excludes = ["error"]: closed/stopped
+		// sessions remain visible — the regression fix for users who
+		// found the upstream default too aggressive.
+		{"erronly-stopped-visible", FilterModeActive, session.StatusStopped, errorOnly, true},
+		{"erronly-error-hidden", FilterModeActive, session.StatusError, errorOnly, false},
+		{"erronly-running-visible", FilterModeActive, session.StatusRunning, errorOnly, true},
+
+		// Empty exclude-set: % filter shows everything (degenerate but valid).
+		{"empty-error-visible", FilterModeActive, session.StatusError, excludeNothing, true},
+		{"empty-stopped-visible", FilterModeActive, session.StatusStopped, excludeNothing, true},
+
+		// Concrete status filters ignore the exclude-set entirely.
+		{"concrete-running-match", session.StatusRunning, session.StatusRunning, defaultExcludes, true},
+		{"concrete-running-no-match", session.StatusRunning, session.StatusWaiting, defaultExcludes, false},
+		{"concrete-error-match", session.StatusError, session.StatusError, defaultExcludes, true},
+		{"concrete-error-no-stopped", session.StatusError, session.StatusStopped, defaultExcludes, false},
 	}
 	for _, tt := range tests {
-		got := matchesStatusFilter(tt.filter, tt.status)
-		if got != tt.want {
-			t.Errorf("matchesStatusFilter(%q, %q) = %v, want %v", tt.filter, tt.status, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Home{activeFilterExcludes: tt.excludes}
+			got := h.matchesStatusFilter(tt.filter, tt.status)
+			if got != tt.want {
+				t.Errorf("matchesStatusFilter(%q, %q, %v) = %v, want %v",
+					tt.filter, tt.status, tt.excludes, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -203,16 +203,18 @@ Rendering and display settings.
 
 ```toml
 [display]
-full_repaint = false              # Force full screen clear every render (for terminals with grapheme issues)
-default_filter = "active"         # Initial status filter: "", "active", "running", "waiting", "idle", "error"
-active_filter_label = "Open"      # Label for the active filter pill (default: "Open")
+full_repaint = false                              # Force full screen clear every render (for terminals with grapheme issues)
+default_filter = "active"                         # Initial status filter: "", "active", "running", "waiting", "idle", "error"
+active_filter_label = "Open"                      # Label for the active filter pill (default: "Open")
+active_filter_excludes = ["error", "stopped"]     # Statuses the % "Open" filter hides (default: ["error", "stopped"])
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `full_repaint` | bool | `false` | Force full redraws (fix for Ghostty 1.3+ drift). Also via `AGENTDECK_REPAINT=full`. |
-| `default_filter` | string | `""` | Status filter applied on TUI startup. `"active"` hides error/stopped sessions. Auto-clears if no sessions match. |
+| `default_filter` | string | `""` | Status filter applied on TUI startup. `"active"` engages the configurable Open filter. Auto-clears if no sessions match. |
 | `active_filter_label` | string | `"Open"` | Label shown on the filter pill when active filter is engaged (e.g., "Active", "Live", "Open"). |
+| `active_filter_excludes` | []string | `["error", "stopped"]` | Statuses hidden when the `%` "Open" filter is engaged. Default matches the original hardcoded behavior. Valid values: `running`, `waiting`, `idle`, `error`, `starting`, `stopped`. Unknown entries are dropped silently; if the resulting list is empty the default applies. **Set to `["error"]`** to keep stopped/closed sessions visible while still hiding errors — fixes the over-broad "Open" semantics where closed sessions disappeared from view. Extend with `idle` for an aggressive "show only running/waiting" definition of open. |
 
 ## [global_search] Section
 


### PR DESCRIPTION
## Summary

Two related TUI fixes for the `%` "Open" filter introduced in #491 / #516:

This allows the original functionality, but leaves the default as currently set (filtering stopped and errors).

1. **Make the exclude-set configurable** via `[display].active_filter_excludes`. Default `["error", "stopped"]` preserves the original upstream behavior — zero behavior change without config. Set to `["error"]` to keep stopped/closed sessions visible while still hiding errors. Unknown statuses are dropped silently; an empty resolved list falls back to the default.

To make this more clear when filtered (using % or any of the other ones)

2. **Highlight the active-filter shortcut character** in the filter-bar hint. The hint (`  !@#$ filter • 0 all • % open`) previously rendered as a static cached faint string with no feedback about which filter was engaged. Now the corresponding shortcut character (`!@#$`, `0`, or `%`) renders in `ColorTextDim` without the `Faint` attribute when its filter is active — same hue, subtle shade lift, the most muted visual difference available in the existing palette.

The pill bar's per-pill dim state also now consults the same exclude-set instead of just the abstract `isActive` flag, so configuring an unconventional set (e.g. including idle) renders consistently with what the filter actually hides.

## How to use

```toml
[display]
active_filter_excludes = ["error"]   # keep stopped/closed sessions visible
```
##TUI Filtering Highlights
<img width="866" height="292" alt="Screenshot 2026-05-05 235937" src="https://github.com/user-attachments/assets/1b8b0576-48f9-48dc-b1ef-319c6c500944" />


## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/ui/... ./internal/session/...` clean
- [x] `go fmt ./...` no changes
- [x] `go test ./internal/ui/ -run TestMatchesStatusFilter -race` — 15 subtests pass (default, opt-in, empty, and concrete cases)
- [x] `go test ./internal/session/ -run TestGetActiveFilterExcludes -race` — 10 subtests pass, including TOML round-trip
- [x] `go test -tags eval_smoke ./tests/eval/...` — eval-smoke mandate paths trigger; PASS
- [x] `go test ./internal/session/ -run TestPersistence_ -race` — PASS (except `TmuxDiesWithoutUserScope`, env-dependent failure pre-existing on plain `main`)
- [x] Visual: relaunched `./build/agent-deck`, verified `%` toggle, hint highlight, default behavior matches v1.7.81 with no config
