### PR TITLE
fix(ui): keycap-width tests vs charmbracelet/x/ansi 0.11 (unblock v1.9.21)

### DIFF
--- a/internal/ui/cellwidth.go
+++ b/internal/ui/cellwidth.go
@@ -7,69 +7,52 @@ import (
 	"github.com/rivo/uniseg"
 )
 
-// cellWidth reports the number of terminal cells that s occupies when rendered,
-// bridging a gap between the uniseg grapheme-cluster width table and what real
-// terminals draw — while preserving ANSI-escape-aware measurement.
+// cellWidth reports the number of terminal cells that s occupies when rendered.
 //
-// Why this exists. The codebase ships through github.com/charmbracelet/x/ansi
-// (uniseg-backed) for grapheme-aware width measurement. ansi.StringWidth
-// correctly classifies <codepoint>+U+FE0F sequences such as 🏷️ 🛠️ ⚙️ 🗂️ as
-// 2 cells — that's the contract issue #937 / PR #948 pinned — and it skips
-// ANSI escape sequences (SGR, OSC, CSI) so styled content measures by visible
-// width, not byte length. ansi.StringWidth does *not* classify "keycap"
-// sequences ( base + U+FE0F + U+20E3, e.g. #️⃣ 0️⃣–9️⃣ *️⃣ ) as wide; uniseg
-// reports them at 1 cell. Every terminal we test (Ghostty, Terminal.app,
-// iTerm2, Warp, Termius) renders 2 cells for those clusters, so the
-// agent-deck row layout drifts by one cell per keycap glyph in the pane
-// content @jennings re-opened #937 against.
+// History (#937 v2, @jennings, 2026-05-13). Earlier versions of
+// github.com/charmbracelet/x/ansi (and the uniseg grapheme tables beneath it)
+// classified keycap sequences such as #️⃣ 0️⃣–9️⃣ *️⃣ — i.e. base + U+FE0F +
+// U+20E3 clusters — as 1 cell, while every terminal we tested rendered them
+// as 2. cellWidth bridged that gap by promoting any cluster ending in U+20E3
+// by one cell on top of ansi.StringWidth.
 //
-// Implementation: ansi.StringWidth(s) gives the ANSI-aware base width;
-// keycapCount(s) walks the ANSI-stripped string and counts the grapheme
-// clusters ending in U+20E3 (COMBINING ENCLOSING KEYCAP). Each such
-// cluster contributes one extra cell beyond what uniseg reported, so the
-// total visual width is base + keycapCount.
-//
-// Critically this preserves ANSI escape sequence boundaries — earlier
-// drafts walked the raw input as uniseg clusters, which broke
-// "\x1b[43m..." into ESC + [ + 4 + 3 + m as separate clusters with
-// non-zero width. That over-counted invisible bytes AND let a downstream
-// truncation cut mid-escape, leaving malformed SGR state and bleeding
-// highlight into the next row (regression caught by the #699 SGR-bleed
-// behavioral eval).
+// As of charmbracelet/x/ansi 0.11.7 (PR #1070 dep bump) ansi.StringWidth now
+// classifies keycap clusters as 2 cells natively, matching the terminal
+// contract pinned by Test_Issue937v2_KeycapWidth_MatchesTerminal. The
+// +keycapCount adjustment is no longer needed for measurement and was
+// double-counting. cellWidth is now a thin shim over ansi.StringWidth, kept
+// to avoid churning the dozen callsites in home.go that route width math
+// through it.
 func cellWidth(s string) int {
-	if s == "" {
-		return 0
-	}
-	return ansi.StringWidth(s) + keycapCount(s)
+	return ansi.StringWidth(s)
 }
 
-// cellTruncate is the truncation analog of cellWidth: it returns a prefix of s
-// whose cellWidth is <= width, appending tail (also measured by cellWidth) if
-// any truncation occurred.
+// cellTruncate returns a prefix of s whose cellWidth is <= width, appending
+// tail (also measured by cellWidth) if any truncation occurred.
 //
-// Implementation: ansi.Truncate already handles ANSI escape sequence
-// boundaries — it never cuts mid-CSI, preserves SGR state through the visible
-// prefix, and skips invisible bytes when budgeting. cellTruncate adjusts the
-// width argument it passes to ansi.Truncate by the keycap count of the input,
-// so the output's cellWidth ( = ansi.StringWidth(out) + keycapCount(out) )
-// cannot exceed the requested width:
+// Why this is not a one-liner over ansi.Truncate. ansi 0.11.7 fixed
+// ansi.StringWidth so keycap clusters are reported as 2 cells, but
+// ansi.Truncate's internal cell accounting still measures keycap clusters
+// as 1 cell when deciding where to cut. That means ansi.Truncate(s, w, t)
+// can return a string whose ansi.StringWidth exceeds w when s contains
+// keycap clusters (verified: ansi.Truncate("1️⃣ 2️⃣ start", 8, "...") returns
+// "1️⃣ 2️⃣ s..." which ansi.StringWidth measures at 10).
+//
+// To keep cellWidth(out) <= width, we shrink the budget passed to
+// ansi.Truncate by the keycap count of the input. Worst case every keycap
+// survives the truncation and each costs +1 cell vs ansi.Truncate's
+// internal measurement, so:
 //
 //	  cellWidth(out)
-//	= ansi.StringWidth(out) + keycapCount(out)
+//	= ansi.StringWidth(out)
+//	= ansi_truncate_internal(out) + keycapCount(out)
 //	<= (width - keycapCount(s)) + keycapCount(out)
-//	<= width                    [since keycapCount(out) <= keycapCount(s)]
+//	<= width                       [since keycapCount(out) <= keycapCount(s)]
 //
-// The adjustment is conservative — if every keycap in s gets truncated away,
-// cellWidth(out) can be up to keycapCount(s) below width. That under-fill is
-// the safety margin against the "keycap kept after truncation" case, where
-// each kept keycap costs +1 cell.
-//
-// Tail width is treated identically: ansi.Truncate already subtracts its
-// own measurement of tail (ansi.StringWidth), and the floor below guards
-// against tail-width > budget, which would make ansi.Truncate emit only
-// the tail and return a string whose cellWidth could exceed `width` if
-// the tail itself contained keycap glyphs (in practice it does not — our
-// callers use "..." / "…" — but the floor keeps the contract honest).
+// ansi.Truncate already handles ANSI escape sequence boundaries — never cuts
+// mid-CSI, preserves SGR state through the visible prefix, and skips
+// invisible bytes when budgeting — which keeps the #699 SGR-bleed
+// invariant intact. The adjustment above is purely additive on top of that.
 func cellTruncate(s string, width int, tail string) string {
 	if width <= 0 {
 		return ""
@@ -82,11 +65,11 @@ func cellTruncate(s string, width int, tail string) string {
 		return ansi.Truncate(s, width, tail)
 	}
 	adj := width - n
-	// If the bonus is so large that adj would push tail off the right
-	// edge, fall back to ansi.Truncate without a tail and let the caller
-	// decide. cellWidth(out) <= width still holds because ansi.Truncate
-	// keeps ansi.StringWidth(out) <= width and out may contain at most
-	// n keycaps — but if both are at max, the inequality is loose.
+	// If shrinking the budget would push tail off the right edge,
+	// drop the tail. cellWidth(out) <= width still holds because
+	// ansi.Truncate keeps its own internal-width(out) <= width, and
+	// out contains at most n keycaps. The output may not exactly
+	// fill the budget in that edge case, but it will never exceed it.
 	if adj < cellWidth(tail) {
 		return ansi.Truncate(s, width, "")
 	}
@@ -94,10 +77,14 @@ func cellTruncate(s string, width int, tail string) string {
 }
 
 // keycapCount returns the number of extended grapheme clusters in s that end
-// with U+20E3 (COMBINING ENCLOSING KEYCAP) — i.e. keycap emoji clusters that
-// uniseg under-counts as 1 cell. ANSI escape sequences are stripped before
-// the grapheme walk so they neither inflate the cluster count nor split a
-// keycap cluster across an escape boundary.
+// with U+20E3 (COMBINING ENCLOSING KEYCAP). Used by cellTruncate to shrink
+// the budget passed to ansi.Truncate — ansi.Truncate's internal cell
+// accounting under-counts keycap clusters by exactly 1 each (see
+// cellTruncate doc).
+//
+// ANSI escape sequences are stripped before the grapheme walk so they
+// neither inflate the cluster count nor split a keycap cluster across an
+// escape boundary.
 //
 // Fast-path: a keycap cluster always contains U+20E3 verbatim, so we can
 // skip the full grapheme walk when that codepoint is absent.
@@ -108,23 +95,10 @@ func keycapCount(s string) int {
 	g := uniseg.NewGraphemes(ansi.Strip(s))
 	n := 0
 	for g.Next() {
-		if clusterIsKeycap(g.Runes()) {
+		runes := g.Runes()
+		if len(runes) > 0 && runes[len(runes)-1] == 0x20E3 {
 			n++
 		}
 	}
 	return n
-}
-
-// clusterIsKeycap reports whether the rune sequence ends with the
-// COMBINING ENCLOSING KEYCAP (U+20E3), which marks the cluster as a
-// keycap sequence (e.g. #️⃣ 0️⃣–9️⃣ *️⃣). The base codepoint and the
-// optional U+FE0F variation selector are not validated; uniseg has
-// already grouped them into one extended grapheme cluster, so any
-// cluster ending in U+20E3 is by construction a keycap glyph that
-// terminals render at 2 cells.
-func clusterIsKeycap(runes []rune) bool {
-	if len(runes) == 0 {
-		return false
-	}
-	return runes[len(runes)-1] == 0x20E3
 }

--- a/internal/ui/issue937_keycap_test.go
+++ b/internal/ui/issue937_keycap_test.go
@@ -67,26 +67,26 @@ func Test_Issue937v2_KeycapWidth_MatchesTerminal(t *testing.T) {
 	}
 }
 
-// Test_Issue937v2_AnsiStringWidth_FailsKeycap documents the upstream
-// disagreement that motivated cellWidth. If a future ansi (or uniseg)
-// release fixes keycap classification, this test starts failing — that's
-// the signal to delete cellWidth and route callsites back to ansi.
-// Informational; refuses to silently lock keycap to width 1.
-func Test_Issue937v2_AnsiStringWidth_FailsKeycap(t *testing.T) {
+// Test_Issue937v2_AnsiStringWidth_HandlesKeycap is the post-upstream-fix
+// counterpart to the original FailsKeycap canary. The canary fired on the
+// charmbracelet/x/ansi 0.11.7 dep bump (#1070): ansi.StringWidth now
+// classifies keycap clusters as 2 cells natively, matching what real
+// terminals render. cellWidth's previous +keycapCount adjustment became
+// double-counting and was removed.
+//
+// This test inverts the canary: it pins the contract that ansi.StringWidth
+// agrees with cellWidth on every keycap case, so that any future ansi/uniseg
+// regression back to width-1 keycaps is caught immediately. If this starts
+// failing, restore the keycapCount adjustment in cellwidth.go.
+func Test_Issue937v2_AnsiStringWidth_HandlesKeycap(t *testing.T) {
 	for _, tc := range keycapCases {
-		if tc.name == "repeat_emoji" {
-			continue
-		}
-		// Inputs in keycapCases that are pure keycap (no ASCII shoulders)
-		// should still under-report under ansi.StringWidth.
-		if tc.name != "keycap_in_text" {
-			if got := ansi.StringWidth(tc.in); got >= tc.want {
-				t.Errorf(
-					"ansi.StringWidth(%q) = %d, expected < %d — upstream "+
-						"may have fixed keycap classification; revisit cellWidth",
-					tc.in, got, tc.want,
-				)
-			}
+		if got := ansi.StringWidth(tc.in); got != tc.want {
+			t.Errorf(
+				"ansi.StringWidth(%q) = %d, want %d (%s) — upstream may "+
+					"have regressed keycap classification; restore the "+
+					"keycapCount adjustment in cellwidth.go.",
+				tc.in, got, tc.want, tc.report,
+			)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The dep bump in #1070 (`charmbracelet/x/ansi 0.11.6 → 0.11.7`) shipped the upstream fix for keycap grapheme-cluster width classification — uniseg now counts `<base>+U+FE0F+U+20E3` sequences such as `#️⃣ 0️⃣–9️⃣ *️⃣` at 2 cells, matching what real terminals render. This is exactly the upstream change that `Test_Issue937v2_AnsiStringWidth_FailsKeycap` was planted to detect; its docstring says:

> If a future ansi (or uniseg) release fixes keycap classification, this test starts failing — that's the signal to delete cellWidth and route callsites back to ansi.

`cellWidth` was double-counting after the bump: it added `keycapCount` on top of an `ansi.StringWidth` that already counted keycaps correctly, so `cellWidth("#️⃣")` returned 3 (want 2). All six `Test_Issue937v2_KeycapWidth_MatchesTerminal` subtests failed for this reason on the v1.9.21 release CI.

## Design choice: Option A (update the implementation)

- **Option A — chosen.** The new `ansi` version is correct; align our code with it.
- **Option B — rejected.** Pinning `ansi` back to `0.11.6` would freeze us out of legitimate upstream fixes and require a coordinated revert of `bubbletea`/`lipgloss` etc. that transitively pull in newer `ansi`.
- **Option C — N/A.** The test expectations already matched terminal reality. The implementation was the lagging piece.

#1070's other 13 dep bumps are untouched and ride along with v1.9.21.

## Per-test resolution

| Failing test | Resolution |
|---|---|
| `KeycapWidth_MatchesTerminal/{hash,asterisk,zero,one,nine}_keycap` | `cellWidth` simplified to a thin shim over `ansi.StringWidth`. Kept as a shim (not deleted) so the dozen callsites in `home.go` don't churn. |
| `KeycapWidth_MatchesTerminal/keycap_in_text` | Same fix; `ansi.StringWidth("a#️⃣b") = 4` natively now. |
| `AnsiStringWidth_FailsKeycap` | Canary has fired — repurposed and renamed to `AnsiStringWidth_HandlesKeycap`. The inverted test now pins the contract that `ansi.StringWidth` agrees with `cellWidth` on every keycap case, catching any future regression back to width-1 keycaps. |
| `CellTruncate_FitsKeycapNote/two_keycaps`<br>`CellTruncate_PreservesAnsiBoundariesAndKeycap/{styled_keycap_truncated, styled_two_keycaps_truncated, reset_keycap_mix}` | `cellTruncate` **kept** the keycap-budget adjustment because `ansi.Truncate v0.11.7` is *inconsistent* with `ansi.StringWidth`: while `StringWidth` correctly returns 2 for keycap clusters, `Truncate`'s internal cell accounting still measures keycaps as 1 cell when deciding where to cut. Verified directly: `ansi.Truncate("1️⃣ 2️⃣ start", 8, "...")` returns `"1️⃣ 2️⃣ s..."` which `ansi.StringWidth` measures at 10. The cellTruncate budget adjustment (`width - keycapCount(s)` passed to `ansi.Truncate`) absorbs the upstream inconsistency. |

## Test plan

- [x] `go test -race -count=1 -run Test_Issue937v2 ./internal/ui/` — PASS (was 5/N failing)
- [x] `go test -race -count=1 -timeout 10m ./internal/ui/` — PASS
- [x] `go test -race -count=1 -timeout 25m ./...` — PASS
- [x] `go test -run TestPersistence_ ./internal/session/... -race -count=1` — PASS (CLAUDE.md mandate)
- [x] `go test ./internal/watcher/... -race -count=1 -timeout 120s` — PASS (CLAUDE.md mandate)
- [ ] Release CI green on this branch (awaiting)
- [ ] Conductor merges after CI green — do not auto-merge

Refs #1070, #937.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cell width calculation for keycap emoji to ensure correct text display and truncation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1087?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->