### PR TITLE
fix(session-share): resolve export.sh exit 5 (closes #895)

### DIFF
--- a/skills/session-share/scripts/export.sh
+++ b/skills/session-share/scripts/export.sh
@@ -127,7 +127,12 @@ while IFS= read -r line || [ -n "$line" ]; do
 
         # Strip thinking blocks if needed
         if [ "$INCLUDE_THINKING" = "false" ]; then
-            filtered=$(echo "$processed_line" | jq -c 'if .message.content then .message.content = [.message.content[] | select(.type != "thinking")] else . end' 2>/dev/null)
+            # Real Claude Code JSONL has records where message.content is a
+            # plain string (slash-command output, local-command caveats, etc.).
+            # Only iterate `.message.content[]` when it's an array, otherwise
+            # pass the record through unchanged — there are no thinking blocks
+            # in a string payload to strip. (#895)
+            filtered=$(echo "$processed_line" | jq -c 'if (.message.content | type) == "array" then .message.content |= map(select(.type != "thinking")) else . end' 2>/dev/null)
             if [ -n "$filtered" ]; then
                 processed_line="$filtered"
             fi

--- a/skills/session-share/scripts/utils.sh
+++ b/skills/session-share/scripts/utils.sh
@@ -3,10 +3,12 @@
 
 set -euo pipefail
 
-# Encode a path the same way Claude does (/ becomes -)
+# Encode a path the same way Claude Code does: both `/` and `.` become `-`.
+# (See #895 — paths like /Users/first.last/... must encode to
+# -Users-first-last-... to find the on-disk projects directory.)
 encode_path() {
     local path="$1"
-    echo "$path" | sed 's|^/|-|' | sed 's|/|-|g'
+    echo "$path" | sed 's|^/|-|' | sed 's|[/.]|-|g'
 }
 
 # Decode an encoded path back to original
@@ -62,7 +64,7 @@ sanitize_jsonl() {
         # Replace username in paths
         sed "s|/Users/$escaped_username|/Users/\$USER|g" | \
         # Remove thinking blocks (they contain internal reasoning)
-        jq -c 'if .message.content then .message.content = [.message.content[] | select(.type != "thinking")] else . end' 2>/dev/null || echo "$content"
+        jq -c 'if (.message.content | type) == "array" then .message.content |= map(select(.type != "thinking")) else . end' 2>/dev/null || echo "$content"
 }
 
 # Generate export filename

--- a/skills/session-share/tests/test_export_895_regression.sh
+++ b/skills/session-share/tests/test_export_895_regression.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Regression tests for https://github.com/asheshgoplani/agent-deck/issues/895
+# Two bugs caused `export.sh` to silently exit 5 on real Claude Code sessions:
+#   - Bug 1: encode_path didn't mirror Claude Code's `.` -> `-` encoding,
+#            so projects whose path contains `.` couldn't be located.
+#   - Bug 2: jq filter at export.sh:130 assumed `.message.content` was always
+#            an array; on a string-shaped record, jq errored and `set -euo
+#            pipefail` killed the script with exit 5.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXPORT_SH="$SCRIPT_DIR/../scripts/export.sh"
+
+if [ ! -x "$EXPORT_SH" ] && [ ! -f "$EXPORT_SH" ]; then
+    echo "FAIL: cannot locate $EXPORT_SH" >&2
+    exit 99
+fi
+
+pass_count=0
+fail_count=0
+
+run_case() {
+    local name="$1"
+    shift
+    if "$@"; then
+        echo "ok - $name"
+        pass_count=$((pass_count + 1))
+    else
+        echo "not ok - $name" >&2
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+make_fixture() {
+    # Args: $1 = project-dir-template (mktemp template, no `.` if you want to
+    #            isolate bug 2 from bug 1)
+    # Echoes: "<HOME> <PROJECT> <UUID>"
+    local template="$1"
+    local home_dir project_dir uuid
+    home_dir=$(mktemp -d)
+    project_dir=$(mktemp -d -p /tmp "$template")
+    uuid="11111111-2222-3333-4444-555555555555"
+
+    # Mirror Claude Code's real encoding: both `/` and `.` become `-`.
+    local encoded
+    encoded=$(echo "$project_dir" | sed 's|^/|-|' | sed 's|[/.]|-|g')
+    mkdir -p "$home_dir/.claude/projects/$encoded"
+
+    # One user record whose message.content is a STRING (the bug 2 trigger
+    # — Claude Code emits these for slash-command output, local-command
+    # caveats, etc.) plus one normal assistant record.
+    cat > "$home_dir/.claude/projects/$encoded/$uuid.jsonl" <<JSONL
+{"type":"user","message":{"role":"user","content":"<local-command-stdout>example</local-command-stdout>"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"acknowledged"}]}}
+JSONL
+
+    echo "$home_dir $project_dir $uuid"
+}
+
+# --- Test 1: bug 2 — exit 5 on string-shaped message.content ---
+test_export_handles_string_content() {
+    local fx home_dir project_dir uuid output rc
+    fx=$(make_fixture "tdd895-strcontent-XXXXXX")
+    read -r home_dir project_dir uuid <<<"$fx"
+    output="$home_dir/out.json"
+
+    rc=0
+    ( cd "$project_dir" && HOME="$home_dir" bash "$EXPORT_SH" \
+        --session "$uuid" --no-sanitize --output "$output" >/dev/null 2>&1 ) \
+        || rc=$?
+
+    rm -rf "$home_dir" "$project_dir"
+
+    if [ "$rc" -ne 0 ]; then
+        echo "  expected exit 0, got $rc (regression for #895 bug 2)" >&2
+        return 1
+    fi
+    return 0
+}
+
+# --- Test 2: bug 1 — encode_path must convert `.` to `-` ---
+# Sourced helper test; doesn't run the full export.
+test_encode_path_handles_dot() {
+    local result
+    # shellcheck source=../scripts/utils.sh
+    result=$(bash -c '
+        set -e
+        source "$1"
+        encode_path "/Users/first.last/Projects/my-app"
+    ' _ "$SCRIPT_DIR/../scripts/utils.sh")
+
+    local expected="-Users-first-last-Projects-my-app"
+    if [ "$result" != "$expected" ]; then
+        echo "  expected $expected, got $result (regression for #895 bug 1)" >&2
+        return 1
+    fi
+    return 0
+}
+
+run_case "export.sh exits 0 when message.content is a string (#895 bug 2)" \
+    test_export_handles_string_content
+run_case "encode_path converts '.' to '-' to match Claude Code (#895 bug 1)" \
+    test_encode_path_handles_dot
+
+echo "---"
+echo "passed: $pass_count, failed: $fail_count"
+[ "$fail_count" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes #895. Two stacked bugs caused `skills/session-share/scripts/export.sh` to exit 5 (silently) on every real Claude Code session. Both fixed; both pinned by a new regression test.

Credit to @victorgasparini-hotmart for the diagnosis — full repro, exact `bash -x` trace of the failing line, and proposed fixes in the issue body.

## Reproduce → fix → verify

### Reproduce (against `origin/main` HEAD)
Minimal fixture: a fake `~/.claude/projects/<encoded>/<uuid>.jsonl` with one user record whose `message.content` is a plain string (the JSONL shape Claude Code emits for slash-command output, `<local-command-caveat>...`, etc.) — then:

```bash
cd <project-dir>
HOME=<fixture-home> bash skills/session-share/scripts/export.sh \
    --session <uuid> --no-sanitize --output /tmp/out.json
echo $?   # → 5
```

Root cause at `export.sh:130`:

```bash
filtered=$(echo "$processed_line" | jq -c 'if .message.content then .message.content = [.message.content[] | select(.type != "thinking")] else . end' 2>/dev/null)
```

`.message.content[]` errors when `.message.content` is a string. `set -o pipefail` propagates the 5, the command-substitution assignment trips `set -e`, and the EXIT trap's `rm -f` returns 0 — silent script exit 5.

Latent **bug 1**: `utils.sh::encode_path` only converted `/` → `-`, but Claude Code also encodes `.` → `-`. Any path containing `.` (e.g. macOS `first.last` accounts) caused `find_session_file` to fail with exit 1.

### Fix
- `export.sh:130` and the matching site in `utils.sh::sanitize_jsonl`: type-check `.message.content` inside jq, so string-shaped records pass through unchanged (there are no thinking blocks to strip from a string).
- `utils.sh::encode_path`: widen the `sed` character class to `[/.]`.

### Verify
New regression test `skills/session-share/tests/test_export_895_regression.sh`:

```
Before fix:
  not ok - export.sh exits 0 when message.content is a string (#895 bug 2)
    expected exit 0, got 5
  not ok - encode_path converts '.' to '-' to match Claude Code (#895 bug 1)
  passed: 0, failed: 2

After fix:
  ok - export.sh exits 0 when message.content is a string (#895 bug 2)
  ok - encode_path converts '.' to '-' to match Claude Code (#895 bug 1)
  passed: 2, failed: 0
```

End-to-end smoke: full `export.sh` run on a JSONL containing string-content, array-content with a `thinking` block, and array-content text — exits 0, output JSON contains all 3 records, thinking block stripped, string content preserved.

## Scope

Touches `skills/session-share/` only. No Go changes.

## Test plan
- [x] Regression test fails on `origin/main` with the exact reporter-observed exit 5
- [x] Regression test passes after the fix
- [x] End-to-end `export.sh` run produces valid JSON with mixed record shapes
- [ ] Reviewer to confirm fix on a real Claude Code session (per #895 repro)

---

Committed by Ashesh Goplani