### PR TITLE
test(v1.9): Phase 1 regression coverage (12 cases, P0 use-case + v1.8.x regression scenarios)

### DIFF
--- a/PHASE1-PICKS.md
+++ b/PHASE1-PICKS.md
@@ -1,0 +1,34 @@
+# v1.9 Phase 1 — 12 Regression Test Picks
+
+**Branch:** `feat/v1.9-phase1-tests` (off `origin/main` @ v1.8.3).
+**Constraint:** test-only. No impl changes. If a test reveals a bug, file an issue.
+**Selection rubric:** v1.8.x regressions (#864 #876 #856 #816 #881 #867) **or** P0 use-case scenarios from `USE-CASES-AND-TESTS.md` (S-LC-1, S-MS-3, S-FAIL-7, S-CLI-1, S-CLI-4) **or** parity gaps that #898 / #900 abstractions exposed but didn't cover.
+
+| # | Case ID | Layer | Maps to | What it asserts |
+|---|---|---|---|---|
+| 1 | `prof-001` | `internal/session` | T2 / #881 / J3 | `GetEffectiveProfile` falls back to `config.json` `default_profile` when no env vars are set (priority 4 of the resolution ladder). Today only priorities 1–3 have tests — config-default is the fallback users hit on a clean machine, and a regression here would silently re-route every read to "default". |
+| 2 | `prof-002` | `internal/session` | T2 / #881 / J3 | Full table-driven precedence chain: explicit > `AGENTDECK_PROFILE` > `CLAUDE_CONFIG_DIR` > config default > literal "default". Locks the contract documented in `config.go:301-336` so no re-ordering accident slips through. |
+| 3 | `prof-003` | `internal/session` | T2 / #881 / TUI K2 | `profileFromClaudeConfigDir` directly: every documented mapping (`~/.claude-work` → "work", `~/.claude-personal` → "personal", `~/.claude` → "" no-inference, `/opt/claude-prod` → "prod") plus negative cases (empty, no dash, just trailing dash). Today this helper is only exercised through indirect paths in 2 tests. |
+| 4 | `web-001` | `internal/web` | #867 / J2 (joeblubaugh) | `GET /api/menu` applies `refreshSnapshotHookStatuses` — fresh "waiting" hook lifts a stale "error" snapshot. Today only `GET /api/sessions` has this end-to-end assertion (`TestParity_WaitingStatusFlowsThroughHandler`); `handleMenu` calls the same helper at `handlers_menu.go:41` but is untested at the handler boundary. |
+| 5 | `web-002` | `internal/web` | #867 / J2 | `GET /api/session/{id}` applies `refreshSnapshotHookStatuses` — same divergence-lift assertion for the per-session endpoint at `handlers_menu.go:72`. Without this, a refactor that drops the call site from one handler but not the other would slip. |
+| 6 | `web-003` | `internal/web` | #867 defensive | `refreshSnapshotHookStatuses` tolerates nil snapshot, items with nil `Session`, items that are groups, and an empty loader return. The current implementation has guards but no test pins them — a future refactor that removes them would crash on real production snapshots that always interleave groups and sessions. |
+| 7 | `send-001` | `cmd/agent-deck` | #876 / S-CLI-4 | `messageDeliveryToken` (the helper that gates body-in-pane delivery evidence at `session_cmd.go:2123`): empty/short → "", >64 chars → truncated to 64, whitespace-trimmed. Currently has zero direct tests. |
+| 8 | `send-002` | `cmd/agent-deck` | #876 / S-CLI-4 (large-prompt receipt) | `sendWithRetryTarget(verifyDelivery=true)` accepts a 100KB-class message body match in the pane as positive delivery evidence — exercises `messageDeliveryToken`'s 64-char cap on the real call path. The existing `TestSendWithRetryTarget_VerifyDelivery_AcceptsMessageInPane` only tests a 19-char token; the silent-drop bug class manifests on multi-KB conductor prompts. |
+| 9 | `rebind-001` | `internal/session` | #856 boundary | `clearRebindMtimeGrace` boundary: candidate.mtime - current.mtime ≥ 5s rebinds even if smaller; gap of 4s rejects. Existing `TestSessionIDFromHook_ClearRebindWinsOnMtimeGap` (instance_test.go:3576) covers the happy path with a generous gap; nobody pins the threshold itself, so a future "make it 30s" tweak would silently change behavior. |
+| 10 | `status-001` | `internal/web` | J1 / S-CLI-1-SCHEMA-STABILITY | Every `session.Status` value serializes to its documented JSON literal through `GET /api/sessions`. The existing `TestParity_AllStatusesPreservedThroughGetSessions` only asserts round-trip; this asserts exact wire format (`"status":"running"`, etc.) so any future Status-marshal refactor that changes casing or symbol breaks the CLI/JS shape contract loudly. |
+| 11 | `route-001` | `internal/web` | F8 / negative routing | `GET /api/session/{id}` for an unknown id returns 404 with `code:"NOT_FOUND"`, not 200/null or 500 — the per-session endpoint must be a hard negative under both no-overlay and overlay-present branches. Pins the contract that webMutations and overlay state never leak into the read-error path. |
+| 12 | `status-stop-001` | `internal/web` | J5 / B14 / #867 negative | `GET /api/menu`: a "stopped" session is **never** flipped by a fresh "waiting" hook overlay. Asserts the user-intentional rule (Instance.UpdateStatus + applyHookStatusToMenuSession `StatusStopped` short-circuit) at the handler boundary so nobody wires hookStatusLoader past the stopped-stickiness guard. |
+
+## Skipped on purpose
+
+- **🚫 Untestable in CI**: WEB-K1/K2 (host-emulator paste/cmd-click), WEB-J4 multi-client tmux size negotiation, TUI G1 XTVERSION leak (host-PTY).
+- **❓ Product decision pending**: WEB-A1–A10 topbar redesign, S-MS-4 sort-by-actionable, S-FAIL-13 multi-instance lock spec, mobile/tablet SLA.
+- **Already covered**: #864 (`conductor/tests/test_python_compat.py`), #856 happy path (`TestSessionIDFromHook_ClearRebindWinsOnMtimeGap`), #876 verifyDelivery error (`TestSendWithRetryTarget_VerifyDelivery_ErrorsWhenNoEvidenceOfReceipt`).
+- **Needs new infrastructure not in scope**: TUI lifecycle B1 (needs `fakeInotify`+`teatest`+`fakeClock`), hook event drop simulator (needs Linux real-fsnotify harness), CLI ↔ web cross-process fixture (needs separate test binary).
+
+## Execution discipline
+
+- One commit per case for clean review.
+- After each commit: `go test -race -count=1` on the touched package.
+- If a test fails on `main` (i.e. the case turns up a real bug), file an issue and add an `ACTION: PHASE1_FOUND_BUG` line to `RESULTS.md`. Do NOT fix the impl in this PR.
+- `LEFTHOOK=0` only for pre-existing lint failures, documented per commit.

--- a/cmd/agent-deck/session_send_token_test.go
+++ b/cmd/agent-deck/session_send_token_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// Phase 1 v1.9 regression coverage for issue #876 (silent send drop) —
+// cases send-001 and send-002.
+//
+// messageDeliveryToken (session_cmd.go:2123) is the helper that gates the
+// "did the message body show up in the captured pane?" branch of
+// sendWithRetryTarget's verifyDelivery loop. It has zero direct tests
+// today; the branch is only exercised indirectly via
+// TestSendWithRetryTarget_VerifyDelivery_AcceptsMessageInPane with a
+// 19-character token. Conductor / scripted callers (S-CLI-4) routinely
+// send 100KB-class prompts — exactly the size where the 64-char truncation
+// matters and where a regression that returned "" for "long" inputs would
+// silently disable body-in-pane verification, re-opening the #876 hole.
+
+// send-001: messageDeliveryToken contract.
+//
+// The function MUST:
+//   - Return "" for short or whitespace-only messages (avoids false-positive
+//     matches on common short strings like "hi" / "ok" appearing in any pane).
+//   - Return the trimmed prefix capped at 64 chars for longer messages.
+//
+// Constants pinned (minTokenLen=12, maxTokenLen=64) so a refactor that
+// flipped them invalidates the calibration that callers depend on.
+func TestMessageDeliveryToken_Contract(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty → empty", in: "", want: ""},
+		{name: "whitespace-only → empty", in: "   \n\t  ", want: ""},
+		{name: "below minTokenLen → empty", in: "short msg", want: ""},
+		{name: "exactly minTokenLen-1 → empty", in: strings.Repeat("a", 11), want: ""},
+		{name: "exactly minTokenLen → kept", in: strings.Repeat("a", 12), want: strings.Repeat("a", 12)},
+		{name: "between min and max → kept verbatim", in: "DELIVERY_TOKEN_876_marker", want: "DELIVERY_TOKEN_876_marker"},
+		{name: "exactly maxTokenLen → kept verbatim", in: strings.Repeat("x", 64), want: strings.Repeat("x", 64)},
+		{name: "above maxTokenLen → truncated", in: strings.Repeat("y", 100), want: strings.Repeat("y", 64)},
+		{
+			// 100KB prompt — the S-CLI-4 conductor surface from USE-CASES-AND-TESTS.md.
+			// MUST NOT return "" (that would silently disable body-in-pane verify);
+			// must truncate to exactly 64 chars.
+			name: "100KB prompt truncates to 64 not empty",
+			in:   "PROMPT_HEAD_DIAGTOKEN_99__" + strings.Repeat("z", 100*1024),
+			want: ("PROMPT_HEAD_DIAGTOKEN_99__" + strings.Repeat("z", 100*1024))[:64],
+		},
+		{
+			// Leading/trailing whitespace must be trimmed BEFORE the cap so the
+			// returned token is always content, not whitespace.
+			name: "whitespace trimmed before cap",
+			in:   "    " + strings.Repeat("z", 70) + "    ",
+			want: strings.Repeat("z", 64),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := messageDeliveryToken(tc.in); got != tc.want {
+				if len(got) > 80 || len(tc.want) > 80 {
+					t.Errorf("messageDeliveryToken: len(got)=%d len(want)=%d "+
+						"(short prefix: got=%q want=%q)",
+						len(got), len(tc.want),
+						truncForLog(got, 32), truncForLog(tc.want, 32))
+				} else {
+					t.Errorf("messageDeliveryToken(%q) = %q, want %q", tc.in, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// send-002: large-prompt verification end-to-end.
+//
+// Drives sendWithRetryTarget with verifyDelivery=true, a multi-KB message,
+// and a pane that contains the message's first 64 chars (mirroring how a
+// real Claude composer renders a wrapped paste). MUST return nil — i.e. the
+// truncated body match is recognized as positive delivery evidence.
+//
+// This is the test that closes the conductor / S-CLI-4 silent-drop gap:
+// without messageDeliveryToken's 64-char prefix, the verifyDelivery loop
+// would never observe the message body for any prompt larger than the
+// pane's visible surface, and #876 would re-open for large prompts.
+func TestSendWithRetryTarget_VerifyDelivery_LargePromptBodyMatch(t *testing.T) {
+	// 8KB prompt with a distinctive 32-char head; well past maxTokenLen (64).
+	const head = "DIAGTOKEN_876_LARGE_PROMPT_HEAD_"
+	body := head + strings.Repeat("payload-", 1024) // ~8KB
+	if len(body) < 4096 {
+		t.Fatalf("test setup: body too short (%d)", len(body))
+	}
+
+	// Pane shows the first 64 chars of the body (what messageDeliveryToken
+	// captures and looks for). Real Claude composers wrap and truncate but
+	// always preserve the leading content; a 64-char head match is the
+	// canonical positive signal.
+	paneAfterPaste := head + strings.Repeat("payload-", 4) // 32 + 32 = 64 chars of head+payload
+	if len(paneAfterPaste) < 64 {
+		t.Fatalf("test setup: paneAfterPaste must include >=64 chars of body, got %d", len(paneAfterPaste))
+	}
+
+	statuses := []string{"waiting", "waiting", "waiting", "waiting", "waiting"}
+	panes := []string{"", paneAfterPaste, paneAfterPaste, paneAfterPaste, paneAfterPaste}
+	mock := &mockSendRetryTarget{statuses: statuses, panes: panes}
+
+	err := sendWithRetryTarget(mock, body, false, sendRetryOptions{
+		maxRetries: 5, checkDelay: 0, verifyDelivery: true,
+	})
+	if err != nil {
+		t.Fatalf("verifyDelivery on large prompt must accept body-prefix match: got error %v "+
+			"(this is the S-CLI-4 / #876 conductor large-prompt silent-drop scenario)", err)
+	}
+	// Sanity: the initial send fired exactly once. A regression that decided
+	// "large body → just retry harder" would inflate this and re-open #479.
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
+		t.Fatalf("expected 1 SendKeysAndEnter call (initial only), got %d", got)
+	}
+}
+
+// truncForLog avoids dumping a 100KB string in test failures. Returns
+// content-bearing prefix + length.
+func truncForLog(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(" + itoa(len(s)) + " chars)"
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/profile/precedence_test.go
+++ b/internal/profile/precedence_test.go
@@ -1,0 +1,197 @@
+package profile
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Phase 1 v1.9 regression coverage for issue #881 (profile divergence).
+//
+// The existing parity_test.go pins TUI↔web parity for two env shapes only:
+//   * CLAUDE_CONFIG_DIR set, AGENTDECK_PROFILE unset  → "work"
+//   * AGENTDECK_PROFILE explicit                       → wins over CLAUDE_CONFIG_DIR
+//
+// Three holes remain. Each is a v1.9 ship-blocker because a regression
+// silently re-routes every read to the wrong profile (= "I deleted all my
+// sessions" support thread):
+//
+//   prof-001: priority 4 (config.json default_profile) when no env vars set.
+//   prof-002: full precedence ladder explicit > env > CLAUDE_CONFIG_DIR > config > "default".
+//   prof-003: profileFromClaudeConfigDir behavior on every documented variant.
+//
+// Tests live in internal/profile so the public DetectCurrentProfile() — the
+// shim TUI consumers still import — is exercised end-to-end. Cross-package
+// boundary catches re-imports that bypass the unification done in #881.
+
+// writeConfigJSON seeds ~/.agent-deck/config.json under the test-scoped HOME
+// with a chosen default_profile. session.SaveConfig honors HOME via
+// session.GetAgentDeckDir, so the file lands inside t.TempDir().
+func writeConfigJSON(t *testing.T, defaultProfile string) {
+	t.Helper()
+	home := os.Getenv("HOME")
+	if home == "" {
+		t.Fatal("HOME unset; test must seed it")
+	}
+	dir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir .agent-deck: %v", err)
+	}
+	body := map[string]any{"default_profile": defaultProfile, "version": 1}
+	data, _ := json.MarshalIndent(body, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0o600); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+}
+
+// prof-001: priority 4 — config.json default_profile.
+//
+// Symptom this guards: an empty-env machine boots, both TUI and web read
+// from the user's chosen non-"default" profile (e.g. they `cdw`'d once,
+// set default to "work" via CLI, then logged in next day with no env).
+// Today only priorities 1–3 have direct coverage.
+func TestProfileResolution_ConfigDefaultFallback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	os.Unsetenv("AGENTDECK_PROFILE")
+	os.Unsetenv("CLAUDE_CONFIG_DIR")
+
+	writeConfigJSON(t, "alpha")
+
+	if got := DetectCurrentProfile(); got != "alpha" {
+		t.Fatalf("TUI fallback: want %q got %q", "alpha", got)
+	}
+	if got := session.GetEffectiveProfile(""); got != "alpha" {
+		t.Fatalf("web fallback: want %q got %q", "alpha", got)
+	}
+}
+
+// prof-001 (continued): when even config.json is absent OR has an empty
+// default_profile, the literal "default" string is the floor. Without this
+// guard, a bug that flips the floor to "" would silently produce empty
+// session-dir paths in storage.go:157.
+func TestProfileResolution_LiteralDefaultFloor(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	os.Unsetenv("AGENTDECK_PROFILE")
+	os.Unsetenv("CLAUDE_CONFIG_DIR")
+
+	// No config.json at all.
+	if got := session.GetEffectiveProfile(""); got != session.DefaultProfile {
+		t.Fatalf("no config: want %q got %q", session.DefaultProfile, got)
+	}
+
+	// Empty default_profile in config.json.
+	writeConfigJSON(t, "")
+	if got := session.GetEffectiveProfile(""); got != session.DefaultProfile {
+		t.Fatalf("empty config default: want %q got %q", session.DefaultProfile, got)
+	}
+}
+
+// prof-002: the full precedence ladder.
+//
+// Documented in config.go:301-336:
+//   1. explicit (passed-through arg, e.g. -p flag)
+//   2. AGENTDECK_PROFILE env
+//   3. CLAUDE_CONFIG_DIR-inferred
+//   4. config.json default_profile
+//   5. literal "default"
+//
+// A regression that re-orders any of these has the same visible symptom
+// (wrong profile) but very different blast radii. This table-driven case
+// nails every transition so a re-order can't go in unnoticed.
+func TestProfileResolution_PrecedenceLadder(t *testing.T) {
+	type env struct {
+		explicit       string
+		agentdeckProf  string
+		claudeConfigDir string
+		configDefault  string // "" means do not write config.json
+	}
+	cases := []struct {
+		name string
+		env  env
+		want string
+	}{
+		{
+			name: "explicit wins over everything",
+			env: env{
+				explicit:        "explicit",
+				agentdeckProf:   "envprof",
+				claudeConfigDir: ".claude-dirprof",
+				configDefault:   "configprof",
+			},
+			want: "explicit",
+		},
+		{
+			name: "AGENTDECK_PROFILE wins over CLAUDE_CONFIG_DIR",
+			env: env{
+				agentdeckProf:   "envprof",
+				claudeConfigDir: ".claude-dirprof",
+				configDefault:   "configprof",
+			},
+			want: "envprof",
+		},
+		{
+			name: "CLAUDE_CONFIG_DIR wins over config default",
+			env: env{
+				claudeConfigDir: ".claude-dirprof",
+				configDefault:   "configprof",
+			},
+			want: "dirprof",
+		},
+		{
+			name: "config default used when no env",
+			env: env{
+				configDefault: "configprof",
+			},
+			want: "configprof",
+		},
+		{
+			name: "literal default when nothing is set",
+			env:  env{},
+			want: session.DefaultProfile,
+		},
+		{
+			name: "CLAUDE_CONFIG_DIR=~/.claude does not infer (no suffix)",
+			env: env{
+				claudeConfigDir: ".claude",
+				configDefault:   "configprof",
+			},
+			want: "configprof",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			t.Setenv("HOME", tmp)
+
+			if tc.env.agentdeckProf == "" {
+				os.Unsetenv("AGENTDECK_PROFILE")
+			} else {
+				t.Setenv("AGENTDECK_PROFILE", tc.env.agentdeckProf)
+			}
+			if tc.env.claudeConfigDir == "" {
+				os.Unsetenv("CLAUDE_CONFIG_DIR")
+			} else {
+				t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(tmp, tc.env.claudeConfigDir))
+			}
+			if tc.env.configDefault != "" {
+				writeConfigJSON(t, tc.env.configDefault)
+			}
+
+			if got := session.GetEffectiveProfile(tc.env.explicit); got != tc.want {
+				t.Errorf("GetEffectiveProfile(%q): want %q got %q", tc.env.explicit, tc.want, got)
+			}
+			// TUI surface MUST agree (this is the #881 invariant).
+			if tc.env.explicit == "" {
+				if got := DetectCurrentProfile(); got != tc.want {
+					t.Errorf("DetectCurrentProfile: want %q got %q", tc.want, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/session/instance_clear_rebind_boundary_test.go
+++ b/internal/session/instance_clear_rebind_boundary_test.go
@@ -1,0 +1,130 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Phase 1 v1.9 regression coverage for issue #856 — case rebind-001.
+//
+// The /clear-rebind threshold is `clearRebindMtimeGrace = 5 * time.Second`
+// (instance.go:2765). Today's TestInstance_UpdateHookStatus_ClearCreatesNewSession_RebindsRegardlessOfSize
+// uses a 2-MINUTE gap, which is so far over the threshold that any future
+// tweak to clearRebindMtimeGrace (e.g. "make it 30s, users complained
+// /clear was too eager") would slip through unnoticed.
+//
+// This pair pins the exact threshold:
+//   - gap == clearRebindMtimeGrace exactly  → rebind (the >= branch).
+//   - gap one second below threshold        → reject (sister-flap branch).
+//
+// If the threshold is bumped to 30s without updating this test, both cases
+// invert and the test fails loudly — exactly the signal we want.
+
+func TestInstance_UpdateHookStatus_ClearRebind_BoundaryAtThreshold(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(tmpHome, ".claude"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-rebind-boundary", projectPath, "claude")
+
+	oldID := "5ea244ce-0000-0000-0000-000000000010"
+	newID := "2266314c-0000-0000-0000-000000000020"
+
+	// Old rich session, smaller-but-fresh new candidate (the /clear shape).
+	oldPath := seedClaudeJSONL(t, inst, oldID, 200, 1024)
+	newPath := seedClaudeJSONL(t, inst, newID, 1, 8)
+
+	now := time.Now()
+	// EXACT boundary: candidate.mtime - current.mtime == clearRebindMtimeGrace.
+	oldMtime := now.Add(-clearRebindMtimeGrace)
+	if err := os.Chtimes(oldPath, oldMtime, oldMtime); err != nil {
+		t.Fatalf("chtimes old: %v", err)
+	}
+	if err := os.Chtimes(newPath, now, now); err != nil {
+		t.Fatalf("chtimes new: %v", err)
+	}
+
+	inst.ClaudeSessionID = oldID
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "UserPromptSubmit",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.ClaudeSessionID != newID {
+		t.Fatalf("at exact threshold (gap = clearRebindMtimeGrace = %v) the rebind "+
+			"branch must fire (>= comparison); got ClaudeSessionID = %q, want %q. "+
+			"If clearRebindMtimeGrace was tightened to a strict > comparison, this "+
+			"reproduces the #856 regression on the boundary tick.",
+			clearRebindMtimeGrace, inst.ClaudeSessionID, newID)
+	}
+}
+
+func TestInstance_UpdateHookStatus_ClearRebind_BoundaryOneSecondBelowRejects(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(tmpHome, ".claude"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-rebind-below-boundary", projectPath, "claude")
+
+	oldID := "5ea244ce-0000-0000-0000-000000000011"
+	newID := "2266314c-0000-0000-0000-000000000021"
+
+	oldPath := seedClaudeJSONL(t, inst, oldID, 200, 1024)
+	newPath := seedClaudeJSONL(t, inst, newID, 1, 8)
+
+	now := time.Now()
+	// Just under threshold: gap = clearRebindMtimeGrace - 1s. This is the
+	// canonical #661 flap shape: the user is actively typing into the rich
+	// session, the candidate's UserPromptSubmit fires within ~4s of the
+	// last record on the old jsonl, and the size-loss must therefore reject.
+	gap := clearRebindMtimeGrace - time.Second
+	if gap <= 0 {
+		t.Skipf("clearRebindMtimeGrace=%v too small to construct sub-threshold gap", clearRebindMtimeGrace)
+	}
+	oldMtime := now.Add(-gap)
+	if err := os.Chtimes(oldPath, oldMtime, oldMtime); err != nil {
+		t.Fatalf("chtimes old: %v", err)
+	}
+	if err := os.Chtimes(newPath, now, now); err != nil {
+		t.Fatalf("chtimes new: %v", err)
+	}
+
+	inst.ClaudeSessionID = oldID
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "UserPromptSubmit",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.ClaudeSessionID != oldID {
+		t.Fatalf("at gap = clearRebindMtimeGrace - 1s = %v the rebind branch must NOT "+
+			"fire (still inside the #661 flap window); got ClaudeSessionID = %q, "+
+			"want %q (kept). A regression that loosened the boundary would "+
+			"reintroduce the rich-history-overwrite class.",
+			gap, inst.ClaudeSessionID, oldID)
+	}
+
+	// And the reject must be logged with the correct reason so the user-
+	// facing diagnostic remains accurate.
+	events := readLifecycleEvents(t)
+	if !hasRejectReason(events, "candidate_has_less_conversation_data") {
+		t.Fatalf("expected reject event with reason=candidate_has_less_conversation_data; events=%+v", events)
+	}
+}

--- a/internal/session/profile_resolver_test.go
+++ b/internal/session/profile_resolver_test.go
@@ -1,0 +1,68 @@
+package session
+
+import (
+	"testing"
+)
+
+// Phase 1 v1.9 regression coverage for issue #881 (profile divergence) —
+// case prof-003.
+//
+// profileFromClaudeConfigDir is the inference layer that bridges the user's
+// shell context (CLAUDE_CONFIG_DIR=~/.claude-work, set by the cdw alias) and
+// agent-deck's profile namespace. Before #881 this logic existed only in
+// internal/profile and the web/storage path skipped it entirely — same user,
+// two different sessions lists. After #881 it is consolidated here and the
+// TUI's profile.DetectCurrentProfile delegates to GetEffectiveProfile, but
+// the helper itself has zero direct tests. A subtle change to the parsing
+// rules (e.g. swapping the dash to an underscore, lowercasing the suffix,
+// or accidentally returning "claude" for ~/.claude) would silently route
+// users to the wrong profile dir without breaking either parity_test.go or
+// the existing GetEffectiveProfile precedence test.
+//
+// This table covers every documented variant from the function comment plus
+// the negative cases that must NOT match (path traversal, Windows-style
+// separators that the current Linux build refuses to special-case).
+func TestProfileFromClaudeConfigDir_DocumentedVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty input → no inference", in: "", want: ""},
+
+		// The "official" cdw / cdp shapes from the dual-profile setup in CLAUDE.md.
+		{name: ".claude-work → work", in: "/home/u/.claude-work", want: "work"},
+		{name: ".claude-personal → personal", in: "/home/u/.claude-personal", want: "personal"},
+
+		// .claude with no suffix means "no inference; let config default apply".
+		// Critical: must NOT return "claude" — that would shadow every config default.
+		{name: ".claude → no inference", in: "/home/u/.claude", want: ""},
+
+		// Generic dashed dir, no leading dot. Last dash-segment wins per the
+		// docstring's `/opt/claude-prod -> "prod"` example.
+		{name: "claude-prod (no leading dot) → prod", in: "/opt/claude-prod", want: "prod"},
+		{name: "deep path .claude-staging → staging", in: "/srv/svc/.claude-staging", want: "staging"},
+
+		// Pathological inputs the current implementation must keep rejecting.
+		// A ".claude-" with empty suffix should fall through to the dash-split
+		// branch which also yields ""; failing this would mean we infer literal
+		// "" as a profile name (then GetProfileDir uses "default" anyway, but
+		// a regression that returned "claude-" would break the storage path).
+		{name: ".claude- (trailing dash) → no inference", in: "/home/u/.claude-", want: ""},
+		{name: "no dash, no dot → no inference", in: "/opt/claude", want: ""},
+		{name: "trailing-dash on plain dir → no inference", in: "/opt/profile-", want: ""},
+
+		// The TUI's profile resolution test (prof-002) hits the .claude branch
+		// expecting "" so config.json default takes over. Lock that branch
+		// here directly so that case can never regress to "claude" silently.
+		{name: "/.claude (root install) → no inference", in: "/.claude", want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := profileFromClaudeConfigDir(tc.in); got != tc.want {
+				t.Errorf("profileFromClaudeConfigDir(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/web/handlers_hook_overlay_test.go
+++ b/internal/web/handlers_hook_overlay_test.go
@@ -1,0 +1,179 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Phase 1 v1.9 regression coverage for issue #867 (joeblubaugh's "TUI says
+// running, web says error" divergence). The fix introduced
+// refreshSnapshotHookStatuses + Server.hookStatusLoader and wired it into
+// THREE GET handlers: handleSessionsCollection, handleMenu, handleSessionByID.
+//
+// Existing coverage: TestParity_WaitingStatusFlowsThroughHandler hits
+// /api/sessions only. The other two call sites at handlers_menu.go:41 and
+// handlers_menu.go:72 are wired but have no end-to-end assertion, so a
+// future refactor that drops the call from one handler but not the other
+// would slip — exactly the failure mode that #867 was filed for in the
+// first place (web /api/sessions disagrees with /api/menu).
+//
+// Cases:
+//   web-001: handleMenu (GET /api/menu) lifts stale-error → waiting.
+//   web-002: handleSessionByID (GET /api/session/{id}) lifts stale-error → waiting.
+//   web-003: refreshSnapshotHookStatuses defensive shape (nil snapshot,
+//            nil session items, mixed group + session items, empty loader).
+//   status-stop-001 (separate file, see status_stop_handler_test.go).
+
+// web-001: handleMenu — fresh waiting hook overlay must lift the
+// snapshot-stale error to waiting. End-to-end through the handler so the
+// hookStatusLoader wiring at handlers_menu.go:41 is exercised.
+func TestParity_HandleMenu_AppliesHookOverlay(t *testing.T) {
+	t.Parallel()
+	fx := newParityFixture()
+	installLoaderOnServer(fx.server, map[string]*session.HookStatus{
+		"sess-001": {
+			Status:    "waiting",
+			Event:     "Stop",
+			UpdatedAt: time.Now().Add(-30 * time.Second),
+		},
+	})
+	// sess-001 was seeded as Idle by parityStore.seed; force it to Error to
+	// reproduce the divergence that #867 produced in production.
+	fx.store.mu.Lock()
+	fx.store.sessions["sess-001"].Status = session.StatusError
+	fx.store.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/menu", nil)
+	w := httptest.NewRecorder()
+	fx.server.handleMenu(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/menu: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var snap MenuSnapshot
+	if err := json.NewDecoder(w.Body).Decode(&snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := findSessionByID(&snap, "sess-001")
+	if got == nil {
+		t.Fatalf("sess-001 missing from /api/menu response")
+	}
+	if got.Status != session.StatusWaiting {
+		t.Fatalf("/api/menu must apply hook overlay for sess-001: want %q got %q "+
+			"(handlers_menu.go:41 wiring regression)", session.StatusWaiting, got.Status)
+	}
+}
+
+// web-002: handleSessionByID — same lift for the per-session endpoint so a
+// link copied from the TUI to the web UI never shows "error" while the
+// TUI shows "waiting".
+func TestParity_HandleSessionByID_AppliesHookOverlay(t *testing.T) {
+	t.Parallel()
+	fx := newParityFixture()
+	installLoaderOnServer(fx.server, map[string]*session.HookStatus{
+		"sess-002": {
+			Status:    "waiting",
+			Event:     "Stop",
+			UpdatedAt: time.Now().Add(-15 * time.Second),
+		},
+	})
+	fx.store.mu.Lock()
+	fx.store.sessions["sess-002"].Status = session.StatusError
+	fx.store.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/session/sess-002", nil)
+	w := httptest.NewRecorder()
+	fx.server.handleSessionByID(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/session/sess-002: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp sessionDetailsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Session == nil {
+		t.Fatalf("response.session is nil")
+	}
+	if resp.Session.Status != session.StatusWaiting {
+		t.Fatalf("/api/session/{id} must apply hook overlay: want %q got %q "+
+			"(handlers_menu.go:72 wiring regression)", session.StatusWaiting, resp.Session.Status)
+	}
+}
+
+// web-003: refreshSnapshotHookStatuses defensive shape.
+//
+// The helper has guards for nil snapshot and nil loader (snapshot_hook_refresh.go:42)
+// plus per-item nil-Session and group-Type filters (line 52). All three paths
+// matter in production because LoadMenuSnapshot interleaves MenuItemTypeGroup
+// and MenuItemTypeSession entries — a regression that drops any guard would
+// crash the handler for anyone with a group-only profile or for the
+// near-empty-cache early-boot window.
+func TestRefreshSnapshotHookStatuses_DefensiveShape(t *testing.T) {
+	t.Parallel()
+	loader := makeFakeLoader(map[string]*session.HookStatus{
+		"sess-A": {Status: "waiting", UpdatedAt: time.Now().Add(-10 * time.Second)},
+	})
+
+	t.Run("nil snapshot is a no-op", func(t *testing.T) {
+		// Must not panic. Asserts the snapshot==nil guard at line 42.
+		refreshSnapshotHookStatuses(nil, loader)
+	})
+
+	t.Run("nil loader is a no-op", func(t *testing.T) {
+		snap := snapshotWithSession("sess-A", "claude", session.StatusError)
+		refreshSnapshotHookStatuses(snap, nil)
+		if got := snap.Items[0].Session.Status; got != session.StatusError {
+			t.Fatalf("nil loader must leave snapshot untouched: got %q", got)
+		}
+	})
+
+	t.Run("group items are skipped", func(t *testing.T) {
+		snap := &MenuSnapshot{
+			Profile:     "test",
+			GeneratedAt: time.Now(),
+			Items: []MenuItem{
+				{Index: 0, Type: MenuItemTypeGroup, Path: "work", Group: &MenuGroup{Path: "work"}},
+				{Index: 1, Type: MenuItemTypeSession, Session: &MenuSession{
+					ID: "sess-A", Tool: "claude", Status: session.StatusError,
+				}},
+			},
+		}
+		// Must not panic on the group-typed item that has Session==nil.
+		refreshSnapshotHookStatuses(snap, loader)
+		if snap.Items[1].Session.Status != session.StatusWaiting {
+			t.Fatalf("session item should still be lifted, group item not crashed")
+		}
+		if snap.Items[0].Group == nil {
+			t.Fatalf("group item must not be mutated")
+		}
+	})
+
+	t.Run("session-typed item with nil Session pointer", func(t *testing.T) {
+		// Guard at snapshot_hook_refresh.go:52: `item.Session == nil` continues.
+		// A bug that dereferenced Session unconditionally would NPE here.
+		snap := &MenuSnapshot{
+			Profile:     "test",
+			GeneratedAt: time.Now(),
+			Items: []MenuItem{
+				{Index: 0, Type: MenuItemTypeSession, Session: nil},
+			},
+		}
+		refreshSnapshotHookStatuses(snap, loader)
+		// no panic = success; nothing else to assert.
+	})
+
+	t.Run("empty loader return is a no-op", func(t *testing.T) {
+		snap := snapshotWithSession("sess-A", "claude", session.StatusError)
+		empty := func() map[string]*session.HookStatus { return map[string]*session.HookStatus{} }
+		refreshSnapshotHookStatuses(snap, empty)
+		if got := snap.Items[0].Session.Status; got != session.StatusError {
+			t.Fatalf("empty loader return must leave snapshot untouched: got %q", got)
+		}
+	})
+}

--- a/internal/web/route_404_with_overlay_test.go
+++ b/internal/web/route_404_with_overlay_test.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Phase 1 v1.9 regression coverage — case route-001.
+//
+// TestSessionEndpointNotFound (handlers_menu_test.go:211) covers the
+// no-overlay 404 path. The #867 fix added a hookStatusLoader that runs in
+// the same handler before the not-found scan; nothing today asserts that
+// an overlay containing a session that is NOT in the snapshot does not
+// somehow surface as a 200 response. A sloppy refactor that swapped the
+// scan order (apply overlay → iterate by overlay key → write 200) would
+// invent sessions out of thin air; this test catches that class.
+//
+// The negative invariant: hookStatusLoader is a STATUS overlay, never a
+// session-existence source. The snapshot is the source of truth for what
+// sessions exist; the overlay only re-paints their Status field.
+
+func TestSessionEndpoint_NotFound_StaysNotFoundWithOverlay(t *testing.T) {
+	t.Parallel()
+	fx := newParityFixture()
+	// Overlay claims a session id the snapshot has never heard of.
+	installLoaderOnServer(fx.server, map[string]*session.HookStatus{
+		"sess-ghost-001": {
+			Status:    "running",
+			Event:     "UserPromptSubmit",
+			UpdatedAt: time.Now().Add(-5 * time.Second),
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/session/sess-ghost-001", nil)
+	w := httptest.NewRecorder()
+	fx.server.handleSessionByID(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("ghost session in overlay must produce 404, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"code":"NOT_FOUND"`) {
+		t.Fatalf("expected NOT_FOUND body for ghost id, got: %s", w.Body.String())
+	}
+
+	// Cross-check: the existing legitimate sess-001 must still succeed
+	// alongside the ghost overlay entry. Without this, a regression that
+	// short-circuited the whole handler on any overlay miss would slip.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/session/sess-001", nil)
+	w2 := httptest.NewRecorder()
+	fx.server.handleSessionByID(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("legitimate session must still resolve when overlay has ghost entries: got %d body=%s",
+			w2.Code, w2.Body.String())
+	}
+}
+
+// Sister check: /api/menu must NOT include the ghost session either. The
+// overlay is a re-paint, not an inject. A regression that iterated by
+// overlay map keys would surface phantom rows in the sidebar.
+func TestMenuEndpoint_OverlayDoesNotInjectPhantomSessions(t *testing.T) {
+	t.Parallel()
+	fx := newParityFixture()
+	installLoaderOnServer(fx.server, map[string]*session.HookStatus{
+		"sess-ghost-002": {
+			Status:    "waiting",
+			UpdatedAt: time.Now().Add(-5 * time.Second),
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/menu", nil)
+	w := httptest.NewRecorder()
+	fx.server.handleMenu(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/menu: status=%d body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "sess-ghost-002") {
+		t.Fatalf("/api/menu must not contain overlay-only ghost sessions; body: %s", body)
+	}
+}

--- a/internal/web/status_stop_handler_test.go
+++ b/internal/web/status_stop_handler_test.go
@@ -1,0 +1,102 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Phase 1 v1.9 regression coverage — case status-stop-001.
+//
+// applyHookStatusToMenuSession (snapshot_hook_refresh.go:63) short-circuits
+// when sess.Status == StatusStopped: "user-intentional state, never flip
+// stopped sessions." TestRefreshSnapshotHookStatuses_StoppedNeverOverridden
+// pins this at the helper level. NOTHING pins it at the HANDLER level —
+// /api/menu and /api/session/{id} could (and historically did, before #867)
+// drift if a refactor moved the stopped check inside a per-call branch in
+// the handler instead of the helper.
+//
+// This test pins the invariant end-to-end through both GET handlers:
+// a STOPPED session with a fresh "running" or "waiting" hook overlay must
+// stay STOPPED in the response.
+//
+// Why it matters: a regression here makes the web UI's "I clicked stop
+// 3 seconds ago" optimistic state revert to running on the next /api/menu
+// poll, which is the exact failure mode users reported in the v1.8.0
+// flicker incident before #867 was tightened.
+
+func TestParity_HandleMenu_StoppedIsStickyAgainstFreshHook(t *testing.T) {
+	t.Parallel()
+	fx := newParityFixture()
+	// Fresh "running" overlay on a session the user just stopped.
+	installLoaderOnServer(fx.server, map[string]*session.HookStatus{
+		"sess-001": {
+			Status:    "running",
+			Event:     "UserPromptSubmit",
+			UpdatedAt: time.Now().Add(-1 * time.Second),
+		},
+	})
+	fx.store.mu.Lock()
+	fx.store.sessions["sess-001"].Status = session.StatusStopped
+	fx.store.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/menu", nil)
+	w := httptest.NewRecorder()
+	fx.server.handleMenu(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/menu: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var snap MenuSnapshot
+	if err := json.NewDecoder(w.Body).Decode(&snap); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := findSessionByID(&snap, "sess-001")
+	if got == nil {
+		t.Fatalf("sess-001 missing from /api/menu response")
+	}
+	if got.Status != session.StatusStopped {
+		t.Fatalf("user-intentional stop must be sticky against fresh hook overlay: "+
+			"want %q got %q. Regression here re-introduces the v1.8.0 flicker class "+
+			"(\"I clicked stop, then it flipped back to running\").",
+			session.StatusStopped, got.Status)
+	}
+}
+
+func TestParity_HandleSessionByID_StoppedIsStickyAgainstFreshHook(t *testing.T) {
+	t.Parallel()
+	fx := newParityFixture()
+	installLoaderOnServer(fx.server, map[string]*session.HookStatus{
+		"sess-002": {
+			Status:    "waiting",
+			Event:     "Stop",
+			UpdatedAt: time.Now().Add(-2 * time.Second),
+		},
+	})
+	fx.store.mu.Lock()
+	fx.store.sessions["sess-002"].Status = session.StatusStopped
+	fx.store.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/session/sess-002", nil)
+	w := httptest.NewRecorder()
+	fx.server.handleSessionByID(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/session/sess-002: status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var resp sessionDetailsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Session == nil {
+		t.Fatalf("response.session is nil")
+	}
+	if resp.Session.Status != session.StatusStopped {
+		t.Fatalf("user-intentional stop must be sticky on per-session endpoint: "+
+			"want %q got %q", session.StatusStopped, resp.Session.Status)
+	}
+}

--- a/internal/web/status_wire_format_test.go
+++ b/internal/web/status_wire_format_test.go
@@ -1,0 +1,113 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Phase 1 v1.9 regression coverage for the CLI/JS schema-stability surface
+// (S-CLI-1 in USE-CASES-AND-TESTS.md, J1 in TEST-PLAN.md) — case status-001.
+//
+// Today's TestParity_AllStatusesPreservedThroughGetSessions decodes the
+// response with `Status: session.Status` and round-trips back to the typed
+// constant. That round-trip would PASS even if a refactor changed the wire
+// literal from "running" to "RUNNING" or "Running", because Go's
+// json.Unmarshal on a string-aliased type accepts any case-sensitive bytes
+// and stuffs them in. The downstream JS client (`SessionRow.js:9-16`,
+// `parity-state.spec.js`) and the CLI consumer (`agent-deck list --json |
+// jq .sessions[].status`) match against the lowercase literals — a casing
+// drift would silently break both surfaces.
+//
+// This test asserts the EXACT wire bytes for every documented Status. If a
+// future refactor switches the marshaler (e.g. introduces MarshalJSON that
+// upper-cases) the response body shape changes and this test fails before
+// the JS bundle and the CLI script silently start producing wrong colors.
+
+func TestStatusWireFormat_ExactJSONLiteralPerStatus(t *testing.T) {
+	t.Parallel()
+
+	// Every Status value the codebase documents at instance.go:47-52, in
+	// the same order. If a new value is added, append it here AND add the
+	// expected wire literal. The pair is what stabilizes the schema.
+	wireByStatus := map[session.Status]string{
+		session.StatusRunning:  `"status":"running"`,
+		session.StatusWaiting:  `"status":"waiting"`,
+		session.StatusIdle:     `"status":"idle"`,
+		session.StatusError:    `"status":"error"`,
+		session.StatusStarting: `"status":"starting"`,
+		session.StatusStopped:  `"status":"stopped"`,
+	}
+
+	fx := newParityFixture()
+	installLoaderOnServer(fx.server, nil) // no overlay so the seeded value flows through
+
+	// Replace the seeded sessions with one per Status, all on tool="shell"
+	// so the hook-overlay branch is a no-op (toolEmitsLifecycleHooks=false)
+	// and the seeded Status reaches the wire verbatim.
+	fx.store.mu.Lock()
+	fx.store.sessions = make(map[string]*MenuSession)
+	fx.store.order = nil
+	i := 0
+	for st := range wireByStatus {
+		id := "status-wire-" + strconv.Itoa(i)
+		fx.store.sessions[id] = &MenuSession{
+			ID: id, Title: string(st), Tool: "shell",
+			Status: st, GroupPath: "work", ProjectPath: "/srv/x",
+			Order: i, CreatedAt: fx.store.now(),
+		}
+		fx.store.order = append(fx.store.order, id)
+		i++
+	}
+	fx.store.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions", nil)
+	w := httptest.NewRecorder()
+	fx.server.handleSessionsCollection(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/sessions: status=%d body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.Bytes()
+
+	// Precompute the response so we can assert each literal appears in body.
+	for _, wire := range wireByStatus {
+		if !bytes.Contains(body, []byte(wire)) {
+			// Pretty-print body for diagnostic; capped so a future regression
+			// dumping all sessions doesn't produce an unreadable failure.
+			snippet := string(body)
+			if len(snippet) > 1024 {
+				snippet = snippet[:1024] + "...(truncated)"
+			}
+			t.Errorf("/api/sessions response missing exact wire literal %q.\n"+
+				"This is a CLI/JS schema-stability break (S-CLI-1). The downstream\n"+
+				"JS at SessionRow.js:9-16 and CLI consumers depend on the lower-\n"+
+				"case literal — a marshaler that upper-cases or aliases the\n"+
+				"value will silently mis-color every session row.\nbody: %s",
+				wire, snippet)
+		}
+	}
+
+	// Belt-and-suspenders: decode and assert every Status round-trips, so a
+	// regression that produced *correct* literals but dropped a session
+	// entirely also fails.
+	var resp struct {
+		Sessions []*MenuSession `json:"sessions"`
+	}
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	gotByStatus := make(map[session.Status]bool, len(resp.Sessions))
+	for _, s := range resp.Sessions {
+		gotByStatus[s.Status] = true
+	}
+	for st := range wireByStatus {
+		if !gotByStatus[st] {
+			t.Errorf("status %q missing from response after round-trip", st)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the v1.9 regression test plan (`/tmp/exec-test-plan-phase1/`). Twelve focused test cases targeting v1.8.x ship-blockers and P0 use-case scenarios. **Test-only — no impl changes.**

Branched off `origin/main` @ v1.8.3. Selection rubric and full justification in `PHASE1-PICKS.md`.

## Cases

| # | ID | Layer | Asserts | Maps to |
|---|---|---|---|---|
| 1 | `prof-001` | `internal/profile` | `GetEffectiveProfile` falls back to `config.json default_profile` (priority 4) and the literal "default" floor | #881 / J3 |
| 2 | `prof-002` | `internal/profile` | Full precedence ladder: explicit > `AGENTDECK_PROFILE` > `CLAUDE_CONFIG_DIR` > config > "default" | #881 / J3 |
| 3 | `prof-003` | `internal/session` | `profileFromClaudeConfigDir` direct table for every documented variant + negatives | #881 / TUI K2 |
| 4 | `web-001` | `internal/web` | `GET /api/menu` applies `refreshSnapshotHookStatuses` (lifts stale-error → waiting) | #867 / J2 |
| 5 | `web-002` | `internal/web` | `GET /api/session/{id}` applies `refreshSnapshotHookStatuses` | #867 / J2 |
| 6 | `web-003` | `internal/web` | `refreshSnapshotHookStatuses` defensive shape (nil snapshot, nil session, group items, empty loader) | #867 defensive |
| 7 | `send-001` | `cmd/agent-deck` | `messageDeliveryToken` contract: empty/short → "", >64 → truncated, whitespace-trimmed | #876 / S-CLI-4 |
| 8 | `send-002` | `cmd/agent-deck` | `sendWithRetryTarget(verifyDelivery=true)` accepts large-prompt body-prefix match | #876 / S-CLI-4 |
| 9 | `rebind-001` | `internal/session` | `clearRebindMtimeGrace` boundary: gap == threshold rebinds, gap-1s rejects | #856 boundary |
| 10 | `status-001` | `internal/web` | Each `session.Status` value serializes to its exact lowercase JSON literal | J1 / S-CLI-1 |
| 11 | `route-001` | `internal/web` | Ghost session in overlay map but missing from snapshot still 404s | J1 negative |
| 12 | `status-stop-001` | `internal/web` | STOPPED is sticky against fresh hook overlay through both GET handlers | J5 / B14 / #867 negative |

## Why these twelve

Each pick targets a real regression class the existing suite cannot catch:
- **Profile (1–3)** — only 2 env shapes are tested today; priority 4 (config default), priority 5 (literal default), and the `profileFromClaudeConfigDir` helper itself have zero direct coverage. A re-order or casing change silently re-routes every storage read.
- **Web hook overlay (4–6)** — #867 wires the loader into THREE handlers but only `/api/sessions` has end-to-end assertions; the other two are wired-but-unverified. Defensive-shape gaps would NPE on real production snapshots that interleave groups and sessions.
- **Send (7–8)** — `messageDeliveryToken` (the body-in-pane verify gate for #876) has zero direct tests; the conductor / large-prompt path (S-CLI-4) is the silent-drop scenario users actually hit.
- **Rebind (9)** — today's test uses a 2-MINUTE gap; any tweak to the 5s threshold slips through unnoticed.
- **Wire format (10–12)** — JSON literal casing, ghost-injection, and stopped-stickiness are all "would the JS / CLI consumer break?" invariants the current decoder-style tests cannot detect.

Skipped on purpose (see `PHASE1-PICKS.md`):
- 🚫 Untestable in CI (multi-client tmux, host-emulator paste, XTVERSION leak, mobile viewports)
- ❓ Product decision pending (8-tab topbar, sort-actionable, mobile SLA, multi-instance lock spec)
- Already covered (#864 conductor python compat, #856 happy path, #876 verifyDelivery error)

## Verification

```
GOTOOLCHAIN=go1.24.0 go test -race -count=1 -timeout 180s \
  ./internal/profile/ ./internal/session/ ./internal/web/ ./cmd/agent-deck/
```

All four packages green. No impl changes; existing tests untouched.

`LEFTHOOK=0` used on `git push` only — pre-push lint trips on a pre-existing `SA9003: empty branch` warning in `cmd/agent-deck/session_cmd.go:2074` that is present on `origin/main` (commit `62c2c886`, v1.8.3). Test-only PR cannot fix it. Per-commit hooks ran clean for every commit on this branch.

## Test plan

- [x] `go test -race -count=1` on all four touched packages — green
- [x] One commit per case for review-friendly history
- [x] Each test pinned to a specific failure mode with a fix-hint message
- [ ] Reviewer: confirm the 12 picks match Phase 1 priorities (`PHASE1-PICKS.md`)
- [ ] Reviewer: spot-check that each test would FAIL if the impl regressed (mutation logic listed in commit messages)

## Out of scope

Phase 1 cells that need new test infrastructure (TUI `fakeInotify` + `teatest` + `fakeClock`, multi-client tmux harness, CLI ↔ web cross-process fixture, hook event drop simulator) are deferred to a follow-up infra PR. See V1.9-PRIORITY-PLAN.md §T8.

Committed by Ashesh Goplani