### PR TITLE
fix(ui): new-session "Type custom path/model" selection keeps focus so you can type (#1190)

### DIFF
--- a/internal/ui/issue1190_custom_input_test.go
+++ b/internal/ui/issue1190_custom_input_test.go
@@ -1,0 +1,213 @@
+package ui
+
+// Regression tests for #1190 — TUI new-session dialog: the free-text "custom
+// path" and "custom model ID" inputs did not accept typed input.
+//
+// Root cause (NOT #1162): #1023 (per-session model selection, extending #772's
+// path dropdown) made Enter on the synthetic "✎ Type custom …" entry call
+// moveFocus(1). Selecting the custom entry therefore JUMPED focus to the next
+// form field instead of landing the cursor in the now-focused text input, so
+// the field the user expected to type into was already blurred. Direct typing
+// worked, but the discoverable UI path (open dropdown → pick "Custom" → type)
+// was dead. #1162 fixed echo-visibility + Esc-scoping but never this focus jump.
+//
+// These tests drive through home.handleNewDialogKey (the real key-routing entry
+// point) — the #1162 tests only called NewDialog.Update directly and so never
+// caught the parent-routed dropdown→custom→type flow.
+//
+// Reported by @marekaf on v1.9.32 (macOS, iTerm2 + tmux 3.6a).
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func enter(h *Home)  { h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyEnter}) }
+func down(h *Home)   { h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyDown}) }
+func escKey(h *Home) { h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyEsc}) }
+
+func typeHome(h *Home, s string) {
+	for _, r := range s {
+		h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+}
+
+// --- Custom path: select "Type custom path…" then type -----------------------
+
+// Happy path: opening the path dropdown, selecting the synthetic "Type custom
+// path…" entry with Enter, must keep focus on the path field and accept typed
+// input (value updates + visible in the rendered view).
+func TestIssue1190_CustomPathSelectThenType(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 120, 40
+	h.newDialog.SetDefaultTool("")
+	h.newDialog.SetSize(120, 50)
+	h.newDialog.Show()
+	h.newDialog.focusIndex = h.newDialog.indexOf(focusPath)
+	h.newDialog.pathInput.SetValue("") // emulate an empty custom-path scenario
+	h.newDialog.updateFocus()
+
+	enter(h) // open the suggestions dropdown
+	if !h.newDialog.IsSuggestionsActive() {
+		t.Fatal("Enter on the path field should open the path suggestions dropdown")
+	}
+	if h.newDialog.pathSuggestionCursor != 0 {
+		t.Fatalf("dropdown should start on the synthetic custom entry (cursor 0), got %d", h.newDialog.pathSuggestionCursor)
+	}
+
+	enter(h) // select "✎ Type custom path…"
+	if got := h.newDialog.currentTarget(); got != focusPath {
+		t.Fatalf("after selecting Type custom path, focus = %v, want focusPath (focus must NOT jump away)", got)
+	}
+
+	const custom = "~/my/custom-path-zzz"
+	typeHome(h, custom)
+	if got := h.newDialog.pathInput.Value(); got != custom {
+		t.Fatalf("custom path value = %q, want %q", got, custom)
+	}
+	if view := h.newDialog.View(); !strings.Contains(view, custom) {
+		t.Fatalf("typed custom path %q not visible in rendered view:\n%s", custom, view)
+	}
+}
+
+// --- Custom model: select "Type custom model ID…" then type ------------------
+
+// Happy path: selecting the synthetic custom-model entry with Enter keeps focus
+// on the model field and accepts typed input (don't regress #1162 echo).
+func TestIssue1190_CustomModelSelectThenType(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 120, 40
+	h.newDialog.SetDefaultTool("codex")
+	h.newDialog.SetSize(120, 50)
+	h.newDialog.Show()
+	h.newDialog.focusIndex = h.newDialog.indexOf(focusModel)
+	if h.newDialog.focusIndex < 0 {
+		t.Fatal("codex should expose a focusable model field")
+	}
+	h.newDialog.modelInput.SetValue("")
+	h.newDialog.updateFocus()
+
+	enter(h) // open the model dropdown
+	if !h.newDialog.IsModelSuggestionsActive() {
+		t.Fatal("Enter on the model field should open the model suggestions dropdown")
+	}
+	if h.newDialog.modelSuggestionCursor != 0 {
+		t.Fatalf("model dropdown should start on the synthetic custom entry (cursor 0), got %d", h.newDialog.modelSuggestionCursor)
+	}
+
+	enter(h) // select "✎ Type custom model ID…"
+	if got := h.newDialog.currentTarget(); got != focusModel {
+		t.Fatalf("after selecting Type custom model ID, focus = %v, want focusModel (focus must NOT jump away)", got)
+	}
+
+	const custom = "qwen3-custom-zzz"
+	typeHome(h, custom)
+	if got := h.newDialog.GetLaunchModelID(); got != custom {
+		t.Fatalf("custom model value = %q, want %q", got, custom)
+	}
+	if view := h.newDialog.View(); !strings.Contains(view, custom) {
+		t.Fatalf("typed custom model %q not visible in rendered view:\n%s", custom, view)
+	}
+}
+
+// --- Regression guards: real-suggestion Enter STILL advances focus -----------
+
+// Selecting a real path suggestion (cursor > 0) with Enter must still apply it
+// and advance focus — the #1190 fix is scoped to the synthetic custom entry.
+func TestIssue1190_RealPathSuggestionEnterStillAdvances(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 120, 40
+	h.newDialog.SetDefaultTool("")
+	h.newDialog.SetSize(120, 50)
+	h.newDialog.Show()
+	h.newDialog.SetPathSuggestions([]string{"/tmp/project-a", "/tmp/project-b"})
+	h.newDialog.focusIndex = h.newDialog.indexOf(focusPath)
+	h.newDialog.pathInput.SetValue("")
+	h.newDialog.updateFocus()
+
+	enter(h) // open dropdown
+	down(h)  // move to first real suggestion (cursor 1)
+	if h.newDialog.pathSuggestionCursor != 1 {
+		t.Fatalf("down should move to first real suggestion (cursor 1), got %d", h.newDialog.pathSuggestionCursor)
+	}
+	enter(h) // accept real suggestion
+	if got := h.newDialog.pathInput.Value(); got != "/tmp/project-a" {
+		t.Fatalf("selected path = %q, want /tmp/project-a", got)
+	}
+	if got := h.newDialog.currentTarget(); got == focusPath {
+		t.Fatal("Enter on a REAL path suggestion should advance focus off the path field")
+	}
+}
+
+// Selecting a real model suggestion (cursor > 0) with Enter must still apply it
+// and advance focus (mirrors existing #1023 behavior; guards the #1190 fix).
+func TestIssue1190_RealModelSuggestionEnterStillAdvances(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 120, 40
+	h.newDialog.SetDefaultTool("codex")
+	h.newDialog.SetSize(120, 50)
+	h.newDialog.Show()
+	h.newDialog.focusIndex = h.newDialog.indexOf(focusModel)
+	h.newDialog.modelInput.SetValue("")
+	h.newDialog.updateFocus()
+
+	enter(h) // open dropdown
+	down(h)  // move to first real suggestion (cursor 1)
+	if h.newDialog.modelSuggestionCursor != 1 {
+		t.Fatalf("down should move to first real model suggestion (cursor 1), got %d", h.newDialog.modelSuggestionCursor)
+	}
+	enter(h) // accept real suggestion
+	if got := h.newDialog.GetLaunchModelID(); got == "" {
+		t.Fatal("Enter on a real model suggestion should apply it")
+	}
+	if got := h.newDialog.currentTarget(); got == focusModel {
+		t.Fatal("Enter on a REAL model suggestion should advance focus off the model field")
+	}
+}
+
+// --- #1162 regression guards (must keep passing) -----------------------------
+
+// Esc inside the model picker dismisses only the picker, keeping the flow alive.
+func TestIssue1190_EscInModelPickerDismissesOnlyPicker(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 120, 40
+	h.newDialog.SetDefaultTool("codex")
+	h.newDialog.SetSize(120, 50)
+	h.newDialog.Show()
+	h.newDialog.focusIndex = h.newDialog.indexOf(focusModel)
+	h.newDialog.updateFocus()
+
+	if !h.newDialog.IsModelPickerOpen() {
+		t.Fatal("precondition: model picker should be open on the model field")
+	}
+	escKey(h)
+	if !h.newDialog.IsVisible() {
+		t.Fatal("Esc in the picker must NOT cancel the new-session flow (#1162)")
+	}
+	if h.newDialog.currentTarget() != focusModel {
+		t.Fatalf("focus after Esc in picker = %v, want focusModel (#1162)", h.newDialog.currentTarget())
+	}
+	escKey(h)
+	if h.newDialog.IsVisible() {
+		t.Fatal("second Esc (picker dismissed) should cancel the flow (#1162)")
+	}
+}
+
+// Esc on the form (name field, no picker) still cancels the whole flow.
+func TestIssue1190_EscOnFormCancels(t *testing.T) {
+	h := NewHome()
+	h.width, h.height = 120, 40
+	h.newDialog.SetDefaultTool("codex")
+	h.newDialog.SetSize(120, 50)
+	h.newDialog.Show() // focus defaults to the name field
+
+	if h.newDialog.IsModelPickerOpen() {
+		t.Fatal("precondition: picker must be closed on the name field")
+	}
+	escKey(h)
+	if h.newDialog.IsVisible() {
+		t.Fatal("Esc on the form (not picker) must cancel the whole flow (#1162)")
+	}
+}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1482,9 +1482,14 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				return d, nil
 			case " ", "enter":
 				// Space: apply highlighted entry + close dropdown (stay in form).
+				// #1190: selecting the synthetic "✎ Type custom path…" entry
+				// (cursor 0) must land the user in the focused path input so they
+				// can type — it must NOT advance focus to the next field. Only
+				// Enter on a real suggestion (cursor > 0) applies + advances.
+				customSelected := d.pathSuggestionCursor == 0
 				d.ApplyHighlightedSuggestion()
 				d.DismissSuggestions()
-				if msg.String() == "enter" {
+				if msg.String() == "enter" && !customSelected {
 					d.moveFocus(1)
 				}
 				return d, nil
@@ -1519,9 +1524,13 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 				}
 				return d, nil
 			case " ", "enter":
+				// #1190: selecting the synthetic "✎ Type custom model ID…" entry
+				// (cursor 0) keeps focus on the model input so the user can type;
+				// only Enter on a real suggestion (cursor > 0) applies + advances.
+				customSelected := d.modelSuggestionCursor == 0
 				d.ApplyHighlightedModelSuggestion()
 				d.DismissModelSuggestions()
-				if msg.String() == "enter" {
+				if msg.String() == "enter" && !customSelected {
 					d.moveFocus(1)
 				}
 				return d, nil


### PR DESCRIPTION
Closes #1190. Reported by @marekaf (v1.9.32, macOS / iTerm2 + tmux 3.6a).

## Symptom
In the TUI new-session dialog, the free-text **custom path** and **custom model ID** inputs wouldn't accept typed input — you couldn't enter a custom path or model at all. Only the predefined options worked.

## Root cause — NOT #1162
The reporter (and our triage) suspected #1162. It isn't. `git blame` puts the regression in **#1023** (per-session model selection, 2026-05-17), which extended **#772**'s path dropdown:

Enter on the synthetic `✎ Type custom …` entry (cursor 0) called `moveFocus(1)`. So selecting the "Custom" option **jumped focus to the next form field** (path → command, model → worktree) instead of landing the cursor in the now-focused text input. The field the user expected to type into was already blurred, so it looked "unusable". Direct typing happened to work, but the discoverable UI flow — open dropdown → pick **Custom** → type — was dead.

**#1162** (v1.9.32) fixed the model picker's echo-visibility and scoped Esc to the picker, but never touched this focus jump — which is exactly why @marekaf still saw the custom-model input broken there, and the custom-**path** input had the identical bug.

## Why our tests missed it
The #1162 regression tests call `NewDialog.Update` **directly** and only type into the field directly — they never went through `home.handleNewDialogKey` (the real key router) nor the dropdown → "Custom" → type flow. The new tests do both.

## Fix
In both the path- and model-suggestion `Enter`/`Space` handlers, only advance focus on `Enter` when a **real** suggestion (cursor > 0) was selected. Selecting the synthetic `Type custom …` entry (cursor 0) keeps focus on the now-focused input so the user can type. `Space` behaviour is unchanged; #1162 echo + Esc-scoping are untouched.

```
- if msg.String() == "enter" {
+ if msg.String() == "enter" && !customSelected {
      d.moveFocus(1)
  }
```

## Surfaces (per agent-deck-tdd-feature)
- **TUI** (`internal/ui/`) — covered, this is the only surface. The new-session dialog and its model/path pickers are TUI-only; Web UI has no equivalent free-text path/model picker, CLI takes path/model as flags (no dropdown), and the change is pure keystroke routing with no persistence/remote/cross-platform code path. Covering test file: `internal/ui/issue1190_custom_input_test.go`.

## Tests (`internal/ui/issue1190_custom_input_test.go`)
Driven through the real `home.handleNewDialogKey` routing:
- **happy** — custom path: select `Type custom path…` → focus stays on path, typed value updates + visible in `View()`
- **happy** — custom model: select `Type custom model ID…` → focus stays on model, typed value updates + visible (no #1162 echo regression)
- **guard** — Enter on a REAL path/model suggestion still applies + advances focus (fix is scoped to cursor 0)
- **#1162 guard** — Esc in the model picker dismisses only the picker; second Esc cancels; Esc on the form cancels the whole flow

## Verification
- `go test ./internal/ui/...` green (incl. all `Issue1162` tests) with `-race`
- `golangci-lint run ./internal/ui/` → 0 issues; `go vet` clean

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard navigation for custom path and model input fields. Selecting "Type custom..." options now keeps focus on the input field, allowing typed characters to be properly registered.
  * Refined Escape key behavior in suggestion pickers for consistent form interaction.

* **Tests**
  * Added regression tests for custom input field keyboard handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->