### PR TITLE
fix(session): preserve StatusStopped on manual stop (closes #953)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3344,6 +3344,15 @@ func (i *Instance) UpdateStatus() error {
 	status, err := i.tmuxSession.GetStatus()
 	i.mu.Lock()
 
+	// Issue #953: a concurrent Kill() may have published StatusStopped
+	// while we were unlocked for the GetStatus call above. Honoring a
+	// stale tmux-derived status now would clobber the user-initiated
+	// stop with idle/running/error and the next render would show the
+	// wrong icon (the original v1.9.20 user-visible symptom).
+	if i.Status == StatusStopped {
+		return nil
+	}
+
 	if err != nil {
 		i.Status = StatusError
 		return err
@@ -4867,8 +4876,26 @@ func (i *Instance) killInternal(sync bool) error {
 	// SIGKILL anything still alive.
 	i.reapTrackedMCPChildren()
 
-	// Kill tmux session first, but always continue to container cleanup.
+	// Issue #953: kill the tmux session AND publish StatusStopped
+	// atomically under i.mu so concurrent UpdateStatus() callers (most
+	// notably the TUI's backgroundStatusUpdate poller) cannot observe
+	// the intermediate state where the tmux pane is gone but Status
+	// still reflects the pre-kill running/idle value. The pre-existing
+	// !tmuxSession.Exists() branch in UpdateStatus then short-circuits
+	// on `Status == StatusStopped` (lines around 3221/3237) and leaves
+	// the status alone. Setting Status only AFTER the tmux Kill (and
+	// not before) also prevents the symmetric "Status is stopped, tmux
+	// is alive — must be a user-initiated restart, flip to Running"
+	// path at line 3245 from firing during the cleanup window.
+	//
+	// Holding the lock around the kill is safe: tmuxSession.Kill() is
+	// a single tmux command (the process-tree reaping is deferred to a
+	// goroutine via ensureProcessesDead). The KillAndWait variant can
+	// take up to 3s when escalating to SIGKILL — only short-lived CLI
+	// processes (session remove) take that path, and they have no
+	// concurrent TUI render contending for the lock.
 	var tmuxErr error
+	i.mu.Lock()
 	if i.tmuxSession != nil {
 		if sync {
 			tmuxErr = i.tmuxSession.KillAndWait()
@@ -4876,6 +4903,8 @@ func (i *Instance) killInternal(sync bool) error {
 			tmuxErr = i.tmuxSession.Kill()
 		}
 	}
+	i.Status = StatusStopped
+	i.mu.Unlock()
 
 	// Clean up sandbox container (only if name matches our prefix convention).
 	// Runs regardless of tmux kill result to avoid orphaned containers.
@@ -4906,7 +4935,9 @@ func (i *Instance) killInternal(sync bool) error {
 	// dir on an unclean shutdown is harmless, just wasteful.
 	i.CleanupWorkerScratchConfigDir()
 
-	i.Status = StatusStopped
+	// Issue #953: StatusStopped was already written under i.mu at the top
+	// of this function. Re-asserting it here without the lock would
+	// reintroduce the write/write data race with concurrent UpdateStatus.
 
 	if tmuxErr != nil {
 		return fmt.Errorf("failed to kill tmux session: %w", tmuxErr)

--- a/internal/session/issue953_stop_persists_test.go
+++ b/internal/session/issue953_stop_persists_test.go
@@ -1,0 +1,195 @@
+package session
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #953: After a user manually stops a session ("agent-deck session stop"
+// or pressing D in the TUI), the session is rendered as error (red ✕) instead
+// of stopped (gray ■).
+//
+// Root cause: killInternal() executes without holding i.mu, but writes
+// i.Status = StatusStopped only at the very end (after the tmux kill, MCP
+// child reaping, container cleanup, and scratch-dir cleanup). A concurrent
+// UpdateStatus() running in the TUI's backgroundStatusUpdate goroutine
+// acquires i.mu, observes tmuxSession.Exists() == false (the tmux session
+// is already dead) AND i.Status != StatusStopped (still the pre-kill value
+// like StatusRunning), and races to set i.Status = StatusError under its
+// lock. killInternal's later unlocked write of i.Status = StatusStopped is
+// not synchronized with that read, so the data race is real and the
+// observable error status can survive to the next save/render tick.
+//
+// The fix: take i.mu around the Status write at the end of killInternal so
+// the write is properly synchronized with any concurrent UpdateStatus.
+// Set the status as the very first thing under the lock — this also
+// guarantees that any UpdateStatus that runs while killInternal is mid-
+// cleanup sees StatusStopped (not the stale running value) and short-
+// circuits at the `if i.Status != StatusStopped { i.Status = StatusError }`
+// guard.
+
+// TestIssue953_KillSetsStatusStoppedAfterKill verifies the baseline
+// contract that Kill() leaves i.Status == StatusStopped. This is the
+// observable invariant a user clicking D in the TUI expects.
+func TestIssue953_KillSetsStatusStoppedAfterKill(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	inst := NewInstance("test-953-baseline", "/tmp")
+	inst.Tool = "shell"
+	inst.Command = "sleep 60"
+
+	require.NoError(t, inst.Start())
+	defer func() { _ = inst.Kill() }()
+
+	// Wait past the 1.5s grace period so UpdateStatus would do real work.
+	time.Sleep(2 * time.Second)
+	require.NoError(t, inst.UpdateStatus())
+
+	// Simulate the user-observed pre-kill state (the session is alive and
+	// running). Without this, the baseline status would be StatusIdle and
+	// the race window in killInternal would have nothing to flip to error.
+	inst.SetStatusThreadSafe(StatusRunning)
+
+	require.NoError(t, inst.Kill())
+
+	assert.Equal(t, StatusStopped, inst.GetStatusThreadSafe(),
+		"Kill() must leave Status == StatusStopped (issue #953)")
+}
+
+// TestIssue953_KillSurvivesConcurrentUpdateStatus is the RED regression
+// test for the race that produces the user-visible error icon. It hammers
+// UpdateStatus() in a tight loop from N background goroutines while the
+// foreground goroutine calls Kill(). After Kill returns AND the hammer
+// drains, the status must be StatusStopped — not StatusError.
+//
+// On main (without the fix) this test fails either via the -race
+// detector (unsynchronized write to i.Status from killInternal) or via
+// observing StatusError in the final assertion when the UpdateStatus
+// race wins the last write. With the fix in place (Status write moved
+// under i.mu inside killInternal), both failure modes are eliminated.
+func TestIssue953_KillSurvivesConcurrentUpdateStatus(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	inst := NewInstance("test-953-race", "/tmp")
+	inst.Tool = "shell"
+	inst.Command = "sleep 60"
+
+	require.NoError(t, inst.Start())
+	defer func() { _ = inst.Kill() }()
+
+	// Wait past the instance-level 1.5s grace period.
+	time.Sleep(2 * time.Second)
+	require.NoError(t, inst.UpdateStatus())
+
+	// Pre-condition for the race: the in-memory status must be NOT-stopped
+	// when killInternal begins. The TUI normally sees StatusRunning /
+	// StatusWaiting / StatusIdle here; StatusRunning is the worst case
+	// because it is the value most likely to be flipped to StatusError by
+	// UpdateStatus when the tmux session vanishes mid-Kill.
+	inst.SetStatusThreadSafe(StatusRunning)
+
+	// Drive UpdateStatus from N goroutines in a tight loop. We want lots
+	// of attempts to land between the tmux-kill and the Status-write
+	// inside killInternal so the race detector and the assertion both
+	// have plenty of opportunity to fire.
+	const hammerGoroutines = 8
+	stop := make(chan struct{})
+	var hammered atomic.Int64
+	var wg sync.WaitGroup
+	for n := 0; n < hammerGoroutines; n++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Clear the lastErrorCheck recency optimization so the
+				// hammer keeps doing real work for every iteration. Without
+				// this, UpdateStatus would short-circuit at the 30s
+				// errorRecheckInterval guard once the first call lands
+				// after the tmux session dies.
+				inst.ForceNextStatusCheck()
+				_ = inst.UpdateStatus()
+				hammered.Add(1)
+			}
+		}()
+	}
+
+	// Issue the manual stop while the hammer is running.
+	require.NoError(t, inst.Kill())
+
+	// Drain the hammer. After Kill returns, the canonical user-observable
+	// status is captured here. Subsequent UpdateStatus calls SHOULD see
+	// StatusStopped and short-circuit (line 3237's `if i.Status !=
+	// StatusStopped` guard), so even if the hammer keeps running for a
+	// few milliseconds after Kill the status must converge to
+	// StatusStopped.
+	close(stop)
+	wg.Wait()
+
+	t.Logf("UpdateStatus hammer iterations: %d", hammered.Load())
+
+	assert.Equal(t, StatusStopped, inst.GetStatusThreadSafe(),
+		"Status must be StatusStopped after Kill() even under concurrent UpdateStatus (issue #953)")
+}
+
+// TestIssue953_KillStatusPersistsAcrossSaveLoad is the integration arm of
+// the regression: it pins the end-to-end contract a user actually
+// observes between `agent-deck session stop` and the next CLI/TUI render.
+//
+//  1. Start a session.
+//  2. Pre-set StatusRunning to simulate the user-observed pre-kill state.
+//  3. Kill().
+//  4. Save to SQLite.
+//  5. Load from SQLite (fresh storage handle, mimicking a new process).
+//  6. RefreshInstancesForCLIStatus + UpdateStatus, same as `agent-deck
+//     status -v` and `agent-deck list --json` do.
+//  7. Assert the rendered status is StatusStopped.
+//
+// This test passes on main because no race is involved in this serial
+// path. It exists to lock down the persistence half of the bug so a
+// future "fix" that only papers over the in-memory race (e.g. by
+// reverting the StatusStopped assignment) is still caught.
+func TestIssue953_KillStatusPersistsAcrossSaveLoad(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	inst := NewInstance("test-953-persist", "/tmp")
+	inst.Tool = "shell"
+	inst.Command = "sleep 60"
+
+	require.NoError(t, inst.Start())
+	defer func() { _ = inst.Kill() }()
+
+	time.Sleep(2 * time.Second)
+	require.NoError(t, inst.UpdateStatus())
+	inst.SetStatusThreadSafe(StatusRunning)
+
+	require.NoError(t, inst.Kill())
+	require.Equal(t, StatusStopped, inst.GetStatusThreadSafe(),
+		"baseline: Kill must set StatusStopped")
+
+	s := newTestStorage(t)
+	require.NoError(t, s.SaveWithGroups([]*Instance{inst}, nil))
+
+	loaded, _, err := s.LoadWithGroups()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	assert.Equal(t, StatusStopped, loaded[0].Status,
+		"loaded Status must be StatusStopped (issue #953 persistence arm)")
+
+	// Mimic `agent-deck list --json` / `agent-deck status -v`: warm the
+	// CLI caches, then call UpdateStatus. The stopped session must NOT
+	// flip to StatusError.
+	RefreshInstancesForCLIStatus(loaded)
+	require.NoError(t, loaded[0].UpdateStatus())
+	assert.Equal(t, StatusStopped, loaded[0].Status,
+		"UpdateStatus after CLI refresh must preserve StatusStopped (issue #953)")
+}


### PR DESCRIPTION
## Summary

Closes #953. After `agent-deck session stop` or pressing `D` in the TUI, the session displayed as **error** (red ✕) instead of **stopped** (gray ■) in both the grouped session list and the top header. Credit @halfmu for the report.

## Repro

1. Start any session in the TUI (or a Claude session with hooks).
2. Press `D` (or run `agent-deck session stop <id>` from another shell).
3. Observe the session shows ✕ red on the next render tick instead of ■ gray. The bad state persists across `agent-deck list`, `agent-deck status -v`, and TUI re-render — it survives save/load.

## Root cause

`killInternal()` published `i.Status = StatusStopped` at the *end* of the function, **outside** `i.mu`, after MCP child reaping, sandbox container cleanup, and scratch-dir cleanup. The TUI's `backgroundStatusUpdate` poller, holding `i.mu`, landed inside `UpdateStatus` during the gap and:

1. Observed `!tmuxSession.Exists()` (tmux already dead) AND `i.Status != StatusStopped` (still pre-kill running/idle), so it hit the `i.Status = StatusError` branch at `internal/session/instance.go:3238` — the immediate user-visible flip.
2. Released `i.mu` around the slow `tmuxSession.GetStatus()` call (line `3343`). A concurrent `Kill` that published `StatusStopped` in that window was clobbered when `UpdateStatus` re-locked and wrote the cached tmux-derived status (`StatusRunning` / `StatusIdle` / etc.).
3. The "session exists again, must be user-initiated restart" auto-flip at line `3245` (`if i.Status == StatusStopped { i.Status = StatusRunning }`) tripped when `Status` had been set to `Stopped` early while tmux was still being torn down.

The trailing unlocked write of `i.Status = StatusStopped` at the end of `killInternal` was also a genuine **data race** — `go test -race` caught it as a write/write conflict with `UpdateStatus`'s locked writes.

## Fix

Two minimal changes in `internal/session/instance.go`:

1. **`killInternal`**: hold `i.mu` around the tmux teardown AND the `Status = StatusStopped` publication. Concurrent `UpdateStatus` callers now observe one of two coherent states — tmux alive with the pre-kill status, or tmux dead with `StatusStopped` — never the broken middle. The pre-existing `if i.Status != StatusStopped` guards (lines `3221` / `3237`) short-circuit correctly. Holding the lock around `tmuxSession.Kill()` is safe: it's a single tmux command (process-tree reaping is deferred to a goroutine via `ensureProcessesDead`).
2. **`UpdateStatus`**: defense-in-depth — after re-acquiring `i.mu` post-`GetStatus`, return immediately if `i.Status == StatusStopped`. A concurrent `Kill` that ran during our unlocked window has already published the user-initiated intent; don't clobber it.

## Test trace

`internal/session/issue953_stop_persists_test.go` adds three regression cases:

- `TestIssue953_KillSetsStatusStoppedAfterKill` — baseline single-shot Kill invariant.
- `TestIssue953_KillSurvivesConcurrentUpdateStatus` — 8-goroutine hammer of `UpdateStatus` racing against `Kill()`. **This is the RED test:** on `main` without the fix, `go test -race -count=1 -run TestIssue953` reports both a `DATA RACE` warning (write at `instance.go:4909` from `killInternal` vs locked write from `UpdateStatus:3358`) AND a final-state mismatch (`expected: stopped, actual: error` or `idle`).
- `TestIssue953_KillStatusPersistsAcrossSaveLoad` — serial save→load→`RefreshInstancesForCLIStatus`+`UpdateStatus` round-trip, pinning the persistence half of the contract.

```
RED on main (no fix):
  WARNING: DATA RACE
  Write at 0x… by goroutine 89:
    .killInternal()  instance.go:4909
  Previous write by goroutine 128:
    .UpdateStatus() instance.go:3358
  expected: "stopped"  actual: "error"
  --- FAIL

GREEN with fix (10 race-on iterations):
  go test -race -count=10 ./internal/session/ -run TestIssue953  ✓ all pass
```

## Don't break

Full repo `go test -race -count=1 ./...` green:

- `internal/session` (107s) — all `TestStop_*` / `TestRestart_*` / `TestStatus*` / `TestLifecycle*` / `Issue1040` / `SpawnAttempt` suites pass.
- `internal/ui` (30s) — `closeSession` / `renderSessionItem` unaffected.
- `internal/tmux` (22s) — `KillAndWait` + `ensure_pids_dead` unchanged.
- `internal/feedback`, `internal/watcher`, `internal/statedb` — untouched mandate suites still pass.
- `TestPersistence_*` (CLAUDE.md session-persistence mandate) — pass.

## Relationship to #1045

Orthogonal. #1045 added a per-instance spawn lock around `Start` / `Restart` / `StartWithMessage`; that path doesn't touch `killInternal` and the new lock-atomic kill block coexists cleanly. No file overlap beyond `instance.go` (same file, different functions). #1045's `Issue1040` / `SpawnAttempt` regression suite still passes under `-race`.

## Test plan

- [x] `go test -race -count=10 ./internal/session/ -run TestIssue953` — all green
- [x] `go test -race -count=1 ./...` — full repo green
- [x] Manual `git diff` review: 2 logical hunks in `instance.go`, 1 new test file. No drive-by refactors.
- [ ] CI green before merge (conductor merges)
- [ ] (post-merge) Spot-check on a real session: `agent-deck session stop` → list shows ■ gray, not ✕ red

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition where stopped session status could be incorrectly overwritten by concurrent operations, ensuring sessions remain properly stopped.

* **Tests**
  * Added regression tests to verify session stopping behavior is correctly maintained under concurrent updates and persistence scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->