### PR TITLE
feat(ui): configurable Sessions/Preview split (closes #1092)

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -183,6 +183,46 @@ type UserConfig struct {
 
 	// Web defines `agent-deck web` HTTP server settings.
 	Web WebSettings `toml:"web"`
+
+	// UI defines TUI layout settings (split ratios, etc).
+	UI UISettings `toml:"ui"`
+}
+
+// UISettings controls TUI layout proportions.
+// See issue #1092.
+type UISettings struct {
+	// PreviewPct is the percentage of horizontal width allocated to the
+	// preview pane (sessions list gets the remainder). Valid range: 10-90.
+	// Default: 65 (current behavior — sessions 35 / preview 65).
+	// Adjustable at runtime via < and > keybindings (5% step).
+	PreviewPct int `toml:"preview_pct"`
+}
+
+// DefaultPreviewPct is the default preview-pane width percentage.
+// Matches the historical hardcoded 0.35 sessions / 0.65 preview split.
+const DefaultPreviewPct = 65
+
+// MinPreviewPct and MaxPreviewPct bound the preview width to keep both
+// panes usable.
+const (
+	MinPreviewPct = 10
+	MaxPreviewPct = 90
+)
+
+// GetPreviewPct returns the configured preview percentage, clamped to
+// [MinPreviewPct, MaxPreviewPct]. Falls back to DefaultPreviewPct when
+// unset or out of range.
+func (u UISettings) GetPreviewPct() int {
+	if u.PreviewPct <= 0 {
+		return DefaultPreviewPct
+	}
+	if u.PreviewPct < MinPreviewPct {
+		return MinPreviewPct
+	}
+	if u.PreviewPct > MaxPreviewPct {
+		return MaxPreviewPct
+	}
+	return u.PreviewPct
 }
 
 // WebSettings configures the `agent-deck web` HTTP server.

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -247,6 +247,7 @@ func (h *HelpOverlay) View() string {
 				{skillsKey, "Skills Manager"},
 				{"$", "Cost Dashboard"},
 				{previewKey, "Toggle preview mode (output/stats/both)"},
+				{"< / >", "Shrink / grow preview pane by 5% (issue #1092)"},
 				{unreadKey, "Mark unread"},
 				{quickApproveKey, "Quick approve (send '1' to Claude)"},
 				{reorderUpKeys, "Reorder up (auto-promote at edge)"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -404,6 +404,12 @@ type Home struct {
 	activeFilterLabel    string                  // from config.toml [display] active_filter_label
 	activeFilterExcludes map[session.Status]bool // from config.toml [display] active_filter_excludes; default {error}
 
+	// Sessions/Preview split (issue #1092): percentage of width allocated to
+	// preview pane. Loaded from config.toml [ui] preview_pct, adjustable
+	// live via < and > keybindings, persisted back to config on adjustment.
+	previewPct          int       // 10-90, default 65
+	previewPctOverlayAt time.Time // when to hide the split overlay (zero = hidden)
+
 	// Performance observability (debug mode only, zero cost when off)
 	debugMode          bool         // true when AGENTDECK_DEBUG=1, enables perf overlay
 	lastRenderDuration atomic.Int64 // microseconds, for debug status bar
@@ -843,10 +849,12 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.activeFilterExcludes = cfg.Display.GetActiveFilterExcludes()
 		h.sysStatsConfig = cfg.SystemStats
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(cfg, actualProfile)
+		h.previewPct = cfg.UI.GetPreviewPct()
 	} else {
 		h.fullRepaint = (session.DisplaySettings{}).GetFullRepaint()
 		h.activeFilterExcludes = (session.DisplaySettings{}).GetActiveFilterExcludes()
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(nil, actualProfile)
+		h.previewPct = session.DefaultPreviewPct
 	}
 
 	// Initialize system stats collector if enabled
@@ -3555,7 +3563,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// width column where Y-based routing is ambiguous enough to
 			// leave as list-scroll).
 			if h.getLayoutMode() == LayoutModeDual {
-				leftWidth := int(float64(h.width) * 0.35)
+				leftWidth := h.sessionsPaneWidth()
 				if msg.X >= leftWidth {
 					if msg.Button == tea.MouseButtonWheelUp {
 						h.previewScrollOffset++
@@ -5683,7 +5691,7 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 		// Check if click is in the session list panel
 		if h.getLayoutMode() == LayoutModeDual {
-			leftWidth := int(float64(h.width) * 0.35)
+			leftWidth := h.sessionsPaneWidth()
 			if msg.X >= leftWidth {
 				return h, nil
 			}
@@ -6483,6 +6491,22 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "?":
 		h.helpOverlay.SetSize(h.width, h.height)
 		h.helpOverlay.Show()
+		return h, nil
+
+	case "<":
+		// Sessions/Preview split: shrink preview by previewPctStep (#1092).
+		// Bound to dual layout — single/stacked layouts have no horizontal
+		// split to adjust.
+		if h.getLayoutMode() == LayoutModeDual {
+			h.adjustPreviewPct(-previewPctStep)
+		}
+		return h, nil
+
+	case ">":
+		// Sessions/Preview split: grow preview by previewPctStep (#1092).
+		if h.getLayoutMode() == LayoutModeDual {
+			h.adjustPreviewPct(previewPctStep)
+		}
 		return h, nil
 
 	case "S":
@@ -10471,8 +10495,8 @@ func ensureExactWidth(content string, width int) string {
 func (h *Home) renderDualColumnLayout(contentHeight int) string {
 	var b strings.Builder
 
-	// Calculate panel widths (35% left, 65% right for more preview space)
-	leftWidth := int(float64(h.width) * 0.35)
+	// Calculate panel widths from configurable split (issue #1092 — [ui] preview_pct)
+	leftWidth := h.sessionsPaneWidth()
 	rightWidth := h.width - leftWidth - 3 // -3 for separator
 
 	// Panel title is exactly 2 lines (title + underline)
@@ -10480,15 +10504,24 @@ func (h *Home) renderDualColumnLayout(contentHeight int) string {
 	panelTitleLines := 2
 	panelContentHeight := contentHeight - panelTitleLines
 
-	// Build left panel (session list) with styled title
-	leftTitle := h.renderPanelTitle("SESSIONS", leftWidth)
+	// Build left panel (session list) with styled title.
+	// Issue #1092: when the user just adjusted the split, briefly append
+	// the new ratio to both titles so the change is visible.
+	sessionsTitle := "SESSIONS"
+	previewTitle := "PREVIEW"
+	if !h.previewPctOverlayAt.IsZero() && time.Now().Before(h.previewPctOverlayAt) {
+		pct := h.getPreviewPct()
+		sessionsTitle = fmt.Sprintf("SESSIONS %d%%", 100-pct)
+		previewTitle = fmt.Sprintf("PREVIEW %d%%", pct)
+	}
+	leftTitle := h.renderPanelTitle(sessionsTitle, leftWidth)
 	leftContent := h.renderSessionList(leftWidth, panelContentHeight)
 	// CRITICAL: Ensure left content has exactly panelContentHeight lines
 	leftContent = ensureExactHeight(leftContent, panelContentHeight)
 	leftPanel := leftTitle + "\n" + leftContent
 
 	// Build right panel (preview) with styled title
-	rightTitle := h.renderPanelTitle("PREVIEW", rightWidth)
+	rightTitle := h.renderPanelTitle(previewTitle, rightWidth)
 	rightContent := h.renderPreviewPane(rightWidth, panelContentHeight)
 	// CRITICAL: Ensure right content has exactly panelContentHeight lines
 	rightContent = ensureExactHeight(rightContent, panelContentHeight)

--- a/internal/ui/issue1092_split_test.go
+++ b/internal/ui/issue1092_split_test.go
@@ -1,0 +1,197 @@
+// Issue #1092 — Configurable Sessions/Preview split ratio.
+//
+// Reporter: @ddorman-dn. Previously hardcoded to 35% sessions / 65%
+// preview. Users want to either bias the split toward preview
+// permanently (e.g. 20/80) or adjust it live without restart.
+//
+// Two delivery surfaces:
+//   1. config.toml [ui] preview_pct (10-90)
+//   2. Runtime keybindings: < shrinks preview by 5%, > grows by 5%
+//
+// Bounds [10, 90] keep both panes usable. Adjustments persist back to
+// config.toml so they survive restart.
+
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// setIsolatedAgentDeckDir gives each test its own ~/.agent-deck so
+// SaveUserConfig / LoadUserConfig don't clobber the user's real config
+// or interfere with each other.
+//
+// session.GetAgentDeckDir() resolves via os.UserHomeDir(), which honors
+// HOME on POSIX, so we point HOME at a temp dir and create
+// .agent-deck/ inside it.
+func setIsolatedAgentDeckDir(t *testing.T) string {
+	t.Helper()
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	dir := filepath.Join(tmpHome, ".agent-deck")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir .agent-deck: %v", err)
+	}
+	// LoadUserConfig caches by mtime; reset between tests.
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+	return dir
+}
+
+func TestIssue1092_DefaultSplit_Is65PreviewPct(t *testing.T) {
+	setIsolatedAgentDeckDir(t)
+
+	home := NewHome()
+	home.width = 100
+
+	got := home.getPreviewPct()
+	if got != session.DefaultPreviewPct {
+		t.Fatalf("default preview_pct = %d, want %d (preserve historical 35/65 split)",
+			got, session.DefaultPreviewPct)
+	}
+
+	// sessionsPaneWidth should be 35% of 100 = 35.
+	if w := home.sessionsPaneWidth(); w != 35 {
+		t.Fatalf("sessionsPaneWidth at width=100, preview_pct=65 = %d, want 35", w)
+	}
+}
+
+func TestIssue1092_ConfigOverride_PicksUpCustomValue(t *testing.T) {
+	dir := setIsolatedAgentDeckDir(t)
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("[ui]\npreview_pct = 80\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	session.ClearUserConfigCache()
+
+	cfg, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	if got := cfg.UI.GetPreviewPct(); got != 80 {
+		t.Fatalf("cfg.UI.GetPreviewPct() = %d, want 80 — config not parsed", got)
+	}
+
+	home := NewHome()
+	home.width = 100
+	if got := home.getPreviewPct(); got != 80 {
+		t.Fatalf("home.previewPct after init = %d, want 80 — config not threaded into Home",
+			got)
+	}
+	// 20% of 100 = 20.
+	if w := home.sessionsPaneWidth(); w != 20 {
+		t.Fatalf("sessionsPaneWidth at preview_pct=80 = %d, want 20", w)
+	}
+}
+
+func TestIssue1092_KeybindingShiftsBy5Pct(t *testing.T) {
+	setIsolatedAgentDeckDir(t)
+
+	home := NewHome()
+	home.previewPct = 60 // start from a clean baseline
+
+	if !home.adjustPreviewPct(previewPctStep) {
+		t.Fatalf("expected adjustPreviewPct(+5) to report a change from 60")
+	}
+	if home.getPreviewPct() != 65 {
+		t.Fatalf("after +5: previewPct = %d, want 65", home.getPreviewPct())
+	}
+
+	if !home.adjustPreviewPct(-previewPctStep) {
+		t.Fatalf("expected adjustPreviewPct(-5) to report a change from 65")
+	}
+	if home.getPreviewPct() != 60 {
+		t.Fatalf("after -5: previewPct = %d, want 60", home.getPreviewPct())
+	}
+}
+
+func TestIssue1092_KeybindingClampsToBounds(t *testing.T) {
+	setIsolatedAgentDeckDir(t)
+
+	home := NewHome()
+
+	// Drive the percentage down past the floor.
+	home.previewPct = 12
+	home.adjustPreviewPct(-previewPctStep) // 12 -> 10 (clamped, was 7)
+	if got := home.getPreviewPct(); got != session.MinPreviewPct {
+		t.Fatalf("after -5 from 12: previewPct = %d, want %d (lower bound)",
+			got, session.MinPreviewPct)
+	}
+	// Already at the floor — another nudge should be a no-op for value
+	// (but still triggers overlay) and should NOT underflow.
+	if home.adjustPreviewPct(-previewPctStep) {
+		t.Fatalf("expected adjustPreviewPct at floor to return false")
+	}
+	if got := home.getPreviewPct(); got != session.MinPreviewPct {
+		t.Fatalf("after second -5 at floor: previewPct = %d, want %d",
+			got, session.MinPreviewPct)
+	}
+
+	// Drive the percentage up past the ceiling.
+	home.previewPct = 88
+	home.adjustPreviewPct(previewPctStep) // 88 -> 90 (clamped, was 93)
+	if got := home.getPreviewPct(); got != session.MaxPreviewPct {
+		t.Fatalf("after +5 from 88: previewPct = %d, want %d (upper bound)",
+			got, session.MaxPreviewPct)
+	}
+	if home.adjustPreviewPct(previewPctStep) {
+		t.Fatalf("expected adjustPreviewPct at ceiling to return false")
+	}
+	if got := home.getPreviewPct(); got != session.MaxPreviewPct {
+		t.Fatalf("after second +5 at ceiling: previewPct = %d, want %d",
+			got, session.MaxPreviewPct)
+	}
+}
+
+func TestIssue1092_AdjustmentPersistsToConfig(t *testing.T) {
+	dir := setIsolatedAgentDeckDir(t)
+
+	home := NewHome()
+	home.previewPct = 60
+	home.adjustPreviewPct(previewPctStep) // -> 65
+
+	// File should now contain preview_pct = 65.
+	cfgPath := filepath.Join(dir, "config.toml")
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("expected config.toml to be written after adjust: %v", err)
+	}
+	session.ClearUserConfigCache()
+	cfg, err := session.LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig after adjust: %v", err)
+	}
+	if got := cfg.UI.GetPreviewPct(); got != 65 {
+		t.Fatalf("persisted preview_pct = %d, want 65 — adjustment did not save",
+			got)
+	}
+}
+
+func TestIssue1092_GetPreviewPct_ClampsLegacyValues(t *testing.T) {
+	// A user (or a stale Home struct built before this feature) might have
+	// previewPct of 0 or out-of-range. getPreviewPct must always return a
+	// usable value so layout math never produces a 0-width pane.
+	cases := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"zero falls back to default", 0, session.DefaultPreviewPct},
+		{"negative falls back to default", -5, session.DefaultPreviewPct},
+		{"below min clamps up", 3, session.MinPreviewPct},
+		{"above max clamps down", 99, session.MaxPreviewPct},
+		{"in-range passes through", 42, 42},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Home{previewPct: tc.in}
+			if got := h.getPreviewPct(); got != tc.want {
+				t.Fatalf("getPreviewPct(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ui/split_config.go
+++ b/internal/ui/split_config.go
@@ -1,0 +1,95 @@
+// Sessions/Preview split configuration (issue #1092).
+//
+// Resolves a configurable horizontal split between the SESSIONS list and
+// the PREVIEW pane. Defaults preserve the historical 35/65 layout.
+//
+// Two surfaces:
+//   - Config file: ~/.agent-deck/config.toml -> [ui] preview_pct (10-90)
+//   - Runtime keybinding: < shrinks preview by 5%, > grows it by 5%
+//
+// The runtime adjustment persists back to config.toml so it survives
+// restart. The brief overlay showing the new ratio is drawn by the
+// home renderer when previewPctOverlayAt is in the future.
+
+package ui
+
+import (
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// previewPctStep is the percentage delta per < / > keystroke.
+const previewPctStep = 5
+
+// previewPctOverlayDuration is how long the "Sessions / Preview ratio"
+// overlay stays visible after an adjustment.
+const previewPctOverlayDuration = 1500 * time.Millisecond
+
+// getPreviewPct returns the current preview percentage with bounds
+// applied. Falls back to the package default when the field is zero
+// (which is the case for Home instances built before this feature
+// landed and for tests that bypass NewHome).
+func (h *Home) getPreviewPct() int {
+	if h.previewPct <= 0 {
+		return session.DefaultPreviewPct
+	}
+	if h.previewPct < session.MinPreviewPct {
+		return session.MinPreviewPct
+	}
+	if h.previewPct > session.MaxPreviewPct {
+		return session.MaxPreviewPct
+	}
+	return h.previewPct
+}
+
+// sessionsPaneWidth returns the column width allocated to the sessions
+// list panel in the dual layout. Replaces the historical
+// `int(float64(h.width) * 0.35)` literal.
+func (h *Home) sessionsPaneWidth() int {
+	previewPct := h.getPreviewPct()
+	sessionsPct := 100 - previewPct
+	return int(float64(h.width) * float64(sessionsPct) / 100.0)
+}
+
+// adjustPreviewPct shifts the preview percentage by delta (in percent
+// points), clamps to [MinPreviewPct, MaxPreviewPct], persists the new
+// value to config.toml, and arms the on-screen overlay.
+//
+// Returns true if the value actually changed so callers can decide
+// whether to trigger a repaint.
+func (h *Home) adjustPreviewPct(delta int) bool {
+	current := h.getPreviewPct()
+	next := current + delta
+	if next < session.MinPreviewPct {
+		next = session.MinPreviewPct
+	}
+	if next > session.MaxPreviewPct {
+		next = session.MaxPreviewPct
+	}
+	if next == current {
+		// Already at a bound; still arm the overlay so the user gets
+		// visual feedback that the keystroke was received.
+		h.previewPctOverlayAt = time.Now().Add(previewPctOverlayDuration)
+		return false
+	}
+	h.previewPct = next
+	h.previewPctOverlayAt = time.Now().Add(previewPctOverlayDuration)
+	persistPreviewPct(next)
+	return true
+}
+
+// persistPreviewPct writes the new preview percentage to config.toml.
+// Errors are swallowed: a failed save shouldn't crash the TUI, and the
+// in-memory value still takes effect for the current session.
+func persistPreviewPct(pct int) {
+	cfg, err := session.LoadUserConfig()
+	if err != nil || cfg == nil {
+		return
+	}
+	if cfg.UI.PreviewPct == pct {
+		return
+	}
+	cfg.UI.PreviewPct = pct
+	_ = session.SaveUserConfig(cfg)
+}


### PR DESCRIPTION
## Summary

The dual-column layout had a hardcoded 35% sessions / 65% preview split (`int(float64(h.width) * 0.35)`, three call sites). [@ddorman-dn](https://github.com/ddorman-dn) wanted 20/80 and a way to configure it — so this PR makes the split configurable both at rest and at runtime, while preserving the historical default.

Closes #1092.

## Surfaces

### 1. Config file — `~/.agent-deck/config.toml`

```toml
[ui]
preview_pct = 80   # 10-90, default 65
```

`preview_pct` is the percentage of horizontal width given to the preview pane; the sessions list gets the remainder. Out-of-range values clamp to `[10, 90]`; `0` / missing falls back to the default (`65` — preserves the current 35/65 layout, so existing users see no surprise).

### 2. Runtime keybindings (dual layout only)

| Key | Effect |
|-----|--------|
| `<` | Shrink preview by 5% |
| `>` | Grow preview by 5% |

Bounded to `[10, 90]`. After each adjustment, the new ratio briefly shows in the panel titles (`SESSIONS 20%` / `PREVIEW 80%`) for 1.5 s — visual cue confirms the change without a modal. The new value is persisted back to `config.toml`, so the adjusted split survives restart.

## Code changes

- `internal/session/userconfig.go` — new `UISettings { PreviewPct int }`, `GetPreviewPct()` with clamping, constants `DefaultPreviewPct = 65`, `MinPreviewPct = 10`, `MaxPreviewPct = 90`
- `internal/ui/split_config.go` (new) — `Home.getPreviewPct()`, `sessionsPaneWidth()`, `adjustPreviewPct()` + persist hook
- `internal/ui/home.go` — three hardcoded `int(float64(h.width) * 0.35)` sites now call `h.sessionsPaneWidth()`; `<` and `>` cases in the key handler (gated to `LayoutModeDual`); dual layout title row shows the overlay text while `previewPctOverlayAt` is in the future; `previewPct` field initialized from config in the constructor
- `internal/ui/help.go` — `?` overlay lists the new bindings

## Tests

New `internal/ui/issue1092_split_test.go` — 6 cases (10 sub-tests):

- `TestIssue1092_DefaultSplit_Is65PreviewPct` — `Home` constructed with no config returns `preview_pct=65` and `sessionsPaneWidth(100)=35`
- `TestIssue1092_ConfigOverride_PicksUpCustomValue` — writes `[ui] preview_pct = 80` to a temp `config.toml`, asserts both `cfg.UI.GetPreviewPct()` and the threaded `home.previewPct` pick it up; `sessionsPaneWidth(100)=20`
- `TestIssue1092_KeybindingShiftsBy5Pct` — `+5` and `-5` round-trip cleanly
- `TestIssue1092_KeybindingClampsToBounds` — driving below 10 or above 90 clamps; a second nudge at the bound returns `false` (no-op)
- `TestIssue1092_AdjustmentPersistsToConfig` — after `adjustPreviewPct(+5)` the value round-trips through disk
- `TestIssue1092_GetPreviewPct_ClampsLegacyValues` — table-driven: `0`, `-5`, `3`, `99`, `42` → safe values

```
=== RUN   TestIssue1092_DefaultSplit_Is65PreviewPct
--- PASS (0.08s)
=== RUN   TestIssue1092_ConfigOverride_PicksUpCustomValue
--- PASS (0.07s)
=== RUN   TestIssue1092_KeybindingShiftsBy5Pct
--- PASS (0.08s)
=== RUN   TestIssue1092_KeybindingClampsToBounds
--- PASS (0.08s)
=== RUN   TestIssue1092_AdjustmentPersistsToConfig
--- PASS (0.06s)
=== RUN   TestIssue1092_GetPreviewPct_ClampsLegacyValues (5 sub-tests)
--- PASS (0.00s)
ok      github.com/asheshgoplani/agent-deck/internal/ui   0.394s
```

Full suite (`go test ./...`) green — 36 packages, including the mandated `session`, `ui`, `tmux`, `feedback`, `watcher`, `cmd/agent-deck` suites.

## Test plan

- [ ] Default behavior: open the TUI without touching `config.toml` — layout matches today's 35/65 split
- [ ] Config file: `[ui] preview_pct = 80` in `~/.agent-deck/config.toml` → preview pane fills 80% on next launch
- [ ] Runtime: press `>` repeatedly → preview grows in 5% steps, stops at 90%, ratio banner appears in titles
- [ ] Runtime: press `<` repeatedly → preview shrinks in 5% steps, stops at 10%
- [ ] Persistence: adjust with `<`/`>`, quit, relaunch → split is preserved
- [ ] Help (`?`) → lists `< / >` shortcut under preview controls

## Credit

Requested by [@ddorman-dn](https://github.com/ddorman-dn). Thanks for the report and the specific ask.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable Sessions/Preview split ratio in the dual-column view with persistent settings.
  * Keyboard shortcuts (`<` and `>`) to adjust the preview pane size in real-time.
  * New `[ui]` configuration section with adjustable `preview_pct` setting (10–90% range, default 65%).
  * Dynamic overlay displaying current split percentage during adjustments.

* **Tests**
  * Added comprehensive test suite for the split ratio functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1099?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->