### PR TITLE
feat: first-class Cursor CLI (cursor agent) support

### DIFF
--- a/cmd/agent-deck/copilot_detect_test.go
+++ b/cmd/agent-deck/copilot_detect_test.go
@@ -25,6 +25,25 @@ func TestDetectTool_Copilot(t *testing.T) {
 	}
 }
 
+// Cursor CLI (`cursor agent`) must register as tool "cursor", not "shell".
+func TestDetectTool_Cursor(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"agent subcommand", "cursor agent", "cursor"},
+		{"bare binary", "cursor", "cursor"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got != tt.want {
+				t.Errorf("detectTool(%q) = %q, want %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
 // Pi must detect via token match (not strings.Contains) so short-name
 // false matches like "epic", "tapioca", "spider", "happiness" don't
 // hijack the tool identity. Co-credit @masta-g3 (PR #674).

--- a/internal/integration/detection_test.go
+++ b/internal/integration/detection_test.go
@@ -261,7 +261,7 @@ func TestDetection_CompilePatterns(t *testing.T) {
 // TestDetection_ToolConfig verifies that NewInstanceWithTool correctly sets the
 // Tool field for each supported tool type.
 func TestDetection_ToolConfig(t *testing.T) {
-	tools := []string{"claude", "gemini", "opencode", "codex", "shell"}
+	tools := []string{"claude", "gemini", "opencode", "codex", "shell", "cursor"}
 
 	for _, tool := range tools {
 		t.Run(tool, func(t *testing.T) {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1253,6 +1253,27 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	return envPrefix + command + yoloFlag + modelFlag
 }
 
+// buildCursorCommand builds the command for the Cursor CLI (`cursor agent`).
+// continuePrev adds --continue so Restart resumes the previous chat in the workspace.
+// Env files from [shell].env_files are applied via buildEnvSourceCommand.
+func (i *Instance) buildCursorCommand(baseCommand string, continuePrev bool) string {
+	if i.Tool != "cursor" {
+		return baseCommand
+	}
+
+	envPrefix := i.buildEnvSourceCommand()
+	cmd := strings.TrimSpace(baseCommand)
+	if cmd == "" || strings.EqualFold(cmd, "cursor") {
+		cmd = "cursor agent"
+	}
+
+	out := envPrefix + cmd
+	if continuePrev && !strings.Contains(strings.ToLower(cmd), "--continue") {
+		out += " --continue"
+	}
+	return out
+}
+
 // codexRolloutExists reports whether Codex has flushed a rollout JSONL for
 // the given session ID under $CODEX_HOME/sessions. Used by buildCodexCommand
 // to gate `codex resume <sid>` on a real on-disk rollout file (Issue #756).
@@ -2578,6 +2599,8 @@ func (i *Instance) Start() error {
 		command = i.buildCodexCommand(i.Command)
 		// Record start time for session ID detection (Unix millis)
 		i.CodexStartedAt = time.Now().UnixMilli()
+	case i.Tool == "cursor":
+		command = i.buildCursorCommand(i.Command, false)
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -2749,6 +2772,8 @@ func (i *Instance) StartWithMessage(message string) error {
 	case IsCodexCompatible(i.Tool):
 		command = i.buildCodexCommand(i.Command)
 		i.CodexStartedAt = time.Now().UnixMilli()
+	case i.Tool == "cursor":
+		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "crush":
 		command = i.buildCrushCommand(i.Command)
 	default:
@@ -5007,6 +5032,8 @@ func (i *Instance) Restart() error {
 			command = i.buildCodexCommand(i.Command)
 			// Record start time for async session ID detection
 			i.CodexStartedAt = time.Now().UnixMilli()
+		case i.Tool == "cursor":
+			command = i.buildCursorCommand(i.Command, true)
 		case i.Tool == "crush":
 			command = i.buildCrushCommand(i.Command)
 		default:

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1735,6 +1735,34 @@ func TestBuildCodexCommand_InlineCodexHomeDropsStaleID(t *testing.T) {
 	}
 }
 
+func TestBuildCursorCommand(t *testing.T) {
+	inst := NewInstanceWithTool("c1", "/tmp/c1", "cursor")
+	inst.Command = ""
+	got := inst.buildCursorCommand(inst.Command, false)
+	if !strings.Contains(got, "cursor agent") {
+		t.Fatalf("fresh session: want cursor agent in command, got %q", got)
+	}
+	if strings.Contains(strings.ToLower(got), "--continue") {
+		t.Fatalf("fresh session: should not add --continue, got %q", got)
+	}
+
+	got = inst.buildCursorCommand("cursor agent", true)
+	if !strings.Contains(strings.ToLower(got), "--continue") {
+		t.Fatalf("restart: want --continue, got %q", got)
+	}
+
+	inst.Command = "cursor agent --continue"
+	got = inst.buildCursorCommand(inst.Command, true)
+	if strings.Count(strings.ToLower(got), "--continue") != 1 {
+		t.Fatalf("duplicate --continue: got %q", got)
+	}
+
+	inst.Tool = "shell"
+	if passthrough := inst.buildCursorCommand("echo hi", true); passthrough != "echo hi" {
+		t.Fatalf("non-cursor tool should passthrough, got %q", passthrough)
+	}
+}
+
 // writeFakeCodexRollout creates an empty rollout JSONL under
 // codexHome/sessions/YYYY/MM/DD/ matching the layout buildCodexCommand
 // globs against (Issue #756).

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -104,6 +104,18 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 				`re:(?m)^\s*›\s`,
 			},
 		}
+	case "cursor":
+		return &RawPatterns{
+			BusyPatterns: []string{
+				"ctrl+c to interrupt",
+				"esc to interrupt",
+				"thinking",
+			},
+			PromptPatterns: []string{
+				"How can I help",
+				`re:(?m)^\s*›\s`,
+			},
+		}
 	case "shell":
 		return &RawPatterns{
 			PromptPatterns: []string{"$ ", "# ", "% "},

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -537,7 +537,7 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "pi"}
+var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "pi", "cursor", "crush"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"claude": {
@@ -576,6 +576,11 @@ var toolDetectionPatterns = map[string][]*regexp.Regexp{
 		regexp.MustCompile(`(?i)\bpi\s+cli\b`),
 		regexp.MustCompile(`(?i)\bpi\s+code\b`),
 	},
+	"cursor": {
+		// Cursor CLI agent TUI
+		regexp.MustCompile(`(?i)\bcursor\s+agent\b`),
+		regexp.MustCompile(`(?i)cursor\s+cli\b`),
+	},
 }
 
 func detectToolFromCommand(command string) string {
@@ -602,6 +607,8 @@ func detectToolFromCommand(command string) string {
 			return "crush"
 		case "pi":
 			return "pi"
+		case "cursor":
+			return "cursor"
 		}
 	}
 
@@ -620,6 +627,8 @@ func detectToolFromCommand(command string) string {
 		return "crush"
 	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
 		return "pi"
+	case strings.Contains(cmdLower, "cursor"):
+		return "cursor"
 	default:
 		return ""
 	}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -570,6 +570,7 @@ func TestDetectToolFromCommand(t *testing.T) {
 		{name: "opencode", command: "open-code --continue", want: "opencode"},
 		{name: "codex", command: "codex --dangerously-bypass-approvals-and-sandbox", want: "codex"},
 		{name: "pi", command: "pi --model fast", want: "pi"},
+		{name: "cursor", command: "cursor agent", want: "cursor"},
 		{name: "shell command", command: "npm run dev", want: ""},
 		{name: "empty", command: "", want: ""},
 	}

--- a/internal/ui/edit_session_dialog.go
+++ b/internal/ui/edit_session_dialog.go
@@ -428,8 +428,11 @@ func renderToolPills(presets []string, cursor int) string {
 		name := cmd
 		if name == "" {
 			name = "shell"
-		} else if def := session.GetToolDef(cmd); def != nil && def.Icon != "" {
-			name = def.Icon + " " + name
+		} else {
+			name = displayCommandPreset(cmd)
+			if def := session.GetToolDef(cmd); def != nil && def.Icon != "" {
+				name = def.Icon + " " + name
+			}
 		}
 		if i == cursor {
 			buttons[i] = selected.Render(name)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8368,6 +8368,9 @@ func createSessionTool(command string) (string, string) {
 		tool = "pi"
 	case "copilot":
 		tool = "copilot"
+	case "cursor":
+		tool = "cursor"
+		command = "cursor agent"
 	case "crush":
 		tool = "crush"
 	default:
@@ -8489,7 +8492,11 @@ func (h *Home) quickCreateSession() tea.Cmd {
 		tool = "claude"
 	}
 	if command == "" {
-		command = tool
+		if tool == "cursor" {
+			command = "cursor agent"
+		} else {
+			command = tool
+		}
 	}
 
 	// Generate unique name
@@ -12098,6 +12105,13 @@ func (h *Home) renderLaunchingState(inst *session.Instance, width int, startTime
 			toolDesc = "Resuming OpenCode session..."
 		} else {
 			toolDesc = "Starting OpenCode..."
+		}
+	case "cursor":
+		toolName = "Cursor Agent"
+		if isResuming {
+			toolDesc = "Resuming Cursor session..."
+		} else {
+			toolDesc = "Starting Cursor Agent..."
 		}
 	default:
 		toolName = "Shell"

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -233,10 +233,20 @@ type dialogSnapshot struct {
 	conductorCursor  int
 }
 
+// displayCommandPreset returns the visible label for a built-in preset slot.
+// The stored preset for Cursor remains "cursor" (tool id); the pill shows the
+// actual CLI users run ("cursor agent").
+func displayCommandPreset(cmd string) string {
+	if cmd == "cursor" {
+		return "cursor agent"
+	}
+	return cmd
+}
+
 // buildPresetCommands returns the list of commands for the picker,
 // including any custom tools from config.toml.
 func buildPresetCommands() []string {
-	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush"}
+	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "cursor", "crush"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}
@@ -2201,6 +2211,8 @@ func (d *NewDialog) View() string {
 		displayName := cmd
 		if displayName == "" {
 			displayName = "shell"
+		} else {
+			displayName = displayCommandPreset(cmd)
 		}
 		// Prepend icon for custom tools
 		if icon := session.GetToolIcon(cmd); cmd != "" && icon != "" {

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -253,11 +253,23 @@ func TestRenderLaunchModelInfoLines_ShowsModelAndVersion(t *testing.T) {
 	}
 }
 
+func TestDisplayCommandPreset(t *testing.T) {
+	if got := displayCommandPreset("cursor"); got != "cursor agent" {
+		t.Errorf("cursor → %q, want cursor agent", got)
+	}
+	if got := displayCommandPreset("claude"); got != "claude" {
+		t.Errorf("claude passthrough: got %q", got)
+	}
+	if got := displayCommandPreset(""); got != "" {
+		t.Errorf("empty passthrough: got %q", got)
+	}
+}
+
 func TestDialogPresetCommands(t *testing.T) {
 	d := NewNewDialog()
 
-	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, crush
-	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush"}
+	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, cursor, crush
+	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "cursor", "crush"}
 
 	if len(d.presetCommands) != len(expectedCommands) {
 		t.Errorf("Expected %d preset commands, got %d", len(expectedCommands), len(d.presetCommands))

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -107,8 +107,8 @@ type SettingsPanel struct {
 // builtinToolNames and builtinToolValues are the built-in tools. Custom tools
 // from config are appended dynamically in LoadConfig.
 var (
-	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Crush"}
-	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "crush"}
+	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Cursor", "Crush"}
+	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "cursor", "crush"}
 )
 
 // Search tier names for radio selection

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -30,6 +30,18 @@ func setSettingsPanelHotkeyConfigForTest(t *testing.T, tomlBody string) {
 	t.Cleanup(session.ClearUserConfigCache)
 }
 
+// toolValueIndex returns the index of value in panel.toolValues (for name-based tests).
+func toolValueIndex(t *testing.T, panel *SettingsPanel, value string) int {
+	t.Helper()
+	for i, v := range panel.toolValues {
+		if v == value {
+			return i
+		}
+	}
+	t.Fatalf("tool value %q not found in %#v", value, panel.toolValues)
+	return -1
+}
+
 func TestSettingsPanel_InitialState(t *testing.T) {
 	panel := NewSettingsPanel()
 
@@ -86,9 +98,8 @@ func TestSettingsPanel_LoadConfig(t *testing.T) {
 	}
 	panel.LoadConfig(config)
 
-	// Check tool selection (gemini should be index 1)
-	if panel.selectedTool != 1 {
-		t.Errorf("selectedTool: got %d, want 1 (gemini)", panel.selectedTool)
+	if got := panel.toolValues[panel.selectedTool]; got != "gemini" {
+		t.Errorf("default tool: got %q, want %q", got, "gemini")
 	}
 	if !panel.dangerousMode {
 		t.Error("dangerousMode should be true")
@@ -156,18 +167,19 @@ func TestSettingsPanel_LoadConfig_DefaultTool(t *testing.T) {
 	panel := NewSettingsPanel()
 
 	tests := []struct {
-		name     string
-		tool     string
-		expected int
+		name      string
+		tool      string
+		wantValue string // selected slot's config value ("", "" for None / unknown)
 	}{
-		{"claude", "claude", 0},
-		{"gemini", "gemini", 1},
-		{"opencode", "opencode", 2},
-		{"codex", "codex", 3},
-		{"pi", "pi", 4},
-		{"crush", "crush", 5},
-		{"empty", "", 6}, // None
-		{"unknown", "unknown-tool", 6},
+		{"claude", "claude", "claude"},
+		{"gemini", "gemini", "gemini"},
+		{"opencode", "opencode", "opencode"},
+		{"codex", "codex", "codex"},
+		{"pi", "pi", "pi"},
+		{"cursor", "cursor", "cursor"},
+		{"crush", "crush", "crush"},
+		{"empty", "", ""}, // None
+		{"unknown", "unknown-tool", ""},
 	}
 
 	for _, tt := range tests {
@@ -176,9 +188,9 @@ func TestSettingsPanel_LoadConfig_DefaultTool(t *testing.T) {
 				DefaultTool: tt.tool,
 			}
 			panel.LoadConfig(config)
-			if panel.selectedTool != tt.expected {
-				t.Errorf("LoadConfig(%q): selectedTool = %d, want %d",
-					tt.tool, panel.selectedTool, tt.expected)
+			if got := panel.toolValues[panel.selectedTool]; got != tt.wantValue {
+				t.Errorf("LoadConfig(%q): toolValues[selectedTool] = %q, want %q",
+					tt.tool, got, tt.wantValue)
 			}
 		})
 	}
@@ -198,8 +210,8 @@ func TestSettingsPanel_LoadConfig_CustomTools(t *testing.T) {
 
 	panel.LoadConfig(config)
 
-	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Crush", "Openclaw", "Zeta", "None"}
-	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "crush", "openclaw", "zeta", ""}
+	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Cursor", "Crush", "Openclaw", "Zeta", "None"}
+	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "cursor", "crush", "openclaw", "zeta", ""}
 
 	if !reflect.DeepEqual(panel.toolNames, wantNames) {
 		t.Fatalf("toolNames = %#v, want %#v", panel.toolNames, wantNames)
@@ -207,8 +219,9 @@ func TestSettingsPanel_LoadConfig_CustomTools(t *testing.T) {
 	if !reflect.DeepEqual(panel.toolValues, wantValues) {
 		t.Fatalf("toolValues = %#v, want %#v", panel.toolValues, wantValues)
 	}
-	if panel.selectedTool != 6 {
-		t.Fatalf("selectedTool = %d, want 6 for openclaw", panel.selectedTool)
+	wantIdx := toolValueIndex(t, panel, "openclaw")
+	if panel.selectedTool != wantIdx {
+		t.Fatalf("selectedTool = %d, want %d for openclaw", panel.selectedTool, wantIdx)
 	}
 }
 
@@ -245,7 +258,7 @@ func TestSettingsPanel_LoadConfig_SearchTier(t *testing.T) {
 
 func TestSettingsPanel_GetConfig(t *testing.T) {
 	panel := NewSettingsPanel()
-	panel.selectedTool = 2 // opencode
+	panel.selectedTool = toolValueIndex(t, panel, "opencode")
 	panel.dangerousMode = true
 	panel.claudeConfigDir = "~/.claude-custom"
 	panel.checkForUpdates = false
@@ -348,25 +361,26 @@ func TestSettingsPanel_GetConfig_ToolMapping(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		index    int
+		value    string
 		expected string
 	}{
-		{"claude", 0, "claude"},
-		{"gemini", 1, "gemini"},
-		{"opencode", 2, "opencode"},
-		{"codex", 3, "codex"},
-		{"pi", 4, "pi"},
-		{"crush", 5, "crush"},
-		{"none", 6, ""},
+		{"claude", "claude", "claude"},
+		{"gemini", "gemini", "gemini"},
+		{"opencode", "opencode", "opencode"},
+		{"codex", "codex", "codex"},
+		{"pi", "pi", "pi"},
+		{"cursor", "cursor", "cursor"},
+		{"crush", "crush", "crush"},
+		{"none", "", ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			panel.selectedTool = tt.index
+			panel.selectedTool = toolValueIndex(t, panel, tt.value)
 			config := panel.GetConfig()
 			if config.DefaultTool != tt.expected {
-				t.Errorf("GetConfig for tool index %d: DefaultTool = %q, want %q",
-					tt.index, config.DefaultTool, tt.expected)
+				t.Errorf("GetConfig for tool %q: DefaultTool = %q, want %q",
+					tt.value, config.DefaultTool, tt.expected)
 			}
 		})
 	}
@@ -380,7 +394,7 @@ func TestSettingsPanel_GetConfig_CustomToolMapping(t *testing.T) {
 		},
 	})
 
-	panel.selectedTool = 6
+	panel.selectedTool = toolValueIndex(t, panel, "openclaw")
 	config := panel.GetConfig()
 	if config.DefaultTool != "openclaw" {
 		t.Fatalf("DefaultTool: got %q, want %q", config.DefaultTool, "openclaw")

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -54,7 +54,7 @@ func NewSetupWizard() *SetupWizard {
 		visible:             false,
 		complete:            false,
 		currentStep:         0,
-		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "crush", "shell"},
+		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "cursor", "crush"},
 		selectedTool:        0, // Default to Claude
 		dangerousMode:       false,
 		useDefaultConfigDir: true,
@@ -394,6 +394,7 @@ func (w *SetupWizard) View() string {
 			"pi":       "Pi CLI - lightweight coding assistant",
 			"crush":    "Crush - Charm's terminal-first AI coding assistant",
 			"shell":    "Shell - No AI tool (plain terminal)",
+			"cursor":   "Cursor Agent - Cursor CLI (cursor agent)",
 		}
 
 		for i, tool := range w.toolOptions {

--- a/internal/ui/setup_wizard_test.go
+++ b/internal/ui/setup_wizard_test.go
@@ -140,7 +140,7 @@ func TestSetupWizard_ToolOptions(t *testing.T) {
 	wizard := NewSetupWizard()
 
 	// Verify tool options
-	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "crush", "shell"}
+	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "cursor", "crush"}
 	if len(wizard.toolOptions) != len(expectedTools) {
 		t.Errorf("Tool options count: got %d, want %d", len(wizard.toolOptions), len(expectedTools))
 	}

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -47,6 +47,7 @@ func TestToolIcon(t *testing.T) {
 		{"gemini", IconGemini},
 		{"opencode", IconOpenCode},
 		{"codex", IconCodex},
+		{"cursor", "📝"},
 		{"pi", IconPi},
 		{"shell", IconShell},
 		{"unknown", IconShell},


### PR DESCRIPTION
- Session start/restart builds cursor agent with optional --continue

- TUI presets, settings, wizard, tmux detection, display label

- Tests for command builder, detection, presets