### PR TITLE
fix(release): raise test timeout 10m→20m for race-detector overhead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           zoxide --version
 
       - name: Run tests
-        run: go test -race -timeout 10m ./...
+        run: go test -race -timeout 20m ./...
 
       # Evaluator harness full tier. Blocking — a release that fails eval
       # does not get a tag. See docs/rfc/EVALUATOR_HARNESS.md (#37).


### PR DESCRIPTION
## Why

v1.9.21 release CI failed on Run tests with a panic landing on TestWaitForCompletion_TransientRecovery. Investigation (by worker) found this is cumulative-time exhaustion, not a real deadlock — the test passes locally (5/5) but the full cmd/agent-deck + internal/session suite under -race takes too long on CI runners.

## Fix

Raise -timeout from 10m to 20m. Long-term: per-package CI split.

## Refs

- #1083 (added the 10m timeout — too tight)
- v1.9.21 release CI failures