### PR TITLE
feat(ui): widen new session dialog for long paths

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -135,6 +135,17 @@ const (
 	focusOptions               // tool-specific options panel (conditional).
 )
 
+// New session dialog: outer box and textinput widths stay in sync so long
+// project paths are not clipped in the path field.
+const (
+	newDialogPreferredOuterWidth = 84
+	newDialogMinOuterWidth       = 44
+	newDialogTerminalGutter      = 10 // margin when shrinking to terminal width
+	newDialogInputWidthPad       = 12 // outer width minus indent ≈ textinput width
+	newDialogInputMinWidth       = 28
+	newDialogInputMaxWidth       = 100
+)
+
 // settingDisplay pairs a label with a formatted value for read-only display.
 type settingDisplay struct {
 	label string
@@ -260,13 +271,11 @@ func NewNewDialog() *NewDialog {
 	nameInput.Placeholder = "session-name"
 	nameInput.Focus()
 	nameInput.CharLimit = MaxNameLength
-	nameInput.Width = 40
 
 	// Create path input
 	pathInput := textinput.New()
 	pathInput.Placeholder = "~/project/path"
 	pathInput.CharLimit = 256
-	pathInput.Width = 40
 	pathInput.ShowSuggestions = false // we use our own dropdown with filtering
 
 	// Get current working directory for default path
@@ -279,13 +288,11 @@ func NewNewDialog() *NewDialog {
 	commandInput := textinput.New()
 	commandInput.Placeholder = "custom command"
 	commandInput.CharLimit = 100
-	commandInput.Width = 40
 
 	// Create branch input for worktree
 	branchInput := textinput.New()
 	branchInput.Placeholder = "feature/branch-name"
 	branchInput.CharLimit = 100
-	branchInput.Width = 40
 
 	dlg := &NewDialog{
 		nameInput:       nameInput,
@@ -305,6 +312,7 @@ func NewNewDialog() *NewDialog {
 		worktreeEnabled: false,
 		branchPrefix:    "feature/",
 	}
+	dlg.syncInputWidths()
 	dlg.updateToolOptions() // Also calls rebuildFocusTargets.
 	return dlg
 }
@@ -418,10 +426,36 @@ func (d *NewDialog) GetSelectedGroup() string {
 	return d.parentGroupPath
 }
 
+func (d *NewDialog) effectiveDialogWidth() int {
+	w := newDialogPreferredOuterWidth
+	if d.width > 0 && d.width < w+newDialogTerminalGutter {
+		w = d.width - newDialogTerminalGutter
+		if w < newDialogMinOuterWidth {
+			w = newDialogMinOuterWidth
+		}
+	}
+	return w
+}
+
+func (d *NewDialog) syncInputWidths() {
+	iw := d.effectiveDialogWidth() - newDialogInputWidthPad
+	if iw < newDialogInputMinWidth {
+		iw = newDialogInputMinWidth
+	}
+	if iw > newDialogInputMaxWidth {
+		iw = newDialogInputMaxWidth
+	}
+	d.nameInput.Width = iw
+	d.pathInput.Width = iw
+	d.commandInput.Width = iw
+	d.branchInput.Width = iw
+}
+
 // SetSize sets the dialog dimensions
 func (d *NewDialog) SetSize(width, height int) {
 	d.width = width
 	d.height = height
+	d.syncInputWidths()
 	if d.branchPicker != nil {
 		d.branchPicker.SetSize(width, height)
 	}
@@ -1536,14 +1570,7 @@ func (d *NewDialog) View() string {
 	labelStyle := lipgloss.NewStyle().
 		Foreground(ColorText)
 
-	// Responsive dialog width
-	dialogWidth := 60
-	if d.width > 0 && d.width < dialogWidth+10 {
-		dialogWidth = d.width - 10
-		if dialogWidth < 40 {
-			dialogWidth = 40
-		}
-	}
+	dialogWidth := d.effectiveDialogWidth()
 
 	dialogStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -52,6 +52,22 @@ func TestDialogSetSize(t *testing.T) {
 	}
 }
 
+func TestNewDialog_SetSize_syncsPathInputWidth(t *testing.T) {
+	d := NewNewDialog()
+
+	d.SetSize(120, 40)
+	// Preferred outer width 84 → text fields 84 − 12 = 72.
+	if got := d.pathInput.Width; got != 72 {
+		t.Fatalf("wide terminal: pathInput.Width = %d, want 72", got)
+	}
+
+	d.SetSize(55, 40)
+	// Outer shrinks to terminal−10 (45), above min 44 → inputs 45 − 12 = 33.
+	if got := d.pathInput.Width; got != 33 {
+		t.Fatalf("narrow terminal: pathInput.Width = %d, want 33", got)
+	}
+}
+
 func TestDialogPresetCommands(t *testing.T) {
 	d := NewNewDialog()
 


### PR DESCRIPTION
Raise default dialog width to 84 columns and tie text field widths to the effective dialog size so project paths are not clipped on typical terminals.