### PR TITLE
feat: add Jujutsu (jj) support (minimal port of @jennings #754)

### DIFF
--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 // handleLaunch combines add + start + optional send into a single command.
@@ -184,18 +185,15 @@ func handleLaunch(profile string, args []string) {
 	}
 
 	// Handle worktree creation
-	var worktreePath, worktreeRepoRoot string
+	var worktreePath, worktreeRepoRoot, worktreeType string
 	if wtBranch != "" {
-		if !git.IsGitRepoOrBareProjectRoot(path) {
-			out.Error(fmt.Sprintf("%s is not a git repository", path), ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
-
-		repoRoot, err := git.GetWorktreeBaseRoot(path)
+		backend, err := detectAndCreateBackend(path)
 		if err != nil {
-			out.Error(fmt.Sprintf("failed to get repo root: %v", err), ErrCodeInvalidOperation)
+			out.Error(fmt.Sprintf("%v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
+		worktreeType = string(backend.Type())
+		repoRoot := backend.RepoDir()
 
 		// Apply configured branch prefix before validation/existence checks
 		wtSettings := session.GetWorktreeSettings()
@@ -206,7 +204,7 @@ func handleLaunch(profile string, args []string) {
 			os.Exit(1)
 		}
 
-		branchExists := git.BranchExists(repoRoot, wtBranch)
+		branchExists := backend.BranchExists(wtBranch)
 		if createNewBranch && branchExists {
 			out.Error(fmt.Sprintf("branch '%s' already exists (remove -b flag to use existing branch)", wtBranch), ErrCodeInvalidOperation)
 			os.Exit(1)
@@ -217,16 +215,15 @@ func handleLaunch(profile string, args []string) {
 			location = *worktreeLocation
 		}
 
-		worktreePath = git.WorktreePath(git.WorktreePathOptions{
+		worktreePath = backend.WorktreePath(vcs.WorktreePathOptions{
 			Branch:    wtBranch,
 			Location:  location,
-			RepoDir:   repoRoot,
 			SessionID: git.GeneratePathID(),
 			Template:  wtSettings.Template(),
 		})
 
 		// Check for an existing worktree for this branch before creating a new one
-		if existingPath, err := git.GetWorktreeForBranch(repoRoot, wtBranch); err == nil && existingPath != "" {
+		if existingPath, err := backend.GetWorktreeForBranch(wtBranch); err == nil && existingPath != "" {
 			fmt.Fprintf(os.Stderr, "Reusing existing worktree at %s for branch %s\n", existingPath, wtBranch)
 			worktreePath = existingPath
 		} else {
@@ -240,7 +237,7 @@ func handleLaunch(profile string, args []string) {
 				os.Exit(1)
 			}
 
-			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+			setupErr, err := createWorktreeWithSetup(backend, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
 			if err != nil {
 				out.Error(fmt.Sprintf("failed to create worktree: %v", err), ErrCodeInvalidOperation)
 				os.Exit(1)
@@ -396,6 +393,7 @@ func handleLaunch(profile string, args []string) {
 		newInstance.WorktreePath = worktreePath
 		newInstance.WorktreeRepoRoot = worktreeRepoRoot
 		newInstance.WorktreeBranch = wtBranch
+		newInstance.WorktreeType = worktreeType
 	}
 
 	if *resumeSession != "" {

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 	"github.com/asheshgoplani/agent-deck/internal/ui"
 	"github.com/asheshgoplani/agent-deck/internal/update"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
@@ -1343,20 +1344,15 @@ func handleAdd(profile string, args []string) {
 	}
 
 	// Handle worktree creation
-	var worktreePath, worktreeRepoRoot string
+	var worktreePath, worktreeRepoRoot, worktreeType string
 	if wtBranch != "" {
-		// Validate path is a git repo (or a bare-repo project root with nested .bare/)
-		if !git.IsGitRepoOrBareProjectRoot(path) {
-			fmt.Fprintf(os.Stderr, "Error: %s is not a git repository\n", path)
-			os.Exit(1)
-		}
-
-		// Get repo root (resolve through worktrees to prevent nesting)
-		repoRoot, err := git.GetWorktreeBaseRoot(path)
+		backend, err := detectAndCreateBackend(path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: failed to get repo root: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
+		worktreeType = string(backend.Type())
+		repoRoot := backend.RepoDir()
 
 		// Determine worktree settings and apply configured branch prefix
 		// (e.g., "$USER/" -> "dani.fernandez/") before validation/existence checks
@@ -1370,7 +1366,7 @@ func handleAdd(profile string, args []string) {
 		}
 
 		// Check -b flag logic: if -b is passed, branch must NOT exist (user wants new branch)
-		branchExists := git.BranchExists(repoRoot, wtBranch)
+		branchExists := backend.BranchExists(wtBranch)
 		if createNewBranch && branchExists {
 			fmt.Fprintf(
 				os.Stderr,
@@ -1386,16 +1382,15 @@ func handleAdd(profile string, args []string) {
 		}
 
 		// Generate worktree path
-		worktreePath = git.WorktreePath(git.WorktreePathOptions{
+		worktreePath = backend.WorktreePath(vcs.WorktreePathOptions{
 			Branch:    wtBranch,
 			Location:  location,
-			RepoDir:   repoRoot,
 			SessionID: git.GeneratePathID(),
 			Template:  wtSettings.Template(),
 		})
 
 		// Check for an existing worktree for this branch before creating a new one
-		if existingPath, err := git.GetWorktreeForBranch(repoRoot, wtBranch); err == nil && existingPath != "" {
+		if existingPath, err := backend.GetWorktreeForBranch(wtBranch); err == nil && existingPath != "" {
 			fmt.Fprintf(os.Stderr, "Reusing existing worktree at %s for branch %s\n", existingPath, wtBranch)
 			worktreePath = existingPath
 		} else {
@@ -1407,7 +1402,7 @@ func handleAdd(profile string, args []string) {
 
 			// Create worktree atomically (git handles existence checks).
 			// This avoids a TOCTOU race from separate check-then-create steps.
-			setupErr, err := git.CreateWorktreeWithSetup(repoRoot, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+			setupErr, err := createWorktreeWithSetup(backend, worktreePath, wtBranch, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
 			if err != nil {
 				if isWorktreeAlreadyExistsError(err) {
 					fmt.Fprintf(os.Stderr, "Error: worktree already exists at %s\n", worktreePath)
@@ -1550,6 +1545,7 @@ func handleAdd(profile string, args []string) {
 		newInstance.WorktreePath = worktreePath
 		newInstance.WorktreeRepoRoot = worktreeRepoRoot
 		newInstance.WorktreeBranch = wtBranch
+		newInstance.WorktreeType = worktreeType
 	}
 
 	// Apply sandbox config if requested.
@@ -2036,12 +2032,16 @@ func handleRemove(profile string, args []string) {
 
 	// Clean up worktree directory if this is a worktree session
 	if inst.IsWorktree() {
-		if err := git.RemoveWorktree(inst.WorktreeRepoRoot, inst.WorktreePath, false); err != nil {
-			if !*jsonOutput {
-				fmt.Printf("Warning: failed to remove worktree: %v\n", err)
+		if backend, err := detectAndCreateBackend(inst.WorktreeRepoRoot); err == nil {
+			if err := backend.RemoveWorktree(inst.WorktreePath, false); err != nil {
+				if !*jsonOutput {
+					fmt.Printf("Warning: failed to remove worktree: %v\n", err)
+				}
 			}
+			_ = backend.PruneWorktrees()
+		} else if !*jsonOutput {
+			fmt.Printf("Warning: failed to initialize VCS for worktree cleanup: %v\n", err)
 		}
-		_ = git.PruneWorktrees(inst.WorktreeRepoRoot)
 	}
 
 	// Rebuild instance list without the deleted session and persist groups.

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 	"github.com/asheshgoplani/agent-deck/internal/ui"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 // handleSession dispatches session subcommands
@@ -707,36 +708,34 @@ func handleSessionFork(profile string, args []string) {
 
 	// Handle worktree creation
 	var opts *session.ClaudeOptions
+	var worktreeType string
 	if wtBranch != "" {
-		if !git.IsGitRepoOrBareProjectRoot(inst.ProjectPath) {
-			out.Error("session path is not a git repository", ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
-		repoRoot, err := git.GetWorktreeBaseRoot(inst.ProjectPath)
+		backend, err := detectAndCreateBackend(inst.ProjectPath)
 		if err != nil {
-			out.Error(fmt.Sprintf("failed to get repo root: %v", err), ErrCodeInvalidOperation)
+			out.Error(fmt.Sprintf("%v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
+		worktreeType = string(backend.Type())
+		repoRoot := backend.RepoDir()
 
 		// Apply configured branch prefix before validation/existence checks
 		wtSettings := session.GetWorktreeSettings()
 		wtBranch = wtSettings.ApplyBranchPrefix(wtBranch)
 
-		if !createNewBranch && !git.BranchExists(repoRoot, wtBranch) {
+		if !createNewBranch && !backend.BranchExists(wtBranch) {
 			out.Error(fmt.Sprintf("branch '%s' does not exist (use -b to create)", wtBranch), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
 
-		worktreePath := git.WorktreePath(git.WorktreePathOptions{
+		worktreePath := backend.WorktreePath(vcs.WorktreePathOptions{
 			Branch:    wtBranch,
 			Location:  wtSettings.DefaultLocation,
-			RepoDir:   repoRoot,
 			SessionID: git.GeneratePathID(),
 			Template:  wtSettings.Template(),
 		})
 
 		// Check for an existing worktree for this branch before creating a new one
-		if existingPath, err := git.GetWorktreeForBranch(repoRoot, wtBranch); err == nil && existingPath != "" {
+		if existingPath, err := backend.GetWorktreeForBranch(wtBranch); err == nil && existingPath != "" {
 			fmt.Fprintf(os.Stderr, "Reusing existing worktree at %s for branch %s\n", existingPath, wtBranch)
 			worktreePath = existingPath
 		} else {
@@ -750,16 +749,28 @@ func handleSessionFork(profile string, args []string) {
 				os.Exit(1)
 			}
 
-			setupErr, err := git.CreateWorktreeWithStateAndSetup(
-				repoRoot, worktreePath, wtBranch,
-				git.WorktreeStateOptions{WithState: wantState, WithIgnored: *withStateGitignored},
-				os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
-			if err != nil {
-				out.Error(fmt.Sprintf("worktree creation failed: %v", err), ErrCodeInvalidOperation)
-				os.Exit(1)
-			}
-			if setupErr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: worktree setup script failed: %v\n", setupErr)
+			// --with-state* is git-specific (uses index/stash). Reject for jujutsu.
+			if backend.Type() == vcs.TypeGit {
+				setupErr, err := git.CreateWorktreeWithStateAndSetup(
+					repoRoot, worktreePath, wtBranch,
+					git.WorktreeStateOptions{WithState: wantState, WithIgnored: *withStateGitignored},
+					os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+				if err != nil {
+					out.Error(fmt.Sprintf("worktree creation failed: %v", err), ErrCodeInvalidOperation)
+					os.Exit(1)
+				}
+				if setupErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: worktree setup script failed: %v\n", setupErr)
+				}
+			} else {
+				if wantState {
+					out.Error("--with-state is only supported for git repositories", ErrCodeInvalidOperation)
+					os.Exit(1)
+				}
+				if err := backend.CreateWorktree(worktreePath, wtBranch); err != nil {
+					out.Error(fmt.Sprintf("worktree creation failed: %v", err), ErrCodeInvalidOperation)
+					os.Exit(1)
+				}
 			}
 		}
 
@@ -776,6 +787,10 @@ func handleSessionFork(profile string, args []string) {
 	if err != nil {
 		out.Error(fmt.Sprintf("failed to create fork: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
+	}
+
+	if worktreeType != "" {
+		forkedInst.WorktreeType = worktreeType
 	}
 
 	// Apply sandbox config if requested.

--- a/cmd/agent-deck/session_remove_cmd.go
+++ b/cmd/agent-deck/session_remove_cmd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
@@ -197,10 +196,12 @@ func removeAllErrored(
 func pruneSessionWorktree(inst *session.Instance) {
 	_ = inst.KillAndWait()
 	if inst.IsWorktree() {
-		if err := git.RemoveWorktree(inst.WorktreeRepoRoot, inst.WorktreePath, true); err != nil {
-			fmt.Fprintf(os.Stderr, "warn: worktree remove failed for %s: %v\n", inst.ID, err)
+		if backend, err := detectAndCreateBackend(inst.WorktreeRepoRoot); err == nil {
+			if err := backend.RemoveWorktree(inst.WorktreePath, true); err != nil {
+				fmt.Fprintf(os.Stderr, "warn: worktree remove failed for %s: %v\n", inst.ID, err)
+			}
+			_ = backend.PruneWorktrees()
 		}
-		_ = git.PruneWorktrees(inst.WorktreeRepoRoot)
 	}
 }
 

--- a/cmd/agent-deck/vcs_helper.go
+++ b/cmd/agent-deck/vcs_helper.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/jujutsu"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
+)
+
+// gitBackend is a thin adapter that satisfies vcs.Backend by wrapping
+// internal/git's existing free functions. It lives in cmd/agent-deck so
+// the internal/git package keeps its current free-function API unchanged
+// (see PR #754 takeover Option B).
+type gitBackend struct {
+	repoDir string
+}
+
+var _ vcs.Backend = (*gitBackend)(nil)
+
+func newGitBackend(dir string) (*gitBackend, error) {
+	if !git.IsGitRepoOrBareProjectRoot(dir) {
+		return nil, fmt.Errorf("not a git repository: %s", dir)
+	}
+	root, err := git.GetWorktreeBaseRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	return &gitBackend{repoDir: root}, nil
+}
+
+func (g *gitBackend) Type() vcs.Type  { return vcs.TypeGit }
+func (g *gitBackend) RepoDir() string { return g.repoDir }
+
+func (g *gitBackend) WorktreePath(opts vcs.WorktreePathOptions) string {
+	return git.WorktreePath(git.WorktreePathOptions{
+		Branch:    opts.Branch,
+		Location:  opts.Location,
+		RepoDir:   g.repoDir,
+		SessionID: opts.SessionID,
+		Template:  opts.Template,
+	})
+}
+
+func (g *gitBackend) BranchExists(name string) bool {
+	return git.BranchExists(g.repoDir, name)
+}
+
+func (g *gitBackend) GetCurrentBranch() (string, error) {
+	return git.GetCurrentBranch(g.repoDir)
+}
+
+func (g *gitBackend) GetDefaultBranch() (string, error) {
+	return git.GetDefaultBranch(g.repoDir)
+}
+
+func (g *gitBackend) DeleteBranch(name string, force bool) error {
+	return git.DeleteBranch(g.repoDir, name, force)
+}
+
+func (g *gitBackend) MergeBranch(name string) error {
+	return git.MergeBranch(g.repoDir, name)
+}
+
+func (g *gitBackend) CreateWorktree(worktreePath, branchName string) error {
+	return git.CreateWorktree(g.repoDir, worktreePath, branchName)
+}
+
+func (g *gitBackend) ListWorktrees() ([]vcs.Worktree, error) {
+	wts, err := git.ListWorktrees(g.repoDir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]vcs.Worktree, len(wts))
+	for i, w := range wts {
+		out[i] = vcs.Worktree{Path: w.Path, Branch: w.Branch, Commit: w.Commit, Bare: w.Bare}
+	}
+	return out, nil
+}
+
+func (g *gitBackend) RemoveWorktree(worktreePath string, force bool) error {
+	return git.RemoveWorktree(g.repoDir, worktreePath, force)
+}
+
+func (g *gitBackend) GetWorktreeForBranch(branchName string) (string, error) {
+	return git.GetWorktreeForBranch(g.repoDir, branchName)
+}
+
+func (g *gitBackend) PruneWorktrees() error {
+	return git.PruneWorktrees(g.repoDir)
+}
+
+// detectAndCreateBackend detects the VCS type for the given directory and
+// returns the appropriate Backend. Jujutsu is preferred when both jj and git
+// are present (matching jennings's original ordering in #754) so that mixed
+// repos opt into jj semantics.
+func detectAndCreateBackend(dir string) (vcs.Backend, error) {
+	if b, err := jujutsu.NewJJBackend(dir); err == nil {
+		return b, nil
+	}
+	if b, err := newGitBackend(dir); err == nil {
+		return b, nil
+	}
+	return nil, fmt.Errorf("not a git or jujutsu repository: %s", dir)
+}
+
+// createWorktreeWithSetup creates a worktree via the backend. For git
+// backends it also runs the per-repo worktree-setup script (git path
+// retains the existing CreateWorktreeWithSetup contract). For non-git
+// backends (jujutsu) the worktree is created without running a setup
+// script — this is the Option B minimal-port limitation noted in the
+// PR body.
+func createWorktreeWithSetup(backend vcs.Backend, worktreePath, branchName string, stdout, stderr io.Writer, setupTimeout time.Duration) (setupErr error, err error) {
+	if backend.Type() == vcs.TypeGit {
+		return git.CreateWorktreeWithSetup(backend.RepoDir(), worktreePath, branchName, stdout, stderr, setupTimeout)
+	}
+	return nil, backend.CreateWorktree(worktreePath, branchName)
+}

--- a/cmd/agent-deck/worktree_cmd.go
+++ b/cmd/agent-deck/worktree_cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
 // handleWorktree dispatches worktree subcommands
@@ -91,22 +92,15 @@ func handleWorktreeList(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Check if in a git repo (or a bare-repo project root)
-	if !git.IsGitRepoOrBareProjectRoot(cwd) {
-		out.Error("not in a git repository", ErrCodeInvalidOperation)
-		os.Exit(1)
-	}
-
-	// Get repo root (resolve through worktrees to prevent nesting; also
-	// handles bare-repo project roots by returning the parent of .bare/).
-	repoRoot, err := git.GetWorktreeBaseRoot(cwd)
+	backend, err := detectAndCreateBackend(cwd)
 	if err != nil {
-		out.Error(fmt.Sprintf("failed to get repo root: %v", err), ErrCodeInvalidOperation)
+		out.Error(fmt.Sprintf("%v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
+	repoRoot := backend.RepoDir()
 
 	// List worktrees
-	worktrees, err := git.ListWorktrees(repoRoot)
+	worktrees, err := backend.ListWorktrees()
 	if err != nil {
 		out.Error(fmt.Sprintf("failed to list worktrees: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
@@ -329,31 +323,29 @@ func handleWorktreeCleanup(profile string, args []string) {
 	}
 
 	// Find orphaned worktrees (exist but no session points to them)
-	var orphanedWorktrees []git.Worktree
-	var repoRoot string
+	var orphanedWorktrees []vcs.Worktree
+	var cleanupBackend vcs.Backend
 
-	if git.IsGitRepoOrBareProjectRoot(cwd) {
-		repoRoot, err = git.GetWorktreeBaseRoot(cwd)
-		if err == nil {
-			worktrees, err := git.ListWorktrees(repoRoot)
-			if err == nil {
-				// Build set of paths that sessions use
-				sessionPaths := make(map[string]bool)
-				for _, inst := range instances {
-					sessionPaths[inst.ProjectPath] = true
-					if inst.WorktreePath != "" {
-						sessionPaths[inst.WorktreePath] = true
-					}
+	if backend, bErr := detectAndCreateBackend(cwd); bErr == nil {
+		cleanupBackend = backend
+		worktrees, wErr := cleanupBackend.ListWorktrees()
+		if wErr == nil {
+			// Build set of paths that sessions use
+			sessionPaths := make(map[string]bool)
+			for _, inst := range instances {
+				sessionPaths[inst.ProjectPath] = true
+				if inst.WorktreePath != "" {
+					sessionPaths[inst.WorktreePath] = true
 				}
+			}
 
-				// Check each worktree (skip the first one which is usually the main repo)
-				for i, wt := range worktrees {
-					if i == 0 {
-						continue // Skip main repo
-					}
-					if !sessionPaths[wt.Path] {
-						orphanedWorktrees = append(orphanedWorktrees, wt)
-					}
+			// Check each worktree (skip the first one which is usually the main repo)
+			for i, wt := range worktrees {
+				if i == 0 {
+					continue // Skip main repo
+				}
+				if !sessionPaths[wt.Path] {
+					orphanedWorktrees = append(orphanedWorktrees, wt)
 				}
 			}
 		}
@@ -470,7 +462,11 @@ func handleWorktreeCleanup(profile string, args []string) {
 	// Remove orphaned worktrees
 	removedWorktrees := 0
 	for _, wt := range orphanedWorktrees {
-		if err := git.RemoveWorktree(repoRoot, wt.Path, false); err != nil {
+		if cleanupBackend == nil {
+			fmt.Fprintf(os.Stderr, "Warning: no VCS backend for worktree removal\n")
+			break
+		}
+		if err := cleanupBackend.RemoveWorktree(wt.Path, false); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to remove worktree %s: %v\n", wt.Path, err)
 			continue
 		}
@@ -548,7 +544,13 @@ func handleWorktreeFinish(profile string, args []string) {
 	worktreePath := inst.WorktreePath
 	worktreeBranch := inst.WorktreeBranch
 
-	// Check for uncommitted changes
+	finishBackend, err := detectAndCreateBackend(repoRoot)
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to initialize VCS: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	// Check for uncommitted changes (uses worktree path, not repoDir — stays standalone)
 	if !*force {
 		dirty, err := git.HasUncommittedChanges(worktreePath)
 		if err != nil {
@@ -570,7 +572,7 @@ func handleWorktreeFinish(profile string, args []string) {
 	// Determine target branch
 	targetBranch := *into
 	if targetBranch == "" && !*noMerge {
-		targetBranch, err = git.GetDefaultBranch(repoRoot)
+		targetBranch, err = finishBackend.GetDefaultBranch()
 		if err != nil {
 			out.Error(fmt.Sprintf("could not determine target branch: %v\nUse --into <branch> to specify", err), ErrCodeInvalidOperation)
 			os.Exit(1)
@@ -624,10 +626,12 @@ func handleWorktreeFinish(profile string, args []string) {
 		}
 
 		// Merge the worktree branch
-		if err := git.MergeBranch(repoRoot, worktreeBranch); err != nil {
-			// Abort the merge to leave things clean
-			abortCmd := exec.Command("git", "-C", repoRoot, "merge", "--abort")
-			_ = abortCmd.Run()
+		if err := finishBackend.MergeBranch(worktreeBranch); err != nil {
+			// Abort the merge to leave things clean (git-specific)
+			if finishBackend.Type() == vcs.TypeGit {
+				abortCmd := exec.Command("git", "-C", repoRoot, "merge", "--abort")
+				_ = abortCmd.Run()
+			}
 			out.Error(fmt.Sprintf("merge failed (aborted): %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
@@ -637,18 +641,18 @@ func handleWorktreeFinish(profile string, args []string) {
 	// Step 2: Remove worktree
 	if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
 		fmt.Printf("Removing worktree at %s...\n", FormatPath(worktreePath))
-		if err := git.RemoveWorktree(repoRoot, worktreePath, *force); err != nil {
+		if err := finishBackend.RemoveWorktree(worktreePath, *force); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to remove worktree: %v\n", err)
 		} else {
 			fmt.Printf("  %s Worktree removed\n", successSymbol)
 		}
 	}
-	_ = git.PruneWorktrees(repoRoot)
+	_ = finishBackend.PruneWorktrees()
 
 	// Step 3: Delete branch (if not --keep-branch)
 	if !*keepBranch {
 		fmt.Printf("Deleting branch %s...\n", worktreeBranch)
-		if err := git.DeleteBranch(repoRoot, worktreeBranch, *force); err != nil {
+		if err := finishBackend.DeleteBranch(worktreeBranch, *force); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to delete branch: %v\n", err)
 		} else {
 			fmt.Printf("  %s Branch deleted\n", successSymbol)

--- a/internal/jujutsu/jujutsu.go
+++ b/internal/jujutsu/jujutsu.go
@@ -1,0 +1,338 @@
+// Package jujutsu provides jj (Jujutsu) VCS operations for agent-deck.
+// It mirrors the internal/git package pattern with package-level functions
+// that execute jj CLI commands.
+package jujutsu
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
+)
+
+type JJBackend struct {
+	repoDir string
+}
+
+// Compile-time check that *JJBackend satisfies vcs.Backend.
+var _ vcs.Backend = (*JJBackend)(nil)
+
+func NewJJBackend(dir string) (*JJBackend, error) {
+	if !IsJJRepo(dir) {
+		return nil, fmt.Errorf("not a jujutsu repository: %s", dir)
+	}
+	root, err := GetWorktreeBaseRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	return &JJBackend{root}, nil
+}
+
+func (g *JJBackend) Type() vcs.Type { return vcs.TypeJujutsu }
+
+// RepoDir returns the root directory of the repository.
+func (b *JJBackend) RepoDir() string { return b.repoDir }
+
+// WorktreePath generates a workspace path using the backend's repoDir.
+// Delegates to the shared template logic in the git package (VCS-agnostic).
+func (b *JJBackend) WorktreePath(opts vcs.WorktreePathOptions) string {
+	return git.WorktreePath(git.WorktreePathOptions{
+		Branch:    opts.Branch,
+		Location:  opts.Location,
+		RepoDir:   b.repoDir,
+		SessionID: opts.SessionID,
+		Template:  opts.Template,
+	})
+}
+
+// IsJJRepo checks if the given directory is inside a jj repository by running
+// `jj root`. Returns false if jj is not installed or the directory is not a jj repo.
+func IsJJRepo(dir string) bool {
+	if _, err := exec.LookPath("jj"); err != nil {
+		return false
+	}
+	cmd := exec.Command("jj", "root", "-R", dir, "--ignore-working-copy")
+	return cmd.Run() == nil
+}
+
+// GetRepoRoot returns the root directory of the jj repository.
+func GetRepoRoot(dir string) (string, error) {
+	cmd := exec.Command("jj", "root", "-R", dir, "--ignore-working-copy")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("not a jj repository: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// GetCurrentBranch returns the first bookmark of the current working-copy change.
+func (b *JJBackend) GetCurrentBranch() (string, error) {
+	cmd := exec.Command("jj", "log", "-r", "@", "--no-graph", "-T", "bookmarks", "-R", b.repoDir, "--ignore-working-copy")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current bookmark: %w", err)
+	}
+	raw := strings.TrimSpace(string(output))
+	if raw == "" {
+		return "", nil
+	}
+	// jj may return multiple bookmarks separated by spaces; take the first
+	parts := strings.Fields(raw)
+	// jj appends a '*' to bookmarks that have local changes; strip it
+	return strings.TrimRight(parts[0], "*"), nil
+}
+
+// BranchExists checks if a bookmark exists in the repository.
+func (b *JJBackend) BranchExists(branchName string) bool {
+	cmd := exec.Command("jj", "bookmark", "list", "--name", branchName, "-R", b.repoDir, "--ignore-working-copy")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) != ""
+}
+
+// Workspace represents a jj workspace parsed from `jj workspace list`.
+type Workspace struct {
+	Name string
+	Path string
+}
+
+// ListWorktrees returns all workspaces for the repository.
+func (b *JJBackend) ListWorktrees() ([]vcs.Worktree, error) {
+	cmd := exec.Command("jj", "workspace", "list", "-R", b.repoDir, "-T", "name ++ ':' ++ target.commit_id() ++ \"\\n\"", "--ignore-working-copy")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workspaces: %w", err)
+	}
+	return parseWorkspacesList(string(output))
+}
+
+func parseWorkspacesList(output string) ([]vcs.Worktree, error) {
+	var workspaces []vcs.Worktree
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		// Format: "name: rest..."
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		commitId := strings.TrimSpace(parts[1])
+		workspaces = append(workspaces, vcs.Worktree{
+			Branch: name,
+			Commit: commitId,
+		})
+	}
+	return workspaces, nil
+}
+
+// getWorkspacePath returns the filesystem path for a named workspace.
+// It resolves the path from the repo root's .jj/working-copy stores.
+func getWorkspacePath(repoDir, workspaceName string) (string, error) {
+	if workspaceName == "default" {
+		return GetRepoRoot(repoDir)
+	}
+
+	cmd := exec.Command("jj", "workspace", "root", "--name", workspaceName, "--ignore-working-copy")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get workspace path: %w", err)
+	}
+	return string(output), nil
+}
+
+// IsDefaultWorkspace returns true if the given directory is the default workspace.
+func IsDefaultWorkspace(dir string) (bool, error) {
+	root, err := GetRepoRoot(dir)
+	if err != nil {
+		return false, err
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return false, err
+	}
+	return absDir == root, nil
+}
+
+// IsWorktree checks if the directory is a non-default jj workspace.
+func IsWorktree(dir string) bool {
+	isDefault, err := IsDefaultWorkspace(dir)
+	if err != nil {
+		return false
+	}
+	return !isDefault
+}
+
+// GetWorktreeBaseRoot returns the default workspace path (equivalent to main worktree in git).
+func GetWorktreeBaseRoot(dir string) (string, error) {
+	return GetRepoRoot(dir)
+}
+
+// CreateWorktree creates a new jj workspace at the given path.
+func (b *JJBackend) CreateWorktree(workspacePath, branchName string) error {
+	// Derive workspace name from the path
+	wsName := workspaceNameFromPath(workspacePath)
+
+	cmd := exec.Command("jj", "workspace", "add", "--name", wsName, workspacePath, "-R", b.repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create workspace: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+
+	// Create/set bookmark on the new workspace's working copy
+	if branchName != "" {
+		if b.BranchExists(branchName) {
+			// Set existing bookmark to point to the new workspace's working copy
+			cmd = exec.Command("jj", "bookmark", "set", branchName, "-r", "@", "-R", workspacePath)
+		} else {
+			// Create new bookmark
+			cmd = exec.Command("jj", "bookmark", "create", branchName, "-r", "@", "-R", workspacePath)
+		}
+		output, err = cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to set bookmark: %s: %w", strings.TrimSpace(string(output)), err)
+		}
+	}
+
+	return nil
+}
+
+// RemoveWorktree forgets a workspace and optionally removes its directory.
+func (b *JJBackend) RemoveWorktree(workspacePath string, force bool) error {
+	wsName := workspaceNameFromPath(workspacePath)
+
+	cmd := exec.Command("jj", "workspace", "forget", wsName, "-R", b.repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to forget workspace: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+
+	// jj workspace forget doesn't remove the directory, so we do it ourselves
+	if err := os.RemoveAll(workspacePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove workspace directory: %w", err)
+	}
+
+	return nil
+}
+
+// PruneWorktrees removes workspace entries whose directories no longer exist.
+func (b *JJBackend) PruneWorktrees() error {
+	workspaces, err := b.ListWorktrees()
+	if err != nil {
+		return err
+	}
+	for _, ws := range workspaces {
+		if ws.Path == "default" {
+			continue
+		}
+		path, pathErr := getWorkspacePath(b.repoDir, ws.Branch)
+		if pathErr != nil {
+			continue
+		}
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			cmd := exec.Command("jj", "workspace", "forget", ws.Branch, "-R", b.repoDir)
+			_ = cmd.Run()
+		}
+	}
+	return nil
+}
+
+// HasUncommittedChanges checks if the working copy has uncommitted changes.
+func (b *JJBackend) HasUncommittedChanges() (bool, error) {
+	cmd := exec.Command("jj", "diff", "--stat", "-R", b.repoDir, "--ignore-working-copy")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("failed to check jj diff: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return strings.TrimSpace(string(output)) != "", nil
+}
+
+// GetDefaultBranch returns the default branch name (checks for main/master bookmarks).
+func (b *JJBackend) GetDefaultBranch() (string, error) {
+	if b.BranchExists("main") {
+		return "main", nil
+	}
+	if b.BranchExists("master") {
+		return "master", nil
+	}
+	return "", errors.New("could not determine default branch (no main or master bookmark)")
+}
+
+// MergeBranch creates a merge change combining the current change with the given bookmark.
+func (b *JJBackend) MergeBranch(branchName string) error {
+	cmd := exec.Command("jj", "new", "@", branchName, "-R", b.repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("merge failed: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// DeleteBranch deletes a bookmark.
+func (b *JJBackend) DeleteBranch(branchName string, force bool) error {
+	cmd := exec.Command("jj", "bookmark", "delete", branchName, "-R", b.repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to delete bookmark: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// CheckoutBranch moves the working copy to a new change based on the given bookmark.
+func (b *JJBackend) CheckoutBranch(branchName string) error {
+	cmd := exec.Command("jj", "new", branchName, "-R", b.repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to checkout %s: %s: %w", branchName, strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// AbortMerge undoes the last operation (equivalent to aborting a merge).
+func AbortMerge(repoDir string) error {
+	cmd := exec.Command("jj", "undo", "-R", repoDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to undo: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
+}
+
+// GetMainWorktreePath returns the path to the default workspace.
+func GetMainWorktreePath(dir string) (string, error) {
+	return GetRepoRoot(dir)
+}
+
+// workspaceNameFromPath generates a workspace name from a filesystem path.
+func workspaceNameFromPath(path string) string {
+	name := filepath.Base(path)
+	// Replace characters that might be problematic in workspace names
+	name = strings.ReplaceAll(name, " ", "-")
+	return name
+}
+
+func (b *JJBackend) GetWorktreeForBranch(branchName string) (string, error) {
+	worktrees, err := b.ListWorktrees()
+	if err != nil {
+		return "", err
+	}
+
+	for _, wt := range worktrees {
+		if wt.Branch == branchName {
+			return wt.Path, nil
+		}
+	}
+
+	return "", nil
+}

--- a/internal/jujutsu/jujutsu_test.go
+++ b/internal/jujutsu/jujutsu_test.go
@@ -1,0 +1,78 @@
+package jujutsu
+
+import (
+	"os/exec"
+	"reflect"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/vcs"
+)
+
+// TestJujutsuDetect_NonJJDir verifies that IsJJRepo returns false for a
+// directory that is not a jj repository. When jj is not installed at all
+// this still returns false (LookPath miss), which matches the "git
+// fallback" path in detectAndCreateBackend.
+func TestJujutsuDetect_NonJJDir(t *testing.T) {
+	tmp := t.TempDir()
+	if IsJJRepo(tmp) {
+		t.Fatalf("IsJJRepo returned true for non-jj dir %s", tmp)
+	}
+}
+
+// TestJujutsuDetect_JJNotInstalled covers the missing-binary path. We can't
+// guarantee jj is absent on every dev machine, so this test only asserts
+// the contract: when LookPath fails, IsJJRepo returns false without panic.
+func TestJujutsuDetect_JJNotInstalled(t *testing.T) {
+	if _, err := exec.LookPath("jj"); err == nil {
+		t.Skip("jj binary is available; skipping not-installed path")
+	}
+	if IsJJRepo(t.TempDir()) {
+		t.Fatal("IsJJRepo should return false when jj is not installed")
+	}
+}
+
+// TestJujutsuDetect_NewJJBackendOnNonRepo verifies the error path of
+// NewJJBackend on a non-jj directory.
+func TestJujutsuDetect_NewJJBackendOnNonRepo(t *testing.T) {
+	tmp := t.TempDir()
+	if _, err := NewJJBackend(tmp); err == nil {
+		t.Fatalf("NewJJBackend(%s) should error for non-jj dir", tmp)
+	}
+}
+
+// TestJujutsuParseWorkspacesList exercises the parser used by ListWorktrees
+// without invoking the jj binary. Keeps coverage useful on machines without jj.
+func TestJujutsuParseWorkspacesList(t *testing.T) {
+	output := "default: abc123\nfeature-x: def456\n\nempty-line-ignored:\n"
+	got, err := parseWorkspacesList(output)
+	if err != nil {
+		t.Fatalf("parseWorkspacesList errored: %v", err)
+	}
+	want := []vcs.Worktree{
+		{Branch: "default", Commit: "abc123"},
+		{Branch: "feature-x", Commit: "def456"},
+		{Branch: "empty-line-ignored", Commit: ""},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseWorkspacesList mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// TestJujutsuWorkspaceNameFromPath asserts path-to-name sanitization used
+// by CreateWorktree/RemoveWorktree.
+func TestJujutsuWorkspaceNameFromPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/tmp/agent-deck-feature-x", "agent-deck-feature-x"},
+		{"/tmp/with space dir", "with-space-dir"},
+		{"feature-y", "feature-y"},
+	}
+	for _, tc := range cases {
+		got := workspaceNameFromPath(tc.path)
+		if got != tc.want {
+			t.Errorf("workspaceNameFromPath(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -96,6 +96,7 @@ type Instance struct {
 	WorktreePath     string `json:"worktree_path,omitempty"`      // Path to worktree (if session is in worktree)
 	WorktreeRepoRoot string `json:"worktree_repo_root,omitempty"` // Original repo root
 	WorktreeBranch   string `json:"worktree_branch,omitempty"`    // Branch name in worktree
+	WorktreeType     string `json:"worktree_type,omitempty"`      // "git", "jujutsu", or "" (legacy = git)
 
 	// Multi-repo support
 	MultiRepoEnabled   bool                `json:"multi_repo_enabled,omitempty"`

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -1,0 +1,49 @@
+// Package vcs defines a version control system abstraction layer.
+package vcs
+
+// Worktree represents a VCS worktree.
+type Worktree struct {
+	Path   string // Filesystem path to the worktree
+	Branch string // Branch name checked out in this worktree
+	Commit string // HEAD commit SHA
+	Bare   bool   // Whether this is the bare repository
+}
+
+// WorktreePathOptions configures worktree path generation for a Backend.
+// Unlike git.WorktreePathOptions, it omits RepoDir because the backend supplies it.
+type WorktreePathOptions struct {
+	Branch    string
+	Location  string
+	SessionID string
+	Template  string
+}
+
+type Type string
+
+const (
+	TypeGit     Type = "git"
+	TypeJujutsu Type = "jujutsu"
+)
+
+// Backend abstracts version control operations scoped to a repository.
+type Backend interface {
+	Type() Type
+
+	// RepoDir returns the root directory of the repository.
+	RepoDir() string
+
+	// Branch operations
+	BranchExists(branchName string) bool
+	GetCurrentBranch() (string, error)
+	GetDefaultBranch() (string, error)
+	DeleteBranch(branchName string, force bool) error
+	MergeBranch(branchName string) error
+
+	// Worktree operations
+	WorktreePath(opts WorktreePathOptions) string
+	CreateWorktree(worktreePath, branchName string) error
+	ListWorktrees() ([]Worktree, error)
+	RemoveWorktree(worktreePath string, force bool) error
+	GetWorktreeForBranch(branchName string) (string, error)
+	PruneWorktrees() error
+}


### PR DESCRIPTION
## Summary

Takeover of #754 — adds Jujutsu VCS support to agent-deck. Original design and adapter code by @jennings, who green-lit this takeover when he couldn't carry the PR over the finish line.

This is **Option B (minimal port)**: we keep `internal/git`'s existing free-function API exactly as-is and introduce Jujutsu through a thin `vcs.Backend` interface, rather than re-applying jennings's ~3500-line structural refactor of `internal/git` into methods on `*GitBackend`. End result: user-visible `jj` support across the CLI without churning the shared `internal/git` surface.

## What works

Worktree-aware paths now detect git vs jujutsu and dispatch to the right backend:

- `agent-deck add ... --worktree-branch foo` (works in a jj repo too)
- `agent-deck launch ... --worktree-branch foo`
- `agent-deck session fork ... --worktree-branch foo`
- `agent-deck worktree list / cleanup / finish`
- `agent-deck rm` (cleans up jj workspaces correctly)

Detection precedence matches jennings's original: if both `jj` and `git` are valid for a path, the jj backend is used (mixed-repo opt-in).

## Files added

| Path | Notes |
| --- | --- |
| `internal/vcs/vcs.go` | `Backend` interface, `Worktree`, `WorktreePathOptions`, `Type` consts. Identical to jennings's design. |
| `internal/jujutsu/jujutsu.go` | `JJBackend` + helpers. **Copied verbatim from #754** — depends only on `git.WorktreePath` (existing free function), so no internal/git refactor needed. |
| `internal/jujutsu/jujutsu_test.go` | `TestJujutsuDetect_*` (parallel naming to the existing `TestCrushDetect_*` style), parser tests, workspace-name sanitization tests. Tests run without the `jj` binary. |
| `cmd/agent-deck/vcs_helper.go` | `gitBackend` adapter wrapping `internal/git` free functions + `detectAndCreateBackend(dir)` + `createWorktreeWithSetup(backend, …)` dispatch helper (git path runs the existing setup script flow; jj just creates the workspace). |

## Files touched (call-site rewires only)

`cmd/agent-deck/launch_cmd.go`, `main.go`, `session_cmd.go`, `session_remove_cmd.go`, `worktree_cmd.go`. Each block that previously hard-coded `git.IsGitRepoOrBareProjectRoot` + `git.GetWorktreeBaseRoot` + `git.BranchExists` + `git.WorktreePath` + `git.CreateWorktreeWithSetup` etc. now opens a `vcs.Backend` via `detectAndCreateBackend(path)` and uses its methods.

`internal/session/instance.go` adds a single field — `WorktreeType string` — so the persisted instance remembers whether it lives in a git or jj worktree (legacy `""` is treated as git).

## Files dropped from jennings's diff

- `internal/git/*` structural refactor (free funcs → methods on `*GitBackend`). This is the big one — Option B's whole purpose.
- `internal/ui/home.go` TUI integration (kept git-only for this PR; will follow up if the CLI surface bakes in).
- `.github/workflows/*` workflow tweaks (stale relative to current main).
- `.claude/worktrees/agent-*` worker scratch.

## Known limitations (intentional, callable out in this PR)

1. **`agent-deck session fork --with-state` stays git-only.** It uses the git index/stash to ship dirty state to a new worktree; jj has no parallel today. We return a clear error for jj instead of silently doing nothing.
2. **Worktree setup scripts run only for git backends.** `git.CreateWorktreeWithSetup` runs a per-repo `.agent-deck/worktree-setup.sh`. For jj we just call `backend.CreateWorktree()` directly — no setup script. Trivial follow-up.
3. **TUI (`internal/ui/home.go`) still calls `internal/git` free functions directly.** jj users should use the CLI surface (`agent-deck add`, `agent-deck launch`, `agent-deck worktree`) for now.

## Verification

- `go test -race -count=1 ./...` — green on Linux/amd64 (Go 1.25.10)
- `TestPersistence_*` (mandated suite per `CLAUDE.md`) — green
- `internal/jujutsu` unit tests — green (parser + non-repo detection paths, no `jj` binary required)
- **Smoke test against a real jj repo requires the `jj` binary**, which is not installed in this environment. Maintainers with `jj` installed can validate by running `jj git init test && cd test && agent-deck add -t demo --worktree-branch foo`.

## Credit

- Original PR: #754
- Original author: @jennings
- Takeover scope: trim the diff to keep `internal/git`'s public API stable while still delivering user-visible `jj` support. No conceptual change to jennings's adapter design.

## Test plan

- [ ] CI green
- [ ] Maintainer with `jj` installed smoke-tests `agent-deck add --worktree-branch` in a jj repo
- [ ] Maintainer reviews the dropped sections (`internal/git/*` refactor, TUI integration) and signs off on the deferred-to-follow-up scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Jujutsu repository support alongside existing Git support.
  * Worktree operations now consistently work across Git and Jujutsu backends with automatic backend detection.

* **Tests**
  * Added tests for Jujutsu backend detection and workspace parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->