### PR TITLE
fix(notify): filter transition events against current registry to skip removed sessions (closes #962)

### DIFF
--- a/internal/session/issue962_no_replay_test.go
+++ b/internal/session/issue962_no_replay_test.go
@@ -1,0 +1,110 @@
+package session
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestTransitionNotifier_SkipsRemovedSessions_RegressionFor962 is the RED test
+// for issue #962. A deferred transition event held in the retry queue must NOT
+// be dispatched once the child it names has been removed from the registry —
+// otherwise the conductor receives "[EVENT] Child '<id>' is waiting" messages
+// for sessions that no longer exist (the all-day stale-event spam reported on
+// conductor-innotrade and others).
+//
+// rm-time cleanup at cmd/agent-deck/session_remove_cmd.go and main.go already
+// sweeps the per-conductor inbox (SweepInboxesForChildSession) and the dedup
+// ledger (RemoveNotifyStateRecord, both for #910). The deferred retry queue
+// at runtime/transition-deferred-queue.json is the remaining replay vector:
+// DrainRetryQueueWithResolver only checks target availability, never child
+// presence. So a child that gets rm'd while one of its events sits queued
+// gets redelivered on every poll cycle until rm-state is manually wiped.
+//
+// The fix is consumer-side defense-in-depth: filter the queue against the
+// current registry on every drain. This survives concurrent rm + drain
+// races, rm paths that bypass the sweeper, and stale queue files left behind
+// by older agent-deck versions on upgrade.
+func TestTransitionNotifier_SkipsRemovedSessions_RegressionFor962(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+	if err := os.MkdirAll(home+"/.agent-deck", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	profile := "_test-962-no-replay"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	defer storage.Close()
+
+	now := time.Now()
+	parent := &Instance{
+		ID:          "parent-conductor-962",
+		Title:       "conductor-962",
+		ProjectPath: "/tmp/p962",
+		GroupPath:   DefaultGroupPath,
+		Tool:        "claude",
+		Status:      StatusIdle,
+		CreatedAt:   now,
+	}
+	child := &Instance{
+		ID:              "child-removed-962",
+		Title:           "worker",
+		ProjectPath:     "/tmp/c962",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: parent.ID,
+		Tool:            "shell",
+		Status:          StatusWaiting,
+		CreatedAt:       now,
+	}
+	if err := storage.SaveWithGroups([]*Instance{parent, child}, nil); err != nil {
+		t.Fatalf("save initial: %v", err)
+	}
+
+	n := NewTransitionNotifier()
+	var sent atomic.Int32
+	n.sender = func(profile, targetID, message string) error {
+		sent.Add(1)
+		return nil
+	}
+	t.Cleanup(n.Close)
+
+	event := TransitionNotificationEvent{
+		ChildSessionID:  child.ID,
+		ChildTitle:      child.Title,
+		Profile:         profile,
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       now,
+		TargetSessionID: parent.ID,
+		TargetKind:      "parent",
+	}
+	n.EnqueueDeferred(event)
+
+	// Simulate `agent-deck rm <child>` landing between the enqueue and the
+	// next drain. The deferred queue file still references the child id.
+	if err := storage.DeleteInstance(child.ID); err != nil {
+		t.Fatalf("delete child: %v", err)
+	}
+
+	// Drain with availability always true: target IS free, so on current main
+	// the queued event redispatches. The only thing that should stop it is the
+	// registry-presence filter we expect this test to drive into existence.
+	n.DrainRetryQueueWithResolver(profile, func(p, id string) bool { return true })
+	n.Flush()
+
+	if got := sent.Load(); got != 0 {
+		t.Fatalf("issue #962: notifier dispatched %d events for a removed child; expected 0", got)
+	}
+
+	if entries := n.snapshotQueueForTest(); len(entries) != 0 {
+		t.Fatalf("issue #962: queue still holds %d entries for removed child; expected drained", len(entries))
+	}
+}

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -83,6 +83,15 @@ type TransitionNotifier struct {
 	// inject a deterministic stub.
 	availability targetAvailabilityResolver
 
+	// childPresence reports whether the named child session still exists in
+	// the registry. Used by DrainRetryQueueWithResolver to drop queued
+	// events whose child has been rm'd between enqueue and drain — issue
+	// #962. Nil means no filter (preserved for tests that build the
+	// notifier via a bare struct literal); production sets it via
+	// NewTransitionNotifier so the daemon's drain loop never replays
+	// events for vanished children.
+	childPresence targetAvailabilityResolver
+
 	mu    sync.Mutex
 	state transitionNotifyState
 
@@ -149,6 +158,7 @@ func NewTransitionNotifier() *TransitionNotifier {
 		terminatedFingerprints: map[string]bool{},
 		stopCh:                 make(chan struct{}),
 	}
+	n.childPresence = n.liveChildPresence
 	n.loadState()
 	n.loadQueue()
 	return n
@@ -703,10 +713,22 @@ func (n *TransitionNotifier) DrainRetryQueueWithResolver(profile string, isAvail
 	var keep []deferredQueueEntry
 	var toDispatch []deferredQueueEntry
 	var toExpire []deferredQueueEntry
+	var toDropRemoved []deferredQueueEntry
 
 	for _, entry := range snapshot {
 		if entry.Event.Profile != profile {
 			keep = append(keep, entry)
+			continue
+		}
+		// Issue #962: drop events whose child has been removed from the
+		// registry between enqueue and drain. The rm path (issue #910)
+		// sweeps the inbox and dedup ledger but not this queue file, so
+		// without this filter the daemon redispatches stale child events
+		// on every poll until the queue file is hand-edited. Done BEFORE
+		// the age-out check so we don't emit "expired" missed-log lines
+		// for sessions that simply no longer exist.
+		if n.childPresence != nil && !n.childPresence(profile, entry.Event.ChildSessionID) {
+			toDropRemoved = append(toDropRemoved, entry)
 			continue
 		}
 		expired := now.Sub(entry.FirstDeferredAt) > defaultQueueMaxAge ||
@@ -723,6 +745,9 @@ func (n *TransitionNotifier) DrainRetryQueueWithResolver(profile string, isAvail
 		toDispatch = append(toDispatch, entry)
 	}
 
+	for _, entry := range toDropRemoved {
+		n.logMissed(entry.Event, "child_removed_from_registry")
+	}
 	for _, entry := range toExpire {
 		n.logMissed(entry.Event, "expired")
 	}
@@ -758,6 +783,37 @@ func (n *TransitionNotifier) liveTargetAvailability(profile, targetID string) bo
 		}
 		_ = inst.UpdateStatus()
 		return inst.GetStatusThreadSafe() != StatusRunning
+	}
+	return false
+}
+
+// liveChildPresence reports whether childID still exists in the registry for
+// the given profile. Issue #962: the drain loop filter that prevents the
+// notifier from replaying transition events for sessions removed via
+// `agent-deck rm` between the enqueue and the next drain pass.
+//
+// Fail-open on storage errors: if the SQLite file is missing, locked, or
+// the load returns an error, return true so a transient outage doesn't
+// silently drop legitimate events. The trade-off is that during a real
+// outage we may briefly replay events; the alternative (fail-closed) would
+// be a silent-loss path that's strictly worse than the bug we're fixing.
+func (n *TransitionNotifier) liveChildPresence(profile, childID string) bool {
+	if strings.TrimSpace(childID) == "" {
+		return false
+	}
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		return true
+	}
+	defer storage.Close()
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		return true
+	}
+	for _, inst := range instances {
+		if inst.ID == childID {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

Closes #962.

The transition-notifier's deferred retry queue (`runtime/transition-deferred-queue.json`) kept replaying transition events for child sessions removed via `agent-deck rm`. **The conductor has been spammed all day today** with `[EVENT] Child '<id>' is waiting` messages for workers that completed, were stopped, and have been gone from the registry for hours. Manual workaround: hand-truncate the queue file. Real fix: filter on replay.

## What was missing

PR for #910 added rm-time sweeps for two replay vectors:
- per-conductor inbox JSONL (`SweepInboxesForChildSession`)
- dedup ledger (`RemoveNotifyStateRecord`)

It did **not** sweep the third vector — the deferred retry queue. `DrainRetryQueueWithResolver` only checked target availability, never child presence, so any queue entry enqueued before the rm survived as a redispatch loop.

## The fix

Consumer-side defense-in-depth in `DrainRetryQueueWithResolver`: drop queue entries whose `ChildSessionID` is no longer present in the profile registry (`storage.LoadWithGroups()`). Removed events are logged to `notifier-missed.log` with reason `child_removed_from_registry` so operators retain actionable signal.

The check is wired via a nullable resolver field (`n.childPresence`) so existing struct-literal test helpers in `transition_notifier_queue_test.go` stay backwards compatible — only notifiers built via `NewTransitionNotifier` get the live filter. **Fail-open** on storage errors: if the SQLite file is locked or missing, return true rather than silently drop legitimate events.

## RED → GREEN

`TestTransitionNotifier_SkipsRemovedSessions_RegressionFor962` in `internal/session/issue962_no_replay_test.go`:

1. Create parent + child in storage.
2. Enqueue a deferred transition event for the child.
3. `DeleteInstance(child.ID)` — simulates `agent-deck rm` landing between enqueue and drain.
4. `DrainRetryQueueWithResolver` with availability always true.
5. **Pre-fix:** 1 send fires for the removed child. **Post-fix:** 0 sends, queue cleared.

## Test plan

- [x] `go test -race -count=1 ./internal/session/...` — green (94s including mandatory `TestPersistence_*` suite)
- [x] `go test -race -count=1 ./...` — green (one pre-existing `TestResponseRoutingNoXTalk` flake in `mcppool`; passes 3x in isolation, unrelated to notifier)
- [x] `go test -run TestQueue_ ./internal/session/...` — all existing queue tests still pass (backwards-compat via nullable resolver)