### PR TITLE
feat(ci): add diff-scope guard (>200 files = block)

### DIFF
--- a/.github/workflows/pr-diffscope.yml
+++ b/.github/workflows/pr-diffscope.yml
@@ -1,0 +1,20 @@
+name: PR diff-scope guard
+on:
+  pull_request: { branches: [main] }
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  diffscope:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Count changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          n=$(gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --name-only | wc -l)
+          echo "Changed files: $n"
+          if [ "$n" -gt 200 ]; then
+            echo "::error::PR touches $n files (>200). Likely stale base or generated-code dump. Inspect before merge."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a tiny CI job that fails if a PR touches more than 200 files. Catches stale-base merges, generated-code dumps, and accidental mass-rewrites before a human has to read the diff.

## How

`.github/workflows/pr-diffscope.yml` runs on every PR, calls `gh pr diff --name-only | wc -l`, and fails the job with a clear error message if the count exceeds 200. The threshold is conservative — most legitimate PRs to this repo are well under 50 files.

## Why separate from PR-1

PR-1 ships defensive analysis tooling (CodeQL, govulncheck, golangci-lint, Dependabot). This PR ships a meta-control over PRs themselves. Keeping them separate means either can be reverted in isolation if the guard turns out to be too strict or trips on legitimate large refactors.

## Test plan

- [ ] Workflow appears as a required-status check candidate
- [ ] Job runs green on this PR (1 file changed)
- [ ] Verify failure path manually later by opening a synthetic large PR (out of scope here)

Reference: `~/.agent-deck/conductor/agent-deck/SECURITY-PIPELINE-PLAN.md`

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pull request validation workflow to monitor and enforce repository standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->