### PR TITLE
fix(ui): Shift+Enter handles remote sessions + opens iTerm tab by default (closes #1100, follow-up to #1098)

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -196,6 +196,12 @@ type UISettings struct {
 	// Default: 65 (current behavior — sessions 35 / preview 65).
 	// Adjustable at runtime via < and > keybindings (5% step).
 	PreviewPct int `toml:"preview_pct"`
+
+	// ITermOpenAs controls whether Shift+Enter pops the focused session
+	// into a new iTerm2 *tab* or a new iTerm2 *window* on macOS. Valid
+	// values: "tab", "window". Empty defaults to "tab" (iTerm's natural
+	// UX). Issue #1100, follow-up to #1098 — credit @ddorman-dn.
+	ITermOpenAs string `toml:"iterm_open_as"`
 }
 
 // DefaultPreviewPct is the default preview-pane width percentage.
@@ -207,6 +213,13 @@ const DefaultPreviewPct = 65
 const (
 	MinPreviewPct = 10
 	MaxPreviewPct = 90
+)
+
+// iTerm "open as" modes for Shift+Enter dispatch.
+const (
+	ITermOpenAsTab     = "tab"
+	ITermOpenAsWindow  = "window"
+	DefaultITermOpenAs = ITermOpenAsTab
 )
 
 // GetPreviewPct returns the configured preview percentage, clamped to
@@ -223,6 +236,19 @@ func (u UISettings) GetPreviewPct() int {
 		return MaxPreviewPct
 	}
 	return u.PreviewPct
+}
+
+// GetITermOpenAs returns the configured iTerm open mode. Unknown or
+// empty values fall through to the default ("tab"). Matching is
+// case-insensitive so users can write "Tab" or "WINDOW" in TOML.
+func (u UISettings) GetITermOpenAs() string {
+	switch strings.ToLower(strings.TrimSpace(u.ITermOpenAs)) {
+	case ITermOpenAsWindow:
+		return ITermOpenAsWindow
+	case ITermOpenAsTab:
+		return ITermOpenAsTab
+	}
+	return DefaultITermOpenAs
 }
 
 // WebSettings configures the `agent-deck web` HTTP server.

--- a/internal/terminal/issue1100_launcher_test.go
+++ b/internal/terminal/issue1100_launcher_test.go
@@ -1,0 +1,108 @@
+package terminal
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #1100 (by @ddorman-dn, follow-up to #1098):
+//   (a) Shift+Enter on a REMOTE session did nothing — the dispatch path
+//       only constructed local-tmux AttachRequests, so the launcher had
+//       no SSH information to act on.
+//   (b) For local sessions Shift+Enter opened a fresh iTerm WINDOW —
+//       users expect a TAB (iTerm's natural UX). Tabbed iTerm users
+//       in particular found a detached window jarring.
+//
+// These tests pin both fixes at the BuildAttachCommand layer so the
+// shell command shape is locked in regardless of which platform
+// implementation runs it.
+
+// TestIssue1100_BuildAttachCommand_RemoteSession verifies that an
+// AttachRequest with a populated Remote field renders an ssh invocation
+// that runs `agent-deck session attach <id>` on the remote host. The
+// shell command must be safe to paste into a freshly-spawned terminal
+// — no unquoted spaces, no shell-metachar surprises in the host or
+// session id.
+func TestIssue1100_BuildAttachCommand_RemoteSession(t *testing.T) {
+	got := BuildAttachCommand(AttachRequest{
+		Name: "abc-123",
+		Remote: &RemoteAttach{
+			Host:          "user@server.example",
+			AgentDeckPath: "/usr/local/bin/agent-deck",
+			Profile:       "work",
+		},
+	})
+
+	for _, want := range []string{
+		"ssh -tt",
+		" -o ControlMaster=auto",
+		" -o ControlPath='/tmp/agent-deck-ssh/%r@%h:%p'",
+		" -o ControlPersist=600",
+		"'user@server.example'",
+		"'/usr/local/bin/agent-deck'",
+		"-p 'work'",
+		"session attach 'abc-123'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("remote BuildAttachCommand missing %q\nfull:\n%s", want, got)
+		}
+	}
+}
+
+// TestIssue1100_BuildAttachCommand_RemoteDefaultProfileOmitsFlag pins
+// the contract that the default profile is implicit on the remote side
+// — adding `-p default` would force agent-deck to look for a profile
+// named "default" instead of falling through to its own defaults.
+func TestIssue1100_BuildAttachCommand_RemoteDefaultProfileOmitsFlag(t *testing.T) {
+	got := BuildAttachCommand(AttachRequest{
+		Name: "abc-123",
+		Remote: &RemoteAttach{
+			Host:    "u@h",
+			Profile: "default",
+		},
+	})
+	if strings.Contains(got, "-p 'default'") {
+		t.Errorf("remote command should not pass -p 'default' explicitly:\n%s", got)
+	}
+	if !strings.Contains(got, "session attach 'abc-123'") {
+		t.Errorf("remote command must still attach to the session id:\n%s", got)
+	}
+}
+
+// TestIssue1100_BuildAttachCommand_RemoteEmptyAgentDeckPathFallsBack
+// pins the default path lookup — leaving AgentDeckPath blank must
+// still produce a runnable command (relies on PATH on the remote).
+func TestIssue1100_BuildAttachCommand_RemoteEmptyAgentDeckPathFallsBack(t *testing.T) {
+	got := BuildAttachCommand(AttachRequest{
+		Name:   "id",
+		Remote: &RemoteAttach{Host: "u@h"},
+	})
+	if !strings.Contains(got, "'agent-deck'") {
+		t.Errorf("expected bare 'agent-deck' fallback path:\n%s", got)
+	}
+}
+
+// TestIssue1100_BuildAttachCommand_RemoteEmptyHostReturnsEmpty pins
+// the safety guard — a Remote with no Host is unrunnable, and an
+// empty string is the contract for "do not invoke the launcher".
+func TestIssue1100_BuildAttachCommand_RemoteEmptyHostReturnsEmpty(t *testing.T) {
+	got := BuildAttachCommand(AttachRequest{
+		Name:   "id",
+		Remote: &RemoteAttach{Host: "   "},
+	})
+	if got != "" {
+		t.Errorf("empty host should produce empty command, got %q", got)
+	}
+}
+
+// TestIssue1100_BuildAttachCommand_LocalUnchanged pins the
+// non-regression guarantee: a request without Remote still produces
+// the local tmux invocation shipped in #1077. The follow-up fixes for
+// #1098/#1100 must not alter the local command shape.
+func TestIssue1100_BuildAttachCommand_LocalUnchanged(t *testing.T) {
+	got := BuildAttachCommand(AttachRequest{Name: "myproj", SocketName: "agentdeck"})
+	want := "tmux -L 'agentdeck' attach -t 'myproj'"
+	if got != want {
+		t.Errorf("local BuildAttachCommand changed:\n got=%q\nwant=%q", got, want)
+	}
+}

--- a/internal/terminal/launcher.go
+++ b/internal/terminal/launcher.go
@@ -25,30 +25,83 @@ var ErrUnsupported = errors.New("terminal: opening a new window is not yet suppo
 // AttachRequest describes the tmux session a new terminal window should
 // attach to once spawned.
 //
-// Name is required. SocketName may be empty (meaning the default tmux
-// server), matching the semantics of tmux.Session.SocketName.
+// Name is required for local sessions. For remote sessions, Remote must
+// be populated instead (Name then refers to the remote agent-deck session
+// ID — what `agent-deck session attach <id>` expects on the other side).
+// SocketName may be empty (meaning the default tmux server), matching the
+// semantics of tmux.Session.SocketName.
 type AttachRequest struct {
-	// Name is the tmux session name (the `-t` argument of `tmux attach`).
+	// Name is the tmux session name (the `-t` argument of `tmux attach`)
+	// for local sessions, or the remote agent-deck session ID when
+	// Remote != nil.
 	Name string
 
 	// SocketName is the optional `-L <socket>` selector. Empty means the
-	// default server.
+	// default server. Ignored when Remote != nil.
 	SocketName string
 
 	// Terminal is an optional hint for which native terminal to use
 	// (e.g. "iterm2"). Empty means "use the platform default".
 	Terminal string
+
+	// OpenAs controls whether the platform launcher opens a new tab or a
+	// new window when both are supported (currently: iTerm2 on macOS).
+	// Valid values: "tab", "window". Empty falls through to the platform
+	// default, which is "tab" on macOS — matching iTerm's natural UX.
+	// Issue #1100.
+	OpenAs string
+
+	// Remote, when non-nil, switches BuildAttachCommand from a local
+	// `tmux attach` invocation to an `ssh` invocation that runs
+	// `agent-deck session attach <Name>` on the remote host. Issue #1100,
+	// follow-up to #1098 — Shift+Enter for remote sessions.
+	Remote *RemoteAttach
 }
 
-// BuildAttachCommand returns the shell command string that, when executed
-// inside a fresh terminal window, attaches to the requested tmux session.
+// RemoteAttach carries the SSH and agent-deck details needed to attach
+// to a remote agent-deck session from a freshly-spawned terminal window.
 //
-// It is exported (and pure) so platform implementations and tests can share
-// the exact same string-building logic without depending on os/exec.
+// Fields mirror the runtime values used by session.SSHRunner so the
+// generated ssh command is byte-for-byte equivalent to what the in-TUI
+// remote-attach path runs — same control-socket flags, same remote
+// binary, same profile selector.
+type RemoteAttach struct {
+	// Host is the SSH destination (e.g. "user@host" or "user@host:port").
+	Host string
+
+	// AgentDeckPath is the agent-deck binary path on the remote host.
+	// Empty defaults to "agent-deck".
+	AgentDeckPath string
+
+	// Profile is the remote profile selector. Empty or "default" omits
+	// the -p flag.
+	Profile string
+}
+
+// SSHControlDir is the directory the launcher tells SSH to keep its
+// ControlMaster sockets in. Mirrors internal/session.sshControlDir so a
+// remote attach launched via Shift+Enter shares the same multiplexed
+// connection as a normal in-TUI remote attach.
+const SSHControlDir = "/tmp/agent-deck-ssh"
+
+// BuildAttachCommand returns the shell command string that, when executed
+// inside a fresh terminal window, attaches to the requested session.
+//
+// For local requests (Remote == nil) it produces a `tmux attach …`
+// invocation. For remote requests it produces an `ssh -tt …
+// '<agent-deck-path> [-p profile] session attach <name>'` invocation
+// that mirrors session.SSHRunner.Attach.
+//
+// It is exported (and pure) so platform implementations and tests can
+// share the exact same string-building logic without depending on
+// os/exec.
 func BuildAttachCommand(req AttachRequest) string {
 	name := strings.TrimSpace(req.Name)
 	if name == "" {
 		return ""
+	}
+	if req.Remote != nil {
+		return buildRemoteAttachCommand(name, req.Remote)
 	}
 	var b strings.Builder
 	b.WriteString("tmux")
@@ -58,6 +111,48 @@ func BuildAttachCommand(req AttachRequest) string {
 	}
 	b.WriteString(" attach -t ")
 	b.WriteString(shellQuote(name))
+	return b.String()
+}
+
+// buildRemoteAttachCommand renders the ssh invocation that attaches to
+// a remote agent-deck session. The remote command pieces mirror
+// session.SSHRunner.buildRemoteCommand so the user lands in the same
+// session regardless of which path opened it.
+//
+// We rely on ssh's documented behavior of joining trailing args with
+// spaces before sending them to the remote shell, so each piece only
+// needs to be locally shell-safe — no nested re-quoting of the whole
+// command string.
+func buildRemoteAttachCommand(remoteName string, r *RemoteAttach) string {
+	host := strings.TrimSpace(r.Host)
+	if host == "" {
+		return ""
+	}
+	agentDeckPath := strings.TrimSpace(r.AgentDeckPath)
+	if agentDeckPath == "" {
+		agentDeckPath = "agent-deck"
+	}
+	profile := strings.TrimSpace(r.Profile)
+
+	// ssh with -tt (force remote PTY) and the same ControlMaster flags
+	// as the in-TUI remote attach, so the multiplexed connection is
+	// reused.
+	var b strings.Builder
+	b.WriteString("ssh -tt")
+	b.WriteString(" -o ControlMaster=auto")
+	b.WriteString(" -o ControlPath=")
+	b.WriteString(shellQuote(SSHControlDir + "/%r@%h:%p"))
+	b.WriteString(" -o ControlPersist=600")
+	b.WriteString(" ")
+	b.WriteString(shellQuote(host))
+	b.WriteString(" ")
+	b.WriteString(shellQuote(agentDeckPath))
+	if profile != "" && profile != "default" {
+		b.WriteString(" -p ")
+		b.WriteString(shellQuote(profile))
+	}
+	b.WriteString(" session attach ")
+	b.WriteString(shellQuote(remoteName))
 	return b.String()
 }
 

--- a/internal/terminal/launcher_darwin.go
+++ b/internal/terminal/launcher_darwin.go
@@ -8,37 +8,68 @@ import (
 	"strings"
 )
 
-// OpenSessionInNewWindow opens a new iTerm2 window and types the tmux attach
-// command into its first session. On macOS this requires that iTerm2 is
-// installed; if osascript reports it cannot find the application we surface
-// that error to the caller so the TUI can fall back gracefully.
+// OpenSessionInNewWindow opens a new iTerm2 tab or window (per
+// req.OpenAs) and types the attach command into its session. On macOS
+// this requires that iTerm2 is installed; if osascript reports it cannot
+// find the application we surface that error to the caller so the TUI
+// can fall back gracefully.
 //
-// The command is built via BuildAttachCommand so it stays in lockstep with
-// the cross-platform tests.
+// The command is built via BuildAttachCommand so it stays in lockstep
+// with the cross-platform tests.
 func OpenSessionInNewWindow(req AttachRequest) error {
 	cmd := BuildAttachCommand(req)
 	if cmd == "" {
-		return fmt.Errorf("terminal: empty tmux session name")
+		return fmt.Errorf("terminal: empty attach command (missing session name or remote host)")
 	}
-	script := buildITerm2AppleScript(cmd)
+	script := buildITerm2AppleScript(cmd, req.OpenAs)
 	return exec.Command("osascript", "-e", script).Run()
 }
 
-// buildITerm2AppleScript returns the AppleScript that spawns a new iTerm2
-// window with the user's default profile and runs attachCmd inside it.
+// buildITerm2AppleScript returns the AppleScript that spawns a new
+// iTerm2 tab or window (per openAs) with the user's default profile and
+// runs attachCmd inside it.
+//
+// openAs == "window" reproduces the pre-#1100 behavior (new iTerm2
+// window). Any other value, including "" and "tab", produces a new tab
+// inside the current window — matching iTerm's natural UX.
 //
 // We keep this pure and exported-to-tests so the script can be exercised
 // without invoking osascript.
-func buildITerm2AppleScript(attachCmd string) string {
-	// AppleScript string literals are double-quoted; escape inner quotes and
-	// backslashes so a tmux session name containing them cannot break out.
+func buildITerm2AppleScript(attachCmd string, openAs string) string {
+	// AppleScript string literals are double-quoted; escape inner quotes
+	// and backslashes so a name (or ssh user@host) containing them
+	// cannot break out.
 	escaped := strings.ReplaceAll(attachCmd, `\`, `\\`)
 	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
-	return fmt.Sprintf(`tell application "iTerm2"
+
+	if strings.EqualFold(strings.TrimSpace(openAs), "window") {
+		return fmt.Sprintf(`tell application "iTerm2"
 	activate
 	set newWindow to (create window with default profile)
 	tell current session of newWindow
 		write text "%s"
 	end tell
 end tell`, escaped)
+	}
+
+	// Default ("tab" / "" / unknown): open a tab in the frontmost
+	// window, falling back to creating a window if no iTerm window
+	// exists yet. `create tab with default profile` returns a tab
+	// whose current session is where we write the attach command.
+	return fmt.Sprintf(`tell application "iTerm2"
+	activate
+	if (count of windows) = 0 then
+		set newWindow to (create window with default profile)
+		tell current session of newWindow
+			write text "%s"
+		end tell
+	else
+		tell current window
+			set newTab to (create tab with default profile)
+			tell current session of newTab
+				write text "%s"
+			end tell
+		end tell
+	end if
+end tell`, escaped, escaped)
 }

--- a/internal/terminal/launcher_darwin_test.go
+++ b/internal/terminal/launcher_darwin_test.go
@@ -10,9 +10,13 @@ import (
 // On darwin, buildITerm2AppleScript should embed the tmux attach command
 // inside an AppleScript that targets iTerm2's default profile. We verify the
 // script shape without actually invoking osascript.
-func TestBuildITerm2AppleScript_EmbedsAttachCommand(t *testing.T) {
+//
+// Issue #1100: the script now branches on openAs. "window" preserves the
+// pre-#1100 "create window with default profile" behavior; everything
+// else defaults to a new tab in the frontmost window.
+func TestBuildITerm2AppleScript_WindowModeCreatesWindow(t *testing.T) {
 	cmd := BuildAttachCommand(AttachRequest{Name: "myproj", SocketName: "agentdeck"})
-	script := buildITerm2AppleScript(cmd)
+	script := buildITerm2AppleScript(cmd, "window")
 
 	for _, want := range []string{
 		`tell application "iTerm2"`,
@@ -23,16 +27,62 @@ func TestBuildITerm2AppleScript_EmbedsAttachCommand(t *testing.T) {
 			t.Errorf("AppleScript missing %q\nfull script:\n%s", want, script)
 		}
 	}
+	if strings.Contains(script, "create tab with default profile") {
+		t.Errorf("window mode should NOT create a tab:\n%s", script)
+	}
+}
+
+// TestBuildITerm2AppleScript_TabModeIsDefault pins issue #1100 fix (b):
+// Shift+Enter must open a TAB by default (iTerm's natural UX), not a
+// fresh detached window like #1098 originally shipped.
+func TestBuildITerm2AppleScript_TabModeIsDefault(t *testing.T) {
+	cmd := BuildAttachCommand(AttachRequest{Name: "myproj", SocketName: "agentdeck"})
+	// Empty openAs == default.
+	script := buildITerm2AppleScript(cmd, "")
+
+	for _, want := range []string{
+		`tell application "iTerm2"`,
+		`create tab with default profile`,
+		`tmux -L 'agentdeck' attach -t 'myproj'`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("default-mode AppleScript missing %q\nfull script:\n%s", want, script)
+		}
+	}
+	// The tab variant must still cover the no-windows-open fallback by
+	// creating a fresh window — otherwise Shift+Enter from a state with
+	// no iTerm windows would no-op.
+	if !strings.Contains(script, "create window with default profile") {
+		t.Errorf("tab-mode AppleScript missing the (count of windows) = 0 fallback:\n%s", script)
+	}
+}
+
+// TestBuildITerm2AppleScript_TabModeExplicit verifies the explicit "tab"
+// value behaves identically to the default fallback (issue #1100).
+func TestBuildITerm2AppleScript_TabModeExplicit(t *testing.T) {
+	cmd := BuildAttachCommand(AttachRequest{Name: "myproj"})
+	defaultScript := buildITerm2AppleScript(cmd, "")
+	tabScript := buildITerm2AppleScript(cmd, "tab")
+	if defaultScript != tabScript {
+		t.Fatalf("explicit \"tab\" should match default mode\ndefault:\n%s\ntab:\n%s",
+			defaultScript, tabScript)
+	}
 }
 
 func TestBuildITerm2AppleScript_EscapesDoubleQuotes(t *testing.T) {
 	// Defensive: if a tmux name ever contained " or \, the AppleScript
 	// must escape it so the surrounding double-quoted literal stays valid.
-	script := buildITerm2AppleScript(`echo "hi" \ bye`)
-	if strings.Contains(script, `"hi"`) {
-		t.Fatalf("double quotes inside command leaked into AppleScript literal:\n%s", script)
-	}
-	if !strings.Contains(script, `\"hi\"`) {
-		t.Fatalf("expected escaped quotes \\\"hi\\\" in script:\n%s", script)
+	// Exercise both modes — the tab branch interpolates the command
+	// twice (fallback + tab path) and both copies must be escaped.
+	for _, openAs := range []string{"", "window"} {
+		script := buildITerm2AppleScript(`echo "hi" \ bye`, openAs)
+		if strings.Contains(script, `"hi"`) {
+			t.Errorf("openAs=%q: double quotes inside command leaked into AppleScript literal:\n%s",
+				openAs, script)
+		}
+		if !strings.Contains(script, `\"hi\"`) {
+			t.Errorf("openAs=%q: expected escaped quotes \\\"hi\\\" in script:\n%s",
+				openAs, script)
+		}
 	}
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -570,6 +570,44 @@ func (h *Home) openInNewWindow(req terminal.AttachRequest, sessionExists bool) e
 	return terminal.OpenSessionInNewWindow(req)
 }
 
+// resolveITermOpenAs reads the [ui] iterm_open_as setting from the user
+// config, returning "tab" by default if the config can't be loaded or
+// the value is unset/unknown. Issue #1100.
+func resolveITermOpenAs() string {
+	cfg, err := session.LoadUserConfig()
+	if err != nil || cfg == nil {
+		return session.DefaultITermOpenAs
+	}
+	return cfg.UI.GetITermOpenAs()
+}
+
+// buildRemoteAttachRequest constructs a terminal.AttachRequest that
+// runs `agent-deck session attach <id>` over SSH on the named remote.
+// Returns ok=false when the remote can't be resolved from user config or
+// is missing a host. Issue #1100.
+func buildRemoteAttachRequest(remoteName, sessionID, openAs string) (terminal.AttachRequest, bool) {
+	if remoteName == "" || sessionID == "" {
+		return terminal.AttachRequest{}, false
+	}
+	cfg, err := session.LoadUserConfig()
+	if err != nil || cfg == nil || cfg.Remotes == nil {
+		return terminal.AttachRequest{}, false
+	}
+	rc, ok := cfg.Remotes[remoteName]
+	if !ok || rc.Host == "" {
+		return terminal.AttachRequest{}, false
+	}
+	return terminal.AttachRequest{
+		Name:   sessionID,
+		OpenAs: openAs,
+		Remote: &terminal.RemoteAttach{
+			Host:          rc.Host,
+			AgentDeckPath: rc.GetAgentDeckPath(),
+			Profile:       rc.GetProfile(),
+		},
+	}, true
+}
+
 func (h *Home) normalizeMainKey(pressed string) string {
 	// Shift+Enter relay: csiuReader emits the Private-Use rune
 	// shiftEnterMarker (U+E5E5) when it sees a Shift+Enter CSI u or
@@ -6044,9 +6082,10 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case "shift+enter":
-		// Open the focused session in a new native terminal window (e.g. a
-		// fresh iTerm2 window on macOS), leaving agent-deck running here.
-		// Issue #1069 feature 2, credit @ddorman-dn.
+		// Open the focused session in a new native terminal tab (or
+		// window, per [ui] iterm_open_as), leaving agent-deck running
+		// here. Issue #1069 feature 2 + #1100 remote-session support,
+		// credit @ddorman-dn.
 		//
 		// Reaching this arm at all required the #1093 fix to keyboard_compat.go
 		// + normalizeMainKey: Bubble Tea v1.3.10 has no shift+enter string,
@@ -6054,15 +6093,24 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// reader and rewrite it to "shift+enter" before this switch sees it.
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
-			if item.Type == session.ItemTypeSession && item.Session != nil {
+			openAs := resolveITermOpenAs()
+			switch {
+			case item.Type == session.ItemTypeSession && item.Session != nil:
 				tmuxSess := item.Session.GetTmuxSession()
 				if tmuxSess != nil {
 					req := terminal.AttachRequest{
 						Name:       tmuxSess.Name,
 						SocketName: tmuxSess.SocketName,
+						OpenAs:     openAs,
 					}
 					if err := h.openInNewWindow(req, item.Session.Exists()); err != nil {
 						h.setError(fmt.Errorf("open in new window: %w", err))
+					}
+				}
+			case item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil:
+				if req, ok := buildRemoteAttachRequest(item.RemoteName, item.RemoteSession.ID, openAs); ok {
+					if err := h.openInNewWindow(req, true); err != nil {
+						h.setError(fmt.Errorf("open remote in new window: %w", err))
 					}
 				}
 			}

--- a/internal/ui/issue1100_shift_enter_remote_test.go
+++ b/internal/ui/issue1100_shift_enter_remote_test.go
@@ -1,0 +1,194 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/terminal"
+)
+
+// Issue #1100 (by @ddorman-dn, follow-up to #1098):
+//
+//	(a) Shift+Enter on a REMOTE session did nothing — the dispatch arm
+//	    only handled ItemTypeSession, so the launcher was never
+//	    invoked for remote items.
+//	(b) Local Shift+Enter opened a new iTerm WINDOW; users expect a
+//	    TAB by default.
+//
+// These tests pin both fixes at the dispatch boundary in home.go.
+
+// withTempAgentDeckHome points $HOME at a fresh tempdir, optionally
+// writing a config.toml there, and clears the LoadUserConfig cache so
+// the next call reads from the new path. The returned cleanup restores
+// both HOME and the cache. Tests must run in t.Cleanup order, so we
+// register the cleanup before returning.
+func withTempAgentDeckHome(t *testing.T, configTOML string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	if configTOML != "" {
+		dir := filepath.Join(tmpDir, ".agent-deck")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(configTOML), 0o644); err != nil {
+			t.Fatalf("write config.toml: %v", err)
+		}
+	}
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", tmpDir); err != nil {
+		t.Fatalf("setenv HOME: %v", err)
+	}
+	session.ClearUserConfigCache()
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", oldHome)
+		session.ClearUserConfigCache()
+	})
+}
+
+// armHomeWithOneRemoteSession sets up a Home whose cursor sits on a
+// remote session item, mirroring armHomeWithOneSession's contract but
+// for the remote dispatch path. The remote is named in $HOME's
+// config.toml so buildRemoteAttachRequest can resolve it.
+func armHomeWithOneRemoteSession(t *testing.T) *Home {
+	t.Helper()
+
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+agent_deck_path = "/usr/local/bin/agent-deck"
+profile = "work"
+`)
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	// Synthesize a single remote-session flat item at the cursor.
+	home.flatItems = []session.Item{
+		{
+			Type:       session.ItemTypeRemoteSession,
+			RemoteName: "lab",
+			RemoteSession: &session.RemoteSessionInfo{
+				ID:    "remote-id-xyz",
+				Title: "remote session",
+			},
+		},
+	}
+	home.cursor = 0
+	return home
+}
+
+// TestIssue1100_HomeDispatch_ShiftEnterRemoteCallsLauncher pins fix (a):
+// pressing Shift+Enter on a remote session must invoke the launcher
+// with a Remote-populated AttachRequest that carries the resolved SSH
+// host, binary path, profile, and remote session id.
+func TestIssue1100_HomeDispatch_ShiftEnterRemoteCallsLauncher(t *testing.T) {
+	home := armHomeWithOneRemoteSession(t)
+
+	var called bool
+	var captured terminal.AttachRequest
+	home.openInNewWindowSink = func(req terminal.AttachRequest) error {
+		called = true
+		captured = req
+		return nil
+	}
+
+	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}}
+	_, _ = home.handleMainKey(keyMsg)
+
+	if !called {
+		t.Fatal("Shift+Enter on remote session did NOT call the new-window launcher (the #1100a regression)")
+	}
+	if captured.Remote == nil {
+		t.Fatalf("AttachRequest.Remote should be populated for remote dispatch, got %+v", captured)
+	}
+	if got, want := captured.Remote.Host, "alice@lab.example"; got != want {
+		t.Errorf("AttachRequest.Remote.Host = %q, want %q", got, want)
+	}
+	if got, want := captured.Remote.AgentDeckPath, "/usr/local/bin/agent-deck"; got != want {
+		t.Errorf("AttachRequest.Remote.AgentDeckPath = %q, want %q", got, want)
+	}
+	if got, want := captured.Remote.Profile, "work"; got != want {
+		t.Errorf("AttachRequest.Remote.Profile = %q, want %q", got, want)
+	}
+	if got, want := captured.Name, "remote-id-xyz"; got != want {
+		t.Errorf("AttachRequest.Name = %q, want %q (remote session id)", got, want)
+	}
+}
+
+// TestIssue1100_HomeDispatch_ShiftEnterDefaultsToTab pins fix (b): the
+// dispatch path must read [ui] iterm_open_as from user config and pass
+// it through to the launcher, with "tab" as the default when unset.
+func TestIssue1100_HomeDispatch_ShiftEnterDefaultsToTab(t *testing.T) {
+	withTempAgentDeckHome(t, "") // no config => default
+	home, _, _ := armHomeWithOneSession(t)
+
+	var captured terminal.AttachRequest
+	home.openInNewWindowSink = func(req terminal.AttachRequest) error {
+		captured = req
+		return nil
+	}
+
+	_, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}})
+
+	if captured.OpenAs != "tab" {
+		t.Fatalf("default OpenAs = %q, want %q (the #1100b regression — window was the old default)", captured.OpenAs, "tab")
+	}
+}
+
+// TestIssue1100_HomeDispatch_ShiftEnterRespectsWindowConfig pins the
+// opt-in path: a user who set iterm_open_as = "window" gets the
+// pre-#1100 detached-window behavior.
+func TestIssue1100_HomeDispatch_ShiftEnterRespectsWindowConfig(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[ui]
+iterm_open_as = "window"
+`)
+	home, _, _ := armHomeWithOneSession(t)
+
+	var captured terminal.AttachRequest
+	home.openInNewWindowSink = func(req terminal.AttachRequest) error {
+		captured = req
+		return nil
+	}
+
+	_, _ = home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{shiftEnterMarker}})
+
+	if captured.OpenAs != "window" {
+		t.Fatalf("OpenAs with iterm_open_as=window = %q, want %q", captured.OpenAs, "window")
+	}
+}
+
+// TestIssue1100_BuildRemoteAttachRequest_UnknownRemoteReturnsFalse pins
+// the safety guard: if the user cursor lands on a remote item whose
+// remote name isn't in user config (stale state, deleted remote), we
+// must NOT spawn an empty SSH command — the helper returns ok=false
+// and the dispatch arm skips the launcher.
+func TestIssue1100_BuildRemoteAttachRequest_UnknownRemoteReturnsFalse(t *testing.T) {
+	withTempAgentDeckHome(t, "") // no remotes configured
+
+	req, ok := buildRemoteAttachRequest("missing-remote", "some-id", "tab")
+	if ok {
+		t.Fatalf("expected ok=false for unknown remote, got req=%+v", req)
+	}
+}
+
+// TestIssue1100_BuildRemoteAttachRequest_EmptyInputsReturnFalse pins
+// the input-validation guard.
+func TestIssue1100_BuildRemoteAttachRequest_EmptyInputsReturnFalse(t *testing.T) {
+	withTempAgentDeckHome(t, `
+[remotes.lab]
+host = "alice@lab.example"
+`)
+	if _, ok := buildRemoteAttachRequest("", "id", "tab"); ok {
+		t.Errorf("empty remoteName must return false")
+	}
+	if _, ok := buildRemoteAttachRequest("lab", "", "tab"); ok {
+		t.Errorf("empty sessionID must return false")
+	}
+}


### PR DESCRIPTION
## Summary

Two bugs in v1.9.23's Shift+Enter dispatch, reported by @ddorman-dn in #1100 (follow-up to the #1098 fix):

- **(a) Shift+Enter on a REMOTE session did nothing.** The dispatch arm only constructed local-tmux `AttachRequest`s, so the launcher had no SSH information to act on.
- **(b) Local Shift+Enter opened a fresh iTerm WINDOW.** Users (especially tabbed-iTerm users) expect a TAB by default.

## Fix (a) — remote sessions

- Extend `terminal.AttachRequest` with a `Remote *RemoteAttach` field carrying the SSH host, agent-deck binary path, profile, and remote session id.
- `BuildAttachCommand` now renders an `ssh -tt -o ControlMaster=auto -o ControlPath='/tmp/agent-deck-ssh/%r@%h:%p' -o ControlPersist=600 <host> <agent-deck> [-p <profile>] session attach <id>` invocation that mirrors `session.SSHRunner.Attach` (same control-socket flags, same remote binary, same profile selector — so the multiplexed connection is reused and the user lands in the same session regardless of which path opened it).
- `home.go` Shift+Enter dispatch arm now handles `ItemTypeRemoteSession` and resolves the remote's host/path/profile from user config.

## Fix (b) — tab vs window

- Add `[ui] iterm_open_as = "tab" | "window"` config option in `UISettings`, defaulting to `"tab"` (iTerm's natural UX).
- `buildITerm2AppleScript` branches on the resolved value:
  - `"tab"` (default): `tell current window to create tab with default profile`, with a fallback that creates a window when no iTerm window is open yet.
  - `"window"`: preserves the pre-#1100 `create window with default profile` behavior for users who opt in.
- Runtime-configurable via `~/.agent-deck/config.toml`; no recompile needed.

## Test plan

- [x] `go test ./internal/terminal/...` — new `issue1100_launcher_test.go` covers remote SSH command construction (host, path, profile, session id, empty-host safety guard, default-profile flag omission, local non-regression).
- [x] `go test ./internal/terminal/...` (darwin) — updated `launcher_darwin_test.go` covers tab-mode vs window-mode AppleScript shape (including the no-windows fallback) and quote escaping for both branches.
- [x] `go test ./internal/ui/...` — new `issue1100_shift_enter_remote_test.go` covers the `home.go` dispatch path: remote-session launcher call with resolved SSH details, default `OpenAs = "tab"`, explicit `iterm_open_as = "window"` respected, and safety guards for unknown remotes and empty inputs.
- [x] `go test ./internal/terminal/... ./internal/ui/... ./internal/session/... -count=1` — all green.
- [x] `go test ./internal/terminal/... ./internal/ui/ -race -count=1 -run "Issue1100|Issue1093|Issue1069|BuildAttachCommand|BuildITerm2AppleScript|ShellQuote"` — race-clean.
- [x] `go test ./cmd/agent-deck/... -count=1` — green.
- [x] Linux build clean; darwin build clean (`GOOS=darwin go build ./...`).
- [x] Windows surface unchanged — pre-existing `syscall.Kill` / `syscall.Statfs_t` issues are unrelated to this change (`GOOS=windows go build ./internal/terminal/` succeeds).
- [x] #1098 local-only fix still works (now defaults to tab); explicit `iterm_open_as = "window"` opt-in restores the old behavior.
- [x] Existing local Enter (in-pane attach) untouched.

Credit: @ddorman-dn for the report.

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added remote session support to enable attaching to sessions over SSH
  * Added iTerm2 configuration option to control opening sessions in tabs or windows
  * Extended Shift+Enter hotkey to support launching remote sessions

* **Tests**
  * Added comprehensive test coverage for remote session attachment and iTerm2 tab/window behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->