### PR TITLE
fix(feedback): per-major-version opt-out instead of forever (closes #967)

### DIFF
--- a/cmd/agent-deck/feedback_cmd.go
+++ b/cmd/agent-deck/feedback_cmd.go
@@ -219,12 +219,15 @@ func isFeedbackOptedOut(st *feedback.State, cfg *session.UserConfig) bool {
 // persistFeedbackOptOut writes the opt-out to BOTH stores and prints the
 // given message. Errors on either write are non-fatal — they log to stderr
 // but do not abort the CLI flow. v1.7.38.
+//
+// The opt-out is scoped to the running release series via the package-level
+// Version, so a future release-series bump can re-show the prompt (#967).
 func persistFeedbackOptOut(w io.Writer, userMessage string) {
 	st, _ := feedback.LoadState()
 	if st == nil {
 		st = &feedback.State{MaxShows: 3}
 	}
-	feedback.RecordOptOut(st)
+	feedback.RecordOptOut(st, Version)
 	if saveErr := feedback.SaveState(st); saveErr != nil {
 		fmt.Fprintf(os.Stderr, "feedback: save state: %v\n", saveErr)
 	}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -544,6 +544,9 @@ func main() {
 	// inflate the counter.
 	if fbSt, _ := feedback.LoadState(); fbSt != nil {
 		feedback.RecordLaunch(fbSt, time.Now())
+		// #967: migrate pre-existing forever-opt-outs to per-release-series.
+		// Idempotent — no-op once OptOutVersion is set or feedback is enabled.
+		feedback.MigrateLegacyOptOut(fbSt, Version)
 		_ = feedback.SaveState(fbSt)
 	}
 

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -121,7 +121,7 @@ func TestRecordOptOut(t *testing.T) {
 		ShownCount:       0,
 		MaxShows:         3,
 	}
-	feedback.RecordOptOut(st)
+	feedback.RecordOptOut(st, "1.5.1")
 	require.NoError(t, feedback.SaveState(st))
 
 	loaded, err := feedback.LoadState()
@@ -233,4 +233,92 @@ func TestSend_Headless(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, clipboardCalled, "clipboard must be called in headless mode")
 	require.False(t, browserCalled, "browser must NOT be called in headless mode")
+}
+
+// TestUpgradeFeedback_ShownPerMajorVersion_RegressionFor967 pins the fix for
+// issue #967: opting out of the upgrade feedback dialog at one major.minor
+// release ("1.9.5") must NOT silence the dialog forever. When the user upgrades
+// to the next release series ("1.10.0"), the dialog must show again so they get
+// the chance to comment on the new version's prompt.
+//
+// Pre-#967 behavior: RecordOptOut flipped FeedbackEnabled=false permanently,
+// gating every future ShouldShow call regardless of the version bump.
+// Post-#967 behavior: RecordOptOut records the major.minor at which the user
+// dismissed; ShouldShow only honors the opt-out while the current version is
+// still on that same series.
+func TestUpgradeFeedback_ShownPerMajorVersion_RegressionFor967(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Seed the state so pacing gates pass — the test is about version-scoped
+	// opt-out, not pacing.
+	st := oldShouldShowBypass(&feedback.State{
+		LastRatedVersion: "",
+		FeedbackEnabled:  true,
+		ShownCount:       0,
+		MaxShows:         3,
+	})
+
+	// Step 1: user is on v1.9.5 and dismisses the feedback prompt.
+	feedback.RecordOptOut(st, "1.9.5")
+	require.NoError(t, feedback.SaveState(st))
+
+	loaded, err := feedback.LoadState()
+	require.NoError(t, err)
+	require.False(t, feedback.ShouldShow(loaded, "1.9.5", time.Now()),
+		"on the same release series the opt-out must still suppress the dialog")
+
+	// Step 2: agent-deck is upgraded to v1.10.0 (new release series).
+	// The per-major-series opt-out should be cleared and the dialog should show.
+	require.True(t, feedback.ShouldShow(loaded, "1.10.0", time.Now()),
+		"after the release-series bump the opt-out must expire and the dialog must show again (#967)")
+}
+
+// TestUpgradeFeedback_LegacyForeverOptOut_MigratesGracefully pins the migration
+// requirement from #967: existing state files that have FeedbackEnabled=false
+// but no OptOutVersion (written before this fix) must be treated as
+// "dismissed at the current release series" — i.e. they continue to suppress
+// the dialog on the user's current version, but a future release-series bump
+// re-shows it. They must NOT be treated as forever-silent.
+//
+// Production wiring runs MigrateLegacyOptOut from the TUI launch path
+// (cmd/agent-deck/main.go) right after LoadState — this test mirrors that
+// shape so the contract is pinned at the package boundary.
+func TestUpgradeFeedback_LegacyForeverOptOut_MigratesGracefully(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Legacy state: FeedbackEnabled=false, no OptOutVersion. This is what a
+	// pre-#967 user has on disk after clicking "no thanks" once.
+	st := oldShouldShowBypass(&feedback.State{
+		LastRatedVersion: "",
+		FeedbackEnabled:  false,
+		ShownCount:       0,
+		MaxShows:         3,
+	})
+	require.NoError(t, feedback.SaveState(st))
+
+	// First TUI launch on a binary that ships #967. The migration anchors
+	// the opt-out at the currently-running release series.
+	loaded, err := feedback.LoadState()
+	require.NoError(t, err)
+	require.True(t, feedback.MigrateLegacyOptOut(loaded, "1.9.5"),
+		"first encounter with legacy state must migrate (and signal that state needs to be saved)")
+	require.NoError(t, feedback.SaveState(loaded))
+
+	// At the current version the migrated opt-out should still suppress the
+	// dialog — users must not be re-prompted immediately after upgrading the
+	// CLI itself.
+	require.False(t, feedback.ShouldShow(loaded, "1.9.5", time.Now()),
+		"migrated legacy opt-out must still suppress the dialog at the migration-anchor release series")
+
+	// But a release-series bump must re-show it — this is the whole point of #967.
+	require.True(t, feedback.ShouldShow(loaded, "1.10.0", time.Now()),
+		"migrated legacy opt-out must expire on the next release-series bump (#967)")
+
+	// Idempotence: re-running migration must be a no-op once OptOutVersion
+	// is set — otherwise a later launch would silently re-anchor the opt-out
+	// at a newer series and re-silence the user.
+	require.False(t, feedback.MigrateLegacyOptOut(loaded, "1.10.0"),
+		"migration must be idempotent once OptOutVersion is set")
 }

--- a/internal/feedback/state.go
+++ b/internal/feedback/state.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -14,9 +15,19 @@ import (
 //
 // v1.7.41 added LaunchCount, FirstSeenAt, LastPromptedAt to pace the first
 // prompt for new users. Serialized via RFC3339 through time.Time's MarshalJSON.
+//
+// #967 added OptOutVersion to scope the dismiss-feedback opt-out to a single
+// release series (MAJOR.MINOR). A user who declined at v1.9.5 is silenced
+// only while the running version is still on the 1.9.x line; the next
+// release-series bump re-shows the prompt. Pre-#967 state files stored a
+// permanent FeedbackEnabled=false with no OptOutVersion — those are
+// migrated in-memory in ShouldShow by treating them as "dismissed at the
+// current series" (suppresses the immediate launch but expires on the next
+// series bump).
 type State struct {
 	LastRatedVersion string    `json:"last_rated_version"`
 	FeedbackEnabled  bool      `json:"feedback_enabled"`
+	OptOutVersion    string    `json:"opt_out_version,omitempty"`
 	ShownCount       int       `json:"shown_count"`
 	MaxShows         int       `json:"max_shows"`
 	LaunchCount      int       `json:"launch_count,omitempty"`
@@ -150,8 +161,46 @@ func PromptCooldownDays() int {
 	return envInt(envCooldownDays, defaultPromptCooldownDays)
 }
 
+// majorSeries returns the "MAJOR.MINOR" prefix of a semver-ish version string
+// — e.g. "1.9.5" → "1.9", "1.10.0" → "1.10", "2" → "2". An empty input
+// returns "". Used as the granularity for the version-scoped opt-out (#967):
+// a user who dismisses at v1.9.5 is silenced for every 1.9.x build, but the
+// dialog reappears once the running version flips to 1.10.x.
+func majorSeries(version string) string {
+	if version == "" {
+		return ""
+	}
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) >= 2 {
+		return parts[0] + "." + parts[1]
+	}
+	return parts[0]
+}
+
+// MigrateLegacyOptOut rewrites a pre-#967 forever-opt-out (FeedbackEnabled
+// false with no OptOutVersion) into a per-series opt-out anchored at
+// currentVersion. Idempotent: a state that already records an OptOutVersion
+// or has feedback enabled is left untouched. Returns true if the caller
+// should persist the result via SaveState.
+//
+// Production wiring lives in cmd/agent-deck/main.go, which calls this from
+// the TUI launch path right next to RecordLaunch — so the legacy migration
+// happens exactly once per affected user, on their first TUI launch after
+// upgrading to a binary that ships #967.
+func MigrateLegacyOptOut(s *State, currentVersion string) bool {
+	if s.OptOutVersion != "" {
+		return false
+	}
+	if s.FeedbackEnabled {
+		return false
+	}
+	s.OptOutVersion = currentVersion
+	return true
+}
+
 // ShouldShow returns true only when every gate is clear:
-//  1. feedback_enabled is true
+//  1. the user is not opted out for the current release series (#967 —
+//     opt-out is scoped to MAJOR.MINOR, not forever)
 //  2. last_rated_version does not match currentVersion
 //  3. shown_count < max_shows
 //  4. user has been around for at least MinDaysBeforeFirstPrompt days
@@ -161,7 +210,18 @@ func PromptCooldownDays() int {
 // Pure: never mutates state. Callers that want to track first-seen should
 // call RecordLaunch at process start.
 func ShouldShow(s *State, currentVersion string, now time.Time) bool {
-	if !s.FeedbackEnabled {
+	if s.OptOutVersion != "" {
+		// Post-#967: opt-out is scoped to the MAJOR.MINOR series. Same
+		// series → block; release-series bump → fall through.
+		if majorSeries(s.OptOutVersion) == majorSeries(currentVersion) {
+			return false
+		}
+	} else if !s.FeedbackEnabled {
+		// Legacy un-migrated state. Block until MigrateLegacyOptOut runs at
+		// the next TUI launch and anchors the opt-out to a real version.
+		// Without that anchor we cannot tell which series the user dismissed,
+		// so we conservatively suppress here too — re-prompt only happens
+		// after migration + a real release-series bump.
 		return false
 	}
 	if s.LastRatedVersion == currentVersion {
@@ -222,10 +282,17 @@ func RecordRating(s *State, currentVersion string, rating int) {
 	_ = rating // rating is used by the caller for display/formatting; stored externally
 }
 
-// RecordOptOut sets feedback_enabled to false (permanent opt-out).
+// RecordOptOut records a feedback dismissal scoped to the running release
+// series. After #967 this is no longer a permanent kill-switch — the
+// opt-out only suppresses prompts while the running version stays on the
+// same MAJOR.MINOR line (e.g. "1.9.x"). The legacy FeedbackEnabled flag is
+// still toggled off so external readers (config.toml sync, the explicit
+// `agent-deck feedback` re-enable prompt) continue to see the user as
+// opted out until something explicitly clears it.
 // Does NOT save — caller must call SaveState.
-func RecordOptOut(s *State) {
+func RecordOptOut(s *State, currentVersion string) {
 	s.FeedbackEnabled = false
+	s.OptOutVersion = currentVersion
 }
 
 // RatingEmoji maps a numeric rating (1-5) to an emoji.

--- a/internal/ui/feedback_dialog.go
+++ b/internal/ui/feedback_dialog.go
@@ -156,7 +156,7 @@ func (d *FeedbackDialog) Update(msg tea.KeyMsg) (*FeedbackDialog, tea.Cmd) {
 			d.commentInput.SetValue("")
 			d.commentInput.Focus()
 		case "n":
-			feedback.RecordOptOut(d.state)
+			feedback.RecordOptOut(d.state, d.version)
 			_ = feedback.SaveState(d.state)
 			syncOptOutToConfig()
 			d.Hide()
@@ -195,7 +195,7 @@ func (d *FeedbackDialog) Update(msg tea.KeyMsg) (*FeedbackDialog, tea.Cmd) {
 			// Anything else — 'n', 'N', Esc, Enter, stray keys — declines.
 			// v1.7.38: decline at disclosure is a persistent opt-out, not a
 			// one-shot dismiss. Matches the CLI's "Post this? [y/N]" path.
-			feedback.RecordOptOut(d.state)
+			feedback.RecordOptOut(d.state, d.version)
 			_ = feedback.SaveState(d.state)
 			syncOptOutToConfig()
 			d.step = stepDismissed


### PR DESCRIPTION
## Summary

Closes #967.

The upgrade feedback dialog was gated by a single `feedback_enabled` boolean in `~/.agent-deck/feedback-state.json`. Once a user clicked "no thanks" the flag stayed `false` permanently, silencing the dialog on every subsequent release — including upgrade-specific prompts unrelated to the original dismissal. The "opt out of one nag" UX silently became "never hear from us again."

## Fix

- New `State.OptOutVersion` field records the version at which the user dismissed.
- `RecordOptOut(state, currentVersion)` writes both `FeedbackEnabled=false` and `OptOutVersion=currentVersion`.
- `ShouldShow` now suppresses the dialog only while the running version stays on the same `MAJOR.MINOR` release series (`1.9.x` -> `1.9.x`). A release-series bump (e.g. `1.9.5` -> `1.10.0`) re-shows the dialog.
- `MigrateLegacyOptOut(state, currentVersion)` rewrites pre-existing forever-opt-outs to the running release series, wired into the TUI launch path next to `RecordLaunch`. Idempotent.

## Behavior matrix

| Scenario | Before #967 | After #967 |
|---|---|---|
| User dismisses at v1.9.5 -> still on v1.9.x | suppressed | suppressed (unchanged) |
| User dismisses at v1.9.5 -> upgrades to v1.10.0 | suppressed (bug) | **shows** |
| Legacy state on disk, first launch on v1.9.5 ships fix | suppressed | suppressed (no surprise re-prompt) |
| Legacy state, then user upgrades to v1.10.0 | suppressed forever | **shows** |

## Test plan

- [x] `TestUpgradeFeedback_ShownPerMajorVersion_RegressionFor967` — pins the bug fix.
- [x] `TestUpgradeFeedback_LegacyForeverOptOut_MigratesGracefully` — pins the migration contract (no immediate re-prompt + idempotence).
- [x] `go test ./... -race` — full repo green.
- [x] All pre-existing feedback / UI / CLI tests still pass.

Committed by Ashesh Goplani