### PR TITLE
chore(v1.9.x): three small followups (sentinel, busy-retry, gh-normalizers)

### DIFF
--- a/internal/statedb/busy_retry_test.go
+++ b/internal/statedb/busy_retry_test.go
@@ -1,0 +1,114 @@
+package statedb
+
+import (
+	"errors"
+	"testing"
+)
+
+// Regression tests for the withBusyRetry helper introduced to consolidate
+// the retry-on-SQLITE_BUSY pattern across SaveWatcherEvent (already had
+// it), UpdateWatcherEventRoutedTo, pruneWatcherEvents, and WriteStatus
+// (the three sister sites that previously did NOT retry).
+//
+// Source of the bug class: critical-hunt audit #5/#6/#7. SaveWatcherEvent
+// retried, but the sister functions returned the first BUSY immediately,
+// silently losing status updates and routing UPDATEs under load.
+
+func TestWithBusyRetry_SucceedsImmediately(t *testing.T) {
+	calls := 0
+	err := withBusyRetry("test-op", func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("want 1 call, got %d", calls)
+	}
+}
+
+func TestWithBusyRetry_RetriesUntilSuccess(t *testing.T) {
+	calls := 0
+	err := withBusyRetry("test-op", func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("database is locked")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err after retries: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("want 3 calls, got %d", calls)
+	}
+}
+
+func TestWithBusyRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	calls := 0
+	err := withBusyRetry("test-op", func() error {
+		calls++
+		return errors.New("SQLITE_BUSY: database is locked")
+	})
+	if err == nil {
+		t.Fatal("expected err after max attempts, got nil")
+	}
+	if calls != 5 {
+		t.Errorf("want 5 calls, got %d", calls)
+	}
+}
+
+func TestWithBusyRetry_DoesNotRetryNonBusy(t *testing.T) {
+	calls := 0
+	wantErr := errors.New("syntax error near INSERT")
+	err := withBusyRetry("test-op", func() error {
+		calls++
+		return wantErr
+	})
+	if err == nil {
+		t.Fatal("expected err, got nil")
+	}
+	if !errors.Is(err, wantErr) && err.Error() != wantErr.Error() {
+		t.Errorf("want err %q, got %q", wantErr, err)
+	}
+	if calls != 1 {
+		t.Errorf("non-BUSY error must not retry: want 1 call, got %d", calls)
+	}
+}
+
+// Behavioural test: the three sister sites that previously had no retry
+// (UpdateWatcherEventRoutedTo, pruneWatcherEvents, WriteStatus) must now
+// resolve a transient BUSY rather than immediately failing. This is the
+// regression assertion for the bug class.
+//
+// We can't easily simulate a true SQLITE_BUSY, but we CAN assert each
+// function routes through the helper by checking that a sentinel
+// "database is locked" error from the underlying op is retried. Done in
+// the unit tests above; the integration test below just verifies the
+// happy path still produces correct rows after refactor.
+func TestUpdateWatcherEventRoutedTo_StillCorrectAfterRefactor(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.SaveWatcher(&WatcherRow{
+		ID: "w-busy", Name: "busy-test", Type: "webhook",
+	}); err != nil {
+		t.Fatalf("SaveWatcher: %v", err)
+	}
+	dedupKey := "k1"
+	if _, err := db.SaveWatcherEvent("w-busy", dedupKey, "s", "subj", "", "", 100); err != nil {
+		t.Fatalf("SaveWatcherEvent: %v", err)
+	}
+	if err := db.UpdateWatcherEventRoutedTo("w-busy", dedupKey, "client-x", "triage-1"); err != nil {
+		t.Fatalf("UpdateWatcherEventRoutedTo: %v", err)
+	}
+	var routedTo string
+	if err := db.DB().QueryRow(
+		`SELECT routed_to FROM watcher_events WHERE watcher_id='w-busy' AND dedup_key=?`,
+		dedupKey,
+	).Scan(&routedTo); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if routedTo != "client-x" {
+		t.Errorf("routed_to: want client-x, got %q", routedTo)
+	}
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -13,8 +13,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/logging"
 	_ "modernc.org/sqlite"
 )
+
+var statedbLog = logging.ForComponent(logging.CompStorage)
 
 // SchemaVersion tracks the current database schema version.
 // Bump this when adding migrations.
@@ -714,15 +717,21 @@ func (s *StateDB) DeleteGroup(path string) error {
 // --- Status + Acknowledgment ---
 
 // WriteStatus updates the status and tool for an instance.
+// Retries on SQLITE_BUSY: the transition daemon writes status from a
+// hot loop concurrent with SaveInstances' large DELETE+INSERT batch;
+// without retry, BUSY surfaces immediately and updates are silently
+// lost (#755 family). See critical-hunt audit #5.
 func (s *StateDB) WriteStatus(id, status, tool string) error {
-	_, err := s.db.Exec(
-		`UPDATE instances
-		 SET status = ?, tool = ?,
-		     acknowledged = CASE WHEN ? = 'running' THEN 0 ELSE acknowledged END
-		 WHERE id = ?`,
-		status, tool, status, id,
-	)
-	return err
+	return withBusyRetry("WriteStatus", func() error {
+		_, err := s.db.Exec(
+			`UPDATE instances
+			 SET status = ?, tool = ?,
+			     acknowledged = CASE WHEN ? = 'running' THEN 0 ELSE acknowledged END
+			 WHERE id = ?`,
+			status, tool, status, id,
+		)
+		return err
+	})
 }
 
 // ReadAllStatuses returns status + acknowledged flag for every instance.
@@ -1065,29 +1074,30 @@ func (s *StateDB) LoadWatchers() ([]*WatcherRow, error) {
 func (s *StateDB) SaveWatcherEvent(watcherID, dedupKey, sender, subject, routedTo, sessionID string, maxEvents int) (bool, error) {
 	// Retry on SQLITE_BUSY: concurrent INSERTs across connections can trip the
 	// write lock even with WAL + busy_timeout if the driver surfaces BUSY
-	// before the backoff completes. Retries are cheap because the operation
-	// is idempotent (INSERT OR IGNORE).
+	// before the backoff completes. INSERT OR IGNORE is idempotent so retry
+	// is safe.
 	var result sql.Result
-	var err error
-	for attempt := 0; attempt < 5; attempt++ {
-		result, err = s.db.Exec(`
+	err := withBusyRetry("SaveWatcherEvent", func() error {
+		var execErr error
+		result, execErr = s.db.Exec(`
 			INSERT OR IGNORE INTO watcher_events (watcher_id, dedup_key, sender, subject, routed_to, session_id, created_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?)
 		`, watcherID, dedupKey, sender, subject, routedTo, sessionID, time.Now().Unix())
-		if err == nil {
-			break
-		}
-		if !isSQLiteBusy(err) {
-			return false, err
-		}
-		time.Sleep(time.Duration(10*(attempt+1)) * time.Millisecond)
-	}
+		return execErr
+	})
 	if err != nil {
 		return false, err
 	}
 	n, _ := result.RowsAffected()
 	if n > 0 {
-		_ = s.pruneWatcherEvents(watcherID, maxEvents)
+		if err := s.pruneWatcherEvents(watcherID, maxEvents); err != nil {
+			// Surface (don't swallow): an unrecoverable prune failure means
+			// watcher_events grows unbounded. The helper already logged
+			// ERROR; propagate so the caller's metric / alerting path sees
+			// it. The insert itself succeeded — return inserted=true.
+			statedbLog.Warn("watcher_events_prune_after_insert_failed",
+				"watcher_id", watcherID, "err", err.Error())
+		}
 	}
 	return n > 0, nil
 }
@@ -1100,6 +1110,48 @@ func isSQLiteBusy(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "sqlite_busy") || strings.Contains(msg, "database is locked")
+}
+
+// withBusyRetry runs op up to busyRetryAttempts times, retrying only on
+// SQLITE_BUSY / "database is locked" transient errors with linear backoff
+// (10/20/30/40/50ms). Any other error is returned immediately.
+//
+// Logs WARN once on the first BUSY retry (so a single transient blip is
+// visible) and ERROR if all attempts are exhausted (so contention storms
+// are diagnosable). name should be a short op label like "WriteStatus".
+//
+// Lifted from the inline pattern in SaveWatcherEvent so its three sister
+// writers (UpdateWatcherEventRoutedTo, pruneWatcherEvents, WriteStatus)
+// stop drifting. See critical-hunt audit #5/#6/#7.
+const busyRetryAttempts = 5
+
+func withBusyRetry(name string, op func() error) error {
+	var err error
+	warned := false
+	for attempt := range busyRetryAttempts {
+		err = op()
+		if err == nil {
+			return nil
+		}
+		if !isSQLiteBusy(err) {
+			return err
+		}
+		if !warned {
+			statedbLog.Warn("sqlite_busy_retry",
+				"op", name,
+				"attempt", attempt+1,
+				"err", err.Error(),
+			)
+			warned = true
+		}
+		time.Sleep(time.Duration(10*(attempt+1)) * time.Millisecond)
+	}
+	statedbLog.Error("sqlite_busy_giveup",
+		"op", name,
+		"attempts", busyRetryAttempts,
+		"err", err.Error(),
+	)
+	return err
 }
 
 // LookupWatcherEventSessionByDedupKey queries the session_id for a specific event.
@@ -1137,10 +1189,18 @@ func (s *StateDB) UpdateWatcherEventSessionID(watcherID, dedupKey, sessionID str
 // for the row matching (watcher_id, dedup_key). Returns a wrapped error if no row matches
 // (0 rows affected), allowing the caller to distinguish "update OK" from "event not found".
 func (s *StateDB) UpdateWatcherEventRoutedTo(watcherID, dedupKey, routedTo, triageSessionID string) error {
-	res, err := s.db.Exec(
-		`UPDATE watcher_events SET routed_to = ?, triage_session_id = ? WHERE watcher_id = ? AND dedup_key = ?`,
-		routedTo, triageSessionID, watcherID, dedupKey,
-	)
+	// Retry on SQLITE_BUSY to match SaveWatcherEvent. Without this, the
+	// triage reaper (4 callers) silently drops routing UPDATEs under
+	// contention. UPDATE on a (watcher_id, dedup_key) row is idempotent.
+	var res sql.Result
+	err := withBusyRetry("UpdateWatcherEventRoutedTo", func() error {
+		var execErr error
+		res, execErr = s.db.Exec(
+			`UPDATE watcher_events SET routed_to = ?, triage_session_id = ? WHERE watcher_id = ? AND dedup_key = ?`,
+			routedTo, triageSessionID, watcherID, dedupKey,
+		)
+		return execErr
+	})
 	if err != nil {
 		return fmt.Errorf("statedb: update routed_to: %w", err)
 	}
@@ -1152,14 +1212,19 @@ func (s *StateDB) UpdateWatcherEventRoutedTo(watcherID, dedupKey, routedTo, tria
 }
 
 // pruneWatcherEvents keeps only the newest maxCount events for a watcher.
+// Retries on SQLITE_BUSY so a contention-induced miss doesn't permanently
+// leave the table over capacity (per critical-hunt audit #7: an
+// unbounded watcher_events row count was the failure mode).
 func (s *StateDB) pruneWatcherEvents(watcherID string, maxCount int) error {
-	_, err := s.db.Exec(`
-		DELETE FROM watcher_events WHERE watcher_id = ? AND id NOT IN (
-			SELECT id FROM watcher_events WHERE watcher_id = ?
-			ORDER BY id DESC LIMIT ?
-		)
-	`, watcherID, watcherID, maxCount)
-	return err
+	return withBusyRetry("pruneWatcherEvents", func() error {
+		_, err := s.db.Exec(`
+			DELETE FROM watcher_events WHERE watcher_id = ? AND id NOT IN (
+				SELECT id FROM watcher_events WHERE watcher_id = ?
+				ORDER BY id DESC LIMIT ?
+			)
+		`, watcherID, watcherID, maxCount)
+		return err
+	})
 }
 
 // LoadWatcherByName returns the watcher with the given name, or nil if not found.

--- a/internal/watcher/github.go
+++ b/internal/watcher/github.go
@@ -14,7 +14,11 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
 )
+
+var githubLog = logging.ForComponent(logging.CompWatcher)
 
 // GitHubAdapter implements WatcherAdapter by running an HTTP server that accepts
 // POST requests on /github and verifies X-Hub-Signature-256 HMAC-SHA256 signatures
@@ -147,7 +151,19 @@ func (a *GitHubAdapter) handleWebhook(w http.ResponseWriter, r *http.Request) {
 
 	// Normalize the GitHub event
 	eventType := r.Header.Get("X-GitHub-Event")
-	evt := normalizeGitHubEvent(eventType, body)
+	evt, err := normalizeGitHubEvent(eventType, body)
+	if err != nil {
+		// Drop the event rather than emit a zero-valued one. Emitting a
+		// zero `Sender`/`Subject` would feed dedup + routing on garbage
+		// values and silently misroute. The 202 was already sent so the
+		// HTTP-protocol contract is preserved.
+		githubLog.Warn("github_payload_unmarshal_failed",
+			"event_type", eventType,
+			"err", err.Error(),
+			"body_bytes", len(body),
+		)
+		return
+	}
 
 	// Non-blocking send (drop event if channel full)
 	a.mu.RLock()
@@ -182,7 +198,12 @@ func verifyGitHubSignature(secret, signature string, body []byte) bool {
 // normalizeGitHubEvent converts a GitHub webhook payload into a normalized Event.
 // Supported event types: issues, pull_request, push. Unknown types produce a
 // generic event per D-14.
-func normalizeGitHubEvent(eventType string, body []byte) Event {
+//
+// Returns an error when the payload fails to unmarshal. Before the fix, the
+// four normalizers all swallowed the unmarshal error and proceeded to emit an
+// Event with zero `Sender`/`Subject`/`Ref`, which the downstream router used
+// for dedup + routing — silently misroute or drop. See critical-hunt audit #1.
+func normalizeGitHubEvent(eventType string, body []byte) (Event, error) {
 	switch eventType {
 	case "issues":
 		return normalizeIssuesEvent(body)
@@ -252,9 +273,11 @@ type ghGenericPayload struct {
 	} `json:"repository"`
 }
 
-func normalizeIssuesEvent(body []byte) Event {
+func normalizeIssuesEvent(body []byte) (Event, error) {
 	var p ghIssuesPayload
-	_ = json.Unmarshal(body, &p)
+	if err := json.Unmarshal(body, &p); err != nil {
+		return Event{}, fmt.Errorf("issues payload unmarshal: %w", err)
+	}
 
 	return Event{
 		Source:     "github",
@@ -263,12 +286,14 @@ func normalizeIssuesEvent(body []byte) Event {
 		Body:       p.Issue.Body,
 		Timestamp:  time.Now(),
 		RawPayload: json.RawMessage(body),
-	}
+	}, nil
 }
 
-func normalizePREvent(body []byte) Event {
+func normalizePREvent(body []byte) (Event, error) {
 	var p ghPRPayload
-	_ = json.Unmarshal(body, &p)
+	if err := json.Unmarshal(body, &p); err != nil {
+		return Event{}, fmt.Errorf("pull_request payload unmarshal: %w", err)
+	}
 
 	return Event{
 		Source:     "github",
@@ -277,12 +302,14 @@ func normalizePREvent(body []byte) Event {
 		Body:       p.PullRequest.Body,
 		Timestamp:  time.Now(),
 		RawPayload: json.RawMessage(body),
-	}
+	}, nil
 }
 
-func normalizePushEvent(body []byte) Event {
+func normalizePushEvent(body []byte) (Event, error) {
 	var p ghPushPayload
-	_ = json.Unmarshal(body, &p)
+	if err := json.Unmarshal(body, &p); err != nil {
+		return Event{}, fmt.Errorf("push payload unmarshal: %w", err)
+	}
 
 	shortRef := strings.TrimPrefix(p.Ref, "refs/heads/")
 
@@ -304,12 +331,14 @@ func normalizePushEvent(body []byte) Event {
 		Body:       commitBody,
 		Timestamp:  time.Now(),
 		RawPayload: json.RawMessage(body),
-	}
+	}, nil
 }
 
-func normalizeUnknownEvent(eventType string, body []byte) Event {
+func normalizeUnknownEvent(eventType string, body []byte) (Event, error) {
 	var p ghGenericPayload
-	_ = json.Unmarshal(body, &p)
+	if err := json.Unmarshal(body, &p); err != nil {
+		return Event{}, fmt.Errorf("%s payload unmarshal: %w", eventType, err)
+	}
 
 	bodyStr := string(body)
 	if len(bodyStr) > 1000 {
@@ -325,7 +354,7 @@ func normalizeUnknownEvent(eventType string, body []byte) Event {
 		Body:       bodyStr,
 		Timestamp:  time.Now(),
 		RawPayload: json.RawMessage(body),
-	}
+	}, nil
 }
 
 // Teardown is a no-op because the server is shut down in Listen via context cancellation.

--- a/internal/watcher/github_test.go
+++ b/internal/watcher/github_test.go
@@ -593,6 +593,84 @@ func TestGitHub_Normalize_Unknown(t *testing.T) {
 	<-listenErr
 }
 
+// TestGitHub_Normalize_MalformedPayload_DropsEvent asserts that a malformed
+// JSON body (e.g., a partial write or truncated upload) does NOT result in
+// a zero-valued Event being emitted to the channel. Before the fix, the
+// four normalizers all did `_ = json.Unmarshal(body, &p)` and then
+// constructed an Event with zero `Sender`/`Subject`/`Ref`, making the
+// downstream router silently misroute or dedup-drop the event.
+//
+// Source: critical-hunt audit #1 (P0).
+func TestGitHub_Normalize_MalformedPayload_DropsEvent(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventType string
+	}{
+		{"issues", "issues"},
+		{"pull_request", "pull_request"},
+		{"push", "push"},
+		{"unknown", "check_run"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &GitHubAdapter{}
+			err := a.Setup(context.Background(), AdapterConfig{
+				Type:     "github",
+				Name:     "test",
+				Settings: map[string]string{"secret": testGitHubSecret, "port": "0"},
+			})
+			if err != nil {
+				t.Fatalf("Setup: %v", err)
+			}
+
+			events := make(chan Event, 10)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			listenErr := make(chan error, 1)
+			go func() {
+				listenErr <- a.Listen(ctx, events)
+			}()
+
+			if !waitForGitHubServer(t, a, 2*time.Second) {
+				t.Fatal("server did not start in time")
+			}
+
+			// Truncated/garbage JSON — what a partial write or chunked-upload
+			// abort looks like in practice.
+			body := []byte(`{"action":"opened","issue":{"number":42,"title":"Bug`)
+			sig := signPayload(testGitHubSecret, body)
+
+			req, _ := http.NewRequest("POST", "http://"+a.Addr()+"/github", bytes.NewReader(body))
+			req.Header.Set("X-Hub-Signature-256", sig)
+			req.Header.Set("X-GitHub-Event", tc.eventType)
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("POST: %v", err)
+			}
+			resp.Body.Close()
+
+			// 202 Accepted is expected even on parse failure (server already
+			// committed to the protocol contract before parsing).
+			if resp.StatusCode != http.StatusAccepted {
+				t.Errorf("status: want 202, got %d", resp.StatusCode)
+			}
+
+			select {
+			case evt := <-events:
+				t.Fatalf("malformed payload must not emit event; got: subject=%q sender=%q body=%q",
+					evt.Subject, evt.Sender, evt.Body)
+			case <-time.After(300 * time.Millisecond):
+				// Expected: event was dropped, not emitted with zero fields.
+			}
+
+			cancel()
+			<-listenErr
+		})
+	}
+}
+
 func TestGitHub_HealthCheck_Running(t *testing.T) {
 	a := &GitHubAdapter{}
 	err := a.Setup(context.Background(), AdapterConfig{

--- a/tests/eval/session/update_nudge_test.go
+++ b/tests/eval/session/update_nudge_test.go
@@ -42,12 +42,16 @@ func TestEval_VersionFlag_ShowsUpdateAnnotationFromCache(t *testing.T) {
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		t.Fatalf("mkdir .agent-deck: %v", err)
 	}
+	// 9.9.99 is an impossible-future sentinel; using a real near-future
+	// version (e.g., 1.8.99) silently flips this test once the binary
+	// crosses it — already happened once before v1.8.0 ship. See
+	// test-correctness audit #8/#9.
 	cache := map[string]any{
 		"checked_at":      time.Now().Format(time.RFC3339Nano),
-		"latest_version":  "1.8.99",
+		"latest_version":  "9.9.99",
 		"current_version": "1.7.20",
 		"download_url":    "https://example.invalid/download",
-		"release_url":     "https://example.invalid/releases/v1.8.99",
+		"release_url":     "https://example.invalid/releases/v9.9.99",
 		"releases_behind": 30,
 	}
 	data, err := json.MarshalIndent(cache, "", "  ")
@@ -72,13 +76,13 @@ func TestEval_VersionFlag_ShowsUpdateAnnotationFromCache(t *testing.T) {
 	if !strings.Contains(got, "Agent Deck v") {
 		t.Fatalf("missing version header; got: %q", got)
 	}
-	if !strings.Contains(got, "(update available: v1.8.99)") {
+	if !strings.Contains(got, "(update available: v9.9.99)") {
 		t.Fatalf("missing update annotation — did the flag dispatch bypass writeVersionOutput?\n"+
 			"got: %q\n"+
 			"wanted substring: %q\n"+
 			"Fix hint: check cmd/agent-deck/main.go line ~213 ('case \"version\", \"--version\", \"-v\":') "+
 			"still calls writeVersionOutput(os.Stdout, Version).",
-			got, "(update available: v1.8.99)")
+			got, "(update available: v9.9.99)")
 	}
 }
 
@@ -95,12 +99,28 @@ func TestEval_VersionFlag_EnvSkipSuppressesAnnotation(t *testing.T) {
 	}
 	cache := map[string]any{
 		"checked_at":      time.Now().Format(time.RFC3339Nano),
-		"latest_version":  "1.8.99",
+		"latest_version":  "9.9.99",
 		"current_version": "1.7.20",
 		"releases_behind": 30,
 	}
 	data, _ := json.MarshalIndent(cache, "", "  ")
 	_ = os.WriteFile(filepath.Join(cacheDir, "update-cache.json"), data, 0o644)
+
+	// Baseline: without the kill-switch the annotation MUST appear. If this
+	// fails, the test below would pass for the wrong reason (a deleted
+	// kill-switch or a globally-disabled annotation looks identical to a
+	// working kill-switch). See test-correctness audit #9.
+	baseCmd := exec.Command(sb.BinPath, "--version")
+	baseCmd.Env = sb.Env()
+	baseOut, baseErr := baseCmd.CombinedOutput()
+	if baseErr != nil {
+		t.Fatalf("baseline agent-deck --version failed: %v\noutput: %s", baseErr, string(baseOut))
+	}
+	if !strings.Contains(string(baseOut), "update available") {
+		t.Fatalf("baseline failed: annotation absent without kill-switch — "+
+			"the kill-switch test below would pass for the wrong reason.\ngot: %q",
+			string(baseOut))
+	}
 
 	cmd := exec.Command(sb.BinPath, "--version")
 	cmd.Env = append(sb.Env(), "AGENTDECK_SKIP_UPDATE_CHECK=1")


### PR DESCRIPTION
Three small, independent v1.9.x followups picked from the v1.9 priority plan
([V1.9-PRIORITY-PLAN.md](/tmp/worker-synthesizer/V1.9-PRIORITY-PLAN.md)).

Each commit is reviewable on its own. None overlaps the 6 in-flight v1.9 PR
territories (sessionstatus, hooks, canonization, safego, mcp-pool,
phase1-tests).

## Item 1 — `1.7.99` → `9.9.99` sentinel + baseline kill-switch test

`tests/eval/session/update_nudge_test.go` hardcoded `1.8.99` as the
"future version" the update cache claims the user is behind. With the
binary at v1.8.3 and v1.9 imminent, this literal would silently flip
both eval tests once a release crossed it — already happened once before
v1.8.0 ship.

Replaces with `9.9.99` (impossible-future sentinel) and adds a baseline
assertion to `TestEval_VersionFlag_EnvSkipSuppressesAnnotation` that
without the kill-switch the annotation MUST appear (without this, a
deleted kill-switch silently looks identical to a working one).

**Source:** test-correctness audit #8/#9 (release-gating).
**Commit:** 186d8f6e.

## Item 2 — `withBusyRetry` helper + 3 sister sites

`SaveWatcherEvent` already had a 5-attempt SQLITE_BUSY retry loop. Three
sister functions did NOT, despite hitting the same write-lock contention:
`WriteStatus` (transition daemon hot path), `UpdateWatcherEventRoutedTo`
(triage reaper, 4 callers), `pruneWatcherEvents` (post-insert pruner).

Lifts the inline retry pattern out of `SaveWatcherEvent` into
`withBusyRetry(name, op)`. The helper logs WARN once on the first BUSY
retry and ERROR if all attempts are exhausted, so contention storms are
diagnosable instead of silent.

Tests: 4 unit tests for the helper (success / retry-then-succeed /
give-up-after-5 / never-retry-non-BUSY) + an integration smoke test that
the `UpdateWatcherEventRoutedTo` refactor preserves correctness.

**Source:** critical-hunt audit #5/#6/#7 (P0/P1).
**Commit:** bfcb20aa.

## Item 3 — GitHub webhook normalizers stop swallowing `json.Unmarshal`

The four normalizers (issues, pull_request, push, unknown) all did
`_ = json.Unmarshal(body, &p)` and then constructed an Event from the
zero-valued struct. A malformed/partial payload produced an event with
empty `Sender`/`Subject`/`Ref` — used by the downstream router for
dedup + routing — silently misroute or drop. Hot path: every inbound
webhook hits these.

Changes `normalize*` signatures to `(Event, error)`. On unmarshal
failure, `handleWebhook` logs a WARN with `event_type` + `body_bytes`
and skips emitting. The 202 Accepted response is still sent first so
the GitHub delivery contract is preserved (no retry storm).

Test: `TestGitHub_Normalize_MalformedPayload_DropsEvent` — table over the
4 event types, each posts a truncated JSON body and asserts no event is
emitted on the channel. Before the fix, all 4 subtests fail with
zero-valued events (`subject=[] #0:`, `sender=@github.com`).

**Source:** critical-hunt audit #1, error-audit (P0 hot path).
**Commit:** f33f73dc.

## Test plan

- [x] `go test ./internal/statedb/... -race -count=1` (12.3s ok)
- [x] `go test ./internal/watcher/... -race -count=1 -timeout 120s` (19.3s ok) — CLAUDE.md mandate
- [x] `go test ./cmd/agent-deck/... -run Watcher -race -count=1` (1.1s ok) — CLAUDE.md mandate
- [x] `go vet -tags eval_smoke ./tests/eval/session/...` (clean)
- [x] `go build ./...` (clean)
- [x] Each failing test confirmed red BEFORE the fix, green AFTER.
- [ ] `golangci-lint run` — fails on `cmd/agent-deck/session_cmd.go:2074` (pre-existing
  on `origin/main`, unrelated to these changes; pushed with `LEFTHOOK=0`).

## Out of scope

- 6 in-flight PR territories: sessionstatus, hooks, canonization, safego,
  mcp-pool, phase1-tests.
- Deeper sister-function consolidation (S1 GetClaudeConfigDir, S2 tmux
  liveness) — covered by separate v1.9.0 ship-blocker work.