### PR TITLE
fix(remote): verify SHA-256 before deploy + enforce SSH host-key stance (security hardening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,11 @@ agent-deck remote update dev      # specific remote
 
 Remote configuration is stored under `[remotes]` in `~/.agent-deck/config.toml`. All `remote` subcommands support `--json` output for scripting. Run `agent-deck remote --help` for the full flag reference.
 
+#### Security
+
+- **SSH host-key stance.** agent-deck verifies remote host keys against your `~/.ssh/known_hosts` using OpenSSH's secure default — it never sets `StrictHostKeyChecking=no` and never points `UserKnownHostsFile` at `/dev/null`. Every connection (list, attach, deploy) runs with `BatchMode=yes`, so an **unknown or changed host key fails fast** with a clear `Host key verification failed` error instead of silently trusting the host or hanging on a prompt. Add each remote to `known_hosts` first (e.g. `ssh user@host` once interactively, or `ssh-keyscan`), and authenticate with keys/an agent (BatchMode disables interactive password prompts). A changed host key is treated as a potential MITM and refused until you resolve it.
+- **Verified binary deploys.** `agent-deck remote update` downloads the GitHub release archive and verifies its **SHA-256 against the release's published `checksums.txt`** before deploying. A missing `checksums.txt`, a missing entry, or a hash mismatch aborts the deploy — an unverified or tampered artifact is never piped to a remote.
+
 ### Reaching services running inside remote sessions
 
 If you run a dev server, REPL, or web UI inside a remote session and want to reach it from your local browser, use **[Tailscale](https://tailscale.com)** rather than ad-hoc SSH port forwarding. Tailscale gives every machine on your tailnet a direct IP, so a service on `localhost:3000` of your remote box is reachable at `http://<remote-tailnet-ip>:3000` from your laptop with no `-L`/`-R` setup, no port collisions when multiple sessions share a remote, and no ControlMaster edge cases.

--- a/cmd/agent-deck/remote_cmd.go
+++ b/cmd/agent-deck/remote_cmd.go
@@ -582,17 +582,13 @@ func installOnRemote(runner *session.SSHRunner, ctx context.Context) error {
 		return fmt.Errorf("failed to fetch release info: %w", err)
 	}
 
-	// Get download URL for the remote's platform
-	downloadURL := update.GetAssetURLForPlatform(release, goos, goarch)
-	if downloadURL == "" {
-		return fmt.Errorf("no release binary available for %s/%s", goos, goarch)
-	}
-
-	// Download and extract the binary
-	fmt.Printf("  Downloading %s/%s binary...\n", goos, goarch)
-	binaryData, err := update.DownloadAndExtractBinary(downloadURL)
+	// Download, verify SHA-256 against the release's checksums.txt, and extract.
+	// We NEVER pipe an unverified artifact to a remote: a missing checksums.txt,
+	// a missing entry, or a hash mismatch aborts the deploy (#1206).
+	fmt.Printf("  Downloading + verifying %s/%s binary...\n", goos, goarch)
+	binaryData, err := update.DownloadVerifiedBinary(release, goos, goarch)
 	if err != nil {
-		return fmt.Errorf("download failed: %w", err)
+		return fmt.Errorf("download/verify failed: %w", err)
 	}
 
 	// Deploy to remote and verify the remote actually runs the new version

--- a/internal/session/issue1206_remote_hostkey_test.go
+++ b/internal/session/issue1206_remote_hostkey_test.go
@@ -1,0 +1,124 @@
+package session
+
+// Regression tests for #1206 (security): the SSH transport had no documented
+// host-key stance and Attach() omitted the BatchMode/ConnectTimeout options the
+// other paths carried — an unknown/changed host key could hang on an
+// interactive prompt instead of failing fast. These tests pin:
+//   - the shared connection options never weaken host-key checking
+//     (no StrictHostKeyChecking=no, no /dev/null known_hosts),
+//   - BatchMode + ConnectTimeout are consistent across run AND attach,
+//   - a malicious ssh host (ssh option-injection via leading "-") is rejected.
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSSHConnOpts_SafeHostKeyStance(t *testing.T) {
+	r := &SSHRunner{Host: "user@host", AgentDeckPath: "agent-deck"}
+	opts := strings.Join(r.sshConnOpts(), " ")
+
+	// MITM holes that must NEVER be emitted.
+	if strings.Contains(opts, "StrictHostKeyChecking=no") {
+		t.Fatalf("sshConnOpts must never disable host-key checking: %s", opts)
+	}
+	if strings.Contains(opts, "/dev/null") {
+		t.Fatalf("sshConnOpts must never point known_hosts at /dev/null: %s", opts)
+	}
+	// Fail-fast, non-interactive stance must be present.
+	if !strings.Contains(opts, "BatchMode=yes") {
+		t.Fatalf("sshConnOpts must set BatchMode=yes for a clear non-interactive failure: %s", opts)
+	}
+	if !strings.Contains(opts, "ConnectTimeout=") {
+		t.Fatalf("sshConnOpts must bound the dial with ConnectTimeout: %s", opts)
+	}
+}
+
+func TestAttachArgs_ConsistentWithRunPath(t *testing.T) {
+	r := &SSHRunner{Host: "user@host", AgentDeckPath: "agent-deck"}
+	args := r.buildAttachArgs("sess123")
+	joined := strings.Join(args, " ")
+
+	// #1206 regression: Attach() used to omit BatchMode + ConnectTimeout.
+	if !strings.Contains(joined, "-tt") {
+		t.Fatalf("attach args must force a remote PTY with -tt: %s", joined)
+	}
+	if !strings.Contains(joined, "BatchMode=yes") {
+		t.Fatalf("attach must use BatchMode=yes for parity with run/stream paths: %s", joined)
+	}
+	if !strings.Contains(joined, "ConnectTimeout=") {
+		t.Fatalf("attach must bound the dial with ConnectTimeout: %s", joined)
+	}
+	if strings.Contains(joined, "StrictHostKeyChecking=no") || strings.Contains(joined, "/dev/null") {
+		t.Fatalf("attach must not weaken host-key checking: %s", joined)
+	}
+	// Still actually attaches to the requested session.
+	if !strings.Contains(joined, "session") || !strings.Contains(joined, "attach") || !strings.Contains(joined, "sess123") {
+		t.Fatalf("attach args must run `session attach sess123`: %s", joined)
+	}
+}
+
+func TestSSHBaseArgs_SafeHostKeyStance(t *testing.T) {
+	r := &SSHRunner{Host: "user@host", AgentDeckPath: "agent-deck"}
+	joined := strings.Join(r.sshBaseArgs("uname -s -m"), " ")
+	if strings.Contains(joined, "StrictHostKeyChecking=no") || strings.Contains(joined, "/dev/null") {
+		t.Fatalf("sshBaseArgs must not weaken host-key checking: %s", joined)
+	}
+	if !strings.Contains(joined, "BatchMode=yes") {
+		t.Fatalf("sshBaseArgs must set BatchMode=yes: %s", joined)
+	}
+}
+
+func TestValidateSSHHost(t *testing.T) {
+	good := []string{"user@host", "host", "deploy@10.0.0.1", "u@host.example.com"}
+	for _, h := range good {
+		if err := ValidateSSHHost(h); err != nil {
+			t.Errorf("ValidateSSHHost(%q) = %v, want nil", h, err)
+		}
+	}
+	bad := []string{
+		"",                    // empty
+		"-oProxyCommand=evil", // ssh option-injection
+		"-l root host",        // leading dash + whitespace
+		"host with space",     // whitespace
+		"host\nrm -rf",        // newline injection
+	}
+	for _, h := range bad {
+		if err := ValidateSSHHost(h); err == nil {
+			t.Errorf("ValidateSSHHost(%q) = nil, want rejection", h)
+		}
+	}
+}
+
+// A malicious host must be rejected by the real SSH exec paths BEFORE any ssh
+// subprocess is spawned. Stubs (runFn/remoteExecFn) are intentionally NOT set
+// so we hit the validation guard on the real path.
+func TestSSHRunner_RejectsOptionInjectionHost(t *testing.T) {
+	r := &SSHRunner{Host: "-oProxyCommand=touch /tmp/pwned", AgentDeckPath: "agent-deck"}
+
+	if _, err := r.run(context.Background(), "list", "--json"); err == nil {
+		t.Fatal("run() must reject an option-injection host before spawning ssh")
+	}
+	if _, err := r.remoteExec(context.Background(), "uname -s", nil); err == nil {
+		t.Fatal("remoteExec() must reject an option-injection host before spawning ssh")
+	}
+	if err := r.Attach("sess123"); err == nil {
+		t.Fatal("Attach() must reject an option-injection host before spawning ssh")
+	}
+}
+
+// buildRemoteCommand already shell-quotes every dynamic operand; pin it for a
+// malicious path/arg so command-injection into the remote shell stays closed.
+func TestBuildRemoteCommand_QuotesMaliciousPathAndArgs(t *testing.T) {
+	r := &SSHRunner{AgentDeckPath: "/bin/agent-deck; rm -rf ~", Profile: "default"}
+	got := r.buildRemoteCommand("rename", "id", "$(reboot)")
+	// The dangerous binary path must be single-quoted as one operand.
+	if !strings.Contains(got, "'/bin/agent-deck; rm -rf ~'") {
+		t.Fatalf("malicious agent_deck_path must be single-quoted: %s", got)
+	}
+	// Command substitution in an arg must be quoted, not left live.
+	if !strings.Contains(got, "'$(reboot)'") {
+		t.Fatalf("malicious arg must be single-quoted: %s", got)
+	}
+}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -82,18 +82,13 @@ func (r *SSHRunner) OpenStream(ctx context.Context, args ...string) (io.WriteClo
 	if r.openStreamFn != nil {
 		return r.openStreamFn(ctx, args...)
 	}
+	if err := ValidateSSHHost(r.Host); err != nil {
+		return nil, nil, err
+	}
 	_ = os.MkdirAll(sshControlDir, 0700)
 
 	remoteCmd := r.buildRemoteCommand(args...)
-	sshArgs := []string{
-		"-o", "ControlMaster=auto",
-		"-o", "ControlPath=" + sshControlDir + "/%r@%h:%p",
-		"-o", "ControlPersist=600",
-		"-o", "ConnectTimeout=10",
-		"-o", "BatchMode=yes",
-		r.Host,
-		remoteCmd,
-	}
+	sshArgs := r.sshBaseArgs(remoteCmd)
 
 	cmd := exec.CommandContext(ctx, "ssh", sshArgs...)
 	stdin, err := cmd.StdinPipe()
@@ -127,19 +122,13 @@ func (r *SSHRunner) run(ctx context.Context, args ...string) ([]byte, error) {
 	if r.runFn != nil {
 		return r.runFn(ctx, args...)
 	}
+	if err := ValidateSSHHost(r.Host); err != nil {
+		return nil, err
+	}
 	_ = os.MkdirAll(sshControlDir, 0700)
 
 	remoteCmd := r.buildRemoteCommand(args...)
-
-	sshArgs := []string{
-		"-o", "ControlMaster=auto",
-		"-o", "ControlPath=" + sshControlDir + "/%r@%h:%p",
-		"-o", "ControlPersist=600",
-		"-o", "ConnectTimeout=10",
-		"-o", "BatchMode=yes",
-		r.Host,
-		remoteCmd,
-	}
+	sshArgs := r.sshBaseArgs(remoteCmd)
 
 	cmd := exec.CommandContext(ctx, "ssh", sshArgs...)
 	var stdout, stderr bytes.Buffer
@@ -159,18 +148,12 @@ func (r *SSHRunner) run(ctx context.Context, args ...string) ([]byte, error) {
 // PTY in sync when the local terminal is resized, and sends SIGWINCH to
 // self on detach so Bubble Tea re-queries the terminal size.
 func (r *SSHRunner) Attach(sessionID string) error {
+	if err := ValidateSSHHost(r.Host); err != nil {
+		return err
+	}
 	_ = os.MkdirAll(sshControlDir, 0700)
 
-	remoteCmd := r.buildRemoteCommand("session", "attach", sessionID)
-
-	sshArgs := []string{
-		"-tt", // force remote PTY
-		"-o", "ControlMaster=auto",
-		"-o", "ControlPath=" + sshControlDir + "/%r@%h:%p",
-		"-o", "ControlPersist=600",
-		r.Host,
-		remoteCmd,
-	}
+	sshArgs := r.buildAttachArgs(sessionID)
 
 	cmd := exec.Command("ssh", sshArgs...)
 
@@ -414,6 +397,9 @@ func (r *SSHRunner) FetchCostSummary(ctx context.Context) (*costs.RemoteCostSumm
 
 // DetectPlatform returns the remote host's OS and architecture (e.g., "linux", "amd64").
 func (r *SSHRunner) DetectPlatform(ctx context.Context) (goos, goarch string, err error) {
+	if err := ValidateSSHHost(r.Host); err != nil {
+		return "", "", err
+	}
 	_ = os.MkdirAll(sshControlDir, 0700)
 
 	// Run uname on the remote to detect OS and machine architecture
@@ -466,6 +452,9 @@ const defaultRemoteInstallSubpath = ".local/bin/agent-deck"
 func (r *SSHRunner) remoteExec(ctx context.Context, remoteCmd string, stdin []byte) ([]byte, error) {
 	if r.remoteExecFn != nil {
 		return r.remoteExecFn(ctx, remoteCmd, stdin)
+	}
+	if err := ValidateSSHHost(r.Host); err != nil {
+		return nil, err
 	}
 	_ = os.MkdirAll(sshControlDir, 0700)
 
@@ -626,17 +615,64 @@ func (r *SSHRunner) InstallBinary(ctx context.Context, binaryData []byte, expect
 	return fmt.Errorf("post-deploy verification failed: remote does not report v%s at %s or on $PATH", want, path)
 }
 
-// sshBaseArgs returns common SSH args for running a raw command on the remote.
-func (r *SSHRunner) sshBaseArgs(remoteCmd string) []string {
+// sshConnOpts returns the SSH -o options shared by every connection agent-deck
+// makes. They are the single source of truth for agent-deck's host-key stance:
+//
+//   - Host-key checking is left at ssh's secure default. agent-deck NEVER passes
+//     StrictHostKeyChecking=no and NEVER points UserKnownHostsFile at /dev/null,
+//     so an unknown or changed host key surfaces ssh's "Host key verification
+//     failed" error (verified against the user's ~/.ssh/known_hosts) instead of
+//     being silently trusted — MITM protection.
+//   - BatchMode=yes makes that failure fast and non-interactive on EVERY path
+//     (run, stream, deploy, and attach), so an unknown key or a missing
+//     credential errors clearly instead of hanging on a prompt.
+//   - ConnectTimeout bounds the dial.
+//
+// See the README "Remote Instances" section for the documented assumption.
+func (r *SSHRunner) sshConnOpts() []string {
 	return []string{
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPath=" + sshControlDir + "/%r@%h:%p",
 		"-o", "ControlPersist=600",
 		"-o", "ConnectTimeout=10",
 		"-o", "BatchMode=yes",
-		r.Host,
-		remoteCmd,
 	}
+}
+
+// ValidateSSHHost rejects host strings ssh would misinterpret as options rather
+// than a destination. A host beginning with "-" (e.g. "-oProxyCommand=…") is
+// argument injection: passed as a discrete argv element, ssh parses it as a
+// flag and can be coerced into running an arbitrary local command. Whitespace
+// and empty hosts are rejected too. Hosts come from the user's own config, but
+// this closes the option-injection vector cheaply (#1206).
+func ValidateSSHHost(host string) error {
+	h := strings.TrimSpace(host)
+	if h == "" {
+		return fmt.Errorf("ssh host is empty")
+	}
+	if strings.HasPrefix(h, "-") {
+		return fmt.Errorf("invalid ssh host %q: must not begin with '-' (ssh would parse it as an option)", host)
+	}
+	if strings.ContainsAny(h, " \t\r\n") {
+		return fmt.Errorf("invalid ssh host %q: must not contain whitespace", host)
+	}
+	return nil
+}
+
+// sshBaseArgs returns common SSH args for running a raw command on the remote.
+func (r *SSHRunner) sshBaseArgs(remoteCmd string) []string {
+	return append(r.sshConnOpts(), r.Host, remoteCmd)
+}
+
+// buildAttachArgs builds the ssh argv for an interactive attach. It shares
+// sshConnOpts() with every other path so the host-key/BatchMode stance is
+// identical (#1206 regression: Attach() previously omitted BatchMode and
+// ConnectTimeout, so an unknown host key could hang on a prompt instead of
+// failing fast). "-tt" forces a remote PTY.
+func (r *SSHRunner) buildAttachArgs(sessionID string) []string {
+	remoteCmd := r.buildRemoteCommand("session", "attach", sessionID)
+	args := append([]string{"-tt"}, r.sshConnOpts()...)
+	return append(args, r.Host, remoteCmd)
 }
 
 // CreateSession creates and starts a new session on the remote, returning its ID.

--- a/internal/update/checksum.go
+++ b/internal/update/checksum.go
@@ -1,0 +1,139 @@
+package update
+
+// Release-asset integrity verification (#1206 security hardening).
+//
+// `agent-deck remote update` downloads a GitHub release asset and pipes it onto
+// every configured remote via `ssh "cat > path"`. HTTPS authenticates the
+// transport but not the artifact: a compromised release, a swapped asset, or a
+// TLS-stripping position can plant an arbitrary executable on every remote.
+// goreleaser publishes a `checksums.txt` (SHA-256, see .goreleaser.yml
+// `checksum.name_template`); we verify the downloaded archive against it and
+// fail closed — never deploying an unverified artifact.
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ChecksumsAssetName is the release asset goreleaser publishes containing the
+// SHA-256 of every archive (.goreleaser.yml `checksum.name_template`).
+const ChecksumsAssetName = "checksums.txt"
+
+// ParseChecksums parses a goreleaser checksums.txt body into a map of
+// filename -> lowercase hex SHA-256. Each non-blank line is
+// "<hex><space(s)><filename>"; a "*" binary-mode prefix on the filename
+// (as emitted by `sha256sum -b`) is tolerated and stripped.
+func ParseChecksums(data []byte) map[string]string {
+	out := map[string]string{}
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		sum := strings.ToLower(fields[0])
+		name := strings.TrimPrefix(fields[1], "*")
+		out[name] = sum
+	}
+	return out
+}
+
+// GetChecksumsURL returns the download URL of the release's checksums.txt asset,
+// or "" when the release publishes none (which callers must treat as a hard
+// failure — there is nothing to verify against).
+func GetChecksumsURL(release *Release) string {
+	if release == nil {
+		return ""
+	}
+	for _, a := range release.Assets {
+		if a.Name == ChecksumsAssetName {
+			return a.BrowserDownloadURL
+		}
+	}
+	return ""
+}
+
+// VerifyAssetChecksum fails closed: it returns an error unless assetName is
+// present in checksums AND the SHA-256 of archive matches it exactly. A missing
+// entry or a mismatch is a refusal to deploy, not a warning.
+func VerifyAssetChecksum(assetName string, archive []byte, checksums map[string]string) error {
+	want, ok := checksums[assetName]
+	if !ok || strings.TrimSpace(want) == "" {
+		return fmt.Errorf("no published SHA-256 checksum for %q in %s — refusing to deploy an unverified artifact", assetName, ChecksumsAssetName)
+	}
+	sum := sha256.Sum256(archive)
+	got := hex.EncodeToString(sum[:])
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("SHA-256 mismatch for %q: published %s, downloaded %s — refusing to deploy a tampered or corrupt artifact", assetName, want, got)
+	}
+	return nil
+}
+
+// assetArchiveName returns the goreleaser archive filename for a version+platform.
+// It mirrors the name template in .goreleaser.yml and the lookup in
+// GetAssetURLForPlatform, so the checksums.txt entry will be found.
+func assetArchiveName(release *Release, goos, goarch string) string {
+	version := strings.TrimPrefix(release.TagName, "v")
+	return fmt.Sprintf("agent-deck_%s_%s_%s.tar.gz", version, goos, goarch)
+}
+
+// httpGetBytes downloads url fully into memory under a bounded timeout.
+func httpGetBytes(url string, timeout time.Duration) ([]byte, error) {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// DownloadVerifiedBinary downloads the release archive for goos/goarch, verifies
+// its SHA-256 against the release's checksums.txt, then extracts and returns the
+// agent-deck binary bytes. It is the integrity gate for remote deploys and is
+// safe to reuse for local self-update. It fails closed: a missing platform
+// asset, a missing checksums.txt asset, an asset absent from checksums.txt, or a
+// hash mismatch all abort BEFORE any binary is returned.
+func DownloadVerifiedBinary(release *Release, goos, goarch string) ([]byte, error) {
+	if release == nil {
+		return nil, fmt.Errorf("nil release")
+	}
+	assetURL := GetAssetURLForPlatform(release, goos, goarch)
+	if assetURL == "" {
+		return nil, fmt.Errorf("no release binary available for %s/%s", goos, goarch)
+	}
+	checksumsURL := GetChecksumsURL(release)
+	if checksumsURL == "" {
+		return nil, fmt.Errorf("release %s publishes no %s — refusing to deploy an unverified artifact", release.TagName, ChecksumsAssetName)
+	}
+
+	archive, err := httpGetBytes(assetURL, 120*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download release archive: %w", err)
+	}
+	checksumsData, err := httpGetBytes(checksumsURL, 30*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download %s: %w", ChecksumsAssetName, err)
+	}
+
+	assetName := assetArchiveName(release, goos, goarch)
+	if err := VerifyAssetChecksum(assetName, archive, ParseChecksums(checksumsData)); err != nil {
+		return nil, err
+	}
+
+	return extractBinaryFromTarGzBytes(archive)
+}

--- a/internal/update/issue1206_remote_checksum_test.go
+++ b/internal/update/issue1206_remote_checksum_test.go
@@ -1,0 +1,210 @@
+package update
+
+// Regression tests for #1206 (security): `agent-deck remote update` deployed
+// release binaries to remotes with NO integrity check. These tests pin the
+// fail-closed SHA-256 verification gate: a matching checksum proceeds, a
+// mismatch or a missing checksum aborts WITHOUT returning a binary to deploy.
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// makeTarGz builds a goreleaser-style .tar.gz containing an `agent-deck` binary
+// with the given bytes, so DownloadVerifiedBinary can extract it.
+func makeTarGz(t *testing.T, binary []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name:     "agent-deck",
+		Mode:     0o755,
+		Size:     int64(len(binary)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("tar header: %v", err)
+	}
+	if _, err := tw.Write(binary); err != nil {
+		t.Fatalf("tar write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func sha256hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestParseChecksums_GoreleaserFormat(t *testing.T) {
+	// goreleaser checksums.txt: "<hex>  <filename>", optional "*" binary-mode
+	// prefix, blank lines tolerated.
+	body := "abc123  agent-deck_1.2.3_linux_amd64.tar.gz\n" +
+		"\n" +
+		"DEF456  *agent-deck_1.2.3_darwin_arm64.tar.gz\n"
+	got := ParseChecksums([]byte(body))
+	if got["agent-deck_1.2.3_linux_amd64.tar.gz"] != "abc123" {
+		t.Fatalf("linux entry = %q, want abc123", got["agent-deck_1.2.3_linux_amd64.tar.gz"])
+	}
+	// hex normalized to lowercase, "*" stripped.
+	if got["agent-deck_1.2.3_darwin_arm64.tar.gz"] != "def456" {
+		t.Fatalf("darwin entry = %q, want def456 (lowercased, * stripped)", got["agent-deck_1.2.3_darwin_arm64.tar.gz"])
+	}
+}
+
+func TestGetChecksumsURL(t *testing.T) {
+	rel := &Release{Assets: []Asset{
+		{Name: "agent-deck_1.2.3_linux_amd64.tar.gz", BrowserDownloadURL: "https://x/bin"},
+		{Name: "checksums.txt", BrowserDownloadURL: "https://x/checksums.txt"},
+	}}
+	if url := GetChecksumsURL(rel); url != "https://x/checksums.txt" {
+		t.Fatalf("GetChecksumsURL = %q, want the checksums.txt asset URL", url)
+	}
+	// Fail closed: no checksums asset → empty.
+	none := &Release{Assets: []Asset{{Name: "agent-deck_1.2.3_linux_amd64.tar.gz"}}}
+	if url := GetChecksumsURL(none); url != "" {
+		t.Fatalf("GetChecksumsURL with no checksums asset = %q, want empty", url)
+	}
+}
+
+func TestVerifyAssetChecksum_Match(t *testing.T) {
+	archive := []byte("the-archive-bytes")
+	sums := map[string]string{"asset.tar.gz": sha256hex(archive)}
+	if err := VerifyAssetChecksum("asset.tar.gz", archive, sums); err != nil {
+		t.Fatalf("matching checksum should pass, got: %v", err)
+	}
+}
+
+func TestVerifyAssetChecksum_Mismatch(t *testing.T) {
+	archive := []byte("the-archive-bytes")
+	sums := map[string]string{"asset.tar.gz": sha256hex([]byte("DIFFERENT"))}
+	err := VerifyAssetChecksum("asset.tar.gz", archive, sums)
+	if err == nil {
+		t.Fatal("mismatched checksum MUST return an error (fail closed), got nil")
+	}
+}
+
+func TestVerifyAssetChecksum_Missing(t *testing.T) {
+	archive := []byte("the-archive-bytes")
+	// asset absent from the checksums map → must fail closed.
+	err := VerifyAssetChecksum("asset.tar.gz", archive, map[string]string{})
+	if err == nil {
+		t.Fatal("missing checksum entry MUST return an error (fail closed), got nil")
+	}
+}
+
+// releaseServer spins up an httptest server hosting the archive and a
+// checksums.txt, returning a Release whose asset URLs point at it.
+func releaseServer(t *testing.T, archive, checksums []byte, includeChecksumsAsset bool) (*Release, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/agent-deck_1.2.3_linux_amd64.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	mux.HandleFunc("/checksums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(checksums)
+	})
+	srv := httptest.NewServer(mux)
+	rel := &Release{
+		TagName: "v1.2.3",
+		Assets: []Asset{
+			{Name: "agent-deck_1.2.3_linux_amd64.tar.gz", BrowserDownloadURL: srv.URL + "/agent-deck_1.2.3_linux_amd64.tar.gz"},
+		},
+	}
+	if includeChecksumsAsset {
+		rel.Assets = append(rel.Assets, Asset{Name: "checksums.txt", BrowserDownloadURL: srv.URL + "/checksums.txt"})
+	}
+	return rel, srv.Close
+}
+
+func TestDownloadVerifiedBinary_MatchingChecksumProceeds(t *testing.T) {
+	binary := []byte("ELF-agent-deck-binary")
+	archive := makeTarGz(t, binary)
+	checksums := []byte(sha256hex(archive) + "  agent-deck_1.2.3_linux_amd64.tar.gz\n")
+	rel, cleanup := releaseServer(t, archive, checksums, true)
+	defer cleanup()
+
+	got, err := DownloadVerifiedBinary(rel, "linux", "amd64")
+	if err != nil {
+		t.Fatalf("matching checksum should deploy, got error: %v", err)
+	}
+	if !bytes.Equal(got, binary) {
+		t.Fatalf("returned binary = %q, want extracted %q", got, binary)
+	}
+}
+
+func TestDownloadVerifiedBinary_MismatchedChecksumAborts(t *testing.T) {
+	binary := []byte("ELF-agent-deck-binary")
+	archive := makeTarGz(t, binary)
+	// Published checksum is for a DIFFERENT artifact → tampered/corrupt.
+	checksums := []byte(sha256hex([]byte("tampered")) + "  agent-deck_1.2.3_linux_amd64.tar.gz\n")
+	rel, cleanup := releaseServer(t, archive, checksums, true)
+	defer cleanup()
+
+	got, err := DownloadVerifiedBinary(rel, "linux", "amd64")
+	if err == nil {
+		t.Fatal("mismatched checksum MUST abort the deploy, got nil error")
+	}
+	if got != nil {
+		t.Fatalf("on mismatch no binary may be returned, got %d bytes", len(got))
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "mismatch") {
+		t.Fatalf("error should name the SHA-256 mismatch, got: %v", err)
+	}
+}
+
+func TestDownloadVerifiedBinary_MissingChecksumsAssetAborts(t *testing.T) {
+	binary := []byte("ELF-agent-deck-binary")
+	archive := makeTarGz(t, binary)
+	// Release publishes NO checksums.txt asset → cannot verify → fail closed.
+	rel, cleanup := releaseServer(t, archive, nil, false)
+	defer cleanup()
+
+	got, err := DownloadVerifiedBinary(rel, "linux", "amd64")
+	if err == nil {
+		t.Fatal("a release without checksums.txt MUST abort the deploy (fail closed), got nil error")
+	}
+	if got != nil {
+		t.Fatalf("no binary may be returned when checksums are unavailable, got %d bytes", len(got))
+	}
+}
+
+func TestDownloadVerifiedBinary_AssetNotInChecksumsAborts(t *testing.T) {
+	binary := []byte("ELF-agent-deck-binary")
+	archive := makeTarGz(t, binary)
+	// checksums.txt exists but lists a different filename → our asset is unverified.
+	checksums := []byte(sha256hex(archive) + "  agent-deck_1.2.3_windows_amd64.tar.gz\n")
+	rel, cleanup := releaseServer(t, archive, checksums, true)
+	defer cleanup()
+
+	if _, err := DownloadVerifiedBinary(rel, "linux", "amd64"); err == nil {
+		t.Fatal("an asset absent from checksums.txt MUST abort the deploy (fail closed), got nil error")
+	}
+}
+
+// Ensure the verified path computes the same archive name the download path
+// fetches, so a real release's checksums entry will be found.
+func TestAssetArchiveName_MatchesAssetURL(t *testing.T) {
+	rel := &Release{TagName: "v1.2.3", Assets: []Asset{
+		{Name: "agent-deck_1.2.3_linux_amd64.tar.gz", BrowserDownloadURL: "https://x/a"},
+	}}
+	name := fmt.Sprintf("agent-deck_%s_%s_%s.tar.gz", "1.2.3", "linux", "amd64")
+	if GetAssetURLForPlatform(rel, "linux", "amd64") == "" {
+		t.Fatalf("asset URL lookup failed for computed name %q", name)
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -3,6 +3,7 @@ package update
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
@@ -382,35 +383,6 @@ func FetchReleaseByTag(tag string) (*Release, error) {
 	}
 
 	return &release, nil
-}
-
-// DownloadAndExtractBinary downloads a release tarball and returns the binary bytes.
-func DownloadAndExtractBinary(downloadURL string) ([]byte, error) {
-	client := &http.Client{Timeout: 120 * time.Second}
-	resp, err := client.Get(downloadURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
-	}
-
-	tmpFile, err := os.CreateTemp("", "agent-deck-update-*.tar.gz")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file: %w", err)
-	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
-
-	if _, err = io.Copy(tmpFile, resp.Body); err != nil {
-		tmpFile.Close()
-		return nil, fmt.Errorf("failed to save download: %w", err)
-	}
-	tmpFile.Close()
-
-	return extractBinaryFromTarGz(tmpPath)
 }
 
 // CompareVersions compares two semantic versions
@@ -800,15 +772,27 @@ func FormatChangelogForDisplay(entries []ChangelogEntry) string {
 	return sb.String()
 }
 
-// extractBinaryFromTarGz extracts the agent-deck binary from a .tar.gz file
+// extractBinaryFromTarGz extracts the agent-deck binary from a .tar.gz file.
 func extractBinaryFromTarGz(tarPath string) ([]byte, error) {
 	file, err := os.Open(tarPath)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
+	return extractBinaryFromTarGzReader(file)
+}
 
-	gzr, err := gzip.NewReader(file)
+// extractBinaryFromTarGzBytes extracts the agent-deck binary from an in-memory
+// .tar.gz, used by the verified-download path so the archive bytes can be
+// SHA-256'd before extraction (#1206).
+func extractBinaryFromTarGzBytes(data []byte) ([]byte, error) {
+	return extractBinaryFromTarGzReader(bytes.NewReader(data))
+}
+
+// extractBinaryFromTarGzReader extracts the agent-deck binary from a gzipped
+// tar stream.
+func extractBinaryFromTarGzReader(r io.Reader) ([]byte, error) {
+	gzr, err := gzip.NewReader(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #1206. Closes the two remote-path security gaps identified in the remote-feature assessment (KEEP + HARDEN, §2/§3/§5/§6). Security hardening — fail-closed, regression-tested.

## GAP 1 (highest severity) — unverified binary deploy

`agent-deck remote update` downloaded a GitHub release asset (`installOnRemote` → `DownloadAndExtractBinary`) and piped it onto **every configured remote** via `ssh "cat > path"` with **zero integrity check** (`internal/update` had no sha256 references). A tampered/MITM'd or corrupt asset got deployed and made executable on the remote.

**Fix:** new `internal/update/checksum.go` adds a fail-closed SHA-256 gate. `DownloadVerifiedBinary(release, goos, goarch)`:
1. resolves the platform archive URL + the release's goreleaser-published `checksums.txt` URL,
2. downloads both, computes the archive's sha256, compares against the published entry,
3. **only then** extracts the binary.

A missing `checksums.txt` asset, a missing entry for our archive, or a hash mismatch **aborts the deploy** — no unverified artifact ever reaches a remote. `installOnRemote` now calls it. The old unverified `DownloadAndExtractBinary` helper is **removed** (internal pkg, no external consumers) so the gap can't be reintroduced.

## GAP 2 — undefined SSH host-key stance

The transport used `BatchMode=yes`/`ConnectTimeout` on run/stream/deploy but **`Attach()` omitted both** — an unknown/changed host key could hang on an interactive prompt instead of failing fast.

**Fix:** centralized every ssh invocation's `-o` options in `SSHRunner.sshConnOpts()` (single enforcement point):
- Host-key checking left at ssh's **secure default** — never `StrictHostKeyChecking=no`, never `/dev/null` known_hosts — so an unknown/changed key surfaces `Host key verification failed` (checked against `~/.ssh/known_hosts`) instead of silent trust.
- `BatchMode=yes` + `ConnectTimeout` now **consistent across run, stream, deploy AND attach**.
- Documented in README → Remote Instances → **Security**.

## Scan findings (prompt's "also scan" items)

- **ssh option-injection (fixed):** a remote host beginning with `-` (e.g. `-oProxyCommand=…`), passed as a discrete argv element, is parsed by ssh as a *flag*. New `ValidateSSHHost` rejects leading-dash/whitespace/empty hosts before any ssh subprocess spawns, on every real exec path (`run`, `OpenStream`, `remoteExec`, `DetectPlatform`, `Attach`).
- **insert-mode hex wire protocol (`T <hex>`/`N <name>`/`E`) — confirmed safe:** text is hex-encoded (arbitrary bytes round-trip), named keys reject newlines (no wire-protocol line injection), and the stream feeds a remote `agent-deck session send-keys --stream` process over the authenticated SSH stdin pipe — never `sh -c`. Operates only on the user's own sessions.
- **No `StrictHostKeyChecking=no` / `UserKnownHostsFile=/dev/null` exists anywhere** — confirmed and pinned with regression guards.

## Surfaces & tests

| Surface | Test file | Covers |
|---|---|---|
| **Remote / internal/update** | `internal/update/issue1206_remote_checksum_test.go` | happy (match → proceeds), failure (mismatch → abort, no binary), boundary (missing checksums.txt, asset-not-in-checksums → fail closed); parse + URL-lookup units |
| **Remote / internal/session** | `internal/session/issue1206_remote_hostkey_test.go` | conn-opts never weaken host-key checking; attach parity with run (BatchMode/ConnectTimeout); option-injection host rejected on real paths; malicious path/arg stays shell-quoted |
| **CLI** (`cmd/agent-deck/remote_cmd.go`) | covered via `installOnRemote` → `DownloadVerifiedBinary` (the gated path) | — |

Surfaces not applicable: **TUI / Web UI / Persistence** — this PR touches the SSH transport + release-asset integrity only; no session record, web route, or rendered view changes.

## Verification

- `go test -race -count=1 ./internal/update/... ./internal/session/... ./cmd/agent-deck/...` — **green**
- `golangci-lint run` (changed pkgs) — **0 issues**
- `govulncheck ./...` — **No vulnerabilities found**
- grep-confirmed no `StrictHostKeyChecking=no` / `/dev/null` known_hosts in any code path

## Follow-up (out of scope, same class)

Local self-update (`update.PerformUpdate`) still downloads without checksum verification (assessment §3). The `DownloadVerifiedBinary` primitive added here is ready to reuse for it — tracked separately to keep this PR scoped to the remote-deploy gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Binary integrity verification using SHA-256 checksums for secure remote deployments
  * SSH host validation to prevent malicious argument injection

* **Bug Fixes**
  * Remote deployments now require checksum verification before installation; unverified artifacts are rejected
  * Hardened SSH connections to prevent host-key weakening and option-injection attacks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->