### PR TITLE
fix(costs): pin clock in TotalLastWeek to fix Monday UTC flake (closes #932)

### DIFF
--- a/internal/costs/store.go
+++ b/internal/costs/store.go
@@ -9,12 +9,19 @@ import (
 
 // Store persists and queries cost events in SQLite.
 type Store struct {
-	db *sql.DB
+	db  *sql.DB
+	now func() time.Time
 }
 
 // NewStore creates a Store using an existing database connection.
 func NewStore(db *sql.DB) *Store {
-	return &Store{db: db}
+	return &Store{db: db, now: time.Now}
+}
+
+// SetClock overrides the clock used for time-windowed queries. Tests use this
+// to pin "now" to a deterministic instant (e.g. a Monday UTC boundary).
+func (s *Store) SetClock(now func() time.Time) {
+	s.now = now
 }
 
 // DB returns the underlying database for transactional operations.
@@ -75,11 +82,19 @@ func (s *Store) TotalYesterday() (CostSummary, error) {
 		AND timestamp < date('now', 'start of day')`)
 }
 
-// TotalLastWeek returns the prior ISO-week's total costs (Monday start),
-// mirroring the boundary semantics of TotalThisWeek.
+// TotalLastWeek returns the prior ISO-week's total costs (Monday start).
+// Boundaries are computed in Go from the injected clock so the result is
+// stable across the Monday UTC tick — SQLite's `date('now', 'weekday 1')`
+// is a no-op on Monday and shifts the window by 7 days, producing the
+// week-before-last instead of last week (#932).
 func (s *Store) TotalLastWeek() (CostSummary, error) {
-	return s.querySum(`WHERE timestamp >= date('now', 'weekday 1', '-14 days')
-		AND timestamp < date('now', 'weekday 1', '-7 days')`)
+	now := s.now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	daysSinceMonday := (int(today.Weekday()) + 6) % 7 // Mon=0..Sun=6
+	thisMonday := today.AddDate(0, 0, -daysSinceMonday)
+	lastMonday := thisMonday.AddDate(0, 0, -7)
+	return s.querySum(`WHERE timestamp >= ? AND timestamp < ?`,
+		lastMonday.Format(time.RFC3339), thisMonday.Format(time.RFC3339))
 }
 
 // TotalLastMonth returns the prior calendar month's total costs.

--- a/internal/costs/store_test.go
+++ b/internal/costs/store_test.go
@@ -285,6 +285,67 @@ func TestStore_TotalLastWeek_OnlyLastWeekEvent(t *testing.T) {
 	}
 }
 
+// TestStore_TotalLastWeek_HandlesMondayBoundary pins the clock to a Monday at
+// 00:00:01 UTC and verifies that "last week" resolves to [previous Monday,
+// this Monday) — not [two-Mondays-ago, last Monday), which is what the
+// SQLite-only implementation produced because `date('now', 'weekday 1')` is a
+// no-op on Monday. Regression for #932.
+func TestStore_TotalLastWeek_HandlesMondayBoundary(t *testing.T) {
+	s := testStore(t)
+
+	// Pin to Monday 2025-11-10 at 00:00:01 UTC. This date is deliberately far
+	// from the wall-clock "now": a broken implementation that ignores the
+	// injected clock will compute the window relative to today's real date
+	// and find none of the inserted events, producing total=0 instead of the
+	// expected 71000.
+	monday := time.Date(2025, 11, 10, 0, 0, 1, 0, time.UTC)
+	s.SetClock(func() time.Time { return monday })
+
+	// Event firmly inside last week relative to pinned Monday (Thu 2025-11-06).
+	lastWeekEvent := time.Date(2025, 11, 6, 12, 0, 0, 0, time.UTC)
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-lw-mon", SessionID: "s1", Timestamp: lastWeekEvent,
+		Model: "claude-sonnet-4-6", CostMicrodollars: 70000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Event at last Monday 00:00 — boundary INCLUSIVE (2025-11-03).
+	lastMonday := time.Date(2025, 11, 3, 0, 0, 0, 0, time.UTC)
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-lw-start", SessionID: "s1", Timestamp: lastMonday,
+		Model: "claude-sonnet-4-6", CostMicrodollars: 1000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Event at the pinned Monday (this week's start) — boundary EXCLUSIVE.
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-this-mon", SessionID: "s1", Timestamp: monday,
+		Model: "claude-sonnet-4-6", CostMicrodollars: 50000,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Event two weeks ago relative to pinned Monday (Thu 2025-10-30).
+	twoWeeksAgo := time.Date(2025, 10, 30, 12, 0, 0, 0, time.UTC)
+	if err := s.WriteCostEvent(costs.CostEvent{
+		ID: "evt-2w", SessionID: "s1", Timestamp: twoWeeksAgo,
+		Model: "claude-sonnet-4-6", CostMicrodollars: 99999,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := s.TotalLastWeek()
+	if err != nil {
+		t.Fatalf("TotalLastWeek: %v", err)
+	}
+	want := int64(71000) // 70000 + 1000
+	if summary.TotalCostMicrodollars != want {
+		t.Errorf("Monday UTC: last-week total = %d, want %d", summary.TotalCostMicrodollars, want)
+	}
+	if summary.EventCount != 2 {
+		t.Errorf("Monday UTC: event count = %d, want 2", summary.EventCount)
+	}
+}
+
 func TestStore_TotalLastWeek_TwoWeeksAgoExcluded(t *testing.T) {
 	s := testStore(t)
 	twoWeeksAgo := time.Now().AddDate(0, 0, -16)


### PR DESCRIPTION
## Summary
Closes #932.

`TestStore_TotalLastWeek_OnlyLastWeekEvent` flaked on the Weekly Regression cron whenever the CI runner woke across the Monday 00:00 UTC tick. Root cause is in production: SQLite's \`date('now', 'weekday 1')\` modifier is a **no-op on Monday** (today already *is* weekday 1), so on a Monday UTC tick the SQL window shifted by 7 days and `TotalLastWeek` returned the week BEFORE last — events the test inserted for "last Thursday" fell outside the window.

## Fix shape
- `internal/costs/store.go:80-93` — `TotalLastWeek` now computes its `[lastMonday, thisMonday)` boundary in Go using an injectable clock and passes them as bound parameters. Removes reliance on SQLite's quirky `weekday N` modifier.
- `Store.SetClock(func() time.Time)` exposes the clock for tests. Default is `time.Now` (no behavior change for callers).

## Regression test
- `TestStore_TotalLastWeek_HandlesMondayBoundary` pins the clock to **Monday 2025-11-10 00:00:01 UTC** and asserts the window is `[2025-11-03, 2025-11-10)`. Fails deterministically on the old SQL, passes on the fix.

### Failing test output BEFORE fix
\`\`\`
=== RUN   TestStore_TotalLastWeek_HandlesMondayBoundary
    store_test.go:342: Monday UTC: last-week total = 0, want 71000
    store_test.go:345: Monday UTC: event count = 0, want 2
--- FAIL: TestStore_TotalLastWeek_HandlesMondayBoundary (0.14s)
FAIL
\`\`\`

### Passing test output AFTER fix
\`\`\`
=== RUN   TestStore_TotalLastWeek_NoEvents
--- PASS: TestStore_TotalLastWeek_NoEvents (0.10s)
=== RUN   TestStore_TotalLastWeek_OnlyThisWeekEvent
--- PASS: TestStore_TotalLastWeek_OnlyThisWeekEvent (0.09s)
=== RUN   TestStore_TotalLastWeek_OnlyLastWeekEvent
--- PASS: TestStore_TotalLastWeek_OnlyLastWeekEvent (0.09s)
=== RUN   TestStore_TotalLastWeek_HandlesMondayBoundary
--- PASS: TestStore_TotalLastWeek_HandlesMondayBoundary (0.14s)
=== RUN   TestStore_TotalLastWeek_TwoWeeksAgoExcluded
--- PASS: TestStore_TotalLastWeek_TwoWeeksAgoExcluded (0.10s)
PASS
ok  	github.com/asheshgoplani/agent-deck/internal/costs	1.543s
\`\`\`

Also stabilizes the Weekly Regression cron, which previously had a 1-in-7 chance of failing on the Monday UTC boundary even though the production query was deterministic.

## Test plan
- [x] New regression test fails before fix, passes after
- [x] \`go test ./internal/costs/ -race -count=1\` green
- [x] \`go test ./internal/web/ -race -count=1 -run Cost\` green (other consumers of \`costs.NewStore\` unaffected)
- [ ] Re-run Weekly Regression cron on Monday UTC to confirm stability