### PR TITLE
fix(ui): viewport invalidation on resize/switch + correct emoji+VS16 cell width (closes #936 #937)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4361,12 +4361,17 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Re-enable mouse mode after returning from tea.Exec (tmux detach-client
 		// resets mouse reporting), restore legacy keyboard reporting (tmux's
 		// extended-keys setting leaves Kitty/modifyOtherKeys on the outer terminal;
-		// see RestoreLegacyKeyboardCmd for the full rationale), and schedule a
-		// delayed repaint for any pane-title/content cache changes that settle just
-		// after tmux restores the outer client.
+		// see RestoreLegacyKeyboardCmd for the full rationale), force-poll
+		// terminal dimensions (#936: SIGWINCH propagation through nested SSH is
+		// late or lost — a host-terminal Cmd++ zoom during attach would otherwise
+		// land us back in the menu with stale pre-zoom column counts, making the
+		// input line render above the real viewport bottom and run off the
+		// right edge), and schedule a delayed repaint for any pane-title/content
+		// cache changes that settle just after tmux restores the outer client.
 		return h, tea.Batch(
 			tea.EnableMouseCellMotion,
 			RestoreLegacyKeyboardCmd(os.Stdout),
+			tea.WindowSize(),
 			tea.Tick(attachReturnRefreshDelay, func(time.Time) tea.Msg { return attachReturnRefreshMsg{} }),
 		)
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -25,7 +25,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/mattn/go-runewidth"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/asheshgoplani/agent-deck/internal/clipboard"
@@ -10512,7 +10511,10 @@ func renderSimpleMCPLine(b *strings.Builder, mcpInfo *session.MCPInfo, width int
 
 	for i, part := range mcpParts {
 		plainPart := tmux.StripANSI(part)
-		partWidth := runewidth.StringWidth(plainPart)
+		// #937: ansi.StringWidth (uniseg grapheme-cluster aware) instead of
+		// runewidth.StringWidth, which under-counts <codepoint>+VS16 emoji
+		// sequences and produced row-offset drift on titles like "🏷️ ...".
+		partWidth := ansi.StringWidth(plainPart)
 
 		addedWidth := partWidth
 		if mcpCount > 0 {
@@ -10527,7 +10529,7 @@ func renderSimpleMCPLine(b *strings.Builder, mcpInfo *session.MCPInfo, width int
 			wouldExceed = currentWidth+addedWidth > mcpMaxWidth
 		} else {
 			moreIndicator := fmt.Sprintf(" (+%d more)", remaining)
-			moreWidth := runewidth.StringWidth(moreIndicator)
+			moreWidth := ansi.StringWidth(moreIndicator)
 			wouldExceed = currentWidth+addedWidth+moreWidth > mcpMaxWidth
 		}
 
@@ -12629,7 +12631,10 @@ func (h *Home) renderPreviewPane(width, height int) string {
 			for i, part := range mcpParts {
 				// Strip ANSI codes to measure actual display width
 				plainPart := tmux.StripANSI(part)
-				partWidth := runewidth.StringWidth(plainPart)
+				// #937: ansi.StringWidth (uniseg grapheme-cluster aware)
+				// instead of runewidth.StringWidth — see comment at the other
+				// MCP-row sizing loop for full rationale.
+				partWidth := ansi.StringWidth(plainPart)
 
 				// Calculate width including separator if not first
 				addedWidth := partWidth
@@ -12649,7 +12654,7 @@ func (h *Home) renderPreviewPane(width, height int) string {
 				} else {
 					// Not last - check with indicator space reserved
 					moreIndicator := fmt.Sprintf(" (+%d more)", remaining)
-					moreWidth := runewidth.StringWidth(moreIndicator)
+					moreWidth := ansi.StringWidth(moreIndicator)
 					wouldExceed = currentWidth+addedWidth+moreWidth > mcpMaxWidth
 				}
 
@@ -13487,7 +13492,13 @@ func (h *Home) renderNotesSection(inst *session.Instance, width, maxLines int) s
 			}
 			for _, line := range displayLines {
 				safe := stripControlCharsPreserveANSI(line)
-				safe = runewidth.Truncate(safe, contentWidth, "...")
+				// #937: ansi.Truncate is uniseg grapheme-cluster aware so
+				// pane content (notes lines) containing emoji+VS16 stays
+				// inside the panel width budget — runewidth.Truncate
+				// under-counted by 1 cell per VS16 sequence and let the
+				// overflow scroll the layout. Reported by @jennings as
+				// the pane-content half of #937.
+				safe = ansi.Truncate(safe, contentWidth, "...")
 				lines = append(lines, notesStyle.Render(safe))
 			}
 			if overflow && len(lines) > 0 {
@@ -13584,9 +13595,14 @@ func remapANSIBackground(s, replacement string) string {
 	return ansiBackgroundRE.ReplaceAllString(s, replacement)
 }
 
-// truncatePath shortens a path to fit within maxLen display width
+// truncatePath shortens a path to fit within maxLen display width.
+//
+// #937: width and truncate route through ansi.* (uniseg grapheme-cluster
+// aware) instead of runewidth.*, which under-counts <codepoint>+VS16 emoji
+// sequences and let oversized titles past the truncation gate, producing
+// row-offset drift on titles like "🏷️ /Users/foo/project".
 func truncatePath(path string, maxLen int) string {
-	pathWidth := runewidth.StringWidth(path)
+	pathWidth := ansi.StringWidth(path)
 	if pathWidth <= maxLen {
 		return path
 	}
@@ -13599,8 +13615,8 @@ func truncatePath(path string, maxLen int) string {
 	startLen := maxLen / 3
 	endLen := maxLen*2/3 - 3
 	if startLen+endLen+3 > len(runes) {
-		// Path is short in runes but wide in display - use simple truncation
-		return runewidth.Truncate(path, maxLen-3, "...")
+		// Path is short in runes but wide in display - use width-aware truncation
+		return ansi.Truncate(path, maxLen-3, "...")
 	}
 	return string(runes[:startLen]) + "..." + string(runes[len(runes)-endLen:])
 }
@@ -13796,9 +13812,13 @@ func (h *Home) renderGroupPreview(group *session.Group, width, height int) strin
 	var truncatedLines []string
 	for _, line := range lines {
 		cleanLine := tmux.StripANSI(line)
-		displayWidth := runewidth.StringWidth(cleanLine)
+		// #937: ansi.StringWidth + ansi.Truncate are uniseg-aware and
+		// count <codepoint>+VS16 emoji sequences as 2 cells (matching
+		// terminal rendering); runewidth.* counts them as 1 and let
+		// oversized lines overflow into the next row.
+		displayWidth := ansi.StringWidth(cleanLine)
 		if displayWidth > maxWidth {
-			truncated := runewidth.Truncate(cleanLine, maxWidth-3, "...")
+			truncated := ansi.Truncate(cleanLine, maxWidth-3, "...")
 			truncatedLines = append(truncatedLines, truncated)
 		} else {
 			truncatedLines = append(truncatedLines, line)

--- a/internal/ui/issue936_attach_resize_test.go
+++ b/internal/ui/issue936_attach_resize_test.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"reflect"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Regression tests for #936 — Input line drifts off the visible viewport
+// after host-terminal zoom or session switch.
+//
+// Reporter: Kevsosmooth, on agent-deck running on Linux Synology DSM 7
+// via SSH from a macOS host terminal. Reliable repro: zoom in (Cmd++),
+// then switch to another agent-deck session — input area renders above
+// the real viewport bottom and long prompts run off the right edge.
+//
+// Root cause: cached column/row count from the previous viewport is not
+// invalidated when the host terminal sends a resize after a zoom, or
+// when the attached-to session has different dimensions. SIGWINCH
+// propagation through nested SSH+tmux is late or lost.
+//
+// Fix: force-poll terminal dims by emitting tea.WindowSize() from the
+// statusUpdateMsg (post-attach) handler. Bubbletea intercepts the
+// returned windowSizeMsg{} and replies with a fresh tea.WindowSizeMsg,
+// which the existing WindowSizeMsg handler already turns into a
+// updateSizes()+syncViewport() recompute.
+
+// Test_Issue936_StatusUpdateMsg_ForcesWindowSizeRepoll asserts that the
+// post-attach handler includes a tea.WindowSize() command in its
+// returned batch. Without this, host-terminal zoom that happens during
+// attach is silently dropped and the input line renders at the old
+// viewport bottom.
+func Test_Issue936_StatusUpdateMsg_ForcesWindowSizeRepoll(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+
+	_, cmd := home.Update(statusUpdateMsg{})
+	if cmd == nil {
+		t.Fatal("statusUpdateMsg returned nil cmd — viewport revalidation hook missing")
+	}
+
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected tea.BatchMsg from statusUpdateMsg handler, got %T", cmd())
+	}
+
+	if !batchContainsWindowSizeRepoll(batch) {
+		t.Fatalf(
+			"statusUpdateMsg batch must contain a tea.WindowSize() command after #936.\n" +
+				"Without this, host-terminal zoom during attach is dropped — input renders " +
+				"above the real viewport bottom and long prompts run off the right edge.\n" +
+				"Reported by Kevsosmooth on Linux Synology DSM 7 via SSH from macOS.",
+		)
+	}
+}
+
+// Test_Issue936_WindowSizeMsg_RebuildsViewport pins the downstream
+// contract: when a fresh WindowSizeMsg arrives (because we polled, or
+// because SIGWINCH did fire), the handler must update both
+// h.width / h.height. Without this the re-poll is wasted.
+func Test_Issue936_WindowSizeMsg_RebuildsViewport(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+
+	model, _ := home.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatalf("Update returned %T, want *Home", model)
+	}
+	if h.width != 80 {
+		t.Errorf("h.width = %d after WindowSizeMsg{80,24}, want 80 (cached pre-zoom dim survived)", h.width)
+	}
+	if h.height != 24 {
+		t.Errorf("h.height = %d after WindowSizeMsg{80,24}, want 24 (cached pre-zoom dim survived)", h.height)
+	}
+}
+
+// batchContainsWindowSizeRepoll walks a tea.BatchMsg looking for the
+// bubbletea-internal windowSizeMsg{} (the message tea.WindowSize()
+// emits). The type is package-private to bubbletea, so we identify it
+// by reflect-name. Narrow by design: "the batch contains the cmd that
+// tea.WindowSize() returns", nothing more.
+func batchContainsWindowSizeRepoll(batch tea.BatchMsg) bool {
+	for _, c := range batch {
+		if c == nil {
+			continue
+		}
+		msg := c()
+		if msg == nil {
+			continue
+		}
+		t := reflect.TypeOf(msg)
+		if t == nil {
+			continue
+		}
+		if t.PkgPath() == "github.com/charmbracelet/bubbletea" && t.Name() == "windowSizeMsg" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ui/issue937_emoji_vs16_test.go
+++ b/internal/ui/issue937_emoji_vs16_test.go
@@ -1,0 +1,108 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
+)
+
+// Regression tests for #937 — Session titles AND pane content with
+// emoji+VS16 (e.g. 🏷️ 🛠️ ⚙️ 🗂️) cause per-frame row-offset drift in the
+// agent-deck Bubble Tea TUI.
+//
+// Root cause: go-runewidth and terminal emulators disagree on the cell
+// width of <codepoint>+U+FE0F (Variation Selector 16) sequences.
+// runewidth reports width 1; terminals (Ghostty, Terminal.app, Warp,
+// Termius) render 2 cells. This is a stable, cross-terminal desync.
+//
+// Fix: replace the remaining `runewidth.StringWidth` / `runewidth.Truncate`
+// callsites in internal/ui/home.go with `ansi.StringWidth` /
+// `ansi.Truncate` (uniseg grapheme-cluster aware, same family as
+// `lipgloss.Width` which this codebase already uses elsewhere — see the
+// comment at internal/ui/home.go in `ensureExactWidth`).
+//
+// Reporters: maxfi (#937 original), jennings (scope expansion to pane
+// content).
+
+// vs16Cases pairs each VS16-suffixed emoji string with the cell count
+// that real terminals render it at. runewidth disagrees with every
+// non-control entry; ansi.StringWidth agrees with all.
+var vs16Cases = []struct {
+	name   string
+	in     string
+	want   int
+	report string
+}{
+	{"label_vs16", "🏷️", 2, "U+1F3F7 + VS16 — maxfi (#937, 2026-04-17)"},
+	{"hammer_wrench_vs16", "🛠️", 2, "U+1F6E0 + VS16 — maxfi (#937, 2026-05-11)"},
+	{"gear_vs16", "⚙️", 2, "U+2699 + VS16 — example in #937 summary"},
+	{"card_index_vs16", "🗂️", 2, "U+1F5C2 + VS16 — example in #937 summary"},
+	{"label_vs16_with_text", "🏷️ session", 10, "title prefix + ASCII suffix"},
+	{"emoji_default_robot", "🤖", 2, "control: emoji-default presentation, no VS16"},
+	{"plain_ascii", "hello", 5, "control: ASCII baseline"},
+}
+
+// Test_Issue937_RunewidthDesync_Documented captures the empirical desync
+// in go-runewidth that motivates the swap. Informational — it asserts
+// the *bug* in the upstream library; if a future runewidth release fixes
+// VS16, this test fails and the shim becomes redundant.
+func Test_Issue937_RunewidthDesync_Documented(t *testing.T) {
+	for _, tc := range vs16Cases {
+		if tc.name == "emoji_default_robot" || tc.name == "plain_ascii" {
+			continue
+		}
+		if got := runewidth.StringWidth(tc.in); got >= tc.want {
+			t.Errorf(
+				"runewidth.StringWidth(%q) = %d, expected < %d — upstream "+
+					"may have fixed VS16; revisit the ansi.StringWidth shim",
+				tc.in, got, tc.want,
+			)
+		}
+	}
+}
+
+// Test_Issue937_AnsiStringWidth_HandlesVS16 locks in that the width
+// function used by the fixed call sites (ansi.StringWidth) agrees with
+// terminal rendering for every <codepoint>+VS16 sequence reported in
+// #937. If a future refactor swaps the sites back to runewidth, this
+// test fails and surfaces row-offset drift before it ships.
+func Test_Issue937_AnsiStringWidth_HandlesVS16(t *testing.T) {
+	for _, tc := range vs16Cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ansi.StringWidth(tc.in); got != tc.want {
+				t.Fatalf(
+					"ansi.StringWidth(%q) = %d, want %d (%s)",
+					tc.in, got, tc.want, tc.report,
+				)
+			}
+		})
+	}
+}
+
+// Test_Issue937_TruncatePath_FitsVS16Title exercises a real production
+// home.go function with a VS16-bearing input and asserts the post-
+// truncate output fits inside the requested cell budget, as measured by
+// the same uniseg-aware function the terminal uses.
+//
+// Pre-fix: truncatePath called runewidth.StringWidth, which reported
+// width 20 for the input below — equal to maxLen, so no truncation
+// happened. The caller then printed 21 cells into a 20-cell slot, the
+// row wrapped, and subsequent lines drifted down by one row per
+// offending title. Post-fix (ansi.StringWidth + ansi.Truncate), the same
+// input is correctly measured at 21 and truncated to fit.
+func Test_Issue937_TruncatePath_FitsVS16Title(t *testing.T) {
+	in := "🏷️ /Users/foo/project" // ansi width = 21, runewidth = 20
+	const maxLen = 20
+	out := truncatePath(in, maxLen)
+	if got := ansi.StringWidth(out); got > maxLen {
+		t.Fatalf(
+			"truncatePath(%q, %d) = %q with ansi.StringWidth = %d cells; "+
+				"want <= %d. The function is still measuring width with "+
+				"go-runewidth, which under-counts emoji+VS16 sequences by "+
+				"1 cell and lets oversized output past the truncation gate, "+
+				"producing #937's row-offset drift.",
+			in, maxLen, out, got, maxLen,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

Two P1 TUI rendering bugs bundled in one PR — both viewport/cell-width bookkeeping in `internal/ui/`. Each ships with its own regression-tested commit.

- **closes #936** — Input line drifts off the visible viewport after host-terminal zoom or session switch. Reported by @Kevsosmooth (Linux Synology DSM 7 via SSH from macOS, iTerm2 / Ghostty).
- **closes #937** — Session titles AND pane content with emoji+VS16 (🏷️ 🛠️ ⚙️ 🗂️) cause per-frame row-offset drift. Original report by @maxfi (v1.7.x and v1.9.1, surviving since #607 closed in April); pane-content scope expansion by @jennings.

## #937 — emoji + Variation Selector 16 cell-width drift

**Root cause.** `go-runewidth` reports cell width `1` for `<emoji>+U+FE0F` sequences while every tested terminal (Ghostty, Terminal.app, Warp, Termius) renders 2 cells. Six width measurements and three truncations in `internal/ui/home.go` were under-counting by 1 cell per VS16 sequence; oversized output slipped past truncation gates, wrapped to the next row, and pushed downstream content down by one row per offending title.

Empirically (before fix):
- `runewidth.StringWidth("🏷️") = 1`
- `ansi.StringWidth("🏷️")      = 2`  ✓ (uniseg grapheme-cluster aware)
- `lipgloss.Width("🏷️")        = 2`  ✓ (calls `ansi.StringWidth`)

The repo already had a comment at `home.go:10020-10037` calling out this exact desync — `ensureExactWidth` had been migrated to `lipgloss.Width`; the remaining 9 callsites had not. This PR finishes that migration.

**Fix.** Swap the remaining 6× `runewidth.StringWidth` and 3× `runewidth.Truncate` callsites in `internal/ui/home.go` to `github.com/charmbracelet/x/ansi` (already imported and used heavily elsewhere in the file). Drop the now-unused `mattn/go-runewidth` import.

Affected sites:
- `renderSimpleMCPLine` (MCP row sizing, ×2)
- `renderPreviewPane` MCP row sizing (×2)
- `renderNotesSection` (notes pane content truncation — @jennings's pane-content scope)
- `truncatePath` (project path display)
- help-bar line truncation

**Regression guards** (`internal/ui/issue937_emoji_vs16_test.go`):
- `Test_Issue937_RunewidthDesync_Documented` — pins the empirical upstream desync.
- `Test_Issue937_AnsiStringWidth_HandlesVS16` — table-driven over 🏷️ 🛠️ ⚙️ 🗂️ "🏷️ session" 🤖 (control) "hello" (control).
- `Test_Issue937_TruncatePath_FitsVS16Title` — exercises the production callsite. Pre-fix returns 21 cells for a 20-cell budget; post-fix truncates to fit.

## #936 — input drifts off viewport after host-terminal zoom or session switch

**Root cause.** After a tmux attach (which includes agent-deck's "switch session" flow), the post-attach `statusUpdateMsg` handler at `internal/ui/home.go:4225` relied on bubbletea's `WindowSizeMsg`-on-SIGWINCH path to repaint at correct dims. Through nested SSH+tmux, SIGWINCH is late or lost when the host terminal zooms during attach — cached pre-zoom dims survive the detach, the existing `WindowSizeMsg` handler at `home.go:3383` never fires, and the input line renders above the real viewport bottom with long prompts running off the right edge.

**Fix.** Prepend `tea.WindowSize()` to the `tea.Batch` returned by the `statusUpdateMsg` branch. `tea.WindowSize()` asks the bubbletea runtime to re-query the underlying tty and emit a fresh `tea.WindowSizeMsg` through the normal Update loop. The existing `WindowSizeMsg` handler already calls `updateSizes()+syncViewport()` on every dimensional message, so a single batch entry restores correctness without touching bubbletea integration patterns elsewhere.

**Regression guards** (`internal/ui/issue936_attach_resize_test.go`):
- `Test_Issue936_StatusUpdateMsg_ForcesWindowSizeRepoll` — walks the returned `tea.BatchMsg`, asserts at least one entry produces bubbletea's internal `windowSizeMsg{}` on invocation (identified by reflect-name since the type is package-private to bubbletea).
- `Test_Issue936_WindowSizeMsg_RebuildsViewport` — pins the downstream contract that a fresh `WindowSizeMsg` updates `h.width` / `h.height`.
- Pre-existing `TestHomeUpdateStatusUpdateMsgBatchesKeyboardRestore` (PR #613 guard) still passes: it asserts `len(batch) >= 2`; post-fix batch is length 4.

## Why bundle

Both fixes touch the same `internal/ui/` viewport bookkeeping layer. Shared test discipline (terminal-rendered cell-count fixtures + post-attach batch inspection) lets us lock in correctness for both classes in one PR.

## Test plan

- [x] `GOTOOLCHAIN=go1.24.0 go test -race -count=1 ./internal/ui/...` — green (29.4s).
- [x] `GOTOOLCHAIN=go1.24.0 go test -race -count=1 ./...` — green across all 35 packages.
- [x] Pre-commit hooks (lefthook `fmt-check` + `vet`) green on both commits.
- [ ] Manual verification of @Kevsosmooth's exact repro (Linux Synology DSM 7 + nested SSH + iTerm2 Cmd++ + session switch) — not done; see manual-verify gap below.
- [ ] Manual verification of @maxfi / @jennings emoji+VS16 titles on Ghostty / Terminal.app / Warp / Termius — not done; relies on unit-test width contract.

## Manual-verify gap (honest)

These are TUI rendering bugs whose end-to-end repro requires a host terminal capable of physical Cmd++ zoom and a remote agent-deck session over SSH. Unit tests verify the width helper agrees with terminal-rendered cell counts for every reported VS16 sequence, that a representative production callsite (`truncatePath`) now truncates oversized VS16 input, and that the post-attach handler emits the dimension-repoll command bubbletea requires for fresh tty polling.

What unit tests do **not** verify:
- That @Kevsosmooth's exact repro now lands at the correct viewport bottom in practice.
- That `tea.WindowSize()` reliably delivers a fresh `tea.WindowSizeMsg` through the bubbletea runtime on every host-terminal/emulator combo.

A follow-up eval case under `tests/eval/` (per repo `CLAUDE.md`'s behavioral-evaluator mandate for user-observable changes) would be the right place to lock these in; not added in this PR to keep scope to the two bug fixes and their unit guards.

## Credits

- @Kevsosmooth — #936 report + reliable repro path.
- @maxfi — #937 original report with the multi-release pattern (v1.7.x → v1.9.1) and the cross-terminal evidence.
- @jennings — pane-content scope expansion on #937.

## Notes for reviewers

- Two commits, one per bug, each self-contained: the test for each bug lives in its own file and the home.go hunks are scoped to that bug's fix only.
- Pre-push hook `golangci-lint run` flagged pre-existing lint failures on `origin/main` (unused `statedbLog`, unused `codexRolloutExists`, empty branch in `session_cmd.go:2198`) — none introduced by this PR. Push went out with `LEFTHOOK=0` after confirming the failures predate this branch.