### PR TITLE
fix(registry): custom-command sessions don't false-error from null claude_session_id (closes #911)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -5127,6 +5127,18 @@ func (i *Instance) CanRestart() bool {
 		return true
 	}
 
+	// Claude sessions without ID can still restart (will start fresh or
+	// resume the latest JSONL via ensureClaudeSessionIDFromDisk). REQ-7
+	// reopen #911: custom-command Claude sessions (Tool=claude with a
+	// wrapper Command) bypass happy-path session-id capture and have an
+	// intentionally empty ClaudeSessionID. Without this branch they fall
+	// to the dead-or-error fallback below and the registry refuses
+	// restart even when the underlying tmux pane is alive — the false-
+	// error class this issue tracks. Mirrors the opencode/codex policy.
+	if IsClaudeCompatible(i.Tool) {
+		return true
+	}
+
 	// OpenCode sessions with known session ID can always be restarted
 	if i.Tool == "opencode" && i.OpenCodeSessionID != "" {
 		return true

--- a/internal/session/issue911_custom_command_test.go
+++ b/internal/session/issue911_custom_command_test.go
@@ -1,0 +1,85 @@
+package session
+
+// Issue #911 — REQ-7 reopened (v1.9.x stability sweep).
+//
+// Custom-command sessions launched via wrapper scripts (start-conductor.sh,
+// launch-subagent.sh, etc.) end up with claude_session_id="" because the
+// spawn happens outside agent-deck's happy-path capture. The registry then
+// treats them as broken, refusing restart even when the underlying tmux pane
+// is alive and Claude is healthy.
+//
+// The structural fix surface lives in CanRestart (instance.go:5119). The
+// opencode and codex branches (lines 5137 and 5148) explicitly allow restart
+// of empty-ID sessions because spawn-time capture isn't always possible. The
+// Claude branch (line 5126) requires a non-empty ClaudeSessionID, so a
+// custom-command Claude session falls all the way to the dead-or-error
+// fallback (line 5158) — meaning a healthy alive session reports
+// "unrestartable", the user-visible symptom #911 tracks.
+//
+// See ~/.claude/projects/-home-ashesh-goplani--agent-deck/memory/
+// conductor_restart_history_loss.md for the structural background.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegistry_CustomCommand_NoFalseError_RegressionFor911 pins the contract:
+// a Claude session with a custom Command (wrapper script) and an empty
+// ClaudeSessionID, whose tmux pane is alive, MUST behave like a healthy
+// session for registry-level capability checks — same as opencode/codex
+// without session IDs.
+func TestRegistry_CustomCommand_NoFalseError_RegressionFor911(t *testing.T) {
+	// Use skipIfNoTmuxBinary (not skipIfNoTmuxServer): the latter is a
+	// pre-bootstrap legacy guard that skips when only the TestMain-spawned
+	// bootstrap session exists. This new test runs against the isolated
+	// socket and creates its own session via Start(), so the bootstrap is
+	// sufficient.
+	skipIfNoTmuxBinary(t)
+
+	inst := NewInstanceWithTool("test-911-custom-cmd", "/tmp", "claude")
+	// Tool=claude with a custom Command (not the default "claude") models
+	// the launch-subagent.sh / start-conductor.sh class of spawns that
+	// bypass happy-path session-id capture.
+	inst.Command = "sleep 30"
+	require.Empty(t, inst.ClaudeSessionID,
+		"precondition: REQ-7 scenario starts with empty claude_session_id "+
+			"because spawn happens outside happy-path capture")
+
+	err := inst.Start()
+	require.NoError(t, err, "Start() must succeed for custom-command claude session")
+	defer func() { _ = inst.Kill() }()
+
+	// Wait past the 1.5s instance-level grace period so UpdateStatus
+	// performs a real status derivation rather than the StatusStarting hold.
+	time.Sleep(2 * time.Second)
+
+	err = inst.UpdateStatus()
+	require.NoError(t, err, "UpdateStatus() must succeed against an alive tmux pane")
+
+	// Status check assertion: a healthy custom-command Claude session must
+	// not be classified as error after a status check. This guards the
+	// scenario where a stale Status=Error survives a cascade and the next
+	// status refresh fails to clear it because of the empty session_id.
+	assert.NotEqual(t, StatusError, inst.Status,
+		"REQ-7 #911: custom-command claude session with alive tmux pane "+
+			"must not be StatusError after a status check; got %s", inst.Status)
+
+	// Registry capability assertion (RED on main): CanRestart returns false
+	// for this scenario because the claude branch at instance.go:5126
+	// requires non-empty ClaudeSessionID. The opencode and codex branches
+	// (lines 5137, 5148) explicitly allow empty-ID restart. The fix wires
+	// a parallel claude branch so custom-command Claude sessions get the
+	// same treatment — the cascade-recoverable contract REQ-7 promises.
+	require.True(t, inst.CanRestart(),
+		"REQ-7 #911 RED: CanRestart() returned false for a healthy custom-"+
+			"command Claude session with alive tmux. Opencode/codex sessions "+
+			"with empty session IDs are explicitly restartable (instance.go:"+
+			"5137/5148). The Claude branch must mirror that contract so "+
+			"custom-command sessions launched via wrapper scripts (where "+
+			"spawn-time capture is intentionally null) are not treated as "+
+			"broken by the registry.")
+}


### PR DESCRIPTION
## Summary

REQ-7 reopened (#911) — custom-command Claude sessions launched via wrapper scripts (`start-conductor.sh`, `launch-subagent.sh`) end up with `claude_session_id: null` in the registry because the spawn happens outside agent-deck's happy-path capture. The registry then treats them as broken: `CanRestart()` returns `false` for an alive session because the Claude branch (`instance.go:5126`) requires non-empty `ClaudeSessionID`, and the dead-or-error fallback (`instance.go:5158`) only allows restart of actually-dead sessions.

The opencode and codex branches (`instance.go:5137` / `5148`) already mirror this contract for their respective tools — empty session ID is allowed and the next start fills it in. Claude needed the same treatment.

## Fix

Add a parallel Claude branch in `CanRestart()` that allows empty-ID restart, matching opencode/codex policy. The downstream `Start()` path already discovers the latest JSONL on disk via `ensureClaudeSessionIDFromDisk` (v1.5.2 REQ-7 manifestation 1 fix), so a custom-command Claude restart still resumes the latest conversation when one exists, and falls through to a fresh session otherwise.

## TDD

`TestRegistry_CustomCommand_NoFalseError_RegressionFor911` in `internal/session/issue911_custom_command_test.go`:

- **RED on parent commit**: assertion `inst.CanRestart() == true` fails because the Claude branch requires non-empty ClaudeSessionID.
- **GREEN with this commit**: passes (2.14s) using real tmux against the isolated TestMain socket.

Two assertions:
1. `Status != StatusError` after a status check on a healthy custom-command Claude session — pinning the symptom.
2. `CanRestart() == true` for the same scenario — pinning the structural fix.

## REQ-7 history

- v1.5.2: original REQ-7 (manifestation 1) — custom-command sessions discovered the latest JSONL on disk during `Start()` so `--resume <uuid>` was emitted. Pinned by `TestPersistence_CustomCommandResumesFromLatestJSONL`.
- v1.7.7: REQ-7 manifestation 2 — per-instance `config_dir` resolution for `sessionHasConversationData`. Pinned by `TestSessionHasConversationData_RespectsPerInstanceConfigDir`.
- v1.9.x (this PR): REQ-7 manifestation 3 — registry capability check (`CanRestart`) treats empty Claude session ID as broken; mirrors opencode/codex empty-ID restart policy.

See memory note `conductor_restart_history_loss.md` for the structural background on the two-manifestation diagnostic flow.

## Test plan

- [x] RED test confirmed on parent commit (`CanRestart=false`)
- [x] GREEN with the four-line addition (test passes in 2.14s)
- [x] Full `go test -race ./internal/session/...` green (91s)
- [x] Full repo `go test -race ./...` green except for one unrelated pre-existing flake in `internal/mcppool/TestResponseRoutingNoXTalk` and a pre-push race surface in `internal/ui/TestStatusUpdateMsg_ReconcilesAttachedSessionBeforeRender` — both pass 3x in isolation, neither touches `CanRestart`.
- [ ] Manual: launch a worker via `launch-subagent.sh`; verify `agent-deck restart` succeeds even when `agent-deck list --json` shows `claude_session_id: null`.

Committed by Ashesh Goplani