### PR TITLE
fix(remote): waiting-status + arrow keys + insert perf (closes #1112, follow-ups to #1102/#1110)

### DIFF
--- a/cmd/agent-deck/issue1112_send_keys_stream_test.go
+++ b/cmd/agent-deck/issue1112_send_keys_stream_test.go
@@ -1,0 +1,182 @@
+// Issue #1112 — bug 2 CLI side: `agent-deck session send-keys <id>
+// --stream` reads stdin lines until EOF and dispatches each to the
+// session's tmux pane. These tests verify the wire-format parser
+// matches the StreamingRemoteKeySender's emitter shape
+// (internal/session/remote_keysender.go) — if either drifts, the
+// remote loop silently ignores commands and the user's typing
+// disappears.
+
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// recordingSink captures every dispatch the stream loop performs.
+type recordingSink struct {
+	texts  []string
+	named  []string
+	enters int
+	errOn  string // when non-empty, error on the first verb matching this prefix
+}
+
+func (r *recordingSink) SendKeys(text string) error {
+	if r.errOn == "T" {
+		r.errOn = ""
+		return errors.New("forced")
+	}
+	r.texts = append(r.texts, text)
+	return nil
+}
+func (r *recordingSink) SendNamedKey(key string) error {
+	if r.errOn == "N" {
+		r.errOn = ""
+		return errors.New("forced")
+	}
+	r.named = append(r.named, key)
+	return nil
+}
+func (r *recordingSink) SendEnter() error {
+	if r.errOn == "E" {
+		r.errOn = ""
+		return errors.New("forced")
+	}
+	r.enters++
+	return nil
+}
+
+// hexLine builds a "T <hex>\n" line so tests stay readable.
+func hexLine(verb, payload string) string {
+	switch verb {
+	case "T":
+		return "T " + hex.EncodeToString([]byte(payload)) + "\n"
+	case "N":
+		return "N " + payload + "\n"
+	case "E":
+		return "E\n"
+	}
+	panic("unknown verb")
+}
+
+// TestIssue1112_runSendKeysStream_HappyPath verifies the parser
+// dispatches a realistic mixed sequence in order.
+func TestIssue1112_runSendKeysStream_HappyPath(t *testing.T) {
+	var input bytes.Buffer
+	input.WriteString(hexLine("T", "hi"))
+	input.WriteString(hexLine("N", "Down"))
+	input.WriteString(hexLine("E", ""))
+	input.WriteString(hexLine("T", "bye"))
+
+	sink := &recordingSink{}
+	if err := runSendKeysStream(&input, sink); err != nil {
+		t.Fatalf("runSendKeysStream: %v", err)
+	}
+	if got, want := sink.texts, []string{"hi", "bye"}; !equalStrings(got, want) {
+		t.Errorf("texts = %v, want %v", got, want)
+	}
+	if got, want := sink.named, []string{"Down"}; !equalStrings(got, want) {
+		t.Errorf("named = %v, want %v", got, want)
+	}
+	if sink.enters != 1 {
+		t.Errorf("enters = %d, want 1", sink.enters)
+	}
+}
+
+// TestIssue1112_runSendKeysStream_IgnoresBlanksAndUnknownVerbs covers
+// the forward-compatibility guarantee: blank lines and lines starting
+// with verbs the current binary doesn't know must NOT halt the loop.
+// Otherwise an older remote agent-deck would brick the moment the
+// local sender added a new verb.
+func TestIssue1112_runSendKeysStream_IgnoresBlanksAndUnknownVerbs(t *testing.T) {
+	var input bytes.Buffer
+	input.WriteString("\n")            // blank
+	input.WriteString("X something\n") // unknown verb
+	input.WriteString("# comment\n")   // also unknown
+	input.WriteString(hexLine("T", "ok"))
+
+	sink := &recordingSink{}
+	if err := runSendKeysStream(&input, sink); err != nil {
+		t.Fatalf("runSendKeysStream: %v", err)
+	}
+	if got, want := sink.texts, []string{"ok"}; !equalStrings(got, want) {
+		t.Errorf("texts = %v, want %v — unknown verbs must not halt stream", got, want)
+	}
+}
+
+// TestIssue1112_runSendKeysStream_BinarySafeText round-trips bytes
+// that would corrupt a text-only protocol (newlines, NULL, high-bit).
+func TestIssue1112_runSendKeysStream_BinarySafeText(t *testing.T) {
+	payload := "line1\nline2\x00\xff"
+	var input bytes.Buffer
+	input.WriteString(hexLine("T", payload))
+
+	sink := &recordingSink{}
+	if err := runSendKeysStream(&input, sink); err != nil {
+		t.Fatalf("runSendKeysStream: %v", err)
+	}
+	if len(sink.texts) != 1 || sink.texts[0] != payload {
+		t.Errorf("texts = %q, want [%q]", sink.texts, payload)
+	}
+}
+
+// TestIssue1112_runSendKeysStream_InvalidHex surfaces a malformed
+// payload as an error — the local sender shouldn't have produced it,
+// but if it did we want a loud failure rather than silent garbage.
+func TestIssue1112_runSendKeysStream_InvalidHex(t *testing.T) {
+	var input bytes.Buffer
+	input.WriteString("T zzznotahex\n")
+
+	sink := &recordingSink{}
+	if err := runSendKeysStream(&input, sink); err == nil {
+		t.Fatal("expected error for invalid hex")
+	} else if !strings.Contains(err.Error(), "invalid hex") {
+		t.Errorf("error = %v, want one mentioning 'invalid hex'", err)
+	}
+}
+
+// TestIssue1112_runSendKeysStream_DispatchErrorPropagates verifies a
+// per-keystroke error doesn't get silently swallowed.
+func TestIssue1112_runSendKeysStream_DispatchErrorPropagates(t *testing.T) {
+	var input bytes.Buffer
+	input.WriteString(hexLine("T", "x"))
+
+	sink := &recordingSink{errOn: "T"}
+	if err := runSendKeysStream(&input, sink); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestIssue1112_runSendKeysStream_HighThroughput sanity-checks the
+// parser's overhead: 1000 lines through the loop must complete in
+// well under a second. This is the inverse of the perf test in
+// internal/session — we want the receiver to be cheap too.
+func TestIssue1112_runSendKeysStream_HighThroughput(t *testing.T) {
+	var input bytes.Buffer
+	for i := 0; i < 1000; i++ {
+		input.WriteString(hexLine("T", fmt.Sprintf("k%d", i)))
+	}
+	sink := &recordingSink{}
+	if err := runSendKeysStream(&input, sink); err != nil {
+		t.Fatalf("runSendKeysStream: %v", err)
+	}
+	if len(sink.texts) != 1000 {
+		t.Errorf("dispatched %d, want 1000", len(sink.texts))
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/agent-deck/session_send_keys_cmd.go
+++ b/cmd/agent-deck/session_send_keys_cmd.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"bufio"
+	"encoding/hex"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 )
 
 // handleSessionSendKeys implements `agent-deck session send-keys <id>
@@ -30,6 +34,7 @@ func handleSessionSendKeys(profile string, args []string) {
 	text := fs.String("text", "", "Literal text to type (tmux send-keys -l)")
 	namedKey := fs.String("named-key", "", "Tmux named key (e.g. BSpace, Up, C-c)")
 	sendEnter := fs.Bool("enter", false, "Send an Enter keystroke")
+	stream := fs.Bool("stream", false, "Read dispatch commands from stdin until EOF (#1112)")
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("q", false, "Quiet mode")
 
@@ -64,7 +69,7 @@ func handleSessionSendKeys(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Validate exactly one dispatch flag.
+	// Validate exactly one dispatch flag (or --stream).
 	count := 0
 	if *text != "" {
 		count++
@@ -75,8 +80,13 @@ func handleSessionSendKeys(profile string, args []string) {
 	if *sendEnter {
 		count++
 	}
-	if count != 1 {
-		out.Error("exactly one of --text, --named-key, or --enter required", ErrCodeInvalidOperation)
+	if *stream {
+		if count != 0 {
+			out.Error("--stream is mutually exclusive with --text/--named-key/--enter", ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+	} else if count != 1 {
+		out.Error("exactly one of --text, --named-key, --enter, or --stream required", ErrCodeInvalidOperation)
 		os.Exit(1)
 	}
 
@@ -110,6 +120,21 @@ func handleSessionSendKeys(profile string, args []string) {
 	}
 
 	switch {
+	case *stream:
+		// #1112 bug 2: persistent stream amortizes the per-keystroke ssh
+		// fork+exec across an entire insert-mode session. The local TUI
+		// spawns this CLI once, writes one command line per keystroke to
+		// stdin, and closes stdin on insert-mode exit. Each line is one
+		// of:
+		//   T <hex-text>\n   (SendKeys; text is hex so newlines etc are safe)
+		//   N <name>\n       (SendNamedKey; e.g. Up, BSpace, C-c)
+		//   E\n              (SendEnter)
+		// Blank lines and unknown verbs are ignored to keep the stream
+		// resilient to forward-compatible extensions.
+		if err := runSendKeysStream(os.Stdin, tmuxSess); err != nil {
+			out.Error(fmt.Sprintf("send-keys stream: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
 	case *text != "":
 		if err := tmuxSess.SendKeys(*text); err != nil {
 			out.Error(fmt.Sprintf("send-keys failed: %v", err), ErrCodeInvalidOperation)
@@ -132,4 +157,71 @@ func handleSessionSendKeys(profile string, args []string) {
 		"session_id":    inst.ID,
 		"session_title": inst.Title,
 	})
+}
+
+// streamKeySink is the minimum tmux-session surface runSendKeysStream
+// needs. The CLI invocation uses *tmux.Session; tests can pass a fake
+// that records calls.
+type streamKeySink interface {
+	SendKeys(text string) error
+	SendNamedKey(key string) error
+	SendEnter() error
+}
+
+// runSendKeysStream reads dispatch commands from r and forwards each to
+// sink in order. Errors on individual dispatches surface as the
+// returned error so the CLI exits non-zero — partial streams are NOT
+// silently dropped (a partial stream means the TUI's typed input was
+// lost, which is exactly what #1112 bug 2's persistent stream is meant
+// to prevent recurring with).
+//
+// Wire protocol (line-oriented, LF-terminated):
+//
+//	T <hex-text>   — SendKeys(hex.Decode(<hex-text>))
+//	N <name>       — SendNamedKey(<name>)
+//	E              — SendEnter()
+//
+// Blank lines and unknown verbs are ignored so future versions can add
+// commands without breaking older `agent-deck` binaries on the remote.
+func runSendKeysStream(r io.Reader, sink streamKeySink) error {
+	scanner := bufio.NewScanner(r)
+	// 1 MiB max line — well above any realistic insert-mode burst.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "T "):
+			payload, err := hex.DecodeString(strings.TrimPrefix(line, "T "))
+			if err != nil {
+				return fmt.Errorf("stream: invalid hex text: %w", err)
+			}
+			if len(payload) == 0 {
+				continue
+			}
+			if err := sink.SendKeys(string(payload)); err != nil {
+				return fmt.Errorf("stream: SendKeys: %w", err)
+			}
+		case strings.HasPrefix(line, "N "):
+			key := strings.TrimPrefix(line, "N ")
+			if strings.TrimSpace(key) == "" {
+				continue
+			}
+			if err := sink.SendNamedKey(key); err != nil {
+				return fmt.Errorf("stream: SendNamedKey(%q): %w", key, err)
+			}
+		case line == "E":
+			if err := sink.SendEnter(); err != nil {
+				return fmt.Errorf("stream: SendEnter: %w", err)
+			}
+		default:
+			// Unknown verb — ignore for forward compatibility.
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("stream: read: %w", err)
+	}
+	return nil
 }

--- a/docs/terminal-shortcuts.md
+++ b/docs/terminal-shortcuts.md
@@ -1,0 +1,64 @@
+# Terminal shortcuts and gotchas
+
+This page documents keyboard shortcuts that interact with agent-deck's
+tmux-backed session model — and the small set of platform / terminal
+quirks that can surprise users.
+
+## Detach from an attached session
+
+| Keystroke | What happens |
+| --------- | ------------ |
+| `Ctrl-Q`  | Detach from the currently attached agent-deck session and return to the agent-deck TUI. |
+
+`Ctrl-Q` is agent-deck's wrapper for tmux's session-detach binding. It
+works in every terminal emulator we ship support for (iTerm2, Terminal.app,
+Alacritty, Ghostty, gnome-terminal, kitty, WezTerm, the Linux console).
+
+## Known terminal gotchas
+
+### iTerm2 tabs disconnect on `Ctrl-Q` (expected)
+
+When agent-deck is attached to a session inside an iTerm2 tab and you
+press `Ctrl-Q`, iTerm2 itself receives the keystroke first. iTerm2's
+default key map binds `Ctrl-Q` to "soft-quit / close window," which
+tears down the SSH tunnel and the visible agent-deck panes along with
+it. This is intentional iTerm2 behavior, not an agent-deck bug — the
+keystroke is consumed by the terminal before reaching tmux.
+
+Workarounds, in order of preference:
+
+1. **Use the agent-deck TUI's own back-out keys** (`q` from a session
+   list view, `Esc` from most overlays) instead of `Ctrl-Q` when inside
+   iTerm2. They go through the TUI's bubbletea event loop, never
+   through tmux's detach binding, and never reach iTerm2's hotkey
+   handler.
+2. **Remap iTerm2's `Ctrl-Q`**: open iTerm2 → Preferences → Keys → Key
+   Bindings, find `^Q`, and either delete the binding or change it to
+   "Send Escape Sequence" with no payload. After that `Ctrl-Q` flows
+   through to tmux exactly like every other terminal.
+3. **Attach via the macOS Terminal.app or a different terminal** for
+   workflows that rely heavily on `Ctrl-Q`. Terminal.app does not bind
+   the keystroke by default.
+
+This is the same class of conflict as macOS's system `Cmd-Q` (force-
+quit) — a terminal-level binding wins against any program running
+inside the terminal. Tracked at GitHub #1112 (bug 4). No code change
+ships in agent-deck for this case; the documentation here is the fix.
+
+### `Ctrl-Q` inside an outer tmux
+
+If you've launched `agent-deck` inside an outer tmux instance and that
+outer tmux's prefix is `Ctrl-Q`, the detach is consumed by the outer
+tmux instead of the agent-deck-owned tmux. Pick a non-default prefix
+for your outer tmux (`Ctrl-A` and `Ctrl-B` are the conventional
+choices) to keep `Ctrl-Q` reserved for agent-deck's detach.
+
+## Related references
+
+- `internal/tmux/pty.go` — the agent-deck-side intercept for `Ctrl-Q`
+  across keyboard-encoding modes (raw bytes, xterm, kitty).
+- GitHub #356, #357 — earlier hardening of `Ctrl-Q` detection across
+  encodings.
+- GitHub #1112 — the cluster of remote / direct-type bugs that
+  motivated this page; this entry covers sub-issue 4 (Ctrl-Q in iTerm
+  tabs).

--- a/internal/session/issue1112_insert_perf_test.go
+++ b/internal/session/issue1112_insert_perf_test.go
@@ -1,0 +1,289 @@
+package session
+
+// Issue #1112 — bug 2 (by @ddorman-dn on v1.9.24): "Direct type STILL
+// slow." The #1102/#1110 fix made local insert mode fast (persistent
+// `tmux -C` client) but every keystroke on a REMOTE session still
+// shelled out to `ssh ... agent-deck session send-keys` — fork+exec on
+// both ends per keystroke plus an SSH round-trip. At realistic typing
+// speeds (>15ms between keys) that's 100ms+ of perceived per-keystroke
+// lag.
+//
+// Fix: StreamingRemoteKeySender opens ONE persistent
+// `ssh ... agent-deck session send-keys <id> --stream` subprocess for
+// the lifetime of the insert-mode session and writes one stdin line per
+// keystroke. After the first call the SSH transport is a hot pipe; per
+// keystroke cost collapses to a stdin write (<1µs).
+//
+// These tests assert:
+//
+//  1. The streaming sender opens exactly ONE SSH subprocess for an
+//     entire 100-keystroke burst (counts invocations, per the prompt).
+//  2. 100 keystrokes through the streaming dispatch path complete in
+//     well under the 500ms budget — when the test stream is a
+//     bytes.Buffer the budget is effectively unbounded; the
+//     measurement-with-bound pattern is the regression fence so a
+//     future regression that re-introduces per-call exec blows it.
+//  3. The wire format matches the CLI handler (T <hex>, N <key>, E)
+//     — round-trip via runSendKeysStream's parser would surface any
+//     drift, but for unit purposes we assert on the emitted bytes.
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeStream is a thread-safe in-memory pipe simulating the persistent
+// SSH stdin. The "subprocess" never runs — but `closeCount` and
+// `bytesWritten` let tests assert that exactly one open/close pair
+// happened and that every keystroke produced a line.
+type fakeStream struct {
+	buf        bytes.Buffer
+	closeCount atomic.Int32
+}
+
+func (f *fakeStream) Write(p []byte) (int, error) { return f.buf.Write(p) }
+func (f *fakeStream) Close() error {
+	f.closeCount.Add(1)
+	return nil
+}
+
+// captureStreamOpenCount returns an SSHRunner whose openStreamFn
+// counts spawns and returns a fakeStream. The companion accessor
+// reveals how many times OpenStream was invoked.
+func captureStreamOpenCount() (*SSHRunner, *atomic.Int32, *fakeStream) {
+	var opens atomic.Int32
+	stream := &fakeStream{}
+	r := &SSHRunner{
+		Host:          "test-host",
+		AgentDeckPath: "/usr/local/bin/agent-deck",
+		openStreamFn: func(ctx context.Context, args ...string) (io.WriteCloser, func() error, error) {
+			opens.Add(1)
+			return stream, stream.Close, nil
+		},
+	}
+	return r, &opens, stream
+}
+
+// TestIssue1112_StreamingRemoteKeySender_OneSubprocessFor100Keys is the
+// headline regression fence for bug 2: 100 SendKeys calls must NOT
+// spawn 100 ssh subprocesses. The streaming sender opens once at
+// OpenStreamingRemoteKeySender and reuses the stream for every Send.
+// If a future refactor accidentally re-spawns per call, opens jumps to
+// 100 and this test fails loudly.
+func TestIssue1112_StreamingRemoteKeySender_OneSubprocessFor100Keys(t *testing.T) {
+	runner, opens, stream := captureStreamOpenCount()
+
+	sender, err := OpenStreamingRemoteKeySender(runner, "remote-sess-id", context.Background())
+	if err != nil {
+		t.Fatalf("OpenStreamingRemoteKeySender: %v", err)
+	}
+	defer sender.Close()
+
+	const n = 100
+	for i := 0; i < n; i++ {
+		if err := sender.SendKeys("x"); err != nil {
+			t.Fatalf("SendKeys %d: %v", i, err)
+		}
+	}
+
+	if got := opens.Load(); got != 1 {
+		t.Errorf("ssh subprocess spawns = %d, want 1 — streaming sender must reuse the connection (#1112 bug 2)", got)
+	}
+	// Each SendKeys emits one line.
+	lines := strings.Count(stream.buf.String(), "\n")
+	if lines != n {
+		t.Errorf("emitted %d stream lines, want %d (one per keystroke)", lines, n)
+	}
+}
+
+// TestIssue1112_StreamingRemoteKeySender_PerfBudget100KeysUnder500ms
+// asserts the 500ms / 100 keystrokes budget the prompt called for.
+// With a fake stream the actual work is bounded by hex encoding and
+// buffer writes — comfortably sub-millisecond. The 500ms is the
+// regression bound: a future change that re-introduces per-call
+// fork+exec or any blocking I/O will blow it.
+func TestIssue1112_StreamingRemoteKeySender_PerfBudget100KeysUnder500ms(t *testing.T) {
+	runner, _, _ := captureStreamOpenCount()
+	sender, err := OpenStreamingRemoteKeySender(runner, "remote-sess-id", context.Background())
+	if err != nil {
+		t.Fatalf("OpenStreamingRemoteKeySender: %v", err)
+	}
+	defer sender.Close()
+
+	const n = 100
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		if err := sender.SendKeys("a"); err != nil {
+			t.Fatalf("SendKeys %d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("100 streaming SendKeys took %v, want <500ms (#1112 bug 2 perf budget)", elapsed)
+	}
+	t.Logf("100 streaming keystrokes: %v (%.2fµs/keystroke)",
+		elapsed, float64(elapsed.Microseconds())/float64(n))
+}
+
+// TestIssue1112_StreamingRemoteKeySender_WireFormat asserts the lines
+// emitted to the stream match the protocol parsed by runSendKeysStream
+// in cmd/agent-deck/session_send_keys_cmd.go. If they ever drift, the
+// remote loop will silently ignore commands (the "unknown verb"
+// branch) and the user's typing disappears.
+func TestIssue1112_StreamingRemoteKeySender_WireFormat(t *testing.T) {
+	runner, _, stream := captureStreamOpenCount()
+	sender, err := OpenStreamingRemoteKeySender(runner, "x", context.Background())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer sender.Close()
+
+	if err := sender.SendKeys("hi"); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+	if err := sender.SendNamedKey("Up"); err != nil {
+		t.Fatalf("SendNamedKey: %v", err)
+	}
+	if err := sender.SendEnter(); err != nil {
+		t.Fatalf("SendEnter: %v", err)
+	}
+
+	wantLines := []string{
+		"T " + hex.EncodeToString([]byte("hi")),
+		"N Up",
+		"E",
+	}
+	gotLines := strings.Split(strings.TrimRight(stream.buf.String(), "\n"), "\n")
+	if len(gotLines) != len(wantLines) {
+		t.Fatalf("got %d lines, want %d: %q", len(gotLines), len(wantLines), stream.buf.String())
+	}
+	for i, want := range wantLines {
+		if gotLines[i] != want {
+			t.Errorf("line %d = %q, want %q", i, gotLines[i], want)
+		}
+	}
+}
+
+// TestIssue1112_StreamingRemoteKeySender_EmptyTextIsNoOp guards the
+// flush-empty-buffer case: insert mode flushes the rune buffer on any
+// non-rune key, and the buffer is often empty. The streaming sender
+// must not emit a stream line in that case (a literal "T \n" would
+// decode to empty bytes on the remote, harmless but noisy).
+func TestIssue1112_StreamingRemoteKeySender_EmptyTextIsNoOp(t *testing.T) {
+	runner, _, stream := captureStreamOpenCount()
+	sender, err := OpenStreamingRemoteKeySender(runner, "x", context.Background())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer sender.Close()
+
+	if err := sender.SendKeys(""); err != nil {
+		t.Fatalf("SendKeys(\"\"): %v", err)
+	}
+	if got := stream.buf.Len(); got != 0 {
+		t.Errorf("buffer = %q, want empty for SendKeys(\"\")", stream.buf.String())
+	}
+}
+
+// TestIssue1112_StreamingRemoteKeySender_CloseStopsDispatch is the
+// failure-mode test: after Close the sender must refuse new dispatches
+// (so the UI doesn't accidentally race insert-mode-exit teardown).
+func TestIssue1112_StreamingRemoteKeySender_CloseStopsDispatch(t *testing.T) {
+	runner, _, stream := captureStreamOpenCount()
+	sender, err := OpenStreamingRemoteKeySender(runner, "x", context.Background())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	if err := sender.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if got := stream.closeCount.Load(); got != 1 {
+		t.Errorf("closeCount = %d, want 1", got)
+	}
+	if err := sender.Close(); err != nil {
+		t.Errorf("second Close should be a no-op: %v", err)
+	}
+
+	if err := sender.SendKeys("late"); err == nil {
+		t.Fatal("SendKeys after Close must fail")
+	} else if !strings.Contains(err.Error(), "closed") {
+		t.Errorf("error after Close = %v, want one containing 'closed'", err)
+	}
+}
+
+// TestIssue1112_StreamingRemoteKeySender_OpenErrorPropagates verifies
+// that an SSH open failure is surfaced so the UI can fall back to the
+// per-call RemoteKeySender (openRemoteInsertKeySender does this).
+// Without this, a transient ssh failure would silently swallow
+// insert-mode entirely on remote.
+func TestIssue1112_StreamingRemoteKeySender_OpenErrorPropagates(t *testing.T) {
+	wantErr := errors.New("ssh: connection refused")
+	runner := &SSHRunner{
+		Host:          "test-host",
+		AgentDeckPath: "/usr/local/bin/agent-deck",
+		openStreamFn: func(ctx context.Context, args ...string) (io.WriteCloser, func() error, error) {
+			return nil, nil, wantErr
+		},
+	}
+	_, err := OpenStreamingRemoteKeySender(runner, "x", context.Background())
+	if err == nil {
+		t.Fatal("expected error to surface")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error chain missing wrapped cause; got %v", err)
+	}
+}
+
+// TestIssue1112_StreamingRemoteKeySender_NamedKeyRejectsNewline guards
+// the wire shape: a newline in the named key would break out of one
+// line into a forged second command. Fail fast on the local side.
+func TestIssue1112_StreamingRemoteKeySender_NamedKeyRejectsNewline(t *testing.T) {
+	runner, _, _ := captureStreamOpenCount()
+	sender, err := OpenStreamingRemoteKeySender(runner, "x", context.Background())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer sender.Close()
+
+	if err := sender.SendNamedKey("Up\nE"); err == nil {
+		t.Error("SendNamedKey with embedded newline must fail")
+	}
+}
+
+// TestIssue1112_StreamingRemoteKeySender_BinarySafeText asserts that
+// text containing newlines, NULL, and non-UTF8 bytes round-trips via
+// hex without corruption. Paste-into-insert-mode is the realistic
+// trigger.
+func TestIssue1112_StreamingRemoteKeySender_BinarySafeText(t *testing.T) {
+	runner, _, stream := captureStreamOpenCount()
+	sender, err := OpenStreamingRemoteKeySender(runner, "x", context.Background())
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer sender.Close()
+
+	payload := "line1\nline2\x00\xff"
+	if err := sender.SendKeys(payload); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+
+	line := strings.TrimRight(stream.buf.String(), "\n")
+	if !strings.HasPrefix(line, "T ") {
+		t.Fatalf("expected T-prefixed line, got %q", line)
+	}
+	decoded, err := hex.DecodeString(strings.TrimPrefix(line, "T "))
+	if err != nil {
+		t.Fatalf("hex decode: %v", err)
+	}
+	if string(decoded) != payload {
+		t.Errorf("round-trip mismatch: got %q, want %q", string(decoded), payload)
+	}
+}

--- a/internal/session/issue1112_insert_remote_named_keys_test.go
+++ b/internal/session/issue1112_insert_remote_named_keys_test.go
@@ -1,0 +1,185 @@
+package session
+
+// Issue #1112 — bug 3 (by @ddorman-dn on v1.9.24): arrow keys + Enter for
+// menu navigation work in insert mode against LOCAL sessions but appear
+// broken against REMOTE sessions. The hypothesis was "RPC for named keys
+// not extending to remote." These tests are the regression fence proving
+// every menu-nav key the user can press lands on the remote with the
+// correct argv shape — Up/Down/Left/Right/Tab/Shift-Tab/Enter.
+//
+// Distinct from #1102's RemoteKeySender tests: those covered the
+// general dispatch verbs. These bind the SPECIFIC menu-nav keys named
+// in the bug report so a future refactor can't silently drop one of
+// them.
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// captureRemoteCalls is a local helper so this file stays independent of
+// issue1102_insert_remote_test.go's captureSSHRunner — same idea, but a
+// distinct fixture so #1112 regressions are caught even if #1102's
+// fixture is later changed.
+func captureRemoteCalls() (*SSHRunner, func() [][]string) {
+	var (
+		mu    sync.Mutex
+		calls [][]string
+	)
+	r := &SSHRunner{
+		Host:          "test-host",
+		AgentDeckPath: "/usr/local/bin/agent-deck",
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			callCopy := make([]string, len(args))
+			copy(callCopy, args)
+			calls = append(calls, callCopy)
+			return []byte(`{"success":true}`), nil
+		},
+	}
+	return r, func() [][]string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([][]string, len(calls))
+		for i, c := range calls {
+			out[i] = append([]string(nil), c...)
+		}
+		return out
+	}
+}
+
+// TestIssue1112_RemoteKeySender_ForwardsAllArrowKeys asserts the four
+// arrow keys forward to the remote with the canonical tmux names. If a
+// regression turns "Up" into something tmux doesn't recognize (e.g.
+// "ArrowUp"), the remote pane sees garbage and the menu picker freezes.
+func TestIssue1112_RemoteKeySender_ForwardsAllArrowKeys(t *testing.T) {
+	cases := []string{"Up", "Down", "Left", "Right"}
+	for _, key := range cases {
+		t.Run(key, func(t *testing.T) {
+			runner, captured := captureRemoteCalls()
+			sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+			if err := sender.SendNamedKey(key); err != nil {
+				t.Fatalf("SendNamedKey(%q): %v", key, err)
+			}
+			calls := captured()
+			if len(calls) != 1 {
+				t.Fatalf("expected 1 SSH call for %s, got %d: %v", key, len(calls), calls)
+			}
+			got := strings.Join(calls[0], " ")
+			want := "session send-keys remote-sess-id --named-key " + key
+			if got != want {
+				t.Errorf("argv = %q, want %q (#1112 bug 3)", got, want)
+			}
+		})
+	}
+}
+
+// TestIssue1112_RemoteKeySender_ForwardsTabAndShiftTab covers Tab and
+// BTab (tmux's name for Shift-Tab). Claude's pickers use Tab to advance
+// between fields and Shift-Tab to step back; both must round-trip.
+func TestIssue1112_RemoteKeySender_ForwardsTabAndShiftTab(t *testing.T) {
+	cases := []string{"Tab", "BTab"}
+	for _, key := range cases {
+		t.Run(key, func(t *testing.T) {
+			runner, captured := captureRemoteCalls()
+			sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+			if err := sender.SendNamedKey(key); err != nil {
+				t.Fatalf("SendNamedKey(%q): %v", key, err)
+			}
+			calls := captured()
+			if len(calls) != 1 || calls[0][len(calls[0])-1] != key {
+				t.Errorf("argv = %v, want last token %q", calls, key)
+			}
+		})
+	}
+}
+
+// TestIssue1112_RemoteKeySender_ForwardsEnter covers the Enter dispatch.
+// Enter is its own verb (--enter), not a named key, so the remote
+// handler can apply the bracketed-paste flush delay that local
+// SendEnter uses.
+func TestIssue1112_RemoteKeySender_ForwardsEnter(t *testing.T) {
+	runner, captured := captureRemoteCalls()
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	if err := sender.SendEnter(); err != nil {
+		t.Fatalf("SendEnter: %v", err)
+	}
+	calls := captured()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 SSH call, got %d: %v", len(calls), calls)
+	}
+	want := []string{"session", "send-keys", "remote-sess-id", "--enter"}
+	if !sliceEqualLocal(calls[0], want) {
+		t.Errorf("argv = %v, want %v", calls[0], want)
+	}
+}
+
+// TestIssue1112_RemoteKeySender_MenuNavSequence simulates a realistic
+// menu-nav sequence (DownDownEnter — pick the third item in a picker)
+// and asserts every key reached the remote, in order. Catches dispatch
+// reordering bugs that single-key tests would miss.
+func TestIssue1112_RemoteKeySender_MenuNavSequence(t *testing.T) {
+	runner, captured := captureRemoteCalls()
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	if err := sender.SendNamedKey("Down"); err != nil {
+		t.Fatalf("Down 1: %v", err)
+	}
+	if err := sender.SendNamedKey("Down"); err != nil {
+		t.Fatalf("Down 2: %v", err)
+	}
+	if err := sender.SendEnter(); err != nil {
+		t.Fatalf("Enter: %v", err)
+	}
+
+	calls := captured()
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 SSH calls, got %d: %v", len(calls), calls)
+	}
+	wantSequence := [][]string{
+		{"session", "send-keys", "remote-sess-id", "--named-key", "Down"},
+		{"session", "send-keys", "remote-sess-id", "--named-key", "Down"},
+		{"session", "send-keys", "remote-sess-id", "--enter"},
+	}
+	for i, want := range wantSequence {
+		if !sliceEqualLocal(calls[i], want) {
+			t.Errorf("call %d argv = %v, want %v", i, calls[i], want)
+		}
+	}
+}
+
+// TestIssue1112_RemoteKeySender_RejectsUnknownNamedKey is the failure-
+// mode guard: an empty named key must fail fast on the local side, not
+// land on the remote and produce an opaque tmux error.
+func TestIssue1112_RemoteKeySender_RejectsUnknownNamedKey(t *testing.T) {
+	runner, captured := captureRemoteCalls()
+	sender := NewRemoteKeySender(runner, "remote-sess-id", context.Background())
+
+	if err := sender.SendNamedKey(""); err == nil {
+		t.Fatal("SendNamedKey(\"\") should fail")
+	}
+	if calls := captured(); len(calls) != 0 {
+		t.Errorf("empty key should not produce an SSH call; got %v", calls)
+	}
+}
+
+// sliceEqualLocal duplicates sliceEqual from issue1102_insert_remote_test.go
+// — keeping #1112 tests free of cross-file fixture coupling so renames in
+// one file don't cascade.
+func sliceEqualLocal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/session/issue1112_remote_waiting_status_test.go
+++ b/internal/session/issue1112_remote_waiting_status_test.go
@@ -1,0 +1,240 @@
+package session
+
+// Issue #1112 — bug 1 (by @ddorman-dn on v1.9.24): the remote "waiting for
+// input" icon doesn't update in the local TUI. The remote-side status RPC
+// (`agent-deck list --json`) must report `"status":"waiting"` when claude
+// is at a prompt, and the local fetch path must surface that to the
+// remoteSessions map so the row icon (◉ yellow) is rendered.
+//
+// These are pure-unit tests against the JSON wire format. They are the
+// regression fence that proves:
+//
+//	1. SSHRunner.FetchSessions parses every status string the remote can
+//	   emit ("running", "waiting", "idle", "stopped", "error").
+//	2. The `RemoteName` field is stamped on every returned session so the
+//	   local TUI can route the icon update to the right remote-group.
+//	3. Status changes between two fetches are observed verbatim — no
+//	   stale-cache surprises.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// jsonListResponse builds a fake `agent-deck list --json` payload from a
+// slice of (id, title, status) tuples — exactly the shape the remote
+// emits (see cmd/agent-deck/main.go:handleList JSON branch).
+func jsonListResponse(sessions []struct{ ID, Title, Status string }) []byte {
+	type sessionJSON struct {
+		ID         string `json:"id"`
+		Title      string `json:"title"`
+		Path       string `json:"path"`
+		Group      string `json:"group"`
+		Tool       string `json:"tool"`
+		Status     string `json:"status"`
+		CreatedAt  string `json:"created_at"`
+		RemoteName string `json:"-"`
+	}
+	out := make([]sessionJSON, 0, len(sessions))
+	for _, s := range sessions {
+		out = append(out, sessionJSON{
+			ID:     s.ID,
+			Title:  s.Title,
+			Path:   "/tmp/x",
+			Tool:   "claude",
+			Status: s.Status,
+		})
+	}
+	body, _ := json.Marshal(out)
+	return body
+}
+
+// stubbedRunner returns an SSHRunner whose runFn answers with the supplied
+// JSON bytes for every call. Captures the args so the test can assert the
+// `list --json` argv was used.
+func stubbedRunner(payload []byte) (*SSHRunner, *[]string) {
+	var (
+		mu       sync.Mutex
+		lastArgs []string
+	)
+	r := &SSHRunner{
+		Host:          "test-host",
+		AgentDeckPath: "/usr/local/bin/agent-deck",
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			lastArgs = append([]string(nil), args...)
+			return payload, nil
+		},
+	}
+	return r, &lastArgs
+}
+
+// TestIssue1112_RemoteFetchSessions_PreservesWaitingStatus is the headline
+// regression fence for bug 1: when the remote replies with
+// `"status":"waiting"` for a session, the local FetchSessions surfaces it
+// verbatim. Prior to the fix this was the suspected gap — the icon
+// "wouldn't update" because the field never reached the renderer.
+func TestIssue1112_RemoteFetchSessions_PreservesWaitingStatus(t *testing.T) {
+	payload := jsonListResponse([]struct{ ID, Title, Status string }{
+		{ID: "abc", Title: "claude-1", Status: "waiting"},
+	})
+	runner, _ := stubbedRunner(payload)
+
+	sessions, err := runner.FetchSessions(context.Background())
+	if err != nil {
+		t.Fatalf("FetchSessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("len(sessions)=%d, want 1", len(sessions))
+	}
+	if got := sessions[0].Status; got != "waiting" {
+		t.Errorf("Status=%q, want %q — remote status RPC must propagate waiting (#1112 bug 1)", got, "waiting")
+	}
+}
+
+// TestIssue1112_RemoteFetchSessions_AllStatusesPropagate guards against a
+// partial map (e.g. an enum-style switch that handles "running"+"idle" but
+// silently swallows "waiting" or "error"). Every status the remote can emit
+// must round-trip the JSON unmarshal.
+func TestIssue1112_RemoteFetchSessions_AllStatusesPropagate(t *testing.T) {
+	statuses := []string{"running", "waiting", "idle", "stopped", "error", "starting"}
+	in := make([]struct{ ID, Title, Status string }, 0, len(statuses))
+	for i, s := range statuses {
+		in = append(in, struct{ ID, Title, Status string }{
+			ID:     "id-" + s,
+			Title:  s,
+			Status: s,
+		})
+		_ = i
+	}
+	payload := jsonListResponse(in)
+	runner, _ := stubbedRunner(payload)
+
+	sessions, err := runner.FetchSessions(context.Background())
+	if err != nil {
+		t.Fatalf("FetchSessions: %v", err)
+	}
+	if len(sessions) != len(statuses) {
+		t.Fatalf("len(sessions)=%d, want %d", len(sessions), len(statuses))
+	}
+	for i, s := range sessions {
+		if s.Status != statuses[i] {
+			t.Errorf("sessions[%d].Status=%q, want %q", i, s.Status, statuses[i])
+		}
+	}
+}
+
+// TestIssue1112_RemoteFetchSessions_StatusChangeObserved exercises the
+// "icon didn't update" symptom: a session reports running on the first
+// fetch, then waiting on the second. The struct returned by the second
+// fetch must reflect the new status — if the SSHRunner accidentally
+// memoized the response, the icon would freeze.
+func TestIssue1112_RemoteFetchSessions_StatusChangeObserved(t *testing.T) {
+	var responses [][]byte
+	responses = append(responses,
+		jsonListResponse([]struct{ ID, Title, Status string }{
+			{ID: "p", Title: "p", Status: "running"},
+		}),
+		jsonListResponse([]struct{ ID, Title, Status string }{
+			{ID: "p", Title: "p", Status: "waiting"},
+		}),
+	)
+	idx := 0
+	runner := &SSHRunner{
+		Host:          "test-host",
+		AgentDeckPath: "/usr/local/bin/agent-deck",
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			r := responses[idx]
+			idx++
+			return r, nil
+		},
+	}
+
+	first, err := runner.FetchSessions(context.Background())
+	if err != nil {
+		t.Fatalf("first FetchSessions: %v", err)
+	}
+	if first[0].Status != "running" {
+		t.Fatalf("first Status=%q, want running", first[0].Status)
+	}
+	second, err := runner.FetchSessions(context.Background())
+	if err != nil {
+		t.Fatalf("second FetchSessions: %v", err)
+	}
+	if second[0].Status != "waiting" {
+		t.Errorf("second Status=%q, want waiting — status change must propagate (#1112 bug 1)", second[0].Status)
+	}
+}
+
+// TestIssue1112_RemoteFetchSessions_RoutesViaListJSON guards the wire shape:
+// the remote status RPC must be `agent-deck list --json`. If we ever
+// regress this argv (e.g., introduce a `list -o json` flavor that the
+// older remote binary doesn't grok), every status read silently fails and
+// the icon stays stuck.
+func TestIssue1112_RemoteFetchSessions_RoutesViaListJSON(t *testing.T) {
+	payload := jsonListResponse([]struct{ ID, Title, Status string }{
+		{ID: "x", Title: "x", Status: "waiting"},
+	})
+	runner, lastArgs := stubbedRunner(payload)
+	if _, err := runner.FetchSessions(context.Background()); err != nil {
+		t.Fatalf("FetchSessions: %v", err)
+	}
+	got := strings.Join(*lastArgs, " ")
+	want := "list --json"
+	if got != want {
+		t.Errorf("ssh argv = %q, want %q — the status RPC must use the list --json wire form", got, want)
+	}
+}
+
+// TestIssue1112_RemoteFetchSessions_FieldsRoundTrip verifies the full
+// RemoteSessionInfo shape survives JSON unmarshal — Title, Path, Tool,
+// Group all matter for downstream rendering (#1066 was the cautionary
+// tale: Tool dropped → render fell back to generic).
+func TestIssue1112_RemoteFetchSessions_FieldsRoundTrip(t *testing.T) {
+	body := `[{"id":"abc","title":"My Claude","path":"/work/x","group":"main","tool":"claude","status":"waiting","created_at":"2026-05-21T10:00:00Z"}]`
+	runner := &SSHRunner{
+		Host:          "test-host",
+		AgentDeckPath: "/usr/local/bin/agent-deck",
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			return []byte(body), nil
+		},
+	}
+	sessions, err := runner.FetchSessions(context.Background())
+	if err != nil {
+		t.Fatalf("FetchSessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("len(sessions)=%d, want 1", len(sessions))
+	}
+	s := sessions[0]
+	if s.ID != "abc" || s.Title != "My Claude" || s.Path != "/work/x" ||
+		s.Group != "main" || s.Tool != "claude" || s.Status != "waiting" {
+		t.Errorf("RemoteSessionInfo fields not round-tripped: %+v", s)
+	}
+}
+
+// TestIssue1112_RemoteFetchSessions_EmptyListIsNotAnError covers the boundary
+// case the remote reports when no sessions exist. The runner used to err on
+// the non-JSON banner ("No sessions found in profile '...'."); now it must
+// return an empty slice with no error so the icon-update loop can clear
+// stale entries without surfacing a bogus error to the user.
+func TestIssue1112_RemoteFetchSessions_EmptyListIsNotAnError(t *testing.T) {
+	runner := &SSHRunner{
+		Host:          "test-host",
+		AgentDeckPath: "/usr/local/bin/agent-deck",
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			return []byte("No sessions found in profile 'default'.\n"), nil
+		},
+	}
+	sessions, err := runner.FetchSessions(context.Background())
+	if err != nil {
+		t.Fatalf("FetchSessions on empty remote: unexpected error %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("len(sessions)=%d, want 0", len(sessions))
+	}
+}

--- a/internal/session/remote_keysender.go
+++ b/internal/session/remote_keysender.go
@@ -2,7 +2,9 @@ package session
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 )
@@ -104,5 +106,98 @@ func (r *RemoteKeySender) Close() error {
 	r.mu.Lock()
 	r.closed = true
 	r.mu.Unlock()
+	return nil
+}
+
+// StreamingRemoteKeySender amortizes the per-keystroke ssh fork+exec cost
+// (#1112 bug 2) across an entire insert-mode session by holding one
+// long-running `ssh ... agent-deck session send-keys <id> --stream`
+// subprocess open. Each Send writes one line to that subprocess's stdin
+// — sub-millisecond regardless of network RTT, because the SSH transport
+// is already negotiated.
+//
+// Wire protocol (matches cmd/agent-deck/session_send_keys_cmd.go's
+// runSendKeysStream):
+//
+//	T <hex-text>\n   — SendKeys(decode(<hex-text>))
+//	N <name>\n       — SendNamedKey(<name>)
+//	E\n              — SendEnter()
+//
+// Hex encoding for text means newlines/NULL/non-printables round-trip
+// safely without escape-sequence gymnastics.
+type StreamingRemoteKeySender struct {
+	stdin   io.WriteCloser
+	closeFn func() error
+
+	mu     sync.Mutex
+	closed bool
+}
+
+// OpenStreamingRemoteKeySender spawns the persistent SSH stream and
+// returns a sender ready to dispatch. Falls back to a per-call
+// RemoteKeySender if the stream can't open (caller can check via
+// errors.Is — the streaming type implements the same insertKeySender
+// interface as RemoteKeySender).
+func OpenStreamingRemoteKeySender(runner *SSHRunner, sessionID string, ctx context.Context) (*StreamingRemoteKeySender, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	stdin, closeFn, err := runner.OpenStream(ctx, "session", "send-keys", sessionID, "--stream")
+	if err != nil {
+		return nil, fmt.Errorf("open stream: %w", err)
+	}
+	return &StreamingRemoteKeySender{stdin: stdin, closeFn: closeFn}, nil
+}
+
+// SendKeys writes a "T <hex>\n" line to the persistent stream. Empty
+// text is a no-op (matches RemoteKeySender).
+func (s *StreamingRemoteKeySender) SendKeys(text string) error {
+	if text == "" {
+		return nil
+	}
+	return s.write("T " + hex.EncodeToString([]byte(text)) + "\n")
+}
+
+// SendNamedKey writes "N <key>\n" to the stream. Empty key fails fast.
+func (s *StreamingRemoteKeySender) SendNamedKey(key string) error {
+	if strings.TrimSpace(key) == "" {
+		return fmt.Errorf("streaming remote keysender: empty named key")
+	}
+	if strings.ContainsRune(key, '\n') {
+		return fmt.Errorf("streaming remote keysender: named key must not contain newline")
+	}
+	return s.write("N " + key + "\n")
+}
+
+// SendEnter writes "E\n" to the stream.
+func (s *StreamingRemoteKeySender) SendEnter() error {
+	return s.write("E\n")
+}
+
+func (s *StreamingRemoteKeySender) write(line string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return fmt.Errorf("streaming remote keysender: closed")
+	}
+	if _, err := io.WriteString(s.stdin, line); err != nil {
+		return fmt.Errorf("streaming remote keysender: write: %w", err)
+	}
+	return nil
+}
+
+// Close terminates the persistent stream. Idempotent.
+func (s *StreamingRemoteKeySender) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	closeFn := s.closeFn
+	s.mu.Unlock()
+	if closeFn != nil {
+		return closeFn()
+	}
 	return nil
 }

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -37,6 +37,10 @@ type SSHRunner struct {
 
 	// runFn lets tests stub out command execution. nil = real SSH.
 	runFn func(ctx context.Context, args ...string) ([]byte, error)
+
+	// openStreamFn lets tests stub out the persistent-stream subprocess
+	// without spawning real ssh. nil = real SSH (#1112 bug 2).
+	openStreamFn func(ctx context.Context, args ...string) (io.WriteCloser, func() error, error)
 }
 
 // NewSSHRunner creates an SSHRunner from a RemoteConfig.
@@ -53,6 +57,58 @@ func (r *SSHRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	return r.run(timeoutCtx, args...)
+}
+
+// OpenStream spawns a single long-running remote `agent-deck <args...>`
+// subprocess over SSH and returns its stdin pipe + a close function that
+// terminates the subprocess. Used by #1112 bug 2's persistent insert-mode
+// stream so 100 keystrokes amortize to one ssh fork+exec instead of 100.
+//
+// The returned WriteCloser is goroutine-safe at the OS pipe layer; the
+// caller is responsible for serializing if it needs message-level
+// ordering (RemoteKeySender does this with its own mutex).
+func (r *SSHRunner) OpenStream(ctx context.Context, args ...string) (io.WriteCloser, func() error, error) {
+	if r.openStreamFn != nil {
+		return r.openStreamFn(ctx, args...)
+	}
+	_ = os.MkdirAll(sshControlDir, 0700)
+
+	remoteCmd := r.buildRemoteCommand(args...)
+	sshArgs := []string{
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=" + sshControlDir + "/%r@%h:%p",
+		"-o", "ControlPersist=600",
+		"-o", "ConnectTimeout=10",
+		"-o", "BatchMode=yes",
+		r.Host,
+		remoteCmd,
+	}
+
+	cmd := exec.CommandContext(ctx, "ssh", sshArgs...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("stream stdin pipe: %w", err)
+	}
+	// Drop the subprocess's stdout/stderr — `--stream` mode prints nothing
+	// on success, and surfacing partial errors would require parsing the
+	// CLIOutput JSON. Failures already surface via the stdin write erroring
+	// when the remote exits.
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return nil, nil, fmt.Errorf("stream start: %w", err)
+	}
+	closeFn := func() error {
+		_ = stdin.Close()
+		if cmd.Process != nil {
+			// stdin close should make the remote loop exit; kill as backstop.
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+		return nil
+	}
+	return stdin, closeFn, nil
 }
 
 // run executes an agent-deck command on the remote host using the provided context directly.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4385,6 +4385,12 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.remoteCostsMu.Lock()
 		h.remoteCosts = msg.costs
 		h.remoteCostsMu.Unlock()
+		// #1112 bug 1: a remote running→waiting transition wouldn't update
+		// the header pill ("[◐ Waiting N]") because countSessionStatuses
+		// caches for 500ms. The row icon updated (read from the map
+		// directly), but the pill froze on the previous fetch's totals.
+		// Invalidate so the next View() recomputes.
+		h.cachedStatusCounts.valid.Store(false)
 		h.rebuildFlatItems()
 		return h, nil
 

--- a/internal/ui/insert_keysender.go
+++ b/internal/ui/insert_keysender.go
@@ -65,6 +65,13 @@ func defaultInsertOpenKeySender(target insertTargetRef) (insertKeySender, error)
 // RemoteKeySender bound to (remoteName, sessionID). Separated out so the
 // configuration-load + runner construction is unit-testable without
 // touching the UI.
+//
+// #1112 bug 2: prefers the streaming RemoteKeySender (one persistent
+// `ssh ... agent-deck session send-keys --stream` subprocess for the
+// entire insert-mode session) over the per-call variant. If the stream
+// fails to open (older remote agent-deck without --stream support, ssh
+// transient error), falls back to the per-call sender so the feature
+// still works — just slower.
 func openRemoteInsertKeySender(remoteName, sessionID string) (insertKeySender, error) {
 	config, err := session.LoadUserConfig()
 	if err != nil {
@@ -78,5 +85,8 @@ func openRemoteInsertKeySender(remoteName, sessionID string) (insertKeySender, e
 		return nil, errInsertNoRemoteConfig
 	}
 	runner := session.NewSSHRunner(remoteName, rc)
+	if streamer, err := session.OpenStreamingRemoteKeySender(runner, sessionID, context.Background()); err == nil {
+		return streamer, nil
+	}
 	return session.NewRemoteKeySender(runner, sessionID, context.Background()), nil
 }

--- a/internal/ui/issue1112_insert_remote_keys_test.go
+++ b/internal/ui/issue1112_insert_remote_keys_test.go
@@ -1,0 +1,164 @@
+// Issue #1112 — bug 3 (by @ddorman-dn on v1.9.24): arrow keys + Enter
+// for menu navigation in insert mode work for local sessions but appear
+// broken on REMOTE. Wire-level tests live in
+// internal/session/issue1112_insert_remote_named_keys_test.go; these
+// UI-level tests bind the TUI keypress → insertKeySender dispatch path
+// for a remote target so a regression in the insert_mode.go switch
+// (e.g., a stray return or a missing case) fails loudly here.
+
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// remoteCapturingSender records every dispatch for assertion.
+type remoteCapturingSender struct {
+	texts  []string
+	named  []string
+	enters int
+	closed bool
+}
+
+func (r *remoteCapturingSender) SendKeys(text string) error {
+	r.texts = append(r.texts, text)
+	return nil
+}
+func (r *remoteCapturingSender) SendNamedKey(key string) error {
+	r.named = append(r.named, key)
+	return nil
+}
+func (r *remoteCapturingSender) SendEnter() error {
+	r.enters++
+	return nil
+}
+func (r *remoteCapturingSender) Close() error {
+	r.closed = true
+	return nil
+}
+
+// armRemoteInsertMode wires Home with a single REMOTE session as the
+// cursor target and stubs the keysender opener to return a capturing
+// fake. After this returns, Home is in insert mode against the remote.
+func armRemoteInsertMode(t *testing.T) (*Home, *remoteCapturingSender) {
+	t.Helper()
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	const remoteName = "dev"
+	rs := session.RemoteSessionInfo{
+		ID: "r1", Title: "claude-remote", Tool: "claude",
+		Status: "waiting", RemoteName: remoteName,
+	}
+	home.remoteSessionsMu.Lock()
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		remoteName: {rs},
+	}
+	home.remoteSessionsMu.Unlock()
+	home.rebuildFlatItems()
+
+	// Move cursor to the remote session row (after the group header).
+	for i, item := range home.flatItems {
+		if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil &&
+			item.RemoteSession.ID == "r1" {
+			home.cursor = i
+			break
+		}
+	}
+
+	fake := &remoteCapturingSender{}
+	home.insertOpenKeySender = func(target insertTargetRef) (insertKeySender, error) {
+		if !target.isRemote() {
+			t.Fatalf("test setup: opener called with non-remote target (%+v)", target)
+		}
+		return fake, nil
+	}
+	home.insertKeySink = nil
+	home.insertNamedKeySink = nil
+
+	// Press `I` to enter insert mode.
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'I'}})
+	home = model.(*Home)
+	if !home.insertMode {
+		t.Fatal("test setup: failed to enter insert mode on remote target")
+	}
+	if home.insertModeRemoteName != remoteName {
+		t.Fatalf("test setup: remote name = %q, want %q", home.insertModeRemoteName, remoteName)
+	}
+	return home, fake
+}
+
+// TestIssue1112_RemoteInsertMode_ArrowKeysDispatch verifies the four
+// arrow keys reach SendNamedKey on a remote target — the bug 3 happy
+// path. If a future refactor drops the remote branch from
+// dispatchInsertNamedKey, this test catches it.
+func TestIssue1112_RemoteInsertMode_ArrowKeysDispatch(t *testing.T) {
+	cases := []struct {
+		key  tea.KeyType
+		want string
+	}{
+		{tea.KeyUp, "Up"},
+		{tea.KeyDown, "Down"},
+		{tea.KeyLeft, "Left"},
+		{tea.KeyRight, "Right"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			home, fake := armRemoteInsertMode(t)
+			model, _ := home.Update(tea.KeyMsg{Type: tc.key})
+			_ = model.(*Home)
+			if len(fake.named) != 1 || fake.named[0] != tc.want {
+				t.Errorf("dispatched named keys = %v, want [%q] (#1112 bug 3)", fake.named, tc.want)
+			}
+		})
+	}
+}
+
+// TestIssue1112_RemoteInsertMode_EnterDispatches verifies pressing Enter
+// while in remote insert mode goes through SendEnter (not SendKeys
+// "\n", not SendNamedKey "Enter") — the remote-side handler counts on
+// the discrete --enter verb for the bracketed-paste flush.
+func TestIssue1112_RemoteInsertMode_EnterDispatches(t *testing.T) {
+	home, fake := armRemoteInsertMode(t)
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	_ = model.(*Home)
+	if fake.enters != 1 {
+		t.Errorf("SendEnter calls = %d, want 1 (#1112 bug 3)", fake.enters)
+	}
+	if len(fake.named) != 0 {
+		t.Errorf("Enter must not dispatch as a named key; got named=%v", fake.named)
+	}
+}
+
+// TestIssue1112_RemoteInsertMode_TabDispatches verifies Tab goes through
+// the named-key path with the tmux name "Tab" (not the literal "\t").
+func TestIssue1112_RemoteInsertMode_TabDispatches(t *testing.T) {
+	home, fake := armRemoteInsertMode(t)
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyTab})
+	_ = model.(*Home)
+	if len(fake.named) != 1 || fake.named[0] != "Tab" {
+		t.Errorf("Tab dispatched as %v, want [Tab]", fake.named)
+	}
+}
+
+// TestIssue1112_RemoteInsertMode_FullMenuNavSequence simulates a real
+// user picking the third item in a picker: Down, Down, Enter. All three
+// dispatches must land in order on the remote sender.
+func TestIssue1112_RemoteInsertMode_FullMenuNavSequence(t *testing.T) {
+	home, fake := armRemoteInsertMode(t)
+	for _, key := range []tea.KeyType{tea.KeyDown, tea.KeyDown, tea.KeyEnter} {
+		model, _ := home.Update(tea.KeyMsg{Type: key})
+		home = model.(*Home)
+	}
+	if got := fake.named; len(got) != 2 || got[0] != "Down" || got[1] != "Down" {
+		t.Errorf("named = %v, want [Down Down]", got)
+	}
+	if fake.enters != 1 {
+		t.Errorf("enters = %d, want 1", fake.enters)
+	}
+}

--- a/internal/ui/issue1112_remote_waiting_status_test.go
+++ b/internal/ui/issue1112_remote_waiting_status_test.go
@@ -1,0 +1,127 @@
+// Issue #1112 — bug 1 (by @ddorman-dn on v1.9.24): the remote "waiting for
+// input" icon doesn't refresh in the local TUI when the remote session
+// transitions running → waiting. The root cause is in
+// `case remoteSessionsFetchedMsg:` (home.go:4377): the handler swapped
+// `h.remoteSessions` for the new map but never invalidated the 500ms
+// cached status counters, so the header pill "[◐ Waiting N]" kept
+// rendering the pre-fetch count. The row icon (read directly from the
+// map) updated on the next View, but the pill froze.
+//
+// The fix: invalidate `cachedStatusCounts` whenever the remote fetch
+// publishes a new map. Test below pumps a remoteSessionsFetchedMsg into
+// the handler and asserts the counter recomputes.
+
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestIssue1112_RemoteFetchMsg_InvalidatesStatusCounterCache reproduces the
+// stale-pill symptom: fetch #1 populates the cache with one "running"
+// remote; fetch #2 publishes the same remote as "waiting" but with the
+// cache still valid (well within the 500ms window). countSessionStatuses
+// MUST observe the new waiting status — if it returns the pre-fetch
+// running=1 / waiting=0, the user sees the wrong header pill.
+func TestIssue1112_RemoteFetchMsg_InvalidatesStatusCounterCache(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.refreshSessionRenderSnapshot(nil)
+
+	// Seed: one remote, status=running.
+	home.remoteSessionsMu.Lock()
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev": {{ID: "r1", Title: "p", Tool: "claude", Status: "running", RemoteName: "dev"}},
+	}
+	home.remoteSessionsMu.Unlock()
+	home.cachedStatusCounts.valid.Store(false)
+	running, waiting, _, _, _ := home.countSessionStatuses()
+	if running != 1 || waiting != 0 {
+		t.Fatalf("seed counts: running=%d waiting=%d, want 1/0", running, waiting)
+	}
+
+	// Cache is now valid for 500ms. Simulate a remote fetch landing with
+	// the same session reporting waiting. Without the cache-invalidation
+	// fix the counters return stale running=1.
+	newSessions := map[string][]session.RemoteSessionInfo{
+		"dev": {{ID: "r1", Title: "p", Tool: "claude", Status: "waiting", RemoteName: "dev"}},
+	}
+	model, _ := home.Update(remoteSessionsFetchedMsg{sessions: newSessions})
+	home = model.(*Home)
+
+	running, waiting, _, _, _ = home.countSessionStatuses()
+	if running != 0 {
+		t.Errorf("running=%d, want 0 — remote fetch must invalidate the cache (#1112 bug 1)", running)
+	}
+	if waiting != 1 {
+		t.Errorf("waiting=%d, want 1 — the new waiting state must surface immediately (#1112 bug 1)", waiting)
+	}
+}
+
+// TestIssue1112_RemoteFetchMsg_ZeroSessionsClearsStaleCounts covers the
+// "remote went away" failure mode: a remote that previously had a
+// running claude is now empty (claude killed, machine offline, etc).
+// The header pill must drop the count rather than show a phantom
+// running session.
+func TestIssue1112_RemoteFetchMsg_ZeroSessionsClearsStaleCounts(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.refreshSessionRenderSnapshot(nil)
+
+	home.remoteSessionsMu.Lock()
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev": {{ID: "r1", Title: "p", Tool: "claude", Status: "running", RemoteName: "dev"}},
+	}
+	home.remoteSessionsMu.Unlock()
+	home.cachedStatusCounts.valid.Store(false)
+	_, _, _, _, _ = home.countSessionStatuses()
+
+	// Remote fetch lands with empty session list.
+	model, _ := home.Update(remoteSessionsFetchedMsg{sessions: map[string][]session.RemoteSessionInfo{}})
+	home = model.(*Home)
+
+	running, waiting, _, _, _ := home.countSessionStatuses()
+	if running != 0 || waiting != 0 {
+		t.Errorf("after empty fetch: running=%d waiting=%d, want 0/0 — counter must drop entries (#1112 bug 1)", running, waiting)
+	}
+}
+
+// TestIssue1112_RemoteFetchMsg_ConcurrentLocalChangeStillReflected guards
+// the boundary where a local session status update happens in the same
+// tick as a remote fetch. Both must show; neither must mask the other.
+func TestIssue1112_RemoteFetchMsg_ConcurrentLocalChangeStillReflected(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.refreshSessionRenderSnapshot(nil)
+
+	// Remote: one waiting session.
+	model, _ := home.Update(remoteSessionsFetchedMsg{
+		sessions: map[string][]session.RemoteSessionInfo{
+			"dev": {{ID: "r1", Title: "p", Tool: "claude", Status: "waiting", RemoteName: "dev"}},
+		},
+	})
+	home = model.(*Home)
+	// Ensure the cache window is fresh so the next call returns cached if not invalidated.
+	home.cachedStatusCounts.timestamp = time.Now()
+	home.cachedStatusCounts.valid.Store(true)
+
+	// A second remote fetch arrives reporting same session still waiting —
+	// the counter must remain at waiting=1, never flicker to 0.
+	model, _ = home.Update(remoteSessionsFetchedMsg{
+		sessions: map[string][]session.RemoteSessionInfo{
+			"dev": {{ID: "r1", Title: "p", Tool: "claude", Status: "waiting", RemoteName: "dev"}},
+		},
+	})
+	home = model.(*Home)
+
+	_, waiting, _, _, _ := home.countSessionStatuses()
+	if waiting != 1 {
+		t.Errorf("waiting=%d, want 1 — back-to-back fetches must not drop the waiting state", waiting)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1112. Bug cluster reported by @ddorman-dn on v1.9.24, four sub-issues:

1. **Remote waiting-status icon didn't refresh.** `remoteSessionsFetchedMsg` updated the session map but never invalidated `cachedStatusCounts.valid`, so the header pill counter froze on pre-fetch totals for up to 500ms after every fetch. One-line fix in `internal/ui/home.go`; tests bind JSON propagation + cache invalidation.

2. **Direct type STILL slow on remote.** #1102/#1110 made local insert mode fast, but remote keystrokes still paid one ssh fork+exec each. Added `StreamingRemoteKeySender` which opens ONE persistent `ssh ... agent-deck session send-keys <id> --stream` subprocess and writes one stdin line per keystroke (T `<hex>` / N `<key>` / E). The matching `--stream` CLI flag reads the protocol and dispatches via existing `tmux.Session` helpers. `openRemoteInsertKeySender` prefers the streaming variant; falls back to per-call `RemoteKeySender` if the stream can't open. Perf test asserts 1 subprocess for 100 keys and <500ms total.

3. **Arrow keys + Enter on remote.** Wire-level tests bind every menu-nav key (Up/Down/Left/Right/Tab/BTab/Enter) through the remote SSH argv shape. UI-level tests bind the bubbletea keypress → `insertKeySender` dispatch for a remote target. Catches any future regression that drops a key from `handleInsertModeKey` or skips the remote branch in `dispatchInsertNamedKey`.

4. **Ctrl+Q in iTerm tab.** Documented as expected behavior. New `docs/terminal-shortcuts.md` explains iTerm2 binds `Ctrl-Q` at the terminal layer so the keystroke never reaches tmux. Suggests remapping iTerm's `Ctrl-Q`, switching to Terminal.app, or using the TUI's `q`/`Esc`. No code change.

## Surfaces covered (per `agent-deck-tdd-feature` SKILL)

- **TUI** (`internal/ui/`):
  - `issue1112_remote_waiting_status_test.go` — cache-invalidation regression (happy path + zero-sessions failure mode + back-to-back fetch boundary).
  - `issue1112_insert_remote_keys_test.go` — keypress→sender for arrows / Enter / Tab / multi-key sequence.
- **CLI** (`cmd/agent-deck/`):
  - `issue1112_send_keys_stream_test.go` — stream parser happy path, unknown-verb forward-compat, binary-safe hex round-trip, invalid-hex error, dispatch-error propagation, 1000-line throughput.
- **Remote** (`internal/session/`):
  - `issue1112_remote_waiting_status_test.go` — JSON propagation for every status + wire-shape assertion + empty-list boundary.
  - `issue1112_insert_remote_named_keys_test.go` — every arrow / Tab / Enter / multi-key sequence at the SSH argv layer.
  - `issue1112_insert_perf_test.go` — one subprocess for 100 keys, 500ms budget, wire-format equality with the CLI parser, binary-safe text, close-stops-dispatch, open-error propagation, newline-rejection.
- **Persistence**: not touched; no schema added or migrated.
- **Cross-platform**: stream layer uses `io.Reader` / `exec.CommandContext`; no OS-specific paths.

## Test plan

- [x] `go test -race -count=1 ./internal/session/... ./internal/ui/... ./cmd/agent-deck/...` (all green; ran via pre-push hook).
- [x] `go test -race -count=1 -run TestPersistence_ ./internal/session/...` (mandated by CLAUDE.md).
- [x] `go test -race -count=1 -run 'Feedback|Sender_' ./internal/feedback/... ./internal/ui/... ./cmd/agent-deck/...` (mandated).
- [x] `go test -tags eval_smoke ./tests/eval/...` (mandated for user-observable changes).
- [x] `gofmt -l .` clean.
- [x] `go vet ./...` clean.
- [ ] Manual: attach to a remote agent-deck session and verify (a) waiting icon flips within one fetch tick, (b) arrow keys navigate Claude's pickers, (c) typing latency feels local (was 100ms+/key before).

Credit: @ddorman-dn for filing the cluster against v1.9.24.

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming keystroke dispatch mode for remote sessions, enabling more efficient transmission of multiple keystrokes.
  * Optimized remote key sender to reduce SSH overhead by maintaining persistent connections instead of creating new ones per keystroke.

* **Bug Fixes**
  * Fixed status counter cache invalidation to ensure remote session status changes (e.g., running → waiting) are immediately reflected in the UI header.

* **Tests**
  * Added extensive regression test coverage for streaming keystroke dispatch, including performance benchmarks and wire protocol validation.
  * Added tests for remote key dispatch operations (arrow keys, Enter, Tab) and session status tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->