### PR TITLE
fix(ui): SSH remote sessions get claude-specific render (closes #1091, follow-up to #1073)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12181,7 +12181,10 @@ func (h *Home) renderRemoteSessionItem(b *strings.Builder, item session.Item, se
 
 	toolStr := ""
 	if rs.Tool != "" {
-		tStyle := DimStyle
+		// #1091: use brand-specific color (claude=orange, gemini=purple, …)
+		// so SSH-remote rows match local rows. Falls back to ColorTextDim
+		// for unknown/empty tool names via GetToolStyle.
+		tStyle := GetToolStyle(rs.Tool)
 		if selected {
 			tStyle = SessionStatusSelStyle
 		}

--- a/internal/ui/issue1091_remote_render_test.go
+++ b/internal/ui/issue1091_remote_render_test.go
@@ -1,0 +1,153 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Force TrueColor so lipgloss emits actual ANSI escapes during tests;
+// otherwise the auto-detect falls back to Ascii under `go test` and
+// strips every color, making the "tool style applied" assertion vacuous.
+// The forceTrueColorProfile helper itself lives in issue391_tui_test.go.
+
+// TestIssue1091_RemoteSession_ToolColorMatchesLocal asserts that a remote
+// session with Tool="claude" renders the tool label using the same
+// brand-specific style (orange) as a local claude session — NOT the
+// generic DimStyle (gray) that the buggy renderer used.
+//
+// Bug: PR #1073 (v1.9.22) propagated the Tool field over the wire so
+// remote sessions know they're "claude", but renderRemoteSessionItem
+// still rendered the tool label with DimStyle, dropping the
+// claude-specific color (Anthropic orange). Reported by @ddorman-dn in
+// #1091 with a screenshot showing colorless "claude"/"shell" labels.
+//
+// Fix: renderRemoteSessionItem must use GetToolStyle(rs.Tool) for the
+// tool label, matching the local renderSessionItem path at home.go:11812.
+func TestIssue1091_RemoteSession_ToolColorMatchesLocal(t *testing.T) {
+	forceTrueColorProfile()
+
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID:         "remote-claude-1",
+		Title:      "my-claude-session",
+		Status:     "running",
+		Tool:       "claude",
+		RemoteName: "myserver",
+	}
+	item := session.Item{
+		Type:          session.ItemTypeRemoteSession,
+		RemoteSession: &remote,
+		RemoteName:    "myserver",
+	}
+
+	var b strings.Builder
+	home.renderRemoteSessionItem(&b, item, false)
+	rendered := b.String()
+
+	// What a local claude session would render for the " claude" tool label.
+	expectedToolLabel := GetToolStyle("claude").Render(" claude")
+	// What the buggy implementation rendered (gray DimStyle).
+	dimToolLabel := DimStyle.Render(" claude")
+
+	if !strings.Contains(rendered, expectedToolLabel) {
+		t.Fatalf("remote claude session must render tool label with GetToolStyle(\"claude\") (orange) "+
+			"to match local renderSessionItem.\n"+
+			"want substring: %q\n"+
+			"got rendered:   %q",
+			expectedToolLabel, rendered)
+	}
+
+	// Sanity: if the tool style and dim style happen to be identical (some
+	// theme edge case), the assertion above already passes — skip the
+	// negative check. Otherwise the remote row must NOT use DimStyle for
+	// the tool, which is the v1.9.22 bug.
+	if expectedToolLabel != dimToolLabel && strings.Contains(rendered, dimToolLabel) {
+		t.Fatalf("remote claude session still rendering tool label with DimStyle (gray) — "+
+			"this is the #1091 regression. rendered: %q", rendered)
+	}
+}
+
+// TestIssue1091_RemoteSession_ToolColorAllTools asserts the brand-color
+// styling works for every tool agent-deck supports remotely, not just
+// claude. Each tool has its own color in ToolStyleCache (claude=orange,
+// gemini=purple, codex=cyan, aider=red, etc.).
+func TestIssue1091_RemoteSession_ToolColorAllTools(t *testing.T) {
+	forceTrueColorProfile()
+
+	tools := []string{"claude", "gemini", "codex", "aider", "opencode", "cursor"}
+
+	for _, tool := range tools {
+		t.Run(tool, func(t *testing.T) {
+			home := NewHome()
+			home.width = 100
+			home.height = 30
+
+			remote := session.RemoteSessionInfo{
+				ID:         "remote-" + tool,
+				Title:      tool + "-session",
+				Status:     "running",
+				Tool:       tool,
+				RemoteName: "myserver",
+			}
+			item := session.Item{
+				Type:          session.ItemTypeRemoteSession,
+				RemoteSession: &remote,
+				RemoteName:    "myserver",
+			}
+
+			var b strings.Builder
+			home.renderRemoteSessionItem(&b, item, false)
+			rendered := b.String()
+
+			expectedToolLabel := GetToolStyle(tool).Render(" " + tool)
+			if !strings.Contains(rendered, expectedToolLabel) {
+				t.Fatalf("remote %s session must render tool label with GetToolStyle(%q).\n"+
+					"want substring: %q\n"+
+					"got rendered:   %q",
+					tool, tool, expectedToolLabel, rendered)
+			}
+		})
+	}
+}
+
+// TestIssue1091_RemoteSession_SelectedStateUnchanged asserts the fix
+// doesn't break selection styling — when the row is selected, the tool
+// label should use the selection style (SessionStatusSelStyle), same as
+// the local render path.
+func TestIssue1091_RemoteSession_SelectedStateUnchanged(t *testing.T) {
+	forceTrueColorProfile()
+
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID:         "remote-claude-1",
+		Title:      "my-claude-session",
+		Status:     "running",
+		Tool:       "claude",
+		RemoteName: "myserver",
+	}
+	item := session.Item{
+		Type:          session.ItemTypeRemoteSession,
+		RemoteSession: &remote,
+		RemoteName:    "myserver",
+	}
+
+	var b strings.Builder
+	home.renderRemoteSessionItem(&b, item, true) // selected=true
+	rendered := b.String()
+
+	expectedToolLabel := SessionStatusSelStyle.Render(" claude")
+	if !strings.Contains(rendered, expectedToolLabel) {
+		t.Fatalf("selected remote claude session must render tool label with SessionStatusSelStyle.\n"+
+			"want substring: %q\n"+
+			"got rendered:   %q",
+			expectedToolLabel, rendered)
+	}
+}


### PR DESCRIPTION
## Summary

- Remote SSH session rows now render the tool label in the same brand color local rows use (claude=orange, gemini=purple, codex=cyan, aider=red, etc.) instead of an always-grey `DimStyle`.
- 1-line render fix in `renderRemoteSessionItem`; 3 new tests (8 subtests) pin the contract against TrueColor escapes.

## The bug (#1091, @ddorman-dn)

On v1.9.22, SSH remote sessions in the dashboard show the tool label text (`claude`, `shell`, ...) but the label is grey, not the brand color local sessions get. Screenshot in #1091 shows colorless `claude` labels — the visual identity that lets users scan a long list for their claude sessions doesn't work for SSH remotes.

@ddorman-dn confirmed reproducibility after upgrading **both** local and remote agent-deck binaries to v1.9.22, so this is not a wire-side / version-mismatch issue.

## Root cause

`renderRemoteSessionItem` (`internal/ui/home.go`) hard-coded `DimStyle` for the tool label regardless of which tool the remote was running:

```go
tStyle := DimStyle             // <-- always grey
if selected { tStyle = SessionStatusSelStyle }
toolStr = tStyle.Render(" " + rs.Tool)
```

The local row renderer at `home.go:11812` uses `GetToolStyle(instTool)`, which returns brand colors from `ToolStyleCache`. The remote renderer just never made the same call. PR #1073 confirmed the wire was already propagating `Tool` and added structural tests — but the render-time style lookup was outside that PR's scope.

## Fix

One-line swap: `tStyle := GetToolStyle(rs.Tool)` instead of `DimStyle`. Selection branch still wins (selected rows keep the selection style). `GetToolStyle` falls back to `ColorTextDim` for empty/unknown tool names, so plain shell remotes look the same as before.

## Tests

Added `internal/ui/issue1091_remote_render_test.go`. All assertions force TrueColor profile (lipgloss strips escapes under `go test` otherwise — same pattern as the #391 tests):

- `TestIssue1091_RemoteSession_ToolColorMatchesLocal` — RED on v1.9.22 main, GREEN with the fix. Asserts the row contains `GetToolStyle("claude").Render(" claude")` (orange) AND does NOT contain `DimStyle.Render(" claude")` (grey).
- `TestIssue1091_RemoteSession_ToolColorAllTools` — same assertion for claude/gemini/codex/aider/opencode/cursor; each remote row must match its local counterpart's color.
- `TestIssue1091_RemoteSession_SelectedStateUnchanged` — selected remote row still uses `SessionStatusSelStyle`. Guards against regressing the selection branch.

## Test plan

- [x] `go test ./internal/ui/... ./internal/session/... -race -count=1` — all pass
- [x] `go build ./...` — clean
- [x] RED phase confirmed on `origin/main` (see commit body for ANSI diff)
- [ ] Manual: @ddorman-dn re-verifies the dashboard against an SSH remote post-merge

## Doesn't break

- Local session rendering (#1076 insert mode, #1071 rename, #1072 status) — not on this path.
- Remote-session tests from #1073 / #1066 — all still pass.
- Selection styling for remote rows — `TestIssue1091_RemoteSession_SelectedStateUnchanged` pins it.

## Credit

Bug report and reproduction screenshot from @ddorman-dn (#1091). Thanks for the version-mismatch ruling-out cycle — saved us from shipping the wrong fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote session tool labels now display with correct tool-specific brand colors, aligning with local session styling. Selection state styling is preserved.

* **Tests**
  * Added test coverage for remote session rendering to verify tool-specific styling and selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->