### PR TITLE
feat(session): --idle-timeout auto-stops dormant child sessions (closes #1143)

### DIFF
--- a/cmd/agent-deck/issue1143_idle_timeout_cli_test.go
+++ b/cmd/agent-deck/issue1143_idle_timeout_cli_test.go
@@ -1,0 +1,56 @@
+// Issue #1143: --idle-timeout flag on `agent-deck launch` / `session set`.
+// CLI surface tests: flag parsing happy path, negative-value rejection, and
+// session-set field validation.
+package main
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestLaunch_IdleTimeoutFlag_AppliesToInstance verifies that
+// `agent-deck launch ... --idle-timeout 30m` produces an Instance with
+// IdleTimeoutSecs = 1800 (30 minutes in seconds).
+func TestLaunch_IdleTimeoutFlag_AppliesToInstance(t *testing.T) {
+	secs, err := session.ParseIdleTimeoutFlag("30m")
+	if err != nil {
+		t.Fatalf("ParseIdleTimeoutFlag(30m): %v", err)
+	}
+	if secs != 1800 {
+		t.Fatalf("30m should be 1800 seconds, got %d", secs)
+	}
+}
+
+// TestLaunch_IdleTimeoutFlag_RejectsNegative verifies that
+// --idle-timeout -1s returns an error (not silently disabled).
+func TestLaunch_IdleTimeoutFlag_RejectsNegative(t *testing.T) {
+	if _, err := session.ParseIdleTimeoutFlag("-1s"); err == nil {
+		t.Fatalf("ParseIdleTimeoutFlag(-1s) should error; got nil")
+	}
+}
+
+// TestSessionSet_IdleTimeout_FieldRecognized verifies that the field name is
+// in the validator list and dispatches to the right setter.
+func TestSessionSet_IdleTimeout_FieldRecognized(t *testing.T) {
+	inst := session.NewInstance("test", "/tmp")
+	if _, _, err := session.SetField(inst, "idle-timeout", "10m", nil); err != nil {
+		t.Fatalf("SetField idle-timeout: %v", err)
+	}
+	if inst.IdleTimeoutSecs != 600 {
+		t.Fatalf("after SetField, IdleTimeoutSecs = %d, want 600", inst.IdleTimeoutSecs)
+	}
+
+	// Clearing to 0 via empty / "0".
+	if _, _, err := session.SetField(inst, "idle-timeout", "0", nil); err != nil {
+		t.Fatalf("SetField idle-timeout=0: %v", err)
+	}
+	if inst.IdleTimeoutSecs != 0 {
+		t.Fatalf("idle-timeout=0 should clear, got %d", inst.IdleTimeoutSecs)
+	}
+
+	// Rejects malformed.
+	if _, _, err := session.SetField(inst, "idle-timeout", "garbage", nil); err == nil {
+		t.Fatalf("SetField idle-timeout=garbage should error")
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -91,6 +91,9 @@ func handleLaunch(profile string, args []string) {
 	// this one session, captured once and persisted on the Instance.
 	tmuxSocket := fs.String("tmux-socket", "", "tmux -L socket name for this session (overrides [tmux].socket_name)")
 
+	// Issue #1143: auto-stop dormant child sessions.
+	idleTimeout := fs.String("idle-timeout", "", "Auto-stop session after this duration of no tmux output (Go duration: 30m, 1h, 24h). 0 or unset = disabled")
+
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck launch [path] [options]")
 		fmt.Println()
@@ -394,6 +397,15 @@ func handleLaunch(profile string, args []string) {
 		newInstance.WorktreeRepoRoot = worktreeRepoRoot
 		newInstance.WorktreeBranch = wtBranch
 		newInstance.WorktreeType = worktreeType
+	}
+
+	// Issue #1143: --idle-timeout 30m → 1800s on the Instance, picked up by
+	// the central watcher on its next tick.
+	if idleSecs, err := session.ParseIdleTimeoutFlag(strings.TrimSpace(*idleTimeout)); err != nil {
+		out.Error(err.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
+	} else {
+		newInstance.IdleTimeoutSecs = idleSecs
 	}
 
 	if *resumeSession != "" {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1159,6 +1159,7 @@ func handleSessionSet(profile string, args []string) {
 		fmt.Println("  claude-session-id  Claude conversation ID")
 		fmt.Println("  gemini-session-id  Gemini conversation ID")
 		fmt.Println("  account            Named account slot (#924) — resolves via [profiles.<account>.claude].config_dir; restart required")
+		fmt.Println("  idle-timeout       Auto-stop after no tmux output for this duration (#1143; Go duration: 30m, 1h, 24h; 0 disables)")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()

--- a/internal/session/idle_timeout_persist.go
+++ b/internal/session/idle_timeout_persist.go
@@ -1,0 +1,62 @@
+// Issue #1143: idle-timeout JSON helpers.
+//
+// These thin wrappers merge / extract the idle_timeout_secs field on the
+// tool_data blob without changing the positional MarshalToolData /
+// UnmarshalToolData signatures. The MergeToolDataExtras layer in statedb
+// preserves keys outside the typed schema across INSERT OR REPLACE, so a
+// row written by an old binary survives a round-trip through a new binary
+// (and vice versa).
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+const toolDataIdleTimeoutKey = "idle_timeout_secs"
+
+// WriteIdleTimeoutSecsToToolData merges idle_timeout_secs into the given
+// tool_data JSON blob. Passing secs == 0 removes the key (keeps the blob
+// shape identical to a pre-#1143 row, so downgrades stay clean).
+func WriteIdleTimeoutSecsToToolData(td json.RawMessage, secs int64) json.RawMessage {
+	m := map[string]json.RawMessage{}
+	if len(td) > 0 {
+		_ = json.Unmarshal(td, &m)
+	}
+	if secs > 0 {
+		raw, _ := json.Marshal(secs)
+		m[toolDataIdleTimeoutKey] = raw
+	} else {
+		delete(m, toolDataIdleTimeoutKey)
+	}
+	out, _ := json.Marshal(m)
+	return out
+}
+
+// ReadIdleTimeoutSecsFromToolData extracts idle_timeout_secs from the blob.
+// Returns 0 (disabled) for missing/malformed/legacy rows.
+func ReadIdleTimeoutSecsFromToolData(td json.RawMessage) int64 {
+	if len(td) == 0 {
+		return 0
+	}
+	var blob struct {
+		IdleTimeoutSecs int64 `json:"idle_timeout_secs"`
+	}
+	_ = json.Unmarshal(td, &blob)
+	return blob.IdleTimeoutSecs
+}
+
+// readFileOrEmpty returns file content; empty bytes + nil error when the file
+// is missing. Used by tests to inspect the lifecycle log without flapping on
+// the "no log written yet" path.
+func readFileOrEmpty(path string) ([]byte, error) {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return data, nil
+}

--- a/internal/session/idle_timeout_watcher.go
+++ b/internal/session/idle_timeout_watcher.go
@@ -1,0 +1,280 @@
+// Issue #1143: central poll watcher that auto-stops sessions whose tmux pane
+// content hasn't changed for `IdleTimeoutSecs` seconds.
+//
+// Design (per RFC in PR body):
+//
+//   - One watcher per agent-deck process (TUI or daemon). It walks every
+//     instance on each Tick — no per-session goroutine.
+//   - The "idle" signal is the FNV-1a hash of the tmux capture-pane content.
+//     Anything cheaper (status transitions) doesn't catch the dormant-worker
+//     case the self-improvement report flagged on 2026-05-21.
+//   - On trigger: Stop callback fires + a single JSONL row is appended to
+//     ~/.agent-deck/logs/session-lifecycle.jsonl with action
+//     "idle-timeout-expired".
+//   - Idempotent: once a session is stopped, its lastSeen entry is dropped so
+//     a Restart() re-enters the watcher fresh.
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
+)
+
+var idleLog = logging.ForComponent(logging.CompSession)
+
+// SessionLifecycleEvent is a single row in session-lifecycle.jsonl.
+type SessionLifecycleEvent struct {
+	InstanceID string `json:"instance_id"`
+	Action     string `json:"action"` // currently only "idle-timeout-expired"
+	Reason     string `json:"reason,omitempty"`
+	Timestamp  int64  `json:"ts"`
+}
+
+const ReasonIdleTimeoutExpired = "idle-timeout-expired"
+
+var sessionLifecycleLogMu sync.Mutex
+
+// GetSessionLifecycleLogPath returns ~/.agent-deck/logs/session-lifecycle.jsonl.
+// Distinct from session-id-lifecycle.jsonl (which logs bind/rebind), this
+// covers process-level lifecycle decisions like idle-timeout-expired.
+func GetSessionLifecycleLogPath() string {
+	agentDeckDir, err := GetAgentDeckDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".agent-deck", "logs", "session-lifecycle.jsonl")
+	}
+	return filepath.Join(agentDeckDir, "logs", "session-lifecycle.jsonl")
+}
+
+// WriteSessionLifecycleEvent appends a single JSONL row.
+func WriteSessionLifecycleEvent(ev SessionLifecycleEvent) error {
+	if ev.Timestamp == 0 {
+		ev.Timestamp = time.Now().Unix()
+	}
+
+	logPath := GetSessionLifecycleLogPath()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+		return fmt.Errorf("create session lifecycle log dir: %w", err)
+	}
+
+	line, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("marshal session lifecycle event: %w", err)
+	}
+	line = append(line, '\n')
+
+	sessionLifecycleLogMu.Lock()
+	defer sessionLifecycleLogMu.Unlock()
+
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644) //nolint:gosec // log file
+	if err != nil {
+		return fmt.Errorf("open session lifecycle log: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(line); err != nil {
+		return fmt.Errorf("write session lifecycle event: %w", err)
+	}
+	return nil
+}
+
+// IdleTimeoutWatcherConfig wires the watcher to its environment. All fields
+// are optional and default to production behavior; tests inject Now / Capture
+// / Stop so they don't touch real tmux or real clocks.
+type IdleTimeoutWatcherConfig struct {
+	// Now is the clock source. Defaults to time.Now.
+	Now func() time.Time
+	// Capture returns the current tmux pane content for the instance.
+	// Defaults to instance.tmuxSession.CapturePane().
+	Capture func(*Instance) (string, error)
+	// Stop is invoked once when an instance has been idle for >= its
+	// IdleTimeoutSecs. Defaults to inst.Kill().
+	Stop func(*Instance) error
+	// LogEvent persists a "session lifecycle" row. Defaults to
+	// WriteSessionLifecycleEvent.
+	LogEvent func(SessionLifecycleEvent) error
+}
+
+// IdleTimeoutWatcher polls running sessions, tracks per-instance pane-content
+// hashes, and triggers Stop when content stays unchanged longer than
+// IdleTimeoutSecs.
+//
+// Safe for use from one goroutine. Tick is the unit of work; production code
+// drives Tick from an existing 2-second ticker (e.g. statusWorker in the TUI)
+// and ticks roughly once per minute via Start.
+type IdleTimeoutWatcher struct {
+	cfg IdleTimeoutWatcherConfig
+
+	mu       sync.Mutex
+	lastSeen map[string]idleSeenEntry
+}
+
+type idleSeenEntry struct {
+	hash       uint64
+	lastChange time.Time
+}
+
+// NewIdleTimeoutWatcher constructs a watcher with production defaults filled
+// in for any nil config callback.
+func NewIdleTimeoutWatcher(cfg IdleTimeoutWatcherConfig) *IdleTimeoutWatcher {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Capture == nil {
+		cfg.Capture = defaultCapture
+	}
+	if cfg.Stop == nil {
+		cfg.Stop = defaultStop
+	}
+	if cfg.LogEvent == nil {
+		cfg.LogEvent = WriteSessionLifecycleEvent
+	}
+	return &IdleTimeoutWatcher{
+		cfg:      cfg,
+		lastSeen: map[string]idleSeenEntry{},
+	}
+}
+
+// Tick scans the given instances. Sessions with IdleTimeoutSecs <= 0 are
+// skipped (and their tracking state is cleared so toggling off via SetField
+// works on the next tick). Non-running sessions are skipped too.
+func (w *IdleTimeoutWatcher) Tick(instances []*Instance) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	now := w.cfg.Now()
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		if inst.IdleTimeoutSecs <= 0 {
+			delete(w.lastSeen, inst.ID)
+			continue
+		}
+		if !idleTimeoutWatchable(inst) {
+			delete(w.lastSeen, inst.ID)
+			continue
+		}
+
+		content, err := w.cfg.Capture(inst)
+		if err != nil {
+			// transient capture failure (tmux race, snapshot truncate) —
+			// don't reset state, just try again next tick.
+			continue
+		}
+		h := hashPaneContent(content)
+		prev, ok := w.lastSeen[inst.ID]
+		if !ok || prev.hash != h {
+			w.lastSeen[inst.ID] = idleSeenEntry{hash: h, lastChange: now}
+			continue
+		}
+		elapsed := now.Sub(prev.lastChange)
+		threshold := time.Duration(inst.IdleTimeoutSecs) * time.Second
+		if elapsed < threshold {
+			continue
+		}
+		// idle threshold exceeded — trigger stop.
+		if stopErr := w.cfg.Stop(inst); stopErr != nil {
+			idleLog.Warn("idle_timeout_stop_failed",
+				slog.String("instance_id", inst.ID),
+				slog.String("error", stopErr.Error()),
+			)
+			continue
+		}
+		if logErr := w.cfg.LogEvent(SessionLifecycleEvent{
+			InstanceID: inst.ID,
+			Action:     ReasonIdleTimeoutExpired,
+			Reason: fmt.Sprintf(
+				"no tmux pane output change for %ds (threshold=%ds)",
+				int64(elapsed/time.Second), inst.IdleTimeoutSecs,
+			),
+		}); logErr != nil {
+			idleLog.Warn("idle_timeout_log_failed",
+				slog.String("instance_id", inst.ID),
+				slog.String("error", logErr.Error()),
+			)
+		}
+		delete(w.lastSeen, inst.ID)
+	}
+}
+
+// Start runs Tick at the given interval until ctx is cancelled. instances is
+// re-fetched each tick via the snapshot func; pass the parent TUI/daemon's
+// instance accessor so the watcher always sees fresh state.
+func (w *IdleTimeoutWatcher) Start(ctx context.Context, interval time.Duration, snapshot func() []*Instance) {
+	if interval <= 0 {
+		interval = 60 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if snapshot == nil {
+				continue
+			}
+			w.Tick(snapshot())
+		}
+	}
+}
+
+func idleTimeoutWatchable(inst *Instance) bool {
+	switch inst.Status {
+	case StatusRunning, StatusWaiting, StatusIdle:
+		return true
+	default:
+		return false
+	}
+}
+
+func hashPaneContent(s string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s))
+	return h.Sum64()
+}
+
+func defaultCapture(inst *Instance) (string, error) {
+	if inst == nil {
+		return "", errors.New("nil instance")
+	}
+	tm := inst.GetTmuxSession()
+	if tm == nil {
+		return "", errors.New("no tmux session bound")
+	}
+	return tm.CapturePane()
+}
+
+func defaultStop(inst *Instance) error {
+	if inst == nil {
+		return errors.New("nil instance")
+	}
+	return inst.Kill()
+}
+
+// ParseIdleTimeoutFlag parses a --idle-timeout flag value: a Go-style
+// duration like "30m", "1h", "24h". Empty string and "0" mean disabled
+// (returns 0). Negative durations are rejected so a typo like "-1s" surfaces
+// loudly instead of silently disabling. Returns the value in seconds (int64).
+func ParseIdleTimeoutFlag(value string) (int64, error) {
+	if value == "" || value == "0" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --idle-timeout %q: %w (use Go duration like 30m, 1h, 24h)", value, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("invalid --idle-timeout %q: negative durations not allowed (use 0 to disable)", value)
+	}
+	return int64(d / time.Second), nil
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -263,6 +263,12 @@ type Instance struct {
 	// non-claude tools — they use the ambient profile as-is.
 	WorkerScratchConfigDir string `json:"worker_scratch_config_dir,omitempty"`
 
+	// IdleTimeoutSecs is the auto-stop threshold (#1143). When > 0, a central
+	// watcher poll triggers Kill() if the tmux pane content stays unchanged
+	// for this many seconds. 0 = disabled (current behavior). Default is 0
+	// so existing sessions are unaffected on upgrade.
+	IdleTimeoutSecs int64 `json:"idle_timeout_secs,omitempty"`
+
 	// IsForkAwaitingStart signals that this instance was produced by
 	// CreateForkedInstanceWithOptions and holds a pre-built fork command
 	// in Command that must be run verbatim on the first Start() (#745).

--- a/internal/session/issue1143_idle_timeout_test.go
+++ b/internal/session/issue1143_idle_timeout_test.go
@@ -1,0 +1,368 @@
+// Issue #1143: --idle-timeout flag auto-stops dormant child sessions.
+//
+// Self-improvement report 2026-05-21 found 4 workers (adeck-tdd-1031 x17,
+// adeck-tdd-1020 x12, adeck-feat-1029 x10, adeck-tdd-973 x9) that completed
+// work but never got cleaned up — they continued firing EVENT notifications
+// and consuming registry tracking forever. A --idle-timeout 30m flag would
+// auto-stop these after 30 min of no tmux pane output change.
+//
+// These tests cover the watcher tick logic, the lifecycle log entry, the
+// "0 = disabled" boundary, and the mid-flight timeout change.
+package session
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock returns a deterministic now() that advances via Advance.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock(start time.Time) *fakeClock { return &fakeClock{now: start} }
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// fakeCapture returns whatever the test sets per instance ID.
+type fakeCapture struct {
+	mu       sync.Mutex
+	contents map[string]string
+}
+
+func newFakeCapture() *fakeCapture { return &fakeCapture{contents: map[string]string{}} }
+
+func (f *fakeCapture) Set(id, content string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.contents[id] = content
+}
+
+func (f *fakeCapture) Capture(inst *Instance) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.contents[inst.ID], nil
+}
+
+// recordingStopper captures Stop() invocations.
+type recordingStopper struct {
+	mu      sync.Mutex
+	stopped []string
+}
+
+func (s *recordingStopper) Stop(inst *Instance) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stopped = append(s.stopped, inst.ID)
+	return nil
+}
+
+func (s *recordingStopper) StoppedIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.stopped))
+	copy(out, s.stopped)
+	return out
+}
+
+func newRunningInstance(id, title string, idleTimeoutSecs int64) *Instance {
+	inst := NewInstance(title, "/tmp")
+	inst.ID = id
+	inst.Status = StatusRunning
+	inst.IdleTimeoutSecs = idleTimeoutSecs
+	return inst
+}
+
+// Test 1: idle_timeout=10s, no output change for 11s → Stop called + lifecycle entry.
+func TestIssue1143_IdleTimeoutWatcher_TriggersStopAfterInactivity(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	capture := newFakeCapture()
+	stopper := &recordingStopper{}
+
+	// Route lifecycle log to a temp dir so we can verify the entry.
+	t.Setenv("HOME", t.TempDir())
+
+	inst := newRunningInstance("inst-idle-1", "worker-1", 10)
+	capture.Set(inst.ID, "static pane content")
+
+	w := NewIdleTimeoutWatcher(IdleTimeoutWatcherConfig{
+		Now:     clock.Now,
+		Capture: capture.Capture,
+		Stop:    stopper.Stop,
+	})
+
+	// First tick at t=0: records last-seen, doesn't stop yet.
+	w.Tick([]*Instance{inst})
+	if got := stopper.StoppedIDs(); len(got) != 0 {
+		t.Fatalf("first tick should not stop session yet (no elapsed time): got %v", got)
+	}
+
+	// Advance 11s with same content → idle.
+	clock.Advance(11 * time.Second)
+	w.Tick([]*Instance{inst})
+
+	stopped := stopper.StoppedIDs()
+	if len(stopped) != 1 || stopped[0] != inst.ID {
+		t.Fatalf("expected Stop called for %q after idle, got %v", inst.ID, stopped)
+	}
+
+	// Lifecycle log must contain idle-timeout-expired entry for this instance.
+	logPath := GetSessionLifecycleLogPath()
+	data, err := readFileQuiet(logPath)
+	if err != nil {
+		t.Fatalf("read lifecycle log %s: %v", logPath, err)
+	}
+	body := string(data)
+	if !strings.Contains(body, inst.ID) {
+		t.Fatalf("lifecycle log missing instance id %q: %s", inst.ID, body)
+	}
+	if !strings.Contains(body, "idle-timeout-expired") {
+		t.Fatalf("lifecycle log missing reason idle-timeout-expired: %s", body)
+	}
+}
+
+// Test 2: idle_timeout=10s, output changes every 5s → session stays running.
+func TestIssue1143_IdleTimeoutWatcher_OutputChangeResetsTimer(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	capture := newFakeCapture()
+	stopper := &recordingStopper{}
+
+	t.Setenv("HOME", t.TempDir())
+
+	inst := newRunningInstance("inst-active", "worker-active", 10)
+
+	w := NewIdleTimeoutWatcher(IdleTimeoutWatcherConfig{
+		Now:     clock.Now,
+		Capture: capture.Capture,
+		Stop:    stopper.Stop,
+	})
+
+	// Simulate 12 ticks at 5s apart, each with new output content.
+	for i := 0; i < 12; i++ {
+		capture.Set(inst.ID, "line-")
+		capture.Set(inst.ID, "line-"+itoa(i))
+		w.Tick([]*Instance{inst})
+		clock.Advance(5 * time.Second)
+	}
+
+	if got := stopper.StoppedIDs(); len(got) != 0 {
+		t.Fatalf("output-active session must not be stopped, got Stop for %v", got)
+	}
+}
+
+// Test 3: idle_timeout=0 → watcher never stops the session regardless of inactivity.
+func TestIssue1143_IdleTimeoutWatcher_ZeroDisablesAutoStop(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	capture := newFakeCapture()
+	stopper := &recordingStopper{}
+
+	t.Setenv("HOME", t.TempDir())
+
+	inst := newRunningInstance("inst-zero", "worker-zero", 0) // disabled
+	capture.Set(inst.ID, "frozen")
+
+	w := NewIdleTimeoutWatcher(IdleTimeoutWatcherConfig{
+		Now:     clock.Now,
+		Capture: capture.Capture,
+		Stop:    stopper.Stop,
+	})
+
+	for i := 0; i < 100; i++ {
+		w.Tick([]*Instance{inst})
+		clock.Advance(60 * time.Second)
+	}
+
+	if got := stopper.StoppedIDs(); len(got) != 0 {
+		t.Fatalf("idle_timeout=0 must disable auto-stop; got Stop for %v", got)
+	}
+}
+
+// Test 4: changing IdleTimeoutSecs via SetField must apply on next watcher tick.
+func TestIssue1143_IdleTimeoutWatcher_ChangingTimeoutAppliesNextTick(t *testing.T) {
+	clock := newFakeClock(time.Unix(1_700_000_000, 0))
+	capture := newFakeCapture()
+	stopper := &recordingStopper{}
+
+	t.Setenv("HOME", t.TempDir())
+
+	inst := newRunningInstance("inst-flex", "worker-flex", 0) // start disabled
+	capture.Set(inst.ID, "no change")
+
+	w := NewIdleTimeoutWatcher(IdleTimeoutWatcherConfig{
+		Now:     clock.Now,
+		Capture: capture.Capture,
+		Stop:    stopper.Stop,
+	})
+
+	// 10 minutes of no output, idle disabled → no stop.
+	for i := 0; i < 10; i++ {
+		w.Tick([]*Instance{inst})
+		clock.Advance(60 * time.Second)
+	}
+	if got := stopper.StoppedIDs(); len(got) != 0 {
+		t.Fatalf("disabled timer must not stop session; got %v", got)
+	}
+
+	// Enable idle timeout via SetField (5s window).
+	if _, _, err := SetField(inst, FieldIdleTimeout, "5s", nil); err != nil {
+		t.Fatalf("SetField idle-timeout: %v", err)
+	}
+	if inst.IdleTimeoutSecs != 5 {
+		t.Fatalf("expected IdleTimeoutSecs=5 after SetField, got %d", inst.IdleTimeoutSecs)
+	}
+
+	// First tick after enabling records baseline; second tick after 6s triggers stop.
+	w.Tick([]*Instance{inst})
+	clock.Advance(6 * time.Second)
+	w.Tick([]*Instance{inst})
+
+	stopped := stopper.StoppedIDs()
+	if len(stopped) != 1 || stopped[0] != inst.ID {
+		t.Fatalf("expected Stop after timer enabled + elapsed, got %v", stopped)
+	}
+}
+
+// Test 5a (CLI): ParseIdleTimeout accepts Go-style durations.
+func TestIssue1143_ParseIdleTimeout_Valid(t *testing.T) {
+	cases := map[string]int64{
+		"":     0,
+		"0":    0,
+		"30m":  int64((30 * time.Minute).Seconds()),
+		"1h":   int64((1 * time.Hour).Seconds()),
+		"24h":  int64((24 * time.Hour).Seconds()),
+		"500s": 500,
+	}
+	for input, want := range cases {
+		got, err := ParseIdleTimeoutFlag(input)
+		if err != nil {
+			t.Fatalf("ParseIdleTimeoutFlag(%q) error: %v", input, err)
+		}
+		if got != want {
+			t.Errorf("ParseIdleTimeoutFlag(%q) = %d, want %d", input, got, want)
+		}
+	}
+}
+
+// Test 5b (CLI): ParseIdleTimeout rejects negative and malformed input.
+func TestIssue1143_ParseIdleTimeout_RejectsNegative(t *testing.T) {
+	bad := []string{"-1s", "-30m", "garbage", "30x"}
+	for _, in := range bad {
+		if _, err := ParseIdleTimeoutFlag(in); err == nil {
+			t.Errorf("ParseIdleTimeoutFlag(%q) should error; got nil", in)
+		}
+	}
+}
+
+// Boundary: persistence round-trip preserves IdleTimeoutSecs.
+func TestIssue1143_IdleTimeout_PersistenceRoundTrip(t *testing.T) {
+	td := WriteIdleTimeoutSecsToToolData(nil, 1800)
+	got := ReadIdleTimeoutSecsFromToolData(td)
+	if got != 1800 {
+		t.Fatalf("ReadIdleTimeoutSecsFromToolData after Write = %d, want 1800", got)
+	}
+
+	// Setting back to 0 removes the key (forward-compat with legacy rows).
+	cleared := WriteIdleTimeoutSecsToToolData(td, 0)
+	if got := ReadIdleTimeoutSecsFromToolData(cleared); got != 0 {
+		t.Fatalf("Write(td, 0) should clear, got %d", got)
+	}
+
+	// Round-trip preserves unrelated fields.
+	mixed := []byte(`{"color":"#ff00aa","claude_session_id":"abc"}`)
+	out := WriteIdleTimeoutSecsToToolData(mixed, 600)
+	if got := ReadIdleTimeoutSecsFromToolData(out); got != 600 {
+		t.Fatalf("round-trip with extras lost idle_timeout_secs: got %d", got)
+	}
+	if !strings.Contains(string(out), `"color":"#ff00aa"`) {
+		t.Fatalf("round-trip dropped color: %s", string(out))
+	}
+	if !strings.Contains(string(out), `"claude_session_id":"abc"`) {
+		t.Fatalf("round-trip dropped claude_session_id: %s", string(out))
+	}
+}
+
+// Boundary: SQLite round-trip preserves IdleTimeoutSecs across save/load.
+// Verifies the storage path actually persists the field (not just the helpers).
+func TestIssue1143_IdleTimeout_SQLiteRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	storage := newTestStorage(t)
+
+	inst := NewInstance("idle-roundtrip", "/tmp")
+	inst.Tool = "shell"
+	inst.IdleTimeoutSecs = 1800
+
+	groupTree := NewGroupTreeWithGroups([]*Instance{inst}, nil)
+	if err := storage.SaveWithGroups([]*Instance{inst}, groupTree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	// Reload from the same SQLite DB through the public load path.
+	loaded, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(loaded))
+	}
+	if loaded[0].IdleTimeoutSecs != 1800 {
+		t.Fatalf("IdleTimeoutSecs not preserved across SQLite round-trip: got %d, want 1800", loaded[0].IdleTimeoutSecs)
+	}
+}
+
+// Failure mode: ParseIdleTimeoutFlag must reject huge negative durations that
+// could overflow int64 seconds when coerced. We pin a representative cluster.
+func TestIssue1143_ParseIdleTimeout_RejectsBogusUnits(t *testing.T) {
+	bad := []string{"5", "5 m", "five minutes"}
+	for _, in := range bad {
+		if _, err := ParseIdleTimeoutFlag(in); err == nil {
+			t.Errorf("ParseIdleTimeoutFlag(%q) should reject (no unit / malformed); got nil", in)
+		}
+	}
+}
+
+// readFileQuiet returns file content; if the file doesn't exist returns empty
+// instead of error (the watcher writes on demand).
+func readFileQuiet(path string) ([]byte, error) {
+	return readFileOrEmpty(path)
+}
+
+func itoa(i int) string {
+	// Minimal int-to-string to avoid importing strconv in test fixtures
+	// (keeps test imports tight and lint-clean).
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	idx := len(buf)
+	for i > 0 {
+		idx--
+		buf[idx] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		idx--
+		buf[idx] = '-'
+	}
+	return string(buf[idx:])
+}
+
+// keep filepath import alive for any future expansion.
+var _ = filepath.Join

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -29,7 +29,8 @@ const (
 	FieldNoTransitionNotify = "no-transition-notify"
 	FieldSkipPermissions    = "skip-permissions"
 	FieldAutoMode           = "auto-mode"
-	FieldAccount            = "account" // #924 per-session named account slot
+	FieldAccount            = "account"      // #924 per-session named account slot
+	FieldIdleTimeout        = "idle-timeout" // #1143 auto-stop dormant sessions
 )
 
 var ValidMutableFields = []string{
@@ -50,6 +51,7 @@ var ValidMutableFields = []string{
 	FieldSkipPermissions,
 	FieldAutoMode,
 	FieldAccount,
+	FieldIdleTimeout,
 }
 
 type FieldRestartPolicy int
@@ -286,6 +288,16 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 		// conversation is lost, that's the documented Option 1 tradeoff.
 		oldValue = inst.Account
 		inst.Account = strings.TrimSpace(value)
+
+	case FieldIdleTimeout:
+		// #1143: parses a Go duration like "30m"; 0 (or "0", "") disables.
+		// Live: the next watcher tick reads the new value.
+		oldValue = strconv.FormatInt(inst.IdleTimeoutSecs, 10)
+		secs, perr := ParseIdleTimeoutFlag(strings.TrimSpace(value))
+		if perr != nil {
+			return oldValue, nil, &MutationError{Field: field, Msg: perr.Error()}
+		}
+		inst.IdleTimeoutSecs = secs
 
 	default:
 		return "", nil, &MutationError{

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -135,6 +135,9 @@ type InstanceData struct {
 	AdditionalPaths    []string                        `json:"additional_paths,omitempty"`
 	MultiRepoTempDir   string                          `json:"multi_repo_temp_dir,omitempty"`
 	MultiRepoWorktrees []statedb.MultiRepoWorktreeData `json:"multi_repo_worktrees,omitempty"`
+
+	// IdleTimeoutSecs mirrors Instance.IdleTimeoutSecs (#1143). 0 = disabled.
+	IdleTimeoutSecs int64 `json:"idle_timeout_secs,omitempty"`
 }
 
 // GroupData represents serializable group data
@@ -635,6 +638,10 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 		inst.AutoLinkedChannels,        // RFC §4.7 (G4/C2 fix)
 		inst.Color,                     // issue #391
 	)
+	// #1143: idle_timeout_secs lives in the tool_data extras zone — outside
+	// the positional MarshalToolData signature so legacy binaries that don't
+	// know the key preserve it via MergeToolDataExtras.
+	toolData = WriteIdleTimeoutSecsToToolData(toolData, inst.IdleTimeoutSecs)
 
 	return &statedb.InstanceRow{
 		ID:                 inst.ID,
@@ -797,6 +804,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			PluginChannelLinkDisabled: pluginChannelLinkDisabled2,
 			AutoLinkedChannels:        autoLinkedChannels2,
 			Color:                     color2,
+			IdleTimeoutSecs:           ReadIdleTimeoutSecsFromToolData(r.ToolData),
 		}
 	}
 
@@ -911,6 +919,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			PluginChannelLinkDisabled: pluginChannelLinkDisabled,
 			AutoLinkedChannels:        autoLinkedChannels,
 			Color:                     color,
+			IdleTimeoutSecs:           ReadIdleTimeoutSecsFromToolData(r.ToolData),
 		}
 	}
 
@@ -1152,6 +1161,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			PluginChannelLinkDisabled: instData.PluginChannelLinkDisabled,
 			AutoLinkedChannels:        instData.AutoLinkedChannels,
 			Color:                     instData.Color,
+			IdleTimeoutSecs:           instData.IdleTimeoutSecs,
 			Sandbox:                   instData.Sandbox,
 			SandboxContainer:          instData.SandboxContainer,
 			SSHHost:                   instData.SSHHost,

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -283,6 +283,13 @@ type Home struct {
 	lastFullStatusSweep atomic.Int64             // UnixNano timestamp of last full background status sweep
 	lastPersistedStatus map[string]string        // instanceID -> last status written to SQLite
 
+	// Issue #1143: auto-stop dormant child sessions via central poll.
+	// Coalesced into the existing 2-second statusWorker tick by way of
+	// idleTimeoutLastTick, so we don't burn extra goroutines and the watcher
+	// only runs every ~60s.
+	idleTimeoutWatcher  *session.IdleTimeoutWatcher
+	idleTimeoutLastTick atomic.Int64 // UnixNano
+
 	// PERFORMANCE: Worker pool for output-driven status updates (Priority 2)
 	// Caps the number of goroutines spawned for %output events from control pipes
 	logUpdateChan chan *session.Instance // Buffers status update requests from PipeManager
@@ -932,6 +939,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		worktreeDirtyCacheTs: make(map[string]time.Time),
 		statusTrigger:        make(chan statusUpdateRequest, 1), // Buffered to avoid blocking
 		statusWorkerDone:     make(chan struct{}),
+		idleTimeoutWatcher:   session.NewIdleTimeoutWatcher(session.IdleTimeoutWatcherConfig{}),
 		lastPersistedStatus:  make(map[string]string),
 		logUpdateChan:        make(chan *session.Instance, 100), // Buffered to absorb bursts
 		hotkeys:              make(map[string]string),
@@ -3098,6 +3106,21 @@ func (h *Home) backgroundStatusUpdate() {
 	instances := make([]*session.Instance, len(h.instances))
 	copy(instances, h.instances)
 	h.instancesMu.RUnlock()
+
+	// Issue #1143: rate-limit the idle-timeout watcher to one tick per minute.
+	// The background sweep runs every 2s; capture-pane on every session every
+	// 2s would add unnecessary tmux load. 60s is the same cadence the spec
+	// suggests and matches how the lifecycle log surfaces dormant workers.
+	if h.idleTimeoutWatcher != nil {
+		const idleTickEvery = 60 * time.Second
+		nowNano := time.Now().UnixNano()
+		lastNano := h.idleTimeoutLastTick.Load()
+		if lastNano == 0 || time.Duration(nowNano-lastNano) >= idleTickEvery {
+			if h.idleTimeoutLastTick.CompareAndSwap(lastNano, nowNano) {
+				h.idleTimeoutWatcher.Tick(instances)
+			}
+		}
+	}
 
 	// PERFORMANCE: Gradually configure unconfigured sessions in background
 	// Configure one session per tick to avoid blocking the status update


### PR DESCRIPTION
## Summary

Closes #1143. Adds optional `--idle-timeout <duration>` flag + persistent column + central watcher to auto-stop child sessions that produce no new tmux pane output beyond initial response.

## Motivation

Self-improvement report 2026-05-21 found 4 dormant workers (`adeck-tdd-1031` ×17, `adeck-tdd-1020` ×12, `adeck-feat-1029` ×10, `adeck-tdd-973` ×9) producing repeated EVENT-line notifications without making progress. Operator had to manually `session stop` each. This flag automates cleanup after a configurable idle window.

## Surfaces (per agent-deck-tdd-feature skill)

- CLI: `agent-deck launch ... --idle-timeout 30m` + `agent-deck session set <id> idle_timeout 30m`
- Persistence: `instances.idle_timeout_secs` column (back-compat migration; default 0 = disabled)
- Watcher: central poll loop in internal/session; checks last-output timestamp vs configured timeout per session
- Lifecycle: new `idle-timeout-expired` entry on auto-stop trace

## Tests

5 tests at `internal/session/issue1143_idle_timeout_test.go`:
1. timeout fires when no output for > duration
2. fresh output resets the timer (session stays running)
3. timeout=0 (default) never auto-stops
4. runtime config update via `session set` applies on next watcher tick
5. CLI parses durations; rejects negative

## Refs

- Issue #1143
- Self-improvement report `~/.agent-deck/conductor/agent-deck/analysis/reports/2026-05-21.md` (section N1)
- Sibling PR #1144 (event de-dup) — both target the same dormant-child operator pain