### PR TITLE
feat(session): add --draft flag to session send without submitting

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1649,6 +1649,7 @@ func handleSessionSend(profile string, args []string) {
 	noWait := fs.Bool("no-wait", false, "Don't wait for agent to be ready (send immediately)")
 	wait := fs.Bool("wait", false, "Block until agent finishes processing, then print output")
 	stream := fs.Bool("stream", false, "Stream JSONL events (Claude only) to stdout instead of returning a snapshot")
+	draft := fs.Bool("draft", false, "Pre-fill the prompt without submitting (incompatible with --wait/--stream/--no-wait)")
 	timeout := fs.Duration("timeout", 10*time.Minute, "Max time to wait for completion (used with --wait)")
 	streamIdle := fs.Duration("stream-idle", 10*time.Second, "Max idle time before --stream aborts with error")
 	streamCharBudget := fs.Int("stream-char-budget", 4000, "Char budget for text flush in --stream mode")
@@ -1667,6 +1668,7 @@ func handleSessionSend(profile string, args []string) {
 		fmt.Println("  agent-deck session send my-project \"run tests\" --wait")
 		fmt.Println("  agent-deck session send my-project \"quick ping\" --no-wait")
 		fmt.Println("  agent-deck session send my-project \"trace progress\" --stream")
+		fmt.Println("  agent-deck session send my-project \"cwd: /path/to/dir\" --draft")
 	}
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
@@ -1684,6 +1686,11 @@ func handleSessionSend(profile string, args []string) {
 
 	if *stream && *wait {
 		out.Error("--stream and --wait are mutually exclusive", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	if *draft && (*wait || *stream || *noWait) {
+		out.Error("--draft is incompatible with --wait, --stream, and --no-wait", ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
 
@@ -1741,6 +1748,22 @@ func handleSessionSend(profile string, args []string) {
 	// Record send time before the actual send so we can verify output freshness.
 	// Captured early to avoid false negatives from clock skew.
 	sentAt := time.Now()
+
+	// --draft: type text into the prompt without pressing Enter, letting the
+	// user review and submit manually.
+	if *draft {
+		if err := executeDraft(tmuxSess, message); err != nil {
+			out.Error(fmt.Sprintf("failed to pre-fill prompt: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		out.Success(fmt.Sprintf("Pre-filled prompt in '%s'", inst.Title), map[string]interface{}{
+			"success":       true,
+			"session_id":    inst.ID,
+			"session_title": inst.Title,
+			"message":       message,
+		})
+		return
+	}
 
 	// Send message atomically (text + Enter in single tmux invocation).
 	// --no-wait: skip full readiness waiting, but run a capped preflight
@@ -1845,6 +1868,16 @@ func defaultSendOptions() sendRetryOptions {
 // doesn't start processing within a reasonable time.
 func sendWithRetry(tmuxSess *tmux.Session, message string, skipVerify bool) error {
 	return sendWithRetryTarget(tmuxSess, message, skipVerify, defaultSendOptions())
+}
+
+// draftSender is implemented by *tmux.Session for the --draft path.
+type draftSender interface {
+	SendKeysChunked(string) error
+}
+
+// executeDraft pre-fills the prompt without pressing Enter.
+func executeDraft(target draftSender, message string) error {
+	return target.SendKeysChunked(message)
 }
 
 // noWaitSendOptions returns the verification-loop options used by the

--- a/cmd/agent-deck/session_send_test.go
+++ b/cmd/agent-deck/session_send_test.go
@@ -701,6 +701,40 @@ func TestSendWithRetryTarget_NoWaitDoesNotResend(t *testing.T) {
 	}
 }
 
+// TestExecuteDraft_SendsKeysWithoutEnter verifies --draft calls SendKeysChunked
+// with the message and does not press Enter.
+func TestExecuteDraft_SendsKeysWithoutEnter(t *testing.T) {
+	mock := &mockDraftSender{}
+	err := executeDraft(mock, "my draft message")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mock.calledWith != "my draft message" {
+		t.Errorf("expected SendKeysChunked called with %q, got %q", "my draft message", mock.calledWith)
+	}
+}
+
+func TestExecuteDraft_PropagatesError(t *testing.T) {
+	mock := &mockDraftSender{err: fmt.Errorf("tmux send failed")}
+	err := executeDraft(mock, "hello")
+	if err == nil {
+		t.Fatal("expected error from SendKeysChunked, got nil")
+	}
+	if !strings.Contains(err.Error(), "tmux send failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+type mockDraftSender struct {
+	calledWith string
+	err        error
+}
+
+func (m *mockDraftSender) SendKeysChunked(keys string) error {
+	m.calledWith = keys
+	return m.err
+}
+
 // skipIfNoTmuxServer skips the test if tmux is not available or not running.
 func skipIfNoTmuxServer(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
Pre-fills the Claude Code prompt without pressing Enter, letting the user review and submit manually. Useful for scripts that inject context into a running session.