### PR TITLE
fix(ui): insert mode actual perf fix + remote-session support (closes #1102, follow-up to #1096)

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -67,6 +67,8 @@ func handleSession(profile string, args []string) {
 		handleSessionMove(profile, args[1:])
 	case "send":
 		handleSessionSend(profile, args[1:])
+	case "send-keys":
+		handleSessionSendKeys(profile, args[1:])
 	case "output":
 		handleSessionOutput(profile, args[1:])
 	case "search":

--- a/cmd/agent-deck/session_send_keys_cmd.go
+++ b/cmd/agent-deck/session_send_keys_cmd.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// handleSessionSendKeys implements `agent-deck session send-keys <id>
+// [--text TEXT] [--enter] [--named-key KEY]` — the low-level keystroke
+// dispatch the TUI's insert mode invokes on a REMOTE agent-deck instance
+// over SSH (#1102 bug 2). The locally-running agent-deck TUI uses the
+// in-process tmux.KeySender for local sessions; remote sessions land here
+// via the RemoteKeySender → SSHRunner.Run → ssh → this CLI handler.
+//
+// Distinct from `session send`:
+//   - `send` is the high-level "wait for agent, deliver a message, optionally
+//     wait for response" flow used by users at the CLI.
+//   - `send-keys` is the low-level "type these bytes into the pane right
+//     now" primitive used by the TUI; it does no readiness checking and
+//     returns immediately so the TUI's interactive latency stays low.
+//
+// Flags are mutually exclusive in the dispatch sense: exactly one of --text,
+// --enter, or --named-key per invocation. This keeps the wire protocol
+// trivial and avoids encoding ordering ("text then enter? enter then named?")
+// at the CLI boundary — the TUI calls once per logical key it wants to send.
+func handleSessionSendKeys(profile string, args []string) {
+	fs := flag.NewFlagSet("session send-keys", flag.ExitOnError)
+	fs.SetOutput(os.Stdout)
+	text := fs.String("text", "", "Literal text to type (tmux send-keys -l)")
+	namedKey := fs.String("named-key", "", "Tmux named key (e.g. BSpace, Up, C-c)")
+	sendEnter := fs.Bool("enter", false, "Send an Enter keystroke")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("q", false, "Quiet mode")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session send-keys <id|title> [options]")
+		fmt.Println()
+		fmt.Println("Forward a single keystroke (or rune burst) to a running session's")
+		fmt.Println("tmux pane. Used by the TUI insert mode (#1069/#1094/#1102); not")
+		fmt.Println("typically invoked by users directly.")
+		fmt.Println()
+		fmt.Println("Exactly one of --text, --named-key, or --enter must be specified.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck session send-keys my-project --text \"hello\"")
+		fmt.Println("  agent-deck session send-keys my-project --named-key BSpace")
+		fmt.Println("  agent-deck session send-keys my-project --enter")
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+	remaining := fs.Args()
+
+	out := NewCLIOutput(*jsonOutput, *quiet)
+
+	if len(remaining) < 1 {
+		fs.Usage()
+		out.Error("session id or title is required", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	// Validate exactly one dispatch flag.
+	count := 0
+	if *text != "" {
+		count++
+	}
+	if *namedKey != "" {
+		count++
+	}
+	if *sendEnter {
+		count++
+	}
+	if count != 1 {
+		out.Error("exactly one of --text, --named-key, or --enter required", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	sessionRef := remaining[0]
+
+	_, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	inst, errMsg, errCode := ResolveSession(sessionRef, instances)
+	if inst == nil {
+		out.Error(errMsg, errCode)
+		if errCode == ErrCodeNotFound {
+			os.Exit(2)
+		}
+		os.Exit(1)
+		return
+	}
+
+	if !inst.Exists() {
+		out.Error(fmt.Sprintf("session '%s' is not running", inst.Title), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	tmuxSess := inst.GetTmuxSession()
+	if tmuxSess == nil {
+		out.Error(fmt.Sprintf("session '%s' has no tmux pane", inst.Title), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	switch {
+	case *text != "":
+		if err := tmuxSess.SendKeys(*text); err != nil {
+			out.Error(fmt.Sprintf("send-keys failed: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+	case *namedKey != "":
+		if err := tmuxSess.SendNamedKey(*namedKey); err != nil {
+			out.Error(fmt.Sprintf("send-named-key failed: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+	case *sendEnter:
+		if err := tmuxSess.SendEnter(); err != nil {
+			out.Error(fmt.Sprintf("send-enter failed: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+	}
+
+	out.Success("", map[string]interface{}{
+		"success":       true,
+		"session_id":    inst.ID,
+		"session_title": inst.Title,
+	})
+}

--- a/internal/session/issue1102_insert_remote_test.go
+++ b/internal/session/issue1102_insert_remote_test.go
@@ -1,0 +1,243 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// Issue #1102 (by @ddorman-dn against v1.9.23): insert mode silently no-op'd
+// for remote sessions because the TUI's dispatch only ever resolved the
+// selection to a local `*Instance` — remote sessions are
+// `RemoteSessionInfo`, not Instance, so enterInsertMode bailed before any
+// keys were forwarded. These tests cover the follow-up: a RemoteKeySender
+// that uses the existing SSHRunner.Run RPC to invoke `agent-deck session
+// send-keys <id>` on the remote host.
+
+// captureSSHRunner returns an SSHRunner whose runFn records every invocation
+// in the slice it returns. The runner doesn't actually fork ssh — the
+// tests stay deterministic and fast.
+func captureSSHRunner(t *testing.T) (*SSHRunner, func() [][]string) {
+	t.Helper()
+	var (
+		mu    sync.Mutex
+		calls [][]string
+	)
+	r := &SSHRunner{
+		Host:          "test-host",
+		AgentDeckPath: "/usr/local/bin/agent-deck",
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			callCopy := make([]string, len(args))
+			copy(callCopy, args)
+			calls = append(calls, callCopy)
+			return []byte(`{"success":true}`), nil
+		},
+	}
+	return r, func() [][]string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([][]string, len(calls))
+		for i, c := range calls {
+			out[i] = append([]string(nil), c...)
+		}
+		return out
+	}
+}
+
+// TestIssue1102_RemoteKeySender_SendKeysRoutesViaSSH is the headline test:
+// calling SendKeys on a RemoteKeySender must reach the SSHRunner with the
+// canonical `session send-keys <id> --text <text>` argv. Previously this
+// path didn't exist at all, so insert mode dropped the keystroke silently.
+func TestIssue1102_RemoteKeySender_SendKeysRoutesViaSSH(t *testing.T) {
+	runner, captured := captureSSHRunner(t)
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	if err := sender.SendKeys("hello"); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+
+	calls := captured()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 SSH call, got %d: %v", len(calls), calls)
+	}
+	want := []string{"session", "send-keys", "remote-sess-id", "--text", "hello"}
+	if !sliceEqual(calls[0], want) {
+		t.Errorf("SSH argv = %v, want %v", calls[0], want)
+	}
+}
+
+// TestIssue1102_RemoteKeySender_SendNamedKeyRoutesViaSSH verifies the named-
+// key dispatch path (Backspace, arrows, Tab, Ctrl-{C,D} — every key #1094
+// taught insert mode about) reaches the remote with the right wire format.
+func TestIssue1102_RemoteKeySender_SendNamedKeyRoutesViaSSH(t *testing.T) {
+	runner, captured := captureSSHRunner(t)
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	if err := sender.SendNamedKey("BSpace"); err != nil {
+		t.Fatalf("SendNamedKey: %v", err)
+	}
+
+	calls := captured()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 SSH call, got %d: %v", len(calls), calls)
+	}
+	want := []string{"session", "send-keys", "remote-sess-id", "--named-key", "BSpace"}
+	if !sliceEqual(calls[0], want) {
+		t.Errorf("SSH argv = %v, want %v", calls[0], want)
+	}
+}
+
+// TestIssue1102_RemoteKeySender_SendEnterRoutesViaSSH covers the Enter
+// dispatch — modeled as a discrete flag so the remote handler can apply the
+// tmux bracketed-paste flush delay the local SendEnter uses (see
+// internal/tmux/tmux.go:3984).
+func TestIssue1102_RemoteKeySender_SendEnterRoutesViaSSH(t *testing.T) {
+	runner, captured := captureSSHRunner(t)
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	if err := sender.SendEnter(); err != nil {
+		t.Fatalf("SendEnter: %v", err)
+	}
+
+	calls := captured()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 SSH call, got %d: %v", len(calls), calls)
+	}
+	want := []string{"session", "send-keys", "remote-sess-id", "--enter"}
+	if !sliceEqual(calls[0], want) {
+		t.Errorf("SSH argv = %v, want %v", calls[0], want)
+	}
+}
+
+// TestIssue1102_RemoteKeySender_EmptyTextIsNoOp verifies SendKeys("") doesn't
+// produce an SSH call — buffer flushes after non-rune keys can hand an empty
+// string here and we shouldn't pay an SSH round-trip for nothing.
+func TestIssue1102_RemoteKeySender_EmptyTextIsNoOp(t *testing.T) {
+	runner, captured := captureSSHRunner(t)
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	if err := sender.SendKeys(""); err != nil {
+		t.Fatalf("SendKeys(\"\"): %v", err)
+	}
+
+	if calls := captured(); len(calls) != 0 {
+		t.Errorf("empty SendKeys should be a no-op; got SSH call %v", calls)
+	}
+}
+
+// TestIssue1102_RemoteKeySender_EmptyNamedKeyRejected guards against the
+// dispatch sending a malformed `session send-keys --named-key` (with an
+// empty value) — that would land on the remote and produce an opaque tmux
+// error rather than failing fast on the local side.
+func TestIssue1102_RemoteKeySender_EmptyNamedKeyRejected(t *testing.T) {
+	runner, _ := captureSSHRunner(t)
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	err := sender.SendNamedKey("   ")
+	if err == nil {
+		t.Fatal("expected error for empty named key, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty named key") {
+		t.Errorf("error = %q, want one mentioning 'empty named key'", err)
+	}
+}
+
+// TestIssue1102_RemoteKeySender_CloseStopsDispatch verifies the close path
+// works idempotently and refuses further dispatches. Important because the
+// TUI calls Close on insert-mode exit and then defer-closes on panic
+// recovery; a panic on second close would brick the TUI.
+func TestIssue1102_RemoteKeySender_CloseStopsDispatch(t *testing.T) {
+	runner, captured := captureSSHRunner(t)
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	if err := sender.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := sender.Close(); err != nil {
+		t.Errorf("second Close should be a no-op; got %v", err)
+	}
+
+	err := sender.SendKeys("after-close")
+	if err == nil {
+		t.Error("SendKeys after Close should fail")
+	} else if !strings.Contains(err.Error(), "closed") {
+		t.Errorf("error after Close = %v, want one mentioning 'closed'", err)
+	}
+
+	if calls := captured(); len(calls) != 0 {
+		t.Errorf("no SSH calls expected after Close, got %v", calls)
+	}
+}
+
+// TestIssue1102_RemoteKeySender_PropagatesSSHError verifies the error from
+// SSHRunner.Run is surfaced verbatim (wrapped) so the TUI's setError shows
+// the user what's actually wrong — network down, remote agent-deck binary
+// missing, session ID stale, etc. Previously, with no dispatch path at all,
+// the user got silence.
+func TestIssue1102_RemoteKeySender_PropagatesSSHError(t *testing.T) {
+	wantErr := errors.New("ssh: connection refused")
+	runner := &SSHRunner{
+		Host:          "test-host",
+		AgentDeckPath: "/usr/local/bin/agent-deck",
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			return nil, wantErr
+		},
+	}
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	err := sender.SendKeys("hello")
+	if err == nil {
+		t.Fatal("expected error to surface from SSH layer")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error chain does not include SSH error; got %v", err)
+	}
+}
+
+// TestIssue1102_RemoteKeySender_ConcurrentSendsSerialize covers the
+// concurrency contract: the dispatch path stores no mutable state per call
+// and the underlying SSHRunner.runFn is goroutine-safe, so 100 concurrent
+// SendKeys calls must all reach the remote without losing any or
+// corrupting state.
+func TestIssue1102_RemoteKeySender_ConcurrentSendsSerialize(t *testing.T) {
+	runner, captured := captureSSHRunner(t)
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	var wg sync.WaitGroup
+	var failures atomic.Int32
+	const n = 100
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if err := sender.SendKeys("x"); err != nil {
+				failures.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if got := failures.Load(); got != 0 {
+		t.Errorf("%d/100 concurrent SendKeys failed", got)
+	}
+	if calls := captured(); len(calls) != n {
+		t.Errorf("got %d SSH calls, want %d (each concurrent call must reach the remote)", len(calls), n)
+	}
+}
+
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/session/remote_keysender.go
+++ b/internal/session/remote_keysender.go
@@ -1,0 +1,108 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// RemoteKeySender dispatches insert-mode keystrokes to a session living on a
+// remote agent-deck instance over the existing SSHRunner RPC (#1102 bug 2:
+// previously, insert mode silently no-op'd for remote sessions because
+// dispatch only saw `*Instance`, not `RemoteSessionInfo`). Each Send shells
+// to the remote `agent-deck session send-keys <id>` subcommand; ControlMaster
+// keeps the SSH multiplex channel warm so calls don't pay the full
+// TCP+SSH handshake every time.
+//
+// Unlike the local path, this does NOT open a long-running subprocess —
+// `ssh ... agent-deck session send-keys <id> -- <text>` is fork+exec per
+// call. Acceptable because:
+//   - Remote latency is dominated by network RTT, not local fork+exec.
+//   - SSH ControlMaster (already set up in SSHRunner) amortizes the
+//     connection cost across all calls during an insert-mode session.
+//   - Keeping a persistent `ssh ... -t` interactive session would require
+//     a custom on-remote shell protocol — out of scope for the bugfix.
+//
+// The remote side's `session send-keys` handler uses the existing tmux
+// SendKeys / SendNamedKey / SendEnter on the remote Instance, so the
+// behavior reaching the pane is bit-identical to a local insert-mode send.
+type RemoteKeySender struct {
+	runner    *SSHRunner
+	sessionID string
+	ctx       context.Context
+
+	mu     sync.Mutex
+	closed bool
+}
+
+// NewRemoteKeySender wires up a sender bound to a single remote session.
+// The context governs every Send call's deadline; pass context.Background()
+// to inherit SSHRunner.Run's default 10s timeout, or a derived context for
+// the lifetime of the insert-mode session.
+func NewRemoteKeySender(runner *SSHRunner, sessionID string, ctx context.Context) *RemoteKeySender {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &RemoteKeySender{
+		runner:    runner,
+		sessionID: sessionID,
+		ctx:       ctx,
+	}
+}
+
+// SendKeys forwards `text` as literal keystrokes to the remote session.
+// Empty text is a no-op so the caller doesn't have to guard before flushing
+// an empty rune buffer.
+func (r *RemoteKeySender) SendKeys(text string) error {
+	if text == "" {
+		return nil
+	}
+	return r.run("--text", text)
+}
+
+// SendNamedKey forwards a tmux named key (BSpace/Up/Down/Left/Right/Tab/
+// BTab/C-c/C-d — the same set #1094 added to the local path).
+func (r *RemoteKeySender) SendNamedKey(key string) error {
+	if strings.TrimSpace(key) == "" {
+		return fmt.Errorf("remote keysender: empty named key")
+	}
+	return r.run("--named-key", key)
+}
+
+// SendEnter forwards a single Enter keystroke. Modeled as a discrete flag so
+// the remote handler can preserve the existing tmux SendEnter semantics
+// (with bracketed-paste flush delay; see internal/tmux/tmux.go:3984).
+func (r *RemoteKeySender) SendEnter() error {
+	return r.run("--enter")
+}
+
+// run invokes `agent-deck session send-keys <id> <flags…>` on the remote
+// host. Each call goes through SSHRunner which honors ControlMaster, so
+// after the first call the SSH channel is reused.
+func (r *RemoteKeySender) run(extraArgs ...string) error {
+	r.mu.Lock()
+	closed := r.closed
+	r.mu.Unlock()
+	if closed {
+		return fmt.Errorf("remote keysender: closed")
+	}
+
+	args := []string{"session", "send-keys", r.sessionID}
+	args = append(args, extraArgs...)
+	if _, err := r.runner.Run(r.ctx, args...); err != nil {
+		return fmt.Errorf("remote send-keys: %w", err)
+	}
+	return nil
+}
+
+// Close marks the sender as closed. Subsequent Send calls fail with
+// "closed". Idempotent so panic-recovery flows can safely double-close.
+// Does NOT tear down the SSH ControlMaster — that's shared across the
+// process and persists per ssh -o ControlPersist=600.
+func (r *RemoteKeySender) Close() error {
+	r.mu.Lock()
+	r.closed = true
+	r.mu.Unlock()
+	return nil
+}

--- a/internal/tmux/keysender.go
+++ b/internal/tmux/keysender.go
@@ -1,0 +1,148 @@
+package tmux
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// KeySender pushes keystrokes to a tmux pane over a persistent connection,
+// amortizing the per-call fork+exec cost of `tmux send-keys` (#1102, follow-up
+// to #1096). #1096 added 15ms rune batching, but at realistic typing speeds
+// (>15ms between keys) every keystroke still triggers its own fork+exec — on
+// macOS each one costs 10-50ms, so the user feels per-keystroke lag despite
+// the batch window. KeySender opens one `tmux -L <socket> -C` subprocess at
+// the start of an insert-mode session and streams send-keys commands over
+// stdin for the lifetime of that mode, dropping per-call dispatch to a stdin
+// write (<1ms regardless of platform).
+type KeySender interface {
+	// SendKeys forwards `text` as literal keystrokes (tmux send-keys -l).
+	SendKeys(text string) error
+	// SendNamedKey forwards a tmux named key (e.g. "Up", "BSpace", "C-c").
+	SendNamedKey(key string) error
+	// SendEnter forwards a single Enter keystroke.
+	SendEnter() error
+	// Close releases the underlying subprocess. Subsequent Send calls fail.
+	Close() error
+}
+
+// localKeySender is the in-process KeySender backed by a long-running
+// `tmux -L <socket> -C` subprocess. Each Send writes one command line to its
+// stdin; tmux executes commands in-server without spawning new clients.
+type localKeySender struct {
+	target string
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+
+	mu     sync.Mutex
+	closed bool
+}
+
+// OpenKeySender starts a persistent tmux control-mode client on `socket`
+// (empty = the user's default tmux server) and returns a KeySender bound to
+// `target` (a tmux session/pane selector like "my-session" or "id:0.0").
+//
+// The subprocess does NOT attach to any session — it stays in control mode,
+// reads commands from stdin, and emits status notifications on stdout (which
+// are drained and discarded). At least one session must exist on the server
+// for it to remain running; this is always true at the call site because
+// insert mode targets an existing session.
+//
+// Returns a started KeySender on success. On any setup failure the
+// subprocess is cleaned up and an error is returned, so callers can fall
+// back to per-call fork+exec (the legacy path via Session.SendKeys).
+func OpenKeySender(socket, target string) (KeySender, error) {
+	if strings.TrimSpace(target) == "" {
+		return nil, fmt.Errorf("keysender: target required")
+	}
+	// Go through the sanctioned tmuxExec factory — it's the one place in
+	// the codebase that knows how to assemble a tmux argv with the `-L
+	// <socket>` selector, and the lint test in tmux_exec_lint_test.go
+	// enforces this. Plain `exec.Command("tmux", ...)` would silently
+	// defeat socket isolation when the user has opted in (#687).
+	cmd := tmuxExec(socket, "-C")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("keysender: stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("keysender: stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return nil, fmt.Errorf("keysender: start tmux -C: %w", err)
+	}
+	// Drain stdout so the OS pipe buffer never fills and blocks Send writes.
+	// We don't parse %begin/%end responses — send-keys never returns useful
+	// data, and any error is reflected when the next stdin write fails.
+	go func() { _, _ = io.Copy(io.Discard, stdout) }()
+	return &localKeySender{target: target, cmd: cmd, stdin: stdin}, nil
+}
+
+func (k *localKeySender) SendKeys(text string) error {
+	if text == "" {
+		return nil
+	}
+	return k.writeCmd("send-keys -l -t " + tmuxQuote(k.target) + " -- " + tmuxQuote(text))
+}
+
+func (k *localKeySender) SendNamedKey(key string) error {
+	if strings.TrimSpace(key) == "" {
+		return fmt.Errorf("keysender: empty named key")
+	}
+	return k.writeCmd("send-keys -t " + tmuxQuote(k.target) + " " + tmuxQuote(key))
+}
+
+func (k *localKeySender) SendEnter() error {
+	return k.writeCmd("send-keys -t " + tmuxQuote(k.target) + " Enter")
+}
+
+func (k *localKeySender) writeCmd(line string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.closed {
+		return fmt.Errorf("keysender: closed")
+	}
+	if _, err := io.WriteString(k.stdin, line+"\n"); err != nil {
+		return fmt.Errorf("keysender: write %q: %w", line, err)
+	}
+	return nil
+}
+
+func (k *localKeySender) Close() error {
+	k.mu.Lock()
+	if k.closed {
+		k.mu.Unlock()
+		return nil
+	}
+	k.closed = true
+	stdin := k.stdin
+	cmd := k.cmd
+	k.mu.Unlock()
+
+	if stdin != nil {
+		_ = stdin.Close()
+	}
+	if cmd != nil && cmd.Process != nil {
+		// stdin close should make tmux -C exit cleanly; kill as a backstop in
+		// case the server is in an unresponsive state (rare; observed once on
+		// a hung tmux 3.4 socket during the v1.5.x cascade incident).
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}
+	return nil
+}
+
+// tmuxQuote wraps s in single quotes for tmux's command parser, escaping
+// embedded single quotes by closing the quoted region, inserting a
+// backslash-escaped single quote, then re-opening. Single quotes treat
+// every other byte as literal, so this is safe for arbitrary user input
+// (e.g., insert-mode rune bursts that may contain ", $, \, backticks).
+func tmuxQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/tmux/keysender_test.go
+++ b/internal/tmux/keysender_test.go
@@ -1,0 +1,228 @@
+package tmux
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// requireTmux skips the test when no `tmux` binary is on PATH. Several CI
+// stages run in containers without tmux, and the package's existing tests
+// (e.g. TestPersistence_*) use the same skip pattern.
+func requireTmux(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux binary not on PATH; skipping")
+	}
+}
+
+// makeIsolatedServer creates a tmux server on a per-test socket with one
+// detached session and returns the socket name plus a cleanup that kills
+// the server. Isolating the server prevents test cross-talk with the
+// developer's interactive tmux and survives parallel runs.
+func makeIsolatedServer(t *testing.T) (socket, target string) {
+	t.Helper()
+	// Hash the test name into a short socket selector — Unix socket paths
+	// have a hard ~108 byte limit and long test names like
+	// TestOpenKeySender_Issue1102_PerfBudget100KeysUnder500ms blow it out.
+	socket = fmt.Sprintf("ks%x", sha256.Sum256([]byte(t.Name())))[:14]
+	target = "tgt"
+	if out, err := exec.Command("tmux", "-L", socket, "new-session", "-d", "-s", target, "bash").CombinedOutput(); err != nil {
+		t.Fatalf("create tmux session: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	})
+	return socket, target
+}
+
+// TestOpenKeySender_StreamsLiteralKeysToPane verifies that SendKeys writes
+// the literal bytes to the target pane via the persistent control-mode
+// client, instead of fork+exec'ing a tmux client per call.
+func TestOpenKeySender_StreamsLiteralKeysToPane(t *testing.T) {
+	requireTmux(t)
+	socket, target := makeIsolatedServer(t)
+
+	sender, err := OpenKeySender(socket, target)
+	if err != nil {
+		t.Fatalf("OpenKeySender: %v", err)
+	}
+	defer sender.Close()
+
+	for _, chunk := range []string{"he", "llo", " world"} {
+		if err := sender.SendKeys(chunk); err != nil {
+			t.Fatalf("SendKeys(%q): %v", chunk, err)
+		}
+	}
+
+	// Give tmux a moment to flush; control mode is async.
+	time.Sleep(100 * time.Millisecond)
+
+	pane, err := exec.Command("tmux", "-L", socket, "capture-pane", "-t", target, "-p").CombinedOutput()
+	if err != nil {
+		t.Fatalf("capture-pane: %v: %s", err, pane)
+	}
+	if !strings.Contains(string(pane), "hello world") {
+		t.Errorf("pane does not contain typed text; got:\n%s", pane)
+	}
+}
+
+// TestOpenKeySender_Issue1102_PerfBudget100KeysUnder500ms is the regression
+// test for #1102's headline complaint: per-keystroke fork+exec made typing
+// visibly slow even with #1096's batching. With the persistent client, 100
+// individual SendKeys calls must complete well under the 500ms budget the
+// user-facing fix targets.
+//
+// The old implementation (`(*Session).SendKeys` calling `tmux send-keys -l`
+// per call) costs ~3-50ms per call depending on platform load — on Apple
+// Silicon under heavy AV the user reported 100 keys taking many seconds.
+// The new path streams stdin to one already-running tmux client, so each
+// call is a memcpy plus syscall.
+func TestOpenKeySender_Issue1102_PerfBudget100KeysUnder500ms(t *testing.T) {
+	requireTmux(t)
+	socket, target := makeIsolatedServer(t)
+
+	sender, err := OpenKeySender(socket, target)
+	if err != nil {
+		t.Fatalf("OpenKeySender: %v", err)
+	}
+	defer sender.Close()
+
+	const n = 100
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		if err := sender.SendKeys("x"); err != nil {
+			t.Fatalf("SendKeys: %v", err)
+		}
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("100 SendKeys took %v, want <500ms (#1102 perf budget)", elapsed)
+	}
+	t.Logf("100 SendKeys via persistent client: %v (%.2fms/keystroke)",
+		elapsed, float64(elapsed.Microseconds())/1000.0/float64(n))
+}
+
+// TestOpenKeySender_NamedKeyAndEnter exercises the non-rune dispatch paths
+// (Up/Down/Backspace via SendNamedKey, Enter via SendEnter). These are the
+// keystrokes #1094 added so users could navigate claude pickers and submit
+// prompts — they must keep working through the persistent client.
+func TestOpenKeySender_NamedKeyAndEnter(t *testing.T) {
+	requireTmux(t)
+	socket, target := makeIsolatedServer(t)
+
+	sender, err := OpenKeySender(socket, target)
+	if err != nil {
+		t.Fatalf("OpenKeySender: %v", err)
+	}
+	defer sender.Close()
+
+	if err := sender.SendKeys("abc"); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+	if err := sender.SendNamedKey("BSpace"); err != nil {
+		t.Fatalf("SendNamedKey: %v", err)
+	}
+	if err := sender.SendEnter(); err != nil {
+		t.Fatalf("SendEnter: %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	pane, err := exec.Command("tmux", "-L", socket, "capture-pane", "-t", target, "-p").CombinedOutput()
+	if err != nil {
+		t.Fatalf("capture-pane: %v: %s", err, pane)
+	}
+	// After "abc" + BSpace + Enter, the bash prompt sees "ab" submitted.
+	// Without asserting exact prompt layout (varies by user shell), we
+	// at least require "ab" appears and "abc" does not (BSpace took effect).
+	got := string(pane)
+	if !strings.Contains(got, "ab") {
+		t.Errorf("pane missing 'ab' after BSpace+Enter:\n%s", got)
+	}
+	if strings.Contains(got, "abc") {
+		t.Errorf("pane still shows 'abc' — BSpace did not take effect:\n%s", got)
+	}
+}
+
+// TestOpenKeySender_CloseIsIdempotent guards against the common refcount-
+// driven double-close pattern (exit insert mode → close, then defer-close on
+// panic recovery). The second Close must return nil and not crash.
+func TestOpenKeySender_CloseIsIdempotent(t *testing.T) {
+	requireTmux(t)
+	socket, target := makeIsolatedServer(t)
+
+	sender, err := OpenKeySender(socket, target)
+	if err != nil {
+		t.Fatalf("OpenKeySender: %v", err)
+	}
+
+	if err := sender.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := sender.Close(); err != nil {
+		t.Errorf("second Close should be a no-op; got %v", err)
+	}
+	if err := sender.SendKeys("x"); err == nil {
+		t.Error("SendKeys after Close should fail")
+	} else if !strings.Contains(err.Error(), "closed") {
+		t.Errorf("error after Close = %v, want one mentioning 'closed'", err)
+	}
+}
+
+// TestOpenKeySender_RejectsEmptyTarget guards the caller contract: a blank
+// target is a programming error (e.g. a stub Session.Name), not user input,
+// and would otherwise produce an opaque tmux usage error on the first send.
+func TestOpenKeySender_RejectsEmptyTarget(t *testing.T) {
+	if _, err := OpenKeySender("", ""); err == nil {
+		t.Error("empty target should be rejected")
+	} else if !strings.Contains(err.Error(), "target") {
+		t.Errorf("error = %v, want mention of 'target'", err)
+	}
+}
+
+// TestTmuxQuote_HandlesEmbeddedSingleQuotes verifies the tmux-side quoting
+// keeps user input opaque to the command parser. Insert mode bursts may
+// contain apostrophes, backticks, dollars — all of which tmux's parser would
+// interpret in unquoted or double-quoted contexts.
+func TestTmuxQuote_HandlesEmbeddedSingleQuotes(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", `''`},
+		{"abc", `'abc'`},
+		{"it's", `'it'\''s'`},
+		{`$( foo )`, `'$( foo )'`},
+		{`"hi"`, `'"hi"'`},
+	}
+	for _, tc := range cases {
+		got := tmuxQuote(tc.in)
+		if got != tc.want {
+			t.Errorf("tmuxQuote(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestOpenKeySender_ErrAfterCloseIsTyped is a tiny robustness check: the
+// "closed" error path is exercised by callers in the UI on panic recovery,
+// so make sure it's a real error value (not nil masquerading as success).
+func TestOpenKeySender_ErrAfterCloseIsTyped(t *testing.T) {
+	requireTmux(t)
+	socket, target := makeIsolatedServer(t)
+
+	sender, err := OpenKeySender(socket, target)
+	if err != nil {
+		t.Fatalf("OpenKeySender: %v", err)
+	}
+	_ = sender.Close()
+
+	err = sender.SendKeys("x")
+	if err == nil || errors.Is(err, nil) {
+		t.Fatalf("expected non-nil error after Close, got %v", err)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3970,6 +3970,15 @@ func (s *Session) SendEnter() error {
 	return cmd.Run()
 }
 
+// OpenKeySender opens a persistent tmux control-mode client bound to this
+// session's pane. Used by TUI insert mode (#1102) to amortize the fork+exec
+// cost of `tmux send-keys` across a typing burst. Returns nil and an error
+// when the user's tmux can't be reached or the session no longer exists;
+// callers should fall back to per-call SendKeys / SendEnter / SendNamedKey.
+func (s *Session) OpenKeySender() (KeySender, error) {
+	return OpenKeySender(s.SocketName, s.Name)
+}
+
 // SendNamedKey sends a single tmux named key (e.g. "BSpace", "Up", "Down",
 // "Left", "Right", "Tab", "BTab", "C-c", "C-d") to the session. Unlike
 // SendKeys it does NOT use the -l flag, so tmux interprets the argument as a

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -506,6 +506,25 @@ type Home struct {
 	// (Backspace, arrows, Tab, Ctrl-C, Ctrl-D — #1094). When nil, named keys
 	// are sent via the session's tmux pane (SendNamedKey).
 	insertNamedKeySink func(inst *session.Instance, key string) error
+	// insertKeySender is the persistent dispatch path opened on
+	// enterInsertMode and closed on exitInsertMode (#1102 perf fix +
+	// remote support). Local sessions get a tmux.KeySender (control-mode
+	// client, no per-keystroke fork+exec); remote sessions get a
+	// session.RemoteKeySender (SSH RPC to the remote agent-deck). When
+	// insertKeySink/insertNamedKeySink are set (test mode) they win;
+	// when neither is set, dispatch falls back to per-call SendKeys
+	// (the legacy path, ~50× slower but unconditional).
+	insertKeySender insertKeySender
+	// insertOpenKeySender creates a persistent KeySender for the given
+	// insert target. Defaulted to the production opener at construction
+	// time; tests override to inject a mock without real tmux/SSH.
+	insertOpenKeySender func(target insertTargetRef) (insertKeySender, error)
+	// insertModeRemoteName / insertModeRemoteID identify the remote
+	// agent-deck and session ID when insert mode targets a remote session
+	// (ItemTypeRemoteSession). Empty for local sessions, which use
+	// insertModeSessionID instead.
+	insertModeRemoteName string
+	insertModeRemoteID   string
 
 	// Insert-mode keystroke batching (#1094). Per-keystroke tmux send-keys
 	// invocations are too slow when typing fast. Runes are accumulated in
@@ -887,6 +906,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		feedbackSender:       feedback.NewSender(),
 		watcherPanel:         NewWatcherPanel(),
 		insertBatchDuration:  defaultInsertBatchDuration,
+		insertOpenKeySender:  defaultInsertOpenKeySender,
 		cursor:               0,
 		initialLoading:       true, // Show splash until sessions load
 		ctx:                  ctx,

--- a/internal/ui/insert_errors.go
+++ b/internal/ui/insert_errors.go
@@ -1,0 +1,13 @@
+package ui
+
+import "errors"
+
+// Sentinel errors for insert-mode KeySender bring-up. These let callers
+// disambiguate "no target session selected" from "tmux is sick" so the UI
+// can decide between a quiet fallback (per-call SendKeys) and a user-facing
+// setError.
+var (
+	errInsertNoTarget       = errors.New("insert mode: no target session")
+	errInsertNoTmuxSession  = errors.New("insert mode: target has no tmux pane")
+	errInsertNoRemoteConfig = errors.New("insert mode: remote not configured")
+)

--- a/internal/ui/insert_keysender.go
+++ b/internal/ui/insert_keysender.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"context"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// insertKeySender is the local interface the insert-mode dispatch path uses
+// to forward keystrokes. It abstracts the local (tmux control-mode client)
+// and remote (SSH RPC) implementations behind a single type so #1102's UI
+// changes stay platform-independent and unit-testable.
+//
+// Mirrors tmux.KeySender deliberately — same shape, decoupled package so the
+// UI doesn't pull a tmux symbol into its public surface and tests can supply
+// in-process fakes without depending on real tmux or SSH.
+type insertKeySender interface {
+	SendKeys(text string) error
+	SendNamedKey(key string) error
+	SendEnter() error
+	Close() error
+}
+
+// insertTargetRef describes the session insert mode is dispatching to. Either
+// a local Instance (with its tmux session bound) or a remote
+// (remoteName, remoteID) tuple — never both, never neither.
+type insertTargetRef struct {
+	// Local target. nil for remote sessions.
+	local *session.Instance
+	// Remote target name (the SSH remote alias, e.g. "windows"). Empty for
+	// local sessions. When non-empty, remoteID must also be set.
+	remoteName string
+	remoteID   string
+}
+
+// isRemote reports whether the target is a remote session.
+func (r insertTargetRef) isRemote() bool { return r.remoteName != "" }
+
+// defaultInsertOpenKeySender is the production opener wired up by NewHome.
+// It selects the local or remote path based on the target, and falls back to
+// returning an error so the caller can degrade to per-call SendKeys (#1102).
+//
+// Note: this is the ONLY place the UI package decides between local and
+// remote KeySender backends. Adding a new backend (e.g. Docker-sandboxed) is
+// a one-liner here, not a scatter-shot across insert_mode.go.
+func defaultInsertOpenKeySender(target insertTargetRef) (insertKeySender, error) {
+	if target.isRemote() {
+		return openRemoteInsertKeySender(target.remoteName, target.remoteID)
+	}
+	if target.local == nil {
+		return nil, errInsertNoTarget
+	}
+	tmuxSess := target.local.GetTmuxSession()
+	if tmuxSess == nil {
+		return nil, errInsertNoTmuxSession
+	}
+	ks, err := tmuxSess.OpenKeySender()
+	if err != nil {
+		return nil, err
+	}
+	return ks, nil
+}
+
+// openRemoteInsertKeySender resolves the remote configuration and returns a
+// RemoteKeySender bound to (remoteName, sessionID). Separated out so the
+// configuration-load + runner construction is unit-testable without
+// touching the UI.
+func openRemoteInsertKeySender(remoteName, sessionID string) (insertKeySender, error) {
+	config, err := session.LoadUserConfig()
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, errInsertNoRemoteConfig
+	}
+	rc, ok := config.Remotes[remoteName]
+	if !ok {
+		return nil, errInsertNoRemoteConfig
+	}
+	runner := session.NewSSHRunner(remoteName, rc)
+	return session.NewRemoteKeySender(runner, sessionID, context.Background()), nil
+}

--- a/internal/ui/insert_mode.go
+++ b/internal/ui/insert_mode.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,7 +14,13 @@ import (
 // defaultInsertBatchDuration is the production debounce window for coalescing
 // rune-by-rune typing into a single tmux send-keys call (#1094). Picked to
 // be small enough that the user can't feel it (~one frame at 60Hz) but large
-// enough that bursts of typing collapse into a single fork+exec.
+// enough that bursts of typing collapse into a single send.
+//
+// Pre-#1102 this also served as the only defense against per-keystroke
+// fork+exec cost — but at realistic typing speeds (>15ms between keys) every
+// keystroke still landed in its own batch and paid the full fork+exec. The
+// persistent KeySender (#1102) makes the per-call cost sub-millisecond, so
+// the batch window now only matters for true bursts and can stay small.
 const defaultInsertBatchDuration = 15 * time.Millisecond
 
 // insertFlushMsg is dispatched by the tea.Tick scheduled when the first rune
@@ -27,40 +34,132 @@ type insertFlushMsg struct{}
 // being interpreted as TUI commands. Esc returns to normal mode.
 
 // enterInsertMode arms insert mode if the cursor is on a session whose tmux
-// pane exists. Returns true on success. Errors are surfaced via setError so
-// the user sees why nothing happened.
+// pane exists (local) or a remote session row. Returns true on success.
+// Errors are surfaced via setError so the user sees why nothing happened.
+//
+// #1102 changes: also accepts ItemTypeRemoteSession rows. The local path
+// still requires a live tmux pane; the remote path doesn't (the pane lives
+// on the remote agent-deck and is reached by the SSH-backed KeySender).
 func (h *Home) enterInsertMode() bool {
-	inst := h.getSelectedSession()
-	if inst == nil {
-		h.setError(fmt.Errorf("insert mode: select a session first"))
+	target, ok := h.selectedInsertTarget()
+	if !ok {
 		return false
 	}
-	if inst.GetTmuxSession() == nil {
-		h.setError(fmt.Errorf("insert mode: session %q has no tmux pane", inst.Title))
+
+	// Open the persistent KeySender FIRST so a bring-up failure (no tmux,
+	// no remote, dead session) keeps the TUI in normal mode. If we flipped
+	// insertMode=true first and then failed, the user would be stranded.
+	ks, err := h.openInsertKeySender(target)
+	if err != nil && !errors.Is(err, errInsertNoTmuxSession) {
+		// errInsertNoTmuxSession is the recoverable case for local
+		// sessions whose pane vanished between selection and enter —
+		// surface a clear error.  Other errors fall back to per-call
+		// SendKeys (legacy path) so the feature stays usable on
+		// environments where the persistent client can't open
+		// (e.g., container without `tmux -C` support).
+		if !errors.Is(err, errInsertNoRemoteConfig) {
+			h.insertKeySender = nil
+		} else {
+			h.setError(fmt.Errorf("insert mode: %w", err))
+			return false
+		}
+	} else if err == nil {
+		h.insertKeySender = ks
+	} else {
+		h.setError(fmt.Errorf("insert mode: %w", err))
 		return false
 	}
+
 	h.insertMode = true
-	h.insertModeSessionID = inst.ID
+	if target.isRemote() {
+		h.insertModeSessionID = ""
+		h.insertModeRemoteName = target.remoteName
+		h.insertModeRemoteID = target.remoteID
+	} else {
+		h.insertModeSessionID = target.local.ID
+		h.insertModeRemoteName = ""
+		h.insertModeRemoteID = ""
+	}
 	return true
+}
+
+// selectedInsertTarget resolves the row under the cursor to an insertTargetRef
+// or returns ok=false (with an error already pushed to the TUI) when the
+// selection isn't a valid insert-mode target.
+func (h *Home) selectedInsertTarget() (insertTargetRef, bool) {
+	if len(h.flatItems) == 0 || h.cursor >= len(h.flatItems) {
+		h.setError(fmt.Errorf("insert mode: select a session first"))
+		return insertTargetRef{}, false
+	}
+	item := h.flatItems[h.cursor]
+	switch item.Type {
+	case session.ItemTypeSession:
+		if item.Session == nil {
+			h.setError(fmt.Errorf("insert mode: select a session first"))
+			return insertTargetRef{}, false
+		}
+		if item.Session.GetTmuxSession() == nil {
+			h.setError(fmt.Errorf("insert mode: session %q has no tmux pane", item.Session.Title))
+			return insertTargetRef{}, false
+		}
+		return insertTargetRef{local: item.Session}, true
+	case session.ItemTypeWindow:
+		inst := h.getInstanceByID(item.WindowSessionID)
+		if inst == nil || inst.GetTmuxSession() == nil {
+			h.setError(fmt.Errorf("insert mode: session has no tmux pane"))
+			return insertTargetRef{}, false
+		}
+		return insertTargetRef{local: inst}, true
+	case session.ItemTypeRemoteSession:
+		if item.RemoteSession == nil || item.RemoteName == "" {
+			h.setError(fmt.Errorf("insert mode: remote session row is malformed"))
+			return insertTargetRef{}, false
+		}
+		return insertTargetRef{
+			remoteName: item.RemoteName,
+			remoteID:   item.RemoteSession.ID,
+		}, true
+	default:
+		h.setError(fmt.Errorf("insert mode: select a session first"))
+		return insertTargetRef{}, false
+	}
+}
+
+// openInsertKeySender invokes the configured KeySender opener (production
+// default or test override) for `target`. Pulled out so enterInsertMode is
+// readable and tests can stub the opener without touching production code.
+func (h *Home) openInsertKeySender(target insertTargetRef) (insertKeySender, error) {
+	if h.insertOpenKeySender == nil {
+		return nil, nil // legacy fallback path — flushInsertBuf will use SendKeys
+	}
+	return h.insertOpenKeySender(target)
 }
 
 // exitInsertMode returns the TUI to normal navigation mode. Any pending
 // keystrokes in the batch buffer are dropped — they should have been flushed
-// by the caller via flushInsertBuf() if the user wanted them preserved.
+// by the caller via flushInsertBuf() if the user wanted them preserved. The
+// persistent KeySender (if any) is closed here, releasing the tmux -C
+// subprocess or SSH ControlMaster slot.
 func (h *Home) exitInsertMode() {
 	h.insertMode = false
 	h.insertModeSessionID = ""
+	h.insertModeRemoteName = ""
+	h.insertModeRemoteID = ""
 	h.insertBuf.Reset()
 	h.insertFlushPending = false
+	if h.insertKeySender != nil {
+		_ = h.insertKeySender.Close()
+		h.insertKeySender = nil
+	}
 }
 
 // handleInsertModeKey is the keyboard handler used while insert mode is
 // active. Esc exits, Enter sends a newline, and printable runes (and the
-// space key) are buffered then flushed in batches to amortize the fork+exec
-// cost of tmux send-keys (#1094 latency). Backspace, arrow keys, Tab,
-// ShiftTab, Ctrl-C, and Ctrl-D are forwarded as tmux named keys so users can
-// edit input and navigate menus inside the focused session (claude often
-// shows arrow-driven pickers).
+// space key) are buffered then flushed in batches to amortize the per-call
+// cost of sending keys (#1094 latency, #1102 perf). Backspace, arrow keys,
+// Tab, ShiftTab, Ctrl-C, and Ctrl-D are forwarded as tmux named keys so
+// users can edit input and navigate menus inside the focused session
+// (claude often shows arrow-driven pickers).
 func (h *Home) handleInsertModeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyEsc:
@@ -156,17 +255,49 @@ func (h *Home) flushInsertBuf() {
 }
 
 // dispatchInsertKey forwards literal text (optionally followed by Enter) to
-// the target session's tmux pane via the registered sink (real send-keys by
-// default; tests override via h.insertKeySink).
+// the target session. Dispatch order:
+//  1. insertKeySink — test override that captures calls
+//  2. insertKeySender — production persistent client (local tmux -C OR
+//     remote SSH RPC; opened in enterInsertMode)
+//  3. legacy fallback — fork+exec one tmux send-keys per call (slow but
+//     unconditional; used when the persistent client failed to open)
 func (h *Home) dispatchInsertKey(text string, sendEnter bool) {
-	inst := h.resolveInsertTarget()
-	if inst == nil {
-		return
-	}
+	// Tests use insertKeySink to inspect calls without running tmux.
 	if h.insertKeySink != nil {
+		inst := h.resolveInsertTarget()
+		if inst == nil {
+			return
+		}
 		if err := h.insertKeySink(inst, text, sendEnter); err != nil {
 			h.setError(fmt.Errorf("insert mode send failed: %w", err))
 		}
+		return
+	}
+
+	// Production: prefer the persistent KeySender. One fork+exec at
+	// enterInsertMode; per-keystroke calls become stdin writes (local)
+	// or amortize over SSH ControlMaster (remote).
+	if h.insertKeySender != nil {
+		if text != "" {
+			if err := h.insertKeySender.SendKeys(text); err != nil {
+				h.setError(fmt.Errorf("insert mode send-keys failed: %w", err))
+				return
+			}
+		}
+		if sendEnter {
+			if err := h.insertKeySender.SendEnter(); err != nil {
+				h.setError(fmt.Errorf("insert mode send-enter failed: %w", err))
+			}
+		}
+		return
+	}
+
+	// Legacy fallback: per-call fork+exec via the Session's tmux helpers.
+	// Hit only when OpenKeySender failed at enterInsertMode (rare). Remote
+	// sessions never reach here because they error out at enterInsertMode
+	// when no SSHRunner is configured.
+	inst := h.resolveInsertTarget()
+	if inst == nil {
 		return
 	}
 	tmuxSess := inst.GetTmuxSession()
@@ -189,17 +320,29 @@ func (h *Home) dispatchInsertKey(text string, sendEnter bool) {
 }
 
 // dispatchInsertNamedKey forwards a tmux named key (Up/Down/Left/Right/Tab/
-// BTab/BSpace/C-c/C-d) to the focused session. In tests an override sink
-// captures the key instead of running tmux.
+// BTab/BSpace/C-c/C-d) to the focused session. Same dispatch precedence as
+// dispatchInsertKey: test sink → persistent KeySender → legacy fork+exec.
 func (h *Home) dispatchInsertNamedKey(key string) {
-	inst := h.resolveInsertTarget()
-	if inst == nil {
-		return
-	}
 	if h.insertNamedKeySink != nil {
+		inst := h.resolveInsertTarget()
+		if inst == nil {
+			return
+		}
 		if err := h.insertNamedKeySink(inst, key); err != nil {
 			h.setError(fmt.Errorf("insert mode send named key failed: %w", err))
 		}
+		return
+	}
+
+	if h.insertKeySender != nil {
+		if err := h.insertKeySender.SendNamedKey(key); err != nil {
+			h.setError(fmt.Errorf("insert mode send-named-key failed: %w", err))
+		}
+		return
+	}
+
+	inst := h.resolveInsertTarget()
+	if inst == nil {
 		return
 	}
 	tmuxSess := inst.GetTmuxSession()
@@ -213,13 +356,21 @@ func (h *Home) dispatchInsertNamedKey(key string) {
 	}
 }
 
-// resolveInsertTarget returns the instance for the session insert mode is
-// targeting, or nil if it has disappeared (in which case insert mode is also
-// exited so the user isn't stranded).
+// resolveInsertTarget returns the local Instance for insert mode, or nil if
+// the target is remote or has disappeared. Remote sessions never have an
+// Instance — callers that need them (test sinks, legacy fork+exec fallback)
+// will see nil here and bail; the dispatchInsert* functions already route
+// remote sessions through h.insertKeySender before reaching this fallback.
 func (h *Home) resolveInsertTarget() *session.Instance {
 	if h.insertModeSessionID == "" {
-		h.exitInsertMode()
-		h.setError(fmt.Errorf("insert mode: no target session"))
+		// Remote sessions are valid insert-mode targets but have no local
+		// Instance. The non-sink dispatch path uses insertKeySender for
+		// them; only test sinks call this resolver, and they're set up by
+		// local-session tests.
+		if h.insertModeRemoteID == "" {
+			h.exitInsertMode()
+			h.setError(fmt.Errorf("insert mode: no target session"))
+		}
 		return nil
 	}
 	inst := h.getInstanceByID(h.insertModeSessionID)
@@ -240,10 +391,7 @@ func (h *Home) renderInsertModeBar() string {
 	borderStyle := lipgloss.NewStyle().Foreground(ColorBorder)
 	border := borderStyle.Render(repeatRune('─', max(0, h.width)))
 
-	targetTitle := ""
-	if inst := h.getInstanceByID(h.insertModeSessionID); inst != nil {
-		targetTitle = inst.Title
-	}
+	targetTitle := h.insertTargetDisplayName()
 
 	badge := lipgloss.NewStyle().
 		Foreground(ColorBg).
@@ -262,6 +410,27 @@ func (h *Home) renderInsertModeBar() string {
 	line += "  " + hintStyle.Render("Esc to exit · Enter to submit")
 
 	return lipgloss.JoinVertical(lipgloss.Left, border, line)
+}
+
+// insertTargetDisplayName returns the title (or remote-qualified label) for
+// the insert-mode target, so the bottom-bar indicator names something the
+// user recognises even when typing into a remote session.
+func (h *Home) insertTargetDisplayName() string {
+	if h.insertModeRemoteName != "" {
+		// Look up the remote session row for its title.
+		h.remoteSessionsMu.RLock()
+		defer h.remoteSessionsMu.RUnlock()
+		for _, s := range h.remoteSessions[h.insertModeRemoteName] {
+			if s.ID == h.insertModeRemoteID {
+				return h.insertModeRemoteName + "/" + s.Title
+			}
+		}
+		return h.insertModeRemoteName + "/" + h.insertModeRemoteID
+	}
+	if inst := h.getInstanceByID(h.insertModeSessionID); inst != nil {
+		return inst.Title
+	}
+	return ""
 }
 
 // repeatRune is a thin wrapper so insert_mode.go doesn't introduce strings

--- a/internal/ui/issue1102_insert_perf_test.go
+++ b/internal/ui/issue1102_insert_perf_test.go
@@ -1,0 +1,242 @@
+package ui
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Issue #1102 (by @ddorman-dn against v1.9.23): #1096's 15ms rune batching
+// didn't actually fix the latency complaint, because at realistic typing
+// speeds (>15ms between keystrokes) every keystroke still triggers a
+// separate flush which pays the full tmux fork+exec cost. These tests cover
+// the follow-up: every flush now goes through a persistent KeySender opened
+// at enterInsertMode (one fork+exec for the whole insert session) and torn
+// down at exitInsertMode.
+
+// fakeInsertKeySender simulates the persistent client by tracking how many
+// dispatches it received. SendKeys is intentionally costed at zero so the
+// 100-keys-in-500ms budget reflects in-process work, not the latency of
+// the dispatch sink itself.
+type fakeInsertKeySender struct {
+	sendCount     atomic.Int32
+	namedKeyCount atomic.Int32
+	enterCount    atomic.Int32
+	closeCount    atomic.Int32
+	lastText      string
+}
+
+func (f *fakeInsertKeySender) SendKeys(text string) error {
+	f.sendCount.Add(1)
+	f.lastText = text
+	return nil
+}
+func (f *fakeInsertKeySender) SendNamedKey(string) error {
+	f.namedKeyCount.Add(1)
+	return nil
+}
+func (f *fakeInsertKeySender) SendEnter() error {
+	f.enterCount.Add(1)
+	return nil
+}
+func (f *fakeInsertKeySender) Close() error {
+	f.closeCount.Add(1)
+	return nil
+}
+
+// armInsertModeWithFakeKeySender returns a Home wired with one focused
+// session whose insert-mode dispatch path is intercepted by a fake
+// persistent sender. The TUI-level insertKeySink/insertNamedKeySink are
+// deliberately NOT installed — this verifies the production dispatch
+// precedence (sink → sender → fallback) routes to the sender as expected.
+func armInsertModeWithFakeKeySender(t *testing.T) (*Home, *fakeInsertKeySender) {
+	t.Helper()
+	home, _, _ := armHomeWithOneSession(t)
+	// Clear the legacy sinks installed by armHomeWithOneSession so the
+	// dispatch path falls through to the persistent KeySender.
+	home.insertKeySink = nil
+	home.insertNamedKeySink = nil
+
+	fake := &fakeInsertKeySender{}
+	home.insertOpenKeySender = func(insertTargetRef) (insertKeySender, error) {
+		return fake, nil
+	}
+
+	// Enter insert mode — this is the moment that opens the sender.
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	home = model.(*Home)
+	if !home.insertMode {
+		t.Fatal("test setup: failed to enter insert mode")
+	}
+	if home.insertKeySender == nil {
+		t.Fatal("test setup: KeySender was not installed on enterInsertMode")
+	}
+	return home, fake
+}
+
+// TestIssue1102_PersistentKeySender_Opened verifies that pressing `I` opens
+// a persistent KeySender and stores it on Home — proving the production
+// dispatch path goes through the new persistent client instead of paying
+// per-keystroke fork+exec via the legacy Session.SendKeys path.
+func TestIssue1102_PersistentKeySender_Opened(t *testing.T) {
+	home, fake := armInsertModeWithFakeKeySender(t)
+	if home.insertKeySender == nil {
+		t.Fatal("insert mode did not install a persistent KeySender")
+	}
+	if home.insertKeySender != fake {
+		t.Errorf("insertKeySender = %v, want %v (the injected fake)", home.insertKeySender, fake)
+	}
+}
+
+// TestIssue1102_PersistentKeySender_ClosedOnExit verifies the KeySender's
+// Close is invoked when the user leaves insert mode — otherwise the tmux
+// -C subprocess (and an SSH ControlMaster slot for remote sessions) leak
+// for the lifetime of the TUI.
+func TestIssue1102_PersistentKeySender_ClosedOnExit(t *testing.T) {
+	home, fake := armInsertModeWithFakeKeySender(t)
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	home = model.(*Home)
+
+	if home.insertMode {
+		t.Error("Esc should exit insert mode")
+	}
+	if home.insertKeySender != nil {
+		t.Error("Esc should clear the persistent KeySender reference")
+	}
+	if got := fake.closeCount.Load(); got != 1 {
+		t.Errorf("Close() invoked %d times, want exactly 1", got)
+	}
+}
+
+// TestIssue1102_PersistentKeySender_TypedRunesGoThroughIt verifies that runes
+// typed in insert mode reach the persistent KeySender's SendKeys — proving
+// the fast path is used in production (i.e., not silently bypassed by the
+// legacy fork+exec fallback).
+func TestIssue1102_PersistentKeySender_TypedRunesGoThroughIt(t *testing.T) {
+	home, fake := armInsertModeWithFakeKeySender(t)
+	home.insertBatchDuration = -1 // sync: 1 sink call per rune for deterministic counting
+
+	for _, r := range "hello" {
+		model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		home = model.(*Home)
+	}
+
+	if got := fake.sendCount.Load(); got != 5 {
+		t.Errorf("SendKeys called %d times, want 5 (one per rune in sync mode)", got)
+	}
+}
+
+// TestIssue1102_PersistentKeySender_NamedKeysGoThroughIt verifies that
+// Backspace/arrows/Tab/Ctrl-C/Ctrl-D continue working in insert mode and
+// route through the KeySender's SendNamedKey instead of the legacy
+// Session.SendNamedKey fork+exec.
+func TestIssue1102_PersistentKeySender_NamedKeysGoThroughIt(t *testing.T) {
+	home, fake := armInsertModeWithFakeKeySender(t)
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	home = model.(*Home)
+
+	if got := fake.namedKeyCount.Load(); got != 1 {
+		t.Errorf("SendNamedKey called %d times, want 1 (Backspace)", got)
+	}
+}
+
+// TestIssue1102_PersistentKeySender_EnterGoesThroughIt covers the third
+// dispatch verb: Enter must reach the KeySender's SendEnter (which on the
+// remote path becomes a separate `agent-deck session send-keys --enter`
+// invocation and on the local path uses tmux's bracketed-paste-flush
+// SendEnter helper).
+func TestIssue1102_PersistentKeySender_EnterGoesThroughIt(t *testing.T) {
+	home, fake := armInsertModeWithFakeKeySender(t)
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	home = model.(*Home)
+
+	if got := fake.enterCount.Load(); got != 1 {
+		t.Errorf("SendEnter called %d times, want 1", got)
+	}
+}
+
+// TestIssue1102_InsertModePerf_100KeysUnder500ms is the headline regression
+// test for the latency complaint. Pumping 100 individual keystrokes through
+// the production insert-mode handler — with sync batching to force one
+// dispatch per keystroke (the realistic-typing case where the 15ms batch
+// window never coalesces) — must complete in under 500ms (5ms/keystroke
+// budget). The OLD implementation would fork+exec tmux per keystroke and
+// blow this budget on macOS under load; the NEW implementation goes through
+// the persistent KeySender and stays under the budget by orders of
+// magnitude.
+func TestIssue1102_InsertModePerf_100KeysUnder500ms(t *testing.T) {
+	home, fake := armInsertModeWithFakeKeySender(t)
+	home.insertBatchDuration = -1 // sync mode: force one dispatch per keystroke
+
+	const n = 100
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{rune('a' + i%26)}})
+		home = model.(*Home)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("100 keystrokes through insert mode took %v, want <500ms (#1102 perf budget)", elapsed)
+	}
+	if got := fake.sendCount.Load(); got != int32(n) {
+		t.Errorf("expected exactly %d SendKeys calls in sync mode; got %d", n, got)
+	}
+	t.Logf("100 keystrokes via persistent KeySender path: %v (%.2fms/keystroke)",
+		elapsed, float64(elapsed.Microseconds())/1000.0/float64(n))
+}
+
+// TestIssue1102_LegacyFallbackUsedWhenSenderUnavailable documents the
+// degradation path: when OpenKeySender returns an error (e.g., tmux -C
+// unsupported in some container), the dispatch falls back to the per-call
+// Session.SendKeys path so the feature still works — just slower. This
+// guards against a future regression where a broken sender opener would
+// disable insert mode entirely.
+func TestIssue1102_LegacyFallbackUsedWhenSenderUnavailable(t *testing.T) {
+	home, inst, runeCap := armHomeWithOneSession(t)
+	// Force the opener to fail — but the legacy fallback should keep the
+	// dispatch alive via insertKeySink (the test's per-call sink), proving
+	// no degradation in functionality.
+	home.insertOpenKeySender = func(insertTargetRef) (insertKeySender, error) {
+		return nil, errInsertNoRemoteConfig
+	}
+	// Reset opener so enterInsertMode error path fires — but in this case
+	// errInsertNoRemoteConfig is a local-session bring-up failure, not a
+	// remote one. Let's instead simulate "tmux not supported": return a
+	// non-sentinel error to take the silent fallback branch.
+	home.insertOpenKeySender = func(insertTargetRef) (insertKeySender, error) {
+		// Returning errInsertNoTmuxSession would set error; returning a
+		// generic error takes the fallback branch silently.
+		return nil, &fakeOpenerErr{}
+	}
+
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	home = model.(*Home)
+	if !home.insertMode {
+		t.Fatal("insert mode should still arm even if persistent sender fails to open")
+	}
+	if home.insertKeySender != nil {
+		t.Error("persistent sender should be nil when opener failed")
+	}
+
+	// Type one rune — should go through the legacy insertKeySink path
+	// (which armHomeWithOneSession installed).
+	model, _ = home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	_ = model
+	_ = inst
+	if len(runeCap.calls) != 1 {
+		t.Errorf("legacy fallback dispatch produced %d calls, want 1", len(runeCap.calls))
+	}
+}
+
+// fakeOpenerErr is a marker error used by the fallback test to take the
+// non-sentinel error branch in enterInsertMode (where the UI silently
+// degrades to per-call dispatch instead of surfacing the failure).
+type fakeOpenerErr struct{}
+
+func (*fakeOpenerErr) Error() string { return "tmux -C not supported in this environment" }

--- a/internal/ui/issue1102_insert_perf_test.go
+++ b/internal/ui/issue1102_insert_perf_test.go
@@ -137,7 +137,7 @@ func TestIssue1102_PersistentKeySender_NamedKeysGoThroughIt(t *testing.T) {
 	home, fake := armInsertModeWithFakeKeySender(t)
 
 	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyBackspace})
-	home = model.(*Home)
+	_ = model.(*Home) // assert type; we only check the fake's counters
 
 	if got := fake.namedKeyCount.Load(); got != 1 {
 		t.Errorf("SendNamedKey called %d times, want 1 (Backspace)", got)
@@ -153,7 +153,7 @@ func TestIssue1102_PersistentKeySender_EnterGoesThroughIt(t *testing.T) {
 	home, fake := armInsertModeWithFakeKeySender(t)
 
 	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	home = model.(*Home)
+	_ = model.(*Home) // assert type; we only check the fake's counters
 
 	if got := fake.enterCount.Load(); got != 1 {
 		t.Errorf("SendEnter called %d times, want 1", got)


### PR DESCRIPTION
## Summary

#1096 added 15ms rune batching for insert mode (#1094 / #1069) but @ddorman-dn confirmed against **v1.9.23** that:

1. **Latency** — typing in insert mode is still very slow for local sessions despite the batching.
2. **Remote** — typing in insert mode does nothing for remote sessions.

Two root causes; one fix.

### Bug 1 — latency

#1096's 15ms window only coalesces true bursts. At realistic typing speed (>15ms between keys) every keystroke still triggers its own flush, and each flush pays the full `tmux send-keys` **fork+exec** cost — on macOS under AV this is 10-50ms per keystroke; on Linux ~3-5ms.

Measured here (Linux, local tmux):
- 100 `send-keys` fork+exec calls: **374ms** (3.7ms / call)
- 100 `SendKeys` via persistent client: **<1ms** total (sub-µs / call)

### Bug 2 — remote

`enterInsertMode` only resolved the cursor row to a local `*Instance`. Remote sessions on the home view are `RemoteSessionInfo`, so the dispatch path never fired — silently. No error, just nothing happened when you typed.

## Fix

A `KeySender` interface opened at `enterInsertMode` and closed at `exitInsertMode`:

- **Local**: `tmux -L <sock> -C` control-mode subprocess (one fork+exec at the boundary; per-keystroke calls become stdin writes). Goes through the sanctioned `tmuxExec` factory so socket isolation (#687) is preserved — the lint test in `internal/tmux/tmux_exec_lint_test.go` enforces this.
- **Remote**: SSH-backed `RemoteKeySender` invoking a new `agent-deck session send-keys <id> [--text TEXT] [--enter] [--named-key KEY]` subcommand on the remote agent-deck. SSH ControlMaster (already in `SSHRunner`) amortizes the connection cost.
- Falls back to legacy per-call `Session.SendKeys` when bring-up fails (e.g., environment where `tmux -C` is unsupported) — insert mode still works, just slower.

## Tests

**`internal/tmux/keysender_test.go`** (8 cases)
- streams literal keys, perf budget (100 keystrokes <500ms — actually 73µs), named keys + Enter, idempotent close, target validation, single-quote escaping safety.

**`internal/ui/issue1102_insert_perf_test.go`** (7 cases)
- TUI opens/closes the persistent sender on enter/exit, routes runes / named keys / Enter through it, perf budget, and the legacy fork+exec fallback when the opener fails.

**`internal/session/issue1102_insert_remote_test.go`** (8 cases)
- `RemoteKeySender.SendKeys` / `SendNamedKey` / `SendEnter` reach the SSHRunner with the right argv, error propagation, empty-input rejection, idempotent close, concurrent-dispatch serialization.

All existing #1069 / #1094 / #687 / persistence / feedback / watcher / eval tests still pass. Full suite + race detector green.

## Don't break (from PROMPT)

- ✅ Local Backspace / arrow / Ctrl-key support from #1094 — covered by existing `TestIssue1094_*` (still green)
- ✅ Esc still exits insert mode — covered by `TestIssue1069_EscExitsInsertMode` (still green)
- ✅ Enter sends newline — covered by `TestIssue1069_EnterSendsNewlineToFocusedSession` (still green)
- ✅ `I` (Shift+i) enters insert mode — covered by `TestIssue1069_PressIEntersInsertMode` (still green)

## Credit

Credit @ddorman-dn for the v1.9.23 repro that surfaced both bugs.

## Test plan

- [ ] Local insert mode: type into a focused Claude pane at normal speed — characters appear with no perceptible lag (was: visible per-keystroke lag on v1.9.23).
- [ ] Local insert mode burst (paste 200 chars): single tmux send-keys call, no fork+exec storm.
- [ ] Remote insert mode (configure a remote with `agent-deck remote add`, focus a remote session, press `I`, type): characters arrive on the remote pane (was: silent no-op on v1.9.23).
- [ ] Remote `agent-deck session send-keys <id> --text foo` on a running session injects the keys.
- [ ] Esc closes the persistent client (verify with `pgrep -af 'tmux.*-C'`: count goes to zero after exit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI command to send single keystrokes (text, named keys, Enter) to sessions.
  * Persistent local and remote keystroke senders to stream input for faster insert-mode typing.
  * Insert-mode now uses a persistent sender with graceful fallback to legacy per-call sends.

* **Tests**
  * Extensive tests covering local/remote sending, error handling, concurrency, and a 100-keys/500ms perf regression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->