### PR TITLE
fix(ui): remote session preview pane + cost/usage propagation (closes #1101, follow-up to #1095 + #1073)

### DIFF
--- a/cmd/agent-deck/costs_cmd.go
+++ b/cmd/agent-deck/costs_cmd.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 
@@ -21,7 +23,7 @@ func handleCosts(profile string, args []string) {
 	case "sync":
 		handleCostsSync(profile)
 	case "summary":
-		handleCostsSummary(profile)
+		handleCostsSummary(profile, args[1:])
 	case "recompute":
 		handleCostsRecompute(profile, args[1:])
 	default:
@@ -108,14 +110,44 @@ func handleCostsSync(profile string) {
 	}
 }
 
-func handleCostsSummary(profile string) {
+func handleCostsSummary(profile string, args []string) {
+	// #1101: --json output so a remote agent-deck can be queried over SSH and
+	// its cost totals merged into the local TUI's status-line cost segment.
+	fs := flag.NewFlagSet("costs summary", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(1)
+	}
+
 	costStore, storage := openCostStore(profile)
 	defer storage.Close()
 
 	today, _ := costStore.TotalToday()
+	yesterday, _ := costStore.TotalYesterday()
 	week, _ := costStore.TotalThisWeek()
+	lastWeek, _ := costStore.TotalLastWeek()
 	month, _ := costStore.TotalThisMonth()
+	lastMonth, _ := costStore.TotalLastMonth()
 	projected, _ := costStore.ProjectedMonthly()
+
+	if *jsonOutput {
+		// Wire shape mirrors costs.RemoteCostSummary so SSHRunner can json.Unmarshal directly.
+		payload := map[string]interface{}{
+			"cost_today_microdollars":      today.TotalCostMicrodollars,
+			"cost_yesterday_microdollars":  yesterday.TotalCostMicrodollars,
+			"cost_this_week_microdollars":  week.TotalCostMicrodollars,
+			"cost_last_week_microdollars":  lastWeek.TotalCostMicrodollars,
+			"cost_this_month_microdollars": month.TotalCostMicrodollars,
+			"cost_last_month_microdollars": lastMonth.TotalCostMicrodollars,
+			"cost_projected_microdollars":  projected,
+			"events_today":                 today.EventCount,
+			"events_this_week":             week.EventCount,
+			"events_this_month":            month.EventCount,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		_ = enc.Encode(payload)
+		return
+	}
 
 	fmt.Printf("Cost Summary:\n")
 	fmt.Printf("  Today:      %s (%d events)\n", costs.FormatUSD(today.TotalCostMicrodollars), today.EventCount)

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2783,6 +2783,11 @@ func handleSessionOutput(profile string, args []string) {
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
 	copyFlag := fs.Bool("copy", false, "Copy output to system clipboard")
+	// #1101: --pane returns the raw tmux capture-pane content (with ANSI escapes
+	// and the tool's full UI chrome) instead of the parsed transcript "last
+	// response". The local TUI preview uses capture-pane; remote sessions
+	// fetched via SSH need this same content to render claude-formatted output.
+	paneFlag := fs.Bool("pane", false, "Return tmux capture-pane content (full UI with ANSI)")
 
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session output [id|title] [options]")
@@ -2827,6 +2832,32 @@ func handleSessionOutput(profile string, args []string) {
 			inst.ClaudeSessionID = freshID
 			inst.ClaudeDetectedAt = time.Now()
 		}
+	}
+
+	// #1101: --pane short-circuits the transcript path and returns the live
+	// tmux pane capture so remote previews can render the same claude-formatted
+	// content the local preview shows. We still emit a ResponseOutput-shaped
+	// JSON so the wire format is unchanged.
+	if *paneFlag {
+		paneContent, paneErr := inst.PreviewFull()
+		if paneErr != nil {
+			out.Error(fmt.Sprintf("failed to capture pane: %v", paneErr), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+		jsonData := map[string]interface{}{
+			"success":       true,
+			"session_id":    inst.ID,
+			"session_title": inst.Title,
+			"tool":          inst.Tool,
+			"role":          "pane",
+			"content":       paneContent,
+		}
+		if quietMode {
+			fmt.Println(paneContent)
+			return
+		}
+		out.Print(paneContent, jsonData)
+		return
 	}
 
 	// Get the last response (best-effort fallback for smoother CLI reads)

--- a/internal/costs/costs.go
+++ b/internal/costs/costs.go
@@ -48,3 +48,42 @@ type DailyCost struct {
 func FormatUSD(microdollars int64) string {
 	return fmt.Sprintf("$%.2f", float64(microdollars)/1_000_000)
 }
+
+// RemoteCostSummary mirrors `agent-deck costs summary --json` output. #1101:
+// when an SSH remote is configured, the TUI fetches one of these per remote
+// and folds the totals into the local cost-line totals so the status bar
+// reflects spend across every host.
+type RemoteCostSummary struct {
+	CostTodayMicrodollars     int64 `json:"cost_today_microdollars"`
+	CostYesterdayMicrodollars int64 `json:"cost_yesterday_microdollars"`
+	CostThisWeekMicrodollars  int64 `json:"cost_this_week_microdollars"`
+	CostLastWeekMicrodollars  int64 `json:"cost_last_week_microdollars"`
+	CostThisMonthMicrodollars int64 `json:"cost_this_month_microdollars"`
+	CostLastMonthMicrodollars int64 `json:"cost_last_month_microdollars"`
+	CostProjectedMicrodollars int64 `json:"cost_projected_microdollars"`
+	EventsToday               int   `json:"events_today"`
+	EventsThisWeek            int   `json:"events_this_week"`
+	EventsThisMonth           int   `json:"events_this_month"`
+}
+
+// MergeRemoteCostSummaries sums per-remote summaries into a single aggregate.
+// Used by the TUI to display a combined "local + all remotes" cost line.
+func MergeRemoteCostSummaries(summaries map[string]*RemoteCostSummary) RemoteCostSummary {
+	var out RemoteCostSummary
+	for _, s := range summaries {
+		if s == nil {
+			continue
+		}
+		out.CostTodayMicrodollars += s.CostTodayMicrodollars
+		out.CostYesterdayMicrodollars += s.CostYesterdayMicrodollars
+		out.CostThisWeekMicrodollars += s.CostThisWeekMicrodollars
+		out.CostLastWeekMicrodollars += s.CostLastWeekMicrodollars
+		out.CostThisMonthMicrodollars += s.CostThisMonthMicrodollars
+		out.CostLastMonthMicrodollars += s.CostLastMonthMicrodollars
+		out.CostProjectedMicrodollars += s.CostProjectedMicrodollars
+		out.EventsToday += s.EventsToday
+		out.EventsThisWeek += s.EventsThisWeek
+		out.EventsThisMonth += s.EventsThisMonth
+	}
+	return out
+}

--- a/internal/costs/issue1101_remote_cost_test.go
+++ b/internal/costs/issue1101_remote_cost_test.go
@@ -1,0 +1,117 @@
+package costs
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestIssue1101_RemoteCostSummary_JSONRoundtrip pins the wire format that
+// `agent-deck costs summary --json` emits and that the local TUI's SSH
+// fetcher decodes back into a RemoteCostSummary. The field names are an
+// API contract — renaming any of them silently breaks remote cost
+// aggregation across an agent-deck-on-each-side upgrade.
+func TestIssue1101_RemoteCostSummary_JSONRoundtrip(t *testing.T) {
+	original := RemoteCostSummary{
+		CostTodayMicrodollars:     1_500_000, // $1.50
+		CostYesterdayMicrodollars: 2_000_000,
+		CostThisWeekMicrodollars:  10_000_000,
+		CostLastWeekMicrodollars:  9_000_000,
+		CostThisMonthMicrodollars: 25_000_000,
+		CostLastMonthMicrodollars: 23_000_000,
+		CostProjectedMicrodollars: 30_000_000,
+		EventsToday:               5,
+		EventsThisWeek:            42,
+		EventsThisMonth:           180,
+	}
+
+	raw, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Spot-check the JSON keys — these are what `costs summary --json`
+	// writes and what SSHRunner.FetchCostSummary reads.
+	wantSubstrings := []string{
+		`"cost_today_microdollars":1500000`,
+		`"cost_this_week_microdollars":10000000`,
+		`"cost_projected_microdollars":30000000`,
+		`"events_today":5`,
+		`"events_this_month":180`,
+	}
+	got := string(raw)
+	for _, want := range wantSubstrings {
+		if !contains(got, want) {
+			t.Fatalf("missing %q in JSON output: %s", want, got)
+		}
+	}
+
+	var decoded RemoteCostSummary
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded != original {
+		t.Fatalf("roundtrip mismatch:\nwant %+v\ngot  %+v", original, decoded)
+	}
+}
+
+// TestIssue1101_MergeRemoteCostSummaries_AggregatesTotals asserts that the
+// TUI's per-host summary aggregator sums every microdollar field across all
+// configured remotes. This is the core arithmetic that makes the
+// status-line cost segment reflect "local + every remote" instead of
+// "local only" (which is what users on v1.9.23 see today for remote
+// claude sessions).
+func TestIssue1101_MergeRemoteCostSummaries_AggregatesTotals(t *testing.T) {
+	summaries := map[string]*RemoteCostSummary{
+		"dev": {
+			CostTodayMicrodollars:    1_000_000,
+			CostThisWeekMicrodollars: 5_000_000,
+			EventsToday:              3,
+		},
+		"prod": {
+			CostTodayMicrodollars:    2_500_000,
+			CostThisWeekMicrodollars: 12_000_000,
+			EventsToday:              7,
+		},
+		// nil entry simulates a failed fetch (e.g., older remote without
+		// `costs summary --json`); aggregator must skip it without panic.
+		"broken": nil,
+	}
+
+	got := MergeRemoteCostSummaries(summaries)
+
+	if want := int64(3_500_000); got.CostTodayMicrodollars != want {
+		t.Fatalf("CostTodayMicrodollars = %d, want %d", got.CostTodayMicrodollars, want)
+	}
+	if want := int64(17_000_000); got.CostThisWeekMicrodollars != want {
+		t.Fatalf("CostThisWeekMicrodollars = %d, want %d", got.CostThisWeekMicrodollars, want)
+	}
+	if want := 10; got.EventsToday != want {
+		t.Fatalf("EventsToday = %d, want %d", got.EventsToday, want)
+	}
+}
+
+// TestIssue1101_MergeRemoteCostSummaries_EmptyInput is a safety guard for
+// the cold-start case (no remotes configured, or first fetch hasn't
+// completed). The renderer calls Merge on every paint; it must return a
+// zero value cleanly, not panic on nil/empty maps.
+func TestIssue1101_MergeRemoteCostSummaries_EmptyInput(t *testing.T) {
+	if got := MergeRemoteCostSummaries(nil); got != (RemoteCostSummary{}) {
+		t.Fatalf("nil input: got %+v, want zero value", got)
+	}
+	if got := MergeRemoteCostSummaries(map[string]*RemoteCostSummary{}); got != (RemoteCostSummary{}) {
+		t.Fatalf("empty map: got %+v, want zero value", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/costs"
 	"github.com/asheshgoplani/agent-deck/internal/termreply"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 	"github.com/creack/pty"
@@ -296,6 +297,48 @@ func (r *SSHRunner) FetchSessionOutput(ctx context.Context, sessionID string) (s
 	}
 
 	return parseRemoteSessionOutput(output)
+}
+
+// FetchSessionPane retrieves the tmux capture-pane content for a remote session.
+// #1101: Local TUI previews render capture-pane content (ANSI + tool UI chrome).
+// Remote previews used to fetch only the parsed transcript text via
+// FetchSessionOutput, which is why claude-formatted output never showed for
+// SSH sessions. FetchSessionPane closes that gap by asking the remote for the
+// raw pane content via `session output --pane --json`.
+func (r *SSHRunner) FetchSessionPane(ctx context.Context, sessionID string) (string, error) {
+	output, err := r.Run(ctx, "session", "output", sessionID, "--pane", "--json")
+	if err != nil {
+		return "", err
+	}
+
+	return parseRemoteSessionOutput(output)
+}
+
+// FetchCostSummary retrieves the remote agent-deck's cost summary as JSON.
+// #1101: the local TUI's status-line cost segment used to show only events
+// written to the local cost_events table — remote sessions' Stop hooks write
+// to the remote DB, so their spend never surfaced locally. The TUI calls this
+// per configured remote and folds the totals into the displayed figures.
+//
+// Returns nil with no error when the remote returns empty output (older
+// agent-deck builds that predate `costs summary --json`). Callers should
+// treat a nil summary as "remote not available; render local-only totals".
+func (r *SSHRunner) FetchCostSummary(ctx context.Context) (*costs.RemoteCostSummary, error) {
+	output, err := r.Run(ctx, "costs", "summary", "--json")
+	if err != nil {
+		return nil, err
+	}
+
+	trimmed := bytes.TrimSpace(output)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, nil
+	}
+
+	var summary costs.RemoteCostSummary
+	if err := json.Unmarshal(trimmed, &summary); err != nil {
+		return nil, fmt.Errorf("failed to parse remote cost summary: %w", err)
+	}
+	return &summary, nil
 }
 
 // DetectPlatform returns the remote host's OS and architecture (e.g., "linux", "amd64").

--- a/internal/session/ssh_test_helper.go
+++ b/internal/session/ssh_test_helper.go
@@ -1,0 +1,14 @@
+package session
+
+import "context"
+
+// SetSSHRunnerRunFnForTest assigns the unexported runFn field on an SSHRunner.
+// Tests in other packages (notably internal/ui) need this to stub out SSH
+// command execution without spawning a real ssh subprocess.
+//
+// Do not call from non-test code; runFn is meant for test injection only.
+func SetSSHRunnerRunFnForTest(r *SSHRunner, fn func(args ...string) ([]byte, error)) {
+	r.runFn = func(_ context.Context, args ...string) ([]byte, error) {
+		return fn(args...)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -466,7 +466,11 @@ type Home struct {
 	lastRemoteLatencyFetch  time.Time
 	remoteLatencyFetchBusy  bool
 	remoteLatencyRefreshSec int // resolved once at construction
-
+// #1101: remote cost summaries fetched alongside session listings so the
+	// status-line cost segment reflects spend on every configured remote, not
+	// just events written to the local cost_events table.
+	remoteCosts   map[string]*costs.RemoteCostSummary // remoteName -> summary
+	remoteCostsMu sync.RWMutex
 	// Cost tracking
 	costStore            *costs.Store
 	costPricer           *costs.Pricer
@@ -764,6 +768,8 @@ type sendOutputResultMsg struct {
 // remoteSessionsFetchedMsg is sent when async remote sessions fetch completes.
 type remoteSessionsFetchedMsg struct {
 	sessions map[string][]session.RemoteSessionInfo
+	// #1101: per-remote cost summary collected on the same SSH fanout.
+	costs map[string]*costs.RemoteCostSummary
 }
 
 // remoteLatenciesFetchedMsg is sent when an async batch of latency
@@ -2192,6 +2198,13 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 	}
 
 	results := make(map[string][]session.RemoteSessionInfo)
+	// #1101: remote cost summaries piggy-back on the existing remote-fetch
+	// channel so the status-line cost segment doesn't lag behind the session
+	// list. nil-valued entries indicate fetch failures (e.g., older remote
+	// agent-deck without `costs summary --json`); the renderer treats those
+	// as "remote contributes zero" so a single broken remote can't poison
+	// the displayed total.
+	costResults := make(map[string]*costs.RemoteCostSummary)
 	ctx, cancel := context.WithTimeout(h.ctx, 15*time.Second)
 	defer cancel()
 
@@ -2205,9 +2218,13 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 			sessions[i].RemoteName = name
 		}
 		results[name] = sessions
+
+		if summary, costErr := runner.FetchCostSummary(ctx); costErr == nil && summary != nil {
+			costResults[name] = summary
+		}
 	}
 
-	return remoteSessionsFetchedMsg{sessions: results}
+	return remoteSessionsFetchedMsg{sessions: results, costs: costResults}
 }
 
 // measureRemoteLatencies measures round-trip latency to every configured
@@ -2604,7 +2621,18 @@ func (h *Home) fetchRemotePreview(remoteName, sessionID, key string) tea.Cmd {
 		ctx, cancel := context.WithTimeout(h.ctx, 15*time.Second)
 		defer cancel()
 
-		content, fetchErr := runner.FetchSessionOutput(ctx, sessionID)
+		// #1101: use FetchSessionPane (raw capture-pane content with ANSI +
+		// tool UI chrome) instead of FetchSessionOutput (parsed transcript
+		// text) so claude-formatted previews render the same way local
+		// sessions do. If the remote agent-deck predates --pane, fall back
+		// to the transcript path so the preview is at least non-empty.
+		content, fetchErr := runner.FetchSessionPane(ctx, sessionID)
+		if fetchErr != nil || strings.TrimSpace(content) == "" {
+			if fallback, fbErr := runner.FetchSessionOutput(ctx, sessionID); fbErr == nil && strings.TrimSpace(fallback) != "" {
+				content = fallback
+				fetchErr = nil
+			}
+		}
 		content = truncateRemotePreviewContent(content)
 		return previewFetchedMsg{previewKey: key, content: content, err: fetchErr}
 	}
@@ -4332,6 +4360,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.lastRemoteFetch = time.Now()
 		h.remotesFetchActive = false
 		h.remoteSessionsMu.Unlock()
+		// #1101: store remote cost summaries so renderCostLine can fold them
+		// into the displayed totals on the next paint.
+		h.remoteCostsMu.Lock()
+		h.remoteCosts = msg.costs
+		h.remoteCostsMu.Unlock()
 		h.rebuildFlatItems()
 		return h, nil
 
@@ -10084,14 +10117,21 @@ func (h *Home) View() string {
 	// See session.ResolveCostLineTemplate for the [costs] / per-profile
 	// override chain. RenderCostLine returns "" when hide_when_zero is on
 	// and every recognized variable rendered to $0.00.
+	// #1101: aggregate remote per-host summaries on top of local totals so the
+	// status-line cost segment reflects spend across every configured host,
+	// not only events written to the local cost_events table. Remotes whose
+	// fetch failed contribute zero — the local figures still render.
+	h.remoteCostsMu.RLock()
+	remoteAgg := costs.MergeRemoteCostSummaries(h.remoteCosts)
+	h.remoteCostsMu.RUnlock()
 	costVars := map[string]int64{
-		"cost_today":      h.costToday.Load(),
-		"cost_yesterday":  h.costYesterday.Load(),
-		"cost_this_week":  h.costWeek.Load(),
-		"cost_last_week":  h.costLastWeek.Load(),
-		"cost_this_month": h.costThisMonth.Load(),
-		"cost_last_month": h.costLastMonth.Load(),
-		"cost_projected":  h.costProjected.Load(),
+		"cost_today":      h.costToday.Load() + remoteAgg.CostTodayMicrodollars,
+		"cost_yesterday":  h.costYesterday.Load() + remoteAgg.CostYesterdayMicrodollars,
+		"cost_this_week":  h.costWeek.Load() + remoteAgg.CostThisWeekMicrodollars,
+		"cost_last_week":  h.costLastWeek.Load() + remoteAgg.CostLastWeekMicrodollars,
+		"cost_this_month": h.costThisMonth.Load() + remoteAgg.CostThisMonthMicrodollars,
+		"cost_last_month": h.costLastMonth.Load() + remoteAgg.CostLastMonthMicrodollars,
+		"cost_projected":  h.costProjected.Load() + remoteAgg.CostProjectedMicrodollars,
 	}
 	if rendered := costs.RenderCostLine(h.costLineTemplate, costVars, h.costLineHideWhenZero); rendered != "" {
 		costStyle := lipgloss.NewStyle().Foreground(ColorCyan)

--- a/internal/ui/issue1101_remote_preview_test.go
+++ b/internal/ui/issue1101_remote_preview_test.go
@@ -1,0 +1,123 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestIssue1101_RemotePreview_RendersClaudeFormattedContent asserts that when
+// the preview cache holds claude-formatted output (the kind capture-pane
+// returns — ANSI escapes, the ╭─ box border, the `> ` prompt), the remote
+// preview renderer writes that content verbatim into the output.
+//
+// Bug context: PR #1095 (v1.9.23) fixed the tool-label color for remote rows,
+// but @ddorman-dn confirmed in #1101 that the preview pane still doesn't show
+// claude-formatted output for SSH sessions. The root cause is that
+// `fetchRemotePreview` used `FetchSessionOutput`, which on the remote side
+// returns parsed transcript text via `GetLastResponseBestEffort()`. Local
+// previews use `tmux capture-pane -p -e`, which is what produces the
+// claude-formatted UI we want on remotes too.
+//
+// Fix: a new `FetchSessionPane` SSH method calls `agent-deck session output
+// --pane --json` on the remote, which the CLI now serves with PreviewFull()
+// (capture-pane content). This test pins the rendering contract — given a
+// populated cache with claude-formatted content, the renderer must emit
+// the ANSI/border markers, not strip them.
+func TestIssue1101_RemotePreview_RendersClaudeFormattedContent(t *testing.T) {
+	forceTrueColorProfile()
+
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID:         "remote-claude-1",
+		Title:      "my-claude-session",
+		Status:     "running",
+		Tool:       "claude",
+		RemoteName: "myserver",
+	}
+	item := session.Item{
+		Type:          session.ItemTypeRemoteSession,
+		RemoteName:    "myserver",
+		RemoteSession: &remote,
+	}
+
+	// Simulate the fix: cache populated by FetchSessionPane with raw
+	// capture-pane content (ANSI + claude box-drawing border + prompt).
+	// This is what `session output --pane --json` returns post-fix.
+	claudeFormatted := "\x1b[38;5;208m╭─────────────────────╮\x1b[0m\n" +
+		"\x1b[38;5;208m│\x1b[0m Welcome to Claude \x1b[38;5;208m│\x1b[0m\n" +
+		"\x1b[38;5;208m╰─────────────────────╯\x1b[0m\n" +
+		"\n> "
+
+	key := remotePreviewCacheKey("myserver", remote.ID)
+	home.previewCacheMu.Lock()
+	if home.previewCache == nil {
+		home.previewCache = make(map[string]string)
+	}
+	if home.previewCacheTime == nil {
+		home.previewCacheTime = make(map[string]time.Time)
+	}
+	home.previewCache[key] = claudeFormatted
+	home.previewCacheTime[key] = time.Now()
+	home.previewCacheMu.Unlock()
+
+	out := home.renderRemotePreview(item, 100, 30)
+
+	// The box-drawing border is the most reliable proof that the
+	// claude-formatted content reached the renderer. If the bug regressed
+	// (renderer strips ANSI or content is empty), this assertion fires.
+	if !strings.Contains(out, "╭") || !strings.Contains(out, "╮") {
+		t.Fatalf("expected claude box border in preview output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Welcome to Claude") {
+		t.Fatalf("expected claude content text in preview output; got:\n%s", out)
+	}
+	// The prompt marker also matters because the launching-animation code
+	// looks for "\n> " to decide the agent is ready.
+	if !strings.Contains(out, "> ") {
+		t.Fatalf("expected claude prompt marker '> ' in preview output; got:\n%s", out)
+	}
+}
+
+// TestIssue1101_RemotePreview_FetchUsesPaneFlag asserts that the
+// remote-preview fetch path calls the SSH runner with `--pane` (the new flag
+// added to `agent-deck session output` for #1101). If we ever revert to the
+// transcript-text path (`session output --json` without `--pane`), this test
+// fires — remote claude previews would silently degrade to plain text again.
+func TestIssue1101_RemotePreview_FetchUsesPaneFlag(t *testing.T) {
+	var gotArgs []string
+	runner := &session.SSHRunner{}
+	session.SetSSHRunnerRunFnForTest(runner, func(args ...string) ([]byte, error) {
+		gotArgs = append([]string(nil), args...)
+		// Return a minimal JSON envelope; the parser only needs `content`.
+		// Use \u001b for ANSI ESC because raw 0x1B is invalid in a JSON string.
+		return []byte(`{"content":"\u001b\u001b[38;5;208m╭─╮\u001b[0m"}`), nil
+	})
+
+	content, err := runner.FetchSessionPane(context.Background(), "abc")
+	if err != nil {
+		t.Fatalf("FetchSessionPane error: %v", err)
+	}
+	if !strings.Contains(content, "╭") {
+		t.Fatalf("expected ANSI/box-border content; got %q", content)
+	}
+	if len(gotArgs) < 4 {
+		t.Fatalf("expected runner called with >=4 args, got %v", gotArgs)
+	}
+	sawPane := false
+	for _, a := range gotArgs {
+		if a == "--pane" {
+			sawPane = true
+			break
+		}
+	}
+	if !sawPane {
+		t.Fatalf("expected `--pane` in SSH args; got %v", gotArgs)
+	}
+}


### PR DESCRIPTION
## Summary

#1101 by @ddorman-dn confirmed that after #1095 fixed the cell-list tool-color for SSH remotes, two gaps remain on v1.9.23:

1. **Preview pane**: claude-formatted output never renders for remote sessions
2. **Cost/usage**: status-line totals don't reflect spend on remote hosts

Both are now fixed and pinned by regression tests.

## The bugs

### A. Preview pane

`Home.fetchRemotePreview` called `SSHRunner.FetchSessionOutput`, which on the remote side runs `agent-deck session output --json`. That command returns the **parsed transcript text** via `GetLastResponseBestEffort()` — plain text, no borders, no colors.

Local previews use `tmux capture-pane -p -e` (via `Instance.PreviewFull()`), which is what produces the claude-formatted UI users actually want.

### B. Cost/usage

The status-line cost segment renders `h.costToday.Load()` etc. — totals computed from the local SQLite `cost_events` table. Remote sessions' Claude Stop hooks fire on the remote host and write to the **remote** DB. Locally, those events are invisible.

## Fix

### Preview path
- New `--pane` flag on `agent-deck session output` short-circuits the transcript parser and returns `Instance.PreviewFull()` (the same capture-pane content local preview uses), keeping the `ResponseOutput` JSON envelope.
- New `SSHRunner.FetchSessionPane(ctx, id)` calls `session output --pane --json`.
- `fetchRemotePreview` now prefers `FetchSessionPane`; on empty content or error (older remote that doesn't know `--pane`) it falls back to `FetchSessionOutput` so previews stay non-empty during a rolling upgrade.

### Cost path
- `agent-deck costs summary --json` emits a `RemoteCostSummary` payload (today/yesterday/this_week/last_week/this_month/last_month/projected microdollars + event counts).
- `SSHRunner.FetchCostSummary(ctx)` decodes it. Returns `nil` on empty/legacy output so a single broken remote can't poison the local total.
- `costs.MergeRemoteCostSummaries(map)` aggregates per-host summaries.
- `fetchRemoteSessions` collects cost summaries on the same SSH fanout (free ride on `ControlMaster=auto`).
- The renderer folds the merged remote totals into the existing `costVars` map, so the status-line cost segment now reflects local + every reachable remote.

## Tests

Per CLAUDE.md TDD mandate, regression tests land with the fix:

- `internal/ui/issue1101_remote_preview_test.go`
  - `TestIssue1101_RemotePreview_RendersClaudeFormattedContent` — ANSI + box-border content in the preview cache must reach the renderer's output verbatim.
  - `TestIssue1101_RemotePreview_FetchUsesPaneFlag` — `FetchSessionPane` must pass `--pane` over SSH; pins the contract so we can't silently regress to the transcript path.
- `internal/costs/issue1101_remote_cost_test.go`
  - `TestIssue1101_RemoteCostSummary_JSONRoundtrip` — wire-format contract for `costs summary --json`.
  - `TestIssue1101_MergeRemoteCostSummaries_AggregatesTotals` — sum across two remotes plus a nil (failed-fetch) entry.
  - `TestIssue1101_MergeRemoteCostSummaries_EmptyInput` — cold-start safety: nil/empty map returns zero-value, not panic.
- `internal/session/ssh_test_helper.go` — exports `SetSSHRunnerRunFnForTest` so UI tests can stub SSH without spawning a real subprocess.

## Test plan

- [x] `go test ./internal/ui/... ./internal/session/... ./internal/costs/... ./cmd/agent-deck/... -race -count=1` — all pass
- [x] `go test ./... -race -count=1` — full suite green (36 packages)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [ ] Manual: @ddorman-dn re-verifies the dashboard against an SSH remote post-merge (preview should now show the claude UI; cost segment should aggregate)

## Doesn't break

- Local session preview — not on this path.
- Local cost/usage — local `costStore` totals still loaded normally; remote aggregator is additive only.
- #1095 list cell color fix — `renderRemoteSessionItem` untouched.
- #1073 base remote tool propagation — wire shape unchanged for the legacy `FetchSessionOutput` path.

## Backwards compatibility

If a user upgrades their local agent-deck but not their remote:
- Preview path: `FetchSessionPane` errors → fallback to `FetchSessionOutput` (today's behavior).
- Cost path: `FetchCostSummary` gets empty/non-JSON output → returns nil → that remote contributes zero. No crash.

Full functionality requires both sides upgraded, same as #1095.

## Credit

Bug report and precise repro from @ddorman-dn (#1101). The screenshot showing a correctly-colored tool label next to an empty preview was what made the wire-vs-transcript split jump out.

Closes #1101 (follow-up to #1095 + #1073).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--json` to `costs summary` (JSON includes per-period totals and projected monthly totals)
  * Added `--pane` to `session output` to show raw pane content (preserves ANSI and UI chrome)
  * UI now fetches and aggregates remote cost summaries into the header cost display

* **Bug Fixes**
  * Remote previews preserve formatting (ANSI, box-drawing, prompts) and prefer pane capture with fallback

* **Tests**
  * Added tests for remote cost JSON/aggregation and remote preview behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->