### PR TITLE
feat(watcher): dispatch routed events to conductor tmux pane

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -391,6 +391,11 @@ type Home struct {
 	transitionTrackerOnce sync.Once
 	transitionTracker     *transitionTracker
 
+	// Logs once per engine instance when the first watcher event is consumed
+	// from the engine's EventCh. Helps diagnose listener-not-firing issues
+	// without needing to instrument every event.
+	firstWatcherEventOnce sync.Once
+
 	// Full repaint mode: issue tea.ClearScreen every tick to avoid
 	// incremental redraw drift in terminals with unicode grapheme widths
 	fullRepaint          bool
@@ -1989,11 +1994,27 @@ func (h *Home) startWatcherEngine() tea.Cmd {
 	}
 
 	h.watcherEngine = eng
+	h.firstWatcherEventOnce = sync.Once{}
+
+	uiLog.Info("watcher_engine_started",
+		slog.Int("watcher_count", len(rows)),
+		slog.Int("running_count", runningCount(rows)))
 
 	return tea.Batch(
 		listenForWatcherEvent(eng.EventCh()),
 		listenForWatcherHealth(eng.HealthCh()),
 	)
+}
+
+// runningCount returns how many watcher rows are in the "running" state.
+func runningCount(rows []*statedb.WatcherRow) int {
+	n := 0
+	for _, r := range rows {
+		if r != nil && r.Status == "running" {
+			n++
+		}
+	}
+	return n
 }
 
 // propagateThemeToSessions updates COLORFGBG in all running tmux sessions
@@ -4574,6 +4595,12 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case watcherEventMsg:
+		// One-shot log per engine instance to confirm the listener path is alive.
+		h.firstWatcherEventOnce.Do(func() {
+			uiLog.Info("watcher_event_first_received",
+				slog.String("sender", msg.event.Sender),
+				slog.String("routed_to", msg.event.RoutedTo))
+		})
 		// Refresh watcher panel data on new events and re-register listener.
 		h.refreshWatcherPanel()
 		// Deliver event to the routed conductor's tmux pane (parity with

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4576,6 +4576,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case watcherEventMsg:
 		// Refresh watcher panel data on new events and re-register listener.
 		h.refreshWatcherPanel()
+		// Deliver event to the routed conductor's tmux pane (parity with
+		// dispatchHealthAlert). Skipped for triage and unrouted events.
+		h.dispatchWatcherEvent(msg.event)
 		if h.watcherEngine != nil {
 			return h, listenForWatcherEvent(h.watcherEngine.EventCh())
 		}
@@ -7158,6 +7161,40 @@ func (h *Home) refreshWatcherPanel() {
 			}
 			h.watcherPanel.SetEvents(displayEvents)
 		}
+	}
+}
+
+// dispatchWatcherEvent sends a routed watcher event into the conductor's tmux pane.
+// Skipped for triage and unrouted events (RoutedTo empty or "triage") since those have no
+// concrete delivery target yet. Mirrors dispatchHealthAlert: looks up the conductor session
+// by title and uses tmux send-keys (T-16-08) to deliver the formatted line.
+func (h *Home) dispatchWatcherEvent(evt watcher.Event) {
+	if evt.RoutedTo == "" || evt.RoutedTo == "triage" || strings.HasPrefix(evt.RoutedTo, "triage-") {
+		return
+	}
+	msg := fmt.Sprintf("[%s] %s: %s", evt.Source, evt.Sender, evt.Subject)
+	sessionTitle := session.ConductorSessionTitle(evt.RoutedTo)
+	h.instancesMu.RLock()
+	instances := h.instances
+	h.instancesMu.RUnlock()
+	for _, inst := range instances {
+		if inst.Title != sessionTitle {
+			continue
+		}
+		ts := inst.GetTmuxSession()
+		if ts == nil || ts.Name == "" {
+			return
+		}
+		tmuxName := ts.Name
+		socket := inst.TmuxSocketName
+		go func() {
+			if err := tmux.Exec(socket, "send-keys", "-t", tmuxName, msg, "Enter").Run(); err != nil {
+				uiLog.Warn("dispatch_watcher_event_send_failed",
+					slog.String("tmux_session", tmuxName),
+					slog.String("error", err.Error()))
+			}
+		}()
+		return
 	}
 }
 

--- a/internal/ui/watcher_listener_test.go
+++ b/internal/ui/watcher_listener_test.go
@@ -1,0 +1,61 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/watcher"
+)
+
+// TestListenForWatcherEvent_DeliversMsg verifies that listenForWatcherEvent's
+// tea.Cmd returns a watcherEventMsg carrying the event it received on the
+// channel. This guards against the listener-cmd-loss class of bug where a
+// dispatch path silently stops firing.
+func TestListenForWatcherEvent_DeliversMsg(t *testing.T) {
+	ch := make(chan watcher.Event, 1)
+	want := watcher.Event{
+		Source:   "github",
+		Sender:   "octocat@github.com",
+		Subject:  "[PR opened] #1: hello",
+		RoutedTo: "demo",
+	}
+	ch <- want
+
+	cmd := listenForWatcherEvent(ch)
+	if cmd == nil {
+		t.Fatal("listenForWatcherEvent returned nil cmd")
+	}
+
+	done := make(chan struct{})
+	var got any
+	go func() {
+		got = cmd()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener cmd did not return within 2s")
+	}
+
+	msg, ok := got.(watcherEventMsg)
+	if !ok {
+		t.Fatalf("got msg type %T, want watcherEventMsg", got)
+	}
+	if msg.event.Sender != want.Sender || msg.event.RoutedTo != want.RoutedTo {
+		t.Errorf("event mismatch: got %+v, want %+v", msg.event, want)
+	}
+}
+
+// TestListenForWatcherEvent_ReturnsNilOnClosedChannel verifies that the
+// listener exits cleanly when the engine closes the event channel (Stop).
+func TestListenForWatcherEvent_ReturnsNilOnClosedChannel(t *testing.T) {
+	ch := make(chan watcher.Event)
+	close(ch)
+
+	got := listenForWatcherEvent(ch)()
+	if got != nil {
+		t.Errorf("got %T (%v); want nil after closed channel", got, got)
+	}
+}

--- a/internal/watcher/adapter.go
+++ b/internal/watcher/adapter.go
@@ -69,6 +69,11 @@ type Event struct {
 	// ThreadSessionID is populated by the engine's writerLoop when a thread reply
 	// is routed to an existing session. Empty means spawn a new session.
 	ThreadSessionID string `json:"thread_session_id,omitempty"`
+
+	// RoutedTo is populated by the engine's writerLoop with the conductor name
+	// from Router.Match(Sender), or "triage" / "" when no rule matches.
+	// Consumed by the TUI to deliver events into the conductor's tmux pane.
+	RoutedTo string `json:"routed_to,omitempty"`
 }
 
 // DedupKey returns a deterministic hex-encoded SHA-256 hash of the event's

--- a/internal/watcher/engine.go
+++ b/internal/watcher/engine.go
@@ -432,6 +432,7 @@ func (e *Engine) writerLoop() {
 				}
 
 				// Non-blocking send to routedEventCh for TUI consumption.
+				env.event.RoutedTo = routedTo
 				select {
 				case e.routedEventCh <- env.event:
 				default:

--- a/internal/watcher/engine_test.go
+++ b/internal/watcher/engine_test.go
@@ -649,3 +649,43 @@ func TestWatcherEngine_Stop_ClosesExportedChannels(t *testing.T) {
 		t.Errorf("HealthCh: expected closed channel, got blocking read")
 	}
 }
+
+// TestWatcherEngine_EventCh_PopulatesRoutedTo verifies that events delivered on the
+// engine's EventCh have RoutedTo set to the matched conductor name. The TUI relies
+// on this to deliver events into the conductor's tmux pane.
+func TestWatcherEngine_EventCh_PopulatesRoutedTo(t *testing.T) {
+	clients := map[string]ClientEntry{
+		"user@company.com": {
+			Conductor: "conductor-a",
+			Group:     "g",
+			Name:      "A",
+		},
+	}
+
+	engine, db := newTestEngine(t, clients)
+	saveTestWatcher(t, db, "w1", "test-watcher", "mock")
+
+	adapter := &MockAdapter{
+		events: []Event{
+			{Source: "mock", Sender: "user@company.com", Subject: "hi", Timestamp: time.Now()},
+		},
+	}
+	engine.RegisterAdapter("w1", adapter, AdapterConfig{Type: "mock", Name: "test-watcher"}, 60)
+
+	if err := engine.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	select {
+	case evt, ok := <-engine.EventCh():
+		if !ok {
+			t.Fatal("EventCh closed before event arrived")
+		}
+		if evt.RoutedTo != "conductor-a" {
+			t.Errorf("RoutedTo = %q, want %q", evt.RoutedTo, "conductor-a")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for routed event on EventCh")
+	}
+}


### PR DESCRIPTION
## Summary

Watcher events are persisted and shown in the TUI panel but **never reach the routed conductor's tmux pane** — so a Claude conductor session has no way to react to GitHub PRs, issue comments, labels, CI results, etc. arriving through its watcher.

Health-state alerts already use `tmux send-keys` to deliver into the conductor (`dispatchHealthAlert` in `internal/ui/home.go`). This PR does the same for normal routed events.

## Changes

- `watcher.Event`: add `RoutedTo` field so TUI consumers know the matched conductor without having to re-run `Router.Match`.
- `engine.writerLoop`: populate `Event.RoutedTo` from the router result before publishing on `routedEventCh`.
- `ui.dispatchWatcherEvent`: mirror `dispatchHealthAlert` — look up the conductor instance by `ConductorSessionTitle(evt.RoutedTo)` and `send-keys` the formatted line `"[<source>] <sender>: <subject>"`. Skips triage and unrouted events.
- `ui.Update`: call `dispatchWatcherEvent` on each `watcherEventMsg`.

## Test plan

- [x] New unit test in `internal/watcher/engine_test.go::TestWatcherEngine_EventCh_PopulatesRoutedTo` verifies the writerLoop sets `Event.RoutedTo` to the matched conductor before delivery on `EventCh()`.
- [x] `go test ./internal/watcher/...` passes (full suite).
- [x] End-to-end verified with a github adapter: signed webhook -> cloudflared tunnel -> watcher (HMAC-verified) -> `clients.json` route -> conductor pane received `[github] martins-fresh@github.com: [PR opened] #47: Trace run` and Claude immediately reacted with a `gh pr view` lookup.
- [x] No-op for events whose `RoutedTo` is `""`, `"triage"`, or `"triage-*"` — those have no concrete delivery target yet.

## Notes

- Depends on `[source]` settings being loaded so the github adapter can actually start — pending PR #938. The two PRs are independent in code, but a watcher needs both to be useful end-to-end.
- A follow-up could broaden dispatch to a `*@github.com` wildcard rule so bot events (Dependabot, GitHub Actions) also route, since exact-key matches today only cover human authors.