### PR TITLE
fix(lint): install golangci-lint v2 to match .golangci.yml config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ fmt:
 
 # Lint
 lint:
-	@which golangci-lint > /dev/null || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@which golangci-lint > /dev/null || go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	golangci-lint run
 
 # Run local CI checks (same as pre-push hook: lint + test + build in parallel)


### PR DESCRIPTION
The config uses `version: "2"` but the Makefile installed v1, which
immediately errors out with "please use golangci-lint v2".

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting tool version to v2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->