### PR TITLE
fix(ui): focus text input on rename-group dialog open (closes #1068)

### DIFF
--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -161,7 +161,9 @@ func (g *GroupDialog) ShowRename(currentPath, currentName string) {
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
 	g.nameInput.CursorEnd() // Issue #604: place cursor at end of pre-filled name.
-	g.nameInput.Focus()
+	// Issue #1068: must reset focusIndex and blur pathInput, otherwise stale
+	// state from a prior Create-dialog Tab routes keys to the invisible path.
+	g.focusName()
 }
 
 // ShowMove shows the dialog for moving a session to a group path.
@@ -181,7 +183,9 @@ func (g *GroupDialog) ShowRenameSession(sessionID, currentName string) {
 	g.validationErr = ""
 	g.nameInput.SetValue(currentName)
 	g.nameInput.CursorEnd() // Issue #604: place cursor at end of pre-filled name.
-	g.nameInput.Focus()
+	// Issue #1068: must reset focusIndex and blur pathInput, otherwise stale
+	// state from a prior Create-dialog Tab routes keys to the invisible path.
+	g.focusName()
 }
 
 // GetSessionID returns the session ID being renamed

--- a/internal/ui/issue1068_rename_focus_test.go
+++ b/internal/ui/issue1068_rename_focus_test.go
@@ -1,0 +1,80 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Issue #1068: rename-group dialog's text input is unresponsive when opened
+// after the Create-group dialog has previously tabbed focus to the path input.
+//
+// Root cause: ShowRename() (and ShowRenameSession()) call nameInput.Focus()
+// but leave focusIndex at whatever value the last Create dialog set it to
+// (focusIndex=1 after Tab). Update() then routes keystrokes to the invisible
+// pathInput. Restart wipes the focusIndex and "fixes" the bug.
+//
+// The fix must guarantee that opening Rename / RenameSession always lands
+// focus on nameInput regardless of leftover dialog state.
+
+// TestIssue1068_RenameAfterCreateTab_AcceptsKeystrokes reproduces the bug
+// at the GroupDialog level using only the public API.
+func TestIssue1068_RenameAfterCreateTab_AcceptsKeystrokes(t *testing.T) {
+	g := NewGroupDialog()
+	g.SetSize(100, 30)
+
+	// Step 1: User opens Create-Subgroup dialog (CanToggle is false here, so
+	// Tab moves focus to the path input rather than toggling).
+	g.ShowCreateSubgroup("parent", "Parent")
+
+	// Step 2: User Tabs to the optional "Default Path" field.
+	g, _ = g.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	// Step 3: User cancels the Create dialog (mimics pressing Esc → Hide).
+	g.Hide()
+
+	// Step 4: User presses 'r' on a group → ShowRename is called.
+	g.ShowRename("some/group", "old-name")
+	if !g.IsVisible() {
+		t.Fatal("Rename dialog should be visible after ShowRename")
+	}
+	if g.Mode() != GroupDialogRename {
+		t.Fatalf("Mode = %v, want GroupDialogRename", g.Mode())
+	}
+
+	// Step 5: User types 'a'. With the bug, the key is routed to the
+	// invisible pathInput and the name value never changes. With the fix,
+	// the key lands on the visible nameInput.
+	g, _ = g.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+
+	got := g.GetValue()
+	want := "old-namea"
+	if got != want {
+		t.Errorf("GetValue() after typing 'a' = %q, want %q (key was routed to pathInput instead of nameInput)", got, want)
+	}
+}
+
+// TestIssue1068_RenameSessionAfterCreateTab_AcceptsKeystrokes covers the
+// same stale-focus regression for the rename-session path, since
+// ShowRenameSession has the identical defect as ShowRename.
+func TestIssue1068_RenameSessionAfterCreateTab_AcceptsKeystrokes(t *testing.T) {
+	g := NewGroupDialog()
+	g.SetSize(100, 30)
+
+	g.ShowCreateSubgroup("parent", "Parent")
+	g, _ = g.Update(tea.KeyMsg{Type: tea.KeyTab})
+	g.Hide()
+
+	g.ShowRenameSession("sess-1", "old-title")
+	if g.Mode() != GroupDialogRenameSession {
+		t.Fatalf("Mode = %v, want GroupDialogRenameSession", g.Mode())
+	}
+
+	g, _ = g.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'X'}})
+
+	got := g.GetValue()
+	want := "old-titleX"
+	if got != want {
+		t.Errorf("GetValue() after typing 'X' = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1068 — credit @ddorman-dn for the repro.

The rename-group dialog opened but ignored every keystroke on first use; pressing `Ctrl+C` and restarting "fixed" it. Classic stale-state bug.

## Symptom

- Press `r` on a group → "Rename Group" dialog appears with current name pre-filled
- User types — **nothing happens**; the value never changes
- `Ctrl+C` → relaunch → press `r` again → typing works correctly

## Root cause

`GroupDialog` is reused across all four modes (Create / Rename / Move / RenameSession). The `focusIndex` field (0 = name input, 1 = path input) is a long-lived struct field that survives `Hide()`.

The `Create` dialog exposes a `Default Path` field reachable via `Tab` (#918). When the user `Tab`s into it, `focusPath()` sets `focusIndex = 1` and calls `pathInput.Focus()`. `Hide()` only blurs the name input.

`ShowRename()` and `ShowRenameSession()` then called only `g.nameInput.Focus()`:

```go
func (g *GroupDialog) ShowRename(currentPath, currentName string) {
    ...
    g.nameInput.Focus()    // sets nameInput.focus = true
    // BUT: focusIndex is still 1
    // AND: pathInput.focus is still true
}
```

In `Update`, the routing checks `focusIndex`:

```go
if g.focusIndex == 1 {
    g.pathInput, cmd = g.pathInput.Update(msg)   // ← key goes here
} else {
    g.nameInput, cmd = g.nameInput.Update(msg)
}
```

So keystrokes are silently absorbed by the invisible `pathInput`. Restarting the binary zeroes `focusIndex` and the next rename "just works".

## Fix

Make both rename entry points call the existing `focusName()` helper, which is what `Show()` / `ShowCreateSubgroup()` already use. It resets `focusIndex = 0`, focuses the name input, and blurs the path input — three things in lockstep.

```diff
-    g.nameInput.Focus()
+    // Issue #1068: must reset focusIndex and blur pathInput, otherwise stale
+    // state from a prior Create-dialog Tab routes keys to the invisible path.
+    g.focusName()
```

## Test trace

`internal/ui/issue1068_rename_focus_test.go` adds two tests that reproduce the bug at the GroupDialog level via the public API only:

1. **TestIssue1068_RenameAfterCreateTab_AcceptsKeystrokes** — opens Create-Subgroup, Tabs to path, Hides, opens Rename, types `'a'`, asserts the name field captured the key.
2. **TestIssue1068_RenameSessionAfterCreateTab_AcceptsKeystrokes** — same flow for the rename-session path.

### Before the fix (RED)

```
=== RUN   TestIssue1068_RenameAfterCreateTab_AcceptsKeystrokes
    issue1068_rename_focus_test.go:53: GetValue() after typing 'a' = "old-name", want "old-namea" (key was routed to pathInput instead of nameInput)
--- FAIL: TestIssue1068_RenameAfterCreateTab_AcceptsKeystrokes (0.00s)
=== RUN   TestIssue1068_RenameSessionAfterCreateTab_AcceptsKeystrokes
    issue1068_rename_focus_test.go:78: GetValue() after typing 'X' = "old-title", want "old-titleX"
--- FAIL: TestIssue1068_RenameSessionAfterCreateTab_AcceptsKeystrokes (0.00s)
FAIL
```

### After the fix (GREEN)

```
=== RUN   TestIssue1068_RenameAfterCreateTab_AcceptsKeystrokes
--- PASS: TestIssue1068_RenameAfterCreateTab_AcceptsKeystrokes (0.00s)
=== RUN   TestIssue1068_RenameSessionAfterCreateTab_AcceptsKeystrokes
--- PASS: TestIssue1068_RenameSessionAfterCreateTab_AcceptsKeystrokes (0.00s)
PASS
```

Full repo `go test -race -count=1 ./...` is green.

## Test plan

- [x] New regression tests fail on main, pass on this branch
- [x] `go test -race -count=1 ./internal/ui/...` green
- [x] `go test -race -count=1 ./...` green
- [ ] Manual TUI smoke: launch agent-deck → open Create dialog → Tab to path → Esc → press `r` on a group → confirm typing now lands in the name field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard focus issue in rename dialogs that occurred after using create dialogs, preventing proper text input during renaming operations.

* **Tests**
  * Added regression tests to verify rename functionality works correctly after create dialog interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->