### PR TITLE
fix(ui): emacs ctrl+n/ctrl+p navigation (takeover of @MauriceDHani's #885, closes Feedback Hub @balazser point 3)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5759,7 +5759,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.lastEscTime = time.Now()
 		return h, nil
 
-	case "up", "k":
+	case "up", "k", "ctrl+p":
 		if h.cursor > 0 {
 			h.cursor--
 			h.previewScrollOffset = 0
@@ -5771,7 +5771,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
-	case "down", "j":
+	case "down", "j", "ctrl+n":
 		if h.cursor < len(h.flatItems)-1 {
 			h.cursor++
 			h.previewScrollOffset = 0

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5760,9 +5760,9 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case "up", "k", "ctrl+p":
+		h.previewScrollOffset = 0
 		if h.cursor > 0 {
 			h.cursor--
-			h.previewScrollOffset = 0
 			h.syncViewport()
 			h.markNavigationActivity()
 			// PERFORMANCE: Debounced preview fetch - waits 150ms for navigation to settle
@@ -5772,9 +5772,9 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case "down", "j", "ctrl+n":
+		h.previewScrollOffset = 0
 		if h.cursor < len(h.flatItems)-1 {
 			h.cursor++
-			h.previewScrollOffset = 0
 			h.syncViewport()
 			h.markNavigationActivity()
 			// PERFORMANCE: Debounced preview fetch - waits 150ms for navigation to settle

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -3001,7 +3001,8 @@ func TestRegression743_NOnRemoteGroup_QuickCreatesNoDialog(t *testing.T) {
 // added alongside the existing vi-style pagination (#38). PgUp/PgDn are
 // half-page aliases of Ctrl+U/Ctrl+D; Home/End jump to the first/last item
 // (End fills the gap where no single-key jump-to-bottom existed, since G
-// opens global search).
+// opens global search). Also covers the emacs-style Ctrl+N/Ctrl+P line
+// navigation aliases for the main session list.
 func TestHome_TerminalNavigationKeys(t *testing.T) {
 	// Build a 100-item list so pagination + absolute jumps have room to move.
 	items := make([]session.Item, 100)
@@ -3038,6 +3039,11 @@ func TestHome_TerminalNavigationKeys(t *testing.T) {
 		{"Home at top no-op", tea.KeyMsg{Type: tea.KeyHome}, 0, 0},
 		{"End from middle", tea.KeyMsg{Type: tea.KeyEnd}, 5, last},
 		{"End at bottom no-op", tea.KeyMsg{Type: tea.KeyEnd}, last, last},
+		// Emacs-style line navigation (ctrl+n / ctrl+p)
+		{"ctrl+n moves down", tea.KeyMsg{Type: tea.KeyCtrlN}, 10, 11},
+		{"ctrl+n clamps at bottom", tea.KeyMsg{Type: tea.KeyCtrlN}, last, last},
+		{"ctrl+p moves up", tea.KeyMsg{Type: tea.KeyCtrlP}, 10, 9},
+		{"ctrl+p clamps at top", tea.KeyMsg{Type: tea.KeyCtrlP}, 0, 0},
 	}
 
 	for _, tc := range tests {

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1325,11 +1325,11 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 		// Recent sessions picker handling
 		if d.showRecentPicker && len(d.recentSessions) > 0 {
 			switch msg.String() {
-			case "ctrl+n", "down":
+			case "ctrl+n", "down", "j":
 				d.recentSessionCursor = (d.recentSessionCursor + 1) % len(d.recentSessions)
 				d.previewRecentSession(d.recentSessions[d.recentSessionCursor])
 				return d, nil
-			case "ctrl+p", "up":
+			case "ctrl+p", "up", "k":
 				d.recentSessionCursor--
 				if d.recentSessionCursor < 0 {
 					d.recentSessionCursor = len(d.recentSessions) - 1
@@ -1412,10 +1412,10 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			}
 			total := len(d.pathSuggestions) + 1 // +1 for the "Type custom" entry
 			switch msg.String() {
-			case "down", "j":
+			case "down", "j", "ctrl+n":
 				d.pathSuggestionCursor = (d.pathSuggestionCursor + 1) % total
 				return d, nil
-			case "up", "k":
+			case "up", "k", "ctrl+p":
 				d.pathSuggestionCursor--
 				if d.pathSuggestionCursor < 0 {
 					d.pathSuggestionCursor = total - 1
@@ -1591,6 +1591,27 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.suggestionNavigated = true
 				return d, nil
 			}
+			// Emacs fallback: advance to next form field (mirrors "down").
+			if cur == focusConductor {
+				total := len(d.conductorSessions) + 1
+				if d.conductorCursor < total-1 {
+					d.conductorCursor++
+					return d, nil
+				}
+			}
+			if cur == focusMultiRepo && d.multiRepoEnabled && !d.multiRepoEditing {
+				if d.multiRepoPathCursor < len(d.multiRepoPaths)-1 {
+					d.multiRepoPathCursor++
+					return d, nil
+				}
+			}
+			if d.focusIndex < maxIdx {
+				d.focusIndex++
+				d.updateFocus()
+			} else if cur == focusOptions && d.toolOptions != nil {
+				return d, d.toolOptions.Update(msg)
+			}
+			return d, nil
 
 		case "ctrl+p":
 			// Previous suggestion (cursor space includes synthetic "Type custom" at 0).
@@ -1604,6 +1625,28 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.suggestionNavigated = true
 				return d, nil
 			}
+			// Emacs fallback: retreat to previous form field (mirrors "shift+tab"/"up").
+			if cur == focusConductor {
+				if d.conductorCursor > 0 {
+					d.conductorCursor--
+					return d, nil
+				}
+			}
+			if cur == focusMultiRepo && d.multiRepoEnabled && !d.multiRepoEditing {
+				if d.multiRepoPathCursor > 0 {
+					d.multiRepoPathCursor--
+					return d, nil
+				}
+			}
+			if cur == focusOptions && d.toolOptions != nil && !d.toolOptions.AtTop() {
+				return d, d.toolOptions.Update(msg)
+			}
+			d.focusIndex--
+			if d.focusIndex < 0 {
+				d.focusIndex = maxIdx
+			}
+			d.updateFocus()
+			return d, nil
 
 		case "ctrl+w":
 			// Path-aware backward word delete: stop at '/', not just whitespace.

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -1838,6 +1838,131 @@ func TestNewDialog_ShowInGroup_LoadsConfiguredClaudeExtraArgs(t *testing.T) {
 // pathInput, branchInput, etc. but never resets claudeOptions.startQueryInput.
 // This test opens the dialog, sets a query, closes, re-opens, and asserts
 // the field is empty.
+func TestNewDialog_CtrlN_CtrlP_FieldNavigation(t *testing.T) {
+	// ctrl+n / ctrl+p must move between form fields when not on a path field
+	// with active suggestions — same semantics as down / shift+tab+up.
+	dialog := NewNewDialog()
+	dialog.Show()
+	dialog.worktreeEnabled = false
+	dialog.sandboxEnabled = false
+	dialog.inheritedSettings = nil
+	dialog.rebuildFocusTargets()
+
+	if dialog.focusIndex != 0 {
+		t.Fatalf("precondition: focusIndex = %d, want 0", dialog.focusIndex)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.focusIndex != 1 {
+		t.Fatalf("ctrl+n: focusIndex = %d, want 1", dialog.focusIndex)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.focusIndex != 2 {
+		t.Fatalf("ctrl+n x2: focusIndex = %d, want 2", dialog.focusIndex)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.focusIndex != 1 {
+		t.Fatalf("ctrl+p: focusIndex = %d, want 1", dialog.focusIndex)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.focusIndex != 0 {
+		t.Fatalf("ctrl+p x2: focusIndex = %d, want 0", dialog.focusIndex)
+	}
+}
+
+func TestNewDialog_CtrlP_WrapsToLastField(t *testing.T) {
+	dialog := NewNewDialog()
+	dialog.Show()
+	dialog.worktreeEnabled = false
+	dialog.sandboxEnabled = false
+	dialog.inheritedSettings = nil
+	dialog.rebuildFocusTargets()
+	maxIdx := len(dialog.focusTargets) - 1
+
+	// ctrl+p from first field should wrap to last.
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.focusIndex != maxIdx {
+		t.Fatalf("ctrl+p at top: focusIndex = %d, want %d (last)", dialog.focusIndex, maxIdx)
+	}
+}
+
+func TestNewDialog_SuggestionsDropdown_CtrlN_CtrlP(t *testing.T) {
+	// ctrl+n / ctrl+p must navigate the path-suggestions dropdown when it is
+	// active, consistent with j / k.
+	dialog := NewNewDialog()
+	dialog.Show()
+	dialog.SetPathSuggestions([]string{"/a", "/b", "/c"})
+
+	// Force path field focus and open the dropdown.
+	dialog.focusIndex = dialog.indexOf(focusPath)
+	dialog.updateFocus()
+	dialog.suggestionsActive = true
+	dialog.pathSuggestionCursor = 0
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.pathSuggestionCursor != 1 {
+		t.Fatalf("ctrl+n: pathSuggestionCursor = %d, want 1", dialog.pathSuggestionCursor)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.pathSuggestionCursor != 2 {
+		t.Fatalf("ctrl+n x2: pathSuggestionCursor = %d, want 2", dialog.pathSuggestionCursor)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.pathSuggestionCursor != 1 {
+		t.Fatalf("ctrl+p: pathSuggestionCursor = %d, want 1", dialog.pathSuggestionCursor)
+	}
+
+	// Dropdown must remain open during navigation.
+	if !dialog.suggestionsActive {
+		t.Fatal("suggestionsActive should remain true during ctrl+n/ctrl+p navigation")
+	}
+}
+
+func TestNewDialog_RecentPicker_JK(t *testing.T) {
+	// j / k must navigate the recent-sessions picker, consistent with
+	// ctrl+n / ctrl+p and down / up.
+	dialog := NewNewDialog()
+	dialog.Show()
+	dialog.recentSessions = []*statedb.RecentSessionRow{
+		{Title: "alpha", ProjectPath: "/a", Tool: "claude"},
+		{Title: "beta", ProjectPath: "/b", Tool: "claude"},
+		{Title: "gamma", ProjectPath: "/c", Tool: "claude"},
+	}
+	dialog.showRecentPicker = true
+	dialog.recentSessionCursor = 0
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if dialog.recentSessionCursor != 1 {
+		t.Fatalf("j: recentSessionCursor = %d, want 1", dialog.recentSessionCursor)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if dialog.recentSessionCursor != 2 {
+		t.Fatalf("j x2: recentSessionCursor = %d, want 2", dialog.recentSessionCursor)
+	}
+
+	// Wrap around.
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if dialog.recentSessionCursor != 0 {
+		t.Fatalf("j wrap: recentSessionCursor = %d, want 0", dialog.recentSessionCursor)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if dialog.recentSessionCursor != 2 {
+		t.Fatalf("k from 0: recentSessionCursor = %d, want 2 (wrap)", dialog.recentSessionCursor)
+	}
+
+	dialog, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if dialog.recentSessionCursor != 1 {
+		t.Fatalf("k: recentSessionCursor = %d, want 1", dialog.recentSessionCursor)
+	}
+}
+
 func TestNewDialog_StartQuery_ClearsBetweenOpenings(t *testing.T) {
 	dialog := NewNewDialog()
 	dialog.Show()

--- a/internal/ui/skill_dialog.go
+++ b/internal/ui/skill_dialog.go
@@ -390,10 +390,10 @@ func (d *SkillDialog) Update(msg tea.KeyMsg) (*SkillDialog, tea.Cmd) {
 		d.column = SkillColumnAvailable
 		d.resetTypeJump()
 		d.normalizeSelectionAndScroll()
-	case "up", "k":
+	case "up", "k", "ctrl+p":
 		d.resetTypeJump()
 		d.moveBy(-1)
-	case "down", "j":
+	case "down", "j", "ctrl+n":
 		d.resetTypeJump()
 		d.moveBy(1)
 	case "pgup", "ctrl+b":

--- a/internal/ui/skill_dialog_test.go
+++ b/internal/ui/skill_dialog_test.go
@@ -359,6 +359,41 @@ func TestSkillDialog_ScrollWindowFollowsSelection(t *testing.T) {
 	}
 }
 
+func TestSkillDialog_CtrlN_CtrlP_Navigation(t *testing.T) {
+	dialog := NewSkillDialog()
+	dialog.visible = true
+	dialog.tool = "claude"
+	dialog.column = SkillColumnAvailable
+	dialog.available = []SkillDialogItem{
+		{Candidate: session.SkillCandidate{Name: "a", ID: "pool/a"}},
+		{Candidate: session.SkillCandidate{Name: "b", ID: "pool/b"}},
+		{Candidate: session.SkillCandidate{Name: "c", ID: "pool/c"}},
+	}
+	dialog.availableIdx = 0
+
+	// ctrl+n moves down.
+	_, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.availableIdx != 1 {
+		t.Fatalf("ctrl+n: availableIdx = %d, want 1", dialog.availableIdx)
+	}
+
+	_, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if dialog.availableIdx != 2 {
+		t.Fatalf("ctrl+n x2: availableIdx = %d, want 2", dialog.availableIdx)
+	}
+
+	// ctrl+p moves up.
+	_, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.availableIdx != 1 {
+		t.Fatalf("ctrl+p: availableIdx = %d, want 1", dialog.availableIdx)
+	}
+
+	_, _ = dialog.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if dialog.availableIdx != 0 {
+		t.Fatalf("ctrl+p x2: availableIdx = %d, want 0", dialog.availableIdx)
+	}
+}
+
 func TestSkillDialog_ViewShowsCounts(t *testing.T) {
 	dialog := NewSkillDialog()
 	dialog.visible = true

--- a/internal/ui/watcher_panel.go
+++ b/internal/ui/watcher_panel.go
@@ -129,7 +129,7 @@ func (wp *WatcherPanel) Update(msg tea.Msg) (*WatcherPanel, tea.Cmd) {
 			wp.Hide()
 		}
 
-	case "j", "down":
+	case "j", "down", "ctrl+n":
 		if wp.detailMode {
 			wp.detailCursor++
 		} else {
@@ -138,7 +138,7 @@ func (wp *WatcherPanel) Update(msg tea.Msg) (*WatcherPanel, tea.Cmd) {
 			}
 		}
 
-	case "k", "up":
+	case "k", "up", "ctrl+p":
 		if wp.detailMode {
 			if wp.detailCursor > 0 {
 				wp.detailCursor--

--- a/internal/ui/watcher_panel_test.go
+++ b/internal/ui/watcher_panel_test.go
@@ -241,6 +241,42 @@ func TestWatcherPanelTruncate(t *testing.T) {
 }
 
 // TestWatcherPanelNoActionOnEmptyList verifies no panic or cmd when list is empty.
+func TestWatcherPanel_CtrlN_CtrlP_Navigation(t *testing.T) {
+	wp := NewWatcherPanel()
+	wp.SetWatchers(sampleWatchers())
+	wp.Show()
+
+	// ctrl+n moves down.
+	wp, _ = wp.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if wp.cursor != 1 {
+		t.Errorf("ctrl+n: cursor = %d, want 1", wp.cursor)
+	}
+
+	wp, _ = wp.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if wp.cursor != 2 {
+		t.Errorf("ctrl+n x2: cursor = %d, want 2", wp.cursor)
+	}
+
+	// Clamps at last item.
+	wp, _ = wp.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	if wp.cursor != 2 {
+		t.Errorf("ctrl+n past end: cursor = %d, want 2 (clamped)", wp.cursor)
+	}
+
+	// ctrl+p moves up.
+	wp, _ = wp.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if wp.cursor != 1 {
+		t.Errorf("ctrl+p: cursor = %d, want 1", wp.cursor)
+	}
+
+	// Clamps at first item.
+	wp.cursor = 0
+	wp, _ = wp.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	if wp.cursor != 0 {
+		t.Errorf("ctrl+p at top: cursor = %d, want 0 (clamped)", wp.cursor)
+	}
+}
+
 func TestWatcherPanelNoActionOnEmptyList(t *testing.T) {
 	wp := NewWatcherPanel()
 	wp.Show()


### PR DESCRIPTION
## Takeover of #885 by @MauriceDHani

**Original work by [@MauriceDHani](https://github.com/MauriceDHani) in #885** — this PR re-applies Maurice's contribution against current `origin/main` and fixes a regression that was failing in his own newly added tests.

Maurice's #885 has been open since 2026-05-06 with two failing cases in the test suite he added:

```
--- FAIL: TestHome_TerminalNavigationKeys/ctrl+n_clamps_at_bottom
    home_test.go:3012: previewScrollOffset = 42, want 0 (nav handlers must reset)
--- FAIL: TestHome_TerminalNavigationKeys/ctrl+p_clamps_at_top
    home_test.go:3012: previewScrollOffset = 42, want 0 (nav handlers must reset)
```

Rather than let the PR rot any longer, this opens a takeover so Maurice's work can ship. I'd love for him to keep the credit (this PR's first commit message and title both call him out).

## What this PR does

### Commit 1 — Maurice's original work (re-applied)
Adds emacs-style `ctrl+n` / `ctrl+p` line-navigation aliases across all list views and dialogs, matching the existing `down`/`j` and `up`/`k` bindings:

- `internal/ui/home.go` — main session list
- `internal/ui/newdialog.go` — form-field navigation, recent-sessions picker, path-suggestions dropdown (also adds `j`/`k` to the recent picker)
- `internal/ui/skill_dialog.go` — skill column navigation
- `internal/ui/watcher_panel.go` — watcher list + detail mode

Plus matching test coverage in `home_test.go`, `newdialog_test.go`, `skill_dialog_test.go`, and `watcher_panel_test.go`.

### Commit 2 — fix the regression Maurice's own tests exposed
The new `TestHome_TerminalNavigationKeys` cases set `previewScrollOffset = 42` before each key press and assert it's reset to `0` after — the nav-resets-preview contract. The clamp cases (`ctrl+n` at the last item, `ctrl+p` at index 0) failed because the reset lived **inside** the movement guard:

```go
case "up", "k", "ctrl+p":
    if h.cursor > 0 {
        h.cursor--
        h.previewScrollOffset = 0   // skipped when clamped
        ...
```

Hoisting `h.previewScrollOffset = 0` above the guard makes the behavior consistent with `pgup`/`pgdown`/`home`/`end`/`ctrl+b`/`ctrl+f`, which all reset unconditionally.

## Why this is also @balazser's request

Closes Feedback Hub #600 point 3 — @balazser called out "Missing Ctrl+P / Ctrl+N for up/down navigation". Maurice did the work; this PR makes sure it lands.

## Verification

Before fix (Maurice's branch / commit 1 alone):
```
--- FAIL: TestHome_TerminalNavigationKeys/ctrl+n_clamps_at_bottom
    home_test.go:3060: previewScrollOffset = 42, want 0 (nav handlers must reset)
--- FAIL: TestHome_TerminalNavigationKeys/ctrl+p_clamps_at_top
    home_test.go:3060: previewScrollOffset = 42, want 0 (nav handlers must reset)
```

After fix:
```
ok  	github.com/asheshgoplani/agent-deck/internal/ui	1.482s
```

Full `go test -race -count=1 ./...` is green across every package.

## Test plan

- [x] `go test -race -count=1 -run TestHome_TerminalNavigationKeys ./internal/ui/...`
- [x] `go test -race -count=1 ./...` — all packages green
- [ ] Manual smoke: open `agent-deck`, press `ctrl+n` / `ctrl+p` in the main list, the new dialog form, the recent-sessions picker, the path-suggestions dropdown, the skill dialog, and the watcher panel.

## Notes

- Branched from current `origin/main` (HEAD: `release: prepare v1.9.15 changelog + version bump`).
- Maurice's branch is **not** force-pushed. #885 stays as-is for Maurice to decide.
- Please don't auto-close #885 on merge — that's Maurice's call.

Committed by Ashesh Goplani