### PR TITLE
feat: add first-class Grok (grok-build) tool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ Agent Deck works with any terminal-based AI tool:
 | **Crush** (charmbracelet/crush) | Status detection, organization, launch |
 | **Cursor** (terminal) | Status detection, organization |
 | **Hermes Agent** | Organization, launch |
+| **Grok** (xAI grok-build) | Status detection, organization, launch |
 | **Custom tools** | Configurable via `[tools.*]` in config.toml |
 
 ### Cost Tracking Dashboard

--- a/cmd/agent-deck/gemini_yolo.go
+++ b/cmd/agent-deck/gemini_yolo.go
@@ -23,8 +23,18 @@ func applyCLIYoloOverride(inst *session.Instance, enabled bool) error {
 		if err := inst.SetCodexOptions(opts); err != nil {
 			return err
 		}
+	case "grok":
+		yolo := true
+		opts := inst.GetGrokOptions()
+		if opts == nil {
+			opts = &session.GrokOptions{}
+		}
+		opts.YoloMode = &yolo
+		if err := inst.SetGrokOptions(opts); err != nil {
+			return err
+		}
 	default:
-		return fmt.Errorf("--yolo only works with Gemini or Codex sessions")
+		return fmt.Errorf("--yolo only works with Gemini, Codex, or Grok sessions")
 	}
 	return nil
 }

--- a/cmd/agent-deck/grok_detect_test.go
+++ b/cmd/agent-deck/grok_detect_test.go
@@ -1,0 +1,47 @@
+package main
+
+import "testing"
+
+// `agent-deck add -c grok .` must set Instance.Tool = "grok" instead of
+// falling back to "shell". This is the CLI-layer detection (not tmux's
+// detectToolFromCommand) — it lives in main.go.
+
+func TestDetectTool_Grok(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"bare", "grok", "grok"},
+		{"with model", "grok -m grok-build", "grok"},
+		{"uppercase", "Grok", "grok"},
+		{"always-approve", "grok --always-approve", "grok"},
+		{"absolute path", "/Users/me/.grok/bin/grok", "grok"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got != tt.want {
+				t.Errorf("detectTool(%q) = %q, want %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectTool_Grok_Negative(t *testing.T) {
+	// detectTool uses strings.Contains, so only truly unrelated strings are
+	// guarded here (mirrors the crush/hermes precedent).
+	tests := []struct {
+		name string
+		cmd  string
+	}{
+		{"empty string", ""},
+		{"unrelated", "ls -la"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectTool(tt.cmd); got == "grok" {
+				t.Errorf("detectTool(%q) = %q, should NOT match grok", tt.cmd, got)
+			}
+		})
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -3105,6 +3105,8 @@ func detectTool(cmd string) string {
 		return "cursor"
 	case strings.Contains(cmd, "hermes"):
 		return "hermes"
+	case strings.Contains(cmd, "grok"):
+		return "grok"
 	default:
 		return "shell"
 	}

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -282,6 +282,8 @@ func (i *Instance) getToolEnvFile() string {
 		return config.Crush.EnvFile
 	case "hermes":
 		return config.Hermes.EnvFile
+	case "grok":
+		return config.Grok.EnvFile
 	default:
 		// Check custom tools
 		if def := GetToolDef(i.Tool); def != nil {

--- a/internal/session/grok.go
+++ b/internal/session/grok.go
@@ -1,0 +1,154 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Grok adapter (xAI Grok Build CLI).
+//
+// `grok` from xAI (https://docs.x.ai/build/overview) is a Claude-Code-style
+// interactive TUI. agent-deck integrates it at the same level as gemini/codex:
+// launch the TUI in a tmux pane with optional env_file sourcing, an optional
+// command override, a per-session model (`-m <model>`), and an opt-in
+// `--always-approve` flag (Grok's auto-approve / yolo equivalent).
+//
+// Default model: grok-build. Resume (`-r/--resume <id>`) is intentionally NOT
+// wired yet — a reliable Grok session-ID extraction path has not been verified
+// (deferred; see PR notes). Status detection uses the busy/prompt patterns in
+// internal/tmux/patterns.go (DefaultRawPatterns), captured from the real TUI.
+
+// GrokOptions holds launch options for Grok Build CLI sessions.
+type GrokOptions struct {
+	// Model overrides the Grok model for this session (e.g., "grok-build").
+	// Passed as `-m <model>`. Empty means the CLI's own default.
+	Model string `json:"model,omitempty"`
+	// YoloMode enables `--always-approve` (auto-approve all tool calls).
+	// nil = inherit from config, true/false = explicit override.
+	YoloMode *bool `json:"yolo_mode,omitempty"`
+}
+
+// ToolName returns "grok"
+func (o *GrokOptions) ToolName() string {
+	return "grok"
+}
+
+// ToArgs returns command-line arguments based on options.
+func (o *GrokOptions) ToArgs() []string {
+	var args []string
+	if o.Model != "" {
+		args = append(args, "-m", o.Model)
+	}
+	if o.YoloMode != nil && *o.YoloMode {
+		args = append(args, "--always-approve")
+	}
+	return args
+}
+
+// NewGrokOptions creates GrokOptions with defaults from global config.
+func NewGrokOptions(config *UserConfig) *GrokOptions {
+	opts := &GrokOptions{}
+	if config != nil {
+		opts.Model = config.Grok.DefaultModel
+		if config.Grok.YoloMode {
+			yolo := true
+			opts.YoloMode = &yolo
+		}
+	}
+	return opts
+}
+
+// UnmarshalGrokOptions deserializes GrokOptions from the JSON wrapper.
+func UnmarshalGrokOptions(data json.RawMessage) (*GrokOptions, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var wrapper ToolOptionsWrapper
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, err
+	}
+
+	if wrapper.Tool != "grok" {
+		return nil, nil
+	}
+
+	var opts GrokOptions
+	if err := json.Unmarshal(wrapper.Options, &opts); err != nil {
+		return nil, err
+	}
+
+	return &opts, nil
+}
+
+// GetGrokOptions returns Grok-specific options, or nil if not set.
+func (i *Instance) GetGrokOptions() *GrokOptions {
+	if len(i.ToolOptionsJSON) == 0 {
+		return nil
+	}
+	opts, err := UnmarshalGrokOptions(i.ToolOptionsJSON)
+	if err != nil {
+		return nil
+	}
+	return opts
+}
+
+// SetGrokOptions stores Grok-specific options.
+func (i *Instance) SetGrokOptions(opts *GrokOptions) error {
+	if opts == nil {
+		i.ToolOptionsJSON = nil
+		return nil
+	}
+	data, err := MarshalToolOptions(opts)
+	if err != nil {
+		return err
+	}
+	i.ToolOptionsJSON = data
+	return nil
+}
+
+// buildGrokCommand builds the launch command for the Grok Build CLI.
+// Applies env sourcing, command override, and per-session/global flags
+// (model, --always-approve). If baseCommand differs from the bare tool name
+// "grok", it is treated as a user-supplied passthrough command and returned
+// without flag injection — matching the buildGeminiCommand/buildCrushCommand
+// pattern.
+func (i *Instance) buildGrokCommand(baseCommand string) string {
+	if i.Tool != "grok" {
+		return baseCommand
+	}
+
+	envPrefix := i.buildEnvSourceCommand()
+
+	// Passthrough: custom command from CLI (not the bare name).
+	trimmed := strings.TrimSpace(baseCommand)
+	if trimmed != "" && trimmed != "grok" {
+		return envPrefix + trimmed
+	}
+
+	cmd := GetToolCommand("grok")
+
+	// Per-session options take priority; any field left unset falls back to
+	// the global [grok] config. Filling per-field (rather than only when the
+	// whole wrapper is nil) means a partial override — e.g. `--yolo` alone via
+	// applyCLIYoloOverride — still inherits default_model, regardless of the
+	// order the options were written.
+	config, _ := LoadUserConfig()
+	defaults := NewGrokOptions(config)
+	opts := i.GetGrokOptions()
+	if opts == nil {
+		opts = defaults
+	} else {
+		if opts.Model == "" {
+			opts.Model = defaults.Model
+		}
+		if opts.YoloMode == nil {
+			opts.YoloMode = defaults.YoloMode
+		}
+	}
+	if args := opts.ToArgs(); len(args) > 0 {
+		cmd += " " + strings.Join(args, " ")
+	}
+
+	return envPrefix + cmd
+}

--- a/internal/session/grok_test.go
+++ b/internal/session/grok_test.go
@@ -1,0 +1,227 @@
+package session
+
+import (
+	"reflect"
+	"testing"
+)
+
+// xAI Grok Build CLI support. These tests define the Tool="grok" contract:
+// options marshalling, ToArgs for model + --always-approve, factory from
+// config, and the command builder (bare name, config defaults, per-session
+// options, command override, passthrough, wrong-tool gate).
+//
+// Binary: `grok` (https://docs.x.ai/build/overview). Claude-Code-style TUI.
+// Key flags: -m/--model, --always-approve.
+
+func TestGrokOptions_ToolName(t *testing.T) {
+	opts := &GrokOptions{}
+	if got := opts.ToolName(); got != "grok" {
+		t.Errorf("GrokOptions.ToolName() = %q, want %q", got, "grok")
+	}
+}
+
+func TestGrokOptions_ToArgs(t *testing.T) {
+	yoloTrue := true
+	yoloFalse := false
+
+	tests := []struct {
+		name     string
+		opts     GrokOptions
+		expected []string
+	}{
+		{"default - no args", GrokOptions{}, nil},
+		{"yolo nil - no args", GrokOptions{YoloMode: nil}, nil},
+		{"yolo false - no args", GrokOptions{YoloMode: &yoloFalse}, nil},
+		{"yolo true", GrokOptions{YoloMode: &yoloTrue}, []string{"--always-approve"}},
+		{"model only", GrokOptions{Model: "grok-build"}, []string{"-m", "grok-build"}},
+		{"model + yolo", GrokOptions{Model: "grok-build", YoloMode: &yoloTrue}, []string{"-m", "grok-build", "--always-approve"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.opts.ToArgs()
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("ToArgs() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewGrokOptions_Defaults(t *testing.T) {
+	opts := NewGrokOptions(nil)
+	if opts == nil {
+		t.Fatal("NewGrokOptions(nil) returned nil")
+	}
+	if opts.YoloMode != nil {
+		t.Errorf("default YoloMode = %v, want nil", opts.YoloMode)
+	}
+	if opts.Model != "" {
+		t.Errorf("default Model = %q, want empty", opts.Model)
+	}
+}
+
+func TestNewGrokOptions_FromConfig(t *testing.T) {
+	cfg := &UserConfig{
+		Grok: GrokSettings{YoloMode: true, DefaultModel: "grok-build"},
+	}
+	opts := NewGrokOptions(cfg)
+	if opts == nil {
+		t.Fatal("NewGrokOptions returned nil")
+	}
+	if opts.YoloMode == nil || !*opts.YoloMode {
+		t.Errorf("YoloMode = %v, want true", opts.YoloMode)
+	}
+	if opts.Model != "grok-build" {
+		t.Errorf("Model = %q, want %q", opts.Model, "grok-build")
+	}
+}
+
+func TestGrokOptions_MarshalUnmarshalRoundtrip(t *testing.T) {
+	yolo := true
+	orig := &GrokOptions{Model: "grok-build", YoloMode: &yolo}
+
+	data, err := MarshalToolOptions(orig)
+	if err != nil {
+		t.Fatalf("MarshalToolOptions error: %v", err)
+	}
+
+	got, err := UnmarshalGrokOptions(data)
+	if err != nil {
+		t.Fatalf("UnmarshalGrokOptions error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("UnmarshalGrokOptions returned nil")
+	}
+	if !reflect.DeepEqual(got, orig) {
+		t.Errorf("roundtrip = %+v, want %+v", got, orig)
+	}
+}
+
+func TestUnmarshalGrokOptions_WrongTool(t *testing.T) {
+	// A codex wrapper must not be decoded as grok options.
+	data, err := MarshalToolOptions(&CodexOptions{Model: "gpt-5"})
+	if err != nil {
+		t.Fatalf("MarshalToolOptions error: %v", err)
+	}
+	got, err := UnmarshalGrokOptions(data)
+	if err != nil {
+		t.Fatalf("UnmarshalGrokOptions error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("UnmarshalGrokOptions on codex wrapper = %+v, want nil", got)
+	}
+}
+
+func TestBuildGrokCommand_BareName(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	inst := &Instance{Tool: "grok"}
+	cmd := inst.buildGrokCommand("grok")
+	if !endsWith(cmd, "grok") {
+		t.Errorf("buildGrokCommand(\"grok\") = %q, want suffix %q", cmd, "grok")
+	}
+}
+
+func TestBuildGrokCommand_YoloFromConfig(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{Grok: GrokSettings{YoloMode: true}}
+
+	inst := &Instance{Tool: "grok"}
+	cmd := inst.buildGrokCommand("grok")
+	if !endsWith(cmd, "grok --always-approve") {
+		t.Errorf("buildGrokCommand() = %q, want suffix %q", cmd, "grok --always-approve")
+	}
+}
+
+func TestBuildGrokCommand_DefaultModelFromConfig(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{Grok: GrokSettings{DefaultModel: "grok-build"}}
+
+	inst := &Instance{Tool: "grok"}
+	cmd := inst.buildGrokCommand("grok")
+	if !endsWith(cmd, "grok -m grok-build") {
+		t.Errorf("buildGrokCommand() = %q, want suffix %q", cmd, "grok -m grok-build")
+	}
+}
+
+func TestBuildGrokCommand_PerSessionOptions(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	// Config has no defaults; per-session options should drive the flags.
+	userConfigCache = &UserConfig{}
+
+	inst := &Instance{Tool: "grok"}
+	if err := inst.ApplyLaunchModel("grok-build"); err != nil {
+		t.Fatalf("ApplyLaunchModel error: %v", err)
+	}
+	cmd := inst.buildGrokCommand("grok")
+	if !endsWith(cmd, "grok -m grok-build") {
+		t.Errorf("buildGrokCommand() = %q, want suffix %q", cmd, "grok -m grok-build")
+	}
+}
+
+// A yolo-only per-session override (e.g. from `--yolo`) must still inherit the
+// configured default_model: a partial wrapper would otherwise skip the config
+// fallback and silently drop the model.
+func TestBuildGrokCommand_PartialOptionsInheritConfigModel(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{Grok: GrokSettings{DefaultModel: "grok-build"}}
+
+	inst := &Instance{Tool: "grok"}
+	yolo := true
+	if err := inst.SetGrokOptions(&GrokOptions{YoloMode: &yolo}); err != nil {
+		t.Fatalf("SetGrokOptions error: %v", err)
+	}
+	cmd := inst.buildGrokCommand("grok")
+	if !endsWith(cmd, "grok -m grok-build --always-approve") {
+		t.Errorf("buildGrokCommand() = %q, want suffix %q", cmd, "grok -m grok-build --always-approve")
+	}
+}
+
+func TestBuildGrokCommand_CommandOverride(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{Grok: GrokSettings{Command: "grok --reasoning-effort high"}}
+
+	inst := &Instance{Tool: "grok"}
+	cmd := inst.buildGrokCommand("grok")
+	if !endsWith(cmd, "grok --reasoning-effort high") {
+		t.Errorf("buildGrokCommand() = %q, want suffix %q", cmd, "grok --reasoning-effort high")
+	}
+}
+
+func TestBuildGrokCommand_Passthrough(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{}
+
+	inst := &Instance{Tool: "grok"}
+	got := inst.buildGrokCommand("grok --some-flag")
+	if !endsWith(got, "grok --some-flag") {
+		t.Errorf("buildGrokCommand passthrough = %q, want suffix %q", got, "grok --some-flag")
+	}
+}
+
+func TestBuildGrokCommand_WrongTool(t *testing.T) {
+	inst := &Instance{Tool: "claude"}
+	got := inst.buildGrokCommand("anything")
+	if got != "anything" {
+		t.Errorf("buildGrokCommand with wrong tool = %q, want %q", got, "anything")
+	}
+}
+
+func TestGetToolEnvFile_Grok(t *testing.T) {
+	oldCache := userConfigCache
+	defer func() { userConfigCache = oldCache }()
+	userConfigCache = &UserConfig{Grok: GrokSettings{EnvFile: "/tmp/grok.env"}}
+
+	inst := &Instance{Tool: "grok"}
+	if got := inst.getToolEnvFile(); got != "/tmp/grok.env" {
+		t.Errorf("getToolEnvFile() for grok = %q, want %q", got, "/tmp/grok.env")
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2777,6 +2777,8 @@ func (i *Instance) Start() error {
 		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "hermes":
 		command = i.buildHermesCommand(i.Command)
+	case i.Tool == "grok":
+		command = i.buildGrokCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -2981,6 +2983,8 @@ func (i *Instance) StartWithMessage(message string) error {
 		command = i.buildCursorCommand(i.Command, false)
 	case i.Tool == "hermes":
 		command = i.buildHermesCommand(i.Command)
+	case i.Tool == "grok":
+		command = i.buildGrokCommand(i.Command)
 	default:
 		// Check if this is a custom tool with session resume config
 		if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -5407,6 +5411,8 @@ func (i *Instance) Restart() error {
 			command = i.buildCursorCommand(i.Command, true)
 		case i.Tool == "hermes":
 			command = i.buildHermesCommand(i.Command)
+		case i.Tool == "grok":
+			command = i.buildGrokCommand(i.Command)
 		default:
 			// Check if this is a custom tool with session resume config
 			if toolDef := GetToolDef(i.Tool); toolDef != nil {
@@ -5640,7 +5646,7 @@ func (i *Instance) SetGeminiModel(model string) error {
 // SupportsLaunchModel reports whether a newly-created session can receive an
 // explicit model override through Agent Deck's generic session creation path.
 func SupportsLaunchModel(tool string) bool {
-	return IsClaudeCompatible(tool) || tool == "gemini" || tool == "opencode" || IsCodexCompatible(tool)
+	return IsClaudeCompatible(tool) || tool == "gemini" || tool == "opencode" || IsCodexCompatible(tool) || tool == "grok"
 }
 
 // ApplyLaunchModel stores a per-session model override in the tool-specific
@@ -5679,6 +5685,14 @@ func (i *Instance) ApplyLaunchModel(model string) error {
 		}
 		opts.Model = model
 		return i.SetCodexOptions(opts)
+	case i.Tool == "grok":
+		opts := i.GetGrokOptions()
+		if opts == nil {
+			userConfig, _ := LoadUserConfig()
+			opts = NewGrokOptions(userConfig)
+		}
+		opts.Model = model
+		return i.SetGrokOptions(opts)
 	default:
 		return fmt.Errorf("model selection is not supported for tool %q", i.Tool)
 	}
@@ -6784,6 +6798,7 @@ var builtinAgentTools = map[string]bool{
 	"cursor":   true,
 	"hermes":   true,
 	"crush":    true,
+	"grok":     true,
 }
 
 // isBuiltinAgentTool reports whether tool is a first-party agent (or a custom

--- a/internal/session/model_info.go
+++ b/internal/session/model_info.go
@@ -36,6 +36,10 @@ func (i *Instance) LaunchModelID() string {
 		if opts := i.GetCodexOptions(); opts != nil {
 			return strings.TrimSpace(opts.Model)
 		}
+	case i.Tool == "grok":
+		if opts := i.GetGrokOptions(); opts != nil {
+			return strings.TrimSpace(opts.Model)
+		}
 	}
 
 	return ""

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -108,6 +108,9 @@ type UserConfig struct {
 	// Hermes defines Hermes Agent CLI integration settings
 	Hermes HermesSettings `toml:"hermes"`
 
+	// Grok defines xAI Grok Build CLI integration settings
+	Grok GrokSettings `toml:"grok"`
+
 	// Worktree defines git worktree preferences
 	Worktree WorktreeSettings `toml:"worktree"`
 
@@ -1101,6 +1104,27 @@ type CrushSettings struct {
 	// YoloMode enables --yolo flag for Crush sessions (auto-accept all
 	// permission prompts). Default: false
 	YoloMode bool `toml:"yolo_mode"`
+}
+
+// GrokSettings defines xAI Grok Build CLI configuration.
+// Binary: `grok` from xAI (https://docs.x.ai/build/overview). Claude-Code-style
+// interactive TUI. Key flags: -m/--model, --always-approve, --cwd.
+type GrokSettings struct {
+	// Command overrides the default binary/invocation for Grok sessions.
+	// Supports flags (e.g., "grok --reasoning-effort high"). Default: "grok"
+	Command string `toml:"command"`
+
+	// EnvFile is a .env file specific to Grok sessions (sourced before the
+	// `grok` command runs, like [gemini].env_file). Optional.
+	EnvFile string `toml:"env_file"`
+
+	// YoloMode enables --always-approve for Grok sessions (auto-approve all
+	// tool calls). Default: false
+	YoloMode bool `toml:"yolo_mode"`
+
+	// DefaultModel is the model to use for new Grok sessions (e.g.,
+	// "grok-build"). If empty, the Grok CLI uses its own default.
+	DefaultModel string `toml:"default_model"`
 }
 
 // WorktreeSettings contains git worktree preferences.
@@ -2224,13 +2248,17 @@ func GetToolCommand(toolName string) string {
 		if config.Hermes.Command != "" {
 			return config.Hermes.Command
 		}
+	case "grok":
+		if config.Grok.Command != "" {
+			return config.Grok.Command
+		}
 	}
 	return toolName
 }
 
 func isBuiltinToolName(toolName string) bool {
 	switch toolName {
-	case "claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi", "shell", "aider":
+	case "claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "grok", "pi", "shell", "aider":
 		return true
 	default:
 		return false
@@ -2262,6 +2290,8 @@ func GetToolIcon(toolName string) string {
 		return "📝"
 	case "hermes":
 		return "☤"
+	case "grok":
+		return "✕"
 	case "pi":
 		return "π"
 	case "shell":
@@ -2813,6 +2843,15 @@ func CreateExampleConfig() error {
 # [profiles.work.codex]
 # config_dir = "~/.codex-work"
 # Enable --yolo (bypass approvals and sandbox) by default (default: false)
+# yolo_mode = true
+
+# Grok Build CLI integration (xAI)
+# [grok]
+# Grok CLI command or alias to use (default: "grok")
+# command = "grok"
+# Default model for new sessions (default: Grok CLI's own default, grok-build)
+# default_model = "grok-build"
+# Enable --always-approve (auto-approve all tool calls) by default (default: false)
 # yolo_mode = true
 
 # Log file management

--- a/internal/tmux/grok_test.go
+++ b/internal/tmux/grok_test.go
@@ -1,0 +1,52 @@
+package tmux
+
+import "testing"
+
+// xAI Grok Build CLI — tmux-layer detection tests (command + content).
+
+func TestDetectToolFromCommand_Grok(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"bare grok", "grok", "grok"},
+		{"grok with model", "grok -m grok-build", "grok"},
+		{"grok absolute path", "/Users/me/.grok/bin/grok", "grok"},
+		{"uppercase binary", "GROK", "grok"},
+		{"grok always-approve", "grok --always-approve", "grok"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromCommand(tt.command); got != tt.want {
+				t.Fatalf("detectToolFromCommand(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromCommand_Grok_Negative(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{"empty", ""},
+		{"unrelated tool", "ls -la"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectToolFromCommand(tt.command); got == "grok" {
+				t.Fatalf("detectToolFromCommand(%q) = %q, should NOT match grok", tt.command, got)
+			}
+		})
+	}
+}
+
+func TestDetectToolFromContent_Grok(t *testing.T) {
+	// "Grok Build" is the composer border label present in the real TUI.
+	if got := detectToolFromContent("╰─ Grok Build · always-approve ─╯"); got != "grok" {
+		t.Fatalf("detectToolFromContent(grok banner) = %q, want %q", got, "grok")
+	}
+}

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -122,6 +122,35 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 				`re:(?m)^\s*›\s`,
 			},
 		}
+	case "grok":
+		// xAI Grok Build CLI (https://docs.x.ai/build/overview) — a
+		// Claude-Code-style TUI. Patterns captured from the real v0.2.14 TUI
+		// and verified end-to-end (3x --wait round-trips + a live conductor
+		// turn). GetStatus checks busy BEFORE prompt, which is what keeps
+		// these prompt markers safe.
+		//
+		// "Grok Build" (the composer border label) is DELIBERATELY excluded
+		// from PromptPatterns: it is present in every frame — including the
+		// post-submit, pre-reply transient — so using it as a ready marker
+		// reports "waiting" too early and races the reply render in
+		// waitForCompletion. The fresh home screen carries "New worktree";
+		// the post-turn settled footer carries "Shift+Tab:mode" /
+		// "Ctrl+.:shortcuts"; "Enter:send" appears once text is queued.
+		return &RawPatterns{
+			BusyPatterns: []string{
+				"Ctrl+c:cancel",
+				"Ctrl+Enter:interject",
+				"Thinking…",
+				"Responding…",
+				"Connecting MCPs",
+			},
+			PromptPatterns: []string{
+				"New worktree",
+				"Ctrl+.:shortcuts",
+				"Shift+Tab:mode",
+				"Enter:send",
+			},
+		}
 	case "shell":
 		return &RawPatterns{
 			PromptPatterns: []string{"$ ", "# ", "% "},

--- a/internal/tmux/patterns_test.go
+++ b/internal/tmux/patterns_test.go
@@ -138,6 +138,44 @@ func TestDefaultRawPatterns_Pi(t *testing.T) {
 	}
 }
 
+func TestDefaultRawPatterns_Grok(t *testing.T) {
+	raw := DefaultRawPatterns("grok")
+	if raw == nil {
+		t.Fatal("expected non-nil for grok")
+	}
+	if len(raw.BusyPatterns) == 0 {
+		t.Error("grok should have busy patterns")
+	}
+	if len(raw.PromptPatterns) == 0 {
+		t.Error("grok should have prompt patterns")
+	}
+
+	// Verified busy markers (captured from the real TUI).
+	wantBusy := map[string]bool{
+		"Ctrl+c:cancel": false, "Ctrl+Enter:interject": false,
+		"Thinking…": false, "Responding…": false, "Connecting MCPs": false,
+	}
+	for _, p := range raw.BusyPatterns {
+		if _, ok := wantBusy[p]; ok {
+			wantBusy[p] = true
+		}
+	}
+	for p, found := range wantBusy {
+		if !found {
+			t.Errorf("grok busy patterns missing %q", p)
+		}
+	}
+
+	// Regression guard (2026-05-31 grok-wait-fix): "Grok Build" is the
+	// always-present composer label and must NOT be a prompt marker, or
+	// hasPromptIndicator reports "waiting" too early and races the reply.
+	for _, p := range raw.PromptPatterns {
+		if p == "Grok Build" {
+			t.Error(`grok prompt patterns must NOT include "Grok Build" (wait-fix regression)`)
+		}
+	}
+}
+
 func TestDefaultRawPatterns_Unknown(t *testing.T) {
 	raw := DefaultRawPatterns("unknowntool")
 	if raw != nil {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -537,7 +537,7 @@ func SupportsHyperlinks() bool {
 }
 
 // Tool detection patterns (used by DetectTool for initial tool identification)
-var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi"}
+var toolDetectionOrder = []string{"claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "grok", "pi"}
 
 var toolDetectionPatterns = map[string][]*regexp.Regexp{
 	"claude": {
@@ -575,6 +575,11 @@ var toolDetectionPatterns = map[string][]*regexp.Regexp{
 		// Hermes Agent CLI (github.com/NousResearch/hermes-agent).
 		regexp.MustCompile(`(?i)\bhermes\s+agent\b`),
 		regexp.MustCompile(`(?i)\bnous\s*research\b`),
+	},
+	"grok": {
+		// xAI Grok Build CLI — "Grok Build" is the composer border label
+		// present in every TUI frame (https://docs.x.ai/build/overview).
+		regexp.MustCompile(`(?i)\bgrok\s+build\b`),
 	},
 	"pi": {
 		regexp.MustCompile(`(?mi)^\s*pi>\s*`),
@@ -614,6 +619,8 @@ func detectToolFromCommand(command string) string {
 			return "cursor"
 		case "hermes":
 			return "hermes"
+		case "grok":
+			return "grok"
 		case "pi":
 			return "pi"
 		}
@@ -636,6 +643,8 @@ func detectToolFromCommand(command string) string {
 		return "cursor"
 	case strings.Contains(cmdLower, "hermes"):
 		return "hermes"
+	case strings.Contains(cmdLower, "grok"):
+		return "grok"
 	case strings.Contains(cmdLower, " pi ") || strings.HasPrefix(cmdLower, "pi "):
 		return "pi"
 	default:

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7166,7 +7166,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case "y":
-		// Toggle YOLO mode for Gemini or Codex sessions (requires restart)
+		// Toggle YOLO mode for Gemini, Codex, or Grok sessions (requires restart)
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil {
@@ -7205,6 +7205,25 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 					opts.YoloMode = &newYolo
 					_ = inst.SetCodexOptions(opts)
+					toggled = true
+
+				case "grok":
+					currentYolo := false
+					opts := inst.GetGrokOptions()
+					if opts != nil && opts.YoloMode != nil {
+						currentYolo = *opts.YoloMode
+					} else {
+						userConfig, _ := session.LoadUserConfig()
+						if userConfig != nil {
+							currentYolo = userConfig.Grok.YoloMode
+						}
+					}
+					newYolo := !currentYolo
+					if opts == nil {
+						opts = &session.GrokOptions{}
+					}
+					opts.YoloMode = &newYolo
+					_ = inst.SetGrokOptions(opts)
 					toggled = true
 				}
 
@@ -8908,6 +8927,8 @@ func createSessionTool(command string) (string, string) {
 		command = "cursor agent"
 	case "hermes":
 		tool = "hermes"
+	case "grok":
+		tool = "grok"
 	default:
 		if toolDef := session.GetToolDef(command); toolDef != nil {
 			tool = command

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -248,7 +248,7 @@ func displayCommandPreset(cmd string) string {
 // buildPresetCommands returns the list of commands for the picker,
 // including any custom tools from config.toml.
 func buildPresetCommands() []string {
-	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
+	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "grok"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}
@@ -836,6 +836,11 @@ func knownModelIDsForTool(tool string) []string {
 			"o3-pro",
 			"o3",
 		}
+	case tool == "grok":
+		return []string{
+			"grok-build",
+			"grok-code-fast-1",
+		}
 	default:
 		return nil
 	}
@@ -1076,6 +1081,8 @@ func (d *NewDialog) updateModelPlaceholder() {
 		d.modelInput.Placeholder = "openai/gpt-5.5"
 	case session.IsCodexCompatible(cmd):
 		d.modelInput.Placeholder = "gpt-5.5"
+	case cmd == "grok":
+		d.modelInput.Placeholder = "grok-build"
 	default:
 		d.modelInput.Placeholder = "tool default"
 	}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -268,8 +268,8 @@ func TestDisplayCommandPreset(t *testing.T) {
 func TestDialogPresetCommands(t *testing.T) {
 	d := NewNewDialog()
 
-	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, crush, cursor, hermes
-	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
+	// Should have shell (empty), claude, gemini, opencode, codex, pi, copilot, crush, cursor, hermes, grok
+	expectedCommands := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "grok"}
 
 	if len(d.presetCommands) != len(expectedCommands) {
 		t.Errorf("Expected %d preset commands, got %d", len(expectedCommands), len(d.presetCommands))

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -107,8 +107,8 @@ type SettingsPanel struct {
 // builtinToolNames and builtinToolValues are the built-in tools. Custom tools
 // from config are appended dynamically in LoadConfig.
 var (
-	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes"}
-	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
+	builtinToolNames  = []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "Grok"}
+	builtinToolValues = []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "grok"}
 )
 
 // Search tier names for radio selection
@@ -324,7 +324,7 @@ func (s *SettingsPanel) buildToolLists(config *session.UserConfig) {
 		builtins := map[string]bool{
 			"claude": true, "gemini": true, "opencode": true,
 			"codex": true, "pi": true, "crush": true, "copilot": true,
-			"shell": true, "cursor": true, "aider": true,
+			"shell": true, "cursor": true, "aider": true, "grok": true,
 		}
 		var custom []string
 		for name := range config.Tools {

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -212,8 +212,8 @@ func TestSettingsPanel_LoadConfig_CustomTools(t *testing.T) {
 
 	panel.LoadConfig(config)
 
-	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "Openclaw", "Zeta", "None"}
-	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "openclaw", "zeta", ""}
+	wantNames := []string{"Claude", "Gemini", "OpenCode", "Codex", "Pi", "Copilot", "Crush", "Cursor", "Hermes", "Grok", "Openclaw", "Zeta", "None"}
+	wantValues := []string{"claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes", "grok", "openclaw", "zeta", ""}
 
 	if !reflect.DeepEqual(panel.toolNames, wantNames) {
 		t.Fatalf("toolNames = %#v, want %#v", panel.toolNames, wantNames)

--- a/internal/ui/setup_wizard.go
+++ b/internal/ui/setup_wizard.go
@@ -54,7 +54,7 @@ func NewSetupWizard() *SetupWizard {
 		visible:             false,
 		complete:            false,
 		currentStep:         0,
-		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes"},
+		toolOptions:         []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes", "grok"},
 		selectedTool:        0, // Default to Claude
 		dangerousMode:       false,
 		useDefaultConfigDir: true,
@@ -395,6 +395,7 @@ func (w *SetupWizard) View() string {
 			"crush":    "Crush - Charm's terminal-first AI coding assistant",
 			"shell":    "Shell - No AI tool (plain terminal)",
 			"cursor":   "Cursor Agent - Cursor CLI (cursor agent)",
+			"grok":     "Grok - xAI's Grok Build coding assistant",
 		}
 
 		for i, tool := range w.toolOptions {

--- a/internal/ui/setup_wizard_test.go
+++ b/internal/ui/setup_wizard_test.go
@@ -140,7 +140,7 @@ func TestSetupWizard_ToolOptions(t *testing.T) {
 	wizard := NewSetupWizard()
 
 	// Verify tool options
-	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes"}
+	expectedTools := []string{"claude", "gemini", "opencode", "codex", "pi", "shell", "copilot", "crush", "cursor", "hermes", "grok"}
 	if len(wizard.toolOptions) != len(expectedTools) {
 		t.Errorf("Tool options count: got %d, want %d", len(wizard.toolOptions), len(expectedTools))
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -529,6 +529,7 @@ func initStyles() {
 		"shell":    lipgloss.NewStyle().Foreground(ColorText),
 		"opencode": lipgloss.NewStyle().Foreground(ColorText),
 		"crush":    lipgloss.NewStyle().Foreground(ColorPurple),
+		"grok":     lipgloss.NewStyle().Foreground(ColorText),
 	}
 
 	// DefaultToolStyle
@@ -610,6 +611,8 @@ func ToolIcon(tool string) string {
 		return "📝"
 	case "hermes":
 		return "☤"
+	case "grok":
+		return "✕"
 	case "pi":
 		return IconPi
 	case "shell":
@@ -637,6 +640,8 @@ func ToolColor(tool string) lipgloss.Color {
 		return ColorAccent // Blue for Cursor
 	case "hermes":
 		return ColorYellow // Gold for Hermes Agent
+	case "grok":
+		return ColorText // Neutral for xAI Grok (monochrome brand)
 	case "pi":
 		return ColorAccent
 	case "aider":

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -12,6 +12,7 @@ All options for `~/.agent-deck/config.toml`.
 - [[codex] Section](#codex-section)
 - [[copilot] Section](#copilot-section)
 - [[hermes] Section](#hermes-section)
+- [[grok] Section](#grok-section)
 - [[docker] Section](#docker-section)
 - [[worktree] Section](#worktree-section)
 - [[logs] Section](#logs-section)
@@ -219,6 +220,27 @@ yolo_mode = false
 Status detection: process-alive/dead only. Content-sniffing planned for future release.
 
 When using a different Codex home, prefer an inline command such as `CODEX_HOME=~/.codex-work codex` or export `CODEX_HOME` before starting agent-deck. Shell aliases are allowed, but agent-deck cannot infer `CODEX_HOME` hidden inside an alias for resume-file discovery.
+
+## [grok] Section
+
+xAI Grok Build CLI integration settings ([docs.x.ai/build](https://docs.x.ai/build/overview)). Grok is a Claude-Code-style interactive TUI; default model is `grok-build`.
+
+```toml
+[grok]
+command = "grok"
+env_file = "~/.grok.env"
+yolo_mode = false
+default_model = "grok-build"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `command` | string | `"grok"` | Override the binary/invocation. Supports flags. |
+| `env_file` | string | `""` | A .env file sourced for Grok sessions only. See [Path Resolution](#path-resolution). |
+| `yolo_mode` | bool | `false` | Maps to `grok --always-approve` (auto-approve all tool calls). |
+| `default_model` | string | `""` | Model for new sessions, passed as `grok -m <model>`. Empty = Grok CLI default. |
+
+Status detection: busy/prompt content patterns captured from the real Grok TUI. Resume is not yet wired (deferred — Grok session-ID extraction is not verified).
 
 ## [docker] Section
 
@@ -550,7 +572,7 @@ env = { API_KEY = "token", BASE_URL = "https://api.example.com" }
 | `env_file` | string | No | A .env file sourced for this tool only. Sourced after global `[shell].env_files`. See [Path Resolution](#path-resolution). |
 | `env` | map | No | Inline environment variables exported for this tool. These take highest priority, overriding both `[shell].env_files` and `env_file`. Values are single-quoted to prevent shell expansion. |
 
-**Built-in icons:** claude=🤖, gemini=✨, opencode=🌐, codex=💻, copilot=🐙, hermes=☤, cursor=📝, shell=🐚
+**Built-in icons:** claude=🤖, gemini=✨, opencode=🌐, codex=💻, copilot=🐙, hermes=☤, grok=✕, cursor=📝, shell=🐚
 
 ## Path Resolution
 


### PR DESCRIPTION
## What

Graduates xAI's **Grok Build** CLI from a local `[tools.grok]` config-shim to a built-in agent-deck tool, alongside claude/codex/gemini/copilot/crush/hermes. Grok is a Claude-Code-style interactive TUI (default model `grok-build`).

## Why

Grok Build is a capable, claude-compatible coding TUI whose API surface maps ~1:1 to claude. It already worked via the generic `--cmd` backdoor, but first-class support gives it the menu entry, model picker, icon, yolo toggle, and — most importantly — verified default status patterns out of the box.

## Approach

Mirrors the existing simple-TUI adapters (gemini/codex/crush/hermes) — per-tool case-adds, **no new abstractions**:

- `internal/session/grok.go`: `GrokOptions{Model, YoloMode}` (mirrors `CodexOptions`); `ToArgs()` emits `-m <model>` and `--always-approve`. Per-session options persist via the generic `ToolOptionsJSON` blob and merge per-field with global `[grok]` config defaults at build time.
- Detection / dispatch wired through `detectTool`, `Start`, `StartWithMessage`, restart/recreate, `builtinAgentTools`.
- Model catalog + launch-model support; yolo `--yolo` → `--always-approve` + `y` hotkey toggle.
- Config: `GrokSettings` + commented `[grok]` template. UI: New Session preset, icon (✕) + color. Docs: README table + config-reference.

## Status patterns (the subtle bit)

`DefaultRawPatterns` were captured from the real TUI (v0.2.14) and **verified end-to-end**. `"Grok Build"` (the composer border label) is deliberately **excluded** from prompt patterns — it appears in *every* frame including the post-submit pre-reply transient, so as a ready marker it races the reply render in `waitForCompletion`. `GetStatus` checks busy before prompt, keeping the chosen markers safe.

## Deferred

Resume (`-r/--resume`) is intentionally deferred — a reliable Grok session-ID extraction path isn't verified yet, so no `GrokSessionID` field is added rather than faking it.

## Testing

- New unit tests pass: `GrokOptions` (ToolName, ToArgs across default/yolo/model/model+yolo combos), `detectTool` (bare/with-model/uppercase/always-approve/absolute-path + negative cases), tmux pattern detection.
- `go build ./...` clean.
- Note: 3 pre-existing failures on `internal/session` (`#965` MCP reap, `#956` chat-history persistence, `PERSIST-12` JSONL resume) reproduce identically on clean `main` with no grok code present — environment-specific, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grok added as a built-in agent: selectable in UI, config, and setup; supports model overrides and YOLO (--always-approve) toggling.
  * Improved automatic Grok detection for CLI and terminal sessions; preset commands and model placeholders updated.

* **Tests**
  * Added unit tests covering Grok detection, options, command building, UI presets, and patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->