### PR TITLE
feat(ui): default path for group creation dialog (closes #918)

### DIFF
--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -24,6 +24,8 @@ type GroupDialog struct {
 	visible       bool
 	mode          GroupDialogMode
 	nameInput     textinput.Model
+	pathInput     textinput.Model // Optional default working directory for new groups (Issue #918)
+	focusIndex    int             // 0 = nameInput, 1 = pathInput (Create mode only)
 	width         int
 	height        int
 	groupPath     string   // Current group being edited (for rename) or parent path (for create subgroup)
@@ -45,8 +47,15 @@ func NewGroupDialog() *GroupDialog {
 	ti.CharLimit = 50
 	ti.Width = 30
 
+	// Issue #918: optional default working directory for new groups.
+	pi := textinput.New()
+	pi.Placeholder = "Default path (optional)"
+	pi.CharLimit = 1024
+	pi.Width = 30
+
 	return &GroupDialog{
 		nameInput:  ti,
+		pathInput:  pi,
 		groupPaths: []string{},
 	}
 }
@@ -60,7 +69,8 @@ func (g *GroupDialog) Show() {
 	g.validationErr = ""
 	g.nameInput.SetValue("")
 	g.nameInput.CursorEnd() // Issue #604: reset cursor — SetValue only clamps, it does not reset.
-	g.nameInput.Focus()
+	g.resetPathInput()
+	g.focusName()
 }
 
 // ShowCreateSubgroup shows the dialog for creating a subgroup under a parent
@@ -72,7 +82,8 @@ func (g *GroupDialog) ShowCreateSubgroup(parentPath, parentName string) {
 	g.validationErr = ""
 	g.nameInput.SetValue("")
 	g.nameInput.CursorEnd() // Issue #604
-	g.nameInput.Focus()
+	g.resetPathInput()
+	g.focusName()
 }
 
 // ShowCreateWithContext opens the create dialog with cursor context for Tab toggling.
@@ -86,7 +97,8 @@ func (g *GroupDialog) ShowCreateWithContext(parentPath, parentName string) {
 	g.validationErr = ""
 	g.nameInput.SetValue("")
 	g.nameInput.CursorEnd() // Issue #604
-	g.nameInput.Focus()
+	g.resetPathInput()
+	g.focusName()
 
 	if parentPath != "" {
 		// Default to subgroup mode
@@ -110,7 +122,8 @@ func (g *GroupDialog) ShowCreateWithContextDefaultRoot(parentPath, parentName st
 	g.validationErr = ""
 	g.nameInput.SetValue("")
 	g.nameInput.CursorEnd() // Issue #604
-	g.nameInput.Focus()
+	g.resetPathInput()
+	g.focusName()
 
 	// Default to root mode, Tab toggles to subgroup
 	g.groupPath = ""
@@ -195,6 +208,35 @@ func (g *GroupDialog) Mode() GroupDialogMode {
 // GetValue returns the input value
 func (g *GroupDialog) GetValue() string {
 	return strings.TrimSpace(g.nameInput.Value())
+}
+
+// GetDefaultPath returns the default-path input value for the group being
+// created (Issue #918). Empty when the user left the field blank or when the
+// dialog is in a mode that does not expose the field.
+func (g *GroupDialog) GetDefaultPath() string {
+	return strings.TrimSpace(g.pathInput.Value())
+}
+
+// resetPathInput clears the path field and blurs it. Called by every Show*
+// entry point so a previous Create dialog never leaks its path into a Rename.
+func (g *GroupDialog) resetPathInput() {
+	g.pathInput.SetValue("")
+	g.pathInput.CursorEnd()
+	g.pathInput.Blur()
+}
+
+// focusName focuses the name input and updates the focus index accordingly.
+func (g *GroupDialog) focusName() {
+	g.focusIndex = 0
+	g.nameInput.Focus()
+	g.pathInput.Blur()
+}
+
+// focusPath focuses the path input and updates the focus index accordingly.
+func (g *GroupDialog) focusPath() {
+	g.focusIndex = 1
+	g.nameInput.Blur()
+	g.pathInput.Focus()
 }
 
 // Validate checks if the dialog values are valid and returns an error message if not
@@ -283,14 +325,39 @@ func (g *GroupDialog) Update(msg tea.KeyMsg) (*GroupDialog, tea.Cmd) {
 		return g, nil
 	}
 
-	// Tab toggles between Root and Subgroup modes
-	if msg.String() == "tab" && g.CanToggle() {
-		g.ToggleRootSubgroup()
-		return g, nil
+	// Issue #918: in Create mode, Tab cycles name ↔ path. Shift+Tab cycles back.
+	// When the Root/Subgroup toggle from #111 is available, Tab still toggles
+	// while focus is on the name field — preserving the existing #111 binding
+	// — and on the path field Tab returns focus to name.
+	if g.mode == GroupDialogCreate {
+		switch msg.String() {
+		case "tab":
+			if g.CanToggle() && g.focusIndex == 0 {
+				g.ToggleRootSubgroup()
+				return g, nil
+			}
+			if g.focusIndex == 0 {
+				g.focusPath()
+			} else {
+				g.focusName()
+			}
+			return g, nil
+		case "shift+tab":
+			if g.focusIndex == 0 {
+				g.focusPath()
+			} else {
+				g.focusName()
+			}
+			return g, nil
+		}
 	}
 
 	var cmd tea.Cmd
-	g.nameInput, cmd = g.nameInput.Update(msg)
+	if g.focusIndex == 1 {
+		g.pathInput, cmd = g.pathInput.Update(msg)
+	} else {
+		g.nameInput, cmd = g.nameInput.Update(msg)
+	}
 	return g, cmd
 }
 
@@ -305,15 +372,21 @@ func (g *GroupDialog) View() string {
 
 	switch g.mode {
 	case GroupDialogCreate:
+		labelStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+		// Issue #918: show "Name" + optional "Default Path" fields stacked.
+		nameRow := labelStyle.Render("Name:         ") + g.nameInput.View()
+		pathRow := labelStyle.Render("Default Path: ") + g.pathInput.View()
+		fields := nameRow + "\n" + pathRow
+
 		if g.parentName != "" {
 			title = "Create Subgroup"
 			parentInfo := lipgloss.NewStyle().
 				Foreground(ColorCyan).
 				Render("Parent: " + g.parentName)
-			content = parentInfo + "\n\n" + g.nameInput.View()
+			content = parentInfo + "\n\n" + fields
 		} else {
 			title = "Create New Group"
-			content = g.nameInput.View()
+			content = fields
 		}
 
 		// Add Root/Subgroup toggle indicator when Tab toggle is available
@@ -373,9 +446,12 @@ func (g *GroupDialog) View() string {
 	titleStyle := DialogTitleStyle.Width(titleWidth)
 	hintStyle := lipgloss.NewStyle().Foreground(ColorComment)
 	var hint string
-	if g.CanToggle() {
-		hint = hintStyle.Render("Tab toggle │ Enter confirm │ Esc cancel")
-	} else {
+	switch {
+	case g.mode == GroupDialogCreate && g.CanToggle():
+		hint = hintStyle.Render("Tab toggle/next │ Shift+Tab prev │ Enter confirm │ Esc cancel")
+	case g.mode == GroupDialogCreate:
+		hint = hintStyle.Render("Tab next │ Shift+Tab prev │ Enter confirm │ Esc cancel")
+	default:
 		hint = hintStyle.Render("Enter confirm │ Esc cancel")
 	}
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7720,13 +7720,20 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case GroupDialogCreate:
 			name := h.groupDialog.GetValue()
 			if name != "" {
+				var created *session.Group
 				if h.groupDialog.HasParent() {
 					// Create subgroup under parent
 					parentPath := h.groupDialog.GetParentPath()
-					h.groupTree.CreateSubgroup(parentPath, name)
+					created = h.groupTree.CreateSubgroup(parentPath, name)
 				} else {
 					// Create root-level group
-					h.groupTree.CreateGroup(name)
+					created = h.groupTree.CreateGroup(name)
+				}
+				// Issue #918: persist the optional default path captured in the dialog.
+				if created != nil {
+					if defaultPath := h.groupDialog.GetDefaultPath(); defaultPath != "" {
+						h.groupTree.SetDefaultPathForGroup(created.Path, defaultPath)
+					}
 				}
 				h.rebuildFlatItems()
 				h.saveInstances() // Persist the new group

--- a/internal/ui/issue918_default_path_test.go
+++ b/internal/ui/issue918_default_path_test.go
@@ -1,0 +1,90 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestGroupDialog_DefaultPath_PersistsAndPrefills_For918 is the regression test
+// for issue #918 (@banjocat): the group-create dialog must accept an optional
+// default path that (1) is captured by the dialog, (2) is persisted on the
+// created group, and (3) auto-fills the new-session dialog opened against
+// that group.
+//
+// Today the dialog has no path field, so this test fails RED until the field
+// is added and home.go wires SetDefaultPathForGroup after CreateGroup.
+func TestGroupDialog_DefaultPath_PersistsAndPrefills_For918(t *testing.T) {
+	tmpRepo := t.TempDir() // absolute, existing dir — survives resolveGroupDefaultPath untouched.
+
+	// --- Dialog accepts a default path field ---
+	g := NewGroupDialog()
+	g.Show()
+
+	// Type the group name.
+	for _, r := range "projects" {
+		key := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+		updated, _ := g.Update(key)
+		g = updated
+	}
+	if got := g.GetValue(); got != "projects" {
+		t.Fatalf("name input = %q, want %q", got, "projects")
+	}
+
+	// Navigate to the default-path field via Tab and type the path.
+	tabKey := tea.KeyMsg{Type: tea.KeyTab}
+	updated, _ := g.Update(tabKey)
+	g = updated
+	for _, r := range tmpRepo {
+		key := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+		updated, _ := g.Update(key)
+		g = updated
+	}
+
+	if got := g.GetDefaultPath(); got != tmpRepo {
+		t.Fatalf("GetDefaultPath() = %q, want %q", got, tmpRepo)
+	}
+
+	// --- Persistence: simulate the home.go save flow ---
+	tree := session.NewGroupTree(nil)
+	tree.CreateGroup(g.GetValue())
+	if !tree.SetDefaultPathForGroup(g.GetValue(), g.GetDefaultPath()) {
+		t.Fatalf("SetDefaultPathForGroup returned false for new group %q", g.GetValue())
+	}
+
+	if got := tree.DefaultPathForGroup("projects"); got != tmpRepo {
+		t.Fatalf("tree.DefaultPathForGroup(\"projects\") = %q, want %q", got, tmpRepo)
+	}
+
+	// --- New-session dialog prefills the path from the configured group default ---
+	nd := NewNewDialog()
+	nd.ShowInGroup("projects", "projects", tree.DefaultPathForGroup("projects"), nil, "")
+
+	if got := nd.pathInput.Value(); got != tmpRepo {
+		t.Fatalf("new-session dialog pathInput = %q, want prefilled %q", got, tmpRepo)
+	}
+}
+
+// TestGroupDialog_DefaultPath_OptionalLeftBlank_For918 confirms that leaving the
+// default-path field empty is valid (issue #918 explicitly calls the field
+// optional) — the group is still created and DefaultPathForGroup falls back to
+// session-history derivation, returning "" when the group has no sessions.
+func TestGroupDialog_DefaultPath_OptionalLeftBlank_For918(t *testing.T) {
+	g := NewGroupDialog()
+	g.Show()
+
+	for _, r := range "blank" {
+		key := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+		updated, _ := g.Update(key)
+		g = updated
+	}
+
+	if got := g.GetDefaultPath(); got != "" {
+		t.Fatalf("GetDefaultPath() with no path entered = %q, want \"\"", got)
+	}
+	if err := g.Validate(); err != "" {
+		t.Fatalf("Validate() with blank default path = %q, want \"\" (path is optional)", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #918 — credit to @banjocat for the report (and the kind words 🙏).

Adds an optional **Default Path** input to the group-create dialog so users can seed a group's default working directory at creation time instead of dropping to the CLI. The new-session prefill behavior was already wired (`home.getDefaultPathForGroup` → `NewDialog.ShowInGroup(defaultPath)`); this PR just closes the TUI gap.

## UX

\`\`\`
┌─────────────────────────────────────────┐
│           Create New Group              │
├─────────────────────────────────────────┤
│ Name:         [ projects             ]  │
│ Default Path: [ /home/work           ]  │
│                                         │
│ Tab next │ Shift+Tab prev │ Enter ─ Esc │
└─────────────────────────────────────────┘
\`\`\`

- **Tab / Shift+Tab** cycle focus between Name and Default Path.
- **Enter** persists name + (optional) default path.
- The **Root/Subgroup toggle** from #111 is preserved: when that toggle is available, Tab on the Name field still toggles Root↔Subgroup; once focus moves to Default Path, Tab cycles fields.
- Leaving Default Path blank falls back to the existing session-history derivation in `DefaultPathForGroup`.

## Schema migration

**None.** `Group.DefaultPath` is already part of `GroupData`'s JSON shape and the `groups` SQLite row — the field has existed since the `--default-path` CLI flag landed. This PR only adds a second `textinput.Model` to the dialog and a `SetDefaultPathForGroup` call after `CreateGroup`/`CreateSubgroup`.

## Test plan

- [x] RED: `TestGroupDialog_DefaultPath_PersistsAndPrefills_For918` fails on `origin/main` because `GroupDialog.GetDefaultPath` does not exist.
- [x] GREEN: same test passes after the patch — dialog captures the path, `GroupTree.SetDefaultPathForGroup` persists it, `NewDialog.ShowInGroup` prefills `pathInput`.
- [x] `TestGroupDialog_DefaultPath_OptionalLeftBlank_For918` confirms the field is genuinely optional (no validation regression).
- [x] `go test -race ./... -count=1` — full suite green.

### Files

- `internal/ui/group_dialog.go` — new `pathInput`, `focusIndex`, `GetDefaultPath()`, Tab/Shift+Tab routing.
- `internal/ui/home.go` — wire `SetDefaultPathForGroup(created.Path, defaultPath)` after `CreateGroup`/`CreateSubgroup` in `handleGroupDialogKey`.
- `internal/ui/issue918_default_path_test.go` — regression tests.