### PR TITLE
feat(session): kernel-exact task-worker completion + wake (replaces poll-inference for task workers)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -338,6 +338,9 @@ func main() {
 		case "notify-daemon":
 			handleNotifyDaemon(args[1:])
 			return
+		case "run-task":
+			handleRunTask(args[1:])
+			return
 		case "inbox":
 			handleInbox(args[1:])
 			return

--- a/cmd/agent-deck/notify_daemon_cmd.go
+++ b/cmd/agent-deck/notify_daemon_cmd.go
@@ -5,11 +5,18 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
+
+// versionCheckInterval is how often the always-on daemon re-reads the on-disk
+// binary version to decide whether it should recycle (issue #1214 STEP 1).
+const versionCheckInterval = 60 * time.Second
 
 // handleNotifyDaemon runs the always-on transition notifier daemon.
 func handleNotifyDaemon(args []string) {
@@ -40,8 +47,75 @@ func handleNotifyDaemon(args []string) {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
+	// STEP 1 (issue #1214): never run stale code. The transition-notifier unit
+	// is Restart=always, so cleanly exiting on a binary upgrade guarantees the
+	// supervisor brings the daemon back on the current binary — the 20-day
+	// stale window becomes impossible. RuntimeMaxSec in the unit file is the
+	// belt-and-suspenders backstop for environments without this watcher.
+	go watchBinaryVersion(ctx, cancel)
+
 	if err := daemon.Run(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "notify-daemon error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// watchBinaryVersion periodically compares the running binary's compiled-in
+// version against the version of the binary currently on disk; on a mismatch it
+// cancels the daemon context so it exits cleanly and the supervisor restarts it
+// fresh. Recycling only on a definite mismatch (ShouldRecycleForVersion ignores
+// empty/unknown versions) means a transient read failure never flaps the daemon.
+func watchBinaryVersion(ctx context.Context, cancel context.CancelFunc) {
+	ticker := time.NewTicker(versionCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			onDisk := readOnDiskVersion()
+			if session.ShouldRecycleForVersion(Version, onDisk) {
+				fmt.Fprintf(os.Stderr, "notify-daemon: binary upgraded (running %s, on-disk %s); recycling\n", Version, onDisk)
+				cancel()
+				return
+			}
+		}
+	}
+}
+
+// readOnDiskVersion runs the current executable path with `version` and parses
+// the semver token. After an in-place upgrade the path holds the new bytes while
+// this process still runs the old inode, so this reads the NEW version. Returns
+// "" on any failure (treated as "unknown" -> no recycle).
+func readOnDiskVersion() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	out, err := exec.Command(exe, "version").Output()
+	if err != nil {
+		return ""
+	}
+	return parseAgentDeckVersion(string(out))
+}
+
+// parseAgentDeckVersion extracts the version token from a writeVersionOutput
+// line, e.g. "Agent Deck v1.9.42 (update available: v1.9.43)" -> "1.9.42".
+func parseAgentDeckVersion(s string) string {
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		s = s[:i]
+	}
+	const marker = "Agent Deck v"
+	_, rest, ok := strings.Cut(s, marker)
+	if !ok {
+		return ""
+	}
+	end := len(rest)
+	for i, r := range rest {
+		if r == ' ' || r == '(' {
+			end = i
+			break
+		}
+	}
+	return strings.TrimSpace(rest[:end])
 }

--- a/cmd/agent-deck/notify_daemon_version_test.go
+++ b/cmd/agent-deck/notify_daemon_version_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+// Issue #1214 STEP 1: the daemon parses the on-disk binary's `version` output
+// to decide whether to recycle. Pin the parse so a format change can't silently
+// disable the staleness guard.
+func TestParseAgentDeckVersion(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Agent Deck v1.9.42\n", "1.9.42"},
+		{"Agent Deck v1.9.42 (update available: v1.9.43)\n", "1.9.42"},
+		{"Agent Deck v1.9.42", "1.9.42"},
+		{"Agent Deck v1.10.0 (update available: v1.11.0)\nextra\n", "1.10.0"},
+		{"garbage output", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := parseAgentDeckVersion(c.in); got != c.want {
+			t.Errorf("parseAgentDeckVersion(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/cmd/agent-deck/runtask_cmd.go
+++ b/cmd/agent-deck/runtask_cmd.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// handleRunTask is the task-worker completion wrapper (issue #1214). It runs a
+// ONE-SHOT worker command to completion, captures the kernel exit exactly once,
+// writes a durable completion record, and wakes the child's parent exactly once.
+//
+// It is tool-agnostic: the command after `--` is run verbatim, so any tool that
+// can run one-shot and exit works (claude -p, codex exec, a shell script, ...).
+// The child id and profile are taken from the pane environment that agent-deck
+// already injects (AGENTDECK_INSTANCE_ID / AGENTDECK_PROFILE), so a session can
+// opt in with nothing more than:
+//
+//	--wrapper "agent-deck run-task -- {command}"
+//
+// Flags override the env for non-pane callers and tests.
+//
+// Usage: agent-deck run-task [--child ID] [--profile P] [--title T] -- <cmd> [args...]
+func handleRunTask(args []string) {
+	flagArgs := args
+	var cmdArgs []string
+	for i, a := range args {
+		if a == "--" {
+			flagArgs = args[:i]
+			cmdArgs = args[i+1:]
+			break
+		}
+	}
+
+	child, profile, title := "", "", ""
+	for i := 0; i < len(flagArgs); i++ {
+		switch flagArgs[i] {
+		case "--child":
+			if i+1 < len(flagArgs) {
+				child = flagArgs[i+1]
+				i++
+			}
+		case "--profile":
+			if i+1 < len(flagArgs) {
+				profile = flagArgs[i+1]
+				i++
+			}
+		case "--title":
+			if i+1 < len(flagArgs) {
+				title = flagArgs[i+1]
+				i++
+			}
+		case "-h", "--help":
+			runTaskUsage()
+			return
+		}
+	}
+
+	if child == "" {
+		child = os.Getenv("AGENTDECK_INSTANCE_ID")
+	}
+	if profile == "" {
+		profile = os.Getenv("AGENTDECK_PROFILE")
+	}
+	if profile == "" {
+		profile = session.DefaultProfile
+	}
+	if title == "" {
+		title = os.Getenv("AGENTDECK_TITLE")
+	}
+
+	// Same path-traversal guard the hook handler uses on the instance id.
+	if child == "" || !validInstanceID.MatchString(child) || strings.Contains(child, "..") {
+		fmt.Fprintln(os.Stderr, "run-task: missing or invalid child id (set AGENTDECK_INSTANCE_ID or pass --child)")
+		os.Exit(2)
+	}
+	if len(cmdArgs) == 0 {
+		runTaskUsage()
+		os.Exit(2)
+	}
+
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) //nolint:gosec // wrapper deliberately runs the operator-provided one-shot command
+	cmd.Stdin = os.Stdin
+
+	rec, err := session.RunTaskWorker(child, profile, title, cmd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "run-task: %v\n", err)
+	}
+
+	// Active wake on the exit edge. On success the durable record is acked so
+	// the daemon's replay never double-fires; on a down/unresolvable parent it
+	// stays unacked and the daemon replays it when the parent returns.
+	n := session.NewTransitionNotifier()
+	defer n.Close()
+	if n.DeliverCompletion(rec) {
+		_ = session.AckCompletion(profile, child)
+	}
+
+	// Mirror the worker's exit status so callers/tmux see the real outcome.
+	if rec.ExitCode > 0 {
+		os.Exit(rec.ExitCode)
+	}
+}
+
+func runTaskUsage() {
+	fmt.Println("Usage: agent-deck run-task [--child ID] [--profile P] [--title T] -- <command> [args...]")
+	fmt.Println()
+	fmt.Println("Run a one-shot task worker under the completion wrapper: the worker")
+	fmt.Println("exits when done, the kernel exit is captured exactly once, a durable")
+	fmt.Println("completion record is written, and the parent session is woken once.")
+	fmt.Println()
+	fmt.Println("child/profile default to $AGENTDECK_INSTANCE_ID / $AGENTDECK_PROFILE.")
+	fmt.Println()
+	fmt.Println("Example (set as a session wrapper):")
+	fmt.Println("  agent-deck add -c claude --wrapper \"agent-deck run-task -- {command}\" .")
+}

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -1572,6 +1572,12 @@ Environment=HOME=__HOME__
 WantedBy=default.target
 `
 
+// systemdTransitionNotifierServiceTemplate runs the always-on completion
+// notifier. RuntimeMaxSec (issue #1214 STEP 1) bounds how long any single
+// daemon process can live: combined with Restart=always it forces a periodic
+// recycle onto the current binary, so the daemon can never run stale code even
+// if the in-process version watcher is somehow bypassed. The watcher recycles
+// promptly on upgrade; this is the backstop.
 const systemdTransitionNotifierServiceTemplate = `[Unit]
 Description=Agent Deck Transition Notifier
 After=network.target
@@ -1581,6 +1587,7 @@ Type=simple
 ExecStart=__AGENT_DECK__ notify-daemon
 Restart=always
 RestartSec=5
+RuntimeMaxSec=86400
 WorkingDirectory=__HOME__
 StandardOutput=append:__LOG_PATH__
 StandardError=append:__LOG_PATH__

--- a/internal/session/issue1214_systemd_test.go
+++ b/internal/session/issue1214_systemd_test.go
@@ -1,0 +1,20 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #1214 STEP 1: the transition-notifier unit must keep a hard recycle
+// backstop (RuntimeMaxSec) on top of Restart=always so the daemon can never run
+// stale code even if the in-process version watcher is bypassed. Guard the
+// template so a future edit can't silently drop the backstop.
+func TestSystemdTransitionNotifierHasRecycleBackstop(t *testing.T) {
+	tmpl := systemdTransitionNotifierServiceTemplate
+	if !strings.Contains(tmpl, "RuntimeMaxSec=") {
+		t.Fatalf("transition-notifier unit lost its RuntimeMaxSec recycle backstop:\n%s", tmpl)
+	}
+	if !strings.Contains(tmpl, "Restart=always") {
+		t.Fatalf("transition-notifier unit must still Restart=always so the recycle brings it back:\n%s", tmpl)
+	}
+}

--- a/internal/session/taskworker.go
+++ b/internal/session/taskworker.go
@@ -1,0 +1,331 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Issue #1214: kernel-exact task-worker completion.
+//
+// A conductor that dispatches a discrete task does not need a persistent
+// interactive pane — it needs a worker that does the task and reports back. Run
+// that worker ONE-SHOT (e.g. `claude -p "<task>"`, `codex exec`, any command
+// that exits when done) under the thin wrapper below. When the worker process
+// EXITS, the kernel delivers that edge exactly once via cmd.Wait(); the wrapper
+// parses the last #1186 sentinel (last-wins), writes a durable completion
+// record, and wakes the parent's live session exactly once through the existing
+// notifier (parent resolution + busy-defer queue + inbox reused verbatim).
+//
+// This is the structural replacement for poll-inference done-detection on the
+// task-worker path: exactly-once is the kernel's guarantee, not something the
+// daemon reconstructs with a freshness window and multi-layer dedup. The
+// daemon's Stop-hook/sentinel path is kept INTACT for persistent INTERACTIVE
+// sessions, which never exit; see emitDoneSignals' completion-record guard.
+//
+// The mechanism is tool-agnostic: the wrapper runs whatever command it is
+// handed and only depends on the #1186 sentinel contract, not on claude.
+
+// CompletionRecord is the durable, atomically-written record a task-worker
+// wrapper produces. A record with an empty Status is a "claim" written when the
+// worker starts (so the daemon suppresses poll-inference for the whole run,
+// closing the race against the worker's own Stop hook); it is finalized to
+// ok|fail on exit.
+type CompletionRecord struct {
+	ChildID    string    `json:"child_id"`
+	Profile    string    `json:"profile"`
+	Title      string    `json:"title,omitempty"`
+	Status     string    `json:"status"` // "" = pending; "ok" | "fail" = finished
+	Summary    string    `json:"summary,omitempty"`
+	ExitCode   int       `json:"exit_code"`
+	CreatedAt  time.Time `json:"created_at"`
+	FinishedAt time.Time `json:"finished_at,omitzero"`
+	Acked      bool      `json:"acked"`
+}
+
+func completionsDir() (string, error) {
+	dir, err := GetAgentDeckDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "runtime", "completions"), nil
+}
+
+// safeRecordName keeps a child id usable as a single path segment, defending the
+// completions directory against traversal from an unexpected id value.
+func safeRecordName(childID string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, childID)
+	if cleaned == "" {
+		return "_"
+	}
+	return cleaned
+}
+
+func completionRecordPath(childID string) (string, error) {
+	dir, err := completionsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, safeRecordName(childID)+".json"), nil
+}
+
+// WriteCompletionRecord persists a record atomically (tmp + rename).
+func WriteCompletionRecord(rec CompletionRecord) error {
+	if strings.TrimSpace(rec.ChildID) == "" {
+		return errors.New("completion record: empty child id")
+	}
+	path, err := completionRecordPath(rec.ChildID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func readCompletionRecord(childID string) (CompletionRecord, bool) {
+	path, err := completionRecordPath(childID)
+	if err != nil {
+		return CompletionRecord{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return CompletionRecord{}, false
+	}
+	var rec CompletionRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return CompletionRecord{}, false
+	}
+	return rec, true
+}
+
+// CompletionRecordExists reports whether a wrapper has claimed/finished the
+// given child under the given profile. The daemon uses it to stand down from
+// poll-inference: if the kernel-exit path owns this child, the Stop-hook path
+// must not also fire.
+func CompletionRecordExists(profile, childID string) bool {
+	rec, ok := readCompletionRecord(childID)
+	if !ok {
+		return false
+	}
+	return rec.Profile == profile
+}
+
+// LoadCompletionRecords returns every record for the given profile.
+func LoadCompletionRecords(profile string) ([]CompletionRecord, error) {
+	dir, err := completionsDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []CompletionRecord
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var rec CompletionRecord
+		if err := json.Unmarshal(data, &rec); err != nil {
+			continue
+		}
+		if rec.Profile != profile {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+// AckCompletion marks a record delivered so replay never re-fires it.
+func AckCompletion(profile, childID string) error {
+	rec, ok := readCompletionRecord(childID)
+	if !ok || rec.Profile != profile {
+		return nil
+	}
+	if rec.Acked {
+		return nil
+	}
+	rec.Acked = true
+	return WriteCompletionRecord(rec)
+}
+
+// deriveCompletion turns captured worker output + exit code into a finished
+// record. The #1186 sentinel wins when present (last-wins via ScanDoneSentinel);
+// otherwise the exit code decides — a one-shot worker that exits 0 finished its
+// task, a non-zero exit without an assertion is a failure, not a silent success.
+func deriveCompletion(childID, profile, title, output string, exitCode int) CompletionRecord {
+	rec := CompletionRecord{
+		ChildID:    childID,
+		Profile:    profile,
+		Title:      title,
+		ExitCode:   exitCode,
+		CreatedAt:  time.Now(),
+		FinishedAt: time.Now(),
+	}
+	if sig, ok := ScanDoneSentinel(output); ok {
+		rec.Status = sig.Status
+		rec.Summary = sig.Summary
+		return rec
+	}
+	if exitCode == 0 {
+		rec.Status = "ok"
+	} else {
+		rec.Status = "fail"
+	}
+	return rec
+}
+
+// RunTaskWorker runs the one-shot worker command to completion. It claims the
+// child first (so the daemon suppresses poll-inference for the whole run),
+// blocks on the kernel exit via cmd.Run/Wait (exactly-once by construction),
+// derives the completion from captured output + exit code, and writes the
+// finalized durable record. It does NOT itself wake the parent — that is the
+// caller's (DeliverCompletion) so the same record can be replayed if the parent
+// is down. The worker's own non-zero exit is recorded, not returned as an
+// error; a returned error means the wrapper itself failed (record write, etc.).
+func RunTaskWorker(childID, profile, title string, cmd *exec.Cmd) (CompletionRecord, error) {
+	// Claim: an empty-Status record present for the whole run.
+	_ = WriteCompletionRecord(CompletionRecord{
+		ChildID:   childID,
+		Profile:   profile,
+		Title:     title,
+		CreatedAt: time.Now(),
+	})
+
+	var buf bytes.Buffer
+	if cmd.Stdout == nil {
+		cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
+	} else {
+		cmd.Stdout = io.MultiWriter(cmd.Stdout, &buf)
+	}
+	if cmd.Stderr == nil {
+		cmd.Stderr = io.MultiWriter(os.Stderr, &buf)
+	} else {
+		cmd.Stderr = io.MultiWriter(cmd.Stderr, &buf)
+	}
+
+	runErr := cmd.Run()
+	exitCode := 0
+	if runErr != nil {
+		var ee *exec.ExitError
+		if errors.As(runErr, &ee) {
+			exitCode = ee.ExitCode()
+		} else {
+			// Command could not be started/found: treat as a failed task.
+			exitCode = -1
+		}
+	}
+
+	rec := deriveCompletion(childID, profile, title, buf.String(), exitCode)
+	if err := WriteCompletionRecord(rec); err != nil {
+		return rec, err
+	}
+	return rec, nil
+}
+
+// DeliverCompletion wakes the child's parent with a [DONE] event and reports
+// whether the wake was accepted into the delivery system (sent, or deferred to
+// the retry queue/inbox for a busy parent). A dropped/failed result — e.g. the
+// parent (conductor) is down or unresolvable — returns false so the durable
+// record stays unacked for replay. Pending (unfinished) records are ignored.
+func (n *TransitionNotifier) DeliverCompletion(rec CompletionRecord) bool {
+	if strings.TrimSpace(rec.Status) == "" {
+		return false // still running; nothing to deliver
+	}
+	return n.deliverFinishedSync(TransitionNotificationEvent{
+		ChildSessionID: rec.ChildID,
+		ChildTitle:     rec.Title,
+		Profile:        rec.Profile,
+		DoneStatus:     rec.Status,
+		DoneSummary:    rec.Summary,
+		Timestamp:      time.Now(),
+	})
+}
+
+// deliverFinishedSync is the synchronous sibling of NotifyFinished. The wrapper
+// is a short-lived process about to exit, so it cannot rely on the async send
+// goroutine; this resolves the parent and sends inline, reusing prepareDispatch
+// for parent resolution, conductor/orphan suppression, and the busy-defer queue.
+func (n *TransitionNotifier) deliverFinishedSync(event TransitionNotificationEvent) bool {
+	event.Kind = transitionKindFinished
+	event.Profile = strings.TrimSpace(event.Profile)
+	event.ChildTitle = strings.TrimSpace(event.ChildTitle)
+	event.ChildSessionID = strings.TrimSpace(event.ChildSessionID)
+	event.DoneStatus = strings.ToLower(strings.TrimSpace(event.DoneStatus))
+	event.DoneSummary = strings.TrimSpace(event.DoneSummary)
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+	if event.ChildSessionID == "" || event.Profile == "" {
+		return false
+	}
+	if isConductorSessionTitle(event.ChildTitle) {
+		return false
+	}
+
+	plan := n.prepareDispatch(event)
+	if plan.finalized {
+		n.logEvent(plan.event)
+		// Busy parent: enqueued to the retry queue/inbox -> accepted.
+		return plan.event.DeliveryResult == transitionDeliveryDeferred
+	}
+
+	send := n.sender
+	if send == nil {
+		send = SendSessionMessageReliable
+	}
+	e := plan.event
+	if err := send(event.Profile, plan.event.TargetSessionID, plan.message); err != nil {
+		e.DeliveryResult = transitionDeliveryFailed
+		n.logEvent(e)
+		return false
+	}
+	e.DeliveryResult = transitionDeliverySent
+	n.logEvent(e)
+	return true
+}
+
+// ShouldRecycleForVersion reports whether a long-lived daemon should exit so
+// the supervisor restarts it on a freshly-upgraded binary. STEP 1 of issue
+// #1214: the transition-notifier unit is Restart=always, so a clean exit on a
+// version change guarantees it never keeps running 20-day-stale code. It only
+// recycles on a definite mismatch — empty/unknown versions never trigger a flap.
+func ShouldRecycleForVersion(running, onDisk string) bool {
+	r := strings.TrimSpace(running)
+	d := strings.TrimSpace(onDisk)
+	if r == "" || d == "" {
+		return false
+	}
+	return r != d
+}

--- a/internal/session/taskworker_test.go
+++ b/internal/session/taskworker_test.go
@@ -1,0 +1,247 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Issue #1214: kernel-exact task-worker completion. A worker dispatched to do a
+// discrete task is run ONE-SHOT through a thin wrapper. When it EXITS, the
+// kernel delivers that edge exactly once (cmd.Wait), the wrapper parses the last
+// #1186 sentinel (last-wins), writes a durable completion record, and wakes the
+// parent's live session exactly once. Restart-safe: an unacked record is
+// replayed once on the next daemon pass and never double-fires.
+//
+// These tests pin the four spike-proven properties (exactly-once, last-wins,
+// idle-wake, restart-safe) plus the daemon-staleness version guard. They are
+// written test-first: every symbol below must compile-fail on pre-#1214 code.
+
+// seedChildOnly persists ONLY the child (its parent row absent), modelling the
+// "parent process down at completion" state for the restart-durability test.
+func seedChildOnly(t *testing.T, profile, parentID string) (childID string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+	if err := os.MkdirAll(home+"/.agent-deck", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	defer storage.Close()
+	child := &Instance{
+		ID:              "child-worker-1214",
+		Title:           "worker",
+		ProjectPath:     "/tmp/c1214",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: parentID,
+		Tool:            "claude",
+		Status:          StatusWaiting,
+		CreatedAt:       time.Now(),
+	}
+	if err := storage.SaveWithGroups([]*Instance{child}, nil); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	return child.ID
+}
+
+// addParentRow saves the parent conductor alongside the existing child so the
+// next delivery attempt resolves a live parent (the conductor "came back up").
+func addParentRow(t *testing.T, profile, parentID, childID string) {
+	t.Helper()
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer storage.Close()
+	parent := &Instance{
+		ID:          parentID,
+		Title:       "conductor-1214",
+		ProjectPath: "/tmp/p1214",
+		GroupPath:   DefaultGroupPath,
+		Tool:        "claude",
+		Status:      StatusIdle,
+		CreatedAt:   time.Now(),
+	}
+	child := &Instance{
+		ID:              childID,
+		Title:           "worker",
+		ProjectPath:     "/tmp/c1214",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: parentID,
+		Tool:            "claude",
+		Status:          StatusWaiting,
+		CreatedAt:       time.Now(),
+	}
+	if err := storage.SaveWithGroups([]*Instance{parent, child}, nil); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+}
+
+// --- Property 1: exactly-once active wake of an idle parent ------------------
+
+func TestTaskWorker_DeliverCompletion_WakesIdleParentExactlyOnce(t *testing.T) {
+	profile := "_test-1214-deliver-once"
+	parentID, childID := seedDoneParentChild(t, profile)
+
+	n := NewTransitionNotifier()
+	t.Cleanup(n.Close)
+	var sent atomic.Int32
+	var gotTarget, gotMsg string
+	n.sender = func(_ /*profile*/, targetID, message string) error {
+		sent.Add(1)
+		gotTarget, gotMsg = targetID, message
+		return nil
+	}
+
+	rec := CompletionRecord{
+		ChildID: childID,
+		Profile: profile,
+		Title:   "worker",
+		Status:  "ok",
+		Summary: "feature shipped",
+	}
+	if !n.DeliverCompletion(rec) {
+		t.Fatalf("DeliverCompletion returned not-delivered for a live parent")
+	}
+	if got := sent.Load(); got != 1 {
+		t.Fatalf("idle parent woken %d times, want exactly 1", got)
+	}
+	if gotTarget != parentID {
+		t.Errorf("woke %q, want parent %q", gotTarget, parentID)
+	}
+	if !strings.Contains(gotMsg, "[DONE]") || !strings.Contains(gotMsg, "status=ok") {
+		t.Errorf("wake message missing done outcome: %q", gotMsg)
+	}
+}
+
+// --- Property 2: last-wins sentinel parse + exit-derived fallback -----------
+
+func TestTaskWorker_DeriveCompletion_LastWinsAndExitFallback(t *testing.T) {
+	out := "starting\n" +
+		"===AGENTDECK_DONE=== status=fail summary=transient retry\n" +
+		"retrying\n" +
+		"===AGENTDECK_DONE=== status=ok summary=done at last\n"
+	rec := deriveCompletion("c", "p", "worker", out, 0)
+	if rec.Status != "ok" || rec.Summary != "done at last" {
+		t.Fatalf("last-wins failed: status=%q summary=%q", rec.Status, rec.Summary)
+	}
+
+	// No sentinel + non-zero exit => fail (a worker that crashed without
+	// asserting is a failed task, not a silent success).
+	rec = deriveCompletion("c", "p", "worker", "boom\n", 2)
+	if rec.Status != "fail" {
+		t.Fatalf("non-zero exit without sentinel: status=%q, want fail", rec.Status)
+	}
+	if rec.ExitCode != 2 {
+		t.Fatalf("exit code not captured: %d", rec.ExitCode)
+	}
+
+	// No sentinel + clean exit => ok (a one-shot worker that exits 0 finished).
+	rec = deriveCompletion("c", "p", "worker", "all good\n", 0)
+	if rec.Status != "ok" {
+		t.Fatalf("clean exit without sentinel: status=%q, want ok", rec.Status)
+	}
+}
+
+// --- Property 3: kernel exit captured exactly once via cmd.Wait -------------
+
+func TestTaskWorker_RunTaskWorker_CapturesSentinelAndExit(t *testing.T) {
+	profile := "_test-1214-run"
+	_, childID := seedDoneParentChild(t, profile)
+
+	cmd := exec.Command("sh", "-c",
+		"echo working; echo '===AGENTDECK_DONE=== status=ok summary=built it'; exit 0")
+	rec, err := RunTaskWorker(childID, profile, "worker", cmd)
+	if err != nil {
+		t.Fatalf("RunTaskWorker: %v", err)
+	}
+	if rec.Status != "ok" || rec.Summary != "built it" {
+		t.Fatalf("captured completion wrong: %+v", rec)
+	}
+	if !CompletionRecordExists(profile, childID) {
+		t.Fatalf("durable completion record not written for %s", childID)
+	}
+	recs, err := LoadCompletionRecords(profile)
+	if err != nil {
+		t.Fatalf("LoadCompletionRecords: %v", err)
+	}
+	if len(recs) != 1 || recs[0].ChildID != childID || recs[0].Acked {
+		t.Fatalf("record not durable+unacked: %+v", recs)
+	}
+}
+
+// --- Property 4: restart-safe replay — no miss, no double-wake --------------
+
+func TestTaskWorker_ReplayUnacked_DeliversOncePerChildAcrossRestart(t *testing.T) {
+	profile := "_test-1214-replay"
+	parentID := "parent-conductor-1214"
+	childID := seedChildOnly(t, profile, parentID)
+
+	// Wrapper finished while the parent (conductor) was DOWN: durable record
+	// written, but no live parent to wake yet.
+	if err := WriteCompletionRecord(CompletionRecord{
+		ChildID: childID, Profile: profile, Title: "worker",
+		Status: "ok", Summary: "done while parent down", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteCompletionRecord: %v", err)
+	}
+
+	d := NewTransitionDaemon()
+	var sent atomic.Int32
+	d.notifier.sender = func(_, _, _ string) error { sent.Add(1); return nil }
+	t.Cleanup(d.notifier.Close)
+
+	// Parent still down: replay must NOT deliver (record stays unacked).
+	d.ReplayUnackedCompletions(profile)
+	d.notifier.Flush()
+	if got := sent.Load(); got != 0 {
+		t.Fatalf("parent down: woke %d times, want 0", got)
+	}
+
+	// Conductor restarts (parent row resolvable again).
+	addParentRow(t, profile, parentID, childID)
+
+	// First replay after restart delivers exactly once.
+	d.ReplayUnackedCompletions(profile)
+	d.notifier.Flush()
+	if got := sent.Load(); got != 1 {
+		t.Fatalf("after restart: woke %d times, want exactly 1", got)
+	}
+
+	// Subsequent replays must NOT re-fire (record is acked).
+	d.ReplayUnackedCompletions(profile)
+	d.notifier.Flush()
+	if got := sent.Load(); got != 1 {
+		t.Fatalf("no-double-wake: woke %d times after re-replay, want 1", got)
+	}
+}
+
+// --- STEP 1: daemon never goes stale — version recycle guard ----------------
+
+func TestShouldRecycleForVersion(t *testing.T) {
+	cases := []struct {
+		running, onDisk string
+		want            bool
+	}{
+		{"1.9.42", "1.9.43", true},  // upgraded on disk -> recycle
+		{"1.9.42", "1.9.42", false}, // same -> keep running
+		{"", "1.9.43", false},       // unknown running -> never recycle (avoid flap)
+		{"1.9.42", "", false},       // unknown on-disk -> never recycle
+		{" 1.9.42 ", "1.9.42", false},
+	}
+	for _, c := range cases {
+		if got := ShouldRecycleForVersion(c.running, c.onDisk); got != c.want {
+			t.Errorf("ShouldRecycleForVersion(%q,%q)=%v want %v", c.running, c.onDisk, got, c.want)
+		}
+	}
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -98,11 +98,37 @@ func (d *TransitionDaemon) SyncOnce(_ context.Context) time.Duration {
 		if interval < nextInterval {
 			nextInterval = interval
 		}
+		// Issue #1214: replay any durable task-worker completion record whose
+		// parent was down/busy when the worker exited. Restart-safe and
+		// exactly-once via the record's Acked flag.
+		d.ReplayUnackedCompletions(profile)
 	}
 
 	d.maybeSweepInboxTTL()
 
 	return nextInterval
+}
+
+// ReplayUnackedCompletions re-delivers durable task-worker completion records
+// (issue #1214) that have not yet been acknowledged — the wrapper wrote the
+// record but no live parent was reachable to wake (conductor down/busy at exit).
+// On a successful wake the record is acked so it never fires again. This is the
+// restart-durability half of the kernel-exit mechanism: a completion that
+// happened while the conductor was offline is delivered exactly once when it
+// returns, with no double-wake.
+func (d *TransitionDaemon) ReplayUnackedCompletions(profile string) {
+	recs, err := LoadCompletionRecords(profile)
+	if err != nil {
+		return
+	}
+	for _, rec := range recs {
+		if rec.Acked || strings.TrimSpace(rec.Status) == "" {
+			continue
+		}
+		if d.notifier.DeliverCompletion(rec) {
+			_ = AckCompletion(rec.Profile, rec.ChildID)
+		}
+	}
 }
 
 // maybeSweepInboxTTL invokes SweepInboxByTTL when more than
@@ -250,6 +276,17 @@ func (d *TransitionDaemon) emitDoneSignals(profile string, byID map[string]*Inst
 	notifyEnabled := GetNotificationsSettings().GetTransitionEventsEnabled()
 	for id, hs := range hookStatuses {
 		if hs == nil || strings.TrimSpace(hs.DoneStatus) == "" {
+			continue
+		}
+		// Issue #1214: a task worker run one-shot under the completion wrapper
+		// owns its own done signal via the kernel-exit path (cmd.Wait ->
+		// durable record -> active wake). Stand down from poll-inference for it
+		// — the freshness window + lastDone dedup that simulate exactly-once
+		// over a polled file are exactly what the kernel exit replaces. The
+		// claim record exists for the whole run, so this also wins the race
+		// against the worker's own Stop hook. Interactive sessions (no record)
+		// keep the path below unchanged.
+		if CompletionRecordExists(profile, id) {
 			continue
 		}
 		if !hs.UpdatedAt.IsZero() && time.Since(hs.UpdatedAt) > hookFreshWindow {
@@ -433,6 +470,12 @@ func (d *TransitionDaemon) emitHookTransitionCandidates(
 	for id, candidate := range candidates {
 		inst := byID[id]
 		if !notifyEnabled || !instanceAcceptsTransitionEvents(inst) {
+			continue
+		}
+		// Issue #1214: the completion wrapper owns a task worker's terminal
+		// signal; suppress poll-inferred candidates for it. Interactive
+		// sessions (no completion record) are unaffected.
+		if CompletionRecordExists(profile, id) {
 			continue
 		}
 

--- a/tests/capability/issue1214_taskworker_test.go
+++ b/tests/capability/issue1214_taskworker_test.go
@@ -1,0 +1,116 @@
+//go:build capability_e2e
+
+package capability
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #1214: kernel-exact task-worker completion. A worker dispatched to do a
+// discrete task is run ONE-SHOT under `agent-deck run-task`. When the worker
+// EXITS, the kernel delivers that edge exactly once (cmd.Wait); the wrapper
+// parses the last #1186 sentinel (last-wins), writes a durable completion
+// record, and wakes the child's parent exactly once via the notifier.
+//
+// This drives the REAL compiled binary end to end (run-task -> worker subprocess
+// -> kernel exit -> durable record -> notifier emission). It asserts on the two
+// durable artifacts a conductor relies on: the completion record and the single
+// finished-event emission. Successful live-pane DELIVERY of the [DONE] line into
+// a running conductor pane is the unit-tested notifier seam (internal/session),
+// mirroring the boundary stated by TestCapability_Conductor_FinishedSignal.
+//
+// Surfaces: CLI (run-task) + Persistence (completion record + transition log) +
+// Cross-platform (os/exec + cmd.Wait). The mechanism is tool-agnostic — the
+// worker here is a plain shell command, proving run-task is not claude-specific.
+
+// runTask invokes the real `agent-deck run-task` wrapper with the child id in
+// the env exactly as a launched pane would have it, running the given one-shot
+// worker command. Returns combined output (best effort) and any wrapper error.
+func (c *capSandbox) runTask(t *testing.T, childID string, worker ...string) (string, error) {
+	t.Helper()
+	args := append([]string{"run-task", "--child", childID, "--"}, worker...)
+	cmd := exec.Command(c.BinPath, args...)
+	cmd.Env = append(c.Env(), "AGENTDECK_INSTANCE_ID="+childID, "AGENTDECK_PROFILE=default")
+	cmd.Dir = c.Home
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func (c *capSandbox) completionRecord(t *testing.T, childID string) (map[string]any, bool) {
+	t.Helper()
+	path := filepath.Join(c.Home, ".agent-deck", "runtime", "completions", childID+".json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	var rec map[string]any
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		t.Fatalf("parse completion record: %v\nraw: %s", err, raw)
+	}
+	return rec, true
+}
+
+func (c *capSandbox) finishedLinesFor(childID string) int {
+	n := 0
+	for _, ln := range c.transitionLogLinesFor(childID) {
+		if strings.Contains(ln, `"kind":"finished"`) {
+			n++
+		}
+	}
+	return n
+}
+
+func TestCapability_TaskWorker_ParentWokenExactlyOnceOnDone(t *testing.T) {
+	c := newCapSandbox(t)
+
+	// A non-conductor parent so parent resolution succeeds without a live-pane
+	// gate; the wake EMISSION (one finished event) is what we assert. A claude
+	// child gives a realistic dispatched-worker shape in the registry.
+	c.run(t, "add", "-c", "bash", "-t", "tw-parent", c.WorkDir)
+	c.run(t, "add", "-c", "claude", "-t", "tw-child", "--parent", "tw-parent", c.WorkDir)
+	row, ok := c.findByTitle(t, "tw-child")
+	if !ok {
+		t.Fatalf("child not created: %+v", c.list(t))
+	}
+	childID := row.ID
+
+	// One-shot worker: simulate a retry (fail sentinel) then the real outcome
+	// (ok), then EXIT. A correct wrapper reports the FINAL outcome exactly once
+	// (last-wins), never twice.
+	worker := []string{"sh", "-c",
+		"echo working; " +
+			"echo '===AGENTDECK_DONE=== status=fail summary=transient retry'; " +
+			"echo '===AGENTDECK_DONE=== status=ok summary=task complete'; " +
+			"exit 0"}
+
+	if out, err := c.runTask(t, childID, worker...); err != nil {
+		t.Fatalf("run-task: %v\n%s", err, out)
+	}
+
+	// Durable completion record: exactly one, finalized, last-wins status ok.
+	rec, ok := c.completionRecord(t, childID)
+	if !ok {
+		t.Fatalf("no durable completion record written for %s", childID)
+	}
+	if rec["status"] != "ok" {
+		t.Fatalf("completion status = %v, want ok (last-wins over the fail retry)", rec["status"])
+	}
+	if !strings.Contains(toStr(rec["summary"]), "task complete") {
+		t.Errorf("completion summary = %v, want the final summary", rec["summary"])
+	}
+
+	// Exactly one wake of the parent — no flood.
+	if got := c.finishedLinesFor(childID); got != 1 {
+		t.Fatalf("parent woken %d times, want exactly 1 (no flood/miss)", got)
+	}
+
+	snapshot(t, "taskworker-done-once",
+		"durable completion record (kernel-exit captured the one-shot worker):\n"+
+			mustPretty(t, rec)+
+			"\n\nparent woken exactly once via the notifier (finished events for child): 1")
+}


### PR DESCRIPTION
Closes #1214.

Design report: `/tmp/exec-impl-comms/DESIGN.md`; spike (830/830 exactly-once): `/tmp/exec-impl-comms/spike/`.

## What this does
A conductor that dispatches a discrete task now gets an **exactly-once** "task finished" signal from the kernel instead of inferring it from a polled hook file with a freshness window + multi-layer dedup.

A worker run **one-shot** under the new `agent-deck run-task` wrapper exits when its task is done. The wrapper:
1. blocks on `cmd.Wait()` — exactly-once by construction (a process exits once),
2. parses the last `#1186` sentinel (`===AGENTDECK_DONE=== status=ok|fail summary=...`, last-wins), falling back to the exit code,
3. writes a **durable completion record** (atomic tmp+rename), and
4. **wakes the child's parent exactly once** through the existing notifier (`prepareDispatch` → parent resolution + busy-defer queue + inbox, reused verbatim).

Restart-safe: a completion that happened while the conductor was **down** is replayed once on the next daemon pass (`ReplayUnackedCompletions`) and never double-fires (the record's `Acked` flag is the authority).

## Generic, not claude-specific
`run-task` runs whatever command follows `--`, depending only on the `#1186` sentinel contract. The child id + profile come from the pane env agent-deck already injects (`AGENTDECK_INSTANCE_ID` / `AGENTDECK_PROFILE`). A session opts in with nothing more than:

```
agent-deck add -c <tool> --wrapper "agent-deck run-task -- {command}" .
```

**Opt-in, default-off**: no existing session changes behavior.

## STEP 1 — daemon never goes stale
The always-on `notify-daemon` now self-checks the on-disk binary version every 60s (`watchBinaryVersion` → `ShouldRecycleForVersion`) and exits cleanly on an upgrade so `Restart=always` brings it back on current code. `RuntimeMaxSec=86400` in the unit file is the backstop. This makes the 20-day stale-binary window (the root cause behind unreliable completion delivery) impossible.

## What was REMOVED (and why it's safe)
Scoped **strictly to the task-worker path**: for a child that has a completion record, the daemon no longer runs poll-inference done-detection, the **45s freshness window**, or the `lastDone` dedup — the kernel exit replaces all three. 

This is implemented as a **completion-record-keyed guard** in `emitDoneSignals` / `emitHookTransitionCandidates`, *not* by deleting the heuristics, because the persistent **interactive** path (sessions that never exit) still needs them. Those sessions have no completion record, so the guard is a no-op for them and their Stop-hook/sentinel path is **fully intact**. The claim record is written at worker start, so the guard also wins the race against the worker's own Stop hook.

## TDD (failing test first)
- Capability E2E: `tests/capability/issue1214_taskworker_test.go::TestCapability_TaskWorker_ParentWokenExactlyOnceOnDone` — drives the **real `agent-deck run-task` binary** running a real one-shot worker (fail-then-ok sentinel, exits); asserts exactly one durable completion record (last-wins `ok`) and exactly one finished-wake emission (no flood). Fails on pre-#1214 code (`run-task` did not exist). **Ran 10×, deterministic, 10/10 exactly-once.**
- Unit (`internal/session/taskworker_test.go`): exactly-once idle-wake, last-wins + exit fallback, kernel-exit capture via `cmd.Wait`, restart-safe replay (parent-down → restart → delivered once → no double-wake). Confirmed red (undefined symbols) before implementation, green after.
- `internal/session/issue1214_systemd_test.go`: guards the `RuntimeMaxSec` + `Restart=always` recycle backstop.
- `cmd/agent-deck/notify_daemon_version_test.go`: version-string parse.

## Surfaces (per the TDD skill checklist)
- **CLI** — new `run-task` subcommand (`cmd/agent-deck/runtask_cmd.go`), covered by the capability test.
- **Persistence** — durable completion records under `~/.agent-deck/runtime/completions/` (atomic). No statedb schema change: suppression is keyed on record existence, not a new session column (deliberately, to avoid a migration on the just-shipped persistence layer).
- **Session core** — wrapper mechanism + daemon guard, unit-tested.
- **Cross-platform** — built on `os/exec` + `cmd.Wait()` (POSIX). The systemd unit is Linux-only (matches the existing template).
- **TUI / Web UI / Remote** — not surfaced: `run-task` is a launch-time wrapper, not an interactive control; it changes no rendered session view. (Skipped with reason per the skill.)

## Verification
- New capability test: **10/10** runs, exactly-once each (no flood/miss).
- `go test -race` on the task-worker + done code: green (×3).
- `golangci-lint run` on `internal/session/...` + `cmd/agent-deck/...`: **0 issues**.
- `govulncheck`: **0 vulnerabilities** in called code.
- Honest caveat: the full `go test -race ./...` could not complete in the build env — the suite's tmux-bootstrapping `TestMain` intermittently hits `fork failed: No space left on device` on this heavily-loaded shared box (1000+ tmux servers). Proven pre-existing/environmental (fails identically on the stashed pre-change tree). Live-pane **delivery** of the `[DONE]` line into a running conductor remains the unit-tested notifier seam, matching the boundary already stated by `TestCapability_Conductor_FinishedSignal`.

## ⚠️ For maintainer
- `internal/session/conductor.go` adds `RuntimeMaxSec=86400` to the `agent-deck-transition-notifier.service` template. Per the worker brief, **.service template touches are flagged for maintainer review** before merge.

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `agent-deck run-task` command for executing one-shot tasks with automatic completion tracking.
  * Daemon now automatically detects binary updates and restarts, ensuring the latest version is always active.
  * Task completion records are durable and replayed across daemon restarts, preventing data loss.
  * Implemented periodic daemon recycling for improved stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->