### PR TITLE
fix(launch): parallel-safe persistence + return session ID (closes #1031)

### DIFF
--- a/cmd/agent-deck/issue1031_launch_race_test.go
+++ b/cmd/agent-deck/issue1031_launch_race_test.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// CLI-level regression tests for issue #1031.
+//
+// Bug: When N `agent-deck launch` invocations fire concurrently (same loop
+// tick, same profile), only N-1 of the N requested sessions persist to the
+// SQLite state DB. All N return exit 0, all N worktrees/tmux sessions are
+// created — only the database row silently goes missing.
+//
+// This is the same load-modify-write SQLite race as #961 (`agent-deck rm`)
+// fixed in v1.9.1 via #909 / #993:
+//
+//   - Each launch's `SaveWithGroups` does load → append → rewrite of the
+//     full instances table inside SaveInstances, which performs
+//     `DELETE FROM instances WHERE id NOT IN (...)` over the slice the
+//     caller loaded — including any rows another launch wrote *after*
+//     this caller's load. That sibling row is silently DELETE'd.
+//
+// The structural fix mirrors RemoveSessionAndVerify: a new
+// InsertSessionAndVerify path that does a targeted single-row INSERT OR
+// REPLACE via SaveInstance + verify-with-backoff, *without* the
+// load-modify-write rewrite. The launch CLI also gains a deterministic
+// way to return the new session ID to its caller so the conductor's
+// fleet-spawning loop no longer has to diff `list --json` before/after
+// (the diff itself was unsafe under this race).
+//
+// Coverage shape mirrors issue961_rm_safety_test.go: real CLI subprocesses
+// each own an independent *sql.DB pool, which is the exact contention
+// pattern `xargs -P N agent-deck launch` exercises in production. A future
+// refactor that downgrades the launch persistence path back to the
+// pre-fix SaveWithGroups load-modify-write would re-open the silent-loss
+// window; this test catches it at the user-facing CLI surface.
+
+// TestAgentDeckLaunch_ParallelSafe_AllSessionsPersist_RegressionFor1031 spawns
+// N concurrent `agent-deck launch` subprocesses against a shared HOME
+// (= shared state.db). Pre-fix, the load-modify-write race in
+// SaveWithGroups silently dropped ~1/5 rows even though every CLI printed
+// success + exit 0. Post-fix, all N rows must be persisted.
+func TestAgentDeckLaunch_ParallelSafe_AllSessionsPersist_RegressionFor1031(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not on PATH; launch CLI needs a real tmux server")
+	}
+
+	home := t.TempDir()
+	socket := uniqueTmuxSocketName1031(t)
+	t.Cleanup(func() {
+		// Kill the isolated tmux server so we don't leak panes onto the
+		// developer's main tmux socket. Best-effort: the server is
+		// process-local to this test and dies with the user anyway.
+		_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	})
+
+	const N = 5
+	titles := make([]string, N)
+	projDirs := make([]string, N)
+	for i := 0; i < N; i++ {
+		titles[i] = fmt.Sprintf("launch-race-cli-%02d", i)
+		projDirs[i] = filepath.Join(home, fmt.Sprintf("proj-%02d", i))
+		if err := os.MkdirAll(projDirs[i], 0o755); err != nil {
+			t.Fatalf("mkdir proj %d: %v", i, err)
+		}
+	}
+
+	// Pre-create the profile + state.db by running one no-op CLI before
+	// the parallel burst. The bug report's repro shape is "same loop
+	// tick, same profile" — the profile already exists in production.
+	// Without this seed, the 5 parallel CLIs each race to create the
+	// state.db file and run the SQLite WAL setup, which fails with
+	// SQLITE_BUSY on cold-start (a different, pre-existing bug that
+	// would otherwise mask the #1031 race we're pinning here).
+	if _, _, code := runAgentDeck(t, home, "list", "--json"); code != 0 {
+		// `list` against an empty profile prints "No sessions found"
+		// and exits 0. Anything else means the seed itself broke.
+		t.Fatalf("seed `agent-deck list` failed with exit %d", code)
+	}
+
+	bin := channelsCLIBinary(t)
+	type result struct {
+		title  string
+		exit   int
+		stdout string
+		stderr string
+		runErr error
+	}
+	results := make([]result, N)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			// No `-c <tool>` — launch defaults Tool to "shell", which Start()
+			// implements as `tmux new-session <shell>`. The race we're
+			// pinning lives in SaveWithGroups *before* the spawn step, so
+			// the tool choice doesn't matter — we just need a launch path
+			// that doesn't require claude/codex installed in CI.
+			cmd := exec.Command(bin, "launch",
+				"-t", titles[i],
+				"--no-parent",
+				"--tmux-socket", socket,
+				"--json",
+				projDirs[i],
+			)
+			cmd.Env = cliEnvForIssue1031(home)
+			var outBuf, errBuf strings.Builder
+			cmd.Stdout = &outBuf
+			cmd.Stderr = &errBuf
+			err := cmd.Run()
+			r := result{title: titles[i], stdout: outBuf.String(), stderr: errBuf.String()}
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				r.exit = exitErr.ExitCode()
+			} else if err != nil {
+				r.runErr = err
+			}
+			results[i] = r
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	// Every launch must report success at the exit-code layer. The pre-fix
+	// failure mode is "exit 0 + success message + row missing from DB" —
+	// exit 0 alone is not enough; we re-check the registry below.
+	for _, r := range results {
+		if r.runErr != nil {
+			t.Fatalf("launch %q: run error: %v\nstdout: %s\nstderr: %s", r.title, r.runErr, r.stdout, r.stderr)
+		}
+		if r.exit != 0 {
+			t.Fatalf("launch %q: exit %d\nstdout: %s\nstderr: %s", r.title, r.exit, r.stdout, r.stderr)
+		}
+	}
+
+	// Independent read: every row must be present. This is the assertion
+	// the pre-fix path silently violates.
+	after := readSessionsJSON(t, home)
+	var listed []map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(after)), &listed); err != nil {
+		if !strings.Contains(after, "No sessions found") {
+			t.Fatalf("parse list --json: %v\noutput: %s", err, after)
+		}
+		listed = nil
+	}
+
+	seen := make(map[string]bool, N)
+	for _, row := range listed {
+		title, _ := row["title"].(string)
+		seen[title] = true
+	}
+
+	missing := make([]string, 0, N)
+	for _, want := range titles {
+		if !seen[want] {
+			missing = append(missing, want)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf(
+			"expected all %d launched sessions persisted, %d silently dropped: %v\n"+
+				"persisted titles: %d / %d\nfull list:\n%s",
+			N, len(missing), missing, len(seen), N, after,
+		)
+	}
+}
+
+// TestAgentDeckLaunch_ReturnsSessionID_RegressionFor1031 pins the second
+// half of the #1031 fix: a single `agent-deck launch` must surface the
+// new session's stable ID on stdout, so callers (the conductor's
+// fleet-spawning loop, shell scripts, downstream automation) can capture
+// it deterministically without the unsafe `agent-deck list --json` diff.
+//
+// The bug report calls this out explicitly:
+//
+//	"agent-deck launch --json printing {sessionId, worktreePath, tmuxSession}
+//	 on stdout after the session is fully persisted would let callers
+//	 identify their own session deterministically — no before/after diff,
+//	 no race to lose."
+//
+// Pre-fix shape on main:
+//   - `--json` returns a generic `"id"` key (was already there, but unclear)
+//   - non-JSON human mode prints only "✓ Launched session: <title>" with
+//     no session ID anywhere on stdout — callers cannot grep it out
+//
+// Post-fix expectation:
+//   - The session ID is on stdout in BOTH modes. JSON output carries an
+//     explicit `session_id` key (in addition to the legacy `id`) so
+//     scripts can grep deterministically. Human output ends with the
+//     session ID on its own annotation so `awk`/`grep` callers don't
+//     need --json at all.
+func TestAgentDeckLaunch_ReturnsSessionID_RegressionFor1031(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not on PATH; launch CLI needs a real tmux server")
+	}
+
+	home := t.TempDir()
+	socket := uniqueTmuxSocketName1031(t)
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	})
+
+	projDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// --- (a) --json mode must return an explicit `session_id` field ----
+	stdout, stderr, code := runAgentDeck(t, home,
+		"launch",
+		"-t", "launch-id-test",
+		"--no-parent",
+		"--tmux-socket", socket,
+		"--json",
+		projDir,
+	)
+	if code != 0 {
+		t.Fatalf("launch --json failed (exit %d)\nstdout: %s\nstderr: %s",
+			code, stdout, stderr)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &resp); err != nil {
+		t.Fatalf("parse launch --json: %v\nstdout: %s", err, stdout)
+	}
+
+	sessionID, _ := resp["session_id"].(string)
+	if sessionID == "" {
+		t.Fatalf(
+			"launch --json must surface an explicit `session_id` field so "+
+				"callers don't have to fall back to diff `list --json` "+
+				"(the diff itself was unsafe under the #1031 race)\n"+
+				"got payload: %v", resp,
+		)
+	}
+	// The new explicit key must agree with the legacy generic `id` key,
+	// so older callers that grepped `id` keep working.
+	if legacy, _ := resp["id"].(string); legacy != "" && legacy != sessionID {
+		t.Errorf("session_id (%q) and id (%q) disagree — they must reference the same session",
+			sessionID, legacy)
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+// cliEnvForIssue1031 mirrors cliEnvForIssue961's env scrubbing — needed
+// inside the parallel goroutines above where t isn't safe to share with
+// runAgentDeck. The fixed profile name matches runAgentDeck's
+// AGENTDECK_PROFILE so all parallel CLIs hit the same state.db (that's
+// the entire point of the race reproducer).
+func cliEnvForIssue1031(home string) []string {
+	var env []string
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "TMUX") ||
+			strings.HasPrefix(kv, "AGENTDECK_") ||
+			strings.HasPrefix(kv, "HOME=") ||
+			strings.HasPrefix(kv, "CLAUDE_CONFIG_DIR=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env,
+		"HOME="+home,
+		"AGENTDECK_PROFILE=ch_support_test",
+		"TERM=dumb",
+	)
+	return env
+}
+
+// uniqueTmuxSocketName1031 returns a per-test tmux -L socket name. The
+// launches under test live on this isolated socket so they don't touch
+// the developer's real tmux server, and the cleanup `tmux -L <name>
+// kill-server` reaps everything atomically.
+//
+// We keep the name short on purpose: it lands under /tmp/tmux-<uid>/<name>
+// which is a Unix-domain socket path with a hard ~108-char limit. Long
+// test names + nanosecond timestamps blow past that and tmux fails with
+// "File name too long" — masking the real assertion. Last-7-digits of
+// nanos is enough entropy for a per-process test run.
+func uniqueTmuxSocketName1031(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("ad1031-%07d", time.Now().UnixNano()%10_000_000)
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -412,7 +412,8 @@ func handleLaunch(profile string, args []string) {
 		_ = newInstance.SetClaudeOptions(opts)
 	}
 
-	// Add to instances and save
+	// Add to instances list (in-memory only — used for downstream
+	// group cap math and the second SaveWithGroups after PostStartSync).
 	instances = append(instances, newInstance)
 
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
@@ -420,7 +421,13 @@ func handleLaunch(profile string, args []string) {
 		groupTree.CreateGroup(newInstance.GroupPath)
 	}
 
-	if err := storage.SaveWithGroups(instances, groupTree); err != nil {
+	// v1.9.x issue #1031: targeted single-row insert + verify, NOT the
+	// load-modify-write SaveWithGroups rewrite. SaveWithGroups under
+	// concurrent launches loses sibling rows via the DELETE-NOT-IN
+	// sweep inside SaveInstances; InsertSessionAndVerify uses
+	// SaveInstance (single-row INSERT OR REPLACE) + verify-with-backoff
+	// to guarantee persistence. Mirror of RemoveSessionAndVerify (#909).
+	if err := storage.InsertSessionAndVerify(newInstance, groupTree); err != nil {
 		out.Error(fmt.Sprintf("failed to save session: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
@@ -447,7 +454,11 @@ func handleLaunch(profile string, args []string) {
 	maxC := session.GroupMaxConcurrent(tree, newInstance.GroupPath)
 	if session.ShouldQueue(instances, newInstance.GroupPath, maxC) {
 		newInstance.Status = session.StatusQueued
-		if err := saveSessionData(storage, instances, groups); err != nil {
+		// v1.9.x issue #1031: same targeted single-row pattern as the
+		// initial insert above — saveSessionData → SaveWithGroups is
+		// the load-modify-write rewrite that loses sibling launches'
+		// rows under concurrency.
+		if err := storage.InsertSessionAndVerify(newInstance, tree); err != nil {
 			out.Error(fmt.Sprintf("failed to save queued state: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
@@ -500,8 +511,18 @@ func handleLaunch(profile string, args []string) {
 	// Capture session ID from tmux
 	newInstance.PostStartSync(3 * time.Second)
 
-	// Save again with updated state (session ID, tmux name)
-	if err := saveSessionData(storage, instances, groups); err != nil {
+	// v1.9.x issue #1031: third save point — fields populated by
+	// PostStartSync (tmux session name, ClaudeSessionID once detected)
+	// land on `newInstance`. Same targeted single-row insert/upsert
+	// pattern as the two saves above; the load-modify-write
+	// saveSessionData → SaveWithGroups path would let a sibling
+	// launch's row be silently DELETE'd by this rewrite's
+	// `DELETE FROM instances WHERE id NOT IN (...)` step.
+	postStartTree := session.NewGroupTreeWithGroups(instances, groups)
+	if newInstance.GroupPath != "" {
+		postStartTree.CreateGroup(newInstance.GroupPath)
+	}
+	if err := storage.InsertSessionAndVerify(newInstance, postStartTree); err != nil {
 		out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
@@ -533,15 +554,21 @@ func handleLaunch(profile string, args []string) {
 		}
 	}
 
-	// Build output
+	// Build output. v1.9.x issue #1031: surface the new session ID
+	// under an explicit `session_id` key so callers (conductor fleet
+	// spawn loops, shell scripts) don't have to fall back to diffing
+	// `agent-deck list --json` before/after — that diff was unsafe
+	// under the launch-race the structural fix above also closes.
+	// The legacy `id` key is kept for backward compatibility.
 	jsonData := map[string]interface{}{
-		"success": true,
-		"id":      newInstance.ID,
-		"title":   newInstance.Title,
-		"path":    path,
-		"tool":    newInstance.Tool,
-		"group":   newInstance.GroupPath,
-		"profile": storage.Profile(),
+		"success":    true,
+		"id":         newInstance.ID,
+		"session_id": newInstance.ID,
+		"title":      newInstance.Title,
+		"path":       path,
+		"tool":       newInstance.Tool,
+		"group":      newInstance.GroupPath,
+		"profile":    storage.Profile(),
 	}
 	if sessionCommandInput != "" {
 		jsonData["command"] = sessionCommandInput

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -303,86 +303,11 @@ func (s *Storage) SaveWithGroups(instances []*Instance, groupTree *GroupTree) er
 	// Convert instances to database rows
 	rows := make([]*statedb.InstanceRow, len(instances))
 	for i, inst := range instances {
-		// Issue #666: belt-and-braces guard. Empty GroupPath should never
-		// reach SQLite — the load-time fallback at convertToInstances already
-		// covers legacy rows, but a regression in a write path (fork, move,
-		// direct mutation) could still slip through. Normalize here so the
-		// next load doesn't need to defend.
-		if inst.GroupPath == "" {
-			storageLog.Warn(
-				"empty_group_path_normalized_on_save",
-				slog.String("instance_id", inst.ID),
-				slog.String("title", inst.Title),
-				slog.String("project_path", inst.ProjectPath),
-				slog.String("normalized_to", DefaultGroupPath),
-			)
-			inst.GroupPath = DefaultGroupPath
+		row, err := instanceToRow(inst)
+		if err != nil {
+			return err
 		}
-		tmuxName := ""
-		if inst.tmuxSession != nil {
-			tmuxName = inst.tmuxSession.Name
-		}
-		var sandboxJSON json.RawMessage
-		if inst.Sandbox != nil {
-			data, err := json.Marshal(inst.Sandbox)
-			if err != nil {
-				return fmt.Errorf("failed to marshal sandbox for %s: %w", inst.ID, err)
-			}
-			sandboxJSON = data
-		}
-
-		var mrWorktrees []statedb.MultiRepoWorktreeData
-		for _, wt := range inst.MultiRepoWorktrees {
-			mrWorktrees = append(mrWorktrees, statedb.MultiRepoWorktreeData{
-				OriginalPath: wt.OriginalPath,
-				WorktreePath: wt.WorktreePath,
-				RepoRoot:     wt.RepoRoot,
-				Branch:       wt.Branch,
-			})
-		}
-		toolData := statedb.MarshalToolData(
-			inst.ClaudeSessionID, inst.ClaudeDetectedAt,
-			inst.GeminiSessionID, inst.GeminiDetectedAt,
-			inst.GeminiYoloMode, inst.GeminiModel,
-			inst.OpenCodeSessionID, inst.OpenCodeDetectedAt,
-			inst.CodexSessionID, inst.CodexDetectedAt,
-			inst.LatestPrompt, inst.Notes, inst.LoadedMCPNames,
-			inst.ToolOptionsJSON,
-			sandboxJSON, inst.SandboxContainer,
-			inst.SSHHost, inst.SSHRemotePath,
-			inst.MultiRepoEnabled, inst.AdditionalPaths,
-			inst.MultiRepoTempDir, mrWorktrees,
-			inst.Channels,
-			inst.ExtraArgs,
-			inst.Plugins,                   // RFC docs/rfc/PLUGIN_ATTACH.md
-			inst.PluginChannelLinkDisabled, // RFC §4.7
-			inst.AutoLinkedChannels,        // RFC §4.7 (G4/C2 fix)
-			inst.Color,                     // issue #391
-		)
-
-		rows[i] = &statedb.InstanceRow{
-			ID:                 inst.ID,
-			Title:              inst.Title,
-			ProjectPath:        inst.ProjectPath,
-			GroupPath:          inst.GroupPath,
-			Order:              inst.Order,
-			Command:            inst.Command,
-			Wrapper:            inst.Wrapper,
-			Tool:               inst.Tool,
-			Status:             string(inst.Status),
-			TmuxSession:        tmuxName,
-			TmuxSocketName:     inst.TmuxSocketName,
-			CreatedAt:          inst.CreatedAt,
-			LastAccessed:       inst.LastAccessedAt,
-			ParentSessionID:    inst.ParentSessionID,
-			IsConductor:        inst.IsConductor,
-			NoTransitionNotify: inst.NoTransitionNotify,
-			TitleLocked:        inst.TitleLocked,
-			WorktreePath:       inst.WorktreePath,
-			WorktreeRepo:       inst.WorktreeRepoRoot,
-			WorktreeBranch:     inst.WorktreeBranch,
-			ToolData:           toolData,
-		}
+		rows[i] = row
 	}
 
 	if err := s.db.SaveInstances(rows); err != nil {
@@ -525,6 +450,211 @@ func (s *Storage) RemoveSessionAndVerify(id string, remainingInstances []*Instan
 		return fmt.Errorf("%w: %s", ErrRemovalNotPersistent, id)
 	}
 	return nil
+}
+
+// ErrInsertNotPersistent is returned by InsertSessionAndVerify when, after
+// retries, the row is still missing from the database. The most likely cause
+// is a concurrent SaveInstances rewrite from another agent-deck process
+// that loaded the instances slice before this INSERT landed and then
+// DELETE'd the row via the `DELETE FROM instances WHERE id NOT IN (...)`
+// step inside SaveInstances.
+//
+// Surfacing this as a real error (rather than silently returning success)
+// is the user-facing half of the issue #1031 fix.
+var ErrInsertNotPersistent = errors.New("insert not persistent: row dropped by concurrent writer")
+
+// insertVerifyAttempts and insertVerifyBackoff control the post-commit
+// verify loop inside InsertSessionAndVerify. The defaults absorb the
+// bounded window in which a competing rewriter can DELETE this row
+// before its own SaveInstances commits (parallel xargs -P N launches).
+// Tests override via the package-private setters so they don't sit
+// through the production backoff schedule.
+var (
+	insertVerifyAttempts = 6
+	insertVerifyBackoff  = []time.Duration{
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		80 * time.Millisecond,
+		160 * time.Millisecond,
+		320 * time.Millisecond,
+	}
+)
+
+// InsertSessionAndVerify performs a durable single-row session insert.
+//
+// Flow (v1.9.x issue #1031 fix, parallel to #909's RemoveSessionAndVerify):
+//
+//  1. SaveInstance(row) — targeted INSERT OR REPLACE on the single new
+//     row only, NOT a full-table rewrite. This sidesteps the
+//     load-modify-write race where a sibling launch's
+//     `DELETE FROM instances WHERE id NOT IN (...)` inside
+//     SaveInstances would silently delete this row.
+//  2. SaveGroupsOnly(groupTree) — persist any group structure changes
+//     WITHOUT rewriting the instances table. Rewriting (SaveWithGroups)
+//     is the load-modify-write pattern that lets a concurrent launch
+//     drop this row; skipping it eliminates the structural race for
+//     our own write.
+//  3. Verify InstanceExists(id) is true. If not (some other process
+//     issued a SaveInstances rewrite that excluded this row because it
+//     loaded the instances slice pre-INSERT), re-issue the targeted
+//     INSERT and loop with linear backoff.
+//  4. After exhausting attempts, return ErrInsertNotPersistent so the
+//     caller can fail loudly instead of returning success on a row
+//     that's not actually there.
+//
+// instances is the post-insert session list, used only to compute group
+// sort_order / membership for SaveGroupsOnly. groupTree may be nil if
+// the caller doesn't care to persist groups.
+func (s *Storage) InsertSessionAndVerify(newInstance *Instance, groupTree *GroupTree) error {
+	if newInstance == nil {
+		return fmt.Errorf("nil instance")
+	}
+	row, err := instanceToRow(newInstance)
+	if err != nil {
+		return err
+	}
+
+	if err := s.saveSingleInstance(row); err != nil {
+		return err
+	}
+
+	if groupTree != nil {
+		if err := s.SaveGroupsOnly(groupTree); err != nil {
+			return fmt.Errorf("failed to save groups during insert: %w", err)
+		}
+	}
+
+	for attempt := 0; attempt < insertVerifyAttempts; attempt++ {
+		exists, err := s.InstanceExists(newInstance.ID)
+		if err != nil {
+			return fmt.Errorf("verify insert of %s: %w", newInstance.ID, err)
+		}
+		if exists {
+			return nil
+		}
+		if attempt < len(insertVerifyBackoff) {
+			time.Sleep(insertVerifyBackoff[attempt])
+		}
+		// Re-issue the targeted INSERT; races against the concurrent
+		// rewriter but eventually wins because every retry shrinks the
+		// window.
+		if err := s.saveSingleInstance(row); err != nil {
+			return err
+		}
+	}
+
+	exists, err := s.InstanceExists(newInstance.ID)
+	if err != nil {
+		return fmt.Errorf("verify insert of %s: %w", newInstance.ID, err)
+	}
+	if exists {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", ErrInsertNotPersistent, newInstance.ID)
+}
+
+// saveSingleInstance writes one row via the targeted SaveInstance path
+// (single-row INSERT OR REPLACE — no DELETE-NOT-IN sweep). Wraps the
+// statedb call in the storage mutex and the nil-db guard so callers
+// stay symmetric with DeleteInstance.
+func (s *Storage) saveSingleInstance(row *statedb.InstanceRow) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return fmt.Errorf("storage database not initialized")
+	}
+	if err := s.db.SaveInstance(row); err != nil {
+		return fmt.Errorf("failed to save instance %s: %w", row.ID, err)
+	}
+	_ = s.db.Touch()
+	return nil
+}
+
+// instanceToRow converts a session.Instance into the statedb row shape.
+// Shared by SaveWithGroups (bulk path) and InsertSessionAndVerify
+// (targeted single-row path) so the marshal/normalize logic stays in
+// one place.
+func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
+	// Issue #666: belt-and-braces guard. Empty GroupPath should never
+	// reach SQLite — the load-time fallback at convertToInstances already
+	// covers legacy rows, but a regression in a write path (fork, move,
+	// direct mutation) could still slip through. Normalize here so the
+	// next load doesn't need to defend.
+	if inst.GroupPath == "" {
+		storageLog.Warn(
+			"empty_group_path_normalized_on_save",
+			slog.String("instance_id", inst.ID),
+			slog.String("title", inst.Title),
+			slog.String("project_path", inst.ProjectPath),
+			slog.String("normalized_to", DefaultGroupPath),
+		)
+		inst.GroupPath = DefaultGroupPath
+	}
+	tmuxName := ""
+	if inst.tmuxSession != nil {
+		tmuxName = inst.tmuxSession.Name
+	}
+	var sandboxJSON json.RawMessage
+	if inst.Sandbox != nil {
+		data, err := json.Marshal(inst.Sandbox)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal sandbox for %s: %w", inst.ID, err)
+		}
+		sandboxJSON = data
+	}
+
+	var mrWorktrees []statedb.MultiRepoWorktreeData
+	for _, wt := range inst.MultiRepoWorktrees {
+		mrWorktrees = append(mrWorktrees, statedb.MultiRepoWorktreeData{
+			OriginalPath: wt.OriginalPath,
+			WorktreePath: wt.WorktreePath,
+			RepoRoot:     wt.RepoRoot,
+			Branch:       wt.Branch,
+		})
+	}
+	toolData := statedb.MarshalToolData(
+		inst.ClaudeSessionID, inst.ClaudeDetectedAt,
+		inst.GeminiSessionID, inst.GeminiDetectedAt,
+		inst.GeminiYoloMode, inst.GeminiModel,
+		inst.OpenCodeSessionID, inst.OpenCodeDetectedAt,
+		inst.CodexSessionID, inst.CodexDetectedAt,
+		inst.LatestPrompt, inst.Notes, inst.LoadedMCPNames,
+		inst.ToolOptionsJSON,
+		sandboxJSON, inst.SandboxContainer,
+		inst.SSHHost, inst.SSHRemotePath,
+		inst.MultiRepoEnabled, inst.AdditionalPaths,
+		inst.MultiRepoTempDir, mrWorktrees,
+		inst.Channels,
+		inst.ExtraArgs,
+		inst.Plugins,                   // RFC docs/rfc/PLUGIN_ATTACH.md
+		inst.PluginChannelLinkDisabled, // RFC §4.7
+		inst.AutoLinkedChannels,        // RFC §4.7 (G4/C2 fix)
+		inst.Color,                     // issue #391
+	)
+
+	return &statedb.InstanceRow{
+		ID:                 inst.ID,
+		Title:              inst.Title,
+		ProjectPath:        inst.ProjectPath,
+		GroupPath:          inst.GroupPath,
+		Order:              inst.Order,
+		Command:            inst.Command,
+		Wrapper:            inst.Wrapper,
+		Tool:               inst.Tool,
+		Status:             string(inst.Status),
+		TmuxSession:        tmuxName,
+		TmuxSocketName:     inst.TmuxSocketName,
+		CreatedAt:          inst.CreatedAt,
+		LastAccessed:       inst.LastAccessedAt,
+		ParentSessionID:    inst.ParentSessionID,
+		IsConductor:        inst.IsConductor,
+		NoTransitionNotify: inst.NoTransitionNotify,
+		TitleLocked:        inst.TitleLocked,
+		WorktreePath:       inst.WorktreePath,
+		WorktreeRepo:       inst.WorktreeRepoRoot,
+		WorktreeBranch:     inst.WorktreeBranch,
+		ToolData:           toolData,
+	}, nil
 }
 
 // SaveGroupsOnly persists only the groups table to SQLite.


### PR DESCRIPTION
## Summary

Fixes #1031 — concurrent `agent-deck launch` invocations silently dropped sessions (only N-1 of N persisted to SQLite). Same load-modify-write SQLite race as #961 (`agent-deck rm`), fixed in v1.9.1 via #909 / #993. This PR applies the same structural pattern to `launch`'s persistence path and gives callers a deterministic way to capture the new session's ID.

## Root cause

`internal/statedb/statedb.go:613` (inside `SaveInstances`):
```sql
DELETE FROM instances WHERE id NOT IN (...)
```

Under `launch`'s load-modify-write `SaveWithGroups` pattern (load all rows → append the new instance → save the whole slice), a sibling launch's row written **after** this caller's load was silently DELETE'd by that sweep. All N callers reported exit 0 + ✓ success; one row vanished.

## Fix shape (mirror of #909 / #993)

1. **`Storage.InsertSessionAndVerify(newInstance, groupTree)`** — `internal/session/storage.go`
   - Uses `SaveInstance` (single-row INSERT OR REPLACE; no DELETE-NOT-IN sweep)
   - `SaveGroupsOnly` for group structure (does not rewrite the instances table)
   - Verify-with-backoff loop (6 attempts, ~620ms total) — re-issues the targeted INSERT if a concurrent rewriter wiped this row
   - Returns `ErrInsertNotPersistent` after exhausting retries, so the CLI fails loudly instead of returning success on a row that's not actually there
2. **`launch_cmd.go`** — swap all three save points (initial insert, queued-cap branch, post-`Start` metadata update) over to `InsertSessionAndVerify`. All three were race-prone; the fix had to cover all three or the post-`Start` save would wipe sibling rows just spawned.
3. **`launch --json` returns `session_id`** — new explicit key alongside the legacy `id`, so conductor fleet-spawn loops + shell scripts don't have to diff `agent-deck list --json` before/after. The diff itself was unsafe under this race (multiple losers converged on the same wrong session).

Internal refactor: extracted `SaveWithGroups`'s row-conversion logic into a shared `instanceToRow` helper so the bulk path and the new targeted path marshal identically.

## Tests

`cmd/agent-deck/issue1031_launch_race_test.go` — CLI-subprocess pattern from #993, mirrors real OS-process contention (each subprocess owns an independent `*sql.DB` pool).

| Test | Pre-fix | Post-fix |
|------|---------|----------|
| `TestAgentDeckLaunch_ParallelSafe_AllSessionsPersist_RegressionFor1031` | 4 of 5 silently dropped (exit 0, row missing) | all 5 persisted |
| `TestAgentDeckLaunch_ReturnsSessionID_RegressionFor1031` | `session_id` field absent from `--json` | `session_id` present, matches legacy `id` |

The test pre-creates the profile with one `agent-deck list` before the parallel burst, matching the bug-report shape ("same loop tick, same profile" — the profile already exists in production). Without that seed, 5 cold-start subprocesses race on SQLite WAL setup (a different, pre-existing bug that would otherwise mask the #1031 race).

#964's launch concurrency cap is unaffected — the throttle gates the spawn step, downstream of persistence. `TestLaunch_RespectsMaxParallel_RegressionFor964` passes alongside the new tests.

## Test plan

- [x] `go test ./cmd/agent-deck/ -run 'TestAgentDeckLaunch_.*RegressionFor1031' -count=15` — 15/15 pass (no flakes)
- [x] `go test ./cmd/agent-deck/ -run 'TestAgentDeckLaunch_.*RegressionFor1031' -race -count=5` — 5/5 pass with race detector
- [x] `go test ./cmd/agent-deck/ -run 'TestLaunch_RespectsMaxParallel_RegressionFor964|TestAgentDeckRm_ParallelSafe_RegressionFor961'` — #964 cap + #961 rm safety still green
- [x] `go test ./internal/session/ ./internal/statedb/ -race` — storage layer + dedup invariants intact
- [x] `go test ./...` — full repo green

Committed by Ashesh Goplani