### PR TITLE
fix(testutil): fix 15 macOS tests broken by TMUX socket path length

### DIFF
--- a/internal/testutil/tmuxenv.go
+++ b/internal/testutil/tmuxenv.go
@@ -60,7 +60,7 @@ func IsolateTmuxSocket() func() {
 	_ = os.Unsetenv("TMUX")
 	_ = os.Unsetenv("TMUX_PANE")
 
-	dir, err := os.MkdirTemp("", "agent-deck-test-tmux-")
+	dir, err := os.MkdirTemp(shortTmuxTmpBase(), "ad-tmux-")
 	if err != nil {
 		// If we can't isolate via MkdirTemp, we still want tests to
 		// run — but we REALLY don't want them on the default socket.
@@ -81,6 +81,36 @@ func IsolateTmuxSocket() func() {
 		// the kernel removes them when the bound tmux server exits.
 		_ = os.RemoveAll(dir)
 	}
+}
+
+// shortTmuxTmpBase returns a short base directory for the per-test TMUX_TMPDIR.
+//
+// UNIX-domain socket paths are capped at sockaddr_un.sun_path (104 chars on
+// darwin, 108 on linux). tmux appends "/tmux-<uid>/<sock>" (~17 chars) to
+// TMUX_TMPDIR, and MkdirTemp's random suffix eats ~10 more, so the base must
+// stay well under ~75 chars. On darwin, os.TempDir() returns
+// /var/folders/<aa>/<32-char-hash>/T (resolved through /private/...) which is
+// ~56 chars and immediately overshoots the limit. /tmp is the well-known short
+// path on every Unix-like OS, matches tmux's own default location, and matches
+// the existing failure-mode fallback at the bottom of IsolateTmuxSocket.
+//
+// Returns "/tmp" when writable; otherwise returns "" so os.MkdirTemp falls
+// back to os.TempDir() (preserving the prior behavior on hosts that remap
+// TMPDIR but leave /tmp unwritable — rare under sandboxes/SELinux/AppArmor).
+func shortTmuxTmpBase() string {
+	const candidate = "/tmp"
+	info, err := os.Stat(candidate)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+	probe, err := os.CreateTemp(candidate, ".ad-tmux-probe-")
+	if err != nil {
+		return ""
+	}
+	name := probe.Name()
+	_ = probe.Close()
+	_ = os.Remove(name)
+	return candidate
 }
 
 // restoreEnv puts an env var back to its original state. If it wasn't set


### PR DESCRIPTION
## Summary

- UNIX-domain socket paths are capped at `sockaddr_un.sun_path` (104 chars on darwin, 108 on linux). `os.TempDir()` on darwin returns `/var/folders/<aa>/<32-char-hash>/T` (~56 chars, resolved through `/private/...`), so once tmux appended `/tmux-<uid>/default` and `MkdirTemp` added its random suffix, the resulting socket path overshot the limit and every test that spawned a real tmux server died at `bind()` with the misleading `File name too long` errno. ~16 tests in `cmd/agent-deck/...` and `internal/session/...` failed deterministically on every macOS host.
- Routes `IsolateTmuxSocket`'s `MkdirTemp` through `/tmp` when writable, falling back to `os.TempDir()` otherwise. Linux behavior is unchanged (`TempDir()` is already `/tmp` on every common distro and CI image). On darwin, the post-fix socket path is ~40 chars — 64 chars of headroom under the 104-char limit.
- One file, +31/-1 lines. No production-code change, no public-API change.

## Empirical impact (macOS, full suite over `./cmd/agent-deck/... ./internal/session/...`)

| State          | main | branch |
|----------------|------|--------|
| Failing tests  | 19   | 7      |

**15 tests flipped FAIL → PASS**, including the entire `TestPersistence_*` PR gate that `CLAUDE.local.md` mandates pass before any session-lifecycle change merges, plus all `TestUpdateStatus_CLIvsTUIParity_*`, both `TestRestart_ShellSession_*`, and `TestTmuxBootstrap_ServerIsRunning`.

## Newly exposed (not regressions)

After the fix, 3 tests went SKIP → FAIL:

- `TestSyncSessionIDsFromTmux_NoOverwriteWithEmpty`
- `TestInstance_GetSessionIDFromTmux`
- `TestInstance_Restart_InterruptsAndResumes`

Root cause: these gate on `skipIfNoTmuxServer`, which skips when no non-bootstrap session exists in `TMUX_TMPDIR`. On main, the socket bug prevented earlier tests from creating any sessions, so the guard always fired. Now that earlier tests succeed, the guard lets these run and they fail on their own pre-existing logic bugs — bugs that have been silently skipped for months. **Not caused by this fix; revealed by it.** Worth a separate ticket.

## Still failing on both branches (independent root causes, out of scope)

- `TestOuterTmuxGuard` — dev shell has `TMUX` set; needs `t.Setenv("TMUX", "")` in the test
- `TestConductor_Restart_PreservesChatHistory_RegressionFor956`
- `TestSessionStop_ReapsMcpChildren_RegressionFor965`
- `TestPersistence_CustomCommandResumesFromLatestJSONL` — exposes a separate logic bug at `instance.go:1895-1901`
- `TestEval_Session_InjectStatusLine_RealTmux` — same root-cause class but in a separate code path (`tests/eval/harness/sandbox.go:103`, uses `t.TempDir()` directly, bypasses `IsolateTmuxSocket`)
- `TestAggregateSize_ReportsLargestClient` (in `internal/testutil/multiclienttmux`) — same root-cause class, also bypasses `IsolateTmuxSocket`

The two same-class failures (eval harness + multiclienttmux) are deliberate follow-ups — fixing them requires analogous changes in those code paths and is out of scope for this PR.

## Test plan

- [x] `go build ./...` clean on darwin
- [x] `go vet ./internal/testutil/...` clean
- [x] `go test ./internal/testutil/...` passes (`TestIsolateTmuxSocket_*` still asserts the dir is not `/tmp` and doesn't match `/tmp/tmux-` prefix — both hold for the new `/tmp/ad-tmux-XXX` paths)
- [x] `TestPersistence_*` gate passes on darwin (6/7 PASS; the 7th is a pre-existing logic bug exposed by the fix, see above)
- [x] Branch-vs-main full-suite diff confirms strict net reduction in failures (15 fixed, 0 socket-path regressions, 3 SKIP→FAIL revelations)
- [ ] Linux non-regression — verified by reading the code path (`shortTmuxTmpBase()` returns `/tmp`, which is what `os.TempDir()` already returns on linux), to be confirmed by CI on push
- [ ] `eval-smoke` CI green

## Files changed

- `internal/testutil/tmuxenv.go` — one new helper `shortTmuxTmpBase()`, one line changed in `IsolateTmuxSocket` to use it, shorter dir prefix (`ad-tmux-` vs `agent-deck-test-tmux-`). The fallback path on `MkdirTemp` error is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal testing infrastructure for temporary directory handling to enhance compatibility across different system configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1050?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->