### PR TITLE
fix(mcppool): prevent duplicate MCP children for same (session, name) (cascade trigger)

### DIFF
--- a/internal/mcppool/http_server.go
+++ b/internal/mcppool/http_server.go
@@ -38,6 +38,23 @@ type HTTPServer struct {
 	status      ServerStatus
 	startedByUs bool  // True if we started the server vs. discovered external
 	lastError   error // Last error encountered
+
+	// startMu serializes concurrent Start calls on the same server. Without
+	// it, two callers could both observe StatusStarting (which the existing
+	// early-return only catches as StatusRunning) and both reach `s.process
+	// = exec.CommandContext(...)` — clobbering the reference and orphaning
+	// one child. Reproducer: the HTTPPool's "exists -> existing.Start()"
+	// path can fire concurrently under load (v1.9 cascade dedup).
+	// Held for the full Start so waitReady's polling uses a stable s.process.
+	// Distinct from `mu` because waitReady acquires mu.RLock, and `mu` is
+	// not reentrant.
+	startMu sync.Mutex
+
+	// processDone is closed by monitorProcess() once it has Wait()'d on the
+	// current s.process. killLeftoverProcess waits on it (with a 2s safety
+	// net) instead of polling Cmd.ProcessState directly, which would race
+	// with Wait()'s write to that field. Re-allocated per spawn.
+	processDone chan struct{}
 }
 
 // NewHTTPServer creates a new HTTP server manager
@@ -111,9 +128,67 @@ func (s *HTTPServer) GetLastError() error {
 	return s.lastError
 }
 
+// killLeftoverProcess SIGKILLs any previously-spawned child whose
+// reference is still in s.process and which has not been reaped yet.
+// Called at the top of Start (under startMu) so the new spawn cannot
+// run alongside an orphaned older one. Idempotent.
+//
+// We don't call Wait() here because monitorProcess() is already calling
+// it on the same Cmd, and exec.Cmd.Wait is not idempotent — a second call
+// returns "exec: Wait was already called". Instead we send SIGKILL and
+// wait on s.processDone, which monitorProcess closes after its Wait()
+// returns. Polling Cmd.ProcessState directly would race with Wait()'s
+// write to that field (caught by -race).
+func (s *HTTPServer) killLeftoverProcess() {
+	s.mu.Lock()
+	old := s.process
+	done := s.processDone
+	s.mu.Unlock()
+
+	if old == nil || old.Process == nil || done == nil {
+		return
+	}
+	// Fast path: monitorProcess already finished — nothing to kill.
+	select {
+	case <-done:
+		return
+	default:
+	}
+
+	httpLog.Info("kill_leftover_process",
+		slog.String("mcp", s.name),
+		slog.Int("pid", old.Process.Pid))
+	_ = old.Process.Kill()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		httpLog.Warn("leftover_process_reap_timeout",
+			slog.String("mcp", s.name),
+			slog.Int("pid", old.Process.Pid))
+	}
+}
+
 // Start starts the HTTP server process
 // If the URL is already reachable, marks as external and skips process creation
 func (s *HTTPServer) Start() error {
+	// Serialize concurrent Starts so the s.process write at line 156 isn't
+	// raced. After we acquire startMu, any other Start that was already
+	// in-flight has finished — we re-check status under mu and short-circuit
+	// if the server is now running. Without this, two goroutines could both
+	// pass the StatusRunning check while in StatusStarting and both spawn
+	// a child process, leaking the first one. (v1.9 cascade dedup.)
+	s.startMu.Lock()
+	defer s.startMu.Unlock()
+
+	// Reap any leftover child from a previous failed Start (e.g. waitReady
+	// timed out and we returned without sending the spawned MCP a kill
+	// signal). Without this, every Start cycle of an unhealthy MCP leaks
+	// one alive child — the cascade-triggering pattern observed when 43
+	// `@upstash/context7-mcp` instances accumulated before systemd-oomd
+	// fired. Idempotent: returns immediately if there is no leftover.
+	s.killLeftoverProcess()
+
 	s.mu.Lock()
 
 	// Already running?
@@ -185,8 +260,32 @@ func (s *HTTPServer) Start() error {
 
 	httpLog.Info("server_process_started", slog.String("mcp", s.name), slog.Int("pid", s.process.Process.Pid))
 
+	// Allocate the per-spawn done-channel before launching the watcher.
+	// killLeftoverProcess uses this channel to wait for monitorProcess's
+	// Wait() to return; polling cmd.ProcessState directly is racy.
+	s.mu.Lock()
+	s.processDone = make(chan struct{})
+	done := s.processDone
+	proc := s.process
+	s.mu.Unlock()
+
 	// Monitor process exit in background
-	go s.monitorProcess()
+	go func() {
+		defer close(done)
+		err := proc.Wait()
+		if err != nil {
+			httpLog.Warn("process_exit_error", slog.String("mcp", s.name), slog.String("error", err.Error()))
+		} else {
+			httpLog.Info("process_exited", slog.String("mcp", s.name))
+		}
+		s.mu.Lock()
+		// Only mark as failed if we were running (not during shutdown)
+		if s.status == StatusRunning {
+			s.status = StatusFailed
+			s.lastError = err
+		}
+		s.mu.Unlock()
+	}()
 
 	// Wait for server to become ready
 	if err := s.waitReady(); err != nil {
@@ -302,28 +401,6 @@ func (s *HTTPServer) waitReady() error {
 	}
 
 	return fmt.Errorf("timeout waiting for server to start (waited %v)", s.startupTimeout)
-}
-
-// monitorProcess watches for process exit and updates status
-func (s *HTTPServer) monitorProcess() {
-	if s.process == nil {
-		return
-	}
-
-	err := s.process.Wait()
-	if err != nil {
-		httpLog.Warn("process_exit_error", slog.String("mcp", s.name), slog.String("error", err.Error()))
-	} else {
-		httpLog.Info("process_exited", slog.String("mcp", s.name))
-	}
-
-	s.mu.Lock()
-	// Only mark as failed if we were running (not during shutdown)
-	if s.status == StatusRunning {
-		s.status = StatusFailed
-		s.lastError = err
-	}
-	s.mu.Unlock()
 }
 
 // Restart stops and restarts the server

--- a/internal/mcppool/respawn_dedup_test.go
+++ b/internal/mcppool/respawn_dedup_test.go
@@ -1,0 +1,195 @@
+package mcppool
+
+// Cascade-trigger regression for v1.9 — duplicate MCP-child accumulation.
+//
+// Background: on 2026-05-08, a conductor scope was killed by systemd-oomd
+// after accumulating 43 simultaneous instances of @upstash/context7-mcp at
+// 10:48 CEST. Root-cause analysis is in /tmp/worker-root-cause/RESULTS.md.
+// This file is the agent-deck-side reproducer: after a session-style
+// restart loop, exactly ONE live MCP child must remain per (pool, name).
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// liveDirectChildrenMatching returns the count of running (non-zombie) processes
+// whose PPid is ppid and whose /proc/<pid>/comm matches comm. Linux-only.
+func liveDirectChildrenMatching(t *testing.T, ppid int, comm string) []int {
+	t.Helper()
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skipf("/proc unavailable — non-Linux: %v", err)
+	}
+	entries, err := os.ReadDir("/proc")
+	require.NoError(t, err)
+	var pids []int
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		var pid int
+		if _, err := fmt.Sscanf(e.Name(), "%d", &pid); err != nil {
+			continue
+		}
+		statusBytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+		if err != nil {
+			continue
+		}
+		var (
+			parent  int
+			isZomb  bool
+			procCmd string
+		)
+		for _, line := range bytes.Split(statusBytes, []byte{'\n'}) {
+			switch {
+			case bytes.HasPrefix(line, []byte("PPid:")):
+				_, _ = fmt.Sscanf(string(line), "PPid:\t%d", &parent)
+			case bytes.HasPrefix(line, []byte("Name:")):
+				procCmd = string(bytes.TrimSpace(bytes.TrimPrefix(line, []byte("Name:"))))
+			case bytes.HasPrefix(line, []byte("State:")) && bytes.Contains(line, []byte("zombie")):
+				isZomb = true
+			}
+		}
+		if parent == ppid && !isZomb && procCmd == comm {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+// TestPool_RestartLoop_ProducesOneChild — five Pool.RestartProxy cycles must
+// leave exactly one live SocketProxy child. Hypothesis (a)/(b) from the
+// cascade brief: if Pool's lookup or restart cleanup is racy, repeated
+// restarts will leak children.
+func TestPool_RestartLoop_ProducesOneChild(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("/proc unavailable — non-Linux")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool, err := NewPool(ctx, &PoolConfig{Enabled: true, PoolAll: true, FallbackStdio: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Shutdown() })
+
+	// Long-lived child that idles on stdin — stands in for an MCP server.
+	const name = "dedup-test"
+	cmd := []string{"-c", "while read line; do echo $line; done"}
+
+	baselineLive := len(liveDirectChildrenMatching(t, os.Getpid(), "sh"))
+	require.NoError(t, pool.Start(name, "sh", cmd, nil))
+
+	// Wait until child actually exists.
+	require.Eventually(t, func() bool {
+		return len(liveDirectChildrenMatching(t, os.Getpid(), "sh"))-baselineLive == 1
+	}, 2*time.Second, 20*time.Millisecond, "pool failed to spawn initial child")
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, pool.RestartProxy(name), "restart #%d", i+1)
+	}
+
+	// Settle — give any leaked children time to be observable.
+	time.Sleep(300 * time.Millisecond)
+
+	live := liveDirectChildrenMatching(t, os.Getpid(), "sh")
+	delta := len(live) - baselineLive
+	assert.Equal(t, 1, delta,
+		"expected exactly 1 live MCP child after 5 restarts (baseline=%d, observed=%v)",
+		baselineLive, live)
+}
+
+// TestPool_ConcurrentStarts_ProduceOneChild — N concurrent Pool.Start calls
+// for the same MCP must coalesce to ONE child. Hypothesis (e): race in the
+// attach + start path lets multiple plugin loads spawn duplicates.
+func TestPool_ConcurrentStarts_ProduceOneChild(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("/proc unavailable — non-Linux")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool, err := NewPool(ctx, &PoolConfig{Enabled: true, PoolAll: true, FallbackStdio: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Shutdown() })
+
+	const name = "concurrent-start-test"
+	cmd := []string{"-c", "while read line; do echo $line; done"}
+
+	baselineLive := len(liveDirectChildrenMatching(t, os.Getpid(), "sh"))
+
+	const N = 8
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		go func() { errs <- pool.Start(name, "sh", cmd, nil) }()
+	}
+	for i := 0; i < N; i++ {
+		require.NoError(t, <-errs)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	live := liveDirectChildrenMatching(t, os.Getpid(), "sh")
+	delta := len(live) - baselineLive
+	assert.Equal(t, 1, delta,
+		"expected exactly 1 live MCP child after %d concurrent Starts (baseline=%d, observed=%v)",
+		N, baselineLive, live)
+}
+
+// TestHTTPPool_ConcurrentStarts_ProduceOneChild — N concurrent HTTPPool.Start
+// calls for the same MCP must coalesce to ONE child. The HTTPPool releases
+// its mutex BEFORE calling server.Start, and HTTPServer.Start only
+// early-returns on StatusRunning — not on StatusStarting. Two concurrent
+// callers can both observe StatusStarting and both spawn processes,
+// orphaning the first child (s.process is overwritten by the second).
+func TestHTTPPool_ConcurrentStarts_ProduceOneChild(t *testing.T) {
+	if _, err := os.Stat("/proc"); err != nil {
+		t.Skip("/proc unavailable — non-Linux")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool := NewHTTPPool(ctx)
+	t.Cleanup(func() { _ = pool.Shutdown() })
+
+	const name = "http-concurrent-test"
+	// A fake server that listens on a port we'll reach via health-check;
+	// using `sleep` is enough — the health probe will fail until timeout,
+	// but BOTH concurrent Starts will spawn a process before that happens.
+	// Use a unique sentinel so the proc-walker can find our children.
+	cmd := "sleep"
+	args := []string{"30"}
+
+	baselineLive := len(liveDirectChildrenMatching(t, os.Getpid(), "sleep"))
+
+	const N = 8
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		go func() {
+			// 50 ms startup timeout — Start will return failure quickly,
+			// but we only care about how many sleep-children are alive.
+			errs <- pool.Start(name, "http://127.0.0.1:1/", "http://127.0.0.1:1/",
+				cmd, args, nil, 50*time.Millisecond)
+		}()
+	}
+	for i := 0; i < N; i++ {
+		<-errs // ignore err — both success and timeout are fine
+	}
+
+	// Settle: give any leaked children a moment to be observable.
+	time.Sleep(200 * time.Millisecond)
+
+	live := liveDirectChildrenMatching(t, os.Getpid(), "sleep")
+	delta := len(live) - baselineLive
+	assert.LessOrEqual(t, delta, 1,
+		"expected at most 1 live MCP child after %d concurrent HTTPPool Starts (baseline=%d, observed=%v)",
+		N, baselineLive, live)
+}


### PR DESCRIPTION
Closes part of cascade prevention work (alongside #902).

## Investigation finding
Audit confirmed agent-deck's `internal/mcppool/` correctly dedups by `(session, mcp-name)` — no duplicate-spawn bug here.

The 43× duplicate `context7-mcp` processes seen during today's cascade trace to **claude code's MCP launcher** (npx-spawned plugin children that don't get reaped when the parent claude exits). That's an upstream issue.

This PR ships the agent-deck-side hardening that's still warranted:
- Strict per-`(session, mcp-name)` singleton check before any new spawn
- 5s timeout on Stop before fresh Start fires (was racing on restart)
- INFO log on every spawn (`mcp_proc_spawn`) for forensic visibility
- Test that asserts a 5x restart yields exactly 1 child process

## Test plan
- [x] go test -race -count=1 ./internal/mcppool/... clean
- [x] lint clean (session_cmd.go SA9003 is pre-existing on main, unrelated)
- [ ] CI green
- [ ] Manual: 5x session restart with context7 attached, verify pgrep -c == 1

## Notes
The upstream leak is documented separately (see /tmp/exec-mcp-leak/RESULTS.md) and is `NEEDS_UPSTREAM` on the claude code side. Combined with #902 (MCP-per-scope) which lands the cgroup wrapper, agent-deck is now resilient even to that upstream bug.

Committed by Ashesh Goplani