### PR TITLE
fix(ui): Prevent dropdowns from obscuring content in short terminal windows

### DIFF
--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -2079,6 +2079,12 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 	return d, cmd
 }
 
+// Returns the screen row/col where a dialog of the given size, in a terminal
+// of (termWidth x termHeight), begins.
+func dialogOrigin(termWidth, termHeight, dialogWidth, dialogHeight int) (row, col int) {
+	return max(0, (termHeight-dialogHeight)/2), max(0, (termWidth-dialogWidth)/2)
+}
+
 // View renders the dialog.
 func (d *NewDialog) View() string {
 	if !d.visible {
@@ -2558,13 +2564,9 @@ func (d *NewDialog) View() string {
 	// Rendered as a floating bordered menu over the placed dialog so it
 	// doesn't shift the layout when it appears/disappears.
 	if suggestionsOverlay := d.renderSuggestionsDropdown(); suggestionsOverlay != "" {
-		// Find where to place the overlay:
-		// The dialog is centered, so we need the dialog's top-left position
-		// within the placed output, plus the line offset to the path input.
-		dialogHeight := lipgloss.Height(dialog)
-		dialogWidth := lipgloss.Width(dialog)
-		topRow := (d.height - dialogHeight) / 2
-		leftCol := (d.width - dialogWidth) / 2
+		// Anchor the floating menu to the dialog's top-left, then add the line
+		// offset down to the path input.
+		topRow, leftCol := dialogOrigin(d.width, d.height, lipgloss.Width(dialog), lipgloss.Height(dialog))
 
 		// suggestionsLineOffset is the content line where the dropdown should appear.
 		// Add border (1) + top padding (2) to get the actual row within the dialog box.
@@ -2576,10 +2578,7 @@ func (d *NewDialog) View() string {
 	}
 
 	if modelOverlay := d.renderModelSuggestionsDropdown(); modelOverlay != "" {
-		dialogHeight := lipgloss.Height(dialog)
-		dialogWidth := lipgloss.Width(dialog)
-		topRow := (d.height - dialogHeight) / 2
-		leftCol := (d.width - dialogWidth) / 2
+		topRow, leftCol := dialogOrigin(d.width, d.height, lipgloss.Width(dialog), lipgloss.Height(dialog))
 
 		overlayRow := topRow + 1 + 2 + d.modelLineOffset
 		overlayCol := leftCol + 1 + 4

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2126,6 +2126,11 @@ func TestNewDialog_CtrlW_BranchField(t *testing.T) {
 
 // Tests the overlay placement math. Dropdowns are placed relative
 // to the associated dialog's top-left corner.
+//
+// Remote-parity: not applicable. NewDialog is the local new-session dialog
+// only; pressing `n` on a remote group/session routes through
+// createRemoteSession (SSH) and never opens this dialog (#743). This overlay
+// positioning fix therefore has no remote surface.
 func TestDialogOrigin(t *testing.T) {
 	tests := []struct {
 		name                           string

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2123,3 +2123,28 @@ func TestNewDialog_CtrlW_BranchField(t *testing.T) {
 		t.Errorf("branchInput after ctrl+w = %q, want %q", got, want)
 	}
 }
+
+// Tests the overlay placement math. Dropdowns are placed relative
+// to the associated dialog's top-left corner.
+func TestDialogOrigin(t *testing.T) {
+	tests := []struct {
+		name                           string
+		termW, termH, dialogW, dialogH int
+		wantRow, wantCol               int
+	}{
+		{"fits centered", 120, 50, 80, 30, 10, 20},
+		{"taller than terminal clamps row", 120, 25, 80, 30, 0, 20},
+		{"wider than terminal clamps col", 60, 50, 80, 30, 10, 0},
+		{"larger than terminal both clamp", 60, 25, 80, 30, 0, 0},
+		{"exact fit", 80, 30, 80, 30, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			row, col := dialogOrigin(tt.termW, tt.termH, tt.dialogW, tt.dialogH)
+			if row != tt.wantRow || col != tt.wantCol {
+				t.Errorf("dialogOrigin(%d,%d,%d,%d) = (row %d, col %d), want (row %d, col %d)",
+					tt.termW, tt.termH, tt.dialogW, tt.dialogH, row, col, tt.wantRow, tt.wantCol)
+			}
+		})
+	}
+}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2129,8 +2129,11 @@ func TestNewDialog_CtrlW_BranchField(t *testing.T) {
 //
 // Remote-parity: not applicable. NewDialog is the local new-session dialog
 // only; pressing `n` on a remote group/session routes through
-// createRemoteSession (SSH) and never opens this dialog (#743). This overlay
-// positioning fix therefore has no remote surface.
+// createRemoteSession (SSH) and never opens this dialog (#743), so this
+// overlay-positioning fix has no remote surface. That routing — and the fact
+// the dialog never opens on a remote selection — is itself covered by
+// TestRegression743_NOnRemoteSession_QuickCreatesNoDialog and
+// TestRegression743_NOnRemoteGroup_QuickCreatesNoDialog in home_test.go.
 func TestDialogOrigin(t *testing.T) {
 	tests := []struct {
 		name                           string


### PR DESCRIPTION
When opening the new session dialog on a terminal too short to fit the whole thing, the path-suggestions dropdown would obscure content (so you can't see the content being input). The model dropdown had the same issue.

The dialog is centered with `lipgloss.Place`, and the dropdown overlay is positioned relative to the dialog's computed top-left corner:

      topRow := (d.height - dialogHeight) / 2

When the dialog is taller than the terminal, it's rendered at row 0, but `topRow` is then negative, shifting the overlay up (and obscuring the input).

Clamping `topRow` to 0 addresses the issue. Extracted this calculation into a helper for easy unit testing.

## Visual evidence

| Before | After |
|--|--|
|  <img width="400" src="https://github.com/user-attachments/assets/431785df-faa4-440d-a761-050e072ac486" /> | <img width="400" src="https://github.com/user-attachments/assets/e02cb503-4454-4ac5-b461-6e6986cb20fa" />  |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog overlay placement for suggestion dropdowns (path and model): overlays are better centered, respect borders/padding, and clamp correctly on small or exact-fit terminals.

* **Tests**
  * Added unit tests covering dialog overlay positioning: centered placement, width/height clamping, combined oversize scenarios, and exact-fit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->