### PR TITLE
feat(conductor): inject HEARTBEAT_RULES.md in OS heartbeat (parity with bridge.py)

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -736,8 +736,31 @@ fi
 # Only send if the session is running
 STATUS=$(agent-deck -p "$PROFILE" session show "$SESSION" --json 2>/dev/null | awk -F'"' '/"status"/{print $4; exit}')
 
+# Resolve HEARTBEAT_RULES.md (per-conductor, then per-profile, then global fallback).
+# Mirrors the lookup order used by conductor/bridge.py since PR #218.
+RULES_FILE=""
+for candidate in \
+    "$HOME/.agent-deck/conductor/{NAME}/HEARTBEAT_RULES.md" \
+    "$HOME/.agent-deck/conductor/{PROFILE}/HEARTBEAT_RULES.md" \
+    "$HOME/.agent-deck/conductor/HEARTBEAT_RULES.md"; do
+    if [ -f "$candidate" ]; then
+        RULES_FILE="$candidate"
+        break
+    fi
+done
+
+MSG="[HEARTBEAT] Check sessions in your group ({NAME}). List any that are waiting, auto-respond where safe, and report what needs my attention."
+if [ -n "$RULES_FILE" ]; then
+    RULES=$(cat "$RULES_FILE")
+    if [ -n "$RULES" ]; then
+        MSG="$MSG
+
+$RULES"
+    fi
+fi
+
 if [ "$STATUS" = "idle" ] || [ "$STATUS" = "waiting" ]; then
-    agent-deck -p "$PROFILE" session send "$SESSION" "Heartbeat: Check sessions in your group ({NAME}). List any that are waiting, auto-respond where safe, and report what needs my attention." --no-wait -q
+    agent-deck -p "$PROFILE" session send "$SESSION" "$MSG" --no-wait -q
 fi
 `
 

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -610,6 +610,28 @@ func TestConductorHeartbeatScript_StatusParsingHandlesWhitespace(t *testing.T) {
 	}
 }
 
+// TestConductorHeartbeatScript_InjectsHeartbeatRules verifies parity with
+// conductor/bridge.py (PR #218): the OS heartbeat must also resolve and inline
+// HEARTBEAT_RULES.md so rules survive context compaction regardless of which
+// heartbeat mechanism is active.
+func TestConductorHeartbeatScript_InjectsHeartbeatRules(t *testing.T) {
+	if !strings.Contains(conductorHeartbeatScript, "HEARTBEAT_RULES.md") {
+		t.Fatal("heartbeat script should reference HEARTBEAT_RULES.md")
+	}
+	if !strings.Contains(conductorHeartbeatScript, "{NAME}/HEARTBEAT_RULES.md") {
+		t.Fatal("heartbeat script should look up per-conductor HEARTBEAT_RULES.md first")
+	}
+	if !strings.Contains(conductorHeartbeatScript, "{PROFILE}/HEARTBEAT_RULES.md") {
+		t.Fatal("heartbeat script should look up per-profile HEARTBEAT_RULES.md")
+	}
+	if !strings.Contains(conductorHeartbeatScript, "/.agent-deck/conductor/HEARTBEAT_RULES.md") {
+		t.Fatal("heartbeat script should fall back to the global HEARTBEAT_RULES.md")
+	}
+	if !strings.Contains(conductorHeartbeatScript, "[HEARTBEAT]") {
+		t.Fatal("heartbeat script should send messages prefixed with [HEARTBEAT] (matches bridge.py)")
+	}
+}
+
 // --- Symlink-based CLAUDE.md tests ---
 
 func TestInstallSharedClaudeMD_Default(t *testing.T) {


### PR DESCRIPTION
## Motivation

PR #218 externalized heartbeat instructions into `HEARTBEAT_RULES.md` so policy rules survive context compaction. That fix only landed in `conductor/bridge.py`.

Agent-deck has a second heartbeat path: `heartbeat.sh`, generated from `internal/session/conductor.go`'s `conductorHeartbeatScript` template and scheduled by systemd / launchd. When the OS heartbeat daemon is detected, bridge.py auto-disables its own loop:

> `OS heartbeat daemon detected, bridge heartbeat loop disabled (avoiding double-trigger)`

So on any host using the OS daemon (the default on Linux/macOS once a timer is installed), `HEARTBEAT_RULES.md` is silently ignored — the file exists, the docs reference it, but the script that actually fires never reads it. The conductor only sees the rules when the human prompts for them.

## Summary

Bring the OS heartbeat to parity with bridge.py:

1. Resolve `HEARTBEAT_RULES.md` with the same triple fallback — per-conductor → per-profile → global.
2. Append the rules to the heartbeat message after a blank line, only when the file exists and is non-empty.
3. Switch the message prefix from `Heartbeat:` to `[HEARTBEAT]` to match bridge.py and the conductor template docs (which already describe periodic `[HEARTBEAT]` messages — see `internal/session/conductor_templates.go:280`).

## Migration

No user action required. `MigrateConductorHeartbeatScripts` already rewrites `heartbeat.sh` whenever its content drifts from the template. The managed-script markers (`# Heartbeat for conductor:` and `SESSION="conductor-`) are preserved, so existing installs auto-upgrade on the next `agent-deck` invocation; user-customized heartbeat.sh files (without those markers) are left alone.

## Tests

- New: `TestConductorHeartbeatScript_InjectsHeartbeatRules` asserts the three lookup paths and the `[HEARTBEAT]` prefix.
- All existing `internal/session/` tests still pass (`go test ./internal/session/`).
- Rendered template passes `bash -n`; lookup precedence verified end-to-end with a fixture for each fallback case (per-conductor → per-profile → global → none).

## Out of scope

The post-`/clear` orientation heartbeat in `internal/ui/home.go:2876` sends the same hardcoded message after auto-clear-on-compact and has the same drift. Same one-line fix applies — happy to address in a follow-up PR if you'd like it kept separate.
