### PR TITLE
fix(ui): status line counter — stopped sessions get their own bucket (re-closes #953)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -381,9 +381,9 @@ type Home struct {
 
 	// Cached status counts (invalidated on instance changes)
 	cachedStatusCounts struct {
-		running, waiting, idle, errored int
-		valid                           atomic.Bool // THREAD-SAFE: accessed from main and worker goroutines
-		timestamp                       time.Time   // For time-based expiration
+		running, waiting, idle, stopped, errored int
+		valid                                    atomic.Bool // THREAD-SAFE: accessed from main and worker goroutines
+		timestamp                                time.Time   // For time-based expiration
 	}
 
 	// Status-transition tracker: emits enriched status_changed INFO,
@@ -9552,13 +9552,14 @@ func (h *Home) importSessions() tea.Msg {
 // Cache expires after 500ms to balance freshness with performance
 // PERFORMANCE: Increased from 100ms to 500ms - status changes are rare
 // during UI interaction, and longer cache reduces View() overhead
-func (h *Home) countSessionStatuses() (running, waiting, idle, errored int) {
+func (h *Home) countSessionStatuses() (running, waiting, idle, stopped, errored int) {
 	// Return cached values if valid and not expired
 	const cacheDuration = 500 * time.Millisecond
 	if h.cachedStatusCounts.valid.Load() &&
 		time.Since(h.cachedStatusCounts.timestamp) < cacheDuration {
 		return h.cachedStatusCounts.running, h.cachedStatusCounts.waiting,
-			h.cachedStatusCounts.idle, h.cachedStatusCounts.errored
+			h.cachedStatusCounts.idle, h.cachedStatusCounts.stopped,
+			h.cachedStatusCounts.errored
 	}
 
 	// Compute counts
@@ -9575,7 +9576,14 @@ func (h *Home) countSessionStatuses() (running, waiting, idle, errored int) {
 			waiting++
 		case session.StatusIdle:
 			idle++
-		case session.StatusError, session.StatusStopped:
+		case session.StatusStopped:
+			// Issue #953 (re-opened): manually-stopped sessions get their
+			// own bucket so the header counter does not slander them as
+			// errors. StatusStopped reaches here only via i.Kill()'s
+			// canonical contract (see internal/session/instance.go) —
+			// crashes still surface as StatusError below.
+			stopped++
+		case session.StatusError:
 			errored++
 		}
 	}
@@ -9595,7 +9603,9 @@ func (h *Home) countSessionStatuses() (running, waiting, idle, errored int) {
 				waiting++
 			case "idle":
 				idle++
-			case "error", "stopped":
+			case "stopped":
+				stopped++
+			case "error":
 				errored++
 			}
 		}
@@ -9606,16 +9616,17 @@ func (h *Home) countSessionStatuses() (running, waiting, idle, errored int) {
 	h.cachedStatusCounts.running = running
 	h.cachedStatusCounts.waiting = waiting
 	h.cachedStatusCounts.idle = idle
+	h.cachedStatusCounts.stopped = stopped
 	h.cachedStatusCounts.errored = errored
 	h.cachedStatusCounts.valid.Store(true)
 	h.cachedStatusCounts.timestamp = time.Now()
-	return running, waiting, idle, errored
+	return running, waiting, idle, stopped, errored
 }
 
 // renderFilterBar renders the quick filter pills
-// Format: [All] [● Running 2] [◐ Waiting 1] [○ Idle 5] [✕ Error 1]
+// Format: [All] [● Running 2] [◐ Waiting 1] [○ Idle 5] [■ Stopped 1] [✕ Error 1]
 func (h *Home) renderFilterBar() string {
-	running, waiting, idle, errored := h.countSessionStatuses()
+	running, waiting, idle, stopped, errored := h.countSessionStatuses()
 
 	// Pill styling
 	activePillStyle := lipgloss.NewStyle().
@@ -9709,6 +9720,28 @@ func (h *Home) renderFilterBar() string {
 			Foreground(ColorText).
 			Background(ColorSurface).
 			Padding(0, 1).Render(idleLabel))
+	}
+
+	// Stopped pill (issue #953): manually-stopped sessions deserve their own
+	// affordance — they're not errors, they're intentional. Render-only-if
+	// non-zero or actively filtered, mirroring the error pill's pattern, so
+	// the bar stays compact when no stopped sessions exist.
+	if stopped > 0 || h.statusFilter == session.StatusStopped {
+		stoppedLabel := fmt.Sprintf("■ %d", stopped)
+		if h.statusFilter == session.StatusStopped {
+			pills = append(pills, lipgloss.NewStyle().
+				Foreground(ColorBg).
+				Background(ColorTextDim).
+				Bold(true).
+				Padding(0, 1).Render(stoppedLabel))
+		} else if isActive && h.activeFilterExcludes[session.StatusStopped] {
+			pills = append(pills, dimPillStyle.Render(stoppedLabel))
+		} else if stopped > 0 {
+			pills = append(pills, lipgloss.NewStyle().
+				Foreground(ColorTextDim).
+				Background(ColorSurface).
+				Padding(0, 1).Render(stoppedLabel))
+		}
 	}
 
 	if errored > 0 || h.statusFilter == session.StatusError {
@@ -9874,7 +9907,7 @@ func (h *Home) View() string {
 	// HEADER BAR
 	// ═══════════════════════════════════════════════════════════════════
 	// Calculate real session status counts for logo and stats
-	running, waiting, idle, errored := h.countSessionStatuses()
+	running, waiting, idle, stopped, errored := h.countSessionStatuses()
 	logo := RenderLogoCompact(running, waiting, idle)
 
 	titleStyle := lipgloss.NewStyle().
@@ -9918,6 +9951,14 @@ func (h *Home) View() string {
 		statsParts = append(
 			statsParts,
 			lipgloss.NewStyle().Foreground(ColorText).Render(fmt.Sprintf("○ %d idle", idle)),
+		)
+	}
+	if stopped > 0 {
+		// Issue #953: stopped sessions get their own segment so users can see
+		// at a glance how many sessions are intentionally off vs. errored.
+		statsParts = append(
+			statsParts,
+			lipgloss.NewStyle().Foreground(ColorTextDim).Render(fmt.Sprintf("■ %d stopped", stopped)),
 		)
 	}
 	if errored > 0 {
@@ -14013,7 +14054,7 @@ func (h *Home) renderGroupPreview(group *session.Group, width, height int) strin
 	b.WriteString("\n\n")
 
 	// Status breakdown with inline badges
-	running, waiting, idle, errored := 0, 0, 0, 0
+	running, waiting, idle, stopped, errored := 0, 0, 0, 0, 0
 	for _, sess := range group.Sessions {
 		switch sess.Status {
 		case session.StatusRunning:
@@ -14022,7 +14063,11 @@ func (h *Home) renderGroupPreview(group *session.Group, width, height int) strin
 			waiting++
 		case session.StatusIdle:
 			idle++
-		case session.StatusError, session.StatusStopped:
+		case session.StatusStopped:
+			// Issue #953: keep stopped separate from errored in the group
+			// preview panel for the same reason as the header counter.
+			stopped++
+		case session.StatusError:
 			errored++
 		}
 	}
@@ -14043,6 +14088,9 @@ func (h *Home) renderGroupPreview(group *session.Group, width, height int) strin
 	}
 	if idle > 0 {
 		statuses = append(statuses, lipgloss.NewStyle().Foreground(ColorText).Render(fmt.Sprintf("○ %d idle", idle)))
+	}
+	if stopped > 0 {
+		statuses = append(statuses, lipgloss.NewStyle().Foreground(ColorTextDim).Render(fmt.Sprintf("■ %d stopped", stopped)))
 	}
 	if errored > 0 {
 		statuses = append(statuses, lipgloss.NewStyle().Foreground(ColorRed).Render(fmt.Sprintf("✕ %d error", errored)))

--- a/internal/ui/issue1066_remote_counter_test.go
+++ b/internal/ui/issue1066_remote_counter_test.go
@@ -41,7 +41,8 @@ func TestIssue1066_RemoteSessions_CountedInStatusCounter(t *testing.T) {
 	// Invalidate the 500ms cache so the next call recomputes.
 	home.cachedStatusCounts.valid.Store(false)
 
-	running, waiting, idle, errored := home.countSessionStatuses()
+	running, waiting, idle, stopped, errored := home.countSessionStatuses()
+	_ = stopped
 
 	if running != 1 {
 		t.Errorf("running = %d, want 1 (remote dev/r1) — counter is ignoring remote sessions", running)

--- a/internal/ui/issue953_counter_test.go
+++ b/internal/ui/issue953_counter_test.go
@@ -1,0 +1,185 @@
+// Issue #953 (re-opened) — Status-line aggregate counter buckets manually
+// stopped sessions under "✕ errors". PR #1072 fixed StatusStopped
+// persistence for the per-session display, but countSessionStatuses still
+// folded StatusStopped into the errored count, so the TUI header read
+// "3 running, 1 waiting, 2 errors" when one of those "errors" was in fact a
+// user-initiated stop.
+//
+// Reporter: @halfmu. The fix gives StatusStopped its own bucket so the
+// header now reads e.g. "3 running, 1 waiting, 1 stopped, 1 error". This
+// applies to both local instances and remote sessions discovered via SSH.
+//
+// The same bucketing must hold whether the status arrives as a
+// session.Status (local snapshot) or a lowercase string (remote payload),
+// because both paths feed the same aggregate counter.
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestIssue953_StoppedSessions_NotCountedAsErrors_Local(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	// Build a render snapshot directly. We don't need real Instances — the
+	// counter only consults sessionRenderState.status. 3 running + 1 waiting
+	// + 1 idle + 1 stopped + 2 errors covers every bucket the counter must
+	// distinguish.
+	snap := map[string]sessionRenderState{
+		"r1": {status: session.StatusRunning},
+		"r2": {status: session.StatusRunning},
+		"r3": {status: session.StatusRunning},
+		"w1": {status: session.StatusWaiting},
+		"i1": {status: session.StatusIdle},
+		"s1": {status: session.StatusStopped},
+		"e1": {status: session.StatusError},
+		"e2": {status: session.StatusError},
+	}
+	home.sessionRenderSnapshot.Store(snap)
+	home.cachedStatusCounts.valid.Store(false)
+
+	running, waiting, idle, stopped, errored := home.countSessionStatuses()
+
+	if running != 3 {
+		t.Errorf("running = %d, want 3", running)
+	}
+	if waiting != 1 {
+		t.Errorf("waiting = %d, want 1", waiting)
+	}
+	if idle != 1 {
+		t.Errorf("idle = %d, want 1", idle)
+	}
+	if stopped != 1 {
+		t.Errorf("stopped = %d, want 1 — manual-stop sessions need their own bucket (issue #953)", stopped)
+	}
+	if errored != 2 {
+		t.Errorf("errored = %d, want 2 — stopped sessions must NOT inflate the error count (issue #953)", errored)
+	}
+}
+
+func TestIssue953_StoppedSessions_NotCountedAsErrors_Remote(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	// No local instances — same bug class must hold for remote sessions
+	// whose status arrives as a lowercase string from `agent-deck list
+	// --json` on the remote host (see internal/session/discovery.go).
+	home.refreshSessionRenderSnapshot(nil)
+
+	home.remoteSessionsMu.Lock()
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev": {
+			{ID: "r1", Title: "run-a", Tool: "claude", Status: "running", RemoteName: "dev"},
+			{ID: "r2", Title: "wait-a", Tool: "claude", Status: "waiting", RemoteName: "dev"},
+			{ID: "r3", Title: "stop-a", Tool: "claude", Status: "stopped", RemoteName: "dev"},
+			{ID: "r4", Title: "err-a", Tool: "claude", Status: "error", RemoteName: "dev"},
+		},
+	}
+	home.remoteSessionsMu.Unlock()
+	home.cachedStatusCounts.valid.Store(false)
+
+	running, waiting, idle, stopped, errored := home.countSessionStatuses()
+
+	if running != 1 {
+		t.Errorf("running = %d, want 1", running)
+	}
+	if waiting != 1 {
+		t.Errorf("waiting = %d, want 1", waiting)
+	}
+	if idle != 0 {
+		t.Errorf("idle = %d, want 0", idle)
+	}
+	if stopped != 1 {
+		t.Errorf("stopped = %d, want 1 — remote stopped session must land in its own bucket", stopped)
+	}
+	if errored != 1 {
+		t.Errorf("errored = %d, want 1 — remote stopped session must NOT inflate the error count", errored)
+	}
+}
+
+// TestIssue953_StatusLineRender_ShowsStoppedBucket asserts the header
+// stats string the user actually reads contains a "stopped" segment when
+// stopped sessions are present and does NOT silently fold them into the
+// "error" segment.
+func TestIssue953_StatusLineRender_ShowsStoppedBucket(t *testing.T) {
+	home := NewHome()
+	home.width = 200
+	home.height = 30
+
+	snap := map[string]sessionRenderState{
+		"r1": {status: session.StatusRunning},
+		"r2": {status: session.StatusRunning},
+		"r3": {status: session.StatusRunning},
+		"w1": {status: session.StatusWaiting},
+		"s1": {status: session.StatusStopped},
+		"e1": {status: session.StatusError},
+		"e2": {status: session.StatusError},
+	}
+	home.sessionRenderSnapshot.Store(snap)
+	home.cachedStatusCounts.valid.Store(false)
+	home.initialLoading = false // Skip splash so View() renders the real header
+
+	out := home.View()
+
+	// Stats segment uses the words "running", "waiting", "stopped",
+	// "error". Stopped must appear with count 1, error with count 2.
+	mustContain := []string{
+		"3 running",
+		"1 waiting",
+		"1 stopped",
+		"2 error",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(out, want) {
+			t.Errorf("header stats missing %q (full output below):\n%s", want, out)
+		}
+	}
+
+	// Negative: the wrong count "3 error" (2 real errors + 1 stopped
+	// folded in) must NOT appear. This is the regression to lock down.
+	if strings.Contains(out, "3 error") {
+		t.Errorf("header stats contains %q — stopped session was wrongly folded into the error bucket (issue #953)", "3 error")
+	}
+}
+
+// TestIssue953_FilterBar_HasStoppedPill verifies the filter pill bar gains
+// a stopped pill when stopped sessions are present. The pill row sits
+// directly under the header and is the user's primary filter affordance —
+// if there's no pill, there's no way to filter to "stopped".
+func TestIssue953_FilterBar_HasStoppedPill(t *testing.T) {
+	home := NewHome()
+	home.width = 200
+	home.height = 30
+
+	snap := map[string]sessionRenderState{
+		"s1": {status: session.StatusStopped},
+		"r1": {status: session.StatusRunning},
+	}
+	home.sessionRenderSnapshot.Store(snap)
+	home.cachedStatusCounts.valid.Store(false)
+
+	bar := home.renderFilterBar()
+
+	// Pills are "● N", "◐ N", "○ N", "■ N", "✕ N". The stopped pill must
+	// show its count next to the stopped icon (■ — matching the canonical
+	// symbol mapping in internal/session/notifications.go). Error count must
+	// remain at 0 (no pill, since the bar hides empty error pills).
+	if !strings.Contains(bar, "● 1") {
+		t.Errorf("filter bar missing running pill: %s", bar)
+	}
+	if !strings.Contains(bar, "■ 1") {
+		t.Errorf("filter bar missing stopped pill (■ 1): %s", bar)
+	}
+	// No error pill should appear when errored == 0.
+	if strings.Contains(bar, "✕ ") {
+		t.Errorf("filter bar shows error pill even though errored == 0: %s", bar)
+	}
+}
+


### PR DESCRIPTION
## Summary

Issue #953 was re-opened by @halfmu after PR #1072. PR #1072 fixed `StatusStopped` persistence for the per-session display, but the TUI **top status line aggregate counter** still folded `StatusStopped` into the errored count. So a manually-stopped session inflated the "✕ N error" segment in the header — the exact symptom @halfmu reported.

This PR closes the second half of the bug.

## What changed

- `countSessionStatuses` (`internal/ui/home.go`) now returns a fifth value `stopped`. Both the local `sessionRenderSnapshot` loop and the remote-session loop (issue #1066) emit into the new bucket — error and stopped no longer share a `case`.
- Header stats segment gains `■ N stopped`, rendered only when non-zero (matching the existing compactness rule for the error pill).
- Filter pill bar gains the same stopped pill, with the same render-when-relevant rule.
- `renderGroupPreview` had the same `StatusError, StatusStopped` bucket bug — fixed in the same commit for consistency, since group-preview is a user-visible aggregate.
- The cached-counts struct gained a `stopped` field; cache invalidation paths are unchanged.

## Test plan

New regression file: `internal/ui/issue953_counter_test.go` — four tests.

- [x] `TestIssue953_StoppedSessions_NotCountedAsErrors_Local` — 3 running + 1 waiting + 1 idle + 1 stopped + 2 errors via `sessionRenderSnapshot`; asserts each bucket count.
- [x] `TestIssue953_StoppedSessions_NotCountedAsErrors_Remote` — same shape via `RemoteSessionInfo.Status` strings (`"stopped"` must not bucket as `"error"`).
- [x] `TestIssue953_StatusLineRender_ShowsStoppedBucket` — calls `home.View()`, asserts header contains `"1 stopped"` and `"2 error"`, and **never** the wrong `"3 error"`.
- [x] `TestIssue953_FilterBar_HasStoppedPill` — asserts `■ 1` pill appears, `✕` pill does not when errored == 0.
- [x] Existing `TestIssue1066_RemoteSessions_CountedInStatusCounter` still green (caller updated for the new return arity).
- [x] `go test ./...` green.
- [x] `go test -race ./internal/ui/... ./internal/session/...` green.

## Doesn't break

- Real error sessions still surface in the error bucket (asserted by `..._Local` test).
- `running`, `waiting`, `idle` counts unchanged.
- Default "Open" filter still excludes both `StatusError` and `StatusStopped` (unchanged in `userconfig.go`); only the user-facing **count display** changed.
- Removal eligibility (`session_remove_cmd.go:130`) still treats stopped and error sessions identically — unchanged.

## Credit

Regression reporter: @halfmu. Thanks for confirming PR #1072 only fixed half the bug.

Re-closes #953.

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions with "stopped" status are now explicitly distinguished from errored sessions in status counts and filters.
  * Added dedicated "stopped" indicators in the filter bar and status header when stopped sessions are present.

* **Tests**
  * Added regression test coverage for stopped session status counting and display behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->