### PR TITLE
fix(mcppool): refresh .mcp.json plugin pins on upgrade (closes #960)

### DIFF
--- a/internal/session/issue960_pin_refresh_test.go
+++ b/internal/session/issue960_pin_refresh_test.go
@@ -1,0 +1,94 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPluginUpgrade_RefreshesMcpJsonPins_RegressionFor960 covers issue #960:
+// when a Claude Code plugin upgrades on disk, any .mcp.json entry whose
+// command/args reference the now-stale <profile>/plugins/cache/<source>/<name>/<version>/
+// path must be rewritten to the currently-installed version. Without this,
+// /mcp reconnect silently keeps loading the outdated plugin.
+func TestPluginUpgrade_RefreshesMcpJsonPins_RegressionFor960(t *testing.T) {
+	profileDir := t.TempDir()
+	projectDir := t.TempDir()
+
+	source := "marketplace-x"
+	name := "fooplug"
+	pluginRoot := filepath.Join(profileDir, "plugins", "cache", source, name)
+
+	// Install plugin v1.0.0 on disk.
+	v1Dir := filepath.Join(pluginRoot, "1.0.0")
+	if err := os.MkdirAll(v1Dir, 0o755); err != nil {
+		t.Fatalf("mkdir v1: %v", err)
+	}
+	v1Server := filepath.Join(v1Dir, "server.js")
+	if err := os.WriteFile(v1Server, []byte("v1"), 0o644); err != nil {
+		t.Fatalf("write v1 server: %v", err)
+	}
+
+	// Write a .mcp.json entry that pins the v1 absolute path. The entry name
+	// is NOT in agent-deck's config.toml catalog, so the existing
+	// WriteMCPJsonFromConfig merge logic would preserve it verbatim (#146).
+	mcpFile := filepath.Join(projectDir, ".mcp.json")
+	initial := map[string]any{
+		"mcpServers": map[string]any{
+			name: map[string]any{
+				"type":    "stdio",
+				"command": "node",
+				"args":    []string{v1Server, "--flag"},
+			},
+		},
+	}
+	initialBytes, err := json.MarshalIndent(initial, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal initial: %v", err)
+	}
+	if err := os.WriteFile(mcpFile, initialBytes, 0o644); err != nil {
+		t.Fatalf("write initial mcp.json: %v", err)
+	}
+
+	// Simulate plugin upgrade: 1.0.0 removed, 2.0.0 installed.
+	if err := os.RemoveAll(v1Dir); err != nil {
+		t.Fatalf("remove v1: %v", err)
+	}
+	v2Dir := filepath.Join(pluginRoot, "2.0.0")
+	if err := os.MkdirAll(v2Dir, 0o755); err != nil {
+		t.Fatalf("mkdir v2: %v", err)
+	}
+	v2Server := filepath.Join(v2Dir, "server.js")
+	if err := os.WriteFile(v2Server, []byte("v2"), 0o644); err != nil {
+		t.Fatalf("write v2 server: %v", err)
+	}
+
+	// Trigger refresh.
+	refreshed, err := RefreshStalePluginPins(mcpFile, []string{profileDir})
+	if err != nil {
+		t.Fatalf("RefreshStalePluginPins: %v", err)
+	}
+	if refreshed != 1 {
+		t.Errorf("expected 1 entry refreshed, got %d", refreshed)
+	}
+
+	// Verify .mcp.json now references v2 path, not v1.
+	data, err := os.ReadFile(mcpFile)
+	if err != nil {
+		t.Fatalf("read mcp.json after refresh: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "1.0.0") {
+		t.Errorf(".mcp.json still references stale 1.0.0 pin after refresh:\n%s", s)
+	}
+	if !strings.Contains(s, v2Server) {
+		t.Errorf(".mcp.json missing refreshed v2 path %q:\n%s", v2Server, s)
+	}
+
+	// The non-versioned --flag arg must survive untouched.
+	if !strings.Contains(s, "--flag") {
+		t.Errorf(".mcp.json lost --flag arg during refresh:\n%s", s)
+	}
+}

--- a/internal/session/mcp_catalog.go
+++ b/internal/session/mcp_catalog.go
@@ -152,6 +152,17 @@ func WriteMCPJsonFromConfig(projectPath string, enabledNames []string) error {
 	availableMCPs := GetAvailableMCPs()
 	pool := GetGlobalPool() // Get pool instance (may be nil)
 
+	// #960: refresh stale plugin-cache version pins in the file on disk before
+	// the merge reads it. Preserved (non-catalog) entries are reused verbatim
+	// (#146), so without this step a `claude plugin upgrade` leaves the old
+	// version path baked into .mcp.json forever and /mcp reconnect silently
+	// keeps loading the outdated plugin.
+	if profile := GetClaudeConfigDir(); profile != "" {
+		if _, err := RefreshStalePluginPins(mcpFile, []string{profile}); err != nil {
+			mcpCatLog.Warn("plugin_pin_refresh_failed", "path", mcpFile, "error", err)
+		}
+	}
+
 	// Read existing .mcp.json to preserve entries not managed by agent-deck (#146)
 	existingServers := readExistingLocalMCPServers(mcpFile)
 

--- a/internal/session/pin_refresh.go
+++ b/internal/session/pin_refresh.go
@@ -1,0 +1,171 @@
+// Pin refresh — issue #960.
+//
+// Claude Code plugins install under <profile>/plugins/cache/<source>/<name>/<version>/,
+// and any .mcp.json entry whose command/args bake an absolute path into that
+// versioned directory goes stale the moment the user runs `claude plugin upgrade`.
+// agent-deck's existing merge logic (#146) preserves such entries verbatim, so
+// regeneration never refreshes them — /mcp reconnect silently keeps loading the
+// outdated plugin.
+//
+// RefreshStalePluginPins rewrites stale version segments in-place. It's called
+// from WriteMCPJsonFromConfig before the merge step so the existing-entry
+// preservation path sees the refreshed paths, and is also exported for the
+// regression test.
+
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// RefreshStalePluginPins scans mcpFile for mcpServers entries whose `command`
+// or `args` strings reference <profileDir>/plugins/cache/<source>/<name>/<version>/...
+// where <version> no longer exists on disk. Each stale reference is rewritten
+// to point at the most recently installed version directory under the same
+// <source>/<name>. Returns the number of entries that were modified.
+//
+// If mcpFile does not exist, returns (0, nil). If no profileDirs are supplied
+// or no pins are stale, returns (0, nil) without touching the file.
+func RefreshStalePluginPins(mcpFile string, profileDirs []string) (int, error) {
+	if len(profileDirs) == 0 {
+		return 0, nil
+	}
+	data, err := os.ReadFile(mcpFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return 0, fmt.Errorf("parse .mcp.json: %w", err)
+	}
+	servers, ok := root["mcpServers"].(map[string]any)
+	if !ok {
+		return 0, nil
+	}
+
+	refreshed := 0
+	for _, entryRaw := range servers {
+		entry, ok := entryRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		changed := false
+		if cmd, ok := entry["command"].(string); ok {
+			if newCmd, did := refreshPluginCachePath(cmd, profileDirs); did {
+				entry["command"] = newCmd
+				changed = true
+			}
+		}
+		if argsRaw, ok := entry["args"].([]any); ok {
+			for i, a := range argsRaw {
+				s, ok := a.(string)
+				if !ok {
+					continue
+				}
+				if newArg, did := refreshPluginCachePath(s, profileDirs); did {
+					argsRaw[i] = newArg
+					changed = true
+				}
+			}
+		}
+		if changed {
+			refreshed++
+		}
+	}
+
+	if refreshed == 0 {
+		return 0, nil
+	}
+
+	newData, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return 0, fmt.Errorf("marshal refreshed .mcp.json: %w", err)
+	}
+	tmp := mcpFile + ".tmp"
+	if err := os.WriteFile(tmp, newData, 0o644); err != nil {
+		return 0, fmt.Errorf("write refreshed .mcp.json: %w", err)
+	}
+	if err := os.Rename(tmp, mcpFile); err != nil {
+		os.Remove(tmp)
+		return 0, fmt.Errorf("save refreshed .mcp.json: %w", err)
+	}
+	return refreshed, nil
+}
+
+// refreshPluginCachePath returns (rewritten, true) if s contains a stale
+// <profileDir>/plugins/cache/<source>/<name>/<version>/... pin and we can
+// resolve a current version to replace <version> with. Otherwise returns
+// (s, false).
+func refreshPluginCachePath(s string, profileDirs []string) (string, bool) {
+	for _, prof := range profileDirs {
+		if prof == "" {
+			continue
+		}
+		marker := filepath.Join(prof, "plugins", "cache") + string(filepath.Separator)
+		idx := strings.Index(s, marker)
+		if idx < 0 {
+			continue
+		}
+		rest := s[idx+len(marker):]
+		parts := strings.SplitN(rest, string(filepath.Separator), 4)
+		if len(parts) < 3 {
+			continue
+		}
+		source, name, version := parts[0], parts[1], parts[2]
+		if source == "" || name == "" || version == "" {
+			continue
+		}
+		verDir := filepath.Join(prof, "plugins", "cache", source, name, version)
+		if _, err := os.Stat(verDir); err == nil {
+			// Version still installed — pin is fresh, leave alone.
+			continue
+		}
+		newest := newestPluginVersionDir(filepath.Join(prof, "plugins", "cache", source, name))
+		if newest == "" || newest == version {
+			continue
+		}
+		newPath := s[:idx+len(marker)] + source + string(filepath.Separator) + name + string(filepath.Separator) + newest
+		if len(parts) == 4 {
+			newPath += string(filepath.Separator) + parts[3]
+		}
+		return newPath, true
+	}
+	return s, false
+}
+
+// newestPluginVersionDir returns the name of the subdirectory under base with
+// the most recent ModTime, or "" if base does not exist or has no subdirs.
+// Picks by mtime (not lex/semver) because `claude plugin install` always
+// touches the freshly installed version last, regardless of the version
+// scheme the plugin author uses.
+func newestPluginVersionDir(base string) string {
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		return ""
+	}
+	var bestName string
+	var bestMtime time.Time
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if bestName == "" || info.ModTime().After(bestMtime) {
+			bestName = e.Name()
+			bestMtime = info.ModTime()
+		}
+	}
+	return bestName
+}


### PR DESCRIPTION
## Summary

Closes #960.

Claude Code plugins install under `<profile>/plugins/cache/<source>/<name>/<version>/`, and `.mcp.json` entries can bake that versioned path into `command`/`args`. The merge logic in `WriteMCPJsonFromConfig` (#146) preserves non-catalog entries verbatim, so a `claude plugin upgrade` leaves the old version path pinned forever — `/mcp` reconnect silently keeps loading the outdated plugin.

## Fix

- New `RefreshStalePluginPins(mcpFile, profileDirs)` in `internal/session/pin_refresh.go` rewrites `.mcp.json` entries whose `command`/`args` reference a plugin-cache path whose `<version>` directory no longer exists. The replacement version is the most-recently-modified version dir under the same `<source>/<name>` — `mtime`-based, not semver, so arbitrary version schemes work.
- `WriteMCPJsonFromConfig` calls the refresh at the top of every regen, so preserved entries pick up the fresh version before the merge reads them. Best-effort: errors are logged, never block the write.
- If both old and new versions coexist on disk, the pin is left alone (could be a deliberate user choice).

## Test plan

- [x] `TestPluginUpgrade_RefreshesMcpJsonPins_RegressionFor960` — fails on `origin/main` (function undefined), passes after the fix
- [x] `go test -race -count=1 ./internal/session/...` green (86s)
- [x] `go test -race -count=1 ./...` green across the whole repo

Committed by Ashesh Goplani