### PR TITLE
ci: bump all deprecated GitHub Actions (supersedes #991, covers perf-smoke + lighthouse-ci)

### DIFF
--- a/.github/workflows/issue-notify.yml
+++ b/.github/workflows/issue-notify.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Gather issue context
         id: context
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -110,7 +110,7 @@ jobs:
           go-version: '1.25.10'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -195,7 +195,7 @@ jobs:
 
       - name: Upload Lighthouse results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lighthouse-results-${{ github.run_id }}
           retention-days: 14

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,10 +33,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload from /site folder
           path: './site'

--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload perf median log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-medians
           path: perf-medians.txt
@@ -81,7 +81,7 @@ jobs:
             | tee benchout.txt
 
       - name: Upload bench output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: perf-bench-output
           path: benchout.txt

--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Gather PR context
         id: context
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -42,7 +42,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run GoReleaser (snapshot, no publish)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
           args: release --snapshot --skip=publish --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Run GoReleaser
         timeout-minutes: 15
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
           args: release --clean

--- a/.github/workflows/telegram-reliability.yml
+++ b/.github/workflows/telegram-reliability.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -68,7 +68,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -78,7 +78,7 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-ubuntu-${{ hashFiles('tests/web/package-lock.json') }}
@@ -100,7 +100,7 @@ jobs:
       # can see what changed without reproducing locally.
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: tests/web/playwright-report
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload screenshot diffs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-screenshots
           path: tests/web/e2e-output

--- a/.github/workflows/weekly-regression.yml
+++ b/.github/workflows/weekly-regression.yml
@@ -78,7 +78,7 @@ jobs:
           GOTOOLCHAIN: go1.25.10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: weekly-regression-${{ github.run_id }}
           retention-days: 30
@@ -149,7 +149,7 @@ jobs:
 
       - name: Create or update regression issue
         if: steps.visual.outcome == 'failure' || steps.lighthouse.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Why

The GitHub Actions Node-runner deprecation retires actions pinned to older Node runtimes. Several workflows still referenced deprecated majors and will **break** once the deprecation is enforced.

**This PR supersedes #991.** PR #991 bumped a set of actions but went stale: it was opened before `perf-smoke.yml` and `lighthouse-ci.yml` were added to `main`, so it never touched them — and both still used the deprecated `actions/upload-artifact@v4` / `actions/setup-node@v4`. A few other files also retained deprecated majors that #991 did not fully cover on the current `main`.

This PR bumps **every** remaining deprecated action across **all** `.github/workflows/*.yml`, using the same canonical version mapping #991 established.

## Version mapping applied

| Action | Old | New |
|---|---|---|
| `actions/github-script` | v7 | v9 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/cache` | v4 | v5 |
| `actions/configure-pages` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/checkout` | v4 | v6 |
| `actions/setup-go` | v5 | v6 |
| `goreleaser/goreleaser-action` | v6 | v7 |

## Files changed (10)

`issue-notify.yml`, `lighthouse-ci.yml` ⭐, `pages.yml`, `perf-smoke.yml` ⭐, `pr-notify.yml`, `release.yml`, `release-snapshot.yml`, `telegram-reliability.yml`, `web-tests.yml`, `weekly-regression.yml`

⭐ = the files #991 missed.

## Verification

- Grepped all workflows: **zero** remaining deprecated `actions/*` or `goreleaser` majors.
- All workflow files parse as valid YAML.
- `github/codeql-action@v4` and `golangci/golangci-lint-action@v9` are already on their current majors (left as-is).

## Request

@asheshgoplani — please **close #991** as superseded by this PR. Workflow PRs are maintainer-merge; not merging this myself.

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped CI/CD action versions across multiple GitHub Actions workflows to current releases.
  * These updates improve compatibility, reliability, and security of automated builds, tests, and deployments.
  * No functional changes to workflows, job logic, or product behavior were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->