### PR TITLE
fix(launch): derive group from cwd, not parent session (closes #972)

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -124,12 +124,21 @@ func splitFirstWord(raw string) (string, string) {
 	return s, ""
 }
 
-// resolveGroupSelection applies parent-group inheritance rules.
-// If the user explicitly provided -g/--group, keep that value.
-// Otherwise inherit the parent's group.
-func resolveGroupSelection(currentGroup, parentGroup string, explicitGroupProvided bool) string {
+// resolveGroupSelection picks the group for a new session using a fixed
+// priority order. Priority (issue #972):
+//  1. Explicit -g/--group always wins.
+//  2. Otherwise the cwd-derived project group wins.
+//  3. Parent-session group is the fallback only when no cwd-derived group is
+//     available (e.g. an empty project path mapping).
+//
+// Prior to #972 step 2 did not exist, so every conductor-spawned child
+// silently inherited the conductor's `conductor` group.
+func resolveGroupSelection(currentGroup, cwdDerivedGroup, parentGroup string, explicitGroupProvided bool) string {
 	if explicitGroupProvided {
 		return currentGroup
+	}
+	if cwdDerivedGroup != "" {
+		return cwdDerivedGroup
 	}
 	return parentGroup
 }

--- a/cmd/agent-deck/cli_utils_test.go
+++ b/cmd/agent-deck/cli_utils_test.go
@@ -321,6 +321,7 @@ func TestResolveGroupSelection(t *testing.T) {
 	tests := []struct {
 		name                  string
 		currentGroup          string
+		cwdDerivedGroup       string
 		parentGroup           string
 		explicitGroupProvided bool
 		want                  string
@@ -333,27 +334,25 @@ func TestResolveGroupSelection(t *testing.T) {
 			want:                  "ard",
 		},
 		{
-			name:                  "inherit parent when no explicit group",
-			currentGroup:          "",
-			parentGroup:           "conductor",
-			explicitGroupProvided: false,
-			want:                  "conductor",
+			name:         "inherit parent when no explicit group and no cwd-derived group",
+			currentGroup: "",
+			parentGroup:  "conductor",
+			want:         "conductor",
 		},
 		{
-			name:                  "no explicit group and empty parent",
-			currentGroup:          "",
-			parentGroup:           "",
-			explicitGroupProvided: false,
-			want:                  "",
+			name:         "no explicit group and empty parent",
+			currentGroup: "",
+			parentGroup:  "",
+			want:         "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveGroupSelection(tt.currentGroup, tt.parentGroup, tt.explicitGroupProvided)
+			got := resolveGroupSelection(tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided)
 			if got != tt.want {
-				t.Fatalf("resolveGroupSelection(%q, %q, %v) = %q, want %q",
-					tt.currentGroup, tt.parentGroup, tt.explicitGroupProvided, got, tt.want)
+				t.Fatalf("resolveGroupSelection(%q, %q, %q, %v) = %q, want %q",
+					tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided, got, tt.want)
 			}
 		})
 	}

--- a/cmd/agent-deck/issue972_launch_group_test.go
+++ b/cmd/agent-deck/issue972_launch_group_test.go
@@ -1,0 +1,72 @@
+package main
+
+import "testing"
+
+// TestLaunch_DerivesGroupFromCwdNotParent_RegressionFor972 pins the fix for
+// https://github.com/asheshgoplani/agent-deck/issues/972.
+//
+// Bug: `agent-deck launch <project-path>` from inside a conductor session
+// (whose own group is `conductor`) inherited the parent's group instead of
+// deriving a group from the cwd / project path. Every conductor-spawned child
+// landed in `conductor` and required a follow-up `agent-deck group move` to
+// land in the project group.
+//
+// Expected priority (regression-pinned):
+//  1. Explicit `-g/--group` always wins.
+//  2. Otherwise, the cwd-derived project group wins.
+//  3. Parent-session group is the fallback ONLY when no cwd-derived group is
+//     available (e.g. an empty path mapping).
+//
+// Cross-reference: memory note
+// `feedback_agent_deck_conductor_uses_agent_deck_group.md` — each conductor's
+// children must land in that conductor's project group, never in `conductor`.
+func TestLaunch_DerivesGroupFromCwdNotParent_RegressionFor972(t *testing.T) {
+	tests := []struct {
+		name                  string
+		currentGroup          string
+		cwdDerivedGroup       string
+		parentGroup           string
+		explicitGroupProvided bool
+		want                  string
+	}{
+		{
+			name:            "regression 972: cwd-derived group wins over conductor parent",
+			currentGroup:    "",
+			cwdDerivedGroup: "agent-deck",
+			parentGroup:     "conductor",
+			want:            "agent-deck",
+		},
+		{
+			name:                  "explicit -g still wins over both cwd-derived and parent",
+			currentGroup:          "ard",
+			cwdDerivedGroup:       "agent-deck",
+			parentGroup:           "conductor",
+			explicitGroupProvided: true,
+			want:                  "ard",
+		},
+		{
+			name:            "parent group is fallback only when no cwd-derived group",
+			currentGroup:    "",
+			cwdDerivedGroup: "",
+			parentGroup:     "conductor",
+			want:            "conductor",
+		},
+		{
+			name:            "no parent and no cwd-derived returns empty (caller chooses default)",
+			currentGroup:    "",
+			cwdDerivedGroup: "",
+			parentGroup:     "",
+			want:            "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveGroupSelection(tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided)
+			if got != tt.want {
+				t.Fatalf("resolveGroupSelection(curr=%q, cwd=%q, parent=%q, explicit=%v) = %q, want %q",
+					tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -258,7 +258,13 @@ func handleLaunch(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Resolve parent session if specified
+	// Resolve parent session if specified.
+	// Issue #972: when no explicit -g is passed, prefer the cwd-derived
+	// project group over the parent's group, so conductor-spawned children
+	// land in the project group (e.g. `agent-deck`) instead of the
+	// conductor's own group (`conductor`). The parent group is now a
+	// fallback for path mappings that produce no group.
+	cwdDerivedGroup := session.GroupPathForProject(path)
 	var parentInstance *session.Instance
 	if sessionParent != "" {
 		var errMsg string
@@ -271,11 +277,11 @@ func handleLaunch(profile string, args []string) {
 			out.Error("cannot create sub-session of a sub-session (single level only)", ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
-		sessionGroup = resolveGroupSelection(sessionGroup, parentInstance.GroupPath, explicitGroupProvided)
+		sessionGroup = resolveGroupSelection(sessionGroup, cwdDerivedGroup, parentInstance.GroupPath, explicitGroupProvided)
 	} else if !*noParent {
 		parentInstance = resolveAutoParentInstance(instances)
 		if parentInstance != nil && !parentInstance.IsSubSession() {
-			sessionGroup = resolveGroupSelection(sessionGroup, parentInstance.GroupPath, explicitGroupProvided)
+			sessionGroup = resolveGroupSelection(sessionGroup, cwdDerivedGroup, parentInstance.GroupPath, explicitGroupProvided)
 		} else {
 			parentInstance = nil
 		}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1222,11 +1222,15 @@ func handleAdd(profile string, args []string) {
 			fmt.Printf("Error: cannot create sub-session of a sub-session (single level only)\n")
 			os.Exit(1)
 		}
-		sessionGroup = resolveGroupSelection(sessionGroup, parentInstance.GroupPath, explicitGroupProvided)
+		// handleAdd resolves `path` AFTER this block (see below), so the
+		// cwd-derived group is not available here. Passing "" preserves
+		// handleAdd's existing behavior; the #972 cwd-over-parent priority
+		// is wired into `launch` where path is already known at this point.
+		sessionGroup = resolveGroupSelection(sessionGroup, "", parentInstance.GroupPath, explicitGroupProvided)
 	} else if !*noParent {
 		parentInstance = resolveAutoParentInstance(instances)
 		if parentInstance != nil && !parentInstance.IsSubSession() {
-			sessionGroup = resolveGroupSelection(sessionGroup, parentInstance.GroupPath, explicitGroupProvided)
+			sessionGroup = resolveGroupSelection(sessionGroup, "", parentInstance.GroupPath, explicitGroupProvided)
 		} else {
 			parentInstance = nil
 		}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -601,6 +601,15 @@ func NewInstanceWithGroupAndTool(title, projectPath, groupPath, tool string) *In
 	return inst
 }
 
+// GroupPathForProject is the exported wrapper around extractGroupPath. It
+// gives CLI callers (issue #972) a single source of truth for "what group
+// does this project path imply" — matching what NewInstance assigns by
+// default — so launch/add can prefer cwd-derived groups over inherited
+// parent groups without duplicating the heuristic.
+func GroupPathForProject(projectPath string) string {
+	return extractGroupPath(projectPath)
+}
+
 // extractGroupPath extracts a group path from project path
 // e.g., "/home/user/projects/devops" -> "projects"
 func extractGroupPath(projectPath string) string {


### PR DESCRIPTION
## Summary

Closes #972.

`agent-deck launch <path>` from inside a conductor session (whose own group is `conductor`) was silently inheriting the parent's `conductor` group instead of landing in the project group derived from the cwd. Every conductor-spawned child required a follow-up `agent-deck group move` to land in the right group — silent, repetitive friction.

## Fix

Extends `resolveGroupSelection` with a cwd-derived slot and a fixed priority order:

1. **Explicit `-g/--group`** — always wins (unchanged override semantics).
2. **Cwd-derived project group** — new; computed from the resolved project path via the new exported wrapper `session.GroupPathForProject` around the existing `extractGroupPath` heuristic. Launch and `NewInstance` now share one source of truth for "what group does this path imply".
3. **Parent-session group** — fallback only when no cwd-derived group is available (e.g. empty path mapping).

`handleAdd` keeps its existing semantics (passes `""` for the cwd-derived slot) because its path resolution happens *after* group resolution; fixing that path-vs-group ordering is out of scope here.

## Why per-conductor groups matter

Per the long-standing convention (memory note `feedback_agent_deck_conductor_uses_agent_deck_group.md`), each conductor has a matching project group, and every child it launches must land there:

- conductor `agent-deck` → children in group `agent-deck`
- conductor `<client-conductor>` → children in group `<client-group>`
- … and so on for each other conductor's matching project group

The `conductor` group is reserved exclusively for the conductor sessions themselves; mixing children into it clutters the top of the TUI tree and breaks per-group dashboards/heartbeats.

## TDD trail

- **RED:** `cmd/agent-deck/issue972_launch_group_test.go::TestLaunch_DerivesGroupFromCwdNotParent_RegressionFor972` — compile-fails on `main` (signature mismatch), passes on this branch.
- **GREEN:** same test plus updated `TestResolveGroupSelection` cases verify all three priority levels.
- **Full suite:** `GOTOOLCHAIN=go1.24.0 go test -race -count=1 ./...` — all packages green, including the mandate suites (`TestPersistence_*`, `Feedback*`, `Sender_*`, `Watcher*`).

## Test plan

- [ ] From an `agent-deck` conductor session, run `agent-deck launch /path/to/some-project -c claude` with no `-g`; verify the child's group is the project group, not `conductor`.
- [ ] Same call with `-g some-other-group`; verify explicit `-g` still overrides everything.
- [ ] Launch with a path whose `extractGroupPath` returns empty (degenerate path); verify it falls back to the parent's group rather than crashing.

Committed by Ashesh Goplani
