### PR TITLE
feat: add kiro-cli support

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -3098,6 +3098,8 @@ func detectTool(cmd string) string {
 		return "cursor"
 	case strings.Contains(cmd, "hermes"):
 		return "hermes"
+	case strings.Contains(cmd, "kiro"):
+		return "kiro"
 	default:
 		return "shell"
 	}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -3098,7 +3098,7 @@ func detectTool(cmd string) string {
 		return "cursor"
 	case strings.Contains(cmd, "hermes"):
 		return "hermes"
-	case strings.Contains(cmd, "kiro"):
+	case hasCommandToken(cmd, "kiro") || strings.Contains(cmd, "kiro-cli"):
 		return "kiro"
 	default:
 		return "shell"

--- a/internal/docker/config.go
+++ b/internal/docker/config.go
@@ -79,10 +79,9 @@ var agentConfigMounts = []AgentConfigMount{
 		skipEntries:     []string{"sandbox"},
 	},
 	{
-		hostRel:         ".aws",
-		containerSuffix: ".aws",
+		hostRel:         ".aws/sso",
+		containerSuffix: ".aws/sso",
 		skipEntries:     []string{"sandbox"},
-		copyDirs:        []string{"sso"},
 	},
 }
 

--- a/internal/docker/config.go
+++ b/internal/docker/config.go
@@ -68,6 +68,22 @@ var agentConfigMounts = []AgentConfigMount{
 		containerSuffix: ".gemini",
 		skipEntries:     []string{"sandbox"},
 	},
+	{
+		hostRel:         ".kiro",
+		containerSuffix: ".kiro",
+		skipEntries:     []string{"sandbox"},
+	},
+	{
+		hostRel:         ".local/share/kiro-cli",
+		containerSuffix: ".local/share/kiro-cli",
+		skipEntries:     []string{"sandbox"},
+	},
+	{
+		hostRel:         ".aws",
+		containerSuffix: ".aws",
+		skipEntries:     []string{"sandbox"},
+		copyDirs:        []string{"sso"},
+	},
 }
 
 // Mount path blocklists — prevent accidental exposure of sensitive host and container paths.

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -225,7 +225,7 @@ func GetConductorAgentSpec(agent string) (ConductorAgentSpec, error) {
 	normalized := normalizeConductorAgent(agent)
 	spec, ok := conductorAgentSpecs[normalized]
 	if !ok {
-		return ConductorAgentSpec{}, fmt.Errorf("unsupported conductor agent %q (supported: %s, %s)", agent, ConductorAgentClaude, ConductorAgentCodex)
+		return ConductorAgentSpec{}, fmt.Errorf("unsupported conductor agent %q (supported: %s, %s, %s)", agent, ConductorAgentClaude, ConductorAgentCodex, ConductorAgentKiro)
 	}
 	return spec, nil
 }

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -17,6 +17,7 @@ import (
 const (
 	ConductorAgentClaude = "claude"
 	ConductorAgentCodex  = "codex"
+	ConductorAgentKiro   = "kiro"
 
 	ConductorSessionTitlePrefix     = "conductor-"
 	ConductorHeartbeatMessagePrefix = "Heartbeat:"
@@ -50,6 +51,13 @@ var conductorAgentSpecs = map[string]ConductorAgentSpec{
 		DisplayName:            "Codex",
 		DefaultCommand:         "codex",
 		InstructionsFileName:   "AGENTS.md",
+		SupportsClearOnCompact: false,
+	},
+	ConductorAgentKiro: {
+		Agent:                  ConductorAgentKiro,
+		DisplayName:            "Kiro",
+		DefaultCommand:         "kiro-cli",
+		InstructionsFileName:   "KIRO.md",
 		SupportsClearOnCompact: false,
 	},
 }

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1326,12 +1326,16 @@ func (i *Instance) buildKiroCommand(baseCommand string) string {
 
 	// Apply tool options if set
 	opts := i.GetKiroOptions()
+	hasResume := false
 	if opts != nil {
 		for _, arg := range opts.ToArgs() {
 			args += " " + arg
+			if arg == "--resume-id" || arg == "--resume" {
+				hasResume = true
+			}
 		}
-	} else if i.KiroSessionID != "" {
-		// Resume existing session on restart
+	}
+	if !hasResume && i.KiroSessionID != "" {
 		args += " --resume-id " + i.KiroSessionID
 	}
 
@@ -1347,7 +1351,7 @@ func (i *Instance) buildKiroCommand(baseCommand string) string {
 	if opts == nil || opts.Agent == "" {
 		userConfig, _ := LoadUserConfig()
 		if userConfig != nil && userConfig.Kiro.DefaultAgent != "" {
-			args += " --agent " + userConfig.Kiro.DefaultAgent
+			args += " --agent " + shellescape.Quote(userConfig.Kiro.DefaultAgent)
 		}
 	}
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3461,6 +3461,11 @@ func (i *Instance) UpdateStatus() error {
 		}
 	}
 
+	// Refresh kiro filesystem status before the fast path so hookStatus is current.
+	if i.Tool == "kiro" && i.KiroSessionID != "" {
+		i.updateKiroFilesystemStatus()
+	}
+
 	// HOOK FAST PATH: hook-based status for tools that emit lifecycle events.
 	// Freshness is tool- and state-specific (e.g. Codex running vs waiting).
 	// When this path is stale/missing, control naturally falls through to tmux

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -166,9 +166,8 @@ type Instance struct {
 	CopilotAllowAll   bool      `json:"copilot_allow_all,omitempty"` // Per-session --allow-all override
 
 	// Kiro CLI integration
-	KiroSessionID         string    `json:"kiro_session_id,omitempty"`
-	KiroDetectedAt        time.Time `json:"kiro_detected_at,omitempty"`
-	lastKiroCostTurnCount int       `json:"-"` // tracks emitted cost turns
+	KiroSessionID  string    `json:"kiro_session_id,omitempty"`
+	KiroDetectedAt time.Time `json:"kiro_detected_at,omitempty"`
 
 	// Latest user input for context (extracted from session files)
 	LatestPrompt      string    `json:"latest_prompt,omitempty"`
@@ -1340,8 +1339,8 @@ func (i *Instance) buildKiroCommand(baseCommand string) string {
 	}
 
 	// Apply config-level trust-all-tools if no explicit option set
+	userConfig, _ := LoadUserConfig()
 	if opts == nil || !opts.TrustAllTools {
-		userConfig, _ := LoadUserConfig()
 		if userConfig != nil && userConfig.Kiro.TrustAllTools {
 			args += " --trust-all-tools"
 		}
@@ -1349,7 +1348,6 @@ func (i *Instance) buildKiroCommand(baseCommand string) string {
 
 	// Apply config-level default agent if no explicit option set
 	if opts == nil || opts.Agent == "" {
-		userConfig, _ := LoadUserConfig()
 		if userConfig != nil && userConfig.Kiro.DefaultAgent != "" {
 			args += " --agent " + shellescape.Quote(userConfig.Kiro.DefaultAgent)
 		}
@@ -1445,12 +1443,13 @@ func (i *Instance) updateKiroFilesystemStatus() {
 	if json.Unmarshal(lockData, &lock) != nil {
 		return
 	}
-	// Check PID liveness
-	if err := syscall.Kill(lock.PID, 0); err != nil {
-		// PID dead - session ended
-		i.hookStatus = "dead"
-		i.hookLastUpdate = time.Now()
-		return
+	// Check PID liveness (skip when sandboxed — PID is inside the container)
+	if !i.IsSandboxed() {
+		if err := syscall.Kill(lock.PID, 0); err != nil {
+			i.hookStatus = "dead"
+			i.hookLastUpdate = time.Now()
+			return
+		}
 	}
 
 	// Check JSONL mtime
@@ -1469,45 +1468,6 @@ func (i *Instance) updateKiroFilesystemStatus() {
 	// Not recently modified = waiting (idle)
 	i.hookStatus = "waiting"
 	i.hookLastUpdate = time.Now()
-}
-
-// emitKiroCostEvents processes new cost turns from kiro session data.
-func (i *Instance) emitKiroCostEvents() {
-	if i.Tool != "kiro" || i.KiroSessionID == "" {
-		return
-	}
-	homeDir, _ := os.UserHomeDir()
-	sessionFile := filepath.Join(homeDir, ".kiro", "sessions", "cli", i.KiroSessionID+".json")
-	data, err := os.ReadFile(sessionFile)
-	if err != nil {
-		return
-	}
-	var sess struct {
-		SessionState struct {
-			ConversationMetadata struct {
-				UserTurnMetadatas []struct {
-					MeteringUsage []struct {
-						Value float64 `json:"value"`
-						Unit  string  `json:"unit"`
-					} `json:"metering_usage"`
-				} `json:"user_turn_metadatas"`
-			} `json:"conversation_metadata"`
-		} `json:"session_state"`
-	}
-	if json.Unmarshal(data, &sess) != nil {
-		return
-	}
-	turns := sess.SessionState.ConversationMetadata.UserTurnMetadatas
-	if len(turns) <= i.lastKiroCostTurnCount {
-		return // No new turns
-	}
-	// Process new turns only
-	for idx := i.lastKiroCostTurnCount; idx < len(turns); idx++ {
-		for _, usage := range turns[idx].MeteringUsage {
-			_ = usage.Value // Cost event emission would go here
-		}
-	}
-	i.lastKiroCostTurnCount = len(turns)
 }
 
 // buildCursorCommand builds the command for the Cursor CLI (`cursor agent`).
@@ -3476,11 +3436,6 @@ func (i *Instance) UpdateStatus() error {
 	// Session exists - clear error check timestamp
 	i.lastErrorCheck = time.Time{}
 
-	// Kiro session ID discovery — runs early, before idle skip, since it's lightweight.
-	if i.Tool == "kiro" && i.KiroSessionID == "" {
-		i.detectKiroSessionFromDisk()
-	}
-
 	// Tiered polling: skip expensive checks for idle sessions with no new activity
 	if i.Status == StatusIdle {
 		currentTS := i.tmuxSession.GetCachedWindowActivity()
@@ -3690,7 +3645,6 @@ func (i *Instance) UpdateStatus() error {
 			if i.Tool == "kiro" {
 				i.detectKiroSessionFromDisk()
 				i.updateKiroFilesystemStatus()
-				i.emitKiroCostEvents()
 			}
 		}
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1407,11 +1407,6 @@ func (i *Instance) detectKiroSessionFromDisk() {
 		if sess.Cwd != projectPath && sess.Cwd != effectiveDir {
 			continue
 		}
-		// Skip sessions locked by another process
-		lockFile := filepath.Join(sessionsDir, sess.SessionID+".lock")
-		if _, err := os.Stat(lockFile); err == nil {
-			continue
-		}
 		t, _ := time.Parse(time.RFC3339Nano, sess.UpdatedAt)
 		if t.After(bestTime) {
 			bestTime = t
@@ -3470,7 +3465,7 @@ func (i *Instance) UpdateStatus() error {
 	// Freshness is tool- and state-specific (e.g. Codex running vs waiting).
 	// When this path is stale/missing, control naturally falls through to tmux
 	// polling and tool-specific session sync (tmux env/process-files/disk).
-	if (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini") &&
+	if (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini" || i.Tool == "kiro") &&
 		i.hookStatus != "" &&
 		time.Since(i.hookLastUpdate) < hookFastPathFreshnessForTool(i.Tool, i.hookStatus) {
 		switch i.hookStatus {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"al.essio.dev/pkg/shellescape"
@@ -163,6 +164,11 @@ type Instance struct {
 	CopilotStartedAt  int64     `json:"-"`                           // Unix millis when we started Copilot (for session matching, not persisted)
 	CopilotModel      string    `json:"copilot_model,omitempty"`     // Active model for this session
 	CopilotAllowAll   bool      `json:"copilot_allow_all,omitempty"` // Per-session --allow-all override
+
+	// Kiro CLI integration
+	KiroSessionID         string    `json:"kiro_session_id,omitempty"`
+	KiroDetectedAt        time.Time `json:"kiro_detected_at,omitempty"`
+	lastKiroCostTurnCount int       `json:"-"` // tracks emitted cost turns
 
 	// Latest user input for context (extracted from session files)
 	LatestPrompt      string    `json:"latest_prompt,omitempty"`
@@ -1300,6 +1306,204 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	}
 
 	return envPrefix + command + yoloFlag + modelFlag
+}
+
+// buildKiroCommand builds the command for Kiro CLI (`kiro-cli chat`).
+// Handles resume via --resume-id, --trust-all-tools, --agent, and --model flags.
+func (i *Instance) buildKiroCommand(baseCommand string) string {
+	envPrefix := i.buildEnvSourceCommand()
+	cmd := strings.TrimSpace(baseCommand)
+	if cmd == "" || strings.EqualFold(cmd, "kiro-cli") || strings.EqualFold(cmd, "kiro") {
+		cmd = GetKiroCommand()
+	}
+
+	args := cmd + " chat"
+
+	// Discover session ID from disk if not already known
+	if i.KiroSessionID == "" {
+		i.detectKiroSessionFromDisk()
+	}
+
+	// Apply tool options if set
+	opts := i.GetKiroOptions()
+	if opts != nil {
+		for _, arg := range opts.ToArgs() {
+			args += " " + arg
+		}
+	} else if i.KiroSessionID != "" {
+		// Resume existing session on restart
+		args += " --resume-id " + i.KiroSessionID
+	}
+
+	// Apply config-level trust-all-tools if no explicit option set
+	if opts == nil || !opts.TrustAllTools {
+		userConfig, _ := LoadUserConfig()
+		if userConfig != nil && userConfig.Kiro.TrustAllTools {
+			args += " --trust-all-tools"
+		}
+	}
+
+	// Apply config-level default agent if no explicit option set
+	if opts == nil || opts.Agent == "" {
+		userConfig, _ := LoadUserConfig()
+		if userConfig != nil && userConfig.Kiro.DefaultAgent != "" {
+			args += " --agent " + userConfig.Kiro.DefaultAgent
+		}
+	}
+
+	return envPrefix + args
+}
+
+// GetKiroOptions returns the KiroOptions for this instance, or nil.
+func (i *Instance) GetKiroOptions() *KiroOptions {
+	if i.ToolOptionsJSON == nil || len(i.ToolOptionsJSON) == 0 {
+		return nil
+	}
+	opts, _ := UnmarshalKiroOptions(i.ToolOptionsJSON)
+	return opts
+}
+
+// detectKiroSessionFromDisk discovers the kiro session ID by scanning session files on disk.
+func (i *Instance) detectKiroSessionFromDisk() {
+	if i.Tool != "kiro" || i.KiroSessionID != "" {
+		return
+	}
+	homeDir, _ := os.UserHomeDir()
+	if homeDir == "" {
+		return
+	}
+	sessionsDir := filepath.Join(homeDir, ".kiro", "sessions", "cli")
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return
+	}
+
+	// Expand project path for comparison (stored as ~/... but kiro uses absolute)
+	projectPath := i.ProjectPath
+	if strings.HasPrefix(projectPath, "~/") {
+		projectPath = filepath.Join(homeDir, projectPath[2:])
+	}
+	effectiveDir := i.EffectiveWorkingDir()
+	if strings.HasPrefix(effectiveDir, "~/") {
+		effectiveDir = filepath.Join(homeDir, effectiveDir[2:])
+	}
+
+	var bestID string
+	var bestTime time.Time
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") || strings.HasSuffix(e.Name(), ".lock") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(sessionsDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var sess struct {
+			SessionID string `json:"session_id"`
+			Cwd       string `json:"cwd"`
+			UpdatedAt string `json:"updated_at"`
+		}
+		if json.Unmarshal(data, &sess) != nil {
+			continue
+		}
+		if sess.Cwd != projectPath && sess.Cwd != effectiveDir {
+			continue
+		}
+		t, _ := time.Parse(time.RFC3339Nano, sess.UpdatedAt)
+		if t.After(bestTime) {
+			bestTime = t
+			bestID = sess.SessionID
+		}
+	}
+	if bestID != "" {
+		i.KiroSessionID = bestID
+		i.KiroDetectedAt = time.Now()
+	}
+}
+
+// updateKiroFilesystemStatus detects kiro session status from filesystem signals.
+func (i *Instance) updateKiroFilesystemStatus() {
+	if i.Tool != "kiro" || i.KiroSessionID == "" {
+		return
+	}
+	homeDir, _ := os.UserHomeDir()
+	sessionsDir := filepath.Join(homeDir, ".kiro", "sessions", "cli")
+
+	// Check lock file
+	lockFile := filepath.Join(sessionsDir, i.KiroSessionID+".lock")
+	lockData, err := os.ReadFile(lockFile)
+	if err != nil {
+		return // No lock = can't determine status from filesystem
+	}
+	var lock struct {
+		PID int `json:"pid"`
+	}
+	if json.Unmarshal(lockData, &lock) != nil {
+		return
+	}
+	// Check PID liveness
+	if err := syscall.Kill(lock.PID, 0); err != nil {
+		// PID dead - session ended
+		i.hookStatus = "dead"
+		i.hookLastUpdate = time.Now()
+		return
+	}
+
+	// Check JSONL mtime
+	jsonlFile := filepath.Join(sessionsDir, i.KiroSessionID+".jsonl")
+	info, err := os.Stat(jsonlFile)
+	if err != nil {
+		return
+	}
+	age := time.Since(info.ModTime())
+	if age < 5*time.Second {
+		// Recently modified = running
+		i.hookStatus = "running"
+		i.hookLastUpdate = time.Now()
+		return
+	}
+	// Not recently modified = waiting (idle)
+	i.hookStatus = "waiting"
+	i.hookLastUpdate = time.Now()
+}
+
+// emitKiroCostEvents processes new cost turns from kiro session data.
+func (i *Instance) emitKiroCostEvents() {
+	if i.Tool != "kiro" || i.KiroSessionID == "" {
+		return
+	}
+	homeDir, _ := os.UserHomeDir()
+	sessionFile := filepath.Join(homeDir, ".kiro", "sessions", "cli", i.KiroSessionID+".json")
+	data, err := os.ReadFile(sessionFile)
+	if err != nil {
+		return
+	}
+	var sess struct {
+		SessionState struct {
+			ConversationMetadata struct {
+				UserTurnMetadatas []struct {
+					MeteringUsage []struct {
+						Value float64 `json:"value"`
+						Unit  string  `json:"unit"`
+					} `json:"metering_usage"`
+				} `json:"user_turn_metadatas"`
+			} `json:"conversation_metadata"`
+		} `json:"session_state"`
+	}
+	if json.Unmarshal(data, &sess) != nil {
+		return
+	}
+	turns := sess.SessionState.ConversationMetadata.UserTurnMetadatas
+	if len(turns) <= i.lastKiroCostTurnCount {
+		return // No new turns
+	}
+	// Process new turns only
+	for idx := i.lastKiroCostTurnCount; idx < len(turns); idx++ {
+		for _, usage := range turns[idx].MeteringUsage {
+			_ = usage.Value // Cost event emission would go here
+		}
+	}
+	i.lastKiroCostTurnCount = len(turns)
 }
 
 // buildCursorCommand builds the command for the Cursor CLI (`cursor agent`).
@@ -2722,6 +2926,8 @@ func (i *Instance) Start() error {
 		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "hermes":
 		command = i.buildHermesCommand(i.Command)
+	case i.Tool == "kiro":
+		command = i.buildKiroCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -2926,6 +3132,8 @@ func (i *Instance) StartWithMessage(message string) error {
 		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "hermes":
 		command = i.buildHermesCommand(i.Command)
+	case i.Tool == "kiro":
+		command = i.buildKiroCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -3264,6 +3472,11 @@ func (i *Instance) UpdateStatus() error {
 	// Session exists - clear error check timestamp
 	i.lastErrorCheck = time.Time{}
 
+	// Kiro session ID discovery — runs early, before idle skip, since it's lightweight.
+	if i.Tool == "kiro" && i.KiroSessionID == "" {
+		i.detectKiroSessionFromDisk()
+	}
+
 	// Tiered polling: skip expensive checks for idle sessions with no new activity
 	if i.Status == StatusIdle {
 		currentTS := i.tmuxSession.GetCachedWindowActivity()
@@ -3402,11 +3615,11 @@ func (i *Instance) UpdateStatus() error {
 			// Preserve configured custom tool names.
 		} else {
 			switch detectedTool {
-			case "claude", "gemini", "opencode", "codex":
+			case "claude", "gemini", "opencode", "codex", "kiro":
 				i.Tool = detectedTool
 			case "shell":
 				switch i.Tool {
-				case "", "shell", "claude", "gemini", "opencode", "codex":
+				case "", "shell", "claude", "gemini", "opencode", "codex", "kiro":
 					i.Tool = detectedTool
 				}
 			}
@@ -3416,7 +3629,7 @@ func (i *Instance) UpdateStatus() error {
 	// Update session metadata tracking only for active/waiting sessions.
 	// This path can perform filesystem and tmux env reads while i.mu is held, so
 	// rate-limit it to reduce intermittent render/key handling stalls under load.
-	if i.Status == StatusRunning || i.Status == StatusWaiting {
+	if i.Status == StatusRunning || i.Status == StatusWaiting || (i.Tool == "kiro" && i.Status == StatusIdle) {
 		interval := 2 * time.Second
 		// Bootstrap unknown IDs faster for newly-started sessions.
 		switch {
@@ -3430,6 +3643,10 @@ func (i *Instance) UpdateStatus() error {
 			}
 		case IsCodexCompatible(i.Tool):
 			if i.CodexSessionID == "" {
+				interval = 500 * time.Millisecond
+			}
+		case i.Tool == "kiro":
+			if i.KiroSessionID == "" {
 				interval = 500 * time.Millisecond
 			}
 		}
@@ -3463,6 +3680,13 @@ func (i *Instance) UpdateStatus() error {
 				i.mu.Unlock()
 				i.UpdateOpenCodeSession()
 				i.mu.Lock()
+			}
+
+			// Update Kiro session tracking (non-blocking, best-effort)
+			if i.Tool == "kiro" {
+				i.detectKiroSessionFromDisk()
+				i.updateKiroFilesystemStatus()
+				i.emitKiroCostEvents()
 			}
 		}
 	}
@@ -5295,6 +5519,8 @@ func (i *Instance) Restart() error {
 			command = i.buildCursorCommand(i.Command, true)
 		case i.Tool == "hermes":
 			command = i.buildHermesCommand(i.Command)
+		case i.Tool == "kiro":
+			command = i.buildKiroCommand(i.Command)
 		default:
 			// Check if this is a custom tool with session resume config
 			if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -6098,6 +6324,8 @@ func (i *Instance) GetMCPInfo() *MCPInfo {
 		return GetMCPInfo(i.ProjectPath)
 	case i.Tool == "gemini":
 		return GetGeminiMCPInfo(i.ProjectPath)
+	case i.Tool == "kiro":
+		return GetKiroMCPInfo(i.ProjectPath)
 	default:
 		return nil
 	}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1318,11 +1318,6 @@ func (i *Instance) buildKiroCommand(baseCommand string) string {
 
 	args := cmd + " chat"
 
-	// Discover session ID from disk if not already known
-	if i.KiroSessionID == "" {
-		i.detectKiroSessionFromDisk()
-	}
-
 	// Apply tool options if set
 	opts := i.GetKiroOptions()
 	hasResume := false
@@ -1334,8 +1329,9 @@ func (i *Instance) buildKiroCommand(baseCommand string) string {
 			}
 		}
 	}
-	if !hasResume && i.KiroSessionID != "" {
-		args += " --resume-id " + i.KiroSessionID
+	// Resume most recent session for this directory on restart
+	if !hasResume && !i.LastStartedAt.IsZero() {
+		args += " --resume"
 	}
 
 	// Apply config-level trust-all-tools if no explicit option set
@@ -1409,6 +1405,11 @@ func (i *Instance) detectKiroSessionFromDisk() {
 			continue
 		}
 		if sess.Cwd != projectPath && sess.Cwd != effectiveDir {
+			continue
+		}
+		// Skip sessions locked by another process
+		lockFile := filepath.Join(sessionsDir, sess.SessionID+".lock")
+		if _, err := os.Stat(lockFile); err == nil {
 			continue
 		}
 		t, _ := time.Parse(time.RFC3339Nano, sess.UpdatedAt)

--- a/internal/session/kiro_mcp.go
+++ b/internal/session/kiro_mcp.go
@@ -4,11 +4,18 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // GetKiroMCPInfo returns MCP server information for a kiro session.
 func GetKiroMCPInfo(projectPath string) *MCPInfo {
 	info := &MCPInfo{}
+
+	// Expand ~/
+	homeDir, _ := os.UserHomeDir()
+	if strings.HasPrefix(projectPath, "~/") && homeDir != "" {
+		projectPath = filepath.Join(homeDir, projectPath[2:])
+	}
 
 	// Read workspace mcp.json
 	workspacePath := filepath.Join(projectPath, ".kiro", "settings", "mcp.json")
@@ -19,7 +26,6 @@ func GetKiroMCPInfo(projectPath string) *MCPInfo {
 	}
 
 	// Read global mcp.json
-	homeDir, _ := os.UserHomeDir()
 	globalPath := filepath.Join(homeDir, ".kiro", "settings", "mcp.json")
 	if names := readKiroMCPNames(globalPath); len(names) > 0 {
 		info.Global = names

--- a/internal/session/kiro_mcp.go
+++ b/internal/session/kiro_mcp.go
@@ -1,0 +1,100 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// GetKiroMCPInfo returns MCP server information for a kiro session.
+func GetKiroMCPInfo(projectPath string) *MCPInfo {
+	info := &MCPInfo{}
+
+	// Read workspace mcp.json
+	workspacePath := filepath.Join(projectPath, ".kiro", "settings", "mcp.json")
+	if names := readKiroMCPNames(workspacePath); len(names) > 0 {
+		for _, n := range names {
+			info.LocalMCPs = append(info.LocalMCPs, LocalMCP{Name: n, SourcePath: filepath.Dir(workspacePath)})
+		}
+	}
+
+	// Read global mcp.json
+	homeDir, _ := os.UserHomeDir()
+	globalPath := filepath.Join(homeDir, ".kiro", "settings", "mcp.json")
+	if names := readKiroMCPNames(globalPath); len(names) > 0 {
+		info.Global = names
+	}
+
+	return info
+}
+
+func readKiroMCPNames(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var cfg struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if json.Unmarshal(data, &cfg) != nil {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.MCPServers))
+	for name := range cfg.MCPServers {
+		names = append(names, name)
+	}
+	return names
+}
+
+// GetKiroMCPNames returns all MCP server names for a kiro project.
+func GetKiroMCPNames(projectPath string) []string {
+	info := GetKiroMCPInfo(projectPath)
+	if info == nil {
+		return nil
+	}
+	all := make([]string, 0, len(info.Global)+len(info.LocalMCPs))
+	all = append(all, info.Global...)
+	for _, m := range info.LocalMCPs {
+		all = append(all, m.Name)
+	}
+	return all
+}
+
+// WriteKiroMCP writes an MCP server config to kiro's mcp.json.
+func WriteKiroMCP(projectPath, name, scope string, serverConfig json.RawMessage) error {
+	var path string
+	switch scope {
+	case "workspace", "local":
+		path = filepath.Join(projectPath, ".kiro", "settings", "mcp.json")
+	case "global":
+		homeDir, _ := os.UserHomeDir()
+		path = filepath.Join(homeDir, ".kiro", "settings", "mcp.json")
+	default:
+		return fmt.Errorf("unknown scope: %s", scope)
+	}
+
+	// Read existing
+	var cfg struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	data, err := os.ReadFile(path)
+	if err == nil {
+		_ = json.Unmarshal(data, &cfg)
+	}
+	if cfg.MCPServers == nil {
+		cfg.MCPServers = make(map[string]json.RawMessage)
+	}
+
+	cfg.MCPServers[name] = serverConfig
+
+	// Write
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0644)
+}

--- a/internal/session/kiro_mcp.go
+++ b/internal/session/kiro_mcp.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -45,56 +44,4 @@ func readKiroMCPNames(path string) []string {
 		names = append(names, name)
 	}
 	return names
-}
-
-// GetKiroMCPNames returns all MCP server names for a kiro project.
-func GetKiroMCPNames(projectPath string) []string {
-	info := GetKiroMCPInfo(projectPath)
-	if info == nil {
-		return nil
-	}
-	all := make([]string, 0, len(info.Global)+len(info.LocalMCPs))
-	all = append(all, info.Global...)
-	for _, m := range info.LocalMCPs {
-		all = append(all, m.Name)
-	}
-	return all
-}
-
-// WriteKiroMCP writes an MCP server config to kiro's mcp.json.
-func WriteKiroMCP(projectPath, name, scope string, serverConfig json.RawMessage) error {
-	var path string
-	switch scope {
-	case "workspace", "local":
-		path = filepath.Join(projectPath, ".kiro", "settings", "mcp.json")
-	case "global":
-		homeDir, _ := os.UserHomeDir()
-		path = filepath.Join(homeDir, ".kiro", "settings", "mcp.json")
-	default:
-		return fmt.Errorf("unknown scope: %s", scope)
-	}
-
-	// Read existing
-	var cfg struct {
-		MCPServers map[string]json.RawMessage `json:"mcpServers"`
-	}
-	data, err := os.ReadFile(path)
-	if err == nil {
-		_ = json.Unmarshal(data, &cfg)
-	}
-	if cfg.MCPServers == nil {
-		cfg.MCPServers = make(map[string]json.RawMessage)
-	}
-
-	cfg.MCPServers[name] = serverConfig
-
-	// Write
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-	out, err := json.MarshalIndent(cfg, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(path, out, 0644)
 }

--- a/internal/session/kiro_test.go
+++ b/internal/session/kiro_test.go
@@ -111,7 +111,10 @@ func TestBuildKiroCommand_WithOptions(t *testing.T) {
 		Agent:         "my-agent",
 		Model:         "claude-opus-4.7",
 	}
-	data, _ := MarshalToolOptions(opts)
+	data, err := MarshalToolOptions(opts)
+	if err != nil {
+		t.Fatalf("MarshalToolOptions: %v", err)
+	}
 	inst.ToolOptionsJSON = data
 
 	cmd := inst.buildKiroCommand("kiro-cli")

--- a/internal/session/kiro_test.go
+++ b/internal/session/kiro_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestKiroOptions_ToolName(t *testing.T) {
@@ -94,13 +95,13 @@ func TestBuildKiroCommand(t *testing.T) {
 	}
 }
 
-func TestBuildKiroCommand_WithSessionID(t *testing.T) {
+func TestBuildKiroCommand_WithResumeOnRestart(t *testing.T) {
 	inst := NewInstanceWithTool("test-kiro", "/tmp/project", "kiro")
-	inst.KiroSessionID = "abc-def-123"
+	inst.LastStartedAt = time.Now().Add(-time.Minute)
 
 	cmd := inst.buildKiroCommand("kiro-cli")
-	if !strings.Contains(cmd, "--resume-id abc-def-123") {
-		t.Errorf("buildKiroCommand should contain '--resume-id abc-def-123', got %q", cmd)
+	if !strings.Contains(cmd, "--resume") {
+		t.Errorf("buildKiroCommand should contain '--resume' on restart, got %q", cmd)
 	}
 }
 

--- a/internal/session/kiro_test.go
+++ b/internal/session/kiro_test.go
@@ -1,0 +1,127 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestKiroOptions_ToolName(t *testing.T) {
+	opts := &KiroOptions{}
+	if got := opts.ToolName(); got != "kiro" {
+		t.Errorf("KiroOptions.ToolName() = %q, want %q", got, "kiro")
+	}
+}
+
+func TestKiroOptions_ToArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		opts KiroOptions
+		want []string
+	}{
+		{"empty", KiroOptions{}, nil},
+		{"resume latest", KiroOptions{SessionMode: "resume"}, []string{"--resume"}},
+		{"resume by id", KiroOptions{SessionMode: "resume", ResumeSessionID: "abc-123"}, []string{"--resume-id", "abc-123"}},
+		{"trust all tools", KiroOptions{TrustAllTools: true}, []string{"--trust-all-tools"}},
+		{"agent", KiroOptions{Agent: "my-agent"}, []string{"--agent", "my-agent"}},
+		{"model", KiroOptions{Model: "claude-sonnet-4.6"}, []string{"--model", "claude-sonnet-4.6"}},
+		{"combined", KiroOptions{SessionMode: "resume", ResumeSessionID: "x", TrustAllTools: true, Agent: "a"}, []string{"--resume-id", "x", "--agent", "a", "--trust-all-tools"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.opts.ToArgs()
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if strings.Join(got, " ") != strings.Join(tt.want, " ") {
+				t.Errorf("ToArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKiroOptions_MarshalUnmarshal(t *testing.T) {
+	opts := &KiroOptions{
+		SessionMode:     "resume",
+		ResumeSessionID: "test-uuid-123",
+		Agent:           "kiro_planner",
+		TrustAllTools:   true,
+	}
+
+	data, err := MarshalToolOptions(opts)
+	if err != nil {
+		t.Fatalf("MarshalToolOptions: %v", err)
+	}
+
+	got, err := UnmarshalKiroOptions(data)
+	if err != nil {
+		t.Fatalf("UnmarshalKiroOptions: %v", err)
+	}
+	if got == nil {
+		t.Fatal("UnmarshalKiroOptions returned nil")
+	}
+	if got.SessionMode != opts.SessionMode {
+		t.Errorf("SessionMode = %q, want %q", got.SessionMode, opts.SessionMode)
+	}
+	if got.ResumeSessionID != opts.ResumeSessionID {
+		t.Errorf("ResumeSessionID = %q, want %q", got.ResumeSessionID, opts.ResumeSessionID)
+	}
+	if got.Agent != opts.Agent {
+		t.Errorf("Agent = %q, want %q", got.Agent, opts.Agent)
+	}
+	if got.TrustAllTools != opts.TrustAllTools {
+		t.Errorf("TrustAllTools = %v, want %v", got.TrustAllTools, opts.TrustAllTools)
+	}
+}
+
+func TestKiroOptions_UnmarshalWrongTool(t *testing.T) {
+	data := json.RawMessage(`{"tool":"claude","options":{}}`)
+	got, err := UnmarshalKiroOptions(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for wrong tool, got %+v", got)
+	}
+}
+
+func TestBuildKiroCommand(t *testing.T) {
+	inst := NewInstanceWithTool("test-kiro", "/tmp/project", "kiro")
+
+	cmd := inst.buildKiroCommand("kiro-cli")
+	if !strings.Contains(cmd, "kiro-cli chat") {
+		t.Errorf("buildKiroCommand should contain 'kiro-cli chat', got %q", cmd)
+	}
+}
+
+func TestBuildKiroCommand_WithSessionID(t *testing.T) {
+	inst := NewInstanceWithTool("test-kiro", "/tmp/project", "kiro")
+	inst.KiroSessionID = "abc-def-123"
+
+	cmd := inst.buildKiroCommand("kiro-cli")
+	if !strings.Contains(cmd, "--resume-id abc-def-123") {
+		t.Errorf("buildKiroCommand should contain '--resume-id abc-def-123', got %q", cmd)
+	}
+}
+
+func TestBuildKiroCommand_WithOptions(t *testing.T) {
+	inst := NewInstanceWithTool("test-kiro", "/tmp/project", "kiro")
+	opts := &KiroOptions{
+		TrustAllTools: true,
+		Agent:         "my-agent",
+		Model:         "claude-opus-4.7",
+	}
+	data, _ := MarshalToolOptions(opts)
+	inst.ToolOptionsJSON = data
+
+	cmd := inst.buildKiroCommand("kiro-cli")
+	if !strings.Contains(cmd, "--trust-all-tools") {
+		t.Errorf("expected --trust-all-tools in %q", cmd)
+	}
+	if !strings.Contains(cmd, "--agent my-agent") {
+		t.Errorf("expected --agent my-agent in %q", cmd)
+	}
+	if !strings.Contains(cmd, "--model claude-opus-4.7") {
+		t.Errorf("expected --model claude-opus-4.7 in %q", cmd)
+	}
+}

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -136,7 +136,7 @@ func GetProjectSkillsDir(tool string) (string, bool) {
 	switch {
 	case IsClaudeCompatible(tool):
 		return projectClaudeSkillsDir, true
-	case tool == "gemini" || tool == "codex" || tool == "pi":
+	case tool == "gemini" || tool == "codex" || tool == "pi" || tool == "kiro":
 		return projectAgentsSkillsDir, true
 	default:
 		return "", false

--- a/internal/session/tooloptions.go
+++ b/internal/session/tooloptions.go
@@ -501,3 +501,68 @@ func UnmarshalClaudeOptions(data json.RawMessage) (*ClaudeOptions, error) {
 
 	return &opts, nil
 }
+
+// KiroOptions holds launch options for Kiro CLI sessions
+type KiroOptions struct {
+	SessionMode     string `json:"session_mode,omitempty"`      // "new", "resume"
+	ResumeSessionID string `json:"resume_session_id,omitempty"` // --resume-id <UUID>
+	Agent           string `json:"agent,omitempty"`             // --agent <name>
+	Model           string `json:"model,omitempty"`             // --model <id>
+	TrustAllTools   bool   `json:"trust_all_tools,omitempty"`   // --trust-all-tools
+}
+
+// ToolName returns "kiro"
+func (o *KiroOptions) ToolName() string {
+	return "kiro"
+}
+
+// ToArgs returns command-line arguments based on options
+func (o *KiroOptions) ToArgs() []string {
+	var args []string
+	switch o.SessionMode {
+	case "resume":
+		if o.ResumeSessionID != "" {
+			args = append(args, "--resume-id", o.ResumeSessionID)
+		} else {
+			args = append(args, "--resume")
+		}
+	}
+	if o.Agent != "" {
+		args = append(args, "--agent", o.Agent)
+	}
+	if o.Model != "" {
+		args = append(args, "--model", o.Model)
+	}
+	if o.TrustAllTools {
+		args = append(args, "--trust-all-tools")
+	}
+	return args
+}
+
+// NewKiroOptions creates KiroOptions with defaults
+func NewKiroOptions() *KiroOptions {
+	return &KiroOptions{}
+}
+
+// UnmarshalKiroOptions deserializes KiroOptions from JSON wrapper
+func UnmarshalKiroOptions(data json.RawMessage) (*KiroOptions, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, err
+	}
+
+	if wrapper.Tool != "kiro" {
+		return nil, nil
+	}
+
+	var opts KiroOptions
+	if err := json.Unmarshal(wrapper.Options, &opts); err != nil {
+		return nil, err
+	}
+
+	return &opts, nil
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -108,6 +108,9 @@ type UserConfig struct {
 	// Hermes defines Hermes Agent CLI integration settings
 	Hermes HermesSettings `toml:"hermes"`
 
+	// Kiro defines Kiro CLI integration settings
+	Kiro KiroSettings `toml:"kiro"`
+
 	// Worktree defines git worktree preferences
 	Worktree WorktreeSettings `toml:"worktree"`
 
@@ -1027,6 +1030,21 @@ type HermesSettings struct {
 	// YoloMode enables --yolo flag for Hermes sessions (auto-approve all tool calls).
 	// Default: false
 	YoloMode bool `toml:"yolo_mode"`
+}
+
+// KiroSettings defines Kiro CLI configuration.
+// Binary: `kiro-cli` from kiro.dev. Full-screen TUI agent.
+// Key flags: --resume-id <UUID>, --trust-all-tools, --agent <name>, --model <id>.
+type KiroSettings struct {
+	// Command is the Kiro CLI command to use.
+	// Default: "kiro-cli"
+	Command string `toml:"command"`
+	// TrustAllTools enables --trust-all-tools flag (skip all permission prompts).
+	// Default: false
+	TrustAllTools bool `toml:"trust_all_tools"`
+	// DefaultAgent is the agent to use by default (--agent flag).
+	// Default: "" (uses kiro_default)
+	DefaultAgent string `toml:"default_agent"`
 }
 
 // CrushSettings defines charmbracelet/crush CLI configuration (Issue #940).
@@ -2041,6 +2059,15 @@ func GetCodexCommand() string {
 		return strings.TrimSpace(userConfig.Codex.Command)
 	}
 	return "codex"
+}
+
+// GetKiroCommand returns the configured kiro-cli command or the default "kiro-cli".
+func GetKiroCommand() string {
+	userConfig, _ := LoadUserConfig()
+	if userConfig != nil && strings.TrimSpace(userConfig.Kiro.Command) != "" {
+		return strings.TrimSpace(userConfig.Kiro.Command)
+	}
+	return "kiro-cli"
 }
 
 func isClaudeCommand(command string) bool {

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2194,13 +2194,17 @@ func GetToolCommand(toolName string) string {
 		if config.Hermes.Command != "" {
 			return config.Hermes.Command
 		}
+	case "kiro":
+		if config.Kiro.Command != "" {
+			return config.Kiro.Command
+		}
 	}
 	return toolName
 }
 
 func isBuiltinToolName(toolName string) bool {
 	switch toolName {
-	case "claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi", "shell", "aider":
+	case "claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "kiro", "pi", "shell", "aider":
 		return true
 	default:
 		return false
@@ -2232,6 +2236,8 @@ func GetToolIcon(toolName string) string {
 		return "📝"
 	case "hermes":
 		return "☤"
+	case "kiro":
+		return "🦊"
 	case "pi":
 		return "π"
 	case "shell":

--- a/internal/tmux/detector.go
+++ b/internal/tmux/detector.go
@@ -81,6 +81,32 @@ func (d *PromptDetector) HasPrompt(content string) bool {
 		// with a status bar (model · path · branch · usage) below it.
 		return d.hasCodexPromptMarker(content)
 
+	case "kiro":
+		// Kiro CLI uses a full-screen TUI. Primary status detection is via
+		// filesystem signals (lock file + JSONL mtime) in instance.go.
+		// This prompt detector is a fallback for tmux content-based detection.
+		//
+		// The TUI always shows an input area at the bottom. The key distinction:
+		//   Busy:  "type to queue a message" / "Kiro is working" / "esc to cancel"
+		//   Idle:  "Enter to send"
+		//   Permission: "requires approval" / "Yes, single permission"
+		lower := strings.ToLower(content)
+		// Busy: agent is streaming, executing tools, or running subagents
+		if strings.Contains(content, "type to queue") ||
+			strings.Contains(content, "Kiro is working") ||
+			strings.Contains(lower, "esc to cancel") ||
+			strings.Contains(lower, "esc to interrupt") ||
+			strings.Contains(lower, "ctrl+c to interrupt") {
+			return false
+		}
+		// Permission approval prompt (waiting state)
+		if strings.Contains(content, "requires approval") ||
+			strings.Contains(content, "Yes, single permission") {
+			return true
+		}
+		// Idle: input area shows "Enter to send" (only when agent is NOT working)
+		return strings.Contains(content, "Enter to send")
+
 	default:
 		// Generic shell - check for common prompts
 		return d.hasShellPrompt(content)

--- a/internal/tmux/detector.go
+++ b/internal/tmux/detector.go
@@ -83,13 +83,13 @@ func (d *PromptDetector) HasPrompt(content string) bool {
 
 	case "kiro":
 		lower := strings.ToLower(content)
-		if strings.Contains(content, "type to queue") ||
-			strings.Contains(content, "Kiro is working") ||
+		if strings.Contains(lower, "type to queue") ||
+			strings.Contains(lower, "kiro is working") ||
 			strings.Contains(lower, "esc to cancel") {
 			return false
 		}
-		return strings.Contains(content, "requires approval") ||
-			strings.Contains(content, "Enter to send")
+		return strings.Contains(lower, "requires approval") ||
+			strings.Contains(lower, "enter to send")
 
 	default:
 		// Generic shell - check for common prompts

--- a/internal/tmux/detector.go
+++ b/internal/tmux/detector.go
@@ -82,30 +82,14 @@ func (d *PromptDetector) HasPrompt(content string) bool {
 		return d.hasCodexPromptMarker(content)
 
 	case "kiro":
-		// Kiro CLI uses a full-screen TUI. Primary status detection is via
-		// filesystem signals (lock file + JSONL mtime) in instance.go.
-		// This prompt detector is a fallback for tmux content-based detection.
-		//
-		// The TUI always shows an input area at the bottom. The key distinction:
-		//   Busy:  "type to queue a message" / "Kiro is working" / "esc to cancel"
-		//   Idle:  "Enter to send"
-		//   Permission: "requires approval" / "Yes, single permission"
 		lower := strings.ToLower(content)
-		// Busy: agent is streaming, executing tools, or running subagents
 		if strings.Contains(content, "type to queue") ||
 			strings.Contains(content, "Kiro is working") ||
-			strings.Contains(lower, "esc to cancel") ||
-			strings.Contains(lower, "esc to interrupt") ||
-			strings.Contains(lower, "ctrl+c to interrupt") {
+			strings.Contains(lower, "esc to cancel") {
 			return false
 		}
-		// Permission approval prompt (waiting state)
-		if strings.Contains(content, "requires approval") ||
-			strings.Contains(content, "Yes, single permission") {
-			return true
-		}
-		// Idle: input area shows "Enter to send" (only when agent is NOT working)
-		return strings.Contains(content, "Enter to send")
+		return strings.Contains(content, "requires approval") ||
+			strings.Contains(content, "Enter to send")
 
 	default:
 		// Generic shell - check for common prompts

--- a/internal/tmux/kiro_test.go
+++ b/internal/tmux/kiro_test.go
@@ -80,7 +80,7 @@ func TestPromptDetector_Kiro(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := d.HasPrompt(tt.content); got != tt.want {
-				t.Fatalf("HasPrompt(%q) = %v, want %v", tt.name, got, tt.want)
+				t.Fatalf("HasPrompt(%q) = %v, want %v", tt.content, got, tt.want)
 			}
 		})
 	}

--- a/internal/tmux/kiro_test.go
+++ b/internal/tmux/kiro_test.go
@@ -1,0 +1,87 @@
+package tmux
+
+import "testing"
+
+func TestDetectToolFromCommand_Kiro(t *testing.T) {
+	tests := []struct {
+		command string
+		want    string
+	}{
+		{"kiro-cli", "kiro"},
+		{"kiro-cli chat", "kiro"},
+		{"kiro-cli chat --resume", "kiro"},
+		{"kiro-cli chat --trust-all-tools", "kiro"},
+		{"/home/user/.local/bin/kiro-cli chat --agent my-agent", "kiro"},
+		{"kiro-cli chat --resume-id abc123", "kiro"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			if got := detectToolFromCommand(tt.command); got != tt.want {
+				t.Fatalf("detectToolFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromCommand_Kiro_Negative(t *testing.T) {
+	tests := []struct {
+		command string
+		want    string
+	}{
+		{"claude", "claude"},
+		{"gemini", "gemini"},
+		{"bash", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			got := detectToolFromCommand(tt.command)
+			if got != tt.want {
+				t.Fatalf("detectToolFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromContent_Kiro(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"kiro cli mention", "Welcome to Kiro CLI v2.3.0", "kiro"},
+		{"kiro-cli in output", "Running kiro-cli chat session", "kiro"},
+		{"unrelated content", "hello world", "shell"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromContent(tt.content); got != tt.want {
+				t.Fatalf("detectToolFromContent(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPromptDetector_Kiro(t *testing.T) {
+	d := NewPromptDetector("kiro")
+
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"busy - esc to cancel", "Running tool...\nesc to cancel", false},
+		{"busy - type to queue", "Kiro · auto · ◔ 10%\nWorking · type to queue a message", false},
+		{"busy - working", "● Shell go build ./...\nWorking", false},
+		{"busy - ctrl+c", "Streaming response\nctrl+c to interrupt", false},
+		{"idle - enter to send", "Previous response\nEnter to send", true},
+		{"permission prompt", "subagent requires approval\n ❯ Yes, single permission\n   Trust, always allow", true},
+		{"busy with subagent - has queue text", "◔ Subagent researching\ntype to queue a message\nEnter to send", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := d.HasPrompt(tt.content); got != tt.want {
+				t.Fatalf("HasPrompt(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -122,6 +122,21 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 				`re:(?m)^\s*›\s`,
 			},
 		}
+	case "kiro":
+		return &RawPatterns{
+			BusyPatterns: []string{
+				"type to queue",
+				"esc to cancel",
+				"esc to interrupt",
+				"ctrl+c to interrupt",
+				"Kiro is working",
+			},
+			PromptPatterns: []string{
+				"Enter to send",
+				"requires approval",
+				"Yes, single permission",
+			},
+		}
 	case "shell":
 		return &RawPatterns{
 			PromptPatterns: []string{"$ ", "# ", "% "},

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3687,9 +3687,9 @@ func (s *Session) hasBusyIndicatorResolved(content string) bool {
 	// briefly disappears. If it was visible recently, stay busy.
 	if tracker.InGracePeriod() {
 		// Override grace period if a prompt pattern is explicitly present.
-		// This handles tools like kiro where a permission prompt replaces
-		// the busy indicator but the grace window hasn't expired yet.
-		if patterns != nil && len(patterns.PromptStrings) > 0 {
+		// This handles kiro where a permission prompt replaces the busy
+		// indicator but the grace window hasn't expired yet.
+		if tool == "kiro" && patterns != nil && len(patterns.PromptStrings) > 0 {
 			recentLines := lastNLines(content, 15)
 			recentContent := strings.Join(recentLines, "\n")
 			lowerRecent := strings.ToLower(recentContent)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -643,7 +643,7 @@ func detectToolFromCommand(command string) string {
 		return "cursor"
 	case strings.Contains(cmdLower, "hermes"):
 		return "hermes"
-	case strings.Contains(cmdLower, "kiro"):
+	case strings.Contains(cmdLower, "kiro-cli") || strings.Contains(cmdLower, " kiro ") || strings.HasPrefix(cmdLower, "kiro ") || cmdLower == "kiro":
 		return "kiro"
 	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
 		return "pi"

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -537,7 +537,7 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi"}
+var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "kiro", "pi"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"claude": {
@@ -586,6 +586,11 @@ var toolDetectionPatterns = map[string][]*regexp.Regexp{
 		regexp.MustCompile(`(?i)\bcursor\s+agent\b`),
 		regexp.MustCompile(`(?i)cursor\s+cli\b`),
 	},
+	"kiro": {
+		// Kiro CLI (AWS/Kiro agentic IDE terminal interface)
+		regexp.MustCompile(`(?i)\bkiro\s+cli\b`),
+		regexp.MustCompile(`(?i)\bkiro-cli\b`),
+	},
 }
 
 func detectToolFromCommand(command string) string {
@@ -614,6 +619,8 @@ func detectToolFromCommand(command string) string {
 			return "cursor"
 		case "hermes":
 			return "hermes"
+		case "kiro-cli", "kiro":
+			return "kiro"
 		case "pi":
 			return "pi"
 		}
@@ -636,6 +643,8 @@ func detectToolFromCommand(command string) string {
 		return "cursor"
 	case strings.Contains(cmdLower, "hermes"):
 		return "hermes"
+	case strings.Contains(cmdLower, "kiro"):
+		return "kiro"
 	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
 		return "pi"
 	default:
@@ -3677,6 +3686,22 @@ func (s *Session) hasBusyIndicatorResolved(content string) bool {
 	// No busy signal. Check grace period: between tool calls the spinner
 	// briefly disappears. If it was visible recently, stay busy.
 	if tracker.InGracePeriod() {
+		// Override grace period if a prompt pattern is explicitly present.
+		// This handles tools like kiro where a permission prompt replaces
+		// the busy indicator but the grace window hasn't expired yet.
+		if patterns != nil && len(patterns.PromptStrings) > 0 {
+			recentLines := lastNLines(content, 15)
+			recentContent := strings.Join(recentLines, "\n")
+			lowerRecent := strings.ToLower(recentContent)
+			for _, ps := range patterns.PromptStrings {
+				if strings.Contains(lowerRecent, strings.ToLower(ps)) {
+					statusLog.Debug("busy_grace_overridden_by_prompt",
+						slog.String("session", shortName),
+						slog.String("prompt_pattern", ps))
+					return false
+				}
+			}
+		}
 		statusLog.Debug("busy_spinner_grace", slog.String("session", shortName),
 			slog.Duration("since_busy", time.Since(tracker.lastBusyTime)))
 		return true

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5618,6 +5618,11 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			yolo := h.newDialog.GetCodexYoloMode()
 			codexOpts := &session.CodexOptions{YoloMode: &yolo}
 			toolOptionsJSON, _ = session.MarshalToolOptions(codexOpts)
+		} else if command == "kiro" {
+			if h.newDialog.GetKiroTrustAllTools() {
+				kiroOpts := &session.KiroOptions{TrustAllTools: true}
+				toolOptionsJSON, _ = session.MarshalToolOptions(kiroOpts)
+			}
 		}
 
 		parentSessionID := h.newDialog.GetParentSessionID()
@@ -8785,6 +8790,9 @@ func createSessionTool(command string) (string, string) {
 		command = "cursor agent"
 	case "hermes":
 		tool = "hermes"
+	case "kiro":
+		tool = "kiro"
+		command = "kiro-cli"
 	default:
 		if toolDef := session.GetToolDef(command); toolDef != nil {
 			tool = command
@@ -12657,11 +12665,21 @@ func (h *Home) renderLaunchingState(inst *session.Instance, width int, startTime
 			toolDesc = "Starting Cursor Agent..."
 		}
 	default:
-		toolName = "Shell"
-		if isResuming {
-			toolDesc = "Resuming shell session..."
+		// Check for kiro before falling through to shell
+		if inst.Tool == "kiro" {
+			toolName = "Kiro"
+			if isResuming {
+				toolDesc = "Resuming Kiro session..."
+			} else {
+				toolDesc = "Starting Kiro..."
+			}
 		} else {
-			toolDesc = "Launching shell session..."
+			toolName = "Shell"
+			if isResuming {
+				toolDesc = "Resuming shell session..."
+			} else {
+				toolDesc = "Launching shell session..."
+			}
 		}
 	}
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12665,7 +12665,6 @@ func (h *Home) renderLaunchingState(inst *session.Instance, width int, startTime
 			toolDesc = "Starting Cursor Agent..."
 		}
 	default:
-		// Check for kiro before falling through to shell
 		if inst.Tool == "kiro" {
 			toolName = "Kiro"
 			if isResuming {

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -162,6 +162,7 @@ type NewDialog struct {
 	claudeOptions         *ClaudeOptionsPanel // Claude-specific options (concrete for value extraction).
 	geminiOptions         *YoloOptionsPanel   // Gemini YOLO panel (concrete for value extraction).
 	codexOptions          *YoloOptionsPanel   // Codex YOLO panel (concrete for value extraction).
+	kiroOptions           *YoloOptionsPanel   // Kiro trust-all-tools panel.
 	toolOptions           OptionsPanel        // Currently active tool options panel (nil if none).
 	focusTargets          []focusTarget       // Ordered list of active focusable elements.
 	focusIndex            int                 // Index into focusTargets.
@@ -246,7 +247,7 @@ func displayCommandPreset(cmd string) string {
 // buildPresetCommands returns the list of commands for the picker,
 // including any custom tools from config.toml.
 func buildPresetCommands() []string {
-	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
+	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "kiro"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}
@@ -328,6 +329,7 @@ func NewNewDialog() *NewDialog {
 		claudeOptions:   NewClaudeOptionsPanel(),
 		geminiOptions:   NewYoloOptionsPanel("Gemini", "YOLO mode - auto-approve all"),
 		codexOptions:    NewYoloOptionsPanel("Codex", "YOLO mode - bypass approvals and sandbox"),
+		kiroOptions:     NewYoloOptionsPanel("Kiro", "Trust all tools - skip permission prompts"),
 		focusIndex:      0,
 		visible:         false,
 		presetCommands:  buildPresetCommands(),
@@ -925,6 +927,11 @@ func (d *NewDialog) GetCodexYoloMode() bool {
 	return d.codexOptions.GetYoloMode()
 }
 
+// GetKiroTrustAllTools returns whether Kiro trust-all-tools mode is enabled.
+func (d *NewDialog) GetKiroTrustAllTools() bool {
+	return d.kiroOptions.GetYoloMode()
+}
+
 // IsSandboxEnabled returns whether Docker sandbox mode is enabled.
 func (d *NewDialog) IsSandboxEnabled() bool {
 	return d.sandboxEnabled
@@ -1213,6 +1220,8 @@ func (d *NewDialog) updateToolOptions() {
 		d.toolOptions = d.geminiOptions
 	case cmd == "codex":
 		d.toolOptions = d.codexOptions
+	case cmd == "kiro":
+		d.toolOptions = d.kiroOptions
 	default:
 		d.toolOptions = nil
 	}
@@ -1228,6 +1237,7 @@ func (d *NewDialog) updateFocus() {
 	d.claudeOptions.Blur()
 	d.geminiOptions.Blur()
 	d.codexOptions.Blur()
+	d.kiroOptions.Blur()
 
 	// Reset dropdown and soft-select state when focus changes.
 	d.pathSoftSelected = false

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -229,6 +229,7 @@ type dialogSnapshot struct {
 	claudeOptions    *session.ClaudeOptions
 	geminiYolo       bool
 	codexYolo        bool
+	kiroTrustAll     bool
 	multiRepoEnabled bool
 	multiRepoPaths   []string
 	conductorCursor  int
@@ -417,9 +418,11 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	// Initialize tool options from global config.
 	d.geminiOptions.SetDefaults(false)
 	d.codexOptions.SetDefaults(false)
+	d.kiroOptions.SetDefaults(false)
 	if userConfig, err := session.LoadUserConfig(); err == nil && userConfig != nil {
 		d.geminiOptions.SetDefaults(userConfig.Gemini.YoloMode)
 		d.codexOptions.SetDefaults(userConfig.Codex.YoloMode)
+		d.kiroOptions.SetDefaults(userConfig.Kiro.TrustAllTools)
 		d.claudeOptions.SetDefaults(userConfig)
 		d.sandboxEnabled = userConfig.Docker.DefaultEnabled
 		d.worktreeEnabled = userConfig.Worktree.DefaultEnabled
@@ -617,6 +620,7 @@ func (d *NewDialog) saveSnapshot() *dialogSnapshot {
 		claudeOptions:    claudeOpts,
 		geminiYolo:       d.geminiOptions.GetYoloMode(),
 		codexYolo:        d.codexOptions.GetYoloMode(),
+		kiroTrustAll:     d.kiroOptions.GetYoloMode(),
 		multiRepoEnabled: d.multiRepoEnabled,
 		multiRepoPaths:   append([]string{}, d.multiRepoPaths...),
 		conductorCursor:  d.conductorCursor,
@@ -639,6 +643,7 @@ func (d *NewDialog) restoreSnapshot(s *dialogSnapshot) {
 	}
 	d.geminiOptions.SetDefaults(s.geminiYolo)
 	d.codexOptions.SetDefaults(s.codexYolo)
+	d.kiroOptions.SetDefaults(s.kiroTrustAll)
 	d.multiRepoEnabled = s.multiRepoEnabled
 	d.multiRepoPaths = append([]string{}, s.multiRepoPaths...)
 	d.multiRepoPathCursor = 0

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -610,6 +610,8 @@ func ToolIcon(tool string) string {
 		return "📝"
 	case "hermes":
 		return "☤"
+	case "kiro":
+		return "🦊"
 	case "pi":
 		return IconPi
 	case "shell":
@@ -637,6 +639,8 @@ func ToolColor(tool string) lipgloss.Color {
 		return ColorAccent // Blue for Cursor
 	case "hermes":
 		return ColorYellow // Gold for Hermes Agent
+	case "kiro":
+		return ColorGreen // Green for Kiro/AWS
 	case "pi":
 		return ColorAccent
 	case "aider":

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -523,6 +523,7 @@ func initStyles() {
 		"codex":    lipgloss.NewStyle().Foreground(ColorCyan),
 		"copilot":  lipgloss.NewStyle().Foreground(ColorAccent),
 		"hermes":   lipgloss.NewStyle().Foreground(ColorYellow),
+		"kiro":     lipgloss.NewStyle().Foreground(ColorGreen),
 		"pi":       lipgloss.NewStyle().Foreground(ColorAccent),
 		"aider":    lipgloss.NewStyle().Foreground(ColorRed),
 		"cursor":   lipgloss.NewStyle().Foreground(ColorAccent),

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -523,7 +523,7 @@ func initStyles() {
 		"codex":    lipgloss.NewStyle().Foreground(ColorCyan),
 		"copilot":  lipgloss.NewStyle().Foreground(ColorAccent),
 		"hermes":   lipgloss.NewStyle().Foreground(ColorYellow),
-		"kiro":     lipgloss.NewStyle().Foreground(ColorGreen),
+		"kiro":     lipgloss.NewStyle().Foreground(ColorPurple),
 		"pi":       lipgloss.NewStyle().Foreground(ColorAccent),
 		"aider":    lipgloss.NewStyle().Foreground(ColorRed),
 		"cursor":   lipgloss.NewStyle().Foreground(ColorAccent),
@@ -641,7 +641,7 @@ func ToolColor(tool string) lipgloss.Color {
 	case "hermes":
 		return ColorYellow // Gold for Hermes Agent
 	case "kiro":
-		return ColorGreen // Green for Kiro/AWS
+		return ColorPurple // Purple for Kiro/AWS
 	case "pi":
 		return ColorAccent
 	case "aider":

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -60,6 +60,8 @@ RUN npm install -g @openai/codex@0
 RUN npm install -g @google/gemini-cli@0
 
 # ── Kiro CLI (AWS) ──────────────────────────────────────────────────
+# Pin to 2.x series; update periodically.
+# NOTE: kiro's installer does not support version pinning — it always pulls latest.
 RUN curl -fsSL https://cli.kiro.dev/install | bash
 
 # Pre-create credential directories for auth volume mounts.

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -59,6 +59,9 @@ RUN npm install -g @openai/codex@0
 # Pin major version; update periodically.
 RUN npm install -g @google/gemini-cli@0
 
+# ── Kiro CLI (AWS) ──────────────────────────────────────────────────
+RUN curl -fsSL https://cli.kiro.dev/install | bash
+
 # Pre-create credential directories for auth volume mounts.
 RUN mkdir -p /root/.claude \
     /root/.config/opencode \
@@ -66,6 +69,9 @@ RUN mkdir -p /root/.claude \
     /root/.local/state/opencode \
     /root/.codex \
     /root/.gemini \
+    /root/.kiro \
+    /root/.local/share/kiro-cli \
+    /root/.aws \
     /root/.ssh
 
 # Make /root traversable by the non-root runtime user (--user uid:gid).


### PR DESCRIPTION
## Summary

Add [Kiro CLI](https://kiro.dev/cli/) (`kiro-cli`) as a supported tool in agent-deck. Kiro is an agentic AI coding assistant from AWS with a rich terminal TUI, MCP support, custom agents, session persistence, and lifecycle hooks.

## What this PR delivers

- `agent-deck add . -c kiro` launches a kiro-cli session
- Status detection (running/waiting/idle) via TUI content patterns + filesystem signals
- Permission prompt detection (waiting/yellow when approval needed)
- Session resume on restart via `--resume` flag
- MCP integration: reads `.kiro/settings/mcp.json` (workspace + global)
- Conductor support: `agent-deck conductor setup <name> --agent kiro`
- TUI: icon (🦊), purple color, preset in new session dialog, trust-all-tools checkbox
- Docker sandbox: kiro-cli in image, auth shared via `~/.kiro` + `~/.local/share/kiro-cli` + `~/.aws/sso`
- Skills directory mapping (`.agents/`)
- `[kiro]` config section in `config.toml`

## Files changed (17 files, +684/-13)

| File | Changes |
|------|---------|
| `cmd/agent-deck/main.go` | Add kiro to `detectTool()` with token-aware matching |
| `internal/docker/config.go` | Add `~/.kiro`, `~/.local/share/kiro-cli`, `~/.aws/sso` to sandbox mounts |
| `internal/session/conductor.go` | Add `ConductorAgentKiro` spec |
| `internal/session/instance.go` | `buildKiroCommand`, `detectKiroSessionFromDisk`, `updateKiroFilesystemStatus`, session fields, hook fast path |
| `internal/session/kiro_mcp.go` | `GetKiroMCPInfo` — reads workspace + global mcp.json |
| `internal/session/kiro_test.go` | Options, command building, marshal/unmarshal tests |
| `internal/session/skills_catalog.go` | Add kiro to `GetProjectSkillsDir` |
| `internal/session/tooloptions.go` | `KiroOptions` struct |
| `internal/session/userconfig.go` | `KiroSettings`, `GetKiroCommand`, register in built-in helpers |
| `internal/tmux/detector.go` | `HasPrompt` kiro case (fallback) |
| `internal/tmux/kiro_test.go` | Detection and prompt tests |
| `internal/tmux/patterns.go` | `DefaultRawPatterns("kiro")` busy/prompt patterns |
| `internal/tmux/tmux.go` | Tool detection patterns, grace period override (kiro-scoped) |
| `internal/ui/home.go` | `createSessionTool`, launch animation, trust-all-tools wiring |
| `internal/ui/newdialog.go` | Preset list, YoloOptionsPanel, snapshot lifecycle |
| `internal/ui/styles.go` | Icon (🦊), color (purple), ToolStyleCache |
| `sandbox/Dockerfile` | Install kiro-cli, pre-create credential directories |

## Status detection strategy

Kiro uses a full-screen TUI. Detection uses two layers:

1. **Filesystem signals** (hook fast path): lock file PID liveness + JSONL mtime → running/waiting/dead
2. **TUI content patterns** (fallback): `type to queue` / `Kiro is working` = busy; `requires approval` = waiting; `Enter to send` = idle

Grace period override is scoped to kiro only — when a permission prompt appears during the busy grace window, it correctly transitions to waiting.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt` — clean
- [x] `go test ./internal/tmux/ -run Kiro` — all pass
- [x] `go test ./internal/session/ -run Kiro` — all pass
- [x] Manual: session starts, shows 🦊 icon, correct status transitions
- [x] Manual: permission prompts show waiting (yellow)
- [x] Manual: trust-all-tools checkbox works
- [x] Manual: restart resumes conversation via `--resume`
- [x] Manual: Docker sandbox launches with auth

## Does not break

- All existing tool detection tests pass unchanged
- Grace period override scoped to kiro only (no effect on other tools)
- Docker mounts are additive (only `~/.aws/sso`, not full `~/.aws`)
- Conductor/TUI/styles additions are mechanical and isolated
- No modifications to existing tool code paths

## Not included (follow-up)

- Cost tracking (kiro session JSON has `metering_usage` data — needs wiring to cost event sink)
- Stop hook for real-time status (requires user agent config setup)
- Fork support (not feasible — TUI-only slash command)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kiro CLI as a selectable tool for creating and managing agent sessions
  * Integrated Kiro-specific configuration options (agent selection, trust-all-tools setting, command override)
  * Enabled Kiro session detection and automatic resumption capabilities
  * Added comprehensive Kiro MCP server integration support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->