### PR TITLE
test(capability): Wave 1 — lifecycle + echo-agent round-trip E2E + gate script + dashboard

### DIFF
--- a/docs/status/capability-dashboard.html
+++ b/docs/status/capability-dashboard.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agent-deck Capability E2E Dashboard</title>
+<style>
+  :root {
+    --green: #16a34a;
+    --amber: #d97706;
+    --red: #dc2626;
+    --grey: #8b949e;
+    --ink: #1f2328;
+    --muted: #57606a;
+    --line: #d8dee4;
+    --bg: #f6f8fa;
+  }
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: var(--ink); line-height: 1.55; margin: 0; background: #fff;
+  }
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 40px 24px 80px; }
+  header.page { border-bottom: 2px solid var(--line); padding-bottom: 20px; margin-bottom: 28px; }
+  header.page h1 { font-size: 28px; margin: 0 0 6px; letter-spacing: -0.02em; }
+  header.page .date { color: var(--muted); font-size: 14px; }
+  header.page .pitch { font-size: 15px; color: var(--ink); margin-top: 12px; max-width: 780px; }
+  h2 { font-size: 20px; margin: 36px 0 12px; letter-spacing: -0.01em; }
+  .muted { color: var(--muted); }
+  .summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin: 16px 0 8px; }
+  .stat { border: 1px solid var(--line); border-radius: 10px; padding: 14px 16px; background: #fff; }
+  .stat .label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
+  .stat .value { font-size: 26px; font-weight: 650; margin-top: 4px; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 14px; margin: 12px 0; }
+  .card { border: 1px solid var(--line); border-radius: 10px; padding: 16px 18px; box-shadow: 0 1px 2px rgba(0,0,0,0.04); background: #fff; }
+  .card.green { border-top: 3px solid var(--green); }
+  .card.amber { border-top: 3px solid var(--amber); }
+  .card.red { border-top: 3px solid var(--red); }
+  .card.grey { border-top: 3px solid var(--grey); }
+  .card h3 { font-size: 15px; margin: 0 0 8px; }
+  .status { font-size: 12px; font-weight: 650; letter-spacing: 0.04em; }
+  .dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
+  .dot.green { background: var(--green); }
+  .dot.amber { background: var(--amber); }
+  .dot.red { background: var(--red); }
+  .dot.grey { background: var(--grey); }
+  .how { font-size: 13.5px; color: var(--ink); margin: 8px 0; }
+  .assert { font-size: 12.5px; color: var(--muted); margin: 6px 0; }
+  .meta { font-size: 12px; color: var(--muted); margin-top: 8px; }
+  .chips { margin-top: 8px; }
+  .chip { display: inline-block; font-size: 11px; background: var(--bg); border: 1px solid var(--line); border-radius: 999px; padding: 2px 9px; margin: 2px 4px 2px 0; color: var(--muted); }
+  footer { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--line); font-size: 12.5px; color: var(--muted); }
+</style>
+</head>
+<body>
+<div class="wrap">
+<header class="page">
+  <h1>agent-deck Capability E2E Dashboard</h1>
+  <div class="date">Generated 2026-05-26T12:03:17Z</div>
+  <p class="pitch">One card per capability agent-deck promises a user can do. Each fast-gate capability is verified by a test that performs the real action through the compiled binary on an isolated tmux socket and asserts on the real effect: registry rows or live pane content. Nightly capabilities need real agents, keys, or network and run out of band.</p>
+</header>
+
+<section class="summary">
+  <div class="stat"><div class="label">Capabilities</div><div class="value">11</div></div>
+  <div class="stat"><div class="label">Green</div><div class="value">8</div></div>
+  <div class="stat"><div class="label">Failed</div><div class="value">0</div></div>
+  <div class="stat"><div class="label">Nightly only</div><div class="value">3</div></div>
+  <div class="stat"><div class="label">Not yet covered</div><div class="value">0</div></div>
+</section>
+
+
+<h2>Session lifecycle</h2>
+<div class="cards">
+  
+  <div class="card green">
+    <div class="status"><span class="dot green"></span>PASS</div>
+    <h3>Register a session</h3>
+    <p class="how">We run the add command to register a new session, then read the saved registry back. We confirm the row exists with the title, tool, group, and folder we asked for.</p>
+    <p class="assert">Pass when: new registry row carries the given title, tool, group, and working directory</p>
+    <div class="meta">Tier F . Runtime: 2.1s . TestCapability_Lifecycle_Add</div>
+    <div class="chips"><span class="chip">Local-isolated</span></div>
+  </div>
+  
+  <div class="card green">
+    <div class="status"><span class="dot green"></span>PASS</div>
+    <h3>Start a session</h3>
+    <p class="how">We register a session and start it. We then ask the throwaway tmux server whether a live pane actually appeared, and confirm the registry flips the session to an active state.</p>
+    <p class="assert">Pass when: a real tmux pane appears on the isolated socket and status becomes active</p>
+    <div class="meta">Tier F . Runtime: 1.4s . TestCapability_Lifecycle_Start</div>
+    <div class="chips"><span class="chip">Local-isolated</span></div>
+  </div>
+  
+  <div class="card green">
+    <div class="status"><span class="dot green"></span>PASS</div>
+    <h3>Stop a session</h3>
+    <p class="how">We start a session, then stop it. We confirm the tmux pane is gone and the registry returns the session to the stopped state.</p>
+    <p class="assert">Pass when: tmux pane disappears and registry status returns to stopped</p>
+    <div class="meta">Tier F . Runtime: 1.5s . TestCapability_Lifecycle_Stop</div>
+    <div class="chips"><span class="chip">Local-isolated</span></div>
+  </div>
+  
+  <div class="card green">
+    <div class="status"><span class="dot green"></span>PASS</div>
+    <h3>Restart a session</h3>
+    <p class="how">We start a session and restart it. We confirm exactly one pane exists afterward (no accidental duplicate) and the session is active again.</p>
+    <p class="assert">Pass when: exactly one pane remains after restart and status is active (guards the #30 double-spawn)</p>
+    <div class="meta">Tier F . Runtime: 2.6s . TestCapability_Lifecycle_Restart</div>
+    <div class="chips"><span class="chip">Local-isolated</span></div>
+  </div>
+  
+  <div class="card green">
+    <div class="status"><span class="dot green"></span>PASS</div>
+    <h3>Remove a session</h3>
+    <p class="how">We confirm a stopped session can be removed and disappears from the registry, and that removing a still-running session is refused unless forced, so it is not destroyed by accident.</p>
+    <p class="assert">Pass when: stopped session leaves the registry; a running session is refused without force</p>
+    <div class="meta">Tier F . Runtime: 11.1s . TestCapability_Lifecycle_Rm</div>
+    <div class="chips"><span class="chip">Local-isolated</span></div>
+  </div>
+  
+  <div class="card green">
+    <div class="status"><span class="dot green"></span>PASS</div>
+    <h3>Launch in one step</h3>
+    <p class="how">We use the single launch command, which creates, starts, and messages a session at once, pointed at the stand-in echo agent. We confirm the registry row exists and the echoed message shows up on screen.</p>
+    <p class="assert">Pass when: one launch command creates the row, starts the pane, and the echoed message appears</p>
+    <div class="meta">Tier F . Runtime: 7.1s . TestCapability_Lifecycle_Launch</div>
+    <div class="chips"><span class="chip">Local-isolated</span><span class="chip">Deterministic-stub</span></div>
+  </div>
+  
+  <div class="card green">
+    <div class="status"><span class="dot green"></span>PASS</div>
+    <h3>Fork guard</h3>
+    <p class="how">Forking is only valid for a Claude session with live context. We confirm forking a non-Claude session is cleanly refused and creates no orphan child row. The full context-inheriting fork is a documented nightly gap.</p>
+    <p class="assert">Pass when: forking a non-Claude session is refused and no child row is created</p>
+    <div class="meta">Tier F . Runtime: 0.1s . TestCapability_Lifecycle_Fork</div>
+    <div class="chips"><span class="chip">Local-isolated</span></div>
+  </div>
+  
+</div>
+
+<h2>Agent interaction</h2>
+<div class="cards">
+  
+  <div class="card green">
+    <div class="status"><span class="dot green"></span>PASS</div>
+    <h3>Send a message to an agent and read its reply</h3>
+    <p class="how">We launch a tiny stand-in agent that simply repeats whatever you say. We send it a unique message through the normal send command, then read the screen back. If the screen shows the echoed message we know it reached the agent and a reply came out the other side.</p>
+    <p class="assert">Pass when: the pane shows ECHO:&lt;token&gt; after a real send, proving readiness, send-keys, and capture read-back</p>
+    <div class="meta">Tier F . Runtime: 6.4s . TestCapability_Agent_EchoRoundTrip</div>
+    <div class="chips"><span class="chip">Local-isolated</span><span class="chip">Deterministic-stub</span></div>
+  </div>
+  
+  <div class="card grey">
+    <div class="status"><span class="dot grey"></span>NIGHTLY</div>
+    <h3>Real agent round trip (Claude)</h3>
+    <p class="how">We launch a real Claude session, wait for its prompt, send a fixed instruction, and check the reply. This needs a real API key and network, so it runs nightly, not on every release.</p>
+    <p class="assert">Pass when: a real Claude reply contains the expected token</p>
+    <div class="meta">Tier N . Runtime: not measured</div>
+    <div class="chips"><span class="chip">Real-agent</span><span class="chip">Needs-creds</span><span class="chip">Needs-network</span></div>
+  </div>
+  
+  <div class="card grey">
+    <div class="status"><span class="dot grey"></span>NIGHTLY</div>
+    <h3>Fork inherits Claude context</h3>
+    <p class="how">We fork a live Claude session and confirm the child inherits the conversation with a distinct id and a parent link. This needs a real Claude session id from a live transcript, so it runs nightly.</p>
+    <p class="assert">Pass when: child session links the parent and inherits conversation context</p>
+    <div class="meta">Tier N . Runtime: not measured</div>
+    <div class="chips"><span class="chip">Real-agent</span><span class="chip">Needs-creds</span><span class="chip">Needs-network</span></div>
+  </div>
+  
+</div>
+
+<h2>MCP</h2>
+<div class="cards">
+  
+  <div class="card grey">
+    <div class="status"><span class="dot grey"></span>NIGHTLY</div>
+    <h3>MCP actually loads in the agent</h3>
+    <p class="how">We attach a tool server and ask a real agent to list its tools, confirming the agent honors the attachment. This needs a real agent to introspect, so it runs nightly.</p>
+    <p class="assert">Pass when: the agent lists the attached MCP server</p>
+    <div class="meta">Tier N . Runtime: not measured</div>
+    <div class="chips"><span class="chip">Real-agent</span><span class="chip">Needs-creds</span><span class="chip">Needs-network</span></div>
+  </div>
+  
+</div>
+
+
+<footer>
+  Rendered from docs/status/capability-e2e-manifest.json by tools/capability-report. Regenerate with scripts/capability-e2e.sh. Honest gaps are tracked in docs/testing/capability-gaps.md.
+</footer>
+</div>
+</body>
+</html>

--- a/docs/status/capability-e2e-manifest.json
+++ b/docs/status/capability-e2e-manifest.json
@@ -1,0 +1,171 @@
+{
+  "generated_at": "2026-05-26T12:03:17Z",
+  "summary": {
+    "total": 11,
+    "green": 8,
+    "failed": 0,
+    "nightly_only": 3,
+    "not_covered": 0
+  },
+  "capabilities": [
+    {
+      "id": "add",
+      "group": "Session lifecycle",
+      "title": "Register a session",
+      "how_we_test": "We run the add command to register a new session, then read the saved registry back. We confirm the row exists with the title, tool, group, and folder we asked for.",
+      "assertion": "new registry row carries the given title, tool, group, and working directory",
+      "tier": "F",
+      "chips": [
+        "Local-isolated"
+      ],
+      "test_name": "TestCapability_Lifecycle_Add",
+      "status": "pass",
+      "runtime_seconds": 2.06
+    },
+    {
+      "id": "start",
+      "group": "Session lifecycle",
+      "title": "Start a session",
+      "how_we_test": "We register a session and start it. We then ask the throwaway tmux server whether a live pane actually appeared, and confirm the registry flips the session to an active state.",
+      "assertion": "a real tmux pane appears on the isolated socket and status becomes active",
+      "tier": "F",
+      "chips": [
+        "Local-isolated"
+      ],
+      "test_name": "TestCapability_Lifecycle_Start",
+      "status": "pass",
+      "runtime_seconds": 1.43
+    },
+    {
+      "id": "stop",
+      "group": "Session lifecycle",
+      "title": "Stop a session",
+      "how_we_test": "We start a session, then stop it. We confirm the tmux pane is gone and the registry returns the session to the stopped state.",
+      "assertion": "tmux pane disappears and registry status returns to stopped",
+      "tier": "F",
+      "chips": [
+        "Local-isolated"
+      ],
+      "test_name": "TestCapability_Lifecycle_Stop",
+      "status": "pass",
+      "runtime_seconds": 1.5
+    },
+    {
+      "id": "restart",
+      "group": "Session lifecycle",
+      "title": "Restart a session",
+      "how_we_test": "We start a session and restart it. We confirm exactly one pane exists afterward (no accidental duplicate) and the session is active again.",
+      "assertion": "exactly one pane remains after restart and status is active (guards the #30 double-spawn)",
+      "tier": "F",
+      "chips": [
+        "Local-isolated"
+      ],
+      "test_name": "TestCapability_Lifecycle_Restart",
+      "status": "pass",
+      "runtime_seconds": 2.6
+    },
+    {
+      "id": "rm",
+      "group": "Session lifecycle",
+      "title": "Remove a session",
+      "how_we_test": "We confirm a stopped session can be removed and disappears from the registry, and that removing a still-running session is refused unless forced, so it is not destroyed by accident.",
+      "assertion": "stopped session leaves the registry; a running session is refused without force",
+      "tier": "F",
+      "chips": [
+        "Local-isolated"
+      ],
+      "test_name": "TestCapability_Lifecycle_Rm",
+      "status": "pass",
+      "runtime_seconds": 11.09
+    },
+    {
+      "id": "launch",
+      "group": "Session lifecycle",
+      "title": "Launch in one step",
+      "how_we_test": "We use the single launch command, which creates, starts, and messages a session at once, pointed at the stand-in echo agent. We confirm the registry row exists and the echoed message shows up on screen.",
+      "assertion": "one launch command creates the row, starts the pane, and the echoed message appears",
+      "tier": "F",
+      "chips": [
+        "Local-isolated",
+        "Deterministic-stub"
+      ],
+      "test_name": "TestCapability_Lifecycle_Launch",
+      "status": "pass",
+      "runtime_seconds": 7.1
+    },
+    {
+      "id": "fork",
+      "group": "Session lifecycle",
+      "title": "Fork guard",
+      "how_we_test": "Forking is only valid for a Claude session with live context. We confirm forking a non-Claude session is cleanly refused and creates no orphan child row. The full context-inheriting fork is a documented nightly gap.",
+      "assertion": "forking a non-Claude session is refused and no child row is created",
+      "tier": "F",
+      "chips": [
+        "Local-isolated"
+      ],
+      "test_name": "TestCapability_Lifecycle_Fork",
+      "status": "pass",
+      "runtime_seconds": 0.15
+    },
+    {
+      "id": "send-output-echo",
+      "group": "Agent interaction",
+      "title": "Send a message to an agent and read its reply",
+      "how_we_test": "We launch a tiny stand-in agent that simply repeats whatever you say. We send it a unique message through the normal send command, then read the screen back. If the screen shows the echoed message we know it reached the agent and a reply came out the other side.",
+      "assertion": "the pane shows ECHO:\u003ctoken\u003e after a real send, proving readiness, send-keys, and capture read-back",
+      "tier": "F",
+      "chips": [
+        "Local-isolated",
+        "Deterministic-stub"
+      ],
+      "test_name": "TestCapability_Agent_EchoRoundTrip",
+      "status": "pass",
+      "runtime_seconds": 6.4
+    },
+    {
+      "id": "send-output-claude",
+      "group": "Agent interaction",
+      "title": "Real agent round trip (Claude)",
+      "how_we_test": "We launch a real Claude session, wait for its prompt, send a fixed instruction, and check the reply. This needs a real API key and network, so it runs nightly, not on every release.",
+      "assertion": "a real Claude reply contains the expected token",
+      "tier": "N",
+      "chips": [
+        "Real-agent",
+        "Needs-creds",
+        "Needs-network"
+      ],
+      "status": "nightly",
+      "runtime_seconds": 0
+    },
+    {
+      "id": "fork-context",
+      "group": "Agent interaction",
+      "title": "Fork inherits Claude context",
+      "how_we_test": "We fork a live Claude session and confirm the child inherits the conversation with a distinct id and a parent link. This needs a real Claude session id from a live transcript, so it runs nightly.",
+      "assertion": "child session links the parent and inherits conversation context",
+      "tier": "N",
+      "chips": [
+        "Real-agent",
+        "Needs-creds",
+        "Needs-network"
+      ],
+      "status": "nightly",
+      "runtime_seconds": 0
+    },
+    {
+      "id": "mcp-loads",
+      "group": "MCP",
+      "title": "MCP actually loads in the agent",
+      "how_we_test": "We attach a tool server and ask a real agent to list its tools, confirming the agent honors the attachment. This needs a real agent to introspect, so it runs nightly.",
+      "assertion": "the agent lists the attached MCP server",
+      "tier": "N",
+      "chips": [
+        "Real-agent",
+        "Needs-creds",
+        "Needs-network"
+      ],
+      "status": "nightly",
+      "runtime_seconds": 0
+    }
+  ]
+}

--- a/docs/testing/capability-gaps.md
+++ b/docs/testing/capability-gaps.md
@@ -1,0 +1,60 @@
+# Capability E2E: honest gaps
+
+This file records capabilities that the fast gate (Tier F) cannot verify
+deterministically and offline, so they are not faked green. They live in Tier N
+(nightly, needs creds) and show on the dashboard as greyed "NIGHTLY" cards. See
+the strategy doc, `docs/testing/2026-05-26-capability-e2e-strategy.md`.
+
+The principle (Pattern 5): a capability we cannot verify in the fast pass is
+shown as a documented gap, never as a passing test that does not actually
+exercise the capability.
+
+## Wave 1 gaps
+
+### Fork that inherits Claude context
+`session fork` only fully works for a Claude-compatible session that has a live
+`ClaudeSessionID` captured from a real claude transcript (see
+`internal/session/instance.go` `CanFork`). That id is non-deterministic and
+key-gated, and the fork itself runs `claude --resume`, which needs the real CLI
+and auth. Wave 1 therefore tests the deterministic half of the capability: the
+precondition guard refuses to fork a non-Claude session and creates no orphan
+child row (`TestCapability_Lifecycle_Fork`). The context-inheriting happy path
+is Tier N.
+
+### Real agent round trips (claude, codex, gemini, opencode)
+The backbone send-and-reply round trip is verified offline against a
+deterministic echo agent (`TestCapability_Agent_EchoRoundTrip`). Verifying a
+real agent actually replies needs that CLI installed plus its auth, and the
+reply is non-deterministic. These run nightly on a host that has the CLIs and
+secrets. The echo proxy guards the wiring; the nightly real-agent test guards
+drift between the proxy and reality.
+
+The deterministic echo agent uses `session send --no-wait`. The default send
+path includes a Ctrl+C "full resend" recovery (issues #479 / #876) tuned for
+real agents that sit visibly "active" after receiving input. A trivial echo
+stand-in returns to its prompt too quickly for that heuristic, and the Ctrl+C
+would kill it. `--no-wait` still exercises the real send-keys, the readiness
+preflight, and the delivery verifier, so the round trip is genuine. The default
+send path against a real agent is covered by the Tier N round trips.
+
+### MCP actually loads in an agent
+Tier F (a later wave) proves the `.mcp.json` is written with the correct shape.
+Proving a real agent honors the attachment needs a real agent to introspect its
+own tool list (for example `/mcp`), so it is Tier N.
+
+### Remote over SSH
+`remote add` / `remote sessions` need an SSH endpoint. Loopback SSH
+(`ssh localhost` to a second `HOME`) can promote this to Tier F if the CI image
+allows it; the default is Tier N against a real host.
+
+## Not yet covered in Wave 1 (planned later waves)
+
+These are not gaps in the "cannot be deterministic" sense; they are simply not
+built yet. They are scheduled per the strategy build plan:
+
+- Conductor finished-signal (#1186) and EVENT dedup (#1187) end to end (Wave 2).
+- Web mutation endpoints and the terminal bridge via httptest (Wave 2).
+- MCP attach / detach `.mcp.json` assertions (Wave 2).
+- Worktree create + finish against a throwaway git repo (Wave 2).
+- Groups / profiles isolation and the offline multi-tool readiness-detector
+  golden-fixture test (Wave 3).

--- a/scripts/capability-e2e.sh
+++ b/scripts/capability-e2e.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# capability-e2e.sh: run the capability-level E2E suite, emit a JSON manifest,
+# and regenerate the HTML dashboard from it.
+#
+# This is the single entry point referenced by the capability-e2e strategy
+# (docs/testing/2026-05-26-capability-e2e-strategy.md section 4). It is safe to
+# run standalone today; wiring it into release.yml is a one-line add later
+# (Wave 3).
+#
+# Usage:
+#   scripts/capability-e2e.sh            # Tier F fast gate (default)
+#   scripts/capability-e2e.sh --nightly  # also run Tier N (real agents, creds)
+#
+# Exit status: non-zero if any Tier F capability failed (so it can gate a
+# release) or if the test runner itself errored. Tier N failures are reported
+# but do not fail the fast gate.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TAGS="capability_e2e"
+if [[ "${1:-}" == "--nightly" ]]; then
+  TAGS="capability_e2e capability_nightly"
+  echo "capability-e2e: including Tier N (nightly) capabilities"
+fi
+
+# Isolated-socket discipline (belt to the harness suspenders): refuse to run
+# inside a live tmux session unless the isolation marker is set. The harness
+# unsets TMUX per-process and forces a per-test socket, but a stray run from a
+# real conductor pane must never risk the user's real tmux server.
+if [[ -n "${TMUX:-}" && -z "${AGENT_DECK_TEST_ISOLATED:-}" ]]; then
+  echo "capability-e2e: refusing to run with TMUX set and AGENT_DECK_TEST_ISOLATED unset." >&2
+  echo "  Run from outside tmux, or export AGENT_DECK_TEST_ISOLATED=1 if you know the run is isolated." >&2
+  exit 2
+fi
+
+MANIFEST="docs/status/capability-e2e-manifest.json"
+DASHBOARD="docs/status/capability-dashboard.html"
+RESULTS="$(mktemp -t cap-e2e-results.XXXXXX.json)"
+trap 'rm -f "$RESULTS"' EXIT
+
+echo "capability-e2e: running suite (tags: $TAGS)"
+# Capture go test -json regardless of pass/fail; the manifest must reflect both.
+TEST_STATUS=0
+go test -tags "$TAGS" -race -count=1 -timeout 8m -json ./tests/capability/... >"$RESULTS" || TEST_STATUS=$?
+
+echo "capability-e2e: rendering manifest + dashboard"
+# capability-report exits non-zero if a Tier F capability failed.
+REPORT_STATUS=0
+go run ./tools/capability-report \
+  --json-input "$RESULTS" \
+  --manifest "$MANIFEST" \
+  --dashboard "$DASHBOARD" || REPORT_STATUS=$?
+
+if [[ "$TEST_STATUS" -ne 0 ]]; then
+  echo "capability-e2e: test runner exited $TEST_STATUS" >&2
+fi
+if [[ "$REPORT_STATUS" -ne 0 ]]; then
+  echo "capability-e2e: a Tier F capability regressed; failing the gate" >&2
+  exit 1
+fi
+if [[ "$TEST_STATUS" -ne 0 ]]; then
+  exit "$TEST_STATUS"
+fi
+echo "capability-e2e: all fast-gate capabilities green"

--- a/tests/capability/capability_test.go
+++ b/tests/capability/capability_test.go
@@ -1,0 +1,182 @@
+//go:build capability_e2e
+
+// Package capability holds capability-level end-to-end tests for agent-deck.
+//
+// A capability test refuses to mock the thing under test. For each action
+// agent-deck promises a user can perform, one test runs the real action
+// through the compiled binary against a real tmux server on an isolated
+// socket, then asserts on the real effect: registry rows in state.db or the
+// live tmux pane content, the same surface a human would see.
+//
+// The suite is gated behind the `capability_e2e` build tag so it stays out of
+// the default `go test ./...` run (mirroring the eval_smoke tier). Run it with:
+//
+//	go test -tags capability_e2e ./tests/capability/...
+//
+// or via scripts/capability-e2e.sh, which also emits the manifest and
+// regenerates the dashboard. See
+// docs/testing/2026-05-26-capability-e2e-strategy.md for the design.
+//
+// Isolation discipline (non-negotiable, see the 2026-04-17 cascade incident):
+// every test goes through harness.Sandbox + Sandbox.InstallTmuxShim, which
+// forces every tmux invocation onto a per-test socket via `-S`, and through
+// testutil.IsolateTmuxSocket in TestMain, which unsets TMUX so a spawned
+// binary can never join the user's real tmux server.
+package capability
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+	"github.com/asheshgoplani/agent-deck/tests/eval/harness"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := testutil.IsolateTmuxSocket()
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}
+
+// capSandbox wraps harness.Sandbox with a real-tmux shim installed and a
+// scratch project directory ready for use.
+type capSandbox struct {
+	*harness.Sandbox
+	WorkDir string
+}
+
+// newCapSandbox builds an isolated sandbox, installs the tmux shim so all
+// pane spawns land on the per-test socket, and creates a scratch project dir
+// inside the sandbox HOME. It deliberately does NOT set [tmux].socket_name,
+// because that would make the binary emit its own `-L name` which would win
+// over the shim's `-S` and break isolation.
+func newCapSandbox(t *testing.T) *capSandbox {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not on PATH")
+	}
+	sb := harness.NewSandbox(t)
+	sb.InstallTmuxShim(t)
+
+	work := filepath.Join(sb.Home, "project")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatalf("mkdir workdir: %v", err)
+	}
+	return &capSandbox{Sandbox: sb, WorkDir: work}
+}
+
+// run executes the agent-deck binary with the sandbox env and fails the test
+// on a non-zero exit.
+func (c *capSandbox) run(t *testing.T, args ...string) string {
+	t.Helper()
+	out, err := c.try(args...)
+	if err != nil {
+		t.Fatalf("agent-deck %v: %v\n%s", args, err, out)
+	}
+	return out
+}
+
+// try is the best-effort variant: it returns combined output and error
+// without failing the test. Used for negative cases and cleanup.
+func (c *capSandbox) try(args ...string) (string, error) {
+	cmd := exec.Command(c.BinPath, args...)
+	cmd.Env = c.Env()
+	cmd.Dir = c.Home
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// sessionRow is the subset of `agent-deck list --json` fields the capability
+// tests assert on.
+type sessionRow struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Status string `json:"status"`
+	Tool   string `json:"tool"`
+	Path   string `json:"path"`
+	Group  string `json:"group"`
+}
+
+// list returns all registry rows via `list --json`.
+func (c *capSandbox) list(t *testing.T) []sessionRow {
+	t.Helper()
+	out := c.run(t, "list", "--json")
+	out = strings.TrimSpace(out)
+	if out == "" || out == "null" {
+		return nil
+	}
+	var rows []sessionRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("parse list --json: %v\nraw: %s", err, out)
+	}
+	return rows
+}
+
+// findByTitle returns the registry row with the given title, or ok=false.
+func (c *capSandbox) findByTitle(t *testing.T, title string) (sessionRow, bool) {
+	t.Helper()
+	for _, r := range c.list(t) {
+		if r.Title == title {
+			return r, true
+		}
+	}
+	return sessionRow{}, false
+}
+
+// tmuxSessionNames returns the names of every tmux session on the sandbox
+// socket that agent-deck owns (the agentdeck_ prefix).
+func (c *capSandbox) tmuxSessionNames(t *testing.T) []string {
+	t.Helper()
+	out, err := c.TmuxTry("list-sessions", "-F", "#{session_name}")
+	if err != nil {
+		// No server running yet is not an error for our purposes.
+		return nil
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "agentdeck_") {
+			names = append(names, line)
+		}
+	}
+	return names
+}
+
+// waitForTmuxSession polls until an agentdeck_ tmux session appears (or the
+// deadline passes) and returns its name. Empty string means none appeared.
+func (c *capSandbox) waitForTmuxSession(t *testing.T, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if names := c.tmuxSessionNames(t); len(names) > 0 {
+			return names[0]
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return ""
+}
+
+// waitForNoTmuxSession polls until zero agentdeck_ tmux sessions remain.
+func (c *capSandbox) waitForNoTmuxSession(t *testing.T, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(c.tmuxSessionNames(t)) == 0 {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+// stopQuietly best-effort stops a session so the shared tmux server exits
+// cleanly. Failures are non-fatal; Sandbox.teardown kill-servers as a backstop.
+func (c *capSandbox) stopQuietly(ref string) {
+	_, _ = c.try("session", "stop", ref)
+}

--- a/tests/capability/lifecycle_test.go
+++ b/tests/capability/lifecycle_test.go
@@ -1,0 +1,173 @@
+//go:build capability_e2e
+
+package capability
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// waitForStatus polls the registry until the session reaches one of the wanted
+// statuses, returning the last seen status and whether a match was found.
+func (c *capSandbox) waitForStatus(t *testing.T, title string, timeout time.Duration, wanted ...string) (string, bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		if row, ok := c.findByTitle(t, title); ok {
+			last = row.Status
+			for _, w := range wanted {
+				if last == w {
+					return last, true
+				}
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return last, false
+}
+
+// TestCapability_Lifecycle_Add proves `agent-deck add` writes a real registry
+// row carrying the title, tool, group, and working directory the user passed.
+func TestCapability_Lifecycle_Add(t *testing.T) {
+	c := newCapSandbox(t)
+
+	c.run(t, "add", "-c", "bash", "-t", "cap-add", "-g", "capgrp", c.WorkDir)
+
+	row, ok := c.findByTitle(t, "cap-add")
+	if !ok {
+		t.Fatalf("after add, no registry row titled cap-add.\nrows: %+v", c.list(t))
+	}
+	// agent-deck canonicalizes the `bash` builtin to the tool name "shell".
+	if row.Tool != "shell" {
+		t.Errorf("tool = %q, want shell (the canonical name for the bash builtin)", row.Tool)
+	}
+	if !strings.Contains(row.Path, "project") {
+		t.Errorf("path = %q, want it to contain the project workdir", row.Path)
+	}
+	if row.Group != "capgrp" {
+		t.Errorf("group = %q, want capgrp", row.Group)
+	}
+}
+
+// TestCapability_Lifecycle_Start proves `session start` spawns a real tmux pane
+// on the isolated socket and flips the registry status to an active state.
+func TestCapability_Lifecycle_Start(t *testing.T) {
+	c := newCapSandbox(t)
+	c.run(t, "add", "-c", "bash", "-t", "cap-start", c.WorkDir)
+
+	c.run(t, "session", "start", "cap-start")
+	defer c.stopQuietly("cap-start")
+
+	if name := c.waitForTmuxSession(t, 8*time.Second); name == "" {
+		t.Fatalf("no agentdeck_ tmux session appeared after start.\nrows: %+v", c.list(t))
+	}
+	if got, ok := c.waitForStatus(t, "cap-start", 8*time.Second, "running", "starting", "idle", "waiting"); !ok {
+		t.Fatalf("status did not reach an active state after start; last = %q", got)
+	}
+}
+
+// TestCapability_Lifecycle_Stop proves `session stop` tears down the tmux pane
+// and returns the registry status to stopped.
+func TestCapability_Lifecycle_Stop(t *testing.T) {
+	c := newCapSandbox(t)
+	c.run(t, "add", "-c", "bash", "-t", "cap-stop", c.WorkDir)
+	c.run(t, "session", "start", "cap-stop")
+	if name := c.waitForTmuxSession(t, 8*time.Second); name == "" {
+		t.Fatalf("session never started, cannot test stop")
+	}
+
+	c.run(t, "session", "stop", "cap-stop")
+
+	if !c.waitForNoTmuxSession(t, 8*time.Second) {
+		t.Fatalf("tmux session still present after stop: %v", c.tmuxSessionNames(t))
+	}
+	if got, ok := c.waitForStatus(t, "cap-stop", 5*time.Second, "stopped"); !ok {
+		t.Fatalf("status did not return to stopped; last = %q", got)
+	}
+}
+
+// TestCapability_Lifecycle_Restart proves `session restart` respawns the pane
+// without leaving a duplicate (the #30 double-spawn guard) and ends running.
+func TestCapability_Lifecycle_Restart(t *testing.T) {
+	c := newCapSandbox(t)
+	c.run(t, "add", "-c", "bash", "-t", "cap-restart", c.WorkDir)
+	c.run(t, "session", "start", "cap-restart")
+	defer c.stopQuietly("cap-restart")
+	if name := c.waitForTmuxSession(t, 8*time.Second); name == "" {
+		t.Fatalf("session never started, cannot test restart")
+	}
+
+	// --force skips the freshness guard so the restart proceeds even though we
+	// only just started; asserting exactly one pane afterward is what proves
+	// the guard against a double-spawn.
+	c.run(t, "session", "restart", "cap-restart", "--force")
+
+	if name := c.waitForTmuxSession(t, 8*time.Second); name == "" {
+		t.Fatalf("no tmux session after restart")
+	}
+	if names := c.tmuxSessionNames(t); len(names) != 1 {
+		t.Fatalf("expected exactly one pane after restart, got %d: %v", len(names), names)
+	}
+	if got, ok := c.waitForStatus(t, "cap-restart", 8*time.Second, "running", "starting", "idle", "waiting"); !ok {
+		t.Fatalf("status not active after restart; last = %q", got)
+	}
+}
+
+// TestCapability_Lifecycle_Rm proves `rm` drops a stopped session from the
+// registry (happy path) and refuses a running session without --force
+// (failure mode, the destructive-action guard).
+func TestCapability_Lifecycle_Rm(t *testing.T) {
+	c := newCapSandbox(t)
+
+	// Failure mode first: rm on a running session must be refused.
+	c.run(t, "add", "-c", "bash", "-t", "cap-rm-running", c.WorkDir)
+	c.run(t, "session", "start", "cap-rm-running")
+	defer c.stopQuietly("cap-rm-running")
+	if name := c.waitForTmuxSession(t, 8*time.Second); name == "" {
+		t.Fatalf("session never started, cannot test rm guard")
+	}
+	if out, err := c.try("session", "remove", "cap-rm-running"); err == nil {
+		t.Fatalf("session remove of a running session should be refused without --force, got success:\n%s", out)
+	}
+	if _, ok := c.findByTitle(t, "cap-rm-running"); !ok {
+		t.Fatalf("refused rm must leave the session in the registry, but it is gone")
+	}
+
+	// Happy path: stop then rm removes the row.
+	c.run(t, "add", "-c", "bash", "-t", "cap-rm-stopped", c.WorkDir)
+	c.run(t, "session", "start", "cap-rm-stopped")
+	if name := c.waitForTmuxSession(t, 8*time.Second); name == "" {
+		t.Fatalf("cap-rm-stopped never started")
+	}
+	c.run(t, "session", "stop", "cap-rm-stopped")
+	c.waitForNoTmuxSession(t, 8*time.Second)
+	c.run(t, "session", "remove", "cap-rm-stopped")
+	if _, ok := c.findByTitle(t, "cap-rm-stopped"); ok {
+		t.Fatalf("after session remove, the row should be absent from the registry")
+	}
+}
+
+// TestCapability_Lifecycle_Fork proves the fork precondition guard: forking a
+// non-Claude session is refused with a clear error and creates no child row.
+//
+// The full happy path (a fork that inherits a real Claude conversation, gets a
+// distinct id, and links ParentSessionID) needs a real ClaudeSessionID from a
+// live claude transcript, which is non-deterministic and key-gated. That path
+// is a documented Tier N gap. See docs/testing/capability-gaps.md.
+func TestCapability_Lifecycle_Fork(t *testing.T) {
+	c := newCapSandbox(t)
+	c.run(t, "add", "-c", "bash", "-t", "cap-fork", c.WorkDir)
+
+	out, err := c.try("session", "fork", "cap-fork")
+	if err == nil {
+		t.Fatalf("fork of a non-Claude session should be refused, got success:\n%s", out)
+	}
+	if !strings.Contains(out, "not a Claude session") {
+		t.Errorf("fork refusal should name the precondition, got:\n%s", out)
+	}
+	if _, ok := c.findByTitle(t, "cap-fork-fork"); ok {
+		t.Fatalf("a refused fork must not create a child registry row")
+	}
+}

--- a/tests/capability/roundtrip_test.go
+++ b/tests/capability/roundtrip_test.go
@@ -1,0 +1,133 @@
+//go:build capability_e2e
+
+package capability
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// setupEchobot installs the deterministic echo agent into the sandbox and
+// registers it as a custom tool in config.toml, so `launch -c echobot` and
+// `session start` resolve it. The script is copied out of testdata into the
+// scratch HOME with the executable bit set, so the test never depends on the
+// repo file's permissions.
+//
+// It returns nothing; the tool name is the literal "echobot".
+func setupEchobot(t *testing.T, c *capSandbox) {
+	t.Helper()
+
+	src, err := filepath.Abs(filepath.Join("testdata", "echobot.sh"))
+	if err != nil {
+		t.Fatalf("resolve echobot.sh: %v", err)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read echobot.sh: %v", err)
+	}
+	scriptPath := filepath.Join(c.Home, "echobot.sh")
+	if err := os.WriteFile(scriptPath, data, 0o755); err != nil {
+		t.Fatalf("write echobot.sh into sandbox: %v", err)
+	}
+
+	cfgDir := filepath.Join(c.Home, ".agent-deck")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir .agent-deck: %v", err)
+	}
+	// prompt_patterns makes PromptDetector treat "ECHOBOT READY" as the ready
+	// prompt so the readiness gate opens. busy_patterns is set to a token that
+	// never appears so the detector never reads the pane as busy.
+	cfg := fmt.Sprintf(`[tools.echobot]
+command = %q
+icon = "E"
+prompt_patterns = ["ECHOBOT READY"]
+busy_patterns = ["WORKING"]
+`, scriptPath)
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+}
+
+// waitForPaneContains polls `session output --pane` until the substring shows
+// up or the deadline passes, returning the final capture and whether it matched.
+func (c *capSandbox) waitForPaneContains(t *testing.T, ref, want string, timeout time.Duration) (string, bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		out, err := c.try("session", "output", ref, "--pane")
+		if err == nil {
+			last = out
+			if strings.Contains(out, want) {
+				return last, true
+			}
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	return last, false
+}
+
+// TestCapability_Agent_EchoRoundTrip is the backbone capability test: a message
+// reaches a live agent and a reply comes back. It drives the deterministic
+// echo agent through the exact production path a real claude send takes:
+// waitForAgentReady polls capture-pane and runs PromptDetector against the
+// custom prompt pattern, sendWithRetry issues the literal send-keys + Enter,
+// and `session output --pane` reads the result back. Only the brain on the far
+// end is made deterministic.
+func TestCapability_Agent_EchoRoundTrip(t *testing.T) {
+	c := newCapSandbox(t)
+	setupEchobot(t, c)
+
+	c.run(t, "add", "-c", "echobot", "-t", "cap-echo", c.WorkDir)
+	c.run(t, "session", "start", "cap-echo")
+	defer c.stopQuietly("cap-echo")
+
+	if name := c.waitForTmuxSession(t, 8*time.Second); name == "" {
+		t.Fatalf("echobot session never started.\nrows: %+v", c.list(t))
+	}
+
+	// --no-wait uses the send path that does not fire the Ctrl+C "full resend"
+	// recovery (issue #479 / #876). That recovery is tuned for real agents,
+	// which sit visibly "active" after receiving input; our deterministic
+	// stand-in returns to its prompt too quickly for that heuristic, and the
+	// Ctrl+C would kill it. The send still goes through the real send-keys +
+	// Enter, the readiness preflight, and the delivery verifier (which confirms
+	// the token reached the pane), so the round trip is exercised end to end.
+	token := "PING-" + strings.ReplaceAll(t.Name(), "/", "-")
+	c.run(t, "session", "send", "cap-echo", token, "--no-wait")
+
+	want := "ECHO:" + token
+	if pane, ok := c.waitForPaneContains(t, "cap-echo", want, 20*time.Second); !ok {
+		t.Fatalf("pane never showed %q within timeout.\nThe send -> readiness -> capture round trip is broken.\nlast pane:\n%s", want, pane)
+	}
+}
+
+// TestCapability_Lifecycle_Launch proves the atomic add+start+send path: a
+// single `launch -m` command creates the session, starts the pane, waits for
+// readiness, and delivers the message, with the echoed token visible in the
+// pane afterward.
+func TestCapability_Lifecycle_Launch(t *testing.T) {
+	c := newCapSandbox(t)
+	setupEchobot(t, c)
+
+	token := "PINGLAUNCH-cap-e2e-token"
+	c.run(t, "launch", c.WorkDir, "-c", "echobot", "-t", "cap-launch", "-m", token)
+	defer c.stopQuietly("cap-launch")
+
+	row, ok := c.findByTitle(t, "cap-launch")
+	if !ok {
+		t.Fatalf("launch did not create a registry row.\nrows: %+v", c.list(t))
+	}
+	if row.Tool != "echobot" {
+		t.Errorf("tool = %q, want echobot", row.Tool)
+	}
+
+	want := "ECHO:" + token
+	if pane, ok := c.waitForPaneContains(t, "cap-launch", want, 20*time.Second); !ok {
+		t.Fatalf("launch -m did not result in %q in the pane.\nlast pane:\n%s", want, pane)
+	}
+}

--- a/tests/capability/testdata/echobot.sh
+++ b/tests/capability/testdata/echobot.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# echobot: a deterministic stand-in agent for the capability E2E suite.
+#
+# It plays the role a real coding agent (claude/codex/gemini) plays in a tmux
+# pane, minus the non-determinism, the network, and the API key:
+#
+#   1. On start it prints a fixed ready marker, "ECHOBOT READY", so
+#      agent-deck's PromptDetector (configured via prompt_patterns in
+#      config.toml) sees a ready prompt and the readiness gate in
+#      `waitForAgentReady` opens.
+#   2. It then loops: read one line from stdin (the literal keystrokes that
+#      `session send` delivers via tmux send-keys + Enter) and echo it back as
+#      "ECHO:<line>", then reprint the ready marker so the next send is gated
+#      the same way.
+#
+# The round-trip test asserts the pane contains "ECHO:PING-<uuid>", which
+# proves the full production path: readiness detection -> send-keys -> Enter ->
+# capture-pane read-back. The only thing made deterministic is the brain on the
+# far end. See docs/testing/2026-05-26-capability-e2e-strategy.md.
+set -u
+
+ready() { printf 'ECHOBOT READY > '; }
+
+# Braille spinner frames. These are agent-deck's default spinner characters
+# (internal/tmux/patterns.go defaultSpinnerChars). A real agent animates a
+# spinner like this while it is thinking, and agent-deck's status detector
+# reads that as the 'active' state.
+frames="⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏"
+
+ready
+while IFS= read -r line; do
+  # Present a visible, sustained "busy" state after receiving a line. This is
+  # not cosmetic: agent-deck's send-delivery verifier (issue #876) only treats
+  # a send as delivered once the agent transitions to 'active'. Animating the
+  # spinner is the authoritative active signal (the spinner fallback in
+  # hasBusyIndicatorResolved marks any spinner char busy for non-claude tools),
+  # and it keeps tmux window-activity changing across several status-check
+  # cycles (the verifier polls every ~300ms and needs roughly two active
+  # reads). Without it the verifier exhausts its budget and fires a Ctrl+C
+  # resend that would kill this stand-in. ~2s of animation covers the window.
+  for _ in 1 2 3 4; do
+    for f in $frames; do
+      printf '\r%s working' "$f"
+      sleep 0.05
+    done
+  done
+  printf '\nECHO:%s\n' "$line"
+  ready
+done

--- a/tools/capability-report/main.go
+++ b/tools/capability-report/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func main() {
+	jsonInput := flag.String("json-input", "-", "path to `go test -json` output, or - for stdin")
+	manifestPath := flag.String("manifest", "docs/status/capability-e2e-manifest.json", "where to write the JSON manifest")
+	dashboardPath := flag.String("dashboard", "docs/status/capability-dashboard.html", "where to write the HTML dashboard")
+	flag.Parse()
+
+	raw, err := readInput(*jsonInput)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "capability-report: read input: %v\n", err)
+		os.Exit(2)
+	}
+
+	results := ParseTestResults(raw)
+	manifest := BuildManifest(results, time.Now())
+
+	if err := writeManifest(*manifestPath, manifest); err != nil {
+		fmt.Fprintf(os.Stderr, "capability-report: write manifest: %v\n", err)
+		os.Exit(2)
+	}
+	html, err := RenderDashboard(manifest)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "capability-report: render dashboard: %v\n", err)
+		os.Exit(2)
+	}
+	if err := writeFile(*dashboardPath, []byte(html)); err != nil {
+		fmt.Fprintf(os.Stderr, "capability-report: write dashboard: %v\n", err)
+		os.Exit(2)
+	}
+
+	s := manifest.Summary
+	fmt.Printf("capability-report: %d capabilities, %d green, %d failed, %d nightly, %d not covered\n",
+		s.Total, s.Green, s.Failed, s.NightlyOnly, s.NotCovered)
+	fmt.Printf("capability-report: wrote %s and %s\n", *manifestPath, *dashboardPath)
+
+	// Exit non-zero when a fast-gate capability failed so the gate script can
+	// block the release. Tier N failures do not fail the fast gate.
+	if manifest.HasFastFailure() {
+		fmt.Fprintln(os.Stderr, "capability-report: a Tier F capability FAILED")
+		os.Exit(1)
+	}
+}
+
+func readInput(path string) ([]byte, error) {
+	if path == "-" || path == "" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(path)
+}
+
+func writeManifest(path string, m Manifest) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return writeFile(path, data)
+}
+
+func writeFile(path string, data []byte) error {
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/tools/capability-report/report.go
+++ b/tools/capability-report/report.go
@@ -1,0 +1,429 @@
+// Command capability-report turns `go test -json` output from the capability
+// E2E suite into a JSON manifest and a self-contained HTML dashboard.
+//
+// It is the typed, testable rendering step referenced by
+// scripts/capability-e2e.sh. The manifest is the ground truth: every card on
+// the dashboard traces back to one capability entry, and a re-run is one
+// command. See docs/testing/2026-05-26-capability-e2e-strategy.md section 4.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"time"
+)
+
+// Tier classifies how a capability is verified.
+const (
+	// TierF is the fast gate: deterministic, offline, isolated socket, runs on
+	// every release.
+	TierF = "F"
+	// TierN is nightly / on-demand: real external agents, real SSH, real keys.
+	// Not run in the fast pass; shown greyed on the dashboard.
+	TierN = "N"
+)
+
+// Result statuses a capability can hold in the manifest.
+const (
+	StatusPass    = "pass"
+	StatusFail    = "fail"
+	StatusNightly = "nightly"  // Tier N, not run in this fast pass.
+	StatusNotRun  = "not-run"  // Tier F capability with no matching test result.
+)
+
+// Capability is one row of the inventory: the static metadata plus the result
+// filled in from a test run. Static fields come from the registry below; the
+// dynamic fields (Status, RuntimeSeconds) are populated by BuildManifest.
+type Capability struct {
+	ID         string   `json:"id"`
+	Group      string   `json:"group"`
+	Title      string   `json:"title"`
+	HowWeTest  string   `json:"how_we_test"`
+	Assertion  string   `json:"assertion"`
+	Tier       string   `json:"tier"`
+	Chips      []string `json:"chips"`
+	TestName   string   `json:"test_name,omitempty"`
+	Status     string   `json:"status"`
+	RuntimeSeconds float64 `json:"runtime_seconds"`
+}
+
+// Summary is the headline strip on the dashboard.
+type Summary struct {
+	Total       int `json:"total"`
+	Green       int `json:"green"`
+	Failed      int `json:"failed"`
+	NightlyOnly int `json:"nightly_only"`
+	NotCovered  int `json:"not_covered"`
+}
+
+// Manifest is the full report: a snapshot timestamp, the summary, and every
+// capability in inventory order.
+type Manifest struct {
+	GeneratedAt  string       `json:"generated_at"`
+	Summary      Summary      `json:"summary"`
+	Capabilities []Capability `json:"capabilities"`
+}
+
+// testResult is the pass/fail + runtime parsed for a single test function.
+type testResult struct {
+	status  string
+	elapsed float64
+}
+
+// registry is the authoritative capability inventory for Wave 1. Test names
+// map 1:1 to the capability tests in tests/capability/. Tier N rows have no
+// test yet and are surfaced as honest, documented gaps (see
+// docs/testing/capability-gaps.md), not faked green.
+func registry() []Capability {
+	const (
+		chipLocal = "Local-isolated"
+		chipStub  = "Deterministic-stub"
+		chipReal  = "Real-agent"
+		chipKey   = "Needs-creds"
+		chipNet   = "Needs-network"
+	)
+	return []Capability{
+		{
+			ID: "add", Group: "Session lifecycle", TestName: "TestCapability_Lifecycle_Add",
+			Title: "Register a session",
+			HowWeTest: "We run the add command to register a new session, then read the saved registry back. We confirm the row exists with the title, tool, group, and folder we asked for.",
+			Assertion: "new registry row carries the given title, tool, group, and working directory",
+			Tier: TierF, Chips: []string{chipLocal},
+		},
+		{
+			ID: "start", Group: "Session lifecycle", TestName: "TestCapability_Lifecycle_Start",
+			Title: "Start a session",
+			HowWeTest: "We register a session and start it. We then ask the throwaway tmux server whether a live pane actually appeared, and confirm the registry flips the session to an active state.",
+			Assertion: "a real tmux pane appears on the isolated socket and status becomes active",
+			Tier: TierF, Chips: []string{chipLocal},
+		},
+		{
+			ID: "stop", Group: "Session lifecycle", TestName: "TestCapability_Lifecycle_Stop",
+			Title: "Stop a session",
+			HowWeTest: "We start a session, then stop it. We confirm the tmux pane is gone and the registry returns the session to the stopped state.",
+			Assertion: "tmux pane disappears and registry status returns to stopped",
+			Tier: TierF, Chips: []string{chipLocal},
+		},
+		{
+			ID: "restart", Group: "Session lifecycle", TestName: "TestCapability_Lifecycle_Restart",
+			Title: "Restart a session",
+			HowWeTest: "We start a session and restart it. We confirm exactly one pane exists afterward (no accidental duplicate) and the session is active again.",
+			Assertion: "exactly one pane remains after restart and status is active (guards the #30 double-spawn)",
+			Tier: TierF, Chips: []string{chipLocal},
+		},
+		{
+			ID: "rm", Group: "Session lifecycle", TestName: "TestCapability_Lifecycle_Rm",
+			Title: "Remove a session",
+			HowWeTest: "We confirm a stopped session can be removed and disappears from the registry, and that removing a still-running session is refused unless forced, so it is not destroyed by accident.",
+			Assertion: "stopped session leaves the registry; a running session is refused without force",
+			Tier: TierF, Chips: []string{chipLocal},
+		},
+		{
+			ID: "launch", Group: "Session lifecycle", TestName: "TestCapability_Lifecycle_Launch",
+			Title: "Launch in one step",
+			HowWeTest: "We use the single launch command, which creates, starts, and messages a session at once, pointed at the stand-in echo agent. We confirm the registry row exists and the echoed message shows up on screen.",
+			Assertion: "one launch command creates the row, starts the pane, and the echoed message appears",
+			Tier: TierF, Chips: []string{chipLocal, chipStub},
+		},
+		{
+			ID: "fork", Group: "Session lifecycle", TestName: "TestCapability_Lifecycle_Fork",
+			Title: "Fork guard",
+			HowWeTest: "Forking is only valid for a Claude session with live context. We confirm forking a non-Claude session is cleanly refused and creates no orphan child row. The full context-inheriting fork is a documented nightly gap.",
+			Assertion: "forking a non-Claude session is refused and no child row is created",
+			Tier: TierF, Chips: []string{chipLocal},
+		},
+		{
+			ID: "send-output-echo", Group: "Agent interaction", TestName: "TestCapability_Agent_EchoRoundTrip",
+			Title: "Send a message to an agent and read its reply",
+			HowWeTest: "We launch a tiny stand-in agent that simply repeats whatever you say. We send it a unique message through the normal send command, then read the screen back. If the screen shows the echoed message we know it reached the agent and a reply came out the other side.",
+			Assertion: "the pane shows ECHO:<token> after a real send, proving readiness, send-keys, and capture read-back",
+			Tier: TierF, Chips: []string{chipLocal, chipStub},
+		},
+		// Tier N: documented honest gaps. No test in Wave 1; shown greyed.
+		{
+			ID: "send-output-claude", Group: "Agent interaction",
+			Title: "Real agent round trip (Claude)",
+			HowWeTest: "We launch a real Claude session, wait for its prompt, send a fixed instruction, and check the reply. This needs a real API key and network, so it runs nightly, not on every release.",
+			Assertion: "a real Claude reply contains the expected token",
+			Tier: TierN, Chips: []string{chipReal, chipKey, chipNet},
+		},
+		{
+			ID: "fork-context", Group: "Agent interaction",
+			Title: "Fork inherits Claude context",
+			HowWeTest: "We fork a live Claude session and confirm the child inherits the conversation with a distinct id and a parent link. This needs a real Claude session id from a live transcript, so it runs nightly.",
+			Assertion: "child session links the parent and inherits conversation context",
+			Tier: TierN, Chips: []string{chipReal, chipKey, chipNet},
+		},
+		{
+			ID: "mcp-loads", Group: "MCP",
+			Title: "MCP actually loads in the agent",
+			HowWeTest: "We attach a tool server and ask a real agent to list its tools, confirming the agent honors the attachment. This needs a real agent to introspect, so it runs nightly.",
+			Assertion: "the agent lists the attached MCP server",
+			Tier: TierN, Chips: []string{chipReal, chipKey, chipNet},
+		},
+	}
+}
+
+// ParseTestResults reads `go test -json` event lines and returns a map from
+// test function name to its pass/fail status and elapsed seconds. Lines that
+// are not JSON objects (e.g. build output) are ignored.
+func ParseTestResults(jsonl []byte) map[string]testResult {
+	results := make(map[string]testResult)
+	for _, line := range bytes.Split(jsonl, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var ev struct {
+			Action  string  `json:"Action"`
+			Test    string  `json:"Test"`
+			Elapsed float64 `json:"Elapsed"`
+		}
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+		if ev.Test == "" {
+			continue
+		}
+		switch ev.Action {
+		case "pass":
+			results[ev.Test] = testResult{status: StatusPass, elapsed: ev.Elapsed}
+		case "fail":
+			results[ev.Test] = testResult{status: StatusFail, elapsed: ev.Elapsed}
+		}
+	}
+	return results
+}
+
+// BuildManifest joins the static registry with parsed test results, computing
+// each capability's status and the headline summary.
+func BuildManifest(results map[string]testResult, generatedAt time.Time) Manifest {
+	caps := registry()
+	var sum Summary
+	for i := range caps {
+		c := &caps[i]
+		switch {
+		case c.Tier == TierN:
+			c.Status = StatusNightly
+		case c.TestName != "":
+			if r, ok := results[c.TestName]; ok {
+				c.Status = r.status
+				c.RuntimeSeconds = r.elapsed
+			} else {
+				c.Status = StatusNotRun
+			}
+		default:
+			c.Status = StatusNotRun
+		}
+
+		sum.Total++
+		switch c.Status {
+		case StatusPass:
+			sum.Green++
+		case StatusFail:
+			sum.Failed++
+		case StatusNightly:
+			sum.NightlyOnly++
+		case StatusNotRun:
+			sum.NotCovered++
+		}
+	}
+	return Manifest{
+		GeneratedAt:  generatedAt.UTC().Format(time.RFC3339),
+		Summary:      sum,
+		Capabilities: caps,
+	}
+}
+
+// HasFastFailure reports whether any Tier F capability failed. The gate script
+// exits non-zero when this is true.
+func (m Manifest) HasFastFailure() bool {
+	for _, c := range m.Capabilities {
+		if c.Tier == TierF && c.Status == StatusFail {
+			return true
+		}
+	}
+	return false
+}
+
+// groupedView is the per-group slice handed to the template.
+type groupedView struct {
+	Name string
+	Caps []Capability
+}
+
+// grouped returns capabilities bucketed by Group, preserving first-seen group
+// order so the dashboard sections match the inventory order.
+func (m Manifest) grouped() []groupedView {
+	var order []string
+	buckets := map[string][]Capability{}
+	for _, c := range m.Capabilities {
+		if _, ok := buckets[c.Group]; !ok {
+			order = append(order, c.Group)
+		}
+		buckets[c.Group] = append(buckets[c.Group], c)
+	}
+	out := make([]groupedView, 0, len(order))
+	for _, g := range order {
+		out = append(out, groupedView{Name: g, Caps: buckets[g]})
+	}
+	return out
+}
+
+// statusClass maps a status to the dashboard's color class.
+func statusClass(status string) string {
+	switch status {
+	case StatusPass:
+		return "green"
+	case StatusFail:
+		return "red"
+	case StatusNightly:
+		return "grey"
+	default:
+		return "amber"
+	}
+}
+
+// statusLabel is the human-readable status word on a card.
+func statusLabel(status string) string {
+	switch status {
+	case StatusPass:
+		return "PASS"
+	case StatusFail:
+		return "FAIL"
+	case StatusNightly:
+		return "NIGHTLY"
+	default:
+		return "NOT RUN"
+	}
+}
+
+// runtimeLabel formats the measured runtime, or a dash placeholder when the
+// capability did not run in this pass.
+func runtimeLabel(c Capability) string {
+	if c.Status == StatusPass || c.Status == StatusFail {
+		return fmt.Sprintf("%.1fs", c.RuntimeSeconds)
+	}
+	return "not measured"
+}
+
+var dashboardTmpl = template.Must(template.New("dashboard").Funcs(template.FuncMap{
+	"statusClass":  statusClass,
+	"statusLabel":  statusLabel,
+	"runtimeLabel": runtimeLabel,
+}).Parse(dashboardHTML))
+
+// RenderDashboard renders the full self-contained HTML dashboard from a
+// manifest. The output is deterministic for a given manifest, which is what
+// makes it unit-testable.
+func RenderDashboard(m Manifest) (string, error) {
+	var buf bytes.Buffer
+	data := struct {
+		Manifest
+		Groups []groupedView
+	}{Manifest: m, Groups: m.grouped()}
+	if err := dashboardTmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// dashboardHTML is the self-contained template. Style rules: inline CSS, system
+// font stack, the green/amber/red CSS variables from the testing-overview page,
+// no em-dash separators, no emoji. Status is shown with a colored dot plus a
+// word so it reads without color alone.
+const dashboardHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>agent-deck Capability E2E Dashboard</title>
+<style>
+  :root {
+    --green: #16a34a;
+    --amber: #d97706;
+    --red: #dc2626;
+    --grey: #8b949e;
+    --ink: #1f2328;
+    --muted: #57606a;
+    --line: #d8dee4;
+    --bg: #f6f8fa;
+  }
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: var(--ink); line-height: 1.55; margin: 0; background: #fff;
+  }
+  .wrap { max-width: 1100px; margin: 0 auto; padding: 40px 24px 80px; }
+  header.page { border-bottom: 2px solid var(--line); padding-bottom: 20px; margin-bottom: 28px; }
+  header.page h1 { font-size: 28px; margin: 0 0 6px; letter-spacing: -0.02em; }
+  header.page .date { color: var(--muted); font-size: 14px; }
+  header.page .pitch { font-size: 15px; color: var(--ink); margin-top: 12px; max-width: 780px; }
+  h2 { font-size: 20px; margin: 36px 0 12px; letter-spacing: -0.01em; }
+  .muted { color: var(--muted); }
+  .summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin: 16px 0 8px; }
+  .stat { border: 1px solid var(--line); border-radius: 10px; padding: 14px 16px; background: #fff; }
+  .stat .label { font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
+  .stat .value { font-size: 26px; font-weight: 650; margin-top: 4px; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 14px; margin: 12px 0; }
+  .card { border: 1px solid var(--line); border-radius: 10px; padding: 16px 18px; box-shadow: 0 1px 2px rgba(0,0,0,0.04); background: #fff; }
+  .card.green { border-top: 3px solid var(--green); }
+  .card.amber { border-top: 3px solid var(--amber); }
+  .card.red { border-top: 3px solid var(--red); }
+  .card.grey { border-top: 3px solid var(--grey); }
+  .card h3 { font-size: 15px; margin: 0 0 8px; }
+  .status { font-size: 12px; font-weight: 650; letter-spacing: 0.04em; }
+  .dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
+  .dot.green { background: var(--green); }
+  .dot.amber { background: var(--amber); }
+  .dot.red { background: var(--red); }
+  .dot.grey { background: var(--grey); }
+  .how { font-size: 13.5px; color: var(--ink); margin: 8px 0; }
+  .assert { font-size: 12.5px; color: var(--muted); margin: 6px 0; }
+  .meta { font-size: 12px; color: var(--muted); margin-top: 8px; }
+  .chips { margin-top: 8px; }
+  .chip { display: inline-block; font-size: 11px; background: var(--bg); border: 1px solid var(--line); border-radius: 999px; padding: 2px 9px; margin: 2px 4px 2px 0; color: var(--muted); }
+  footer { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--line); font-size: 12.5px; color: var(--muted); }
+</style>
+</head>
+<body>
+<div class="wrap">
+<header class="page">
+  <h1>agent-deck Capability E2E Dashboard</h1>
+  <div class="date">Generated {{.GeneratedAt}}</div>
+  <p class="pitch">One card per capability agent-deck promises a user can do. Each fast-gate capability is verified by a test that performs the real action through the compiled binary on an isolated tmux socket and asserts on the real effect: registry rows or live pane content. Nightly capabilities need real agents, keys, or network and run out of band.</p>
+</header>
+
+<section class="summary">
+  <div class="stat"><div class="label">Capabilities</div><div class="value">{{.Summary.Total}}</div></div>
+  <div class="stat"><div class="label">Green</div><div class="value">{{.Summary.Green}}</div></div>
+  <div class="stat"><div class="label">Failed</div><div class="value">{{.Summary.Failed}}</div></div>
+  <div class="stat"><div class="label">Nightly only</div><div class="value">{{.Summary.NightlyOnly}}</div></div>
+  <div class="stat"><div class="label">Not yet covered</div><div class="value">{{.Summary.NotCovered}}</div></div>
+</section>
+
+{{range .Groups}}
+<h2>{{.Name}}</h2>
+<div class="cards">
+  {{range .Caps}}
+  <div class="card {{statusClass .Status}}">
+    <div class="status"><span class="dot {{statusClass .Status}}"></span>{{statusLabel .Status}}</div>
+    <h3>{{.Title}}</h3>
+    <p class="how">{{.HowWeTest}}</p>
+    <p class="assert">Pass when: {{.Assertion}}</p>
+    <div class="meta">Tier {{.Tier}} . Runtime: {{runtimeLabel .}}{{if .TestName}} . {{.TestName}}{{end}}</div>
+    <div class="chips">{{range .Chips}}<span class="chip">{{.}}</span>{{end}}</div>
+  </div>
+  {{end}}
+</div>
+{{end}}
+
+<footer>
+  Rendered from docs/status/capability-e2e-manifest.json by tools/capability-report. Regenerate with scripts/capability-e2e.sh. Honest gaps are tracked in docs/testing/capability-gaps.md.
+</footer>
+</div>
+</body>
+</html>
+`

--- a/tools/capability-report/report_test.go
+++ b/tools/capability-report/report_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedTime is a stable timestamp so dashboard rendering is deterministic.
+var fixedTime = time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+
+// sampleResults pretends the Wave 1 fast-gate tests all passed, except one we
+// flip to fail in dedicated cases.
+func sampleResults() map[string]testResult {
+	return map[string]testResult{
+		"TestCapability_Lifecycle_Add":       {status: StatusPass, elapsed: 2.0},
+		"TestCapability_Lifecycle_Start":     {status: StatusPass, elapsed: 1.4},
+		"TestCapability_Lifecycle_Stop":      {status: StatusPass, elapsed: 1.4},
+		"TestCapability_Lifecycle_Restart":   {status: StatusPass, elapsed: 2.5},
+		"TestCapability_Lifecycle_Rm":        {status: StatusPass, elapsed: 11.0},
+		"TestCapability_Lifecycle_Launch":    {status: StatusPass, elapsed: 7.1},
+		"TestCapability_Lifecycle_Fork":      {status: StatusPass, elapsed: 0.1},
+		"TestCapability_Agent_EchoRoundTrip": {status: StatusPass, elapsed: 5.7},
+	}
+}
+
+func TestParseTestResults(t *testing.T) {
+	jsonl := `
+{"Time":"2026-05-26T12:00:00Z","Action":"run","Test":"TestCapability_Lifecycle_Add"}
+{"Time":"2026-05-26T12:00:02Z","Action":"pass","Test":"TestCapability_Lifecycle_Add","Elapsed":2.0}
+{"Time":"2026-05-26T12:00:03Z","Action":"fail","Test":"TestCapability_Lifecycle_Stop","Elapsed":1.5}
+not-json build noise
+{"Action":"pass","Elapsed":0.1}
+`
+	got := ParseTestResults([]byte(jsonl))
+	if r, ok := got["TestCapability_Lifecycle_Add"]; !ok || r.status != StatusPass || r.elapsed != 2.0 {
+		t.Errorf("Add result = %+v, want pass/2.0", r)
+	}
+	if r, ok := got["TestCapability_Lifecycle_Stop"]; !ok || r.status != StatusFail {
+		t.Errorf("Stop result = %+v, want fail", r)
+	}
+	// The package-level event with no Test field must be ignored.
+	if len(got) != 2 {
+		t.Errorf("parsed %d results, want 2 (events without a Test name are ignored)", len(got))
+	}
+}
+
+func TestBuildManifest_StatusesAndSummary(t *testing.T) {
+	m := BuildManifest(sampleResults(), fixedTime)
+
+	// Eight fast-gate capabilities pass; the Tier N rows are nightly.
+	if m.Summary.Green != 8 {
+		t.Errorf("Green = %d, want 8", m.Summary.Green)
+	}
+	if m.Summary.Failed != 0 {
+		t.Errorf("Failed = %d, want 0", m.Summary.Failed)
+	}
+	if m.Summary.NightlyOnly < 1 {
+		t.Errorf("NightlyOnly = %d, want at least 1 documented gap", m.Summary.NightlyOnly)
+	}
+	if m.Summary.Total != len(m.Capabilities) {
+		t.Errorf("Total %d != len(capabilities) %d", m.Summary.Total, len(m.Capabilities))
+	}
+
+	// A Tier N capability must read as nightly with no measured runtime.
+	for _, c := range m.Capabilities {
+		if c.Tier == TierN && c.Status != StatusNightly {
+			t.Errorf("Tier N capability %q status = %q, want nightly", c.ID, c.Status)
+		}
+	}
+	if m.HasFastFailure() {
+		t.Error("HasFastFailure() = true, want false when all fast tests pass")
+	}
+}
+
+func TestBuildManifest_NotRunWhenTestMissing(t *testing.T) {
+	// Empty results: every fast-gate capability is not-run, none failed.
+	m := BuildManifest(map[string]testResult{}, fixedTime)
+	if m.Summary.Green != 0 {
+		t.Errorf("Green = %d, want 0 with no results", m.Summary.Green)
+	}
+	if m.Summary.NotCovered == 0 {
+		t.Error("NotCovered = 0, want the fast-gate capabilities flagged not-run")
+	}
+	if m.HasFastFailure() {
+		t.Error("a missing test is not-run, not a failure; HasFastFailure should be false")
+	}
+}
+
+func TestBuildManifest_FastFailureBlocks(t *testing.T) {
+	res := sampleResults()
+	res["TestCapability_Agent_EchoRoundTrip"] = testResult{status: StatusFail, elapsed: 4.2}
+	m := BuildManifest(res, fixedTime)
+	if !m.HasFastFailure() {
+		t.Error("HasFastFailure() = false, want true when a Tier F capability fails")
+	}
+	if m.Summary.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", m.Summary.Failed)
+	}
+}
+
+func TestRenderDashboard_ContainsCapabilityContent(t *testing.T) {
+	m := BuildManifest(sampleResults(), fixedTime)
+	html, err := RenderDashboard(m)
+	if err != nil {
+		t.Fatalf("RenderDashboard: %v", err)
+	}
+
+	for _, want := range []string{
+		"<!DOCTYPE html>",
+		"agent-deck Capability E2E Dashboard",
+		"Send a message to an agent and read its reply", // the backbone card title
+		"Session lifecycle",                             // a group heading
+		"Agent interaction",
+		"PASS",
+		"NIGHTLY",
+		"TestCapability_Agent_EchoRoundTrip",
+		"2026-05-26T12:00:00Z",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("dashboard missing expected content: %q", want)
+		}
+	}
+
+	// Style discipline: no emoji, no em-dash separators.
+	if strings.ContainsRune(html, '—') {
+		t.Error("dashboard contains an em-dash; the style rules forbid em-dash separators")
+	}
+	for _, emoji := range []string{"✅", "❌", "⚠", "🔘", "💤", "💻", "🧪", "🌍", "🔑", "🌐"} {
+		if strings.Contains(html, emoji) {
+			t.Errorf("dashboard contains emoji %q; the style rules forbid emoji", emoji)
+		}
+	}
+}
+
+func TestRenderDashboard_FailingCardUsesRed(t *testing.T) {
+	res := sampleResults()
+	res["TestCapability_Lifecycle_Add"] = testResult{status: StatusFail, elapsed: 2.0}
+	html, err := RenderDashboard(BuildManifest(res, fixedTime))
+	if err != nil {
+		t.Fatalf("RenderDashboard: %v", err)
+	}
+	if !strings.Contains(html, `card red`) {
+		t.Error("a failing capability should render a red card")
+	}
+	if !strings.Contains(html, "FAIL") {
+		t.Error("a failing capability should show the FAIL label")
+	}
+}


### PR DESCRIPTION
## What

Wave 1 of the capability-level E2E suite (design: `docs/testing/2026-05-26-capability-e2e-strategy.md`, green-lit). For each thing agent-deck promises a user can do, one test performs the real action through the compiled CLI on an isolated tmux socket and asserts on the real effect: `state.db` rows (`list --json`) or live `tmux capture-pane` content. It refuses to mock the thing under test.

Layered on the existing `tests/eval/harness` `Sandbox` + `internal/testutil` `IsolateTmuxSocket` (no new harness), and gated behind a `//go:build capability_e2e` tag so the default `go test ./...` is unaffected (verified by the pre-push full suite: `tests/capability` shows `[no test files]` under default tags).

## Capabilities covered (Tier F, fast gate, ~32s with -race)

| Capability | Test | Real effect asserted |
|---|---|---|
| add | `TestCapability_Lifecycle_Add` | registry row carries title/tool/group/cwd |
| start | `TestCapability_Lifecycle_Start` | real pane on isolated socket; status active |
| stop | `TestCapability_Lifecycle_Stop` | pane gone; status stopped |
| restart | `TestCapability_Lifecycle_Restart` | exactly one pane (guards #30 double-spawn) |
| rm | `TestCapability_Lifecycle_Rm` | stopped removed; running refused without --force |
| launch | `TestCapability_Lifecycle_Launch` | one command creates+starts+messages; echo appears |
| fork (guard) | `TestCapability_Lifecycle_Fork` | non-Claude fork refused, no orphan child |
| send + read reply | `TestCapability_Agent_EchoRoundTrip` | `ECHO:<token>` appears after a real send |

The backbone is the echo round trip: `testdata/echobot.sh` is a deterministic stand-in agent wired via `[tools.echobot]`; the test sends a unique token through the normal send path and reads it back, exercising readiness detection + send-keys + capture. It uses `--no-wait` (see capability-gaps.md for why the default Ctrl+C-resend path is unsuitable for a trivial stand-in; real-agent default-path sends are Tier N).

## Tooling
- `tools/capability-report`: typed, testable Go-template step. Turns `go test -json` into `docs/status/capability-e2e-manifest.json` (ground truth) and renders `docs/status/capability-dashboard.html` (one card per capability, plain-English "how we test it", pass/fail, runtime, environment chips). No emoji, no em-dash, inline CSS. Unit-tested in `report_test.go`.
- `scripts/capability-e2e.sh`: standalone gate. Runs the suite, emits the manifest, regenerates the dashboard, exits non-zero on any Tier F failure. Refuses to run with `TMUX` set and `AGENT_DECK_TEST_ISOLATED` unset (second belt to the harness's isolation).
- `docs/testing/capability-gaps.md`: honest Tier N gaps (real-agent round trips, context-inheriting fork, MCP-loads-in-agent, remote over SSH) shown greyed on the dashboard rather than faked green.

## Surfaces (per agent-deck-tdd-feature skill)
This is test infrastructure, not a user-facing feature. It touches the **CLI** surface (drives `add`/`launch`/`session start|stop|restart|remove|fork|send|output` end to end). TUI/Web/Remote/Persistence/Cross-platform: not applicable, this PR adds tests + tooling and changes no product code.

## Verification
- `go test -tags capability_e2e -race -count=1 ./tests/capability/...` — green in ~32s (ceiling 3m).
- `go test ./...` (default tags) — capability tests excluded; full suite green via pre-push hook.
- `bash scripts/capability-e2e.sh` — emits manifest + regenerates dashboard; 11 capabilities, 8 green, 3 nightly.
- `golangci-lint run --build-tags capability_e2e ./tools/capability-report/... ./tests/capability/...` — 0 issues.

## Discipline
- Isolated tmux socket on every test via the harness; gate refuses unsafe runs.
- `release.yml` gating deferred to Wave 3 as designed; the gate script is a one-line add then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a capability E2E dashboard displaying test status, results summary, and capability cards grouped by category (session lifecycle, agent interaction, MCP).

* **Tests**
  * Introduced comprehensive E2E test suite covering session lifecycle operations, agent interactions, and roundtrip testing to verify capability functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->