### PR TITLE
feat(models): add Claude Opus 4.8 to MODEL_ID_CATALOG (closes #1241)

### DIFF
--- a/internal/ui/issue1241_opus48_catalog_test.go
+++ b/internal/ui/issue1241_opus48_catalog_test.go
@@ -1,0 +1,26 @@
+package ui
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestKnownModelIDsIncludeOpus48 is the regression gate for issue #1241:
+// the latest Claude Opus 4.8 must be selectable in the TUI new-session model
+// picker, mirroring the web MODEL_ID_CATALOG. knownModelIDsForTool feeds the
+// dropdown rows, so the new ID has to appear alongside the existing 4.7 entry.
+func TestKnownModelIDsIncludeOpus48(t *testing.T) {
+	cases := []struct {
+		tool string
+		want string
+	}{
+		{"claude", "claude-opus-4-8"},
+		{"opencode", "anthropic/claude-opus-4-8"},
+	}
+	for _, tc := range cases {
+		ids := knownModelIDsForTool(tc.tool)
+		if !slices.Contains(ids, tc.want) {
+			t.Errorf("knownModelIDsForTool(%q) missing %q; got %v", tc.tool, tc.want, ids)
+		}
+	}
+}

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -784,6 +784,7 @@ func knownModelIDsForTool(tool string) []string {
 	case session.IsClaudeCompatible(tool):
 		return []string{
 			"claude-sonnet-4-6",
+			"claude-opus-4-8",
 			"claude-opus-4-7",
 			"claude-haiku-4-5",
 			"claude-haiku-4-5-20251001",
@@ -810,6 +811,7 @@ func knownModelIDsForTool(tool string) []string {
 			"openai/gpt-5",
 			"openai/o3",
 			"anthropic/claude-sonnet-4-6",
+			"anthropic/claude-opus-4-8",
 			"anthropic/claude-opus-4-7",
 			"anthropic/claude-haiku-4-5",
 		}

--- a/internal/web/static/app/CreateSessionDialog.js
+++ b/internal/web/static/app/CreateSessionDialog.js
@@ -16,6 +16,7 @@ const TOOL_LABELS = {
 const MODEL_ID_CATALOG = {
   claude: [
     { value: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+    { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
     { value: 'claude-opus-4-7', label: 'Claude Opus 4.7' },
     { value: 'claude-haiku-4-5', label: 'Claude Haiku 4.5 alias' },
     { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5 pinned' },
@@ -62,6 +63,7 @@ const MODEL_ID_CATALOG = {
     { value: 'openai/gpt-5', label: 'OpenAI GPT-5' },
     { value: 'openai/o3', label: 'OpenAI o3' },
     { value: 'anthropic/claude-sonnet-4-6', label: 'Anthropic Claude Sonnet 4.6' },
+    { value: 'anthropic/claude-opus-4-8', label: 'Anthropic Claude Opus 4.8' },
     { value: 'anthropic/claude-opus-4-7', label: 'Anthropic Claude Opus 4.7' },
     { value: 'anthropic/claude-haiku-4-5', label: 'Anthropic Claude Haiku 4.5' },
   ],

--- a/internal/web/static_files_test.go
+++ b/internal/web/static_files_test.go
@@ -170,6 +170,7 @@ func TestCreateSessionDialogUsesModelIDCatalog(t *testing.T) {
 		"gpt-5.3-codex",
 		"o3-pro",
 		"claude-sonnet-4-6",
+		"claude-opus-4-8",
 		"claude-opus-4-7",
 		"claude-haiku-4-5-20251001",
 		"gemini-3.1-pro-preview",
@@ -177,6 +178,7 @@ func TestCreateSessionDialogUsesModelIDCatalog(t *testing.T) {
 		"gemini-2.5-flash-lite",
 		"openai/gpt-5.5",
 		"anthropic/claude-sonnet-4-6",
+		"anthropic/claude-opus-4-8",
 		"Custom model ID",
 	} {
 		if !strings.Contains(body, want) {


### PR DESCRIPTION
## Problem

Closes #1241. The new-session model picker's catalog topped out at `claude-opus-4-7`, so the latest **Claude Opus 4.8** (`claude-opus-4-8`) was not offered as a selectable row in either the web or TUI dropdown — even though `[claude] default_model = "claude-opus-4-8"` works at launch, it could not be picked interactively per-session, and the "Custom model ID" input is broken (#1190).

## Fix

The picker is fed by two parallel hardcoded catalogs; both are updated, matching the existing `4-7` pattern:

- **Web** — `MODEL_ID_CATALOG` in `internal/web/static/app/CreateSessionDialog.js`
  - `{ value: 'claude-opus-4-8', label: 'Claude Opus 4.8' }`
  - `{ value: 'anthropic/claude-opus-4-8', label: 'Anthropic Claude Opus 4.8' }`
- **TUI** — `knownModelIDsForTool` in `internal/ui/newdialog.go`
  - `claude-opus-4-8` (claude) and `anthropic/claude-opus-4-8` (opencode)

The issue references the "TUI/web new-session model picker", so both pickers are updated to genuinely close it.

## Tests (failing-first / TDD)

- Extended `TestCreateSessionDialogUsesModelIDCatalog` (`internal/web`) to assert the embedded JS contains `claude-opus-4-8` and `anthropic/claude-opus-4-8`.
- Added `TestKnownModelIDsIncludeOpus48` (`internal/ui`) asserting the TUI catalog includes the new IDs for `claude` and `opencode`.
- Both tests were confirmed RED before the catalog edits, then GREEN after.

## Verification

- `go test -race ./internal/web/ ./internal/ui/` — pass
- `golangci-lint run ./internal/ui/... ./internal/web/...` — 0 issues

## Out of scope

Pricing (`internal/costs`) and context-window (`internal/session/analytics.go`) tables are intentionally untouched — they are separate from the picker catalog and have fallbacks. No version bump (a bundled release is planned separately).

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Claude Opus 4.8 model is now available for selection in the model ID dropdown when using compatible tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->