### PR TITLE
test(tmux): closeGate burst harness + dose-response on #4980

### DIFF
--- a/internal/tmux/burst_close_test.go
+++ b/internal/tmux/burst_close_test.go
@@ -1,0 +1,255 @@
+package tmux
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestPipeManager_BurstClose_DoesNotCrashServer is a regression check for the
+// 2026-05-07 #4980 trigger pattern: many ControlPipe.Close() calls dispatched
+// within a few milliseconds of each other against a tmux server with active
+// pane state. The race is server-side in `control_notify_client_detached`,
+// which iterates remaining control clients on each detach to send
+// %client-detached notifications — back-to-back detaches let the iteration
+// hit a freed-but-still-listed client.
+//
+// See ~/.claude/scratchpad/agent-deck/tmux-issues/PLAN.md section P0'' for
+// the full diagnosis.
+//
+// Method:
+//  1. Spawn N tmux sessions, each running a small notification-load script
+//     (windowing operations + steady output) so the server's notify-walk
+//     list is non-trivial.
+//  2. Open a ControlPipe per session via PipeManager.
+//  3. Release all goroutines from a barrier so every Disconnect() (which
+//     calls cp.Close()) starts within microseconds of the others —
+//     compressing the close cascade more tightly than the 16-ms real-world
+//     reload_storage_changed pattern.
+//  4. Assert the tmux server is still alive via `tmux list-sessions`.
+//  5. Repeat for many trials and report the crash rate.
+//
+// This test takes seconds and does not run on -short. It also requires a
+// short TMPDIR (e.g. TMPDIR=/tmp/) on macOS — the default
+// /private/var/folders/... path overflows tmux's 104-char socket limit.
+//
+// Tunable via env (helpful when measuring baseline crash rate or tuning the
+// future closeGate fix):
+//
+//	BURST_CLOSE_TRIALS  - number of trials (default 100)
+//	BURST_CLOSE_N       - sessions per trial (default 10)
+//
+// On any crash, the test logs the trial number and continues so the rate is
+// observable in a single run; t.Errorf at the end fails the overall test if
+// crashes > 0.
+func TestPipeManager_BurstClose_DoesNotCrashServer(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	if testing.Short() {
+		t.Skip("integration: real tmux required, takes seconds")
+	}
+	// Gated: empirically a smoke check (0/400 trials across configs
+	// 2026-05-07) — fresh isolated server can't reach the freed-but-listed
+	// timing window. Kept as on-demand closeGate-fix validation harness.
+	if os.Getenv("AGENT_DECK_BURST_TEST") == "" {
+		t.Skip("integration: set AGENT_DECK_BURST_TEST=1 to run; see PLAN.md")
+	}
+
+	trials := envInt("BURST_CLOSE_TRIALS", 100)
+	n := envInt("BURST_CLOSE_N", 10)
+	socket := isolatedTmuxSocket(t)
+
+	crashes := 0
+	for trial := 0; trial < trials; trial++ {
+		if !runBurstCloseTrial(t, socket, trial, n) {
+			crashes++
+			// Give the OS a beat to settle before the next trial recreates
+			// a fresh server.
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	t.Logf("burst-close: %d/%d trials crashed (N=%d sessions per trial)", crashes, trials, n)
+	if crashes > 0 {
+		t.Errorf("tmux server crashed under burst-close pattern: %d/%d trials (#4980)", crashes, trials)
+	}
+}
+
+// runBurstCloseTrial returns true if the tmux server survived the trial.
+func runBurstCloseTrial(t *testing.T, socket string, trial, n int) (alive bool) {
+	t.Helper()
+
+	sessions := make([]string, n)
+	for i := range sessions {
+		sessions[i] = fmt.Sprintf("burst-close-%d-%d", trial, i)
+		if !spawnNoisySession(t, socket, sessions[i]) {
+			t.Logf("trial %d: spawn %q failed; skipping", trial, sessions[i])
+			return true
+		}
+	}
+	defer killSessionsBestEffort(socket, sessions)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pm := NewPipeManager(ctx, func(string) {})
+	defer pm.Close()
+
+	for _, name := range sessions {
+		if err := pm.Connect(name, socket); err != nil {
+			t.Logf("trial %d: Connect(%s) failed: %v; skipping trial", trial, name, err)
+			return true
+		}
+	}
+
+	// Age the connections — the real-world reproduction had established,
+	// long-lived control clients with accumulated state (scrollback,
+	// per-pane buffers, copy-mode etc.). 50 ms barely lets the handshake
+	// complete; let them settle for longer to approach the real-world
+	// "freed-but-still-in-list" timing window.
+	ageDur := time.Duration(envInt("BURST_CLOSE_AGE_MS", 200)) * time.Millisecond
+	time.Sleep(ageDur)
+
+	// Stir the server's notify-walk list by triggering a few new-window /
+	// kill-window events across random sessions. This mimics the real
+	// workload where the server is mid-bookkeeping when the close cascade
+	// arrives. (Skips silently if a stir op fails — best-effort load.)
+	if envInt("BURST_CLOSE_STIR", 1) > 0 {
+		for _, name := range sessions[:n/2] {
+			_ = tmuxExec(socket, "new-window", "-t", name).Run()
+			_ = tmuxExec(socket, "kill-window", "-t", name+":^").Run()
+		}
+	}
+
+	// Two-wave close pattern. The bug requires that one client's notify-walk
+	// iterate over another client whose free has begun but whose unlink
+	// from the global control-clients list hasn't yet completed. With ALL
+	// pipes closing in one wave, the server may have no remaining clients
+	// to iterate over by the time the race-prone state appears. Splitting
+	// into two waves separated by a small gap gives the first wave's
+	// detaches a population of freshly-freed-but-still-listed siblings
+	// during the second wave's notify-walks — mirroring the real-world
+	// reload_storage_changed cascade more faithfully than a single-wave
+	// barrier.
+	//
+	// BURST_CLOSE_RECONNECT=0 disables the reconnect arm.
+	// BURST_CLOSE_GAP_MS controls the inter-wave gap (default 5 ms).
+	reconnectArm := envInt("BURST_CLOSE_RECONNECT", 1) > 0
+	gap := time.Duration(envInt("BURST_CLOSE_GAP_MS", 5)) * time.Millisecond
+
+	half := n / 2
+	if half == 0 {
+		half = 1
+	}
+	wave1 := sessions[:half]
+	wave2 := sessions[half:]
+
+	dispatchWave := func(names []string, barrier <-chan struct{}, wg *sync.WaitGroup) {
+		for _, name := range names {
+			name := name
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-barrier
+				pm.Disconnect(name)
+				if reconnectArm {
+					_ = pm.Connect(name, socket)
+				}
+			}()
+		}
+	}
+
+	var wg sync.WaitGroup
+	b1 := make(chan struct{})
+	b2 := make(chan struct{})
+	dispatchWave(wave1, b1, &wg)
+	dispatchWave(wave2, b2, &wg)
+	close(b1)
+	time.Sleep(gap)
+	close(b2)
+	wg.Wait()
+
+	// Liveness check — the bug crashes the entire tmux server, not just
+	// one session. If `list-sessions` fails or reports "no server running"
+	// we know the server died.
+	out, err := tmuxExec(socket, "list-sessions").CombinedOutput()
+	if err != nil || strings.Contains(string(out), "no server running") {
+		t.Logf("trial %d: server died after burst-close (err=%v out=%q)",
+			trial, err, strings.TrimSpace(string(out)))
+		return false
+	}
+	return true
+}
+
+// spawnNoisySession creates a detached tmux session with extra panes and
+// some steady output, to give the server's control-client notify-walk a
+// non-trivial bookkeeping load. Returns false on creation failure (caller
+// should skip the trial rather than fail).
+func spawnNoisySession(t *testing.T, socket, name string) bool {
+	t.Helper()
+	// Body process: print a short line every ~5ms forever. Enough output
+	// to keep the server's per-pane buffers churning without blowing up
+	// log/disk.
+	body := "while :; do printf 'x\\n'; sleep 0.005; done"
+	if err := tmuxExec(socket, "new-session", "-d", "-s", name, "sh", "-c", body).Run(); err != nil {
+		return false
+	}
+	// Add 2 extra windows, each with a split pane, so each session has
+	// 3 windows × 1-2 panes. Mirrors a realistic editor+repl layout.
+	for i := 0; i < 2; i++ {
+		if err := tmuxExec(socket, "new-window", "-t", name, "sh", "-c", body).Run(); err != nil {
+			return false
+		}
+		if err := tmuxExec(socket, "split-window", "-t", name, "sh", "-c", body).Run(); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func killSessionsBestEffort(socket string, sessions []string) {
+	for _, name := range sessions {
+		_ = tmuxExec(socket, "kill-session", "-t", name).Run()
+	}
+}
+
+// isolatedTmuxSocket returns a unique short -L socket name for a fresh tmux
+// server scoped to this test. Uses tmux -L (default tmpdir, short name) rather
+// than -S (full path) so we don't run afoul of the 104-char socket-path limit
+// that bites macOS /var/folders/... defaults. Registers a t.Cleanup that
+// kills the test server so we don't leak background tmux processes between
+// test runs. CRITICAL: every test in this package that targets tmux MUST go
+// through an isolated socket — this package's whole reason for existing is
+// to crash the targeted server, and the user's real agent-deck-managed
+// sessions live on the user's default socket.
+func isolatedTmuxSocket(t *testing.T) string {
+	t.Helper()
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatalf("rand.Read for socket suffix: %v", err)
+	}
+	socket := "ad-burst-test-" + hex.EncodeToString(b[:])
+	t.Cleanup(func() {
+		// kill-server returns "no server running" on success-path teardown
+		// (server already gone) — we don't care, just want to ensure no
+		// background tmux processes outlive the test.
+		_ = tmuxExec(socket, "kill-server").Run()
+	})
+	return socket
+}
+
+func envInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	var out int
+	if _, err := fmt.Sscanf(v, "%d", &out); err != nil || out <= 0 {
+		return def
+	}
+	return out
+}

--- a/internal/tmux/burst_close_test.go
+++ b/internal/tmux/burst_close_test.go
@@ -20,9 +20,6 @@ import (
 // %client-detached notifications — back-to-back detaches let the iteration
 // hit a freed-but-still-listed client.
 //
-// See ~/.claude/scratchpad/agent-deck/tmux-issues/PLAN.md section P0'' for
-// the full diagnosis.
-//
 // Method:
 //  1. Spawn N tmux sessions, each running a small notification-load script
 //     (windowing operations + steady output) so the server's notify-walk
@@ -53,11 +50,15 @@ func TestPipeManager_BurstClose_DoesNotCrashServer(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration: real tmux required, takes seconds")
 	}
-	// Gated: empirically a smoke check (0/400 trials across configs
-	// 2026-05-07) — fresh isolated server can't reach the freed-but-listed
-	// timing window. Kept as on-demand closeGate-fix validation harness.
+	// Gated: at the un-gated production default (closeGateStagger=0)
+	// this harness produces 0 crashes — a fresh isolated server can't
+	// reach the freed-but-still-listed timing window without server-
+	// aging state. The harness reproduces reliably (~14 % at
+	// stagger=15ms) when AGENT_DECK_CLOSE_STAGGER_MS is set into the
+	// danger band, which is why it's kept in tree as a regression-
+	// against-mistakes canary, not run on the default test path.
 	if os.Getenv("AGENT_DECK_BURST_TEST") == "" {
-		t.Skip("integration: set AGENT_DECK_BURST_TEST=1 to run; see PLAN.md")
+		t.Skip("integration: set AGENT_DECK_BURST_TEST=1 to run")
 	}
 
 	trials := envInt("BURST_CLOSE_TRIALS", 100)

--- a/internal/tmux/closegate_test.go
+++ b/internal/tmux/closegate_test.go
@@ -10,8 +10,9 @@ import (
 // TestTriggerCloseGated_SerializesWithStagger pins the closeGate primitive's
 // behavior: N concurrent triggerCloseGated calls must record their trigger
 // times >= closeGateStagger apart (modulo a small scheduler-jitter slack).
-// The whole point of the gate is to keep server-side detach triggers from
-// stacking inside tmux's notify-walk drain window — see PLAN.md P0''.
+// The gate's purpose is to keep server-side detach triggers from stacking
+// inside tmux's notify-walk drain window (the freed-but-still-listed race
+// in tmux/tmux#4980).
 //
 // This is a unit test for the gating primitive only; the integration shape
 // (gated burst doesn't crash a real tmux server) is exercised by the

--- a/internal/tmux/closegate_test.go
+++ b/internal/tmux/closegate_test.go
@@ -1,0 +1,50 @@
+package tmux
+
+import (
+	"sort"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestTriggerCloseGated_SerializesWithStagger pins the closeGate primitive's
+// behavior: N concurrent triggerCloseGated calls must record their trigger
+// times >= closeGateStagger apart (modulo a small scheduler-jitter slack).
+// The whole point of the gate is to keep server-side detach triggers from
+// stacking inside tmux's notify-walk drain window — see PLAN.md P0''.
+//
+// This is a unit test for the gating primitive only; the integration shape
+// (gated burst doesn't crash a real tmux server) is exercised by the
+// AGENT_DECK_BURST_TEST=1 burst tests.
+func TestTriggerCloseGated_SerializesWithStagger(t *testing.T) {
+	const n = 8
+	times := make([]time.Time, n)
+
+	var wg sync.WaitGroup
+	barrier := make(chan struct{})
+	for i := 0; i < n; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-barrier
+			triggerCloseGated(func() { times[i] = time.Now() })
+		}()
+	}
+	close(barrier)
+	wg.Wait()
+
+	sort.Slice(times, func(a, b int) bool { return times[a].Before(times[b]) })
+
+	// Allow 5 ms slack for goroutine scheduling jitter — empirically
+	// time.Sleep on macOS overshoots by 1-3 ms but rarely undershoots.
+	tolerance := 5 * time.Millisecond
+	want := closeGateStagger - tolerance
+	for i := 1; i < n; i++ {
+		gap := times[i].Sub(times[i-1])
+		if gap < want {
+			t.Errorf("gap[%d] = %v < %v (closeGateStagger=%v - %v slack)",
+				i, gap, want, closeGateStagger, tolerance)
+		}
+	}
+}

--- a/internal/tmux/controlpipe.go
+++ b/internal/tmux/controlpipe.go
@@ -391,7 +391,12 @@ func (cp *ControlPipe) Close() {
 		// timeout, while still routing the underlying cmd.Wait() through
 		// the waitOnce gate that protects against a concurrent Wait from
 		// reader() (#677).
-		_ = reapWithEOFGrace(cp.reap, cp.cmd.Process, controlPipeEOFExitGrace, controlClientKillGrace)
+		usedFallback := reapWithEOFGrace(cp.reap, cp.cmd.Process, controlPipeEOFExitGrace, controlClientKillGrace)
+		if usedFallback {
+			pipeLog.Warn("eof_fallback_fired",
+				slog.String("session", cp.sessionName),
+				slog.Duration("eof_grace", controlPipeEOFExitGrace))
+		}
 
 		pipeLog.Debug("pipe_closed", slog.String("session", cp.sessionName))
 	})

--- a/internal/tmux/controlpipe.go
+++ b/internal/tmux/controlpipe.go
@@ -384,7 +384,13 @@ func (cp *ControlPipe) Close() {
 		cp.mu.Unlock()
 
 		// Stage 1: stdin EOF triggers tmux's orderly-detach %exit path.
-		cp.stdin.Close()
+		// Routed through the closeGate primitive so the burst regression
+		// harness (AGENT_DECK_BURST_TEST=1, AGENT_DECK_CLOSE_STAGGER_MS) can
+		// opt into a cadence inside tmux/tmux#4980's freed-but-still-listed
+		// window to trigger the bug deterministically. Production default
+		// is stagger=0, which short-circuits triggerCloseGated to a direct
+		// call — no behavior change vs. a bare cp.stdin.Close().
+		triggerCloseGated(func() { cp.stdin.Close() })
 
 		// Stage 2 (fast path) and Stage 3 (signal escalation fallback).
 		// reapWithEOFGrace runs cp.reap() in a goroutine so we get a

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -501,14 +501,77 @@ func killStaleControlClients(sessionName, socketName string) {
 // times for `tmux -C attach-session` on macOS + Linux.
 const controlClientKillGrace = 500 * time.Millisecond
 
+// closeGateStagger is the minimum spacing between server-side detach
+// triggers (stdin EOF on a ControlPipe; SIGTERM on an orphan tmux -C
+// client). Defaults to 0 — gate disabled in production.
+//
+// The 2026-05-08 parameter sweep (PLAN.md §closeGate dose-response)
+// showed the freed-but-still-listed race in tmux/tmux#4980 has an
+// empirical window of ~5-100 ms: any client-side stagger inside that
+// window INCREASES crash rate (peaked at ~18 % at 50 ms vs. 0 %
+// un-gated) by spacing each detach into the previous one's notify-walk
+// drain window. Both 0 ms and >= 200 ms are safe in our harness; 0 ms
+// also matches HEAD behavior, so prod ships un-gated.
+//
+// The knob is retained so the burst regression tests
+// (AGENT_DECK_BURST_TEST=1) can opt into the in-window cadence to
+// reliably trigger the bug, giving us a regression-against-mistakes
+// canary: any future code path that introduces an inadvertent 5-100 ms
+// close cadence will be caught by re-running the harness at the cadence
+// in question. Override via AGENT_DECK_CLOSE_STAGGER_MS.
+var closeGateStagger = func() time.Duration {
+	if s := os.Getenv("AGENT_DECK_CLOSE_STAGGER_MS"); s != "" {
+		var ms int
+		if _, err := fmt.Sscanf(s, "%d", &ms); err == nil && ms >= 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return 0
+}()
+
+// closeGateMu serializes server-side detach triggers across every Close
+// path in this process. Held only for the trigger syscall plus
+// closeGateStagger — never for the EOF-wait or SIGKILL-poll phases, so
+// per-close latency stays bounded by the underlying grace, not by
+// N × stagger. Process-global because there is one tmux server per
+// socket and one PipeManager per agent-deck process: the gate
+// corresponds to "this server's notify-walk drain budget" regardless
+// of which goroutine triggered the detach.
+var closeGateMu sync.Mutex
+
+// triggerCloseGated invokes trigger under closeGateMu and sleeps
+// closeGateStagger before unlocking. trigger MUST be the call that
+// initiates the server-side detach (cp.stdin.Close, syscall.Kill
+// SIGTERM); the reap / poll-for-exit phase MUST run outside this gate
+// so per-close latency stays bounded by the underlying grace, not
+// N × stagger. A zero closeGateStagger short-circuits to a direct
+// trigger() call — production default, identical to the un-gated
+// path that shipped pre-2026-05-08.
+func triggerCloseGated(trigger func()) {
+	if closeGateStagger == 0 {
+		trigger()
+		return
+	}
+	closeGateMu.Lock()
+	defer closeGateMu.Unlock()
+	trigger()
+	time.Sleep(closeGateStagger)
+}
+
 // softKillProcess sends SIGTERM to pid, polls every 25ms up to grace for the
 // process to exit, and escalates to SIGKILL if it doesn't. Returns true iff
 // SIGKILL was ultimately used. A non-existent pid (ESRCH) is treated as
 // already-dead and returns false without escalation.
 func softKillProcess(pid int, grace time.Duration) bool {
-	// Initial SIGTERM. If the process is already gone, we're done.
-	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
+	// Initial SIGTERM, routed through closeGate so burst-regression
+	// tests can opt into a freed-but-still-listed cadence via
+	// AGENT_DECK_CLOSE_STAGGER_MS. The gate is a no-op at stagger=0 (the
+	// production default), so this call is identical to a bare
+	// syscall.Kill in shipped builds.
+	var sigtermErr error
+	triggerCloseGated(func() { sigtermErr = syscall.Kill(pid, syscall.SIGTERM) })
+	if sigtermErr != nil {
+		if errors.Is(sigtermErr, syscall.ESRCH) {
 			return false
 		}
 		// Permission or other error — try SIGKILL as last resort.

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -452,9 +452,13 @@ func killStaleControlClients(sessionName, socketName string) {
 	}
 
 	// Track burst stats so production logs surface how often this function
-	// fires N>0 SIGTERMs across parallel Connect() calls. Crash 2 on
-	// 2026-05-08 10:32:17 was 5 SIGTERMs in 11 ms across 3 concurrent
-	// Connect()s — see PLAN.md P0''.
+	// fires N>0 SIGTERMs across parallel Connect() calls. The cascade
+	// pattern (multiple SIGTERMs within tens of milliseconds, across
+	// concurrent Connect() goroutines) is the trigger shape for
+	// tmux/tmux#4980's server-side use-after-free in
+	// control_notify_client_detached. The Debug-level
+	// killed_stale_control_client log emits per-PID; this Info line
+	// surfaces the cascade as a single observable event.
 	burstStart := time.Now()
 	killCount := 0
 
@@ -505,13 +509,15 @@ const controlClientKillGrace = 500 * time.Millisecond
 // triggers (stdin EOF on a ControlPipe; SIGTERM on an orphan tmux -C
 // client). Defaults to 0 — gate disabled in production.
 //
-// The 2026-05-08 parameter sweep (PLAN.md §closeGate dose-response)
-// showed the freed-but-still-listed race in tmux/tmux#4980 has an
-// empirical window of ~5-100 ms: any client-side stagger inside that
-// window INCREASES crash rate (peaked at ~18 % at 50 ms vs. 0 %
-// un-gated) by spacing each detach into the previous one's notify-walk
-// drain window. Both 0 ms and >= 200 ms are safe in our harness; 0 ms
-// also matches HEAD behavior, so prod ships un-gated.
+// Empirical parameter sweep on the burst regression harness in this
+// package (TestPipeManager_BurstClose_DoesNotCrashServer at varying
+// AGENT_DECK_CLOSE_STAGGER_MS values) showed the freed-but-still-listed
+// race in tmux/tmux#4980 has an empirical window of ~5-100 ms: any
+// client-side stagger inside that window INCREASES crash rate
+// (peaked at ~18 % at 50 ms vs. 0 % un-gated) by spacing each detach
+// into the previous one's notify-walk drain window. Both 0 ms and
+// >= 200 ms are safe in the harness; 0 ms also matches the un-gated
+// production default.
 //
 // The knob is retained so the burst regression tests
 // (AGENT_DECK_BURST_TEST=1) can opt into the in-window cadence to

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -451,6 +451,13 @@ func killStaleControlClients(sessionName, socketName string) {
 		return // session may not exist or no clients attached
 	}
 
+	// Track burst stats so production logs surface how often this function
+	// fires N>0 SIGTERMs across parallel Connect() calls. Crash 2 on
+	// 2026-05-08 10:32:17 was 5 SIGTERMs in 11 ms across 3 concurrent
+	// Connect()s — see PLAN.md P0''.
+	burstStart := time.Now()
+	killCount := 0
+
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		if line == "" {
 			continue
@@ -474,10 +481,18 @@ func killStaleControlClients(sessionName, socketName string) {
 		// lets the client drain and exit cleanly; SIGKILL is retained as a
 		// 500ms fallback for clients that ignore TERM.
 		usedSIGKILL := softKillProcess(pid, controlClientKillGrace)
+		killCount++
 		pipeLog.Debug("killed_stale_control_client",
 			slog.String("session", sessionName),
 			slog.Int("pid", pid),
 			slog.Bool("used_sigkill", usedSIGKILL))
+	}
+
+	if killCount > 0 {
+		pipeLog.Info("stale_control_clients_swept",
+			slog.String("session", sessionName),
+			slog.Int("kill_count", killCount),
+			slog.Duration("duration", time.Since(burstStart)))
 	}
 }
 

--- a/internal/tmux/sigterm_burst_test.go
+++ b/internal/tmux/sigterm_burst_test.go
@@ -50,13 +50,13 @@ func TestKillStaleControlClients_BurstDoesNotCrashServer(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration: real tmux required, takes seconds")
 	}
-	// Gated: 100 trials × 10 clients × 100 ms settle ≈ 4 min on macOS, and
-	// the test was empirically a smoke check (0/100 baseline 2026-05-08,
-	// 0/400 prior closeGate-path baseline 2026-05-07) — useful as on-demand
-	// validation harness for the closeGate fix, not as a default-path
-	// regression check. See PLAN.md P0''-companion notes.
+	// Gated: 100 trials × 10 clients × 100 ms settle ≈ 4 min on macOS,
+	// and at every closeGate cadence tested so far the harness produces
+	// 0 crashes — the orphan-PID SIGTERM-burst path needs server-aging
+	// state that a per-trial fresh server can't reach. Kept on-demand
+	// rather than on the default test path.
 	if os.Getenv("AGENT_DECK_BURST_TEST") == "" {
-		t.Skip("integration: set AGENT_DECK_BURST_TEST=1 to run; see PLAN.md")
+		t.Skip("integration: set AGENT_DECK_BURST_TEST=1 to run")
 	}
 
 	trials := envInt("SIGTERM_BURST_TRIALS", 100)

--- a/internal/tmux/sigterm_burst_test.go
+++ b/internal/tmux/sigterm_burst_test.go
@@ -1,0 +1,180 @@
+package tmux
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestKillStaleControlClients_BurstDoesNotCrashServer is a regression check
+// for the 2026-05-08 10:32:17 trigger pattern. From the debug log:
+//
+//	10:32:17.145  killed_stale_control_client align-laurel pid=17364
+//	10:32:17.150  killed_stale_control_client investigate-s3 pid=17357
+//	10:32:17.150  killed_stale_control_client gleaming-fern pid=17360
+//	10:32:17.156  killed_stale_control_client gleaming-fern pid=17363
+//	10:32:17.156  killed_stale_control_client investigate-s3 pid=17362
+//	             [server dies — 5 SIGTERMs in 11 ms across 3 parallel
+//	              Connect() invocations]
+//
+// 5 SIGTERMs to control-mode tmux clients in 11 ms expose tmux #4980's
+// use-after-free in control_notify_client_detached. The EOF fast-path
+// fix landed on the agent-deck-owned control pipe (`ControlPipe.Close`),
+// but `killStaleControlClients` uses `softKillProcess` (SIGTERM+grace) on
+// orphan tmux -C clients we don't own the stdin of — so the EOF fix
+// doesn't cover this path.
+//
+// This test spawns N `tmux -C attach-session` children on the isolated
+// socket, lets them complete the control-mode handshake, then barrier-
+// releases N concurrent `softKillProcess` calls to compress the cascade
+// to microseconds. Liveness check via `tmux list-sessions` confirms
+// whether the server survived.
+//
+// Tunable via env (helpful when measuring baseline rate or tuning the
+// future closeGate fix):
+//
+//	SIGTERM_BURST_TRIALS  - number of trials (default 100)
+//	SIGTERM_BURST_N       - clients per trial (default 10)
+//	SIGTERM_BURST_AGE_MS  - settle time after attach before SIGTERM
+//	                        (default 100 ms — enough for the control
+//	                        handshake to complete on macOS)
+//
+// Crashes are tallied across all trials and the test fails if any occur.
+func TestKillStaleControlClients_BurstDoesNotCrashServer(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	if testing.Short() {
+		t.Skip("integration: real tmux required, takes seconds")
+	}
+	// Gated: 100 trials × 10 clients × 100 ms settle ≈ 4 min on macOS, and
+	// the test was empirically a smoke check (0/100 baseline 2026-05-08,
+	// 0/400 prior closeGate-path baseline 2026-05-07) — useful as on-demand
+	// validation harness for the closeGate fix, not as a default-path
+	// regression check. See PLAN.md P0''-companion notes.
+	if os.Getenv("AGENT_DECK_BURST_TEST") == "" {
+		t.Skip("integration: set AGENT_DECK_BURST_TEST=1 to run; see PLAN.md")
+	}
+
+	trials := envInt("SIGTERM_BURST_TRIALS", 100)
+	n := envInt("SIGTERM_BURST_N", 10)
+	socket := isolatedTmuxSocket(t)
+
+	crashes := 0
+	for trial := 0; trial < trials; trial++ {
+		if !runSigtermBurstTrial(t, socket, trial, n) {
+			crashes++
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	t.Logf("sigterm-burst: %d/%d trials crashed (N=%d clients per trial)", crashes, trials, n)
+	if crashes > 0 {
+		t.Errorf("tmux server crashed under SIGTERM burst: %d/%d trials (#4980)", crashes, trials)
+	}
+}
+
+// runSigtermBurstTrial returns true if the tmux server survived the trial.
+func runSigtermBurstTrial(t *testing.T, socket string, trial, n int) (alive bool) {
+	t.Helper()
+
+	sessions := make([]string, n)
+	for i := range sessions {
+		sessions[i] = fmt.Sprintf("sigterm-burst-%d-%d", trial, i)
+		if !spawnNoisySession(t, socket, sessions[i]) {
+			t.Logf("trial %d: spawn %q failed; skipping", trial, sessions[i])
+			return true
+		}
+	}
+	defer killSessionsBestEffort(socket, sessions)
+
+	// Spawn a `tmux -C attach-session -t SESSION` child per session. These
+	// stand in for the orphan control clients that killStaleControlClients
+	// targets in production.
+	clients := make([]*exec.Cmd, 0, n)
+	stdins := make([]io.Closer, 0, n)
+	defer func() {
+		// Belt-and-suspenders cleanup. softKillProcess in the barrier-release
+		// path should have already reaped most clients; this is for any
+		// straggler.
+		for i, c := range clients {
+			if c.Process != nil {
+				_ = c.Process.Kill()
+				_ = c.Wait()
+			}
+			if i < len(stdins) {
+				_ = stdins[i].Close()
+			}
+		}
+	}()
+	for _, name := range sessions {
+		cmd := tmuxExec(socket, "-C", "attach-session", "-t", name)
+		// Pipe stdin so the child doesn't see EOF and exit before the
+		// SIGTERM cascade. We never close these — the cascade is purely
+		// signal-driven (mirrors killStaleControlClients, which also
+		// signals orphan PIDs without owning their stdin).
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			t.Logf("trial %d: stdin pipe for %s: %v; skip", trial, name, err)
+			return true
+		}
+		if err := cmd.Start(); err != nil {
+			t.Logf("trial %d: start tmux -C for %s: %v; skip", trial, name, err)
+			_ = stdin.Close()
+			return true
+		}
+		clients = append(clients, cmd)
+		stdins = append(stdins, stdin)
+	}
+
+	// Settle: let each client complete the control-mode handshake and
+	// register in the server's control-clients list.
+	settle := time.Duration(envInt("SIGTERM_BURST_AGE_MS", 100)) * time.Millisecond
+	time.Sleep(settle)
+
+	// Sanity check: server should actually report >= N clients attached.
+	out, err := tmuxExec(socket, "list-clients").Output()
+	if err != nil {
+		t.Logf("trial %d: list-clients failed pre-barrier: %v; skip", trial, err)
+		return true
+	}
+	attached := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			attached++
+		}
+	}
+	if attached < n {
+		t.Logf("trial %d: only %d/%d clients attached pre-barrier; skip", trial, attached, n)
+		return true
+	}
+
+	// Barrier-release N concurrent softKillProcess calls. Goroutine wake-up
+	// + a single syscall.Kill should compress the cascade tighter than the
+	// 11 ms observed in the real-world crash 2.
+	var wg sync.WaitGroup
+	barrier := make(chan struct{})
+	for _, c := range clients {
+		c := c
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-barrier
+			if c.Process != nil {
+				_ = softKillProcess(c.Process.Pid, controlClientKillGrace)
+			}
+		}()
+	}
+	close(barrier)
+	wg.Wait()
+
+	// Liveness check.
+	if err := tmuxExec(socket, "list-sessions").Run(); err != nil {
+		t.Logf("trial %d: tmux server died after SIGTERM burst (err=%v)", trial, err)
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
> **Status: RFC / draft.** Filing this to share the empirical findings + proposed real fix. **Nothing in this PR is a fix.**

## TL;DR

Trying to TDD a fix for the recurring [`tmux/tmux#4980`](https://github.com/tmux/tmux/issues/4980) crashes that #882's EOF fast-path only partly mitigates (MTBF ~22 h on macOS 3.6a; two crashes 2026-05-08), I built a parameterised burst harness. Headline finding: **any client-side close-cascade stagger inside ~5–100 ms makes things WORSE.** The "naturally serialise concurrent closes with a small gap" instinct turns out to be exactly the wrong shape.

This PR ships **no production-default behaviour change** — `closeGateStagger` defaults to 0, gate disabled. What it ships is the harness + the falsification report. The proposed real fix (`PipeManager.ReconcileSessions`, sketched below) is **not implemented here**; it's a follow-up. Depends on #906 being merged first (the instrumentation companion).

## Dose-response

50-trial sweep, per-trial-isolated tmux 3.6a server, varying `AGENT_DECK_CLOSE_STAGGER_MS`:

| stagger | crashes / 50 | rate |
| --- | --- | --- |
| 0 ms (off, equiv. to bare `main`) | 0 / 50 | 0 % |
| 2 ms | 2 / 50 | 4 % |
| 5 ms | 2 / 50 | 4 % |
| 15 ms | 7 / 50 | 14 % |
| 50 ms | 9 / 50 | 18 % |
| 200 ms | 0 / 50 | 0 % |

The freed-but-still-listed window in `control_notify_client_detached` is empirically ~5–100 ms wide. Below that, all walks complete before any sibling's `client` struct is freed. Above that, each detach finishes its free-and-unlink before the next begins. In between, walk N hits sibling N–1 mid-free → segfault.

## Where the cascade comes from

`reload_storage_changed` populates `h.instances` with new/recovered sessions but doesn't directly fire any close. The actual cascade lives in `internal/ui/home.go:4666-4679` — the 20-second periodic-cache-prune block — which fans out N goroutines that each independently call `pm.Connect`. Inside `pm.Connect`, two destructive operations run against the shared tmux server:

1. **Dead-pipe cleanup** (`pipemanager.go:67-69`): `existing.Close()` runs before `NewControlPipe` for any pipe that's dead. With N parallel goroutines × N dead pipes, this is the close-cascade that crashed the server on 2026-05-07.
2. **Stale-client SIGTERM** (`pipemanager.go:91` → `killStaleControlClients`): SIGTERMs orphan `tmux -C` clients. With N parallel `Connect()`s × orphans on each, this is the SIGTERM burst that crashed the server on 2026-05-08.

Both crash patterns are the same structural issue — N goroutines smashing the shared server with destructive ops in tight, scheduler-dependent succession. Goroutine wake-up + a single syscall is on the order of 1–10 ms, which is the bottom edge of the danger band.

## Proposed real fix (follow-up PR)

Replace the goroutine fanout with a single coordinated reconcile pass owned by `PipeManager`:

```go
func (pm *PipeManager) ReconcileSessions(desired []SessionRef) {
    pm.reconcileMu.Lock()
    defer pm.reconcileMu.Unlock()

    // Phase 1: destructive — sequential, sub-millisecond cadence.
    // Validated by this PR's harness: stagger=0 is one of the two safe regimes.
    for _, s := range desired { /* Close any dead pipe */ }
    for _, s := range desired { /* killStaleControlClients */ }

    // Phase 2: constructive — parallel handshakes (~4 s timeout each).
    // Safe because the server's per-detach state has cleared.
    var wg sync.WaitGroup
    for _, s := range desired { /* go pm.openOnly(...) */ }
    wg.Wait()
}
```

UI side becomes a single `pm.ReconcileSessions(desired)` call. `reconcileMu` is qualitatively different from the per-syscall `closeGate` this PR falsifies — "only one reconcile at a time" is a much narrower lock than "throttle every syscall."

## What's in this PR

1. The closeGate primitive, **defaulted to `stagger = 0`**, retained as a tunable knob the harness opts into via `AGENT_DECK_CLOSE_STAGGER_MS`. Wired into `softKillProcess` + `ControlPipe.Close` so future code paths inadvertently introducing a 5–100 ms close cadence get caught by re-running the harness.
2. `burst_close_test.go` + `sigterm_burst_test.go`, gated behind `AGENT_DECK_BURST_TEST=1`, with documented `TMPDIR=/tmp/` requirement on macOS (104-char socket-path limit).
3. `closegate_test.go` — unit test pinning the gate primitive's behaviour.
4. `isolatedTmuxSocket(t)` helper that closes a latent safety hole in the previous burst harness (it relied solely on `TestMain`'s `TMUX_TMPDIR` isolation; bare `tmux …` invocations would have hit the user's real default socket if ever run outside `TestMain`).

## Cross-reference

- **#778** — predecessor SIGTERM+grace mitigation. Probability shift, not fix.
- **#882** — EOF fast-path, current production state. Probability shift, not fix.
- **#906** — instrumentation companion (this PR depends on it).
- **#902 / #904** — Ashesh's parallel investigation of the 2026-05-08 incident from the Linux/cgroup layer (systemd-oomd unified-cgroup kill on the conductor scope). Different root cause; short-circuits on macOS, so doesn't address the macOS repro here. Worth landing alongside for defence-in-depth.

## Test plan

- [x] `go vet ./internal/tmux/...` clean
- [x] `go test -race -count=1 ./internal/tmux/...` PASS (default path, harness skipped)
- [x] `AGENT_DECK_BURST_TEST=1 BURST_CLOSE_TRIALS=100 go test -run TestPipeManager_BurstClose ./internal/tmux/` — 0 / 100 at `stagger = 0`, 12 / 100 at `stagger = 15 ms` (sweep data above)
- [x] mandated `TestPersistence_*` — only `CustomCommandResumesFromLatestJSONL` fails, and fails on bare `main` too (pre-existing)
- [ ] `pm.ReconcileSessions` implementation + tests — out of scope; follow-up PR
