### PR TITLE
chore(tmux): observability for close-cascade + orphan-PID bursts

### DIFF
--- a/internal/tmux/controlpipe.go
+++ b/internal/tmux/controlpipe.go
@@ -391,7 +391,12 @@ func (cp *ControlPipe) Close() {
 		// timeout, while still routing the underlying cmd.Wait() through
 		// the waitOnce gate that protects against a concurrent Wait from
 		// reader() (#677).
-		_ = reapWithEOFGrace(cp.reap, cp.cmd.Process, controlPipeEOFExitGrace, controlClientKillGrace)
+		usedFallback := reapWithEOFGrace(cp.reap, cp.cmd.Process, controlPipeEOFExitGrace, controlClientKillGrace)
+		if usedFallback {
+			pipeLog.Warn("eof_fallback_fired",
+				slog.String("session", cp.sessionName),
+				slog.Duration("eof_grace", controlPipeEOFExitGrace))
+		}
 
 		pipeLog.Debug("pipe_closed", slog.String("session", cp.sessionName))
 	})

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -452,9 +452,13 @@ func killStaleControlClients(sessionName, socketName string) {
 	}
 
 	// Track burst stats so production logs surface how often this function
-	// fires N>0 SIGTERMs across parallel Connect() calls. Crash 2 on
-	// 2026-05-08 10:32:17 was 5 SIGTERMs in 11 ms across 3 concurrent
-	// Connect()s — see PLAN.md P0''.
+	// fires N>0 SIGTERMs across parallel Connect() calls. The cascade
+	// pattern (multiple SIGTERMs within tens of milliseconds, across
+	// concurrent Connect() goroutines) is the trigger shape for
+	// tmux/tmux#4980's server-side use-after-free in
+	// control_notify_client_detached. The Debug-level
+	// killed_stale_control_client log emits per-PID; this Info line
+	// surfaces the cascade as a single observable event.
 	burstStart := time.Now()
 	killCount := 0
 

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -451,6 +451,13 @@ func killStaleControlClients(sessionName, socketName string) {
 		return // session may not exist or no clients attached
 	}
 
+	// Track burst stats so production logs surface how often this function
+	// fires N>0 SIGTERMs across parallel Connect() calls. Crash 2 on
+	// 2026-05-08 10:32:17 was 5 SIGTERMs in 11 ms across 3 concurrent
+	// Connect()s — see PLAN.md P0''.
+	burstStart := time.Now()
+	killCount := 0
+
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		if line == "" {
 			continue
@@ -474,10 +481,18 @@ func killStaleControlClients(sessionName, socketName string) {
 		// lets the client drain and exit cleanly; SIGKILL is retained as a
 		// 500ms fallback for clients that ignore TERM.
 		usedSIGKILL := softKillProcess(pid, controlClientKillGrace)
+		killCount++
 		pipeLog.Debug("killed_stale_control_client",
 			slog.String("session", sessionName),
 			slog.Int("pid", pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
+	}
+
+	if killCount > 0 {
+		pipeLog.Info("stale_control_clients_swept",
+			slog.String("session", sessionName),
+			slog.Int("kill_count", killCount),
+			slog.Duration("duration", time.Since(burstStart)))
 	}
 }
 


### PR DESCRIPTION
## Summary

Two production diagnostics for the [`tmux/tmux#4980`](https://github.com/tmux/tmux/issues/4980) race that the EOF fast-path mitigation in #882 only partly addresses. Pure additions — no behavior change.

- **`eof_fallback_fired`** (`Warn`) in `controlpipe.go:Close`: captures the previously-discarded `reapWithEOFGrace` return and logs when the EOF fast-path times out and the soft-kill fallback fires. The fast-path's design assumption is "fallback should essentially never fire" — production logs will tell us whether burst-close pressure is silently dropping us out of the fast path.
- **`stale_control_clients_swept`** (`Info`, with `kill_count` + `duration`) in `pipemanager.go:killStaleControlClients`: emitted whenever the function SIGTERMs ≥ 1 orphan `tmux -C` client. The 2026-05-08 crash on this path was 5 SIGTERMs in 11 ms across 3 parallel `Connect()` invocations — a pattern not previously surfaceable because each individual SIGTERM was `Debug`-logged separately. The burst-shape `Info` line lets the cascade be observed as a single event in `~/.agent-deck/debug.log`.

## Context

I'm seeing tmux #4980 crashes recur on the v1.7.72-2-g6b82525 EOF build (now upstream as #882) at MTBF ~22 h on macOS Homebrew tmux 3.6a, with two distinct trigger patterns:

1. **Close-cascade** during `reload_storage_changed`: 5 `pipe_closed` events in ~16 ms (2026-05-07 crash).
2. **Orphan-PID SIGTERM burst** during `Connect()`: 5 SIGTERMs in 11 ms across 3 parallel `Connect()` calls (2026-05-08 crash 2).

Without these two log lines, when the crash recurs I can't tell which path was the trigger. Closing that observability gap is a prerequisite for the next mitigation attempt — see follow-up RFC #907 for the cascade-source analysis and proposed real fix.

## Test plan

- [x] `go vet ./internal/tmux/...` clean
- [x] `go test -race -count=1 ./internal/tmux/...` PASS
- [x] mandated `go test -run TestPersistence_ ./internal/session/... -race -count=1` — only `TestPersistence_CustomCommandResumesFromLatestJSONL` fails, and it fails on bare `main` too (pre-existing, unrelated)
- [x] Built + adhoc-signed + installed v1.8.3-2-g8991554; smoke check that startup + session attach/detach surfaces neither line spuriously, and that an induced EOF timeout produces `eof_fallback_fired`
