### PR TITLE
fix(web): restore <header> semantic element in web shell (closes #1022 part 1)

### DIFF
--- a/internal/web/issue1022_header_test.go
+++ b/internal/web/issue1022_header_test.go
@@ -1,0 +1,65 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestWebShell_HasHeaderElement_RegressionFor1022 is the regression test for
+// issue #1022 part 1: the web shell's Topbar component renders a generic
+// <div class="topbar"> instead of a semantic <header> element. Several
+// Playwright visual tests (tests/e2e/cascade-baseline.spec.ts,
+// tests/e2e/mobile-e2e.spec.ts, tests/e2e/visual/p9-pol*.spec.ts) wait for
+// `page.waitForSelector('header', ...)` to detect that the Preact app has
+// mounted. With no <header> in the rendered DOM, those tests time out
+// before the screenshot step, so the weekly visual regression suite
+// surfaces a failure with no diff image to triage.
+//
+// The web shell is a Preact SPA: the served index.html is just an empty
+// <div id="app-root"> shell; the real markup is produced client-side by
+// the modules under /static/app/. So this test asserts on the source of
+// Topbar.js (the component that owns the top-bar landmark) rather than
+// on a server-rendered DOM. That is what the Playwright tests actually
+// observe at runtime — once Topbar.js emits <header>, the selector
+// resolves and the weekly suite is unblocked.
+//
+// The fix is to change the root element of Topbar() from
+// `<div class="topbar">` to `<header class="topbar">` (the CSS grid in
+// app.css targets the .topbar class, not the tag, so layout is preserved).
+func TestWebShell_HasHeaderElement_RegressionFor1022(t *testing.T) {
+	t.Parallel()
+
+	s := NewServer(Config{})
+	mux := http.NewServeMux()
+	mux.Handle("/static/", http.StripPrefix("/static/", s.staticFileServer()))
+
+	req := httptest.NewRequest(http.MethodGet, "/static/app/Topbar.js", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /static/app/Topbar.js: status %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+
+	// The Topbar component must render a semantic <header> landmark so
+	// that page.locator('header') in the Playwright visual suite resolves.
+	// htm/preact tagged templates compile from JSX-like syntax, so the
+	// source contains the literal opening tag.
+	headerOpen := regexp.MustCompile(`<header[\s>]`)
+	if !headerOpen.MatchString(body) {
+		t.Errorf("Topbar.js must render a <header> element (issue #1022): " +
+			"found neither `<header>` nor `<header ...>` in the component source")
+	}
+
+	// Guard against the regression itself: the previous root was
+	// `<div class="topbar">`. If that string still appears as the
+	// Topbar's outer element, the fix has not landed.
+	if strings.Contains(body, `<div class="topbar">`) {
+		t.Errorf("Topbar.js still uses `<div class=\"topbar\">` as its root; " +
+			"issue #1022 requires a <header class=\"topbar\"> root")
+	}
+}

--- a/internal/web/static/app/Topbar.js
+++ b/internal/web/static/app/Topbar.js
@@ -39,7 +39,7 @@ export function Topbar() {
     : { background: 'var(--tn-red)', boxShadow: '0 0 6px var(--tn-red)' }
 
   return html`
-    <div class="topbar">
+    <header class="topbar">
       <div class="top-brand">
         <${Logo}/>
         <div class="brand-text">agent-deck<span class="dim">web</span></div>
@@ -98,6 +98,6 @@ export function Topbar() {
           <${Icon} d=${ICONS.settings}/>
         </button>
       </div>
-    </div>
+    </header>
   `
 }


### PR DESCRIPTION
## Summary

- Web shell's Topbar component rendered `<div class="topbar">` instead of `<header class="topbar">` after the PR-B redesign port (b923e8bc).
- Several Playwright visual tests (`tests/e2e/cascade-baseline.spec.ts`, `tests/e2e/mobile-e2e.spec.ts`, `tests/e2e/visual/p9-pol*.spec.ts`) gate on `page.waitForSelector('header', ...)` to detect that the Preact app has mounted. Without a `<header>` landmark in the rendered DOM, they time out **before** the screenshot step, so the weekly visual regression suite (#1022) reports failures with no diff image to triage.
- Fix: swap the Topbar's root element back to `<header class="topbar">`. The CSS grid in `app.css` targets the `.topbar` class (not the tag), so layout/styling are unaffected — the change is purely semantic.

## Root cause

`b923e8bc feat(web): WebUI redesign port (PR-B) (#860)` introduced the new five-zone shell with a `<div>` wrapper around the topbar. The original shell used `<header>`, which the Playwright suite still relies on.

## TDD

Regression test: `internal/web/issue1022_header_test.go` → `TestWebShell_HasHeaderElement_RegressionFor1022`
- Fetches `/static/app/Topbar.js` via the server's static file handler
- Asserts the component source contains a `<header` opening tag
- Guards against the regression: asserts the old `<div class="topbar">` root is gone

The web shell is a Preact SPA (served `index.html` is just `<div id="app-root">`), so the assertion is on the component source — which is what the browser executes and what the Playwright tests ultimately observe.

RED on `origin/main`; GREEN with the fix.

## Test plan

- [x] `go test ./internal/web/ -run TestWebShell_HasHeaderElement_RegressionFor1022 -v` — FAIL → PASS after fix
- [x] `go test -race ./internal/web/` — green
- [x] `go test -race ./...` — green across all packages
- [ ] Weekly visual regression suite re-run (post-merge) confirms `header`-gated tests now reach the screenshot step

Committed by Ashesh Goplani