### PR TITLE
fix(cli): session send --timeout actually extends agent-ready wait (closes #957)

### DIFF
--- a/cmd/agent-deck/issue957_send_timeout_test.go
+++ b/cmd/agent-deck/issue957_send_timeout_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// neverReadyChecker simulates a busy agent that never reaches "waiting"/"idle".
+// GetStatus always returns "active" (the loading state), so waitForAgentReady
+// can never satisfy its readiness predicate and must hit the timeout.
+type neverReadyChecker struct {
+	calls atomic.Int64
+}
+
+func (m *neverReadyChecker) GetStatus() (string, error) {
+	m.calls.Add(1)
+	return "active", nil
+}
+
+func (m *neverReadyChecker) CapturePaneFresh() (string, error) {
+	return "", nil
+}
+
+// TestSessionSend_RespectsTimeoutFlag_RegressionFor957 is the regression test
+// for issue #957: `session send --timeout <duration>` must bound the
+// agent-ready wait, not just the post-ready completion wait.
+//
+// Before the fix, waitForAgentReady ignored its caller's timeout and used a
+// hardcoded 80s (400 attempts × 200ms). With a 1s caller-supplied timeout
+// against a never-ready mock, the call took ~80s instead of ~1s.
+//
+// After the fix, the function returns within a small multiple of the
+// requested timeout.
+func TestSessionSend_RespectsTimeoutFlag_RegressionFor957(t *testing.T) {
+	mock := &neverReadyChecker{}
+
+	requested := 1 * time.Second
+	start := time.Now()
+	err := waitForAgentReady(mock, "shell", requested)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected timeout error for never-ready agent, got nil (elapsed=%v)", elapsed)
+	}
+
+	// Must not have run anywhere near the legacy hardcoded 80s gate.
+	// Allow generous headroom for CI scheduling jitter (3× the requested).
+	upper := 3 * requested
+	if elapsed > upper {
+		t.Fatalf("waitForAgentReady ignored --timeout: elapsed=%v, requested=%v, upper bound=%v (legacy hardcoded gate was ~80s — looks unfixed)", elapsed, requested, upper)
+	}
+
+	// Must not have returned instantly (would mean the wait loop is broken).
+	lower := requested / 2
+	if elapsed < lower {
+		t.Fatalf("waitForAgentReady returned too quickly: elapsed=%v, requested=%v, lower bound=%v", elapsed, requested, lower)
+	}
+
+	// Error message should reference the timeout so operators can diagnose.
+	if !strings.Contains(err.Error(), "not ready") {
+		t.Errorf("expected error to mention readiness, got: %v", err)
+	}
+
+	if mock.calls.Load() == 0 {
+		t.Errorf("expected GetStatus to be polled at least once, got 0 calls")
+	}
+}
+
+// TestWaitForAgentReady_ShorterTimeout_ReturnsFaster asserts the wait actually
+// scales with --timeout (not just "anything <80s passes"). Catches regressions
+// where someone might cap the timeout silently.
+func TestWaitForAgentReady_ShorterTimeout_ReturnsFaster(t *testing.T) {
+	mock := &neverReadyChecker{}
+
+	requested := 500 * time.Millisecond
+	start := time.Now()
+	err := waitForAgentReady(mock, "shell", requested)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("500ms timeout took %v — wait loop not honoring caller timeout", elapsed)
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1741,7 +1741,7 @@ func handleSessionSend(profile string, args []string) {
 	wait := fs.Bool("wait", false, "Block until agent finishes processing, then print output")
 	stream := fs.Bool("stream", false, "Stream JSONL events (Claude only) to stdout instead of returning a snapshot")
 	draft := fs.Bool("draft", false, "Pre-fill the prompt without submitting (incompatible with --wait/--stream/--no-wait)")
-	timeout := fs.Duration("timeout", 10*time.Minute, "Max time to wait for completion (used with --wait)")
+	timeout := fs.Duration("timeout", 10*time.Minute, "Max time to wait for the agent to become ready and (with --wait) to finish processing")
 	streamIdle := fs.Duration("stream-idle", 10*time.Second, "Max idle time before --stream aborts with error")
 	streamCharBudget := fs.Int("stream-char-budget", 4000, "Char budget for text flush in --stream mode")
 	streamToolBudget := fs.Int("stream-tool-budget", 3, "Tool-event budget for text flush in --stream mode")
@@ -1828,9 +1828,12 @@ func handleSessionSend(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Wait for agent to be ready (unless --no-wait is specified)
+	// Wait for agent to be ready (unless --no-wait is specified).
+	// Issue #957: honor --timeout for the readiness phase too, not just the
+	// post-ready completion wait. Otherwise --timeout 5m against a busy
+	// recipient silently fails at ~80s.
 	if !*noWait {
-		if err := waitForAgentReady(tmuxSess, inst.Tool); err != nil {
+		if err := waitForAgentReady(tmuxSess, inst.Tool, *timeout); err != nil {
 			out.Error(fmt.Sprintf("timeout waiting for agent: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
@@ -2257,17 +2260,38 @@ func messageDeliveryToken(message string) string {
 	return trimmed
 }
 
+// agentReadyChecker abstracts the tmux surface that waitForAgentReady needs.
+// Lets tests exercise the readiness/timeout loop without a real tmux session.
+// *tmux.Session satisfies this interface naturally.
+type agentReadyChecker interface {
+	GetStatus() (string, error)
+	CapturePaneFresh() (string, error)
+}
+
 // waitForAgentReady waits for Claude/Gemini/other agents to be ready for input
-// Uses status detection: waits for "active" → "waiting" transition
-func waitForAgentReady(tmuxSess *tmux.Session, tool string) error {
+// Uses status detection: waits for "active" → "waiting" transition.
+//
+// Issue #957: before v1.9.x this loop was hardcoded to 80s and silently
+// overrode the caller's --timeout. `--timeout` now bounds the agent-ready
+// phase too, so `session send --timeout 5m` against a busy recipient actually
+// waits up to 5m for readiness before giving up.
+func waitForAgentReady(target agentReadyChecker, tool string, timeout time.Duration) error {
+	const pollInterval = 200 * time.Millisecond
+	if timeout <= 0 {
+		timeout = 80 * time.Second // preserve historical default if caller passes zero
+	}
+	maxAttempts := int(timeout / pollInterval)
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
 	sawActive := false
 	readyCount := 0
-	maxAttempts := 400 // 80 seconds max (400 * 200ms)
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(pollInterval)
 
-		status, err := tmuxSess.GetStatus()
+		status, err := target.GetStatus()
 		if err != nil {
 			readyCount = 0
 			continue
@@ -2291,7 +2315,7 @@ func waitForAgentReady(tmuxSess *tmux.Session, tool string) error {
 		alreadyReady := readyCount >= 10 && attempt >= 15 // At least 3s elapsed
 		if (sawActive && (status == "waiting" || status == "idle")) || alreadyReady {
 			if tool == "claude" {
-				if rawContent, captureErr := tmuxSess.CapturePaneFresh(); captureErr == nil && !send.HasCurrentComposerPrompt(tmux.StripANSI(rawContent)) {
+				if rawContent, captureErr := target.CapturePaneFresh(); captureErr == nil && !send.HasCurrentComposerPrompt(tmux.StripANSI(rawContent)) {
 					// Claude can report waiting before the interactive prompt is visible.
 					// Keep polling until the prompt line is present.
 					continue
@@ -2300,7 +2324,7 @@ func waitForAgentReady(tmuxSess *tmux.Session, tool string) error {
 			// Gate Codex sends on prompt readiness: wait for "codex>" or
 			// "Continue?" to be visible before considering the agent ready.
 			if tool == "codex" {
-				if rawContent, captureErr := tmuxSess.CapturePaneFresh(); captureErr == nil {
+				if rawContent, captureErr := target.CapturePaneFresh(); captureErr == nil {
 					content := tmux.StripANSI(rawContent)
 					detector := tmux.NewPromptDetector("codex")
 					if !detector.HasPrompt(content) {
@@ -2314,7 +2338,7 @@ func waitForAgentReady(tmuxSess *tmux.Session, tool string) error {
 		}
 	}
 
-	return fmt.Errorf("agent not ready after 80 seconds")
+	return fmt.Errorf("agent not ready after %s", timeout)
 }
 
 // statusChecker abstracts tmux status polling so waitForCompletion is testable.


### PR DESCRIPTION
## Summary

Closes #957.

`agent-deck session send <name> "msg" --timeout 5m` against a busy recipient silently failed at ~80s instead of waiting the requested 5 minutes. The `--timeout` flag was parsed and threaded into `waitForCompletion`, but the **agent-ready** phase that runs first used a hardcoded 80s gate (`waitForAgentReady` had `maxAttempts := 400` × 200ms poll = 80s, with no timeout parameter).

This PR makes `--timeout` bound both phases, matching the documented behavior and the flag name.

## Root cause

`cmd/agent-deck/session_cmd.go:2262` — `waitForAgentReady(tmuxSess *tmux.Session, tool string)` had no timeout parameter and unconditionally looped 400 times.
`cmd/agent-deck/session_cmd.go:1833` (call site) — the caller's `*timeout` (already in scope) was never passed.

## Changes

- Introduce `agentReadyChecker` interface (GetStatus + CapturePaneFresh), mirroring the existing `statusChecker` pattern at line 2321. `*tmux.Session` satisfies it naturally; tests can now drive the readiness/timeout loop without a real tmux session.
- `waitForAgentReady(target, tool, timeout)` derives `maxAttempts` from the caller's timeout. Zero/negative preserves the legacy 80s default for safety.
- Thread `*timeout` from the `session send` call site.
- Update `--timeout` help text to reflect that it now covers the ready phase too.

## Regression test (TDD)

`cmd/agent-deck/issue957_send_timeout_test.go`:

- `TestSessionSend_RespectsTimeoutFlag_RegressionFor957` — mocks a never-ready agent (`GetStatus` returns `"active"` forever), calls `waitForAgentReady(mock, "shell", 1*time.Second)`, asserts the call returns in ≤ 3s with a readiness error. On `origin/main` this fails to compile (new signature), proving RED. After the fix: PASS in ~1.0s.
- `TestWaitForAgentReady_ShorterTimeout_ReturnsFaster` — same mock, 500ms timeout, asserts elapsed < 2s.

```
=== RUN   TestSessionSend_RespectsTimeoutFlag_RegressionFor957
--- PASS: TestSessionSend_RespectsTimeoutFlag_RegressionFor957 (1.00s)
=== RUN   TestWaitForAgentReady_ShorterTimeout_ReturnsFaster
--- PASS: TestWaitForAgentReady_ShorterTimeout_ReturnsFaster (0.40s)
```

## Test plan

- [x] `go test ./cmd/agent-deck/... -race -count=1` — PASS (62.6s)
- [x] `go test ./internal/session/... -run TestPersistence_ -race -count=1` — PASS (mandatory per CLAUDE.md)
- [x] `go build ./...` — clean
- [x] RED on `origin/main`: test fails to compile (proves new contract is enforced)
- [x] GREEN after fix: both regression tests pass

Committed by Ashesh Goplani