### PR TITLE
feat(ui): sort sessions by most actionable within groups (closes #857)

### DIFF
--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -75,6 +75,63 @@ type GroupTree struct {
 	Expanded  map[string]bool   // Collapsed state persistence
 }
 
+// actionablePriority maps a session.Status to an "attention-needed" rank
+// used by SortInstancesByActionable. Lower = more actionable = surfaces
+// higher in the in-group list (issue #857).
+//
+// Buckets:
+//
+//	0  error                       (something broke, look at me)
+//	1  waiting                     (model done, awaiting user input)
+//	2  running, starting           (model actively working)
+//	3  idle, queued, "" (unset)    (nothing to do; "" matches legacy
+//	                                instances persisted before this field
+//	                                was widely populated — TestSessionOrder*
+//	                                rely on this neutral default)
+//	4  stopped                     (user-parked, bottom of pile)
+//
+// Any future Status value not enumerated above defaults to 5 so it sorts
+// after every known bucket rather than silently slotting into "idle".
+func actionablePriority(s Status) int {
+	switch s {
+	case StatusError:
+		return 0
+	case StatusWaiting:
+		return 1
+	case StatusRunning, StatusStarting:
+		return 2
+	case StatusIdle, StatusQueued, "":
+		return 3
+	case StatusStopped:
+		return 4
+	}
+	return 5
+}
+
+// SortInstancesByActionable sorts the given slice in place so the most
+// recently actionable sessions surface first within a group (issue #857).
+// Key precedence:
+//
+//  1. actionablePriority(Status)   asc  — error/waiting/running first
+//  2. LastAccessedAt              desc  — recent attention first
+//  3. Order                        asc  — preserves user-customized
+//     position as a stable tie-breaker
+//     (TestSessionOrderPersistence,
+//     TestSessionOrderMigration)
+func SortInstancesByActionable(insts []*Instance) {
+	sort.SliceStable(insts, func(i, j int) bool {
+		pi, pj := actionablePriority(insts[i].Status), actionablePriority(insts[j].Status)
+		if pi != pj {
+			return pi < pj
+		}
+		ai, aj := insts[i].LastAccessedAt, insts[j].LastAccessedAt
+		if !ai.Equal(aj) {
+			return ai.After(aj)
+		}
+		return insts[i].Order < insts[j].Order
+	})
+}
+
 // NewGroupTree creates a new group tree from instances
 func NewGroupTree(instances []*Instance) *GroupTree {
 	tree := &GroupTree{
@@ -110,11 +167,12 @@ func NewGroupTree(instances []*Instance) *GroupTree {
 		group.Sessions = append(group.Sessions, inst)
 	}
 
-	// Sort sessions within each group by persisted Order
+	// Sort sessions within each group by actionability (issue #857).
+	// Persisted Order is preserved as the stable tie-breaker, so
+	// instances without a Status set behave identically to the prior
+	// Order-only sort.
 	for _, group := range tree.Groups {
-		sort.SliceStable(group.Sessions, func(i, j int) bool {
-			return group.Sessions[i].Order < group.Sessions[j].Order
-		})
+		SortInstancesByActionable(group.Sessions)
 	}
 
 	// Sort groups alphabetically and assign order
@@ -179,11 +237,12 @@ func NewGroupTreeWithGroups(instances []*Instance, storedGroups []*GroupData) *G
 		group.Sessions = append(group.Sessions, inst)
 	}
 
-	// Sort sessions within each group by persisted Order
+	// Sort sessions within each group by actionability (issue #857).
+	// Persisted Order is preserved as the stable tie-breaker, so
+	// instances without a Status set behave identically to the prior
+	// Order-only sort.
 	for _, group := range tree.Groups {
-		sort.SliceStable(group.Sessions, func(i, j int) bool {
-			return group.Sessions[i].Order < group.Sessions[j].Order
-		})
+		SortInstancesByActionable(group.Sessions)
 	}
 
 	// Rebuild group list maintaining stored order

--- a/internal/ui/issue857_sort_actionable_test.go
+++ b/internal/ui/issue857_sort_actionable_test.go
@@ -1,0 +1,112 @@
+package ui
+
+// Regression coverage for #857 — sort sessions by most recently actionable
+// within a group. The reporter's pain: 2-3 active sessions get buried among
+// 7+ parked ones because the in-group order is fixed/creation-order. The fix
+// reorders within each group so the most "ready for me" sessions surface to
+// the top.
+//
+// Priority (lower = more actionable, surfaces higher):
+//   error    : something broke, surface first
+//   waiting  : model done, awaiting user input
+//   running  : model actively working
+//   idle     : nothing to do
+//   stopped  : user-parked, bottom of pile
+//
+// Tie-break within the same status: LastAccessedAt desc (recent attention
+// first), then persisted Order asc as the stable third key so user-customized
+// position still survives when statuses match (TestSessionOrderPersistence,
+// TestSessionOrderMigration).
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestSessionList_SortByActionable_RegressionFor857 sets up five sessions in
+// one group — one each of running/waiting/error/idle/stopped — and asserts
+// the rendered order is the actionable order, not the persisted Order. The
+// `Order` values intentionally invert the desired output so a regression to
+// the old Order-based sort flips at least four positions.
+func TestSessionList_SortByActionable_RegressionFor857(t *testing.T) {
+	now := time.Now()
+
+	// Order values are reversed vs. the desired actionable order; the
+	// pre-fix code sorted by Order asc and would produce
+	// [running, waiting, error, idle, stopped].
+	instances := []*session.Instance{
+		{ID: "run", Title: "running-sess", GroupPath: "g", Order: 1, Status: session.StatusRunning, LastAccessedAt: now.Add(-1 * time.Minute)},
+		{ID: "wait", Title: "waiting-sess", GroupPath: "g", Order: 2, Status: session.StatusWaiting, LastAccessedAt: now.Add(-2 * time.Minute)},
+		{ID: "err", Title: "error-sess", GroupPath: "g", Order: 3, Status: session.StatusError, LastAccessedAt: now.Add(-3 * time.Minute)},
+		{ID: "idle", Title: "idle-sess", GroupPath: "g", Order: 4, Status: session.StatusIdle, LastAccessedAt: now.Add(-4 * time.Minute)},
+		{ID: "stop", Title: "stopped-sess", GroupPath: "g", Order: 5, Status: session.StatusStopped, LastAccessedAt: now.Add(-5 * time.Minute)},
+	}
+
+	tree := session.NewGroupTree(instances)
+	group := tree.Groups["g"]
+	if group == nil {
+		t.Fatalf("group %q not in tree", "g")
+	}
+	if len(group.Sessions) != 5 {
+		t.Fatalf("expected 5 sessions in group, got %d", len(group.Sessions))
+	}
+
+	wantIDs := []string{"err", "wait", "run", "idle", "stop"}
+	gotIDs := make([]string, len(group.Sessions))
+	for i, s := range group.Sessions {
+		gotIDs[i] = s.ID
+	}
+
+	for i, want := range wantIDs {
+		if gotIDs[i] != want {
+			t.Errorf("position %d: want %q (status %s), got %q\n  full order: got=%v want=%v",
+				i, want, statusForID(instances, want), gotIDs[i], gotIDs, wantIDs)
+		}
+	}
+}
+
+// TestSessionList_SortByActionable_TimestampTieBreak verifies the secondary
+// sort: when two sessions share the same status, the one accessed more
+// recently surfaces first. Mirrors the issue's "ready for me" intuition —
+// the actionable session you just left should stay above one you parked
+// hours ago.
+func TestSessionList_SortByActionable_TimestampTieBreak(t *testing.T) {
+	now := time.Now()
+
+	instances := []*session.Instance{
+		{ID: "old-wait", Title: "old", GroupPath: "g", Order: 1, Status: session.StatusWaiting, LastAccessedAt: now.Add(-3 * time.Hour)},
+		{ID: "new-wait", Title: "new", GroupPath: "g", Order: 2, Status: session.StatusWaiting, LastAccessedAt: now.Add(-5 * time.Minute)},
+		{ID: "old-run", Title: "old-r", GroupPath: "g", Order: 3, Status: session.StatusRunning, LastAccessedAt: now.Add(-1 * time.Hour)},
+		{ID: "new-run", Title: "new-r", GroupPath: "g", Order: 4, Status: session.StatusRunning, LastAccessedAt: now.Add(-1 * time.Minute)},
+	}
+
+	tree := session.NewGroupTree(instances)
+	group := tree.Groups["g"]
+	if group == nil {
+		t.Fatalf("group %q not in tree", "g")
+	}
+
+	// Waiting (priority 1) ranks above running (priority 2). Within each
+	// status bucket the recently-accessed session ranks first.
+	want := []string{"new-wait", "old-wait", "new-run", "old-run"}
+	got := make([]string, len(group.Sessions))
+	for i, s := range group.Sessions {
+		got[i] = s.ID
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: want %q, got %q (full: got=%v want=%v)", i, want[i], got[i], got, want)
+		}
+	}
+}
+
+func statusForID(insts []*session.Instance, id string) session.Status {
+	for _, i := range insts {
+		if i.ID == id {
+			return i.Status
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Within each group, sessions are now ordered by "attention needed" instead of by the persisted `Order` field alone.

Closes #857.

### Ordering rationale (from the issue)

The reporter runs 10+ sessions across groups; the 2-3 actively-worked ones get buried among 7+ parked sessions, forcing a constant scan to find anything actionable. The new sort surfaces "ready for me" sessions to the top of each group.

Priority (lower = higher in the list):

| Bucket | Statuses | Why surface here |
|---|---|---|
| 0 | `error` | Something broke, look at it first |
| 1 | `waiting` | Model finished, awaiting user input — the literal "ready for me" state from #857 |
| 2 | `running`, `starting` | Model actively working — your live focus |
| 3 | `idle`, `queued`, `""` (unset) | Nothing to do; `""` covers legacy persisted instances |
| 4 | `stopped` | User-parked, bottom of pile |

Tie-break inside a bucket:
1. `LastAccessedAt` desc — recent attention first
2. `Order` asc — preserves user-customized reorder position as a stable third key, so existing `TestSessionOrderPersistence` / `TestSessionOrderMigration` semantics are unchanged for instances that don't set `Status`

### Files

- `internal/session/groups.go` — new `SortInstancesByActionable` + `actionablePriority`, wired into both `NewGroupTree` and `NewGroupTreeWithGroups`
- `internal/ui/issue857_sort_actionable_test.go` — RED-first regression coverage for both the status priority and the timestamp tie-break

## Test plan

- [x] `TestSessionList_SortByActionable_RegressionFor857` (5 statuses in one group, `Order` reversed vs. desired output → fails on `main`, passes on this branch)
- [x] `TestSessionList_SortByActionable_TimestampTieBreak` (two waiting + two running, asserts recency win within bucket)
- [x] `go test -race ./... -count=1` — all packages green
- [x] Existing `TestSessionOrderPersistence` and `TestSessionOrderMigration` still pass (Status unset → same bucket → falls through to `Order` tie-break)