### PR TITLE
fix(tmux): pane fills full terminal width on session open/attach (#1167)

### DIFF
--- a/internal/session/issue1167_remote_attach_width_test.go
+++ b/internal/session/issue1167_remote_attach_width_test.go
@@ -1,0 +1,86 @@
+//go:build !windows
+// +build !windows
+
+package session
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+	"github.com/creack/pty"
+)
+
+// TestRemoteAttach_FullWidthFromFrameOne is the remote-surface (#1167) parity
+// test. The remote attach path (SSHRunner.Attach in ssh.go) now starts its
+// local PTY through the shared tmux.StartAttachPTY helper rather than a bare
+// pty.Start. This test exercises that exact dependency: with a wide controlling
+// terminal, the attached tmux client must size the window to the full terminal
+// width, not the 80-col default that produced the ~50% symptom.
+//
+// A full SSH round-trip needs a live remote host, so this covers the sizing
+// dependency the remote path relies on. The local TUI path is covered by
+// internal/tmux/issue1167_attach_width_test.go.
+func TestRemoteAttach_FullWidthFromFrameOne(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux binary not available")
+	}
+	const cols, rows uint16 = 200, 50
+	const name = "issue1167-remote-fullwidth"
+	socket := filepath.Join(t.TempDir(), "sock")
+
+	// Reproduce a remote session's birth: detached (default 80x24),
+	// window-size=largest + aggressive-resize=on.
+	run := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-S", socket}, args...)
+		if out, err := exec.Command("tmux", full...).CombinedOutput(); err != nil {
+			t.Fatalf("tmux %v: %v\n%s", args, err, out)
+		}
+	}
+	run("new-session", "-d", "-s", name)
+	run("set-option", "-t", name, "window-size", "largest")
+	run("set-window-option", "-t", name, "aggressive-resize", "on")
+	t.Cleanup(func() { _ = exec.Command("tmux", "-S", socket, "kill-server").Run() })
+
+	termPTY, termTTY, err := pty.Open()
+	if err != nil {
+		t.Fatalf("pty.Open: %v", err)
+	}
+	defer func() { _ = termPTY.Close(); _ = termTTY.Close() }()
+	if err := pty.Setsize(termPTY, &pty.Winsize{Cols: cols, Rows: rows}); err != nil {
+		t.Fatalf("Setsize: %v", err)
+	}
+
+	cmd := exec.Command("tmux", "-S", socket, "attach-session", "-t", name)
+	ptmx, err := tmux.StartAttachPTY(cmd, termTTY)
+	if err != nil {
+		t.Fatalf("StartAttachPTY: %v", err)
+	}
+	defer func() {
+		_ = ptmx.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	out, err := exec.Command("tmux", "-S", socket,
+		"display", "-p", "-t", name, "#{window_width}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("display window_width: %v\n%s", err, out)
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parse window_width %q: %v", out, err)
+	}
+	if got != int(cols) {
+		t.Fatalf("remote attach window width = %d, want %d (full terminal); #1167", got, cols)
+	}
+}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -174,9 +174,13 @@ func (r *SSHRunner) Attach(sessionID string) error {
 
 	cmd := exec.Command("ssh", sshArgs...)
 
-	// Start SSH with a local PTY so it can detect terminal dimensions.
-	// Without this, piping stdin causes SSH to default to 80x24.
-	ptmx, err := pty.Start(cmd)
+	// Start SSH with a local PTY pre-sized to the controlling terminal so the
+	// remote tmux client connects full-width from frame one (#1167). A bare
+	// pty.Start creates the PTY at the 80x24 default, which under the remote
+	// session's window-size=largest pins the pane to ~half a wide terminal
+	// until an async SIGWINCH grows it. Shares the local-attach helper so both
+	// paths size identically.
+	ptmx, err := tmux.StartAttachPTY(cmd, os.Stdin)
 	if err != nil {
 		return fmt.Errorf("failed to start ssh with pty: %w", err)
 	}

--- a/internal/tmux/issue1167_attach_width_test.go
+++ b/internal/tmux/issue1167_attach_width_test.go
@@ -1,0 +1,155 @@
+//go:build !windows
+// +build !windows
+
+package tmux
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// Regression tests for #1167: opening/attaching a claude session renders the
+// pane at ~50% of the terminal width instead of 100%.
+//
+// Root cause: a detached `tmux new-session` (no -x/-y) is born at tmux's
+// default-size (80x24). When agent-deck attaches via the bare pty.Start, the
+// attach client's PTY is *also* created at the 80x24 default, so tmux's
+// window-size=largest pins the window to 80 cols — ~half of a wide terminal —
+// until an async SIGWINCH grows it. StartAttachPTY pre-sizes the attach PTY to
+// the controlling terminal so the client connects full-width from frame one.
+
+func tmuxCtl1167(t *testing.T, socket string, args ...string) {
+	t.Helper()
+	full := append([]string{"-S", socket}, args...)
+	if out, err := exec.Command("tmux", full...).CombinedOutput(); err != nil {
+		t.Fatalf("tmux %v: %v\n%s", args, err, out)
+	}
+}
+
+func windowWidth1167(t *testing.T, socket, name string) int {
+	t.Helper()
+	out, err := exec.Command("tmux", "-S", socket,
+		"display", "-p", "-t", name, "#{window_width}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("display window_width: %v\n%s", err, out)
+	}
+	w, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parse window_width %q: %v", out, err)
+	}
+	return w
+}
+
+// newDetachedSession1167 reproduces production session birth: a detached
+// session with NO -x/-y (so tmux uses its 80x24 default-size) plus the
+// window-size=largest / aggressive-resize=on options Session.Start pins.
+func newDetachedSession1167(t *testing.T, name string) string {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux binary not available")
+	}
+	socket := filepath.Join(t.TempDir(), "sock")
+	tmuxCtl1167(t, socket, "new-session", "-d", "-s", name)
+	tmuxCtl1167(t, socket, "set-option", "-t", name, "window-size", "largest")
+	tmuxCtl1167(t, socket, "set-window-option", "-t", name, "aggressive-resize", "on")
+	t.Cleanup(func() { _ = exec.Command("tmux", "-S", socket, "kill-server").Run() })
+	return socket
+}
+
+// attachAt1167 opens a controlling terminal of the given size, attaches through
+// StartAttachPTY, waits for tmux to register the client, and returns the window
+// width tmux reports.
+func attachAt1167(t *testing.T, socket, name string, cols, rows uint16) int {
+	t.Helper()
+
+	termPTY, termTTY, err := pty.Open()
+	if err != nil {
+		t.Fatalf("pty.Open: %v", err)
+	}
+	defer func() { _ = termPTY.Close(); _ = termTTY.Close() }()
+	if err := pty.Setsize(termPTY, &pty.Winsize{Cols: cols, Rows: rows}); err != nil {
+		t.Fatalf("Setsize: %v", err)
+	}
+
+	cmd := exec.Command("tmux", "-S", socket, "attach-session", "-t", name)
+	ptmx, err := StartAttachPTY(cmd, termTTY)
+	if err != nil {
+		t.Fatalf("StartAttachPTY: %v", err)
+	}
+	defer func() {
+		_ = ptmx.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	}()
+
+	// Give tmux a beat to register the client and arbitrate window-size.
+	time.Sleep(200 * time.Millisecond)
+	return windowWidth1167(t, socket, name)
+}
+
+// TestStartAttachPTY_FullWidthFromFrameOne is the happy path: attaching with a
+// wide controlling terminal must grow the window to the full terminal width,
+// not leave it at the 80-col default that produced the ~50% symptom.
+func TestStartAttachPTY_FullWidthFromFrameOne(t *testing.T) {
+	const cols, rows uint16 = 200, 50
+	socket := newDetachedSession1167(t, "issue1167-fullwidth")
+
+	got := attachAt1167(t, socket, "issue1167-fullwidth", cols, rows)
+	if got != int(cols) {
+		t.Fatalf("attached window width = %d, want %d (full terminal). "+
+			"#1167: the pane renders at ~50%% because the attach PTY started at "+
+			"the 80-col default instead of the controlling terminal size", got, cols)
+	}
+}
+
+// TestStartAttachPTY_MatchesNarrowTerminal is the boundary case: the window must
+// track the *actual* terminal size, proving StartAttachPTY uses the real
+// dimensions rather than any hardcoded width.
+func TestStartAttachPTY_MatchesNarrowTerminal(t *testing.T) {
+	const cols, rows uint16 = 132, 30
+	socket := newDetachedSession1167(t, "issue1167-narrow")
+
+	got := attachAt1167(t, socket, "issue1167-narrow", cols, rows)
+	if got != int(cols) {
+		t.Fatalf("attached window width = %d, want %d (exact terminal size)", got, cols)
+	}
+}
+
+// TestStartAttachPTY_FallsBackWhenSizeUnavailable is the failure mode: when the
+// controlling fd is not a terminal (GetsizeFull fails), StartAttachPTY must
+// still start the PTY (degraded, default size) rather than erroring out — the
+// attach must never break just because the size probe failed.
+func TestStartAttachPTY_FallsBackWhenSizeUnavailable(t *testing.T) {
+	socket := newDetachedSession1167(t, "issue1167-fallback")
+
+	// An os.Pipe read end is a valid *os.File but not a tty, so GetsizeFull
+	// returns an error and the helper must fall back to a plain start.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer func() { _ = r.Close(); _ = w.Close() }()
+
+	cmd := exec.Command("tmux", "-S", socket, "attach-session", "-t", "issue1167-fallback")
+	ptmx, err := StartAttachPTY(cmd, r)
+	if err != nil {
+		t.Fatalf("StartAttachPTY must not fail when size is unavailable: %v", err)
+	}
+	if ptmx == nil {
+		t.Fatal("StartAttachPTY returned a nil PTY on fallback")
+	}
+	_ = ptmx.Close()
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}
+}

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -108,6 +108,27 @@ func emitScrollbackClear(w io.Writer) {
 	_, _ = io.WriteString(w, itermClearScrollback)
 }
 
+// StartAttachPTY starts cmd attached to a new PTY pre-sized to tty's current
+// dimensions.
+//
+// #1167: tmux clients connect at their PTY's size. A detached `new-session`
+// (no -x/-y) is born at tmux's 80x24 default-size, and a bare pty.Start creates
+// the attach client's PTY at the same 80x24 default — so window-size=largest
+// pins the window to 80 cols, ~half of a wide terminal, until an async SIGWINCH
+// grows it. Reading the controlling terminal's real size up front and starting
+// the PTY with it makes the client full-width from frame one.
+//
+// When tty is not a terminal (size probe fails), it falls back to a plain start
+// at the default size: a degraded attach is still better than no attach.
+func StartAttachPTY(cmd *exec.Cmd, tty *os.File) (*os.File, error) {
+	if tty != nil {
+		if ws, err := pty.GetsizeFull(tty); err == nil && ws.Cols > 0 && ws.Rows > 0 {
+			return pty.StartWithSize(cmd, ws)
+		}
+	}
+	return pty.Start(cmd)
+}
+
 // Attach attaches to the tmux session with full PTY support.
 // The configured detach key (default Ctrl+Q) will detach and return to the caller.
 // Pass an optional detachByte to override the default (0x11 / Ctrl+Q).
@@ -169,8 +190,9 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 	// SIGINT is restored in cleanupAttach() via signal.Reset(syscall.SIGINT).
 	signal.Ignore(syscall.SIGINT)
 
-	// Start command with PTY
-	ptmx, err := pty.Start(cmd)
+	// Start command with PTY, pre-sized to the controlling terminal so the
+	// tmux client connects full-width from frame one (#1167).
+	ptmx, err := StartAttachPTY(cmd, os.Stdin)
 	if err != nil {
 		signal.Reset(syscall.SIGINT)
 		return fmt.Errorf("failed to start pty: %w", err)


### PR DESCRIPTION
## Problem

Reported via Feedback Hub by **@OrNatanAxon** (v1.9.20, darwin arm64): opening/attaching a claude session renders the pane at **~50% of the terminal width** instead of 100%.

## Root cause

tmux geometry, confirmed on tmux 3.4:

1. agent-deck creates the session **detached** (`tmux new-session -d`, no `-x/-y`) — tmux's `default-size` births it at **80×24**.
2. On attach, `pty.Start(cmd)` creates the attach client's PTY at the **same 80×24 default**.
3. The session pins `window-size=largest` (+ `aggressive-resize=on`), so the window sizes to the *largest attached client* — 80 cols. On a 160-col terminal that's exactly **50%**.
4. The only thing that grows it is an **async post-start `SIGWINCH`** (`pty.go`), so the user sees a half-width frame on open until that race resolves — and the inner app (claude) may have already painted at 80.

## Fix (geometry/resize layer)

New shared helper `tmux.StartAttachPTY(cmd, tty)` reads the controlling terminal's real size up front and starts the attach PTY with it via `pty.StartWithSize`, so the tmux client connects **full-width from frame one** — no race. Falls back to a plain start when the size probe fails (degraded attach beats no attach).

Both attach paths use it for parity:
- **Local TUI attach** — `internal/tmux/pty.go` (`Session.Attach`)
- **Remote SSH attach** — `internal/session/ssh.go` (`SSHRunner.Attach`)

The test helper `multiclienttmux` already started its clients with `pty.StartWithSize`; production attach was the asymmetric one.

## Surfaces

| Surface | Covered | Test file |
|---|---|---|
| **TUI** (local attach) | ✅ | `internal/tmux/issue1167_attach_width_test.go` |
| **Remote** (ssh attach) | ✅ shares `StartAttachPTY` | `internal/session/issue1167_remote_attach_width_test.go` |
| **Web UI** | n/a — `terminal_bridge.go` already sizes the PTY from the xterm.js/FitAddon viewport (`pty.Setsize`), a different path unaffected by this bug |
| **CLI / Persistence** | n/a — no attach-width logic |
| **Cross-platform** | unix pty path (`//go:build !windows`), consistent with the existing attach code; Windows uses a separate path |

## Tests (integration, isolated tmux socket, `!windows`)

Each reproduces production session birth (detached, default 80×24, `window-size=largest`), then attaches through a controlling PTY of a chosen size and asserts `#{window_width}`:

- **Happy path** — wide terminal (200) → window 200 (was 80 before the fix)
- **Boundary** — narrow terminal (132) → window 132 (proves real size, not a hardcoded value)
- **Failure mode** — non-tty fd → falls back, still returns a valid PTY (no error)
- **Remote** — full-width via the shared helper the ssh path now calls

All written test-first: confirmed RED (`width = 80, want 200`) before the fix, GREEN after. Race-clean, `golangci-lint` 0 issues.

> Pre-existing unrelated failure `TestSession_SetsUpActivityMonitoring` fails identically on `main` in this sandbox (activity-monitoring hook can't be set here) — not introduced by this change.

## Note on #1168

Investigated — **not** the same root cause. #1168 is a **web** Playwright visual-regression run where **all 18/18** snapshots failed uniformly with text anti-aliasing diffs while layout stayed identical (font/rendering-environment drift / stale baselines), across unrelated views and viewports. A TUI tmux-geometry bug cannot cause web snapshot diffs. It needs a separate re-baseline in the CI rendering environment, not a code fix — left out of this PR deliberately.

Closes #1167

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed remote tmux session attachments (via SSH) to properly detect and use the full terminal width from the initial connection, resolving sizing issues where windows defaulted to smaller dimensions.

* **Tests**
  * Added regression tests to verify remote session attachments correctly match the controlling terminal's dimensions across various terminal sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->