### PR TITLE
test(e2e): add phone-viewport applicability guards to desktop-coupled specs (closes the PR #1236 phone gap)

### DIFF
--- a/tests/web/e2e/children-panel.spec.js
+++ b/tests/web/e2e/children-panel.spec.js
@@ -103,6 +103,8 @@ test.describe('children endpoint: API surface', () => {
 })
 
 test.describe('children panel: UI rendering', () => {
+  // desktop-only: the right-rail CHILDREN card is not rendered on the phone touch-first layout (<768px) — the right rail (and sidebar `.sess` rows) is collapsed.
+  test.skip(({ viewport }) => (viewport?.width || 1280) < 768, 'phone viewport: children panel is desktop/tablet only')
   test.beforeEach(async ({ request }) => {
     await request.post('/__fixture/reset')
   })

--- a/tests/web/e2e/close-undo.spec.js
+++ b/tests/web/e2e/close-undo.spec.js
@@ -94,7 +94,9 @@ test.describe('non-destructive close + undo delete', () => {
     expect(undo3.status()).toBe(404)
   })
 
-  test('Shift+D in the UI triggers the close action (not delete)', async ({ page, request }) => {
+  test('Shift+D in the UI triggers the close action (not delete)', async ({ page, request, viewport }) => {
+    // desktop-only: keyboard nav (`j`) + Shift+D act on sidebar `.sess` rows, collapsed on the phone touch-first layout (<768px). The sibling API tests above stay phone-applicable.
+    test.skip((viewport?.width || 1280) < 768, 'phone viewport: keyboard-driven close is desktop/tablet only')
     await page.goto('/')
     await page.waitForSelector('.sess', { timeout: 5000 })
 

--- a/tests/web/e2e/mcps.spec.js
+++ b/tests/web/e2e/mcps.spec.js
@@ -137,6 +137,8 @@ test.describe('MCP management — REST API parity', () => {
 })
 
 test.describe('MCP management — UI', () => {
+  // desktop-only: the MCP tab nav + management pane live in the desktop shell (#app-root-grid), not rendered on the phone touch-first layout (<768px).
+  test.skip(({ viewport }) => (viewport?.width || 1280) < 768, 'phone viewport: MCP management UI is desktop/tablet only')
   test.beforeEach(async ({ request }) => {
     await resetFixture(request)
   })

--- a/tests/web/e2e/skills.spec.js
+++ b/tests/web/e2e/skills.spec.js
@@ -76,7 +76,9 @@ test.describe('skills management', () => {
     expect(res.status()).toBe(400)
   })
 
-  test('UI: Skills tab lists the seeded attachment and catalog', async ({ page }) => {
+  test('UI: Skills tab lists the seeded attachment and catalog', async ({ page, viewport }) => {
+    // desktop-only: gotoSkills() clicks sidebar `.sess` rows + the desktop Skills tab nav, absent on the phone touch-first layout (<768px). The API tests above stay phone-applicable.
+    test.skip((viewport?.width || 1280) < 768, 'phone viewport: skills UI is desktop/tablet only')
     await gotoSkills(page)
     // The attached column should show alpha.
     const attachedRows = page.locator('[data-testid="skill-attached-row"]')
@@ -89,7 +91,9 @@ test.describe('skills management', () => {
     await expect(catalogRows.first()).toContainText(/beta|gamma/)
   })
 
-  test('UI: clicking Attach moves a skill from catalog to attached', async ({ page }) => {
+  test('UI: clicking Attach moves a skill from catalog to attached', async ({ page, viewport }) => {
+    // desktop-only: gotoSkills() clicks sidebar `.sess` rows + the desktop Skills tab nav, absent on the phone touch-first layout (<768px). The API tests above stay phone-applicable.
+    test.skip((viewport?.width || 1280) < 768, 'phone viewport: skills UI is desktop/tablet only')
     await gotoSkills(page)
     // Click the first available catalog row's Attach button.
     const firstCatalog = page.locator('[data-testid="skill-catalog-row"]').first()
@@ -99,7 +103,9 @@ test.describe('skills management', () => {
     await expect(page.locator('[data-testid="skill-attached-row"]', { hasText: skillName.trim() })).toBeVisible({ timeout: 4000 })
   })
 
-  test('UI: clicking Detach removes a skill from the attached list', async ({ page }) => {
+  test('UI: clicking Detach removes a skill from the attached list', async ({ page, viewport }) => {
+    // desktop-only: gotoSkills() clicks sidebar `.sess` rows + the desktop Skills tab nav, absent on the phone touch-first layout (<768px). The API tests above stay phone-applicable.
+    test.skip((viewport?.width || 1280) < 768, 'phone viewport: skills UI is desktop/tablet only')
     await gotoSkills(page)
     const row = page.locator('[data-testid="skill-attached-row"]').first()
     await row.locator('[data-testid="skill-detach-btn"]').click()


### PR DESCRIPTION
**These tests are not broken on phone — they are not applicable on phone.** This PR declares the viewport coupling that the keyboard-parity spec already uses.

The four specs assert against DOM that the touch-first 393px phone layout intentionally does not render (collapsed sidebar `.sess` rows, collapsed right rail, desktop tab nav). On phone these tests fail not because a feature regressed, but because the feature is desktop/tablet-only by design. The fix is purely metadata: the same `test.skip` viewport predicate already used by `keyboard-parity.spec.js` for the same reason — turning each skip into an **applicability gate**, not a workaround.

Crucially, the viewport-**independent** REST-API describe blocks in `mcps.spec.js` and `skills.spec.js` (and the whole API-surface describe in `children-panel.spec.js`) are left untouched and **continue to run on phone** — they exercise HTTP contracts that don't care about viewport. Over-skipping would hide real phone regressions in code paths that do work on phone, so the guards are surgical to the describe/test level.

### What gets the guard, and what intentionally does not

| Spec | Guarded (desktop-coupled) | NOT guarded — runs on phone (why) |
|------|---------------------------|-----------------------------------|
| `children-panel.spec.js` | `describe('children panel: UI rendering')` — right-rail CHILDREN card | `describe('children endpoint: API surface')` — `/children` REST contract, viewport-independent |
| `close-undo.spec.js` | `test('Shift+D in the UI …')` — keyboard nav + Shift+D on sidebar `.sess` rows | The 4 API tests (close / undelete / LIFO / empty-stack) — REST contract, viewport-independent |
| `mcps.spec.js` | `describe('MCP management — UI')` — MCP tab nav + pane in desktop shell | `describe('MCP management — REST API parity')` — 11 attach/detach/scope REST tests, viewport-independent |
| `skills.spec.js` | 3 `UI:` tests (list / Attach / Detach) — `gotoSkills()` clicks `.sess` rows + Skills tab nav | The 5 API tests (catalog / attach / detach / 404 / 400) — REST contract, viewport-independent |

`children-panel` and `mcps` have clean, separate UI describe blocks, so the guard sits at `describe()` level (accurate retry/skip counts). `close-undo` and `skills` mix API + UI tests in a single describe, so the guard is per-test (in-body `test.skip(condition, …)`), matching the per-test conditional-skip form `keyboard-parity.spec.js` itself uses — this avoids skipping the sibling API tests. Every guard carries a one-line `// desktop-only:` comment naming the desktop-coupled DOM.

### Precedent

`tests/web/e2e/keyboard-parity.spec.js:29` already declares exactly this gate for exactly this reason (its shortcuts are desktop-only): `test.skip(({ viewport }) => (viewport?.width || 1280) < 768, 'phone viewport: …')`. This PR reuses that predicate verbatim — same helper, same `<768` threshold (phone 393px is skipped; tablet 820px and desktop 1280px still run), same console-skip message style.

### Discovery / lineage

- **#1235** surfaced these failures via CI.
- **#1236** (sibling PR, open) fixed the 16 desktop+tablet failures; CI stayed red purely on 9 chromium-phone failures across these four specs. This PR closes that remaining gap. Branch is off clean `main` and disjoint from #1236's files, so no conflict / no need to wait for it to merge.

### CI signal

Before → after for the chromium-phone project (desktop + tablet unchanged):

- `children-panel.spec.js` UI rendering ×4 → skipped (API surface ×4 still run)
- `close-undo.spec.js` Shift+D UI ×1 → skipped (API ×4 still run)
- `mcps.spec.js` UI ×1 → skipped (REST API ×11 still run)
- `skills.spec.js` UI ×3 → skipped (API ×5 still run)

**9 chromium-phone failures → 0, desktop + tablet stay green.**

### Local verification

Ran the four specs against a hand-extracted local browser (the same lib constraint #1236 noted): **chromium-phone now skips all 9 desktop-coupled tests and still runs/passes every viewport-independent API test; chromium-desktop runs and passes the children-panel UI ×4 and the close-undo Shift+D test (confirming no over-skip — the `<768` predicate cleanly separates phone from tablet/desktop).** Two unrelated tests fail in the *local* fixture build only (`mcps.spec.js:123` global-scope reset quirk; `skills.spec.js` UI skills-pane not rendering locally) — both verified identical on pristine `main` (pre-existing, not introduced here) and both green in CI.

### Follow-up (not in this PR)

A shared `describe.desktopOnly` helper or an ESLint rule could prevent recurrence, but it isn't trivially four lines — the two mixed-describe specs need per-test guards, so a single describe-level helper wouldn't cover them cleanly, and a lint rule would need to understand which selectors are desktop-coupled. Worth a dedicated issue rather than bundling here; the inline `// desktop-only:` comments are the documentation in the meantime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated UI test suites to conditionally skip on phone-sized viewports, as certain interface elements (children panel, MCP management, and skills controls) are not rendered in touch-first layouts. This ensures accurate test coverage across different device sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->