### PR TITLE
fix(ui): model picker — echo typed input + scope Esc to picker (#1162)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5718,6 +5718,15 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		)
 
 	case "esc":
+		// #1162: when the model picker dropdown is open, Esc dismisses only the
+		// picker and keeps the new-session form alive (focus stays on the model
+		// field) rather than cancelling the whole flow. Forward to the dialog so
+		// its picker-level Esc handler runs.
+		if h.newDialog.IsModelPickerOpen() {
+			var cmd tea.Cmd
+			h.newDialog, cmd = h.newDialog.Update(msg)
+			return h, cmd
+		}
 		h.newDialog.Hide()
 		h.clearError() // Clear any validation error
 		return h, nil

--- a/internal/ui/issue1162_model_picker_test.go
+++ b/internal/ui/issue1162_model_picker_test.go
@@ -1,0 +1,165 @@
+package ui
+
+// Regression tests for #1162 — TUI new-session model picker.
+//
+// Bug 1: typing a custom model name into the model picker showed no echo —
+//        the suggestions dropdown overlay was painted directly on top of the
+//        model input line, hiding whatever the user typed.
+//
+// Bug 2: pressing Esc while in the model picker closed the ENTIRE new-session
+//        flow instead of dismissing only the picker. The Esc handler in
+//        home.go's handleNewDialogKey called newDialog.Hide() before the
+//        dialog could intercept Esc as a "close-self" for the picker.
+//
+// Reported via Feedback Hub by @wbonnefond on v1.9.30 (darwin/arm64, 2/5).
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// focusModelForCodex returns a visible new-session dialog with the codex tool
+// selected and focus parked on the model field (the model picker is showing).
+func focusModelForCodex(t *testing.T) *NewDialog {
+	t.Helper()
+	d := NewNewDialog()
+	d.SetDefaultTool("codex")
+	d.SetSize(100, 50)
+	d.Show()
+	d.focusIndex = d.indexOf(focusModel)
+	if d.focusIndex < 0 {
+		t.Fatal("codex should expose a focusable model field")
+	}
+	d.updateFocus()
+	return d
+}
+
+// typeRunes feeds each rune of s to the dialog as individual key messages,
+// mirroring real keystrokes through the Bubble Tea Update loop.
+func typeRunes(d *NewDialog, s string) *NewDialog {
+	for _, r := range s {
+		d, _ = d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	return d
+}
+
+// --- Bug 1: typed custom model name must be visible ------------------------
+
+// Happy path: a custom model ID that matches no known suggestion must still be
+// echoed back in the rendered view (it can only show if the input line is not
+// covered by the dropdown overlay).
+func TestIssue1162_CustomModelNameVisibleWhileTyping(t *testing.T) {
+	d := focusModelForCodex(t)
+	const custom = "qwen3-custom-zzz"
+	d = typeRunes(d, custom)
+
+	if got := d.GetLaunchModelID(); got != custom {
+		t.Fatalf("GetLaunchModelID() = %q, want %q", got, custom)
+	}
+	if view := d.View(); !strings.Contains(view, custom) {
+		t.Fatalf("typed custom model %q not visible in rendered view (overlay hides input?):\n%s", custom, view)
+	}
+}
+
+// Boundary: unicode custom model name (no suggestion match) must also echo.
+func TestIssue1162_UnicodeModelNameVisibleWhileTyping(t *testing.T) {
+	d := focusModelForCodex(t)
+	const custom = "модель-абв"
+	d = typeRunes(d, custom)
+
+	if view := d.View(); !strings.Contains(view, custom) {
+		t.Fatalf("unicode custom model %q not visible in rendered view:\n%s", custom, view)
+	}
+}
+
+// --- Bug 2: Esc inside the picker dismisses only the picker ----------------
+
+// IsModelPickerOpen reflects whether the picker is showing for the model field.
+func TestIssue1162_IsModelPickerOpen(t *testing.T) {
+	d := focusModelForCodex(t)
+	if !d.IsModelPickerOpen() {
+		t.Fatal("model picker should report open when focused on model field")
+	}
+	// A tool without model support (shell) must never report the picker open.
+	shell := NewNewDialog()
+	shell.SetDefaultTool("")
+	shell.SetSize(100, 50)
+	shell.Show()
+	if shell.IsModelPickerOpen() {
+		t.Fatal("shell tool has no model field; picker must not report open")
+	}
+}
+
+// Dialog level: Esc while the picker is open dismisses the picker but keeps the
+// dialog visible with focus still on the model field.
+func TestIssue1162_EscDismissesPickerKeepsDialog(t *testing.T) {
+	d := focusModelForCodex(t)
+	d = typeRunes(d, "gpt-5.5")
+
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEsc})
+
+	if !d.IsVisible() {
+		t.Fatal("Esc inside the model picker must NOT hide the new-session dialog")
+	}
+	if d.currentTarget() != focusModel {
+		t.Fatalf("focus after Esc inside picker = %v, want focusModel", d.currentTarget())
+	}
+	if d.IsModelPickerOpen() {
+		t.Fatal("Esc inside the picker should dismiss the picker dropdown")
+	}
+	// Typed value is preserved — only the picker closed.
+	if got := d.GetLaunchModelID(); got != "gpt-5.5" {
+		t.Fatalf("GetLaunchModelID() after dismiss = %q, want gpt-5.5", got)
+	}
+}
+
+// Home level (the real reproduction): the parent intercepts Esc. When the
+// picker is open, Esc must close only the picker; the form stays alive.
+func TestIssue1162_HomeEscInPickerKeepsFlowAlive(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 100, 30
+	h.newDialog.SetDefaultTool("codex")
+	h.newDialog.SetSize(100, 50)
+	h.newDialog.Show()
+	h.newDialog.focusIndex = h.newDialog.indexOf(focusModel)
+	h.newDialog.updateFocus()
+
+	if !h.newDialog.IsModelPickerOpen() {
+		t.Fatal("precondition: model picker should be open")
+	}
+
+	// First Esc: dismiss only the picker — flow must stay alive.
+	h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if !h.newDialog.IsVisible() {
+		t.Fatal("Esc in picker closed the entire new-session flow (bug #1162)")
+	}
+	if h.newDialog.currentTarget() != focusModel {
+		t.Fatalf("focus after Esc = %v, want focusModel", h.newDialog.currentTarget())
+	}
+
+	// Second Esc: picker already dismissed, so this cancels the flow.
+	h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if h.newDialog.IsVisible() {
+		t.Fatal("second Esc (picker dismissed) should cancel the new-session flow")
+	}
+}
+
+// Regression: Esc on the form itself (not in the picker) still cancels the flow.
+func TestIssue1162_HomeEscOnFormCancelsFlow(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 100, 30
+	h.newDialog.SetDefaultTool("codex")
+	h.newDialog.SetSize(100, 50)
+	h.newDialog.Show() // focus defaults to the name field, not the picker.
+
+	if h.newDialog.IsModelPickerOpen() {
+		t.Fatal("precondition: picker must be closed on the name field")
+	}
+
+	h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if h.newDialog.IsVisible() {
+		t.Fatal("Esc on the form (not picker) must cancel the whole flow")
+	}
+}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -554,6 +554,17 @@ func (d *NewDialog) IsModelSuggestionsActive() bool {
 	return d.modelSuggestionActive
 }
 
+// IsModelPickerOpen reports whether the model picker dropdown is currently
+// shown: focus is on the model field, the tool supports a model override, and
+// the picker has not been explicitly dismissed. The parent (home.go) uses this
+// so Esc dismisses only the picker rather than cancelling the whole
+// new-session flow (#1162).
+func (d *NewDialog) IsModelPickerOpen() bool {
+	return d.currentTarget() == focusModel &&
+		d.selectedToolSupportsModel() &&
+		!d.modelSuggestionHidden
+}
+
 func (d *NewDialog) IsModelTypeCustomHighlighted() bool {
 	return d.modelSuggestionActive && d.modelSuggestionCursor == 0
 }
@@ -1743,6 +1754,16 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				d.pathInput.Blur()
 				return d, nil
 			}
+			// #1162 bug 2: Esc inside the model picker dismisses ONLY the picker
+			// and keeps the form alive with focus on the model field, instead of
+			// cancelling the entire new-session flow. A second Esc (picker already
+			// dismissed) falls through to Hide(). The parent forwards Esc here
+			// whenever IsModelPickerOpen() is true.
+			if d.IsModelPickerOpen() {
+				d.DismissModelSuggestions()
+				d.modelInput.Focus()
+				return d, nil
+			}
 			d.Hide()
 			return d, nil
 
@@ -2265,7 +2286,19 @@ func (d *NewDialog) View() string {
 		}
 		content.WriteString("\n  ")
 		content.WriteString(d.modelInput.View())
-		d.modelLineOffset = strings.Count(content.String(), "\n")
+		// #1162 bug 1: position the dropdown overlay using the *visual* (wrapped)
+		// line count, not the raw newline count. The command-button row above the
+		// model field wraps to extra lines at narrow widths; a newline count would
+		// undercount those and paint the dropdown directly over the model input,
+		// hiding whatever the user typed. lipgloss.Height of the width-wrapped
+		// content-so-far yields the row just below the input (the path field has
+		// no wrapping above it, so its newline count already lands correctly).
+		innerWidth := dialogWidth - 8 // Padding(2,4) → 4 columns each side.
+		if innerWidth < 1 {
+			innerWidth = 1
+		}
+		wrapped := lipgloss.NewStyle().Width(innerWidth).Render(content.String())
+		d.modelLineOffset = lipgloss.Height(wrapped)
 		if hint := d.modelInputHint(); hint != "" {
 			dimStyle := lipgloss.NewStyle().Foreground(ColorComment)
 			content.WriteString("\n  ")


### PR DESCRIPTION
Closes #1162.

Two model-picker UX bugs in the new-session flow, reported via Feedback Hub by **@wbonnefond** (v1.9.30, darwin/arm64, 2/5). Credit to @wbonnefond for the report.

## Bug 1 — typed custom model name invisible
The suggestions dropdown overlay was positioned by counting raw **content newlines** (`strings.Count(content, "\n")`). But the command-button row directly above the model field wraps to extra **visual** lines at narrow widths, so the newline count under-counted and the dropdown was painted directly on top of the model input — hiding whatever the user typed.

**Fix:** position the overlay from the visual (width-wrapped) line count via `lipgloss.Height`, so the dropdown lands on the row *below* the input. (The path-suggestions overlay never hit this because it sits *above* the wrapping command row.)

## Bug 2 — Esc killed the entire new-session flow
`home.go`'s `handleNewDialogKey` intercepted `esc` and called `newDialog.Hide()` *before* the dialog could treat Esc as a close-self for the picker. The dialog's own Esc handler only ran while the dropdown was *actively navigated* (arrow keys), not while *typing* — exactly the path users hit.

**Fix:** the parent now forwards Esc to the dialog when `IsModelPickerOpen()` is true. The dialog dismisses **only** the picker (focus stays on the model field, form stays alive). A second Esc (picker already dismissed) cancels the flow, and Esc on any other field cancels as before.

## Surfaces
| Surface | Applies? | Coverage |
|---|---|---|
| **TUI** (`internal/ui/`) | ✅ | `internal/ui/issue1162_model_picker_test.go` |
| Web UI | ❌ | The model picker is a Bubble Tea overlay in the TUI new-session dialog; the web new-session form does not render this picker overlay. |
| CLI | ❌ | No flag/subcommand change. |
| Remote | ❌ | Dialog is a pre-launch local form; no `LocalSession`/`RemoteSession` behavior touched. |
| Persistence | ❌ | No schema/record change. |
| Cross-platform | ❌ | Pure rendering/key-routing logic; no OS-specific paths. |

## Tests (`issue1162_model_picker_test.go`)
- **Happy:** custom model name (`qwen3-custom-zzz`) echoes in the rendered view.
- **Boundary:** unicode model name (`модель-абв`) echoes (and proves the assertion isn't satisfied by a suggestion-list match).
- `IsModelPickerOpen` true on the model field, false for shell (no model field).
- **Failure-mode / core fix:** dialog- and home-level — Esc dismisses the picker, keeps the form alive, preserves the typed value; a second Esc cancels.
- **Regression:** Esc on the form (name field, picker closed) still cancels the whole flow.

## Verification
- `go test ./internal/ui/...` ✅
- `go test -race -count=1 ./internal/ui/...` ✅
- `go test ./...` (full suite) ✅
- `golangci-lint run internal/ui/` → 0 issues ✅
- `govulncheck ./...` → 0 vulnerabilities in called code ✅

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Esc key handling in the new-session dialog's model picker: pressing Esc now dismisses only the picker dropdown while keeping the form active.
  * Fixed model suggestions overlay positioning at narrow terminal widths.

* **Tests**
  * Added regression test suite covering model picker functionality, including custom model name input and keyboard navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->