### PR TITLE
fix(session): restart properly respawns --channels plugin MCPs (fixes mass telegram outage, #1134)

### DIFF
--- a/internal/session/issue1134_channel_plugin_enabled_test.go
+++ b/internal/session/issue1134_channel_plugin_enabled_test.go
@@ -1,0 +1,177 @@
+// Package session — issue #1134 regression.
+//
+// agent-deck v1.7.68 introduced a scratch CLAUDE_CONFIG_DIR for
+// channel-owning conductors whose ambient profile has
+// `enabledPlugins."telegram@claude-plugins-official" = true` (the
+// "global antipattern" — issue #941). The scratch's settings.json
+// pinned the plugin to *false* on the theory that `--channels` would
+// re-activate it as the sole spawn source.
+//
+// That theory does not match real claude behavior. With the plugin
+// disabled in settings.json, claude does not establish the MCP stdio
+// transport for the channel server. The bun child either never spawns
+// or spawns into task-mode (stdout redirected to a task output file,
+// no MCP handshake) and dies in a crash-respawn loop. Net effect: a
+// conductor on `--channels plugin:telegram@...` is *deaf* to Telegram
+// inbound even though every other component (token, .env, plugin
+// install, agent-deck channel record) is correct.
+//
+// Fix: when a session owns the telegram channel, the scratch
+// settings.json must set `enabledPlugins."telegram@claude-plugins-official"
+// = true`. `--channels` is a routing/wiring directive — the plugin
+// must already be enabled for the wiring to reach a live MCP server.
+// Workers (no telegram channel) continue to be pinned false: their
+// "denied" path is unchanged.
+
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Happy path: a channel-owning conductor with the global-antipattern
+// topology (settings.telegram=true in source) gets a scratch dir whose
+// settings.json ENABLES telegram. `--channels` then has a live MCP
+// transport to wire its channel routing to.
+func TestIssue1134_ScratchEnablesTelegramForChannelOwner(t *testing.T) {
+	withTelegramConductorPresent(t)
+	source := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(source, "settings.json"),
+		[]byte(`{"enabledPlugins":{"telegram@claude-plugins-official":true}}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", source)
+
+	inst := &Instance{
+		ID:       "1134-happy",
+		Tool:     "claude",
+		Title:    "conductor-1134",
+		Channels: []string{"plugin:telegram@claude-plugins-official"},
+	}
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(source)
+	if err != nil {
+		t.Fatalf("EnsureWorkerScratchConfigDir: %v", err)
+	}
+	if scratch == "" {
+		t.Fatalf("channel-owning conductor with global antipattern MUST receive a scratch (issue #941 trigger)")
+	}
+
+	data, err := os.ReadFile(filepath.Join(scratch, "settings.json"))
+	if err != nil {
+		t.Fatalf("read scratch settings: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse scratch settings: %v", err)
+	}
+	plugins, _ := parsed["enabledPlugins"].(map[string]interface{})
+	v, ok := plugins[telegramPluginID].(bool)
+	if !ok {
+		t.Fatalf("scratch settings.json missing %q in enabledPlugins (got map=%v); --channels has nothing to wire", telegramPluginID, plugins)
+	}
+	if !v {
+		t.Fatalf("scratch settings.json has %q=false — this is the issue #1134 root cause; --channels cannot activate a disabled plugin and bun crashes in a respawn loop", telegramPluginID)
+	}
+}
+
+// Failure mode / regression guard: worker sessions (no telegram
+// channel) MUST still get telegram=false. We're only flipping behavior
+// for channel-owners; workers continue to be defended against the
+// auto-poller leak (issue #941, issue #1133).
+func TestIssue1134_WorkerWithoutChannelStillDenied(t *testing.T) {
+	withTelegramConductorPresent(t)
+	source := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(source, "settings.json"),
+		[]byte(`{"enabledPlugins":{"telegram@claude-plugins-official":true}}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", source)
+
+	inst := &Instance{
+		ID:    "1134-worker",
+		Tool:  "claude",
+		Title: "background-worker",
+		// no Channels — this is a plain worker, not a channel owner
+	}
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(source)
+	if err != nil {
+		t.Fatalf("EnsureWorkerScratchConfigDir: %v", err)
+	}
+	if scratch == "" {
+		t.Fatal("worker on a host with a telegram conductor MUST get a scratch dir")
+	}
+	data, _ := os.ReadFile(filepath.Join(scratch, "settings.json"))
+	var parsed map[string]interface{}
+	_ = json.Unmarshal(data, &parsed)
+	plugins, _ := parsed["enabledPlugins"].(map[string]interface{})
+	v, ok := plugins[telegramPluginID].(bool)
+	if !ok || v {
+		t.Fatalf("worker scratch must pin telegram=false; got %v (workers must not auto-spawn a second poller)", plugins[telegramPluginID])
+	}
+}
+
+// Boundary case: a session with a non-telegram channel (hypothetical
+// future plugin, e.g. discord) MUST NOT have telegram enabled in scratch
+// — the allow-for-channel-owner rule fires only on telegramChannelPrefix.
+// This guards against an over-broad fix that enables telegram for any
+// channel-owning session.
+func TestIssue1134_NonTelegramChannelDoesNotEnableTelegram(t *testing.T) {
+	withTelegramConductorPresent(t)
+	source := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(source, "settings.json"),
+		[]byte(`{"enabledPlugins":{"telegram@claude-plugins-official":true}}`),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", source)
+
+	inst := &Instance{
+		ID:       "1134-other-channel",
+		Tool:     "claude",
+		Title:    "discord-conductor",
+		Channels: []string{"plugin:discord@some-other-marketplace"},
+	}
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(source)
+	if err != nil {
+		t.Fatalf("EnsureWorkerScratchConfigDir: %v", err)
+	}
+	// Whether or not a scratch is built for a non-telegram channel
+	// owner is governed by other triggers (NeedsWorkerScratchConfigDir
+	// fires only on telegram conflict + explicit plugins today). If a
+	// scratch IS built — by any future trigger — telegram must remain
+	// pinned false because this session does NOT own the telegram
+	// channel.
+	if scratch == "" {
+		return // no scratch built → no settings.json to check; vacuously satisfied
+	}
+	data, _ := os.ReadFile(filepath.Join(scratch, "settings.json"))
+	var parsed map[string]interface{}
+	_ = json.Unmarshal(data, &parsed)
+	plugins, _ := parsed["enabledPlugins"].(map[string]interface{})
+	if v, ok := plugins[telegramPluginID].(bool); ok && v {
+		t.Fatalf("scratch enabled telegram=true for a session that does NOT own the telegram channel — over-broad fix; got plugins=%v", plugins)
+	}
+}

--- a/internal/session/issue941_global_antipattern_test.go
+++ b/internal/session/issue941_global_antipattern_test.go
@@ -109,29 +109,28 @@ func TestTelegram_GlobalScope_OneBunPollerOnly_RegressionFor941(t *testing.T) {
 		t.Fatalf("write poller: %v", err)
 	}
 
-	// fake-claude.sh — counts activation sources, then forks one poller
-	// per source. Sources:
-	//   (a) settings.json has `"telegram@claude-plugins-official": true`
-	//   (b) --channels argv contains "plugin:telegram@"
+	// fake-claude.sh — models real claude's plugin spawn behavior:
+	//   * The plugin's MCP server (bun telegram) is spawned IFF
+	//     settings.json enables the plugin
+	//     (`"telegram@claude-plugins-official": true`).
+	//   * `--channels plugin:telegram@...` is a ROUTING/WIRING directive
+	//     that requires the plugin's MCP transport to already be open —
+	//     it does NOT spawn a second server. If the plugin is disabled,
+	//     --channels has nothing to wire to and bun never sustains
+	//     (crash-respawn). Issue #1134 corrected the prior model where
+	//     this fake counted --channels as an additive spawn source.
 	fakeClaude := filepath.Join(binDir, "fake-claude.sh")
 	fakeClaudeBody := `#!/bin/bash
 set -u
-COUNT=0
+SPAWN=0
 if [ -n "${CLAUDE_CONFIG_DIR:-}" ] && [ -f "$CLAUDE_CONFIG_DIR/settings.json" ]; then
   if grep -Eq '"telegram@claude-plugins-official"[[:space:]]*:[[:space:]]*true' "$CLAUDE_CONFIG_DIR/settings.json"; then
-    COUNT=$((COUNT+1))
+    SPAWN=1
   fi
 fi
-for a in "$@"; do
-  case "$a" in
-    *plugin:telegram@*) COUNT=$((COUNT+1));;
-  esac
-done
-i=0
-while [ "$i" -lt "$COUNT" ]; do
+if [ "$SPAWN" = "1" ]; then
   "` + pollerScript + `" &
-  i=$((i+1))
-done
+fi
 sleep 20
 `
 	if err := os.WriteFile(fakeClaude, []byte(fakeClaudeBody), 0o755); err != nil {

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -143,8 +143,43 @@ func globalTelegramEnablementSet(sourceProfileDir string) bool {
 }
 
 func computeDenyList(i *Instance) []string {
+	// Issue #1134: channel-owning sessions MUST keep their channel
+	// plugin enabled — `--channels` is a routing/wiring directive and
+	// claude only opens the MCP stdio transport when the plugin is
+	// enabled in settings.json. Denying telegram here causes the bun
+	// child to spawn in task-mode (no MCP handshake) and crash-respawn,
+	// taking Telegram inbound offline for the conductor.
+	// computeChannelPluginAllowList re-enables the plugin in scratch
+	// settings.json; we must also stop denying it here so the deny
+	// pass doesn't overwrite the allow.
+	if sessionHasTelegramChannel(i) {
+		return nil
+	}
 	if needsScratchForTelegram(i) || needsScratchForGlobalChannelConflict(i) {
 		return []string{telegramPluginID}
+	}
+	return nil
+}
+
+// computeChannelPluginAllowList returns plugin IDs that this session
+// references via .Channels and MUST therefore be ENABLED in the
+// scratch settings.json. Channel plugins are wired by claude's
+// `--channels` arg AFTER the plugin's MCP server starts; if the plugin
+// is disabled in settings.json the server never starts, `--channels`
+// has nothing to wire, and bun crashes in a respawn loop. Issue #1134.
+//
+// Today only telegram is a channel plugin; if other channel plugins
+// land in the future, add their (channel-prefix, plugin-id) pairs
+// here. The allow list is applied AFTER computeAllowList so it cannot
+// be silently dropped by the catalog default-false pass.
+func computeChannelPluginAllowList(i *Instance) []string {
+	if i == nil {
+		return nil
+	}
+	for _, ch := range i.Channels {
+		if strings.HasPrefix(ch, telegramChannelPrefix) {
+			return []string{telegramPluginID}
+		}
 	}
 	return nil
 }
@@ -261,6 +296,15 @@ func (i *Instance) EnsureWorkerScratchConfigDir(sourceProfileDir string) (string
 	}
 	allowSet := map[string]struct{}{}
 	for _, id := range computeAllowList(i) {
+		plugins[id] = true
+		allowSet[id] = struct{}{}
+	}
+	// Issue #1134: channel-owning sessions need their channel plugin
+	// enabled so claude's `--channels` flag has a live MCP server to
+	// wire its routing to. Applied AFTER computeAllowList so the
+	// catalog default-false pass below treats channel plugins as
+	// attached and leaves them true.
+	for _, id := range computeChannelPluginAllowList(i) {
 		plugins[id] = true
 		allowSet[id] = struct{}{}
 	}

--- a/internal/session/worker_scratch_test.go
+++ b/internal/session/worker_scratch_test.go
@@ -176,8 +176,17 @@ func TestEnsureWorkerScratchConfigDir_ChannelOwnerKeepsAmbientProfile(t *testing
 
 // Issue #941: when a channel-owning conductor's ambient profile has the
 // GLOBAL_ANTIPATTERN (enabledPlugins.telegram=true), the worker-scratch
-// guard MUST fire — pinning telegram off so --channels is the sole
-// activation source and only one bun poller spawns.
+// guard MUST fire so the conductor's claude reads scratch settings (not
+// the ambient profile) — that's how agent-deck owns the plugin
+// enablement state per-session instead of leaking ambient changes.
+//
+// Issue #1134 amended the assertion: scratch must KEEP telegram ENABLED
+// for channel-owning sessions (not pin it off). claude's `--channels`
+// flag is a routing directive and requires the plugin's MCP stdio
+// transport to already be live; pinning telegram=false breaks the
+// transport and bun crashes in a respawn loop. The "sole-activation"
+// reading of --channels was wrong; the correct reading is "use the
+// already-enabled plugin to route channel events here."
 func TestEnsureWorkerScratchConfigDir_ChannelOwner_GlobalAntipattern_GetsScratch(t *testing.T) {
 	withTelegramConductorPresent(t)
 	source := t.TempDir()
@@ -210,8 +219,8 @@ func TestEnsureWorkerScratchConfigDir_ChannelOwner_GlobalAntipattern_GetsScratch
 		t.Fatalf("parse: %v", err)
 	}
 	plugins := parsed["enabledPlugins"].(map[string]interface{})
-	if v, ok := plugins[telegramPluginID].(bool); !ok || v {
-		t.Errorf("issue #941: scratch settings.json must pin telegram OFF (false); got %v", plugins[telegramPluginID])
+	if v, ok := plugins[telegramPluginID].(bool); !ok || !v {
+		t.Errorf("issue #1134: scratch settings.json must keep telegram ENABLED for channel-owning conductors so --channels has a live MCP transport to wire to; got %v", plugins[telegramPluginID])
 	}
 }
 


### PR DESCRIPTION
## Summary

Channel-owning conductor sessions (`Channels = ["plugin:telegram@claude-plugins-official"]`) have been silently deaf to Telegram inbound on every restart since the worker-scratch GLOBAL_ANTIPATTERN guard landed (#941). Net effect on the maintainer's host: **all 7 conductors offline at once.** This PR re-enables the plugin in the scratch settings.json for channel owners so claude's `--channels` flag has a live MCP transport to wire to. Fixes #1134.

## Hypothesis tree

This was investigated against the five hypotheses in the worker prompt, plus one new hypothesis surfaced during evidence-gathering.

| # | Hypothesis | Disposition |
|---|---|---|
| H1 | `--channels` flag arg malformed on restart | **Ruled out.** `pgrep -af 'claude.*channels'` shows the flag is correctly on every conductor's argv. |
| H2 | `env_file` not set → no TSD → plugin can't find .env → silent exit | **Partial.** `env_file` is wired via `~/.agent-deck/config.toml` and `.envrc` is sourced; `TELEGRAM_STATE_DIR` reaches the conductor's claude environ. Env propagation is fine. |
| H3 | stdio pipe between claude and plugin breaks during respawn | **Symptom, not cause.** The stdio pipe never *opens* because the plugin is disabled in settings.json. |
| H4 | Race: claude tries to spawn plugin before parent bash sources `.envrc` | **Ruled out.** Env is sourced before `claude --resume` is exec'd; PID inspection confirms env is present at exec time. |
| H5 | agent-deck conductor's launch script strips env vars | **Ruled out.** `TELEGRAM_STATE_DIR` and `.env`-loaded `TELEGRAM_BOT_TOKEN` reach claude. |
| **H6** *(new — confirmed root cause)* | `worker_scratch.go` pins `enabledPlugins.telegram=false` in the scratch CCD for channel owners. `--channels` cannot activate a disabled plugin. bun spawns in task-mode (stdout → task output file, no MCP handshake), MCP init fails, claude respawns it; crash-respawn loop. | **Root cause.** Filed as #1134. |

Confirming evidence from the live host:

* All 7 conductor claude processes had `CLAUDE_CONFIG_DIR=<scratch>` with `enabledPlugins."telegram@claude-plugins-official": false` in settings.json.
* `pgrep -P <conductor-pid> -af 'bun.*telegram'` returned **empty** for every conductor.
* The 19 `bun-telegram` processes alive on the host were all from worker/subagent claudes (not conductors) inheriting the global enablement from `~/.claude/settings.json`. None had `TELEGRAM_STATE_DIR` in their environ → all polled the default `~/.claude/channels/telegram/` token, racing each other.
* One conductor itself diagnosed the crash-respawn loop mid-session: *"each new bun has stdout redirected to a fresh tasks/<id>.output file in /tmp/claude-1000/.../tasks/ instead of to the MCP stdio pipe ... bun spawns, crashes before consuming, claude respawns it. Forever loop."*

## Fix

`internal/session/worker_scratch.go`:

1. **`computeDenyList(i)`** returns `nil` when `sessionHasTelegramChannel(i)` is true. A session that owns the telegram channel must not have its channel plugin denied — `--channels` would have nothing live to wire to.
2. **`computeChannelPluginAllowList(i)`** (new) returns `[telegramPluginID]` when the session has a telegram channel. Applied in `EnsureWorkerScratchConfigDir` *after* `computeAllowList` so the catalog default-false pass treats channel plugins as attached.

Net effect: a channel-owning conductor's scratch `settings.json` now has `"telegram@claude-plugins-official": true`. The MCP stdio transport opens, `--channels` wires routing to the live plugin, exactly **one** bun runs per conductor, the Bot API delivers updates without 409s.

Worker sessions (no telegram channel) are unchanged — `telegram` is still pinned `false` in their scratch (the defense from #941 and #1133 is preserved).

## Tests

Per `agent-deck-tdd-feature` SKILL: happy path + failure mode + boundary case.

* `internal/session/issue1134_channel_plugin_enabled_test.go` *(new)*
  * `TestIssue1134_ScratchEnablesTelegramForChannelOwner` — **happy path**: channel-owning conductor with global-antipattern source gets `enabledPlugins.telegram == true` in scratch.
  * `TestIssue1134_WorkerWithoutChannelStillDenied` — **failure mode / regression guard**: workers without a telegram channel still get `telegram = false`. The #941 / #1133 defense is intact.
  * `TestIssue1134_NonTelegramChannelDoesNotEnableTelegram` — **boundary**: a hypothetical future non-telegram channel-owning session does NOT incidentally enable telegram. Guards against over-broad fix.
* `internal/session/worker_scratch_test.go` — `TestEnsureWorkerScratchConfigDir_ChannelOwner_GlobalAntipattern_GetsScratch` assertion inverted to match the corrected invariant (telegram=true for channel owners). The original assertion encoded the bug.
* `internal/session/issue941_global_antipattern_test.go` — fake-claude updated to model real claude behavior: `--channels` is a routing/wiring directive, not an additive spawn source. The one-poller invariant from #941 still holds, but is now enforced by enabling the plugin in scratch (not by `--channels`-as-sole-source).

## Verification

* `go test -race -count=1 -timeout 15m ./...` → all packages green (full repo run, 128s)
* `golangci-lint run --timeout=5m --issues-exit-code=1 ./...` → 0 issues
* `govulncheck ./...` → no vulnerabilities
* `go build ./...` → clean

## Test plan post-merge

- [ ] Pull on the host, rebuild `agent-deck` binary
- [ ] `agent-deck session restart <conductor>` (single-conductor canary)
- [ ] Confirm `jq '.enabledPlugins["telegram@claude-plugins-official"]' <conductor-scratch>/settings.json` returns `true`
- [ ] Confirm `pgrep -P <conductor-claude-pid> -af 'bun.*telegram'` returns one child
- [ ] Send a Telegram test message to the conductor's bot; confirm it lands in the conductor pane
- [ ] If canary green, restart the remaining 6 conductors

## Surfaces

| Surface | Touched? | Test |
|---|---|---|
| TUI | No | feature has no TUI surface — scratch construction is invisible to the UI |
| Web UI | No | feature has no Web UI surface — scratch construction is server-side only |
| CLI | Indirect | `session restart` path consumes the new scratch; covered transitively via `prepareWorkerScratchConfigDirForSpawn` |
| Remote | Indirect | RemoteSession's spawn path goes through the same `Instance` methods via `applyWorkerScratchOverride` (single seam, #922) |
| Persistence | **Yes** (settings.json) | new `issue1134_*` tests cover happy / failure / boundary |
| Cross-platform | n/a | enabledPlugins map mutation only; no OS-specific paths or signals |

## Severity

P0 — all 7 of @asheshgoplani's conductors were deaf to Telegram inbound. DO NOT merge until CI is green; the conductor that delegated this fix merges and restarts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Telegram plugin was not properly retained as enabled for sessions owning Telegram channels, ensuring correct configuration in worker scratch settings.
  
* **Tests**
  * Added regression tests validating correct Telegram plugin enablement for channel-owning sessions and denial for sessions without appropriate channels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
