### PR TITLE
chore(coderabbit): proper config for OSS Go repo (skip bots, drafts, docs, testdata)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,57 @@
+# CodeRabbit config — agent-deck (public OSS Go repo)
+# Docs: https://docs.coderabbit.ai/reference/configuration
+
+language: en
+
 reviews:
-  profile: chill
-  request_changes_workflow: false
+  profile: chill                    # less nitpicky, ship-friendly
+  request_changes_workflow: false   # never block merge with "Request Changes"
   high_level_summary: true
-  poem: false
+  poem: false                       # save tokens; the bunny is cute but eats budget
+  review_status: true
+  collapse_walkthrough: true
+
   auto_review:
     enabled: true
-    drafts: false
-language: en
+    drafts: false                   # don't review draft PRs (RFCs etc.)
+    base_branches:
+      - main
+    # Don't review trivial / generated PRs to save tokens + seat noise:
+    ignore_title_keywords:
+      - "[skip ci]"
+      - "[no-review]"
+      - "WIP"
+
+  # Don't review pure dependency bumps (Dependabot opens lots of these;
+  # govulncheck + golangci-lint already cover real risk):
+  path_filters:
+    - "!.github/dependabot.yml"
+    - "!**/*.md"                    # markdown-only churn (changelog/docs)
+    - "!CHANGELOG.md"
+    - "!**/testdata/**"
+
+  # Bots that open PRs should NOT trigger reviews or consume seats:
+  ignore_users:
+    - dependabot[bot]
+    - github-actions[bot]
+    - renovate[bot]
+
+  tools:
+    # Repo already runs these in CI; let CodeRabbit hook into their output:
+    golangci-lint:
+      enabled: true
+    gosec:
+      enabled: true
+    yamllint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: false                # noisy on docs-heavy repos
+
+chat:
+  auto_reply: true                  # respond to @coderabbitai mentions
+
+knowledge_base:
+  learnings:
+    scope: auto                     # learn this repo's patterns over time


### PR DESCRIPTION
## Why

The default `.coderabbit.yaml` (added in #1052) is minimal. This tunes it for our actual contribution flow:

- **Skip bot-authored PRs** (`dependabot[bot]`, `github-actions[bot]`, `renovate[bot]`) — these are already covered by govulncheck + golangci-lint in CI and consume CodeRabbit seats/tokens for no value.
- **Skip drafts** (RFCs, WIPs)
- **Skip markdown-only / CHANGELOG-only / testdata churn** — no review value
- **chill profile** — less nitpicky, ship-friendly for high-volume contribution
- **never request-changes** — don't block merges, only post comments
- **enable golangci-lint, gosec, yamllint, shellcheck** hooks
- **disable poem** — saves tokens

## Refs

- #1052 (security pipeline that added the default .coderabbit.yaml)

Separately requesting the **Open Source plan** via CodeRabbit support — once approved, the Pro Plus trial converts to free unlimited OSS plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized and clarified review configuration, moving language to top-level and normalizing review status and walkthrough collapse.
  * Expanded auto-review controls (base branch filters, title keywords) and added path filters to skip dependency updates, markdown-only edits, changelogs, and test data.
  * Added ignored bot users, toggled linters (enabled golangci-lint, gosec, yamllint, shellcheck; disabled markdownlint), enabled chat auto-replies, and set knowledge-base learning scope to auto.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1074?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->