### PR TITLE
feat(watcher): dispatch routed events to conductor tmux pane (takeover of @martins-fresh's #939)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -391,6 +391,11 @@ type Home struct {
 	transitionTrackerOnce sync.Once
 	transitionTracker     *transitionTracker
 
+	// Logs once per engine instance when the first watcher event is consumed
+	// from the engine's EventCh. Helps diagnose listener-not-firing issues
+	// without needing to instrument every event.
+	firstWatcherEventOnce sync.Once
+
 	// Full repaint mode: issue tea.ClearScreen every tick to avoid
 	// incremental redraw drift in terminals with unicode grapheme widths
 	fullRepaint          bool
@@ -1990,11 +1995,27 @@ func (h *Home) startWatcherEngine() tea.Cmd {
 	}
 
 	h.watcherEngine = eng
+	h.firstWatcherEventOnce = sync.Once{}
+
+	uiLog.Info("watcher_engine_started",
+		slog.Int("watcher_count", len(rows)),
+		slog.Int("running_count", runningCount(rows)))
 
 	return tea.Batch(
 		listenForWatcherEvent(eng.EventCh()),
 		listenForWatcherHealth(eng.HealthCh()),
 	)
+}
+
+// runningCount returns how many watcher rows are in the "running" state.
+func runningCount(rows []*statedb.WatcherRow) int {
+	n := 0
+	for _, r := range rows {
+		if r != nil && r.Status == "running" {
+			n++
+		}
+	}
+	return n
 }
 
 // loadWatcherSourceSettings reads the [source] table from
@@ -4657,8 +4678,17 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case watcherEventMsg:
+		// One-shot log per engine instance to confirm the listener path is alive.
+		h.firstWatcherEventOnce.Do(func() {
+			uiLog.Info("watcher_event_first_received",
+				slog.String("sender", msg.event.Sender),
+				slog.String("routed_to", msg.event.RoutedTo))
+		})
 		// Refresh watcher panel data on new events and re-register listener.
 		h.refreshWatcherPanel()
+		// Deliver event to the routed conductor's tmux pane (parity with
+		// dispatchHealthAlert). Skipped for triage and unrouted events.
+		h.dispatchWatcherEvent(msg.event)
 		if h.watcherEngine != nil {
 			return h, listenForWatcherEvent(h.watcherEngine.EventCh())
 		}
@@ -7292,6 +7322,40 @@ func (h *Home) refreshWatcherPanel() {
 			}
 			h.watcherPanel.SetEvents(displayEvents)
 		}
+	}
+}
+
+// dispatchWatcherEvent sends a routed watcher event into the conductor's tmux pane.
+// Skipped for triage and unrouted events (RoutedTo empty or "triage") since those have no
+// concrete delivery target yet. Mirrors dispatchHealthAlert: looks up the conductor session
+// by title and uses tmux send-keys (T-16-08) to deliver the formatted line.
+func (h *Home) dispatchWatcherEvent(evt watcher.Event) {
+	if evt.RoutedTo == "" || evt.RoutedTo == "triage" || strings.HasPrefix(evt.RoutedTo, "triage-") {
+		return
+	}
+	msg := fmt.Sprintf("[%s] %s: %s", evt.Source, evt.Sender, evt.Subject)
+	sessionTitle := session.ConductorSessionTitle(evt.RoutedTo)
+	h.instancesMu.RLock()
+	instances := h.instances
+	h.instancesMu.RUnlock()
+	for _, inst := range instances {
+		if inst.Title != sessionTitle {
+			continue
+		}
+		ts := inst.GetTmuxSession()
+		if ts == nil || ts.Name == "" {
+			return
+		}
+		tmuxName := ts.Name
+		socket := inst.TmuxSocketName
+		go func() {
+			if err := tmux.Exec(socket, "send-keys", "-t", tmuxName, msg, "Enter").Run(); err != nil {
+				uiLog.Warn("dispatch_watcher_event_send_failed",
+					slog.String("tmux_session", tmuxName),
+					slog.String("error", err.Error()))
+			}
+		}()
+		return
 	}
 }
 

--- a/internal/ui/watcher_listener_test.go
+++ b/internal/ui/watcher_listener_test.go
@@ -1,0 +1,61 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/watcher"
+)
+
+// TestListenForWatcherEvent_DeliversMsg verifies that listenForWatcherEvent's
+// tea.Cmd returns a watcherEventMsg carrying the event it received on the
+// channel. This guards against the listener-cmd-loss class of bug where a
+// dispatch path silently stops firing.
+func TestListenForWatcherEvent_DeliversMsg(t *testing.T) {
+	ch := make(chan watcher.Event, 1)
+	want := watcher.Event{
+		Source:   "github",
+		Sender:   "octocat@github.com",
+		Subject:  "[PR opened] #1: hello",
+		RoutedTo: "demo",
+	}
+	ch <- want
+
+	cmd := listenForWatcherEvent(ch)
+	if cmd == nil {
+		t.Fatal("listenForWatcherEvent returned nil cmd")
+	}
+
+	done := make(chan struct{})
+	var got any
+	go func() {
+		got = cmd()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener cmd did not return within 2s")
+	}
+
+	msg, ok := got.(watcherEventMsg)
+	if !ok {
+		t.Fatalf("got msg type %T, want watcherEventMsg", got)
+	}
+	if msg.event.Sender != want.Sender || msg.event.RoutedTo != want.RoutedTo {
+		t.Errorf("event mismatch: got %+v, want %+v", msg.event, want)
+	}
+}
+
+// TestListenForWatcherEvent_ReturnsNilOnClosedChannel verifies that the
+// listener exits cleanly when the engine closes the event channel (Stop).
+func TestListenForWatcherEvent_ReturnsNilOnClosedChannel(t *testing.T) {
+	ch := make(chan watcher.Event)
+	close(ch)
+
+	got := listenForWatcherEvent(ch)()
+	if got != nil {
+		t.Errorf("got %T (%v); want nil after closed channel", got, got)
+	}
+}

--- a/internal/watcher/adapter.go
+++ b/internal/watcher/adapter.go
@@ -69,6 +69,11 @@ type Event struct {
 	// ThreadSessionID is populated by the engine's writerLoop when a thread reply
 	// is routed to an existing session. Empty means spawn a new session.
 	ThreadSessionID string `json:"thread_session_id,omitempty"`
+
+	// RoutedTo is populated by the engine's writerLoop with the conductor name
+	// from Router.Match(Sender), or "triage" / "" when no rule matches.
+	// Consumed by the TUI to deliver events into the conductor's tmux pane.
+	RoutedTo string `json:"routed_to,omitempty"`
 }
 
 // DedupKey returns a deterministic hex-encoded SHA-256 hash of the event's

--- a/internal/watcher/engine.go
+++ b/internal/watcher/engine.go
@@ -432,6 +432,7 @@ func (e *Engine) writerLoop() {
 				}
 
 				// Non-blocking send to routedEventCh for TUI consumption.
+				env.event.RoutedTo = routedTo
 				select {
 				case e.routedEventCh <- env.event:
 				default:

--- a/internal/watcher/engine_test.go
+++ b/internal/watcher/engine_test.go
@@ -649,3 +649,43 @@ func TestWatcherEngine_Stop_ClosesExportedChannels(t *testing.T) {
 		t.Errorf("HealthCh: expected closed channel, got blocking read")
 	}
 }
+
+// TestWatcherEngine_EventCh_PopulatesRoutedTo verifies that events delivered on the
+// engine's EventCh have RoutedTo set to the matched conductor name. The TUI relies
+// on this to deliver events into the conductor's tmux pane.
+func TestWatcherEngine_EventCh_PopulatesRoutedTo(t *testing.T) {
+	clients := map[string]ClientEntry{
+		"user@company.com": {
+			Conductor: "conductor-a",
+			Group:     "g",
+			Name:      "A",
+		},
+	}
+
+	engine, db := newTestEngine(t, clients)
+	saveTestWatcher(t, db, "w1", "test-watcher", "mock")
+
+	adapter := &MockAdapter{
+		events: []Event{
+			{Source: "mock", Sender: "user@company.com", Subject: "hi", Timestamp: time.Now()},
+		},
+	}
+	engine.RegisterAdapter("w1", adapter, AdapterConfig{Type: "mock", Name: "test-watcher"}, 60)
+
+	if err := engine.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer engine.Stop()
+
+	select {
+	case evt, ok := <-engine.EventCh():
+		if !ok {
+			t.Fatal("EventCh closed before event arrived")
+		}
+		if evt.RoutedTo != "conductor-a" {
+			t.Errorf("RoutedTo = %q, want %q", evt.RoutedTo, "conductor-a")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for routed event on EventCh")
+	}
+}


### PR DESCRIPTION
## Summary

Takeover of #939 by @martins-fresh — rebased on top of today's `internal/ui/home.go` and `internal/watcher/engine.go` merges. Original PR was conflicting; full credit to @martins-fresh for the design and implementation.

Watcher events are now delivered into the routed conductor's tmux pane via `tmux send-keys`, mirroring the existing `dispatchHealthAlert` pattern.

## Changes (unchanged from #939)

- `internal/watcher/adapter.go`: add `Event.RoutedTo` field
- `internal/watcher/engine.go`: writerLoop populates `RoutedTo` from `Router.Match(Sender)` before non-blocking send to `routedEventCh`
- `internal/watcher/engine_test.go`: `TestWatcherEngine_EventCh_PopulatesRoutedTo`
- `internal/ui/home.go`:
  - `firstWatcherEventOnce sync.Once` field + one-shot `watcher_event_first_received` log
  - `runningCount(rows)` helper + `watcher_engine_started` log
  - `case watcherEventMsg` calls `h.dispatchWatcherEvent(msg.event)`
  - `dispatchWatcherEvent` looks up conductor session by `session.ConductorSessionTitle(evt.RoutedTo)`, skips triage/unrouted, uses `tmux.Exec(socket, "send-keys", ...)`
- `internal/ui/watcher_listener_test.go`: new tests for `listenForWatcherEvent` cmd

## Conflict resolution

Only `internal/ui/home.go` conflicted — both this PR and a recent main merge added a new function in the slot after `startWatcherEngine()`. Resolved by keeping both `runningCount` (this PR) and `loadWatcherSourceSettings` (main) side-by-side. No semantic changes to @martins-fresh's original work.

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] `internal/watcher` tests pass (incl. new `TestWatcherEngine_EventCh_PopulatesRoutedTo`)
- [x] `internal/ui` tests pass (incl. new `TestListenForWatcherEvent_*`)
- [x] Build: `go build ./...` clean

Original PR: #939
Closes the takeover — please review and merge if approved.