### PR TITLE
feat(release): SLSA build provenance attestation with fail-closed artifact verification (supersedes #1159)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,14 @@ concurrency:
 
 permissions:
   contents: write
+  # Sigstore OIDC + GitHub artifact attestation (SLSA build provenance).
+  id-token: write
+  attestations: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     # Tag-push runs use the pushed tag; manual dispatch supplies it explicitly.
     env:
       REF_NAME: ${{ inputs.tag || github.ref_name }}
@@ -50,6 +54,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          # Disable the module cache in this write-permission workflow: a
+          # poisoned cache entry could otherwise influence the very build we
+          # then sign provenance for.
+          cache: false
 
       - name: Validate tag matches code version
         run: |
@@ -65,12 +73,14 @@ jobs:
       # ubuntu-latest by default; install here so `go test ./...` doesn't
       # false-fail on the non-title-lock zoxide_picker_test suite.
       - name: Install zoxide
+        timeout-minutes: 5
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y zoxide
           zoxide --version
 
       - name: Run tests
+        timeout-minutes: 25
         run: go test -race -timeout 20m ./...
 
       # Evaluator harness full tier. Blocking — a release that fails eval
@@ -79,12 +89,14 @@ jobs:
       # a longer timeout so smoke coverage is enforced at the release gate
       # too, not just on PRs.
       - name: Run eval harness (full tier)
+        timeout-minutes: 10
         env:
           GOTOOLCHAIN: go1.25.10
         run: |
           go test -tags 'eval_smoke eval_full' -race -count=1 -timeout 6m ./tests/eval/... ./internal/ui/...
 
       - name: Run GoReleaser
+        timeout-minutes: 15
         uses: goreleaser/goreleaser-action@v6
         with:
           version: '~> v2'
@@ -94,6 +106,7 @@ jobs:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
       - name: Validate release assets
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -136,3 +149,83 @@ jobs:
           ASSET_COUNT=$(echo "$ASSETS" | wc -l | tr -d ' ')
           echo "All ${#EXPECTED[@]} platform tarballs and checksums.txt verified successfully."
           echo "Total assets in release: ${ASSET_COUNT}"
+
+      # SLSA build provenance: attest the published artifacts so consumers can
+      # cryptographically verify they were built by this repo's CI from the
+      # tagged source (`gh attestation verify`, see SECURITY.md).
+      #
+      # An attestation is a SIGNED claim — attesting an incomplete or corrupt
+      # set is worse than not attesting, because consumers trust it. So this
+      # step downloads every expected artifact, fails the moment any single
+      # download fails or yields an empty file, verifies each tarball against
+      # the published SHA-256 checksum, and asserts an exact artifact count
+      # BEFORE the attest step runs. Anything off → fail closed, no signature.
+      - name: Download and verify release artifacts for attestation
+        timeout-minutes: 5
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          VERSION="${REF_NAME#v}"
+          mkdir -p dist-attest
+
+          # Keep in lockstep with the EXPECTED list in "Validate release
+          # assets" above and with .goreleaser's archive matrix.
+          ARTIFACTS=(
+            "agent-deck_${VERSION}_darwin_amd64.tar.gz"
+            "agent-deck_${VERSION}_darwin_arm64.tar.gz"
+            "agent-deck_${VERSION}_linux_amd64.tar.gz"
+            "agent-deck_${VERSION}_linux_arm64.tar.gz"
+          )
+
+          # Download each artifact (plus checksums.txt) one at a time, checking
+          # each individually. A loop without these checks could attest a
+          # partial set — the #1159 defect this step exists to prevent.
+          for asset in "${ARTIFACTS[@]}" "checksums.txt"; do
+            echo "Downloading ${asset}..."
+            if ! gh release download "${REF_NAME}" \
+                --repo "${REPO}" \
+                --pattern "${asset}" \
+                --dir dist-attest; then
+              echo "ERROR: failed to download ${asset} for attestation — failing closed"
+              exit 1
+            fi
+            if [[ ! -s "dist-attest/${asset}" ]]; then
+              echo "ERROR: ${asset} is missing or empty after download — failing closed"
+              exit 1
+            fi
+          done
+
+          # Verify every downloaded tarball against the published checksum
+          # before attesting. We filter checksums.txt to the assets we hold so
+          # that unrelated entries don't make `sha256sum -c` fail on a missing
+          # file, and we fail closed if any expected entry is absent.
+          echo "Verifying SHA-256 checksums..."
+          (
+            cd dist-attest
+            for asset in "${ARTIFACTS[@]}"; do
+              if ! line=$(grep -- "  ${asset}$" checksums.txt); then
+                echo "ERROR: ${asset} has no entry in checksums.txt — failing closed"
+                exit 1
+              fi
+              echo "${line}" | sha256sum -c -
+            done
+          )
+
+          # Final guard: exactly the platform tarballs + checksums.txt, nothing
+          # missing and nothing extra, before we hand the directory to attest.
+          EXPECTED_COUNT=$(( ${#ARTIFACTS[@]} + 1 ))
+          ACTUAL_COUNT=$(find dist-attest -maxdepth 1 -type f | wc -l | tr -d ' ')
+          if [[ "${ACTUAL_COUNT}" -ne "${EXPECTED_COUNT}" ]]; then
+            echo "ERROR: expected ${EXPECTED_COUNT} artifacts to attest, found ${ACTUAL_COUNT} — failing closed"
+            find dist-attest -maxdepth 1 -type f
+            exit 1
+          fi
+          echo "Verified ${#ARTIFACTS[@]} tarballs against checksums.txt; ready to attest."
+
+      - name: Attest build provenance
+        timeout-minutes: 10
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'dist-attest/*'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,3 +19,11 @@ Out of scope: third-party Claude / agent CLI tools agent-deck wraps, third-party
 - We use Dependabot (weekly) + govulncheck on PRs for Go module CVEs.
 - We use CodeQL + golangci-lint (gosec, staticcheck) for static analysis.
 - GitHub Actions are pinned by SHA where third-party.
+- Release artifacts carry [SLSA build provenance](https://slsa.dev/) via GitHub's
+  artifact attestation. The release workflow verifies every artifact (count +
+  SHA-256 against `checksums.txt`) before signing and fails closed otherwise, so
+  an attestation only ever covers the complete, intact release. Consumers can
+  verify a binary was built by this repo's CI from the tagged source:
+  ```bash
+  gh attestation verify agent-deck_*_linux_amd64.tar.gz --repo asheshgoplani/agent-deck
+  ```


### PR DESCRIPTION
## Summary

Attest all release artifacts with [SLSA build provenance](https://slsa.dev/) via `actions/attest-build-provenance@v2`, so consumers can cryptographically verify any release binary was built by this repo's CI from the tagged source. **Supersedes #1159** with corrected, fail-closed verification.

## Why supersede #1159?

#1159 added the attestation but its artifact-download loop had **no error handling**:

```bash
for asset in ...; do
  gh release download "${GITHUB_REF_NAME}" --pattern "$asset" --dir dist-attest
done
```

A failed `gh release download` was swallowed, and the attest step would then sign **whatever happened to land in `dist-attest/`** — potentially an incomplete set. An attestation is a **signed claim consumers trust**, so attesting a partial or corrupt set is *worse* than not attesting at all: it vouches for binaries that may differ from what shipped.

(#1159 also used `$GITHUB_REF_NAME`, which on `workflow_dispatch` resolves to the branch — `main` — not the tag.)

## What this does instead — fail closed

In the new **"Download and verify release artifacts for attestation"** step:

- `set -euo pipefail`.
- Download each expected artifact **plus** `checksums.txt` one at a time; abort the moment any single download fails **or** yields an empty file.
- Verify every tarball against the published **SHA-256** in `checksums.txt` (and fail if an expected entry is absent) **before** attesting.
- Assert an **exact artifact count** (4 platform tarballs + `checksums.txt`) so nothing is missing and nothing extra slips into the signed set.
- Only after all checks pass does **Attest build provenance** run over the verified directory.

It also reuses the workflow's existing `REF_NAME` env (correct on both tag-push and `workflow_dispatch`) and passes `github.repository` via a `REPO` env var rather than interpolating into the shell (injection-safe).

## Hardening carried over from #1159

- `id-token: write` + `attestations: write` permissions (Sigstore OIDC).
- `cache: false` on `actions/setup-go` in this write-permission workflow (no cache-poisoning into a signed build).
- Explicit job (`timeout-minutes: 90`) and per-step timeouts.

## SECURITY.md

Documents the consumer verification command and notes the fail-closed guarantee:

```bash
gh attestation verify agent-deck_*_linux_amd64.tar.gz --repo asheshgoplani/agent-deck
```

## Test plan

- [x] `actionlint` (incl. shellcheck on `run:` blocks) passes on the workflow.
- [x] YAML validates.
- [ ] Next tag push triggers download → verify → attest within timeouts.
- [ ] `gh attestation verify` succeeds on the resulting artifacts.

## Ask

Please **close #1159** in favor of this PR.

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fully automated release publishing workflow triggered on version tag pushes with GoReleaser integration
  * Added SLSA provenance attestation and SHA-256 checksum verification for strengthened release security
  * Implemented explicit timeout safeguards and improved release artifact validation with strict error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->