### PR TITLE
fix(ui): add ctrl+n/ctrl+p emacs navigation across all list views

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5652,7 +5652,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.lastEscTime = time.Now()
 		return h, nil
 
-	case "up", "k":
+	case "up", "k", "ctrl+p":
 		if h.cursor > 0 {
 			h.cursor--
 			h.previewScrollOffset = 0
@@ -5664,7 +5664,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
-	case "down", "j":
+	case "down", "j", "ctrl+n":
 		if h.cursor < len(h.flatItems)-1 {
 			h.cursor++
 			h.previewScrollOffset = 0

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2953,7 +2953,8 @@ func TestRegression743_NOnRemoteGroup_QuickCreatesNoDialog(t *testing.T) {
 // added alongside the existing vi-style pagination (#38). PgUp/PgDn are
 // half-page aliases of Ctrl+U/Ctrl+D; Home/End jump to the first/last item
 // (End fills the gap where no single-key jump-to-bottom existed, since G
-// opens global search).
+// opens global search). Also covers the emacs-style Ctrl+N/Ctrl+P line
+// navigation aliases for the main session list.
 func TestHome_TerminalNavigationKeys(t *testing.T) {
 	// Build a 100-item list so pagination + absolute jumps have room to move.
 	items := make([]session.Item, 100)
@@ -2990,6 +2991,11 @@ func TestHome_TerminalNavigationKeys(t *testing.T) {
 		{"Home at top no-op", tea.KeyMsg{Type: tea.KeyHome}, 0, 0},
 		{"End from middle", tea.KeyMsg{Type: tea.KeyEnd}, 5, last},
 		{"End at bottom no-op", tea.KeyMsg{Type: tea.KeyEnd}, last, last},
+		// Emacs-style line navigation (ctrl+n / ctrl+p)
+		{"ctrl+n moves down", tea.KeyMsg{Type: tea.KeyCtrlN}, 10, 11},
+		{"ctrl+n clamps at bottom", tea.KeyMsg{Type: tea.KeyCtrlN}, last, last},
+		{"ctrl+p moves up", tea.KeyMsg{Type: tea.KeyCtrlP}, 10, 9},
+		{"ctrl+p clamps at top", tea.KeyMsg{Type: tea.KeyCtrlP}, 0, 0},
 	}
 
 	for _, tc := range tests {

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1046,11 +1046,11 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 		// Recent sessions picker handling
 		if d.showRecentPicker && len(d.recentSessions) > 0 {
 			switch msg.String() {
-			case "ctrl+n", "down":
+			case "ctrl+n", "down", "j":
 				d.recentSessionCursor = (d.recentSessionCursor + 1) % len(d.recentSessions)
 				d.previewRecentSession(d.recentSessions[d.recentSessionCursor])
 				return d, nil
-			case "ctrl+p", "up":
+			case "ctrl+p", "up", "k":
 				d.recentSessionCursor--
 				if d.recentSessionCursor < 0 {
 					d.recentSessionCursor = len(d.recentSessions) - 1
@@ -1090,10 +1090,10 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 		if d.suggestionsActive && d.currentTarget() == focusPath {
 			total := len(d.pathSuggestions) + 1 // +1 for the "Type custom" entry
 			switch msg.String() {
-			case "down", "j":
+			case "down", "j", "ctrl+n":
 				d.pathSuggestionCursor = (d.pathSuggestionCursor + 1) % total
 				return d, nil
-			case "up", "k":
+			case "up", "k", "ctrl+p":
 				d.pathSuggestionCursor--
 				if d.pathSuggestionCursor < 0 {
 					d.pathSuggestionCursor = total - 1
@@ -1212,6 +1212,27 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.suggestionNavigated = true
 				return d, nil
 			}
+			// Emacs fallback: advance to next form field (mirrors "down").
+			if cur == focusConductor {
+				total := len(d.conductorSessions) + 1
+				if d.conductorCursor < total-1 {
+					d.conductorCursor++
+					return d, nil
+				}
+			}
+			if cur == focusMultiRepo && d.multiRepoEnabled && !d.multiRepoEditing {
+				if d.multiRepoPathCursor < len(d.multiRepoPaths)-1 {
+					d.multiRepoPathCursor++
+					return d, nil
+				}
+			}
+			if d.focusIndex < maxIdx {
+				d.focusIndex++
+				d.updateFocus()
+			} else if cur == focusOptions && d.toolOptions != nil {
+				return d, d.toolOptions.Update(msg)
+			}
+			return d, nil
 
 		case "ctrl+p":
 			// Previous suggestion (cursor space includes synthetic "Type custom" at 0).
@@ -1225,6 +1246,28 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.suggestionNavigated = true
 				return d, nil
 			}
+			// Emacs fallback: retreat to previous form field (mirrors "shift+tab"/"up").
+			if cur == focusConductor {
+				if d.conductorCursor > 0 {
+					d.conductorCursor--
+					return d, nil
+				}
+			}
+			if cur == focusMultiRepo && d.multiRepoEnabled && !d.multiRepoEditing {
+				if d.multiRepoPathCursor > 0 {
+					d.multiRepoPathCursor--
+					return d, nil
+				}
+			}
+			if cur == focusOptions && d.toolOptions != nil && !d.toolOptions.AtTop() {
+				return d, d.toolOptions.Update(msg)
+			}
+			d.focusIndex--
+			if d.focusIndex < 0 {
+				d.focusIndex = maxIdx
+			}
+			d.updateFocus()
+			return d, nil
 
 		case "ctrl+f":
 			if cur == focusBranch {

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -1632,6 +1632,131 @@ func TestNewDialog_ShowInGroup_LoadsConfiguredClaudeExtraArgs(t *testing.T) {
 // pathInput, branchInput, etc. but never resets claudeOptions.startQueryInput.
 // This test opens the dialog, sets a query, closes, re-opens, and asserts
 // the field is empty.
+func TestNewDialog_CtrlN_CtrlP_FieldNavigation(t *testing.T) {
+	// ctrl+n / ctrl+p must move between form fields when not on a path field
+	// with active suggestions — same semantics as down / shift+tab+up.
+	dialog := NewNewDialog()
+	dialog.Show()
+	dialog.worktreeEnabled = false
+	dialog.sandboxEnabled = false
+	dialog.inheritedSettings = nil
+	dialog.rebuildFocusTargets()
+
+	if dialog.focusIndex != 0 {
+		t.Fatalf("precondition: focusIndex = %d, want 0", dialog.focusIndex)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.focusIndex != 1 {
+		t.Fatalf("ctrl+n: focusIndex = %d, want 1", dialog.focusIndex)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.focusIndex != 2 {
+		t.Fatalf("ctrl+n x2: focusIndex = %d, want 2", dialog.focusIndex)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.focusIndex != 1 {
+		t.Fatalf("ctrl+p: focusIndex = %d, want 1", dialog.focusIndex)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.focusIndex != 0 {
+		t.Fatalf("ctrl+p x2: focusIndex = %d, want 0", dialog.focusIndex)
+	}
+}
+
+func TestNewDialog_CtrlP_WrapsToLastField(t *testing.T) {
+	dialog := NewNewDialog()
+	dialog.Show()
+	dialog.worktreeEnabled = false
+	dialog.sandboxEnabled = false
+	dialog.inheritedSettings = nil
+	dialog.rebuildFocusTargets()
+	maxIdx := len(dialog.focusTargets) - 1
+
+	// ctrl+p from first field should wrap to last.
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.focusIndex != maxIdx {
+		t.Fatalf("ctrl+p at top: focusIndex = %d, want %d (last)", dialog.focusIndex, maxIdx)
+	}
+}
+
+func TestNewDialog_SuggestionsDropdown_CtrlN_CtrlP(t *testing.T) {
+	// ctrl+n / ctrl+p must navigate the path-suggestions dropdown when it is
+	// active, consistent with j / k.
+	dialog := NewNewDialog()
+	dialog.Show()
+	dialog.SetPathSuggestions([]string{"/a", "/b", "/c"})
+
+	// Force path field focus and open the dropdown.
+	dialog.focusIndex = dialog.indexOf(focusPath)
+	dialog.updateFocus()
+	dialog.suggestionsActive = true
+	dialog.pathSuggestionCursor = 0
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.pathSuggestionCursor != 1 {
+		t.Fatalf("ctrl+n: pathSuggestionCursor = %d, want 1", dialog.pathSuggestionCursor)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.pathSuggestionCursor != 2 {
+		t.Fatalf("ctrl+n x2: pathSuggestionCursor = %d, want 2", dialog.pathSuggestionCursor)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.pathSuggestionCursor != 1 {
+		t.Fatalf("ctrl+p: pathSuggestionCursor = %d, want 1", dialog.pathSuggestionCursor)
+	}
+
+	// Dropdown must remain open during navigation.
+	if !dialog.suggestionsActive {
+		t.Fatal("suggestionsActive should remain true during ctrl+n/ctrl+p navigation")
+	}
+}
+
+func TestNewDialog_RecentPicker_JK(t *testing.T) {
+	// j / k must navigate the recent-sessions picker, consistent with
+	// ctrl+n / ctrl+p and down / up.
+	dialog := NewNewDialog()
+	dialog.Show()
+	dialog.recentSessions = []*statedb.RecentSessionRow{
+		{Title: "alpha", ProjectPath: "/a", Tool: "claude"},
+		{Title: "beta", ProjectPath: "/b", Tool: "claude"},
+		{Title: "gamma", ProjectPath: "/c", Tool: "claude"},
+	}
+	dialog.showRecentPicker = true
+	dialog.recentSessionCursor = 0
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if dialog.recentSessionCursor != 1 {
+		t.Fatalf("j: recentSessionCursor = %d, want 1", dialog.recentSessionCursor)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if dialog.recentSessionCursor != 2 {
+		t.Fatalf("j x2: recentSessionCursor = %d, want 2", dialog.recentSessionCursor)
+	}
+
+	// Wrap around.
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if dialog.recentSessionCursor != 0 {
+		t.Fatalf("j wrap: recentSessionCursor = %d, want 0", dialog.recentSessionCursor)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if dialog.recentSessionCursor != 2 {
+		t.Fatalf("k from 0: recentSessionCursor = %d, want 2 (wrap)", dialog.recentSessionCursor)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if dialog.recentSessionCursor != 1 {
+		t.Fatalf("k: recentSessionCursor = %d, want 1", dialog.recentSessionCursor)
+	}
+}
+
 func TestNewDialog_StartQuery_ClearsBetweenOpenings(t *testing.T) {
 	dialog := NewNewDialog()
 	dialog.Show()

--- a/internal/ui/skill_dialog.go
+++ b/internal/ui/skill_dialog.go
@@ -390,10 +390,10 @@ func (d *SkillDialog) Update(msg tea.KeyMsg) (*SkillDialog, tea.Cmd) {
 		d.column = SkillColumnAvailable
 		d.resetTypeJump()
 		d.normalizeSelectionAndScroll()
-	case "up", "k":
+	case "up", "k", "ctrl+p":
 		d.resetTypeJump()
 		d.moveBy(-1)
-	case "down", "j":
+	case "down", "j", "ctrl+n":
 		d.resetTypeJump()
 		d.moveBy(1)
 	case "pgup", "ctrl+b":

--- a/internal/ui/skill_dialog_test.go
+++ b/internal/ui/skill_dialog_test.go
@@ -359,6 +359,41 @@ func TestSkillDialog_ScrollWindowFollowsSelection(t *testing.T) {
 	}
 }
 
+func TestSkillDialog_CtrlN_CtrlP_Navigation(t *testing.T) {
+	dialog := NewSkillDialog()
+	dialog.visible = true
+	dialog.tool = "claude"
+	dialog.column = SkillColumnAvailable
+	dialog.available = []SkillDialogItem{
+		{Candidate: session.SkillCandidate{Name: "a", ID: "pool/a"}},
+		{Candidate: session.SkillCandidate{Name: "b", ID: "pool/b"}},
+		{Candidate: session.SkillCandidate{Name: "c", ID: "pool/c"}},
+	}
+	dialog.availableIdx = 0
+
+	// ctrl+n moves down.
+	_, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.availableIdx != 1 {
+		t.Fatalf("ctrl+n: availableIdx = %d, want 1", dialog.availableIdx)
+	}
+
+	_, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.availableIdx != 2 {
+		t.Fatalf("ctrl+n x2: availableIdx = %d, want 2", dialog.availableIdx)
+	}
+
+	// ctrl+p moves up.
+	_, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.availableIdx != 1 {
+		t.Fatalf("ctrl+p: availableIdx = %d, want 1", dialog.availableIdx)
+	}
+
+	_, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.availableIdx != 0 {
+		t.Fatalf("ctrl+p x2: availableIdx = %d, want 0", dialog.availableIdx)
+	}
+}
+
 func TestSkillDialog_ViewShowsCounts(t *testing.T) {
 	dialog := NewSkillDialog()
 	dialog.visible = true

--- a/internal/ui/watcher_panel.go
+++ b/internal/ui/watcher_panel.go
@@ -129,7 +129,7 @@ func (wp *WatcherPanel) Update(msg tea.Msg) (*WatcherPanel, tea.Cmd) {
 			wp.Hide()
 		}
 
-	case "j", "down":
+	case "j", "down", "ctrl+n":
 		if wp.detailMode {
 			wp.detailCursor++
 		} else {
@@ -138,7 +138,7 @@ func (wp *WatcherPanel) Update(msg tea.Msg) (*WatcherPanel, tea.Cmd) {
 			}
 		}
 
-	case "k", "up":
+	case "k", "up", "ctrl+p":
 		if wp.detailMode {
 			if wp.detailCursor > 0 {
 				wp.detailCursor--

--- a/internal/ui/watcher_panel_test.go
+++ b/internal/ui/watcher_panel_test.go
@@ -241,6 +241,42 @@ func TestWatcherPanelTruncate(t *testing.T) {
 }
 
 // TestWatcherPanelNoActionOnEmptyList verifies no panic or cmd when list is empty.
+func TestWatcherPanel_CtrlN_CtrlP_Navigation(t *testing.T) {
+	wp := NewWatcherPanel()
+	wp.SetWatchers(sampleWatchers())
+	wp.Show()
+
+	// ctrl+n moves down.
+	wp, _ = wp.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if wp.cursor != 1 {
+		t.Errorf("ctrl+n: cursor = %d, want 1", wp.cursor)
+	}
+
+	wp, _ = wp.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if wp.cursor != 2 {
+		t.Errorf("ctrl+n x2: cursor = %d, want 2", wp.cursor)
+	}
+
+	// Clamps at last item.
+	wp, _ = wp.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if wp.cursor != 2 {
+		t.Errorf("ctrl+n past end: cursor = %d, want 2 (clamped)", wp.cursor)
+	}
+
+	// ctrl+p moves up.
+	wp, _ = wp.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if wp.cursor != 1 {
+		t.Errorf("ctrl+p: cursor = %d, want 1", wp.cursor)
+	}
+
+	// Clamps at first item.
+	wp.cursor = 0
+	wp, _ = wp.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if wp.cursor != 0 {
+		t.Errorf("ctrl+p at top: cursor = %d, want 0 (clamped)", wp.cursor)
+	}
+}
+
 func TestWatcherPanelNoActionOnEmptyList(t *testing.T) {
 	wp := NewWatcherPanel()
 	wp.Show()


### PR DESCRIPTION
## Problem

`ctrl+n` (next line) and `ctrl+p` (previous line) are the most fundamental emacs cursor movement keys, but they only worked in some parts of the TUI. Navigation was inconsistent:

| Surface | `j`/`k` | `ctrl+n`/`ctrl+p` |
|---|---|---|
| Main session list | ✓ | ✗ |
| New session dialog — path suggestions dropdown | ✓ | ✗ |
| New session dialog — recent sessions picker | ✗ | ✓ (but not `j`/`k`) |
| New session dialog — field-to-field navigation | ✗ | ✗ (only worked on path field) |
| Skill dialog | ✓ | ✗ |
| Watcher panel | ✓ | ✗ |
| Zoxide picker | — | ✓ (already correct) |
| Branch picker | — | ✓ (already correct) |

## Changes

**`internal/ui/home.go`** — add `ctrl+p`/`ctrl+n` as aliases for `k`/`j` in the main session list.

**`internal/ui/newdialog.go`**:
- Path-suggestions dropdown: add `ctrl+n`/`ctrl+p` alongside `j`/`k`.
- Recent-sessions picker: add `j`/`k` alongside the existing `ctrl+n`/`ctrl+p`.
- `ctrl+n`/`ctrl+p` outside a path field with active suggestions: fall through to form field navigation (mirrors `down`/`shift+tab`+`up`), including the conductor and multi-repo sub-list handling.

**`internal/ui/skill_dialog.go`** — add `ctrl+n`/`ctrl+p` as aliases for `j`/`k`.

**`internal/ui/watcher_panel.go`** — add `ctrl+n`/`ctrl+p` as aliases for `j`/`k`.

## Tests

Every changed surface has new tests:
- `TestHome_TerminalNavigationKeys` extended with `ctrl+n`/`ctrl+p` cases.
- `TestNewDialog_CtrlN_CtrlP_FieldNavigation` — field navigation in the new-session form.
- `TestNewDialog_CtrlP_WrapsToLastField` — wrap-around on first field.
- `TestNewDialog_SuggestionsDropdown_CtrlN_CtrlP` — dropdown navigation.
- `TestNewDialog_RecentPicker_JK` — `j`/`k` in recent-sessions picker.
- `TestSkillDialog_CtrlN_CtrlP_Navigation` — skill dialog navigation.
- `TestWatcherPanel_CtrlN_CtrlP_Navigation` — watcher panel navigation.

## Notes

- No new dependencies, no config changes.
- All changes are purely additive aliases to existing switch cases — existing `j`/`k` and arrow-key bindings are untouched.
- `ctrl+f`/`ctrl+b` (page forward/back) and `ctrl+u`/`ctrl+d` (half-page) already work in `home.go` — this PR does not touch those.