### PR TITLE
fix(web): prevent hidden terminal tab from shrinking tmux window

### DIFF
--- a/internal/web/static/app/TerminalPanel.js
+++ b/internal/web/static/app/TerminalPanel.js
@@ -168,7 +168,9 @@ export function TerminalPanel() {
       }
     }
 
-    fitAddon.fit()
+    if (container.offsetWidth && container.offsetHeight) {
+      fitAddon.fit()
+    }
 
     // PERF-E: single AbortController for every listener registered in this
     // effect. Calling controller.abort() in the cleanup detaches all 8
@@ -220,9 +222,10 @@ export function TerminalPanel() {
     function scheduleFitAndResize(delayMs) {
       clearTimeout(resizeTimer)
       resizeTimer = setTimeout(() => {
+        if (!container.offsetWidth || !container.offsetHeight) return
         fitAddon.fit()
         const { cols, rows } = terminal
-        if (cols > 1 && rows > 0 && ctx.ws && ctx.ws.readyState === WebSocket.OPEN && ctx.terminalAttached) {
+        if (cols >= 10 && rows >= 3 && ctx.ws && ctx.ws.readyState === WebSocket.OPEN && ctx.terminalAttached) {
           ctx.ws.send(JSON.stringify({ type: 'resize', cols, rows }))
         }
       }, delayMs)

--- a/internal/web/terminal_bridge.go
+++ b/internal/web/terminal_bridge.go
@@ -165,6 +165,9 @@ func (b *tmuxPTYBridge) Resize(cols, rows int) error {
 	if cols <= 0 || rows <= 0 {
 		return fmt.Errorf("invalid dimensions: cols=%d rows=%d", cols, rows)
 	}
+	if cols < 10 || rows < 3 {
+		return fmt.Errorf("dimensions too small for a usable terminal: cols=%d rows=%d", cols, rows)
+	}
 
 	b.ptmxMu.RLock()
 	defer b.ptmxMu.RUnlock()

--- a/internal/web/terminal_bridge_test.go
+++ b/internal/web/terminal_bridge_test.go
@@ -69,6 +69,64 @@ func TestTmuxAttachCommand_SocketNameOverridesEnv(t *testing.T) {
 	}
 }
 
+// TestResize_RejectsNonsensicalDimensions: the web bridge must reject resize
+// requests with dimensions too small to be a real terminal. When xterm.js
+// calls fitAddon.fit() on a display:none container, it computes cols≈2 rows≈1
+// which, if forwarded to the PTY, shrinks the tmux window via window-size=largest
+// and corrupts all session output until a session restart.
+func TestResize_RejectsNonsensicalDimensions(t *testing.T) {
+	bridge := &tmuxPTYBridge{}
+
+	cases := []struct {
+		name string
+		cols int
+		rows int
+	}{
+		{"cols=2 rows=1 (hidden container)", 2, 1},
+		{"cols=5 rows=2 (still too small)", 5, 2},
+		{"cols=9 rows=10 (just below col minimum)", 9, 10},
+		{"cols=80 rows=2 (just below row minimum)", 80, 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := bridge.Resize(tc.cols, tc.rows)
+			if err == nil {
+				t.Fatalf("Resize(%d, %d) should reject nonsensical dimensions", tc.cols, tc.rows)
+			}
+			if !strings.Contains(err.Error(), "too small") {
+				t.Fatalf("expected 'too small' error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestResize_AcceptsReasonableDimensions(t *testing.T) {
+	bridge := &tmuxPTYBridge{}
+
+	cases := []struct {
+		name string
+		cols int
+		rows int
+	}{
+		{"minimum acceptable", 10, 3},
+		{"typical terminal", 120, 40},
+		{"wide monitor", 300, 80},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := bridge.Resize(tc.cols, tc.rows)
+			if err == nil {
+				return
+			}
+			if strings.Contains(err.Error(), "too small") {
+				t.Fatalf("Resize(%d, %d) should not reject reasonable dimensions", tc.cols, tc.rows)
+			}
+		})
+	}
+}
+
 // TestTmuxAttachCommand_WhitespaceSocketNameFallsBackToEnv: the same
 // defensive trim we use elsewhere. A typo like `socket_name = "   "` in
 // config must not send the web bridge to a phantom server named "   " —


### PR DESCRIPTION
When the web UI's active tab (persisted in localStorage) is not
"terminal", the TerminalPane container has display:none. FitAddon
computed cols≈2 on the zero-size container and sent that resize to the
server, which forwarded it to the PTY. With window-size=largest and the
web bridge being the only non-control-mode client, tmux shrank the
window to 2 columns — corrupting all session output until restart.

Three-layer fix:
- Skip fitAddon.fit() when container has zero dimensions
- Raise client-side resize guard from cols>1 to cols>=10 && rows>=3
- Server rejects resize requests below the same minimum

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal panel initialization to prevent sizing operations when the container layout is not yet ready, ensuring more stable terminal startup
  * Added validation checks to reject terminal resize requests with dimensions below acceptable minimums, improving operational stability

* **Tests**
  * Added unit tests for terminal dimension validation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->