### PR TITLE
fix(ui): improve responsiveness - flush lone ESC immediately

### DIFF
--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/termreply"
 	tea "github.com/charmbracelet/bubbletea"
@@ -270,6 +271,8 @@ type csiuReader struct {
 	inBuf       []byte // buffered input bytes not yet processed
 	err         error  // pending source error to return after draining buffers
 	replyFilter termreply.Filter
+	// pollFn checks whether more bytes follow a lone ESC within a timeout.
+	pollFn func(time.Duration) bool
 }
 
 // csiuFileReader wraps a *os.File and overrides Read with CSI u translation.
@@ -303,6 +306,10 @@ func NewCSIuReader(r io.Reader) io.Reader {
 		inBuf: make([]byte, 0, 256),
 	}
 	if f, ok := r.(*os.File); ok {
+		fd := int(f.Fd())
+		inner.pollFn = func(timeout time.Duration) bool {
+			return pollFdReady(fd, timeout)
+		}
 		return &csiuFileReader{File: f, inner: inner}
 	}
 	return inner
@@ -355,6 +362,16 @@ func (c *csiuReader) Read(p []byte) (int, error) {
 		if err != nil {
 			c.err = err
 			return 0, err
+		}
+
+		// Flush lone ESC after 50ms poll timeout (ncurses ESCDELAY convention).
+		if len(c.inBuf) == 1 && c.inBuf[0] == 0x1b && c.pollFn != nil {
+			if !c.pollFn(50 * time.Millisecond) {
+				p[0] = c.inBuf[0]
+				c.inBuf = c.inBuf[:0]
+				return 1, nil
+			}
+			// More bytes incoming — loop to bundle them with the ESC.
 		}
 	}
 }

--- a/internal/ui/keyboard_compat_poll_posix.go
+++ b/internal/ui/keyboard_compat_poll_posix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package ui
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// pollFdReady reports whether the file descriptor has input data available
+// within the given timeout. Used by csiuReader to detect whether a lone ESC
+// byte is the start of an escape sequence (more bytes imminent) or a
+// standalone Escape keypress (no bytes follow).
+func pollFdReady(fd int, timeout time.Duration) bool {
+	ms := int(timeout.Milliseconds())
+	if ms < 1 {
+		ms = 1
+	}
+	fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+	for {
+		n, err := unix.Poll(fds, ms)
+		if err == unix.EINTR {
+			continue // retry after signal interruption
+		}
+		return err == nil && n > 0
+	}
+}

--- a/internal/ui/keyboard_compat_poll_windows.go
+++ b/internal/ui/keyboard_compat_poll_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package ui
+
+import "time"
+
+// pollFdReady always returns false on Windows (no unix.Poll available).
+// The lone-ESC timeout fix is inactive on Windows; ESC handling falls back
+// to the original buffering behaviour.
+func pollFdReady(_ int, _ time.Duration) bool {
+	return false
+}

--- a/internal/ui/keyboard_compat_test.go
+++ b/internal/ui/keyboard_compat_test.go
@@ -776,3 +776,78 @@ func TestCSIuReader_SS3HomeEnd_ChunkedRead(t *testing.T) {
 		})
 	}
 }
+
+// TestCSIuReader_StandaloneEsc_PollTimeout_FlushedBeforeNextKey verifies that a
+// lone ESC is flushed to the caller without waiting for the next keypress when
+// the poll function reports no data within the timeout. This is the fix for the
+// "UI stuck / Esc ignored" bug: previously the ESC was held in inBuf until
+// another byte arrived, making it appear the first Esc did nothing.
+func TestCSIuReader_StandaloneEsc_PollTimeout_FlushedBeforeNextKey(t *testing.T) {
+	r := &csiuReader{
+		src:    &chunkedReader{chunks: [][]byte{[]byte("\x1b"), []byte("a")}},
+		inBuf:  make([]byte, 0, 256),
+		pollFn: func(time.Duration) bool { return false }, // simulate timeout: no sequence follows
+	}
+
+	buf := make([]byte, 10)
+
+	// First Read: ESC must be returned immediately without waiting for 'a'.
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("Read 1 error: %v", err)
+	}
+	if n != 1 || buf[0] != 0x1b {
+		t.Fatalf("Read 1: expected lone ESC (0x1b), got %q (n=%d)", buf[:n], n)
+	}
+
+	// Second Read: 'a' follows as a separate event.
+	n, err = r.Read(buf)
+	if err != nil {
+		t.Fatalf("Read 2 error: %v", err)
+	}
+	if n != 1 || buf[0] != 'a' {
+		t.Fatalf("Read 2: expected 'a', got %q (n=%d)", buf[:n], n)
+	}
+}
+
+// TestCSIuReader_EscThenCSI_PollReady_BundledAsSequence verifies that when the
+// poll function reports data ready (bytes follow immediately), the lone ESC is
+// NOT flushed — instead it is bundled with the incoming bytes so that
+// sequences like ESC [ A (up-arrow) are correctly emitted as one unit.
+func TestCSIuReader_EscThenCSI_PollReady_BundledAsSequence(t *testing.T) {
+	r := &csiuReader{
+		src:    &chunkedReader{chunks: [][]byte{[]byte("\x1b"), []byte("[A")}},
+		inBuf:  make([]byte, 0, 256),
+		pollFn: func(time.Duration) bool { return true }, // sequence bytes follow immediately
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != "\x1b[A" {
+		t.Errorf("got %q, want %q (ESC + CSI should be bundled when poll is ready)", string(out), "\x1b[A")
+	}
+}
+
+// TestCSIuReader_DoubleEsc_PollTimeout_BothFlushed verifies that pressing Esc
+// twice delivers two separate ESC bytes, each flushed on its own Read().
+func TestCSIuReader_DoubleEsc_PollTimeout_BothFlushed(t *testing.T) {
+	r := &csiuReader{
+		src:    &chunkedReader{chunks: [][]byte{[]byte("\x1b"), []byte("\x1b")}},
+		inBuf:  make([]byte, 0, 256),
+		pollFn: func(time.Duration) bool { return false },
+	}
+
+	buf := make([]byte, 10)
+
+	n, _ := r.Read(buf)
+	if n != 1 || buf[0] != 0x1b {
+		t.Fatalf("first ESC: got %q (n=%d)", buf[:n], n)
+	}
+
+	n, _ = r.Read(buf)
+	if n != 1 || buf[0] != 0x1b {
+		t.Fatalf("second ESC: got %q (n=%d)", buf[:n], n)
+	}
+}


### PR DESCRIPTION
OS: Mac Os 14.x

UI was sluggish, ie. had to double press action buttons like ESC, yN, etc. inside TUI dialogs

Tasked Claude with this and the fix seems to work

## Claude desc

csiuReader was buffering a lone 0x1b byte waiting for the next byte to decide if it was the start of an escape sequence. On a blocking stdin this meant ESC was never delivered until another key arrived, so the first Esc press appeared to do nothing in every dialog.

Add a pollFn field (backed by unix.Poll on POSIX, stub on Windows) that checks within 50ms whether more bytes follow. If none arrive the ESC is flushed immediately as a standalone keypress; if bytes do follow they are bundled with the ESC as before, preserving SS3/CSI sequence handling.

## How other libs handle it

 ---
  How bubbletea handles it

  Bubbletea has evolved through a few approaches:

  - v1 (parser-only): The parseSequence function checks len(buf) — if the buffer has only 0x1b, it returns KeyEscape immediately. But this depends on how bytes arrive from Read(), which is exactly the bug your commit fixes.
  - v2 / ultraviolet (timer-based): The newer charmbracelet/ultraviolet library uses a goroutine that reads raw bytes into a channel, then accumulates them with a time.NewTimer (default 100ms). When the timer fires and the buffer still has
  unconsumed bytes, it flushes them to the decoder with an expired=true flag — so a lone ESC gets emitted. This is the same concept as your pollFn, just implemented with Go channels/timers instead of unix.Poll.
  - Kitty keyboard protocol (v2): The long-term fix — terminals that support it disambiguate keys at the emulator level, eliminating the problem entirely.

We use bubbletea v1.3.10. So the ESC disambiguation isn't handled by the framework at this version, which is why the commit had to bolt it on via pollFn in the custom csiuReader. Upgrading to bubbletea v2 / ultraviolet would get the timer-based fix for free, but that's a much bigger migration.

  ---
  How ncurses does it

  The logic lives in ncurses/base/lib_getch.c:

  - Default ESCDELAY is 1000ms (most apps override to 25-100ms)
  - In kgetch() (~line 795), after reading an initial 0x1b, it sets a timer to ESCDELAY ms and polls for more bytes. If none arrive before the timer fires, it returns the ESC as a standalone keypress. If bytes do arrive, they're matched against
  terminfo key definitions.

  ---
  Your commit's approach (50ms unix.Poll) is essentially the same strategy ncurses uses, just at a lower level than bubbletea's v2 timer-based solution. The 50ms value is right in the sweet spot — ncurses recommends overriding to 25-100ms for
  responsive UIs.