### PR TITLE
feat(comms): activate outbox-drain (conductor-scoped Stop sync + heartbeat drain) + release v1.9.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.44] - 2026-05-29
+
+### Added
+
+- **Durable per-parent outbox for inter-agent completions** ([#1225](https://github.com/asheshgoplani/agent-deck/issues/1225) / [#1226](https://github.com/asheshgoplani/agent-deck/pull/1226)). Child completions are committed to a durable, per-parent outbox (`~/.agent-deck/inboxes/<parent>.jsonl`) and drained by the parent on its own schedule, replacing the push-into-tmux model that silently lost completions to an always-busy conductor. At-least-once delivery with exactly-once effects (last-wins per child, consumed-turn dedup ledger); survives parent busy-ness, restart, and compaction.
+
+### Changed
+
+- **Activated the durable-outbox comms engine** ([#1225](https://github.com/asheshgoplani/agent-deck/issues/1225) / [#1226](https://github.com/asheshgoplani/agent-deck/pull/1226)). The conductor Stop hook is now **synchronous** so Claude Code reads the `{decision:"block"}` the hook emits and injects busy-parent completions at the next turn boundary, and `agent-deck inbox drain self` is the first step of every conductor heartbeat (the idle-conductor fallback). The Stop-sync flip is **conductor-scoped at runtime**, not globally: a session with an empty inbox (every leaf/non-conductor session) fast-returns with no block and zero ledger writes, so the flip is inert for them. The loop guard is crash-safe and fails safe on an absent `stop_hook_active` flag. Roll out canary-first to one conductor. Zero billed inference — the hook is a Go handler, no `claude -p`.
+
+### Fixed
+
+- **Work-profile 401 `/login` loop on session spawn/restart** ([#1222](https://github.com/asheshgoplani/agent-deck/issues/1222) / [#1224](https://github.com/asheshgoplani/agent-deck/pull/1224)). The scratch `.credentials.json` symlink is re-asserted on spawn and on start/restart, stopping the work-profile credential loss that forced a re-login loop.
+
 ## [1.9.43] - 2026-05-28
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -38,7 +38,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.9.43" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.9.44" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/documentation/CONDUCTOR.md
+++ b/documentation/CONDUCTOR.md
@@ -163,7 +163,22 @@ If you enabled heartbeat at setup (it is enabled by default), agent-deck install
 [HEARTBEAT]
 ```
 
-The conductor is instructed to respond with either:
+The first action on every heartbeat is to drain its inbox:
+
+```bash
+agent-deck inbox drain self
+```
+
+This pulls any child completions that landed in the conductor's durable outbox
+(`~/.agent-deck/inboxes/<id>.jsonl`) while it was busy. Delivery is pull, not push
+(issue [#1225](https://github.com/asheshgoplani/agent-deck/issues/1225) /
+[#1226](https://github.com/asheshgoplani/agent-deck/issues/1226)): a child that
+finishes mid-turn commits its completion to disk rather than typing into the
+conductor's pane. The conductor's synchronous Stop hook drains the same queue at
+each turn boundary (the busy-conductor path); this heartbeat drain is the
+idle-conductor fallback. Together they guarantee no completion is missed.
+
+The conductor then responds with either:
 
 ```
 [STATUS] {one-line summary of current state}

--- a/internal/session/claude_hooks.go
+++ b/internal/session/claude_hooks.go
@@ -42,15 +42,16 @@ var hookEventConfigs = []struct {
 }{
 	{Event: "SessionStart", Async: true},
 	{Event: "UserPromptSubmit", Async: true},
-	// Stop stays ASYNC in this PR (#1225 ships inert). The ACTIVATION PR flips it
-	// to sync so Claude Code reads the {decision:"block"} the hook emits to inject
-	// busy-parent completions. Audit B12 flagged a GLOBAL sync flip as the top
-	// risk; the scope is enforced at RUNTIME, not per-session install: DrainForStopHook
-	// fast-returns (no block, ZERO ledger writes) for any session without a pending
-	// inbox — i.e. every non-conductor/leaf session — so the flip is provably inert
-	// for them. The MaxStopHookBlocks loop guard is crash-safe (B4) and fails safe on
-	// an absent stop_hook_active flag (B8). See the scoped activation note in the PR.
-	{Event: "Stop", Async: true},
+	// Issue #1225/#1226 ACTIVATION: Stop is SYNCHRONOUS so Claude Code reads the
+	// {decision:"block",reason} the hook emits to inject busy-parent completions.
+	// Audit B12 (global-flip risk) is mitigated by RUNTIME scope, not a per-session
+	// install (hooks are per config-dir, shared by conductor + workers):
+	//   - DrainForStopHook fast-returns with no block and ZERO ledger writes for any
+	//     session with an empty inbox (every leaf/non-conductor session) — inert flip.
+	//   - The MaxStopHookBlocks loop guard is crash-safe (B4) and fails safe on an
+	//     absent stop_hook_active flag (B8), so it cannot be defeated into a loop.
+	// Canary one conductor before flipping fleet-wide (GAP §5).
+	{Event: "Stop", Async: false},
 	// PermissionRequest is synchronous so the hook handler's stdout decision is
 	// consulted by Claude Code. In headless / /remote-control contexts an async
 	// hook with no UI fallback caused silent deny; the sync hook plus an

--- a/internal/session/claude_hooks_test.go
+++ b/internal/session/claude_hooks_test.go
@@ -66,6 +66,50 @@ func TestInjectClaudeHooks_Fresh(t *testing.T) {
 	}
 }
 
+// TestStopHookIsSynchronousForActivation guards the issue #1225/#1226 ACTIVATION:
+// the Stop hook must install SYNCHRONOUSLY so Claude Code consults the hook's
+// stdout {decision:"block",reason} and injects busy-parent completions. An async
+// Stop hook makes Claude ignore stdout, so the durable-outbox engine ships inert.
+// The flip is provably safe for non-conductor sessions via the DrainForStopHook
+// InboxHasPending fast path (see TestB12_StopHook_LeafSessionNeverBlocksNorWritesLedger).
+func TestStopHookIsSynchronousForActivation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if _, err := InjectClaudeHooks(tmpDir); err != nil {
+		t.Fatalf("InjectClaudeHooks failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("Failed to read settings.json: %v", err)
+	}
+	var settings map[string]json.RawMessage
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("Failed to parse settings: %v", err)
+	}
+
+	var hooks map[string]json.RawMessage
+	if err := json.Unmarshal(settings["hooks"], &hooks); err != nil {
+		t.Fatalf("Failed to parse hooks: %v", err)
+	}
+
+	var matchers []claudeHookMatcher
+	if err := json.Unmarshal(hooks["Stop"], &matchers); err != nil {
+		t.Fatalf("Failed to parse Stop matchers: %v", err)
+	}
+	if len(matchers) == 0 || len(matchers[0].Hooks) == 0 {
+		t.Fatal("Stop has no hooks")
+	}
+
+	hook := matchers[0].Hooks[0]
+	if hook.Async {
+		t.Error("Stop hook must be synchronous (Async should be false) so Claude Code reads the busy-parent {decision:\"block\"} — see issue #1225/#1226 activation")
+	}
+	if hook.Command != agentDeckHookCommand {
+		t.Errorf("Stop hook command = %q, want %q", hook.Command, agentDeckHookCommand)
+	}
+}
+
 func TestPreCompactHookIsSynchronous(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -61,6 +61,20 @@ Every N minutes, the bridge sends you a message like:
 [HEARTBEAT] [<name>] Status: 2 waiting, 3 running, 1 idle, 0 error. Waiting sessions: frontend (project: ~/src/app), api-fix (project: ~/src/api). Check if any need auto-response or user attention.
 ` + "```" + `
 
+**FIRST step of EVERY heartbeat — drain your inbox:**
+
+` + "```bash" + `
+agent-deck inbox drain self
+` + "```" + `
+
+This pulls any child completions that landed in your durable outbox while you were
+busy (issue #1225/#1226). Delivery is pull, not push: a child that finished mid-turn
+committed its completion to ` + "`" + `~/.agent-deck/inboxes/<your-id>.jsonl` + "`" + ` rather than typing
+into your pane. The drain marks records consumed (exactly-once effects) and prints
+them; act on each before composing your status. Your Stop hook drains the same queue
+automatically at each turn boundary, so this heartbeat drain is the idle-conductor
+fallback — together they guarantee no completion is missed whether you are busy or idle.
+
 **Your heartbeat response format:**
 
 ` + "```" + `


### PR DESCRIPTION
## What this is

The **ON-SWITCH** for the durable per-parent outbox comms engine merged in #1226 (issue #1225). That PR shipped the engine **inert** — the consumer (`DrainForStopHook`), the durable two-phase drain, the loop guard, and the heartbeat `inbox drain` command all landed, but the conductor Stop hook stayed **async**, so Claude Code never read the `{decision:"block"}` the hook emits. This PR flips it on.

## Changes

1. **`internal/session/claude_hooks.go`** — flip the `Stop` hook from `Async: true` → **`Async: false`** (sync). Claude Code only consults a Stop hook's stdout `{decision:"block",reason}` when it runs synchronously; with the flip, a busy conductor's pending child completions are injected at its next turn boundary.

2. **`internal/session/conductor_templates.go` + `documentation/CONDUCTOR.md`** — wire **`agent-deck inbox drain self`** as the **first step of every conductor heartbeat**. This is the idle-conductor drain fallback (§3d Tier 1) that complements the busy-conductor Stop hook (§3c). One durable queue, two drain triggers.

3. **`cmd/agent-deck/main.go`** — bump `Version` to **1.9.44**.

4. **`CHANGELOG.md`** — v1.9.44 entry crediting the durable-outbox comms fix (#1225/#1226), the activation, and the work-profile credential 401 fix (#1222/#1224).

## Conductor-scoped — NOT a global flip

The re-audit's top risk (B12) was that hooks install per Claude **config-dir** (shared by a conductor and its leaf workers), so there is **no install-time seam** to make the Stop hook sync "only for conductors." Scoping is therefore enforced at **runtime**:

- `DrainForStopHook` calls `InboxHasPending` (a cheap stat) first. A session with an empty inbox — **every leaf / non-conductor session** — returns immediately with **no block and zero stop-block ledger writes**. The sync flip is provably **inert** for them: no added blocking, the only added work is one `stat`.
- Guarded by `TestB12_StopHook_LeafSessionNeverBlocksNorWritesLedger` (existing) + the new `TestStopHookIsSynchronousForActivation` (guards the flip itself).
- The `MaxStopHookBlocks` loop guard is crash-safe (B4) and fails safe on an absent `stop_hook_active` flag (B8 → `resolveStopHookActive`), so it cannot be defeated into a token-burn loop.

Zero billed inference — the hook is a Go handler, **no `claude -p`**.

## Verification

- `go test -race ./internal/session/... ./cmd/agent-deck/...` → **green** (70s / 70s).
- `golangci-lint run` on changed packages → **0 issues**.
- `govulncheck ./...` → **no vulnerabilities**.
- Confirmed conductor-scoped: leaf/non-conductor Stop is a no-op (no block, no ledger write, single stat).

## Rollout

**Canary-first** (GAP §5): flip one conductor, watch it drain busy-parent completions correctly at turn boundaries and heartbeats, then roll fleet-wide. **Do not** tag/release from this PR — the maintainer handles tag-push after merge.

Refs #1225, #1226.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Released version 1.9.44

* **Bug Fixes**
  * Fixed Claude Code Stop event to execute synchronously for improved reliability
  * Enhanced heartbeat processing to drain inbox before composing responses, ensuring no completions are missed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->