### PR TITLE
fix(notify): clean target-busy inbox entries on redelivery + TTL (closes #962 variant)

### DIFF
--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Per-conductor inbox: a JSONL file at
@@ -167,6 +168,207 @@ func ResetInboxFingerprintCacheForTest() {
 	inboxWriteMu.Lock()
 	defer inboxWriteMu.Unlock()
 	inboxFingerprintCache = map[string]map[string]struct{}{}
+}
+
+// defaultInboxTTL is the age past which a persisted inbox entry is swept
+// by SweepInboxByTTL. Issue #962 variant (running-session): without a
+// TTL, deferred_target_busy entries for children that never see another
+// transition accumulate unboundedly. Seven days is the same horizon the
+// deferred-queue uses for "old enough to give up on" semantics, scaled
+// up from minutes to days because the inbox is the operator-facing
+// drain rather than the in-process retry path.
+const defaultInboxTTL = 7 * 24 * time.Hour
+
+// InboxTTL returns the configured age past which persisted inbox events
+// are swept. Honors AGENT_DECK_INBOX_TTL (parsed by time.ParseDuration)
+// and falls back to defaultInboxTTL when unset or unparseable.
+func InboxTTL() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("AGENT_DECK_INBOX_TTL"))
+	if raw == "" {
+		return defaultInboxTTL
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultInboxTTL
+	}
+	return d
+}
+
+// SweepInboxByTuple drops every entry in the parent's inbox file whose
+// (child_session_id, from_status, to_status) matches the given tuple.
+// Returns the count of dropped entries.
+//
+// Issue #962 variant: when a transition for (child, from, to) is later
+// delivered successfully, any earlier persisted entry for the same
+// tuple represents an event the operator no longer needs to see — the
+// state it described has already been signaled to the conductor by the
+// live send. Without this sweep, the inbox JSONL grows by one entry
+// every time the target is busy at first-attempt time.
+//
+// Idempotent and best-effort: missing files are not an error. The
+// rewrite is atomic via temp file + rename, mirroring
+// SweepInboxesForChildSession.
+func SweepInboxByTuple(parentSessionID, childSessionID, fromStatus, toStatus string) (int, error) {
+	if strings.TrimSpace(parentSessionID) == "" {
+		return 0, errors.New("inbox tuple sweep: empty parent session id")
+	}
+	if strings.TrimSpace(childSessionID) == "" {
+		return 0, errors.New("inbox tuple sweep: empty child session id")
+	}
+
+	path := InboxPathFor(parentSessionID)
+
+	inboxWriteMu.Lock()
+	defer inboxWriteMu.Unlock()
+
+	return rewriteInboxLocked(path, func(ev TransitionNotificationEvent) bool {
+		return ev.ChildSessionID == childSessionID &&
+			ev.FromStatus == fromStatus &&
+			ev.ToStatus == toStatus
+	})
+}
+
+// SweepInboxByTTL walks every inbox file and drops entries older than
+// maxAge (computed against TransitionNotificationEvent.Timestamp).
+// Returns the total entries dropped across all inbox files.
+//
+// Issue #962 variant: defense-in-depth alongside SweepInboxByTuple. The
+// tuple sweep relies on a future successful transition for the same
+// (child, from, to) to clear stale entries. Children that complete and
+// never transition again would otherwise leave their last
+// deferred_target_busy entry in the inbox forever. The TTL puts a hard
+// ceiling on inbox growth.
+func SweepInboxByTTL(maxAge time.Duration) (int, error) {
+	if maxAge <= 0 {
+		return 0, errors.New("inbox TTL sweep: non-positive maxAge")
+	}
+
+	dir := InboxDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	cutoff := time.Now().Add(-maxAge)
+
+	inboxWriteMu.Lock()
+	defer inboxWriteMu.Unlock()
+
+	totalDropped := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		dropped, err := rewriteInboxLocked(path, func(ev TransitionNotificationEvent) bool {
+			// Drop entries whose timestamp is older than the cutoff.
+			// Entries with a zero timestamp (e.g. legacy or test data
+			// without a stable clock) are conservatively kept.
+			if ev.Timestamp.IsZero() {
+				return false
+			}
+			return ev.Timestamp.Before(cutoff)
+		})
+		if err != nil {
+			return totalDropped, err
+		}
+		totalDropped += dropped
+	}
+	return totalDropped, nil
+}
+
+// rewriteInboxLocked streams one inbox file and writes out every line
+// whose decoded event does NOT match shouldDrop. Returns the count of
+// dropped lines. Caller holds inboxWriteMu.
+//
+// Mirrors the rm_sweep.go strategy: temp file + atomic rename, with
+// unparseable lines preserved verbatim to avoid silent data loss during
+// cleanup.
+func rewriteInboxLocked(path string, shouldDrop func(TransitionNotificationEvent) bool) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer f.Close()
+
+	var kept [][]byte
+	var dropped int
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		raw := scanner.Bytes()
+		if len(strings.TrimSpace(string(raw))) == 0 {
+			continue
+		}
+		var ev TransitionNotificationEvent
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			kept = append(kept, append([]byte(nil), raw...))
+			continue
+		}
+		if shouldDrop(ev) {
+			dropped++
+			continue
+		}
+		kept = append(kept, append([]byte(nil), raw...))
+	}
+	if err := scanner.Err(); err != nil {
+		return dropped, err
+	}
+	_ = f.Close()
+
+	if dropped == 0 {
+		return 0, nil
+	}
+
+	if len(kept) == 0 {
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return dropped, err
+		}
+		delete(inboxFingerprintCache, path)
+		return dropped, nil
+	}
+
+	tmp := path + ".sweep.tmp"
+	out, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return dropped, err
+	}
+	w := bufio.NewWriter(out)
+	for _, line := range kept {
+		if _, err := w.Write(line); err != nil {
+			_ = w.Flush()
+			_ = out.Close()
+			_ = os.Remove(tmp)
+			return dropped, err
+		}
+		if _, err := w.Write([]byte{'\n'}); err != nil {
+			_ = w.Flush()
+			_ = out.Close()
+			_ = os.Remove(tmp)
+			return dropped, err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return dropped, err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return dropped, err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return dropped, err
+	}
+	delete(inboxFingerprintCache, path)
+	return dropped, nil
 }
 
 // ReadAndTruncateInbox reads all events from the parent's inbox and removes

--- a/internal/session/issue962_target_busy_ttl_test.go
+++ b/internal/session/issue962_target_busy_ttl_test.go
@@ -1,0 +1,287 @@
+package session
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression coverage for the running-session variant of issue #962
+// reported by @seanyoungberg after PR #992 closed the removed-session
+// angle. When a conductor delivers a transition event but the target is
+// busy (StatusRunning), the notifier persists the event to the
+// per-conductor inbox JSONL with delivery_result=deferred_target_busy.
+// Pre-fix, these entries were never cleaned up — neither when the target
+// became available and was successfully reached again, nor when they
+// aged past a sensible TTL. Conductor-A on the reporter's machine had 15
+// entries spanning 4 days (7 unique children) growing unbounded on every
+// busy day.
+
+// TestTransitionNotifier_TargetBusyEntries_CleanedOnSuccess_RegressionFor962Variant
+// asserts: an inbox entry persisted for (child, from, to) is removed
+// when a later successful delivery covers the same tuple. The hook is
+// SweepInboxByTuple, invoked from the success paths in the notifier.
+func TestTransitionNotifier_TargetBusyEntries_CleanedOnSuccess_RegressionFor962Variant(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	ResetInboxFingerprintCacheForTest()
+	t.Cleanup(func() {
+		ClearUserConfigCache()
+		ResetInboxFingerprintCacheForTest()
+	})
+
+	parent := "parent-962-variant-success"
+	// Simulate the exhausted-busy-retries history: an earlier transition
+	// of the same (child, from, to) already landed in the inbox.
+	earlier := TransitionNotificationEvent{
+		ChildSessionID:  "pepper",
+		ChildTitle:      "pepper",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       time.Now().Add(-2 * time.Hour),
+		TargetSessionID: parent,
+		TargetKind:      "parent",
+		DeliveryResult:  transitionDeliveryDeferred,
+	}
+	if err := WriteInboxEvent(parent, earlier); err != nil {
+		t.Fatalf("WriteInboxEvent earlier: %v", err)
+	}
+
+	// An unrelated entry must survive the tuple-targeted sweep.
+	other := earlier
+	other.ChildSessionID = "garlic"
+	other.Timestamp = time.Now().Add(-1 * time.Hour)
+	if err := WriteInboxEvent(parent, other); err != nil {
+		t.Fatalf("WriteInboxEvent other: %v", err)
+	}
+
+	// A new live transition for the same (child=pepper, running→waiting)
+	// successfully reaches the now-idle target. The notifier must sweep
+	// the inbox for entries matching this tuple as part of the success
+	// path.
+	n := newInboxTestNotifier(t, home)
+	n.busyBackoff = []time.Duration{5 * time.Millisecond}
+	n.availability = func(profile, targetID string) bool { return true }
+	n.sender = func(profile, targetID, message string) error { return nil }
+
+	live := earlier
+	live.Timestamp = time.Now() // fresh fingerprint, not "terminated"
+	n.scheduleBusyRetry(live)
+	n.Flush()
+
+	remaining, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("ReadAndTruncateInbox: %v", err)
+	}
+	for _, ev := range remaining {
+		if ev.ChildSessionID == "pepper" && ev.FromStatus == "running" && ev.ToStatus == "waiting" {
+			t.Fatalf("expected inbox entry for (pepper, running, waiting) removed after successful redelivery; still present: %+v", ev)
+		}
+	}
+	// The unrelated (garlic) entry must survive.
+	var survived bool
+	for _, ev := range remaining {
+		if ev.ChildSessionID == "garlic" {
+			survived = true
+			break
+		}
+	}
+	if !survived {
+		t.Fatalf("tuple sweep must not drop unrelated inbox entries; got %d entries: %+v", len(remaining), remaining)
+	}
+}
+
+// TestTransitionNotifier_TargetBusyEntries_TTLEnforced_RegressionFor962Variant
+// asserts: inbox entries persisted longer ago than the configured TTL
+// are removed by the TTL sweep. Without this, even a fixed cleanup-on-
+// success path is not enough — entries for children that never see
+// another transition (e.g. a worker that completed once and stayed gone)
+// accumulate forever.
+func TestTransitionNotifier_TargetBusyEntries_TTLEnforced_RegressionFor962Variant(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	ResetInboxFingerprintCacheForTest()
+	t.Cleanup(func() {
+		ClearUserConfigCache()
+		ResetInboxFingerprintCacheForTest()
+	})
+
+	parent := "parent-962-variant-ttl"
+
+	// One entry well past the 7-day TTL — must be swept.
+	stale := TransitionNotificationEvent{
+		ChildSessionID:  "ancient-worker",
+		ChildTitle:      "ancient",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       time.Now().Add(-10 * 24 * time.Hour),
+		TargetSessionID: parent,
+		TargetKind:      "parent",
+		DeliveryResult:  transitionDeliveryDeferred,
+	}
+	if err := WriteInboxEvent(parent, stale); err != nil {
+		t.Fatalf("WriteInboxEvent stale: %v", err)
+	}
+
+	// One entry within the TTL — must survive.
+	fresh := stale
+	fresh.ChildSessionID = "recent-worker"
+	fresh.Timestamp = time.Now().Add(-1 * time.Hour)
+	if err := WriteInboxEvent(parent, fresh); err != nil {
+		t.Fatalf("WriteInboxEvent fresh: %v", err)
+	}
+
+	dropped, err := SweepInboxByTTL(7 * 24 * time.Hour)
+	if err != nil {
+		t.Fatalf("SweepInboxByTTL: %v", err)
+	}
+	if dropped != 1 {
+		t.Fatalf("expected exactly 1 stale entry dropped, got %d", dropped)
+	}
+
+	remaining, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("ReadAndTruncateInbox: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Fatalf("expected 1 surviving inbox entry, got %d: %+v", len(remaining), remaining)
+	}
+	if remaining[0].ChildSessionID != "recent-worker" {
+		t.Fatalf("TTL sweep dropped the wrong entry: %+v", remaining[0])
+	}
+}
+
+// TestTransitionNotifier_SweepInboxByTuple_DropsMatching is a direct
+// unit test for the public sweep helper. Guards against accidental
+// matches on similar tuples (e.g. same child, different status flip).
+func TestTransitionNotifier_SweepInboxByTuple_DropsMatching(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	ResetInboxFingerprintCacheForTest()
+	t.Cleanup(func() {
+		ClearUserConfigCache()
+		ResetInboxFingerprintCacheForTest()
+	})
+
+	parent := "parent-962-tuple"
+	mk := func(child, from, to string, ago time.Duration) TransitionNotificationEvent {
+		return TransitionNotificationEvent{
+			ChildSessionID:  child,
+			Profile:         "_test",
+			FromStatus:      from,
+			ToStatus:        to,
+			Timestamp:       time.Now().Add(-ago),
+			TargetSessionID: parent,
+			TargetKind:      "parent",
+			DeliveryResult:  transitionDeliveryDeferred,
+		}
+	}
+	rows := []TransitionNotificationEvent{
+		mk("pepper", "running", "waiting", 3*time.Hour),
+		mk("pepper", "running", "waiting", 2*time.Hour), // duplicate tuple, different ts
+		mk("pepper", "waiting", "running", 1*time.Hour), // SAME child, different tuple
+		mk("garlic", "running", "waiting", 1*time.Hour), // different child
+	}
+	for i, ev := range rows {
+		if err := WriteInboxEvent(parent, ev); err != nil {
+			t.Fatalf("WriteInboxEvent row %d: %v", i, err)
+		}
+	}
+
+	dropped, err := SweepInboxByTuple(parent, "pepper", "running", "waiting")
+	if err != nil {
+		t.Fatalf("SweepInboxByTuple: %v", err)
+	}
+	if dropped != 2 {
+		t.Fatalf("expected 2 matching entries dropped, got %d", dropped)
+	}
+
+	remaining, err := ReadAndTruncateInbox(parent)
+	if err != nil {
+		t.Fatalf("ReadAndTruncateInbox: %v", err)
+	}
+	if len(remaining) != 2 {
+		t.Fatalf("expected 2 surviving entries, got %d: %+v", len(remaining), remaining)
+	}
+	for _, ev := range remaining {
+		if ev.ChildSessionID == "pepper" && ev.FromStatus == "running" && ev.ToStatus == "waiting" {
+			t.Fatalf("matching entry survived sweep: %+v", ev)
+		}
+	}
+}
+
+// TestTransitionNotifier_SweepInboxByTTL_EnvVarOverride verifies that
+// the daemon-facing TTL helper honors AGENT_DECK_INBOX_TTL when caller
+// resolves the duration via InboxTTL().
+func TestTransitionNotifier_SweepInboxByTTL_EnvVarOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	t.Setenv("AGENT_DECK_INBOX_TTL", "1h")
+	ClearUserConfigCache()
+	ResetInboxFingerprintCacheForTest()
+	t.Cleanup(func() {
+		ClearUserConfigCache()
+		ResetInboxFingerprintCacheForTest()
+	})
+
+	ttl := InboxTTL()
+	if ttl != time.Hour {
+		t.Fatalf("AGENT_DECK_INBOX_TTL=1h must yield 1h, got %s", ttl)
+	}
+
+	// Default (env unset) must return the 7-day default.
+	t.Setenv("AGENT_DECK_INBOX_TTL", "")
+	if got := InboxTTL(); got != 7*24*time.Hour {
+		t.Fatalf("InboxTTL default must be 7 days, got %s", got)
+	}
+
+	// Restore for the rest of the test.
+	t.Setenv("AGENT_DECK_INBOX_TTL", "1h")
+
+	parent := "parent-962-ttl-env"
+	old := TransitionNotificationEvent{
+		ChildSessionID:  "stale",
+		Profile:         "_test",
+		FromStatus:      "running",
+		ToStatus:        "waiting",
+		Timestamp:       time.Now().Add(-2 * time.Hour),
+		TargetSessionID: parent,
+		DeliveryResult:  transitionDeliveryDeferred,
+	}
+	if err := WriteInboxEvent(parent, old); err != nil {
+		t.Fatalf("WriteInboxEvent: %v", err)
+	}
+
+	dropped, err := SweepInboxByTTL(InboxTTL())
+	if err != nil {
+		t.Fatalf("SweepInboxByTTL: %v", err)
+	}
+	if dropped != 1 {
+		t.Fatalf("expected 1 entry dropped under 1h TTL, got %d", dropped)
+	}
+	if _, err := os.Stat(InboxPathFor(parent)); err == nil {
+		// File still exists — must contain no surviving entries.
+		remaining, err := ReadAndTruncateInbox(parent)
+		if err != nil {
+			t.Fatalf("ReadAndTruncateInbox: %v", err)
+		}
+		if len(remaining) != 0 {
+			t.Fatalf("expected inbox emptied by TTL sweep, got %d entries", len(remaining))
+		}
+	}
+	_ = strings.TrimSpace // keep imports stable across test edits
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -15,6 +15,13 @@ const (
 	notifyPollMedium = 2 * time.Second
 	notifyPollSlow   = 3 * time.Second
 	hookFreshWindow  = 45 * time.Second
+
+	// inboxTTLSweepInterval rate-limits the per-process TTL sweep over
+	// every inbox file. Issue #962 variant: without a periodic sweep,
+	// the cleanup-on-success path alone can't reach entries whose
+	// children never transition again. One pass per hour keeps the
+	// disk churn negligible while bounding inbox size to TTL+1h.
+	inboxTTLSweepInterval = time.Hour
 )
 
 type hookTransitionCandidate struct {
@@ -31,6 +38,11 @@ type TransitionDaemon struct {
 
 	lastStatus  map[string]map[string]string
 	initialized map[string]bool
+
+	// lastInboxTTLSweep tracks the most recent SweepInboxByTTL call so
+	// the daemon runs it at most once per inboxTTLSweepInterval. Zero
+	// means "never run" — the first SyncOnce pass will perform it.
+	lastInboxTTLSweep time.Time
 }
 
 func NewTransitionDaemon() *TransitionDaemon {
@@ -80,7 +92,24 @@ func (d *TransitionDaemon) SyncOnce(_ context.Context) time.Duration {
 			nextInterval = interval
 		}
 	}
+
+	d.maybeSweepInboxTTL()
+
 	return nextInterval
+}
+
+// maybeSweepInboxTTL invokes SweepInboxByTTL when more than
+// inboxTTLSweepInterval has elapsed since the last call. Issue #962
+// variant: prevents inbox-file growth from children that never see a
+// later transition (the cleanup-on-success path alone can't reach
+// them).
+func (d *TransitionDaemon) maybeSweepInboxTTL() {
+	now := time.Now()
+	if !d.lastInboxTTLSweep.IsZero() && now.Sub(d.lastInboxTTLSweep) < inboxTTLSweepInterval {
+		return
+	}
+	d.lastInboxTTLSweep = now
+	_, _ = SweepInboxByTTL(InboxTTL())
 }
 
 func profilesForTransitionDaemon() []string {

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -400,6 +400,12 @@ func (n *TransitionNotifier) dispatchAsync(targetID, message string, event Trans
 			e.DeliveryResult = transitionDeliveryFailed
 		} else {
 			e.DeliveryResult = transitionDeliverySent
+			// Issue #962 variant: clear any earlier persisted inbox
+			// entry for the same (child, from, to) now that the live
+			// delivery succeeded — see SweepInboxByTuple.
+			if targetID != "" {
+				_, _ = SweepInboxByTuple(targetID, event.ChildSessionID, event.FromStatus, event.ToStatus)
+			}
 		}
 		doneCh <- e
 		// Slot is only released once the send really returns, which prevents
@@ -1015,6 +1021,13 @@ func (n *TransitionNotifier) scheduleBusyRetry(event TransitionNotificationEvent
 				// event back in between the queue prune and the mark.
 				n.markTerminated(event)
 				n.removeFromQueue(event)
+				// Issue #962 variant: any earlier persisted inbox entry
+				// for the same (child, from, to) is now superseded by
+				// this live delivery — sweep it so the operator's next
+				// drain doesn't replay stale events.
+				if event.TargetSessionID != "" {
+					_, _ = SweepInboxByTuple(event.TargetSessionID, event.ChildSessionID, event.FromStatus, event.ToStatus)
+				}
 				return
 			}
 			// Send failed: try the next backoff entry.


### PR DESCRIPTION
## Summary

Closes the running-session variant of #962 reported by @seanyoungberg after PR #992 (v1.9.8) closed the removed-session angle.

When the transition notifier delivers an event but the target conductor is `StatusRunning` (busy), the event is busy-retried in-process and, on exhaustion, persisted to the per-conductor inbox JSONL at `~/.agent-deck/inboxes/<conductor-id>.jsonl` with `delivery_result=deferred_target_busy`. Pre-fix, **those entries were never cleaned up** — not on a subsequent successful delivery of the same `(child, from, to)`, not on age. The only way to clear them was `agent-deck inbox <id>` (manual drain) or hand-truncating the file.

Real-machine numbers from @seanyoungberg's report (v1.9.7, macOS):
- conductor-A inbox: **15 entries over 4 days, 7 unique children**, every entry `deferred_target_busy`, never cleaned
- conductor-B inbox: 6 entries going back 3 days, same shape
- Growth unbounded — every busy day made it worse on every machine

## The fix

Two new public helpers in `internal/session/inbox.go`:

1. **`SweepInboxByTuple(parent, child, from, to)`** — atomically rewrites the parent's inbox file dropping entries that match the tuple. Hooked into both success paths in `transition_notifier.go`:
   - `scheduleBusyRetry` success branch (target frees up during in-process backoff)
   - `dispatchAsync` success branch (direct send + queue-drain redelivery)

2. **`SweepInboxByTTL(maxAge)`** — walks every inbox file, drops entries whose `Timestamp` exceeds `maxAge`. Default `defaultInboxTTL = 7 * 24h`, configurable via `AGENT_DECK_INBOX_TTL` (parsed by `time.ParseDuration`).

The TTL sweep is invoked from `TransitionDaemon.SyncOnce` via `maybeSweepInboxTTL`, rate-limited to one pass per hour. The cleanup-on-success path alone cannot reach entries for children that complete and never transition again; the TTL puts a hard ceiling on inbox size at `TTL + 1h`.

Both sweeps mirror `rm_sweep.go`'s atomic strategy: stream-read → keep-list → temp file + `os.Rename`. Unparseable lines are preserved verbatim — replay over silent loss during cleanup.

## RED → GREEN

`internal/session/issue962_target_busy_ttl_test.go` adds 4 regression tests:

- `TestTransitionNotifier_TargetBusyEntries_CleanedOnSuccess_RegressionFor962Variant` — earlier persisted `(child, from, to)` entry is removed after a fresh successful delivery covers the same tuple; unrelated entries survive.
- `TestTransitionNotifier_TargetBusyEntries_TTLEnforced_RegressionFor962Variant` — 10-day-old entry is dropped, 1-hour-old entry survives under a 7-day TTL.
- `TestTransitionNotifier_SweepInboxByTuple_DropsMatching` — unit test for the tuple helper; same child but different `from→to` is preserved.
- `TestTransitionNotifier_SweepInboxByTTL_EnvVarOverride` — `AGENT_DECK_INBOX_TTL=1h` is honored; empty env falls back to 7-day default.

All four tests fail on `main`, pass with the fix.

## Test plan

- [x] `go test -race -count=1 ./internal/session/...` — green (87s)
- [x] `go test -race -count=1 ./...` — green across all packages (full suite)
- [x] New tests fail on `main` for the right reason (assertion, not compile) when stubs return zero values; verified the RED step before implementing.

## Notes

- No on-disk format change. Existing inbox files keep working; the TTL sweep simply ignores entries whose `Timestamp` is zero (legacy/test data).
- Cleanup paths are best-effort — failures don't block sends, mirroring `SweepInboxesForChildSession`.
- `AGENT_DECK_INBOX_TTL` accepts any `time.ParseDuration` string (e.g. `168h`, `7d` is **not** valid Go-duration; use `168h`).