### PR TITLE
fix(hooks): inotify overflow recovery + WARN-log silent swallows + flicker detector (T1+T3)

### DIFF
--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -4,14 +4,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
+
+var hookHandlerLog = logging.ForComponent(logging.CompSession)
 
 // maxHookPayloadSize limits the size of JSON payloads read from stdin
 // to prevent denial-of-service via oversized input.
@@ -171,6 +175,11 @@ func writeHookStatus(instanceID, status, sessionID, event string) {
 
 	hooksDir := getHooksDir()
 	if err := os.MkdirAll(hooksDir, 0700); err != nil {
+		hookHandlerLog.Warn("hook_status_mkdir_failed",
+			slog.String("dir", hooksDir),
+			slog.String("instance", instanceID),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 
@@ -190,15 +199,34 @@ func writeHookStatus(instanceID, status, sessionID, event string) {
 
 	jsonData, err := json.Marshal(statusFile)
 	if err != nil {
+		hookHandlerLog.Warn("hook_status_marshal_failed",
+			slog.String("instance", instanceID),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 
 	filePath := filepath.Join(hooksDir, filepath.Base(instanceID)+".json")
 	tmpPath := filePath + ".tmp"
 	if err := os.WriteFile(tmpPath, jsonData, 0600); err != nil {
+		hookHandlerLog.Warn("hook_status_write_failed",
+			slog.String("path", tmpPath),
+			slog.String("instance", instanceID),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
-	_ = os.Rename(tmpPath, filePath)
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		hookHandlerLog.Warn("hook_status_rename_failed",
+			slog.String("from", tmpPath),
+			slog.String("to", filePath),
+			slog.String("instance", instanceID),
+			slog.String("error", err.Error()),
+		)
+		// Best-effort cleanup of the orphaned temp file.
+		_ = os.Remove(tmpPath)
+		return
+	}
 
 	// Clear sticky session mapping when the upstream session is explicitly ended.
 	if isTerminalHookEvent(event) {
@@ -443,6 +471,11 @@ func writeCostEvent(instanceID string, rawPayload []byte) {
 
 	costDir := getCostEventsDir()
 	if err := os.MkdirAll(costDir, 0700); err != nil {
+		hookHandlerLog.Warn("cost_event_mkdir_failed",
+			slog.String("dir", costDir),
+			slog.String("instance", instanceID),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 
@@ -459,6 +492,10 @@ func writeCostEvent(instanceID string, rawPayload []byte) {
 
 	jsonData, err := json.Marshal(cf)
 	if err != nil {
+		hookHandlerLog.Warn("cost_event_marshal_failed",
+			slog.String("instance", instanceID),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 
@@ -467,11 +504,23 @@ func writeCostEvent(instanceID string, rawPayload []byte) {
 	finalPath := filepath.Join(costDir, filename)
 
 	if err := os.WriteFile(tmpPath, jsonData, 0600); err != nil {
+		hookHandlerLog.Warn("cost_event_write_failed",
+			slog.String("path", tmpPath),
+			slog.String("instance", instanceID),
+			slog.String("error", err.Error()),
+		)
 		logCostDebug("write failed: %v", err)
 		return
 	}
 	if err := os.Rename(tmpPath, finalPath); err != nil {
+		hookHandlerLog.Warn("cost_event_rename_failed",
+			slog.String("from", tmpPath),
+			slog.String("to", finalPath),
+			slog.String("instance", instanceID),
+			slog.String("error", err.Error()),
+		)
 		logCostDebug("rename failed: %v", err)
+		_ = os.Remove(tmpPath)
 		return
 	}
 	logCostDebug("wrote cost event: %s model=%s in=%d out=%d", finalPath, cf.Model, cf.InputTokens, cf.OutputTokens)

--- a/cmd/agent-deck/hook_handler_warnlog_test.go
+++ b/cmd/agent-deck/hook_handler_warnlog_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
+)
+
+// initTestLogging redirects the global logger to a temp dir's debug.log
+// so a test can assert on the JSON log output produced inside the
+// hook-handler write paths.
+func initTestLogging(t *testing.T) string {
+	t.Helper()
+	logging.Shutdown()
+	logDir := t.TempDir()
+	logging.Init(logging.Config{
+		Debug:  true,
+		LogDir: logDir,
+		Level:  "debug",
+		Format: "json",
+	})
+	t.Cleanup(func() { logging.Shutdown() })
+	return logDir
+}
+
+// TestWriteHookStatus_WarnsOnMkdirError verifies that when the hooks
+// directory cannot be created (path occupied by a regular file), the
+// failure produces a WARN log instead of being silently swallowed.
+//
+// Regression: cmd/agent-deck/hook_handler.go writeHookStatus previously
+// swallowed os.MkdirAll errors → producer-side failures invisible to
+// operators while the consumer (web/session_data_service) showed stale
+// status.
+func TestWriteHookStatus_WarnsOnMkdirError(t *testing.T) {
+	logDir := initTestLogging(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Place a regular file where the hooks directory should be, so MkdirAll
+	// fails with "not a directory".
+	adDir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(adDir, 0o755); err != nil {
+		t.Fatalf("setup .agent-deck: %v", err)
+	}
+	hooksPath := filepath.Join(adDir, "hooks")
+	if err := os.WriteFile(hooksPath, []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("create blocking file: %v", err)
+	}
+
+	writeHookStatus("inst-mkdirfail", "running", "", "UserPromptSubmit")
+
+	logging.Shutdown()
+	body := readLog(t, logDir)
+	if !strings.Contains(body, `"hook_status_mkdir_failed"`) {
+		t.Errorf("expected hook_status_mkdir_failed WARN; got:\n%s", body)
+	}
+	if !strings.Contains(body, `"level":"WARN"`) {
+		t.Errorf("expected WARN level; got:\n%s", body)
+	}
+}
+
+// TestWriteHookStatus_WarnsOnWriteFileError verifies that when WriteFile
+// fails (read-only hooks directory), a WARN is logged.
+func TestWriteHookStatus_WarnsOnWriteFileError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission test requires non-root")
+	}
+
+	logDir := initTestLogging(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	hooksDir := filepath.Join(home, ".agent-deck", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	if err := os.Chmod(hooksDir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer func() { _ = os.Chmod(hooksDir, 0o755) }()
+
+	writeHookStatus("inst-writefail", "running", "", "UserPromptSubmit")
+
+	logging.Shutdown()
+	body := readLog(t, logDir)
+	if !strings.Contains(body, `"hook_status_write_failed"`) {
+		t.Errorf("expected hook_status_write_failed WARN; got:\n%s", body)
+	}
+}
+
+// TestWriteCostEvent_WarnsOnMkdirError exercises the second function
+// (writeCostEvent) with a Stop hook payload pointing at a fake transcript;
+// makes the cost-events directory unwritable to trigger MkdirAll failure.
+func TestWriteCostEvent_WarnsOnMkdirError(t *testing.T) {
+	logDir := initTestLogging(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Stage a valid Claude transcript so writeCostEvent gets past the
+	// transcript-path validation and reaches the MkdirAll(costDir) call.
+	claudeDir := filepath.Join(home, ".claude", "projects", "abc")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("setup transcript dir: %v", err)
+	}
+	transcript := filepath.Join(claudeDir, "session.jsonl")
+	body := `{"type":"assistant","message":{"model":"claude-test","usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}`
+	if err := os.WriteFile(transcript, []byte(body), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	// Block cost-events dir creation: place a regular file at the path.
+	adDir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(adDir, 0o755); err != nil {
+		t.Fatalf("mkdir .agent-deck: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(adDir, "cost-events"), []byte("blocker"), 0o644); err != nil {
+		t.Fatalf("create blocker file: %v", err)
+	}
+
+	stopPayload := []byte(`{"hook_event_name":"Stop","transcript_path":"` + transcript + `"}`)
+	writeCostEvent("inst-cost", stopPayload)
+
+	logging.Shutdown()
+	logBody := readLog(t, logDir)
+	if !strings.Contains(logBody, `"cost_event_mkdir_failed"`) {
+		t.Errorf("expected cost_event_mkdir_failed WARN; got:\n%s", logBody)
+	}
+}
+
+func readLog(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "debug.log"))
+	if err != nil {
+		t.Fatalf("read debug.log: %v", err)
+	}
+	return string(data)
+}

--- a/internal/session/flicker_detector.go
+++ b/internal/session/flicker_detector.go
@@ -1,0 +1,107 @@
+package session
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
+)
+
+// FlickerDetector observes status transitions per session and emits a
+// synthetic "flicker_detected" WARN log when a session oscillates more
+// than flickerThreshold times within flickerWindow.
+//
+// Motivation: today's six-flicker oscillation incident was logged at
+// Debug only and provided no aggregate signal. Operators had to grep
+// status_changed lines manually. A single WARN per burst per session
+// is enough to trigger an alert without spamming logs during a sustained
+// flicker storm (rate-limited via flickerCooldown).
+type FlickerDetector struct {
+	mu sync.Mutex
+	// transitions[sessionID] is a sliding window of transition timestamps
+	// within the last flickerWindow. Older entries are pruned on Observe.
+	transitions map[string][]time.Time
+	// lastWarned[sessionID] holds the time we last emitted flicker_detected
+	// for this session, used to enforce flickerCooldown.
+	lastWarned map[string]time.Time
+
+	logger *slog.Logger
+}
+
+const (
+	// flickerThreshold is the number of transitions in the window that
+	// constitutes a flicker. Strict-greater-than: 4+ transitions trigger.
+	flickerThreshold = 3
+	// flickerWindow is the sliding window within which transitions count.
+	flickerWindow = 60 * time.Second
+	// flickerCooldown silences repeat warns for the same session while it
+	// is still flickering. One alert per burst is enough.
+	flickerCooldown = 60 * time.Second
+)
+
+// NewFlickerDetector creates a fresh detector. Tests construct their own;
+// production uses GlobalFlickerDetector.
+func NewFlickerDetector() *FlickerDetector {
+	return &FlickerDetector{
+		transitions: make(map[string][]time.Time),
+		lastWarned:  make(map[string]time.Time),
+		logger:      logging.ForComponent(logging.CompSession),
+	}
+}
+
+var (
+	globalFlickerOnce sync.Once
+	globalFlicker     *FlickerDetector
+)
+
+// GlobalFlickerDetector returns the process-wide detector used by the TUI's
+// status_changed call site.
+func GlobalFlickerDetector() *FlickerDetector {
+	globalFlickerOnce.Do(func() {
+		globalFlicker = NewFlickerDetector()
+	})
+	return globalFlicker
+}
+
+// Observe records a status transition for sessionID at the current time.
+// Callers should only invoke this when the new status differs from the
+// previous status — Observe does not de-duplicate.
+func (d *FlickerDetector) Observe(sessionID, status string) {
+	d.observeAt(sessionID, status, time.Now())
+}
+
+// observeAt is the testable form of Observe.
+func (d *FlickerDetector) observeAt(sessionID, status string, now time.Time) {
+	if sessionID == "" {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	cutoff := now.Add(-flickerWindow)
+	filtered := d.transitions[sessionID][:0:0]
+	for _, ts := range d.transitions[sessionID] {
+		if ts.After(cutoff) {
+			filtered = append(filtered, ts)
+		}
+	}
+	filtered = append(filtered, now)
+	d.transitions[sessionID] = filtered
+
+	if len(filtered) <= flickerThreshold {
+		return
+	}
+
+	if last, ok := d.lastWarned[sessionID]; ok && now.Sub(last) < flickerCooldown {
+		return
+	}
+	d.lastWarned[sessionID] = now
+
+	d.logger.Warn("flicker_detected",
+		slog.String("session", sessionID),
+		slog.String("latest_status", status),
+		slog.Int("transitions", len(filtered)),
+		slog.Duration("window", flickerWindow),
+	)
+}

--- a/internal/session/flicker_detector_test.go
+++ b/internal/session/flicker_detector_test.go
@@ -1,0 +1,152 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
+)
+
+// TestFlickerDetector_BelowThreshold_NoWarn verifies that a small number of
+// transitions within the window does NOT emit a flicker_detected log.
+func TestFlickerDetector_BelowThreshold_NoWarn(t *testing.T) {
+	logging.Shutdown()
+	logDir := t.TempDir()
+	logging.Init(logging.Config{
+		Debug: true, LogDir: logDir, Level: "debug", Format: "json",
+	})
+	defer logging.Shutdown()
+
+	d := NewFlickerDetector()
+	now := time.Unix(1_700_000_000, 0)
+	d.observeAt("inst-A", "running", now)
+	d.observeAt("inst-A", "waiting", now.Add(20*time.Second))
+
+	logging.Shutdown()
+	body := readLogFile(t, logDir)
+	if strings.Contains(body, `"flicker_detected"`) {
+		t.Errorf("did not expect flicker_detected for 2 transitions in 60s; got:\n%s", body)
+	}
+}
+
+// TestFlickerDetector_AboveThreshold_EmitsWarn verifies that >3 transitions
+// in the 60s window emit exactly one flicker_detected WARN.
+func TestFlickerDetector_AboveThreshold_EmitsWarn(t *testing.T) {
+	logging.Shutdown()
+	logDir := t.TempDir()
+	logging.Init(logging.Config{
+		Debug: true, LogDir: logDir, Level: "debug", Format: "json",
+	})
+	defer logging.Shutdown()
+
+	d := NewFlickerDetector()
+	base := time.Unix(1_700_000_000, 0)
+	d.observeAt("inst-A", "running", base)
+	d.observeAt("inst-A", "waiting", base.Add(5*time.Second))
+	d.observeAt("inst-A", "running", base.Add(10*time.Second))
+	d.observeAt("inst-A", "waiting", base.Add(15*time.Second)) // 4th transition: WARN here
+
+	logging.Shutdown()
+	body := readLogFile(t, logDir)
+	if !strings.Contains(body, `"flicker_detected"`) {
+		t.Errorf("expected flicker_detected after 4 transitions in 15s; got:\n%s", body)
+	}
+	if !strings.Contains(body, `"level":"WARN"`) {
+		t.Errorf("expected WARN level; got:\n%s", body)
+	}
+	if !strings.Contains(body, `"session":"inst-A"`) {
+		t.Errorf("expected session attribute on log; got:\n%s", body)
+	}
+}
+
+// TestFlickerDetector_SpreadOutsideWindow_NoWarn verifies that 4
+// transitions spread over 5 minutes don't trigger flicker (each new
+// transition prunes anything older than 60s before evaluating).
+func TestFlickerDetector_SpreadOutsideWindow_NoWarn(t *testing.T) {
+	logging.Shutdown()
+	logDir := t.TempDir()
+	logging.Init(logging.Config{
+		Debug: true, LogDir: logDir, Level: "debug", Format: "json",
+	})
+	defer logging.Shutdown()
+
+	d := NewFlickerDetector()
+	base := time.Unix(1_700_000_000, 0)
+	for i := 0; i < 4; i++ {
+		d.observeAt("inst-A", "running", base.Add(time.Duration(i)*90*time.Second))
+	}
+
+	logging.Shutdown()
+	body := readLogFile(t, logDir)
+	if strings.Contains(body, `"flicker_detected"`) {
+		t.Errorf("did not expect flicker for transitions spread across >60s windows; got:\n%s", body)
+	}
+}
+
+// TestFlickerDetector_PerSessionIsolated verifies that a flicker on one
+// session does not implicate another quiet session.
+func TestFlickerDetector_PerSessionIsolated(t *testing.T) {
+	logging.Shutdown()
+	logDir := t.TempDir()
+	logging.Init(logging.Config{
+		Debug: true, LogDir: logDir, Level: "debug", Format: "json",
+	})
+	defer logging.Shutdown()
+
+	d := NewFlickerDetector()
+	base := time.Unix(1_700_000_000, 0)
+	for i := 0; i < 4; i++ {
+		d.observeAt("inst-A", "running", base.Add(time.Duration(i)*5*time.Second))
+	}
+	d.observeAt("inst-B", "running", base.Add(2*time.Second))
+
+	logging.Shutdown()
+	body := readLogFile(t, logDir)
+	if !strings.Contains(body, `"session":"inst-A"`) {
+		t.Errorf("expected inst-A flicker; got:\n%s", body)
+	}
+	if strings.Contains(body, `"session":"inst-B"`) {
+		t.Errorf("did not expect inst-B in flicker log; got:\n%s", body)
+	}
+}
+
+// TestFlickerDetector_RateLimited verifies that a sustained flicker burst
+// produces only ONE flicker_detected log within the cooldown window
+// (otherwise a hot-looping session would spam the log).
+func TestFlickerDetector_RateLimited(t *testing.T) {
+	logging.Shutdown()
+	logDir := t.TempDir()
+	logging.Init(logging.Config{
+		Debug: true, LogDir: logDir, Level: "debug", Format: "json",
+	})
+	defer logging.Shutdown()
+
+	d := NewFlickerDetector()
+	base := time.Unix(1_700_000_000, 0)
+	for i := 0; i < 12; i++ {
+		d.observeAt("inst-A", "running", base.Add(time.Duration(i)*2*time.Second))
+	}
+
+	logging.Shutdown()
+	body := readLogFile(t, logDir)
+	count := strings.Count(body, `"flicker_detected"`)
+	if count != 1 {
+		t.Errorf("expected exactly 1 flicker_detected log within cooldown, got %d:\n%s", count, body)
+	}
+}
+
+func readLogFile(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "debug.log"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Lumberjack only creates the file on first write. No file = no log = OK.
+			return ""
+		}
+		t.Fatalf("read debug.log: %v", err)
+	}
+	return string(data)
+}

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -125,9 +126,92 @@ func (w *StatusFileWatcher) Start() {
 			if !ok {
 				return
 			}
+			if isOverflowError(err) {
+				w.handleOverflow(err)
+				continue
+			}
 			hookLog.Warn("hook_watcher_error", slog.String("error", err.Error()))
 		}
 	}
+}
+
+// isOverflowError reports whether err is (or wraps) fsnotify.ErrEventOverflow.
+func isOverflowError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, fsnotify.ErrEventOverflow)
+}
+
+// handleOverflow recovers from an inotify queue overflow by re-walking the
+// hooks directory from disk and atomically replacing the in-memory status
+// map. After overflow, individual file events were dropped, so the in-memory
+// map can be arbitrarily out of sync with disk; a full re-scan is the only
+// reliable recovery.
+func (w *StatusFileWatcher) handleOverflow(err error) {
+	hookLog.Warn("hook_watcher_overflow_resync",
+		slog.String("dir", w.hooksDir),
+		slog.String("error", errString(err)),
+	)
+
+	rebuilt := w.scanDisk()
+
+	w.mu.Lock()
+	w.statuses = rebuilt
+	w.mu.Unlock()
+
+	if w.onChange != nil {
+		w.onChange()
+	}
+}
+
+// scanDisk reads every .json hook status file in hooksDir and returns a
+// fresh map. Errors on individual files are skipped (they're either
+// mid-write or corrupt; the next event will retry).
+func (w *StatusFileWatcher) scanDisk() map[string]*HookStatus {
+	out := make(map[string]*HookStatus)
+	entries, err := os.ReadDir(w.hooksDir)
+	if err != nil {
+		hookLog.Warn("hook_watcher_scan_read_dir_failed",
+			slog.String("dir", w.hooksDir),
+			slog.String("error", err.Error()),
+		)
+		return out
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(w.hooksDir, entry.Name())
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			continue
+		}
+		var raw struct {
+			Status    string `json:"status"`
+			SessionID string `json:"session_id"`
+			Event     string `json:"event"`
+			Timestamp int64  `json:"ts"`
+		}
+		if uerr := json.Unmarshal(data, &raw); uerr != nil {
+			continue
+		}
+		instanceID := strings.TrimSuffix(entry.Name(), ".json")
+		out[instanceID] = &HookStatus{
+			Status:    raw.Status,
+			SessionID: raw.SessionID,
+			Event:     raw.Event,
+			UpdatedAt: time.Unix(raw.Timestamp, 0),
+		}
+	}
+	return out
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 // Stop shuts down the watcher.

--- a/internal/session/hook_watcher_overflow_test.go
+++ b/internal/session/hook_watcher_overflow_test.go
@@ -1,0 +1,135 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
+)
+
+// TestStatusFileWatcher_HandleOverflow_ResyncsFromDisk verifies that when
+// fsnotify reports IN_Q_OVERFLOW (ErrEventOverflow), the watcher re-walks
+// the hooks directory from disk and replaces its in-memory map atomically.
+//
+// Regression: hook_watcher.go previously dropped overflow events silently
+// (logged at Warn but did not re-sync), leaving stale state until restart.
+func TestStatusFileWatcher_HandleOverflow_ResyncsFromDisk(t *testing.T) {
+	tmpDir := t.TempDir()
+	hooksDir := filepath.Join(tmpDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	w := &StatusFileWatcher{
+		hooksDir: hooksDir,
+		statuses: make(map[string]*HookStatus),
+	}
+
+	// Pre-populate with a STALE entry that is NOT on disk (simulates a
+	// session that stopped writing files but is still in the in-memory map).
+	w.statuses["stale-inst"] = &HookStatus{
+		Status:    "running",
+		Event:     "old",
+		UpdatedAt: time.Now().Add(-time.Hour),
+	}
+
+	// Write fresh files to disk that the watcher never observed (simulates
+	// the inotify queue overflow window where many writes are dropped).
+	for _, inst := range []struct{ id, status string }{
+		{"fresh-1", "waiting"},
+		{"fresh-2", "running"},
+	} {
+		data, _ := json.Marshal(map[string]any{
+			"status":     inst.status,
+			"session_id": "sid-" + inst.id,
+			"event":      "UserPromptSubmit",
+			"ts":         time.Now().Unix(),
+		})
+		if err := os.WriteFile(filepath.Join(hooksDir, inst.id+".json"), data, 0644); err != nil {
+			t.Fatalf("write %s: %v", inst.id, err)
+		}
+	}
+
+	// Trigger the overflow recovery path. This method does not yet exist;
+	// the test fails until the implementation is added.
+	w.handleOverflow(fsnotify.ErrEventOverflow)
+
+	// After recovery, the map MUST reflect disk contents:
+	if w.GetHookStatus("fresh-1") == nil {
+		t.Error("fresh-1 missing after overflow recovery (re-walk did not happen)")
+	}
+	if w.GetHookStatus("fresh-2") == nil {
+		t.Error("fresh-2 missing after overflow recovery")
+	}
+	// And the stale entry that no longer has a backing file MUST be gone:
+	if w.GetHookStatus("stale-inst") != nil {
+		t.Error("stale-inst still present after overflow recovery (map not replaced atomically)")
+	}
+}
+
+// TestStatusFileWatcher_HandleOverflow_LogsWarn verifies that the overflow
+// recovery emits a WARN-level log line so an operator can correlate
+// flickering sessions with an inotify overflow event.
+func TestStatusFileWatcher_HandleOverflow_LogsWarn(t *testing.T) {
+	logging.Shutdown()
+	logDir := t.TempDir()
+	logging.Init(logging.Config{
+		Debug:  true,
+		LogDir: logDir,
+		Level:  "debug",
+		Format: "json",
+	})
+	defer logging.Shutdown()
+
+	hooksDir := filepath.Join(t.TempDir(), "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	w := &StatusFileWatcher{
+		hooksDir: hooksDir,
+		statuses: make(map[string]*HookStatus),
+	}
+
+	w.handleOverflow(fsnotify.ErrEventOverflow)
+
+	// Force log flush
+	logging.Shutdown()
+
+	data, err := os.ReadFile(filepath.Join(logDir, "debug.log"))
+	if err != nil {
+		t.Fatalf("read debug.log: %v", err)
+	}
+	if !strings.Contains(string(data), `"hook_watcher_overflow_resync"`) {
+		t.Errorf("expected hook_watcher_overflow_resync WARN log; got:\n%s", string(data))
+	}
+	if !strings.Contains(string(data), `"level":"WARN"`) {
+		t.Errorf("expected WARN level; got:\n%s", string(data))
+	}
+}
+
+// TestStatusFileWatcher_OverflowDispatch_DetectsErrEventOverflow verifies
+// that errors.Is(err, fsnotify.ErrEventOverflow) is the trigger condition,
+// not a string match. Catches future fsnotify versions that wrap the error.
+func TestStatusFileWatcher_OverflowDispatch_DetectsErrEventOverflow(t *testing.T) {
+	wrapped := fmt.Errorf("inotify: %w", fsnotify.ErrEventOverflow)
+	if !errors.Is(wrapped, fsnotify.ErrEventOverflow) {
+		t.Skip("fsnotify error wrapping precondition not met")
+	}
+	if !isOverflowError(wrapped) {
+		t.Errorf("isOverflowError must use errors.Is, not strings.Contains")
+	}
+	if isOverflowError(errors.New("some other error")) {
+		t.Errorf("isOverflowError matched a non-overflow error")
+	}
+	if isOverflowError(nil) {
+		t.Errorf("isOverflowError matched nil")
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2943,6 +2943,9 @@ func (h *Home) backgroundStatusUpdate() {
 					slog.String("old", string(oldStatus)),
 					slog.String("new", string(newStatus)),
 				)
+				// T1+T3: synthesize a flicker_detected WARN if this session
+				// has oscillated >3 times within 60s. One alert per burst.
+				session.GlobalFlickerDetector().Observe(inst.ID, string(newStatus))
 			}
 			return nil
 		})

--- a/internal/web/session_data_service.go
+++ b/internal/web/session_data_service.go
@@ -2,15 +2,20 @@ package web
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
+
+var hookStatusLog = logging.ForComponent(logging.CompWeb)
 
 const (
 	MenuItemTypeGroup   = "group"
@@ -168,6 +173,15 @@ func defaultLoadHookStatuses() map[string]*session.HookStatus {
 
 	entries, err := os.ReadDir(hooksDir)
 	if err != nil {
+		// ENOENT is benign — directory simply hasn't been created yet
+		// because no hook event has fired in this profile. Anything else
+		// (perm denied, IO error) is a real signal worth surfacing.
+		if !errors.Is(err, os.ErrNotExist) {
+			hookStatusLog.Warn("hook_status_dir_read_failed",
+				slog.String("dir", hooksDir),
+				slog.String("error", err.Error()),
+			)
+		}
 		return hooksByInstance
 	}
 
@@ -183,11 +197,21 @@ func defaultLoadHookStatuses() map[string]*session.HookStatus {
 
 		raw, err := os.ReadFile(filepath.Join(hooksDir, entry.Name()))
 		if err != nil {
+			hookStatusLog.Warn("hook_status_read_failed",
+				slog.String("file", entry.Name()),
+				slog.String("instance", instanceID),
+				slog.String("error", err.Error()),
+			)
 			continue
 		}
 
 		var parsed rawHookStatus
 		if err := json.Unmarshal(raw, &parsed); err != nil {
+			hookStatusLog.Warn("hook_status_unmarshal_failed",
+				slog.String("file", entry.Name()),
+				slog.String("instance", instanceID),
+				slog.String("error", err.Error()),
+			)
 			continue
 		}
 		if parsed.Status == "" {

--- a/internal/web/session_data_service_warnlog_test.go
+++ b/internal/web/session_data_service_warnlog_test.go
@@ -1,0 +1,151 @@
+package web
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestDefaultLoadHookStatuses_WarnsOnUnmarshalError verifies that a
+// malformed hook JSON file produces a WARN log instead of being silently
+// skipped (session_data_service.go ~line 190 used to `continue` with no
+// log, masking producer-side bugs in cmd/agent-deck/hook_handler.go).
+func TestDefaultLoadHookStatuses_WarnsOnUnmarshalError(t *testing.T) {
+	logging.Shutdown()
+	logDir := t.TempDir()
+	logging.Init(logging.Config{
+		Debug:  true,
+		LogDir: logDir,
+		Level:  "debug",
+		Format: "json",
+	})
+	defer logging.Shutdown()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	hooksDir := session.GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	// Malformed JSON — must trigger json.Unmarshal error path.
+	if err := os.WriteFile(filepath.Join(hooksDir, "inst-bad.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write broken hook: %v", err)
+	}
+
+	_ = defaultLoadHookStatuses()
+
+	logging.Shutdown()
+
+	data, err := os.ReadFile(filepath.Join(logDir, "debug.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, `"hook_status_unmarshal_failed"`) {
+		t.Errorf("expected hook_status_unmarshal_failed WARN; got:\n%s", body)
+	}
+	if !strings.Contains(body, `"level":"WARN"`) {
+		t.Errorf("expected WARN level; got:\n%s", body)
+	}
+	if !strings.Contains(body, `"file":"inst-bad.json"`) && !strings.Contains(body, `inst-bad.json`) {
+		t.Errorf("expected log to identify the offending file; got:\n%s", body)
+	}
+}
+
+// TestDefaultLoadHookStatuses_WarnsOnReadFileError verifies that an
+// unreadable hook file produces a WARN log instead of being silently
+// skipped.
+func TestDefaultLoadHookStatuses_WarnsOnReadFileError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission test requires non-root")
+	}
+
+	logging.Shutdown()
+	logDir := t.TempDir()
+	logging.Init(logging.Config{
+		Debug:  true,
+		LogDir: logDir,
+		Level:  "debug",
+		Format: "json",
+	})
+	defer logging.Shutdown()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	hooksDir := session.GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	bad := filepath.Join(hooksDir, "inst-unreadable.json")
+	if err := os.WriteFile(bad, []byte(`{"status":"running"}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.Chmod(bad, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer func() { _ = os.Chmod(bad, 0o644) }()
+
+	_ = defaultLoadHookStatuses()
+
+	logging.Shutdown()
+
+	data, err := os.ReadFile(filepath.Join(logDir, "debug.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, `"hook_status_read_failed"`) {
+		t.Errorf("expected hook_status_read_failed WARN; got:\n%s", body)
+	}
+}
+
+// TestDefaultLoadHookStatuses_WarnsOnReadDirError verifies that when the
+// hooks directory exists but cannot be read (e.g. perms), a WARN is logged
+// rather than silent return. ENOENT is treated as benign and not logged.
+func TestDefaultLoadHookStatuses_WarnsOnReadDirError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission test requires non-root")
+	}
+
+	logging.Shutdown()
+	logDir := t.TempDir()
+	logging.Init(logging.Config{
+		Debug:  true,
+		LogDir: logDir,
+		Level:  "debug",
+		Format: "json",
+	})
+	defer logging.Shutdown()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	hooksDir := session.GetHooksDir()
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Make the directory unreadable.
+	if err := os.Chmod(hooksDir, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer func() { _ = os.Chmod(hooksDir, 0o755) }()
+
+	_ = defaultLoadHookStatuses()
+
+	logging.Shutdown()
+
+	data, err := os.ReadFile(filepath.Join(logDir, "debug.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, `"hook_status_dir_read_failed"`) {
+		t.Errorf("expected hook_status_dir_read_failed WARN; got:\n%s", body)
+	}
+}


### PR DESCRIPTION
## Summary

Three resilience fixes for the v1.9 hook fast-path covering themes **T1** (state divergence) and **T3** (silent error swallows + logging signal) from `V1.9-PRIORITY-PLAN.md`. Effort: ~2 worker-days as scoped.

### 1. inotify `IN_Q_OVERFLOW` recovery (`internal/session/hook_watcher.go`)

**Bug:** when fsnotify reports a queue overflow, individual file events are dropped — but the watcher previously logged one Warn line and kept serving its now-stale in-memory map until process restart. This is the root cause of the v1.8 "flickering red dots" report.

**Fix:** `handleOverflow()` re-walks the hooks dir from disk, builds a fresh map, and atomically swaps it under `w.mu`. Detection uses `errors.Is(err, fsnotify.ErrEventOverflow)` (not `strings.Contains`) so wrapped errors from future fsnotify versions still trigger recovery.

### 2. `session_data_service.go` WARN logs (lines 170 / 185 / 190)

**Bug:** `defaultLoadHookStatuses` silently `continue`d on `os.ReadDir`, `os.ReadFile`, and `json.Unmarshal` errors. Producer-side hook bugs from `cmd/agent-deck/hook_handler.go` were invisible from the consumer side, while the UI showed stale status.

**Fix:** WARN logs at all three sites (`hook_status_dir_read_failed`, `hook_status_read_failed`, `hook_status_unmarshal_failed`). `os.ErrNotExist` on the dir stays silent — that's the legitimate first-run condition, not a bug.

### 3. `cmd/agent-deck/hook_handler.go` 8 silent swallows

**Bug:** `writeHookStatus` and `writeCostEvent` silently dropped errors from `MkdirAll`, `json.Marshal`, `WriteFile`, and `Rename` (4 sites each = 8). Producer side of the file the consumer in (2) silently fails on — full double-blind.

**Fix:** WARN at all 8 sites with file/instance/error context. Added best-effort `.tmp` cleanup on Rename failure (previously orphaned tmp files accumulated).

### 4. `flicker_detected` synthetic event

**Bug:** the six-flicker oscillation incident (logging-review G6) was logged at Debug only — operators had to grep `status_changed` lines manually to detect it.

**Fix:** new `internal/session/flicker_detector.go` watches per-session status transitions over a sliding 60s window. Emits **one** WARN per session per 60s cooldown when transitions exceed 3. Wired into `internal/ui/home.go` at the existing `status_changed` site (only fires when `newStatus != oldStatus`, so quiet sessions pay no cost).

---

## Test plan

TDD discipline followed throughout — failing test landed first for every behavior change, then implementation, then verified the test went from red → green.

**14 new tests added:**

| File | Test | Asserts |
|---|---|---|
| `internal/session/hook_watcher_overflow_test.go` | `TestStatusFileWatcher_HandleOverflow_ResyncsFromDisk` | re-walk replaces stale map atomically |
| ″ | `TestStatusFileWatcher_HandleOverflow_LogsWarn` | WARN log emitted |
| ″ | `TestStatusFileWatcher_OverflowDispatch_DetectsErrEventOverflow` | `errors.Is` (not string match) |
| `internal/web/session_data_service_warnlog_test.go` | `TestDefaultLoadHookStatuses_WarnsOnUnmarshalError` | malformed JSON ⇒ WARN |
| ″ | `TestDefaultLoadHookStatuses_WarnsOnReadFileError` | unreadable file ⇒ WARN |
| ″ | `TestDefaultLoadHookStatuses_WarnsOnReadDirError` | unreadable dir ⇒ WARN |
| `cmd/agent-deck/hook_handler_warnlog_test.go` | `TestWriteHookStatus_WarnsOnMkdirError` | blocked hooks dir ⇒ WARN |
| ″ | `TestWriteHookStatus_WarnsOnWriteFileError` | read-only hooks dir ⇒ WARN |
| ″ | `TestWriteCostEvent_WarnsOnMkdirError` | blocked cost-events dir ⇒ WARN |
| `internal/session/flicker_detector_test.go` | `TestFlickerDetector_BelowThreshold_NoWarn` | 2 transitions/60s: no WARN |
| ″ | `TestFlickerDetector_AboveThreshold_EmitsWarn` | 4 transitions/15s: WARN |
| ″ | `TestFlickerDetector_SpreadOutsideWindow_NoWarn` | 4 transitions/6min: no WARN |
| ″ | `TestFlickerDetector_PerSessionIsolated` | one session's flicker doesn't taint another |
| ″ | `TestFlickerDetector_RateLimited` | 12 transitions in cooldown: exactly 1 WARN |

```
$ GOTOOLCHAIN=go1.24.0 go test ./internal/session/ ./internal/web/ \
                          ./cmd/agent-deck/ ./internal/ui/ -race -count=1
ok  internal/session   29.6s
ok  internal/web        2.1s
ok  cmd/agent-deck     58.9s
ok  internal/ui        28.8s

$ GOTOOLCHAIN=go1.24.0 go test -run TestPersistence_ \
                          ./internal/session/... -race -count=1
ok  4.8s   (mandatory CLAUDE.md gate)
```

## Notes

- **Pre-existing lint error in `cmd/agent-deck/session_cmd.go:2074`** (`SA9003: empty branch`) was introduced by PR #876 (commit `0681fa7d`) and is **not** touched by this PR. The push hook flagged it; bypassed with `LEFTHOOK=0` per the PROMPT's allowance for pre-existing lint blockers. All other hooks (fmt-check, vet, build, test) ran clean. Recommend a follow-up PR to fix the SA9003 separately so it doesn't keep blocking unrelated branches.
- No scope expansion: T2 (sister-function consolidation), T4 (test-correctness rewrites), T5 (FD leaks), T6 (safeGo wrapper), T7 (SQLite atomic writes) intentionally untouched here — separate v1.9 PRs per the priority plan.
- `flicker_detected` is a new log line; downstream parsers consuming `~/.agent-deck/debug.log` may want to whitelist it.

Refs: V1.9 priority plan T1 + T3. Issue rank #6 (inotify resync), #7 (hook read/parse logs), #8 (hook-handler swallows), #25 (flicker_detected WARN).