### PR TITLE
feat(launch): concurrency cap to prevent swap thrash (closes #964)

### DIFF
--- a/cmd/agent-deck/issue964_launch_cap_test.go
+++ b/cmd/agent-deck/issue964_launch_cap_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestLaunch_RespectsMaxParallel_RegressionFor964 pins the fix for
+// https://github.com/asheshgoplani/agent-deck/issues/964.
+//
+// Bug: parallel `agent-deck launch` calls cascade into swap thrash because
+// each launch spawns claude (~1-2GB RSS, ~71GB VSZ) plus a go test runner /
+// build (~1-2GB more). With 6+ concurrent launches the host runs out of
+// physical RAM and committed virtual memory; the "stability" mitigation
+// `vm.overcommit_memory=2` then blocks every subsequent fork.
+//
+// This regression test pins the structural fix: a process-wide semaphore
+// caps the number of in-flight launches at a small default (3, matching
+// the safe-launch convention). The cap is configurable via the
+// AGENT_DECK_MAX_PARALLEL_LAUNCH env var.
+func TestLaunch_RespectsMaxParallel_RegressionFor964(t *testing.T) {
+	const cap = 3
+	const callers = 5
+
+	throttle := newLaunchThrottle(cap)
+
+	var (
+		inFlight atomic.Int32
+		maxSeen  atomic.Int32
+		wg       sync.WaitGroup
+	)
+
+	// Fire 5 launches simultaneously. Without the cap, all 5 would run in
+	// parallel — the exact pattern that crashed the conductor twice.
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			throttle.Acquire()
+			defer throttle.Release()
+
+			cur := inFlight.Add(1)
+			for {
+				prev := maxSeen.Load()
+				if cur <= prev || maxSeen.CompareAndSwap(prev, cur) {
+					break
+				}
+			}
+			// Simulate the heavy work (claude boot + go build).
+			time.Sleep(40 * time.Millisecond)
+			inFlight.Add(-1)
+		}()
+	}
+	wg.Wait()
+
+	if got := maxSeen.Load(); got > int32(cap) {
+		t.Fatalf("max concurrent launches=%d exceeded cap=%d — throttle did not gate the spawn point", got, cap)
+	}
+	if got := maxSeen.Load(); got == 0 {
+		t.Fatalf("throttle never observed any in-flight callers; instrumentation broken")
+	}
+}
+
+// TestLaunchThrottleCap_DefaultAndEnvOverride_RegressionFor964 documents the
+// default cap (3) and the AGENT_DECK_MAX_PARALLEL_LAUNCH env-var override.
+// The default matches the safe-launch convention referenced in PROMPT.md.
+func TestLaunchThrottleCap_DefaultAndEnvOverride_RegressionFor964(t *testing.T) {
+	t.Run("default cap is 3", func(t *testing.T) {
+		t.Setenv("AGENT_DECK_MAX_PARALLEL_LAUNCH", "")
+		if got := launchThrottleCap(); got != 3 {
+			t.Errorf("default launchThrottleCap()=%d, want 3", got)
+		}
+	})
+
+	t.Run("env var overrides default", func(t *testing.T) {
+		t.Setenv("AGENT_DECK_MAX_PARALLEL_LAUNCH", "5")
+		if got := launchThrottleCap(); got != 5 {
+			t.Errorf("with env=5, launchThrottleCap()=%d, want 5", got)
+		}
+	})
+
+	t.Run("invalid env value falls back to default", func(t *testing.T) {
+		t.Setenv("AGENT_DECK_MAX_PARALLEL_LAUNCH", "not-a-number")
+		if got := launchThrottleCap(); got != 3 {
+			t.Errorf("with garbage env, launchThrottleCap()=%d, want 3", got)
+		}
+	})
+
+	t.Run("non-positive env value falls back to default", func(t *testing.T) {
+		t.Setenv("AGENT_DECK_MAX_PARALLEL_LAUNCH", "0")
+		if got := launchThrottleCap(); got != 3 {
+			t.Errorf("with env=0, launchThrottleCap()=%d, want 3", got)
+		}
+	})
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -466,6 +466,15 @@ func handleLaunch(profile string, args []string) {
 	// Start the session.
 	// - default: StartWithMessage waits for readiness and delivers initial prompt
 	// - --no-wait: start immediately, then fire-and-forget send below
+	//
+	// Issue #964: gate the spawn through a process-wide semaphore so a burst
+	// of parallel `agent-deck launch` calls cannot cascade into swap thrash +
+	// fork:ENOMEM. Cap defaults to defaultMaxParallelLaunch (3) and honours
+	// AGENT_DECK_MAX_PARALLEL_LAUNCH.
+	throttle := defaultLaunchThrottle()
+	throttle.Acquire()
+	defer throttle.Release()
+
 	if initialMessage != "" && !*noWait {
 		if err := newInstance.StartWithMessage(initialMessage); err != nil {
 			out.Error(fmt.Sprintf("failed to start session: %v", err), ErrCodeInvalidOperation)

--- a/cmd/agent-deck/launch_throttle.go
+++ b/cmd/agent-deck/launch_throttle.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"sync"
+)
+
+// defaultMaxParallelLaunch caps in-flight `agent-deck launch` spawns when no
+// AGENT_DECK_MAX_PARALLEL_LAUNCH override is set. 3 matches the safe-launch
+// convention and keeps total claude+toolchain RAM under ~6-9GB on typical
+// dev hosts. See issue #964 for the swap-thrash incidents that motivated it.
+const defaultMaxParallelLaunch = 3
+
+// launchThrottle is a buffered-channel semaphore that bounds the number of
+// concurrent launch spawns. Used by handleLaunch to gate the Start /
+// StartWithMessage call so a burst of parallel `agent-deck launch` invocations
+// cannot cascade into swap thrash + fork:ENOMEM.
+type launchThrottle struct {
+	sem chan struct{}
+}
+
+func newLaunchThrottle(cap int) *launchThrottle {
+	if cap < 1 {
+		cap = 1
+	}
+	return &launchThrottle{sem: make(chan struct{}, cap)}
+}
+
+func (t *launchThrottle) Acquire() { t.sem <- struct{}{} }
+func (t *launchThrottle) Release() { <-t.sem }
+
+// launchThrottleCap resolves the effective cap, honouring
+// AGENT_DECK_MAX_PARALLEL_LAUNCH when it parses to a positive int.
+func launchThrottleCap() int {
+	if v := os.Getenv("AGENT_DECK_MAX_PARALLEL_LAUNCH"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultMaxParallelLaunch
+}
+
+var (
+	globalLaunchThrottle     *launchThrottle
+	globalLaunchThrottleOnce sync.Once
+)
+
+func defaultLaunchThrottle() *launchThrottle {
+	globalLaunchThrottleOnce.Do(func() {
+		globalLaunchThrottle = newLaunchThrottle(launchThrottleCap())
+	})
+	return globalLaunchThrottle
+}


### PR DESCRIPTION
## Summary
- Add a process-wide buffered-channel semaphore (`launchThrottle`) that gates the spawn site in `handleLaunch` so a burst of parallel `agent-deck launch` calls cannot cascade into swap thrash + `fork: ENOMEM`.
- Default cap = **3** (matches the safe-launch convention; keeps total claude + toolchain RAM under ~6-9 GB on typical dev hosts).
- Configurable per-host via `AGENT_DECK_MAX_PARALLEL_LAUNCH=<N>`. Non-positive / garbage values fall back to the default.

## Why now — closes #964
The conductor session was killed by oomd **twice today** under exactly the pattern described in #964: 6+ parallel `agent-deck launch` calls each spawning `claude` (~1-2 GB RSS, ~71 GB VSZ) + go build/test runner (~1-2 GB more). Once physical RAM was exhausted, the naive `vm.overcommit_memory=2` mitigation then made things worse: committed VSZ alone overflowed `CommitLimit`, blocking every subsequent fork even with ~36 GB of physical RAM still free. Lost work in both crashes.

Root cause is structural: `handleLaunch` had no concurrency gate. Each `launch` was independent and unaware of its siblings.

## Implementation
- `cmd/agent-deck/launch_throttle.go` — buffered-channel semaphore + `launchThrottleCap()` resolver (env-var aware, lazily initialised once per process via `sync.Once`).
- `cmd/agent-deck/launch_cmd.go` — `Acquire()` immediately before `newInstance.Start{,WithMessage}`, `defer Release()` so the slot is freed whether the spawn succeeds or `os.Exit(1)` fires.
- `cmd/agent-deck/issue964_launch_cap_test.go` — TDD regression test. Fires 5 callers in goroutines, asserts max-in-flight ≤ 3, and pins the env-var override (default, override, invalid, non-positive).

## Configuration
| Env var | Default | Effect |
|---------|---------|--------|
| `AGENT_DECK_MAX_PARALLEL_LAUNCH` | `3` | Caps concurrent `agent-deck launch` spawns. Set higher only on hosts with verified memory headroom. |

## Test plan
- [x] `go test ./cmd/agent-deck/ -run 'TestLaunch_RespectsMaxParallel_RegressionFor964|TestLaunchThrottleCap_DefaultAndEnvOverride_RegressionFor964' -race` — passes
- [x] `go test ./... -race -count=1` — full repo green
- [x] Failing test verified RED before implementation (TDD)
- [ ] Manual: fire 5 parallel `agent-deck launch` calls and confirm load avg + RSS stay bounded (defer to maintainer; reproducing the crash is hostile to the dev host)