### PR TITLE
test(tmux): poll-until-width instead of fixed sleep in #1167 attach tests (fixes release-CI flake)

### DIFF
--- a/internal/session/issue1167_remote_attach_width_test.go
+++ b/internal/session/issue1167_remote_attach_width_test.go
@@ -69,16 +69,34 @@ func TestRemoteAttach_FullWidthFromFrameOne(t *testing.T) {
 		}
 	}()
 
-	time.Sleep(200 * time.Millisecond)
-
-	out, err := exec.Command("tmux", "-S", socket,
-		"display", "-p", "-t", name, "#{window_width}").CombinedOutput()
-	if err != nil {
-		t.Fatalf("display window_width: %v\n%s", err, out)
+	// Read the window width tmux reports for the attached client.
+	readWidth := func() int {
+		t.Helper()
+		out, err := exec.Command("tmux", "-S", socket,
+			"display", "-p", "-t", name, "#{window_width}").CombinedOutput()
+		if err != nil {
+			t.Fatalf("display window_width: %v\n%s", err, out)
+		}
+		w, err := strconv.Atoi(strings.TrimSpace(string(out)))
+		if err != nil {
+			t.Fatalf("parse window_width %q: %v", out, err)
+		}
+		return w
 	}
-	got, err := strconv.Atoi(strings.TrimSpace(string(out)))
-	if err != nil {
-		t.Fatalf("parse window_width %q: %v", out, err)
+
+	// Poll until tmux registers the client and arbitrates window-size up to the
+	// expected width, or a generous timeout elapses. A fixed sleep races under
+	// heavy CI load: the async SIGWINCH/client-registration can take longer than
+	// any single guess, so the read fires while the window is still at the 80-col
+	// default. Polling stays fast on idle runners, waits as needed on loaded ones,
+	// and still surfaces the real (failing) width if a genuine regression never
+	// grows the window.
+	want := int(cols)
+	deadline := time.Now().Add(5 * time.Second)
+	got := readWidth()
+	for got != want && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+		got = readWidth()
 	}
 	if got != int(cols) {
 		t.Fatalf("remote attach window width = %d, want %d (full terminal); #1167", got, cols)

--- a/internal/tmux/issue1167_attach_width_test.go
+++ b/internal/tmux/issue1167_attach_width_test.go
@@ -91,9 +91,21 @@ func attachAt1167(t *testing.T, socket, name string, cols, rows uint16) int {
 		}
 	}()
 
-	// Give tmux a beat to register the client and arbitrate window-size.
-	time.Sleep(200 * time.Millisecond)
-	return windowWidth1167(t, socket, name)
+	// Poll until tmux registers the client and arbitrates window-size up to the
+	// expected width, or a generous timeout elapses. A fixed sleep races under
+	// heavy CI load: the async SIGWINCH/client-registration can take longer than
+	// any single guess, so the read fires while the window is still at the 80-col
+	// default. Polling stays fast on idle runners, waits as needed on loaded ones,
+	// and still returns the real (failing) width if a genuine regression never
+	// grows the window.
+	want := int(cols)
+	deadline := time.Now().Add(5 * time.Second)
+	width := windowWidth1167(t, socket, name)
+	for width != want && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+		width = windowWidth1167(t, socket, name)
+	}
+	return width
 }
 
 // TestStartAttachPTY_FullWidthFromFrameOne is the happy path: attaching with a


### PR DESCRIPTION
## Problem

The #1167 attach-width regression tests (`internal/tmux/issue1167_attach_width_test.go` and `internal/session/issue1167_remote_attach_width_test.go`) pass locally and in PR-CI but **deterministically fail in the release.yml runner**:

```
issue1167_attach_width_test.go:108: attached window width = 80, want 200
issue1167_attach_width_test.go:123: attached window width = 80, want 132
issue1167_remote_attach_width_test.go:84: remote attach window width = 80, want 200
```

## Root cause

Both helpers waited a **fixed `time.Sleep(200ms)`** for tmux to register the attach client and arbitrate `window-size=largest`, then read the window width once. Under the release runner's heavy parallel load (full suite + eval harness), 200ms is too short — the read fires before the async SIGWINCH grows the window from the 80-col default. Locally and in PR-CI the machine is fast enough, so it passes there.

## Fix

Replace the fixed sleep + single read with a **bounded poll loop**: read `window_width` every 50ms until it reaches the expected width or a generous 5s timeout elapses. Return the last-read width so a genuine regression still fails with the real value.

- Fast runners pass immediately; slow runners wait as needed; a real regression still fails after the timeout.
- Assertion semantics unchanged (still asserts `width == expected`) — only the **wait** changed, not the threshold.
- The fix code (`StartAttachPTY` in `internal/tmux/pty.go`) is **not touched**.

## Verification

- `go test -count=3 -run "Issue1167|StartAttachPTY|RemoteAttach" ./internal/tmux/... ./internal/session/...` — green every run
- `go test -count=3 -race ./internal/tmux/... ./internal/session/...` — green (approximates release-runner pressure)
- `golangci-lint run` — 0 issues

Refs #1167

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of remote attach width tests by replacing fixed timing delays with adaptive polling mechanisms that verify window width stabilization, reducing flakiness on heavily loaded CI systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->