### PR TITLE
fix(session): persist Codex + Gemini session-id rebinds to SQLite (closes #1139, mirrors #1140 for claude)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3649,18 +3649,7 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		if sessionID == i.CodexSessionID {
 			return
 		}
-		sessionLog.Debug("codex_session_update_from_hook",
-			slog.String("old_id", i.CodexSessionID),
-			slog.String("new_id", sessionID),
-			slog.String("event", status.Event),
-		)
-		i.CodexSessionID = sessionID
-		i.CodexDetectedAt = time.Now()
-		i.hookSessionID = sessionID
-
-		if i.tmuxSession != nil && i.tmuxSession.Exists() {
-			_ = i.tmuxSession.SetEnvironment("CODEX_SESSION_ID", sessionID)
-		}
+		i.bindCodexSessionFromHook(sessionID, status.Event)
 	case i.Tool == "gemini":
 		if sessionID == i.GeminiSessionID {
 			return
@@ -3668,18 +3657,86 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		// Quality gate: only accept when candidate session appears valid on disk,
 		// OR when current session is empty (first detection/bootstrap).
 		if i.GeminiSessionID == "" || geminiSessionHasConversationData(sessionID, i.ProjectPath) {
-			sessionLog.Debug("gemini_session_update_from_hook",
-				slog.String("old_id", i.GeminiSessionID),
-				slog.String("new_id", sessionID),
-				slog.String("event", status.Event),
-			)
-			i.GeminiSessionID = sessionID
-			i.GeminiDetectedAt = time.Now()
-			i.hookSessionID = sessionID
+			i.bindGeminiSessionFromHook(sessionID, status.Event)
+		}
+	}
+}
 
-			if i.tmuxSession != nil && i.tmuxSession.Exists() {
-				_ = i.tmuxSession.SetEnvironment("GEMINI_SESSION_ID", sessionID)
-			}
+// bindCodexSessionFromHook is the Codex counterpart of
+// bindClaudeSessionFromHook (see that function's doc comment for the
+// PERSIST-12 rationale). It performs the same bookkeeping that the
+// inlined pre-#1139 code did — debug log, in-memory mutation, tmux env
+// propagation — and then persists the new binding to SQLite so
+// DB-direct consumers and peer agent-deck processes observe the new
+// codex_session_id immediately, instead of reloading the stale row and
+// clobbering the in-memory mutation on the next save cycle.
+func (i *Instance) bindCodexSessionFromHook(sessionID, hookEvent string) {
+	sessionLog.Debug("codex_session_update_from_hook",
+		slog.String("old_id", i.CodexSessionID),
+		slog.String("new_id", sessionID),
+		slog.String("event", hookEvent),
+	)
+	i.CodexSessionID = sessionID
+	i.CodexDetectedAt = time.Now()
+	i.hookSessionID = sessionID
+
+	if i.tmuxSession != nil && i.tmuxSession.Exists() {
+		_ = i.tmuxSession.SetEnvironment("CODEX_SESSION_ID", sessionID)
+	}
+
+	// Persist the rebind to SQLite. See bindClaudeSessionFromHook for the
+	// full rationale: none of the three UpdateHookStatus callers (TUI
+	// tick, web refresh, CLI status refresh) save after a hook-triggered
+	// rebind, so tool_data.codex_session_id stays pinned at the stale
+	// UUID indefinitely for DB-direct consumers, and peer processes
+	// holding stale snapshots keep clobbering the in-memory mutation —
+	// producing a runaway loop of fresh "rebind" decisions on every
+	// poll. WriteCodexSessionBinding rewrites only the typed schema
+	// fields via json_set, leaving every other tool_data key untouched.
+	if db := statedb.GetGlobal(); db != nil {
+		if err := db.WriteCodexSessionBinding(i.ID, sessionID, i.CodexDetectedAt); err != nil {
+			sessionLog.Warn("codex_session_rebind_persist_failed",
+				slog.String("instance_id", i.ID),
+				slog.String("new_id", sessionID),
+				slog.String("error", err.Error()))
+		}
+	}
+}
+
+// bindGeminiSessionFromHook is the Gemini counterpart of
+// bindClaudeSessionFromHook. See that function's doc comment for the
+// PERSIST-12 rationale. The quality gate (GeminiSessionID == "" ||
+// geminiSessionHasConversationData(...)) is enforced by the caller in
+// UpdateHookStatus before this function is invoked, mirroring the
+// invariant the inlined pre-#1139 code preserved.
+func (i *Instance) bindGeminiSessionFromHook(sessionID, hookEvent string) {
+	sessionLog.Debug("gemini_session_update_from_hook",
+		slog.String("old_id", i.GeminiSessionID),
+		slog.String("new_id", sessionID),
+		slog.String("event", hookEvent),
+	)
+	i.GeminiSessionID = sessionID
+	i.GeminiDetectedAt = time.Now()
+	i.hookSessionID = sessionID
+
+	if i.tmuxSession != nil && i.tmuxSession.Exists() {
+		_ = i.tmuxSession.SetEnvironment("GEMINI_SESSION_ID", sessionID)
+	}
+
+	// Persist the rebind to SQLite. See bindClaudeSessionFromHook for
+	// the full rationale on why the in-memory mutation alone is not
+	// enough: the bug pattern (#1138 for Claude, #1139 for
+	// Codex/Gemini) is that UpdateHookStatus callers don't call Save
+	// afterwards, so peer agent-deck processes keep reloading the stale
+	// row and clobbering this instance's in-memory state. The targeted
+	// json_set UPDATE atomically rewrites only $.gemini_session_id and
+	// $.gemini_detected_at, preserving the rest of tool_data.
+	if db := statedb.GetGlobal(); db != nil {
+		if err := db.WriteGeminiSessionBinding(i.ID, sessionID, i.GeminiDetectedAt); err != nil {
+			sessionLog.Warn("gemini_session_rebind_persist_failed",
+				slog.String("instance_id", i.ID),
+				slog.String("new_id", sessionID),
+				slog.String("error", err.Error()))
 		}
 	}
 }

--- a/internal/session/issue1139_codex_session_persist_test.go
+++ b/internal/session/issue1139_codex_session_persist_test.go
@@ -1,0 +1,316 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+// Regression for issue #1139 — Codex variant of the persist gap fixed
+// for Claude in #1140 (PR 304d05a7). #1138 / #1140 documents the root
+// cause in full; the short version is that `bindCodexSessionFromHook`
+// mutated `i.CodexSessionID` in memory and propagated the new ID into
+// the tmux env, but none of the `UpdateHookStatus` callers (TUI tick,
+// web refresh, CLI status refresh) called `Save` afterwards. So
+// `instances.tool_data.codex_session_id` in `state.db` stayed pinned at
+// the pre-/clear UUID indefinitely. DB-direct consumers saw the stale
+// ID, and peer agent-deck processes kept reloading the stale row from
+// disk and clobbering each other's in-memory bind — producing a runaway
+// loop of fresh `rebind` lifecycle entries until something else triggered
+// a full save.
+//
+// These tests pin the fix: both the cold `bind` branch and the `rebind`
+// branch must leave `tool_data.codex_session_id` matching the new UUID
+// the instant `UpdateHookStatus` returns.
+
+// readCodexSessionIDFromDB returns tool_data.codex_session_id for the
+// given instance, reading via a fresh query so the assertion reflects
+// what a DB-direct consumer would observe (no in-memory caching).
+func readCodexSessionIDFromDB(t *testing.T, db *statedb.StateDB, id string) string {
+	t.Helper()
+	rows, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	for _, row := range rows {
+		if row.ID != id {
+			continue
+		}
+		var blob struct {
+			CodexSessionID string `json:"codex_session_id"`
+		}
+		if len(row.ToolData) == 0 {
+			return ""
+		}
+		if err := json.Unmarshal(row.ToolData, &blob); err != nil {
+			t.Fatalf("unmarshal tool_data for %s: %v (raw=%s)", id, err, string(row.ToolData))
+		}
+		return blob.CodexSessionID
+	}
+	t.Fatalf("instance %q not found in DB", id)
+	return ""
+}
+
+// TestRebindPersistsCodexSessionIDToDB exercises the rebind shape:
+// instance already bound to OLD, UpdateHookStatus fires for NEW. After
+// the call, tool_data.codex_session_id in the database must equal NEW.
+//
+// Pre-fix this test fails: in-memory CodexSessionID advances but the
+// row in the DB stays at OLD.
+func TestRebindPersistsCodexSessionIDToDB(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	db := withTempGlobalStateDB(t)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-codex-rebind-persist", projectPath, "codex")
+
+	oldID := "5ea244ce-0000-0000-0000-000000000a01"
+	newID := "2266314c-0000-0000-0000-000000000a02"
+
+	now := time.Now()
+	seedRow := &statedb.InstanceRow{
+		ID:          inst.ID,
+		Title:       inst.Title,
+		ProjectPath: inst.ProjectPath,
+		GroupPath:   inst.GroupPath,
+		Command:     inst.Command,
+		Tool:        "codex",
+		Status:      "idle",
+		CreatedAt:   now,
+		ToolData:    json.RawMessage(`{"codex_session_id":"` + oldID + `"}`),
+	}
+	if err := db.SaveInstance(seedRow); err != nil {
+		t.Fatalf("SaveInstance seed: %v", err)
+	}
+
+	inst.CodexSessionID = oldID
+	if got := readCodexSessionIDFromDB(t, db, inst.ID); got != oldID {
+		t.Fatalf("pre-condition: DB codex_session_id = %q, want %q", got, oldID)
+	}
+
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "UserPromptSubmit",
+		UpdatedAt: time.Now(),
+	})
+
+	// Post-condition (in-memory) — the existing behavior pre-fix.
+	if inst.CodexSessionID != newID {
+		t.Fatalf("in-memory CodexSessionID = %q, want %q (rebind path didn't fire)",
+			inst.CodexSessionID, newID)
+	}
+
+	// Post-condition (DB) — the regression we are pinning. Pre-fix this
+	// stays at OLD because the rebind never reached SQLite.
+	if got := readCodexSessionIDFromDB(t, db, inst.ID); got != newID {
+		t.Fatalf("post-rebind DB codex_session_id = %q, want %q. "+
+			"bindCodexSessionFromHook mutated in-memory state but did not "+
+			"persist to tool_data — DB-direct consumers will see the stale UUID "+
+			"until something else triggers a save.", got, newID)
+	}
+}
+
+// TestBindPersistsCodexSessionIDToDB covers the cold-start branch —
+// when an instance has no CodexSessionID yet and the very first hook
+// event arrives. Must persist just as eagerly as the rebind path.
+func TestBindPersistsCodexSessionIDToDB(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	db := withTempGlobalStateDB(t)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-codex-bind-persist", projectPath, "codex")
+
+	newID := "7a3b9c10-0000-0000-0000-000000000a03"
+
+	seedRow := &statedb.InstanceRow{
+		ID:          inst.ID,
+		Title:       inst.Title,
+		ProjectPath: inst.ProjectPath,
+		GroupPath:   inst.GroupPath,
+		Command:     inst.Command,
+		Tool:        "codex",
+		Status:      "idle",
+		CreatedAt:   time.Now(),
+		ToolData:    json.RawMessage(`{}`),
+	}
+	if err := db.SaveInstance(seedRow); err != nil {
+		t.Fatalf("SaveInstance seed: %v", err)
+	}
+
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "SessionStart",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.CodexSessionID != newID {
+		t.Fatalf("in-memory CodexSessionID = %q, want %q", inst.CodexSessionID, newID)
+	}
+	if got := readCodexSessionIDFromDB(t, db, inst.ID); got != newID {
+		t.Fatalf("post-bind DB codex_session_id = %q, want %q — cold-start bind "+
+			"did not persist to tool_data", got, newID)
+	}
+}
+
+// TestCodexRebindNoOpWhenStateDBUnset confirms the persistence call is
+// optional: when no global StateDB is wired (CLI processes that haven't
+// initialized statedb yet, certain test paths), the rebind must still
+// mutate in-memory state and not panic. Protects the existing contract
+// that UpdateHookStatus is callable from any context.
+func TestCodexRebindNoOpWhenStateDBUnset(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	prev := statedb.GetGlobal()
+	statedb.SetGlobal(nil)
+	t.Cleanup(func() { statedb.SetGlobal(prev) })
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-codex-rebind-nodb", projectPath, "codex")
+
+	newID := "9f5e1d80-0000-0000-0000-000000000a04"
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "SessionStart",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.CodexSessionID != newID {
+		t.Fatalf("in-memory CodexSessionID = %q, want %q (rebind path must work "+
+			"even without a global StateDB)", inst.CodexSessionID, newID)
+	}
+}
+
+// TestCodexRebindPreservesUnrelatedToolDataKeys pins the json_set
+// semantics of WriteCodexSessionBinding: only $.codex_session_id and
+// $.codex_detected_at may be rewritten — every other key in tool_data
+// must survive untouched. Prevents a future "let's just do
+// tool_data = ?" simplification from silently dropping unrelated state
+// on every Codex rebind.
+func TestCodexRebindPreservesUnrelatedToolDataKeys(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	db := withTempGlobalStateDB(t)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-codex-rebind-extras", projectPath, "codex")
+
+	oldID := "5ea244ce-0000-0000-0000-000000000a05"
+	newID := "2266314c-0000-0000-0000-000000000a06"
+
+	seedJSON := `{
+		"codex_session_id": "` + oldID + `",
+		"codex_detected_at": 1700000000,
+		"latest_prompt": "what does this code do?",
+		"notes": "user prefers terse responses",
+		"loaded_mcp_names": ["github", "linear"],
+		"ssh_host": "dev01.coder",
+		"clear_on_compact": true
+	}`
+	seedRow := &statedb.InstanceRow{
+		ID:          inst.ID,
+		Title:       inst.Title,
+		ProjectPath: inst.ProjectPath,
+		GroupPath:   inst.GroupPath,
+		Command:     inst.Command,
+		Tool:        "codex",
+		Status:      "idle",
+		CreatedAt:   time.Now(),
+		ToolData:    json.RawMessage(seedJSON),
+	}
+	if err := db.SaveInstance(seedRow); err != nil {
+		t.Fatalf("SaveInstance seed: %v", err)
+	}
+
+	inst.CodexSessionID = oldID
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "UserPromptSubmit",
+		UpdatedAt: time.Now(),
+	})
+
+	rows, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	var found *statedb.InstanceRow
+	for _, row := range rows {
+		if row.ID == inst.ID {
+			found = row
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("instance %q missing from DB", inst.ID)
+	}
+	var blob map[string]any
+	if err := json.Unmarshal(found.ToolData, &blob); err != nil {
+		t.Fatalf("unmarshal tool_data: %v (raw=%s)", err, string(found.ToolData))
+	}
+
+	if got, _ := blob["codex_session_id"].(string); got != newID {
+		t.Errorf("codex_session_id = %q, want %q (rebind didn't persist)", got, newID)
+	}
+	if v, ok := blob["codex_detected_at"]; !ok {
+		t.Errorf("codex_detected_at missing — rebind should have written it")
+	} else if f, _ := v.(float64); int64(f) == 1700000000 {
+		t.Errorf("codex_detected_at = %v, want a fresh timestamp", v)
+	}
+
+	preserved := map[string]any{
+		"latest_prompt":    "what does this code do?",
+		"notes":            "user prefers terse responses",
+		"ssh_host":         "dev01.coder",
+		"clear_on_compact": true,
+	}
+	for k, want := range preserved {
+		got, ok := blob[k]
+		if !ok {
+			t.Errorf("tool_data lost key %q after rebind — json_set must not "+
+				"replace the whole column.", k)
+			continue
+		}
+		if got != want {
+			t.Errorf("tool_data[%q] = %v, want %v", k, got, want)
+		}
+	}
+	mcps, ok := blob["loaded_mcp_names"].([]any)
+	if !ok {
+		t.Errorf("tool_data lost loaded_mcp_names after rebind (got %T)", blob["loaded_mcp_names"])
+	} else if len(mcps) != 2 || mcps[0] != "github" || mcps[1] != "linear" {
+		t.Errorf("loaded_mcp_names = %v, want [github linear]", mcps)
+	}
+}

--- a/internal/session/issue1139_gemini_session_persist_test.go
+++ b/internal/session/issue1139_gemini_session_persist_test.go
@@ -1,0 +1,320 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+// Regression for issue #1139 — Gemini variant of the persist gap fixed
+// for Claude in #1140 (PR 304d05a7). See the Codex sibling test file
+// and the issue threads for the full RCA. Short version: hook-driven
+// rebind mutated `i.GeminiSessionID` in memory but never reached
+// SQLite. DB-direct consumers and peer agent-deck processes saw the
+// stale UUID indefinitely, and the lifecycle log accumulated fresh
+// `rebind` entries forever.
+
+// readGeminiSessionIDFromDB returns tool_data.gemini_session_id for the
+// given instance, reading via a fresh query (no in-memory caching).
+func readGeminiSessionIDFromDB(t *testing.T, db *statedb.StateDB, id string) string {
+	t.Helper()
+	rows, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	for _, row := range rows {
+		if row.ID != id {
+			continue
+		}
+		var blob struct {
+			GeminiSessionID string `json:"gemini_session_id"`
+		}
+		if len(row.ToolData) == 0 {
+			return ""
+		}
+		if err := json.Unmarshal(row.ToolData, &blob); err != nil {
+			t.Fatalf("unmarshal tool_data for %s: %v (raw=%s)", id, err, string(row.ToolData))
+		}
+		return blob.GeminiSessionID
+	}
+	t.Fatalf("instance %q not found in DB", id)
+	return ""
+}
+
+// seedGeminiSessionFile writes a minimal Gemini session JSON the
+// quality-gate (geminiSessionHasConversationData) accepts. The file
+// name pattern session-*-<first8>.json is required by the disk glob.
+func seedGeminiSessionFile(t *testing.T, projectPath, sessionID string) {
+	t.Helper()
+	sessionsDir := GetGeminiSessionsDir(projectPath)
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir gemini sessions dir: %v", err)
+	}
+	filePath := filepath.Join(sessionsDir, "session-2026-05-21T10-00-"+sessionID[:8]+".json")
+	content := `{"sessionId":"` + sessionID + `","messages":[{"type":"user","content":"hi"}]}`
+	if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write gemini session file: %v", err)
+	}
+}
+
+// TestRebindPersistsGeminiSessionIDToDB exercises the rebind shape:
+// instance bound to OLD, UpdateHookStatus fires for NEW with a valid
+// on-disk session file (required by the gemini quality gate). After
+// the call, tool_data.gemini_session_id in the database must equal NEW.
+//
+// Pre-fix this test fails: in-memory GeminiSessionID advances but the
+// row in the DB stays at OLD.
+func TestRebindPersistsGeminiSessionIDToDB(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	db := withTempGlobalStateDB(t)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-gemini-rebind-persist", projectPath, "gemini")
+
+	oldID := "5ea244ce-0000-0000-0000-000000000b01"
+	newID := "2266314c-0000-0000-0000-000000000b02"
+
+	// The rebind path's quality gate (geminiSessionHasConversationData)
+	// rejects the candidate when GeminiSessionID is already set unless
+	// the candidate's session file exists on disk with at least one
+	// message — seed it so we exercise the rebind branch.
+	seedGeminiSessionFile(t, projectPath, newID)
+
+	now := time.Now()
+	seedRow := &statedb.InstanceRow{
+		ID:          inst.ID,
+		Title:       inst.Title,
+		ProjectPath: inst.ProjectPath,
+		GroupPath:   inst.GroupPath,
+		Command:     inst.Command,
+		Tool:        "gemini",
+		Status:      "idle",
+		CreatedAt:   now,
+		ToolData:    json.RawMessage(`{"gemini_session_id":"` + oldID + `"}`),
+	}
+	if err := db.SaveInstance(seedRow); err != nil {
+		t.Fatalf("SaveInstance seed: %v", err)
+	}
+
+	inst.GeminiSessionID = oldID
+	if got := readGeminiSessionIDFromDB(t, db, inst.ID); got != oldID {
+		t.Fatalf("pre-condition: DB gemini_session_id = %q, want %q", got, oldID)
+	}
+
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "UserPromptSubmit",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.GeminiSessionID != newID {
+		t.Fatalf("in-memory GeminiSessionID = %q, want %q (rebind path didn't fire — "+
+			"check geminiSessionHasConversationData seed)", inst.GeminiSessionID, newID)
+	}
+
+	if got := readGeminiSessionIDFromDB(t, db, inst.ID); got != newID {
+		t.Fatalf("post-rebind DB gemini_session_id = %q, want %q. "+
+			"bindGeminiSessionFromHook mutated in-memory state but did not "+
+			"persist to tool_data — DB-direct consumers will see the stale UUID.",
+			got, newID)
+	}
+}
+
+// TestBindPersistsGeminiSessionIDToDB covers the cold-start branch —
+// GeminiSessionID == "" lets the quality gate through without a
+// session file on disk. Must persist as eagerly as the rebind path.
+func TestBindPersistsGeminiSessionIDToDB(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	db := withTempGlobalStateDB(t)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-gemini-bind-persist", projectPath, "gemini")
+
+	newID := "7a3b9c10-0000-0000-0000-000000000b03"
+
+	seedRow := &statedb.InstanceRow{
+		ID:          inst.ID,
+		Title:       inst.Title,
+		ProjectPath: inst.ProjectPath,
+		GroupPath:   inst.GroupPath,
+		Command:     inst.Command,
+		Tool:        "gemini",
+		Status:      "idle",
+		CreatedAt:   time.Now(),
+		ToolData:    json.RawMessage(`{}`),
+	}
+	if err := db.SaveInstance(seedRow); err != nil {
+		t.Fatalf("SaveInstance seed: %v", err)
+	}
+
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "SessionStart",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.GeminiSessionID != newID {
+		t.Fatalf("in-memory GeminiSessionID = %q, want %q", inst.GeminiSessionID, newID)
+	}
+	if got := readGeminiSessionIDFromDB(t, db, inst.ID); got != newID {
+		t.Fatalf("post-bind DB gemini_session_id = %q, want %q — cold-start bind "+
+			"did not persist to tool_data", got, newID)
+	}
+}
+
+// TestGeminiRebindNoOpWhenStateDBUnset confirms the persistence call
+// is optional: when no global StateDB is wired, the rebind must still
+// mutate in-memory state and not panic.
+func TestGeminiRebindNoOpWhenStateDBUnset(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	prev := statedb.GetGlobal()
+	statedb.SetGlobal(nil)
+	t.Cleanup(func() { statedb.SetGlobal(prev) })
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-gemini-rebind-nodb", projectPath, "gemini")
+
+	newID := "9f5e1d80-0000-0000-0000-000000000b04"
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "SessionStart",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.GeminiSessionID != newID {
+		t.Fatalf("in-memory GeminiSessionID = %q, want %q (rebind path must work "+
+			"even without a global StateDB)", inst.GeminiSessionID, newID)
+	}
+}
+
+// TestGeminiRebindPreservesUnrelatedToolDataKeys pins json_set
+// semantics: only $.gemini_session_id and $.gemini_detected_at may
+// be rewritten — every other key in tool_data must survive untouched.
+func TestGeminiRebindPreservesUnrelatedToolDataKeys(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	db := withTempGlobalStateDB(t)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := NewInstanceWithTool("hook-gemini-rebind-extras", projectPath, "gemini")
+
+	newID := "2266314c-0000-0000-0000-000000000b06"
+
+	// Use the cold-start bind branch (GeminiSessionID == "") so we
+	// don't need to seed a gemini session file on disk — the
+	// persistence path is identical to the rebind branch (both call
+	// bindGeminiSessionFromHook).
+	seedJSON := `{
+		"latest_prompt": "summarize the README",
+		"notes": "user prefers concise answers",
+		"loaded_mcp_names": ["github", "linear"],
+		"ssh_host": "dev01.coder",
+		"clear_on_compact": true
+	}`
+	seedRow := &statedb.InstanceRow{
+		ID:          inst.ID,
+		Title:       inst.Title,
+		ProjectPath: inst.ProjectPath,
+		GroupPath:   inst.GroupPath,
+		Command:     inst.Command,
+		Tool:        "gemini",
+		Status:      "idle",
+		CreatedAt:   time.Now(),
+		ToolData:    json.RawMessage(seedJSON),
+	}
+	if err := db.SaveInstance(seedRow); err != nil {
+		t.Fatalf("SaveInstance seed: %v", err)
+	}
+
+	inst.GeminiSessionID = ""
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "SessionStart",
+		UpdatedAt: time.Now(),
+	})
+
+	rows, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	var found *statedb.InstanceRow
+	for _, row := range rows {
+		if row.ID == inst.ID {
+			found = row
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("instance %q missing from DB", inst.ID)
+	}
+	var blob map[string]any
+	if err := json.Unmarshal(found.ToolData, &blob); err != nil {
+		t.Fatalf("unmarshal tool_data: %v (raw=%s)", err, string(found.ToolData))
+	}
+
+	if got, _ := blob["gemini_session_id"].(string); got != newID {
+		t.Errorf("gemini_session_id = %q, want %q (rebind didn't persist)", got, newID)
+	}
+	if _, ok := blob["gemini_detected_at"]; !ok {
+		t.Errorf("gemini_detected_at missing — rebind should have written it")
+	}
+
+	preserved := map[string]any{
+		"latest_prompt":    "summarize the README",
+		"notes":            "user prefers concise answers",
+		"ssh_host":         "dev01.coder",
+		"clear_on_compact": true,
+	}
+	for k, want := range preserved {
+		got, ok := blob[k]
+		if !ok {
+			t.Errorf("tool_data lost key %q after rebind — json_set must not "+
+				"replace the whole column.", k)
+			continue
+		}
+		if got != want {
+			t.Errorf("tool_data[%q] = %v, want %v", k, got, want)
+		}
+	}
+	mcps, ok := blob["loaded_mcp_names"].([]any)
+	if !ok {
+		t.Errorf("tool_data lost loaded_mcp_names after rebind (got %T)", blob["loaded_mcp_names"])
+	} else if len(mcps) != 2 || mcps[0] != "github" || mcps[1] != "linear" {
+		t.Errorf("loaded_mcp_names = %v, want [github linear]", mcps)
+	}
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -883,6 +883,49 @@ func (s *StateDB) WriteClaudeSessionBinding(id, sessionID string, detectedAt tim
 	})
 }
 
+// WriteCodexSessionBinding is the Codex counterpart of
+// WriteClaudeSessionBinding: it atomically rewrites $.codex_session_id
+// and $.codex_detected_at inside the tool_data JSON column without
+// touching any unrelated keys. See WriteClaudeSessionBinding for the
+// full rationale (PERSIST-12, json_set vs. tool_data = ?, withBusyRetry).
+// This sibling exists because the Codex rebind path in
+// bindCodexSessionFromHook has the same in-memory-only mutation shape
+// that the Claude fix in #1140 addressed — tracked as #1139.
+func (s *StateDB) WriteCodexSessionBinding(id, sessionID string, detectedAt time.Time) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(
+			`UPDATE instances
+			   SET tool_data = json_set(
+			         COALESCE(tool_data, '{}'),
+			         '$.codex_session_id', ?,
+			         '$.codex_detected_at', ?)
+			 WHERE id = ?`,
+			sessionID, detectedAt.Unix(), id,
+		)
+		return err
+	})
+}
+
+// WriteGeminiSessionBinding is the Gemini counterpart of
+// WriteClaudeSessionBinding. See that function's doc comment for the
+// PERSIST-12 / json_set / withBusyRetry rationale; the Gemini rebind
+// path in bindGeminiSessionFromHook had the same persistence gap
+// (#1139).
+func (s *StateDB) WriteGeminiSessionBinding(id, sessionID string, detectedAt time.Time) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(
+			`UPDATE instances
+			   SET tool_data = json_set(
+			         COALESCE(tool_data, '{}'),
+			         '$.gemini_session_id', ?,
+			         '$.gemini_detected_at', ?)
+			 WHERE id = ?`,
+			sessionID, detectedAt.Unix(), id,
+		)
+		return err
+	})
+}
+
 // ReadAllStatuses returns status + acknowledged flag for every instance.
 func (s *StateDB) ReadAllStatuses() (map[string]StatusRow, error) {
 	rows, err := s.db.Query("SELECT id, status, tool, acknowledged FROM instances")


### PR DESCRIPTION
## Summary

Sibling of #1138 / #1140 — extends @tarekrached's Claude rebind-persistence fix (commit 304d05a7, merged via #1140) to the Codex and Gemini paths. After a hook-driven session-id rebind inside a Codex or Gemini tile, the in-memory `CodexSessionID` / `GeminiSessionID` advanced to the new UUID but `instances.tool_data.{codex,gemini}_session_id` in `state.db` stayed pinned at the pre-rebind UUID indefinitely. DB-direct consumers saw the stale ID, and peer agent-deck processes kept reloading the stale row and clobbering each others' in-memory bind — producing a runaway loop of fresh `rebind` lifecycle entries on every poll instead of converging.

The Codex (`instance.go:3648`) and Gemini (`instance.go:3664`) rebind branches inside `UpdateHookStatus` were inlined; Claude already went through a helper (`bindClaudeSessionFromHook`). This PR extracts two parallel helpers — `bindCodexSessionFromHook` and `bindGeminiSessionFromHook` — that preserve the existing bookkeeping (debug log, in-memory mutation, tmux env propagation) and then call new statedb helpers that atomically rewrite the typed JSON fields via `json_set`:

- `statedb.WriteCodexSessionBinding` — rewrites `$.codex_session_id` + `$.codex_detected_at`
- `statedb.WriteGeminiSessionBinding` — rewrites `$.gemini_session_id` + `$.gemini_detected_at`

Both are wrapped in `withBusyRetry`, matching the Claude sibling. The `json_set` form preserves every other `tool_data` key (`latest_prompt`, `notes`, `loaded_mcp_names`, `ssh_host`, plugins, unmodeled extras like `clear_on_compact`) — so a concurrent writer holding a stale snapshot can't clobber unrelated state. Same contract @tarekrached pinned for the Claude path.

## Credit

Full RCA + reference implementation by @tarekrached in #1138 / #1140. The commit message on 304d05a7 explicitly flagged this Codex + Gemini follow-up as #1139:

> Codex (instance.go:3648) and Gemini (instance.go:3664) have the same in-memory-only mutation shape but are inlined rather than going through a helper like the Claude path. Tracked separately in #1139 — extending the fix there needs helper extraction and per-tool tests, kept out of this commit to keep review scope tight.

This PR is a direct mirror of his pattern to the two remaining tools.

## Tests

`internal/session/issue1139_codex_session_persist_test.go` and `internal/session/issue1139_gemini_session_persist_test.go` mirror Tarek's `instance_rebind_persist_test.go` structure 1:1:

| Test | Surface |
|------|---------|
| `TestRebindPersistsCodexSessionIDToDB` / `TestRebindPersistsGeminiSessionIDToDB` | rebind branch |
| `TestBindPersistsCodexSessionIDToDB` / `TestBindPersistsGeminiSessionIDToDB` | cold-start bind branch |
| `TestCodexRebindNoOpWhenStateDBUnset` / `TestGeminiRebindNoOpWhenStateDBUnset` | safety when statedb is unwired |
| `TestCodexRebindPreservesUnrelatedToolDataKeys` / `TestGeminiRebindPreservesUnrelatedToolDataKeys` | `json_set` contract against a future `tool_data = ?` simplification |

**TDD evidence**: 6 of 8 tests fail on `origin/main` (verified via `git stash` + rerun before implementing the fix). All 8 pass with the fix applied. The two `*NoOpWhenStateDBUnset` tests pass either way — they only assert in-memory state.

## Surface checklist

| Surface | Test coverage | Notes |
|---------|---------------|-------|
| **Persistence** (`internal/statedb/`) | `Test{Codex,Gemini}RebindPreservesUnrelatedToolDataKeys` | New `Write{Codex,Gemini}SessionBinding` helpers |
| **Session core** (`internal/session/`) | `TestRebindPersists{Codex,Gemini}SessionIDToDB`, `TestBindPersists{Codex,Gemini}SessionIDToDB` | New `bind{Codex,Gemini}SessionFromHook` helpers |
| **Remote/Local** | Covered transitively — both `LocalSession` and `RemoteSession` route through `Instance.UpdateHookStatus`, which calls the new helpers. No remote-specific branches added. | |
| **TUI / Web UI / CLI** | n/a — this is an internal hook-rebind path; no user-facing surface changes. The TUI tick, web refresh, and CLI status refresh all reach this code through `UpdateHookStatus` and now observe up-to-date `tool_data.{codex,gemini}_session_id` immediately. | |
| **Cross-platform** | n/a — pure Go, no platform-specific paths touched. | |

## Did not break

- ✅ #1140 (claude persist) — `TestRebindPersistsClaudeSessionIDToDB`, `TestBindPersistsClaudeSessionIDToDB`, `TestRebindNoOpWhenStateDBUnset`, `TestRebindPreservesUnrelatedToolDataKeys` still green
- ✅ #856 (size-guard reject loop) — boundary tests for `clearRebindMtimeGrace` still pass
- ✅ #923 (`.sid` re-inject) — sid-related tests still pass
- ✅ Full race-detector suite (`go test -race -count=1 -timeout 15m ./...`) green
- ✅ `golangci-lint run` clean (0 issues)
- ✅ `govulncheck` clean (no vulnerabilities)

## Test plan

- [x] New tests fail on baseline, pass with fix
- [x] Full race suite green across all packages
- [x] Lint clean
- [x] Vuln clean
- [x] Build clean

Closes #1139
Refs #1138, #1140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex and Gemini session persistence to ensure session IDs and timestamps are reliably saved and restored across application sessions.

* **Tests**
  * Added comprehensive regression tests to verify session binding persistence and data integrity for both Codex and Gemini tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->