### PR TITLE
fix(ui): wire Shift+Enter to iTerm launcher on darwin (closes #1093, follow-up to #1077)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -777,6 +777,15 @@ func main() {
 	ui.DisableKittyKeyboard(os.Stdout)
 	defer ui.RestoreKittyKeyboard(os.Stdout)
 
+	// Issue #1093: also request xterm modifyOtherKeys mode 1 so iTerm2 (and
+	// other xterm-compatible terminals) send Shift+Enter as a distinct
+	// CSI 27;2;13~ sequence instead of plain '\r'. Without this, Bubble Tea
+	// v1.3.10 cannot distinguish Shift+Enter from Enter on a fresh launch,
+	// and the "open in new iTerm window" binding shipped in #1077 falls
+	// through to the in-pane attach handler. Plain Enter is unaffected.
+	ui.EnableModifyOtherKeys(os.Stdout)
+	defer ui.DisableModifyOtherKeys(os.Stdout)
+
 	p := tea.NewProgram(
 		homeModel,
 		tea.WithAltScreen(),

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -220,6 +220,7 @@ func (h *HelpOverlay) View() string {
 				{"1-9", "Jump to root group"},
 				{"Space", "Jump mode"},
 				{"Enter", "Attach / toggle"},
+				{"Shift+Enter", "Open session in new iTerm window (macOS)"},
 			},
 		},
 		{

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -498,7 +498,11 @@ type Home struct {
 	insertBuf           strings.Builder
 	insertFlushPending  bool
 	insertBatchDuration time.Duration
-}
+// openInNewWindowSink is an optional override used by tests to capture
+	// Shift+Enter dispatches without spawning a real iTerm2 window. When
+	// nil, the dispatch calls terminal.OpenSessionInNewWindow directly.
+	// See issue #1093.
+	openInNewWindowSink func(req terminal.AttachRequest) error}
 
 // reloadState preserves UI state during storage reload
 type reloadState struct {
@@ -542,7 +546,33 @@ func (h *Home) setHotkeys(bindings map[string]string) {
 	}
 }
 
+// openInNewWindow dispatches the Shift+Enter new-window launch through an
+// optional test sink, or falls back to the real terminal launcher.
+//
+// The sessionExists flag short-circuits the real launcher for dead sessions
+// — opening a fresh iTerm2 window only to land on a "tmux: no such session"
+// error is worse UX than a silent no-op. The sink path skips this guard so
+// tests can pin the dispatch without faking tmux state. Issue #1093.
+func (h *Home) openInNewWindow(req terminal.AttachRequest, sessionExists bool) error {
+	if h.openInNewWindowSink != nil {
+		return h.openInNewWindowSink(req)
+	}
+	if !sessionExists {
+		return nil
+	}
+	return terminal.OpenSessionInNewWindow(req)
+}
+
 func (h *Home) normalizeMainKey(pressed string) string {
+	// Shift+Enter relay: csiuReader emits the Private-Use rune
+	// shiftEnterMarker (U+E5E5) when it sees a Shift+Enter CSI u or
+	// modifyOtherKeys sequence (issue #1093). Bubble Tea v1.3.10 has no
+	// native shift+enter string, so we rewrite the rune to the canonical
+	// label here, before any hotkey lookup, so the dispatch arm at
+	// `case "shift+enter":` is reachable.
+	if pressed == string(shiftEnterMarker) {
+		pressed = "shift+enter"
+	}
 	if canonical, ok := h.hotkeyLookup[pressed]; ok {
 		return canonical
 	}
@@ -6008,16 +6038,21 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Open the focused session in a new native terminal window (e.g. a
 		// fresh iTerm2 window on macOS), leaving agent-deck running here.
 		// Issue #1069 feature 2, credit @ddorman-dn.
+		//
+		// Reaching this arm at all required the #1093 fix to keyboard_compat.go
+		// + normalizeMainKey: Bubble Tea v1.3.10 has no shift+enter string,
+		// so we relay Shift+Enter via a Private-Use rune through the input
+		// reader and rewrite it to "shift+enter" before this switch sees it.
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
-			if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.Exists() {
+			if item.Type == session.ItemTypeSession && item.Session != nil {
 				tmuxSess := item.Session.GetTmuxSession()
 				if tmuxSess != nil {
-					err := terminal.OpenSessionInNewWindow(terminal.AttachRequest{
+					req := terminal.AttachRequest{
 						Name:       tmuxSess.Name,
 						SocketName: tmuxSess.SocketName,
-					})
-					if err != nil {
+					}
+					if err := h.openInNewWindow(req, item.Session.Exists()); err != nil {
 						h.setError(fmt.Errorf("open in new window: %w", err))
 					}
 				}

--- a/internal/ui/issue1093_shift_enter_test.go
+++ b/internal/ui/issue1093_shift_enter_test.go
@@ -1,0 +1,174 @@
+package ui
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/terminal"
+)
+
+// Issue #1093 (by @ddorman-dn): Shift+Enter, shipped in #1077, did not actually
+// open the focused session in a new iTerm window on darwin arm64 — it fell
+// through to the plain-Enter handler and replaced the agent-deck screen.
+//
+// Root cause: Bubble Tea v1.3.10 has no native Shift+Enter parsing — its KeyMsg
+// struct has no Shift modifier and its escape-sequence table contains no entry
+// for shift+enter — so a `case "shift+enter":` switch arm was unreachable. The
+// repo's own keyboard_compat layer (which IS where the Shift bit lives, on
+// terminals using CSI u or xterm modifyOtherKeys) was discarding that bit when
+// codepoint==13.
+//
+// These tests pin the fix at the four layers it touches:
+//   1. ParseCSIu preserves Shift on Enter (returns a sentinel distinct from
+//      plain KeyEnter).
+//   2. ParseModifyOtherKeys preserves Shift on Enter.
+//   3. csiuReader translates the on-the-wire bytes into a distinct byte
+//      sequence (NOT plain '\r'), so Bubble Tea can decode it and the home
+//      switch can see it.
+//   4. Home.normalizeMainKey maps that byte sequence to canonical
+//      "shift+enter", so the existing dispatch arm fires.
+//
+// Plain-Enter regression cases are pinned alongside so the fix can't silently
+// break the in-pane attach path.
+
+// TestIssue1093_ParseCSIu_PreservesShiftOnEnter pins the parser contract.
+func TestIssue1093_ParseCSIu_PreservesShiftOnEnter(t *testing.T) {
+	plain := ParseCSIu([]byte("\x1b[13u"))
+	shifted := ParseCSIu([]byte("\x1b[13;2u"))
+
+	if plain == nil || shifted == nil {
+		t.Fatalf("ParseCSIu returned nil: plain=%v shifted=%v", plain, shifted)
+	}
+	if plain.Type != tea.KeyEnter {
+		t.Fatalf("plain Enter should be KeyEnter, got %v", plain.Type)
+	}
+	// The fix point: shifted Enter must NOT be indistinguishable from plain
+	// KeyEnter. The chosen representation is an implementation detail (PUA
+	// rune via KeyRunes), but it must differ from plain KeyEnter so downstream
+	// code can route it to the new-window launcher instead of the attach path.
+	if shifted.Type == tea.KeyEnter && len(shifted.Runes) == 0 {
+		t.Fatalf("Shift+Enter via CSI u was reduced to plain KeyEnter — Shift bit dropped (the #1093 regression)")
+	}
+}
+
+// TestIssue1093_ParseModifyOtherKeys_PreservesShiftOnEnter mirrors the CSI u
+// test for the xterm modifyOtherKeys path. tmux's `extended-keys on` (set on
+// every session by internal/tmux/tmux.go ~1948) leaves the outer iTerm2 in
+// modifyOtherKeys mode after the first attach — so this is the path the live
+// bug report actually hit.
+func TestIssue1093_ParseModifyOtherKeys_PreservesShiftOnEnter(t *testing.T) {
+	plain := ParseModifyOtherKeys([]byte("\x1b[27;1;13~"))
+	shifted := ParseModifyOtherKeys([]byte("\x1b[27;2;13~"))
+
+	if plain == nil || shifted == nil {
+		t.Fatalf("ParseModifyOtherKeys returned nil: plain=%v shifted=%v", plain, shifted)
+	}
+	if plain.Type != tea.KeyEnter {
+		t.Fatalf("plain Enter via modifyOtherKeys should be KeyEnter, got %v", plain.Type)
+	}
+	if shifted.Type == tea.KeyEnter && len(shifted.Runes) == 0 {
+		t.Fatalf("Shift+Enter via modifyOtherKeys was reduced to plain KeyEnter — Shift bit dropped (the #1093 regression)")
+	}
+}
+
+// TestIssue1093_CSIuReader_ShiftEnterEmitsDistinctBytes verifies the reader
+// layer translates Shift+Enter sequences into bytes Bubble Tea will NOT decode
+// as plain Enter ('\r'). This is the layer the live TUI consumes via
+// tea.WithInput(ui.NewCSIuReader(os.Stdin)) in cmd/agent-deck/main.go.
+func TestIssue1093_CSIuReader_ShiftEnterEmitsDistinctBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{"CSI u Shift+Enter", "\x1b[13;2u"},
+		{"modifyOtherKeys Shift+Enter", "\x1b[27;2;13~"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewCSIuReader(bytes.NewReader([]byte(tc.input)))
+			out, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			if string(out) == "\r" || string(out) == "\n" {
+				t.Fatalf("Shift+Enter %q translated to plain Enter (%q) — Bubble Tea will see KeyEnter and fire in-pane attach instead of the launcher",
+					tc.input, string(out))
+			}
+			if len(out) == 0 {
+				t.Fatalf("Shift+Enter %q translated to empty bytes — dropped", tc.input)
+			}
+		})
+	}
+}
+
+// TestIssue1093_CSIuReader_PlainEnterStillEmitsCR pins the non-regression
+// guarantee for plain Enter — every "attach" / "submit" path in the TUI
+// depends on this.
+func TestIssue1093_CSIuReader_PlainEnterStillEmitsCR(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"CSI u plain Enter", "\x1b[13u", "\r"},
+		{"modifyOtherKeys plain Enter", "\x1b[27;1;13~", "\r"},
+		{"raw CR (terminal default Enter)", "\r", "\r"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewCSIuReader(bytes.NewReader([]byte(tc.input)))
+			out, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			if string(out) != tc.want {
+				t.Errorf("plain Enter %q translated to %q, want %q", tc.input, string(out), tc.want)
+			}
+		})
+	}
+}
+
+// TestIssue1093_NormalizeMainKey_MarkerMapsToShiftEnter is the final hop: the
+// PUA rune that csiuReader emits for Shift+Enter must normalize to canonical
+// "shift+enter" so the home.go switch arm fires. Without this mapping the
+// rune would fall through unmatched and Shift+Enter would still silently
+// do nothing.
+func TestIssue1093_NormalizeMainKey_MarkerMapsToShiftEnter(t *testing.T) {
+	home := NewHome()
+	got := home.normalizeMainKey(string(shiftEnterMarker))
+	if got != "shift+enter" {
+		t.Fatalf("normalizeMainKey(shift+enter marker) = %q, want %q", got, "shift+enter")
+	}
+}
+
+// TestIssue1093_HomeDispatch_ShiftEnterCallsLauncher exercises the full
+// keypress → launcher path through the public Home.handleMainKey entrypoint.
+// Synthetic KeyMsg matches what Bubble Tea produces from the UTF-8 bytes of
+// our marker rune. The launcher itself is captured via an injected sink so
+// the test does not spawn an actual iTerm2 window.
+func TestIssue1093_HomeDispatch_ShiftEnterCallsLauncher(t *testing.T) {
+	home, _, _ := armHomeWithOneSession(t)
+
+	var called bool
+	var capturedReq terminal.AttachRequest
+	home.openInNewWindowSink = func(req terminal.AttachRequest) error {
+		called = true
+		capturedReq = req
+		return nil
+	}
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}}
+	if got := home.normalizeMainKey(keyMsg.String()); got != "shift+enter" {
+		t.Fatalf("precondition: normalizeMainKey of synthetic Shift+Enter KeyMsg = %q, want shift+enter", got)
+	}
+
+	_, _ = home.handleMainKey(keyMsg)
+
+	if !called {
+		t.Fatal("Shift+Enter dispatch did NOT call the new-window launcher — fell through to in-pane attach (this is the #1093 regression)")
+	}
+	if capturedReq.Name == "" {
+		t.Errorf("launcher called with empty AttachRequest.Name (got %+v) — handler didn't pull the tmux session name", capturedReq)
+	}
+}

--- a/internal/ui/keyboard_compat.go
+++ b/internal/ui/keyboard_compat.go
@@ -28,6 +28,18 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// shiftEnterMarker is the Unicode Private-Use-Area rune used to relay
+// Shift+Enter from the CSI u / xterm-modifyOtherKeys parser through
+// Bubble Tea v1.3.10 (which has no native Shift+Enter representation) and
+// out to home.go's keybinding switch. It is emitted in UTF-8 form by the
+// csiuReader; Bubble Tea decodes the UTF-8 to a KeyRunes message; and
+// Home.normalizeMainKey rewrites it back to the canonical "shift+enter"
+// string the dispatch switch matches on. See issue #1093.
+// U+E5E5 sits in the Basic Multilingual Plane Private Use Area
+// (U+E000..U+F8FF), which Unicode reserves for application-private use
+// and no standard keyboard or input method can produce.
+const shiftEnterMarker rune = 0xE5E5
+
 // DisableKittyKeyboard writes the escape sequence that pops the Kitty keyboard
 // protocol stack, restoring the previous keyboard mode. If nothing was on the
 // stack, this is a safe no-op. After this call, Kitty-protocol-aware terminals
@@ -64,6 +76,31 @@ func RestoreLegacyKeyboardCmd(w io.Writer) tea.Cmd {
 // return.
 func EnableKittyKeyboard(w io.Writer) {
 	_, _ = io.WriteString(w, "\x1b[>1u")
+}
+
+// EnableModifyOtherKeys writes the xterm escape sequence that requests
+// modifyOtherKeys mode 1: terminals supporting the protocol (iTerm2, xterm,
+// Konsole, …) start sending modified keys — including the previously
+// indistinguishable Shift+Enter — as CSI 27;<modifier>;<codepoint>~
+// sequences rather than the legacy unmodified byte. Unmodified keys still
+// arrive as their normal bytes, so plain Enter is unaffected.
+//
+// This is the upstream half of the #1093 fix: without it, a fresh agent-deck
+// launch in iTerm2 sees plain '\r' for both Enter and Shift+Enter and cannot
+// distinguish them. With it, Shift+Enter arrives as \x1b[27;2;13~ and our
+// csiuReader relays it through to home.go as "shift+enter".
+//
+// Pair with DisableModifyOtherKeys on TUI exit so the user's shell prompt
+// returns to default key-reporting behavior.
+func EnableModifyOtherKeys(w io.Writer) {
+	_, _ = io.WriteString(w, "\x1b[>4;1m")
+}
+
+// DisableModifyOtherKeys writes the xterm escape sequence that returns the
+// terminal to default key reporting (modifyOtherKeys mode 0). Call on TUI
+// exit so the user's shell behaves normally again.
+func DisableModifyOtherKeys(w io.Writer) {
+	_, _ = io.WriteString(w, "\x1b[>4;0m")
 }
 
 // RestoreKittyKeyboard writes the escape sequence that pops the keyboard mode
@@ -133,6 +170,14 @@ func ParseCSIu(data []byte) *tea.KeyMsg {
 	// Map well-known control codepoints to tea key types.
 	switch codepoint {
 	case 13: // CR = Enter
+		if shiftHeld {
+			// Bubble Tea v1.3.10 has no Shift+Enter representation, so we
+			// relay it via a Private-Use-Area rune. home.go's
+			// normalizeMainKey rewrites this back to "shift+enter". See
+			// issue #1093.
+			msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}}
+			return &msg
+		}
 		msg := tea.KeyMsg{Type: tea.KeyEnter}
 		return &msg
 	case 9: // HT = Tab
@@ -219,6 +264,11 @@ func ParseModifyOtherKeys(data []byte) *tea.KeyMsg {
 
 	switch codepoint {
 	case 13:
+		if shiftHeld {
+			// See ParseCSIu / shiftEnterMarker comment. Issue #1093.
+			msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}}
+			return &msg
+		}
 		msg := tea.KeyMsg{Type: tea.KeyEnter}
 		return &msg
 	case 9:


### PR DESCRIPTION
## Summary

v1.9.22 regression: Shift+Enter from #1077 was dead on every platform — pressing it opened the session **in the same terminal window** (replacing agent-deck) instead of a new iTerm window. Reported by @ddorman-dn in #1093.

## Root cause

Bubble Tea v1.3.10 has no native Shift+Enter representation: `tea.KeyMsg` has no Shift modifier, and the escape-sequence table contains no `shift+enter` entry. `msg.String()` can never return `"shift+enter"` — so `home.go`'s `case "shift+enter":` was **unreachable**.

The bit IS visible on the wire via CSI u (`\x1b[13;2u`) and xterm modifyOtherKeys (`\x1b[27;2;13~`) — the repo's own `keyboard_compat.go` parses both — but `ParseCSIu` and `ParseModifyOtherKeys` **discarded the Shift modifier when codepoint==13**, collapsing shifted and unshifted Enter to the same `tea.KeyEnter` → `'\r'`. Bubble Tea then fired the in-pane attach handler at `home.go:6001`.

Two upstream gaps compounded the issue:
1. `main.go` disabled the Kitty keyboard protocol at startup (right for Wayland) but never requested xterm modifyOtherKeys, so iTerm2 on a fresh launch sent plain `'\r'` for both Enter and Shift+Enter — no signal to act on.
2. The binding was missing from the help overlay (per @ddorman-dn follow-up).

## Fix (four layers, mechanically pinned by tests)

1. **`keyboard_compat.go`** — `ParseCSIu` + `ParseModifyOtherKeys` now emit a distinct sentinel (Unicode Private-Use rune **U+E5E5**) for Shift+Enter, so the modifier survives the parser. PUA is unreachable from any keyboard / input method.
2. **`csiuReader.translate()`** — already UTF-8-encodes `KeyRunes`, so the sentinel surfaces to Bubble Tea as a regular `KeyRunes` message no real keyboard can produce.
3. **`home.go`** — `normalizeMainKey` rewrites the sentinel back to canonical `"shift+enter"` before the dispatch switch sees it. The dispatch arm now routes through a new `openInNewWindow` helper that respects an injected sink (for tests) and short-circuits on dead sessions (no point spawning a window only to fail `tmux attach`).
4. **`main.go`** — sends xterm modifyOtherKeys mode-1 enable on TUI start (paired with disable on exit), so iTerm2 sends the extended sequence **even on a fresh launch**, before any tmux negotiation. Mode 1 only affects modified keys — plain Enter is untouched.

Also adds the binding to `help.go`'s NAVIGATION block per @ddorman-dn follow-up:
\`Shift+Enter — Open session in new iTerm window (macOS)\`

## Regression coverage

`internal/ui/issue1093_shift_enter_test.go` pins the fix at every layer:

- \`TestIssue1093_ParseCSIu_PreservesShiftOnEnter\` — parser keeps Shift bit on Enter (vs. dropping it pre-fix).
- \`TestIssue1093_ParseModifyOtherKeys_PreservesShiftOnEnter\` — same for the modifyOtherKeys path tmux uses.
- \`TestIssue1093_CSIuReader_ShiftEnterEmitsDistinctBytes\` — reader emits a sequence Bubble Tea will NOT decode as plain `'\r'`.
- \`TestIssue1093_CSIuReader_PlainEnterStillEmitsCR\` — plain Enter still emits `'\r'` across CSI u, modifyOtherKeys, and raw-CR.
- \`TestIssue1093_NormalizeMainKey_MarkerMapsToShiftEnter\` — sentinel rune normalizes to canonical `"shift+enter"`.
- \`TestIssue1093_HomeDispatch_ShiftEnterCallsLauncher\` — full keypress → launcher path through `Home.handleMainKey` with an injected sink.

## Test plan

- [x] \`go test ./internal/ui/... ./internal/terminal/...\` ✅
- [x] \`go test -race -count=1 ./internal/ui/... ./internal/terminal/...\` ✅
- [x] \`go test -tags eval_smoke ./tests/eval/... ./internal/ui/...\` ✅
- [x] \`go test -count=1 ./cmd/agent-deck/...\` ✅
- [ ] Manual: macOS arm64, fresh agent-deck launch in iTerm2 → focus a running session → Shift+Enter → new iTerm window opens with that session, original agent-deck window unaffected
- [ ] Manual: same flow on Ghostty / Wayland Foot to confirm CSI u path also lands
- [ ] Manual: plain Enter still attaches in-pane (regression check)
- [ ] Manual: \`?\` opens help overlay and shows the new \`Shift+Enter\` row

## Credit

Reported by @ddorman-dn (#1093, follow-up help-overlay note). Original feature in #1077.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift+Enter shortcut now opens the current session in a new iTerm window (macOS); help overlay updated.

* **Improvements**
  * Better keyboard handling to reliably detect Shift+Enter across xterm-compatible and other terminals; enables/restore modified-key reporting during TUI startup.

* **Tests**
  * Added regression tests covering Shift+Enter parsing and dispatch across input layers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->