### PR TITLE
fix(worktree): fall back to a normal session when default_enabled on non-repo dirs (#1185)

### DIFF
--- a/internal/ui/forkdialog.go
+++ b/internal/ui/forkdialog.go
@@ -28,6 +28,7 @@ type ForkDialog struct {
 
 	// Worktree support
 	worktreeEnabled bool
+	worktreeToggled bool // true once the user explicitly toggled the worktree checkbox (vs config default_enabled); see #1185.
 	branchInput     textinput.Model
 	branchPicker    *BranchPickerDialog
 	isGitRepo       bool
@@ -112,6 +113,7 @@ func (d *ForkDialog) Show(originalName, projectPath, groupPath string, conductor
 
 	// Reset worktree fields from global config defaults.
 	d.worktreeEnabled = false
+	d.worktreeToggled = false
 	d.sandboxEnabled = false
 	d.isGitRepo = git.IsGitRepo(projectPath)
 
@@ -191,6 +193,14 @@ func (d *ForkDialog) SetSize(width, height int) {
 // ToggleWorktree toggles the worktree checkbox
 func (d *ForkDialog) ToggleWorktree() {
 	d.worktreeEnabled = !d.worktreeEnabled
+	d.worktreeToggled = true // user made an explicit choice; see #1185.
+}
+
+// IsWorktreeExplicit reports whether the worktree state reflects an explicit
+// user choice (the checkbox was toggled) rather than the config default
+// (`[worktree] default_enabled`). See #1185.
+func (d *ForkDialog) IsWorktreeExplicit() bool {
+	return d.worktreeToggled
 }
 
 // IsWorktreeEnabled returns whether worktree mode is enabled

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5678,34 +5678,24 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Resolve worktree target if enabled; actual worktree creation runs in async command.
 		var worktreePath, worktreeRepoRoot string
 		if worktreeEnabled && branchName != "" {
-			// Validate path is a git repo OR a bare-repo project root (#742 /
-			// #715): IsGitRepoOrBareProjectRoot accepts a directory that
-			// contains a nested .bare/ even though the directory itself has
-			// no .git. Downstream GetWorktreeBaseRoot + CreateWorktreeWithSetup
-			// handle both layouts transparently.
-			if !git.IsGitRepoOrBareProjectRoot(path) {
-				h.newDialog.SetError("Path is not a git repository")
+			// resolveWorktreeTarget validates the path is a git repo OR a
+			// bare-repo project root (#742 / #715) and implements the #1185
+			// fallback: a worktree enabled by config default (not an explicit
+			// user toggle) on a non-repo dir falls back to a normal session
+			// instead of erroring, while an explicit worktree still fails loud.
+			wtPath, repoRoot, fallback, errMsg := resolveWorktreeTarget(path, branchName, h.newDialog.IsWorktreeExplicit())
+			if errMsg != "" {
+				h.newDialog.SetError(errMsg)
 				return h, nil
 			}
-
-			repoRoot, err := git.GetWorktreeBaseRoot(path)
-			if err != nil {
-				h.newDialog.SetError(fmt.Sprintf("Failed to get repo root: %v", err))
-				return h, nil
+			if fallback {
+				// #1185: create a normal session on this non-repo dir.
+				worktreeEnabled = false
+				branchName = ""
+			} else {
+				worktreePath = wtPath
+				worktreeRepoRoot = repoRoot
 			}
-
-			// Generate worktree path using configured location/template
-			wtSettings := session.GetWorktreeSettings()
-			worktreePath = git.WorktreePath(git.WorktreePathOptions{
-				Branch:    branchName,
-				Location:  wtSettings.DefaultLocation,
-				RepoDir:   repoRoot,
-				SessionID: git.GeneratePathID(),
-				Template:  wtSettings.Template(),
-			})
-
-			// Store repo root for later use
-			worktreeRepoRoot = repoRoot
 		}
 
 		// Build generic toolOptionsJSON from tool-specific options
@@ -8372,35 +8362,25 @@ func (h *Home) handleForkDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				source := item.Session
 
 				// Resolve worktree target if enabled; actual creation runs in async command.
+				// Bare-repo project roots must pass — same contract as the
+				// new-session path (#742). #1185: a worktree enabled by config
+				// default (not an explicit toggle) on a non-repo dir falls back
+				// to a normal fork instead of erroring.
 				if worktreeEnabled && branchName != "" {
-					// Bare-repo project roots must pass — same contract as
-					// the new-session path (#742).
-					if !git.IsGitRepoOrBareProjectRoot(source.ProjectPath) {
-						h.forkDialog.SetError("Path is not a git repository")
+					worktreePath, repoRoot, fallback, errMsg := resolveWorktreeTarget(source.ProjectPath, branchName, h.forkDialog.IsWorktreeExplicit())
+					if errMsg != "" {
+						h.forkDialog.SetError(errMsg)
 						return h, nil
 					}
-					repoRoot, err := git.GetWorktreeBaseRoot(source.ProjectPath)
-					if err != nil {
-						h.forkDialog.SetError(fmt.Sprintf("Failed to get repo root: %v", err))
-						return h, nil
+					if !fallback {
+						if opts == nil {
+							opts = &session.ClaudeOptions{}
+						}
+						opts.WorkDir = worktreePath
+						opts.WorktreePath = worktreePath
+						opts.WorktreeRepoRoot = repoRoot
+						opts.WorktreeBranch = branchName
 					}
-
-					wtSettings := session.GetWorktreeSettings()
-					worktreePath := git.WorktreePath(git.WorktreePathOptions{
-						Branch:    branchName,
-						Location:  wtSettings.DefaultLocation,
-						RepoDir:   repoRoot,
-						SessionID: git.GeneratePathID(),
-						Template:  wtSettings.Template(),
-					})
-					if opts == nil {
-						opts = &session.ClaudeOptions{}
-					}
-
-					opts.WorkDir = worktreePath
-					opts.WorktreePath = worktreePath
-					opts.WorktreeRepoRoot = repoRoot
-					opts.WorktreeBranch = branchName
 				}
 
 				parentID := h.forkDialog.GetParentSessionID()

--- a/internal/ui/issue1185_worktree_fallback_test.go
+++ b/internal/ui/issue1185_worktree_fallback_test.go
@@ -1,0 +1,143 @@
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// Regression tests for #1185: with [worktree] default_enabled=true, every new
+// session tried to create a git worktree — including sessions on directories
+// that are not git repos, which failed hard with "Path is not a git
+// repository". The default-enabled path must silently fall back to a normal
+// session on non-repo dirs, while an EXPLICIT worktree request must still fail
+// loudly.
+
+func makeGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test User"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git %s failed: %v", args[0], err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"add", "."},
+		{"commit", "-m", "init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git %s failed: %v", args[0], err)
+		}
+	}
+}
+
+// Case 1: default_enabled=true + non-git dir → fall back to a normal session
+// (fallback=true, no error).
+func TestResolveWorktreeTarget_DefaultEnabledNonRepo_FallsBack(t *testing.T) {
+	dir := t.TempDir() // not a git repo
+
+	wtPath, repoRoot, fallback, errMsg := resolveWorktreeTarget(dir, "feature/x", false /* explicit */)
+
+	if errMsg != "" {
+		t.Fatalf("default-enabled on non-repo dir must not error, got %q", errMsg)
+	}
+	if !fallback {
+		t.Fatalf("default-enabled on non-repo dir must fall back to a normal session")
+	}
+	if wtPath != "" || repoRoot != "" {
+		t.Fatalf("fallback must not produce a worktree path/root, got wtPath=%q repoRoot=%q", wtPath, repoRoot)
+	}
+}
+
+// Case 2 (regression): default_enabled=true + git repo → worktree created as
+// before.
+func TestResolveWorktreeTarget_RepoCreatesWorktree(t *testing.T) {
+	dir := t.TempDir()
+	makeGitRepo(t, dir)
+
+	wtPath, repoRoot, fallback, errMsg := resolveWorktreeTarget(dir, "feature/x", false /* explicit */)
+
+	if errMsg != "" {
+		t.Fatalf("git repo must not error, got %q", errMsg)
+	}
+	if fallback {
+		t.Fatalf("git repo must NOT fall back; a worktree should be created")
+	}
+	if wtPath == "" || repoRoot == "" {
+		t.Fatalf("git repo must produce a worktree path and repo root, got wtPath=%q repoRoot=%q", wtPath, repoRoot)
+	}
+}
+
+// Case 3: explicit worktree + non-git dir → still errors (explicit intent
+// preserved).
+func TestResolveWorktreeTarget_ExplicitNonRepo_Errors(t *testing.T) {
+	dir := t.TempDir() // not a git repo
+
+	wtPath, repoRoot, fallback, errMsg := resolveWorktreeTarget(dir, "feature/x", true /* explicit */)
+
+	if errMsg == "" {
+		t.Fatalf("explicit worktree on a non-repo dir must fail loudly")
+	}
+	if fallback {
+		t.Fatalf("explicit worktree on a non-repo dir must NOT fall back silently")
+	}
+	if wtPath != "" || repoRoot != "" {
+		t.Fatalf("errored resolution must not produce a worktree path/root")
+	}
+}
+
+// Boundary: explicit worktree + git repo → worktree created (explicit on a real
+// repo still works).
+func TestResolveWorktreeTarget_ExplicitRepo_CreatesWorktree(t *testing.T) {
+	dir := t.TempDir()
+	makeGitRepo(t, dir)
+
+	wtPath, repoRoot, fallback, errMsg := resolveWorktreeTarget(dir, "feature/x", true /* explicit */)
+
+	if errMsg != "" || fallback || wtPath == "" || repoRoot == "" {
+		t.Fatalf("explicit worktree on a git repo must create a worktree: errMsg=%q fallback=%v wtPath=%q repoRoot=%q", errMsg, fallback, wtPath, repoRoot)
+	}
+}
+
+// Dialog explicitness: a worktree enabled purely by config default is NOT
+// explicit; once the user toggles the checkbox it becomes explicit intent.
+func TestNewDialog_IsWorktreeExplicit_DefaultVsToggle(t *testing.T) {
+	d := NewNewDialog()
+
+	// Simulate config default_enabled=true without an explicit user toggle.
+	d.worktreeEnabled = true
+	if d.IsWorktreeExplicit() {
+		t.Fatalf("worktree enabled by config default must not be reported as explicit")
+	}
+
+	// User toggles the checkbox → explicit intent.
+	d.ToggleWorktree()
+	if !d.IsWorktreeExplicit() {
+		t.Fatalf("worktree toggled by the user must be reported as explicit")
+	}
+}
+
+func TestForkDialog_IsWorktreeExplicit_DefaultVsToggle(t *testing.T) {
+	d := NewForkDialog()
+
+	d.worktreeEnabled = true
+	if d.IsWorktreeExplicit() {
+		t.Fatalf("fork worktree enabled by config default must not be reported as explicit")
+	}
+
+	d.ToggleWorktree()
+	if !d.IsWorktreeExplicit() {
+		t.Fatalf("fork worktree toggled by the user must be reported as explicit")
+	}
+}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -187,6 +187,7 @@ type NewDialog struct {
 	modelLineOffset       int      // Content line where model suggestions overlay should appear.
 	// Worktree support.
 	worktreeEnabled bool
+	worktreeToggled bool // true once the user explicitly toggled the worktree checkbox (vs config default_enabled); see #1185.
 	branchInput     textinput.Model
 	branchAutoSet   bool   // true if branch was auto-derived from session name.
 	branchPrefix    string // configured prefix for auto-generated branch names.
@@ -223,6 +224,7 @@ type dialogSnapshot struct {
 	modelInput       string
 	sandboxEnabled   bool
 	worktreeEnabled  bool
+	worktreeToggled  bool
 	branch           string
 	branchAutoSet    bool
 	claudeOptions    *session.ClaudeOptions
@@ -390,6 +392,7 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	d.updateToolOptions()
 	// Reset worktree fields from global config defaults.
 	d.worktreeEnabled = false
+	d.worktreeToggled = false
 	d.branchInput.SetValue("")
 	d.branchAutoSet = false
 	d.branchPrefix = "feature/" // default; overridden below if config provides one.
@@ -628,6 +631,7 @@ func (d *NewDialog) saveSnapshot() *dialogSnapshot {
 		modelInput:       d.modelInput.Value(),
 		sandboxEnabled:   d.sandboxEnabled,
 		worktreeEnabled:  d.worktreeEnabled,
+		worktreeToggled:  d.worktreeToggled,
 		branch:           d.branchInput.Value(),
 		branchAutoSet:    d.branchAutoSet,
 		claudeOptions:    claudeOpts,
@@ -648,6 +652,7 @@ func (d *NewDialog) restoreSnapshot(s *dialogSnapshot) {
 	d.modelInput.SetValue(s.modelInput)
 	d.sandboxEnabled = s.sandboxEnabled
 	d.worktreeEnabled = s.worktreeEnabled
+	d.worktreeToggled = s.worktreeToggled
 	d.branchInput.SetValue(s.branch)
 	d.branchAutoSet = s.branchAutoSet
 	if s.claudeOptions != nil {
@@ -741,6 +746,7 @@ func (d *NewDialog) previewRecentSession(rs *statedb.RecentSessionRow) {
 
 	// Reset worktree (ephemeral, never pre-filled)
 	d.worktreeEnabled = false
+	d.worktreeToggled = false
 	d.branchInput.SetValue("")
 	d.branchAutoSet = false
 
@@ -933,10 +939,20 @@ func (d *NewDialog) GetValues() (name, path, command string) {
 // When enabling, auto-populates the branch name from the session name.
 func (d *NewDialog) ToggleWorktree() {
 	d.worktreeEnabled = !d.worktreeEnabled
+	d.worktreeToggled = true // user made an explicit choice; see #1185.
 	if d.worktreeEnabled {
 		d.autoBranchFromName()
 	}
 	d.rebuildFocusTargets()
+}
+
+// IsWorktreeExplicit reports whether the worktree state reflects an explicit
+// user choice (the checkbox was toggled) rather than the config default
+// (`[worktree] default_enabled`). Used by #1185 to decide whether a worktree on
+// a non-repo dir should fail loudly (explicit) or fall back to a normal
+// session (default).
+func (d *NewDialog) IsWorktreeExplicit() bool {
+	return d.worktreeToggled
 }
 
 // autoBranchFromName sets the branch input to "<prefix><session-name>" if the

--- a/internal/ui/worktree_target.go
+++ b/internal/ui/worktree_target.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// resolveWorktreeTarget resolves the worktree path for a new or forked session
+// whose worktree checkbox is enabled.
+//
+// It implements the #1185 fallback: when the worktree was enabled by config
+// default (explicit == false) and the target path is NOT a git repository, it
+// returns fallback == true so the caller creates a normal (non-worktree)
+// session instead of erroring. When the worktree was EXPLICITLY requested
+// (explicit == true) on a non-repo path, it returns a non-empty errMsg so the
+// caller fails loudly, preserving explicit intent.
+//
+// On a git repo (or bare-repo project root) it computes and returns the
+// worktree path and repo root unchanged from the previous behaviour.
+func resolveWorktreeTarget(path, branch string, explicit bool) (worktreePath, repoRoot string, fallback bool, errMsg string) {
+	// IsGitRepoOrBareProjectRoot accepts a directory that contains a nested
+	// .bare/ even though the directory itself has no .git (#742 / #715).
+	if !git.IsGitRepoOrBareProjectRoot(path) {
+		if explicit {
+			return "", "", false, "Path is not a git repository"
+		}
+		// #1185: worktree was on by config default, not explicit user intent —
+		// fall back to a normal session on non-repo dirs instead of erroring.
+		return "", "", true, ""
+	}
+
+	root, err := git.GetWorktreeBaseRoot(path)
+	if err != nil {
+		return "", "", false, fmt.Sprintf("Failed to get repo root: %v", err)
+	}
+
+	wtSettings := session.GetWorktreeSettings()
+	worktreePath = git.WorktreePath(git.WorktreePathOptions{
+		Branch:    branch,
+		Location:  wtSettings.DefaultLocation,
+		RepoDir:   root,
+		SessionID: git.GeneratePathID(),
+		Template:  wtSettings.Template(),
+	})
+	return worktreePath, root, false, ""
+}


### PR DESCRIPTION
## Summary

Fixes #1185 (reported by @marekaf).

With `[worktree] default_enabled = true`, **every** new/forked session pre-checked the worktree checkbox — including sessions on directories that aren't git repos. Those failed hard with `Path is not a git repository`, making worktree-by-default unusable for anyone who mixes repo and non-repo session directories.

The TUI new-session and fork paths now distinguish a worktree that was enabled **by config default** from one the user **explicitly toggled**:

| Worktree state | Target dir | Behaviour |
|---|---|---|
| default-enabled (untoggled) | non-repo | **fall back to a normal session** (the fix) |
| explicit toggle | non-repo | still errors (explicit intent preserved) |
| default or explicit | git repo / bare-repo root | worktree created as before |

Detection reuses the existing `git.IsGitRepoOrBareProjectRoot`.

## Implementation

- `internal/ui/worktree_target.go` — new `resolveWorktreeTarget(path, branch, explicit)` helper centralises the repo-check / fallback / error decision (also de-duplicates the new-session and fork code paths in `home.go`).
- `internal/ui/newdialog.go` + `internal/ui/forkdialog.go` — track `worktreeToggled` and expose `IsWorktreeExplicit()` so the dialogs can tell config-default from an explicit user toggle (snapshot save/restore updated too).
- `internal/ui/home.go` — both worktree blocks call the helper and fall back instead of erroring on the default path.

## Surfaces

- **TUI** new-session (`newdialog`) — fixed, covered.
- **TUI** fork (`forkdialog`) — fixed for parity, covered.
- **CLI** `agent-deck add` — **unchanged**: only creates a worktree for an explicit `-w/--worktree` flag, so it is always explicit intent and correctly stays fail-loud (TDD case 3).
- **Web** — N/A: the web new-session API (`CreateSession(title, tool, projectPath, groupPath, modelID)`) takes no worktree params, so it never triggers default-worktree creation.

## Tests (`internal/ui/issue1185_worktree_fallback_test.go`)

- default-enabled + non-git dir → falls back, no error
- default-enabled + git repo → worktree created (regression)
- explicit + non-git dir → still errors (intent preserved)
- explicit + git repo → worktree created (boundary)
- `NewDialog` / `ForkDialog` `IsWorktreeExplicit()`: config default is not explicit; user toggle is

```
go test -race ./internal/ui/... ./internal/session/... ./cmd/agent-deck/...
```
All green except two **pre-existing, unrelated** failures (`TestIssue1190_Custom*`, present on a clean `main` before this branch). `golangci-lint run` on `internal/ui/...`: 0 issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree session creation with intelligent fallback behavior for non-git directories when worktree is enabled by default
  * Enhanced error handling when worktree is explicitly requested in unsupported locations

* **Tests**
  * Added regression tests for worktree fallback behavior and user choice tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->