### PR TITLE
fix(send): skip Claude-tuned post-send verify for codex tools (#1205)

### DIFF
--- a/cmd/agent-deck/issue1205_codex_send_test.go
+++ b/cmd/agent-deck/issue1205_codex_send_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// #1205: codex's TUI exposes no "active" transition or composer/paste markers,
+// so the #876 delivery-verify false-negatives and its Ctrl+C recovery kills the
+// pane. Codex sends are routed through skipVerify instead.
+
+// codexShapedTarget returns a mock whose status never reaches "active" and whose
+// pane shows no composer marker — the shape that broke the verifier for codex.
+func codexShapedTarget() *mockSendRetryTarget {
+	return &mockSendRetryTarget{statuses: []string{"waiting"}, panes: []string{""}}
+}
+
+// TestSendWithRetryTarget_CodexSkipVerify_NoDestructiveRecovery asserts the codex
+// path (skipVerify) is a single atomic send: no Ctrl+C, no Enter spam, no error,
+// even though the target never transitions to "active".
+func TestSendWithRetryTarget_CodexSkipVerify_NoDestructiveRecovery(t *testing.T) {
+	mock := codexShapedTarget()
+	err := sendWithRetryTarget(mock, "hello codex", true, sendRetryOptions{
+		maxRetries: 50, checkDelay: 0, verifyDelivery: true,
+	})
+	if err != nil {
+		t.Fatalf("codex skipVerify send should succeed, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
+		t.Fatalf("expected 1 SendKeysAndEnter, got %d", got)
+	}
+	if got := atomic.LoadInt32(&mock.sendCtrlCCalls); got != 0 {
+		t.Fatalf("codex must never receive Ctrl+C, got %d", got)
+	}
+	if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+		t.Fatalf("expected no Enter nudges, got %d", got)
+	}
+}
+
+// TestSendWithRetryTarget_CodexShapedWithoutSkip_TriggersCtrlC guards the
+// regression: without skipVerify the same codex-shaped state drives the
+// destructive Ctrl+C recovery the fix avoids.
+func TestSendWithRetryTarget_CodexShapedWithoutSkip_TriggersCtrlC(t *testing.T) {
+	mock := codexShapedTarget()
+	_ = sendWithRetryTarget(mock, "hello codex", false, sendRetryOptions{
+		maxRetries: 12, checkDelay: 0, maxFullResends: 1,
+	})
+	if atomic.LoadInt32(&mock.sendCtrlCCalls) == 0 {
+		t.Fatal("expected Ctrl+C recovery on codex-shaped waiting state")
+	}
+}
+
+// TestSendWithRetryTarget_Codex_RemoteSessionNotApplicable documents, per the
+// cmd/agent-deck RemoteSession guideline, why this change needs no
+// RemoteSession-specific coverage.
+func TestSendWithRetryTarget_Codex_RemoteSessionNotApplicable(t *testing.T) {
+	t.Skip("RemoteSession N/A: `agent-deck session send` has no remote branch — it " +
+		"drives the local tmux session via sendWithRetryTarget. RemoteSession is a " +
+		"TUI-over-SSH viewer (remote_keysender) with no post-send verify loop, so the " +
+		"codex skip-verify applies to the local/CLI send path only.")
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -559,7 +559,7 @@ func handleLaunch(profile string, args []string) {
 	if initialMessage != "" && *noWait {
 		tmuxSess := newInstance.GetTmuxSession()
 		if tmuxSess != nil {
-			if err := sendWithRetryTarget(tmuxSess, initialMessage, false, sendRetryOptions{
+			if err := sendWithRetryTarget(tmuxSess, initialMessage, session.IsCodexCompatible(newInstance.Tool), sendRetryOptions{
 				maxRetries: 8,
 				checkDelay: 150 * time.Millisecond,
 			}); err != nil {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2016,7 +2016,7 @@ func handleSessionSend(profile string, args []string) {
 			os.Exit(1)
 		}
 	} else {
-		if err := sendWithRetry(tmuxSess, message, false); err != nil {
+		if err := sendWithRetry(tmuxSess, message, session.IsCodexCompatible(inst.Tool)); err != nil {
 			out.Error(fmt.Sprintf("failed to send message: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
@@ -2232,7 +2232,7 @@ func sendNoWait(target sendRetryTarget, tool, message string) error {
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
-	return sendWithRetryTarget(target, message, false, noWaitSendOptions())
+	return sendWithRetryTarget(target, message, session.IsCodexCompatible(tool), noWaitSendOptions())
 }
 
 type sendRetryTarget interface {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3152,6 +3152,12 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 				return fmt.Errorf("failed to send message: %w", err)
 			}
 
+			// Codex exposes no "active"/composer markers, so the verify loop
+			// below false-negatives and Enter-spams it; skip it for codex (#1205).
+			if IsCodexCompatible(i.Tool) {
+				return nil
+			}
+
 			// Verify the agent accepted Enter and began processing.
 			// Strategy:
 			// - If unsent prompt is visible, press Enter again immediately.


### PR DESCRIPTION
Fixes #1205.

## Problem
`agent-deck session send` (and `launch -m`) to a `tool=codex` session always fails with `send dropped silently: no evidence of delivery after N checks (issue #876)` (exit 1). In the session-send path the Ctrl+C recovery then quits codex and kills the pane, so the session goes to `error`. As the issue reports, the message is actually delivered and codex responds — only the verification is wrong.

## Root cause
The #876 delivery-evidence verifier is Claude-tuned: it waits for an `"active"` status transition plus composer / unsent-paste markers. Codex's TUI exposes neither, so a successful send false-negatives, and the Ctrl+C-then-resend recovery tears the session down.

## Fix
Codex reliably consumes the atomic `send-keys` input and readiness is already gated before sending, so for codex tools skip the Claude-tuned post-send verify:
- `internal/session/instance.go` `sendMessageWhenReady` (launch -m): return `nil` right after `SendKeysAndEnter` for codex (also avoids 50x stray Enter nudges).
- `cmd/agent-deck/session_cmd.go` session-send + `sendNoWait`: pass `skipVerify` for codex.
- `cmd/agent-deck/launch_cmd.go` `--no-wait` initial send: pass `skipVerify` for codex.

Gated via the existing `session.IsCodexCompatible(tool)`.

## Tests
`cmd/agent-deck/issue1205_codex_send_test.go`:
- codex/skipVerify path -> single atomic send, no Ctrl+C, no Enter-nudge spam, no error (even when the status never goes `active`).
- guard: the same codex-shaped waiting state **without** skipVerify drives the destructive Ctrl+C recovery the fix avoids.

`gofmt` / `go vet` clean; `cmd/agent-deck` + `internal/session` package tests green; builds on `main`.

## Verified live
codex-cli 0.134.0 with agent-deck built from this change: `session send --wait`, `launch -m`, and `--no-wait` all succeed, the session stays alive, and codex receives + processes the message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating send-and-retry and recovery behavior for Codex-shaped sessions, covering both verification and skip-verify scenarios.

* **Bug Fixes**
  * Send flow now skips unnecessary post-send verification and retry for Codex-compatible tools, improving initial message delivery reliability.
* **Behavior**
  * The skip-verify option is now derived from tool compatibility for no-wait sends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->