### PR TITLE
fix(ci): repair Weekly Regression Check cron (closes #943)

### DIFF
--- a/.github/workflows/weekly-regression.yml
+++ b/.github/workflows/weekly-regression.yml
@@ -66,6 +66,17 @@ jobs:
         env:
           GOTOOLCHAIN: go1.24.0
 
+      - name: Build headless test server
+        # The main `agent-deck web` subcommand falls through to a Bubble Tea
+        # TUI launch, which under `&` background + no-TTY fails with
+        # "cancelreader: add reader to epoll interest list" and kills the
+        # process before /healthz can respond. `agent-deck-test-server` is
+        # the TUI-less entry point built for exactly this case.
+        # See cmd/agent-deck-test-server/main.go and issue #943.
+        run: go build -o ./build/agent-deck-test-server ./cmd/agent-deck-test-server
+        env:
+          GOTOOLCHAIN: go1.24.0
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -82,8 +93,11 @@ jobs:
 
       - name: Start test server
         run: |
-          env -i HOME=$HOME PATH=$PATH TERM=xterm-256color AGENTDECK_PROFILE=_ci_weekly \
-            ./build/agent-deck web --listen 127.0.0.1:18420 --token test &
+          # Use the dedicated TUI-less test-server binary. The previous
+          # `agent-deck web` invocation tripped Bubble Tea on a non-TTY
+          # stdin and killed the process before /healthz answered (#943).
+          AGENTDECK_PROFILE=_ci_weekly \
+            ./build/agent-deck-test-server -listen 127.0.0.1:18420 -profile _ci_weekly &
           SERVER_PID=$!
           echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
           # Wait for /healthz (up to 30 seconds)

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,8 +1,8 @@
 {
   "ci": {
     "collect": {
-      "startServerCommand": "AGENTDECK_PROFILE=_test ./build/agent-deck web --listen 127.0.0.1:19999 --token test",
-      "startServerReadyPattern": "Listening on",
+      "startServerCommand": "AGENTDECK_PROFILE=_test ./build/agent-deck-test-server -listen 127.0.0.1:19999 -profile _test",
+      "startServerReadyPattern": "listening on",
       "url": [
         "http://127.0.0.1:19999/"
       ],


### PR DESCRIPTION
## Summary

Repairs the `Weekly Regression Check` cron (`.github/workflows/weekly-regression.yml`), which has failed every Saturday since 2026-04-12 (5+ consecutive runs). Closes #943.

## Root cause

The workflow's "Start test server" step backgrounds `./build/agent-deck web` in a no-TTY environment. The `web` subcommand, however, falls through to the interactive TUI launch path (`cmd/agent-deck/main.go:305-308` then `:739-756`). Under `&` with detached stdin, Bubble Tea's `cancelreader` fails to register stdin in epoll:

```
Error: error creating cancelreader: bubbletea: error creating cancel reader: add reader to epoll interest list
```

`tea.Run` returns the error, `os.Exit(1)` fires, and the process dies before `/healthz` answers. The 30-second curl loop in the workflow then times out and fails the step. (See latest failing run: <https://github.com/asheshgoplani/agent-deck/actions/runs/25619109313>.)

The same bug exists in `.lighthouserc.json`'s `startServerCommand`, which also invokes `agent-deck web`.

## Fix shape

The repo already contains the right tool: `cmd/agent-deck-test-server/main.go` is a TUI-less web entry point whose own header comment says it exists *"so that Playwright tests can run […] where the main `agent-deck web` subcommand refuses to launch (because it falls through to the TUI launch path which trips the nested-session guard and fails to allocate a TTY)."*

- `.github/workflows/weekly-regression.yml`: add a "Build headless test server" step and switch the "Start test server" step to `./build/agent-deck-test-server -listen 127.0.0.1:18420 -profile _ci_weekly`. Drops the now-unnecessary `env -i` wrapper and the `--token test` flag (the test-server runs unauthenticated; Playwright's existing `?token=test` query string is ignored by `internal/web/auth.go:9-12` when `cfg.Token == ""`).
- `.lighthouserc.json`: switch `startServerCommand` to the same headless binary; update `startServerReadyPattern` from `"Listening on"` to `"listening on"` to match the test-server's stdout marker (`agent-deck-test-server: listening on http://…`).

## Reproduction & verification

Reproduces the CI failure verbatim from a local shell:

```
env -i HOME=$HOME PATH=$PATH TERM=xterm-256color AGENTDECK_PROFILE=_ci \
  ./build/agent-deck web --listen 127.0.0.1:18422 --token test &
# → bubbletea epoll error, process exits 1, /healthz never answers
```

Post-fix, the same backgrounded no-TTY invocation succeeds:

```
AGENTDECK_PROFILE=_ci_weekly \
  ./build/agent-deck-test-server -listen 127.0.0.1:18420 -profile _ci_weekly &
# → "Server ready after 1s", /healthz returns {"ok":true,...}
```

## Test plan

- [ ] Manually trigger `Weekly Regression Check` via `workflow_dispatch` on this branch and confirm it reaches the visual + Lighthouse steps
- [ ] Confirm `regression-check` job no longer fails at "Start test server"
- [ ] Confirm subsequent scheduled Saturday run is green (or fails only on legitimate regressions, not infra)

## Not in scope

- The `agent-deck web` subcommand's TUI-coupled startup behavior is left untouched. Decoupling it would be a larger refactor; the test-server binary already exists as the documented escape hatch.
- `release.yml` is not modified.

Last failing run for evidence: <https://github.com/asheshgoplani/agent-deck/actions/runs/25619109313>