### PR TITLE
fix(auth): clean-symlink credentials (drop mtime-promote) + keep-warm refresh daemon — subscription-safe multi-session (no API key)

### DIFF
--- a/cmd/agent-deck/creds_refresh_cmd.go
+++ b/cmd/agent-deck/creds_refresh_cmd.go
@@ -1,0 +1,131 @@
+// Package main — `agent-deck creds-refresh` subcommand.
+//
+// The keep-warm OAuth refresh daemon (Part B of the recurring "/login" outage
+// fix). It keeps each profile's canonical `.credentials.json` token fresh so
+// the N symlinked worker sessions never hit an expired access token and never
+// race Anthropic's single-use rotating refresh token. See the package doc in
+// internal/credrefresh and /tmp/oauth-fix/SUBSCRIPTION-FIX.md.
+//
+// Subscription-safe: it uses the profile's existing OAuth refresh token and
+// clientId — NO API key, no per-token billing. It exchanges the refresh token
+// at the OAuth /token endpoint and atomically rewrites canonical under the same
+// proper-lockfile Claude uses, so a running session and the daemon never
+// refresh at the same instant.
+//
+// Usage:
+//
+//	agent-deck creds-refresh --once                 # single pass, exit (cron-friendly)
+//	agent-deck creds-refresh                         # run forever (systemd --user)
+//	agent-deck creds-refresh --config-dir ~/.claude --config-dir ~/.claude-work
+//	agent-deck creds-refresh --interval 25m --threshold 20m
+//
+// Default config dirs (when none given): ~/.claude and ~/.claude-work, whichever
+// has a .credentials.json present.
+//
+// NOTE: not started automatically anywhere. Enable it deliberately via the
+// systemd --user unit in scripts/systemd/ (see that file's header).
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/credrefresh"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// stringSliceFlag collects a repeatable string flag (--config-dir a --config-dir b).
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string { return strings.Join(*s, ",") }
+func (s *stringSliceFlag) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+func handleCredsRefresh(args []string) {
+	fs := flag.NewFlagSet("creds-refresh", flag.ExitOnError)
+	once := fs.Bool("once", false, "run a single refresh pass and exit (cron-friendly)")
+	interval := fs.Duration("interval", credrefresh.DefaultInterval, "refresh cadence when running as a daemon")
+	threshold := fs.Duration("threshold", credrefresh.DefaultThreshold, "refresh when the access token expires within this window")
+	endpoint := fs.String("endpoint", credrefresh.DefaultTokenEndpoint, "OAuth token endpoint (override for testing only)")
+	var configDirs stringSliceFlag
+	fs.Var(&configDirs, "config-dir", "profile config dir to keep warm (repeatable); defaults to ~/.claude and ~/.claude-work")
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	dirs := resolveCredConfigDirs(configDirs)
+	if len(dirs) == 0 {
+		fmt.Fprintln(os.Stderr, "creds-refresh: no profile config dir with a .credentials.json found; pass --config-dir explicitly")
+		os.Exit(1)
+	}
+
+	cfg := credrefresh.DaemonConfig{
+		ConfigDirs: dirs,
+		Interval:   *interval,
+		Refresh: credrefresh.RefreshConfig{
+			TokenEndpoint: *endpoint,
+			Threshold:     *threshold,
+		},
+		OnResult: logCredsRefreshResult,
+	}
+
+	if *once {
+		// Single pass: a tick with an already-cancelled context returns after
+		// the immediate refresh.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		credrefresh.Run(ctx, cfg)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "creds-refresh: keeping %d profile(s) warm every %s (threshold %s)\n", len(dirs), *interval, *threshold)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	credrefresh.Run(ctx, cfg)
+}
+
+// resolveCredConfigDirs expands the explicit --config-dir flags, or falls back
+// to the standard dual-profile pair, keeping only dirs that actually hold a
+// .credentials.json (so a single-profile host doesn't error on the other).
+func resolveCredConfigDirs(explicit stringSliceFlag) []string {
+	candidates := explicit
+	if len(candidates) == 0 {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			candidates = stringSliceFlag{
+				filepath.Join(home, ".claude"),
+				filepath.Join(home, ".claude-work"),
+			}
+		}
+	}
+	out := make([]string, 0, len(candidates))
+	for _, d := range candidates {
+		dir := session.ExpandPath(d)
+		if _, err := os.Stat(credrefresh.CanonicalCredPath(dir)); err == nil {
+			out = append(out, dir)
+		}
+	}
+	return out
+}
+
+func logCredsRefreshResult(credPath string, res credrefresh.RefreshResult, err error) {
+	ts := time.Now().Format(time.RFC3339)
+	switch {
+	case err != nil:
+		fmt.Fprintf(os.Stderr, "%s creds-refresh ERROR %s: %v\n", ts, credPath, err)
+	case res.Refreshed:
+		fmt.Fprintf(os.Stderr, "%s creds-refresh OK %s rotated; next expiry %s\n", ts, credPath, res.ExpiresAt.Format(time.RFC3339))
+	default:
+		fmt.Fprintf(os.Stderr, "%s creds-refresh skip %s (%s)\n", ts, credPath, res.Reason)
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -347,6 +347,9 @@ func main() {
 		case "feedback":
 			handleFeedback(args[1:])
 			return
+		case "creds-refresh":
+			handleCredsRefresh(args[1:])
+			return
 		case "debug-dump":
 			handleDebugDump()
 			return

--- a/internal/credrefresh/daemon.go
+++ b/internal/credrefresh/daemon.go
@@ -1,0 +1,67 @@
+package credrefresh
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+)
+
+// credentialsFileName is the profile's OAuth credentials file.
+const credentialsFileName = ".credentials.json"
+
+// CanonicalCredPath returns the canonical credentials path for a profile config
+// dir (e.g. ~/.claude → ~/.claude/.credentials.json).
+func CanonicalCredPath(configDir string) string {
+	return filepath.Join(configDir, credentialsFileName)
+}
+
+// DaemonConfig configures the keep-warm refresh loop.
+type DaemonConfig struct {
+	// ConfigDirs are the profile config dirs to keep warm (one per profile,
+	// e.g. ~/.claude and ~/.claude-work). The canonical credentials path is
+	// derived from each.
+	ConfigDirs []string
+	// Interval is the tick cadence. Defaults to DefaultInterval.
+	Interval time.Duration
+	// Refresh is the per-attempt config (endpoint, client, threshold, clock).
+	Refresh RefreshConfig
+	// OnResult, if set, is called after every refresh attempt with the
+	// canonical path, result, and error. Used for logging.
+	OnResult func(credPath string, res RefreshResult, err error)
+}
+
+func (c DaemonConfig) interval() time.Duration {
+	if c.Interval > 0 {
+		return c.Interval
+	}
+	return DefaultInterval
+}
+
+// Run keeps the canonical credentials warm until ctx is cancelled. It refreshes
+// immediately on startup (so a host that woke past expiry is healed at once),
+// then on every Interval tick. Each profile is refreshed independently; one
+// profile's error never blocks another. Run blocks until ctx is done.
+func Run(ctx context.Context, cfg DaemonConfig) {
+	tick := func() {
+		for _, dir := range cfg.ConfigDirs {
+			credPath := CanonicalCredPath(dir)
+			res, err := RefreshIfNeeded(credPath, cfg.Refresh)
+			if cfg.OnResult != nil {
+				cfg.OnResult(credPath, res, err)
+			}
+		}
+	}
+
+	tick() // immediate
+
+	ticker := time.NewTicker(cfg.interval())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tick()
+		}
+	}
+}

--- a/internal/credrefresh/daemon_test.go
+++ b/internal/credrefresh/daemon_test.go
@@ -63,8 +63,8 @@ func TestRun_RefreshesImmediatelyThenStopsOnCancel(t *testing.T) {
 		t.Fatal("Run did not return after context cancel")
 	}
 
-	if len(*calls) < 1 {
-		t.Fatalf("expected at least one token request from the immediate tick; got %d", len(*calls))
+	if calls.len() < 1 {
+		t.Fatalf("expected at least one token request from the immediate tick; got %d", calls.len())
 	}
 	if !results[0].Refreshed {
 		t.Fatalf("immediate tick should have refreshed the near-expiry token")

--- a/internal/credrefresh/daemon_test.go
+++ b/internal/credrefresh/daemon_test.go
@@ -1,0 +1,81 @@
+package credrefresh
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Run must perform an immediate refresh on startup (not wait a full interval),
+// then stop cleanly when the context is cancelled.
+func TestRun_RefreshesImmediatelyThenStopsOnCancel(t *testing.T) {
+	now := fixedNow()
+	configDir := t.TempDir()
+	credPath := filepath.Join(configDir, ".credentials.json")
+	writeCreds(t, credPath, map[string]any{
+		"accessToken": "old", "refreshToken": "rt", "clientId": "c",
+		"expiresAt": float64(now().Add(time.Minute).UnixMilli()), // near expiry
+	}, nil)
+
+	srv, calls := mockTokenServer(t, "new", "new-rt", 3600)
+
+	var mu sync.Mutex
+	var results []RefreshResult
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		Run(ctx, DaemonConfig{
+			ConfigDirs: []string{configDir},
+			Interval:   time.Hour, // long — only the immediate tick should fire
+			Refresh:    RefreshConfig{TokenEndpoint: srv.URL, HTTPClient: srv.Client(), Threshold: 20 * time.Minute, Now: now},
+			OnResult: func(_ string, r RefreshResult, _ error) {
+				mu.Lock()
+				results = append(results, r)
+				mu.Unlock()
+			},
+		})
+		close(done)
+	}()
+
+	// Wait for the immediate refresh, then cancel.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		n := len(results)
+		mu.Unlock()
+		if n >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			t.Fatal("Run did not perform an immediate refresh within 2s")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+
+	if len(*calls) < 1 {
+		t.Fatalf("expected at least one token request from the immediate tick; got %d", len(*calls))
+	}
+	if !results[0].Refreshed {
+		t.Fatalf("immediate tick should have refreshed the near-expiry token")
+	}
+}
+
+// CanonicalCredPath joins a config dir with the credentials file name.
+func TestCanonicalCredPath(t *testing.T) {
+	got := CanonicalCredPath("/home/x/.claude")
+	want := filepath.Join("/home/x/.claude", ".credentials.json")
+	if got != want {
+		t.Fatalf("CanonicalCredPath = %q; want %q", got, want)
+	}
+}

--- a/internal/credrefresh/lock.go
+++ b/internal/credrefresh/lock.go
@@ -7,6 +7,27 @@ import (
 	"time"
 )
 
+// claudeLockPath returns the exact lockfile path Claude Code locks on its
+// OAuth-refresh path, so the daemon serializes against Claude's own writes.
+//
+// Verified in the shipped binary (cli.js): the refresh path calls
+// proper-lockfile's lock() with the CONFIG_DIR (the dir holding
+// .credentials.json), with no options. proper-lockfile resolves realpath() of
+// its argument (realpath:true by default) and appends ".lock", so the lock dir
+// is `realpath(CONFIG_DIR)+".lock"` — a SIBLING of the profile dir
+// (e.g. ~/.claude.lock), NOT ~/.claude/.credentials.json.lock.
+//
+// credPath is the credentials FILE path; its parent dir is the CONFIG_DIR.
+// EvalSymlinks resolves the dir's realpath (the dir always exists here).
+func claudeLockPath(credPath string) (string, error) {
+	configDir := filepath.Dir(credPath)
+	resolved, err := filepath.EvalSymlinks(configDir)
+	if err != nil {
+		return "", err
+	}
+	return resolved + ".lock", nil
+}
+
 // acquireLock takes a proper-lockfile-compatible lock so the refresh daemon
 // serializes against Claude Code's own credential writes. proper-lockfile (the
 // npm package Claude uses) represents a held lock as a DIRECTORY at

--- a/internal/credrefresh/lock.go
+++ b/internal/credrefresh/lock.go
@@ -1,0 +1,80 @@
+package credrefresh
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// acquireLock takes a proper-lockfile-compatible lock so the refresh daemon
+// serializes against Claude Code's own credential writes. proper-lockfile (the
+// npm package Claude uses) represents a held lock as a DIRECTORY at
+// `<file>.lock`: mkdir is atomic, so the first mkdir wins. A lock whose mtime
+// is older than lockStaleThreshold is considered abandoned (crashed holder)
+// and stolen, matching proper-lockfile's staleness recovery.
+//
+// Returns a release func that removes the lock dir. Blocks up to timeout
+// against a fresh, actively-held lock, then returns an error rather than
+// stealing it — a fresh lock means Claude is mid-refresh and we must not race.
+func acquireLock(lockPath string, timeout time.Duration) (func(), error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		err := os.Mkdir(lockPath, 0o700)
+		if err == nil {
+			// Stamp mtime now so concurrent stealers see us as fresh.
+			now := time.Now()
+			_ = os.Chtimes(lockPath, now, now)
+			return func() { _ = os.Remove(lockPath) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, fmt.Errorf("mkdir lock %s: %w", lockPath, err)
+		}
+
+		// Lock exists — steal it iff it is stale (abandoned by a crashed holder).
+		if fi, statErr := os.Stat(lockPath); statErr == nil {
+			if time.Since(fi.ModTime()) > lockStaleThreshold {
+				// Best-effort steal; if another stealer beat us the next
+				// mkdir simply contends again.
+				_ = os.Remove(lockPath)
+				continue
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("lock %s held and fresh; timed out after %s", lockPath, timeout)
+		}
+		time.Sleep(lockRetryInterval)
+	}
+}
+
+// atomicWriteFile writes data to path via a temp file in the same directory
+// then renames atomically. rename(2) does not follow the destination, so a
+// concurrent reader never sees a torn file and a symlink at path is replaced
+// rather than dereferenced. The temp file is created with perm so the secret
+// is never briefly world-readable.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-"+filepath.Base(path)+"-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if _, statErr := os.Stat(tmpPath); statErr == nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/credrefresh/refresh.go
+++ b/internal/credrefresh/refresh.go
@@ -134,15 +134,25 @@ type tokenResponse struct {
 // half-write the only token. Unknown fields (subscriptionType, rateLimitTier,
 // and any extra keys) are preserved verbatim across the round-trip.
 func RefreshIfNeeded(credPath string, cfg RefreshConfig) (RefreshResult, error) {
-	// Resolve symlinks so the lock path matches the one Claude derives via
-	// realpath() — symlinked scratch creds and the canonical file then share
-	// a single lock.
+	// Resolve symlinks so we read/write the canonical file even when credPath
+	// is a symlink to it.
 	realPath := credPath
 	if rp, err := filepath.EvalSymlinks(credPath); err == nil {
 		realPath = rp
 	}
 
-	release, err := acquireLock(realPath+".lock", httpTimeout+5*time.Second)
+	// Lock the SAME path Claude Code locks on its OAuth-refresh path so the
+	// daemon and any running session never refresh at the same instant.
+	// Verified in the shipped binary: the refresh path calls
+	// proper-lockfile's lock() with the CONFIG_DIR (Y7()), NOT the
+	// credentials file — so the lock dir is realpath(CONFIG_DIR)+".lock"
+	// (e.g. ~/.claude.lock), a sibling of the profile dir. Matching it
+	// exactly is what makes the cross-process serialization real.
+	lockPath, err := claudeLockPath(credPath)
+	if err != nil {
+		return RefreshResult{}, fmt.Errorf("resolve credentials lock path: %w", err)
+	}
+	release, err := acquireLock(lockPath, httpTimeout+5*time.Second)
 	if err != nil {
 		return RefreshResult{}, fmt.Errorf("acquire credentials lock: %w", err)
 	}

--- a/internal/credrefresh/refresh.go
+++ b/internal/credrefresh/refresh.go
@@ -1,0 +1,283 @@
+// Package credrefresh is the subscription-safe keep-warm OAuth refresh daemon
+// (Part B of the recurring "/login" outage fix). It reads the single canonical
+// `.credentials.json` for a profile, and when the access token is within a
+// short window of expiry, exchanges the rotating refresh token for a fresh one
+// at Anthropic's OAuth token endpoint and atomically writes the result back.
+//
+// Why a daemon at all. Claude Code stores OAuth credentials in
+// `$CLAUDE_CONFIG_DIR/.credentials.json` and re-reads that file from disk on
+// access-token expiry (confirmed by disassembling v2.1.159 — the Linux
+// plaintext store has no in-memory cache and watches the file mtime). When N
+// agent-deck worker sessions all symlink their scratch `.credentials.json` to
+// ONE canonical file, Claude's cross-process lock — keyed on
+// `realpath(...)` — collapses to a single lock, so the workers serialize their
+// refreshes instead of racing. A refresh daemon that keeps the canonical token
+// warm removes even the brief lock-contention storm and the cold-start case
+// where the whole host was asleep past expiry. No API key, no per-worker
+// restart: workers pick up the new token on their next disk read. See
+// /tmp/oauth-fix/SUBSCRIPTION-FIX.md and the bug_oauth_multisession_rotation
+// root-cause memo.
+//
+// This package NEVER hits the real endpoint in tests and NEVER hardcodes a
+// token: the endpoint and HTTP client are injectable, and tests pass a mock.
+package credrefresh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultTokenEndpoint is Claude Code's OAuth token endpoint (the
+	// `claudeAiOauth` subscription flow), read from the shipped binary.
+	// #nosec G101 -- this is a public OAuth endpoint URL, not a credential.
+	DefaultTokenEndpoint = "https://platform.claude.com/v1/oauth/token"
+
+	// DefaultThreshold is the early-refresh window: refresh when the access
+	// token expires within this much time. Access tokens live ~1h.
+	DefaultThreshold = 20 * time.Minute
+
+	// DefaultInterval is the recommended daemon cadence. Shorter than the
+	// ~1h token lifetime so a single missed tick never lets the token lapse.
+	DefaultInterval = 25 * time.Minute
+
+	// oauthKey is the top-level object holding the subscription credentials.
+	oauthKey = "claudeAiOauth"
+
+	// httpTimeout bounds a single token request (Claude uses 10s).
+	httpTimeout = 10 * time.Second
+
+	// lockStaleThreshold matches proper-lockfile semantics: a lock whose
+	// directory mtime is older than this is treated as abandoned and stolen.
+	// Generous relative to our sub-second-to-10s hold so we never steal a
+	// lock another writer is actively holding.
+	lockStaleThreshold = 30 * time.Second
+
+	// lockRetryInterval is how often acquireLock retries a held lock.
+	lockRetryInterval = 50 * time.Millisecond
+)
+
+// RefreshConfig configures a single refresh attempt. All fields are optional;
+// zero values fall back to the package defaults.
+type RefreshConfig struct {
+	// TokenEndpoint is the OAuth /token URL. Defaults to DefaultTokenEndpoint.
+	TokenEndpoint string
+	// HTTPClient performs the token request. Defaults to a client with httpTimeout.
+	HTTPClient *http.Client
+	// Threshold is the early-refresh window. Defaults to DefaultThreshold.
+	Threshold time.Duration
+	// Now is an injectable clock for the expiry decision. Defaults to time.Now.
+	Now func() time.Time
+}
+
+// RefreshResult reports the outcome of a single RefreshIfNeeded call.
+type RefreshResult struct {
+	// Refreshed is true iff a rotation happened and canonical was rewritten.
+	Refreshed bool
+	// Reason explains a no-op (e.g. "token not near expiry").
+	Reason string
+	// ExpiresAt is the access-token expiry after the call (rotated or current).
+	ExpiresAt time.Time
+}
+
+func (c RefreshConfig) endpoint() string {
+	if c.TokenEndpoint != "" {
+		return c.TokenEndpoint
+	}
+	return DefaultTokenEndpoint
+}
+
+func (c RefreshConfig) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return &http.Client{Timeout: httpTimeout}
+}
+
+func (c RefreshConfig) threshold() time.Duration {
+	if c.Threshold > 0 {
+		return c.Threshold
+	}
+	return DefaultThreshold
+}
+
+func (c RefreshConfig) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+// tokenResponse is the subset of the OAuth /token response we consume.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"` // seconds
+}
+
+// RefreshIfNeeded reads the canonical credentials at credPath, and if the
+// access token expires within cfg.Threshold, exchanges the rotating refresh
+// token for a fresh one and atomically rewrites canonical (temp+rename, 0600).
+//
+// It serializes against Claude's own refreshes by holding a
+// proper-lockfile-compatible lock at `realpath(credPath)+".lock"` for the
+// duration of the read-rotate-write. On any endpoint error the canonical file
+// is left byte-for-byte unchanged — a transient 4xx/5xx must never corrupt or
+// half-write the only token. Unknown fields (subscriptionType, rateLimitTier,
+// and any extra keys) are preserved verbatim across the round-trip.
+func RefreshIfNeeded(credPath string, cfg RefreshConfig) (RefreshResult, error) {
+	// Resolve symlinks so the lock path matches the one Claude derives via
+	// realpath() — symlinked scratch creds and the canonical file then share
+	// a single lock.
+	realPath := credPath
+	if rp, err := filepath.EvalSymlinks(credPath); err == nil {
+		realPath = rp
+	}
+
+	release, err := acquireLock(realPath+".lock", httpTimeout+5*time.Second)
+	if err != nil {
+		return RefreshResult{}, fmt.Errorf("acquire credentials lock: %w", err)
+	}
+	defer release()
+
+	doc, oauth, err := readCredentials(realPath)
+	if err != nil {
+		return RefreshResult{}, err
+	}
+
+	expiresAt := time.UnixMilli(jsonInt64(oauth["expiresAt"]))
+	if expiresAt.Sub(cfg.now()) > cfg.threshold() {
+		return RefreshResult{Refreshed: false, Reason: "token not near expiry", ExpiresAt: expiresAt}, nil
+	}
+
+	refreshToken := jsonString(oauth["refreshToken"])
+	if refreshToken == "" {
+		return RefreshResult{}, fmt.Errorf("no refresh token in %s", realPath)
+	}
+
+	tok, err := requestRefresh(cfg, refreshToken, jsonString(oauth["clientId"]), jsonScopes(oauth["scopes"]))
+	if err != nil {
+		// Canonical untouched on failure.
+		return RefreshResult{Refreshed: false, ExpiresAt: expiresAt}, err
+	}
+
+	newExpiry := cfg.now().Add(time.Duration(tok.ExpiresIn) * time.Second)
+	oauth["accessToken"] = tok.AccessToken
+	oauth["refreshToken"] = tok.RefreshToken
+	oauth["expiresAt"] = newExpiry.UnixMilli()
+	doc[oauthKey] = oauth
+
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return RefreshResult{}, fmt.Errorf("marshal refreshed credentials: %w", err)
+	}
+	if err := atomicWriteFile(realPath, out, 0o600); err != nil {
+		return RefreshResult{}, fmt.Errorf("write refreshed credentials: %w", err)
+	}
+	return RefreshResult{Refreshed: true, ExpiresAt: newExpiry}, nil
+}
+
+// readCredentials parses the credentials file, returning the full document
+// (for round-trip preservation of unknown keys) and the claudeAiOauth object.
+func readCredentials(path string) (map[string]any, map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read credentials %s: %w", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, nil, fmt.Errorf("parse credentials %s: %w", path, err)
+	}
+	oauth, ok := doc[oauthKey].(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("%s missing %q object", path, oauthKey)
+	}
+	return doc, oauth, nil
+}
+
+// requestRefresh POSTs the rotating refresh token to the OAuth token endpoint
+// and returns the rotated tokens. It mirrors Claude's subscription refresh:
+// form-urlencoded grant_type/refresh_token/client_id/scope.
+func requestRefresh(cfg RefreshConfig, refreshToken, clientID string, scopes []string) (tokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	if clientID != "" {
+		form.Set("client_id", clientID)
+	}
+	if len(scopes) > 0 {
+		form.Set("scope", strings.Join(scopes, " "))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.endpoint(), strings.NewReader(form.Encode()))
+	if err != nil {
+		return tokenResponse{}, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := cfg.httpClient().Do(req)
+	if err != nil {
+		return tokenResponse{}, fmt.Errorf("token request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return tokenResponse{}, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var tok tokenResponse
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return tokenResponse{}, fmt.Errorf("parse token response: %w", err)
+	}
+	if tok.AccessToken == "" || tok.RefreshToken == "" {
+		return tokenResponse{}, fmt.Errorf("token response missing access_token or refresh_token")
+	}
+	return tok, nil
+}
+
+// jsonString coerces a decoded JSON value to a string ("" if absent/wrong type).
+func jsonString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+// jsonInt64 coerces a decoded JSON number (float64 from encoding/json) to int64.
+func jsonInt64(v any) int64 {
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case json.Number:
+		i, _ := n.Int64()
+		return i
+	}
+	return 0
+}
+
+// jsonScopes coerces a decoded JSON array of strings to []string.
+func jsonScopes(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, e := range arr {
+		if s, ok := e.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/credrefresh/refresh_test.go
+++ b/internal/credrefresh/refresh_test.go
@@ -13,9 +13,36 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
+
+// callRecorder collects token-endpoint requests under a mutex. The httptest
+// server invokes its handler in a separate goroutine, so the slice append must
+// be synchronized against the test goroutine's reads (else -race flags it).
+type callRecorder struct {
+	mu    sync.Mutex
+	calls []map[string]string
+}
+
+func (r *callRecorder) add(c map[string]string) {
+	r.mu.Lock()
+	r.calls = append(r.calls, c)
+	r.mu.Unlock()
+}
+
+func (r *callRecorder) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+func (r *callRecorder) at(i int) map[string]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls[i]
+}
 
 // writeCreds writes a credentials document with a claudeAiOauth block plus an
 // arbitrary extra top-level key, to prove unknown fields survive a round-trip.
@@ -55,15 +82,15 @@ func readOAuth(t *testing.T, path string) map[string]any {
 // mockTokenServer returns an httptest server that rotates the token, recording
 // every request it received so tests can assert the request shape (and that it
 // was or was not called).
-func mockTokenServer(t *testing.T, newAccess, newRefresh string, expiresIn int) (*httptest.Server, *[]map[string]string) {
+func mockTokenServer(t *testing.T, newAccess, newRefresh string, expiresIn int) (*httptest.Server, *callRecorder) {
 	t.Helper()
-	var calls []map[string]string
+	rec := &callRecorder{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			http.Error(w, "bad form", http.StatusBadRequest)
 			return
 		}
-		calls = append(calls, map[string]string{
+		rec.add(map[string]string{
 			"grant_type":    r.Form.Get("grant_type"),
 			"refresh_token": r.Form.Get("refresh_token"),
 			"client_id":     r.Form.Get("client_id"),
@@ -76,7 +103,7 @@ func mockTokenServer(t *testing.T, newAccess, newRefresh string, expiresIn int) 
 		})
 	}))
 	t.Cleanup(srv.Close)
-	return srv, &calls
+	return srv, rec
 }
 
 func fixedNow() func() time.Time {
@@ -113,10 +140,10 @@ func TestRefreshIfNeeded_RefreshesWhenNearExpiry(t *testing.T) {
 	}
 
 	// Endpoint was called exactly once with the correct grant + rotating token.
-	if len(*calls) != 1 {
-		t.Fatalf("expected exactly 1 token request; got %d", len(*calls))
+	if calls.len() != 1 {
+		t.Fatalf("expected exactly 1 token request; got %d", calls.len())
 	}
-	c := (*calls)[0]
+	c := calls.at(0)
 	if c["grant_type"] != "refresh_token" {
 		t.Fatalf("grant_type = %q; want refresh_token", c["grant_type"])
 	}
@@ -174,8 +201,8 @@ func TestRefreshIfNeeded_SkipsWhenFarFromExpiry(t *testing.T) {
 	if res.Refreshed {
 		t.Fatal("expected Refreshed=false when far from expiry")
 	}
-	if len(*calls) != 0 {
-		t.Fatalf("token endpoint must NOT be called when far from expiry; got %d calls", len(*calls))
+	if calls.len() != 0 {
+		t.Fatalf("token endpoint must NOT be called when far from expiry; got %d calls", calls.len())
 	}
 	after, err := os.ReadFile(credPath)
 	if err != nil {
@@ -279,10 +306,11 @@ func TestRefreshIfNeeded_EndpointErrorLeavesCanonicalUntouched(t *testing.T) {
 }
 
 // (6) The proper-lockfile-compatible lock is released after a successful
-// refresh (no leaked lock dir at realpath(cred)+".lock").
+// refresh — no leaked lock dir at Claude's lock path (the CONFIG_DIR sibling).
 func TestRefreshIfNeeded_ReleasesLock(t *testing.T) {
 	now := fixedNow()
-	credPath := filepath.Join(t.TempDir(), ".credentials.json")
+	configDir := t.TempDir()
+	credPath := filepath.Join(configDir, ".credentials.json")
 	writeCreds(t, credPath, map[string]any{
 		"accessToken": "old", "refreshToken": "rt", "clientId": "c",
 		"expiresAt": float64(now().Add(time.Minute).UnixMilli()),
@@ -293,8 +321,40 @@ func TestRefreshIfNeeded_ReleasesLock(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("RefreshIfNeeded: %v", err)
 	}
-	if _, err := os.Stat(credPath + ".lock"); !os.IsNotExist(err) {
-		t.Fatalf("lock dir must be released after refresh; stat err = %v", err)
+	lockPath, err := claudeLockPath(credPath)
+	if err != nil {
+		t.Fatalf("claudeLockPath: %v", err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock dir %s must be released after refresh; stat err = %v", lockPath, err)
+	}
+}
+
+// (8) BLOCKER regression: the daemon must lock the SAME path Claude locks on its
+// OAuth-refresh path. Verified in the shipped binary: Claude calls
+// proper-lockfile lock() with the CONFIG_DIR, so the lock dir is
+// realpath(CONFIG_DIR)+".lock" — a SIBLING of the profile dir, NOT
+// <profile>/.credentials.json.lock. A mismatch means the daemon and a running
+// session could refresh simultaneously and burn the rotating token.
+func TestClaudeLockPath_IsConfigDirSibling(t *testing.T) {
+	configDir := t.TempDir()
+	credPath := filepath.Join(configDir, ".credentials.json")
+
+	got, err := claudeLockPath(credPath)
+	if err != nil {
+		t.Fatalf("claudeLockPath: %v", err)
+	}
+	resolvedDir, err := filepath.EvalSymlinks(configDir)
+	if err != nil {
+		t.Fatalf("evalsymlinks: %v", err)
+	}
+	want := resolvedDir + ".lock"
+	if got != want {
+		t.Fatalf("lock path = %q; want CONFIG_DIR sibling %q", got, want)
+	}
+	// Explicitly NOT the credentials-file lock.
+	if got == credPath+".lock" {
+		t.Fatalf("lock path must NOT be the credentials-file lock (%s); Claude locks the CONFIG_DIR", got)
 	}
 }
 

--- a/internal/credrefresh/refresh_test.go
+++ b/internal/credrefresh/refresh_test.go
@@ -1,0 +1,329 @@
+// Package credrefresh tests — the subscription-safe keep-warm OAuth refresh
+// daemon (Part B of the OAuth /login outage fix).
+//
+// These tests NEVER hit the real Anthropic endpoint and NEVER use a real
+// refresh token — every case injects an httptest mock and synthetic tokens.
+// Burning the real single-use rotating refresh token in a test would log the
+// host out, which is the exact outage we are preventing.
+package credrefresh
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeCreds writes a credentials document with a claudeAiOauth block plus an
+// arbitrary extra top-level key, to prove unknown fields survive a round-trip.
+func writeCreds(t *testing.T, path string, oauth map[string]any, extraTopLevel map[string]any) {
+	t.Helper()
+	doc := map[string]any{"claudeAiOauth": oauth}
+	for k, v := range extraTopLevel {
+		doc[k] = v
+	}
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal creds: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write creds: %v", err)
+	}
+}
+
+// readOAuth reads the claudeAiOauth block back out of a credentials file.
+func readOAuth(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read creds: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal creds: %v", err)
+	}
+	oauth, ok := doc["claudeAiOauth"].(map[string]any)
+	if !ok {
+		t.Fatalf("claudeAiOauth missing or wrong shape in %s", path)
+	}
+	return oauth
+}
+
+// mockTokenServer returns an httptest server that rotates the token, recording
+// every request it received so tests can assert the request shape (and that it
+// was or was not called).
+func mockTokenServer(t *testing.T, newAccess, newRefresh string, expiresIn int) (*httptest.Server, *[]map[string]string) {
+	t.Helper()
+	var calls []map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "bad form", http.StatusBadRequest)
+			return
+		}
+		calls = append(calls, map[string]string{
+			"grant_type":    r.Form.Get("grant_type"),
+			"refresh_token": r.Form.Get("refresh_token"),
+			"client_id":     r.Form.Get("client_id"),
+			"scope":         r.Form.Get("scope"),
+		})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  newAccess,
+			"refresh_token": newRefresh,
+			"expires_in":    expiresIn,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func fixedNow() func() time.Time {
+	t := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	return func() time.Time { return t }
+}
+
+// (1) Near expiry: the daemon POSTs the refresh token and atomically rewrites
+// canonical with the rotated tokens and a recomputed expiresAt.
+func TestRefreshIfNeeded_RefreshesWhenNearExpiry(t *testing.T) {
+	now := fixedNow()
+	credPath := filepath.Join(t.TempDir(), ".credentials.json")
+	writeCreds(t, credPath, map[string]any{
+		"accessToken":  "old-access",
+		"refreshToken": "old-refresh",
+		"clientId":     "client-xyz",
+		"scopes":       []any{"user:inference", "user:profile"},
+		"expiresAt":    float64(now().Add(5 * time.Minute).UnixMilli()), // within window
+	}, nil)
+
+	srv, calls := mockTokenServer(t, "new-access", "new-refresh", 3600)
+
+	res, err := RefreshIfNeeded(credPath, RefreshConfig{
+		TokenEndpoint: srv.URL,
+		HTTPClient:    srv.Client(),
+		Threshold:     20 * time.Minute,
+		Now:           now,
+	})
+	if err != nil {
+		t.Fatalf("RefreshIfNeeded: %v", err)
+	}
+	if !res.Refreshed {
+		t.Fatal("expected Refreshed=true when within threshold")
+	}
+
+	// Endpoint was called exactly once with the correct grant + rotating token.
+	if len(*calls) != 1 {
+		t.Fatalf("expected exactly 1 token request; got %d", len(*calls))
+	}
+	c := (*calls)[0]
+	if c["grant_type"] != "refresh_token" {
+		t.Fatalf("grant_type = %q; want refresh_token", c["grant_type"])
+	}
+	if c["refresh_token"] != "old-refresh" {
+		t.Fatalf("refresh_token = %q; want old-refresh", c["refresh_token"])
+	}
+	if c["client_id"] != "client-xyz" {
+		t.Fatalf("client_id = %q; want client-xyz", c["client_id"])
+	}
+	if c["scope"] != "user:inference user:profile" {
+		t.Fatalf("scope = %q; want space-joined scopes", c["scope"])
+	}
+
+	// Canonical now holds the rotated tokens + recomputed expiry.
+	oauth := readOAuth(t, credPath)
+	if oauth["accessToken"] != "new-access" {
+		t.Fatalf("accessToken = %v; want new-access", oauth["accessToken"])
+	}
+	if oauth["refreshToken"] != "new-refresh" {
+		t.Fatalf("refreshToken = %v; want new-refresh", oauth["refreshToken"])
+	}
+	wantExpiry := float64(now().Add(3600 * time.Second).UnixMilli())
+	if oauth["expiresAt"] != wantExpiry {
+		t.Fatalf("expiresAt = %v; want %v", oauth["expiresAt"], wantExpiry)
+	}
+}
+
+// (2) Far from expiry: no network call, canonical byte-for-byte unchanged.
+func TestRefreshIfNeeded_SkipsWhenFarFromExpiry(t *testing.T) {
+	now := fixedNow()
+	credPath := filepath.Join(t.TempDir(), ".credentials.json")
+	writeCreds(t, credPath, map[string]any{
+		"accessToken":  "still-good",
+		"refreshToken": "rt",
+		"clientId":     "client-xyz",
+		"expiresAt":    float64(now().Add(50 * time.Minute).UnixMilli()), // outside window
+	}, nil)
+
+	before, err := os.ReadFile(credPath)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+
+	srv, calls := mockTokenServer(t, "should-not-be-used", "nope", 3600)
+
+	res, err := RefreshIfNeeded(credPath, RefreshConfig{
+		TokenEndpoint: srv.URL,
+		HTTPClient:    srv.Client(),
+		Threshold:     20 * time.Minute,
+		Now:           now,
+	})
+	if err != nil {
+		t.Fatalf("RefreshIfNeeded: %v", err)
+	}
+	if res.Refreshed {
+		t.Fatal("expected Refreshed=false when far from expiry")
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("token endpoint must NOT be called when far from expiry; got %d calls", len(*calls))
+	}
+	after, err := os.ReadFile(credPath)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("canonical must be untouched when no refresh is due")
+	}
+}
+
+// (3) Unknown fields (subscriptionType, rateLimitTier, extra top-level keys)
+// survive the rotation round-trip.
+func TestRefreshIfNeeded_PreservesUnknownFields(t *testing.T) {
+	now := fixedNow()
+	credPath := filepath.Join(t.TempDir(), ".credentials.json")
+	writeCreds(t, credPath, map[string]any{
+		"accessToken":      "old-access",
+		"refreshToken":     "old-refresh",
+		"clientId":         "client-xyz",
+		"expiresAt":        float64(now().Add(time.Minute).UnixMilli()),
+		"subscriptionType": "pro",
+		"rateLimitTier":    "default",
+	}, map[string]any{"someOtherKey": "keep-me"})
+
+	srv, _ := mockTokenServer(t, "new-access", "new-refresh", 3600)
+	if _, err := RefreshIfNeeded(credPath, RefreshConfig{
+		TokenEndpoint: srv.URL, HTTPClient: srv.Client(), Threshold: 20 * time.Minute, Now: now,
+	}); err != nil {
+		t.Fatalf("RefreshIfNeeded: %v", err)
+	}
+
+	data, _ := os.ReadFile(credPath)
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if doc["someOtherKey"] != "keep-me" {
+		t.Fatalf("top-level unknown field dropped: %v", doc["someOtherKey"])
+	}
+	oauth := doc["claudeAiOauth"].(map[string]any)
+	if oauth["subscriptionType"] != "pro" {
+		t.Fatalf("subscriptionType dropped: %v", oauth["subscriptionType"])
+	}
+	if oauth["rateLimitTier"] != "default" {
+		t.Fatalf("rateLimitTier dropped: %v", oauth["rateLimitTier"])
+	}
+}
+
+// (4) The rewritten canonical keeps 0600 token perms.
+func TestRefreshIfNeeded_PreservesSecurePerms(t *testing.T) {
+	now := fixedNow()
+	credPath := filepath.Join(t.TempDir(), ".credentials.json")
+	writeCreds(t, credPath, map[string]any{
+		"accessToken": "old", "refreshToken": "rt", "clientId": "c",
+		"expiresAt": float64(now().Add(time.Minute).UnixMilli()),
+	}, nil)
+	srv, _ := mockTokenServer(t, "new", "new-rt", 3600)
+	if _, err := RefreshIfNeeded(credPath, RefreshConfig{
+		TokenEndpoint: srv.URL, HTTPClient: srv.Client(), Threshold: 20 * time.Minute, Now: now,
+	}); err != nil {
+		t.Fatalf("RefreshIfNeeded: %v", err)
+	}
+	fi, err := os.Stat(credPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("refreshed canonical must be 0600; got %o", perm)
+	}
+}
+
+// (5) A failing endpoint must leave canonical untouched — never half-write or
+// corrupt the only token on a transient 4xx/5xx.
+func TestRefreshIfNeeded_EndpointErrorLeavesCanonicalUntouched(t *testing.T) {
+	now := fixedNow()
+	credPath := filepath.Join(t.TempDir(), ".credentials.json")
+	writeCreds(t, credPath, map[string]any{
+		"accessToken": "good", "refreshToken": "rt", "clientId": "c",
+		"expiresAt": float64(now().Add(time.Minute).UnixMilli()),
+	}, nil)
+	before, _ := os.ReadFile(credPath)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+
+	res, err := RefreshIfNeeded(credPath, RefreshConfig{
+		TokenEndpoint: srv.URL, HTTPClient: srv.Client(), Threshold: 20 * time.Minute, Now: now,
+	})
+	if err == nil {
+		t.Fatal("expected an error on a 400 from the token endpoint")
+	}
+	if res.Refreshed {
+		t.Fatal("Refreshed must be false on endpoint error")
+	}
+	after, _ := os.ReadFile(credPath)
+	if string(before) != string(after) {
+		t.Fatalf("canonical must be untouched on endpoint error")
+	}
+}
+
+// (6) The proper-lockfile-compatible lock is released after a successful
+// refresh (no leaked lock dir at realpath(cred)+".lock").
+func TestRefreshIfNeeded_ReleasesLock(t *testing.T) {
+	now := fixedNow()
+	credPath := filepath.Join(t.TempDir(), ".credentials.json")
+	writeCreds(t, credPath, map[string]any{
+		"accessToken": "old", "refreshToken": "rt", "clientId": "c",
+		"expiresAt": float64(now().Add(time.Minute).UnixMilli()),
+	}, nil)
+	srv, _ := mockTokenServer(t, "new", "new-rt", 3600)
+	if _, err := RefreshIfNeeded(credPath, RefreshConfig{
+		TokenEndpoint: srv.URL, HTTPClient: srv.Client(), Threshold: 20 * time.Minute, Now: now,
+	}); err != nil {
+		t.Fatalf("RefreshIfNeeded: %v", err)
+	}
+	if _, err := os.Stat(credPath + ".lock"); !os.IsNotExist(err) {
+		t.Fatalf("lock dir must be released after refresh; stat err = %v", err)
+	}
+}
+
+// (7) acquireLock steals a stale lock (older than the stale threshold) but
+// refuses a fresh one within the acquisition timeout.
+func TestAcquireLock_StealsStaleLockRefusesFresh(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, ".credentials.json.lock")
+
+	// Fresh lock held by "another process" → cannot acquire within a short timeout.
+	if err := os.Mkdir(lockPath, 0o700); err != nil {
+		t.Fatalf("seed fresh lock: %v", err)
+	}
+	if release, err := acquireLock(lockPath, 200*time.Millisecond); err == nil {
+		release()
+		t.Fatal("expected acquireLock to time out against a fresh held lock")
+	}
+
+	// Age the lock past the stale threshold → it gets stolen.
+	stale := time.Now().Add(-2 * lockStaleThreshold)
+	if err := os.Chtimes(lockPath, stale, stale); err != nil {
+		t.Fatalf("age lock: %v", err)
+	}
+	release, err := acquireLock(lockPath, 2*time.Second)
+	if err != nil {
+		t.Fatalf("expected to steal a stale lock; got %v", err)
+	}
+	release()
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("lock must be removed after release; stat err = %v", err)
+	}
+}

--- a/internal/session/issue1222_credentials_symlink_reassert_test.go
+++ b/internal/session/issue1222_credentials_symlink_reassert_test.go
@@ -123,52 +123,100 @@ func TestMirrorProfileEntries_CorrectCredentialSymlink_LeftAlone(t *testing.T) {
 	}
 }
 
-// (d) Promote-then-relink: a scratch real-file NEWER than canonical (a fresh
-// in-session /login) must be promoted to canonical FIRST (atomic, 0600
-// preserved), THEN scratch must be re-linked to canonical. This is what makes
-// an in-session login propagate to every other session.
-func TestMirrorProfileEntries_NewerScratchCredentials_PromotedThenRelinked(t *testing.T) {
+// (d) NO-PROMOTE (subscription OAuth fix): a scratch real-file even NEWER than
+// canonical (a diverged in-session /login, or an mtime-bumped stale copy) must
+// be force-replaced with a clean symlink to canonical, and canonical must NEVER
+// be overwritten. Binary disassembly of Claude v2.1.159 showed mtime is not a
+// valid-token signal for single-use rotating refresh tokens, so the old
+// mtime-promote could clobber a good canonical with a stale scratch token and
+// fork a second rotation chain. The single canonical token is the only source
+// of truth; in-session /login must be done in the canonical profile instead.
+func TestMirrorProfileEntries_NewerScratchCredentials_NeverPromoted(t *testing.T) {
 	source := t.TempDir()
 	dest := t.TempDir()
 
-	staleCanonical := `{"token":"old-canonical"}`
-	freshLogin := `{"token":"fresh-in-session-login"}`
+	canonical := `{"token":"canonical-source-of-truth"}`
+	divergedNewer := `{"token":"diverged-in-session-copy"}`
 	now := time.Now()
-	writeCredFile(t, filepath.Join(source, ".credentials.json"), staleCanonical, now.Add(-2*time.Hour))
-	// Scratch real-file is NEWER than canonical → fresh login, promote it.
-	writeCredFile(t, filepath.Join(dest, ".credentials.json"), freshLogin, now)
+	target := filepath.Join(source, ".credentials.json")
+	writeCredFile(t, target, canonical, now.Add(-2*time.Hour))
+	// Scratch real-file is NEWER than canonical — the old code would have
+	// promoted it. The fix must refuse to promote.
+	writeCredFile(t, filepath.Join(dest, ".credentials.json"), divergedNewer, now)
+
+	canonicalStatBefore, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat canonical: %v", err)
+	}
 
 	if err := mirrorProfileEntries(dest, source); err != nil {
 		t.Fatalf("mirrorProfileEntries: %v", err)
 	}
 
-	// Canonical now holds the fresh token (promoted).
-	target := filepath.Join(source, ".credentials.json")
+	// Canonical must be byte-for-byte unchanged — never overwritten by a
+	// newer scratch copy.
 	got, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatalf("read canonical: %v", err)
 	}
-	if string(got) != freshLogin {
-		t.Fatalf("fresh in-session login must be promoted to canonical; got %q want %q", string(got), freshLogin)
+	if string(got) != canonical {
+		t.Fatalf("canonical must NEVER be overwritten by a newer scratch copy; got %q want %q", string(got), canonical)
 	}
-
-	// Canonical keeps 0600 token perms after the atomic promote.
-	fi, err := os.Stat(target)
+	canonicalStatAfter, err := os.Stat(target)
 	if err != nil {
-		t.Fatalf("stat canonical: %v", err)
+		t.Fatalf("stat canonical after: %v", err)
 	}
-	if perm := fi.Mode().Perm(); perm != 0o600 {
-		t.Fatalf("promoted canonical must be 0600; got %o", perm)
+	if !canonicalStatBefore.ModTime().Equal(canonicalStatAfter.ModTime()) {
+		t.Fatalf("canonical mtime changed (%v → %v): it was rewritten", canonicalStatBefore.ModTime(), canonicalStatAfter.ModTime())
 	}
 
-	// Scratch is re-linked to canonical, so it reads the promoted token.
+	// Scratch real-file is replaced by a clean symlink to canonical, so it
+	// now resolves to the single source-of-truth token.
 	assertIsSymlinkTo(t, filepath.Join(dest, ".credentials.json"), target)
 	viaLink, err := os.ReadFile(filepath.Join(dest, ".credentials.json"))
 	if err != nil {
 		t.Fatalf("read scratch via link: %v", err)
 	}
-	if string(viaLink) != freshLogin {
-		t.Fatalf("scratch link must resolve to promoted token; got %q", string(viaLink))
+	if string(viaLink) != canonical {
+		t.Fatalf("scratch link must resolve to canonical token; got %q", string(viaLink))
+	}
+}
+
+// (f) Canonical missing + scratch real-file: with no canonical to point at, the
+// reassert must leave the only token copy in place rather than stranding it
+// behind a dangling symlink (and it must still never write canonical). Once the
+// user logs in to canonical, the next start replaces this with a symlink.
+func TestMirrorProfileEntries_CanonicalMissing_RealFileLeftIntact(t *testing.T) {
+	source := t.TempDir()
+	dest := t.TempDir()
+
+	onlyCopy := `{"token":"stranded-but-only-copy"}`
+	scratchCred := filepath.Join(dest, ".credentials.json")
+	writeCredFile(t, scratchCred, onlyCopy, time.Now())
+	// No canonical credentials in source.
+
+	if err := mirrorProfileEntries(dest, source); err != nil {
+		t.Fatalf("mirrorProfileEntries: %v", err)
+	}
+
+	// Canonical must not have been created by a promote.
+	if _, err := os.Lstat(filepath.Join(source, ".credentials.json")); !os.IsNotExist(err) {
+		t.Fatalf("canonical must not be created when absent; lstat err = %v", err)
+	}
+	// The only token copy must survive as a real file.
+	fi, err := os.Lstat(scratchCred)
+	if err != nil {
+		t.Fatalf("lstat scratch cred: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("scratch credentials must remain a real file when canonical is absent (no dangling symlink)")
+	}
+	got, err := os.ReadFile(scratchCred)
+	if err != nil {
+		t.Fatalf("read scratch cred: %v", err)
+	}
+	if string(got) != onlyCopy {
+		t.Fatalf("only token copy must be left intact; got %q want %q", string(got), onlyCopy)
 	}
 }
 

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -421,25 +421,40 @@ func mirrorProfileEntries(dest, source string) error {
 	return reassertCredentialSymlink(dest, source)
 }
 
-// reassertCredentialSymlink guarantees dest/.credentials.json is a symlink to
-// source/.credentials.json (the canonical profile credentials), healing the
-// in-session `/login` clobber described in issue #1222.
+// reassertCredentialSymlink guarantees dest/.credentials.json is a clean symlink
+// to source/.credentials.json (the single canonical profile credentials),
+// healing the in-session `/login` clobber described in issue #1222.
 //
 //   - dest entry is the correct symlink → left untouched (idempotent).
 //   - dest entry is absent → symlinked to canonical (when canonical exists).
 //   - dest entry is a symlink to the WRONG target → repointed to canonical.
-//   - dest entry is a real file STALE relative to canonical → replaced with
-//     the symlink; canonical is the source of truth and is left unchanged.
-//   - dest entry is a real file NEWER than canonical (a fresh in-session
-//     `/login`) → its contents are atomically promoted to canonical FIRST
-//     (temp+rename, 0600 token perms preserved, canonical never torn), THEN
-//     dest is replaced with the symlink — so the fresh token propagates to
-//     every symlinked session instead of being stranded in this scratch.
+//   - dest entry is a REAL FILE (the `/login` clobber, or any diverged copy) →
+//     force-replaced with a symlink to canonical, regardless of mtime.
+//     Canonical is NEVER overwritten.
+//   - dest entry is a real file but canonical is ABSENT → left intact, so the
+//     only token copy is not stranded behind a dangling symlink. The next
+//     start, once canonical exists, replaces it with the symlink.
+//
+// Why no mtime-promote (removed; see the OAuth root-cause memo and the
+// disassembly of Claude v2.1.159 in /tmp/oauth-fix/SUBSCRIPTION-FIX.md):
+// Anthropic OAuth uses single-use ROTATING refresh tokens, so a scratch copy's
+// mtime is NOT a "this token is newer/valid" signal. The previous code promoted
+// a strictly-newer scratch real-file to canonical, which could overwrite a good
+// canonical with a stale (or already-rotated-out) scratch token and fork a
+// second rotation chain — re-introducing the `invalid_grant` /login race for
+// every session sharing that profile. Claude re-reads .credentials.json on
+// expiry and serializes refreshes on a cross-process lock keyed by
+// realpath(); collapsing every scratch to ONE canonical symlink is what makes
+// that lock actually serialize the workers. The load-bearing invariant is
+// therefore "the scratch credentials must always be a symlink to the one
+// canonical file, never a real file", and we enforce it on every
+// spawn/start/restart here.
 //
 // WARNING for operators: do NOT run `/login` inside a managed agent-deck
-// session. Log in once in the canonical profile and every session inherits it
-// through this symlink. An in-session login is recovered here on the next
-// start, but only after a restart.
+// session — it writes a real file that diverges from canonical until the next
+// restart relinks it (the in-session token is dropped, NOT promoted). Log in
+// once in the canonical profile (e.g. `CLAUDE_CONFIG_DIR=~/.claude claude` →
+// /login) and every session inherits it through this symlink.
 func reassertCredentialSymlink(dest, source string) error {
 	target := filepath.Join(source, credentialsFileName)
 	linkPath := filepath.Join(dest, credentialsFileName)
@@ -468,32 +483,18 @@ func reassertCredentialSymlink(dest, source string) error {
 		return symlinkReplace(target, linkPath)
 	}
 
-	// dest is a REAL FILE (the `/login` clobber). Decide promote vs relink.
-	promote := false
-	ti, terr := os.Stat(target)
-	switch {
-	case terr != nil && os.IsNotExist(terr):
-		promote = true // canonical missing → scratch is the only copy
-	case terr != nil:
+	// dest is a REAL FILE — the `/login` clobber, or a diverged copy. Always
+	// force-replace it with a clean symlink to canonical; NEVER promote its
+	// contents (mtime is not a valid-token signal for rotating tokens).
+	if _, terr := os.Stat(target); terr != nil {
+		if os.IsNotExist(terr) {
+			// No canonical to point at — leave the only token copy intact
+			// rather than stranding it behind a dangling symlink. Once the
+			// user logs in to canonical, the next start relinks this.
+			return nil
+		}
 		return fmt.Errorf("stat canonical credentials: %w", terr)
-	default:
-		// Promote only when the scratch copy is strictly newer — a fresh
-		// in-session login. Equal/older is treated as stale (relink only).
-		promote = li.ModTime().After(ti.ModTime())
 	}
-
-	if promote {
-		data, rerr := os.ReadFile(linkPath)
-		if rerr != nil {
-			return fmt.Errorf("read scratch credentials for promote: %w", rerr)
-		}
-		// Atomic temp+rename into canonical: 0600 token perms preserved,
-		// canonical never torn even under a concurrent reader (G5/G1).
-		if err := atomicWriteFile(target, data, 0o600); err != nil {
-			return fmt.Errorf("promote scratch credentials to canonical: %w", err)
-		}
-	}
-
 	return symlinkReplace(target, linkPath)
 }
 

--- a/scripts/systemd/agent-deck-creds-refresh.service
+++ b/scripts/systemd/agent-deck-creds-refresh.service
@@ -50,10 +50,13 @@ RestartSec=30
 # The token files are 0600 secrets; keep the process unprivileged and sandboxed.
 NoNewPrivileges=true
 ProtectSystem=strict
-ProtectHome=read-only
-# It must WRITE the canonical credentials under the two profile dirs.
-ReadWritePaths=%h/.claude %h/.claude-work
 PrivateTmp=true
+# It must WRITE the canonical credentials under the profile dirs AND create the
+# proper-lockfile lock dir Claude uses, which is a SIBLING of each profile dir
+# in $HOME (realpath(CONFIG_DIR)+".lock", e.g. ~/.claude.lock). Because that
+# lock is created at runtime directly in $HOME, the whole home must be writable;
+# ProtectSystem=strict still keeps the rest of the filesystem read-only.
+ReadWritePaths=%h
 
 [Install]
 WantedBy=default.target

--- a/scripts/systemd/agent-deck-creds-refresh.service
+++ b/scripts/systemd/agent-deck-creds-refresh.service
@@ -1,0 +1,59 @@
+# agent-deck keep-warm OAuth refresh daemon (systemd --user unit).
+#
+# Part B of the recurring "Please run /login" outage fix. Keeps each profile's
+# canonical ~/.claude*/.credentials.json access token fresh so the N symlinked
+# worker sessions never hit an expired token and never race Anthropic's
+# single-use rotating refresh token. Subscription-safe: it uses the profile's
+# existing OAuth refresh token + clientId — NO API key, no per-token billing.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# NOT auto-started. Enable it deliberately, once you have confirmed both
+# profiles are logged in at their canonical path:
+#
+#   # 1. (one time) make sure canonical is logged in:
+#   CLAUDE_CONFIG_DIR=~/.claude      claude   # then /login
+#   CLAUDE_CONFIG_DIR=~/.claude-work claude   # then /login
+#
+#   # 2. install + enable the unit:
+#   mkdir -p ~/.config/systemd/user
+#   cp scripts/systemd/agent-deck-creds-refresh.service ~/.config/systemd/user/
+#   #   (edit ExecStart below if `agent-deck` is not on the default PATH)
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now agent-deck-creds-refresh.service
+#
+#   # 3. watch it:
+#   systemctl --user status agent-deck-creds-refresh.service
+#   journalctl --user -u agent-deck-creds-refresh.service -f
+#
+# To keep it running after logout (so it warms tokens while you are away):
+#   loginctl enable-linger "$USER"
+#
+# By default it keeps ~/.claude and ~/.claude-work warm (whichever has a
+# .credentials.json). To pin specific profiles, add repeated --config-dir flags
+# to ExecStart, e.g.:
+#   ExecStart=%h/.local/bin/agent-deck creds-refresh --config-dir %h/.claude
+# ─────────────────────────────────────────────────────────────────────────────
+
+[Unit]
+Description=agent-deck keep-warm OAuth credential refresh (subscription-safe)
+Documentation=https://github.com/asheshgoplani/agent-deck
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Adjust the path if `agent-deck` lives elsewhere (e.g. /usr/local/bin or a Go
+# bin dir). `%h` expands to the user's home directory.
+ExecStart=%h/.local/bin/agent-deck creds-refresh --interval 25m --threshold 20m
+Restart=always
+RestartSec=30
+# The token files are 0600 secrets; keep the process unprivileged and sandboxed.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+# It must WRITE the canonical credentials under the two profile dirs.
+ReadWritePaths=%h/.claude %h/.claude-work
+PrivateTmp=true
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Why

Durable fix for the recurring **\"Please run /login\"** OAuth outage that hits N concurrent worker sessions sharing one subscription login. **No API key, no per-token billing.**

**Root cause** (confirmed by disassembling Claude Code v2.1.159 — see `/tmp/oauth-fix/SUBSCRIPTION-FIX.md` and the `bug_oauth_multisession_rotation` root-cause memo): Anthropic OAuth uses **single-use rotating refresh tokens**. Claude re-reads `.credentials.json` on expiry and serializes refreshes on a cross-process lock keyed by `realpath()`. When every scratch session symlinks `.credentials.json` to **one** canonical file, all N realpaths collapse to **one** lock and the workers cannot race. The race only happens when that symlink is **clobbered into a real file** — via an in-session `/login`, or the **mtime-based promote** that overwrote canonical with a stale scratch token.

## Part A — drop the mtime-promote, always clean-symlink

`internal/session/worker_scratch.go` `reassertCredentialSymlink`:

- **Removed** the mtime-based promote-to-canonical path (`li.ModTime().After(ti.ModTime())` → `atomicWriteFile(canonical, …)`). mtime is **not** a valid-token signal for rotating tokens, so promoting a \"newer\" scratch copy could clobber a good canonical and fork a second rotation chain — re-introducing the `invalid_grant` race for every session on that profile.
- A real-file scratch `.credentials.json` (even with a newer mtime) is now **always force-replaced with a clean symlink** to the single canonical path on every spawn/start/restart. **Canonical is never overwritten.**
- When canonical is absent, the only token copy is left intact rather than stranded behind a dangling symlink.

## Part B — keep-warm refresh daemon (subscription-safe)

New `internal/credrefresh` package + `agent-deck creds-refresh` subcommand + a systemd `--user` unit template (`scripts/systemd/agent-deck-creds-refresh.service`).

- Reads canonical; if the access token expires within ~20m, exchanges the **rotating refresh token** (using the creds' own `clientId`/`scopes`) at the OAuth `/token` endpoint and **atomically temp+rename** writes the rotated token back (`0600`).
- Holds a **proper-lockfile-compatible lock** at `realpath(canonical).lock` so it never refreshes at the same instant as a running session.
- Cadence ~25m (access tokens ~1h). Workers pick up the fresh token on their next disk read — **no restart, no inotify**.
- **NOT auto-started anywhere.** Enable deliberately via the systemd unit after confirming both canonicals are logged in. The unit header documents the steps.

## Tests (`go test -race`, golangci clean)

- **Part A**: a newer scratch real-file is relinked and canonical is never overwritten; canonical-missing leaves the only copy intact; the existing idempotent / stale / settings-excluded / restart-repair cases still hold.
- **Part B**: **mock token endpoint only** — never the real endpoint, never a real refresh token (burning it would cause the very outage we prevent). Covers: refresh-on-near-expiry (asserts request shape: `grant_type`/`refresh_token`/`client_id`/`scope`), skip-when-far, unknown-field preservation, `0600` perms, endpoint-error leaves canonical untouched, lock acquire/steal-stale/release, daemon immediate-tick + clean cancel.

## Not in scope / operator follow-ups
- Re-login both canonicals once (dead refresh tokens cannot be revived).
- The branch does **not** auto-enable the daemon on the live host.

🚫 Do not merge yet — for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an interactive CLI subcommand to refresh OAuth credentials, with single-pass (--once) or continuous daemon modes and configurable interval/threshold.
  * Includes a systemd user service for automatic background refresh.

* **Bug Fixes / Behavioral Changes**
  * Scratch credential files now consistently reassert as symlinks to the canonical file; canonical is never overwritten.
  * Refreshes are atomic and preserve secure file permissions to avoid corruption or exposure.

* **Tests**
  * Expanded test coverage for refresh, locking, and symlink behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->