### PR TITLE
feat(session,statedb): migrate sessions/conductors/groups across profiles (#928)

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -43,6 +44,8 @@ func handleConductor(profile string, args []string) {
 		handleConductorStatus(profile, args[1:])
 	case "list":
 		handleConductorList(profile, args[1:])
+	case "move":
+		handleConductorMove(profile, args[1:])
 	case "help", "--help", "-h":
 		printConductorHelp()
 	default:
@@ -1201,4 +1204,77 @@ func printConductorHelp() {
 	fmt.Println("  agent-deck conductor status")
 	fmt.Println("  agent-deck conductor teardown infra --remove")
 	fmt.Println("  agent-deck conductor teardown --all --remove")
+	fmt.Println("  agent-deck conductor move ryan --to-profile march")
+}
+
+// handleConductorMove migrates a conductor (session row + all child sessions
+// + meta.json) to another profile (issue #928).
+func handleConductorMove(sourceProfile string, args []string) {
+	fs := flag.NewFlagSet("conductor move", flag.ExitOnError)
+	toProfile := fs.String("to-profile", "", "Target profile (required)")
+	force := fs.Bool("force", false, "Migrate even if the conductor or a worker is running")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck conductor move <name> --to-profile <profile> [--force]")
+		fmt.Println()
+		fmt.Println("Migrate a conductor session and all its worker sessions to another")
+		fmt.Println("profile's DB, and update ~/.agent-deck/conductor/<name>/meta.json in lockstep.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	out := NewCLIOutput(*jsonOutput, *quiet || *quietShort)
+
+	if fs.NArg() < 1 {
+		out.Error("conductor move requires <name>", ErrCodeInvalidOperation)
+		fs.Usage()
+		os.Exit(1)
+	}
+	if *toProfile == "" {
+		out.Error("--to-profile is required", ErrCodeInvalidOperation)
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	name := fs.Arg(0)
+	result, err := session.MigrateConductorToProfile(
+		name, sourceProfile, *toProfile,
+		session.ProfileMigrateOptions{Force: *force},
+	)
+	if err != nil {
+		exitCode := ErrCodeInvalidOperation
+		hint := ""
+		switch {
+		case errors.Is(err, session.ErrProfileMissing):
+			exitCode = ErrCodeNotFound
+		case errors.Is(err, session.ErrSessionRunning):
+			hint = " (stop the conductor/workers first, or re-run with --force)"
+		}
+		out.Error(fmt.Sprintf("%v%s", err, hint), exitCode)
+		os.Exit(1)
+	}
+
+	out.Success(
+		fmt.Sprintf("Migrated conductor %q: profile %s → %s (%d sessions)",
+			name, sourceProfile, *toProfile, len(result.MovedSessionIDs)),
+		map[string]interface{}{
+			"success":        true,
+			"conductor":      name,
+			"from_profile":   sourceProfile,
+			"to_profile":     *toProfile,
+			"sessions_moved": result.MovedSessionIDs,
+			"cost_events":    result.MovedCostEvents,
+			"watcher_events": result.MovedWatcherEvents,
+			"groups_created": result.CreatedGroups,
+			"meta_updated":   result.MetaUpdated,
+		},
+	)
 }

--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -646,21 +647,26 @@ func handleGroupDelete(profile string, args []string) {
 	})
 }
 
-// handleGroupMove moves a session to a different group
+// handleGroupMove moves a session to a different group, or (with --to-profile)
+// migrates every session in a group to another profile's DB (issue #928).
 func handleGroupMove(profile string, args []string) {
 	fs := flag.NewFlagSet("group move", flag.ExitOnError)
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	toProfile := fs.String("to-profile", "", "Migrate every session in <group> to another profile's DB (issue #928)")
+	force := fs.Bool("force", false, "With --to-profile: migrate even if a session is running")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck group move <session-id> <group>")
+		fmt.Println("       agent-deck group move <group> --to-profile <name> [--force]")
 		fmt.Println()
-		fmt.Println("Move a session to a different group.")
+		fmt.Println("Move a session to a different group (default form), or migrate every")
+		fmt.Println("session in <group> to another profile's DB (with --to-profile).")
 		fmt.Println()
 		fmt.Println("Arguments:")
 		fmt.Println("  <session-id>   Session title, ID prefix, or path")
-		fmt.Println("  <group>        Target group path (use \"\" or root for ungrouped)")
+		fmt.Println("  <group>        Target group path (or, with --to-profile, the source group)")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -669,6 +675,7 @@ func handleGroupMove(profile string, args []string) {
 		fmt.Println("  agent-deck group move my-project work/frontend")
 		fmt.Println("  agent-deck group move my-project \"\"              # Move to root")
 		fmt.Println("  agent-deck group move my-project root            # Move to root")
+		fmt.Println("  agent-deck group move work/api --to-profile march")
 	}
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
@@ -676,6 +683,22 @@ func handleGroupMove(profile string, args []string) {
 	}
 
 	out := NewCLIOutput(*jsonOutput, *quiet || *quietShort)
+
+	// Cross-profile group migration (issue #928): different argument shape.
+	if *toProfile != "" {
+		if fs.NArg() < 1 {
+			out.Error("group move --to-profile requires <group>", ErrCodeInvalidOperation)
+			fs.Usage()
+			os.Exit(1)
+		}
+		if fs.NArg() > 1 {
+			out.Error("--to-profile takes a single <group> argument", ErrCodeInvalidOperation)
+			fs.Usage()
+			os.Exit(1)
+		}
+		handleGroupMoveToProfile(profile, *toProfile, fs.Arg(0), *force, out)
+		return
+	}
 
 	sessionID := fs.Arg(0)
 	targetGroup := fs.Arg(1)
@@ -1164,4 +1187,45 @@ func handleGroupChange(profile string, args []string) {
 		"from": sourcePath,
 		"to":   newPath,
 	})
+}
+
+// handleGroupMoveToProfile implements `group move <group> --to-profile <name>`
+// (issue #928). Every session in <group> at the source profile is migrated to
+// the target profile. The group row itself is also created in the target.
+func handleGroupMoveToProfile(sourceProfile, targetProfile, groupPath string, force bool, out *CLIOutput) {
+	if groupPath == "root" || groupPath == "" {
+		groupPath = session.DefaultGroupPath
+	}
+
+	result, err := session.MigrateGroupToProfile(
+		groupPath, sourceProfile, targetProfile,
+		session.ProfileMigrateOptions{Force: force},
+	)
+	if err != nil {
+		exitCode := ErrCodeInvalidOperation
+		hint := ""
+		switch {
+		case errors.Is(err, session.ErrProfileMissing):
+			exitCode = ErrCodeNotFound
+		case errors.Is(err, session.ErrSessionRunning):
+			hint = " (stop the running session(s) first, or re-run with --force)"
+		}
+		out.Error(fmt.Sprintf("%v%s", err, hint), exitCode)
+		os.Exit(1)
+	}
+
+	out.Success(
+		fmt.Sprintf("Migrated group %q: profile %s → %s (%d sessions)",
+			groupPath, sourceProfile, targetProfile, len(result.MovedSessionIDs)),
+		map[string]interface{}{
+			"success":        true,
+			"group":          groupPath,
+			"from_profile":   sourceProfile,
+			"to_profile":     targetProfile,
+			"sessions_moved": result.MovedSessionIDs,
+			"cost_events":    result.MovedCostEvents,
+			"watcher_events": result.MovedWatcherEvents,
+			"groups_created": result.CreatedGroups,
+		},
+	)
 }

--- a/cmd/agent-deck/profile_migrate_cli_test.go
+++ b/cmd/agent-deck/profile_migrate_cli_test.go
@@ -230,6 +230,45 @@ func TestGroupMoveToProfile_BatchMigratesAllSessions(t *testing.T) {
 	}
 }
 
+// TestSessionMoveToProfile_RejectsIncompatibleFlags asserts that --to-profile
+// errors out when combined with --group / --no-restart / --copy rather than
+// silently ignoring them (Copilot fix #6).
+func TestSessionMoveToProfile_RejectsIncompatibleFlags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	bootstrapProfile(t, home, "src")
+	bootstrapProfile(t, home, "dst")
+	id := addInProfile(t, home, "src", "incompat", filepath.Join(home, "p"))
+
+	cases := []struct {
+		name string
+		flag string
+	}{
+		{"group", "--group"},
+		{"no-restart", "--no-restart"},
+		{"copy", "--copy"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{"-p", "src", "session", "move", id,
+				"--to-profile", "dst", "--json", tc.flag}
+			if tc.flag == "--group" {
+				args = append(args, "work/api")
+			}
+			stdout, stderr, code := runAgentDeck(t, home, args...)
+			if code == 0 {
+				t.Fatalf("expected failure when --to-profile is combined with %s; stdout=%s", tc.flag, stdout)
+			}
+			combined := strings.ToLower(stdout + stderr)
+			if !strings.Contains(combined, "incompatible") {
+				t.Errorf("error should mention incompatibility; got stdout=%s stderr=%s", stdout, stderr)
+			}
+		})
+	}
+}
+
 func TestConductorMoveToProfile_RequiresToProfile(t *testing.T) {
 	if testing.Short() {
 		t.Skip("subprocess CLI test skipped in short mode")

--- a/cmd/agent-deck/profile_migrate_cli_test.go
+++ b/cmd/agent-deck/profile_migrate_cli_test.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// CLI subprocess tests for issue #928: `session move --to-profile`,
+// `group move --to-profile`, and `conductor move --to-profile`.
+//
+// These complement the unit tests in internal/session/profile_migrate_test.go
+// by exercising the actual binary, argv parsing, and JSON output shape.
+
+// bootstrapProfile runs a harmless `list` command in the named profile so
+// `~/.agent-deck/profiles/<name>/state.db` is created on disk. The cross-
+// profile migration deliberately refuses missing target profiles, so every
+// test that migrates into "<dst>" must call this first.
+func bootstrapProfile(t *testing.T, home, profile string) {
+	t.Helper()
+	stdout, stderr, code := runAgentDeck(t, home, "-p", profile, "list", "--json")
+	if code != 0 {
+		t.Fatalf("bootstrap profile %q failed: code=%d\nstdout: %s\nstderr: %s",
+			profile, code, stdout, stderr)
+	}
+}
+
+// addInProfile adds a stopped session in the given profile and returns its ID.
+func addInProfile(t *testing.T, home, profile, title, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	stdout, stderr, code := runAgentDeck(t, home,
+		"-p", profile, "add",
+		"-t", title,
+		"--no-parent",
+		"--json",
+		path,
+	)
+	if code != 0 {
+		t.Fatalf("add in profile %q failed: code=%d\nstdout: %s\nstderr: %s",
+			profile, code, stdout, stderr)
+	}
+	var resp struct{ ID string `json:"id"` }
+	if err := json.Unmarshal([]byte(stdout), &resp); err != nil {
+		t.Fatalf("parse add response: %v\nstdout: %s", err, stdout)
+	}
+	if resp.ID == "" {
+		t.Fatalf("add returned empty id: %s", stdout)
+	}
+	return resp.ID
+}
+
+func listJSONForProfile(t *testing.T, home, profile string) string {
+	t.Helper()
+	stdout, stderr, code := runAgentDeck(t, home, "-p", profile, "list", "--json")
+	if code != 0 {
+		t.Fatalf("list -p %q failed: code=%d\nstderr: %s", profile, code, stderr)
+	}
+	return stdout
+}
+
+// TestSessionMoveToProfile_Basic — happy path: row absent in src, present in dst.
+func TestSessionMoveToProfile_Basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	bootstrapProfile(t, home, "src")
+	bootstrapProfile(t, home, "dst")
+	id := addInProfile(t, home, "src", "basic-migrate", filepath.Join(home, "proj"))
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"-p", "src", "session", "move", id,
+		"--to-profile", "dst",
+		"--json",
+	)
+	if code != 0 {
+		t.Fatalf("migrate failed: code=%d\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+
+	srcList := listJSONForProfile(t, home, "src")
+	if strings.Contains(srcList, id) {
+		t.Errorf("src still has session %s: %s", id, srcList)
+	}
+	dstList := listJSONForProfile(t, home, "dst")
+	if !strings.Contains(dstList, id) {
+		t.Errorf("dst missing session %s: %s", id, dstList)
+	}
+}
+
+func TestSessionMoveToProfile_RefusesMissingTargetProfile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	bootstrapProfile(t, home, "src")
+	id := addInProfile(t, home, "src", "no-target", filepath.Join(home, "p"))
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"-p", "src", "session", "move", id,
+		"--to-profile", "ghost",
+		"--json",
+	)
+	if code == 0 {
+		t.Fatalf("expected failure for missing target profile; got success\nstdout: %s", stdout)
+	}
+	combined := strings.ToLower(stdout + stderr)
+	if !strings.Contains(combined, "ghost") || !strings.Contains(combined, "does not exist") {
+		t.Errorf("error should mention the missing profile name; got stdout=%s stderr=%s", stdout, stderr)
+	}
+}
+
+func TestSessionMoveToProfile_RefusesSameProfile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	bootstrapProfile(t, home, "src")
+	id := addInProfile(t, home, "src", "same-profile", filepath.Join(home, "p"))
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"-p", "src", "session", "move", id,
+		"--to-profile", "src",
+		"--json",
+	)
+	if code == 0 {
+		t.Fatalf("expected failure for same profile; got success\nstdout: %s", stdout)
+	}
+	combined := strings.ToLower(stdout + stderr)
+	if !strings.Contains(combined, "same") {
+		t.Errorf("error should mention same-profile; got stdout=%s stderr=%s", stdout, stderr)
+	}
+}
+
+func TestSessionMoveToProfile_RejectsPathAndToProfileTogether(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	bootstrapProfile(t, home, "src")
+	bootstrapProfile(t, home, "dst")
+	id := addInProfile(t, home, "src", "two-args", filepath.Join(home, "p"))
+
+	_, stderr, code := runAgentDeck(t, home,
+		"-p", "src", "session", "move", id,
+		filepath.Join(home, "new-path"),
+		"--to-profile", "dst",
+		"--json",
+	)
+	if code == 0 {
+		t.Fatal("expected exit-1 when both <new-path> and --to-profile are given")
+	}
+	if !strings.Contains(strings.ToLower(stderr), "incompatible") {
+		t.Errorf("stderr should mention incompatibility; got %s", stderr)
+	}
+}
+
+func TestSessionMoveToProfile_Idempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	bootstrapProfile(t, home, "src")
+	bootstrapProfile(t, home, "dst")
+	id := addInProfile(t, home, "src", "idem", filepath.Join(home, "p"))
+
+	for i := 0; i < 2; i++ {
+		stdout, stderr, code := runAgentDeck(t, home,
+			"-p", "src", "session", "move", id,
+			"--to-profile", "dst", "--json",
+		)
+		if code != 0 {
+			t.Fatalf("migrate iteration %d: code=%d\nstdout: %s\nstderr: %s",
+				i, code, stdout, stderr)
+		}
+	}
+	dstList := listJSONForProfile(t, home, "dst")
+	if strings.Count(dstList, id) == 0 {
+		t.Errorf("dst missing session after idempotent re-run: %s", dstList)
+	}
+}
+
+func TestGroupMoveToProfile_BatchMigratesAllSessions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	bootstrapProfile(t, home, "src")
+	bootstrapProfile(t, home, "dst")
+
+	// Add 3 sessions and assign them to a custom group.
+	var ids []string
+	for i, name := range []string{"a", "b", "c"} {
+		path := filepath.Join(home, "proj-"+name)
+		id := addInProfile(t, home, "src", "grp-"+name, path)
+		ids = append(ids, id)
+		_, stderr, code := runAgentDeck(t, home,
+			"-p", "src", "group", "move", id, "work/api",
+			"--json",
+		)
+		if code != 0 {
+			t.Fatalf("assign session %d to group: code=%d stderr=%s", i, code, stderr)
+		}
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"-p", "src", "group", "move", "work/api",
+		"--to-profile", "dst", "--json",
+	)
+	if code != 0 {
+		t.Fatalf("group migrate failed: code=%d\nstdout: %s\nstderr: %s",
+			code, stdout, stderr)
+	}
+
+	srcList := listJSONForProfile(t, home, "src")
+	for _, id := range ids {
+		if strings.Contains(srcList, id) {
+			t.Errorf("src still has session %s after group migrate", id)
+		}
+	}
+	dstList := listJSONForProfile(t, home, "dst")
+	for _, id := range ids {
+		if !strings.Contains(dstList, id) {
+			t.Errorf("dst missing session %s after group migrate", id)
+		}
+	}
+}
+
+func TestConductorMoveToProfile_RequiresToProfile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	bootstrapProfile(t, home, "src")
+
+	_, stderr, code := runAgentDeck(t, home,
+		"-p", "src", "conductor", "move", "alpha",
+	)
+	if code == 0 {
+		t.Fatal("expected non-zero exit when --to-profile is missing")
+	}
+	if !strings.Contains(strings.ToLower(stderr), "to-profile") {
+		t.Errorf("stderr should mention --to-profile; got %s", stderr)
+	}
+}

--- a/cmd/agent-deck/session_move.go
+++ b/cmd/agent-deck/session_move.go
@@ -68,6 +68,21 @@ func handleSessionMove(profile string, args []string) {
 			fs.Usage()
 			os.Exit(1)
 		}
+		// Reject path-move flags that don't apply when migrating across
+		// profiles — silently ignoring them masks user mistakes. Detect via
+		// flag.Visit which only enumerates flags that were explicitly set.
+		var incompatible []string
+		fs.Visit(func(f *flag.Flag) {
+			switch f.Name {
+			case "group", "no-restart", "copy":
+				incompatible = append(incompatible, "--"+f.Name)
+			}
+		})
+		if len(incompatible) > 0 {
+			out.Error(fmt.Sprintf("--to-profile is incompatible with: %s", incompatible), ErrCodeInvalidOperation)
+			fs.Usage()
+			os.Exit(1)
+		}
 		handleSessionMoveToProfile(profile, *toProfile, fs.Arg(0), *force, out)
 		return
 	}

--- a/cmd/agent-deck/session_move.go
+++ b/cmd/agent-deck/session_move.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -21,12 +23,18 @@ func handleSessionMove(profile string, args []string) {
 	group := fs.String("group", "", "Also move to this group path (optional)")
 	noRestart := fs.Bool("no-restart", false, "Skip automatic restart after migration")
 	copyHistory := fs.Bool("copy", false, "Copy Claude session history instead of moving (preserves old path data)")
+	toProfile := fs.String("to-profile", "", "Migrate the session to another profile's DB (issue #928); incompatible with <new-path>")
+	force := fs.Bool("force", false, "With --to-profile: migrate running sessions (tmux process keeps running)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session move <id|title> <new-path> [options]")
+		fmt.Println("       agent-deck session move <id|title> --to-profile <name> [--force]")
 		fmt.Println()
-		fmt.Println("Move a session to a new project path, migrating its Claude")
+		fmt.Println("Move a session to a new project path (default form), migrating its Claude")
 		fmt.Println("conversation history from ~/.claude/projects/<old>/ to <new>/.")
+		fmt.Println()
+		fmt.Println("With --to-profile, instead migrate the session row to another profile's DB,")
+		fmt.Println("preserving all metadata and associated rows (cost_events, watcher_events).")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -36,6 +44,7 @@ func handleSessionMove(profile string, args []string) {
 		fmt.Println("  agent-deck session move my-project /new/path --group work/frontend")
 		fmt.Println("  agent-deck session move my-project /new/path --no-restart")
 		fmt.Println("  agent-deck session move my-project /new/path --copy")
+		fmt.Println("  agent-deck session move my-project --to-profile march")
 	}
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
@@ -44,6 +53,24 @@ func handleSessionMove(profile string, args []string) {
 
 	quietMode := *quiet || *quietShort
 	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	// Cross-profile migration mode (issue #928): different argument shape and
+	// completely different code path. Branch as early as possible so the
+	// existing path-move flow doesn't run.
+	if *toProfile != "" {
+		if fs.NArg() < 1 {
+			out.Error("session move --to-profile requires <id|title>", ErrCodeInvalidOperation)
+			fs.Usage()
+			os.Exit(1)
+		}
+		if fs.NArg() > 1 {
+			out.Error("--to-profile is incompatible with a <new-path> positional argument", ErrCodeInvalidOperation)
+			fs.Usage()
+			os.Exit(1)
+		}
+		handleSessionMoveToProfile(profile, *toProfile, fs.Arg(0), *force, out)
+		return
+	}
 
 	if fs.NArg() < 2 {
 		out.Error("session move requires <id|title> and <new-path>", ErrCodeInvalidOperation)
@@ -129,5 +156,79 @@ func handleSessionMove(profile string, args []string) {
 		"new_group": inst.GroupPath,
 		"restarted": restarted,
 		"copied":    *copyHistory,
+	})
+}
+
+// handleSessionMoveToProfile implements `session move <id> --to-profile <name>`
+// (issue #928). The identifier is resolved against the source profile (and,
+// if missing there, the target — preserving idempotency on re-runs), then
+// the session row + cost_events + watcher_events are transferred to the
+// target profile's state.db via session.MigrateSessionsToProfile.
+func handleSessionMoveToProfile(sourceProfile, targetProfile, identifier string, force bool, out *CLIOutput) {
+	// Resolve identifier → ID using the source profile's instance list. We do
+	// this in the CLI layer (not in MigrateSessionsToProfile) because
+	// ResolveSession lives in cmd/agent-deck and supports title/path lookup
+	// that the storage layer does not.
+	_, srcInstances, _, err := loadSessionData(sourceProfile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+	inst, errMsg, errCode := ResolveSession(identifier, srcInstances)
+	if inst == nil {
+		// Idempotent re-run: the session may already be at the target.
+		// Resolve there and let MigrateSessionsToProfile report it as a
+		// SkippedIdempotent success. Skip if the target doesn't exist yet —
+		// loadSessionData would auto-create it via NewStorageWithProfile and
+		// mask the cleaner "target profile does not exist" error from
+		// MigrateSessionsToProfile.
+		if dstDir, derr := session.GetProfileDir(targetProfile); derr == nil {
+			if _, statErr := os.Stat(filepath.Join(dstDir, "state.db")); statErr == nil {
+				if _, dstInstances, _, lerr := loadSessionData(targetProfile); lerr == nil {
+					if dstInst, _, _ := ResolveSession(identifier, dstInstances); dstInst != nil {
+						inst = dstInst
+					}
+				}
+			}
+		}
+	}
+	if inst == nil {
+		out.Error(errMsg, errCode)
+		if errCode == ErrCodeNotFound {
+			os.Exit(2)
+		}
+		os.Exit(1)
+		return
+	}
+
+	result, err := session.MigrateSessionsToProfile(
+		sourceProfile, targetProfile, []string{inst.ID},
+		session.ProfileMigrateOptions{Force: force},
+	)
+	if err != nil {
+		exitCode := ErrCodeInvalidOperation
+		hint := ""
+		switch {
+		case errors.Is(err, session.ErrProfileMissing):
+			exitCode = ErrCodeNotFound
+		case errors.Is(err, session.ErrSameProfile):
+			exitCode = ErrCodeInvalidOperation
+		case errors.Is(err, session.ErrSessionRunning):
+			hint = " (stop the session with `agent-deck session stop`, or re-run with --force)"
+		}
+		out.Error(fmt.Sprintf("%v%s", err, hint), exitCode)
+		os.Exit(1)
+	}
+
+	out.Success(fmt.Sprintf("Migrated %q: profile %s → %s", inst.Title, sourceProfile, targetProfile), map[string]interface{}{
+		"success":         true,
+		"id":              inst.ID,
+		"title":           inst.Title,
+		"from_profile":    sourceProfile,
+		"to_profile":      targetProfile,
+		"cost_events":     result.MovedCostEvents,
+		"watcher_events":  result.MovedWatcherEvents,
+		"groups_created":  result.CreatedGroups,
+		"already_at_dest": len(result.SkippedIdempotent) > 0,
 	})
 }

--- a/internal/session/profile_migrate.go
+++ b/internal/session/profile_migrate.go
@@ -135,40 +135,53 @@ func MigrateConductorToProfile(name, sourceProfile, targetProfile string, opts P
 	dst := dstStorage.GetDB()
 
 	// Find the conductor session in src by title + is_conductor.
-	// Fall back to dst if it's already migrated (idempotency).
 	conductorTitle := ConductorSessionTitle(name)
-	conductorRow, err := findConductorByTitle(src, conductorTitle)
+	srcConductor, err := findConductorByTitle(src, conductorTitle)
 	if err != nil {
 		return nil, err
 	}
-	if conductorRow == nil {
-		// Already at dst? Then we only need to update meta.json.
-		if existsAt, err := findConductorByTitle(dst, conductorTitle); err == nil && existsAt != nil {
-			result := &ProfileMigrateResult{SkippedIdempotent: []string{existsAt.ID}}
-			if err := updateConductorMetaProfile(name, targetProfile); err != nil {
-				return result, fmt.Errorf("update conductor meta.json: %w", err)
-			}
-			result.MetaUpdated = true
-			return result, nil
-		}
+	dstConductor, err := findConductorByTitle(dst, conductorTitle)
+	if err != nil {
+		return nil, err
+	}
+	if srcConductor == nil && dstConductor == nil {
 		return nil, fmt.Errorf("conductor %q not found in profile %q", name, sourceProfile)
 	}
 
-	// Children first, conductor last on the source-delete side (parent_session_id
-	// will be re-anchored by the target writes since IDs round-trip). For the
-	// target-write side, order doesn't matter — INSERT OR REPLACE.
-	children, err := src.LoadInstanceChildren(conductorRow.ID)
-	if err != nil {
-		return nil, fmt.Errorf("load conductor children: %w", err)
+	// Determine the conductor ID used to look up worker children — fall back
+	// to dst when the conductor row itself has already been migrated, so a
+	// partial prior run (conductor moved but some workers stranded) still
+	// completes on re-run rather than leaving children in the source profile.
+	conductorID := ""
+	if srcConductor != nil {
+		conductorID = srcConductor.ID
+	} else {
+		conductorID = dstConductor.ID
 	}
 
-	ids := make([]string, 0, len(children)+1)
-	ids = append(ids, conductorRow.ID)
-	for _, c := range children {
+	// Workers first, conductor last in the migration order. If we ever crash
+	// after the conductor row leaves src but before all workers do, a re-run
+	// hits the dstConductor != nil branch above with conductorID == dstConductor.ID
+	// and still sweeps the stranded workers.
+	srcChildren, err := src.LoadInstanceChildren(conductorID)
+	if err != nil {
+		return nil, fmt.Errorf("load conductor children from src: %w", err)
+	}
+	ids := make([]string, 0, len(srcChildren)+1)
+	for _, c := range srcChildren {
 		ids = append(ids, c.ID)
+	}
+	if srcConductor != nil {
+		ids = append(ids, srcConductor.ID)
 	}
 
 	result := &ProfileMigrateResult{}
+	if dstConductor != nil && srcConductor == nil {
+		// Conductor itself is already migrated. Report it as
+		// SkippedIdempotent so CLI output reflects what happened.
+		result.SkippedIdempotent = append(result.SkippedIdempotent, dstConductor.ID)
+		result.MovedSessionIDs = append(result.MovedSessionIDs, dstConductor.ID)
+	}
 	for _, id := range ids {
 		if err := migrateOneSession(src, dst, id, opts, result); err != nil {
 			return result, err
@@ -235,8 +248,11 @@ func MigrateGroupToProfile(groupPath, sourceProfile, targetProfile string, opts 
 			}
 		}
 	}
+	// Empty source group is a successful no-op for idempotency: a second run
+	// of the same migration finds the source emptied by the first run, which
+	// is the desired end state — not an error.
 	if len(rows) == 0 {
-		return nil, fmt.Errorf("group %q has no sessions in profile %q", groupPath, sourceProfile)
+		return &ProfileMigrateResult{}, nil
 	}
 
 	ids := make([]string, 0, len(rows))
@@ -322,7 +338,24 @@ func migrateOneSession(src, dst *statedb.StateDB, sessionID string, opts Profile
 		}
 		result.MovedCostEvents++
 	}
+	// Before inserting watcher_events, ensure the referenced watcher row
+	// exists at dst — watcher_events.watcher_id is a foreign key to
+	// watchers(id) and foreign_keys are ON, so a missing watcher would fail
+	// the event insert. Track which watcher_ids we've already checked this
+	// call so the round-trip cost is one statedb hit per distinct watcher.
+	seenWatchers := make(map[string]bool, 4)
 	for _, ev := range watcherRows {
+		if !seenWatchers[ev.WatcherID] {
+			seenWatchers[ev.WatcherID] = true
+			if err := ensureWatcherAtDst(src, dst, ev.WatcherID); err != nil {
+				if dstRow == nil {
+					_ = dst.DeleteInstanceRow(sessionID)
+					_ = dst.DeleteCostEventsForSession(sessionID)
+					_ = dst.DeleteWatcherEventsForSession(sessionID)
+				}
+				return fmt.Errorf("ensure watcher %q at target: %w", ev.WatcherID, err)
+			}
+		}
 		if err := dst.InsertWatcherEventRow(ev); err != nil {
 			if dstRow == nil {
 				_ = dst.DeleteInstanceRow(sessionID)
@@ -354,14 +387,45 @@ func migrateOneSession(src, dst *statedb.StateDB, sessionID string, opts Profile
 }
 
 // rollbackTargetWrites removes rows from dst that the current call inserted.
-// If targetAlreadyHadInstance is true, the instance row was pre-existing and
-// must be left in place (we only added the children rows).
+// If targetAlreadyHadInstance is true, the destination may have legitimately
+// pre-existing cost_events / watcher_events for this session_id (e.g., from
+// a partial prior migration that we are now re-running). Bulk-deleting them
+// would clobber legitimate data, so in that branch we leave everything in
+// place — re-running the migration is safe (INSERT OR IGNORE / INSERT OR
+// REPLACE on every target write).
 func rollbackTargetWrites(dst *statedb.StateDB, sessionID string, targetAlreadyHadInstance bool) {
+	if targetAlreadyHadInstance {
+		return
+	}
 	_ = dst.DeleteWatcherEventsForSession(sessionID)
 	_ = dst.DeleteCostEventsForSession(sessionID)
-	if !targetAlreadyHadInstance {
-		_ = dst.DeleteInstanceRow(sessionID)
+	_ = dst.DeleteInstanceRow(sessionID)
+}
+
+// ensureWatcherAtDst copies the watchers row referenced by a watcher_event
+// from src to dst if dst lacks it. Required because watcher_events.watcher_id
+// has a foreign-key constraint to watchers(id) and foreign_keys are ON.
+// No-op if dst already has the watcher (leaving its state field untouched —
+// watcher status is owned by whichever process is actually running it).
+func ensureWatcherAtDst(src, dst *statedb.StateDB, watcherID string) error {
+	existing, err := dst.LoadWatcherByID(watcherID)
+	if err != nil {
+		return err
 	}
+	if existing != nil {
+		return nil
+	}
+	srcWatcher, err := src.LoadWatcherByID(watcherID)
+	if err != nil {
+		return err
+	}
+	if srcWatcher == nil {
+		// Watcher row is gone from src too — the event references a deleted
+		// watcher. Surface a clear error so the user can decide whether to
+		// drop the orphaned event manually before migrating.
+		return fmt.Errorf("watcher %q is referenced by watcher_events but missing from both source and target", watcherID)
+	}
+	return dst.SaveWatcher(srcWatcher)
 }
 
 // ensureGroupAtDst copies a group row from src to dst if dst lacks it.

--- a/internal/session/profile_migrate.go
+++ b/internal/session/profile_migrate.go
@@ -1,0 +1,448 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+// ProfileMigrateOptions controls a cross-profile migration (issue #928).
+type ProfileMigrateOptions struct {
+	// Force bypasses the "session is running" safety check. Without this, a
+	// running session is refused with a hint to stop it first.
+	Force bool
+}
+
+// ProfileMigrateResult summarizes what a migration moved. All counts include
+// rows that were already present at the destination (skipped idempotently).
+type ProfileMigrateResult struct {
+	// MovedSessionIDs are the IDs that ended up in the destination DB. This
+	// includes IDs that were already there (idempotent re-run).
+	MovedSessionIDs []string
+	// SkippedIdempotent lists session IDs that were already in the destination
+	// (the migration only needed to clean up the source side, if any).
+	SkippedIdempotent []string
+	// MovedCostEvents is the count of cost_events rows inserted at dst.
+	MovedCostEvents int
+	// MovedWatcherEvents is the count of watcher_events rows inserted at dst.
+	MovedWatcherEvents int
+	// CreatedGroups lists group_path values that did not exist in dst and were
+	// created by the migration.
+	CreatedGroups []string
+	// MetaUpdated indicates the conductor meta.json was rewritten with the new
+	// profile (conductor migrations only).
+	MetaUpdated bool
+}
+
+// ErrSessionRunning is returned when a session is in "running" status and
+// Force is false. CLI handlers translate this to a non-zero exit with a hint.
+var ErrSessionRunning = errors.New("session is running; stop it first or pass --force")
+
+// ErrProfileMissing is returned when the destination profile has no state.db
+// (i.e., it has never been used). Profiles are otherwise lazily created.
+var ErrProfileMissing = errors.New("target profile does not exist")
+
+// ErrSameProfile is returned when source == target.
+var ErrSameProfile = errors.New("source and target profile are the same")
+
+// MigrateSessionsToProfile moves the listed session rows from sourceProfile to
+// targetProfile. All associated rows (cost_events, watcher_events linked via
+// session_id or triage_session_id) are moved alongside. The session's group
+// row is created in the target if missing.
+//
+// The algorithm is target-write-then-source-delete, with a best-effort
+// rollback on source-delete failure. Two SQLite databases cannot share a
+// transaction, so we accept a tiny window where a crash between phases would
+// leave the row in both DBs — re-running the command cleans this up.
+//
+// Refuses running sessions unless opts.Force is set. Idempotent: a session
+// already in dst is treated as already-migrated and only the source side is
+// reconciled.
+func MigrateSessionsToProfile(sourceProfile, targetProfile string, sessionIDs []string, opts ProfileMigrateOptions) (*ProfileMigrateResult, error) {
+	if sourceProfile == "" {
+		sourceProfile = DefaultProfile
+	}
+	if targetProfile == "" {
+		targetProfile = DefaultProfile
+	}
+	if sourceProfile == targetProfile {
+		return nil, ErrSameProfile
+	}
+	if err := requireProfileExists(targetProfile); err != nil {
+		return nil, err
+	}
+
+	srcStorage, err := NewStorageWithProfile(sourceProfile)
+	if err != nil {
+		return nil, fmt.Errorf("open source profile %q: %w", sourceProfile, err)
+	}
+	defer srcStorage.Close()
+
+	dstStorage, err := NewStorageWithProfile(targetProfile)
+	if err != nil {
+		return nil, fmt.Errorf("open target profile %q: %w", targetProfile, err)
+	}
+	defer dstStorage.Close()
+
+	result := &ProfileMigrateResult{}
+	for _, id := range sessionIDs {
+		if err := migrateOneSession(srcStorage.GetDB(), dstStorage.GetDB(), id, opts, result); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+// MigrateConductorToProfile moves a conductor session AND every child session
+// (where parent_session_id == conductor.ID) from src to dst, then atomically
+// rewrites ~/.agent-deck/conductor/<name>/meta.json with the new profile.
+//
+// Per CLAUDE.md and issue #928: workers MUST travel with their conductor — a
+// split would orphan the children's parent_session_id reference.
+func MigrateConductorToProfile(name, sourceProfile, targetProfile string, opts ProfileMigrateOptions) (*ProfileMigrateResult, error) {
+	if err := ValidateConductorName(name); err != nil {
+		return nil, err
+	}
+	if sourceProfile == "" {
+		sourceProfile = DefaultProfile
+	}
+	if targetProfile == "" {
+		targetProfile = DefaultProfile
+	}
+	if sourceProfile == targetProfile {
+		return nil, ErrSameProfile
+	}
+	if err := requireProfileExists(targetProfile); err != nil {
+		return nil, err
+	}
+
+	srcStorage, err := NewStorageWithProfile(sourceProfile)
+	if err != nil {
+		return nil, fmt.Errorf("open source profile %q: %w", sourceProfile, err)
+	}
+	defer srcStorage.Close()
+	dstStorage, err := NewStorageWithProfile(targetProfile)
+	if err != nil {
+		return nil, fmt.Errorf("open target profile %q: %w", targetProfile, err)
+	}
+	defer dstStorage.Close()
+
+	src := srcStorage.GetDB()
+	dst := dstStorage.GetDB()
+
+	// Find the conductor session in src by title + is_conductor.
+	// Fall back to dst if it's already migrated (idempotency).
+	conductorTitle := ConductorSessionTitle(name)
+	conductorRow, err := findConductorByTitle(src, conductorTitle)
+	if err != nil {
+		return nil, err
+	}
+	if conductorRow == nil {
+		// Already at dst? Then we only need to update meta.json.
+		if existsAt, err := findConductorByTitle(dst, conductorTitle); err == nil && existsAt != nil {
+			result := &ProfileMigrateResult{SkippedIdempotent: []string{existsAt.ID}}
+			if err := updateConductorMetaProfile(name, targetProfile); err != nil {
+				return result, fmt.Errorf("update conductor meta.json: %w", err)
+			}
+			result.MetaUpdated = true
+			return result, nil
+		}
+		return nil, fmt.Errorf("conductor %q not found in profile %q", name, sourceProfile)
+	}
+
+	// Children first, conductor last on the source-delete side (parent_session_id
+	// will be re-anchored by the target writes since IDs round-trip). For the
+	// target-write side, order doesn't matter — INSERT OR REPLACE.
+	children, err := src.LoadInstanceChildren(conductorRow.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load conductor children: %w", err)
+	}
+
+	ids := make([]string, 0, len(children)+1)
+	ids = append(ids, conductorRow.ID)
+	for _, c := range children {
+		ids = append(ids, c.ID)
+	}
+
+	result := &ProfileMigrateResult{}
+	for _, id := range ids {
+		if err := migrateOneSession(src, dst, id, opts, result); err != nil {
+			return result, err
+		}
+	}
+
+	// Rows are now in dst. Update meta.json to point at the new profile.
+	// If this fails, the rows are still migrated — the user can re-run the
+	// command (it is idempotent) or hand-edit meta.json.
+	if err := updateConductorMetaProfile(name, targetProfile); err != nil {
+		return result, fmt.Errorf("update conductor meta.json (rows already migrated): %w", err)
+	}
+	result.MetaUpdated = true
+	return result, nil
+}
+
+// MigrateGroupToProfile moves every session whose group_path matches groupPath
+// from src to dst. The group row itself (preserving expanded/order/default_path)
+// is also created in dst. Empty groups are refused.
+func MigrateGroupToProfile(groupPath, sourceProfile, targetProfile string, opts ProfileMigrateOptions) (*ProfileMigrateResult, error) {
+	if groupPath == "" {
+		groupPath = DefaultGroupPath
+	}
+	if sourceProfile == "" {
+		sourceProfile = DefaultProfile
+	}
+	if targetProfile == "" {
+		targetProfile = DefaultProfile
+	}
+	if sourceProfile == targetProfile {
+		return nil, ErrSameProfile
+	}
+	if err := requireProfileExists(targetProfile); err != nil {
+		return nil, err
+	}
+
+	srcStorage, err := NewStorageWithProfile(sourceProfile)
+	if err != nil {
+		return nil, fmt.Errorf("open source profile %q: %w", sourceProfile, err)
+	}
+	defer srcStorage.Close()
+	dstStorage, err := NewStorageWithProfile(targetProfile)
+	if err != nil {
+		return nil, fmt.Errorf("open target profile %q: %w", targetProfile, err)
+	}
+	defer dstStorage.Close()
+
+	src := srcStorage.GetDB()
+	dst := dstStorage.GetDB()
+
+	rows, err := src.LoadInstancesByGroup(groupPath)
+	if err != nil {
+		return nil, fmt.Errorf("load source group %q: %w", groupPath, err)
+	}
+	// Group paths in the DB are sanitized at creation (CreateGroup, line ~698),
+	// which replaces "/" with "-" inside a single-name group. Accept the
+	// human form ("work/api") by falling back to the sanitized form
+	// ("work-api") when the literal lookup is empty.
+	if len(rows) == 0 {
+		if sanitized := sanitizeGroupName(groupPath); sanitized != groupPath {
+			if alt, lerr := src.LoadInstancesByGroup(sanitized); lerr == nil && len(alt) > 0 {
+				rows = alt
+				groupPath = sanitized
+			}
+		}
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("group %q has no sessions in profile %q", groupPath, sourceProfile)
+	}
+
+	ids := make([]string, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.ID)
+	}
+	sort.Strings(ids) // deterministic order for test stability
+
+	result := &ProfileMigrateResult{}
+	for _, id := range ids {
+		if err := migrateOneSession(src, dst, id, opts, result); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+// --- internals ---
+
+// migrateOneSession is the primitive that all three public entrypoints call.
+// It mutates the running result struct, appending counts and ids.
+func migrateOneSession(src, dst *statedb.StateDB, sessionID string, opts ProfileMigrateOptions, result *ProfileMigrateResult) error {
+	srcRow, err := src.LoadInstanceByID(sessionID)
+	if err != nil {
+		return fmt.Errorf("load source instance %s: %w", sessionID, err)
+	}
+	dstRow, err := dst.LoadInstanceByID(sessionID)
+	if err != nil {
+		return fmt.Errorf("load target instance %s: %w", sessionID, err)
+	}
+
+	// Pure idempotent no-op: row already at dst, nothing in src.
+	if srcRow == nil && dstRow != nil {
+		result.MovedSessionIDs = append(result.MovedSessionIDs, sessionID)
+		result.SkippedIdempotent = append(result.SkippedIdempotent, sessionID)
+		return nil
+	}
+	if srcRow == nil && dstRow == nil {
+		return fmt.Errorf("session %s not found", sessionID)
+	}
+
+	// Running-session guard.
+	if srcRow != nil && srcRow.Status == "running" && !opts.Force {
+		return fmt.Errorf("%w: session %s (%s)", ErrSessionRunning, sessionID, srcRow.Title)
+	}
+
+	// Read associated rows from the source. We collect them BEFORE writing to
+	// dst so a read failure aborts without touching state.
+	costRows, err := src.LoadCostEventsForSession(sessionID)
+	if err != nil {
+		return fmt.Errorf("load cost_events for %s: %w", sessionID, err)
+	}
+	watcherRows, err := src.LoadWatcherEventsForSession(sessionID)
+	if err != nil {
+		return fmt.Errorf("load watcher_events for %s: %w", sessionID, err)
+	}
+
+	// Ensure the destination group exists.
+	createdGroup, err := ensureGroupAtDst(src, dst, srcRow.GroupPath)
+	if err != nil {
+		return fmt.Errorf("ensure group %q in target: %w", srcRow.GroupPath, err)
+	}
+	if createdGroup {
+		result.CreatedGroups = append(result.CreatedGroups, srcRow.GroupPath)
+	}
+
+	// Target-write phase. If any step fails, we have not touched src yet —
+	// return the error and let the user retry.
+	if dstRow == nil {
+		if err := dst.InsertInstanceRow(srcRow); err != nil {
+			return fmt.Errorf("insert instance at target: %w", err)
+		}
+	}
+	for _, ev := range costRows {
+		if err := dst.InsertCostEventRow(ev); err != nil {
+			// Best-effort rollback: drop the instance we just wrote (only if
+			// it wasn't already in dst).
+			if dstRow == nil {
+				_ = dst.DeleteInstanceRow(sessionID)
+				_ = dst.DeleteCostEventsForSession(sessionID)
+			}
+			return fmt.Errorf("insert cost_event at target: %w", err)
+		}
+		result.MovedCostEvents++
+	}
+	for _, ev := range watcherRows {
+		if err := dst.InsertWatcherEventRow(ev); err != nil {
+			if dstRow == nil {
+				_ = dst.DeleteInstanceRow(sessionID)
+				_ = dst.DeleteCostEventsForSession(sessionID)
+				_ = dst.DeleteWatcherEventsForSession(sessionID)
+			}
+			return fmt.Errorf("insert watcher_event at target: %w", err)
+		}
+		result.MovedWatcherEvents++
+	}
+
+	// Source-delete phase. On any failure, attempt to roll back the target
+	// inserts so the user is not left with a duplicate.
+	if err := src.DeleteWatcherEventsForSession(sessionID); err != nil {
+		rollbackTargetWrites(dst, sessionID, dstRow != nil)
+		return fmt.Errorf("delete watcher_events from source: %w", err)
+	}
+	if err := src.DeleteCostEventsForSession(sessionID); err != nil {
+		rollbackTargetWrites(dst, sessionID, dstRow != nil)
+		return fmt.Errorf("delete cost_events from source: %w", err)
+	}
+	if err := src.DeleteInstanceRow(sessionID); err != nil {
+		rollbackTargetWrites(dst, sessionID, dstRow != nil)
+		return fmt.Errorf("delete instance from source: %w", err)
+	}
+
+	result.MovedSessionIDs = append(result.MovedSessionIDs, sessionID)
+	return nil
+}
+
+// rollbackTargetWrites removes rows from dst that the current call inserted.
+// If targetAlreadyHadInstance is true, the instance row was pre-existing and
+// must be left in place (we only added the children rows).
+func rollbackTargetWrites(dst *statedb.StateDB, sessionID string, targetAlreadyHadInstance bool) {
+	_ = dst.DeleteWatcherEventsForSession(sessionID)
+	_ = dst.DeleteCostEventsForSession(sessionID)
+	if !targetAlreadyHadInstance {
+		_ = dst.DeleteInstanceRow(sessionID)
+	}
+}
+
+// ensureGroupAtDst copies a group row from src to dst if dst lacks it.
+// Returns true when the group was newly created.
+func ensureGroupAtDst(src, dst *statedb.StateDB, groupPath string) (bool, error) {
+	if groupPath == "" || groupPath == DefaultGroupPath {
+		return false, nil
+	}
+	existing, err := dst.LoadGroup(groupPath)
+	if err != nil {
+		return false, err
+	}
+	if existing != nil {
+		return false, nil
+	}
+	srcGroup, err := src.LoadGroup(groupPath)
+	if err != nil {
+		return false, err
+	}
+	if srcGroup == nil {
+		// Source has no explicit group row either; nothing to migrate.
+		return false, nil
+	}
+	if err := dst.SaveGroup(srcGroup); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// findConductorByTitle returns the conductor row, or (nil, nil) if absent.
+// We match on title AND is_conductor=1 so a session that happens to be
+// titled "conductor-foo" without the flag set is not picked up.
+func findConductorByTitle(db *statedb.StateDB, title string) (*statedb.InstanceRow, error) {
+	// statedb has no by-title query; reuse the children scan plumbing via the
+	// LoadInstances API and filter in Go. The instances table is small enough
+	// (~10s-100s of rows) that a linear scan is acceptable.
+	rows, err := db.LoadInstances()
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		if r.IsConductor && r.Title == title {
+			return r, nil
+		}
+	}
+	return nil, nil
+}
+
+// updateConductorMetaProfile rewrites the Profile field on
+// ~/.agent-deck/conductor/<name>/meta.json atomically. No-op if meta.json
+// does not exist (the conductor may have been created without the standard
+// `conductor setup` flow).
+func updateConductorMetaProfile(name, profile string) error {
+	if !IsConductorSetup(name) {
+		return nil
+	}
+	meta, err := LoadConductorMeta(name)
+	if err != nil {
+		return err
+	}
+	if meta.Profile == profile {
+		return nil
+	}
+	meta.Profile = profile
+	return SaveConductorMeta(meta)
+}
+
+// requireProfileExists returns ErrProfileMissing unless the target profile's
+// state.db is already on disk. We deliberately bypass NewStorageWithProfile
+// here because that function auto-creates the profile directory.
+func requireProfileExists(profile string) error {
+	dir, err := GetProfileDir(profile)
+	if err != nil {
+		return err
+	}
+	dbPath := filepath.Join(dir, "state.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%w: profile %q has no state.db (run any agent-deck command with --profile %s first to create it)", ErrProfileMissing, profile, profile)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/session/profile_migrate_test.go
+++ b/internal/session/profile_migrate_test.go
@@ -500,6 +500,141 @@ func TestMigrateSessionsToProfile_ConcurrentDifferentSessions(t *testing.T) {
 	}
 }
 
+// TestMigrateConductorToProfile_RescuesStrandedChildrenOnRerun simulates the
+// partial-failure case Copilot flagged: a prior run moved the conductor and
+// the first worker, then crashed before the second worker migrated. Re-running
+// must sweep the stranded worker rather than just updating meta.json.
+func TestMigrateConductorToProfile_RescuesStrandedChildrenOnRerun(t *testing.T) {
+	src, dst := migrateTestSetup(t, "src", "dst")
+
+	// Conductor + worker A already in dst (the prior-run survivors).
+	cond := makeRow("c-resume", ConductorSessionTitle("rescue"), DefaultGroupPath)
+	cond.IsConductor = true
+	seedSession(t, dst.GetDB(), cond)
+	wA := makeRow("worker-a-resume", "worker-a", DefaultGroupPath)
+	wA.ParentSessionID = cond.ID
+	seedSession(t, dst.GetDB(), wA)
+
+	// Worker B is stranded in src, still pointing at the (now-dst) conductor.
+	wB := makeRow("worker-b-resume", "worker-b", DefaultGroupPath)
+	wB.ParentSessionID = cond.ID
+	seedSession(t, src.GetDB(), wB)
+
+	if err := SaveConductorMeta(&ConductorMeta{
+		Name: "rescue", Agent: ConductorAgentClaude, Profile: "src",
+	}); err != nil {
+		t.Fatalf("seed meta: %v", err)
+	}
+
+	result, err := MigrateConductorToProfile("rescue", "src", "dst", ProfileMigrateOptions{})
+	if err != nil {
+		t.Fatalf("rerun migrate: %v", err)
+	}
+	// The stranded worker must be at dst now and gone from src.
+	if r, _ := dst.GetDB().LoadInstanceByID(wB.ID); r == nil {
+		t.Errorf("stranded worker %q was not rescued to dst", wB.ID)
+	}
+	if r, _ := src.GetDB().LoadInstanceByID(wB.ID); r != nil {
+		t.Errorf("stranded worker %q still in src after re-run", wB.ID)
+	}
+	// Conductor is reported as idempotent-skipped.
+	foundCond := false
+	for _, id := range result.SkippedIdempotent {
+		if id == cond.ID {
+			foundCond = true
+		}
+	}
+	if !foundCond {
+		t.Errorf("expected conductor %q in SkippedIdempotent, got %v", cond.ID, result.SkippedIdempotent)
+	}
+	got, _ := LoadConductorMeta("rescue")
+	if got == nil || got.Profile != "dst" {
+		t.Errorf("meta.json not updated to dst on rescue rerun: %+v", got)
+	}
+}
+
+// TestMigrateSessionsToProfile_CopiesReferencedWatcherRow verifies fix #3 from
+// the Copilot review: watcher_events.watcher_id is FK-constrained, so we
+// must copy the watchers row from src→dst before inserting events.
+func TestMigrateSessionsToProfile_CopiesReferencedWatcherRow(t *testing.T) {
+	src, dst := migrateTestSetup(t, "src", "dst")
+	seedSession(t, src.GetDB(), makeRow("sess-fk", "S", DefaultGroupPath))
+
+	// Watcher exists in src only. Without the fix, the watcher_event insert
+	// at dst would fail with FOREIGN KEY constraint failed.
+	if err := src.GetDB().SaveWatcher(&statedb.WatcherRow{
+		ID: "w-fk", Name: "fk-watch", Type: "github", ConfigPath: "/tmp/w.toml",
+		Status: "stopped", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed src watcher: %v", err)
+	}
+	if err := src.GetDB().InsertWatcherEventRow(&statedb.WatcherEventRow{
+		WatcherID: "w-fk", DedupKey: "d-fk", SessionID: "sess-fk", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed watcher event: %v", err)
+	}
+
+	if _, err := MigrateSessionsToProfile("src", "dst", []string{"sess-fk"}, ProfileMigrateOptions{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// dst must have the watcher row (copied) AND the event.
+	w, _ := dst.GetDB().LoadWatcherByID("w-fk")
+	if w == nil {
+		t.Error("dst missing watcher row that was referenced by a migrated event")
+	}
+	events, _ := dst.GetDB().LoadWatcherEventsForSession("sess-fk")
+	if len(events) != 1 {
+		t.Errorf("dst missing migrated watcher event: %d", len(events))
+	}
+}
+
+// TestMigrateGroupToProfile_EmptyGroupIsNoOp verifies fix #5: re-running a
+// group migration after the source group has been emptied must succeed.
+func TestMigrateGroupToProfile_EmptyGroupIsNoOp(t *testing.T) {
+	migrateTestSetup(t, "src", "dst")
+	// No sessions seeded in src.
+	result, err := MigrateGroupToProfile("nonexistent-group", "src", "dst", ProfileMigrateOptions{})
+	if err != nil {
+		t.Errorf("expected empty group to be a no-op, got error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result on no-op")
+	}
+	if len(result.MovedSessionIDs) != 0 {
+		t.Errorf("expected zero moved sessions, got %v", result.MovedSessionIDs)
+	}
+}
+
+// TestRollbackTargetWrites_PreservesPreexistingRows ensures fix #4: if the
+// migration is rerun and the destination already has the session row + its
+// associated cost/watcher rows from a prior partial run, a source-delete
+// failure must NOT bulk-delete those rows at the destination.
+func TestRollbackTargetWrites_PreservesPreexistingRows(t *testing.T) {
+	_, dst := migrateTestSetup(t, "src", "dst")
+
+	// Seed dst with a session + cost event that we'd consider "legitimately
+	// pre-existing" from a prior partial migration.
+	seedSession(t, dst.GetDB(), makeRow("preexist", "P", DefaultGroupPath))
+	if err := dst.GetDB().InsertCostEventRow(&statedb.CostEventRow{
+		ID: "cp-1", SessionID: "preexist", Timestamp: time.Now().UTC().Format(time.RFC3339), Model: "m", CostMicrodollars: 100,
+	}); err != nil {
+		t.Fatalf("seed dst cost: %v", err)
+	}
+
+	// Simulate rollback with targetAlreadyHadInstance=true: must NOT delete
+	// the pre-existing cost row.
+	rollbackTargetWrites(dst.GetDB(), "preexist", true)
+
+	costs, _ := dst.GetDB().LoadCostEventsForSession("preexist")
+	if len(costs) != 1 {
+		t.Errorf("rollback with targetAlreadyHadInstance=true clobbered pre-existing cost rows: have %d, want 1", len(costs))
+	}
+	inst, _ := dst.GetDB().LoadInstanceByID("preexist")
+	if inst == nil {
+		t.Error("rollback clobbered pre-existing instance row")
+	}
+}
+
 // Sanity check: the helper that pre-validates target existence rejects a
 // directory-without-state.db case.
 func TestRequireProfileExists_RejectsBareDir(t *testing.T) {

--- a/internal/session/profile_migrate_test.go
+++ b/internal/session/profile_migrate_test.go
@@ -1,0 +1,523 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+// migrateTestSetup pins HOME to a temp dir and pre-creates the named profiles
+// so MigrateSessionsToProfile can validate target existence. Returns the
+// source + target *Storage and their *StateDB handles for direct seeding.
+//
+// Note: cross-profile migration explicitly forbids running while
+// AGENTDECK_PROFILE is set to something stale (it forces the explicit-arg
+// path), so we clear it.
+func migrateTestSetup(t *testing.T, src, dst string) (srcStorage, dstStorage *Storage) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTDECK_PROFILE", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	var err error
+	srcStorage, err = NewStorageWithProfile(src)
+	if err != nil {
+		t.Fatalf("open source profile: %v", err)
+	}
+	t.Cleanup(func() { _ = srcStorage.Close() })
+	dstStorage, err = NewStorageWithProfile(dst)
+	if err != nil {
+		t.Fatalf("open target profile: %v", err)
+	}
+	t.Cleanup(func() { _ = dstStorage.Close() })
+	return srcStorage, dstStorage
+}
+
+// makeRow returns an InstanceRow seeded with sentinel values across every
+// migrated field, so PreservesAllFields can verify each one round-trips.
+func makeRow(id, title, groupPath string) *statedb.InstanceRow {
+	yolo := true
+	tdBlob, _ := json.Marshal(map[string]any{
+		"claude_session_id":   "claude-" + id,
+		"claude_detected_at":  1700000000,
+		"gemini_session_id":   "gem-" + id,
+		"gemini_yolo_mode":    &yolo,
+		"notes":               "migration sentinel " + id,
+		"latest_prompt":       "hello",
+		"loaded_mcp_names":    []string{"mcp-a", "mcp-b"},
+		"channels":            []string{"chan-1"},
+	})
+	return &statedb.InstanceRow{
+		ID:              id,
+		Title:           title,
+		ProjectPath:     "/tmp/migrate/" + id,
+		GroupPath:       groupPath,
+		Order:           7,
+		Command:         "echo hello",
+		Wrapper:         "claude",
+		Tool:            "claude",
+		Status:          "stopped",
+		TmuxSession:     "tmux-" + id,
+		TmuxSocketName:  "sock-" + id,
+		CreatedAt:       time.Unix(1700000000, 0),
+		LastAccessed:    time.Unix(1700001000, 0),
+		ParentSessionID: "parent-of-" + id,
+		IsConductor:     false,
+		TitleLocked:     true,
+		WorktreePath:    "/wt/" + id,
+		WorktreeRepo:    "repo-" + id,
+		WorktreeBranch:  "branch-" + id,
+		ToolData:        tdBlob,
+	}
+}
+
+func seedSession(t *testing.T, db *statedb.StateDB, row *statedb.InstanceRow) {
+	t.Helper()
+	if err := db.InsertInstanceRow(row); err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+}
+
+func TestMigrateSessionsToProfile_PreservesAllFields(t *testing.T) {
+	src, dst := migrateTestSetup(t, "src", "dst")
+	row := makeRow("sess-1", "Project One", DefaultGroupPath)
+	seedSession(t, src.GetDB(), row)
+
+	result, err := MigrateSessionsToProfile("src", "dst", []string{"sess-1"}, ProfileMigrateOptions{})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if len(result.MovedSessionIDs) != 1 {
+		t.Fatalf("expected 1 moved id, got %v", result.MovedSessionIDs)
+	}
+
+	// Source must be gone.
+	srcRow, err := src.GetDB().LoadInstanceByID("sess-1")
+	if err != nil {
+		t.Fatalf("load src after: %v", err)
+	}
+	if srcRow != nil {
+		t.Errorf("source still has session row %v", srcRow)
+	}
+
+	// Target must have a verbatim copy.
+	got, err := dst.GetDB().LoadInstanceByID("sess-1")
+	if err != nil {
+		t.Fatalf("load dst after: %v", err)
+	}
+	if got == nil {
+		t.Fatal("target missing migrated session")
+	}
+	for _, c := range []struct{ field, want, have string }{
+		{"Title", row.Title, got.Title},
+		{"ProjectPath", row.ProjectPath, got.ProjectPath},
+		{"GroupPath", row.GroupPath, got.GroupPath},
+		{"Tool", row.Tool, got.Tool},
+		{"Status", row.Status, got.Status},
+		{"TmuxSession", row.TmuxSession, got.TmuxSession},
+		{"TmuxSocketName", row.TmuxSocketName, got.TmuxSocketName},
+		{"ParentSessionID", row.ParentSessionID, got.ParentSessionID},
+		{"WorktreePath", row.WorktreePath, got.WorktreePath},
+		{"WorktreeRepo", row.WorktreeRepo, got.WorktreeRepo},
+		{"WorktreeBranch", row.WorktreeBranch, got.WorktreeBranch},
+	} {
+		if c.have != c.want {
+			t.Errorf("%s: want %q got %q", c.field, c.want, c.have)
+		}
+	}
+	if got.Order != row.Order {
+		t.Errorf("Order: want %d got %d", row.Order, got.Order)
+	}
+	if got.TitleLocked != row.TitleLocked {
+		t.Errorf("TitleLocked: want %v got %v", row.TitleLocked, got.TitleLocked)
+	}
+	// tool_data must round-trip key-by-key. We don't assert byte equality
+	// because INSERT OR REPLACE may re-serialize the JSON.
+	var srcTD, dstTD map[string]any
+	_ = json.Unmarshal(row.ToolData, &srcTD)
+	_ = json.Unmarshal(got.ToolData, &dstTD)
+	for k, v := range srcTD {
+		if dvJSON, _ := json.Marshal(dstTD[k]); string(dvJSON) == "" {
+			t.Errorf("tool_data missing key %q in dst", k)
+			continue
+		}
+		svJSON, _ := json.Marshal(v)
+		dvJSON, _ := json.Marshal(dstTD[k])
+		if string(svJSON) != string(dvJSON) {
+			t.Errorf("tool_data[%q]: want %s got %s", k, svJSON, dvJSON)
+		}
+	}
+}
+
+func TestMigrateSessionsToProfile_MigratesCostAndWatcherEvents(t *testing.T) {
+	src, dst := migrateTestSetup(t, "src", "dst")
+	seedSession(t, src.GetDB(), makeRow("sess-cost", "S", DefaultGroupPath))
+
+	// Two cost events.
+	for _, ce := range []*statedb.CostEventRow{
+		{ID: "c1", SessionID: "sess-cost", Timestamp: time.Now().UTC().Format(time.RFC3339), Model: "claude-sonnet-4-6", CostMicrodollars: 1234},
+		{ID: "c2", SessionID: "sess-cost", Timestamp: time.Now().UTC().Format(time.RFC3339), Model: "gemini-2.5", CostMicrodollars: 5678},
+	} {
+		if err := src.GetDB().InsertCostEventRow(ce); err != nil {
+			t.Fatalf("seed cost: %v", err)
+		}
+	}
+
+	// Watcher + watcher events (we need a watcher row first because of FK).
+	if err := src.GetDB().SaveWatcher(&statedb.WatcherRow{
+		ID: "wid-1", Name: "watch-a", Type: "github", ConfigPath: "/tmp/w.toml",
+		Status: "running", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed watcher: %v", err)
+	}
+	if err := dst.GetDB().SaveWatcher(&statedb.WatcherRow{
+		ID: "wid-1", Name: "watch-a", Type: "github", ConfigPath: "/tmp/w.toml",
+		Status: "running", CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("seed watcher dst: %v", err)
+	}
+	for _, we := range []*statedb.WatcherEventRow{
+		{WatcherID: "wid-1", DedupKey: "d1", Sender: "user", Subject: "hi", SessionID: "sess-cost", CreatedAt: time.Now()},
+		{WatcherID: "wid-1", DedupKey: "d2", Sender: "user", Subject: "yo", TriageSessionID: "sess-cost", CreatedAt: time.Now()},
+	} {
+		if err := src.GetDB().InsertWatcherEventRow(we); err != nil {
+			t.Fatalf("seed watcher event: %v", err)
+		}
+	}
+
+	result, err := MigrateSessionsToProfile("src", "dst", []string{"sess-cost"}, ProfileMigrateOptions{})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if result.MovedCostEvents != 2 {
+		t.Errorf("expected 2 cost events moved, got %d", result.MovedCostEvents)
+	}
+	if result.MovedWatcherEvents != 2 {
+		t.Errorf("expected 2 watcher events moved, got %d", result.MovedWatcherEvents)
+	}
+
+	// Verify dst has the cost rows; src has none.
+	dstCosts, _ := dst.GetDB().LoadCostEventsForSession("sess-cost")
+	if len(dstCosts) != 2 {
+		t.Errorf("dst cost rows: want 2, got %d", len(dstCosts))
+	}
+	srcCosts, _ := src.GetDB().LoadCostEventsForSession("sess-cost")
+	if len(srcCosts) != 0 {
+		t.Errorf("src cost rows should be empty, got %d", len(srcCosts))
+	}
+	dstWE, _ := dst.GetDB().LoadWatcherEventsForSession("sess-cost")
+	if len(dstWE) != 2 {
+		t.Errorf("dst watcher events: want 2, got %d", len(dstWE))
+	}
+	srcWE, _ := src.GetDB().LoadWatcherEventsForSession("sess-cost")
+	if len(srcWE) != 0 {
+		t.Errorf("src watcher events should be empty, got %d", len(srcWE))
+	}
+}
+
+func TestMigrateSessionsToProfile_CreatesMissingGroup(t *testing.T) {
+	src, dst := migrateTestSetup(t, "src", "dst")
+
+	// Source group with metadata; target lacks it.
+	groupPath := "work/api"
+	if err := src.GetDB().SaveGroup(&statedb.GroupRow{
+		Path: groupPath, Name: "api", Expanded: true, Order: 5, DefaultPath: "/var/api",
+	}); err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	row := makeRow("sess-g", "Grouped", groupPath)
+	seedSession(t, src.GetDB(), row)
+
+	result, err := MigrateSessionsToProfile("src", "dst", []string{"sess-g"}, ProfileMigrateOptions{})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if len(result.CreatedGroups) != 1 || result.CreatedGroups[0] != groupPath {
+		t.Errorf("expected CreatedGroups=[%q], got %v", groupPath, result.CreatedGroups)
+	}
+	got, _ := dst.GetDB().LoadGroup(groupPath)
+	if got == nil {
+		t.Fatal("target missing migrated group")
+	}
+	if got.DefaultPath != "/var/api" {
+		t.Errorf("DefaultPath: want /var/api got %q", got.DefaultPath)
+	}
+	if got.Order != 5 {
+		t.Errorf("Order: want 5 got %d", got.Order)
+	}
+}
+
+func TestMigrateSessionsToProfile_RefusesRunning(t *testing.T) {
+	src, _ := migrateTestSetup(t, "src", "dst")
+	row := makeRow("sess-run", "Running", DefaultGroupPath)
+	row.Status = "running"
+	seedSession(t, src.GetDB(), row)
+
+	_, err := MigrateSessionsToProfile("src", "dst", []string{"sess-run"}, ProfileMigrateOptions{})
+	if !errors.Is(err, ErrSessionRunning) {
+		t.Fatalf("want ErrSessionRunning, got %v", err)
+	}
+
+	// Source row must still exist (no partial state).
+	got, _ := src.GetDB().LoadInstanceByID("sess-run")
+	if got == nil {
+		t.Fatal("source row was incorrectly deleted on running-refusal")
+	}
+}
+
+func TestMigrateSessionsToProfile_ForceAllowsRunning(t *testing.T) {
+	src, dst := migrateTestSetup(t, "src", "dst")
+	row := makeRow("sess-run-force", "Running", DefaultGroupPath)
+	row.Status = "running"
+	seedSession(t, src.GetDB(), row)
+
+	if _, err := MigrateSessionsToProfile("src", "dst", []string{"sess-run-force"}, ProfileMigrateOptions{Force: true}); err != nil {
+		t.Fatalf("migrate --force: %v", err)
+	}
+	got, _ := dst.GetDB().LoadInstanceByID("sess-run-force")
+	if got == nil {
+		t.Fatal("target missing forced-migrated session")
+	}
+	if got.Status != "running" {
+		t.Errorf("Status should round-trip even when forcing; got %q", got.Status)
+	}
+	srcRow, _ := src.GetDB().LoadInstanceByID("sess-run-force")
+	if srcRow != nil {
+		t.Error("source still has row after force migration")
+	}
+}
+
+func TestMigrateSessionsToProfile_RefusesMissingTargetProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTDECK_PROFILE", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	// Create source only.
+	src, err := NewStorageWithProfile("src")
+	if err != nil {
+		t.Fatalf("open src: %v", err)
+	}
+	defer src.Close()
+
+	_, err = MigrateSessionsToProfile("src", "phantom", []string{"any"}, ProfileMigrateOptions{})
+	if !errors.Is(err, ErrProfileMissing) {
+		t.Fatalf("want ErrProfileMissing, got %v", err)
+	}
+}
+
+func TestMigrateSessionsToProfile_RefusesSameProfile(t *testing.T) {
+	migrateTestSetup(t, "src", "dst")
+	_, err := MigrateSessionsToProfile("same", "same", []string{"x"}, ProfileMigrateOptions{})
+	if !errors.Is(err, ErrSameProfile) {
+		t.Fatalf("want ErrSameProfile, got %v", err)
+	}
+}
+
+func TestMigrateSessionsToProfile_Idempotent(t *testing.T) {
+	src, dst := migrateTestSetup(t, "src", "dst")
+	row := makeRow("sess-idem", "Idem", DefaultGroupPath)
+	seedSession(t, src.GetDB(), row)
+
+	if _, err := MigrateSessionsToProfile("src", "dst", []string{"sess-idem"}, ProfileMigrateOptions{}); err != nil {
+		t.Fatalf("first migrate: %v", err)
+	}
+	// Re-run: source is empty, target has the row — must succeed as a no-op.
+	result, err := MigrateSessionsToProfile("src", "dst", []string{"sess-idem"}, ProfileMigrateOptions{})
+	if err != nil {
+		t.Fatalf("second migrate (idempotent): %v", err)
+	}
+	if len(result.SkippedIdempotent) != 1 {
+		t.Errorf("expected SkippedIdempotent=[sess-idem], got %v", result.SkippedIdempotent)
+	}
+	got, _ := dst.GetDB().LoadInstanceByID("sess-idem")
+	if got == nil {
+		t.Fatal("dst row vanished on idempotent re-run")
+	}
+}
+
+func TestMigrateConductorToProfile_MovesChildren(t *testing.T) {
+	src, dst := migrateTestSetup(t, "src", "dst")
+
+	// Conductor + 2 workers under it.
+	conductor := makeRow("cond-1", ConductorSessionTitle("alpha"), DefaultGroupPath)
+	conductor.IsConductor = true
+	conductor.ParentSessionID = ""
+	seedSession(t, src.GetDB(), conductor)
+	for _, id := range []string{"worker-a", "worker-b"} {
+		w := makeRow(id, "worker-"+id, DefaultGroupPath)
+		w.ParentSessionID = "cond-1"
+		seedSession(t, src.GetDB(), w)
+	}
+
+	// Pre-create meta.json so the helper has something to rewrite.
+	if err := SaveConductorMeta(&ConductorMeta{
+		Name:    "alpha",
+		Agent:   ConductorAgentClaude,
+		Profile: "src",
+	}); err != nil {
+		t.Fatalf("seed conductor meta: %v", err)
+	}
+
+	result, err := MigrateConductorToProfile("alpha", "src", "dst", ProfileMigrateOptions{})
+	if err != nil {
+		t.Fatalf("migrate conductor: %v", err)
+	}
+	if len(result.MovedSessionIDs) != 3 {
+		t.Errorf("expected 3 sessions moved (conductor+2 workers), got %d (%v)", len(result.MovedSessionIDs), result.MovedSessionIDs)
+	}
+	if !result.MetaUpdated {
+		t.Error("MetaUpdated should be true")
+	}
+
+	// All three should be at dst, none at src.
+	for _, id := range []string{"cond-1", "worker-a", "worker-b"} {
+		if r, _ := dst.GetDB().LoadInstanceByID(id); r == nil {
+			t.Errorf("dst missing migrated id %q", id)
+		}
+		if r, _ := src.GetDB().LoadInstanceByID(id); r != nil {
+			t.Errorf("src still has migrated id %q", id)
+		}
+	}
+
+	// Verify meta.json was rewritten.
+	got, err := LoadConductorMeta("alpha")
+	if err != nil {
+		t.Fatalf("reload meta: %v", err)
+	}
+	if got.Profile != "dst" {
+		t.Errorf("meta.json profile: want dst got %q", got.Profile)
+	}
+}
+
+func TestMigrateConductorToProfile_AtomicMetaWriteNoTempLeftover(t *testing.T) {
+	src, _ := migrateTestSetup(t, "src", "dst")
+
+	cond := makeRow("c2", ConductorSessionTitle("beta"), DefaultGroupPath)
+	cond.IsConductor = true
+	seedSession(t, src.GetDB(), cond)
+	if err := SaveConductorMeta(&ConductorMeta{
+		Name: "beta", Agent: ConductorAgentClaude, Profile: "src",
+	}); err != nil {
+		t.Fatalf("seed meta: %v", err)
+	}
+
+	if _, err := MigrateConductorToProfile("beta", "src", "dst", ProfileMigrateOptions{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	dir, _ := ConductorNameDir("beta")
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "meta.json.tmp.") {
+			t.Errorf("atomic write left a temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestMigrateGroupToProfile_BatchMovesEverything(t *testing.T) {
+	src, dst := migrateTestSetup(t, "src", "dst")
+
+	groupPath := "work/api"
+	if err := src.GetDB().SaveGroup(&statedb.GroupRow{
+		Path: groupPath, Name: "api", Expanded: true, Order: 3,
+	}); err != nil {
+		t.Fatalf("seed group: %v", err)
+	}
+	for _, id := range []string{"g-1", "g-2", "g-3"} {
+		seedSession(t, src.GetDB(), makeRow(id, id, groupPath))
+	}
+	// Plus a session in a different group — must NOT migrate.
+	otherRow := makeRow("other-1", "other", "elsewhere")
+	if err := src.GetDB().SaveGroup(&statedb.GroupRow{Path: "elsewhere", Name: "elsewhere", Expanded: true}); err != nil {
+		t.Fatalf("seed other group: %v", err)
+	}
+	seedSession(t, src.GetDB(), otherRow)
+
+	result, err := MigrateGroupToProfile(groupPath, "src", "dst", ProfileMigrateOptions{})
+	if err != nil {
+		t.Fatalf("migrate group: %v", err)
+	}
+	if len(result.MovedSessionIDs) != 3 {
+		t.Errorf("expected 3 sessions moved, got %d", len(result.MovedSessionIDs))
+	}
+	for _, id := range []string{"g-1", "g-2", "g-3"} {
+		if r, _ := dst.GetDB().LoadInstanceByID(id); r == nil {
+			t.Errorf("dst missing %q", id)
+		}
+		if r, _ := src.GetDB().LoadInstanceByID(id); r != nil {
+			t.Errorf("src still has %q", id)
+		}
+	}
+	// Untouched session.
+	if r, _ := src.GetDB().LoadInstanceByID("other-1"); r == nil {
+		t.Error("group-scoped migration should not touch other-1")
+	}
+	if r, _ := dst.GetDB().LoadInstanceByID("other-1"); r != nil {
+		t.Error("group-scoped migration leaked other-1 to dst")
+	}
+}
+
+// TestMigrateSessionsToProfile_ConcurrentDifferentSessions exercises
+// withBusyRetry: two goroutines migrate different sessions into the same dst
+// at the same time. Both must succeed.
+func TestMigrateSessionsToProfile_ConcurrentDifferentSessions(t *testing.T) {
+	src, dst := migrateTestSetup(t, "src", "dst")
+	for _, id := range []string{"par-1", "par-2"} {
+		seedSession(t, src.GetDB(), makeRow(id, id, DefaultGroupPath))
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for _, id := range []string{"par-1", "par-2"} {
+		id := id
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := MigrateSessionsToProfile("src", "dst", []string{id}, ProfileMigrateOptions{})
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent migrate failed: %v", err)
+		}
+	}
+	for _, id := range []string{"par-1", "par-2"} {
+		if r, _ := dst.GetDB().LoadInstanceByID(id); r == nil {
+			t.Errorf("dst missing %q after concurrent migrate", id)
+		}
+	}
+}
+
+// Sanity check: the helper that pre-validates target existence rejects a
+// directory-without-state.db case.
+func TestRequireProfileExists_RejectsBareDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Create a profile directory but no state.db inside.
+	dir, _ := GetProfileDir("phantom")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := requireProfileExists("phantom"); !errors.Is(err, ErrProfileMissing) {
+		t.Errorf("want ErrProfileMissing, got %v", err)
+	}
+	// Sanity: a real state.db is accepted.
+	if _, err := os.Create(filepath.Join(dir, "state.db")); err != nil {
+		t.Fatalf("touch state.db: %v", err)
+	}
+	if err := requireProfileExists("phantom"); err != nil {
+		t.Errorf("want nil, got %v", err)
+	}
+}

--- a/internal/statedb/migrate_xfer.go
+++ b/internal/statedb/migrate_xfer.go
@@ -1,0 +1,375 @@
+package statedb
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Low-level helpers used by the cross-profile migration code in
+// internal/session/profile_migrate.go (issue #928). They are deliberately
+// small wrappers over single-row SQL: the migration orchestrator composes
+// them into a target-write-then-source-delete sequence with best-effort
+// rollback. Each writer is wrapped in withBusyRetry because cross-profile
+// moves race against background heartbeat/status writers on the source DB.
+
+// LoadInstanceByID returns the row with the given id, or (nil, nil) if it
+// does not exist. Any other error (driver, schema, etc.) is returned as-is.
+func (s *StateDB) LoadInstanceByID(id string) (*InstanceRow, error) {
+	row := &InstanceRow{}
+	var createdUnix, accessedUnix int64
+	var toolDataStr string
+	var isConductorInt, noTransitionNotifyInt, titleLockedInt int
+	err := s.db.QueryRow(`
+		SELECT id, title, project_path, group_path, sort_order,
+			command, wrapper, tool, status, tmux_session, tmux_socket_name,
+			created_at, last_accessed,
+			parent_session_id, is_conductor, no_transition_notify,
+			worktree_path, worktree_repo, worktree_branch,
+			tool_data, title_locked
+		FROM instances WHERE id = ?
+	`, id).Scan(
+		&row.ID, &row.Title, &row.ProjectPath, &row.GroupPath, &row.Order,
+		&row.Command, &row.Wrapper, &row.Tool, &row.Status, &row.TmuxSession, &row.TmuxSocketName,
+		&createdUnix, &accessedUnix,
+		&row.ParentSessionID, &isConductorInt, &noTransitionNotifyInt,
+		&row.WorktreePath, &row.WorktreeRepo, &row.WorktreeBranch,
+		&toolDataStr, &titleLockedInt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	row.CreatedAt = time.Unix(createdUnix, 0)
+	if accessedUnix > 0 {
+		row.LastAccessed = time.Unix(accessedUnix, 0)
+	}
+	row.IsConductor = isConductorInt != 0
+	row.NoTransitionNotify = noTransitionNotifyInt != 0
+	row.TitleLocked = titleLockedInt != 0
+	row.ToolData = json.RawMessage(toolDataStr)
+	return row, nil
+}
+
+// LoadInstanceChildren returns rows whose parent_session_id matches the given id.
+func (s *StateDB) LoadInstanceChildren(parentID string) ([]*InstanceRow, error) {
+	rows, err := s.db.Query(`
+		SELECT id, title, project_path, group_path, sort_order,
+			command, wrapper, tool, status, tmux_session, tmux_socket_name,
+			created_at, last_accessed,
+			parent_session_id, is_conductor, no_transition_notify,
+			worktree_path, worktree_repo, worktree_branch,
+			tool_data, title_locked
+		FROM instances WHERE parent_session_id = ? ORDER BY sort_order
+	`, parentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*InstanceRow
+	for rows.Next() {
+		r := &InstanceRow{}
+		var createdUnix, accessedUnix int64
+		var toolDataStr string
+		var isConductorInt, noTransitionNotifyInt, titleLockedInt int
+		if err := rows.Scan(
+			&r.ID, &r.Title, &r.ProjectPath, &r.GroupPath, &r.Order,
+			&r.Command, &r.Wrapper, &r.Tool, &r.Status, &r.TmuxSession, &r.TmuxSocketName,
+			&createdUnix, &accessedUnix,
+			&r.ParentSessionID, &isConductorInt, &noTransitionNotifyInt,
+			&r.WorktreePath, &r.WorktreeRepo, &r.WorktreeBranch,
+			&toolDataStr, &titleLockedInt,
+		); err != nil {
+			return nil, err
+		}
+		r.CreatedAt = time.Unix(createdUnix, 0)
+		if accessedUnix > 0 {
+			r.LastAccessed = time.Unix(accessedUnix, 0)
+		}
+		r.IsConductor = isConductorInt != 0
+		r.NoTransitionNotify = noTransitionNotifyInt != 0
+		r.TitleLocked = titleLockedInt != 0
+		r.ToolData = json.RawMessage(toolDataStr)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// LoadInstancesByGroup returns rows whose group_path exactly matches the given path.
+func (s *StateDB) LoadInstancesByGroup(groupPath string) ([]*InstanceRow, error) {
+	rows, err := s.db.Query(`
+		SELECT id, title, project_path, group_path, sort_order,
+			command, wrapper, tool, status, tmux_session, tmux_socket_name,
+			created_at, last_accessed,
+			parent_session_id, is_conductor, no_transition_notify,
+			worktree_path, worktree_repo, worktree_branch,
+			tool_data, title_locked
+		FROM instances WHERE group_path = ? ORDER BY sort_order
+	`, groupPath)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*InstanceRow
+	for rows.Next() {
+		r := &InstanceRow{}
+		var createdUnix, accessedUnix int64
+		var toolDataStr string
+		var isConductorInt, noTransitionNotifyInt, titleLockedInt int
+		if err := rows.Scan(
+			&r.ID, &r.Title, &r.ProjectPath, &r.GroupPath, &r.Order,
+			&r.Command, &r.Wrapper, &r.Tool, &r.Status, &r.TmuxSession, &r.TmuxSocketName,
+			&createdUnix, &accessedUnix,
+			&r.ParentSessionID, &isConductorInt, &noTransitionNotifyInt,
+			&r.WorktreePath, &r.WorktreeRepo, &r.WorktreeBranch,
+			&toolDataStr, &titleLockedInt,
+		); err != nil {
+			return nil, err
+		}
+		r.CreatedAt = time.Unix(createdUnix, 0)
+		if accessedUnix > 0 {
+			r.LastAccessed = time.Unix(accessedUnix, 0)
+		}
+		r.IsConductor = isConductorInt != 0
+		r.NoTransitionNotify = noTransitionNotifyInt != 0
+		r.TitleLocked = titleLockedInt != 0
+		r.ToolData = json.RawMessage(toolDataStr)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// InsertInstanceRow inserts (or replaces) a single instance row. Unlike
+// SaveInstance it does not merge tool_data extras — cross-profile migration
+// is a verbatim transfer and the caller has already prepared the row.
+func (s *StateDB) InsertInstanceRow(inst *InstanceRow) error {
+	toolData := inst.ToolData
+	if len(toolData) == 0 {
+		toolData = json.RawMessage("{}")
+	}
+	isConductorInt := 0
+	if inst.IsConductor {
+		isConductorInt = 1
+	}
+	noTransitionNotifyInt := 0
+	if inst.NoTransitionNotify {
+		noTransitionNotifyInt = 1
+	}
+	titleLockedInt := 0
+	if inst.TitleLocked {
+		titleLockedInt = 1
+	}
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(`
+			INSERT OR REPLACE INTO instances (
+				id, title, project_path, group_path, sort_order,
+				command, wrapper, tool, status, tmux_session, tmux_socket_name,
+				created_at, last_accessed,
+				parent_session_id, is_conductor, no_transition_notify,
+				worktree_path, worktree_repo, worktree_branch,
+				tool_data, title_locked
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`,
+			inst.ID, inst.Title, inst.ProjectPath, inst.GroupPath, inst.Order,
+			inst.Command, inst.Wrapper, inst.Tool, inst.Status, inst.TmuxSession, inst.TmuxSocketName,
+			inst.CreatedAt.Unix(), instLastAccessedUnix(inst),
+			inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
+			inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch,
+			string(toolData), titleLockedInt,
+		)
+		return err
+	})
+}
+
+// DeleteInstanceRow removes a single row by ID. Cost / watcher rows are NOT
+// touched — those are deleted explicitly by the migration so the orchestrator
+// can sequence cleanup with the target-write phase.
+func (s *StateDB) DeleteInstanceRow(id string) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(`DELETE FROM instances WHERE id = ?`, id)
+		return err
+	})
+}
+
+// --- cost_events round-trip ---
+
+// LoadCostEventsForSession returns every cost_events row matching session_id.
+// Timestamp is preserved verbatim as TEXT — we can't reliably round-trip
+// through time.Time without risking timezone drift.
+func (s *StateDB) LoadCostEventsForSession(sessionID string) ([]*CostEventRow, error) {
+	rows, err := s.db.Query(`
+		SELECT id, session_id, timestamp, model,
+			input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+			cost_microdollars, budget_stop_triggered
+		FROM cost_events WHERE session_id = ?
+	`, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*CostEventRow
+	for rows.Next() {
+		r := &CostEventRow{}
+		var budgetStop int
+		if err := rows.Scan(
+			&r.ID, &r.SessionID, &r.Timestamp, &r.Model,
+			&r.InputTokens, &r.OutputTokens, &r.CacheReadTokens, &r.CacheWriteTokens,
+			&r.CostMicrodollars, &budgetStop,
+		); err != nil {
+			return nil, err
+		}
+		r.BudgetStopTriggered = budgetStop != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// InsertCostEventRow inserts a single cost_events row verbatim, preserving id
+// (which is also the dedup key in costs.WriteCostEvent — using INSERT OR
+// IGNORE makes the migration safely retriable).
+func (s *StateDB) InsertCostEventRow(ev *CostEventRow) error {
+	budgetStop := 0
+	if ev.BudgetStopTriggered {
+		budgetStop = 1
+	}
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(`
+			INSERT OR IGNORE INTO cost_events (
+				id, session_id, timestamp, model,
+				input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+				cost_microdollars, budget_stop_triggered
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`,
+			ev.ID, ev.SessionID, ev.Timestamp, ev.Model,
+			ev.InputTokens, ev.OutputTokens, ev.CacheReadTokens, ev.CacheWriteTokens,
+			ev.CostMicrodollars, budgetStop,
+		)
+		return err
+	})
+}
+
+// DeleteCostEventsForSession removes every cost_events row matching session_id.
+func (s *StateDB) DeleteCostEventsForSession(sessionID string) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(`DELETE FROM cost_events WHERE session_id = ?`, sessionID)
+		return err
+	})
+}
+
+// --- watcher_events round-trip ---
+
+// LoadWatcherEventsForSession returns every watcher_events row whose
+// session_id OR triage_session_id matches sessionID. The dual match preserves
+// triage links when migrating a triage target.
+func (s *StateDB) LoadWatcherEventsForSession(sessionID string) ([]*WatcherEventRow, error) {
+	rows, err := s.db.Query(`
+		SELECT id, watcher_id, dedup_key, sender, subject, routed_to,
+			session_id, triage_session_id, created_at
+		FROM watcher_events WHERE session_id = ? OR triage_session_id = ?
+	`, sessionID, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*WatcherEventRow
+	for rows.Next() {
+		var r WatcherEventRow
+		var createdAt int64
+		if err := rows.Scan(
+			&r.ID, &r.WatcherID, &r.DedupKey, &r.Sender, &r.Subject, &r.RoutedTo,
+			&r.SessionID, &r.TriageSessionID, &createdAt,
+		); err != nil {
+			return nil, err
+		}
+		r.CreatedAt = time.Unix(createdAt, 0)
+		out = append(out, &r)
+	}
+	return out, rows.Err()
+}
+
+// InsertWatcherEventRow inserts a watcher_events row with INSERT OR IGNORE
+// against the (watcher_id, dedup_key) UNIQUE constraint — safe to retry.
+// Note: the source row's `id` (auto-increment) is intentionally NOT preserved;
+// the unique constraint is what dedupes across DBs.
+func (s *StateDB) InsertWatcherEventRow(ev *WatcherEventRow) error {
+	createdAt := ev.CreatedAt.Unix()
+	if createdAt <= 0 {
+		createdAt = time.Now().Unix()
+	}
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(`
+			INSERT OR IGNORE INTO watcher_events (
+				watcher_id, dedup_key, sender, subject, routed_to,
+				session_id, triage_session_id, created_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`,
+			ev.WatcherID, ev.DedupKey, ev.Sender, ev.Subject, ev.RoutedTo,
+			ev.SessionID, ev.TriageSessionID, createdAt,
+		)
+		return err
+	})
+}
+
+// DeleteWatcherEventsForSession removes watcher_events rows whose session_id
+// OR triage_session_id matches the given sessionID.
+func (s *StateDB) DeleteWatcherEventsForSession(sessionID string) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(
+			`DELETE FROM watcher_events WHERE session_id = ? OR triage_session_id = ?`,
+			sessionID, sessionID,
+		)
+		return err
+	})
+}
+
+// --- group round-trip ---
+
+// LoadGroup returns the row for the given path, or (nil, nil) if absent.
+func (s *StateDB) LoadGroup(path string) (*GroupRow, error) {
+	var g GroupRow
+	var expanded int
+	err := s.db.QueryRow(`
+		SELECT path, name, expanded, sort_order, default_path
+		FROM groups WHERE path = ?
+	`, path).Scan(&g.Path, &g.Name, &expanded, &g.Order, &g.DefaultPath)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	g.Expanded = expanded != 0
+	return &g, nil
+}
+
+// SaveGroup inserts or replaces a single group row.
+func (s *StateDB) SaveGroup(g *GroupRow) error {
+	if g == nil || g.Path == "" {
+		return fmt.Errorf("statedb: SaveGroup requires non-empty path")
+	}
+	expanded := 0
+	if g.Expanded {
+		expanded = 1
+	}
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(`
+			INSERT OR REPLACE INTO groups (path, name, expanded, sort_order, default_path)
+			VALUES (?, ?, ?, ?, ?)
+		`, g.Path, g.Name, expanded, g.Order, g.DefaultPath)
+		return err
+	})
+}
+
+// instLastAccessedUnix returns LastAccessed as a unix timestamp, or 0 if zero.
+// SaveInstance uses .Unix() directly which surfaces -6795364578871 for the
+// zero time — avoid that for cross-profile migration so rows look natural in
+// the destination DB.
+func instLastAccessedUnix(inst *InstanceRow) int64 {
+	if inst.LastAccessed.IsZero() {
+		return 0
+	}
+	return inst.LastAccessed.Unix()
+}

--- a/internal/statedb/migrate_xfer.go
+++ b/internal/statedb/migrate_xfer.go
@@ -325,6 +325,28 @@ func (s *StateDB) DeleteWatcherEventsForSession(sessionID string) error {
 	})
 }
 
+// LoadWatcherByID returns the watcher row with the given id, or (nil, nil)
+// if absent. Used by cross-profile migration to copy referenced watcher rows
+// from src to dst before inserting watcher_events (the events table FK-
+// references watchers(id) with foreign_keys=on).
+func (s *StateDB) LoadWatcherByID(id string) (*WatcherRow, error) {
+	var w WatcherRow
+	var createdAt, updatedAt int64
+	err := s.db.QueryRow(`
+		SELECT id, name, type, config_path, status, conductor, created_at, updated_at
+		FROM watchers WHERE id = ?
+	`, id).Scan(&w.ID, &w.Name, &w.Type, &w.ConfigPath, &w.Status, &w.Conductor, &createdAt, &updatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	w.CreatedAt = time.Unix(createdAt, 0)
+	w.UpdatedAt = time.Unix(updatedAt, 0)
+	return &w, nil
+}
+
 // --- group round-trip ---
 
 // LoadGroup returns the row for the given path, or (nil, nil) if absent.

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -110,14 +110,32 @@ type WatcherRow struct {
 
 // WatcherEventRow represents a single event row from the watcher_events table.
 type WatcherEventRow struct {
-	ID        int64
-	WatcherID string
-	DedupKey  string
-	Sender    string
-	Subject   string
-	RoutedTo  string
-	SessionID string
-	CreatedAt time.Time
+	ID              int64
+	WatcherID       string
+	DedupKey        string
+	Sender          string
+	Subject         string
+	RoutedTo        string
+	SessionID       string
+	TriageSessionID string
+	CreatedAt       time.Time
+}
+
+// CostEventRow mirrors the cost_events table for raw round-trip operations
+// (e.g., cross-profile migration). The canonical CostEvent type lives in
+// internal/costs, but we keep this minimal struct here so the statedb package
+// can read/write rows without a circular import.
+type CostEventRow struct {
+	ID                  string
+	SessionID           string
+	Timestamp           string // RFC3339; preserve verbatim — cost_events stores TEXT
+	Model               string
+	InputTokens         int64
+	OutputTokens        int64
+	CacheReadTokens     int64
+	CacheWriteTokens    int64
+	CostMicrodollars    int64
+	BudgetStopTriggered bool
 }
 
 // GroupRow represents a group row in the database.


### PR DESCRIPTION
## Summary

Resolves #928. Adds three new CLI surfaces for relocating data between profile DBs — previously only possible by hand-editing SQLite + `meta.json`:

- `agent-deck session move <id> --to-profile <name> [--force]`
- `agent-deck conductor move <name> --to-profile <name> [--force]` — moves conductor session + every child worker + atomically rewrites `meta.json`
- `agent-deck group move <group> --to-profile <name> [--force]` — batch

The orchestrator (`internal/session/profile_migrate.go`) is `target-write-then-source-delete`, with best-effort rollback if source-delete fails after target-insert. `cost_events` and `watcher_events` (matched on both `session_id` and `triage_session_id`) travel with each session, group rows are auto-created in the destination, and every state.db write is wrapped in the existing `withBusyRetry` helper.

**Behavior decisions** (clarified with the requester):
- Running sessions are refused; `--force` overrides at the user's risk.
- Conductor scope moves conductor + all children (`parent_session_id == conductor.id`).
- Missing target profile is refused (typo safety); user must bootstrap with `--profile <name>` first.
- Re-running is idempotent.

## Test plan

- [x] New unit tests (`internal/session/profile_migrate_test.go`, 11 cases): preserves-all-fields, cost/watcher events, group creation, running-refusal + force, missing/same profile, idempotency, conductor children + atomic meta, group batch, concurrent migrations
- [x] New CLI subprocess tests (`cmd/agent-deck/profile_migrate_cli_test.go`, 6 cases)
- [x] CLAUDE.md mandates: `TestPerGroupConfig_*`, `TestPersistence_*`, watcher framework (both `internal/watcher` and `cmd/agent-deck -run Watcher`)
- [x] Full `internal/statedb`, `internal/costs`, `cmd/agent-deck` suites (race + count=1)
- [x] Full `internal/session` suite — passes excluding 3 pre-existing date/timing-flaky tests unrelated to this change (`TestBuildCodexCommand_CustomWrapperPreservesToolIdentity` hardcodes a 2026-04-24 rollout path; `TestLifecycle_StoppedRestartedRunningError` and `TestStatusCycle_ShellSessionWithCommand` are timing-sensitive)
- [x] Eval harness: confirmed not in scope per `tests/eval/README.md` (no tmux/disclosure/TUI surface)