### PR TITLE
fix(instance): default to single-instance per profile (allow_multiple=false) to stop concurrent tear-down (closes #1246)

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -636,9 +636,12 @@ func (n NotificationsConfig) GetTransitionEventsEnabled() bool {
 
 // InstanceSettings configures multiple agent-deck instance behavior
 type InstanceSettings struct {
-	// AllowMultiple allows running multiple agent-deck TUI instances for the same profile
-	// When true (default), multiple instances can run, but only the first (primary) manages the notification bar
-	// When false, only one instance can run per profile
+	// AllowMultiple allows running multiple agent-deck TUI instances for the same profile.
+	// When false (default), only one instance can run per profile — a safe default that
+	// prevents concurrent reviver/restart loops from tearing down each other's live
+	// sessions (issue #1246). When true (explicit opt-in), multiple instances can run,
+	// but only the first (primary) manages the notification bar — useful for multi-pane
+	// workflows (e.g. PC + phone-over-SSH).
 	AllowMultiple *bool `toml:"allow_multiple"`
 
 	// FollowCwdOnAttach updates the session's ProjectPath from tmux pane_current_path
@@ -647,10 +650,14 @@ type InstanceSettings struct {
 	FollowCwdOnAttach *bool `toml:"follow_cwd_on_attach"`
 }
 
-// GetAllowMultiple returns whether multiple instances are allowed, defaulting to true
+// GetAllowMultiple returns whether multiple instances are allowed, defaulting to false.
+// Single-instance-per-profile is the safe default: it engages the primary-election gate
+// so a second instance is rejected, preventing concurrent reviver/restart loops from
+// tearing down each other's live sessions (issue #1246). Multi-instance is an explicit
+// opt-in via allow_multiple = true.
 func (i *InstanceSettings) GetAllowMultiple() bool {
 	if i.AllowMultiple == nil {
-		return true // Default: allow multiple instances (better UX for multi-pane workflows)
+		return false // Default: single instance per profile (prevents concurrent tear-down)
 	}
 	return *i.AllowMultiple
 }
@@ -2763,8 +2770,14 @@ func CreateExampleConfig() error {
 # detach = "ctrl+d"   # PTY-attach detach key, default ctrl+q (issue #434).
                       # Alias [tmux].detach_key exists; [hotkeys].detach wins.
 
-# Attach-return project path sync (optional)
+# Instance behavior (optional)
 # [instances]
+# allow_multiple = false   # Default: one agent-deck per profile (single-instance gate).
+                           # A second instance is rejected to prevent concurrent
+                           # reviver/restart loops from tearing down each other's live
+                           # sessions (issue #1246). Set true to opt in to multiple
+                           # instances (e.g. PC + phone-over-SSH); the first instance
+                           # (primary) owns the notification bar.
 # follow_cwd_on_attach = true
 
 # Preview settings (optional)

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -1095,6 +1095,61 @@ func TestPreviewSettingsNotesOutputSplitDefaultsAndClamp(t *testing.T) {
 	}
 }
 
+// TestInstanceSettingsAllowMultipleDefault is the #1246 regression guard.
+// allow_multiple previously defaulted to TRUE, so two agent-deck instances
+// could run against one profile and their reviver/restart loops tore down
+// each other's live sessions. The safe default is single-instance per
+// profile: GetAllowMultiple() must default to FALSE so the primary-election
+// gate in main.go engages unless the user explicitly opts in.
+func TestInstanceSettingsAllowMultipleDefault(t *testing.T) {
+	settings := InstanceSettings{}
+	if settings.GetAllowMultiple() {
+		t.Fatal("GetAllowMultiple should default to false (single-instance per profile)")
+	}
+}
+
+// TestInstanceSettingsAllowMultipleExplicit verifies that multi-instance
+// remains available as an explicit opt-in (and that explicit false is
+// honored), so existing users who rely on multi-pane workflows are not
+// silently broken — they only need to set allow_multiple = true.
+func TestInstanceSettingsAllowMultipleExplicit(t *testing.T) {
+	enabled := true
+	settings := InstanceSettings{AllowMultiple: &enabled}
+	if !settings.GetAllowMultiple() {
+		t.Fatal("GetAllowMultiple should return explicit true (opt-in to multi-instance)")
+	}
+
+	disabled := false
+	settings.AllowMultiple = &disabled
+	if settings.GetAllowMultiple() {
+		t.Fatal("GetAllowMultiple should return explicit false")
+	}
+}
+
+// TestUserConfigParseAllowMultiple verifies that an existing config with an
+// explicit allow_multiple = true continues to parse and grant multi-instance,
+// so the default flip does not break users who set the flag deliberately.
+func TestUserConfigParseAllowMultiple(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	content := `
+[instances]
+allow_multiple = true
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	var config UserConfig
+	if _, err := toml.DecodeFile(configPath, &config); err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+
+	if !config.Instances.GetAllowMultiple() {
+		t.Fatal("instances.allow_multiple = true should parse as true (opt-in preserved)")
+	}
+}
+
 func TestInstanceSettingsFollowCwdOnAttach(t *testing.T) {
 	settings := InstanceSettings{}
 	if settings.GetFollowCwdOnAttach() {

--- a/internal/tmux/controlpipe_test.go
+++ b/internal/tmux/controlpipe_test.go
@@ -351,7 +351,7 @@ func TestPipeManager_ConnectCleansStaleClients(t *testing.T) {
 }
 
 // TestKillStaleControlClients_PreservesLiveSibling is the #927 regression
-// guard. With allow_multiple=true (default), two simultaneous agent-deck
+// guard. With allow_multiple=true (opt-in), two simultaneous agent-deck
 // TUIs share a tmux server and each spawns its own control-mode client per
 // session. Before the fix, each TUI's killStaleControlClients sweep treated
 // the OTHER TUI's clients as orphans and SIGTERM'd them — both pipes


### PR DESCRIPTION
## Summary

Closes #1246 (SEVERE).

`allow_multiple` defaulted to **TRUE**, so multiple agent-deck instances could run against a single profile. Each instance runs its own reviver/restart loop, and those loops tore down each other's live sessions — `restart_fallback_recreate` → `claude --resume` interrupts in-flight turns, and one logical session was observed spread across **5 tmux names**.

The single-instance enforcement already exists and is tested (`statedb.ElectPrimary` primary-election lock + the gate in `cmd/agent-deck/main.go:448`), but it was **dormant** because the default permitted multiple instances. This PR flips `GetAllowMultiple()` to default **FALSE**, engaging the per-profile gate by default. A second instance is rejected with:

```
Error: agent-deck is already running for this profile
Set [instances] allow_multiple = true in config.toml to allow multiple instances
```

## ⚠️ DEFAULT-BEHAVIOR CHANGE — maintainer review needed

**This changes default behavior.** Before this PR, an unset `allow_multiple` allowed multiple concurrent instances per profile; after it, the default is single-instance and a second instance is gated/rejected.

- Users who **relied on the implicit multi-instance default** (e.g. desktop TUI + phone-over-SSH TUI against the same profile) must now explicitly set `[instances] allow_multiple = true`.
- Users who **already set `allow_multiple` explicitly** (true or false) are **unaffected** — only the nil/unset default changes.

This is intentional: the previous default is what causes the #1246 cross-instance session tear-down. Single-instance is the safe default; multi-instance becomes an explicit, informed opt-in. Flagging here so maintainers can confirm the trade-off and call it out in release notes.

## Changes

- `internal/session/userconfig.go`: `GetAllowMultiple()` defaults to `false`; updated struct + method docs; documented `allow_multiple` in the generated config template.
- `internal/tmux/controlpipe_test.go`: corrected a now-stale `(default)` comment in the #927 regression test (the multi-TUI scenario is now opt-in, not default).

## Tests (TDD — test written first, watched fail, then fixed)

- `TestInstanceSettingsAllowMultipleDefault` — default is now `false` (the regression guard for #1246).
- `TestInstanceSettingsAllowMultipleExplicit` — explicit `true`/`false` are honored (opt-in preserved).
- `TestUserConfigParseAllowMultiple` — an existing config with explicit `allow_multiple = true` still parses and grants multi-instance.

Existing `statedb` tests already cover the gate itself: `TestElectPrimary_FirstInstance`, `TestElectPrimary_SecondInstance` (rejects a second live instance), `TestElectPrimary_Failover`.

## Verification

- `go test -race ./internal/session/ ./internal/statedb/` — pass
- `golangci-lint run ./internal/session/... ./internal/tmux/... ./cmd/...` — 0 issues
- `go build ./...` — clean

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Changes**
  * Updated default instance behavior to single-instance-per-profile. Users can opt-in to multiple instances by setting `allow_multiple = true` in configuration.

* **Documentation**
  * Clarified instance configuration documentation and updated example config.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->