### PR TITLE
fix(telegram): force-correct scratch settings on every spawn + post-spawn health check + telegram-doctor CLI (permanent fix for recurring telegram drops, fixes #1138)

### DIFF
--- a/.github/workflows/telegram-reliability.yml
+++ b/.github/workflows/telegram-reliability.yml
@@ -1,0 +1,49 @@
+# Telegram channel-plugin reliability regression gate (issue #1138).
+# No untrusted GitHub event inputs are interpolated into run: blocks.
+
+name: telegram-reliability
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'internal/session/worker_scratch*.go'
+      - 'internal/session/telegram_reliability.go'
+      - 'internal/session/telegram_validator.go'
+      - 'internal/session/env.go'
+      - 'internal/session/issue113*_*.go'
+      - 'cmd/agent-deck/cmd_telegram_doctor*.go'
+      - 'cmd/agent-deck/main.go'
+      - '.github/workflows/telegram-reliability.yml'
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Targeted regression tests
+        run: |
+          go test -race -count=1 -timeout 5m \
+            -run "TestIssue1138|TestIssue1134|TestDoctor|TestHasTelegramChannel|TestEnsureWorkerScratch_AllowAndDenyCoexist|TestEnsureWorkerScratchConfigDir_ChannelOwner|TestComputeChannelPluginAllowList|TestComputeDenyList_FiresOnlyWhenTelegramScratchNeeded" \
+            ./internal/session/ ./cmd/agent-deck/
+
+      - name: Build binary
+        run: go build -o /tmp/agent-deck ./cmd/agent-deck
+
+      - name: CLI smoke — empty profile must exit 0
+        env:
+          HOME: /tmp/td-home
+        run: |
+          mkdir -p "$HOME/.agent-deck"
+          /tmp/agent-deck telegram-doctor --json > /tmp/doctor.json
+          cat /tmp/doctor.json
+          test -s /tmp/doctor.json

--- a/cmd/agent-deck/cmd_telegram_doctor.go
+++ b/cmd/agent-deck/cmd_telegram_doctor.go
@@ -1,0 +1,287 @@
+// Package main — `agent-deck telegram-doctor` subcommand (issue #1138).
+//
+// Surfaces silent Telegram channel-plugin drops at any time. For each
+// session in the active profile that owns a `plugin:telegram@…`
+// channel, the command checks:
+//
+//  1. The EFFECTIVE settings.json (scratch when present, ambient
+//     otherwise) has the channel plugin enabled. This is the necessary
+//     condition for `--channels` to wire onto a live MCP transport.
+//  2. A `bun telegram` poller process is currently running on the host.
+//     If a session is configured to own the channel but no poller is
+//     visible, Telegram inbound is dropping.
+//
+// The check uses the same VerifyTelegramChannelEnabled helper that the
+// session prepare path uses, so the diagnostic is the same in both
+// directions: what we set up at spawn time is what we report at audit
+// time.
+//
+// Exit codes:
+//
+//	0 — every channel-owning session has a healthy poller, settings.json
+//	    has telegram=true.
+//	1 — at least one channel-owning session is unhealthy (settings drift,
+//	    missing poller, or both). Stderr names the offending session and
+//	    prints the heal command to run.
+//
+// The user can run this ad-hoc or cron it (every 5–10 minutes) for
+// periodic monitoring. See PR fix(telegram): force-correct scratch
+// settings on every spawn + post-spawn health check + telegram-doctor CLI.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// handleTelegramDoctor is the entry point dispatched from main.go.
+func handleTelegramDoctor(profile string, args []string) {
+	fs := flag.NewFlagSet("telegram-doctor", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "emit machine-readable JSON output")
+	quiet := fs.Bool("quiet", false, "suppress healthy lines; only print drift")
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	out := NewCLIOutput(*jsonOutput, *quiet)
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to initialize storage: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to load sessions: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	runningPollers := scanBunTelegramProcesses()
+
+	type report struct {
+		Title          string `json:"title"`
+		InstanceID     string `json:"instance_id"`
+		ConfigDir      string `json:"config_dir"`
+		EffectiveValue string `json:"effective_value"`
+		Reason         string `json:"reason,omitempty"`
+		PollerPIDs     []int  `json:"poller_pids,omitempty"`
+		Healthy        bool   `json:"healthy"`
+	}
+
+	reports := make([]report, 0)
+	anyUnhealthy := false
+	channelOwners := 0
+
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		if !hasTelegramChannel(inst.Channels) {
+			continue
+		}
+		channelOwners++
+
+		// Resolve the EFFECTIVE config dir — scratch wins when present
+		// (matches the spawn path's applyWorkerScratchOverride logic).
+		effectiveDir := inst.WorkerScratchConfigDir
+		if effectiveDir == "" {
+			effectiveDir = session.GetClaudeConfigDirForInstance(inst)
+		}
+
+		result := session.VerifyTelegramChannelEnabled(effectiveDir, inst.Channels)
+		pollerPIDs := pollersForInstance(inst, runningPollers)
+		healthy := result.OK && len(pollerPIDs) > 0
+		reason := result.Reason
+		if result.OK && len(pollerPIDs) == 0 {
+			reason = "no `bun telegram` poller process is running for this conductor; --channels has nothing to deliver to"
+		}
+		reports = append(reports, report{
+			Title:          inst.Title,
+			InstanceID:     inst.ID,
+			ConfigDir:      effectiveDir,
+			EffectiveValue: result.EffectiveValue,
+			Reason:         reason,
+			PollerPIDs:     pollerPIDs,
+			Healthy:        healthy,
+		})
+		if !healthy {
+			anyUnhealthy = true
+		}
+	}
+
+	if *jsonOutput {
+		out.Print("", map[string]interface{}{
+			"profile":        profile,
+			"channel_owners": channelOwners,
+			"reports":        reports,
+		})
+	} else {
+		if channelOwners == 0 {
+			out.Print("no telegram channel-owning sessions in this profile", nil)
+		}
+		for _, r := range reports {
+			if r.Healthy {
+				if !*quiet {
+					fmt.Printf("OK     %-32s  pids=%v  settings=%s\n", r.Title, r.PollerPIDs, r.EffectiveValue)
+				}
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "DRIFT  %-32s  reason=%s\n", r.Title, r.Reason)
+			fmt.Fprintf(os.Stderr, "       heal:  agent-deck -p %s session restart %s\n", profile, r.InstanceID)
+			fmt.Fprintf(os.Stderr, "       (the scratch CLAUDE_CONFIG_DIR is rewritten on every restart and should\n")
+			fmt.Fprintf(os.Stderr, "        force-correct enabledPlugins.%q=true in %s)\n",
+				"telegram@claude-plugins-official", r.ConfigDir)
+		}
+	}
+
+	if anyUnhealthy {
+		os.Exit(1)
+	}
+}
+
+// hasTelegramChannel mirrors session.sessionHasTelegramChannel but is
+// reachable from the cmd/ package. Channel ids start with
+// "plugin:telegram@" for the official plugin and any fork.
+func hasTelegramChannel(channels []string) bool {
+	for _, ch := range channels {
+		if strings.HasPrefix(ch, "plugin:telegram@") {
+			return true
+		}
+	}
+	return false
+}
+
+// scanBunTelegramProcesses returns the PIDs of every running `bun
+// telegram` process on the host. We use `pgrep -af` because it matches
+// the maintainer's documented diagnostic command (CLAUDE.md notes
+// `pgrep -af 'bun.*telegram'`). Falling back silently to an empty list
+// on platforms without pgrep keeps the doctor usable on macOS too.
+func scanBunTelegramProcesses() []procInfo {
+	out, err := exec.Command("pgrep", "-af", "bun.*telegram").Output()
+	if err != nil {
+		return nil
+	}
+	var procs []procInfo
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, " ", 2)
+		if len(fields) < 2 {
+			continue
+		}
+		pid := 0
+		if _, err := fmt.Sscanf(fields[0], "%d", &pid); err != nil {
+			continue
+		}
+		procs = append(procs, procInfo{PID: pid, Cmdline: fields[1]})
+	}
+	return procs
+}
+
+type procInfo struct {
+	PID     int
+	Cmdline string
+}
+
+// pollersForInstance correlates a session with the `bun telegram`
+// processes that belong to it via TELEGRAM_STATE_DIR. The conductor's
+// state dir is captured in /proc/<pid>/environ on Linux — we read that
+// directly because the conductor host is Linux in every reported
+// instance of #1138.
+//
+// Resolution chain for the expected state dir:
+//  1. The conductor env_file declared in ~/.agent-deck/config.toml
+//     under [conductors.<name>.claude].env_file. The file contains
+//     a line like `export TELEGRAM_STATE_DIR=<dir>`.
+//  2. Any `TELEGRAM_STATE_DIR=` line found in the file is taken as
+//     authoritative.
+//
+// On macOS /proc isn't available, so this function falls back to
+// "any running bun-telegram counts" — coarser, but still useful as a
+// pulse check.
+func pollersForInstance(inst *session.Instance, all []procInfo) []int {
+	if inst == nil {
+		return nil
+	}
+	wantStateDir := readConductorTelegramStateDir(inst)
+
+	var matched []int
+	for _, p := range all {
+		if wantStateDir == "" {
+			matched = append(matched, p.PID)
+			continue
+		}
+		envData, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", p.PID))
+		if err != nil {
+			// Non-Linux or process gone — keep the PID as a coarse match
+			// so we don't false-alarm.
+			matched = append(matched, p.PID)
+			continue
+		}
+		if strings.Contains(string(envData), "TELEGRAM_STATE_DIR="+wantStateDir) {
+			matched = append(matched, p.PID)
+		}
+	}
+	return matched
+}
+
+// readConductorTelegramStateDir looks up the conductor's env_file via
+// [conductors.<name>.claude].env_file in config.toml and extracts the
+// TELEGRAM_STATE_DIR value if present. Returns "" if the session isn't
+// a conductor, the env_file isn't declared, or the file is missing.
+//
+// Best-effort: any failure degrades to coarse PID matching (all bun
+// pollers counted as candidates) rather than a hard error.
+func readConductorTelegramStateDir(inst *session.Instance) string {
+	if inst == nil {
+		return ""
+	}
+	name := strings.TrimPrefix(inst.Title, "conductor-")
+	if name == "" || name == inst.Title {
+		return ""
+	}
+	cfg, err := session.LoadUserConfig()
+	if err != nil || cfg == nil {
+		return ""
+	}
+	cond, ok := cfg.Conductors[name]
+	if !ok {
+		return ""
+	}
+	envFile := cond.Claude.EnvFile
+	if envFile == "" {
+		return ""
+	}
+	if strings.HasPrefix(envFile, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			envFile = home + envFile[1:]
+		}
+	}
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "export ")
+		if !strings.HasPrefix(line, "TELEGRAM_STATE_DIR=") {
+			continue
+		}
+		v := strings.TrimPrefix(line, "TELEGRAM_STATE_DIR=")
+		v = strings.Trim(v, "\"'")
+		if strings.HasPrefix(v, "~/") {
+			if home, err := os.UserHomeDir(); err == nil {
+				v = home + v[1:]
+			}
+		}
+		return v
+	}
+	return ""
+}

--- a/cmd/agent-deck/cmd_telegram_doctor_test.go
+++ b/cmd/agent-deck/cmd_telegram_doctor_test.go
@@ -1,0 +1,114 @@
+// Tests for `agent-deck telegram-doctor` (issue #1138). Three cases:
+//
+//	happy path  — settings.json has telegram=true, doctor reports OK
+//	settings drift — settings.json has telegram=false or absent, reported as DRIFT
+//	non-channel session — ignored entirely (no false alarms for non-conductors)
+//
+// `pollersForInstance` is exercised via `scanBunTelegramProcesses`'s
+// pgrep dependency, which is not present in CI for all platforms.
+// The unit tests below cover the pure-function path
+// (VerifyTelegramChannelEnabled) which is the actual diagnostic logic.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// hasTelegramChannel is the local mirror; pin it.
+func TestHasTelegramChannel(t *testing.T) {
+	if !hasTelegramChannel([]string{"plugin:telegram@claude-plugins-official"}) {
+		t.Errorf("official telegram channel must be detected")
+	}
+	if !hasTelegramChannel([]string{"plugin:telegram@acme/fork"}) {
+		t.Errorf("forked telegram channel must be detected (prefix match)")
+	}
+	if hasTelegramChannel([]string{"plugin:discord@claude-plugins-official"}) {
+		t.Errorf("non-telegram channel must not match")
+	}
+	if hasTelegramChannel(nil) {
+		t.Errorf("empty channels must not match")
+	}
+}
+
+// TestDoctor_VerifyHealthy mirrors how the doctor evaluates a healthy
+// session: an effective config dir whose settings.json enables the
+// channel plugin must yield OK=true.
+func TestDoctor_VerifyHealthy(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"),
+		[]byte(`{"enabledPlugins":{"telegram@claude-plugins-official":true}}`),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := session.VerifyTelegramChannelEnabled(dir, []string{"plugin:telegram@claude-plugins-official"})
+	if !r.OK {
+		t.Fatalf("healthy session must report OK; got %+v", r)
+	}
+	if r.EffectiveValue != "true" {
+		t.Errorf("EffectiveValue: got %q, want %q", r.EffectiveValue, "true")
+	}
+}
+
+// TestDoctor_VerifyDriftFalse — telegram=false is the drop variant
+// where claude can't open the MCP transport. Doctor must report DRIFT.
+func TestDoctor_VerifyDriftFalse(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"),
+		[]byte(`{"enabledPlugins":{"telegram@claude-plugins-official":false}}`),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := session.VerifyTelegramChannelEnabled(dir, []string{"plugin:telegram@claude-plugins-official"})
+	if r.OK {
+		t.Fatalf("drift session (telegram=false) must report not-OK")
+	}
+	if r.EffectiveValue != "false" {
+		t.Errorf("EffectiveValue: got %q, want %q", r.EffectiveValue, "false")
+	}
+}
+
+// TestDoctor_VerifyDriftAbsent — the other observed variant: entry
+// completely missing from enabledPlugins.
+func TestDoctor_VerifyDriftAbsent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"),
+		[]byte(`{"enabledPlugins":{"superpowers@claude-plugins-official":true}}`),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := session.VerifyTelegramChannelEnabled(dir, []string{"plugin:telegram@claude-plugins-official"})
+	if r.OK {
+		t.Fatalf("drift session (telegram absent) must report not-OK")
+	}
+	if r.EffectiveValue != "absent" {
+		t.Errorf("EffectiveValue: got %q, want %q", r.EffectiveValue, "absent")
+	}
+}
+
+// TestDoctor_NonChannelSession_Ignored — sessions without a telegram
+// channel must yield OK=true so the doctor never false-alarms on plain
+// workers.
+func TestDoctor_NonChannelSession_Ignored(t *testing.T) {
+	r := session.VerifyTelegramChannelEnabled(t.TempDir(), nil)
+	if !r.OK {
+		t.Errorf("non-channel session must be vacuously OK; got %+v", r)
+	}
+}
+
+// TestDoctor_MissingSettingsFile — a config dir whose settings.json
+// doesn't exist for a channel-owning session is reported as drift.
+func TestDoctor_MissingSettingsFile(t *testing.T) {
+	r := session.VerifyTelegramChannelEnabled(t.TempDir(),
+		[]string{"plugin:telegram@claude-plugins-official"})
+	if r.OK {
+		t.Errorf("missing settings.json for channel owner must be DRIFT; got %+v", r)
+	}
+	if r.EffectiveValue != "missing-file" {
+		t.Errorf("EffectiveValue: got %q, want missing-file", r.EffectiveValue)
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -291,6 +291,9 @@ func main() {
 		case "conductor":
 			handleConductor(profile, args[1:])
 			return
+		case "telegram-doctor":
+			handleTelegramDoctor(profile, args[1:])
+			return
 		case "watcher":
 			handleWatcher(profile, args[1:])
 			return
@@ -2945,6 +2948,7 @@ func printHelp() {
 	fmt.Println("  web              Start TUI with web UI server running alongside")
 	fmt.Println("  remote           Manage remote agent-deck instances")
 	fmt.Println("  conductor        Manage conductor meta-agent orchestration")
+	fmt.Println("  telegram-doctor  Audit channel-owning sessions for telegram drops (#1138)")
 	fmt.Println("  profile          Manage profiles")
 	fmt.Println("  update           Check for and install updates")
 	fmt.Println("  debug-dump       Dump debug ring buffer to file for sharing")

--- a/internal/session/issue1138_telegram_reliability_test.go
+++ b/internal/session/issue1138_telegram_reliability_test.go
@@ -1,0 +1,293 @@
+// Package session — issue #1138 regression suite for recurring telegram drops.
+//
+// Background. PR #1136 (issue #1134) made the channel-owning scratch
+// settings.json set `enabledPlugins."telegram@claude-plugins-official"=true`,
+// so `--channels` would have a live MCP transport to wire onto. That fix
+// closed the issue on hosts whose ambient profile already carried the
+// "global antipattern" (settings.telegram=true). But the maintainer kept
+// observing the same drop pattern every few hours:
+//
+//	Bot reachable via Telegram API ✅
+//	claude process running --channels plugin:telegram@…       ✅
+//	bun-telegram plugin process: MISSING ❌
+//	Scratch settings.json: enabledPlugins["telegram@…"] is
+//	  either `false` OR absent ❌
+//
+// Root cause (multi-vector): scratch creation is gated on three signals
+// (telegramStateDirStrip, explicit plugins, global antipattern). For the
+// recommended post-#941 topology — channel-owning conductor with
+// global enablement DISABLED, no extra plugins — none of those signals
+// fire. NeedsWorkerScratchConfigDir returns false, no scratch is created,
+// and the conductor depends entirely on the ambient settings.json carrying
+// `telegram=true`. Any drift in the ambient (manual edit, `/plugin disable`,
+// Claude Code rewrite) silently disables the channel transport, and on
+// restart there is no force-correct pass to heal it.
+//
+// Fix. A channel-owning session ALWAYS needs the scratch indirection so
+// agent-deck owns the enablement of its own channel plugin. The scratch
+// settings.json is rewritten on every spawn (idempotent, force-correct).
+// A post-spawn warning fires when --channels references a plugin that
+// the effective settings.json does not enable, surfacing drift loudly.
+//
+// All 4 tests in this file MUST fail on the pre-fix tree and pass after
+// the fix lands. Grep tag: issue1138, telegram-reliability.
+
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// channelOwnerInstance constructs the canonical channel-owning conductor
+// instance used by every test in this file. Centralising it keeps every
+// case asserting the SAME minimal topology so we can't accidentally
+// regress one case by tweaking another.
+func channelOwnerInstance(id string) *Instance {
+	return &Instance{
+		ID:       id,
+		Tool:     "claude",
+		Title:    "conductor-personal",
+		Channels: []string{"plugin:telegram@claude-plugins-official"},
+	}
+}
+
+// readScratchTelegramState returns (present, value) for
+// enabledPlugins."telegram@claude-plugins-official" in the given scratch
+// settings.json. Both `false` and absence are bugs — distinguish them so
+// the failure message can name which variant fired.
+func readScratchTelegramState(t *testing.T, scratchDir string) (present bool, enabled bool) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(scratchDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read scratch settings.json: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse scratch settings.json: %v", err)
+	}
+	plugins, _ := parsed["enabledPlugins"].(map[string]interface{})
+	v, ok := plugins[telegramPluginID].(bool)
+	return ok, v
+}
+
+// TestIssue1138_ScratchAlwaysCreatedForChannelOwner is the headline
+// regression: a channel-owning conductor session must ALWAYS receive a
+// scratch CLAUDE_CONFIG_DIR even when no other trigger fires. Without
+// this gate, the ambient settings.json is the only source of plugin
+// enablement, and any drift there silently disables the channel
+// transport.
+//
+// Pre-fix: NeedsWorkerScratchConfigDir returns false on a host without
+// a TG conductor (hostHasTelegramConductor=false), no global antipattern,
+// no explicit plugins — even though Channels carries the telegram channel.
+// Post-fix: needsScratchForTelegramChannelOwner fires, scratch is built,
+// and computeChannelPluginAllowList pins telegram=true.
+func TestIssue1138_ScratchAlwaysCreatedForChannelOwner(t *testing.T) {
+	orig := hostHasTelegramConductor
+	hostHasTelegramConductor = func() bool { return false }
+	t.Cleanup(func() { hostHasTelegramConductor = orig })
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Ambient profile: telegram NOT in enabledPlugins (the post-#941
+	// recommended state). Without a scratch, --channels would have
+	// nothing to wire to.
+	source := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "settings.json"),
+		[]byte(`{"enabledPlugins":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", source)
+
+	inst := channelOwnerInstance("1138-always-create")
+
+	if !inst.NeedsWorkerScratchConfigDir() {
+		t.Fatalf("channel-owning conductor must always need a scratch (issue #1138); got NeedsWorkerScratchConfigDir=false")
+	}
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(source)
+	if err != nil {
+		t.Fatalf("EnsureWorkerScratchConfigDir: %v", err)
+	}
+	if scratch == "" {
+		t.Fatalf("channel-owning conductor must receive a scratch even on a clean host; got empty")
+	}
+
+	present, enabled := readScratchTelegramState(t, scratch)
+	if !present {
+		t.Fatalf("scratch settings.json missing %q in enabledPlugins — --channels has nothing to wire (issue #1138 absent-variant)", telegramPluginID)
+	}
+	if !enabled {
+		t.Fatalf("scratch settings.json has %q=false — --channels cannot activate a disabled plugin (issue #1138 false-variant)", telegramPluginID)
+	}
+}
+
+// TestIssue1138_RestartHealsDriftedScratchSettings asserts the
+// force-correct invariant: if the scratch settings.json drifts (manual
+// edit, external rewrite, Claude Code's own /plugin disable), the next
+// call to EnsureWorkerScratchConfigDir MUST overwrite it back to
+// telegram=true. Idempotency is the contract — `EnsureWorkerScratchConfigDir`
+// is the canonical heal point and must not assume prior state is sane.
+func TestIssue1138_RestartHealsDriftedScratchSettings(t *testing.T) {
+	orig := hostHasTelegramConductor
+	hostHasTelegramConductor = func() bool { return false }
+	t.Cleanup(func() { hostHasTelegramConductor = orig })
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	source := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "settings.json"),
+		[]byte(`{"enabledPlugins":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", source)
+
+	inst := channelOwnerInstance("1138-heal")
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(source)
+	if err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	if scratch == "" {
+		t.Fatalf("scratch must be created for channel owner (issue #1138)")
+	}
+
+	// Simulate drift: a 3rd party (or Claude Code itself) rewrites the
+	// scratch settings.json with telegram pinned off.
+	driftPath := filepath.Join(scratch, "settings.json")
+	if err := os.WriteFile(driftPath,
+		[]byte(`{"enabledPlugins":{"telegram@claude-plugins-official":false}}`),
+		0o600); err != nil {
+		t.Fatalf("inject drift: %v", err)
+	}
+
+	// Restart path: prepare ⇒ ensure. Force-correct must heal the drift.
+	scratch2, err := inst.EnsureWorkerScratchConfigDir(source)
+	if err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	if scratch2 != scratch {
+		t.Fatalf("scratch dir must be stable across restarts; got %q vs %q", scratch2, scratch)
+	}
+
+	present, enabled := readScratchTelegramState(t, scratch2)
+	if !present || !enabled {
+		t.Fatalf("restart must heal drifted scratch settings.json back to telegram=true; got present=%v enabled=%v", present, enabled)
+	}
+}
+
+// TestIssue1138_HealsAbsentEntry covers the "completely absent" variant
+// of the bug: a scratch settings.json that has the enabledPlugins block
+// but no entry for telegram at all. Force-correct must inject it.
+func TestIssue1138_HealsAbsentEntry(t *testing.T) {
+	orig := hostHasTelegramConductor
+	hostHasTelegramConductor = func() bool { return false }
+	t.Cleanup(func() { hostHasTelegramConductor = orig })
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	source := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "settings.json"),
+		[]byte(`{"enabledPlugins":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", source)
+
+	inst := channelOwnerInstance("1138-absent")
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(source)
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	// Drift: enabledPlugins block exists but telegram entry is absent.
+	driftPath := filepath.Join(scratch, "settings.json")
+	if err := os.WriteFile(driftPath,
+		[]byte(`{"enabledPlugins":{"superpowers@claude-plugins-official":true}}`),
+		0o600); err != nil {
+		t.Fatalf("inject absent drift: %v", err)
+	}
+
+	// Restart heals.
+	if _, err := inst.EnsureWorkerScratchConfigDir(source); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	present, enabled := readScratchTelegramState(t, scratch)
+	if !present {
+		t.Fatalf("issue #1138 absent-variant: scratch must have explicit %q entry after restart; got absent", telegramPluginID)
+	}
+	if !enabled {
+		t.Fatalf("issue #1138 absent-variant: scratch entry must be true; got false")
+	}
+}
+
+// TestIssue1138_PostSpawnDriftWarning asserts the new diagnostic: when a
+// session has `--channels plugin:telegram@…` but the effective
+// settings.json (after scratch resolution) does NOT enable the plugin,
+// agent-deck must log a CLEAR, structured warning so the user sees the
+// silent failure mode. Without this, the drop is invisible until the
+// user happens to send a telegram message and notice no response.
+//
+// The warning fires via VerifyTelegramChannelEnabled(configDir, channels)
+// which inspects settings.json and returns a structured result. The
+// session prepare path logs at WARN level when the check fails.
+func TestIssue1138_PostSpawnDriftWarning(t *testing.T) {
+	// Capture the session logger output via a buffer-backed handler so
+	// we can assert on what was emitted.
+	var buf bytes.Buffer
+	origLog := sessionLog
+	sessionLog = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	t.Cleanup(func() { sessionLog = origLog })
+
+	// Setup: a config dir whose settings.json says telegram=false. This
+	// is the silent-failure topology the warning must surface.
+	configDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configDir, "settings.json"),
+		[]byte(`{"enabledPlugins":{"telegram@claude-plugins-official":false}}`),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	channels := []string{"plugin:telegram@claude-plugins-official"}
+	result := VerifyTelegramChannelEnabled(configDir, channels)
+	if result.OK {
+		t.Fatalf("VerifyTelegramChannelEnabled must report not-OK when channel set but plugin=false; got OK")
+	}
+	if result.Reason == "" {
+		t.Fatalf("VerifyTelegramChannelEnabled must return a non-empty Reason; got empty")
+	}
+
+	// Now exercise the diagnostic emitter — must log at WARN with a
+	// stable, greppable code so operators / monitoring can detect it.
+	EmitTelegramChannelDriftWarning("conductor-personal", "instance-id-x", configDir, channels, result)
+
+	got := buf.String()
+	if !strings.Contains(got, "telegram_channel_plugin_drift") {
+		t.Fatalf("warning must use the stable code %q for grep/alerting; got %s", "telegram_channel_plugin_drift", got)
+	}
+	if !strings.Contains(got, "level=WARN") {
+		t.Fatalf("warning must be at WARN level; got %s", got)
+	}
+	if !strings.Contains(got, telegramPluginID) {
+		t.Fatalf("warning must name the plugin id (%s); got %s", telegramPluginID, got)
+	}
+	if !strings.Contains(got, "instance-id-x") {
+		t.Fatalf("warning must name the instance id for triage; got %s", got)
+	}
+}

--- a/internal/session/telegram_reliability.go
+++ b/internal/session/telegram_reliability.go
@@ -1,0 +1,197 @@
+// Package session — telegram channel-plugin reliability helpers (issue #1138).
+//
+// PR #1136 closed the channel-owner case where the global antipattern
+// (settings.telegram=true in the source profile) triggered scratch
+// creation: scratch's settings.json now keeps the channel plugin
+// enabled so `--channels` has a live MCP transport to wire onto.
+//
+// What was still wrong. Scratch creation was gated on three orthogonal
+// signals — TG conductor present + non-channel-owning worker, explicit
+// plugins, or the global antipattern — none of which fire for the
+// recommended post-#941 topology (channel-owning conductor with the
+// global flag DISABLED, no extra plugins). In that case
+// NeedsWorkerScratchConfigDir returned false, no scratch was created,
+// and the conductor depended entirely on the ambient settings.json
+// carrying `telegram=true`. Any drift in the ambient (manual edit,
+// Claude Code's `/plugin disable`, an out-of-band rewriter) silently
+// disabled the channel transport. On the next restart there was no
+// force-correct pass to heal it — only a passive `--channels` wiring
+// directive that landed on nothing.
+//
+// What this file adds.
+//   - needsScratchForTelegramChannelOwner: a fourth gate that always
+//     fires for channel-owning sessions. The scratch becomes the single
+//     point of truth for channel-plugin enablement and the heal point
+//     on every spawn.
+//   - VerifyTelegramChannelEnabled: pure-function check that returns a
+//     structured result describing whether `--channels` will find a
+//     live MCP server in the given config dir.
+//   - EmitTelegramChannelDriftWarning: structured WARN-level log entry
+//     with a stable code (`telegram_channel_plugin_drift`) so operators
+//     and monitoring can detect the silent-failure topology.
+//
+// All three are wired into prepareWorkerScratchConfigDirForSpawn so the
+// channel-owner is healed on every restart AND a loud warning fires if
+// the effective state still doesn't enable the plugin (defense in depth).
+
+package session
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// needsScratchForTelegramChannelOwner is the issue #1138 gate.
+//
+// A claude session whose Channels contains a `plugin:telegram@…` id
+// ALWAYS needs a scratch CLAUDE_CONFIG_DIR so agent-deck owns the
+// enablement of its own channel plugin. The scratch's settings.json is
+// rewritten on every spawn (idempotent, force-correct), so any drift
+// — manual edit, `/plugin disable`, external rewriter — is healed at
+// the start of the next session. Without this gate, channel-owning
+// conductors that have correctly DISABLED the global antipattern (per
+// #941 guidance) end up trusting the ambient profile, which has no
+// agent-deck-controlled invariant.
+func needsScratchForTelegramChannelOwner(i *Instance) bool {
+	if i == nil || i.Tool != "claude" {
+		return false
+	}
+	return sessionHasTelegramChannel(i)
+}
+
+// TelegramChannelEnablementResult is the structured outcome of
+// VerifyTelegramChannelEnabled. OK is the only consumer-relevant bit;
+// Reason carries the human-readable diagnostic for log lines.
+type TelegramChannelEnablementResult struct {
+	// OK is true when the session has no telegram channel OR the
+	// effective settings.json has telegram=true. Either case means
+	// `--channels` will not silently land on a disabled plugin.
+	OK bool
+
+	// Reason describes the failure when OK=false. Empty when OK=true.
+	// Stable English phrasing — operators grep for substrings.
+	Reason string
+
+	// EffectiveValue is the value found in settings.json
+	// (true/false/absent). Carried so the warning can name the exact
+	// drift variant the operator is observing.
+	EffectiveValue string
+}
+
+// VerifyTelegramChannelEnabled inspects the given config dir's
+// settings.json and reports whether a session whose `--channels`
+// references `plugin:telegram@…` will find a live MCP transport.
+//
+// The check is conservative: a missing or unreadable settings.json is
+// treated as "not enabled" (Reason fills in). This matches Claude
+// Code's own behavior — absence equals disabled for channel plugins.
+//
+// Pure / read-only; safe to call from prepare path and from a runtime
+// monitor (telegram-doctor CLI).
+func VerifyTelegramChannelEnabled(configDir string, channels []string) TelegramChannelEnablementResult {
+	// No telegram channel → vacuously OK; nothing to verify.
+	hasTG := false
+	for _, ch := range channels {
+		if strings.HasPrefix(ch, telegramChannelPrefix) {
+			hasTG = true
+			break
+		}
+	}
+	if !hasTG {
+		return TelegramChannelEnablementResult{OK: true}
+	}
+
+	if configDir == "" {
+		return TelegramChannelEnablementResult{
+			OK:             false,
+			Reason:         "config dir is empty; cannot resolve effective settings.json",
+			EffectiveValue: "no-config-dir",
+		}
+	}
+
+	settingsPath := filepath.Join(configDir, "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return TelegramChannelEnablementResult{
+				OK:             false,
+				Reason:         "settings.json does not exist at " + settingsPath,
+				EffectiveValue: "missing-file",
+			}
+		}
+		return TelegramChannelEnablementResult{
+			OK:             false,
+			Reason:         "read settings.json failed: " + err.Error(),
+			EffectiveValue: "read-error",
+		}
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return TelegramChannelEnablementResult{
+			OK:             false,
+			Reason:         "settings.json is not valid JSON: " + err.Error(),
+			EffectiveValue: "parse-error",
+		}
+	}
+
+	plugins, _ := parsed["enabledPlugins"].(map[string]interface{})
+	if plugins == nil {
+		return TelegramChannelEnablementResult{
+			OK:             false,
+			Reason:         "settings.json has no enabledPlugins block; --channels has nothing to wire",
+			EffectiveValue: "absent",
+		}
+	}
+	raw, present := plugins[telegramPluginID]
+	if !present {
+		return TelegramChannelEnablementResult{
+			OK:             false,
+			Reason:         "enabledPlugins is missing the " + telegramPluginID + " entry; --channels has nothing to wire",
+			EffectiveValue: "absent",
+		}
+	}
+	v, isBool := raw.(bool)
+	if !isBool {
+		return TelegramChannelEnablementResult{
+			OK:             false,
+			Reason:         "enabledPlugins[" + telegramPluginID + "] is not a boolean",
+			EffectiveValue: "non-bool",
+		}
+	}
+	if !v {
+		return TelegramChannelEnablementResult{
+			OK:             false,
+			Reason:         "enabledPlugins[" + telegramPluginID + "] = false; --channels cannot activate a disabled plugin",
+			EffectiveValue: "false",
+		}
+	}
+	return TelegramChannelEnablementResult{OK: true, EffectiveValue: "true"}
+}
+
+// EmitTelegramChannelDriftWarning logs a WARN-level structured entry
+// when VerifyTelegramChannelEnabled returns OK=false for a session
+// that owns a telegram channel. The code field is stable
+// (`telegram_channel_plugin_drift`) so log-monitoring rules can
+// trigger on it without parsing free-form text.
+//
+// Intentionally a no-op when result.OK is true — callers can invoke
+// it unconditionally on the prepare path.
+func EmitTelegramChannelDriftWarning(title, instanceID, configDir string, channels []string, result TelegramChannelEnablementResult) {
+	if result.OK {
+		return
+	}
+	sessionLog.Warn("telegram_channel_plugin_drift",
+		slog.String("instance_id", instanceID),
+		slog.String("title", title),
+		slog.String("plugin_id", telegramPluginID),
+		slog.String("config_dir", configDir),
+		slog.String("channels", strings.Join(channels, ",")),
+		slog.String("effective_value", result.EffectiveValue),
+		slog.String("reason", result.Reason),
+		slog.String("hint", "agent-deck telegram-doctor reports per-conductor health; the scratch CLAUDE_CONFIG_DIR is rewritten on every restart and should heal this drift on the next session restart."),
+	)
+}

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -73,7 +73,8 @@ var hostHasTelegramConductor = func() bool {
 func (i *Instance) NeedsWorkerScratchConfigDir() bool {
 	return needsScratchForTelegram(i) ||
 		needsScratchForExplicitPlugins(i) ||
-		needsScratchForGlobalChannelConflict(i)
+		needsScratchForGlobalChannelConflict(i) ||
+		needsScratchForTelegramChannelOwner(i)
 }
 
 func needsScratchForTelegram(i *Instance) bool {
@@ -454,6 +455,21 @@ func (i *Instance) prepareWorkerScratchConfigDirForSpawn() {
 		return
 	}
 	i.WorkerScratchConfigDir = scratch
+
+	// Issue #1138: post-write verification. After the scratch
+	// settings.json is rewritten, confirm the channel plugin is
+	// actually enabled in the EFFECTIVE config dir (scratch when
+	// present, ambient otherwise). Any failure here means `--channels`
+	// would land on a disabled plugin and bun-telegram would never
+	// spawn — surface it loudly so operators can heal manually if the
+	// force-correct itself somehow drifted.
+	effectiveDir := scratch
+	if effectiveDir == "" {
+		effectiveDir = sourceDir
+	}
+	if result := VerifyTelegramChannelEnabled(effectiveDir, i.Channels); !result.OK {
+		EmitTelegramChannelDriftWarning(i.Title, i.ID, effectiveDir, i.Channels, result)
+	}
 }
 
 // macOSScratchWarningEmitter is the package-level seam that lets tests

--- a/internal/session/worker_scratch_test.go
+++ b/internal/session/worker_scratch_test.go
@@ -136,24 +136,34 @@ func TestEnsureWorkerScratchConfigDir_ConductorKeepsAmbientProfile(t *testing.T)
 	}
 }
 
-// A session that carries a `plugin:telegram@...` channel is the
-// explicit, opted-in telegram bot owner and MUST keep the ambient
-// profile when the v3 topology is correct (global enabledPlugins.telegram
-// disabled, --channels is the sole activation). Isolating it would
-// break its own bot.
+// Issue #1138 amendment (was: ChannelOwnerKeepsAmbientProfile).
 //
-// Issue #941 amendment: if the ambient profile has global
-// enabledPlugins.telegram=true (the GLOBAL_ANTIPATTERN), scratch
-// creation is now expected (see
-// TestEnsureWorkerScratchConfigDir_ChannelOwner_GlobalAntipattern_GetsScratch).
-func TestEnsureWorkerScratchConfigDir_ChannelOwnerKeepsAmbientProfile(t *testing.T) {
+// History: pre-#1138 a channel owner with v3 topology (global
+// enabledPlugins.telegram=false, --channels as activation) kept the
+// ambient profile because the scratch indirection seemed unnecessary —
+// claude would supposedly read `--channels` and find the plugin
+// already enabled globally.
+//
+// That assumption broke in production. With the ambient settings.json
+// as the only source of truth for plugin enablement, ANY drift in the
+// ambient (manual edit, Claude Code's `/plugin disable`, an out-of-band
+// rewriter) silently disabled the channel transport. On the next
+// restart there was no force-correct pass to heal it — channels
+// silently dropped for hours until the maintainer noticed.
+//
+// Post-#1138: channel-owning sessions ALWAYS receive a scratch dir.
+// The scratch is a shallow mirror of the ambient profile (everything
+// is symlinked through), so the bot's own token files / commands /
+// agents / plugins keep working. The only file the scratch OWNS is
+// settings.json, where agent-deck force-writes
+// enabledPlugins["telegram@claude-plugins-official"]=true on every
+// spawn. That makes the scratch the heal point for drift.
+func TestEnsureWorkerScratchConfigDir_ChannelOwner_AlwaysGetsScratch(t *testing.T) {
 	withTelegramConductorPresent(t)
 	source := t.TempDir()
 	// v3 topology: global flag is unset, only --channels activates.
 	_ = os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{}}`), 0o644)
 
-	// Pin source resolution so needsScratchForGlobalChannelConflict reads
-	// THIS settings.json (not the host's real ~/.claude).
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("CLAUDE_CONFIG_DIR", source)
@@ -169,8 +179,22 @@ func TestEnsureWorkerScratchConfigDir_ChannelOwnerKeepsAmbientProfile(t *testing
 	if err != nil {
 		t.Fatalf("EnsureWorkerScratchConfigDir: %v", err)
 	}
-	if got != "" {
-		t.Errorf("telegram channel owner with correct v3 topology must keep ambient profile; got scratch=%q", got)
+	if got == "" {
+		t.Fatalf("issue #1138: telegram channel owner MUST get a scratch dir for force-correct of channel-plugin enablement; got empty")
+	}
+
+	data, err := os.ReadFile(filepath.Join(got, "settings.json"))
+	if err != nil {
+		t.Fatalf("read scratch settings: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	plugins, _ := parsed["enabledPlugins"].(map[string]interface{})
+	v, ok := plugins[telegramPluginID].(bool)
+	if !ok || !v {
+		t.Fatalf("scratch must force telegram=true for channel owner; got present=%v value=%v", ok, v)
 	}
 }
 


### PR DESCRIPTION
## Summary

PR #1136 (issue #1134) made channel-owning scratch settings.json keep `enabledPlugins.telegram=true` so `--channels` could wire onto a live MCP transport. The fix landed and worked when it ran, but the maintainer kept observing the exact same drop pattern every few hours:

| Signal | State |
|---|---|
| Bot reachable via Telegram Bot API | ✅ |
| claude running with `--channels plugin:telegram@…` | ✅ |
| `bun telegram` plugin process | ❌ MISSING |
| Scratch `settings.json` `enabledPlugins["telegram@…"]` | ❌ `false` OR absent |

## Recurrence pattern / hypothesis tree

Scratch creation was gated on three orthogonal signals:

1. `needsScratchForTelegram` — TG conductor present + non-channel-owning worker
2. `needsScratchForExplicitPlugins` — `Instance.Plugins` non-empty
3. `needsScratchForGlobalChannelConflict` — global antipattern (`enabledPlugins.telegram=true` in source profile)

The **recommended post-#941 topology** — channel-owning conductor with the global flag DISABLED, no extra plugins — fires NONE of those. The conductor depended entirely on the ambient `settings.json` carrying `telegram=true`. Any drift in the ambient (manual edit, Claude Code's `/plugin disable`, an out-of-band rewriter, a fresh `enabledPlugins` block written by `/plugin install`) silently disabled the channel transport. On restart there was no force-correct pass to heal it — only a passive `--channels` wiring directive landing on nothing. Telegram inbound dropped invisibly until the user noticed no responses.

## The fix (defense in depth)

1. **`needsScratchForTelegramChannelOwner` (4th scratch gate)** — channel-owning sessions ALWAYS get a scratch dir so agent-deck owns the enablement of its own channel plugin. The scratch settings.json is rewritten on every spawn (idempotent / force-correct), so any drift is healed at the start of the next restart.
2. **`VerifyTelegramChannelEnabled`** — pure-function inspector returning a structured result (`OK`, `Reason`, `EffectiveValue`). Six distinct drift variants: `true`, `false`, `absent`, `missing-file`, `parse-error`, `non-bool`. Used by both the prepare path and the doctor CLI.
3. **`EmitTelegramChannelDriftWarning`** — stable WARN-level log code `telegram_channel_plugin_drift`, with structured fields (`instance_id`, `title`, `plugin_id`, `config_dir`, `effective_value`, `reason`). Greppable for monitoring/alerting.
4. **`prepareWorkerScratchConfigDirForSpawn` post-write verification** — emits the drift warning when the effective settings.json STILL doesn't enable the plugin. Covers the case where the force-correct itself somehow drifted.
5. **`agent-deck telegram-doctor` CLI** — new subcommand. Audits every channel-owning session in a profile, reports settings drift + missing bun-telegram pollers via `pgrep -af bun.*telegram`, prints heal commands, exits 1 on any drift. Cron-friendly with `--json`.

## Test coverage

Per `agent-deck-tdd-feature` surface checklist:

| Surface | Tests added |
|---|---|
| Persistence / spawn (`internal/session/`) | `issue1138_telegram_reliability_test.go` — 4 cases: always-create, drift heal (false → true), drift heal (absent → true), post-spawn warning code/level/fields |
| Persistence (amended) | `worker_scratch_test.go` — `TestEnsureWorkerScratchConfigDir_ChannelOwner_AlwaysGetsScratch` replaces the old `ChannelOwnerKeepsAmbientProfile` assertion (which was the bug encoded as a test) |
| CLI (`cmd/agent-deck/`) | `cmd_telegram_doctor_test.go` — 6 cases: channel-id detector (official + fork + non-telegram + nil), healthy, drift-false, drift-absent, non-channel ignored, missing settings file |
| CI gate | `.github/workflows/telegram-reliability.yml` — targeted regression gate on the 4-file footprint of the fix |

Each test grep-tags `issue1138` so the regression is permanently linked to this PR.

### Skipped surfaces (documented per skill rule)
- **TUI** — channel-owner scratch state is invisible in the home view; no TUI affordance changes. `telegram-doctor` is a one-shot CLI, not a TUI panel (planned follow-up: TUI status segment for channel-plugin drift).
- **Web UI** — same as TUI; no `/web/` route exposes channel-plugin enablement today.
- **Remote** — channel-owning sessions are local conductors by design (RemoteSession does not own a bot token).
- **Cross-platform** — `pgrep` is the documented diagnostic on Linux/macOS; `pollersForInstance` falls back to coarse PID matching on non-Linux platforms (no `/proc/<pid>/environ`).

## Test plan

- [x] `go test -race -count=1 -timeout 5m ./internal/session/ ./cmd/agent-deck/` ✅
- [x] `golangci-lint run --timeout=5m --issues-exit-code=1 ./internal/session/ ./cmd/agent-deck/` → `0 issues`
- [x] `go vet ./...` → clean
- [x] `go build ./...` → clean
- [x] CLI smoke: `agent-deck telegram-doctor` on empty profile → exit 0, "no channel-owning sessions"
- [x] CLI smoke: `agent-deck telegram-doctor --help` → flags `-json`, `-quiet` documented
- [ ] Manual verification on maintainer's host: run `agent-deck -p personal telegram-doctor`, then deliberately set scratch `enabledPlugins.telegram=false`, restart, confirm next spawn heals it

## Follow-up to #1136

#1136 is the foundation this PR extends. The mental model after this PR:
- **#1136**: when the scratch IS created for a channel owner, its `settings.json` keeps `telegram=true`.
- **#1138** (this PR): channel owners ALWAYS get a scratch, and we WARN loudly if the effective state still drifts.

No revert of #1136 is needed — it's still the correctness guarantee for the `EnsureWorkerScratchConfigDir` writer; this PR just extends WHEN that writer runs.

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `telegram-doctor` command to diagnose Telegram channel plugin configuration and health status.

* **Bug Fixes**
  * Improved reliability of Telegram channel plugins by detecting and automatically correcting configuration drift.

* **Tests**
  * Added comprehensive test coverage for Telegram plugin diagnostics and health verification.

* **Chores**
  * Added CI workflow for automated Telegram reliability checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->