### PR TITLE
fix(spawn,hooks): unify restart paths + clean sidecar on session-id clear (closes #922 #923)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -624,16 +624,11 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 	// Also skip if using a custom command (alias handles config dir)
 	configDirPrefix := ""
 	if !hasCustomCommand && IsClaudeConfigDirExplicitForInstance(i) {
-		configDir := GetClaudeConfigDirForInstance(i)
-		// Worker scratch dir override: if a per-instance scratch
-		// CLAUDE_CONFIG_DIR has been prepared (issue #59, v1.7.68),
-		// route the claude binary through it so it loads the mutated
-		// settings.json with the telegram plugin pinned off. Conductors
-		// and explicit channel owners leave WorkerScratchConfigDir
-		// empty and use the ambient profile — see worker_scratch.go.
-		if i.WorkerScratchConfigDir != "" {
-			configDir = i.WorkerScratchConfigDir
-		}
+		// Worker scratch dir override: see applyWorkerScratchOverride
+		// (worker_scratch.go). Issue #922 routed every spawn-construction
+		// branch through this seam so the override emits a single INFO
+		// log line instead of being silent.
+		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
 		configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir)
 	}
 
@@ -758,15 +753,10 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 func (i *Instance) buildBashExportPrefix() string {
 	prefix := fmt.Sprintf("export AGENTDECK_INSTANCE_ID=%s; ", i.ID)
 	if IsClaudeConfigDirExplicitForInstance(i) {
-		configDir := GetClaudeConfigDirForInstance(i)
-		// Worker scratch dir override (issue #59, v1.7.68). Mirrors the
-		// same override in the inline CLAUDE_CONFIG_DIR= prefix path
-		// above — both must route workers through the scratch dir so
-		// the telegram plugin is pinned off regardless of which
-		// command-build branch runs.
-		if i.WorkerScratchConfigDir != "" {
-			configDir = i.WorkerScratchConfigDir
-		}
+		// Worker scratch dir override: see applyWorkerScratchOverride
+		// (worker_scratch.go). Issue #922 unified the override + INFO
+		// log emission across every spawn-construction branch.
+		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
 		prefix += fmt.Sprintf("export CLAUDE_CONFIG_DIR=%s; ", configDir)
 	}
 	return prefix
@@ -4458,6 +4448,15 @@ func (i *Instance) Restart() error {
 	// Skip if MCP dialog just wrote the config (avoids race condition).
 	i.prepareRestartMCPConfig()
 
+	// Issue #922: prepare worker-scratch CLAUDE_CONFIG_DIR for every
+	// restart sub-path (respawn-pane AND recreate-tmux fallback) before
+	// branching. Previously only the recreate fallback called this — the
+	// respawn-pane branch reused whatever WorkerScratchConfigDir happened
+	// to be on the in-memory instance, so a CLI restart that loaded the
+	// instance fresh from storage could end up with stale or missing
+	// scratch state and silently swap the user's per-group config_dir.
+	i.prepareSpawnConfigForRestart()
+
 	// If Claude session with known ID AND tmux session exists, use respawn-pane.
 	if IsClaudeCompatible(i.Tool) && i.ClaudeSessionID != "" && i.tmuxSession != nil && i.tmuxSession.Exists() {
 		resumeCmd, containerName, err := i.prepareCommand(i.buildClaudeResumeCommand())
@@ -4853,16 +4852,11 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// Also skip if using a custom command (alias handles config dir)
 	configDirPrefix := ""
 	if !hasCustomCommand && IsClaudeConfigDirExplicitForInstance(i) {
-		configDir := GetClaudeConfigDirForInstance(i)
-		// Worker scratch dir override: if a per-instance scratch
-		// CLAUDE_CONFIG_DIR has been prepared (issue #59, v1.7.68),
-		// route the claude binary through it so it loads the mutated
-		// settings.json with the telegram plugin pinned off. Conductors
-		// and explicit channel owners leave WorkerScratchConfigDir
-		// empty and use the ambient profile — see worker_scratch.go.
-		if i.WorkerScratchConfigDir != "" {
-			configDir = i.WorkerScratchConfigDir
-		}
+		// Worker scratch dir override: see applyWorkerScratchOverride
+		// (worker_scratch.go). Issue #922 routed every spawn-construction
+		// branch through this seam so the override emits a single INFO
+		// log line instead of being silent.
+		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
 		configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir)
 	}
 

--- a/internal/session/issue922_spawn_unify_test.go
+++ b/internal/session/issue922_spawn_unify_test.go
@@ -1,0 +1,164 @@
+// Issue #922 — CLI session restart and TUI R diverged at the spawn-env
+// construction point: Restart()'s respawn-pane branch did NOT call
+// prepareWorkerScratchConfigDirForSpawn, while the recreate fallback DID.
+// Combined with the silent worker-scratch override of the resolved
+// CLAUDE_CONFIG_DIR, a user who configured per-group config_dir saw
+// claude land on the WRONG account with no log line to debug it.
+//
+// Bug reporter: @bautrey, audit pass 2026-05-10.
+//
+// Fix shape per the issue:
+//  1. All restart sub-paths must funnel the worker-scratch decision through
+//     the same call site (prepareSpawnConfigForRestart helper, invoked once
+//     at the top of Restart()).
+//  2. When worker-scratch overrides the resolved CLAUDE_CONFIG_DIR, emit a
+//     single INFO log line with both the resolved dir and the scratch dir
+//     so the override is debuggable instead of silent.
+
+package session
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPrepareSpawnConfigForRestart_PreparesWorkerScratch locks the
+// unification half of the fix: the helper that Restart() calls at its
+// top must populate WorkerScratchConfigDir for any non-conductor claude
+// worker on a host with a telegram conductor — regardless of whether
+// the eventual restart will take the respawn-pane path or the recreate
+// fallback.
+func TestPrepareSpawnConfigForRestart_PreparesWorkerScratch(t *testing.T) {
+	withTelegramConductorPresent(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	profile := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(profile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "settings.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+
+	inst := &Instance{
+		ID:          "00000000-0000-0000-0000-000000000922",
+		Tool:        "claude",
+		Title:       "issue-922",
+		ProjectPath: filepath.Join(home, "proj"),
+	}
+	if inst.WorkerScratchConfigDir != "" {
+		t.Fatalf("setup: WorkerScratchConfigDir should start empty; got %q", inst.WorkerScratchConfigDir)
+	}
+
+	inst.prepareSpawnConfigForRestart()
+
+	if inst.WorkerScratchConfigDir == "" {
+		t.Fatal("prepareSpawnConfigForRestart did not populate WorkerScratchConfigDir; both restart sub-paths will diverge again (issue #922)")
+	}
+	// Defensive: the scratch dir must actually exist on disk — otherwise
+	// the spawn would fail with ENOENT.
+	if _, err := os.Stat(inst.WorkerScratchConfigDir); err != nil {
+		t.Fatalf("scratch dir not on disk: %v", err)
+	}
+}
+
+// TestBuildClaudeCommand_WorkerScratchOverrideEmitsInfoLog locks the
+// debuggability half of the fix: when WorkerScratchConfigDir overrides
+// the resolved CLAUDE_CONFIG_DIR, an INFO line must record both the
+// original resolved dir and the scratch dir so the override is no
+// longer silent.
+func TestBuildClaudeCommand_WorkerScratchOverrideEmitsInfoLog(t *testing.T) {
+	withTelegramConductorPresent(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	profile := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(profile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "settings.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+
+	inst := &Instance{
+		ID:          "00000000-0000-0000-0000-000000000922",
+		Tool:        "claude",
+		Title:       "issue-922",
+		ProjectPath: filepath.Join(home, "proj"),
+	}
+	scratch, err := inst.EnsureWorkerScratchConfigDir(profile)
+	if err != nil {
+		t.Fatalf("setup scratch: %v", err)
+	}
+	if scratch == "" {
+		t.Fatal("setup: expected non-empty scratch dir")
+	}
+	inst.WorkerScratchConfigDir = scratch
+
+	// Capture sessionLog at INFO level for this test.
+	var buf bytes.Buffer
+	origLog := sessionLog
+	sessionLog = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	t.Cleanup(func() { sessionLog = origLog })
+
+	_ = inst.buildClaudeCommand("claude")
+
+	output := buf.String()
+	if !strings.Contains(output, "worker_scratch_override") {
+		t.Errorf("expected `worker_scratch_override` INFO event; got: %s", output)
+	}
+	if !strings.Contains(output, profile) {
+		t.Errorf("override log must include the resolved (overridden) config_dir %q; got: %s", profile, output)
+	}
+	if !strings.Contains(output, scratch) {
+		t.Errorf("override log must include the scratch dir %q; got: %s", scratch, output)
+	}
+	// `buildClaudeCommand` chains two spawn-env contributors that each
+	// emit `CLAUDE_CONFIG_DIR` (the bash-export prefix and the inline
+	// prefix). Both legitimately go through applyWorkerScratchOverride
+	// and each one should log — anything between 1 and 2 is OK.
+	if got := strings.Count(output, "worker_scratch_override"); got < 1 || got > 2 {
+		t.Errorf("expected 1 or 2 `worker_scratch_override` logs per build; got %d\noutput: %s", got, output)
+	}
+}
+
+// TestBuildClaudeCommand_NoOverrideNoLog guards against a noisy fix:
+// when WorkerScratchConfigDir is empty (conductor / channel-owner /
+// non-claude-worker), no override log must fire.
+func TestBuildClaudeCommand_NoOverrideNoLog(t *testing.T) {
+	withTelegramConductorPresent(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	profile := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(profile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "settings.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+
+	// Conductor — keeps ambient profile, never gets a scratch dir.
+	inst := &Instance{
+		ID:          "00000000-0000-0000-0000-000000000a00",
+		Tool:        "claude",
+		Title:       "conductor-x",
+		ProjectPath: filepath.Join(home, "proj"),
+	}
+
+	var buf bytes.Buffer
+	origLog := sessionLog
+	sessionLog = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	t.Cleanup(func() { sessionLog = origLog })
+
+	_ = inst.buildClaudeCommand("claude")
+
+	if strings.Contains(buf.String(), "worker_scratch_override") {
+		t.Errorf("override log must not fire when WorkerScratchConfigDir is empty; got: %s", buf.String())
+	}
+}

--- a/internal/session/issue923_sid_clear_test.go
+++ b/internal/session/issue923_sid_clear_test.go
@@ -1,0 +1,91 @@
+// Issue #923 — clearing claude_session_id via the CLI/TUI mutator must
+// also drop the hook .sid sidecar, otherwise the next restart re-reads
+// the stale anchor and re-injects the old id (negating the user's clear).
+//
+// Bug reporter: @bautrey, audit pass 2026-05-10.
+
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSetField_ClearClaudeSessionID_DeletesHookSidecar locks the
+// fix shape: when SetField clears the claude session id, the
+// `~/.agent-deck/hooks/<id>.sid` anchor must be removed so a
+// subsequent ReadHookSessionAnchor returns empty.
+func TestSetField_ClearClaudeSessionID_DeletesHookSidecar(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	const instanceID = "00000000-0000-0000-0000-000000000923"
+	const oldID = "abc-123-stale"
+
+	// Pre-condition: a non-empty .sid anchor exists for the instance,
+	// matching the real-world state before the user clears the id.
+	WriteHookSessionAnchor(instanceID, oldID)
+	if got := ReadHookSessionAnchor(instanceID); got != oldID {
+		t.Fatalf("setup: expected anchor %q, got %q", oldID, got)
+	}
+
+	inst := &Instance{
+		ID:              instanceID,
+		Tool:            "claude",
+		Title:           "issue-923",
+		ClaudeSessionID: oldID,
+	}
+
+	// User explicitly clears the session id.
+	if _, _, err := SetField(inst, FieldClaudeSessionID, "", nil); err != nil {
+		t.Fatalf("SetField clear: %v", err)
+	}
+
+	// Post-condition: the in-memory field is empty AND the sidecar is
+	// gone (or at minimum reads as empty).
+	if inst.ClaudeSessionID != "" {
+		t.Fatalf("instance ClaudeSessionID not cleared; got %q", inst.ClaudeSessionID)
+	}
+	if got := ReadHookSessionAnchor(instanceID); got != "" {
+		t.Fatalf("hook sidecar still has stale id after clear; got %q want \"\"", got)
+	}
+
+	// Belt-and-suspenders: also assert the file is gone on disk so a
+	// future hook tick can't re-populate from a half-deleted state.
+	sidPath := filepath.Join(home, ".agent-deck", "hooks", instanceID+".sid")
+	if _, err := os.Stat(sidPath); !os.IsNotExist(err) {
+		t.Errorf("hook sidecar file still present at %q; want removed (stat err=%v)", sidPath, err)
+	}
+}
+
+// TestSetField_NonEmptyClaudeSessionID_KeepsSidecar guards against a
+// fix that over-deletes — when a CALLER replaces one id with another
+// non-empty id, the sidecar must be left alone (or kept consistent
+// with the new value); we MUST NOT clear it as a side-effect.
+func TestSetField_NonEmptyClaudeSessionID_KeepsSidecar(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	const instanceID = "00000000-0000-0000-0000-000000000924"
+	const oldID = "old-id"
+	const newID = "new-id"
+
+	WriteHookSessionAnchor(instanceID, oldID)
+
+	inst := &Instance{
+		ID:              instanceID,
+		Tool:            "claude",
+		Title:           "issue-923-keep",
+		ClaudeSessionID: oldID,
+	}
+
+	if _, _, err := SetField(inst, FieldClaudeSessionID, newID, nil); err != nil {
+		t.Fatalf("SetField replace: %v", err)
+	}
+
+	// Anchor must NOT be empty — fix should ONLY clear on empty value.
+	if got := ReadHookSessionAnchor(instanceID); got == "" {
+		t.Fatalf("hook sidecar wrongly cleared on non-empty replace")
+	}
+}

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -177,6 +177,16 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 		inst.ClaudeSessionID = value
 		inst.ClaudeDetectedAt = time.Now()
 		postCommit = makeSessionEnvPostCommit(inst, "CLAUDE_SESSION_ID", value)
+		// Issue #923: when the user explicitly clears the session id, the
+		// hook .sid sidecar at ~/.agent-deck/hooks/<id>.sid must also be
+		// removed. Otherwise the next restart's spawn-env construction
+		// reads the stale anchor and re-injects the old id, undoing the
+		// clear. Sidecar is read on restart via ReadHookSessionAnchor
+		// (instance.go async sync). DB is authoritative for the empty
+		// case; empty means abandon, not "fall back to last seen".
+		if value == "" {
+			ClearHookSessionAnchor(inst.ID)
+		}
 
 	case FieldGeminiSessionID:
 		oldValue = inst.GeminiSessionID

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -201,6 +201,36 @@ func (i *Instance) CleanupWorkerScratchConfigDir() {
 	i.WorkerScratchConfigDir = ""
 }
 
+// prepareSpawnConfigForRestart unifies the spawn-env preparation that
+// every Restart() sub-path needs (issue #922). Before this helper, the
+// respawn-pane branch in Restart() skipped worker-scratch preparation
+// while the recreate fallback ran it — so the same session restarted
+// via different conditions could land in different CLAUDE_CONFIG_DIRs.
+// Calling this helper once at the top of Restart() means both sub-paths
+// see identical config-resolution state.
+func (i *Instance) prepareSpawnConfigForRestart() {
+	i.prepareWorkerScratchConfigDirForSpawn()
+}
+
+// applyWorkerScratchOverride is the single seam where the worker-scratch
+// CLAUDE_CONFIG_DIR replaces the resolved one. Returns the effective
+// config dir to use. Centralising the override in one helper means both
+// the inline (`CLAUDE_CONFIG_DIR=...`) and the bash-export
+// (`export CLAUDE_CONFIG_DIR=...`) command-build branches log the swap
+// with identical wording — issue #922 closed the silent-override hole
+// by making this the only place the swap can happen.
+func (i *Instance) applyWorkerScratchOverride(resolvedConfigDir string) string {
+	if i.WorkerScratchConfigDir == "" {
+		return resolvedConfigDir
+	}
+	sessionLog.Info("worker_scratch_override",
+		slog.String("instance_id", i.ID),
+		slog.String("resolved_config_dir", resolvedConfigDir),
+		slog.String("worker_scratch_config_dir", i.WorkerScratchConfigDir),
+	)
+	return i.WorkerScratchConfigDir
+}
+
 // prepareWorkerScratchConfigDirForSpawn is the spawn-path wrapper
 // around EnsureWorkerScratchConfigDir. Called from Start(),
 // StartWithMessage(), and the restart fallback path. Best-effort —


### PR DESCRIPTION
Closes #922.
Closes #923.

Two adjacent bugs from @bautrey's 2026-05-10 audit cluster
([#920–#925](https://github.com/asheshgoplani/agent-deck/issues?q=author%3Abautrey+is%3Aopen+is%3Aissue)).
Both live in the spawn / hook lifecycle and share code paths, so the audit
itself recommended bundling them into a single PR — that's this one.

## Bug 1 — #922: silent worker-scratch override on CLI restart

`Restart()`'s respawn-pane sub-path did NOT call
`prepareWorkerScratchConfigDirForSpawn` — only the recreate-tmux fallback
did. A CLI restart that loaded the instance fresh from storage (with empty
`WorkerScratchConfigDir`) hit the respawn-pane path and silently spawned
claude against the bare ambient profile, bypassing the per-group
`[groups."X".claude] config_dir` override. There was also no log line
when worker-scratch overrode the resolved `CLAUDE_CONFIG_DIR`, so users
whose statusline went blank had nothing to grep for.

**Fix:**
- Hoist the prep call into a named `prepareSpawnConfigForRestart` helper
  invoked once at the top of `Restart()`, so respawn-pane and recreate-tmux
  see identical config-resolution state.
- Route every `WorkerScratchConfigDir` swap through a single
  `applyWorkerScratchOverride` seam that emits one INFO event per swap,
  carrying both the resolved dir and the scratch dir.
- Worker-scratch behaviour is unchanged beyond logging — explicitly within
  the audit's scope guidance.

## Bug 2 — #923: stale .sid sidecar re-injects cleared session id

`agent-deck session set <id> claude-session-id ""` cleared the in-memory
field and propagated to the tmux env, but left the
`~/.agent-deck/hooks/<id>.sid` sidecar intact. The next restart's
spawn-env construction read the stale anchor via `ReadHookSessionAnchor`
and re-injected the OLD id, undoing the user's clear.

**Fix:** `SetField(FieldClaudeSessionID, "")` now also calls
`ClearHookSessionAnchor`. DB is authoritative for the empty case — empty
means abandon, not "fall back to last seen". Replacing one non-empty id
with another leaves the sidecar alone (over-deletion guard test).

## Tests (TDD-first, regression-locked)

- `TestPrepareSpawnConfigForRestart_PreparesWorkerScratch` — both restart
  sub-paths see prepared scratch state.
- `TestBuildClaudeCommand_WorkerScratchOverrideEmitsInfoLog` — INFO log
  fires with both dirs when override happens.
- `TestBuildClaudeCommand_NoOverrideNoLog` — no log when no override.
- `TestSetField_ClearClaudeSessionID_DeletesHookSidecar` — clear empties
  in-memory id AND removes sidecar.
- `TestSetField_NonEmptyClaudeSessionID_KeepsSidecar` — replace doesn't
  clobber sidecar.

Each test was watched fail before the fix (RED), then pass (GREEN).

## Verification

```
go test -race -count=1 -timeout 300s ./...
```

All packages green locally. Mandated suites
(`TestPersistence_*`, `TestPerGroupConfig_*`, `Watcher`) pass.

## Out of scope

- #924 (multi-account conversation slots) — feature design, scoped separately.
- #925 (resolved-account env hint) — separate PR.

## Push hook note

Pre-push lefthook surfaced two pre-existing lint failures on `origin/main`
(`cmd/agent-deck/session_cmd.go:2133` SA9003 empty-branch and
`internal/statedb/statedb.go:21` `statedbLog` unused). Neither file is
touched by this branch. Pushed with `LEFTHOOK=0` after explicit
authorisation; the failures should be cleaned up on `main` separately.

Credit: @bautrey for the audit pass that surfaced both bugs.

Committed by Ashesh Goplani