### PR TITLE
fix(update): detect failed brew upgrade and fail loudly (closes #954)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -2654,30 +2655,76 @@ func handleUpdateToSpecificVersion(requested string, checkOnly bool) {
 	fmt.Println("  Restart agent-deck to use this version.")
 }
 
+// brewRunner abstracts `brew <args...>` so tests can inject canned output
+// without touching the real binary. The contract: return the combined
+// stdout+stderr captured from the invocation, plus the process exit error
+// (nil on exit 0). Implementations may also tee output to the terminal so
+// the user still sees brew's live progress.
+type brewRunner interface {
+	Run(args ...string) ([]byte, error)
+}
+
+// execBrewRunner is the production runner: it invokes the real `brew` binary
+// and tees its output to the user's terminal while capturing a copy for the
+// post-run inspection that #954 requires.
+type execBrewRunner struct{ bin string }
+
+func (e *execBrewRunner) Run(args ...string) ([]byte, error) {
+	cmd := exec.Command(e.bin, args...)
+	cmd.Stdin = os.Stdin
+	var buf bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &buf)
+	err := cmd.Run()
+	return buf.Bytes(), err
+}
+
 func runHomebrewUpgradeWithRefresh(homebrewUpgradeCmd string) error {
 	cmdParts := strings.Fields(homebrewUpgradeCmd)
 	if len(cmdParts) == 0 {
 		return fmt.Errorf("empty Homebrew upgrade command")
 	}
+	return runHomebrewUpgradeWith(&execBrewRunner{bin: cmdParts[0]}, homebrewUpgradeCmd)
+}
 
-	brewBin := cmdParts[0]
-	refreshCmd := exec.Command(brewBin, "update")
-	refreshCmd.Stdout = os.Stdout
-	refreshCmd.Stderr = os.Stderr
-	refreshCmd.Stdin = os.Stdin
-	if err := refreshCmd.Run(); err != nil {
+// runHomebrewUpgradeWith executes `brew update` then `brew <upgrade args>` via
+// the supplied runner. It fails loudly when brew exits 0 but its output shows
+// the formula was refused (e.g. "Warning: agent-deck X.Y.Z already installed")
+// — see #954, reported by @alexandergharibian.
+func runHomebrewUpgradeWith(r brewRunner, homebrewUpgradeCmd string) error {
+	cmdParts := strings.Fields(homebrewUpgradeCmd)
+	if len(cmdParts) == 0 {
+		return fmt.Errorf("empty Homebrew upgrade command")
+	}
+
+	if _, err := r.Run("update"); err != nil {
 		return fmt.Errorf("failed to refresh Homebrew metadata: %w", err)
 	}
 
-	upgradeCmd := exec.Command(brewBin, cmdParts[1:]...)
-	upgradeCmd.Stdout = os.Stdout
-	upgradeCmd.Stderr = os.Stderr
-	upgradeCmd.Stdin = os.Stdin
-	if err := upgradeCmd.Run(); err != nil {
+	out, err := r.Run(cmdParts[1:]...)
+	if err != nil {
 		return fmt.Errorf("failed to run `%s`: %w", homebrewUpgradeCmd, err)
 	}
 
+	if brewRefusedUpgrade(string(out)) {
+		return fmt.Errorf(
+			"brew did not upgrade agent-deck; the tap formula may be stale (#954). "+
+				"Try `brew untap asheshgoplani/tap && brew tap asheshgoplani/tap && %s`, "+
+				"or download the latest release directly from GitHub. brew output: %s",
+			homebrewUpgradeCmd,
+			strings.TrimSpace(string(out)),
+		)
+	}
+
 	return nil
+}
+
+// brewRefusedUpgrade reports whether `brew upgrade` output indicates brew
+// declined to install a new version. Brew prints "Warning: <formula> X.Y.Z
+// already installed" and exits 0 in that case — exactly the lying-success
+// path that #954 surfaced.
+func brewRefusedUpgrade(output string) bool {
+	return strings.Contains(strings.ToLower(output), "already installed")
 }
 
 // displayChangelog fetches and displays changelog between versions

--- a/cmd/agent-deck/update_cmd_test.go
+++ b/cmd/agent-deck/update_cmd_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// fakeBrewRunner records calls and returns canned outputs/errors per call,
+// so tests can simulate brew's stdout/stderr without touching the real binary.
+type fakeBrewRunner struct {
+	calls   [][]string
+	outputs []string
+	errs    []error
+}
+
+func (f *fakeBrewRunner) Run(args ...string) ([]byte, error) {
+	n := len(f.calls)
+	f.calls = append(f.calls, args)
+	var out []byte
+	if n < len(f.outputs) {
+		out = []byte(f.outputs[n])
+	}
+	var err error
+	if n < len(f.errs) {
+		err = f.errs[n]
+	}
+	return out, err
+}
+
+// TestUpdate_DetectsNoVersionBump_FailsLoudly_RegressionFor954 reproduces #954
+// (reported by @alexandergharibian): `agent-deck update` printed
+//
+//	Already up-to-date. Warning: 1.8.3 already installed
+//	✓ Updated to v1.9.4
+//
+// even though brew explicitly refused to upgrade. The CLI must instead fail
+// loudly with a clear message — never claim success when brew said no.
+func TestUpdate_DetectsNoVersionBump_FailsLoudly_RegressionFor954(t *testing.T) {
+	runner := &fakeBrewRunner{
+		outputs: []string{
+			// `brew update` — metadata fetch succeeds.
+			"Already up-to-date.\n",
+			// `brew upgrade asheshgoplani/tap/agent-deck` — brew refuses
+			// because the tap formula still pins the old version. Exit 0.
+			"Warning: agent-deck 1.8.3 already installed\n",
+		},
+		errs: []error{nil, nil},
+	}
+
+	err := runHomebrewUpgradeWith(runner, "brew upgrade asheshgoplani/tap/agent-deck")
+	if err == nil {
+		t.Fatalf("expected error when brew refuses upgrade (regression #954: CLI printed '✓ Updated' while brew said 'already installed')")
+	}
+	msg := err.Error()
+	if !strings.Contains(strings.ToLower(msg), "did not upgrade") {
+		t.Errorf("error must clearly state brew did not upgrade; got: %v", err)
+	}
+	if !strings.Contains(msg, "954") {
+		t.Errorf("error should cite issue #954 so users can trace; got: %v", err)
+	}
+
+	if len(runner.calls) != 2 {
+		t.Fatalf("expected 2 brew calls (update + upgrade); got %d: %+v", len(runner.calls), runner.calls)
+	}
+	if len(runner.calls[0]) == 0 || runner.calls[0][0] != "update" {
+		t.Errorf("first call should be `brew update`; got %v", runner.calls[0])
+	}
+	if len(runner.calls[1]) == 0 || runner.calls[1][0] != "upgrade" {
+		t.Errorf("second call should be `brew upgrade`; got %v", runner.calls[1])
+	}
+}
+
+// TestUpdate_AcceptsRealUpgrade_NoFalseFailure guards against over-shooting the
+// #954 fix: when brew actually upgrades, runHomebrewUpgradeWith must return nil.
+func TestUpdate_AcceptsRealUpgrade_NoFalseFailure(t *testing.T) {
+	runner := &fakeBrewRunner{
+		outputs: []string{
+			"Already up-to-date.\n",
+			"==> Upgrading asheshgoplani/tap/agent-deck\n==> Pouring agent-deck-1.9.4.bottle.tar.gz\n🍺  /opt/homebrew/Cellar/agent-deck/1.9.4: 5 files\n",
+		},
+		errs: []error{nil, nil},
+	}
+	if err := runHomebrewUpgradeWith(runner, "brew upgrade asheshgoplani/tap/agent-deck"); err != nil {
+		t.Fatalf("real-upgrade output should not be flagged as a refused upgrade; got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`agent-deck update` was printing a green success line even when Homebrew
explicitly refused to upgrade. Reported by **@alexandergharibian** in #954:

> ```
> $ agent-deck update
> agent-deck update output: 'Already up-to-date. Warning: 1.8.3 already installed'
> followed misleadingly by '✓ Updated to v1.9.4'
> ```

That's a real "the tool lied to me" UX bug, regardless of *why* brew refused
the upgrade. This PR fixes the lying CLI. The underlying tap staleness
(HOMEBREW_TAP_GITHUB_TOKEN secret missing on the release workflow, so the
tap formula doesn't roll forward) is a separate user-action and remains
tracked elsewhere.

## Root cause

`runHomebrewUpgradeWithRefresh` in `cmd/agent-deck/main.go` shelled out to
`brew update` then `brew upgrade …` and only checked the process exit
code. Brew exits **0** when it prints `Warning: agent-deck X.Y.Z already
installed` and skips the upgrade — so `handleUpdate` happily fell through
to `fmt.Printf("\n✓ Updated to v%s\n", info.LatestVersion)`.

## Fix

1. New `brewRunner` interface — `Run(args ...string) ([]byte, error)` — so
   the brew shell-out is injectable. The production runner tees output to
   the user's terminal while capturing a copy for inspection.
2. After `brew upgrade` returns, scan its combined stdout/stderr for the
   `already installed` refusal marker. When detected, return an error
   that cites #954, includes the brew output, and points at the tap-
   staleness recovery path (`brew untap` / re-tap).
3. `handleUpdate` already surfaces returned errors via `os.Exit(1)` — no
   change there, just a real error to propagate now.

## Tests

`cmd/agent-deck/update_cmd_test.go` (RED-first):

- `TestUpdate_DetectsNoVersionBump_FailsLoudly_RegressionFor954` — replays
  @alexandergharibian's exact reproducer through a fake `brewRunner` and
  asserts the CLI returns a non-nil error containing "did not upgrade"
  and "954". Was failing on current `main`; passes after this commit.
- `TestUpdate_AcceptsRealUpgrade_NoFalseFailure` — guards against
  over-fitting: a real `Pouring agent-deck-1.9.4.bottle.tar.gz` output
  must NOT be flagged.

Full `go test -race -count=1 ./...` green.

## Credits

@alexandergharibian — clear repro with exact brew output made this a
1-shot fix. Thank you.

Closes #954.