### PR TITLE
fix(quickwins): bridge.py Python 3.8 compat (#864) + brew install regression (#873)

### DIFF
--- a/.github/workflows/homebrew-verify.yml
+++ b/.github/workflows/homebrew-verify.yml
@@ -1,0 +1,29 @@
+name: homebrew-verify
+
+# Regression gate for #873 - users on Mac/Linux/WSL run
+# `brew install asheshgoplani/tap/agent-deck` from README and release notes.
+# That path silently broke once when goreleaser's brews block was misconfigured;
+# this workflow probes the live tap so the next break is caught in CI.
+
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+      - '.goreleaser.yml'
+      - 'scripts/verify-homebrew-install.sh'
+      - '.github/workflows/homebrew-verify.yml'
+  push:
+    tags:
+      - 'v*'
+  schedule:
+    # Weekly probe so a broken tap is detected even without commits.
+    - cron: '0 9 * * 1'
+  workflow_dispatch: {}
+
+jobs:
+  verify-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify homebrew tap publishes a working formula
+        run: bash scripts/verify-homebrew-install.sh

--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -1,0 +1,41 @@
+name: python-compat
+
+# Regression gate for #864 - bridge.py must import on the Python version
+# shipped by default with WSL Ubuntu 20.04 (3.8). Runs on every PR that
+# touches the conductor bridge or its tests.
+
+on:
+  pull_request:
+    paths:
+      - 'conductor/bridge.py'
+      - 'conductor/tests/**'
+      - '.github/workflows/python-compat.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'conductor/bridge.py'
+      - 'conductor/tests/**'
+      - '.github/workflows/python-compat.yml'
+
+jobs:
+  bridge-import:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install runtime deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install toml aiogram pytest
+      - name: Compile-check
+        run: python -m py_compile conductor/bridge.py
+      - name: Import-check
+        run: python -c "import sys; sys.path.insert(0, 'conductor'); import bridge"
+      - name: Compatibility test suite
+        run: python -m pytest conductor/tests/test_python_compat.py -v

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -28,9 +28,8 @@ import subprocess
 import sys
 import time
 from collections import deque
-from collections.abc import Coroutine
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Coroutine
 
 import toml
 

--- a/conductor/tests/test_python_compat.py
+++ b/conductor/tests/test_python_compat.py
@@ -1,0 +1,117 @@
+"""Regression tests for bridge.py Python version compatibility.
+
+Background (#864): WSL Ubuntu 20.04 ships Python 3.8 by default. bridge.py
+must import cleanly on 3.8+ so users on that platform can run the conductor
+bridge without manually installing a newer Python.
+
+The most common way this regresses is using runtime PEP 585 generics from
+``collections.abc`` (e.g. ``Coroutine[X, Y, Z]``), which only became
+subscriptable in 3.9. ``from __future__ import annotations`` does NOT cover
+runtime-evaluated type aliases — only annotations.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+BRIDGE_PATH = Path(__file__).parent.parent / "bridge.py"
+
+# collections.abc names that are NOT subscriptable until Python 3.9 (PEP 585).
+COLLECTIONS_ABC_GENERICS = {
+    "Coroutine", "Awaitable", "AsyncIterable", "AsyncIterator", "AsyncGenerator",
+    "Iterable", "Iterator", "Generator", "Reversible", "Container",
+    "Collection", "Callable", "Set", "MutableSet", "Mapping", "MutableMapping",
+    "Sequence", "MutableSequence", "ByteString", "MappingView", "KeysView",
+    "ItemsView", "ValuesView",
+}
+
+
+def _names_imported_from(tree: ast.AST, module: str) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == module:
+            for alias in node.names:
+                names.add(alias.asname or alias.name)
+    return names
+
+
+def _runtime_subscripts(tree: ast.AST) -> list[tuple[str, int]]:
+    """Return (name, lineno) for each ast.Subscript whose value is a Name,
+    excluding subscripts that appear inside an annotation context (where
+    ``from __future__ import annotations`` makes them lazy strings)."""
+    annotation_nodes: set[int] = set()
+
+    for node in ast.walk(tree):
+        # Mark annotation subtrees so we can skip them.
+        ann = None
+        if isinstance(node, (ast.AnnAssign, ast.arg)):
+            ann = node.annotation
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            ann = node.returns
+        if ann is not None:
+            for sub in ast.walk(ann):
+                annotation_nodes.add(id(sub))
+
+    hits: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Subscript) and id(node) not in annotation_nodes:
+            value = node.value
+            if isinstance(value, ast.Name):
+                hits.append((value.id, node.lineno))
+    return hits
+
+
+def test_bridge_imports_on_current_python():
+    """Smoke test: bridge.py must import on whatever Python runs the test."""
+    src = BRIDGE_PATH.read_text()
+    # Compile-only; full import requires optional deps (toml, aiogram).
+    compile(src, str(BRIDGE_PATH), "exec")
+
+
+def test_no_runtime_pep585_from_collections_abc():
+    """Regression for #864.
+
+    Subscripting ``collections.abc.Coroutine`` (etc.) at runtime crashes on
+    Python 3.8 with ``TypeError: 'ABCMeta' object is not subscriptable``.
+    The fix is to import those names from ``typing`` instead, which has
+    been subscriptable since 3.5.
+    """
+    tree = ast.parse(BRIDGE_PATH.read_text())
+    abc_imports = _names_imported_from(tree, "collections.abc") & COLLECTIONS_ABC_GENERICS
+    if not abc_imports:
+        return  # Nothing imported from collections.abc that could be subscripted.
+
+    offenders = [
+        (name, lineno)
+        for name, lineno in _runtime_subscripts(tree)
+        if name in abc_imports
+    ]
+    assert not offenders, (
+        f"bridge.py uses runtime PEP 585 subscripts from collections.abc "
+        f"that fail on Python 3.8: {offenders}. "
+        f"Import these from `typing` instead, or move the alias into a "
+        f"TYPE_CHECKING-only block."
+    )
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 9),
+    reason="Re-runs the import on whatever Python pytest uses; the 3.8 matrix "
+    "in .github/workflows/python-compat.yml is the real gate.",
+)
+def test_bridge_imports_on_python_38():
+    """When pytest itself is invoked under Python 3.8, the bridge must import.
+
+    The CI matrix in ``.github/workflows/python-compat.yml`` runs this suite
+    on 3.8, 3.9, 3.10, 3.11, and 3.12 to lock the floor.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("bridge", BRIDGE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    # Will raise TypeError on 3.8 if collections.abc.Coroutine[...] is used.
+    spec.loader.exec_module(module)

--- a/scripts/verify-homebrew-install.sh
+++ b/scripts/verify-homebrew-install.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Regression gate for #873: README and release notes advertise
+# `brew install asheshgoplani/tap/agent-deck`. Goreleaser publishes the
+# formula to https://github.com/asheshgoplani/homebrew-tap on each release.
+#
+# This script verifies the public path users actually take:
+#   1. The tap repo is reachable.
+#   2. The formula file exists in the expected directory.
+#   3. The formula's `version` matches the latest GitHub release tag.
+#   4. Every download URL in the formula resolves (no 404 dangling refs).
+#
+# Run on every release tag; also run on PRs that touch install docs or
+# the goreleaser brews block.
+
+set -euo pipefail
+
+OWNER="asheshgoplani"
+TAP_REPO="homebrew-tap"
+FORMULA_NAME="agent-deck"
+FORMULA_PATH="Formula/${FORMULA_NAME}.rb"
+RAW_BASE="https://raw.githubusercontent.com/${OWNER}/${TAP_REPO}/main"
+RELEASES_API="https://api.github.com/repos/${OWNER}/agent-deck/releases/latest"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+fail() { echo -e "${RED}FAIL${NC}: $*" >&2; exit 1; }
+pass() { echo -e "${GREEN}OK${NC}  : $*"; }
+
+# 1. Tap reachable
+if ! curl -sf -o /dev/null "https://github.com/${OWNER}/${TAP_REPO}"; then
+  fail "tap repo https://github.com/${OWNER}/${TAP_REPO} is not reachable"
+fi
+pass "tap repo reachable"
+
+# 2. Formula exists
+formula_url="${RAW_BASE}/${FORMULA_PATH}"
+formula=$(curl -sf "${formula_url}") || fail "formula not found at ${formula_url}"
+pass "formula exists at ${FORMULA_PATH}"
+
+# 3. Version matches latest release
+formula_version=$(printf '%s\n' "${formula}" | sed -nE 's/^[[:space:]]*version "([^"]+)".*/\1/p' | head -1)
+[ -n "${formula_version}" ] || fail "could not parse formula version"
+
+latest_tag=$(curl -sf "${RELEASES_API}" | sed -nE 's/.*"tag_name":[[:space:]]*"v?([^"]+)".*/\1/p' | head -1)
+[ -n "${latest_tag}" ] || fail "could not fetch latest release tag"
+
+if [ "${formula_version}" != "${latest_tag}" ]; then
+  fail "formula version ${formula_version} != latest release ${latest_tag} (goreleaser publish step likely failed)"
+fi
+pass "formula version ${formula_version} matches latest release"
+
+# 4. All URLs in formula resolve
+urls=$(printf '%s\n' "${formula}" | sed -nE 's/^[[:space:]]*url "([^"]+)".*/\1/p')
+[ -n "${urls}" ] || fail "no asset URLs found in formula"
+
+while IFS= read -r url; do
+  code=$(curl -sIL -o /dev/null -w "%{http_code}" "${url}")
+  if [ "${code}" != "200" ]; then
+    fail "asset ${url} returned HTTP ${code}"
+  fi
+  pass "asset reachable: ${url##*/}"
+done <<< "${urls}"
+
+# 5. README still advertises the same install command (catches doc drift)
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+readme="${script_dir}/../README.md"
+if ! grep -qF "brew install ${OWNER}/tap/${FORMULA_NAME}" "${readme}"; then
+  fail "README.md no longer references 'brew install ${OWNER}/tap/${FORMULA_NAME}'; tap is configured but advertised command drifted"
+fi
+pass "README install command matches tap"
+
+echo
+echo "All homebrew install path checks passed."


### PR DESCRIPTION
## Summary

Two v1.8.1 quickwins, one commit per issue so they can be reviewed independently.

### #864 — bridge.py crashes on Python 3.8 (WSL Ubuntu 20.04 default)

`conductor/bridge.py` imported `Coroutine` from `collections.abc` and built a runtime type alias `ReplyCallback = Callable[[str], Coroutine[Any, Any, None]]`. `collections.abc.Coroutine` only became subscriptable in Python 3.9 (PEP 585), so the import crashes on 3.8 with `TypeError: 'ABCMeta' object is not subscriptable`. The existing `from __future__ import annotations` doesn't help here because the alias is a runtime expression, not an annotation.

**Fix:** import `Coroutine` from `typing` instead. `typing.Coroutine` has been subscriptable since 3.5, identical at the type-checker level.

**Regression coverage:**
- `conductor/tests/test_python_compat.py` — AST scan that fails on any runtime PEP 585 subscript of a name imported from `collections.abc`. Verified to fail on the unfixed code, pass on the fix.
- `.github/workflows/python-compat.yml` — matrix import-check on Python 3.8 / 3.9 / 3.10 / 3.11 / 3.12 with the runtime deps (`toml`, `aiogram`).

Verified locally with `cpython-3.8.20`: bridge.py imports cleanly and `discover_conductors()` returns the expected list.

### #873 — `brew install asheshgoplani/tap/agent-deck` install path

Investigated against the live tap. As of **v1.8.0** the goreleaser `brews:` block is publishing correctly to `asheshgoplani/homebrew-tap`:
- formula version 1.8.0 matches latest GitHub release ✓
- all four release tarballs (darwin/linux × amd64/arm64) return 200 ✓
- README and release-notes install command match the published tap ✓

The path **works today**. The remaining risk is silent regression — a misconfigured brews block, expired `HOMEBREW_TAP_GITHUB_TOKEN`, or someone deleting the tap would break installs without any user-visible signal until the next bug report.

**Regression coverage:**
- `scripts/verify-homebrew-install.sh` — probes the live tap, asserts formula version matches latest GitHub release, asserts every asset URL in the formula resolves, asserts README still advertises the same `brew install` command.
- `.github/workflows/homebrew-verify.yml` — runs the probe on PRs touching install docs/goreleaser, on every release tag, and weekly via cron so a broken tap is caught even without commits.

## Test plan

- [x] `uv run --python 3.8 ... pytest conductor/tests/test_python_compat.py` — all 3 tests pass on Python 3.8
- [x] Reverting `bridge.py` fix makes `test_no_runtime_pep585_from_collections_abc` fail with the expected message
- [x] `bash scripts/verify-homebrew-install.sh` — all 8 checks pass against the live v1.8.0 tap
- [x] `python -c "import yaml; yaml.safe_load(...)"` on both new workflow files
- [x] lefthook pre-push (lint + go test + build + css-verify) clean