### PR TITLE
fix(test): drop dead assignment caught by strict golangci-lint (hotfix main)

### DIFF
--- a/internal/ui/issue1069_type_through_test.go
+++ b/internal/ui/issue1069_type_through_test.go
@@ -218,7 +218,7 @@ func TestIssue1069_SpaceForwardedAsLiteral(t *testing.T) {
 	home = model.(*Home)
 
 	model, _ = home.Update(tea.KeyMsg{Type: tea.KeySpace})
-	home = model.(*Home)
+	_ = model.(*Home) // assert type, value unused for remaining assertions
 
 	if len(capture.calls) != 1 {
 		t.Fatalf("Space should produce 1 sink call, got %d", len(capture.calls))


### PR DESCRIPTION
## Why

Main is **failing golangci-lint** after #1078 flipped to strict mode. One SA4006 finding from #1076's new test file (`internal/ui/issue1069_type_through_test.go:221`):

```
internal/ui/issue1069_type_through_test.go:221:2: SA4006: this value of home is never used (staticcheck)
```

## Fix

Change `home = model.(*Home)` (unused assignment) to `_ = model.(*Home)` — keeps the type assertion as documentation, drops the dead bind.

## Refs

- #1076 (introduced the test)
- #1078 (flipped lint to strict, exposed the finding)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and structure for issue handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1079?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->