### PR TITLE
feat: add Hermes Agent CLI + uniform env_file (takeover of @sergeytrofimovsky's #951, closes #919)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Hermes Agent CLI as first-class tool** — Launch, attach, kill Hermes sessions (`hermes` from NousResearch/hermes-agent). Icon ☤, color gold. Config via `[hermes]` section with `command`, `env_file`, `yolo_mode`. Status: process-alive/dead (content-sniffing deferred). Detection via binary basename + content patterns. Original work by @sergeytrofimovsky in [#951](https://github.com/asheshgoplani/agent-deck/pull/951).
+
+- **Uniform `[tool].command` override for all builtin agents** — All builtin agents (claude, gemini, opencode, codex, copilot, hermes) now support a `command` field in their config section to override the default binary/invocation (e.g., `[gemini] command = "gemini-nightly --flag"`). Previously only `[claude].command` worked. Also adds `env_file` to `[codex]` and promotes copilot to a dedicated command builder.
+
 ### Fixed
 
 - **Auto-confirm Claude "Resume from summary" picker on long-running conductors** ([#67](https://github.com/asheshgoplani/agent-deck/issues/67)). Previously, once a session crossed ~250k tokens, `claude --resume` showed an interactive picker that an unattended conductor could not answer, leaving the session frozen on `waiting`. After restart, agent-deck now samples the tmux pane for the picker text and auto-presses Enter to accept the default (Resume from summary). Opt out with `[claude].auto_resume_summary = false`.
+
+- **`[opencode].env_file`, `[codex].env_file`, and `[copilot].env_file` silently ignored** — `getToolEnvFile()` fell through to `GetToolDef()` for these builtins, which returned nil. Now explicitly handled.
 
 ## [1.9.18] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -540,8 +540,10 @@ Agent Deck works with any terminal-based AI tool:
 | **Gemini CLI** | Full (status, MCP, resume) |
 | **OpenCode** | Status detection, organization |
 | **Codex** | Status detection, organization, conductor |
+| **Copilot** | Organization, launch |
 | **Crush** (charmbracelet/crush) | Status detection, organization, launch |
 | **Cursor** (terminal) | Status detection, organization |
+| **Hermes Agent** | Organization, launch |
 | **Custom tools** | Configurable via `[tools.*]` in config.toml |
 
 ### Cost Tracking Dashboard

--- a/cmd/agent-deck/hermes_detect_test.go
+++ b/cmd/agent-deck/hermes_detect_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+// Hermes Agent CLI: `agent-deck add -c hermes .` must set Instance.Tool = "hermes"
+// instead of falling back to "shell". This is the CLI-layer detection (not
+// tmux's detectToolFromCommand) — it lives in main.go.
+
+func TestDetectTool_Hermes(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"bare", "hermes", "hermes"},
+		{"with flags", "hermes --yolo", "hermes"},
+		{"uppercase", "Hermes", "hermes"},
+		{"with resume", "hermes --resume 20260225_143052_a1b2c3", "hermes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got != tt.want {
+				t.Errorf("detectTool(%q) = %q, want %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectTool_Hermes_Negative(t *testing.T) {
+	// Note: detectTool uses strings.Contains, so "hermesctl" would match.
+	// This is a known limitation shared with all tools (copilot, codex, etc.).
+	// Only truly unrelated strings are tested here.
+	tests := []struct {
+		name string
+		cmd  string
+	}{
+		{"empty string", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got == "hermes" {
+				t.Errorf("detectTool(%q) = %q, should NOT match hermes", tt.cmd, got)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -3071,6 +3071,8 @@ func detectTool(cmd string) string {
 		return "crush"
 	case strings.Contains(cmd, "cursor"):
 		return "cursor"
+	case strings.Contains(cmd, "hermes"):
+		return "hermes"
 	default:
 		return "shell"
 	}

--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -394,11 +394,7 @@ func IsClaudeConfigDirExplicitForInstance(inst *Instance) bool {
 // This allows users to configure an alias like "cdw" or "cdp" that sets
 // CLAUDE_CONFIG_DIR automatically, avoiding the need for config_dir setting
 func GetClaudeCommand() string {
-	userConfig, _ := LoadUserConfig()
-	if userConfig != nil && userConfig.Claude.Command != "" {
-		return userConfig.Claude.Command
-	}
-	return "claude"
+	return GetToolCommand("claude")
 }
 
 // GetClaudeSessionID returns the ACTIVE session ID for a project path

--- a/internal/session/command_override_test.go
+++ b/internal/session/command_override_test.go
@@ -1,0 +1,243 @@
+package session
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Tests for the uniform command/env_file override layer.
+// Verifies GetToolCommand, buildCopilotCommand, and getToolEnvFile wiring.
+
+func TestGetToolCommand_NoConfig(t *testing.T) {
+	// With no config file on disk, GetToolCommand should return the bare tool name.
+	tmpDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+	ClearUserConfigCache()
+	defer ClearUserConfigCache()
+
+	tools := []string{"claude", "gemini", "opencode", "codex", "copilot", "hermes"}
+	for _, tool := range tools {
+		got := GetToolCommand(tool)
+		if got != tool {
+			t.Errorf("GetToolCommand(%q) with no config = %q, want %q", tool, got, tool)
+		}
+	}
+}
+
+func TestGetToolCommand_WithOverride(t *testing.T) {
+	cfg := &UserConfig{
+		Claude:   ClaudeSettings{Command: "/usr/local/bin/claude-custom"},
+		Gemini:   GeminiSettings{Command: "gemini --custom-flag"},
+		OpenCode: OpenCodeSettings{Command: "opencode-nightly"},
+		Codex:    CodexSettings{Command: "codex --experimental"},
+		Copilot:  CopilotSettings{Command: "gh copilot"},
+		Hermes:   HermesSettings{Command: "hermes --model gpt-5.5-pro --provider openai"},
+	}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	tests := []struct {
+		tool     string
+		expected string
+	}{
+		{"claude", "/usr/local/bin/claude-custom"},
+		{"gemini", "gemini --custom-flag"},
+		{"opencode", "opencode-nightly"},
+		{"codex", "codex --experimental"},
+		{"copilot", "gh copilot"},
+		{"hermes", "hermes --model gpt-5.5-pro --provider openai"},
+	}
+
+	for _, tt := range tests {
+		got := GetToolCommand(tt.tool)
+		if got != tt.expected {
+			t.Errorf("GetToolCommand(%q) = %q, want %q", tt.tool, got, tt.expected)
+		}
+	}
+}
+
+func TestGetToolCommand_EmptyOverrideFallsBack(t *testing.T) {
+	// Empty Command fields should fall back to bare tool name.
+	cfg := &UserConfig{
+		Claude:   ClaudeSettings{Command: ""},
+		Gemini:   GeminiSettings{Command: ""},
+		OpenCode: OpenCodeSettings{Command: ""},
+		Codex:    CodexSettings{Command: ""},
+		Copilot:  CopilotSettings{Command: ""},
+		Hermes:   HermesSettings{Command: ""},
+	}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	tools := []string{"claude", "gemini", "opencode", "codex", "copilot", "hermes"}
+	for _, tool := range tools {
+		got := GetToolCommand(tool)
+		if got != tool {
+			t.Errorf("GetToolCommand(%q) with empty override = %q, want %q", tool, got, tool)
+		}
+	}
+}
+
+func TestGetToolCommand_UnknownTool(t *testing.T) {
+	cfg := &UserConfig{}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	got := GetToolCommand("unknown-tool")
+	if got != "unknown-tool" {
+		t.Errorf("GetToolCommand(\"unknown-tool\") = %q, want %q", got, "unknown-tool")
+	}
+}
+
+func TestGetClaudeCommand_DelegatesToGetToolCommand(t *testing.T) {
+	cfg := &UserConfig{
+		Claude: ClaudeSettings{Command: "claude-wrapper"},
+	}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	got := GetClaudeCommand()
+	if got != "claude-wrapper" {
+		t.Errorf("GetClaudeCommand() = %q, want %q", got, "claude-wrapper")
+	}
+}
+
+func TestBuildCopilotCommand_BareNameNoConfig(t *testing.T) {
+	cfg := &UserConfig{}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	inst := &Instance{Tool: "copilot"}
+	got := inst.buildCopilotCommand("copilot")
+	// Should end with "copilot" (may have env prefix)
+	if !strings.HasSuffix(got, "copilot") {
+		t.Errorf("buildCopilotCommand(\"copilot\") = %q, want suffix \"copilot\"", got)
+	}
+}
+
+func TestBuildCopilotCommand_BareNameWithOverride(t *testing.T) {
+	cfg := &UserConfig{
+		Copilot: CopilotSettings{Command: "gh copilot"},
+	}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	inst := &Instance{Tool: "copilot"}
+	got := inst.buildCopilotCommand("copilot")
+	if !strings.HasSuffix(got, "gh copilot") {
+		t.Errorf("buildCopilotCommand(\"copilot\") with override = %q, want suffix \"gh copilot\"", got)
+	}
+}
+
+func TestBuildCopilotCommand_CustomCommandPassthrough(t *testing.T) {
+	cfg := &UserConfig{
+		Copilot: CopilotSettings{Command: "gh copilot"},
+	}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	inst := &Instance{Tool: "copilot"}
+	got := inst.buildCopilotCommand("copilot --verbose")
+	// Custom command should pass through, NOT use the config override
+	if !strings.HasSuffix(got, "copilot --verbose") {
+		t.Errorf("buildCopilotCommand(\"copilot --verbose\") = %q, want suffix \"copilot --verbose\"", got)
+	}
+	if strings.Contains(got, "gh copilot") {
+		t.Errorf("buildCopilotCommand should not apply config override for custom commands, got %q", got)
+	}
+}
+
+func TestBuildCopilotCommand_WrongTool(t *testing.T) {
+	inst := &Instance{Tool: "claude"}
+	got := inst.buildCopilotCommand("some-command")
+	if got != "some-command" {
+		t.Errorf("buildCopilotCommand with wrong tool = %q, want %q", got, "some-command")
+	}
+}
+
+func TestGetToolEnvFile_AllBuiltins(t *testing.T) {
+	cfg := &UserConfig{
+		Claude:   ClaudeSettings{EnvFile: "/tmp/claude.env"},
+		Gemini:   GeminiSettings{EnvFile: "/tmp/gemini.env"},
+		OpenCode: OpenCodeSettings{EnvFile: "/tmp/opencode.env"},
+		Codex:    CodexSettings{EnvFile: "/tmp/codex.env"},
+		Copilot:  CopilotSettings{EnvFile: "/tmp/copilot.env"},
+		Hermes:   HermesSettings{EnvFile: "/tmp/hermes.env"},
+	}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	tests := []struct {
+		tool     string
+		expected string
+	}{
+		{"claude", "/tmp/claude.env"},
+		{"gemini", "/tmp/gemini.env"},
+		{"opencode", "/tmp/opencode.env"},
+		{"codex", "/tmp/codex.env"},
+		{"copilot", "/tmp/copilot.env"},
+		{"hermes", "/tmp/hermes.env"},
+	}
+
+	for _, tt := range tests {
+		inst := &Instance{Tool: tt.tool}
+		got := inst.getToolEnvFile()
+		if got != tt.expected {
+			t.Errorf("getToolEnvFile() for %q = %q, want %q", tt.tool, got, tt.expected)
+		}
+	}
+}
+
+func TestBuildCodexCommand_Passthrough(t *testing.T) {
+	cfg := &UserConfig{
+		Codex: CodexSettings{Command: "codex-nightly"},
+	}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	inst := &Instance{Tool: "codex"}
+	got := inst.buildCodexCommand("codex-custom --flag")
+	// Custom command should pass through without flag injection
+	if !strings.HasSuffix(got, "codex-custom --flag") {
+		t.Errorf("buildCodexCommand passthrough = %q, want suffix \"codex-custom --flag\"", got)
+	}
+	// Should NOT contain --yolo (passthrough mode)
+	if strings.Contains(got, "--yolo") {
+		t.Errorf("buildCodexCommand passthrough should not inject --yolo, got %q", got)
+	}
+}
+
+func TestBuildCodexCommand_BareNameUsesOverride(t *testing.T) {
+	cfg := &UserConfig{
+		Codex: CodexSettings{Command: "codex-nightly", YoloMode: true},
+	}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	inst := &Instance{Tool: "codex"}
+	got := inst.buildCodexCommand("codex")
+	// Should use the override binary
+	if !strings.Contains(got, "codex-nightly") {
+		t.Errorf("buildCodexCommand bare name = %q, want to contain \"codex-nightly\"", got)
+	}
+}
+
+func TestBuildGeminiCommand_UsesOverride(t *testing.T) {
+	cfg := &UserConfig{
+		Gemini: GeminiSettings{Command: "gemini-nightly"},
+	}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	inst := &Instance{Tool: "gemini"}
+	got := inst.buildGeminiCommand("gemini")
+	if !strings.Contains(got, "gemini-nightly") {
+		t.Errorf("buildGeminiCommand with override = %q, want to contain \"gemini-nightly\"", got)
+	}
+	if strings.Contains(got, "gemini-nightly-nightly") {
+		t.Errorf("buildGeminiCommand doubled the override: %q", got)
+	}
+}

--- a/internal/session/command_override_test.go
+++ b/internal/session/command_override_test.go
@@ -210,6 +210,39 @@ func TestBuildCodexCommand_Passthrough(t *testing.T) {
 	}
 }
 
+// TestBuildCodexCommand_PassthroughKeepsAgentdeckEnv asserts that the
+// AGENTDECK_INSTANCE_ID / AGENTDECK_TITLE / AGENTDECK_TOOL env injection is
+// preserved on the codex custom-command passthrough path. The uniform-command
+// rework on #951 originally introduced an early-return that dropped this
+// prefix; review flagged it as a behaviour regression (Claude/Codex hook
+// subprocesses use AGENTDECK_INSTANCE_ID to find the spawning session), so
+// the takeover restores the inline injection ahead of the passthrough
+// early-return. Regression-pin so this never silently regresses again.
+func TestBuildCodexCommand_PassthroughKeepsAgentdeckEnv(t *testing.T) {
+	cfg := &UserConfig{
+		Codex: CodexSettings{Command: "codex-nightly"},
+	}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	inst := &Instance{
+		ID:    "test-instance-id",
+		Title: "test session",
+		Tool:  "codex",
+	}
+	got := inst.buildCodexCommand("codex-custom --flag")
+
+	if !strings.Contains(got, "AGENTDECK_INSTANCE_ID=test-instance-id") {
+		t.Errorf("custom-command codex passthrough must include AGENTDECK_INSTANCE_ID, got %q", got)
+	}
+	if !strings.Contains(got, "AGENTDECK_TOOL=codex") {
+		t.Errorf("custom-command codex passthrough must include AGENTDECK_TOOL=codex, got %q", got)
+	}
+	if !strings.Contains(got, `AGENTDECK_TITLE="test session"`) {
+		t.Errorf("custom-command codex passthrough must include AGENTDECK_TITLE, got %q", got)
+	}
+}
+
 func TestBuildCodexCommand_BareNameUsesOverride(t *testing.T) {
 	cfg := &UserConfig{
 		Codex: CodexSettings{Command: "codex-nightly", YoloMode: true},

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -272,8 +272,16 @@ func (i *Instance) getToolEnvFile() string {
 		return config.Claude.EnvFile
 	case "gemini":
 		return config.Gemini.EnvFile
+	case "opencode":
+		return config.OpenCode.EnvFile
+	case "codex":
+		return config.Codex.EnvFile
+	case "copilot":
+		return config.Copilot.EnvFile
 	case "crush":
 		return config.Crush.EnvFile
+	case "hermes":
+		return config.Hermes.EnvFile
 	default:
 		// Check custom tools
 		if def := GetToolDef(i.Tool); def != nil {

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// HermesOptions holds launch options for Hermes Agent CLI sessions.
+// Binary: `hermes` from github.com/NousResearch/hermes-agent (MIT, v0.13.0+).
+// Status detection: process-alive/dead only (content-sniffing deferred).
+// NOTE: CLI --yolo override (via applyCLIYoloOverride) is deferred until
+// HermesOptions is wired into the launch command builder.
+type HermesOptions struct {
+	// YoloMode enables --yolo flag (auto-approve all tool calls).
+	// nil = inherit from config, true/false = explicit override.
+	YoloMode *bool `json:"yolo_mode,omitempty"`
+}
+
+// ToolName returns "hermes"
+func (o *HermesOptions) ToolName() string {
+	return "hermes"
+}
+
+// ToArgs returns command-line arguments based on options.
+func (o *HermesOptions) ToArgs() []string {
+	var args []string
+	if o.YoloMode != nil && *o.YoloMode {
+		args = append(args, "--yolo")
+	}
+	return args
+}
+
+// NewHermesOptions creates HermesOptions with defaults from config.
+func NewHermesOptions(config *UserConfig) *HermesOptions {
+	opts := &HermesOptions{}
+	if config != nil && config.Hermes.YoloMode {
+		yolo := true
+		opts.YoloMode = &yolo
+	}
+	return opts
+}
+
+// UnmarshalHermesOptions deserializes HermesOptions from JSON wrapper.
+func UnmarshalHermesOptions(data json.RawMessage) (*HermesOptions, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, err
+	}
+
+	if wrapper.Tool != "hermes" {
+		return nil, nil
+	}
+
+	var opts HermesOptions
+	if err := json.Unmarshal(wrapper.Options, &opts); err != nil {
+		return nil, err
+	}
+
+	return &opts, nil
+}
+
+// buildHermesCommand builds the launch command for Hermes Agent CLI.
+// Applies env sourcing, command override, and --yolo flag.
+// If baseCommand differs from the bare tool name "hermes", it is treated as a
+// user-supplied passthrough command and returned without flag injection.
+func (i *Instance) buildHermesCommand(baseCommand string) string {
+	if i.Tool != "hermes" {
+		return baseCommand
+	}
+
+	envPrefix := i.buildEnvSourceCommand()
+
+	// Passthrough: custom command from CLI (not the bare name)
+	if baseCommand != "hermes" && baseCommand != "" {
+		return envPrefix + baseCommand
+	}
+
+	cmd := GetToolCommand("hermes")
+
+	// Apply flags from ToolOptionsJSON (includes --yolo if set at session creation)
+	if len(i.ToolOptionsJSON) > 0 {
+		opts, err := UnmarshalHermesOptions(i.ToolOptionsJSON)
+		if err == nil && opts != nil {
+			args := opts.ToArgs()
+			if len(args) > 0 {
+				cmd += " " + strings.Join(args, " ")
+			}
+		}
+	} else {
+		// No per-session options — fall back to global config for --yolo
+		config, _ := LoadUserConfig()
+		if config != nil && config.Hermes.YoloMode {
+			cmd += " --yolo"
+		}
+	}
+
+	return envPrefix + cmd
+}

--- a/internal/session/hermes_test.go
+++ b/internal/session/hermes_test.go
@@ -1,0 +1,248 @@
+package session
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Hermes Agent CLI support tests.
+// These tests define the Tool="hermes" contract: options marshalling,
+// ToArgs for yolo mode, factory from config, and identity gates
+// (icon, IsClaudeCompatible, builtin-name filter).
+//
+// Binary: `hermes` (github.com/NousResearch/hermes-agent), interactive TUI.
+
+func TestHermesOptions_ToolName(t *testing.T) {
+	opts := &HermesOptions{}
+	if got := opts.ToolName(); got != "hermes" {
+		t.Errorf("HermesOptions.ToolName() = %q, want %q", got, "hermes")
+	}
+}
+
+func TestHermesOptions_ToArgs(t *testing.T) {
+	yoloTrue := true
+	yoloFalse := false
+
+	tests := []struct {
+		name     string
+		opts     HermesOptions
+		expected []string
+	}{
+		{
+			name:     "default - no args",
+			opts:     HermesOptions{},
+			expected: nil,
+		},
+		{
+			name:     "yolo nil - no args",
+			opts:     HermesOptions{YoloMode: nil},
+			expected: nil,
+		},
+		{
+			name:     "yolo false - no args",
+			opts:     HermesOptions{YoloMode: &yoloFalse},
+			expected: nil,
+		},
+		{
+			name:     "yolo true - --yolo present",
+			opts:     HermesOptions{YoloMode: &yoloTrue},
+			expected: []string{"--yolo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.opts.ToArgs()
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("ToArgs() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewHermesOptions_Defaults(t *testing.T) {
+	opts := NewHermesOptions(nil)
+	if opts == nil {
+		t.Fatal("NewHermesOptions(nil) returned nil")
+	}
+	if opts.YoloMode != nil {
+		t.Errorf("default YoloMode = %v, want nil", opts.YoloMode)
+	}
+}
+
+func TestNewHermesOptions_WithYoloConfig(t *testing.T) {
+	cfg := &UserConfig{
+		Hermes: HermesSettings{YoloMode: true},
+	}
+	opts := NewHermesOptions(cfg)
+	if opts == nil {
+		t.Fatal("NewHermesOptions returned nil")
+	}
+	if opts.YoloMode == nil || !*opts.YoloMode {
+		t.Errorf("YoloMode = %v, want true", opts.YoloMode)
+	}
+}
+
+func TestNewHermesOptions_WithoutYoloConfig(t *testing.T) {
+	cfg := &UserConfig{
+		Hermes: HermesSettings{YoloMode: false},
+	}
+	opts := NewHermesOptions(cfg)
+	if opts == nil {
+		t.Fatal("NewHermesOptions returned nil")
+	}
+	if opts.YoloMode != nil {
+		t.Errorf("YoloMode = %v, want nil (not set when config is false)", opts.YoloMode)
+	}
+}
+
+func TestHermesOptions_MarshalUnmarshalRoundtrip(t *testing.T) {
+	yolo := true
+	orig := &HermesOptions{YoloMode: &yolo}
+
+	data, err := MarshalToolOptions(orig)
+	if err != nil {
+		t.Fatalf("MarshalToolOptions: %v", err)
+	}
+
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		t.Fatalf("unmarshal wrapper: %v", err)
+	}
+	if wrapper.Tool != "hermes" {
+		t.Errorf("wrapper.Tool = %q, want %q", wrapper.Tool, "hermes")
+	}
+
+	got, err := UnmarshalHermesOptions(data)
+	if err != nil {
+		t.Fatalf("UnmarshalHermesOptions: %v", err)
+	}
+	if got == nil {
+		t.Fatal("UnmarshalHermesOptions returned nil")
+	}
+	if got.YoloMode == nil || !*got.YoloMode {
+		t.Errorf("roundtrip mismatch: YoloMode = %v", got.YoloMode)
+	}
+}
+
+func TestUnmarshalHermesOptions_WrongTool(t *testing.T) {
+	raw := json.RawMessage(`{"tool":"codex","options":{}}`)
+	got, err := UnmarshalHermesOptions(raw)
+	if err != nil {
+		t.Fatalf("UnmarshalHermesOptions: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for wrong tool, got %+v", got)
+	}
+}
+
+func TestIsClaudeCompatible_HermesNotCompatible(t *testing.T) {
+	if IsClaudeCompatible("hermes") {
+		t.Error("IsClaudeCompatible(\"hermes\") must be false")
+	}
+}
+
+func TestGetToolIcon_Hermes(t *testing.T) {
+	icon := GetToolIcon("hermes")
+	if icon == "" {
+		t.Error("GetToolIcon(\"hermes\") returned empty")
+	}
+	if icon == GetToolIcon("shell") {
+		t.Errorf("GetToolIcon(\"hermes\") = %q equals shell fallback (want a distinct icon)", icon)
+	}
+	if icon != "☤" {
+		t.Errorf("GetToolIcon(\"hermes\") = %q, want %q", icon, "☤")
+	}
+}
+
+func TestGetCustomToolNames_HermesIsBuiltin(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+
+	userConfigCache = &UserConfig{
+		Tools: map[string]ToolDef{
+			"hermes":     {Command: "hermes"},
+			"my-wrapper": {Command: "claude"},
+		},
+	}
+
+	names := GetCustomToolNames()
+	for _, n := range names {
+		if n == "hermes" {
+			t.Errorf("GetCustomToolNames() returned %q as custom; hermes is built-in", n)
+		}
+	}
+}
+
+func TestNewInstanceWithTool_Hermes(t *testing.T) {
+	inst := NewInstanceWithTool("hermes-test", "/tmp/hermes-test-proj", "hermes")
+	if inst == nil {
+		t.Fatal("NewInstanceWithTool returned nil")
+	}
+	if inst.Tool != "hermes" {
+		t.Errorf("inst.Tool = %q, want %q", inst.Tool, "hermes")
+	}
+}
+
+func TestBuildHermesCommand_CommandOverride(t *testing.T) {
+	restore := resetUserConfigCache(t, &UserConfig{
+		Hermes: HermesSettings{
+			Command: "hermes --model gpt-5.5-pro --provider openai",
+		},
+	})
+	defer restore()
+
+	inst := &Instance{Tool: "hermes"}
+	cmd := inst.buildHermesCommand("hermes")
+	want := "hermes --model gpt-5.5-pro --provider openai"
+	if !strings.HasSuffix(cmd, want) {
+		t.Errorf("buildHermesCommand() = %q, want suffix %q", cmd, want)
+	}
+}
+
+func TestBuildHermesCommand_CommandOverrideWithYolo(t *testing.T) {
+	restore := resetUserConfigCache(t, &UserConfig{
+		Hermes: HermesSettings{
+			Command:  "hermes --model gpt-5.5-pro --provider openai",
+			YoloMode: true,
+		},
+	})
+	defer restore()
+
+	inst := &Instance{Tool: "hermes"}
+	cmd := inst.buildHermesCommand("hermes")
+	want := "hermes --model gpt-5.5-pro --provider openai --yolo"
+	if !strings.HasSuffix(cmd, want) {
+		t.Errorf("buildHermesCommand() = %q, want suffix %q", cmd, want)
+	}
+}
+
+func TestBuildHermesCommand_DefaultCommand(t *testing.T) {
+	restore := resetUserConfigCache(t, &UserConfig{
+		Hermes: HermesSettings{},
+	})
+	defer restore()
+
+	inst := &Instance{Tool: "hermes"}
+	cmd := inst.buildHermesCommand("hermes")
+	if !strings.HasSuffix(cmd, "hermes") {
+		t.Errorf("buildHermesCommand() = %q, want suffix %q", cmd, "hermes")
+	}
+	if strings.Contains(cmd, "--model") {
+		t.Errorf("buildHermesCommand() = %q, should not contain --model", cmd)
+	}
+}
+
+func TestBuildHermesCommand_Passthrough(t *testing.T) {
+	cfg := &UserConfig{}
+	restore := resetUserConfigCache(t, cfg)
+	defer restore()
+
+	inst := &Instance{Tool: "hermes"}
+	got := inst.buildHermesCommand("hermes --special-flag")
+	if !strings.HasSuffix(got, "hermes --special-flag") {
+		t.Errorf("buildHermesCommand passthrough = %q, want suffix \"hermes --special-flag\"", got)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -996,12 +996,14 @@ func (i *Instance) buildGeminiCommand(baseCommand string) string {
 
 	// If baseCommand is just "gemini", handle specially
 	if baseCommand == "gemini" {
+		cmd := GetToolCommand("gemini")
 		// If we already have a session ID, use simple resume
 		if i.GeminiSessionID != "" {
 			// GEMINI_YOLO_MODE and GEMINI_SESSION_ID are propagated via host-side
 			// SetEnvironment after tmux start. No inline tmux set-environment.
 			return envPrefix + fmt.Sprintf(
-				"gemini --resume %s%s%s",
+				"%s --resume %s%s%s",
+				cmd,
 				i.GeminiSessionID,
 				yoloFlag,
 				modelFlag,
@@ -1013,7 +1015,8 @@ func (i *Instance) buildGeminiCommand(baseCommand string) string {
 		// because Gemini processes the "." prompt which takes too long
 		// GEMINI_YOLO_MODE is propagated via host-side SetEnvironment after tmux start.
 		return envPrefix + fmt.Sprintf(
-			`gemini%s%s`,
+			`%s%s%s`,
+			cmd,
 			yoloFlag,
 			modelFlag,
 		)
@@ -1040,17 +1043,18 @@ func (i *Instance) buildOpenCodeCommand(baseCommand string) string {
 
 	// If baseCommand is just "opencode", handle specially
 	if baseCommand == "opencode" {
+		cmd := GetToolCommand("opencode")
 		extraFlags := i.buildOpenCodeExtraFlags()
 
 		// If we already have a session ID, use resume with -s flag.
 		// OPENCODE_SESSION_ID is propagated via host-side SetEnvironment after tmux start.
 		if i.OpenCodeSessionID != "" {
-			return envPrefix + fmt.Sprintf("opencode -s %s%s",
-				i.OpenCodeSessionID, extraFlags)
+			return envPrefix + fmt.Sprintf("%s -s %s%s",
+				cmd, i.OpenCodeSessionID, extraFlags)
 		}
 
 		// Start OpenCode fresh - session ID will be captured async after startup
-		return envPrefix + "opencode" + extraFlags
+		return envPrefix + cmd + extraFlags
 	}
 
 	// For custom commands (e.g., fork commands), return as-is
@@ -1217,6 +1221,16 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	}
 
 	envPrefix := i.buildEnvSourceCommand()
+
+	// Passthrough: if the tool is literally "codex" and user gave a custom command
+	// (not the bare "codex" name), return as-is without flag injection.
+	// Codex-compatible tools (e.g., "my-codex" with CompatibleWith="codex") always
+	// get the full treatment regardless of their command name.
+	trimmed := strings.TrimSpace(baseCommand)
+	if i.Tool == "codex" && trimmed != "codex" && trimmed != "" {
+		return envPrefix + trimmed
+	}
+
 	agentdeckEnvPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_TITLE=%q AGENTDECK_TOOL=%s ",
 		i.ID, i.Title, i.Tool)
 	envPrefix += agentdeckEnvPrefix
@@ -1283,6 +1297,23 @@ func (i *Instance) buildCursorCommand(baseCommand string, continuePrev bool) str
 		out += " --continue"
 	}
 	return out
+}
+
+// buildCopilotCommand builds the command for GitHub Copilot CLI.
+// If baseCommand is the bare "copilot" name, applies config command override + env prefix.
+// Otherwise returns the custom command as-is with env prefix (passthrough).
+func (i *Instance) buildCopilotCommand(baseCommand string) string {
+	if i.Tool != "copilot" {
+		return baseCommand
+	}
+
+	envPrefix := i.buildEnvSourceCommand()
+
+	if baseCommand != "copilot" {
+		return envPrefix + baseCommand
+	}
+
+	return envPrefix + GetToolCommand("copilot")
 }
 
 // codexRolloutExists reports whether Codex has flushed a rollout JSONL for
@@ -2635,8 +2666,12 @@ func (i *Instance) Start() error {
 		command = i.buildCodexCommand(i.Command)
 		// Record start time for session ID detection (Unix millis)
 		i.CodexStartedAt = time.Now().UnixMilli()
+	case i.Tool == "copilot":
+		command = i.buildCopilotCommand(i.Command)
 	case i.Tool == "cursor":
 		command = i.buildCursorCommand(i.Command, false)
+	case i.Tool == "hermes":
+		command = i.buildHermesCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -2808,10 +2843,14 @@ func (i *Instance) StartWithMessage(message string) error {
 	case IsCodexCompatible(i.Tool):
 		command = i.buildCodexCommand(i.Command)
 		i.CodexStartedAt = time.Now().UnixMilli()
-	case i.Tool == "cursor":
-		command = i.buildCursorCommand(i.Command, false)
+	case i.Tool == "copilot":
+		command = i.buildCopilotCommand(i.Command)
 	case i.Tool == "crush":
 		command = i.buildCrushCommand(i.Command)
+	case i.Tool == "cursor":
+		command = i.buildCursorCommand(i.Command, false)
+	case i.Tool == "hermes":
+		command = i.buildHermesCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -5089,10 +5128,14 @@ func (i *Instance) Restart() error {
 			command = i.buildCodexCommand(i.Command)
 			// Record start time for async session ID detection
 			i.CodexStartedAt = time.Now().UnixMilli()
-		case i.Tool == "cursor":
-			command = i.buildCursorCommand(i.Command, true)
+		case i.Tool == "copilot":
+			command = i.buildCopilotCommand(i.Command)
 		case i.Tool == "crush":
 			command = i.buildCrushCommand(i.Command)
+		case i.Tool == "cursor":
+			command = i.buildCursorCommand(i.Command, true)
+		case i.Tool == "hermes":
+			command = i.buildHermesCommand(i.Command)
 		default:
 			// Check if this is a custom tool with session resume config
 			if toolDef := GetToolDef(i.Tool); toolDef != nil {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1222,6 +1222,15 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 
 	envPrefix := i.buildEnvSourceCommand()
 
+	// AGENTDECK_* env injection is required for the hook subprocesses spawned
+	// by tools in the codex family to find this session's state, so it is
+	// injected BEFORE the custom-command passthrough early-return below.
+	// Dropping it on custom-command sessions was the design regression flagged
+	// on #951 review — keep AGENTDECK_* on every codex-flavoured launch.
+	agentdeckEnvPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_TITLE=%q AGENTDECK_TOOL=%s ",
+		i.ID, i.Title, i.Tool)
+	envPrefix += agentdeckEnvPrefix
+
 	// Passthrough: if the tool is literally "codex" and user gave a custom command
 	// (not the bare "codex" name), return as-is without flag injection.
 	// Codex-compatible tools (e.g., "my-codex" with CompatibleWith="codex") always
@@ -1230,10 +1239,6 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	if i.Tool == "codex" && trimmed != "codex" && trimmed != "" {
 		return envPrefix + trimmed
 	}
-
-	agentdeckEnvPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_TITLE=%q AGENTDECK_TOOL=%s ",
-		i.ID, i.Title, i.Tool)
-	envPrefix += agentdeckEnvPrefix
 	if isCodexHomeExplicit() {
 		codexHome := strings.TrimSpace(getCodexHomeDir())
 		if codexHome != "" {

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -105,6 +105,9 @@ type UserConfig struct {
 	// Crush defines charmbracelet/crush CLI integration settings (Issue #940)
 	Crush CrushSettings `toml:"crush"`
 
+	// Hermes defines Hermes Agent CLI integration settings
+	Hermes HermesSettings `toml:"hermes"`
+
 	// Worktree defines git worktree preferences
 	Worktree WorktreeSettings `toml:"worktree"`
 
@@ -839,6 +842,10 @@ type GeminiSettings struct {
 	// Sourced AFTER global [shell].env_files
 	// Path can be absolute, ~ for home, $HOME/${VAR} for env vars, or relative to session working directory
 	EnvFile string `toml:"env_file"`
+
+	// Command overrides the default binary/invocation for Gemini sessions.
+	// Supports flags (e.g., "gemini --custom-flag"). Default: "gemini"
+	Command string `toml:"command"`
 }
 
 // OpenCodeSettings defines OpenCode CLI configuration
@@ -856,6 +863,10 @@ type OpenCodeSettings struct {
 	// Sourced AFTER global [shell].env_files
 	// Path can be absolute, ~ for home, $HOME/${VAR} for env vars, or relative to session working directory
 	EnvFile string `toml:"env_file"`
+
+	// Command overrides the default binary/invocation for OpenCode sessions.
+	// Supports flags (e.g., "opencode --custom-flag"). Default: "opencode"
+	Command string `toml:"command"`
 }
 
 // CodexSettings defines Codex CLI configuration
@@ -871,6 +882,11 @@ type CodexSettings struct {
 	// YoloMode enables --yolo flag for Codex sessions (bypass approvals and sandbox)
 	// Default: false
 	YoloMode bool `toml:"yolo_mode"`
+
+	// EnvFile is a .env file specific to Codex sessions
+	// Sourced AFTER global [shell].env_files
+	// Path can be absolute, ~ for home, $HOME/${VAR} for env vars, or relative to session working directory
+	EnvFile string `toml:"env_file"`
 }
 
 // GetProfileCodexConfigDir returns the profile-specific Codex config directory, if configured.
@@ -892,6 +908,26 @@ type CopilotSettings struct {
 	// EnvFile is a .env file specific to Copilot sessions (sourced before
 	// the `copilot` command runs, like [gemini].env_file). Optional.
 	EnvFile string `toml:"env_file"`
+
+	// Command overrides the default binary/invocation for Copilot sessions.
+	// Supports flags (e.g., "copilot --custom-flag"). Default: "copilot"
+	Command string `toml:"command"`
+}
+
+// HermesSettings defines Hermes Agent CLI configuration.
+// Binary: `hermes` from github.com/NousResearch/hermes-agent (MIT, v0.13.0+).
+// Status detection: process-alive/dead only (content-sniffing deferred).
+type HermesSettings struct {
+	// Command is the Hermes CLI command or invocation to use.
+	// Supports flags (e.g., "hermes --model gpt-5.5-pro --provider openai").
+	// Default: "hermes"
+	Command string `toml:"command"`
+	// EnvFile is a .env file specific to Hermes sessions (sourced before
+	// the `hermes` command runs). Optional.
+	EnvFile string `toml:"env_file"`
+	// YoloMode enables --yolo flag for Hermes sessions (auto-approve all tool calls).
+	// Default: false
+	YoloMode bool `toml:"yolo_mode"`
 }
 
 // CrushSettings defines charmbracelet/crush CLI configuration (Issue #940).
@@ -2000,9 +2036,45 @@ func GetCustomToolNames() []string {
 	return names
 }
 
+// GetToolCommand returns the configured command override for a builtin tool,
+// falling back to the bare tool name if no override is set.
+func GetToolCommand(toolName string) string {
+	config, _ := LoadUserConfig()
+	if config == nil {
+		return toolName
+	}
+	switch toolName {
+	case "claude":
+		if config.Claude.Command != "" {
+			return config.Claude.Command
+		}
+	case "gemini":
+		if config.Gemini.Command != "" {
+			return config.Gemini.Command
+		}
+	case "opencode":
+		if config.OpenCode.Command != "" {
+			return config.OpenCode.Command
+		}
+	case "codex":
+		if config.Codex.Command != "" {
+			return config.Codex.Command
+		}
+	case "copilot":
+		if config.Copilot.Command != "" {
+			return config.Copilot.Command
+		}
+	case "hermes":
+		if config.Hermes.Command != "" {
+			return config.Hermes.Command
+		}
+	}
+	return toolName
+}
+
 func isBuiltinToolName(toolName string) bool {
 	switch toolName {
-	case "claude", "gemini", "opencode", "codex", "copilot", "crush", "pi", "shell", "cursor", "aider":
+	case "claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi", "shell", "aider":
 		return true
 	default:
 		return false
@@ -2030,10 +2102,12 @@ func GetToolIcon(toolName string) string {
 		return "🐙"
 	case "crush":
 		return "💘"
-	case "pi":
-		return "π"
 	case "cursor":
 		return "📝"
+	case "hermes":
+		return "☤"
+	case "pi":
+		return "π"
 	case "shell":
 		return "🐚"
 	default:

--- a/internal/tmux/hermes_test.go
+++ b/internal/tmux/hermes_test.go
@@ -1,0 +1,59 @@
+package tmux
+
+import "testing"
+
+// Hermes Agent CLI: tmux-layer detection tests.
+
+func TestDetectToolFromCommand_Hermes(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"bare hermes", "hermes", "hermes"},
+		{"hermes with yolo flag", "hermes --yolo", "hermes"},
+		{"hermes absolute path", "/usr/local/bin/hermes", "hermes"},
+		{"hermes home path", "/home/user/.local/bin/hermes", "hermes"},
+		{"uppercase binary", "HERMES", "hermes"},
+		{"hermes with args", "hermes --resume 20260225_143052_a1b2c3", "hermes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromCommand(tt.command); got != tt.want {
+				t.Fatalf("detectToolFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromCommand_Hermes_Negative(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		// Note: strings.Contains fallback is intentionally permissive
+		// (same as copilot matching "npx @github/copilot"). Only the
+		// basename switch provides strict matching.
+		{"herm is not hermes", "herm"},
+		{"prometheus is not hermes", "prometheus --config.file=prometheus.yml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectToolFromCommand(tt.command)
+			if got == "hermes" {
+				t.Fatalf("detectToolFromCommand(%q) = %q, should NOT match hermes", tt.command, got)
+			}
+		})
+	}
+}
+
+func TestDefaultRawPatterns_Hermes_ReturnsNil(t *testing.T) {
+	// Hermes has no content-sniffing patterns (deferred).
+	// DefaultRawPatterns should return nil, which is handled gracefully.
+	raw := DefaultRawPatterns("hermes")
+	if raw != nil {
+		t.Errorf("DefaultRawPatterns(\"hermes\") = %+v, want nil (no patterns registered)", raw)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -537,7 +537,7 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "pi", "cursor", "crush"}
+var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"claude": {
@@ -570,6 +570,11 @@ var toolDetectionPatterns = map[string][]*regexp.Regexp{
 		// Distinct phrases to avoid colliding with the English word "crush".
 		regexp.MustCompile(`(?i)\bcharm\s+crush\b`),
 		regexp.MustCompile(`(?i)\bcrush>\s*`),
+	},
+	"hermes": {
+		// Hermes Agent CLI (github.com/NousResearch/hermes-agent).
+		regexp.MustCompile(`(?i)\bhermes\s+agent\b`),
+		regexp.MustCompile(`(?i)\bnous\s*research\b`),
 	},
 	"pi": {
 		regexp.MustCompile(`(?mi)^\s*pi>\s*`),
@@ -605,10 +610,12 @@ func detectToolFromCommand(command string) string {
 			return "copilot"
 		case "crush":
 			return "crush"
-		case "pi":
-			return "pi"
 		case "cursor":
 			return "cursor"
+		case "hermes":
+			return "hermes"
+		case "pi":
+			return "pi"
 		}
 	}
 
@@ -625,10 +632,12 @@ func detectToolFromCommand(command string) string {
 		return "copilot"
 	case strings.Contains(cmdLower, "crush"):
 		return "crush"
-	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
-		return "pi"
 	case strings.Contains(cmdLower, "cursor"):
 		return "cursor"
+	case strings.Contains(cmdLower, "hermes"):
+		return "hermes"
+	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
+		return "pi"
 	default:
 		return ""
 	}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8368,11 +8368,13 @@ func createSessionTool(command string) (string, string) {
 		tool = "pi"
 	case "copilot":
 		tool = "copilot"
+	case "crush":
+		tool = "crush"
 	case "cursor":
 		tool = "cursor"
 		command = "cursor agent"
-	case "crush":
-		tool = "crush"
+	case "hermes":
+		tool = "hermes"
 	default:
 		if toolDef := session.GetToolDef(command); toolDef != nil {
 			tool = command

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -168,6 +168,16 @@ func TestCreateSessionTool_Crush(t *testing.T) {
 	}
 }
 
+// TUI session creation must produce Tool="hermes" rather than
+// Tool="shell" with Command="hermes", matching the tmux/userconfig
+// wiring for the Hermes Agent CLI integration.
+func TestCreateSessionTool_Hermes(t *testing.T) {
+	tool, command := createSessionTool("hermes")
+	if tool != "hermes" || command != "hermes" {
+		t.Fatalf("createSessionTool(\"hermes\") = (%q, %q), want (\"hermes\", \"hermes\")", tool, command)
+	}
+}
+
 func TestHomeInit(t *testing.T) {
 	home := NewHome()
 	cmd := home.Init()

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -246,7 +246,7 @@ func displayCommandPreset(cmd string) string {
 // buildPresetCommands returns the list of commands for the picker,
 // including any custom tools from config.toml.
 func buildPresetCommands() []string {
-	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "cursor", "crush"}
+	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -268,8 +268,8 @@ func TestDisplayCommandPreset(t *testing.T) {
 func TestDialogPresetCommands(t *testing.T) {
 	d := NewNewDialog()
 
-	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, cursor, crush
-	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "cursor", "crush"}
+	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, crush, cursor, hermes
+	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
 
 	if len(d.presetCommands) != len(expectedCommands) {
 		t.Errorf("Expected %d preset commands, got %d", len(expectedCommands), len(d.presetCommands))

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -107,8 +107,8 @@ type SettingsPanel struct {
 // builtinToolNames and builtinToolValues are the built-in tools. Custom tools
 // from config are appended dynamically in LoadConfig.
 var (
-	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Cursor", "Crush"}
-	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "cursor", "crush"}
+	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes"}
+	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
 )
 
 // Search tier names for radio selection

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -176,8 +176,10 @@ func TestSettingsPanel_LoadConfig_DefaultTool(t *testing.T) {
 		{"opencode", "opencode", "opencode"},
 		{"codex", "codex", "codex"},
 		{"pi", "pi", "pi"},
-		{"cursor", "cursor", "cursor"},
+		{"copilot", "copilot", "copilot"},
 		{"crush", "crush", "crush"},
+		{"cursor", "cursor", "cursor"},
+		{"hermes", "hermes", "hermes"},
 		{"empty", "", ""}, // None
 		{"unknown", "unknown-tool", ""},
 	}
@@ -210,8 +212,8 @@ func TestSettingsPanel_LoadConfig_CustomTools(t *testing.T) {
 
 	panel.LoadConfig(config)
 
-	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Cursor", "Crush", "Openclaw", "Zeta", "None"}
-	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "cursor", "crush", "openclaw", "zeta", ""}
+	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "Openclaw", "Zeta", "None"}
+	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "openclaw", "zeta", ""}
 
 	if !reflect.DeepEqual(panel.toolNames, wantNames) {
 		t.Fatalf("toolNames = %#v, want %#v", panel.toolNames, wantNames)
@@ -369,8 +371,10 @@ func TestSettingsPanel_GetConfig_ToolMapping(t *testing.T) {
 		{"opencode", "opencode", "opencode"},
 		{"codex", "codex", "codex"},
 		{"pi", "pi", "pi"},
-		{"cursor", "cursor", "cursor"},
+		{"copilot", "copilot", "copilot"},
 		{"crush", "crush", "crush"},
+		{"cursor", "cursor", "cursor"},
+		{"hermes", "hermes", "hermes"},
 		{"none", "", ""},
 	}
 

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -54,7 +54,7 @@ func NewSetupWizard() *SetupWizard {
 		visible:             false,
 		complete:            false,
 		currentStep:         0,
-		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "cursor", "crush"},
+		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes"},
 		selectedTool:        0, // Default to Claude
 		dangerousMode:       false,
 		useDefaultConfigDir: true,

--- a/internal/ui/setup_wizard_test.go
+++ b/internal/ui/setup_wizard_test.go
@@ -140,7 +140,7 @@ func TestSetupWizard_ToolOptions(t *testing.T) {
 	wizard := NewSetupWizard()
 
 	// Verify tool options
-	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "cursor", "crush"}
+	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes"}
 	if len(wizard.toolOptions) != len(expectedTools) {
 		t.Errorf("Tool options count: got %d, want %d", len(wizard.toolOptions), len(expectedTools))
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -521,6 +521,8 @@ func initStyles() {
 		"claude":   lipgloss.NewStyle().Foreground(ColorOrange),
 		"gemini":   lipgloss.NewStyle().Foreground(ColorPurple),
 		"codex":    lipgloss.NewStyle().Foreground(ColorCyan),
+		"copilot":  lipgloss.NewStyle().Foreground(ColorAccent),
+		"hermes":   lipgloss.NewStyle().Foreground(ColorYellow),
 		"pi":       lipgloss.NewStyle().Foreground(ColorAccent),
 		"aider":    lipgloss.NewStyle().Foreground(ColorRed),
 		"cursor":   lipgloss.NewStyle().Foreground(ColorAccent),
@@ -600,12 +602,16 @@ func ToolIcon(tool string) string {
 		return IconOpenCode
 	case "codex":
 		return IconCodex
+	case "copilot":
+		return "🐙"
 	case "crush":
 		return "💘"
-	case "pi":
-		return IconPi
 	case "cursor":
 		return "📝"
+	case "hermes":
+		return "☤"
+	case "pi":
+		return IconPi
 	case "shell":
 		return IconShell
 	default:
@@ -623,14 +629,18 @@ func ToolColor(tool string) lipgloss.Color {
 		return ColorPurple // Google AI purple
 	case "codex":
 		return ColorCyan // Light blue for OpenAI
+	case "copilot":
+		return ColorAccent // Blue for GitHub Copilot
 	case "crush":
 		return ColorPurple // Pink/magenta for Charm Crush
+	case "cursor":
+		return ColorAccent // Blue for Cursor
+	case "hermes":
+		return ColorYellow // Gold for Hermes Agent
 	case "pi":
 		return ColorAccent
 	case "aider":
 		return ColorRed // Red for Aider
-	case "cursor":
-		return ColorAccent // Blue for Cursor
 	default:
 		return ColorTextDim // Default gray
 	}

--- a/scripts/verify-command-override.d/fake-tool.sh
+++ b/scripts/verify-command-override.d/fake-tool.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# fake-tool.sh — Generic tool stub for verify-command-override.sh.
+#
+# Symlinked as hermes, gemini, opencode, codex, copilot, claude.
+# Logs the full invocation (basename + args) to $AGENT_DECK_VERIFY_ARGV_OUT,
+# then sleeps so the tmux pane stays alive for assertions.
+#
+# Contract:
+#   - Appends one line per invocation: "<basename> <args...>"
+#   - Never mutates user state. Never needs network.
+set -euo pipefail
+
+OUT="${AGENT_DECK_VERIFY_ARGV_OUT:-/tmp/adeck-verify-argv.$$}"
+mkdir -p "$(dirname "$OUT")"
+printf '%s %s\n' "$(basename "$0")" "$*" >> "$OUT"
+
+exec sleep infinity

--- a/scripts/verify-command-override.sh
+++ b/scripts/verify-command-override.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+# verify-command-override.sh — End-to-end verification for [tool].command and
+# [tool].env_file config overrides across all builtin agents.
+#
+# Tests that:
+#   1. Bare tool name (no config) → tmux runs the bare binary
+#   2. [tool].command override → tmux runs the overridden command
+#   3. CLI -c "tool --flags" → passthrough wins over config override
+#   4. [tool].yolo_mode (hermes) → --yolo appears in argv
+#   5. [tool].env_file → source prefix appears before command
+#
+# Usage:
+#   ./scripts/verify-command-override.sh           # Run all scenarios
+#   SCENARIO=3 ./scripts/verify-command-override.sh  # Run only scenario 3
+#
+# Requires: agent-deck binary on PATH (or built at ./agent-deck), tmux.
+# Uses fake tool stubs — no real AI binaries needed.
+set -euo pipefail
+
+# ---------- color + logging ----------
+readonly C_RED='\033[31m'
+readonly C_GREEN='\033[32m'
+readonly C_YELLOW='\033[33m'
+readonly C_RESET='\033[0m'
+
+banner_pass() { printf "${C_GREEN}[PASS]${C_RESET} %s\n" "$*"; }
+banner_fail() { printf "${C_RED}[FAIL]${C_RESET} %s\n" "$*" >&2; FAILED=1; }
+banner_skip() { printf "${C_YELLOW}[SKIP]${C_RESET} %s\n" "$*"; }
+log() { printf '    %s\n' "$*"; }
+
+FAILED=0
+RUN_ID="$$"
+TMPROOT="$(mktemp -d -t adeck-cmdoverride.XXXXXX)"
+TEST_HOME="${TMPROOT}/home"
+STUB_DIR="$(cd "$(dirname "$0")/verify-command-override.d" && pwd)"
+ARGV_OUT="${TMPROOT}/argv.log"
+SESSION_PREFIX="verify-cmd-${RUN_ID}"
+TMUX_SOCKET="adeck-verify-cmd-${RUN_ID}"
+
+export AGENT_DECK_VERIFY_ARGV_OUT="${ARGV_OUT}"
+
+# ---------- cleanup ----------
+cleanup() {
+  set +e
+  # Kill the isolated tmux server
+  tmux -L "${TMUX_SOCKET}" kill-server >/dev/null 2>&1 || true
+  # Remove tempdir
+  if [[ -n "${TMPROOT}" && "${TMPROOT}" == /tmp/adeck-cmdoverride.* ]]; then
+    rm -rf "${TMPROOT}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# ---------- preflight ----------
+AGENT_DECK_BIN=""
+if [[ -x "./agent-deck" ]]; then
+  AGENT_DECK_BIN="$(pwd)/agent-deck"
+elif command -v agent-deck >/dev/null 2>&1; then
+  AGENT_DECK_BIN="$(command -v agent-deck)"
+else
+  printf "${C_RED}ERROR${C_RESET}: agent-deck binary not found (./agent-deck or PATH).\n" >&2
+  exit 2
+fi
+if ! command -v tmux >/dev/null 2>&1; then
+  printf "${C_RED}ERROR${C_RESET}: tmux binary not on PATH.\n" >&2
+  exit 2
+fi
+
+log "agent-deck: ${AGENT_DECK_BIN}"
+log "tmux socket: ${TMUX_SOCKET}"
+log "test home: ${TEST_HOME}"
+
+# ---------- setup isolated environment ----------
+mkdir -p "${TEST_HOME}/.agent-deck"
+mkdir -p "${TMPROOT}/bin"
+mkdir -p "${TMPROOT}/project"
+
+# Create symlinks for all tool stubs (bare names + common override names)
+for tool in hermes gemini opencode codex copilot claude gemini-nightly codex-experimental gh; do
+  ln -sf "${STUB_DIR}/fake-tool.sh" "${TMPROOT}/bin/${tool}"
+done
+# Also symlink agent-deck into our bin dir
+ln -sf "${AGENT_DECK_BIN}" "${TMPROOT}/bin/agent-deck"
+
+# ---------- helpers ----------
+write_config() {
+  cat > "${TEST_HOME}/.agent-deck/config.toml" <<EOF
+[tmux]
+socket_name = "${TMUX_SOCKET}"
+
+$1
+EOF
+}
+
+# Run agent-deck with isolated HOME
+ad() {
+  HOME="${TEST_HOME}" PATH="${TMPROOT}/bin:${PATH}" \
+    TERM=dumb NO_COLOR=1 AGENTDECK_COLOR=none \
+    agent-deck "$@"
+}
+
+# Create a session, start it, wait, capture argv.
+# Outputs TWO lines: line 1 = stub argv (tool-level), line 2 = pane_start_command (full bash -c wrapper).
+# Callers use get_stub_argv / get_pane_cmd to extract.
+run_session() {
+  local name="$1"
+  local tool_or_cmd="$2"
+  shift 2
+  local extra_args=("$@")
+
+  : > "${ARGV_OUT}"
+
+  # Create session
+  ad add -t "${name}" -c "${tool_or_cmd}" "${extra_args[@]}" "${TMPROOT}/project" >/dev/null 2>&1
+
+  # Start session
+  ad session start "${name}" >/dev/null 2>&1
+  sleep 2
+
+  # Capture stub argv (what the fake tool binary received)
+  local stub_argv=""
+  if [[ -s "${ARGV_OUT}" ]]; then
+    stub_argv="$(tail -1 "${ARGV_OUT}")"
+  fi
+
+  # Capture pane_start_command (full bash -c wrapper including source prefix)
+  local pane_cmd=""
+  local tmux_sess
+  tmux_sess="$(ad session show --json "${name}" 2>/dev/null | jq -r '.tmux_session // empty' 2>/dev/null || true)"
+  if [[ -n "${tmux_sess}" && "${tmux_sess}" != "null" ]]; then
+    pane_cmd="$(tmux -L "${TMUX_SOCKET}" list-panes -t "${tmux_sess}" -F '#{pane_start_command}' 2>/dev/null | head -1 || true)"
+  fi
+
+  # Stop session
+  ad session stop "${name}" >/dev/null 2>&1 || true
+  sleep 1
+
+  # Return both (newline-separated). Use LAST_STUB_ARGV / LAST_PANE_CMD globals.
+  LAST_STUB_ARGV="${stub_argv}"
+  LAST_PANE_CMD="${pane_cmd}"
+}
+
+# Convenience: run session and return stub argv (for command/flag assertions)
+get_argv() {
+  echo "${LAST_STUB_ARGV}"
+}
+
+# Convenience: return pane_start_command (for env_file/source assertions)
+get_pane_cmd() {
+  echo "${LAST_PANE_CMD}"
+}
+
+want_scenario() {
+  local n="$1"
+  if [[ -z "${SCENARIO:-}" ]]; then return 0; fi
+  [[ "${SCENARIO}" == "${n}" ]]
+}
+
+# ---------- checklist ----------
+cat <<'EOF'
+==========================================================
+verify-command-override.sh — command/env_file override e2e
+==========================================================
+[ 1] hermes: bare name (no config override)
+[ 2] hermes: [hermes].command override
+[ 3] hermes: [hermes].yolo_mode = true
+[ 4] hermes: CLI extra args combine with config override
+[ 5] hermes: [hermes].env_file
+[ 6] gemini: bare name
+[ 7] gemini: [gemini].command override
+[ 8] gemini: [gemini].env_file
+[ 9] opencode: bare name
+[10] opencode: [opencode].command override
+[11] opencode: [opencode].env_file
+[12] codex: bare name
+[13] codex: [codex].command override
+[14] codex: [codex].env_file
+[15] copilot: bare name
+[16] copilot: [copilot].command override
+[17] copilot: [copilot].env_file
+==========================================================
+EOF
+
+# ---------- Scenario 1: hermes bare ----------
+if want_scenario 1; then
+  write_config ''
+  run_session "${SESSION_PREFIX}-s1" "hermes"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q "^hermes" || echo "${LAST_PANE_CMD}" | grep -q "hermes"; then
+    banner_pass "[1] hermes bare name → runs 'hermes'"
+  else
+    banner_fail "[1] hermes bare name: expected 'hermes' in output"
+  fi
+fi
+
+# ---------- Scenario 2: hermes command override ----------
+if want_scenario 2; then
+  write_config '[hermes]
+command = "hermes --model gpt-5.5-pro --provider openai"'
+  run_session "${SESSION_PREFIX}-s2" "hermes"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q -- "--model gpt-5.5-pro" || echo "${LAST_PANE_CMD}" | grep -q -- "--model gpt-5.5-pro"; then
+    banner_pass "[2] hermes command override → runs overridden command"
+  else
+    banner_fail "[2] hermes command override: expected '--model gpt-5.5-pro' in output"
+  fi
+fi
+
+# ---------- Scenario 3: hermes yolo_mode ----------
+if want_scenario 3; then
+  write_config '[hermes]
+yolo_mode = true'
+  run_session "${SESSION_PREFIX}-s3" "hermes"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q -- "--yolo" || echo "${LAST_PANE_CMD}" | grep -q -- "--yolo"; then
+    banner_pass "[3] hermes yolo_mode = true → --yolo in argv"
+  else
+    banner_fail "[3] hermes yolo_mode: expected '--yolo' in output"
+  fi
+fi
+
+# ---------- Scenario 4: hermes CLI extra args via wrapper ----------
+if want_scenario 4; then
+  write_config '[hermes]
+command = "hermes --model gpt-5.5-pro"'
+  run_session "${SESSION_PREFIX}-s4" "hermes --special-flag"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  # CLI "-c hermes --special-flag" splits into tool=hermes + wrapper="{command} --special-flag"
+  # Config override applies (--model gpt-5.5-pro), then wrapper appends --special-flag
+  combined="${LAST_STUB_ARGV} ${LAST_PANE_CMD}"
+  if echo "${combined}" | grep -q -- "--special-flag" && echo "${combined}" | grep -q -- "--model gpt-5.5-pro"; then
+    banner_pass "[4] hermes CLI extra args: config override + wrapper both applied"
+  else
+    banner_fail "[4] hermes CLI extra args: expected both '--model gpt-5.5-pro' and '--special-flag' in output"
+  fi
+fi
+
+# ---------- Scenario 5: hermes env_file ----------
+if want_scenario 5; then
+  echo 'HERMES_TEST_VAR=1' > "${TMPROOT}/hermes.env"
+  write_config "[hermes]
+env_file = \"${TMPROOT}/hermes.env\""
+  run_session "${SESSION_PREFIX}-s5" "hermes"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_PANE_CMD}" | grep -q "hermes.env"; then
+    banner_pass "[5] hermes env_file → source prefix in pane command"
+  else
+    banner_fail "[5] hermes env_file: no 'hermes.env' in pane_start_command"
+  fi
+fi
+
+# ---------- Scenario 6: gemini bare ----------
+if want_scenario 6; then
+  write_config ''
+  run_session "${SESSION_PREFIX}-s6" "gemini"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q "^gemini" || echo "${LAST_PANE_CMD}" | grep -q "gemini"; then
+    banner_pass "[6] gemini bare name → runs 'gemini'"
+  else
+    banner_fail "[6] gemini bare name: expected 'gemini' in output"
+  fi
+fi
+
+# ---------- Scenario 7: gemini command override ----------
+if want_scenario 7; then
+  write_config '[gemini]
+command = "gemini-nightly --experimental"'
+  run_session "${SESSION_PREFIX}-s7" "gemini"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q "gemini-nightly" || echo "${LAST_PANE_CMD}" | grep -q "gemini-nightly"; then
+    banner_pass "[7] gemini command override → runs overridden command"
+  else
+    banner_fail "[7] gemini command override: expected 'gemini-nightly' in output"
+  fi
+fi
+
+# ---------- Scenario 8: gemini env_file ----------
+if want_scenario 8; then
+  echo 'GEMINI_KEY=test' > "${TMPROOT}/gemini.env"
+  write_config "[gemini]
+env_file = \"${TMPROOT}/gemini.env\""
+  run_session "${SESSION_PREFIX}-s8" "gemini"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_PANE_CMD}" | grep -q "gemini.env"; then
+    banner_pass "[8] gemini env_file → source prefix in pane command"
+  else
+    banner_fail "[8] gemini env_file: no 'gemini.env' in pane_start_command"
+  fi
+fi
+
+# ---------- Scenario 9: opencode bare ----------
+if want_scenario 9; then
+  write_config ''
+  run_session "${SESSION_PREFIX}-s9" "opencode"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q "opencode" || echo "${LAST_PANE_CMD}" | grep -q "opencode"; then
+    banner_pass "[9] opencode bare name → runs 'opencode'"
+  else
+    banner_fail "[9] opencode bare name: expected 'opencode' in output"
+  fi
+fi
+
+# ---------- Scenario 10: opencode command override ----------
+if want_scenario 10; then
+  write_config '[opencode]
+command = "opencode --custom-flag"'
+  run_session "${SESSION_PREFIX}-s10" "opencode"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q -- "--custom-flag" || echo "${LAST_PANE_CMD}" | grep -q -- "--custom-flag"; then
+    banner_pass "[10] opencode command override → runs overridden command"
+  else
+    banner_fail "[10] opencode command override: expected '--custom-flag' in output"
+  fi
+fi
+
+# ---------- Scenario 11: opencode env_file ----------
+if want_scenario 11; then
+  echo 'OC_KEY=test' > "${TMPROOT}/opencode.env"
+  write_config "[opencode]
+env_file = \"${TMPROOT}/opencode.env\""
+  run_session "${SESSION_PREFIX}-s11" "opencode"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_PANE_CMD}" | grep -q "opencode.env"; then
+    banner_pass "[11] opencode env_file → source prefix in pane command"
+  else
+    banner_fail "[11] opencode env_file: no 'opencode.env' in pane_start_command"
+  fi
+fi
+
+# ---------- Scenario 12: codex bare ----------
+if want_scenario 12; then
+  write_config ''
+  run_session "${SESSION_PREFIX}-s12" "codex"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q "codex" || echo "${LAST_PANE_CMD}" | grep -q "codex"; then
+    banner_pass "[12] codex bare name → runs 'codex'"
+  else
+    banner_fail "[12] codex bare name: expected 'codex' in output"
+  fi
+fi
+
+# ---------- Scenario 13: codex command override ----------
+if want_scenario 13; then
+  write_config '[codex]
+command = "codex-experimental"'
+  run_session "${SESSION_PREFIX}-s13" "codex"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q "codex-experimental" || echo "${LAST_PANE_CMD}" | grep -q "codex-experimental"; then
+    banner_pass "[13] codex command override → runs overridden command"
+  else
+    banner_fail "[13] codex command override: expected 'codex-experimental' in output"
+  fi
+fi
+
+# ---------- Scenario 14: codex env_file ----------
+if want_scenario 14; then
+  echo 'CODEX_KEY=test' > "${TMPROOT}/codex.env"
+  write_config "[codex]
+env_file = \"${TMPROOT}/codex.env\""
+  run_session "${SESSION_PREFIX}-s14" "codex"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_PANE_CMD}" | grep -q "codex.env"; then
+    banner_pass "[14] codex env_file → source prefix in pane command"
+  else
+    banner_fail "[14] codex env_file: no 'codex.env' in pane_start_command"
+  fi
+fi
+
+# ---------- Scenario 15: copilot bare ----------
+if want_scenario 15; then
+  write_config ''
+  run_session "${SESSION_PREFIX}-s15" "copilot"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q "copilot" || echo "${LAST_PANE_CMD}" | grep -q "copilot"; then
+    banner_pass "[15] copilot bare name → runs 'copilot'"
+  else
+    banner_fail "[15] copilot bare name: expected 'copilot' in output"
+  fi
+fi
+
+# ---------- Scenario 16: copilot command override ----------
+if want_scenario 16; then
+  write_config '[copilot]
+command = "gh copilot-chat"'
+  run_session "${SESSION_PREFIX}-s16" "copilot"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_STUB_ARGV}" | grep -q "copilot-chat" || echo "${LAST_PANE_CMD}" | grep -q "copilot-chat"; then
+    banner_pass "[16] copilot command override → runs overridden command"
+  else
+    banner_fail "[16] copilot command override: expected 'copilot-chat' in output"
+  fi
+fi
+
+# ---------- Scenario 17: copilot env_file ----------
+if want_scenario 17; then
+  echo 'GH_TOKEN=test' > "${TMPROOT}/copilot.env"
+  write_config "[copilot]
+env_file = \"${TMPROOT}/copilot.env\""
+  run_session "${SESSION_PREFIX}-s17" "copilot"
+  log "stub_argv: ${LAST_STUB_ARGV}"
+  log "pane_cmd:  ${LAST_PANE_CMD}"
+  if echo "${LAST_PANE_CMD}" | grep -q "copilot.env"; then
+    banner_pass "[17] copilot env_file → source prefix in pane command"
+  else
+    banner_fail "[17] copilot env_file: no 'copilot.env' in pane_start_command"
+  fi
+fi
+
+# ---------- summary ----------
+echo "=========================================================="
+if [[ "${FAILED}" -ne 0 ]]; then
+  printf "${C_RED}OVERALL: FAIL${C_RESET}\n" >&2
+  exit 1
+fi
+printf "${C_GREEN}OVERALL: PASS${C_RESET}\n"
+exit 0

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -7,7 +7,11 @@ All options for `~/.agent-deck/config.toml`.
 - [Top-Level](#top-level)
 - [[shell] Section](#shell-section)
 - [[claude] Section](#claude-section)
+- [[gemini] Section](#gemini-section)
+- [[opencode] Section](#opencode-section)
 - [[codex] Section](#codex-section)
+- [[copilot] Section](#copilot-section)
+- [[hermes] Section](#hermes-section)
 - [[docker] Section](#docker-section)
 - [[worktree] Section](#worktree-section)
 - [[logs] Section](#logs-section)
@@ -82,6 +86,7 @@ config_dir = "~/.claude-work"      # Optional override for profile "work"
 | `use_teammate_mode` | bool | `false` | Adds `--teammate-mode tmux` to Claude sessions and is remembered from the New Session dialog. |
 | `extra_args` | array of strings | `[]` | Extra Claude CLI flags remembered from the New Session dialog and appended to new/restarted Claude sessions. Do not store secrets here. |
 | `env_file` | string | `""` | A .env file sourced for Claude sessions only. Sourced after global `[shell].env_files`. See [Path Resolution](#path-resolution). |
+| `command` | string | `"claude"` | Override the binary/invocation (e.g., `"cdw"` for a wrapper that sets `CLAUDE_CONFIG_DIR`). |
 
 Config resolution order for Claude config dir:
 1. `CLAUDE_CONFIG_DIR` env var
@@ -120,6 +125,44 @@ agent-deck hooks status -p work
 agent-deck hooks status -p clientx
 ```
 
+## [gemini] Section
+
+Gemini CLI integration settings.
+
+```toml
+[gemini]
+yolo_mode = true                    # Enable --yolo (auto-approve all actions)
+default_model = "gemini-2.5-flash"  # Model override
+env_file = "~/.gemini.env"          # .env file for Gemini sessions
+command = "gemini"                   # Binary/invocation override
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `yolo_mode` | bool | `false` | Maps to Gemini `--yolo`. |
+| `default_model` | string | `""` | Model to use (e.g., `"gemini-2.5-flash"`). Empty uses Gemini's default. |
+| `env_file` | string | `""` | A .env file sourced for Gemini sessions only. See [Path Resolution](#path-resolution). |
+| `command` | string | `"gemini"` | Override the binary/invocation. Supports flags. |
+
+## [opencode] Section
+
+OpenCode CLI integration settings.
+
+```toml
+[opencode]
+default_model = "anthropic/claude-sonnet-4-5-20250929"
+default_agent = ""
+env_file = "~/.opencode.env"
+command = "opencode"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `default_model` | string | `""` | Model in `provider/model` format. |
+| `default_agent` | string | `""` | Agent to use. Empty uses OpenCode's default. |
+| `env_file` | string | `""` | A .env file sourced for OpenCode sessions only. See [Path Resolution](#path-resolution). |
+| `command` | string | `"opencode"` | Override the binary/invocation. |
+
 ## [codex] Section
 
 Codex CLI integration settings.
@@ -128,12 +171,50 @@ Codex CLI integration settings.
 [codex]
 command = "codex"  # Codex CLI command or alias
 yolo_mode = true   # Enable --yolo (bypass approvals and sandbox)
+env_file = "~/.codex.env"
+command = "codex"
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `command` | string | `codex` | Codex CLI command or alias to launch built-in Codex sessions. Examples: `codex-v2`, `CODEX_HOME=~/.codex-work codex`. |
 | `yolo_mode` | bool | `false` | Maps to `codex --yolo` (`--dangerously-bypass-approvals-and-sandbox`). Can be overridden per-session. |
+| `env_file` | string | `""` | A .env file sourced for Codex sessions only. See [Path Resolution](#path-resolution). |
+| `command` | string | `"codex"` | Override the binary/invocation. |
+
+## [copilot] Section
+
+GitHub Copilot CLI integration settings.
+
+```toml
+[copilot]
+env_file = "~/.copilot.env"
+command = "copilot"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `env_file` | string | `""` | A .env file sourced for Copilot sessions only. See [Path Resolution](#path-resolution). |
+| `command` | string | `"copilot"` | Override the binary/invocation. |
+
+## [hermes] Section
+
+Hermes Agent CLI integration settings ([NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)).
+
+```toml
+[hermes]
+command = "hermes --model gpt-5.5-pro --provider openai"
+env_file = "~/.hermes.env"
+yolo_mode = false
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `command` | string | `"hermes"` | Override the binary/invocation. Supports flags (e.g., model/provider). |
+| `env_file` | string | `""` | A .env file sourced for Hermes sessions only. See [Path Resolution](#path-resolution). |
+| `yolo_mode` | bool | `false` | Maps to `hermes --yolo` (auto-approve all tool calls). |
+
+Status detection: process-alive/dead only. Content-sniffing planned for future release.
 
 When using a different Codex home, prefer an inline command such as `CODEX_HOME=~/.codex-work codex` or export `CODEX_HOME` before starting agent-deck. Shell aliases are allowed, but agent-deck cannot infer `CODEX_HOME` hidden inside an alias for resume-file discovery.
 
@@ -467,7 +548,7 @@ env = { API_KEY = "token", BASE_URL = "https://api.example.com" }
 | `env_file` | string | No | A .env file sourced for this tool only. Sourced after global `[shell].env_files`. See [Path Resolution](#path-resolution). |
 | `env` | map | No | Inline environment variables exported for this tool. These take highest priority, overriding both `[shell].env_files` and `env_file`. Values are single-quoted to prevent shell expansion. |
 
-**Built-in icons:** claude=🤖, gemini=✨, opencode=🌐, codex=💻, cursor=📝, shell=🐚
+**Built-in icons:** claude=🤖, gemini=✨, opencode=🌐, codex=💻, copilot=🐙, hermes=☤, cursor=📝, shell=🐚
 
 ## Path Resolution
 
@@ -501,8 +582,24 @@ env_file = "~/.claude.env"
 [profiles.work.claude]
 config_dir = "~/.claude-work"
 
+[gemini]
+yolo_mode = true
+env_file = "~/.gemini.env"
+
+[opencode]
+env_file = "~/.opencode.env"
+
 [codex]
 command = "codex"
+yolo_mode = false
+env_file = "~/.codex.env"
+
+[copilot]
+env_file = "~/.copilot.env"
+
+[hermes]
+command = "hermes --model gpt-5.5-pro --provider openai"
+env_file = "~/.hermes.env"
 yolo_mode = false
 
 [docker]


### PR DESCRIPTION
## Summary

Takeover of @sergeytrofimovsky's [#951](https://github.com/asheshgoplani/agent-deck/pull/951) — open for days, last touch was the rebase several days ago and the morning's specific-blocker comment got no reply in 4h. Re-applied against current `origin/main` (post-v1.9.18) with all three conflict clusters resolved and the design question answered.

Two commits:

1. **`feat: add Hermes Agent CLI support`** — Sergey's original commit (`Author: Sergey Trofimovsky`), cherry-picked onto current main with conflicts resolved. Sergey's authorship is preserved; the takeover note + cluster-merge notes are in the commit body.
2. **`fix(config): preserve AGENTDECK_* env injection`** — Restores the codex-passthrough AGENTDECK_INSTANCE_ID / AGENTDECK_TITLE / AGENTDECK_TOOL injection that the uniform-command rework had moved after the early-return. Pinned by a new regression test.

Closes #919.

## What lands

- **Hermes Agent CLI** as a first-class builtin agent (icon ☤, color gold, `[hermes]` config block with `command`, `env_file`, `yolo_mode`). Detection on binary basename + content patterns (`hermes agent`, `nous research`). UI presets land Hermes in the New Session dialog, setup wizard, and settings panel.
- **Uniform `[tool].command` + `[tool].env_file` override** for every builtin agent. `GetToolCommand()` is the shared helper; `GetClaudeCommand()` delegates to it. `Command` is now exposed on `GeminiSettings`, `OpenCodeSettings`, `CopilotSettings`. `EnvFile` is added to `CodexSettings` (was missing — closes the silent-ignore bug below).
- **Fix: `[opencode].env_file`, `[codex].env_file`, `[copilot].env_file` no longer silently ignored.** `getToolEnvFile()` fell through to `GetToolDef()` for these builtins which returned nil; now explicitly handled per tool.
- **`buildCopilotCommand` promoted** from default-case fallthrough to its own dedicated builder for symmetry with claude/gemini/opencode/codex/cursor/crush/hermes.
- **AGENTDECK_* env preserved on custom codex commands.** New regression test pins the contract.

## Reviewer findings from #951 + how the takeover resolved them

| Cluster | What collided | Resolution |
|---|---|---|
| **Adapter-registration sites** (`newdialog.go`, `settings_panel.go`, `home.go`, `instance.go`, `setup_wizard.go`, `tmux.go`, `styles.go`, `main.go`) | #1028 (Crush, May 17) and #893 (Cursor, today) added entries into the same lists/switches Hermes targets — preset arrays, tool-detection regex maps, tool→icon/color switches, `cmd→tool` router. | Alphabetised Hermes alongside Crush/Cursor in every list. Where the existing convention put `pi` after the core 4, the new ordering is `claude, gemini, opencode, codex, pi, copilot, crush, cursor, hermes`. Tests in `newdialog_test.go`, `settings_panel_test.go`, `setup_wizard_test.go`, `home_test.go`, `styles_test.go` updated in sync. Switched the test fixtures over to the HEAD `toolValueIndex(t, panel, …)` pattern (which survives reorderings) rather than sergey's hardcoded integer indices. |
| **`userconfig.go` overlaps #1038** | #1038 reshaped the env_file resolution path (added `GetGroupClaudeEnvFile` helper, per-group inheritance). Sergey's diff touched the same struct surface and added Codex env_file + Hermes config. | Re-applied env_file fix on top of #1038's helper. Resolved a duplicate `Command` field on `CodexSettings` (#1043 added `Command` for the codex home work; sergey's diff added another). Kept #1043's version, dropped sergey's duplicate. Hermes config landed alongside the other builtin sections. |
| **`cmd/agent-deck/main.go` + `CHANGELOG.md` vs v1.9.17/v1.9.18 scaffolding** | The cmd→tool router got Crush + Cursor cases in #1028/#893. CHANGELOG had a `[Unreleased]` re-anchor + the v1.9.18 entry above where sergey was adding entries. | Trivial textual merge. Sergey's Hermes/uniform-command entries land under `[Unreleased]`; v1.9.18 stays above v1.9.17 as released. |

## Design decision (from #951 review)

> Should the codex custom-command passthrough path drop the inline `AGENTDECK_INSTANCE_ID` / `AGENTDECK_TITLE` / `AGENTDECK_TOOL` env injection?

**No.** The uniform-command refactor on #951 introduced an early-return on the codex custom-command passthrough that returned before the `agentdeckEnvPrefix` line. That breaks the contract Claude/Codex hook subprocesses rely on — they read `AGENTDECK_INSTANCE_ID` from the inherited env to find the spawning session. Dropping it silently breaks hook state lookup for any user who runs codex via a wrapper script (which is exactly the case `[codex].command` is meant to support).

The fix (commit 2) moves the AGENTDECK_* injection ahead of the early-return so it lands on every codex-flavoured launch, custom command or not. Pinned by `TestBuildCodexCommand_PassthroughKeepsAgentdeckEnv` so this can't silently regress again. The other build*Command paths (claude, gemini, opencode, cursor, crush, hermes, copilot) set `AGENTDECK_INSTANCE_ID` at the `tmux.SetEnvironment` layer in `Start()` — only codex needs the inline prefix because its hook subprocesses do not inherit the tmux pane env.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Targeted regression tests pass (`TestBuildClaudeCommand_*`, `TestBuildCodexCommand_*`, `TestSpawnEnv_ExposesResolvedConfigDirHint*`)
- [x] Full `go test -race -count=1 ./...` green across all 36 packages
- [x] New `TestBuildCodexCommand_PassthroughKeepsAgentdeckEnv` regression test pins the AGENTDECK_* contract
- [ ] CI to confirm on full GitHub Actions matrix

## Credit

Original work by **@sergeytrofimovsky** in **#951**. The Hermes adapter scaffolding, the uniform `[tool].command` / `[tool].env_file` helper, and the `verify-command-override.sh` e2e script are all his. Takeover only handled the rebase + the AGENTDECK_* design call.