### PR TITLE
fix(session): preserve chat history across conductor restart (closes #956)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2426,6 +2426,41 @@ func (i *Instance) ensureClaudeSessionIDFromDisk() {
 		slog.String("reason", "jsonl_discovery"))
 }
 
+// ensureClaudeSessionIDFromDiskForRestart is the Restart()-path variant of
+// ensureClaudeSessionIDFromDisk. Issue #956: custom-command Claude sessions
+// (Tool=claude with a wrapper Command) bypass happy-path session-id capture,
+// and if no hook ever propagated CLAUDE_SESSION_ID back to the Instance the
+// ClaudeSessionID field stays empty even after a real conversation has
+// written a JSONL transcript to disk. On Restart() the fallback recreate
+// branch then re-spawns the wrapper without `--resume`, dropping history.
+//
+// Start()'s prelude (ensureClaudeSessionIDFromDisk) refuses to discover for
+// instances with ClaudeDetectedAt==zero (issue #608) so a brand-new spawn
+// does not adopt another session's history from the same project directory.
+// Restart() implies the instance previously ran — the tmux session existed
+// and (in the bug scenario) had a live Claude conversation — so the gate
+// is safe to bypass here. ClaudeDetectedAt is then stamped so subsequent
+// callers (status refresh, persistence) see a consistent capture time.
+func (i *Instance) ensureClaudeSessionIDFromDiskForRestart() {
+	if i.ClaudeSessionID != "" {
+		return
+	}
+	lookupPath := i.EffectiveWorkingDir()
+	uuid, found := discoverLatestClaudeJSONL(lookupPath)
+	if !found {
+		return
+	}
+	i.ClaudeSessionID = uuid
+	if i.ClaudeDetectedAt.IsZero() {
+		i.ClaudeDetectedAt = time.Now()
+	}
+	sessionLog.Info("resume: id="+uuid+" reason=jsonl_discovery_restart",
+		slog.String("instance_id", i.ID),
+		slog.String("claude_session_id", uuid),
+		slog.String("path", lookupPath),
+		slog.String("reason", "jsonl_discovery_restart"))
+}
+
 // Start starts the session in tmux
 func (i *Instance) Start() error {
 	if i.tmuxSession == nil {
@@ -4631,6 +4666,20 @@ func (i *Instance) Restart() error {
 	// current state. Same call as Start()/recreate paths — idempotent
 	// per (sourceProfileDir, plugins-set) and best-effort on failure.
 	i.prepareWorkerScratchConfigDirForSpawn()
+
+	// Issue #956: custom-command Claude sessions whose hooks never fired
+	// (or whose wrapper script overrode CLAUDE_CONFIG_DIR) arrive at
+	// Restart() with empty ClaudeSessionID even when the live conversation
+	// wrote a JSONL to disk. Without this prelude the fallback recreate
+	// path below dispatches through buildClaudeCommand(i.Command), re-runs
+	// the wrapper fresh, and silently drops chat history. Discovery here
+	// populates ClaudeSessionID so the respawn-pane fast path
+	// (buildClaudeResumeCommand) engages and emits `claude --resume <uuid>`.
+	// Mirrors Start()'s ensureClaudeSessionIDFromDisk but bypasses the
+	// #608 brand-new-session gate — Restart() implies the instance ran.
+	if IsClaudeCompatible(i.Tool) && i.ClaudeSessionID == "" {
+		i.ensureClaudeSessionIDFromDiskForRestart()
+	}
 
 	// If Claude session with known ID AND tmux session exists, use respawn-pane.
 	if IsClaudeCompatible(i.Tool) && i.ClaudeSessionID != "" && i.tmuxSession != nil && i.tmuxSession.Exists() {

--- a/internal/session/issue956_chat_history_restart_test.go
+++ b/internal/session/issue956_chat_history_restart_test.go
@@ -1,0 +1,126 @@
+package session
+
+// Issue #956 — Conductor restart loses Claude Code chat history.
+//
+// Custom-command Claude sessions (Tool=claude with a wrapper Command) bypass
+// agent-deck's happy-path session-id capture. When such a session has had a
+// real conversation (Claude wrote a JSONL transcript to disk) but the
+// session id was never propagated back into the Instance (hooks didn't fire,
+// or CLAUDE_CONFIG_DIR override kept hooks from being installed), Restart()
+// must still pick up the latest JSONL on disk and emit `claude --resume
+// <uuid>` so chat history survives the restart.
+//
+// Start() and StartWithMessage() already handle this via
+// `ensureClaudeSessionIDFromDisk` (v1.5.2 REQ-7). Restart() was missed:
+// its dispatch tree at instance.go:Restart() falls through to the fallback
+// recreate path when ClaudeSessionID is empty, which calls
+// `buildClaudeCommand(i.Command)` — running the wrapper directly with no
+// --resume, dropping history.
+//
+// PR #989 (REQ-7 manifestation 3) addressed CanRestart() for the same
+// class of sessions (registry-level check), but the resume dispatch was
+// out of scope. This file pins the end-to-end contract.
+//
+// See ~/.claude/projects/-home-ashesh-goplani--agent-deck/memory/
+// conductor_restart_history_loss.md for the structural background.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConductor_Restart_PreservesChatHistory_RegressionFor956 pins the
+// contract: when a custom-command Claude session has empty ClaudeSessionID
+// at Restart() time and a JSONL transcript exists on disk (written during
+// the live conversation), Restart() MUST discover the latest JSONL and
+// resume from it (--resume <uuid>) rather than spawn a fresh wrapper that
+// loses history.
+//
+// RED on main: Restart()'s fallback recreate path (instance.go:Restart)
+// dispatches through buildClaudeCommand(i.Command), running the wrapper
+// fresh. No --resume is emitted. The argv log shows wrapper invocation
+// without any --resume flag.
+//
+// GREEN with the fix: Restart() invokes the disk-discovery prelude before
+// dispatch (same logic as Start()'s ensureClaudeSessionIDFromDisk, but
+// bypassing the #608 brand-new-session gate because Restart() implies the
+// instance previously ran). ClaudeSessionID is populated from the latest
+// JSONL, the respawn-pane fast path engages, and `claude --resume <uuid>`
+// is spawned via buildClaudeResumeCommand.
+func TestConductor_Restart_PreservesChatHistory_RegressionFor956(t *testing.T) {
+	requireTmux(t)
+	home := isolatedHomeDir(t)
+	argvLog := setupStubClaudeOnPATH(t, home)
+	inst := newClaudeInstanceForDispatch(t, home)
+
+	// Custom-command preconditions: wrapper bypasses happy-path capture.
+	inst.Command = writeCustomWrapperScript(t, home)
+	// Clear the auto-assigned ClaudeSessionID from newClaudeInstanceForDispatch
+	// so we model the real bug scenario: a session id was never captured.
+	inst.ClaudeSessionID = ""
+	// ClaudeDetectedAt stays zero — the session never propagated its id back
+	// to the Instance. This is the hostile case for ensureClaudeSessionIDFromDisk:
+	// Start()'s prelude early-returns on zero ClaudeDetectedAt (#608 gate),
+	// so the Restart() fix MUST handle the case independently.
+	inst.ClaudeDetectedAt = time.Time{}
+
+	// First Start: no JSONL exists yet, custom wrapper runs, ClaudeSessionID
+	// stays empty. This mirrors the real-world flow where a conductor is
+	// launched fresh via a wrapper script.
+	require.NoError(t, inst.Start(), "Start: custom-command claude session must boot")
+	// Allow the tmux pane to start and the wrapper to log its argv.
+	time.Sleep(500 * time.Millisecond)
+	require.Empty(t, inst.ClaudeSessionID,
+		"precondition: no JSONL on disk at Start time → no discovery → "+
+			"ClaudeSessionID stays empty (this is what triggers the bug at Restart)")
+
+	// Now write a JSONL on disk — simulating the live conversation Claude
+	// just had. This is the state at the moment the user runs `restart`.
+	const jsonlUUID = "9560ab10-9560-9560-9560-956000000956"
+	projectDir := filepath.Join(home, ".claude", "projects", ConvertToClaudeDirName(inst.ProjectPath))
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	jsonlPath := filepath.Join(projectDir, jsonlUUID+".jsonl")
+	body := []byte(`{"sessionId":"` + jsonlUUID + `","role":"user","content":"remember my favorite color is blue"}` + "\n" +
+		`{"sessionId":"` + jsonlUUID + `","role":"assistant","content":"got it, blue"}` + "\n")
+	require.NoError(t, os.WriteFile(jsonlPath, body, 0o644))
+	// Backdate slightly so any newer file would clearly beat it on mtime;
+	// here there is only one, so this is just hygiene.
+	past := time.Now().Add(-10 * time.Second)
+	require.NoError(t, os.Chtimes(jsonlPath, past, past))
+	t.Cleanup(func() { _ = os.Remove(jsonlPath) })
+
+	// Reset the argv log so the Restart's argv is the only entry we inspect.
+	require.NoError(t, os.WriteFile(argvLog, nil, 0o644))
+
+	// Restart: must discover the JSONL and resume rather than spawn fresh.
+	require.NoError(t, inst.Restart(), "Restart: must succeed")
+
+	argv := readCapturedClaudeArgv(t, argvLog, 3*time.Second)
+	joined := strings.Join(argv, " ")
+
+	// Contract assertion: post-restart, the spawned claude argv must contain
+	// --resume <jsonl-uuid>. On main this fails because Restart()'s
+	// fallback path runs the wrapper without --resume.
+	require.Contains(t, joined, "--resume",
+		"Issue #956 RED: Restart() of custom-command claude session with "+
+			"empty ClaudeSessionID and a JSONL transcript on disk must "+
+			"discover the JSONL and pass --resume to preserve chat history. "+
+			"Got argv: %v. The fix mirrors Start()'s ensureClaudeSessionIDFromDisk "+
+			"prelude but bypasses the #608 brand-new gate because Restart() "+
+			"implies the session previously ran.", argv)
+	require.Contains(t, joined, jsonlUUID,
+		"Issue #956 RED: Restart() must resume the newest JSONL uuid "+
+			"(%s), not mint a fresh id. Got argv: %v", jsonlUUID, argv)
+
+	// Write-through assertion: after Restart(), the Instance MUST carry the
+	// discovered session id so subsequent Restart() / status reads see it.
+	require.Equal(t, jsonlUUID, inst.ClaudeSessionID,
+		"Issue #956: Restart() must persist the discovered JSONL uuid onto "+
+			"the Instance so the next operation sees a populated id. "+
+			"Mirrors PERSIST-12 write-through from the Start() path.")
+}


### PR DESCRIPTION
## Summary

Closes #956. Custom-command Claude sessions (Tool=claude with a wrapper Command) that never propagated their session id back to the Instance — Claude hooks didn't fire, or the wrapper overrode CLAUDE_CONFIG_DIR — lost their chat history on every Restart(). The fallback recreate branch dispatched through `buildClaudeCommand(i.Command)`, re-running the wrapper without `--resume`, so Claude started a fresh conversation.

`Start()` and `StartWithMessage()` already had the v1.5.2 REQ-7 prelude (`ensureClaudeSessionIDFromDisk`) that scans the project's JSONL directory for the newest transcript and populates `ClaudeSessionID` before dispatch. `Restart()` had its own dispatch tree and was missed.

## Relationship to #989

PR #989 (REQ-7 manifestation 3, currently open) addresses `CanRestart()` for the same class of sessions — the registry-level capability check. The resume dispatch itself (this PR) is independent: even with #989 merged, `Restart()` on an empty-`ClaudeSessionID` Claude session falls into the fallback recreate path and runs the wrapper fresh. Both fixes are needed for the end-to-end contract.

Investigation: I verified #989 does **not** auto-resolve #956 by tracing `Restart()`'s dispatch tree (instance.go:Restart) and confirming that `ensureClaudeSessionIDFromDisk` was only invoked from `Start()` / `StartWithMessage()` — never from `Restart()`. The new regression test fails RED on parent commit `b2917682` exactly as predicted: argv is `[wrapper_invoked]`, no `--resume`.

## Fix

Sibling helper `ensureClaudeSessionIDFromDiskForRestart` (instance.go) mirrors the `Start()` prelude but **bypasses the #608 brand-new-session gate** — `Restart()` implies the instance previously ran, so adopting the latest JSONL on disk is safe. `ClaudeDetectedAt` is stamped on write-through. `Restart()` calls the helper before its dispatch tree; with `ClaudeSessionID` now populated, the respawn-pane fast path engages and `buildClaudeResumeCommand` emits `claude --resume <uuid>`.

## TDD

`TestConductor_Restart_PreservesChatHistory_RegressionFor956` in `internal/session/issue956_chat_history_restart_test.go` exercises the real `Start()` → write JSONL → `Restart()` flow against a real tmux session with a stub `claude` on PATH:

- **RED on parent commit** (`b2917682`): argv post-Restart is `[wrapper_invoked]` — wrapper ran without `--resume`, history lost. Verified by stashing the `instance.go` change.
- **GREEN with this commit**: argv contains `--resume <jsonl-uuid>`. `inst.ClaudeSessionID` carries the discovered uuid (PERSIST-12 write-through).

## REQ-7 history

- v1.5.2: original REQ-7 — `Start()` discovers JSONL on disk via `ensureClaudeSessionIDFromDisk`. Pinned by `TestPersistence_CustomCommandResumesFromLatestJSONL`.
- v1.7.7: per-instance `config_dir` resolution for `sessionHasConversationData`. Pinned by `TestSessionHasConversationData_RespectsPerInstanceConfigDir`.
- PR #989 (open): `CanRestart()` allows empty-Claude-ID restart, mirroring opencode/codex policy.
- **This PR**: `Restart()` discovers JSONL on disk, mirroring the v1.5.2 Start() prelude. Closes the manifestation gap #956 names.

## Test plan

- [x] RED confirmed on parent commit `b2917682` (stash the fix, run new test → fails on `--resume` assertion)
- [x] GREEN with the fix (`go test -run TestConductor_Restart_PreservesChatHistory_RegressionFor956 ./internal/session/...` passes in 0.87s)
- [x] `go test -race ./internal/session/...` green (84s)
- [x] `go build ./...` and `go vet ./internal/session/...` clean
- [ ] Manual: launch a conductor via wrapper script, send a message, restart; verify chat history is preserved (`claude --resume <uuid>` in pane history rather than a fresh prompt)

Committed by Ashesh Goplani