### PR TITLE
fix(ui): pad viewport rows to prevent iTerm2 ghost lines on scroll

### DIFF
--- a/internal/ui/cellwidth.go
+++ b/internal/ui/cellwidth.go
@@ -27,6 +27,36 @@ func cellWidth(s string) int {
 	return ansi.StringWidth(s)
 }
 
+// fitCellWidth returns s truncated or space-padded so it occupies exactly width
+// terminal cells. Used by clampViewToViewport so each frame overwrites the full
+// row and incremental redraw does not leave ghost characters (issue #607) —
+// avoids tea.ClearScreen / flicker on iTerm2.
+func fitCellWidth(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	w := cellWidth(s)
+	if w > width {
+		return cellTruncate(s, width, "")
+	}
+	if w < width {
+		return s + strings.Repeat(" ", width-w)
+	}
+	return s
+}
+
+// fitLinesToWidth applies fitCellWidth to each line of a multi-line string.
+func fitLinesToWidth(content string, width int) string {
+	if width <= 0 || content == "" {
+		return content
+	}
+	lines := strings.Split(content, "\n")
+	for i := range lines {
+		lines[i] = fitCellWidth(lines[i], width)
+	}
+	return strings.Join(lines, "\n")
+}
+
 // cellTruncate returns a prefix of s whose cellWidth is <= width, appending
 // tail (also measured by cellWidth) if any truncation occurred.
 //

--- a/internal/ui/cellwidth.go
+++ b/internal/ui/cellwidth.go
@@ -27,6 +27,11 @@ func cellWidth(s string) int {
 	return ansi.StringWidth(s)
 }
 
+// ansiEraseLineEnd clears from the cursor to the end of the current line (EL).
+// Appended after padded rows so iTerm2 incremental redraw does not leave stale
+// glyphs when a shorter line replaces a longer one (#607), without ClearScreen.
+const ansiEraseLineEnd = "\x1b[K"
+
 // fitCellWidth returns s truncated or space-padded so it occupies exactly width
 // terminal cells. Used by clampViewToViewport so each frame overwrites the full
 // row and incremental redraw does not leave ghost characters (issue #607) —
@@ -43,6 +48,15 @@ func fitCellWidth(s string, width int) string {
 		return s + strings.Repeat(" ", width-w)
 	}
 	return s
+}
+
+// fitCellWidthErase is fitCellWidth plus EL so terminals clear trailing cells on
+// the row even when width math and lipgloss disagree by a cell or two.
+func fitCellWidthErase(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	return fitCellWidth(s, width) + ansiEraseLineEnd
 }
 
 // fitLinesToWidth applies fitCellWidth to each line of a multi-line string.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10844,7 +10844,7 @@ func clampViewToViewport(content string, width, height int) string {
 	for i, line := range lines {
 		// Pad/truncate to exactly width cells so incremental redraw does not
 		// leave stale glyphs when a shorter line replaces a longer one (#607).
-		lines[i] = fitCellWidth(line, width)
+		lines[i] = fitCellWidthErase(line, width)
 	}
 
 	return strings.Join(lines, "\n")
@@ -11827,8 +11827,7 @@ func (h *Home) renderSessionList(width, height int) string {
 
 	// Show "more above" indicator if scrolled down
 	if h.viewOffset > 0 {
-		b.WriteString(DimStyle.Render(fmt.Sprintf("  ⋮ +%d above", h.viewOffset)))
-		b.WriteString("\n")
+		writeListLine(&b, DimStyle.Render(fmt.Sprintf("  ⋮ +%d above", h.viewOffset)), width)
 		maxVisible-- // Account for the indicator line
 	}
 
@@ -11844,7 +11843,7 @@ func (h *Home) renderSessionList(width, height int) string {
 		if h.jumpMode && i < len(jumpHints) {
 			// Render item to temp buffer, then overlay hint badge at name position
 			var itemBuf strings.Builder
-			h.renderItem(&itemBuf, item, i == h.cursor, i, groupStats, snapshot)
+			h.renderItem(&itemBuf, item, i == h.cursor, i, groupStats, snapshot, width)
 			raw := itemBuf.String()
 			hint := jumpHints[i]
 			isMatch := h.jumpBuffer == "" || strings.HasPrefix(hint, h.jumpBuffer)
@@ -11854,17 +11853,22 @@ func (h *Home) renderSessionList(width, height int) string {
 				itemName := jumpItemName(item)
 				// Overlay hint on the first line, preserve rest exactly
 				if idx := strings.Index(raw, "\n"); idx >= 0 {
-					b.WriteString(h.overlayJumpHint(raw[:idx], hint, h.jumpBuffer, itemName))
+					b.WriteString(fitCellWidthErase(h.overlayJumpHint(raw[:idx], hint, h.jumpBuffer, itemName), width))
 					b.WriteString(raw[idx:]) // includes \n and any subsequent lines
 				} else {
-					b.WriteString(h.overlayJumpHint(raw, hint, h.jumpBuffer, itemName))
+					writeListLine(&b, h.overlayJumpHint(raw, hint, h.jumpBuffer, itemName), width)
 				}
 			} else {
 				// Non-matching: render normally (no dimming to preserve layout)
-				b.WriteString(raw)
+				if idx := strings.Index(raw, "\n"); idx >= 0 {
+					b.WriteString(fitCellWidthErase(raw[:idx], width))
+					b.WriteString(raw[idx:])
+				} else {
+					writeListLine(&b, strings.TrimSuffix(raw, "\n"), width)
+				}
 			}
 		} else {
-			h.renderItem(&b, item, i == h.cursor, i, groupStats, snapshot)
+			h.renderItem(&b, item, i == h.cursor, i, groupStats, snapshot, width)
 		}
 		visibleCount++
 	}
@@ -11872,11 +11876,11 @@ func (h *Home) renderSessionList(width, height int) string {
 	// Show "more below" indicator if there are more items
 	remaining := len(h.flatItems) - (h.viewOffset + visibleCount)
 	if remaining > 0 {
-		b.WriteString(DimStyle.Render(fmt.Sprintf("  ⋮ +%d below", remaining)))
+		writeListLine(&b, DimStyle.Render(fmt.Sprintf("  ⋮ +%d below", remaining)), width)
 	}
 
 	// Height padding is handled by ensureExactHeight() in View() for consistency
-	return fitLinesToWidth(b.String(), width)
+	return b.String()
 }
 
 type groupRenderStats struct {
@@ -11934,6 +11938,15 @@ func (h *Home) buildGroupRenderStats(snapshot map[string]sessionRenderState) map
 	return stats
 }
 
+// writeListLine writes one session-list row padded to width cells plus EL (#607).
+func writeListLine(b *strings.Builder, line string, width int) {
+	if width > 0 {
+		line = fitCellWidthErase(line, width)
+	}
+	b.WriteString(line)
+	b.WriteString("\n")
+}
+
 // renderItem renders a single item (group or session) for the left panel
 func (h *Home) renderItem(
 	b *strings.Builder,
@@ -11942,22 +11955,23 @@ func (h *Home) renderItem(
 	itemIndex int,
 	groupStats map[string]groupRenderStats,
 	snapshot map[string]sessionRenderState,
+	listWidth int,
 ) {
 	switch item.Type {
 	case session.ItemTypeGroup:
-		h.renderGroupItem(b, item, selected, itemIndex, groupStats)
+		h.renderGroupItem(b, item, selected, itemIndex, groupStats, listWidth)
 	case session.ItemTypeSession:
 		if item.CreatingID != "" {
-			h.renderCreatingSessionItem(b, item, selected)
+			h.renderCreatingSessionItem(b, item, selected, listWidth)
 		} else {
-			h.renderSessionItem(b, item, selected, snapshot)
+			h.renderSessionItem(b, item, selected, snapshot, listWidth)
 		}
 	case session.ItemTypeWindow:
-		h.renderWindowItem(b, item, selected)
+		h.renderWindowItem(b, item, selected, listWidth)
 	case session.ItemTypeRemoteGroup:
-		h.renderRemoteGroupItem(b, item, selected)
+		h.renderRemoteGroupItem(b, item, selected, listWidth)
 	case session.ItemTypeRemoteSession:
-		h.renderRemoteSessionItem(b, item, selected)
+		h.renderRemoteSessionItem(b, item, selected, listWidth)
 	}
 }
 
@@ -11969,6 +11983,7 @@ func (h *Home) renderGroupItem(
 	selected bool,
 	itemIndex int,
 	groupStats map[string]groupRenderStats,
+	listWidth int,
 ) {
 	group := item.Group
 
@@ -12031,8 +12046,7 @@ func (h *Home) renderGroupItem(
 		countStr,
 		statusStr,
 	)
-	b.WriteString(row)
-	b.WriteString("\n")
+	writeListLine(b, row, listWidth)
 }
 
 // Tree drawing characters for visual hierarchy
@@ -12099,33 +12113,26 @@ func (h *Home) renderCreatingSessionItem(
 	b *strings.Builder,
 	item session.Item,
 	selected bool,
+	listWidth int,
 ) {
 	spinnerFrames := []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 	spinner := spinnerFrames[h.animationFrame]
 
-	// Selection styling
+	selPrefix := "  "
 	if selected {
-		b.WriteString(lipgloss.NewStyle().
-			Foreground(ColorAccent).
-			Bold(true).
-			Render("▸ "))
-	} else {
-		b.WriteString("  ")
+		selPrefix = lipgloss.NewStyle().Foreground(ColorAccent).Bold(true).Render("▸ ")
 	}
-
-	// Tree connector
+	treePrefix := ""
 	if item.Level > 0 {
-		b.WriteString(TreeConnectorStyle.Render("├── "))
+		treePrefix = TreeConnectorStyle.Render("├── ")
 	}
-
-	// Spinner + title
 	spinnerStyle := lipgloss.NewStyle().Foreground(ColorPurple)
 	titleStyle := lipgloss.NewStyle().Foreground(ColorText).Italic(true)
-	b.WriteString(spinnerStyle.Render(spinner))
-	b.WriteString(" ")
-	b.WriteString(titleStyle.Render(item.CreatingTitle))
-	b.WriteString(lipgloss.NewStyle().Foreground(ColorTextDim).Italic(true).Render(" (creating worktree...)"))
-	b.WriteString("\n")
+	row := selPrefix + treePrefix +
+		spinnerStyle.Render(spinner) + " " +
+		titleStyle.Render(item.CreatingTitle) +
+		lipgloss.NewStyle().Foreground(ColorTextDim).Italic(true).Render(" (creating worktree...)")
+	writeListLine(b, row, listWidth)
 }
 
 func (h *Home) renderSessionItem(
@@ -12133,6 +12140,7 @@ func (h *Home) renderSessionItem(
 	item session.Item,
 	selected bool,
 	snapshot map[string]sessionRenderState,
+	listWidth int,
 ) {
 	inst := item.Session
 
@@ -12365,7 +12373,7 @@ func (h *Home) renderSessionItem(
 	// the panel and shove subsequent rows down by one cell. See
 	// internal/ui/cellwidth.go for the upstream disagreement.
 	if selected && instState.paneTitle != "" {
-		remaining := h.width - cellWidth(row) - 2 // -2 for trailing margin
+		remaining := listWidth - cellWidth(row) - 2 // -2 for trailing margin
 		if remaining > 10 {
 			pt := instState.paneTitle
 			if cellWidth(pt) > remaining {
@@ -12375,12 +12383,11 @@ func (h *Home) renderSessionItem(
 		}
 	}
 
-	b.WriteString(row)
-	b.WriteString("\n")
+	writeListLine(b, row, listWidth)
 }
 
 // renderWindowItem renders a single window item (child of a session) for the left panel
-func (h *Home) renderWindowItem(b *strings.Builder, item session.Item, selected bool) {
+func (h *Home) renderWindowItem(b *strings.Builder, item session.Item, selected bool, listWidth int) {
 	treeStyle := TreeConnectorStyle
 
 	// Base indent — windows are children of sessions.
@@ -12441,8 +12448,7 @@ func (h *Home) renderWindowItem(b *strings.Builder, item session.Item, selected 
 		winName,
 		toolBadge,
 	)
-	b.WriteString(row)
-	b.WriteString("\n")
+	writeListLine(b, row, listWidth)
 }
 
 // renderLaunchingState renders the animated launching/resuming indicator for sessions
@@ -12540,7 +12546,7 @@ func (h *Home) renderRemotePreview(item session.Item, width, height int) string 
 }
 
 // renderRemoteGroupItem renders a remote group header (e.g., "remotes/dev")
-func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, selected bool) {
+func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, selected bool, listWidth int) {
 	// Count sessions for this remote
 	h.remoteSessionsMu.RLock()
 	count := 0
@@ -12559,13 +12565,14 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 		selPrefix = "▶ "
 	}
 
-	b.WriteString(fmt.Sprintf("%s%s %s%s%s\n",
+	row := fmt.Sprintf("%s%s %s%s%s",
 		selPrefix,
 		expandIcon,
 		nameStyle.Render("remotes/"+item.RemoteName),
 		countStyle.Render(fmt.Sprintf(" (%d)", count)),
 		h.renderRemoteLatencyMarker(item.RemoteName, selected),
-	))
+	)
+	writeListLine(b, row, listWidth)
 }
 
 // renderRemoteLatencyMarker returns the colored ` — Xms` (or ` — offline`)
@@ -12611,7 +12618,7 @@ func (h *Home) renderRemoteLatencyMarker(remoteName string, selected bool) strin
 }
 
 // renderRemoteSessionItem renders a single remote session row
-func (h *Home) renderRemoteSessionItem(b *strings.Builder, item session.Item, selected bool) {
+func (h *Home) renderRemoteSessionItem(b *strings.Builder, item session.Item, selected bool, listWidth int) {
 	rs := item.RemoteSession
 	if rs == nil {
 		return
@@ -12668,13 +12675,14 @@ func (h *Home) renderRemoteSessionItem(b *strings.Builder, item session.Item, se
 		selPrefix = "▶ "
 	}
 
-	b.WriteString(fmt.Sprintf("%s  %s %s %s%s\n",
+	row := fmt.Sprintf("%s  %s %s %s%s",
 		selPrefix,
 		DimStyle.Render(treeConnector),
 		sStyle.Render(statusIcon),
 		titleStyle.Render(titleStr),
 		toolStr,
-	))
+	)
+	writeListLine(b, row, listWidth)
 }
 
 func (h *Home) renderLaunchingState(inst *session.Instance, width int, startTime time.Time) string {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10842,65 +10842,19 @@ func clampViewToViewport(content string, width, height int) string {
 	}
 
 	for i, line := range lines {
-		// #937 v2: cellWidth/cellTruncate (not ansi.*) so this final
-		// viewport-clamp safety net sees keycap clusters at their true
-		// terminal cell count. Any line that slips past upstream gates
-		// with a #️⃣ 0️⃣–9️⃣ *️⃣ glyph would otherwise overflow into the
-		// next row here — exactly @jennings's pane-content drift report.
-		if cellWidth(line) > width {
-			lines[i] = cellTruncate(line, width, "")
-		}
+		// Pad/truncate to exactly width cells so incremental redraw does not
+		// leave stale glyphs when a shorter line replaces a longer one (#607).
+		lines[i] = fitCellWidth(line, width)
 	}
 
 	return strings.Join(lines, "\n")
 }
 
-// ensureExactWidth ensures each line in content has exactly the specified visual width.
-// This is essential for proper horizontal panel alignment in lipgloss.JoinHorizontal.
-//
-// CRITICAL: Uses lipgloss.Width() for measurement to stay consistent with
-// lipgloss.JoinHorizontal's internal width calculation. Using a different
-// measurement (e.g. runewidth.StringWidth after custom ANSI stripping) can
-// disagree by even 1 character, causing JoinHorizontal to pad all lines to
-// the wider measurement. This makes the joined output exceed terminal width,
-// lines wrap, and Bubble Tea's renderer loses cursor tracking — producing
-// duplicated/stacked content (the "scrolling artifact" bug).
-//
-// Behavior:
-//   - Measures width using lipgloss.Width (same as JoinHorizontal)
-//   - Pads short lines with spaces to reach target width
-//   - Truncates long lines using lipgloss.MaxWidth (preserves ANSI where possible)
-//   - Guarantees every line is exactly `width` visual characters
+// ensureExactWidth ensures each line occupies exactly width terminal cells.
+// Uses cellWidth/fitCellWidth (#937) so panel rows overwrite the full line on
+// incremental redraw (#607); lipgloss.Width can under-count emoji/keycaps.
 func ensureExactWidth(content string, width int) string {
-	if width <= 0 {
-		return content
-	}
-
-	lines := strings.Split(content, "\n")
-	result := make([]string, len(lines))
-
-	for i, line := range lines {
-		// Measure visual width using lipgloss (same measurement as JoinHorizontal)
-		displayWidth := lipgloss.Width(line)
-
-		if displayWidth == width {
-			result[i] = line
-		} else if displayWidth < width {
-			// Pad with spaces to reach target width
-			result[i] = line + strings.Repeat(" ", width-displayWidth)
-		} else {
-			// Line too wide — truncate using lipgloss for consistent ANSI handling
-			truncated := lipgloss.NewStyle().MaxWidth(width).Render(line)
-			// Verify and pad if truncation left it short
-			truncWidth := lipgloss.Width(truncated)
-			if truncWidth < width {
-				truncated += strings.Repeat(" ", width-truncWidth)
-			}
-			result[i] = truncated
-		}
-	}
-
-	return strings.Join(result, "\n")
+	return fitLinesToWidth(content, width)
 }
 
 // renderDualColumnLayout renders side-by-side panels for wide terminals (80+ cols)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10914,12 +10914,9 @@ func (h *Home) renderDualColumnLayout(contentHeight int) string {
 	// Join panels horizontally - all components have exact heights AND widths now
 	mainContent := lipgloss.JoinHorizontal(lipgloss.Top, leftPanel, separator, rightPanel)
 
-	// Safety net: enforce per-line MaxWidth on the joined output.
-	// Even with ensureExactWidth, JoinHorizontal can produce lines wider than
-	// h.width due to separator ANSI codes or rounding. Any line that wraps in the
-	// terminal adds a visual line, which shifts Bubble Tea's cursor tracking and
-	// causes duplicated/stacked content on scroll.
-	mainContent = lipgloss.NewStyle().MaxWidth(h.width).Render(mainContent)
+	// Pad joined lines to h.width (not lipgloss.MaxWidth, which wraps and leaves
+	// ghost cells on incremental redraw — issue #607).
+	mainContent = fitLinesToWidth(mainContent, h.width)
 
 	b.WriteString(mainContent)
 
@@ -11879,7 +11876,7 @@ func (h *Home) renderSessionList(width, height int) string {
 	}
 
 	// Height padding is handled by ensureExactHeight() in View() for consistency
-	return b.String()
+	return fitLinesToWidth(b.String(), width)
 }
 
 type groupRenderStats struct {

--- a/internal/ui/issue1091_remote_render_test.go
+++ b/internal/ui/issue1091_remote_render_test.go
@@ -46,7 +46,7 @@ func TestIssue1091_RemoteSession_ToolColorMatchesLocal(t *testing.T) {
 	}
 
 	var b strings.Builder
-	home.renderRemoteSessionItem(&b, item, false)
+	home.renderRemoteSessionItem(&b, item, false, 80)
 	rendered := b.String()
 
 	// What a local claude session would render for the " claude" tool label.
@@ -101,7 +101,7 @@ func TestIssue1091_RemoteSession_ToolColorAllTools(t *testing.T) {
 			}
 
 			var b strings.Builder
-			home.renderRemoteSessionItem(&b, item, false)
+			home.renderRemoteSessionItem(&b, item, false, 80)
 			rendered := b.String()
 
 			expectedToolLabel := GetToolStyle(tool).Render(" " + tool)
@@ -140,7 +140,7 @@ func TestIssue1091_RemoteSession_SelectedStateUnchanged(t *testing.T) {
 	}
 
 	var b strings.Builder
-	home.renderRemoteSessionItem(&b, item, true) // selected=true
+	home.renderRemoteSessionItem(&b, item, true, 80) // selected=true
 	rendered := b.String()
 
 	expectedToolLabel := SessionStatusSelStyle.Render(" claude")

--- a/internal/ui/issue1103_header_latency_render_test.go
+++ b/internal/ui/issue1103_header_latency_render_test.go
@@ -38,7 +38,7 @@ func TestIssue1103_Header_ShowsLatencyMs_ForConnectedRemote(t *testing.T) {
 		RemoteName: "dev",
 	}
 	var b strings.Builder
-	home.renderRemoteGroupItem(&b, item, false)
+	home.renderRemoteGroupItem(&b, item, false, 80)
 	rendered := b.String()
 
 	if !strings.Contains(stripANSILatency(rendered), "remotes/dev") {
@@ -79,7 +79,7 @@ func TestIssue1103_Header_ColorByThreshold(t *testing.T) {
 				RemoteName: "dev",
 			}
 			var b strings.Builder
-			home.renderRemoteGroupItem(&b, item, false)
+			home.renderRemoteGroupItem(&b, item, false, 80)
 			got := b.String()
 
 			// Build the expected styled fragment with the same lipgloss style
@@ -111,7 +111,7 @@ func TestIssue1103_Header_OfflineRendersOfflineMarker(t *testing.T) {
 		RemoteName: "dev",
 	}
 	var b strings.Builder
-	home.renderRemoteGroupItem(&b, item, false)
+	home.renderRemoteGroupItem(&b, item, false, 80)
 	rendered := stripANSILatency(b.String())
 
 	if !strings.Contains(rendered, "— offline") {
@@ -138,7 +138,7 @@ func TestIssue1103_Header_NeverMeasured_SuppressesMarker(t *testing.T) {
 		RemoteName: "dev",
 	}
 	var b strings.Builder
-	home.renderRemoteGroupItem(&b, item, false)
+	home.renderRemoteGroupItem(&b, item, false, 80)
 	rendered := stripANSILatency(b.String())
 
 	if strings.Contains(rendered, " — ") {

--- a/internal/ui/issue391_tui_test.go
+++ b/internal/ui/issue391_tui_test.go
@@ -67,7 +67,7 @@ func renderSingleSessionRow(t *testing.T, inst *session.Instance) string {
 	}
 
 	var b strings.Builder
-	h.renderSessionItem(&b, item, false, snapshot)
+	h.renderSessionItem(&b, item, false, snapshot, h.width)
 	return b.String()
 }
 

--- a/internal/ui/issue937_keycap_test.go
+++ b/internal/ui/issue937_keycap_test.go
@@ -276,3 +276,21 @@ func Test_Issue937v2_CellTruncate_PreservesAnsiBoundariesAndKeycap(t *testing.T)
 		})
 	}
 }
+
+// Test_clampViewToViewport_PadsEveryRow ensures the final frame pads narrow lines.
+func Test_clampViewToViewport_PadsEveryRow(t *testing.T) {
+	const width, height = 30, 3
+	in := strings.Join([]string{
+		strings.Repeat("X", width),
+		"short",
+		"",
+	}, "\n")
+	out := clampViewToViewport(in, width, height)
+	lines := strings.Split(out, "\n")
+	if len(lines) != height {
+		t.Fatalf("want %d lines, got %d", height, len(lines))
+	}
+	if got := cellWidth(lines[1]); got != width {
+		t.Fatalf("line 1 cellWidth = %d; want %d (must pad, not only truncate)", got, width)
+	}
+}


### PR DESCRIPTION
Pad each frame line to full terminal cell width so incremental redraw overwrites stale glyphs when scrolling the session list, without using tea.ClearScreen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering artifacts when line lengths change during incremental viewport updates.
  * Ensured every line is padded or truncated to the exact terminal cell width to prevent ghost glyphs and wrapping issues.

* **Tests**
  * Added a regression test to verify viewport rows are padded to the requested width/height.
  * Updated multiple rendering tests and helpers to exercise the width-aware rendering path by passing an explicit width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->