### PR TITLE
fix(remote): keep last-good remote sessions on transient SSH errors + configurable poll (#1170)

### DIFF
--- a/internal/session/issue1170_remote_session_refresh_test.go
+++ b/internal/session/issue1170_remote_session_refresh_test.go
@@ -1,0 +1,34 @@
+// Issue #1170 (by @devtechwebsource on v1.9.30): remote sessions created
+// after the TUI launches don't appear until quit+relaunch. The remote list
+// is polled on a tick, but the cadence was a hardcoded 30s and a single
+// slow remote could starve the others. This config knob lets users tune the
+// poll interval; the default (15s) tightens the visibility latency the
+// reporter hit. Mirrors the [ui] remote_latency_refresh_secs path (#1103).
+package session
+
+import "testing"
+
+// TestIssue1170_UISettings_GetRemoteSessionRefreshSecs covers the config
+// path the fix introduces: `[ui] remote_session_refresh_secs`. Unset falls
+// back to the default; values clamp to the safe [5, 300] range so a user
+// can't accidentally hammer SSH every second or freeze the list for an hour.
+func TestIssue1170_UISettings_GetRemoteSessionRefreshSecs(t *testing.T) {
+	cases := []struct {
+		name string
+		ui   UISettings
+		want int
+	}{
+		{"unset uses default", UISettings{}, DefaultRemoteSessionRefreshSecs},
+		{"explicit value", UISettings{RemoteSessionRefreshSecs: 20}, 20},
+		{"clamp below min", UISettings{RemoteSessionRefreshSecs: 1}, MinRemoteSessionRefreshSecs},
+		{"clamp above max", UISettings{RemoteSessionRefreshSecs: 9999}, MaxRemoteSessionRefreshSecs},
+		{"negative uses default", UISettings{RemoteSessionRefreshSecs: -5}, DefaultRemoteSessionRefreshSecs},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ui.GetRemoteSessionRefreshSecs(); got != tc.want {
+				t.Fatalf("GetRemoteSessionRefreshSecs() on %+v = %d, want %d", tc.ui, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -207,6 +207,12 @@ type UISettings struct {
 	// range: 2-300. Default: matches [system_stats].refresh_seconds (5s)
 	// so the latency marker ticks alongside CPU/RAM/load.
 	RemoteLatencyRefreshSecs int `toml:"remote_latency_refresh_secs"`
+	// RemoteSessionRefreshSecs sets how often the TUI re-fetches the remote
+	// session list over SSH (issue #1170). Remote sessions created after the
+	// TUI launched were invisible until quit+relaunch; this is the poll
+	// cadence that reconciles the list. Valid range: 5-300. Default: 15s,
+	// tightening the visibility latency reported on v1.9.30.
+	RemoteSessionRefreshSecs int `toml:"remote_session_refresh_secs"`
 }
 
 // DefaultPreviewPct is the default preview-pane width percentage.
@@ -254,6 +260,33 @@ func (u UISettings) GetITermOpenAs() string {
 		return ITermOpenAsTab
 	}
 	return DefaultITermOpenAs
+}
+
+// Remote session-list poll cadence bounds (issue #1170). The default is
+// deliberately tighter than the historical hardcoded 30s so new remote
+// sessions surface promptly; the min keeps a floor on SSH frequency.
+const (
+	DefaultRemoteSessionRefreshSecs = 15
+	MinRemoteSessionRefreshSecs     = 5
+	MaxRemoteSessionRefreshSecs     = 300
+)
+
+// GetRemoteSessionRefreshSecs returns the remote session-list poll interval
+// in seconds, clamped to [MinRemoteSessionRefreshSecs,
+// MaxRemoteSessionRefreshSecs]. Unset (<= 0) falls back to
+// DefaultRemoteSessionRefreshSecs. See issue #1170.
+func (u UISettings) GetRemoteSessionRefreshSecs() int {
+	val := u.RemoteSessionRefreshSecs
+	if val <= 0 {
+		return DefaultRemoteSessionRefreshSecs
+	}
+	if val < MinRemoteSessionRefreshSecs {
+		return MinRemoteSessionRefreshSecs
+	}
+	if val > MaxRemoteSessionRefreshSecs {
+		return MaxRemoteSessionRefreshSecs
+	}
+	return val
 }
 
 // GetRemoteLatencyRefreshSecs returns the remote latency refresh interval

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -465,6 +465,10 @@ type Home struct {
 	remoteSessionsMu   sync.RWMutex
 	lastRemoteFetch    time.Time // When remote sessions were last fetched
 	remotesFetchActive bool      // Prevents overlapping fetches
+	// remoteSessionRefreshSec is the poll cadence (seconds) for re-fetching
+	// the remote session list, resolved once at construction from
+	// [ui] remote_session_refresh_secs. Issue #1170.
+	remoteSessionRefreshSec int
 
 	// Remote latency (issue #1103) — measured per remote host on the same
 	// cadence as CPU/RAM (see UISettings.GetRemoteLatencyRefreshSecs).
@@ -796,6 +800,10 @@ type remoteSessionsFetchedMsg struct {
 	sessions map[string][]session.RemoteSessionInfo
 	// #1101: per-remote cost summary collected on the same SSH fanout.
 	costs map[string]*costs.RemoteCostSummary
+	// failed marks remotes whose fetch errored this round (issue #1170).
+	// The handler keeps their last-good sessions instead of wiping them,
+	// so one slow/offline remote can't flicker the whole list.
+	failed map[string]bool
 }
 
 // remoteLatenciesFetchedMsg is sent when an async batch of latency
@@ -968,12 +976,14 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(cfg, actualProfile)
 		h.previewPct = cfg.UI.GetPreviewPct()
 		h.remoteLatencyRefreshSec = cfg.UI.GetRemoteLatencyRefreshSecs(cfg.SystemStats.GetRefreshSeconds())
+		h.remoteSessionRefreshSec = cfg.UI.GetRemoteSessionRefreshSecs()
 	} else {
 		h.fullRepaint = (session.DisplaySettings{}).GetFullRepaint()
 		h.activeFilterExcludes = (session.DisplaySettings{}).GetActiveFilterExcludes()
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(nil, actualProfile)
 		h.previewPct = session.DefaultPreviewPct
 		h.remoteLatencyRefreshSec = (session.UISettings{}).GetRemoteLatencyRefreshSecs(0)
+		h.remoteSessionRefreshSec = (session.UISettings{}).GetRemoteSessionRefreshSecs()
 	}
 	h.remoteLatency = make(map[string]session.RemoteLatency)
 
@@ -2225,34 +2235,97 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 		return remoteSessionsFetchedMsg{sessions: nil}
 	}
 
-	results := make(map[string][]session.RemoteSessionInfo)
+	results := make(map[string][]session.RemoteSessionInfo, len(config.Remotes))
 	// #1101: remote cost summaries piggy-back on the existing remote-fetch
 	// channel so the status-line cost segment doesn't lag behind the session
 	// list. nil-valued entries indicate fetch failures (e.g., older remote
 	// agent-deck without `costs summary --json`); the renderer treats those
 	// as "remote contributes zero" so a single broken remote can't poison
 	// the displayed total.
-	costResults := make(map[string]*costs.RemoteCostSummary)
-	ctx, cancel := context.WithTimeout(h.ctx, 15*time.Second)
-	defer cancel()
+	costResults := make(map[string]*costs.RemoteCostSummary, len(config.Remotes))
+	// #1170: track remotes that errored so the handler keeps their last-good
+	// sessions instead of dropping them.
+	failed := make(map[string]bool, len(config.Remotes))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
 
+	// #1170: fetch every remote in parallel, each with its OWN timeout, so a
+	// single slow/offline remote can't starve the others. The previous code
+	// shared one 15s budget across all remotes fetched sequentially, which
+	// made healthy remotes drop out of the result map (and flicker in the
+	// TUI) whenever an earlier remote was slow.
 	for name, rc := range config.Remotes {
-		runner := session.NewSSHRunner(name, rc)
-		sessions, err := runner.FetchSessions(ctx)
-		if err != nil {
+		wg.Add(1)
+		go func(name string, rc session.RemoteConfig) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(h.ctx, 15*time.Second)
+			defer cancel()
+
+			runner := session.NewSSHRunner(name, rc)
+			sessions, err := runner.FetchSessions(ctx)
+			if err != nil {
+				mu.Lock()
+				failed[name] = true
+				mu.Unlock()
+				return
+			}
+			for i := range sessions {
+				sessions[i].RemoteName = name
+			}
+			summary, costErr := runner.FetchCostSummary(ctx)
+
+			mu.Lock()
+			results[name] = sessions
+			if costErr == nil && summary != nil {
+				costResults[name] = summary
+			}
+			mu.Unlock()
+		}(name, rc)
+	}
+	wg.Wait()
+
+	return remoteSessionsFetchedMsg{sessions: results, costs: costResults, failed: failed}
+}
+
+// mergeRemoteSessions reconciles a freshly fetched remote-session map against
+// the previously displayed one (issue #1170). The contract:
+//
+//   - remotes present in fetched → replaced wholesale (new sessions appear,
+//     removed sessions drop);
+//   - remotes in failed (errored this round) → keep their last-good sessions
+//     from prev, so a transient SSH hiccup never wipes a remote;
+//   - remotes absent from both fetched and failed → dropped (deconfigured).
+//
+// It is a pure function so the reconciliation logic is unit-testable without
+// SSH or the Bubble Tea event loop.
+func mergeRemoteSessions(prev, fetched map[string][]session.RemoteSessionInfo, failed map[string]bool) map[string][]session.RemoteSessionInfo {
+	merged := make(map[string][]session.RemoteSessionInfo, len(fetched)+len(failed))
+	for name, sess := range fetched {
+		merged[name] = sess
+	}
+	for name := range failed {
+		if _, ok := merged[name]; ok {
+			// A successful result for this remote (if any) always wins.
 			continue
 		}
-		for i := range sessions {
-			sessions[i].RemoteName = name
-		}
-		results[name] = sessions
-
-		if summary, costErr := runner.FetchCostSummary(ctx); costErr == nil && summary != nil {
-			costResults[name] = summary
+		if prevSess, ok := prev[name]; ok && len(prevSess) > 0 {
+			merged[name] = prevSess
 		}
 	}
+	return merged
+}
 
-	return remoteSessionsFetchedMsg{sessions: results, costs: costResults}
+// shouldFetchRemoteSessions reports whether the periodic tick should kick off
+// a remote-session re-fetch: the configured interval has elapsed since the
+// last fetch and no fetch is currently in flight. Issue #1170.
+func (h *Home) shouldFetchRemoteSessions(now time.Time) bool {
+	interval := h.remoteSessionRefreshSec
+	if interval <= 0 {
+		interval = session.DefaultRemoteSessionRefreshSecs
+	}
+	h.remoteSessionsMu.RLock()
+	defer h.remoteSessionsMu.RUnlock()
+	return !h.remotesFetchActive && now.Sub(h.lastRemoteFetch) >= time.Duration(interval)*time.Second
 }
 
 // measureRemoteLatencies measures round-trip latency to every configured
@@ -4399,7 +4472,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case remoteSessionsFetchedMsg:
 		h.remoteSessionsMu.Lock()
-		h.remoteSessions = msg.sessions
+		// #1170: merge rather than wholesale-replace so a remote that errored
+		// this round keeps its last-good sessions instead of flickering out.
+		h.remoteSessions = mergeRemoteSessions(h.remoteSessions, msg.sessions, msg.failed)
 		h.lastRemoteFetch = time.Now()
 		h.remotesFetchActive = false
 		h.remoteSessionsMu.Unlock()
@@ -5038,11 +5113,10 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.saveUIState()
 		}
 
-		// Periodic remote session fetch (every 30 seconds)
-		h.remoteSessionsMu.RLock()
-		shouldFetch := !h.remotesFetchActive && time.Since(h.lastRemoteFetch) >= 30*time.Second
-		h.remoteSessionsMu.RUnlock()
-		if shouldFetch {
+		// Periodic remote session fetch (issue #1170). Cadence is configurable
+		// via [ui] remote_session_refresh_secs (default 15s); see
+		// shouldFetchRemoteSessions for the stale/in-flight gating.
+		if h.shouldFetchRemoteSessions(time.Now()) {
 			h.remoteSessionsMu.Lock()
 			h.remotesFetchActive = true
 			h.remoteSessionsMu.Unlock()

--- a/internal/ui/issue1170_remote_refresh_test.go
+++ b/internal/ui/issue1170_remote_refresh_test.go
@@ -1,0 +1,183 @@
+// Issue #1170 (by @devtechwebsource on v1.9.30): remote sessions created
+// after the TUI launches never appear until quit+relaunch.
+//
+// The shipped code DID poll remotes every 30s on tickMsg, but two defects
+// kept the list stale/flickering for the reporter's 3-federated-remote
+// setup:
+//
+//  1. fetchRemoteSessions shared a single 15s context across ALL remotes
+//     fetched sequentially, so one slow/offline remote starved the others
+//     and they dropped out of the result map.
+//  2. the result handler did a wholesale `h.remoteSessions = msg.sessions`,
+//     so any remote missing from a partial/failed fetch had its sessions
+//     wiped — last-good data was lost on every transient SSH hiccup.
+//
+// The fix: per-remote timeouts + a `failed` set on the fetch message, and a
+// merge that keeps last-good sessions for a remote that errored this tick
+// while still dropping sessions/remotes that genuinely went away. Plus a
+// configurable, tighter poll interval (issue #1170 / GetRemoteSessionRefreshSecs).
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func remoteInfo(remote, id, title, status string) session.RemoteSessionInfo {
+	return session.RemoteSessionInfo{ID: id, Title: title, Tool: "claude", Status: status, RemoteName: remote}
+}
+
+// --- Periodic poll gating (the "re-fetch on tick" mechanism, scenario 1) ---
+
+// TestIssue1170_ShouldFetch_WhenStale: once the configured interval elapses,
+// the tick must trigger a re-fetch. Without this the list freezes at the
+// startup snapshot — the headline symptom.
+func TestIssue1170_ShouldFetch_WhenStale(t *testing.T) {
+	home := NewHome()
+	home.remoteSessionRefreshSec = 15
+	home.lastRemoteFetch = time.Now().Add(-30 * time.Second)
+	home.remotesFetchActive = false
+	if !home.shouldFetchRemoteSessions(time.Now()) {
+		t.Fatal("expected a stale remote list (>interval) to trigger a re-fetch")
+	}
+}
+
+// TestIssue1170_ShouldFetch_SkipsWhenFresh: don't hammer SSH — a fetch that
+// just happened must not re-fire until the interval elapses.
+func TestIssue1170_ShouldFetch_SkipsWhenFresh(t *testing.T) {
+	home := NewHome()
+	home.remoteSessionRefreshSec = 15
+	home.lastRemoteFetch = time.Now()
+	home.remotesFetchActive = false
+	if home.shouldFetchRemoteSessions(time.Now()) {
+		t.Fatal("expected a fresh fetch (<interval) to be skipped")
+	}
+}
+
+// TestIssue1170_ShouldFetch_SkipsWhenActive: overlapping fetches must not
+// stack — an in-flight fetch blocks the next trigger regardless of age.
+func TestIssue1170_ShouldFetch_SkipsWhenActive(t *testing.T) {
+	home := NewHome()
+	home.remoteSessionRefreshSec = 15
+	home.lastRemoteFetch = time.Now().Add(-1 * time.Hour)
+	home.remotesFetchActive = true
+	if home.shouldFetchRemoteSessions(time.Now()) {
+		t.Fatal("expected an in-flight fetch to suppress a new trigger")
+	}
+}
+
+// --- Merge behavior (happy / removed / failure / boundary) ---
+
+// TestIssue1170_NewRemoteSession_Appears (happy path): a session created on
+// the remote after startup must surface once the next fetch lands.
+func TestIssue1170_NewRemoteSession_Appears(t *testing.T) {
+	prev := map[string][]session.RemoteSessionInfo{
+		"dev": {remoteInfo("dev", "r1", "existing", "running")},
+	}
+	fetched := map[string][]session.RemoteSessionInfo{
+		"dev": {remoteInfo("dev", "r1", "existing", "running"), remoteInfo("dev", "r2", "fresh-session", "running")},
+	}
+	got := mergeRemoteSessions(prev, fetched, nil)
+	if len(got["dev"]) != 2 {
+		t.Fatalf("dev sessions = %d, want 2 — new remote session must appear", len(got["dev"]))
+	}
+}
+
+// TestIssue1170_RemovedRemoteSession_Drops: a session closed on the remote
+// must drop from the list on the next successful fetch.
+func TestIssue1170_RemovedRemoteSession_Drops(t *testing.T) {
+	prev := map[string][]session.RemoteSessionInfo{
+		"dev": {remoteInfo("dev", "r1", "a", "running"), remoteInfo("dev", "r2", "b", "running")},
+	}
+	fetched := map[string][]session.RemoteSessionInfo{
+		"dev": {remoteInfo("dev", "r1", "a", "running")},
+	}
+	got := mergeRemoteSessions(prev, fetched, nil)
+	if len(got["dev"]) != 1 || got["dev"][0].ID != "r1" {
+		t.Fatalf("dev sessions = %+v, want only r1 — removed session must drop", got["dev"])
+	}
+}
+
+// TestIssue1170_FailedRemoteFetch_KeepsLastGood (THE fix / failure mode): a
+// remote that errors on this tick must retain its last-good sessions rather
+// than being wiped. This is the wholesale-replace bug that made remotes
+// flicker out for the 3-remote reporter.
+func TestIssue1170_FailedRemoteFetch_KeepsLastGood(t *testing.T) {
+	prev := map[string][]session.RemoteSessionInfo{
+		"dev":  {remoteInfo("dev", "r1", "a", "running")},
+		"prod": {remoteInfo("prod", "r9", "z", "waiting")},
+	}
+	// dev fetched fine; prod timed out this tick.
+	fetched := map[string][]session.RemoteSessionInfo{
+		"dev": {remoteInfo("dev", "r1", "a", "running")},
+	}
+	failed := map[string]bool{"prod": true}
+
+	got := mergeRemoteSessions(prev, fetched, failed)
+	if len(got["prod"]) != 1 || got["prod"][0].ID != "r9" {
+		t.Fatalf("prod sessions = %+v, want last-good r9 retained — a failed fetch must not wipe a remote", got["prod"])
+	}
+	if len(got["dev"]) != 1 {
+		t.Fatalf("dev sessions = %+v, want r1 — healthy remote unaffected", got["dev"])
+	}
+}
+
+// TestIssue1170_RemovedFromConfig_DropsRemote (boundary): a remote removed
+// from config (absent from both fetched and failed) must disappear — we only
+// keep last-good for *errored* remotes, not deconfigured ones.
+func TestIssue1170_RemovedFromConfig_DropsRemote(t *testing.T) {
+	prev := map[string][]session.RemoteSessionInfo{
+		"dev":     {remoteInfo("dev", "r1", "a", "running")},
+		"retired": {remoteInfo("retired", "r2", "b", "running")},
+	}
+	fetched := map[string][]session.RemoteSessionInfo{
+		"dev": {remoteInfo("dev", "r1", "a", "running")},
+	}
+	got := mergeRemoteSessions(prev, fetched, nil)
+	if _, ok := got["retired"]; ok {
+		t.Fatalf("retired remote still present %+v — deconfigured remote must drop", got["retired"])
+	}
+}
+
+// TestIssue1170_FailedRemote_NoPriorData (boundary): a remote that errors and
+// has no last-good data simply yields no sessions — never a nil-deref panic.
+func TestIssue1170_FailedRemote_NoPriorData(t *testing.T) {
+	got := mergeRemoteSessions(nil, nil, map[string]bool{"prod": true})
+	if len(got["prod"]) != 0 {
+		t.Fatalf("prod sessions = %+v, want empty when no last-good exists", got["prod"])
+	}
+}
+
+// TestIssue1170_RemoteFetchMsg_FailedRemoteKeepsLastGood wires the merge
+// through the real Update handler: seed dev+prod, then deliver a fetch where
+// prod failed. The rendered list must still contain prod's session.
+func TestIssue1170_RemoteFetchMsg_FailedRemoteKeepsLastGood(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.refreshSessionRenderSnapshot(nil)
+
+	home.remoteSessionsMu.Lock()
+	home.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev":  {remoteInfo("dev", "r1", "a", "running")},
+		"prod": {remoteInfo("prod", "r9", "z", "waiting")},
+	}
+	home.remoteSessionsMu.Unlock()
+
+	model, _ := home.Update(remoteSessionsFetchedMsg{
+		sessions: map[string][]session.RemoteSessionInfo{
+			"dev": {remoteInfo("dev", "r1", "a", "running")},
+		},
+		failed: map[string]bool{"prod": true},
+	})
+	home = model.(*Home)
+
+	home.remoteSessionsMu.RLock()
+	prodCount := len(home.remoteSessions["prod"])
+	home.remoteSessionsMu.RUnlock()
+	if prodCount != 1 {
+		t.Fatalf("prod sessions after failed fetch = %d, want 1 (last-good retained, #1170)", prodCount)
+	}
+}


### PR DESCRIPTION
Closes #1170. Reported by @devtechwebsource.

## Summary

Remote sessions created after the TUI launched could stay invisible or flicker out, especially with multiple federated SSH remotes.

**Correction to the issue's root cause:** the shipped code (v1.9.30/.31) *does* re-poll remotes every 30s on `tickMsg` (`internal/ui/home.go`), so `fetchRemoteSessions` is **not** invoked only once. The real defects were:

1. **One shared timeout starved remotes.** `fetchRemoteSessions` shared a single 15s `context` across *all* remotes fetched **sequentially**. One slow/offline remote consumed the budget, the rest timed out and were `continue`d out of the result map.
2. **Wholesale replace wiped last-good data.** The handler did `h.remoteSessions = msg.sessions`. Any remote missing from a partial/failed fetch had its sessions erased until the next fully-successful fetch — producing the "stuck"/flickering list the reporter saw.

## Fix

- **Per-remote parallel fetch with its own 15s timeout** (mirrors the existing `measureRemoteLatencies` fanout) so no remote can starve another.
- **`failed` set on `remoteSessionsFetchedMsg` + pure `mergeRemoteSessions`**: errored remotes **keep last-good** sessions; successful fetches replace wholesale (new sessions appear, removed sessions drop); deconfigured remotes drop. Async, never blocks the UI thread.
- **Configurable cadence** `[ui] remote_session_refresh_secs` (default **15s**, clamped 5–300), resolved once at construction, gated through the testable `shouldFetchRemoteSessions(now)` helper.

## Surfaces

| Surface | Status | Evidence |
|---|---|---|
| **TUI** (`internal/ui/`) | ✅ Fixed + tested | `internal/ui/issue1170_remote_refresh_test.go` |
| **Persistence/config** (`internal/session/`) | ✅ Tested | `internal/session/issue1170_remote_session_refresh_test.go` |
| **Remote** (Local/RemoteSession) | ✅ Core of the fix | merge + per-remote timeout |
| **Web UI** (`internal/web/`) | N/A | Web does not render the federated remote-session list (only per-session SSH fields like `sshHost`); the frozen list this bug concerns is TUI-only |
| **CLI** (`cmd/agent-deck`) | N/A | `agent-deck remote sessions` is a one-shot fetch with no in-memory cache |
| **Cross-platform** | N/A | SSH fanout is platform-agnostic; no OS-specific path |

## Tests (happy / removed / failure / boundary)

- `ShouldFetch_WhenStale` / `SkipsWhenFresh` / `SkipsWhenActive` — poll gating (re-fetch mechanism, don't hammer SSH).
- `NewRemoteSession_Appears` — happy path: new remote session surfaces.
- `RemovedRemoteSession_Drops` — closed session drops on next fetch.
- `FailedRemoteFetch_KeepsLastGood` — **the fix**: errored remote retains last-good (no wipe).
- `RemovedFromConfig_DropsRemote` — boundary: deconfigured remote disappears.
- `FailedRemote_NoPriorData` — boundary: errored remote with no prior data → no panic.
- `RemoteFetchMsg_FailedRemoteKeepsLastGood` — same through the real `Update` handler.
- `GetRemoteSessionRefreshSecs` — config default/clamp table.

## Verification

- `go test -race -count=1 ./...` — green
- `golangci-lint run --timeout=5m` — 0 issues
- `govulncheck ./...` — 0 vulnerabilities in called code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable remote session refresh interval for SSH remote polling (default: 15 seconds, range: 5–300 seconds).

* **Improvements**
  * Remote session fetching now runs in parallel per-remote with independent timeouts.
  * Failed remote fetches now retain previously cached session data instead of clearing it.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->