### PR TITLE
fix(telegram): guard against duplicate bun pollers from global enablement (closes #941)

### DIFF
--- a/internal/session/issue941_global_antipattern_test.go
+++ b/internal/session/issue941_global_antipattern_test.go
@@ -1,0 +1,188 @@
+package session
+
+// Issue #941 regression — telegram GLOBAL_ANTIPATTERN duplicate-poller spawn.
+//
+// When a conductor session is launched with `--channels plugin:telegram@...`
+// AND the ambient profile's settings.json has
+// `enabledPlugins["telegram@claude-plugins-official"] = true`, the claude
+// process loads the plugin TWICE (once from the global flag, once from
+// --channels). Each load spawns its own `bun telegram start` poller on the
+// conductor's TELEGRAM_STATE_DIR. The two pollers race for the same bot
+// token and Telegram Bot API returns 409 Conflict.
+//
+// The TelegramValidator already EMITS a GLOBAL_ANTIPATTERN+DOUBLE_LOAD pair
+// for this topology — but warnings don't prevent the spawn. v3 topology
+// (memory: telegram_channel_conductor_only.md) requires:
+//
+//	conductor uses --channels explicitly; enabledPlugins must be false globally
+//
+// ...but that contract is enforced only by docs. This test, plus the
+// fix it drives, lifts it into the code path.
+//
+// Strategy: spawn a fake `claude` binary that mimics the plugin activation
+// arithmetic — one bun poller per activation source (global flag in
+// settings.json + --channels arg). Use real OS process detection (pgrep on
+// a unique tag carried via TELEGRAM_STATE_DIR) to count. With the fix in
+// place, `prepareWorkerScratchConfigDirForSpawn` rewrites the conductor's
+// CLAUDE_CONFIG_DIR to a scratch profile that pins enabledPlugins.telegram
+// off → --channels becomes the only activation → 1 poller.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTelegram_GlobalScope_OneBunPollerOnly_RegressionFor941(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("issue #941 reproduces on linux conductor hosts; pgrep/proc-environ semantics not portable")
+	}
+	if _, err := exec.LookPath("pgrep"); err != nil {
+		t.Skip("pgrep not available — required for real-process detection")
+	}
+
+	// Hermetic HOME so userconfig + workerscratch land in tempdirs.
+	home := withTempHome(t)
+	withTelegramConductorPresent(t) // makes hostHasTelegramConductor() == true
+
+	// Ambient profile (the conductor's CLAUDE_CONFIG_DIR) — the
+	// GLOBAL_ANTIPATTERN: enabledPlugins.telegram=true.
+	sourceProfile := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(sourceProfile, 0o755); err != nil {
+		t.Fatalf("mkdir source profile: %v", err)
+	}
+	srcSettings := `{"enabledPlugins":{"telegram@claude-plugins-official":true}}`
+	if err := os.WriteFile(filepath.Join(sourceProfile, "settings.json"), []byte(srcSettings), 0o644); err != nil {
+		t.Fatalf("write source settings: %v", err)
+	}
+	// Pin source resolution via env so GetClaudeConfigDirForInstance →
+	// this dir regardless of host config.
+	t.Setenv("CLAUDE_CONFIG_DIR", sourceProfile)
+
+	// Conductor session: channel-owner with --channels telegram@...
+	inst := &Instance{
+		ID:          "11111111-1111-1111-1111-111111111111",
+		Tool:        "claude",
+		Title:       "conductor-941",
+		ProjectPath: home,
+		Channels:    []string{"plugin:telegram@claude-plugins-official"},
+	}
+
+	// Run the real spawn-prep path. With the fix this creates a scratch
+	// CLAUDE_CONFIG_DIR pinning telegram OFF; without the fix it no-ops
+	// (channel-owners are excluded from worker-scratch today).
+	inst.prepareWorkerScratchConfigDirForSpawn()
+	configDir := inst.WorkerScratchConfigDir
+	if configDir == "" {
+		configDir = sourceProfile
+	}
+
+	// Build fake binaries to simulate the plugin's spawn arithmetic.
+	// We do NOT run real claude/bun — the assertion is that the spawn
+	// path agent-deck prepares results in ONE poller, not two.
+	binDir := t.TempDir()
+
+	// Unique tag carried in TELEGRAM_STATE_DIR — used as the pgrep filter
+	// so we count only this test's pollers, not anything else on the host.
+	tag := fmt.Sprintf("tdd941-%d", time.Now().UnixNano())
+	tsd := filepath.Join(t.TempDir(), tag)
+	if err := os.MkdirAll(tsd, 0o755); err != nil {
+		t.Fatalf("mkdir tsd: %v", err)
+	}
+
+	// Poller script — filename embeds the tag and the literal "bun-telegram"
+	// marker so /proc/<pid>/cmdline carries both substrings. pgrep -af on
+	// the tag will match this script's argv[0] reliably without relying on
+	// non-portable exec -a tricks.
+	pollerScript := filepath.Join(binDir, "bun-telegram-poller-"+tag+".sh")
+	// Do NOT exec sleep — we want the shell process to stay alive with
+	// the script path in /proc/<pid>/cmdline (which is what pgrep -af
+	// reads). exec sleep would replace argv and lose the tag.
+	if err := os.WriteFile(pollerScript, []byte(
+		"#!/bin/sh\nsleep 30\n",
+	), 0o755); err != nil {
+		t.Fatalf("write poller: %v", err)
+	}
+
+	// fake-claude.sh — counts activation sources, then forks one poller
+	// per source. Sources:
+	//   (a) settings.json has `"telegram@claude-plugins-official": true`
+	//   (b) --channels argv contains "plugin:telegram@"
+	fakeClaude := filepath.Join(binDir, "fake-claude.sh")
+	fakeClaudeBody := `#!/bin/bash
+set -u
+COUNT=0
+if [ -n "${CLAUDE_CONFIG_DIR:-}" ] && [ -f "$CLAUDE_CONFIG_DIR/settings.json" ]; then
+  if grep -Eq '"telegram@claude-plugins-official"[[:space:]]*:[[:space:]]*true' "$CLAUDE_CONFIG_DIR/settings.json"; then
+    COUNT=$((COUNT+1))
+  fi
+fi
+for a in "$@"; do
+  case "$a" in
+    *plugin:telegram@*) COUNT=$((COUNT+1));;
+  esac
+done
+i=0
+while [ "$i" -lt "$COUNT" ]; do
+  "` + pollerScript + `" &
+  i=$((i+1))
+done
+sleep 20
+`
+	if err := os.WriteFile(fakeClaude, []byte(fakeClaudeBody), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+
+	// Spawn fake claude with the SAME env agent-deck would set:
+	//   - CLAUDE_CONFIG_DIR = scratch (post-fix) or source (pre-fix)
+	//   - TELEGRAM_STATE_DIR carrying our test tag
+	//   - --channels echoed onto argv (matches Instance.spawnFlags())
+	cmd := exec.Command(fakeClaude, "--channels", "plugin:telegram@claude-plugins-official")
+	cmd.Env = append(os.Environ(),
+		"CLAUDE_CONFIG_DIR="+configDir,
+		"TELEGRAM_STATE_DIR="+tsd,
+		"TAG="+tag,
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake claude: %v", err)
+	}
+
+	// Cleanup: kill the fake claude tree and any stray pollers carrying
+	// our tag. Best-effort — leaks here would only affect this test's
+	// pgrep filter, not other tests.
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		_ = exec.Command("pkill", "-f", tag).Run()
+	})
+
+	// Settle. The fake forks pollers immediately, but give the kernel a
+	// beat to populate /proc.
+	time.Sleep(400 * time.Millisecond)
+
+	// Real process detection: pgrep -af on the unique tag.
+	out, _ := exec.Command("pgrep", "-af", tag).CombinedOutput()
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	pollerCount := 0
+	for _, line := range lines {
+		if !strings.Contains(line, tag) {
+			continue
+		}
+		if !strings.Contains(line, "bun") || !strings.Contains(line, "telegram") {
+			continue
+		}
+		pollerCount++
+	}
+
+	if pollerCount != 1 {
+		t.Fatalf("issue #941 regression: expected exactly 1 bun telegram poller "+
+			"(channel-owning conductor must not duplicate when global enabledPlugins.telegram=true), "+
+			"got %d.\npgrep output:\n%s\nscratch=%q source=%q",
+			pollerCount, string(out), inst.WorkerScratchConfigDir, sourceProfile)
+	}
+}

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -62,10 +62,18 @@ var hostHasTelegramConductor = func() bool {
 //  2. Per-session plugin enablement (RFC docs/rfc/PLUGIN_ATTACH.md) —
 //     write enabledPlugins[<id>] = true without contaminating the ambient
 //     profile or peer sessions.
+//  3. GLOBAL_ANTIPATTERN guard (issue #941) — channel-owning conductor with
+//     `enabledPlugins.telegram=true` already in the ambient settings.json.
+//     The TelegramValidator surfaces this as DOUBLE_LOAD but warnings
+//     don't prevent the spawn; the scratch pins telegram off so --channels
+//     is the only activation source and exactly one bun poller runs.
 //
-// When both fire, EnsureWorkerScratchConfigDir combines the deny+allow lists.
+// When multiple reasons fire, EnsureWorkerScratchConfigDir combines the
+// deny+allow lists.
 func (i *Instance) NeedsWorkerScratchConfigDir() bool {
-	return needsScratchForTelegram(i) || needsScratchForExplicitPlugins(i)
+	return needsScratchForTelegram(i) ||
+		needsScratchForExplicitPlugins(i) ||
+		needsScratchForGlobalChannelConflict(i)
 }
 
 func needsScratchForTelegram(i *Instance) bool {
@@ -82,8 +90,60 @@ func needsScratchForExplicitPlugins(i *Instance) bool {
 	return len(i.Plugins) > 0
 }
 
+// needsScratchForGlobalChannelConflict fires for issue #941: a
+// channel-owning conductor session whose ambient profile has
+// `enabledPlugins."telegram@claude-plugins-official" = true`.
+// Without intervention, claude loads the plugin twice (once from the
+// global setting, once from --channels) and two bun pollers race for
+// the same bot token → 409 Conflict.
+//
+// We can't just rely on the user disabling the global flag — the rule
+// is documented but not enforced. This predicate detects the topology
+// and triggers a scratch CLAUDE_CONFIG_DIR that pins telegram off.
+// --channels remains the only activation, yielding exactly one poller.
+func needsScratchForGlobalChannelConflict(i *Instance) bool {
+	if i == nil || i.Tool != "claude" {
+		return false
+	}
+	if !sessionHasTelegramChannel(i) {
+		return false
+	}
+	sourceDir := GetClaudeConfigDirForInstance(i)
+	if sourceDir == "" {
+		return false
+	}
+	return globalTelegramEnablementSet(sourceDir)
+}
+
+func sessionHasTelegramChannel(i *Instance) bool {
+	for _, ch := range i.Channels {
+		if strings.HasPrefix(ch, telegramChannelPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// globalTelegramEnablementSet reports whether the source profile's
+// settings.json has enabledPlugins."telegram@claude-plugins-official"=true.
+// Missing files, parse errors, or absent keys all return false — we
+// only fire the scratch guard when the antipattern is unambiguously present.
+func globalTelegramEnablementSet(sourceProfileDir string) bool {
+	data, err := os.ReadFile(filepath.Join(sourceProfileDir, "settings.json"))
+	if err != nil {
+		return false
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return false
+	}
+	plugins, _ := parsed["enabledPlugins"].(map[string]interface{})
+	v, ok := plugins[telegramPluginID].(bool)
+	return ok && v
+}
+
 func computeDenyList(i *Instance) []string {
-	if needsScratchForTelegram(i) {
+	if needsScratchForTelegram(i) || needsScratchForGlobalChannelConflict(i) {
 		return []string{telegramPluginID}
 	}
 	return nil
@@ -292,6 +352,19 @@ func (i *Instance) prepareWorkerScratchConfigDirForSpawn() {
 		return
 	}
 	sourceDir := GetClaudeConfigDirForInstance(i)
+
+	// Issue #941: surface the GLOBAL_ANTIPATTERN at spawn so operators can
+	// flip enabledPlugins.telegram=false in their profile and stop relying
+	// on this guard. Log-level WARN keeps it visible without blocking.
+	if needsScratchForGlobalChannelConflict(i) {
+		sessionLog.Warn("telegram_global_antipattern_suppressed",
+			slog.String("instance_id", i.ID),
+			slog.String("title", i.Title),
+			slog.String("source_profile_dir", sourceDir),
+			slog.String("plugin_id", telegramPluginID),
+			slog.String("guidance", "enabledPlugins.\"telegram@claude-plugins-official\"=true in the ambient settings.json would have caused a duplicate bun telegram poller (issue #941). Pinning the plugin off in a per-session scratch config dir so --channels is the sole activation. Recommended fix: remove the global enablement and rely on --channels."),
+		)
+	}
 
 	// Step 1: install plugin code into the SOURCE profile (not scratch).
 	// Best-effort — failures log but don't block. Runs first so the

--- a/internal/session/worker_scratch_plugins_test.go
+++ b/internal/session/worker_scratch_plugins_test.go
@@ -179,6 +179,13 @@ func TestComputeDenyList_FiresOnlyWhenTelegramScratchNeeded(t *testing.T) {
 			hostHasTelegramConductor = func() bool { return tc.hostHasTG }
 			defer func() { hostHasTelegramConductor = orig }()
 
+			// Isolate from the host's real ~/.claude/settings.json so the
+			// issue #941 globalTelegramEnablementSet detection doesn't bleed
+			// the maintainer's profile state into the test. With CLAUDE_CONFIG_DIR
+			// pointed at an empty tempdir, the global antipattern is absent.
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+
 			inst := &Instance{ID: "x", Tool: "claude", Title: "worker"}
 			if !tc.stripExpr {
 				// Make telegramStateDirStripExpr return "" by adding a TG channel.

--- a/internal/session/worker_scratch_test.go
+++ b/internal/session/worker_scratch_test.go
@@ -138,11 +138,25 @@ func TestEnsureWorkerScratchConfigDir_ConductorKeepsAmbientProfile(t *testing.T)
 
 // A session that carries a `plugin:telegram@...` channel is the
 // explicit, opted-in telegram bot owner and MUST keep the ambient
-// profile — isolating it would break its own bot.
+// profile when the v3 topology is correct (global enabledPlugins.telegram
+// disabled, --channels is the sole activation). Isolating it would
+// break its own bot.
+//
+// Issue #941 amendment: if the ambient profile has global
+// enabledPlugins.telegram=true (the GLOBAL_ANTIPATTERN), scratch
+// creation is now expected (see
+// TestEnsureWorkerScratchConfigDir_ChannelOwner_GlobalAntipattern_GetsScratch).
 func TestEnsureWorkerScratchConfigDir_ChannelOwnerKeepsAmbientProfile(t *testing.T) {
 	withTelegramConductorPresent(t)
 	source := t.TempDir()
-	_ = os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{"telegram@claude-plugins-official":true}}`), 0o644)
+	// v3 topology: global flag is unset, only --channels activates.
+	_ = os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{}}`), 0o644)
+
+	// Pin source resolution so needsScratchForGlobalChannelConflict reads
+	// THIS settings.json (not the host's real ~/.claude).
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", source)
 
 	inst := &Instance{
 		ID:       "bot1",
@@ -156,7 +170,48 @@ func TestEnsureWorkerScratchConfigDir_ChannelOwnerKeepsAmbientProfile(t *testing
 		t.Fatalf("EnsureWorkerScratchConfigDir: %v", err)
 	}
 	if got != "" {
-		t.Errorf("telegram channel owner must keep ambient profile; got scratch=%q", got)
+		t.Errorf("telegram channel owner with correct v3 topology must keep ambient profile; got scratch=%q", got)
+	}
+}
+
+// Issue #941: when a channel-owning conductor's ambient profile has the
+// GLOBAL_ANTIPATTERN (enabledPlugins.telegram=true), the worker-scratch
+// guard MUST fire — pinning telegram off so --channels is the sole
+// activation source and only one bun poller spawns.
+func TestEnsureWorkerScratchConfigDir_ChannelOwner_GlobalAntipattern_GetsScratch(t *testing.T) {
+	withTelegramConductorPresent(t)
+	source := t.TempDir()
+	_ = os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{"telegram@claude-plugins-official":true}}`), 0o644)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", source)
+
+	inst := &Instance{
+		ID:       "bot941",
+		Tool:     "claude",
+		Title:    "conductor-941",
+		Channels: []string{"plugin:telegram@claude-plugins-official"},
+	}
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(source)
+	if err != nil {
+		t.Fatalf("EnsureWorkerScratchConfigDir: %v", err)
+	}
+	if scratch == "" {
+		t.Fatalf("issue #941: channel owner with global enabledPlugins.telegram=true MUST get a scratch dir (got empty)")
+	}
+	data, err := os.ReadFile(filepath.Join(scratch, "settings.json"))
+	if err != nil {
+		t.Fatalf("read scratch settings: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	plugins := parsed["enabledPlugins"].(map[string]interface{})
+	if v, ok := plugins[telegramPluginID].(bool); !ok || v {
+		t.Errorf("issue #941: scratch settings.json must pin telegram OFF (false); got %v", plugins[telegramPluginID])
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #941. When a conductor session uses `--channels plugin:telegram@...` AND the ambient profile's `settings.json` has `enabledPlugins.\"telegram@claude-plugins-official\"=true` (the **GLOBAL_ANTIPATTERN**), `claude` loads the plugin twice. Each load spawns its own `bun telegram start` poller, and Telegram Bot API returns 409 Conflict.

The `TelegramValidator` (added in v1.7.22 / #658) already SURFACES this as `GLOBAL_ANTIPATTERN` + `DOUBLE_LOAD` warnings, and the memory rule [telegram_channel_conductor_only.md] documents the contract:

> conductor uses `--channels` explicitly; `enabledPlugins` must be false globally

…but the contract was enforced only by docs. This PR lifts it into the spawn path.

## Mechanism

The worker-scratch system (#759, #779) was previously **only** invoked for non-channel-owning workers. This PR extends it to also fire for channel-owning conductors when the global antipattern is detected:

1. **New predicate** `needsScratchForGlobalChannelConflict` — true iff the session is a claude session, carries a `plugin:telegram@...` channel, AND the resolved source profile's `settings.json` has the global flag set.
2. **`NeedsWorkerScratchConfigDir`** ORs the new predicate, triggering scratch creation.
3. **`computeDenyList`** pins `telegram@claude-plugins-official=false` in the scratch `settings.json` — leaving `--channels` as the **sole** activation source ⇒ exactly one bun poller.
4. **WARN emission** (`telegram_global_antipattern_suppressed`) in `prepareWorkerScratchConfigDirForSpawn`, so operators see the guard fire and can correct their profile permanently.

## Test

`internal/session/issue941_global_antipattern_test.go` uses **real OS process detection** per the spec (not a mock, since the bug is a real spawn duplication). It:

- Spawns a fake `claude` script that mimics the plugin's activation arithmetic (one bun-telegram poller per activation source — `settings.json` flag + `--channels` arg).
- Counts pollers via `pgrep -af <unique-tag>` filtered through `TELEGRAM_STATE_DIR`.
- Asserts exactly 1 poller.

### RED on main

```
--- FAIL: TestTelegram_GlobalScope_OneBunPollerOnly_RegressionFor941
    issue941_global_antipattern_test.go:183: issue #941 regression: expected exactly 1 bun telegram poller
        (channel-owning conductor must not duplicate when global enabledPlugins.telegram=true), got 2.
        pgrep output:
        1349819 /bin/sh /tmp/.../bun-telegram-poller-tdd941-1778828522825187972.sh
        1349820 /bin/sh /tmp/.../bun-telegram-poller-tdd941-1778828522825187972.sh
        scratch="" source="/tmp/.../001/.claude"
```

`scratch=""` confirms the old behavior excluded channel-owners.

### GREEN with fix

```
ok  	github.com/asheshgoplani/agent-deck/internal/session	0.587s
```

## Behavior change

Two pre-existing tests encoded the OLD invariant ("channel-owners always keep ambient profile"):

- `TestEnsureWorkerScratchConfigDir_ChannelOwnerKeepsAmbientProfile` — updated to use the v3-correct topology (global flag UNSET). The original case (global SET) is now covered by a new assertion: `TestEnsureWorkerScratchConfigDir_ChannelOwner_GlobalAntipattern_GetsScratch`.
- `TestComputeDenyList_FiresOnlyWhenTelegramScratchNeeded` — now isolates `HOME`/`CLAUDE_CONFIG_DIR` so the host's real profile state doesn't bleed into the predicate.

## WARN users will see

When the guard fires, the session log carries:

```
level=WARN msg=telegram_global_antipattern_suppressed
  instance_id=<id> title=<title>
  source_profile_dir=<path>
  plugin_id=telegram@claude-plugins-official
  guidance=enabledPlugins.\"telegram@claude-plugins-official\"=true in the ambient settings.json
           would have caused a duplicate bun telegram poller (issue #941). Pinning the plugin off
           in a per-session scratch config dir so --channels is the sole activation.
           Recommended fix: remove the global enablement and rely on --channels.
```

## Test plan

- [x] `go test -run TestTelegram_GlobalScope_OneBunPollerOnly_RegressionFor941 ./internal/session/...` — RED on main, GREEN with fix
- [x] `go test -race -count=1 ./...` — green everywhere
- [ ] Manual: on a TG-conductor host, set `enabledPlugins.telegram=true` in `~/.claude/settings.json`, restart conductor, verify only ONE `bun telegram start` in `pgrep -af`

## Related

- #779 — per-session plugin enablement (the structural rails this rides on)
- #658 / v1.7.22 — original v3 topology + TelegramValidator
- Memory: `telegram_channel_conductor_only.md`