### PR TITLE
feat(mcppool): spawn each MCP child in its own systemd scope (cascade prevention)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP-per-scope cascade prevention.** On Linux+systemd hosts, each MCP child process now spawns inside its own transient user scope (`mcp-<owner>-<mcp>-<ts>.scope` under `mcp-pool.slice`) with `MemoryMax=1G`, `CPUWeight=50`, and `TasksMax=200`. Background: a 2026-05-08 cascade saw 43 simultaneous duplicate `@upstash/context7-mcp` instances accumulate inside the conductor's tmux scope (58.2 GB resident); when `user@1000` memory pressure crossed 50 %, systemd-oomd ranked cgroups by memory × pressure × pgscan and picked the conductor scope (largest by RSS) — SIGKILLing 604 processes in one shot, including the conductor itself. Per-MCP scopes give systemd-oomd a precise kill target so a misbehaving MCP becomes its own victim instead of dragging the orchestrator down. Gated behind `AGENT_DECK_MCP_ISOLATION` (default ON on Linux, OFF elsewhere); falls back to plain `exec.Cmd` when `systemd-run` is missing (containers, minimal images) or on macOS/Windows. Scope semantics use `systemd-run --scope`, which `execve`'s into the target command — so PID, file descriptors, env vars, process group, and the existing `Setpgid + SIGTERM-the-pgroup` cancel logic in `socket_proxy.go` all keep working unchanged. Wired into both stdio (`internal/mcppool/socket_proxy.go`) and HTTP (`internal/mcppool/http_server.go`) MCP launch paths. Eight new regression tests in `internal/mcppool/scope_launcher_test.go` and `scope_launcher_integration_test.go`, including a two-way correctness check (mutating `wrapMCPCommand` to drop the wrapper makes the integration test fail with the child landing back in the parent's scope — exactly the cascade pattern from the root cause analysis).
+
 ## [1.8.3] - 2026-05-07
 
 Hotfix bundle on top of v1.8.2. Three contributor PRs: a TUI inline-title regression and two conductor heartbeat-rules improvements bringing the OS heartbeat path to parity with `bridge.py`.

--- a/internal/mcppool/http_server.go
+++ b/internal/mcppool/http_server.go
@@ -152,8 +152,17 @@ func (s *HTTPServer) Start() error {
 	}
 	s.logWriter = logWriter
 
-	// Start the server process
-	s.process = exec.CommandContext(s.ctx, s.command, s.args...)
+	// Start the server process. On Linux+systemd we wrap each MCP child
+	// inside its own transient user scope so systemd-oomd's per-cgroup
+	// kill heuristic targets the misbehaving MCP, not the conductor.
+	launchCmd, launchArgs, scopeWrapped, scopeUnit := wrapMCPCommand(
+		fmt.Sprintf("%d", os.Getpid()), s.name, s.command, s.args)
+	s.process = exec.CommandContext(s.ctx, launchCmd, launchArgs...)
+	if scopeWrapped {
+		httpLog.Info("mcp_isolation_scope",
+			slog.String("mcp", s.name),
+			slog.String("unit", scopeUnit))
+	}
 	cmdEnv := os.Environ()
 	for k, v := range s.env {
 		// Reject environment variables that could be used for code injection.

--- a/internal/mcppool/scope_launcher.go
+++ b/internal/mcppool/scope_launcher.go
@@ -1,0 +1,136 @@
+package mcppool
+
+// MCP-per-scope cascade prevention (v1.9).
+//
+// On Linux+systemd, each MCP child process is launched inside its own
+// transient user scope (`mcp-<owner>-<mcp>-<ts>.scope` under
+// `mcp-pool.slice`). When systemd-oomd ranks cgroups for kill selection
+// it walks per-scope memory, pressure, and pgscan deltas — so a
+// misbehaving MCP becomes its own kill target rather than dragging the
+// conductor or session scope down with it.
+//
+// Background: 2026-05-08 cascade — 43 simultaneous duplicate
+// `@upstash/context7-mcp` instances accumulated inside the conductor's
+// tmux scope (58.2 GB resident). When user@1000 pressure crossed 50%,
+// systemd-oomd picked the conductor scope (largest by RSS) and SIGKILLed
+// 604 processes in one shot. Per-MCP scopes prevent the kill from
+// targeting the orchestrator. See worker-root-cause/RESULTS.md.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// lookupSystemdRun returns the absolute path to systemd-run, or "" if it
+// is not on PATH. Overridable in tests.
+var lookupSystemdRun = func() string {
+	p, err := exec.LookPath("systemd-run")
+	if err != nil {
+		return ""
+	}
+	return p
+}
+
+// runtimeGOOS shadows runtime.GOOS so tests can simulate non-Linux hosts
+// without needing a real cross-build.
+var runtimeGOOS = runtime.GOOS
+
+// scopeIsolationEnabled reports whether MCP-per-scope wrapping is active.
+// Default: ON on Linux, OFF elsewhere. Overridable via the
+// AGENT_DECK_MCP_ISOLATION env var: 1/true/on/yes enable, 0/false/off/no
+// disable.
+func scopeIsolationEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("AGENT_DECK_MCP_ISOLATION"))) {
+	case "1", "true", "on", "yes":
+		return true
+	case "0", "false", "off", "no":
+		return false
+	}
+	return runtimeGOOS == "linux"
+}
+
+// sanitizeScopeToken keeps systemd-acceptable characters (alnum, dash,
+// underscore) and replaces the rest with '-'. Empty input becomes "x".
+// Truncates to 32 chars so the assembled unit name stays well under the
+// 256-char systemd unit-name limit.
+func sanitizeScopeToken(s string) string {
+	if s == "" {
+		return "x"
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := b.String()
+	if len(out) > 32 {
+		out = out[:32]
+	}
+	if out == "" {
+		return "x"
+	}
+	return out
+}
+
+// scopeUnitName builds a unique transient .scope name for an MCP child.
+// Format: mcp-<owner>-<mcp>-<utc-timestamp>.scope
+func scopeUnitName(ownerID, mcpName string) string {
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	return fmt.Sprintf("mcp-%s-%s-%s.scope",
+		sanitizeScopeToken(ownerID),
+		sanitizeScopeToken(mcpName),
+		ts)
+}
+
+// wrapMCPCommand returns the (cmd, args) to use when starting an MCP
+// child process. When scope isolation is enabled and supported, the
+// returned command runs the original command inside a transient
+// per-MCP systemd user scope. When isolation is disabled, missing
+// systemd-run, or running on a non-Linux host, the original command
+// and args are returned untouched and wrapped is false.
+//
+// ownerID is a short, stable identifier for the owning agent-deck
+// instance (typically the process PID). It exists only to disambiguate
+// scope names when multiple agent-deck instances coexist on the same
+// host. mcpName is the user-facing MCP server name.
+func wrapMCPCommand(ownerID, mcpName, origCommand string, origArgs []string) (cmd string, args []string, wrapped bool, unit string) {
+	if !scopeIsolationEnabled() {
+		return origCommand, origArgs, false, ""
+	}
+	if runtimeGOOS != "linux" {
+		return origCommand, origArgs, false, ""
+	}
+	sr := lookupSystemdRun()
+	if sr == "" {
+		return origCommand, origArgs, false, ""
+	}
+
+	unit = scopeUnitName(ownerID, mcpName)
+	wrapArgs := []string{
+		"--user",
+		"--scope",
+		"--quiet",
+		"--collect",
+		"--unit=" + unit,
+		"--slice=mcp-pool.slice",
+		"-p", "MemoryMax=1G",
+		"-p", "CPUWeight=50",
+		"-p", "TasksMax=200",
+		"--",
+		origCommand,
+	}
+	wrapArgs = append(wrapArgs, origArgs...)
+	return sr, wrapArgs, true, unit
+}

--- a/internal/mcppool/scope_launcher_integration_test.go
+++ b/internal/mcppool/scope_launcher_integration_test.go
@@ -1,0 +1,111 @@
+package mcppool
+
+// Integration test: prove the SocketProxy spawn path actually applies
+// the per-MCP scope wrapper end-to-end. Wrapper-unit tests (in
+// scope_launcher_test.go) only verify the argv shape; this test catches
+// regressions where the wrapper exists but is not called from the spawn
+// site.
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSocketProxy_SpawnsChildInPerMCPScope verifies that after Start(),
+// the MCP child PID is registered under `mcp-pool.slice/mcp-*.scope`.
+// This is the regression gate for the cascade-prevention work: if the
+// spawn site forgets to call wrapMCPCommand (or someone reverts the
+// wrapping), the child lands back in the parent's scope and this test
+// fails.
+func TestSocketProxy_SpawnsChildInPerMCPScope(t *testing.T) {
+	if !systemdRunAvailable() {
+		t.Skip("systemd-run / user manager unavailable")
+	}
+	t.Setenv("AGENT_DECK_MCP_ISOLATION", "1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// `sh -c 'sleep 30'` stays alive long enough to read its cgroup
+	// before it exits. We don't actually speak MCP protocol — the goal
+	// is to exercise the spawn site, not the JSON-RPC layer.
+	proxy, err := NewSocketProxy(ctx, "scopetest", "sh", []string{"-c", "sleep 30"}, nil)
+	if err != nil {
+		t.Fatalf("NewSocketProxy: %v", err)
+	}
+	t.Cleanup(func() { _ = proxy.Stop() })
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("proxy.Start: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	var (
+		cgroupContents string
+		childPID       int
+	)
+	for time.Now().Before(deadline) {
+		if proxy.mcpProcess == nil || proxy.mcpProcess.Process == nil {
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		childPID = proxy.mcpProcess.Process.Pid
+		data, err := os.ReadFile("/proc/" + strconv.Itoa(childPID) + "/cgroup")
+		if err == nil {
+			cgroupContents = string(data)
+			if strings.Contains(cgroupContents, "mcp-pool.slice/mcp-") &&
+				strings.Contains(cgroupContents, ".scope") {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if childPID == 0 {
+		t.Fatalf("child process never started")
+	}
+	t.Fatalf("child pid=%d cgroup did not enter mcp-pool.slice/mcp-*.scope within 3s\ncgroup contents:\n%s",
+		childPID, cgroupContents)
+}
+
+// TestSocketProxy_DisabledIsolation_StaysInParentScope is the negative
+// case: when AGENT_DECK_MCP_ISOLATION=0, the child must NOT be wrapped.
+// The child's /proc/<pid>/comm should be 'sh' (the original command),
+// not 'systemd-run'.
+func TestSocketProxy_DisabledIsolation_StaysInParentScope(t *testing.T) {
+	if _, err := os.Stat("/proc/self/cgroup"); err != nil {
+		t.Skip("non-Linux")
+	}
+	t.Setenv("AGENT_DECK_MCP_ISOLATION", "0")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	proxy, err := NewSocketProxy(ctx, "scopetest-off", "sh", []string{"-c", "sleep 30"}, nil)
+	if err != nil {
+		t.Fatalf("NewSocketProxy: %v", err)
+	}
+	t.Cleanup(func() { _ = proxy.Stop() })
+
+	if err := proxy.Start(); err != nil {
+		t.Fatalf("proxy.Start: %v", err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	if proxy.mcpProcess == nil || proxy.mcpProcess.Process == nil {
+		t.Fatalf("no child process")
+	}
+
+	comm, err := os.ReadFile("/proc/" + strconv.Itoa(proxy.mcpProcess.Process.Pid) + "/comm")
+	if err != nil {
+		t.Fatalf("read /proc/comm: %v", err)
+	}
+	got := strings.TrimSpace(string(comm))
+	if got == "systemd-run" {
+		t.Fatalf("isolation disabled but child is systemd-run; wrapper leaked: comm=%q", got)
+	}
+}

--- a/internal/mcppool/scope_launcher_test.go
+++ b/internal/mcppool/scope_launcher_test.go
@@ -1,0 +1,204 @@
+package mcppool
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// systemdRunAvailable returns true on Linux when systemd-run is on PATH and
+// the user's systemd instance is reachable. Tests that depend on a real
+// scope being registered must skip if this returns false.
+func systemdRunAvailable() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		return false
+	}
+	if err := exec.Command("systemctl", "--user", "is-system-running").Run(); err != nil {
+		// is-system-running returns non-zero for "degraded" too; that's fine.
+		// Only skip if the user manager can't be reached at all (exit > 4).
+		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() < 5 {
+			return true
+		}
+		return false
+	}
+	return true
+}
+
+// TestWrapMCPCommand_LinuxArgvShape verifies the wrapped argv on Linux
+// when systemd-run is available and isolation is enabled. This is the
+// regression-gate test: if the wrapper is removed or bypassed, this test
+// fails.
+func TestWrapMCPCommand_LinuxArgvShape(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only: argv shape uses systemd-run")
+	}
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		t.Skip("systemd-run not on PATH")
+	}
+	t.Setenv("AGENT_DECK_MCP_ISOLATION", "1")
+
+	cmd, args, wrapped, unit := wrapMCPCommand("sess-abc", "context7", "/usr/bin/npm", []string{"exec", "@upstash/context7-mcp"})
+
+	if !wrapped {
+		t.Fatalf("wrapMCPCommand: expected wrapped=true on Linux with systemd-run available; got false")
+	}
+	if !strings.HasSuffix(cmd, "systemd-run") {
+		t.Errorf("cmd: want suffix 'systemd-run', got %q", cmd)
+	}
+	if !strings.HasPrefix(unit, "mcp-") || !strings.HasSuffix(unit, ".scope") {
+		t.Errorf("unit name: want mcp-...scope, got %q", unit)
+	}
+	if !strings.Contains(unit, "context7") {
+		t.Errorf("unit name should embed mcp name 'context7', got %q", unit)
+	}
+
+	joined := strings.Join(args, " ")
+	wants := []string{
+		"--user",
+		"--scope",
+		"--slice=mcp-pool.slice",
+		"MemoryMax=1G",
+		"CPUWeight=50",
+		"TasksMax=200",
+	}
+	for _, w := range wants {
+		if !strings.Contains(joined, w) {
+			t.Errorf("argv missing %q; full args: %v", w, args)
+		}
+	}
+
+	// The original command and its args must come AFTER the `--` sentinel
+	// so user-supplied args can never be interpreted as systemd-run flags.
+	sentinelIdx := -1
+	for i, a := range args {
+		if a == "--" {
+			sentinelIdx = i
+			break
+		}
+	}
+	if sentinelIdx < 0 {
+		t.Fatalf("expected `--` separator in args: %v", args)
+	}
+	if sentinelIdx+1 >= len(args) || args[sentinelIdx+1] != "/usr/bin/npm" {
+		t.Errorf("expected /usr/bin/npm right after `--`, got args=%v", args)
+	}
+	if sentinelIdx+3 >= len(args) || args[sentinelIdx+2] != "exec" || args[sentinelIdx+3] != "@upstash/context7-mcp" {
+		t.Errorf("expected original args after command, got tail=%v", args[sentinelIdx+1:])
+	}
+}
+
+// TestWrapMCPCommand_DisabledByEnv verifies the env-var opt-out.
+func TestWrapMCPCommand_DisabledByEnv(t *testing.T) {
+	t.Setenv("AGENT_DECK_MCP_ISOLATION", "0")
+	cmd, args, wrapped, unit := wrapMCPCommand("s", "m", "/bin/echo", []string{"hi"})
+	if wrapped {
+		t.Errorf("expected wrapped=false with AGENT_DECK_MCP_ISOLATION=0")
+	}
+	if cmd != "/bin/echo" {
+		t.Errorf("cmd should pass through unchanged; got %q", cmd)
+	}
+	if len(args) != 1 || args[0] != "hi" {
+		t.Errorf("args should pass through unchanged; got %v", args)
+	}
+	if unit != "" {
+		t.Errorf("unit should be empty when not wrapped; got %q", unit)
+	}
+}
+
+// TestWrapMCPCommand_FallbackWhenSystemdRunMissing verifies graceful fallback
+// when systemd-run is not on PATH (covers Docker containers, minimal images,
+// and similar Linux-but-no-systemd environments).
+func TestWrapMCPCommand_FallbackWhenSystemdRunMissing(t *testing.T) {
+	t.Setenv("AGENT_DECK_MCP_ISOLATION", "1")
+
+	orig := lookupSystemdRun
+	t.Cleanup(func() { lookupSystemdRun = orig })
+	lookupSystemdRun = func() string { return "" }
+
+	cmd, args, wrapped, _ := wrapMCPCommand("s", "m", "/bin/echo", []string{"hi"})
+	if wrapped {
+		t.Errorf("expected wrapped=false when systemd-run missing")
+	}
+	if cmd != "/bin/echo" || len(args) != 1 || args[0] != "hi" {
+		t.Errorf("expected pass-through; got cmd=%q args=%v", cmd, args)
+	}
+}
+
+// TestWrapMCPCommand_NonLinuxFallback verifies the wrapper is a no-op
+// on macOS/Windows even with isolation enabled, so dev workflows on
+// those platforms aren't broken.
+func TestWrapMCPCommand_NonLinuxFallback(t *testing.T) {
+	t.Setenv("AGENT_DECK_MCP_ISOLATION", "1")
+	orig := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = orig })
+	runtimeGOOS = "darwin"
+
+	cmd, _, wrapped, _ := wrapMCPCommand("s", "m", "/bin/echo", []string{"hi"})
+	if wrapped {
+		t.Errorf("expected wrapped=false on darwin")
+	}
+	if cmd != "/bin/echo" {
+		t.Errorf("expected pass-through on darwin; got %q", cmd)
+	}
+}
+
+// TestWrapMCPCommand_DefaultIsOnForLinux: with no env var set, isolation
+// should default to ON on Linux (the cascade-prevention default).
+func TestWrapMCPCommand_DefaultIsOnForLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only")
+	}
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		t.Skip("systemd-run not on PATH")
+	}
+	// Setenv-then-unset to guarantee a clean state.
+	t.Setenv("AGENT_DECK_MCP_ISOLATION", "")
+	_, _, wrapped, _ := wrapMCPCommand("s", "m", "/bin/true", nil)
+	if !wrapped {
+		t.Errorf("default isolation should be ON on Linux when env unset")
+	}
+}
+
+// TestWrapMCPCommand_ScopeAppearsInCgls launches a real /bin/sleep through
+// the wrapper, then verifies the resulting unit is registered with the
+// user's systemd instance via `systemctl --user is-active`.
+func TestWrapMCPCommand_ScopeAppearsInCgls(t *testing.T) {
+	if !systemdRunAvailable() {
+		t.Skip("systemd-run / user manager unavailable")
+	}
+	t.Setenv("AGENT_DECK_MCP_ISOLATION", "1")
+
+	cmd, args, wrapped, unit := wrapMCPCommand("smoke", "appears", "/bin/sleep", []string{"5"})
+	if !wrapped {
+		t.Fatalf("expected wrapping in this environment")
+	}
+
+	proc := exec.Command(cmd, args...)
+	if err := proc.Start(); err != nil {
+		t.Fatalf("start wrapped sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		if proc.Process != nil {
+			_ = proc.Process.Kill()
+		}
+		_, _ = proc.Process.Wait()
+	})
+
+	// Give systemd-run a moment to register the scope.
+	deadline := time.Now().Add(3 * time.Second)
+	var lastState string
+	for time.Now().Before(deadline) {
+		out, _ := exec.Command("systemctl", "--user", "is-active", unit).CombinedOutput()
+		lastState = strings.TrimSpace(string(out))
+		if lastState == "active" || lastState == "activating" {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("scope %q never became active; last state=%q", unit, lastState)
+}

--- a/internal/mcppool/socket_proxy.go
+++ b/internal/mcppool/socket_proxy.go
@@ -214,7 +214,14 @@ func (p *SocketProxy) Start() error {
 	}
 	p.logWriter = logWriter
 
-	p.mcpProcess = exec.CommandContext(p.ctx, p.command, p.args...)
+	launchCmd, launchArgs, scopeWrapped, scopeUnit := wrapMCPCommand(
+		fmt.Sprintf("%d", os.Getpid()), p.name, p.command, p.args)
+	p.mcpProcess = exec.CommandContext(p.ctx, launchCmd, launchArgs...)
+	if scopeWrapped {
+		proxyLog.Info("mcp_isolation_scope",
+			slog.String("mcp", p.name),
+			slog.String("unit", scopeUnit))
+	}
 	cmdEnv := os.Environ()
 	for k, v := range p.env {
 		// Reject environment variables that could be used for code injection.


### PR DESCRIPTION
## Summary

Patches the MCP spawn path so each MCP child process spawns inside its own
transient systemd user scope (`mcp-<owner>-<mcp>-<ts>.scope` under
`mcp-pool.slice`) on Linux+systemd. When systemd-oomd evaluates cgroups
for kill selection (memory × pressure × pgscan), each MCP becomes its own
kill target instead of dragging the conductor or session scope down.

- New `internal/mcppool/scope_launcher.go` — `wrapMCPCommand` returns the
  `(cmd, args)` to feed `exec.CommandContext`. Wraps `systemd-run --user
  --scope --slice=mcp-pool.slice -p MemoryMax=1G -p CPUWeight=50 -p
  TasksMax=200 -- <orig>`. Falls back to plain exec when `systemd-run`
  is missing (containers, minimal images) or on macOS/Windows. Gated on
  `AGENT_DECK_MCP_ISOLATION` (default ON on Linux, OFF elsewhere).
- Wired into both stdio (`socket_proxy.go:217`) and HTTP
  (`http_server.go:156`) MCP launch paths.
- `systemd-run --scope` execve's into the target command — so PID, fds,
  env, pgid, and the existing `Setpgid + SIGTERM-the-pgroup` cancel logic
  in `socket_proxy.go:239` keep working unchanged. No MCP runtime
  semantics changed (timeout, retry, env injection all untouched).

## Why

See `worker-root-cause/RESULTS.md`. 2026-05-08 cascade summary:

- 43 simultaneous duplicate `@upstash/context7-mcp` instances
  accumulated inside the conductor's tmux scope
  (`agentdeck-tmux-agentdeck-agent-deck-2c2a0915.scope`, 58.2 GB
  resident).
- When `user@1000` memory pressure crossed 50 % (avg10), systemd-oomd
  ranked 41 cgroups by **memory × pressure × pgscan delta** and picked
  the conductor scope — largest by RSS, highest pgscan delta.
- `unified.kill_all=true` SIGKILLed 604 processes in one shot, including
  the conductor itself.

The fix is *targeting*: per-MCP scopes give oomd a precise victim so the
misbehaving MCP becomes its own kill target instead of the orchestrator
that has been patiently accumulating MCP children.

## TDD evidence

Eight new tests in `internal/mcppool/`:

| Test | Type | What it locks down |
|---|---|---|
| `TestWrapMCPCommand_LinuxArgvShape` | unit | argv begins with `systemd-run --user --scope --slice=mcp-pool.slice -p MemoryMax=1G ...`; original args sit AFTER `--` (no flag-injection vector); unit name embeds MCP name |
| `TestWrapMCPCommand_DisabledByEnv` | unit | `AGENT_DECK_MCP_ISOLATION=0` → pass-through |
| `TestWrapMCPCommand_FallbackWhenSystemdRunMissing` | unit | missing `systemd-run` → pass-through, no error |
| `TestWrapMCPCommand_NonLinuxFallback` | unit | `runtimeGOOS=darwin` → pass-through |
| `TestWrapMCPCommand_DefaultIsOnForLinux` | unit | env unset on Linux → wrapping enabled |
| `TestWrapMCPCommand_ScopeAppearsInCgls` | smoke | runs `/bin/sleep` through wrapper, verifies `systemctl --user is-active <unit>` reports `active`/`activating` |
| `TestSocketProxy_SpawnsChildInPerMCPScope` | integration | spawns real `SocketProxy`, reads `/proc/<child-pid>/cgroup`, asserts the child landed in `mcp-pool.slice/mcp-*.scope` |
| `TestSocketProxy_DisabledIsolation_StaysInParentScope` | integration | with isolation=0, child's `/proc/<pid>/comm` is the original command, not `systemd-run` |

### Failing test that proved the bug (TDD red)

The bug — that MCP children inherit the conductor's scope — is captured
by `TestSocketProxy_SpawnsChildInPerMCPScope`. On `main` (without this
patch) the test fails as:

```
child pid=3834272 cgroup did not enter mcp-pool.slice/mcp-*.scope within 3s
cgroup contents:
0::/user.slice/user-1000.slice/user@1000.service/app.slice/agentdeck-tmux-agentdeck-sessions-e24301e8.scope
```

That cgroup path — the parent's tmux scope — is **exactly the cascade
pattern**. Two-way correctness verified: mutating `wrapMCPCommand` to
unconditionally return the original command makes 4 tests fail
(`LinuxArgvShape`, `DefaultIsOnForLinux`, `ScopeAppearsInCgls`,
`SpawnsChildInPerMCPScope`).

### Test results

```
$ go test -race -count=1 ./internal/mcppool/...
ok    github.com/asheshgoplani/agent-deck/internal/mcppool    2.680s

$ go test -count=1 ./cmd/agent-deck/...
ok    github.com/asheshgoplani/agent-deck/cmd/agent-deck    58.355s
```

## Test plan

- [ ] Reviewer runs `GOTOOLCHAIN=go1.24.0 go test -race -count=1 ./internal/mcppool/...` on a Linux+systemd host
- [ ] Reviewer confirms `mcp-*.scope` units appear in `systemctl --user list-units --type=scope` after starting an MCP (and disappear after MCP exits, thanks to `--collect`)
- [ ] On a non-Linux host (macOS): confirm the wrapper short-circuits and MCP spawn semantics are unchanged
- [ ] Verify cancel still terminates the MCP child correctly (existing `TestSocketProxy_NoZombie_*` tests pass)

## Deviations / known notes

- **`LEFTHOOK=0` was used on `git push`.** Two pre-push checks fail on a
  clean checkout of `main`, unrelated to this change:
  1. `lint`: `internal/web/static_files.go:15:5: embed
     static/.brute-tw.src.css: open
     internal/web/static/.brute-tw.src.css: no such file or directory`
     — the embed file is missing in the working tree; pre-existing.
  2. `test`: `TestResponseRoutingNoXTalk` is a pre-existing flake under
     full-repo `go test -race -count=1 ./...` parallel load (passes
     reliably when the package is run on its own — verified with
     `-count=3`). Not introduced by this PR.
  
  Per `PROMPT.md`: "Use `LEFTHOOK=0` only if a PRE-EXISTING lint blocker
  is encountered; document in PR body."

- The `--collect` flag on `systemd-run` causes systemd to GC the scope
  unit when the process exits, so successful runs leave no residue in
  `systemctl --user list-units --all`.

- `MemoryMax=1G` is conservative — most MCPs idle under 100 MB. If a
  legitimate MCP regularly OOMs at 1 GB we should raise the cap rather
  than removing the wrapper. Surfacing OOM kills via the
  `mcp_isolation_killed` log line is left to a follow-up (would require
  monitoring scope status post-exit).

🚫 Per `~/.claude/CLAUDE.md`: do not merge — only Ashesh merges.