### PR TITLE
test(perf): Tier-1 WARM suite with correct warm measurement (supersedes #1234)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,14 @@ test:
 
 # Run hard-gated walltime regression tests (Track B). Honors PERF_BUDGET_MULTIPLIER
 # (default 1.0 locally; CI sets 2.0). See docs/perf-budget-suite.md.
+#
+# ./... (not just ./cmd/agent-deck/...) so Tier 1 TestPerf_* added in any
+# package — internal/statedb, internal/session — are exercised locally, matching
+# the perf-smoke.yml CI gate which already runs the whole module.
 test-perf:
 	PERF_BUDGET_MULTIPLIER=$${PERF_BUDGET_MULTIPLIER:-1.0} \
 		go test -run '^TestPerf_' -race -v -count=1 -timeout 120s \
-		./cmd/agent-deck/...
+		./...
 
 # Run advisory benchmarks (Track A). No -race — race overhead distorts ns/op.
 # Output is for trending; not a CI gate.

--- a/internal/session/group_perf_test.go
+++ b/internal/session/group_perf_test.go
@@ -1,0 +1,173 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// Tier-1 WARM perf gate for the storage-mediated group lifecycle.
+//
+// PR #790 explicitly carved group create/delete out of its first perf pass:
+// done purely in-memory (GroupTree map mutation) it "exercises the wrong
+// layer" — the map ops are nanoseconds and gate nothing real. This test gates
+// it at the storage layer by reconstructing the exact choreography the real
+// user-facing handlers perform — cmd/agent-deck/group_cmd.go handleGroupCreate
+// (~L396-442) and handleGroupDelete (~L689-705):
+//
+//	storage.LoadWithGroups()                     // full read of all instances + groups
+//	session.NewGroupTreeWithGroups(insts, grps)  // rebuild the tree
+//	groupTree.CreateGroup / DeleteGroup          // the mutation
+//	storage.SaveWithGroups(insts, groupTree)     // rewrite the WHOLE instances
+//	                                             // table + groups + Touch() + dedup
+//
+// This is deliberately NOT Storage.SaveGroupsOnly: that is the lightweight
+// expand/collapse visual-state path (its own doc comment says so) and skips
+// both the instances round-trip and Touch(). Group create/delete goes through
+// SaveWithGroups, where the dominant cost is the instances-table read+rewrite
+// — which is why this test runs against a populated deck (perfGroupPopN
+// instances), not an empty DB.
+//
+// What this test does NOT cover: the literal CLI shell (flag parsing,
+// NewStorageWithProfile, out.Success/os.Exit). Driving that in-process needs
+// the same injection seam deferred for session create/delete — see the PR
+// description. The seam-free remainder (flag parse + stdout formatting) carries
+// no meaningful, tmux-touching cost, so the storage choreography above is the
+// faithful Tier-1 target.
+//
+// Why WARM, not COLD: pure in-process Go against an SQLite handle on a
+// t.TempDir() path (tmpfs on CI Linux). No process boundary, no real-disk
+// fsync, no child spawn, no network. Seeded rows carry TmuxSession="" so
+// LoadWithGroups' lazy tmux.ReconnectSessionLazy branch never runs — zero tmux
+// code executes. TrimmedMeanWarm forces a GC cycle per iteration and disables
+// auto-GC in the timed window, so the tighter base×3 WarmBudget is safe. See
+// internal/testutil/perfbudget.go and docs/perf-budget-suite.md ("Tier 1 vs
+// Tier 2").
+//
+// No real tmux. No network. Pure-Go in-process SQLite on tmpfs.
+
+// perfGroupPopN is the instance population the deck is seeded with. 50 is the
+// representative upper-end deck size cited in code (internal/web/handlers_costs.go:529
+// notes the sidebar "grows past ~50 sessions"); group create/delete rewrites
+// this whole table via SaveWithGroups, so a realistic population is the point.
+const perfGroupPopN = 50
+
+// perfGroupBaseline is the number of groups the seeded deck spans (5 sessions
+// per group across the perfGroupPopN instances → ~10 groups).
+const perfGroupBaseline = 10
+
+// perfGroupBase is the local median observed under -race at
+// PERF_BUDGET_MULTIPLIER=1.0 for the real create+delete choreography (two full
+// LoadWithGroups → SaveWithGroups round trips over a perfGroupPopN-instance
+// deck). WarmBudget multiplies by 3 and applies the 1ms floor and the env
+// multiplier (CI sets 2.0 → 6× local gate).
+//
+// Local median under -race: ~67ms (two LoadWithGroups + two SaveWithGroups
+// full instances-table rewrites over a 50-instance deck).
+const perfGroupBase = 70 * time.Millisecond // → WarmBudget = 210ms local, 420ms CI
+
+// newPerfStorage builds a Storage backed by a migrated SQLite DB on a
+// tmpfs-backed t.TempDir() path. Constructed directly (rather than via
+// NewStorageWithProfile) to keep the fixture hermetic — no HOME/profile
+// migration scanning — while exercising the identical LoadWithGroups /
+// SaveWithGroups paths the CLI handlers hit.
+func newPerfStorage(t *testing.T) *Storage {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	db, err := statedb.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return &Storage{db: db, dbPath: dbPath, profile: "perf"}
+}
+
+// seedDeck persists perfGroupPopN instances spread across perfGroupBaseline
+// groups directly via the statedb layer (setup, excluded from timing). Rows
+// carry TmuxSession="" so the later LoadWithGroups conversion runs no tmux code.
+func seedDeck(t *testing.T, storage *Storage) {
+	t.Helper()
+	rows := make([]*statedb.InstanceRow, perfGroupPopN)
+	now := time.Now()
+	for i := 0; i < perfGroupPopN; i++ {
+		rows[i] = &statedb.InstanceRow{
+			ID:          fmt.Sprintf("perf-%04d", i),
+			Title:       fmt.Sprintf("Session %d", i),
+			ProjectPath: fmt.Sprintf("/home/dev/project-%d", i),
+			GroupPath:   fmt.Sprintf("group-%d", i%perfGroupBaseline),
+			Order:       i,
+			Tool:        "claude",
+			Status:      "idle",
+			CreatedAt:   now,
+			ToolData:    json.RawMessage(`{"claude_session_id":"sess-abcdef"}`),
+		}
+	}
+	if err := storage.db.SaveInstances(rows); err != nil {
+		t.Fatalf("seed SaveInstances: %v", err)
+	}
+}
+
+// TestPerf_Group_CreateDelete gates the storage-mediated group create+delete
+// lifecycle by reconstructing the handleGroupCreate / handleGroupDelete
+// choreography (see file header) against a perfGroupPopN-instance deck.
+//
+// The timed op runs both halves — a create cycle then a delete cycle, each a
+// full LoadWithGroups → rebuild tree → mutate → SaveWithGroups round trip.
+// Creating then deleting the same ephemeral group is net-zero on persisted
+// state, so the deck returns to baseline each iteration and TrimmedMeanWarm (no
+// per-iter fixture rebuild) applies. The dominant measured cost is the two
+// instances-table read+rewrite passes — exactly the regression class Tier 1
+// gates ("we added N ms of CPU work in the group save path").
+func TestPerf_Group_CreateDelete(t *testing.T) {
+	testutil.SkipIfShort(t)
+	storage := newPerfStorage(t)
+	seedDeck(t, storage)
+
+	budget := testutil.WarmBudget(t, perfGroupBase)
+
+	// createCycle mirrors handleGroupCreate: load, rebuild tree, CreateGroup,
+	// SaveWithGroups(loaded instances, tree).
+	createCycle := func() {
+		instances, groups, err := storage.LoadWithGroups()
+		if err != nil {
+			t.Fatalf("create LoadWithGroups: %v", err)
+		}
+		tree := NewGroupTreeWithGroups(instances, groups)
+		tree.CreateGroup("perf-ephemeral")
+		if err := storage.SaveWithGroups(instances, tree); err != nil {
+			t.Fatalf("create SaveWithGroups: %v", err)
+		}
+	}
+
+	// deleteCycle mirrors handleGroupDelete: load, rebuild tree, DeleteGroup,
+	// SaveWithGroups(tree.GetAllInstances(), tree).
+	deleteCycle := func() {
+		instances, groups, err := storage.LoadWithGroups()
+		if err != nil {
+			t.Fatalf("delete LoadWithGroups: %v", err)
+		}
+		tree := NewGroupTreeWithGroups(instances, groups)
+		tree.DeleteGroup("perf-ephemeral")
+		if err := storage.SaveWithGroups(tree.GetAllInstances(), tree); err != nil {
+			t.Fatalf("delete SaveWithGroups: %v", err)
+		}
+	}
+
+	got := testutil.TrimmedMeanWarm(func() {
+		createCycle()
+		deleteCycle()
+	})
+
+	if got > budget {
+		t.Fatalf("group create+delete (LoadWithGroups→SaveWithGroups ×2, %d-instance deck) trimmed mean = %v, budget = %v (regression in the group save path)", perfGroupPopN, got, budget)
+	}
+	t.Logf("group create+delete (LoadWithGroups→SaveWithGroups ×2, %d-instance deck) trimmed mean = %v (budget = %v)", perfGroupPopN, got, budget)
+}

--- a/internal/statedb/statedb_perf_test.go
+++ b/internal/statedb/statedb_perf_test.go
@@ -1,0 +1,310 @@
+package statedb
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// Tier-1 WARM perf gates for the StateDB persistence layer.
+//
+// These tests cover the deferred "persistence-touching lifecycle" items from
+// PR #790 / #1047 (see docs/perf-budget-suite.md, "Tier 1 vs Tier 2"). They
+// run against a t.TempDir() SQLite database — tmpfs on CI Linux — so fsync is
+// effectively free and the measured cost is CPU + Go-runtime cost only (driver
+// marshalling, statement prep, row scanning, SQLite page churn). That is the
+// regression class Tier 1 gates: "we added N ms of CPU work in the save/read
+// path". It does NOT gate fsync/transaction *counts* — that is Tier 2 (count
+// assertions), owned by a sibling session, see the //TODO in the watcher-event
+// test below.
+//
+// Why WARM, not COLD: every operation is pure in-process Go against an
+// SQLite handle on tmpfs. No process boundary, no real-disk fsync, no child
+// spawn, no network — exactly the WARM criteria. WARM measurement
+// (TrimmedMeanWarm / TrimmedMeanWarmWithSetup) forces a GC cycle per iteration and
+// disables auto-GC inside the timed window, removing the dominant noise source;
+// the tighter base×3 WarmBudget is therefore safe. See
+// internal/testutil/perfbudget.go for the full cold/warm convention.
+//
+// Population size N: 50 rows. This is the representative upper-end session
+// count cited in the codebase — internal/web/handlers_costs.go:529 notes the
+// sidebar "grows past ~50 sessions" (and llms-full.txt cites 30-session
+// workspaces). 50 is a realistic heavily-loaded deck, not an invented number.
+//
+// No real tmux. No network. Pure-Go in-process SQLite on tmpfs.
+
+// perfPopN is the representative session population for the CRUD scaling gates.
+// See file header: ~50 is the cited upper-end deck size
+// (internal/web/handlers_costs.go:529).
+const perfPopN = 50
+
+// Base local medians observed under -race at PERF_BUDGET_MULTIPLIER=1.0
+// (Linux/WSL2, this dev host). WarmBudget multiplies by 3 and applies the
+// 1ms floor and the env multiplier (CI sets 2.0 → 6× local gate).
+const (
+	// 50× SaveInstance into an empty table (per-session insert path).
+	// Local median under -race: ~206ms (50 autocommit WAL txns dominate).
+	perfStateDBInsertBase = 210 * time.Millisecond // → WarmBudget = 630ms local, 1.26s CI
+	// 50× InstanceExists (read-by-id query path; rm-verify uses this).
+	// Local median under -race: ~9.3ms.
+	perfStateDBReadByIDBase = 10 * time.Millisecond // → WarmBudget = 30ms local, 60ms CI
+	// One LoadInstances over a 50-row table (list path).
+	// Local median under -race: ~6.9ms.
+	perfStateDBListBase = 7 * time.Millisecond // → WarmBudget = 21ms local, 42ms CI
+	// 50× DeleteInstance (the `agent-deck rm` xargs path, issue #909).
+	// Local median under -race: ~166ms (50 autocommit txns + withBusyRetry).
+	perfStateDBDeleteBase = 170 * time.Millisecond // → WarmBudget = 510ms local, 1.02s CI
+	// Ingest 50 fresh events on a 500-event steady-state table (insert + prune
+	// per event; prune is the DELETE ... NOT IN subquery, the CPU target here).
+	// Local median under -race: ~1.42s.
+	perfWatcherIngestBase = 1450 * time.Millisecond // → WarmBudget = 4.35s local, 8.7s CI
+)
+
+// newPerfDB opens a migrated StateDB on a tmpfs-backed t.TempDir() path.
+func newPerfDB(t *testing.T) *StateDB {
+	t.Helper()
+	db, err := Open(filepath.Join(t.TempDir(), "perf.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// perfRows builds n representative instance rows with stable ids.
+func perfRows(n int) []*InstanceRow {
+	rows := make([]*InstanceRow, n)
+	now := time.Now()
+	for i := 0; i < n; i++ {
+		rows[i] = &InstanceRow{
+			ID:          fmt.Sprintf("perf-%04d", i),
+			Title:       fmt.Sprintf("Session %d", i),
+			ProjectPath: fmt.Sprintf("/home/dev/project-%d", i),
+			GroupPath:   fmt.Sprintf("group-%d", i%5),
+			Order:       i,
+			Tool:        "claude",
+			Status:      "idle",
+			CreatedAt:   now,
+			ToolData:    json.RawMessage(`{"claude_session_id":"sess-abcdef"}`),
+		}
+	}
+	return rows
+}
+
+// clearInstances truncates the instances table (setup helper, excluded from
+// the timed window).
+func clearInstances(t *testing.T, db *StateDB) {
+	t.Helper()
+	if _, err := db.DB().Exec("DELETE FROM instances"); err != nil {
+		t.Fatalf("clear instances: %v", err)
+	}
+}
+
+// TestPerf_StateDB_InsertN gates the cost of creating perfPopN sessions one at
+// a time via SaveInstance (the per-session save: SELECT existing tool_data +
+// INSERT OR REPLACE). Catches CPU regressions in the row-marshalling /
+// tool-data-merge path.
+func TestPerf_StateDB_InsertN(t *testing.T) {
+	testutil.SkipIfShort(t)
+	db := newPerfDB(t)
+	rows := perfRows(perfPopN)
+	budget := testutil.WarmBudget(t, perfStateDBInsertBase)
+
+	got := testutil.TrimmedMeanWarmWithSetup(
+		func() { clearInstances(t, db) },
+		func() {
+			for _, r := range rows {
+				if err := db.SaveInstance(r); err != nil {
+					t.Fatalf("SaveInstance: %v", err)
+				}
+			}
+		},
+	)
+
+	if got > budget {
+		t.Fatalf("insert %d instances trimmed mean = %v, budget = %v (regression in SaveInstance marshalling/tool-data merge)", perfPopN, got, budget)
+	}
+	t.Logf("insert %d instances trimmed mean = %v (budget = %v)", perfPopN, got, budget)
+}
+
+// TestPerf_StateDB_ReadByID gates perfPopN read-by-id lookups (InstanceExists —
+// the indexed point-query used by the rm-verify path, issue #909). The table is
+// populated once outside the timed window; the op is read-only, so
+// TrimmedMeanWarm (no per-iter fixture rebuild) is sufficient.
+func TestPerf_StateDB_ReadByID(t *testing.T) {
+	testutil.SkipIfShort(t)
+	db := newPerfDB(t)
+	rows := perfRows(perfPopN)
+	if err := db.SaveInstances(rows); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+	budget := testutil.WarmBudget(t, perfStateDBReadByIDBase)
+
+	got := testutil.TrimmedMeanWarm(func() {
+		for _, r := range rows {
+			ok, err := db.InstanceExists(r.ID)
+			if err != nil || !ok {
+				t.Fatalf("InstanceExists(%s) = %v, %v", r.ID, ok, err)
+			}
+		}
+	})
+
+	if got > budget {
+		t.Fatalf("read-by-id ×%d trimmed mean = %v, budget = %v (regression in point-query path)", perfPopN, got, budget)
+	}
+	t.Logf("read-by-id ×%d trimmed mean = %v (budget = %v)", perfPopN, got, budget)
+}
+
+// TestPerf_StateDB_List gates one LoadInstances over a perfPopN-row table (the
+// full-scan + per-row Scan path hit on every reload). Read-only → TrimmedMeanWarm.
+func TestPerf_StateDB_List(t *testing.T) {
+	testutil.SkipIfShort(t)
+	db := newPerfDB(t)
+	rows := perfRows(perfPopN)
+	if err := db.SaveInstances(rows); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+	budget := testutil.WarmBudget(t, perfStateDBListBase)
+
+	got := testutil.TrimmedMeanWarm(func() {
+		loaded, err := db.LoadInstances()
+		if err != nil {
+			t.Fatalf("LoadInstances: %v", err)
+		}
+		if len(loaded) != perfPopN {
+			t.Fatalf("LoadInstances returned %d rows, want %d", len(loaded), perfPopN)
+		}
+	})
+
+	if got > budget {
+		t.Fatalf("list %d instances trimmed mean = %v, budget = %v (regression in full-scan/row-scan path)", perfPopN, got, budget)
+	}
+	t.Logf("list %d instances trimmed mean = %v (budget = %v)", perfPopN, got, budget)
+}
+
+// TestPerf_StateDB_DeleteN gates removing perfPopN sessions one at a time via
+// DeleteInstance (the `agent-deck rm` path; xargs -P fan-out hits this per
+// row, issue #909). Each iteration mutates state, so the fixture is rebuilt in
+// setup (excluded from timing) via TrimmedMeanWarmWithSetup.
+func TestPerf_StateDB_DeleteN(t *testing.T) {
+	testutil.SkipIfShort(t)
+	db := newPerfDB(t)
+	rows := perfRows(perfPopN)
+	budget := testutil.WarmBudget(t, perfStateDBDeleteBase)
+
+	got := testutil.TrimmedMeanWarmWithSetup(
+		func() {
+			clearInstances(t, db)
+			if err := db.SaveInstances(rows); err != nil {
+				t.Fatalf("repopulate: %v", err)
+			}
+		},
+		func() {
+			for _, r := range rows {
+				if err := db.DeleteInstance(r.ID); err != nil {
+					t.Fatalf("DeleteInstance: %v", err)
+				}
+			}
+		},
+	)
+
+	if got > budget {
+		t.Fatalf("delete %d instances trimmed mean = %v, budget = %v (regression in DeleteInstance path)", perfPopN, got, budget)
+	}
+	t.Logf("delete %d instances trimmed mean = %v (budget = %v)", perfPopN, got, budget)
+}
+
+// perfWatcherSteadyState is the number of events the watcher_events table is
+// pre-filled to before the timed batch — the default retention bound
+// (max_events_per_watcher default 500, internal/session/userconfig.go:3419).
+const perfWatcherSteadyState = 500
+
+// perfWatcherIngestBatch is the number of fresh events ingested per timed
+// iteration on top of the steady state.
+const perfWatcherIngestBatch = 50
+
+// TestPerf_StateDB_WatcherEventIngest gates the watcher-event ingestion path:
+// SaveWatcherEvent does an INSERT OR IGNORE followed (on a real insert) by a
+// prune — DELETE ... WHERE id NOT IN (SELECT ... ORDER BY id DESC LIMIT N).
+// That prune subquery is the CPU regression target; its cost scales with the
+// steady-state table size, so we pre-fill to the default 500-event bound and
+// time a 50-event batch on top. Each batch event triggers one insert + one
+// prune at a full table.
+//
+// Fixture (a 500-row table) is rebuilt per iteration in setup, excluded from
+// timing, via TrimmedMeanWarmWithSetup.
+//
+// TODO(tier2): a Tier 2 count assertion belongs here too — "ingesting one new
+// event past the bound = exactly 1 INSERT + 1 prune DELETE, no extra round
+// trips". Counts are syscall-side (COLD); left to the sibling outbox/drain
+// session per docs/perf-budget-suite.md.
+func TestPerf_StateDB_WatcherEventIngest(t *testing.T) {
+	testutil.SkipIfShort(t)
+	db := newPerfDB(t)
+
+	const watcherID = "perf-watcher"
+	if err := db.SaveWatcher(&WatcherRow{
+		ID:     watcherID,
+		Name:   "perf",
+		Type:   "gmail",
+		Status: "running",
+	}); err != nil {
+		t.Fatalf("SaveWatcher: %v", err)
+	}
+
+	// prefill rebuilds the steady-state table directly (bypassing the prune in
+	// SaveWatcherEvent) so setup cost stays low and the timed op sees a full
+	// 500-row table.
+	prefill := func() {
+		if _, err := db.DB().Exec("DELETE FROM watcher_events"); err != nil {
+			t.Fatalf("clear events: %v", err)
+		}
+		tx, err := db.DB().Begin()
+		if err != nil {
+			t.Fatalf("begin prefill: %v", err)
+		}
+		stmt, err := tx.Prepare(`INSERT INTO watcher_events (watcher_id, dedup_key, created_at) VALUES (?, ?, ?)`)
+		if err != nil {
+			t.Fatalf("prepare prefill: %v", err)
+		}
+		now := time.Now().Unix()
+		for i := 0; i < perfWatcherSteadyState; i++ {
+			if _, err := stmt.Exec(watcherID, fmt.Sprintf("base-%05d", i), now+int64(i)); err != nil {
+				t.Fatalf("prefill exec: %v", err)
+			}
+		}
+		_ = stmt.Close()
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit prefill: %v", err)
+		}
+	}
+
+	budget := testutil.WarmBudget(t, perfWatcherIngestBase)
+
+	got := testutil.TrimmedMeanWarmWithSetup(
+		prefill,
+		func() {
+			for i := 0; i < perfWatcherIngestBatch; i++ {
+				inserted, err := db.SaveWatcherEvent(watcherID, fmt.Sprintf("batch-%05d", i), "sender@example.com", "subj", "", "", perfWatcherSteadyState)
+				if err != nil {
+					t.Fatalf("SaveWatcherEvent: %v", err)
+				}
+				if !inserted {
+					t.Fatalf("SaveWatcherEvent batch-%05d unexpectedly deduped", i)
+				}
+			}
+		},
+	)
+
+	if got > budget {
+		t.Fatalf("ingest %d events @ steady-state %d trimmed mean = %v, budget = %v (regression in insert+prune path)", perfWatcherIngestBatch, perfWatcherSteadyState, got, budget)
+	}
+	t.Logf("ingest %d events @ steady-state %d trimmed mean = %v (budget = %v)", perfWatcherIngestBatch, perfWatcherSteadyState, got, budget)
+}

--- a/internal/testutil/perfbudget.go
+++ b/internal/testutil/perfbudget.go
@@ -164,11 +164,27 @@ func TrimmedMeanWarm(fn func()) time.Duration {
 // fresh fixture per iteration (e.g. a populated tree before timing
 // DeleteAll). Setup and op share state via closure capture in the caller.
 //
-// COLD variant — no GC manipulation. For warm work needing setup,
-// compose: temporarily disable GC yourself or call runtime.GC() inside
-// setup before each timed op.
+// COLD variant — no GC manipulation. For WARM work that also needs a
+// per-iteration fixture, use TrimmedMeanWarmWithSetup instead: pairing
+// WarmBudget's tighter base×3 gate with this COLD measurement is unsound,
+// because the GC noise WarmBudget assumes away is not actually controlled.
 func TrimmedMeanWithSetup(setup, op func()) time.Duration {
 	return trimmedMeanCore(false, setup, op)
+}
+
+// TrimmedMeanWarmWithSetup is TrimmedMeanWithSetup with controlled GC: it
+// runs setup() before each timed op() (excluded from the timing window) and,
+// like TrimmedMeanWarm, forces a runtime.GC() before each timed iteration and
+// disables auto-GC during the timed window via debug.SetGCPercent(-1),
+// restoring the original setting on return.
+//
+// This is the correct partner for WarmBudget when the timed primitive mutates
+// state and therefore needs a fresh fixture per iteration (e.g. insert/delete
+// against a DB, or a prune over a pre-filled table). TrimmedMeanWithSetup is
+// the COLD variant and does NOT control GC, so pairing it with WarmBudget's
+// tighter base×3 gate would measure GC noise the budget assumes away.
+func TrimmedMeanWarmWithSetup(setup, op func()) time.Duration {
+	return trimmedMeanCore(true, setup, op)
 }
 
 func trimmedMeanCore(controlGC bool, setup, op func()) time.Duration {


### PR DESCRIPTION
**Supersedes #1234.** Same Tier-1 WARM perf suite (statedb CRUD + storage-mediated group lifecycle), corrected for measurement rigor before merge.

## Why this supersedes #1234

#1234 classifies three gates as **WARM** (`InsertN`, `DeleteN`, `WatcherEventIngest`) and applies `WarmBudget`'s tighter **base×3** gate to them — but measures them with `testutil.TrimmedMeanWithSetup`, which is the **COLD** variant. That helper does **not** force a GC before each timed iteration and does **not** disable auto-GC inside the timed window.

The `WarmBudget`/`TrimmedMeanWarm` pairing is the whole basis for the tighter warm gate (see `internal/testutil/perfbudget.go` docblock: the 3× factor is "safe because `TrimmedMeanWarm` forces a GC cycle and disables auto-GC during each timed window"). Using the COLD measurement under a WARM budget leaves the exact GC variance the budget assumes away **uncontrolled** — so those three gates can flap (false reds) or pass on lucky GC timing (false greens). The file headers even *claim* `TrimmedMeanWarm` semantics, so the code contradicted its own documented contract.

## The fix

- **Add `testutil.TrimmedMeanWarmWithSetup`** — the missing WARM partner for `WarmBudget` when the timed primitive mutates state and needs a per-iteration fixture. It composes the *existing* `trimmedMeanCore(controlGC=true, setup, op)` (GC forced **outside** each timed window, auto-GC disabled **inside** it), so no new measurement machinery — just the correct entry point.
- **Switch `InsertN` / `DeleteN` / `WatcherEventIngest`** to `TrimmedMeanWarmWithSetup`, and fix their doc comments to name the right helper.
- **Clarify `TrimmedMeanWithSetup`'s doc** to steer WARM+setup callers to the new helper instead of the COLD one.

Read-only WARM gates (`ReadByID`, `List`) and `Group_CreateDelete` already used `TrimmedMeanWarm` and are unchanged. The `TODO(tier2)` count-assertion note on the watcher-event path is preserved.

## Verification

`make test-perf` scope (this branch keeps #1234's `./...` Makefile broadening):

- `PERF_BUDGET_MULTIPLIER=1.0` — all six `TestPerf_*` green under `-race`.
- `PERF_BUDGET_MULTIPLIER=2.0` (CI) — all six green under `-race`.
- `go build ./...` and `go vet` of `internal/statedb`, `internal/session`, `internal/testutil` clean.

| Test | Measurement | Budget@1.0 | Local (×1.0, -race) |
|------|-------------|-----------|---------------------|
| `TestPerf_StateDB_InsertN` | `TrimmedMeanWarmWithSetup` ✅ | 630ms | 513ms |
| `TestPerf_StateDB_ReadByID` | `TrimmedMeanWarm` | 30ms | 24ms |
| `TestPerf_StateDB_List` | `TrimmedMeanWarm` | 21ms | 18ms |
| `TestPerf_StateDB_DeleteN` | `TrimmedMeanWarmWithSetup` ✅ | 510ms | 395ms |
| `TestPerf_StateDB_WatcherEventIngest` | `TrimmedMeanWarmWithSetup` ✅ | 4.35s | 2.57s |
| `TestPerf_Group_CreateDelete` | `TrimmedMeanWarm` | 210ms | 153ms |

✅ = the three gates corrected from COLD to WARM measurement vs #1234.

Committed by Ashesh Goplani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded performance regression test suite to cover additional modules, ensuring broader performance stability monitoring
  * Added new performance tests for group lifecycle operations and state database persistence layer
  * Enhanced test infrastructure documentation for performance measurement utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->