### PR TITLE
test(capability): Wave 1.5 — embed terminal pane snapshots in the dashboard (visual proof)

### DIFF
--- a/docs/status/capability-dashboard.html
+++ b/docs/status/capability-dashboard.html
@@ -49,6 +49,13 @@
   .meta { font-size: 12px; color: var(--muted); margin-top: 8px; }
   .chips { margin-top: 8px; }
   .chip { display: inline-block; font-size: 11px; background: var(--bg); border: 1px solid var(--line); border-radius: 999px; padding: 2px 9px; margin: 2px 4px 2px 0; color: var(--muted); }
+  .term { margin-top: 12px; }
+  .term .term-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); margin-bottom: 5px; }
+  .terminal {
+    margin: 0; background: #0d1117; color: #e6edf3; border: 1px solid #30363d; border-radius: 8px;
+    padding: 12px 14px; font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 12px; line-height: 1.45; white-space: pre; overflow-x: auto; tab-size: 4;
+  }
   footer { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--line); font-size: 12.5px; color: var(--muted); }
 </style>
 </head>
@@ -56,7 +63,7 @@
 <div class="wrap">
 <header class="page">
   <h1>agent-deck Capability E2E Dashboard</h1>
-  <div class="date">Generated 2026-05-26T12:03:17Z</div>
+  <div class="date">Generated 2026-05-26T12:20:13Z</div>
   <p class="pitch">One card per capability agent-deck promises a user can do. Each fast-gate capability is verified by a test that performs the real action through the compiled binary on an isolated tmux socket and asserts on the real effect: registry rows or live pane content. Nightly capabilities need real agents, keys, or network and run out of band.</p>
 </header>
 
@@ -77,8 +84,15 @@
     <h3>Register a session</h3>
     <p class="how">We run the add command to register a new session, then read the saved registry back. We confirm the row exists with the title, tool, group, and folder we asked for.</p>
     <p class="assert">Pass when: new registry row carries the given title, tool, group, and working directory</p>
-    <div class="meta">Tier F . Runtime: 2.1s . TestCapability_Lifecycle_Add</div>
+    <div class="meta">Tier F . Runtime: 2.9s . TestCapability_Lifecycle_Add</div>
     <div class="chips"><span class="chip">Local-isolated</span></div>
+    <div class="term"><div class="term-label">What the terminal showed at verification</div><pre class="terminal">Profile: default
+
+TITLE                GROUP           PATH                                     ID
+--------------------------------------------------------------------------------------------
+cap-add              capgrp          /tmp/TestCapability_Lifecycle_Add3720... 5cefc6c6-177
+
+Total: 1 sessions</pre></div>
   </div>
   
   <div class="card green">
@@ -86,8 +100,16 @@
     <h3>Start a session</h3>
     <p class="how">We register a session and start it. We then ask the throwaway tmux server whether a live pane actually appeared, and confirm the registry flips the session to an active state.</p>
     <p class="assert">Pass when: a real tmux pane appears on the isolated socket and status becomes active</p>
-    <div class="meta">Tier F . Runtime: 1.4s . TestCapability_Lifecycle_Start</div>
+    <div class="meta">Tier F . Runtime: 1.7s . TestCapability_Lifecycle_Start</div>
     <div class="chips"><span class="chip">Local-isolated</span></div>
+    <div class="term"><div class="term-label">What the terminal showed at verification</div><pre class="terminal">To run a command as administrator (user &#34;root&#34;), use &#34;sudo &lt;command&gt;&#34;.
+See &#34;man sudo_root&#34; for details.
+
+ashesh-goplani@ashesh-goplani-CELSIUS-M7010power:~/project$ bash -c &#39;bash&#39;
+To run a command as administrator (user &#34;root&#34;), use &#34;sudo &lt;command&gt;&#34;.
+See &#34;man sudo_root&#34; for details.
+
+ashesh-goplani@ashesh-goplani-CELSIUS-M7010power:~/project$</pre></div>
   </div>
   
   <div class="card green">
@@ -95,8 +117,15 @@
     <h3>Stop a session</h3>
     <p class="how">We start a session, then stop it. We confirm the tmux pane is gone and the registry returns the session to the stopped state.</p>
     <p class="assert">Pass when: tmux pane disappears and registry status returns to stopped</p>
-    <div class="meta">Tier F . Runtime: 1.5s . TestCapability_Lifecycle_Stop</div>
+    <div class="meta">Tier F . Runtime: 1.7s . TestCapability_Lifecycle_Stop</div>
     <div class="chips"><span class="chip">Local-isolated</span></div>
+    <div class="term"><div class="term-label">What the terminal showed at verification</div><pre class="terminal">Profile: default
+
+TITLE                GROUP           PATH                                     ID
+--------------------------------------------------------------------------------------------
+cap-stop             001             /tmp/TestCapability_Lifecycle_Stop249... 2d988fcd-177
+
+Total: 1 sessions</pre></div>
   </div>
   
   <div class="card green">
@@ -104,8 +133,16 @@
     <h3>Restart a session</h3>
     <p class="how">We start a session and restart it. We confirm exactly one pane exists afterward (no accidental duplicate) and the session is active again.</p>
     <p class="assert">Pass when: exactly one pane remains after restart and status is active (guards the #30 double-spawn)</p>
-    <div class="meta">Tier F . Runtime: 2.6s . TestCapability_Lifecycle_Restart</div>
+    <div class="meta">Tier F . Runtime: 2.5s . TestCapability_Lifecycle_Restart</div>
     <div class="chips"><span class="chip">Local-isolated</span></div>
+    <div class="term"><div class="term-label">What the terminal showed at verification</div><pre class="terminal">To run a command as administrator (user &#34;root&#34;), use &#34;sudo &lt;command&gt;&#34;.
+See &#34;man sudo_root&#34; for details.
+
+ashesh-goplani@ashesh-goplani-CELSIUS-M7010power:~/project$ bash -c &#39;bash&#39;
+To run a command as administrator (user &#34;root&#34;), use &#34;sudo &lt;command&gt;&#34;.
+See &#34;man sudo_root&#34; for details.
+
+ashesh-goplani@ashesh-goplani-CELSIUS-M7010power:~/project$</pre></div>
   </div>
   
   <div class="card green">
@@ -115,6 +152,17 @@
     <p class="assert">Pass when: stopped session leaves the registry; a running session is refused without force</p>
     <div class="meta">Tier F . Runtime: 11.1s . TestCapability_Lifecycle_Rm</div>
     <div class="chips"><span class="chip">Local-isolated</span></div>
+    <div class="term"><div class="term-label">What the terminal showed at verification</div><pre class="terminal">$ agent-deck session remove cap-rm-running
+Error: session &#39;cap-rm-running&#39; is in state &#39;starting&#39;; only stopped/error sessions may be removed without --force
+
+$ agent-deck list   (after stopping and removing cap-rm-stopped)
+Profile: default
+
+TITLE                GROUP           PATH                                     ID
+--------------------------------------------------------------------------------------------
+cap-rm-running       001             /tmp/TestCapability_Lifecycle_Rm30872... 9956720c-177
+
+Total: 1 sessions</pre></div>
   </div>
   
   <div class="card green">
@@ -122,8 +170,12 @@
     <h3>Launch in one step</h3>
     <p class="how">We use the single launch command, which creates, starts, and messages a session at once, pointed at the stand-in echo agent. We confirm the registry row exists and the echoed message shows up on screen.</p>
     <p class="assert">Pass when: one launch command creates the row, starts the pane, and the echoed message appears</p>
-    <div class="meta">Tier F . Runtime: 7.1s . TestCapability_Lifecycle_Launch</div>
+    <div class="meta">Tier F . Runtime: 7.2s . TestCapability_Lifecycle_Launch</div>
     <div class="chips"><span class="chip">Local-isolated</span><span class="chip">Deterministic-stub</span></div>
+    <div class="term"><div class="term-label">What the terminal showed at verification</div><pre class="terminal">ECHOBOT READY &gt; PINGLAUNCH-cap-e2e-token
+⠏ working
+ECHO:PINGLAUNCH-cap-e2e-token
+ECHOBOT READY &gt;</pre></div>
   </div>
   
   <div class="card green">
@@ -133,6 +185,8 @@
     <p class="assert">Pass when: forking a non-Claude session is refused and no child row is created</p>
     <div class="meta">Tier F . Runtime: 0.1s . TestCapability_Lifecycle_Fork</div>
     <div class="chips"><span class="chip">Local-isolated</span></div>
+    <div class="term"><div class="term-label">What the terminal showed at verification</div><pre class="terminal">$ agent-deck session fork cap-fork
+Error: session &#39;cap-fork&#39; is not a Claude session (tool: shell)</pre></div>
   </div>
   
 </div>
@@ -145,8 +199,25 @@
     <h3>Send a message to an agent and read its reply</h3>
     <p class="how">We launch a tiny stand-in agent that simply repeats whatever you say. We send it a unique message through the normal send command, then read the screen back. If the screen shows the echoed message we know it reached the agent and a reply came out the other side.</p>
     <p class="assert">Pass when: the pane shows ECHO:&lt;token&gt; after a real send, proving readiness, send-keys, and capture read-back</p>
-    <div class="meta">Tier F . Runtime: 6.4s . TestCapability_Agent_EchoRoundTrip</div>
+    <div class="meta">Tier F . Runtime: 5.7s . TestCapability_Agent_EchoRoundTrip</div>
     <div class="chips"><span class="chip">Local-isolated</span><span class="chip">Deterministic-stub</span></div>
+    <div class="term"><div class="term-label">What the terminal showed at verification</div><pre class="terminal">ECHOBOT READY &gt; PING-TestCapability_Agent_EchoRoundTrip
+⠼ working
+⠏ working
+⠼ working
+⠏ working
+⠼ working
+⠸ working
+⠏ working
+ECHO:PING-TestCapability_Agent_EchoRoundTrip
+⠸ workingEADY &gt;
+⠹ working
+⠙ working
+⠋ working
+⠏ working
+ECHO:
+⠋ workingEADY &gt;
+⠏ working</pre></div>
   </div>
   
   <div class="card grey">
@@ -156,6 +227,7 @@
     <p class="assert">Pass when: a real Claude reply contains the expected token</p>
     <div class="meta">Tier N . Runtime: not measured</div>
     <div class="chips"><span class="chip">Real-agent</span><span class="chip">Needs-creds</span><span class="chip">Needs-network</span></div>
+    
   </div>
   
   <div class="card grey">
@@ -165,6 +237,7 @@
     <p class="assert">Pass when: child session links the parent and inherits conversation context</p>
     <div class="meta">Tier N . Runtime: not measured</div>
     <div class="chips"><span class="chip">Real-agent</span><span class="chip">Needs-creds</span><span class="chip">Needs-network</span></div>
+    
   </div>
   
 </div>
@@ -179,6 +252,7 @@
     <p class="assert">Pass when: the agent lists the attached MCP server</p>
     <div class="meta">Tier N . Runtime: not measured</div>
     <div class="chips"><span class="chip">Real-agent</span><span class="chip">Needs-creds</span><span class="chip">Needs-network</span></div>
+    
   </div>
   
 </div>

--- a/docs/status/capability-e2e-manifest.json
+++ b/docs/status/capability-e2e-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-26T12:03:17Z",
+  "generated_at": "2026-05-26T12:20:13Z",
   "summary": {
     "total": 11,
     "green": 8,
@@ -20,7 +20,8 @@
       ],
       "test_name": "TestCapability_Lifecycle_Add",
       "status": "pass",
-      "runtime_seconds": 2.06
+      "runtime_seconds": 2.89,
+      "snapshot": "Profile: default\n\nTITLE                GROUP           PATH                                     ID\n--------------------------------------------------------------------------------------------\ncap-add              capgrp          /tmp/TestCapability_Lifecycle_Add3720... 5cefc6c6-177\n\nTotal: 1 sessions"
     },
     {
       "id": "start",
@@ -34,7 +35,8 @@
       ],
       "test_name": "TestCapability_Lifecycle_Start",
       "status": "pass",
-      "runtime_seconds": 1.43
+      "runtime_seconds": 1.68,
+      "snapshot": "To run a command as administrator (user \"root\"), use \"sudo \u003ccommand\u003e\".\nSee \"man sudo_root\" for details.\n\nashesh-goplani@ashesh-goplani-CELSIUS-M7010power:~/project$ bash -c 'bash'\nTo run a command as administrator (user \"root\"), use \"sudo \u003ccommand\u003e\".\nSee \"man sudo_root\" for details.\n\nashesh-goplani@ashesh-goplani-CELSIUS-M7010power:~/project$"
     },
     {
       "id": "stop",
@@ -48,7 +50,8 @@
       ],
       "test_name": "TestCapability_Lifecycle_Stop",
       "status": "pass",
-      "runtime_seconds": 1.5
+      "runtime_seconds": 1.7,
+      "snapshot": "Profile: default\n\nTITLE                GROUP           PATH                                     ID\n--------------------------------------------------------------------------------------------\ncap-stop             001             /tmp/TestCapability_Lifecycle_Stop249... 2d988fcd-177\n\nTotal: 1 sessions"
     },
     {
       "id": "restart",
@@ -62,7 +65,8 @@
       ],
       "test_name": "TestCapability_Lifecycle_Restart",
       "status": "pass",
-      "runtime_seconds": 2.6
+      "runtime_seconds": 2.52,
+      "snapshot": "To run a command as administrator (user \"root\"), use \"sudo \u003ccommand\u003e\".\nSee \"man sudo_root\" for details.\n\nashesh-goplani@ashesh-goplani-CELSIUS-M7010power:~/project$ bash -c 'bash'\nTo run a command as administrator (user \"root\"), use \"sudo \u003ccommand\u003e\".\nSee \"man sudo_root\" for details.\n\nashesh-goplani@ashesh-goplani-CELSIUS-M7010power:~/project$"
     },
     {
       "id": "rm",
@@ -76,7 +80,8 @@
       ],
       "test_name": "TestCapability_Lifecycle_Rm",
       "status": "pass",
-      "runtime_seconds": 11.09
+      "runtime_seconds": 11.11,
+      "snapshot": "$ agent-deck session remove cap-rm-running\nError: session 'cap-rm-running' is in state 'starting'; only stopped/error sessions may be removed without --force\n\n$ agent-deck list   (after stopping and removing cap-rm-stopped)\nProfile: default\n\nTITLE                GROUP           PATH                                     ID\n--------------------------------------------------------------------------------------------\ncap-rm-running       001             /tmp/TestCapability_Lifecycle_Rm30872... 9956720c-177\n\nTotal: 1 sessions"
     },
     {
       "id": "launch",
@@ -91,7 +96,8 @@
       ],
       "test_name": "TestCapability_Lifecycle_Launch",
       "status": "pass",
-      "runtime_seconds": 7.1
+      "runtime_seconds": 7.18,
+      "snapshot": "ECHOBOT READY \u003e PINGLAUNCH-cap-e2e-token\n⠏ working\nECHO:PINGLAUNCH-cap-e2e-token\nECHOBOT READY \u003e"
     },
     {
       "id": "fork",
@@ -105,7 +111,8 @@
       ],
       "test_name": "TestCapability_Lifecycle_Fork",
       "status": "pass",
-      "runtime_seconds": 0.15
+      "runtime_seconds": 0.13,
+      "snapshot": "$ agent-deck session fork cap-fork\nError: session 'cap-fork' is not a Claude session (tool: shell)"
     },
     {
       "id": "send-output-echo",
@@ -120,7 +127,8 @@
       ],
       "test_name": "TestCapability_Agent_EchoRoundTrip",
       "status": "pass",
-      "runtime_seconds": 6.4
+      "runtime_seconds": 5.66,
+      "snapshot": "ECHOBOT READY \u003e PING-TestCapability_Agent_EchoRoundTrip\n⠼ working\n⠏ working\n⠼ working\n⠏ working\n⠼ working\n⠸ working\n⠏ working\nECHO:PING-TestCapability_Agent_EchoRoundTrip\n⠸ workingEADY \u003e\n⠹ working\n⠙ working\n⠋ working\n⠏ working\nECHO:\n⠋ workingEADY \u003e\n⠏ working"
     },
     {
       "id": "send-output-claude",

--- a/scripts/capability-e2e.sh
+++ b/scripts/capability-e2e.sh
@@ -37,6 +37,13 @@ fi
 
 MANIFEST="docs/status/capability-e2e-manifest.json"
 DASHBOARD="docs/status/capability-dashboard.html"
+# Per-capability terminal pane snapshots: each test writes "<id>.txt" here at
+# its verification point, and capability-report reads them back to embed the
+# real terminal content in the dashboard. Wiping it first means a removed test
+# can never leave a stale snapshot on a card.
+SNAPSHOT_DIR="tests/capability/testdata/snapshots"
+export CAPABILITY_SNAPSHOT_DIR="$PWD/$SNAPSHOT_DIR"
+rm -f "$SNAPSHOT_DIR"/*.txt 2>/dev/null || true
 RESULTS="$(mktemp -t cap-e2e-results.XXXXXX.json)"
 trap 'rm -f "$RESULTS"' EXIT
 
@@ -45,13 +52,14 @@ echo "capability-e2e: running suite (tags: $TAGS)"
 TEST_STATUS=0
 go test -tags "$TAGS" -race -count=1 -timeout 8m -json ./tests/capability/... >"$RESULTS" || TEST_STATUS=$?
 
-echo "capability-e2e: rendering manifest + dashboard"
+echo "capability-e2e: rendering manifest + dashboard (snapshots from $SNAPSHOT_DIR)"
 # capability-report exits non-zero if a Tier F capability failed.
 REPORT_STATUS=0
 go run ./tools/capability-report \
   --json-input "$RESULTS" \
   --manifest "$MANIFEST" \
-  --dashboard "$DASHBOARD" || REPORT_STATUS=$?
+  --dashboard "$DASHBOARD" \
+  --snapshot-dir "$SNAPSHOT_DIR" || REPORT_STATUS=$?
 
 if [[ "$TEST_STATUS" -ne 0 ]]; then
   echo "capability-e2e: test runner exited $TEST_STATUS" >&2

--- a/tests/capability/capability_test.go
+++ b/tests/capability/capability_test.go
@@ -180,3 +180,45 @@ func (c *capSandbox) waitForNoTmuxSession(t *testing.T, timeout time.Duration) b
 func (c *capSandbox) stopQuietly(ref string) {
 	_, _ = c.try("session", "stop", ref)
 }
+
+// snapshotDir is where capability tests write their per-capability terminal
+// snapshots. tools/capability-report reads "<id>.txt" from here when it
+// regenerates the dashboard. It is overridable via CAPABILITY_SNAPSHOT_DIR so
+// the gate script can point it at a collected location; the default is the
+// committed testdata path (relative to this package's working directory), so a
+// bare `go test -tags capability_e2e ./tests/capability/...` also produces the
+// snapshots the Verify step expects.
+func snapshotDir() string {
+	if d := os.Getenv("CAPABILITY_SNAPSHOT_DIR"); d != "" {
+		return d
+	}
+	return filepath.Join("testdata", "snapshots")
+}
+
+// snapshot records the real terminal/CLI content visible at a test's
+// verification point, keyed by capability id. It is DISPLAY proof only: the
+// pass/fail assertion lives on registry/pane state, never on this text. Writes
+// are best-effort so a snapshot failure never masks the real assertion result.
+func snapshot(t *testing.T, id, content string) {
+	t.Helper()
+	dir := snapshotDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Logf("snapshot %s: mkdir %s: %v (display-only, ignoring)", id, dir, err)
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dir, id+".txt"), []byte(content), 0o644); err != nil {
+		t.Logf("snapshot %s: write: %v (display-only, ignoring)", id, err)
+	}
+}
+
+// snapshotPane captures the live tmux pane for ref via the same `session
+// output --pane` read path a human uses, for use as a display snapshot.
+func (c *capSandbox) snapshotPane(t *testing.T, id, ref string) {
+	t.Helper()
+	out, err := c.try("session", "output", ref, "--pane")
+	if err != nil {
+		t.Logf("snapshot %s: pane read failed: %v (display-only, ignoring)", id, err)
+		return
+	}
+	snapshot(t, id, out)
+}

--- a/tests/capability/lifecycle_test.go
+++ b/tests/capability/lifecycle_test.go
@@ -49,6 +49,10 @@ func TestCapability_Lifecycle_Add(t *testing.T) {
 	if row.Group != "capgrp" {
 		t.Errorf("group = %q, want capgrp", row.Group)
 	}
+
+	// Display proof: the registry as a human sees it, showing the row that the
+	// assertions above checked field by field.
+	snapshot(t, "add", c.run(t, "list"))
 }
 
 // TestCapability_Lifecycle_Start proves `session start` spawns a real tmux pane
@@ -66,6 +70,9 @@ func TestCapability_Lifecycle_Start(t *testing.T) {
 	if got, ok := c.waitForStatus(t, "cap-start", 8*time.Second, "running", "starting", "idle", "waiting"); !ok {
 		t.Fatalf("status did not reach an active state after start; last = %q", got)
 	}
+
+	// Display proof: the live pane that just came up on the isolated socket.
+	c.snapshotPane(t, "start", "cap-start")
 }
 
 // TestCapability_Lifecycle_Stop proves `session stop` tears down the tmux pane
@@ -86,6 +93,10 @@ func TestCapability_Lifecycle_Stop(t *testing.T) {
 	if got, ok := c.waitForStatus(t, "cap-stop", 5*time.Second, "stopped"); !ok {
 		t.Fatalf("status did not return to stopped; last = %q", got)
 	}
+
+	// Display proof: pane is gone, so we show the registry returning the
+	// session to stopped (the visible effect a human checks after stop).
+	snapshot(t, "stop", c.run(t, "list"))
 }
 
 // TestCapability_Lifecycle_Restart proves `session restart` respawns the pane
@@ -113,6 +124,9 @@ func TestCapability_Lifecycle_Restart(t *testing.T) {
 	if got, ok := c.waitForStatus(t, "cap-restart", 8*time.Second, "running", "starting", "idle", "waiting"); !ok {
 		t.Fatalf("status not active after restart; last = %q", got)
 	}
+
+	// Display proof: the single respawned pane on the isolated socket.
+	c.snapshotPane(t, "restart", "cap-restart")
 }
 
 // TestCapability_Lifecycle_Rm proves `rm` drops a stopped session from the
@@ -128,8 +142,9 @@ func TestCapability_Lifecycle_Rm(t *testing.T) {
 	if name := c.waitForTmuxSession(t, 8*time.Second); name == "" {
 		t.Fatalf("session never started, cannot test rm guard")
 	}
-	if out, err := c.try("session", "remove", "cap-rm-running"); err == nil {
-		t.Fatalf("session remove of a running session should be refused without --force, got success:\n%s", out)
+	refusal, err := c.try("session", "remove", "cap-rm-running")
+	if err == nil {
+		t.Fatalf("session remove of a running session should be refused without --force, got success:\n%s", refusal)
 	}
 	if _, ok := c.findByTitle(t, "cap-rm-running"); !ok {
 		t.Fatalf("refused rm must leave the session in the registry, but it is gone")
@@ -147,6 +162,13 @@ func TestCapability_Lifecycle_Rm(t *testing.T) {
 	if _, ok := c.findByTitle(t, "cap-rm-stopped"); ok {
 		t.Fatalf("after session remove, the row should be absent from the registry")
 	}
+
+	// Display proof: the destructive-action guard refusing a running session,
+	// then the registry after the stopped session was removed.
+	snapshot(t, "rm", "$ agent-deck session remove cap-rm-running\n"+
+		strings.TrimRight(refusal, "\n")+
+		"\n\n$ agent-deck list   (after stopping and removing cap-rm-stopped)\n"+
+		c.run(t, "list"))
 }
 
 // TestCapability_Lifecycle_Fork proves the fork precondition guard: forking a
@@ -170,4 +192,8 @@ func TestCapability_Lifecycle_Fork(t *testing.T) {
 	if _, ok := c.findByTitle(t, "cap-fork-fork"); ok {
 		t.Fatalf("a refused fork must not create a child registry row")
 	}
+
+	// Display proof: the precondition guard refusing to fork a non-Claude
+	// session.
+	snapshot(t, "fork", "$ agent-deck session fork cap-fork\n"+strings.TrimRight(out, "\n"))
 }

--- a/tests/capability/roundtrip_test.go
+++ b/tests/capability/roundtrip_test.go
@@ -101,9 +101,15 @@ func TestCapability_Agent_EchoRoundTrip(t *testing.T) {
 	c.run(t, "session", "send", "cap-echo", token, "--no-wait")
 
 	want := "ECHO:" + token
-	if pane, ok := c.waitForPaneContains(t, "cap-echo", want, 20*time.Second); !ok {
+	pane, ok := c.waitForPaneContains(t, "cap-echo", want, 20*time.Second)
+	if !ok {
 		t.Fatalf("pane never showed %q within timeout.\nThe send -> readiness -> capture round trip is broken.\nlast pane:\n%s", want, pane)
 	}
+
+	// Display proof, the backbone snapshot: the same pane shows the token we
+	// sent AND the agent's echoed reply, so a reader can literally see the
+	// conversation that the assertion above confirmed.
+	snapshot(t, "send-output-echo", pane)
 }
 
 // TestCapability_Lifecycle_Launch proves the atomic add+start+send path: a
@@ -127,7 +133,11 @@ func TestCapability_Lifecycle_Launch(t *testing.T) {
 	}
 
 	want := "ECHO:" + token
-	if pane, ok := c.waitForPaneContains(t, "cap-launch", want, 20*time.Second); !ok {
+	pane, ok := c.waitForPaneContains(t, "cap-launch", want, 20*time.Second)
+	if !ok {
 		t.Fatalf("launch -m did not result in %q in the pane.\nlast pane:\n%s", want, pane)
 	}
+
+	// Display proof: the one-step launch pane with the echoed message visible.
+	snapshot(t, "launch", pane)
 }

--- a/tests/capability/testdata/snapshots/.gitignore
+++ b/tests/capability/testdata/snapshots/.gitignore
@@ -1,0 +1,6 @@
+# Per-capability terminal pane snapshots are runtime artifacts: each capability
+# test writes "<id>.txt" here at its verification point, and capability-report
+# reads them back into the manifest + dashboard (both of which ARE committed).
+# The raw captures are non-deterministic (spinner frames, hostnames, ids), so we
+# keep the directory but ignore the generated files.
+*.txt

--- a/tools/capability-report/main.go
+++ b/tools/capability-report/main.go
@@ -14,6 +14,7 @@ func main() {
 	jsonInput := flag.String("json-input", "-", "path to `go test -json` output, or - for stdin")
 	manifestPath := flag.String("manifest", "docs/status/capability-e2e-manifest.json", "where to write the JSON manifest")
 	dashboardPath := flag.String("dashboard", "docs/status/capability-dashboard.html", "where to write the HTML dashboard")
+	snapshotDir := flag.String("snapshot-dir", "tests/capability/testdata/snapshots", "directory of per-capability terminal pane snapshots (<id>.txt)")
 	flag.Parse()
 
 	raw, err := readInput(*jsonInput)
@@ -24,6 +25,7 @@ func main() {
 
 	results := ParseTestResults(raw)
 	manifest := BuildManifest(results, time.Now())
+	manifest.AttachSnapshots(*snapshotDir)
 
 	if err := writeManifest(*manifestPath, manifest); err != nil {
 		fmt.Fprintf(os.Stderr, "capability-report: write manifest: %v\n", err)

--- a/tools/capability-report/report.go
+++ b/tools/capability-report/report.go
@@ -12,6 +12,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -47,6 +50,10 @@ type Capability struct {
 	TestName   string   `json:"test_name,omitempty"`
 	Status     string   `json:"status"`
 	RuntimeSeconds float64 `json:"runtime_seconds"`
+	// Snapshot is the real terminal pane (or CLI/registry output) captured at
+	// the test's verification point. It is display-only proof, not asserted on;
+	// empty when no snapshot was captured for this capability.
+	Snapshot string `json:"snapshot,omitempty"`
 }
 
 // Summary is the headline strip on the dashboard.
@@ -248,6 +255,47 @@ func (m Manifest) HasFastFailure() bool {
 	return false
 }
 
+// AttachSnapshots fills each capability's Snapshot from a per-capability
+// artifact file named "<id>.txt" inside dir, as written by the capability
+// tests at their verification point. A missing dir or missing file is not an
+// error: snapshots are optional display data, and a re-run without the tests
+// (or a Tier N capability that never ran) simply leaves Snapshot empty. Files
+// with no matching capability id are ignored.
+func (m *Manifest) AttachSnapshots(dir string) {
+	for i := range m.Capabilities {
+		c := &m.Capabilities[i]
+		raw, err := os.ReadFile(filepath.Join(dir, c.ID+".txt"))
+		if err != nil {
+			continue
+		}
+		if s := cleanSnapshot(string(raw)); s != "" {
+			c.Snapshot = s
+		}
+	}
+}
+
+// cleanSnapshot normalizes a captured pane for display: it strips carriage
+// returns, trims trailing whitespace on each line, and drops leading and
+// trailing blank lines. It keeps interior blank lines and all meaningful
+// content. The result is the text shown verbatim (HTML-escaped) in the
+// dashboard's terminal block.
+func cleanSnapshot(raw string) string {
+	raw = strings.ReplaceAll(raw, "\r\n", "\n")
+	raw = strings.ReplaceAll(raw, "\r", "")
+	lines := strings.Split(raw, "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight(ln, " \t")
+	}
+	start, end := 0, len(lines)
+	for start < end && lines[start] == "" {
+		start++
+	}
+	for end > start && lines[end-1] == "" {
+		end--
+	}
+	return strings.Join(lines[start:end], "\n")
+}
+
 // groupedView is the per-group slice handed to the template.
 type groupedView struct {
 	Name string
@@ -385,6 +433,13 @@ const dashboardHTML = `<!DOCTYPE html>
   .meta { font-size: 12px; color: var(--muted); margin-top: 8px; }
   .chips { margin-top: 8px; }
   .chip { display: inline-block; font-size: 11px; background: var(--bg); border: 1px solid var(--line); border-radius: 999px; padding: 2px 9px; margin: 2px 4px 2px 0; color: var(--muted); }
+  .term { margin-top: 12px; }
+  .term .term-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); margin-bottom: 5px; }
+  .terminal {
+    margin: 0; background: #0d1117; color: #e6edf3; border: 1px solid #30363d; border-radius: 8px;
+    padding: 12px 14px; font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 12px; line-height: 1.45; white-space: pre; overflow-x: auto; tab-size: 4;
+  }
   footer { margin-top: 40px; padding-top: 16px; border-top: 1px solid var(--line); font-size: 12.5px; color: var(--muted); }
 </style>
 </head>
@@ -415,6 +470,7 @@ const dashboardHTML = `<!DOCTYPE html>
     <p class="assert">Pass when: {{.Assertion}}</p>
     <div class="meta">Tier {{.Tier}} . Runtime: {{runtimeLabel .}}{{if .TestName}} . {{.TestName}}{{end}}</div>
     <div class="chips">{{range .Chips}}<span class="chip">{{.}}</span>{{end}}</div>
+    {{if .Snapshot}}<div class="term"><div class="term-label">What the terminal showed at verification</div><pre class="terminal">{{.Snapshot}}</pre></div>{{end}}
   </div>
   {{end}}
 </div>

--- a/tools/capability-report/report_test.go
+++ b/tools/capability-report/report_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -130,6 +132,100 @@ func TestRenderDashboard_ContainsCapabilityContent(t *testing.T) {
 		if strings.Contains(html, emoji) {
 			t.Errorf("dashboard contains emoji %q; the style rules forbid emoji", emoji)
 		}
+	}
+}
+
+func TestAttachSnapshots_EmbedsContentByID(t *testing.T) {
+	dir := t.TempDir()
+	// One snapshot file named by capability id, plus a stale file with no
+	// matching capability (must be ignored, not error).
+	if err := os.WriteFile(filepath.Join(dir, "send-output-echo.txt"), []byte("$ send PING-42\nECHO:PING-42\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "no-such-capability.txt"), []byte("orphan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := BuildManifest(sampleResults(), fixedTime)
+	m.AttachSnapshots(dir)
+
+	var echo *Capability
+	for i := range m.Capabilities {
+		if m.Capabilities[i].ID == "send-output-echo" {
+			echo = &m.Capabilities[i]
+		}
+	}
+	if echo == nil {
+		t.Fatal("send-output-echo capability missing from registry")
+	}
+	if !strings.Contains(echo.Snapshot, "ECHO:PING-42") {
+		t.Errorf("snapshot not attached to send-output-echo: %q", echo.Snapshot)
+	}
+	if !strings.Contains(echo.Snapshot, "send PING-42") {
+		t.Errorf("snapshot should show the sent token: %q", echo.Snapshot)
+	}
+
+	// A capability without a snapshot file keeps an empty Snapshot.
+	for _, c := range m.Capabilities {
+		if c.ID == "fork-context" && c.Snapshot != "" {
+			t.Errorf("capability %q with no snapshot file should stay empty, got %q", c.ID, c.Snapshot)
+		}
+	}
+}
+
+func TestAttachSnapshots_MissingDirIsNoop(t *testing.T) {
+	m := BuildManifest(sampleResults(), fixedTime)
+	// Must not panic or error when the directory does not exist; snapshots are
+	// optional display data.
+	m.AttachSnapshots(filepath.Join(t.TempDir(), "does-not-exist"))
+	for _, c := range m.Capabilities {
+		if c.Snapshot != "" {
+			t.Errorf("capability %q should have no snapshot when dir is absent", c.ID)
+		}
+	}
+}
+
+func TestRenderDashboard_RendersTerminalBlockEscaped(t *testing.T) {
+	dir := t.TempDir()
+	// Deliberately include HTML-special characters and newlines so we can prove
+	// the terminal block escapes them and preserves line breaks.
+	raw := "$ session send cap-echo 'PING & <go>'\nECHO:PING & <go>\nECHOBOT READY"
+	if err := os.WriteFile(filepath.Join(dir, "send-output-echo.txt"), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := BuildManifest(sampleResults(), fixedTime)
+	m.AttachSnapshots(dir)
+
+	html, err := RenderDashboard(m)
+	if err != nil {
+		t.Fatalf("RenderDashboard: %v", err)
+	}
+
+	// The terminal block is present.
+	if !strings.Contains(html, "terminal") {
+		t.Error("dashboard should contain a terminal-styled snapshot block")
+	}
+	// HTML special characters are escaped, not injected raw.
+	if !strings.Contains(html, "ECHO:PING &amp; &lt;go&gt;") {
+		t.Errorf("snapshot must be HTML-escaped (&amp;/&lt;/&gt;); html did not contain the escaped echo line")
+	}
+	if strings.Contains(html, "ECHO:PING & <go>") {
+		t.Error("dashboard contains the raw unescaped snapshot; HTML escaping is broken")
+	}
+	// A reader-facing label introduces the block.
+	if !strings.Contains(html, "What the terminal showed") {
+		t.Error("dashboard should label the terminal block for readers")
+	}
+}
+
+func TestRenderDashboard_NoTerminalBlockWithoutSnapshot(t *testing.T) {
+	// No snapshots attached: cards must not render an empty terminal block.
+	html, err := RenderDashboard(BuildManifest(sampleResults(), fixedTime))
+	if err != nil {
+		t.Fatalf("RenderDashboard: %v", err)
+	}
+	if strings.Contains(html, "What the terminal showed") {
+		t.Error("with no snapshots attached, no terminal block should render")
 	}
 }
 


### PR DESCRIPTION
Builds on the merged Wave 1 (#1191).

Closes #1192

## What this does
The Wave 1 dashboard showed pass/fail, prose, and runtime per capability. It did not show what the terminal actually displayed. Wave 1.5 makes the dashboard show authentic visual proof: the real tmux pane (or CLI/registry output) captured at each test's verification point, rendered as a terminal block under each card.

The backbone is the echo round-trip card: its snapshot shows the token we **sent** and the agent's **echoed reply** in the same pane, so a reader can literally see it talking to the agent.

## How the snapshot rejoins the report
Wave 1 has a clean seam: tests emit pass/fail via `go test -json`, and `tools/capability-report` joins that with a static registry keyed by capability `id`. Snapshots are a second data stream that rejoins at the report tool via per-capability artifact files (`<id>.txt`), keyed by the same id. The `-json` parser is untouched.

## Discipline held
- Isolated tmux socket only (Wave 1 harness); never touches real sessions.
- Snapshots are DISPLAY-only. Pass/fail still asserts on registry/pane state, never byte-for-byte on captured text (panes carry spinner frames / ids and are non-deterministic).
- Suite stays build-tag-gated (`capability_e2e`), excluded from default `./...`.
- Raw `.txt` captures are gitignored; the committed manifest + dashboard carry the content.

## Surfaces and tests
This is a test-harness + report-tool change, not an agent-deck product-surface change. Mapping per the surface checklist:

| Surface | Applies? | Coverage |
|---|---|---|
| Report rendering logic (`tools/capability-report`) | yes | `report_test.go`: `TestAttachSnapshots_EmbedsContentByID` (happy + ignores orphan file), `TestAttachSnapshots_MissingDirIsNoop` (failure mode), `TestRenderDashboard_RendersTerminalBlockEscaped` (boundary: `<`,`>`,`&` escaped + newlines preserved), `TestRenderDashboard_NoTerminalBlockWithoutSnapshot` |
| Capability E2E capture (`tests/capability`) | yes | All 8 fast-gate tests capture at their assertion point; verified green by `go test -tags capability_e2e ./tests/capability/...` and the gate script |
| Gate script (`scripts/capability-e2e.sh`) | yes | Wipes stale snapshots, exports `CAPABILITY_SNAPSHOT_DIR`, passes `--snapshot-dir`; verified by a full `bash scripts/capability-e2e.sh` run |
| TUI / Web UI / CLI / Remote / Persistence / Cross-platform | no | These are agent-deck product surfaces. Wave 1.5 changes only the test harness and the offline report renderer; it adds no flag, route, schema field, or session behavior. |

## Verification (all green locally)
- `go test -tags capability_e2e -count=1 ./tests/capability/...` — pass, 8 snapshots produced.
- `bash scripts/capability-e2e.sh` — 11 capabilities, 8 green; manifest carries snapshots; dashboard renders 8 terminal blocks (echo block shows token + `ECHO:` reply).
- `go build ./...` (default) — unaffected.
- `golangci-lint run` on `tools/capability-report/...` and `--build-tags capability_e2e ./tests/capability/...` — 0 issues.
- Inspected the rendered HTML: terminal blocks are HTML-escaped (`&gt;`), newlines preserved (`white-space: pre`), no em-dash, no emoji.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capability tests now capture terminal output as execution evidence
  * Dashboard displays terminal snapshots showing captured session output for session lifecycle operations (register, start, stop, restart, remove), fork guard rejection, and agent message exchanges
  * Updated capability manifest to include terminal snapshots alongside test results for improved transparency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->