### PR TITLE
fix(jujutsu): annotate 3 exec.Command sites with #nosec G204 (hotfix main red)

### DIFF
--- a/internal/jujutsu/jujutsu.go
+++ b/internal/jujutsu/jujutsu.go
@@ -73,7 +73,7 @@ func GetRepoRoot(dir string) (string, error) {
 
 // GetCurrentBranch returns the first bookmark of the current working-copy change.
 func (b *JJBackend) GetCurrentBranch() (string, error) {
-	cmd := exec.Command("jj", "log", "-r", "@", "--no-graph", "-T", "bookmarks", "-R", b.repoDir, "--ignore-working-copy")
+	cmd := exec.Command("jj", "log", "-r", "@", "--no-graph", "-T", "bookmarks", "-R", b.repoDir, "--ignore-working-copy") // #nosec G204 -- jj invocations with slice args + internal repoDir/branch fields, not shell-formed
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current bookmark: %w", err)
@@ -106,7 +106,7 @@ type Workspace struct {
 
 // ListWorktrees returns all workspaces for the repository.
 func (b *JJBackend) ListWorktrees() ([]vcs.Worktree, error) {
-	cmd := exec.Command("jj", "workspace", "list", "-R", b.repoDir, "-T", "name ++ ':' ++ target.commit_id() ++ \"\\n\"", "--ignore-working-copy")
+	cmd := exec.Command("jj", "workspace", "list", "-R", b.repoDir, "-T", "name ++ ':' ++ target.commit_id() ++ \"\\n\"", "--ignore-working-copy") // #nosec G204 -- jj invocations with slice args + internal repoDir/branch fields, not shell-formed
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list workspaces: %w", err)
@@ -241,7 +241,7 @@ func (b *JJBackend) PruneWorktrees() error {
 			continue
 		}
 		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-			cmd := exec.Command("jj", "workspace", "forget", ws.Branch, "-R", b.repoDir)
+			cmd := exec.Command("jj", "workspace", "forget", ws.Branch, "-R", b.repoDir) // #nosec G204 -- jj invocations with slice args + internal repoDir/branch fields, not shell-formed
 			_ = cmd.Run()
 		}
 	}


### PR DESCRIPTION
## Why

Main golangci-lint is failing after #1080 merged because the new internal/jujutsu package has 3 G204 (subprocess) findings. All 3 are slice-form exec.Command invocations with internal repoDir/branch fields — not shell-formed, not user-input-tainted. Annotate with #nosec G204 + reason.

## Refs

- #1080 (introduced internal/jujutsu)
- #1078 (flipped lint strict, exposed findings)