### PR TITLE
feat(ui): + / - to reorder sessions and groups in tree (takeover of @oryaacov's #892)

### DIFF
--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -166,8 +166,8 @@ func (h *HelpOverlay) View() string {
 	// Define help sections
 	newKeys := h.keyPair(hotkeyNewSession, hotkeyQuickCreate, "n/N")
 	forkKeys := h.keyPair(hotkeyQuickFork, hotkeyForkWithOptions, "f/F")
-	reorderUpKeys := "K / Shift+↑"
-	reorderDownKeys := "J / Shift+↓"
+	reorderUpKeys := "+ / K / Shift+↑"
+	reorderDownKeys := "- / J / Shift+↓"
 	indentKeys := "Shift+→/←"
 	searchKey := h.key(hotkeySearch, "/")
 	settingsKey := h.key(hotkeySettings, "S")

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6060,7 +6060,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
-	case "shift+up", "K":
+	case "shift+up", "ctrl+up", "+", "K":
 		// Move item up
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
@@ -6087,7 +6087,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return h, nil
 
-	case "shift+down", "J":
+	case "shift+down", "ctrl+down", "-", "J":
 		// Move item down
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
@@ -11099,6 +11099,7 @@ func (h *Home) renderHelpBarFull() string {
 	// Global shortcuts (right side) - more compact with separators
 	globalStyle := lipgloss.NewStyle().Foreground(ColorComment)
 	globalParts := []string{globalStyle.Render("↑↓ Nav")}
+	globalParts = append(globalParts, globalStyle.Render("+/- Move"))
 	if key := h.actionKey(hotkeySearch); key != "" {
 		globalParts = append(globalParts, globalStyle.Render(key+" Search"))
 	}

--- a/internal/ui/reorder_keys_test.go
+++ b/internal/ui/reorder_keys_test.go
@@ -1,0 +1,73 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestReorderKeysPlusMinus is a regression guard for PR #892 (takeover of @oryaacov):
+// `+` and `-` must reorder sessions in the tree, alongside the existing `K`/`J` and
+// `Shift+↑/↓` bindings. Many terminals drop modifier info on arrow keys, so the
+// plain-ASCII `+`/`-` is the discoverable, terminal-portable default.
+func TestReorderKeysPlusMinus(t *testing.T) {
+	build := func() (*Home, []*session.Instance) {
+		h := NewHome()
+		h.width, h.height = 120, 30
+		instances := []*session.Instance{
+			session.NewInstanceWithTool("alpha", "/tmp/a", "claude"),
+			session.NewInstanceWithTool("bravo", "/tmp/b", "claude"),
+		}
+		for _, inst := range instances {
+			inst.GroupPath = "g"
+		}
+		h.instancesMu.Lock()
+		h.instances = instances
+		h.instancesMu.Unlock()
+		h.groupTree = session.NewGroupTree(instances)
+		h.rebuildFlatItems()
+		return h, instances
+	}
+
+	sessionIDs := func(h *Home) []string {
+		g := h.groupTree.Groups["g"]
+		ids := make([]string, len(g.Sessions))
+		for i, s := range g.Sessions {
+			ids[i] = s.ID
+		}
+		return ids
+	}
+
+	findSession := func(h *Home, id string) int {
+		for i, it := range h.flatItems {
+			if it.Type == session.ItemTypeSession && it.Session != nil && it.Session.ID == id {
+				return i
+			}
+		}
+		return -1
+	}
+
+	// `+` on second session moves it up.
+	h, instances := build()
+	h.cursor = findSession(h, instances[1].ID)
+	if h.cursor < 0 {
+		t.Fatal("bravo not in flatItems")
+	}
+	h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'+'}})
+	if got := sessionIDs(h); got[0] != instances[1].ID || got[1] != instances[0].ID {
+		t.Fatalf("+ should move bravo above alpha; got order=%v", got)
+	}
+
+	// `-` on first session moves it down.
+	h, instances = build()
+	h.cursor = findSession(h, instances[0].ID)
+	if h.cursor < 0 {
+		t.Fatal("alpha not in flatItems")
+	}
+	h.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'-'}})
+	if got := sessionIDs(h); got[0] != instances[1].ID || got[1] != instances[0].ID {
+		t.Fatalf("- should move alpha below bravo; got order=%v", got)
+	}
+}

--- a/skills/agent-deck/references/tui-reference.md
+++ b/skills/agent-deck/references/tui-reference.md
@@ -22,8 +22,8 @@ Complete reference for agent-deck Terminal UI features.
 | `n` | New session (inherits current group) |
 | `r` | Rename session or group |
 | `R` | Restart session (reloads MCPs) |
-| `K` / `Shift+↑` | Move item up (auto-promotes a sub-session to top-level when at the parent's first child) |
-| `J` / `Shift+↓` | Move item down (auto-promotes a sub-session to top-level when at the parent's last child) |
+| `+` / `K` / `Shift+↑` | Move item up (auto-promotes a sub-session to top-level when at the parent's first child) |
+| `-` / `J` / `Shift+↓` | Move item down (auto-promotes a sub-session to top-level when at the parent's last child) |
 | `Shift+→` / `Shift+←` | Indent / outdent within current group (single-level nesting) |
 | `M` | Move session to different group |
 | `m` | Open MCP Manager (Claude/Gemini) |


### PR DESCRIPTION
## Credit

**Takeover of #892 by @oryaacov.** Or opened #892 on 2026-05-07 with a clean, terminal-friendly idea — `+` / `-` as reorder keys, because many terminals drop modifier info on `Shift+↑/↓`. The PR has been sitting open and the heavy merge train (v1.9.x release work) put it into a conflicting state with the new help-overlay layout. Re-applying his change here against current `main` so it can ship; #892 is left open for @oryaacov to close at his discretion.

All design credit to @oryaacov.

## Summary

- `+` / `-` reorder the cursor item up / down in the main tree (sessions and groups).
- `ctrl+up` / `ctrl+down` added as additional bindings for terminals that do pass modifiers.
- Existing `K` / `J` and `Shift+↑/↓` are preserved — per @oryaacov's original test plan ("K/J still work as before").
- Bottom-right hint bar shows `+/- Move` next to `↑↓ Nav`.
- Help overlay (`?`) shows `+ / K / Shift+↑` and `- / J / Shift+↓`.
- `skills/agent-deck/references/tui-reference.md` updated to match.

## Why +/-

From @oryaacov's original PR: macOS Terminal.app and default iTerm2 profiles silently drop modifier info on arrow keys, so `Shift+↑` arrives as plain `↑` and the reorder doesn't fire. `+` and `-` are plain ASCII — they work everywhere, including over weird SSH/tmux paths.

## Re-application notes (vs. the original 9 LOC)

- Current `main` separated `reorderKeys` into `reorderUpKeys` / `reorderDownKeys` in `help.go` (post-#892). Updated both strings rather than the single combined one.
- Kept `K` / `J` in the home.go case statements rather than removing them. Original diff dropped them, but @oryaacov's PR description explicitly says "K/J still work as before" — going with the documented intent.
- Same diff for `home.go` renderHelpBarFull (`+/- Move` hint) and the tui-reference docs.
- Added a small regression test (`reorder_keys_test.go`) that the original PR didn't include — asserts `+` moves cursor item up and `-` moves it down.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/ui/ -count=1` passes (incl. new `TestReorderKeysPlusMinus`)
- [ ] Manual: `+` on a session moves it up; `-` moves it down (please verify in your terminal)
- [ ] Manual: `+` / `-` also works on groups
- [ ] Manual: bottom-right hint bar shows `+/- Move`
- [ ] Manual: `K` / `J` and `Shift+↑/↓` still work
- [ ] Manual: ordering persists across restart

## Files

- `internal/ui/home.go` — add `ctrl+up`, `+`, `ctrl+down`, `-` to reorder cases; add `+/- Move` to hint bar
- `internal/ui/help.go` — update `reorderUpKeys` / `reorderDownKeys` strings
- `skills/agent-deck/references/tui-reference.md` — update doc rows
- `internal/ui/reorder_keys_test.go` — new regression test

Committed by Ashesh Goplani