### PR TITLE
feat(session): per-session account profile slot (closes #924, MVP)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1170,6 +1170,12 @@ func handleAdd(profile string, args []string) {
 	// subsequent start/restart/revive always target the same socket.
 	tmuxSocket := fs.String("tmux-socket", "", "tmux -L socket name for this session (overrides [tmux].socket_name)")
 
+	// Per-session named account slot (#924). Maps to
+	// [profiles.<account>.claude].config_dir in ~/.agent-deck/config.toml
+	// and becomes the most-specific level of CLAUDE_CONFIG_DIR resolution.
+	// Empty = fall through to conductor/group/env/profile/global/default.
+	account := fs.String("account", "", "Named account slot (resolves via [profiles.<account>.claude].config_dir; #924)")
+
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck add [path] [options]")
 		fmt.Println()
@@ -1528,6 +1534,13 @@ func handleAdd(profile string, args []string) {
 	// Set wrapper if provided
 	if sessionWrapperResolved != "" {
 		newInstance.Wrapper = sessionWrapperResolved
+	}
+
+	// #924 per-session named account slot — captured verbatim. The
+	// resolver silently falls through when no matching [profiles.<account>]
+	// block exists, so unknown names are never an error here.
+	if trimmed := strings.TrimSpace(*account); trimmed != "" {
+		newInstance.Account = trimmed
 	}
 
 	// Apply per-session model override after command/tool resolution so the

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1156,6 +1156,7 @@ func handleSessionSet(profile string, args []string) {
 		fmt.Println("  color              Optional TUI row tint: '#RRGGBB' or ANSI '0'..'255' or '' (issue #391)")
 		fmt.Println("  claude-session-id  Claude conversation ID")
 		fmt.Println("  gemini-session-id  Gemini conversation ID")
+		fmt.Println("  account            Named account slot (#924) — resolves via [profiles.<account>.claude].config_dir; restart required")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()

--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -241,6 +241,7 @@ type resolveOpts struct {
 //
 // Returns (path, source) where source is one of:
 //
+//	"account"   — Instance.Account (issue #924) resolved via [profiles.<account>.claude].config_dir
 //	"env"       — CLAUDE_CONFIG_DIR env var
 //	"conductor" — [conductors.<name>.claude].config_dir
 //	"group"     — [groups."<groupPath>".claude].config_dir
@@ -248,7 +249,8 @@ type resolveOpts struct {
 //	"global"    — top-level [claude].config_dir
 //	"default"   — ~/.claude
 //
-// On the instance chain conductor and group beat env (the #881 fix); see
+// On the instance chain Account is the most-specific level (beats
+// conductor/group/env). Conductor and group beat env (the #881 fix); see
 // GetClaudeConfigDirForInstance doc for the rationale.
 func resolveClaudeConfigDir(opts resolveOpts) (path, source string) {
 	userConfig, _ := LoadUserConfig()
@@ -259,6 +261,16 @@ func resolveClaudeConfigDir(opts resolveOpts) (path, source string) {
 	}
 
 	if opts.inst != nil {
+		// Instance chain: account is the most-specific override (#924).
+		// Falls through to conductor/group/env when the account name has
+		// no matching [profiles.<account>.claude].config_dir block — so an
+		// unconfigured account name is a silent no-op, matching the
+		// permissive style of the other levels.
+		if userConfig != nil && opts.inst.Account != "" {
+			if accountDir := userConfig.GetProfileClaudeConfigDir(opts.inst.Account); accountDir != "" {
+				return accountDir, "account"
+			}
+		}
 		// Instance chain: conductor / group beat env.
 		if userConfig != nil {
 			if name := conductorNameFromInstance(opts.inst); name != "" {
@@ -353,13 +365,14 @@ func conductorNameFromInstance(inst *Instance) string {
 //
 // Priority (most-specific → least-specific):
 //
-//  1. [conductors.<name>.claude].config_dir — consulted only when
+//  1. Instance.Account (#924) → [profiles.<account>.claude].config_dir
+//  2. [conductors.<name>.claude].config_dir — consulted only when
 //     Instance.Title starts with "conductor-"
-//  2. [groups."<group>".claude].config_dir
-//  3. CLAUDE_CONFIG_DIR env var
-//  4. [profiles.<profile>.claude].config_dir
-//  5. [claude].config_dir
-//  6. ~/.claude
+//  3. [groups."<group>".claude].config_dir
+//  4. CLAUDE_CONFIG_DIR env var
+//  5. [profiles.<profile>.claude].config_dir
+//  6. [claude].config_dir
+//  7. ~/.claude
 //
 // Why conductor/group beat env (fix-config-dir-priority, 2026-04-17):
 // developer shells commonly export CLAUDE_CONFIG_DIR via aliases (cdp,
@@ -376,8 +389,8 @@ func GetClaudeConfigDirForInstance(inst *Instance) string {
 }
 
 // GetClaudeConfigDirSourceForInstance returns (path, source) for the
-// instance chain. Source labels: "conductor", "group", "env", "profile",
-// "global", "default".
+// instance chain. Source labels: "account" (issue #924), "conductor",
+// "group", "env", "profile", "global", "default".
 func GetClaudeConfigDirSourceForInstance(inst *Instance) (path, source string) {
 	return resolveClaudeConfigDir(resolveOpts{inst: inst})
 }

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -98,6 +98,17 @@ type Instance struct {
 	WorktreeBranch   string `json:"worktree_branch,omitempty"`    // Branch name in worktree
 	WorktreeType     string `json:"worktree_type,omitempty"`      // "git", "jujutsu", or "" (legacy = git)
 
+	// Account is the per-session named account slot (issue #924). Maps to
+	// `[profiles.<account>.claude].config_dir` in ~/.agent-deck/config.toml
+	// at spawn time and becomes the most-specific level in the
+	// CLAUDE_CONFIG_DIR resolution chain — beating conductor / group / env.
+	// Switching the value requires a session restart (the Option 1 MVP
+	// tradeoff): the in-flight Claude conversation is lost since the new
+	// account's settings.json and history live elsewhere. Empty means
+	// "fall through to conductor/group/env/profile/global/default" so
+	// pre-#924 sessions keep their existing behavior unchanged.
+	Account string `json:"account,omitempty"`
+
 	// Multi-repo support
 	MultiRepoEnabled   bool                `json:"multi_repo_enabled,omitempty"`
 	AdditionalPaths    []string            `json:"additional_paths,omitempty"`    // Paths beyond ProjectPath

--- a/internal/session/issue924_account_field_test.go
+++ b/internal/session/issue924_account_field_test.go
@@ -1,0 +1,196 @@
+// Issue #924 — per-session named account slot (Option 1 MVP).
+//
+// These tests lock the schema migration, persistence round-trip, and
+// SetField surface for the new Instance.Account field. The companion
+// resolution + restart tests live in issue924_account_switch_test.go.
+//
+// Bug reporter: @bautrey. Design discussion: github issue #924 (Option 1
+// — lightweight per-session profile slot, no Claude-side changes; the
+// in-flight conversation is intentionally lost on switch).
+package session
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+// TestPersistence_Account_RoundTrip locks that an instance's Account
+// field survives Save → Load via both LoadWithGroups (the canonical
+// path) and LoadLite (the CLI fast-path).
+func TestPersistence_Account_RoundTrip(t *testing.T) {
+	s := newTestStorage(t)
+
+	instances := []*Instance{
+		{
+			ID:          "with-account",
+			Title:       "work-session",
+			ProjectPath: "/tmp/p1",
+			GroupPath:   "grp",
+			Command:     "claude",
+			Tool:        "claude",
+			Status:      StatusIdle,
+			CreatedAt:   time.Now(),
+			Account:     "work",
+		},
+		{
+			ID:          "no-account",
+			Title:       "default-session",
+			ProjectPath: "/tmp/p2",
+			GroupPath:   "grp",
+			Command:     "claude",
+			Tool:        "claude",
+			Status:      StatusIdle,
+			CreatedAt:   time.Now(),
+		},
+	}
+
+	if err := s.SaveWithGroups(instances, nil); err != nil {
+		t.Fatalf("SaveWithGroups failed: %v", err)
+	}
+
+	loaded, _, err := s.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups failed: %v", err)
+	}
+	byID := map[string]*Instance{}
+	for _, inst := range loaded {
+		byID[inst.ID] = inst
+	}
+	if got := byID["with-account"].Account; got != "work" {
+		t.Errorf("with-account.Account = %q, want %q (lost on round-trip)", got, "work")
+	}
+	if got := byID["no-account"].Account; got != "" {
+		t.Errorf("no-account.Account = %q, want empty (default must not leak)", got)
+	}
+
+	// LoadLite is the fast-path used by every CLI subcommand — it must
+	// surface Account too or `session set` reads would see stale state.
+	lite, _, err := s.LoadLite()
+	if err != nil {
+		t.Fatalf("LoadLite failed: %v", err)
+	}
+	liteByID := map[string]*InstanceData{}
+	for _, d := range lite {
+		liteByID[d.ID] = d
+	}
+	if got := liteByID["with-account"].Account; got != "work" {
+		t.Errorf("LoadLite with-account.Account = %q, want %q", got, "work")
+	}
+	if got := liteByID["no-account"].Account; got != "" {
+		t.Errorf("LoadLite no-account.Account = %q, want empty", got)
+	}
+}
+
+// TestPersistence_Account_SchemaMigration locks the v9 ALTER migration:
+// a DB created at the pre-#924 schema and then upgraded MUST gain the
+// `account` column with default ” so legacy rows load cleanly.
+func TestPersistence_Account_SchemaMigration(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "state.db")
+
+	// Open + migrate twice — the second open simulates an upgrade. With
+	// the alterMigrations entry being idempotent (duplicate-column
+	// ignore) and the v9 version-gated migration also being idempotent,
+	// both must succeed without error.
+	for i := 0; i < 2; i++ {
+		db, err := statedb.Open(dbPath)
+		if err != nil {
+			t.Fatalf("open pass %d: %v", i, err)
+		}
+		if err := db.Migrate(); err != nil {
+			t.Fatalf("migrate pass %d: %v", i, err)
+		}
+		// Sanity check: save and reload a row carrying Account to confirm
+		// the column is functionally present (not just declared).
+		row := &statedb.InstanceRow{
+			ID:          "m1",
+			Title:       "migrated",
+			ProjectPath: "/tmp/m",
+			GroupPath:   "grp",
+			Command:     "claude",
+			Tool:        "claude",
+			Status:      "idle",
+			CreatedAt:   time.Now(),
+			Account:     "work",
+		}
+		if err := db.SaveInstance(row); err != nil {
+			t.Fatalf("SaveInstance pass %d: %v", i, err)
+		}
+		rows, err := db.LoadInstances()
+		if err != nil {
+			t.Fatalf("LoadInstances pass %d: %v", i, err)
+		}
+		if len(rows) != 1 {
+			t.Fatalf("pass %d: expected 1 row, got %d", i, len(rows))
+		}
+		if rows[0].Account != "work" {
+			t.Errorf("pass %d: row.Account = %q, want %q", i, rows[0].Account, "work")
+		}
+		db.Close()
+	}
+}
+
+// TestSetField_Account_RoundTrip locks that the session-set field name
+// "account" (FieldAccount) hits the right struct field, normalises
+// whitespace, and that the empty string clears the slot.
+func TestSetField_Account_RoundTrip(t *testing.T) {
+	inst := &Instance{ID: "x", Tool: "claude"}
+
+	old, _, err := SetField(inst, FieldAccount, "  work  ", nil)
+	if err != nil {
+		t.Fatalf("SetField(account=work) returned err: %v", err)
+	}
+	if old != "" {
+		t.Errorf("first set: oldValue = %q, want empty", old)
+	}
+	if inst.Account != "work" {
+		t.Errorf("Account after set = %q, want %q (whitespace not trimmed)", inst.Account, "work")
+	}
+
+	old, _, err = SetField(inst, FieldAccount, "personal", nil)
+	if err != nil {
+		t.Fatalf("SetField(account=personal) returned err: %v", err)
+	}
+	if old != "work" {
+		t.Errorf("second set: oldValue = %q, want %q", old, "work")
+	}
+	if inst.Account != "personal" {
+		t.Errorf("Account = %q, want %q", inst.Account, "personal")
+	}
+
+	// Empty clears the override — restart-required policy means the
+	// next start falls back to conductor/group/env (validated in the
+	// switch test).
+	if _, _, err := SetField(inst, FieldAccount, "", nil); err != nil {
+		t.Fatalf("SetField(account=\"\") returned err: %v", err)
+	}
+	if inst.Account != "" {
+		t.Errorf("Account after clear = %q, want empty", inst.Account)
+	}
+}
+
+// TestSetField_Account_IsRestartRequired locks the restart policy:
+// switching the account dir mid-session means the new account's
+// settings.json / history live elsewhere, so the running conversation
+// cannot continue without a restart. This is the Option 1 MVP tradeoff.
+func TestSetField_Account_IsRestartRequired(t *testing.T) {
+	if got := RestartPolicyFor(FieldAccount); got != FieldRestartRequired {
+		t.Errorf("RestartPolicyFor(%q) = %v, want FieldRestartRequired — switching account changes CLAUDE_CONFIG_DIR and loses in-flight conversation", FieldAccount, got)
+	}
+}
+
+// TestValidMutableFields_IncludesAccount locks that the field is
+// advertised through the canonical mutable-field list (the CLI usage
+// message and TUI edit dialog read from this slice — without it, the
+// flag is invisible).
+func TestValidMutableFields_IncludesAccount(t *testing.T) {
+	for _, f := range ValidMutableFields {
+		if f == FieldAccount {
+			return
+		}
+	}
+	t.Errorf("FieldAccount missing from ValidMutableFields; CLI/TUI surfaces won't list it")
+}

--- a/internal/session/issue924_account_switch_test.go
+++ b/internal/session/issue924_account_switch_test.go
@@ -1,0 +1,239 @@
+// Issue #924 — per-session account switch behavior.
+//
+// Locks the resolver wiring: when Instance.Account names a profile that
+// has a [profiles.<name>.claude].config_dir block, the spawn env's
+// CLAUDE_CONFIG_DIR and the AGENTDECK_RESOLVED_* hint vars (#925) both
+// reflect the account-level dir. Clearing the field falls back through
+// the existing chain. The source label "account" appears in CFG-07
+// observability.
+//
+// Bug reporter: @bautrey. Companion: issue924_account_field_test.go.
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withTempAgentDeckHome sets up an isolated $HOME with a freshly-rendered
+// ~/.agent-deck/config.toml and clears the user-config cache so the next
+// LoadUserConfig picks up the new file. Returns the resolved
+// ~/.claude-* directories caller-named via `wantedAccounts`.
+//
+// The caller usually wants to assert both that the named account
+// resolves *and* that a different account resolves to its own dir, so
+// the helper writes both blocks.
+func withTempAgentDeckHome(t *testing.T, tomlBody string) (tmpHome string) {
+	t.Helper()
+	tmpHome = t.TempDir()
+	origHome := os.Getenv("HOME")
+	origProfile := os.Getenv("AGENTDECK_PROFILE")
+	origEnvDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origProfile != "" {
+			_ = os.Setenv("AGENTDECK_PROFILE", origProfile)
+		} else {
+			_ = os.Unsetenv("AGENTDECK_PROFILE")
+		}
+		if origEnvDir != "" {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", origEnvDir)
+		} else {
+			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+		}
+		ClearUserConfigCache()
+	})
+	_ = os.Setenv("HOME", tmpHome)
+	_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+	_ = os.Unsetenv("AGENTDECK_PROFILE")
+
+	agentDeckDir := filepath.Join(tmpHome, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDeckDir, "config.toml"), []byte(tomlBody), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	ClearUserConfigCache()
+	return tmpHome
+}
+
+// TestAccount_ResolvesToProfileConfigDir locks the resolver:
+// Instance.Account="work" must select [profiles.work.claude].config_dir.
+func TestAccount_ResolvesToProfileConfigDir(t *testing.T) {
+	tmpHome := withTempAgentDeckHome(t, `
+[profiles.work.claude]
+config_dir = "~/.claude-work"
+
+[profiles.personal.claude]
+config_dir = "~/.claude-personal"
+`)
+
+	inst := &Instance{
+		ID:          "switch-1",
+		Tool:        "claude",
+		Title:       "switch-test",
+		ProjectPath: "/tmp/p",
+		GroupPath:   "default",
+		Account:     "work",
+	}
+	got, source := GetClaudeConfigDirSourceForInstance(inst)
+	wantPath := filepath.Join(tmpHome, ".claude-work")
+	if got != wantPath {
+		t.Errorf("Account=work: got dir=%q, want %q", got, wantPath)
+	}
+	if source != "account" {
+		t.Errorf("Account=work: source label = %q, want %q (CFG-07 observability)", source, "account")
+	}
+
+	// Switch to the other account — same resolver, different output.
+	inst.Account = "personal"
+	got, source = GetClaudeConfigDirSourceForInstance(inst)
+	wantPath = filepath.Join(tmpHome, ".claude-personal")
+	if got != wantPath {
+		t.Errorf("Account=personal: got dir=%q, want %q", got, wantPath)
+	}
+	if source != "account" {
+		t.Errorf("Account=personal: source label = %q, want %q", source, "account")
+	}
+}
+
+// TestAccount_BeatsConductor_AndGroup locks the priority: Account is
+// the most-specific level. With a conductor name AND a group block
+// both configured, the per-session Account must still win.
+func TestAccount_BeatsConductor_AndGroup(t *testing.T) {
+	tmpHome := withTempAgentDeckHome(t, `
+[profiles.work.claude]
+config_dir = "~/.claude-account-wins"
+
+[conductors."mybot".claude]
+config_dir = "~/.claude-conductor-loses"
+
+[groups."mygroup".claude]
+config_dir = "~/.claude-group-loses"
+`)
+
+	inst := &Instance{
+		ID:          "priority-1",
+		Tool:        "claude",
+		Title:       "conductor-mybot",
+		ProjectPath: "/tmp/p",
+		GroupPath:   "mygroup",
+		Account:     "work",
+	}
+	got, source := GetClaudeConfigDirSourceForInstance(inst)
+	wantPath := filepath.Join(tmpHome, ".claude-account-wins")
+	if got != wantPath {
+		t.Errorf("Account must beat conductor+group: got=%q want=%q (source=%q)", got, wantPath, source)
+	}
+	if source != "account" {
+		t.Errorf("source label = %q, want %q", source, "account")
+	}
+
+	// Clear Account — chain should fall through to conductor (its level
+	// beats group, per the existing #881 fix).
+	inst.Account = ""
+	got, source = GetClaudeConfigDirSourceForInstance(inst)
+	wantPath = filepath.Join(tmpHome, ".claude-conductor-loses")
+	if got != wantPath {
+		t.Errorf("After clearing Account, conductor must take over: got=%q want=%q (source=%q)", got, wantPath, source)
+	}
+	if source != "conductor" {
+		t.Errorf("after Account cleared: source = %q, want %q", source, "conductor")
+	}
+}
+
+// TestAccount_UnknownNameFallsThrough locks the permissive behaviour:
+// an Account name with no matching [profiles.<name>] block silently
+// falls through to the existing chain, never erroring.
+func TestAccount_UnknownNameFallsThrough(t *testing.T) {
+	tmpHome := withTempAgentDeckHome(t, `
+[profiles.work.claude]
+config_dir = "~/.claude-work"
+
+[groups."default".claude]
+config_dir = "~/.claude-group"
+`)
+
+	inst := &Instance{
+		ID:          "unknown-1",
+		Tool:        "claude",
+		Title:       "unknown-account",
+		ProjectPath: "/tmp/p",
+		GroupPath:   "default",
+		Account:     "does-not-exist",
+	}
+	got, source := GetClaudeConfigDirSourceForInstance(inst)
+	wantPath := filepath.Join(tmpHome, ".claude-group")
+	if got != wantPath {
+		t.Errorf("unknown Account must fall through to group: got=%q want=%q (source=%q)", got, wantPath, source)
+	}
+	if source != "group" {
+		t.Errorf("source label = %q, want %q", source, "group")
+	}
+}
+
+// TestAccount_SwitchChangesSpawnEnv locks the end-to-end MVP behaviour:
+// flipping Instance.Account and calling buildClaudeCommand emits a
+// different CLAUDE_CONFIG_DIR in the spawn env. This is exactly what
+// "stop + restart with new account" gets after persistence — proving
+// the resolver wires through the actual spawn path.
+func TestAccount_SwitchChangesSpawnEnv(t *testing.T) {
+	withTelegramConductorPresent(t)
+	tmpHome := withTempAgentDeckHome(t, `
+[profiles.work.claude]
+config_dir = "~/.claude-work"
+
+[profiles.personal.claude]
+config_dir = "~/.claude-personal"
+`)
+
+	// Pre-seed both account dirs so EnsureWorkerScratchConfigDir doesn't
+	// trip on missing source profiles when the spawn path runs.
+	for _, name := range []string{".claude-work", ".claude-personal"} {
+		dir := filepath.Join(tmpHome, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(`{}`), 0o644); err != nil {
+			t.Fatalf("seed settings.json: %v", err)
+		}
+	}
+
+	inst := &Instance{
+		ID:          "00000000-0000-0000-0000-000000000924",
+		Tool:        "claude",
+		Title:       "issue-924",
+		ProjectPath: filepath.Join(tmpHome, "proj"),
+		GroupPath:   "default",
+		Account:     "work",
+	}
+
+	cmdWork := inst.buildClaudeCommand("claude")
+	wantWorkHint := "AGENTDECK_RESOLVED_CONFIG_DIR=" + filepath.Join(tmpHome, ".claude-work")
+	if !strings.Contains(cmdWork, wantWorkHint) {
+		t.Errorf("Account=work spawn must contain %q;\ngot: %s", wantWorkHint, cmdWork)
+	}
+	wantWorkSource := "AGENTDECK_RESOLVED_SOURCE=account"
+	if !strings.Contains(cmdWork, wantWorkSource) {
+		t.Errorf("Account=work spawn must label source via %q;\ngot: %s", wantWorkSource, cmdWork)
+	}
+
+	// Switch to the other account — same instance, new spawn env.
+	inst.Account = "personal"
+	// Drop the prior worker-scratch dir so the next spawn re-derives it
+	// from the new source profile (otherwise EnsureWorkerScratchConfigDir
+	// would skip and we'd be testing stale state, not the switch).
+	inst.WorkerScratchConfigDir = ""
+
+	cmdPersonal := inst.buildClaudeCommand("claude")
+	wantPersonalHint := "AGENTDECK_RESOLVED_CONFIG_DIR=" + filepath.Join(tmpHome, ".claude-personal")
+	if !strings.Contains(cmdPersonal, wantPersonalHint) {
+		t.Errorf("Account=personal spawn must contain %q;\ngot: %s", wantPersonalHint, cmdPersonal)
+	}
+	if strings.Contains(cmdPersonal, wantWorkHint) {
+		t.Errorf("Account=personal spawn must NOT carry the old work hint;\ngot cmd containing %q: %s", wantWorkHint, cmdPersonal)
+	}
+}

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -29,6 +29,7 @@ const (
 	FieldNoTransitionNotify = "no-transition-notify"
 	FieldSkipPermissions    = "skip-permissions"
 	FieldAutoMode           = "auto-mode"
+	FieldAccount            = "account" // #924 per-session named account slot
 )
 
 var ValidMutableFields = []string{
@@ -48,6 +49,7 @@ var ValidMutableFields = []string{
 	FieldNoTransitionNotify,
 	FieldSkipPermissions,
 	FieldAutoMode,
+	FieldAccount,
 }
 
 type FieldRestartPolicy int
@@ -60,7 +62,7 @@ const (
 func RestartPolicyFor(field string) FieldRestartPolicy {
 	switch field {
 	case FieldCommand, FieldWrapper, FieldTool, FieldChannels, FieldPlugins, FieldExtraArgs, FieldPath,
-		FieldSkipPermissions, FieldAutoMode:
+		FieldSkipPermissions, FieldAutoMode, FieldAccount:
 		return FieldRestartRequired
 	default:
 		return FieldLive
@@ -275,6 +277,15 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 		if err != nil {
 			return oldValue, nil, err
 		}
+
+	case FieldAccount:
+		// #924 per-session named account slot. Stored verbatim; an
+		// unconfigured name silently falls through the resolver chain.
+		// Empty string clears the override (back to conductor/group/env).
+		// Restart required (see RestartPolicyFor) — the in-flight
+		// conversation is lost, that's the documented Option 1 tradeoff.
+		oldValue = inst.Account
+		inst.Account = strings.TrimSpace(value)
 
 	default:
 		return "", nil, &MutationError{

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -63,6 +63,10 @@ type InstanceData struct {
 	WorktreeRepoRoot string `json:"worktree_repo_root,omitempty"`
 	WorktreeBranch   string `json:"worktree_branch,omitempty"`
 
+	// Account is the per-session named account (issue #924). See
+	// Instance.Account for full semantics.
+	Account string `json:"account,omitempty"`
+
 	// Claude session (persisted for resume after app restart)
 	ClaudeSessionID  string    `json:"claude_session_id,omitempty"`
 	ClaudeDetectedAt time.Time `json:"claude_detected_at,omitempty"`
@@ -653,6 +657,7 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 		WorktreePath:       inst.WorktreePath,
 		WorktreeRepo:       inst.WorktreeRepoRoot,
 		WorktreeBranch:     inst.WorktreeBranch,
+		Account:            inst.Account,
 		ToolData:           toolData,
 	}, nil
 }
@@ -763,6 +768,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			WorktreePath:              r.WorktreePath,
 			WorktreeRepoRoot:          r.WorktreeRepo,
 			WorktreeBranch:            r.WorktreeBranch,
+			Account:                   r.Account,
 			ClaudeSessionID:           claudeSID,
 			ClaudeDetectedAt:          claudeAt,
 			GeminiSessionID:           geminiSID,
@@ -876,6 +882,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			WorktreePath:              r.WorktreePath,
 			WorktreeRepoRoot:          r.WorktreeRepo,
 			WorktreeBranch:            r.WorktreeBranch,
+			Account:                   r.Account,
 			ClaudeSessionID:           claudeSID,
 			ClaudeDetectedAt:          claudeAt,
 			GeminiSessionID:           geminiSID,
@@ -1123,6 +1130,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			WorktreePath:              instData.WorktreePath,
 			WorktreeRepoRoot:          instData.WorktreeRepoRoot,
 			WorktreeBranch:            instData.WorktreeBranch,
+			Account:                   instData.Account,
 			TmuxSocketName:            instData.TmuxSocketName,
 			ClaudeSessionID:           instData.ClaudeSessionID,
 			ClaudeDetectedAt:          instData.ClaudeDetectedAt,

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -54,7 +54,7 @@ func withBusyRetry(op func() error) error {
 
 // SchemaVersion tracks the current database schema version.
 // Bump this when adding migrations.
-const SchemaVersion = 7
+const SchemaVersion = 9
 
 // StateDB wraps a SQLite database for session/group persistence.
 // Thread-safe for concurrent use from multiple goroutines within one process.
@@ -90,7 +90,12 @@ type InstanceRow struct {
 	WorktreePath   string
 	WorktreeRepo   string
 	WorktreeBranch string
-	ToolData       json.RawMessage // JSON blob for tool-specific data
+	// Account is the per-session named account (v1.9.22+, issue #924). Maps to
+	// `[profiles.<account>.claude].config_dir` at spawn time and becomes the
+	// most-specific level in the CLAUDE_CONFIG_DIR resolution chain. Empty
+	// means "fall through to conductor/group/env/profile/global/default".
+	Account  string
+	ToolData json.RawMessage // JSON blob for tool-specific data
 }
 
 // WatcherRow represents a watcher row in the database.
@@ -273,6 +278,7 @@ func (s *StateDB) Migrate() error {
 			worktree_path     TEXT NOT NULL DEFAULT '',
 			worktree_repo     TEXT NOT NULL DEFAULT '',
 			worktree_branch   TEXT NOT NULL DEFAULT '',
+			account           TEXT NOT NULL DEFAULT '',
 			tool_data       TEXT NOT NULL DEFAULT '{}',
 			acknowledged    INTEGER NOT NULL DEFAULT 0
 		)
@@ -415,6 +421,10 @@ func (s *StateDB) Migrate() error {
 		// v8 (issue #697, v1.7.52): title lock blocks Claude session-name sync.
 		// Default 0 keeps the pre-v1.7.52 behavior (#572 sync default-on) for existing rows.
 		"ALTER TABLE instances ADD COLUMN title_locked INTEGER NOT NULL DEFAULT 0",
+		// v9 (issue #924): per-session named account. Default '' preserves
+		// the pre-v1.9.22 behavior for legacy rows (fall through to
+		// conductor/group/env/profile/global/default).
+		"ALTER TABLE instances ADD COLUMN account TEXT NOT NULL DEFAULT ''",
 	}
 	for _, stmt := range alterMigrations {
 		if _, err := tx.Exec(stmt); err != nil {
@@ -465,6 +475,13 @@ func (s *StateDB) Migrate() error {
 			if _, err := tx.Exec(`ALTER TABLE instances ADD COLUMN title_locked INTEGER NOT NULL DEFAULT 0`); err != nil {
 				if !strings.Contains(err.Error(), "duplicate column") {
 					return fmt.Errorf("statedb: migrate v8 title_locked: %w", err)
+				}
+			}
+		}
+		if oldVer < 9 {
+			if _, err := tx.Exec(`ALTER TABLE instances ADD COLUMN account TEXT NOT NULL DEFAULT ''`); err != nil {
+				if !strings.Contains(err.Error(), "duplicate column") {
+					return fmt.Errorf("statedb: migrate v9 account: %w", err)
 				}
 			}
 		}
@@ -523,15 +540,15 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 			command, wrapper, tool, status, tmux_session, tmux_socket_name,
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
-			worktree_path, worktree_repo, worktree_branch,
+			worktree_path, worktree_repo, worktree_branch, account,
 			tool_data, title_locked
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		inst.ID, inst.Title, inst.ProjectPath, inst.GroupPath, inst.Order,
 		inst.Command, inst.Wrapper, inst.Tool, inst.Status, inst.TmuxSession, inst.TmuxSocketName,
 		inst.CreatedAt.Unix(), inst.LastAccessed.Unix(),
 		inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
-		inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch,
+		inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch, inst.Account,
 		string(toolData), titleLockedInt,
 	)
 	return err
@@ -623,9 +640,9 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 			command, wrapper, tool, status, tmux_session, tmux_socket_name,
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
-			worktree_path, worktree_repo, worktree_branch,
+			worktree_path, worktree_repo, worktree_branch, account,
 			tool_data, title_locked
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return err
@@ -657,7 +674,7 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 			inst.Command, inst.Wrapper, inst.Tool, inst.Status, inst.TmuxSession, inst.TmuxSocketName,
 			inst.CreatedAt.Unix(), inst.LastAccessed.Unix(),
 			inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
-			inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch,
+			inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch, inst.Account,
 			string(toolData), titleLockedInt,
 		); err != nil {
 			return err
@@ -674,7 +691,7 @@ func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
 			command, wrapper, tool, status, tmux_session, tmux_socket_name,
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
-			worktree_path, worktree_repo, worktree_branch,
+			worktree_path, worktree_repo, worktree_branch, account,
 			tool_data, title_locked
 		FROM instances ORDER BY sort_order
 	`)
@@ -694,7 +711,7 @@ func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
 			&r.Command, &r.Wrapper, &r.Tool, &r.Status, &r.TmuxSession, &r.TmuxSocketName,
 			&createdUnix, &accessedUnix,
 			&r.ParentSessionID, &isConductorInt, &noTransitionNotifyInt,
-			&r.WorktreePath, &r.WorktreeRepo, &r.WorktreeBranch,
+			&r.WorktreePath, &r.WorktreeRepo, &r.WorktreeBranch, &r.Account,
 			&toolDataStr, &titleLockedInt,
 		); err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

Implements the per-session named account slot from [#924](https://github.com/asheshgoplani/agent-deck/issues/924) using **Option 1** (lightweight, no Claude-side changes).

Each session can now belong to a named account via `Instance.Account`. The account name resolves through the existing `[profiles.<account>.claude].config_dir` TOML block and becomes the **most-specific** level of the `CLAUDE_CONFIG_DIR` resolution chain (beats conductor / group / env).

## Design — Option 1 MVP tradeoff

> Each session belongs to a named account. Switching accounts re-launches the session with a different `CLAUDE_CONFIG_DIR` env. Lightweight, no Claude-side changes. Caveat: you lose the in-flight conversation when switching.

The lost conversation is **intentional**: a true mid-conversation account swap would require Claude-Code-side state migration. Option 1 is the smallest possible vertical slice that delivers the user-visible feature today, with a clean place to extend later.

## CLI

```bash
# Create a session bound to the "work" account:
agent-deck add --account work -c claude .

# Switch the account on an existing session (restart-required):
agent-deck session set <id> account personal
```

Configure the account in `~/.agent-deck/config.toml`:

```toml
[profiles.work.claude]
config_dir = "~/.claude-<profile>"

[profiles.personal.claude]
config_dir = "~/.claude-personal"
```

## Resolver priority (instance chain)

1. **`Instance.Account` (#924)** ← new most-specific level
2. `[conductors.<name>.claude].config_dir`
3. `[groups."<group>".claude].config_dir`
4. `CLAUDE_CONFIG_DIR` env
5. `[profiles.<profile>.claude].config_dir`
6. `[claude].config_dir`
7. `~/.claude`

Unknown account names silently fall through — matches the permissive style of the other levels and means `--account someName` is never an error.

## Schema migration

- v9: new `account TEXT NOT NULL DEFAULT ''` column on `instances`
- Idempotent ALTER + version-gated migration; legacy rows load unchanged with `Account=""`

## Tests (9, all green)

`internal/session/issue924_account_field_test.go`:
- `TestPersistence_Account_RoundTrip` — Save/Load via both `LoadWithGroups` and `LoadLite`
- `TestPersistence_Account_SchemaMigration` — two-pass migrate is idempotent
- `TestSetField_Account_RoundTrip` — `session set account` whitespace-trims and clears
- `TestSetField_Account_IsRestartRequired` — locks the MVP tradeoff in code
- `TestValidMutableFields_IncludesAccount`

`internal/session/issue924_account_switch_test.go`:
- `TestAccount_ResolvesToProfileConfigDir` — resolver returns the right path + `source="account"`
- `TestAccount_BeatsConductor_AndGroup` — priority chain locked
- `TestAccount_UnknownNameFallsThrough` — permissive fallback
- `TestAccount_SwitchChangesSpawnEnv` — end-to-end: flipping Account changes the spawn env

Full suite green:
- `go test ./internal/session/... ./internal/statedb/... ./internal/watcher/... -race -count=1`
- `go test ./cmd/agent-deck/... -count=1`

## Scope

- 94 production LOC, 435 test LOC
- TUI keybinding for switching is **deferred** to a follow-up — the prompt mentioned `A` as a possible keybinding but wiring it would push this PR well over the 500-LOC budget. The CLI + persistence + resolver landing first is enough to validate the design and let downstream tooling (conductor, scripts) start using the slot.

Bug reporter: @bautrey — thanks for the original report and design discussion on #924.

## Test plan

- [ ] Pull this branch, add a `[profiles.work.claude]` and `[profiles.personal.claude]` block to `~/.agent-deck/config.toml`
- [ ] `agent-deck add --account work -c claude /tmp/test` — confirm the session spawns with `CLAUDE_CONFIG_DIR` pointing at the `work` dir
- [ ] `agent-deck session set <id> account personal` then restart — confirm the new spawn picks up the `personal` dir
- [ ] `agent-deck session set <id> account ""` then restart — confirm fall-through to conductor/group/env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--account` flag to `agent-deck add` command to set a named account slot per session, enabling selection of profile-specific Claude configuration directories.
  * The account setting is session-persistent and requires a restart for changes to take effect.
  * Account configuration takes priority over other fallback options when determining the Claude config directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1089?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
