### PR TITLE
fix(send): tool-aware post-send verify — stop false-negative drops for non-Claude tools (closes #1238, #1205, #876)

### DIFF
--- a/cmd/agent-deck/issue1238_toolaware_send_test.go
+++ b/cmd/agent-deck/issue1238_toolaware_send_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// #1238: the #876 delivery-verify keys off Claude-specific signals (an "active"
+// transition, composer glyph, unsent-paste markers). Non-Claude tools
+// (codewhale, gemini, codex) never surface those, so a *delivered* message gets
+// reported as "dropped silently". The fix routes the post-send verify through
+// session.UsesClaudeDeliveryVerify(tool): Claude tools keep the verify, all
+// non-Claude tools skip it — the general superset of #1228's codex-only skip.
+
+// nonClaudeShapedTarget returns a mock in the shape that breaks the verifier:
+// status stays "waiting" and the pane never renders a Claude composer/paste
+// marker, even though (in the real world) the inner agent is processing.
+func nonClaudeShapedTarget() *mockSendRetryTarget {
+	return &mockSendRetryTarget{statuses: []string{"waiting"}, panes: []string{""}}
+}
+
+// TestSend_NonClaudeTool_NotReportedDropped is the issue #1238 regression: a
+// successful send to a non-Claude tool must NOT return the "dropped silently"
+// error, for every non-Claude tool — not just codex (#1205).
+func TestSend_NonClaudeTool_NotReportedDropped(t *testing.T) {
+	for _, tool := range []string{"codex", "codewhale", "gemini", "opencode"} {
+		t.Run(tool, func(t *testing.T) {
+			mock := nonClaudeShapedTarget()
+			err := sendWithRetryTarget(mock, "do the multi-line task please", skipClaudeDeliveryVerify(tool), sendRetryOptions{
+				maxRetries: 50, checkDelay: 0, verifyDelivery: true,
+			})
+			if err != nil {
+				t.Fatalf("%s: delivered send must not be reported dropped, got: %v", tool, err)
+			}
+			if got := atomic.LoadInt32(&mock.sendKeysCalls); got != 1 {
+				t.Fatalf("%s: expected exactly 1 atomic send, got %d", tool, got)
+			}
+			if got := atomic.LoadInt32(&mock.sendCtrlCCalls); got != 0 {
+				t.Fatalf("%s: must never receive destructive Ctrl+C recovery, got %d", tool, got)
+			}
+			if got := atomic.LoadInt32(&mock.sendEnterCalls); got != 0 {
+				t.Fatalf("%s: must not Enter-spam a non-Claude composer, got %d", tool, got)
+			}
+		})
+	}
+}
+
+// TestSend_ClaudeTool_VerifyPreserved guards against over-skipping: Claude tools
+// must still run the #876 verify, so a genuinely silent drop (no markers, never
+// active) is still surfaced as an error.
+func TestSend_ClaudeTool_VerifyPreserved(t *testing.T) {
+	mock := nonClaudeShapedTarget()
+	err := sendWithRetryTarget(mock, "do the multi-line task please", skipClaudeDeliveryVerify("claude"), sendRetryOptions{
+		maxRetries: 12, checkDelay: 0, verifyDelivery: true,
+	})
+	if err == nil {
+		t.Fatal("claude must keep the #876 verify: a silent drop should still error")
+	}
+	if !strings.Contains(err.Error(), "dropped silently") {
+		t.Fatalf("expected #876 silent-drop error, got: %v", err)
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -559,7 +559,7 @@ func handleLaunch(profile string, args []string) {
 	if initialMessage != "" && *noWait {
 		tmuxSess := newInstance.GetTmuxSession()
 		if tmuxSess != nil {
-			if err := sendWithRetryTarget(tmuxSess, initialMessage, false, sendRetryOptions{
+			if err := sendWithRetryTarget(tmuxSess, initialMessage, skipClaudeDeliveryVerify(newInstance.Tool), sendRetryOptions{
 				maxRetries: 8,
 				checkDelay: 150 * time.Millisecond,
 			}); err != nil {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2016,7 +2016,7 @@ func handleSessionSend(profile string, args []string) {
 			os.Exit(1)
 		}
 	} else {
-		if err := sendWithRetry(tmuxSess, message, false); err != nil {
+		if err := sendWithRetry(tmuxSess, message, skipClaudeDeliveryVerify(inst.Tool)); err != nil {
 			out.Error(fmt.Sprintf("failed to send message: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
@@ -2135,6 +2135,17 @@ func sendWithRetry(tmuxSess *tmux.Session, message string, skipVerify bool) erro
 	return sendWithRetryTarget(tmuxSess, message, skipVerify, defaultSendOptions())
 }
 
+// skipClaudeDeliveryVerify reports whether the Claude-tuned post-send delivery
+// verification (issue #876) should be skipped for tool. The verify keys off
+// Claude-specific TUI signals (an "active" transition, the composer glyph,
+// unsent-paste markers); non-Claude tools never surface those, so running it
+// false-negatives a delivered message as "dropped silently" (#1238, #1205,
+// #876). Claude tools keep the verify; every non-Claude tool skips it — the
+// general superset of #1228's codex-only skip.
+func skipClaudeDeliveryVerify(tool string) bool {
+	return !session.UsesClaudeDeliveryVerify(tool)
+}
+
 // draftSender is implemented by *tmux.Session for the --draft path.
 type draftSender interface {
 	SendKeysChunked(string) error
@@ -2232,7 +2243,7 @@ func sendNoWait(target sendRetryTarget, tool, message string) error {
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
-	return sendWithRetryTarget(target, message, false, noWaitSendOptions())
+	return sendWithRetryTarget(target, message, skipClaudeDeliveryVerify(tool), noWaitSendOptions())
 }
 
 type sendRetryTarget interface {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3152,6 +3152,15 @@ func (i *Instance) sendMessageWhenReady(message string) error {
 				return fmt.Errorf("failed to send message: %w", err)
 			}
 
+			// The verify loop below keys off Claude-specific signals (an
+			// "active" transition, composer glyph, unsent-paste markers). Non-
+			// Claude tools never surface those, so the loop false-negatives a
+			// delivered message and Enter-spams the composer; skip it for every
+			// non-Claude tool (#1238 — generalizes #1228's codex-only skip).
+			if !UsesClaudeDeliveryVerify(i.Tool) {
+				return nil
+			}
+
 			// Verify the agent accepted Enter and began processing.
 			// Strategy:
 			// - If unsent prompt is visible, press Enter again immediately.

--- a/internal/session/issue1238_verify_tool_test.go
+++ b/internal/session/issue1238_verify_tool_test.go
@@ -1,0 +1,44 @@
+package session
+
+import "testing"
+
+// #1238: the post-send delivery verification (issue #876) keys off
+// Claude-specific TUI signals — an "active" status transition, the composer
+// glyph, and unsent-paste markers. Non-Claude tools (codex #1205, codewhale,
+// gemini #876) never surface those, so the verify false-negatives and reports a
+// delivered message as "dropped silently". UsesClaudeDeliveryVerify is the
+// single tool-aware predicate that decides whether the Claude-tuned verify
+// applies. It must be true ONLY for Claude-compatible tools — the general
+// superset of #1228's codex-only skip.
+func TestUsesClaudeDeliveryVerify(t *testing.T) {
+	cases := []struct {
+		tool string
+		want bool
+	}{
+		{"claude", true},
+		{"codex", false},     // #1205
+		{"codewhale", false}, // #1238 (the reporter's tool)
+		{"gemini", false},    // #876
+		{"opencode", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := UsesClaudeDeliveryVerify(tc.tool); got != tc.want {
+			t.Errorf("UsesClaudeDeliveryVerify(%q) = %v, want %v", tc.tool, got, tc.want)
+		}
+	}
+}
+
+// TestUsesClaudeDeliveryVerify_SupersetOfCodex pins the relationship to #1228:
+// every tool #1228 skips (codex-compatible) is also skipped here, and the new
+// behavior additionally skips the rest of the non-Claude tools.
+func TestUsesClaudeDeliveryVerify_SupersetOfCodex(t *testing.T) {
+	// codex is a strict subset of the tools that skip the Claude-tuned verify.
+	if IsCodexCompatible("codex") && UsesClaudeDeliveryVerify("codex") {
+		t.Fatal("codex must skip the Claude-tuned verify (subsumes #1228)")
+	}
+	// A non-codex, non-Claude tool must also skip — that is the superset.
+	if UsesClaudeDeliveryVerify("codewhale") {
+		t.Fatal("non-Claude tools beyond codex must also skip the Claude-tuned verify")
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2077,6 +2077,18 @@ func IsClaudeCompatible(toolName string) bool {
 	return false
 }
 
+// UsesClaudeDeliveryVerify reports whether the Claude-tuned post-send delivery
+// verification (issue #876) should be applied for this tool. That verify keys
+// off Claude-specific TUI signals — an "active" status transition, the composer
+// glyph, and unsent-paste markers. Only Claude-compatible tools surface those;
+// every other tool (codex #1205, codewhale/deepseek #1238, gemini #876,
+// opencode, and custom CLIs) would false-negative the verify and be reported as
+// a silent drop despite successful delivery. Those tools therefore skip the
+// Claude-tuned verify. This is the general superset of #1228's codex-only skip.
+func UsesClaudeDeliveryVerify(toolName string) bool {
+	return IsClaudeCompatible(toolName)
+}
+
 // IsCodexCompatible returns true if the tool is "codex" or a custom tool
 // whose underlying command is "codex". Use this for capability gates
 // where custom tools wrapping Codex should get full Codex functionality


### PR DESCRIPTION
## Problem

The post-send delivery verification that backs `session send` (added for #876) polls the pane for **Claude-specific readiness signals**: an `active` status transition, a composer/unsent-paste marker, and the message body echoed in the pane. Non-Claude tools never surface those the same way, so a **delivered** message is reported as a failure:

```
Error: failed to send message: send dropped silently: no evidence of delivery
after 30 checks (issue #876). The agent never transitioned to 'active', no
composer/unsent-paste marker appeared, and the message body was not visible in
the pane.
```

This is the mirror image of the original #876 (which was a false **positive**):

| Issue | Tool | Symptom |
|-------|------|---------|
| #876 (original) | claude | false **positive** — `send` returns ✓, nothing delivered |
| #876 (variant) / #1238 | codewhale (deepseek-v4-pro) | false **negative** — `send` errors, but it *was* delivered |
| #1205 | codex | false **negative** — same shape, plus destructive Ctrl+C recovery |

**Impact:** callers/orchestrators that trust the return code treat delivered messages as failures and **retry**, causing double-delivery — duplicate prompts, or duplicate keystrokes into approval modals (which can mis-answer a gate).

## Fix

Make the post-send verify **tool-aware**. New single predicate `session.UsesClaudeDeliveryVerify(tool)` decides whether the Claude-tuned heuristics apply — true **only** for Claude-compatible tools. Every non-Claude tool (codex, gemini, codewhale, opencode, custom CLIs) skips the Claude-specific verify and the send is treated as the atomic delivery it already is.

Wired at every call site that ran the verify:
- `session send` (`handleSessionSend`) and `--no-wait` (`sendNoWait`)
- `launch --no-wait` initial message
- `internal/session` `sendMessageWhenReady` verify loop

Claude tools keep the full verify, so genuine silent drops are still surfaced (guarded by `TestSend_ClaudeTool_VerifyPreserved`).

## Relationship to #1228 (this is the general superset)

Contributor PR **#1228** (@AndreIntelas) fixes the **codex-only** case: `skipVerify = IsCodexCompatible(tool)`, plus a codex-only early return in `sendMessageWhenReady`. That correctly closes #1205 but leaves #1238 (codewhale) and #876's non-Claude variants open, since codex is just one member of the non-Claude set.

This PR is the **general superset**: `skipVerify = !IsClaudeCompatible(tool)` (via `UsesClaudeDeliveryVerify`). Codex is a strict subset, so **this subsumes #1228** — pinned by `TestUsesClaudeDeliveryVerify_SupersetOfCodex`. The maintainer can merge **either** #1228 (codex-only, smaller) **or** this PR (all non-Claude tools), but not both — they touch the same call sites. Recommend this one, as it closes #1238 + #1205 + #876 together.

## Tests (TDD)

- `internal/session`: `TestUsesClaudeDeliveryVerify` — the predicate is true only for Claude (claude→true; codex/codewhale/gemini/opencode→false), plus `TestUsesClaudeDeliveryVerify_SupersetOfCodex`.
- `cmd/agent-deck`: `TestSend_NonClaudeTool_NotReportedDropped` — a non-Claude-shaped target (status `waiting`, no composer markers) is **not** reported dropped, for `{codex, codewhale, gemini, opencode}`; no destructive Ctrl+C, no Enter-spam.
- `TestSend_ClaudeTool_VerifyPreserved` — Claude still surfaces a genuine silent drop (no over-skipping).

Both written test-first (watched fail → implemented). `go test -race ./internal/session/ ./cmd/agent-deck/` passes; `golangci-lint run` reports 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed delivery verification behavior for non-Claude tools. Issue `#1238`: Non-Claude tools (codex, gemini, opencode, codewhale) no longer incorrectly report "dropped silently" errors during message delivery.
  * Delivery verification now conditionally adapts based on the selected tool, preserving Claude tool behavior while preventing false negatives for other tools.

* **Tests**
  * Added regression tests for tool-aware delivery verification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->