### PR TITLE
fix(tmux): route iTerm badge updates through attach process so renames take effect (closes #1114)

### DIFF
--- a/cmd/agent-deck/hook_name_sync.go
+++ b/cmd/agent-deck/hook_name_sync.go
@@ -123,11 +123,21 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 		_ = storage.SaveWithGroups(instances, groupTree)
 		_ = storage.Close()
 
-		// If the user is attached to this session in iTerm2, push the
-		// badge through tmux DCS passthrough — agent-deck's own attach
-		// emits only fire on attach/detach, not on mid-attach renames.
-		// Silent no-op outside iTerm2, when the feature is disabled,
-		// or when this hook subprocess has no controlling tty.
+		// #1114: signal the attached agent-deck process to re-emit the
+		// iTerm2 badge for the new title. This hook subprocess is
+		// spawned detached (setsid) by Claude Code, so it has no
+		// controlling tty — the previous EmitITermBadgeViaTty path
+		// silently no-op'd because /dev/tty returned ENXIO. Writing a
+		// per-tmux-session file succeeds without a tty; the attach
+		// process (which owns the outer iTerm2 tty via os.Stdout)
+		// picks it up via fsnotify and emits the OSC.
+		//
+		// Also keep the via-tty emit for the rare case where the hook
+		// does happen to have a tty (e.g. a future Claude that doesn't
+		// setsid its hooks) — it's a silent no-op when it doesn't.
+		if tmuxSess := target.GetTmuxSession(); tmuxSess != nil && tmuxSess.Name != "" {
+			_ = tmux.WriteBadgeUpdate(tmuxSess.Name, name)
+		}
 		tmux.EmitITermBadgeViaTty(name, session.GetTerminalSettings().GetITermBadge())
 		return
 	}

--- a/internal/tmux/badge_update.go
+++ b/internal/tmux/badge_update.go
@@ -1,0 +1,196 @@
+//go:build !windows
+
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Issue #1114: Badge update signal channel from hook to attach.
+//
+// Background
+// ----------
+// `EmitITermBadgeViaTty` opens /dev/tty and writes a tmux DCS-wrapped OSC
+// 1337 SetBadgeFormat sequence. That works when the caller has a
+// controlling terminal — e.g. the agent-deck process itself during
+// Attach. It does NOT work when the caller is a Claude Code hook
+// subprocess: Claude spawns its hooks detached via setsid (no
+// controlling tty), so /dev/tty returns ENXIO and the OSC is dropped
+// silently.
+//
+// Result on main: after Claude /rename or `claude --name X` mid-attach,
+// the DB title updates (#572 path) but the iTerm2 badge stays at the
+// attach-time value.
+//
+// Fix shape
+// ---------
+// File writes succeed regardless of controlling-terminal state. So:
+//
+//   - Hook side  → WriteBadgeUpdate(tmuxSessionName, title)
+//     drops a per-session file under ~/.agent-deck/badge-updates/.
+//
+//   - Attach side → WatchBadgeUpdates(ctx, tmuxSessionName, w, configEnabled, ready)
+//     watches the same directory via fsnotify (already a project dep
+//     for ~/.agent-deck/events/), and when the file for THIS session
+//     changes, reads the new title and emits the OSC through `w`. In
+//     production `w` is `os.Stdout`, which the attach process owns;
+//     the outer iTerm2 sees the OSC directly.
+//
+// Why not Option B (tmux env var)
+// -------------------------------
+// `tmux set-environment` requires the tmux server to accept the command
+// and the attach process to poll or subscribe. Polling has latency
+// (visible badge lag) and subscribing requires a control-mode socket
+// that we'd then have to multiplex. The file-signal approach reuses the
+// same fsnotify machinery as the existing status event channel — zero
+// new dependencies, same operational shape for ops.
+
+// badgeUpdatesDirEnv lets tests redirect the signal directory away from
+// the real ~/.agent-deck/badge-updates path so parallel runs do not
+// collide. The env var is intentionally undocumented in user-facing
+// config — it exists for the test harness only.
+const badgeUpdatesDirEnv = "AGENTDECK_BADGE_UPDATES_DIR"
+
+// BadgeUpdatesDir returns the directory where rename-hook signals live.
+// Mirrors GetEventsDir's shape (also under ~/.agent-deck/) so an ops
+// engineer staring at the directory tree sees one consistent pattern.
+func BadgeUpdatesDir() string {
+	if v := strings.TrimSpace(os.Getenv(badgeUpdatesDirEnv)); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".agent-deck", "badge-updates")
+	}
+	return filepath.Join(home, ".agent-deck", "badge-updates")
+}
+
+// WriteBadgeUpdate atomically writes title under tmuxSessionName so the
+// attach-side watcher can pick it up. Called by the Claude rename hook
+// (which has no controlling tty) instead of the doomed
+// EmitITermBadgeViaTty path.
+//
+// Atomic via tmp + rename — same idiom as WriteStatusEvent — so the
+// fsnotify CREATE/WRITE the watcher sees never points at a partial file.
+// tmuxSessionName is used verbatim as the filename; tmux session names
+// are constrained enough (no slashes) that the path stays single-segment.
+func WriteBadgeUpdate(tmuxSessionName, title string) error {
+	if tmuxSessionName == "" {
+		return fmt.Errorf("badge update: empty tmux session name")
+	}
+	dir := BadgeUpdatesDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("badge update: mkdir %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, tmuxSessionName)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(title), 0o644); err != nil {
+		return fmt.Errorf("badge update: write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("badge update: rename: %w", err)
+	}
+	return nil
+}
+
+// WatchBadgeUpdates blocks until ctx is cancelled. While running, it
+// emits an iTerm2 SetBadgeFormat OSC to w every time the badge-update
+// file for tmuxSessionName changes. The same two gates as
+// emitITermBadge apply (iTerm2 detection + configEnabled), so the
+// watcher cannot bypass the user's opt-out.
+//
+// ready, if non-nil, is closed once the fsnotify watch is registered.
+// Callers that race a Write against the watcher's startup (i.e. tests)
+// must wait on ready before writing — fsnotify drops events that fire
+// before Add() returns.
+//
+// Called from Attach() in its own goroutine; the ctx cancel that runs
+// on detach is what stops it.
+func WatchBadgeUpdates(ctx context.Context, tmuxSessionName string, w io.Writer, configEnabled bool, ready chan<- struct{}) {
+	if tmuxSessionName == "" {
+		if ready != nil {
+			close(ready)
+		}
+		return
+	}
+	dir := BadgeUpdatesDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		if ready != nil {
+			close(ready)
+		}
+		return
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		if ready != nil {
+			close(ready)
+		}
+		return
+	}
+	defer watcher.Close()
+
+	if err := watcher.Add(dir); err != nil {
+		if ready != nil {
+			close(ready)
+		}
+		return
+	}
+
+	// Catch-up: if the hook fired before the watcher registered, we'd
+	// miss the event. Read the file once at startup so a rename that
+	// completed during agent-deck's attach setup still updates the
+	// badge. No-op when the file does not exist.
+	emitFromFile(filepath.Join(dir, tmuxSessionName), w, configEnabled)
+
+	if ready != nil {
+		close(ready)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			if ev.Op&(fsnotify.Create|fsnotify.Write) == 0 {
+				continue
+			}
+			// Filter strictly on filename — concurrent attaches in the
+			// same iTerm2 window must not steal each other's badges.
+			if filepath.Base(ev.Name) != tmuxSessionName {
+				continue
+			}
+			emitFromFile(ev.Name, w, configEnabled)
+		case _, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			// fsnotify errors are non-fatal here; the next event will
+			// retry. We deliberately do NOT log to stdout because that's
+			// the iTerm2 tty in production — a stray log line would
+			// corrupt the user's display.
+		}
+	}
+}
+
+// emitFromFile reads the badge title from path and writes the OSC to w,
+// gated on the same iTerm2-active + configEnabled rules as the
+// on-attach emitITermBadge. Missing file is a silent no-op (the user
+// may have detached / cleaned up between the event and the read).
+func emitFromFile(path string, w io.Writer, configEnabled bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	emitITermBadge(w, string(data), configEnabled)
+}

--- a/internal/tmux/issue1114_badge_rename_test.go
+++ b/internal/tmux/issue1114_badge_rename_test.go
@@ -1,0 +1,303 @@
+//go:build !windows
+
+package tmux
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #1114 — iTerm2 badge stays stale after Claude /rename or
+// `claude --name`. Root cause: the Claude rename hook subprocess is
+// spawned detached (setsid) and has NO controlling tty, so the original
+// `EmitITermBadgeViaTty` silently no-ops (open /dev/tty returns ENXIO).
+//
+// Fix design (Option A): the hook (which CAN write files even without a
+// tty) writes the new badge title to ~/.agent-deck/badge-updates/<tmux>.
+// The agent-deck Attach process — which owns the outer iTerm2 tty via
+// os.Stdout — watches the directory and re-emits the OSC when the file
+// changes.
+//
+// These tests exercise the file-signal contract directly so the bug
+// stays fixed without needing a real Claude subprocess in CI.
+
+// lockedWriter serializes writes so the asserting goroutine and the
+// watcher goroutine don't race on the underlying buffer.
+type lockedWriter struct {
+	mu  sync.Mutex
+	buf *bytes.Buffer
+}
+
+func (w *lockedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *lockedWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+func newLockedWriter() *lockedWriter {
+	return &lockedWriter{buf: &bytes.Buffer{}}
+}
+
+// useTestBadgeDir redirects BadgeUpdatesDir() to a per-test temp path so
+// concurrent test runs don't fight over ~/.agent-deck/badge-updates.
+func useTestBadgeDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("AGENTDECK_BADGE_UPDATES_DIR", dir)
+	return dir
+}
+
+// waitForOSC blocks until w contains an OSC SetBadgeFormat for title, or
+// the deadline expires.
+func waitForOSC(t *testing.T, w *lockedWriter, title string, timeout time.Duration) {
+	t.Helper()
+	want := formatITermBadgeOSC(title)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if strings.Contains(w.String(), want) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("waited %v for badge OSC for %q; writer contained: %q", timeout, title, w.String())
+}
+
+// TestIssue1114_WriteBadgeUpdate_AtomicFileWrite is the bottom of the
+// stack: the hook subprocess (which has no tty) must be able to drop a
+// signal that the attach process will pick up. Even when /dev/tty is
+// unavailable, file writes work.
+func TestIssue1114_WriteBadgeUpdate_AtomicFileWrite(t *testing.T) {
+	dir := useTestBadgeDir(t)
+
+	require.NoError(t, WriteBadgeUpdate("ad-rename-fixture", "session-renamed"))
+
+	got, err := os.ReadFile(filepath.Join(dir, "ad-rename-fixture"))
+	require.NoError(t, err)
+	require.Equal(t, "session-renamed", string(got),
+		"WriteBadgeUpdate must persist the new title verbatim under the tmux-session-name key")
+}
+
+// TestIssue1114_AttachWatcher_EmitsOSCOnFileChange is the happy path:
+// the attach process's watcher picks up a file written by the hook side
+// and writes the iTerm2 OSC to the writer it was handed (os.Stdout in
+// production, a buffer in this test). This is the structural inverse of
+// the pre-fix bug where EmitITermBadgeViaTty silently dropped the OSC.
+func TestIssue1114_AttachWatcher_EmitsOSCOnFileChange(t *testing.T) {
+	useTestBadgeDir(t)
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("ITERM_SESSION_ID", "")
+	t.Setenv("LC_TERMINAL", "")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	w := newLockedWriter()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		WatchBadgeUpdates(ctx, "ad-rename-fixture", w, true, ready)
+	}()
+
+	// Wait for the watcher to register its fsnotify subscription before
+	// writing — fsnotify drops events from before Add() returns.
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher never signaled ready")
+	}
+
+	require.NoError(t, WriteBadgeUpdate("ad-rename-fixture", "fresh-title"))
+	waitForOSC(t, w, "fresh-title", 3*time.Second)
+
+	// And a second rename mid-attach must also propagate — the watcher
+	// keeps running across multiple updates, not a one-shot.
+	require.NoError(t, WriteBadgeUpdate("ad-rename-fixture", "fresh-title-2"))
+	waitForOSC(t, w, "fresh-title-2", 3*time.Second)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not exit after ctx cancel")
+	}
+}
+
+// TestIssue1114_Watcher_IgnoresOtherSessions is the boundary case: a
+// concurrent attach to session "other" must not steal session "mine"'s
+// badge update. The filename-based filter is the only thing standing
+// between two attached agent-deck users in the same iTerm2 window.
+func TestIssue1114_Watcher_IgnoresOtherSessions(t *testing.T) {
+	useTestBadgeDir(t)
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("ITERM_SESSION_ID", "")
+	t.Setenv("LC_TERMINAL", "")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	w := newLockedWriter()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		WatchBadgeUpdates(ctx, "session-mine", w, true, ready)
+	}()
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher never signaled ready")
+	}
+
+	// Write for an unrelated session — must NOT emit.
+	require.NoError(t, WriteBadgeUpdate("session-other", "not-for-me"))
+	time.Sleep(300 * time.Millisecond) // give fsnotify time to misfire if buggy
+	require.NotContains(t, w.String(), formatITermBadgeOSC("not-for-me"),
+		"watcher for session-mine must ignore updates for session-other; got %q", w.String())
+
+	// Now write for the real session — must emit, proving the watcher is
+	// alive and only filtering on filename match.
+	require.NoError(t, WriteBadgeUpdate("session-mine", "for-me"))
+	waitForOSC(t, w, "for-me", 3*time.Second)
+
+	cancel()
+	<-done
+}
+
+// TestIssue1114_Watcher_NoOpOutsideITerm2 is the failure mode: when the
+// outer terminal is not iTerm2, we must not blast OSC 1337 bytes at it
+// (other terminals render the payload as literal garbage in the user's
+// pane). Same gate as the original emitITermBadge — but the gate must
+// also live in the watcher path, not just the on-attach emit.
+func TestIssue1114_Watcher_NoOpOutsideITerm2(t *testing.T) {
+	useTestBadgeDir(t)
+	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
+	t.Setenv("ITERM_SESSION_ID", "")
+	t.Setenv("LC_TERMINAL", "")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	w := newLockedWriter()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		WatchBadgeUpdates(ctx, "ad-rename-fixture", w, true, ready)
+	}()
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher never signaled ready")
+	}
+
+	require.NoError(t, WriteBadgeUpdate("ad-rename-fixture", "any-title"))
+	time.Sleep(400 * time.Millisecond)
+
+	require.Empty(t, w.String(),
+		"watcher must be a strict no-op when the outer terminal is not iTerm2; got %q", w.String())
+
+	cancel()
+	<-done
+}
+
+// TestIssue1114_Watcher_ConfigDisabledSuppresses pins the second gate:
+// even on iTerm2, if [terminal].iterm_badge=false (and AGENTDECK_ITERM_BADGE
+// doesn't force-enable), the watcher must not emit. This matches the
+// existing emitITermBadge gating exactly so the via-watch path can't
+// silently bypass the user's opt-out.
+func TestIssue1114_Watcher_ConfigDisabledSuppresses(t *testing.T) {
+	useTestBadgeDir(t)
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("ITERM_SESSION_ID", "")
+	t.Setenv("LC_TERMINAL", "")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	w := newLockedWriter()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		WatchBadgeUpdates(ctx, "ad-rename-fixture", w, false /* configEnabled */, ready)
+	}()
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher never signaled ready")
+	}
+
+	require.NoError(t, WriteBadgeUpdate("ad-rename-fixture", "any-title"))
+	time.Sleep(400 * time.Millisecond)
+
+	require.Empty(t, w.String(),
+		"watcher must respect configEnabled=false even on iTerm2; got %q", w.String())
+
+	cancel()
+	<-done
+}
+
+// TestIssue1114_OSCMatchesAttachEmit asserts that the OSC byte sequence
+// emitted by the watcher is byte-identical to the on-attach emit.
+// Drift here would cause iTerm2 to render two different badges for the
+// same DisplayName depending on whether the attach was fresh or post-rename.
+func TestIssue1114_OSCMatchesAttachEmit(t *testing.T) {
+	useTestBadgeDir(t)
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("ITERM_SESSION_ID", "")
+	t.Setenv("LC_TERMINAL", "")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+
+	w := newLockedWriter()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		WatchBadgeUpdates(ctx, "ad-rename-fixture", w, true, ready)
+	}()
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher never signaled ready")
+	}
+
+	const title = "renamed-mid-attach"
+	require.NoError(t, WriteBadgeUpdate("ad-rename-fixture", title))
+	waitForOSC(t, w, title, 3*time.Second)
+
+	// The exact byte sequence iTerm2 parses on the wire.
+	wantOSC := "\x1b]1337;SetBadgeFormat=" + base64.StdEncoding.EncodeToString([]byte(title)) + "\a"
+	require.Contains(t, w.String(), wantOSC,
+		"watcher OSC must be byte-identical to the on-attach emitITermBadge format")
+
+	cancel()
+	<-done
+}

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -143,6 +143,15 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 	// it off at runtime. AGENTDECK_ITERM_BADGE=1 ad-hoc enables.
 	emitITermBadge(os.Stdout, s.DisplayName, s.terminalChromeIsEnabled())
 
+	// #1114: subscribe to mid-attach badge updates from the Claude
+	// rename hook. The hook subprocess has no controlling tty (Claude
+	// spawns hooks detached via setsid), so its EmitITermBadgeViaTty
+	// path silently no-ops. Instead, the hook drops a file under
+	// ~/.agent-deck/badge-updates/ and this goroutine — which DOES own
+	// the outer iTerm2 tty via os.Stdout — re-emits the OSC. Stopped
+	// by the ctx cancel that fires in cleanupAttach.
+	go WatchBadgeUpdates(ctx, s.Name, os.Stdout, s.terminalChromeIsEnabled(), nil)
+
 	// Create context with cancel for detach
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
## Summary

Diagnosis credit: @tarekrached for the full root-cause trace.

After `claude --name X` or `/rename` mid-attach, the DB title syncs (#572 path) but the iTerm2 badge stays at the attach-time value.

Root cause: `EmitITermBadgeViaTty` (internal/tmux/chrome.go:125) opens `/dev/tty` to write the OSC. Claude Code spawns its rename hook subprocess **detached via setsid** — the subprocess has **no controlling tty**, so `os.OpenFile("/dev/tty", os.O_WRONLY, 0)` returns `ENXIO` and the OSC is silently dropped.

## Fix (Option A) — file signal from hook → attach process

| Side | Where | What |
|------|-------|------|
| **Hook (no tty)** | `cmd/agent-deck/hook_name_sync.go` | After updating storage, drop the new title under `~/.agent-deck/badge-updates/<tmux-session-name>` via new `tmux.WriteBadgeUpdate`. File writes succeed without a controlling tty. |
| **Attach (owns tty)** | `internal/tmux/pty.go` | `Attach()` spawns a `WatchBadgeUpdates` goroutine that fsnotify-subscribes to the same directory and re-emits the OSC through `os.Stdout` (which the attach process **does** own) on each change. Stopped by the `ctx` cancel that runs in `cleanupAttach`. |

### Why not Option B (tmux env var)
Polling has visible badge lag; control-mode subscription would need a separate socket multiplexer. The file-signal path reuses the existing fsnotify machinery already used for `~/.agent-deck/events/` — zero new deps, same operational shape an ops engineer already knows.

### Gates preserved
Same two gates as `emitITermBadge` apply to the watcher path:
1. iTerm2 detection (`TERM_PROGRAM`/`LC_TERMINAL`)
2. `iTermBadgeEffective(configEnabled)` (config + `AGENTDECK_ITERM_BADGE` env override)

Non-iTerm2 terminals, `[terminal].iterm_badge=false`, and `AGENTDECK_ITERM_BADGE=0` all still result in a strict no-op. The watcher cannot bypass the user's opt-out.

## Tests (internal/tmux/issue1114_badge_rename_test.go)

Six explicit cases, each greppable on `#1114`:

| Test | Surface |
|------|---------|
| `WriteBadgeUpdate_AtomicFileWrite` | hook helper (CLI) — atomic tmp+rename writes title verbatim |
| `AttachWatcher_EmitsOSCOnFileChange` | happy path — watcher emits OSC, covers multiple sequential renames |
| `Watcher_IgnoresOtherSessions` | boundary — two attaches in one iTerm2 window cannot steal each other's badges |
| `Watcher_NoOpOutsideITerm2` | failure mode — non-iTerm2 receives no OSC garbage |
| `Watcher_ConfigDisabledSuppresses` | failure mode — config opt-out honored via watcher path |
| `OSCMatchesAttachEmit` | byte-identical OSC to the on-attach emit (prevents the two-codepath drift class) |

Test trace before fix:
```
internal/tmux/issue1114_badge_rename_test.go:87:21: undefined: WriteBadgeUpdate
internal/tmux/issue1114_badge_rename_test.go:116:3:  undefined: WatchBadgeUpdates
```
After fix:
```
$ go test -race -count=1 ./internal/tmux/... ./cmd/agent-deck/...
ok  github.com/asheshgoplani/agent-deck/internal/tmux       25.271s
ok  github.com/asheshgoplani/agent-deck/cmd/agent-deck      70.538s
```

Full module suite green: `go test -race -count=1 ./...` (all 40 packages ok). `golangci-lint run`: 0 issues. `govulncheck ./...`: no vulnerabilities.

## Surface coverage

- [x] **TUI** — `Attach()` is the single seam; existing `TestAttach_EmitsITermBadgeOnEntry` still green; new watcher does not change attach-time emit behavior.
- [x] **CLI** — `cmd/agent-deck/hook_name_sync.go` is the CLI hook handler; new `WriteBadgeUpdate` call exercised by `TestApplyClaudeTitleSync_*` paths + the new tmux unit tests.
- [x] **Remote** — RemoteSession's tmux attach routes through the same `tmux.Session.Attach()` on the remote box; the `~/.agent-deck/badge-updates/` dir lives on the box that runs agent-deck, which is also where the watcher runs. `LC_TERMINAL` SSH propagation gate unchanged.
- [x] **Persistence** — no schema change; signal files live outside SQLite (same as status events).
- [x] **Cross-platform** — both new files are `//go:build !windows`, matching `chrome.go` and `pty.go`.
- [ ] **Web UI** — N/A: badge is an iTerm2 terminal-emulator OSC, not a browser UI concept.

## Don't-break checklist

- [x] Attach-time emit at `pty.go:144` (unchanged — still owns the tty)
- [x] iTerm2 badge on initial attach (`TestAttach_EmitsITermBadgeOnEntry` still green)
- [x] Non-iTerm2 terminals (gates preserved + new `Watcher_NoOpOutsideITerm2` test)
- [x] DB rename flow (#572 — all `TestApplyClaudeTitleSync_*` tests still green)
- [x] `EmitITermBadgeViaTty` left in place as a fallback (silent no-op when no tty, real emit when a future caller has one)

## Test plan

- [ ] On iTerm2 host: attach to an agent-deck session; run `claude --name foo`; confirm badge updates to `foo` without detach.
- [ ] On iTerm2 host: `/rename bar` mid-attach inside Claude; confirm badge updates to `bar`.
- [ ] On Apple Terminal: same scenarios; confirm no escape-garbage in pane (gate honored).
- [ ] Set `AGENTDECK_ITERM_BADGE=0`; rename; confirm badge stays cleared.

Closes #1114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iTerm2 badge renaming in tmux when the hook subprocess lacks a controlling TTY. Badge updates now synchronize reliably using a file-based mechanism.

* **Tests**
  * Added comprehensive test coverage for badge update behavior in various scenarios and configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->