### PR TITLE
fix(test): clear user-config cache in plugin catalog helpers

### DIFF
--- a/cmd/agent-deck/plugin_cli_test.go
+++ b/cmd/agent-deck/plugin_cli_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 // withTempPluginCatalog redirects HOME to a tempdir and writes a
@@ -30,15 +32,12 @@ func withTempPluginCatalog(t *testing.T, content string) string {
 }
 
 // clearSessionUserConfigCache forces a fresh read of config.toml between
-// tests. The cache is keyed on file mtime which can collide on the same
-// nanosecond in tight test loops.
+// tests. Required because withTempPluginCatalog swaps HOME between calls
+// and mtime equality on a fresh tempdir would otherwise return a stale
+// cached UserConfig (carrying the previous test's [plugins.*] block).
 func clearSessionUserConfigCache(t *testing.T) {
 	t.Helper()
-	// Use the exported cache-clear from the session package indirectly
-	// via package-level reload — the catalog accessor reads through the
-	// package cache which we can invalidate by importing session.
-	// Tests already do this through GetAvailablePlugins triggering a
-	// stat-based reload; advance mtime by 1s to be safe.
+	session.ClearUserConfigCache()
 }
 
 func TestValidatePluginFlags_Empty(t *testing.T) {

--- a/internal/ui/edit_session_dialog_plugins_test.go
+++ b/internal/ui/edit_session_dialog_plugins_test.go
@@ -13,7 +13,10 @@ import (
 )
 
 // withPluginCatalog redirects HOME and writes a config.toml so
-// session.GetAvailablePluginNames returns predictable values.
+// session.GetAvailablePluginNames returns predictable values. Clears the
+// user-config cache because the tempdir's config.toml may share an mtime
+// with the previous test's, causing the cache to return stale plugin
+// definitions.
 func withPluginCatalog(t *testing.T, content string) {
 	t.Helper()
 	temp := t.TempDir()
@@ -28,6 +31,7 @@ func withPluginCatalog(t *testing.T, content string) {
 	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
+	session.ClearUserConfigCache()
 }
 
 // TestEditSessionDialog_PluginsFieldShownForClaudeWithCatalog asserts the


### PR DESCRIPTION
## Summary

Two plugin-catalog test helpers — `clearSessionUserConfigCache` in `cmd/agent-deck/plugin_cli_test.go` and `withPluginCatalog` in `internal/ui/edit_session_dialog_plugins_test.go` — swap `HOME` to a tempdir and write a fresh `config.toml`, but never invalidate `session.userConfigCache`. The cache keys on the file's mtime; two tempdirs created in the same nanosecond produce identical mtimes, so the cache returns the previous test's plugin definitions and the subsequent test sees a polluted catalog.

The `clearSessionUserConfigCache` helper exists for exactly this reason — its current body is just a comment describing what it should do, with no actual code. `session.ClearUserConfigCache()` (at `internal/session/userconfig.go:2041`) is the canonical test-isolation hook and is already used by `internal/session/new_instance_socket_test.go`, `transition_notifier_fdleak_test.go`, and others.

This PR wires both helpers to that function.

## Failures resolved

On `main` (commit `d534fe70`), `go test -race ./...` exhibits:

```
--- FAIL: TestValidatePluginFlags_TelegramForkAccepted (0.00s)
    plugin_cli_test.go:121: telegram fork (different source) must be accepted; got --plugin "tg-fork": not in catalog. Available: discord, octopus.
--- FAIL: TestValidatePluginFlags_EmptyCatalogActionableError (0.00s)
    plugin_cli_test.go:132: empty catalog must reject any plugin name
--- FAIL: TestEditSessionDialog_PluginsFieldHiddenWhenCatalogEmpty (0.00s)
    edit_session_dialog_plugins_test.go: FieldPlugins must be hidden when catalog is empty; got it visible
```

All three pass after this change.

## Test plan

- [x] `go test ./cmd/agent-deck/ -run TestValidatePluginFlags` — 7/7 pass
- [x] `go test -race ./internal/ui/ -run TestEditSessionDialog_Plugins` — 4/4 pass
- [x] `go test ./cmd/agent-deck/` full package — 556 pass, 0 fail
- [x] No new linter warnings (`go vet ./...`)

Other failures observed in `make test` on this machine (`internal/mcppool/TestPool_*`, `internal/tmux/TestSocketProxy_*`, `internal/session/TestStart_Service_SuccessPath`, etc.) reproduce on `main` without these changes and appear to be environment-dependent (cgroup/systemd-user-scope availability) — they are not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring proper cache clearing between test cases to prevent stale plugin catalog data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->