### PR TITLE
feat(conductor): pause heartbeats after inactivity (takeover of @yaroshevych's #839)

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -114,6 +114,7 @@ func handleConductorSetup(profile string, args []string) {
 	description := fs.String("description", "", "Description for this conductor")
 	heartbeat := fs.Bool("heartbeat", false, "Enable heartbeat for this conductor (default)")
 	noHeartbeat := fs.Bool("no-heartbeat", false, "Disable heartbeat for this conductor")
+	heartbeatIdleMinutes := fs.Int("heartbeat-idle-minutes", 0, "Minutes of idle time before pausing heartbeats (default 0=disabled, negative also disabled)")
 	instructionsMD := fs.String("instructions-md", "", "Custom instructions file for this conductor (agent-specific, e.g., ~/docs/conductor-ops.md)")
 	sharedInstructionsMD := fs.String("shared-instructions-md", "", "Custom shared instructions file for all conductors of this agent")
 	claudeMD := fs.String("claude-md", "", "Custom CLAUDE.md for this conductor (e.g., ~/docs/conductor-ryan.md)")
@@ -144,6 +145,8 @@ func handleConductorSetup(profile string, args []string) {
 		fmt.Println("        Enable heartbeat for this conductor (default)")
 		fmt.Println("  -no-heartbeat")
 		fmt.Println("        Disable heartbeat for this conductor")
+		fmt.Println("  -heartbeat-idle-minutes int")
+		fmt.Println("        Minutes of idle time before pausing heartbeats (default 0=disabled, negative also disabled)")
 		fmt.Println("  -no-clear-on-compact")
 		fmt.Println("        Claude-only: allow normal compaction instead of /clear when context fills up")
 		fmt.Println()
@@ -468,7 +471,7 @@ func handleConductorSetup(profile string, args []string) {
 	if len(envFlags) > 0 {
 		envMap = map[string]string(envFlags)
 	}
-	if err := session.SetupConductorWithAgent(name, resolvedProfile, spec.Agent, heartbeatEnabled, clearOnCompact, *description, resolvedInstructionsMD, *policyMD, *heartbeatRulesMD, envMap, *envFile); err != nil {
+	if err := session.SetupConductorWithAgent(name, resolvedProfile, spec.Agent, heartbeatEnabled, clearOnCompact, *description, resolvedInstructionsMD, *policyMD, *heartbeatRulesMD, envMap, *envFile, *heartbeatIdleMinutes); err != nil {
 		fmt.Fprintf(os.Stderr, "Error setting up conductor %s: %v\n", name, err)
 		os.Exit(1)
 	}
@@ -924,26 +927,35 @@ func handleConductorStatus(_ string, args []string) {
 	}
 
 	type conductorStatus struct {
-		Name        string `json:"name"`
-		Agent       string `json:"agent"`
-		Profile     string `json:"profile"`
-		DirExists   bool   `json:"dir_exists"`
-		SessionID   string `json:"session_id,omitempty"`
-		SessionDone bool   `json:"session_registered"`
-		Running     bool   `json:"running"`
-		Heartbeat   bool   `json:"heartbeat"`
-		Description string `json:"description,omitempty"`
+		Name                 string `json:"name"`
+		Agent                string `json:"agent"`
+		Profile              string `json:"profile"`
+		DirExists            bool   `json:"dir_exists"`
+		SessionID            string `json:"session_id,omitempty"`
+		SessionDone          bool   `json:"session_registered"`
+		Running              bool   `json:"running"`
+		Heartbeat            bool   `json:"heartbeat"`
+		Description          string `json:"description,omitempty"`
+		LastActivityAt       string `json:"last_activity_at,omitempty"`
+		HeartbeatIdleMinutes int    `json:"heartbeat_idle_minutes"`
 	}
 	var statuses []conductorStatus
 
 	for _, meta := range conductors {
 		cs := conductorStatus{
-			Name:        meta.Name,
-			Agent:       meta.GetAgent(),
-			Profile:     meta.Profile,
-			DirExists:   session.IsConductorSetup(meta.Name),
-			Heartbeat:   meta.HeartbeatEnabled,
-			Description: meta.Description,
+			Name:                 meta.Name,
+			Agent:                meta.GetAgent(),
+			Profile:              meta.Profile,
+			DirExists:            session.IsConductorSetup(meta.Name),
+			Heartbeat:            meta.HeartbeatEnabled,
+			Description:          meta.Description,
+			HeartbeatIdleMinutes: meta.GetHeartbeatIdleMinutes(),
+		}
+
+		// Get last activity time across managed sessions (excludes conductor window).
+		// Zero time means no data — omit rather than emit a spurious ancient timestamp.
+		if lastActivity, err := session.GetConductorLastActivity(meta.Name, meta.Profile); err == nil && !lastActivity.IsZero() {
+			cs.LastActivityAt = lastActivity.UTC().Format("2006-01-02T15:04:05Z07:00")
 		}
 
 		// Check session

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1923,6 +1923,17 @@ func handleSessionSend(profile string, args []string) {
 		os.Exit(1)
 	}
 
+	if shouldSkipConductorHeartbeatSend(inst, message) {
+		out.Success(fmt.Sprintf("Skipped heartbeat for '%s'", inst.Title), map[string]interface{}{
+			"success":       true,
+			"skipped":       true,
+			"session_id":    inst.ID,
+			"session_title": inst.Title,
+			"message":       message,
+		})
+		return
+	}
+
 	// Get tmux session
 	tmuxSess := inst.GetTmuxSession()
 	if tmuxSess == nil {
@@ -2071,6 +2082,32 @@ func defaultSendOptions() sendRetryOptions {
 		checkDelay:     300 * time.Millisecond,
 		verifyDelivery: true,
 	}
+}
+
+func shouldSkipConductorHeartbeatSend(inst *session.Instance, message string) bool {
+	if inst == nil || !session.IsConductorHeartbeatMessage(message) {
+		return false
+	}
+	name := strings.TrimPrefix(inst.Title, session.ConductorSessionTitlePrefix)
+	if name == inst.Title || name == "" {
+		return false
+	}
+	meta, err := session.LoadConductorMeta(name)
+	if err != nil {
+		return false
+	}
+	idleMinutes := meta.GetHeartbeatIdleMinutes()
+	if idleMinutes <= 0 {
+		return false
+	}
+	lastActivity, err := session.GetConductorLastActivity(name, meta.Profile)
+	if err != nil {
+		return false
+	}
+	if lastActivity.IsZero() {
+		return false
+	}
+	return time.Since(lastActivity) >= time.Duration(idleMinutes)*time.Minute
 }
 
 // sendWithRetry sends a message atomically and retries Enter if the agent

--- a/cmd/agent-deck/session_send_test.go
+++ b/cmd/agent-deck/session_send_test.go
@@ -48,6 +48,192 @@ func TestWaitForCompletion_ImmediateWaiting(t *testing.T) {
 	}
 }
 
+func TestShouldSkipConductorHeartbeatSend_UsesHeartbeatPrefixOnlyForConductors(t *testing.T) {
+	conductor := &session.Instance{Title: "conductor-ops"}
+	regular := &session.Instance{Title: "ops"}
+
+	if shouldSkipConductorHeartbeatSend(regular, session.ConductorHeartbeatMessagePrefix+" check") {
+		t.Fatal("regular sessions must not be treated as conductor heartbeats")
+	}
+	if shouldSkipConductorHeartbeatSend(regular, session.ConductorBridgeHeartbeatPrefix+" check") {
+		t.Fatal("regular sessions must not be treated as bridge conductor heartbeats")
+	}
+	if shouldSkipConductorHeartbeatSend(conductor, "hello") {
+		t.Fatal("non-heartbeat messages must not be treated as conductor heartbeats")
+	}
+}
+
+func TestShouldSkipConductorHeartbeatSend_ZeroLastActivitySends(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	if err := session.SaveConductorMeta(&session.ConductorMeta{
+		Name:                 "ops",
+		Profile:              "default",
+		Agent:                session.ConductorAgentClaude,
+		HeartbeatEnabled:     true,
+		HeartbeatIdleMinutes: 10,
+		CreatedAt:            "2026-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("save conductor meta: %v", err)
+	}
+
+	storage, err := session.NewStorageWithProfile("default")
+	if err != nil {
+		t.Fatalf("setup storage: %v", err)
+	}
+	conductor := session.NewInstance("conductor-ops", "/tmp")
+	conductor.IsConductor = true
+	if err := storage.Save([]*session.Instance{conductor}); err != nil {
+		t.Fatalf("save conductor instance: %v", err)
+	}
+
+	if shouldSkipConductorHeartbeatSend(conductor, session.ConductorHeartbeatMessagePrefix+" check") {
+		t.Fatal("zero last activity must not suppress conductor heartbeats")
+	}
+}
+
+// writeHookStatusForTest writes a hook-status JSON file for the given instance
+// with the timestamp set to `age` ago. Used by the inactivity-pause tests to
+// simulate sessions that last produced activity at a known point in the past.
+func writeHookStatusForTest(t *testing.T, instanceID string, age time.Duration) {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("home dir: %v", err)
+	}
+	hooksDir := filepath.Join(home, ".agent-deck", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks: %v", err)
+	}
+	ts := time.Now().Add(-age).Unix()
+	body := fmt.Sprintf(`{"status":"waiting","session_id":%q,"event":"Stop","ts":%d}`, instanceID, ts)
+	if err := os.WriteFile(filepath.Join(hooksDir, instanceID+".json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write hook status: %v", err)
+	}
+}
+
+// TestShouldSkipConductorHeartbeatSend_SkipsWhenIdleExceeded is the
+// positive-case regression for @yaroshevych's #839: when the most recent
+// managed-session activity is older than HeartbeatIdleMinutes, the conductor's
+// heartbeat MUST be suppressed.
+func TestShouldSkipConductorHeartbeatSend_SkipsWhenIdleExceeded(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	if err := session.SaveConductorMeta(&session.ConductorMeta{
+		Name:                 "ops",
+		Profile:              "default",
+		Agent:                session.ConductorAgentClaude,
+		HeartbeatEnabled:     true,
+		HeartbeatIdleMinutes: 10,
+		CreatedAt:            "2026-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("save conductor meta: %v", err)
+	}
+
+	storage, err := session.NewStorageWithProfile("default")
+	if err != nil {
+		t.Fatalf("setup storage: %v", err)
+	}
+
+	conductor := session.NewInstance("conductor-ops", "/tmp")
+	conductor.IsConductor = true
+	worker := session.NewInstance("worker-1", "/tmp/work")
+	worker.ParentSessionID = conductor.ID
+	if err := storage.Save([]*session.Instance{conductor, worker}); err != nil {
+		t.Fatalf("save instances: %v", err)
+	}
+
+	// Worker last produced activity 11 minutes ago — past the 10-minute gate.
+	writeHookStatusForTest(t, worker.ID, 11*time.Minute)
+
+	if !shouldSkipConductorHeartbeatSend(conductor, session.ConductorHeartbeatMessagePrefix+" check") {
+		t.Fatal("heartbeat should be skipped when last activity exceeds idle threshold")
+	}
+	if !shouldSkipConductorHeartbeatSend(conductor, session.ConductorBridgeHeartbeatPrefix+" check") {
+		t.Fatal("heartbeat should also be skipped for bridge-prefix heartbeat messages")
+	}
+}
+
+// TestShouldSkipConductorHeartbeatSend_DoesNotSkipWithinIdleWindow ensures
+// that activity newer than HeartbeatIdleMinutes leaves the heartbeat enabled.
+// This is the boundary case that proves the gate isn't simply "fire always" or
+// "fire never".
+func TestShouldSkipConductorHeartbeatSend_DoesNotSkipWithinIdleWindow(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	if err := session.SaveConductorMeta(&session.ConductorMeta{
+		Name:                 "ops",
+		Profile:              "default",
+		Agent:                session.ConductorAgentClaude,
+		HeartbeatEnabled:     true,
+		HeartbeatIdleMinutes: 10,
+		CreatedAt:            "2026-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("save conductor meta: %v", err)
+	}
+
+	storage, err := session.NewStorageWithProfile("default")
+	if err != nil {
+		t.Fatalf("setup storage: %v", err)
+	}
+
+	conductor := session.NewInstance("conductor-ops", "/tmp")
+	conductor.IsConductor = true
+	worker := session.NewInstance("worker-1", "/tmp/work")
+	worker.ParentSessionID = conductor.ID
+	if err := storage.Save([]*session.Instance{conductor, worker}); err != nil {
+		t.Fatalf("save instances: %v", err)
+	}
+
+	// Worker last produced activity 5 minutes ago — well within the 10-minute gate.
+	writeHookStatusForTest(t, worker.ID, 5*time.Minute)
+
+	if shouldSkipConductorHeartbeatSend(conductor, session.ConductorHeartbeatMessagePrefix+" check") {
+		t.Fatal("heartbeat must not be skipped while activity is within the idle window")
+	}
+}
+
+// TestShouldSkipConductorHeartbeatSend_DisabledThresholdNeverSkips proves the
+// feature is opt-in: HeartbeatIdleMinutes=0 disables the gate even when the
+// last activity is far older than any plausible threshold.
+func TestShouldSkipConductorHeartbeatSend_DisabledThresholdNeverSkips(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	if err := session.SaveConductorMeta(&session.ConductorMeta{
+		Name:                 "ops",
+		Profile:              "default",
+		Agent:                session.ConductorAgentClaude,
+		HeartbeatEnabled:     true,
+		HeartbeatIdleMinutes: 0, // disabled
+		CreatedAt:            "2026-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("save conductor meta: %v", err)
+	}
+
+	storage, err := session.NewStorageWithProfile("default")
+	if err != nil {
+		t.Fatalf("setup storage: %v", err)
+	}
+
+	conductor := session.NewInstance("conductor-ops", "/tmp")
+	conductor.IsConductor = true
+	worker := session.NewInstance("worker-1", "/tmp/work")
+	worker.ParentSessionID = conductor.ID
+	if err := storage.Save([]*session.Instance{conductor, worker}); err != nil {
+		t.Fatalf("save instances: %v", err)
+	}
+
+	writeHookStatusForTest(t, worker.ID, 24*time.Hour)
+
+	if shouldSkipConductorHeartbeatSend(conductor, session.ConductorHeartbeatMessagePrefix+" check") {
+		t.Fatal("heartbeat must not be skipped when HeartbeatIdleMinutes is 0")
+	}
+}
+
 func TestWaitForCompletion_ActiveThenWaiting(t *testing.T) {
 	mock := &mockStatusChecker{
 		statuses: []string{"active", "active", "waiting"},

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -17,7 +17,16 @@ import (
 const (
 	ConductorAgentClaude = "claude"
 	ConductorAgentCodex  = "codex"
+
+	ConductorSessionTitlePrefix     = "conductor-"
+	ConductorHeartbeatMessagePrefix = "Heartbeat:"
+	ConductorBridgeHeartbeatPrefix  = "[HEARTBEAT]"
 )
+
+func IsConductorHeartbeatMessage(message string) bool {
+	return strings.HasPrefix(message, ConductorHeartbeatMessagePrefix) ||
+		strings.HasPrefix(message, ConductorBridgeHeartbeatPrefix)
+}
 
 // ConductorAgentSpec describes conductor-specific behavior for an agent runtime.
 type ConductorAgentSpec struct {
@@ -145,6 +154,10 @@ type ConductorMeta struct {
 	// EnvFile is a path to a .env file to source before the conductor command.
 	// Supports ~ and $VAR expansion.
 	EnvFile string `json:"env_file,omitempty"`
+
+	// HeartbeatIdleMinutes is the minutes of inactivity before pausing heartbeats.
+	// 0 or negative = disabled (never pause). Positive = number of minutes.
+	HeartbeatIdleMinutes int `json:"heartbeat_idle_minutes"`
 }
 
 // GetAgent returns the normalized conductor agent, defaulting to Claude.
@@ -226,6 +239,98 @@ func (c *ConductorSettings) GetHeartbeatInterval() int {
 	return c.HeartbeatInterval
 }
 
+// GetHeartbeatIdleMinutes returns the heartbeat idle threshold in minutes.
+// Returns 0 when disabled (value is 0 or negative).
+// Returns the configured value when positive.
+func (m *ConductorMeta) GetHeartbeatIdleMinutes() int {
+	if m == nil {
+		return 0 // nil meta: disabled
+	}
+	if m.HeartbeatIdleMinutes <= 0 {
+		return 0 // disabled (0 or negative)
+	}
+	return m.HeartbeatIdleMinutes
+}
+
+// GetConductorLastActivity returns the most recent persistent agent activity across
+// sessions watched by the conductor. Conductors watch sessions in their profile,
+// including sessions that are not parented under the conductor, so the activity
+// scope includes every non-conductor session in the profile plus any conductor
+// descendants. The conductor's own session is intentionally excluded so that
+// heartbeat responses written to it do not reset the idle timer.
+//
+// Returns zero time (and no error) when the conductor has no managed sessions;
+// callers decide whether zero means "no data" or "idle".
+func GetConductorLastActivity(name, profile string) (time.Time, error) {
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("storage for profile %s: %w", profile, err)
+	}
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("load instances: %w", err)
+	}
+
+	// Find the conductor's session ID.
+	conductorTitle := ConductorSessionTitle(name)
+	var conductorID string
+	for _, inst := range instances {
+		if inst.Title == conductorTitle {
+			conductorID = inst.ID
+			break
+		}
+	}
+	if conductorID == "" {
+		return time.Time{}, fmt.Errorf("conductor session %q not found in storage", conductorTitle)
+	}
+
+	// Build a parent→children index for a single BFS pass.
+	children := make(map[string][]*Instance, len(instances))
+	for _, inst := range instances {
+		if inst.ParentSessionID != "" {
+			children[inst.ParentSessionID] = append(children[inst.ParentSessionID], inst)
+		}
+	}
+
+	var latest time.Time
+	seen := make(map[string]struct{}, len(instances))
+	consider := func(inst *Instance) {
+		if inst == nil {
+			return
+		}
+		if _, ok := seen[inst.ID]; ok {
+			return
+		}
+		seen[inst.ID] = struct{}{}
+
+		if hs := readHookStatusFile(inst.ID); hs != nil && hs.UpdatedAt.After(latest) {
+			latest = hs.UpdatedAt
+		}
+	}
+
+	// Include unparented/watched profile sessions. This matches conductor
+	// behavior: a conductor can monitor sessions that were created before it
+	// and therefore have no ParentSessionID link to the conductor.
+	for _, inst := range instances {
+		if inst.ID == conductorID || inst.IsConductor {
+			continue
+		}
+		consider(inst)
+	}
+
+	// Also include explicit descendants in case future conductor-managed
+	// sessions are marked as conductors or otherwise fall outside the broad
+	// profile scan above.
+	queue := children[conductorID]
+	for len(queue) > 0 {
+		inst := queue[0]
+		queue = queue[1:]
+		consider(inst)
+		queue = append(queue, children[inst.ID]...)
+	}
+	return latest, nil
+}
+
 // GetProfiles returns the configured profiles, defaulting to ["default"]
 func (c *ConductorSettings) GetProfiles() []string {
 	if len(c.Profiles) == 0 {
@@ -269,7 +374,7 @@ func ConductorProfileDir(profile string) (string, error) {
 
 // ConductorSessionTitle returns the session title for a named conductor
 func ConductorSessionTitle(name string) string {
-	return fmt.Sprintf("conductor-%s", name)
+	return ConductorSessionTitlePrefix + name
 }
 
 // ValidateConductorName checks that a conductor name is valid
@@ -465,7 +570,7 @@ func SetupConductor(name, profile string, heartbeatEnabled bool, clearOnCompact 
 // If customHeartbeatRulesMD is provided, creates a per-conductor HEARTBEAT_RULES.md symlink
 // (overrides the shared HEARTBEAT_RULES.md and any per-profile override).
 // It does NOT register the session (that's done by the CLI handler which has access to storage).
-func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool, clearOnCompact bool, description string, customInstructionsMD string, customPolicyMD string, customHeartbeatRulesMD string, env map[string]string, envFile string) error {
+func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool, clearOnCompact bool, description string, customInstructionsMD string, customPolicyMD string, customHeartbeatRulesMD string, env map[string]string, envFile string, heartbeatIdleMinutes ...int) error {
 	if err := ValidateConductorName(name); err != nil {
 		return err
 	}
@@ -546,6 +651,10 @@ func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool,
 	if !clearOnCompact {
 		meta.ClearOnCompact = &clearOnCompact
 	}
+	// Set heartbeat idle minutes if provided (non-negative value)
+	if len(heartbeatIdleMinutes) > 0 && heartbeatIdleMinutes[0] >= 0 {
+		meta.HeartbeatIdleMinutes = heartbeatIdleMinutes[0]
+	}
 	if err := SaveConductorMeta(meta); err != nil {
 		return fmt.Errorf("failed to write meta.json: %w", err)
 	}
@@ -568,16 +677,20 @@ func InstallHeartbeatScript(name, profile string) error {
 	if err != nil {
 		return err
 	}
-	profile = normalizeConductorProfile(profile)
+	scriptPath := filepath.Join(dir, "heartbeat.sh")
+	return os.WriteFile(scriptPath, []byte(renderConductorHeartbeatScript(name, profile)), 0o755)
+}
 
+func renderConductorHeartbeatScript(name, profile string) string {
+	profile = normalizeConductorProfile(profile)
 	script := strings.ReplaceAll(conductorHeartbeatScript, "{NAME}", name)
 	script = strings.ReplaceAll(script, "{PROFILE}", profile)
+	script = strings.ReplaceAll(script, "{HEARTBEAT_PREFIX}", ConductorBridgeHeartbeatPrefix)
 	if profile == DefaultProfile {
 		// For default profile, omit -p flag entirely
 		script = strings.ReplaceAll(script, `-p "$PROFILE" `, "")
 	}
-	scriptPath := filepath.Join(dir, "heartbeat.sh")
-	return os.WriteFile(scriptPath, []byte(script), 0o755)
+	return script
 }
 
 // HeartbeatPlistLabel returns the launchd label for a conductor's heartbeat
@@ -785,7 +898,7 @@ for candidate in \
     fi
 done
 
-MSG="[HEARTBEAT] Check sessions in your group ({NAME}). List any that are waiting, auto-respond where safe, and report what needs my attention."
+MSG="{HEARTBEAT_PREFIX} Check sessions in your group ({NAME}). List any that are waiting, auto-respond where safe, and report what needs my attention."
 if [ -n "$RULES_FILE" ]; then
     RULES=$(cat "$RULES_FILE")
     if [ -n "$RULES" ]; then
@@ -1208,11 +1321,7 @@ func MigrateConductorHeartbeatScripts() ([]string, error) {
 		}
 
 		scriptPath := filepath.Join(dir, "heartbeat.sh")
-		expected := strings.ReplaceAll(conductorHeartbeatScript, "{NAME}", meta.Name)
-		expected = strings.ReplaceAll(expected, "{PROFILE}", normalizeConductorProfile(meta.Profile))
-		if normalizeConductorProfile(meta.Profile) == DefaultProfile {
-			expected = strings.ReplaceAll(expected, `-p "$PROFILE" `, "")
-		}
+		expected := renderConductorHeartbeatScript(meta.Name, meta.Profile)
 
 		existing, err := os.ReadFile(scriptPath)
 		if err != nil {

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -211,6 +211,20 @@ func TestConductorSessionTitle(t *testing.T) {
 	}
 }
 
+func TestIsConductorHeartbeatMessage(t *testing.T) {
+	for _, msg := range []string{
+		ConductorHeartbeatMessagePrefix + " Check sessions",
+		ConductorBridgeHeartbeatPrefix + " [ops] Status: 1 waiting",
+	} {
+		if !IsConductorHeartbeatMessage(msg) {
+			t.Fatalf("expected heartbeat message to match: %q", msg)
+		}
+	}
+	if IsConductorHeartbeatMessage("hello") {
+		t.Fatal("non-heartbeat message should not match")
+	}
+}
+
 func TestHeartbeatPlistLabel(t *testing.T) {
 	label := HeartbeatPlistLabel("test")
 	expected := "com.agentdeck.conductor-heartbeat.test"
@@ -627,8 +641,46 @@ func TestConductorHeartbeatScript_InjectsHeartbeatRules(t *testing.T) {
 	if !strings.Contains(conductorHeartbeatScript, "/.agent-deck/conductor/HEARTBEAT_RULES.md") {
 		t.Fatal("heartbeat script should fall back to the global HEARTBEAT_RULES.md")
 	}
-	if !strings.Contains(conductorHeartbeatScript, "[HEARTBEAT]") {
-		t.Fatal("heartbeat script should send messages prefixed with [HEARTBEAT] (matches bridge.py)")
+	// The rendered (not raw) script should carry the bridge-style prefix so the
+	// idle-pause matcher (IsConductorHeartbeatMessage) can recognise heartbeat
+	// messages emitted by this OS-level heartbeat path.
+	rendered := renderConductorHeartbeatScript("alpha", "default")
+	if !strings.Contains(rendered, ConductorBridgeHeartbeatPrefix) {
+		t.Fatalf("rendered heartbeat script should emit %q prefix (matches bridge.py)", ConductorBridgeHeartbeatPrefix)
+	}
+}
+
+// TestRenderConductorHeartbeatScript_ReplacesHeartbeatPrefix verifies the
+// {HEARTBEAT_PREFIX} placeholder is rendered using a Go constant so the
+// producer (shell script) and the consumer (IsConductorHeartbeatMessage)
+// cannot drift apart in future refactors.
+func TestRenderConductorHeartbeatScript_ReplacesHeartbeatPrefix(t *testing.T) {
+	script := renderConductorHeartbeatScript("test", "default")
+	if strings.Contains(script, "{HEARTBEAT_PREFIX}") {
+		t.Fatalf("heartbeat script must not contain unresolved prefix placeholder:\n%s", script)
+	}
+	if !strings.Contains(script, ConductorBridgeHeartbeatPrefix+" Check sessions in your group (test)") {
+		t.Fatalf("heartbeat script should contain rendered heartbeat message prefix:\n%s", script)
+	}
+}
+
+// TestConductorStatusJSON_ZeroActivityOmitted verifies that when
+// GetConductorLastActivity returns zero time (no managed sessions), the
+// conductor status JSON omits last_activity_at entirely rather than emitting
+// 0001-01-01T00:00:00Z. An ancient timestamp would cause the bridge to
+// suppress heartbeats forever when heartbeat_idle_minutes > 0.
+func TestConductorStatusJSON_ZeroActivityOmitted(t *testing.T) {
+	type conductorStatus struct {
+		LastActivityAt *string `json:"last_activity_at,omitempty"`
+	}
+	// Simulate a zero last_activity pointer (nil → omitted).
+	cs := conductorStatus{LastActivityAt: nil}
+	data, err := json.Marshal(cs)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "last_activity_at") {
+		t.Errorf("last_activity_at must be omitted when nil, got: %s", data)
 	}
 }
 
@@ -2347,5 +2399,241 @@ func TestSetupConductor_WithoutEnvVars(t *testing.T) {
 	}
 	if meta.EnvFile != "" {
 		t.Errorf("expected empty env_file, got %s", meta.EnvFile)
+	}
+}
+
+// --- GetConductorLastActivity tests ---
+
+// TestGetConductorLastActivity_NoConductorSession verifies that an error is
+// returned when the conductor session does not exist in storage — not a zero
+// time — so callers can distinguish "no data" from "no managed sessions".
+func TestGetConductorLastActivity_NoConductorSession(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// Bootstrap a storage profile so NewStorageWithProfile succeeds.
+	if _, err := NewStorageWithProfile("default"); err != nil {
+		t.Fatalf("setup storage: %v", err)
+	}
+
+	_, err := GetConductorLastActivity("no-such-conductor", "default")
+	if err == nil {
+		t.Fatal("expected error when conductor session not in storage, got nil")
+	}
+}
+
+// TestGetConductorLastActivity_NoWatchedSessions verifies that zero time is
+// returned (not an error) when the conductor session exists in storage but there
+// are no watched non-conductor sessions. Zero time signals "no data" to the idle
+// gate, which must not suppress heartbeats in this case.
+func TestGetConductorLastActivity_NoManagedSessions(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	storage, err := NewStorageWithProfile("default")
+	if err != nil {
+		t.Fatalf("setup storage: %v", err)
+	}
+
+	// Register the conductor session itself (no children).
+	conductorInst := NewInstance("conductor-alpha", "/tmp")
+	conductorInst.IsConductor = true
+	if err := storage.Save([]*Instance{conductorInst}); err != nil {
+		t.Fatalf("save conductor instance: %v", err)
+	}
+
+	got, err := GetConductorLastActivity("alpha", "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.IsZero() {
+		t.Errorf("expected zero time for conductor with no managed sessions, got %v", got)
+	}
+}
+
+// TestGetConductorLastActivity_ExcludesConductorWindow verifies that the
+// conductor's own tmux window is NOT included in the activity scan. This ensures
+// heartbeat responses (which produce output in the conductor window) cannot
+// reset the idle timer. Unparented watched sessions are included because
+// conductors monitor profile sessions even when they are not descendants.
+func TestGetConductorLastActivity_ExcludesConductorWindow(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	storage, err := NewStorageWithProfile("default")
+	if err != nil {
+		t.Fatalf("setup storage: %v", err)
+	}
+
+	conductorInst := NewInstance("conductor-beta", "/tmp")
+	conductorInst.IsConductor = true
+
+	// A managed session parented to the conductor.
+	managed := NewInstance("worker-1", "/tmp/work")
+	managed.ParentSessionID = conductorInst.ID
+
+	// Unparented watched profile session; must contribute to activity scope.
+	unparented := NewInstance("other-session", "/tmp/other")
+
+	if err := storage.Save([]*Instance{conductorInst, managed, unparented}); err != nil {
+		t.Fatalf("save instances: %v", err)
+	}
+
+	// We can't call tmux in a unit test, so just verify the function proceeds
+	// past the storage lookup without panicking. The tmux calls will fail
+	// gracefully (no tmux server) and GetConductorLastActivity returns zero.
+	got, err := GetConductorLastActivity("beta", "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Without tmux, window_activity lookups fail silently → zero time is correct.
+	if !got.IsZero() {
+		t.Errorf("expected zero time (no tmux server), got %v", got)
+	}
+}
+
+// TestGetConductorLastActivity_IncludesUnparentedWatchedSessions verifies the
+// activity scope matches what conductors actually monitor: non-conductor
+// sessions in the same profile, even when they were created before the
+// conductor and have no ParentSessionID link.
+func TestGetConductorLastActivity_IncludesUnparentedWatchedSessions(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	storage, err := NewStorageWithProfile("default")
+	if err != nil {
+		t.Fatalf("setup storage: %v", err)
+	}
+
+	conductorInst := NewInstance("conductor-delta", "/tmp")
+	conductorInst.IsConductor = true
+	watched := NewInstance("preexisting-worker", "/tmp/work")
+
+	if err := storage.Save([]*Instance{conductorInst, watched}); err != nil {
+		t.Fatalf("save instances: %v", err)
+	}
+
+	got, err := GetConductorLastActivity("delta", "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Without a live tmux server window_activity lookups fail silently, so the
+	// result is zero. The important regression guard is that this call treats the
+	// unparented worker as in-scope and still completes without requiring a
+	// ParentSessionID edge.
+	if !got.IsZero() {
+		t.Errorf("expected zero time (no tmux server), got %v", got)
+	}
+}
+
+// TestGetConductorLastActivity_TransitiveScan verifies that sub-sessions
+// (grandchildren of the conductor) are included in the activity scan.
+// Without transitive scanning, a managed session that is idle/waiting on a
+// sub-session would cause the idle gate to miss the sub-session's activity.
+func TestGetConductorLastActivity_TransitiveScan(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	storage, err := NewStorageWithProfile("default")
+	if err != nil {
+		t.Fatalf("setup storage: %v", err)
+	}
+
+	conductorInst := NewInstance("conductor-gamma", "/tmp")
+	conductorInst.IsConductor = true
+
+	// Direct child of conductor.
+	managed := NewInstance("worker-2", "/tmp/work")
+	managed.ParentSessionID = conductorInst.ID
+
+	// Sub-session (grandchild of conductor, child of managed).
+	subSession := NewInstance("sub-worker-a", "/tmp/sub")
+	subSession.ParentSessionID = managed.ID
+
+	// Unrelated session — must not appear in the scan.
+	unrelated := NewInstance("other", "/tmp/other")
+
+	if err := storage.Save([]*Instance{conductorInst, managed, subSession, unrelated}); err != nil {
+		t.Fatalf("save instances: %v", err)
+	}
+
+	// Without a live tmux server all window_activity queries fail silently;
+	// the function must still complete without error.
+	got, err := GetConductorLastActivity("gamma", "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Zero is correct in a no-tmux environment; the important thing is that
+	// the BFS traversal reached the sub-session without panicking or erroring.
+	if !got.IsZero() {
+		t.Errorf("expected zero time (no tmux server), got %v", got)
+	}
+}
+
+// --- Inactivity pause tests ---
+
+func TestGetHeartbeatIdleMinutes(t *testing.T) {
+	tests := []struct {
+		name     string
+		minutes  int
+		expected int
+	}{
+		{"zero means disabled (never pause)", 0, 0},
+		{"negative means disabled", -1, 0},
+		{"negative large means disabled", -100, 0},
+		{"custom value 5", 5, 5},
+		{"custom value 30", 30, 30},
+		{"custom value 60", 60, 60},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := &ConductorMeta{HeartbeatIdleMinutes: tt.minutes}
+			if got := meta.GetHeartbeatIdleMinutes(); got != tt.expected {
+				t.Errorf("GetHeartbeatIdleMinutes() with %d = %d, want %d", tt.minutes, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetHeartbeatIdleMinutes_NilMeta(t *testing.T) {
+	var meta *ConductorMeta
+	if got := meta.GetHeartbeatIdleMinutes(); got != 0 {
+		t.Errorf("GetHeartbeatIdleMinutes() with nil meta = %d, want 0", got)
+	}
+}
+
+func TestConductorMeta_InactivityPauseJSON(t *testing.T) {
+	// Test that HeartbeatIdleMinutes is properly serialized/deserialized
+	meta := &ConductorMeta{
+		Name:                 "test-inactivity",
+		Profile:              "default",
+		HeartbeatEnabled:     true,
+		HeartbeatIdleMinutes: 30,
+		CreatedAt:            "2026-01-01T00:00:00Z",
+	}
+
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	// Verify the field appears in JSON with correct tag
+	if !strings.Contains(string(data), "heartbeat_idle_minutes") {
+		t.Error("JSON should contain 'heartbeat_idle_minutes' field")
+	}
+
+	// Verify the value is present
+	if !strings.Contains(string(data), `"heartbeat_idle_minutes":30`) {
+		t.Errorf("JSON should contain heartbeat_idle_minutes=30, got: %s", string(data))
+	}
+
+	// Deserialize and verify
+	var loaded ConductorMeta
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if loaded.HeartbeatIdleMinutes != 30 {
+		t.Errorf("HeartbeatIdleMinutes after unmarshal = %d, want 30", loaded.HeartbeatIdleMinutes)
 	}
 }


### PR DESCRIPTION
## Summary

Re-applies @yaroshevych's #839 against current `main` with conflicts resolved.
His PR has been conflicting and unresponsive for ~5h, so this takeover lands
the feature on top of the two PRs his branch couldn't be cleanly rebased onto:

- **#1017** — `fix(heartbeat): retire identical NEED lines after 3 cycles (closes #971)`
- **#1012** — `feat(skills): self-improvement pipeline + goal-driven worker autonomy`

Both are merged into `main`, so this re-applies @yaroshevych's diff and
resolves the four mechanical conflicts that arose.

## What this adds (faithful to @yaroshevych's design)

- `-heartbeat-idle-minutes` flag on `agent-deck conductor setup`
  - `0` (default) or negative = disabled, never pause
  - positive `N` = pause heartbeat sends after `N` minutes of inactivity
- `ConductorMeta.HeartbeatIdleMinutes` persisted in `meta.json`
- `shouldSkipConductorHeartbeatSend()` short-circuits `session send` when the
  target is a conductor session and the last managed-session activity exceeds
  the configured threshold
- `GetConductorLastActivity()` scans every non-conductor session in the
  conductor's profile, plus transitive conductor descendants. The conductor's
  own window is intentionally excluded so heartbeat-response output cannot
  reset the idle timer.
- `agent-deck conductor status --json` now includes `last_activity_at` and
  `heartbeat_idle_minutes`. `last_activity_at` is omitted (not `0001-01-01…`)
  when there's no data — guards against the bridge interpreting an ancient
  timestamp as "permanently idle".
- `IsConductorHeartbeatMessage()` matches both `Heartbeat:` (legacy) and
  `[HEARTBEAT]` (bridge.py / main) prefixes so the gate works regardless of
  which heartbeat path produced the message.

## Conflict resolutions (vs current `main`)

| File | Resolution |
| --- | --- |
| `internal/session/conductor.go` (signature) | Keep `customHeartbeatRulesMD` param from main; append @yaroshevych's `heartbeatIdleMinutes ...int` variadic at the end (backward-compat). |
| `cmd/agent-deck/conductor_cmd.go` (call site) | Pass both `*heartbeatRulesMD` and `*heartbeatIdleMinutes`. |
| `internal/session/conductor.go` (heartbeat script) | Keep main's `\$MSG` form (preserves the `HEARTBEAT_RULES.md` inline injection from #218); adopt @yaroshevych's `{HEARTBEAT_PREFIX}` placeholder mapped to `ConductorBridgeHeartbeatPrefix` so the emitted prefix stays `[HEARTBEAT]`. |
| `cmd/agent-deck/session_cmd.go` | Keep main's `defaultSendOptions` next to @yaroshevych's `shouldSkipConductorHeartbeatSend`; both functions live side-by-side. |
| `internal/session/conductor_test.go` | Keep both `TestConductorHeartbeatScript_InjectsHeartbeatRules` (main) and `TestRenderConductorHeartbeatScript_ReplacesHeartbeatPrefix` (yarosh); the latter now asserts the bridge prefix is rendered. |

## Regression tests added on top of @yaroshevych's set

@yaroshevych's diff only covered the zero-activity negative case. I added the
positive happy-path + boundary tests since "every bug shipped is a missing test":

- `TestShouldSkipConductorHeartbeatSend_SkipsWhenIdleExceeded` — activity 11 min
  ago + threshold 10 min → heartbeat IS skipped (both legacy and bridge prefixes).
- `TestShouldSkipConductorHeartbeatSend_DoesNotSkipWithinIdleWindow` — activity
  5 min ago + threshold 10 min → heartbeat is NOT skipped.
- `TestShouldSkipConductorHeartbeatSend_DisabledThresholdNeverSkips` — threshold
  0 with 24h-old activity → heartbeat is NOT skipped (opt-in semantics).

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -timeout 8m ./...` green across every package
- [x] Targeted: `TestShouldSkipConductorHeartbeatSend*`, `TestGetConductorLastActivity*`, `TestIsConductorHeartbeatMessage`, `TestRenderConductorHeartbeatScript*`, `TestConductorStatusJSON_ZeroActivityOmitted`, `TestConductorHeartbeatScript_InjectsHeartbeatRules`, `TestGetHeartbeatIdleMinutes*`, `TestConductorMeta_InactivityPauseJSON` — all pass under \`-race\`.
- [x] `python -m pytest conductor/tests` — 30 passed, 1 skipped, 1 pre-existing Linux \`ETXTBSY\` failure (`test_hooks.py::TestRunHook::test_env_vars_set`) which reproduces on stock \`origin/main\` and is environmental, not caused by this PR.

## Credit

All conceptual + implementation credit to **@yaroshevych** for the original
#839. This PR only re-applies and reconciles his work against the two newer
PRs his branch couldn't cleanly land on. Closing #839 in favor of this one
once it's merged.

## Do not merge

Per the takeover protocol, this PR is for review — please don't merge until
@yaroshevych has had a chance to comment.