### PR TITLE
fix(conductor): bridge.py output parsing + UTF-8 decode robustness

### DIFF
--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -648,7 +648,8 @@ def run_cli(
     log.debug("CLI: %s", " ".join(cmd))
     try:
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout
+            cmd, capture_output=True, text=True, timeout=timeout,
+            errors="replace",
         )
         return result
     except subprocess.TimeoutExpired:
@@ -674,13 +675,23 @@ def get_session_status(session: str, profile: str | None = None) -> str:
 
 
 def get_session_output(session: str, profile: str | None = None) -> str:
-    """Get the last response from a session."""
+    """Get the last response from a session.
+
+    Uses --json mode so we get the structured 'content' field (the actual
+    assistant reply) instead of the raw pane capture (which includes the
+    cosmetic frame / statusline at the top and can be mistaken for a reply).
+    """
     result = run_cli(
-        "session", "output", session, "-q", profile=profile, timeout=30
+        "session", "output", session, "--json", profile=profile, timeout=30
     )
     if result.returncode != 0:
         return f"[Error getting output: {result.stderr.strip()}]"
-    return result.stdout.strip()
+    try:
+        data = json.loads(result.stdout)
+        return (data.get("content") or "").strip()
+    except json.JSONDecodeError:
+        # Fallback: stdout might be the legacy raw-text format.
+        return result.stdout.strip()
 
 
 def send_to_conductor(
@@ -695,8 +706,12 @@ def send_to_conductor(
     Returns (success, response_text). When wait_for_reply=False, response_text is "".
     """
     if wait_for_reply:
-        # Single-call flow: send + wait + print raw response.
-        # Avoids extra status/output polling round-trips.
+        # ` + "`" + `session send --wait` + "`" + ` returns only the send-confirmation as JSON;
+        # the response itself is printed as a raw pane capture afterward.
+        # We ignore that stdout entirely and re-fetch via ` + "`" + `session output
+        # --json` + "`" + `, which DOES return a clean { content, role, ... } object.
+        # ` + "`" + `--wait` + "`" + ` blocks until the assistant's JSONL entry is flushed, so
+        # the subsequent output call sees the new reply.
         result = run_cli(
             "session", "send", session, message,
             "--wait", "--timeout", f"{response_timeout}s", "-q",
@@ -713,6 +728,9 @@ def send_to_conductor(
             "Failed to send to conductor: %s", result.stderr.strip()
         )
         return False, ""
+    if wait_for_reply:
+        # Now fetch the clean assistant reply.
+        return True, get_session_output(session, profile=profile)
     return True, result.stdout.strip()
 
 


### PR DESCRIPTION
## Summary

Three fixes to the conductor bridge.py template (`internal/session/conductor_templates.go`):

1. `subprocess.run(..., errors="replace")` — survive non-UTF-8 bytes in CLI output. Fixes the bridge crashing with `UnicodeDecodeError` when CLI captures contain ANSI escape sequences with high-bit chars. **Closes #920.**

2. `get_session_output()` switches from `-q` to `--json` and parses the `content` field. The `-q` mode returned raw pane capture, so the bridge was forwarding the cosmetic frame + statusline to Telegram instead of the assistant reply. **Closes #921 (output path).**

3. `send_to_conductor()`'s `--wait` branch now fetches the reply via a separate `session output --json` call rather than parsing `session send --wait`'s stdout. Discovered during testing: `--wait` emits only a send-confirmation JSON, then prints the response as raw pane capture — so the reply can't be extracted from that stdout cleanly. The two-call pattern resolves this. **Closes #921 (wait/send path).**

## Validation

- All three fixes patched into a live `~/.agent-deck/conductor/bridge.py` and exercised over multiple Telegram round-trips before and after — confirmed assistant replies arrive clean (no JSON wrapper, no statusline garbage, no UTF-8 crashes).
- `go test ./internal/session/...` passes locally.
- `go build ./...` clean.

## Environment validated on

- macOS 26.x ARM64
- Python 3.14.4 (the Python version that exposed #920 — earlier versions silently mangled bytes rather than crashing)
- tmux 3.6a
- agent-deck v1.7.75

## Notes

- Fix 3 surfaces a separate observation worth considering: `agent-deck session send --wait --json` could itself be improved to emit the response as a structured second JSON object (so callers wouldn't need the two-call pattern). Filed for discussion as part of #921 but not required for this PR.