### PR TITLE
fix(notify): respect NoTransitionNotify mute flag on inbox replay (closes #962 v3)

### DIFF
--- a/internal/session/issue962_v3_mute_replay_test.go
+++ b/internal/session/issue962_v3_mute_replay_test.go
@@ -1,0 +1,127 @@
+package session
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestTransitionNotifier_MuteFlagRespectedOnReplay_RegressionFor962V3 pins the
+// third variant of issue #962 reported by @seanyoungberg: the per-session
+// `NoTransitionNotify` mute flag is checked at NEW event emission time
+// (transition_daemon.go:210 and :375) but NOT during inbox / deferred-queue
+// replay (DrainRetryQueueWithResolver). Once an event is sitting in the
+// deferred queue, toggling `agent-deck session set-transition-notify <child>
+// off` does not stop further re-deliveries — the queue keeps firing
+// "[EVENT] Child '<child>' is waiting" into the conductor pane on every
+// poll until the queue drains by some other means.
+//
+// Fix shape: generalize the existing childPresence resolver (from variant 1,
+// PR #992) into an eventDeliverable resolver that checks BOTH registry
+// presence AND the child's current NoTransitionNotify flag. Same boundary,
+// same test seam, broader predicate. Centralizes "is this event still
+// deliverable to this session?" at the replay-dispatch site so future
+// variants (session-paused, conductor-stopped, etc.) plug in here too.
+//
+// Setup mirrors TestTransitionNotifier_SkipsRemovedSessions_RegressionFor962:
+// build storage, save parent+child, enqueue deferred events, mutate state
+// between enqueue and drain, then assert zero sends.
+func TestTransitionNotifier_MuteFlagRespectedOnReplay_RegressionFor962V3(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+	if err := os.MkdirAll(home+"/.agent-deck", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	profile := "_test-962-v3-mute-replay"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	defer storage.Close()
+
+	now := time.Now()
+	parent := &Instance{
+		ID:          "parent-conductor-962v3",
+		Title:       "conductor-962v3",
+		ProjectPath: "/tmp/p962v3",
+		GroupPath:   DefaultGroupPath,
+		Tool:        "claude",
+		Status:      StatusIdle,
+		CreatedAt:   now,
+	}
+	child := &Instance{
+		ID:                 "child-muted-962v3",
+		Title:              "noisy-worker",
+		ProjectPath:        "/tmp/c962v3",
+		GroupPath:          DefaultGroupPath,
+		ParentSessionID:    parent.ID,
+		Tool:               "shell",
+		Status:             StatusWaiting,
+		CreatedAt:          now,
+		NoTransitionNotify: false, // mute not yet set at enqueue time
+	}
+	if err := storage.SaveWithGroups([]*Instance{parent, child}, nil); err != nil {
+		t.Fatalf("save initial: %v", err)
+	}
+
+	n := NewTransitionNotifier()
+	var sent atomic.Int32
+	n.sender = func(profile, targetID, message string) error {
+		sent.Add(1)
+		return nil
+	}
+	t.Cleanup(n.Close)
+
+	// Production trace from seanyoungberg: a single child transition gets
+	// 4-5 re-fires from accumulated queue. Reproduce with 5 deferred events
+	// for the same child against the same parent — distinct from→to tuples
+	// so the dedup ledger doesn't collapse them.
+	tuples := []struct{ from, to string }{
+		{"running", "waiting"},
+		{"waiting", "running"},
+		{"running", "error"},
+		{"error", "waiting"},
+		{"waiting", "idle"},
+	}
+	for i, tup := range tuples {
+		event := TransitionNotificationEvent{
+			ChildSessionID:  child.ID,
+			ChildTitle:      child.Title,
+			Profile:         profile,
+			FromStatus:      tup.from,
+			ToStatus:        tup.to,
+			Timestamp:       now.Add(time.Duration(i) * time.Second),
+			TargetSessionID: parent.ID,
+			TargetKind:      "parent",
+		}
+		n.EnqueueDeferred(event)
+	}
+
+	// Simulate the user running `agent-deck session set-transition-notify
+	// <child> off` AFTER the events are queued. The mutator writes
+	// no_transition_notify=1 to the DB row; the queue file is untouched.
+	child.NoTransitionNotify = true
+	if err := storage.SaveWithGroups([]*Instance{parent, child}, nil); err != nil {
+		t.Fatalf("save muted: %v", err)
+	}
+
+	// Drain with availability always true: target IS free. On current main
+	// the queue ignores the mute flag and dispatches all 5 events. The fix
+	// is to consult the child's current NoTransitionNotify before dispatch.
+	n.DrainRetryQueueWithResolver(profile, func(p, id string) bool { return true })
+	n.Flush()
+
+	if got := sent.Load(); got != 0 {
+		t.Fatalf("issue #962 v3: notifier dispatched %d events for a muted child; expected 0", got)
+	}
+
+	if entries := n.snapshotQueueForTest(); len(entries) != 0 {
+		t.Fatalf("issue #962 v3: queue still holds %d entries for muted child; expected drained", len(entries))
+	}
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -204,10 +204,7 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 			continue
 		}
 		inst := byID[id]
-		if inst == nil {
-			continue
-		}
-		if !notifyEnabled || inst.NoTransitionNotify {
+		if !notifyEnabled || !instanceAcceptsTransitionEvents(inst) {
 			continue
 		}
 		event := TransitionNotificationEvent{
@@ -369,10 +366,7 @@ func (d *TransitionDaemon) emitHookTransitionCandidates(
 	notifyEnabled := GetNotificationsSettings().GetTransitionEventsEnabled()
 	for id, candidate := range candidates {
 		inst := byID[id]
-		if inst == nil {
-			continue
-		}
-		if !notifyEnabled || inst.NoTransitionNotify {
+		if !notifyEnabled || !instanceAcceptsTransitionEvents(inst) {
 			continue
 		}
 

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -83,14 +83,18 @@ type TransitionNotifier struct {
 	// inject a deterministic stub.
 	availability targetAvailabilityResolver
 
-	// childPresence reports whether the named child session still exists in
-	// the registry. Used by DrainRetryQueueWithResolver to drop queued
-	// events whose child has been rm'd between enqueue and drain — issue
-	// #962. Nil means no filter (preserved for tests that build the
-	// notifier via a bare struct literal); production sets it via
-	// NewTransitionNotifier so the daemon's drain loop never replays
-	// events for vanished children.
-	childPresence targetAvailabilityResolver
+	// eventDeliverable is the centralized "is this event still deliverable
+	// to this session?" gate at the replay-dispatch boundary. Returns
+	// (false, reason) when the child should be dropped from the queue; the
+	// reason string flows into notifier-missed.log so the operator can tell
+	// removed-vs-muted apart. Issue #962 variants 1 and 3:
+	//   - variant 1 (PR #992): child rm'd between enqueue and drain
+	//   - variant 3 (this PR): child marked NoTransitionNotify after enqueue
+	// Future per-session bypass conditions (session paused, conductor
+	// stopped, etc.) plug in here too. Nil means no filter (test
+	// struct-literal back-compat); production sets it via
+	// NewTransitionNotifier.
+	eventDeliverable eventDeliverabilityResolver
 
 	mu    sync.Mutex
 	state transitionNotifyState
@@ -158,7 +162,7 @@ func NewTransitionNotifier() *TransitionNotifier {
 		terminatedFingerprints: map[string]bool{},
 		stopCh:                 make(chan struct{}),
 	}
-	n.childPresence = n.liveChildPresence
+	n.eventDeliverable = n.liveEventDeliverable
 	n.loadState()
 	n.loadQueue()
 	return n
@@ -699,6 +703,14 @@ func deferredKey(event TransitionNotificationEvent) string {
 // live instance's status; tests pass a canned function.
 type targetAvailabilityResolver func(profile, targetID string) bool
 
+// eventDeliverabilityResolver is the centralized per-child gate used at the
+// replay-dispatch boundary (DrainRetryQueueWithResolver). It returns
+// (true, "") to let the queued event through, or (false, reason) to drop it
+// — the reason string is logged into notifier-missed.log so removed-vs-
+// muted-vs-future-bypass categories stay distinguishable in diagnostics.
+// Issue #962 v1 (removed) + v3 (muted) share this seam.
+type eventDeliverabilityResolver func(profile, childID string) (deliverable bool, reason string)
+
 // DrainRetryQueue is the production entry point used by the daemon's poll
 // loop. It resolves target availability by reading the live session state.
 func (n *TransitionNotifier) DrainRetryQueue(profile string) {
@@ -716,26 +728,34 @@ func (n *TransitionNotifier) DrainRetryQueueWithResolver(profile string, isAvail
 	n.queue.Entries = nil
 	n.queueMu.Unlock()
 
+	type droppedEntry struct {
+		entry  deferredQueueEntry
+		reason string
+	}
 	var keep []deferredQueueEntry
 	var toDispatch []deferredQueueEntry
 	var toExpire []deferredQueueEntry
-	var toDropRemoved []deferredQueueEntry
+	var toDrop []droppedEntry
 
 	for _, entry := range snapshot {
 		if entry.Event.Profile != profile {
 			keep = append(keep, entry)
 			continue
 		}
-		// Issue #962: drop events whose child has been removed from the
-		// registry between enqueue and drain. The rm path (issue #910)
-		// sweeps the inbox and dedup ledger but not this queue file, so
-		// without this filter the daemon redispatches stale child events
-		// on every poll until the queue file is hand-edited. Done BEFORE
-		// the age-out check so we don't emit "expired" missed-log lines
-		// for sessions that simply no longer exist.
-		if n.childPresence != nil && !n.childPresence(profile, entry.Event.ChildSessionID) {
-			toDropRemoved = append(toDropRemoved, entry)
-			continue
+		// Issue #962 (v1 + v3): consult the centralized per-child gate
+		// before re-dispatch. Drops events whose child has been removed
+		// from the registry (v1, PR #992) OR has been muted via
+		// `set-transition-notify off` after the event was queued (v3, this
+		// PR). Done BEFORE the age-out check so we don't emit "expired"
+		// missed-log lines for sessions that are no longer valid delivery
+		// targets. The resolver returns a category string so
+		// notifier-missed.log stays diagnostic-friendly across both
+		// variants.
+		if n.eventDeliverable != nil {
+			if ok, reason := n.eventDeliverable(profile, entry.Event.ChildSessionID); !ok {
+				toDrop = append(toDrop, droppedEntry{entry: entry, reason: reason})
+				continue
+			}
 		}
 		expired := now.Sub(entry.FirstDeferredAt) > defaultQueueMaxAge ||
 			entry.Attempts >= defaultQueueMaxAttempts
@@ -751,8 +771,8 @@ func (n *TransitionNotifier) DrainRetryQueueWithResolver(profile string, isAvail
 		toDispatch = append(toDispatch, entry)
 	}
 
-	for _, entry := range toDropRemoved {
-		n.logMissed(entry.Event, "child_removed_from_registry")
+	for _, d := range toDrop {
+		n.logMissed(d.entry.Event, d.reason)
 	}
 	for _, entry := range toExpire {
 		n.logMissed(entry.Event, "expired")
@@ -793,35 +813,65 @@ func (n *TransitionNotifier) liveTargetAvailability(profile, targetID string) bo
 	return false
 }
 
-// liveChildPresence reports whether childID still exists in the registry for
-// the given profile. Issue #962: the drain loop filter that prevents the
-// notifier from replaying transition events for sessions removed via
-// `agent-deck rm` between the enqueue and the next drain pass.
+// liveEventDeliverable is the production wiring of eventDeliverable. It
+// answers "is this child currently a valid delivery target?" by reading the
+// live registry. Returns (false, reason) when the queued event should be
+// dropped on the next drain pass:
+//
+//   - "child_removed_from_registry" — child rm'd between enqueue and drain
+//     (issue #962 v1, PR #992). The rm path sweeps the inbox + dedup ledger
+//     but not this queue file, so consumer-side defense-in-depth catches
+//     stale entries surviving across upgrades or rm/drain races.
+//   - "child_muted" — child has NoTransitionNotify=true (issue #962 v3, this
+//     PR). The flag is checked at NEW emission (transition_daemon.go:210
+//     and :375) but pre-fix never on replay, so per-session mute toggled
+//     after enqueue had no effect on already-queued events.
 //
 // Fail-open on storage errors: if the SQLite file is missing, locked, or
-// the load returns an error, return true so a transient outage doesn't
-// silently drop legitimate events. The trade-off is that during a real
-// outage we may briefly replay events; the alternative (fail-closed) would
-// be a silent-loss path that's strictly worse than the bug we're fixing.
-func (n *TransitionNotifier) liveChildPresence(profile, childID string) bool {
+// the load returns an error, return (true, "") so a transient outage
+// doesn't silently drop legitimate events. The trade-off is that during a
+// real outage we may briefly replay events; the alternative (fail-closed)
+// would be a silent-loss path strictly worse than the bug being fixed.
+func (n *TransitionNotifier) liveEventDeliverable(profile, childID string) (bool, string) {
 	if strings.TrimSpace(childID) == "" {
-		return false
+		return false, "child_removed_from_registry"
 	}
 	storage, err := NewStorageWithProfile(profile)
 	if err != nil {
-		return true
+		return true, ""
 	}
 	defer storage.Close()
 	instances, _, err := storage.LoadWithGroups()
 	if err != nil {
-		return true
+		return true, ""
 	}
 	for _, inst := range instances {
 		if inst.ID == childID {
-			return true
+			if !instanceAcceptsTransitionEvents(inst) {
+				return false, "child_muted"
+			}
+			return true, ""
 		}
 	}
-	return false
+	return false, "child_removed_from_registry"
+}
+
+// instanceAcceptsTransitionEvents is the centralized per-session predicate
+// shared by NEW-emission (transition_daemon.go) and replay-dispatch
+// (DrainRetryQueueWithResolver via liveEventDeliverable). All "is this
+// session currently accepting transition events?" logic lives here so the
+// two code paths can't drift — the original bite path for issue #962 v3
+// was exactly that the emission site checked NoTransitionNotify and the
+// replay site did not. Future per-session bypass conditions (paused,
+// stopped, etc.) extend this predicate, not its callers.
+func instanceAcceptsTransitionEvents(inst *Instance) bool {
+	if inst == nil {
+		return false
+	}
+	if inst.NoTransitionNotify {
+		return false
+	}
+	return true
 }
 
 func (n *TransitionNotifier) snapshotQueueForTest() []deferredQueueEntry {


### PR DESCRIPTION
## Summary

Third variant of #962, reported by @seanyoungberg. The per-session `NoTransitionNotify` mute flag is checked at NEW event emission (`transition_daemon.go:210` and `:375`) but pre-fix was **never re-consulted during inbox / deferred-queue replay**. Once an event sits queued, running `agent-deck session set-transition-notify <child> off` does not stop further re-deliveries — the conductor pane keeps receiving `[EVENT] Child '<child>' is waiting` 4-5× per single underlying transition until the queue drains by some other means.

## Variants of #962 — common root cause

The replay path doesn't re-validate against current session state. All three variants share that shape:

| Variant | Bite path | Fix |
|---|---|---|
| 1 ([PR #992](https://github.com/asheshgoplani/agent-deck/pull/992)) | Child rm'd between enqueue and drain — queue keeps firing | `childPresence` resolver at drain boundary |
| 2 ([PR #1009](https://github.com/asheshgoplani/agent-deck/pull/1009)) | Target-busy inbox entries never cleaned — same tuple re-fires on every flush | `SweepInboxByTuple` on success + TTL sweep |
| **3 (this PR)** | Mute flag toggled after enqueue ignored on replay | Centralized `eventDeliverable` gate (this PR generalizes #992's seam) |

## Architectural change

Rather than patching only the mute check, this PR **centralizes the \"is this event still deliverable to this session?\" predicate at the replay-dispatch boundary** so future variants (session paused, conductor stopped, etc.) plug in once:

- New: `instanceAcceptsTransitionEvents(inst)` — pure predicate used by BOTH new-emission (`transition_daemon.go`) and replay-dispatch (via `liveEventDeliverable`). Single source of truth for per-session deliverability.
- Renamed: `childPresence` resolver → `eventDeliverable eventDeliverabilityResolver` returning `(deliverable bool, reason string)`. The reason flows into `notifier-missed.log` so `child_removed_from_registry` vs `child_muted` stay distinguishable in operator diagnostics.
- Drain boundary in `DrainRetryQueueWithResolver` now calls `eventDeliverable` once per entry — drops both removed-children (variant 1) and muted-children (variant 3) without code paths drifting.

The original bite path for v3 was exactly that the emission site checked `inst.NoTransitionNotify` and the replay site did not. With both paths funneling through `instanceAcceptsTransitionEvents`, that drift class is gone.

## Test

Added `TestTransitionNotifier_MuteFlagRespectedOnReplay_RegressionFor962V3`:

1. Save parent + child with `NoTransitionNotify=false`
2. Enqueue 5 deferred events for the child against the parent (distinct from→to tuples to bypass dedup ledger)
3. Flip child's `NoTransitionNotify=true` and save (simulates `set-transition-notify off` after queue accumulation)
4. Drain with target availability=true (parent IS free)
5. Assert: **zero** sender invocations, queue cleared

Pre-fix: 4 dispatches. Post-fix: 0. Variant 1 (`TestTransitionNotifier_SkipsRemovedSessions_RegressionFor962`) and variant 2 (`TestTransitionNotifier_TargetBusyEntries_CleanedOnSuccess_RegressionFor962Variant`) still green.

## Test plan

- [x] `go test -race ./internal/session/...` green (90s)
- [x] `go test -race ./...` green across whole repo
- [x] RED reproduced on `origin/main` (4 unwanted dispatches)
- [x] GREEN after fix (0 dispatches)
- [x] Variant 1 (#992) regression test still passes
- [x] Variant 2 (#1009) regression test still passes
- [ ] Manual smoke against a live conductor with set-transition-notify toggling mid-flush (left for reviewer if desired)

Credit to @seanyoungberg for the source-pinpoint repro (`transition_daemon.go:181`/`:346` checked, `DrainRetryQueueWithResolver` not) — made this a surgical fix instead of a hunt.

Closes #962 (v3).