### PR TITLE
feat(conductor): add --heartbeat-rules-md flag for per-conductor rules override

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -115,6 +115,7 @@ func handleConductorSetup(profile string, args []string) {
 	sharedInstructionsMD := fs.String("shared-instructions-md", "", "Custom shared instructions file for all conductors of this agent")
 	claudeMD := fs.String("claude-md", "", "Custom CLAUDE.md for this conductor (e.g., ~/docs/conductor-ryan.md)")
 	policyMD := fs.String("policy-md", "", "Custom POLICY.md for this conductor (e.g., ~/docs/my-policy.md)")
+	heartbeatRulesMD := fs.String("heartbeat-rules-md", "", "Custom HEARTBEAT_RULES.md for this conductor (e.g., ~/docs/my-heartbeat-rules.md)")
 	sharedClaudeMD := fs.String("shared-claude-md", "", "Custom path for shared CLAUDE.md (e.g., ~/docs/conductor-shared.md)")
 	sharedPolicyMD := fs.String("shared-policy-md", "", "Custom path for shared POLICY.md (e.g., ~/docs/conductor-policy.md)")
 	envFile := fs.String("env-file", "", "Path to .env file to source before conductor starts (e.g., ~/.conductor.env)")
@@ -150,6 +151,8 @@ func handleConductorSetup(profile string, args []string) {
 		fmt.Println("        Deprecated Claude-only alias for -instructions-md")
 		fmt.Println("  -policy-md string")
 		fmt.Println("        Custom POLICY.md for this conductor (e.g., ~/docs/my-policy.md)")
+		fmt.Println("  -heartbeat-rules-md string")
+		fmt.Println("        Custom HEARTBEAT_RULES.md for this conductor (e.g., ~/docs/my-heartbeat-rules.md)")
 		fmt.Println()
 		fmt.Println("Shared files (all conductors):")
 		fmt.Println("  -shared-instructions-md string")
@@ -462,7 +465,7 @@ func handleConductorSetup(profile string, args []string) {
 	if len(envFlags) > 0 {
 		envMap = map[string]string(envFlags)
 	}
-	if err := session.SetupConductorWithAgent(name, resolvedProfile, spec.Agent, heartbeatEnabled, clearOnCompact, *description, resolvedInstructionsMD, *policyMD, envMap, *envFile); err != nil {
+	if err := session.SetupConductorWithAgent(name, resolvedProfile, spec.Agent, heartbeatEnabled, clearOnCompact, *description, resolvedInstructionsMD, *policyMD, *heartbeatRulesMD, envMap, *envFile); err != nil {
 		fmt.Fprintf(os.Stderr, "Error setting up conductor %s: %v\n", name, err)
 		os.Exit(1)
 	}

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -431,15 +431,17 @@ func matchesTemplateContent(actual, expected string) bool {
 
 // SetupConductor creates a Claude conductor for backward compatibility.
 // New callers should prefer SetupConductorWithAgent.
-func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact bool, description string, customClaudeMD string, customPolicyMD string, env map[string]string, envFile string) error {
-	return SetupConductorWithAgent(name, profile, ConductorAgentClaude, heartbeatEnabled, clearOnCompact, description, customClaudeMD, customPolicyMD, env, envFile)
+func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact bool, description string, customClaudeMD string, customPolicyMD string, customHeartbeatRulesMD string, env map[string]string, envFile string) error {
+	return SetupConductorWithAgent(name, profile, ConductorAgentClaude, heartbeatEnabled, clearOnCompact, description, customClaudeMD, customPolicyMD, customHeartbeatRulesMD, env, envFile)
 }
 
 // SetupConductorWithAgent creates the conductor directory, agent-specific instructions file, and meta.json.
 // If customInstructionsMD is provided, creates a symlink instead of writing the template.
 // If customPolicyMD is provided, creates a per-conductor POLICY.md symlink (overrides the shared POLICY.md).
+// If customHeartbeatRulesMD is provided, creates a per-conductor HEARTBEAT_RULES.md symlink
+// (overrides the shared HEARTBEAT_RULES.md and any per-profile override).
 // It does NOT register the session (that's done by the CLI handler which has access to storage).
-func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool, clearOnCompact bool, description string, customInstructionsMD string, customPolicyMD string, env map[string]string, envFile string) error {
+func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool, clearOnCompact bool, description string, customInstructionsMD string, customPolicyMD string, customHeartbeatRulesMD string, env map[string]string, envFile string) error {
 	if err := ValidateConductorName(name); err != nil {
 		return err
 	}
@@ -493,6 +495,16 @@ func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool,
 		policyPath := filepath.Join(dir, "POLICY.md")
 		if err := createSymlinkWithExpansion(policyPath, customPolicyMD); err != nil {
 			return fmt.Errorf("failed to create POLICY.md symlink: %w", err)
+		}
+	}
+
+	// Write per-conductor HEARTBEAT_RULES.md symlink if custom path provided.
+	// Takes precedence over the per-profile and global HEARTBEAT_RULES.md
+	// (lookup order is mirrored by both conductor/bridge.py and the OS heartbeat script).
+	if customHeartbeatRulesMD != "" {
+		rulesPath := filepath.Join(dir, "HEARTBEAT_RULES.md")
+		if err := createSymlinkWithExpansion(rulesPath, customHeartbeatRulesMD); err != nil {
+			return fmt.Errorf("failed to create HEARTBEAT_RULES.md symlink: %w", err)
 		}
 	}
 
@@ -784,7 +796,7 @@ const conductorHeartbeatPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 // SetupConductorProfile creates a default Claude conductor for a profile.
 // Deprecated: Use SetupConductor instead. Kept for backward compatibility.
 func SetupConductorProfile(profile string) error {
-	return SetupConductor(profile, profile, true, true, "", "", "", nil, "")
+	return SetupConductor(profile, profile, true, true, "", "", "", "", nil, "")
 }
 
 // createSymlinkWithExpansion creates a symlink from target to source, with ~ expansion and validation.

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -796,7 +796,7 @@ func TestSetupConductor_DefaultTemplate(t *testing.T) {
 	defer os.RemoveAll(filepath.Join(homeDir, ".agent-deck", "conductor", name))
 
 	// Setup without custom path (uses default template)
-	err := SetupConductor(name, profile, true, true, "test description", "", "", nil, "")
+	err := SetupConductor(name, profile, true, true, "test description", "", "", "", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -843,7 +843,7 @@ func TestSetupConductorWithAgent_Codex(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	name := "test-codex"
-	if err := SetupConductorWithAgent(name, "default", ConductorAgentCodex, true, true, "codex conductor", "", "", nil, ""); err != nil {
+	if err := SetupConductorWithAgent(name, "default", ConductorAgentCodex, true, true, "codex conductor", "", "", "", nil, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -877,10 +877,10 @@ func TestSetupConductorWithAgent_RemovesStaleInstructionsFile(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	name := "switch-agent"
-	if err := SetupConductor(name, "default", true, true, "", "", "", nil, ""); err != nil {
+	if err := SetupConductor(name, "default", true, true, "", "", "", "", nil, ""); err != nil {
 		t.Fatalf("failed to create initial Claude conductor: %v", err)
 	}
-	if err := SetupConductorWithAgent(name, "default", ConductorAgentCodex, true, true, "", "", "", nil, ""); err != nil {
+	if err := SetupConductorWithAgent(name, "default", ConductorAgentCodex, true, true, "", "", "", "", nil, ""); err != nil {
 		t.Fatalf("failed to switch conductor to Codex: %v", err)
 	}
 
@@ -910,7 +910,7 @@ func TestSetupConductor_CustomSymlink(t *testing.T) {
 	defer os.RemoveAll(filepath.Join(homeDir, ".agent-deck", "conductor", name))
 
 	// Setup with custom path (creates symlink)
-	err := SetupConductor(name, profile, true, true, "test description", customPath, "", nil, "")
+	err := SetupConductor(name, profile, true, true, "test description", customPath, "", "", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -940,7 +940,7 @@ func TestSetupConductor_EmptyProfileNormalizesToDefault(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	name := "default-profile-conductor"
-	if err := SetupConductor(name, "", true, true, "", "", "", nil, ""); err != nil {
+	if err := SetupConductor(name, "", true, true, "", "", "", "", nil, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -967,11 +967,11 @@ func TestSetupConductor_ProfileConflict(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	name := "profile-conflict"
-	if err := SetupConductor(name, "work", true, true, "", "", "", nil, ""); err != nil {
+	if err := SetupConductor(name, "work", true, true, "", "", "", "", nil, ""); err != nil {
 		t.Fatalf("first setup failed: %v", err)
 	}
 
-	err := SetupConductor(name, "personal", true, true, "", "", "", nil, "")
+	err := SetupConductor(name, "personal", true, true, "", "", "", "", nil, "")
 	if err == nil {
 		t.Fatal("expected conflict error when reusing conductor name across profiles")
 	}
@@ -1366,7 +1366,7 @@ func TestSetupConductor_PolicyOverride(t *testing.T) {
 	defer os.RemoveAll(filepath.Join(homeDir, ".agent-deck", "conductor", name))
 
 	// Setup with custom policy path (creates per-conductor symlink)
-	err := SetupConductor(name, profile, true, true, "test description", "", customPolicyPath, nil, "")
+	err := SetupConductor(name, profile, true, true, "test description", "", customPolicyPath, "", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1387,6 +1387,48 @@ func TestSetupConductor_PolicyOverride(t *testing.T) {
 	// Verify reading through symlink works
 	content, _ := os.ReadFile(policyPath)
 	if !strings.Contains(string(content), "My Conductor Policy") {
+		t.Error("reading through symlink should return custom content")
+	}
+}
+
+func TestSetupConductor_HeartbeatRulesOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	customRulesPath := filepath.Join(tmpDir, "my-conductor-HEARTBEAT_RULES.md")
+
+	// Create custom file first
+	if err := os.WriteFile(customRulesPath, []byte("# My Conductor Heartbeat Rules\n"), 0o644); err != nil {
+		t.Fatalf("failed to create custom file: %v", err)
+	}
+
+	name := "test-heartbeat-rules-override"
+	profile := "default"
+
+	// Clean up after test
+	homeDir, _ := os.UserHomeDir()
+	defer os.RemoveAll(filepath.Join(homeDir, ".agent-deck", "conductor", name))
+
+	// Setup with custom heartbeat rules path (creates per-conductor symlink)
+	err := SetupConductor(name, profile, true, true, "test description", "", "", customRulesPath, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify per-conductor HEARTBEAT_RULES.md symlink exists
+	dir, _ := ConductorNameDir(name)
+	rulesPath := filepath.Join(dir, "HEARTBEAT_RULES.md")
+	linkDest, err := os.Readlink(rulesPath)
+	if err != nil {
+		t.Fatalf("HEARTBEAT_RULES.md should be a symlink: %v", err)
+	}
+
+	// Verify symlink points to custom file
+	if linkDest != customRulesPath {
+		t.Errorf("symlink should point to %q, got %q", customRulesPath, linkDest)
+	}
+
+	// Verify reading through symlink works
+	content, _ := os.ReadFile(rulesPath)
+	if !strings.Contains(string(content), "My Conductor Heartbeat Rules") {
 		t.Error("reading through symlink should return custom content")
 	}
 }
@@ -1545,7 +1587,7 @@ func TestSetupConductorCreatesLearnings(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	name := "learnings-test"
-	if err := SetupConductor(name, "default", true, true, "", "", "", nil, ""); err != nil {
+	if err := SetupConductor(name, "default", true, true, "", "", "", "", nil, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1570,7 +1612,7 @@ func TestSetupConductorPreservesExistingLearnings(t *testing.T) {
 
 	name := "learnings-preserve"
 	// First setup creates the file
-	if err := SetupConductor(name, "default", true, true, "", "", "", nil, ""); err != nil {
+	if err := SetupConductor(name, "default", true, true, "", "", "", "", nil, ""); err != nil {
 		t.Fatalf("first setup failed: %v", err)
 	}
 
@@ -1583,7 +1625,7 @@ func TestSetupConductorPreservesExistingLearnings(t *testing.T) {
 	}
 
 	// Re-running setup should NOT overwrite
-	if err := SetupConductor(name, "default", true, true, "", "", "", nil, ""); err != nil {
+	if err := SetupConductor(name, "default", true, true, "", "", "", "", nil, ""); err != nil {
 		t.Fatalf("second setup failed: %v", err)
 	}
 
@@ -2232,7 +2274,7 @@ func TestSetupConductor_WithEnvVars(t *testing.T) {
 		"ANTHROPIC_BASE_URL":   "https://api.z.ai/api/anthropic",
 		"ANTHROPIC_AUTH_TOKEN": "test-token",
 	}
-	err := SetupConductor(name, "default", true, true, "env test", "", "", env, "~/.conductor.env")
+	err := SetupConductor(name, "default", true, true, "env test", "", "", "", env, "~/.conductor.env")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2268,7 +2310,7 @@ func TestSetupConductor_WithoutEnvVars(t *testing.T) {
 	t.Setenv("HOME", tmpHome)
 
 	name := "test-no-env-conductor"
-	err := SetupConductor(name, "default", true, true, "", "", "", nil, "")
+	err := SetupConductor(name, "default", true, true, "", "", "", "", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/session/env_test.go
+++ b/internal/session/env_test.go
@@ -459,7 +459,7 @@ func TestGetConductorEnv(t *testing.T) {
 		"MY_API_KEY": "conductor-value",
 		"DEBUG":      "true",
 	}
-	if err := SetupConductor(name, "default", true, true, "", "", "", env, ""); err != nil {
+	if err := SetupConductor(name, "default", true, true, "", "", "", "", env, ""); err != nil {
 		t.Fatalf("setup failed: %v", err)
 	}
 


### PR DESCRIPTION
## Motivation

`agent-deck conductor setup` already supports `--policy-md` to point a conductor at an external `POLICY.md` (e.g. one checked into a project repo) without copying files into `~/.agent-deck/conductor/<name>/`. There's no equivalent for `HEARTBEAT_RULES.md`, even though that file has the same per-conductor / per-profile / global lookup order in both `conductor/bridge.py` (added in #218) and the OS heartbeat script.

This PR closes the gap.

## Summary

Add `--heartbeat-rules-md`, a direct mirror of `--policy-md`. Example:

```bash
agent-deck conductor setup ai-platform \
    --policy-md ~/Workspaces/ai-platform/.agent-deck/conductor/swe-org/POLICY.md \
    --heartbeat-rules-md ~/Workspaces/ai-platform/.agent-deck/conductor/swe-org/HEARTBEAT_RULES.md
```

The flag creates a symlink at `~/.agent-deck/conductor/<name>/HEARTBEAT_RULES.md` pointing at the user-supplied path. This is the highest-precedence entry in the per-conductor → per-profile → global lookup order, so the linked file is what gets injected into every heartbeat.

## Changes

- `cmd/agent-deck/conductor_cmd.go` — add `--heartbeat-rules-md` flag and document it next to `--policy-md` in the Usage block.
- `internal/session/conductor.go` — extend `SetupConductor` and `SetupConductorWithAgent` with `customHeartbeatRulesMD`, slotted right after `customPolicyMD`. After the `POLICY.md` symlink block, create the `HEARTBEAT_RULES.md` symlink via the existing `createSymlinkWithExpansion` helper (handles `~` expansion, source-existence validation, and clean replacement).
- Internal callers (`SetupConductorProfile` + tests) updated for the new positional parameter; `""` everywhere the flag is not exercised.

## Tests

- New: `TestSetupConductor_HeartbeatRulesOverride` — mirrors `TestSetupConductor_PolicyOverride`. Asserts the symlink is created, points at the supplied path, and reads back the custom content.
- All existing `internal/session/...` tests pass (`go test ./internal/session/`).
- Full repo build (`go build ./...`) clean.
- Unrelated `internal/ui/zoxide_picker_test.go` failures pre-exist on `main` and are not introduced by this change.

## Out of scope

`--shared-heartbeat-rules-md` (a global analogue to `--shared-policy-md`) — the global `~/.agent-deck/conductor/HEARTBEAT_RULES.md` is currently installed only by `conductor/setup.sh`, not by the Go code, so there's no `InstallHeartbeatRulesMD` to wire a `--shared-*` flag into. Happy to add it as a follow-up if there's demand.
