### PR TITLE
fix(deps): restrict Dependabot grouping to minor+patch updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,25 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: "/"
-    schedule: { interval: weekly, day: monday }
+    schedule:
+      interval: weekly
+      day: monday
     open-pull-requests-limit: 5
     groups:
       go-minor-patch:
-        update-types: [minor, patch]
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: "/"
-    schedule: { interval: weekly, day: monday }
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
     groups:
-      actions-all:
-        patterns: ["*"]
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Why

Dependabot's first run (#1056, now closed) bundled 12 major-version action bumps into a single PR: actions/checkout v4-v6, golangci-lint-action v6-v9, goreleaser-action v6-v7, and 9 others. Major bumps carry breaking changes that need individual testing — collapsing them into one all-or-nothing PR makes them untestable.

## Fix

Add 'update-types: [minor, patch]' to both group rules in .github/dependabot.yml. Major bumps will now open as individual PRs; minor + patch stay grouped to keep noise down.

## Refs

- Closed #1056 (the bundled-majors PR)
- #1052 (security pipeline that wired up Dependabot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration formatting to improve maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->