### PR TITLE
fix(session): re-assert scratch .credentials.json symlink on spawn+start/restart (stops work-profile 401 /login loop)

### DIFF
--- a/docs/CONDUCTOR-SETUP.md
+++ b/docs/CONDUCTOR-SETUP.md
@@ -317,6 +317,26 @@ agent-deck conductor teardown <name> --remove   # stop and delete dir + session
 agent-deck conductor teardown --all --remove    # nuke every conductor in this profile
 ```
 
+### 7. "Sessions keep dropping into `/login` (401 loop) — do NOT `/login` inside a managed session"
+
+Managed claude sessions share one OAuth token: agent-deck symlinks each
+session's scratch `$CLAUDE_CONFIG_DIR/.credentials.json` to the canonical
+profile credentials (e.g. `~/.claude-work/.credentials.json`). **Log in once,
+in the canonical profile, and every session inherits it through that symlink.**
+
+If you run `/login` *inside* a managed session, Claude replaces the symlink
+with a real-file **copy** of the token. Anthropic rotates the refresh token on
+each refresh, so that copy `401`s on the next rotation — and the fresh token
+you just minted is stranded in scratch instead of reaching canonical, so the
+other sessions stay stale too. This was the 2026-05-29 work-profile 401 storm
+(issue #1222).
+
+agent-deck now self-heals this: on the next session **start / restart**, the
+scratch seeding re-asserts the symlink, and if your in-session login was newer
+than canonical it is promoted to canonical first so it propagates to every
+session. But the clean habit is: **never `/login` inside a managed session** —
+do it once in the canonical profile.
+
 ---
 
 ## Running several conductors

--- a/internal/session/issue1222_credentials_symlink_reassert_test.go
+++ b/internal/session/issue1222_credentials_symlink_reassert_test.go
@@ -1,0 +1,269 @@
+// Package session — regression tests for issue #1222.
+//
+// The work-profile 401 "/login" loop. agent-deck seeds each managed
+// session's scratch `$CLAUDE_CONFIG_DIR/.credentials.json` as a SYMLINK to
+// the canonical profile credentials (e.g. `~/.claude-work/.credentials.json`)
+// so every session shares one OAuth token. Running `/login` INSIDE a managed
+// session makes Claude overwrite that symlink with a real-file COPY of the
+// token. Anthropic OAuth rotates the refresh token on each refresh, so every
+// stale real-file copy 401s on the next rotation, and the fresh in-session
+// token is stranded in scratch instead of reaching canonical.
+//
+// Root cause, confirmed on the innotrade conductor 2026-05-29: 72 work
+// sessions correctly symlinked, 12 had stale diverged real-file copies — and
+// those 12 were exactly the sessions that 401'd. `mirrorProfileEntries` was
+// idempotent the wrong way (`Lstat(linkPath)==nil → continue`), so once the
+// symlink was clobbered into a real file it was never repaired, on any
+// start/restart/resume.
+//
+// These tests pin the heal: for `.credentials.json` specifically the scratch
+// seeding must re-assert the symlink to canonical, promoting a fresh
+// in-session login to canonical first when the scratch copy is newer.
+
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeCredFile writes a fake credentials file with the given token and mtime
+// (0600 — token perms). Returns nothing; fails the test on error.
+func writeCredFile(t *testing.T, path, token string, mtime time.Time) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(token), 0o600); err != nil {
+		t.Fatalf("write cred file %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}
+
+// assertIsSymlinkTo asserts linkPath is a symlink resolving to wantTarget.
+func assertIsSymlinkTo(t *testing.T, linkPath, wantTarget string) {
+	t.Helper()
+	fi, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", linkPath, err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s must be a symlink after re-assertion; got mode %v", linkPath, fi.Mode())
+	}
+	got, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("readlink %s: %v", linkPath, err)
+	}
+	if got != wantTarget {
+		t.Fatalf("%s points at %q; want %q", linkPath, got, wantTarget)
+	}
+}
+
+// (a) A stale REAL-FILE copy of .credentials.json in scratch (the /login
+// clobber) must be re-asserted to a symlink to canonical. Canonical is the
+// source of truth here (scratch copy is older), so it must be left unchanged.
+func TestMirrorProfileEntries_StaleRealFileCredentials_ReassertedToSymlink(t *testing.T) {
+	source := t.TempDir()
+	dest := t.TempDir()
+
+	canonicalToken := `{"token":"canonical-fresh"}`
+	staleToken := `{"token":"stale-copy"}`
+	now := time.Now()
+	writeCredFile(t, filepath.Join(source, ".credentials.json"), canonicalToken, now)
+	// Scratch real-file copy is OLDER than canonical → stale, relink only.
+	writeCredFile(t, filepath.Join(dest, ".credentials.json"), staleToken, now.Add(-time.Hour))
+
+	if err := mirrorProfileEntries(dest, source); err != nil {
+		t.Fatalf("mirrorProfileEntries: %v", err)
+	}
+
+	assertIsSymlinkTo(t, filepath.Join(dest, ".credentials.json"), filepath.Join(source, ".credentials.json"))
+
+	// Canonical untouched — we did not promote a stale copy over it.
+	got, err := os.ReadFile(filepath.Join(source, ".credentials.json"))
+	if err != nil {
+		t.Fatalf("read canonical: %v", err)
+	}
+	if string(got) != canonicalToken {
+		t.Fatalf("canonical credentials must be untouched by a stale relink; got %q want %q", string(got), canonicalToken)
+	}
+}
+
+// (b) A correct symlink to canonical must be left alone (idempotent). Running
+// the seeding repeatedly must not churn the link or rewrite canonical.
+func TestMirrorProfileEntries_CorrectCredentialSymlink_LeftAlone(t *testing.T) {
+	source := t.TempDir()
+	dest := t.TempDir()
+
+	canonicalToken := `{"token":"canonical"}`
+	target := filepath.Join(source, ".credentials.json")
+	writeCredFile(t, target, canonicalToken, time.Now())
+	if err := os.Symlink(target, filepath.Join(dest, ".credentials.json")); err != nil {
+		t.Fatalf("seed symlink: %v", err)
+	}
+
+	canonicalStatBefore, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat canonical: %v", err)
+	}
+
+	if err := mirrorProfileEntries(dest, source); err != nil {
+		t.Fatalf("mirrorProfileEntries: %v", err)
+	}
+
+	assertIsSymlinkTo(t, filepath.Join(dest, ".credentials.json"), target)
+
+	canonicalStatAfter, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat canonical after: %v", err)
+	}
+	if !canonicalStatBefore.ModTime().Equal(canonicalStatAfter.ModTime()) {
+		t.Fatalf("idempotent run rewrote canonical (mtime changed %v → %v)", canonicalStatBefore.ModTime(), canonicalStatAfter.ModTime())
+	}
+}
+
+// (d) Promote-then-relink: a scratch real-file NEWER than canonical (a fresh
+// in-session /login) must be promoted to canonical FIRST (atomic, 0600
+// preserved), THEN scratch must be re-linked to canonical. This is what makes
+// an in-session login propagate to every other session.
+func TestMirrorProfileEntries_NewerScratchCredentials_PromotedThenRelinked(t *testing.T) {
+	source := t.TempDir()
+	dest := t.TempDir()
+
+	staleCanonical := `{"token":"old-canonical"}`
+	freshLogin := `{"token":"fresh-in-session-login"}`
+	now := time.Now()
+	writeCredFile(t, filepath.Join(source, ".credentials.json"), staleCanonical, now.Add(-2*time.Hour))
+	// Scratch real-file is NEWER than canonical → fresh login, promote it.
+	writeCredFile(t, filepath.Join(dest, ".credentials.json"), freshLogin, now)
+
+	if err := mirrorProfileEntries(dest, source); err != nil {
+		t.Fatalf("mirrorProfileEntries: %v", err)
+	}
+
+	// Canonical now holds the fresh token (promoted).
+	target := filepath.Join(source, ".credentials.json")
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read canonical: %v", err)
+	}
+	if string(got) != freshLogin {
+		t.Fatalf("fresh in-session login must be promoted to canonical; got %q want %q", string(got), freshLogin)
+	}
+
+	// Canonical keeps 0600 token perms after the atomic promote.
+	fi, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat canonical: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("promoted canonical must be 0600; got %o", perm)
+	}
+
+	// Scratch is re-linked to canonical, so it reads the promoted token.
+	assertIsSymlinkTo(t, filepath.Join(dest, ".credentials.json"), target)
+	viaLink, err := os.ReadFile(filepath.Join(dest, ".credentials.json"))
+	if err != nil {
+		t.Fatalf("read scratch via link: %v", err)
+	}
+	if string(viaLink) != freshLogin {
+		t.Fatalf("scratch link must resolve to promoted token; got %q", string(viaLink))
+	}
+}
+
+// (e) settings.json must remain excluded from the symlink/credentials path —
+// it is OWNED (copied + mutated) by the scratch seeding. The credentials heal
+// must not generalize to settings.json or break the telegram-gate behavior.
+func TestMirrorProfileEntries_SettingsJsonStillExcluded(t *testing.T) {
+	source := t.TempDir()
+	dest := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{}}`), 0o644); err != nil {
+		t.Fatalf("write source settings: %v", err)
+	}
+	writeCredFile(t, filepath.Join(source, ".credentials.json"), `{"token":"canonical"}`, time.Now())
+
+	// dest already owns a real-file settings.json (written by the seeding
+	// before mirrorProfileEntries runs).
+	ownedSettings := `{"enabledPlugins":{"telegram@claude-plugins-official":false}}`
+	destSettings := filepath.Join(dest, "settings.json")
+	if err := os.WriteFile(destSettings, []byte(ownedSettings), 0o600); err != nil {
+		t.Fatalf("write dest settings: %v", err)
+	}
+
+	if err := mirrorProfileEntries(dest, source); err != nil {
+		t.Fatalf("mirrorProfileEntries: %v", err)
+	}
+
+	// settings.json must stay a REAL FILE with its owned content (never a symlink).
+	fi, err := os.Lstat(destSettings)
+	if err != nil {
+		t.Fatalf("lstat dest settings: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("settings.json must remain a real file, never symlinked; got symlink")
+	}
+	got, err := os.ReadFile(destSettings)
+	if err != nil {
+		t.Fatalf("read dest settings: %v", err)
+	}
+	if string(got) != ownedSettings {
+		t.Fatalf("owned settings.json must be untouched; got %q want %q", string(got), ownedSettings)
+	}
+
+	// But .credentials.json IS symlinked.
+	assertIsSymlinkTo(t, filepath.Join(dest, ".credentials.json"), filepath.Join(source, ".credentials.json"))
+}
+
+// (c) Start/restart re-assertion: the heal must run through the real spawn
+// entry point EnsureWorkerScratchConfigDir (called on every Start / Restart /
+// --resume via prepareWorkerScratchConfigDirForSpawn). First spawn links;
+// an in-session /login clobbers the link into a real file; the next start
+// re-asserts the symlink.
+func TestEnsureWorkerScratchConfigDir_RestartRepairsClobberedCredentialSymlink(t *testing.T) {
+	withTelegramConductorPresent(t)
+
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{}}`), 0o644); err != nil {
+		t.Fatalf("write source settings: %v", err)
+	}
+	canonicalToken := `{"token":"canonical"}`
+	writeCredFile(t, filepath.Join(source, ".credentials.json"), canonicalToken, time.Now())
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	inst := &Instance{
+		ID:    "00000000-0000-0000-0000-0000000012222",
+		Tool:  "claude",
+		Title: "my-worker",
+	}
+
+	// First spawn — scratch .credentials.json is a symlink to canonical.
+	scratch, err := inst.EnsureWorkerScratchConfigDir(source)
+	if err != nil {
+		t.Fatalf("first EnsureWorkerScratchConfigDir: %v", err)
+	}
+	if scratch == "" {
+		t.Fatal("setup: scratch dir should be non-empty for a worker")
+	}
+	scratchCred := filepath.Join(scratch, ".credentials.json")
+	assertIsSymlinkTo(t, scratchCred, filepath.Join(source, ".credentials.json"))
+
+	// Simulate `/login` inside the session: Claude replaces the symlink with
+	// a real-file copy (older than canonical → stale on next rotation).
+	if err := os.Remove(scratchCred); err != nil {
+		t.Fatalf("remove symlink: %v", err)
+	}
+	writeCredFile(t, scratchCred, `{"token":"stale-in-session-copy"}`, time.Now().Add(-time.Hour))
+	if fi, _ := os.Lstat(scratchCred); fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("setup: clobbered entry should be a real file, not a symlink")
+	}
+
+	// Next start / restart / --resume re-runs the seeding and must repair it.
+	if _, err := inst.EnsureWorkerScratchConfigDir(source); err != nil {
+		t.Fatalf("restart EnsureWorkerScratchConfigDir: %v", err)
+	}
+	assertIsSymlinkTo(t, scratchCred, filepath.Join(source, ".credentials.json"))
+}

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -371,20 +371,39 @@ func (i *Instance) EnsureWorkerScratchConfigDir(sourceProfileDir string) (string
 	return scratch, nil
 }
 
+// credentialsFileName is the profile's OAuth credentials file. It is the one
+// scratch entry that must be RE-ASSERTED (not merely left alone) on every
+// seeding — see reassertCredentialSymlink and issue #1222.
+const credentialsFileName = ".credentials.json"
+
 // mirrorProfileEntries symlinks every top-level entry in source (except
-// settings.json) into dest. Idempotent: existing dest entries are left
-// alone; G6 EEXIST races are benign.
+// settings.json) into dest. For most entries it is idempotent the simple way:
+// an existing dest entry is left alone (G6 EEXIST races are benign).
+//
+// `.credentials.json` is the exception. It is handled by
+// reassertCredentialSymlink, which heals the issue #1222 clobber: running
+// `/login` inside a managed session replaces the scratch symlink with a
+// real-file COPY of the OAuth token. Anthropic rotates the refresh token on
+// each refresh, so that stale copy 401s on the next rotation while the fresh
+// token is stranded in scratch. Re-asserting the symlink (and promoting a
+// fresh in-session login to canonical first) restores the single-source-of-
+// truth invariant on the next start/restart/resume.
 func mirrorProfileEntries(dest, source string) error {
 	entries, err := os.ReadDir(source)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			// Source absent: still re-assert credentials in case scratch
+			// holds a stranded in-session login to promote (no canonical).
+			return reassertCredentialSymlink(dest, source)
 		}
 		return fmt.Errorf("read source profile: %w", err)
 	}
 	for _, entry := range entries {
 		name := entry.Name()
-		if name == "settings.json" {
+		// settings.json is OWNED (copied + mutated) by the scratch seeding;
+		// .credentials.json is re-asserted explicitly below. Both are skipped
+		// from the generic leave-alone mirror.
+		if name == "settings.json" || name == credentialsFileName {
 			continue
 		}
 		linkPath := filepath.Join(dest, name)
@@ -398,6 +417,97 @@ func mirrorProfileEntries(dest, source string) error {
 			}
 			return fmt.Errorf("symlink %s: %w", name, err)
 		}
+	}
+	return reassertCredentialSymlink(dest, source)
+}
+
+// reassertCredentialSymlink guarantees dest/.credentials.json is a symlink to
+// source/.credentials.json (the canonical profile credentials), healing the
+// in-session `/login` clobber described in issue #1222.
+//
+//   - dest entry is the correct symlink → left untouched (idempotent).
+//   - dest entry is absent → symlinked to canonical (when canonical exists).
+//   - dest entry is a symlink to the WRONG target → repointed to canonical.
+//   - dest entry is a real file STALE relative to canonical → replaced with
+//     the symlink; canonical is the source of truth and is left unchanged.
+//   - dest entry is a real file NEWER than canonical (a fresh in-session
+//     `/login`) → its contents are atomically promoted to canonical FIRST
+//     (temp+rename, 0600 token perms preserved, canonical never torn), THEN
+//     dest is replaced with the symlink — so the fresh token propagates to
+//     every symlinked session instead of being stranded in this scratch.
+//
+// WARNING for operators: do NOT run `/login` inside a managed agent-deck
+// session. Log in once in the canonical profile and every session inherits it
+// through this symlink. An in-session login is recovered here on the next
+// start, but only after a restart.
+func reassertCredentialSymlink(dest, source string) error {
+	target := filepath.Join(source, credentialsFileName)
+	linkPath := filepath.Join(dest, credentialsFileName)
+
+	li, lerr := os.Lstat(linkPath)
+	switch {
+	case lerr != nil && os.IsNotExist(lerr):
+		// Nothing in scratch yet — link to canonical when it exists.
+		if _, terr := os.Stat(target); terr == nil {
+			return symlinkReplace(target, linkPath)
+		}
+		return nil
+	case lerr != nil:
+		return fmt.Errorf("lstat scratch credentials: %w", lerr)
+	}
+
+	if li.Mode()&os.ModeSymlink != 0 {
+		// Already a symlink — leave it iff it points at canonical.
+		if cur, rerr := os.Readlink(linkPath); rerr == nil && cur == target {
+			return nil
+		}
+		// Wrong/stale symlink → repoint (only meaningful if canonical exists).
+		if _, terr := os.Stat(target); terr != nil {
+			return nil
+		}
+		return symlinkReplace(target, linkPath)
+	}
+
+	// dest is a REAL FILE (the `/login` clobber). Decide promote vs relink.
+	promote := false
+	ti, terr := os.Stat(target)
+	switch {
+	case terr != nil && os.IsNotExist(terr):
+		promote = true // canonical missing → scratch is the only copy
+	case terr != nil:
+		return fmt.Errorf("stat canonical credentials: %w", terr)
+	default:
+		// Promote only when the scratch copy is strictly newer — a fresh
+		// in-session login. Equal/older is treated as stale (relink only).
+		promote = li.ModTime().After(ti.ModTime())
+	}
+
+	if promote {
+		data, rerr := os.ReadFile(linkPath)
+		if rerr != nil {
+			return fmt.Errorf("read scratch credentials for promote: %w", rerr)
+		}
+		// Atomic temp+rename into canonical: 0600 token perms preserved,
+		// canonical never torn even under a concurrent reader (G5/G1).
+		if err := atomicWriteFile(target, data, 0o600); err != nil {
+			return fmt.Errorf("promote scratch credentials to canonical: %w", err)
+		}
+	}
+
+	return symlinkReplace(target, linkPath)
+}
+
+// symlinkReplace atomically points linkPath at target, removing any existing
+// entry first. An EEXIST from a concurrent creator is benign.
+func symlinkReplace(target, linkPath string) error {
+	if err := os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale credentials entry: %w", err)
+	}
+	if err := os.Symlink(target, linkPath); err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+		return fmt.Errorf("symlink credentials: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes the work-profile **401 / `/login` loop** that cost hours across all 7 conductors (issue #1222), confirmed on a client conductor **2026-05-29**.

Managed claude sessions share one OAuth token: agent-deck symlinks each session's scratch `$CLAUDE_CONFIG_DIR/.credentials.json` to the canonical profile credentials (e.g. `~/.claude-<profile>/.credentials.json`). Running `/login` **inside** a managed session makes Claude replace that symlink with a real-file **copy** of the token. Anthropic rotates the refresh token on each refresh, so the stale copy `401`s on the next rotation — and the fresh in-session token is **stranded in scratch** while canonical stays stale and every other symlinked session inherits stale.

**Evidence (2026-05-29):** 72 work sessions correctly symlinked; **12 had stale diverged real-file copies = exactly the ones that 401'd.** Converting copies→symlinks + promoting the fresh in-scratch token to canonical fixed it; a fresh session then authenticated with no login prompt.

## Root cause

`mirrorProfileEntries` was idempotent the **wrong way**: `if _, statErr := os.Lstat(linkPath); statErr == nil { continue }` left **any** existing scratch entry alone — including a clobbered real-file copy. So once the symlink became a real file it was never repaired, on any start/restart/resume. (The re-seeding *did* run on every `Start`/`StartWithMessage`/`Restart` via `prepareWorkerScratchConfigDirForSpawn` → `EnsureWorkerScratchConfigDir` → `mirrorProfileEntries`; it just short-circuited.)

## Fix

`.credentials.json` is now special-cased via a new `reassertCredentialSymlink`:

| Scratch state | Action |
|---|---|
| Correct symlink to canonical | **left untouched** (idempotent) |
| Stale real-file copy (≤ canonical mtime) | **replaced** with symlink to canonical |
| Real file **newer** than canonical (fresh in-session login) | **promoted** to canonical first (atomic temp+rename, `0600` preserved), **then** relinked — so the fresh token propagates to every session |
| Symlink to wrong target | repointed |
| Absent | created (when canonical exists) |

`settings.json` stays **owned/excluded** — the telegram-gate behavior is unchanged.

**Requirement 2 (re-assert on start/restart/--resume) is satisfied with no `instance.go` change**: the re-assertion lives in `mirrorProfileEntries`, which already runs on every `Start` / `StartWithMessage` / `Restart` (and `--resume` through them). A clobbered link self-heals on the next session start. This also kept the PR clear of unrelated in-flight working-tree changes in `instance.go`.

## Surfaces (per `agent-deck-tdd-feature` skill)

| Surface | Applies? | Coverage |
|---|---|---|
| **Persistence / session lifecycle** | ✅ primary | `internal/session/worker_scratch.go` + `internal/session/issue1222_credentials_symlink_reassert_test.go` |
| **Cross-platform** | partial | Linux uses file-based `.credentials.json` (in scope). macOS keys the OAuth token in Keychain, not this file; the scratch symlink heal is a pure filesystem operation with no macOS-specific path, so no build-tagged variant is needed. |
| TUI / Web / CLI / Remote | ❌ no surface change | This is below the session-spawn env layer, shared by Local + Remote sessions alike; no keystroke/route/flag/render changes. |

## Tests (failing → passing)

File: `internal/session/issue1222_credentials_symlink_reassert_test.go`

Bug-demonstrating (verified **FAIL before** the fix, **PASS after**):
- `TestMirrorProfileEntries_StaleRealFileCredentials_ReassertedToSymlink` — (a) stale real-file copy → re-asserted to symlink; canonical untouched.
- `TestMirrorProfileEntries_NewerScratchCredentials_PromotedThenRelinked` — (d) promote-then-relink; canonical gets the fresh token, `0600` preserved, scratch relinked.
- `TestEnsureWorkerScratchConfigDir_RestartRepairsClobberedCredentialSymlink` — (c) start/restart through the real spawn entry point repairs a clobbered link.

Preservation guards (pass on old + new code — assert invariants the fix must not break):
- `TestMirrorProfileEntries_CorrectCredentialSymlink_LeftAlone` — (b) idempotent; correct symlink left alone, canonical not rewritten.
- `TestMirrorProfileEntries_SettingsJsonStillExcluded` — (e) `settings.json` stays a real owned file, never symlinked; credentials still linked.

All tests use `t.TempDir()` for fake profile + scratch dirs and control `mtime` with `os.Chtimes` — they never touch the real `~/.claude*` credentials, and no `claude -p` is invoked.

## Verification

- `go test -race -count=1 ./internal/session/` → **ok** (76s)
- `go test -race -count=1 -timeout 15m ./...` → **40 packages ok, 0 failures**
- `golangci-lint run ./internal/session/...` → **0 issues**
- `govulncheck ./internal/session/...` → **No vulnerabilities found**
- `go build ./...` → clean

## Operator note

Added a "Common gotchas" entry to `docs/CONDUCTOR-SETUP.md` and a code-comment warning: **do not `/login` inside a managed session** — log in once in the canonical profile and it propagates via the symlink. The fix self-heals an in-session login on the next restart, but the clean habit avoids the round-trip.

Closes #1222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed credential symlink handling in worker directories to prevent corruption when credentials are updated. Symlinks are now properly healed and maintained.

* **Tests**
  * Added comprehensive regression tests for credential symlink management, including scenarios for stale credentials, symlink repair after restart, and newer credentials promotion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
