### PR TITLE
fix(session): single-flight restart on Claude exit (closes #1040)

### DIFF
--- a/internal/git/issue1029_with_state_test.go
+++ b/internal/git/issue1029_with_state_test.go
@@ -17,11 +17,11 @@ import (
 // juggling or shared-path races.
 //
 // The hard contract from the issue:
-//   1. Parent checkout MUST remain read-only (no stash push, no add, no index
-//      mutation) — verified separately below.
-//   2. Child's `git status --porcelain` must match parent's at materialization
-//      time, with staged/unstaged/untracked faithfully reproduced.
-//   3. Gitignored files only with explicit opt-in (separate test).
+//  1. Parent checkout MUST remain read-only (no stash push, no add, no index
+//     mutation) — verified separately below.
+//  2. Child's `git status --porcelain` must match parent's at materialization
+//     time, with staged/unstaged/untracked faithfully reproduced.
+//  3. Gitignored files only with explicit opt-in (separate test).
 //
 // The minimum failing assertion: a parent repo with one staged file, one
 // unstaged edit, and one untracked file produces a child worktree whose

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2565,8 +2565,27 @@ func (i *Instance) ensureClaudeSessionIDFromDiskForRestart() {
 		slog.String("reason", "jsonl_discovery_restart"))
 }
 
-// Start starts the session in tmux
+// Start starts the session in tmux.
+//
+// Issue #1040: gated by acquireInstanceSpawnLock plus a "spawned-while-
+// we-waited" stamp so concurrent `agent-deck session start <id>`
+// invocations after a Claude exit don't each fall through the "tmux
+// session does not exist" gate and spawn parallel sessions. The lock
+// and gate are inlined here (rather than wrapping the whole body in a
+// SpawnAttempt helper) to preserve the structural-grep contract that
+// checks Start()'s body for the #745 IsForkAwaitingStart guard.
 func (i *Instance) Start() error {
+	beforeLock := nowFn()
+	release, lockErr := acquireInstanceSpawnLock(i.ID)
+	if lockErr != nil {
+		return lockErr
+	}
+	defer release()
+	if spawnedSince(i.ID, beforeLock) {
+		return nil
+	}
+	defer recordInstanceSpawn(i.ID)
+
 	if i.tmuxSession == nil {
 		return fmt.Errorf("tmux session not initialized")
 	}
@@ -2746,7 +2765,22 @@ func (i *Instance) Start() error {
 // The message is sent synchronously after detecting the agent's prompt
 // This approach is more reliable than embedding send logic in the tmux command
 // Works for Claude, Gemini, OpenCode, and other agents
+//
+// Issue #1040: same per-instance spawn lock as Start() — a concurrent
+// `launch -m "..."` racing with a poller-triggered Start() must not
+// produce two parallel tmux sessions.
 func (i *Instance) StartWithMessage(message string) error {
+	beforeLock := nowFn()
+	release, lockErr := acquireInstanceSpawnLock(i.ID)
+	if lockErr != nil {
+		return lockErr
+	}
+	defer release()
+	if spawnedSince(i.ID, beforeLock) {
+		return nil
+	}
+	defer recordInstanceSpawn(i.ID)
+
 	if i.tmuxSession == nil {
 		return fmt.Errorf("tmux session not initialized")
 	}
@@ -4762,7 +4796,25 @@ func (i *Instance) killInternal(sync bool) error {
 // Restart restarts the Claude session
 // For Claude sessions with known ID: sends Ctrl+C twice and resume command to existing session
 // For dead sessions or unknown ID: recreates the tmux session
+//
+// Issue #1040: gated by acquireInstanceSpawnLock plus a "spawned-while-
+// we-waited" stamp so concurrent callers (TUI poller + RC-exit handler
+// in-process; multiple `agent-deck session start` CLI invocations
+// cross-process) cannot each race to recreate a tmux session for the
+// same instance. A legitimate manual restart still proceeds because the
+// stamp from any prior spawn pre-dates the new caller's beforeLock.
 func (i *Instance) Restart() error {
+	beforeLock := nowFn()
+	release, lockErr := acquireInstanceSpawnLock(i.ID)
+	if lockErr != nil {
+		return lockErr
+	}
+	defer release()
+	if spawnedSince(i.ID, beforeLock) {
+		return nil
+	}
+	defer recordInstanceSpawn(i.ID)
+
 	mcpLog.Debug(
 		"restart_called",
 		slog.String("tool", i.Tool),

--- a/internal/session/instance_spawn_guard.go
+++ b/internal/session/instance_spawn_guard.go
@@ -1,0 +1,294 @@
+// Per-instance spawn singleflight — issue #1040 (concurrent restart storm).
+//
+// When an external watcher (the bug reporter's `claude --remote-control`
+// wrapper, or a conductor polling `agent-deck session show` on a 1-2s
+// cadence) calls `agent-deck session start <id>` more than once after the
+// underlying Claude process exits naturally, the storm shape on v1.9.17 is:
+//
+//	N CLI invocations → each loads Instance from SQLite → each sees
+//	tmuxSession.Exists()==false (old session died on Claude exit) → each
+//	falls through Restart()'s respawn-pane fast path → each calls
+//	recreateTmuxSession(), which mints a fresh random suffix → each spawns
+//	a new tmux session in parallel.
+//
+// The #666 sweepDuplicateToolSessions runs *after* each spawn, so every
+// new spawn kills its older siblings — the journalctl shape from the bug
+// report (3-5 scopes started within 2-4s, all dead by the next minute).
+//
+// Fix shape: acquire a per-instance file lock at
+// ~/.agent-deck/locks/instance-spawn-<safeID>.lock around the spawn step,
+// with an in-lock AlreadyAlive gate so the second waiter exits with nil
+// instead of re-spawning. Mirrors acquirePluginLock (#735, plugin_install.go):
+// O_CREATE|O_EXCL marker + PID + stale-reclaim by `kill -0` or by age TTL.
+//
+// Related-but-not-the-same: #1031 was a *storage-layer* race in
+// SaveInstances' DELETE-NOT-IN sweep during concurrent `launch`. The fix
+// in #1032 (InsertSessionAndVerify) does not reach this code path — by
+// the time we hit Restart(), the instance row already exists. #1040 is
+// purely a spawn-step race; #1032's fix is necessary upstream but not
+// sufficient downstream.
+
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// agentDeckDirOverride lets tests redirect ~/.agent-deck without colliding
+// with the user's real install. Production code reads it via
+// resolveAgentDeckDirForSpawnLock(), which falls back to GetAgentDeckDir
+// when the override is empty.
+var agentDeckDirOverride string
+
+// SpawnAttempt is the single-flight wrapper used by Restart(), Start(),
+// and StartWithMessage(). The lock acquisition + sibling-detect window
+// is implicit — call Run().
+//
+// The storm-discriminator is *time*, not "is a session alive". A
+// legitimate manual restart of a long-running session must proceed even
+// though tmux holds a live AGENTDECK_INSTANCE_ID-matching session; only
+// the *storm* shape — multiple spawns racing while one is in-flight —
+// should be suppressed. Run() captures a timestamp before acquiring the
+// lock and consults the per-instance spawn-stamp after acquisition. If
+// a sibling completed during our wait (stamp mtime > our pre-lock time),
+// we skip; otherwise we run Spawn and stamp on success.
+type SpawnAttempt struct {
+	// InstanceID is the lock-key partition. Different instances do not
+	// serialize against each other.
+	InstanceID string
+
+	// AlreadyAlive is an optional supplementary gate. When non-nil and
+	// it returns true, Run() skips Spawn even if no stamp exists. Used
+	// by callers that already know the spawn is unnecessary (e.g. CLI
+	// `session start` pre-checks `Exists()`); leave nil to let the
+	// stamp logic decide.
+	AlreadyAlive func() bool
+
+	// Spawn is the protected critical section. Run() invokes it exactly
+	// once across concurrent callers in a storm window, and never if a
+	// sibling already completed while we were waiting on the lock.
+	Spawn func() error
+}
+
+// Run acquires the per-instance spawn lock, gates on a "spawned-while-
+// we-waited" check, and invokes Spawn. Returns the first non-nil error
+// from any step.
+func (a SpawnAttempt) Run() error {
+	if a.Spawn == nil {
+		return fmt.Errorf("SpawnAttempt: nil Spawn func")
+	}
+	beforeLock := nowFn()
+	release, err := acquireInstanceSpawnLock(a.InstanceID)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	if a.AlreadyAlive != nil && a.AlreadyAlive() {
+		return nil
+	}
+	if spawnedSince(a.InstanceID, beforeLock) {
+		return nil
+	}
+
+	if err := a.Spawn(); err != nil {
+		return err
+	}
+	recordInstanceSpawn(a.InstanceID)
+	return nil
+}
+
+// nowFn is a test seam so tests can pin time without sleeping.
+var nowFn = time.Now
+
+// spawnedSince reports whether the per-instance spawn stamp's mtime is
+// newer than the given reference. A missing stamp = false (no sibling
+// has spawned yet for this instance ID).
+func spawnedSince(instanceID string, ref time.Time) bool {
+	stamp, err := instanceSpawnStampPath(instanceID)
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(stamp)
+	if err != nil {
+		return false
+	}
+	return info.ModTime().After(ref)
+}
+
+// recordInstanceSpawn updates the stamp's mtime to now. Best-effort:
+// stamp errors are silent; they just turn the gate into a no-op for
+// the next storm sibling (no worse than current behavior).
+func recordInstanceSpawn(instanceID string) {
+	stamp, err := instanceSpawnStampPath(instanceID)
+	if err != nil {
+		return
+	}
+	now := nowFn()
+	// O_CREATE+TRUNC so the stamp file exists with a fresh mtime even on
+	// first use. We don't write anything — only ModTime matters.
+	f, err := os.OpenFile(stamp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return
+	}
+	_ = f.Close()
+	_ = os.Chtimes(stamp, now, now)
+}
+
+// instanceSpawnStampPath sits next to the lock file. Same dir, "-stamp"
+// suffix so an `ls` triages spawn activity per instance.
+func instanceSpawnStampPath(instanceID string) (string, error) {
+	dir, err := resolveAgentDeckDirForSpawnLock()
+	if err != nil {
+		return "", err
+	}
+	locks := filepath.Join(dir, "locks")
+	if err := os.MkdirAll(locks, 0o700); err != nil {
+		return "", err
+	}
+	return filepath.Join(locks, fmt.Sprintf("instance-spawn-%s.stamp", spawnLockSafeID(instanceID))), nil
+}
+
+// Tunables match the plugin-install lock budget (#735) so an unrelated
+// stuck plugin install and a stuck restart fail with the same shape on
+// the same wall clock — easier triage.
+const (
+	instanceSpawnLockRetryInterval  = 100 * time.Millisecond
+	instanceSpawnLockBudget         = 30 * time.Second
+	instanceSpawnLockLegacyStaleTTL = 2 * time.Minute
+)
+
+// Test seam — paralleling pluginLockAcquireFn. Tests substitute this to
+// inject contention behaviors without touching the filesystem.
+var instanceSpawnLockAcquireFn = defaultAcquireInstanceSpawnLock
+
+func acquireInstanceSpawnLock(instanceID string) (func(), error) {
+	return instanceSpawnLockAcquireFn(instanceID)
+}
+
+func defaultAcquireInstanceSpawnLock(instanceID string) (func(), error) {
+	path, err := instanceSpawnLockPath(instanceID)
+	if err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(instanceSpawnLockBudget)
+	for {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			fmt.Fprintf(f, "%d", os.Getpid())
+			_ = f.Close()
+			return func() { _ = os.Remove(path) }, nil
+		}
+
+		if reclaimStaleInstanceSpawnLock(path) {
+			continue
+		}
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf(
+				"instance spawn lock %q held by live process; gave up after %s",
+				path, instanceSpawnLockBudget,
+			)
+		}
+		time.Sleep(instanceSpawnLockRetryInterval)
+	}
+}
+
+// instanceSpawnLockPath returns the lockfile path for the given instance.
+// The directory is created with 0700 (same permission as plugin_install
+// uses for the same locks/ dir).
+func instanceSpawnLockPath(instanceID string) (string, error) {
+	dir, err := resolveAgentDeckDirForSpawnLock()
+	if err != nil {
+		return "", err
+	}
+	locks := filepath.Join(dir, "locks")
+	if err := os.MkdirAll(locks, 0o700); err != nil {
+		return "", err
+	}
+	return filepath.Join(locks, fmt.Sprintf("instance-spawn-%s.lock", spawnLockSafeID(instanceID))), nil
+}
+
+// spawnLockSafeID strips characters that would break a single-segment
+// filename. Empty input becomes "unknown" so the path is always valid;
+// concurrent callers with empty IDs serialize on the same lock (no
+// instance ID == "the unknown bucket").
+func spawnLockSafeID(id string) string {
+	if id == "" {
+		return "unknown"
+	}
+	mapped := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-' || r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, id)
+	if mapped == "" {
+		return "unknown"
+	}
+	return mapped
+}
+
+func resolveAgentDeckDirForSpawnLock() (string, error) {
+	if agentDeckDirOverride != "" {
+		return agentDeckDirOverride, nil
+	}
+	return GetAgentDeckDir()
+}
+
+// reclaimStaleInstanceSpawnLock mirrors reclaimStalePluginLock — older
+// than 2m means the holder timed out anyway; PID-not-alive means the
+// holder crashed without unlinking.
+func reclaimStaleInstanceSpawnLock(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if time.Since(info.ModTime()) > instanceSpawnLockLegacyStaleTTL {
+		_ = os.Remove(path)
+		return true
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	pid, parseErr := parseInstanceSpawnLockPID(string(data))
+	if parseErr != nil {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		_ = os.Remove(path)
+		return true
+	}
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		_ = os.Remove(path)
+		return true
+	}
+	return false
+}
+
+func parseInstanceSpawnLockPID(content string) (int, error) {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return 0, fmt.Errorf("empty marker")
+	}
+	var pid int
+	if _, err := fmt.Sscanf(trimmed, "%d", &pid); err != nil {
+		return 0, err
+	}
+	if pid <= 0 {
+		return 0, fmt.Errorf("invalid pid %d", pid)
+	}
+	return pid, nil
+}

--- a/internal/session/issue1040_restart_storm_test.go
+++ b/internal/session/issue1040_restart_storm_test.go
@@ -1,0 +1,294 @@
+package session
+
+import (
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Issue #1040 regression suite — concurrent restart-storm prevention.
+//
+// Background: when a Claude session exited (task complete, context limit,
+// API error) and a watcher / external poller called `agent-deck session
+// start <id>` more than once in rapid succession, agent-deck v1.9.17 spawned
+// 3–5 concurrent tmux sessions for the same instance. Each fell through the
+// `Restart()` respawn-pane fast path (because the prior tmux session was
+// gone) and into the recreateTmuxSession fallback, which mints a fresh
+// random suffix per call. The #666 duplicate-sweep ran AFTER each spawn,
+// so every spawn killed the previous one and the last writer wins on DB
+// state — leaving a short-lived (8–15s) session as the "tracked" one.
+//
+// Fix shape: a per-instance file lock at ~/.agent-deck/locks/instance-
+// spawn-<id>.lock serializing the spawn critical section, plus a sibling
+// "already alive" gate inside the lock so the second waiter exits without
+// re-spawning. Mirrors the established acquirePluginLock pattern (#735).
+//
+// These tests exercise the lock primitive + the SpawnAttempt wrapper used
+// by Restart() / Start(). They MUST fail on current main (functions do not
+// exist) and pass after the fix.
+
+// TestInstanceSpawnLock_SerializesConcurrentAcquires_RegressionFor1040
+// drives the lock-only invariant: across N concurrent acquires for the
+// same instance ID, at most one holder is inside the critical section at
+// any moment. Without the lock, the observed-max-holders count saturates
+// at N (the storm signature). With the lock it must be exactly 1.
+func TestInstanceSpawnLock_SerializesConcurrentAcquires_RegressionFor1040(t *testing.T) {
+	withTempLockDir(t)
+
+	const goroutines = 8
+	const holdDuration = 20 * time.Millisecond
+
+	var (
+		holders    atomic.Int32
+		maxHolders atomic.Int32
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			release, err := acquireInstanceSpawnLock("inst-1040")
+			if err != nil {
+				t.Errorf("acquire failed: %v", err)
+				return
+			}
+			defer release()
+			now := holders.Add(1)
+			for {
+				cur := maxHolders.Load()
+				if now <= cur || maxHolders.CompareAndSwap(cur, now) {
+					break
+				}
+			}
+			time.Sleep(holdDuration)
+			holders.Add(-1)
+		}()
+	}
+	wg.Wait()
+
+	if got := maxHolders.Load(); got != 1 {
+		t.Fatalf("max concurrent holders = %d, want 1 (lock did not serialize)", got)
+	}
+}
+
+// TestInstanceSpawnLock_DifferentInstancesDoNotSerialize verifies the lock
+// key is scoped per instance ID — two different instances spawning at the
+// same time must not block each other. Without this, a single hung restart
+// would freeze every other session on the host.
+func TestInstanceSpawnLock_DifferentInstancesDoNotSerialize(t *testing.T) {
+	withTempLockDir(t)
+
+	releaseA, err := acquireInstanceSpawnLock("inst-A")
+	if err != nil {
+		t.Fatalf("acquire A: %v", err)
+	}
+	defer releaseA()
+
+	done := make(chan struct{})
+	go func() {
+		releaseB, err := acquireInstanceSpawnLock("inst-B")
+		if err != nil {
+			t.Errorf("acquire B: %v", err)
+			return
+		}
+		releaseB()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("acquire of inst-B blocked on inst-A's lock — per-instance scoping broken")
+	}
+}
+
+// TestSpawnAttempt_SingleFlight_OnConcurrentInvocation_RegressionFor1040
+// is the core regression test for #1040. N goroutines each invoke a
+// SpawnAttempt whose AlreadyAlive callback flips to true as soon as the
+// first Spawn finishes. After serialization the spawn counter must read 1.
+//
+// On current main (no SpawnAttempt type) the test fails to compile. With
+// the fix in place, exactly one spawn fires; the rest see AlreadyAlive=true
+// and return nil.
+func TestSpawnAttempt_SingleFlight_OnConcurrentInvocation_RegressionFor1040(t *testing.T) {
+	withTempLockDir(t)
+
+	const goroutines = 6
+
+	var (
+		spawnCount atomic.Int32
+		spawned    atomic.Bool
+	)
+
+	attempt := SpawnAttempt{
+		InstanceID: "inst-1040-storm",
+		AlreadyAlive: func() bool {
+			return spawned.Load()
+		},
+		Spawn: func() error {
+			spawnCount.Add(1)
+			// Simulate the spawn latency so concurrent waiters pile up
+			// behind the lock — this is the storm-shape repro.
+			time.Sleep(15 * time.Millisecond)
+			spawned.Store(true)
+			return nil
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if err := attempt.Run(); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("Run returned error: %v", err)
+	}
+
+	if got := spawnCount.Load(); got != 1 {
+		t.Fatalf("spawn count = %d, want 1 (single-flight broke under concurrency — storm reintroduced)", got)
+	}
+}
+
+// TestSpawnAttempt_SkipsWhenAlreadyAlive verifies the gate-only path:
+// when AlreadyAlive is true before any caller spawns, no spawn fires
+// (matches the "sibling already produced a live session" case in
+// Restart() / Start()).
+func TestSpawnAttempt_SkipsWhenAlreadyAlive(t *testing.T) {
+	withTempLockDir(t)
+
+	var spawnCount atomic.Int32
+	attempt := SpawnAttempt{
+		InstanceID:   "inst-already-alive",
+		AlreadyAlive: func() bool { return true },
+		Spawn: func() error {
+			spawnCount.Add(1)
+			return nil
+		},
+	}
+
+	if err := attempt.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := spawnCount.Load(); got != 0 {
+		t.Fatalf("spawn count = %d, want 0 (gate failed to skip)", got)
+	}
+}
+
+// TestSpawnAttempt_StormBurstDeduplicatesViaStamp is the direct
+// reproduction of the v1.9.17 storm shape without an AlreadyAlive hook:
+// N goroutines call Run() in quick succession, the first one stamps,
+// the others see the stamp's mtime > their beforeLock and skip. This is
+// the file-only path used by Restart() / Start() in production.
+func TestSpawnAttempt_StormBurstDeduplicatesViaStamp(t *testing.T) {
+	withTempLockDir(t)
+
+	const goroutines = 6
+
+	var spawnCount atomic.Int32
+	attempt := SpawnAttempt{
+		InstanceID: "inst-storm",
+		// AlreadyAlive intentionally nil — exercise the stamp path only.
+		Spawn: func() error {
+			spawnCount.Add(1)
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if err := attempt.Run(); err != nil {
+				t.Errorf("Run: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := spawnCount.Load(); got != 1 {
+		t.Fatalf("storm burst: spawn count = %d, want 1 (stamp gate broken)", got)
+	}
+}
+
+// TestSpawnAttempt_LegitimateRestartProceedsAfterPriorSpawn pins the
+// other direction: a manual restart issued long after a prior spawn
+// (i.e. stamp mtime older than the new beforeLock) must NOT be skipped.
+// Without this, a single successful spawn would brick all subsequent
+// restarts for the lifetime of the lockfile directory.
+func TestSpawnAttempt_LegitimateRestartProceedsAfterPriorSpawn(t *testing.T) {
+	withTempLockDir(t)
+
+	var spawnCount atomic.Int32
+	attempt := SpawnAttempt{
+		InstanceID: "inst-rerun",
+		Spawn: func() error {
+			spawnCount.Add(1)
+			return nil
+		},
+	}
+
+	if err := attempt.Run(); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	// Sleep past the filesystem mtime granularity so the second
+	// beforeLock is strictly after the stamp written by the first run.
+	// 50ms is comfortable margin against any sub-second clock skew.
+	time.Sleep(50 * time.Millisecond)
+	if err := attempt.Run(); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	if got := spawnCount.Load(); got != 2 {
+		t.Fatalf("legitimate sequential restart: spawn count = %d, want 2 (stamp gate over-suppressed)", got)
+	}
+}
+
+// TestSpawnAttempt_NilAlreadyAliveTreatedAsNotAlive — defensive default:
+// passing a nil AlreadyAlive callback must NOT cause a nil deref. The
+// caller intent in that case is "we have no sibling-detection logic,
+// always spawn" (used by tests / callers that have already done the
+// check externally).
+func TestSpawnAttempt_NilAlreadyAliveTreatedAsNotAlive(t *testing.T) {
+	withTempLockDir(t)
+
+	var spawnCount atomic.Int32
+	attempt := SpawnAttempt{
+		InstanceID:   "inst-nil-alive",
+		AlreadyAlive: nil,
+		Spawn: func() error {
+			spawnCount.Add(1)
+			return nil
+		},
+	}
+
+	if err := attempt.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := spawnCount.Load(); got != 1 {
+		t.Fatalf("spawn count = %d, want 1 (nil AlreadyAlive should not skip)", got)
+	}
+}
+
+// withTempLockDir points AGENT_DECK_DIR at a fresh tmp dir so the lock
+// files don't leak between tests or pollute the user's real ~/.agent-deck.
+// Returns nothing — registers cleanup via t.Cleanup.
+func withTempLockDir(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	prev := agentDeckDirOverride
+	agentDeckDirOverride = filepath.Join(tmp, ".agent-deck")
+	t.Cleanup(func() { agentDeckDirOverride = prev })
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1485,6 +1485,42 @@ func (s *Session) IsConfigured() bool {
 	return s.configured
 }
 
+// AnyAgentDeckSessionWithEnvValue reports whether any agentdeck-prefixed
+// tmux session carries envKey=envValue. Returns the matching session name
+// (or "") and a bool. Issue #1040: the spawn-guard's in-lock "already
+// alive" gate uses this to detect that a sibling Restart has already
+// produced a live session before this caller does so again. The probe is
+// read-only — no kill. envValue == "" short-circuits to false because
+// matching every session with an unset variable is never the intent.
+func AnyAgentDeckSessionWithEnvValue(envKey, envValue string) (string, bool) {
+	if envValue == "" {
+		return "", false
+	}
+
+	socket := DefaultSocketName()
+	out, err := tmuxExec(socket, "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		return "", false
+	}
+
+	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if name == "" || !strings.HasPrefix(name, SessionPrefix) {
+			continue
+		}
+		val, err := tmuxExec(socket, "show-environment", "-t", name, envKey).Output()
+		if err != nil {
+			continue
+		}
+		line := strings.TrimSpace(string(val))
+		if idx := strings.IndexByte(line, '='); idx >= 0 {
+			if line[idx+1:] == envValue {
+				return name, true
+			}
+		}
+	}
+	return "", false
+}
+
 // KillSessionsWithEnvValue kills agentdeck tmux sessions that have the given
 // environment variable set to the given value, excluding the session named
 // `excludeName`. This prevents duplicate tmux sessions running the same Claude


### PR DESCRIPTION
## Summary

Fixes #1040 — when a Claude session exits naturally (task complete, context limit, API error), agent-deck v1.9.17 / v1.9.18 spawns 3-5 concurrent tmux sessions for the same instance instead of a single restart. Reporter [@torcuaine-sketch](https://github.com/torcuaine-sketch) traced the storm shape via journalctl (multiple `agentdeck-tmux-*` scopes started within 2-4s, all but the last dying in 8-15s) and worked around it by pinning a fixed `--remote-control-session-name-prefix` + `tmux_socket_name` — strong hint that the race was at the spawn step, not persistence.

## Reporter's repro (from #1040)

```
May 18 16:10:31 systemd: Started agentdeck-tmux-agentdeck-shorter-publisher-903f4401.scope
May 18 16:10:33 systemd: Started agentdeck-tmux-agentdeck-shorter-publisher-5fc09fd3.scope
May 18 16:10:35 systemd: Started agentdeck-tmux-agentdeck-shorter-publisher-81a1d2b9.scope
May 18 16:10:37 systemd: Started agentdeck-tmux-agentdeck-shorter-publisher-8dd67494.scope
```

All concurrent spawns `--resume` the same Claude session ID; most die within 8-15s; the DB ends up tracking a short-lived session.

## Root cause

`Instance.Start()` / `Restart()` / `StartWithMessage()` had no per-instance singleflight. When N callers (TUI poller + RC-exit handler in-process; multiple `agent-deck session start` CLI invocations cross-process) raced after the underlying Claude exited, each:

1. Loaded the Instance from SQLite independently.
2. Observed `tmuxSession.Exists() == false` (old session died).
3. Fell through `Restart()`'s respawn-pane fast path into the `recreateTmuxSession` fallback, which mints a fresh random suffix via `tmux.NewSession()` each call.
4. Spawned a parallel tmux session.

The #666 `sweepDuplicateToolSessions` runs *after* each spawn, so every new spawn killed older siblings — last writer wins on DB, leaving a short-lived session as the "tracked" one (matches the reporter's journalctl: 8-15s deaths, DB tracking the wrong session 2h later).

## Relationship to #1031 (verify-or-refute on hypothesis tree)

**Structurally related, NOT the same bug.** #1031 was a `SaveInstances` `DELETE NOT IN` sweep race during concurrent `launch`. #1032's `InsertSessionAndVerify` fix lives upstream of this code path — by the time `Restart()` runs, the instance row already exists. Both bugs share the **cross-process-race-on-per-instance** shape, hence the watcher's suspicion, but the fixes are separate concerns:

|              | #1031 (closed)                 | #1040 (this PR)                 |
|--------------|--------------------------------|---------------------------------|
| Layer        | SQLite persistence             | Spawn step (tmux new-session)   |
| Trigger      | Concurrent `launch`            | Concurrent `start` / `restart`  |
| Symptom      | N-1 of N rows persisted        | N of 1 tmux sessions spawned    |
| Fix          | `InsertSessionAndVerify` + DB retry | Per-instance file lock + stamp |

## Fix shape

`acquireInstanceSpawnLock(instanceID)` — file lock at `~/.agent-deck/locks/instance-spawn-<safeID>.lock` mirroring `acquirePluginLock` (#735, `plugin_install.go`): `O_CREATE|O_EXCL` marker with holder PID, stale reclaim by `kill -0` or by age TTL (2m).

The storm-discriminator is **time**, not "is a session alive": a legitimate manual restart of a long-running session must proceed even though a live `AGENTDECK_INSTANCE_ID`-matching session exists. Each spawn captures a timestamp before acquiring the lock and consults the per-instance stamp after acquisition:

```go
beforeLock := nowFn()
release, _ := acquireInstanceSpawnLock(i.ID)
defer release()
if spawnedSince(i.ID, beforeLock) { return nil }  // storm sibling
defer recordInstanceSpawn(i.ID)
// ... existing body ...
```

- Storm siblings see `stamp.mtime > beforeLock` → return nil.
- Legitimate later restarts see `stamp.mtime < beforeLock` → proceed.

Wired into `Instance.Start()`, `Instance.StartWithMessage()`, and `Instance.Restart()`. All three were race-prone; the fix had to cover all three or a poller-triggered Start racing with a manual Restart would still produce two parallel sessions.

Inlined (rather than wrapping the body in a `SpawnAttempt` helper) so the existing structural-grep contract in `fork_start_dispatch_test.go` keeps finding the #745 `IsForkAwaitingStart` guard inside `Start()`'s literal body.

Also adds `tmux.AnyAgentDeckSessionWithEnvValue` — a read-only mirror of `KillSessionsWithEnvValue` used by the optional `AlreadyAlive` gate so callers that have explicit live-session signals (CLI pre-checks, etc.) can short-circuit before consulting the stamp.

## Tests

`internal/session/issue1040_restart_storm_test.go`:

| Test | Pre-fix | Post-fix |
|------|---------|----------|
| `TestInstanceSpawnLock_SerializesConcurrentAcquires_RegressionFor1040` | max concurrent holders = 8 (storm) | max = 1 |
| `TestInstanceSpawnLock_DifferentInstancesDoNotSerialize` | n/a | passes — per-instance scoping verified |
| `TestSpawnAttempt_SingleFlight_OnConcurrentInvocation_RegressionFor1040` | spawnCount = 6 | spawnCount = 1 |
| `TestSpawnAttempt_StormBurstDeduplicatesViaStamp` | spawnCount = 6 | spawnCount = 1 |
| `TestSpawnAttempt_LegitimateRestartProceedsAfterPriorSpawn` | n/a | passes — proves stamp expires per-call |
| `TestSpawnAttempt_SkipsWhenAlreadyAlive` | n/a | passes — auxiliary gate |
| `TestSpawnAttempt_NilAlreadyAliveTreatedAsNotAlive` | n/a | passes — defensive nil handling |

Lock + stamp files are isolated to a per-test tmp dir via the `agentDeckDirOverride` seam, so suites running in parallel don't collide.

## Test plan

- [x] `go test -race -count=2 ./internal/session/ -run 'Issue1040|SpawnAttempt|InstanceSpawnLock|StormBurst|LegitimateRestart'` — 7/7 pass, no flakes.
- [x] `go test -race -count=1 ./internal/session/` — full session package green (including the three integration tests `TestRegression745_ForkTargetCarriesAwaitingStartSentinel`, `TestConductor_Restart_PreservesChatHistory_RegressionFor956`, `TestPersistence_RestartResumesConversation` that broke during an earlier extracted-helper iteration of this fix before the guard was inlined back into `Start()` / `Restart()`).
- [x] `go test -race -count=1 ./...` — full repo green.

## Doesn't break

- #1031 (concurrent launch parallel-safety, v1.9.15) — launch's `InsertSessionAndVerify` runs upstream of `Start()`; the new spawn lock serializes the spawn step it dispatches into.
- #1006 (RegisterMCPChild wiring) — untouched.
- #984 (sidecar clear + spawn unify) — untouched.
- #30 (restart freshness guard) — orthogonal: that guard short-circuits the CLI handler before `Restart()` runs; this fix serializes the spawn step inside `Restart()`.
- #666 (`sweepDuplicateToolSessions`) — still runs post-spawn; with single-flight it is now a no-op in the common case (no siblings to sweep) instead of the chaos source it was.

## Credit

Credit @torcuaine-sketch for the precise journalctl repro and the "fixed prefix + socket name" workaround that pinned the race surface to the spawn step.