### PR TITLE
fix(session): exit-to-shell on agent exit, then resume same session (#1161)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -299,6 +299,13 @@ type Instance struct {
 	// survive the bash -c wrapper.
 	ExtraArgs []string `json:"extra_args,omitempty"`
 
+	// ExitToShell is the per-session override for the [shell] exit_to_shell
+	// toggle (issue #1161). nil → inherit the global config default (off);
+	// non-nil → force on/off for this session regardless of config. When on
+	// and the tool is a built-in agent, the spawn command is wrapped so that
+	// exiting the agent drops the pane to an interactive shell at the same cwd.
+	ExitToShell *bool `json:"exit_to_shell,omitempty"`
+
 	// StartupQuery is the claude-code positional "startup query" (#725,
 	// v1.7.67). Set from the new-session dialog's "Start query" field and
 	// emitted as a single shell-quoted positional arg on the claude
@@ -6759,11 +6766,80 @@ func (i *Instance) wrapForSandbox(command string) (string, string, error) {
 	return wrappedCmd, containerName, nil
 }
 
+// builtinAgentTools are the first-party agent CLIs agent-deck launches as a
+// pane's initial process and whose clean exit (e.g. `/exit`) can fall back to
+// an interactive shell when exit_to_shell is enabled (issue #1161).
+var builtinAgentTools = map[string]bool{
+	"claude":   true,
+	"gemini":   true,
+	"opencode": true,
+	"codex":    true,
+	"copilot":  true,
+	"cursor":   true,
+	"hermes":   true,
+	"crush":    true,
+}
+
+// isBuiltinAgentTool reports whether tool is a first-party agent (or a custom
+// tool wrapping claude/codex). Custom non-agent commands and "shell" are not
+// agents and must never be exit-to-shell wrapped.
+func isBuiltinAgentTool(tool string) bool {
+	if builtinAgentTools[tool] {
+		return true
+	}
+	return IsClaudeCompatible(tool) || IsCodexCompatible(tool)
+}
+
+// exitToShellEnabled resolves the exit-to-shell toggle for this instance.
+// Per-session override (Instance.ExitToShell) wins; otherwise the global
+// [shell] exit_to_shell config flag applies. Default is OFF (opt-in). #1161.
+func (i *Instance) exitToShellEnabled() bool {
+	if i.ExitToShell != nil {
+		return *i.ExitToShell
+	}
+	cfg, _ := LoadUserConfig()
+	return cfg != nil && cfg.Shell.GetExitToShell()
+}
+
+// wrapExitToShell rewrites a built-in agent's spawn command so the pane falls
+// back to an interactive shell at the same cwd when the agent exits, restoring
+// the pre-#503 exit→shell→resume workflow (issue #1161, Option A).
+//
+// The transform is:
+//
+//	<agent cmd>; exec "$SHELL" -i
+//
+// with the agent's own `exec ` launcher neutralised — claude execs itself for
+// job control, which would replace the wrapping bash and prevent the trailing
+// shell exec from ever running. Only the first `exec ` (the launcher) is
+// stripped; any later "exec " lives inside a shell-quoted startup-query suffix.
+// Agents that do not exec (gemini, codex, …) are unaffected by the strip and
+// simply get the suffix appended.
+//
+// No-op when the flag is off, the command is empty, the session is sandboxed
+// (docker exec owns the in-container process), or the tool is not a built-in
+// agent. Resume is unaffected: i.ClaudeSessionID is captured in Go before the
+// command is built, so the `--session-id`/`--resume` id still targets the same
+// session after the shell detour.
+func (i *Instance) wrapExitToShell(command string) string {
+	if command == "" || i.IsSandboxed() || !i.exitToShellEnabled() || !isBuiltinAgentTool(i.Tool) {
+		return command
+	}
+	rewritten := strings.Replace(command, "exec ", "", 1)
+	return rewritten + `; exec "$SHELL" -i`
+}
+
 // prepareCommand applies the full command wrapping chain: user wrapper → sandbox → ignore-suspend.
 // Returns the wrapped command, the sandbox container name (empty if not sandboxed), and an error.
 // All code paths that launch or respawn a tmux pane should use this instead of calling
 // applyWrapper/wrapForSandbox/wrapIgnoreSuspend individually.
 func (i *Instance) prepareCommand(cmd string) (string, string, error) {
+	// Exit-to-shell wrap FIRST, on the bare agent command, so the agent's own
+	// `exec ` launcher is still visible to neutralise and the trailing shell
+	// exec stays the outermost statement before any user-wrapper / bash -c /
+	// SSH layering. No-op unless opt-in for a built-in agent (issue #1161).
+	cmd = i.wrapExitToShell(cmd)
+
 	// Apply the user wrapper FIRST so that extra args folded into a
 	// "{command} --flag1 --flag2" wrapper template become part of the string
 	// that the bash -c wrap protects. Previously the order was reversed

--- a/internal/session/issue1161_exit_to_shell_test.go
+++ b/internal/session/issue1161_exit_to_shell_test.go
@@ -1,0 +1,305 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// Issue #1161 (reporter @Djeeteg007): exiting an agent (`/exit`) should be able
+// to drop the pane back to an interactive shell at the same cwd, so the user can
+// do shell-only work (aws-vault exec, direnv, …) and then `claude --resume` the
+// SAME session. PR #503 made the agent the pane's initial process, which removed
+// the parent shell that used to survive `/exit`. Option A (design doc
+// docs/decisions/1161-exit-to-shell-then-resume.md) restores the shell fallback
+// behind an opt-in flag by wrapping the spawn command as
+// `<agent cmd>; exec "$SHELL" -i` (note: NO `exec` before the agent), keeping the
+// #503 perf win.
+//
+// These tests pin the contract: flag ON wraps, flag OFF is byte-for-byte
+// unchanged, the session id survives the wrap (resume still works), and
+// non-agent / sandboxed sessions are unaffected.
+
+const exitToShellSuffix = `; exec "$SHELL" -i`
+
+// exitToShellTestEnv isolates CLAUDE_CONFIG_DIR / HOME so command building is
+// deterministic. Mirrors extraArgsTestEnv (extraargs_test.go:14).
+func exitToShellTestEnv(t *testing.T) {
+	t.Helper()
+	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	origHome := os.Getenv("HOME")
+	os.Unsetenv("CLAUDE_CONFIG_DIR")
+	os.Setenv("HOME", t.TempDir())
+	ClearUserConfigCache()
+	t.Cleanup(func() {
+		if origConfigDir != "" {
+			os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
+		} else {
+			os.Unsetenv("CLAUDE_CONFIG_DIR")
+		}
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	})
+}
+
+// boolPtr is provided by gemini_yolo_test.go in this package.
+
+// --- Happy path: flag ON wraps the claude spawn command ---------------------
+
+func TestExitToShell_ClaudeWrappedWhenEnabled(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	inst := NewInstanceWithTool("e2s-claude", t.TempDir(), "claude")
+	inst.ExitToShell = boolPtr(true)
+
+	raw := inst.buildClaudeCommand("claude")
+	wrapped := inst.wrapExitToShell(raw)
+
+	if !strings.HasSuffix(wrapped, exitToShellSuffix) {
+		t.Fatalf("wrapped command must end with %q, got:\n%s", exitToShellSuffix, wrapped)
+	}
+	// The agent must NOT be exec'd, otherwise it would replace the wrapping
+	// bash and the trailing `exec "$SHELL"` would never run.
+	if strings.Contains(wrapped, "exec env") || strings.Contains(wrapped, "exec claude") {
+		t.Fatalf("agent launcher must not be exec'd in exit-to-shell mode, got:\n%s", wrapped)
+	}
+}
+
+// --- Regression: flag OFF leaves the command byte-for-byte unchanged --------
+
+func TestExitToShell_DisabledLeavesCommandUnchanged(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	inst := NewInstanceWithTool("e2s-off", t.TempDir(), "claude")
+	// No per-session override and no config flag -> default OFF.
+
+	raw := inst.buildClaudeCommand("claude")
+	wrapped := inst.wrapExitToShell(raw)
+
+	if wrapped != raw {
+		t.Fatalf("flag OFF must not alter the command.\n raw:     %s\n wrapped: %s", raw, wrapped)
+	}
+	if strings.Contains(wrapped, exitToShellSuffix) {
+		t.Fatalf("flag OFF must not append the shell suffix, got:\n%s", wrapped)
+	}
+}
+
+// --- Resume metadata preserved: the session id survives the wrap ------------
+
+func TestExitToShell_PreservesClaudeSessionID(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	inst := NewInstanceWithTool("e2s-resume", t.TempDir(), "claude")
+	inst.ExitToShell = boolPtr(true)
+
+	raw := inst.buildClaudeCommand("claude")
+	wrapped := inst.wrapExitToShell(raw)
+
+	if inst.ClaudeSessionID == "" {
+		t.Fatal("ClaudeSessionID must be captured in Go memory for resume; got empty")
+	}
+	// The id must still be on the command line so `claude --session-id <uuid>`
+	// (and therefore `--resume <uuid>`) targets the SAME session after the
+	// shell detour. Cross-checks conductor_restart_history_loss.
+	if !strings.Contains(wrapped, inst.ClaudeSessionID) {
+		t.Fatalf("wrapped command lost the session id %q, got:\n%s", inst.ClaudeSessionID, wrapped)
+	}
+}
+
+// --- Boundary: a tool that does not use `exec` (gemini) still wraps ----------
+
+func TestExitToShell_GeminiWrappedWhenEnabled(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	inst := NewInstanceWithTool("e2s-gemini", t.TempDir(), "gemini")
+	inst.ExitToShell = boolPtr(true)
+
+	raw := inst.buildGeminiCommand("gemini")
+	wrapped := inst.wrapExitToShell(raw)
+
+	if !strings.HasSuffix(wrapped, exitToShellSuffix) {
+		t.Fatalf("gemini command must end with %q, got:\n%s", exitToShellSuffix, wrapped)
+	}
+	if !strings.Contains(wrapped, "gemini") {
+		t.Fatalf("gemini invocation lost from wrapped command, got:\n%s", wrapped)
+	}
+}
+
+// --- Failure mode: non-agent (shell) tool is never wrapped ------------------
+
+func TestExitToShell_ShellToolNotWrapped(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	inst := NewInstanceWithTool("e2s-shell", t.TempDir(), "shell")
+	inst.ExitToShell = boolPtr(true)
+
+	raw := "vim"
+	wrapped := inst.wrapExitToShell(raw)
+
+	if wrapped != raw {
+		t.Fatalf("shell tool must not be exit-to-shell wrapped, got:\n%s", wrapped)
+	}
+}
+
+// --- Failure mode: sandboxed sessions are excluded (docker exec path) -------
+
+func TestExitToShell_SandboxNotWrapped(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	inst := NewInstanceWithTool("e2s-sandbox", t.TempDir(), "claude")
+	inst.ExitToShell = boolPtr(true)
+	inst.Sandbox = &SandboxConfig{Enabled: true, Image: "agentdeck/sandbox:latest"}
+
+	raw := inst.buildClaudeCommand("claude")
+	wrapped := inst.wrapExitToShell(raw)
+
+	if wrapped != raw {
+		t.Fatalf("sandboxed session must not be exit-to-shell wrapped, got:\n%s", wrapped)
+	}
+}
+
+// --- Empty command is a no-op (defensive) -----------------------------------
+
+func TestExitToShell_EmptyCommandNoop(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	inst := NewInstanceWithTool("e2s-empty", t.TempDir(), "claude")
+	inst.ExitToShell = boolPtr(true)
+
+	if got := inst.wrapExitToShell(""); got != "" {
+		t.Fatalf("empty command must stay empty, got:\n%s", got)
+	}
+}
+
+// --- Config default is OFF (opt-in) -----------------------------------------
+
+func TestExitToShell_ConfigDefaultOff(t *testing.T) {
+	var s ShellSettings
+	if s.GetExitToShell() {
+		t.Fatal("ShellSettings.GetExitToShell() must default to false (opt-in)")
+	}
+	s.ExitToShell = boolPtr(true)
+	if !s.GetExitToShell() {
+		t.Fatal("ShellSettings.GetExitToShell() must honor an explicit true")
+	}
+}
+
+// --- Per-session override beats config; config used when override is nil ----
+
+func TestExitToShell_ResolutionPrecedence(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	// Override nil + config off -> off.
+	inst := NewInstanceWithTool("e2s-prec", t.TempDir(), "claude")
+	if inst.exitToShellEnabled() {
+		t.Fatal("default (no override, no config) must be OFF")
+	}
+
+	// Override true wins regardless of config.
+	inst.ExitToShell = boolPtr(true)
+	if !inst.exitToShellEnabled() {
+		t.Fatal("per-session override true must enable exit-to-shell")
+	}
+
+	// Override false wins regardless of config.
+	inst.ExitToShell = boolPtr(false)
+	if inst.exitToShellEnabled() {
+		t.Fatal("per-session override false must disable exit-to-shell")
+	}
+}
+
+// --- Integration: the actual spawn path (prepareCommand) applies the wrap ----
+
+// prepareCommand is the universal choke point every start/restart/fork path
+// flows through. For a plain non-sandbox, non-wrapper claude session it returns
+// the command otherwise unchanged, so this asserts the feature is wired in, not
+// just that the helper exists.
+func TestExitToShell_PrepareCommandWiresInWrap(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	inst := NewInstanceWithTool("e2s-prepare", t.TempDir(), "claude")
+	inst.ExitToShell = boolPtr(true)
+
+	raw := inst.buildClaudeCommand("claude")
+	prepared, container, err := inst.prepareCommand(raw)
+	if err != nil {
+		t.Fatalf("prepareCommand: %v", err)
+	}
+	if container != "" {
+		t.Fatalf("non-sandbox session must not produce a container, got %q", container)
+	}
+	if !strings.HasSuffix(prepared, exitToShellSuffix) {
+		t.Fatalf("prepareCommand must apply the exit-to-shell wrap, got:\n%s", prepared)
+	}
+	if !strings.Contains(prepared, inst.ClaudeSessionID) {
+		t.Fatalf("prepared command lost session id %q, got:\n%s", inst.ClaudeSessionID, prepared)
+	}
+}
+
+func TestExitToShell_PrepareCommandUnchangedWhenDisabled(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	inst := NewInstanceWithTool("e2s-prepare-off", t.TempDir(), "claude")
+	// Flag OFF (default).
+
+	raw := inst.buildClaudeCommand("claude")
+	prepared, _, err := inst.prepareCommand(raw)
+	if err != nil {
+		t.Fatalf("prepareCommand: %v", err)
+	}
+	if strings.Contains(prepared, exitToShellSuffix) {
+		t.Fatalf("flag OFF must not wrap via prepareCommand, got:\n%s", prepared)
+	}
+}
+
+// --- Persistence: the per-session override round-trips through JSON ----------
+
+// The override lives on Instance (Storage.Save → Storage.Load uses json), so it
+// must survive a marshal/unmarshal cycle for restart to honor it.
+func TestExitToShell_OverridePersistsThroughJSON(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	inst := NewInstanceWithTool("e2s-persist", t.TempDir(), "claude")
+	inst.ExitToShell = boolPtr(true)
+
+	data, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatalf("json.Marshal(inst): %v", err)
+	}
+	if !strings.Contains(string(data), `"exit_to_shell":`) {
+		t.Fatalf("marshalled instance missing \"exit_to_shell\" json tag; got:\n%s", string(data))
+	}
+
+	revived := &Instance{}
+	if err := json.Unmarshal(data, revived); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if revived.ExitToShell == nil || !*revived.ExitToShell {
+		t.Fatalf("revived ExitToShell = %v, want true", revived.ExitToShell)
+	}
+	if !revived.exitToShellEnabled() {
+		t.Fatal("revived instance must still resolve exit-to-shell as enabled")
+	}
+}
+
+// --- Default-off contract via the global config (no override) ----------------
+
+// A session with no override and the default config must NOT wrap, even though
+// the tool is a built-in agent — proving the feature is genuinely opt-in.
+func TestExitToShell_GlobalDefaultIsOptIn(t *testing.T) {
+	exitToShellTestEnv(t)
+
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	if cfg.Shell.GetExitToShell() {
+		t.Fatal("default loaded config must have exit_to_shell OFF")
+	}
+
+	inst := NewInstanceWithTool("e2s-global-default", t.TempDir(), "claude")
+	if inst.exitToShellEnabled() {
+		t.Fatal("instance with no override under default config must be OFF")
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -679,6 +679,15 @@ type ShellSettings struct {
 	// IgnoreMissingEnvFiles silently ignores missing .env files (default: true)
 	// When false, sessions will error if an env_file doesn't exist
 	IgnoreMissingEnvFiles *bool `toml:"ignore_missing_env_files"`
+
+	// ExitToShell, when true, wraps built-in agent spawn commands so that
+	// exiting the agent (e.g. `/exit` from Claude Code) drops the pane back to
+	// an interactive shell at the same cwd instead of the pane dying / the TUI
+	// auto-restarting. This restores the pre-#503 workflow: exit → do shell-only
+	// work (aws-vault exec, direnv, …) → `claude --resume` the same session.
+	// Default: false (opt-in). Issue #1161, design doc
+	// docs/decisions/1161-exit-to-shell-then-resume.md.
+	ExitToShell *bool `toml:"exit_to_shell"`
 }
 
 // GetIgnoreMissingEnvFiles returns whether to ignore missing env files, defaulting to true
@@ -687,6 +696,15 @@ func (s *ShellSettings) GetIgnoreMissingEnvFiles() bool {
 		return true // Default: ignore missing files (fail-safe)
 	}
 	return *s.IgnoreMissingEnvFiles
+}
+
+// GetExitToShell returns whether agent sessions should fall back to an
+// interactive shell on agent exit, defaulting to false (opt-in). Issue #1161.
+func (s *ShellSettings) GetExitToShell() bool {
+	if s.ExitToShell == nil {
+		return false // Default: OFF (preserve current exit/resume behavior)
+	}
+	return *s.ExitToShell
 }
 
 // GetShowAnalytics returns whether to show analytics, defaulting to false

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -39,6 +39,7 @@ Shell environment configuration applied to all sessions.
 env_files = ["~/.agent-deck.env", ".env"]   # .env files to source for ALL sessions
 init_script = "~/.agent-deck/init.sh"       # Script or command to run before each session
 ignore_missing_env_files = true             # Silently skip missing .env files (default: true)
+exit_to_shell = false                       # Drop to an interactive shell when an agent exits (default: false)
 ```
 
 | Key | Type | Default | Description |
@@ -46,6 +47,7 @@ ignore_missing_env_files = true             # Silently skip missing .env files (
 | `env_files` | array of strings | `[]` | List of .env files to source for ALL sessions, in order. Later files override earlier ones. See [Path Resolution](#path-resolution). |
 | `init_script` | string | `""` | Shell script or inline command to run before each session. Useful for direnv, nvm, pyenv, etc. File paths (starting with `/`, `~/`, `./`, `../`) are sourced; anything else is treated as an inline command. |
 | `ignore_missing_env_files` | bool | `true` | When `true`, missing .env files are silently skipped using `[ -f file ] && source file`. When `false`, sessions will error if an env file doesn't exist. |
+| `exit_to_shell` | bool | `false` | When `true`, exiting a built-in agent (e.g. `/exit` from Claude Code) drops the pane back to an interactive shell at the same cwd instead of dying / auto-restarting. Lets you do shell-only work (`aws-vault exec`, `direnv`) then `claude --resume` the same session. Opt-in; the session id is preserved so resume targets the same conversation. Per-session override via the session record. Excludes sandboxed sessions. Issue #1161. |
 
 ### Sourcing order
 


### PR DESCRIPTION
## What & why

Restores the pre-#503 workflow requested by @Djeeteg007 in #1161:

1. Work in an agent session (Claude Code, etc.)
2. `/exit` → land in a **normal interactive shell at the same `cwd`**
3. Do shell-only work that must wrap a shell (`aws-vault exec …`, `direnv`, env-mutating subshells)
4. `claude --resume` (or agent-deck restart) → back in the **same** session with full context

PR #503 (`5d5cdf80`) made the agent the pane's **initial process** to skip the ~2s pane-ready poll. That removed the parent interactive `$SHELL` that used to survive `/exit`, so today exit + resume are fused into one round-trip with no shell gap.

## Approach — Option A (opt-in, default OFF)

Per the approved design doc [`docs/decisions/1161-exit-to-shell-then-resume.md`](../blob/fix/1161-exit-to-shell-then-resume/docs/decisions/1161-exit-to-shell-then-resume.md).

When the flag is on and the tool is a built-in agent, the spawn command is wrapped:

```
<agent cmd>; exec "$SHELL" -i        # note: NO `exec` before <agent cmd>
```

`wrapExitToShell` neutralizes the agent's own first `exec ` launcher (claude execs itself for job control, which would otherwise replace the wrapping bash and prevent the trailing shell exec from ever running) and appends `; exec "$SHELL" -i`. Agents that don't `exec` (gemini, codex, …) just get the suffix appended. The #503 fast path is preserved — sessions are still launched as the pane's initial process, so there's no reintroduced pane-ready poll.

Applied at the single `prepareCommand` choke point that every start / restart / fork path flows through, so the behavior is consistent (and resume parity is automatic) — gated so default users are byte-for-byte unaffected.

### Resume is preserved
`i.ClaudeSessionID` is captured **in Go** (`instance.go:821`) before the command string is built, then persisted to statedb. Wrapping the command can't break id capture; `--session-id`/`--resume` still targets the same conversation after the shell detour. Cross-checked against `conductor_restart_history_loss` — that learning was about empty ids on *custom-command* sessions; the standard agent launch path always populates the id.

## Config

```toml
[shell]
exit_to_shell = true   # default false (opt-in)
```

Plus a per-session override (`Instance.ExitToShell *bool`) that wins over the global flag and round-trips through statedb JSON. Sandboxed sessions and non-agent (`shell` / custom) tools are excluded.

## Surfaces

| Surface | Applies? | Coverage |
|---|---|---|
| **Persistence** (`internal/statedb` via Instance JSON) | yes | `TestExitToShell_OverridePersistsThroughJSON` (round-trips `exit_to_shell` tag + resolves enabled) |
| **Session/launch** (`internal/session`) | yes | full file below |
| **Cross-platform** | covered | uses `"$SHELL"` (bash-expanded inside the existing `bash -c` initial-process wrap); no OS-specific path handling added |
| **TUI** (`internal/ui`) | no new surface | flag is config/launch-level; with exit-to-shell the post-exit pane holds a **live** shell, so `Session.Exists()` is true and `IsPaneDead()` is false — the auto-restart arms at `home.go:6379`/`:6388` (which fire on dead/missing panes) naturally don't trigger. `enter` attaches to the live shell. No keybinding/panel change. Status-detection refinement (showing "agent exited" vs "running" for a trailing shell prompt) is a cosmetic follow-up noted in the design doc, not required for the workflow. |
| **Web UI** | no | `exit_to_shell` is not surfaced in any `/web/` session view (launch-behavior config only) |
| **CLI** | no new flag | configured via `config.toml`; per-session override set on the session record |
| **Remote** | partial | global `[shell] exit_to_shell` works on whichever host spawns the session (remote reads its own `config.toml`). Per-session-override propagation over the remote protocol is a follow-up. |

## Tests — `internal/session/issue1161_exit_to_shell_test.go`

Happy path · failure mode · boundary, all green:
- `ClaudeWrappedWhenEnabled` — flag ON wraps; agent is **not** exec'd
- `DisabledLeavesCommandUnchanged` — flag OFF is byte-for-byte unchanged (regression)
- `PreservesClaudeSessionID` — id captured + still on the command line (resume)
- `GeminiWrappedWhenEnabled` — boundary: tool that never uses `exec`
- `ShellToolNotWrapped` / `SandboxNotWrapped` / `EmptyCommandNoop` — failure modes
- `ConfigDefaultOff` / `GlobalDefaultIsOptIn` — opt-in contract
- `ResolutionPrecedence` — per-session override beats config
- `PrepareCommandWiresInWrap` / `PrepareCommandUnchangedWhenDisabled` — the actual spawn-path choke point

## Verification

- `go test -race ./internal/session/... ./internal/ui/...` → green
- `golangci-lint run` → 0 issues
- `govulncheck ./...` → 0 called vulnerabilities
- Flag default confirmed **OFF**

Closes #1161



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "exit-to-shell" option that allows agent sessions to drop into an interactive shell at the same working directory when the agent exits.
  * Can be configured globally or overridden per-session.
  * Feature is OFF by default and does not apply to non-agent tools or sandboxed sessions.

* **Tests**
  * Added comprehensive test suite for exit-to-shell behavior and configuration resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->