### PR TITLE
fix(wakeup): retry policy + observability for upstream 5xx (closes #976)

### DIFF
--- a/skills/agent-deck/scripts/goal/manager.py
+++ b/skills/agent-deck/scripts/goal/manager.py
@@ -32,9 +32,25 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+
+# Retry policy for nudge delivery (regression: issue #976).
+# An autonomous ScheduleWakeup loop went silent for ~5h when a burst of
+# upstream 5xx errors landed on the wake-up that nudges the worker. The
+# retry below absorbs transient failures and emits a log line per attempt
+# so a stalled loop is observable instead of silent.
+BACKOFF_SECONDS = (1, 5, 30)
+
+
+def log_attempt(attempt: int, total: int, *, reason: str) -> None:
+    """Emit one observability line per wake-up attempt (#976)."""
+    print(
+        f"[manager] wakeup attempt {attempt}/{total}: {reason}",
+        file=sys.stderr,
+    )
 
 GOALS_DIR = Path.home() / ".agent-deck" / "goals"
 ESCALATIONS_DIR = GOALS_DIR / "escalations"
@@ -127,20 +143,33 @@ def newer_than(ts_a: str, ts_b: str | None) -> bool:
 
 
 def agent_deck_send(session_id_or_title: str, message: str, dry_run: bool, verbose: bool) -> bool:
-    """Send a nudge to a worker. Returns True on success."""
+    """Send a nudge to a worker. Returns True on success.
+
+    Retries on transient failures with exponential backoff (BACKOFF_SECONDS).
+    Logs every attempt with the reason so a stalled autonomous loop is
+    observable instead of silent. Regression fix for issue #976.
+    """
     cmd = ["agent-deck", "session", "send", session_id_or_title, message, "--no-wait", "-q"]
     vlog(verbose, "nudge cmd: " + " ".join(shlex.quote(c) for c in cmd))
     if dry_run:
         return True
-    try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-        if r.returncode != 0:
-            print(f"[manager] nudge failed: {r.stderr.strip()}", file=sys.stderr)
-            return False
-        return True
-    except Exception as e:  # noqa: BLE001
-        print(f"[manager] nudge error: {e}", file=sys.stderr)
-        return False
+
+    total = len(BACKOFF_SECONDS)
+    for i in range(total):
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            if r.returncode == 0:
+                log_attempt(i + 1, total, reason="ok")
+                return True
+            reason = (r.stderr or r.stdout or "non-zero exit").strip() or "non-zero exit"
+        except Exception as e:  # noqa: BLE001
+            reason = f"exception: {e}"
+
+        log_attempt(i + 1, total, reason=reason)
+        if i < total - 1:
+            time.sleep(BACKOFF_SECONDS[i])
+
+    return False
 
 
 def agent_deck_stop(session_id_or_title: str, dry_run: bool, verbose: bool) -> bool:

--- a/skills/agent-deck/scripts/goal/tests/test_manager.py
+++ b/skills/agent-deck/scripts/goal/tests/test_manager.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -424,6 +425,82 @@ class TestSkipInactive(unittest.TestCase):
         manager.walk_goal(path, dry_run=False, verbose=False)
         loaded = json.loads(path.read_text())
         self.assertEqual(loaded["state"]["status"], "done")
+
+
+class TestScheduleWakeup_RetryOn5xx_LogsAndBackoffs_RegressionFor976(unittest.TestCase):
+    """Regression for issue #976.
+
+    The autonomous ScheduleWakeup loop silently stalled for hours when a
+    transient upstream failure (Anthropic API 5xx) hit the wake-up that
+    drives the worker. agent_deck_send is the in-repo seam that delivers
+    that wake-up: if it can't reach the worker on the first try, the loop
+    needs to retry with exponential backoff and log every attempt so the
+    failure is observable instead of silent.
+
+    Contract under test:
+      - 3 attempts total before giving up
+      - exponential backoff between attempts: BACKOFF_SECONDS = (1, 5, 30)
+      - every attempt logged with the reason for that attempt
+      - returns True once a retry succeeds (no spurious failure surface)
+    """
+
+    def setUp(self):
+        self._sleeps: list[float] = []
+        self._sleep_patch = patch("manager.time.sleep", side_effect=self._sleeps.append)
+        self._sleep_patch.start()
+
+    def tearDown(self):
+        self._sleep_patch.stop()
+
+    @staticmethod
+    def _fail(stderr: str) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+    @staticmethod
+    def _ok() -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="ok\n", stderr="")
+
+    def test_retries_three_times_with_backoff_and_logs(self):
+        attempts = [
+            self._fail("upstream returned HTTP 503"),
+            self._fail("upstream returned HTTP 502"),
+            self._ok(),
+        ]
+        with patch("manager.subprocess.run", side_effect=attempts) as mock_run, \
+             patch("manager.log_attempt") as mock_log:
+            result = manager.agent_deck_send(
+                "worker-session", "wake up", dry_run=False, verbose=False
+            )
+
+        self.assertTrue(result, "third attempt succeeded; agent_deck_send must return True")
+        self.assertEqual(mock_run.call_count, 3, "should retry until success (max 3 attempts)")
+        # Backoff before retries — two sleeps total (after attempt 1 and after attempt 2)
+        self.assertEqual(
+            self._sleeps,
+            [manager.BACKOFF_SECONDS[0], manager.BACKOFF_SECONDS[1]],
+            "exponential backoff must use [1s, 5s] before retries",
+        )
+        self.assertEqual(manager.BACKOFF_SECONDS, (1, 5, 30),
+                         "backoff schedule must be the documented [1s, 5s, 30s]")
+        # Every attempt is logged with a reason — that's the observability fix.
+        self.assertEqual(mock_log.call_count, 3, "every attempt must be logged")
+        reasons = [c.kwargs.get("reason") or c.args[-1] for c in mock_log.call_args_list]
+        self.assertIn("HTTP 503", reasons[0])
+        self.assertIn("HTTP 502", reasons[1])
+
+    def test_gives_up_after_three_failures_and_logs_each(self):
+        attempts = [self._fail(f"HTTP 50{i}") for i in (0, 2, 3)]
+        with patch("manager.subprocess.run", side_effect=attempts) as mock_run, \
+             patch("manager.log_attempt") as mock_log:
+            result = manager.agent_deck_send(
+                "worker-session", "wake up", dry_run=False, verbose=False
+            )
+
+        self.assertFalse(result, "all 3 attempts failed; must surface failure")
+        self.assertEqual(mock_run.call_count, 3, "must not exceed 3 attempts")
+        self.assertEqual(mock_log.call_count, 3, "every attempt logged, even on terminal failure")
+        # Backoff applied between attempts 1->2 and 2->3, but not after the last fail.
+        self.assertEqual(self._sleeps, [manager.BACKOFF_SECONDS[0], manager.BACKOFF_SECONDS[1]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds a 3-attempt retry with exponential backoff `[1s, 5s, 30s]` inside `agent_deck_send`, the nudge-delivery seam that drives the autonomous `ScheduleWakeup` loop.
- Every attempt emits a structured log line (`[manager] wakeup attempt N/M: <reason>`), so a stalled loop is observable instead of silent.
- Return contract is unchanged: three failed attempts still surface as `False`, so the existing nudge-counting + escalation path in `walk_goal` still triggers on terminal failure — but a transient 5xx burst no longer silently strands the worker.

## Why
Closes #976 — observed once over ~4 weeks of autonomous operation. A burst of Anthropic API 500s landed on a scheduled wake-up; the single-shot `subprocess.run` returned non-zero, the nudge was dropped, and the conductor went dark for ~5 hours until a human nudged it manually.

## Implementation notes
- `BACKOFF_SECONDS = (1, 5, 30)` is a module constant — tests pin both the values and that the schedule has length 3.
- `time.sleep` is referenced via the module (`manager.time.sleep`) so the test patches it and runs in milliseconds rather than ~36 s.
- `log_attempt(attempt, total, *, reason)` is a tiny seam — keeps the retry loop testable without coupling to a logging framework.

## Test plan
- [x] New regression class `TestScheduleWakeup_RetryOn5xx_LogsAndBackoffs_RegressionFor976`
  - [x] `test_retries_three_times_with_backoff_and_logs`: 503 → 502 → 200; assert 3 subprocess calls, sleeps `[1, 5]`, 3 log lines with reasons containing the upstream codes.
  - [x] `test_gives_up_after_three_failures_and_logs_each`: 500 → 502 → 503; assert returns `False`, exactly 3 attempts, 3 log lines, 2 backoff sleeps.
- [x] Verified RED on `origin/main` (test errors with `AttributeError: module 'manager' has no attribute 'time'` — the seam doesn't exist yet).
- [x] Verified GREEN after fix (25/25 in `skills/agent-deck/scripts/goal/tests`, was 23 before).

Committed by Ashesh Goplani