### PR TITLE
fix(session): complete #965 production wiring — reap MCP children in Instance.Kill (closes #1086, unskips CI test)

### DIFF
--- a/internal/session/issue965_wiring_test.go
+++ b/internal/session/issue965_wiring_test.go
@@ -13,7 +13,6 @@
 package session
 
 import (
-	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -32,9 +31,6 @@ import (
 // {claude,node,zsh,bash,sh,cat,npm} whitelist in
 // internal/tmux/tmux.go:isOurProcess) don't reparent to PID 1.
 func TestKillInternal_DiscoversAndReapsMcpChildrenFromPaneTree_RegressionFor965(t *testing.T) {
-	if os.Getenv("CI") == "true" {
-		t.Skip("flaky on CI runners — production wiring for #965 incomplete; see issue follow-up. Local-only test.")
-	}
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("unix-only: relies on syscall.Kill semantics")
 	}

--- a/internal/session/mcp_child_reap.go
+++ b/internal/session/mcp_child_reap.go
@@ -3,15 +3,33 @@ package session
 import (
 	"log/slog"
 	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
 
 // mcpReapGracePeriod is how long we wait after SIGTERM before escalating
-// to SIGKILL on a tracked MCP child. Kept short — stdio MCP children
-// generally exit immediately when their stdio is closed, so anything
-// that survives 500ms is almost certainly stuck.
-const mcpReapGracePeriod = 500 * time.Millisecond
+// to SIGKILL on a tracked MCP child. Stdio MCP children generally exit
+// immediately when their stdio is closed, so anything that survives this
+// window is almost certainly stuck and needs the harder signal.
+//
+// Raised from 500ms → 1s in the issue #1086 fix: on CI runners under
+// the race detector, scheduler latency between the SIGTERM and the
+// child's libc signal handler can exceed 500ms, causing a spurious
+// SIGKILL escalation that races with the child's already-in-flight
+// exit.
+const mcpReapGracePeriod = 1 * time.Second
+
+// mcpReapVerifyTimeout is how long we wait AFTER SIGKILL for the child
+// to actually be gone (reaped by init or exit'd by the kernel). Without
+// this verification, killInternal returns while children are still
+// transitioning, which leaves a window where callers (and tests) can
+// observe live PIDs even though the kernel has accepted SIGKILL. See
+// issue #1086.
+const mcpReapVerifyTimeout = 2 * time.Second
 
 // RegisterMCPChild records the OS PID of a stdio MCP child spawned for
 // this session. Session stop iterates these PIDs and signals each
@@ -69,37 +87,76 @@ func (i *Instance) UnregisterMCPChild(pid int) {
 //     into their own session, escaping tmux's pgroup kill — those
 //     are exactly the leakers from issue #965.
 //
-// Issue #965 wiring follow-up to PR #1000.
+// Issue #965 wiring follow-up to PR #1000. Hardened in issue #1086
+// to use a single ps snapshot (was: two snapshots, which could
+// disagree under load on CI runners and skip a depth-2 child whose
+// intermediate parent had just exec-optimized).
 func (i *Instance) discoverMCPChildrenFromPaneTree() {
-	pids := i.collectTmuxPaneProcessTreePIDs()
-	if len(pids) <= 1 {
+	if i.tmuxSession == nil || !i.tmuxSession.Exists() {
 		return
 	}
-	panePID := pids[0]
+	panePID := i.readPanePID()
+	if panePID <= 0 {
+		return
+	}
 
-	// Build a {pid -> ppid} map from a single ps snapshot so we can
-	// classify each descendant by its immediate parent without an
-	// extra syscall per PID. Falls back to no-op on platforms where
-	// `ps -eo pid=,ppid=` isn't available (same fallback shape as
-	// collectProcessTreePIDsFromTable in instance.go).
 	procTable, err := exec.Command("ps", "-eo", "pid=,ppid=").Output()
-	if err != nil {
+	if err != nil || len(procTable) == 0 {
 		return
 	}
 	childrenByParent := parsePSParentChildMap(procTable)
-	parentByPID := make(map[int]int, len(pids))
-	for parent, children := range childrenByParent {
-		for _, child := range children {
-			parentByPID[child] = parent
-		}
+	if len(childrenByParent) == 0 {
+		return
 	}
 
-	for _, pid := range pids[1:] {
-		if parentByPID[pid] == panePID {
-			continue // depth-1 — tmux teardown owns this
-		}
-		i.RegisterMCPChild(pid)
+	// BFS from pane PID with depth tracking. Single snapshot — every
+	// classification decision (depth-1 skip vs depth-2+ register) is
+	// against the same ps output, removing the two-snapshot race the
+	// previous implementation had between collectTmuxPaneProcessTreePIDs
+	// and the per-pid parent lookup.
+	type queued struct {
+		pid   int
+		depth int
 	}
+	seen := map[int]bool{panePID: true}
+	queue := []queued{{pid: panePID, depth: 0}}
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+
+		for _, child := range childrenByParent[node.pid] {
+			if child <= 0 || seen[child] {
+				continue
+			}
+			seen[child] = true
+			childDepth := node.depth + 1
+			if childDepth >= 2 {
+				i.RegisterMCPChild(child)
+			}
+			queue = append(queue, queued{pid: child, depth: childDepth})
+		}
+	}
+}
+
+// readPanePID returns the pane PID for this Instance's tmux session,
+// or 0 if it cannot be determined. Extracted so discovery can take a
+// single ps snapshot rather than indirecting through
+// collectTmuxPaneProcessTreePIDs (which also takes its own snapshot).
+func (i *Instance) readPanePID() int {
+	target := i.tmuxSession.Name + ":"
+	out, err := tmux.Exec(i.TmuxSocketName, "list-panes", "-t", target, "-F", "#{pane_pid}").Output()
+	if err != nil {
+		return 0
+	}
+	pidStr := strings.TrimSpace(string(out))
+	if idx := strings.IndexByte(pidStr, '\n'); idx >= 0 {
+		pidStr = pidStr[:idx]
+	}
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
 }
 
 // reapTrackedMCPChildren SIGTERMs every PID in TrackedMCPPIDs, waits a
@@ -109,6 +166,13 @@ func (i *Instance) discoverMCPChildrenFromPaneTree() {
 // Errors signaling a single PID are logged and swallowed: a missing
 // child (ESRCH) is the success case, and we never want a single stuck
 // PID to block tmux teardown.
+//
+// Issue #1086: after SIGKILL, this function now blocks until every PID
+// has actually been reaped (ESRCH or zombie) or mcpReapVerifyTimeout
+// elapses. Previously it returned immediately after sending SIGKILL,
+// which allowed callers (and the issue #965 regression test) to
+// observe live PIDs in the brief window before the kernel reaped
+// them — flaky on CI runners under -race.
 func (i *Instance) reapTrackedMCPChildren() {
 	i.mcpPIDsMu.Lock()
 	pids := append([]int(nil), i.TrackedMCPPIDs...)
@@ -125,8 +189,37 @@ func (i *Instance) reapTrackedMCPChildren() {
 		}
 	}
 
-	deadline := time.Now().Add(mcpReapGracePeriod)
-	for time.Now().Before(deadline) {
+	if waitPIDsGone(pids, mcpReapGracePeriod) {
+		return
+	}
+
+	for _, pid := range pids {
+		if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+			mcpLog.Debug("mcp_child_sigkill_failed", slog.Int("pid", pid), slog.Any("error", err))
+		}
+	}
+
+	if !waitPIDsGone(pids, mcpReapVerifyTimeout) {
+		var survivors []int
+		for _, pid := range pids {
+			if syscall.Kill(pid, syscall.Signal(0)) == nil {
+				survivors = append(survivors, pid)
+			}
+		}
+		if len(survivors) > 0 {
+			mcpLog.Warn("mcp_child_sigkill_unverified",
+				slog.Any("survivors", survivors),
+				slog.Duration("waited", mcpReapVerifyTimeout))
+		}
+	}
+}
+
+// waitPIDsGone polls until every PID in the slice is gone (ESRCH on
+// signal-0 probe) or the deadline elapses. Returns true when all PIDs
+// are confirmed gone, false on timeout.
+func waitPIDsGone(pids []int, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for {
 		anyAlive := false
 		for _, pid := range pids {
 			if syscall.Kill(pid, syscall.Signal(0)) == nil {
@@ -135,14 +228,11 @@ func (i *Instance) reapTrackedMCPChildren() {
 			}
 		}
 		if !anyAlive {
-			return
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
 		}
 		time.Sleep(20 * time.Millisecond)
-	}
-
-	for _, pid := range pids {
-		if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
-			mcpLog.Debug("mcp_child_sigkill_failed", slog.Int("pid", pid), slog.Any("error", err))
-		}
 	}
 }


### PR DESCRIPTION
## Summary

Issue #1086 reported that the issue-#965 regression test
`TestKillInternal_DiscoversAndReapsMcpChildrenFromPaneTree_RegressionFor965`
fails reproducibly on CI runners despite passing 5/5 locally. PR #1085
worked around the symptom by skipping the test when `CI=true`; this PR
**fixes the underlying flakiness** and **unskips the test**.

Closes #1086. Completes the wiring trail started in #965 / #1000 / #1006.

## Gap analysis

PR #1000 shipped `Instance.RegisterMCPChild` / `reapTrackedMCPChildren`
as the *mechanism*. PR #1006 wired `Instance.killInternal` to call
`discoverMCPChildrenFromPaneTree` + `reapTrackedMCPChildren` as the
*policy*. Both have been on main since v1.9.9.

The remaining gap surfaced only on CI under `-race`:

1. **Two-snapshot discovery race.** `discoverMCPChildrenFromPaneTree`
   went through `collectTmuxPaneProcessTreePIDs` (snapshot #1, returns
   flat descendant list) and then took a *second* `ps` snapshot to
   classify each descendant by its immediate parent. Between the two
   snapshots a process could exit / exec / reparent, causing the
   second snapshot to mislabel a depth-2 MCP child.

2. **No post-SIGKILL verification.** `reapTrackedMCPChildren` returned
   immediately after sending SIGKILL without waiting for the kernel to
   actually reap the children. Even though `kill(2)` is synchronous
   for the *delivery*, the test's `syscall.Kill(pid, 0)` probe could
   still see the PID briefly before the kernel completed its tear-down.

Combined effect: a small but real window where `Instance.Kill()`
returned with tracked PIDs still observable.

## Design

1. **Single ps snapshot.** `discoverMCPChildrenFromPaneTree` now takes
   ONE `ps -eo pid=,ppid=` snapshot, then walks pane → descendants
   BFS with **depth tracking inline**. The depth-1-skip / depth-2+
   register decision is made against the same snapshot, removing the
   two-snapshot race entirely.

2. **Post-SIGKILL verify.** `reapTrackedMCPChildren` now blocks up to
   `mcpReapVerifyTimeout` (2s) after SIGKILL for every tracked PID
   to be confirmed gone (ESRCH on signal-0 probe). Stragglers are
   logged as `mcp_child_sigkill_unverified` rather than silently
   leaking. SIGTERM grace also bumped 500ms → 1s for CI scheduler
   latency under `-race`.

3. **`waitPIDsGone` shared primitive.** Used after SIGTERM (to
   short-circuit when sleep/etc. handle it cleanly) AND after SIGKILL
   (to verify reap before returning).

## Don't break

- **tmux pgroup kill** is still the primary teardown — discovery
  only registers depth-2+ descendants, which is where setsid-detached
  MCP servers (the #965 leakers) live.
- **tmux `isOurProcess` whitelist** is unchanged. This file
  *intentionally* does not filter by `comm` — the point of #965 is
  reaping processes OUTSIDE the whitelist (uvx, python, bun-based
  MCPs; modeled by `sleep` in the test).
- **#953 StatusStopped persist**, **#1045 single-flight restart**,
  **#1049 heartbeat-pause**: all upstream of this code path.

## Test trace (local linux, race detector on, no `CI=true`)

```
$ go test -race -count=5 -run TestKillInternal_Discovers... ./internal/session/
ok  5/5  2.78s

$ go test -race -count=1 -timeout 600s ./internal/session/
ok  111.87s

$ go test -race -timeout 20m ./...
# All session/tmux/watcher/feedback/cmd green.
# One pre-existing failure in internal/ui (issue937 keycap test);
# reproduces on clean main, unrelated to this PR.
```

CI is now the source of truth — conductor will not merge until green.

## Test plan

- [ ] CI runs `go test -race -timeout 20m ./...` on `ubuntu-latest`
- [ ] `TestKillInternal_DiscoversAndReapsMcpChildrenFromPaneTree_RegressionFor965` now executes (no `t.Skip`) and passes
- [ ] All existing regression suites green (`TestStop_*`, `TestRestart_*`, `TestKillInternal_*`, `TestPersistence_*`, `TestSessionStop_Reaps*`)
- [ ] Session-persistence verify-script unaffected (this PR doesn't touch lifecycle ordering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of child process cleanup with enhanced verification and detection mechanisms.
  * Extended timeout periods for more robust process termination handling.

* **Tests**
  * Updated test execution to run process lifecycle tests in CI environments for better coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->