### PR TITLE
fix(ui): popup Enter selects highlighted + arrow keys reliable (closes #896 residual sub-bugs)

### DIFF
--- a/internal/ui/issue896_residual_test.go
+++ b/internal/ui/issue896_residual_test.go
@@ -1,0 +1,139 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Issue #896 sub-bug 3 (paskal's enumeration): the path-suggestions popup is
+// visible after typing a prefix, but pressing Enter does NOT select the
+// highlighted suggestion — it submits whatever value is in the input. The
+// popup looks interactive but Enter ignores it.
+//
+// Root cause: home.go's Enter handler only intercepts when
+// IsSuggestionsActive() is true, which today requires the user to first press
+// Space or Ctrl+N to enter "arrow-key mode". Plain arrow keys on a freshly
+// shown popup do not activate it — they move dialog focus instead.
+//
+// Fix contract verified here: once the user presses Down on a visible popup,
+// the popup becomes active and the highlighted real suggestion is the one
+// that gets applied (i.e. ApplyHighlightedSuggestion writes it to pathInput).
+// home.go's existing Enter handler then submits with that path.
+func TestNewDialog_PopupEnter_SelectsHighlightedSuggestion_RegressionFor896(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+
+	suggestions := []string{"/p/alpha", "/p/beta", "/p/gamma"}
+	d.SetPathSuggestions(suggestions)
+
+	// Focus the path field — focusIndex 2 in the default layout
+	// (focusName, focusMultiRepo, focusPath, ...).
+	d.focusIndex = 2
+	d.updateFocus()
+
+	// User has typed a prefix; the popup is visible (path focused, not hidden).
+	d.pathInput.SetValue("/p/")
+
+	// User presses Down twice — cursor should advance through:
+	//   0 ("Type custom") -> 1 (/p/alpha) -> 2 (/p/beta)
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyDown})
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyDown})
+
+	// Precondition for the Enter handler in home.go: popup must be active so
+	// IsSuggestionsActive() is true and apply-highlighted runs.
+	if !d.IsSuggestionsActive() {
+		t.Fatalf("after Down arrows on visible popup, IsSuggestionsActive()=false; home.go's Enter handler will be skipped and form will submit with typed value (issue #896 sub-bug 3)")
+	}
+	if d.IsTypeCustomHighlighted() {
+		t.Fatalf("after 2 Down arrows, Type-custom is highlighted; cursor=%d, expected to be on a real suggestion", d.pathSuggestionCursor)
+	}
+	if got := d.pathSuggestionCursor; got != 2 {
+		t.Fatalf("after 2 Down arrows, pathSuggestionCursor=%d, want 2 (second real suggestion)", got)
+	}
+
+	// Now simulate exactly what home.handleNewDialogKey does on Enter when the
+	// popup is active and a real suggestion is highlighted:
+	//   d.ApplyHighlightedSuggestion(); d.DismissSuggestions();
+	// then falls through to the form-submit Enter handler.
+	d.ApplyHighlightedSuggestion()
+	d.DismissSuggestions()
+
+	got := d.pathInput.Value()
+	want := "/p/beta"
+	if got != want {
+		t.Errorf("after popup-Enter on highlighted suggestion 2, pathInput=%q, want %q\n"+
+			"this is issue #896 sub-bug 3: Enter selected the wrong target", got, want)
+	}
+	if got == "/p/" {
+		t.Errorf("popup-Enter kept the typed prefix instead of applying the highlighted suggestion (#896 sub-bug 3)")
+	}
+	if got == "/p/alpha" {
+		t.Errorf("popup-Enter applied suggestion 0 (off-by-one) instead of the highlighted suggestion 2 (#896 sub-bug 3)")
+	}
+}
+
+// Issue #896 sub-bug 4 (paskal's enumeration): "I am not sure but I think
+// sometimes arrows work in pop up, but most of the time and you need to
+// operate using ctrl+n and space".
+//
+// Root cause: when the popup is visible on the path field, Up/Down arrow
+// keys are NOT routed to the popup unless suggestionsActive=true. The user
+// has to press Space (or Right) first to enter arrow-key mode, otherwise
+// arrows move dialog focus between fields. From the user's perspective,
+// arrows on a visible popup do nothing useful.
+//
+// Fix contract: arrows on a visible popup over the path field must navigate
+// the popup cursor reliably from press 1, no off-by-one, no skipped frames,
+// wrap-around at the ends.
+func TestNewDialog_PopupArrows_NavigateReliably_RegressionFor896(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+
+	suggestions := []string{"/p/a", "/p/b", "/p/c"}
+	d.SetPathSuggestions(suggestions)
+
+	d.focusIndex = 2 // focusPath
+	d.updateFocus()
+
+	// Popup is visible because path is focused, suggestions are non-empty,
+	// and suggestionsHidden is false (default after Show + SetPathSuggestions).
+	if d.suggestionsHidden {
+		t.Fatalf("test precondition: suggestionsHidden=true but popup should be visible")
+	}
+
+	// Press Down — cursor space is: 0 ("Type custom"), 1..3 (real suggestions).
+	// On a visible popup, Down must navigate the popup; today it advances
+	// focusIndex instead, leaving the popup unmoved.
+	steps := []struct {
+		key      tea.KeyType
+		wantCur  int
+		wantName string
+	}{
+		{tea.KeyDown, 1, "down 1 (a)"},
+		{tea.KeyDown, 2, "down 2 (b)"},
+		{tea.KeyDown, 3, "down 3 (c)"},
+		{tea.KeyDown, 0, "down 4 (wrap to Type-custom)"},
+		{tea.KeyUp, 3, "up 1 (wrap back to c)"},
+		{tea.KeyUp, 2, "up 2 (b)"},
+		{tea.KeyUp, 1, "up 3 (a)"},
+		{tea.KeyUp, 0, "up 4 (Type-custom)"},
+	}
+
+	for i, s := range steps {
+		d, _ = d.Update(tea.KeyMsg{Type: s.key})
+
+		if !d.IsSuggestionsActive() {
+			t.Fatalf("step %d (%s): popup arrow did not activate suggestions; user has to fall back to Ctrl+N (issue #896 sub-bug 4)", i, s.wantName)
+		}
+		if d.pathSuggestionCursor != s.wantCur {
+			t.Fatalf("step %d (%s): pathSuggestionCursor=%d, want %d (issue #896 sub-bug 4: arrow navigation flaky)",
+				i, s.wantName, d.pathSuggestionCursor, s.wantCur)
+		}
+		// Path field must remain focused — arrows must navigate the popup,
+		// not jump to other dialog fields.
+		if d.currentTarget() != focusPath {
+			t.Fatalf("step %d (%s): focus left the path field (target=%v); popup arrows must stay scoped to the popup", i, s.wantName, d.currentTarget())
+		}
+	}
+}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1118,6 +1118,25 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			return d, nil
 		}
 
+		// Issue #896 sub-bug 4: when the path-suggestions popup is visible,
+		// arrow keys must navigate the popup from the very first press.
+		// Previously the user had to press Space or Ctrl+N first to enter
+		// "arrow-key mode"; arrows on a freshly-shown popup fell through to
+		// dialog focus advancement, leaving the popup feeling half-broken.
+		// Auto-activate on the first arrow press so the suggestionsActive
+		// handler below takes over and home.go's Enter handler can pick the
+		// highlighted suggestion (sub-bug 3).
+		if !d.suggestionsActive && d.currentTarget() == focusPath &&
+			len(d.pathSuggestions) > 0 && !d.suggestionsHidden {
+			if s := msg.String(); s == "down" || s == "up" {
+				d.suggestionsActive = true
+				d.pathSoftSelected = false
+				d.pathInput.Blur()
+				d.suggestionNavigated = true
+				// fall through to the suggestionsActive arrow handler below
+			}
+		}
+
 		// Suggestions dropdown active: arrow keys navigate, space/enter select,
 		// left/esc exit. The dropdown shows a synthetic "Type custom path..."
 		// entry at index 0, followed by real suggestions at indices 1..N.


### PR DESCRIPTION
## Summary

Closes the two **residual** sub-bugs from @paskal's #896 enumeration that PR #908 didn't cover.

| #896 sub-bug | Status |
|--------------|--------|
| 1. Tab on invalid path jumps to agent selector | ✅ fixed in #908 |
| 2. Ctrl+W wipes the entire path field | ✅ fixed in #908 |
| **3. Popup Enter selects wrong target** | ✅ **this PR** |
| **4. Arrow keys flaky in popup** | ✅ **this PR** |

## Root cause (shared)

The path-suggestions popup had two distinct states — *visible* (rendered for hint) vs *active* (consuming nav keys) — gated by separate flags. Only Space/Ctrl+N flipped the `suggestionsActive` flag. Plain arrow keys on a freshly-shown popup fell through to dialog focus advancement, so:

- **sub-bug 4**: Down/Up moved between dialog fields instead of navigating the popup. The popup looked interactive but wasn't.
- **sub-bug 3**: Because the popup never became active, `IsSuggestionsActive()` was false, so home.go's Enter handler skipped the apply-highlighted step and submitted the form with whatever was in the input.

## Fix

When the popup is visible on the path field (`focusPath` + non-empty suggestions + not explicitly dismissed) and the user presses the first Down/Up arrow, auto-activate it. The existing `suggestionsActive` arrow handler then advances the cursor, and home.go's existing Enter handler applies the highlighted suggestion and submits — exactly the original design intent.

Minimal change: one new pre-block in `newdialog.go` ahead of the existing `suggestionsActive` arrow handler. No new fields, no API changes.

## Regression tests

`internal/ui/issue896_residual_test.go`:

- `TestNewDialog_PopupEnter_SelectsHighlightedSuggestion_RegressionFor896` — type prefix, Down twice, simulate home.go's Enter (apply-highlighted), assert `pathInput` equals the 2nd real suggestion (not the typed prefix, not the 1st suggestion).
- `TestNewDialog_PopupArrows_NavigateReliably_RegressionFor896` — 8-step Down/Up trace through the cursor space `[0..3]` including wrap-around at both ends; asserts cursor + `IsSuggestionsActive()` + focus-still-on-path at every step.

Both tests are RED on `origin/main` and GREEN with the fix.

## Test plan

- [x] `go test -run "TestNewDialog_PopupEnter_SelectsHighlightedSuggestion_RegressionFor896|TestNewDialog_PopupArrows_NavigateReliably_RegressionFor896" ./internal/ui/...` — GREEN
- [x] `go test -count=1 ./internal/ui/...` — GREEN
- [x] `go test -race -count=1 ./internal/ui/...` — GREEN (pre-existing flaky `mcppool` race unrelated to this change)
- [ ] Manual: `n` → type prefix → arrow keys navigate popup → Enter creates session with highlighted path

Credit: @paskal for the original report and triage in #896.