### PR TITLE
fix(notifier): trustworthy worker-finished signal via completion sentinel (#1186)

### DIFF
--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -39,6 +39,12 @@ type hookStatusFile struct {
 	SessionID string `json:"session_id,omitempty"`
 	Event     string `json:"event"`
 	Timestamp int64  `json:"ts"`
+	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
+	// detected on the Stop edge (issue #1186). omitempty so ordinary Stops
+	// (no sentinel) leave the fields absent, which the daemon reads as
+	// "no finished event to emit."
+	DoneStatus  string `json:"done_status,omitempty"`
+	DoneSummary string `json:"done_summary,omitempty"`
 }
 
 // mapEventToStatus maps a Claude Code hook event to an agent-deck status string.
@@ -124,7 +130,21 @@ func handleHookHandler() {
 		return
 	}
 
-	writeHookStatus(instanceID, status, payload.SessionID, payload.HookEventName)
+	// Issue #1186: on the Stop edge — the completion edge — scan the transcript
+	// tail for a worker-printed completion sentinel. When present, persist the
+	// parsed outcome into the hook status file so the daemon can emit a
+	// distinct "finished" event to the parent instead of the conductor having
+	// to poll artifacts. Absent on ordinary mid-task Stops, so the existing
+	// "waiting" behavior is unchanged.
+	if payload.HookEventName == "Stop" {
+		if sig, ok := detectDoneSentinel(data); ok {
+			writeHookStatus(instanceID, status, payload.SessionID, payload.HookEventName, sig)
+		} else {
+			writeHookStatus(instanceID, status, payload.SessionID, payload.HookEventName)
+		}
+	} else {
+		writeHookStatus(instanceID, status, payload.SessionID, payload.HookEventName)
+	}
 
 	// #572: Sync agent-deck title from Claude Code's --name / /rename value.
 	// Event-driven so user-facing rename lands within one hook tick; silent
@@ -168,7 +188,9 @@ func parentIsDSP() bool {
 }
 
 // writeHookStatus writes a hook status file atomically for one instance.
-func writeHookStatus(instanceID, status, sessionID, event string) {
+// The optional done argument carries a completion sentinel (issue #1186);
+// when supplied its status/summary are persisted alongside the hook status.
+func writeHookStatus(instanceID, status, sessionID, event string, done ...session.DoneSignal) {
 	if instanceID == "" || status == "" {
 		return
 	}
@@ -195,6 +217,10 @@ func writeHookStatus(instanceID, status, sessionID, event string) {
 		SessionID: sessionID,
 		Event:     event,
 		Timestamp: time.Now().Unix(),
+	}
+	if len(done) > 0 {
+		statusFile.DoneStatus = done[0].Status
+		statusFile.DoneSummary = done[0].Summary
 	}
 
 	jsonData, err := json.Marshal(statusFile)
@@ -524,6 +550,87 @@ func writeCostEvent(instanceID string, rawPayload []byte) {
 		return
 	}
 	logCostDebug("wrote cost event: %s model=%s in=%d out=%d", finalPath, cf.Model, cf.InputTokens, cf.OutputTokens)
+}
+
+// transcriptContentMessage extracts the assistant message content blocks from
+// the last transcript line, for completion-sentinel detection (issue #1186).
+type transcriptContentMessage struct {
+	Type    string `json:"type"`
+	Message struct {
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+// detectDoneSentinel parses transcript_path out of a Stop hook payload and
+// scans the transcript tail for a worker-printed completion sentinel. It
+// applies the same path-traversal / ~/.claude containment guards as the cost
+// path so a crafted payload can't read arbitrary files.
+func detectDoneSentinel(rawPayload []byte) (session.DoneSignal, bool) {
+	var stop stopHookPayload
+	if err := json.Unmarshal(rawPayload, &stop); err != nil {
+		return session.DoneSignal{}, false
+	}
+	if stop.TranscriptPath == "" {
+		return session.DoneSignal{}, false
+	}
+	cleanPath := filepath.Clean(stop.TranscriptPath)
+	if strings.Contains(cleanPath, "..") {
+		return session.DoneSignal{}, false
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if !strings.HasPrefix(cleanPath, filepath.Join(home, ".claude")) {
+			return session.DoneSignal{}, false
+		}
+	}
+	return scanTranscriptForDone(cleanPath)
+}
+
+// scanTranscriptForDone reads the last transcript line, and if it is an
+// assistant turn, scans its text content for a completion sentinel. The path
+// is the injectable source: tests point it at a temp file, no live agent
+// required. A missing/unreadable file or a non-assistant tail yields no
+// sentinel rather than an error.
+func scanTranscriptForDone(path string) (session.DoneSignal, bool) {
+	lastLine, err := readLastLine(path)
+	if err != nil {
+		return session.DoneSignal{}, false
+	}
+	var msg transcriptContentMessage
+	if err := json.Unmarshal([]byte(lastLine), &msg); err != nil {
+		return session.DoneSignal{}, false
+	}
+	if msg.Type != "assistant" {
+		return session.DoneSignal{}, false
+	}
+	return session.ScanDoneSentinel(transcriptText(msg.Message.Content))
+}
+
+// transcriptText flattens an assistant message's content into plain text.
+// Claude transcripts encode content either as a string or as an array of
+// typed blocks ({"type":"text","text":"..."}); only text blocks contribute.
+func transcriptText(content json.RawMessage) string {
+	if len(content) == 0 {
+		return ""
+	}
+	var asString string
+	if err := json.Unmarshal(content, &asString); err == nil {
+		return asString
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, b := range blocks {
+		if b.Type == "text" {
+			sb.WriteString(b.Text)
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
 }
 
 // readLastLine reads the last non-empty line from a file.

--- a/cmd/agent-deck/issue1186_done_signal_test.go
+++ b/cmd/agent-deck/issue1186_done_signal_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Issue #1186: a worker asserts task completion by printing a completion
+// sentinel. On the Stop hook edge, agent-deck scans the transcript tail for
+// that sentinel and persists the parsed outcome into the hook status file so
+// the daemon can emit a distinct "finished" event to the parent. These tests
+// cover the cmd-side detection + persistence; the daemon-side emit lives in
+// internal/session. The transcript source is injectable (a file path) so the
+// tests don't need a live agent.
+
+// writeTranscript writes JSONL lines to a temp file and returns its path.
+func writeTranscript(t *testing.T, lines ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// assistantLine builds a transcript assistant message whose text content holds
+// the supplied body.
+func assistantLine(t *testing.T, body string) string {
+	t.Helper()
+	msg := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"role":    "assistant",
+			"content": []map[string]any{{"type": "text", "text": body}},
+		},
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal assistant line: %v", err)
+	}
+	return string(b)
+}
+
+func TestScanTranscriptForDone_OK(t *testing.T) {
+	path := writeTranscript(t,
+		assistantLine(t, "doing work"),
+		assistantLine(t, "all set.\n===AGENTDECK_DONE=== status=ok summary=feature shipped"),
+	)
+	sig, ok := scanTranscriptForDone(path)
+	if !ok {
+		t.Fatalf("expected sentinel detected in transcript")
+	}
+	if sig.Status != "ok" || sig.Summary != "feature shipped" {
+		t.Errorf("got status=%q summary=%q", sig.Status, sig.Summary)
+	}
+}
+
+func TestScanTranscriptForDone_Fail(t *testing.T) {
+	path := writeTranscript(t,
+		assistantLine(t, "===AGENTDECK_DONE=== status=fail summary=could not build"),
+	)
+	sig, ok := scanTranscriptForDone(path)
+	if !ok {
+		t.Fatalf("expected sentinel detected")
+	}
+	if sig.Status != "fail" || sig.Summary != "could not build" {
+		t.Errorf("got status=%q summary=%q", sig.Status, sig.Summary)
+	}
+}
+
+func TestScanTranscriptForDone_NoSentinel(t *testing.T) {
+	path := writeTranscript(t,
+		assistantLine(t, "just an ordinary mid-task turn, no sentinel here"),
+	)
+	if _, ok := scanTranscriptForDone(path); ok {
+		t.Errorf("expected no sentinel for ordinary turn")
+	}
+}
+
+func TestScanTranscriptForDone_MalformedIgnored(t *testing.T) {
+	path := writeTranscript(t,
+		assistantLine(t, "===AGENTDECK_DONE=== status=maybe summary=garbage"),
+	)
+	if _, ok := scanTranscriptForDone(path); ok {
+		t.Errorf("expected malformed sentinel to be ignored")
+	}
+}
+
+func TestScanTranscriptForDone_NonAssistantLastLine(t *testing.T) {
+	// A user/tool line as the tail must not be mined for a sentinel.
+	userLine := `{"type":"user","message":{"role":"user","content":"===AGENTDECK_DONE=== status=ok summary=spoofed"}}`
+	path := writeTranscript(t, userLine)
+	if _, ok := scanTranscriptForDone(path); ok {
+		t.Errorf("expected non-assistant tail to yield no sentinel")
+	}
+}
+
+func TestScanTranscriptForDone_MissingFile(t *testing.T) {
+	if _, ok := scanTranscriptForDone(filepath.Join(t.TempDir(), "nope.jsonl")); ok {
+		t.Errorf("expected missing transcript to yield no sentinel, not a crash")
+	}
+}
+
+func TestWriteHookStatus_PersistsDoneFields(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	instanceID := "inst-done"
+
+	done := session.DoneSignal{Status: "ok", Summary: "done and dusted"}
+	writeHookStatus(instanceID, "waiting", "sess-1", "Stop", done)
+
+	data, err := os.ReadFile(filepath.Join(getHooksDir(), instanceID+".json"))
+	if err != nil {
+		t.Fatalf("read hook file: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal hook file: %v", err)
+	}
+	if parsed["done_status"] != "ok" {
+		t.Errorf("done_status = %v, want ok", parsed["done_status"])
+	}
+	if parsed["done_summary"] != "done and dusted" {
+		t.Errorf("done_summary = %v, want %q", parsed["done_summary"], "done and dusted")
+	}
+}
+
+func TestWriteHookStatus_NoDoneFieldsWhenAbsent(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	instanceID := "inst-nodone"
+
+	writeHookStatus(instanceID, "waiting", "sess-2", "Stop")
+
+	data, err := os.ReadFile(filepath.Join(getHooksDir(), instanceID+".json"))
+	if err != nil {
+		t.Fatalf("read hook file: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal hook file: %v", err)
+	}
+	if _, present := parsed["done_status"]; present {
+		t.Errorf("done_status should be omitted for ordinary Stop, got %v", parsed["done_status"])
+	}
+}

--- a/internal/session/done_sentinel.go
+++ b/internal/session/done_sentinel.go
@@ -1,0 +1,69 @@
+package session
+
+import "strings"
+
+// DoneSentinelMarker is the token a worker prints to assert that it has
+// finished its assigned task. Issue #1186: the conductor previously had no
+// trustworthy "worker finished" signal because Claude's Stop hook fires at
+// the end of every turn and is mapped to the generic "waiting" status.
+// Completion is now asserted by the only party that knows — the worker —
+// by ending its final turn with a line of the form:
+//
+//	===AGENTDECK_DONE=== status=<ok|fail> summary=<text to end of line>
+const DoneSentinelMarker = "===AGENTDECK_DONE==="
+
+// DoneSignal is the parsed payload of a completion sentinel.
+type DoneSignal struct {
+	Status  string // "ok" or "fail"
+	Summary string // free text to end of line; may be empty
+}
+
+// ParseDoneSentinel parses a single line. It returns the signal and true only
+// when the line contains the marker followed by a valid status=<ok|fail>.
+// A summary= field is optional; its value runs to the end of the line.
+// Anything that doesn't match — no marker, missing status, an unrecognized
+// status value — is rejected (ok=false) rather than guessed at.
+func ParseDoneSentinel(line string) (DoneSignal, bool) {
+	_, afterMarker, hasMarker := strings.Cut(line, DoneSentinelMarker)
+	if !hasMarker {
+		return DoneSignal{}, false
+	}
+	rest := strings.TrimSpace(afterMarker)
+
+	_, afterStatus, hasStatus := strings.Cut(rest, "status=")
+	if !hasStatus {
+		return DoneSignal{}, false
+	}
+
+	// status value is the first whitespace-delimited token after status=.
+	status := afterStatus
+	if cut := strings.IndexAny(status, " \t"); cut >= 0 {
+		status = status[:cut]
+	}
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status != "ok" && status != "fail" {
+		return DoneSignal{}, false
+	}
+
+	summary := ""
+	if _, after, hasSummary := strings.Cut(rest, "summary="); hasSummary {
+		summary = strings.TrimSpace(after)
+	}
+
+	return DoneSignal{Status: status, Summary: summary}, true
+}
+
+// ScanDoneSentinel scans multi-line text and returns the LAST line that parses
+// as a valid sentinel. Last-wins so a worker that retried (printing fail then
+// ok) reports its final outcome.
+func ScanDoneSentinel(text string) (DoneSignal, bool) {
+	var found DoneSignal
+	var ok bool
+	for line := range strings.SplitSeq(text, "\n") {
+		if sig, valid := ParseDoneSentinel(line); valid {
+			found = sig
+			ok = true
+		}
+	}
+	return found, ok
+}

--- a/internal/session/done_sentinel_test.go
+++ b/internal/session/done_sentinel_test.go
@@ -1,0 +1,95 @@
+package session
+
+import "testing"
+
+// Issue #1186: a worker asserts task completion by printing a machine-greppable
+// sentinel line. These tests pin the parse contract for that line so the
+// detection (cmd/agent-deck) and emit (daemon) sides agree on the format.
+
+func TestParseDoneSentinel_OK(t *testing.T) {
+	sig, ok := ParseDoneSentinel("===AGENTDECK_DONE=== status=ok summary=did the thing")
+	if !ok {
+		t.Fatalf("expected sentinel to parse, got ok=false")
+	}
+	if sig.Status != "ok" {
+		t.Errorf("status = %q, want ok", sig.Status)
+	}
+	if sig.Summary != "did the thing" {
+		t.Errorf("summary = %q, want %q", sig.Summary, "did the thing")
+	}
+}
+
+func TestParseDoneSentinel_Fail(t *testing.T) {
+	sig, ok := ParseDoneSentinel("===AGENTDECK_DONE=== status=fail summary=tests red")
+	if !ok {
+		t.Fatalf("expected sentinel to parse, got ok=false")
+	}
+	if sig.Status != "fail" {
+		t.Errorf("status = %q, want fail", sig.Status)
+	}
+	if sig.Summary != "tests red" {
+		t.Errorf("summary = %q, want %q", sig.Summary, "tests red")
+	}
+}
+
+func TestParseDoneSentinel_LeadingPrefixOnLine(t *testing.T) {
+	// The worker may print the sentinel with surrounding prose on the same
+	// line; the marker just has to appear. Summary runs to end of line.
+	sig, ok := ParseDoneSentinel("blah blah ===AGENTDECK_DONE=== status=ok summary=all green now")
+	if !ok {
+		t.Fatalf("expected sentinel to parse")
+	}
+	if sig.Status != "ok" || sig.Summary != "all green now" {
+		t.Errorf("got status=%q summary=%q", sig.Status, sig.Summary)
+	}
+}
+
+func TestParseDoneSentinel_EmptySummary(t *testing.T) {
+	sig, ok := ParseDoneSentinel("===AGENTDECK_DONE=== status=ok summary=")
+	if !ok {
+		t.Fatalf("expected sentinel to parse")
+	}
+	if sig.Status != "ok" || sig.Summary != "" {
+		t.Errorf("got status=%q summary=%q", sig.Status, sig.Summary)
+	}
+}
+
+func TestParseDoneSentinel_Malformed(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"no marker", "just some ordinary assistant output"},
+		{"marker no status", "===AGENTDECK_DONE=== summary=missing status"},
+		{"invalid status value", "===AGENTDECK_DONE=== status=maybe summary=nope"},
+		{"empty status value", "===AGENTDECK_DONE=== status= summary=x"},
+		{"empty line", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := ParseDoneSentinel(tc.line); ok {
+				t.Errorf("expected malformed line %q to be rejected", tc.line)
+			}
+		})
+	}
+}
+
+func TestScanDoneSentinel_LastWins(t *testing.T) {
+	text := "doing work\n" +
+		"===AGENTDECK_DONE=== status=fail summary=first attempt\n" +
+		"retrying\n" +
+		"===AGENTDECK_DONE=== status=ok summary=second attempt succeeded\n"
+	sig, ok := ScanDoneSentinel(text)
+	if !ok {
+		t.Fatalf("expected scan to find a sentinel")
+	}
+	if sig.Status != "ok" || sig.Summary != "second attempt succeeded" {
+		t.Errorf("expected last sentinel to win, got status=%q summary=%q", sig.Status, sig.Summary)
+	}
+}
+
+func TestScanDoneSentinel_None(t *testing.T) {
+	if _, ok := ScanDoneSentinel("nothing\nto\nsee\nhere"); ok {
+		t.Errorf("expected no sentinel found in plain text")
+	}
+}

--- a/internal/session/event_fingerprint.go
+++ b/internal/session/event_fingerprint.go
@@ -32,6 +32,18 @@ func EventFingerprint(e TransitionNotificationEvent) string {
 	b.WriteString(strings.ToLower(strings.TrimSpace(e.ToStatus)))
 	b.WriteByte('|')
 	b.WriteString(strconv.FormatInt(e.Timestamp.UnixNano(), 10))
+	// Issue #1186: finished events carry no from→to transition, so without
+	// the kind + outcome the fingerprint would collapse distinct completions
+	// (and could collide with a same-timestamp transition). Append them so
+	// each completion assertion is its own logical event.
+	if e.Kind != "" {
+		b.WriteByte('|')
+		b.WriteString(e.Kind)
+		b.WriteByte('|')
+		b.WriteString(strings.ToLower(strings.TrimSpace(e.DoneStatus)))
+		b.WriteByte('|')
+		b.WriteString(strings.TrimSpace(e.DoneSummary))
+	}
 	sum := sha256.Sum256([]byte(b.String()))
 	return hex.EncodeToString(sum[:])
 }

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -24,6 +24,10 @@ type HookStatus struct {
 	SessionID string    // Claude session ID
 	Event     string    // Hook event name
 	UpdatedAt time.Time // When this status was received
+	// DoneStatus/DoneSummary carry a worker-printed completion sentinel
+	// detected on the Stop edge (issue #1186). Empty for ordinary turns.
+	DoneStatus  string // "ok" or "fail" when a completion sentinel was seen
+	DoneSummary string // free-text completion summary
 }
 
 // StatusFileWatcher watches ~/.agent-deck/hooks/ for status file changes
@@ -188,20 +192,24 @@ func (w *StatusFileWatcher) scanDisk() map[string]*HookStatus {
 			continue
 		}
 		var raw struct {
-			Status    string `json:"status"`
-			SessionID string `json:"session_id"`
-			Event     string `json:"event"`
-			Timestamp int64  `json:"ts"`
+			Status      string `json:"status"`
+			SessionID   string `json:"session_id"`
+			Event       string `json:"event"`
+			Timestamp   int64  `json:"ts"`
+			DoneStatus  string `json:"done_status"`
+			DoneSummary string `json:"done_summary"`
 		}
 		if uerr := json.Unmarshal(data, &raw); uerr != nil {
 			continue
 		}
 		instanceID := strings.TrimSuffix(entry.Name(), ".json")
 		out[instanceID] = &HookStatus{
-			Status:    raw.Status,
-			SessionID: raw.SessionID,
-			Event:     raw.Event,
-			UpdatedAt: time.Unix(raw.Timestamp, 0),
+			Status:      raw.Status,
+			SessionID:   raw.SessionID,
+			Event:       raw.Event,
+			UpdatedAt:   time.Unix(raw.Timestamp, 0),
+			DoneStatus:  raw.DoneStatus,
+			DoneSummary: raw.DoneSummary,
 		}
 	}
 	return out
@@ -269,10 +277,12 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 	}
 
 	var status struct {
-		Status    string `json:"status"`
-		SessionID string `json:"session_id"`
-		Event     string `json:"event"`
-		Timestamp int64  `json:"ts"`
+		Status      string `json:"status"`
+		SessionID   string `json:"session_id"`
+		Event       string `json:"event"`
+		Timestamp   int64  `json:"ts"`
+		DoneStatus  string `json:"done_status"`
+		DoneSummary string `json:"done_summary"`
 	}
 	if err := json.Unmarshal(data, &status); err != nil {
 		hookLog.Warn("hook_file_corrupt",
@@ -289,10 +299,12 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 	instanceID := strings.TrimSuffix(base, ".json")
 
 	hookStatus := &HookStatus{
-		Status:    status.Status,
-		SessionID: status.SessionID,
-		Event:     status.Event,
-		UpdatedAt: time.Unix(status.Timestamp, 0),
+		Status:      status.Status,
+		SessionID:   status.SessionID,
+		Event:       status.Event,
+		UpdatedAt:   time.Unix(status.Timestamp, 0),
+		DoneStatus:  status.DoneStatus,
+		DoneSummary: status.DoneSummary,
 	}
 
 	w.mu.Lock()

--- a/internal/session/issue1186_done_emit_test.go
+++ b/internal/session/issue1186_done_emit_test.go
@@ -1,0 +1,236 @@
+package session
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Issue #1186: the daemon turns a worker-printed completion sentinel (persisted
+// into the hook status file by the Stop-hook handler) into a distinct
+// "finished" event delivered to the parent. These tests pin the emit side:
+// the [DONE] message format, ok/fail outcome, and per-task idempotency.
+
+// seedDoneParentChild creates a live conductor parent and a worker child in a
+// fresh profile's storage, returning the profile and ids.
+func seedDoneParentChild(t *testing.T, profile string) (parentID, childID string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+	if err := os.MkdirAll(home+"/.agent-deck", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	defer storage.Close()
+
+	now := time.Now()
+	parent := &Instance{
+		ID:          "parent-conductor-1186",
+		Title:       "conductor-1186",
+		ProjectPath: "/tmp/p1186",
+		GroupPath:   DefaultGroupPath,
+		Tool:        "claude",
+		Status:      StatusIdle,
+		CreatedAt:   now,
+	}
+	child := &Instance{
+		ID:              "child-worker-1186",
+		Title:           "worker",
+		ProjectPath:     "/tmp/c1186",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: parent.ID,
+		Tool:            "claude",
+		Status:          StatusWaiting,
+		CreatedAt:       now,
+	}
+	if err := storage.SaveWithGroups([]*Instance{parent, child}, nil); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	return parent.ID, child.ID
+}
+
+func TestNotifyFinished_EmitsDoneMessageToParent(t *testing.T) {
+	profile := "_test-1186-finished-ok"
+	parentID, childID := seedDoneParentChild(t, profile)
+
+	n := NewTransitionNotifier()
+	t.Cleanup(n.Close)
+	var mu sync.Mutex
+	var gotTarget, gotMsg string
+	n.sender = func(profile, targetID, message string) error {
+		mu.Lock()
+		gotTarget, gotMsg = targetID, message
+		mu.Unlock()
+		return nil
+	}
+
+	n.NotifyFinished(TransitionNotificationEvent{
+		ChildSessionID: childID,
+		ChildTitle:     "worker",
+		Profile:        profile,
+		DoneStatus:     "ok",
+		DoneSummary:    "feature shipped",
+		Timestamp:      time.Now(),
+	})
+	n.Flush()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotTarget != parentID {
+		t.Errorf("delivered to %q, want parent %q", gotTarget, parentID)
+	}
+	if !strings.Contains(gotMsg, "[DONE]") {
+		t.Errorf("message missing [DONE] marker: %q", gotMsg)
+	}
+	if !strings.Contains(gotMsg, "status=ok") || !strings.Contains(gotMsg, "summary=feature shipped") {
+		t.Errorf("message missing parsed outcome: %q", gotMsg)
+	}
+	if !strings.Contains(gotMsg, childID) {
+		t.Errorf("message missing child id: %q", gotMsg)
+	}
+	if strings.Contains(gotMsg, "[EVENT]") {
+		t.Errorf("finished event must not reuse the [EVENT] waiting format: %q", gotMsg)
+	}
+}
+
+func TestNotifyFinished_FailStatus(t *testing.T) {
+	profile := "_test-1186-finished-fail"
+	_, childID := seedDoneParentChild(t, profile)
+
+	n := NewTransitionNotifier()
+	t.Cleanup(n.Close)
+	var mu sync.Mutex
+	var gotMsg string
+	n.sender = func(profile, targetID, message string) error {
+		mu.Lock()
+		gotMsg = message
+		mu.Unlock()
+		return nil
+	}
+
+	n.NotifyFinished(TransitionNotificationEvent{
+		ChildSessionID: childID,
+		ChildTitle:     "worker",
+		Profile:        profile,
+		DoneStatus:     "fail",
+		DoneSummary:    "build broke",
+		Timestamp:      time.Now(),
+	})
+	n.Flush()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !strings.Contains(gotMsg, "status=fail") || !strings.Contains(gotMsg, "summary=build broke") {
+		t.Errorf("fail outcome not reflected: %q", gotMsg)
+	}
+}
+
+func TestDaemon_EmitDoneSignals_HappyAndIdempotent(t *testing.T) {
+	profile := "_test-1186-daemon-idem"
+	_, childID := seedDoneParentChild(t, profile)
+
+	d := NewTransitionDaemon()
+	var sent atomic.Int32
+	d.notifier.sender = func(profile, targetID, message string) error {
+		sent.Add(1)
+		return nil
+	}
+	t.Cleanup(d.notifier.Close)
+
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer storage.Close()
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	byID := map[string]*Instance{}
+	for _, inst := range instances {
+		byID[inst.ID] = inst
+	}
+
+	hookStatuses := map[string]*HookStatus{
+		childID: {
+			Status:      "waiting",
+			Event:       "Stop",
+			DoneStatus:  "ok",
+			DoneSummary: "first done",
+			UpdatedAt:   time.Now(),
+		},
+	}
+
+	// First pass emits the finished event.
+	d.emitDoneSignals(profile, byID, hookStatuses)
+	d.notifier.Flush()
+	if got := sent.Load(); got != 1 {
+		t.Fatalf("first emit: sent=%d, want 1", got)
+	}
+
+	// Second pass with the SAME sentinel must NOT re-emit (idempotent per task).
+	d.emitDoneSignals(profile, byID, hookStatuses)
+	d.notifier.Flush()
+	if got := sent.Load(); got != 1 {
+		t.Fatalf("idempotency: sent=%d after re-poll of same sentinel, want 1", got)
+	}
+
+	// A genuinely new completion (different summary) emits again.
+	hookStatuses[childID] = &HookStatus{
+		Status:      "waiting",
+		Event:       "Stop",
+		DoneStatus:  "ok",
+		DoneSummary: "second done",
+		UpdatedAt:   time.Now(),
+	}
+	d.emitDoneSignals(profile, byID, hookStatuses)
+	d.notifier.Flush()
+	if got := sent.Load(); got != 2 {
+		t.Fatalf("new completion: sent=%d, want 2", got)
+	}
+}
+
+func TestDaemon_EmitDoneSignals_NoSentinelNoEmit(t *testing.T) {
+	profile := "_test-1186-daemon-nosentinel"
+	_, childID := seedDoneParentChild(t, profile)
+
+	d := NewTransitionDaemon()
+	var sent atomic.Int32
+	d.notifier.sender = func(profile, targetID, message string) error {
+		sent.Add(1)
+		return nil
+	}
+	t.Cleanup(d.notifier.Close)
+
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer storage.Close()
+	instances, _, _ := storage.LoadWithGroups()
+	byID := map[string]*Instance{}
+	for _, inst := range instances {
+		byID[inst.ID] = inst
+	}
+
+	// Ordinary mid-task Stop: hook status present but NO done fields.
+	hookStatuses := map[string]*HookStatus{
+		childID: {Status: "waiting", Event: "Stop", UpdatedAt: time.Now()},
+	}
+	d.emitDoneSignals(profile, byID, hookStatuses)
+	d.notifier.Flush()
+	if got := sent.Load(); got != 0 {
+		t.Fatalf("no sentinel must not emit a finished event; sent=%d", got)
+	}
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -39,6 +39,12 @@ type TransitionDaemon struct {
 	lastStatus  map[string]map[string]string
 	initialized map[string]bool
 
+	// lastDone tracks the most recently emitted completion sentinel per
+	// (profile, instance) so a finished event (issue #1186) is emitted once
+	// per distinct completion. Re-reading the same done-bearing hook file
+	// across polls — or a later identical Stop — does not re-fire.
+	lastDone map[string]map[string]DoneSignal
+
 	// lastInboxTTLSweep tracks the most recent SweepInboxByTTL call so
 	// the daemon runs it at most once per inboxTTLSweepInterval. Zero
 	// means "never run" — the first SyncOnce pass will perform it.
@@ -51,6 +57,7 @@ func NewTransitionDaemon() *TransitionDaemon {
 		storages:    map[string]*Storage{},
 		lastStatus:  map[string]map[string]string{},
 		initialized: map[string]bool{},
+		lastDone:    map[string]map[string]DoneSignal{},
 	}
 }
 
@@ -134,11 +141,13 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 
 	byID := make(map[string]*Instance, len(instances))
 	hookCandidates := make(map[string]hookTransitionCandidate, len(instances))
+	hookStatuses := make(map[string]*HookStatus, len(instances))
 	for _, inst := range instances {
 		byID[inst.ID] = inst
 		if IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" {
 			if hs := d.hookStatusForInstance(inst.ID); hs != nil {
 				inst.UpdateHookStatus(hs)
+				hookStatuses[inst.ID] = hs
 				if candidate, ok := terminalHookTransitionCandidate(inst.Tool, hs); ok {
 					hookCandidates[inst.ID] = candidate
 				}
@@ -191,6 +200,7 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 	if !d.initialized[profile] {
 		// Cover fast transitions that completed before we observed a running snapshot.
 		d.emitHookTransitionCandidates(profile, byID, nil, statuses, hookCandidates)
+		d.emitDoneSignals(profile, byID, hookStatuses)
 		d.lastStatus[profile] = copyStatusMap(statuses)
 		d.initialized[profile] = true
 		return choosePollInterval(statuses)
@@ -219,9 +229,60 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 		_ = d.notifier.NotifyTransition(event)
 	}
 	d.emitHookTransitionCandidates(profile, byID, prev, statuses, hookCandidates)
+	d.emitDoneSignals(profile, byID, hookStatuses)
 
 	d.lastStatus[profile] = copyStatusMap(statuses)
 	return choosePollInterval(statuses)
+}
+
+// emitDoneSignals turns a worker-printed completion sentinel (persisted into
+// the hook status file by the Stop-hook handler, issue #1186) into a distinct
+// "finished" event delivered to the parent. Per-task idempotency is enforced
+// via d.lastDone: the same sentinel re-read across polls — or repeated on a
+// later identical Stop — fires at most once. A genuinely new completion
+// (different status/summary) fires again. Stale hook files (older than
+// hookFreshWindow) are ignored so a daemon restart doesn't replay a long-dead
+// completion.
+func (d *TransitionDaemon) emitDoneSignals(profile string, byID map[string]*Instance, hookStatuses map[string]*HookStatus) {
+	if len(hookStatuses) == 0 {
+		return
+	}
+	notifyEnabled := GetNotificationsSettings().GetTransitionEventsEnabled()
+	for id, hs := range hookStatuses {
+		if hs == nil || strings.TrimSpace(hs.DoneStatus) == "" {
+			continue
+		}
+		if !hs.UpdatedAt.IsZero() && time.Since(hs.UpdatedAt) > hookFreshWindow {
+			continue
+		}
+		sig := DoneSignal{
+			Status:  strings.ToLower(strings.TrimSpace(hs.DoneStatus)),
+			Summary: strings.TrimSpace(hs.DoneSummary),
+		}
+		if prev, ok := d.lastDone[profile][id]; ok && prev == sig {
+			continue // already emitted this exact completion
+		}
+
+		inst := byID[id]
+		if !notifyEnabled || !instanceAcceptsTransitionEvents(inst) {
+			continue
+		}
+
+		event := TransitionNotificationEvent{
+			ChildSessionID: id,
+			ChildTitle:     inst.Title,
+			Profile:        profile,
+			DoneStatus:     sig.Status,
+			DoneSummary:    sig.Summary,
+			Timestamp:      hs.UpdatedAt,
+		}
+		_ = d.notifier.NotifyFinished(event)
+
+		if d.lastDone[profile] == nil {
+			d.lastDone[profile] = map[string]DoneSignal{}
+		}
+		d.lastDone[profile][id] = sig
+	}
 }
 
 func (d *TransitionDaemon) getStorage(profile string) *Storage {
@@ -331,10 +392,12 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		return nil
 	}
 	var raw struct {
-		Status    string `json:"status"`
-		SessionID string `json:"session_id"`
-		Event     string `json:"event"`
-		Timestamp int64  `json:"ts"`
+		Status      string `json:"status"`
+		SessionID   string `json:"session_id"`
+		Event       string `json:"event"`
+		Timestamp   int64  `json:"ts"`
+		DoneStatus  string `json:"done_status"`
+		DoneSummary string `json:"done_summary"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil
@@ -347,10 +410,12 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		updatedAt = time.Unix(raw.Timestamp, 0)
 	}
 	return &HookStatus{
-		Status:    raw.Status,
-		SessionID: raw.SessionID,
-		Event:     raw.Event,
-		UpdatedAt: updatedAt,
+		Status:      raw.Status,
+		SessionID:   raw.SessionID,
+		Event:       raw.Event,
+		UpdatedAt:   updatedAt,
+		DoneStatus:  raw.DoneStatus,
+		DoneSummary: raw.DoneSummary,
 	}
 }
 

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -59,7 +59,22 @@ type TransitionNotificationEvent struct {
 	TargetSessionID string `json:"target_session_id,omitempty"`
 	TargetKind      string `json:"target_kind,omitempty"` // parent | conductor
 	DeliveryResult  string `json:"delivery_result,omitempty"`
+
+	// Kind distinguishes a finished event (issue #1186) from the default
+	// status-transition event. Empty means the legacy transition event
+	// ("[EVENT] Child is waiting"); transitionKindFinished means a
+	// worker-asserted completion ("[DONE] Child finished: status=…").
+	Kind string `json:"kind,omitempty"`
+
+	// DoneStatus/DoneSummary carry the parsed completion sentinel for a
+	// finished event. Unused for transition events.
+	DoneStatus  string `json:"done_status,omitempty"`
+	DoneSummary string `json:"done_summary,omitempty"`
 }
+
+// transitionKindFinished marks a TransitionNotificationEvent as a worker-
+// asserted task-completion signal rather than a status transition.
+const transitionKindFinished = "finished"
 
 type transitionNotifyRecord struct {
 	From string `json:"from"`
@@ -303,6 +318,45 @@ func (n *TransitionNotifier) NotifyTransition(event TransitionNotificationEvent)
 	return plan.event
 }
 
+// NotifyFinished dispatches a worker-asserted completion event (issue #1186)
+// to the child's parent. Unlike NotifyTransition it is not gated by
+// ShouldNotifyTransition (a finished event has no from→to transition); per-task
+// idempotency is the daemon's responsibility (it only calls this when the
+// detected sentinel actually changed). It reuses prepareDispatch so a finished
+// event still benefits from parent resolution, conductor/orphan suppression,
+// and the busy-defer retry queue.
+func (n *TransitionNotifier) NotifyFinished(event TransitionNotificationEvent) TransitionNotificationEvent {
+	event.Kind = transitionKindFinished
+	event.Profile = strings.TrimSpace(event.Profile)
+	event.ChildTitle = strings.TrimSpace(event.ChildTitle)
+	event.ChildSessionID = strings.TrimSpace(event.ChildSessionID)
+	event.DoneStatus = strings.ToLower(strings.TrimSpace(event.DoneStatus))
+	event.DoneSummary = strings.TrimSpace(event.DoneSummary)
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+
+	if event.ChildSessionID == "" || event.Profile == "" {
+		event.DeliveryResult = transitionDeliveryDropped
+		return event
+	}
+	if isConductorSessionTitle(event.ChildTitle) {
+		event.DeliveryResult = transitionDeliveryDropped
+		return event
+	}
+
+	plan := n.prepareDispatch(event)
+	if plan.finalized {
+		n.logEvent(plan.event)
+		return plan.event
+	}
+
+	n.dispatchAsync(plan.event.TargetSessionID, plan.message, plan.event)
+
+	plan.event.DeliveryResult = transitionDeliveryDispatching
+	return plan.event
+}
+
 type dispatchPlan struct {
 	event     TransitionNotificationEvent
 	message   string
@@ -508,6 +562,18 @@ func (n *TransitionNotifier) Flush() {
 }
 
 func buildTransitionMessage(event TransitionNotificationEvent) string {
+	if event.Kind == transitionKindFinished {
+		// Issue #1186: a worker-asserted completion. Distinct [DONE] prefix
+		// and outcome so the conductor gets "done + status + summary" in one
+		// signal instead of polling artifacts.
+		return fmt.Sprintf(
+			"[DONE] Child '%s' (%s) finished: status=%s summary=%s",
+			event.ChildTitle,
+			event.ChildSessionID,
+			event.DoneStatus,
+			event.DoneSummary,
+		)
+	}
 	return fmt.Sprintf(
 		"[EVENT] Child '%s' (%s) is %s.\nCheck: agent-deck -p %s session output %s -q",
 		event.ChildTitle,
@@ -600,21 +666,48 @@ func (n *TransitionNotifier) outputHashTTL() time.Duration {
 	return defaultOutputHashDedupTTL
 }
 
-// transitionEventOutputHash derives the cheap stable pane-activity signal
-// used by the issue #1142 output-hash dedup. It returns the inst's
-// LastActivityTime serialized to ns precision: identical bytes mean the pane
-// content hasn't changed since the last accepted [EVENT], so the notifier
-// safely suppresses the re-fire. Empty string for nil/missing — falls back
-// to the legacy 90s dedup window.
+// transitionEventOutputHash derives the stable content signal used by the
+// issue #1142 output-hash dedup. The key must be IDENTICAL across polls while
+// the child's logical state is unchanged, and MUST change on a genuine new
+// turn.
+//
+// issue #1187: the previous implementation keyed on
+// inst.GetLastActivityTime().UnixNano(), but that timestamp is re-stamped to
+// time.Now() on every tmux window_activity tick (tmux.go:2956/3102/3303). A
+// live Claude pane sitting at the prompt animates its footer/token-counter/
+// cursor/hint lines, so window_activity bumped every poll → the key moved
+// every poll → layer-2 dedup could never match → the same [EVENT] re-fired
+// 10-40x. The signal was clock-derived, structurally incapable of matching a
+// live pane.
+//
+// The fix derives the key from session CONTENT (the transcript), which the
+// animated chrome never touches. See transitionContentSignal. Empty string for
+// nil/missing/non-transcript tools — falls back to the legacy 90s dedup window,
+// exactly as before.
 func transitionEventOutputHash(inst *Instance) string {
 	if inst == nil {
 		return ""
 	}
-	t := inst.GetLastActivityTime()
-	if t.IsZero() {
+	return transitionContentSignal(inst)
+}
+
+// transitionContentSignal returns a dedup signal derived from the child's
+// transcript size. A Claude-compatible JSONL transcript is append-only and
+// grows ONLY when a real message is written (user prompt, assistant turn, tool
+// call) — it is completely untouched when the pane merely redraws its animated
+// chrome. So the signal stays identical across idle polls and strictly changes
+// on a genuine new turn. Returns "" when no transcript is resolvable (e.g.
+// non-Claude tools), which routes the caller to the legacy 90s window.
+func transitionContentSignal(inst *Instance) string {
+	path := inst.GetJSONLPath()
+	if path == "" {
 		return ""
 	}
-	return fmt.Sprintf("act:%d", t.UnixNano())
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("jsonl:%d", info.Size())
 }
 
 func (n *TransitionNotifier) markNotified(event TransitionNotificationEvent) {
@@ -786,7 +879,13 @@ func (n *TransitionNotifier) enqueueDeferredAtForTest(event TransitionNotificati
 }
 
 func deferredKey(event TransitionNotificationEvent) string {
-	return event.ChildSessionID + "|" + event.FromStatus + "|" + event.ToStatus
+	key := event.ChildSessionID + "|" + event.FromStatus + "|" + event.ToStatus
+	if event.Kind != "" {
+		// Finished events (issue #1186) have no from→to; key on kind + outcome
+		// so distinct completions don't collapse onto one another in the queue.
+		key += "|" + event.Kind + "|" + event.DoneStatus + "|" + event.DoneSummary
+	}
+	return key
 }
 
 // targetAvailabilityResolver reports whether the given target session is

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -153,6 +153,36 @@ Files to read first:
 - Brand-new files (`Write` to a path that does not yet exist): no prelude needed — the guard only applies to modifications.
 - For conductor nudges that re-fire the same prompt across cycles, keep Step 0 in the prompt. The second-cycle process may not have prior reads in context.
 
+### Completion sentinel (trustworthy "worker finished" signal, #1186)
+
+A worker's `Stop` hook fires at the end of *every* turn, so "waiting" never means "done" — the conductor would otherwise have to poll RESULTS files / `gh pr` / `session output` to know a task actually finished. Instead, instruct every worker to **assert completion** by ending its final turn with a single machine-greppable line:
+
+```
+===AGENTDECK_DONE=== status=<ok|fail> summary=<one line to end of line>
+```
+
+agent-deck detects this on the `Stop` edge (scanning the transcript tail) and emits a distinct event to the parent:
+
+```
+[DONE] Child '<name>' (<id>) finished: status=ok summary=<...>
+```
+
+instead of the generic `[EVENT] … is waiting`. This is by-construction: completion is asserted by the only party that knows (the worker), not inferred from terminal cosmetics.
+
+**Bake this line into every worker prompt's final instruction:**
+
+```
+## Final step — assert completion
+When the task is fully done, print exactly this as the last line of your final message:
+  ===AGENTDECK_DONE=== status=ok summary=<what you accomplished, one line>
+Use status=fail if you could not complete it; put the blocker in the summary.
+```
+
+Notes:
+- Fires once per distinct completion (idempotent per task): re-reading the same sentinel across polls — or repeating an identical sentinel on a later `Stop` — does not re-emit. A genuinely new completion (different summary) emits again.
+- Absent on ordinary mid-task `Stop` edges, so existing `waiting` behavior is unchanged.
+- Malformed sentinel lines (missing/invalid `status`) are ignored, not guessed at.
+
 ## Consult Another Agent (Codex, Gemini)
 
 **Use when:** User says "consult with codex", "ask gemini", "get codex's opinion", "what does codex think", "consult another agent", "brainstorm with codex/gemini", "get a second opinion"


### PR DESCRIPTION
Closes #1186.

## Problem
Claude's `Stop` hook — the only clean completion edge — is mapped to the generic `waiting` status (`hook_handler.go`), and `Stop` fires at the end of *every* turn, not at task end. So `waiting` conflates truly-done, mid-task-pause, and blocked-on-permission. There is no `done` concept anywhere. Conductors are forced to poll artifacts (RESULTS files, `gh pr`, `session output`) because the system has nothing better.

## Fix (by-construction): worker-printed sentinel, detected on the Stop edge
Completion is **asserted by the party that knows** (the worker), not inferred from terminal cosmetics.

- **Detection (cmd side).** On the `Stop` edge — the only place the transcript path is available — scan the transcript tail for `===AGENTDECK_DONE=== status=<ok|fail> summary=<text to end of line>` (reuses the existing JSONL read path used for cost). Persist the parsed outcome into `~/.agent-deck/hooks/{id}.json` (`done_status`, `done_summary`, `omitempty`).
- **Emit (session side).** The transition daemon turns a fresh, *changed* sentinel into a distinct **finished** event delivered to the parent:
  `[DONE] Child '<name>' (<id>) finished: status=ok summary=<...>`
  — separate from the `[EVENT] … is waiting` transition message.
- **Idempotent per task.** The daemon tracks the last-emitted sentinel per `(profile, instance)` keyed on **content** (`status`+`summary`), not a clock — so re-reading the same sentinel across polls, or an identical sentinel on a later `Stop`, fires once. A genuinely new completion (different summary) fires again. Stale hook files (> `hookFreshWindow`) are ignored, so a daemon restart can't replay a dead completion.
- **No behavior change for ordinary Stops.** No sentinel ⇒ no finished event; `waiting` semantics unchanged. Malformed sentinels (missing/invalid `status`) are ignored, not guessed at.

The spawn-prompt convention (telling workers to print the sentinel) is documented in `skills/agent-deck/SKILL.md`; the code deliverable here is **detect → emit**.

## Surfaces
| Surface | Applies | Coverage |
|---|---|---|
| **CLI** (`cmd/agent-deck/`) | ✅ | `issue1186_done_signal_test.go` — transcript detection (ok/fail/none/malformed/non-assistant/missing-file) + hook-file persistence (present/absent) |
| **Persistence** (hook status file) | ✅ | `done_status`/`done_summary` round-trip asserted in the CLI test; all three readers (`hook_watcher` scanDisk + parseHookFile, `transition_daemon` readHookStatusFile) parse the new fields |
| **Notifier / daemon** (`internal/session/`) | ✅ | `done_sentinel_test.go` (parse contract + last-wins scan), `issue1186_done_emit_test.go` (`[DONE]` format, ok/fail, daemon idempotency + no-sentinel-no-emit) |
| **Remote** (LocalSession/RemoteSession) | ✅ no split | The finished event is delivered to the parent's tmux pane via the same `sender` (`SendSessionMessageReliable`) as every `[EVENT]`; there is no Local/Remote branch in the notify path, so no separate remote rendering exists to diverge. |
| **TUI** / **Web UI** | ⚪ n/a | This adds a parent-directed message event, not a session status enum value (no `done` status was added). Nothing renders it in the TUI/Web session views; it surfaces only as a delivered message in the parent conductor's pane. |
| **Cross-platform** | ⚪ n/a | Pure Go: `filepath` for paths, no OS-specific code, signals, or tmux interaction added. |

## Demonstration
Feeding a transcript whose final assistant turn ends in the sentinel + a `Stop` produces, delivered to the parent:
```
DETECT: ok=true status="ok" summary="opened PR #1186 closing the done-signal gap"
DELIVERED to parent "parent-conductor-1186":
  [DONE] Child 'worker' (child-worker-1186) finished: status=ok summary=opened PR #1186 closing the done-signal gap
```

## Verification
- `go test -race -count=1 ./cmd/agent-deck/... ./internal/session/...` — green
- Full `go test -race ./...` — green
- `golangci-lint run` — 0 issues
- `govulncheck ./...` — 0 vulnerabilities



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workers can now explicitly signal task completion with success/failure status and optional summary messages. Completion signals are reliably detected, persisted, and reported to parent systems with built-in duplicate detection to prevent redundant notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->