### PR TITLE
test(perf): gate the durable per-parent outbox drain (WARM walltime + Tier 2 fsync count)

### DIFF
--- a/docs/perf-budget-suite.md
+++ b/docs/perf-budget-suite.md
@@ -14,8 +14,13 @@ Any PR modifying performance-sensitive lifecycle paths MUST run:
 ```bash
 GOTOOLCHAIN=go1.25.10 PERF_BUDGET_MULTIPLIER=2.0 \
   go test -run '^TestPerf_' -race -count=1 -timeout 120s \
-  ./cmd/agent-deck/...
+  ./...
 ```
+
+Scope is `./...` (not just `cmd/agent-deck/...`) so a `TestPerf_*` added in any
+package is exercised — the mandate covers the whole module (`**/*_perf_test.go`)
+and the durable-outbox drain gate lives in `internal/session`. `make test-perf`
+and `.github/workflows/perf-smoke.yml` both use this scope.
 
 CI runs this as `.github/workflows/perf-smoke.yml`. Only the `perf-tests` job is a hard gate; `perf-bench-trend` is advisory (`continue-on-error: true`) and may show red without blocking merge.
 

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -34,6 +34,32 @@ import (
 
 var inboxWriteMu sync.Mutex // serializes appends to a single inbox file
 
+// fsyncFile is the seam through which the durable-write primitive
+// (writeFileDurable) and its directory-fsync helper (fsyncDir) flush to disk.
+// Production points it at (*os.File).Sync — a plain pass-through, zero overhead.
+//
+// It exists so the Tier 2 count-assertion perf tests (docs/perf-budget-suite.md)
+// can gate the drain's I/O PATTERN on COUNTS rather than walltime. Disk fsync
+// latency varies ~100× across SSD / HDD / cloud volumes and is un-normalizable,
+// so "we now fsync once per record instead of once per batch" can only be caught
+// by counting syncs — which requires a seam the test can wrap. The companion
+// Tier 1 WARM walltime gate stubs this to a no-op so it measures pure CPU +
+// Go-runtime cost with disk speed factored out (the doc's tmpfs/in-memory
+// requirement). See SetFsyncHookForTest and internal/testutil.FsyncCounter.
+var fsyncFile = (*os.File).Sync
+
+// SetFsyncHookForTest swaps the durable-write fsync seam and returns a restore
+// func (defer it). The two perf gates added for the durable per-parent outbox
+// use it: the Tier 2 test wraps it with a counter to assert N messages drain in
+// a CONSTANT number of fsyncs, and the Tier 1 WARM walltime test no-ops it to
+// isolate in-process Go cost from disk. Production never calls it. Package tests
+// run serially (no t.Parallel on the perf tests), so the global swap is safe.
+func SetFsyncHookForTest(fn func(*os.File) error) func() {
+	prev := fsyncFile
+	fsyncFile = fn
+	return func() { fsyncFile = prev }
+}
+
 // maxInboxLineBytes caps a single JSONL line when scanning inbox / WAL /
 // dead-letter files. Audit B6: the old 1 MB cap silently truncated (and failed
 // the whole drain on) an oversized event — a DoneSummary that swallowed a large
@@ -63,7 +89,7 @@ func writeFileDurable(path string, data []byte, perm os.FileMode) error {
 		_ = os.Remove(tmp)
 		return err
 	}
-	if err := f.Sync(); err != nil {
+	if err := fsyncFile(f); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
 		return err
@@ -90,7 +116,7 @@ func fsyncDir(dir string) {
 		return
 	}
 	defer d.Close()
-	_ = d.Sync()
+	_ = fsyncFile(d)
 }
 
 // inboxFingerprintCache holds, per inbox file path, the set of event

--- a/internal/session/outbox_drain_perf_test.go
+++ b/internal/session/outbox_drain_perf_test.go
@@ -1,0 +1,210 @@
+package session
+
+import (
+	"os"
+	"runtime"
+	"runtime/debug"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// Perf gates for the durable per-parent outbox DRAIN (issues #1225/#1226,
+// activated in #1227). The drain runs on every conductor Stop hook and every
+// heartbeat (DrainForStopHook → DrainInboxForParent, and `agent-deck inbox
+// drain self`), and until now it was ungated — the highest-ROI gap from the
+// deferred list in #790/#1047. See docs/perf-budget-suite.md for the mandate.
+//
+// The drain path under test is purely in-process: DrainInboxForParent stages
+// the inbox to an in-flight WAL (writeFileDurable), truncates the inbox,
+// collapses last-wins per child, dedups against the consumed-turns ledger, and
+// persists the ledger (writeFileDurable). It touches NO real tmux and spawns no
+// child process. Both tests scope all state to t.TempDir via inboxTestHome
+// (HOME override), so the files live on the test scratch dir, never the real
+// ~/.agent-deck.
+//
+// Two complementary gates, one per tier in docs/perf-budget-suite.md:
+//
+//   - Tier 1 (WARM walltime) — TestPerf_OutboxDrain_Drain25. Catches a CPU /
+//     Go-runtime regression in the drain ("we added 200ms of work to the save
+//     path"). Classified WARM because, with fsync stubbed to a no-op via the
+//     production seam (SetFsyncHookForTest), the measured work is pure
+//     in-process Go against the page cache — no real-disk fsync, so disk speed
+//     is irrelevant exactly as the WARM/tmpfs contract requires. This is more
+//     robust than relying on t.TempDir happening to be tmpfs (it is on CI
+//     Linux, but not on every dev box, e.g. WSL2/ext4).
+//
+//   - Tier 2 (count assertion) — TestPerf_OutboxDrain_FsyncCount. Catches an
+//     I/O-PATTERN regression Tier 1 cannot see ("we now fsync once per record
+//     instead of once per batch"). Asserts the drain issues a CONSTANT number
+//     of durable writes regardless of how many messages it drains. No walltime
+//     budget; the doc classifies fsync-count gates as COLD (syscall side).
+//
+// Representative N: the live drain stress test
+// (TestIssue1225_DrainInbox_ConcurrentDrainNoDoubleNoLoss, inbox_consumer_test.go)
+// fixes a conductor's fan-out at `const n = 25` distinct children. We reuse that
+// figure so the perf load tracks the codebase's own notion of a busy drain
+// rather than an invented number; childIDForN is the same id generator.
+const outboxDrainFanout = 25
+
+// Base local median observed under -race at PERF_BUDGET_MULTIPLIER=1.0
+// (Linux WSL2 container, n=25 distinct-child records, fsync stubbed to no-op so
+// the figure is disk-independent): ~2.1ms (six runs spanned 1.99–2.21ms).
+// WarmBudget multiplies by 3 and applies the 1ms floor and the env multiplier:
+//
+//	base × 3 × multiplier, floored at 1ms
+//	→ 6.3ms locally (mult 1.0), 12.6ms in CI (mult 2.0).
+//
+// The 3× factor over the observed median leaves headroom for the residual
+// warm-host jitter the forced-GC discipline (see the test) can't fully remove,
+// while still catching a CPU/Go-runtime regression that doubles the drain cost.
+const outboxDrain25Base = 2100 * time.Microsecond
+
+// TestPerf_OutboxDrain_Drain25 measures DrainInboxForParent over a representative
+// 25-child inbox. WARM (docs/perf-budget-suite.md): fsync is stubbed to a no-op
+// via the durable-write seam, so the timed window is pure in-process Go work
+// against the page cache — the WARM/tmpfs contract holds on any filesystem.
+//
+// Setup (excluded from the timed window via TrimmedMeanWithSetup) rebuilds a
+// fresh inbox of 25 distinct-child records and wipes the WAL + consumed-turns
+// ledger each iteration, so every timed drain hits the identical steady-state
+// path: stage 25 records to the WAL, truncate, persist a 25-entry ledger. That
+// keeps the measurement stationary across the n=11 samples.
+//
+// TrimmedMeanWithSetup is the COLD (no-GC-control) measurement helper, but this
+// test is WARM, so we compose the GC control ourselves exactly as
+// perfbudget.go's docs instruct: disable auto-GC for the test lifetime and
+// force a collection inside setup() before each timed op, so the drain never
+// absorbs an unrelated GC pause — the same discipline TrimmedMeanWarm applies.
+func TestPerf_OutboxDrain_Drain25(t *testing.T) {
+	testutil.SkipIfShort(t)
+	inboxTestHome(t)
+
+	// Stub fsync: WARM measures CPU + Go-runtime, not disk. Restored on return.
+	restore := SetFsyncHookForTest(func(*os.File) error { return nil })
+	defer restore()
+
+	// WARM GC control composed with TrimmedMeanWithSetup: auto-GC off for the
+	// test, a forced collection per setup() (below) outside the timed window.
+	defer debug.SetGCPercent(debug.SetGCPercent(-1))
+
+	const parent = "conductor-perf-drain25"
+	budget := testutil.WarmBudget(t, outboxDrain25Base)
+
+	var lastDrained int
+	got := testutil.TrimmedMeanWithSetup(
+		func() {
+			populateInboxForDrain(t, parent, outboxDrainFanout)
+			runtime.GC() // pay collection outside the timed window (WARM discipline)
+		},
+		func() {
+			events, err := DrainInboxForParent(parent)
+			if err != nil {
+				t.Fatalf("drain: %v", err)
+			}
+			lastDrained = len(events)
+		},
+	)
+
+	// Sanity: the drain must actually deliver all 25 (a no-op drain would make
+	// the walltime meaningless — the bug class a bare budget wouldn't notice).
+	if lastDrained != outboxDrainFanout {
+		t.Fatalf("drain delivered %d events, want %d (setup or dedup broke the steady state)", lastDrained, outboxDrainFanout)
+	}
+	if got > budget {
+		t.Fatalf("outbox drain (n=%d) trimmed mean = %v, budget = %v (regression in DrainInboxForParent CPU/Go-runtime cost)", outboxDrainFanout, got, budget)
+	}
+	t.Logf("outbox drain (n=%d) trimmed mean = %v (budget = %v)", outboxDrainFanout, got, budget)
+}
+
+// TestPerf_OutboxDrain_FsyncCount is the Tier 2 I/O-pattern gate
+// (docs/perf-budget-suite.md). The durable backing is *os.File (writeFileDurable:
+// fsync the data file, atomic rename, best-effort fsync the parent dir), so the
+// doc's "real-disk count assertions" tier applies: assert on fsync COUNT, not
+// un-normalizable disk walltime.
+//
+// Derived by reading the drain code (inbox_consumer.go), NOT by recording
+// observed values. DrainInboxForParent issues exactly TWO durable writes for any
+// non-empty drain of distinct-child, not-yet-consumed records:
+//
+//  1. stageInboxDrainLocked → writeInflightLocked → writeFileDurable(WAL)
+//     — stages ALL pending records in ONE write (1 data fsync + 1 dir fsync).
+//  2. finalizeInboxDrain → saveConsumedTurnsLocked → writeFileDurable(ledger)
+//     — persists the WHOLE consumed-turns map in ONE write (1 data fsync + 1
+//     dir fsync).
+//
+// So a drain of N messages = 2 file fsyncs + 2 directory fsyncs, INDEPENDENT of
+// N. Proving the count is identical for N=1 and N=25 is the regression guard: a
+// change to fsync-per-record would make the file-fsync count scale with N. The
+// inbox truncate (os.Remove) and the WAL drop (os.Remove) issue no fsync.
+func TestPerf_OutboxDrain_FsyncCount(t *testing.T) {
+	testutil.SkipIfShort(t)
+	inboxTestHome(t)
+
+	// Count fsyncs through the durable-write seam; real Sync still runs (cheap
+	// on the scratch dir). Producer appends (CommitToInbox) fsync directly, not
+	// through this seam, so setup contributes zero counted syncs — but Reset()
+	// before each drain makes the assertion robust regardless.
+	fc := new(testutil.FsyncCounter)
+	restore := SetFsyncHookForTest(fc.Wrap(nil))
+	defer restore()
+
+	const (
+		wantFileSyncs = 2 // WAL stage + consumed-ledger persist
+		wantDirSyncs  = 2 // one best-effort parent-dir fsync per durable write
+	)
+
+	for _, n := range []int{1, outboxDrainFanout} {
+		parent := "conductor-perf-fsync"
+		populateInboxForDrain(t, parent, n)
+		fc.Reset()
+
+		events, err := DrainInboxForParent(parent)
+		if err != nil {
+			t.Fatalf("n=%d drain: %v", n, err)
+		}
+		if len(events) != n {
+			t.Fatalf("n=%d: drain delivered %d events, want %d", n, len(events), n)
+		}
+		if fc.FileSyncs() != wantFileSyncs {
+			t.Fatalf("n=%d: drain issued %d file fsyncs, want exactly %d (a per-record fsync regression scales this with N)", n, fc.FileSyncs(), wantFileSyncs)
+		}
+		if fc.DirSyncs() != wantDirSyncs {
+			t.Fatalf("n=%d: drain issued %d directory fsyncs, want exactly %d", n, fc.DirSyncs(), wantDirSyncs)
+		}
+		t.Logf("n=%d: drain issued %d file + %d dir fsyncs (constant, as derived)", n, fc.FileSyncs(), fc.DirSyncs())
+	}
+}
+
+// populateInboxForDrain rebuilds a fresh inbox of n distinct-child completion
+// records for parent and wipes the in-flight WAL + consumed-turns ledger, so the
+// next DrainInboxForParent hits the full steady-state path (stage N + persist an
+// N-entry ledger) with no carry-over dedup from a prior drain. childIDForN is
+// the shared id generator used by the #1225 drain tests.
+func populateInboxForDrain(t *testing.T, parent string, n int) {
+	t.Helper()
+	// Wipe any state a prior iteration/drain left behind. Removing the consumed
+	// ledger is what guarantees every record below is a NEW turn (not deduped),
+	// so the drain always performs both durable writes.
+	_ = os.Remove(InboxPathFor(parent))
+	_ = os.Remove(inboxInflightPathFor(parent))
+	_ = os.Remove(consumedTurnsPathFor(parent))
+	ResetInboxFingerprintCacheForTest()
+
+	now := time.Now()
+	for i := 0; i < n; i++ {
+		ev := TransitionNotificationEvent{
+			ChildSessionID: childIDForN(i),
+			ChildTitle:     "worker",
+			Profile:        "personal",
+			FromStatus:     "running",
+			ToStatus:       "waiting",
+			LastOutputHash: childIDForN(i) + "-turn", // distinct per child → distinct turn fingerprint
+			Timestamp:      now,
+		}
+		if err := CommitToInbox(parent, ev); err != nil {
+			t.Fatalf("populate commit %d: %v", i, err)
+		}
+	}
+}

--- a/internal/testutil/fsynccounter.go
+++ b/internal/testutil/fsynccounter.go
@@ -1,0 +1,94 @@
+package testutil
+
+import (
+	"os"
+	"sync"
+)
+
+// FsyncCounter is the reusable Tier 2 instrumentation the perf-budget doc
+// anticipates (docs/perf-budget-suite.md, "real-disk count assertions"):
+//
+//	"Disk walltime varies 100× across SSDs / HDDs / cloud volumes —
+//	 un-normalizable. Instead instrument the storage layer (*sql.DB and
+//	 *os.File wrappers exposing fsync count, transaction count, rows written)
+//	 and assert on counts: 'create one group = exactly 1 transaction + 1 fsync'."
+//
+// It wraps a `func(*os.File) error` fsync seam (e.g. the one a package routes
+// (*os.File).Sync through) and tallies the calls, bucketed by whether the
+// descriptor is a regular file or a directory. The two carry different
+// regression signals: a durable atomic write fsyncs the DATA file (content
+// durability) and then best-effort fsyncs the PARENT directory (rename
+// durability), so a test that asserts on both pins the exact I/O shape.
+//
+// Today only the durable per-parent outbox drain wires it (one caller), but it
+// is package-level testutil rather than a one-off in that test because the doc
+// frames the wrapper as shared infrastructure every future persistence-touching
+// Tier 2 gate should reuse — a single counting convention beats a bespoke
+// counter per save path.
+//
+// Construct with new(FsyncCounter); install via the seam's test hook:
+//
+//	fc := new(testutil.FsyncCounter)
+//	restore := session.SetFsyncHookForTest(fc.Wrap(nil)) // nil → real Sync
+//	defer restore()
+//	... exercise the code under test ...
+//	fc.Reset()                 // discard setup syncs
+//	... run the timed/counted op ...
+//	if fc.FileSyncs() != 2 { ... }
+//
+// All methods are safe for concurrent use; the seam may fire from background
+// goroutines in the code under test.
+type FsyncCounter struct {
+	mu        sync.Mutex
+	fileSyncs int
+	dirSyncs  int
+}
+
+// Wrap returns a fsync-seam function that records each call then delegates to
+// real. Pass real=nil to delegate to (*os.File).Sync (the production default),
+// which is the common case — the count is the assertion, the underlying fsync
+// is left intact (and is cheap on the tmpfs scratch dir a Tier 2 test uses).
+func (c *FsyncCounter) Wrap(real func(*os.File) error) func(*os.File) error {
+	if real == nil {
+		real = (*os.File).Sync
+	}
+	return func(f *os.File) error {
+		// Bucket BEFORE delegating so a fsync that returns an error (e.g. a
+		// directory fsync rejected with EINVAL/ENOTSUP on some filesystems —
+		// which the durable-write path treats as benign) is still counted: the
+		// regression signal is "was the syscall issued", not "did it succeed".
+		if info, err := f.Stat(); err == nil && info.IsDir() {
+			c.mu.Lock()
+			c.dirSyncs++
+			c.mu.Unlock()
+		} else {
+			c.mu.Lock()
+			c.fileSyncs++
+			c.mu.Unlock()
+		}
+		return real(f)
+	}
+}
+
+// FileSyncs returns the number of fsyncs issued against regular files.
+func (c *FsyncCounter) FileSyncs() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.fileSyncs
+}
+
+// DirSyncs returns the number of fsyncs issued against directories.
+func (c *FsyncCounter) DirSyncs() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.dirSyncs
+}
+
+// Reset zeroes both counters. Call it after fixture setup (whose own durable
+// writes are not part of the operation under test) and before the counted op.
+func (c *FsyncCounter) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fileSyncs = 0
+	c.dirSyncs = 0
+}


### PR DESCRIPTION
## Summary

Lands the **first hard-gated `TestPerf_*` for the durable per-parent outbox DRAIN** — `DrainInboxForParent`, which runs on **every conductor Stop hook and every heartbeat** (`DrainForStopHook` and `agent-deck inbox drain self`), introduced in #1226 and activated in #1227. It was the highest-ROI item on the deferred list in #790/#1047: an unconditionally-hot lifecycle path with zero walltime gating.

Authority for everything below is **`docs/perf-budget-suite.md`** (the relocated #790/#1047 mandate): cold/warm classification, the `WarmBudget` formula, the n=11 trimmed mean, the 1ms floor, and the Tier 1 / Tier 2 split for I/O-touching tests.

## What the drain does (path under test)

`DrainInboxForParent` is purely in-process and tmux-free. Two-phase, crash-safe:
1. **Stage** — recover any in-flight WAL, read the inbox, durably stage the union to the WAL (`writeFileDurable`), then truncate the inbox.
2. **Finalize** — collapse last-wins per child, dedup against the consumed-turns ledger, persist the ledger (`writeFileDurable`), drop the WAL.

The durable backing is `*os.File` (`writeFileDurable`: fsync data file → atomic rename → best-effort fsync parent dir), so both perf-budget tiers apply.

## The two gates (one per tier)

### Tier 1 — `TestPerf_OutboxDrain_Drain25` (WARM walltime)
- `TrimmedMeanWithSetup`: `setup()` rebuilds a fresh inbox of **N=25 distinct-child records** and wipes the WAL + consumed ledger each iteration (so every timed drain hits the identical steady-state path); `op()` times `DrainInboxForParent` only.
- **N=25 is not invented** — it's the fan-out the live drain stress test `TestIssue1225_DrainInbox_ConcurrentDrainNoDoubleNoLoss` fixes at `const n = 25`; this reuses `childIDForN`, the same id generator.
- **Classified WARM** because fsync is stubbed to a no-op via the new seam, so the timed window is pure CPU + Go-runtime against the page cache — the WARM "disk speed is irrelevant" contract holds on **any** filesystem (more robust than relying on `t.TempDir` being tmpfs, which it isn't on e.g. WSL2/ext4). WARM GC discipline is composed onto `TrimmedMeanWithSetup` (auto-GC off + forced collection inside `setup()`), exactly as `perfbudget.go` instructs.
- **No real tmux, no real fsync, no child process.** State is scoped to `t.TempDir` via `inboxTestHome` (HOME override).

### Tier 2 — `TestPerf_OutboxDrain_FsyncCount` (count assertion)
Disk fsync latency is un-normalizable (~100× across SSD/HDD/cloud), so the I/O-pattern regression is gated on **counts**, per the doc. Derived by **reading the drain code, not recording observed values**: a non-empty drain of distinct-child, not-yet-consumed records issues **exactly 2 file fsyncs + 2 directory fsyncs** (WAL stage + ledger persist, each batched into one `writeFileDurable`), **independent of N**. The test asserts the count is **identical for N=1 and N=25** — a fsync-per-record regression would scale the file count with N. (The inbox truncate and WAL drop are `os.Remove`, no fsync.)

## Supporting infrastructure

- **`internal/session/inbox.go`** — adds the `fsyncFile` seam (default `(*os.File).Sync`, zero production overhead) routing `writeFileDurable` + `fsyncDir`, plus `SetFsyncHookForTest`. This is the `*os.File` seam the doc explicitly anticipates for Tier 2 gates. **No production behavior change.**
- **`internal/testutil/fsynccounter.go`** — reusable `FsyncCounter` wrapper bucketing file vs directory syncs. Landed as shared testutil (not a one-off) because the doc frames the wrapper as infrastructure for every future persistence-touching Tier 2 gate.
- **`Makefile` + `docs/perf-budget-suite.md`** — align `make test-perf` scope to `./...` (matching `.github/workflows/perf-smoke.yml`, which already uses `./...`) so a `TestPerf_*` in any package — like this `internal/session` gate — is exercised, not just `cmd/agent-deck`.

## Observed local median & budgets

Measured under `-race`, `PERF_BUDGET_MULTIPLIER=1.0`, Linux WSL2 container, N=25, fsync no-op'd (disk-independent):

| | value |
|---|---|
| Observed trimmed-mean median | **~2.1ms** (six runs spanned 1.99–2.21ms) |
| `base` constant | `2.1ms` |
| WarmBudget @ mult 1.0 (local) | `base × 3` = **6.3ms** |
| WarmBudget @ mult 2.0 (CI) | `base × 3 × 2` = **12.6ms** |

The `base` cites the observed median directly (per the mandate), with the WARM 3× factor for residual warm-host jitter.

## Verification (Linux WSL2; template per #1047)

| Check | Result |
|---|---|
| `make test-perf` (mult 1.0) — outbox gates | PASS — drain trimmed mean **1.95–2.71ms** (budget 6.3ms); fsync **2 file + 2 dir** at N=1 and N=25 |
| `PERF_BUDGET_MULTIPLIER=2.0 make test-perf` — outbox gates | PASS — drain **2.00ms** (budget 12.6ms); fsync **2+2** |
| `go test -race -count=1 ./internal/session/` (inbox/drain/outbox/stophook + perf) | PASS |
| `go test -race -count=1 ./internal/testutil/` | PASS |
| `go build ./...` | clean |
| `gofmt -l` (changed files) | clean |

**Known caveats (both pre-existing, both proven on the clean tree with this PR stashed — not introduced here):**
- `TestPerf_ColdStart_{Help,Version}` fail **locally** on this WSL2 box (cold start ~300–330ms vs the 40ms budget) — a slow-process-spawn environment artifact; the cold-start budget holds on CI's `ubuntu-latest`. Untouched per the non-goals.
- The `internal/session` status/lifecycle `sleep`-timing tests (`TestStatusCycle_ShellSessionWithCommand`, `TestLifecycle_StoppedRestartedRunningError`) flake under the loaded full-package `-race` run; they pass in isolation and fail **identically on the clean tree**. Unrelated to the fsync seam.

## Non-goals honored

No cold-start changes; no existing budget widened; no benchstat/trending infra; no real tmux in any `TestPerf_*`; the 1ms floor and n=11 convention are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added performance regression tests for outbox drain operations to measure timing and verify efficiency.
  * Introduced test utilities for monitoring and validating file synchronization behavior patterns.
  * Enhanced test infrastructure with fsync seam controls to enable better isolation and behavioral verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->