### PR TITLE
feat(multi-repo): enhance Claude context with @path imports and permission settings

### DIFF
--- a/cmd/agent-deck/issue1149_multirepo_trust_test.go
+++ b/cmd/agent-deck/issue1149_multirepo_trust_test.go
@@ -71,7 +71,7 @@ func TestIssue1149_MultiRepoClaudeSession_PreAcceptsTrustAndWritesParentMD(t *te
 	}
 
 	// Parent CLAUDE.md created and lists every repo subdir.
-	mdBytes, err := os.ReadFile(filepath.Join(parentDir, "CLAUDE.md"))
+	mdBytes, err := os.ReadFile(filepath.Join(parentDir, ".claude", "CLAUDE.md"))
 	if err != nil {
 		t.Fatalf("read CLAUDE.md: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestIssue1149_ParentClaudeMD_ListsAllRepoSubdirs(t *testing.T) {
 		t.Fatalf("ApplyMultiRepoClaudeContext: %v", err)
 	}
 
-	md, err := os.ReadFile(filepath.Join(parentDir, "CLAUDE.md"))
+	md, err := os.ReadFile(filepath.Join(parentDir, ".claude", "CLAUDE.md"))
 	if err != nil {
 		t.Fatalf("read CLAUDE.md: %v", err)
 	}
@@ -137,8 +137,8 @@ func TestIssue1149_SingleRepoSession_DoesNotModifyClaudeJSON(t *testing.T) {
 	if string(got) != original {
 		t.Errorf("claude.json modified for single-repo session.\nwant:\n%s\ngot:\n%s", original, got)
 	}
-	if _, err := os.Stat(filepath.Join(parentPath, "CLAUDE.md")); !os.IsNotExist(err) {
-		t.Errorf("CLAUDE.md should not exist for single-repo session, stat err=%v", err)
+	if _, err := os.Stat(filepath.Join(parentPath, ".claude", "CLAUDE.md")); !os.IsNotExist(err) {
+		t.Errorf(".claude/CLAUDE.md should not exist for single-repo session, stat err=%v", err)
 	}
 }
 
@@ -231,7 +231,7 @@ func TestIssue1149_NonClaudeTool_IsNoop(t *testing.T) {
 		if _, err := os.Stat(claudeJSON); !os.IsNotExist(err) {
 			t.Errorf("claude.json created for tool=%q, stat err=%v", tool, err)
 		}
-		if _, err := os.Stat(filepath.Join(parentDir, "CLAUDE.md")); !os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(parentDir, ".claude", "CLAUDE.md")); !os.IsNotExist(err) {
 			t.Errorf("CLAUDE.md created for tool=%q, stat err=%v", tool, err)
 		}
 	}
@@ -266,5 +266,178 @@ func TestIssue1149_Idempotent(t *testing.T) {
 
 	if string(first) != string(second) {
 		t.Errorf("claude.json not idempotent.\nfirst:  %s\nsecond: %s", first, second)
+	}
+}
+
+// @path imports — CLAUDE.md includes @path references for child projects that
+// have their own CLAUDE.md files.
+func TestIssue1149_ClaudeMD_IncludesAtPathImports(t *testing.T) {
+	parentDir := t.TempDir()
+	claudeJSON := filepath.Join(parentDir, ".claude.json")
+
+	// Create child repos with CLAUDE.md in different locations.
+	// repo-a uses .claude/CLAUDE.md
+	if err := os.MkdirAll(filepath.Join(parentDir, "repo-a", ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parentDir, "repo-a", ".claude", "CLAUDE.md"), []byte("# Repo A"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// repo-b uses root CLAUDE.md
+	if err := os.MkdirAll(filepath.Join(parentDir, "repo-b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parentDir, "repo-b", "CLAUDE.md"), []byte("# Repo B"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// repo-c has no CLAUDE.md
+	if err := os.MkdirAll(filepath.Join(parentDir, "repo-c"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repos := []string{"repo-a", "repo-b", "repo-c"}
+	if err := session.ApplyMultiRepoClaudeContext("claude", true, claudeJSON, parentDir, repos); err != nil {
+		t.Fatalf("ApplyMultiRepoClaudeContext: %v", err)
+	}
+
+	md, err := os.ReadFile(filepath.Join(parentDir, ".claude", "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read .claude/CLAUDE.md: %v", err)
+	}
+	content := string(md)
+
+	// .claude/CLAUDE.md is preferred over root CLAUDE.md
+	if !strings.Contains(content, "@repo-a/.claude/CLAUDE.md") {
+		t.Errorf("missing @path import for repo-a (.claude/CLAUDE.md); got:\n%s", content)
+	}
+	// Falls back to root CLAUDE.md
+	if !strings.Contains(content, "@repo-b/CLAUDE.md") {
+		t.Errorf("missing @path import for repo-b (root CLAUDE.md); got:\n%s", content)
+	}
+	// No import for repo without CLAUDE.md
+	if strings.Contains(content, "@repo-c") {
+		t.Errorf("should not have @path import for repo-c (no CLAUDE.md); got:\n%s", content)
+	}
+}
+
+// Command scoping instructions — CLAUDE.md includes git -C and cd && guidance.
+func TestIssue1149_ClaudeMD_IncludesScopingInstructions(t *testing.T) {
+	parentDir := t.TempDir()
+	claudeJSON := filepath.Join(parentDir, ".claude.json")
+
+	if err := session.ApplyMultiRepoClaudeContext("claude", true, claudeJSON, parentDir, []string{"proj"}); err != nil {
+		t.Fatalf("ApplyMultiRepoClaudeContext: %v", err)
+	}
+
+	md, err := os.ReadFile(filepath.Join(parentDir, ".claude", "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read .claude/CLAUDE.md: %v", err)
+	}
+	content := string(md)
+
+	if !strings.Contains(content, "git -C") {
+		t.Errorf("missing git -C scoping instruction; got:\n%s", content)
+	}
+	if !strings.Contains(content, "cd <project-dir> &&") {
+		t.Errorf("missing cd && scoping instruction; got:\n%s", content)
+	}
+}
+
+// Settings.json — intersection of allow, union of deny and ask.
+func TestIssue1149_SettingsJSON_PermissionIntersection(t *testing.T) {
+	parentDir := t.TempDir()
+	claudeJSON := filepath.Join(parentDir, ".claude.json")
+
+	// repo-a allows make and yarn, denies db:drop
+	repoA := filepath.Join(parentDir, "repo-a", ".claude")
+	if err := os.MkdirAll(repoA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoA, "settings.json"), []byte(`{
+		"permissions": {
+			"allow": ["Bash(make:*)", "Bash(yarn run:*)"],
+			"deny": ["Bash(php artisan db:drop:*)"],
+			"ask": ["Bash(docker compose exec:*)"]
+		}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// repo-b allows make and composer, denies deploy
+	repoB := filepath.Join(parentDir, "repo-b", ".claude")
+	if err := os.MkdirAll(repoB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoB, "settings.json"), []byte(`{
+		"permissions": {
+			"allow": ["Bash(make:*)", "Bash(composer:*)"],
+			"deny": ["Bash(make deploy:*)"],
+			"ask": ["Bash(php artisan migrate:*)"]
+		}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos := []string{"repo-a", "repo-b"}
+	if err := session.ApplyMultiRepoClaudeContext("claude", true, claudeJSON, parentDir, repos); err != nil {
+		t.Fatalf("ApplyMultiRepoClaudeContext: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(parentDir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read .claude/settings.json: %v", err)
+	}
+
+	var settings struct {
+		Permissions struct {
+			Allow []string `json:"allow"`
+			Deny  []string `json:"deny"`
+			Ask   []string `json:"ask"`
+		} `json:"permissions"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal settings.json: %v", err)
+	}
+
+	// Intersection of allow: only Bash(make:*) is in both
+	if len(settings.Permissions.Allow) != 1 || settings.Permissions.Allow[0] != "Bash(make:*)" {
+		t.Errorf("allow should be intersection [Bash(make:*)], got: %v", settings.Permissions.Allow)
+	}
+
+	// Union of deny: both entries
+	denySet := map[string]bool{}
+	for _, d := range settings.Permissions.Deny {
+		denySet[d] = true
+	}
+	if !denySet["Bash(php artisan db:drop:*)"] || !denySet["Bash(make deploy:*)"] {
+		t.Errorf("deny should be union of both projects, got: %v", settings.Permissions.Deny)
+	}
+
+	// Union of ask: both entries
+	askSet := map[string]bool{}
+	for _, a := range settings.Permissions.Ask {
+		askSet[a] = true
+	}
+	if !askSet["Bash(docker compose exec:*)"] || !askSet["Bash(php artisan migrate:*)"] {
+		t.Errorf("ask should be union of both projects, got: %v", settings.Permissions.Ask)
+	}
+}
+
+// Settings.json not written when no child has settings.
+func TestIssue1149_SettingsJSON_NotWrittenWhenNoChildSettings(t *testing.T) {
+	parentDir := t.TempDir()
+	claudeJSON := filepath.Join(parentDir, ".claude.json")
+
+	// Create repos without .claude/settings.json
+	if err := os.MkdirAll(filepath.Join(parentDir, "repo-x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := session.ApplyMultiRepoClaudeContext("claude", true, claudeJSON, parentDir, []string{"repo-x"}); err != nil {
+		t.Fatalf("ApplyMultiRepoClaudeContext: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(parentDir, ".claude", "settings.json")); !os.IsNotExist(err) {
+		t.Errorf("settings.json should not exist when no child has settings, stat err=%v", err)
 	}
 }

--- a/internal/session/claude_trust.go
+++ b/internal/session/claude_trust.go
@@ -72,10 +72,10 @@ func PreAcceptClaudeTrust(claudeJSONPath, parentDir string) error {
 	return nil
 }
 
-// WriteMultiRepoParentClaudeMD writes a CLAUDE.md to parentDir telling Claude
-// that this is a multi-repo session and which subdirectories contain real
-// repos. The first entry in repoNames becomes the default working
-// subdirectory recommendation.
+// WriteMultiRepoParentClaudeMD writes a .claude/CLAUDE.md to parentDir telling
+// Claude that this is a multi-repo session, which subdirectories contain real
+// repos, how to scope commands, and @path imports for each child project's
+// CLAUDE.md (front-loading full project context at session start).
 //
 // Why (#1149): without this hint Claude treats parentDir as a single project
 // and runs build/test commands at the parent — where there is no makefile,
@@ -89,8 +89,10 @@ func WriteMultiRepoParentClaudeMD(parentDir string, repoNames []string) error {
 	if len(repoNames) == 0 {
 		return fmt.Errorf("repoNames is empty")
 	}
-	if err := os.MkdirAll(parentDir, 0o755); err != nil {
-		return fmt.Errorf("mkdir %s: %w", parentDir, err)
+
+	claudeDir := filepath.Join(parentDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", claudeDir, err)
 	}
 
 	var b strings.Builder
@@ -101,12 +103,27 @@ func WriteMultiRepoParentClaudeMD(parentDir string, repoNames []string) error {
 	for _, name := range repoNames {
 		fmt.Fprintf(&b, "- `%s/`\n", name)
 	}
-	b.WriteString("\n## Working directory\n\n")
-	fmt.Fprintf(&b, "Default to `%s/` for project-specific commands (build, test, run). ", repoNames[0])
-	b.WriteString("`cd` into the appropriate repository subdirectory before invoking `make`, `npm`, `cargo`, etc. — ")
-	b.WriteString("each repo has its own toolchain configuration.\n")
+	b.WriteString("\n## Command scoping\n\n")
+	b.WriteString("Every Bash call must be scoped to its target project:\n\n")
+	b.WriteString("- Git operations: `git -C <project-dir> <command>`\n")
+	b.WriteString("- Non-git commands: `cd <project-dir> && <command>`\n")
 
-	mdPath := filepath.Join(parentDir, "CLAUDE.md")
+	// @path imports for child CLAUDE.md files.
+	var imports []string
+	for _, name := range repoNames {
+		mdPath := findChildClaudeMD(parentDir, name)
+		if mdPath != "" {
+			imports = append(imports, mdPath)
+		}
+	}
+	if len(imports) > 0 {
+		b.WriteString("\n## Project instructions\n\n")
+		for _, imp := range imports {
+			fmt.Fprintf(&b, "@%s\n", imp)
+		}
+	}
+
+	mdPath := filepath.Join(claudeDir, "CLAUDE.md")
 	tmp := mdPath + ".tmp"
 	if err := os.WriteFile(tmp, []byte(b.String()), 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", tmp, err)
@@ -115,14 +132,174 @@ func WriteMultiRepoParentClaudeMD(parentDir string, repoNames []string) error {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("rename %s: %w", mdPath, err)
 	}
+
+	// Remove legacy root-level CLAUDE.md from initial #1155 implementation.
+	_ = os.Remove(filepath.Join(parentDir, "CLAUDE.md"))
+
 	return nil
+}
+
+// findChildClaudeMD returns the relative path (from parentDir) to the child
+// project's CLAUDE.md. Checks .claude/CLAUDE.md first, then root CLAUDE.md.
+// Returns "" if neither exists.
+func findChildClaudeMD(parentDir, repoName string) string {
+	candidates := []string{
+		filepath.Join(repoName, ".claude", "CLAUDE.md"),
+		filepath.Join(repoName, "CLAUDE.md"),
+	}
+	for _, rel := range candidates {
+		if _, err := os.Stat(filepath.Join(parentDir, rel)); err == nil {
+			return rel
+		}
+	}
+	return ""
+}
+
+// WriteMultiRepoParentSettings writes a .claude/settings.json to parentDir
+// containing the intersection of all child projects' permissions.allow and the
+// union of permissions.deny and permissions.ask.
+//
+// Intersection for allow ensures no command is auto-approved in the parent that
+// would be unsafe in any child project. Union for deny/ask ensures safety
+// boundaries from any child are always enforced.
+func WriteMultiRepoParentSettings(parentDir string, repoNames []string) error {
+	if parentDir == "" {
+		return fmt.Errorf("parentDir is empty")
+	}
+	if len(repoNames) == 0 {
+		return fmt.Errorf("repoNames is empty")
+	}
+
+	claudeDir := filepath.Join(parentDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", claudeDir, err)
+	}
+
+	type permissions struct {
+		Allow []string `json:"allow,omitempty"`
+		Deny  []string `json:"deny,omitempty"`
+		Ask   []string `json:"ask,omitempty"`
+	}
+	type settingsFile struct {
+		Permissions *permissions `json:"permissions,omitempty"`
+	}
+
+	var allAllow []map[string]bool
+	denySet := map[string]bool{}
+	askSet := map[string]bool{}
+
+	for _, name := range repoNames {
+		childSettings := findChildSettings(parentDir, name)
+		if childSettings == "" {
+			// If any child has no settings, intersection of allow is empty.
+			allAllow = append(allAllow, map[string]bool{})
+			continue
+		}
+
+		data, err := os.ReadFile(childSettings)
+		if err != nil {
+			allAllow = append(allAllow, map[string]bool{})
+			continue
+		}
+
+		var sf settingsFile
+		if err := json.Unmarshal(data, &sf); err != nil || sf.Permissions == nil {
+			allAllow = append(allAllow, map[string]bool{})
+			continue
+		}
+
+		allowSet := map[string]bool{}
+		for _, a := range sf.Permissions.Allow {
+			allowSet[a] = true
+		}
+		allAllow = append(allAllow, allowSet)
+
+		for _, d := range sf.Permissions.Deny {
+			denySet[d] = true
+		}
+		for _, a := range sf.Permissions.Ask {
+			askSet[a] = true
+		}
+	}
+
+	// Intersection of allow: only entries present in ALL child projects.
+	var allowIntersection []string
+	if len(allAllow) > 0 {
+		for entry := range allAllow[0] {
+			inAll := true
+			for i := 1; i < len(allAllow); i++ {
+				if !allAllow[i][entry] {
+					inAll = false
+					break
+				}
+			}
+			if inAll {
+				allowIntersection = append(allowIntersection, entry)
+			}
+		}
+	}
+	sort.Strings(allowIntersection)
+
+	var denyList []string
+	for d := range denySet {
+		denyList = append(denyList, d)
+	}
+	sort.Strings(denyList)
+
+	var askList []string
+	for a := range askSet {
+		askList = append(askList, a)
+	}
+	sort.Strings(askList)
+
+	// Only write if there's something to configure.
+	if len(allowIntersection) == 0 && len(denyList) == 0 && len(askList) == 0 {
+		return nil
+	}
+
+	sf := settingsFile{
+		Permissions: &permissions{
+			Allow: allowIntersection,
+			Deny:  denyList,
+			Ask:   askList,
+		},
+	}
+
+	out, err := json.MarshalIndent(sf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	tmp := settingsPath + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, settingsPath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename %s: %w", settingsPath, err)
+	}
+	return nil
+}
+
+// findChildSettings returns the absolute path to a child project's
+// .claude/settings.json, or "" if it doesn't exist.
+func findChildSettings(parentDir, repoName string) string {
+	p := filepath.Join(parentDir, repoName, ".claude", "settings.json")
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	return ""
 }
 
 // ApplyMultiRepoClaudeContext is the single integration point called from
 // home.go after creating a multi-repo parent dir. It pre-accepts the trust
-// dialog and writes a parent CLAUDE.md describing the layout — but only when
-// tool == "claude" AND multiRepoEnabled is true. For any other combination
-// it is a no-op, leaving claudeJSONPath untouched.
+// dialog, writes a parent .claude/CLAUDE.md describing the layout (with @path
+// imports for child project instructions), and generates a .claude/settings.json
+// with the intersection of allowed permissions across all child projects.
+//
+// Only acts when tool == "claude" AND multiRepoEnabled is true. For any other
+// combination it is a no-op, leaving claudeJSONPath untouched.
 //
 // repoNames is the list of subdirectory names inside parentDir (one per
 // repo). The caller is responsible for deriving them from the multi-repo
@@ -139,6 +316,9 @@ func ApplyMultiRepoClaudeContext(tool string, multiRepoEnabled bool, claudeJSONP
 	sort.Strings(sorted)
 	if err := WriteMultiRepoParentClaudeMD(parentDir, sorted); err != nil {
 		return fmt.Errorf("write parent CLAUDE.md: %w", err)
+	}
+	if err := WriteMultiRepoParentSettings(parentDir, sorted); err != nil {
+		return fmt.Errorf("write parent settings.json: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Follow-up to #1155 — enhances the multi-repo Claude context generation to address remaining gaps from the design in #1149:

- **Move CLAUDE.md to `.claude/CLAUDE.md`** — standard location, groups with settings.json
- **Add `@path` imports** for each child project's CLAUDE.md, front-loading full project context at session start (detects `.claude/CLAUDE.md` first, falls back to root `CLAUDE.md`)
- **Add command scoping instructions** — `git -C <project-dir>` for git, `cd <project-dir> &&` for non-git
- **Generate `.claude/settings.json`** with permission intersection (`allow`) and union (`deny`, `ask`) across all child projects
- **Remove legacy root `CLAUDE.md`** left by #1155

### Why @path imports

Multi-repo sessions require manually selecting projects, so the count is naturally limited. User intent is overarching cross-repo work — context from all repos is needed from the start. Without front-loading, Claude lacks project conventions until it happens to read files in that subdirectory.

### Why permission intersection

Only commands that appear in ALL child `.claude/settings.json` files are auto-allowed in the parent. This ensures no command is approved in the parent that would be unsafe in any child project. `deny` and `ask` use union — safety boundaries from any child are always enforced.

## Test plan

- [x] All `Issue1149*` tests pass: `go test -race -run Issue1149 ./cmd/agent-deck/...`
- [x] Full build: `go build ./...`
- [x] Lint clean: `golangci-lint run --timeout=5m ./internal/session/ ./cmd/agent-deck/`
- [ ] Manual: spawn a multi-repo claude session with two projects that have `.claude/CLAUDE.md` and `.claude/settings.json`, verify @path imports appear and permission intersection is correct

Relates to #1149.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Moved parent Claude configuration files from project root to `.claude/` directory for better organization.
  * Enhanced multi-repo context generation with command scoping instructions and automatic `@path` imports.
  * Implemented proper permission aggregation across child repositories in settings files.

* **Tests**
  * Added integration test coverage for multi-repo Claude context behavior and settings generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->