### PR TITLE
fix(web): re-baseline parity guards + wire skills-service in fixture + add json tags to ProjectSkillAttachment

### DIFF
--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -73,15 +73,21 @@ type SkillCandidate struct {
 }
 
 // ProjectSkillAttachment is persisted in .agent-deck/skills.toml.
+//
+// The json tags are required for the web API: without them encoding/json
+// ignores the toml tags and falls back to the exported field names, emitting
+// PascalCase (`Name`) instead of the `name` the frontend + e2e tests read.
+// Tag style mirrors the sibling SkillCandidate so both skill types serialize
+// consistently across the /api/skills surface.
 type ProjectSkillAttachment struct {
-	ID         string `toml:"id"`
-	Name       string `toml:"name"`
-	Source     string `toml:"source"`
-	SourcePath string `toml:"source_path"`
-	EntryName  string `toml:"entry_name"`
-	TargetPath string `toml:"target_path"` // relative to project path
-	Mode       string `toml:"mode,omitempty"`
-	AttachedAt string `toml:"attached_at,omitempty"`
+	ID         string `toml:"id" json:"id"`
+	Name       string `toml:"name" json:"name"`
+	Source     string `toml:"source" json:"source"`
+	SourcePath string `toml:"source_path" json:"source_path"`
+	EntryName  string `toml:"entry_name" json:"entry_name"`
+	TargetPath string `toml:"target_path" json:"target_path"` // relative to project path
+	Mode       string `toml:"mode,omitempty" json:"mode,omitempty"`
+	AttachedAt string `toml:"attached_at,omitempty" json:"attached_at,omitempty"`
 }
 
 // ProjectSkillsManifest is the project-local attachment state.

--- a/internal/session/skills_catalog_test.go
+++ b/internal/session/skills_catalog_test.go
@@ -1,12 +1,45 @@
 package session
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+// TestProjectSkillAttachment_JSONTags guards the web-API contract: the struct
+// must serialize with explicit json keys (lowercase), not Go's PascalCase
+// field-name fallback. Without json tags, /api/sessions/{id}/skills emits
+// {"Name":...} while the frontend + e2e tests read s.name, silently breaking
+// the skills pane. See internal/web/handlers_skills.go.
+func TestProjectSkillAttachment_JSONTags(t *testing.T) {
+	att := ProjectSkillAttachment{
+		ID: "pool/alpha", Name: "alpha", Source: "pool",
+		SourcePath: "/src/alpha", EntryName: "alpha",
+		TargetPath: ".claude/skills/alpha",
+	}
+	raw, err := json.Marshal(att)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, bad := got["Name"]; bad {
+		t.Fatalf("ProjectSkillAttachment marshaled PascalCase key \"Name\" — missing json tags: %s", raw)
+	}
+	if got["name"] != "alpha" {
+		t.Fatalf("expected json key \"name\"=alpha, got: %s", raw)
+	}
+	for _, key := range []string{"id", "source", "source_path", "entry_name", "target_path"} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("expected json key %q in output: %s", key, raw)
+		}
+	}
+}
 
 func setupSkillTestEnv(t *testing.T) (string, func()) {
 	t.Helper()

--- a/tests/web/PARITY_MATRIX.md
+++ b/tests/web/PARITY_MATRIX.md
@@ -40,10 +40,10 @@ Every keyboard action in the TUI that mutates state or navigates must have a web
 | List MCPs | `internal/ui/home.go:5965` (`m` key → MCPDialog) | GET `/api/sessions/{id}/mcps` | `MCPManager.ListAttached` | `handlers_mcps_test.go` | Returns `{local,global,user}`; catalog at GET `/api/mcps` |
 | Toggle pooled ↔ local | `internal/ui/home.go:5965` (`m` key → MCPDialog) | PATCH `/api/sessions/{id}/mcps/{name}` | `MCPManager.Move` | `handlers_mcps_test.go` | Body `{scope}` or `{pooled:bool}`; pooled=true→global, pooled=false→local |
 | **SKILLS MANAGEMENT** |
-| Attach skill | `internal/ui/home.go:6015` (`s` key → SkillDialog) | `POST /api/sessions/{id}/skills/{name}` | `apiFetch('POST', …)` from `SkillsPane.js` | `tests/web/e2e/skills.spec.js` | Wired via `web.SkillsService`; writes project config |
-| Detach skill | `internal/ui/home.go:6015` (`s` key → SkillDialog) | `DELETE /api/sessions/{id}/skills/{name}` | `apiFetch('DELETE', …)` from `SkillsPane.js` | `tests/web/e2e/skills.spec.js` | Wired via `web.SkillsService` |
-| List skills (catalog) | `internal/ui/home.go:6015` (`s` key → SkillDialog) | `GET /api/skills` | `SkillsPane.js` catalog column | `tests/web/e2e/skills.spec.js` | Mirrors `session.ListAvailableSkills` |
-| List skills (attached) | `internal/ui/home.go:6015` (`s` key → SkillDialog) | `GET /api/sessions/{id}/skills` | `SkillsPane.js` attached column | `tests/web/e2e/skills.spec.js` | Mirrors `session.GetAttachedProjectSkills(projectPath)` |
+| Attach skill | `internal/ui/home.go:6015` (`s` key → SkillDialog) | POST `/api/sessions/{id}/skills/{name}` | `apiFetch('POST', …)` from `SkillsPane.js` | `tests/web/e2e/skills.spec.js` | Wired via `web.SkillsService`; writes project config |
+| Detach skill | `internal/ui/home.go:6015` (`s` key → SkillDialog) | DELETE `/api/sessions/{id}/skills/{name}` | `apiFetch('DELETE', …)` from `SkillsPane.js` | `tests/web/e2e/skills.spec.js` | Wired via `web.SkillsService` |
+| List skills (catalog) | `internal/ui/home.go:6015` (`s` key → SkillDialog) | GET `/api/skills` | `SkillsPane.js` catalog column | `tests/web/e2e/skills.spec.js` | Mirrors `session.ListAvailableSkills` |
+| List skills (attached) | `internal/ui/home.go:6015` (`s` key → SkillDialog) | GET `/api/sessions/{id}/skills` | `SkillsPane.js` attached column | `tests/web/e2e/skills.spec.js` | Mirrors `session.GetAttachedProjectSkills(projectPath)` |
 | **SETTINGS & DISPLAY** |
 | Edit session settings | `internal/ui/home.go:5953` (`P`/`shift+p` → EditSessionDialog) | MISSING | `SetField` (indirect) | N/A | Title, color, notes, tool options, channels |
 | Edit multi-repo paths | `internal/ui/home.go:5942` (`p` → EditPathsDialog) | MISSING | N/A | N/A | Multi-repo session paths |
@@ -94,8 +94,8 @@ Every observable session field shown in the TUI must appear in the web API JSON 
 | `last_accessed_at` | Info section | `MenuSession.lastAccessedAt` | ✅ Present |
 | **RELATIONSHIPS** |
 | `parent_session_id` | Sub-session indicator | `MenuSession.parentSessionId` + `GET /api/sessions/{id}/children` | ✅ Present; tree endpoint surfaces full conductor child topology in the right-rail Children card (`internal/web/handlers_children.go`, `tests/web/e2e/children-panel.spec.js`) |
-| `is_conductor` | (Not shown in TUI) | MISSING | Conductor metadata; tree exposure now lives at `GET /api/sessions/{id}/children` (kind derived UI-side from title/groupPath in `dataModel.js`) |
-| `is_conductor` | (Not shown in TUI) | `MenuSession.isConductor` | ✅ Present; conductor metadata || **PROCESS STATE** |
+| `is_conductor` | (Not shown in TUI) | `MenuSession.isConductor` | ✅ Present; conductor metadata. Tree topology also surfaced at `GET /api/sessions/{id}/children` (kind derived UI-side from title/groupPath in `dataModel.js`) |
+| **PROCESS STATE** |
 | `tmux_session` | Internal reference | `MenuSession.tmuxSession` | ✅ Present (tmux session name) |
 | `tmux_socket_name` | (Internal) | `MenuSession.tmuxSocketName` | ✅ Present; issue #687 |
 | **TOOL-SPECIFIC** |

--- a/tests/web/e2e/parity-actions.spec.js
+++ b/tests/web/e2e/parity-actions.spec.js
@@ -19,8 +19,15 @@ const MATRIX = loadMatrix()
 // Pinned row counts. If the matrix grows or shrinks, these MUST be updated
 // in the same PR — the failure is the point.
 const EXPECTED_ACTION_ROWS = 48
-// Decremented from 9 to 8 in PR #1126: "Finish worktree" promoted out of MISSING.
-const EXPECTED_PROBEABLE_MISSING = 8
+// Probeable = MISSING rows that inferMissingProbe() maps to a URL. Decremented
+// as endpoints land and their matrix rows flip MISSING → Present:
+//   15 (PR-A #804) → 9 (#1124 skills+MCP, 6 closed) → 7 (#1129 Close + Undo
+//   Delete, 2 closed) → 6 (#1126/#1153 Finish worktree, 1 closed).
+// #1129 flipped the close/undelete rows but missed this decrement (9→7), so the
+// pin was stuck 2 high and the suite went red on every later PR. Re-baselined to
+// the true count: Restart fresh, Rename session, Move session to group, Edit
+// session settings, Edit notes inline, Mark session unread.
+const EXPECTED_PROBEABLE_MISSING = 6
 
 test.describe.configure({ mode: 'serial' })
 

--- a/tests/web/fixtures/cmd/web-fixture/main.go
+++ b/tests/web/fixtures/cmd/web-fixture/main.go
@@ -65,6 +65,11 @@ func main() {
 	})
 	server.SetMutator(store)
 	server.SetMCPManager(newFixtureMCPManager())
+	// Without this, GET /api/skills falls back to defaultSkillsService, which
+	// scans the host's real ~/.agent-deck/skills + ~/.claude/skills via
+	// session.ListAvailableSkills() — so the seeded alpha/beta/gamma catalog is
+	// never served and skills.spec.js fails (empty/host-dependent catalog).
+	server.SetSkillsService(store)
 
 	// Wrap the server's handler with the fixture admin endpoints so tests can
 	// reset and inspect state without going through the real Go test harness.


### PR DESCRIPTION
Fixes the 5-day-red Playwright web suite. Three root causes, all addressed; no `.github/workflows` touched.

## 1. Re-baseline parity guards (test-only, not weakened)
- `parity-actions.spec.js`: `EXPECTED_PROBEABLE_MISSING` was stuck at **8**. #1129 flipped the Close/Undo-Delete rows MISSING→Present but missed the decrement. True count is **6** (Restart fresh, Rename session, Move session to group, Edit session settings, Edit notes inline, Mark session unread). `EXPECTED_ACTION_ROWS` stays 48.
- `PARITY_MATRIX.md`: removed a duplicate `is_conductor` row and repaired a merged `**PROCESS STATE**` divider that had inflated the state-field count. The matrix now yields **45 state rows / 42 present**, matching `parity-state.spec.js`'s pins (which were already correct).
- Verified via the `helpers/parity-matrix.js` parser: action=48, probeable-missing=6, state=45, present=42 — all match the pinned guards.

## 2. Wire `server.SetSkillsService(store)` in the web-fixture
#1122 added `SkillsService` but the fixture (`tests/web/fixtures/cmd/web-fixture/main.go`) never injected it, so `GET /api/skills` fell back to `defaultSkillsService` → real-disk discovery, serving a host-dependent catalog instead of the seeded `alpha/beta/gamma`.

## 3. PRODUCTION FIX — `json` tags on `ProjectSkillAttachment`
The struct carried only `toml:` tags, so `encoding/json` fell back to exported field names and the attached-skills API emitted PascalCase (`Name`) while the frontend (`SkillsPane.js`) + e2e tests read `s.name`. Added `json:` tags mirroring the sibling `SkillCandidate` so both serialize consistently across the `/api/skills` surface. **The API now emits lowercase json keys.** Added a Go regression test (`TestProjectSkillAttachment_JSONTags`) asserting the marshaled shape has no `Name` key and `name` is present.

## Verification
- `go test ./internal/web/... ./internal/session/...` — **PASS** (includes new json-tag test).
- golangci-lint — clean on changed files.
- Playwright (`parity-actions`, `parity-state`, `skills` via `run-e2e.mjs`, `--workers=1`): **246 passed**. All parity tests green; all API-level skills tests green (directly exercise the `s.name` json-tag fix; skills failures dropped ~54 → 9).
- The 9 remaining failures are the `skills.spec.js` **UI**-navigation tests, which time out in `gotoSkills` at `waitForSelector('.sess')` — the page snapshot shows the 4 seeded session rows render but are **not visible** (sidebar collapsed in the headless test viewport). This is a pre-existing browser-env/viewport issue upstream of all three fixes (none touch `.sess` rendering or sidebar visibility), not a regression from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API response field naming to use lowercase snake_case format expected by client applications.

* **Tests**
  * Added validation for API response format compliance.
  * Updated test fixtures to ensure proper service configuration for end-to-end testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->