### PR TITLE
fix(worktree): dismissing a worktree_reuse session deletes the original repo (#1200) — DATA LOSS

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -492,6 +492,49 @@ func parseWorktreeList(output string) []Worktree {
 	return worktrees
 }
 
+// IsLinkedWorktree reports whether path is a git LINKED (secondary) worktree —
+// i.e. one that agent-deck (or the user) created with `git worktree add`, as
+// opposed to the repository's main working tree or a non-repo directory.
+//
+// A linked worktree's git directory lives at <repo>/.git/worktrees/<id> (its
+// parent is named "worktrees"), whereas the main working tree's git directory
+// is <repo>/.git. This distinction is the only safe, location-independent way
+// to tell an agent-deck-managed worktree from the user's original repository:
+// worktree placement is user-configurable (sibling, <repo>/.worktrees, or a
+// custom template), so a fixed "managed directory" prefix check is unreliable.
+//
+// Used as the load-bearing guard against issue #1200 (deleting the original
+// repo on dismiss of a worktree_reuse session). Any error or ambiguity returns
+// false, so callers fail safe (skip deletion) rather than risk data loss.
+func IsLinkedWorktree(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	// Primary signal: a live linked worktree's git dir is <repo>/.git/worktrees/<id>
+	// (parent named "worktrees"). The main working tree's git dir is <repo>/.git.
+	// rev-parse succeeding is authoritative, so we trust its verdict either way.
+	if out, err := exec.Command("git", "-C", path, "rev-parse", "--absolute-git-dir").Output(); err == nil {
+		if gitDir := strings.TrimSpace(string(out)); gitDir != "" {
+			return filepath.Base(filepath.Dir(gitDir)) == "worktrees"
+		}
+	}
+	// Fallback for an ORPHANED linked worktree whose admin entry under
+	// <repo>/.git/worktrees/<id> was already removed (rev-parse then fails): the
+	// directory's own .git is still a regular FILE "gitdir: <...>/worktrees/<id>".
+	// The main working tree's .git is a DIRECTORY, so this never matches it —
+	// the original repo stays protected (#1200) while stale worktrees clean up.
+	info, err := os.Lstat(filepath.Join(path, ".git"))
+	if err != nil || info.IsDir() {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(path, ".git"))
+	if err != nil {
+		return false
+	}
+	gitdir := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(data)), "gitdir:"))
+	return filepath.Base(filepath.Dir(gitdir)) == "worktrees"
+}
+
 // RemoveWorktree removes a worktree from the repository.
 // If force is true, it will remove even if there are uncommitted changes.
 // When force is true and git fails (e.g. "Directory not empty" due to
@@ -525,6 +568,16 @@ func RemoveWorktree(repoDir, worktreePath string, force bool) error {
 		// submodule's git history.
 		if isGitDir(worktreePath) {
 			return fmt.Errorf("refusing to remove %q: path is a git directory, not a working tree (likely a stale session row from before the submodule path-normalization fix)", worktreePath)
+		}
+		// #1200 (data loss): the os.RemoveAll fallback must only ever delete a
+		// genuine LINKED worktree. A worktree_reuse session points WorktreePath
+		// at the repository's MAIN working tree (the user's original repo); git
+		// refuses `worktree remove` on it, and without this guard the fallback
+		// would os.RemoveAll the entire repository. Refuse anything that is not
+		// a linked worktree (the main tree, or a non-worktree path) — better to
+		// leak a directory than to destroy the user's repo.
+		if !IsLinkedWorktree(worktreePath) {
+			return fmt.Errorf("refusing to remove %q: not a linked git worktree (main working tree or non-worktree path) — declining os.RemoveAll to avoid deleting the original repository (#1200)", worktreePath)
 		}
 		if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
 			return fmt.Errorf("failed to remove worktree directory: %w (git error: %s)", rmErr, strings.TrimSpace(string(output)))

--- a/internal/git/issue1200_no_delete_main_worktree_test.go
+++ b/internal/git/issue1200_no_delete_main_worktree_test.go
@@ -1,0 +1,133 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Issue #1200 (reported by @mic-web): dismissing a session created with
+// worktree_reuse permanently deleted the user's ORIGINAL repository.
+//
+// When the repo was already on the desired branch, agent-deck created no
+// dedicated worktree and the session's WorktreePath pointed at the real repo
+// root. On dismiss, RemoveWorktree(repoRoot, repoRoot, force=true) ran
+// `git worktree remove --force <repoRoot>` (which fails on a main working
+// tree), then the force-mode fallback ran os.RemoveAll(repoRoot) — destroying
+// the repository (uncommitted changes, stashes, local branches), silently and
+// with no undo.
+//
+// These tests pin the git-layer guard: the force fallback must NEVER
+// os.RemoveAll a path that is not a LINKED worktree (the main working tree, or
+// any non-worktree path). Legitimate linked-worktree cleanup must still work.
+
+// TestRemoveWorktree_RefusesToDeleteMainWorktree_Issue1200 is THE critical
+// data-loss regression. It must FAIL on pre-fix code (the repo is deleted) and
+// PASS after the fix (the repo survives).
+func TestRemoveWorktree_RefusesToDeleteMainWorktree_Issue1200(t *testing.T) {
+	repo := t.TempDir()
+	createTestRepo(t, repo)
+
+	// Sentinel standing in for the user's irreplaceable work. If this file
+	// disappears, the repository was destroyed.
+	sentinel := filepath.Join(repo, "PRECIOUS_USER_WORK.txt")
+	if err := os.WriteFile(sentinel, []byte("uncommitted work, stashes, branches"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	// Reproduce worktree_reuse: worktreePath == repoRoot (the main working tree).
+	err := RemoveWorktree(repo, repo, true)
+
+	if _, statErr := os.Stat(sentinel); os.IsNotExist(statErr) {
+		t.Fatalf("DATA LOSS (#1200): RemoveWorktree deleted the original repository — sentinel %s is gone", sentinel)
+	}
+	if _, statErr := os.Stat(filepath.Join(repo, ".git")); os.IsNotExist(statErr) {
+		t.Fatalf("DATA LOSS (#1200): RemoveWorktree deleted the repository .git directory")
+	}
+	if err == nil {
+		t.Fatalf("expected RemoveWorktree to refuse removing the main working tree, got nil error")
+	}
+}
+
+// TestRemoveWorktree_RefusesNonWorktreePath_Issue1200 covers the paranoid edge:
+// a force removal aimed at a plain directory that is not a git worktree at all
+// must also be refused rather than blindly os.RemoveAll'd.
+func TestRemoveWorktree_RefusesNonWorktreePath_Issue1200(t *testing.T) {
+	repo := t.TempDir()
+	createTestRepo(t, repo)
+
+	// A plain directory living outside any worktree of repo.
+	outside := filepath.Join(t.TempDir(), "not-a-worktree")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	keep := filepath.Join(outside, "keep.txt")
+	if err := os.WriteFile(keep, []byte("do not delete"), 0o644); err != nil {
+		t.Fatalf("write keep: %v", err)
+	}
+
+	err := RemoveWorktree(repo, outside, true)
+
+	if _, statErr := os.Stat(keep); os.IsNotExist(statErr) {
+		t.Fatalf("DATA LOSS (#1200): RemoveWorktree deleted a non-worktree directory %s", outside)
+	}
+	if err == nil {
+		t.Fatalf("expected RemoveWorktree to refuse removing a non-worktree path, got nil error")
+	}
+}
+
+// TestRemoveWorktree_StillRemovesLinkedWorktree_Issue1200 guards against
+// over-correction: a genuine agent-deck-created linked worktree (whose
+// `git worktree remove --force` fails due to untracked files, forcing the
+// os.RemoveAll fallback) must still be removed, and the main repo must survive.
+func TestRemoveWorktree_StillRemovesLinkedWorktree_Issue1200(t *testing.T) {
+	repo := t.TempDir()
+	createTestRepo(t, repo)
+	sentinel := filepath.Join(repo, "PRECIOUS_USER_WORK.txt")
+	if err := os.WriteFile(sentinel, []byte("main repo work"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	wt := filepath.Join(t.TempDir(), "linked-wt")
+	if err := CreateWorktree(repo, wt, "feature-x"); err != nil {
+		t.Fatalf("create linked worktree: %v", err)
+	}
+	// Untracked file makes `git worktree remove --force` exit non-zero,
+	// exercising the os.RemoveAll fallback for a legitimate worktree.
+	if err := os.WriteFile(filepath.Join(wt, "untracked.txt"), []byte("y"), 0o644); err != nil {
+		t.Fatalf("write untracked: %v", err)
+	}
+
+	if err := RemoveWorktree(repo, wt, true); err != nil {
+		t.Fatalf("expected linked worktree removal to succeed, got: %v", err)
+	}
+	if _, statErr := os.Stat(wt); !os.IsNotExist(statErr) {
+		t.Fatalf("expected linked worktree dir %s to be removed", wt)
+	}
+	if _, statErr := os.Stat(sentinel); os.IsNotExist(statErr) {
+		t.Fatalf("DATA LOSS (#1200): main repo sentinel removed during linked-worktree cleanup")
+	}
+}
+
+// TestIsLinkedWorktree_Issue1200 pins the helper that distinguishes a linked
+// (agent-deck-managed) worktree from the main working tree and non-repo dirs.
+func TestIsLinkedWorktree_Issue1200(t *testing.T) {
+	repo := t.TempDir()
+	createTestRepo(t, repo)
+
+	if IsLinkedWorktree(repo) {
+		t.Errorf("main working tree must NOT be reported as a linked worktree")
+	}
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	if err := CreateWorktree(repo, wt, "feat"); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	if !IsLinkedWorktree(wt) {
+		t.Errorf("linked worktree must be reported as a linked worktree")
+	}
+
+	if IsLinkedWorktree(t.TempDir()) {
+		t.Errorf("non-repo directory must NOT be reported as a linked worktree")
+	}
+}

--- a/internal/session/issue1200_worktree_reuse_no_delete_test.go
+++ b/internal/session/issue1200_worktree_reuse_no_delete_test.go
@@ -1,0 +1,139 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// Issue #1200 (reported by @mic-web): dismissing a session created with
+// worktree_reuse deleted the user's ORIGINAL repository.
+//
+// A reused session has WorktreePath pointing at the primary working tree (the
+// repo the user is on), NOT at an agent-deck-created linked worktree. Routing
+// dismissal through IsRemovableWorktree / RemoveSessionWorktree must never
+// delete such a repo, while still cleaning up real linked worktrees.
+
+func issue1200InitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("-c", "init.defaultBranch=main", "init")
+	run("config", "user.email", "test@test.com")
+	run("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# repo"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	run("add", ".")
+	run("commit", "-m", "init")
+	return dir
+}
+
+func issue1200AddWorktree(t *testing.T, repo, branch string) string {
+	t.Helper()
+	wt := filepath.Join(t.TempDir(), "wt-"+branch)
+	cmd := exec.Command("git", "worktree", "add", "-b", branch, wt)
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	return wt
+}
+
+// TestRemoveSessionWorktree_ReuseDoesNotDeleteRepo_Issue1200 is THE critical
+// regression: a worktree_reuse session (WorktreePath == repo root) must NOT be
+// removed on dismissal, and the original repo + its contents must survive.
+func TestRemoveSessionWorktree_ReuseDoesNotDeleteRepo_Issue1200(t *testing.T) {
+	repo := issue1200InitRepo(t)
+	sentinel := filepath.Join(repo, "PRECIOUS_USER_WORK.txt")
+	if err := os.WriteFile(sentinel, []byte("uncommitted work, stashes, branches"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	// worktree_reuse: repo already on the desired branch → path == repo root,
+	// no dedicated worktree created.
+	inst := &Instance{WorktreePath: repo, WorktreeRepoRoot: repo}
+
+	removed, err := RemoveSessionWorktree(inst)
+	if err != nil {
+		t.Fatalf("RemoveSessionWorktree returned error for a reused repo: %v", err)
+	}
+	if removed {
+		t.Fatalf("reused repo must NOT be removed on dismissal")
+	}
+	if _, statErr := os.Stat(sentinel); os.IsNotExist(statErr) {
+		t.Fatalf("DATA LOSS (#1200): dismissing a reused session deleted the original repository")
+	}
+	if _, statErr := os.Stat(filepath.Join(repo, ".git")); os.IsNotExist(statErr) {
+		t.Fatalf("DATA LOSS (#1200): dismissing a reused session deleted the repository .git directory")
+	}
+}
+
+// TestRemoveSessionWorktree_RemovesDedicatedWorktree_Issue1200 guards real
+// cleanup: an agent-deck-created linked worktree must still be removed, and the
+// original repo must survive.
+func TestRemoveSessionWorktree_RemovesDedicatedWorktree_Issue1200(t *testing.T) {
+	repo := issue1200InitRepo(t)
+	sentinel := filepath.Join(repo, "PRECIOUS_USER_WORK.txt")
+	if err := os.WriteFile(sentinel, []byte("main repo work"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	wt := issue1200AddWorktree(t, repo, "feature-x")
+
+	inst := &Instance{WorktreePath: wt, WorktreeRepoRoot: repo}
+
+	removed, err := RemoveSessionWorktree(inst)
+	if err != nil {
+		t.Fatalf("RemoveSessionWorktree(dedicated worktree) error: %v", err)
+	}
+	if !removed {
+		t.Fatalf("a dedicated linked worktree must be removed on dismissal")
+	}
+	if _, statErr := os.Stat(wt); !os.IsNotExist(statErr) {
+		t.Fatalf("expected dedicated worktree %s to be removed", wt)
+	}
+	if _, statErr := os.Stat(sentinel); os.IsNotExist(statErr) {
+		t.Fatalf("DATA LOSS (#1200): original repo removed during dedicated-worktree cleanup")
+	}
+}
+
+func TestIsRemovableWorktree_Issue1200(t *testing.T) {
+	repo := issue1200InitRepo(t)
+	wt := issue1200AddWorktree(t, repo, "feat")
+
+	// A plain directory that is not a worktree, but with WorktreePath set —
+	// the paranoid guard must still refuse it.
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		inst *Instance
+		want bool
+	}{
+		{"nil instance", nil, false},
+		{"empty metadata", &Instance{}, false},
+		{"empty worktree path", &Instance{WorktreeRepoRoot: repo}, false},
+		{"empty repo root", &Instance{WorktreePath: wt}, false},
+		{"reused repo (path == root)", &Instance{WorktreePath: repo, WorktreeRepoRoot: repo}, false},
+		{"path outside, not a worktree", &Instance{WorktreePath: outside, WorktreeRepoRoot: repo}, false},
+		{"dedicated linked worktree", &Instance{WorktreePath: wt, WorktreeRepoRoot: repo}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsRemovableWorktree(tc.inst); got != tc.want {
+				t.Errorf("IsRemovableWorktree = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/session/worktree_removal.go
+++ b/internal/session/worktree_removal.go
@@ -1,0 +1,66 @@
+package session
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+)
+
+// IsRemovableWorktree reports whether agent-deck may safely delete the
+// session's worktree directory on dismiss. It is deliberately conservative: a
+// path is removable ONLY when every check passes, because a false positive
+// means os.RemoveAll on a real repository (issue #1200 — silent data loss).
+//
+// All of the following must hold:
+//  1. agent-deck recorded a worktree at all (non-empty WorktreePath and
+//     WorktreeRepoRoot). A worktree_reuse session that pointed at the original
+//     repo can leave these empty depending on the creation path.
+//  2. the worktree path is NOT the original repo root (worktree_reuse points
+//     WorktreePath at the user's primary working tree).
+//  3. git itself confirms the path is a LINKED worktree (created via
+//     `git worktree add`), never the main working tree or a non-worktree dir.
+//     This is the location-independent proof that agent-deck created it:
+//     worktree placement is user-configurable, so a fixed managed-directory
+//     prefix check is unreliable.
+func IsRemovableWorktree(inst *Instance) bool {
+	if inst == nil {
+		return false
+	}
+	wt := strings.TrimSpace(inst.WorktreePath)
+	root := strings.TrimSpace(inst.WorktreeRepoRoot)
+	if wt == "" || root == "" {
+		return false
+	}
+	if canonicalPath(wt) == canonicalPath(root) {
+		return false
+	}
+	return git.IsLinkedWorktree(wt)
+}
+
+// RemoveSessionWorktree removes the session's worktree directory if and only if
+// IsRemovableWorktree permits it. It returns whether a removal was performed.
+// A reused original repo (or any non-linked-worktree path) is left untouched —
+// the caller should simply drop the session from the registry (#1200).
+func RemoveSessionWorktree(inst *Instance) (removed bool, err error) {
+	if !IsRemovableWorktree(inst) {
+		return false, nil
+	}
+	if err := git.RemoveWorktree(inst.WorktreeRepoRoot, inst.WorktreePath, true); err != nil {
+		return false, err
+	}
+	// Best-effort: drop the now-stale worktree administrative reference.
+	_ = git.PruneWorktrees(inst.WorktreeRepoRoot)
+	return true, nil
+}
+
+// canonicalPath resolves symlinks and cleans a path for equality comparison so
+// that e.g. /var vs /private/var (macOS) or other symlinked roots do not let a
+// reused repo slip past the path == root check. Falls back to a lexical clean
+// when the path cannot be resolved (e.g. it no longer exists).
+func canonicalPath(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(p)
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9307,11 +9307,17 @@ func (h *Home) deleteSession(inst *session.Instance) tea.Cmd {
 	return func() tea.Msg {
 		killErr := inst.Kill()
 		if isWorktree {
-			if err := git.RemoveWorktree(worktreeRepoRoot, worktreePath, true); err != nil {
+			// #1200: route worktree teardown through the session guard so a
+			// worktree_reuse session (WorktreePath == the user's original repo)
+			// is never os.RemoveAll'd. Only genuine agent-deck-created linked
+			// worktrees are removed; a reused repo is left intact and merely
+			// dropped from the registry.
+			snap := &session.Instance{WorktreePath: worktreePath, WorktreeRepoRoot: worktreeRepoRoot}
+			switch removed, err := session.RemoveSessionWorktree(snap); {
+			case err != nil:
 				uiLog.Warn("worktree_remove_err", slog.String("path", worktreePath), slog.String("err", err.Error()))
-			}
-			if err := git.PruneWorktrees(worktreeRepoRoot); err != nil {
-				uiLog.Warn("worktree_prune_err", slog.String("repo", worktreeRepoRoot), slog.String("err", err.Error()))
+			case !removed:
+				uiLog.Info("worktree_remove_skipped", slog.String("path", worktreePath), slog.String("repo", worktreeRepoRoot), slog.String("reason", "reused or non-linked worktree (#1200 guard)"))
 			}
 		}
 		if isMultiRepo {


### PR DESCRIPTION
## ⚠️ Critical data-loss fix — closes #1200

Dismissing (`d`) a session created with **worktree_reuse** — where the repo is already on the desired branch, so agent-deck creates **no** dedicated worktree — ran `os.RemoveAll` on the **original repository path**, permanently deleting the user's repo (uncommitted changes, stashes, local branches) with no confirmation and no undo.

Reported by **@mic-web** with debug evidence: `DEBUG Worktree removed {"path": "/home/username/wsl"}`.

### Root cause
The reuse path sets `WorktreePath = existingPath` (from `GetWorktreeForBranch`), which is the repository's **main working tree** when the repo is already on the target branch. On dismiss, `git.RemoveWorktree(force=true)` is called; git refuses to remove a main working tree, so the **force-mode fallback ran `os.RemoveAll` on the repo root**.

### Fix (defense in depth)
1. **`internal/git` — load-bearing guard.** New `IsLinkedWorktree(path)`: the location-independent test for an agent-deck-created worktree (git dir under `<repo>/.git/worktrees/<id>`; falls back to the worktree's own `.git` *file* for orphaned admin entries — the main tree has a `.git` *directory*). `RemoveWorktree`'s force fallback now **refuses `os.RemoveAll` on anything that isn't a linked worktree**. This one guard protects every caller: TUI dismiss, CLI `session rm`, web finish, multi-repo cleanup.
2. **`internal/session` — high-level guard.** New `IsRemovableWorktree(inst)` + `RemoveSessionWorktree(inst)`: removable only when `WorktreePath`/`WorktreeRepoRoot` are set, the path is not the repo root, and git confirms a linked worktree. Reused repos are left intact and merely dropped from the registry.
3. **`internal/ui` — the `d` handler.** `deleteSession` now routes worktree teardown through `RemoveSessionWorktree`, so a reused repo is never even handed to `RemoveWorktree`.

> Note: the reporter's suggested "only delete under `~/.agent-deck/worktrees/`" doesn't fit this codebase — worktree placement is user-configurable (`sibling`, `<repo>/.worktrees`, or a custom template). Git's own linked-vs-main worktree distinction is the robust, location-independent signal.

### Surfaces (per agent-deck-tdd-feature)
| Surface | Covered | How |
|---|---|---|
| **TUI** (`internal/ui/`) | ✅ | `deleteSession` (`d` handler) routes through `RemoveSessionWorktree` |
| **CLI** (`cmd/agent-deck/`) | ✅ | `pruneSessionWorktree` / `remove` reach `git.RemoveWorktree` → guarded by `IsLinkedWorktree` |
| **Web** (`internal/web/`) | ✅ | `web_mutator` finish reaches `git.RemoveWorktree` → guarded |
| **Persistence** (`internal/statedb/`) | n/a | no schema change; reads existing `worktree_path`/`worktree_repo_root` |
| **Remote** | n/a | worktree teardown is a host-local filesystem op, not a per-session-type behavior |
| **Cross-platform** | ✅ | symlink-canonicalized path compare (`/var` vs `/private/var`); git semantics identical |

### Regression tests (fail before, pass after)
- `internal/git/issue1200_no_delete_main_worktree_test.go` — refuses to delete the main working tree (the critical data-loss repro) and non-worktree paths; **still** removes genuine linked worktrees incl. the orphaned-admin-entry fallback.
- `internal/session/issue1200_worktree_reuse_no_delete_test.go` — dismissing a reused repo leaves it + a sentinel file intact (`removed=false`); a dedicated worktree is still removed; `IsRemovableWorktree` table covers nil/empty/reused/outside/linked.

### Verification
- Critical test **failed before** the fix (sentinel deleted), **passes after**.
- `go test -race -count=1 ./internal/git/... ./internal/session/... ./internal/ui/...` — green.
- Full `go test ./...` — green.
- `golangci-lint run` — 0 issues.
- Manual trace: the only path that can `os.RemoveAll` a worktree is `git.RemoveWorktree`'s force fallback, now guarded; all dismiss callers route through it.

Closes #1200

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented safeguards to prevent accidental deletion of the main repository when dismissing sessions with worktrees. The system now validates that only linked worktrees are removed, protecting against data loss.

* **Tests**
  * Added comprehensive regression tests for worktree removal safety across multiple scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->