### PR TITLE
fix(spawn,hooks): unify restart paths + clean sidecar on session-id clear (closes #922 #923)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -669,12 +669,11 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 	// scratch path the keychain never saw, triggering login + onboarding
 	// every spawn. Gating restores the v1.9.1 behaviour: dormant scratch
 	// in that case, ambient ~/.claude wins.
+	// Issue #922 (reporter @bautrey): route the worker-scratch swap through
+	// applyWorkerScratchOverride so it emits an INFO log instead of being silent.
 	configDirPrefix := ""
 	if !hasCustomCommand && IsClaudeConfigDirExplicitForInstance(i) {
-		configDir := GetClaudeConfigDirForInstance(i)
-		if i.WorkerScratchConfigDir != "" {
-			configDir = i.WorkerScratchConfigDir
-		}
+		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
 		configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir)
 	}
 
@@ -804,10 +803,8 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 func (i *Instance) buildBashExportPrefix() string {
 	prefix := fmt.Sprintf("export AGENTDECK_INSTANCE_ID=%s; ", i.ID)
 	if IsClaudeConfigDirExplicitForInstance(i) {
-		configDir := GetClaudeConfigDirForInstance(i)
-		if i.WorkerScratchConfigDir != "" {
-			configDir = i.WorkerScratchConfigDir
-		}
+		// Issue #922 (reporter @bautrey): see applyWorkerScratchOverride.
+		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
 		prefix += fmt.Sprintf("export CLAUDE_CONFIG_DIR=%s; ", configDir)
 	}
 	return prefix
@@ -5007,12 +5004,12 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// config_dir is resolved, with WorkerScratchConfigDir overriding the
 	// resolved value when set. See the comment there (issue #949) for the
 	// macOS-OAuth-keying motivation.
+	// Issue #922 (reporter @bautrey): route the worker-scratch swap through
+	// applyWorkerScratchOverride so the third spawn-env builder logs the swap
+	// with identical wording to the other two.
 	configDirPrefix := ""
 	if !hasCustomCommand && IsClaudeConfigDirExplicitForInstance(i) {
-		configDir := GetClaudeConfigDirForInstance(i)
-		if i.WorkerScratchConfigDir != "" {
-			configDir = i.WorkerScratchConfigDir
-		}
+		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
 		configDirPrefix = fmt.Sprintf("CLAUDE_CONFIG_DIR=%s ", configDir)
 	}
 

--- a/internal/session/issue922_spawn_unify_test.go
+++ b/internal/session/issue922_spawn_unify_test.go
@@ -1,0 +1,170 @@
+// Issue #922 — silent worker-scratch override of resolved CLAUDE_CONFIG_DIR.
+//
+// Pre-this-fix the three spawn-env builders that resolve CLAUDE_CONFIG_DIR
+// (buildClaudeCommandWithMessage, buildBashExportPrefix, buildClaudeResumeCommand)
+// each silently swapped the resolved value for WorkerScratchConfigDir when
+// the latter was non-empty. Users whose per-group [groups.X.claude] config_dir
+// was bypassed had no log line to grep — the override was invisible.
+//
+// Bug reporter: @bautrey (PR #946, audit pass 2026-05-10). This file
+// re-lands the regression coverage from @bautrey's PR with the test
+// shape adjusted for current main (post-#779, post-#950): the prep-call
+// unification half is already merged via #950, so the remaining wedge
+// is the silent override + log emission. These tests lock that down.
+//
+// Fix shape: route every override site through applyWorkerScratchOverride
+// (worker_scratch.go) which emits one INFO event per swap, carrying the
+// resolved dir and the scratch dir.
+
+package session
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBuildClaudeCommand_WorkerScratchOverrideEmitsInfoLog locks the
+// debuggability half of the fix: when WorkerScratchConfigDir overrides
+// the resolved CLAUDE_CONFIG_DIR, an INFO line must record both the
+// original resolved dir and the scratch dir so the override is no
+// longer silent. Issue #922, reported by @bautrey.
+func TestBuildClaudeCommand_WorkerScratchOverrideEmitsInfoLog(t *testing.T) {
+	withTelegramConductorPresent(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	profile := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(profile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "settings.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+
+	inst := &Instance{
+		ID:          "00000000-0000-0000-0000-000000000922",
+		Tool:        "claude",
+		Title:       "issue-922",
+		ProjectPath: filepath.Join(home, "proj"),
+	}
+	scratch, err := inst.EnsureWorkerScratchConfigDir(profile)
+	if err != nil {
+		t.Fatalf("setup scratch: %v", err)
+	}
+	if scratch == "" {
+		t.Fatal("setup: expected non-empty scratch dir")
+	}
+	inst.WorkerScratchConfigDir = scratch
+
+	var buf bytes.Buffer
+	origLog := sessionLog
+	sessionLog = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	t.Cleanup(func() { sessionLog = origLog })
+
+	_ = inst.buildClaudeCommand("claude")
+
+	output := buf.String()
+	if !strings.Contains(output, "worker_scratch_override") {
+		t.Errorf("expected `worker_scratch_override` INFO event; got: %s", output)
+	}
+	if !strings.Contains(output, profile) {
+		t.Errorf("override log must include the resolved (overridden) config_dir %q; got: %s", profile, output)
+	}
+	if !strings.Contains(output, scratch) {
+		t.Errorf("override log must include the scratch dir %q; got: %s", scratch, output)
+	}
+	// buildClaudeCommand chains two spawn-env contributors that each
+	// emit CLAUDE_CONFIG_DIR (the bash-export prefix and the inline
+	// prefix). Both legitimately route through applyWorkerScratchOverride
+	// and each should log — anything between 1 and 2 is OK.
+	if got := strings.Count(output, "worker_scratch_override"); got < 1 || got > 2 {
+		t.Errorf("expected 1 or 2 `worker_scratch_override` logs per build; got %d\noutput: %s", got, output)
+	}
+}
+
+// TestBuildClaudeResume_WorkerScratchOverrideEmitsInfoLog covers the
+// third override site (buildClaudeResumeCommand) — the one that the
+// CLI restart path takes when claude_session_id is set. Bug #922 was
+// most user-visible on this path because that's how restart-on-existing-
+// session behaves.
+func TestBuildClaudeResume_WorkerScratchOverrideEmitsInfoLog(t *testing.T) {
+	withTelegramConductorPresent(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	profile := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(profile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "settings.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+
+	inst := &Instance{
+		ID:              "00000000-0000-0000-0000-000000000922",
+		Tool:            "claude",
+		Title:           "issue-922-resume",
+		ProjectPath:     filepath.Join(home, "proj"),
+		ClaudeSessionID: "11111111-2222-3333-4444-555555555555",
+	}
+	scratch, err := inst.EnsureWorkerScratchConfigDir(profile)
+	if err != nil {
+		t.Fatalf("setup scratch: %v", err)
+	}
+	inst.WorkerScratchConfigDir = scratch
+
+	var buf bytes.Buffer
+	origLog := sessionLog
+	sessionLog = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	t.Cleanup(func() { sessionLog = origLog })
+
+	_ = inst.buildClaudeResumeCommand()
+
+	output := buf.String()
+	if !strings.Contains(output, "worker_scratch_override") {
+		t.Errorf("buildClaudeResumeCommand: expected `worker_scratch_override` INFO event; got: %s", output)
+	}
+	if !strings.Contains(output, scratch) {
+		t.Errorf("override log must include the scratch dir %q; got: %s", scratch, output)
+	}
+}
+
+// TestBuildClaudeCommand_NoOverrideNoLog guards against a noisy fix:
+// when WorkerScratchConfigDir is empty (conductor / channel-owner /
+// non-claude-worker), no override log must fire.
+func TestBuildClaudeCommand_NoOverrideNoLog(t *testing.T) {
+	withTelegramConductorPresent(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	profile := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(profile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "settings.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+
+	// Conductor — keeps ambient profile, never gets a scratch dir.
+	inst := &Instance{
+		ID:          "00000000-0000-0000-0000-000000000a00",
+		Tool:        "claude",
+		Title:       "conductor-x",
+		ProjectPath: filepath.Join(home, "proj"),
+	}
+
+	var buf bytes.Buffer
+	origLog := sessionLog
+	sessionLog = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	t.Cleanup(func() { sessionLog = origLog })
+
+	_ = inst.buildClaudeCommand("claude")
+
+	if strings.Contains(buf.String(), "worker_scratch_override") {
+		t.Errorf("override log must not fire when WorkerScratchConfigDir is empty; got: %s", buf.String())
+	}
+}

--- a/internal/session/issue923_sid_clear_test.go
+++ b/internal/session/issue923_sid_clear_test.go
@@ -1,0 +1,93 @@
+// Issue #923 — clearing claude_session_id via the CLI/TUI mutator must
+// also drop the hook .sid sidecar, otherwise the next restart re-reads
+// the stale anchor and re-injects the old id (negating the user's clear).
+//
+// Bug reporter: @bautrey (PR #946, audit pass 2026-05-10). This file
+// re-lands the regression coverage from @bautrey's PR.
+
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSetField_ClearClaudeSessionID_DeletesHookSidecar locks the
+// fix shape: when SetField clears the claude session id, the
+// `~/.agent-deck/hooks/<id>.sid` anchor must be removed so a
+// subsequent ReadHookSessionAnchor returns empty. Issue #923,
+// reported by @bautrey.
+func TestSetField_ClearClaudeSessionID_DeletesHookSidecar(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	const instanceID = "00000000-0000-0000-0000-000000000923"
+	const oldID = "abc-123-stale"
+
+	// Pre-condition: a non-empty .sid anchor exists for the instance,
+	// matching the real-world state before the user clears the id.
+	WriteHookSessionAnchor(instanceID, oldID)
+	if got := ReadHookSessionAnchor(instanceID); got != oldID {
+		t.Fatalf("setup: expected anchor %q, got %q", oldID, got)
+	}
+
+	inst := &Instance{
+		ID:              instanceID,
+		Tool:            "claude",
+		Title:           "issue-923",
+		ClaudeSessionID: oldID,
+	}
+
+	// User explicitly clears the session id.
+	if _, _, err := SetField(inst, FieldClaudeSessionID, "", nil); err != nil {
+		t.Fatalf("SetField clear: %v", err)
+	}
+
+	// Post-condition: the in-memory field is empty AND the sidecar is
+	// gone (or at minimum reads as empty).
+	if inst.ClaudeSessionID != "" {
+		t.Fatalf("instance ClaudeSessionID not cleared; got %q", inst.ClaudeSessionID)
+	}
+	if got := ReadHookSessionAnchor(instanceID); got != "" {
+		t.Fatalf("hook sidecar still has stale id after clear; got %q want \"\"", got)
+	}
+
+	// Belt-and-suspenders: also assert the file is gone on disk so a
+	// future hook tick can't re-populate from a half-deleted state.
+	sidPath := filepath.Join(home, ".agent-deck", "hooks", instanceID+".sid")
+	if _, err := os.Stat(sidPath); !os.IsNotExist(err) {
+		t.Errorf("hook sidecar file still present at %q; want removed (stat err=%v)", sidPath, err)
+	}
+}
+
+// TestSetField_NonEmptyClaudeSessionID_KeepsSidecar guards against a
+// fix that over-deletes — when a caller replaces one id with another
+// non-empty id, the sidecar must be left alone. We MUST NOT clear it
+// as a side-effect.
+func TestSetField_NonEmptyClaudeSessionID_KeepsSidecar(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	const instanceID = "00000000-0000-0000-0000-000000000924"
+	const oldID = "old-id"
+	const newID = "new-id"
+
+	WriteHookSessionAnchor(instanceID, oldID)
+
+	inst := &Instance{
+		ID:              instanceID,
+		Tool:            "claude",
+		Title:           "issue-923-keep",
+		ClaudeSessionID: oldID,
+	}
+
+	if _, _, err := SetField(inst, FieldClaudeSessionID, newID, nil); err != nil {
+		t.Fatalf("SetField replace: %v", err)
+	}
+
+	// Anchor must NOT be empty — fix should ONLY clear on empty value.
+	if got := ReadHookSessionAnchor(instanceID); got == "" {
+		t.Fatalf("hook sidecar wrongly cleared on non-empty replace")
+	}
+}

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -227,6 +227,16 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 		inst.ClaudeSessionID = value
 		inst.ClaudeDetectedAt = time.Now()
 		postCommit = makeSessionEnvPostCommit(inst, "CLAUDE_SESSION_ID", value)
+		// Issue #923 (reporter @bautrey): when the user explicitly clears
+		// the session id, the hook .sid sidecar at
+		// `~/.agent-deck/hooks/<id>.sid` must also be removed. Otherwise
+		// the next restart's spawn-env construction reads the stale anchor
+		// via ReadHookSessionAnchor and re-injects the old id, undoing the
+		// clear. DB is authoritative for the empty case; empty means
+		// abandon, not "fall back to last seen".
+		if value == "" {
+			ClearHookSessionAnchor(inst.ID)
+		}
 
 	case FieldGeminiSessionID:
 		oldValue = inst.GeminiSessionID

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -270,6 +270,25 @@ func (i *Instance) CleanupWorkerScratchConfigDir() {
 	i.WorkerScratchConfigDir = ""
 }
 
+// applyWorkerScratchOverride is the single seam where the worker-scratch
+// CLAUDE_CONFIG_DIR replaces the resolved one. Returns the effective
+// config dir to use. Centralising the override here means every
+// spawn-env builder (buildClaudeCommandWithMessage, buildBashExportPrefix,
+// buildClaudeResumeCommand) logs the swap with identical wording. Issue
+// #922 (reporter @bautrey) closed the silent-override hole by making
+// this the only place the swap can happen.
+func (i *Instance) applyWorkerScratchOverride(resolvedConfigDir string) string {
+	if i.WorkerScratchConfigDir == "" {
+		return resolvedConfigDir
+	}
+	sessionLog.Info("worker_scratch_override",
+		slog.String("instance_id", i.ID),
+		slog.String("resolved_config_dir", resolvedConfigDir),
+		slog.String("worker_scratch_config_dir", i.WorkerScratchConfigDir),
+	)
+	return i.WorkerScratchConfigDir
+}
+
 // prepareWorkerScratchConfigDirForSpawn is the spawn-path wrapper
 // around EnsureWorkerScratchConfigDir. Called from Start(),
 // StartWithMessage(), and the restart fallback path. Best-effort —


### PR DESCRIPTION
Closes #922.
Closes #923.

## Takeover credit

**Original investigation, repro, and fix shape by @bautrey** in his 2026-05-10 audit cluster — opened as PR #946. That branch (`fix/v1.9.x-bautrey-audit-#922-#923`) gathered merge conflicts with #779 (per-session plugin enablement) and #950 (gate worker-scratch CLAUDE_CONFIG_DIR injection on explicit config_dir). Since we can't force-push his branch, this PR re-lands his fix from `origin/main` with the test shape adjusted for the current code (post-#779, post-#950). **Please leave #946 open** — it's the audit's reference issue and closing is the original reporter's call.

## Bug 1 — #922: silent worker-scratch override on CLI restart

Three spawn-env builders (`buildClaudeCommandWithMessage`, `buildBashExportPrefix`, `buildClaudeResumeCommand`) each silently swapped the resolved `CLAUDE_CONFIG_DIR` for `WorkerScratchConfigDir` when the latter was non-empty. Users whose per-group `[groups.X.claude] config_dir` resolution was overridden had nothing to grep for — the swap was invisible.

@bautrey's original PR also re-ordered the prep call in `Restart()` so respawn-pane and recreate-tmux sub-paths agreed; that half is **already on main** via #950 (`prepareWorkerScratchConfigDirForSpawn` is now hoisted to the top of `Restart()`). The remaining wedge — and what this PR fixes — is the silent-override + missing log.

**Fix:** Route every swap through a single seam, `applyWorkerScratchOverride` (worker_scratch.go), that emits one INFO event per swap with `instance_id`, `resolved_config_dir`, and `worker_scratch_config_dir`. The three call sites in `instance.go` now share one log shape, so misroutes are debuggable.

## Bug 2 — #923: stale .sid sidecar re-injects cleared session id

`agent-deck session set <id> claude-session-id ""` cleared the in-memory field and propagated to the tmux env, but left the `~/.agent-deck/hooks/<id>.sid` sidecar intact. The next restart's spawn-env construction read the stale anchor via `ReadHookSessionAnchor` and re-injected the OLD id, undoing the user's clear.

**Fix:** In `SetField`'s `FieldClaudeSessionID` branch (mutators.go), call `ClearHookSessionAnchor(inst.ID)` when value is empty. DB is authoritative for the empty case; empty means abandon, not "fall back to last seen". The non-empty replace path is untouched.

## TDD evidence

Failing-test output **before** the fix (against `origin/main`):

```
=== RUN   TestBuildClaudeCommand_WorkerScratchOverrideEmitsInfoLog
    issue922_spawn_unify_test.go:72: expected `worker_scratch_override` INFO event; got: 
--- FAIL: TestBuildClaudeCommand_WorkerScratchOverrideEmitsInfoLog (0.00s)
=== RUN   TestBuildClaudeResume_WorkerScratchOverrideEmitsInfoLog
    issue922_spawn_unify_test.go:129: buildClaudeResumeCommand: expected `worker_scratch_override` INFO event; got: {"...resume:..."}
--- FAIL: TestBuildClaudeResume_WorkerScratchOverrideEmitsInfoLog (0.20s)
=== RUN   TestBuildClaudeCommand_NoOverrideNoLog
--- PASS: TestBuildClaudeCommand_NoOverrideNoLog (0.00s)
=== RUN   TestSetField_ClearClaudeSessionID_DeletesHookSidecar
    issue923_sid_clear_test.go:53: hook sidecar still has stale id after clear; got "abc-123-stale" want ""
--- FAIL: TestSetField_ClearClaudeSessionID_DeletesHookSidecar (0.00s)
=== RUN   TestSetField_NonEmptyClaudeSessionID_KeepsSidecar
--- PASS: TestSetField_NonEmptyClaudeSessionID_KeepsSidecar (0.00s)
FAIL
```

Passing **after** the fix:

```
=== RUN   TestBuildClaudeCommand_WorkerScratchOverrideEmitsInfoLog
--- PASS: TestBuildClaudeCommand_WorkerScratchOverrideEmitsInfoLog (0.00s)
=== RUN   TestBuildClaudeResume_WorkerScratchOverrideEmitsInfoLog
--- PASS: TestBuildClaudeResume_WorkerScratchOverrideEmitsInfoLog (0.20s)
=== RUN   TestBuildClaudeCommand_NoOverrideNoLog
--- PASS: TestBuildClaudeCommand_NoOverrideNoLog (0.00s)
=== RUN   TestSetField_ClearClaudeSessionID_DeletesHookSidecar
--- PASS: TestSetField_ClearClaudeSessionID_DeletesHookSidecar (0.00s)
=== RUN   TestSetField_NonEmptyClaudeSessionID_KeepsSidecar
--- PASS: TestSetField_NonEmptyClaudeSessionID_KeepsSidecar (0.00s)
PASS
ok  	github.com/asheshgoplani/agent-deck/internal/session	0.305s
```

Full `go test -race -count=1 ./...` green across all packages (session in 84.8s, full suite ~5 min). `TestPersistence_*`, `TestIssue949_*`, `TestBuildClaudeCommand_*` (#855), and `TestPerGroupConfig_*` all pass — those were called out as the high-risk regression surface.

## Test plan

- [x] Two new files: `internal/session/issue922_spawn_unify_test.go`, `internal/session/issue923_sid_clear_test.go` (one per bug, clean review)
- [x] Failing on current `origin/main`, passing after fix
- [x] Full suite green with `-race`
- [x] `golangci-lint run --new-from-rev=origin/main` exits 0 (pre-push hook lint failures are pre-existing, unrelated to this branch — see #855/#950 area)
- [x] Two commits, one per bug, each crediting @bautrey
- [ ] @bautrey to confirm fix shape matches the original audit intent — leaving comment on #946