### PR TITLE
fix(multi-repo): pre-accept Claude trust and emit parent CLAUDE.md (closes #1149)

### DIFF
--- a/cmd/agent-deck/issue1149_multirepo_trust_test.go
+++ b/cmd/agent-deck/issue1149_multirepo_trust_test.go
@@ -1,0 +1,270 @@
+package main
+
+// Regression tests for issue #1149 — multi-repo worktree parent dirs must
+// pre-accept the Claude trust dialog and emit a parent CLAUDE.md telling
+// Claude which subdirectory to cd into for project commands.
+//
+// Without these, every multi-repo session greets the user with "do you
+// trust this directory?" and Claude then runs build commands at the empty
+// parent dir because it has no idea the real repos live one level deeper.
+//
+// Per @spawnia's spec (gh issue 1149) the fix has two halves:
+//
+//	if inst.Tool == "claude" {
+//	    preAcceptClaudeTrust(parentDir)
+//	    writeParentClaudeMD(parentDir, repos)
+//	}
+//
+// invoked inside the multi-repo branch of home.go. The tests below exercise
+// the integration entry point session.ApplyMultiRepoClaudeContext directly
+// because home.go's session-creation Cmd is not callable from a unit test
+// without spinning up the full TUI.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Happy path — spawning a multi-repo claude session adds a trust entry and
+// writes a CLAUDE.md naming every repo subdir.
+func TestIssue1149_MultiRepoClaudeSession_PreAcceptsTrustAndWritesParentMD(t *testing.T) {
+	dir := t.TempDir()
+	claudeJSON := filepath.Join(dir, ".claude.json")
+	parentDir := filepath.Join(dir, "multi-repo-worktrees", "feature-x-abcd1234")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+
+	repos := []string{"limes-api", "limes-frontend"}
+	if err := session.ApplyMultiRepoClaudeContext("claude", true, claudeJSON, parentDir, repos); err != nil {
+		t.Fatalf("ApplyMultiRepoClaudeContext: %v", err)
+	}
+
+	// Trust entry created.
+	data, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatalf("read claude.json: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal claude.json: %v", err)
+	}
+	projects, ok := cfg["projects"].(map[string]any)
+	if !ok {
+		t.Fatalf("projects key missing or wrong type: %T", cfg["projects"])
+	}
+	entry, ok := projects[parentDir].(map[string]any)
+	if !ok {
+		keys := make([]string, 0, len(projects))
+		for k := range projects {
+			keys = append(keys, k)
+		}
+		t.Fatalf("parentDir entry missing: keys=%v", keys)
+	}
+	if entry["hasTrustDialogAccepted"] != true {
+		t.Fatalf("hasTrustDialogAccepted: got %v want true", entry["hasTrustDialogAccepted"])
+	}
+
+	// Parent CLAUDE.md created and lists every repo subdir.
+	mdBytes, err := os.ReadFile(filepath.Join(parentDir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	md := string(mdBytes)
+	for _, name := range repos {
+		if !strings.Contains(md, name) {
+			t.Errorf("CLAUDE.md missing repo %q; got:\n%s", name, md)
+		}
+	}
+	if !strings.Contains(md, "multi-repo") && !strings.Contains(md, "Multi-Repo") {
+		t.Errorf("CLAUDE.md does not advertise multi-repo nature; got:\n%s", md)
+	}
+}
+
+// Boundary — parent CLAUDE.md must enumerate every repo subdir even when
+// there are three or more (sanity check that we are not capping at the
+// first two).
+func TestIssue1149_ParentClaudeMD_ListsAllRepoSubdirs(t *testing.T) {
+	parentDir := t.TempDir()
+	claudeJSON := filepath.Join(parentDir, ".claude.json")
+	repos := []string{"repo-alpha", "repo-beta", "repo-gamma", "repo-delta"}
+
+	if err := session.ApplyMultiRepoClaudeContext("claude", true, claudeJSON, parentDir, repos); err != nil {
+		t.Fatalf("ApplyMultiRepoClaudeContext: %v", err)
+	}
+
+	md, err := os.ReadFile(filepath.Join(parentDir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	for _, name := range repos {
+		if !strings.Contains(string(md), name) {
+			t.Errorf("CLAUDE.md missing %q", name)
+		}
+	}
+}
+
+// Failure mode for the integration guard — a non-multi-repo session must
+// leave ~/.claude.json untouched and must not produce a CLAUDE.md at the
+// project path. Test 3 of @spawnia's spec.
+func TestIssue1149_SingleRepoSession_DoesNotModifyClaudeJSON(t *testing.T) {
+	dir := t.TempDir()
+	claudeJSON := filepath.Join(dir, ".claude.json")
+	original := `{"projects":{"/some/unrelated":{"hasTrustDialogAccepted":true}},"someTopLevel":"keep-me"}`
+	if err := os.WriteFile(claudeJSON, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed claude.json: %v", err)
+	}
+
+	parentPath := filepath.Join(dir, "project") // would be inst.ProjectPath in a single-repo session
+	if err := os.MkdirAll(parentPath, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// multiRepoEnabled=false → no-op, even though tool is claude.
+	if err := session.ApplyMultiRepoClaudeContext("claude", false, claudeJSON, parentPath, []string{"project"}); err != nil {
+		t.Fatalf("ApplyMultiRepoClaudeContext: %v", err)
+	}
+
+	got, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatalf("read claude.json: %v", err)
+	}
+	if string(got) != original {
+		t.Errorf("claude.json modified for single-repo session.\nwant:\n%s\ngot:\n%s", original, got)
+	}
+	if _, err := os.Stat(filepath.Join(parentPath, "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Errorf("CLAUDE.md should not exist for single-repo session, stat err=%v", err)
+	}
+}
+
+// Failure mode — preserving existing unrelated entries in ~/.claude.json.
+// Test 4 of @spawnia's spec. A bug where we round-tripped via a typed struct
+// would silently drop fields we don't model.
+func TestIssue1149_PreservesExistingClaudeJSONEntries(t *testing.T) {
+	dir := t.TempDir()
+	claudeJSON := filepath.Join(dir, ".claude.json")
+	original := map[string]any{
+		"someTopLevelField":      "keep-me",
+		"hasCompletedOnboarding": true,
+		"projects": map[string]any{
+			"/home/user/projectA": map[string]any{
+				"hasTrustDialogAccepted": true,
+				"lastSessionId":          "abc-123",
+				"customField":            "preserved",
+			},
+			"/home/user/projectB": map[string]any{
+				"hasTrustDialogAccepted": false,
+			},
+		},
+	}
+	data, _ := json.Marshal(original)
+	if err := os.WriteFile(claudeJSON, data, 0o600); err != nil {
+		t.Fatalf("seed claude.json: %v", err)
+	}
+
+	parentDir := filepath.Join(dir, "multi-repo-worktrees", "branch-9999aaaa")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+
+	if err := session.ApplyMultiRepoClaudeContext("claude", true, claudeJSON, parentDir, []string{"r1"}); err != nil {
+		t.Fatalf("ApplyMultiRepoClaudeContext: %v", err)
+	}
+
+	after, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatalf("read claude.json: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(after, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if cfg["someTopLevelField"] != "keep-me" {
+		t.Errorf("top-level field dropped: %v", cfg["someTopLevelField"])
+	}
+	if cfg["hasCompletedOnboarding"] != true {
+		t.Errorf("hasCompletedOnboarding dropped: %v", cfg["hasCompletedOnboarding"])
+	}
+
+	projects := cfg["projects"].(map[string]any)
+	a := projects["/home/user/projectA"].(map[string]any)
+	if a["hasTrustDialogAccepted"] != true {
+		t.Errorf("projectA.hasTrustDialogAccepted: %v", a["hasTrustDialogAccepted"])
+	}
+	if a["lastSessionId"] != "abc-123" {
+		t.Errorf("projectA.lastSessionId dropped: %v", a["lastSessionId"])
+	}
+	if a["customField"] != "preserved" {
+		t.Errorf("projectA.customField dropped: %v", a["customField"])
+	}
+	b := projects["/home/user/projectB"].(map[string]any)
+	if b["hasTrustDialogAccepted"] != false {
+		t.Errorf("projectB.hasTrustDialogAccepted: %v", b["hasTrustDialogAccepted"])
+	}
+	parentEntry := projects[parentDir].(map[string]any)
+	if parentEntry["hasTrustDialogAccepted"] != true {
+		t.Errorf("parentDir.hasTrustDialogAccepted: %v", parentEntry["hasTrustDialogAccepted"])
+	}
+}
+
+// Failure mode — tool != "claude" must be a no-op. Codex / Gemini sessions
+// would otherwise corrupt ~/.claude.json with paths they have no business
+// touching.
+func TestIssue1149_NonClaudeTool_IsNoop(t *testing.T) {
+	dir := t.TempDir()
+	claudeJSON := filepath.Join(dir, ".claude.json")
+	parentDir := filepath.Join(dir, "parent")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+
+	for _, tool := range []string{"codex", "gemini", "copilot", ""} {
+		if err := session.ApplyMultiRepoClaudeContext(tool, true, claudeJSON, parentDir, []string{"r1"}); err != nil {
+			t.Fatalf("ApplyMultiRepoClaudeContext(tool=%q): %v", tool, err)
+		}
+		if _, err := os.Stat(claudeJSON); !os.IsNotExist(err) {
+			t.Errorf("claude.json created for tool=%q, stat err=%v", tool, err)
+		}
+		if _, err := os.Stat(filepath.Join(parentDir, "CLAUDE.md")); !os.IsNotExist(err) {
+			t.Errorf("CLAUDE.md created for tool=%q, stat err=%v", tool, err)
+		}
+	}
+}
+
+// Idempotence — running the setup twice produces identical state. Worktree
+// recreation / session restart commonly re-invokes the path.
+func TestIssue1149_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	claudeJSON := filepath.Join(dir, ".claude.json")
+	parentDir := filepath.Join(dir, "multi-repo-worktrees", "branch-xx")
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	repos := []string{"a", "b"}
+
+	if err := session.ApplyMultiRepoClaudeContext("claude", true, claudeJSON, parentDir, repos); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	first, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatalf("read 1: %v", err)
+	}
+
+	if err := session.ApplyMultiRepoClaudeContext("claude", true, claudeJSON, parentDir, repos); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	second, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatalf("read 2: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Errorf("claude.json not idempotent.\nfirst:  %s\nsecond: %s", first, second)
+	}
+}

--- a/internal/session/claude_trust.go
+++ b/internal/session/claude_trust.go
@@ -1,0 +1,144 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// PreAcceptClaudeTrust adds a `projects[parentDir].hasTrustDialogAccepted = true`
+// entry to the Claude config at claudeJSONPath, preserving all existing
+// top-level fields and project entries.
+//
+// Why this exists (#1149): multi-repo worktree parent dirs live at synthetic
+// paths under ~/.agent-deck/multi-repo-worktrees/ with no .claude/ or .git
+// markers, so Claude Code prompts "do you trust this directory?" on every
+// launch. The trust state is keyed by the literal parentDir string in
+// ~/.claude.json — pre-seeding the entry skips the prompt the same way that
+// accepting it in the UI would.
+//
+// If claudeJSONPath does not exist, it is created with the new entry. If it
+// exists but is malformed, an error is returned without touching the file.
+func PreAcceptClaudeTrust(claudeJSONPath, parentDir string) error {
+	if claudeJSONPath == "" {
+		return fmt.Errorf("claudeJSONPath is empty")
+	}
+	if parentDir == "" {
+		return fmt.Errorf("parentDir is empty")
+	}
+
+	cfg := map[string]any{}
+	if data, err := os.ReadFile(claudeJSONPath); err == nil {
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &cfg); err != nil {
+				return fmt.Errorf("parse %s: %w", claudeJSONPath, err)
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", claudeJSONPath, err)
+	}
+
+	projects, _ := cfg["projects"].(map[string]any)
+	if projects == nil {
+		projects = map[string]any{}
+	}
+	entry, _ := projects[parentDir].(map[string]any)
+	if entry == nil {
+		entry = map[string]any{}
+	}
+	entry["hasTrustDialogAccepted"] = true
+	projects[parentDir] = entry
+	cfg["projects"] = projects
+
+	if err := os.MkdirAll(filepath.Dir(claudeJSONPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir parent of %s: %w", claudeJSONPath, err)
+	}
+
+	out, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal claude config: %w", err)
+	}
+	tmp := claudeJSONPath + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, claudeJSONPath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename %s: %w", claudeJSONPath, err)
+	}
+	return nil
+}
+
+// WriteMultiRepoParentClaudeMD writes a CLAUDE.md to parentDir telling Claude
+// that this is a multi-repo session and which subdirectories contain real
+// repos. The first entry in repoNames becomes the default working
+// subdirectory recommendation.
+//
+// Why (#1149): without this hint Claude treats parentDir as a single project
+// and runs build/test commands at the parent — where there is no makefile,
+// no package.json, no .git — so every project-specific command fails until
+// the user manually cds in. The generated file is plain markdown that Claude
+// reads on session start.
+func WriteMultiRepoParentClaudeMD(parentDir string, repoNames []string) error {
+	if parentDir == "" {
+		return fmt.Errorf("parentDir is empty")
+	}
+	if len(repoNames) == 0 {
+		return fmt.Errorf("repoNames is empty")
+	}
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", parentDir, err)
+	}
+
+	var b strings.Builder
+	b.WriteString("# Multi-Repo Session\n\n")
+	b.WriteString("This directory is an agent-deck multi-repo worktree parent. ")
+	b.WriteString("It contains one subdirectory per project repository — there is no source code at this level.\n\n")
+	b.WriteString("## Repositories\n\n")
+	for _, name := range repoNames {
+		fmt.Fprintf(&b, "- `%s/`\n", name)
+	}
+	b.WriteString("\n## Working directory\n\n")
+	fmt.Fprintf(&b, "Default to `%s/` for project-specific commands (build, test, run). ", repoNames[0])
+	b.WriteString("`cd` into the appropriate repository subdirectory before invoking `make`, `npm`, `cargo`, etc. — ")
+	b.WriteString("each repo has its own toolchain configuration.\n")
+
+	mdPath := filepath.Join(parentDir, "CLAUDE.md")
+	tmp := mdPath + ".tmp"
+	if err := os.WriteFile(tmp, []byte(b.String()), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, mdPath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename %s: %w", mdPath, err)
+	}
+	return nil
+}
+
+// ApplyMultiRepoClaudeContext is the single integration point called from
+// home.go after creating a multi-repo parent dir. It pre-accepts the trust
+// dialog and writes a parent CLAUDE.md describing the layout — but only when
+// tool == "claude" AND multiRepoEnabled is true. For any other combination
+// it is a no-op, leaving claudeJSONPath untouched.
+//
+// repoNames is the list of subdirectory names inside parentDir (one per
+// repo). The caller is responsible for deriving them from the multi-repo
+// worktree result (see DeduplicateDirnames + CreateMultiRepoWorktrees).
+func ApplyMultiRepoClaudeContext(tool string, multiRepoEnabled bool, claudeJSONPath, parentDir string, repoNames []string) error {
+	if tool != "claude" || !multiRepoEnabled {
+		return nil
+	}
+	if err := PreAcceptClaudeTrust(claudeJSONPath, parentDir); err != nil {
+		return fmt.Errorf("pre-accept trust: %w", err)
+	}
+	// Sort for stable output across runs (map iteration in callers).
+	sorted := append([]string(nil), repoNames...)
+	sort.Strings(sorted)
+	if err := WriteMultiRepoParentClaudeMD(parentDir, sorted); err != nil {
+		return fmt.Errorf("write parent CLAUDE.md: %w", err)
+	}
+	return nil
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8711,6 +8711,22 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			if inst.GetTmuxSession() != nil {
 				inst.GetTmuxSession().WorkDir = inst.MultiRepoTempDir
 			}
+
+			// Pre-accept the Claude trust dialog and emit a parent CLAUDE.md
+			// describing the layout (#1149, credit @spawnia). Skips silently
+			// for non-claude tools or empty repo lists. Failures are logged
+			// but non-fatal — the session can still launch; user just sees
+			// the usual trust prompt.
+			repoNames := make([]string, 0, len(inst.AllProjectPaths()))
+			for _, p := range inst.AllProjectPaths() {
+				repoNames = append(repoNames, filepath.Base(p))
+			}
+			if ctxErr := session.ApplyMultiRepoClaudeContext(
+				inst.Tool, inst.MultiRepoEnabled,
+				session.GetUserMCPRootPath(), inst.MultiRepoTempDir, repoNames,
+			); ctxErr != nil {
+				uiLog.Warn("multi_repo_claude_context", slog.String("error", ctxErr.Error()))
+			}
 		}
 
 		if parentSessionID != "" {


### PR DESCRIPTION
## Summary

Implements @spawnia's proposal from #1149: when agent-deck spawns a Claude session whose working directory is a multi-repo worktree parent (e.g. `~/.agent-deck/multi-repo-worktrees/feature-x-abcd1234/`), we now:

1. **Pre-accept the trust dialog.** Write `projects[parentDir].hasTrustDialogAccepted = true` into `~/.claude.json`, preserving every other top-level field and existing project entry. Round-tripped via `map[string]any` (not a typed struct) so unrelated keys don't get dropped.
2. **Emit a parent CLAUDE.md.** Tell Claude that the parent dir is a multi-repo container, list the repo subdirectories, and recommend the first as the default cwd for build / test commands.

Both halves are guarded by `tool == "claude" && multiRepoEnabled`, so single-repo and non-claude sessions are unaffected.

Credit: @spawnia for the issue, the spec, and the implementation outline.

## Surfaces

| Surface          | Test file                                                         | Notes                                                                                           |
|------------------|-------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
| **CLI / session** | `cmd/agent-deck/issue1149_multirepo_trust_test.go` (6 tests)      | Happy path, multi-repo CLAUDE.md enumeration, single-repo no-op, existing entries preserved, non-claude no-op, idempotence |
| **TUI**          | _N/A — feature does not surface a key binding, panel, or status_  | Trust + CLAUDE.md are side effects of session creation, not user-facing TUI controls            |
| **Web UI**       | _N/A — Web UI does not handle session creation today_              | Session creation lives in `internal/ui/home.go` (TUI); no Web counterpart exists yet            |
| **Remote**       | _N/A — multi-repo sessions are LocalSession only today_           | `RemoteSession` does not implement multi-repo worktrees; this fix piggybacks on Local           |
| **Persistence**  | _N/A — no new fields on Session / Group / MCP records_            | Trust state lives in `~/.claude.json`, not agent-deck's statedb                                 |
| **Cross-platform** | _N/A — path handling is `filepath`-based; no OS branches_       | Helper uses `filepath.Join` / `filepath.Dir` / atomic temp-file rename, all stdlib              |

## Files

- `internal/session/claude_trust.go` (new) — `PreAcceptClaudeTrust`, `WriteMultiRepoParentClaudeMD`, `ApplyMultiRepoClaudeContext` (integration guard).
- `internal/ui/home.go` — call `session.ApplyMultiRepoClaudeContext(...)` inside the multi-repo branch, after creating the parent dir and before `inst.Start()`.
- `cmd/agent-deck/issue1149_multirepo_trust_test.go` (new) — 6 unit tests.

## Test plan

- [x] All 6 `Issue1149*` tests pass: `go test -race -run Issue1149 ./cmd/agent-deck/...`
- [x] Full race suite green: `go test -race -count=1 -timeout 15m ./...`
- [x] Lint clean: `golangci-lint run --timeout=5m --issues-exit-code=1 ./...`
- [x] Vuln clean: `govulncheck ./...`
- [ ] Manual: spawn a multi-repo claude session, confirm no trust prompt + `make` runs in the first repo's cwd

Closes #1149.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-repo Claude support now automatically pre-accepts trust dialogs and applies Claude context during session initialization
  * Automatically generates parent directory documentation identifying multi-repo layouts and listing all repository subdirectories
  * Configuration files are safely updated with atomic operations while preserving existing settings

* **Tests**
  * Added comprehensive regression test suite verifying multi-repo Claude context application, including idempotence, preservation of existing configurations, and edge-case handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->