### PR TITLE
docs(skill): codify trust-but-verify pattern from 2026-05-18 incident

### DIFF
--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -541,6 +541,77 @@ agent-deck goal resume <id> "<hint>"  # send context-rich hint, reset nudge coun
 
 For the full design — three-entity model, registry schema, worker contract prompt, manager loop pseudocode, nudge generator, escalation bundle, done-condition guidelines, failure modes, implementation phases, and the verification this closes the FINDINGS 18-hour stall — see [references/goal.md](references/goal.md).
 
+## Trust-but-Verify
+
+**Use when:** A conductor or worker reports any non-trivial completion claim — "PR is merge-ready", "release shipped", "tap updated", "comment posted", "goal done", "bulk drain complete". Treat all such claims as unverified until an independent verifier session has hit ground truth.
+
+### The rule
+
+For ANY non-trivial done-claim, spawn a **separate** Claude session (not the same conductor, not the same worker) whose job is to re-derive the claim from primary sources. The verifier MUST hit:
+
+- Live state (test runs, GitHub API, release artifacts, file contents on disk)
+- Not transcripts. Not the original worker's self-report. Not a same-session review.
+
+Same-session reviewers carry the same blind spots that produced the claim. A separate session re-reads the world from scratch.
+
+### Claim → verifier mapping
+
+| Done-claim | Independent verifier MUST run |
+|---|---|
+| "PR is merge-ready" | `gh pr checkout <N> && go test -race ./...` AND `gh pr view <N> --json mergeable,statusCheckRollup` |
+| "release shipped" | `gh release view <tag> --json assets` AND probe each download URL (HTTP 200, non-empty body, correct content-type) |
+| "brew tap updated" | `gh api repos/<owner>/homebrew-tap/contents/Formula/agent-deck.rb` — confirm the SHA + URL match the new release |
+| "comment posted" | `gh issue view <N> --comments` (or `gh pr view <N> --comments`) and string-match the expected body |
+| "goal worker done" | The manager's `done_cmd` must return `rc=0` AS PART OF the verify cycle — the worker's self-report alone never closes a goal |
+| "bulk drain complete" | Spawn a read-only AUDIT worker that enumerates the residual open items (open issues, open PRs, pending releases) and diffs them against the claimed-closed set |
+
+### How to spawn the verifier
+
+Use `launch-subagent.sh` from a different session than the one making the claim (peer session, not child of the claimant). Block with `--wait` so the conductor gets the verifier's answer before reporting up:
+
+```bash
+$SKILL_DIR/scripts/launch-subagent.sh "Verify PR #885" \
+  "Independently verify PR #885 is merge-ready. Run \`gh pr checkout 885 && go test -race ./...\` and \`gh pr view 885 --json mergeable,statusCheckRollup\`. Report PASS only if BOTH succeed; otherwise report the exact failing tests + the mergeable state." \
+  --wait --timeout 600
+```
+
+Key points:
+- **Verifier prompt asks for primary-source commands, not opinions.** The verifier reports what the commands returned, not what it thinks.
+- **`--wait` is mandatory.** Fire-and-forget defeats the purpose — the claim ships before the verifier answers.
+- **One verifier per claim.** Don't fold three claims into one verifier; that re-introduces the blind-spot pattern at a smaller scale.
+- **Verifier MUST be a peer (or root) session**, not a child of the claimant. A child of the claimant inherits the claimant's working state and is structurally closer to "same blind spots".
+
+### Concrete examples from 2026-05-18 (the day this section was baked in)
+
+1. **PR #885 over-claim.** A worker review reported "merge-ready; clean diff". Independent local re-test (`gh pr checkout 885 && go test -race ./...`) caught 2 failing tests. The reviewer had grepped the diff for obvious issues but never ran the suite. Lesson: code-review confidence ≠ test pass.
+
+2. **ux-rethink-path verdict false-positive.** The ux-rethink-path worker reported "merge as-is; clean diff" for #885. User asked for a second look; a fresh peer verifier caught the same 2 failing tests the original worker missed. Lesson: reviewer + author in the same session-tree share priors. A peer session re-derives.
+
+3. **Goal framework "metronome wakes".** The conductor's hourly wake cycles were firing `[STATUS]` replies with no actual work — the wake-loop had degenerated into a heartbeat instead of a do-work loop. User had to flag it manually. Lesson: a worker that hasn't run a ground-truth check since the last wake is not a working worker, it's a metronome. Bake the priority-0 check (below) into the wake template so this can't recur.
+
+### Wake-loop priority 0 (mandatory)
+
+The goal worker contract prompt at [scripts/goal/prompts/worker.md](scripts/goal/prompts/worker.md) now begins each wake with **PRIORITY 0**: before reporting status or taking the next bounded step, run **one ground-truth verifier check** against any non-trivial claim made in the previous wake's receipt. If no claim was made last wake, skip priority 0 and go to step 1.
+
+This converts a metronome wake into a do-work wake. See the worker template for the exact wording the cycle uses.
+
+### Anti-patterns
+
+- ❌ "I reviewed my own diff and it looks clean" — same-session review.
+- ❌ "Codex agreed with me" — consult is brainstorming, not verification. Codex did not run your tests.
+- ❌ "The PR's CI is green" alone — CI lag, flaky tests, or test-skip can hide real failures. Pair CI with a local re-run.
+- ❌ "Bulk close all 200 — done." — without an audit pass, you don't know how many silently failed.
+- ❌ Fire-and-forget verifier — by the time it answers, the conductor has already shipped the claim upstream.
+
+### When you don't need a verifier
+
+For trivial mechanical actions where the action IS its own verification (and the claim is "I did X"):
+- File edit + git diff visible → diff IS verification
+- `agent-deck list` reporting current sessions → list IS verification
+- Reading a file and quoting its contents → quote IS verification
+
+The verifier requirement attaches to claims about external mutable state: PRs, releases, comments, deployments, bulk operations.
+
 ## Configuration
 
 **File:** `~/.agent-deck/config.toml`

--- a/skills/agent-deck/scripts/goal/prompts/worker.md
+++ b/skills/agent-deck/scripts/goal/prompts/worker.md
@@ -22,6 +22,27 @@ The manager (external Python daemon) runs this on a schedule. You don't run it. 
 
 ## PROTOCOL — execute exactly this on every wake
 
+### PRIORITY 0 — Trust-but-verify the last cycle's claim
+
+Before taking any new bounded step, run **one ground-truth verifier check** against any non-trivial claim made in the previous wake's receipt. This converts a metronome wake (status-only heartbeat) into a do-work wake.
+
+The check MUST hit primary sources:
+
+- "PR is merge-ready" → `gh pr checkout <N> && go test -race ./...` (and/or `gh pr view <N> --json mergeable,statusCheckRollup`)
+- "release shipped" → `gh release view <tag> --json assets` AND probe each download URL
+- "brew tap updated" → `gh api repos/<owner>/homebrew-tap/contents/Formula/agent-deck.rb` — confirm SHA matches new release
+- "comment posted" → `gh issue view <N> --comments` and string-match the expected body
+- "bulk drain complete" → enumerate residual open items vs the claimed-closed set
+- "goal worker done" → defer to the manager's `done_cmd` (you do not declare this yourself)
+
+If the verifier disagrees with the prior claim, your bounded step for THIS wake is to record the disagreement in the receipt and correct the state — not to advance the goal. Honest re-tracking beats false forward motion.
+
+If the prior receipt made NO claim about external mutable state (PRs, releases, comments, deployments, bulk ops), skip priority 0 and proceed to step 1.
+
+**Why this exists:** Same-session reviewers and metronome wakes both fail by re-asserting last-cycle's confidence without re-deriving truth. The 2026-05-18 incident (PR #885 over-claim + ux-rethink false-positive + goal-framework metronome wakes) was the third independent recurrence; priority 0 bakes the fix into the contract.
+
+See the [Trust-but-Verify section](../../../SKILL.md#trust-but-verify) of the agent-deck skill for the full pattern and the claim→verifier mapping.
+
 ### 1. Recall context
 
 Read the task log at `{WORKDIR}/task-log.md`. Identify your most recent receipt to remember what you've done. If the file doesn't exist yet, this is your first cycle.

--- a/skills/agent-deck/scripts/goal/tests/test_worker_prompt.py
+++ b/skills/agent-deck/scripts/goal/tests/test_worker_prompt.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Smoke test for the goal worker prompt template.
+
+Confirms the trust-but-verify pattern baked in after the 2026-05-18 incident
+(PR #885 over-claim + ux-rethink false-positive + goal-framework metronome
+wakes) is still present in the contract prompt. The keywords are the contract
+itself — losing them silently would re-introduce the metronome failure mode.
+
+Run from anywhere:
+    python3 -m unittest discover -s tests -v
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+WORKER_PROMPT = (
+    Path(__file__).resolve().parent.parent / "prompts" / "worker.md"
+)
+
+
+class TestWorkerPromptTrustButVerify(unittest.TestCase):
+    """The worker contract MUST carry the priority-0 trust-but-verify rule.
+
+    These assertions are intentionally string-level: the prompt is consumed
+    verbatim by a fresh Claude session every wake, so the literal wording
+    *is* the contract. A refactor that loses the keywords loses the rule.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = WORKER_PROMPT.read_text(encoding="utf-8")
+
+    def test_prompt_file_exists(self) -> None:
+        self.assertTrue(
+            WORKER_PROMPT.exists(),
+            f"worker prompt template missing at {WORKER_PROMPT}",
+        )
+
+    def test_priority_zero_keyword_present(self) -> None:
+        self.assertIn(
+            "PRIORITY 0",
+            self.text,
+            "Worker contract must include 'PRIORITY 0' header — this is the "
+            "trust-but-verify rule baked in after 2026-05-18. Without it, "
+            "wakes regress to metronome status-only heartbeats.",
+        )
+
+    def test_trust_but_verify_keyword_present(self) -> None:
+        # Case-insensitive — the section can be titled either way, but the
+        # phrase has to appear so future maintainers can grep for it.
+        self.assertIn(
+            "trust-but-verify",
+            self.text.lower(),
+            "Worker contract must reference 'trust-but-verify' so the rule "
+            "is greppable and the link to the SKILL.md section is intact.",
+        )
+
+    def test_priority_zero_appears_before_step_one(self) -> None:
+        idx_p0 = self.text.find("PRIORITY 0")
+        idx_step1 = self.text.find("### 1. Recall context")
+        self.assertGreater(idx_p0, 0, "PRIORITY 0 section not found")
+        self.assertGreater(idx_step1, 0, "Step 1 section not found")
+        self.assertLess(
+            idx_p0,
+            idx_step1,
+            "PRIORITY 0 must come BEFORE step 1 — otherwise the worker takes "
+            "a new bounded step before verifying last cycle's claim, "
+            "defeating the entire pattern.",
+        )
+
+    def test_ground_truth_verifier_examples_present(self) -> None:
+        # At least one concrete primary-source command must appear so the
+        # worker has a template to imitate, not just abstract guidance.
+        candidates = ["gh pr view", "gh release view", "gh api", "gh issue view"]
+        hits = [c for c in candidates if c in self.text]
+        self.assertTrue(
+            hits,
+            "Worker contract must include at least one concrete `gh` "
+            f"primary-source command from {candidates}. Found none — "
+            "abstract guidance without examples regresses to vibes.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Bake today's hard-won lesson into the agent-deck skill so future conductors do trust-but-verify automatically, instead of re-discovering it through incident.

**Skill-only change. No Go code touched.** Hold for merge until audit-day verifier signs off — that's the working example this PR documents.

## Today's three incidents (2026-05-18)

All three were the same root pattern: an actor judging its own completeness.

1. **PR #885 over-claim.** A worker review reported "merge-ready; clean diff". Local re-test (`gh pr checkout 885 && go test -race ./...`) caught 2 failing tests. Reviewer had grepped the diff for obvious issues but never ran the suite.
2. **ux-rethink-path verdict false-positive.** The ux-rethink worker reported "merge as-is; clean diff" for #885. User asked for a second look; a fresh peer verifier caught the same 2 failing tests. Reviewer + author in the same session-tree shared priors.
3. **Goal-framework metronome wakes.** The conductor's hourly wake cycles fired `[STATUS]` replies with no actual work — the wake-loop had degenerated into a heartbeat. User flagged manually.

The common shape: a single actor (worker or reviewer or wake-cycle) was trusted to assess its own progress. Three independent recurrences in one day means the fix has to live in the skill, not in any individual operator's discipline.

## What this PR changes

### `skills/agent-deck/SKILL.md` — new "Trust-but-Verify" section

Slotted between **Goal** and **Configuration** (the goal section already separates worker / verifier / manager — this extends that principle to all done-claims).

Includes:
- The rule (independent peer session, hits primary sources, never self-assessment)
- Claim → verifier mapping for the 6 common patterns (PR merge-ready, release shipped, brew tap updated, comment posted, goal worker done, bulk drain complete)
- Exact `launch-subagent.sh` invocation with `--wait` mandatory and peer (not child) session requirement
- The 3 concrete examples above, in-line so future readers see the *why*
- Anti-patterns ("Codex agreed with me", "CI is green alone", fire-and-forget verifier)
- Carve-outs for trivial mechanical claims where the action IS its own verification

### `skills/agent-deck/scripts/goal/prompts/worker.md` — PRIORITY 0

Inserted before step 1. Every wake now begins with: *"run one ground-truth verifier check against any non-trivial claim made in the previous wake's receipt."* If the verifier disagrees with the prior claim, the bounded step for this wake is to record the disagreement and correct state — honest re-tracking beats false forward motion.

If no claim was made last wake, PRIORITY 0 is skipped — covers first-cycle and pure-investigation cycles without forcing a fake check.

Cross-links to the SKILL.md section so future maintainers see the full pattern.

### `skills/agent-deck/scripts/goal/tests/test_worker_prompt.py` — smoke test

5 assertions that the contract keywords don't silently drift out of the template:
- `PRIORITY 0` header present
- `trust-but-verify` (case-insensitive) greppable
- PRIORITY 0 appears *before* step 1 (otherwise the worker takes a new step before verifying — defeats the pattern)
- At least one concrete `gh` primary-source command remains as a template

The literal wording IS the contract — workers consume the prompt verbatim each wake. String-level assertions are the right granularity here.

## Working example this PR documents

The audit-day verifier we spawned today is exactly this pattern in action. It's a peer session, read-only, re-deriving which open issues / PRs / releases actually closed today versus which were claimed-closed but still hanging. That worker's verdict is what gates merging this PR.

## Test plan

- [x] `python3 -m unittest discover -s tests -v` — 30 tests pass (25 existing + 5 new)
- [ ] Audit-day verifier signs off on the working example (gating merge)
- [ ] Conductor merges after sign-off; ships in next release