### PR TITLE
feat(title-sync): add global sync_title config to disable session-name sync (closes #1254)

### DIFF
--- a/cmd/agent-deck/hook_name_sync.go
+++ b/cmd/agent-deck/hook_name_sync.go
@@ -67,6 +67,16 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 		return
 	}
 
+	// Global, tool-agnostic switch (config: sync_title = false). When the user
+	// has disabled title sync, agent-deck never overwrites a session Title with
+	// the agent's own session-name — for any tool. The per-session TitleLocked
+	// flag (checked below) stays as a finer-grained override.
+	// NOTE: this is currently the only title-sync path; any future non-Claude
+	// session-name sync MUST honor GetSyncTitle() the same way.
+	if cfg, err := session.LoadUserConfig(); err == nil && cfg != nil && !cfg.GetSyncTitle() {
+		return
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return

--- a/cmd/agent-deck/hook_name_sync_test.go
+++ b/cmd/agent-deck/hook_name_sync_test.go
@@ -312,3 +312,92 @@ func TestApplyClaudeTitleSync_NoopWhenTitleLocked(t *testing.T) {
 		t.Errorf("TitleLocked lost across storage round-trip: got false, want true")
 	}
 }
+
+// writeAgentDeckConfig seeds ~/.agent-deck/config.toml under the test HOME.
+func writeAgentDeckConfig(t *testing.T, home, toml string) {
+	t.Helper()
+	dir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir .agent-deck: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(toml), 0o644); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+}
+
+// titleAfterSync seeds one Claude session + one agent-deck instance under the
+// given profile, runs applyClaudeTitleSync, and returns the post-sync Title.
+func titleAfterSync(t *testing.T, home, profile, sid, claudeName, startTitle string) string {
+	t.Helper()
+	writeClaudeSessionFile(t, filepath.Join(home, ".claude"), 4242, map[string]any{
+		"pid":       4242,
+		"sessionId": sid,
+		"name":      claudeName,
+	})
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("new storage: %v", err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	inst := &session.Instance{
+		ID:          "inst-sync",
+		Title:       startTitle,
+		Tool:        "claude",
+		ProjectPath: projectDir,
+		Command:     "claude",
+	}
+	if err := storage.Save([]*session.Instance{inst}); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	applyClaudeTitleSync("inst-sync", sid)
+
+	loaded, err := storage.Load()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	for _, i := range loaded {
+		if i.ID == "inst-sync" {
+			return i.Title
+		}
+	}
+	t.Fatal("instance disappeared")
+	return ""
+}
+
+// TestApplyClaudeTitleSync_NoopWhenSyncDisabled: the global, tool-agnostic
+// switch (config sync_title = false) must block Claude's session-name from
+// overwriting the agent-deck title — for any session, without needing a
+// per-session TitleLocked. Companion to the #697 per-session test above.
+func TestApplyClaudeTitleSync_NoopWhenSyncDisabled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTDECK_PROFILE", "sync_test_disabled")
+	writeAgentDeckConfig(t, home, "sync_title = false\n")
+
+	got := titleAfterSync(t, home, "sync_test_disabled", "sid-off", "auto-generated-summary", "loupe")
+	if got != "loupe" {
+		t.Errorf("post-sync Title = %q, want %q (sync_title=false must block sync)", got, "loupe")
+	}
+}
+
+// TestApplyClaudeTitleSync_SyncsWhenEnabled is the positive control: with
+// sync_title explicitly true (the default), the title still syncs — guards
+// against the gate accidentally short-circuiting the normal path.
+func TestApplyClaudeTitleSync_SyncsWhenEnabled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTDECK_PROFILE", "sync_test_enabled")
+	writeAgentDeckConfig(t, home, "sync_title = true\n")
+
+	got := titleAfterSync(t, home, "sync_test_enabled", "sid-on", "renamed-by-user", "loupe")
+	if got != "renamed-by-user" {
+		t.Errorf("post-sync Title = %q, want %q (sync_title=true must allow sync)", got, "renamed-by-user")
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -54,6 +54,13 @@ type UserConfig struct {
 	// Default: true (nil = true)
 	ManageMCPJson *bool `toml:"manage_mcp_json"`
 
+	// SyncTitle controls whether agent-deck overwrites a session's Title with the
+	// agent's own session-name (e.g. Claude's `--name` / `/rename`, issues #572/#697).
+	// Tool-agnostic, global switch. Set false to keep the title you gave the session.
+	// The per-session TitleLocked flag remains available as a finer-grained override.
+	// Default: true (nil = true)
+	SyncTitle *bool `toml:"sync_title"`
+
 	// MCPs defines available MCP servers for the MCP Manager
 	// These can be attached/detached per-project via the MCP Manager (M key)
 	MCPs map[string]MCPDef `toml:"mcps"`
@@ -810,6 +817,16 @@ func (c *UserConfig) GetShowAnalytics() bool {
 // GetShowNotes returns whether to show notes section, defaulting to false
 func (c *UserConfig) GetShowNotes() bool {
 	return c.Preview.GetShowNotes()
+}
+
+// GetSyncTitle returns whether agent-deck may overwrite a session Title with the
+// agent's own session-name. Tool-agnostic. Defaults to true (nil = true) so
+// existing installs keep the current behavior; set sync_title = false to opt out.
+func (c *UserConfig) GetSyncTitle() bool {
+	if c.SyncTitle == nil {
+		return true
+	}
+	return *c.SyncTitle
 }
 
 // ClaudeSettings defines Claude Code configuration

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -44,10 +44,11 @@ const (
 	SettingStatsShowNetwork
 	SettingStatsShowGPU
 	SettingStatsShowLoad
+	SettingSyncTitle
 )
 
 // Total number of navigable settings.
-const settingsCount = 28
+const settingsCount = 29
 
 // SettingsPanel displays and edits user configuration
 type SettingsPanel struct {
@@ -81,7 +82,8 @@ type SettingsPanel struct {
 	showOutput          bool
 	showAnalytics       bool
 	showNotes           bool
-	notesOutputSplit    int // percentage 10-90 (displayed as %, stored as 0.10-0.90)
+	syncTitle           bool // global: let the agent rename the session (off = keep your title)
+	notesOutputSplit    int  // percentage 10-90 (displayed as %, stored as 0.10-0.90)
 	maintenanceEnabled  bool
 	statsEnabled        bool
 	statsRefreshSecs    int
@@ -142,6 +144,7 @@ func NewSettingsPanel() *SettingsPanel {
 		recentDays:          90,
 		showOutput:          true,  // Default: output ON (shows launch animation)
 		showAnalytics:       false, // Default: analytics OFF (opt-in)
+		syncTitle:           true,  // Default: title sync ON (matches GetSyncTitle default)
 		notesOutputSplit:    33,    // Default: 33%
 		statsEnabled:        true,  // Default: stats ON
 		statsRefreshSecs:    5,     // Default: 5 seconds
@@ -283,6 +286,9 @@ func (s *SettingsPanel) LoadConfig(config *session.UserConfig) {
 	s.showOutput = config.GetShowOutput()
 	s.showAnalytics = config.GetShowAnalytics()
 	s.showNotes = config.GetShowNotes()
+
+	// Session settings
+	s.syncTitle = config.GetSyncTitle()
 	split := config.Preview.GetNotesOutputSplit()
 	s.notesOutputSplit = int(split * 100)
 	if s.notesOutputSplit < 10 {
@@ -402,6 +408,10 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 	showNotes := s.showNotes
 	config.Preview.ShowNotes = &showNotes
 	config.Preview.NotesOutputSplit = float64(s.notesOutputSplit) / 100.0
+
+	// Session settings
+	syncTitle := s.syncTitle
+	config.SyncTitle = &syncTitle
 
 	// Maintenance settings.
 	config.Maintenance.Enabled = s.maintenanceEnabled
@@ -637,6 +647,10 @@ func (s *SettingsPanel) toggleValue() bool {
 
 	case SettingShowNotes:
 		s.showNotes = !s.showNotes
+		return true
+
+	case SettingSyncTitle:
+		s.syncTitle = !s.syncTitle
 		return true
 
 	case SettingMaintenanceEnabled:
@@ -1009,6 +1023,19 @@ func (s *SettingsPanel) View() string {
 
 	content.WriteString(netCol + gpuCol + loadCol + "\n\n")
 
+	// SESSIONS
+	content.WriteString(sectionStyle.Render("SESSIONS"))
+	content.WriteString("\n")
+
+	line = s.renderCheckbox(
+		"Sync session title",
+		s.syncTitle,
+	) + " - Let the agent rename the session (off = keep your title)"
+	if s.cursor == int(SettingSyncTitle) {
+		line = highlightStyle.Render(line)
+	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
+
 	// MCP & TOOLS
 	content.WriteString(sectionStyle.Render("MCP SERVERS & CUSTOM TOOLS"))
 	content.WriteString("\n")
@@ -1070,6 +1097,7 @@ func (s *SettingsPanel) View() string {
 			48, // SettingStatsShowNetwork (row with GPU, Load)
 			48, // SettingStatsShowGPU
 			48, // SettingStatsShowLoad
+			51, // SettingSyncTitle (SESSIONS section, after stats)
 		}
 		cursorLine := cursorToLine[s.cursor]
 

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -28,7 +28,13 @@ All options for `~/.agent-deck/config.toml`.
 
 ```toml
 default_tool = "claude"   # Pre-selected tool when creating sessions
+sync_title   = true       # Let agents rename sessions from their session-name
 ```
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `default_tool` | string | `"claude"` | Pre-selected tool when creating sessions. |
+| `sync_title` | bool | `true` | When `true`, agent-deck overwrites a session's title with the agent's own session-name (e.g. Claude's `--name` / `/rename`, issues #572/#697). Set `false` to keep the title you gave the session — globally, for every tool. The per-session title-lock (`agent-deck session set-title-lock <id> on`) remains as a finer-grained override. Also toggleable in the TUI Settings panel (`S`) under **SESSIONS**. |
 
 ## [shell] Section
 


### PR DESCRIPTION
## Summary

Closes #1254. Completes the *Optional: Config Toggle* proposed in #572 (which shipped the title sync itself but never the toggle).

Adds a global, tool-agnostic config knob `sync_title` (default `true`) that lets users keep the title they gave a session. When `false`, agent-deck never overwrites a session's title with the agent's own session-name. The per-session `TitleLocked` (#697) remains as a finer-grained override.

<img width="1346" height="2256" alt="CleanShot 2026-06-02 at 21 58 27@2x" src="https://github.com/user-attachments/assets/5b9125fa-62b5-4e80-b33f-be0d9a969f81" />


## No default-behavior change

`sync_title` defaults to `true` (nil = true), so existing installs behave exactly as before. Only users who explicitly set `sync_title = false` opt out of the auto-rename. Same nil-pointer-with-default pattern as `dangerous_mode` / `hooks_enabled`.

## Changes

- `internal/session/userconfig.go`: new top-level `SyncTitle *bool` (`toml:"sync_title"`) on `UserConfig` + `GetSyncTitle()` getter (default true), mirroring `GetHooksEnabled`.
- `cmd/agent-deck/hook_name_sync.go`: early-return gate in `applyClaudeTitleSync` when `!cfg.GetSyncTitle()`. This is the only title-sync path today; a comment notes that any future (Gemini/Codex/…) session-name sync path must honor the same check — keeping the knob tool-agnostic.
- `internal/ui/settings_panel.go`: visible "Sync session title" toggle in the Settings panel (`S`) under a new **SESSIONS** section, mirroring the existing `SettingShowOutput` / `SettingShowNotes` top-level toggles.
- `cmd/agent-deck/hook_name_sync_test.go`: `TestApplyClaudeTitleSync_NoopWhenSyncDisabled` plus a positive control that sync still fires with the default.
- `skills/agent-deck/references/config-reference.md`: documents `sync_title` and its relation to `set-title-lock`.

## Testing

- `gofmt` clean; `go build` OK; `go test -race -run TestApplyClaudeTitleSync ./cmd/agent-deck/` green.
- `tests/eval/title-lock.eval.sh` still 3/3 (no regression to the per-session #697 behavior).
- Manual E2E via the real `hook-handler` path: with `sync_title = false` a Claude `/rename` no longer changes the agent-deck title; with the default (or `true`), sync still applies.

## Note on naming

#572 floated `sync_session_name` under `[claude]`. This PR uses a top-level `sync_title` instead, to keep the switch tool-agnostic (not tied to the `[claude]` table) since the title-sync concept isn't Claude-specific. Happy to rename if you'd prefer the original term.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added `sync_title` configuration option to control whether agent-deck synchronizes session titles with agent names
* Added session title sync toggle to the settings panel for easy on/off control

**Tests**
* Added comprehensive test coverage for title sync configuration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->