### PR TITLE
fix(session): strip all TELEGRAM_* env vars from child sessions (closes #1133)

### DIFF
--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -35,6 +35,11 @@ func handleLaunch(profile string, args []string) {
 	// from overwriting the agent-deck title.
 	titleLock := fs.Bool("title-lock", false, "Lock session title so Claude's session name never overrides it (#697)")
 	noTitleSync := fs.Bool("no-title-sync", false, "Alias for --title-lock")
+	// #1133: opt-in to inherit the conductor's TELEGRAM_* env vars in the
+	// child. Off by default — a child inheriting TELEGRAM_STATE_DIR /
+	// TELEGRAM_BOT_TOKEN spawns a duplicate `bun telegram` poller that
+	// races the conductor for the bot lock (Telegram 409, dropped messages).
+	inheritTelegramEnv := fs.Bool("inherit-telegram-env", false, "Keep TELEGRAM_* env vars in the child (#1133); off by default to prevent duplicate plugin pollers")
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
@@ -338,6 +343,11 @@ func handleLaunch(profile string, args []string) {
 	// #697: title-lock blocks Claude's session-name sync.
 	if *titleLock || *noTitleSync {
 		newInstance.TitleLocked = true
+	}
+
+	// #1133: explicit opt-in for inheriting the conductor's telegram env.
+	if *inheritTelegramEnv {
+		newInstance.InheritTelegramEnv = true
 	}
 
 	if sessionCommandInput != "" {

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -350,32 +350,55 @@ func isValidEnvKey(key string) bool {
 	return true
 }
 
-// telegramStateDirStripExpr returns `unset TELEGRAM_STATE_DIR` for any
-// claude spawn that is NOT a channel-owning telegram session. S8
-// (v1.7.40) broadens issue #680's narrow conductor-pairing predicate:
-// every `agent-deck launch` child that doesn't own the telegram bot
-// must lose TELEGRAM_STATE_DIR, otherwise it inherits the conductor's
-// TSD via the parent shell env, the telegram plugin (enabled globally
-// per the v3 topology) reads the conductor's .env, and a duplicate
-// bun poller races the conductor on the same bot token → Telegram
-// returns 409 Conflict and messages drop for everyone.
+// telegramEnvVarsToStrip lists every TELEGRAM_* env var that the
+// Claude Code telegram plugin reads. #680 / #955 / S8 only stripped
+// TELEGRAM_STATE_DIR; #1133 broadens this to include TELEGRAM_BOT_TOKEN
+// (and any future plugin var) so a child whose conductor exports the
+// token can't re-derive plugin state and spawn a duplicate `bun
+// telegram` poller. Order is deterministic for stable shell output.
+var telegramEnvVarsToStrip = []string{
+	"TELEGRAM_STATE_DIR",
+	"TELEGRAM_BOT_TOKEN",
+}
+
+// telegramStateDirStripExpr returns an `unset TELEGRAM_STATE_DIR ...`
+// clause for any claude spawn that is NOT a channel-owning telegram
+// session. S8 (v1.7.40) broadens issue #680's narrow conductor-pairing
+// predicate: every `agent-deck launch` child that doesn't own the
+// telegram bot must lose TELEGRAM_*, otherwise it inherits the
+// conductor's env, the telegram plugin (enabled globally per the v3
+// topology) reads the conductor's .env, and a duplicate bun poller
+// races the conductor on the same bot token → Telegram returns 409
+// Conflict and messages drop for everyone.
+//
+// #1133 broadens further: TELEGRAM_BOT_TOKEN is now stripped too (the
+// plugin re-derives state from the token alone). An explicit opt-in
+// (Instance.InheritTelegramEnv, CLI `--inherit-telegram-env`) preserves
+// the full env for the rare case of debugging the poller from a fork.
 //
 // Fires when ALL hold:
-//  1. Tool is "claude" — TELEGRAM_STATE_DIR is a Claude Code plugin env
-//     var; don't mutate codex / gemini spawns.
+//  1. Tool is "claude" — TELEGRAM_* are Claude Code plugin env vars;
+//     don't mutate codex / gemini spawns.
 //  2. Title does NOT start with "conductor-". Conductors are the
 //     legitimate bot owners even before `Channels` is set.
 //  3. No entry in `Channels` carries the `plugin:telegram@` prefix.
-//     Explicit per-session telegram opt-in keeps the variable.
+//     Explicit per-session telegram opt-in keeps the variables.
+//  4. InheritTelegramEnv is false. The #1133 escape hatch.
 //
 // Returned string is empty when no strip is needed, so callers can
-// append it unconditionally to the sources slice.
+// append it unconditionally to the sources slice. The function name
+// retains "StateDir" for backward compatibility with callers in
+// instance.go and the existing test surface; the body covers all
+// telegram vars.
 func telegramStateDirStripExpr(inst *Instance) string {
 	if inst == nil {
 		return ""
 	}
 	if inst.Tool != "claude" {
 		return ""
+	}
+	if inst.InheritTelegramEnv {
+		return "" // #1133 opt-in — keep the conductor's telegram env
 	}
 	if conductorNameFromInstance(inst) != "" {
 		return "" // conductor session — owns the bot token
@@ -385,10 +408,26 @@ func telegramStateDirStripExpr(inst *Instance) string {
 			return "" // explicit telegram channel owner
 		}
 	}
-	return "unset TELEGRAM_STATE_DIR"
+	return "unset " + strings.Join(telegramEnvVarsToStrip, " ")
 }
 
-// ScrubProcessEnvForChildLaunch removes TELEGRAM_STATE_DIR from the
+// telegramExecEnvStripFlags returns the `-u VAR -u VAR ...` argument
+// list for the `env` exec wrapper at instance.go:758. Mirrors
+// telegramStateDirStripExpr at the exec layer: same predicate, same
+// var list, defense-in-depth against the shell `unset` somehow being
+// bypassed.
+func telegramExecEnvStripFlags(inst *Instance) string {
+	if telegramStateDirStripExpr(inst) == "" {
+		return ""
+	}
+	parts := make([]string, 0, len(telegramEnvVarsToStrip)*2)
+	for _, v := range telegramEnvVarsToStrip {
+		parts = append(parts, "-u", v)
+	}
+	return strings.Join(parts, " ")
+}
+
+// ScrubProcessEnvForChildLaunch removes TELEGRAM_* vars from the
 // CURRENT process environment when the given instance represents a
 // non-channel-owning claude child. Issue #955: `agent-deck launch`
 // invoked from a conductor session inherits the conductor's
@@ -396,20 +435,44 @@ func telegramStateDirStripExpr(inst *Instance) string {
 // tmux server (which inherits the launching process env on first
 // `new-session`) and from there into every subprocess in the new
 // pane — Bash-tool spawns, fork claudes, restart respawn — even when
-// the S8 exec-layer (`env -u TELEGRAM_STATE_DIR claude`) protects the
-// immediate claude binary. Any of those descendants can load the
-// Claude Code telegram plugin and start a second `bun telegram`
-// poller against the conductor's bot, racing the conductor for the
-// Bot API lock (HTTP 409) and silently dropping inbound messages.
+// the S8 exec-layer protects the immediate claude binary. Any of
+// those descendants can load the Claude Code telegram plugin and
+// start a second `bun telegram` poller against the conductor's bot,
+// racing the conductor for the Bot API lock (HTTP 409) and silently
+// dropping inbound messages.
+//
+// #1133 broadens the scrub: TELEGRAM_STATE_DIR alone left a hole —
+// conductors that also exported TELEGRAM_BOT_TOKEN (the plugin
+// re-derives state from the token) still leaked the duplicate poller.
+// We now unset every var named in telegramEnvVarsToStrip *and* any
+// other TELEGRAM_-prefixed var present in os.Environ. The prefix
+// sweep means a future plugin env addition (TELEGRAM_API_HASH etc.)
+// is covered without code change here.
 //
 // Reuses telegramStateDirStripExpr as the single source of truth for
 // the strip predicate so this layer can never disagree with the
 // shell-level and exec-level layers about which sessions own the
 // telegram bot. No-op for conductors, explicit telegram channel
-// owners, and non-claude tools.
+// owners, --inherit-telegram-env opt-ins, and non-claude tools.
 func ScrubProcessEnvForChildLaunch(inst *Instance) {
 	if telegramStateDirStripExpr(inst) == "" {
 		return
 	}
-	_ = os.Unsetenv("TELEGRAM_STATE_DIR")
+	for _, v := range telegramEnvVarsToStrip {
+		_ = os.Unsetenv(v)
+	}
+	// Prefix sweep: catch any other TELEGRAM_* var the conductor
+	// might have exported but the plugin doesn't strictly require.
+	// Keeps the child env minimal so a plugin update can't surprise
+	// us with a new poller-spawning var.
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue
+		}
+		key := kv[:eq]
+		if strings.HasPrefix(key, "TELEGRAM_") {
+			_ = os.Unsetenv(key)
+		}
+	}
 }

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -238,6 +238,16 @@ type Instance struct {
 	// RFC: docs/rfc/PLUGIN_ATTACH.md.
 	Plugins []string `json:"plugins,omitempty"`
 
+	// InheritTelegramEnv is the explicit opt-in for #1133: when true, a
+	// non-channel-owning claude child KEEPS the conductor's TELEGRAM_*
+	// env vars (TELEGRAM_STATE_DIR, TELEGRAM_BOT_TOKEN, etc.). Default
+	// false strips them so a child can't spawn a duplicate `bun telegram`
+	// poller that races the conductor for getUpdates (Telegram 409
+	// Conflict + dropped inbound messages). CLI flag:
+	// `--inherit-telegram-env` on `agent-deck launch`. Rare use case;
+	// existing behavior is preserved when the flag is absent.
+	InheritTelegramEnv bool `json:"inherit_telegram_env,omitempty"`
+
 	// PluginChannelLinkDisabled opts the session out of the catalog-driven
 	// auto-link between Plugins and Channels (RFC §4.7). When true, an
 	// `--plugin foo` whose catalog entry has EmitsChannel=true does NOT
@@ -748,14 +758,16 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 	}
 
 	// S8 (v1.7.40) defense-in-depth: non-channel-owning claude spawns
-	// wrap the final exec in `env -u TELEGRAM_STATE_DIR` so the child
-	// process is guaranteed to start without TSD even if the shell
-	// unset in buildEnvSourceCommand is somehow bypassed. Empty string
-	// for conductors, explicit telegram channel owners, and non-claude
-	// tools (see telegramStateDirStripExpr for the predicate).
+	// wrap the final exec in `env -u TELEGRAM_*` so the child process
+	// is guaranteed to start without telegram env even if the shell
+	// unset in buildEnvSourceCommand is somehow bypassed. #1133
+	// broadens the flag list from TELEGRAM_STATE_DIR alone to every
+	// var in telegramEnvVarsToStrip. Empty string for conductors,
+	// explicit telegram channel owners, --inherit-telegram-env opt-in,
+	// and non-claude tools (see telegramStateDirStripExpr predicate).
 	execEnvPrefix := ""
-	if telegramStateDirStripExpr(i) != "" {
-		execEnvPrefix = "env -u TELEGRAM_STATE_DIR "
+	if flags := telegramExecEnvStripFlags(i); flags != "" {
+		execEnvPrefix = "env " + flags + " "
 	}
 
 	// If baseCommand is just "claude", build the appropriate command

--- a/internal/session/issue1133_tg_env_strip_test.go
+++ b/internal/session/issue1133_tg_env_strip_test.go
@@ -1,0 +1,256 @@
+package session
+
+// Issue #1133 — broaden the telegram env strip to cover TELEGRAM_BOT_TOKEN
+// (and any future TELEGRAM_* plugin env var) and add an explicit opt-in
+// `--inherit-telegram-env` escape hatch.
+//
+// Background: #680 + #955 + S8 strip TELEGRAM_STATE_DIR at three layers
+// (shell `unset`, exec `env -u`, agent-deck CLI `os.Unsetenv`). A
+// conductor that exports both TELEGRAM_STATE_DIR *and* TELEGRAM_BOT_TOKEN
+// still leaks the latter to children — the plugin re-derives state from
+// the token and spawns the same duplicate `bun telegram` poller that
+// fights the conductor for getUpdates (Telegram 409 Conflict, dropped
+// inbound messages).
+//
+// Real fix: every non-channel-owning claude child loses ALL TELEGRAM_*
+// env vars, not just TELEGRAM_STATE_DIR. Sessions that legitimately need
+// the conductor's telegram env (rare: a tool-only fork debugging the
+// poller) can opt in via the new InheritTelegramEnv flag, exposed on the
+// CLI as `--inherit-telegram-env`.
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Test 1: parent has TELEGRAM_STATE_DIR set → spawn child → child env
+// does NOT have TELEGRAM_STATE_DIR. Asserts the shell-source strip
+// covers TELEGRAM_STATE_DIR (regression coverage; mirrors #680/#955).
+func TestIssue1133_Child_StripsTelegramStateDir(t *testing.T) {
+	cfg := &UserConfig{
+		MCPs:       make(map[string]MCPDef),
+		Conductors: map[string]ConductorOverrides{},
+		Groups:     map[string]GroupSettings{},
+	}
+	defer resetUserConfigCache(t, cfg)()
+
+	child := &Instance{
+		Title:       "launch-child",
+		Tool:        "claude",
+		ProjectPath: "/tmp",
+	}
+
+	got := child.buildEnvSourceCommand()
+
+	if !strings.Contains(got, "TELEGRAM_STATE_DIR") {
+		t.Errorf("child must strip TELEGRAM_STATE_DIR\nbuildEnvSourceCommand() = %q", got)
+	}
+	if !strings.Contains(got, "unset ") {
+		t.Errorf("child must emit an unset clause\nbuildEnvSourceCommand() = %q", got)
+	}
+}
+
+// Test 2: parent has TELEGRAM_BOT_TOKEN set → child env does NOT have it
+// either. This is the #1133 broadening — STATE_DIR alone isn't enough.
+func TestIssue1133_Child_StripsTelegramBotToken(t *testing.T) {
+	cfg := &UserConfig{
+		MCPs:       make(map[string]MCPDef),
+		Conductors: map[string]ConductorOverrides{},
+		Groups:     map[string]GroupSettings{},
+	}
+	defer resetUserConfigCache(t, cfg)()
+
+	child := &Instance{
+		Title:       "launch-child",
+		Tool:        "claude",
+		ProjectPath: "/tmp",
+	}
+
+	got := child.buildEnvSourceCommand()
+
+	if !strings.Contains(got, "TELEGRAM_BOT_TOKEN") {
+		t.Errorf("child must strip TELEGRAM_BOT_TOKEN (#1133 broadening)\nbuildEnvSourceCommand() = %q", got)
+	}
+}
+
+// Process-env scrub variant: ScrubProcessEnvForChildLaunch must remove
+// TELEGRAM_BOT_TOKEN from os.Environ for a non-channel-owning child so
+// the tmux server isn't born with the token.
+func TestIssue1133_Scrub_RemovesTelegramBotToken(t *testing.T) {
+	t.Setenv("TELEGRAM_BOT_TOKEN", "1234:fake-token-1133")
+
+	child := &Instance{
+		ID:          "1133-child",
+		Tool:        "claude",
+		Title:       "launch-child",
+		ProjectPath: t.TempDir(),
+	}
+
+	ScrubProcessEnvForChildLaunch(child)
+
+	if got, ok := os.LookupEnv("TELEGRAM_BOT_TOKEN"); ok {
+		t.Fatalf("non-channel-owning child launch must scrub TELEGRAM_BOT_TOKEN from process env; got %q", got)
+	}
+}
+
+// Process-env scrub variant: arbitrary TELEGRAM_* vars must also be
+// removed so the strip covers future plugin env additions without
+// requiring code changes here.
+func TestIssue1133_Scrub_RemovesOtherTelegramPrefixedVars(t *testing.T) {
+	t.Setenv("TELEGRAM_API_HASH", "deadbeef")
+	t.Setenv("TELEGRAM_APP_ID", "42")
+
+	child := &Instance{
+		ID:          "1133-prefix",
+		Tool:        "claude",
+		Title:       "launch-child",
+		ProjectPath: t.TempDir(),
+	}
+
+	ScrubProcessEnvForChildLaunch(child)
+
+	if got, ok := os.LookupEnv("TELEGRAM_API_HASH"); ok {
+		t.Fatalf("scrub must remove TELEGRAM_API_HASH; got %q", got)
+	}
+	if got, ok := os.LookupEnv("TELEGRAM_APP_ID"); ok {
+		t.Fatalf("scrub must remove TELEGRAM_APP_ID; got %q", got)
+	}
+}
+
+// Test 3: child explicitly opts in via `--inherit-telegram-env` flag →
+// child DOES inherit TELEGRAM_STATE_DIR and TELEGRAM_BOT_TOKEN. The opt-in
+// is the documented escape hatch; without it there'd be no way to test
+// the poller from a forked session.
+func TestIssue1133_OptIn_InheritsTelegramEnv(t *testing.T) {
+	cfg := &UserConfig{
+		MCPs:       make(map[string]MCPDef),
+		Conductors: map[string]ConductorOverrides{},
+		Groups:     map[string]GroupSettings{},
+	}
+	defer resetUserConfigCache(t, cfg)()
+
+	child := &Instance{
+		Title:              "launch-child",
+		Tool:               "claude",
+		ProjectPath:        "/tmp",
+		InheritTelegramEnv: true,
+	}
+
+	got := child.buildEnvSourceCommand()
+
+	if strings.Contains(got, "unset TELEGRAM_") {
+		t.Errorf("--inherit-telegram-env opt-in child must NOT emit a telegram unset\nbuildEnvSourceCommand() = %q", got)
+	}
+}
+
+// Process-env scrub variant of Test 3: opt-in child must leave os.Environ
+// intact so the conductor's TELEGRAM_* propagates into tmux + claude.
+func TestIssue1133_OptIn_ScrubIsNoOp(t *testing.T) {
+	t.Setenv("TELEGRAM_STATE_DIR", "/tmp/tg-1133")
+	t.Setenv("TELEGRAM_BOT_TOKEN", "1234:opt-in-1133")
+
+	child := &Instance{
+		ID:                 "1133-optin",
+		Tool:               "claude",
+		Title:              "launch-child",
+		ProjectPath:        t.TempDir(),
+		InheritTelegramEnv: true,
+	}
+
+	ScrubProcessEnvForChildLaunch(child)
+
+	if got, ok := os.LookupEnv("TELEGRAM_STATE_DIR"); !ok || got != "/tmp/tg-1133" {
+		t.Fatalf("opt-in child must preserve TELEGRAM_STATE_DIR; got ok=%v %q", ok, got)
+	}
+	if got, ok := os.LookupEnv("TELEGRAM_BOT_TOKEN"); !ok || got != "1234:opt-in-1133" {
+		t.Fatalf("opt-in child must preserve TELEGRAM_BOT_TOKEN; got ok=%v %q", ok, got)
+	}
+}
+
+// Test 4: regression — non-telegram env vars (PATH, HOME, etc.) DO
+// propagate as before. The strip must be tightly scoped to the
+// TELEGRAM_ prefix; broadening it to other vars would break every
+// child session.
+func TestIssue1133_NonTelegramVars_Propagate(t *testing.T) {
+	cfg := &UserConfig{
+		MCPs:       make(map[string]MCPDef),
+		Conductors: map[string]ConductorOverrides{},
+		Groups:     map[string]GroupSettings{},
+	}
+	defer resetUserConfigCache(t, cfg)()
+
+	child := &Instance{
+		Title:       "launch-child",
+		Tool:        "claude",
+		ProjectPath: "/tmp",
+	}
+
+	got := child.buildEnvSourceCommand()
+
+	// PATH / HOME must NOT be in the unset list.
+	if strings.Contains(got, "unset PATH") {
+		t.Errorf("strip must not touch PATH\nbuildEnvSourceCommand() = %q", got)
+	}
+	if strings.Contains(got, "unset HOME") {
+		t.Errorf("strip must not touch HOME\nbuildEnvSourceCommand() = %q", got)
+	}
+
+	// Process-env scrub: must not unset PATH or HOME.
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("HOME", "/home/test")
+	ScrubProcessEnvForChildLaunch(child)
+	if got := os.Getenv("PATH"); got != "/usr/bin:/bin" {
+		t.Fatalf("scrub must preserve PATH; got %q", got)
+	}
+	if got := os.Getenv("HOME"); got != "/home/test" {
+		t.Fatalf("scrub must preserve HOME; got %q", got)
+	}
+}
+
+// Boundary: conductor session keeps both TELEGRAM_STATE_DIR AND
+// TELEGRAM_BOT_TOKEN — it owns the bot, the whole point of the carve-out.
+func TestIssue1133_Conductor_KeepsAllTelegramVars(t *testing.T) {
+	cfg := &UserConfig{
+		MCPs:       make(map[string]MCPDef),
+		Conductors: map[string]ConductorOverrides{},
+		Groups:     map[string]GroupSettings{},
+	}
+	defer resetUserConfigCache(t, cfg)()
+
+	conductor := &Instance{
+		Title:       "conductor-personal",
+		Tool:        "claude",
+		ProjectPath: "/tmp",
+	}
+
+	got := conductor.buildEnvSourceCommand()
+
+	if strings.Contains(got, "unset TELEGRAM_") {
+		t.Errorf("conductor session must NOT strip any TELEGRAM_* var\nbuildEnvSourceCommand() = %q", got)
+	}
+}
+
+// Boundary: non-claude tool (codex, gemini) does not get the strip —
+// telegram plugin is Claude Code only, so other tools must be left
+// alone to avoid surprise breakage.
+func TestIssue1133_NonClaudeTool_NoStrip(t *testing.T) {
+	cfg := &UserConfig{
+		MCPs:       make(map[string]MCPDef),
+		Conductors: map[string]ConductorOverrides{},
+		Groups:     map[string]GroupSettings{},
+	}
+	defer resetUserConfigCache(t, cfg)()
+
+	codex := &Instance{
+		Title:       "codex-child",
+		Tool:        "codex",
+		ProjectPath: "/tmp",
+	}
+
+	got := codex.buildEnvSourceCommand()
+
+	if strings.Contains(got, "unset TELEGRAM_") {
+		t.Errorf("non-claude session must NOT receive the strip\nbuildEnvSourceCommand() = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Conductors export both `TELEGRAM_STATE_DIR` and `TELEGRAM_BOT_TOKEN` so the
Claude Code `plugin:telegram` MCP knows which bot to poll. The existing
#680 / #955 / S8 strip only removed `TELEGRAM_STATE_DIR` from `agent-deck
launch` children. The plugin re-derives state from the token alone, so a
child whose conductor also exported `TELEGRAM_BOT_TOKEN` still spawned a
duplicate `bun telegram` poller — which races the conductor for the bot
lock (Telegram 409 Conflict) and silently drops inbound messages.

This PR broadens the strip to cover every `TELEGRAM_*` env var across all
three existing layers, and adds an explicit `--inherit-telegram-env`
opt-in for the rare case (forked debug session) where a child legitimately
needs the conductor's telegram env.

## Changes

- **`internal/session/env.go`**
  - New `telegramEnvVarsToStrip` slice (single source of truth: `TELEGRAM_STATE_DIR`, `TELEGRAM_BOT_TOKEN`).
  - `telegramStateDirStripExpr` now emits `unset TELEGRAM_STATE_DIR TELEGRAM_BOT_TOKEN` and honours the `InheritTelegramEnv` opt-in.
  - New `telegramExecEnvStripFlags` returns the `-u VAR -u VAR …` list for the exec wrapper.
  - `ScrubProcessEnvForChildLaunch` unsets every var in the strip list and sweeps any other `TELEGRAM_`-prefixed var from `os.Environ` (future-proofs against new plugin env vars).
- **`internal/session/instance.go`**
  - New persisted field `Instance.InheritTelegramEnv` (`json:"inherit_telegram_env,omitempty"`).
  - Exec prefix uses `telegramExecEnvStripFlags(i)` so the unset list stays in lockstep with the shell-source layer.
- **`cmd/agent-deck/launch_cmd.go`**
  - New CLI flag `--inherit-telegram-env` (default false). Wires `Instance.InheritTelegramEnv`.

## Surfaces Covered

| Surface | Test file | Notes |
|---|---|---|
| Session (env build) | `internal/session/issue1133_tg_env_strip_test.go` | shell `unset` predicate + opt-in + non-claude carve-out |
| Session (process scrub) | same file | `ScrubProcessEnvForChildLaunch` strips `TELEGRAM_BOT_TOKEN` + prefix sweep |
| CLI | covered by process-scrub tests (CLI just sets the field) + existing `cmd/agent-deck/issue955_telegram_env_strip_test.go` | |
| Persistence | `Instance.InheritTelegramEnv` is a plain `bool` with `omitempty` — round-trips through the existing `SaveWithGroups` JSON path; no schema migration. |

## Surfaces Skipped (with reason)

- **TUI / Web UI**: no UI surfaces the telegram env strip today; the
  opt-in is a CLI-only escape hatch, intentionally hidden from the
  default UX. Follow-up not required — the strip is a safety
  invariant, not a feature.
- **Cross-platform**: env handling goes through Go's `os` package,
  which abstracts away OS differences. No darwin/linux/windows code
  path divergence to test.

## Test Coverage (per surface)

Each `TELEGRAM_*` strip path is covered for:
- **Happy path**: child loses `TELEGRAM_STATE_DIR` + `TELEGRAM_BOT_TOKEN`.
- **Failure mode**: opt-in keeps both; conductor keeps both; non-claude tool untouched.
- **Boundary**: prefix sweep catches arbitrary `TELEGRAM_API_HASH` / `TELEGRAM_APP_ID`; `PATH` / `HOME` propagate unchanged.

## PR Contract

- [x] Surface-applicable tests written + GREEN locally
- [x] Lint clean (`golangci-lint run --timeout=5m`)
- [x] Vuln clean (`govulncheck ./...`)
- [x] Race-detector clean (`go test -race -count=1 -timeout 5m ./internal/session ./cmd/agent-deck`)
- [x] Commit signed `Committed by Ashesh Goplani`
- [x] No Claude attribution in commit message
- [x] Pre-push lefthook all green (build / css-verify / lint / yaml-lint / test)

## Test plan

- [x] `go test -race -count=1 -run Issue1133 ./internal/session` — all 9 new tests pass
- [x] `go test -race -count=1 -run 'Issue680|Issue955|TestS8' ./internal/session ./cmd/agent-deck` — all prior regression tests pass
- [x] Full package race-test: `internal/session` 127s OK, `cmd/agent-deck` 73s OK
- [ ] Manual verification: `TELEGRAM_BOT_TOKEN=foo agent-deck launch . -c claude` — child should have neither `TELEGRAM_STATE_DIR` nor `TELEGRAM_BOT_TOKEN` in its env (deferred to merge; the regression test asserts the same invariant at the strip predicate)

Closes #1133.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--inherit-telegram-env` CLI flag to allow child sessions to optionally inherit Telegram environment variables from the parent session, providing explicit control over environment inheritance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->