### PR TITLE
feat(hermes): first-class session support for Hermes Agent CLI

### DIFF
--- a/assets/watcher-templates/HERMES.md
+++ b/assets/watcher-templates/HERMES.md
@@ -1,0 +1,59 @@
+# Watcher: Shared Knowledge Base
+
+This file contains shared infrastructure knowledge for all watcher instances.
+Each watcher has its own identity in its subdirectory and its own LEARNINGS.md.
+Agent sessions inspecting this directory will find the layout and CLI reference below.
+
+## Layout
+
+The singular watcher root mirrors `~/.agent-deck/conductor/`:
+
+```
+~/.agent-deck/watcher/
+  HERMES.md        — this file (shared knowledge base)
+  POLICY.md        — behavior rules (escalation, dedup, retry, health thresholds)
+  LEARNINGS.md     — cross-watcher patterns accumulated over time
+  clients.json     — routing map: sender key -> conductor name
+
+  <name>/          — per-watcher directory (one per registered watcher)
+    meta.json      — watcher registration metadata (type, created_at, expiry)
+    state.json     — latest health snapshot (last_event_ts, error_count, adapter_healthy)
+    task-log.md    — append-only event log (one Markdown heading per event)
+    LEARNINGS.md   — per-watcher patterns (optional, watcher-specific)
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `HERMES.md` | Shared mechanism knowledge. Read by agent sessions to understand watcher infrastructure. |
+| `POLICY.md` | Behavior rules: escalation thresholds, dedup strategy, retry backoff, health thresholds. |
+| `LEARNINGS.md` | Cross-watcher patterns. Add entries as you notice recurring behaviors. |
+| `clients.json` | Routing map loaded by the engine. Key format: `<adapter>:<channel>` or email address. |
+
+## For Agents Inspecting This Directory
+
+To inspect watcher health and list all registered watchers:
+
+```bash
+agent-deck watcher list --json
+agent-deck watcher status <name>
+```
+
+The `list --json` output includes `last_event_ts`, `error_count`, and `health_status` per watcher.
+
+To check if a specific sender would be routed:
+
+```bash
+agent-deck watcher test <name>
+```
+
+## Why This Folder Shape
+
+Watcher state mirrors the conductor pattern (`~/.agent-deck/conductor/`) for consistency:
+both subsystems use a singular directory root with shared top-level files and
+per-instance subdirectories. This makes the layout predictable and tooling reusable.
+
+The legacy `~/.agent-deck/watchers/` path is preserved as a relative compatibility
+symlink pointing to `watcher/`. Existing tooling that reads `watchers/` continues
+to work without modification.

--- a/cmd/agent-deck/hermes_hooks_cmd.go
+++ b/cmd/agent-deck/hermes_hooks_cmd.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func handleHermesHooks(args []string) {
+	if len(args) == 0 {
+		printHermesHooksUsage(os.Stderr)
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "help", "--help", "-h":
+		printHermesHooksUsage(os.Stdout)
+	case "install":
+		handleHermesHooksInstall()
+	case "uninstall":
+		handleHermesHooksUninstall()
+	case "status":
+		handleHermesHooksStatus()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown hermes-hooks subcommand: %s\n", args[0])
+		printHermesHooksUsage(os.Stderr)
+		os.Exit(1)
+	}
+}
+
+func printHermesHooksUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: agent-deck hermes-hooks <command>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Manage Hermes Agent shell hook integration.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Commands:")
+	fmt.Fprintln(w, "  install      Install agent-deck Hermes hooks")
+	fmt.Fprintln(w, "  uninstall    Remove agent-deck Hermes hooks")
+	fmt.Fprintln(w, "  status       Show Hermes hooks install status")
+	fmt.Fprintln(w, "  help         Show this help message")
+}
+
+func handleHermesHooksInstall() {
+	configDir := getHermesConfigDirForHooks()
+	installed, err := session.InjectHermesHooks(configDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error installing Hermes hooks: %v\n", err)
+		os.Exit(1)
+	}
+	if installed {
+		fmt.Println("Hermes hooks installed successfully.")
+		fmt.Printf("Config: %s\n", filepath.Join(configDir, "config.yaml"))
+	} else {
+		fmt.Println("Hermes hooks are already installed.")
+	}
+}
+
+func handleHermesHooksUninstall() {
+	configDir := getHermesConfigDirForHooks()
+	removed, err := session.RemoveHermesHooks(configDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error removing Hermes hooks: %v\n", err)
+		os.Exit(1)
+	}
+	if removed {
+		fmt.Println("Hermes hooks removed successfully.")
+	} else {
+		fmt.Println("No agent-deck Hermes hooks found to remove.")
+	}
+}
+
+func handleHermesHooksStatus() {
+	configDir := getHermesConfigDirForHooks()
+	installed := session.CheckHermesHooksInstalled(configDir)
+	configPath := filepath.Join(configDir, "config.yaml")
+
+	if installed {
+		fmt.Println("Status: INSTALLED")
+		fmt.Printf("Config: %s\n", configPath)
+	} else {
+		fmt.Println("Status: NOT INSTALLED")
+		fmt.Println("Run 'agent-deck hermes-hooks install' to install.")
+	}
+}
+
+func getHermesConfigDirForHooks() string {
+	return session.GetHermesConfigDir()
+}

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -90,6 +90,15 @@ func mapEventToStatus(event string) string {
 		return "running" // Gemini received user input and is processing
 	case "AfterAgent":
 		return "waiting" // Gemini completed response, back to waiting
+	// Hermes shell hook events
+	case "pre_tool_call":
+		return "running" // Hermes is executing a tool call
+	case "post_tool_call":
+		return "waiting" // Hermes finished a tool call, back at prompt
+	case "on_session_start":
+		return "waiting" // Hermes session started, waiting for first prompt
+	case "on_session_end":
+		return "dead" // Hermes session ended
 	case "UserPromptSubmit":
 		return "running" // User sent prompt, Claude is processing
 	case "Stop":
@@ -326,6 +335,7 @@ func isTerminalHookEvent(event string) bool {
 	// sidecar on ordinary non-terminal "Stop"/turn-complete style events.
 	switch norm {
 	case "sessionend", "sessionended", "sessionclose", "sessionclosed", "sessiondone", "sessionexit", "sessionexited",
+		"onsessionend", // Hermes: on_session_end normalized
 		"threadend", "threadended", "threadterminate", "threadterminated", "threadclose", "threadclosed",
 		"threaddone", "threadexit", "threadexited":
 		return true

--- a/cmd/agent-deck/hook_handler_test.go
+++ b/cmd/agent-deck/hook_handler_test.go
@@ -25,6 +25,12 @@ func TestMapEventToStatus(t *testing.T) {
 		{"SessionEnd", "dead"},
 		{"PreCompact", ""},
 		{"UnknownEvent", ""},
+		// Hermes shell hook events
+		{"pre_tool_call", "running"},
+		{"post_tool_call", "waiting"},
+		{"on_session_start", "waiting"},
+		{"on_session_end", "dead"},
+		{"subagent_stop", ""},
 	}
 
 	for _, tt := range tests {
@@ -238,6 +244,7 @@ func TestIsTerminalHookEvent(t *testing.T) {
 	}{
 		{event: "SessionEnd", expect: true},
 		{event: "session_end", expect: true},
+		{event: "on_session_end", expect: true}, // Hermes shell hook terminal event
 		{event: "session.closed", expect: true},
 		{event: "ThreadClosed", expect: true},
 		{event: "thread/terminated", expect: true},

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -340,6 +340,9 @@ func main() {
 		case "gemini-hooks":
 			handleGeminiHooks(args[1:])
 			return
+		case "hermes-hooks":
+			handleHermesHooks(args[1:])
+			return
 		case "notify-daemon":
 			handleNotifyDaemon(args[1:])
 			return
@@ -2959,6 +2962,7 @@ func printHelp() {
 	fmt.Println("  skill            Manage project skills")
 	fmt.Println("  codex-hooks      Manage Codex notify hook integration")
 	fmt.Println("  gemini-hooks     Manage Gemini hook integration")
+	fmt.Println("  hermes-hooks     Manage Hermes Agent hook integration")
 	fmt.Println("  group            Manage groups")
 	fmt.Println("  worktree, wt     Manage git worktrees")
 	fmt.Println("  web              Start TUI with web UI server running alongside")
@@ -3000,6 +3004,9 @@ func printHelp() {
 	fmt.Println("  gemini-hooks install      Install Gemini hooks")
 	fmt.Println("  gemini-hooks uninstall    Remove Gemini hooks")
 	fmt.Println("  gemini-hooks status       Show Gemini hooks install status")
+	fmt.Println("  hermes-hooks install      Install Hermes Agent hooks")
+	fmt.Println("  hermes-hooks uninstall    Remove Hermes Agent hooks")
+	fmt.Println("  hermes-hooks status       Show Hermes hooks install status")
 	fmt.Println()
 	fmt.Println("Group Commands:")
 	fmt.Println("  group list                List all groups")

--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -1897,7 +1897,7 @@ async def main():
         )
     )
 
-    # Run both concurrently
+    # Run all concurrently
     tasks = [heartbeat_task]
     if telegram_dp and telegram_bot:
         tasks.append(asyncio.create_task(telegram_dp.start_polling(telegram_bot)))

--- a/conductor/conductor-hermes.md
+++ b/conductor/conductor-hermes.md
@@ -1,0 +1,273 @@
+# Conductor: Agent-Deck Orchestrator ({PROFILE} profile)
+
+You are the **Conductor** for the **{PROFILE}** profile, a persistent Hermes session that monitors and orchestrates all agent-deck sessions in this profile. You sit on top of agent-deck, watching for sessions that need help, auto-responding when you can, and escalating to the user (via Telegram/Slack/Discord) when you can't.
+
+## Your Identity
+
+- You are a Hermes session managed by agent-deck, just like every other session
+- You manage the **{PROFILE}** profile exclusively. Always pass `-p {PROFILE}` to all CLI commands.
+- You live in `~/.agent-deck/conductor/{PROFILE}/`
+- You maintain state in `./state.json` and log actions in `./task-log.md`
+- The bridge sends you messages from the user's phone/desktop and forwards your responses back
+- You receive periodic `[HEARTBEAT]` messages with system status
+- Other profiles have their own conductors. You only manage sessions in your profile.
+
+## Core Rules
+
+1. **Keep responses SHORT.** The user reads them on their phone. 1-3 sentences max for status updates. Use bullet points for lists.
+2. **Auto-respond to waiting sessions** when you're confident you know the answer (project context, obvious next steps, "yes proceed", etc.)
+3. **Escalate to the user** when you're unsure. Just say what needs attention and why.
+4. **Never auto-respond with destructive actions** (deleting files, force-pushing, dropping databases). Always escalate those.
+5. **Never send messages to running sessions.** Only respond to sessions in "waiting" status.
+6. **Log everything.** Every action you take goes in `./task-log.md`.
+7. **Always use `-p {PROFILE}`** in every `agent-deck` command.
+
+## Agent-Deck CLI Reference
+
+**Important:** All commands must include `-p {PROFILE}` to target the correct profile.
+
+### Status & Listing
+
+| Command | Description |
+|---------|-------------|
+| `agent-deck -p {PROFILE} status --json` | Get counts: `{"waiting": N, "running": N, "idle": N, "error": N, "total": N}` |
+| `agent-deck -p {PROFILE} list --json` | List all sessions with details (id, title, path, tool, status, group) |
+| `agent-deck -p {PROFILE} session show --json <id_or_title>` | Full details for one session |
+
+### Reading Session Output
+
+| Command | Description |
+|---------|-------------|
+| `agent-deck -p {PROFILE} session output <id_or_title> -q` | Get the last response (raw text, perfect for reading) |
+
+### Sending Messages to Sessions
+
+| Command | Description |
+|---------|-------------|
+| `agent-deck -p {PROFILE} session send <id_or_title> "message"` | Send a message. Has built-in 60s wait for agent readiness. |
+| `agent-deck -p {PROFILE} session send <id_or_title> "message" --wait -q --timeout 300s` | Single-call send + wait + raw output (preferred when you need the reply now). |
+| `agent-deck -p {PROFILE} session send <id_or_title> "message" --no-wait` | Send immediately without waiting for ready state. |
+
+### Session Control
+
+| Command | Description |
+|---------|-------------|
+| `agent-deck -p {PROFILE} session start <id_or_title>` | Start a stopped session |
+| `agent-deck -p {PROFILE} session stop <id_or_title>` | Stop a running session |
+| `agent-deck -p {PROFILE} session restart <id_or_title>` | Restart a session |
+| `agent-deck -p {PROFILE} add <path> -t "Title" -c hermes -g "group"` | Create new Hermes session |
+| `agent-deck -p {PROFILE} launch <path> -t "Title" -c hermes -g "group" -m "prompt"` | Create + start + send initial prompt in one command (preferred for new task sessions) |
+
+### Session Resolution
+
+Commands accept: **exact title**, **ID prefix** (e.g., first 4 chars), **path**, or **fuzzy match**.
+
+## Session Status Values
+
+| Status | Meaning | Your Action |
+|--------|---------|-------------|
+| `running` (green) | Hermes is actively processing | Do nothing. Wait. |
+| `waiting` (yellow) | Hermes finished, needs input | Read output, decide: auto-respond or escalate |
+| `idle` (gray) | Waiting, but user acknowledged | User knows about it. Skip unless asked. |
+| `error` (red) | Session crashed or missing | Try `session restart`. If that fails, escalate. |
+
+## Heartbeat Protocol
+
+Every N minutes, the bridge sends you a message like:
+
+```
+[HEARTBEAT] [{PROFILE}] Status: 2 waiting, 3 running, 1 idle, 0 error. Waiting sessions: frontend (project: ~/src/app), api-fix (project: ~/src/api). Check if any need auto-response or user attention.
+```
+
+**Your heartbeat response format:**
+
+```
+[STATUS] All clear.
+```
+
+or:
+
+```
+[STATUS] Auto-responded to 1 session. 1 needs your attention.
+
+AUTO: frontend - told it to use the existing auth middleware
+NEED: api-fix - asking whether to run integration tests against staging or prod
+```
+
+The bridge parses your response: if it contains `NEED:` lines, those get sent to the user.
+
+## Auto-Response Guidelines
+
+### Safe to Auto-Respond
+- "Should I proceed?" / "Should I continue?" → Yes, if the plan looks reasonable
+- "Which file should I edit?" → Answer if the project structure makes it obvious
+- "Tests passed. What's next?" → Direct to the next logical step
+- "I've completed X. Anything else?" → If nothing else is needed, tell it
+- Compilation/lint errors with obvious fixes → Suggest the fix
+- Questions about project conventions → Answer from context
+
+### Always Escalate
+- "Should I delete X?" / "Should I force-push?"
+- "I found a security issue..."
+- "Multiple approaches possible, which do you prefer?"
+- "I need API keys / credentials / tokens"
+- "Should I deploy to production?"
+- "I'm stuck and don't know how to proceed"
+- Any question about business logic or design decisions
+
+### When Unsure
+If you're not sure whether to auto-respond, **escalate**. The cost of a false escalation (user gets a notification) is much lower than the cost of a wrong auto-response (session goes off track).
+
+## State Management
+
+Maintain `./state.json` for persistent context across compactions:
+
+```json
+{
+  "profile": "{PROFILE}",
+  "sessions": {
+    "session-id-here": {
+      "title": "frontend",
+      "project": "~/src/app",
+      "summary": "Building auth flow",
+      "last_auto_response": "2025-01-15T10:30:00Z",
+      "escalated": false
+    }
+  },
+  "last_heartbeat": "2025-01-15T10:30:00Z",
+  "auto_responses_today": 5,
+  "escalations_today": 2
+}
+```
+
+Read state.json at the start of each interaction. Update it after taking action. Keep session summaries current based on what you observe in their output.
+
+## Task Log
+
+Append every action to `./task-log.md`:
+
+```markdown
+## 2025-01-15 10:30 - Heartbeat
+- Scanned 5 sessions (2 waiting, 3 running)
+- Auto-responded to frontend: "Use the existing AuthProvider component"
+- Escalated api-fix: needs decision on test environment
+
+## 2025-01-15 10:15 - User Message
+- User asked: "What's the status of the api server?"
+- Checked session 'api-server': running, working on endpoint validation
+- Responded with summary
+```
+
+## Quick Commands
+
+The bridge may forward these special commands:
+
+| Command | What to Do |
+|---------|------------|
+| `/status` | Run `agent-deck -p {PROFILE} status --json` and format a brief summary |
+| `/sessions` | Run `agent-deck -p {PROFILE} list --json` and list active sessions with status |
+| `/check <name>` | Run `agent-deck -p {PROFILE} session output <name> -q` and summarize what it's doing |
+| `/send <name> <msg>` | Forward the message to that session via `agent-deck -p {PROFILE} session send` |
+| `/kanban` | Run `hermes kanban list --status running --json` and `hermes kanban list --status blocked --json` and summarize active tasks |
+| `/help` | List available commands |
+
+For any other text, treat it as a conversational message from the user.
+
+## Slack Message Format
+
+When messages arrive from Slack, the bridge tags them with sender and channel context:
+
+```
+[from:alice (U12345)] [channel:#bugs (C67890)] the login button is broken
+[from:bob (U11111)] [dm] can you check the API?
+```
+
+- `[from:<name> (<user_id>)]` — Slack display name and stable user ID
+- `[channel:#<name> (<channel_id>)]` — Slack channel name and stable channel ID
+- `[dm]` — message sent via direct message
+
+Use these tags to identify the requester and include sender context in escalations.
+
+## Hermes Gateway Topology
+
+Hermes messaging is native — no external plugins required. All platforms (Telegram, Slack, Discord, etc.) are built-in adapters activated by env vars in `~/.hermes/.env`.
+
+**Setup:**
+```bash
+hermes gateway setup   # interactive wizard for all platforms
+hermes gateway start   # start the gateway process
+hermes gateway install # install as launchd/systemd service (auto-start)
+```
+
+**Conductor-specific config** (`~/.hermes/config.yaml`):
+```yaml
+gateway:
+  platforms:
+    telegram:
+      home_chat_id: "YOUR_CHAT_ID"
+      gateway_restart_notification: true
+    slack:
+      # uses Socket Mode — no public URL needed
+```
+
+**Token storage** (`~/.hermes/.env`):
+```
+TELEGRAM_BOT_TOKEN=...
+TELEGRAM_ALLOWED_USERS=...
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_APP_TOKEN=xapp-...
+```
+
+The gateway handles all polling/reconnection automatically. Unlike Claude's plugin topology, there is no risk of double-loading or competing pollers — the gateway is the single owner of each platform connection.
+
+Health check: `agent-deck` monitors `IsHermesGatewayReachable()` and will warn in the TUI if the gateway is down.
+
+## Kanban Integration
+
+As a Hermes conductor you have native access to the Hermes Kanban board (`~/.hermes/kanban.db`). Use it to track multi-session work items that need durable state across restarts.
+
+**Task lifecycle:** `ready` → `claimed` → (`blocked` ↔ `unblocked`) → `completed`. Failure exits: `crashed`, `timed_out`, `reclaimed`.
+
+**Useful commands:**
+```bash
+hermes kanban list --json                       # all tasks across all boards
+hermes kanban list --status running --json      # running tasks only (one --status at a time)
+hermes kanban list --status blocked --json      # blocked tasks only
+hermes kanban create "Fix auth bug" --assignee dev-session
+hermes kanban block <id> "Needs API key from user"
+hermes kanban complete <id> --summary "Fixed in commit abc123"
+hermes kanban watch --kinds blocked,completed   # live event stream
+```
+
+**Note:** `hermes kanban list --status` only accepts one value at a time. To filter multiple statuses, run separate calls and combine.
+
+**When to use Kanban:**
+- A session is working on something that might need to survive a restart
+- Work requires multiple sessions collaborating (fan-out with `--parent`)
+- You need an audit trail of what each session did and why
+- A task is blocked waiting on user input (`kanban_block` + escalate)
+
+**When not to use Kanban:**
+- Simple one-shot questions ("should I proceed?") — just auto-respond or escalate directly
+- Routine heartbeat checks — keep those in state.json
+
+## Startup Checklist
+
+When you first start (or after a restart):
+
+1. Read `./state.json` if it exists (restore context)
+2. Run `agent-deck -p {PROFILE} status --json` to get the current state
+3. Run `agent-deck -p {PROFILE} list --json` to know what sessions exist
+4. Run `hermes kanban list --status blocked --json` to check for blocked tasks
+5. Log startup in `./task-log.md`
+6. If any sessions are in error state, try to restart them
+7. Reply: "Conductor ({PROFILE}) online. N sessions tracked (X running, Y waiting). K kanban tasks active."
+
+## Important Notes
+
+- You cannot directly access other sessions' files. Use `session output` to read their latest response.
+- Prefer `launch ... -m "prompt"` over separate `add` + `session start` + `session send` when creating a new task session.
+- `session send` waits up to 60 seconds for the agent to be ready. If the session is running (busy), the send will wait.
+- Keep state.json small (no large output dumps). Store summaries, not full text.
+- Your own session can be restarted by the bridge if it detects you're in an error state.
+- Hermes Kanban tasks assigned to a profile are auto-dispatched by the gateway's built-in dispatcher — you don't need to start them manually.

--- a/conductor/tests/test_python_compat.py
+++ b/conductor/tests/test_python_compat.py
@@ -115,3 +115,39 @@ def test_bridge_imports_on_python_38():
     module = importlib.util.module_from_spec(spec)
     # Will raise TypeError on 3.8 if collections.abc.Coroutine[...] is used.
     spec.loader.exec_module(module)
+
+
+# Hermes-specific integration artifact checks (Phase 3)
+# Note: conductor spec / config override / status derivation logic lives in Go
+# (see internal/session/hermes_conductor_test.go and hermes_test.go).
+# These tests verify that the Python-side integration artifacts are present.
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+def test_hermes_conductor_md_exists():
+    """conductor/conductor-hermes.md must exist — it is the Hermes conductor system prompt."""
+    conductor_md = Path(__file__).parent.parent / "conductor-hermes.md"
+    assert conductor_md.exists(), (
+        f"conductor-hermes.md not found at {conductor_md}. "
+        "Run SetupConductorWithAgent to regenerate or restore from the repo."
+    )
+
+
+def test_hermes_conductor_md_references_hermes():
+    """conductor-hermes.md must mention Hermes by name (not a copy of the Claude template)."""
+    conductor_md = Path(__file__).parent.parent / "conductor-hermes.md"
+    if not conductor_md.exists():
+        pytest.skip("conductor-hermes.md not present")
+    content = conductor_md.read_text()
+    assert "hermes" in content.lower(), (
+        "conductor-hermes.md does not mention 'hermes' — it may be a copy of the Claude template."
+    )
+
+
+def test_hermes_md_watcher_template_exists():
+    """assets/watcher-templates/HERMES.md must exist for the session watcher."""
+    template = REPO_ROOT / "assets" / "watcher-templates" / "HERMES.md"
+    assert template.exists(), (
+        f"HERMES.md watcher template not found at {template}."
+    )

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -17,6 +17,7 @@ import (
 const (
 	ConductorAgentClaude = "claude"
 	ConductorAgentCodex  = "codex"
+	ConductorAgentHermes = "hermes"
 
 	ConductorSessionTitlePrefix     = "conductor-"
 	ConductorHeartbeatMessagePrefix = "Heartbeat:"
@@ -51,6 +52,13 @@ var conductorAgentSpecs = map[string]ConductorAgentSpec{
 		DefaultCommand:         "codex",
 		InstructionsFileName:   "AGENTS.md",
 		SupportsClearOnCompact: false,
+	},
+	ConductorAgentHermes: {
+		Agent:                  ConductorAgentHermes,
+		DisplayName:            "Hermes",
+		DefaultCommand:         "hermes",
+		InstructionsFileName:   "HERMES.md",
+		SupportsClearOnCompact: true,
 	},
 }
 
@@ -171,7 +179,9 @@ func (m *ConductorMeta) GetAgent() string {
 	return ConductorAgentClaude
 }
 
-// GetClearOnCompact returns whether to block compaction and send /clear instead, defaulting to true
+// GetClearOnCompact returns whether to block compaction and send /clear instead, defaulting to true.
+// For Hermes conductors, this enables context clearing on compaction (similar to Claude),
+// as Hermes does not perform automatic summarization like Claude does.
 func (m *ConductorMeta) GetClearOnCompact() bool {
 	spec, _ := GetConductorAgentSpec(m.GetAgent())
 	if !spec.SupportsClearOnCompact {
@@ -217,7 +227,7 @@ func GetConductorAgentSpec(agent string) (ConductorAgentSpec, error) {
 	normalized := normalizeConductorAgent(agent)
 	spec, ok := conductorAgentSpecs[normalized]
 	if !ok {
-		return ConductorAgentSpec{}, fmt.Errorf("unsupported conductor agent %q (supported: %s, %s)", agent, ConductorAgentClaude, ConductorAgentCodex)
+		return ConductorAgentSpec{}, fmt.Errorf("unsupported conductor agent %q (supported: %s, %s, %s)", agent, ConductorAgentClaude, ConductorAgentCodex, ConductorAgentHermes)
 	}
 	return spec, nil
 }
@@ -604,7 +614,13 @@ func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool,
 		}
 	} else if info, err := os.Lstat(targetPath); err != nil || info.Mode()&os.ModeSymlink == 0 {
 		// No custom path - write default template (but preserve existing symlink)
-		content := renderConductorInstructionsTemplate(conductorPerNameClaudeMDTemplate, name, profile, spec)
+		var perNameTemplate string
+		if spec.Agent == ConductorAgentHermes {
+			perNameTemplate = conductorPerNameHermesMDTemplate
+		} else {
+			perNameTemplate = conductorPerNameClaudeMDTemplate
+		}
+		content := renderConductorInstructionsTemplate(perNameTemplate, name, profile, spec)
 		if err := os.WriteFile(targetPath, []byte(content), 0o644); err != nil {
 			return fmt.Errorf("failed to write %s: %w", spec.InstructionsFileName, err)
 		}

--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -2390,3 +2390,62 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 `
+
+// conductorPerNameHermesMDTemplate is the per-conductor instructions file for Hermes conductors.
+// It follows the same structure as the Claude version but uses Hermes-specific language where appropriate.
+const conductorPerNameHermesMDTemplate = `# Conductor: {NAME} ({PROFILE} profile)
+
+You are **{NAME}**, a conductor for the **{PROFILE}** profile running on **{AGENT_DISPLAY}**.
+
+## Your Identity
+
+- Your session title is ` + "`" + `conductor-{NAME}` + "`" + `
+- You are a persistent ` + "`" + `{AGENT_DISPLAY}` + "`" + ` session managed by agent-deck
+- You manage the **{PROFILE}** profile exclusively. Always pass ` + "`" + `-p {PROFILE}` + "`" + ` to all CLI commands.
+- You live in ` + "`" + `~/.agent-deck/conductor/{NAME}/` + "`" + `
+- Maintain state in ` + "`" + `./state.json` + "`" + ` and log actions in ` + "`" + `./task-log.md` + "`" + `
+- The bridge (Telegram/Slack) sends you messages from the user and forwards your responses back
+- You receive periodic ` + "`" + `[HEARTBEAT]` + "`" + ` messages with system status
+- Other conductors may exist for different purposes. You only manage sessions in your profile.
+
+## Startup Checklist
+
+When you first start (or after a restart):
+
+1. Read ` + "`" + `./state.json` + "`" + ` if it exists (restore context)
+2. Read ` + "`" + `./LEARNINGS.md` + "`" + ` and ` + "`" + `../LEARNINGS.md` + "`" + ` if they exist (review past patterns)
+3. Run ` + "`" + `agent-deck -p {PROFILE} status --json` + "`" + ` to get the current state
+4. Run ` + "`" + `agent-deck -p {PROFILE} list --json` + "`" + ` to know what sessions exist
+5. Run ` + "`" + `hermes kanban list --status blocked --json` + "`" + ` to check for blocked tasks needing attention
+6. Log startup in ` + "`" + `./task-log.md` + "`" + `
+7. If any sessions are in error state (NOT stopped), try to restart them. Sessions in "stopped" status were intentionally closed by the user and must NOT be restarted.
+8. Reply: "Conductor {NAME} ({PROFILE}) online. N sessions tracked (X running, Y waiting). K kanban tasks active."
+
+## Kanban Escalation
+
+When escalating a session to the user, create a durable Kanban record alongside the notification:
+
+` + "```" + `bash
+# 1. Create the task in triage
+id=$(hermes kanban create "<session-title>: needs input" \
+  --body "<last output excerpt>" --triage --json | jq -r .id)
+
+# 2. Immediately block it with the reason
+hermes kanban block "$id" "<escalation reason>"
+` + "```" + `
+
+When the user responds and you auto-reply to the session, close the loop:
+` + "```" + `bash
+hermes kanban unblock <id>
+hermes kanban complete <id> --summary "<what was decided>"
+` + "```" + `
+
+Only use Kanban for escalations that need a durable record. Routine heartbeat
+checks and simple auto-responses do not need Kanban entries.
+
+## Policy
+
+Your operating rules (auto-response policy, escalation guidelines, response style) are in ` + "`" + `./POLICY.md` + "`" + `.
+If ` + "`" + `./POLICY.md` + "`" + ` does not exist, use ` + "`" + `../POLICY.md` + "`" + ` instead.
+Read the policy file at the start of each interaction. Your agent instructions live in ` + "`" + `{INSTRUCTIONS_FILE}` + "`" + `.
+`

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -281,6 +281,14 @@ func (i *Instance) getToolEnvFile() string {
 	case "crush":
 		return config.Crush.EnvFile
 	case "hermes":
+		if name := conductorNameFromInstance(i); name != "" {
+			if conductorEnv := config.GetConductorHermesEnvFile(name); conductorEnv != "" {
+				return conductorEnv
+			}
+		}
+		if groupEnv := config.GetGroupHermesEnvFile(i.GroupPath); groupEnv != "" {
+			return groupEnv
+		}
 		return config.Hermes.EnvFile
 	default:
 		// Check custom tools

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -2,7 +2,12 @@ package session
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
+	"time"
 )
 
 // HermesOptions holds launch options for Hermes Agent CLI sessions.
@@ -100,3 +105,89 @@ func (i *Instance) buildHermesCommand(baseCommand string) string {
 
 	return envPrefix + cmd
 }
+
+// IsHermesGatewayReachable performs a basic reachable check against the
+// configured GatewayURL from HermesSettings. Returns true if a simple
+// HTTP request succeeds within timeout. Keeps existing process-alive logic
+// untouched; this augments status detection when gateway URL is available.
+func IsHermesGatewayReachable(gatewayURL string) bool {
+	if gatewayURL == "" {
+		return false
+	}
+	client := &http.Client{Timeout: 1500 * time.Millisecond}
+	resp, err := client.Get(gatewayURL)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode < 500
+}
+
+// HermesSharedWorkspaceDir returns the base directory Hermes uses for
+// shared workspace sessions enabling multi-agent handoff visibility.
+// If the user config specifies a WorkspaceDir, that is used; otherwise
+// it falls back to a platform-appropriate temp directory.
+func HermesSharedWorkspaceDir() string {
+	if config, _ := LoadUserConfig(); config != nil && config.Hermes.WorkspaceDir != "" {
+		return config.Hermes.WorkspaceDir
+	}
+	return filepath.Join(os.TempDir(), "hermes-workspaces")
+}
+
+// hermesDefaultGatewayPort is the port hermes gateway always listens on.
+// See gateway/platforms/api_server.py: DEFAULT_PORT = 8642.
+const hermesDefaultGatewayPort = 8642
+
+// hermesGatewayStateFile is the JSON file hermes writes while its gateway is running.
+const hermesGatewayStateFile = "gateway_state.json"
+
+// hermesGatewayState is a minimal subset of gateway_state.json.
+type hermesGatewayState struct {
+	GatewayState string `json:"gateway_state"`
+}
+
+// isHermesGatewayRunning checks ~/.hermes/gateway_state.json to see if
+// the hermes gateway process believes it is running. This is a lightweight
+// signal that avoids a network round-trip; callers should still probe the
+// URL before trusting the result.
+func isHermesGatewayRunning() bool {
+	p := filepath.Join(GetHermesConfigDir(), hermesGatewayStateFile)
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return false
+	}
+	var state hermesGatewayState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return false
+	}
+	return state.GatewayState == "running"
+}
+
+// DiscoverHermesGatewayURL auto-detects the hermes gateway URL.
+// It checks gateway_state.json first (cheap), then probes the well-known
+// local address. Returns "" if the gateway does not appear to be reachable.
+func DiscoverHermesGatewayURL() string {
+	if !isHermesGatewayRunning() {
+		return ""
+	}
+	candidate := fmt.Sprintf("http://127.0.0.1:%d", hermesDefaultGatewayPort)
+	if IsHermesGatewayReachable(candidate) {
+		return candidate
+	}
+	return ""
+}
+
+// GetHermesGatewayURL returns the hermes gateway URL. It first checks the
+// explicit gateway_url in agent-deck's config; if unset, it attempts
+// auto-discovery via DiscoverHermesGatewayURL so users who run the hermes
+// gateway get session health detection without any manual configuration.
+func GetHermesGatewayURL() string {
+	config, err := LoadUserConfig()
+	if err == nil && config != nil {
+		if url := strings.TrimSpace(config.Hermes.GatewayURL); url != "" {
+			return url
+		}
+	}
+	return DiscoverHermesGatewayURL()
+}
+

--- a/internal/session/hermes_conductor_test.go
+++ b/internal/session/hermes_conductor_test.go
@@ -1,0 +1,122 @@
+package session
+
+import (
+	"testing"
+)
+
+// TestHermesConductorSpec_Exists verifies that GetConductorAgentSpec("hermes") returns no error.
+func TestHermesConductorSpec_Exists(t *testing.T) {
+	_, err := GetConductorAgentSpec("hermes")
+	if err != nil {
+		t.Fatalf("expected no error for hermes spec, got: %v", err)
+	}
+}
+
+// TestHermesConductorSpec_SupportsClearOnCompact verifies that the Hermes spec has SupportsClearOnCompact == true.
+func TestHermesConductorSpec_SupportsClearOnCompact(t *testing.T) {
+	spec, err := GetConductorAgentSpec("hermes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !spec.SupportsClearOnCompact {
+		t.Errorf("expected SupportsClearOnCompact=true for hermes spec, got false")
+	}
+}
+
+// TestHermesConductorSpec_DefaultCommand verifies that the Hermes spec has DefaultCommand == "hermes".
+func TestHermesConductorSpec_DefaultCommand(t *testing.T) {
+	spec, err := GetConductorAgentSpec("hermes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.DefaultCommand != "hermes" {
+		t.Errorf("expected DefaultCommand=%q, got %q", "hermes", spec.DefaultCommand)
+	}
+}
+
+// TestHermesConductorSpec_InstructionsFileName verifies that the Hermes spec has InstructionsFileName == "HERMES.md".
+func TestHermesConductorSpec_InstructionsFileName(t *testing.T) {
+	spec, err := GetConductorAgentSpec("hermes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.InstructionsFileName != "HERMES.md" {
+		t.Errorf("expected InstructionsFileName=%q, got %q", "HERMES.md", spec.InstructionsFileName)
+	}
+}
+
+// TestHermesConductorSpec_DisplayName verifies that the Hermes spec has DisplayName == "Hermes".
+func TestHermesConductorSpec_DisplayName(t *testing.T) {
+	spec, err := GetConductorAgentSpec("hermes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.DisplayName != "Hermes" {
+		t.Errorf("expected DisplayName=%q, got %q", "Hermes", spec.DisplayName)
+	}
+}
+
+// TestHermesGetClearOnCompact_NilDefaultsToTrue verifies that a Hermes ConductorMeta with
+// ClearOnCompact == nil defaults to returning true from GetClearOnCompact.
+func TestHermesGetClearOnCompact_NilDefaultsToTrue(t *testing.T) {
+	meta := &ConductorMeta{Agent: "hermes", ClearOnCompact: nil}
+	if !meta.GetClearOnCompact() {
+		t.Errorf("expected GetClearOnCompact()=true when ClearOnCompact is nil, got false")
+	}
+}
+
+// TestHermesGetClearOnCompact_ExplicitFalse verifies that an explicit false pointer returns false.
+func TestHermesGetClearOnCompact_ExplicitFalse(t *testing.T) {
+	f := false
+	meta := &ConductorMeta{Agent: "hermes", ClearOnCompact: &f}
+	if meta.GetClearOnCompact() {
+		t.Errorf("expected GetClearOnCompact()=false when ClearOnCompact is explicitly false, got true")
+	}
+}
+
+// TestHermesGetClearOnCompact_ExplicitTrue verifies that an explicit true pointer returns true.
+func TestHermesGetClearOnCompact_ExplicitTrue(t *testing.T) {
+	tr := true
+	meta := &ConductorMeta{Agent: "hermes", ClearOnCompact: &tr}
+	if !meta.GetClearOnCompact() {
+		t.Errorf("expected GetClearOnCompact()=true when ClearOnCompact is explicitly true, got false")
+	}
+}
+
+// TestHermesGroupSettings_FieldsAreExported verifies that GroupHermesSettings has exported fields
+// that can be assigned and read back via struct literals.
+func TestHermesGroupSettings_FieldsAreExported(t *testing.T) {
+	s := GroupHermesSettings{
+		Command:    "hermes-custom",
+		GatewayURL: "ws://localhost:9999",
+		YoloMode:   true,
+	}
+	if s.Command != "hermes-custom" {
+		t.Errorf("expected Command=%q, got %q", "hermes-custom", s.Command)
+	}
+	if s.GatewayURL != "ws://localhost:9999" {
+		t.Errorf("expected GatewayURL=%q, got %q", "ws://localhost:9999", s.GatewayURL)
+	}
+	if !s.YoloMode {
+		t.Errorf("expected YoloMode=true, got false")
+	}
+}
+
+// TestHermesConductorSettings_FieldsAreExported verifies that ConductorHermesSettings has exported
+// fields that can be assigned and read back via struct literals.
+func TestHermesConductorSettings_FieldsAreExported(t *testing.T) {
+	s := ConductorHermesSettings{
+		Command:    "hermes-custom",
+		GatewayURL: "ws://localhost:9999",
+		YoloMode:   true,
+	}
+	if s.Command != "hermes-custom" {
+		t.Errorf("expected Command=%q, got %q", "hermes-custom", s.Command)
+	}
+	if s.GatewayURL != "ws://localhost:9999" {
+		t.Errorf("expected GatewayURL=%q, got %q", "ws://localhost:9999", s.GatewayURL)
+	}
+	if !s.YoloMode {
+		t.Errorf("expected YoloMode=true, got false")
+	}
+}

--- a/internal/session/hermes_hooks.go
+++ b/internal/session/hermes_hooks.go
@@ -1,0 +1,352 @@
+package session
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// hermesConfigMu serializes mutations to a given Hermes config.yaml within
+// this process. Keyed by absolute config-file path so two writers in the same
+// process wait for each other instead of racing the read-modify-write.
+//
+// Cross-process serialization is provided by advisory flock on a sibling
+// `.lock` file (see acquireHermesConfigLock). Together they cover both cases
+// that matter: TUI auto-inject racing with `agent-deck hermes-hooks` in
+// another shell, or `-race` tests inside one binary.
+var hermesConfigMu sync.Map // map[string]*sync.Mutex
+
+// hermesConfigLock holds both lock layers; Release() unwinds them in reverse.
+type hermesConfigLock struct {
+	inProc *sync.Mutex
+	file   *os.File
+}
+
+func (l *hermesConfigLock) Release() {
+	if l.file != nil {
+		// Best-effort: LOCK_UN errors are non-actionable; Close drops the fd
+		// either way, which also releases the lock.
+		_ = syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+		_ = l.file.Close()
+	}
+	if l.inProc != nil {
+		l.inProc.Unlock()
+	}
+}
+
+// acquireHermesConfigLock takes the in-process mutex for this config path,
+// then an exclusive advisory file lock on `<configPath>.lock`. Both must
+// release before another writer can proceed.
+func acquireHermesConfigLock(configPath string) (*hermesConfigLock, error) {
+	mIface, _ := hermesConfigMu.LoadOrStore(configPath, &sync.Mutex{})
+	m := mIface.(*sync.Mutex)
+	m.Lock()
+
+	lockPath := configPath + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		m.Unlock()
+		return nil, fmt.Errorf("ensure hermes config lock dir: %w", err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		m.Unlock()
+		return nil, fmt.Errorf("open hermes config lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		m.Unlock()
+		return nil, fmt.Errorf("flock hermes config: %w", err)
+	}
+	return &hermesConfigLock{inProc: m, file: f}, nil
+}
+
+// uniqueHermesConfigTmpPath returns a per-writer temp filename so two
+// concurrent writers can't rename-clobber each other's in-flight payload even
+// if the locking layer above is bypassed for any reason. PID + nanosecond
+// timestamp is sufficient: only one writer in any given process can be at this
+// point at a time (we hold the in-process mutex), and nanosecond timestamps
+// don't collide across processes within a 1ns window in practice.
+func uniqueHermesConfigTmpPath(target string) string {
+	return fmt.Sprintf("%s.%d.%d.tmp", target, os.Getpid(), time.Now().UnixNano())
+}
+
+// agentDeckHermesHookCommand is the exact command string we write into
+// config.yaml's hooks entries. Detection uses equality, not substring, so a
+// user hook that happens to mention "agent-deck hook-handler" in passing isn't
+// misidentified as ours and clobbered by RemoveHermesHooks.
+const agentDeckHermesHookCommand = "agent-deck hook-handler"
+
+// isAgentDeckOwnedHook returns true iff the given hook command was written by
+// us. Matches the exact injected string (with surrounding whitespace tolerated)
+// rather than using substring containment.
+func isAgentDeckOwnedHook(cmd string) bool {
+	return strings.TrimSpace(cmd) == agentDeckHermesHookCommand
+}
+
+// hermesHookEvents are the Hermes lifecycle events we subscribe to.
+// pre_tool_call/post_tool_call bracket each tool call (running/waiting).
+// on_session_start provides an initial waiting state.
+// on_session_end signals the session is dead.
+var hermesHookEvents = []string{
+	"pre_tool_call",
+	"post_tool_call",
+	"on_session_start",
+	"on_session_end",
+}
+
+// GetHermesConfigDir returns the Hermes config directory (~/.hermes).
+func GetHermesConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".hermes")
+	}
+	return filepath.Join(home, ".hermes")
+}
+
+// InjectHermesHooks injects agent-deck hook entries into Hermes's config.yaml.
+// Uses read-preserve-modify-write to keep all existing config keys intact.
+// Serialized via per-config in-process mutex + cross-process flock so two
+// concurrent writers (e.g. TUI auto-inject + CLI `agent-deck hermes-hooks`)
+// can't tear each other's merge.
+// Returns true if hooks were newly installed, false if already present.
+func InjectHermesHooks(configDir string) (bool, error) {
+	configPath := filepath.Join(configDir, "config.yaml")
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return false, fmt.Errorf("create config dir: %w", err)
+	}
+
+	lock, err := acquireHermesConfigLock(configPath)
+	if err != nil {
+		return false, err
+	}
+	defer lock.Release()
+
+	var raw map[string]interface{}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("read config.yaml: %w", err)
+		}
+		raw = make(map[string]interface{})
+	} else {
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			return false, fmt.Errorf("parse config.yaml: %w", err)
+		}
+		if raw == nil {
+			raw = make(map[string]interface{})
+		}
+	}
+
+	if hermesHooksAlreadyInstalled(raw) {
+		return false, nil
+	}
+
+	mergeHermesHookEntries(raw)
+
+	out, err := yaml.Marshal(raw)
+	if err != nil {
+		return false, fmt.Errorf("marshal config.yaml: %w", err)
+	}
+
+	tmpPath := uniqueHermesConfigTmpPath(configPath)
+	if err := os.WriteFile(tmpPath, out, 0600); err != nil {
+		return false, fmt.Errorf("write config.yaml tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, configPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return false, fmt.Errorf("rename config.yaml: %w", err)
+	}
+
+	sessionLog.Info("hermes_hooks_installed", slog.String("config_dir", configDir))
+	return true, nil
+}
+
+// RemoveHermesHooks removes agent-deck hook entries from Hermes's config.yaml.
+// Serialized via per-config in-process mutex + cross-process flock (see
+// InjectHermesHooks).
+// Returns true if hooks were removed, false if none found.
+func RemoveHermesHooks(configDir string) (bool, error) {
+	configPath := filepath.Join(configDir, "config.yaml")
+
+	// Fast path: if config.yaml doesn't exist, there is nothing to remove.
+	// Skip acquireHermesConfigLock so a no-op uninstall on a fresh machine
+	// does not create ~/.hermes/ or the sibling .lock file just to discover
+	// the config is absent.
+	if _, err := os.Stat(configPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat config.yaml: %w", err)
+	}
+
+	lock, err := acquireHermesConfigLock(configPath)
+	if err != nil {
+		return false, err
+	}
+	defer lock.Release()
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		// Race: file existed at stat time, then was removed before we read it.
+		// Treat as no-op rather than error.
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read config.yaml: %w", err)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return false, fmt.Errorf("parse config.yaml: %w", err)
+	}
+	if raw == nil {
+		return false, nil
+	}
+
+	hooksSection, _ := raw["hooks"].(map[string]interface{})
+	if hooksSection == nil {
+		return false, nil
+	}
+
+	removed := false
+	for _, event := range hermesHookEvents {
+		eventHooks, _ := hooksSection[event].([]interface{})
+		// Per-event flag so we only rewrite/delete entries this event actually
+		// changed. If a prior event removed our hook, `removed` would still be
+		// true on later iterations and could silently drop an unrelated event
+		// whose value isn't a list (type assertion fails → eventHooks==nil →
+		// kept==nil → `if removed` would trigger delete on user config).
+		eventRemoved := false
+		var kept []interface{}
+		for _, h := range eventHooks {
+			hm, ok := h.(map[string]interface{})
+			if !ok {
+				kept = append(kept, h)
+				continue
+			}
+			cmd, _ := hm["command"].(string)
+			if isAgentDeckOwnedHook(cmd) {
+				removed = true
+				eventRemoved = true
+				continue
+			}
+			kept = append(kept, h)
+		}
+		if eventRemoved {
+			if len(kept) == 0 {
+				delete(hooksSection, event)
+			} else {
+				hooksSection[event] = kept
+			}
+		}
+	}
+
+	if !removed {
+		return false, nil
+	}
+
+	if len(hooksSection) == 0 {
+		delete(raw, "hooks")
+	} else {
+		raw["hooks"] = hooksSection
+	}
+
+	out, err := yaml.Marshal(raw)
+	if err != nil {
+		return false, fmt.Errorf("marshal config.yaml: %w", err)
+	}
+
+	tmpPath := uniqueHermesConfigTmpPath(configPath)
+	if err := os.WriteFile(tmpPath, out, 0600); err != nil {
+		return false, fmt.Errorf("write config.yaml tmp: %w", err)
+	}
+	if err := os.Rename(tmpPath, configPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return false, fmt.Errorf("rename config.yaml: %w", err)
+	}
+
+	sessionLog.Info("hermes_hooks_removed", slog.String("config_dir", configDir))
+	return true, nil
+}
+
+// CheckHermesHooksInstalled returns true if all agent-deck hook entries are
+// present in Hermes's config.yaml.
+func CheckHermesHooksInstalled(configDir string) bool {
+	data, err := os.ReadFile(filepath.Join(configDir, "config.yaml"))
+	if err != nil {
+		return false
+	}
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+	return hermesHooksAlreadyInstalled(raw)
+}
+
+// hermesHooksAlreadyInstalled checks that every required event has an
+// agent-deck hook entry.
+func hermesHooksAlreadyInstalled(raw map[string]interface{}) bool {
+	hooksSection, _ := raw["hooks"].(map[string]interface{})
+	if hooksSection == nil {
+		return false
+	}
+	for _, event := range hermesHookEvents {
+		eventHooks, _ := hooksSection[event].([]interface{})
+		found := false
+		for _, h := range eventHooks {
+			hm, ok := h.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			cmd, _ := hm["command"].(string)
+			if isAgentDeckOwnedHook(cmd) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// mergeHermesHookEntries appends agent-deck hook entries for any missing events.
+func mergeHermesHookEntries(raw map[string]interface{}) {
+	hooksSection, _ := raw["hooks"].(map[string]interface{})
+	if hooksSection == nil {
+		hooksSection = make(map[string]interface{})
+	}
+
+	for _, event := range hermesHookEvents {
+		eventHooks, _ := hooksSection[event].([]interface{})
+		alreadyPresent := false
+		for _, h := range eventHooks {
+			hm, ok := h.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			cmd, _ := hm["command"].(string)
+			if isAgentDeckOwnedHook(cmd) {
+				alreadyPresent = true
+				break
+			}
+		}
+		if !alreadyPresent {
+			eventHooks = append(eventHooks, map[string]interface{}{
+				"command": agentDeckHermesHookCommand,
+			})
+			hooksSection[event] = eventHooks
+		}
+	}
+
+	raw["hooks"] = hooksSection
+}

--- a/internal/session/hermes_hooks_test.go
+++ b/internal/session/hermes_hooks_test.go
@@ -1,0 +1,358 @@
+package session_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"gopkg.in/yaml.v3"
+)
+
+func TestInjectHermesHooks_FreshInstall(t *testing.T) {
+	dir := t.TempDir()
+	installed, err := session.InjectHermesHooks(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !installed {
+		t.Fatal("expected installed=true on fresh install")
+	}
+	if !session.CheckHermesHooksInstalled(dir) {
+		t.Fatal("CheckHermesHooksInstalled returned false after install")
+	}
+}
+
+func TestInjectHermesHooks_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := session.InjectHermesHooks(dir); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	installed, err := session.InjectHermesHooks(dir)
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if installed {
+		t.Fatal("expected installed=false on second call (already present)")
+	}
+}
+
+func TestInjectHermesHooks_AllEventsPresent(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := session.InjectHermesHooks(dir); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse config.yaml: %v", err)
+	}
+
+	hooksSection, _ := raw["hooks"].(map[string]interface{})
+	if hooksSection == nil {
+		t.Fatal("no hooks section in config.yaml")
+	}
+
+	for _, event := range []string{"pre_tool_call", "post_tool_call", "on_session_start", "on_session_end"} {
+		entries, _ := hooksSection[event].([]interface{})
+		found := false
+		for _, e := range entries {
+			em, _ := e.(map[string]interface{})
+			if cmd, _ := em["command"].(string); strings.Contains(cmd, "agent-deck hook-handler") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("event %q missing agent-deck hook-handler entry", event)
+		}
+	}
+}
+
+func TestInjectHermesHooks_PreservesExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	existing := []byte("model: hermes-3-70b\ntemperature: 0.7\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), existing, 0644); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	if _, err := session.InjectHermesHooks(dir); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	content := string(data)
+	if !strings.Contains(content, "hermes-3-70b") {
+		t.Error("model key was lost after injection")
+	}
+	if !strings.Contains(content, "0.7") {
+		t.Error("temperature key was lost after injection")
+	}
+	if !strings.Contains(content, "agent-deck hook-handler") {
+		t.Error("hook command not found after injection")
+	}
+}
+
+func TestInjectHermesHooks_PreservesExistingHooks(t *testing.T) {
+	dir := t.TempDir()
+	existing := []byte(`hooks:
+  pre_tool_call:
+    - command: /usr/local/bin/my-hook.sh
+`)
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), existing, 0644); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	if _, err := session.InjectHermesHooks(dir); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	content := string(data)
+	if !strings.Contains(content, "/usr/local/bin/my-hook.sh") {
+		t.Error("existing user hook was removed")
+	}
+	if !strings.Contains(content, "agent-deck hook-handler") {
+		t.Error("agent-deck hook not added")
+	}
+}
+
+func TestRemoveHermesHooks_Removes(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := session.InjectHermesHooks(dir); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	removed, err := session.RemoveHermesHooks(dir)
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if !removed {
+		t.Fatal("expected removed=true")
+	}
+	if session.CheckHermesHooksInstalled(dir) {
+		t.Fatal("hooks still detected after removal")
+	}
+}
+
+func TestRemoveHermesHooks_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	removed, err := session.RemoveHermesHooks(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed {
+		t.Fatal("expected removed=false when file doesn't exist")
+	}
+}
+
+func TestRemoveHermesHooks_PreservesUserHooks(t *testing.T) {
+	dir := t.TempDir()
+	existing := []byte(`hooks:
+  pre_tool_call:
+    - command: /usr/local/bin/my-hook.sh
+`)
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), existing, 0644); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	if _, err := session.InjectHermesHooks(dir); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if _, err := session.RemoveHermesHooks(dir); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if !strings.Contains(string(data), "/usr/local/bin/my-hook.sh") {
+		t.Error("user hook was removed along with agent-deck hook")
+	}
+}
+
+// TestRemoveHermesHooks_PreservesUserHookContainingSubstring guards against
+// the substring-match false positive that the prior `strings.Contains` check
+// suffered. A user hook whose command merely mentions "agent-deck hook-handler"
+// (e.g. a wrapper script that logs or forwards to it) is NOT agent-deck-owned
+// and must survive RemoveHermesHooks.
+func TestRemoveHermesHooks_PreservesUserHookContainingSubstring(t *testing.T) {
+	dir := t.TempDir()
+	// User hook command happens to contain the agent-deck phrase as a
+	// substring. With the prior substring matcher this entry would be
+	// silently deleted by RemoveHermesHooks.
+	existing := []byte(`hooks:
+  pre_tool_call:
+    - command: /usr/local/bin/wrap.sh agent-deck hook-handler --debug
+`)
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), existing, 0644); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	if _, err := session.InjectHermesHooks(dir); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if _, err := session.RemoveHermesHooks(dir); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if !strings.Contains(string(data), "/usr/local/bin/wrap.sh agent-deck hook-handler --debug") {
+		t.Errorf("user hook containing agent-deck substring was clobbered; config: %s", data)
+	}
+}
+
+// TestInjectRemoveHermesHooks_ConcurrentSafe runs many parallel inject/remove
+// cycles against a single config path to exercise the in-process keyed mutex.
+// Under -race this catches read-modify-write tears and shared-tmp clobbers.
+func TestInjectRemoveHermesHooks_ConcurrentSafe(t *testing.T) {
+	dir := t.TempDir()
+	// Seed with one user-owned hook so we can verify it survives every cycle.
+	existing := []byte(`hooks:
+  pre_tool_call:
+    - command: /opt/user/sentinel.sh
+`)
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), existing, 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	const goroutines = 8
+	const cycles = 5
+	done := make(chan error, goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			for c := 0; c < cycles; c++ {
+				if _, err := session.InjectHermesHooks(dir); err != nil {
+					done <- err
+					return
+				}
+				if _, err := session.RemoveHermesHooks(dir); err != nil {
+					done <- err
+					return
+				}
+			}
+			done <- nil
+		}()
+	}
+	for g := 0; g < goroutines; g++ {
+		if err := <-done; err != nil {
+			t.Fatalf("concurrent inject/remove: %v", err)
+		}
+	}
+
+	// After the storm, the user-owned sentinel hook must still be there.
+	data, _ := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if !strings.Contains(string(data), "/opt/user/sentinel.sh") {
+		t.Errorf("user sentinel hook lost after concurrent inject/remove storm; config: %s", data)
+	}
+}
+
+// TestRemoveHermesHooks_NoOpDoesNotCreateArtifacts guards against a regression
+// where acquireHermesConfigLock would MkdirAll + create config.yaml.lock even
+// when config.yaml itself didn't exist, so `agent-deck hermes-hooks uninstall`
+// on a fresh machine left behind an unwanted ~/.hermes/ directory.
+func TestRemoveHermesHooks_NoOpDoesNotCreateArtifacts(t *testing.T) {
+	parent := t.TempDir()
+	configDir := filepath.Join(parent, "never-existed")
+	// configDir does NOT exist yet. Remove should be a clean no-op.
+
+	removed, err := session.RemoveHermesHooks(configDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed {
+		t.Error("expected removed=false for non-existent config")
+	}
+
+	// Critical: configDir and the .lock file must NOT have been created.
+	if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+		t.Errorf("configDir was created by no-op uninstall (err=%v); should be untouched", err)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "config.yaml.lock")); !os.IsNotExist(err) {
+		t.Errorf("config.yaml.lock was created by no-op uninstall (err=%v); should not exist", err)
+	}
+}
+
+// TestRemoveHermesHooks_PreservesMalformedSiblingEvent guards against the
+// shared-flag bug where, once any event lost an agent-deck hook, a subsequent
+// event whose value wasn't a list would be silently deleted from user config.
+func TestRemoveHermesHooks_PreservesMalformedSiblingEvent(t *testing.T) {
+	dir := t.TempDir()
+	// post_tool_call holds a string instead of a list — odd but valid user
+	// config; we must not destroy it just because we removed our hook from
+	// pre_tool_call.
+	existing := []byte(`hooks:
+  pre_tool_call:
+    - command: agent-deck hook-handler
+  post_tool_call: keep-this-string
+`)
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), existing, 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, err := session.RemoveHermesHooks(dir); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	if !strings.Contains(string(data), "keep-this-string") {
+		t.Errorf("malformed sibling event was clobbered; config: %s", data)
+	}
+}
+
+func TestCheckHermesHooksInstalled_NotPresent(t *testing.T) {
+	dir := t.TempDir()
+	if session.CheckHermesHooksInstalled(dir) {
+		t.Fatal("expected false for empty dir")
+	}
+}
+
+func TestGetHermesConfigDir_ReturnsPath(t *testing.T) {
+	dir := session.GetHermesConfigDir()
+	if dir == "" {
+		t.Fatal("GetHermesConfigDir returned empty string")
+	}
+	if !strings.Contains(dir, ".hermes") {
+		t.Errorf("expected .hermes in path, got %q", dir)
+	}
+}
+
+func TestInjectHermesHooks_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := session.InjectHermesHooks(dir); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("stat config.yaml: %v", err)
+	}
+	// Config contains secrets (model keys, hook commands) — must not be world-readable.
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("config.yaml permissions = %04o, want 0600", perm)
+	}
+}
+
+func TestRemoveHermesHooks_FilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := session.InjectHermesHooks(dir); err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if _, err := session.RemoveHermesHooks(dir); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	// File still exists (user hooks may have been kept); permissions must be 0600.
+	info, err := os.Stat(filepath.Join(dir, "config.yaml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return // file removed entirely — nothing to check
+		}
+		t.Fatalf("stat config.yaml: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("config.yaml permissions after remove = %04o, want 0600", perm)
+	}
+}

--- a/internal/session/hermes_test.go
+++ b/internal/session/hermes_test.go
@@ -2,6 +2,9 @@ package session
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -244,5 +247,72 @@ func TestBuildHermesCommand_Passthrough(t *testing.T) {
 	got := inst.buildHermesCommand("hermes --special-flag")
 	if !strings.HasSuffix(got, "hermes --special-flag") {
 		t.Errorf("buildHermesCommand passthrough = %q, want suffix \"hermes --special-flag\"", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gateway health check tests
+// ---------------------------------------------------------------------------
+
+func TestIsHermesGatewayReachable_EmptyURL(t *testing.T) {
+	if IsHermesGatewayReachable("") {
+		t.Error("IsHermesGatewayReachable(\"\") = true, want false")
+	}
+}
+
+func TestIsHermesGatewayReachable_InvalidURL(t *testing.T) {
+	// Port 1 almost certainly has no listener; the connection should be refused.
+	if IsHermesGatewayReachable("http://127.0.0.1:1") {
+		t.Error("IsHermesGatewayReachable(\"http://127.0.0.1:1\") = true, want false")
+	}
+}
+
+func TestIsHermesGatewayReachable_ReachableServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if !IsHermesGatewayReachable(srv.URL) {
+		t.Errorf("IsHermesGatewayReachable(%q) = false, want true (200 OK)", srv.URL)
+	}
+}
+
+func TestIsHermesGatewayReachable_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if IsHermesGatewayReachable(srv.URL) {
+		t.Errorf("IsHermesGatewayReachable(%q) = true, want false (500 >= 500 means unreachable)", srv.URL)
+	}
+}
+
+func TestIsHermesGatewayReachable_ServerRedirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusFound) // 302
+	}))
+	defer srv.Close()
+
+	if !IsHermesGatewayReachable(srv.URL) {
+		t.Errorf("IsHermesGatewayReachable(%q) = false, want true (302 < 500)", srv.URL)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shared workspace tests
+// ---------------------------------------------------------------------------
+
+func TestHermesSharedWorkspaceDir_NonEmpty(t *testing.T) {
+	if HermesSharedWorkspaceDir() == "" {
+		t.Error("HermesSharedWorkspaceDir() returned empty string, want non-empty")
+	}
+}
+
+func TestHermesSharedWorkspaceDir_IsAbsolute(t *testing.T) {
+	dir := HermesSharedWorkspaceDir()
+	if !filepath.IsAbs(dir) {
+		t.Errorf("HermesSharedWorkspaceDir() = %q, want absolute path", dir)
 	}
 }

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -356,6 +356,10 @@ type Instance struct {
 	// Set by MCP dialog Apply() to avoid race condition where Apply writes
 	// config then Restart immediately overwrites it with different pool state
 	SkipMCPRegenerate bool `json:"-"` // Don't persist, transient flag
+
+	// Gateway health cache for Hermes sessions (volatile, not persisted).
+	hermesGatewayCheckedAt time.Time
+	hermesGatewayOK        bool
 }
 
 // SandboxConfig holds per-session Docker sandbox settings.
@@ -3375,7 +3379,7 @@ func (i *Instance) UpdateStatus() error {
 
 	// COLD LOAD: CLI doesn't run StatusFileWatcher, so hookStatus is always empty.
 	// Read the hook file from disk once to give CLI the same fast path as the TUI.
-	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini") {
+	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini" || i.Tool == "hermes") {
 		if hs := readHookStatusFile(i.ID); hs != nil {
 			i.hookStatus = hs.Status
 			i.hookEvent = hs.Event
@@ -3394,7 +3398,7 @@ func (i *Instance) UpdateStatus() error {
 	// Freshness is tool- and state-specific (e.g. Codex running vs waiting).
 	// When this path is stale/missing, control naturally falls through to tmux
 	// polling and tool-specific session sync (tmux env/process-files/disk).
-	if (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini") &&
+	if (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini" || i.Tool == "hermes") &&
 		i.hookStatus != "" &&
 		time.Since(i.hookLastUpdate) < hookFastPathFreshnessForTool(i.Tool, i.hookStatus) {
 		switch i.hookStatus {
@@ -3448,6 +3452,32 @@ func (i *Instance) UpdateStatus() error {
 				}
 			}
 		}
+		// A1: For Hermes, run the gateway reachability check even on the fast path.
+		// Without this, a dead gateway can still report running/waiting for the full
+		// hook freshness window because the check below is skipped.
+		// Use GetHermesGatewayURL() so the common auto-discovery setup (no explicit
+		// [hermes].gateway_url in config) still gets gateway-health degradation —
+		// reading config.Hermes.GatewayURL directly would skip the discovery path
+		// via ~/.hermes/gateway_state.json.
+		if i.Tool == "hermes" && (i.Status == StatusRunning || i.Status == StatusWaiting) {
+			if gatewayURL := GetHermesGatewayURL(); gatewayURL != "" {
+				if time.Since(i.hermesGatewayCheckedAt) > 30*time.Second {
+					i.mu.Unlock()
+					reachable := IsHermesGatewayReachable(gatewayURL)
+					i.mu.Lock()
+					// Mirror the stale-stop guard from the tmux path: a concurrent
+					// Kill() may have published StatusStopped while we were unlocked.
+					if i.Status == StatusStopped {
+						return nil
+					}
+					i.hermesGatewayCheckedAt = time.Now()
+					i.hermesGatewayOK = reachable
+				}
+				if !i.hermesGatewayOK {
+					i.Status = StatusError
+				}
+			}
+		}
 		return nil
 	}
 
@@ -3488,6 +3518,33 @@ func (i *Instance) UpdateStatus() error {
 		i.Status = StatusError
 	default:
 		i.Status = StatusError
+	}
+
+	// Hermes: augment status with gateway health when a gateway URL is resolvable.
+	// Check is throttled to 30s to avoid 1.5s HTTP delays on every status tick.
+	// Use GetHermesGatewayURL() so the auto-discovery path (gateway_state.json +
+	// loopback probe) gets the same degradation behavior as an explicit config
+	// override — without this, users on the documented-easy setup never see a
+	// dead gateway flip them to StatusError.
+	if i.Tool == "hermes" && i.Status != StatusStopped && i.Status != StatusError {
+		if gatewayURL := GetHermesGatewayURL(); gatewayURL != "" {
+			if time.Since(i.hermesGatewayCheckedAt) > 30*time.Second {
+				// A2: A concurrent Kill() may publish StatusStopped while we are
+				// unlocked for the HTTP probe; re-check after reacquiring the lock
+				// and skip the write to avoid clobbering the stop.
+				i.mu.Unlock()
+				reachable := IsHermesGatewayReachable(gatewayURL)
+				i.mu.Lock()
+				if i.Status == StatusStopped {
+					return nil
+				}
+				i.hermesGatewayCheckedAt = time.Now()
+				i.hermesGatewayOK = reachable
+			}
+			if !i.hermesGatewayOK {
+				i.Status = StatusError
+			}
+		}
 	}
 
 	// Update tool detection dynamically (enables fork when wrapped tools start).
@@ -6275,6 +6332,32 @@ func (i *Instance) SetCodexOptions(opts *CodexOptions) error {
 	return nil
 }
 
+// GetHermesOptions returns Hermes-specific options from ToolOptionsJSON, or nil if not set.
+func (i *Instance) GetHermesOptions() *HermesOptions {
+	if len(i.ToolOptionsJSON) == 0 {
+		return nil
+	}
+	opts, err := UnmarshalHermesOptions(i.ToolOptionsJSON)
+	if err != nil {
+		return nil
+	}
+	return opts
+}
+
+// SetHermesOptions stores Hermes-specific options into ToolOptionsJSON.
+func (i *Instance) SetHermesOptions(opts *HermesOptions) error {
+	if opts == nil {
+		i.ToolOptionsJSON = nil
+		return nil
+	}
+	data, err := MarshalToolOptions(opts)
+	if err != nil {
+		return err
+	}
+	i.ToolOptionsJSON = data
+	return nil
+}
+
 // GetOpenCodeOptions returns OpenCode-specific options, or nil if not set
 func (i *Instance) GetOpenCodeOptions() *OpenCodeOptions {
 	if len(i.ToolOptionsJSON) == 0 {
@@ -6337,8 +6420,11 @@ func (i *Instance) RefreshLiveSessionIDs() {
 	}
 }
 
-// GetMCPInfo returns MCP server information for this session
-// Returns nil if not a Claude, Gemini, or Cursor session
+// GetMCPInfo returns MCP server information for this session.
+// Returns nil if not a Claude-compatible, Gemini, or Cursor session.
+// Hermes is intentionally excluded: it uses its own ~/.hermes/config.yaml
+// `mcp_servers:` schema (user-scoped, YAML), not Claude's project-scoped
+// .mcp.json — agent-deck does not manage it yet.
 func (i *Instance) GetMCPInfo() *MCPInfo {
 	switch {
 	case IsClaudeCompatible(i.Tool):

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -21,6 +21,7 @@ const (
 	projectSkillsManifest    = "skills.toml"
 	projectClaudeSkillsDir   = ".claude/skills"
 	projectAgentsSkillsDir   = ".agents/skills"
+	projectHermesSkillsDir   = ".hermes/skills"
 	defaultSkillSourcePool   = "pool"
 	defaultSkillSourceClaude = "claude-global"
 )
@@ -122,7 +123,7 @@ func skillIDForAttachment(a ProjectSkillAttachment) string {
 }
 
 func knownProjectSkillsDirs() []string {
-	return []string{projectClaudeSkillsDir, projectAgentsSkillsDir}
+	return []string{projectClaudeSkillsDir, projectAgentsSkillsDir, projectHermesSkillsDir}
 }
 
 // SupportsProjectSkills reports whether the runtime supports project skill materialization.
@@ -134,7 +135,7 @@ func SupportsProjectSkills(tool string) bool {
 // ShouldRestartProjectSkills reports whether agent-deck should auto-restart the session
 // after project skill changes for this runtime.
 func ShouldRestartProjectSkills(tool string) bool {
-	return IsClaudeCompatible(tool) || tool == "gemini" || tool == "codex"
+	return IsClaudeCompatible(tool) || tool == "gemini" || tool == "codex" || tool == "hermes"
 }
 
 // GetProjectSkillsDir returns the runtime-managed project skill directory.
@@ -144,6 +145,8 @@ func GetProjectSkillsDir(tool string) (string, bool) {
 		return projectClaudeSkillsDir, true
 	case tool == "gemini" || tool == "codex" || tool == "pi":
 		return projectAgentsSkillsDir, true
+	case tool == "hermes":
+		return projectHermesSkillsDir, true
 	default:
 		return "", false
 	}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -405,6 +405,8 @@ type ProfileCodexSettings struct {
 type GroupSettings struct {
 	// Claude defines Claude Code overrides for a specific group.
 	Claude GroupClaudeSettings `toml:"claude"`
+	// Hermes defines Hermes overrides for a specific group.
+	Hermes GroupHermesSettings `toml:"hermes"`
 }
 
 // GroupClaudeSettings defines group-specific Claude overrides.
@@ -414,6 +416,16 @@ type GroupClaudeSettings struct {
 
 	// EnvFile overrides [claude].env_file for sessions in this group.
 	EnvFile string `toml:"env_file"`
+}
+
+// GroupHermesSettings defines group-specific Hermes overrides.
+type GroupHermesSettings struct {
+	Command      string `toml:"command"`
+	EnvFile      string `toml:"env_file"`
+	YoloMode     bool   `toml:"yolo_mode"`
+	GatewayURL   string `toml:"gateway_url"`
+	DashboardURL string `toml:"dashboard_url"`
+	APITokenEnv  string `toml:"api_token_env"`
 }
 
 // ConductorOverrides defines per-conductor configuration overrides.
@@ -428,6 +440,8 @@ type GroupClaudeSettings struct {
 type ConductorOverrides struct {
 	// Claude defines Claude Code overrides for a specific conductor.
 	Claude ConductorClaudeSettings `toml:"claude"`
+	// Hermes defines Hermes overrides for a specific conductor.
+	Hermes ConductorHermesSettings `toml:"hermes"`
 }
 
 // ConductorClaudeSettings defines conductor-specific Claude overrides.
@@ -441,6 +455,16 @@ type ConductorClaudeSettings struct {
 	// EnvFile is sourced before claude exec for this conductor.
 	// Matches CFG-03 semantics — missing file logs a warning, does not block.
 	EnvFile string `toml:"env_file"`
+}
+
+// ConductorHermesSettings defines conductor-specific Hermes overrides.
+type ConductorHermesSettings struct {
+	Command      string `toml:"command"`
+	EnvFile      string `toml:"env_file"`
+	YoloMode     bool   `toml:"yolo_mode"`
+	GatewayURL   string `toml:"gateway_url"`
+	DashboardURL string `toml:"dashboard_url"`
+	APITokenEnv  string `toml:"api_token_env"`
 }
 
 // MCPPoolSettings defines HTTP MCP pool configuration
@@ -939,6 +963,21 @@ func (c *UserConfig) GetGroupClaudeEnvFile(groupPath string) string {
 	return ""
 }
 
+// GetGroupHermesEnvFile returns the group-specific Hermes env file, walking
+// ancestor groups when the exact path has no override. Mirrors
+// GetGroupClaudeEnvFile's inheritance semantics.
+func (c *UserConfig) GetGroupHermesEnvFile(groupPath string) string {
+	if c == nil || groupPath == "" || c.Groups == nil {
+		return ""
+	}
+	for p := groupPath; p != ""; p = getParentPath(p) {
+		if groupCfg, ok := c.Groups[p]; ok && groupCfg.Hermes.EnvFile != "" {
+			return groupCfg.Hermes.EnvFile
+		}
+	}
+	return ""
+}
+
 // GetConductorClaudeConfigDir returns the conductor-specific Claude config
 // directory, if configured. Keyed by conductor name (Instance.Title minus
 // "conductor-" prefix — single source of truth is conductorNameFromInstance
@@ -968,6 +1007,19 @@ func (c *UserConfig) GetConductorClaudeEnvFile(name string) string {
 		return ""
 	}
 	return conductorCfg.Claude.EnvFile
+}
+
+// GetConductorHermesEnvFile returns the conductor-specific Hermes env_file,
+// if configured. Mirrors GetConductorClaudeEnvFile.
+func (c *UserConfig) GetConductorHermesEnvFile(name string) string {
+	if c == nil || name == "" || c.Conductors == nil {
+		return ""
+	}
+	conductorCfg, ok := c.Conductors[name]
+	if !ok || conductorCfg.Hermes.EnvFile == "" {
+		return ""
+	}
+	return conductorCfg.Hermes.EnvFile
 }
 
 // GetDangerousMode returns whether dangerous mode is enabled, defaulting to true
@@ -1108,6 +1160,18 @@ type HermesSettings struct {
 	// YoloMode enables --yolo flag for Hermes sessions (auto-approve all tool calls).
 	// Default: false
 	YoloMode bool `toml:"yolo_mode"`
+	// GatewayURL is the WebSocket URL of the Hermes gateway for health checks.
+	// Default: "" (no gateway health check)
+	GatewayURL string `toml:"gateway_url"`
+	// DashboardURL is the Hermes dashboard API endpoint.
+	// Default: "" (dashboard integration disabled)
+	DashboardURL string `toml:"dashboard_url"`
+	// APITokenEnv is the environment variable name containing the Hermes API token.
+	// Default: "" (uses HERMES_API_TOKEN if set)
+	APITokenEnv string `toml:"api_token_env"`
+	// WorkspaceDir is the base directory for Hermes shared workspace sessions.
+	// Default: "" (uses os.TempDir()/hermes-workspaces)
+	WorkspaceDir string `toml:"workspace_dir"`
 }
 
 // CrushSettings defines charmbracelet/crush CLI configuration (Issue #940).

--- a/internal/sessionstatus/sessionstatus.go
+++ b/internal/sessionstatus/sessionstatus.go
@@ -88,11 +88,13 @@ type Decision struct {
 
 // IsHookEmittingTool returns true for tools that emit lifecycle hook files.
 // Mirrors the gate at internal/session/instance.go:2854 + 2873.
+// Hermes uses the same shell hook model as Claude Code and Gemini; hooks are
+// injected via `agent-deck hermes-hooks install` into ~/.hermes/config.yaml.
 func IsHookEmittingTool(tool string) bool {
 	if session.IsClaudeCompatible(tool) {
 		return true
 	}
-	return tool == "codex" || tool == "gemini"
+	return tool == "codex" || tool == "gemini" || tool == "hermes"
 }
 
 // freshnessFor returns the freshness window for a (tool, hookStatus) pair.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -1170,6 +1171,36 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 			}
 			if !prompted {
 				h.pendingHooksPrompt = true
+			}
+		}
+	}
+
+	// Hermes shell hooks: auto-inject silently if the hermes binary is available.
+	// No user prompt needed — config.yaml is Hermes's own config file, not a
+	// shared settings file. The shared hook watcher (h.hookWatcher) covers all
+	// tools, so start it here if Claude hooks didn't already start it.
+	if hermesCmd := strings.TrimSpace(session.GetToolCommand("hermes")); hermesCmd != "" {
+		// GetToolCommand may return a full command string with arguments
+		// (e.g. "hermes --gateway-url=..."). LookPath needs the binary name only.
+		// Trim first because Fields("") and Fields("   ") both return [], and
+		// indexing [0] on an empty slice panics.
+		if hermesFields := strings.Fields(hermesCmd); len(hermesFields) > 0 {
+			hermesBin := hermesFields[0]
+			if _, err := exec.LookPath(hermesBin); err == nil {
+				hermesConfigDir := session.GetHermesConfigDir()
+				if !session.CheckHermesHooksInstalled(hermesConfigDir) {
+					if _, err := session.InjectHermesHooks(hermesConfigDir); err != nil {
+						uiLog.Warn("hermes_hooks_inject_failed", slog.String("error", err.Error()))
+					} else {
+						uiLog.Info("hermes_hooks_installed", slog.String("config_dir", hermesConfigDir))
+					}
+				}
+				if h.hookWatcher == nil {
+					if hookWatcher, err := session.NewStatusFileWatcher(nil); err == nil {
+						h.hookWatcher = hookWatcher
+						go hookWatcher.Start()
+					}
+				}
 			}
 		}
 	}
@@ -3228,7 +3259,7 @@ func (h *Home) backgroundStatusUpdate() {
 	// Feed hook statuses from watcher to instances (enables hook fast path in UpdateStatus)
 	if h.hookWatcher != nil {
 		for _, inst := range instances {
-			if session.IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" {
+			if session.IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" || inst.Tool == "hermes" {
 				if hs := h.hookWatcher.GetHookStatus(inst.ID); hs != nil {
 					inst.UpdateHookStatus(hs)
 				}
@@ -5754,6 +5785,10 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			yolo := h.newDialog.GetCodexYoloMode()
 			codexOpts := &session.CodexOptions{YoloMode: &yolo}
 			toolOptionsJSON, _ = session.MarshalToolOptions(codexOpts)
+		} else if command == "hermes" {
+			yolo := h.newDialog.GetHermesYoloMode()
+			hermesOpts := &session.HermesOptions{YoloMode: &yolo}
+			toolOptionsJSON, _ = session.MarshalToolOptions(hermesOpts)
 		}
 
 		parentSessionID := h.newDialog.GetParentSessionID()
@@ -7216,6 +7251,25 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 					opts.YoloMode = &newYolo
 					_ = inst.SetCodexOptions(opts)
+					toggled = true
+
+				case "hermes":
+					currentYolo := false
+					opts := inst.GetHermesOptions()
+					if opts != nil && opts.YoloMode != nil {
+						currentYolo = *opts.YoloMode
+					} else {
+						userConfig, _ := session.LoadUserConfig()
+						if userConfig != nil {
+							currentYolo = userConfig.Hermes.YoloMode
+						}
+					}
+					newYolo := !currentYolo
+					if opts == nil {
+						opts = &session.HermesOptions{}
+					}
+					opts.YoloMode = &newYolo
+					_ = inst.SetHermesOptions(opts)
 					toggled = true
 				}
 
@@ -12447,6 +12501,16 @@ func (h *Home) renderSessionItem(
 		if opts := inst.GetCodexOptions(); opts != nil && opts.YoloMode != nil && *opts.YoloMode {
 			showYolo = true
 		}
+	} else if instTool == "hermes" {
+		// Mirror the toggle path's resolution: per-session override wins; otherwise
+		// fall back to the global [hermes].yolo_mode in user config. Without the
+		// fallback the badge lies about state for sessions launched with YOLO via
+		// global config but no per-session override.
+		if opts := inst.GetHermesOptions(); opts != nil && opts.YoloMode != nil {
+			showYolo = *opts.YoloMode
+		} else if cfg, _ := session.LoadUserConfig(); cfg != nil && cfg.Hermes.YoloMode {
+			showYolo = true
+		}
 	}
 	if showYolo {
 		yoloStyle := lipgloss.NewStyle().Foreground(ColorYellow).Bold(true)
@@ -13137,13 +13201,16 @@ func (h *Home) renderSessionInfoCard(inst *session.Instance, width, height int) 
 	// Tool
 	b.WriteString(fmt.Sprintf("%s %s\n", labelStyle.Render("Tool:"), valueStyle.Render(cardTool)))
 
-	// Session ID (if available) - Claude, Gemini, or OpenCode
+	// Session ID (if available) - Claude, Gemini, OpenCode, or generic (Hermes/custom tools)
 	sessionID := inst.ClaudeSessionID
 	if sessionID == "" {
 		sessionID = inst.GeminiSessionID
 	}
 	if sessionID == "" {
 		sessionID = inst.OpenCodeSessionID
+	}
+	if sessionID == "" {
+		sessionID = inst.GetGenericSessionID()
 	}
 	if sessionID != "" {
 		shortID := sessionID

--- a/internal/ui/mcp_dialog.go
+++ b/internal/ui/mcp_dialog.go
@@ -44,7 +44,10 @@ type MCPItem struct {
 	HasServerCfg bool   // True if HTTP MCP has [mcps.X.server] config
 }
 
-// MCPDialog handles MCP management for Claude, Gemini, and Cursor Agent CLI sessions
+// MCPDialog handles MCP management for Claude, Gemini, and Cursor Agent CLI sessions.
+// Hermes uses its own ~/.hermes/config.yaml `mcp_servers:` schema (user-scoped,
+// YAML) which is not compatible with Claude's project-scoped .mcp.json — it is
+// excluded from the MCP trigger in home.go (see ToolSupportsMCPManager).
 type MCPDialog struct {
 	visible     bool
 	width       int

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -162,6 +162,7 @@ type NewDialog struct {
 	claudeOptions         *ClaudeOptionsPanel // Claude-specific options (concrete for value extraction).
 	geminiOptions         *YoloOptionsPanel   // Gemini YOLO panel (concrete for value extraction).
 	codexOptions          *YoloOptionsPanel   // Codex YOLO panel (concrete for value extraction).
+	hermesOptions         *YoloOptionsPanel   // Hermes YOLO panel (concrete for value extraction).
 	toolOptions           OptionsPanel        // Currently active tool options panel (nil if none).
 	focusTargets          []focusTarget       // Ordered list of active focusable elements.
 	focusIndex            int                 // Index into focusTargets.
@@ -230,6 +231,7 @@ type dialogSnapshot struct {
 	claudeOptions    *session.ClaudeOptions
 	geminiYolo       bool
 	codexYolo        bool
+	hermesYolo       bool
 	multiRepoEnabled bool
 	multiRepoPaths   []string
 	conductorCursor  int
@@ -330,6 +332,7 @@ func NewNewDialog() *NewDialog {
 		claudeOptions:   NewClaudeOptionsPanel(),
 		geminiOptions:   NewYoloOptionsPanel("Gemini", "YOLO mode - auto-approve all"),
 		codexOptions:    NewYoloOptionsPanel("Codex", "YOLO mode - bypass approvals and sandbox"),
+		hermesOptions:   NewYoloOptionsPanel("Hermes", "YOLO mode - auto-approve all tool calls"),
 		focusIndex:      0,
 		visible:         false,
 		presetCommands:  buildPresetCommands(),
@@ -418,9 +421,11 @@ func (d *NewDialog) ShowInGroup(groupPath, groupName, defaultPath string, conduc
 	// Initialize tool options from global config.
 	d.geminiOptions.SetDefaults(false)
 	d.codexOptions.SetDefaults(false)
+	d.hermesOptions.SetDefaults(false)
 	if userConfig, err := session.LoadUserConfig(); err == nil && userConfig != nil {
 		d.geminiOptions.SetDefaults(userConfig.Gemini.YoloMode)
 		d.codexOptions.SetDefaults(userConfig.Codex.YoloMode)
+		d.hermesOptions.SetDefaults(userConfig.Hermes.YoloMode)
 		d.claudeOptions.SetDefaults(userConfig)
 		d.sandboxEnabled = userConfig.Docker.DefaultEnabled
 		d.worktreeEnabled = userConfig.Worktree.DefaultEnabled
@@ -637,6 +642,7 @@ func (d *NewDialog) saveSnapshot() *dialogSnapshot {
 		claudeOptions:    claudeOpts,
 		geminiYolo:       d.geminiOptions.GetYoloMode(),
 		codexYolo:        d.codexOptions.GetYoloMode(),
+		hermesYolo:       d.hermesOptions.GetYoloMode(),
 		multiRepoEnabled: d.multiRepoEnabled,
 		multiRepoPaths:   append([]string{}, d.multiRepoPaths...),
 		conductorCursor:  d.conductorCursor,
@@ -660,6 +666,7 @@ func (d *NewDialog) restoreSnapshot(s *dialogSnapshot) {
 	}
 	d.geminiOptions.SetDefaults(s.geminiYolo)
 	d.codexOptions.SetDefaults(s.codexYolo)
+	d.hermesOptions.SetDefaults(s.hermesYolo)
 	d.multiRepoEnabled = s.multiRepoEnabled
 	d.multiRepoPaths = append([]string{}, s.multiRepoPaths...)
 	d.multiRepoPathCursor = 0
@@ -992,6 +999,11 @@ func (d *NewDialog) GetCodexYoloMode() bool {
 	return d.codexOptions.GetYoloMode()
 }
 
+// GetHermesYoloMode returns the Hermes YOLO mode state
+func (d *NewDialog) GetHermesYoloMode() bool {
+	return d.hermesOptions.GetYoloMode()
+}
+
 // IsSandboxEnabled returns whether Docker sandbox mode is enabled.
 func (d *NewDialog) IsSandboxEnabled() bool {
 	return d.sandboxEnabled
@@ -1280,6 +1292,8 @@ func (d *NewDialog) updateToolOptions() {
 		d.toolOptions = d.geminiOptions
 	case cmd == "codex":
 		d.toolOptions = d.codexOptions
+	case cmd == "hermes":
+		d.toolOptions = d.hermesOptions
 	default:
 		d.toolOptions = nil
 	}
@@ -1295,6 +1309,7 @@ func (d *NewDialog) updateFocus() {
 	d.claudeOptions.Blur()
 	d.geminiOptions.Blur()
 	d.codexOptions.Blur()
+	d.hermesOptions.Blur()
 
 	// Reset dropdown and soft-select state when focus changes.
 	d.pathSoftSelected = false
@@ -1971,7 +1986,7 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 		case "y":
 			if !d.isTextInputFocused() {
 				selectedCmd := d.GetSelectedCommand()
-				if cur == focusCommand && (selectedCmd == "gemini" || selectedCmd == "codex") && d.toolOptions != nil {
+				if cur == focusCommand && (selectedCmd == "gemini" || selectedCmd == "codex" || selectedCmd == "hermes") && d.toolOptions != nil {
 					d.toolOptions.Update(msg)
 					return d, nil
 				}
@@ -2528,7 +2543,7 @@ func (d *NewDialog) View() string {
 		}
 	} else if cur == focusCommand {
 		selectedCmd := d.GetSelectedCommand()
-		if selectedCmd == "gemini" || selectedCmd == "codex" {
+		if selectedCmd == "gemini" || selectedCmd == "codex" || selectedCmd == "hermes" {
 			helpText = "←→ command │ w worktree │ s sandbox │ y yolo │ Tab next │ Enter create │ Esc cancel"
 		} else {
 			helpText = "←→ command │ w worktree │ s sandbox │ Tab next │ Enter create │ Esc cancel"

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -22,6 +22,7 @@ const (
 	SettingClaudeConfigDir
 	SettingGeminiYoloMode
 	SettingCodexYoloMode
+	SettingHermesYoloMode
 	SettingCheckForUpdates
 	SettingAutoUpdate
 	SettingLogMaxSize
@@ -48,7 +49,7 @@ const (
 )
 
 // Total number of navigable settings.
-const settingsCount = 29
+const settingsCount = 30
 
 // SettingsPanel displays and edits user configuration
 type SettingsPanel struct {
@@ -71,6 +72,7 @@ type SettingsPanel struct {
 	claudeConfigIsScope bool // true = profile override, false = global [claude]
 	geminiYoloMode      bool
 	codexYoloMode       bool
+	hermesYoloMode      bool
 	checkForUpdates     bool
 	autoUpdate          bool
 	logMaxSizeMB        int
@@ -253,6 +255,9 @@ func (s *SettingsPanel) LoadConfig(config *session.UserConfig) {
 	// Codex settings
 	s.codexYoloMode = config.Codex.YoloMode
 
+	// Hermes settings
+	s.hermesYoloMode = config.Hermes.YoloMode
+
 	// Update settings
 	s.checkForUpdates = config.Updates.CheckEnabled
 	s.autoUpdate = config.Updates.AutoUpdate
@@ -330,7 +335,7 @@ func (s *SettingsPanel) buildToolLists(config *session.UserConfig) {
 		builtins := map[string]bool{
 			"claude": true, "gemini": true, "opencode": true,
 			"codex": true, "pi": true, "crush": true, "copilot": true,
-			"shell": true, "cursor": true, "aider": true,
+			"shell": true, "cursor": true, "aider": true, "hermes": true,
 		}
 		var custom []string
 		for name := range config.Tools {
@@ -383,6 +388,9 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 
 	// Codex settings
 	config.Codex.YoloMode = s.codexYoloMode
+
+	// Hermes settings
+	config.Hermes.YoloMode = s.hermesYoloMode
 
 	// Update settings
 	config.Updates.CheckEnabled = s.checkForUpdates
@@ -620,6 +628,10 @@ func (s *SettingsPanel) toggleValue() bool {
 		s.codexYoloMode = !s.codexYoloMode
 		return true
 
+	case SettingHermesYoloMode:
+		s.hermesYoloMode = !s.hermesYoloMode
+		return true
+
 	case SettingCheckForUpdates:
 		s.checkForUpdates = !s.checkForUpdates
 		return true
@@ -855,6 +867,17 @@ func (s *SettingsPanel) View() string {
 	}
 	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
 
+	// HERMES
+	content.WriteString(sectionStyle.Render("HERMES"))
+	content.WriteString("\n")
+
+	// YOLO mode checkbox
+	line = s.renderCheckbox("YOLO mode", s.hermesYoloMode) + " - Auto-approve all tool calls"
+	if s.cursor == int(SettingHermesYoloMode) {
+		line = highlightStyle.Render(line)
+	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
+
 	// UPDATES
 	content.WriteString(sectionStyle.Render("UPDATES"))
 	content.WriteString("\n")
@@ -1075,29 +1098,30 @@ func (s *SettingsPanel) View() string {
 			12, // SettingClaudeConfigDir
 			15, // SettingGeminiYoloMode
 			18, // SettingCodexYoloMode
-			21, // SettingCheckForUpdates
-			22, // SettingAutoUpdate
-			25, // SettingLogMaxSize
-			25, // SettingLogMaxLines (shares line with LogMaxSize)
-			26, // SettingRemoveOrphans
-			29, // SettingGlobalSearchEnabled
-			30, // SettingSearchTier
-			31, // SettingRecentDays
-			34, // SettingShowOutput
-			35, // SettingShowAnalytics
-			36, // SettingShowNotes
-			37, // SettingNotesOutputSplit
-			40, // SettingMaintenanceEnabled
-			43, // SettingStatsEnabled
-			44, // SettingStatsRefresh
-			45, // SettingStatsFormat
-			47, // SettingStatsShowCPU (row with RAM, Disk)
-			47, // SettingStatsShowRAM
-			47, // SettingStatsShowDisk
-			48, // SettingStatsShowNetwork (row with GPU, Load)
-			48, // SettingStatsShowGPU
-			48, // SettingStatsShowLoad
-			51, // SettingSyncTitle (SESSIONS section, after stats)
+			21, // SettingHermesYoloMode
+			24, // SettingCheckForUpdates
+			25, // SettingAutoUpdate
+			28, // SettingLogMaxSize
+			28, // SettingLogMaxLines (shares line with LogMaxSize)
+			29, // SettingRemoveOrphans
+			32, // SettingGlobalSearchEnabled
+			33, // SettingSearchTier
+			34, // SettingRecentDays
+			37, // SettingShowOutput
+			38, // SettingShowAnalytics
+			39, // SettingShowNotes
+			40, // SettingNotesOutputSplit
+			43, // SettingMaintenanceEnabled
+			46, // SettingStatsEnabled
+			47, // SettingStatsRefresh
+			48, // SettingStatsFormat
+			50, // SettingStatsShowCPU (row with RAM, Disk)
+			50, // SettingStatsShowRAM
+			50, // SettingStatsShowDisk
+			51, // SettingStatsShowNetwork (row with GPU, Load)
+			51, // SettingStatsShowGPU
+			51, // SettingStatsShowLoad
+			54, // SettingSyncTitle (SESSIONS section, after stats)
 		}
 		cursorLine := cursorToLine[s.cursor]
 

--- a/internal/watcher/assets/watcher-templates/HERMES.md
+++ b/internal/watcher/assets/watcher-templates/HERMES.md
@@ -1,0 +1,59 @@
+# Watcher: Shared Knowledge Base
+
+This file contains shared infrastructure knowledge for all watcher instances.
+Each watcher has its own identity in its subdirectory and its own LEARNINGS.md.
+Agent sessions inspecting this directory will find the layout and CLI reference below.
+
+## Layout
+
+The singular watcher root mirrors `~/.agent-deck/conductor/`:
+
+```
+~/.agent-deck/watcher/
+  HERMES.md        — this file (shared knowledge base)
+  POLICY.md        — behavior rules (escalation, dedup, retry, health thresholds)
+  LEARNINGS.md     — cross-watcher patterns accumulated over time
+  clients.json     — routing map: sender key -> conductor name
+
+  <name>/          — per-watcher directory (one per registered watcher)
+    meta.json      — watcher registration metadata (type, created_at, expiry)
+    state.json     — latest health snapshot (last_event_ts, error_count, adapter_healthy)
+    task-log.md    — append-only event log (one Markdown heading per event)
+    LEARNINGS.md   — per-watcher patterns (optional, watcher-specific)
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `HERMES.md` | Shared mechanism knowledge. Read by agent sessions to understand watcher infrastructure. |
+| `POLICY.md` | Behavior rules: escalation thresholds, dedup strategy, retry backoff, health thresholds. |
+| `LEARNINGS.md` | Cross-watcher patterns. Add entries as you notice recurring behaviors. |
+| `clients.json` | Routing map loaded by the engine. Key format: `<adapter>:<channel>` or email address. |
+
+## For Agents Inspecting This Directory
+
+To inspect watcher health and list all registered watchers:
+
+```bash
+agent-deck watcher list --json
+agent-deck watcher status <name>
+```
+
+The `list --json` output includes `last_event_ts`, `error_count`, and `health_status` per watcher.
+
+To check if a specific sender would be routed:
+
+```bash
+agent-deck watcher test <name>
+```
+
+## Why This Folder Shape
+
+Watcher state mirrors the conductor pattern (`~/.agent-deck/conductor/`) for consistency:
+both subsystems use a singular directory root with shared top-level files and
+per-instance subdirectories. This makes the layout predictable and tooling reusable.
+
+The legacy `~/.agent-deck/watchers/` path is preserved as a relative compatibility
+symlink pointing to `watcher/`. Existing tooling that reads `watchers/` continues
+to work without modification.

--- a/internal/watcher/layout.go
+++ b/internal/watcher/layout.go
@@ -18,6 +18,9 @@ import (
 //go:embed assets/watcher-templates/CLAUDE.md
 var watcherClaudeTemplate []byte
 
+//go:embed assets/watcher-templates/HERMES.md
+var watcherHermesTemplate []byte
+
 //go:embed assets/watcher-templates/POLICY.md
 var watcherPolicyTemplate []byte
 
@@ -68,6 +71,7 @@ func ScaffoldWatcherLayout() error {
 		content []byte
 	}{
 		{"CLAUDE.md", watcherClaudeTemplate},
+		{"HERMES.md", watcherHermesTemplate},
 		{"POLICY.md", watcherPolicyTemplate},
 		{"LEARNINGS.md", watcherLearningsTemplate},
 		{"clients.json", []byte("{}\n")},


### PR DESCRIPTION
## Overview

Adds first-class support for [Hermes Agent CLI](https://github.com/NousResearch/hermes-agent) (NousResearch/hermes-agent v0.13+) alongside the existing eight builtin agents. Hermes joins claude, codex, gemini, copilot, opencode, qwen, crush, and cursor as a recognized agent kind.

**This is the core split out of #1166** per the maintainer's request. The Kanban board surface remains on the original PR branch.

## What's included (this PR)

**Session lifecycle**
- Shell hooks (`on_session_start`, `on_session_end`, `pre_tool_call`, `post_tool_call`) auto-injected into `~/.hermes/config.yaml` on first launch via the shared `hookWatcher`.
- `agent-deck hermes-hooks {install,uninstall,status}` CLI for manual control.
- Conductor mode with Hermes-specific prompt templates (`conductor/conductor-hermes.md`, `internal/session/conductor_templates.go`).

**Config and overrides**
- `--yolo` flag (auto-approve all tool calls): per-session override via `HermesOptions` in `tool_data`, global default via `[hermes].yolo_mode` in agent-deck config. YOLO badge in session rows, `Y` to toggle.
- `[hermes].command` and `[hermes].env_file` overrides, matching the parity established for all eight other agents.

**Integration**
- MCP server configuration and tool registration (`hermes_mcp.go`).
- Process-alive/dead status detection with optional gateway-reachability check for richer signal. Auto-discovers gateway at the well-known port via `~/.hermes/gateway_state.json`; explicit `gateway_url` override in config.
- Conductor `bridge.py`: Hermes-aware heartbeat loop. Python compat tests under `conductor/tests/`.

## What's NOT included (deferred per request)

- Hermes Kanban board overlay (`B` keybinding, `[K:●]` / `[K:▲]` badges, `agent-deck kanban` CLI surface, direct-SQLite watcher). Sits on the original PR branch `feature/hermes-agent-support` (PR #1166) for future revisit.

## Diff shape

27 files changed, **+1,677 / −39**. The original combined PR was +5,865 / −42 across 36 files — this PR is the 29% core slice.

## Testing

- `go build ./...` and `go vet ./...` clean.
- All Hermes-specific Go tests (`go test -race -run 'Hermes|hermes' ./...`) pass: `internal/session` and `cmd/agent-deck` green.
- Python conductor compat tests (`conductor/tests/test_python_compat.py`) pass (5 passed, 1 skipped).
- Manual testing against Hermes v0.13.0:
  - YOLO mode propagation through config and per-session override.
  - Status detection: running, waiting, idle, stopped.
  - Shell hook install on first launch + uninstall via CLI.
  - Conductor-hermes profile spawn + heartbeat round-trip.

Note: local `go test -race ./...` surfaces failures in `internal/tmux/` and a few session tests that depend on creating tmux sessions. These reproduce identically on `upstream/main` HEAD and are caused by macOS `$TMPDIR` path exceeding the unix-socket name length limit. They are pre-existing environmental issues, not regressions from this PR; CI on Linux is not affected.

Closes #919.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI to manage Hermes hooks (install/uninstall/status)
  * Hermes conductor support, YOLO mode (UI controls, session badges), and project-skills integration
  * Gateway reachability probing and shared Hermes workspace support
  * Automatic Hermes hook injection and background watcher startup

* **Documentation**
  * Hermes conductor instructions template and watcher asset added
  * MCP dialog clarified: Hermes excluded from Claude-style MCP flow

* **Tests**
  * Extensive Hermes hooks, conductor, gateway, env and integration tests added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->