### PR TITLE
fix(mcppool): v1.9.0 release blocker — close FD leak + race in HTTPServer.Start, surface inner exit from systemd-run

### DIFF
--- a/internal/mcppool/http_server.go
+++ b/internal/mcppool/http_server.go
@@ -315,11 +315,30 @@ func (s *HTTPServer) Start() error {
 
 	// Wait for server to become ready
 	if err := s.waitReady(); err != nil {
-		// Process may have already exited
-		s.SetStatus(StatusFailed)
+		// Caller has no Stop() path on a failed Start, so we must
+		// clean up the child + log FD ourselves here. Without this,
+		// every Start cycle of an unhealthy MCP leaked one log FD
+		// (TestHTTPServer_Start_FailingCommand_NoFDLeak, v1.9
+		// release blocker). Kill, then wait on processDone (closed
+		// by monitorProcess after Wait()) before closing logWriter
+		// so the child's stderr can't write into a closed file.
+		if proc != nil && proc.Process != nil {
+			_ = proc.Process.Kill()
+		}
+		if done != nil {
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				httpLog.Warn("waitready_reap_timeout",
+					slog.String("mcp", s.name))
+			}
+		}
+		_ = logWriter.Close()
 		s.mu.Lock()
+		s.logWriter = nil
 		s.lastError = err
 		s.mu.Unlock()
+		s.SetStatus(StatusFailed)
 		return fmt.Errorf("HTTP server %s failed to become ready: %w", s.name, err)
 	}
 
@@ -404,14 +423,24 @@ func (s *HTTPServer) waitReady() error {
 	pollInterval := 100 * time.Millisecond
 	deadline := time.Now().Add(s.startupTimeout)
 
+	// Snapshot the per-spawn done channel. monitorProcess closes it after
+	// Wait() returns, so it is the Wait-safe signal that the child exited.
+	// Reading s.process.ProcessState directly races with Wait()'s write to
+	// that field (see killLeftoverProcess comment for the same pattern).
+	s.mu.RLock()
+	done := s.processDone
+	s.mu.RUnlock()
+
 	for time.Now().Before(deadline) {
-		// Check if process exited
-		s.mu.RLock()
-		if s.process != nil && s.process.ProcessState != nil {
-			s.mu.RUnlock()
-			return fmt.Errorf("process exited before becoming ready")
+		// Check if process exited via the done channel — no race with
+		// the monitor goroutine's Wait().
+		if done != nil {
+			select {
+			case <-done:
+				return fmt.Errorf("process exited before becoming ready")
+			default:
+			}
 		}
-		s.mu.RUnlock()
 
 		// Check if URL is reachable
 		if s.isURLReachable() {

--- a/internal/mcppool/socket_proxy.go
+++ b/internal/mcppool/socket_proxy.go
@@ -204,6 +204,16 @@ func (p *SocketProxy) Start() error {
 		return nil
 	}
 
+	// Validate the inner MCP command exists before wrapping with
+	// systemd-run. When isolation is on, exec.Cmd.Start() runs
+	// systemd-run (which always exists) and the inner exec failure
+	// surfaces asynchronously inside the scope — Start() would
+	// otherwise return nil for a bogus command. (#902 regression;
+	// v1.9 release blocker.)
+	if _, err := exec.LookPath(p.command); err != nil {
+		return err
+	}
+
 	logDir := filepath.Join(os.Getenv("HOME"), ".agent-deck", "logs", "mcppool")
 	_ = os.MkdirAll(logDir, 0700)
 	p.logFile = filepath.Join(logDir, fmt.Sprintf("%s_socket.log", p.name))

--- a/internal/profile/precedence_test.go
+++ b/internal/profile/precedence_test.go
@@ -94,21 +94,21 @@ func TestProfileResolution_LiteralDefaultFloor(t *testing.T) {
 // prof-002: the full precedence ladder.
 //
 // Documented in config.go:301-336:
-//   1. explicit (passed-through arg, e.g. -p flag)
-//   2. AGENTDECK_PROFILE env
-//   3. CLAUDE_CONFIG_DIR-inferred
-//   4. config.json default_profile
-//   5. literal "default"
+//  1. explicit (passed-through arg, e.g. -p flag)
+//  2. AGENTDECK_PROFILE env
+//  3. CLAUDE_CONFIG_DIR-inferred
+//  4. config.json default_profile
+//  5. literal "default"
 //
 // A regression that re-orders any of these has the same visible symptom
 // (wrong profile) but very different blast radii. This table-driven case
 // nails every transition so a re-order can't go in unnoticed.
 func TestProfileResolution_PrecedenceLadder(t *testing.T) {
 	type env struct {
-		explicit       string
-		agentdeckProf  string
+		explicit        string
+		agentdeckProf   string
 		claudeConfigDir string
-		configDefault  string // "" means do not write config.json
+		configDefault   string // "" means do not write config.json
 	}
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

v1.9.0 release was blocked because `internal/mcppool` had two failing tests on `origin/main` after merging #902 (MCP-per-scope spawn) and #904 (MCP respawn dedup). Per-PR CI passed in isolation; combined state regressed.

Per-test log: `/tmp/exec-release-v1.9.0/test-suite.log` (failing tests were `TestSocketProxy_Start_FailingCommand_NoFDLeak` and `TestHTTPServer_Start_FailingCommand_NoFDLeak` under `-race`).

## Bug 1 — SocketProxy.Start swallows missing-binary error (cc44995b)

**Root cause:** #902 wraps the MCP child in `systemd-run --user --scope -- <command>`. Because systemd-run *itself* always exists on PATH, `exec.Cmd.Start()` succeeds even when the inner command (e.g. `/no/such/binary`) is bogus. The inner exec failure surfaces asynchronously inside the scope, **after** Start has already returned `nil`. The test asserted `expected Start to fail for /no/such/binary on cycle 0` — broken.

**Fix:** `socket_proxy.go:207-215` — call `exec.LookPath(p.command)` before the wrap. Restores the pre-#902 fast-fail error shape and runs before any FD allocation. Microseconds on a healthy Start.

**Before:** `expected Start to fail for /no/such/binary on cycle 0`
**After:** `ok  github.com/asheshgoplani/agent-deck/internal/mcppool  1.119s`

## Bug 2 — HTTPServer race on ProcessState + log-FD leak on waitReady fail (b071481e)

**Root cause #1 (race):** #904 introduced `processDone` channel (closed by `monitorProcess` after `Wait()`) so callers wouldn't race `Wait()`'s write to `cmd.ProcessState`. `killLeftoverProcess` adopted it. **`waitReady` was never converted** and still reads `s.process.ProcessState` directly — under `-race`:
```
WARNING: DATA RACE
Write at 0x... by goroutine 21: os/exec.(*Cmd).Wait()  ← http_server.go:301
Previous read at 0x... by goroutine 17: (*HTTPServer).waitReady()  ← http_server.go:410
```

**Root cause #2 (leak):** #902's wrapper means `process.Start()` succeeds for a bogus inner command → `processStarted = true` → existing deferred-close fallback skips the logWriter. `waitReady` correctly detects the immediate exit and returns an error, Start propagates the error — but on a failed Start the caller has no Stop() path, so the log-file FD leaks every cycle. Test grew log FDs by 24-33 across 200 cycles.

**Fixes in `http_server.go`:**
1. **`waitReady` (lines 403-440):** snapshot `s.processDone` under `mu.RLock`, then non-blocking `select` on it instead of reading `s.process.ProcessState`. Same Wait-safe pattern `killLeftoverProcess` already documents.
2. **Start's waitReady-fail branch (lines 318-342):** `proc.Process.Kill()`, wait on `processDone` (2 s safety net), then explicitly `Close` logWriter and clear `s.logWriter`. The existing `processStarted` defer can't help here — once `process.Start` succeeded the child owns `Stderr=logWriter` and we must reap before closing.

**Before:** race detected, 24-33 FD growth across 200 cycles.
**After:**
```
go test -race -count=1 -run TestHTTPServer_Start_FailingCommand_NoFDLeak ./internal/mcppool/
ok   github.com/asheshgoplani/agent-deck/internal/mcppool   21.883s
```

## Full mcppool suite under -race

```
go test -race -count=1 ./internal/mcppool/...
ok   github.com/asheshgoplani/agent-deck/internal/mcppool   25.796s
```

## Full repo suite under -race

```
go test -race -count=1 -timeout 300s ./...
ok   github.com/asheshgoplani/agent-deck/cmd/agent-deck    60.236s
... [all packages OK except chronic costs] ...
ok   github.com/asheshgoplani/agent-deck/internal/mcppool  25.702s
...
FAIL TestStore_TotalLastWeek_OnlyLastWeekEvent — pre-existing chronic
     date-sensitive test, fails identically on origin/main; unrelated to
     mcppool. Acknowledged by the release runbook as the Weekly
     Regression Check cron.
```

## Commits

1. `86f5317c` — chore: `gofmt` drift in `internal/profile/precedence_test.go` (pre-existing whitespace; needed to unblock the pre-commit fmt-check).
2. `cc44995b` — fix Bug 1.
3. `b071481e` — fix Bug 2.

## Hard constraints honored

- No change to #902 or #904 themselves.
- No change to MCP semantics — fixes are pure wiring/lifecycle/concurrency.
- Each bug isolated in its own commit.
- Commits signed `Committed by Ashesh Goplani`; no Claude attribution.

## Test plan

- [x] `go test -race -count=1 -run 'TestSocketProxy_Start_FailingCommand_NoFDLeak|TestHTTPServer_Start_FailingCommand_NoFDLeak' ./internal/mcppool/` — green
- [x] `go test -race -count=1 ./internal/mcppool/...` — green
- [x] `go test -race -count=1 -timeout 300s ./...` — green modulo chronic costs cron
- [ ] **Do not merge** — release-blocker fix; user merges.