### PR TITLE
fix(ui): path-aware ctrl+w and tab-on-invalid-path in new-session dialog (#896)

### DIFF
--- a/internal/ui/editpaths_dialog.go
+++ b/internal/ui/editpaths_dialog.go
@@ -229,6 +229,16 @@ func (d *EditPathsDialog) Update(msg tea.Msg) (*EditPathsDialog, tea.Cmd) {
 			}
 			return d, nil
 
+		case "ctrl+w":
+			// Path-aware backward word delete; default bubbles behaviour
+			// wipes the whole field for spaceless paths. Issue #896.
+			deleteWordBackwardPath(&d.pathInput)
+			d.pathCycler.Reset()
+			d.suggestionNavigated = false
+			d.pathSuggestionCursor = 0
+			d.filterPathSuggestions()
+			return d, nil
+
 		default:
 			d.pathInput, _ = d.pathInput.Update(msg)
 			d.pathCycler.Reset()

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1187,6 +1187,19 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			if d.multiRepoEditing {
 				return d, nil
 			}
+			// Issue #896 (problem 1): don't advance focus from a non-empty path
+			// that doesn't point to an existing directory. Tab should stick to
+			// the input until the user has a usable path; otherwise it silently
+			// jumps to the agent selector and the typed path is left dangling.
+			if isPathEditing {
+				v := strings.Trim(strings.TrimSpace(d.pathInput.Value()), "'\"")
+				if v != "" {
+					expanded := session.ExpandPath(v)
+					if info, err := os.Stat(expanded); err != nil || !info.IsDir() {
+						return d, nil
+					}
+				}
+			}
 			// Move to next field.
 			if d.focusIndex < maxIdx {
 				d.focusIndex++
@@ -1223,6 +1236,28 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 					d.pathSuggestionCursor = len(d.pathSuggestions)
 				}
 				d.suggestionNavigated = true
+				return d, nil
+			}
+
+		case "ctrl+w":
+			// Path-aware backward word delete: stop at '/', not just whitespace.
+			// Default bubbles textinput behaviour wipes the entire field for
+			// path values that contain no spaces. Issue #896.
+			switch {
+			case cur == focusPath || (cur == focusMultiRepo && d.multiRepoEditing):
+				d.pathSoftSelected = false
+				d.pathInput.Focus()
+				deleteWordBackwardPath(&d.pathInput)
+				d.suggestionNavigated = false
+				d.suggestionsActive = false
+				d.suggestionsHidden = false
+				d.pathSuggestionCursor = 0
+				d.pathCycler.Reset()
+				d.filterPathSuggestions()
+				return d, nil
+			case cur == focusBranch:
+				deleteWordBackwardPath(&d.branchInput)
+				d.branchAutoSet = false
 				return d, nil
 			}
 

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -251,10 +251,14 @@ func TestNewDialog_TabDoesNotOverwriteCustomPath(t *testing.T) {
 	d.focusIndex = 2
 	d.updateFocus()
 
-	// User types a completely NEW path that doesn't match any suggestion
-	customPath := "/Users/test/brand-new-project"
+	// User types a completely NEW path that doesn't match any suggestion.
+	// Use a real existing directory so the issue #896 "stay on invalid path"
+	// guard doesn't kick in — this test is specifically about #22 (suggestion
+	// overwrite), not #896 (focus advancement on invalid paths).
+	customPath := t.TempDir()
 	d.pathInput.SetValue(customPath)
 
+	startIdx := d.focusIndex
 	// User presses Tab to move to command selection
 	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyTab})
 
@@ -265,9 +269,9 @@ func TestNewDialog_TabDoesNotOverwriteCustomPath(t *testing.T) {
 		t.Errorf("Tab overwrote custom path!\nGot: %q\nWant: %q\nThis is the bug from Issue #22", path, customPath)
 	}
 
-	// Focus should have moved to command field
-	if d.focusIndex != 3 {
-		t.Errorf("focusIndex = %d, want 3 (command field)", d.focusIndex)
+	// Focus should have advanced (path is valid).
+	if d.focusIndex == startIdx {
+		t.Errorf("Tab on valid custom path did not advance focus from %d", startIdx)
 	}
 }
 
@@ -1272,8 +1276,9 @@ func TestNewDialog_SoftSelect_ReactivatesOnRefocus(t *testing.T) {
 		t.Fatal("should not be soft-selected after typing")
 	}
 
-	// Set a value back and Tab away
-	d.pathInput.SetValue("/some/path")
+	// Set a real value back and Tab away (real dir so the issue #896 invalid-path
+	// guard doesn't keep focus on the field).
+	d.pathInput.SetValue(t.TempDir())
 	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyTab}) // move to command
 
 	// Shift+Tab back to path
@@ -1655,5 +1660,128 @@ func TestNewDialog_StartQuery_ClearsBetweenOpenings(t *testing.T) {
 				"json:\"-\") and must not leak between dialog invocations.",
 			got,
 		)
+	}
+}
+
+// TestNewDialog_Tab_StaysOnInvalidPath verifies that Tab does not advance
+// focus away from the path field when the typed path is non-empty but does
+// not resolve to an existing directory. Issue #896 (problem 1): silently
+// jumping to the agent selector leaves the typed path dangling.
+func TestNewDialog_Tab_StaysOnInvalidPath(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+
+	for d.currentTarget() != focusPath {
+		d.focusIndex++
+		if d.focusIndex >= len(d.focusTargets) {
+			t.Fatal("focusPath not reachable")
+		}
+	}
+	d.updateFocus()
+
+	d.pathSoftSelected = false
+	d.pathInput.Focus()
+	// Path that is statistically guaranteed not to exist.
+	d.pathInput.SetValue("/this-path-should-not-exist-zzz-issue-896")
+	d.pathInput.SetCursor(len(d.pathInput.Value()))
+
+	startIdx := d.focusIndex
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	if d.focusIndex != startIdx {
+		t.Errorf(
+			"Tab on non-existing path advanced focus from %d to %d; expected to stay on path field",
+			startIdx, d.focusIndex,
+		)
+	}
+	if d.currentTarget() != focusPath {
+		t.Errorf("currentTarget = %v, want focusPath", d.currentTarget())
+	}
+}
+
+// TestNewDialog_Tab_AdvancesOnValidPath ensures the invalid-path guard from
+// issue #896 (problem 1) does not regress the happy path: when the user has
+// typed a real directory, Tab still moves to the next field.
+func TestNewDialog_Tab_AdvancesOnValidPath(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+
+	for d.currentTarget() != focusPath {
+		d.focusIndex++
+		if d.focusIndex >= len(d.focusTargets) {
+			t.Fatal("focusPath not reachable")
+		}
+	}
+	d.updateFocus()
+
+	tmp := t.TempDir()
+	d.pathSoftSelected = false
+	d.pathInput.Focus()
+	d.pathInput.SetValue(tmp)
+	d.pathInput.SetCursor(len(tmp))
+
+	startIdx := d.focusIndex
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	if d.focusIndex == startIdx {
+		t.Errorf("Tab on valid path %q did not advance focus (still %d)", tmp, startIdx)
+	}
+}
+
+// TestNewDialog_CtrlW_DeletesPathSegment verifies that ctrl+w on the path
+// input deletes the trailing path segment instead of the whole field. Issue
+// #896 (problem 4): default bubbles textinput treats ctrl+w as delete-word
+// with whitespace boundaries, which wipes spaceless paths like
+// "/Users/dmitry/code/foo".
+func TestNewDialog_CtrlW_DeletesPathSegment(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+
+	// Move focus to the path field.
+	for d.currentTarget() != focusPath {
+		d.focusIndex++
+		if d.focusIndex >= len(d.focusTargets) {
+			t.Fatal("focusPath not reachable from default focus targets")
+		}
+	}
+	d.updateFocus()
+
+	d.pathSoftSelected = false
+	d.pathInput.Focus()
+	d.pathInput.SetValue("/Users/dmitry/code/foo")
+	d.pathInput.SetCursor(len("/Users/dmitry/code/foo"))
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyCtrlW})
+
+	if got, want := d.pathInput.Value(), "/Users/dmitry/code/"; got != want {
+		t.Errorf("pathInput after ctrl+w = %q, want %q", got, want)
+	}
+}
+
+// TestNewDialog_CtrlW_BranchField verifies the same path-aware ctrl+w
+// behaviour applies to the worktree branch input, where slashes are
+// common (e.g. "feature/issue-896").
+func TestNewDialog_CtrlW_BranchField(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+	d.worktreeEnabled = true
+	d.rebuildFocusTargets()
+
+	for d.currentTarget() != focusBranch {
+		d.focusIndex++
+		if d.focusIndex >= len(d.focusTargets) {
+			t.Fatal("focusBranch not reachable")
+		}
+	}
+	d.updateFocus()
+
+	d.branchInput.Focus()
+	d.branchInput.SetValue("feature/issue-896")
+	d.branchInput.SetCursor(len("feature/issue-896"))
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyCtrlW})
+
+	if got, want := d.branchInput.Value(), "feature/"; got != want {
+		t.Errorf("branchInput after ctrl+w = %q, want %q", got, want)
 	}
 }

--- a/internal/ui/textinput_pathdelete.go
+++ b/internal/ui/textinput_pathdelete.go
@@ -1,0 +1,41 @@
+package ui
+
+import (
+	"unicode"
+
+	"github.com/charmbracelet/bubbles/textinput"
+)
+
+// deleteWordBackwardPath performs ctrl+w-style backward deletion that is
+// path-aware: it stops at '/' as well as whitespace, so deleting one word from
+// "/foo/bar/baz" yields "/foo/bar/" instead of clearing the whole field (which
+// is what bubbles' default deleteWordBackward does, since the path contains no
+// whitespace). Issue #896.
+func deleteWordBackwardPath(ti *textinput.Model) {
+	pos := ti.Position()
+	if pos == 0 {
+		return
+	}
+	val := []rune(ti.Value())
+	if pos > len(val) {
+		pos = len(val)
+	}
+
+	i := pos
+	// eat trailing separators (spaces and slashes) right behind the cursor
+	for i > 0 && isPathWordBoundary(val[i-1]) {
+		i--
+	}
+	// then eat the word itself, up to the next boundary
+	for i > 0 && !isPathWordBoundary(val[i-1]) {
+		i--
+	}
+
+	newVal := string(val[:i]) + string(val[pos:])
+	ti.SetValue(newVal)
+	ti.SetCursor(i)
+}
+
+func isPathWordBoundary(r rune) bool {
+	return r == '/' || unicode.IsSpace(r)
+}

--- a/internal/ui/textinput_pathdelete_test.go
+++ b/internal/ui/textinput_pathdelete_test.go
@@ -1,0 +1,98 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/textinput"
+)
+
+func TestDeleteWordBackwardPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		cursor    int
+		wantValue string
+		wantPos   int
+	}{
+		{
+			name:      "trailing segment of absolute path",
+			value:     "/Users/dmitry/code/foo",
+			cursor:    len("/Users/dmitry/code/foo"),
+			wantValue: "/Users/dmitry/code/",
+			wantPos:   len("/Users/dmitry/code/"),
+		},
+		{
+			name:      "trailing slash collapses to previous segment",
+			value:     "/Users/dmitry/code/",
+			cursor:    len("/Users/dmitry/code/"),
+			wantValue: "/Users/dmitry/",
+			wantPos:   len("/Users/dmitry/"),
+		},
+		{
+			name:      "no slash falls back to clearing whole word",
+			value:     "myfolder",
+			cursor:    len("myfolder"),
+			wantValue: "",
+			wantPos:   0,
+		},
+		{
+			name:      "tilde expands cleanly",
+			value:     "~/code/foo",
+			cursor:    len("~/code/foo"),
+			wantValue: "~/code/",
+			wantPos:   len("~/code/"),
+		},
+		{
+			name:      "cursor at start is a no-op",
+			value:     "/foo/bar",
+			cursor:    0,
+			wantValue: "/foo/bar",
+			wantPos:   0,
+		},
+		{
+			name:      "cursor mid-path deletes only behind cursor",
+			value:     "/foo/bar/baz",
+			cursor:    len("/foo/bar/"),
+			wantValue: "/foo/baz",
+			wantPos:   len("/foo/"),
+		},
+		{
+			name:      "preserves text after cursor when deleting at root",
+			value:     "/foo",
+			cursor:    len("/foo"),
+			wantValue: "/",
+			wantPos:   1,
+		},
+		{
+			name:      "branch-style slash works the same",
+			value:     "feature/issue-896",
+			cursor:    len("feature/issue-896"),
+			wantValue: "feature/",
+			wantPos:   len("feature/"),
+		},
+		{
+			name:      "whitespace boundary still works",
+			value:     "hello world",
+			cursor:    len("hello world"),
+			wantValue: "hello ",
+			wantPos:   len("hello "),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ti := textinput.New()
+			ti.SetValue(tt.value)
+			ti.SetCursor(tt.cursor)
+
+			deleteWordBackwardPath(&ti)
+
+			if got := ti.Value(); got != tt.wantValue {
+				t.Errorf("value = %q, want %q", got, tt.wantValue)
+			}
+			if got := ti.Position(); got != tt.wantPos {
+				t.Errorf("cursor = %d, want %d", got, tt.wantPos)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes two pain points in the new-session path input from #896.

## ctrl+w wiped the whole field

Bubbles' default `deleteWordBackward` stops at whitespace. Paths usually have none, so on a value like `/a/b/c` ctrl+w cleared everything instead of dropping the trailing segment.

Added a path-aware backward-word delete that also stops at `/`. Wired into:

- new-session path input (`focusPath`)
- worktree branch input (`focusBranch`) — slashes are common in branch names
- multi-repo path editor
- edit-paths dialog

Examples after the fix:

- `/a/b/c` → `/a/b/`
- `/a/b/` → `/a/`
- `~/x/y` → `~/x/`
- `feature/foo` → `feature/`
- `singleword` → `` (no slash, falls back to clearing — matches default)

## Tab on a non-existing path silently jumped to agent selector

If you typed a path that didn't exist as a directory and pressed Tab, focus advanced to the agent selector and the typed value was left dangling. Now Tab on a non-empty path that doesn't resolve to an existing directory keeps focus on the input. Empty paths and valid directories advance as before.

## Tests

- `TestDeleteWordBackwardPath` — 9 table cases for the helper.
- `TestNewDialog_CtrlW_DeletesPathSegment` / `TestNewDialog_CtrlW_BranchField` — end-to-end through `Update`.
- `TestNewDialog_Tab_StaysOnInvalidPath` / `TestNewDialog_Tab_AdvancesOnValidPath` — Tab guard.

Two existing tests (`TestNewDialog_TabDoesNotOverwriteCustomPath` for #22, `TestNewDialog_SoftSelect_ReactivatesOnRefocus`) incidentally relied on Tab advancing from a non-existent path. Switched them to `t.TempDir()` so they keep exercising their original invariants on the real-path branch.

Tested locally: ctrl+w deletes one segment, Tab on non-existing path keeps cursor on the input.