### PR TITLE
docs(skill): add prelude-read convention to worker prompts (closes #968)

### DIFF
--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -125,6 +125,34 @@ The script auto-detects current session/profile and creates a child session.
 | Code documentation | `context7` |
 | Complex reasoning | `sequential-thinking` |
 
+### Worker Prompt Conventions
+
+When the prompt asks the worker to `Edit` or `Write` any **existing** file, include an explicit **prelude-read** as the first step. Claude Code's tool guard rejects `Edit`/`Write` before `Read` of the same path, and conductor-spawned workers hit this mid-task (#968) when their prompt jumps straight into the change. The interruption forces the worker to backfill reads inside its main loop, breaking flow and burning cycles.
+
+**Template skeleton — bake this into every worker prompt that mutates code:**
+
+```
+## Step 0 — Prelude reads
+Read every file you intend to Edit/Write below. Read calls are cheap
+and do NOT count against scope discipline; they prevent tool-guard
+interruptions mid-task. Skip only for paths that will be created fresh.
+
+Files to read first:
+  - <path/to/file/you/will/edit>
+  - <path/to/other/file/you/will/edit>
+
+## Step 1 — Investigation
+…
+
+## Step 2 — Implementation
+…
+```
+
+**Rules:**
+- Any file the worker will modify: prelude `Read` it first, even if the worker "knows" the contents.
+- Brand-new files (`Write` to a path that does not yet exist): no prelude needed — the guard only applies to modifications.
+- For conductor nudges that re-fire the same prompt across cycles, keep Step 0 in the prompt. The second-cycle process may not have prior reads in context.
+
 ## Consult Another Agent (Codex, Gemini)
 
 **Use when:** User says "consult with codex", "ask gemini", "get codex's opinion", "what does codex think", "consult another agent", "brainstorm with codex/gemini", "get a second opinion"

--- a/skills/agent-deck/references/goal.md
+++ b/skills/agent-deck/references/goal.md
@@ -147,6 +147,12 @@ DONE-CONDITION (external shell, run by the manager):
 
 PROTOCOL — execute exactly:
 
+  0. PRELUDE READS. Before any Edit/Write this cycle, Read every file
+     you intend to modify. Read calls do NOT count against scope; they
+     prevent Claude Code's "Read-before-Edit" tool guard from firing
+     mid-cycle (which costs a wake and corrupts the receipt). Skip only
+     for paths you will create fresh via Write to a new path. (#968)
+
   1. Check current state. Do NOT run the done-condition yourself; that's
      the manager's job. Read task-log.md to recall what you've already done.
 


### PR DESCRIPTION
## Summary

Fixes #968 — conductor-spawned workers were repeatedly hitting Claude Code's "must Read before Edit/Write" tool guard mid-cycle because their PROMPT.md jumped straight into edits. The fix is template-level so future workers get it for free.

- **`skills/agent-deck/SKILL.md`** — new **Worker Prompt Conventions** subsection in Sub-Agent Launch, with a "Step 0 — Prelude reads" template skeleton for prompt authors.
- **`skills/agent-deck/references/goal.md`** — inject **Step 0 — PRELUDE READS** into the autonomous worker contract so goal-driven workers (re-fired across cycles) carry the rule into every wake.

Skill-only change. No Go code touched. Existing self-improvement / goal pipelines from #1012 unaffected.

## Test plan

- [ ] Eyeball SKILL.md diff: new `### Worker Prompt Conventions` block reads cleanly between Recommended MCPs and Consult Another Agent
- [ ] Eyeball goal.md diff: Step 0 lands above the existing Step 1 without disturbing manager-side parsing (manager parses receipts in task-log.md, not the contract text)
- [ ] Spawn a worker via `launch-subagent.sh` with a Step-0-bearing prompt and confirm no tool-guard fault on first Edit

Closes #968.