### PR TITLE
fix(tmux): don't mark live sessions dead on transient tmux stalls

### DIFF
--- a/internal/tmux/exists_timeout_test.go
+++ b/internal/tmux/exists_timeout_test.go
@@ -1,0 +1,45 @@
+package tmux
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestSession_Exists_ProbeTimeoutIsNotTreatedAsAbsent is the regression for the
+// "all sessions X out at once" cascade: when the tmux server is briefly busy
+// (e.g. another session is being torn down), a `has-session` probe can hang.
+// The old code ran the probe with no timeout and treated any non-success as
+// "session gone", flipping live sessions to StatusError. A probe that does not
+// answer in time is indeterminate — we must assume the session still exists and
+// let a later poll resolve it, NOT declare it dead.
+//
+// Contrast with #755 (exists_socket_test.go): a probe that COMPLETES against an
+// absent server must still report false. This test only covers the timeout
+// (no answer) case, which is the one that must change.
+func TestSession_Exists_ProbeTimeoutIsNotTreatedAsAbsent(t *testing.T) {
+	// Stub `tmux` with a binary that hangs past the probe timeout, simulating a
+	// server too busy to answer. It would eventually exit non-zero, but the
+	// probe must give up first and treat the timeout as indeterminate.
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nsleep 1\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Short probe timeout so the test is fast; the fake hangs longer than this.
+	restore := hasSessionProbeTimeout
+	hasSessionProbeTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { hasSessionProbeTimeout = restore })
+
+	// Non-default socket skips the session cache; a unique name guarantees no
+	// live pipe connection — so Exists() reaches the subprocess probe.
+	s := &Session{Name: "busy-server-session", SocketName: "agent-deck-timeout-test"}
+
+	if !s.Exists() {
+		t.Fatalf("Exists() returned false when the has-session probe timed out; " +
+			"a probe that never answers is indeterminate and must not be treated as a dead session")
+	}
+}

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -748,9 +748,19 @@ func softKillProcessGroup(pgid int, grace time.Duration) bool {
 // tmux `-L <name>` selector (Session.SocketName / Instance.TmuxSocketName);
 // pass "" for the default server. All callers (watchPipe reconnect loop,
 // public HasSession/HasSessionOnSocket in tmux.go) go through this.
+//
+// The probe is bounded by hasSessionProbeTimeout: a tmux server that is briefly
+// busy can make `has-session` stall, and a stalled probe is indeterminate — we
+// assume the session still exists (return true) rather than blocking the caller
+// or reporting a live session as gone. A probe that completes is trusted.
 func tmuxSessionExistsOnSocket(socketName, name string) bool {
-	cmd := tmuxExec(socketName, "has-session", "-t", name)
-	return cmd.Run() == nil
+	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
+	defer cancel()
+	err := tmuxExecContext(ctx, socketName, "has-session", "-t", name).Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return true // probe timed out: indeterminate, assume the session still exists
+	}
+	return err == nil
 }
 
 // --- Global singleton ---

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -357,6 +357,20 @@ func (pm *PipeManager) forwardOutputEvents(sessionName string, pipe *ControlPipe
 	}
 }
 
+// shouldConcludeSessionGone decides whether a failed has-session probe during
+// reconnect means the session is permanently gone, or just a transient miss to
+// retry. A tmux server that is briefly busy (e.g. tearing down another session)
+// can make the probe report absent for a session that is actually alive, so a
+// single early miss must not delete the pipe. Only a probe still absent on the
+// final attempt — after the retry/backoff window lets contention clear —
+// concludes the session is gone.
+func shouldConcludeSessionGone(probeFoundSession bool, attempt, maxRetries int) bool {
+	if probeFoundSession {
+		return false
+	}
+	return attempt >= maxRetries-1
+}
+
 // watchPipe monitors a pipe and attempts reconnection when it dies.
 // Uses exponential backoff: 2s, 4s, 8s, 16s, 30s max.
 // Stops retrying if the tmux session no longer exists.
@@ -402,7 +416,8 @@ func (pm *PipeManager) watchPipe(sessionName string, pipe *ControlPipe) {
 		// default server for a session that lives on an isolated agent-deck
 		// socket would answer "no" and silently delete a healthy pipe.
 		reconnectSocket := pipe.socketName
-		if !tmuxSessionExistsOnSocket(reconnectSocket, sessionName) {
+		exists := tmuxSessionExistsOnSocket(reconnectSocket, sessionName)
+		if shouldConcludeSessionGone(exists, attempt, maxRetries) {
 			pipeLog.Debug("pipe_reconnect_session_gone",
 				slog.String("session", sessionName),
 				slog.String("socket", reconnectSocket))
@@ -410,6 +425,20 @@ func (pm *PipeManager) watchPipe(sessionName string, pipe *ControlPipe) {
 			delete(pm.pipes, sessionName)
 			pm.mu.Unlock()
 			return
+		}
+		if !exists {
+			// Probe reported absent but this may be transient tmux-server
+			// contention, not a real death. Back off and retry rather than
+			// deleting a pipe whose session is still alive (the cascade where
+			// one torn-down session flips its neighbors to error).
+			pipeLog.Debug("pipe_reconnect_probe_miss_retry",
+				slog.String("session", sessionName),
+				slog.Int("attempt", attempt+1))
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
 		}
 
 		err := pm.Connect(sessionName, reconnectSocket)

--- a/internal/tmux/pipemanager_reconnect_test.go
+++ b/internal/tmux/pipemanager_reconnect_test.go
@@ -1,6 +1,11 @@
 package tmux
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
 // TestShouldConcludeSessionGone_RetriesEarlyMisses guards the reconnect cascade
 // fix: when a pipe dies and the reconnect loop probes whether the session still
@@ -29,5 +34,29 @@ func TestShouldConcludeSessionGone_RetriesEarlyMisses(t *testing.T) {
 	// Still absent on the final attempt: now we conclude it is gone.
 	if !shouldConcludeSessionGone(false, maxRetries-1, maxRetries) {
 		t.Fatal("a probe still absent on the final attempt must conclude the session is gone")
+	}
+}
+
+// TestTmuxSessionExistsOnSocket_ProbeTimeoutIsNotTreatedAsAbsent guards the
+// reconnect-path companion to the Session.Exists() timeout fix. watchPipe()
+// probes existence via tmuxSessionExistsOnSocket(); if tmux stalls, an
+// unbounded probe blocks the reconnect goroutine before the retry/backoff
+// logic can run. The probe must be bounded and treat a timeout as
+// indeterminate — report the session as still present, not gone.
+func TestTmuxSessionExistsOnSocket_ProbeTimeoutIsNotTreatedAsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nsleep 1\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	restore := hasSessionProbeTimeout
+	hasSessionProbeTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { hasSessionProbeTimeout = restore })
+
+	if !tmuxSessionExistsOnSocket("agent-deck-reconnect-timeout-test", "busy-session") {
+		t.Fatal("tmuxSessionExistsOnSocket returned false when the has-session probe timed out; " +
+			"a stalled probe is indeterminate and must not be treated as a dead session")
 	}
 }

--- a/internal/tmux/pipemanager_reconnect_test.go
+++ b/internal/tmux/pipemanager_reconnect_test.go
@@ -1,0 +1,33 @@
+package tmux
+
+import "testing"
+
+// TestShouldConcludeSessionGone_RetriesEarlyMisses guards the reconnect cascade
+// fix: when a pipe dies and the reconnect loop probes whether the session still
+// exists, a single failed probe must NOT immediately conclude the session is
+// gone. During tmux-server contention (e.g. another session being torn down) a
+// probe can transiently report absent for a session that is actually alive;
+// concluding "gone" on the first miss deletes the pipe and flips a live session
+// to error. Only a probe that is still absent on the final attempt — after the
+// retry/backoff window lets contention clear — means the session is really gone.
+func TestShouldConcludeSessionGone_RetriesEarlyMisses(t *testing.T) {
+	const maxRetries = 5
+
+	// A probe that finds the session is never "gone".
+	if shouldConcludeSessionGone(true, 0, maxRetries) {
+		t.Fatal("a probe that found the session must never conclude it is gone")
+	}
+
+	// A miss on any non-final attempt is possibly-transient: retry, don't give up.
+	for attempt := 0; attempt < maxRetries-1; attempt++ {
+		if shouldConcludeSessionGone(false, attempt, maxRetries) {
+			t.Fatalf("attempt %d of %d: a single early probe miss must be retried, "+
+				"not treated as a dead session", attempt+1, maxRetries)
+		}
+	}
+
+	// Still absent on the final attempt: now we conclude it is gone.
+	if !shouldConcludeSessionGone(false, maxRetries-1, maxRetries) {
+		t.Fatal("a probe still absent on the final attempt must conclude the session is gone")
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2039,6 +2039,14 @@ func (s *Session) Start(command string) error {
 	return nil
 }
 
+// hasSessionProbeTimeout bounds a `tmux has-session` existence probe. A tmux
+// server that is briefly busy (e.g. tearing down another session) can make the
+// probe hang; rather than block a status poll — or, worse, mistake the stall
+// for a dead session — we cap it and treat a timeout as indeterminate (assume
+// the session still exists and let a later poll resolve it). Overridable in
+// tests.
+var hasSessionProbeTimeout = 2 * time.Second
+
 // Exists checks if the tmux session exists
 // Uses cached session list when available (refreshed by RefreshExistingSessions)
 // Falls back to direct tmux call if cache is stale
@@ -2061,9 +2069,18 @@ func (s *Session) Exists() bool {
 	}
 
 	// Cache is stale (or skipped for an isolated socket): fall back to a
-	// direct tmux check on the session's own socket.
-	cmd := s.tmuxCmd("has-session", "-t", s.Name)
-	return cmd.Run() == nil
+	// direct tmux check on the session's own socket. Bound it: a server that
+	// is briefly busy can make the probe hang, and a probe that never answers
+	// is indeterminate — assume the session still exists rather than reporting
+	// it dead (which would flip a live session to StatusError). Only a probe
+	// that actually completes with a non-success status means "gone".
+	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
+	defer cancel()
+	err := s.tmuxCmdContext(ctx, "has-session", "-t", s.Name).Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return true // probe timed out: indeterminate, assume still alive
+	}
+	return err == nil
 }
 
 // IsPaneDead returns true if the session's pane process has exited.


### PR DESCRIPTION
## Summary

Under brief tmux-server contention — e.g. when one session is torn down by an external process while others are active — agent-deck can misread the transient as "session gone" and flip **multiple live sessions to `error` (red ✕) at the same instant**, requiring a manual restart (`Shift+R`). The agent processes are still alive; agent-deck loses contact and mislabels them.

Root cause: two existence-check paths treat *any* `tmux has-session` failure as definitive absence, with no distinction between "the server answered: no such session" and "the server was briefly unreachable/slow."

## Changes

**1. `Session.Exists()` (`internal/tmux/tmux.go`)** ran `tmux has-session` with no timeout and returned `cmd.Run() == nil`. A hung/slow probe could block a status poll, and a transient failure was treated as a dead session. The probe is now bounded by a timeout, and a *timed-out* probe is treated as indeterminate (assume the session still exists; a later poll resolves it). A probe that **completes** with a non-success status is unchanged — so the isolated-socket behavior from #755 is preserved (existing tests still pass).

**2. Pipe reconnect loop (`internal/tmux/pipemanager.go`)** deleted a session's control pipe on the **first** failed `has-session` probe, ignoring its own 5-attempt retry/backoff budget. One transiently-failing probe therefore permanently dropped a live session's pipe — and since a single torn-down session contends the server, this cascaded to *neighboring* sessions. The give-up decision is now factored into `shouldConcludeSessionGone(...)`: early misses are retried, and a session is only concluded gone if still absent on the final attempt.

Both changes have new regression tests.

## Not included (follow-up)

A third path is deliberately left out because fixing it correctly is riskier and deserves its own review: `RefreshSessionCache` can overwrite the shared session cache with a transient **partial** `tmux list-windows -a` result, evicting live sessions. Telling "the server returned a short list under load" apart from "the user actually closed sessions" needs more care. Happy to do this as a separate PR.

## Test plan

- [x] `go test ./internal/tmux/ -run 'TestSession_Exists'` — new timeout test + existing #755 guards green
- [x] `go test ./internal/tmux/ -run TestShouldConcludeSessionGone_RetriesEarlyMisses` — green
- [x] `go build ./...` and `go vet ./internal/tmux/` clean
- [x] Full `internal/tmux` suite green (one unrelated, pre-existing, environment-specific failure — `TestStart_Service_SuccessPath` — also fails on `main` in my environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoids incorrectly marking active sessions as absent when session-probe commands stall or time out.
  * Adds bounded probe timeouts so slow responses are treated as indeterminate, not definitive absence.
  * Improves reconnection retry logic to handle transient probe misses without premature session deletion.

* **Tests**
  * Added tests validating probe-timeout handling and reconnection retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->