### PR TITLE
fix(ui): insert mode supports Backspace, arrows, control keys + batches for latency (closes #1094, follow-up to #1076)

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3970,6 +3970,17 @@ func (s *Session) SendEnter() error {
 	return cmd.Run()
 }
 
+// SendNamedKey sends a single tmux named key (e.g. "BSpace", "Up", "Down",
+// "Left", "Right", "Tab", "BTab", "C-c", "C-d") to the session. Unlike
+// SendKeys it does NOT use the -l flag, so tmux interprets the argument as a
+// key name rather than literal text. Used by insert mode (#1094) to forward
+// Backspace, arrow keys, Tab, and Ctrl-{C,D} from the TUI to the focused pane.
+func (s *Session) SendNamedKey(key string) error {
+	s.invalidateCache()
+	cmd := s.tmuxCmd("send-keys", "-t", s.Name, key)
+	return cmd.Run()
+}
+
 // SendKeysAndEnter sends literal text followed by Enter as two separate tmux
 // calls with a short delay between them. The delay is necessary because tmux
 // 3.2+ wraps send-keys -l in bracketed paste sequences (\e[200~...\e[201~).

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -484,6 +484,20 @@ type Home struct {
 	// without running real tmux. When nil, keys are sent via the session's
 	// tmux pane (SendKeys / SendEnter).
 	insertKeySink func(inst *session.Instance, text string, sendEnter bool) error
+	// insertNamedKeySink is the test override for forwarded named keys
+	// (Backspace, arrows, Tab, Ctrl-C, Ctrl-D — #1094). When nil, named keys
+	// are sent via the session's tmux pane (SendNamedKey).
+	insertNamedKeySink func(inst *session.Instance, key string) error
+
+	// Insert-mode keystroke batching (#1094). Per-keystroke tmux send-keys
+	// invocations are too slow when typing fast. Runes are accumulated in
+	// insertBuf and flushed together after insertBatchDuration, or
+	// immediately on Enter / Esc / a named key. insertBatchDuration <= 0
+	// disables batching (each rune flushes synchronously) and is used by
+	// tests that want to assert call counts deterministically.
+	insertBuf           strings.Builder
+	insertFlushPending  bool
+	insertBatchDuration time.Duration
 }
 
 // reloadState preserves UI state during storage reload
@@ -777,6 +791,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		zoxidePicker:         NewZoxidePicker(),
 		feedbackSender:       feedback.NewSender(),
 		watcherPanel:         NewWatcherPanel(),
+		insertBatchDuration:  defaultInsertBatchDuration,
 		cursor:               0,
 		initialLoading:       true, // Show splash until sessions load
 		ctx:                  ctx,
@@ -3573,6 +3588,18 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			return h.handleMouse(msg)
 		}
+
+	case insertFlushMsg:
+		// Drain any buffered runes from the insert-mode batch (#1094). The
+		// flag is cleared inside flushInsertBuf so a new batch can be
+		// scheduled. If the user already left insert mode we silently drop.
+		if h.insertMode {
+			h.flushInsertBuf()
+		} else {
+			h.insertFlushPending = false
+			h.insertBuf.Reset()
+		}
+		return h, nil
 
 	case loadSessionsMsg:
 		// Clear loading indicators and store file mtime for external change detection

--- a/internal/ui/insert_mode.go
+++ b/internal/ui/insert_mode.go
@@ -2,12 +2,24 @@ package ui
 
 import (
 	"fmt"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
+
+// defaultInsertBatchDuration is the production debounce window for coalescing
+// rune-by-rune typing into a single tmux send-keys call (#1094). Picked to
+// be small enough that the user can't feel it (~one frame at 60Hz) but large
+// enough that bursts of typing collapse into a single fork+exec.
+const defaultInsertBatchDuration = 15 * time.Millisecond
+
+// insertFlushMsg is dispatched by the tea.Tick scheduled when the first rune
+// of a batch is buffered. When it arrives the buffered text is flushed to
+// the focused session.
+type insertFlushMsg struct{}
 
 // Insert mode (#1069 feature 1, by @ddorman-dn): vim-style modal type-through
 // for the TUI. After pressing `I` on a focused session, subsequent keystrokes
@@ -32,39 +44,115 @@ func (h *Home) enterInsertMode() bool {
 	return true
 }
 
-// exitInsertMode returns the TUI to normal navigation mode.
+// exitInsertMode returns the TUI to normal navigation mode. Any pending
+// keystrokes in the batch buffer are dropped — they should have been flushed
+// by the caller via flushInsertBuf() if the user wanted them preserved.
 func (h *Home) exitInsertMode() {
 	h.insertMode = false
 	h.insertModeSessionID = ""
+	h.insertBuf.Reset()
+	h.insertFlushPending = false
 }
 
 // handleInsertModeKey is the keyboard handler used while insert mode is
-// active. Esc exits, Enter sends a newline to the target session, and
-// printable runes (and the space key) are forwarded literally. Other
-// meta-keys (arrows, ctrl combos, Tab, Backspace, function keys) are
-// intentionally ignored in v1 — they remain reserved for future expansion
-// and shouldn't accidentally leak into the session's input stream.
+// active. Esc exits, Enter sends a newline, and printable runes (and the
+// space key) are buffered then flushed in batches to amortize the fork+exec
+// cost of tmux send-keys (#1094 latency). Backspace, arrow keys, Tab,
+// ShiftTab, Ctrl-C, and Ctrl-D are forwarded as tmux named keys so users can
+// edit input and navigate menus inside the focused session (claude often
+// shows arrow-driven pickers).
 func (h *Home) handleInsertModeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyEsc:
+		h.flushInsertBuf()
 		h.exitInsertMode()
 		return h, nil
 	case tea.KeyEnter:
+		h.flushInsertBuf()
 		h.dispatchInsertKey("", true)
 		return h, nil
 	case tea.KeySpace:
-		h.dispatchInsertKey(" ", false)
-		return h, nil
+		h.insertBuf.WriteString(" ")
+		return h, h.scheduleInsertFlush()
 	case tea.KeyRunes:
 		if len(msg.Runes) == 0 {
 			return h, nil
 		}
-		h.dispatchInsertKey(string(msg.Runes), false)
+		h.insertBuf.WriteString(string(msg.Runes))
+		return h, h.scheduleInsertFlush()
+	case tea.KeyBackspace:
+		h.flushInsertBuf()
+		h.dispatchInsertNamedKey("BSpace")
+		return h, nil
+	case tea.KeyUp:
+		h.flushInsertBuf()
+		h.dispatchInsertNamedKey("Up")
+		return h, nil
+	case tea.KeyDown:
+		h.flushInsertBuf()
+		h.dispatchInsertNamedKey("Down")
+		return h, nil
+	case tea.KeyLeft:
+		h.flushInsertBuf()
+		h.dispatchInsertNamedKey("Left")
+		return h, nil
+	case tea.KeyRight:
+		h.flushInsertBuf()
+		h.dispatchInsertNamedKey("Right")
+		return h, nil
+	case tea.KeyTab:
+		h.flushInsertBuf()
+		h.dispatchInsertNamedKey("Tab")
+		return h, nil
+	case tea.KeyShiftTab:
+		h.flushInsertBuf()
+		h.dispatchInsertNamedKey("BTab")
+		return h, nil
+	case tea.KeyCtrlC:
+		h.flushInsertBuf()
+		h.dispatchInsertNamedKey("C-c")
+		return h, nil
+	case tea.KeyCtrlD:
+		h.flushInsertBuf()
+		h.dispatchInsertNamedKey("C-d")
 		return h, nil
 	default:
-		// Drop arrows, ctrl combos, Tab, Backspace, function keys etc. for v1.
+		// Other keys (function keys, more exotic ctrl combos) intentionally
+		// dropped — surface them only if a user actually reports needing them.
 		return h, nil
 	}
+}
+
+// scheduleInsertFlush returns a tea.Cmd that will deliver insertFlushMsg
+// after the batching window, unless one is already pending or batching is
+// disabled (insertBatchDuration <= 0, in which case the buffer flushes
+// synchronously and no Cmd is returned).
+func (h *Home) scheduleInsertFlush() tea.Cmd {
+	if h.insertBatchDuration <= 0 {
+		h.flushInsertBuf()
+		return nil
+	}
+	if h.insertFlushPending {
+		return nil
+	}
+	h.insertFlushPending = true
+	d := h.insertBatchDuration
+	return tea.Tick(d, func(time.Time) tea.Msg { return insertFlushMsg{} })
+}
+
+// flushInsertBuf dispatches any buffered runes to the focused session as a
+// single send-keys call, then clears the buffer. Called from the periodic
+// timer (insertFlushMsg) and synchronously before any non-rune key (Enter,
+// Esc, Backspace, arrows, ...) so the keystroke ordering observed by the
+// target pane matches the order in which the user pressed them.
+func (h *Home) flushInsertBuf() {
+	h.insertFlushPending = false
+	if h.insertBuf.Len() == 0 {
+		return
+	}
+	text := h.insertBuf.String()
+	h.insertBuf.Reset()
+	h.dispatchInsertKey(text, false)
 }
 
 // dispatchInsertKey forwards literal text (optionally followed by Enter) to
@@ -97,6 +185,31 @@ func (h *Home) dispatchInsertKey(text string, sendEnter bool) {
 		if err := tmuxSess.SendEnter(); err != nil {
 			h.setError(fmt.Errorf("insert mode send-enter failed: %w", err))
 		}
+	}
+}
+
+// dispatchInsertNamedKey forwards a tmux named key (Up/Down/Left/Right/Tab/
+// BTab/BSpace/C-c/C-d) to the focused session. In tests an override sink
+// captures the key instead of running tmux.
+func (h *Home) dispatchInsertNamedKey(key string) {
+	inst := h.resolveInsertTarget()
+	if inst == nil {
+		return
+	}
+	if h.insertNamedKeySink != nil {
+		if err := h.insertNamedKeySink(inst, key); err != nil {
+			h.setError(fmt.Errorf("insert mode send named key failed: %w", err))
+		}
+		return
+	}
+	tmuxSess := inst.GetTmuxSession()
+	if tmuxSess == nil {
+		h.exitInsertMode()
+		h.setError(fmt.Errorf("insert mode: tmux session vanished"))
+		return
+	}
+	if err := tmuxSess.SendNamedKey(key); err != nil {
+		h.setError(fmt.Errorf("insert mode send-named-key failed: %w", err))
 	}
 }
 

--- a/internal/ui/issue1069_type_through_test.go
+++ b/internal/ui/issue1069_type_through_test.go
@@ -68,6 +68,11 @@ func armHomeWithOneSession(t *testing.T) (*Home, *session.Instance, *insertSinkC
 	capture := &insertSinkCapture{}
 	home.insertKeySink = capture.sink
 
+	// Disable insert-mode batching (#1094) so per-rune assertions in this
+	// file stay deterministic. Batching is exercised separately in
+	// issue1094_insert_mode_ux_test.go.
+	home.insertBatchDuration = -1
+
 	return home, inst, capture
 }
 

--- a/internal/ui/issue1094_insert_mode_ux_test.go
+++ b/internal/ui/issue1094_insert_mode_ux_test.go
@@ -1,0 +1,328 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Issue #1094 (by @ddorman-dn against v1.9.22): the original insert-mode PR
+// (#1076) dropped Backspace, arrow keys, Tab, and control keys, and shelled
+// out tmux send-keys for each rune — which made typing visibly slow. These
+// tests cover the follow-up fixes: a rune-batching debounce and the missing
+// named-key forwarders.
+
+// namedKeyCapture records every dispatchInsertNamedKey call so assertions
+// can verify named-key forwarding without running real tmux.
+type namedKeyCapture struct {
+	calls []namedKeyCall
+}
+
+type namedKeyCall struct {
+	sessionID string
+	key       string
+}
+
+func (c *namedKeyCapture) sink(inst *session.Instance, key string) error {
+	c.calls = append(c.calls, namedKeyCall{sessionID: inst.ID, key: key})
+	return nil
+}
+
+// arm1094 returns a Home wired with one focused session, both sinks
+// installed, and insert mode already entered (saves boilerplate in every
+// test case). Batch duration defaults to sync — individual tests opt into
+// batching by setting insertBatchDuration > 0.
+func arm1094(t *testing.T) (*Home, *session.Instance, *insertSinkCapture, *namedKeyCapture) {
+	t.Helper()
+	home, inst, runeCap := armHomeWithOneSession(t)
+	namedCap := &namedKeyCapture{}
+	home.insertNamedKeySink = namedCap.sink
+
+	// Enter insert mode.
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	home = model.(*Home)
+	if !home.insertMode {
+		t.Fatal("test setup: failed to enter insert mode")
+	}
+	return home, inst, runeCap, namedCap
+}
+
+// TestIssue1094_Backspace verifies Backspace forwards "BSpace" to the focused
+// session and is NOT swallowed (the v1.9.22 default branch dropped it).
+func TestIssue1094_Backspace(t *testing.T) {
+	home, inst, _, namedCap := arm1094(t)
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	home = model.(*Home)
+
+	if len(namedCap.calls) != 1 {
+		t.Fatalf("Backspace should produce 1 named-key call, got %d", len(namedCap.calls))
+	}
+	if namedCap.calls[0].key != "BSpace" {
+		t.Errorf("Backspace forwarded as %q, want %q", namedCap.calls[0].key, "BSpace")
+	}
+	if namedCap.calls[0].sessionID != inst.ID {
+		t.Errorf("Backspace routed to %q, want %q", namedCap.calls[0].sessionID, inst.ID)
+	}
+	if !home.insertMode {
+		t.Error("Backspace should NOT exit insert mode")
+	}
+}
+
+// TestIssue1094_ArrowKeys verifies Up/Down/Left/Right forward as the
+// corresponding tmux named keys so users can navigate claude pickers.
+func TestIssue1094_ArrowKeys(t *testing.T) {
+	home, _, _, namedCap := arm1094(t)
+
+	cases := []struct {
+		keyType tea.KeyType
+		want    string
+	}{
+		{tea.KeyUp, "Up"},
+		{tea.KeyDown, "Down"},
+		{tea.KeyLeft, "Left"},
+		{tea.KeyRight, "Right"},
+	}
+
+	for _, tc := range cases {
+		model, _ := home.Update(tea.KeyMsg{Type: tc.keyType})
+		home = model.(*Home)
+	}
+
+	if len(namedCap.calls) != len(cases) {
+		t.Fatalf("expected %d named-key calls, got %d", len(cases), len(namedCap.calls))
+	}
+	for i, tc := range cases {
+		if namedCap.calls[i].key != tc.want {
+			t.Errorf("call[%d].key = %q, want %q", i, namedCap.calls[i].key, tc.want)
+		}
+	}
+}
+
+// TestIssue1094_TabAndShiftTab verifies Tab → "Tab" and Shift+Tab → "BTab"
+// so users can step through claude's tab-driven picker UIs.
+func TestIssue1094_TabAndShiftTab(t *testing.T) {
+	home, _, _, namedCap := arm1094(t)
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyTab})
+	home = model.(*Home)
+	model, _ = home.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	home = model.(*Home)
+
+	if len(namedCap.calls) != 2 {
+		t.Fatalf("expected 2 named-key calls (Tab+BTab), got %d", len(namedCap.calls))
+	}
+	if namedCap.calls[0].key != "Tab" {
+		t.Errorf("first call = %q, want Tab", namedCap.calls[0].key)
+	}
+	if namedCap.calls[1].key != "BTab" {
+		t.Errorf("second call = %q, want BTab", namedCap.calls[1].key)
+	}
+}
+
+// TestIssue1094_CtrlCAndCtrlD verifies the two control keys explicitly
+// allow-listed in the spec: C-c (break claude prompt) and C-d (EOF/exit).
+func TestIssue1094_CtrlCAndCtrlD(t *testing.T) {
+	home, _, _, namedCap := arm1094(t)
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	home = model.(*Home)
+	model, _ = home.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	home = model.(*Home)
+
+	if len(namedCap.calls) != 2 {
+		t.Fatalf("expected 2 named-key calls (C-c + C-d), got %d", len(namedCap.calls))
+	}
+	if namedCap.calls[0].key != "C-c" {
+		t.Errorf("Ctrl-C forwarded as %q, want %q", namedCap.calls[0].key, "C-c")
+	}
+	if namedCap.calls[1].key != "C-d" {
+		t.Errorf("Ctrl-D forwarded as %q, want %q", namedCap.calls[1].key, "C-d")
+	}
+	// Ctrl-C in insert mode must NOT exit insert mode — that's Esc's job.
+	// (Exiting on Ctrl-C would surprise users who want to break a claude
+	// prompt without leaving insert mode.)
+	if !home.insertMode {
+		t.Error("Ctrl-C in insert mode should NOT exit insert mode")
+	}
+}
+
+// TestIssue1094_RuneBatching_OneCallPerBurst is the headline latency test:
+// rapid typing must coalesce into a single tmux send-keys call (instead of
+// one fork+exec per keystroke). We arrange for batching to be active, fire
+// the runes that make up "hello", deliver the insertFlushMsg the scheduled
+// tea.Tick would have produced, then assert exactly one sink call with the
+// full word.
+func TestIssue1094_RuneBatching_OneCallPerBurst(t *testing.T) {
+	home, _, runeCap, _ := arm1094(t)
+	home.insertBatchDuration = 15 * time.Millisecond
+
+	for _, r := range "hello" {
+		model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		home = model.(*Home)
+	}
+
+	if len(runeCap.calls) != 0 {
+		t.Fatalf("with batching enabled, no sink call should fire before flush; got %d", len(runeCap.calls))
+	}
+	if !home.insertFlushPending {
+		t.Error("a flush should be pending after the first buffered rune")
+	}
+
+	// Deliver the flush message the way the tea runtime would.
+	model, _ := home.Update(insertFlushMsg{})
+	home = model.(*Home)
+
+	if len(runeCap.calls) != 1 {
+		t.Fatalf("batched flush should produce exactly 1 sink call, got %d", len(runeCap.calls))
+	}
+	if runeCap.calls[0].text != "hello" {
+		t.Errorf("batched text = %q, want %q", runeCap.calls[0].text, "hello")
+	}
+	if home.insertFlushPending {
+		t.Error("insertFlushPending should be cleared after flush")
+	}
+}
+
+// TestIssue1094_NamedKeyFlushesBufferedRunes ensures keystroke ordering is
+// preserved across the batching boundary: if the user types "hi" and then
+// hits Backspace, the focused pane must see "hi" before BSpace — not
+// the other way around because of late flushing.
+func TestIssue1094_NamedKeyFlushesBufferedRunes(t *testing.T) {
+	home, _, runeCap, namedCap := arm1094(t)
+	home.insertBatchDuration = 15 * time.Millisecond
+
+	for _, r := range "hi" {
+		model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		home = model.(*Home)
+	}
+	if len(runeCap.calls) != 0 {
+		t.Fatalf("runes should still be buffered before backspace; got %d", len(runeCap.calls))
+	}
+
+	// Backspace forces an immediate flush, then sends BSpace.
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	home = model.(*Home)
+
+	if len(runeCap.calls) != 1 {
+		t.Fatalf("buffered runes should flush exactly once before backspace; got %d", len(runeCap.calls))
+	}
+	if runeCap.calls[0].text != "hi" {
+		t.Errorf("flushed text = %q, want %q", runeCap.calls[0].text, "hi")
+	}
+	if len(namedCap.calls) != 1 || namedCap.calls[0].key != "BSpace" {
+		t.Errorf("BSpace not forwarded after flush; got namedCap=%+v", namedCap.calls)
+	}
+	if home.insertFlushPending {
+		t.Error("flush should have cleared the pending flag")
+	}
+}
+
+// TestIssue1094_EnterFlushesBufferedRunes is the same ordering invariant
+// for Enter — buffered runes must be sent before the Enter key reaches the
+// pane, otherwise claude sees an empty submission followed by stray runes.
+func TestIssue1094_EnterFlushesBufferedRunes(t *testing.T) {
+	home, _, runeCap, _ := arm1094(t)
+	home.insertBatchDuration = 15 * time.Millisecond
+
+	for _, r := range "hi" {
+		model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		home = model.(*Home)
+	}
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	home = model.(*Home)
+
+	if len(runeCap.calls) != 2 {
+		t.Fatalf("expected flush (text='hi', sendEnter=false) + enter (text='', sendEnter=true); got %d calls: %+v", len(runeCap.calls), runeCap.calls)
+	}
+	if runeCap.calls[0].text != "hi" || runeCap.calls[0].sendEnter {
+		t.Errorf("first call should be text=hi, sendEnter=false; got %+v", runeCap.calls[0])
+	}
+	if runeCap.calls[1].text != "" || !runeCap.calls[1].sendEnter {
+		t.Errorf("second call should be text='', sendEnter=true; got %+v", runeCap.calls[1])
+	}
+}
+
+// TestIssue1094_EscFlushesBufferedRunesAndExits ensures Esc also drains the
+// buffer (so the user doesn't lose typed text by exiting insert mode) and
+// then clears insertMode.
+func TestIssue1094_EscFlushesBufferedRunesAndExits(t *testing.T) {
+	home, _, runeCap, _ := arm1094(t)
+	home.insertBatchDuration = 15 * time.Millisecond
+
+	for _, r := range "ab" {
+		model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		home = model.(*Home)
+	}
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	home = model.(*Home)
+
+	if len(runeCap.calls) != 1 || runeCap.calls[0].text != "ab" {
+		t.Errorf("Esc should flush 'ab' before exiting; got %+v", runeCap.calls)
+	}
+	if home.insertMode {
+		t.Error("Esc should exit insert mode")
+	}
+}
+
+// TestIssue1094_ScheduleInsertFlushIdempotent verifies that piling up runes
+// while a flush is already scheduled does NOT schedule extra ticks. This
+// protects against runaway tea.Cmd queues during fast typing.
+func TestIssue1094_ScheduleInsertFlushIdempotent(t *testing.T) {
+	home, _, _, _ := arm1094(t)
+	home.insertBatchDuration = 50 * time.Millisecond
+
+	model, firstCmd := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	home = model.(*Home)
+	if firstCmd == nil {
+		t.Fatal("first buffered rune should schedule a flush tick")
+	}
+	if !home.insertFlushPending {
+		t.Error("first rune should set insertFlushPending")
+	}
+
+	model, secondCmd := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}})
+	home = model.(*Home)
+	if secondCmd != nil {
+		t.Error("second rune should NOT schedule a duplicate tick while a flush is already pending")
+	}
+}
+
+// TestIssue1094_SyncModeOneCallPerRune verifies that insertBatchDuration<=0
+// reverts to the legacy 1-call-per-rune semantics tests rely on. (Existing
+// #1069 tests depend on this — armHomeWithOneSession sets it explicitly.)
+func TestIssue1094_SyncModeOneCallPerRune(t *testing.T) {
+	home, _, runeCap, _ := arm1094(t)
+	if home.insertBatchDuration > 0 {
+		t.Fatalf("test setup expected sync batching; got %v", home.insertBatchDuration)
+	}
+
+	for _, r := range "xyz" {
+		model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		home = model.(*Home)
+	}
+
+	if len(runeCap.calls) != 3 {
+		t.Fatalf("sync mode should produce 1 call per rune; got %d", len(runeCap.calls))
+	}
+	for i, want := range []string{"x", "y", "z"} {
+		if runeCap.calls[i].text != want {
+			t.Errorf("call[%d].text = %q, want %q", i, runeCap.calls[i].text, want)
+		}
+	}
+}
+
+// TestIssue1094_NewHomeDefaultsToBatching documents the production default —
+// new Home instances batch at defaultInsertBatchDuration so users get the
+// latency fix without opt-in.
+func TestIssue1094_NewHomeDefaultsToBatching(t *testing.T) {
+	h := NewHome()
+	if h.insertBatchDuration != defaultInsertBatchDuration {
+		t.Errorf("NewHome().insertBatchDuration = %v, want %v", h.insertBatchDuration, defaultInsertBatchDuration)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1076 (insert mode). Three UX bugs reported by @ddorman-dn on v1.9.22:

1. **VERY SLOW typing latency** — every keystroke shelled out `tmux send-keys` synchronously, blocking the Bubble Tea event loop. Each fork+exec was 3-10ms, so rapid typing felt sluggish.
2. **No Backspace** — `tea.KeyBackspace` fell through to the `default` branch and was dropped. Users couldn't delete mistakes.
3. **No arrow keys / Tab / Ctrl-C / Ctrl-D** — same drop. Claude's pickers (Up/Down/Tab) were unusable inside insert mode.

## Fixes

- **`internal/tmux`**: new `Session.SendNamedKey(key)` to forward tmux named keys (`BSpace`, `Up`, `Down`, `Left`, `Right`, `Tab`, `BTab`, `C-c`, `C-d`). Distinct from `SendKeys` which uses `-l` for literal text.
- **`internal/ui/insert_mode`**: batch printable runes for ~15ms (`tea.Tick` → `insertFlushMsg` → `flushInsertBuf`) so bursts of typing coalesce into one `send-keys` call. Esc / Enter / any named key flush the buffer **synchronously first** so keystroke order reaching the pane matches the order in which the user pressed them.
- Adds `dispatchInsertNamedKey` + `insertNamedKeySink` test override for deterministic assertions without real tmux.
- `insertBatchDuration <= 0` disables batching (sync per-rune) — used by existing #1069 tests to preserve per-rune call-count assertions.

## Tests

10 new `TestIssue1094_*` cases cover:

- Backspace (forwards `BSpace`, does not exit insert mode)
- Arrow keys (`Up`/`Down`/`Left`/`Right`)
- Tab + ShiftTab (`Tab` + `BTab`)
- Ctrl-C + Ctrl-D
- Rune batching: rapid typing → 1 sink call
- Ordering invariants: named key / Enter / Esc each flush buffered runes **first**
- Idempotent flush scheduling (no duplicate ticks while a flush is pending)
- `NewHome` defaults to production batching

```
$ go test ./internal/ui/ -run "TestIssue109[14]" -count=1
ok  	github.com/asheshgoplani/agent-deck/internal/ui	0.238s
```

Plus full `./internal/ui/` and `./internal/tmux/` suites still pass (`22.9s` + `17.0s`).

## Don't break (verified)

- ✅ Plain rune typing still works (#1076 happy path, sync mode preserved for existing tests)
- ✅ Esc still exits insert mode (and now flushes buffered runes first)
- ✅ Enter still sends newline (and now flushes buffered runes first)
- ✅ Shift+i still enters insert mode (untouched)

## Credit

Thanks to @ddorman-dn for filing the regressions on v1.9.22 immediately after #1076 shipped.

## Test plan

- [x] `go test ./internal/ui/ -run "TestIssue1094|TestIssue1069" -count=1` (all green)
- [x] `go test ./internal/ui/ -count=1` (all green)
- [x] `go test ./internal/tmux/ -count=1` (all green)
- [x] `go build ./...` (clean)
- [ ] Manual verification in a real agent-deck session: type a sentence, hit Backspace, navigate a claude picker with arrows.

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved insert-mode keyboard handling: special keys (Backspace, arrow keys, Tab, Ctrl-C, Ctrl-D) are now properly forwarded to the focused session instead of being dropped.
  * Added input batching in insert mode: rapid keystroke sequences are coalesced and sent together, improving responsiveness.

* **Tests**
  * Added comprehensive test suite for insert-mode keyboard behavior and batching functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->