### PR TITLE
feat(config): configurable default model for Claude sessions (#1172)

### DIFF
--- a/internal/session/issue1172_claude_default_model_test.go
+++ b/internal/session/issue1172_claude_default_model_test.go
@@ -1,0 +1,81 @@
+package session
+
+// Regression tests for #1172 — configurable default model for Claude sessions.
+//
+// Before #1023 shipped per-session model selection the new-session dialog had
+// no model field. After it, the dialog preselected the first catalog entry
+// (claude-sonnet-4-6) for Claude with no way to override it, even though
+// [gemini]/[opencode]/[copilot] already exposed a `default_model` key. This
+// file pins the config-parse half of the fix: [claude].default_model must
+// round-trip through TOML exactly like the other tools' default_model keys.
+//
+// Reported by @marekaf (agent-deck v1.9.29, confirmed absent in v1.9.31).
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Happy path: [claude].default_model parses into ClaudeSettings.DefaultModel.
+func TestIssue1172_ClaudeDefaultModel_ParsesFromTOML(t *testing.T) {
+	const doc = `
+[claude]
+default_model = "claude-opus-4-7"
+`
+	var cfg UserConfig
+	if _, err := toml.Decode(doc, &cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if cfg.Claude.DefaultModel != "claude-opus-4-7" {
+		t.Fatalf("Claude.DefaultModel = %q, want %q", cfg.Claude.DefaultModel, "claude-opus-4-7")
+	}
+}
+
+// Regression/boundary: when [claude] omits default_model the field is empty,
+// preserving the pre-#1172 behavior (tool falls back to its own default).
+func TestIssue1172_ClaudeDefaultModel_EmptyByDefault(t *testing.T) {
+	const doc = `
+[claude]
+dangerous_mode = true
+`
+	var cfg UserConfig
+	if _, err := toml.Decode(doc, &cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if cfg.Claude.DefaultModel != "" {
+		t.Fatalf("Claude.DefaultModel = %q, want empty when unset", cfg.Claude.DefaultModel)
+	}
+}
+
+// Parity: the Claude key uses the same toml tag spelling as the other tools so
+// users get a consistent config surface across [claude]/[gemini]/[opencode]/[copilot].
+func TestIssue1172_ClaudeDefaultModel_TagMatchesOtherTools(t *testing.T) {
+	const doc = `
+[claude]
+default_model = "claude-haiku-4-5"
+[gemini]
+default_model = "gemini-2.5-flash"
+[opencode]
+default_model = "anthropic/claude-opus-4-7"
+[copilot]
+default_model = "gpt-5.2"
+`
+	var cfg UserConfig
+	if _, err := toml.Decode(doc, &cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if cfg.Claude.DefaultModel != "claude-haiku-4-5" {
+		t.Fatalf("Claude.DefaultModel = %q, want claude-haiku-4-5", cfg.Claude.DefaultModel)
+	}
+	// Sanity: the other tools still parse unchanged (no accidental field shadowing).
+	if cfg.Gemini.DefaultModel != "gemini-2.5-flash" {
+		t.Fatalf("Gemini.DefaultModel = %q, want gemini-2.5-flash", cfg.Gemini.DefaultModel)
+	}
+	if cfg.OpenCode.DefaultModel != "anthropic/claude-opus-4-7" {
+		t.Fatalf("OpenCode.DefaultModel = %q, want anthropic/claude-opus-4-7", cfg.OpenCode.DefaultModel)
+	}
+	if cfg.Copilot.DefaultModel != "gpt-5.2" {
+		t.Fatalf("Copilot.DefaultModel = %q, want gpt-5.2", cfg.Copilot.DefaultModel)
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -821,6 +821,12 @@ type ClaudeSettings struct {
 	// copied to Instance.ExtraArgs when a Claude session is created.
 	ExtraArgs []string `toml:"extra_args"`
 
+	// DefaultModel is the model to preselect for new Claude sessions
+	// (e.g., "claude-opus-4-7"). Mirrors [gemini]/[opencode]/[copilot]
+	// default_model. When empty, the dialog leaves the model unset and Claude
+	// Code falls back to its own default (#1172).
+	DefaultModel string `toml:"default_model"`
+
 	// UseChrome enables --chrome by default for Claude sessions.
 	UseChrome bool `toml:"use_chrome"`
 
@@ -2760,6 +2766,8 @@ func CreateExampleConfig() error {
 # dangerous_mode = true
 # Extra Claude CLI flags remembered from the New Session dialog
 # extra_args = ["--agent", "reviewer"]
+# Default model preselected for new sessions (must be a known catalog model)
+# default_model = "claude-opus-4-7"
 # Enable Chrome / teammate mode by default
 # use_chrome = false
 # use_teammate_mode = false

--- a/internal/ui/issue1172_claude_default_model_test.go
+++ b/internal/ui/issue1172_claude_default_model_test.go
@@ -1,0 +1,115 @@
+package ui
+
+// Regression tests for #1172 — the new-session dialog must preselect the
+// configured [claude].default_model instead of always defaulting to the first
+// catalog entry (claude-sonnet-4-6). Reported by @marekaf.
+//
+// The model the dialog will launch with is exactly GetLaunchModelID(); these
+// tests assert that value after ShowInGroup loads the user config.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// showClaudeDialogWithConfig writes a config.toml under a temp HOME, points the
+// loader at it, then opens a fresh new-session dialog with the Claude tool
+// preselected. It returns the dialog so the caller can inspect GetLaunchModelID().
+func showClaudeDialogWithConfig(t *testing.T, cfg *session.UserConfig) *NewDialog {
+	t.Helper()
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	t.Cleanup(func() { os.Setenv("HOME", originalHome) })
+
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := session.SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	session.ClearUserConfigCache()
+
+	d := NewNewDialog()
+	d.SetDefaultTool("claude")
+	d.SetSize(100, 50)
+	d.ShowInGroup("projects", "Projects", "/tmp", nil, "")
+	return d
+}
+
+// Happy path: [claude].default_model set to a catalog model => the dialog
+// preselects it, so a new Claude session launches with --model that value.
+func TestIssue1172_ClaudeDefaultModelPreselected(t *testing.T) {
+	d := showClaudeDialogWithConfig(t, &session.UserConfig{
+		Claude: session.ClaudeSettings{DefaultModel: "claude-opus-4-7"},
+	})
+
+	if got := d.GetLaunchModelID(); got != "claude-opus-4-7" {
+		t.Fatalf("GetLaunchModelID() = %q, want claude-opus-4-7 (the configured default)", got)
+	}
+}
+
+// Regression: no [claude].default_model => the model field stays empty, which
+// is the pre-#1172 behavior (Claude uses its own default). This guards against
+// the fix accidentally forcing a model when none is configured.
+func TestIssue1172_NoDefaultModelFallsBackToEmpty(t *testing.T) {
+	d := showClaudeDialogWithConfig(t, &session.UserConfig{
+		Claude: session.ClaudeSettings{}, // no default_model
+	})
+
+	if got := d.GetLaunchModelID(); got != "" {
+		t.Fatalf("GetLaunchModelID() = %q, want empty when no default_model configured", got)
+	}
+}
+
+// Failure mode: a configured default that is NOT in the known catalog (typo,
+// stale pin, or alias like "opus") must degrade gracefully — no crash, and the
+// field falls back to empty rather than launching a bogus --model flag.
+func TestIssue1172_DefaultModelNotInCatalogGracefulFallback(t *testing.T) {
+	d := showClaudeDialogWithConfig(t, &session.UserConfig{
+		Claude: session.ClaudeSettings{DefaultModel: "claude-made-up-9000"},
+	})
+
+	if got := d.GetLaunchModelID(); got != "" {
+		t.Fatalf("GetLaunchModelID() = %q, want empty for a non-catalog default (graceful fallback)", got)
+	}
+}
+
+// Boundary: the Claude default must not leak into a non-Claude tool. Selecting
+// gemini with only [claude].default_model configured leaves gemini's model
+// empty (gemini has its own default_model path at command-build time).
+func TestIssue1172_ClaudeDefaultDoesNotLeakToOtherTools(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	t.Cleanup(func() { os.Setenv("HOME", originalHome) })
+
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	if err := os.MkdirAll(filepath.Join(tempDir, ".agent-deck"), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := session.SaveUserConfig(&session.UserConfig{
+		Claude: session.ClaudeSettings{DefaultModel: "claude-opus-4-7"},
+	}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	session.ClearUserConfigCache()
+
+	d := NewNewDialog()
+	d.SetDefaultTool("gemini")
+	d.SetSize(100, 50)
+	d.ShowInGroup("projects", "Projects", "/tmp", nil, "")
+
+	if got := d.GetLaunchModelID(); got != "" {
+		t.Fatalf("GetLaunchModelID() for gemini = %q, want empty (Claude default must not leak)", got)
+	}
+}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -426,6 +426,13 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 		}
 		d.inheritedSettings = buildInheritedSettings(userConfig.Docker)
 		d.branchPrefix = userConfig.Worktree.Prefix()
+		// #1172: preselect the configured default model so users who set
+		// [claude].default_model aren't forced to switch off Sonnet on every
+		// new session. Overrides the empty value set above; left empty when
+		// no (valid, in-catalog) default is configured.
+		if dm := preselectDefaultModel(userConfig, d.GetSelectedCommand()); dm != "" {
+			d.modelInput.SetValue(dm)
+		}
 	}
 	d.branchInput.Placeholder = d.branchPrefix + "branch-name"
 	d.rebuildFocusTargets()
@@ -826,6 +833,37 @@ func knownModelIDsForTool(tool string) []string {
 	default:
 		return nil
 	}
+}
+
+// preselectDefaultModel returns the model ID to prefill in the new-session
+// model field for the given tool. It honors the per-tool configured
+// default_model but only when that value is present in the tool's known-model
+// catalog — an empty default, an unset config, or a stale/typo'd value (e.g.
+// an alias like "opus" or a removed pin) all degrade gracefully to "" so the
+// dialog leaves the model unset and the tool falls back to its own default
+// rather than launching a bogus --model flag (#1172). Today only Claude routes
+// its launch model through this dialog field; the other tools apply their
+// default_model at command-build time.
+func preselectDefaultModel(config *session.UserConfig, tool string) string {
+	if config == nil {
+		return ""
+	}
+	var configured string
+	switch {
+	case session.IsClaudeCompatible(tool):
+		configured = config.Claude.DefaultModel
+	default:
+		return ""
+	}
+	if configured = strings.TrimSpace(configured); configured == "" {
+		return ""
+	}
+	for _, id := range knownModelIDsForTool(tool) {
+		if id == configured {
+			return configured
+		}
+	}
+	return ""
 }
 
 func (d *NewDialog) filterModelSuggestions() {


### PR DESCRIPTION
Closes #1172. Credit @marekaf for the report.

## Problem

Since #1023 the new-session dialog has a model field, but for Claude it always defaulted to empty/Sonnet (`claude-sonnet-4-6`) with no way to set a preferred default — forcing a manual switch to Opus on every new session. `[gemini]`, `[opencode]`, and `[copilot]` already exposed `default_model`; `[claude]` had none.

## Fix

1. **Config** — add `default_model` to the `[claude]` block (`ClaudeSettings.DefaultModel`, `toml:"default_model"`), mirroring the other tools' field exactly, plus the sample-config doc line.
2. **New-session dialog (TUI)** — `ShowInGroup` now preselects `[claude].default_model` when it is set **and** present in the known-model catalog. The model flows through the existing dialog field (`modelInput` → `GetLaunchModelID()` → `ApplyLaunchModel()` → `--model`), so a preselected default launches the session with that model end-to-end.
3. **Graceful fallback** — an unset, empty, or non-catalog value (typo, stale pin, or alias like `opus`) degrades to empty, preserving the pre-#1172 behavior (Claude uses its own default). No crash, no bogus `--model` flag.

## Surfaces

| Surface | Covered? | Notes |
|---|---|---|
| **TUI** (`internal/ui/`) | ✅ | `issue1172_claude_default_model_test.go` — preselect, no-default fallback, non-catalog fallback, no-leak-to-other-tools |
| **Persistence / config** (`internal/session/`) | ✅ | `issue1172_claude_default_model_test.go` — TOML parse, empty-default, cross-tool parity |
| **CLI** (`cmd/agent-deck`) | ⏭️ | `agent-deck launch` already accepts explicit `--model`; wiring the `[claude].default_model` into the no-flag CLI path (mirroring gemini's build-time apply) is a follow-up — out of scope per the issue's primary ask (dialog preselect). |
| **Web UI** (`internal/web/`) | ⏭️ | The web dialog sends an explicit `modelId`; surfacing `default_model` there needs a config-exposure endpoint + frontend change — follow-up. |
| **Remote / Cross-platform** | n/a | No session-level or OS-specific code path touched. |

## Tests

- `internal/ui/issue1172_claude_default_model_test.go` — happy path, regression (no default → empty), failure mode (non-catalog → graceful empty), boundary (Claude default must not leak into gemini).
- `internal/session/issue1172_claude_default_model_test.go` — TOML round-trip, empty-by-default, parity with `[gemini]/[opencode]/[copilot]`.

## Verification

- `go test -race -count=1 ./internal/ui/... ./internal/session/...` — green
- `go test -count=1 ./internal/web/... ./cmd/...` — green (no regression from the shared config change)
- `golangci-lint run --timeout=5m ./internal/ui/... ./internal/session/...` — 0 issues
- `go build ./...` — OK
- Other tools' `default_model` behavior unchanged (copilot/opencode/gemini option tests pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now configure a default model for Claude sessions in their settings, which automatically pre-fills the model selection when creating new sessions with graceful fallback for unavailable models.

* **Tests**
  * Added regression tests for TOML configuration parsing of the Claude default model setting.
  * Added UI tests validating model pre-selection, validation against available models, and tool-specific configuration isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->