### PR TITLE
fix(watcher): load [source] settings from watcher.toml

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -20,6 +20,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/BurntSushi/toml"
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -1978,7 +1979,7 @@ func (h *Home) startWatcherEngine() tea.Cmd {
 		adapterCfg := watcher.AdapterConfig{
 			Type:     row.Type,
 			Name:     row.Name,
-			Settings: map[string]string{},
+			Settings: loadWatcherSourceSettings(row.Name),
 		}
 		eng.RegisterAdapter(row.ID, adapter, adapterCfg, maxSilenceMinutes)
 	}
@@ -1994,6 +1995,29 @@ func (h *Home) startWatcherEngine() tea.Cmd {
 		listenForWatcherEvent(eng.EventCh()),
 		listenForWatcherHealth(eng.HealthCh()),
 	)
+}
+
+// loadWatcherSourceSettings reads the [source] table from
+// ~/.agent-deck/watcher/<name>/watcher.toml into a map[string]string suitable for
+// AdapterConfig.Settings. Returns an empty (non-nil) map on any error so the engine
+// falls back to per-adapter defaults instead of failing to register.
+func loadWatcherSourceSettings(name string) map[string]string {
+	out := map[string]string{}
+	dir, err := session.WatcherNameDir(name)
+	if err != nil {
+		return out
+	}
+	path := filepath.Join(dir, "watcher.toml")
+	var cfg struct {
+		Source map[string]string `toml:"source"`
+	}
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		return out
+	}
+	for k, v := range cfg.Source {
+		out[k] = v
+	}
+	return out
 }
 
 // propagateThemeToSessions updates COLORFGBG in all running tmux sessions

--- a/internal/ui/home_watcher_settings_test.go
+++ b/internal/ui/home_watcher_settings_test.go
@@ -1,0 +1,114 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadWatcherSourceSettings_ReadsSourceTable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	name := "gh-watcher"
+	dir := filepath.Join(home, ".agent-deck", "watcher", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	contents := `[watcher]
+name = "gh-watcher"
+type = "github"
+
+[source]
+secret = "deadbeef"
+port = "19999"
+bind = "127.0.0.1"
+
+[routing]
+conductor = "conductor-github"
+group = "conductor"
+`
+	if err := os.WriteFile(filepath.Join(dir, "watcher.toml"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := loadWatcherSourceSettings(name)
+	want := map[string]string{
+		"secret": "deadbeef",
+		"port":   "19999",
+		"bind":   "127.0.0.1",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d keys, want %d: %v", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("key %q: got %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestLoadWatcherSourceSettings_MissingFileReturnsEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := loadWatcherSourceSettings("does-not-exist")
+	if got == nil {
+		t.Fatal("got nil; want non-nil empty map")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v; want empty map", got)
+	}
+}
+
+func TestLoadWatcherSourceSettings_NoSourceSectionReturnsEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	name := "no-source"
+	dir := filepath.Join(home, ".agent-deck", "watcher", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	contents := `[watcher]
+name = "no-source"
+type = "webhook"
+
+[routing]
+conductor = "conductor-x"
+group = "g"
+`
+	if err := os.WriteFile(filepath.Join(dir, "watcher.toml"), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := loadWatcherSourceSettings(name)
+	if got == nil {
+		t.Fatal("got nil; want non-nil empty map")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v; want empty map", got)
+	}
+}
+
+func TestLoadWatcherSourceSettings_MalformedTOMLReturnsEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	name := "bad-toml"
+	dir := filepath.Join(home, ".agent-deck", "watcher", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "watcher.toml"), []byte("this is not = valid toml ["), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := loadWatcherSourceSettings(name)
+	if got == nil {
+		t.Fatal("got nil; want non-nil empty map")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v; want empty map", got)
+	}
+}


### PR DESCRIPTION
## Summary

The watcher engine's `RegisterAdapter` call in `internal/ui/home.go` passes an empty `Settings` map, so adapter `Setup()` always sees no configuration. This makes the **github adapter unusable** (`adapter_setup_failed: github adapter requires a webhook secret`) and forces webhook/ntfy/slack adapters to silently fall back to defaults regardless of what users put in `~/.agent-deck/watcher/<name>/watcher.toml`.

This PR wires a small `loadWatcherSourceSettings()` helper that reads the `[source]` table from each `watcher.toml` before `RegisterAdapter`, restoring the documented behaviour described in `AdapterConfig.Settings`'s comment (`adapter.go`) and in the `watcher-creator` skill's TOML template.

Errors (file missing, parse error, no `[source]` section) yield an empty map so adapters fall back to defaults — matching pre-patch behaviour when no config is present.

## Reproduction (pre-patch)

```bash
agent-deck watcher create github --name gh-test --secret $(openssl rand -hex 32)
cat > ~/.agent-deck/watcher/gh-test/watcher.toml <<'TOML'
[watcher]
name = "gh-test"
type = "github"

[source]
secret = "<same secret as above>"

[routing]
conductor = "conductor-x"
group = "x"
TOML
agent-deck watcher start gh-test
# restart TUI
grep adapter_setup_failed ~/.agent-deck/debug.log
# → "github adapter requires a webhook secret"
ss -tln | grep 18461  # not listening
```

After this patch: port binds on TUI start, signed webhooks are accepted (HTTP 202), events route per `clients.json`.

## Test plan

- [x] New unit tests in `internal/ui/home_watcher_settings_test.go` cover four cases:
  - happy path (full `[source]` returns expected map)
  - missing `watcher.toml` (returns empty, non-nil map)
  - present file without `[source]` section (returns empty)
  - malformed TOML (returns empty)
- [x] `go test ./internal/watcher/...` still passes
- [x] End-to-end verified with a github adapter: cloudflared tunnel → patched watcher → conductor session. Signed payload returns HTTP 202; unsigned/wrong-secret payloads are rejected. Event lands in `Recent Events` and routes through `clients.json`.
- [x] No behaviour change for watchers with no `watcher.toml` (the previous default path).

## Notes

- The `agent-deck watcher create` command still does not write a `watcher.toml` (only `meta.json` + DB row). Users currently have to write it by hand. A follow-up PR could have `create` emit a starter TOML; left out of this PR to keep the fix focused.
- The `[source]` section name follows the existing `AdapterConfig.Settings` comment and the slack-import generator (`generateWatcherToml` in `cmd/agent-deck/watcher_cmd.go`).