### PR TITLE
Authenticate update checks to avoid GitHub anonymous rate limit

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -156,6 +157,59 @@ func saveCache(cache *UpdateCache) error {
 	return os.WriteFile(cachePath, data, 0644)
 }
 
+// resolveGitHubToken returns a GitHub token from (in order) GITHUB_TOKEN,
+// GH_TOKEN, or `gh auth token`. Returns "" if none are available. Any
+// failure invoking `gh` is treated as "no token" so we fall back to
+// anonymous requests.
+func resolveGitHubToken() string {
+	if t := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); t != "" {
+		return t
+	}
+	if t := strings.TrimSpace(os.Getenv("GH_TOKEN")); t != "" {
+		return t
+	}
+	if _, err := exec.LookPath("gh"); err != nil {
+		return ""
+	}
+	out, err := exec.Command("gh", "auth", "token").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// githubAPIGet performs an authenticated GET against the GitHub API when a
+// token is available. On a 403 response from an unauthenticated request it
+// returns a friendlier rate-limit error pointing the user at authentication.
+func githubAPIGet(url string) (*http.Response, bool, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	token := resolveGitHubToken()
+	authed := token != ""
+	if authed {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, authed, err
+	}
+	return resp, authed, nil
+}
+
+// rateLimitError returns a friendlier error for an unauthenticated 403 from
+// GitHub, or the original status-based error otherwise.
+func rateLimitError(status int, authed bool) error {
+	if status == http.StatusForbidden && !authed {
+		return fmt.Errorf("GitHub API rate limit exceeded (anonymous limit is 60/hour). Set GITHUB_TOKEN or install/login with the gh CLI to authenticate")
+	}
+	return fmt.Errorf("GitHub API returned status %d", status)
+}
+
 // fetchRecentReleases fetches the most recent `limit` releases from GitHub
 // (newest first). Used by CheckForUpdate to compute ReleasesBehind.
 func fetchRecentReleases(limit int) ([]Release, error) {
@@ -164,15 +218,14 @@ func fetchRecentReleases(limit int) ([]Release, error) {
 	}
 	url := fmt.Sprintf("%s/repos/%s/releases?per_page=%d", apiBaseURL, GitHubRepo, limit)
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(url)
+	resp, authed, err := githubAPIGet(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list releases: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+		return nil, rateLimitError(resp.StatusCode, authed)
 	}
 
 	var releases []Release
@@ -244,15 +297,14 @@ func ShouldNudge(info *UpdateInfo) bool {
 func fetchLatestRelease() (*Release, error) {
 	url := fmt.Sprintf("%s/repos/%s/releases/latest", apiBaseURL, GitHubRepo)
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(url)
+	resp, authed, err := githubAPIGet(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch release: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+		return nil, rateLimitError(resp.StatusCode, authed)
 	}
 
 	var release Release
@@ -308,8 +360,7 @@ func FetchReleaseByTag(tag string) (*Release, error) {
 
 	url := fmt.Sprintf("%s/repos/%s/releases/tags/%s", apiBaseURL, GitHubRepo, normalized)
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(url)
+	resp, authed, err := githubAPIGet(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch release %s: %w", normalized, err)
 	}
@@ -319,6 +370,9 @@ func FetchReleaseByTag(tag string) (*Release, error) {
 		return nil, fmt.Errorf("release %s not found on GitHub", normalized)
 	}
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusForbidden && !authed {
+			return nil, fmt.Errorf("GitHub API rate limit exceeded fetching release %s (anonymous limit is 60/hour). Set GITHUB_TOKEN or install/login with the gh CLI to authenticate", normalized)
+		}
 		return nil, fmt.Errorf("GitHub API returned status %d for release %s", resp.StatusCode, normalized)
 	}
 


### PR DESCRIPTION
Fixes #1150

## Summary

`agent-deck update` (and the background nudge) hits `api.github.com` without authentication, which exhausts GitHub's 60/hour anonymous quota easily on shared/VPN networks and surfaces as a bare `GitHub API returned status 403`. This PR authenticates the three GitHub releases API calls in `internal/update/update.go` when a token is available, and improves the rate-limit error message.

## Token resolution order

First non-empty value wins:

1. `GITHUB_TOKEN` env var
2. `GH_TOKEN` env var
3. `gh auth token` subprocess output (only attempted if `gh` is on PATH; any failure falls back to anonymous)

When a token is found, requests get an `Authorization: Bearer <token>` header. Anonymous behavior is unchanged when no token is available.

## Error message

When a 403 comes back from an unauthenticated request, the error now reads:

> GitHub API rate limit exceeded (anonymous limit is 60/hour). Set GITHUB_TOKEN or install/login with the gh CLI to authenticate.

When a 403 comes back *with* a token, the original `GitHub API returned status 403` error is preserved — that's a token problem, not a rate-limit problem.

## Scope

- `fetchLatestRelease`, `fetchRecentReleases`, `FetchReleaseByTag` all route through a shared `githubAPIGet` helper.
- No other code paths or behaviors touched. Existing tests in `internal/update` still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced GitHub API integration with authentication support to reduce rate limit issues when checking for updates.
  * Improved error messaging for rate limit scenarios, with clearer feedback for unauthenticated requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->