### PR TITLE
fix: skills e2e specs fail on collapsed sidebar in headless viewport

### DIFF
--- a/tests/web/e2e/skills.spec.js
+++ b/tests/web/e2e/skills.spec.js
@@ -9,14 +9,14 @@
 import { test, expect } from '@playwright/test'
 
 async function gotoSkills(page) {
-  await page.goto('/')
-  await page.waitForSelector('.sess', { timeout: 5000 })
-  // Click the first session row (sess-001 / agent-deck — has alpha attached
-  // in the fixture seed).
-  await page.locator('.sess').first().click()
-  // Activate the Skills tab in the top navigation.
-  await page.getByRole('button', { name: /^skills$/i }).click()
-  await page.waitForSelector('[data-testid="skills-pane"]', { timeout: 5000 })
+  // Open the seeded session directly. In narrow headless viewports the
+  // sidebar is collapsed/hidden, so the seeded .sess rows exist but are not
+  // visible enough for Playwright's default wait/click predicates.
+  await page.addInitScript(() => {
+    localStorage.setItem('agentdeck.tab', JSON.stringify('skills'))
+  })
+  await page.goto('/s/sess-001')
+  await expect(page.locator('[data-testid="skills-pane"]')).toBeVisible({ timeout: 5000 })
 }
 
 test.describe('skills management', () => {


### PR DESCRIPTION
## Summary
The skills e2e specs opened the Skills pane by waiting for the `.sess` sidebar rows and clicking one. In narrow headless viewports the sidebar is collapsed/hidden, so the seeded rows exist but are not visible enough for Playwright's default wait/click predicates, and the specs fail before reaching the Skills pane.

## Why this matters
`gotoSkills` now navigates directly to the seeded session route (`/s/sess-001`, the same pattern `children-panel.spec.js` already uses) and pre-selects the Skills tab through the app's own persistence key (`localStorage['agentdeck.tab']`, read by `internal/web/static/app/uiState.js` via `loadJSON('agentdeck.tab', 'fleet')`). This removes the collapsed-sidebar dependency entirely instead of trying to interact with hidden elements.

Closes #1212.

## Testing
Test-only change to `tests/web/e2e/skills.spec.js`. The route and the `agentdeck.tab` storage key were verified against the app source (`uiState.js`, `children-panel.spec.js`). The Playwright e2e suite itself was not run locally (needs the web fixture server + browsers).

AI was used for assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the Skills navigation test flow to be more direct and reliable by seeding the initial session state and verifying the skills pane loads correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->