### PR TITLE
fix(hook-handler): graceful degrade on missing PROJECT_DIR instead of FATAL-per-call (closes #1233)

### DIFF
--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -31,6 +32,13 @@ type hookPayload struct {
 	SessionID     string          `json:"session_id"`
 	Source        string          `json:"source"`
 	Matcher       json.RawMessage `json:"matcher,omitempty"`
+	// Cwd is the session's working directory (PROJECT_DIR) as reported by
+	// Claude Code on each hook event. Issue #1233: when a running session's
+	// registered worktree is renamed/removed, this points at a path that no
+	// longer exists; we use it to degrade gracefully rather than erroring on
+	// every tool call. Empty when the agent doesn't send a cwd (older Claude
+	// Code) — treated as "present" so behavior is unchanged.
+	Cwd string `json:"cwd"`
 	// StopHookActive is Claude Code's flag: true when this Stop is a
 	// continuation induced by a previous Stop-hook block. Issue #1225 uses it
 	// to bound consecutive inbox-drain blocks so the conductor cannot loop
@@ -126,6 +134,17 @@ func handleHookHandler() {
 
 	var payload hookPayload
 	if err := json.Unmarshal(data, &payload); err != nil {
+		return
+	}
+
+	// Issue #1233: gracefully degrade when the session's working directory
+	// (PROJECT_DIR / cwd) has been renamed or removed out from under a running
+	// session — e.g. a git worktree renamed while the session is live. Rather
+	// than emitting a FATAL-class error on every single tool call, log a single
+	// WARN (deduped per instance+path) that points at the moved path and
+	// suggests `agent-deck session move`, then soft-skip this invocation.
+	if projectDirMissing(payload.Cwd) {
+		warnProjectDirMissingOnce(instanceID, payload.Cwd)
 		return
 	}
 
@@ -312,6 +331,45 @@ func isTerminalHookEvent(event string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// projectDirMissing reports whether cwd is a non-empty path that no longer
+// exists on disk. An empty cwd (older Claude Code, or hook events that omit
+// one) returns false — we can't tell, so behavior stays unchanged. Stat errors
+// other than "not exist" (e.g. permission) also return false: only a confirmed
+// missing directory triggers the degrade path.
+func projectDirMissing(cwd string) bool {
+	if cwd == "" {
+		return false
+	}
+	_, err := os.Stat(cwd)
+	return errors.Is(err, os.ErrNotExist)
+}
+
+// warnProjectDirMissingOnce logs a single WARN for a missing project dir and
+// records a marker so subsequent hook invocations for the same instance+path
+// stay silent. Because each hook runs as a fresh process, the "once" guard is
+// an on-disk marker (next to the hook status files) whose contents are the
+// missing path: if the session is later repointed to a different (also-missing)
+// path, the mismatch lets it warn again instead of being silenced by a stale
+// marker.
+func warnProjectDirMissingOnce(instanceID, cwd string) {
+	hooksDir := getHooksDir()
+	markerPath := filepath.Join(hooksDir, filepath.Base(instanceID)+".projectdir-missing")
+
+	if existing, err := os.ReadFile(markerPath); err == nil && strings.TrimSpace(string(existing)) == cwd {
+		return // already warned for this exact missing path
+	}
+
+	hookHandlerLog.Warn("hook_projectdir_missing",
+		slog.String("instance", instanceID),
+		slog.String("project_dir", cwd),
+		slog.String("suggestion", "run `agent-deck session move <id|title> <new-path>` to repoint the session at its moved worktree"),
+	)
+
+	if err := os.MkdirAll(hooksDir, 0o700); err == nil {
+		_ = os.WriteFile(markerPath, []byte(cwd), 0o600)
 	}
 }
 

--- a/cmd/agent-deck/issue1233_projectdir_degrade_test.go
+++ b/cmd/agent-deck/issue1233_projectdir_degrade_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runHookHandlerWithStdin feeds payload to handleHookHandler via os.Stdin,
+// mirroring how Claude Code invokes `agent-deck hook-handler` as a fresh
+// process per hook event. os.Stdin is restored on return.
+func runHookHandlerWithStdin(t *testing.T, payload string) {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "hook-stdin-*.json")
+	if err != nil {
+		t.Fatalf("create stdin temp: %v", err)
+	}
+	if _, err := f.WriteString(payload); err != nil {
+		t.Fatalf("write stdin temp: %v", err)
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatalf("seek stdin temp: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = f
+	defer func() {
+		os.Stdin = orig
+		_ = f.Close()
+	}()
+	handleHookHandler()
+}
+
+// readLogTolerant returns the debug.log body, or "" if it was never created
+// (no log lines emitted). Unlike readLog it does not fail the test on a
+// missing file, so assertions about the ABSENCE of a log line stay meaningful.
+func readLogTolerant(t *testing.T, dir string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "debug.log"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read debug.log: %v", err)
+	}
+	return string(data)
+}
+
+// TestHookHandler_MissingProjectDir_DegradesNotFatal reproduces issue #1233:
+// when a running session's registered worktree (the hook payload's cwd /
+// PROJECT_DIR) is renamed or removed out from under it, the hook-handler
+// must GRACEFULLY DEGRADE — log a single WARN suggesting `agent-deck session
+// move` and soft-skip the invocation — instead of emitting a FATAL-class
+// error on every tool call.
+func TestHookHandler_MissingProjectDir_DegradesNotFatal(t *testing.T) {
+	logDir := initTestLogging(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTDECK_INSTANCE_ID", "inst-1233")
+
+	// A worktree path that no longer exists (renamed out from under the session).
+	missingDir := filepath.Join(home, "worktrees", "renamed-away")
+
+	// UserPromptSubmit maps to "running"; absent the degrade guard it would
+	// write a status file. We assert it is soft-skipped instead.
+	payload := `{"hook_event_name":"UserPromptSubmit","session_id":"s1","cwd":"` + missingDir + `"}`
+
+	// Two invocations simulate two tool calls in a row (two processes).
+	runHookHandlerWithStdin(t, payload)
+	runHookHandlerWithStdin(t, payload)
+
+	body := readLogTolerant(t, logDir)
+
+	// (1) The degrade marker is emitted at WARN, not as a FATAL/ERROR.
+	if got := strings.Count(body, `"hook_projectdir_missing"`); got != 1 {
+		t.Errorf("expected exactly one hook_projectdir_missing WARN (logged once), got %d; log:\n%s", got, body)
+	}
+	if !strings.Contains(body, `"level":"WARN"`) {
+		t.Errorf("expected WARN level for missing project dir; log:\n%s", body)
+	}
+	if strings.Contains(body, `"level":"ERROR"`) || strings.Contains(body, `"level":"FATAL"`) {
+		t.Errorf("missing project dir must not produce a FATAL/ERROR log line; log:\n%s", body)
+	}
+
+	// (2) The WARN carries the offending path and the session-move remedy.
+	if !strings.Contains(body, missingDir) {
+		t.Errorf("expected the missing path %q in the WARN; log:\n%s", missingDir, body)
+	}
+	if !strings.Contains(body, "session move") {
+		t.Errorf("expected an `agent-deck session move` suggestion in the WARN; log:\n%s", body)
+	}
+
+	// (3) Soft-skip: no status file is written for the broken session.
+	statusFile := filepath.Join(home, ".agent-deck", "hooks", "inst-1233.json")
+	if _, err := os.Stat(statusFile); err == nil {
+		t.Errorf("expected soft-skip (no status file) when project dir is missing, but %s exists", statusFile)
+	}
+}
+
+// TestHookHandler_PresentProjectDir_NotDegraded guards against over-eager
+// skipping: when cwd exists (the normal case) the handler proceeds and writes
+// the status file, and no missing-project-dir WARN is emitted. An empty cwd
+// (older Claude Code that doesn't send one) is treated as present.
+func TestHookHandler_PresentProjectDir_NotDegraded(t *testing.T) {
+	logDir := initTestLogging(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTDECK_INSTANCE_ID", "inst-ok")
+
+	cwd := filepath.Join(home, "live-worktree")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir cwd: %v", err)
+	}
+
+	payload := `{"hook_event_name":"UserPromptSubmit","session_id":"s2","cwd":"` + cwd + `"}`
+	runHookHandlerWithStdin(t, payload)
+
+	body := readLogTolerant(t, logDir)
+	if strings.Contains(body, `"hook_projectdir_missing"`) {
+		t.Errorf("did not expect a missing-project-dir WARN when cwd exists; log:\n%s", body)
+	}
+
+	statusFile := filepath.Join(home, ".agent-deck", "hooks", "inst-ok.json")
+	if _, err := os.Stat(statusFile); err != nil {
+		t.Errorf("expected status file to be written when project dir exists: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

Issue #1233: on agent-deck v1.9.44, `agent-deck hook-handler` emitted a `FATAL: PROJECT_DIR does not exist: <path>` on **every** `PostToolUse` (every tool call) when a running session's registered worktree was renamed/removed out from under it — e.g. a git worktree renamed while the session is live. One FATAL-class line per tool call floods the log; the only workaround was symlinking old→new.

## Fix

The hook handler now decodes the payload's `cwd` (the session's `PROJECT_DIR`, which Claude Code sends on every hook event) and **gracefully degrades** when it points at a path that no longer exists:

- Logs a **single `WARN`** (not FATAL/ERROR), naming the moved path and suggesting `agent-deck session move <id|title> <new-path>` to repoint the session.
- **Deduped per instance+path** via a small on-disk marker beside the hook status files — because each hook runs as a fresh process, "log once" has to be persisted. If the session is later repointed to a different (also-missing) path, the marker mismatch lets it warn again rather than being silenced by a stale marker.
- **Soft-skips** the invocation (still exits 0), so a moved worktree never errors per-call.

Behavior is **unchanged** when `cwd` exists (normal case) or is absent (older Claude Code that doesn't send one — treated as "present").

This addresses both asks in the issue: (a) soft-skip/degrade instead of FATAL-per-call, and (b) detect the moved worktree and suggest `agent-deck session move`.

## Tests (TDD)

`cmd/agent-deck/issue1233_projectdir_degrade_test.go`:

- `TestHookHandler_MissingProjectDir_DegradesNotFatal` — drives `handleHookHandler` twice with a missing-`cwd` payload; asserts exactly **one** `hook_projectdir_missing` WARN (logged once), no FATAL/ERROR level line, the path + `session move` suggestion present, and that the status file is **soft-skipped** (not written).
- `TestHookHandler_PresentProjectDir_NotDegraded` — guard: when `cwd` exists, the handler proceeds normally (status file written, no warning).

Written test-first (red → green).

## Verification

- `go test -race ./cmd/agent-deck/` — full package passes.
- `golangci-lint run ./cmd/agent-deck/` — 0 issues.
- `go build ./...` — clean.

No version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced resilience when a project directory is no longer accessible. The system now continues operating gracefully instead of failing, while logging clear guidance for recovery. This allows interrupted sessions to degrade safely without disrupting your workflow.

* **Tests**
  * Added comprehensive test coverage for project directory availability scenarios and graceful degradation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->