### PR TITLE
feat(session): expose resolved CLAUDE_CONFIG_DIR hint via env (closes #925)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -838,7 +838,28 @@ func (i *Instance) buildBashExportPrefix() string {
 		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
 		prefix += fmt.Sprintf("export CLAUDE_CONFIG_DIR=%s; ", configDir)
 	}
+	prefix += i.buildResolvedAccountHintExports()
 	return prefix
+}
+
+// buildResolvedAccountHintExports emits the three "intended account"
+// hint env vars introduced by issue #925 (reporter @bautrey): the
+// resolved config dir, group path, and source label from the priority
+// chain. These mirror the user's *intent* and intentionally bypass
+// the worker-scratch override applied to CLAUDE_CONFIG_DIR — consumer
+// scripts (statusline, custom prompts, telemetry, hooks) need a stable
+// label of which account this session belongs to, not agent-deck's
+// per-session scratch path. Always emitted for claude-compatible
+// instances (including when source resolves to "default") so consumers
+// can rely on the vars being present.
+func (i *Instance) buildResolvedAccountHintExports() string {
+	resolved, source := GetClaudeConfigDirSourceForInstance(i)
+	return fmt.Sprintf(
+		"export AGENTDECK_RESOLVED_CONFIG_DIR=%s; export AGENTDECK_RESOLVED_GROUP=%s; export AGENTDECK_RESOLVED_SOURCE=%s; ",
+		shellescape.Quote(resolved),
+		shellescape.Quote(i.GroupPath),
+		shellescape.Quote(source),
+	)
 }
 
 // logClaudeConfigResolution emits the CFG-07 observability line documenting

--- a/internal/session/issue925_resolved_account_env_test.go
+++ b/internal/session/issue925_resolved_account_env_test.go
@@ -1,0 +1,97 @@
+// Issue #925 — expose the resolved-account / intended-config-dir hint to
+// the claude subprocess via dedicated env vars so statusline scripts,
+// custom prompts, telemetry and hooks can label/route on the user's
+// intent rather than on agent-deck's worker-scratch implementation
+// detail.
+//
+// Bug reporter: @bautrey. The user-visible problem is that
+// `CLAUDE_CONFIG_DIR` in the spawn env may carry a worker-scratch path
+// (issue #59 / #949) which is opaque to consumers; meanwhile the
+// per-group `[groups.X.claude] config_dir` (or conductor / profile /
+// global / default) that the user *intended* is invisible. This test
+// locks down that buildClaudeCommand emits three new env vars carrying
+// the resolved values, and that the resolved-config-dir hint reflects
+// the priority-chain output (not the scratch override).
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSpawnEnv_ExposesResolvedConfigDirHint_RegressionFor925 locks the
+// spawn-env contract requested in issue #925:
+//
+//	AGENTDECK_RESOLVED_CONFIG_DIR=<resolved path>
+//	AGENTDECK_RESOLVED_GROUP=<group path>
+//	AGENTDECK_RESOLVED_SOURCE=<env|conductor|group|profile|global|default>
+//
+// Critical invariant: the RESOLVED_CONFIG_DIR carries the priority-chain
+// output (what the user configured) — NOT the worker-scratch override.
+// `CLAUDE_CONFIG_DIR` may be swapped to scratch (#922/#949), but the
+// hint must remain stable so consumers can identify the intended account.
+func TestSpawnEnv_ExposesResolvedConfigDirHint_RegressionFor925(t *testing.T) {
+	withTelegramConductorPresent(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Intended profile dir resolved via the env-level priority chain.
+	profile := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(profile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "settings.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", profile)
+
+	inst := &Instance{
+		ID:          "00000000-0000-0000-0000-000000000925",
+		Tool:        "claude",
+		Title:       "issue-925",
+		ProjectPath: filepath.Join(home, "proj"),
+		GroupPath:   "projects/devops",
+	}
+
+	// Prepare worker-scratch so CLAUDE_CONFIG_DIR in spawn env will be
+	// the scratch path while the RESOLVED_CONFIG_DIR hint must stay at
+	// the intended profile.
+	scratch, err := inst.EnsureWorkerScratchConfigDir(profile)
+	if err != nil {
+		t.Fatalf("setup scratch: %v", err)
+	}
+	if scratch == "" || scratch == profile {
+		t.Fatalf("setup: expected non-empty scratch dir distinct from profile; scratch=%q profile=%q", scratch, profile)
+	}
+	inst.WorkerScratchConfigDir = scratch
+
+	cmd := inst.buildClaudeCommand("claude")
+
+	wantHint := "AGENTDECK_RESOLVED_CONFIG_DIR=" + profile
+	if !strings.Contains(cmd, wantHint) {
+		t.Errorf("spawn cmd must contain %q (intended resolved dir, not the scratch override);\ngot: %s", wantHint, cmd)
+	}
+
+	// The hint must NEVER carry the worker-scratch path — that would
+	// make the env var useless for the "which account is this?"
+	// statusline use case the feature exists to support.
+	scratchHint := "AGENTDECK_RESOLVED_CONFIG_DIR=" + scratch
+	if strings.Contains(cmd, scratchHint) {
+		t.Errorf("AGENTDECK_RESOLVED_CONFIG_DIR must reflect the priority-chain resolved dir, not the worker-scratch path;\ngot cmd containing %q: %s", scratchHint, cmd)
+	}
+
+	wantGroup := "AGENTDECK_RESOLVED_GROUP=projects/devops"
+	if !strings.Contains(cmd, wantGroup) {
+		t.Errorf("spawn cmd must contain %q;\ngot: %s", wantGroup, cmd)
+	}
+
+	// With CLAUDE_CONFIG_DIR env set, the instance-chain resolver returns
+	// source="env" (conductor/group beat env, but neither is configured
+	// here so env wins). See resolveClaudeConfigDir.
+	wantSource := "AGENTDECK_RESOLVED_SOURCE=env"
+	if !strings.Contains(cmd, wantSource) {
+		t.Errorf("spawn cmd must contain %q;\ngot: %s", wantSource, cmd)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #925 (reporter @bautrey).

agent-deck may swap `CLAUDE_CONFIG_DIR` for a worker-scratch path (#922 / #949) so non-conductor claude workers don't double-spawn the telegram plugin. That swap is a useful implementation detail — but it makes `CLAUDE_CONFIG_DIR` an unreliable signal for "which account is this session on?", which statusline scripts, custom prompts, telemetry, and hooks all need.

This PR adds three new env vars to the claude spawn env that mirror the user's *intent* (the priority-chain output) and are intentionally **not** subject to the worker-scratch override:

| Env var | Value |
|---|---|
| `AGENTDECK_RESOLVED_CONFIG_DIR` | resolved config dir (path the user configured) |
| `AGENTDECK_RESOLVED_GROUP` | `inst.GroupPath` |
| `AGENTDECK_RESOLVED_SOURCE` | one of `env`, `conductor`, `group`, `profile`, `global`, `default` |

Consumer scripts can read these to label, route, or branch on the user's intent rather than the post-scratch implementation detail.

## Implementation

- New helper `buildResolvedAccountHintExports` routes through the existing `GetClaudeConfigDirSourceForInstance` priority resolver, which (by design) does **not** apply `applyWorkerScratchOverride` — that's the property #925 needs.
- Wired into `buildBashExportPrefix` so the hints land in the spawn env for the default new-session path (and any other spawn path that goes through bash-export prefix).
- Always emitted (including `source=default`) so consumers can rely on the vars being present.

## Test plan

- [x] RED: `TestSpawnEnv_ExposesResolvedConfigDirHint_RegressionFor925` fails on `origin/main` (all three asserts).
- [x] GREEN: same test passes after the fix.
- [x] Critical invariant covered: with worker-scratch prepared, `AGENTDECK_RESOLVED_CONFIG_DIR` reflects the *intended* profile, not the scratch path (while `CLAUDE_CONFIG_DIR` legitimately carries the scratch path).
- [x] `go test ./internal/session/ -race -count=1` green (90s, includes #922 / #949 / #950 / #984 regression suites).
- [x] `go test ./... -count=1` green (full repo).
- [x] No regression to the #950 worker-scratch gate.

Committed by Ashesh Goplani