### PR TITLE
feat(web): Children panel for conductor sessions (closes Children panel stub)

### DIFF
--- a/internal/web/handlers_children.go
+++ b/internal/web/handlers_children.go
@@ -1,0 +1,106 @@
+package web
+
+// Web UI Children-panel handler.
+//
+// Surfaces the conductor → child session topology that the TUI shows
+// natively (internal/ui Home pane indents children under their parent).
+// Before this endpoint, the Web UI right-rail "Children (conductor)"
+// card was an empty stub — see PARITY_MATRIX.md state-fields section.
+//
+// Tree is built from the same MenuSnapshot the menu/session list uses,
+// so child status / hook refresh stay consistent with the rest of the
+// web view.
+
+import (
+	"net/http"
+	"strings"
+)
+
+// SessionChildNode is one node in the children-tree response. It inlines
+// the standard MenuSession fields and adds a recursive `children` array.
+// `children` is always non-nil — even leaves render as `"children":[]` so
+// JS consumers don't have to null-check.
+type SessionChildNode struct {
+	*MenuSession
+	Children []*SessionChildNode `json:"children"`
+}
+
+// SessionChildrenResponse is the body of GET /api/sessions/{id}/children.
+type SessionChildrenResponse struct {
+	SessionID string              `json:"sessionId"`
+	Children  []*SessionChildNode `json:"children"`
+}
+
+// handleSessionChildren serves GET /api/sessions/{id}/children. Non-GET
+// returns 405. Unknown session id returns 404. A session with no
+// descendants (whether or not it is a conductor) returns 200 with
+// `"children":[]` — this is intentional, so the UI can ask any session
+// for its tree without special-casing non-conductors.
+func (s *Server) handleSessionChildren(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if r.Method != http.MethodGet {
+		writeAPIError(w, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	snapshot, err := s.menuData.LoadMenuSnapshot()
+	if err != nil || snapshot == nil {
+		writeAPIError(w, http.StatusInternalServerError, ErrCodeInternalError, "failed to load session data")
+		return
+	}
+
+	// Index sessions by id and build parent→[child ids] adjacency.
+	byID := make(map[string]*MenuSession, len(snapshot.Items))
+	kids := make(map[string][]string)
+	for _, item := range snapshot.Items {
+		if item.Type != MenuItemTypeSession || item.Session == nil {
+			continue
+		}
+		byID[item.Session.ID] = item.Session
+		if item.Session.ParentSessionID != "" {
+			kids[item.Session.ParentSessionID] = append(
+				kids[item.Session.ParentSessionID], item.Session.ID)
+		}
+	}
+
+	if _, ok := byID[sessionID]; !ok {
+		writeAPIError(w, http.StatusNotFound, ErrCodeNotFound, "session not found")
+		return
+	}
+
+	// DFS with a visited set — defends against corrupt snapshots that
+	// contain a cycle (a→b→a). Without this guard the recursion would
+	// run forever; the test TestSessionChildren_CycleSafe locks the
+	// invariant in.
+	visited := make(map[string]bool, len(byID))
+	var build func(id string) []*SessionChildNode
+	build = func(id string) []*SessionChildNode {
+		children := kids[id]
+		out := make([]*SessionChildNode, 0, len(children))
+		for _, cid := range children {
+			if visited[cid] {
+				continue
+			}
+			visited[cid] = true
+			node := &SessionChildNode{
+				MenuSession: byID[cid],
+				Children:    build(cid),
+			}
+			out = append(out, node)
+		}
+		return out
+	}
+	visited[sessionID] = true
+
+	writeJSON(w, http.StatusOK, SessionChildrenResponse{
+		SessionID: sessionID,
+		Children:  build(sessionID),
+	})
+}
+
+// childrenSubpathFromAction returns true if the action suffix from
+// handleSessionByAction is the "children" route, optionally with empty
+// trailing path. Kept here so the routing match in handlers_sessions.go
+// stays alongside its handler.
+func isChildrenAction(action string) bool {
+	return action == "children" || strings.HasPrefix(action, "children/")
+}

--- a/internal/web/handlers_sessions.go
+++ b/internal/web/handlers_sessions.go
@@ -110,6 +110,12 @@ func (s *Server) handleSessionByAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Children sub-route: GET /api/sessions/{id}/children
+	if isChildrenAction(action) {
+		s.handleSessionChildren(w, r, sessionID)
+		return
+	}
+
 	// DELETE /api/sessions/{id}
 	if r.Method == http.MethodDelete && action == "" {
 		if !s.checkMutationsAllowed(w) {

--- a/internal/web/issue1125_children_web_test.go
+++ b/internal/web/issue1125_children_web_test.go
@@ -1,0 +1,267 @@
+package web
+
+// issue1125_children_web_test.go — coverage for the
+// GET /api/sessions/{id}/children endpoint added in PR
+// "feat(web): Children panel for conductor sessions".
+//
+// Per agent-deck-tdd-feature SKILL.md: happy / failure / boundary case per
+// surface. This file covers the Go handler surface; the corresponding
+// browser-driven coverage is in tests/web/e2e/children-panel.spec.js.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Build a snapshot that mimics a conductor session with two direct children
+// and one grandchild via a nested conductor (boundary: deep nesting).
+//
+//	conductor-x (sess-cond)
+//	  ├── child-a   (sess-a, claude)
+//	  ├── child-b   (sess-b, conductor)
+//	  │     └── grandchild-b1 (sess-b1, claude)
+//
+//	standalone (sess-solo) — no parent, no children
+func childrenFixtureSnapshot() *MenuSnapshot {
+	mk := func(id, title, parent string) MenuItem {
+		return MenuItem{
+			Type: MenuItemTypeSession,
+			Session: &MenuSession{
+				ID:              id,
+				Title:           title,
+				ParentSessionID: parent,
+				Status:          session.StatusRunning,
+				Tool:            "claude",
+			},
+		}
+	}
+	return &MenuSnapshot{
+		Profile: "test",
+		Items: []MenuItem{
+			mk("sess-cond", "conductor-x", ""),
+			mk("sess-a", "child-a", "sess-cond"),
+			mk("sess-b", "child-b", "sess-cond"),
+			mk("sess-b1", "grandchild-b1", "sess-b"),
+			mk("sess-solo", "standalone", ""),
+		},
+	}
+}
+
+func newChildrenTestServer(snapshot *MenuSnapshot) *Server {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", Profile: "test"})
+	srv.menuData = &fakeMenuDataLoader{snapshot: snapshot}
+	return srv
+}
+
+type childNodeJSON struct {
+	ID       string           `json:"id"`
+	Title    string           `json:"title"`
+	Children []*childNodeJSON `json:"children"`
+}
+
+type childrenRespJSON struct {
+	SessionID string           `json:"sessionId"`
+	Children  []*childNodeJSON `json:"children"`
+}
+
+func getChildren(t *testing.T, srv *Server, sessionID string) (*httptest.ResponseRecorder, *childrenRespJSON) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/"+sessionID+"/children", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		return rr, nil
+	}
+	var body childrenRespJSON
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode children response: %v\nbody=%s", err, rr.Body.String())
+	}
+	return rr, &body
+}
+
+// Happy path — a conductor with two direct children returns a tree with two
+// nodes at the top level.
+func TestSessionChildren_HappyPath_TwoDirectChildren(t *testing.T) {
+	srv := newChildrenTestServer(childrenFixtureSnapshot())
+
+	rr, body := getChildren(t, srv, "sess-cond")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if body.SessionID != "sess-cond" {
+		t.Errorf("sessionId = %q, want sess-cond", body.SessionID)
+	}
+	if len(body.Children) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(body.Children))
+	}
+	ids := []string{body.Children[0].ID, body.Children[1].ID}
+	gotA, gotB := false, false
+	for _, id := range ids {
+		switch id {
+		case "sess-a":
+			gotA = true
+		case "sess-b":
+			gotB = true
+		}
+	}
+	if !gotA || !gotB {
+		t.Errorf("expected children {sess-a, sess-b}, got %v", ids)
+	}
+}
+
+// Boundary — deep nesting (conductor → conductor → claude) renders
+// recursively. The grandchild MUST appear under its parent, not at the
+// top level.
+func TestSessionChildren_Boundary_DeepNesting(t *testing.T) {
+	srv := newChildrenTestServer(childrenFixtureSnapshot())
+
+	_, body := getChildren(t, srv, "sess-cond")
+	if body == nil {
+		t.Fatal("nil body")
+	}
+
+	var bNode *childNodeJSON
+	for _, c := range body.Children {
+		if c.ID == "sess-b" {
+			bNode = c
+			break
+		}
+	}
+	if bNode == nil {
+		t.Fatal("sess-b child node missing")
+	}
+	if len(bNode.Children) != 1 {
+		t.Fatalf("expected 1 grandchild under sess-b, got %d", len(bNode.Children))
+	}
+	if bNode.Children[0].ID != "sess-b1" {
+		t.Errorf("grandchild id = %q, want sess-b1", bNode.Children[0].ID)
+	}
+	// Grandchild has no further descendants — children array must be empty,
+	// not nil, so JSON consumers always see `"children":[]`.
+	if bNode.Children[0].Children == nil {
+		t.Error("leaf children must be an empty array, not nil/missing")
+	}
+}
+
+// Failure mode — a non-conductor session returns an empty children tree,
+// NOT a 404. Per prompt: "Non-conductor session → empty tree (not 404)."
+func TestSessionChildren_NonConductor_EmptyTreeNot404(t *testing.T) {
+	srv := newChildrenTestServer(childrenFixtureSnapshot())
+
+	rr, body := getChildren(t, srv, "sess-solo")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (empty tree), got %d: %s", rr.Code, rr.Body.String())
+	}
+	if body.SessionID != "sess-solo" {
+		t.Errorf("sessionId = %q, want sess-solo", body.SessionID)
+	}
+	if len(body.Children) != 0 {
+		t.Errorf("non-conductor must have 0 children, got %d", len(body.Children))
+	}
+}
+
+// Failure mode — unknown session id returns 404 with NOT_FOUND code.
+func TestSessionChildren_UnknownSession_404(t *testing.T) {
+	srv := newChildrenTestServer(childrenFixtureSnapshot())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/does-not-exist/children", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !contains(rr.Body.String(), ErrCodeNotFound) {
+		t.Errorf("expected NOT_FOUND code, got %s", rr.Body.String())
+	}
+}
+
+// Failure mode — only GET is allowed; POST/PUT/DELETE return 405.
+func TestSessionChildren_MethodNotAllowed(t *testing.T) {
+	srv := newChildrenTestServer(childrenFixtureSnapshot())
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		req := httptest.NewRequest(method, "/api/sessions/sess-cond/children", nil)
+		rr := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rr, req)
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s expected 405, got %d", method, rr.Code)
+		}
+	}
+}
+
+// Boundary — a conductor with no children returns an empty array (not nil).
+func TestSessionChildren_ConductorWithNoChildren_EmptyArray(t *testing.T) {
+	srv := newChildrenTestServer(&MenuSnapshot{
+		Profile: "test",
+		Items: []MenuItem{
+			{
+				Type: MenuItemTypeSession,
+				Session: &MenuSession{
+					ID:    "lonely-cond",
+					Title: "conductor-empty",
+				},
+			},
+		},
+	})
+
+	rr, body := getChildren(t, srv, "lonely-cond")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if body.Children == nil {
+		t.Fatal("children must be [] not nil for empty conductor")
+	}
+	// Verify the raw JSON contains "children":[] not "children":null.
+	if !contains(rr.Body.String(), `"children":[]`) {
+		t.Errorf("expected JSON to contain \"children\":[], got: %s", rr.Body.String())
+	}
+}
+
+// Boundary — cyclic parent pointers (defensive). If a corrupted snapshot
+// produces a cycle, the handler must not loop forever and must not panic.
+func TestSessionChildren_CycleSafe(t *testing.T) {
+	mk := func(id, parent string) MenuItem {
+		return MenuItem{
+			Type: MenuItemTypeSession,
+			Session: &MenuSession{
+				ID:              id,
+				Title:           id,
+				ParentSessionID: parent,
+			},
+		}
+	}
+	// a → b → a cycle (data corruption scenario).
+	srv := newChildrenTestServer(&MenuSnapshot{
+		Profile: "test",
+		Items: []MenuItem{
+			mk("a", "b"),
+			mk("b", "a"),
+		},
+	})
+
+	rr, _ := getChildren(t, srv, "a")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("cycle-safety: expected 200 (handler must not panic/timeout), got %d", rr.Code)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (haystack == needle || indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(haystack, needle string) int {
+	if len(needle) == 0 {
+		return 0
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/web/static/app/RightRail.js
+++ b/internal/web/static/app/RightRail.js
@@ -3,12 +3,24 @@
 // Cards: Overview, Usage, MCPs, Skills, Children, Events. User toggles which
 // are visible in the rail-add picker at the bottom.
 //
-// MCPs / Skills / Children / Events have no API today; they render an
-// informative "TUI-only feature" hint instead of fake data.
+// The Children card renders the conductor child-session topology. The
+// tree is built client-side from the same menuModelSignal that drives
+// the session list, so it stays in sync with SSE menu updates for free.
+// The Go endpoint at GET /api/sessions/{id}/children exposes the same
+// shape for direct API consumers and lives in handlers_children.go.
+//
+// MCPs / Skills / Events still render an informative "TUI-only" hint
+// because their underlying APIs are not yet wired through the right rail.
 import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
 import { menuModelSignal } from './dataModel.js'
 import { selectedIdSignal } from './state.js'
 import { rightRailPanelsSignal } from './uiState.js'
+
+// Module-scope signal so collapsed state survives RightRail re-mounts
+// (e.g. when the user switches between sessions and back). Keyed by
+// session id so each conductor remembers its own expanded set.
+const collapsedNodesSignal = signal({})
 
 const AVAIL_PANELS = [
   { id: 'overview', label: 'Overview' },
@@ -33,6 +45,76 @@ function Card({ title, badge, children }) {
 
 function NoData({ msg }) {
   return html`<div style="font-family: var(--mono); font-size: 11px; color: var(--muted);">${msg}</div>`
+}
+
+// Build the conductor → children adjacency map once per render. Cycles
+// (corrupt parent pointers) are broken by a visited set so the tree
+// builder cannot loop forever — mirrors the Go handler's defense.
+function buildChildrenTree(rootId, sessions) {
+  const byParent = new Map()
+  for (const s of sessions) {
+    const p = s.raw && s.raw.parentSessionId
+    if (!p) continue
+    if (!byParent.has(p)) byParent.set(p, [])
+    byParent.get(p).push(s)
+  }
+  const visited = new Set([rootId])
+  const walk = (id) => {
+    const kids = byParent.get(id) || []
+    return kids
+      .filter((k) => {
+        if (visited.has(k.id)) return false
+        visited.add(k.id)
+        return true
+      })
+      .map((k) => ({ session: k, children: walk(k.id) }))
+  }
+  return walk(rootId)
+}
+
+// Renders one node + its descendants. Leaf nodes hide the disclosure
+// triangle; non-leaf nodes show ▾/▸ and toggle via collapsedNodesSignal.
+function ChildNode({ node, depth, rootId }) {
+  const collapsed = collapsedNodesSignal.value
+  const key = rootId + ':' + node.session.id
+  const isOpen = !collapsed[key]
+  const hasKids = node.children.length > 0
+  const toggle = () => {
+    collapsedNodesSignal.value = { ...collapsed, [key]: isOpen }
+  }
+  return html`
+    <div class="child-node" data-session-id=${node.session.id} data-depth=${depth}
+         style="font-family: var(--mono); font-size: 11px; line-height: 1.7; padding-left: ${depth * 12}px;">
+      <span class="child-row" style="display: inline-flex; align-items: center; gap: 4px;">
+        <span class="child-toggle"
+              onClick=${hasKids ? toggle : null}
+              style=${`width: 10px; display: inline-block; cursor: ${hasKids ? 'pointer' : 'default'}; color: var(--muted);`}>
+          ${hasKids ? (isOpen ? '▾' : '▸') : ' '}
+        </span>
+        <span class="child-status pill" data-status=${node.session.status}
+              style="font-size: 9px; padding: 0 4px;">${node.session.status}</span>
+        <span class="child-title" style="color: var(--text-hi);">${node.session.title}</span>
+        ${node.session.tool && html`<span class="child-tool" style="color: var(--muted);">· ${node.session.tool}</span>`}
+      </span>
+      ${hasKids && isOpen && node.children.map((kid) => html`
+        <${ChildNode} key=${kid.session.id} node=${kid} depth=${depth + 1} rootId=${rootId}/>
+      `)}
+    </div>
+  `
+}
+
+function ChildrenTree({ rootId, sessions }) {
+  const tree = buildChildrenTree(rootId, sessions)
+  if (tree.length === 0) {
+    return html`<${NoData} msg="No child sessions yet."/>`
+  }
+  return html`
+    <div class="children-tree" data-children-count=${tree.length}>
+      ${tree.map((node) => html`
+        <${ChildNode} key=${node.session.id} node=${node} depth=${0} rootId=${rootId}/>
+      `)}
+    </div>
+  `
 }
 
 export function RightRail() {
@@ -104,8 +186,8 @@ export function RightRail() {
           </${Card}>
         `}
         ${panels.children && session.kind === 'conductor' && html`
-          <${Card} title="CHILDREN">
-            <${NoData} msg="Conductor child topology not exposed via web API."/>
+          <${Card} title="CHILDREN" badge="conductor">
+            <${ChildrenTree} rootId=${session.id} sessions=${sessions}/>
           </${Card}>
         `}
         ${panels.events && session.kind === 'watcher' && html`

--- a/tests/web/PARITY_MATRIX.md
+++ b/tests/web/PARITY_MATRIX.md
@@ -93,8 +93,8 @@ Every observable session field shown in the TUI must appear in the web API JSON 
 | `created_at` | Info section | `MenuSession.createdAt` | ✅ Present |
 | `last_accessed_at` | Info section | `MenuSession.lastAccessedAt` | ✅ Present |
 | **RELATIONSHIPS** |
-| `parent_session_id` | Sub-session indicator | `MenuSession.parentSessionId` | ✅ Present |
-| `is_conductor` | (Not shown in TUI) | MISSING | Conductor metadata |
+| `parent_session_id` | Sub-session indicator | `MenuSession.parentSessionId` + `GET /api/sessions/{id}/children` | ✅ Present; tree endpoint surfaces full conductor child topology in the right-rail Children card (`internal/web/handlers_children.go`, `tests/web/e2e/children-panel.spec.js`) |
+| `is_conductor` | (Not shown in TUI) | MISSING | Conductor metadata; tree exposure now lives at `GET /api/sessions/{id}/children` (kind derived UI-side from title/groupPath in `dataModel.js`) |
 | **PROCESS STATE** |
 | `tmux_session` | Internal reference | `MenuSession.tmuxSession` | ✅ Present (tmux session name) |
 | `tmux_socket_name` | (Internal) | `MenuSession.tmuxSocketName` | ✅ Present; issue #687 |

--- a/tests/web/e2e/children-panel.spec.js
+++ b/tests/web/e2e/children-panel.spec.js
@@ -1,0 +1,184 @@
+// e2e/children-panel.spec.js -- Children-panel parity coverage.
+//
+// Closes the "Conductor child topology not exposed via web API" stub in
+// the right rail. The Go handler ships in internal/web/handlers_children.go
+// with its own surface test (issue1125_children_web_test.go); this file
+// covers the browser-facing surface per agent-deck-tdd-feature SKILL.md:
+// happy / failure / boundary case against the live fixture web server.
+//
+// The fixture exposes no `is_conductor` flag, so we mark a session as a
+// conductor by including the literal string "conductor" in its title —
+// dataModel.js deriveKind() promotes it to kind === 'conductor', which is
+// the UI gate for showing the CHILDREN card.
+
+import { test, expect } from '@playwright/test'
+
+// Seed a parent-child topology on top of the default fixture data:
+//
+//   conductor-e2e  (created via POST /api/sessions)
+//     ├── conductor-e2e (fork)            ← direct child
+//     └── conductor-e2e (fork)            ← direct child, in turn forked
+//           └── conductor-e2e (fork) (fork) ← grandchild (deep nesting)
+//
+// Returns the session ids in an object so tests can address them.
+async function seedConductorTree(request) {
+  const reset = await request.post('/__fixture/reset')
+  expect(reset.status()).toBe(204)
+
+  const created = await request.post('/api/sessions', {
+    data: {
+      title: 'conductor-e2e',
+      tool: 'claude',
+      projectPath: '/srv/conductor-e2e',
+      groupPath: 'work',
+    },
+  })
+  expect(created.status()).toBe(201)
+  const { sessionId: conductorID } = await created.json()
+
+  const forkA = await request.post(`/api/sessions/${conductorID}/fork`)
+  expect(forkA.status()).toBe(200)
+  const { sessionId: childAID } = await forkA.json()
+
+  const forkB = await request.post(`/api/sessions/${conductorID}/fork`)
+  expect(forkB.status()).toBe(200)
+  const { sessionId: childBID } = await forkB.json()
+
+  const forkG = await request.post(`/api/sessions/${childBID}/fork`)
+  expect(forkG.status()).toBe(200)
+  const { sessionId: grandID } = await forkG.json()
+
+  return { conductorID, childAID, childBID, grandID }
+}
+
+test.describe('children endpoint: API surface', () => {
+  test.beforeEach(async ({ request }) => {
+    await request.post('/__fixture/reset')
+  })
+
+  test('GET on an unknown session returns 404', async ({ request }) => {
+    const res = await request.get('/api/sessions/does-not-exist/children')
+    expect(res.status()).toBe(404)
+  })
+
+  test('GET on a session with no children returns 200 with empty tree (not 404)', async ({ request }) => {
+    const res = await request.get('/api/sessions/sess-001/children')
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(body.sessionId).toBe('sess-001')
+    expect(Array.isArray(body.children)).toBe(true)
+    expect(body.children.length).toBe(0)
+  })
+
+  test('GET on a conductor returns nested tree with deep grandchildren', async ({ request }) => {
+    const { conductorID, childAID, childBID, grandID } = await seedConductorTree(request)
+
+    const res = await request.get(`/api/sessions/${conductorID}/children`)
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(body.sessionId).toBe(conductorID)
+    expect(body.children).toHaveLength(2)
+
+    const ids = body.children.map((c) => c.id).sort()
+    expect(ids).toEqual([childAID, childBID].sort())
+
+    // Grandchild must appear under its parent, not at the top level.
+    const bNode = body.children.find((c) => c.id === childBID)
+    expect(bNode).toBeDefined()
+    expect(bNode.children).toHaveLength(1)
+    expect(bNode.children[0].id).toBe(grandID)
+    // Leaf nodes carry an empty array, never null/undefined.
+    expect(bNode.children[0].children).toEqual([])
+  })
+
+  test('non-GET methods on /children return 405', async ({ request }) => {
+    for (const method of ['post', 'put', 'delete']) {
+      const res = await request.fetch('/api/sessions/sess-001/children', { method })
+      expect(
+        res.status(),
+        `expected 405 for ${method.toUpperCase()}, got ${res.status()}`,
+      ).toBe(405)
+    }
+  })
+})
+
+test.describe('children panel: UI rendering', () => {
+  test.beforeEach(async ({ request }) => {
+    await request.post('/__fixture/reset')
+  })
+
+  test('conductor session shows children tree in right rail', async ({ page, request }) => {
+    const { conductorID, childAID, childBID } = await seedConductorTree(request)
+
+    await page.goto(`/s/${conductorID}`)
+    // Wait for the session list to populate (SSE handshake).
+    await page.waitForSelector('.sess', { timeout: 5000 })
+    // The right rail CHILDREN card only renders when session.kind === 'conductor'.
+    // dataModel.js deriveKind() flips to 'conductor' when the title matches /conductor/i.
+    const childrenCard = page.locator('.card', { hasText: 'CHILDREN' })
+    await expect(childrenCard).toBeVisible({ timeout: 5000 })
+
+    // Both forks must appear in the tree. Use data attributes the
+    // ChildNode component emits so we are not coupled to titles or order.
+    const tree = childrenCard.locator('.children-tree')
+    await expect(tree).toBeVisible()
+    await expect(tree.locator(`[data-session-id="${childAID}"]`)).toBeVisible()
+    await expect(tree.locator(`[data-session-id="${childBID}"]`)).toBeVisible()
+  })
+
+  test('deep nesting renders grandchild beneath the right intermediate', async ({ page, request }) => {
+    const { conductorID, childBID, grandID } = await seedConductorTree(request)
+
+    await page.goto(`/s/${conductorID}`)
+    await page.waitForSelector('.sess', { timeout: 5000 })
+
+    const childrenCard = page.locator('.card', { hasText: 'CHILDREN' })
+    await expect(childrenCard).toBeVisible({ timeout: 5000 })
+
+    // Grandchild must live inside childB's subtree, not at the top level.
+    const childBNode = childrenCard.locator(`[data-session-id="${childBID}"]`)
+    const grandNode = childBNode.locator(`[data-session-id="${grandID}"]`)
+    await expect(grandNode).toBeVisible()
+
+    // Grandchild's data-depth must be greater than childB's (visual indent).
+    const childBDepth = await childBNode.first().getAttribute('data-depth')
+    const grandDepth = await grandNode.first().getAttribute('data-depth')
+    expect(Number(grandDepth)).toBeGreaterThan(Number(childBDepth))
+  })
+
+  test('non-conductor session does NOT render the children card (UI gate)', async ({ page, request }) => {
+    // sess-001 is a normal claude session — not promoted to conductor by
+    // deriveKind, so the panel must not appear even though the toggle is
+    // on by default. Visual baselines depend on this invariant.
+    await request.post('/__fixture/reset')
+    await page.goto('/s/sess-001')
+    await page.waitForSelector('.sess', { timeout: 5000 })
+    await page.waitForTimeout(200) // allow rail to settle
+
+    const childrenCard = page.locator('.card', { hasText: 'CHILDREN' })
+    await expect(childrenCard).toHaveCount(0)
+  })
+
+  test('live updates: new fork appears in the tree within ~1s', async ({ page, request }) => {
+    const { conductorID, childAID } = await seedConductorTree(request)
+
+    await page.goto(`/s/${conductorID}`)
+    await page.waitForSelector('.sess', { timeout: 5000 })
+
+    const childrenCard = page.locator('.card', { hasText: 'CHILDREN' })
+    await expect(childrenCard).toBeVisible({ timeout: 5000 })
+    const tree = childrenCard.locator('.children-tree')
+    await expect(tree.locator(`[data-session-id="${childAID}"]`)).toBeVisible()
+
+    // Create another fork — the SSE menu broadcast should re-render the
+    // panel without a manual reload. The bound is generous (~1.5s) to
+    // tolerate scheduler jitter on CI; <1s is achievable on a warm box.
+    const fork = await request.post(`/api/sessions/${conductorID}/fork`)
+    expect(fork.status()).toBe(200)
+    const { sessionId: newChildID } = await fork.json()
+
+    await expect(
+      tree.locator(`[data-session-id="${newChildID}"]`),
+    ).toBeVisible({ timeout: 1500 })
+  })
+})


### PR DESCRIPTION
Closes the right-rail "Children (conductor)" stub that read "Conductor child topology not exposed via web API." Tracked in #1125.

## Endpoint

`GET /api/sessions/{id}/children` → nested tree of child sessions built from the same `MenuSnapshot` the menu/session list uses (so child status + hook refresh stay consistent across the rest of the web view).

- Unknown session id → `404 NOT_FOUND`
- Non-conductor session → `200` with `children:[]` (per prompt: empty tree, not 404)
- Leaf nodes → `children:[]` (never null/missing — UI can iterate without null-checks)
- Non-GET → `405`
- Cycle-safe: a corrupt `parent_session_id` graph (a→b→a) cannot loop the handler

## UI

`internal/web/static/app/RightRail.js` renders a collapsible tree in the Children card (only when `session.kind === 'conductor'`, preserving existing visual baselines for non-conductor sessions). Tree is derived client-side from `menuModelSignal`, so SSE menu broadcasts re-render the tree live without manual polling.

## Surfaces covered (per `~/.agent-deck/skills/pool/agent-deck-tdd-feature/SKILL.md`)

Each applicable surface has happy / failure / boundary coverage:

| Surface | File | Cases |
|---|---|---|
| Web UI (Go handler) | `internal/web/issue1125_children_web_test.go` | 7 — happy / deep-nesting / non-conductor empty tree / unknown id / method not allowed / empty children shape / cycle-safety |
| Web UI (browser) | `tests/web/e2e/children-panel.spec.js` | 8 — API surface (4) + UI rendering, deep nesting, non-conductor UI gate, live-update via SSE |

### Surfaces not touched (with reason)

- **TUI** — already shows the tree natively in the Home pane; no behavior change here.
- **CLI** — no new flag/subcommand; conductor topology was already inspectable via `agent-deck conductor` family.
- **Remote** — `RemoteSession` exposes the same `parent_session_id` field the handler reads; no remote-specific path.
- **Persistence** — read-only consumer of existing schema (`parent_session_id` exists since v4 migration in `statedb.go`).
- **Cross-platform** — no OS-specific code paths.

## PARITY_MATRIX

State-fields RELATIONSHIPS section updated: `parent_session_id` and `is_conductor` rows now reference the tree endpoint as the web exposure path. No row count drift — `EXPECTED_STATE_ROWS` pin holds.

## PR contract checklist

- [x] Go race-detector tests green (`go test -race -count=1 -timeout 10m ./...`)
- [x] `golangci-lint run --timeout=5m --issues-exit-code=1` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities
- [x] No `home := model.(*Home)` dead-assignments
- [x] Commit signed `Committed by Ashesh Goplani`, no Claude attribution
- [x] Builds cleanly after rebase (branched from v1.9.25 release tag, no conflicts)
- [x] PR body lists every applicable surface and its test file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Children (conductor)" panel to the Web UI displaying conductor session hierarchies with expandable/collapsible tree nodes.
  * New API endpoint returns nested session trees with cycle protection.
  * Live UI updates reflect newly created child sessions automatically.

* **Tests**
  * Added unit, integration, and end-to-end tests covering API functionality and UI rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->