### PR TITLE
test(perf): walltime regression suite (takeover of @JMBattista's #790)

### DIFF
--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -1,0 +1,88 @@
+# Performance regression CI gate.
+#
+# Runs on every PR that touches a file under the perf mandate (see
+# docs/perf-budget-suite.md). Two jobs:
+#
+#   1. perf-tests        — TestPerf_* walltime regressions, hard gate.
+#   2. perf-bench-trend  — Benchmark* ns/op output, advisory (continue-on-error).
+#
+# perf-tests red blocks the PR. perf-bench-trend uploads benchout.txt as an
+# artifact for offline trending; it never fails CI on its own.
+#
+# Single-shard ubuntu-latest only. Matrix runs amplify variance and would
+# flake the walltime budgets.
+
+name: Performance smoke
+
+on:
+  pull_request:
+    paths:
+      - 'cmd/agent-deck/main.go'
+      - 'cmd/agent-deck/coldstart_perf_test.go'
+      - 'internal/testutil/perfbudget.go'
+      - 'internal/testutil/perfbudget_test.go'
+      - '**/*_perf_test.go'
+      - '.github/workflows/perf-smoke.yml'
+      - 'docs/perf-budget-suite.md'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  perf-tests:
+    name: TestPerf_ walltime regressions (-race, multiplier=2.0)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run TestPerf_ suite
+        env:
+          PERF_BUDGET_MULTIPLIER: '2.0'
+        # ./... so any TestPerf_* added in any package is exercised — the
+        # path filter triggers on **/*_perf_test.go and the mandate covers
+        # the whole module, so the test invocation must match.
+        run: |
+          go test -run '^TestPerf_' -race -v -count=1 -timeout 120s \
+            ./... \
+            | tee perf-medians.txt
+
+      - name: Upload perf median log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-medians
+          path: perf-medians.txt
+          retention-days: 30
+
+  perf-bench-trend:
+    name: Benchmark ns/op trend (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run benchmarks
+        run: |
+          go test -run '^$' -bench '^Benchmark' -benchmem -benchtime=1x -count=3 -timeout 5m \
+            ./cmd/agent-deck/... ./internal/tmux/... \
+            | tee benchout.txt
+
+      - name: Upload bench output
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-bench-output
+          path: benchout.txt
+          retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run install clean dev release-local test fmt lint ci css tools css-verify test-web test-web-unit test-web-e2e test-web-install
+.PHONY: build run install clean dev release-local test test-perf bench fmt lint ci css tools css-verify test-web test-web-unit test-web-e2e test-web-install
 
 BINARY_NAME=agent-deck
 BUILD_DIR=./build
@@ -129,6 +129,19 @@ dev:
 # Run tests (with race detector)
 test:
 	go test -race -v ./...
+
+# Run hard-gated walltime regression tests (Track B). Honors PERF_BUDGET_MULTIPLIER
+# (default 1.0 locally; CI sets 2.0). See docs/perf-budget-suite.md.
+test-perf:
+	PERF_BUDGET_MULTIPLIER=$${PERF_BUDGET_MULTIPLIER:-1.0} \
+		go test -run '^TestPerf_' -race -v -count=1 -timeout 120s \
+		./cmd/agent-deck/...
+
+# Run advisory benchmarks (Track A). No -race — race overhead distorts ns/op.
+# Output is for trending; not a CI gate.
+bench:
+	go test -run '^$$' -bench '^Benchmark' -benchmem -benchtime=1x -count=3 -timeout 5m \
+		./cmd/agent-deck/... ./internal/tmux/...
 
 # Format code
 fmt:

--- a/cmd/agent-deck/coldstart_perf_test.go
+++ b/cmd/agent-deck/coldstart_perf_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+	"github.com/asheshgoplani/agent-deck/tests/eval/harness"
+)
+
+// Cold-start regression tests for the agent-deck CLI.
+//
+// Both tests build the binary once via the eval harness's buildOnce machinery
+// and exec it with `--help` / `--version`. The timed window covers everything
+// from process spawn through the package init() block (initColorProfile,
+// initUpdateSettings), the pre-dispatch tmux probes
+// (tmux.SetDefaultSocketName, tmux.WarnIfVulnerableTmux), and the
+// subcommand-routing path that prints help/version and exits.
+//
+// These are COLD tests: they cross a process boundary, so the budget
+// formula is base × 5 (with PERF_BUDGET_MULTIPLIER scaling and a 1ms floor)
+// and the measurement is an n=11 trimmed mean. See internal/testutil/perfbudget.go
+// for the full convention.
+//
+// Track B mandate (docs/perf-budget-suite.md): TestPerf_* must not invoke real tmux.
+// AGENTDECK_SUPPRESS_TMUX_WARNING=1 keeps WarnIfVulnerableTmux from shelling
+// out to `tmux -V` on macOS dev hosts (no-op on Linux but set unconditionally
+// for parity).
+
+// Base local medians observed under -race at PERF_BUDGET_MULTIPLIER=1.0
+// (Linux container, Intel Xeon @ 2.10GHz). ColdBudget multiplies by 5
+// and applies the 1ms floor and the env multiplier.
+const (
+	coldStartHelpBase    = 8 * time.Millisecond // → ColdBudget = 40ms locally, 80ms in CI
+	coldStartVersionBase = 8 * time.Millisecond // → ColdBudget = 40ms locally, 80ms in CI
+)
+
+// TestPerf_ColdStart_Help measures `agent-deck --help` end-to-end walltime.
+// Catches regressions in package init (initColorProfile, initUpdateSettings)
+// and the pre-dispatch tmux probes (SetDefaultSocketName, WarnIfVulnerableTmux).
+func TestPerf_ColdStart_Help(t *testing.T) {
+	testutil.SkipIfShort(t)
+	budget := testutil.ColdBudget(t, coldStartHelpBase)
+	sb := harness.NewSandbox(t)
+	env := perfEnv(sb)
+
+	got := testutil.TrimmedMean(func() {
+		runColdStart(t, sb.BinPath, env, "--help")
+	})
+
+	if got > budget {
+		t.Fatalf("agent-deck --help cold start trimmed mean = %v, budget = %v (regression in package init or pre-dispatch tmux probes)", got, budget)
+	}
+	t.Logf("agent-deck --help trimmed mean = %v (budget = %v)", got, budget)
+}
+
+// TestPerf_ColdStart_Version measures `agent-deck --version`. Independent
+// signal from --help: skips printHelp's formatting work but exercises the
+// same init path.
+func TestPerf_ColdStart_Version(t *testing.T) {
+	testutil.SkipIfShort(t)
+	budget := testutil.ColdBudget(t, coldStartVersionBase)
+	sb := harness.NewSandbox(t)
+	env := perfEnv(sb)
+
+	got := testutil.TrimmedMean(func() {
+		runColdStart(t, sb.BinPath, env, "--version")
+	})
+
+	if got > budget {
+		t.Fatalf("agent-deck --version cold start trimmed mean = %v, budget = %v", got, budget)
+	}
+	t.Logf("agent-deck --version trimmed mean = %v (budget = %v)", got, budget)
+}
+
+// perfEnv returns the harness sandbox env with AGENTDECK_SUPPRESS_TMUX_WARNING=1
+// appended. Track B mandate (CLAUDE.md) requires TestPerf_* not invoke real
+// tmux; on macOS the binary's WarnIfVulnerableTmux otherwise shells out to
+// `tmux -V`. Suppressing it is a no-op on Linux (early return) but keeps the
+// macOS dev experience identical to CI.
+func perfEnv(sb *harness.Sandbox) []string {
+	return append(sb.Env(), "AGENTDECK_SUPPRESS_TMUX_WARNING=1")
+}
+
+func runColdStart(t *testing.T, bin string, env []string, arg string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, arg)
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", bin, arg, err, string(out))
+	}
+	// Sanity: --version must mention "Agent Deck" and --help must mention
+	// a top-level subcommand. Cheap correctness check that catches a
+	// regression that swallows output (the bug class the perf budget
+	// alone wouldn't notice).
+	switch arg {
+	case "--version":
+		if !strings.Contains(string(out), "Agent Deck") {
+			t.Fatalf("--version output missing 'Agent Deck' marker:\n%s", string(out))
+		}
+	case "--help":
+		if len(strings.TrimSpace(string(out))) == 0 {
+			t.Fatalf("--help produced empty output")
+		}
+	}
+}
+
+// BenchmarkColdStart_Help — Track A advisory bench, runs without -race via
+// `make bench`. Captures ns/op for trending.
+//
+// Doesn't use the harness sandbox because harness.NewSandbox takes a
+// *testing.T; a fresh build + scratch HOME is cheap to do directly.
+func BenchmarkColdStart_Help(b *testing.B) {
+	bin := buildBinaryForBench(b)
+	home := b.TempDir()
+	env := append(os.Environ(),
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+filepath.Join(home, ".config"),
+		"XDG_STATE_HOME="+filepath.Join(home, ".local", "state"),
+		"AGENTDECK_COLOR=none",
+		"AGENTDECK_SUPPRESS_TMUX_WARNING=1",
+	)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cmd := exec.CommandContext(ctx, bin, "--help")
+		cmd.Env = env
+		if out, err := cmd.CombinedOutput(); err != nil {
+			cancel()
+			b.Fatalf("agent-deck --help failed: %v\n%s", err, string(out))
+		}
+		cancel()
+	}
+}
+
+func buildBinaryForBench(b *testing.B) string {
+	b.Helper()
+	dir := b.TempDir()
+	bin := filepath.Join(dir, "agent-deck")
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/agent-deck")
+	cmd.Dir = repoRootForBench(b)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		b.Fatalf("go build: %v\n%s", err, string(out))
+	}
+	return bin
+}
+
+func repoRootForBench(b *testing.B) string {
+	b.Helper()
+	d, err := os.Getwd()
+	if err != nil {
+		b.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(d, "go.mod")); err == nil {
+			return d
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			b.Fatalf("no go.mod found walking up from cwd")
+		}
+		d = parent
+	}
+}

--- a/docs/perf-budget-suite.md
+++ b/docs/perf-budget-suite.md
@@ -1,0 +1,70 @@
+# Performance regression: mandatory test coverage
+
+> Originally drafted by @JMBattista in PR #790. The prose below lived in
+> `CLAUDE.md` in JM's branch; after #1002 untracked `CLAUDE.md` as a
+> per-developer file, this content was relocated here so it stays
+> version-controlled and shared across contributors.
+
+Agent-deck has a recurring complaint that lifecycle operations (cold start, group create/delete) drift slower release-over-release. **As of v1.7.x, hot-path walltime is permanently test-gated.**
+
+## Required tests
+
+Any PR modifying performance-sensitive lifecycle paths MUST run:
+
+```bash
+GOTOOLCHAIN=go1.24.0 PERF_BUDGET_MULTIPLIER=2.0 \
+  go test -run '^TestPerf_' -race -count=1 -timeout 120s \
+  ./cmd/agent-deck/...
+```
+
+CI runs this as `.github/workflows/perf-smoke.yml`. Only the `perf-tests` job is a hard gate; `perf-bench-trend` is advisory (`continue-on-error: true`) and may show red without blocking merge.
+
+## Paths under the mandate
+
+- `cmd/agent-deck/main.go`
+- `internal/testutil/perfbudget.go`
+- `**/*_perf_test.go`
+- `.github/workflows/perf-smoke.yml`
+
+## Cold vs warm classification (REQUIRED for new TestPerf_* tests)
+
+Every `TestPerf_*` test classifies its work as COLD or WARM based on whether it crosses a process or syscall boundary. The classification picks both the budget formula and the measurement helper.
+
+| Class | When to use | Budget formula | Helper |
+|------|------------|----------------|--------|
+| **COLD** | Cold-start exec, real-disk fsync, child-process spawn, network | `max(base × 5, 1ms) × multiplier` | `testutil.ColdBudget(t, base)` + `testutil.TrimmedMean(fn)` |
+| **WARM** | Pure in-process Go work measurable under controlled GC | `max(base × 3, 1ms) × multiplier` | `testutil.WarmBudget(t, base)` + `testutil.TrimmedMeanWarm(fn)` |
+
+`base` MUST cite the last observed local median (under `-race`, multiplier=1.0) in a comment next to the constant. CI sets `PERF_BUDGET_MULTIPLIER=2.0`; effective CI gate is therefore 10× local for COLD, 6× local for WARM.
+
+The 1 ms floor (`testutil.PerfBudgetFloor`) caps minimum budgets — anything faster is either "just fast" (sub-ms timing dominated by clock resolution / scheduler jitter) or signals the unit under test is too small to be a meaningful regression target. Move such tests to `Benchmark*` (Track A) instead.
+
+## Measurement: n=11 trimmed mean
+
+`TrimmedMean` runs 11 timed iterations (plus 1 warm-up), drops the top 2 + bottom 2, averages the middle 7. Picked because:
+- Odd n: median is well-defined as a fallback diagnostic.
+- ~110 ms per test (11 × ~10 ms typical) — well under the 120 s suite timeout.
+- Drop 2/2 absorbs one GC pause + one scheduler hiccup.
+- Middle 7 → variance scales as 1/√7 ≈ 0.38 (~2× noise reduction vs single sample).
+
+Larger n (21, 51) was rejected: ~30% marginal variance reduction at 2–5× test cost.
+
+## Tier 1 vs Tier 2 (for future I/O-touching tests)
+
+Disk-touching tests fall into one of two tiers. **This PR adds neither tier; the convention is documented for the next contributor.**
+
+- **Tier 1 — tmpfs walltime** for code-side regressions in TUI-touching or persistence-touching paths. Run the test against a tmpfs-backed scratch dir (`/dev/shm` on Linux; `t.TempDir()` is already tmpfs on most CI Linux distros). fsync is effectively free, so the measured cost is CPU + Go-runtime cost only. Catches "we added 200 ms of CPU work in the save path" but NOT "we now do 5 fsyncs instead of 1". Classify as WARM.
+
+- **Tier 2 — real-disk count assertions** for I/O-pattern regressions. Disk walltime varies 100× across SSDs / HDDs / cloud volumes — un-normalizable. Instead instrument the storage layer (`*sql.DB` and `*os.File` wrappers exposing fsync count, transaction count, rows written) and assert on counts: "create one group = exactly 1 transaction + 1 fsync". No walltime budget. Classify as COLD because fsync count is on the syscall side.
+
+When adding a TUI-flow or persistence-touching test, write the Tier 1 walltime gate AND, if the test exercises a save path, the Tier 2 count gate. Both prevent different bug classes.
+
+## Budget changes require an RFC
+
+- Loosening any `TestPerf_*` budget (i.e. raising the `base`) by more than 25% requires an RFC at `docs/rfc/PERF_BUDGETS.md` documenting the cause and the upper bound.
+- Removing a `TestPerf_*` test is forbidden without an RFC.
+- Adding a budget MUST cite the local median and use the matching ColdBudget/WarmBudget helper.
+
+## Track A vs Track B
+
+`Benchmark*` functions are advisory (no `-race`, run via `make bench`). `TestPerf_*` are hard-gated walltime regressions and must remain tmux-free in Track B — including suppressing the macOS `tmux -V` warning probe via `AGENTDECK_SUPPRESS_TMUX_WARNING=1` in any TestPerf_* that exercises `cmd/agent-deck/main.go`. Real-tmux benches live in Track A only.

--- a/internal/testutil/perfbudget.go
+++ b/internal/testutil/perfbudget.go
@@ -1,0 +1,221 @@
+// Package testutil contains shared helpers for agent-deck's test suites.
+//
+// Performance regression API (this file)
+// ======================================
+//
+// All TestPerf_* tests use this small set of primitives. The design has
+// three deliberate parts:
+//
+//  1. Cold vs warm budget classification.
+//  2. n=11 trimmed-mean measurement.
+//  3. 1 ms budget floor.
+//
+// ── Cold vs warm ────────────────────────────────────────────────────────
+//
+// The budget formula differs based on whether the test crosses a process
+// or syscall boundary that introduces external variance the test code
+// can't control:
+//
+//   - COLD tests use ColdBudget(t, base) = max(base × 5, 1 ms) × multiplier.
+//     For: cold-start exec, real-disk fsync (Tier 2 — see
+//     docs/perf-budget-suite.md), child-process spawn, network round-trips.
+//     The 5× factor reflects that runner / loader / fsync variance can't be
+//     capped tighter without false positives.
+//
+//   - WARM tests use WarmBudget(t, base) = max(base × 3, 1 ms) × multiplier.
+//     For: pure in-process Go work measurable under controlled GC. The
+//     tighter 3× factor is safe because TrimmedMeanWarm forces a GC
+//     cycle and disables auto-GC during each timed window — the largest
+//     noise source is eliminated. WARM tests run on tmpfs / in memory
+//     (Tier 1) so disk speed is irrelevant.
+//
+// Both formulas are scaled by PERF_BUDGET_MULTIPLIER (default 1.0; CI
+// sets 2.0 to absorb shared-runner variance). The effective CI gate is
+// 10× local for cold, 6× local for warm.
+//
+// ── n=11 trimmed mean ───────────────────────────────────────────────────
+//
+// TrimmedMean runs n=11 timed iterations, sorts, drops the top 2 and
+// bottom 2 samples, and averages the middle 7 (a 36% trimmed mean).
+//
+// Why n=11:
+//   - Odd: median is well-defined as a fallback diagnostic.
+//   - Cheap: 11 × ~10 ms typical = ~110 ms per test, well under the
+//     60 s perf-suite timeout.
+//   - Drop 2/2: handles one GC pause + one scheduler hiccup without
+//     losing too many samples. In practice, ~1 in 10 samples on a
+//     loaded host is an outlier; dropping 2 from each end is robust.
+//   - Middle 7: variance of the mean scales as 1/√7 ≈ 0.38 — about
+//     2× noise reduction vs a single sample, ~1.5× better than the
+//     median of 5 used previously.
+//
+// Larger n (21, 51) was considered but rejected: marginal variance
+// reduction (~30%) at 2–5× test cost. n=11 is the sweet spot.
+//
+// ── 1 ms floor ──────────────────────────────────────────────────────────
+//
+// PerfBudgetFloor caps the minimum budget at 1 ms regardless of the
+// caller's base × multiplier. Anything faster is either "just fast"
+// (sub-millisecond timing is dominated by clock resolution + scheduler
+// jitter) or a sign that the unit under test is too small to be a
+// meaningful regression target. Move such tests to Benchmark* (Track A)
+// instead of TestPerf_* (Track B).
+package testutil
+
+import (
+	"os"
+	"runtime"
+	"runtime/debug"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// PerfBudgetMultiplierEnv is the env var read by ColdBudget and WarmBudget.
+// CI sets this to 2.0 to absorb shared-runner variance; developers on slow
+// laptops can bump it locally. Default is 1.0.
+const PerfBudgetMultiplierEnv = "PERF_BUDGET_MULTIPLIER"
+
+// PerfBudgetFloor is the minimum budget any TestPerf_* gate may apply.
+// Sub-millisecond budgets are dominated by clock resolution and scheduler
+// jitter, not by the unit under test. See package docblock for rationale.
+const PerfBudgetFloor = 1 * time.Millisecond
+
+// trimmedMeanN is the sample count for TrimmedMean. n=11 is the project
+// default; see the package docblock for the selection rationale.
+const trimmedMeanN = 11
+
+// trimmedMeanDrop is the count dropped from each end before averaging.
+const trimmedMeanDrop = 2
+
+// ColdBudget returns the budget for a COLD test: one that crosses a
+// process or syscall boundary (cold-start exec, real-disk fsync,
+// child-process spawn, network). Formula:
+//
+//	max(base * 5, PerfBudgetFloor) * PERF_BUDGET_MULTIPLIER
+//
+// Pair with TrimmedMean(fn) for measurement.
+func ColdBudget(t *testing.T, base time.Duration) time.Duration {
+	t.Helper()
+	measure := base * 5
+	if measure < PerfBudgetFloor {
+		measure = PerfBudgetFloor
+	}
+	return applyMultiplier(t, measure)
+}
+
+// WarmBudget returns the budget for a WARM test: pure in-process Go work
+// that can be measured under controlled GC. Formula:
+//
+//	max(base * 3, PerfBudgetFloor) * PERF_BUDGET_MULTIPLIER
+//
+// Pair with TrimmedMeanWarm(fn) — that variant forces a GC cycle and
+// disables auto-GC around each timed iteration, eliminating the largest
+// noise source.
+//
+// No callers in this PR; exported to capture the cold/warm convention
+// in code so future contributors classify their tests correctly.
+func WarmBudget(t *testing.T, base time.Duration) time.Duration {
+	t.Helper()
+	measure := base * 3
+	if measure < PerfBudgetFloor {
+		measure = PerfBudgetFloor
+	}
+	return applyMultiplier(t, measure)
+}
+
+func applyMultiplier(t *testing.T, measure time.Duration) time.Duration {
+	t.Helper()
+	raw := os.Getenv(PerfBudgetMultiplierEnv)
+	if raw == "" {
+		return measure
+	}
+	mult, err := strconv.ParseFloat(raw, 64)
+	if err != nil || mult <= 0 {
+		t.Logf("ignoring invalid %s=%q (using 1.0)", PerfBudgetMultiplierEnv, raw)
+		return measure
+	}
+	return time.Duration(float64(measure) * mult)
+}
+
+// TrimmedMean runs fn n=11 times (plus 1 warm-up), sorts the samples,
+// drops the top 2 and bottom 2, and returns the average of the middle 7.
+//
+// Use for COLD tests where GC manipulation in the parent process doesn't
+// help (the timed work happens in a child process or kernel).
+func TrimmedMean(fn func()) time.Duration {
+	return trimmedMeanCore(false, nil, fn)
+}
+
+// TrimmedMeanWarm is TrimmedMean with controlled GC: forces a runtime.GC()
+// before each timed iteration and disables auto-GC during the timed
+// window via debug.SetGCPercent(-1), restoring the original setting on
+// return.
+//
+// Use for WARM tests measuring pure-Go in-process work, where GC pauses
+// are the dominant noise source.
+func TrimmedMeanWarm(fn func()) time.Duration {
+	return trimmedMeanCore(true, nil, fn)
+}
+
+// TrimmedMeanWithSetup runs setup() before each timed op() but excludes
+// setup from the timing window. Use when the timed primitive needs a
+// fresh fixture per iteration (e.g. a populated tree before timing
+// DeleteAll). Setup and op share state via closure capture in the caller.
+//
+// COLD variant — no GC manipulation. For warm work needing setup,
+// compose: temporarily disable GC yourself or call runtime.GC() inside
+// setup before each timed op.
+func TrimmedMeanWithSetup(setup, op func()) time.Duration {
+	return trimmedMeanCore(false, setup, op)
+}
+
+func trimmedMeanCore(controlGC bool, setup, op func()) time.Duration {
+	if setup == nil {
+		setup = func() {}
+	}
+
+	if controlGC {
+		// Disable automatic GC for the full helper lifetime (including
+		// warm-up). We force a single collection per timed iteration
+		// ourselves (below) so the measured op() never absorbs an
+		// unrelated GC pause.
+		orig := debug.SetGCPercent(-1)
+		defer debug.SetGCPercent(orig)
+	}
+
+	// Warm-up: full setup + op cycle. Discarded — first invocation pays
+	// for any package-level lazy init in fn's transitive callees.
+	setup()
+	op()
+
+	samples := make([]time.Duration, trimmedMeanN)
+	for i := 0; i < trimmedMeanN; i++ {
+		setup()
+		if controlGC {
+			runtime.GC() // pay collection cost outside the timed window
+		}
+		start := time.Now()
+		op()
+		samples[i] = time.Since(start)
+	}
+
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	middle := samples[trimmedMeanDrop : trimmedMeanN-trimmedMeanDrop]
+	var sum time.Duration
+	for _, s := range middle {
+		sum += s
+	}
+	return sum / time.Duration(len(middle))
+}
+
+// SkipIfShort skips the test when `go test -short` is in effect. TestPerf_*
+// tests are expensive enough that contributors running quick unit-test
+// loops shouldn't pay for them. CI always runs in long mode.
+func SkipIfShort(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping perf test in -short mode")
+	}
+}

--- a/internal/testutil/perfbudget_test.go
+++ b/internal/testutil/perfbudget_test.go
@@ -1,0 +1,224 @@
+package testutil
+
+import (
+	"os"
+	"runtime"
+	"runtime/debug"
+	"testing"
+	"time"
+)
+
+func TestColdBudget_Formula(t *testing.T) {
+	clearMultiplier(t)
+
+	// base * 5
+	if got := ColdBudget(t, 7*time.Millisecond); got != 35*time.Millisecond {
+		t.Fatalf("ColdBudget(7ms) = %v, want 35ms", got)
+	}
+	// base * 5 below floor → floor
+	if got := ColdBudget(t, 100*time.Microsecond); got != PerfBudgetFloor {
+		t.Fatalf("ColdBudget(100µs) = %v, want %v (floor)", got, PerfBudgetFloor)
+	}
+	// base * 5 at exactly floor → floor (tied)
+	if got := ColdBudget(t, 200*time.Microsecond); got != PerfBudgetFloor {
+		t.Fatalf("ColdBudget(200µs) = %v, want %v (= floor)", got, PerfBudgetFloor)
+	}
+}
+
+func TestWarmBudget_Formula(t *testing.T) {
+	clearMultiplier(t)
+
+	if got := WarmBudget(t, 7*time.Millisecond); got != 21*time.Millisecond {
+		t.Fatalf("WarmBudget(7ms) = %v, want 21ms", got)
+	}
+	if got := WarmBudget(t, 100*time.Microsecond); got != PerfBudgetFloor {
+		t.Fatalf("WarmBudget(100µs) = %v, want %v (floor)", got, PerfBudgetFloor)
+	}
+}
+
+func TestBudget_HonorsMultiplier(t *testing.T) {
+	setMultiplier(t, "2.5")
+
+	if got := ColdBudget(t, 4*time.Millisecond); got != 50*time.Millisecond {
+		t.Fatalf("ColdBudget(4ms) at multiplier 2.5 = %v, want 50ms", got)
+	}
+	if got := WarmBudget(t, 4*time.Millisecond); got != 30*time.Millisecond {
+		t.Fatalf("WarmBudget(4ms) at multiplier 2.5 = %v, want 30ms", got)
+	}
+}
+
+func TestBudget_InvalidMultiplierFallsBack(t *testing.T) {
+	setMultiplier(t, "garbage")
+
+	if got := ColdBudget(t, 7*time.Millisecond); got != 35*time.Millisecond {
+		t.Fatalf("ColdBudget at invalid multiplier = %v, want 35ms (fallback to 1.0)", got)
+	}
+}
+
+func TestTrimmedMean_RunsElevenSamples(t *testing.T) {
+	calls := 0
+	_ = TrimmedMean(func() { calls++ })
+	want := trimmedMeanN + 1 // 1 warm-up + 11 samples
+	if calls != want {
+		t.Fatalf("TrimmedMean ran fn %d times, want %d", calls, want)
+	}
+}
+
+func TestTrimmedMean_DropsExtremes(t *testing.T) {
+	// Construct 11 samples where the means with vs without trimming
+	// would differ noticeably. Use sleep durations from a fixed sequence.
+	// Untrimmed mean ≈ (1+2+3+4+5+6+7+8+9+10+99)/11 ≈ 14ms.
+	// Trimmed (drop top 2, bottom 2; middle 7 = 3..9) → (3+4+5+6+7+8+9)/7 = 6ms.
+	// We can't directly inject samples, but we can verify the trimmed result
+	// is much closer to the middle of the sequence than the untrimmed mean.
+	delays := []time.Duration{
+		1 * time.Millisecond,
+		99 * time.Millisecond, // huge outlier — must be trimmed
+		3 * time.Millisecond,
+		2 * time.Millisecond,
+		4 * time.Millisecond,
+		5 * time.Millisecond,
+		6 * time.Millisecond,
+		7 * time.Millisecond,
+		8 * time.Millisecond,
+		9 * time.Millisecond,
+		10 * time.Millisecond,
+	}
+	idx := 0
+	got := TrimmedMean(func() {
+		// First call is warm-up, discarded. After that, run through delays in order.
+		if idx == 0 {
+			idx++
+			return // warm-up
+		}
+		i := idx - 1
+		idx++
+		if i < len(delays) {
+			time.Sleep(delays[i])
+		}
+	})
+
+	// The 99 ms outlier must be dropped. If trimming is broken the mean
+	// would be ≥ 14 ms. The middle 7 of {1,2,3,4,5,6,7,8,9,10,99} are
+	// {3,4,5,6,7,8,9} → mean 6 ms. Allow generous slack for sleep
+	// imprecision.
+	if got > 12*time.Millisecond {
+		t.Fatalf("TrimmedMean = %v; the 99ms outlier was not trimmed (untrimmed mean would be ~14ms)", got)
+	}
+	if got < 3*time.Millisecond {
+		t.Fatalf("TrimmedMean = %v; suspiciously low — not enough samples being averaged", got)
+	}
+}
+
+func TestTrimmedMeanWithSetup_ExcludesSetup(t *testing.T) {
+	setupCalls, opCalls := 0, 0
+	// Use a deliberately huge setup-vs-op ratio (100ms vs 2ms = 50×) so
+	// that any contamination from setup leaking into the timed window
+	// would be obvious. Allow the trimmed mean up to setupSleep/2 — well
+	// under the setup duration but loose enough to absorb scheduler
+	// jitter on a busy CI runner under -race.
+	const (
+		setupSleep = 100 * time.Millisecond
+		opSleep    = 2 * time.Millisecond
+		// Looser bound than absolute "small": if the helper accidentally
+		// included setup time, even a single contaminated sample would
+		// push the trimmed mean of the middle 7 well above 50 ms.
+		maxAcceptable = setupSleep / 2
+	)
+	got := TrimmedMeanWithSetup(
+		func() {
+			setupCalls++
+			time.Sleep(setupSleep)
+		},
+		func() {
+			opCalls++
+			time.Sleep(opSleep)
+		},
+	)
+	wantCalls := trimmedMeanN + 1
+	if setupCalls != wantCalls || opCalls != wantCalls {
+		t.Fatalf("setup=%d op=%d, want both=%d", setupCalls, opCalls, wantCalls)
+	}
+	if got > maxAcceptable {
+		t.Fatalf("TrimmedMeanWithSetup absorbed setup time: got %v, want < %v (setup=%v)", got, maxAcceptable, setupSleep)
+	}
+}
+
+func TestTrimmedMeanWarm_DisablesGCAndRestores(t *testing.T) {
+	const sentinel = 50
+	orig := debug.SetGCPercent(sentinel)
+	defer debug.SetGCPercent(orig)
+
+	// Track the minimum GCPercent observed across all op calls
+	// (warm-up + timed). It must be -1 — the helper disables auto-GC
+	// for its full lifetime.
+	minSeen := sentinel
+	_ = TrimmedMeanWarm(func() {
+		// Read current GCPercent without changing it: SetGCPercent
+		// returns the previous value, so we set to that same value.
+		cur := debug.SetGCPercent(-1)
+		debug.SetGCPercent(cur)
+		if cur < minSeen {
+			minSeen = cur
+		}
+	})
+
+	if minSeen != -1 {
+		t.Errorf("inside TrimmedMeanWarm, GCPercent never observed as -1; min seen = %d", minSeen)
+	}
+
+	// After return, the helper must have restored GCPercent to sentinel.
+	if got := debug.SetGCPercent(sentinel); got != sentinel {
+		t.Errorf("TrimmedMeanWarm did not restore GCPercent: got %d, want %d", got, sentinel)
+	}
+}
+
+func TestTrimmedMeanWarm_RunsForcedGC(t *testing.T) {
+	// Force the heap to grow a bit so a GC has visible effect.
+	before := readNumGC()
+	_ = TrimmedMeanWarm(func() {
+		// Allocate something garbage-collectable.
+		_ = make([]byte, 1<<16)
+	})
+	after := readNumGC()
+
+	// Each of the 11 timed iterations forces a runtime.GC(). Plus the
+	// warm-up doesn't call runtime.GC, but the forced cycles inside the
+	// loop should still produce at least 11 collections.
+	if after-before < uint32(trimmedMeanN) {
+		t.Errorf("TrimmedMeanWarm did not force GC per iteration: NumGC delta = %d, want >= %d",
+			after-before, trimmedMeanN)
+	}
+}
+
+func readNumGC() uint32 {
+	var s runtime.MemStats
+	runtime.ReadMemStats(&s)
+	return s.NumGC
+}
+
+// ---- helpers --------------------------------------------------------------
+
+func setMultiplier(t *testing.T, val string) {
+	t.Helper()
+	old, had := os.LookupEnv(PerfBudgetMultiplierEnv)
+	os.Setenv(PerfBudgetMultiplierEnv, val)
+	t.Cleanup(func() {
+		if had {
+			os.Setenv(PerfBudgetMultiplierEnv, old)
+		} else {
+			os.Unsetenv(PerfBudgetMultiplierEnv)
+		}
+	})
+}
+
+func clearMultiplier(t *testing.T) {
+	t.Helper()
+	old, had := os.LookupEnv(PerfBudgetMultiplierEnv)
+	os.Unsetenv(PerfBudgetMultiplierEnv)
+	t.Cleanup(func() {
+		if had {
+			os.Setenv(PerfBudgetMultiplierEnv, old)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Takeover of **@JMBattista's #790** — the first hard-gated walltime regression suite for agent-deck (cold-start CLI + shared perf-budget helpers + advisory bench + CI workflow), rebased onto current `main`.

All design credit is JM's. This PR re-applies JM's six-file change against `main` after #790 had been sitting conflicting for 5h+ without a response.

## Why a takeover instead of a rebase on JM's branch

Per the analysis in [this comment on #790](https://github.com/asheshgoplani/agent-deck/pull/790#issuecomment-) (paraphrasing): of JM's six changed files, five apply cleanly against today's `main`. The only real blocker is the **66-line `CLAUDE.md` documentation hunk** — and that hunk has nowhere to land because **#1002 (May 15) untracked `CLAUDE.md`** as a per-developer file.

So this PR does the **option-1 relocate** that was offered on the thread:

> "Move the doc hunk: relocate the CLAUDE.md additions into a tracked file — `internal/testutil/README.md` or `docs/perf-budget-suite.md` would be natural homes."

The doc went into **`docs/perf-budget-suite.md`** — verbatim JM prose plus a one-paragraph preamble documenting the relocation provenance. Internal references to `CLAUDE.md` in JM's other files (the `paths:` filter in `perf-smoke.yml`, the docstring in `perfbudget.go`, the `Track B mandate` comment in `coldstart_perf_test.go`, the `make test-perf` comment in the `Makefile`) were retargeted at the new doc location. Everything else is JM's diff unchanged.

## What's in the suite

- **`internal/testutil/perfbudget.go`** — `ColdBudget` / `WarmBudget` / `TrimmedMean` / `TrimmedMeanWarm` / `TrimmedMeanWithSetup` + `PerfBudgetFloor` (1 ms) + `SkipIfShort`. Cold = `max(base × 5, 1ms) × multiplier`; warm = `max(base × 3, 1ms) × multiplier`. n=11 trimmed mean (drop top 2 + bottom 2, average middle 7).
- **`internal/testutil/perfbudget_test.go`** — formula tests, multiplier-env tests, trim-extremes tests, setup-excluded-from-timing test, GC-control tests.
- **`cmd/agent-deck/coldstart_perf_test.go`** — `TestPerf_ColdStart_Help` + `TestPerf_ColdStart_Version` (hard gate, base 8 ms each → 40 ms local budget, 80 ms CI budget) and `BenchmarkColdStart_Help` (advisory).
- **`.github/workflows/perf-smoke.yml`** — `perf-tests` job (hard gate, `PERF_BUDGET_MULTIPLIER=2.0`) + `perf-bench-trend` job (advisory, `continue-on-error: true`).
- **`Makefile`** — `make test-perf` (hard-gate Track B) + `make bench` (advisory Track A).
- **`docs/perf-budget-suite.md`** — the relocated mandate doc. Spells out cold/warm classification rules, the n=11 measurement convention, Tier 1/Tier 2 conventions for future I/O-touching tests, and the RFC requirement for loosening budgets.

## Verification (Linux)

| Check | Result |
|---|---|
| `make test-perf` | PASS — `--help` trimmed mean 8.07 ms / `--version` 7.07 ms (budget 40 ms) |
| `go test -race -count=1 ./...` | PASS — 35/35 packages green |
| `go build ./...` | clean |

Note: trimmed mean of 8.07 ms is essentially exactly JM's `coldStartHelpBase = 8ms` constant — the local-median citation in JM's code matches my Linux measurement.

## Test plan

- [ ] `perf-smoke.yml` workflow triggers on this PR (touched paths include the workflow itself and the perf test files)
- [ ] `perf-tests` job goes green at CI multiplier 2.0 (budget 80 ms, observed local 8 ms → 10× headroom)
- [ ] `perf-bench-trend` job runs and uploads `benchout.txt`; it's `continue-on-error: true` so red is OK
- [ ] Full `go test -race ./...` green in CI

## Credit

This work is @JMBattista's. The PR description, the budget formulas, the n=11 trimmed-mean rationale, every line of Go and YAML — all JM. I'm just doing the rebase mechanic JM was offered, plus the CLAUDE.md → `docs/perf-budget-suite.md` relocation that #1002 made necessary.

Closes #790.