### PR TITLE
fix(test): drop 3 dead home assignments in issue1094 test (hotfix main)

### DIFF
--- a/internal/ui/issue1094_insert_mode_ux_test.go
+++ b/internal/ui/issue1094_insert_mode_ux_test.go
@@ -110,7 +110,7 @@ func TestIssue1094_TabAndShiftTab(t *testing.T) {
 	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyTab})
 	home = model.(*Home)
 	model, _ = home.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
-	home = model.(*Home)
+	_ = model.(*Home) // assert type, value unused
 
 	if len(namedCap.calls) != 2 {
 		t.Fatalf("expected 2 named-key calls (Tab+BTab), got %d", len(namedCap.calls))
@@ -234,7 +234,7 @@ func TestIssue1094_EnterFlushesBufferedRunes(t *testing.T) {
 	}
 
 	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	home = model.(*Home)
+	_ = model.(*Home) // assert type, value unused
 
 	if len(runeCap.calls) != 2 {
 		t.Fatalf("expected flush (text='hi', sendEnter=false) + enter (text='', sendEnter=true); got %d calls: %+v", len(runeCap.calls), runeCap.calls)
@@ -287,7 +287,7 @@ func TestIssue1094_ScheduleInsertFlushIdempotent(t *testing.T) {
 	}
 
 	model, secondCmd := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}})
-	home = model.(*Home)
+	_ = model.(*Home) // assert type, value unused
 	if secondCmd != nil {
 		t.Error("second rune should NOT schedule a duplicate tick while a flush is already pending")
 	}


### PR DESCRIPTION
Same pattern as #1079. Strict golangci-lint caught 3 SA4006 dead home assignments in #1096's new test file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test assertions for improved code quality without affecting test functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1097?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->