### PR TITLE
feat(fork): --with-state flag preserves parent WIP into worktree (closes #1029)

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -605,6 +605,8 @@ func handleSessionFork(profile string, args []string) {
 	worktreeBranchLong := fs.String("worktree", "", "Create fork in git worktree for branch")
 	newBranch := fs.Bool("b", false, "Create new branch (use with --worktree)")
 	newBranchLong := fs.Bool("new-branch", false, "Create new branch")
+	withState := fs.Bool("with-state", false, "Copy parent's staged+unstaged+untracked files into the new worktree (#1029, requires -w)")
+	withStateGitignored := fs.Bool("with-state-and-gitignored", false, "Like --with-state, plus gitignored files (e.g. .env). Implies --with-state. Requires -w.")
 	sandbox := fs.Bool("sandbox", false, "Run forked session in Docker sandbox")
 	sandboxImage := fs.String("sandbox-image", "", "Docker image for sandbox (overrides config default)")
 
@@ -622,6 +624,8 @@ func handleSessionFork(profile string, args []string) {
 		fmt.Println("  agent-deck session fork my-project -t \"my-fork\" -g \"experiments\"")
 		fmt.Println("  agent-deck session fork my-project -w fork/experiment")
 		fmt.Println("  agent-deck session fork my-project -w fork/new-idea -b")
+		fmt.Println("  agent-deck session fork my-project -w fork/wip -b --with-state")
+		fmt.Println("  agent-deck session fork my-project -w fork/wip -b --with-state-and-gitignored")
 	}
 
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
@@ -694,6 +698,13 @@ func handleSessionFork(profile string, args []string) {
 	}
 	createNewBranch := *newBranch || *newBranchLong
 
+	// #1029: --with-state-and-gitignored implies --with-state.
+	wantState := *withState || *withStateGitignored
+	if wantState && wtBranch == "" {
+		out.Error("--with-state requires an explicit worktree branch (-w/--worktree)", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
 	// Handle worktree creation
 	var opts *session.ClaudeOptions
 	if wtBranch != "" {
@@ -739,7 +750,10 @@ func handleSessionFork(profile string, args []string) {
 				os.Exit(1)
 			}
 
-			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+			setupErr, err := git.CreateWorktreeWithStateAndSetup(
+				repoRoot, worktreePath, wtBranch,
+				git.WorktreeStateOptions{WithState: wantState, WithIgnored: *withStateGitignored},
+				os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
 			if err != nil {
 				out.Error(fmt.Sprintf("worktree creation failed: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)

--- a/internal/git/issue1029_edge_test.go
+++ b/internal/git/issue1029_edge_test.go
@@ -1,0 +1,233 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCreateWorktreeWithStateAndSetup_WiresMaterialization_RegressionFor1029
+// pins the integration shape: when WithState is true, the wrapper creates a
+// fresh worktree AND materializes parent WIP before returning, so the (later)
+// setup hook would observe a realized working tree.
+func TestCreateWorktreeWithStateAndSetup_WiresMaterialization_RegressionFor1029(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	if err := os.WriteFile(filepath.Join(parent, "wip.txt"), []byte("hello-wip\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	child := filepath.Join(t.TempDir(), "child-wired")
+	var stdout, stderr bytes.Buffer
+	_, err := CreateWorktreeWithStateAndSetup(
+		parent, child, "fork-1029-wired",
+		WorktreeStateOptions{WithState: true},
+		&stdout, &stderr, 0,
+	)
+	if err != nil {
+		t.Fatalf("CreateWorktreeWithStateAndSetup: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(child, "wip.txt"))
+	if err != nil {
+		t.Fatalf("read child wip.txt: %v", err)
+	}
+	if string(got) != "hello-wip\n" {
+		t.Fatalf("wip not materialized; got %q", got)
+	}
+}
+
+// TestMaterializeWipFromParent_Empty_NoOp_RegressionFor1029 ensures a clean
+// parent (no WIP) produces a clean child with no error — the boundary case
+// where every diff is empty and ls-files returns nothing.
+func TestMaterializeWipFromParent_Empty_NoOp_RegressionFor1029(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-1029-empty"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	if err := MaterializeWipFromParent(parent, child, false); err != nil {
+		t.Fatalf("MaterializeWipFromParent on clean parent: %v", err)
+	}
+	if got := gitPorcelain(t, child); got != "" {
+		t.Fatalf("child should be clean; got %q", got)
+	}
+}
+
+// TestMaterializeWipFromParent_BinaryFile_RegressionFor1029 — binary blobs
+// must round-trip byte-identically. The PNG magic header + a random byte
+// payload is enough to exercise the `--binary` path through git diff/apply.
+func TestMaterializeWipFromParent_BinaryFile_RegressionFor1029(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	bin := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff, 0x7f, 0x10}
+	if err := os.WriteFile(filepath.Join(parent, "blob.bin"), bin, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitMustRun(t, parent, "add", "blob.bin") // staged-add
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-1029-bin"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	if err := MaterializeWipFromParent(parent, child, false); err != nil {
+		t.Fatalf("MaterializeWipFromParent: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(child, "blob.bin"))
+	if err != nil {
+		t.Fatalf("read child blob.bin: %v", err)
+	}
+	if string(got) != string(bin) {
+		t.Fatalf("binary content drift.\nwant: % x\ngot:  % x", bin, got)
+	}
+}
+
+// TestMaterializeWipFromParent_Symlink_RegressionFor1029 — an untracked
+// symlink in parent must appear as a symlink in child with the same target.
+func TestMaterializeWipFromParent_Symlink_RegressionFor1029(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	if err := os.Symlink("README.md", filepath.Join(parent, "link.md")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-1029-link"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	if err := MaterializeWipFromParent(parent, child, false); err != nil {
+		t.Fatalf("MaterializeWipFromParent: %v", err)
+	}
+
+	info, err := os.Lstat(filepath.Join(child, "link.md"))
+	if err != nil {
+		t.Fatalf("lstat child link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected symlink, got mode %v", info.Mode())
+	}
+	target, err := os.Readlink(filepath.Join(child, "link.md"))
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if target != "README.md" {
+		t.Fatalf("symlink target drift: want README.md, got %s", target)
+	}
+}
+
+// TestMaterializeWipFromParent_IgnoredOptIn_RegressionFor1029 — gitignored
+// files must be skipped by default and copied only when includeIgnored=true.
+// This matches the `--with-state-and-gitignored` opt-in from #1029.
+func TestMaterializeWipFromParent_IgnoredOptIn_RegressionFor1029(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	// Establish .gitignore so secrets.env is ignored.
+	if err := os.WriteFile(filepath.Join(parent, ".gitignore"), []byte("secrets.env\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitMustRun(t, parent, "add", ".gitignore")
+	gitMustRun(t, parent, "commit", "-m", "ignore secrets")
+
+	if err := os.WriteFile(filepath.Join(parent, "secrets.env"), []byte("API_KEY=xyz\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pass 1: without opt-in → child must NOT have the ignored file.
+	child1 := filepath.Join(t.TempDir(), "child1")
+	if err := CreateWorktree(parent, child1, "fork-1029-ign1"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	if err := MaterializeWipFromParent(parent, child1, false); err != nil {
+		t.Fatalf("MaterializeWipFromParent: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(child1, "secrets.env")); !os.IsNotExist(err) {
+		t.Fatalf("ignored file leaked without opt-in: %v", err)
+	}
+
+	// Pass 2: with opt-in → child must have the ignored file with same content.
+	child2 := filepath.Join(t.TempDir(), "child2")
+	if err := CreateWorktree(parent, child2, "fork-1029-ign2"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	if err := MaterializeWipFromParent(parent, child2, true); err != nil {
+		t.Fatalf("MaterializeWipFromParent (with ignored): %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(child2, "secrets.env"))
+	if err != nil {
+		t.Fatalf("ignored file missing with opt-in: %v", err)
+	}
+	if string(got) != "API_KEY=xyz\n" {
+		t.Fatalf("ignored content drift: %q", got)
+	}
+}
+
+// TestMaterializeWipFromParent_RefusesMidMerge_RegressionFor1029 — @smorin's
+// spec requires unsafe in-flight states to be refused with an actionable
+// error rather than silently materialized over the top of a half-done merge.
+func TestMaterializeWipFromParent_RefusesMidMerge_RegressionFor1029(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	// Fake a mid-merge by dropping MERGE_HEAD into the gitdir.
+	gitDir := filepath.Join(parent, ".git")
+	if err := os.WriteFile(filepath.Join(gitDir, "MERGE_HEAD"), []byte("deadbeef\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-1029-merge"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	err := MaterializeWipFromParent(parent, child, false)
+	if err == nil {
+		t.Fatal("expected refusal during mid-merge, got nil")
+	}
+	if !strings.Contains(err.Error(), "merge") {
+		t.Fatalf("expected error to mention 'merge'; got: %v", err)
+	}
+}
+
+// TestMaterializeWipFromParent_DeletedFile_RegressionFor1029 — a tracked file
+// removed in parent's working tree must also be absent (in the same state)
+// in the child.
+func TestMaterializeWipFromParent_DeletedFile_RegressionFor1029(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	// Add a file, commit it, then remove it (unstaged delete).
+	if err := os.WriteFile(filepath.Join(parent, "doomed.txt"), []byte("bye\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitMustRun(t, parent, "add", "doomed.txt")
+	gitMustRun(t, parent, "commit", "-m", "add doomed")
+	if err := os.Remove(filepath.Join(parent, "doomed.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-1029-del"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	if err := MaterializeWipFromParent(parent, child, false); err != nil {
+		t.Fatalf("MaterializeWipFromParent: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(child, "doomed.txt")); !os.IsNotExist(err) {
+		t.Fatalf("deleted-in-parent file present in child: %v", err)
+	}
+	want := gitPorcelain(t, parent)
+	got := gitPorcelain(t, child)
+	if want != got {
+		t.Fatalf("status mismatch.\nparent:\n%s\nchild:\n%s", want, got)
+	}
+}

--- a/internal/git/issue1029_with_state_test.go
+++ b/internal/git/issue1029_with_state_test.go
@@ -1,0 +1,133 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestMaterializeWipFromParent_CopiesStagedUnstagedUntracked_RegressionFor1029
+// is the RED test for issue #1029. @smorin asked for a third fork mode that
+// copies the parent session's full working state — staged + unstaged + untracked
+// (+ optionally gitignored) — into a fresh worktree, so users can explore
+// multiple agent paths in parallel from the exact same WIP without stash
+// juggling or shared-path races.
+//
+// The hard contract from the issue:
+//   1. Parent checkout MUST remain read-only (no stash push, no add, no index
+//      mutation) — verified separately below.
+//   2. Child's `git status --porcelain` must match parent's at materialization
+//      time, with staged/unstaged/untracked faithfully reproduced.
+//   3. Gitignored files only with explicit opt-in (separate test).
+//
+// The minimum failing assertion: a parent repo with one staged file, one
+// unstaged edit, and one untracked file produces a child worktree whose
+// `git status --porcelain` is byte-identical (sorted) to the parent's.
+func TestMaterializeWipFromParent_CopiesStagedUnstagedUntracked_RegressionFor1029(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	// Set up parent WIP: one staged add, one unstaged edit, one untracked.
+	writeWipFile(t, parent, "staged.txt", "staged content\n")
+	gitMustRun(t, parent, "add", "staged.txt")
+
+	appendWipFile(t, parent, "README.md", "\nunstaged edit\n")
+
+	writeWipFile(t, parent, "untracked.txt", "untracked content\n")
+
+	parentStatusBefore := gitPorcelain(t, parent)
+
+	// Create child worktree from parent's HEAD on a fresh branch.
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-1029"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	// ACTION under test.
+	if err := MaterializeWipFromParent(parent, child, false /* includeIgnored */); err != nil {
+		t.Fatalf("MaterializeWipFromParent: %v", err)
+	}
+
+	parentStatusAfter := gitPorcelain(t, parent)
+	if parentStatusAfter != parentStatusBefore {
+		t.Fatalf("parent state MUST remain read-only.\nbefore:\n%s\nafter:\n%s",
+			parentStatusBefore, parentStatusAfter)
+	}
+
+	childStatus := gitPorcelain(t, child)
+	if childStatus != parentStatusBefore {
+		t.Fatalf("child status must mirror parent WIP.\nparent:\n%s\nchild:\n%s",
+			parentStatusBefore, childStatus)
+	}
+
+	// And the file contents must actually be there.
+	mustHaveWipFile(t, child, "staged.txt", "staged content\n")
+	mustHaveWipFile(t, child, "untracked.txt", "untracked content\n")
+	if got := readWipFile(t, child, "README.md"); !strings.Contains(got, "unstaged edit") {
+		t.Fatalf("child README.md missing unstaged edit; got %q", got)
+	}
+}
+
+func writeWipFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func appendWipFile(t *testing.T, dir, rel, suffix string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	f, err := os.OpenFile(full, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(suffix); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readWipFile(t *testing.T, dir, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(b)
+}
+
+func mustHaveWipFile(t *testing.T, dir, rel, want string) {
+	t.Helper()
+	if got := readWipFile(t, dir, rel); got != want {
+		t.Fatalf("%s content mismatch.\nwant: %q\ngot:  %q", rel, want, got)
+	}
+}
+
+func gitMustRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, string(out))
+	}
+}
+
+func gitPorcelain(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", dir, "status", "--porcelain")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	// Sort lines so we compare set-equality, not git's enumeration order.
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}

--- a/internal/git/materialize_wip.go
+++ b/internal/git/materialize_wip.go
@@ -1,0 +1,224 @@
+package git
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// MaterializeWipFromParent copies the working-tree state of parentDir (staged
+// changes, unstaged edits, and untracked files) into childDir, which must be a
+// freshly-created worktree pointing at parentDir's HEAD. When includeIgnored
+// is true, gitignored files are also copied.
+//
+// Contract:
+//   - parentDir is treated read-only — no stash push, no add, no index mutation.
+//   - childDir's `git status --porcelain` becomes equal to parentDir's
+//     `git status --porcelain` after this call.
+//   - Refuses to run when parent is in mid-rebase / merge / cherry-pick /
+//     revert / bisect.
+//
+// Implements issue #1029 (--with-state / --with-state-and-gitignored).
+func MaterializeWipFromParent(parentDir, childDir string, includeIgnored bool) error {
+	if err := refuseUnsafeParentState(parentDir); err != nil {
+		return err
+	}
+
+	// 1. Apply parent's STAGED diff (vs HEAD) into child's index + working tree.
+	if err := applyDiffFromParent(parentDir, childDir, true /* cached */); err != nil {
+		return fmt.Errorf("materialize staged: %w", err)
+	}
+
+	// 2. Apply parent's UNSTAGED diff (working tree vs index) into child's
+	//    working tree only.
+	if err := applyDiffFromParent(parentDir, childDir, false /* cached */); err != nil {
+		return fmt.Errorf("materialize unstaged: %w", err)
+	}
+
+	// 3. Copy untracked files (and gitignored on opt-in).
+	if err := copyUntrackedFromParent(parentDir, childDir, includeIgnored); err != nil {
+		return fmt.Errorf("materialize untracked: %w", err)
+	}
+
+	return nil
+}
+
+// refuseUnsafeParentState returns a non-nil error if parentDir is in the middle
+// of a rebase, merge, cherry-pick, revert, or bisect. The presence of any of
+// these state files means materializing WIP could conflict with the in-flight
+// operation.
+func refuseUnsafeParentState(parentDir string) error {
+	gitDir, err := gitDirOf(parentDir)
+	if err != nil {
+		return err
+	}
+	checks := []struct {
+		path string
+		kind string
+	}{
+		{filepath.Join(gitDir, "MERGE_HEAD"), "merge"},
+		{filepath.Join(gitDir, "CHERRY_PICK_HEAD"), "cherry-pick"},
+		{filepath.Join(gitDir, "REVERT_HEAD"), "revert"},
+		{filepath.Join(gitDir, "BISECT_LOG"), "bisect"},
+		{filepath.Join(gitDir, "rebase-merge"), "rebase"},
+		{filepath.Join(gitDir, "rebase-apply"), "rebase"},
+	}
+	for _, c := range checks {
+		if _, err := os.Stat(c.path); err == nil {
+			return fmt.Errorf("parent is in mid-%s; resolve it before forking with --with-state", c.kind)
+		}
+	}
+	return nil
+}
+
+func gitDirOf(dir string) (string, error) {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "--git-dir")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("rev-parse --git-dir: %w", err)
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(dir, gitDir)
+	}
+	return gitDir, nil
+}
+
+// applyDiffFromParent runs `git diff [--cached] --binary` in parentDir, pipes
+// it through `git apply [--cached --index | --3way]` in childDir. An empty
+// diff is a no-op.
+func applyDiffFromParent(parentDir, childDir string, cached bool) error {
+	diffArgs := []string{"-C", parentDir, "diff", "--binary", "--no-color"}
+	if cached {
+		diffArgs = append(diffArgs, "--cached")
+	}
+	diffCmd := exec.Command("git", diffArgs...)
+	var stdout, stderr bytes.Buffer
+	diffCmd.Stdout = &stdout
+	diffCmd.Stderr = &stderr
+	if err := diffCmd.Run(); err != nil {
+		return fmt.Errorf("git diff: %w: %s", err, stderr.String())
+	}
+	if stdout.Len() == 0 {
+		return nil
+	}
+
+	applyArgs := []string{"-C", childDir, "apply", "--binary"}
+	if cached {
+		// --index (without --cached) writes both index and working tree, so
+		// the staged file content ends up in both — which is what makes
+		// `git status` show `A  file` (staged-added) instead of `AD file`
+		// (staged-added, deleted in working tree).
+		applyArgs = append(applyArgs, "--index")
+	}
+	applyCmd := exec.Command("git", applyArgs...)
+	applyCmd.Stdin = &stdout
+	var applyErr bytes.Buffer
+	applyCmd.Stderr = &applyErr
+	if err := applyCmd.Run(); err != nil {
+		return fmt.Errorf("git apply: %w: %s", err, applyErr.String())
+	}
+	return nil
+}
+
+// copyUntrackedFromParent enumerates parent's untracked (and optionally
+// gitignored) files and copies them to childDir, preserving file mode and
+// symlink target.
+func copyUntrackedFromParent(parentDir, childDir string, includeIgnored bool) error {
+	lsArgs := []string{"-C", parentDir, "ls-files", "--others", "-z", "--exclude-standard"}
+	if includeIgnored {
+		// --ignored alone with --exclude-standard lists only ignored entries;
+		// to capture *both* non-ignored untracked AND ignored, we run two
+		// passes and union them — `--ignored` flips the filter, it doesn't
+		// add to it.
+		nonIgnored, err := runListZ(lsArgs...)
+		if err != nil {
+			return err
+		}
+		ignored, err := runListZ("-C", parentDir, "ls-files", "--others", "-z",
+			"--ignored", "--exclude-standard")
+		if err != nil {
+			return err
+		}
+		return copyEachFile(parentDir, childDir, append(nonIgnored, ignored...))
+	}
+	files, err := runListZ(lsArgs...)
+	if err != nil {
+		return err
+	}
+	return copyEachFile(parentDir, childDir, files)
+}
+
+func runListZ(args ...string) ([]string, error) {
+	cmd := exec.Command("git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("git ls-files: %s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, err
+	}
+	raw := strings.TrimRight(string(out), "\x00")
+	if raw == "" {
+		return nil, nil
+	}
+	return strings.Split(raw, "\x00"), nil
+}
+
+func copyEachFile(srcDir, dstDir string, rels []string) error {
+	for _, rel := range rels {
+		if rel == "" {
+			continue
+		}
+		src := filepath.Join(srcDir, rel)
+		dst := filepath.Join(dstDir, rel)
+		if err := copyOneFile(src, dst); err != nil {
+			return fmt.Errorf("copy %s: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+func copyOneFile(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(src)
+		if err != nil {
+			return err
+		}
+		// Replace any existing entry — child is fresh, but be defensive.
+		_ = os.Remove(dst)
+		return os.Symlink(target, dst)
+	}
+	if info.IsDir() {
+		// `git ls-files --others` doesn't emit directories directly, but
+		// untracked submodules can appear. Skip safely.
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/internal/git/setup.go
+++ b/internal/git/setup.go
@@ -98,8 +98,34 @@ func buildSetupCmd(ctx context.Context, scriptPath string, mode os.FileMode) *ex
 // users couldn't tell whether the script had run, finished, or finished
 // cleanly before claude started.
 func CreateWorktreeWithSetup(repoDir, worktreePath, branchName string, stdout, stderr io.Writer, setupTimeout time.Duration) (setupErr error, err error) {
+	return CreateWorktreeWithStateAndSetup(repoDir, worktreePath, branchName, WorktreeStateOptions{}, stdout, stderr, setupTimeout)
+}
+
+// WorktreeStateOptions controls the issue #1029 with-state behavior of
+// CreateWorktreeWithStateAndSetup. When WithState is false, the worktree is
+// created clean from branch tip — the legacy behavior.
+type WorktreeStateOptions struct {
+	// WithState copies parent's staged/unstaged/untracked files into the
+	// new worktree before the setup hook runs.
+	WithState bool
+	// WithIgnored, when WithState is true, also copies parent's gitignored
+	// files (e.g., .env, .mcp.json). Implies WithState.
+	WithIgnored bool
+}
+
+// CreateWorktreeWithStateAndSetup is CreateWorktreeWithSetup plus optional
+// materialization of the parent session's working-tree state (#1029).
+// Materialization happens BEFORE worktreeinclude processing and the setup
+// script so both observe the realized state, per @smorin's spec.
+func CreateWorktreeWithStateAndSetup(repoDir, worktreePath, branchName string, state WorktreeStateOptions, stdout, stderr io.Writer, setupTimeout time.Duration) (setupErr error, err error) {
 	if err = CreateWorktree(repoDir, worktreePath, branchName); err != nil {
 		return nil, err
+	}
+
+	if state.WithState {
+		if matErr := MaterializeWipFromParent(repoDir, worktreePath, state.WithIgnored); matErr != nil {
+			return nil, fmt.Errorf("materialize parent state: %w", matErr)
+		}
 	}
 
 	if inclErr := ProcessWorktreeInclude(repoDir, worktreePath, stderr); inclErr != nil {


### PR DESCRIPTION
Closes #1029.

## What

Adds a third fork mode — **`agent-deck session fork <session> -w <branch> --with-state`** — that carries the parent session's full working-tree state (staged + unstaged + untracked files) into the fresh worktree. A second flag **`--with-state-and-gitignored`** additionally copies gitignored files (e.g. `.env`, `.mcp.json`), and implies `--with-state`.

Filed by **@smorin** as the missing piece between the two existing fork modes: share-parent-path (race conditions) and clean-worktree-at-tip (loses WIP). With `--with-state` you can spin up multiple worktrees from the same in-flight state and explore divergent agent paths in parallel without stash juggling or temporary commits — agent-deck's home-court use case.

## How

A new `git.MaterializeWipFromParent(parentDir, childDir string, includeIgnored bool) error` runs three pure-read operations on the parent and applies the results into the freshly-created child worktree:

1. `git diff --cached --binary HEAD` → `git apply --binary --index` (staged → child index + working tree)
2. `git diff --binary` → `git apply --binary` (unstaged → child working tree)
3. `git ls-files --others [--ignored] --exclude-standard -z` → copy each file to child (untracked, plus gitignored on opt-in; symlinks preserved as symlinks)

A new `git.CreateWorktreeWithStateAndSetup` wraps the existing `CreateWorktreeWithSetup` and runs materialization **between** `CreateWorktree` and the setup hook (per @smorin's spec — setup script observes the realized working tree). `CreateWorktreeWithSetup` is now a thin shim around the new wrapper with empty `WorktreeStateOptions` — no behavior change for existing callers.

### Rejected alternatives

- **`git stash push` + apply** (PROMPT.md option 1): mutates parent state. The issue explicitly forbids this.
- **`git stash create` + apply**: `git stash create` is read-only but does NOT accept `--include-untracked` (the flag is silently consumed as the stash message — verified empirically). Cannot capture untracked files, so it doesn't meet the contract.
- **rsync + `.git/index` copy** (PROMPT.md option 2): per-worktree index lives at `.git/worktrees/<name>/index` and is HEAD-specific. Cross-worktree index copy is fragile (sparse-checkout state, mode bits). Diff+apply is the canonical git plumbing for this transfer.

## Edge cases covered

- **Empty WIP** → no-op, no error.
- **Binary files** → `--binary` flag handles them; PNG round-trip verified.
- **Symlinks** → copied as symlinks with same target.
- **Deleted-in-parent tracked files** → recorded as deletions in child (status mirrors parent).
- **Gitignored files** → skipped by default, copied only with `--with-state-and-gitignored`.
- **Unsafe parent states** → refused with actionable error: mid-rebase, mid-merge, mid-cherry-pick, mid-revert, mid-bisect.
- **Parent read-only invariant** → verified: parent's `git status --porcelain` is byte-identical before and after.

## Tests

Seven `_RegressionFor1029` tests in `internal/git/`:

- `TestMaterializeWipFromParent_CopiesStagedUnstagedUntracked_RegressionFor1029` — the canonical 3-way WIP fixture.
- `TestMaterializeWipFromParent_Empty_NoOp_RegressionFor1029`
- `TestMaterializeWipFromParent_BinaryFile_RegressionFor1029`
- `TestMaterializeWipFromParent_Symlink_RegressionFor1029`
- `TestMaterializeWipFromParent_IgnoredOptIn_RegressionFor1029`
- `TestMaterializeWipFromParent_RefusesMidMerge_RegressionFor1029`
- `TestMaterializeWipFromParent_DeletedFile_RegressionFor1029`
- `TestCreateWorktreeWithStateAndSetup_WiresMaterialization_RegressionFor1029` — wiring integration test.

Failing-test-first: the canonical test was written and observed to fail at runtime against an empty `MaterializeWipFromParent` stub before any real implementation existed.

`go test ./... -race` passes.

## Defaults

No change to default fork behavior. `--with-state` and `--with-state-and-gitignored` are strictly opt-in and both require explicit `-w/--worktree <branch>`.

## Not yet wired (deliberately out of scope)

- TUI nested checkboxes from the issue body (the CLI surface is the load-bearing contract for #1029; TUI can ride on top once the materialization helper is in place).

Committed by Ashesh Goplani