### PR TITLE
feat: add charmbracelet/crush adapter (closes #940)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **charmbracelet/crush as a first-class builtin agent** ([#940](https://github.com/asheshgoplani/agent-deck/issues/940)). Launch, attach, kill `crush` sessions (Charm's terminal-first AI coding assistant from [github.com/charmbracelet/crush](https://github.com/charmbracelet/crush)). Icon 💘, color magenta. Config via `[crush]` section with `command`, `env_file`, `yolo_mode`. Per-session resume via `--session <id>` / `--continue` flows through `CrushOptions` (ToolOptionsJSON). Detection wired across the CLI (`agent-deck add -c crush .`), tmux pane content patterns (`charm crush`, `crush>`), and the four UI surfaces (new-session dialog, setup wizard, settings panel, home preset). Adapter mirrors the existing copilot adapter — no shared infrastructure changes, no impact on other agents.
+
 ## [1.9.13] - 2026-05-17
 
 First release driven by findings from the **Weekly Regression cron**, which began producing actionable signal once the host-sensitive split landed in v1.9.12 ([#1019](https://github.com/asheshgoplani/agent-deck/pull/1019)). Two merged PRs, both closing the two halves of [#1022](https://github.com/asheshgoplani/agent-deck/issues/1022) (the cron's first real report): a visual-regression fix that restores the `<header>` landmark in the web shell, and a perf fix that code-splits Chart.js off the initial-paint payload to clear the Lighthouse budget overshoot. v1.9.13 is the **eighth release cut under the Option A pipeline** ([#981](https://github.com/asheshgoplani/agent-deck/pull/981) in v1.9.6); the local release worker stops at `git push origin <tag>` and `.github/workflows/release.yml` is the single source of truth for `goreleaser release --clean`.

--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Agent Deck works with any terminal-based AI tool:
 | **Gemini CLI** | Full (status, MCP, resume) |
 | **OpenCode** | Status detection, organization |
 | **Codex** | Status detection, organization, conductor |
+| **Crush** (charmbracelet/crush) | Status detection, organization, launch |
 | **Cursor** (terminal) | Status detection, organization |
 | **Custom tools** | Configurable via `[tools.*]` in config.toml |
 

--- a/cmd/agent-deck/crush_detect_test.go
+++ b/cmd/agent-deck/crush_detect_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+// Issue #940: `agent-deck add -c crush .` must set Instance.Tool = "crush"
+// instead of falling back to "shell". This is the CLI-layer detection (not
+// tmux's detectToolFromCommand) — it lives in main.go.
+
+func TestDetectTool_Crush(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"bare", "crush", "crush"},
+		{"with yolo", "crush --yolo", "crush"},
+		{"uppercase", "Crush", "crush"},
+		{"with session", "crush --session abc123", "crush"},
+		{"with continue", "crush --continue", "crush"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got != tt.want {
+				t.Errorf("detectTool(%q) = %q, want %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectTool_Crush_Negative(t *testing.T) {
+	// Note: detectTool uses strings.Contains, so any string containing "crush"
+	// will match. Only truly unrelated strings are tested here.
+	tests := []struct {
+		name string
+		cmd  string
+	}{
+		{"empty string", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got == "crush" {
+				t.Errorf("detectTool(%q) = %q, should NOT match crush", tt.cmd, got)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -3067,6 +3067,8 @@ func detectTool(cmd string) string {
 		return "pi"
 	case strings.Contains(cmd, "copilot"):
 		return "copilot"
+	case strings.Contains(cmd, "crush"):
+		return "crush"
 	case strings.Contains(cmd, "cursor"):
 		return "cursor"
 	default:

--- a/internal/session/crush.go
+++ b/internal/session/crush.go
@@ -1,0 +1,79 @@
+package session
+
+import (
+	"strings"
+)
+
+// Crush adapter (Issue #940).
+//
+// charmbracelet/crush is an interactive terminal AI assistant
+// (github.com/charmbracelet/crush). The crush CLI is a single TUI binary:
+//
+//	crush                    # interactive TUI
+//	crush --yolo             # auto-accept all permissions
+//	crush --session <id>     # resume a specific session
+//	crush --continue         # resume the most recent session
+//	crush --cwd <path>       # set working directory
+//	crush --debug            # enable debug logging
+//
+// agent-deck integrates crush at the same level as copilot/hermes: launch
+// the TUI in a tmux pane with optional env_file sourcing, an optional
+// command override (e.g., for a wrapper script), and an optional --yolo
+// flag from `[crush].yolo_mode`. Per-session resume IDs flow through
+// CrushOptions (ToolOptionsJSON) when wired by the UI.
+//
+// Status detection: process-alive/dead only at this stage. Content-sniffing
+// patterns live in internal/tmux/tmux.go and will refine the "running"
+// signal once Crush's TUI strings stabilise.
+
+// GetCrushCommand returns the configured crush command/alias.
+// Mirrors GetCodexCommand on main: prefer the user config override, fall
+// back to the bare binary name.
+func GetCrushCommand() string {
+	userConfig, _ := LoadUserConfig()
+	if userConfig != nil && strings.TrimSpace(userConfig.Crush.Command) != "" {
+		return strings.TrimSpace(userConfig.Crush.Command)
+	}
+	return "crush"
+}
+
+// buildCrushCommand builds the launch command for charmbracelet/crush.
+// Applies env sourcing, command override, and any per-session flags.
+// If baseCommand differs from the bare tool name "crush", it is treated
+// as a user-supplied passthrough command and returned without flag
+// injection — matching the buildCopilotCommand pattern on main.
+func (i *Instance) buildCrushCommand(baseCommand string) string {
+	if i.Tool != "crush" {
+		return baseCommand
+	}
+
+	envPrefix := i.buildEnvSourceCommand()
+
+	// Passthrough: custom command from CLI (not the bare name)
+	trimmed := strings.TrimSpace(baseCommand)
+	if trimmed != "" && trimmed != "crush" {
+		return envPrefix + trimmed
+	}
+
+	cmd := GetCrushCommand()
+
+	// Per-session flags from ToolOptionsJSON take priority over global
+	// config. Falls back to [crush].yolo_mode for --yolo when no per-session
+	// override is present.
+	if len(i.ToolOptionsJSON) > 0 {
+		if opts, err := UnmarshalCrushOptions(i.ToolOptionsJSON); err == nil && opts != nil {
+			args := opts.ToArgs()
+			if len(args) > 0 {
+				cmd += " " + strings.Join(args, " ")
+			}
+			return envPrefix + cmd
+		}
+	}
+
+	config, _ := LoadUserConfig()
+	if config != nil && config.Crush.YoloMode {
+		cmd += " --yolo"
+	}
+
+	return envPrefix + cmd
+}

--- a/internal/session/crush_test.go
+++ b/internal/session/crush_test.go
@@ -1,0 +1,287 @@
+package session
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// Issue #940: charmbracelet/crush CLI support.
+// These tests define the Tool="crush" contract: options marshalling,
+// ToArgs for yolo + resume, factory from config, and the basic identity
+// gates (icon, IsClaudeCompatible, builtin-name filter).
+//
+// Binary: `crush` (github.com/charmbracelet/crush). Interactive TUI.
+// Key flags: --yolo (-y), --session/-s <id>, --continue/-C, --cwd, --debug.
+
+func TestCrushOptions_ToolName(t *testing.T) {
+	opts := &CrushOptions{}
+	if got := opts.ToolName(); got != "crush" {
+		t.Errorf("CrushOptions.ToolName() = %q, want %q", got, "crush")
+	}
+}
+
+func TestCrushOptions_ToArgs(t *testing.T) {
+	yoloTrue := true
+	yoloFalse := false
+
+	tests := []struct {
+		name     string
+		opts     CrushOptions
+		expected []string
+	}{
+		{
+			name:     "default - no args",
+			opts:     CrushOptions{},
+			expected: nil,
+		},
+		{
+			name:     "yolo nil - no args",
+			opts:     CrushOptions{YoloMode: nil},
+			expected: nil,
+		},
+		{
+			name:     "yolo false - no args",
+			opts:     CrushOptions{YoloMode: &yoloFalse},
+			expected: nil,
+		},
+		{
+			name:     "yolo true - --yolo present",
+			opts:     CrushOptions{YoloMode: &yoloTrue},
+			expected: []string{"--yolo"},
+		},
+		{
+			name:     "resume with id",
+			opts:     CrushOptions{ResumeSessionID: "abc123"},
+			expected: []string{"--session", "abc123"},
+		},
+		{
+			name:     "continue last",
+			opts:     CrushOptions{ContinueLast: true},
+			expected: []string{"--continue"},
+		},
+		{
+			name:     "yolo + resume",
+			opts:     CrushOptions{YoloMode: &yoloTrue, ResumeSessionID: "sess-42"},
+			expected: []string{"--session", "sess-42", "--yolo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.opts.ToArgs()
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("ToArgs() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewCrushOptions_Defaults(t *testing.T) {
+	opts := NewCrushOptions(nil)
+	if opts == nil {
+		t.Fatal("NewCrushOptions(nil) returned nil")
+	}
+	if opts.YoloMode != nil {
+		t.Errorf("default YoloMode = %v, want nil", opts.YoloMode)
+	}
+}
+
+func TestNewCrushOptions_WithYoloConfig(t *testing.T) {
+	cfg := &UserConfig{
+		Crush: CrushSettings{YoloMode: true},
+	}
+	opts := NewCrushOptions(cfg)
+	if opts == nil {
+		t.Fatal("NewCrushOptions returned nil")
+	}
+	if opts.YoloMode == nil || !*opts.YoloMode {
+		t.Errorf("YoloMode = %v, want true", opts.YoloMode)
+	}
+}
+
+func TestNewCrushOptions_WithoutYoloConfig(t *testing.T) {
+	cfg := &UserConfig{
+		Crush: CrushSettings{YoloMode: false},
+	}
+	opts := NewCrushOptions(cfg)
+	if opts == nil {
+		t.Fatal("NewCrushOptions returned nil")
+	}
+	if opts.YoloMode != nil {
+		t.Errorf("YoloMode = %v, want nil (not set when config is false)", opts.YoloMode)
+	}
+}
+
+func TestCrushOptions_MarshalUnmarshalRoundtrip(t *testing.T) {
+	yolo := true
+	orig := &CrushOptions{YoloMode: &yolo, ResumeSessionID: "sess-42"}
+
+	data, err := MarshalToolOptions(orig)
+	if err != nil {
+		t.Fatalf("MarshalToolOptions: %v", err)
+	}
+
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		t.Fatalf("unmarshal wrapper: %v", err)
+	}
+	if wrapper.Tool != "crush" {
+		t.Errorf("wrapper.Tool = %q, want %q", wrapper.Tool, "crush")
+	}
+
+	got, err := UnmarshalCrushOptions(data)
+	if err != nil {
+		t.Fatalf("UnmarshalCrushOptions: %v", err)
+	}
+	if got == nil {
+		t.Fatal("UnmarshalCrushOptions returned nil")
+	}
+	if got.YoloMode == nil || !*got.YoloMode {
+		t.Errorf("roundtrip YoloMode = %v, want true", got.YoloMode)
+	}
+	if got.ResumeSessionID != "sess-42" {
+		t.Errorf("roundtrip ResumeSessionID = %q, want %q", got.ResumeSessionID, "sess-42")
+	}
+}
+
+func TestUnmarshalCrushOptions_WrongTool(t *testing.T) {
+	raw := json.RawMessage(`{"tool":"codex","options":{}}`)
+	got, err := UnmarshalCrushOptions(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalCrushOptions: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for wrong tool, got %+v", got)
+	}
+}
+
+func TestIsClaudeCompatible_CrushNotCompatible(t *testing.T) {
+	if IsClaudeCompatible("crush") {
+		t.Error("IsClaudeCompatible(\"crush\") must be false")
+	}
+}
+
+func TestGetToolIcon_Crush(t *testing.T) {
+	icon := GetToolIcon("crush")
+	if icon == "" {
+		t.Error("GetToolIcon(\"crush\") returned empty")
+	}
+	if icon == GetToolIcon("shell") {
+		t.Errorf("GetToolIcon(\"crush\") = %q equals shell fallback (want a distinct icon)", icon)
+	}
+}
+
+func TestGetCustomToolNames_CrushIsBuiltin(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+
+	userConfigCache = &UserConfig{
+		Tools: map[string]ToolDef{
+			"crush":      {Command: "crush"},
+			"my-wrapper": {Command: "claude"},
+		},
+	}
+
+	names := GetCustomToolNames()
+	for _, n := range names {
+		if n == "crush" {
+			t.Errorf("GetCustomToolNames() returned %q as custom; crush is built-in", n)
+		}
+	}
+}
+
+func TestNewInstanceWithTool_Crush(t *testing.T) {
+	inst := NewInstanceWithTool("crush-test", "/tmp/crush-test-proj", "crush")
+	if inst == nil {
+		t.Fatal("NewInstanceWithTool returned nil")
+	}
+	if inst.Tool != "crush" {
+		t.Errorf("inst.Tool = %q, want %q", inst.Tool, "crush")
+	}
+}
+
+func TestBuildCrushCommand_BareName(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	inst := &Instance{Tool: "crush"}
+	cmd := inst.buildCrushCommand("crush")
+	if cmd == "" {
+		t.Fatal("buildCrushCommand(\"crush\") returned empty")
+	}
+	// Should end with the bare "crush" binary when no config is present
+	if !endsWith(cmd, "crush") {
+		t.Errorf("buildCrushCommand(\"crush\") = %q, want suffix \"crush\"", cmd)
+	}
+}
+
+func TestBuildCrushCommand_YoloFromConfig(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Crush: CrushSettings{YoloMode: true},
+	}
+
+	inst := &Instance{Tool: "crush"}
+	cmd := inst.buildCrushCommand("crush")
+	if !endsWith(cmd, "crush --yolo") {
+		t.Errorf("buildCrushCommand() = %q, want suffix %q", cmd, "crush --yolo")
+	}
+}
+
+func TestBuildCrushCommand_CommandOverride(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Crush: CrushSettings{Command: "crush --debug"},
+	}
+
+	inst := &Instance{Tool: "crush"}
+	cmd := inst.buildCrushCommand("crush")
+	if !endsWith(cmd, "crush --debug") {
+		t.Errorf("buildCrushCommand() = %q, want suffix %q", cmd, "crush --debug")
+	}
+}
+
+func TestBuildCrushCommand_Passthrough(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	inst := &Instance{Tool: "crush"}
+	got := inst.buildCrushCommand("crush --some-flag")
+	if !endsWith(got, "crush --some-flag") {
+		t.Errorf("buildCrushCommand passthrough = %q, want suffix %q", got, "crush --some-flag")
+	}
+}
+
+func TestBuildCrushCommand_WrongTool(t *testing.T) {
+	inst := &Instance{Tool: "claude"}
+	got := inst.buildCrushCommand("anything")
+	if got != "anything" {
+		t.Errorf("buildCrushCommand with wrong tool = %q, want %q", got, "anything")
+	}
+}
+
+func TestGetToolEnvFile_Crush(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{
+		Crush: CrushSettings{EnvFile: "/tmp/crush.env"},
+	}
+
+	inst := &Instance{Tool: "crush"}
+	got := inst.getToolEnvFile()
+	if got != "/tmp/crush.env" {
+		t.Errorf("getToolEnvFile() for crush = %q, want %q", got, "/tmp/crush.env")
+	}
+}
+
+// endsWith is a small local helper to avoid pulling strings into the test
+// file boilerplate twice (and to mirror the suffix-style assertions used by
+// neighbouring adapter tests).
+func endsWith(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -272,6 +272,8 @@ func (i *Instance) getToolEnvFile() string {
 		return config.Claude.EnvFile
 	case "gemini":
 		return config.Gemini.EnvFile
+	case "crush":
+		return config.Crush.EnvFile
 	default:
 		// Check custom tools
 		if def := GetToolDef(i.Tool); def != nil {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2728,6 +2728,8 @@ func (i *Instance) StartWithMessage(message string) error {
 	case IsCodexCompatible(i.Tool):
 		command = i.buildCodexCommand(i.Command)
 		i.CodexStartedAt = time.Now().UnixMilli()
+	case i.Tool == "crush":
+		command = i.buildCrushCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -4984,6 +4986,8 @@ func (i *Instance) Restart() error {
 			command = i.buildCodexCommand(i.Command)
 			// Record start time for async session ID detection
 			i.CodexStartedAt = time.Now().UnixMilli()
+		case i.Tool == "crush":
+			command = i.buildCrushCommand(i.Command)
 		default:
 			// Check if this is a custom tool with session resume config
 			if toolDef := GetToolDef(i.Tool); toolDef != nil {

--- a/internal/session/tooloptions.go
+++ b/internal/session/tooloptions.go
@@ -363,6 +363,75 @@ func UnmarshalCopilotOptions(data json.RawMessage) (*CopilotOptions, error) {
 	return &opts, nil
 }
 
+// CrushOptions holds launch options for charmbracelet/crush CLI sessions
+// (Issue #940). Binary: `crush` from github.com/charmbracelet/crush.
+type CrushOptions struct {
+	// YoloMode enables --yolo flag (auto-accept all permission prompts).
+	// nil = inherit from config, true/false = explicit override.
+	YoloMode *bool `json:"yolo_mode,omitempty"`
+	// ResumeSessionID is the crush session ID for --session/-s flag.
+	// Empty means start a fresh session.
+	ResumeSessionID string `json:"resume_session_id,omitempty"`
+	// ContinueLast maps to --continue/-C (resume the most recent session).
+	// Mutually exclusive with ResumeSessionID at the crush CLI level; if
+	// both are set, ResumeSessionID wins (it is the more specific signal).
+	ContinueLast bool `json:"continue_last,omitempty"`
+}
+
+// ToolName returns "crush"
+func (o *CrushOptions) ToolName() string {
+	return "crush"
+}
+
+// ToArgs returns command-line arguments based on options.
+// Ordering matches the crush CLI flag groups (session first, then yolo).
+func (o *CrushOptions) ToArgs() []string {
+	var args []string
+	switch {
+	case o.ResumeSessionID != "":
+		args = append(args, "--session", o.ResumeSessionID)
+	case o.ContinueLast:
+		args = append(args, "--continue")
+	}
+	if o.YoloMode != nil && *o.YoloMode {
+		args = append(args, "--yolo")
+	}
+	return args
+}
+
+// NewCrushOptions creates CrushOptions with defaults from global config.
+func NewCrushOptions(config *UserConfig) *CrushOptions {
+	opts := &CrushOptions{}
+	if config != nil && config.Crush.YoloMode {
+		yolo := true
+		opts.YoloMode = &yolo
+	}
+	return opts
+}
+
+// UnmarshalCrushOptions deserializes CrushOptions from JSON wrapper.
+func UnmarshalCrushOptions(data json.RawMessage) (*CrushOptions, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, err
+	}
+
+	if wrapper.Tool != "crush" {
+		return nil, nil
+	}
+
+	var opts CrushOptions
+	if err := json.Unmarshal(wrapper.Options, &opts); err != nil {
+		return nil, err
+	}
+
+	return &opts, nil
+}
+
 // StripResumeFields removes session-specific fields (resume_session_id,
 // session_mode) from serialized ToolOptionsJSON so that a new session
 // inheriting another session's settings starts fresh instead of resuming

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -102,6 +102,9 @@ type UserConfig struct {
 	// Copilot defines GitHub Copilot CLI integration settings (Issue #556)
 	Copilot CopilotSettings `toml:"copilot"`
 
+	// Crush defines charmbracelet/crush CLI integration settings (Issue #940)
+	Crush CrushSettings `toml:"crush"`
+
 	// Worktree defines git worktree preferences
 	Worktree WorktreeSettings `toml:"worktree"`
 
@@ -837,6 +840,23 @@ type CopilotSettings struct {
 	// EnvFile is a .env file specific to Copilot sessions (sourced before
 	// the `copilot` command runs, like [gemini].env_file). Optional.
 	EnvFile string `toml:"env_file"`
+}
+
+// CrushSettings defines charmbracelet/crush CLI configuration (Issue #940).
+// Binary: `crush` from github.com/charmbracelet/crush. Interactive TUI.
+// Key flags: --yolo, --session/-s <id>, --continue/-C, --cwd, --debug.
+type CrushSettings struct {
+	// Command overrides the default binary/invocation for Crush sessions.
+	// Supports flags (e.g., "crush --debug"). Default: "crush"
+	Command string `toml:"command"`
+
+	// EnvFile is a .env file specific to Crush sessions (sourced before
+	// the `crush` command runs, like [gemini].env_file). Optional.
+	EnvFile string `toml:"env_file"`
+
+	// YoloMode enables --yolo flag for Crush sessions (auto-accept all
+	// permission prompts). Default: false
+	YoloMode bool `toml:"yolo_mode"`
 }
 
 // WorktreeSettings contains git worktree preferences.
@@ -1930,7 +1950,7 @@ func GetCustomToolNames() []string {
 
 func isBuiltinToolName(toolName string) bool {
 	switch toolName {
-	case "claude", "gemini", "opencode", "codex", "copilot", "pi", "shell", "cursor", "aider":
+	case "claude", "gemini", "opencode", "codex", "copilot", "crush", "pi", "shell", "cursor", "aider":
 		return true
 	default:
 		return false
@@ -1956,6 +1976,8 @@ func GetToolIcon(toolName string) string {
 		return "💻"
 	case "copilot":
 		return "🐙"
+	case "crush":
+		return "💘"
 	case "pi":
 		return "π"
 	case "cursor":

--- a/internal/tmux/crush_test.go
+++ b/internal/tmux/crush_test.go
@@ -1,0 +1,70 @@
+package tmux
+
+import "testing"
+
+// Issue #940: charmbracelet/crush — tmux-layer detection tests.
+
+func TestDetectToolFromCommand_Crush(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"bare crush", "crush", "crush"},
+		{"crush with yolo flag", "crush --yolo", "crush"},
+		{"crush absolute path", "/usr/local/bin/crush", "crush"},
+		{"crush home path", "/home/user/.local/bin/crush", "crush"},
+		{"uppercase binary", "CRUSH", "crush"},
+		{"crush with session arg", "crush --session abc123", "crush"},
+		{"crush continue", "crush --continue", "crush"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromCommand(tt.command); got != tt.want {
+				t.Fatalf("detectToolFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromCommand_Crush_Negative(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		// Truly unrelated strings — strings.Contains fallback is intentionally
+		// permissive (matches the copilot / hermes precedent), so we only
+		// guard against blatant false positives here.
+		{"empty", ""},
+		{"unrelated tool", "ls -la"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectToolFromCommand(tt.command)
+			if got == "crush" {
+				t.Fatalf("detectToolFromCommand(%q) = %q, should NOT match crush", tt.command, got)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromContent_Crush(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"charm crush banner", "Welcome to Charm Crush", "crush"},
+		{"crush prompt", "> what should I do? crush>", "crush"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromContent(tt.content); got != tt.want {
+				t.Fatalf("detectToolFromContent(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -537,7 +537,7 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "pi"}
+var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "pi"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"claude": {
@@ -564,6 +564,12 @@ var toolDetectionPatterns = map[string][]*regexp.Regexp{
 		regexp.MustCompile(`(?i)\bgithub\s+copilot\b`),
 		regexp.MustCompile(`(?i)\bcopilot\s+cli\b`),
 		regexp.MustCompile(`(?i)^copilot>\s*`),
+	},
+	"crush": {
+		// charmbracelet/crush — Charm's terminal-first AI assistant. Issue #940.
+		// Distinct phrases to avoid colliding with the English word "crush".
+		regexp.MustCompile(`(?i)\bcharm\s+crush\b`),
+		regexp.MustCompile(`(?i)\bcrush>\s*`),
 	},
 	"pi": {
 		regexp.MustCompile(`(?mi)^\s*pi>\s*`),
@@ -592,6 +598,8 @@ func detectToolFromCommand(command string) string {
 			return "codex"
 		case "copilot":
 			return "copilot"
+		case "crush":
+			return "crush"
 		case "pi":
 			return "pi"
 		}
@@ -608,6 +616,8 @@ func detectToolFromCommand(command string) string {
 		return "codex"
 	case strings.Contains(cmdLower, "copilot") || strings.Contains(cmdLower, "@github/copilot"):
 		return "copilot"
+	case strings.Contains(cmdLower, "crush"):
+		return "crush"
 	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
 		return "pi"
 	default:

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8368,6 +8368,8 @@ func createSessionTool(command string) (string, string) {
 		tool = "pi"
 	case "copilot":
 		tool = "copilot"
+	case "crush":
+		tool = "crush"
 	default:
 		if toolDef := session.GetToolDef(command); toolDef != nil {
 			tool = command

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -158,6 +158,16 @@ func TestCreateSessionTool_Copilot(t *testing.T) {
 	}
 }
 
+// TUI session creation must produce Tool="crush" rather than
+// Tool="shell" with Command="crush", matching the tmux/userconfig
+// wiring for the charmbracelet/crush integration (Issue #940).
+func TestCreateSessionTool_Crush(t *testing.T) {
+	tool, command := createSessionTool("crush")
+	if tool != "crush" || command != "crush" {
+		t.Fatalf("createSessionTool(\"crush\") = (%q, %q), want (\"crush\", \"crush\")", tool, command)
+	}
+}
+
 func TestHomeInit(t *testing.T) {
 	home := NewHome()
 	cmd := home.Init()

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -236,7 +236,7 @@ type dialogSnapshot struct {
 // buildPresetCommands returns the list of commands for the picker,
 // including any custom tools from config.toml.
 func buildPresetCommands() []string {
-	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot"}
+	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -256,8 +256,8 @@ func TestRenderLaunchModelInfoLines_ShowsModelAndVersion(t *testing.T) {
 func TestDialogPresetCommands(t *testing.T) {
 	d := NewNewDialog()
 
-	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot
-	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot"}
+	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, crush
+	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush"}
 
 	if len(d.presetCommands) != len(expectedCommands) {
 		t.Errorf("Expected %d preset commands, got %d", len(expectedCommands), len(d.presetCommands))

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -107,8 +107,8 @@ type SettingsPanel struct {
 // builtinToolNames and builtinToolValues are the built-in tools. Custom tools
 // from config are appended dynamically in LoadConfig.
 var (
-	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi"}
-	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi"}
+	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Crush"}
+	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "crush"}
 )
 
 // Search tier names for radio selection
@@ -323,7 +323,8 @@ func (s *SettingsPanel) buildToolLists(config *session.UserConfig) {
 	if len(config.Tools) > 0 {
 		builtins := map[string]bool{
 			"claude": true, "gemini": true, "opencode": true,
-			"codex": true, "pi": true, "shell": true, "cursor": true, "aider": true,
+			"codex": true, "pi": true, "crush": true, "copilot": true,
+			"shell": true, "cursor": true, "aider": true,
 		}
 		var custom []string
 		for name := range config.Tools {

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -165,8 +165,9 @@ func TestSettingsPanel_LoadConfig_DefaultTool(t *testing.T) {
 		{"opencode", "opencode", 2},
 		{"codex", "codex", 3},
 		{"pi", "pi", 4},
-		{"empty", "", 5}, // None
-		{"unknown", "unknown-tool", 5},
+		{"crush", "crush", 5},
+		{"empty", "", 6}, // None
+		{"unknown", "unknown-tool", 6},
 	}
 
 	for _, tt := range tests {
@@ -197,8 +198,8 @@ func TestSettingsPanel_LoadConfig_CustomTools(t *testing.T) {
 
 	panel.LoadConfig(config)
 
-	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Openclaw", "Zeta", "None"}
-	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "openclaw", "zeta", ""}
+	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Crush", "Openclaw", "Zeta", "None"}
+	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "crush", "openclaw", "zeta", ""}
 
 	if !reflect.DeepEqual(panel.toolNames, wantNames) {
 		t.Fatalf("toolNames = %#v, want %#v", panel.toolNames, wantNames)
@@ -206,8 +207,8 @@ func TestSettingsPanel_LoadConfig_CustomTools(t *testing.T) {
 	if !reflect.DeepEqual(panel.toolValues, wantValues) {
 		t.Fatalf("toolValues = %#v, want %#v", panel.toolValues, wantValues)
 	}
-	if panel.selectedTool != 5 {
-		t.Fatalf("selectedTool = %d, want 5 for openclaw", panel.selectedTool)
+	if panel.selectedTool != 6 {
+		t.Fatalf("selectedTool = %d, want 6 for openclaw", panel.selectedTool)
 	}
 }
 
@@ -355,7 +356,8 @@ func TestSettingsPanel_GetConfig_ToolMapping(t *testing.T) {
 		{"opencode", 2, "opencode"},
 		{"codex", 3, "codex"},
 		{"pi", 4, "pi"},
-		{"none", 5, ""},
+		{"crush", 5, "crush"},
+		{"none", 6, ""},
 	}
 
 	for _, tt := range tests {
@@ -378,7 +380,7 @@ func TestSettingsPanel_GetConfig_CustomToolMapping(t *testing.T) {
 		},
 	})
 
-	panel.selectedTool = 5
+	panel.selectedTool = 6
 	config := panel.GetConfig()
 	if config.DefaultTool != "openclaw" {
 		t.Fatalf("DefaultTool: got %q, want %q", config.DefaultTool, "openclaw")

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -54,7 +54,7 @@ func NewSetupWizard() *SetupWizard {
 		visible:             false,
 		complete:            false,
 		currentStep:         0,
-		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell"},
+		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "crush", "shell"},
 		selectedTool:        0, // Default to Claude
 		dangerousMode:       false,
 		useDefaultConfigDir: true,
@@ -392,6 +392,7 @@ func (w *SetupWizard) View() string {
 			"opencode": "OpenCode - Open source AI coding tool",
 			"codex":    "Codex CLI - OpenAI's coding assistant",
 			"pi":       "Pi CLI - lightweight coding assistant",
+			"crush":    "Crush - Charm's terminal-first AI coding assistant",
 			"shell":    "Shell - No AI tool (plain terminal)",
 		}
 

--- a/internal/ui/setup_wizard_test.go
+++ b/internal/ui/setup_wizard_test.go
@@ -140,7 +140,7 @@ func TestSetupWizard_ToolOptions(t *testing.T) {
 	wizard := NewSetupWizard()
 
 	// Verify tool options
-	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell"}
+	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "crush", "shell"}
 	if len(wizard.toolOptions) != len(expectedTools) {
 		t.Errorf("Tool options count: got %d, want %d", len(wizard.toolOptions), len(expectedTools))
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -526,6 +526,7 @@ func initStyles() {
 		"cursor":   lipgloss.NewStyle().Foreground(ColorAccent),
 		"shell":    lipgloss.NewStyle().Foreground(ColorText),
 		"opencode": lipgloss.NewStyle().Foreground(ColorText),
+		"crush":    lipgloss.NewStyle().Foreground(ColorPurple),
 	}
 
 	// DefaultToolStyle
@@ -599,6 +600,8 @@ func ToolIcon(tool string) string {
 		return IconOpenCode
 	case "codex":
 		return IconCodex
+	case "crush":
+		return "💘"
 	case "pi":
 		return IconPi
 	case "cursor":
@@ -620,6 +623,8 @@ func ToolColor(tool string) lipgloss.Color {
 		return ColorPurple // Google AI purple
 	case "codex":
 		return ColorCyan // Light blue for OpenAI
+	case "crush":
+		return ColorPurple // Pink/magenta for Charm Crush
 	case "pi":
 		return ColorAccent
 	case "aider":


### PR DESCRIPTION
## Summary

Adds first-class support for [`charmbracelet/crush`](https://github.com/charmbracelet/crush) as the 7th builtin agent in agent-deck. Closes [#940](https://github.com/asheshgoplani/agent-deck/issues/940).

The adapter is wired parallel to the existing `copilot` adapter on `main` — same surface count, same shape, no shared-infrastructure refactor. Once PR #951 (Hermes + uniform `[tool].command`) merges, the `[crush].command` field already declared here will be picked up by the new `GetToolCommand` helper without further churn.

## What ships

**Data model**

- `CrushSettings` (`[crush]` TOML section: `command`, `env_file`, `yolo_mode`)
- `CrushOptions` (per-session JSON: `yolo_mode`, `resume_session_id`, `continue_last`)

**Launch path**

- `buildCrushCommand` in `internal/session/crush.go` — env-source prefix + bare-name resolve + flag injection + passthrough for custom CLI commands
- Dispatch added in `Instance.Start` and `Instance.Restart`

**Detection**

- `cmd/agent-deck/main.go` — CLI `detectTool("crush")` so `agent-deck add -c crush .` produces `Tool="crush"` (not the `"shell"` fallback)
- `internal/tmux/tmux.go` — basename + substring matchers and content patterns (`charm crush`, `crush>`)

**UI surfaces (preset rows, icons, colors)**

- New-session dialog preset list
- Setup wizard tool options + description
- Settings panel builtin selector
- `home.createSessionTool`
- `ui/styles.go` — icon 💘, color magenta (purple in the palette)

**Tests**

- `internal/session/crush_test.go` — options round-trip, `NewCrushOptions` factory, builtin-vs-custom gate, icon, `buildCrushCommand` (bare / yolo / override / passthrough / wrong-tool / env_file)
- `internal/tmux/crush_test.go` — `detectToolFromCommand` (bare, paths, uppercase, flags, negatives) + `detectToolFromContent`
- `cmd/agent-deck/crush_detect_test.go` — CLI-layer `detectTool`
- Existing `home_test`, `newdialog_test`, `settings_panel_test`, `setup_wizard_test` updated to include the new crush row

All affected packages green with `go test -race ./internal/session/ ./internal/tmux/ ./cmd/agent-deck/ ./internal/ui/`. `go vet ./...` clean.

## crush CLI shape used

```
crush                   # interactive TUI (default)
crush --yolo            # auto-accept all permission prompts
crush --session <id>    # resume a specific session
crush --continue        # resume the most recent session
```

## Example config

```toml
[crush]
command = "crush --debug"
env_file = "~/.crush.env"
yolo_mode = false
```

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/session/ ./internal/tmux/ ./cmd/agent-deck/ ./internal/ui/`
- [x] `go vet ./...`
- [ ] Manual: `agent-deck add -t crush-demo -c crush /tmp/demo && agent-deck session start crush-demo` (requires `crush` binary on PATH)
- [ ] Manual: confirm icon 💘 renders in TUI session list and selector

## Notes

- Does **not** conflict with PR #951 (Hermes). #951 introduces a shared `GetToolCommand` helper and refactors how `[tool].command` is resolved; this PR only adds a new tool through the existing per-adapter pattern, so the two PRs touch different code paths in the overlapping files. Rebase on #951 once it lands is a trivial 5-line edit.
- Status detection is process-alive/dead today; content-sniffing patterns are wired but conservative and can be tightened once Crush's TUI strings stabilise.
- No release worker / pipeline changes.