### PR TITLE
fix(conductor): recover from stale CLAUDE_SESSION_ID via disk scan (stops raw JSON leaking into chat)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,14 +94,24 @@ run:
 
 # Install to /usr/local/bin (requires sudo)
 install: build
+	sudo rm -f /usr/local/bin/$(BINARY_NAME)
 	sudo cp $(BUILD_DIR)/$(BINARY_NAME) /usr/local/bin/$(BINARY_NAME)
+	@# macOS (Apple Silicon) SIGKILLs a binary whose ad-hoc signature was
+	@# invalidated by an in-place overwrite. rm+cp gives a fresh inode and the
+	@# re-sign guarantees a valid signature. No-op on other platforms.
+	@if [ "$$(uname)" = "Darwin" ]; then sudo codesign --force --sign - /usr/local/bin/$(BINARY_NAME); fi
 	@echo "✅ Installed to /usr/local/bin/$(BINARY_NAME)"
 	@echo "Run 'agent-deck' to start"
 
 # Install to user's local bin (no sudo required)
 install-user: build
 	mkdir -p $(HOME)/.local/bin
+	rm -f $(HOME)/.local/bin/$(BINARY_NAME)
 	cp $(BUILD_DIR)/$(BINARY_NAME) $(HOME)/.local/bin/$(BINARY_NAME)
+	@# macOS (Apple Silicon) SIGKILLs a binary whose ad-hoc signature was
+	@# invalidated by an in-place overwrite. rm+cp gives a fresh inode and the
+	@# re-sign guarantees a valid signature. No-op on other platforms.
+	@if [ "$$(uname)" = "Darwin" ]; then codesign --force --sign - $(HOME)/.local/bin/$(BINARY_NAME); fi
 	@echo "✅ Installed to $(HOME)/.local/bin/$(BINARY_NAME)"
 	@echo "Make sure $(HOME)/.local/bin is in your PATH"
 	@echo "Run 'agent-deck' to start"

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4372,6 +4372,20 @@ func (i *Instance) GetLastResponseBestEffort() (*ResponseOutput, error) {
 				return recovered, nil
 			}
 		}
+
+		// Disk scan: the tmux env var is fixed at launch, so after a /clear or
+		// compaction it points at a stale, empty transcript. Find the newest
+		// transcript on disk that carries a real assistant reply. Mirrors the
+		// Gemini syncGeminiSessionFromDisk fallback below.
+		if id, recovered := i.findLatestClaudeTranscriptOnDisk(); recovered != nil {
+			i.ClaudeSessionID = id
+			i.ClaudeDetectedAt = time.Now()
+			// Sync back to tmux so subsequent reads (and restarts) stay current.
+			if i.tmuxSession != nil && i.tmuxSession.Exists() {
+				_ = i.tmuxSession.SetEnvironment("CLAUDE_SESSION_ID", id)
+			}
+			return recovered, nil
+		}
 	}
 
 	// Gemini-specific recovery path (mirrors Claude recovery above)
@@ -4486,6 +4500,70 @@ func (i *Instance) getClaudeLastResponse() (*ResponseOutput, error) {
 	return parseClaudeLastAssistantMessage(data, filepath.Base(sessionFile))
 }
 
+// findLatestClaudeTranscriptOnDisk scans the instance's Claude project directory
+// for the most recently modified transcript that carries a real (non-sidechain)
+// assistant message, returning its session ID and parsed response.
+//
+// This recovers from a stale CLAUDE_SESSION_ID: when a Claude session rolls over
+// (/clear or compaction starts a NEW transcript), the tmux env var — fixed at
+// launch — still points at the OLD, now-empty transcript. Without this fallback
+// the read path drops to raw tmux-pane parsing, which leaks tool output (e.g. a
+// `list --json` dump) into conductor chat replies. Mirrors the Gemini
+// syncGeminiSessionFromDisk fallback.
+//
+// Returns ("", nil) when no suitable transcript is found.
+func (i *Instance) findLatestClaudeTranscriptOnDisk() (string, *ResponseOutput) {
+	configDir := GetClaudeConfigDir()
+
+	resolvedPath := i.ProjectPath
+	if resolved, err := filepath.EvalSymlinks(i.ProjectPath); err == nil {
+		resolvedPath = resolved
+	}
+	projectDir := filepath.Join(configDir, "projects", ConvertToClaudeDirName(resolvedPath))
+
+	entries, err := os.ReadDir(projectDir)
+	if err != nil {
+		return "", nil
+	}
+
+	type candidate struct {
+		id  string
+		mod time.Time
+	}
+	var candidates []candidate
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			id:  strings.TrimSuffix(e.Name(), ".jsonl"),
+			mod: info.ModTime(),
+		})
+	}
+
+	// Newest first; the current conversation is the most recently written file
+	// that still contains a real assistant reply.
+	sort.Slice(candidates, func(a, b int) bool {
+		return candidates[a].mod.After(candidates[b].mod)
+	})
+
+	for _, c := range candidates {
+		data, err := os.ReadFile(filepath.Join(projectDir, c.id+".jsonl"))
+		if err != nil {
+			continue
+		}
+		resp, err := parseClaudeLastAssistantMessage(data, c.id+".jsonl")
+		if err == nil && resp != nil && strings.TrimSpace(resp.Content) != "" {
+			return c.id, resp
+		}
+	}
+	return "", nil
+}
+
 // parseClaudeLastAssistantMessage parses a Claude JSONL file to extract the last assistant message
 func parseClaudeLastAssistantMessage(data []byte, sessionID string) (*ResponseOutput, error) {
 	// JSONL record structure (same as global_search.go)
@@ -4494,10 +4572,11 @@ func parseClaudeLastAssistantMessage(data []byte, sessionID string) (*ResponseOu
 		Content json.RawMessage `json:"content"`
 	}
 	type claudeRecord struct {
-		SessionID string          `json:"sessionId"`
-		Type      string          `json:"type"`
-		Message   json.RawMessage `json:"message"`
-		Timestamp string          `json:"timestamp"`
+		SessionID   string          `json:"sessionId"`
+		Type        string          `json:"type"`
+		Message     json.RawMessage `json:"message"`
+		Timestamp   string          `json:"timestamp"`
+		IsSidechain bool            `json:"isSidechain"`
 	}
 
 	var lastAssistantContent string
@@ -4518,6 +4597,12 @@ func parseClaudeLastAssistantMessage(data []byte, sessionID string) (*ResponseOu
 		var record claudeRecord
 		if err := json.Unmarshal(line, &record); err != nil {
 			continue // Skip malformed lines
+		}
+
+		// Skip subagent sidechain records: the conversation's "last response"
+		// is the parent agent's reply, not a Task subagent's output.
+		if record.IsSidechain {
+			continue
 		}
 
 		// Capture session ID

--- a/internal/session/stale_session_diskscan_test.go
+++ b/internal/session/stale_session_diskscan_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestGetLastResponseBestEffort_RecoversFromStaleSessionIDViaDiskScan locks the
+// fix for the conductor "raw JSON in chat" leak.
+//
+// Repro: a conductor's Claude session rolls over (/clear or compaction starts a
+// NEW transcript), but the tmux env var CLAUDE_SESSION_ID — fixed at launch —
+// still points at the OLD, now-empty transcript. The stored ClaudeSessionID
+// matches that stale env value. getClaudeLastResponse then reads the empty file,
+// finds no assistant message, errors, and GetLastResponseBestEffort falls back
+// to raw tmux-pane parsing (which includes tool output like `list --json`).
+//
+// Without tmux available (as in this hermetic test), the old behavior returns an
+// empty response. The fix adds a disk-scan fallback — mirroring the Gemini
+// syncGeminiSessionFromDisk path — that locates the newest transcript on disk
+// carrying a real assistant message and returns its clean text.
+//
+// RED before the disk-scan fallback exists; GREEN after.
+func TestGetLastResponseBestEffort_RecoversFromStaleSessionIDViaDiskScan(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	origHome := os.Getenv("HOME")
+	origConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	_ = os.Setenv("HOME", tmpHome)
+	_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origConfigDir != "" {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", origConfigDir)
+		} else {
+			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+		}
+		ClearUserConfigCache()
+	})
+	ClearUserConfigCache()
+
+	configDir := filepath.Join(tmpHome, ".claude")
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir projectPath: %v", err)
+	}
+	// Resolve symlinks the same way the read path does (macOS t.TempDir() lives
+	// under /var -> /private/var); production ProjectPaths have no symlink
+	// component so this is a test-environment alignment, not a code concern.
+	resolvedProject := projectPath
+	if r, err := filepath.EvalSymlinks(projectPath); err == nil {
+		resolvedProject = r
+	}
+	encoded := ConvertToClaudeDirName(resolvedProject)
+	projectsDir := filepath.Join(configDir, "projects", encoded)
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatalf("mkdir projects dir: %v", err)
+	}
+
+	// Stale transcript: user record only, no assistant reply (mimics the empty
+	// 7-line file the launch-time env var points at).
+	staleID := "11111111-1111-1111-1111-111111111111"
+	staleBody := fmt.Sprintf(`{"type":"user","sessionId":%q,"message":{"role":"user","content":"hi"}}`+"\n", staleID)
+	writeTranscript(t, projectsDir, staleID, staleBody)
+
+	// A subagent SIDECHAIN transcript, newest by mtime, with an assistant reply.
+	// A naive newest-mtime scan would wrongly pick this; the scan must skip it.
+	sideID := "22222222-2222-2222-2222-222222222222"
+	sideBody := fmt.Sprintf(`{"type":"assistant","isSidechain":true,"sessionId":%q,"timestamp":"2026-05-31T22:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"SUBAGENT NOISE"}]}}`+"\n", sideID)
+
+	// Real, current transcript: a clean assistant reply (no tool output).
+	realID := "33333333-3333-3333-3333-333333333333"
+	realBody := fmt.Sprintf(`{"type":"assistant","sessionId":%q,"timestamp":"2026-05-31T22:05:00Z","message":{"role":"assistant","content":[{"type":"text","text":"CLEAN CONDUCTOR REPLY"}]}}`+"\n", realID)
+	writeTranscript(t, projectsDir, realID, realBody)
+	writeTranscript(t, projectsDir, sideID, sideBody)
+
+	// Force mtime ordering: sidechain newest, then real, then stale oldest.
+	base := time.Now()
+	mustChtime(t, filepath.Join(projectsDir, staleID+".jsonl"), base.Add(-2*time.Minute))
+	mustChtime(t, filepath.Join(projectsDir, realID+".jsonl"), base.Add(-1*time.Minute))
+	mustChtime(t, filepath.Join(projectsDir, sideID+".jsonl"), base)
+
+	inst := NewInstance("conductor-work", projectPath)
+	inst.Tool = "claude"
+	inst.ClaudeSessionID = staleID // stale: points at the empty transcript
+	// No tmuxSession: the only viable recovery is the disk scan.
+
+	resp, err := inst.GetLastResponseBestEffort()
+	if err != nil {
+		t.Fatalf("GetLastResponseBestEffort returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("GetLastResponseBestEffort returned nil response")
+	}
+	if got := resp.Content; got != "CLEAN CONDUCTOR REPLY" {
+		t.Errorf("expected clean reply from newest real transcript, got %q", got)
+	}
+}
+
+func writeTranscript(t *testing.T, dir, id, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, id+".jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write transcript %s: %v", id, err)
+	}
+}
+
+func mustChtime(t *testing.T, path string, mod time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, mod, mod); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Problem

When a conductor's Claude session rolls over (a `/clear` or compaction starts a **new** transcript), the tmux env var `CLAUDE_SESSION_ID` — fixed at launch — keeps pointing at the **old, now-empty** transcript. `getClaudeLastResponse` then reads that empty file, errors, and `GetLastResponseBestEffort` drops to raw tmux-pane parsing. That pane often contains tool output (e.g. a `list --json` dump), which then gets relayed verbatim into the conductor's Telegram/Slack replies — users see a wall of raw JSON instead of the conductor's actual message.

The **Gemini** read path already guards against a stale session ID via `syncGeminiSessionFromDisk`; the **Claude** path had no equivalent. That asymmetry is the bug.

## Fix

- **`findLatestClaudeTranscriptOnDisk()`** — when the stored/env session ID points at a transcript with no real assistant reply, scan the project's transcript dir for the most recently modified file that carries one, and sync the recovered ID back into the tmux env so it self-heals for subsequent reads/restarts. Mirrors the Gemini fallback.
- **Skip subagent sidechain records** (`isSidechain: true`) when extracting the last assistant message, so a Task subagent's output is never mistaken for the conductor's reply (and so a newest-mtime sidechain file can't shadow the real transcript).

## Test

`TestGetLastResponseBestEffort_RecoversFromStaleSessionIDViaDiskScan`: stale stored ID pointing at an empty transcript + a newer real transcript + a *newest* sidechain decoy → asserts the clean reply is returned (not the decoy, not empty). RED before the fix, GREEN after.

## Also: macOS install re-sign (second commit)

While verifying the install, found that `make install`/`install-user` overwrite the binary in place with `cp`, which invalidates its ad-hoc code signature on Apple Silicon — the kernel then **SIGKILLs** the binary on exec even though the bytes are identical to a working build. Both targets now `rm` the target first (fresh inode) and ad-hoc re-sign (`codesign --force --sign -`) after copying, guarded to Darwin (no-op elsewhere).

## Verification

Built and installed locally. With the tmux env forced back to the stale ID (the exact bug condition), `agent-deck session output <conductor> --json` returns clean prose (no JSON) and repairs the env var to the live transcript ID.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced session recovery to restore sessions from local transcripts when standard recovery fails.

* **Bug Fixes**
  * Fixed binary installation on macOS with Apple Silicon to properly handle code signing.
  * Improved installation process to cleanly remove old versions before installing updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->