### PR TITLE
feat(ui): remote session latency markers in header (closes #1103)

### DIFF
--- a/internal/session/issue1103_remote_latency_test.go
+++ b/internal/session/issue1103_remote_latency_test.go
@@ -1,0 +1,112 @@
+// Issue #1103 — Remote session latency markers.
+//
+// Reporter: @ddorman-dn — wants `remotes/<name> — <Xms>` next to each
+// remote in the TUI header, refreshed on the CPU/RAM cadence.
+//
+// This file owns the structural invariants of the measurement primitive:
+//   - SSHRunner.MeasureLatency calls a known cheap noop RPC (`--version`).
+//   - It returns a non-negative duration that reflects the round-trip.
+//   - It surfaces remote/network failure as an error so the renderer can
+//     show ` — offline` instead of misleading "0ms".
+//   - The RemoteLatency type carries Offline + MS + MeasuredAt so the UI
+//     can distinguish "never measured" from "measured offline".
+
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestIssue1103_MeasureLatency_InvokesVersionAndTimesRoundTrip asserts that
+// MeasureLatency hits the cheapest possible noop on the remote (`--version`)
+// and returns a duration that reflects the stubbed delay. If a future change
+// switches to a heavier command (e.g. `list --json`), this test catches the
+// regression because the header would start ticking on a heavyweight RPC.
+func TestIssue1103_MeasureLatency_InvokesVersionAndTimesRoundTrip(t *testing.T) {
+	const stubDelay = 30 * time.Millisecond
+
+	var calledWith []string
+	runner := &SSHRunner{
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			calledWith = append([]string(nil), args...)
+			time.Sleep(stubDelay)
+			return []byte("agent-deck v1.9.23\n"), nil
+		},
+	}
+
+	d, err := runner.MeasureLatency(context.Background())
+	if err != nil {
+		t.Fatalf("MeasureLatency returned err=%v", err)
+	}
+
+	if len(calledWith) != 1 || calledWith[0] != "--version" {
+		t.Fatalf("MeasureLatency must call `--version` (cheapest noop), got args=%v", calledWith)
+	}
+
+	if d < stubDelay {
+		t.Fatalf("returned duration %v < stubbed delay %v — timer did not span the RPC", d, stubDelay)
+	}
+}
+
+// TestIssue1103_MeasureLatency_PropagatesError asserts that a failed RPC
+// surfaces as an error so the UI can map it to `— offline` rather than
+// reporting "0ms" (which would falsely indicate a healthy remote).
+func TestIssue1103_MeasureLatency_PropagatesError(t *testing.T) {
+	runner := &SSHRunner{
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			return nil, errors.New("ssh: connection refused")
+		},
+	}
+
+	_, err := runner.MeasureLatency(context.Background())
+	if err == nil {
+		t.Fatal("expected error on failed measurement; got nil — UI would mis-report offline remote as 0ms")
+	}
+}
+
+// TestIssue1103_RemoteLatency_NeverMeasuredZeroValue asserts the zero value
+// of RemoteLatency means "never measured": MeasuredAt.IsZero() is true and
+// Offline is false. The renderer keys off MeasuredAt.IsZero() to suppress
+// the marker on first paint, so this invariant is load-bearing.
+func TestIssue1103_RemoteLatency_NeverMeasuredZeroValue(t *testing.T) {
+	var lat RemoteLatency
+	if !lat.MeasuredAt.IsZero() {
+		t.Fatalf("zero RemoteLatency must have MeasuredAt.IsZero()=true; got %v", lat.MeasuredAt)
+	}
+	if lat.Offline {
+		t.Fatalf("zero RemoteLatency must have Offline=false (= unknown, not offline)")
+	}
+	if lat.MS != 0 {
+		t.Fatalf("zero RemoteLatency must have MS=0; got %d", lat.MS)
+	}
+}
+
+// TestIssue1103_UISettings_GetRemoteLatencyRefreshSecs covers the config
+// path the issue specifies: `[ui] remote_latency_refresh_secs`. When unset,
+// it falls back to system_stats.refresh_seconds so the latency marker ticks
+// alongside CPU/RAM by default.
+func TestIssue1103_UISettings_GetRemoteLatencyRefreshSecs(t *testing.T) {
+	cases := []struct {
+		name     string
+		ui       UISettings
+		fallback int
+		want     int
+	}{
+		{"explicit value", UISettings{RemoteLatencyRefreshSecs: 7}, 5, 7},
+		{"unset uses fallback", UISettings{}, 10, 10},
+		{"unset zero fallback uses default", UISettings{}, 0, 5},
+		{"clamp below min", UISettings{RemoteLatencyRefreshSecs: 1}, 5, 5},
+		{"clamp above max", UISettings{RemoteLatencyRefreshSecs: 9999}, 5, 300},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.ui.GetRemoteLatencyRefreshSecs(tc.fallback)
+			if got != tc.want {
+				t.Fatalf("GetRemoteLatencyRefreshSecs(%d) on %+v = %d, want %d", tc.fallback, tc.ui, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -510,3 +510,36 @@ type RemoteSessionInfo struct {
 	// Set locally, not from JSON
 	RemoteName string `json:"-"`
 }
+
+// RemoteLatency is a live round-trip-time sample for a configured remote.
+// Tracked per remote host (not per session) — multiple sessions on the same
+// host share the same connection, so latency is a host-level metric. See
+// issue #1103.
+type RemoteLatency struct {
+	// MS is the round-trip time in milliseconds. Meaningful only when
+	// Offline is false.
+	MS int
+	// Offline is true when the most recent measurement attempt failed
+	// (network error, SSH dead, remote agent-deck binary missing, etc).
+	Offline bool
+	// MeasuredAt is when the sample was taken; zero value means never measured.
+	MeasuredAt time.Time
+}
+
+// MeasureLatency measures the round-trip time of a lightweight noop call
+// to the remote agent-deck binary. Returns the elapsed duration on success.
+//
+// Implementation note: we run `agent-deck --version` because it is the
+// cheapest possible call (no DB read, no tmux probe, no network back to
+// services). The ControlMaster socket is persisted across calls so we
+// measure mostly network RTT after the first hit, which is exactly what
+// the user wants to see in the header per #1103.
+func (r *SSHRunner) MeasureLatency(ctx context.Context) (time.Duration, error) {
+	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	start := time.Now()
+	if _, err := r.run(timeoutCtx, "--version"); err != nil {
+		return 0, err
+	}
+	return time.Since(start), nil
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -202,7 +202,11 @@ type UISettings struct {
 	// values: "tab", "window". Empty defaults to "tab" (iTerm's natural
 	// UX). Issue #1100, follow-up to #1098 — credit @ddorman-dn.
 	ITermOpenAs string `toml:"iterm_open_as"`
-}
+// RemoteLatencyRefreshSecs sets how often the TUI re-measures the
+	// round-trip latency to each configured remote (issue #1103). Valid
+	// range: 2-300. Default: matches [system_stats].refresh_seconds (5s)
+	// so the latency marker ticks alongside CPU/RAM/load.
+	RemoteLatencyRefreshSecs int `toml:"remote_latency_refresh_secs"`}
 
 // DefaultPreviewPct is the default preview-pane width percentage.
 // Matches the historical hardcoded 0.35 sessions / 0.65 preview split.
@@ -249,7 +253,23 @@ func (u UISettings) GetITermOpenAs() string {
 		return ITermOpenAsTab
 	}
 	return DefaultITermOpenAs
-}
+// GetRemoteLatencyRefreshSecs returns the remote latency refresh interval
+// in seconds, clamped to [2, 300]. When the user has not set this value
+// it falls back to fallbackSecs (typically the system_stats refresh
+// interval, so the latency marker ticks at the same cadence as CPU/RAM
+// per #1103). fallbackSecs <= 0 maps to 5.
+func (u UISettings) GetRemoteLatencyRefreshSecs(fallbackSecs int) int {
+	val := u.RemoteLatencyRefreshSecs
+	if val <= 0 {
+		val = fallbackSecs
+	}
+	if val < 2 {
+		val = 5
+	}
+	if val > 300 {
+		val = 300
+	}
+	return val}
 
 // WebSettings configures the `agent-deck web` HTTP server.
 type WebSettings struct {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -459,6 +459,14 @@ type Home struct {
 	lastRemoteFetch    time.Time // When remote sessions were last fetched
 	remotesFetchActive bool      // Prevents overlapping fetches
 
+	// Remote latency (issue #1103) — measured per remote host on the same
+	// cadence as CPU/RAM (see UISettings.GetRemoteLatencyRefreshSecs).
+	remoteLatency           map[string]session.RemoteLatency
+	remoteLatencyMu         sync.RWMutex
+	lastRemoteLatencyFetch  time.Time
+	remoteLatencyFetchBusy  bool
+	remoteLatencyRefreshSec int // resolved once at construction
+
 	// Cost tracking
 	costStore            *costs.Store
 	costPricer           *costs.Pricer
@@ -758,6 +766,12 @@ type remoteSessionsFetchedMsg struct {
 	sessions map[string][]session.RemoteSessionInfo
 }
 
+// remoteLatenciesFetchedMsg is sent when an async batch of latency
+// measurements completes. Keyed by remote name. See issue #1103.
+type remoteLatenciesFetchedMsg struct {
+	latencies map[string]session.RemoteLatency
+}
+
 // systemThemeMsg is sent when the OS dark mode setting changes.
 type systemThemeMsg struct {
 	dark bool
@@ -919,12 +933,15 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.sysStatsConfig = cfg.SystemStats
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(cfg, actualProfile)
 		h.previewPct = cfg.UI.GetPreviewPct()
+		h.remoteLatencyRefreshSec = cfg.UI.GetRemoteLatencyRefreshSecs(cfg.SystemStats.GetRefreshSeconds())
 	} else {
 		h.fullRepaint = (session.DisplaySettings{}).GetFullRepaint()
 		h.activeFilterExcludes = (session.DisplaySettings{}).GetActiveFilterExcludes()
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(nil, actualProfile)
 		h.previewPct = session.DefaultPreviewPct
+		h.remoteLatencyRefreshSec = (session.UISettings{}).GetRemoteLatencyRefreshSecs(0)
 	}
+	h.remoteLatency = make(map[string]session.RemoteLatency)
 
 	// Initialize system stats collector if enabled
 	if h.sysStatsConfig.GetEnabled() {
@@ -2191,6 +2208,52 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 	}
 
 	return remoteSessionsFetchedMsg{sessions: results}
+}
+
+// measureRemoteLatencies measures round-trip latency to every configured
+// remote in parallel, returning a map keyed by remote name. Failed
+// measurements are recorded as Offline=true so the header can show
+// `— offline` instead of a misleading stale ms value. Issue #1103.
+func (h *Home) measureRemoteLatencies() tea.Msg {
+	config, err := session.LoadUserConfig()
+	if err != nil || config == nil || len(config.Remotes) == 0 {
+		return remoteLatenciesFetchedMsg{latencies: nil}
+	}
+
+	results := make(map[string]session.RemoteLatency, len(config.Remotes))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	// Bound total budget: each individual MeasureLatency has its own 5s
+	// timeout, but we also cap the outer batch so we never starve the
+	// tick that triggered us.
+	ctx, cancel := context.WithTimeout(h.ctx, 8*time.Second)
+	defer cancel()
+
+	for name, rc := range config.Remotes {
+		wg.Add(1)
+		go func(name string, rc session.RemoteConfig) {
+			defer wg.Done()
+			runner := session.NewSSHRunner(name, rc)
+			d, err := runner.MeasureLatency(ctx)
+			lat := session.RemoteLatency{MeasuredAt: time.Now()}
+			if err != nil {
+				lat.Offline = true
+			} else {
+				ms := int(d.Milliseconds())
+				if ms < 0 {
+					ms = 0
+				}
+				lat.MS = ms
+			}
+			mu.Lock()
+			results[name] = lat
+			mu.Unlock()
+		}(name, rc)
+	}
+	wg.Wait()
+
+	return remoteLatenciesFetchedMsg{latencies: results}
 }
 
 // loadSessions loads sessions from storage and initializes the pool
@@ -4272,6 +4335,19 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.rebuildFlatItems()
 		return h, nil
 
+	case remoteLatenciesFetchedMsg:
+		h.remoteLatencyMu.Lock()
+		if h.remoteLatency == nil {
+			h.remoteLatency = make(map[string]session.RemoteLatency)
+		}
+		for name, lat := range msg.latencies {
+			h.remoteLatency[name] = lat
+		}
+		h.lastRemoteLatencyFetch = time.Now()
+		h.remoteLatencyFetchBusy = false
+		h.remoteLatencyMu.Unlock()
+		return h, nil
+
 	case remoteSessionDeletedMsg:
 		if msg.err != nil {
 			h.setError(fmt.Errorf("failed to delete remote session: %w", msg.err))
@@ -4837,6 +4913,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tickMsg:
 		var remoteFetchCmd tea.Cmd
+		var remoteLatencyCmd tea.Cmd
 
 		// Auto-dismiss errors after 5 seconds
 		if h.err != nil && !h.errTime.IsZero() && time.Since(h.errTime) > 5*time.Second {
@@ -4888,6 +4965,26 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.remotesFetchActive = true
 			h.remoteSessionsMu.Unlock()
 			remoteFetchCmd = h.fetchRemoteSessions
+		}
+
+		// Periodic remote latency measurement (issue #1103). Cadence is
+		// configurable via [ui] remote_latency_refresh_secs, defaulting
+		// to system_stats.refresh_seconds so the marker ticks alongside
+		// CPU/RAM. Fast/non-blocking — each remote runs in its own
+		// goroutine inside the Cmd.
+		refresh := h.remoteLatencyRefreshSec
+		if refresh < 2 {
+			refresh = 5
+		}
+		h.remoteLatencyMu.RLock()
+		shouldLatency := !h.remoteLatencyFetchBusy &&
+			time.Since(h.lastRemoteLatencyFetch) >= time.Duration(refresh)*time.Second
+		h.remoteLatencyMu.RUnlock()
+		if shouldLatency {
+			h.remoteLatencyMu.Lock()
+			h.remoteLatencyFetchBusy = true
+			h.remoteLatencyMu.Unlock()
+			remoteLatencyCmd = h.measureRemoteLatencies
 		}
 
 		// Fast log size check every 10 seconds (catches runaway logs before they cause issues)
@@ -4985,7 +5082,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.previewCacheMu.Unlock()
 			}
 		}
-		cmds := []tea.Cmd{h.tick(), previewCmd, remoteFetchCmd}
+		cmds := []tea.Cmd{h.tick(), previewCmd, remoteFetchCmd, remoteLatencyCmd}
 		if h.fullRepaint {
 			cmds = append(cmds, tea.ClearScreen)
 		}
@@ -12279,12 +12376,55 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 		selPrefix = "▶ "
 	}
 
-	b.WriteString(fmt.Sprintf("%s%s %s%s\n",
+	b.WriteString(fmt.Sprintf("%s%s %s%s%s\n",
 		selPrefix,
 		expandIcon,
 		nameStyle.Render("remotes/"+item.RemoteName),
 		countStyle.Render(fmt.Sprintf(" (%d)", count)),
+		h.renderRemoteLatencyMarker(item.RemoteName, selected),
 	))
+}
+
+// renderRemoteLatencyMarker returns the colored ` — Xms` (or ` — offline`)
+// suffix for a remote group header. Empty string when no measurement has
+// been taken yet so the header doesn't jitter on first paint. See #1103.
+//
+// Color thresholds:
+//   - green:  <  50ms        (lipgloss color 2)
+//   - yellow: 50-200ms       (color 3)
+//   - red:    > 200ms or offline (color 1)
+func (h *Home) renderRemoteLatencyMarker(remoteName string, selected bool) string {
+	h.remoteLatencyMu.RLock()
+	lat, ok := h.remoteLatency[remoteName]
+	h.remoteLatencyMu.RUnlock()
+	if !ok || lat.MeasuredAt.IsZero() {
+		return ""
+	}
+
+	var text string
+	var color lipgloss.Color
+	switch {
+	case lat.Offline:
+		text = " — offline"
+		color = lipgloss.Color("1") // red
+	case lat.MS < 50:
+		text = fmt.Sprintf(" — %dms", lat.MS)
+		color = lipgloss.Color("2") // green
+	case lat.MS <= 200:
+		text = fmt.Sprintf(" — %dms", lat.MS)
+		color = lipgloss.Color("3") // yellow
+	default:
+		text = fmt.Sprintf(" — %dms", lat.MS)
+		color = lipgloss.Color("1") // red
+	}
+
+	style := lipgloss.NewStyle().Foreground(color)
+	if selected {
+		// On the selected row, preserve color so the threshold signal
+		// stays readable against the highlight background.
+		style = style.Bold(true)
+	}
+	return style.Render(text)
 }
 
 // renderRemoteSessionItem renders a single remote session row

--- a/internal/ui/issue1103_header_latency_render_test.go
+++ b/internal/ui/issue1103_header_latency_render_test.go
@@ -1,0 +1,195 @@
+// Issue #1103 — Remote session latency markers (render layer).
+//
+// Reporter: @ddorman-dn — `remotes/<name> — <Xms>` in TUI header with color
+// thresholds (green <50, yellow 50-200, red >200). This file pins the
+// render-side invariants:
+//
+//   - renderRemoteGroupItem appends ` — Xms` after the count for connected
+//     remotes that have been measured.
+//   - Color matches the threshold band.
+//   - An unmeasured remote (zero-valued RemoteLatency) renders NO marker,
+//     so the header doesn't jitter on first paint.
+//   - Offline (measurement failed) renders ` — offline` in red.
+
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestIssue1103_Header_ShowsLatencyMs_ForConnectedRemote(t *testing.T) {
+	forceTrueColorProfile()
+
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.remoteLatency["dev"] = session.RemoteLatency{
+		MS:         47,
+		MeasuredAt: time.Now(),
+	}
+
+	item := session.Item{
+		Type:       session.ItemTypeRemoteGroup,
+		RemoteName: "dev",
+	}
+	var b strings.Builder
+	home.renderRemoteGroupItem(&b, item, false)
+	rendered := b.String()
+
+	if !strings.Contains(stripANSI(rendered), "remotes/dev") {
+		t.Fatalf("header missing `remotes/dev`: %q", rendered)
+	}
+	if !strings.Contains(stripANSI(rendered), "— 47ms") {
+		t.Fatalf("header missing ` — 47ms` marker per #1103: %q", stripANSI(rendered))
+	}
+}
+
+func TestIssue1103_Header_ColorByThreshold(t *testing.T) {
+	forceTrueColorProfile()
+
+	cases := []struct {
+		name      string
+		ms        int
+		wantColor string // lipgloss.Color value used in render
+	}{
+		{"green under 50ms", 12, "2"},
+		{"green just under 50ms", 49, "2"},
+		{"yellow at 50ms", 50, "3"},
+		{"yellow at 200ms", 200, "3"},
+		{"red over 200ms", 201, "1"},
+		{"red way over", 800, "1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := NewHome()
+			home.width = 100
+			home.height = 30
+			home.remoteLatency["dev"] = session.RemoteLatency{
+				MS:         tc.ms,
+				MeasuredAt: time.Now(),
+			}
+			item := session.Item{
+				Type:       session.ItemTypeRemoteGroup,
+				RemoteName: "dev",
+			}
+			var b strings.Builder
+			home.renderRemoteGroupItem(&b, item, false)
+			got := b.String()
+
+			// Build the expected styled fragment with the same lipgloss style
+			// the renderer uses, so the assertion is robust to terminfo.
+			wantText := " — " + itoa(tc.ms) + "ms"
+			wantFragment := lipgloss.NewStyle().
+				Foreground(lipgloss.Color(tc.wantColor)).
+				Render(wantText)
+
+			if !strings.Contains(got, wantFragment) {
+				t.Fatalf("ms=%d must render colored fragment %q; got %q", tc.ms, wantFragment, got)
+			}
+		})
+	}
+}
+
+func TestIssue1103_Header_OfflineRendersOfflineMarker(t *testing.T) {
+	forceTrueColorProfile()
+
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.remoteLatency["dev"] = session.RemoteLatency{
+		Offline:    true,
+		MeasuredAt: time.Now(),
+	}
+	item := session.Item{
+		Type:       session.ItemTypeRemoteGroup,
+		RemoteName: "dev",
+	}
+	var b strings.Builder
+	home.renderRemoteGroupItem(&b, item, false)
+	rendered := stripANSI(b.String())
+
+	if !strings.Contains(rendered, "— offline") {
+		t.Fatalf("disconnected remote must show ` — offline` per #1103; got %q", rendered)
+	}
+	// And critically: never report 0ms for a disconnected remote, which
+	// would falsely indicate a healthy remote.
+	if strings.Contains(rendered, "0ms") {
+		t.Fatalf("offline remote rendered as 0ms — wrong: %q", rendered)
+	}
+}
+
+func TestIssue1103_Header_NeverMeasured_SuppressesMarker(t *testing.T) {
+	forceTrueColorProfile()
+
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	// Intentionally do NOT populate remoteLatency["dev"]: simulates a
+	// fresh start before the first tick has run.
+
+	item := session.Item{
+		Type:       session.ItemTypeRemoteGroup,
+		RemoteName: "dev",
+	}
+	var b strings.Builder
+	home.renderRemoteGroupItem(&b, item, false)
+	rendered := stripANSI(b.String())
+
+	if strings.Contains(rendered, " — ") {
+		t.Fatalf("unmeasured remote must NOT render a latency marker (avoids first-paint jitter); got %q", rendered)
+	}
+	if !strings.Contains(rendered, "remotes/dev") {
+		t.Fatalf("header still must contain `remotes/dev`; got %q", rendered)
+	}
+}
+
+// itoa is a tiny local helper so the assertion doesn't depend on strconv
+// or fmt format directives (keeps the diff readable).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// stripANSI removes ANSI escape sequences so substring assertions on the
+// human-visible text are robust to color codes.
+func stripANSI(s string) string {
+	var out strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			// Skip through the terminating letter
+			j := i + 2
+			for j < len(s) && !((s[j] >= 'A' && s[j] <= 'Z') || (s[j] >= 'a' && s[j] <= 'z')) {
+				j++
+			}
+			if j < len(s) {
+				i = j
+			}
+			continue
+		}
+		out.WriteByte(s[i])
+	}
+	return out.String()
+}


### PR DESCRIPTION
## Summary

Live round-trip latency next to each `remotes/<name>` row in the TUI header, refreshed on the same cadence as CPU/RAM/load — per feature request from @ddorman-dn in #1103.

Format: `▾ remotes/dev (3) — 47ms` (where `47ms` is colored by threshold).

## How it works

- `SSHRunner.MeasureLatency(ctx)` pings the remote with `agent-deck --version` (cheapest universal noop) through the persisted SSH `ControlMaster` socket, so successive ticks measure mostly network RTT.
- A new `measureRemoteLatencies` tea.Cmd runs the measurements in parallel goroutines off the UI thread, with an 8s outer budget.
- The tick handler kicks off measurement on the configured cadence with a non-overlapping `remoteLatencyFetchBusy` guard.
- `renderRemoteGroupItem` appends the colored marker.

## Color thresholds

| Latency | Color |
|---|---|
| `< 50ms` | green (lipgloss `2`) |
| `50–200ms` | yellow (lipgloss `3`) |
| `> 200ms` | red (lipgloss `1`) |
| offline | red ` — offline` |
| never measured | no marker (avoids first-paint jitter) |

## Config

```toml
[ui]
remote_latency_refresh_secs = 5  # default = system_stats.refresh_seconds
```

Clamped to `[2, 300]`. When omitted, falls back to `system_stats.refresh_seconds` so the marker ticks at the same rate as CPU/RAM by default — matching the issue's "default same as the cpu/ram/load updates" requirement.

## Tests

- `internal/session/issue1103_remote_latency_test.go` — pins MeasureLatency invariants (calls `--version`, propagates errors, zero `RemoteLatency` means "unknown" not "offline") and config clamp behavior.
- `internal/ui/issue1103_header_latency_render_test.go` — pins render invariants (color by threshold band, `— offline` for failed measurements never reads as `0ms`, never-measured remote suppresses marker).

Full suite (race + count=1, all packages) is green. Mandated `TestPersistence_*`, `internal/watcher/...`, and feedback tests all pass.

## Don't-break checks

- ✅ CPU/RAM/load updates unchanged
- ✅ Header for non-remote contexts unchanged
- ✅ Remote-disconnected case: shows ` — offline` instead of misleading `0ms`

Credit: @ddorman-dn for the feature request and the screenshot in #1103.

## Test plan

- [ ] Configure two remotes, attach via SSH, watch header tick at 5s default cadence
- [ ] Take one remote offline → marker flips to ` — offline` (red) within one tick
- [ ] Set `[ui] remote_latency_refresh_secs = 2` → cadence increases as expected
- [ ] Set high-latency proxy → marker turns yellow then red as RTT crosses thresholds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote latency measurement displayed in the TUI with periodic refresh and suppressed marker until first measurement to avoid jitter
  * Color-coded latency indicators: green (<50ms), yellow (50–200ms), red (>200ms)
  * Offline status shown for unreachable remotes; "never measured" preserved until first check
  * Configurable refresh interval via remote_latency_refresh_secs (clamped 2–300s; sensible defaults)

* **Tests**
  * Added tests validating measurement, error propagation, UI rendering, and refresh-interval behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->