### PR TITLE
test(costs): make old TotalLastWeek test deterministic via SetClock

### DIFF
--- a/internal/costs/store_test.go
+++ b/internal/costs/store_test.go
@@ -265,14 +265,13 @@ func TestStore_TotalLastWeek_OnlyThisWeekEvent(t *testing.T) {
 
 func TestStore_TotalLastWeek_OnlyLastWeekEvent(t *testing.T) {
 	s := testStore(t)
-	// Compute the midpoint of last week deterministically: walk back to this
-	// week's Monday, then go to last Thursday (Monday-7+3 = -4 days from
-	// this Monday). This avoids the previous fragility where "9 days ago"
-	// landed in the week-before-last when the test ran on Monday UTC.
-	now := time.Now()
-	daysSinceMonday := (int(now.Weekday()) + 6) % 7 // Monday=0..Sunday=6
-	thisMonday := now.AddDate(0, 0, -daysSinceMonday)
-	lastWeekMidpoint := thisMonday.AddDate(0, 0, -4)
+	// Pin to Monday 2025-11-10 UTC using the SetClock hook (#977). The prior
+	// wall-clock-based form walked back from time.Now() and was chronically
+	// flaky on the Monday UTC tick. The fixed clock makes "last week" resolve
+	// to [2025-11-03, 2025-11-10) on every weekday.
+	monday := time.Date(2025, 11, 10, 0, 0, 1, 0, time.UTC)
+	s.SetClock(func() time.Time { return monday })
+	lastWeekMidpoint := time.Date(2025, 11, 6, 12, 0, 0, 0, time.UTC) // Thu of last week
 	if err := s.WriteCostEvent(costs.CostEvent{
 		ID: "evt-lw", SessionID: "s1", Timestamp: lastWeekMidpoint,
 		Model: "claude-sonnet-4-6", CostMicrodollars: 70000,


### PR DESCRIPTION
## Summary

Small follow-up to #977. The OG chronic flake `TestStore_TotalLastWeek_OnlyLastWeekEvent` still computed its event timestamp by walking back from `time.Now()`, so it remained vulnerable on the Monday UTC boundary tick — the very class of failure #977 was built to kill.

Now that #977 landed `Store.SetClock`, this test pins the store's clock to **Mon 2025-11-10 00:00:01 UTC** (the same fixture used by `TestStore_TotalLastWeek_HandlesMondayBoundary`) and places the event at Thu 2025-11-06 — firmly inside the resulting `[2025-11-03, 2025-11-10)` last-week window.

## Why

Closes the chronic Monday-UTC flake class for good. The new sibling test from #977 was already deterministic; the older test was the last lingering hold-out using wall-clock `time.Now()`.

## Test plan

- [x] `go test -race -count=1 ./internal/costs/...` — green
- [x] Verified across `TZ=UTC`, `America/Los_Angeles`, `Asia/Tokyo`, `Pacific/Auckland` (no day-of-week dependency remains)
- [x] One file changed, one commit