### PR TITLE
feat(config): configurable Codex home dir in user config

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1220,6 +1220,17 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	agentdeckEnvPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_TITLE=%q AGENTDECK_TOOL=%s ",
 		i.ID, i.Title, i.Tool)
 	envPrefix += agentdeckEnvPrefix
+	if isCodexHomeExplicit() {
+		codexHome := strings.TrimSpace(getCodexHomeDir())
+		if codexHome != "" {
+			if err := os.MkdirAll(codexHome, 0o755); err != nil {
+				sessionLog.Warn("codex_home_mkdir_failed",
+					slog.String("path", codexHome),
+					slog.String("error", err.Error()))
+			}
+		}
+		envPrefix += "CODEX_HOME=" + codexHome + " "
+	}
 
 	yoloFlag := i.resolveCodexYoloFlag()
 	modelFlag := i.resolveCodexModelFlag()
@@ -1607,11 +1618,36 @@ func getCodexHomeDir() string {
 		return ExpandPath(codexHome)
 	}
 
+	if cfg, err := LoadUserConfig(); err == nil && cfg != nil {
+		profile := GetEffectiveProfile("")
+		if profileDir := cfg.GetProfileCodexConfigDir(profile); profileDir != "" {
+			return profileDir
+		}
+		if cfg.Codex.ConfigDir != "" {
+			return ExpandPath(cfg.Codex.ConfigDir)
+		}
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(os.TempDir(), ".codex")
 	}
 	return filepath.Join(home, ".codex")
+}
+
+func isCodexHomeExplicit() bool {
+	if strings.TrimSpace(os.Getenv("CODEX_HOME")) != "" {
+		return true
+	}
+	cfg, err := LoadUserConfig()
+	if err != nil || cfg == nil {
+		return false
+	}
+	profile := GetEffectiveProfile("")
+	if cfg.GetProfileCodexConfigDir(profile) != "" {
+		return true
+	}
+	return strings.TrimSpace(cfg.Codex.ConfigDir) != ""
 }
 
 // runWithTimeout runs op in a goroutine and waits up to timeout for it to

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1896,6 +1896,109 @@ func TestBuildCodexCommand_RespectsCodexHomeForRolloutCheck(t *testing.T) {
 	}
 }
 
+func TestBuildCodexCommand_UsesProfileCodexConfigDirAsCodexHome(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	originalCodexHome := os.Getenv("CODEX_HOME")
+	_ = os.Unsetenv("CODEX_HOME")
+	defer func() {
+		if originalCodexHome != "" {
+			_ = os.Setenv("CODEX_HOME", originalCodexHome)
+		} else {
+			_ = os.Unsetenv("CODEX_HOME")
+		}
+	}()
+	originalProfile := os.Getenv("AGENTDECK_PROFILE")
+	_ = os.Setenv("AGENTDECK_PROFILE", "work")
+	defer func() {
+		if originalProfile != "" {
+			_ = os.Setenv("AGENTDECK_PROFILE", originalProfile)
+		} else {
+			_ = os.Unsetenv("AGENTDECK_PROFILE")
+		}
+	}()
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", agentDeckDir, err)
+	}
+	cfg := &UserConfig{
+		Profiles: map[string]ProfileSettings{
+			"work": {Codex: ProfileCodexSettings{ConfigDir: "~/.codex-work"}},
+		},
+	}
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	ClearUserConfigCache()
+
+	inst := NewInstanceWithTool("work-codex", "/tmp/work-codex", "codex")
+	cmd := inst.buildCodexCommand(inst.Command)
+	want := "CODEX_HOME=" + filepath.Join(tmpDir, ".codex-work")
+	if !strings.Contains(cmd, want) {
+		t.Fatalf("expected command to include %q, got %q", want, cmd)
+	}
+}
+
+func TestBuildCodexCommand_CreatesMissingExplicitCodexHomeDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	originalCodexHome := os.Getenv("CODEX_HOME")
+	_ = os.Unsetenv("CODEX_HOME")
+	defer func() {
+		if originalCodexHome != "" {
+			_ = os.Setenv("CODEX_HOME", originalCodexHome)
+		} else {
+			_ = os.Unsetenv("CODEX_HOME")
+		}
+	}()
+	originalProfile := os.Getenv("AGENTDECK_PROFILE")
+	_ = os.Setenv("AGENTDECK_PROFILE", "personal")
+	defer func() {
+		if originalProfile != "" {
+			_ = os.Setenv("AGENTDECK_PROFILE", originalProfile)
+		} else {
+			_ = os.Unsetenv("AGENTDECK_PROFILE")
+		}
+	}()
+	ClearUserConfigCache()
+
+	agentDeckDir := filepath.Join(tmpDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", agentDeckDir, err)
+	}
+	cfg := &UserConfig{
+		Profiles: map[string]ProfileSettings{
+			"personal": {Codex: ProfileCodexSettings{ConfigDir: "~/.codex-personal"}},
+		},
+	}
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	ClearUserConfigCache()
+
+	codexHome := filepath.Join(tmpDir, ".codex-personal")
+	if _, err := os.Stat(codexHome); !os.IsNotExist(err) {
+		t.Fatalf("precondition failed: %s should not exist yet", codexHome)
+	}
+
+	inst := NewInstanceWithTool("personal-codex", "/tmp/personal-codex", "codex")
+	_ = inst.buildCodexCommand(inst.Command)
+
+	info, err := os.Stat(codexHome)
+	if err != nil {
+		t.Fatalf("expected codex home to be created, stat err: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %s to be a directory", codexHome)
+	}
+}
+
 func TestCanRestart_CustomCodexWrapperWithKnownID(t *testing.T) {
 	tmpDir := t.TempDir()
 	originalHome := os.Getenv("HOME")

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -248,6 +248,8 @@ func (rc RemoteConfig) GetProfile() string {
 type ProfileSettings struct {
 	// Claude defines Claude Code overrides for a specific profile.
 	Claude ProfileClaudeSettings `toml:"claude"`
+	// Codex defines Codex CLI overrides for a specific profile.
+	Codex ProfileCodexSettings `toml:"codex"`
 	// Costs defines profile-specific cost-tracking overrides.
 	// Nil pointer means "no [profiles.<name>.costs] block in TOML"; the
 	// resolver falls through to global [costs] settings.
@@ -257,6 +259,12 @@ type ProfileSettings struct {
 // ProfileClaudeSettings defines profile-specific Claude overrides.
 type ProfileClaudeSettings struct {
 	// ConfigDir overrides [claude].config_dir for this profile only.
+	ConfigDir string `toml:"config_dir"`
+}
+
+// ProfileCodexSettings defines profile-specific Codex overrides.
+type ProfileCodexSettings struct {
+	// ConfigDir overrides [codex].config_dir for this profile only.
 	ConfigDir string `toml:"config_dir"`
 }
 
@@ -837,9 +845,25 @@ type CodexSettings struct {
 	// Default: "codex"
 	Command string `toml:"command"`
 
+	// ConfigDir is the path to Codex home directory.
+	// Default: ~/.codex (or CODEX_HOME env var)
+	ConfigDir string `toml:"config_dir"`
+
 	// YoloMode enables --yolo flag for Codex sessions (bypass approvals and sandbox)
 	// Default: false
 	YoloMode bool `toml:"yolo_mode"`
+}
+
+// GetProfileCodexConfigDir returns the profile-specific Codex config directory, if configured.
+func (c *UserConfig) GetProfileCodexConfigDir(profile string) string {
+	if c == nil || profile == "" || c.Profiles == nil {
+		return ""
+	}
+	profileCfg, ok := c.Profiles[profile]
+	if !ok || profileCfg.Codex.ConfigDir == "" {
+		return ""
+	}
+	return ExpandPath(profileCfg.Codex.ConfigDir)
 }
 
 // CopilotSettings defines GitHub Copilot CLI configuration (Issue #556).
@@ -2531,6 +2555,12 @@ func CreateExampleConfig() error {
 # [codex]
 # Codex CLI command or alias to use (default: "codex")
 # command = "codex"
+# Custom config directory/home for Codex sessions
+# Default: ~/.codex (or CODEX_HOME env var takes priority)
+# config_dir = "~/.codex-work"
+# Optional per-profile override (takes precedence over [codex] when profile matches)
+# [profiles.work.codex]
+# config_dir = "~/.codex-work"
 # Enable --yolo (bypass approvals and sandbox) by default (default: false)
 # yolo_mode = true
 

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -166,6 +166,43 @@ config_dir = "~/.claude-personal"
 	}
 }
 
+func TestUserConfig_ProfileCodexConfigDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	configContent := `
+[codex]
+config_dir = "~/.codex-global"
+
+[profiles.work.codex]
+config_dir = "~/.codex-work"
+
+[profiles.personal.codex]
+config_dir = "~/.codex-personal"
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	var config UserConfig
+	if _, err := toml.DecodeFile(configPath, &config); err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+
+	if got := config.GetProfileCodexConfigDir("work"); got == "" {
+		t.Fatal("GetProfileCodexConfigDir(work) returned empty string")
+	}
+
+	if got, want := config.Profiles["work"].Codex.ConfigDir, "~/.codex-work"; got != want {
+		t.Errorf("Profiles[work].Codex.ConfigDir = %q, want %q", got, want)
+	}
+	if got, want := config.Profiles["personal"].Codex.ConfigDir, "~/.codex-personal"; got != want {
+		t.Errorf("Profiles[personal].Codex.ConfigDir = %q, want %q", got, want)
+	}
+	if got, want := config.Codex.ConfigDir, "~/.codex-global"; got != want {
+		t.Errorf("Codex.ConfigDir = %q, want %q", got, want)
+	}
+}
+
 func TestUserConfig_ClaudeConfigDirEmpty(t *testing.T) {
 	// Test with no Claude section
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Respect [codex] config_dir and per-profile codex overrides when launching Codex; set CODEX_HOME in the wrapped command and create explicit dirs.