### PR TITLE
fix(heartbeat): retire identical NEED lines after 3 cycles (closes #971)

### DIFF
--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -743,6 +743,67 @@ def parse_conductor_prefix(text: str, conductor_names: list[str]) -> tuple[str |
 
 
 # ---------------------------------------------------------------------------
+# NEED-line retire (issue #971)
+# ---------------------------------------------------------------------------
+
+# Default: after this many *consecutive* identical NEED: lines, escalate
+# once with a distinct "STILL BLOCKED" tactic, then drop on later cycles.
+NEED_RETIRE_THRESHOLD = 3
+
+
+def filter_need_lines(
+    response: str,
+    prev_counts: dict,
+    threshold: int = NEED_RETIRE_THRESHOLD,
+) -> dict:
+    """De-duplicate consecutive identical heartbeat NEED: lines (issue #971).
+
+    Args:
+      response: full conductor reply text (may contain zero or more NEED: lines).
+      prev_counts: per-line consecutive-occurrence counts from the previous
+        heartbeat cycle, keyed by the trimmed NEED: line text.
+      threshold: how many consecutive cycles of an identical NEED: line trigger
+        a one-shot escalation. Subsequent cycles drop the line entirely.
+
+    Returns dict with:
+      "alerts":  list[str]  — NEED lines to forward as-is this cycle.
+      "retired": list[str]  — one-shot escalation notices for lines that just
+                              hit threshold (forwarded instead of the plain
+                              NEED line so the user sees the tactic change).
+      "counts":  dict[str,int] — updated counts for the next cycle. Lines no
+                              longer present are dropped (reset on return).
+
+    Rules (matches issue #971's expected table):
+      * Cycles 1 .. threshold-1: NEED line is forwarded as-is.
+      * Cycle threshold:         line moves to "retired" (escalation tactic
+                                  change, e.g. "STILL BLOCKED for 3h: ...").
+      * Cycle threshold+1..:    line is silently dropped (auto-retire).
+    """
+    counts: dict[str, int] = {}
+    alerts: list[str] = []
+    retired: list[str] = []
+
+    for raw_line in response.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("NEED:"):
+            continue
+
+        prior = prev_counts.get(line, 0)
+        new_count = prior + 1
+        counts[line] = new_count
+
+        if new_count < threshold:
+            alerts.append(line)
+        elif new_count == threshold:
+            retired.append(
+                f"STILL BLOCKED ({threshold} cycles, no reply): {line}"
+            )
+        # new_count > threshold: dropped — already retired previously.
+
+    return {"alerts": alerts, "retired": retired, "counts": counts}
+
+
+# ---------------------------------------------------------------------------
 # Telegram message splitting
 # ---------------------------------------------------------------------------
 
@@ -1536,6 +1597,11 @@ async def heartbeat_loop(config: dict, telegram_bot=None, slack_app=None, slack_
     interval_seconds = global_interval * 60
     tg_user_id = config["telegram"]["user_id"] if config["telegram"]["configured"] else None
 
+    # Per-conductor NEED: dedup state for issue #971 — tracks consecutive
+    # identical NEED lines so we can escalate-once-then-drop instead of
+    # firing the same alert verbatim for 12+ hours.
+    need_state_by_conductor: dict[str, dict] = {}
+
     log.info("Heartbeat loop started (global interval: %d minutes)", global_interval)
 
     while True:
@@ -1695,14 +1761,33 @@ async def heartbeat_loop(config: dict, telegram_bot=None, slack_app=None, slack_
                     name, response[:200],
                 )
 
-                # If conductor flagged items needing attention, notify via Telegram and Slack
-                has_alerts = "NEED:" in response
+                # Dedup repeating NEED: lines (issue #971). Forward only
+                # fresh + escalation lines; drop verbatim repeats past
+                # threshold so the user isn't trained to ignore heartbeats.
+                prev_counts = need_state_by_conductor.get(name, {})
+                need_filtered = filter_need_lines(response, prev_counts)
+                need_state_by_conductor[name] = need_filtered["counts"]
+
+                forwarded_need_lines = (
+                    need_filtered["alerts"] + need_filtered["retired"]
+                )
+                has_alerts = bool(forwarded_need_lines)
+                if need_filtered["retired"]:
+                    log.info(
+                        "Heartbeat [%s]: retiring %d stale NEED line(s) "
+                        "after >= %d cycles: %s",
+                        name,
+                        len(need_filtered["retired"]),
+                        NEED_RETIRE_THRESHOLD,
+                        need_filtered["retired"],
+                    )
                 if has_alerts:
                     all_conductors = discover_conductors()
                     prefix = (
                         f"[{name}] " if len(all_conductors) > 1 else ""
                     )
-                    alert_text = f"{prefix}Conductor alert:\n{response}"
+                    alert_body = "\n".join(forwarded_need_lines)
+                    alert_text = f"{prefix}Conductor alert:\n{alert_body}"
 
                     # Notify via Telegram (with HTML formatting)
                     if telegram_bot and tg_user_id:

--- a/conductor/tests/test_issue971_need_retire.py
+++ b/conductor/tests/test_issue971_need_retire.py
@@ -1,0 +1,133 @@
+"""Regression tests for issue #971.
+
+Heartbeat NEED: lines repeated unchanged for 12-21 hours when the user did
+not respond. There was no de-duplication, no escalation tactic, and no
+auto-retire. This module pins the fix: after a configurable threshold
+(default 3) of consecutive identical NEED: lines, the bridge must either
+escalate via a distinct "STILL BLOCKED" tactic (one-shot) or drop the line
+from heartbeat alerts on subsequent cycles.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from bridge import filter_need_lines  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def _resp(*need_lines: str) -> str:
+    """Build a conductor reply that contains the given NEED: lines."""
+    body = ["[STATUS] Auto-responded to 0 sessions. 1 needs your attention."]
+    body.extend(need_lines)
+    return "\n".join(body)
+
+
+class TestHeartbeatRetiresIdenticalNeedRegressionFor971:
+    """Pin the fix for issue #971: identical NEED lines must retire."""
+
+    def test_cycle_one_passes_need_through(self):
+        result = filter_need_lines(
+            _resp("NEED: api-fix - decide test environment"),
+            prev_counts={},
+        )
+        assert result["alerts"] == ["NEED: api-fix - decide test environment"]
+        assert result["retired"] == []
+        assert result["counts"] == {"NEED: api-fix - decide test environment": 1}
+
+    def test_cycle_two_still_passes_need_through(self):
+        result = filter_need_lines(
+            _resp("NEED: api-fix - decide test environment"),
+            prev_counts={"NEED: api-fix - decide test environment": 1},
+        )
+        assert result["alerts"] == ["NEED: api-fix - decide test environment"]
+        assert result["retired"] == []
+        assert result["counts"] == {"NEED: api-fix - decide test environment": 2}
+
+    def test_cycle_three_retires_with_escalation_marker(self):
+        """3rd consecutive identical NEED: must escalate distinctly, NOT repeat verbatim."""
+        result = filter_need_lines(
+            _resp("NEED: api-fix - decide test environment"),
+            prev_counts={"NEED: api-fix - decide test environment": 2},
+        )
+        # The plain NEED line must NOT be forwarded as-is on the 3rd cycle.
+        assert "NEED: api-fix - decide test environment" not in result["alerts"]
+        # An escalation/retire notice must be emitted instead.
+        assert len(result["retired"]) == 1
+        retire_line = result["retired"][0]
+        assert "STILL BLOCKED" in retire_line or "RETIRED" in retire_line
+        assert "api-fix" in retire_line  # carries the original NEED context
+        assert result["counts"]["NEED: api-fix - decide test environment"] == 3
+
+    def test_cycle_four_drops_stale_need_entirely(self):
+        """After retire, subsequent identical NEED lines are silently dropped."""
+        result = filter_need_lines(
+            _resp("NEED: api-fix - decide test environment"),
+            prev_counts={"NEED: api-fix - decide test environment": 3},
+        )
+        assert result["alerts"] == []
+        assert result["retired"] == []  # already retired previously, no re-escalation
+        assert result["counts"]["NEED: api-fix - decide test environment"] == 4
+
+    def test_new_need_line_after_repeats_still_passes_through(self):
+        """A fresh, different NEED line is not blocked by a stale repeating one."""
+        result = filter_need_lines(
+            _resp(
+                "NEED: api-fix - decide test environment",
+                "NEED: web-build - npm error on Node 22",
+            ),
+            prev_counts={"NEED: api-fix - decide test environment": 5},
+        )
+        assert "NEED: web-build - npm error on Node 22" in result["alerts"]
+        # Stale one is dropped, only the fresh one is forwarded:
+        assert "NEED: api-fix - decide test environment" not in result["alerts"]
+        assert result["counts"]["NEED: web-build - npm error on Node 22"] == 1
+
+    def test_resolved_need_drops_from_state(self):
+        """When the conductor stops emitting a NEED line, its count is cleared."""
+        result = filter_need_lines(
+            _resp("NEED: web-build - npm error on Node 22"),
+            prev_counts={"NEED: api-fix - decide test environment": 2},
+        )
+        assert "NEED: api-fix - decide test environment" not in result["counts"]
+        assert result["counts"]["NEED: web-build - npm error on Node 22"] == 1
+
+    def test_response_without_any_need_lines_yields_empty(self):
+        result = filter_need_lines(
+            "[STATUS] All clear, nothing waiting.",
+            prev_counts={"NEED: api-fix - decide test environment": 2},
+        )
+        assert result["alerts"] == []
+        assert result["retired"] == []
+        assert result["counts"] == {}
+
+    def test_threshold_is_configurable(self):
+        """Caller can lower threshold (e.g. for impatient policies)."""
+        result = filter_need_lines(
+            _resp("NEED: foo"),
+            prev_counts={"NEED: foo": 1},
+            threshold=2,
+        )
+        assert result["alerts"] == []
+        assert len(result["retired"]) == 1
+        assert "foo" in result["retired"][0]
+
+    def test_multiple_lines_independent_state(self):
+        """Each NEED line has its own retire counter."""
+        result = filter_need_lines(
+            _resp("NEED: A", "NEED: B"),
+            prev_counts={"NEED: A": 2, "NEED: B": 0},
+        )
+        # A hits threshold this cycle -> retired
+        assert "NEED: A" not in result["alerts"]
+        assert any("A" in r for r in result["retired"])
+        # B is on its first cycle -> normal alert
+        assert "NEED: B" in result["alerts"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Fix for #971: conductor heartbeat `NEED:` lines were repeating byte-identical for 12–21h once the user stopped responding, drowning out fresh urgent items.

- New pure helper `filter_need_lines(response, prev_counts, threshold=3)` in `conductor/bridge.py`
  - cycles 1..2: forward `NEED:` line as-is
  - cycle 3: emit a one-shot `STILL BLOCKED (3 cycles, no reply): NEED: …` escalation instead of the verbatim line
  - cycles 4+: silently drop (auto-retire) — `has_alerts=False` so no Telegram/Slack noise
  - Lines that stop appearing get cleared from state, so a recurring NEED is re-counted fresh
- Wired into `heartbeat_loop` via a per-conductor `need_state_by_conductor` dict (in-memory; resets across bridge restarts, which is acceptable: worst case 3 more cycles before retire kicks back in)
- Regression test file `conductor/tests/test_issue971_need_retire.py` (9 cases) pins the contract: per-cycle behavior, multi-line independence, configurable threshold, and the non-regression that a fresh NEED still passes even while a stale one is being suppressed

## Test plan
- [x] RED: `test_issue971_need_retire.py` fails on `origin/main` (`filter_need_lines` missing — ImportError)
- [x] GREEN: 9/9 pass after implementation
- [x] Full `conductor/tests/` suite: 30 passed, 1 skipped, 1 preexisting flake (`test_env_vars_set`, "Text file busy" tempfile race — confirmed identical failure on `origin/main` unmodified)
- [x] `go build ./...` and `go vet ./...` clean (no Go changes)
- [ ] Manual: observe bridge after deploy — heartbeat should emit `STILL BLOCKED (3 cycles, no reply): NEED: …` on 3rd repeat, silence on 4th+

Closes #971

Committed by Ashesh Goplani