### PR TITLE
ci(lighthouse): re-enable PR gate via --no-tui flag (takeover of @JMBattista's #789, leverages #1018)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,6 +13,7 @@ These run on pull requests and **must go green** before merge.
 | Workflow | Trigger | What it gates |
 |---|---|---|
 | `session-persistence.yml` | PR touching tmux/session lifecycle paths, or `workflow_dispatch` | The eight `TestPersistence_*` tests (race-detector on) plus `scripts/verify-session-persistence.sh` end-to-end. Covers the class of bug where a single SSH logout destroys every managed tmux session on Linux+systemd. See the "Session persistence: mandatory test coverage" section in the root `CLAUDE.md`. |
+| `lighthouse-ci.yml` | PR touching `internal/web/**`, `.lighthouserc.json`, `tests/lighthouse/**`, or the workflow itself; also re-runs on `labeled` / `unlabeled` so the override below is reactive | Two-layer Lighthouse gate against `agent-deck web --no-tui`: (1) absolute thresholds in `.lighthouserc.json` (`total-byte-weight`, `resource-summary:script:size`, `cumulative-layout-shift` as hard error; FCP/LCP/TBT/Speed Index as soft warn); (2) bundle-delta gate (`tests/lighthouse/compare-deltas.mjs`) that fails if a single PR grows `total-byte-weight` or `script:size` by more than 5% vs the base ref. Reinstated in v1.7.70 after the `--no-tui` flag fixed the bubbletea/headless-CI start failure that disabled the gate in v1.7.42. **Maintainer override on the delta gate**: apply the `lighthouse-regression-acknowledged` label (auto-created by the workflow) to acknowledge an intentional regression — the workflow re-runs on the `labeled` event and the check turns green. The absolute thresholds in layer (1) do not participate in the override. |
 
 Any other red on a PR is either a pre-release workflow (see below) or a bug —
 file an issue and fix it, don't merge through it.
@@ -40,33 +41,33 @@ anything — they can fail silently without affecting merges.
 |---|---|---|
 | `weekly-regression.yml` | Sunday 00:00 UTC cron, or `workflow_dispatch` | Runs the Playwright visual-regression suite (`tests/e2e/pw-visual-regression.config.ts`) and Lighthouse CI (`.lighthouserc.json`) against a freshly built `agent-deck web` server. On failure, opens or appends to a single `Weekly regression check: … [date]` issue labelled `regression,automated` (idempotent — no duplicate issues on back-to-back failures). **Alert-only** — does not block any PR. |
 
-> **Note on weekly-regression reliability (as of v1.7.42):** the underlying
-> `agent-deck web` test server currently fails to start in fully headless CI
-> because a transitive bubbletea import tries to open a cancel-reader on a
-> non-existent TTY (`error creating cancelreader: bubbletea: error creating
-> cancel reader: add reader to epoll interest list`). Both the visual and
-> Lighthouse steps therefore fail with `ERR_CONNECTION_REFUSED`. Because
-> `weekly-regression.yml` is alert-only and idempotent, this produces at most
-> one open issue per week, not a flood. Fixing the server-start path (PTY
-> wrapper or a `--no-tui` startup flag) is tracked as a stability-ledger
-> follow-up; until then, the weekly issue is a known false positive.
+> **Note on the v1.7.70 fix:** the bubbletea cancel-reader failure that broke
+> `agent-deck web` on headless CI (`error creating cancelreader: bubbletea:
+> error creating cancel reader: add reader to epoll interest list`) is fixed
+> by the `--no-tui` flag added in v1.7.70. Both `lighthouse-ci.yml` (PR-time)
+> and `weekly-regression.yml` now invoke the binary with `--no-tui`, which
+> skips the TUI init while keeping the HTTP server. The Playwright
+> visual-regression step in `weekly-regression.yml` benefits from the same
+> flag — the test server now binds reliably on every Sunday run.
 
-## Deliberately removed in v1.7.42 (#682)
+## Deliberately removed in v1.7.42 (#682), partially reinstated in v1.7.70
 
-These PR gates were deleted in v1.7.42 because they were red on every run and
-were teaching the team to ignore red checks (the worst possible CI
-behaviour). Reach the repo at a commit before v1.7.42 if you want the
-original files:
+In v1.7.42 these PR gates were deleted because they were red on every run and
+were teaching the team to ignore red checks. The shared root cause — the
+bubbletea cancel-reader failing on headless CI — was fixed in v1.7.70 by the
+`--no-tui` flag on `agent-deck web`. The Lighthouse gate has been reinstated;
+visual-regression is still pending its own re-baseline of screenshot
+fixtures.
 
-| Workflow | Why it was removed |
+| Workflow | Status |
 |---|---|
-| `visual-regression.yml` | Ran on every PR. Broken since the bubbletea/TTY regression — `agent-deck web` never binds, every Playwright spec fails with `ERR_CONNECTION_REFUSED`. Same test matrix still runs weekly via `weekly-regression.yml`. Developers can re-run locally with `cd tests/e2e && npx playwright test --config=pw-visual-regression.config.ts` against a local `agent-deck web`. |
-| `lighthouse-ci.yml` | Ran on PRs touching `internal/web/**` or `.lighthouserc.json`. Has never passed since 2026-04-10 — same bubbletea server-start failure as above, plus the performance budget in `.lighthouserc.json` was never re-baselined against current webui bundle size. Same Lighthouse suite still runs weekly via `weekly-regression.yml`. Local run: `./tests/lighthouse/calibrate.sh` to re-baseline, then `npx lhci autorun --config=.lighthouserc.json`. |
+| `lighthouse-ci.yml` | **Reinstated in v1.7.70.** Listed under "Active PR gates" above. Thresholds re-baselined against the current webui bundle (`./tests/lighthouse/calibrate.sh` output) and the `--no-tui` flag is wired through `.lighthouserc.json`, `tests/lighthouse/*.sh`, and `weekly-regression.yml`. |
+| `visual-regression.yml` | **Still removed.** The server-start issue is fixed by `--no-tui`, but the screenshot baselines under `tests/e2e/visual/__screenshots__/` were never re-baselined and the suite still flakes on shared runners. The same matrix continues to run weekly via `weekly-regression.yml` (now reliably, since `--no-tui` lets the server bind). |
 
-If you want to reinstate either one as a PR gate, first fix the underlying
-`agent-deck web` headless-startup issue, re-baseline the relevant budget
-file, and land the change in the same PR so it stays green from run #1. Red
-gates worse than no gates.
+Reach the repo at commits before v1.7.42 (`a4b7079^`) if you need the
+original `visual-regression.yml` file. To reinstate it: re-baseline the
+screenshots with `cd tests/e2e && npx playwright test --config=pw-visual-regression.config.ts --update-snapshots`,
+then bring the workflow file back in the same PR.
 
 ## Adding a new workflow
 

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,202 @@
+# Lighthouse CI: enforces performance budgets on every PR touching web code.
+#
+# Two layers:
+#   1. Absolute thresholds (`.lighthouserc.json` ci.assert.assertions) — coarse
+#      upper bound. Hard gates: total-byte-weight, resource-summary:script:size,
+#      cumulative-layout-shift. Soft warnings: FCP, LCP, TBT, Speed Index.
+#   2. Delta gate (`tests/lighthouse/compare-deltas.mjs`) — block any single PR
+#      that grows `total-byte-weight` or `script:size` by more than
+#      MAX_*_DELTA_PCT (default 5%) vs the base ref. This is the answer to the
+#      v1.7.42 audit pattern where absolute thresholds went stale and the gate
+#      was disabled rather than recalibrated.
+#
+# Maintainer override: a delta-gate failure is overridable by applying the
+# `lighthouse-regression-acknowledged` label to the PR. The workflow re-runs
+# on `labeled` / `unlabeled` events, the override step sees the label, and
+# the check turns green with the override logged in the workflow output. The
+# absolute lhci assert step does NOT participate in the override — a hard
+# absolute breach still blocks merge unconditionally. Removing the label
+# re-fails the check on the next workflow trigger.
+#
+# Bootstrap note: the PR that first introduces this workflow is also the PR
+# that adds `--no-tui` to `agent-deck web`. The base ref does not have the
+# flag yet, so the base lhci collect is `continue-on-error: true` and
+# compare-deltas.mjs skips the delta check (with a logged warning) when no
+# base data is present. Every subsequent PR exercises the full gate.
+
+name: Lighthouse CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'internal/web/**'
+      - '.lighthouserc.json'
+      - 'tests/lighthouse/**'
+      - '.github/workflows/lighthouse-ci.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+concurrency:
+  group: lighthouse-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  ACK_LABEL: lighthouse-regression-acknowledged
+
+jobs:
+  lighthouse:
+    name: Performance Budget
+    runs-on: ubuntu-latest
+    env:
+      MAX_BYTE_WEIGHT_DELTA_PCT: 5
+      MAX_SCRIPT_SIZE_DELTA_PCT: 5
+      GOTOOLCHAIN: go1.24.0
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          path: pr
+          fetch-depth: 0
+
+      - name: Checkout base ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+          fetch-depth: 1
+
+      - name: Ensure ack label exists in repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Idempotent: try to create; treat "already exists" as success.
+          # On fork PRs the GITHUB_TOKEN is read-only on the upstream repo
+          # regardless of declared `issues: write` permission, so a label-
+          # bootstrap attempt 403s. Soft-fail with a warning in that case —
+          # a one-time maintainer-side `gh label create` (or any non-fork
+          # run of this workflow) seeds the label, after which every fork
+          # PR hits the "already exists" branch and the override step just
+          # reads the label, which works on read-only tokens.
+          # Other failures (network, malformed args) still hard-fail.
+          set +e
+          output=$(gh label create "$ACK_LABEL" \
+            --repo "$GITHUB_REPOSITORY" \
+            --color "fbca04" \
+            --description "Maintainer ack: lighthouse-ci delta gate regression is intentional. Removing the label re-fails the check." 2>&1)
+          rc=$?
+          if [ "$rc" -eq 0 ]; then
+            echo "Label '$ACK_LABEL' created."
+            exit 0
+          fi
+          if echo "$output" | grep -qiE "already exists|already_exists"; then
+            echo "Label '$ACK_LABEL' already exists; nothing to do."
+            exit 0
+          fi
+          if echo "$output" | grep -qiE "HTTP 403|Resource not accessible by integration"; then
+            echo "::warning title=Skipped ack-label bootstrap::GITHUB_TOKEN is read-only on '$GITHUB_REPOSITORY' (typical for fork PRs). The override step will still read the label if a maintainer has seeded it. To seed once: gh label create '$ACK_LABEL' --repo '$GITHUB_REPOSITORY' --color fbca04"
+            exit 0
+          fi
+          echo "::error title=Failed to ensure ack label::gh label create exited $rc"
+          echo "$output"
+          exit 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.0'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Lighthouse CI
+        run: npm install -g @lhci/cli@0.15.1
+
+      - name: Build PR head
+        working-directory: pr
+        run: make build
+
+      - name: Build base
+        working-directory: base
+        run: make build
+
+      - name: Collect Lighthouse on PR head
+        working-directory: pr
+        run: lhci collect --config=.lighthouserc.json
+
+      - name: Stash PR results
+        run: |
+          mkdir -p lhci-results/pr
+          cp -r pr/.lighthouseci/* lhci-results/pr/
+
+      - name: Stop any lingering test server
+        if: always()
+        run: pkill -TERM -f 'agent-deck.*web' || true
+
+      - name: Collect Lighthouse on base (best-effort)
+        id: base_collect
+        continue-on-error: true
+        working-directory: base
+        # The base ref may predate the --no-tui flag (bootstrap case). We copy
+        # the PR's .lighthouserc.json into the base checkout so the lhci config
+        # itself is consistent across the two collects; only the binary differs.
+        run: |
+          cp ../pr/.lighthouserc.json .lighthouserc.json
+          lhci collect --config=.lighthouserc.json
+
+      - name: Stash base results
+        if: steps.base_collect.outcome == 'success'
+        run: |
+          mkdir -p lhci-results/base
+          cp -r base/.lighthouseci/* lhci-results/base/ || true
+
+      - name: Stop any lingering test server
+        if: always()
+        run: pkill -TERM -f 'agent-deck.*web' || true
+
+      - name: Assert absolute thresholds (PR head)
+        working-directory: pr
+        run: lhci assert --config=.lighthouserc.json
+
+      - name: Compare PR vs base bundle deltas
+        id: delta_gate
+        continue-on-error: true
+        run: node pr/tests/lighthouse/compare-deltas.mjs lhci-results/base lhci-results/pr
+
+      - name: Apply ack-label override to delta gate
+        if: steps.delta_gate.outcome == 'failure'
+        env:
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          if echo ",${PR_LABELS}," | grep -q ",${ACK_LABEL},"; then
+            echo "::notice title=Lighthouse delta override::Regression acknowledged via '${ACK_LABEL}' label by ${{ github.event.pull_request.user.login }} or a maintainer. Check is intentionally green."
+            echo ""
+            echo "Override active. The bundle delta exceeded MAX_*_DELTA_PCT but the maintainer"
+            echo "applied the '${ACK_LABEL}' label to acknowledge this is intentional."
+            echo "Removing the label will re-fail the check on the next workflow trigger."
+            exit 0
+          fi
+          echo "::error title=Lighthouse delta gate failed::PR exceeded the bundle-delta threshold (see previous step). To override, apply the '${ACK_LABEL}' label to the PR; the workflow will re-run on the labeled event."
+          echo ""
+          echo "Bundle delta exceeded threshold and no override label is present."
+          echo ""
+          echo "If the regression is intentional, apply the '${ACK_LABEL}' label to the PR"
+          echo "(Labels sidebar on the right → click the label). The workflow will re-run"
+          echo "on the labeled event and this check will turn green."
+          echo ""
+          echo "If the regression is NOT intentional, recalibrate or split the change."
+          echo "Local debugging: ./tests/lighthouse/budget-check.sh + diff against main."
+          exit 1
+
+      - name: Upload Lighthouse results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-results-${{ github.run_id }}
+          retention-days: 14
+          path: lhci-results/

--- a/.github/workflows/weekly-regression.yml
+++ b/.github/workflows/weekly-regression.yml
@@ -93,11 +93,8 @@ jobs:
 
       - name: Start test server
         run: |
-          # Use the dedicated TUI-less test-server binary. The previous
-          # `agent-deck web` invocation tripped Bubble Tea on a non-TTY
-          # stdin and killed the process before /healthz answered (#943).
           AGENTDECK_PROFILE=_ci_weekly \
-            ./build/agent-deck-test-server -listen 127.0.0.1:18420 -profile _ci_weekly &
+            ./build/agent-deck web --no-tui --listen 127.0.0.1:18420 --token test &
           SERVER_PID=$!
           echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
           # Wait for /healthz (up to 30 seconds)

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,8 +1,8 @@
 {
   "ci": {
     "collect": {
-      "startServerCommand": "AGENTDECK_PROFILE=_test ./build/agent-deck-test-server -listen 127.0.0.1:19999 -profile _test",
-      "startServerReadyPattern": "listening on",
+      "startServerCommand": "AGENTDECK_PROFILE=_test ./build/agent-deck web --no-tui --listen 127.0.0.1:19999 --token test",
+      "startServerReadyPattern": "Web server: http",
       "url": [
         "http://127.0.0.1:19999/"
       ],
@@ -24,12 +24,12 @@
     },
     "assert": {
       "assertions": {
-        "total-byte-weight": ["error", { "maxNumericValue": 180000 }],
-        "resource-summary:script:size": ["error", { "maxNumericValue": 120000 }],
+        "total-byte-weight": ["error", { "maxNumericValue": 349580 }],
+        "resource-summary:script:size": ["error", { "maxNumericValue": 329757 }],
         "first-contentful-paint": ["warn", { "maxNumericValue": 800 }],
-        "largest-contentful-paint": ["warn", { "maxNumericValue": 1500 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 1300 }],
         "total-blocking-time": ["warn", { "maxNumericValue": 200 }],
-        "speed-index": ["warn", { "maxNumericValue": 1500 }],
+        "speed-index": ["warn", { "maxNumericValue": 1100 }],
         "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }],
         "is-on-https": "off",
         "uses-http2": "off",

--- a/tests/lighthouse/README.md
+++ b/tests/lighthouse/README.md
@@ -1,7 +1,103 @@
 # Lighthouse CI
 
 Performance budget enforcement for the agent-deck web app. Lighthouse CI runs
-on every PR that touches `internal/web/**` or `.lighthouserc.json`.
+on every PR that touches `internal/web/**`, `.lighthouserc.json`,
+`tests/lighthouse/**`, or the workflow file itself.
+
+## Two-layer gating
+
+1. **Absolute thresholds** (`.lighthouserc.json` `ci.assert.assertions`). Coarse
+   upper bound, recalibrated whenever the bundle moves materially. See
+   "Threshold Tiers" below and "Recalibrating Thresholds" further down.
+2. **Delta gate** (`tests/lighthouse/compare-deltas.mjs`). Blocks any single
+   PR that grows `total-byte-weight` or `resource-summary:script:size` by more
+   than `MAX_BYTE_WEIGHT_DELTA_PCT` / `MAX_SCRIPT_SIZE_DELTA_PCT` (default 5%
+   each, set in `.github/workflows/lighthouse-ci.yml`). The workflow runs
+   `lhci collect` twice — once on the PR head, once on the base ref — and
+   compares medians. This is the answer to the v1.7.42 audit pattern where the
+   absolute budget went stale, every PR was over budget, and the gate was
+   disabled rather than recalibrated. Slow growth is fine; a single PR that
+   doubles the bundle is not.
+
+   **Maintainer override.** A delta-gate failure is overridable: apply the
+   `lighthouse-regression-acknowledged` label to the PR (Labels sidebar →
+   click the label). The workflow re-runs on the `labeled` event, the
+   override step sees the label, and the check turns green with the override
+   logged in the workflow output. Removing the label re-fails the check on
+   the next workflow trigger. The absolute lhci assert (layer 1) does NOT
+   participate in the override — a hard absolute breach still blocks
+   unconditionally.
+
+   The delta gate skips with a logged warning when no base data is available
+   (e.g. the base ref predates the workflow). Run-of-the-mill PRs after the
+   workflow lands on `main` exercise the full gate.
+
+## Using the delta-gate override
+
+When the delta gate fails, the `Performance Budget` check is red and the
+workflow log emits an `::error::` annotation naming the override label:
+
+```
+Lighthouse delta gate failed
+PR exceeded the bundle-delta threshold. To override, apply the
+`lighthouse-regression-acknowledged` label to the PR; the workflow
+will re-run on the labeled event.
+```
+
+The same step prints the actual numbers above the annotation:
+
+```
+total-byte-weight: 286020 B → 317800 B (+31780 B, +11.11%) [limit +5%] FAIL
+script:size:        269801 B → 299779 B (+29978 B, +11.11%) [limit +5%] FAIL
+```
+
+The full per-run Lighthouse HTML reports for both the PR head and the base
+ref are uploaded as the `lighthouse-results-<run_id>` workflow artifact
+(14-day retention). Download both `pr/` and `base/` to drill into which
+network requests grew before you decide.
+
+### Apply the label when
+
+- A new feature genuinely needs the bundle bytes (a new view, a new
+  dependency that's the lightest available option, etc.) and you've already
+  confirmed the diff isn't accidentally bundling debug code, source maps, or
+  duplicate copies of an existing dependency.
+- A library upgrade legitimately grew the bundle and downgrading or
+  replacing the library is out of scope for this PR.
+- The delta is a known artifact of the change (e.g. enabling a new entry
+  point) and you're prepared to recalibrate the absolute thresholds in
+  `.lighthouserc.json` in a follow-up via `./tests/lighthouse/calibrate.sh`.
+
+### Don't apply the label when
+
+- The bundle grew by accident: an unused import, a debug-only library that
+  wasn't tree-shaken, source maps inadvertently shipped, two copies of the
+  same dependency from different package versions. **Fix the PR instead** —
+  the gate is doing its job.
+- You haven't actually looked at the per-run reports. The label is an
+  explicit ack, not a rubber stamp.
+- The growth is due to something separable (a planned framework upgrade, a
+  new vendored dep). **Land that piece behind its own ack first**, then the
+  feature PR rides on the new baseline at a normal delta.
+
+### How the click works
+
+1. PR sidebar → **Labels** → click `lighthouse-regression-acknowledged`.
+2. GitHub fires a `labeled` event; `lighthouse-ci.yml` re-runs.
+3. The override step sees the label on `github.event.pull_request.labels`,
+   exits 0, and emits a `::notice::` annotation naming the override and the
+   actor (`github.event.pull_request.user.login` — i.e. the PR author for
+   self-applied labels, or the maintainer who applied it).
+4. The `Performance Budget` check turns green; the merge gate clears.
+5. Removing the label fires `unlabeled` and the check re-fails on the next
+   workflow trigger. The label add/remove appears in the PR timeline; that
+   _is_ the audit trail. There is no separate review state.
+
+The override applies only to the delta gate. The absolute thresholds in
+`.lighthouserc.json` (layer 1 above) still hard-block unconditionally — the
+override is for "we expected this growth," not for "ignore the budget
+entirely." A PR that breaches both the absolute ceiling and the delta still
+fails on the absolute step regardless of the label.
 
 ## Threshold Tiers
 
@@ -27,15 +123,26 @@ is unavailable).
 
 ## How CI Works
 
-1. PR touches `internal/web/**` or `.lighthouserc.json`
-2. GitHub Actions workflow `.github/workflows/lighthouse-ci.yml` triggers
-3. Workflow builds the Go binary with `GOTOOLCHAIN=go1.24.0`
-4. `treosh/lighthouse-ci-action@v12` reads `.lighthouserc.json`
-5. LHCI starts the test server via `startServerCommand`
-6. LHCI runs 5 Lighthouse collections (median used for assertions)
-7. LHCI asserts thresholds: `error` failures cause non-zero exit (check fails)
-8. Results uploaded to `temporary-public-storage` (public link in check output)
-9. HTML report artifacts attached to the workflow run
+1. PR touches `internal/web/**`, `.lighthouserc.json`, `tests/lighthouse/**`,
+   or `.github/workflows/lighthouse-ci.yml`.
+2. The workflow checks out the PR head and the base ref into separate
+   directories and builds both binaries (`GOTOOLCHAIN=go1.24.0 make build`).
+3. `lhci collect` runs against the PR-head server (with `--no-tui`).
+4. `lhci collect` runs against the base server (best-effort; failures are
+   non-fatal so the PR still benefits from the absolute threshold check).
+5. `lhci assert` runs against the PR-head reports, enforcing the absolute
+   thresholds in `.lighthouserc.json`.
+6. `tests/lighthouse/compare-deltas.mjs` reads both result dirs, takes the
+   median per metric, and fails if `total-byte-weight` or `script:size` grew
+   by more than `MAX_*_DELTA_PCT` (default 5%). Skipped with a warning when no
+   base data is present.
+7. If the delta gate failed, the override step checks for the
+   `lighthouse-regression-acknowledged` label and exits 0 (with a `::notice::`)
+   if present, else exits 1 (with an `::error::` explaining how to opt in).
+8. Both result dirs (`pr/` and `base/`) are uploaded as the
+   `lighthouse-results-<run_id>` GitHub Actions artifact (14-day retention)
+   for post-mortem inspection. Lighthouse HTML reports for every individual
+   run are inside that artifact.
 
 ## Local Verification
 

--- a/tests/lighthouse/budget-check.sh
+++ b/tests/lighthouse/budget-check.sh
@@ -52,7 +52,7 @@ fi
 # --- Start test server ---
 
 echo "[budget-check] Starting test server on port $PORT..."
-AGENTDECK_PROFILE=_test "$BINARY" web --listen "127.0.0.1:${PORT}" --token test &
+AGENTDECK_PROFILE=_test "$BINARY" web --no-tui --listen "127.0.0.1:${PORT}" --token test &
 SERVER_PID=$!
 
 echo "[budget-check] Waiting for /healthz (max 30s)..."

--- a/tests/lighthouse/calibrate.sh
+++ b/tests/lighthouse/calibrate.sh
@@ -81,7 +81,7 @@ CALEOF
 # --- Start test server ---
 
 echo "[calibrate] Starting test server on port $PORT..."
-AGENTDECK_PROFILE=_test "$BINARY" web --listen "127.0.0.1:${PORT}" --token test &
+AGENTDECK_PROFILE=_test "$BINARY" web --no-tui --listen "127.0.0.1:${PORT}" --token test &
 SERVER_PID=$!
 
 echo "[calibrate] Waiting for /healthz (max 30s)..."

--- a/tests/lighthouse/compare-deltas.mjs
+++ b/tests/lighthouse/compare-deltas.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Compare two lhci collect outputs and gate on percentage deltas.
+//
+// Usage:
+//   node tests/lighthouse/compare-deltas.mjs <baseDir> <headDir>
+//
+// Where each dir holds the .lighthouseci/ output from a single `lhci collect`
+// run (i.e. one or more lhr-*.json files). The script reads, from each report:
+//   - audits['total-byte-weight'].numericValue
+//   - audits['resource-summary'].details.items.find(i => i.resourceType === 'script').transferSize
+// takes the median per metric per dir, and fails if the head-vs-base delta
+// exceeds the threshold env vars below.
+//
+// Env (all percentages, default 5):
+//   MAX_BYTE_WEIGHT_DELTA_PCT  — gates total-byte-weight
+//   MAX_SCRIPT_SIZE_DELTA_PCT  — gates resource-summary:script:size
+//
+// Exit:
+//   0 — both metrics within threshold (or base value is zero, see notes)
+//   1 — at least one metric exceeded threshold
+//   2 — input parse / shape error
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const [, , baseDir, headDir] = process.argv;
+if (!baseDir || !headDir) {
+  console.error('usage: compare-deltas.mjs <baseDir> <headDir>');
+  process.exit(2);
+}
+
+const MAX_BYTE_WEIGHT_DELTA_PCT = Number(process.env.MAX_BYTE_WEIGHT_DELTA_PCT ?? 5);
+const MAX_SCRIPT_SIZE_DELTA_PCT = Number(process.env.MAX_SCRIPT_SIZE_DELTA_PCT ?? 5);
+
+function lhrFiles(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter(f => f.startsWith('lhr-') && f.endsWith('.json'));
+}
+
+function loadReports(dir, { allowEmpty = false } = {}) {
+  const files = lhrFiles(dir);
+  if (files.length === 0) {
+    if (allowEmpty) return [];
+    console.error(`no lhr-*.json files found in ${dir}`);
+    process.exit(2);
+  }
+  return files.map(f => {
+    const path = join(dir, f);
+    let raw;
+    try {
+      raw = readFileSync(path, 'utf8');
+    } catch (e) {
+      console.error(`failed to read ${path}: ${e.message}`);
+      process.exit(2);
+    }
+    try {
+      return JSON.parse(raw);
+    } catch (e) {
+      console.error(`failed to parse ${path} as JSON: ${e.message}`);
+      process.exit(2);
+    }
+  });
+}
+
+function median(values) {
+  const sorted = values.filter(v => Number.isFinite(v)).sort((a, b) => a - b);
+  if (sorted.length === 0) return NaN;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function extractByteWeight(report) {
+  return report?.audits?.['total-byte-weight']?.numericValue;
+}
+
+function extractScriptSize(report) {
+  const items = report?.audits?.['resource-summary']?.details?.items ?? [];
+  const scripts = items.find(i => i.resourceType === 'script');
+  return scripts?.transferSize;
+}
+
+function summarize(reports, label) {
+  const byteWeight = median(reports.map(extractByteWeight));
+  const scriptSize = median(reports.map(extractScriptSize));
+  console.log(`${label}: ${reports.length} run(s) — total-byte-weight=${byteWeight} B, script:size=${scriptSize} B`);
+  return { byteWeight, scriptSize };
+}
+
+function checkDelta(metric, base, head, maxPct) {
+  if (!Number.isFinite(base) || !Number.isFinite(head)) {
+    console.error(`${metric}: missing data (base=${base}, head=${head})`);
+    return { ok: false, reason: 'missing data' };
+  }
+  if (base === 0) {
+    // Zero baseline means no useful relative comparison; treat as pass and
+    // rely on the absolute lhci assert step to catch any unexpected size.
+    console.log(`${metric}: base is 0 B; skipping delta check (absolute thresholds still enforced).`);
+    return { ok: true };
+  }
+  const deltaBytes = head - base;
+  const deltaPct = (deltaBytes / base) * 100;
+  const sign = deltaPct >= 0 ? '+' : '';
+  const verdict = deltaPct > maxPct ? 'FAIL' : 'OK';
+  console.log(`${metric}: ${base} B → ${head} B (${sign}${deltaBytes} B, ${sign}${deltaPct.toFixed(2)}%) [limit +${maxPct}%] ${verdict}`);
+  return { ok: deltaPct <= maxPct, deltaPct };
+}
+
+const baseReports = loadReports(baseDir, { allowEmpty: true });
+const headReports = loadReports(headDir);
+
+if (baseReports.length === 0) {
+  console.log(`No base lhci data in ${baseDir}.`);
+  console.log('Delta gate SKIPPED. Falling through to absolute lhci assert.');
+  console.log('(This is expected on the bootstrap PR that introduces the dual-collect workflow.');
+  console.log(' Subsequent PRs against a base ref that already includes the workflow will gate normally.)');
+  process.exit(0);
+}
+
+console.log(`Comparing ${headReports.length} head run(s) against ${baseReports.length} base run(s).`);
+console.log(`Thresholds: total-byte-weight +${MAX_BYTE_WEIGHT_DELTA_PCT}%, script:size +${MAX_SCRIPT_SIZE_DELTA_PCT}%`);
+console.log('');
+
+const base = summarize(baseReports, 'base');
+const head = summarize(headReports, 'head');
+console.log('');
+
+const byteWeightCheck = checkDelta('total-byte-weight', base.byteWeight, head.byteWeight, MAX_BYTE_WEIGHT_DELTA_PCT);
+const scriptSizeCheck = checkDelta('script:size', base.scriptSize, head.scriptSize, MAX_SCRIPT_SIZE_DELTA_PCT);
+
+console.log('');
+const failed = [];
+if (!byteWeightCheck.ok) failed.push('total-byte-weight');
+if (!scriptSizeCheck.ok) failed.push('script:size');
+
+if (failed.length > 0) {
+  console.error(`Bundle delta gate FAILED for: ${failed.join(', ')}.`);
+  console.error(`Recalibrate or split the change. To re-baseline absolute thresholds: ./tests/lighthouse/calibrate.sh`);
+  process.exit(1);
+}
+
+console.log('Bundle delta gate PASSED.');


### PR DESCRIPTION
## Summary

Re-applies the CI-only portion of @JMBattista's #789 against current `main` (v1.9.15). The Lighthouse PR gate is reinstated as a hard merge check on PRs that touch `internal/web/**`, `.lighthouserc.json`, `tests/lighthouse/**`, or the workflow itself.

JM's PR has been **approved on substance** since the v1.7.72-era review. The original was blocked on serial merge conflicts as the v1.9.x bundle landed 8 PRs ahead of it (`#1011`, `#1018`, `#1023`, `#1026`, `#1027`, `#1028`, `#1030`, `#1032`). On the [thread on #789](https://github.com/asheshgoplani/agent-deck/pull/789), @asheshgoplani offered to follow up with attribution — same pattern used for @strofimovsky's #815 → #840. This is that follow-up.

**Credit:** all design (two-layer gate, label override, delta-PCT math, bootstrap branch in `compare-deltas.mjs`, threshold re-baselining) is @JMBattista's work. The diff applied here is JM's, minus the production code that #1018 already shipped.

## What's different from JM's #789

| File | Status here | Why |
|---|---|---|
| `cmd/agent-deck/main.go` | **dropped** | `--no-tui` flag + headless boot already on main via #1018 |
| `cmd/agent-deck/web_cmd.go` | **dropped** | same |
| `cmd/agent-deck/web_cmd_test.go` | **dropped** | duplicates `cmd/agent-deck/issue_perf_no_tui_test.go` that landed with #1018 |
| `CHANGELOG.md` / VERSION | **dropped** | JM's entry was v1.7.70; main is v1.9.15 |
| `.github/workflows/lighthouse-ci.yml` | applied as-is | core PR gate |
| `.lighthouserc.json` | applied + conflict-resolved | rewires `startServerCommand` to `agent-deck web --no-tui --listen 127.0.0.1:19999 --token test`, `startServerReadyPattern` to `Web server: http`. Re-baseline: total-byte-weight 180 KB → 350 KB, script:size 120 KB → 330 KB, LCP 1500 → 1300, Speed Index 1500 → 1100 |
| `.github/workflows/weekly-regression.yml` | applied + conflict-resolved | drops the `agent-deck-test-server` stop-gap in favor of `agent-deck web --no-tui`, matching the PR-gate path |
| `tests/lighthouse/compare-deltas.mjs` | applied as-is | new delta gate |
| `tests/lighthouse/{README,budget-check.sh,calibrate.sh}` | applied as-is | rewired for `--no-tui` |
| `.github/workflows/README.md` | applied as-is | workflow-table moved from "deliberately removed in v1.7.42" → "Active PR gates"; documents `lighthouse-regression-acknowledged` override |

## #1018 synergy

#1018 (merged 2026-05-16, v1.9.12) shipped the `--no-tui` flag and a headless boot path that emits `Web server: http://...` and blocks on the global SIGINT/SIGTERM handler. JM's PR #789 anticipated this fix; without it, every prior attempt at this gate failed with the bubbletea `cancelreader: add reader to epoll interest list` panic that drove the v1.7.42 removal.

With #1018 in place, this PR is **purely CI infrastructure** — no production code change, no flag toggle, no runtime risk. Lefthook fmt-check passes for everything this PR touches; the pre-existing fmt drift in `internal/git/issue1029_with_state_test.go` is unrelated to this branch (filed separately).

## Local verification

```
$ make build
$ AGENTDECK_PROFILE=_takeover789_verify ./build/agent-deck \
    web --no-tui --listen 127.0.0.1:58039 --token testtok &
$ tail -2 server.log
Headless mode: TUI disabled
Web server: http://127.0.0.1:58039
$ curl -sS "http://127.0.0.1:58039/healthz?token=testtok"
{"ok":true,"profile":"_takeover789_verify","readOnly":false,...}
$ curl -sS -o /dev/null -w "%{http_code}\n" "http://127.0.0.1:58039/?token=testtok"
200
```

Server emits the exact ready pattern (`Web server: http`) that `.lighthouserc.json` waits for, so `lhci collect` will not time out. Process stayed alive — the bubbletea panic from the v1.7.42 era does not recur.

The full `lhci autorun` end-to-end is left for CI itself to exercise on PR open. This is by design from #789: the **first run after merge** is the inaugural full-gate exercise (the bootstrap branch in `compare-deltas.mjs` exits 0 with a logged warning on this PR because the base ref of main does not have lighthouse-ci data yet).

## Test plan

- [x] Branched from current `origin/main` (post-v1.9.15) — confirmed via `git log origin/main..HEAD` showing a single commit on top of `7473eeec`.
- [x] Re-applied JM's CI-only subset; production code skipped because main already has it from #1018.
- [x] Conflicts in `.lighthouserc.json` and `.github/workflows/weekly-regression.yml` resolved with JM's "theirs" side (correct: matches `--no-tui` invocation main now supports).
- [x] `make build` clean, `agent-deck web --no-tui` boots headlessly, emits `Web server: http://...`, `/healthz` returns 200, `/` returns 200, process stays alive.
- [ ] CI itself runs the gate. The bootstrap PR is expected to be green: layer-1 absolute thresholds run against current bundle, layer-2 delta gate skips with a logged warning because the base ref has no lighthouse-ci data yet.

## Conditional gates from JM's #789 (carried forward)

1. **Manual override drill on a follow-up PR**: synthetic >5% bundle bump → check fails → apply `lighthouse-regression-acknowledged` label → workflow re-runs on the `labeled` event → check turns green → remove label → check fails again on the `unlabeled` event. Schedule this as a separate validation PR after merge.
2. **Weekly-regression Sunday run**: confirm the next `weekly-regression.yml` run no longer files the false-positive `Weekly regression check: …` issue. The `--no-tui` invocation in this PR is the same root-cause fix.

## Notes

- Branch: `ci/v1.9.x-takeover-789-lighthouse-pr-gate` (matches the `<type>/v1.9.x-takeover-<num>-<slug>` pattern used by takeovers #885, #922-923, #1011).
- JM's `#789` branch is intentionally left untouched (no force-push). The original PR can be closed manually with a link to this one once this lands.
- Do **not** merge without first running the manual override drill on a follow-up PR — that closes JM's open conditional gate before this becomes the working pattern.

Refs: #789 (original, @JMBattista), #1018 (--no-tui in main, prerequisite, @asheshgoplani).
