### PR TITLE
fix(userconfig): restore missing closing brace + gofmt (hotfix main red)

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -253,6 +253,8 @@ func (u UISettings) GetITermOpenAs() string {
 		return ITermOpenAsTab
 	}
 	return DefaultITermOpenAs
+}
+
 // GetRemoteLatencyRefreshSecs returns the remote latency refresh interval
 // in seconds, clamped to [2, 300]. When the user has not set this value
 // it falls back to fallbackSecs (typically the system_stats refresh


### PR DESCRIPTION
My conflict resolution during #1106 rebase ate the closing brace of GetITermOpenAs causing main golangci+build to fail. Restore the brace + gofmt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Resolved an issue with iTerm terminal application settings configuration to ensure proper default behavior when encountering unrecognized values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->