### PR TITLE
fix(multi-repo): run .worktreeinclude and setup script for each repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,15 +227,34 @@ default_location = "subdirectory"  # "sibling" (default), "subdirectory", or a c
 
 `sibling` creates worktrees next to the repo (`repo-branch`). `subdirectory` creates them inside it (`repo/.worktrees/branch`). A custom path like `~/worktrees` or `/tmp/worktrees` creates repo-namespaced worktrees at `<path>/<repo_name>/<branch>`. The `--location` flag overrides the config per session.
 
+#### Copying Gitignored Files (`.worktreeinclude`)
+
+Gitignored files (`.env`, `.mcp.json`, etc.) aren't copied into new worktrees by default.
+To declare which gitignored files should be copied automatically, create a `.worktreeinclude` file in your repo root:
+
+```gitignore
+# .worktreeinclude — gitignore-syntax patterns
+.env
+.env.local
+.mcp.json
+secrets/
+```
+
+Only files that are both pattern-matched AND gitignored get copied — tracked files are never duplicated.
+Directories are copied recursively and merged into existing destinations.
+Existing files in the worktree are not overwritten.
+
+This works for both single-repo and multi-repo worktree sessions.
+Matches [Claude Code Desktop semantics](https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees).
+
 #### Worktree Setup Script
 
-Gitignored files (`.env`, `.mcp.json`, etc.) aren't copied into new worktrees. To automate this, create a setup script at `.agent-deck/worktree-setup.sh` in your repo. Agent-deck runs it automatically after creating a worktree.
+For imperative setup tasks (installing dependencies, running migrations, etc.), create a script at `.agent-deck/worktree-setup.sh`.
+Agent-deck runs it automatically after creating a worktree and processing `.worktreeinclude`.
 
 ```sh
 #!/bin/sh
-for f in .env .env.local .mcp.json; do
-    [ -f "$AGENT_DECK_REPO_ROOT/$f" ] && cp "$AGENT_DECK_REPO_ROOT/$f" "$AGENT_DECK_WORKTREE_PATH/$f"
-done
+npm install
 ```
 
 The script receives two environment variables:

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8281,13 +8281,8 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 				if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create parent directory: %w", err), tempID: tempID}
 				}
-				var setupBuf bytes.Buffer
-				setupErr, err := git.CreateWorktreeWithSetup(worktreeRepoRoot, worktreePath, worktreeBranch, &setupBuf, &setupBuf, session.GetWorktreeSettings().SetupTimeout())
-				if err != nil {
+				if err := createWorktreeWithSetupAndLog(worktreeRepoRoot, worktreePath, worktreeBranch); err != nil {
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create worktree: %w", err), tempID: tempID}
-				}
-				if setupErr != nil {
-					uiLog.Warn("worktree_setup_script_failed", slog.String("error", setupErr.Error()), slog.String("output", setupBuf.String()))
 				}
 			}
 			path = worktreePath
@@ -8385,7 +8380,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 							}
 							continue
 						}
-						if err := git.CreateWorktree(repoRoot, wtPath, worktreeBranch); err != nil {
+						if err := createWorktreeWithSetupAndLog(repoRoot, wtPath, worktreeBranch); err != nil {
 							uiLog.Warn("multi_repo_worktree_create_fail", slog.String("path", p), slog.String("error", err.Error()))
 							_ = os.Symlink(p, wtPath)
 							if i == 0 {
@@ -8469,6 +8464,21 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 		uiLog.Info("session_create_succeeded", slog.String("id", inst.ID))
 		return sessionCreatedMsg{instance: inst, tempID: tempID}
 	}
+}
+
+// createWorktreeWithSetupAndLog creates a worktree, runs .worktreeinclude and
+// worktree-setup.sh, and logs setup failures. Returns only the creation error;
+// setup failures are non-fatal and logged to uiLog.
+func createWorktreeWithSetupAndLog(repoRoot, wtPath, branch string) error {
+	var buf bytes.Buffer
+	setupErr, err := git.CreateWorktreeWithSetup(repoRoot, wtPath, branch, &buf, &buf, session.GetWorktreeSettings().SetupTimeout())
+	if err != nil {
+		return err
+	}
+	if setupErr != nil {
+		uiLog.Warn("worktree_setup_script_failed", slog.String("error", setupErr.Error()), slog.String("output", buf.String()))
+	}
+	return nil
 }
 
 // createSessionTool maps a free-form command to (tool, command). Built-in
@@ -8842,13 +8852,8 @@ func (h *Home) forkSessionCmdWithOptions(
 				if err := os.MkdirAll(filepath.Dir(opts.WorktreePath), 0o755); err != nil {
 					return sessionForkedMsg{err: fmt.Errorf("failed to create directory: %w", err), sourceID: sourceID}
 				}
-				var setupBuf bytes.Buffer
-				setupErr, err := git.CreateWorktreeWithSetup(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch, &setupBuf, &setupBuf, session.GetWorktreeSettings().SetupTimeout())
-				if err != nil {
+				if err := createWorktreeWithSetupAndLog(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch); err != nil {
 					return sessionForkedMsg{err: fmt.Errorf("worktree creation failed: %w", err), sourceID: sourceID}
-				}
-				if setupErr != nil {
-					uiLog.Warn("worktree_setup_script_failed", slog.String("error", setupErr.Error()), slog.String("output", setupBuf.String()))
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Multi-repo + worktree sessions now run `.worktreeinclude` and `worktree-setup.sh` for each repo
- Extract `createWorktreeWithSetupAndLog` as the single entry point for all worktree creation in `home.go` — all three call sites (new session, multi-repo, fork) now go through one function, making it impossible to accidentally use the bare `CreateWorktree`
- Document `.worktreeinclude` in README (was only in CHANGELOG)

## Design

Rather than testing the wiring with a structural/source-level test, the code is made correct by construction: one helper function wraps `CreateWorktreeWithSetup`, and all call sites use it. There's no wrong function to reach for.

## Discussion

An alternative (or follow-up) would be extracting the entire multi-repo worktree loop into a standalone testable function with a real integration test — two temp git repos, each with `.worktreeinclude`, verify files land in both worktrees. That would test behavior end-to-end without the fragility of marker-based source scanning. Worth the refactoring cost?

## Test plan

- [x] Existing `TestProcessWorktreeInclude_Integration_RunsBeforeSetupScript` proves the underlying behavior
- [x] Existing `TestRegression742_HomeWorktreeGuardsAcceptBareProjectRoot` still passes
- [x] Full build passes
- [x] Manual: created a multi-repo worktree session with two repos that have `.worktreeinclude` — verified gitignored files are copied

🤖 Generated with Claude Code