### PR TITLE
feat(mcp): manage Cursor Agent CLI mcp.json (project + global)

### DIFF
--- a/cmd/agent-deck/mcp_cmd.go
+++ b/cmd/agent-deck/mcp_cmd.go
@@ -252,7 +252,10 @@ func handleMCPAttached(profile string, args []string) {
 	}
 
 	// Get MCP info for this session
-	mcpInfo := session.GetMCPInfo(inst.ProjectPath)
+	mcpInfo := inst.GetMCPInfo()
+	if mcpInfo == nil {
+		mcpInfo = &session.MCPInfo{}
+	}
 	globalMCPs := mcpInfo.Global
 	projectMCPs := mcpInfo.Project
 	localMCPs := mcpInfo.Local() // Call method for backward compatibility
@@ -299,7 +302,10 @@ func handleMCPAttached(profile string, args []string) {
 
 	if len(localMCPs) > 0 {
 		hasAny = true
-		mcpPath := filepath.Join(inst.ProjectPath, ".mcp.json")
+		mcpPath := inst.MCPLocalConfigPath()
+		if mcpPath == "" {
+			mcpPath = filepath.Join(inst.ProjectPath, ".mcp.json")
+		}
 		fmt.Printf("LOCAL (%s):\n", FormatPath(mcpPath))
 		for _, name := range localMCPs {
 			fmt.Printf("  %s %s\n", bulletSymbol, name)
@@ -309,8 +315,10 @@ func handleMCPAttached(profile string, args []string) {
 
 	if len(globalMCPs) > 0 {
 		hasAny = true
-		configDir := session.GetClaudeConfigDir()
-		configPath := filepath.Join(configDir, ".claude.json")
+		configPath := inst.MCPGlobalConfigPath()
+		if configPath == "" {
+			configPath = filepath.Join(session.GetClaudeConfigDir(), ".claude.json")
+		}
 		fmt.Printf("GLOBAL (%s):\n", FormatPath(configPath))
 		for _, name := range globalMCPs {
 			fmt.Printf("  %s %s\n", bulletSymbol, name)
@@ -415,45 +423,45 @@ func handleMCPAttach(profile string, args []string) {
 
 	// Attach the MCP
 	if *global {
-		// Add to global config
-		currentGlobal := session.GetGlobalMCPNames()
-		// Check if already attached
+		mcpInfo := inst.GetMCPInfo()
+		if mcpInfo == nil {
+			mcpInfo = &session.MCPInfo{}
+		}
+		currentGlobal := mcpInfo.Global
 		for _, name := range currentGlobal {
 			if name == mcpName {
 				out.Error(fmt.Sprintf("MCP '%s' is already attached globally", mcpName), ErrCodeAlreadyExists)
 				os.Exit(1)
 			}
 		}
-		// Add to list
 		newGlobal := append(currentGlobal, mcpName)
-		if err := session.WriteGlobalMCP(newGlobal); err != nil {
-			out.Error(fmt.Sprintf("failed to write global config: %v", err), ErrCodeInvalidOperation)
+		if err := inst.WriteGlobalMCPConfig(newGlobal); err != nil {
+			out.Error(fmt.Sprintf("failed to write global MCP config: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
 	} else {
-		// Add to local .mcp.json
-		mcpInfo := session.GetMCPInfo(inst.ProjectPath)
-		// Check if already attached locally
+		mcpInfo := inst.MCPInfoForLocalAttach()
+		if mcpInfo == nil {
+			mcpInfo = &session.MCPInfo{}
+		}
 		for _, name := range mcpInfo.Local() {
 			if name == mcpName {
 				out.Error(fmt.Sprintf("MCP '%s' is already attached locally", mcpName), ErrCodeAlreadyExists)
 				os.Exit(1)
 			}
 		}
-		// Add to local MCPs
 		newLocal := append(mcpInfo.Local(), mcpName)
-		if err := session.WriteMCPJsonFromConfig(inst.ProjectPath, newLocal); err != nil {
-			out.Error(fmt.Sprintf("failed to write .mcp.json: %v", err), ErrCodeInvalidOperation)
+		if err := inst.WriteLocalMCPConfig(newLocal); err != nil {
+			out.Error(fmt.Sprintf("failed to write local MCP config: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
 	}
 
-	// Clear MCP cache for this project
-	session.ClearMCPCache(inst.ProjectPath)
+	inst.InvalidateProjectMCPIntegrationsCache()
 
 	// Restart if requested
 	restarted := false
-	if *restart && (session.IsClaudeCompatible(inst.Tool) || inst.Tool == "gemini") {
+	if *restart && inst.SupportsMCPAgentRestart() {
 		if err := inst.Restart(); err != nil {
 			// Don't fail the whole operation, just warn
 			if !*jsonOutput && !quietMode {
@@ -463,8 +471,8 @@ func handleMCPAttach(profile string, args []string) {
 			restarted = true
 			// Auto-continue: wait for Claude/Gemini to initialize, then send continue message
 			time.Sleep(2 * time.Second)
-			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
-				// Send "continue" and Enter to resume the conversation
+			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil && inst.Tool != "cursor" {
+				// Claude/Gemini only — Cursor restart already resumes the agent session.
 				_ = tmuxSess.SendKeysAndEnter("continue")
 			}
 		}
@@ -558,8 +566,11 @@ func handleMCPDetach(profile string, args []string) {
 
 	// Detach the MCP
 	if *global {
-		// Remove from global config
-		currentGlobal := session.GetGlobalMCPNames()
+		mcpInfo := inst.GetMCPInfo()
+		if mcpInfo == nil {
+			mcpInfo = &session.MCPInfo{}
+		}
+		currentGlobal := mcpInfo.Global
 		found := false
 		newGlobal := make([]string, 0, len(currentGlobal))
 		for _, name := range currentGlobal {
@@ -573,13 +584,15 @@ func handleMCPDetach(profile string, args []string) {
 			out.Error(fmt.Sprintf("MCP '%s' is not attached globally", mcpName), ErrCodeNotFound)
 			os.Exit(2)
 		}
-		if err := session.WriteGlobalMCP(newGlobal); err != nil {
-			out.Error(fmt.Sprintf("failed to write global config: %v", err), ErrCodeInvalidOperation)
+		if err := inst.WriteGlobalMCPConfig(newGlobal); err != nil {
+			out.Error(fmt.Sprintf("failed to write global MCP config: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
 	} else {
-		// Remove from local .mcp.json
-		mcpInfo := session.GetMCPInfo(inst.ProjectPath)
+		mcpInfo := inst.MCPInfoForLocalAttach()
+		if mcpInfo == nil {
+			mcpInfo = &session.MCPInfo{}
+		}
 		found := false
 		localMCPs := mcpInfo.Local()
 		newLocal := make([]string, 0, len(localMCPs))
@@ -594,18 +607,17 @@ func handleMCPDetach(profile string, args []string) {
 			out.Error(fmt.Sprintf("MCP '%s' is not attached locally", mcpName), ErrCodeNotFound)
 			os.Exit(2)
 		}
-		if err := session.WriteMCPJsonFromConfig(inst.ProjectPath, newLocal); err != nil {
-			out.Error(fmt.Sprintf("failed to write .mcp.json: %v", err), ErrCodeInvalidOperation)
+		if err := inst.WriteLocalMCPConfig(newLocal); err != nil {
+			out.Error(fmt.Sprintf("failed to write local MCP config: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
 	}
 
-	// Clear MCP cache for this project
-	session.ClearMCPCache(inst.ProjectPath)
+	inst.InvalidateProjectMCPIntegrationsCache()
 
 	// Restart if requested
 	restarted := false
-	if *restart && (session.IsClaudeCompatible(inst.Tool) || inst.Tool == "gemini") {
+	if *restart && inst.SupportsMCPAgentRestart() {
 		if err := inst.Restart(); err != nil {
 			// Don't fail the whole operation, just warn
 			if !*jsonOutput && !quietMode {
@@ -615,8 +627,8 @@ func handleMCPDetach(profile string, args []string) {
 			restarted = true
 			// Auto-continue: wait for Claude/Gemini to initialize, then send continue message
 			time.Sleep(2 * time.Second)
-			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
-				// Send "continue" and Enter to resume the conversation
+			if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil && inst.Tool != "cursor" {
+				// Claude/Gemini only — Cursor restart already resumes the agent session.
 				_ = tmuxSess.SendKeysAndEnter("continue")
 			}
 		}

--- a/internal/session/cursor_mcp.go
+++ b/internal/session/cursor_mcp.go
@@ -1,0 +1,257 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// GetCursorConfigDir returns ~/.cursor (Cursor IDE / Agent CLI config).
+func GetCursorConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".cursor")
+}
+
+// cursorProjectMCPPath resolves <project>/.cursor/mcp.json from a session project directory.
+// projectPath comes from agent-deck session metadata (local workspace), not remote input.
+func cursorProjectMCPPath(projectPath string) (string, error) {
+	if projectPath == "" {
+		return "", fmt.Errorf("empty project path")
+	}
+	root, err := filepath.Abs(filepath.Clean(projectPath))
+	if err != nil {
+		return "", err
+	}
+	mcpFile := filepath.Join(root, ".cursor", "mcp.json")
+	rel, err := filepath.Rel(root, mcpFile)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("cursor mcp path outside project: %s", projectPath)
+	}
+	return mcpFile, nil
+}
+
+func cursorGlobalMCPPath() string {
+	dir := GetCursorConfigDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "mcp.json")
+}
+
+var (
+	cursorMcpInfoCache   = make(map[string]*MCPInfo)
+	cursorMcpInfoCacheMu sync.RWMutex
+	cursorMcpCacheTimes  = make(map[string]time.Time)
+)
+
+// GetCursorMCPInfo reads Cursor Agent CLI MCP config: ~/.cursor/mcp.json (global)
+// and <project>/.cursor/mcp.json (project). Matches Cursor docs merge semantics for display.
+func GetCursorMCPInfo(projectPath string) *MCPInfo {
+	cursorMcpInfoCacheMu.RLock()
+	if cached, ok := cursorMcpInfoCache[projectPath]; ok {
+		if time.Since(cursorMcpCacheTimes[projectPath]) < mcpCacheExpiry {
+			cursorMcpInfoCacheMu.RUnlock()
+			return cached
+		}
+	}
+	cursorMcpInfoCacheMu.RUnlock()
+
+	info := getCursorMCPInfoUncached(projectPath)
+
+	cursorMcpInfoCacheMu.Lock()
+	cursorMcpInfoCache[projectPath] = info
+	cursorMcpCacheTimes[projectPath] = time.Now()
+	cursorMcpInfoCacheMu.Unlock()
+
+	return info
+}
+
+func getCursorMCPInfoUncached(projectPath string) *MCPInfo {
+	info := &MCPInfo{}
+
+	if gpath := cursorGlobalMCPPath(); gpath != "" {
+		if data, err := os.ReadFile(gpath); err == nil {
+			var cfg projectMCPConfig
+			if json.Unmarshal(data, &cfg) == nil && cfg.MCPServers != nil {
+				for name := range cfg.MCPServers {
+					info.Global = append(info.Global, name)
+				}
+			}
+		}
+	}
+
+	if projectPath != "" {
+		p, err := cursorProjectMCPPath(projectPath)
+		if err == nil {
+			if data, readErr := os.ReadFile(p); readErr == nil {
+				var cfg projectMCPConfig
+				if json.Unmarshal(data, &cfg) == nil && cfg.MCPServers != nil {
+					for name := range cfg.MCPServers {
+						info.LocalMCPs = append(info.LocalMCPs, LocalMCP{
+							Name:       name,
+							SourcePath: projectPath,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	sort.Strings(info.Global)
+	sort.Slice(info.LocalMCPs, func(i, j int) bool {
+		return info.LocalMCPs[i].Name < info.LocalMCPs[j].Name
+	})
+	return info
+}
+
+// ClearCursorMCPCache invalidates cached Cursor MCP info for a project path.
+func ClearCursorMCPCache(projectPath string) {
+	cursorMcpInfoCacheMu.Lock()
+	defer cursorMcpInfoCacheMu.Unlock()
+	delete(cursorMcpInfoCache, projectPath)
+	delete(cursorMcpCacheTimes, projectPath)
+}
+
+// ClearAllCursorMCPInfoCache clears all Cursor MCP cache entries (needed after global ~/.cursor/mcp.json writes).
+func ClearAllCursorMCPInfoCache() {
+	cursorMcpInfoCacheMu.Lock()
+	defer cursorMcpInfoCacheMu.Unlock()
+	clear(cursorMcpInfoCache)
+	clear(cursorMcpCacheTimes)
+}
+
+// PruneCursorMCPCache removes stale Cursor MCP cache entries (TTL), like PruneMCPCache.
+func PruneCursorMCPCache(maxAge time.Duration) {
+	cursorMcpInfoCacheMu.Lock()
+	defer cursorMcpInfoCacheMu.Unlock()
+	now := time.Now()
+	for path, t := range cursorMcpCacheTimes {
+		if now.Sub(t) > maxAge {
+			delete(cursorMcpInfoCache, path)
+			delete(cursorMcpCacheTimes, path)
+		}
+	}
+}
+
+// WriteCursorProjectMCP writes catalog MCPs to <project>/.cursor/mcp.json (Cursor Agent CLI).
+func WriteCursorProjectMCP(projectPath string, enabledNames []string) error {
+	if !GetManageMCPJson() {
+		mcpCatLog.Debug("cursor_mcp_json_management_disabled", "path", projectPath)
+		return nil
+	}
+	if projectPath == "" {
+		return fmt.Errorf("cursor project MCP: empty project path")
+	}
+	mcpFile, err := cursorProjectMCPPath(projectPath)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(mcpFile)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create .cursor directory: %w", err)
+	}
+	if err := WriteMergedMcpJSONFile(mcpFile, enabledNames, ""); err != nil {
+		return err
+	}
+	return nil
+}
+
+// WriteCursorGlobalMCP writes catalog MCPs to ~/.cursor/mcp.json. Preserves other JSON keys if present.
+func WriteCursorGlobalMCP(enabledNames []string) error {
+	if !GetManageMCPJson() {
+		mcpCatLog.Debug("cursor_mcp_json_management_disabled", "scope", "global")
+		return nil
+	}
+	configFile := cursorGlobalMCPPath()
+	if configFile == "" {
+		return fmt.Errorf("cannot resolve ~/.cursor")
+	}
+	if err := os.MkdirAll(filepath.Dir(configFile), 0o755); err != nil {
+		return fmt.Errorf("create cursor config dir: %w", err)
+	}
+
+	var rawConfig map[string]interface{}
+	if data, err := os.ReadFile(configFile); err == nil {
+		if err := json.Unmarshal(data, &rawConfig); err != nil {
+			rawConfig = make(map[string]interface{})
+		}
+	} else {
+		rawConfig = make(map[string]interface{})
+	}
+
+	availableMCPs := GetAvailableMCPs()
+	pool := GetGlobalPool()
+
+	mcpServers := make(map[string]MCPServerConfig)
+	for _, name := range enabledNames {
+		if def, ok := availableMCPs[name]; ok {
+			if def.URL != "" {
+				if def.HasAutoStartServer() {
+					if err := StartHTTPServer(name, &def); err != nil {
+						mcpCatLog.Warn("http_server_start_failed", slog.String("mcp", name), slog.String("scope", "cursor-global"), slog.Any("error", err))
+					}
+				}
+
+				transport := def.Transport
+				if transport == "" {
+					transport = "http"
+				}
+				mcpServers[name] = MCPServerConfig{
+					Type:    transport,
+					URL:     def.URL,
+					Headers: def.Headers,
+				}
+				continue
+			}
+
+			if socketCfg, used := tryPoolSocket(pool, name, "global"); used {
+				mcpServers[name] = socketCfg
+				continue
+			}
+
+			args := def.Args
+			if args == nil {
+				args = []string{}
+			}
+			env := def.Env
+			if env == nil {
+				env = map[string]string{}
+			}
+			mcpServers[name] = MCPServerConfig{
+				Type:    "stdio",
+				Command: def.Command,
+				Args:    args,
+				Env:     env,
+			}
+		}
+	}
+
+	rawConfig["mcpServers"] = mcpServers
+
+	newData, err := json.MarshalIndent(rawConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal cursor mcp.json: %w", err)
+	}
+
+	tmpPath := configFile + ".tmp"
+	if err := os.WriteFile(tmpPath, newData, 0o600); err != nil {
+		return fmt.Errorf("write cursor mcp.json: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, configFile); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("save cursor mcp.json: %w", err)
+	}
+
+	ClearAllCursorMCPInfoCache()
+	return nil
+}

--- a/internal/session/cursor_mcp_test.go
+++ b/internal/session/cursor_mcp_test.go
@@ -1,0 +1,123 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetCursorMCPInfo(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(filepath.Join(proj, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+
+	globalJSON := `{"mcpServers":{"g1":{"command":"echo","args":["g"]},"extra":{"command":"x"}}}`
+	if err := os.WriteFile(filepath.Join(home, ".cursor", "mcp.json"), []byte(globalJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	localJSON := `{"mcpServers":{"l1":{"command":"echo","args":["l"]}}}`
+	if err := os.WriteFile(filepath.Join(proj, ".cursor", "mcp.json"), []byte(localJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ClearCursorMCPCache(proj)
+	info := GetCursorMCPInfo(proj)
+	if info == nil {
+		t.Fatal("nil info")
+	}
+	if len(info.Global) != 2 {
+		t.Fatalf("global count = %d, want 2: %v", len(info.Global), info.Global)
+	}
+	if len(info.LocalMCPs) != 1 || info.LocalMCPs[0].Name != "l1" {
+		t.Fatalf("local = %#v", info.LocalMCPs)
+	}
+}
+
+func TestWriteCursorProjectMCP_MergedWithUnmanaged(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(filepath.Join(proj, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &UserConfig{MCPs: map[string]MCPDef{
+		"cat": {Command: "echo", Args: []string{"meow"}},
+	}}
+	restoreCfg := resetUserConfigCache(t, cfg)
+	t.Cleanup(restoreCfg)
+
+	seed := `{"mcpServers":{"orphan":{"command":"true"}}}`
+	mcpFile := filepath.Join(proj, ".cursor", "mcp.json")
+	if err := os.WriteFile(mcpFile, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteCursorProjectMCP(proj, []string{"cat"}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(mcpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := out.MCPServers["orphan"]; !ok {
+		t.Fatal("expected orphan preserved")
+	}
+	if _, ok := out.MCPServers["cat"]; !ok {
+		t.Fatal("expected cat from catalog")
+	}
+}
+
+func TestWriteCursorGlobalMCP_PreservesOtherKeys(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+
+	cfg := &UserConfig{MCPs: map[string]MCPDef{
+		"cat": {Command: "echo", Args: []string{"purr"}},
+	}}
+	restoreCfg := resetUserConfigCache(t, cfg)
+	t.Cleanup(restoreCfg)
+
+	path := filepath.Join(home, ".cursor", "mcp.json")
+	seed := []byte(`{"foo":1,"mcpServers":{}}`)
+	if err := os.WriteFile(path, seed, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteCursorGlobalMCP([]string{"cat"}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw["foo"] == nil {
+		t.Fatal("expected foo key preserved")
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -6203,13 +6203,15 @@ func (i *Instance) RefreshLiveSessionIDs() {
 }
 
 // GetMCPInfo returns MCP server information for this session
-// Returns nil if not a Claude or Gemini session
+// Returns nil if not a Claude, Gemini, or Cursor session
 func (i *Instance) GetMCPInfo() *MCPInfo {
 	switch {
 	case IsClaudeCompatible(i.Tool):
 		return GetMCPInfo(i.ProjectPath)
 	case i.Tool == "gemini":
 		return GetGeminiMCPInfo(i.ProjectPath)
+	case i.Tool == "cursor":
+		return GetCursorMCPInfo(i.ProjectPath)
 	default:
 		return nil
 	}
@@ -6219,12 +6221,12 @@ func (i *Instance) GetMCPInfo() *MCPInfo {
 // This should be called when a session starts or restarts, so we can track
 // which MCPs are actually loaded in the running Claude session vs just configured
 func (i *Instance) CaptureLoadedMCPs() {
-	if !IsClaudeCompatible(i.Tool) {
+	if !IsClaudeCompatible(i.Tool) && i.Tool != "cursor" {
 		i.LoadedMCPNames = nil
 		return
 	}
 
-	mcpInfo := GetMCPInfo(i.ProjectPath)
+	mcpInfo := i.GetMCPInfo()
 	if mcpInfo == nil {
 		i.LoadedMCPNames = nil
 		return
@@ -6238,6 +6240,38 @@ func (i *Instance) CaptureLoadedMCPs() {
 // Otherwise, MCPs will use stdio configs (npx ...)
 // Returns error if .mcp.json write fails
 func (i *Instance) regenerateMCPConfig() error {
+	if i.Tool == "cursor" {
+		ClearCursorMCPCache(i.ProjectPath)
+		mcpInfo := i.GetMCPInfo()
+		if mcpInfo == nil || !mcpInfo.HasAny() {
+			return nil
+		}
+
+		switch GetMCPDefaultScope() {
+		case "global", "user":
+			globalMCPs := mcpInfo.Global
+			if len(globalMCPs) == 0 {
+				return nil
+			}
+			if err := i.WriteGlobalMCPConfig(globalMCPs); err != nil {
+				mcpLog.Debug("regen_cursor_global_mcp_failed", slog.String("error", err.Error()))
+				return fmt.Errorf("failed to regenerate Cursor global MCP config: %w", err)
+			}
+			mcpLog.Debug("regen_cursor_global_mcp_succeeded", slog.String("title", i.Title), slog.Int("mcp_count", len(globalMCPs)))
+		default:
+			localMCPs := mcpInfo.Local()
+			if len(localMCPs) == 0 {
+				return nil
+			}
+			if err := i.WriteLocalMCPConfig(localMCPs); err != nil {
+				mcpLog.Debug("regen_cursor_project_mcp_failed", slog.String("error", err.Error()))
+				return fmt.Errorf("failed to regenerate .cursor/mcp.json: %w", err)
+			}
+			mcpLog.Debug("regen_cursor_project_mcp_succeeded", slog.String("title", i.Title), slog.Int("mcp_count", len(localMCPs)))
+		}
+		return nil
+	}
+
 	ClearMCPCache(i.ProjectPath) // Force fresh read from disk (not stale 30s cache)
 	mcpInfo := GetMCPInfo(i.ProjectPath)
 	if mcpInfo == nil {

--- a/internal/session/instance_mcp.go
+++ b/internal/session/instance_mcp.go
@@ -1,0 +1,125 @@
+package session
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// ToolSupportsMCPManager reports whether the TUI/CLI MCP surfaces apply to this tool.
+func ToolSupportsMCPManager(toolName string) bool {
+	return IsClaudeCompatible(toolName) || toolName == "gemini" || toolName == "cursor"
+}
+
+// MCPLocalConfigPathForTool returns the project-local MCP config path for display and writes.
+// Empty when the tool has no project-local MCP file (e.g. Gemini uses global settings only).
+func MCPLocalConfigPathForTool(toolName, projectPath string) string {
+	if projectPath == "" {
+		return ""
+	}
+	switch {
+	case IsClaudeCompatible(toolName):
+		return filepath.Join(projectPath, ".mcp.json")
+	case toolName == "cursor":
+		return filepath.Join(projectPath, ".cursor", "mcp.json")
+	default:
+		return ""
+	}
+}
+
+// MCPGlobalConfigPathForTool returns the global MCP config path for display and writes.
+func MCPGlobalConfigPathForTool(toolName string) string {
+	switch {
+	case IsClaudeCompatible(toolName):
+		return filepath.Join(GetClaudeConfigDir(), ".claude.json")
+	case toolName == "gemini":
+		return filepath.Join(GetGeminiConfigDir(), "settings.json")
+	case toolName == "cursor":
+		return filepath.Join(GetCursorConfigDir(), "mcp.json")
+	default:
+		return ""
+	}
+}
+
+// MCPInfoForLocalAttach returns MCP info used for CLI/TUI local attach and detach.
+// Gemini is special: global MCPs live in settings.json, but "local" CLI scope still
+// targets the Claude-style .mcp.json walker in the project tree (legacy behavior).
+func MCPInfoForLocalAttach(toolName, projectPath string) *MCPInfo {
+	if toolName == "gemini" {
+		return GetMCPInfo(projectPath)
+	}
+	switch {
+	case toolName == "cursor":
+		return GetCursorMCPInfo(projectPath)
+	case IsClaudeCompatible(toolName):
+		return GetMCPInfo(projectPath)
+	default:
+		return &MCPInfo{}
+	}
+}
+
+// WriteLocalMCPConfigForTool writes enabled catalog MCPs to the tool's project-local MCP file.
+func WriteLocalMCPConfigForTool(toolName, projectPath string, names []string) error {
+	switch {
+	case toolName == "cursor":
+		return WriteCursorProjectMCP(projectPath, names)
+	case IsClaudeCompatible(toolName) || toolName == "gemini":
+		return WriteMCPJsonFromConfig(projectPath, names)
+	default:
+		return fmt.Errorf("local MCP: unsupported tool %q", toolName)
+	}
+}
+
+// WriteGlobalMCPConfigForTool writes enabled catalog MCPs to the tool's global MCP store.
+func WriteGlobalMCPConfigForTool(toolName string, names []string) error {
+	switch {
+	case IsClaudeCompatible(toolName):
+		return WriteGlobalMCP(names)
+	case toolName == "gemini":
+		return WriteGeminiMCPSettings(names)
+	case toolName == "cursor":
+		return WriteCursorGlobalMCP(names)
+	default:
+		return fmt.Errorf("global MCP: unsupported tool %q", toolName)
+	}
+}
+
+// InvalidateProjectMCPIntegrationsCache clears session caches used by Claude-style and Cursor MCP reads.
+func InvalidateProjectMCPIntegrationsCache(projectPath string) {
+	ClearMCPCache(projectPath)
+	ClearCursorMCPCache(projectPath)
+}
+
+// MCPLocalConfigPath returns the project-local MCP file path for this instance's tool.
+func (i *Instance) MCPLocalConfigPath() string {
+	return MCPLocalConfigPathForTool(i.Tool, i.ProjectPath)
+}
+
+// MCPGlobalConfigPath returns the global MCP file path for this instance's tool.
+func (i *Instance) MCPGlobalConfigPath() string {
+	return MCPGlobalConfigPathForTool(i.Tool)
+}
+
+// MCPInfoForLocalAttach returns MCP info for local attach/detach for this instance.
+func (i *Instance) MCPInfoForLocalAttach() *MCPInfo {
+	return MCPInfoForLocalAttach(i.Tool, i.ProjectPath)
+}
+
+// WriteLocalMCPConfig writes catalog MCPs to this instance's project-local MCP file.
+func (i *Instance) WriteLocalMCPConfig(names []string) error {
+	return WriteLocalMCPConfigForTool(i.Tool, i.ProjectPath, names)
+}
+
+// WriteGlobalMCPConfig writes catalog MCPs to this instance's global MCP store.
+func (i *Instance) WriteGlobalMCPConfig(names []string) error {
+	return WriteGlobalMCPConfigForTool(i.Tool, names)
+}
+
+// InvalidateProjectMCPIntegrationsCache clears MCP read caches for this instance's project.
+func (i *Instance) InvalidateProjectMCPIntegrationsCache() {
+	InvalidateProjectMCPIntegrationsCache(i.ProjectPath)
+}
+
+// SupportsMCPAgentRestart is true when attach/detach --restart may reload the running agent.
+func (i *Instance) SupportsMCPAgentRestart() bool {
+	return ToolSupportsMCPManager(i.Tool)
+}

--- a/internal/session/instance_mcp_test.go
+++ b/internal/session/instance_mcp_test.go
@@ -1,0 +1,52 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMCPLocalConfigPathForTool(t *testing.T) {
+	proj := "/tmp/p"
+	if p := MCPLocalConfigPathForTool("cursor", proj); p != filepath.Join(proj, ".cursor", "mcp.json") {
+		t.Fatalf("cursor: got %q", p)
+	}
+	if p := MCPLocalConfigPathForTool("claude", proj); p != filepath.Join(proj, ".mcp.json") {
+		t.Fatalf("claude: got %q", p)
+	}
+	if p := MCPLocalConfigPathForTool("gemini", proj); p != "" {
+		t.Fatalf("gemini: want empty project-local path, got %q", p)
+	}
+	if MCPLocalConfigPathForTool("claude", "") != "" {
+		t.Fatal("empty project path")
+	}
+}
+
+func TestMCPInfoForLocalAttach_GeminiUsesProjectMcpJsonWalker(t *testing.T) {
+	tmp := t.TempDir()
+	sub := filepath.Join(tmp, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mcpFile := filepath.Join(tmp, ".mcp.json")
+	if err := os.WriteFile(mcpFile, []byte(`{"mcpServers":{"walked":{"command":"true"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info := MCPInfoForLocalAttach("gemini", sub)
+	if info == nil {
+		t.Fatal("nil info")
+	}
+	locals := info.Local()
+	if len(locals) != 1 || locals[0] != "walked" {
+		t.Fatalf("locals = %#v", locals)
+	}
+}
+
+func TestToolSupportsMCPManager(t *testing.T) {
+	if !ToolSupportsMCPManager("claude") || !ToolSupportsMCPManager("gemini") || !ToolSupportsMCPManager("cursor") {
+		t.Fatal("expected claude, gemini, cursor")
+	}
+	if ToolSupportsMCPManager("shell") || ToolSupportsMCPManager("") {
+		t.Fatal("unexpected tool")
+	}
+}

--- a/internal/session/mcp_catalog.go
+++ b/internal/session/mcp_catalog.go
@@ -140,50 +140,35 @@ func readExistingLocalMCPServers(mcpFile string) map[string]json.RawMessage {
 	return config.MCPServers
 }
 
-// WriteMCPJsonFromConfig writes enabled MCPs from config.toml to project's .mcp.json
-// It preserves any existing entries not managed by agent-deck (not defined in config.toml)
-func WriteMCPJsonFromConfig(projectPath string, enabledNames []string) error {
-	if !GetManageMCPJson() {
-		mcpCatLog.Debug("mcp_json_management_disabled", slog.String("path", projectPath))
-		return nil
-	}
-
-	mcpFile := filepath.Join(projectPath, ".mcp.json")
+// WriteMergedMcpJSONFile writes enabled MCPs from config.toml to mcpFile using the
+// Claude/Cursor JSON shape {"mcpServers":{...}}. It preserves entries not defined in
+// config.toml. When pluginPinClaudeProfile is non-empty (Claude project .mcp.json),
+// refreshes stale plugin version pins before merging (#960).
+func WriteMergedMcpJSONFile(mcpFile string, enabledNames []string, pluginPinClaudeProfile string) error {
 	availableMCPs := GetAvailableMCPs()
-	pool := GetGlobalPool() // Get pool instance (may be nil)
+	pool := GetGlobalPool()
 
-	// #960: refresh stale plugin-cache version pins in the file on disk before
-	// the merge reads it. Preserved (non-catalog) entries are reused verbatim
-	// (#146), so without this step a `claude plugin upgrade` leaves the old
-	// version path baked into .mcp.json forever and /mcp reconnect silently
-	// keeps loading the outdated plugin.
-	if profile := GetClaudeConfigDir(); profile != "" {
-		if _, err := RefreshStalePluginPins(mcpFile, []string{profile}); err != nil {
+	if pluginPinClaudeProfile != "" {
+		if _, err := RefreshStalePluginPins(mcpFile, []string{pluginPinClaudeProfile}); err != nil {
 			mcpCatLog.Warn("plugin_pin_refresh_failed", "path", mcpFile, "error", err)
 		}
 	}
 
-	// Read existing .mcp.json to preserve entries not managed by agent-deck (#146)
 	existingServers := readExistingLocalMCPServers(mcpFile)
-
-	// Build agent-deck managed MCP entries
 	agentDeckServers := make(map[string]MCPServerConfig)
 
 	for _, name := range enabledNames {
 		if def, ok := availableMCPs[name]; ok {
-			// Check if this is an HTTP/SSE MCP (has URL configured)
 			if def.URL != "" {
-				// Start HTTP server if configured
 				if def.HasAutoStartServer() {
 					if err := StartHTTPServer(name, &def); err != nil {
 						mcpCatLog.Warn("http_server_start_failed", slog.String("mcp", name), slog.String("scope", "local"), slog.Any("error", err))
-						// Continue anyway - server might be external or user will troubleshoot
 					}
 				}
 
 				transport := def.Transport
 				if transport == "" {
-					transport = "http" // default to http if URL is set
+					transport = "http"
 				}
 				agentDeckServers[name] = MCPServerConfig{
 					Type:    transport,
@@ -194,13 +179,11 @@ func WriteMCPJsonFromConfig(projectPath string, enabledNames []string) error {
 				continue
 			}
 
-			// Try to use pool socket for this MCP (stdio only)
 			if socketCfg, used := tryPoolSocket(pool, name, "local"); used {
 				agentDeckServers[name] = socketCfg
 				continue
 			}
 
-			// Fallback to stdio mode (pool disabled, excluded, or socket failed with fallback enabled)
 			args := def.Args
 			if args == nil {
 				args = []string{}
@@ -219,7 +202,6 @@ func WriteMCPJsonFromConfig(projectPath string, enabledNames []string) error {
 		}
 	}
 
-	// Merge: preserve non-agent-deck entries, then add agent-deck entries (#146)
 	mergedServers := make(map[string]json.RawMessage)
 	for name, raw := range existingServers {
 		if _, managed := availableMCPs[name]; !managed {
@@ -244,21 +226,32 @@ func WriteMCPJsonFromConfig(projectPath string, enabledNames []string) error {
 
 	data, err := json.MarshalIndent(finalConfig, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal .mcp.json: %w", err)
+		return fmt.Errorf("failed to marshal mcp json: %w", err)
 	}
 
-	// Atomic write
 	tmpPath := mcpFile + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
-		return fmt.Errorf("failed to write .mcp.json: %w", err)
+		return fmt.Errorf("failed to write mcp json temp: %w", err)
 	}
 
 	if err := os.Rename(tmpPath, mcpFile); err != nil {
 		os.Remove(tmpPath)
-		return fmt.Errorf("failed to save .mcp.json: %w", err)
+		return fmt.Errorf("failed to save mcp json: %w", err)
 	}
 
 	return nil
+}
+
+// WriteMCPJsonFromConfig writes enabled MCPs from config.toml to project's .mcp.json
+// It preserves any existing entries not managed by agent-deck (not defined in config.toml)
+func WriteMCPJsonFromConfig(projectPath string, enabledNames []string) error {
+	if !GetManageMCPJson() {
+		mcpCatLog.Debug("mcp_json_management_disabled", slog.String("path", projectPath))
+		return nil
+	}
+
+	mcpFile := filepath.Join(projectPath, ".mcp.json")
+	return WriteMergedMcpJSONFile(mcpFile, enabledNames, GetClaudeConfigDir())
 }
 
 // WriteGlobalMCP adds or removes MCPs from Claude's global config

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -243,7 +243,7 @@ func (h *HelpOverlay) View() string {
 				{closeKey, "Close session process"},
 				{undoKey, "Undo delete"},
 				{moveKey, "Move to group"},
-				{mcpKey, "MCP Manager (Claude/Gemini)"},
+				{mcpKey, "MCP Manager (Claude/Gemini/Cursor)"},
 				{pluginKey, "Plugin Manager (Claude — RFC PLUGIN_ATTACH.md)"},
 				{skillsKey, "Skills Manager"},
 				{"$", "Cost Dashboard"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1795,10 +1795,14 @@ func (h *Home) syncViewport() {
 	if h.maintenanceMsg != "" {
 		maintenanceBannerHeight = 1
 	}
+	debugBarHeight := 0
+	if h.debugMode {
+		debugBarHeight = 1
+	}
 
 	// contentHeight = total height for main content area
-	// -1 for header line, -helpBarHeight for help bar, -updateBannerHeight, -maintenanceBannerHeight, -filterBarHeight
-	contentHeight := h.height - 1 - helpBarHeight - updateBannerHeight - maintenanceBannerHeight - filterBarHeight
+	// MUST match View(): subtract debugBarHeight when the debug footer is rendered.
+	contentHeight := h.height - 1 - helpBarHeight - updateBannerHeight - maintenanceBannerHeight - filterBarHeight - debugBarHeight
 
 	// CRITICAL: Calculate panelContentHeight based on current layout mode
 	// This MUST match the calculations in renderStackedLayout/renderDualColumnLayout/renderSingleColumnLayout
@@ -1938,8 +1942,12 @@ func (h *Home) getVisibleHeight() int {
 	if h.maintenanceMsg != "" {
 		maintenanceBannerHeight = 1
 	}
+	debugBarHeight := 0
+	if h.debugMode {
+		debugBarHeight = 1
+	}
 
-	contentHeight := h.height - 1 - helpBarHeight - updateBannerHeight - maintenanceBannerHeight - filterBarHeight
+	contentHeight := h.height - 1 - helpBarHeight - updateBannerHeight - maintenanceBannerHeight - filterBarHeight - debugBarHeight
 
 	var panelContentHeight int
 	layoutMode := h.getLayoutMode()
@@ -2461,6 +2469,7 @@ func (h *Home) pruneAnalyticsCache() {
 
 	// Prune MCP info cache (entries older than 10 minutes)
 	session.PruneMCPCache(maxAge)
+	session.PruneCursorMCPCache(maxAge)
 }
 
 // setError sets an error with timestamp for auto-dismiss
@@ -6671,11 +6680,11 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case "m":
-		// MCP Manager - for Claude and Gemini sessions
+		// MCP Manager — Claude, Gemini, and Cursor Agent CLI
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil &&
-				(session.IsClaudeCompatible(item.Session.Tool) || item.Session.Tool == "gemini") {
+				session.ToolSupportsMCPManager(item.Session.Tool) {
 				h.mcpDialog.SetSize(h.width, h.height)
 				if err := h.mcpDialog.Show(item.Session.ProjectPath, item.Session.ID, item.Session.Tool); err != nil {
 					h.setError(err)
@@ -11355,7 +11364,7 @@ func (h *Home) renderHelpBarMinimal() string {
 					contextKeys += " " + forkRendered
 				}
 			}
-			if item.Session != nil && (session.IsClaudeCompatible(item.Session.Tool) || item.Session.Tool == "gemini") {
+			if item.Session != nil && session.ToolSupportsMCPManager(item.Session.Tool) {
 				mcpRendered := renderKeys(mcpKey)
 				if mcpRendered != "" {
 					contextKeys += " " + mcpRendered
@@ -11455,7 +11464,7 @@ func (h *Home) renderHelpBarCompact() string {
 					contextHints = append(contextHints, h.helpKeyShort(key, "Fork"))
 				}
 			}
-			if item.Session != nil && (session.IsClaudeCompatible(item.Session.Tool) || item.Session.Tool == "gemini") {
+			if item.Session != nil && session.ToolSupportsMCPManager(item.Session.Tool) {
 				if key := h.actionKey(hotkeyMCPManager); key != "" {
 					contextHints = append(contextHints, h.helpKeyShort(key, "MCP"))
 				}
@@ -11634,7 +11643,7 @@ func (h *Home) renderHelpBarFull() string {
 				}
 			}
 			// Show MCP Manager and preview mode toggle for Claude and Gemini sessions
-			if item.Session != nil && (session.IsClaudeCompatible(item.Session.Tool) || item.Session.Tool == "gemini") {
+			if item.Session != nil && session.ToolSupportsMCPManager(item.Session.Tool) {
 				if mcpKey != "" {
 					primaryHints = append(primaryHints, h.helpKey(mcpKey, "MCP"))
 				}
@@ -11893,7 +11902,7 @@ func (h *Home) renderSessionList(width, height int) string {
 		if h.jumpMode && i < len(jumpHints) {
 			// Render item to temp buffer, then overlay hint badge at name position
 			var itemBuf strings.Builder
-			h.renderItem(&itemBuf, item, i == h.cursor, i, groupStats, snapshot)
+			h.renderItem(&itemBuf, item, i == h.cursor, i, groupStats, snapshot, width)
 			raw := itemBuf.String()
 			hint := jumpHints[i]
 			isMatch := h.jumpBuffer == "" || strings.HasPrefix(hint, h.jumpBuffer)
@@ -11913,7 +11922,7 @@ func (h *Home) renderSessionList(width, height int) string {
 				b.WriteString(raw)
 			}
 		} else {
-			h.renderItem(&b, item, i == h.cursor, i, groupStats, snapshot)
+			h.renderItem(&b, item, i == h.cursor, i, groupStats, snapshot, width)
 		}
 		visibleCount++
 	}
@@ -11991,6 +12000,7 @@ func (h *Home) renderItem(
 	itemIndex int,
 	groupStats map[string]groupRenderStats,
 	snapshot map[string]sessionRenderState,
+	listWidth int,
 ) {
 	switch item.Type {
 	case session.ItemTypeGroup:
@@ -11999,7 +12009,7 @@ func (h *Home) renderItem(
 		if item.CreatingID != "" {
 			h.renderCreatingSessionItem(b, item, selected)
 		} else {
-			h.renderSessionItem(b, item, selected, snapshot)
+			h.renderSessionItem(b, item, selected, snapshot, listWidth)
 		}
 	case session.ItemTypeWindow:
 		h.renderWindowItem(b, item, selected)
@@ -12182,6 +12192,7 @@ func (h *Home) renderSessionItem(
 	item session.Item,
 	selected bool,
 	snapshot map[string]sessionRenderState,
+	listWidth int,
 ) {
 	inst := item.Session
 
@@ -12414,7 +12425,11 @@ func (h *Home) renderSessionItem(
 	// the panel and shove subsequent rows down by one cell. See
 	// internal/ui/cellwidth.go for the upstream disagreement.
 	if selected && instState.paneTitle != "" {
-		remaining := h.width - cellWidth(row) - 2 // -2 for trailing margin
+		// Dual layout: sidebar is narrower than h.width (#937). Using full
+		// terminal width here overflows the SESSIONS pane, then lipgloss
+		// truncation disagrees from terminal cells — wrapped lines duplicate
+		// rows visually and mouseY→item indexing breaks until scroll settles.
+		remaining := listWidth - cellWidth(row) - 2 // -2 for trailing margin
 		if remaining > 10 {
 			pt := instState.paneTitle
 			if cellWidth(pt) > remaining {
@@ -13490,6 +13505,23 @@ func (h *Home) renderPreviewPane(width, height int) string {
 			b.WriteString("\n")
 			renderLaunchModelInfoLines(&b, selected)
 		}
+	}
+
+	// Cursor Agent CLI — MCP configuration for `cursor agent`
+	if selected.Tool == "cursor" {
+		cursorHeader := renderSectionDivider("Cursor", width-4)
+		b.WriteString(cursorHeader)
+		b.WriteString("\n")
+
+		labelStyle := lipgloss.NewStyle().Foreground(ColorText)
+		valueStyle := lipgloss.NewStyle().Foreground(ColorText)
+		b.WriteString(labelStyle.Render("Tool:    "))
+		b.WriteString(valueStyle.Render("Cursor Agent CLI"))
+		b.WriteString("\n")
+		renderLaunchModelInfoLines(&b, selected)
+
+		mcpInfo := selected.GetMCPInfo()
+		renderSimpleMCPLine(&b, mcpInfo, width)
 	}
 
 	// OpenCode-specific info (session ID)

--- a/internal/ui/issue391_tui_test.go
+++ b/internal/ui/issue391_tui_test.go
@@ -67,7 +67,7 @@ func renderSingleSessionRow(t *testing.T, inst *session.Instance) string {
 	}
 
 	var b strings.Builder
-	h.renderSessionItem(&b, item, false, snapshot)
+	h.renderSessionItem(&b, item, false, snapshot, h.width)
 	return b.String()
 }
 

--- a/internal/ui/mcp_dialog.go
+++ b/internal/ui/mcp_dialog.go
@@ -44,7 +44,7 @@ type MCPItem struct {
 	HasServerCfg bool   // True if HTTP MCP has [mcps.X.server] config
 }
 
-// MCPDialog handles MCP management for Claude and Gemini sessions
+// MCPDialog handles MCP management for Claude, Gemini, and Cursor Agent CLI sessions
 type MCPDialog struct {
 	visible     bool
 	width       int
@@ -197,6 +197,53 @@ func (m *MCPDialog) Show(projectPath string, sessionID string, tool string) erro
 				})
 			}
 		}
+	} else if tool == "cursor" {
+		// Cursor Agent CLI: project .cursor/mcp.json (local) + ~/.cursor/mcp.json (global)
+		mcpInfo := session.GetCursorMCPInfo(projectPath)
+		localAttachedNames := make(map[string]bool)
+		for _, name := range mcpInfo.Local() {
+			localAttachedNames[name] = true
+		}
+		globalAttachedNames := make(map[string]bool)
+		for _, name := range mcpInfo.Global {
+			globalAttachedNames[name] = true
+		}
+
+		for _, name := range allNames {
+			item := itemsMap[name]
+			if localAttachedNames[name] {
+				m.localAttached = append(m.localAttached, item)
+			} else if !globalAttachedNames[name] {
+				m.localAvailable = append(m.localAvailable, item)
+			}
+		}
+		for name := range localAttachedNames {
+			if !poolNames[name] {
+				m.localAttached = append(m.localAttached, MCPItem{
+					Name:        name,
+					Description: "(not in config.toml)",
+					IsOrphan:    true,
+				})
+			}
+		}
+
+		for _, name := range allNames {
+			item := itemsMap[name]
+			if globalAttachedNames[name] {
+				m.globalAttached = append(m.globalAttached, item)
+			} else {
+				m.globalAvailable = append(m.globalAvailable, item)
+			}
+		}
+		for name := range globalAttachedNames {
+			if !poolNames[name] {
+				m.globalAttached = append(m.globalAttached, MCPItem{
+					Name:        name,
+					Description: "(not in config.toml)",
+					IsOrphan:    true,
+				})
+			}
+		}
 	} else {
 		// Claude: Load LOCAL attached from .mcp.json
 		localAttachedNames := make(map[string]bool)
@@ -289,9 +336,16 @@ func (m *MCPDialog) Show(projectPath string, sessionID string, tool string) erro
 
 	m.visible = true
 	m.projectPath = projectPath
-	// Gemini only has global scope, Claude uses configured default
+	// Gemini only has global scope; Cursor uses LOCAL+GLOBAL (no USER); Claude uses all three
 	if tool == "gemini" {
 		m.scope = MCPScopeGlobal
+	} else if tool == "cursor" {
+		switch session.GetMCPDefaultScope() {
+		case "global", "user":
+			m.scope = MCPScopeGlobal
+		default:
+			m.scope = MCPScopeLocal
+		}
 	} else {
 		switch session.GetMCPDefaultScope() {
 		case "global":
@@ -547,6 +601,33 @@ func (m *MCPDialog) Apply() error {
 		return nil
 	}
 
+	if m.tool == "cursor" {
+		if m.localChanged {
+			enabledNames := make([]string, len(m.localAttached))
+			for i, item := range m.localAttached {
+				enabledNames[i] = item.Name
+			}
+			if err := session.WriteLocalMCPConfigForTool(m.tool, m.projectPath, enabledNames); err != nil {
+				m.err = err
+				return err
+			}
+		}
+		if m.globalChanged {
+			enabledNames := make([]string, len(m.globalAttached))
+			for i, item := range m.globalAttached {
+				enabledNames[i] = item.Name
+			}
+			if err := session.WriteGlobalMCPConfigForTool(m.tool, enabledNames); err != nil {
+				m.err = err
+				return err
+			}
+		}
+		if m.localChanged || m.globalChanged {
+			session.InvalidateProjectMCPIntegrationsCache(m.projectPath)
+		}
+		return nil
+	}
+
 	// Claude: Apply LOCAL changes
 	if m.localChanged {
 		// Get names of attached MCPs
@@ -619,7 +700,17 @@ func (m *MCPDialog) Update(msg tea.KeyMsg) (*MCPDialog, tea.Cmd) {
 	case "tab":
 		// Switch scope: LOCAL -> GLOBAL -> USER -> LOCAL (Claude only)
 		// Gemini only has global scope, so Tab does nothing
-		if m.tool != "gemini" {
+		// Cursor: LOCAL <-> GLOBAL only
+		if m.tool == "gemini" {
+			// no-op
+		} else if m.tool == "cursor" {
+			switch m.scope {
+			case MCPScopeLocal:
+				m.scope = MCPScopeGlobal
+			case MCPScopeGlobal:
+				m.scope = MCPScopeLocal
+			}
+		} else {
 			switch m.scope {
 			case MCPScopeLocal:
 				m.scope = MCPScopeGlobal
@@ -674,17 +765,36 @@ func (m *MCPDialog) View() string {
 
 	// Title varies by tool
 	title := "MCP Manager"
-	if m.tool == "gemini" {
+	switch m.tool {
+	case "gemini":
 		title = "MCP Manager (Gemini)"
+	case "cursor":
+		title = "MCP Manager (Cursor)"
 	}
 
-	// Scope tabs - Gemini only has global
+	// Scope tabs - Gemini only global; Cursor LOCAL+GLOBAL; Claude all three
 	var tabs string
-	if m.tool == "gemini" {
-		// Gemini: Only show GLOBAL (centered)
+	switch m.tool {
+	case "gemini":
 		globalTab := lipgloss.NewStyle().Bold(true).Foreground(ColorAccent).Render("[GLOBAL]")
 		tabs = "──────────────── " + globalTab + " ────────────────"
-	} else {
+	case "cursor":
+		localTab := "LOCAL"
+		globalTab := "GLOBAL"
+		localStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+		globalStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+		switch m.scope {
+		case MCPScopeLocal:
+			localStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
+			localTab = "[" + localTab + "]"
+			globalTab = " " + globalTab + " "
+		case MCPScopeGlobal:
+			globalStyle = lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
+			localTab = " " + localTab + " "
+			globalTab = "[" + globalTab + "]"
+		}
+		tabs = localStyle.Render(localTab) + " ─────────── " + globalStyle.Render(globalTab)
+	default:
 		// Claude: Show LOCAL/GLOBAL/USER tabs
 		localTab := "LOCAL"
 		globalTab := "GLOBAL"
@@ -744,9 +854,23 @@ func (m *MCPDialog) View() string {
 
 	// Scope description
 	var scopeDesc string
-	if m.tool == "gemini" {
+	switch m.tool {
+	case "gemini":
 		scopeDesc = DimStyle.Render("Writes to: ~/.gemini/settings.json")
-	} else {
+	case "cursor":
+		switch m.scope {
+		case MCPScopeLocal:
+			if !session.GetManageMCPJson() {
+				scopeDesc = lipgloss.NewStyle().Foreground(ColorYellow).Render("⚠ .cursor/mcp.json management disabled (manage_mcp_json = false in config.toml)")
+			} else {
+				scopeDesc = DimStyle.Render("Writes to: .cursor/mcp.json (project, Cursor Agent CLI)")
+			}
+		case MCPScopeGlobal:
+			scopeDesc = DimStyle.Render("Writes to: ~/.cursor/mcp.json (global, Cursor Agent CLI)")
+		default:
+			scopeDesc = ""
+		}
+	default:
 		switch m.scope {
 		case MCPScopeLocal:
 			if !session.GetManageMCPJson() {
@@ -770,9 +894,12 @@ func (m *MCPDialog) View() string {
 	// Hint with consistent styling
 	hintStyle := lipgloss.NewStyle().Foreground(ColorComment)
 	var hint string
-	if m.tool == "gemini" {
+	switch m.tool {
+	case "gemini":
 		hint = hintStyle.Render("←→ column │ Type jump │ Space move │ Enter apply │ Esc cancel")
-	} else {
+	case "cursor":
+		hint = hintStyle.Render("Tab scope │ ←→ column │ Type jump │ Space move │ Enter apply │ Esc cancel")
+	default:
 		hint = hintStyle.Render("Tab scope │ ←→ column │ Type jump │ Space move │ Enter apply │ Esc cancel")
 	}
 	if m.typeJumpBuf != "" && time.Now().Before(m.typeJumpUntil) {

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -1018,7 +1018,7 @@ func (s *SettingsPanel) View() string {
 	mcpKey := actionHotkey(hotkeys, hotkeyMCPManager)
 	mcpHint := "  MCP Manager hotkey is unbound."
 	if mcpKey != "" {
-		mcpHint = fmt.Sprintf("  Press %s on any Claude/Gemini session to attach MCPs.", mcpKey)
+		mcpHint = fmt.Sprintf("  Press %s on any Claude, Gemini, or Cursor session to attach MCPs.", mcpKey)
 	}
 	content.WriteString(dimStyle.Render(mcpHint))
 	content.WriteString("\n\n")

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -1014,11 +1014,13 @@ func TestSettingsPanel_ViewUsesConfiguredMCPHotkeyHint(t *testing.T) {
 	setSettingsPanelHotkeyConfigForTest(t, "[hotkeys]\nmcp_manager = \"ctrl+m\"\n")
 
 	panel := NewSettingsPanel()
-	panel.SetSize(100, 80)
+	// Tall viewport so the MCP hint (below many settings rows) is not clipped by scroll windowing.
+	panel.SetSize(120, 200)
 	panel.Show()
+	panel.cursor = int(SettingStatsShowLoad)
 
 	view := panel.View()
-	if !containsString(view, "Press ctrl+m on any Claude/Gemini session to attach MCPs.") {
+	if !containsString(view, "Press ctrl+m on any Claude, Gemini, or Cursor session to attach MCPs.") {
 		t.Fatalf("settings view should show configured MCP key hint, got %q", view)
 	}
 }

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -1020,7 +1020,9 @@ func TestSettingsPanel_ViewUsesConfiguredMCPHotkeyHint(t *testing.T) {
 	panel.cursor = int(SettingStatsShowLoad)
 
 	view := panel.View()
-	if !containsString(view, "Press ctrl+m on any Claude, Gemini, or Cursor session to attach MCPs.") {
+	// Hint may wrap across dialog lines; assert on stable fragments rather than one contiguous string.
+	if !containsString(view, "Press ctrl+m on any Claude, Gemini, or Cursor session") ||
+		!containsString(view, "attach MCPs") {
 		t.Fatalf("settings view should show configured MCP key hint, got %q", view)
 	}
 }


### PR DESCRIPTION
Wire MCP manager, CLI attach/detach, instance regeneration, and TUI to ~/.cursor/mcp.json and .cursor/mcp.json. Share merge logic with Claude via WriteMergedMcpJSONFile. Fix cursor_mcp tests with resetUserConfigCache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full MCP management for Cursor Agent CLI: attach/detach with LOCAL/GLOBAL scopes, merged config writes, preserved orphan entries, and atomic updates.

* **UI Updates**
  * MCP Manager, previews, help text, and hotkey now include Cursor; dialog shows Cursor-specific scopes, targets, warnings, and improved layout/truncation.

* **Behavior**
  * Attach/detach flows use instance-aware paths, respect tool-specific restart/automation differences, and invalidate per-project MCP caches.

* **Tests**
  * Added tests for Cursor MCP discovery, project/global writes, preservation, and instance-level MCP helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->