### PR TITLE
fix(conductor): detect PEP 668 and surface actionable error from installPythonDeps

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -564,7 +565,7 @@ func handleConductorSetup(profile string, args []string) {
 			fmt.Println("Installing bridge...")
 		}
 
-		installPythonDeps()
+		depsInstalled := installPythonDeps()
 
 		if err := session.InstallBridgeScript(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error installing bridge.py: %v\n", err)
@@ -574,16 +575,27 @@ func handleConductorSetup(profile string, args []string) {
 			fmt.Println("[ok] bridge.py installed")
 		}
 
-		// Install daemon (platform-aware: launchd on macOS, systemd on Linux)
-		daemonPath, err := session.InstallBridgeDaemon()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to install bridge daemon: %v\n", err)
-			condDir, _ := session.ConductorDir()
-			fmt.Fprintf(os.Stderr, "Run manually: python3 %s/bridge.py\n", condDir)
-		} else {
-			plistPath = daemonPath
+		if !depsInstalled {
+			// Don't register a launchd job that will crash-loop silently on
+			// the missing imports. installPythonDeps() already printed an
+			// actionable error block; surface a one-liner here too so the
+			// final setup summary visibly mentions the gap.
 			if !*jsonOutput {
-				fmt.Println("[ok] Bridge daemon loaded")
+				fmt.Println("[skip] Bridge daemon NOT installed (Python deps unavailable — see error above)")
+				fmt.Println("       Re-run `agent-deck conductor setup <name>` after installing deps.")
+			}
+		} else {
+			// Install daemon (platform-aware: launchd on macOS, systemd on Linux)
+			daemonPath, err := session.InstallBridgeDaemon()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to install bridge daemon: %v\n", err)
+				condDir, _ := session.ConductorDir()
+				fmt.Fprintf(os.Stderr, "Run manually: python3 %s/bridge.py\n", condDir)
+			} else {
+				plistPath = daemonPath
+				if !*jsonOutput {
+					fmt.Println("[ok] Bridge daemon loaded")
+				}
 			}
 		}
 	}
@@ -1147,11 +1159,120 @@ func handleConductorList(profile string, args []string) {
 	fmt.Println()
 }
 
-// installPythonDeps installs Python dependencies for the bridge
-func installPythonDeps() {
+// pipFailureKind classifies why a `pip install` invocation failed, so
+// installPythonDeps() can emit an actionable error rather than the historical
+// single-line stderr note that silently masked the PEP 668 case.
+type pipFailureKind string
+
+const (
+	pipFailureNone   pipFailureKind = ""
+	pipFailurePEP668 pipFailureKind = "pep668"
+	pipFailureOther  pipFailureKind = "other"
+)
+
+// classifyPipFailure inspects captured pip stderr and returns the failure
+// kind. Empty stderr maps to pipFailureNone (pip succeeded or wasn't run).
+// The canonical PEP 668 marker is the literal phrase
+// `externally-managed-environment`, emitted by pip on any interpreter whose
+// stdlib ships an EXTERNALLY-MANAGED marker file (Homebrew, Debian/Ubuntu
+// system Python).
+func classifyPipFailure(stderr string) pipFailureKind {
+	if stderr == "" {
+		return pipFailureNone
+	}
+	if strings.Contains(stderr, "externally-managed-environment") {
+		return pipFailurePEP668
+	}
+	return pipFailureOther
+}
+
+// pipFailureDiagnostic carries everything the formatter needs to render an
+// actionable error block. Kept as a plain struct (no methods, no constructor)
+// so tests can build instances directly.
+type pipFailureDiagnostic struct {
+	Kind            pipFailureKind
+	InterpreterPath string   // sys.executable; empty if probing failed
+	InterpreterVer  string   // sys.version.split()[0]; empty if probing failed
+	Packages        []string // packages pip was asked to install
+	HasMise         bool     // mise binary on PATH at install time
+	RawStderr       string   // captured stderr from the failing pip call
+}
+
+// formatPipFailureMessage renders the user-facing error block. The PEP 668
+// path lists three remediation options and labels exactly ONE as
+// "recommended" — mise when available on PATH, otherwise the venv option.
+// The Other path surfaces the raw pip stderr and a manual install command,
+// without speculating on the cause.
+func formatPipFailureMessage(d pipFailureDiagnostic) string {
+	pkgs := strings.Join(d.Packages, " ")
+
+	if d.Kind != pipFailurePEP668 {
+		var b strings.Builder
+		b.WriteString("⚠  Python dependencies install failed.\n\n")
+		if d.RawStderr != "" {
+			b.WriteString("   pip stderr:\n")
+			for _, line := range strings.Split(strings.TrimRight(d.RawStderr, "\n"), "\n") {
+				b.WriteString("     ")
+				b.WriteString(line)
+				b.WriteString("\n")
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("   Re-run `agent-deck conductor setup <name>`, or install manually:\n")
+		fmt.Fprintf(&b, "     pip3 install %s\n", pkgs)
+		return b.String()
+	}
+
+	pyDisplay := d.InterpreterPath
+	if d.InterpreterVer != "" {
+		pyDisplay = fmt.Sprintf("%s (%s)", d.InterpreterPath, d.InterpreterVer)
+	}
+
+	// Exactly one option carries the "recommended" label. mise wins when
+	// detected; venv is the fallback recommendation otherwise.
+	miseHeader := "1. Use a version-manager Python:"
+	venvHeader := "2. Install into a dedicated venv (most isolated):"
+	if d.HasMise {
+		miseHeader = "1. Use a version-manager Python (recommended — mise detected on PATH):"
+	} else {
+		venvHeader = "2. Install into a dedicated venv (recommended — most isolated):"
+	}
+
+	var b strings.Builder
+	b.WriteString("✗ Python dependencies could NOT be installed automatically.\n\n")
+	b.WriteString("  Reason:  PEP 668 — externally-managed-environment\n")
+	fmt.Fprintf(&b, "  Python:  %s\n", pyDisplay)
+	fmt.Fprintf(&b, "  Needed:  %s\n\n", strings.Join(d.Packages, ", "))
+	b.WriteString("  This Python interpreter is marked \"externally managed\" (common with\n")
+	b.WriteString("  Homebrew and Debian/Ubuntu system Python), so `pip install --user`\n")
+	b.WriteString("  is blocked by policy. The Telegram bridge cannot start until this\n")
+	b.WriteString("  is resolved, so the launchd daemon was NOT installed.\n\n")
+	b.WriteString("  Pick ONE of these and re-run `agent-deck conductor setup <name>`:\n\n")
+	fmt.Fprintf(&b, "    %s\n", miseHeader)
+	b.WriteString("         mise use -g python@<VERSION> && mise install\n")
+	b.WriteString("         # <VERSION> is any Python 3.11+ — e.g. 3.12 or 3.13.\n")
+	b.WriteString("         # agent-deck does not pin a specific version.\n\n")
+	fmt.Fprintf(&b, "    %s\n", venvHeader)
+	b.WriteString("         python3 -m venv ~/.agent-deck/conductor/.venv\n")
+	fmt.Fprintf(&b, "         ~/.agent-deck/conductor/.venv/bin/pip install %s\n", pkgs)
+	b.WriteString("         # (manual: edit ~/Library/LaunchAgents/com.agentdeck.conductor-bridge.plist\n")
+	b.WriteString("         #  to point at ~/.agent-deck/conductor/.venv/bin/python3)\n\n")
+	b.WriteString("    3. Override the policy (works, but the policy exists for a reason):\n")
+	fmt.Fprintf(&b, "         python3 -m pip install --user --break-system-packages %s\n\n", pkgs)
+	b.WriteString("  After fixing, verify with:  agent-deck conductor status\n")
+	b.WriteString("  If the bridge still won't start: tail ~/.agent-deck/conductor/bridge.log\n")
+	return b.String()
+}
+
+// installPythonDeps installs Python dependencies for the bridge.
+// Returns true on success. On failure it prints a formatted, actionable error
+// (PEP 668 gets a special-cased remediation block listing three fix options;
+// other failures pass the raw pip stderr through) and returns false so the
+// caller can skip the bridge daemon install rather than letting it crash-loop
+// invisibly.
+func installPythonDeps() bool {
 	config, err := session.LoadUserConfig()
-	var packages []string
-	packages = append(packages, "toml")
+	packages := []string{"toml"}
 
 	if err == nil && config != nil {
 		if config.Conductor.Telegram.Token != "" {
@@ -1170,16 +1291,57 @@ func installPythonDeps() {
 		packages = append(packages, "aiogram", "slack-bolt", "slack-sdk", "aiohttp", "discord.py")
 	}
 
+	// Try with --user first; fall back to no --user (venvs, containers).
+	// We capture stderr on the second attempt so a failure can be classified
+	// and surfaced with a remediation message.
 	args := append([]string{"-m", "pip", "install", "--quiet", "--user"}, packages...)
-	if err := exec.Command("python3", args...).Run(); err != nil {
-		// Try without --user (e.g. virtualenvs, containers)
-		args = append([]string{"-m", "pip", "install", "--quiet"}, packages...)
-		if err := exec.Command("python3", args...).Run(); err != nil {
-			// pip failed (e.g. PEP 668 externally-managed env) — rely on system packages
-			fmt.Fprintf(os.Stderr, "Note: pip install failed; using system-installed packages.\n")
-			fmt.Fprintf(os.Stderr, "If the bridge fails to start, install manually: pip3 install %s\n", strings.Join(packages, " "))
-		}
+	if err := exec.Command("python3", args...).Run(); err == nil {
+		return true
 	}
+	var stderrBuf bytes.Buffer
+	args = append([]string{"-m", "pip", "install"}, packages...)
+	cmd := exec.Command("python3", args...)
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Run(); err == nil {
+		return true
+	}
+
+	diag := pipFailureDiagnostic{
+		Kind:      classifyPipFailure(stderrBuf.String()),
+		Packages:  packages,
+		RawStderr: stderrBuf.String(),
+	}
+	diag.InterpreterPath, diag.InterpreterVer = probePythonInterpreter()
+	if _, err := exec.LookPath("mise"); err == nil {
+		diag.HasMise = true
+	}
+
+	if diag.Kind == pipFailureNone {
+		// Pip exited non-zero but emitted nothing on stderr — treat as Other
+		// so the user at least sees the install command.
+		diag.Kind = pipFailureOther
+	}
+	fmt.Fprint(os.Stderr, formatPipFailureMessage(diag))
+	return false
+}
+
+// probePythonInterpreter returns (path, version) by asking python3 to print
+// sys.executable and sys.version. Empty strings on any probe failure — the
+// formatter renders gracefully without them.
+func probePythonInterpreter() (path, version string) {
+	out, err := exec.Command("python3", "-c",
+		"import sys; print(sys.executable); print(sys.version.split()[0])").Output()
+	if err != nil {
+		return "", ""
+	}
+	lines := strings.SplitN(strings.TrimSpace(string(out)), "\n", 2)
+	if len(lines) >= 1 {
+		path = strings.TrimSpace(lines[0])
+	}
+	if len(lines) >= 2 {
+		version = strings.TrimSpace(lines[1])
+	}
+	return path, version
 }
 
 // printConductorHelp prints the conductor subcommand help

--- a/cmd/agent-deck/conductor_pep668_test.go
+++ b/cmd/agent-deck/conductor_pep668_test.go
@@ -1,0 +1,169 @@
+package main
+
+// Detection + clear error message for the PEP 668 ("externally-managed-environment")
+// failure mode in conductor setup's Python dependency install.
+//
+// Background: agent-deck conductor setup runs `python3 -m pip install --user toml aiogram`
+// inside installPythonDeps(). On Homebrew Python and Debian/Ubuntu system Python, that
+// pip invocation fails with PEP 668 ("error: externally-managed-environment"), the
+// failure is swallowed by --quiet, only a one-line stderr note is printed, and the
+// launchd bridge daemon then crash-loops invisibly. This test pins the classifier
+// that lets installPythonDeps() recognise the case and emit an actionable message.
+
+import (
+	"strings"
+	"testing"
+)
+
+// Real stderr from `python3 -m pip install --user toml` against Homebrew's
+// python@3.14 on macOS, captured 2026-05-24. Trimmed to the load-bearing lines;
+// the classifier must not require exact byte-for-byte match.
+const samplePEP668Stderr = `error: externally-managed-environment
+
+× This environment is externally managed
+╰─> To install Python packages system-wide, try brew install
+    xyz, where xyz is the package you are trying to
+    install.
+
+    If you wish to install a Python library that isn't in Homebrew,
+    use a virtual environment:
+
+    python3 -m venv path/to/venv
+    source path/to/venv/bin/activate
+    python3 -m pip install xyz
+`
+
+func TestClassifyPipFailure_DetectsPEP668(t *testing.T) {
+	got := classifyPipFailure(samplePEP668Stderr)
+	if got != pipFailurePEP668 {
+		t.Fatalf("classifyPipFailure(PEP 668 stderr) = %q, want %q", got, pipFailurePEP668)
+	}
+	// Defensive: the marker must be the externally-managed-environment phrase,
+	// not something coincidental in the surrounding prose. If the implementation
+	// ever drifts (e.g. matches on "brew install"), this guard catches it.
+	if !strings.Contains(samplePEP668Stderr, "externally-managed-environment") {
+		t.Fatal("sample stderr no longer contains the canonical PEP 668 marker; update the fixture")
+	}
+}
+
+func TestClassifyPipFailure_NonPEP668ErrorIsOther(t *testing.T) {
+	// Unrelated pip failure — network, missing package, permission, etc. The
+	// classifier must NOT misattribute these to PEP 668, otherwise the
+	// remediation message would be misleading.
+	for _, stderr := range []string{
+		"ERROR: Could not find a version that satisfies the requirement zzzz",
+		"ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied",
+		"WARNING: Retrying ... after connection broken by 'NewConnectionError'",
+	} {
+		if got := classifyPipFailure(stderr); got != pipFailureOther {
+			t.Errorf("classifyPipFailure(%q) = %q, want %q", stderr, got, pipFailureOther)
+		}
+	}
+}
+
+func TestClassifyPipFailure_EmptyStderrIsNone(t *testing.T) {
+	if got := classifyPipFailure(""); got != pipFailureNone {
+		t.Fatalf("classifyPipFailure(\"\") = %q, want %q", got, pipFailureNone)
+	}
+}
+
+// The PEP 668 remediation message MUST name the exact interpreter so the user
+// knows which Python is the problem (Homebrew vs. mise vs. system), MUST list
+// every package the install needed, MUST mention the minimum supported Python
+// (3.11+), and MUST surface all three fix paths (version-manager / venv /
+// --break-system-packages). The interpreter version is informational and may
+// be empty when sys.version probing fails — the formatter must not crash.
+func TestFormatPipFailureMessage_PEP668_ContainsAllRequiredElements(t *testing.T) {
+	diag := pipFailureDiagnostic{
+		Kind:            pipFailurePEP668,
+		InterpreterPath: "/opt/homebrew/opt/python@3.14/bin/python3.14",
+		InterpreterVer:  "3.14.5",
+		Packages:        []string{"toml", "aiogram"},
+	}
+	msg := formatPipFailureMessage(diag)
+
+	required := []string{
+		"PEP 668",
+		"externally-managed",
+		"/opt/homebrew/opt/python@3.14/bin/python3.14",
+		"3.14.5",
+		"toml",
+		"aiogram",
+		"3.11+",
+		"mise use",
+		"python3 -m venv",
+		"--break-system-packages",
+		"agent-deck conductor setup",
+		"agent-deck conductor status",
+	}
+	for _, want := range required {
+		if !strings.Contains(msg, want) {
+			t.Errorf("formatPipFailureMessage(PEP668) missing required substring %q\n----- full message -----\n%s", want, msg)
+		}
+	}
+}
+
+// When mise is detected on PATH, option 1 (version-manager) should be labeled
+// recommended. Without any version manager detected, option 2 (venv) takes
+// the "recommended" label instead — venv is the most isolated fallback.
+func TestFormatPipFailureMessage_PEP668_RecommendsMiseWhenDetected(t *testing.T) {
+	withMise := formatPipFailureMessage(pipFailureDiagnostic{
+		Kind:            pipFailurePEP668,
+		InterpreterPath: "/usr/bin/python3",
+		Packages:        []string{"toml"},
+		HasMise:         true,
+	})
+	if !strings.Contains(withMise, "mise") {
+		t.Fatal("expected mise mention in message")
+	}
+	// "recommended" appears once, on the mise line.
+	if strings.Count(withMise, "recommended") != 1 {
+		t.Errorf("expected exactly one 'recommended' marker (the mise line); got %d\n%s",
+			strings.Count(withMise, "recommended"), withMise)
+	}
+	miseLineIdx := strings.Index(withMise, "mise use")
+	recIdx := strings.Index(withMise, "recommended")
+	if miseLineIdx < 0 || recIdx < 0 || recIdx > miseLineIdx {
+		t.Errorf("'recommended' should appear before the `mise use` command (on the option-1 header line); recIdx=%d miseLineIdx=%d", recIdx, miseLineIdx)
+	}
+
+	withoutMise := formatPipFailureMessage(pipFailureDiagnostic{
+		Kind:            pipFailurePEP668,
+		InterpreterPath: "/usr/bin/python3",
+		Packages:        []string{"toml"},
+		HasMise:         false,
+	})
+	if strings.Count(withoutMise, "recommended") != 1 {
+		t.Errorf("expected exactly one 'recommended' marker (the venv line) when mise absent; got %d\n%s",
+			strings.Count(withoutMise, "recommended"), withoutMise)
+	}
+	venvLineIdx := strings.Index(withoutMise, "python3 -m venv")
+	recIdxNoMise := strings.Index(withoutMise, "recommended")
+	if venvLineIdx < 0 || recIdxNoMise < 0 || recIdxNoMise > venvLineIdx {
+		t.Errorf("without mise, 'recommended' should mark the venv option; recIdx=%d venvLineIdx=%d", recIdxNoMise, venvLineIdx)
+	}
+}
+
+// Non-PEP-668 failures retain the pre-existing behaviour: surface the raw
+// pip stderr so the user sees the actual error, and provide the manual
+// install command as a fallback. The classifier shields us from emitting
+// PEP-668-specific advice for unrelated failures.
+func TestFormatPipFailureMessage_Other_PassesThroughStderr(t *testing.T) {
+	rawErr := "ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied"
+	diag := pipFailureDiagnostic{
+		Kind:      pipFailureOther,
+		Packages:  []string{"toml", "aiogram"},
+		RawStderr: rawErr,
+	}
+	msg := formatPipFailureMessage(diag)
+
+	if !strings.Contains(msg, rawErr) {
+		t.Errorf("Other-kind message should include the raw pip stderr; got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "pip3 install toml aiogram") {
+		t.Errorf("Other-kind message should include the manual install command; got:\n%s", msg)
+	}
+	if strings.Contains(msg, "PEP 668") || strings.Contains(msg, "externally-managed") {
+		t.Errorf("Other-kind message must NOT mention PEP 668 (would mislead the user); got:\n%s", msg)
+	}
+}


### PR DESCRIPTION
## Summary

`agent-deck conductor setup` calls `installPythonDeps()` to `pip install toml aiogram` for the Telegram bridge. On Homebrew Python (macOS) and Debian/Ubuntu system Python the install fails with PEP 668 (`externally-managed-environment`). Today both pip attempts use `--quiet` so the real error never reaches the user; only a one-line note prints to stderr buried mid-setup, and the launchd bridge daemon is registered anyway. The daemon then crash-loops on `import toml`, no `bridge.log` gets created (launchd's `ThrottleInterval` backs off before the file handler opens), and `agent-deck conductor status` reports only `Bridge daemon: STOPPED` with no cause.

This PR detects the case and surfaces an actionable, structured error. It does **not** fix the underlying issue — the user still picks an interpreter.

## What changes

- Adds `classifyPipFailure(stderr)` returning `PEP668 / Other / None` based on the canonical `externally-managed-environment` marker.
- Adds `formatPipFailureMessage(diagnostic)` rendering a structured remediation block. Mise-aware: when `mise` is on PATH, option 1 is labeled `(recommended)`; otherwise option 2 (venv) carries the label. Exactly one option is ever recommended (test enforces).
- Rewrites `installPythonDeps()` to capture pip stderr on the second attempt, classify it, print the formatted message, and return `bool`.
- Updates `handleConductorSetup` to **skip** `InstallBridgeDaemon()` when deps failed, so the launchd plist isn't registered into a known-broken state. A `[skip]` line in the setup summary makes the gap visible.

## Rendered output

PEP 668 with mise detected on PATH:
~~~
✗ Python dependencies could NOT be installed automatically.

  Reason:  PEP 668 — externally-managed-environment
  Python:  /opt/homebrew/opt/python@3.14/bin/python3.14 (3.14.5)
  Needed:  toml, aiogram

  This Python interpreter is marked "externally managed" (common with
  Homebrew and Debian/Ubuntu system Python), so \`pip install --user\`
  is blocked by policy. The Telegram bridge cannot start until this
  is resolved, so the launchd daemon was NOT installed.

  Pick ONE of these and re-run \`agent-deck conductor setup <name>\`:

    1. Use a version-manager Python (recommended — mise detected on PATH):
         mise use -g python@<VERSION> && mise install
         # <VERSION> is any Python 3.11+ — e.g. 3.12 or 3.13.
         # agent-deck does not pin a specific version.

    2. Install into a dedicated venv (most isolated):
         python3 -m venv ~/.agent-deck/conductor/.venv
         ~/.agent-deck/conductor/.venv/bin/pip install toml aiogram
         # (manual: edit ~/Library/LaunchAgents/com.agentdeck.conductor-bridge.plist
         #  to point at ~/.agent-deck/conductor/.venv/bin/python3)

    3. Override the policy (works, but the policy exists for a reason):
         python3 -m pip install --user --break-system-packages toml aiogram

  After fixing, verify with:  agent-deck conductor status
  If the bridge still won't start: tail ~/.agent-deck/conductor/bridge.log
~~~

Non-PEP-668 pip failures fall through to a simpler block that surfaces the raw pip stderr and the manual install command, with no PEP 668 mention (test enforces).

## Out of scope (deliberate)

- No venv creation, no plist rewrite for custom interpreters, no auto-mise-pin.
- No `requirements.txt` / `pyproject.toml` addition (separate concern: dep pinning).
- No documentation update — `documentation/CONDUCTOR.md` still doesn't mention Python deps or bridge logs. Worth a follow-up.
- No change to `bridge.py`.

## Tests

6 new tests in `cmd/agent-deck/conductor_pep668_test.go`, all passing:

- `TestClassifyPipFailure_DetectsPEP668` — real Homebrew Python 3.14 stderr fixture
- `TestClassifyPipFailure_NonPEP668ErrorIsOther` — 3 unrelated pip failures (missing pkg, permission, network)
- `TestClassifyPipFailure_EmptyStderrIsNone`
- `TestFormatPipFailureMessage_PEP668_ContainsAllRequiredElements` — 12 required substrings pinned
- `TestFormatPipFailureMessage_PEP668_RecommendsMiseWhenDetected` — exactly-one-recommended invariant
- `TestFormatPipFailureMessage_Other_PassesThroughStderr` — raw stderr included, no false PEP 668 mention

## Test plan

- [x] \`go test -run 'PEP668|PipFailure|ClassifyPipFailure|FormatPipFailureMessage' ./cmd/agent-deck/...\` → 6/6 PASS
- [x] \`go vet ./cmd/agent-deck/...\` clean
- [x] \`gofmt -l\` clean
- [x] \`go build ./cmd/agent-deck/...\` clean
- [ ] Reviewer: run \`agent-deck conductor setup test-pep668\` against a Homebrew Python 3.14 box (uninstall \`toml\` first) and confirm the rendered error matches the sample above, and that no \`com.agentdeck.conductor-bridge\` launchd job is loaded.

## Pre-existing failure flag (not caused by this PR)

\`TestOuterTmuxGuard\` in \`cmd/agent-deck/main_test.go\` fails on the v1.9.14 baseline when run inside a tmux session — the guard checks \`TMUX\` env and the test doesn't isolate it. Verified by stashing this PR's changes and re-running on a clean tree. Worth a separate fix; out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Bridge daemon installation is now skipped when Python dependencies fail, with actionable error messages and multiple remediation paths provided.
  * Enhanced error detection for externally-managed Python environments with specific fix recommendations (version manager, virtual environment, or override options).

* **Tests**
  * Added test coverage for Python dependency installation error classification and messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->