### PR TITLE
fix(notifier): de-duplicate identical [EVENT] notifications by (child, status, output-hash) (closes #1142)

### DIFF
--- a/internal/session/issue1142_event_dedup_test.go
+++ b/internal/session/issue1142_event_dedup_test.go
@@ -1,0 +1,258 @@
+package session
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// Regression tests for issue #1142 — agent-deck status-transition notifier
+// emits `[EVENT] Child '<id>' is waiting.` repeatedly for the same dormant
+// child. One observed run produced 47 identical [EVENT] notifications for the
+// same child (`adeck-supervisor-drain`) over 15.5 hours (mean interval
+// ~20 min). The parent conductor burned context re-checking the same session
+// on every fire.
+//
+// Root cause: isDuplicate only suppressed identical (from→to) within 90s.
+// A child that flickers running→waiting every 20+ minutes is always outside
+// the window, so each fire re-emits even though the child is dormant and the
+// pane output is unchanged.
+//
+// Fix shape: dedup on (child_id, to_status, last_output_hash) within a long
+// TTL (default 2 hours). If the child re-emits the same transition with the
+// same output hash inside the TTL, suppress. If the output hash changes (real
+// progress), re-emit. If the to_status changes (waiting → error), re-emit.
+// If the TTL elapses, re-emit as a liveness ping so the operator still gets
+// periodic confirmation the child is alive.
+//
+// Tests exercise the dedup boundary directly via isDuplicate + markNotified.
+// That avoids the full storage / parent-resolution / tmux dispatch path while
+// still pinning the behavior the user observes: how many [EVENT] lines land
+// in the conductor pane.
+
+func setupNotifierForDedupTest(t *testing.T) *TransitionNotifier {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() {
+		ClearUserConfigCache()
+		ResetInboxFingerprintCacheForTest()
+	})
+	if err := os.MkdirAll(home+"/.agent-deck", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	n := NewTransitionNotifier()
+	t.Cleanup(n.Close)
+	return n
+}
+
+// countEmitted walks a sequence of events through the dedup boundary the same
+// way NotifyTransition does: check isDuplicate, and if not duplicate, persist
+// via markNotified and count as emitted. This pins the user-visible behavior
+// (how many [EVENT] lines reach the parent pane) without depending on the
+// full dispatch path.
+func countEmitted(n *TransitionNotifier, events []TransitionNotificationEvent) int {
+	emitted := 0
+	for _, ev := range events {
+		if n.isDuplicate(ev) {
+			continue
+		}
+		n.markNotified(ev)
+		emitted++
+	}
+	return emitted
+}
+
+// Test 1: 5 events for the same child with the same to_status and the same
+// output hash collapse to a single emission. This is the literal bug from
+// #1142: a dormant child re-emitting the same (running→waiting) with no new
+// pane content should not flood the parent.
+func TestIssue1142_SameStatusSameHash_EmitsOnce(t *testing.T) {
+	n := setupNotifierForDedupTest(t)
+
+	base := time.Unix(1747800000, 0).UTC() // 2025-05-21-ish
+	const childID = "child-dormant-1142"
+	const hash = "sha1:dormant-output-bytes"
+
+	events := make([]TransitionNotificationEvent, 5)
+	for i := 0; i < 5; i++ {
+		events[i] = TransitionNotificationEvent{
+			ChildSessionID: childID,
+			Profile:        "_test-1142",
+			FromStatus:     "running",
+			ToStatus:       "waiting",
+			LastOutputHash: hash,
+			// Spread 20 minutes apart so the existing 90s short-window
+			// dedup is NOT what catches them — only the new output-hash
+			// dedup can.
+			Timestamp: base.Add(time.Duration(i) * 20 * time.Minute),
+		}
+	}
+
+	got := countEmitted(n, events)
+	if got != 1 {
+		t.Fatalf("issue #1142: expected 1 emit for 5 identical (status+hash) events spaced 20m apart, got %d", got)
+	}
+}
+
+// Test 2: 5 events with the same child + same to_status but DIFFERENT output
+// hashes are all real progress and must all emit. A child writing new content
+// on every transition is doing work and the operator wants every signal.
+func TestIssue1142_SameStatusDifferentHash_EmitsEachTime(t *testing.T) {
+	n := setupNotifierForDedupTest(t)
+
+	base := time.Unix(1747800000, 0).UTC()
+	const childID = "child-progressing-1142"
+
+	events := make([]TransitionNotificationEvent, 5)
+	for i := 0; i < 5; i++ {
+		events[i] = TransitionNotificationEvent{
+			ChildSessionID: childID,
+			Profile:        "_test-1142",
+			FromStatus:     "running",
+			ToStatus:       "waiting",
+			LastOutputHash: "sha1:progress-step-" + time.Duration(i).String(),
+			// Spread 10 minutes apart — well outside the 90s window, so
+			// pre-fix this passes too. The new logic must NOT over-dedup.
+			Timestamp: base.Add(time.Duration(i) * 10 * time.Minute),
+		}
+	}
+
+	got := countEmitted(n, events)
+	if got != 5 {
+		t.Fatalf("issue #1142: expected 5 emits for 5 progressing (different hashes), got %d", got)
+	}
+}
+
+// Test 3: same child re-emitting with a DIFFERENT to_status (waiting → error)
+// must emit each time. Status oscillation is a real state change the operator
+// needs to see — dedup must key on to_status, not just child_id+hash.
+func TestIssue1142_DifferentStatus_EmitsEachTime(t *testing.T) {
+	n := setupNotifierForDedupTest(t)
+
+	base := time.Unix(1747800000, 0).UTC()
+	const childID = "child-oscillating-1142"
+	const hash = "sha1:same-pane-content"
+
+	statuses := []string{"waiting", "error", "waiting", "idle", "waiting"}
+	events := make([]TransitionNotificationEvent, len(statuses))
+	for i, s := range statuses {
+		events[i] = TransitionNotificationEvent{
+			ChildSessionID: childID,
+			Profile:        "_test-1142",
+			FromStatus:     "running",
+			ToStatus:       s,
+			// Same hash across all events — the output didn't change,
+			// only the status classification did. We still want each
+			// distinct status to emit so the operator sees the
+			// transition.
+			LastOutputHash: hash,
+			Timestamp:      base.Add(time.Duration(i) * 5 * time.Minute),
+		}
+	}
+
+	got := countEmitted(n, events)
+	if got != len(statuses) {
+		t.Fatalf("issue #1142: expected %d emits for %d distinct statuses, got %d",
+			len(statuses), len(statuses), got)
+	}
+}
+
+// Test 4: after the TTL elapses, the same (child, status, hash) emits again
+// as a liveness ping. Without this the operator could think a child died
+// silently after one initial event hours ago; with this they get periodic
+// confirmation the child is still in the waiting state.
+//
+// We drive elapsed time via event.Timestamp rather than wall-clock sleep so
+// the test is fast and deterministic. The TTL is the notifier's
+// outputHashDedupTTL (default 2 hours).
+func TestIssue1142_AfterTTL_LivenessPingReEmits(t *testing.T) {
+	n := setupNotifierForDedupTest(t)
+
+	base := time.Unix(1747800000, 0).UTC()
+	const childID = "child-liveness-1142"
+	const hash = "sha1:still-dormant"
+
+	// First event: emit.
+	ev1 := TransitionNotificationEvent{
+		ChildSessionID: childID,
+		Profile:        "_test-1142",
+		FromStatus:     "running",
+		ToStatus:       "waiting",
+		LastOutputHash: hash,
+		Timestamp:      base,
+	}
+
+	// Second event: same child, same status, same hash, BEFORE the TTL
+	// elapses. Must dedup.
+	ev2 := ev1
+	ev2.Timestamp = base.Add(90 * time.Minute) // < default 2h TTL
+
+	// Third event: same child, same status, same hash, AFTER the TTL
+	// elapses. Must re-emit as a liveness ping.
+	ev3 := ev1
+	ev3.Timestamp = base.Add(150 * time.Minute) // > default 2h TTL
+
+	events := []TransitionNotificationEvent{ev1, ev2, ev3}
+
+	got := countEmitted(n, events)
+	if got != 2 {
+		t.Fatalf("issue #1142: expected 2 emits (initial + liveness ping after TTL), got %d", got)
+	}
+}
+
+// Boundary case: an event with no output hash must still benefit from the
+// existing 90s short-window dedup (back-compat with any caller that hasn't
+// been updated to populate the new field). Five rapid fires within 90s with
+// no hash collapse to one. Outside 90s with no hash, every fire emits — the
+// new TTL only kicks in when a hash is present.
+func TestIssue1142_NoHash_FallsBackToLegacyWindow(t *testing.T) {
+	n := setupNotifierForDedupTest(t)
+
+	base := time.Unix(1747800000, 0).UTC()
+	const childID = "child-no-hash-1142"
+
+	// Five fires within 90s with empty hash: legacy dedup catches them.
+	rapid := make([]TransitionNotificationEvent, 5)
+	for i := 0; i < 5; i++ {
+		rapid[i] = TransitionNotificationEvent{
+			ChildSessionID: childID,
+			Profile:        "_test-1142",
+			FromStatus:     "running",
+			ToStatus:       "waiting",
+			LastOutputHash: "",
+			Timestamp:      base.Add(time.Duration(i*10) * time.Second),
+		}
+	}
+	if got := countEmitted(n, rapid); got != 1 {
+		t.Fatalf("legacy 90s dedup: expected 1 emit for 5 rapid fires, got %d", got)
+	}
+
+	// Two fires spaced 10 minutes apart with empty hash: legacy dedup does
+	// NOT catch them, so both emit. (Pre-fix behavior — the bug.) The new
+	// output-hash dedup is opt-in via the hash being populated.
+	n2 := setupNotifierForDedupTest(t)
+	spaced := []TransitionNotificationEvent{
+		{
+			ChildSessionID: childID,
+			Profile:        "_test-1142",
+			FromStatus:     "running",
+			ToStatus:       "waiting",
+			Timestamp:      base,
+		},
+		{
+			ChildSessionID: childID,
+			Profile:        "_test-1142",
+			FromStatus:     "running",
+			ToStatus:       "waiting",
+			Timestamp:      base.Add(10 * time.Minute),
+		},
+	}
+	if got := countEmitted(n2, spaced); got != 2 {
+		t.Fatalf("no-hash spaced fires: expected 2 emits (legacy behavior), got %d", got)
+	}
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -214,6 +214,7 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 			FromStatus:     from,
 			ToStatus:       to,
 			Timestamp:      time.Now(),
+			LastOutputHash: transitionEventOutputHash(inst),
 		}
 		_ = d.notifier.NotifyTransition(event)
 	}
@@ -394,6 +395,7 @@ func (d *TransitionDaemon) emitHookTransitionCandidates(
 			FromStatus:     string(StatusRunning),
 			ToStatus:       to,
 			Timestamp:      candidate.Timestamp,
+			LastOutputHash: transitionEventOutputHash(inst),
 		}
 		_ = d.notifier.NotifyTransition(event)
 	}

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -20,6 +20,24 @@ const (
 	defaultSendTimeout      = 30 * time.Second
 	defaultQueueMaxAge      = 10 * time.Minute
 	defaultQueueMaxAttempts = 20
+
+	// defaultOutputHashDedupTTL caps the (child, to_status, output_hash)
+	// suppression window from issue #1142. A dormant child that re-emits
+	// the same transition with the same pane content is silenced for the
+	// TTL, then re-emits once as a liveness ping so the operator still
+	// sees the child is alive. 2h matches the worst-case 20.2-min mean
+	// interval observed in the 2026-05-21 self-improvement report (47
+	// fires over 15.5 hours) while still giving the operator periodic
+	// confirmation a child hasn't died silently.
+	defaultOutputHashDedupTTL = 2 * time.Hour
+
+	// shortWindowDedupSeconds preserves the pre-#1142 90-second
+	// idempotency window. It catches duplicate polls inside one daemon
+	// tick (e.g. when a hook fires the same transition that the
+	// status-poll also observes). Independent of output-hash dedup so
+	// callers that haven't been wired to populate LastOutputHash still
+	// get the legacy guarantee.
+	shortWindowDedupSeconds = 90
 )
 
 type TransitionNotificationEvent struct {
@@ -30,6 +48,14 @@ type TransitionNotificationEvent struct {
 	ToStatus       string    `json:"to_status"`
 	Timestamp      time.Time `json:"timestamp"`
 
+	// LastOutputHash is a cheap stable signal (e.g. SHA-1 of the last N
+	// bytes of the child's tmux pane at transition time) used by the
+	// notifier's #1142 dedup to suppress repeated [EVENT] notifications
+	// for a dormant child whose pane content hasn't changed. Optional —
+	// empty string disables hash-based dedup and falls back to the legacy
+	// 90s short window.
+	LastOutputHash string `json:"last_output_hash,omitempty"`
+
 	TargetSessionID string `json:"target_session_id,omitempty"`
 	TargetKind      string `json:"target_kind,omitempty"` // parent | conductor
 	DeliveryResult  string `json:"delivery_result,omitempty"`
@@ -39,6 +65,10 @@ type transitionNotifyRecord struct {
 	From string `json:"from"`
 	To   string `json:"to"`
 	At   int64  `json:"at"`
+	// OutputHash mirrors TransitionNotificationEvent.LastOutputHash at
+	// the moment of the last accepted (non-deduped) emission. Used by
+	// isDuplicate to suppress identical re-fires within the TTL.
+	OutputHash string `json:"output_hash,omitempty"`
 }
 
 type transitionNotifyState struct {
@@ -141,6 +171,14 @@ type TransitionNotifier struct {
 	// hangs past sendTimeout.
 	watchersWG sync.WaitGroup
 	sendersWG  sync.WaitGroup
+
+	// outputHashDedupTTLOverride lets tests shrink the issue #1142
+	// output-hash dedup window without waiting hours of wall-clock time.
+	// Zero means "use defaultOutputHashDedupTTL". Production never sets
+	// it. Tests that need a deterministic boundary drive the TTL via
+	// synthetic event.Timestamp values instead — this override exists
+	// only for the rare suite that wants to assert TTL math directly.
+	outputHashDedupTTLOverride time.Duration
 }
 
 func NewTransitionNotifier() *TransitionNotifier {
@@ -513,6 +551,21 @@ func isLiveSessionStatus(status Status) bool {
 	}
 }
 
+// isDuplicate reports whether the event should be suppressed because the
+// parent has already seen an equivalent [EVENT] line. Two layered checks:
+//
+//  1. Short-window (legacy): identical (from→to) within shortWindowDedupSeconds.
+//     Catches duplicate polls inside one daemon tick and back-compat callers
+//     that don't populate LastOutputHash.
+//
+//  2. Output-hash (issue #1142): identical to_status AND identical
+//     LastOutputHash within outputHashDedupTTL. Suppresses a dormant child
+//     re-emitting the same transition with no new pane content. After the
+//     TTL elapses, the event re-emits once as a liveness ping and the
+//     stored record resets via markNotified.
+//
+// Either layer matching is enough to dedup. From-status is intentionally
+// ignored in layer 2 since ShouldNotifyTransition already pins from=running.
 func (n *TransitionNotifier) isDuplicate(event TransitionNotificationEvent) bool {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -521,10 +574,47 @@ func (n *TransitionNotifier) isDuplicate(event TransitionNotificationEvent) bool
 	if !ok {
 		return false
 	}
-	if record.From != event.FromStatus || record.To != event.ToStatus {
-		return false
+
+	elapsed := event.Timestamp.Unix() - record.At
+
+	if record.From == event.FromStatus && record.To == event.ToStatus && elapsed <= shortWindowDedupSeconds {
+		return true
 	}
-	return event.Timestamp.Unix()-record.At <= 90
+
+	if event.LastOutputHash != "" &&
+		record.To == event.ToStatus &&
+		record.OutputHash == event.LastOutputHash &&
+		elapsed <= int64(n.outputHashTTL().Seconds()) {
+		return true
+	}
+
+	return false
+}
+
+// outputHashTTL returns the active TTL for the output-hash dedup layer. The
+// override field is reserved for tests; production callers get the default.
+func (n *TransitionNotifier) outputHashTTL() time.Duration {
+	if n.outputHashDedupTTLOverride > 0 {
+		return n.outputHashDedupTTLOverride
+	}
+	return defaultOutputHashDedupTTL
+}
+
+// transitionEventOutputHash derives the cheap stable pane-activity signal
+// used by the issue #1142 output-hash dedup. It returns the inst's
+// LastActivityTime serialized to ns precision: identical bytes mean the pane
+// content hasn't changed since the last accepted [EVENT], so the notifier
+// safely suppresses the re-fire. Empty string for nil/missing — falls back
+// to the legacy 90s dedup window.
+func transitionEventOutputHash(inst *Instance) string {
+	if inst == nil {
+		return ""
+	}
+	t := inst.GetLastActivityTime()
+	if t.IsZero() {
+		return ""
+	}
+	return fmt.Sprintf("act:%d", t.UnixNano())
 }
 
 func (n *TransitionNotifier) markNotified(event TransitionNotificationEvent) {
@@ -535,9 +625,10 @@ func (n *TransitionNotifier) markNotified(event TransitionNotificationEvent) {
 		n.state.Records = map[string]transitionNotifyRecord{}
 	}
 	n.state.Records[event.ChildSessionID] = transitionNotifyRecord{
-		From: event.FromStatus,
-		To:   event.ToStatus,
-		At:   event.Timestamp.Unix(),
+		From:       event.FromStatus,
+		To:         event.ToStatus,
+		At:         event.Timestamp.Unix(),
+		OutputHash: event.LastOutputHash,
 	}
 	_ = n.saveStateLocked()
 }


### PR DESCRIPTION
## Summary

Closes #1142.

The status-transition notifier emits `[EVENT] Child '<id>' (<sid>) is waiting.` to the parent conductor on every observed `running→waiting` transition. For a dormant child that flickers `running→waiting` once every ~20 minutes, the existing 90-second dedup window never catches the re-fire — so the parent gets a fresh line each time even with no new pane content.

The 2026-05-21 self-improvement report observed **47 identical [EVENT] notifications for one child (`adeck-supervisor-drain`) over 15.5 hours** (mean interval 20.2 min). Each one burned conductor context re-checking a session that hadn't progressed.

## Design choice — dedup key

`(child_id, to_status, last_output_hash)` with a 2-hour TTL, layered on top of the legacy `(from, to)` 90-second short-window check. Either layer matching suppresses the event.

| Re-fire scenario | Behavior |
|---|---|
| Same child, same `to_status`, same output hash, within 2h | **Suppressed** (the bug case) |
| Same child, same `to_status`, **different** output hash | Re-emits (real progress) |
| Same child, **different** `to_status` (e.g. waiting→error) | Re-emits (real state change) |
| Same child, same `to_status`, same hash, after 2h | Re-emits **once** as a liveness ping (operator still gets periodic confirmation the child is alive) |
| Caller doesn't populate `LastOutputHash` | Falls back to legacy 90s window (back-compat) |

**Why `inst.GetLastActivityTime().UnixNano()` as the hash?** It's the cheapest stable signal already cached on every `Instance` — no extra `tmux capture-pane` cost per poll. Identical activity-time bytes mean the pane content hasn't changed since the last accepted [EVENT].

**Why 2h TTL?** Matches the worst-case ~20-min interval from the production trace while still giving the operator periodic dormancy confirmation. Tunable via `outputHashDedupTTLOverride` for tests.

**Why keep the legacy 90s window?** Callers that don't have an `Instance` pointer (e.g. the deferred-queue replay path) can't compute the hash. The 90s window stays as the idempotency floor for those paths and for duplicate polls inside one daemon tick.

## Surfaces

| Surface | Applies? | Coverage |
|---|---|---|
| **TUI** | No | No keystroke / panel / status-line change. The notifier is a backend daemon dispatching to tmux send-keys; the TUI is unaffected. |
| **Web UI** | No | Notifier output doesn't surface in any `/web/` route — verified by `grep -rn "transition-notifier\|TransitionNotificationEvent" internal/web/`: no hits. |
| **CLI** | No | No new flag or subcommand. `agent-deck notify-daemon` payload shape unchanged (the new `LastOutputHash` field is `omitempty` JSON). |
| **Remote** | Implicit | `RemoteSession` instances go through the same notifier path; `GetLastActivityTime()` works identically on local and remote `Instance` records. No remote-specific code path. |
| **Persistence** | Yes — back-compat tested | `transitionNotifyRecord` gains optional `OutputHash` field (`omitempty`). Existing state files load cleanly (zero-value hash = legacy behavior). |
| **Cross-platform** | No | No OS-specific code. `time.Time` and `fmt.Sprintf` only. |

## Test evidence

`internal/session/issue1142_event_dedup_test.go` — 5 tests, all green under `-race`:

- `TestIssue1142_SameStatusSameHash_EmitsOnce` — happy path: 5 events 20 min apart with same hash → 1 emit. The literal bug from the issue.
- `TestIssue1142_SameStatusDifferentHash_EmitsEachTime` — failure mode: real progress with different hashes → 5 emits (no over-dedup).
- `TestIssue1142_DifferentStatus_EmitsEachTime` — boundary: 5 distinct statuses → 5 emits (status changes always pierce dedup).
- `TestIssue1142_AfterTTL_LivenessPingReEmits` — TTL boundary: 90 min after first emit dedups; 150 min re-emits as liveness ping.
- `TestIssue1142_NoHash_FallsBackToLegacyWindow` — back-compat: empty hash falls back to legacy 90s window in both rapid (1 emit) and spaced (2 emits) configurations.

Full suite (`go test -race -count=1 -timeout 15m ./...`): green across all 37 packages. Lint clean (`golangci-lint run --timeout=5m --issues-exit-code=1`). Vuln clean (`govulncheck ./...`).

## Test plan

- [x] New regression tests pin all four prompt scenarios + back-compat
- [x] `go test -race -count=1 ./...` green across all packages
- [x] `golangci-lint run --timeout=5m` clean
- [x] `govulncheck ./...` clean
- [x] Existing notifier dedup / mute-on-replay / missed-log tests stay green (session package: 124s, 0 failures)
- [x] No payload shape change to existing consumers (bridge / telegram / slack) — new field is `omitempty`
- [x] Per-conductor / per-profile isolation preserved (state path unchanged)

## Refs

- Issue: #1142
- Self-improvement report: `~/.agent-deck/conductor/agent-deck/analysis/reports/2026-05-21.md` (section N1)
- Memory: `bug_supervisor_event_loop_no_progress.md`

---

DO NOT MERGE — conductor merges after CI green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved notification deduplication using output hash to prevent redundant alerts when status and output remain unchanged, while maintaining liveness monitoring through TTL-based reemission.

* **Tests**
  * Added comprehensive regression tests validating deduplication across scenarios including identical status with different outputs, distinct status transitions, and legacy time-window behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->