### PR TITLE
feat(ui): Shift+Enter opens session in new iTerm window (macOS, closes #1069 [feature 2])

### DIFF
--- a/internal/terminal/launcher.go
+++ b/internal/terminal/launcher.go
@@ -1,0 +1,70 @@
+// Package terminal provides a thin abstraction for spawning a new terminal
+// window that attaches to an existing tmux session.
+//
+// This is used by the TUI's Shift+Enter binding to "pop out" an agent-deck
+// session into its own native terminal window (e.g. a fresh iTerm2 window on
+// macOS), leaving agent-deck running undisturbed in the original window.
+//
+// The cross-platform surface is intentionally tiny: callers pass the
+// destination tmux session name (and optional `-L <socket>` selector) plus a
+// hint at which terminal program they would like, and the platform-specific
+// implementation does the rest. When a platform has no implementation, the
+// stub returns ErrUnsupported so callers can show a friendly fallback.
+package terminal
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrUnsupported is returned by OpenSessionInNewWindow on platforms that have
+// no native implementation yet. Callers should surface a non-fatal message
+// rather than treating this as an error condition.
+var ErrUnsupported = errors.New("terminal: opening a new window is not yet supported on this platform")
+
+// AttachRequest describes the tmux session a new terminal window should
+// attach to once spawned.
+//
+// Name is required. SocketName may be empty (meaning the default tmux
+// server), matching the semantics of tmux.Session.SocketName.
+type AttachRequest struct {
+	// Name is the tmux session name (the `-t` argument of `tmux attach`).
+	Name string
+
+	// SocketName is the optional `-L <socket>` selector. Empty means the
+	// default server.
+	SocketName string
+
+	// Terminal is an optional hint for which native terminal to use
+	// (e.g. "iterm2"). Empty means "use the platform default".
+	Terminal string
+}
+
+// BuildAttachCommand returns the shell command string that, when executed
+// inside a fresh terminal window, attaches to the requested tmux session.
+//
+// It is exported (and pure) so platform implementations and tests can share
+// the exact same string-building logic without depending on os/exec.
+func BuildAttachCommand(req AttachRequest) string {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("tmux")
+	if s := strings.TrimSpace(req.SocketName); s != "" {
+		b.WriteString(" -L ")
+		b.WriteString(shellQuote(s))
+	}
+	b.WriteString(" attach -t ")
+	b.WriteString(shellQuote(name))
+	return b.String()
+}
+
+// shellQuote single-quotes s for safe use in a /bin/sh command. It is
+// intentionally simple: tmux session names are sanitized upstream (see
+// internal/tmux.sanitizeName) so the input is already alphanumeric-ish, but
+// we still quote defensively in case future names allow spaces.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/terminal/launcher_darwin.go
+++ b/internal/terminal/launcher_darwin.go
@@ -1,0 +1,44 @@
+//go:build darwin
+
+package terminal
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// OpenSessionInNewWindow opens a new iTerm2 window and types the tmux attach
+// command into its first session. On macOS this requires that iTerm2 is
+// installed; if osascript reports it cannot find the application we surface
+// that error to the caller so the TUI can fall back gracefully.
+//
+// The command is built via BuildAttachCommand so it stays in lockstep with
+// the cross-platform tests.
+func OpenSessionInNewWindow(req AttachRequest) error {
+	cmd := BuildAttachCommand(req)
+	if cmd == "" {
+		return fmt.Errorf("terminal: empty tmux session name")
+	}
+	script := buildITerm2AppleScript(cmd)
+	return exec.Command("osascript", "-e", script).Run()
+}
+
+// buildITerm2AppleScript returns the AppleScript that spawns a new iTerm2
+// window with the user's default profile and runs attachCmd inside it.
+//
+// We keep this pure and exported-to-tests so the script can be exercised
+// without invoking osascript.
+func buildITerm2AppleScript(attachCmd string) string {
+	// AppleScript string literals are double-quoted; escape inner quotes and
+	// backslashes so a tmux session name containing them cannot break out.
+	escaped := strings.ReplaceAll(attachCmd, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return fmt.Sprintf(`tell application "iTerm2"
+	activate
+	set newWindow to (create window with default profile)
+	tell current session of newWindow
+		write text "%s"
+	end tell
+end tell`, escaped)
+}

--- a/internal/terminal/launcher_darwin_test.go
+++ b/internal/terminal/launcher_darwin_test.go
@@ -1,0 +1,38 @@
+//go:build darwin
+
+package terminal
+
+import (
+	"strings"
+	"testing"
+)
+
+// On darwin, buildITerm2AppleScript should embed the tmux attach command
+// inside an AppleScript that targets iTerm2's default profile. We verify the
+// script shape without actually invoking osascript.
+func TestBuildITerm2AppleScript_EmbedsAttachCommand(t *testing.T) {
+	cmd := BuildAttachCommand(AttachRequest{Name: "myproj", SocketName: "agentdeck"})
+	script := buildITerm2AppleScript(cmd)
+
+	for _, want := range []string{
+		`tell application "iTerm2"`,
+		`create window with default profile`,
+		`tmux -L 'agentdeck' attach -t 'myproj'`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("AppleScript missing %q\nfull script:\n%s", want, script)
+		}
+	}
+}
+
+func TestBuildITerm2AppleScript_EscapesDoubleQuotes(t *testing.T) {
+	// Defensive: if a tmux name ever contained " or \, the AppleScript
+	// must escape it so the surrounding double-quoted literal stays valid.
+	script := buildITerm2AppleScript(`echo "hi" \ bye`)
+	if strings.Contains(script, `"hi"`) {
+		t.Fatalf("double quotes inside command leaked into AppleScript literal:\n%s", script)
+	}
+	if !strings.Contains(script, `\"hi\"`) {
+		t.Fatalf("expected escaped quotes \\\"hi\\\" in script:\n%s", script)
+	}
+}

--- a/internal/terminal/launcher_other.go
+++ b/internal/terminal/launcher_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package terminal
+
+// OpenSessionInNewWindow is a no-op on non-macOS platforms. It returns
+// ErrUnsupported so the TUI can render a friendly "not yet supported"
+// message instead of treating the case as a hard failure. A future
+// implementation for Linux (`gnome-terminal --`, `kitty`, ...) or Windows
+// (`wt.exe new-tab`) can replace this stub without changing call sites.
+func OpenSessionInNewWindow(_ AttachRequest) error {
+	return ErrUnsupported
+}

--- a/internal/terminal/launcher_other_test.go
+++ b/internal/terminal/launcher_other_test.go
@@ -1,0 +1,18 @@
+//go:build !darwin
+
+package terminal
+
+import (
+	"errors"
+	"testing"
+)
+
+// On non-darwin platforms OpenSessionInNewWindow must surface ErrUnsupported
+// (not panic, not silently succeed) so the TUI can render a graceful fallback
+// message instead of pretending it spawned a window.
+func TestOpenSessionInNewWindow_NotSupportedOffDarwin(t *testing.T) {
+	err := OpenSessionInNewWindow(AttachRequest{Name: "anything"})
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("expected ErrUnsupported, got %v", err)
+	}
+}

--- a/internal/terminal/launcher_test.go
+++ b/internal/terminal/launcher_test.go
@@ -1,0 +1,49 @@
+package terminal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildAttachCommand_NameOnly(t *testing.T) {
+	got := BuildAttachCommand(AttachRequest{Name: "myproj"})
+	want := "tmux attach -t 'myproj'"
+	if got != want {
+		t.Fatalf("BuildAttachCommand mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestBuildAttachCommand_WithSocket(t *testing.T) {
+	got := BuildAttachCommand(AttachRequest{Name: "myproj", SocketName: "agentdeck"})
+	want := "tmux -L 'agentdeck' attach -t 'myproj'"
+	if got != want {
+		t.Fatalf("BuildAttachCommand mismatch:\n got=%q\nwant=%q", got, want)
+	}
+}
+
+func TestBuildAttachCommand_EmptyNameReturnsEmpty(t *testing.T) {
+	if got := BuildAttachCommand(AttachRequest{}); got != "" {
+		t.Fatalf("expected empty string for empty name, got %q", got)
+	}
+	if got := BuildAttachCommand(AttachRequest{Name: "   "}); got != "" {
+		t.Fatalf("expected empty string for whitespace name, got %q", got)
+	}
+}
+
+func TestBuildAttachCommand_QuotingProtectsSingleQuotes(t *testing.T) {
+	// Defensive: tmux names are sanitized upstream, but if a single quote
+	// ever leaked through, the resulting shell command must still be safe.
+	got := BuildAttachCommand(AttachRequest{Name: "weird'name"})
+	if !strings.HasPrefix(got, "tmux attach -t '") {
+		t.Fatalf("prefix wrong: %q", got)
+	}
+	if !strings.Contains(got, `'\''`) {
+		t.Fatalf("expected escaped single quote in %q", got)
+	}
+}
+
+func TestShellQuote_NoSpecials(t *testing.T) {
+	if got := shellQuote("plain"); got != "'plain'" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -35,6 +35,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/asheshgoplani/agent-deck/internal/sysinfo"
+	"github.com/asheshgoplani/agent-deck/internal/terminal"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 	"github.com/asheshgoplani/agent-deck/internal/update"
 	"github.com/asheshgoplani/agent-deck/internal/watcher"
@@ -5944,6 +5945,27 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "alt+/": // In-group filter search
 		h.search.SetSize(h.width, h.height)
 		h.openInGroupSearch()
+		return h, nil
+
+	case "shift+enter":
+		// Open the focused session in a new native terminal window (e.g. a
+		// fresh iTerm2 window on macOS), leaving agent-deck running here.
+		// Issue #1069 feature 2, credit @ddorman-dn.
+		if h.cursor < len(h.flatItems) {
+			item := h.flatItems[h.cursor]
+			if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.Exists() {
+				tmuxSess := item.Session.GetTmuxSession()
+				if tmuxSess != nil {
+					err := terminal.OpenSessionInNewWindow(terminal.AttachRequest{
+						Name:       tmuxSess.Name,
+						SocketName: tmuxSess.SocketName,
+					})
+					if err != nil {
+						h.setError(fmt.Errorf("open in new window: %w", err))
+					}
+				}
+			}
+		}
 		return h, nil
 
 	case "enter":


### PR DESCRIPTION
## Summary

Implements feature 2 from #1069 (credit **@ddorman-dn**): pressing **Shift+Enter** on a focused session in the agent-deck TUI opens that session in a new native terminal window, leaving agent-deck running in the original window.

- macOS MVP: spawns a fresh iTerm2 window via osascript and runs `tmux [-L <socket>] attach -t <name>` in it.
- Linux/Windows: no native implementation yet — the stub returns `ErrUnsupported` and the TUI surfaces a friendly error message instead of crashing or silently no-op'ing. Future Linux/Windows backends drop into the same interface.

## Design

A new `internal/terminal` package isolates the platform surface:

| File | Build tag | Role |
|---|---|---|
| `launcher.go` | (none) | `AttachRequest`, `BuildAttachCommand`, `ErrUnsupported` — pure, testable on every platform |
| `launcher_darwin.go` | `darwin` | iTerm2 AppleScript implementation |
| `launcher_other.go` | `!darwin` | Returns `ErrUnsupported` |

The TUI side is one new `case "shift+enter"` adjacent to the existing `"enter"` handler in `internal/ui/home.go` — guarded by the same "focused item is a live session" preconditions. The `tmux.Session.Name` + `SocketName` fields are passed straight through, so per-group socket isolation (the v1.7.50 path) keeps working without any extra plumbing.

AppleScript escapes both backslashes and double-quotes defensively, and shell-arg construction uses single-quote wrapping with `'\''` escaping. tmux session names are already sanitized upstream by `internal/tmux.sanitizeName`, so this is belt-and-suspenders.

## Don't break

- ✅ Plain `Enter` still attaches in-place (handler is unchanged, shift+enter is a separate case above it).
- ✅ Other modifier+Enter combos are untouched.
- ✅ Cross-compile: `internal/terminal` builds clean on `GOOS=linux`, `GOOS=darwin`, and `GOOS=windows`. (The wider repo's pre-existing `GOOS=windows` errors in `internal/sysinfo`, `internal/mcppool`, and `internal/tmux` exist on `main` and are not introduced here.)

## Test trace

```
$ go test -race -count=1 ./internal/terminal/...
ok  	github.com/asheshgoplani/agent-deck/internal/terminal	1.026s

$ go test -race -count=1 -timeout 120s -run TestPersistence_ ./internal/session/...
ok  	github.com/asheshgoplani/agent-deck/internal/session	5.607s

$ go test -race -count=1 ./...
ok  	github.com/asheshgoplani/agent-deck/cmd/agent-deck	74.334s
ok  	github.com/asheshgoplani/agent-deck/internal/session	111.298s
ok  	github.com/asheshgoplani/agent-deck/internal/terminal	1.026s
ok  	github.com/asheshgoplani/agent-deck/internal/ui	30.783s
... (all packages green)

$ GOOS=darwin go vet ./internal/terminal/...
$ GOOS=windows go vet ./internal/terminal/...
(clean)
```

Tests added:
- `launcher_test.go` — `BuildAttachCommand` shape, empty-name guard, single-quote escaping (linux+darwin+windows).
- `launcher_darwin_test.go` — AppleScript embeds the attach command and escapes embedded double-quotes (darwin only).
- `launcher_other_test.go` — non-darwin path returns `ErrUnsupported` (linux+windows).

## Platform scope

| Platform | Status |
|---|---|
| macOS (iTerm2) | ✅ Implemented |
| Linux | ⏳ Stub — `ErrUnsupported`; future PR can add `gnome-terminal --`, `kitty --`, etc. |
| Windows | ⏳ Stub — `ErrUnsupported`; future PR can add `wt.exe new-tab`. |

Closes #1069 [feature 2].

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Shift+Enter keyboard shortcut to open the currently selected tmux session in a new native terminal window
  * Implemented macOS support with graceful "not yet supported" messaging for other platforms

* **Tests**
  * Added comprehensive unit tests for terminal attachment functionality and platform-specific implementations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1077?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->