### PR TITLE
fix(test): dedupe parent_session_id row in PARITY_MATRIX (hotfix web-tests)

### DIFF
--- a/tests/web/PARITY_MATRIX.md
+++ b/tests/web/PARITY_MATRIX.md
@@ -95,7 +95,6 @@ Every observable session field shown in the TUI must appear in the web API JSON 
 | **RELATIONSHIPS** |
 | `parent_session_id` | Sub-session indicator | `MenuSession.parentSessionId` + `GET /api/sessions/{id}/children` | ✅ Present; tree endpoint surfaces full conductor child topology in the right-rail Children card (`internal/web/handlers_children.go`, `tests/web/e2e/children-panel.spec.js`) |
 | `is_conductor` | (Not shown in TUI) | MISSING | Conductor metadata; tree exposure now lives at `GET /api/sessions/{id}/children` (kind derived UI-side from title/groupPath in `dataModel.js`) |
-| `parent_session_id` | Sub-session indicator | `MenuSession.parentSessionId` | ✅ Present |
 | `is_conductor` | (Not shown in TUI) | `MenuSession.isConductor` | ✅ Present; conductor metadata || **PROCESS STATE** |
 | `tmux_session` | Internal reference | `MenuSession.tmuxSession` | ✅ Present (tmux session name) |
 | `tmux_socket_name` | (Internal) | `MenuSession.tmuxSocketName` | ✅ Present; issue #687 |


### PR DESCRIPTION
Hotfix — duplicate row in PARITY_MATRIX from my conflict-resolution merge during #1128 rebase caused Playwright to fail with duplicate test titles.