### PR TITLE
chore(ci): bump GitHub Actions to Node 24 versions before 2026-06-02 deprecation

### DIFF
--- a/.github/workflows/eval-smoke.yml
+++ b/.github/workflows/eval-smoke.yml
@@ -36,10 +36,10 @@ jobs:
     timeout-minutes: 6
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/homebrew-verify.yml
+++ b/.github/workflows/homebrew-verify.yml
@@ -24,6 +24,6 @@ jobs:
   verify-formula:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Verify homebrew tap publishes a working formula
         run: bash scripts/verify-homebrew-install.sh

--- a/.github/workflows/issue-notify.yml
+++ b/.github/workflows/issue-notify.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Gather issue context
         id: context
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,17 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload from /site folder
           path: './site'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Gather PR context
         id: context
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/python-compat.yml
+++ b/.github/workflows/python-compat.yml
@@ -25,8 +25,8 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install runtime deps

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -32,17 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser (snapshot, no publish)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
           args: release --snapshot --skip=publish --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -68,7 +68,7 @@ jobs:
           go test -tags 'eval_smoke eval_full' -race -count=1 -timeout 6m ./tests/eval/... ./internal/ui/...
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
           args: release --clean

--- a/.github/workflows/session-persistence.yml
+++ b/.github/workflows/session-persistence.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -37,10 +37,10 @@ jobs:
       run:
         working-directory: tests/web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -60,15 +60,15 @@ jobs:
       run:
         working-directory: tests/web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -78,7 +78,7 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-ubuntu-${{ hashFiles('tests/web/package-lock.json') }}
@@ -100,7 +100,7 @@ jobs:
       # can see what changed without reproducing locally.
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: tests/web/playwright-report
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload screenshot diffs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-screenshots
           path: tests/web/e2e-output
@@ -119,8 +119,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Run TestParity_*

--- a/.github/workflows/weekly-regression.yml
+++ b/.github/workflows/weekly-regression.yml
@@ -50,12 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
         env:
@@ -67,7 +67,7 @@ jobs:
           GOTOOLCHAIN: go1.24.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: weekly-regression-${{ github.run_id }}
           retention-days: 30
@@ -138,7 +138,7 @@ jobs:
 
       - name: Create or update regression issue
         if: steps.visual.outcome == 'failure' || steps.lighthouse.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary

GitHub deprecates Node 20-based JavaScript actions on **2026-06-02** ([announcement](https://github.blog/changelog/2025-09-25-actions-deprecating-node-20-and-bumping-node-default-to-node-24-on-june-2-2026/)). After that date, any action whose `action.yml` declares `runs.using: 'node20'` will fail in workflows. This PR bumps every action used in `.github/workflows/` to its current major release that ships with `runs.using: 'node24'` (or `composite`, which is unaffected).

Worker note for v1.9.6 release flagged the upgrade for `actions/checkout`, `setup-go`, `goreleaser-action`; this PR covers those plus the rest of the action inventory in one pass to avoid a second deprecation chore.

## Upgrades

Each upgrade was verified by reading `action.yml` at the new tag and confirming `runs.using: node24` (composite for `upload-pages-artifact`):

| Action | Old | New | Tag verified | Engine |
|---|---|---|---|---|
| `actions/checkout` | `v4` | `v6` | v6.0.2 | node24 |
| `actions/cache` | `v4` | `v5` | v5.0.5 | node24 |
| `actions/setup-go` | `v5` | `v6` | v6.4.0 | node24 |
| `actions/setup-node` | `v4` | `v6` | v6.4.0 | node24 |
| `actions/setup-python` | `v5` | `v6` | v6.2.0 | node24 |
| `actions/upload-artifact` | `v4` | `v7` | v7.0.1 | node24 |
| `actions/github-script` | `v7` | `v9` | v9.0.0 | node24 |
| `actions/configure-pages` | `v4` | `v6` | v6.0.0 | node24 |
| `actions/deploy-pages` | `v4` | `v5` | v5.0.0 | node24 |
| `actions/upload-pages-artifact` | `v3` | `v5` | v5.0.0 | composite |
| `goreleaser/goreleaser-action` | `v6` | `v7` | v7.2.1 | node24 |

Pinned to major to match the existing repo convention (`@v6` rather than `@v6.0.2`); the table records the verified concrete tag at the time of the bump.

## Breaking-change notes

- **`actions/upload-artifact` v4 → v7**: v5 made artifacts immutable (uploading twice with the same name fails instead of merging). Reviewed all callsites; each `name:` is unique per upload, so no behavior change here.
- **`actions/github-script` v7 → v9**: bumps the bundled `@actions/github` / `@octokit` versions. Both callsites use the documented `github.rest.*` surface, which is stable across these majors.
- **`actions/checkout` v4 → v6**: v5/v6 bumped the bundled git binary and reworked credential cleanup; the workflows here use only defaults.

## Test plan

- [ ] CI runs green on this PR (all jobs trigger on PR open / push)
- [ ] `release-snapshot.yml` exercises `setup-go@v6` + `goreleaser-action@v7` end-to-end
- [ ] `pages.yml` exercises `configure-pages@v6` + `upload-pages-artifact@v5` + `deploy-pages@v5`
- [ ] `weekly-regression.yml` exercises `upload-artifact@v7` + `github-script@v9` on schedule
- [ ] If any single action breaks: downgrade that one to its last-known-good v3 tag and re-pin with a comment noting the failure mode

Committed by Ashesh Goplani