### PR TITLE
feat(comms): wire wake-nudge for near-instant idle-conductor delivery (no 14-min lag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.45] - 2026-05-30
+
+### Added
+
+- **Near-instant idle-conductor completion delivery (wake-nudge wired)** ([#1225](https://github.com/asheshgoplani/agent-deck/issues/1225) / [#1226](https://github.com/asheshgoplani/agent-deck/pull/1226)). The durable outbox shipped in v1.9.44 is correct (no loss, exactly-once) but an **idle** conductor only drained on its next heartbeat — up to ~14 min of latency. The `WakeNudger` (built but previously unwired) is now triggered from the single producer commit chokepoint (`commitEventToInbox`), which both producers funnel through: the interactive `running→waiting` path and the one-shot `run-task` kernel-exit path. The moment a completion durably lands in a parent's inbox, an **idle** conductor is woken to drain it — collapsing the idle worst case from ~14 min to **sub-second**. The nudge is event-driven (fired on commit, not polled), conductor-scoped, idle-gated (never sends into a busy pane — a send-keys there only queues, the exact failure the pull model avoids), debounced per-parent (~500ms, coalesces a burst of simultaneous completions into one wake without delaying the first), and **best-effort/fire-and-forget**: a dropped or failed nudge is harmless because the same durable record is still drained on the parent's next Stop/heartbeat (wake ≠ deliver). A busy parent is intentionally left to drain at its next turn boundary — the physical floor for a busy Claude pane — so the nudge adds no noise there. Zero billed inference.
+
 ## [1.9.44] - 2026-05-29
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -38,7 +38,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.9.44" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.9.45" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/internal/session/inbox_nudge_wiring.go
+++ b/internal/session/inbox_nudge_wiring.go
@@ -1,0 +1,151 @@
+package session
+
+import (
+	"log/slog"
+	"os/exec"
+	"time"
+)
+
+// Issue #1225 Tier-2 WIRING. inbox_nudge.go holds the platform-independent
+// policy core (WakeNudger: debounced, idle-only, best-effort). This file wires
+// it into the live producer commit path so an IDLE conductor is woken to drain
+// the MOMENT a completion durably lands — instead of waiting up to ~14 min for
+// its next heartbeat. The trigger is event-driven (fired synchronously from the
+// commit chokepoint, commitEventToInbox), NOT a poll loop.
+//
+// Everything here is best-effort: a nil wiring, a busy/non-conductor parent, or
+// a failed send is harmless because the durable record is still drained on the
+// parent's next Stop/heartbeat. Wake ≠ deliver.
+
+// defaultWakeNudgeDebounce bounds how often a single idle parent is woken by a
+// write-triggered nudge. A burst of N children completing near-simultaneously
+// collapses to ONE wake; the parent's Stop-hook drain then consumes every
+// pending record in that single woken turn, so a suppressed nudge loses no
+// delivery. The window NEVER delays the FIRST completion (Nudge sends the first
+// and only debounces subsequent ones), so it adds zero latency to the common
+// single-completion case. ~500ms is the audit-fleet sweet spot: long enough to
+// kill a thundering-herd of send-keys, short enough to be imperceptible — and
+// well under the ~100-300ms Claude pane-pickup cost that dominates real latency.
+const defaultWakeNudgeDebounce = 500 * time.Millisecond
+
+// wakeNudgeMessage is the prompt fired into an idle conductor's pane to wake it.
+// The content does not affect delivery — taking ANY turn runs the conductor's
+// Stop-hook drain, which is what actually consumes the durable inbox. The text
+// only tells the conductor WHY it woke so it acts on the queue immediately.
+const wakeNudgeMessage = "[INBOX] A child just committed a completion to your inbox — drain it and act on each item now."
+
+// wakeNudgeWiring carries the platform hooks the Tier-2 wake-nudge needs. It is
+// kept out of the WakeNudger policy core so the idle-only/debounced policy stays
+// testable without tmux: tests inject spy probes, production wires the live
+// status probe + a best-effort no-wait pane send.
+type wakeNudgeWiring struct {
+	nudger *WakeNudger
+	now    func() time.Time
+	isIdle func(parent *Instance) bool
+	send   func(parent *Instance, profile string) error
+}
+
+// defaultWakeNudgeWiring is the production wiring: a debounced nudger, the wall
+// clock, the conductor-scoped idle probe, and a best-effort non-blocking pane
+// send.
+func defaultWakeNudgeWiring() *wakeNudgeWiring {
+	return &wakeNudgeWiring{
+		nudger: NewWakeNudger(defaultWakeNudgeDebounce),
+		now:    time.Now,
+		isIdle: parentIsNudgeableIdle,
+		send:   sendWakeNudge,
+	}
+}
+
+// fireWakeNudge invokes the Tier-2 wake-nudge for a parent that just had a
+// completion durably committed. It is best-effort and MUST NOT affect the commit
+// result: a nil wiring, a non-conductor/busy parent, or a send error are all
+// swallowed (the durable record still drains on the next turn/heartbeat). A
+// panic in the injected probe/send is recovered so a wake bug can never take
+// down the producer.
+func (n *TransitionNotifier) fireWakeNudge(parent *Instance, event TransitionNotificationEvent) {
+	w := n.wake
+	if w == nil || w.nudger == nil || parent == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			commsLog.Warn("wake_nudge_panic_recovered",
+				slog.String("parent", parent.ID), slog.Any("panic", r))
+		}
+	}()
+
+	now := time.Now()
+	if w.now != nil {
+		now = w.now()
+	}
+	profile := event.Profile
+	isIdle := func() bool { return w.isIdle != nil && w.isIdle(parent) }
+	send := func() error {
+		if w.send == nil {
+			return nil
+		}
+		return w.send(parent, profile)
+	}
+	if _, err := w.nudger.Nudge(parent.ID, now, isIdle, send); err != nil {
+		// Best-effort: a failed wake is harmless. Log once at debug-ish level so
+		// the operator can see WHY a pane wasn't woken without it being an error.
+		commsLog.Warn("wake_nudge_send_failed",
+			slog.String("parent", parent.ID), slog.String("error", err.Error()))
+	}
+}
+
+// parentIsNudgeableIdle reports whether parent is safe to wake with a send-keys
+// nudge: it must be a conductor (only conductors drain an inbox on Stop, so a
+// nudge to a non-conductor leaf would be pure noise) AND currently idle/waiting,
+// NOT mid-turn. A send-keys into a RUNNING pane only queues the keystroke
+// (issue #36326) — the exact failure the pull model was built to avoid — so a
+// busy conductor is left to drain at its own turn boundary.
+//
+// parent.Status is read directly (not re-probed): the conductor branch of
+// resolveParentNotificationTarget freshly UpdateStatus()'d this same instance
+// moments earlier on the commit path, so a second tmux round-trip would add cost
+// without adding freshness.
+func parentIsNudgeableIdle(parent *Instance) bool {
+	if parent == nil || !isConductorSessionTitle(parent.Title) {
+		return false
+	}
+	switch parent.Status {
+	case StatusIdle, StatusWaiting:
+		return true
+	default:
+		return false
+	}
+}
+
+// sendWakeNudge fires one best-effort wake into the parent conductor's pane and
+// returns immediately. The actual `session send --no-wait` runs detached so a
+// slow/stuck send never blocks the producer commit path; the gate that this is
+// only reached for an IDLE pane means the send won't sit in tmux's busy-queue.
+// A failed send is harmless (the record still drains on the next turn).
+func sendWakeNudge(parent *Instance, profile string) error {
+	if parent == nil {
+		return nil
+	}
+	go func(profile, ref string) {
+		if err := sendWakeNudgeNoWait(profile, ref); err != nil {
+			commsLog.Warn("wake_nudge_dispatch_failed",
+				slog.String("parent", ref), slog.String("error", err.Error()))
+		}
+	}(profile, parent.ID)
+	return nil
+}
+
+// sendWakeNudgeNoWait shells out to `agent-deck [-p profile] session send <ref>
+// <msg> --no-wait -q`. --no-wait keeps it fire-and-forget: it neither blocks for
+// the agent's ready state nor waits for a reply, so it returns fast even if the
+// pane is wedged.
+func sendWakeNudgeNoWait(profile, ref string) error {
+	bin := agentDeckBinaryPath()
+	args := []string{}
+	if profile != "" {
+		args = append(args, "-p", profile)
+	}
+	args = append(args, "session", "send", ref, wakeNudgeMessage, "--no-wait", "-q")
+	return exec.Command(bin, args...).Run()
+}

--- a/internal/session/inbox_nudge_wiring.go
+++ b/internal/session/inbox_nudge_wiring.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"log/slog"
 	"os/exec"
 	"time"
@@ -136,16 +137,33 @@ func sendWakeNudge(parent *Instance, profile string) error {
 	return nil
 }
 
+// wakeNudgeSendTimeout bounds the detached wake-nudge subprocess. --no-wait
+// already returns fast, so 5s is generous; the bound exists purely so a wedged
+// agent-deck binary (e.g. stuck on SQLite/tmux) is reaped instead of leaking the
+// dispatch goroutine indefinitely (PR #1230 audit). A timed-out send is harmless
+// like any dropped nudge — the record still drains on the next turn/heartbeat.
+const wakeNudgeSendTimeout = 5 * time.Second
+
+// wakeNudgeExec runs the resolved command under ctx. It is a package var so a
+// test can substitute a spy and assert the deadline/args without spawning a real
+// process; production runs the real bounded subprocess.
+var wakeNudgeExec = func(ctx context.Context, bin string, args ...string) error {
+	return exec.CommandContext(ctx, bin, args...).Run()
+}
+
 // sendWakeNudgeNoWait shells out to `agent-deck [-p profile] session send <ref>
 // <msg> --no-wait -q`. --no-wait keeps it fire-and-forget: it neither blocks for
 // the agent's ready state nor waits for a reply, so it returns fast even if the
-// pane is wedged.
+// pane is wedged. The context deadline is a belt-and-suspenders backstop for the
+// case where even the subprocess itself hangs.
 func sendWakeNudgeNoWait(profile, ref string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), wakeNudgeSendTimeout)
+	defer cancel()
 	bin := agentDeckBinaryPath()
 	args := []string{}
 	if profile != "" {
 		args = append(args, "-p", profile)
 	}
 	args = append(args, "session", "send", ref, wakeNudgeMessage, "--no-wait", "-q")
-	return exec.Command(bin, args...).Run()
+	return wakeNudgeExec(ctx, bin, args...)
 }

--- a/internal/session/inbox_outbox.go
+++ b/internal/session/inbox_outbox.go
@@ -324,20 +324,22 @@ func writeDeadLetter(event TransitionNotificationEvent) error {
 // --- unified producer commit (shared by interactive + one-shot) -------------
 
 // resolveParentIDForInbox loads the registry and applies the
-// suppression/orphan/conductor guards, returning the resolved parent id to
-// commit to. transient is true on a storage error (the
-// caller should retry later rather than dead-letter). An empty parentID with
-// transient=false means the event is terminally undeliverable (orphan, removed
-// child, self-pointing conductor, no-notify) and should be dead-lettered.
-func (n *TransitionNotifier) resolveParentIDForInbox(event TransitionNotificationEvent) (parentID string, transient bool, reason string) {
+// suppression/orphan/conductor guards, returning the resolved parent instance to
+// commit to (the instance — not just its id — so the caller can idle-gate a
+// wake-nudge against the same freshly-resolved status without a second tmux
+// probe). transient is true on a storage error (the caller should retry later
+// rather than dead-letter). A nil parent with transient=false means the event is
+// terminally undeliverable (orphan, removed child, self-pointing conductor,
+// no-notify) and should be dead-lettered.
+func (n *TransitionNotifier) resolveParentIDForInbox(event TransitionNotificationEvent) (parent *Instance, transient bool, reason string) {
 	storage, err := NewStorageWithProfile(event.Profile)
 	if err != nil {
-		return "", true, ""
+		return nil, true, ""
 	}
 	defer storage.Close()
 	instances, _, err := storage.LoadWithGroups()
 	if err != nil {
-		return "", true, ""
+		return nil, true, ""
 	}
 	byID := make(map[string]*Instance, len(instances))
 	for _, inst := range instances {
@@ -348,36 +350,36 @@ func (n *TransitionNotifier) resolveParentIDForInbox(event TransitionNotificatio
 	if child == nil {
 		// Child removed between commit/observe and resolve — terminal, but the
 		// operator should know a completion was dropped (audit B5).
-		return "", false, deadLetterReasonChildMissing
+		return nil, false, deadLetterReasonChildMissing
 	}
 	if child.NoTransitionNotify {
-		return "", false, deadLetterReasonNoNotify
+		return nil, false, deadLetterReasonNoNotify
 	}
 	// Top-level conductor self-suppress (issue #824 cause B): the root is not
 	// an orphan, drop silently.
 	if strings.TrimSpace(child.ParentSessionID) == "" && isConductorSessionTitle(child.Title) {
-		return "", false, deadLetterReasonSelfConductor
+		return nil, false, deadLetterReasonSelfConductor
 	}
 	// Orphan-on-creation guard (issue #805 cause A): log one WARN per orphan.
 	if strings.TrimSpace(child.ParentSessionID) == "" {
 		n.logOrphanOnce(event, child.ID)
-		return "", false, deadLetterReasonOrphan
+		return nil, false, deadLetterReasonOrphan
 	}
 	if strings.TrimSpace(child.ParentSessionID) == child.ID && isConductorSessionTitle(child.Title) {
-		return "", false, deadLetterReasonSelfConductor
+		return nil, false, deadLetterReasonSelfConductor
 	}
 	// Parent referenced but not present in this profile's registry: removed
 	// mid-flight, or the child's parent lives in a DIFFERENT profile (we only
 	// load event.Profile's registry). Either way it's terminal — but distinguish
 	// it so the operator isn't left guessing (audit B5).
 	if byID[strings.TrimSpace(child.ParentSessionID)] == nil {
-		return "", false, deadLetterReasonParentMissing
+		return nil, false, deadLetterReasonParentMissing
 	}
-	parent := resolveParentNotificationTarget(child, byID)
+	parent = resolveParentNotificationTarget(child, byID)
 	if parent == nil {
-		return "", false, deadLetterReasonUnresolvable
+		return nil, false, deadLetterReasonUnresolvable
 	}
-	return parent.ID, false, ""
+	return parent, false, ""
 }
 
 // commitEventToInbox is the unified producer entry point: it resolves the
@@ -386,13 +388,14 @@ func (n *TransitionNotifier) resolveParentIDForInbox(event TransitionNotificatio
 // retryable error (storage/fs) occurred. committed=false, transient=false means
 // terminally undeliverable — the caller dead-letters.
 func (n *TransitionNotifier) commitEventToInbox(event TransitionNotificationEvent) (committed bool, transient bool, reason string) {
-	parentID, t, reason := n.resolveParentIDForInbox(event)
+	parent, t, reason := n.resolveParentIDForInbox(event)
 	if t {
 		return false, true, ""
 	}
-	if parentID == "" {
+	if parent == nil {
 		return false, false, reason
 	}
+	parentID := parent.ID
 	event.TargetSessionID = parentID
 	event.TargetKind = "parent"
 	event.DeliveryResult = transitionDeliveryCommitted
@@ -403,6 +406,12 @@ func (n *TransitionNotifier) commitEventToInbox(event TransitionNotificationEven
 		return false, true, ""
 	}
 	n.logEvent(event)
+	// Issue #1225 Tier-2: now that the record durably landed, wake an IDLE parent
+	// to drain it immediately instead of on its next ~14-min heartbeat. This is
+	// the event-driven trigger — fired the moment the completion is committed,
+	// not on a poll. Best-effort and non-fatal: a dropped nudge is harmless
+	// because this same record is still drained on the parent's next turn.
+	n.fireWakeNudge(parent, event)
 	return true, false, ""
 }
 

--- a/internal/session/issue1225_wake_nudge_timeout_test.go
+++ b/internal/session/issue1225_wake_nudge_timeout_test.go
@@ -1,0 +1,64 @@
+package session
+
+// Hardening (PR #1230 audit): the detached wake-nudge send must run under a
+// bounded context so a hung agent-deck binary (e.g. wedged on SQLite/tmux)
+// cannot leak the dispatch goroutine indefinitely. These tests pin the deadline
+// behavior without spawning a real slow process.
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The wake-nudge send always runs under a context deadline, ~wakeNudgeSendTimeout
+// out, so a stuck binary is reaped instead of leaking the goroutine forever.
+func TestIssue1225_WakeNudgeSendHasTimeout(t *testing.T) {
+	orig := wakeNudgeExec
+	t.Cleanup(func() { wakeNudgeExec = orig })
+
+	var deadline time.Time
+	var hadDeadline bool
+	wakeNudgeExec = func(ctx context.Context, bin string, args ...string) error {
+		deadline, hadDeadline = ctx.Deadline()
+		return nil
+	}
+
+	if err := sendWakeNudgeNoWait("", "parent-x"); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if !hadDeadline {
+		t.Fatal("wake-nudge send must run under a context deadline (hung-binary guard)")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 || remaining > wakeNudgeSendTimeout+time.Second {
+		t.Fatalf("deadline = %v from now, want within (0, %v]", remaining, wakeNudgeSendTimeout)
+	}
+}
+
+// The resolved command line is the expected `[-p profile] session send <ref>
+// <msg> --no-wait -q` — proving the timeout wrapper didn't drop --no-wait (which
+// is what keeps the send fire-and-forget independent of the context bound).
+func TestIssue1225_WakeNudgeSendCommandShape(t *testing.T) {
+	orig := wakeNudgeExec
+	t.Cleanup(func() { wakeNudgeExec = orig })
+
+	var gotArgs []string
+	wakeNudgeExec = func(ctx context.Context, bin string, args ...string) error {
+		gotArgs = args
+		return nil
+	}
+
+	if err := sendWakeNudgeNoWait("myprofile", "parent-y"); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	want := []string{"-p", "myprofile", "session", "send", "parent-y", wakeNudgeMessage, "--no-wait", "-q"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Fatalf("args = %v, want %v (differ at %d)", gotArgs, want, i)
+		}
+	}
+}

--- a/internal/session/issue1225_wake_nudge_wiring_test.go
+++ b/internal/session/issue1225_wake_nudge_wiring_test.go
@@ -1,0 +1,177 @@
+package session
+
+// Issue #1225 Tier-2 wiring — the wake-nudge was built + unit-tested
+// (issue1225_wake_nudge_test.go) but NOTHING triggered it: an idle conductor
+// only drained on its next heartbeat (up to ~14 min lag). These tests assert
+// the producer commit chokepoint (commitEventToInbox, shared by the interactive
+// running→waiting path AND the one-shot run-task completion path) fires a
+// debounced, idle-only, best-effort wake-nudge to THAT parent the moment a
+// completion durably lands — and that a dropped nudge is harmless because the
+// durable record is still present for the next-turn drain.
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newWakeNudgeFixture seeds a child→parent pair in a fresh profile and returns a
+// notifier plus a finished event whose commit resolves to parentID. The parent
+// is titled non-"conductor-" so resolveParentNotificationTarget keeps it live
+// without a tmux UpdateStatus (the conductor-scoping policy is unit-tested
+// separately in TestIssue1225_ParentIsNudgeableIdle).
+func newWakeNudgeFixture(t *testing.T) (*TransitionNotifier, string, TransitionNotificationEvent) {
+	t.Helper()
+	inboxTestHome(t)
+	profile := "_test-wake-nudge"
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	t.Cleanup(func() { storage.Close() })
+
+	now := time.Now()
+	parentID := "wake-parent-1"
+	child := &Instance{
+		ID:              "wake-child-1",
+		Title:           "worker",
+		ProjectPath:     "/tmp/c",
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: parentID,
+		Tool:            "claude",
+		Status:          StatusRunning,
+		CreatedAt:       now,
+	}
+	parent := &Instance{
+		ID:          parentID,
+		Title:       "orchestrator",
+		ProjectPath: "/tmp/p",
+		GroupPath:   DefaultGroupPath,
+		Tool:        "claude",
+		Status:      StatusIdle,
+		CreatedAt:   now,
+	}
+	if err := storage.SaveWithGroups([]*Instance{child, parent}, nil); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	event := TransitionNotificationEvent{
+		ChildSessionID: child.ID,
+		ChildTitle:     child.Title,
+		Profile:        profile,
+		DoneStatus:     "success",
+		DoneSummary:    "done",
+	}
+	return NewTransitionNotifier(), parentID, event
+}
+
+// A successful commit fires exactly one wake-nudge, aimed at the resolved parent.
+func TestIssue1225_CommitFiresWakeNudgeToParent(t *testing.T) {
+	n, parentID, event := newWakeNudgeFixture(t)
+
+	var mu sync.Mutex
+	var sentTo []string
+	n.wake = &wakeNudgeWiring{
+		nudger: NewWakeNudger(0),
+		now:    func() time.Time { return time.Unix(1000, 0) },
+		isIdle: func(p *Instance) bool { return true },
+		send: func(p *Instance, profile string) error {
+			mu.Lock()
+			sentTo = append(sentTo, p.ID)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	res := n.NotifyFinished(event)
+	if res.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("commit result = %q, want %q", res.DeliveryResult, transitionDeliveryCommitted)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(sentTo) != 1 || sentTo[0] != parentID {
+		t.Fatalf("wake-nudge targets = %v, want exactly [%s]", sentTo, parentID)
+	}
+}
+
+// A busy (non-idle) parent is never nudged — send-keys into a running pane only
+// queues the keystroke (issue #36326). The commit still succeeds.
+func TestIssue1225_CommitDoesNotNudgeBusyParent(t *testing.T) {
+	n, _, event := newWakeNudgeFixture(t)
+	sent := 0
+	n.wake = &wakeNudgeWiring{
+		nudger: NewWakeNudger(0),
+		now:    func() time.Time { return time.Unix(1000, 0) },
+		isIdle: func(p *Instance) bool { return false },
+		send:   func(p *Instance, profile string) error { sent++; return nil },
+	}
+	res := n.NotifyFinished(event)
+	if res.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("commit must still succeed for a busy parent; got %q", res.DeliveryResult)
+	}
+	if sent != 0 {
+		t.Fatalf("busy parent: send called %d times, want 0", sent)
+	}
+}
+
+// Two completions landing in a burst collapse to ONE wake — the parent's drain
+// consumes all pending records in the single woken turn, so the suppressed
+// nudge loses nothing.
+func TestIssue1225_RapidCommitsDebounceToOneNudge(t *testing.T) {
+	n, _, event := newWakeNudgeFixture(t)
+	sent := 0
+	n.wake = &wakeNudgeWiring{
+		nudger: NewWakeNudger(time.Minute),
+		now:    func() time.Time { return time.Unix(2000, 0) },
+		isIdle: func(p *Instance) bool { return true },
+		send:   func(p *Instance, profile string) error { sent++; return nil },
+	}
+	n.NotifyFinished(event)
+	n.NotifyFinished(event) // within the debounce window → suppressed
+	if sent != 1 {
+		t.Fatalf("rapid commits: send called %d times, want 1 (debounced)", sent)
+	}
+}
+
+// A nudge that fails to send is harmless: the commit still reports committed AND
+// the durable record is present for the next heartbeat/turn drain (wake ≠ deliver).
+func TestIssue1225_NudgeSendErrorIsHarmless(t *testing.T) {
+	n, parentID, event := newWakeNudgeFixture(t)
+	n.wake = &wakeNudgeWiring{
+		nudger: NewWakeNudger(0),
+		now:    func() time.Time { return time.Unix(3000, 0) },
+		isIdle: func(p *Instance) bool { return true },
+		send:   func(p *Instance, profile string) error { return errors.New("pane gone") },
+	}
+	res := n.NotifyFinished(event)
+	if res.DeliveryResult != transitionDeliveryCommitted {
+		t.Fatalf("a failed nudge must not fail the commit; got %q", res.DeliveryResult)
+	}
+	got := readInboxLines(t, parentID)
+	if len(got) != 1 {
+		t.Fatalf("durable record count = %d, want 1 (drain-on-next-turn safety net)", len(got))
+	}
+}
+
+// The production idle-probe is conductor-scoped (only conductors drain an inbox)
+// and only green when the pane is idle/waiting (not mid-turn).
+func TestIssue1225_ParentIsNudgeableIdle(t *testing.T) {
+	cases := []struct {
+		title  string
+		status Status
+		want   bool
+	}{
+		{"conductor-x", StatusIdle, true},
+		{"conductor-x", StatusWaiting, true},
+		{"conductor-x", StatusRunning, false}, // busy: send-keys would only queue
+		{"worker", StatusIdle, false},         // non-conductor leaf: no inbox drain → noise
+		{"conductor-x", StatusError, false},
+	}
+	for _, c := range cases {
+		p := &Instance{ID: "p", Title: c.title, Status: c.status}
+		if got := parentIsNudgeableIdle(p); got != c.want {
+			t.Errorf("parentIsNudgeableIdle(title=%q,status=%q)=%v, want %v", c.title, c.status, got, c.want)
+		}
+	}
+}

--- a/internal/session/issue1225_wake_nudge_wiring_test.go
+++ b/internal/session/issue1225_wake_nudge_wiring_test.go
@@ -154,6 +154,27 @@ func TestIssue1225_NudgeSendErrorIsHarmless(t *testing.T) {
 	}
 }
 
+// The PRODUCTION default wiring (not a test spy) is fully populated and routes
+// its idle probe through the conductor-scoped gate end-to-end: a conductor-
+// prefixed title is nudgeable only when idle, a busy conductor and a
+// non-conductor leaf are not. This guards against a future refactor silently
+// swapping defaultWakeNudgeWiring's isIdle for an unscoped probe.
+func TestIssue1225_DefaultWiringUsesConductorIdleGate(t *testing.T) {
+	w := defaultWakeNudgeWiring()
+	if w == nil || w.nudger == nil || w.now == nil || w.isIdle == nil || w.send == nil {
+		t.Fatalf("default wiring must populate every hook, got %+v", w)
+	}
+	if !w.isIdle(&Instance{ID: "c", Title: "conductor-x", Status: StatusIdle}) {
+		t.Fatal("default wiring must nudge an idle conductor")
+	}
+	if w.isIdle(&Instance{ID: "c", Title: "conductor-x", Status: StatusRunning}) {
+		t.Fatal("default wiring must NOT nudge a busy conductor (send-keys would only queue)")
+	}
+	if w.isIdle(&Instance{ID: "l", Title: "worker", Status: StatusIdle}) {
+		t.Fatal("default wiring must NOT nudge a non-conductor leaf (no inbox drain → noise)")
+	}
+}
+
 // The production idle-probe is conductor-scoped (only conductors drain an inbox)
 // and only green when the pane is idle/waiting (not mid-turn).
 func TestIssue1225_ParentIsNudgeableIdle(t *testing.T) {

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -151,6 +151,14 @@ type TransitionNotifier struct {
 	// Lazily initialized against missedPath via deadLetterSink().
 	dlMu   sync.Mutex
 	dlSink *DeadLetterSink
+
+	// wake is the issue #1225 Tier-2 wake-nudge wiring: after a record durably
+	// lands in a parent's inbox, commitEventToInbox fires a debounced, idle-only,
+	// best-effort send-keys to wake that parent so it drains the MOMENT the
+	// completion is committed instead of on its next ~14-min heartbeat. nil
+	// disables nudging (correctness unaffected — the record still drains on the
+	// next turn). Tests inject a spy wiring; production gets defaultWakeNudgeWiring.
+	wake *wakeNudgeWiring
 }
 
 // deadLetterSink returns the notifier's bounded dead-letter sink, initialized
@@ -176,6 +184,7 @@ func NewTransitionNotifier() *TransitionNotifier {
 		orphanWarned: map[string]bool{},
 		missedSeen:   map[string]bool{},
 		terminalSeen: map[string]bool{},
+		wake:         defaultWakeNudgeWiring(),
 	}
 	n.loadState()
 	return n


### PR DESCRIPTION
## What

Wires the existing `WakeNudger` (`internal/session/inbox_nudge.go`, built + unit-tested in #1226 but never triggered) so an **idle** conductor drains the MOMENT a child completion is committed — collapsing the idle-delivery worst case from **~14 min to sub-second**.

## Why

v1.9.44 (#1226) shipped the durable per-parent outbox + drain (#1225): correct, no loss, exactly-once. But delivery is **pull** — the parent drains on its own turn boundary. A **busy** conductor drains via its synchronous Stop hook (fine), but an **idle** conductor only drained on its next *heartbeat*, i.e. up to ~14 min later. The nudge is the latency layer that was missing.

## Mechanism (event-driven, no poll loop)

The nudge fires from the **single producer commit chokepoint**, `commitEventToInbox`, which **both** producers funnel through:

- interactive `running→waiting` path → `NotifyTransition` / `NotifyFinished` → `commitEventToInbox`
- one-shot `run-task` kernel-exit path → `DeliverCompletion` → `commitEventToInbox` (from both `runtask_cmd.go` and the daemon replay)

So one call site covers 100% of producers, in-process, with no new daemon. An inotify watcher was evaluated and **rejected**: it adds a kernel-exit race (the task-worker can write-and-exit before the watcher acts), fd/lifecycle cost, and its ~10ms edge is invisible next to the ~100–300ms Claude pane-pickup cost that actually dominates latency.

## Safety properties (all preserved)

- **Conductor-scoped** — only the resolved parent conductor is nudged; non-conductor leaves are never touched (no inbox drain there → pure noise).
- **Idle-gated** — never `send-keys` into a busy pane (a keystroke there only *queues* — the exact failure the pull model was built to avoid). Reads the freshly-resolved parent status (no second tmux probe).
- **Debounced ~500ms per-parent** — a burst of simultaneous completions coalesces into one wake; the parent's drain then consumes every pending record in that single woken turn. The window never delays the *first* completion.
- **Best-effort / fire-and-forget** — a dropped, failed, or panicking nudge is harmless: the same durable record is still drained on the parent's next Stop/heartbeat (**wake ≠ deliver**). The send runs detached so it never blocks the commit path.
- **Busy parent** = next turn boundary, intentionally. That's the physical floor for a busy Claude pane (going faster needs Ctrl+C, which breaks in-flight work + exactly-once). The nudge adds no noise there.
- **Zero billed inference** — pure Go, no `claude -p`.

## Tests (TDD, failing-first)

New `internal/session/issue1225_wake_nudge_wiring_test.go`:

- `TestIssue1225_CommitFiresWakeNudgeToParent` — a successful commit fires exactly one nudge, aimed at the resolved parent.
- `TestIssue1225_CommitDoesNotNudgeBusyParent` — busy parent → 0 sends, commit still succeeds.
- `TestIssue1225_RapidCommitsDebounceToOneNudge` — two rapid commits → one wake.
- `TestIssue1225_NudgeSendErrorIsHarmless` — a send error doesn't fail the commit; the durable record remains for the next-turn drain.
- `TestIssue1225_ParentIsNudgeableIdle` — the production probe is conductor-scoped and idle-only.

RED confirmed on current code (no trigger wired) → GREEN after wiring. `go test -race ./internal/session/... ./cmd/agent-deck/...` green; golangci `0 issues`; govulncheck clean.

## Version

Bumps `1.9.44` → `1.9.45` + CHANGELOG.

Refs #1225 #1226. Heartbeat-interval reduction was evaluated as an optional fallback and intentionally left out to keep this change surgical (no behavior change to the 7 production conductors' heartbeat config).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event-driven wake nudges: parent conductors are now signaled to drain inboxes immediately after commits, improving responsiveness while leaving commit outcomes unchanged on nudge failures.

* **Tests**
  * Comprehensive tests for wake-nudge behavior: idle-state gating, debounce deduping, send timeouts, command shape, and error resilience.

* **Chores**
  * Version bumped to 1.9.45.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->