### PR TITLE
fix(lefthook): serialize pre-push to remove css-verify/lint race (closes #1146)

### DIFF
--- a/internal/releasetests/issue1146_lefthook_prepush_serial_test.go
+++ b/internal/releasetests/issue1146_lefthook_prepush_serial_test.go
@@ -1,0 +1,52 @@
+// Issue #1146: lefthook pre-push ran `css-verify` and `lint` in parallel.
+// `make css-verify` writes a transient `internal/web/static/.brute-tw.src.css`
+// during its run; `golangci-lint` snapshots `//go:embed static/*` and ~30%
+// of pre-push runs caught the transient file mid-flight, failing lint.
+//
+// The structural fix is config-only: `pre-push` must serialize its commands
+// so `lint` never starts while `css-verify` is touching `internal/web/static/`.
+// This test pins that invariant so a future refactor cannot silently flip
+// `pre-push` back to parallel and re-introduce the race.
+package releasetests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestIssue1146LefthookPrePushIsSerial(t *testing.T) {
+	root := repoRoot(t)
+	path := filepath.Join(root, "lefthook.yml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var cfg struct {
+		PrePush struct {
+			Parallel bool           `yaml:"parallel"`
+			Piped    bool           `yaml:"piped"`
+			Commands map[string]any `yaml:"commands"`
+		} `yaml:"pre-push"`
+	}
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	if _, ok := cfg.PrePush.Commands["css-verify"]; !ok {
+		t.Fatal("pre-push.commands.css-verify missing — invariant relies on it")
+	}
+	if _, ok := cfg.PrePush.Commands["lint"]; !ok {
+		t.Fatal("pre-push.commands.lint missing — invariant relies on it")
+	}
+
+	if cfg.PrePush.Parallel {
+		t.Fatal("pre-push.parallel must be false (or omitted): css-verify and lint race on internal/web/static/.brute-tw.src.css (see issue #1146)")
+	}
+	if !cfg.PrePush.Piped {
+		t.Fatal("pre-push.piped must be true so commands run in defined order and stop on first failure (see issue #1146)")
+	}
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,12 +1,22 @@
-# Local CI pipeline - runs lint, test, and build in parallel
+# Local CI pipeline
 # Called automatically on git push (via pre-push hook) or manually: make ci
+#
+# pre-push runs serially (piped: true) to avoid a race between `css-verify`
+# and `lint` on the transient internal/web/static/.brute-tw.src.css file —
+# see issue #1146 and the comment on pre-push below.
 #
 # Usage:
 #   make ci              Run full CI checks locally
 #   lefthook run pre-push --force   Run directly (--force skips file-change check)
 
 pre-push:
-  parallel: true
+  # piped: true runs the commands below in the order they appear and stops on
+  # the first failure. We need ordered execution (not parallel) because
+  # `css-verify` momentarily writes `internal/web/static/.brute-tw.src.css`
+  # while `golangci-lint` snapshots `//go:embed static/*` — ~30% of runs the
+  # snapshot caught the transient file and lint failed (issue #1146). Order
+  # is fast-failing-first: css-verify, lint, build, then the longer test.
+  piped: true
   commands:
     css-verify:
       run: env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_PREFIX make css-verify
@@ -14,12 +24,12 @@ pre-push:
     lint:
       run: env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_PREFIX golangci-lint run
       tags: [quality]
-    test:
-      run: env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_PREFIX go test -race -count=1 ./...
-      tags: [test]
     build:
       run: env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_PREFIX go build -o /dev/null ./cmd/agent-deck/
       tags: [build]
+    test:
+      run: env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_PREFIX go test -race -count=1 ./...
+      tags: [test]
     release-tests-yaml-lint:
       # Structural guard against the AP-2 foot-gun (sprint REPORT F2): inline
       # `#NNN` issue refs inside plain multi-line scalars truncate via YAML


### PR DESCRIPTION
## Summary

Closes #1146.

`pre-push` had `parallel: true`, letting `css-verify` and `lint` run concurrently. `make css-verify` writes a transient `internal/web/static/.brute-tw.src.css` during the brute-force globbing gate, and `golangci-lint` snapshots `//go:embed static/*` at parse time. ~30% of pre-push runs caught the transient file mid-flight and failed lint with an unrelated embed error.

Switched the pre-push group to `piped: true`. Lefthook 1.13.6 has no per-command dependency syntax — `piped: true` is its canonical "run in defined order, stop on first failure" toggle. Reordered commands so fast-failing ones run first: `css-verify → lint → build → test → release-tests-yaml-lint`.

## Surface coverage (per agent-deck-tdd-feature skill)

This is a config-only fix to `lefthook.yml` (developer tooling, not user-facing). No TUI / Web / CLI / Remote / Persistence / Cross-platform code paths touched.

- **Regression test**: `internal/releasetests/issue1146_lefthook_prepush_serial_test.go` parses `lefthook.yml` and asserts `pre-push.parallel == false` and `pre-push.piped == true`, so a future edit can't silently flip parallel back on. Follows the same pattern as `manifest_test.go`.
- **Happy path**: test passes with the new YAML.
- **Failure mode**: test fails (verified RED-first) when `parallel: true` is present.
- **Boundary**: test also fails if `css-verify` or `lint` commands are removed from the config (the invariant assumes their presence).

## Verification

Local repro of serialization (synthetic fixture, 1s sleeps):
- `parallel: true` — START a / START b overlap to within 1ms; END a / END b overlap.
- `piped: true` — START b is delayed until END a (no overlap).

Full PR contract checks (run against this branch, clean tree):
- [x] `lefthook run pre-push --force` — exit 0, all 5 commands serialized (141s total at push time)
- [x] `golangci-lint run --timeout=5m --issues-exit-code=1` — 0 issues
- [x] `govulncheck ./...` — 0 affected vulnerabilities
- [x] `go test -race -count=1 -timeout 15m ./...` — all packages green
- [x] Commit signed `Committed by Ashesh Goplani` (no Claude attribution)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pre-push hook now executes commands sequentially in a defined order (css-verify, lint, build, test) instead of running in parallel.
  * Added verification test to enforce serial execution configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->