### PR TITLE
feat(display): add include_cwd_prefix toggle (#1221)

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1792,6 +1792,12 @@ type DisplaySettings struct {
 	// Valid statuses: "running", "waiting", "idle", "error", "starting",
 	// "stopped".
 	ActiveFilterExcludes []string `toml:"active_filter_excludes"`
+
+	// IncludeCwdPrefix controls whether the terminal/pane title is prefixed
+	// with "[<cwd-basename>]" (e.g. "[my-project] feature work"). Default true
+	// preserves the historical format; set false to show only the session
+	// title. Consumed by the tmux set-titles-string builder.
+	IncludeCwdPrefix *bool `toml:"include_cwd_prefix"`
 }
 
 // GetActiveFilterExcludes returns the resolved set of statuses the % filter
@@ -1846,6 +1852,15 @@ func (d DisplaySettings) GetFullRepaint() bool {
 		return true
 	}
 	return d.FullRepaint
+}
+
+// GetIncludeCwdPrefix reports whether the "[<cwd-basename>]" title prefix is
+// shown. Defaults to true to preserve the historical title format.
+func (d DisplaySettings) GetIncludeCwdPrefix() bool {
+	if d.IncludeCwdPrefix == nil {
+		return true
+	}
+	return *d.IncludeCwdPrefix
 }
 
 // Default user config (empty maps)

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -10,6 +10,35 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+func TestDisplaySettings_GetIncludeCwdPrefix(t *testing.T) {
+	var d DisplaySettings
+	if !d.GetIncludeCwdPrefix() {
+		t.Fatal("default GetIncludeCwdPrefix() = false, want true (preserve historical prefix)")
+	}
+
+	f := false
+	d.IncludeCwdPrefix = &f
+	if d.GetIncludeCwdPrefix() {
+		t.Fatal("GetIncludeCwdPrefix() with explicit false = true, want false")
+	}
+
+	tr := true
+	d.IncludeCwdPrefix = &tr
+	if !d.GetIncludeCwdPrefix() {
+		t.Fatal("GetIncludeCwdPrefix() with explicit true = false, want true")
+	}
+}
+
+func TestDisplaySettings_IncludeCwdPrefix_TOML(t *testing.T) {
+	var cfg UserConfig
+	if _, err := toml.Decode("[display]\ninclude_cwd_prefix = false\n", &cfg); err != nil {
+		t.Fatalf("toml decode: %v", err)
+	}
+	if cfg.Display.GetIncludeCwdPrefix() {
+		t.Fatal("include_cwd_prefix=false in TOML did not disable the prefix")
+	}
+}
+
 func TestGetCodexCommand_DefaultAndConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	originalHome := os.Getenv("HOME")

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -2122,6 +2123,19 @@ func (s *Session) buildStatusBarArgs() []string {
 	return args
 }
 
+// hideCwdPrefixInTitle, when true, drops the "[<project>] " prefix from the
+// terminal title (set-titles-string). Default false preserves the historical
+// "[<project>] <name>" format. Set once at startup from the user config's
+// [display] include_cwd_prefix via SetHideCwdPrefixInTitle.
+var hideCwdPrefixInTitle atomic.Bool
+
+// SetHideCwdPrefixInTitle configures whether the terminal title includes the
+// "[<cwd-basename>]" prefix. Pass true to drop it (display.include_cwd_prefix =
+// false). Safe to call concurrently; intended to run once at startup.
+func SetHideCwdPrefixInTitle(hide bool) {
+	hideCwdPrefixInTitle.Store(hide)
+}
+
 // buildTerminalTitleArgs returns the tmux command args for configuring the outer
 // terminal title shown by clients such as iTerm2. Session metadata user options
 // are always refreshed so custom title formats can reuse them.
@@ -2139,7 +2153,11 @@ func (s *Session) buildTerminalTitleArgs() []string {
 		defaults = append(defaults, option{key: "set-titles", value: "on"})
 	}
 	if _, overridden := s.OptionOverrides["set-titles-string"]; !overridden {
-		defaults = append(defaults, option{key: "set-titles-string", value: "[#{@agentdeck_project_name}] #{@agentdeck_display_name}"})
+		titleStr := "[#{@agentdeck_project_name}] #{@agentdeck_display_name}"
+		if hideCwdPrefixInTitle.Load() {
+			titleStr = "#{@agentdeck_display_name}"
+		}
+		defaults = append(defaults, option{key: "set-titles-string", value: titleStr})
 	}
 
 	args := make([]string, 0, len(defaults)*6)

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2867,6 +2867,36 @@ func TestBuildTerminalTitleArgs(t *testing.T) {
 	}
 }
 
+func TestBuildTerminalTitleArgs_CwdPrefixHidden(t *testing.T) {
+	parse := func(args []string) map[string]string {
+		m := make(map[string]string)
+		for i, a := range args {
+			if a == "set-option" && i+4 < len(args) {
+				m[args[i+3]] = args[i+4]
+			}
+		}
+		return m
+	}
+
+	s := &Session{
+		Name:        "test-sess",
+		DisplayName: "feature work",
+		WorkDir:     "/tmp/agent-deck",
+	}
+
+	// Default preserves the historical "[<project>] <title>" format.
+	if got := parse(s.buildTerminalTitleArgs())["set-titles-string"]; got != "[#{@agentdeck_project_name}] #{@agentdeck_display_name}" {
+		t.Fatalf("default set-titles-string = %q, want bracketed cwd prefix", got)
+	}
+
+	// [display] include_cwd_prefix = false drops the "[<project>] " prefix.
+	SetHideCwdPrefixInTitle(true)
+	t.Cleanup(func() { SetHideCwdPrefixInTitle(false) })
+	if got := parse(s.buildTerminalTitleArgs())["set-titles-string"]; got != "#{@agentdeck_display_name}" {
+		t.Fatalf("hidden set-titles-string = %q, want display name only", got)
+	}
+}
+
 func TestConfigureTerminalTitle(t *testing.T) {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux not available")

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -978,6 +978,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.defaultFilter = cfg.Display.GetDefaultFilter()
 		h.activeFilterLabel = cfg.Display.ActiveFilterLabel
 		h.activeFilterExcludes = cfg.Display.GetActiveFilterExcludes()
+		tmux.SetHideCwdPrefixInTitle(!cfg.Display.GetIncludeCwdPrefix())
 		h.sysStatsConfig = cfg.SystemStats
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(cfg, actualProfile)
 		h.previewPct = cfg.UI.GetPreviewPct()


### PR DESCRIPTION
Implements #1221.

Adds a `[display] include_cwd_prefix` config knob (default `true`) that gates the `[<cwd-basename>]` prefix on the terminal title (`set-titles-string`). The default preserves the current `[<project>] <name>` format; set it to `false` to show only the session title.

Per the issue thread, the prefix is gated at the single place the title is formatted (`buildTerminalTitleArgs`), driven by config resolved once at startup.

### Changes
- `DisplaySettings.IncludeCwdPrefix *bool` + `GetIncludeCwdPrefix()` — defaults to `true`.
- `internal/tmux`: package-level `hideCwdPrefixInTitle` flag gates the `set-titles-string` value; `SetHideCwdPrefixInTitle(...)` is called once at TUI startup from `cfg.Display.GetIncludeCwdPrefix()`.
- Tests: getter default, TOML decode of the new key, and the title builder emitting the prefix on/off.

### Behavior
Default is `true`, so existing setups are unchanged. To opt out:

```toml
[display]
include_cwd_prefix = false
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration option `include_cwd_prefix` to control whether terminal and pane titles include the current working directory basename prefix. This setting defaults to `true` for backward compatibility and can be disabled to display cleaner terminal titles with only the display name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->