### PR TITLE
fix(ui): prevent iTerm2 ghost-lines without regressing panel width-measurement (supersedes #1240)

### DIFF
--- a/internal/ui/cellwidth.go
+++ b/internal/ui/cellwidth.go
@@ -27,6 +27,34 @@ func cellWidth(s string) int {
 	return ansi.StringWidth(s)
 }
 
+// fitCellWidth returns s truncated or space-padded so it occupies exactly width
+// terminal cells, measured by cellWidth (ansi cells, keycap-aware).
+//
+// Used by clampViewToViewport on the final, already-joined frame so every row
+// fully overwrites the previous frame's row on incremental redraw. Without the
+// pad, when a shorter line replaces a longer one the terminal keeps the stale
+// trailing glyphs — the iTerm2 "ghost line" artifact on session-list scroll
+// (#607 row-offset drift class). Truncation reuses cellTruncate so keycap
+// clusters (#937) are cut at their true 2-cell width.
+//
+// This stays on cellWidth deliberately: clampViewToViewport runs AFTER
+// lipgloss.JoinHorizontal, so it is a terminal-cell safety net, not part of the
+// JoinHorizontal width-measurement path. The pre-join equalizer ensureExactWidth
+// must NOT use cellWidth — it has to agree with lipgloss.Width (see #182).
+func fitCellWidth(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	w := cellWidth(s)
+	if w > width {
+		return cellTruncate(s, width, "")
+	}
+	if w < width {
+		return s + strings.Repeat(" ", width-w)
+	}
+	return s
+}
+
 // cellTruncate returns a prefix of s whose cellWidth is <= width, appending
 // tail (also measured by cellWidth) if any truncation occurred.
 //

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10847,9 +10847,14 @@ func clampViewToViewport(content string, width, height int) string {
 		// terminal cell count. Any line that slips past upstream gates
 		// with a #️⃣ 0️⃣–9️⃣ *️⃣ glyph would otherwise overflow into the
 		// next row here — exactly @jennings's pane-content drift report.
-		if cellWidth(line) > width {
-			lines[i] = cellTruncate(line, width, "")
-		}
+		//
+		// Also PAD short lines to exactly width (not just truncate long
+		// ones): on incremental redraw a shorter line must overwrite the
+		// full previous row, else the terminal keeps the stale trailing
+		// glyphs — the iTerm2 "ghost line" artifact on session-list scroll
+		// (#607 row-offset drift). fitCellWidth does both, on cellWidth so
+		// this post-join clamp stays a true terminal-cell net.
+		lines[i] = fitCellWidth(line, width)
 	}
 
 	return strings.Join(lines, "\n")

--- a/internal/ui/issue937_keycap_test.go
+++ b/internal/ui/issue937_keycap_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -274,5 +275,88 @@ func Test_Issue937v2_CellTruncate_PreservesAnsiBoundariesAndKeycap(t *testing.T)
 				)
 			}
 		})
+	}
+}
+
+// Test_clampViewToViewport_PadsEveryRow guards the iTerm2 ghost-line fix: the
+// final viewport clamp must PAD short rows to full width (not only truncate
+// long ones) so incremental redraw overwrites the previous frame's stale
+// trailing glyphs without resorting to tea.ClearScreen / flicker (#607).
+func Test_clampViewToViewport_PadsEveryRow(t *testing.T) {
+	const width, height = 30, 3
+	in := strings.Join([]string{
+		strings.Repeat("X", width), // already exactly width
+		"short",                    // must be padded out to width
+		"",                         // blank line must also fill the row
+	}, "\n")
+
+	out := clampViewToViewport(in, width, height)
+	lines := strings.Split(out, "\n")
+	if len(lines) != height {
+		t.Fatalf("want %d lines, got %d", height, len(lines))
+	}
+	for i, line := range lines {
+		if got := cellWidth(line); got != width {
+			t.Fatalf("line %d cellWidth = %d; want %d (every row must fill the viewport so stale glyphs are overwritten)", i, got, width)
+		}
+	}
+}
+
+// Test_ensureExactWidth_PanelAlignment_Emoji locks the #182 contract that
+// PR #1240 broke: ensureExactWidth must equalize panel rows using the SAME
+// width basis lipgloss.JoinHorizontal uses internally — lipgloss.Width — so
+// emoji/keycap rows stay column-aligned after the join.
+//
+// If ensureExactWidth is re-pointed at a different measurement (cellWidth /
+// ansi.StringWidth, as #1240 did) that can disagree with lipgloss.Width on a
+// glyph, JoinHorizontal pads every line to the wider figure, the joined frame
+// overflows the terminal, lines wrap, and Bubble Tea cursor drift / stacked
+// content returns. This test asserts the alignment invariant directly so the
+// swap cannot silently reland.
+func Test_ensureExactWidth_PanelAlignment_Emoji(t *testing.T) {
+	const leftWidth, rightWidth = 18, 14
+
+	// Panel rows mixing plain text, wide emoji and keycap clusters. All are
+	// <= the target width, so the contract under test is "pad every row to
+	// exactly <width> lipgloss cells".
+	left := ensureExactWidth(strings.Join([]string{
+		"session-one",
+		"deploy 🚀",
+		"build #️⃣1",
+		"",
+	}, "\n"), leftWidth)
+	right := ensureExactWidth(strings.Join([]string{
+		"PREVIEW ✅",
+		"ok 1️⃣2️⃣3️⃣",
+		"idle",
+		"done",
+	}, "\n"), rightWidth)
+
+	// Contract 1: each equalized row measures exactly <width> by lipgloss.Width
+	// (the JoinHorizontal basis). A width basis that disagrees with lipgloss on
+	// any glyph would break this — which is precisely the assumption #182
+	// forbids relying on.
+	for _, p := range []struct {
+		name  string
+		body  string
+		width int
+	}{{"left", left, leftWidth}, {"right", right, rightWidth}} {
+		for i, line := range strings.Split(p.body, "\n") {
+			if got := lipgloss.Width(line); got != p.width {
+				t.Fatalf("%s row %d lipgloss.Width = %d; want %d — JoinHorizontal will misalign", p.name, i, got, p.width)
+			}
+		}
+	}
+
+	// Contract 2: the joined frame is rectangular — every visual row has the
+	// same lipgloss.Width and never exceeds leftWidth + sep + rightWidth (an
+	// overflow would wrap and reintroduce the scroll-drift artifact).
+	sep := " │ "
+	rows := strings.Split(lipgloss.JoinHorizontal(lipgloss.Top, left, sep, right), "\n")
+	wantWidth := leftWidth + lipgloss.Width(sep) + rightWidth
+	for i, r := range rows {
+		if got := lipgloss.Width(r); got != wantWidth {
+			t.Fatalf("joined row %d width = %d; want %d — panels not aligned (overflow ⇒ wrap ⇒ scroll drift)", i, got, wantWidth)
+		}
 	}
 }


### PR DESCRIPTION
## What

Pad every final-frame row to full terminal cell width in `clampViewToViewport` so incremental redraw overwrites stale trailing glyphs when a shorter line replaces a longer one on session-list scroll — the iTerm2 **ghost-line** artifact (#607 row-offset drift class) — without `tea.ClearScreen` / flicker.

**Supersedes #1240.**

## Why not #1240 as-is

#1240 achieves the same visual fix but also silently re-points `ensureExactWidth` from `lipgloss.Width` to `cellWidth`/`ansi.StringWidth`. That **violates the JoinHorizontal consistency requirement** established by commit `5b28efd0` (#182):

> `ensureExactWidth` must measure with the **same** function `lipgloss.JoinHorizontal` uses internally (`lipgloss.Width`). If the two disagree by even one cell, JoinHorizontal over-pads every line to the wider figure, the joined frame exceeds terminal width, lines wrap, and Bubble Tea loses cursor tracking — producing duplicated / stacked content (the original scroll-artifact bug).

Re-pointing the pre-join equalizer at a different basis reintroduces panel-misalignment risk with emoji/keycaps. The truncation paths also genuinely diverge: `lipgloss.MaxWidth` and `cellTruncate` return different strings for keycap clusters.

## This PR

- **`ensureExactWidth` is left ENTIRELY unchanged** — stays on `lipgloss.Width`, preserving the #182 contract.
- The ghost-line padding clamp lives **only** in `clampViewToViewport`, which runs **after** `JoinHorizontal`. That function is a true terminal-cell safety net, so it correctly stays on `cellWidth` — the same basis it already used for keycap-aware truncation (#937). New `fitCellWidth` helper does truncate-or-pad on that basis.

## Tests

- `Test_clampViewToViewport_PadsEveryRow` — every row fills the viewport width (pads short lines, not just truncates long ones).
- `Test_ensureExactWidth_PanelAlignment_Emoji` — locks the #182 contract: emoji/keycap panel rows stay column-aligned through `JoinHorizontal`, so the #1240 measurement swap cannot silently reland.

Full `internal/ui` suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual artifacts that appeared during incremental screen updates with short text lines.
  * Improved handling and alignment of emoji and special character sequences in terminal display.

* **Tests**
  * Added regression tests to verify line padding behavior and panel alignment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->