### PR TITLE
test(perf): Tier 1 WARM suite — statedb CRUD + storage-mediated group lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,14 @@ test:
 
 # Run hard-gated walltime regression tests (Track B). Honors PERF_BUDGET_MULTIPLIER
 # (default 1.0 locally; CI sets 2.0). See docs/perf-budget-suite.md.
+#
+# ./... (not just ./cmd/agent-deck/...) so Tier 1 TestPerf_* added in any
+# package — internal/statedb, internal/session — are exercised locally, matching
+# the perf-smoke.yml CI gate which already runs the whole module.
 test-perf:
 	PERF_BUDGET_MULTIPLIER=$${PERF_BUDGET_MULTIPLIER:-1.0} \
 		go test -run '^TestPerf_' -race -v -count=1 -timeout 120s \
-		./cmd/agent-deck/...
+		./...
 
 # Run advisory benchmarks (Track A). No -race — race overhead distorts ns/op.
 # Output is for trending; not a CI gate.

--- a/internal/session/group_perf_test.go
+++ b/internal/session/group_perf_test.go
@@ -1,0 +1,101 @@
+package session
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// Tier-1 WARM perf gate for the storage-mediated group lifecycle.
+//
+// PR #790 explicitly carved group create/delete out of its first perf pass:
+// done purely in-memory (GroupTree map mutation) it "exercises the wrong
+// layer" — the map ops are nanoseconds and gate nothing real. This test does
+// it AT the storage layer instead: each create/delete is followed by the
+// persistence call the TUI/CLI actually make — Storage.SaveGroupsOnly, which
+// rewrites the whole groups table in one transaction (DELETE FROM groups +
+// re-INSERT all rows + COMMIT). That transaction commit is the CPU regression
+// target Tier 1 gates.
+//
+// Why WARM, not COLD: the work is pure in-process Go against an SQLite handle
+// on a t.TempDir() path (tmpfs on CI Linux). No process boundary, no real-disk
+// fsync, no child spawn, no network. TrimmedMeanWarm forces a GC cycle per
+// iteration and disables auto-GC in the timed window, so the tighter base×3
+// WarmBudget is safe. See internal/testutil/perfbudget.go and
+// docs/perf-budget-suite.md ("Tier 1 vs Tier 2").
+//
+// No real tmux. No network. Pure-Go in-process SQLite on tmpfs.
+
+// perfGroupBaseline is the number of pre-existing groups the table is seeded
+// with before the timed create/delete round trip. SaveGroupsOnly rewrites the
+// full table, so a realistic baseline matters: a ~50-session deck (the cited
+// upper-end size, internal/web/handlers_costs.go:529) organized at roughly
+// five sessions per group lands near ten groups.
+const perfGroupBaseline = 10
+
+// perfGroupBase is the local median observed under -race at
+// PERF_BUDGET_MULTIPLIER=1.0 for one create→persist→delete→persist round trip
+// (two full-table-rewrite transactions). WarmBudget multiplies by 3 and
+// applies the 1ms floor and the env multiplier (CI sets 2.0 → 6× local gate).
+const perfGroupBase = 9 * time.Millisecond // → WarmBudget = 27ms local, 54ms CI
+
+// newPerfStorage builds a Storage backed by a migrated SQLite DB on a
+// tmpfs-backed t.TempDir() path. Constructed directly (rather than via
+// NewStorageWithProfile) to keep the fixture hermetic — no HOME/profile
+// migration scanning — while exercising the identical SaveGroupsOnly →
+// db.SaveGroups path users hit.
+func newPerfStorage(t *testing.T) *Storage {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	db, err := statedb.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return &Storage{db: db, dbPath: dbPath, profile: "perf"}
+}
+
+// TestPerf_Group_CreateDelete gates one storage-mediated group create+delete
+// round trip against a representative baseline of pre-existing groups. The
+// timed op creates a group, persists, deletes it, and persists again — two
+// SaveGroupsOnly transactions. Because create-then-delete is net-zero on the
+// tree, the fixture returns to baseline each iteration and TrimmedMeanWarm (no
+// per-iter rebuild) applies.
+func TestPerf_Group_CreateDelete(t *testing.T) {
+	testutil.SkipIfShort(t)
+	storage := newPerfStorage(t)
+
+	// Seed a representative baseline of empty groups and persist once.
+	tree := NewGroupTree(nil)
+	for i := 0; i < perfGroupBaseline; i++ {
+		tree.CreateGroup(fmt.Sprintf("group-%d", i))
+	}
+	if err := storage.SaveGroupsOnly(tree); err != nil {
+		t.Fatalf("seed SaveGroupsOnly: %v", err)
+	}
+
+	budget := testutil.WarmBudget(t, perfGroupBase)
+
+	got := testutil.TrimmedMeanWarm(func() {
+		g := tree.CreateGroup("perf-ephemeral")
+		if err := storage.SaveGroupsOnly(tree); err != nil {
+			t.Fatalf("create SaveGroupsOnly: %v", err)
+		}
+		tree.DeleteGroup(g.Path)
+		if err := storage.SaveGroupsOnly(tree); err != nil {
+			t.Fatalf("delete SaveGroupsOnly: %v", err)
+		}
+	})
+
+	if got > budget {
+		t.Fatalf("group create+delete round trip trimmed mean = %v, budget = %v (regression in SaveGroupsOnly transaction path)", got, budget)
+	}
+	t.Logf("group create+delete round trip (baseline %d groups) trimmed mean = %v (budget = %v)", perfGroupBaseline, got, budget)
+}

--- a/internal/session/group_perf_test.go
+++ b/internal/session/group_perf_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -14,40 +15,67 @@ import (
 //
 // PR #790 explicitly carved group create/delete out of its first perf pass:
 // done purely in-memory (GroupTree map mutation) it "exercises the wrong
-// layer" — the map ops are nanoseconds and gate nothing real. This test does
-// it AT the storage layer instead: each create/delete is followed by the
-// persistence call the TUI/CLI actually make — Storage.SaveGroupsOnly, which
-// rewrites the whole groups table in one transaction (DELETE FROM groups +
-// re-INSERT all rows + COMMIT). That transaction commit is the CPU regression
-// target Tier 1 gates.
+// layer" — the map ops are nanoseconds and gate nothing real. This test gates
+// it at the storage layer by reconstructing the exact choreography the real
+// user-facing handlers perform — cmd/agent-deck/group_cmd.go handleGroupCreate
+// (~L396-442) and handleGroupDelete (~L689-705):
 //
-// Why WARM, not COLD: the work is pure in-process Go against an SQLite handle
-// on a t.TempDir() path (tmpfs on CI Linux). No process boundary, no real-disk
-// fsync, no child spawn, no network. TrimmedMeanWarm forces a GC cycle per
-// iteration and disables auto-GC in the timed window, so the tighter base×3
-// WarmBudget is safe. See internal/testutil/perfbudget.go and
-// docs/perf-budget-suite.md ("Tier 1 vs Tier 2").
+//	storage.LoadWithGroups()                     // full read of all instances + groups
+//	session.NewGroupTreeWithGroups(insts, grps)  // rebuild the tree
+//	groupTree.CreateGroup / DeleteGroup          // the mutation
+//	storage.SaveWithGroups(insts, groupTree)     // rewrite the WHOLE instances
+//	                                             // table + groups + Touch() + dedup
+//
+// This is deliberately NOT Storage.SaveGroupsOnly: that is the lightweight
+// expand/collapse visual-state path (its own doc comment says so) and skips
+// both the instances round-trip and Touch(). Group create/delete goes through
+// SaveWithGroups, where the dominant cost is the instances-table read+rewrite
+// — which is why this test runs against a populated deck (perfGroupPopN
+// instances), not an empty DB.
+//
+// What this test does NOT cover: the literal CLI shell (flag parsing,
+// NewStorageWithProfile, out.Success/os.Exit). Driving that in-process needs
+// the same injection seam deferred for session create/delete — see the PR
+// description. The seam-free remainder (flag parse + stdout formatting) carries
+// no meaningful, tmux-touching cost, so the storage choreography above is the
+// faithful Tier-1 target.
+//
+// Why WARM, not COLD: pure in-process Go against an SQLite handle on a
+// t.TempDir() path (tmpfs on CI Linux). No process boundary, no real-disk
+// fsync, no child spawn, no network. Seeded rows carry TmuxSession="" so
+// LoadWithGroups' lazy tmux.ReconnectSessionLazy branch never runs — zero tmux
+// code executes. TrimmedMeanWarm forces a GC cycle per iteration and disables
+// auto-GC in the timed window, so the tighter base×3 WarmBudget is safe. See
+// internal/testutil/perfbudget.go and docs/perf-budget-suite.md ("Tier 1 vs
+// Tier 2").
 //
 // No real tmux. No network. Pure-Go in-process SQLite on tmpfs.
 
-// perfGroupBaseline is the number of pre-existing groups the table is seeded
-// with before the timed create/delete round trip. SaveGroupsOnly rewrites the
-// full table, so a realistic baseline matters: a ~50-session deck (the cited
-// upper-end size, internal/web/handlers_costs.go:529) organized at roughly
-// five sessions per group lands near ten groups.
+// perfGroupPopN is the instance population the deck is seeded with. 50 is the
+// representative upper-end deck size cited in code (internal/web/handlers_costs.go:529
+// notes the sidebar "grows past ~50 sessions"); group create/delete rewrites
+// this whole table via SaveWithGroups, so a realistic population is the point.
+const perfGroupPopN = 50
+
+// perfGroupBaseline is the number of groups the seeded deck spans (5 sessions
+// per group across the perfGroupPopN instances → ~10 groups).
 const perfGroupBaseline = 10
 
 // perfGroupBase is the local median observed under -race at
-// PERF_BUDGET_MULTIPLIER=1.0 for one create→persist→delete→persist round trip
-// (two full-table-rewrite transactions). WarmBudget multiplies by 3 and
-// applies the 1ms floor and the env multiplier (CI sets 2.0 → 6× local gate).
-const perfGroupBase = 9 * time.Millisecond // → WarmBudget = 27ms local, 54ms CI
+// PERF_BUDGET_MULTIPLIER=1.0 for the real create+delete choreography (two full
+// LoadWithGroups → SaveWithGroups round trips over a perfGroupPopN-instance
+// deck). WarmBudget multiplies by 3 and applies the 1ms floor and the env
+// multiplier (CI sets 2.0 → 6× local gate).
+//
+// Local median under -race: ~67ms (two LoadWithGroups + two SaveWithGroups
+// full instances-table rewrites over a 50-instance deck).
+const perfGroupBase = 70 * time.Millisecond // → WarmBudget = 210ms local, 420ms CI
 
 // newPerfStorage builds a Storage backed by a migrated SQLite DB on a
 // tmpfs-backed t.TempDir() path. Constructed directly (rather than via
 // NewStorageWithProfile) to keep the fixture hermetic — no HOME/profile
-// migration scanning — while exercising the identical SaveGroupsOnly →
-// db.SaveGroups path users hit.
+// migration scanning — while exercising the identical LoadWithGroups /
+// SaveWithGroups paths the CLI handlers hit.
 func newPerfStorage(t *testing.T) *Storage {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "state.db")
@@ -62,40 +90,84 @@ func newPerfStorage(t *testing.T) *Storage {
 	return &Storage{db: db, dbPath: dbPath, profile: "perf"}
 }
 
-// TestPerf_Group_CreateDelete gates one storage-mediated group create+delete
-// round trip against a representative baseline of pre-existing groups. The
-// timed op creates a group, persists, deletes it, and persists again — two
-// SaveGroupsOnly transactions. Because create-then-delete is net-zero on the
-// tree, the fixture returns to baseline each iteration and TrimmedMeanWarm (no
-// per-iter rebuild) applies.
+// seedDeck persists perfGroupPopN instances spread across perfGroupBaseline
+// groups directly via the statedb layer (setup, excluded from timing). Rows
+// carry TmuxSession="" so the later LoadWithGroups conversion runs no tmux code.
+func seedDeck(t *testing.T, storage *Storage) {
+	t.Helper()
+	rows := make([]*statedb.InstanceRow, perfGroupPopN)
+	now := time.Now()
+	for i := 0; i < perfGroupPopN; i++ {
+		rows[i] = &statedb.InstanceRow{
+			ID:          fmt.Sprintf("perf-%04d", i),
+			Title:       fmt.Sprintf("Session %d", i),
+			ProjectPath: fmt.Sprintf("/home/dev/project-%d", i),
+			GroupPath:   fmt.Sprintf("group-%d", i%perfGroupBaseline),
+			Order:       i,
+			Tool:        "claude",
+			Status:      "idle",
+			CreatedAt:   now,
+			ToolData:    json.RawMessage(`{"claude_session_id":"sess-abcdef"}`),
+		}
+	}
+	if err := storage.db.SaveInstances(rows); err != nil {
+		t.Fatalf("seed SaveInstances: %v", err)
+	}
+}
+
+// TestPerf_Group_CreateDelete gates the storage-mediated group create+delete
+// lifecycle by reconstructing the handleGroupCreate / handleGroupDelete
+// choreography (see file header) against a perfGroupPopN-instance deck.
+//
+// The timed op runs both halves — a create cycle then a delete cycle, each a
+// full LoadWithGroups → rebuild tree → mutate → SaveWithGroups round trip.
+// Creating then deleting the same ephemeral group is net-zero on persisted
+// state, so the deck returns to baseline each iteration and TrimmedMeanWarm (no
+// per-iter fixture rebuild) applies. The dominant measured cost is the two
+// instances-table read+rewrite passes — exactly the regression class Tier 1
+// gates ("we added N ms of CPU work in the group save path").
 func TestPerf_Group_CreateDelete(t *testing.T) {
 	testutil.SkipIfShort(t)
 	storage := newPerfStorage(t)
-
-	// Seed a representative baseline of empty groups and persist once.
-	tree := NewGroupTree(nil)
-	for i := 0; i < perfGroupBaseline; i++ {
-		tree.CreateGroup(fmt.Sprintf("group-%d", i))
-	}
-	if err := storage.SaveGroupsOnly(tree); err != nil {
-		t.Fatalf("seed SaveGroupsOnly: %v", err)
-	}
+	seedDeck(t, storage)
 
 	budget := testutil.WarmBudget(t, perfGroupBase)
 
+	// createCycle mirrors handleGroupCreate: load, rebuild tree, CreateGroup,
+	// SaveWithGroups(loaded instances, tree).
+	createCycle := func() {
+		instances, groups, err := storage.LoadWithGroups()
+		if err != nil {
+			t.Fatalf("create LoadWithGroups: %v", err)
+		}
+		tree := NewGroupTreeWithGroups(instances, groups)
+		tree.CreateGroup("perf-ephemeral")
+		if err := storage.SaveWithGroups(instances, tree); err != nil {
+			t.Fatalf("create SaveWithGroups: %v", err)
+		}
+	}
+
+	// deleteCycle mirrors handleGroupDelete: load, rebuild tree, DeleteGroup,
+	// SaveWithGroups(tree.GetAllInstances(), tree).
+	deleteCycle := func() {
+		instances, groups, err := storage.LoadWithGroups()
+		if err != nil {
+			t.Fatalf("delete LoadWithGroups: %v", err)
+		}
+		tree := NewGroupTreeWithGroups(instances, groups)
+		tree.DeleteGroup("perf-ephemeral")
+		if err := storage.SaveWithGroups(tree.GetAllInstances(), tree); err != nil {
+			t.Fatalf("delete SaveWithGroups: %v", err)
+		}
+	}
+
 	got := testutil.TrimmedMeanWarm(func() {
-		g := tree.CreateGroup("perf-ephemeral")
-		if err := storage.SaveGroupsOnly(tree); err != nil {
-			t.Fatalf("create SaveGroupsOnly: %v", err)
-		}
-		tree.DeleteGroup(g.Path)
-		if err := storage.SaveGroupsOnly(tree); err != nil {
-			t.Fatalf("delete SaveGroupsOnly: %v", err)
-		}
+		createCycle()
+		deleteCycle()
 	})
 
 	if got > budget {
-		t.Fatalf("group create+delete round trip trimmed mean = %v, budget = %v (regression in SaveGroupsOnly transaction path)", got, budget)
+		t.Fatalf("group create+delete (LoadWithGroups→SaveWithGroups ×2, %d-instance deck) trimmed mean = %v, budget = %v (regression in the group save path)", perfGroupPopN, got, budget)
 	}
-	t.Logf("group create+delete round trip (baseline %d groups) trimmed mean = %v (budget = %v)", perfGroupBaseline, got, budget)
+	t.Logf("group create+delete (LoadWithGroups→SaveWithGroups ×2, %d-instance deck) trimmed mean = %v (budget = %v)", perfGroupPopN, got, budget)
 }

--- a/internal/statedb/statedb_perf_test.go
+++ b/internal/statedb/statedb_perf_test.go
@@ -1,0 +1,310 @@
+package statedb
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// Tier-1 WARM perf gates for the StateDB persistence layer.
+//
+// These tests cover the deferred "persistence-touching lifecycle" items from
+// PR #790 / #1047 (see docs/perf-budget-suite.md, "Tier 1 vs Tier 2"). They
+// run against a t.TempDir() SQLite database — tmpfs on CI Linux — so fsync is
+// effectively free and the measured cost is CPU + Go-runtime cost only (driver
+// marshalling, statement prep, row scanning, SQLite page churn). That is the
+// regression class Tier 1 gates: "we added N ms of CPU work in the save/read
+// path". It does NOT gate fsync/transaction *counts* — that is Tier 2 (count
+// assertions), owned by a sibling session, see the //TODO in the watcher-event
+// test below.
+//
+// Why WARM, not COLD: every operation is pure in-process Go against an
+// SQLite handle on tmpfs. No process boundary, no real-disk fsync, no child
+// spawn, no network — exactly the WARM criteria. WARM measurement
+// (TrimmedMeanWarm / TrimmedMeanWithSetup) forces a GC cycle per iteration and
+// disables auto-GC inside the timed window, removing the dominant noise source;
+// the tighter base×3 WarmBudget is therefore safe. See
+// internal/testutil/perfbudget.go for the full cold/warm convention.
+//
+// Population size N: 50 rows. This is the representative upper-end session
+// count cited in the codebase — internal/web/handlers_costs.go:529 notes the
+// sidebar "grows past ~50 sessions" (and llms-full.txt cites 30-session
+// workspaces). 50 is a realistic heavily-loaded deck, not an invented number.
+//
+// No real tmux. No network. Pure-Go in-process SQLite on tmpfs.
+
+// perfPopN is the representative session population for the CRUD scaling gates.
+// See file header: ~50 is the cited upper-end deck size
+// (internal/web/handlers_costs.go:529).
+const perfPopN = 50
+
+// Base local medians observed under -race at PERF_BUDGET_MULTIPLIER=1.0
+// (Linux/WSL2, this dev host). WarmBudget multiplies by 3 and applies the
+// 1ms floor and the env multiplier (CI sets 2.0 → 6× local gate).
+const (
+	// 50× SaveInstance into an empty table (per-session insert path).
+	// Local median under -race: ~206ms (50 autocommit WAL txns dominate).
+	perfStateDBInsertBase = 210 * time.Millisecond // → WarmBudget = 630ms local, 1.26s CI
+	// 50× InstanceExists (read-by-id query path; rm-verify uses this).
+	// Local median under -race: ~9.3ms.
+	perfStateDBReadByIDBase = 10 * time.Millisecond // → WarmBudget = 30ms local, 60ms CI
+	// One LoadInstances over a 50-row table (list path).
+	// Local median under -race: ~6.9ms.
+	perfStateDBListBase = 7 * time.Millisecond // → WarmBudget = 21ms local, 42ms CI
+	// 50× DeleteInstance (the `agent-deck rm` xargs path, issue #909).
+	// Local median under -race: ~166ms (50 autocommit txns + withBusyRetry).
+	perfStateDBDeleteBase = 170 * time.Millisecond // → WarmBudget = 510ms local, 1.02s CI
+	// Ingest 50 fresh events on a 500-event steady-state table (insert + prune
+	// per event; prune is the DELETE ... NOT IN subquery, the CPU target here).
+	// Local median under -race: ~1.42s.
+	perfWatcherIngestBase = 1450 * time.Millisecond // → WarmBudget = 4.35s local, 8.7s CI
+)
+
+// newPerfDB opens a migrated StateDB on a tmpfs-backed t.TempDir() path.
+func newPerfDB(t *testing.T) *StateDB {
+	t.Helper()
+	db, err := Open(filepath.Join(t.TempDir(), "perf.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// perfRows builds n representative instance rows with stable ids.
+func perfRows(n int) []*InstanceRow {
+	rows := make([]*InstanceRow, n)
+	now := time.Now()
+	for i := 0; i < n; i++ {
+		rows[i] = &InstanceRow{
+			ID:          fmt.Sprintf("perf-%04d", i),
+			Title:       fmt.Sprintf("Session %d", i),
+			ProjectPath: fmt.Sprintf("/home/dev/project-%d", i),
+			GroupPath:   fmt.Sprintf("group-%d", i%5),
+			Order:       i,
+			Tool:        "claude",
+			Status:      "idle",
+			CreatedAt:   now,
+			ToolData:    json.RawMessage(`{"claude_session_id":"sess-abcdef"}`),
+		}
+	}
+	return rows
+}
+
+// clearInstances truncates the instances table (setup helper, excluded from
+// the timed window).
+func clearInstances(t *testing.T, db *StateDB) {
+	t.Helper()
+	if _, err := db.DB().Exec("DELETE FROM instances"); err != nil {
+		t.Fatalf("clear instances: %v", err)
+	}
+}
+
+// TestPerf_StateDB_InsertN gates the cost of creating perfPopN sessions one at
+// a time via SaveInstance (the per-session save: SELECT existing tool_data +
+// INSERT OR REPLACE). Catches CPU regressions in the row-marshalling /
+// tool-data-merge path.
+func TestPerf_StateDB_InsertN(t *testing.T) {
+	testutil.SkipIfShort(t)
+	db := newPerfDB(t)
+	rows := perfRows(perfPopN)
+	budget := testutil.WarmBudget(t, perfStateDBInsertBase)
+
+	got := testutil.TrimmedMeanWithSetup(
+		func() { clearInstances(t, db) },
+		func() {
+			for _, r := range rows {
+				if err := db.SaveInstance(r); err != nil {
+					t.Fatalf("SaveInstance: %v", err)
+				}
+			}
+		},
+	)
+
+	if got > budget {
+		t.Fatalf("insert %d instances trimmed mean = %v, budget = %v (regression in SaveInstance marshalling/tool-data merge)", perfPopN, got, budget)
+	}
+	t.Logf("insert %d instances trimmed mean = %v (budget = %v)", perfPopN, got, budget)
+}
+
+// TestPerf_StateDB_ReadByID gates perfPopN read-by-id lookups (InstanceExists —
+// the indexed point-query used by the rm-verify path, issue #909). The table is
+// populated once outside the timed window; the op is read-only, so
+// TrimmedMeanWarm (no per-iter fixture rebuild) is sufficient.
+func TestPerf_StateDB_ReadByID(t *testing.T) {
+	testutil.SkipIfShort(t)
+	db := newPerfDB(t)
+	rows := perfRows(perfPopN)
+	if err := db.SaveInstances(rows); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+	budget := testutil.WarmBudget(t, perfStateDBReadByIDBase)
+
+	got := testutil.TrimmedMeanWarm(func() {
+		for _, r := range rows {
+			ok, err := db.InstanceExists(r.ID)
+			if err != nil || !ok {
+				t.Fatalf("InstanceExists(%s) = %v, %v", r.ID, ok, err)
+			}
+		}
+	})
+
+	if got > budget {
+		t.Fatalf("read-by-id ×%d trimmed mean = %v, budget = %v (regression in point-query path)", perfPopN, got, budget)
+	}
+	t.Logf("read-by-id ×%d trimmed mean = %v (budget = %v)", perfPopN, got, budget)
+}
+
+// TestPerf_StateDB_List gates one LoadInstances over a perfPopN-row table (the
+// full-scan + per-row Scan path hit on every reload). Read-only → TrimmedMeanWarm.
+func TestPerf_StateDB_List(t *testing.T) {
+	testutil.SkipIfShort(t)
+	db := newPerfDB(t)
+	rows := perfRows(perfPopN)
+	if err := db.SaveInstances(rows); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+	budget := testutil.WarmBudget(t, perfStateDBListBase)
+
+	got := testutil.TrimmedMeanWarm(func() {
+		loaded, err := db.LoadInstances()
+		if err != nil {
+			t.Fatalf("LoadInstances: %v", err)
+		}
+		if len(loaded) != perfPopN {
+			t.Fatalf("LoadInstances returned %d rows, want %d", len(loaded), perfPopN)
+		}
+	})
+
+	if got > budget {
+		t.Fatalf("list %d instances trimmed mean = %v, budget = %v (regression in full-scan/row-scan path)", perfPopN, got, budget)
+	}
+	t.Logf("list %d instances trimmed mean = %v (budget = %v)", perfPopN, got, budget)
+}
+
+// TestPerf_StateDB_DeleteN gates removing perfPopN sessions one at a time via
+// DeleteInstance (the `agent-deck rm` path; xargs -P fan-out hits this per
+// row, issue #909). Each iteration mutates state, so the fixture is rebuilt in
+// setup (excluded from timing) via TrimmedMeanWithSetup.
+func TestPerf_StateDB_DeleteN(t *testing.T) {
+	testutil.SkipIfShort(t)
+	db := newPerfDB(t)
+	rows := perfRows(perfPopN)
+	budget := testutil.WarmBudget(t, perfStateDBDeleteBase)
+
+	got := testutil.TrimmedMeanWithSetup(
+		func() {
+			clearInstances(t, db)
+			if err := db.SaveInstances(rows); err != nil {
+				t.Fatalf("repopulate: %v", err)
+			}
+		},
+		func() {
+			for _, r := range rows {
+				if err := db.DeleteInstance(r.ID); err != nil {
+					t.Fatalf("DeleteInstance: %v", err)
+				}
+			}
+		},
+	)
+
+	if got > budget {
+		t.Fatalf("delete %d instances trimmed mean = %v, budget = %v (regression in DeleteInstance path)", perfPopN, got, budget)
+	}
+	t.Logf("delete %d instances trimmed mean = %v (budget = %v)", perfPopN, got, budget)
+}
+
+// perfWatcherSteadyState is the number of events the watcher_events table is
+// pre-filled to before the timed batch — the default retention bound
+// (max_events_per_watcher default 500, internal/session/userconfig.go:3419).
+const perfWatcherSteadyState = 500
+
+// perfWatcherIngestBatch is the number of fresh events ingested per timed
+// iteration on top of the steady state.
+const perfWatcherIngestBatch = 50
+
+// TestPerf_StateDB_WatcherEventIngest gates the watcher-event ingestion path:
+// SaveWatcherEvent does an INSERT OR IGNORE followed (on a real insert) by a
+// prune — DELETE ... WHERE id NOT IN (SELECT ... ORDER BY id DESC LIMIT N).
+// That prune subquery is the CPU regression target; its cost scales with the
+// steady-state table size, so we pre-fill to the default 500-event bound and
+// time a 50-event batch on top. Each batch event triggers one insert + one
+// prune at a full table.
+//
+// Fixture (a 500-row table) is rebuilt per iteration in setup, excluded from
+// timing, via TrimmedMeanWithSetup.
+//
+// TODO(tier2): a Tier 2 count assertion belongs here too — "ingesting one new
+// event past the bound = exactly 1 INSERT + 1 prune DELETE, no extra round
+// trips". Counts are syscall-side (COLD); left to the sibling outbox/drain
+// session per docs/perf-budget-suite.md.
+func TestPerf_StateDB_WatcherEventIngest(t *testing.T) {
+	testutil.SkipIfShort(t)
+	db := newPerfDB(t)
+
+	const watcherID = "perf-watcher"
+	if err := db.SaveWatcher(&WatcherRow{
+		ID:     watcherID,
+		Name:   "perf",
+		Type:   "gmail",
+		Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveWatcher: %v", err)
+	}
+
+	// prefill rebuilds the steady-state table directly (bypassing the prune in
+	// SaveWatcherEvent) so setup cost stays low and the timed op sees a full
+	// 500-row table.
+	prefill := func() {
+		if _, err := db.DB().Exec("DELETE FROM watcher_events"); err != nil {
+			t.Fatalf("clear events: %v", err)
+		}
+		tx, err := db.DB().Begin()
+		if err != nil {
+			t.Fatalf("begin prefill: %v", err)
+		}
+		stmt, err := tx.Prepare(`INSERT INTO watcher_events (watcher_id, dedup_key, created_at) VALUES (?, ?, ?)`)
+		if err != nil {
+			t.Fatalf("prepare prefill: %v", err)
+		}
+		now := time.Now().Unix()
+		for i := 0; i < perfWatcherSteadyState; i++ {
+			if _, err := stmt.Exec(watcherID, fmt.Sprintf("base-%05d", i), now+int64(i)); err != nil {
+				t.Fatalf("prefill exec: %v", err)
+			}
+		}
+		_ = stmt.Close()
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit prefill: %v", err)
+		}
+	}
+
+	budget := testutil.WarmBudget(t, perfWatcherIngestBase)
+
+	got := testutil.TrimmedMeanWithSetup(
+		prefill,
+		func() {
+			for i := 0; i < perfWatcherIngestBatch; i++ {
+				inserted, err := db.SaveWatcherEvent(watcherID, fmt.Sprintf("batch-%05d", i), "sender@example.com", "subj", "", "", perfWatcherSteadyState)
+				if err != nil {
+					t.Fatalf("SaveWatcherEvent: %v", err)
+				}
+				if !inserted {
+					t.Fatalf("SaveWatcherEvent batch-%05d unexpectedly deduped", i)
+				}
+			}
+		},
+	)
+
+	if got > budget {
+		t.Fatalf("ingest %d events @ steady-state %d trimmed mean = %v, budget = %v (regression in insert+prune path)", perfWatcherIngestBatch, perfWatcherSteadyState, got, budget)
+	}
+	t.Logf("ingest %d events @ steady-state %d trimmed mean = %v (budget = %v)", perfWatcherIngestBatch, perfWatcherSteadyState, got, budget)
+}


### PR DESCRIPTION
## Tier 1 WARM perf suite — deferred items from #790 / #1047

Builds out a basic suite of **Tier 1 (tmpfs walltime)** `TestPerf_*` gates for the deferred persistence-touching lifecycle paths called out in PR #790 and #1047, per the mandate in [`docs/perf-budget-suite.md`](docs/perf-budget-suite.md) — specifically the **"Tier 1 vs Tier 2"** section.

All new tests:
- Run against `t.TempDir()` (tmpfs on CI Linux) — fsync is effectively free, so the measured cost is **CPU + Go-runtime cost only**. No `mkdir` under repo paths.
- Classify as **WARM** (pure in-process Go against an SQLite handle on tmpfs — no process boundary, no real-disk fsync, no child spawn, no network), with a one-line "why WARM not COLD" justification in each file header.
- Use `testutil.WarmBudget` + `testutil.TrimmedMeanWarm` (or `TrimmedMeanWithSetup` where a per-iteration fixture rebuild is excluded from timing).
- Call `testutil.SkipIfShort(t)`.
- Cite the local median measured **under `-race` at `PERF_BUDGET_MULTIPLIER=1.0`** next to the base constant.

**No real tmux is touched.** No network. Pure-Go in-process SQLite only. (`internal/session` Storage is constructed directly against a tmpfs DB; seeded rows carry `TmuxSession=""` so the lazy-reconnect branch in `LoadWithGroups` never executes. `internal/statedb` opens the DB directly.)

### New `TestPerf_*` tests

Local medians measured under `-race` on a WSL2 dev host (the CI Xeon container will differ; budgets carry the `×3` WARM / `×6` CI headroom that absorbs this).

| Test | Path exercised | Local median (`-race`, ×1.0) | Base | Budget @1.0 | Budget @2.0 (CI) |
|------|----------------|------------------------------|------|-------------|------------------|
| `TestPerf_StateDB_InsertN` | 50× `SaveInstance` into empty table (per-session insert) | ~206 ms | 210 ms | 630 ms | 1.26 s |
| `TestPerf_StateDB_ReadByID` | 50× `InstanceExists` (rm-verify point query, #909) | ~9.3 ms | 10 ms | 30 ms | 60 ms |
| `TestPerf_StateDB_List` | one `LoadInstances` over 50 rows (reload scan) | ~6.9 ms | 7 ms | 21 ms | 42 ms |
| `TestPerf_StateDB_DeleteN` | 50× `DeleteInstance` (`agent-deck rm` xargs path, #909) | ~166 ms | 170 ms | 510 ms | 1.02 s |
| `TestPerf_StateDB_WatcherEventIngest` | ingest 50 events at 500-event steady state (`SaveWatcherEvent` insert + prune `DELETE … NOT IN`) | ~1.42 s | 1.45 s | 4.35 s | 8.7 s |
| `TestPerf_Group_CreateDelete` | real `handleGroupCreate`/`handleGroupDelete` choreography: `LoadWithGroups` → `NewGroupTreeWithGroups` → create/delete → `SaveWithGroups` (×2), over a 50-instance deck | ~67 ms | 70 ms | 210 ms | 420 ms |

`WarmBudget = max(base × 3, 1 ms) × PERF_BUDGET_MULTIPLIER`. None of the bases hit the 1 ms floor.

### Coverage rationale

1. **StateDB CRUD scaling** (`internal/statedb/statedb_perf_test.go`) — insert / read-by-id / list / delete, each its own test, at **N = 50**. These deliberately gate the storage **primitives** (the task framed this as "StateDB CRUD scaling"), not an assembled flow. 50 is the representative upper-end deck size cited in code (`internal/web/handlers_costs.go:529`: the sidebar "grows past ~50 sessions"; `llms-full.txt` cites 30-session workspaces) — not an invented number. DB path is `t.TempDir()`.

2. **Group lifecycle, storage-mediated** (`internal/session/group_perf_test.go`) — #790 explicitly carved group create/delete out because doing it in-memory "exercises the wrong layer" (map ops are nanoseconds). This test gates it by **reconstructing the exact storage choreography the real handlers perform** (`cmd/agent-deck/group_cmd.go` `handleGroupCreate` ~L396-442 / `handleGroupDelete` ~L689-705):

   ```
   storage.LoadWithGroups()                     // full read of all instances + groups
   session.NewGroupTreeWithGroups(insts, grps)  // rebuild the tree
   groupTree.CreateGroup / DeleteGroup          // the mutation
   storage.SaveWithGroups(insts, groupTree)     // rewrite the WHOLE instances table + groups + Touch() + dedup
   ```

   Deliberately **not** `Storage.SaveGroupsOnly` — that is the lightweight expand/collapse visual-state path (its own doc comment says so) and skips both the instances round-trip and `Touch()`. The dominant cost in the real path is the instances-table read+rewrite, which is why this runs against a populated 50-instance deck rather than an empty DB.

   **Out of scope (follow-up):** the literal CLI shell — flag parsing, `NewStorageWithProfile`, `out.Success`/`os.Exit`. Driving that in-process needs the same injection seam deferred for session create/delete (below). The seam-free remainder carries no meaningful, tmux-touching cost, so the storage choreography above is the faithful Tier-1 target.

3. **Watcher-event ingestion** (`internal/statedb`) — a distinct persistence lifecycle: `SaveWatcherEvent` does `INSERT OR IGNORE` then a prune `DELETE … WHERE id NOT IN (SELECT … LIMIT N)`. The prune subquery cost scales with steady-state table size, so the table is pre-filled to the default 500-event bound (`max_events_per_watcher` default 500, `internal/session/userconfig.go:3419`) and a 50-event batch is timed on top.

### Tooling

- Broadens `make test-perf` from `./cmd/agent-deck/...` to `./...` so these internal-package gates run locally. This matches `.github/workflows/perf-smoke.yml`, whose `perf-tests` job already runs `./...`, so **no CI workflow change is needed** — the new tests are picked up automatically.

### Verification

- `make test-perf` at `PERF_BUDGET_MULTIPLIER=1.0` **and** `2.0`: all six new tests green (verified at both multipliers).
- `go test -race -count=1 ./internal/statedb/`: green.
- The six new tests pass under `-race` at both multipliers with comfortable margins.

> Note: this dev host (WSL2) cannot pass the **pre-existing** cold-start gates (`TestPerf_ColdStart_*`, ~300 ms process spawn vs a 40 ms budget calibrated on the CI Xeon) or three **pre-existing** `internal/session` shell/lifecycle timing tests (`TestStatusCycle_ShellSessionWithCommand`, `TestLifecycle_StoppedRestartedRunningError`, `TestBuildCodexCommand_CustomWrapperPreservesToolIdentity`). All of these fail identically with this PR's files removed — they are host-specific and untouched here. No cold-start test or existing budget was modified.

### Non-goals (per task scope)

- **No Tier 2 count assertions.** A sibling session owns the outbox/drain Tier 2 work. Where a count gate clearly belongs (the watcher-event insert+prune path), a `// TODO(tier2)` with a one-line rationale is left in place.
- **Session create/delete** Tier 1 gating is intentionally **not** included: it requires an injection seam to avoid real tmux/process spawn, which is a separate, larger piece of work. (The group test's CLI-shell wrapper shares this seam dependency.) Left as a follow-up.
- No cold-start changes, no budget widening, no benchstat/trending infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Performance testing expanded to run locally across the entire module, matching CI behavior
  * Added performance benchmarks for group lifecycle operations (create, persist, delete cycles)
  * Added performance benchmarks for state database operations (insert, read by ID, list, delete, and event ingestion)
* **Chores**
  * Adjusted local perf test target to cover all packages (broader scope)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->