### PR TITLE
fix(launch): consolidate launch-settings wire-up into single helper (closes #958)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -564,6 +564,20 @@ func logSessionCreated(inst *Instance) {
 	)
 }
 
+// applyLaunchSettingsFromConfig copies LaunchInUserScope and LaunchAs from
+// the live TmuxSettings onto the tmux session, just before each Start().
+//
+// Regression pin for #958 (SSH-logout session loss): three Start() call
+// sites in this file each need this wire-up. Consolidating into one helper
+// means dropping a single Start() path can no longer silently regress the
+// fix — the field would just stay at its zero value (false / "") and the
+// hermetic tests in issue958_launch_settings_wiring_test.go would fail.
+func (i *Instance) applyLaunchSettingsFromConfig() {
+	settings := GetTmuxSettings()
+	i.tmuxSession.LaunchInUserScope = settings.GetLaunchInUserScope()
+	i.tmuxSession.LaunchAs = settings.GetLaunchAs()
+}
+
 // NewInstanceWithGroup creates a new session instance with explicit group
 func NewInstanceWithGroup(title, projectPath, groupPath string) *Instance {
 	inst := NewInstance(title, projectPath)
@@ -2522,8 +2536,7 @@ func (i *Instance) Start() error {
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
 	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
-	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
-	i.tmuxSession.LaunchAs = GetTmuxSettings().GetLaunchAs()
+	i.applyLaunchSettingsFromConfig()
 
 	// Start the tmux session
 	if err := i.tmuxSession.Start(command); err != nil {
@@ -2694,8 +2707,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
 	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
-	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
-	i.tmuxSession.LaunchAs = GetTmuxSettings().GetLaunchAs()
+	i.applyLaunchSettingsFromConfig()
 
 	// Start the tmux session
 	if err := i.tmuxSession.Start(command); err != nil {
@@ -4925,8 +4937,7 @@ func (i *Instance) Restart() error {
 	// Sandbox sessions also get remain-on-exit for dead-pane detection.
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
 	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
-	i.tmuxSession.LaunchInUserScope = GetTmuxSettings().GetLaunchInUserScope()
-	i.tmuxSession.LaunchAs = GetTmuxSettings().GetLaunchAs()
+	i.applyLaunchSettingsFromConfig()
 
 	mcpLog.Debug("restart_starting_new_session", slog.String("command", command))
 

--- a/internal/session/issue958_launch_settings_wiring_test.go
+++ b/internal/session/issue958_launch_settings_wiring_test.go
@@ -1,0 +1,94 @@
+// Regression pin for issue #958 — SSH-logout session loss.
+//
+// Issue 958 root cause was a too-strict default: launch_in_user_scope=false
+// on a fresh Linux+systemd install spawned tmux into the SSH login session
+// scope, so `ssh exit` tore down every managed tmux server with the scope.
+// The default flip landed in commit 61a2f866 (2026-04-14) by migrating the
+// field to *bool with isSystemdUserScopeAvailable() as the implicit default.
+//
+// The flip alone is not enough. Three call sites in instance.go must each
+// copy GetTmuxSettings().GetLaunchInUserScope() / GetLaunchAs() onto
+// tmuxSession before tmuxSession.Start() is invoked. The duplication of two
+// nearly-identical lines across three Start() sites is fragile: dropping
+// any one of them silently regresses the bug at that path while existing
+// persistence tests (which exercise GetLaunchInUserScope only, or bypass
+// startCommandSpec via helpers) continue to pass.
+//
+// These tests pin the single-source-of-truth helper
+// (*Instance).applyLaunchSettingsFromConfig — they fail to compile if the
+// helper is removed, and fail at runtime if the helper stops reading both
+// settings.
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestInstance_ApplyLaunchSettingsFromConfig_DefaultLinux_PinsScope pins
+// the production-default wiring for #958: on a Linux+systemd host with
+// no config.toml overrides, applyLaunchSettingsFromConfig MUST copy
+// LaunchInUserScope=true onto the tmux session so the spawn argv is
+// `systemd-run --user --scope … tmux …`, not bare tmux. Skip cleanly on
+// hosts without systemd-run so macOS / minimal-container CI passes.
+func TestInstance_ApplyLaunchSettingsFromConfig_DefaultLinux_PinsScope(t *testing.T) {
+	requireSystemdRun(t)
+	home := isolatedHomeDir(t)
+	cfg := filepath.Join(home, ".agent-deck", "config.toml")
+	if err := os.WriteFile(cfg, []byte(""), 0o644); err != nil {
+		t.Fatalf("write empty config: %v", err)
+	}
+	ClearUserConfigCache()
+
+	inst := NewInstance("issue958-default", "/tmp")
+	inst.applyLaunchSettingsFromConfig()
+
+	if !inst.tmuxSession.LaunchInUserScope {
+		t.Fatalf("#958 regression: applyLaunchSettingsFromConfig did not wire LaunchInUserScope=true on default Linux+systemd config; spawn would inherit login-session cgroup and die on SSH exit")
+	}
+	if inst.tmuxSession.LaunchAs != "" {
+		t.Fatalf("LaunchAs: default (no override) must be empty so resolveLaunchMode defers to LaunchInUserScope; got %q", inst.tmuxSession.LaunchAs)
+	}
+}
+
+// TestInstance_ApplyLaunchSettingsFromConfig_ExplicitLaunchAs_ServicePropagates
+// pins that an explicit `launch_as = "service"` in config.toml reaches the
+// tmux session field — covers the defense-in-depth path where users opt
+// into systemd-managed restart on tmux OOM.
+func TestInstance_ApplyLaunchSettingsFromConfig_ExplicitLaunchAs_ServicePropagates(t *testing.T) {
+	home := isolatedHomeDir(t)
+	cfg := filepath.Join(home, ".agent-deck", "config.toml")
+	if err := os.WriteFile(cfg, []byte("[tmux]\nlaunch_as = \"service\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	ClearUserConfigCache()
+
+	inst := NewInstance("issue958-service", "/tmp")
+	inst.applyLaunchSettingsFromConfig()
+
+	if got := inst.tmuxSession.LaunchAs; got != "service" {
+		t.Fatalf("LaunchAs: want %q, got %q", "service", got)
+	}
+}
+
+// TestInstance_ApplyLaunchSettingsFromConfig_ExplicitOptOut_HonoredOnLinux
+// pins the explicit `launch_in_user_scope = false` opt-out path: even on
+// Linux+systemd, a user-set false MUST disable the systemd-run wrap so
+// the host-tunings escape hatch in CLAUDE.md keeps working.
+func TestInstance_ApplyLaunchSettingsFromConfig_ExplicitOptOut_HonoredOnLinux(t *testing.T) {
+	requireSystemdRun(t)
+	home := isolatedHomeDir(t)
+	cfg := filepath.Join(home, ".agent-deck", "config.toml")
+	if err := os.WriteFile(cfg, []byte("[tmux]\nlaunch_in_user_scope = false\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	ClearUserConfigCache()
+
+	inst := NewInstance("issue958-optout", "/tmp")
+	inst.applyLaunchSettingsFromConfig()
+
+	if inst.tmuxSession.LaunchInUserScope {
+		t.Fatalf("explicit launch_in_user_scope=false must be honored, got true")
+	}
+}


### PR DESCRIPTION
## Summary

- Issue #958 reported all tmux sessions dying on SSH logout because tmux ran in the login-session cgroup. Investigation confirmed the *default flip* (`bool` → `*bool` with `isSystemdUserScopeAvailable()` fallback, commit 61a2f866 on 2026-04-14) already fixes fresh installs.
- What was still fragile: three Start() call sites in `internal/session/instance.go` each duplicated the same two-line wire-up of `GetTmuxSettings().GetLaunch*()` onto `tmuxSession`. Drop any one of those blocks and the bug regresses silently on that path.
- This PR extracts the wire-up into `(*Instance).applyLaunchSettingsFromConfig()` and pins it with three hermetic regression tests.

## Investigation notes

| Layer | State on `main` | Coverage |
|---|---|---|
| `TmuxSettings.GetLaunchInUserScope()` default | `*bool` → `isSystemdUserScopeAvailable()` → true on Linux+systemd | `TestPersistence_LinuxDefaultIsUserScope` |
| `resolveLaunchMode()` | `LaunchInUserScope=true` → `launchModeScope` → `systemd-run --user --scope --quiet --collect --unit … tmux …` | `TestStartCommandSpec_UserScope` |
| cgroup survival of fake-login-scope teardown | passes | `TestPersistence_TmuxSurvivesLoginSessionRemoval` |
| `instance.go` wire-up at 3 Start() sites | duplicated, no hermetic pin | **gap** — closed in this PR |

## Changes

* `internal/session/instance.go`
  - New `(*Instance).applyLaunchSettingsFromConfig()` helper — one source of truth for the wire-up.
  - Replace the duplicated 2-line block at the three Start() sites (`Start`, `StartWithCommand`, restart path) with a single call.
* `internal/session/issue958_launch_settings_wiring_test.go` (new)
  - `TestInstance_ApplyLaunchSettingsFromConfig_DefaultLinux_PinsScope` — default Linux+systemd config produces `LaunchInUserScope=true`, `LaunchAs=""` (skips on hosts without `systemd-run`).
  - `TestInstance_ApplyLaunchSettingsFromConfig_ExplicitLaunchAs_ServicePropagates` — `[tmux] launch_as = "service"` reaches the session.
  - `TestInstance_ApplyLaunchSettingsFromConfig_ExplicitOptOut_HonoredOnLinux` — explicit `launch_in_user_scope = false` is honored even on Linux+systemd.

## TDD discipline

- **RED**: new test file added first → compile-fail at three call sites (`undefined: applyLaunchSettingsFromConfig`).
- **GREEN**: helper added + 3 sites refactored → all 3 new tests pass.
- **Mutation-style proof**: temporarily commented out the `LaunchInUserScope` assignment inside the helper, ran the suite: `TestInstance_ApplyLaunchSettingsFromConfig_DefaultLinux_PinsScope` failed with the targeted `#958 regression: applyLaunchSettingsFromConfig did not wire LaunchInUserScope=true…` diagnostic. Restored and re-greened.

## Verification

```
go test ./internal/session/... ./internal/tmux/... -race -count=1 -timeout 180s
  ok  internal/session  86.563s
  ok  internal/tmux     22.934s

go test ./... -count=1 -timeout 300s
  (all 35 packages OK; no race warnings)

go vet ./...
  (clean)
```

## Non-changes

- Linux scope spawn argv (`systemd-run --user --scope --quiet --collect --unit … tmux …`) is unchanged — the existing shape already matches the prompt's recommendation.
- macOS / non-systemd paths are byte-identical (`isSystemdUserScopeAvailable()` returns false, helper writes `false`/`""` to the session, `resolveLaunchMode()` picks `launchModeDirect`).
- Sample `config.toml` doc comment unchanged.

## Memory note

The recurring "agent-deck mass session death" class of bug is documented in `agent_deck_mass_session_death.md`. This PR closes the remaining wire-up fragility surface for that class.

Closes #958.

Committed by Ashesh Goplani