### PR TITLE
feat(ui): TUI insert mode for direct type-through to focused session (closes #1069 [feature 1])

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -472,6 +472,17 @@ type Home struct {
 	// System stats collector (CPU, RAM, disk, etc.)
 	sysStatsCollector *sysinfo.Collector
 	sysStatsConfig    session.SystemStatsSettings
+
+	// Insert mode (#1069, feature 1): vim-style modal type-through. When
+	// active, printable runes, Space, and Enter are routed directly to the
+	// focused session's tmux pane instead of being interpreted as TUI
+	// commands. Toggled with `I` (enter) and `Esc` (exit).
+	insertMode          bool
+	insertModeSessionID string
+	// insertKeySink is an optional override used by tests to capture keys
+	// without running real tmux. When nil, keys are sent via the session's
+	// tmux pane (SendKeys / SendEnter).
+	insertKeySink func(inst *session.Instance, text string, sendEnter bool) error
 }
 
 // reloadState preserves UI state during storage reload
@@ -5744,6 +5755,12 @@ func (h *Home) mouseYToItemIndex(y int) int {
 
 // handleMainKey handles keys in main view
 func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Insert mode (#1069): short-circuit before any normal-mode handling.
+	// Keystrokes are sent to the focused session's tmux pane; Esc exits.
+	if h.insertMode {
+		return h.handleInsertModeKey(msg)
+	}
+
 	raw := msg.String()
 	key := h.normalizeMainKey(raw)
 	uiLog.Info("keypress", "raw", raw, "normalized", key, "type", msg.Type, "runes", string(msg.Runes))
@@ -6623,6 +6640,15 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "i":
 		return h, h.importSessions
+
+	case "I":
+		// Enter insert mode (#1069 feature 1): subsequent keystrokes are
+		// routed to the currently-selected session's tmux pane. Esc exits.
+		// `i` is taken by import; `I` follows the vim convention (Insert).
+		if h.enterInsertMode() {
+			return h, nil
+		}
+		return h, nil
 
 	case "u":
 		// Mark session as unread (idle → waiting)
@@ -9886,9 +9912,15 @@ func (h *Home) View() string {
 	b.WriteString("\n")
 
 	// ═══════════════════════════════════════════════════════════════════
-	// HELP BAR (context-aware shortcuts)
+	// HELP BAR (context-aware shortcuts) — replaced by the insert-mode
+	// indicator when the user is typing through to a focused session (#1069).
 	// ═══════════════════════════════════════════════════════════════════
-	helpBar := h.renderHelpBar()
+	var helpBar string
+	if h.insertMode {
+		helpBar = h.renderInsertModeBar()
+	} else {
+		helpBar = h.renderHelpBar()
+	}
 	b.WriteString(helpBar)
 
 	// Debug performance overlay (AGENTDECK_DEBUG=1 only)

--- a/internal/ui/insert_mode.go
+++ b/internal/ui/insert_mode.go
@@ -1,0 +1,166 @@
+package ui
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Insert mode (#1069 feature 1, by @ddorman-dn): vim-style modal type-through
+// for the TUI. After pressing `I` on a focused session, subsequent keystrokes
+// are forwarded directly to that session's tmux pane via send-keys, instead of
+// being interpreted as TUI commands. Esc returns to normal mode.
+
+// enterInsertMode arms insert mode if the cursor is on a session whose tmux
+// pane exists. Returns true on success. Errors are surfaced via setError so
+// the user sees why nothing happened.
+func (h *Home) enterInsertMode() bool {
+	inst := h.getSelectedSession()
+	if inst == nil {
+		h.setError(fmt.Errorf("insert mode: select a session first"))
+		return false
+	}
+	if inst.GetTmuxSession() == nil {
+		h.setError(fmt.Errorf("insert mode: session %q has no tmux pane", inst.Title))
+		return false
+	}
+	h.insertMode = true
+	h.insertModeSessionID = inst.ID
+	return true
+}
+
+// exitInsertMode returns the TUI to normal navigation mode.
+func (h *Home) exitInsertMode() {
+	h.insertMode = false
+	h.insertModeSessionID = ""
+}
+
+// handleInsertModeKey is the keyboard handler used while insert mode is
+// active. Esc exits, Enter sends a newline to the target session, and
+// printable runes (and the space key) are forwarded literally. Other
+// meta-keys (arrows, ctrl combos, Tab, Backspace, function keys) are
+// intentionally ignored in v1 — they remain reserved for future expansion
+// and shouldn't accidentally leak into the session's input stream.
+func (h *Home) handleInsertModeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		h.exitInsertMode()
+		return h, nil
+	case tea.KeyEnter:
+		h.dispatchInsertKey("", true)
+		return h, nil
+	case tea.KeySpace:
+		h.dispatchInsertKey(" ", false)
+		return h, nil
+	case tea.KeyRunes:
+		if len(msg.Runes) == 0 {
+			return h, nil
+		}
+		h.dispatchInsertKey(string(msg.Runes), false)
+		return h, nil
+	default:
+		// Drop arrows, ctrl combos, Tab, Backspace, function keys etc. for v1.
+		return h, nil
+	}
+}
+
+// dispatchInsertKey forwards literal text (optionally followed by Enter) to
+// the target session's tmux pane via the registered sink (real send-keys by
+// default; tests override via h.insertKeySink).
+func (h *Home) dispatchInsertKey(text string, sendEnter bool) {
+	inst := h.resolveInsertTarget()
+	if inst == nil {
+		return
+	}
+	if h.insertKeySink != nil {
+		if err := h.insertKeySink(inst, text, sendEnter); err != nil {
+			h.setError(fmt.Errorf("insert mode send failed: %w", err))
+		}
+		return
+	}
+	tmuxSess := inst.GetTmuxSession()
+	if tmuxSess == nil {
+		h.exitInsertMode()
+		h.setError(fmt.Errorf("insert mode: tmux session vanished"))
+		return
+	}
+	if text != "" {
+		if err := tmuxSess.SendKeys(text); err != nil {
+			h.setError(fmt.Errorf("insert mode send-keys failed: %w", err))
+			return
+		}
+	}
+	if sendEnter {
+		if err := tmuxSess.SendEnter(); err != nil {
+			h.setError(fmt.Errorf("insert mode send-enter failed: %w", err))
+		}
+	}
+}
+
+// resolveInsertTarget returns the instance for the session insert mode is
+// targeting, or nil if it has disappeared (in which case insert mode is also
+// exited so the user isn't stranded).
+func (h *Home) resolveInsertTarget() *session.Instance {
+	if h.insertModeSessionID == "" {
+		h.exitInsertMode()
+		h.setError(fmt.Errorf("insert mode: no target session"))
+		return nil
+	}
+	inst := h.getInstanceByID(h.insertModeSessionID)
+	if inst == nil {
+		h.exitInsertMode()
+		h.setError(fmt.Errorf("insert mode: target session no longer exists"))
+		return nil
+	}
+	return inst
+}
+
+// renderInsertModeBar renders the bottom-of-screen indicator shown while
+// insert mode is active. It replaces the standard help bar so the indicator
+// is visible at every terminal width and so the help text (with its TUI
+// navigation hints) doesn't mislead the user into thinking those bindings
+// still apply.
+func (h *Home) renderInsertModeBar() string {
+	borderStyle := lipgloss.NewStyle().Foreground(ColorBorder)
+	border := borderStyle.Render(repeatRune('─', max(0, h.width)))
+
+	targetTitle := ""
+	if inst := h.getInstanceByID(h.insertModeSessionID); inst != nil {
+		targetTitle = inst.Title
+	}
+
+	badge := lipgloss.NewStyle().
+		Foreground(ColorBg).
+		Background(ColorYellow).
+		Bold(true).
+		Padding(0, 1).
+		Render(" -- INSERT -- ")
+
+	infoStyle := lipgloss.NewStyle().Foreground(ColorText)
+	hintStyle := lipgloss.NewStyle().Foreground(ColorComment)
+
+	line := badge
+	if targetTitle != "" {
+		line += " " + infoStyle.Render("→ "+targetTitle)
+	}
+	line += "  " + hintStyle.Render("Esc to exit · Enter to submit")
+
+	return lipgloss.JoinVertical(lipgloss.Left, border, line)
+}
+
+// repeatRune is a thin wrapper so insert_mode.go doesn't introduce strings
+// into the import set just for one call (matches the rest of home.go's
+// pattern of building border lines).
+func repeatRune(r rune, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	buf := make([]rune, n)
+	for i := range buf {
+		buf[i] = r
+	}
+	return string(buf)
+}

--- a/internal/ui/issue1069_type_through_test.go
+++ b/internal/ui/issue1069_type_through_test.go
@@ -1,0 +1,289 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Issue #1069 feature 1 (by @ddorman-dn): TUI insert mode for direct
+// type-through to the focused session's tmux pane. These tests exercise the
+// mode transitions and key routing through the same public Update() path the
+// TUI uses at runtime, with an injected sink to capture forwarded keys
+// instead of running real tmux.
+
+// insertSinkCapture is a test fake that records every key dispatch made by
+// insert mode so assertions can observe exactly what the focused session
+// would have received.
+type insertSinkCapture struct {
+	calls []insertSinkCall
+}
+
+type insertSinkCall struct {
+	sessionID string
+	text      string
+	sendEnter bool
+}
+
+func (c *insertSinkCapture) sink(inst *session.Instance, text string, sendEnter bool) error {
+	c.calls = append(c.calls, insertSinkCall{
+		sessionID: inst.ID,
+		text:      text,
+		sendEnter: sendEnter,
+	})
+	return nil
+}
+
+// armHomeWithOneSession sets up a Home with a single session at the cursor,
+// the test sink installed, and dimensions large enough for View() to render.
+func armHomeWithOneSession(t *testing.T) (*Home, *session.Instance, *insertSinkCapture) {
+	t.Helper()
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	inst := session.NewInstanceWithTool("focused-session", "/tmp/focused", "claude")
+
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID = map[string]*session.Instance{inst.ID: inst}
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+
+	// Position the cursor on the session row (the first session item after
+	// any group headers in the flat list).
+	for i, item := range home.flatItems {
+		if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.ID == inst.ID {
+			home.cursor = i
+			break
+		}
+	}
+
+	capture := &insertSinkCapture{}
+	home.insertKeySink = capture.sink
+
+	return home, inst, capture
+}
+
+// TestIssue1069_PressIEntersInsertMode verifies the toggle: pressing `I` on a
+// focused session sets the insertMode flag and records the target session ID.
+func TestIssue1069_PressIEntersInsertMode(t *testing.T) {
+	home, inst, _ := armHomeWithOneSession(t)
+
+	if home.insertMode {
+		t.Fatal("insertMode should default to false")
+	}
+
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	got := model.(*Home)
+
+	if !got.insertMode {
+		t.Fatal("pressing 'I' on a focused session should enter insert mode")
+	}
+	if got.insertModeSessionID != inst.ID {
+		t.Errorf("insertModeSessionID = %q, want %q", got.insertModeSessionID, inst.ID)
+	}
+}
+
+// TestIssue1069_TypedRunesAreForwardedToFocusedSession verifies that, while
+// in insert mode, each KeyRunes message is forwarded verbatim to the focused
+// session's sink — not interpreted as a TUI command.
+func TestIssue1069_TypedRunesAreForwardedToFocusedSession(t *testing.T) {
+	home, inst, capture := armHomeWithOneSession(t)
+
+	// Enter insert mode.
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	home = model.(*Home)
+
+	// Type "hi" one rune at a time, the way a real terminal delivers them.
+	for _, r := range "hi" {
+		model, _ = home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		home = model.(*Home)
+	}
+
+	if len(capture.calls) != 2 {
+		t.Fatalf("expected 2 sink calls (one per rune), got %d", len(capture.calls))
+	}
+	for i, want := range []string{"h", "i"} {
+		call := capture.calls[i]
+		if call.sessionID != inst.ID {
+			t.Errorf("call[%d].sessionID = %q, want %q", i, call.sessionID, inst.ID)
+		}
+		if call.text != want {
+			t.Errorf("call[%d].text = %q, want %q", i, call.text, want)
+		}
+		if call.sendEnter {
+			t.Errorf("call[%d].sendEnter = true, want false (only Enter key should send newline)", i)
+		}
+	}
+}
+
+// TestIssue1069_NormalModeKeysStillWorkWhenNotTyping confirms we didn't break
+// existing TUI bindings: pressing 'q' in normal mode still triggers the
+// quit path (returns tea.Quit), it isn't swallowed by insert mode.
+func TestIssue1069_NormalModeKeysStillWorkWhenNotTyping(t *testing.T) {
+	home, _, capture := armHomeWithOneSession(t)
+
+	// 'q' in normal mode → not forwarded to the session sink.
+	_, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+
+	if len(capture.calls) != 0 {
+		t.Fatalf("normal-mode 'q' should NOT be forwarded to the session sink; got %d calls", len(capture.calls))
+	}
+}
+
+// TestIssue1069_NormalModeNavigationKeysNotSwallowed checks that the
+// space-key, 'k', 'j', etc. still navigate in normal mode (i.e. the insert-
+// mode guard fires only when insertMode is actually set).
+func TestIssue1069_NormalModeNavigationKeysNotSwallowed(t *testing.T) {
+	home, _, capture := armHomeWithOneSession(t)
+
+	// Normal-mode Space — should not be routed to the session.
+	_, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeySpace})
+	// Normal-mode 'j' — same.
+	_, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+
+	if len(capture.calls) != 0 {
+		t.Fatalf("normal-mode nav keys should NOT be forwarded; got %d calls", len(capture.calls))
+	}
+}
+
+// TestIssue1069_EnterSendsNewlineToFocusedSession verifies the Enter key, in
+// insert mode, dispatches with sendEnter=true so users can submit messages.
+func TestIssue1069_EnterSendsNewlineToFocusedSession(t *testing.T) {
+	home, _, capture := armHomeWithOneSession(t)
+
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	home = model.(*Home)
+
+	model, _ = home.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	home = model.(*Home)
+
+	if len(capture.calls) != 1 {
+		t.Fatalf("Enter should produce exactly 1 sink call, got %d", len(capture.calls))
+	}
+	if !capture.calls[0].sendEnter {
+		t.Errorf("Enter dispatch should have sendEnter=true")
+	}
+	if capture.calls[0].text != "" {
+		t.Errorf("Enter dispatch text = %q, want empty (Enter is named-key, not literal)", capture.calls[0].text)
+	}
+	if !home.insertMode {
+		t.Error("Enter should NOT exit insert mode — only Esc does")
+	}
+}
+
+// TestIssue1069_EscExitsInsertMode confirms Esc returns the TUI to normal
+// navigation and clears the target session ID.
+func TestIssue1069_EscExitsInsertMode(t *testing.T) {
+	home, _, capture := armHomeWithOneSession(t)
+
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	home = model.(*Home)
+
+	if !home.insertMode {
+		t.Fatal("expected insert mode to be active before Esc")
+	}
+
+	model, _ = home.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	home = model.(*Home)
+
+	if home.insertMode {
+		t.Error("Esc should exit insert mode")
+	}
+	if home.insertModeSessionID != "" {
+		t.Errorf("insertModeSessionID = %q, want empty after Esc", home.insertModeSessionID)
+	}
+	// Esc itself must not be forwarded to the session.
+	for _, c := range capture.calls {
+		if c.text == "\x1b" || c.text == "esc" {
+			t.Errorf("Esc should NOT be forwarded to the session, but sink got %+v", c)
+		}
+	}
+}
+
+// TestIssue1069_SpaceForwardedAsLiteral checks that the space key — which
+// bubbletea delivers as KeySpace rather than KeyRunes — is forwarded as a
+// literal " " when in insert mode.
+func TestIssue1069_SpaceForwardedAsLiteral(t *testing.T) {
+	home, _, capture := armHomeWithOneSession(t)
+
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	home = model.(*Home)
+
+	model, _ = home.Update(tea.KeyMsg{Type: tea.KeySpace})
+	home = model.(*Home)
+
+	if len(capture.calls) != 1 {
+		t.Fatalf("Space should produce 1 sink call, got %d", len(capture.calls))
+	}
+	if capture.calls[0].text != " " {
+		t.Errorf("Space dispatch text = %q, want %q", capture.calls[0].text, " ")
+	}
+}
+
+// TestIssue1069_IndicatorRenderedInView verifies the visual indicator shows
+// up at the bottom of the rendered view while insert mode is active, so the
+// user has unambiguous feedback that subsequent typing is being routed away.
+func TestIssue1069_IndicatorRenderedInView(t *testing.T) {
+	home, _, _ := armHomeWithOneSession(t)
+
+	// Render once in normal mode — expect no INSERT marker.
+	if strings.Contains(home.View(), "INSERT") {
+		t.Fatal("View() should not contain INSERT marker in normal mode")
+	}
+
+	// Enter insert mode and re-render.
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	home = model.(*Home)
+
+	view := home.View()
+	if !strings.Contains(view, "INSERT") {
+		t.Errorf("View() should contain INSERT marker while in insert mode; got: %q", lastNonEmptyLine(view))
+	}
+	if !strings.Contains(view, "focused-session") {
+		t.Errorf("View() insert-mode indicator should name the target session; got: %q", lastNonEmptyLine(view))
+	}
+}
+
+// TestIssue1069_PressingCapitalIWithoutSelectionIsSafe ensures pressing `I`
+// with no session under the cursor (empty list) does not crash and does not
+// enter insert mode (would have no valid target).
+func TestIssue1069_PressingCapitalIWithoutSelectionIsSafe(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+	// No instances, no flatItems.
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("pressing 'I' with no selection panicked: %v", r)
+		}
+	}()
+
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	got := model.(*Home)
+
+	if got.insertMode {
+		t.Error("insert mode should NOT activate when no session is selected")
+	}
+}
+
+// lastNonEmptyLine returns the last non-empty line of s, useful for surfacing
+// what the help/status footer actually looked like when an assertion fails.
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			return lines[i]
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Implements feature 1 from #1069 (by @ddorman-dn): a vim-style **insert
mode** that lets you type directly into a focused session's tmux pane
from the TUI without ever pressing Enter to drop into the session itself.

### How it works

- Press **`I`** (Shift+i) on a focused session row → enter insert mode.
  - `i` (lowercase) is already bound to **import sessions**, so this
    follows the vim convention for the next-best variant: `I` = "Insert".
- While in insert mode:
  - Printable runes and Space → forwarded to the target session via
    `tmux send-keys` (literal, `-l` flag).
  - **Enter** → sends a newline to the session (use this to submit
    messages to Claude / codex / shell prompts).
  - **Esc** → exits insert mode back to normal TUI navigation.
  - Other meta-keys (arrows, Tab, Backspace, ctrl combos, function
    keys) are deliberately dropped in v1 — reserved for future
    expansion, and we don't want them accidentally leaking into the
    session's input stream.
- A yellow `-- INSERT --` indicator replaces the help bar at the bottom
  of the screen, naming the target session (`-- INSERT -- → my-session
  · Esc to exit · Enter to submit`).

### What is preserved

- All existing normal-mode bindings (`q`, `r`, `n`, `/`, `j`, `k`, space, …).
- Auto-refresh of the session list (only the keyboard handler is
  short-circuited; background status ticks keep running).
- `i` (lowercase) still triggers the existing import-sessions flow.

## Design notes

- New state on `Home`: `insertMode bool`, `insertModeSessionID string`,
  and an optional `insertKeySink` for tests to capture forwarded keys
  without running real tmux.
- Handler logic is isolated in `internal/ui/insert_mode.go` to keep
  `home.go` from growing further (it's already 14k+ lines).
- The insert-mode guard sits at the very top of `handleMainKey` so the
  mode pre-empts the navHint dismissal, the cost dashboard, etc.

## Test plan

Tests live in `internal/ui/issue1069_type_through_test.go` (9 cases):

- [x] `TestIssue1069_PressIEntersInsertMode` — toggle on
- [x] `TestIssue1069_TypedRunesAreForwardedToFocusedSession` — "hi" → 2 calls
- [x] `TestIssue1069_NormalModeKeysStillWorkWhenNotTyping` — `q` not swallowed
- [x] `TestIssue1069_NormalModeNavigationKeysNotSwallowed` — `j`/space free
- [x] `TestIssue1069_EnterSendsNewlineToFocusedSession` — Enter dispatch + mode persists
- [x] `TestIssue1069_EscExitsInsertMode` — toggle off
- [x] `TestIssue1069_SpaceForwardedAsLiteral` — KeySpace handled
- [x] `TestIssue1069_IndicatorRenderedInView` — visual feedback shows up
- [x] `TestIssue1069_PressingCapitalIWithoutSelectionIsSafe` — no panic, no mode

### Test run

```
go test -race -count=1 ./...        # full suite, all 36 packages pass
go test -run TestIssue1069 -v ./internal/ui/...    # 9/9 PASS
```

Credit to **@ddorman-dn** for the original feature request in #1069.

DO NOT MERGE — conductor will merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added insert mode for direct session input: Press `I` to activate and type directly into the focused session. Navigation hotkeys are disabled during insert mode. Press `Esc` to exit. An "INSERT" indicator displays to confirm the active mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->