### PR TITLE
fix(ui): path selector up/down escapes field unless popup explicitly active (closes #1020)

### DIFF
--- a/internal/ui/issue1020_path_selector_ux_test.go
+++ b/internal/ui/issue1020_path_selector_ux_test.go
@@ -1,0 +1,115 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Issue #1020 (@JMBattista): the path-suggestions popup reacts to Up/Down
+// arrows too aggressively. Once focus lands on the path field with a
+// pre-filled value (the soft-selected state), the popup is visible and the
+// auto-activation added in PR #983 makes EVERY first Up/Down arrow get
+// swallowed by the popup. The user can never move the cursor up or down OUT
+// of the path section to other dialog fields.
+//
+// Pre-#983 contract (and the intent restored here):
+//   - When the path field is soft-selected (Tab-landed, value present,
+//     pathInput blurred), Up/Down navigate between form fields. Space or
+//     Right explicitly enters popup-nav mode.
+//   - When the user is actively editing the path (pathInput focused, value
+//     being typed), arrows auto-activate the popup so paskal's #896 sub-bugs
+//     3+4 still work — see [[issue896_residual_test]].
+//
+// This test pins the soft-selected / form-navigation behavior so #983's
+// auto-activation cannot re-eat arrows on the soft-selected path field.
+func TestNewDialog_PathSelector_UpDownEscapesField_RegressionFor1020(t *testing.T) {
+	d := NewNewDialog()
+	d.Show()
+
+	// Seed suggestions so the popup is visible on the path field.
+	d.SetPathSuggestions([]string{"/p/alpha", "/p/beta", "/p/gamma"})
+
+	// Simulate the user Tab-landing on a path field that already has a
+	// pre-filled value (the common case: cwd or last-used path). updateFocus
+	// puts this in soft-select state — pathInput blurred, pathSoftSelected
+	// true — which is exactly @JMBattista's scenario.
+	d.pathInput.SetValue("/some/preset/path")
+	d.focusIndex = 2 // focusPath in the default layout (Name, MultiRepo, Path, ...)
+	d.updateFocus()
+
+	if !d.pathSoftSelected {
+		t.Fatalf("test precondition: path with non-empty value should be soft-selected on focus")
+	}
+	if d.suggestionsHidden {
+		t.Fatalf("test precondition: popup should be visible (not dismissed) at the start of #1020 scenario")
+	}
+	startTarget := d.currentTarget()
+	if startTarget != focusPath {
+		t.Fatalf("test precondition: focus should be on path field, got %v", startTarget)
+	}
+
+	// === Press Down: must escape to NEXT form field, NOT activate the popup. ===
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyDown})
+
+	if d.suggestionsActive {
+		t.Fatalf("Down on a soft-selected path field auto-activated the popup; this is issue #1020 — arrows must not eat focus when the user hasn't explicitly entered popup-nav mode")
+	}
+	if d.currentTarget() == focusPath {
+		t.Fatalf("Down on a soft-selected path field did not move focus to the next form field (still on focusPath); issue #1020 — the path popup is trapping arrow keys")
+	}
+	afterDownTarget := d.currentTarget()
+
+	// === Now back to path, press Up: must escape to PREVIOUS form field. ===
+	d.focusIndex = 2
+	d.updateFocus()
+	if d.currentTarget() != focusPath || !d.pathSoftSelected {
+		t.Fatalf("test setup: failed to return to soft-selected path field for Up-arrow check")
+	}
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyUp})
+
+	if d.suggestionsActive {
+		t.Fatalf("Up on a soft-selected path field auto-activated the popup; this is issue #1020")
+	}
+	if d.currentTarget() == focusPath {
+		t.Fatalf("Up on a soft-selected path field did not move focus to the previous form field (still on focusPath); issue #1020")
+	}
+	afterUpTarget := d.currentTarget()
+
+	// Sanity: Down and Up landed on different targets — proves focus moved
+	// in opposite directions and the popup didn't just no-op.
+	if afterDownTarget == afterUpTarget {
+		t.Fatalf("Down and Up from path field landed on the same target %v; expected different neighbors", afterDownTarget)
+	}
+
+	// === Popup-nav must still be reachable via explicit gesture. ===
+	// Re-focus the path field, press Space (the documented explicit entry
+	// from soft-select per newdialog.go ~line 1173). Popup activates. Then
+	// Down advances the popup cursor — paskal's #896 sub-bug 4 behavior,
+	// just gated behind an explicit gesture.
+	d.focusIndex = 2
+	d.updateFocus()
+	if d.currentTarget() != focusPath || !d.pathSoftSelected {
+		t.Fatalf("test setup: failed to return to soft-selected path field for popup-entry check")
+	}
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+
+	if !d.suggestionsActive {
+		t.Fatalf("Space on a soft-selected path field must activate the popup (explicit entry gesture); IsSuggestionsActive()=false")
+	}
+	startCursor := d.pathSuggestionCursor
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyDown})
+
+	if !d.suggestionsActive {
+		t.Fatalf("after explicit Space-entry, popup deactivated on Down; popup-nav must stay engaged once entered")
+	}
+	if d.pathSuggestionCursor == startCursor {
+		t.Fatalf("after explicit Space-entry, Down did not advance the popup cursor (still at %d); popup arrows must navigate once popup is engaged", d.pathSuggestionCursor)
+	}
+	if d.currentTarget() != focusPath {
+		t.Fatalf("popup-nav Down moved focus off the path field to %v; arrows scoped to popup must keep focus on path", d.currentTarget())
+	}
+}

--- a/internal/ui/issue896_residual_test.go
+++ b/internal/ui/issue896_residual_test.go
@@ -33,7 +33,15 @@ func TestNewDialog_PopupEnter_SelectsHighlightedSuggestion_RegressionFor896(t *t
 	d.updateFocus()
 
 	// User has typed a prefix; the popup is visible (path focused, not hidden).
+	// In real use, the first keystroke on a soft-selected path clears the
+	// pre-fill, focuses pathInput, and unsets pathSoftSelected (see soft-select
+	// handler in newdialog.go). Mirror that post-typing state so the test
+	// reflects an actively-editing user — which is the only state where
+	// arrows should auto-activate the popup after the #1020 fix. See
+	// [[issue1020_path_selector_ux_test]].
 	d.pathInput.SetValue("/p/")
+	d.pathInput.Focus()
+	d.pathSoftSelected = false
 
 	// User presses Down twice — cursor should advance through:
 	//   0 ("Type custom") -> 1 (/p/alpha) -> 2 (/p/beta)
@@ -95,6 +103,13 @@ func TestNewDialog_PopupArrows_NavigateReliably_RegressionFor896(t *testing.T) {
 
 	d.focusIndex = 2 // focusPath
 	d.updateFocus()
+
+	// Simulate the user having typed in the path field (post soft-select).
+	// In real flow, the first keystroke flips pathSoftSelected=false and
+	// focuses pathInput; only then do arrows auto-activate the popup, per
+	// the #1020 fix in newdialog.go. See [[issue1020_path_selector_ux_test]].
+	d.pathInput.Focus()
+	d.pathSoftSelected = false
 
 	// Popup is visible because path is focused, suggestions are non-empty,
 	// and suggestionsHidden is false (default after Show + SetPathSuggestions).

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1118,19 +1118,23 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			return d, nil
 		}
 
-		// Issue #896 sub-bug 4: when the path-suggestions popup is visible,
-		// arrow keys must navigate the popup from the very first press.
-		// Previously the user had to press Space or Ctrl+N first to enter
-		// "arrow-key mode"; arrows on a freshly-shown popup fell through to
-		// dialog focus advancement, leaving the popup feeling half-broken.
-		// Auto-activate on the first arrow press so the suggestionsActive
-		// handler below takes over and home.go's Enter handler can pick the
-		// highlighted suggestion (sub-bug 3).
+		// Issue #896 sub-bug 4: when the path-suggestions popup is visible
+		// and the user is actively editing the path (pathInput focused,
+		// not soft-selected), arrow keys auto-activate the popup so the
+		// suggestionsActive handler below takes over and home.go's Enter
+		// handler can pick the highlighted suggestion (sub-bug 3).
+		//
+		// Issue #1020 (@JMBattista): in soft-select mode (Tab-landed on a
+		// path field with a pre-filled value, pathInput blurred), Up/Down
+		// must NOT auto-activate — they must fall through to form-field
+		// navigation so the user can escape the path section. Explicit
+		// entry into popup-nav stays available via Space or Right, handled
+		// in the soft-select block just below.
 		if !d.suggestionsActive && d.currentTarget() == focusPath &&
-			len(d.pathSuggestions) > 0 && !d.suggestionsHidden {
+			len(d.pathSuggestions) > 0 && !d.suggestionsHidden &&
+			!d.pathSoftSelected {
 			if s := msg.String(); s == "down" || s == "up" {
 				d.suggestionsActive = true
-				d.pathSoftSelected = false
 				d.pathInput.Blur()
 				d.suggestionNavigated = true
 				// fall through to the suggestionsActive arrow handler below


### PR DESCRIPTION
## Summary

Closes #1020 from @JMBattista: the path-suggestions popup over-aggressively
captures Up/Down arrows on the new-session dialog, making it impossible to
move the cursor out of the path section once focus lands there.

## Root cause

PR #983 (closed @paskal's #896 sub-bugs 3+4) auto-activated the popup on the
first Up/Down arrow whenever:

- focus is on the path field
- there are suggestions
- the popup hasn't been explicitly dismissed

That fix works for the active-editing flow paskal described (type a prefix
→ arrows navigate the popup → Enter applies the highlighted suggestion).
But it fires even when the user just Tab-landed on a pre-filled path field
and is using Up/Down to move between dialog fields — which is exactly
@JMBattista's complaint.

## Approach

Combined of @JMBattista's suggestions 1 + 3: keep popup-nav reachable from
the path field, but only when the user is actually in the path text (or
has explicitly entered popup-nav with Space/Right). Arrows always escape
from soft-select mode.

Discriminator already present in the code: ` + "`pathSoftSelected`" + `.

- ` + "`true`" + ` the instant focus lands on a path field with a pre-filled value
  (` + "`pathInput`" + ` blurred, user navigating between fields)
- ` + "`false`" + ` after the soft-select handler clears it on the first real
  keystroke (` + "`pathInput`" + ` focused, user actively editing)

This is exactly the boundary between @JMBattista's scenario and @paskal's.
Gating #983's auto-activate on ` + "`!d.pathSoftSelected`" + ` restores pre-#983
escape behavior for #1020 while keeping the post-typing path that #896's
sub-bugs 3+4 fix relies on. Explicit popup entry stays available via Space
or Right (the existing soft-select handler).

Net diff in ` + "`newdialog.go`" + ` is one added condition, one removed redundant
assignment, and an updated block comment.

## Regression tests

` + "`internal/ui/issue1020_path_selector_ux_test.go`" + `:
` + "`TestNewDialog_PathSelector_UpDownEscapesField_RegressionFor1020`" + ` —
sets up the soft-selected path field (pre-filled value, Tab-landed) with
the popup visible, asserts Down/Up move focus to neighboring form fields
(not popup cursor), then verifies the explicit Space gesture still
activates popup-nav and Down then advances the popup cursor.

RED on ` + "`origin/main`" + `:

` + "```" + `
--- FAIL: TestNewDialog_PathSelector_UpDownEscapesField_RegressionFor1020
    issue1020_path_selector_ux_test.go:56: Down on a soft-selected path
    field auto-activated the popup; this is issue #1020 — arrows must not
    eat focus when the user hasn't explicitly entered popup-nav mode
` + "```" + `

GREEN with the fix.

` + "`internal/ui/issue896_residual_test.go`" + `: the existing sub-bug 3 + 4
tests bypassed the soft-select handler via direct ` + "`pathInput.SetValue`" + `,
leaving them in a synthetic soft-selected-with-value state that doesn't
occur via real keystrokes. Updated each test to also mirror the
post-typing state (` + "`pathInput.Focus()`" + ` + ` + "`pathSoftSelected = false`" + `)
so they exercise the actual user flow they were always meant to describe.
Both tests stay GREEN.

## Test plan

- [x] ` + "`go test -run \"TestNewDialog_PathSelector_UpDownEscapesField_RegressionFor1020\" ./internal/ui/...`" + ` — RED on main, GREEN with fix
- [x] ` + "`go test -run \"TestNewDialog_PopupEnter_SelectsHighlightedSuggestion_RegressionFor896|TestNewDialog_PopupArrows_NavigateReliably_RegressionFor896\" ./internal/ui/...`" + ` — GREEN (no regression)
- [x] ` + "`go test -race -count=1 ./internal/ui/...`" + ` — GREEN
- [x] ` + "`go build ./...`" + ` — GREEN
- [ ] Manual: ` + "`n`" + ` → Tab to path → Down moves focus to next field; Space → arrows navigate popup; Enter applies highlighted

## Credit

@JMBattista for the report and the surgical fix suggestions. @paskal for
the original #896 triage that PR #983 built on.