### PR TITLE
fix(launch): strip TELEGRAM_STATE_DIR from child env to prevent duplicate poller (closes #955)

### DIFF
--- a/cmd/agent-deck/issue955_telegram_env_strip_test.go
+++ b/cmd/agent-deck/issue955_telegram_env_strip_test.go
@@ -1,0 +1,143 @@
+package main
+
+// Issue #955 regression — TELEGRAM_STATE_DIR env-inheritance leak on
+// `agent-deck launch` from a conductor session.
+//
+// #941 (closed) fixed the GLOBAL_ANTIPATTERN angle (enabledPlugins.telegram
+// = true in settings.json). #955 is a DIFFERENT angle:
+//
+//	When a conductor session spawns a child via `agent-deck launch`, the
+//	agent-deck CLI process inherits the conductor's TELEGRAM_STATE_DIR.
+//	That env var is then propagated to the tmux server that hosts the
+//	child session (tmux inherits the launching process env on first
+//	`new-session`). Even though the S8 layer wraps the final `claude`
+//	exec in `env -u TELEGRAM_STATE_DIR`, every other process in the
+//	pane — restart-respawn, fork claudes, Bash-tool subprocesses, any
+//	future plugin-loading shell — still sees TSD and can race the
+//	conductor for the same Telegram bot lock (HTTP 409, dropped
+//	inbound messages).
+//
+// Real fix: strip TELEGRAM_STATE_DIR from the agent-deck CLI process env
+// before the new session is started, IF the child is not a legitimate
+// telegram channel owner. The strip predicate is the same one the S8
+// exec-layer uses (telegramStateDirStripExpr); we just lift it from the
+// shell-command layer up to the os.Environ layer so the tmux server is
+// born without TSD in the first place.
+//
+// Reporter: asheshgoplani (issue #955).
+
+import (
+	"os"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+const issue955TSDPath = "/fake/conductor/tsd"
+
+// Non-conductor, non-channel-owner child launches MUST scrub
+// TELEGRAM_STATE_DIR from the agent-deck process env before starting
+// the tmux session. Without the strip the tmux server (and every
+// descendant of the pane) inherits TSD, the Claude Code telegram
+// plugin loads inside any non-S8-prefixed subprocess, and a duplicate
+// `bun telegram` poller races the conductor.
+func TestLaunch_DoesNotInheritTelegramStateDir_RegressionFor955(t *testing.T) {
+	t.Setenv("TELEGRAM_STATE_DIR", issue955TSDPath)
+
+	child := &session.Instance{
+		ID:          "955-child",
+		Tool:        "claude",
+		Title:       "launch-child",
+		ProjectPath: t.TempDir(),
+	}
+
+	session.ScrubProcessEnvForChildLaunch(child)
+
+	if got := os.Getenv("TELEGRAM_STATE_DIR"); got != "" {
+		t.Fatalf("issue #955 regression: non-channel-owning child launch must scrub TELEGRAM_STATE_DIR from the agent-deck process env before tmux new-session inherits it; got %q", got)
+	}
+}
+
+// Conductor sessions LEGITIMATELY own the telegram bot token. The
+// strip must NOT fire for them — otherwise the conductor's own
+// poller loses its state-dir handoff and the channel breaks.
+func TestLaunch_Conductor_KeepsTelegramStateDir_RegressionFor955(t *testing.T) {
+	t.Setenv("TELEGRAM_STATE_DIR", issue955TSDPath)
+
+	conductor := &session.Instance{
+		ID:          "955-conductor",
+		Tool:        "claude",
+		Title:       "conductor-test955",
+		ProjectPath: t.TempDir(),
+	}
+
+	session.ScrubProcessEnvForChildLaunch(conductor)
+
+	if got := os.Getenv("TELEGRAM_STATE_DIR"); got != issue955TSDPath {
+		t.Fatalf("conductor sessions own the telegram bot — TELEGRAM_STATE_DIR must be preserved; got %q want %q", got, issue955TSDPath)
+	}
+}
+
+// Sessions launched with an explicit telegram channel (--channel
+// plugin:telegram@…) ARE the channel owner for their bot, so the
+// strip must not fire. Mirrors S8's exec-layer carve-out.
+func TestLaunch_TelegramChannelOwner_KeepsTelegramStateDir_RegressionFor955(t *testing.T) {
+	t.Setenv("TELEGRAM_STATE_DIR", issue955TSDPath)
+
+	owner := &session.Instance{
+		ID:          "955-owner",
+		Tool:        "claude",
+		Title:       "bot-owner",
+		ProjectPath: t.TempDir(),
+		Channels:    []string{"plugin:telegram@claude-plugins-official"},
+	}
+
+	session.ScrubProcessEnvForChildLaunch(owner)
+
+	if got := os.Getenv("TELEGRAM_STATE_DIR"); got != issue955TSDPath {
+		t.Fatalf("telegram channel owner sessions must preserve TELEGRAM_STATE_DIR (they own the bot); got %q want %q", got, issue955TSDPath)
+	}
+}
+
+// Non-claude tools must not be touched. TELEGRAM_STATE_DIR is a
+// Claude Code plugin env var — codex / gemini / shell sessions
+// have no interaction with it, so the strip must leave their
+// process env alone (defense against future env-coupling bugs in
+// other tools).
+func TestLaunch_NonClaudeTool_LeavesEnvAlone_RegressionFor955(t *testing.T) {
+	t.Setenv("TELEGRAM_STATE_DIR", issue955TSDPath)
+
+	codexChild := &session.Instance{
+		ID:          "955-codex",
+		Tool:        "codex",
+		Title:       "launch-child",
+		ProjectPath: t.TempDir(),
+	}
+
+	session.ScrubProcessEnvForChildLaunch(codexChild)
+
+	if got := os.Getenv("TELEGRAM_STATE_DIR"); got != issue955TSDPath {
+		t.Fatalf("non-claude child launches must not touch TELEGRAM_STATE_DIR; got %q want %q", got, issue955TSDPath)
+	}
+}
+
+// When TELEGRAM_STATE_DIR is not set at all, the scrub must be a
+// no-op (no spurious errors, idempotent).
+func TestLaunch_NoTelegramStateDir_NoOp_RegressionFor955(t *testing.T) {
+	// Explicitly clear in case the host has it set.
+	t.Setenv("TELEGRAM_STATE_DIR", "")
+	_ = os.Unsetenv("TELEGRAM_STATE_DIR")
+
+	child := &session.Instance{
+		ID:          "955-noenv",
+		Tool:        "claude",
+		Title:       "launch-child",
+		ProjectPath: t.TempDir(),
+	}
+
+	session.ScrubProcessEnvForChildLaunch(child) // must not panic
+
+	if got, ok := os.LookupEnv("TELEGRAM_STATE_DIR"); ok {
+		t.Fatalf("scrub on an unset env must remain unset; got %q", got)
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -454,6 +454,15 @@ func handleLaunch(profile string, args []string) {
 		return
 	}
 
+	// Issue #955: strip TELEGRAM_STATE_DIR from the agent-deck CLI
+	// process env before the tmux server inherits it on the first
+	// `new-session`. No-op for conductors and explicit telegram
+	// channel owners — they legitimately own the bot token. Sits
+	// above the S8 exec-layer (env -u TELEGRAM_STATE_DIR claude …)
+	// so even non-claude descendants of the pane (Bash-tool spawns,
+	// fork claudes, restart respawn) start with a clean env.
+	session.ScrubProcessEnvForChildLaunch(newInstance)
+
 	// Start the session.
 	// - default: StartWithMessage waits for readiness and delivers initial prompt
 	// - --no-wait: start immediately, then fire-and-forget send below

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -377,3 +377,29 @@ func telegramStateDirStripExpr(inst *Instance) string {
 	}
 	return "unset TELEGRAM_STATE_DIR"
 }
+
+// ScrubProcessEnvForChildLaunch removes TELEGRAM_STATE_DIR from the
+// CURRENT process environment when the given instance represents a
+// non-channel-owning claude child. Issue #955: `agent-deck launch`
+// invoked from a conductor session inherits the conductor's
+// TELEGRAM_STATE_DIR; without this strip the var propagates into the
+// tmux server (which inherits the launching process env on first
+// `new-session`) and from there into every subprocess in the new
+// pane — Bash-tool spawns, fork claudes, restart respawn — even when
+// the S8 exec-layer (`env -u TELEGRAM_STATE_DIR claude`) protects the
+// immediate claude binary. Any of those descendants can load the
+// Claude Code telegram plugin and start a second `bun telegram`
+// poller against the conductor's bot, racing the conductor for the
+// Bot API lock (HTTP 409) and silently dropping inbound messages.
+//
+// Reuses telegramStateDirStripExpr as the single source of truth for
+// the strip predicate so this layer can never disagree with the
+// shell-level and exec-level layers about which sessions own the
+// telegram bot. No-op for conductors, explicit telegram channel
+// owners, and non-claude tools.
+func ScrubProcessEnvForChildLaunch(inst *Instance) {
+	if telegramStateDirStripExpr(inst) == "" {
+		return
+	}
+	_ = os.Unsetenv("TELEGRAM_STATE_DIR")
+}


### PR DESCRIPTION
## Summary
Closes #955. Companion fix to #941 (different angle).

When a conductor session spawns a child via `agent-deck launch`, the `agent-deck` CLI inherits the conductor's `TELEGRAM_STATE_DIR`. That var then propagates into the tmux server (which inherits the launching process env on first `new-session`) and into every subprocess in the new pane — Bash-tool spawns, fork claudes, restart respawn. Even though the S8 layer wraps the immediate claude exec in `env -u TELEGRAM_STATE_DIR`, those descendants still see TSD and any of them can load the Claude Code telegram plugin → second `bun telegram` poller → races the conductor for the Bot API lock → HTTP 409 → inbound messages silently dropped.

#941 (closed) addressed the **GLOBAL_ANTIPATTERN** angle (duplicate spawn when `enabledPlugins.telegram=true` in settings.json + `--channels` both fire). #955 raised by @asheshgoplani is the **env-inheritance** angle (parent process env leaks into the child via tmux).

The workaround (`env -u TELEGRAM_STATE_DIR agent-deck launch ...`) confirmed the root cause; this PR lifts that strip into agent-deck itself.

## Fix
- New `session.ScrubProcessEnvForChildLaunch(inst)` calls `os.Unsetenv("TELEGRAM_STATE_DIR")` when the launching instance is not a telegram channel owner.
- Reuses the existing `telegramStateDirStripExpr` predicate (single source of truth — same carve-out logic as the S8 exec layer and the shell-level unset).
- Wired into `handleLaunch` right before `newInstance.Start()` so the tmux server inherits a clean env from the very first `new-session`.

## Predicate (unchanged — reused)
Strip fires when **all** hold:
1. `Tool == "claude"` (non-claude tools untouched)
2. Title does NOT start with `conductor-` (conductors legitimately own the bot)
3. No `Channels` entry has the `plugin:telegram@` prefix (explicit owners keep TSD)

## Test plan
- [x] `TestLaunch_DoesNotInheritTelegramStateDir_RegressionFor955` — non-owner child strips TSD
- [x] `TestLaunch_Conductor_KeepsTelegramStateDir_RegressionFor955` — conductor preserved
- [x] `TestLaunch_TelegramChannelOwner_KeepsTelegramStateDir_RegressionFor955` — explicit owner preserved
- [x] `TestLaunch_NonClaudeTool_LeavesEnvAlone_RegressionFor955` — codex untouched
- [x] `TestLaunch_NoTelegramStateDir_NoOp_RegressionFor955` — idempotent / safe when unset
- [x] Full `go test ./... -race -count=1` green

## Credit
Reported by @asheshgoplani (issue #955); originally surfaced by the self-improvement pipeline scanning conductor transcripts.

Committed by Ashesh Goplani