### PR TITLE
fix: verify SHA-256 checksum on local self-update binary download

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -124,7 +124,12 @@ func promptForUpdate() bool {
 	}
 
 	fmt.Println()
-	if err := update.PerformUpdate(info.DownloadURL); err != nil {
+	release, err := update.FetchReleaseByTag(info.LatestVersion)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Update failed: failed to fetch release info: %v\n", err)
+		return false
+	}
+	if err := update.PerformVerifiedUpdate(release, runtime.GOOS, runtime.GOARCH); err != nil {
 		fmt.Fprintf(os.Stderr, "Update failed: %v\n", err)
 		return false
 	}
@@ -2698,7 +2703,12 @@ func handleUpdate(args []string) {
 			os.Exit(1)
 		}
 	} else {
-		if err := update.PerformUpdate(info.DownloadURL); err != nil {
+		release, err := update.FetchReleaseByTag(info.LatestVersion)
+		if err != nil {
+			fmt.Printf("Error installing update: failed to fetch release info: %v\n", err)
+			os.Exit(1)
+		}
+		if err := update.PerformVerifiedUpdate(release, runtime.GOOS, runtime.GOARCH); err != nil {
 			fmt.Printf("Error installing update: %v\n", err)
 			os.Exit(1)
 		}
@@ -2788,7 +2798,7 @@ func handleUpdateToSpecificVersion(requested string, checkOnly bool) {
 	}
 
 	fmt.Println()
-	if err := update.PerformUpdate(downloadURL); err != nil {
+	if err := update.PerformVerifiedUpdate(release, runtime.GOOS, runtime.GOARCH); err != nil {
 		fmt.Printf("Error installing v%s: %v\n", targetVersion, err)
 		os.Exit(1)
 	}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -37,6 +37,9 @@ var checkInterval = DefaultCheckInterval
 // apiBaseURL is the base URL for GitHub API calls. Overridable in tests.
 var apiBaseURL = "https://api.github.com"
 
+// detectHomebrewManagedInstall is a test seam for self-update install paths.
+var detectHomebrewManagedInstall = DetectHomebrewManagedInstall
+
 // SetCheckInterval sets the update check interval from config
 func SetCheckInterval(hours int) {
 	if hours > 0 {
@@ -508,7 +511,7 @@ func PerformUpdate(downloadURL string) error {
 		return fmt.Errorf("no download URL available for %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
 
-	execPath, upgradeCmd, managed, err := DetectHomebrewManagedInstall()
+	execPath, upgradeCmd, managed, err := detectHomebrewManagedInstall()
 	if err != nil {
 		return fmt.Errorf("failed to detect install type: %w", err)
 	}
@@ -552,6 +555,32 @@ func PerformUpdate(downloadURL string) error {
 		return fmt.Errorf("failed to extract: %w", err)
 	}
 
+	return installSelfUpdateBinary(execPath, binaryData)
+}
+
+// PerformVerifiedUpdate downloads, verifies, extracts, and installs a release
+// binary for the requested platform. It fails closed: checksum download,
+// missing-entry, or hash mismatch errors occur before the installed binary is
+// touched.
+func PerformVerifiedUpdate(release *Release, goos, goarch string) error {
+	execPath, upgradeCmd, managed, err := detectHomebrewManagedInstall()
+	if err != nil {
+		return fmt.Errorf("failed to detect install type: %w", err)
+	}
+	if managed {
+		return fmt.Errorf("homebrew-managed install detected at %s; use `%s`", execPath, upgradeCmd)
+	}
+
+	fmt.Printf("Downloading and verifying %s/%s release binary...\n", goos, goarch)
+	binaryData, err := DownloadVerifiedBinary(release, goos, goarch)
+	if err != nil {
+		return fmt.Errorf("download/verify failed: %w", err)
+	}
+
+	return installSelfUpdateBinary(execPath, binaryData)
+}
+
+func installSelfUpdateBinary(execPath string, binaryData []byte) error {
 	// Create temp file for new binary
 	newBinaryPath := execPath + ".new"
 	if err := os.WriteFile(newBinaryPath, binaryData, 0755); err != nil {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -262,6 +262,120 @@ func TestFetchReleaseByTag(t *testing.T) {
 	})
 }
 
+func TestPerformVerifiedUpdate_MatchingChecksumInstalls(t *testing.T) {
+	oldBinary := []byte("old-agent-deck")
+	newBinary := []byte("new-agent-deck")
+	execPath := selfUpdateTestTarget(t, oldBinary)
+
+	archive := makeTarGz(t, newBinary)
+	checksums := []byte(sha256hex(archive) + "  agent-deck_1.2.3_linux_amd64.tar.gz\n")
+	rel, cleanup := selfUpdateReleaseServer(t, archive, checksums, http.StatusOK)
+	defer cleanup()
+
+	err := PerformVerifiedUpdate(rel, "linux", "amd64")
+	require.NoError(t, err)
+
+	installed, err := os.ReadFile(execPath)
+	require.NoError(t, err)
+	assert.Equal(t, newBinary, installed)
+}
+
+func TestPerformVerifiedUpdate_MissingChecksumEntryLeavesBinaryUntouched(t *testing.T) {
+	oldBinary := []byte("old-agent-deck")
+	newBinary := []byte("new-agent-deck")
+	execPath := selfUpdateTestTarget(t, oldBinary)
+
+	archive := makeTarGz(t, newBinary)
+	checksums := []byte(sha256hex(archive) + "  agent-deck_1.2.3_windows_amd64.tar.gz\n")
+	rel, cleanup := selfUpdateReleaseServer(t, archive, checksums, http.StatusOK)
+	defer cleanup()
+
+	err := PerformVerifiedUpdate(rel, "linux", "amd64")
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "no published sha-256 checksum")
+
+	installed, readErr := os.ReadFile(execPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, oldBinary, installed)
+}
+
+func TestPerformVerifiedUpdate_MismatchedChecksumLeavesBinaryUntouched(t *testing.T) {
+	oldBinary := []byte("old-agent-deck")
+	newBinary := []byte("new-agent-deck")
+	execPath := selfUpdateTestTarget(t, oldBinary)
+
+	archive := makeTarGz(t, newBinary)
+	checksums := []byte(sha256hex([]byte("different archive")) + "  agent-deck_1.2.3_linux_amd64.tar.gz\n")
+	rel, cleanup := selfUpdateReleaseServer(t, archive, checksums, http.StatusOK)
+	defer cleanup()
+
+	err := PerformVerifiedUpdate(rel, "linux", "amd64")
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "mismatch")
+
+	installed, readErr := os.ReadFile(execPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, oldBinary, installed)
+}
+
+func TestPerformVerifiedUpdate_ChecksumsDownloadFailureLeavesBinaryUntouched(t *testing.T) {
+	oldBinary := []byte("old-agent-deck")
+	newBinary := []byte("new-agent-deck")
+	execPath := selfUpdateTestTarget(t, oldBinary)
+
+	archive := makeTarGz(t, newBinary)
+	rel, cleanup := selfUpdateReleaseServer(t, archive, nil, http.StatusNotFound)
+	defer cleanup()
+
+	err := PerformVerifiedUpdate(rel, "linux", "amd64")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksums.txt")
+	assert.Contains(t, err.Error(), "status 404")
+
+	installed, readErr := os.ReadFile(execPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, oldBinary, installed)
+}
+
+func selfUpdateTestTarget(t *testing.T, initial []byte) string {
+	t.Helper()
+
+	t.Setenv("HOME", t.TempDir())
+	execPath := filepath.Join(t.TempDir(), "agent-deck")
+	require.NoError(t, os.WriteFile(execPath, initial, 0o755))
+
+	orig := detectHomebrewManagedInstall
+	detectHomebrewManagedInstall = func() (string, string, bool, error) {
+		return execPath, "", false, nil
+	}
+	t.Cleanup(func() { detectHomebrewManagedInstall = orig })
+
+	return execPath
+}
+
+func selfUpdateReleaseServer(t *testing.T, archive, checksums []byte, checksumsStatus int) (*Release, func()) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/agent-deck_1.2.3_linux_amd64.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	mux.HandleFunc("/checksums.txt", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(checksumsStatus)
+		_, _ = w.Write(checksums)
+	})
+	srv := httptest.NewServer(mux)
+
+	rel := &Release{
+		TagName: "v1.2.3",
+		Assets: []Asset{
+			{Name: "agent-deck_1.2.3_linux_amd64.tar.gz", BrowserDownloadURL: srv.URL + "/agent-deck_1.2.3_linux_amd64.tar.gz"},
+			{Name: ChecksumsAssetName, BrowserDownloadURL: srv.URL + "/checksums.txt"},
+		},
+	}
+	return rel, srv.Close
+}
+
 func TestHomebrewUpgradeHint(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
The local self-update path (`cmd/agent-deck/main.go` calling `update.PerformUpdate(info.DownloadURL)`) downloads the release binary over HTTP and installs it without verifying a SHA-256 checksum. This is the same integrity gap that #1207 closed for the remote-deploy path and that the in-flight install.sh hardening closes for fresh installs. It was surfaced by the security audit (section 3) and #1207's scope note. `DownloadVerifiedBinary(release, goos, goarch)` was added to `internal/update/checksum.go` in #1207 and is ready to reuse.

## Why this matters
Route the local self-update through the SHA-256-verified download instead of the raw `PerformUpdate(downloadURL)` path. At the self-update call sites in `cmd/agent-deck/main.go` (the `update` command and the auto-update nudge path), fetch the release object and call `update.DownloadVerifiedBinary(release, runtime.GOOS, runtime.GOARCH)` (which already parses the checksums file via `GetChecksumsURL` + `ParseChecksums` and runs `VerifyAssetChecksum`), then install the verified bytes. Fail closed: if the checksum file is missing or the hash mismatches, abort the update with an actionable error rather than installing. Where `PerformUpdate` is the natural seam, add a verified variant that accepts the release and platform so the unverified-URL entry point is no longer used for self-update. Mirror the fail-closed semantics already established for remote deploy in #1207 so behavior is consistent across both paths.

Closes #1208.

## Testing
Added unit tests in `internal/update/update_test.go`. `go build ./...` and `go test ./internal/update/...` pass.

AI was used for assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Binary updates now include checksum verification before installation to ensure file integrity
  * Enhanced error handling with clearer messages for update failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->