### PR TITLE
fix(launch-subagent): inherit parent session group by default

### DIFF
--- a/skills/agent-deck/scripts/launch-subagent.sh
+++ b/skills/agent-deck/scripts/launch-subagent.sh
@@ -71,6 +71,7 @@ CURRENT_JSON=$(agent-deck session current --json 2>/dev/null | grep -v '^20')
 PARENT=$(echo "$CURRENT_JSON" | jq -r '.session')
 PROFILE=$(echo "$CURRENT_JSON" | jq -r '.profile')
 PARENT_PATH=$(echo "$CURRENT_JSON" | jq -r '.path')
+PARENT_GROUP=$(echo "$CURRENT_JSON" | jq -r '.group // empty')
 
 if [ -z "$PARENT" ] || [ "$PARENT" = "null" ]; then
     echo "Error: Not in an agent-deck session" >&2
@@ -90,6 +91,7 @@ mkdir -p "$WORK_DIR"
 
 # Launch session and send initial prompt in one command
 LAUNCH_CMD=(agent-deck -p "$PROFILE" launch "$WORK_DIR" -t "$TITLE" --parent "$PARENT" -c "$TOOL" -m "$PROMPT")
+[ -n "$PARENT_GROUP" ] && LAUNCH_CMD+=(-g "$PARENT_GROUP")
 for mcp in "${MCPS[@]}"; do
     LAUNCH_CMD+=(--mcp "$mcp")
 done


### PR DESCRIPTION
## Problem

When a sub-agent is spawned via `launch-subagent.sh` from a session that belongs to a specific group, the new session lands in the default group instead. This makes it hard to find the sub-agent alongside its parent in the TUI — they end up in different groups.

Example: parent session is in group `"Others"`, spawned sub-agent lands in `"clement.petit"` (the profile default).

## Root cause

The script already calls `agent-deck session current --json`, which includes the `group` field. It reads `session`, `profile`, and `path` from that JSON, but never reads `group`, so `-g` is never passed to `agent-deck launch`.

## Fix

Extract the parent session's group from the existing JSON call and pass it to `agent-deck launch` with `-g` when present.

```diff
+PARENT_GROUP=$(echo "$CURRENT_JSON" | jq -r '.group // empty')
 
 LAUNCH_CMD=(agent-deck -p "$PROFILE" launch "$WORK_DIR" -t "$TITLE" --parent "$PARENT" -c "$TOOL" -m "$PROMPT")
+[ -n "$PARENT_GROUP" ] && LAUNCH_CMD+=(-g "$PARENT_GROUP")
```

The `// empty` guard means sessions with no group set are unaffected.

## Test plan

- [ ] Spawn a sub-agent from a session in a named group; confirm the sub-agent lands in the same group
- [ ] Spawn a sub-agent from a session with no group; confirm behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Example of a sub-agent launched from the group "Others" and configured to keep the parent group, vs another agent also launched from "Others", but which doesn't respect the parent group.

<img width="243" height="90" alt="Screenshot 2026-05-28 at 12 37 25" src="https://github.com/user-attachments/assets/916c28a6-3cdc-445d-ba1c-5bffb52e765f" />


## Summary by CodeRabbit

* **Features**
  * Sub-agent launches now inherit group context from parent sessions, enabling consistent configuration across related agent instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->