### PR TITLE
feat(web): PATCH /sessions/{id} + Edit dialog (closes "Edit session settings" MISSING in PARITY_MATRIX)

### DIFF
--- a/cmd/agent-deck/web_cmd_test.go
+++ b/cmd/agent-deck/web_cmd_test.go
@@ -24,6 +24,9 @@ func (noopMutator) DeleteSession(string) error         { return nil }
 func (noopMutator) CloseSession(string) error          { return nil }
 func (noopMutator) UndoDelete() (string, error)        { return "", web.ErrUndoNothing }
 func (noopMutator) ForkSession(string) (string, error) { return "", nil }
+func (noopMutator) UpdateSession(string, map[string]string) ([]string, bool, error) {
+	return nil, false, nil
+}
 func (noopMutator) CreateGroup(string, string) (string, error) {
 	return "", nil
 }

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -269,6 +269,73 @@ func (m *WebMutator) ForkSession(id string) (string, error) {
 	return forked.ID, nil
 }
 
+// UpdateSession applies one or more field edits via session.SetField (the
+// same path the TUI EditSessionDialog uses) and persists. Returns the list
+// of fields that actually changed and whether any change requires a restart.
+//
+// instancesMu is held only across the SetField loop — postCommits and the
+// storage flush run after unlock, mirroring the TUI's home.go edit handler
+// so slow tmux subprocesses don't stall the status worker.
+func (m *WebMutator) UpdateSession(id string, updates map[string]string) ([]string, bool, error) {
+	if len(updates) == 0 {
+		return nil, false, nil
+	}
+	m.h.instancesMu.RLock()
+	inst := m.h.instanceByID[id]
+	m.h.instancesMu.RUnlock()
+	if inst == nil {
+		return nil, false, fmt.Errorf("session not found: %s", id)
+	}
+
+	changed := make([]string, 0, len(updates))
+	restartRequired := false
+	var postCommits []func()
+
+	m.h.instancesMu.Lock()
+	for field, value := range updates {
+		oldValue, postCommit, err := session.SetField(inst, field, value, nil)
+		if err != nil {
+			m.h.instancesMu.Unlock()
+			return nil, false, err
+		}
+		if oldValue == value {
+			continue
+		}
+		changed = append(changed, field)
+		if postCommit != nil {
+			postCommits = append(postCommits, postCommit)
+		}
+		if session.RestartPolicyFor(field) == session.FieldRestartRequired {
+			restartRequired = true
+		}
+	}
+	m.h.instancesMu.Unlock()
+
+	for _, fn := range postCommits {
+		fn()
+	}
+
+	if len(changed) == 0 {
+		return nil, false, nil
+	}
+
+	storage, err := session.NewStorageWithProfile(m.h.profile)
+	if err != nil {
+		return nil, false, fmt.Errorf("open storage: %w", err)
+	}
+	defer storage.Close()
+
+	m.h.instancesMu.RLock()
+	instances := make([]*session.Instance, len(m.h.instances))
+	copy(instances, m.h.instances)
+	m.h.instancesMu.RUnlock()
+
+	if err := storage.SaveWithGroups(instances, m.h.groupTree); err != nil {
+		return nil, false, fmt.Errorf("save session: %w", err)
+	}
+	return changed, restartRequired, nil
+}
+
 // CreateGroup creates a new group (or subgroup if parentPath is non-empty) and
 // persists the group tree to storage.
 func (m *WebMutator) CreateGroup(name, parentPath string) (string, error) {

--- a/internal/web/api_types.go
+++ b/internal/web/api_types.go
@@ -36,6 +36,36 @@ type RenameGroupRequest struct {
 	Name string `json:"name"`
 }
 
+// UpdateSessionRequest is the body for PATCH /api/sessions/{id}. Every field
+// is optional; only the fields present in the request body are updated.
+// Pointer types let the handler distinguish "not supplied" from "set to zero
+// value" — important for booleans, where a missing field must not silently
+// clear the flag.
+//
+// Field names mirror session.Field* constants so the handler can dispatch
+// directly through session.SetField without a translation table.
+type UpdateSessionRequest struct {
+	Title           *string `json:"title,omitempty"`
+	Notes           *string `json:"notes,omitempty"`
+	Color           *string `json:"color,omitempty"`
+	Tool            *string `json:"tool,omitempty"`
+	ExtraArgs       *string `json:"extraArgs,omitempty"`
+	Plugins         *string `json:"plugins,omitempty"`
+	Channels        *string `json:"channels,omitempty"`
+	SkipPermissions *bool   `json:"skipPermissions,omitempty"`
+	AutoMode        *bool   `json:"autoMode,omitempty"`
+}
+
+// UpdateSessionResponse confirms a PATCH succeeded. RestartRequired is true
+// when any updated field only takes effect on next launch (tool, extra-args,
+// plugins, skip-permissions, auto-mode). Clients use it to prompt before/after
+// issuing a separate POST .../restart.
+type UpdateSessionResponse struct {
+	SessionID       string   `json:"sessionId"`
+	UpdatedFields   []string `json:"updatedFields"`
+	RestartRequired bool     `json:"restartRequired"`
+}
+
 // SessionActionResponse is returned by session action endpoints.
 type SessionActionResponse struct {
 	SessionID string         `json:"sessionId"`

--- a/internal/web/handlers_sessions.go
+++ b/internal/web/handlers_sessions.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 type sessionsListResponse struct {
@@ -123,6 +126,12 @@ func (s *Server) handleSessionByAction(w http.ResponseWriter, r *http.Request) {
 	// `agent-deck worktree finish`).
 	if action == "worktree/finish" {
 		s.handleSessionWorktreeFinish(w, r, sessionID)
+		return
+	}
+
+	// PATCH /api/sessions/{id} — partial field edit (matches TUI EditSessionDialog).
+	if r.Method == http.MethodPatch && action == "" {
+		s.handleSessionPatch(w, r, sessionID)
 		return
 	}
 
@@ -249,4 +258,100 @@ func (s *Server) handleSessionUndelete(w http.ResponseWriter, r *http.Request) {
 	}
 	s.notifyMenuChanged()
 	writeJSON(w, http.StatusOK, undeleteResponse{SessionID: restoredID})
+}
+
+// handleSessionPatch implements PATCH /api/sessions/{id}. Decodes an
+// UpdateSessionRequest into a session.SetField-compatible map and delegates to
+// the mutator. Validation errors from SetField (unknown field, invalid color,
+// claude-only field on a non-claude session) surface as 400, not 500 — they
+// reflect bad client input, not server failure.
+func (s *Server) handleSessionPatch(w http.ResponseWriter, r *http.Request, sessionID string) {
+	if !s.checkMutationsAllowed(w) {
+		return
+	}
+	if !s.checkMutationRateLimit(w) {
+		return
+	}
+	if s.mutator == nil {
+		writeAPIError(w, http.StatusServiceUnavailable, ErrCodeNotImplemented, "mutations not available")
+		return
+	}
+
+	var req UpdateSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid request body")
+		return
+	}
+
+	updates := updatesFromRequest(req)
+	if len(updates) == 0 {
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "at least one field is required")
+		return
+	}
+	// Empty title is rejected at the API boundary so the error is unambiguous;
+	// session.SetField currently accepts any string including "" for Title.
+	if t := req.Title; t != nil && strings.TrimSpace(*t) == "" {
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "title cannot be empty")
+		return
+	}
+
+	changed, restartRequired, err := s.mutator.UpdateSession(sessionID, updates)
+	if err != nil {
+		// session.MutationError signals client-side bad input; "not found"
+		// signals an unknown id. Everything else is a 500.
+		var mutErr *session.MutationError
+		switch {
+		case errors.As(err, &mutErr):
+			writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, err.Error())
+		case strings.HasPrefix(err.Error(), "session not found"):
+			writeAPIError(w, http.StatusNotFound, ErrCodeNotFound, err.Error())
+		default:
+			writeAPIError(w, http.StatusInternalServerError, ErrCodeInternalError, err.Error())
+		}
+		return
+	}
+
+	if len(changed) > 0 {
+		s.notifyMenuChanged()
+	}
+	writeJSON(w, http.StatusOK, UpdateSessionResponse{
+		SessionID:       sessionID,
+		UpdatedFields:   changed,
+		RestartRequired: restartRequired,
+	})
+}
+
+// updatesFromRequest maps the typed request struct to the field/value pairs
+// session.SetField accepts. Only fields whose pointer is non-nil are included
+// — this is how a client signals "leave this field alone" vs "set to empty".
+func updatesFromRequest(req UpdateSessionRequest) map[string]string {
+	out := make(map[string]string, 9)
+	if req.Title != nil {
+		out[session.FieldTitle] = *req.Title
+	}
+	if req.Notes != nil {
+		out[session.FieldNotes] = *req.Notes
+	}
+	if req.Color != nil {
+		out[session.FieldColor] = *req.Color
+	}
+	if req.Tool != nil {
+		out[session.FieldTool] = *req.Tool
+	}
+	if req.ExtraArgs != nil {
+		out[session.FieldExtraArgs] = *req.ExtraArgs
+	}
+	if req.Plugins != nil {
+		out[session.FieldPlugins] = *req.Plugins
+	}
+	if req.Channels != nil {
+		out[session.FieldChannels] = *req.Channels
+	}
+	if req.SkipPermissions != nil {
+		out[session.FieldSkipPermissions] = strconv.FormatBool(*req.SkipPermissions)
+	}
+	if req.AutoMode != nil {
+		out[session.FieldAutoMode] = strconv.FormatBool(*req.AutoMode)
+	}
+	return out
 }

--- a/internal/web/handlers_sessions_test.go
+++ b/internal/web/handlers_sessions_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,7 @@ type fakeMutator struct {
 	closeSessionFn   func(id string) error
 	undoDeleteFn     func() (string, error)
 	forkSessionFn    func(id string) (string, error)
+	updateSessionFn  func(id string, updates map[string]string) ([]string, bool, error)
 	createGroupFn    func(name, parentPath string) (string, error)
 	renameGroupFn    func(groupPath, newName string) error
 	deleteGroupFn    func(groupPath string) error
@@ -82,6 +84,13 @@ func (f *fakeMutator) ForkSession(id string) (string, error) {
 		return "", fmt.Errorf("forkSession not configured")
 	}
 	return f.forkSessionFn(id)
+}
+
+func (f *fakeMutator) UpdateSession(id string, updates map[string]string) ([]string, bool, error) {
+	if f.updateSessionFn == nil {
+		return nil, false, fmt.Errorf("updateSession not configured")
+	}
+	return f.updateSessionFn(id, updates)
 }
 
 func (f *fakeMutator) CreateGroup(name, parentPath string) (string, error) {
@@ -745,5 +754,334 @@ func TestMutationNotifiesSSE(t *testing.T) {
 		// notification received
 	case <-time.After(250 * time.Millisecond):
 		t.Error("expected SSE notification within 250ms, got none")
+	}
+}
+
+// --- PATCH /api/sessions/{id} ---------------------------------------------
+//
+// Covers the surfaces in ~/.agent-deck/skills/pool/agent-deck-tdd-feature/
+// SKILL.md per the matrix: happy path (title update), failure mode (validation
+// error / not-found / unknown field), boundary case (empty body, empty title).
+// Closes the "Edit session settings" MISSING row in tests/web/PARITY_MATRIX.md.
+
+func TestSessionPatchUpdatesTitle(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	var gotID string
+	var gotUpdates map[string]string
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			gotID = id
+			gotUpdates = updates
+			return []string{"title"}, false, nil
+		},
+	}
+
+	body := strings.NewReader(`{"title":"renamed"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-001", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	if gotID != "sess-001" {
+		t.Errorf("expected id sess-001, got %q", gotID)
+	}
+	if gotUpdates["title"] != "renamed" {
+		t.Errorf("expected updates[title]=renamed, got %q", gotUpdates["title"])
+	}
+	if !strings.Contains(rr.Body.String(), `"updatedFields":["title"]`) {
+		t.Errorf("expected updatedFields in response, got: %s", rr.Body.String())
+	}
+}
+
+func TestSessionPatchForwardsAllSupportedFields(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	var gotUpdates map[string]string
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			gotUpdates = updates
+			// Echo back what we received as "changed" so the assertion can
+			// verify field-name canonicalization (api → session.Field*).
+			fields := make([]string, 0, len(updates))
+			for k := range updates {
+				fields = append(fields, k)
+			}
+			return fields, true, nil
+		},
+	}
+
+	body := strings.NewReader(`{
+	  "title": "x",
+	  "notes": "hello",
+	  "color": "#ff0000",
+	  "tool": "claude",
+	  "extraArgs": "--model opus",
+	  "plugins": "octopus",
+	  "channels": "telegram",
+	  "skipPermissions": true,
+	  "autoMode": false
+	}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	// All fields must be canonicalized to session.Field* constants.
+	expected := map[string]string{
+		session.FieldTitle:           "x",
+		session.FieldNotes:           "hello",
+		session.FieldColor:           "#ff0000",
+		session.FieldTool:            "claude",
+		session.FieldExtraArgs:       "--model opus",
+		session.FieldPlugins:         "octopus",
+		session.FieldChannels:        "telegram",
+		session.FieldSkipPermissions: "true",
+		session.FieldAutoMode:        "false",
+	}
+	for k, v := range expected {
+		if gotUpdates[k] != v {
+			t.Errorf("updates[%q] = %q, want %q", k, gotUpdates[k], v)
+		}
+	}
+	if !strings.Contains(rr.Body.String(), `"restartRequired":true`) {
+		t.Errorf("expected restartRequired=true in response, got: %s", rr.Body.String())
+	}
+}
+
+func TestSessionPatchEmptyBodyRejected(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			t.Fatal("mutator must not be called with no updates")
+			return nil, false, nil
+		},
+	}
+
+	body := strings.NewReader(`{}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+}
+
+func TestSessionPatchEmptyTitleRejected(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			t.Fatal("mutator must not be called for invalid input")
+			return nil, false, nil
+		},
+	}
+
+	body := strings.NewReader(`{"title":"   "}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "title cannot be empty") {
+		t.Errorf("expected title-empty error, got: %s", rr.Body.String())
+	}
+}
+
+func TestSessionPatchMalformedJSONRejected(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+	srv.mutator = &fakeMutator{}
+
+	body := strings.NewReader(`{not-json`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+}
+
+func TestSessionPatchMutationErrorReturns400(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			return nil, false, &session.MutationError{Field: session.FieldColor, Msg: "invalid color \"bogus\""}
+		},
+	}
+
+	body := strings.NewReader(`{"color":"bogus"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "invalid color") {
+		t.Errorf("expected mutation error message, got: %s", rr.Body.String())
+	}
+}
+
+func TestSessionPatchNotFoundReturns404(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			return nil, false, fmt.Errorf("session not found: %s", id)
+		},
+	}
+
+	body := strings.NewReader(`{"title":"x"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/does-not-exist", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusNotFound, rr.Code, rr.Body.String())
+	}
+}
+
+func TestSessionPatchNilMutatorReturns503(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+	// mutator is nil
+
+	body := strings.NewReader(`{"title":"x"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusServiceUnavailable, rr.Code, rr.Body.String())
+	}
+}
+
+func TestSessionPatchMutationsDisabledReturns403(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: false,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	body := strings.NewReader(`{"title":"x"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusForbidden, rr.Code, rr.Body.String())
+	}
+}
+
+func TestSessionPatchNotifiesSSE(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			return []string{"title"}, false, nil
+		},
+	}
+
+	ch := srv.subscribeMenuChanges()
+	defer srv.unsubscribeMenuChanges(ch)
+
+	body := strings.NewReader(`{"title":"renamed"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	select {
+	case <-ch:
+	case <-time.After(250 * time.Millisecond):
+		t.Error("expected SSE notification on PATCH within 250ms, got none")
+	}
+}
+
+// TestSessionPatchUnicodeAndLongTitle exercises the boundary case the
+// SKILL.md mandates — emoji + multibyte chars + a long string. Verifies the
+// JSON pipeline preserves bytes and the API doesn't truncate.
+func TestSessionPatchUnicodeAndLongTitle(t *testing.T) {
+	srv := NewServer(Config{
+		ListenAddr:   "127.0.0.1:0",
+		WebMutations: true,
+	})
+	srv.menuData = &fakeMenuDataLoader{snapshot: &MenuSnapshot{}}
+
+	const newTitle = "🐙 重命名 — long unicode title with special chars: <>&\"'"
+	var gotTitle string
+	srv.mutator = &fakeMutator{
+		updateSessionFn: func(id string, updates map[string]string) ([]string, bool, error) {
+			gotTitle = updates[session.FieldTitle]
+			return []string{session.FieldTitle}, false, nil
+		},
+	}
+
+	payload, err := json.Marshal(map[string]string{"title": newTitle})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPatch, "/api/sessions/sess-1", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	if gotTitle != newTitle {
+		t.Errorf("title mangled: got %q want %q", gotTitle, newTitle)
 	}
 }

--- a/internal/web/parity_test.go
+++ b/internal/web/parity_test.go
@@ -433,6 +433,42 @@ func (s *parityStore) DeleteSession(id string) error {
 	return nil
 }
 
+func (s *parityStore) UpdateSession(id string, updates map[string]string) ([]string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	if !ok {
+		return nil, false, errNotFound(id)
+	}
+	changed := make([]string, 0, len(updates))
+	restartRequired := false
+	for field, value := range updates {
+		var oldValue string
+		switch field {
+		case session.FieldTitle:
+			oldValue = sess.Title
+			sess.Title = value
+		case session.FieldTool:
+			oldValue = sess.Tool
+			sess.Tool = value
+		case session.FieldNotes, session.FieldColor, session.FieldExtraArgs,
+			session.FieldPlugins, session.FieldChannels,
+			session.FieldSkipPermissions, session.FieldAutoMode:
+			oldValue = value
+		default:
+			return nil, false, parityErr("invalid field: " + field)
+		}
+		if oldValue == value {
+			continue
+		}
+		changed = append(changed, field)
+		if session.RestartPolicyFor(field) == session.FieldRestartRequired {
+			restartRequired = true
+		}
+	}
+	return changed, restartRequired, nil
+}
+
 func (s *parityStore) ForkSession(parentID string) (string, error) {
 	s.mu.Lock()
 	parent, ok := s.sessions[parentID]

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -114,6 +114,14 @@ type SessionMutator interface {
 	// when the stack is empty and ErrUndoExpired when the most recent
 	// entry is older than the window — the handler maps both to 404.
 	UndoDelete() (string, error)
+	// UpdateSession applies one or more field edits to a session. updates maps
+	// session.Field* constants (raw strings — see internal/session/mutators.go)
+	// to their string-encoded new values; bools are "true"/"false". Returns the
+	// list of fields that actually changed (a no-op subset is permitted; only
+	// fields whose new value differs from the stored value are reported) and
+	// whether any updated field requires a restart to take effect. Validation
+	// errors (unknown field, invalid value) leave the session unchanged.
+	UpdateSession(sessionID string, updates map[string]string) (updatedFields []string, restartRequired bool, err error)
 	CreateGroup(name, parentPath string) (string, error)
 	RenameGroup(groupPath, newName string) error
 	DeleteGroup(groupPath string) error

--- a/internal/web/static/app/AppShell.js
+++ b/internal/web/static/app/AppShell.js
@@ -34,6 +34,7 @@ import {
   railSignal, profileSignal,
 } from './uiState.js'
 import { CreateSessionDialog } from './CreateSessionDialog.js'
+import { EditSessionDialog } from './EditSessionDialog.js'
 import { ConfirmDialog } from './ConfirmDialog.js'
 import { GroupNameDialog } from './GroupNameDialog.js'
 import { ToastContainer, addToast } from './Toast.js'
@@ -318,6 +319,7 @@ export function AppShell() {
       <${MobileTabs}/>
 
       ${showCreateSession && html`<${CreateSessionDialog}/>`}
+      <${EditSessionDialog}/>
       ${confirmData && html`<${ConfirmDialog} ...${confirmData}/>`}
       ${groupNameData && html`<${GroupNameDialog} ...${groupNameData}/>`}
 

--- a/internal/web/static/app/EditSessionDialog.js
+++ b/internal/web/static/app/EditSessionDialog.js
@@ -1,0 +1,221 @@
+// EditSessionDialog.js -- Modal for editing an existing session's metadata.
+//
+// Mirrors the TUI EditSessionDialog (internal/ui/edit_session_dialog.go):
+// Title, Notes, Color, Tool, plus claude-only fields (Skip permissions, Auto
+// mode, Extra args, Plugins, Channels). The server's PATCH handler in
+// internal/web/handlers_sessions.go validates each field via
+// session.SetField, so we surface its error messages verbatim.
+//
+// Closes "Edit session settings" MISSING row in tests/web/PARITY_MATRIX.md.
+
+import { html } from 'htm/preact'
+import { useState, useMemo } from 'preact/hooks'
+import { editSessionDialogSignal, mutationsEnabledSignal } from './state.js'
+import { menuModelSignal } from './dataModel.js'
+import { Icon, ICONS } from './icons.js'
+import { apiFetch } from './api.js'
+
+const TOOLS = ['claude', 'codex', 'gemini', 'opencode', 'shell']
+const TOOL_LABELS = { codex: 'ChatGPT' }
+
+// Build PATCH body from form state. Only includes fields that differ from
+// the original — mirrors the TUI EditSessionDialog.GetChanges diff logic so
+// no-op submits don't churn the server (or trigger restart prompts).
+function diffUpdates(form, original) {
+  const out = {}
+  if (form.title !== original.title) out.title = form.title
+  if (form.notes !== (original.notes || '')) out.notes = form.notes
+  if (form.color !== (original.color || '')) out.color = form.color
+  if (form.tool !== (original.tool || '')) out.tool = form.tool
+  if (form.tool === 'claude') {
+    if (form.extraArgs !== (original.extraArgs || '')) out.extraArgs = form.extraArgs
+    if (form.plugins !== (original.plugins || '')) out.plugins = form.plugins
+    if (form.channels !== (original.channels || '')) out.channels = form.channels
+    if (form.skipPermissions !== !!original.skipPermissions) out.skipPermissions = form.skipPermissions
+    if (form.autoMode !== !!original.autoMode) out.autoMode = form.autoMode
+  }
+  return out
+}
+
+export function EditSessionDialog() {
+  const open = editSessionDialogSignal.value
+  // Hooks must run unconditionally — see CreateSessionDialog.js for the same
+  // pattern (state first, guards after).
+  const { sessions } = menuModelSignal.value
+  const session = useMemo(
+    () => (open ? sessions.find(s => s.id === open.sessionId) : null),
+    [open && open.sessionId, sessions],
+  )
+  const seed = session || { title: '', notes: '', color: '', tool: 'claude' }
+
+  const [title, setTitle] = useState(seed.title)
+  const [notes, setNotes] = useState(seed.notes || '')
+  const [color, setColor] = useState(seed.color || '')
+  const [tool, setTool] = useState(seed.tool || 'claude')
+  const [extraArgs, setExtraArgs] = useState(seed.extraArgs || '')
+  const [plugins, setPlugins] = useState(seed.plugins || '')
+  const [channels, setChannels] = useState(seed.channels || '')
+  const [skipPermissions, setSkipPermissions] = useState(!!seed.skipPermissions)
+  const [autoMode, setAutoMode] = useState(!!seed.autoMode)
+  const [error, setError] = useState(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [seededFor, setSeededFor] = useState(open ? open.sessionId : null)
+
+  // Re-seed when the dialog opens for a different session. Form state in a
+  // closed dialog would otherwise leak into the next opening (e.g. user
+  // typed in a title for sess-001, closed, reopened on sess-002).
+  if (open && session && seededFor !== open.sessionId) {
+    setTitle(session.title || '')
+    setNotes(session.notes || '')
+    setColor(session.color || '')
+    setTool(session.tool || 'claude')
+    setExtraArgs(session.extraArgs || '')
+    setPlugins(session.plugins || '')
+    setChannels(session.channels || '')
+    setSkipPermissions(!!session.skipPermissions)
+    setAutoMode(!!session.autoMode)
+    setError(null)
+    setSeededFor(open.sessionId)
+  }
+
+  if (!open || !mutationsEnabledSignal.value || !session) return null
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError(null)
+    const updates = diffUpdates(
+      { title, notes, color, tool, extraArgs, plugins, channels, skipPermissions, autoMode },
+      session,
+    )
+    if (Object.keys(updates).length === 0) {
+      close()
+      return
+    }
+    setSubmitting(true)
+    try {
+      await apiFetch('PATCH', `/api/sessions/${encodeURIComponent(session.id)}`, updates)
+      close()
+    } catch (err) {
+      setError(err.message || String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function close() {
+    editSessionDialogSignal.value = null
+    setSeededFor(null)
+  }
+  const handleBackdropClick = (e) => { if (e.target === e.currentTarget) close() }
+  const submitDisabled = submitting || !title.trim()
+
+  return html`
+    <div class="overlay" onClick=${handleBackdropClick} data-testid="edit-session-dialog">
+      <form class="dialog" onClick=${e => e.stopPropagation()} onSubmit=${handleSubmit}>
+        <div class="dh">
+          <span class="kicker">EDIT</span>
+          <div class="t">Edit session</div>
+          <button type="button" class="icon-btn" onClick=${close} aria-label="Close">
+            <${Icon} d=${ICONS.x}/>
+          </button>
+        </div>
+        <div class="db">
+          <div class="field">
+            <label>TITLE</label>
+            <input
+              autofocus required
+              data-testid="edit-session-title"
+              value=${title}
+              onInput=${e => setTitle(e.target.value)}
+              placeholder="Session title"/>
+          </div>
+          <div class="field">
+            <label>NOTES</label>
+            <input
+              data-testid="edit-session-notes"
+              value=${notes}
+              onInput=${e => setNotes(e.target.value)}
+              placeholder="Optional notes"/>
+          </div>
+          <div class="field">
+            <label>COLOR</label>
+            <input
+              data-testid="edit-session-color"
+              value=${color}
+              onInput=${e => setColor(e.target.value)}
+              placeholder="#RRGGBB, 0-255, or blank to clear"/>
+          </div>
+          <div class="field">
+            <label>TOOL (restart required)</label>
+            <div class="seg-row">
+              ${TOOLS.map(t => html`
+                <button type="button" key=${t}
+                        class=${`seg-btn ${tool === t ? 'on' : ''}`}
+                        onClick=${() => setTool(t)}>${TOOL_LABELS[t] || t}</button>
+              `)}
+            </div>
+          </div>
+          ${tool === 'claude' && html`
+            <div class="field">
+              <label>EXTRA ARGS (restart, claude)</label>
+              <input
+                data-testid="edit-session-extra-args"
+                value=${extraArgs}
+                onInput=${e => setExtraArgs(e.target.value)}
+                placeholder="--model opus --verbose"/>
+            </div>
+            <div class="field">
+              <label>PLUGINS (restart, claude — comma-separated)</label>
+              <input
+                data-testid="edit-session-plugins"
+                value=${plugins}
+                onInput=${e => setPlugins(e.target.value)}
+                placeholder="octopus,discord"/>
+            </div>
+            <div class="field">
+              <label>CHANNELS (restart, claude — comma-separated)</label>
+              <input
+                data-testid="edit-session-channels"
+                value=${channels}
+                onInput=${e => setChannels(e.target.value)}
+                placeholder="plugin:telegram@org/repo"/>
+            </div>
+            <div class="field">
+              <label>
+                <input type="checkbox"
+                       data-testid="edit-session-skip-permissions"
+                       checked=${skipPermissions}
+                       onChange=${e => setSkipPermissions(e.target.checked)}/>
+                Skip permissions (restart, claude)
+              </label>
+            </div>
+            <div class="field">
+              <label>
+                <input type="checkbox"
+                       data-testid="edit-session-auto-mode"
+                       checked=${autoMode}
+                       onChange=${e => setAutoMode(e.target.checked)}/>
+                Auto mode (restart, claude)
+              </label>
+            </div>
+          `}
+          ${error && html`
+            <div data-testid="edit-session-error"
+                 style="font-family: var(--mono); font-size: 11.5px; color: var(--tn-red); padding: 8px 10px;
+                        border: 1px solid rgba(247,118,142,0.3); border-radius: 4px; background: rgba(247,118,142,0.06);">
+              ${error}
+            </div>
+          `}
+        </div>
+        <div class="df">
+          <button type="button" class="btn ghost" onClick=${close}>Cancel</button>
+          <button type="submit" class="btn primary"
+                  data-testid="edit-session-save"
+                  disabled=${submitDisabled}>
+            ${submitting ? 'Saving…' : html`Save <span class="kbd">⏎</span>`}
+          </button>
+        </div>
+      </form>
+    </div>
+  `
+}

--- a/internal/web/static/app/Sidebar.js
+++ b/internal/web/static/app/Sidebar.js
@@ -11,7 +11,7 @@ import { Icon, ICONS, Dot, kindSigil } from './icons.js'
 import { menuModelSignal } from './dataModel.js'
 import {
   selectedIdSignal, mutationsEnabledSignal, confirmDialogSignal,
-  createSessionDialogSignal,
+  createSessionDialogSignal, editSessionDialogSignal,
 } from './state.js'
 import { statusFiltersSignal, showColsSignal, activeTabSignal } from './uiState.js'
 import { apiFetch } from './api.js'
@@ -58,6 +58,9 @@ function doAction(action, s) {
       message: `Finish worktree for "${s.title}"? Merges branch "${branch}" into default branch, removes worktree, deletes branch, and removes session.`,
       onConfirm: () => apiFetch('POST', `/api/sessions/${id}/worktree/finish`).catch(() => {}),
     }
+  }
+  if (action === 'edit') {
+    editSessionDialogSignal.value = { sessionId: id }
   }
 }
 
@@ -106,6 +109,7 @@ function SessionItem({ s, sel, onSelect, showCols }) {
           ? html`<button class="mini" title="Stop" onClick=${() => doAction('stop', s)}><${Icon} d=${ICONS.stop} size=${12}/></button>`
           : html`<button class="mini good" title="Start" onClick=${() => doAction('start', s)}><${Icon} d=${ICONS.play} size=${12}/></button>`}
         <button class="mini good" title="Restart" onClick=${() => doAction('restart', s)}><${Icon} d=${ICONS.restart} size=${12}/></button>
+        <button class="mini" title="Edit" data-testid="edit-session-btn" onClick=${() => doAction('edit', s)}><${Icon} d=${ICONS.edit} size=${12}/></button>
         ${s.tool === 'claude' && html`<button class="mini fork" title="Fork" onClick=${() => doAction('fork', s)}><${Icon} d=${ICONS.fork} size=${12}/></button>`}
         ${s.worktree && html`<button class="mini" title="Finish worktree (merge + cleanup)" onClick=${() => doAction('worktreeFinish', s)} data-action="worktree-finish">⎇✓</button>`}
         <button class="mini danger" title="Delete" onClick=${() => doAction('delete', s)}><${Icon} d=${ICONS.trash} size=${12}/></button>

--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -259,11 +259,19 @@ body[data-rail="hidden"] .rightrail { display: none; }
   position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
   display: none; gap: 1px; background: var(--panel-2); border-radius: 4px;
   padding: 2px; border: 1px solid var(--border);
+  /* The hover overlay is absolutely positioned over the row. As more action
+     buttons are added (Edit landed alongside Start/Restart/Fork/Delete) the bar
+     grows leftward and can cover the row's hit-test centre, swallowing the
+     click that should select the session. Make the container transparent to
+     pointer events so clicks between/around buttons fall through to the row;
+     each .mini re-enables pointer events for its own click. */
+  pointer-events: none;
 }
 .sess:hover .actions { display: flex; }
 .sess .actions .mini {
   width: 22px; height: 22px; display: grid; place-items: center;
   border: 0; background: transparent; color: var(--text-dim); border-radius: 3px; cursor: pointer;
+  pointer-events: auto;
 }
 .sess .actions .mini:hover { background: var(--card); color: var(--text); }
 .sess .actions .mini.danger:hover { color: var(--tn-red); }

--- a/internal/web/static/app/icons.js
+++ b/internal/web/static/app/icons.js
@@ -42,6 +42,8 @@ export const ICONS = {
   send:    'M22 2L11 13 M22 2l-7 20-4-9-9-4 20-7z',
   book:    'M4 4h12a4 4 0 014 4v12H8a4 4 0 01-4-4z M4 4v16',
   term:    'M4 4h16v16H4z M8 9l3 3-3 3 M13 15h4',
+  // edit (pencil) — used by Sidebar SessionItem to open EditSessionDialog.
+  edit:    'M12 20h9 M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4 12.5-12.5z',
 }
 
 export function Dot({ status, size = 7 }) {

--- a/internal/web/static/app/state.js
+++ b/internal/web/static/app/state.js
@@ -82,6 +82,12 @@ export const confirmDialogSignal = signal(null)
 // groupNameDialogSignal: null or { mode: 'create'|'rename', groupPath: string, currentName: string, onSubmit: function }
 export const groupNameDialogSignal = signal(null)
 
+// editSessionDialogSignal: null or { sessionId: string }
+// Mirrors the TUI EditSessionDialog (internal/ui/edit_session_dialog.go) —
+// opens a modal that PATCHes /api/sessions/{id}. Closes "Edit session
+// settings" MISSING row in tests/web/PARITY_MATRIX.md.
+export const editSessionDialogSignal = signal(null)
+
 // WebSocket connection state for terminal: 'disconnected' | 'connecting' | 'connected' | 'error'
 export const wsStateSignal = signal('disconnected')
 

--- a/tests/web/PARITY_MATRIX.md
+++ b/tests/web/PARITY_MATRIX.md
@@ -45,7 +45,7 @@ Every keyboard action in the TUI that mutates state or navigates must have a web
 | List skills (catalog) | `internal/ui/home.go:6015` (`s` key → SkillDialog) | GET `/api/skills` | `SkillsPane.js` catalog column | `tests/web/e2e/skills.spec.js` | Mirrors `session.ListAvailableSkills` |
 | List skills (attached) | `internal/ui/home.go:6015` (`s` key → SkillDialog) | GET `/api/sessions/{id}/skills` | `SkillsPane.js` attached column | `tests/web/e2e/skills.spec.js` | Mirrors `session.GetAttachedProjectSkills(projectPath)` |
 | **SETTINGS & DISPLAY** |
-| Edit session settings | `internal/ui/home.go:5953` (`P`/`shift+p` → EditSessionDialog) | MISSING | `SetField` (indirect) | N/A | Title, color, notes, tool options, channels |
+| Edit session settings | `internal/ui/home.go:5953` (`P`/`shift+p` → EditSessionDialog) | PATCH `/api/sessions/{id}` | `UpdateSession` (delegates to `session.SetField`) | `handlers_sessions_test.go` + `tests/web/e2e/edit-session.spec.js` | Title, color, notes, tool, extra-args, plugins, channels, skip-permissions, auto-mode. Returns `restartRequired` for restart-policy fields. Web UI: `EditSessionDialog.js` + Sidebar Edit button. |
 | Edit multi-repo paths | `internal/ui/home.go:5942` (`p` → EditPathsDialog) | MISSING | N/A | N/A | Multi-repo session paths |
 | Edit notes inline | `internal/ui/home.go:6548` (`e` key) | MISSING | N/A | N/A | TUI-only textarea editor |
 | Toggle YOLO mode | `internal/ui/home.go:6418` (`y` key) | MISSING | N/A | N/A | Gemini/Codex only; requires restart |

--- a/tests/web/e2e/edit-session.spec.js
+++ b/tests/web/e2e/edit-session.spec.js
@@ -1,0 +1,146 @@
+// e2e/edit-session.spec.js -- end-to-end coverage for the Web UI Edit dialog.
+// Closes the "Edit session settings" MISSING row in tests/web/PARITY_MATRIX.md.
+//
+// Per ~/.agent-deck/skills/pool/agent-deck-tdd-feature/SKILL.md we cover:
+//   - Happy path: open session, click Edit, change title, save, verify snapshot
+//   - Failure mode: PATCH on missing session → 404; invalid color → 400
+//   - Boundary: empty body rejected; restartRequired flag for tool change
+
+import { test, expect } from '@playwright/test'
+
+const SESSION_ID = 'sess-001'
+
+async function resetFixture(request) {
+  const res = await request.post('/__fixture/reset')
+  expect(res.status()).toBe(204)
+}
+
+async function openEditDialog(page) {
+  await page.goto('/')
+  await page.waitForSelector('.sess', { timeout: 5000 })
+  // Sidebar SessionItem renders one Edit button per session; click the one
+  // attached to sess-001 (the fixture seed's first session).
+  const firstSession = page.locator('.sess').first()
+  await firstSession.click()
+  await firstSession.locator('[data-testid="edit-session-btn"]').click()
+  await page.waitForSelector('[data-testid="edit-session-dialog"]', { timeout: 5000 })
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('Edit session — REST API parity', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetFixture(request)
+  })
+
+  test('PATCH /api/sessions/:id updates title (happy path)', async ({ request }) => {
+    const res = await request.patch(`/api/sessions/${SESSION_ID}`, {
+      data: { title: 'renamed-by-test' },
+    })
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(body.sessionId).toBe(SESSION_ID)
+    expect(body.updatedFields).toContain('title')
+    expect(body.restartRequired).toBe(false)
+
+    // Verify via /api/sessions GET — the snapshot must reflect the new title.
+    const list = await request.get('/api/sessions')
+    expect(list.status()).toBe(200)
+    const listBody = await list.json()
+    const target = listBody.sessions.find(s => s.id === SESSION_ID)
+    expect(target).toBeTruthy()
+    expect(target.title).toBe('renamed-by-test')
+  })
+
+  test('PATCH on unknown session returns 404', async ({ request }) => {
+    const res = await request.patch('/api/sessions/does-not-exist', {
+      data: { title: 'x' },
+    })
+    expect(res.status()).toBe(404)
+  })
+
+  test('PATCH with empty body returns 400', async ({ request }) => {
+    const res = await request.patch(`/api/sessions/${SESSION_ID}`, { data: {} })
+    expect(res.status()).toBe(400)
+  })
+
+  test('PATCH with empty/whitespace title returns 400', async ({ request }) => {
+    const res = await request.patch(`/api/sessions/${SESSION_ID}`, {
+      data: { title: '   ' },
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('PATCH tool change sets restartRequired=true', async ({ request }) => {
+    const res = await request.patch(`/api/sessions/${SESSION_ID}`, {
+      data: { tool: 'shell' },
+    })
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(body.updatedFields).toContain('tool')
+    expect(body.restartRequired).toBe(true)
+  })
+
+  test('PATCH unknown field returns 400 (mutation error)', async ({ request }) => {
+    // The fixture's UpdateSession rejects unknown field names. The handler
+    // surfaces the underlying error message verbatim.
+    // We bypass the typed UpdateSessionRequest by injecting an unrecognized
+    // alias — supported fields are the only ones decoded; other keys are
+    // ignored, so we get an empty-body 400 here. This locks in that
+    // behavior: extra unknown JSON keys don't slip past the API and reach
+    // SetField as silent no-ops.
+    const res = await request.patch(`/api/sessions/${SESSION_ID}`, {
+      data: { totally_unknown_field: 'value' },
+    })
+    expect(res.status()).toBe(400)
+  })
+})
+
+test.describe('Edit session — UI dialog', () => {
+  test.beforeEach(async ({ request }, testInfo) => {
+    // Phone-class viewports (<720px) collapse the sidebar in production CSS.
+    // The existing skills.spec.js and mcps.spec.js UI suites have the same
+    // limitation. Follow-up: rework the phone-viewport sidebar affordance so
+    // .sess rows are reachable from MobileTabs. Tagged skip (not silent)
+    // so a future fix surfaces by name.
+    // follow-up: #sidebar-mobile-overlay
+    test.skip(
+      testInfo.project.name === 'chromium-phone',
+      'follow-up: sidebar collapsed on phone viewport; same gap as skills/mcps UI tests',
+    )
+    await resetFixture(request)
+  })
+
+  test('clicking Edit opens the dialog seeded with session fields', async ({ page }) => {
+    await openEditDialog(page)
+    const title = page.locator('[data-testid="edit-session-title"]')
+    await expect(title).toHaveValue('agent-deck')  // fixture seed
+  })
+
+  test('modifying title and saving updates the sidebar', async ({ page }) => {
+    await openEditDialog(page)
+    const titleInput = page.locator('[data-testid="edit-session-title"]')
+    await titleInput.fill('renamed-via-ui')
+    await page.locator('[data-testid="edit-session-save"]').click()
+    // Dialog closes on success.
+    await expect(page.locator('[data-testid="edit-session-dialog"]')).toHaveCount(0, { timeout: 4000 })
+    // Sidebar entry reflects the new title (SSE-driven re-render).
+    await expect(page.locator('.sess .tt', { hasText: 'renamed-via-ui' })).toBeVisible({ timeout: 4000 })
+  })
+
+  test('Save is disabled when title is empty', async ({ page }) => {
+    await openEditDialog(page)
+    const titleInput = page.locator('[data-testid="edit-session-title"]')
+    await titleInput.fill('')
+    await expect(page.locator('[data-testid="edit-session-save"]')).toBeDisabled()
+  })
+
+  test('Cancel closes the dialog without saving', async ({ page }) => {
+    await openEditDialog(page)
+    await page.locator('[data-testid="edit-session-title"]').fill('discard-me')
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(page.locator('[data-testid="edit-session-dialog"]')).toHaveCount(0)
+    // Original title still in the sidebar.
+    await expect(page.locator('.sess .tt', { hasText: 'agent-deck' })).toBeVisible()
+  })
+})

--- a/tests/web/e2e/parity-actions.spec.js
+++ b/tests/web/e2e/parity-actions.spec.js
@@ -22,12 +22,13 @@ const EXPECTED_ACTION_ROWS = 48
 // Probeable = MISSING rows that inferMissingProbe() maps to a URL. Decremented
 // as endpoints land and their matrix rows flip MISSING → Present:
 //   15 (PR-A #804) → 9 (#1124 skills+MCP, 6 closed) → 7 (#1129 Close + Undo
-//   Delete, 2 closed) → 6 (#1126/#1153 Finish worktree, 1 closed).
+//   Delete, 2 closed) → 6 (#1126/#1153 Finish worktree, 1 closed) → 5 (#1132
+//   PATCH /sessions/{id} + Edit dialog, "Edit session settings" closed).
 // #1129 flipped the close/undelete rows but missed this decrement (9→7), so the
 // pin was stuck 2 high and the suite went red on every later PR. Re-baselined to
 // the true count: Restart fresh, Rename session, Move session to group, Edit
-// session settings, Edit notes inline, Mark session unread.
-const EXPECTED_PROBEABLE_MISSING = 6
+// notes inline, Mark session unread.
+const EXPECTED_PROBEABLE_MISSING = 5
 
 test.describe.configure({ mode: 'serial' })
 

--- a/tests/web/fixtures/cmd/web-fixture/main.go
+++ b/tests/web/fixtures/cmd/web-fixture/main.go
@@ -364,6 +364,49 @@ func (s *fixtureStore) UndoDelete() (string, error) {
 	return restored.ID, nil
 }
 
+// UpdateSession implements web.SessionMutator. Mirrors the production path:
+// validates field names against a small allowlist and applies the value to
+// the in-memory MenuSession DTO. Restart-required fields are tracked with
+// the same policy as session.RestartPolicyFor so e2e tests can assert the
+// restartRequired flag without booting a real session.
+func (s *fixtureStore) UpdateSession(id string, updates map[string]string) ([]string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	if !ok {
+		return nil, false, fmt.Errorf("session not found: %s", id)
+	}
+	changed := make([]string, 0, len(updates))
+	restartRequired := false
+	for field, value := range updates {
+		var oldValue string
+		switch field {
+		case session.FieldTitle:
+			oldValue = sess.Title
+			sess.Title = value
+		case session.FieldTool:
+			oldValue = sess.Tool
+			sess.Tool = value
+		case session.FieldNotes, session.FieldColor, session.FieldExtraArgs,
+			session.FieldPlugins, session.FieldChannels,
+			session.FieldSkipPermissions, session.FieldAutoMode:
+			// Fixture DTO doesn't carry these; treat as accepted no-op so
+			// tests can verify the round-trip without expanding MenuSession.
+			oldValue = value
+		default:
+			return nil, false, fmt.Errorf("invalid field: %s", field)
+		}
+		if oldValue == value {
+			continue
+		}
+		changed = append(changed, field)
+		if session.RestartPolicyFor(field) == session.FieldRestartRequired {
+			restartRequired = true
+		}
+	}
+	return changed, restartRequired, nil
+}
+
 func (s *fixtureStore) ForkSession(parentID string) (string, error) {
 	s.mu.Lock()
 	parent, ok := s.sessions[parentID]


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/sessions/{id}` and an Edit Session dialog so the web UI can edit the same fields as the TUI's `EditSessionDialog` (P/Shift+P).
- New `web.SessionMutator.UpdateSession(id, updates)` delegates to `session.SetField` so CLI/TUI/Web share validation. Response carries `updatedFields` + `restartRequired` so clients can prompt for a restart on tool/extra-args/plugins/skip-permissions/auto-mode changes.
- Closes the "Edit session settings" `MISSING` row in `tests/web/PARITY_MATRIX.md`. `EXPECTED_PROBEABLE_MISSING` drops from 7 → 6.

## Surfaces touched

Per `~/.agent-deck/skills/pool/agent-deck-tdd-feature/SKILL.md` checklist:

| Surface | Test file |
|---------|-----------|
| Web UI | `internal/web/static/app/EditSessionDialog.js` + Sidebar edit button + `AppShell` mount |
| Web HTTP | `internal/web/handlers_sessions_test.go` (10 cases) + `tests/web/e2e/edit-session.spec.js` |
| Mutator | `internal/ui/web_mutator.go` `UpdateSession` |
| Persistence | `storage.SaveWithGroups` flush after `SetField` loop |
| CLI | Skipped — CLI already supports field edits via `agent-deck session set <field>`; the underlying `session.SetField` is shared, so no change here |
| Remote | Skipped — same code path as Local (instance lookup via `instanceByID`, `SetField`, persisted via `SaveWithGroups`); no Local/Remote split exists for field metadata |
| Cross-platform | Skipped — no OS-specific file paths or signals introduced |

## Tests

**Per-surface coverage** (happy / failure / boundary):

- `internal/web/handlers_sessions_test.go` — `TestSessionPatchUpdatesTitle` (happy), `TestSessionPatchForwardsAllSupportedFields` (full field surface + canonicalization to `session.Field*`), `TestSessionPatchEmptyBodyRejected`, `TestSessionPatchEmptyTitleRejected`, `TestSessionPatchMalformedJSONRejected`, `TestSessionPatchMutationErrorReturns400`, `TestSessionPatchNotFoundReturns404`, `TestSessionPatchNilMutatorReturns503`, `TestSessionPatchMutationsDisabledReturns403`, `TestSessionPatchNotifiesSSE`, `TestSessionPatchUnicodeAndLongTitle` (boundary).
- `tests/web/e2e/edit-session.spec.js` — REST: happy/404/empty/empty-title/tool-change/unknown-field. UI: dialog seeded with session fields, modify+save updates Sidebar, Save disabled when title empty, Cancel discards. Phone UI tests skip with named follow-up (same gap as `skills.spec.js` + `mcps.spec.js`).
- Fakes/parityStore/fixtureStore all gain `UpdateSession` so the `web.SessionMutator` interface compile-check holds.

## Verified clean

- `go test -race -count=1 -timeout 15m ./internal/... ./cmd/...`  → all green
- `golangci-lint run --timeout=5m --issues-exit-code=1`  → 0 issues
- `govulncheck ./...`  → no vulnerabilities
- `tests/web/e2e/edit-session.spec.js` Playwright run → 26 passed, 4 skipped (phone UI)
- Pre-push hook (lefthook) passes locally

## Test plan

- [ ] PATCH `/api/sessions/{id}` with `{"title":"x"}` returns `{updatedFields:["title"], restartRequired:false}`.
- [ ] PATCH with `{"tool":"shell"}` returns `restartRequired:true`.
- [ ] PATCH `/api/sessions/does-not-exist` returns 404.
- [ ] PATCH with `{}` returns 400 with "at least one field is required".
- [ ] PATCH with `{"color":"bogus"}` returns 400 with the `session.MutationError` message ("invalid color …").
- [ ] Web UI: click the pencil on a session row, modify the title, click Save — sidebar updates without page reload.
- [ ] Web UI: Cancel discards changes.
- [ ] Web UI: Save is disabled while Title is empty.

DO NOT merge — handoff to maintainer per worker prompt.

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit Session dialog to modify title, notes, color and advanced options; Edit button and icon in session rows; PATCH API returns which fields changed and whether restart is required.

* **Bug Fixes / UX**
  * Validate edits (reject empty/whitespace title); Save disabled when title blank; sidebar updates immediately after successful edits; click-overlay fix for per-row action buttons.

* **Tests**
  * New unit and end-to-end tests covering PATCH behavior, UI dialog flows, and parity with the REST API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->