### PR TITLE
fix(cli): accept verb/flag aliases for session/group/launch (closes #974)

### DIFF
--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -10,6 +10,34 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
+// groupVerbCanonical maps a user-supplied group subcommand verb to its
+// canonical form, accepting common aliases. Returns ok=false if unknown.
+//
+// Issue #974: users coming from filesystem/`rm` vocabulary expect
+// `group remove` to work alongside `group delete` / `group rm`. We accept
+// all three so the user doesn't burn a round-trip guessing the verb.
+func groupVerbCanonical(verb string) (canonical string, ok bool) {
+	switch verb {
+	case "list", "ls":
+		return "list", true
+	case "create", "new":
+		return "create", true
+	case "update", "set":
+		return "update", true
+	case "delete", "rm", "remove":
+		return "delete", true
+	case "move", "mv":
+		return "move", true
+	case "change", "reparent":
+		return "change", true
+	case "reorder", "sort":
+		return "reorder", true
+	case "help", "--help", "-h":
+		return "help", true
+	}
+	return "", false
+}
+
 // handleGroup dispatches group subcommands
 func handleGroup(profile string, args []string) {
 	if len(args) == 0 {
@@ -18,29 +46,31 @@ func handleGroup(profile string, args []string) {
 		return
 	}
 
-	switch args[0] {
-	case "list", "ls":
-		handleGroupList(profile, args[1:])
-	case "create", "new":
-		handleGroupCreate(profile, args[1:])
-	case "update", "set":
-		handleGroupUpdate(profile, args[1:])
-	case "delete", "rm":
-		handleGroupDelete(profile, args[1:])
-	case "move", "mv":
-		handleGroupMove(profile, args[1:])
-	case "change", "reparent":
-		handleGroupChange(profile, args[1:])
-	case "reorder", "sort":
-		handleGroupReorder(profile, args[1:])
-	case "help", "--help", "-h":
-		printGroupHelp()
-		return
-	default:
+	canonical, ok := groupVerbCanonical(args[0])
+	if !ok {
 		fmt.Printf("Unknown group command: %s\n", args[0])
 		fmt.Println()
 		printGroupHelp()
 		os.Exit(1)
+	}
+
+	switch canonical {
+	case "list":
+		handleGroupList(profile, args[1:])
+	case "create":
+		handleGroupCreate(profile, args[1:])
+	case "update":
+		handleGroupUpdate(profile, args[1:])
+	case "delete":
+		handleGroupDelete(profile, args[1:])
+	case "move":
+		handleGroupMove(profile, args[1:])
+	case "change":
+		handleGroupChange(profile, args[1:])
+	case "reorder":
+		handleGroupReorder(profile, args[1:])
+	case "help":
+		printGroupHelp()
 	}
 }
 
@@ -52,7 +82,7 @@ func printGroupHelp() {
 	fmt.Println("  list              List all groups with session counts")
 	fmt.Println("  create <name>     Create a new group")
 	fmt.Println("  update <name>     Update group settings")
-	fmt.Println("  delete <name>     Delete a group")
+	fmt.Println("  delete <name>     Delete a group (aliases: rm, remove)")
 	fmt.Println("  move <id> <group> Move session to a different group")
 	fmt.Println("  change <group> [<dest>] Reparent a group (empty dest = move to root)")
 	fmt.Println("  reorder <name>    Reorder a group (--up, --down, --position N)")

--- a/cmd/agent-deck/issue974_verb_aliases_test.go
+++ b/cmd/agent-deck/issue974_verb_aliases_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestCLI_VerbAliases_Accepted_RegressionFor974 covers the three CLI ergonomic
+// rejections reported in issue #974:
+//
+//  1. `agent-deck session update <id> --no-parent`  — verb `update` rejected
+//  2. `agent-deck group remove <name>`              — verb `remove` rejected
+//  3. `agent-deck launch <path> ... -parent <pid>`  — value swallowed by path
+//
+// Each row asserts the user-facing parsing of the rejected form now succeeds
+// and routes to the correct canonical operation.
+func TestCLI_VerbAliases_Accepted_RegressionFor974(t *testing.T) {
+	t.Run("session_update_with_no_parent_routes_to_unset_parent", func(t *testing.T) {
+		canonical, newArgs := resolveSessionUpdateAlias([]string{"sess-abc", "--no-parent"})
+		if canonical != "unset-parent" {
+			t.Errorf("session update --no-parent: expected canonical=unset-parent, got %q", canonical)
+		}
+		if !reflect.DeepEqual(newArgs, []string{"sess-abc"}) {
+			t.Errorf("session update --no-parent: expected args=[sess-abc], got %v", newArgs)
+		}
+	})
+
+	t.Run("session_update_with_parent_value_routes_to_set_parent", func(t *testing.T) {
+		canonical, newArgs := resolveSessionUpdateAlias([]string{"child", "--parent", "papa"})
+		if canonical != "set-parent" {
+			t.Errorf("session update --parent: expected canonical=set-parent, got %q", canonical)
+		}
+		if !reflect.DeepEqual(newArgs, []string{"child", "papa"}) {
+			t.Errorf("session update --parent: expected [child papa], got %v", newArgs)
+		}
+	})
+
+	t.Run("session_update_with_parent_equals_value_routes_to_set_parent", func(t *testing.T) {
+		canonical, newArgs := resolveSessionUpdateAlias([]string{"child", "--parent=papa"})
+		if canonical != "set-parent" {
+			t.Errorf("session update --parent=papa: expected canonical=set-parent, got %q", canonical)
+		}
+		if !reflect.DeepEqual(newArgs, []string{"child", "papa"}) {
+			t.Errorf("session update --parent=papa: expected [child papa], got %v", newArgs)
+		}
+	})
+
+	t.Run("group_remove_aliases_to_delete", func(t *testing.T) {
+		canonical, ok := groupVerbCanonical("remove")
+		if !ok {
+			t.Fatalf("group remove: expected verb to be recognized")
+		}
+		if canonical != "delete" {
+			t.Errorf("group remove: expected canonical=delete, got %q", canonical)
+		}
+	})
+
+	// Sanity: ensure the existing aliases still resolve through the same helper,
+	// so the new `remove` row does not regress them.
+	t.Run("group_rm_still_aliases_to_delete", func(t *testing.T) {
+		canonical, ok := groupVerbCanonical("rm")
+		if !ok || canonical != "delete" {
+			t.Errorf("group rm: expected (delete, true), got (%q, %v)", canonical, ok)
+		}
+	})
+
+	t.Run("launch_single_dash_parent_keeps_value_paired", func(t *testing.T) {
+		in := []string{"/some/path", "-t", "X", "-c", "claude", "-parent", "parent-id"}
+		got := reorderArgsForFlagParsing(in)
+
+		// After reorder, `-parent` must be immediately followed by its value
+		// (`parent-id`), not by the path. Otherwise downstream parsing pairs
+		// `-parent` with `/some/path` and treats `parent-id` as the path.
+		idx := -1
+		for i, a := range got {
+			if a == "-parent" {
+				idx = i
+				break
+			}
+		}
+		if idx == -1 {
+			t.Fatalf("launch -parent: flag missing from reordered args: %v", got)
+		}
+		if idx+1 >= len(got) {
+			t.Fatalf("launch -parent: no following arg in %v", got)
+		}
+		if got[idx+1] != "parent-id" {
+			t.Errorf("launch -parent: expected next arg=parent-id, got %q (full=%v)", got[idx+1], got)
+		}
+	})
+
+	// Sanity: the canonical double-dash form must still pair correctly.
+	t.Run("launch_double_dash_parent_keeps_value_paired", func(t *testing.T) {
+		in := []string{"/some/path", "-t", "X", "-c", "claude", "--parent", "parent-id"}
+		got := reorderArgsForFlagParsing(in)
+		idx := -1
+		for i, a := range got {
+			if a == "--parent" {
+				idx = i
+				break
+			}
+		}
+		if idx == -1 || idx+1 >= len(got) || got[idx+1] != "parent-id" {
+			t.Errorf("launch --parent: expected value=parent-id immediately after flag, got %v", got)
+		}
+	})
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -856,30 +856,40 @@ func extractSelectFlag(args []string) (string, []string) {
 // Go's flag package stops parsing at the first non-flag argument,
 // so "add . -c claude" would fail to parse -c without this fix.
 // This reorders to "add -c claude ." which parses correctly.
+//
+// Issue #974: Go's flag package treats `-parent` and `--parent` as the
+// same flag, but this reorder pass historically only matched the exact
+// double-dash spelling. The result was that `launch -parent <pid>` did
+// not pair `-parent` with `<pid>` — `<pid>` got demoted to a positional
+// and the wrong arg ended up as the parent value. We now match flag
+// names by their normalized form (dashes stripped from the left) so
+// `-parent` and `--parent` behave identically here too.
 func reorderArgsForFlagParsing(args []string) []string {
 	if len(args) == 0 {
 		return args
 	}
 
-	// Known flags that take a value (need to skip their values)
-	// Note: -b/--new-branch are boolean flags (no value), so not included here
-	valueFlags := map[string]bool{
-		"-t": true, "--title": true,
-		"-g": true, "--group": true,
-		"-c": true, "--cmd": true,
-		"-m": true, "--message": true,
-		"-p": true, "--parent": true,
-		"--mcp":       true,
-		"--channel":   true,
-		"--plugin":    true,
-		"--extra-arg": true,
-		"--wrapper":   true,
-		"-w":          true, "--worktree": true,
-		"--location":       true,
-		"--resume-session": true,
-		"--sandbox-image":  true,
-		"--ssh":            true,
-		"--remote-path":    true,
+	// Known flag *names* (no leading dashes) that take a value.
+	// Note: -b/--new-branch are boolean flags (no value), so not included here.
+	valueFlagNames := map[string]bool{
+		"t": true, "title": true,
+		"g": true, "group": true,
+		"c": true, "cmd": true,
+		"m": true, "message": true,
+		"p": true, "parent": true,
+		"mcp":            true,
+		"channel":        true,
+		"plugin":         true,
+		"extra-arg":      true,
+		"wrapper":        true,
+		"w":              true,
+		"worktree":       true,
+		"location":       true,
+		"resume-session": true,
+		"sandbox-image":  true,
+		"ssh":            true,
+		"remote-path":    true,
+		"tmux-socket":    true,
 	}
 
 	var flags []string
@@ -889,12 +899,17 @@ func reorderArgsForFlagParsing(args []string) []string {
 		arg := args[i]
 
 		// Check if it's a flag
-		if strings.HasPrefix(arg, "-") {
+		if strings.HasPrefix(arg, "-") && arg != "-" {
 			flags = append(flags, arg)
 
-			// Check if this flag takes a value (and value is separate)
-			// Handle both "-c value" and "-c=value" formats
-			if !strings.Contains(arg, "=") && valueFlags[arg] && i+1 < len(args) {
+			// `-foo=bar` carries its value in the same token.
+			if strings.Contains(arg, "=") {
+				continue
+			}
+
+			// Normalize "-foo" / "--foo" to "foo" for lookup.
+			name := strings.TrimLeft(arg, "-")
+			if valueFlagNames[name] && i+1 < len(args) {
 				i++
 				flags = append(flags, args[i])
 			}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -51,6 +51,11 @@ func handleSession(profile string, args []string) {
 		handleSessionSetParent(profile, args[1:])
 	case "unset-parent":
 		handleSessionUnsetParent(profile, args[1:])
+	case "update":
+		// Issue #974: users expect `session update <id> --no-parent` and
+		// `session update <id> --parent <p>` to mirror typical CRUD verbs.
+		// Route to the existing canonical handlers.
+		handleSessionUpdate(profile, args[1:])
 	case "set-transition-notify":
 		handleSessionSetTransitionNotify(profile, args[1:])
 	case "set-title-lock":
@@ -97,6 +102,8 @@ func printSessionHelp() {
 	fmt.Println("  search <query>          Search message content across Claude sessions")
 	fmt.Println("  set-parent <id> <parent>  Link session as sub-session of parent")
 	fmt.Println("  unset-parent <id>       Remove sub-session link")
+	fmt.Println("  update <id> --no-parent          Alias for unset-parent <id>")
+	fmt.Println("  update <id> --parent <pid>       Alias for set-parent <id> <pid>")
 	fmt.Println("  set-transition-notify <id> <on|off>  Enable/disable transition notifications")
 	fmt.Println("  set-title-lock <id> <on|off>         Lock/unlock title from Claude session-name sync (#697)")
 	fmt.Println()
@@ -1482,6 +1489,74 @@ func handleSessionSetParent(profile string, args []string) {
 		"group":           inst.GroupPath,
 		"group_inherited": *inheritGroup,
 	})
+}
+
+// resolveSessionUpdateAlias maps `session update <id>` invocations with
+// CRUD-style flags onto the existing canonical handlers. Returns the
+// canonical verb (`unset-parent` or `set-parent`) and the rewritten args
+// that handler expects.
+//
+// Issue #974: `session update <id> --no-parent` should behave the same as
+// `session unset-parent <id>`; `session update <id> --parent <pid>` should
+// behave the same as `session set-parent <id> <pid>`. If neither flag is
+// present we route to the generic `set` handler so the verb stays useful
+// for other field updates.
+//
+// Pure function — no I/O, safe to unit test.
+func resolveSessionUpdateAlias(args []string) (canonical string, newArgs []string) {
+	hasNoParent := false
+	hasParent := false
+	parentVal := ""
+	filtered := make([]string, 0, len(args))
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--no-parent" || a == "-no-parent":
+			hasNoParent = true
+		case a == "--parent" || a == "-parent":
+			if i+1 < len(args) {
+				parentVal = args[i+1]
+				i++
+			}
+			hasParent = true
+		case strings.HasPrefix(a, "--parent="):
+			parentVal = strings.TrimPrefix(a, "--parent=")
+			hasParent = true
+		case strings.HasPrefix(a, "-parent="):
+			parentVal = strings.TrimPrefix(a, "-parent=")
+			hasParent = true
+		default:
+			filtered = append(filtered, a)
+		}
+	}
+
+	switch {
+	case hasNoParent:
+		// `set-parent` and `--no-parent` together is contradictory; prefer
+		// the explicit detach (`--no-parent`) — matches the user's stated
+		// intent in the issue reproducer.
+		return "unset-parent", filtered
+	case hasParent:
+		return "set-parent", append(filtered, parentVal)
+	default:
+		return "set", filtered
+	}
+}
+
+// handleSessionUpdate dispatches `session update <id> [flags]` to the
+// appropriate canonical handler. See resolveSessionUpdateAlias for the
+// mapping rationale.
+func handleSessionUpdate(profile string, args []string) {
+	canonical, rewritten := resolveSessionUpdateAlias(args)
+	switch canonical {
+	case "unset-parent":
+		handleSessionUnsetParent(profile, rewritten)
+	case "set-parent":
+		handleSessionSetParent(profile, rewritten)
+	default:
+		handleSessionSet(profile, rewritten)
+	}
 }
 
 // handleSessionUnsetParent removes the sub-session link


### PR DESCRIPTION
## Summary

Three CLI ergonomic rejections reported in #974, each cumulatively significant because they appear constantly in orchestration scripts. Every rejected form below has a working canonical spelling — the bug is that the obvious neighbour-consistent spelling silently fails:

- `agent-deck session update <id> --no-parent` → "unknown session command: update"
- `agent-deck group remove <name>` → "Unknown group command: remove"
- `agent-deck launch <path> ... -parent <pid>` → silently mis-pairs args; `<pid>` gets demoted to a positional and the path slot eats it

## Fix

1. **`session update`** — `cmd/agent-deck/session_cmd.go`: new `update` case in the dispatcher routes through `resolveSessionUpdateAlias`, a pure helper that maps:
   - `update <id> --no-parent` → `unset-parent <id>`
   - `update <id> --parent <pid>` (and `--parent=<pid>`) → `set-parent <id> <pid>`
   - bare `update <id> <field> <value>` falls through to the existing `set` handler.

2. **`group remove`** — `cmd/agent-deck/group_cmd.go`: extracted `groupVerbCanonical` so all verb aliases live in one map. Added `remove` alongside the existing `delete` and `rm`.

3. **`launch -parent`** — `cmd/agent-deck/main.go`: `reorderArgsForFlagParsing` previously matched flags by literal token (`-p`, `--parent`) and missed `-parent`, so it skipped pairing the flag with its value. Go's own `flag` package treats `-foo` and `--foo` identically — the reorder pass was the lone outlier. Switched the lookup to flag *names* (dashes stripped) so every long-form flag works with either single or double dash. As a side-effect this fixes the previously-missing `--tmux-socket` entry too.

## Test plan

- [x] New `cmd/agent-deck/issue974_verb_aliases_test.go` covers all three rejected forms (plus regression sanity rows for `group rm` and `launch --parent`).
- [x] `go test -race -count=1 ./cmd/agent-deck/...` green.
- [x] Manual reproduction via built binary:
  - `session update <id> --no-parent` → reaches handler, fails on missing session (correct).
  - `group remove <name>` → reaches handler, fails on missing group (correct).
  - `launch /tmp/nope -t X -c claude -parent abc` → error now `path does not exist: /tmp/nope` (was: `/tmp/exec-tdd-974/repo/abc` — proving the value was swallowed).
- [x] Help text for `session` and `group` now lists the new spellings.

Closes #974.