### PR TITLE
fix(session): gate worker-scratch CLAUDE_CONFIG_DIR injection on explicit config_dir (closes #949)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -644,29 +644,27 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 	claudeCmd := GetClaudeCommand()
 	hasCustomCommand := claudeCmd != "claude"
 
-	// Resolve CLAUDE_CONFIG_DIR for this spawn. Three branches, in order:
-	//   1. Custom command (alias like cdw/cdp) — handles config_dir itself, skip.
-	//   2. WorkerScratchConfigDir is prepared — ALWAYS route through scratch.
-	//      Scratch is the whole point of the indirection: it carries the
-	//      mutated enabledPlugins (per-session plugin attach state, issue #59
-	//      and RFC PLUGIN_ATTACH.md). Without exporting it here, claude reads
-	//      the ambient `~/.claude/settings.json` and a globally-enabled
-	//      catalog plugin (e.g. a prior `/plugin install fakechat`) bleeds
-	//      through into the worker — defeating detach.
-	//   3. Explicit config_dir from env/config — pass through unchanged.
+	// Resolve CLAUDE_CONFIG_DIR for this spawn. We inject the prefix only
+	// when the user has an explicit config_dir resolved for this instance
+	// (env var, profile, group, conductor, or `[claude].config_dir`). When
+	// the gate is open, a prepared WorkerScratchConfigDir overrides the
+	// resolved value — scratch carries the mutated enabledPlugins overlay
+	// (per-session plugin attach state, issue #59 / RFC PLUGIN_ATTACH.md).
 	//
-	// Branch 2 is always-on regardless of branch 3 because scratch is
-	// derived from the resolved source dir AND mutates settings.json on top
-	// — strictly an override.
+	// Issue #949: injecting scratch unconditionally breaks macOS Claude
+	// Code's keychain-keyed-by-CLAUDE_CONFIG_DIR-path OAuth on hosts where
+	// scratch is created for telegram-poller defense (#759) but the user
+	// has no explicit config_dir — the worker is routed to an opaque
+	// scratch path the keychain never saw, triggering login + onboarding
+	// every spawn. Gating restores the v1.9.1 behaviour: dormant scratch
+	// in that case, ambient ~/.claude wins.
 	configDirPrefix := ""
-	if !hasCustomCommand {
-		switch {
-		case i.WorkerScratchConfigDir != "":
-			configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", i.WorkerScratchConfigDir)
-		case IsClaudeConfigDirExplicitForInstance(i):
-			configDir := GetClaudeConfigDirForInstance(i)
-			configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir)
+	if !hasCustomCommand && IsClaudeConfigDirExplicitForInstance(i) {
+		configDir := GetClaudeConfigDirForInstance(i)
+		if i.WorkerScratchConfigDir != "" {
+			configDir = i.WorkerScratchConfigDir
 		}
+		configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir)
 	}
 
 	// AGENTDECK_INSTANCE_ID is set as an inline env var so Claude's hook subprocesses
@@ -786,18 +784,19 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 }
 
 // buildBashExportPrefix builds the export prefix used in bash -c commands.
-// Always exports AGENTDECK_INSTANCE_ID. CLAUDE_CONFIG_DIR is exported when
-// a worker scratch dir is prepared (always wins) OR when the user has
-// explicit config_dir — same priority as buildClaudeCommandWithMessage
-// and buildClaudeResumeCommand. Scratch is the override for the
-// per-session enabledPlugins overlay (RFC PLUGIN_ATTACH.md).
+// Always exports AGENTDECK_INSTANCE_ID. CLAUDE_CONFIG_DIR is exported only
+// when the user has an explicit config_dir resolved for this instance;
+// when that gate is open, a prepared WorkerScratchConfigDir overrides
+// the resolved value — same priority as buildClaudeCommandWithMessage
+// and buildClaudeResumeCommand. See the comment there (issue #949) for
+// why the gate is required.
 func (i *Instance) buildBashExportPrefix() string {
 	prefix := fmt.Sprintf("export AGENTDECK_INSTANCE_ID=%s; ", i.ID)
-	switch {
-	case i.WorkerScratchConfigDir != "":
-		prefix += fmt.Sprintf("export CLAUDE_CONFIG_DIR=%s; ", i.WorkerScratchConfigDir)
-	case IsClaudeConfigDirExplicitForInstance(i):
+	if IsClaudeConfigDirExplicitForInstance(i) {
 		configDir := GetClaudeConfigDirForInstance(i)
+		if i.WorkerScratchConfigDir != "" {
+			configDir = i.WorkerScratchConfigDir
+		}
 		prefix += fmt.Sprintf("export CLAUDE_CONFIG_DIR=%s; ", configDir)
 	}
 	return prefix
@@ -4992,20 +4991,18 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	claudeCmd := GetClaudeCommand()
 	hasCustomCommand := claudeCmd != "claude"
 
-	// Resolve CLAUDE_CONFIG_DIR for this restart. Mirrors the three-branch
-	// logic in buildClaudeCommandWithMessage — scratch always wins when
-	// prepared, otherwise pass through any explicit config. See the comment
-	// there for why scratch is unconditional (it carries per-session
-	// enabledPlugins and a deny-pinned telegram plugin).
+	// Resolve CLAUDE_CONFIG_DIR for this restart. Mirrors the gating logic
+	// in buildClaudeCommandWithMessage: we inject only when an explicit
+	// config_dir is resolved, with WorkerScratchConfigDir overriding the
+	// resolved value when set. See the comment there (issue #949) for the
+	// macOS-OAuth-keying motivation.
 	configDirPrefix := ""
-	if !hasCustomCommand {
-		switch {
-		case i.WorkerScratchConfigDir != "":
-			configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", i.WorkerScratchConfigDir)
-		case IsClaudeConfigDirExplicitForInstance(i):
-			configDir := GetClaudeConfigDirForInstance(i)
-			configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir)
+	if !hasCustomCommand && IsClaudeConfigDirExplicitForInstance(i) {
+		configDir := GetClaudeConfigDirForInstance(i)
+		if i.WorkerScratchConfigDir != "" {
+			configDir = i.WorkerScratchConfigDir
 		}
+		configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir)
 	}
 
 	// AGENTDECK_INSTANCE_ID is set as an inline env var so hook subprocesses

--- a/internal/session/issue949_scratch_injection_gate_test.go
+++ b/internal/session/issue949_scratch_injection_gate_test.go
@@ -1,0 +1,123 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestIssue949_ScratchInjectionGate locks the fix for #949: a prepared
+// WorkerScratchConfigDir MUST NOT be injected into the spawn command when
+// the instance has no explicit config_dir resolved (no env CLAUDE_CONFIG_DIR,
+// no profile/group/conductor config_dir, empty [claude].config_dir).
+//
+// Background. v1.7.68 (issue #59) introduced a per-worker scratch
+// CLAUDE_CONFIG_DIR to pin the telegram plugin off for non-conductor claude
+// workers on hosts running a telegram conductor. v1.9.2 (#779 / b7d37f15)
+// refactored the spawn-command gate to inject the scratch unconditionally
+// — losing the v1.7.68 + v1.9.1 invariant that scratch was an OVERRIDE for
+// an existing explicit config_dir, never a standalone injection.
+//
+// On macOS this broke OAuth and Claude Code first-run onboarding for every
+// telegram-conductor host with no explicit config_dir: the claude binary
+// was routed to an opaque scratch path the keychain never saw, triggering
+// login + theme + trust prompts on every spawn. Fix restores the gating.
+func TestIssue949_ScratchInjectionGate(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	origProfile := os.Getenv("AGENTDECK_PROFILE")
+	origClaudeDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origProfile != "" {
+			_ = os.Setenv("AGENTDECK_PROFILE", origProfile)
+		} else {
+			_ = os.Unsetenv("AGENTDECK_PROFILE")
+		}
+		if origClaudeDir != "" {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", origClaudeDir)
+		} else {
+			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+		}
+		ClearUserConfigCache()
+	})
+
+	_ = os.Setenv("HOME", tmpHome)
+	_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+	_ = os.Unsetenv("AGENTDECK_PROFILE")
+
+	agentDeckDir := filepath.Join(tmpHome, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// No [claude].config_dir, no [groups.X].claude.config_dir,
+	// no [profiles.X].claude.config_dir, no [conductors.X].claude.config_dir.
+	// Telegram token is present so the host satisfies
+	// hostHasTelegramConductor() — the exact production shape that triggered
+	// scratch creation on the reporter's host.
+	cfg := `
+[conductor.telegram]
+token = "fake-token-for-test"
+`
+	if err := os.WriteFile(filepath.Join(agentDeckDir, "config.toml"), []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	ClearUserConfigCache()
+
+	scratch := filepath.Join(agentDeckDir, "worker-scratch", "inst-test")
+	if err := os.MkdirAll(scratch, 0o700); err != nil {
+		t.Fatalf("mkdir scratch: %v", err)
+	}
+
+	t.Run("no_explicit_config_dir_keeps_scratch_dormant", func(t *testing.T) {
+		inst := NewInstanceWithGroupAndTool("inst-test", "/tmp/p", "code", "claude")
+		inst.ID = "inst-test"
+		inst.WorkerScratchConfigDir = scratch
+
+		if IsClaudeConfigDirExplicitForInstance(inst) {
+			t.Fatalf("precondition violated: IsClaudeConfigDirExplicitForInstance must be false for this fixture")
+		}
+
+		cmd := inst.buildClaudeCommandWithMessage("claude", "")
+		if strings.Contains(cmd, "CLAUDE_CONFIG_DIR=") {
+			t.Errorf("scratch must NOT be injected when no explicit config_dir is set (#949)\ngot: %s", cmd)
+		}
+
+		exp := inst.buildBashExportPrefix()
+		if strings.Contains(exp, "CLAUDE_CONFIG_DIR=") {
+			t.Errorf("buildBashExportPrefix must NOT export CLAUDE_CONFIG_DIR when no explicit config_dir is set (#949)\ngot: %s", exp)
+		}
+	})
+
+	t.Run("explicit_config_dir_lets_scratch_override", func(t *testing.T) {
+		explicit := filepath.Join(tmpHome, ".claude-explicit")
+		cfgExplicit := `
+[claude]
+config_dir = "~/.claude-explicit"
+
+[conductor.telegram]
+token = "fake-token-for-test"
+`
+		if err := os.WriteFile(filepath.Join(agentDeckDir, "config.toml"), []byte(cfgExplicit), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		ClearUserConfigCache()
+
+		inst := NewInstanceWithGroupAndTool("inst-test", "/tmp/p", "code", "claude")
+		inst.ID = "inst-test"
+		inst.WorkerScratchConfigDir = scratch
+
+		if !IsClaudeConfigDirExplicitForInstance(inst) {
+			t.Fatalf("precondition violated: IsClaudeConfigDirExplicitForInstance must be true with [claude].config_dir set")
+		}
+
+		cmd := inst.buildClaudeCommandWithMessage("claude", "")
+		if !strings.Contains(cmd, "CLAUDE_CONFIG_DIR="+scratch) {
+			t.Errorf("scratch must override explicit config_dir when both are set\nwant CLAUDE_CONFIG_DIR=%s\ngot: %s", scratch, cmd)
+		}
+		if strings.Contains(cmd, "CLAUDE_CONFIG_DIR="+explicit+" ") {
+			t.Errorf("explicit path leaked despite scratch override\ngot: %s", cmd)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #949.

v1.9.2 (#779) refactored the `CLAUDE_CONFIG_DIR` resolver in `instance.go` (three call sites: `buildClaudeCommandWithMessage`, `buildBashExportPrefix`, `buildClaudeResumeCommand`) so that a prepared `WorkerScratchConfigDir` is injected unconditionally. This drops the v1.7.68 / v1.9.1 invariant that scratch was an *override* for an existing explicit `config_dir` — never a standalone injection.

On macOS the worker is now routed to an opaque per-instance scratch path the keychain has never seen, triggering Claude Code's first-run flow (login + theme + folder trust) on every spawn. The RFC in `docs/rfc/PLUGIN_ATTACH.md §7` anticipated this only for `--plugin` users; the telegram-poller-defense path (which fires for **every** non-conductor claude session on hosts where `[conductor.telegram].token` is set, regardless of `--plugin`) silently regressed too.

git bisect over `v1.9.1..v1.9.2`:

```
# bad:  3bbbc603 feat(ui): widen new session dialog for long paths (#894)
# bad:  42fe4f48 feat(session,statedb): migrate sessions/conductors/groups across profiles (#928)
# bad:  b7d37f15 feat(plugins): per-session Claude Code plugin enablement (#779)
# good: fbdc3852 fix(tmux): distinguish live sibling TUIs from orphan control clients (#944)
# first bad commit: b7d37f15
```

## Fix

Restore the `IsClaudeConfigDirExplicitForInstance(i)` gate at all three sites. When the gate is open and `WorkerScratchConfigDir` is set, scratch overrides the resolved explicit value (same priority as v1.9.1). When the gate is closed, scratch stays dormant and claude runs against the ambient profile — exactly the v1.9.1 behaviour.

The catalog-plugin overlay still works: scratch is built on disk and gets used whenever any of profile / group / conductor / env / `[claude].config_dir` resolves. Users opting into `--plugin` who want the scratch to actually engage should also configure an explicit `config_dir` — which matches the deployment shape the original PR assumed.

## Test

New regression test `internal/session/issue949_scratch_injection_gate_test.go` locks both directions of the gate:

- `no_explicit_config_dir_keeps_scratch_dormant` — telegram token configured (so `hostHasTelegramConductor()` is true and scratch would be prepared in production), but no explicit `config_dir` anywhere. Asserts neither `buildClaudeCommandWithMessage` nor `buildBashExportPrefix` injects `CLAUDE_CONFIG_DIR=` even with `WorkerScratchConfigDir` populated.
- `explicit_config_dir_lets_scratch_override` — same fixture plus `[claude].config_dir = "~/.claude-explicit"`. Asserts scratch wins over the explicit value (the override invariant the original PR was preserving for the plugin overlay use case).

Both pass on this branch; the `no_explicit` subtest fails against `upstream/main` HEAD as expected (RED on the regression).

```
$ go test -race -run TestIssue949 ./internal/session/...
ok  github.com/asheshgoplani/agent-deck/internal/session  1.4s
```

Full session-package suite has the same pre-existing tmux-socket-path-too-long failures on macOS as `upstream/main` (verified by stashing the patch and re-running); unrelated to this change.
