### PR TITLE
fix(release): add 10m timeout to release test step (prevent CI hang)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           zoxide --version
 
       - name: Run tests
-        run: go test -race ./...
+        run: go test -race -timeout 10m ./...
 
       # Evaluator harness full tier. Blocking — a release that fails eval
       # does not get a tag. See docs/rfc/EVALUATOR_HARNESS.md (#37).


### PR DESCRIPTION
## Why

v1.9.21 release CI hung 3 hours on 'Run tests' step. The release workflow's 'go test -race ./...' had no explicit timeout, so a deadlocked test could hang the runner indefinitely.

## Fix

Add '-timeout 10m' to the test step. If a test hangs, runner fails fast and the log shows which test was running.

## Refs

- v1.9.21 release CI hung at 09:23 UTC (cancelled at 11:32)