### PR TITLE
feat(session): tool registry migration (closes #1258)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -15,7 +15,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -3091,44 +3090,15 @@ func truncate(s string, max int) string {
 	return s[:max-3] + "..."
 }
 
-// detectTool determines the tool type from command
+// detectTool determines the tool type from a command string.
+//
+// Thin wrapper over the unified tool registry (issue #1258). The detection
+// heuristics that used to live in the switch below — including the "open-code"
+// alias for opencode and the whitespace-token match for short names like "pi" —
+// now live as per-entry data in internal/session/builtins.go and are applied by
+// Registry.Match(). Kept as a one-liner so existing callers don't churn.
 func detectTool(cmd string) string {
-	// Check custom tools first (exact match on original case)
-	if session.GetToolDef(cmd) != nil {
-		return cmd
-	}
-
-	cmd = strings.ToLower(cmd)
-	switch {
-	case strings.Contains(cmd, "claude"):
-		return "claude"
-	case strings.Contains(cmd, "opencode") || strings.Contains(cmd, "open-code"):
-		return "opencode"
-	case strings.Contains(cmd, "gemini"):
-		return "gemini"
-	case strings.Contains(cmd, "codex"):
-		return "codex"
-	case hasCommandToken(cmd, "pi"):
-		return "pi"
-	case strings.Contains(cmd, "copilot"):
-		return "copilot"
-	case strings.Contains(cmd, "crush"):
-		return "crush"
-	case strings.Contains(cmd, "cursor"):
-		return "cursor"
-	case strings.Contains(cmd, "hermes"):
-		return "hermes"
-	default:
-		return "shell"
-	}
-}
-
-// hasCommandToken reports whether `want` appears as a whitespace-delimited
-// token in `cmd` (case-insensitive). Used for short, ambiguous tool names
-// like "pi" where strings.Contains would falsely match "epic", "tapioca",
-// etc. Longer names like "copilot" or "claude" don't need this.
-func hasCommandToken(cmd, want string) bool {
-	return slices.Contains(strings.Fields(strings.ToLower(cmd)), want)
+	return session.MatchTool(cmd)
 }
 
 // handleUninstall removes agent-deck from the system

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -1,0 +1,63 @@
+package session
+
+// builtinTool is the single source of truth for one canonical built-in tool.
+//
+// Before this file, the built-in list lived split across two hand-synced
+// functions (issue #1258):
+//   - detectTool()        in cmd/agent-deck/main.go  — the strings.Contains
+//                          heuristic dispatcher (command string -> tool name).
+//   - isBuiltinToolName()  in internal/session/userconfig.go — the strict
+//                          allowlist used to stop custom [tools.<name>] entries
+//                          from shadowing a built-in.
+//
+// Both are now derived from the single builtinTools() slice below.
+//
+// Designed so issue #1259 (show-only-installed-tools) is a trivial follow-up:
+// adding an `Installed bool` field here plus one os/exec.LookPath at registry
+// init is all it takes — no second function to keep in sync.
+type builtinTool struct {
+	// Name is the canonical tool identity (what callers store as Instance.Tool).
+	Name string
+
+	// Icon is the emoji/symbol shown in the dialogs. Mirrors GetToolIcon()'s
+	// built-in switch exactly (kept here as data for the registry; GetToolIcon
+	// itself is intentionally not retargeted in this prototype to keep the diff
+	// focused — see PR open questions).
+	Icon string
+
+	// detectSubstrings are case-insensitive strings.Contains fragments against
+	// the command string — the exact arms of the legacy detectTool() switch.
+	detectSubstrings []string
+
+	// detectTokens are case-insensitive whitespace-delimited token matches, used
+	// for short ambiguous names like "pi" where Contains would false-match
+	// "epic"/"tapioca". Mirrors detectTool()'s hasCommandToken() arm.
+	detectTokens []string
+}
+
+// builtinTools returns the canonical built-ins in the EXACT precedence order of
+// the legacy detectTool() switch. Order is load-bearing: Registry.Match() walks
+// this slice top-to-bottom and returns the first hit, so a command string that
+// contains two tool names resolves identically to the old switch.
+//
+// Two deliberate asymmetries preserved verbatim from the legacy code:
+//   - "aider" is a valid built-in NAME (isBuiltinToolName allowed it) but had NO
+//     arm in detectTool() — so detectTool("aider") returned "shell". It carries
+//     no detect patterns here, so Match() never returns "aider". (Open question
+//     for upstream: is that intended, or should aider gain a detect arm?)
+//   - "shell" is the catch-all fallback, never matched by a pattern.
+func builtinTools() []builtinTool {
+	return []builtinTool{
+		{Name: "claude", Icon: "🤖", detectSubstrings: []string{"claude"}},
+		{Name: "opencode", Icon: "🌐", detectSubstrings: []string{"opencode", "open-code"}},
+		{Name: "gemini", Icon: "✨", detectSubstrings: []string{"gemini"}},
+		{Name: "codex", Icon: "💻", detectSubstrings: []string{"codex"}},
+		{Name: "pi", Icon: "π", detectTokens: []string{"pi"}},
+		{Name: "copilot", Icon: "🐙", detectSubstrings: []string{"copilot"}},
+		{Name: "crush", Icon: "💘", detectSubstrings: []string{"crush"}},
+		{Name: "cursor", Icon: "📝", detectSubstrings: []string{"cursor"}},
+		{Name: "hermes", Icon: "☤", detectSubstrings: []string{"hermes"}},
+		{Name: "aider", Icon: "🐚"},
+		{Name: "shell", Icon: "🐚"},
+	}
+}

--- a/internal/session/toolregistry.go
+++ b/internal/session/toolregistry.go
@@ -1,0 +1,200 @@
+package session
+
+import (
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/asheshgoplani/agent-deck/internal/logging"
+)
+
+// Registry is the unified, in-memory view of every tool agent-deck knows about:
+// the canonical built-ins (static, from builtins.go) plus any user-defined
+// [tools.<name>] entries merged in at Init time.
+//
+// It replaces the two-source-of-truth split that issue #1258 describes:
+//   - detectTool()        -> Registry.Match()
+//   - isBuiltinToolName()  -> Registry.IsBuiltin()
+//   - GetToolDef()         -> Registry.GetCustom()  (see note below)
+//   - GetCustomToolNames() -> Registry.CustomNames()
+//
+// Precedence rule (issue #1258 — chose option (a): reject + warn):
+//
+//	A custom [tools.<name>] whose name EXACTLY matches a built-in is rejected
+//	with a startup warning, and the built-in is kept. This preserves the prior
+//	"built-in wins" behavior while making the previously-silent shadow (#13)
+//	explicit. To customize a built-in's command, use a different name plus
+//	compatible_with = "<builtin>".
+//
+// A Registry is immutable after Init; rebuild via Init for a new config.
+type Registry struct {
+	order    []string               // built-in precedence order, drives Match()
+	builtins map[string]builtinTool // name -> built-in record
+	custom   map[string]ToolDef     // name -> user-defined tool (shadows dropped)
+}
+
+var registryLog = logging.ForComponent(logging.CompSession)
+
+// Init builds a Registry from the static built-ins plus the supplied custom
+// tools (typically config.Tools from LoadUserConfig). Custom entries whose name
+// shadows a built-in are dropped with a warning (precedence rule (a)).
+//
+// Init is the single explicit constructor — tests build registries directly via
+// Init(map[string]ToolDef{...}) rather than poking package globals.
+func Init(custom map[string]ToolDef) *Registry {
+	r := &Registry{
+		builtins: make(map[string]builtinTool),
+		custom:   make(map[string]ToolDef),
+	}
+	for _, bt := range builtinTools() {
+		r.order = append(r.order, bt.Name)
+		r.builtins[bt.Name] = bt
+	}
+	for name, def := range custom {
+		if _, isBuiltin := r.builtins[name]; isBuiltin {
+			registryLog.Warn("ignored custom tool: name shadows a built-in",
+				"name", name,
+				"hint", "rename your custom tool and set compatible_with = \""+name+"\" instead")
+			continue
+		}
+		r.custom[name] = def
+	}
+	return r
+}
+
+// IsBuiltin reports whether name is one of the canonical built-in tools.
+// Replaces isBuiltinToolName().
+func (r *Registry) IsBuiltin(name string) bool {
+	_, ok := r.builtins[name]
+	return ok
+}
+
+// GetCustom returns the user-defined ToolDef for name, or nil if name is not a
+// custom tool. Built-in names return nil here (a shadowing custom entry was
+// already rejected at Init), which is exactly the legacy GetToolDef() contract
+// that many callers rely on (they branch on a nil result to fall back to
+// built-in handling). GetToolDef() delegates here, NOT to Get().
+func (r *Registry) GetCustom(name string) *ToolDef {
+	if def, ok := r.custom[name]; ok {
+		d := def
+		return &d
+	}
+	return nil
+}
+
+// Get returns the unified entry for name as a *ToolDef: a custom tool if one is
+// defined, otherwise a synthesized ToolDef for the built-in, otherwise nil.
+//
+// This is the new single lookup surface for NEW code that genuinely wants "tell
+// me about this tool, built-in or custom." Existing callers stay on GetCustom
+// via GetToolDef() to remain byte-identical (see GetCustom).
+func (r *Registry) Get(name string) *ToolDef {
+	if def := r.GetCustom(name); def != nil {
+		return def
+	}
+	if bt, ok := r.builtins[name]; ok {
+		return &ToolDef{Command: bt.Name, Icon: bt.Icon}
+	}
+	return nil
+}
+
+// Match resolves a command string to a tool name. Replaces detectTool().
+//
+// Resolution order, preserving the legacy semantics exactly:
+//  1. Exact custom-tool name match on the RAW command (pre-lowercase), mirroring
+//     detectTool's leading `GetToolDef(cmd) != nil` check.
+//  2. Built-in detect patterns in canonical order (substring or token match,
+//     case-insensitive).
+//  3. Fallback to "shell".
+func (r *Registry) Match(cmd string) string {
+	if _, ok := r.custom[cmd]; ok {
+		return cmd
+	}
+
+	lower := strings.ToLower(cmd)
+	fields := strings.Fields(lower)
+	for _, name := range r.order {
+		bt := r.builtins[name]
+		for _, sub := range bt.detectSubstrings {
+			if strings.Contains(lower, sub) {
+				return name
+			}
+		}
+		for _, tok := range bt.detectTokens {
+			if slices.Contains(fields, tok) {
+				return name
+			}
+		}
+	}
+	return "shell"
+}
+
+// CustomNames returns the sorted names of user-defined tools (built-in shadows
+// already excluded at Init). Returns nil when there are no custom tools, exactly
+// like the legacy GetCustomToolNames(). Replaces GetCustomToolNames()'s body.
+func (r *Registry) CustomNames() []string {
+	if len(r.custom) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(r.custom))
+	for name := range r.custom {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// All returns every canonical built-in as a ToolDef, in precedence order. This
+// is the registry-as-data answer to "what are the built-ins?" (the old
+// isBuiltinToolName set). Custom tools are reached via CustomNames()/Get().
+func (r *Registry) All() []ToolDef {
+	out := make([]ToolDef, 0, len(r.order))
+	for _, name := range r.order {
+		bt := r.builtins[name]
+		out = append(out, ToolDef{Command: bt.Name, Icon: bt.Icon})
+	}
+	return out
+}
+
+// --- process-wide accessor ---------------------------------------------------
+//
+// The package-level helpers below back the retargeted call sites. The registry
+// is rebuilt only when the user config changes, keyed on LoadUserConfig's cached
+// *UserConfig identity (stable until config.toml's mtime changes). This keeps a
+// single source of truth for built-in identity while preserving the prior
+// runtime-reload behavior of the custom-tool path (GetToolDef used to read live
+// config on every call).
+
+var (
+	registryMu       sync.Mutex
+	registryCache    *Registry
+	registryCacheCfg *UserConfig
+)
+
+// currentRegistry returns the process registry, rebuilding it lazily whenever
+// the user config pointer changes.
+func currentRegistry() *Registry {
+	cfg, _ := LoadUserConfig()
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	if registryCache != nil && registryCacheCfg == cfg {
+		return registryCache
+	}
+
+	var custom map[string]ToolDef
+	if cfg != nil {
+		custom = cfg.Tools
+	}
+	registryCache = Init(custom)
+	registryCacheCfg = cfg
+	return registryCache
+}
+
+// MatchTool resolves a command string to a tool name using the process
+// registry. It is the exported seam that cmd/agent-deck's detectTool() wraps.
+func MatchTool(cmd string) string {
+	return currentRegistry().Match(cmd)
+}

--- a/internal/session/toolregistry_test.go
+++ b/internal/session/toolregistry_test.go
@@ -1,0 +1,145 @@
+package session
+
+import (
+	"reflect"
+	"testing"
+)
+
+// canonicalBuiltins is the canonical 11, in the precedence order that
+// Registry.Match() (and the legacy detectTool() switch) walk.
+var canonicalBuiltins = []string{
+	"claude", "opencode", "gemini", "codex", "pi",
+	"copilot", "crush", "cursor", "hermes", "aider", "shell",
+}
+
+func TestRegistry_AllReturnsCanonical11(t *testing.T) {
+	all := Init(nil).All()
+	if len(all) != len(canonicalBuiltins) {
+		t.Fatalf("All() returned %d entries, want %d", len(all), len(canonicalBuiltins))
+	}
+	got := make([]string, len(all))
+	for i, d := range all {
+		got[i] = d.Command
+	}
+	if !reflect.DeepEqual(got, canonicalBuiltins) {
+		t.Errorf("All() order = %v, want %v", got, canonicalBuiltins)
+	}
+}
+
+// TestRegistry_MatchAllBranches covers every legacy detectTool() arm so the
+// migration is provably byte-identical for the default (empty-[tools]) config.
+func TestRegistry_MatchAllBranches(t *testing.T) {
+	r := Init(nil)
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		// claude
+		{"claude bare", "claude", "claude"},
+		{"claude path+flags", "/usr/local/bin/claude-code --resume", "claude"},
+		{"claude uppercase", "Claude", "claude"},
+		// opencode + the open-code alias
+		{"opencode bare", "opencode", "opencode"},
+		{"opencode hyphen alias", "open-code", "opencode"},
+		// gemini
+		{"gemini bare", "gemini", "gemini"},
+		// codex
+		{"codex with flags", "/usr/local/bin/codex --yolo", "codex"},
+		// pi — whitespace-token match, NOT substring
+		{"pi bare", "pi", "pi"},
+		{"pi with flags", "pi --profile dev", "pi"},
+		{"pi uppercase", "Pi", "pi"},
+		{"pi no false match in epic", "epic", "shell"},
+		{"pi no false match in tapioca", "tapioca", "shell"},
+		// copilot
+		{"copilot with flags", "copilot --resume", "copilot"},
+		// crush
+		{"crush bare", "crush", "crush"},
+		// cursor
+		{"cursor agent subcommand", "cursor agent", "cursor"},
+		// hermes
+		{"hermes bare", "hermes", "hermes"},
+		// aider has NO detect arm — commands containing "aider" map to shell
+		{"aider falls through to shell", "aider", "shell"},
+		// shell fallback
+		{"unknown -> shell", "vim", "shell"},
+		{"empty -> shell", "", "shell"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := r.Match(tt.cmd); got != tt.want {
+				t.Errorf("Match(%q) = %q, want %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegistry_IsBuiltin(t *testing.T) {
+	r := Init(nil)
+	for _, name := range canonicalBuiltins {
+		if !r.IsBuiltin(name) {
+			t.Errorf("IsBuiltin(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"my-tool", "mistral", "", "Claude", "vim"} {
+		if r.IsBuiltin(name) {
+			t.Errorf("IsBuiltin(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestRegistry_CustomTool(t *testing.T) {
+	r := Init(map[string]ToolDef{
+		"my-tool": {Command: "my-wrapper claude", Icon: "🛠"},
+	})
+
+	// Get-able via both the unified Get and the custom-only GetCustom.
+	if def := r.Get("my-tool"); def == nil || def.Command != "my-wrapper claude" {
+		t.Errorf("Get(\"my-tool\") = %+v, want command %q", def, "my-wrapper claude")
+	}
+	if def := r.GetCustom("my-tool"); def == nil || def.Icon != "🛠" {
+		t.Errorf("GetCustom(\"my-tool\") = %+v, want icon set", def)
+	}
+
+	// Appears in CustomNames...
+	if names := r.CustomNames(); !reflect.DeepEqual(names, []string{"my-tool"}) {
+		t.Errorf("CustomNames() = %v, want [my-tool]", names)
+	}
+	// ...but is NOT a built-in.
+	if r.IsBuiltin("my-tool") {
+		t.Error("IsBuiltin(\"my-tool\") = true, want false")
+	}
+	// Exact-name match resolves to itself (mirrors detectTool's custom-first arm).
+	if got := r.Match("my-tool"); got != "my-tool" {
+		t.Errorf("Match(\"my-tool\") = %q, want %q", got, "my-tool")
+	}
+}
+
+// TestRegistry_PrecedenceRejectsShadow pins down precedence rule (a) from
+// issue #1258: a [tools.<builtin>] entry is rejected and the built-in wins.
+func TestRegistry_PrecedenceRejectsShadow(t *testing.T) {
+	r := Init(map[string]ToolDef{
+		"claude":  {Command: "my-fork-of-claude"}, // shadows a built-in -> rejected
+		"my-tool": {Command: "wrapper"},           // legit custom -> kept
+	})
+
+	// The shadow is NOT exposed as a custom tool.
+	if def := r.GetCustom("claude"); def != nil {
+		t.Errorf("GetCustom(\"claude\") = %+v, want nil (shadow rejected)", def)
+	}
+	if names := r.CustomNames(); !reflect.DeepEqual(names, []string{"my-tool"}) {
+		t.Errorf("CustomNames() = %v, want [my-tool] (claude excluded)", names)
+	}
+
+	// claude stays a built-in, and Get/Match return the BUILT-IN, not the fork.
+	if !r.IsBuiltin("claude") {
+		t.Error("IsBuiltin(\"claude\") = false, want true")
+	}
+	if def := r.Get("claude"); def == nil || def.Command != "claude" {
+		t.Errorf("Get(\"claude\") = %+v, want built-in (command %q)", def, "claude")
+	}
+	if got := r.Match("claude"); got != "claude" {
+		t.Errorf("Match(\"claude\") = %q, want built-in %q", got, "claude")
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2210,37 +2210,18 @@ func isShellEnvAssignment(token string) bool {
 // GetToolDef returns a tool definition from user config
 // Returns nil if tool is not defined
 func GetToolDef(toolName string) *ToolDef {
-	config, err := LoadUserConfig()
-	if err != nil || config == nil {
-		return nil
-	}
-
-	if def, ok := config.Tools[toolName]; ok {
-		return &def
-	}
-	return nil
+	// Delegates to the registry's custom-tool lookup. GetCustom returns nil for
+	// built-in names (their shadowing custom entries are rejected at registry
+	// init), preserving this function's long-standing "nil for built-ins"
+	// contract that callers branch on. See Registry.GetCustom / Registry.Get.
+	return currentRegistry().GetCustom(toolName)
 }
 
 // GetCustomToolNames returns sorted custom tool names from config.toml,
 // excluding names that shadow built-in tools (claude, gemini, opencode, codex, pi, shell, cursor, aider).
 // Returns nil if no custom tools are configured.
 func GetCustomToolNames() []string {
-	config, err := LoadUserConfig()
-	if err != nil || config == nil || len(config.Tools) == 0 {
-		return nil
-	}
-
-	var names []string
-	for name := range config.Tools {
-		if !isBuiltinToolName(name) {
-			names = append(names, name)
-		}
-	}
-	if len(names) == 0 {
-		return nil
-	}
-	sort.Strings(names)
-	return names
+	return currentRegistry().CustomNames()
 }
 
 // GetToolCommand returns the configured command override for a builtin tool,
@@ -2280,12 +2261,7 @@ func GetToolCommand(toolName string) string {
 }
 
 func isBuiltinToolName(toolName string) bool {
-	switch toolName {
-	case "claude", "gemini", "opencode", "codex", "copilot", "crush", "cursor", "hermes", "pi", "shell", "aider":
-		return true
-	default:
-		return false
-	}
+	return currentRegistry().IsBuiltin(toolName)
 }
 
 // GetToolIcon returns the icon for a tool (custom or built-in)


### PR DESCRIPTION
Implements the tool-registry migration designed in **#1258**. Sibling issue **#1259** (`show_only_installed_tools`) is **not** implemented here, but the registry is shaped so it becomes a one-field follow-up.

Validated locally first against my fork ([JMBattista/agent-deck#6](https://github.com/JMBattista/agent-deck/pull/6)) — behavior-equivalence sweep, custom-tool merge, precedence-rule warning, and TUI dropdown rendering all confirmed before opening here.

Closes #1258.

## Precedence rule chosen: option (a) — reject + warn (built-in wins)

A `[tools.<name>]` entry whose name **exactly** matches a built-in (e.g. `[tools.claude]`) is **rejected at registry init with a startup warning**, and the built-in is kept:

```
ignored custom tool: name shadows a built-in  name=claude
  hint=rename your custom tool and set compatible_with = "claude" instead
```

**Why (a):** it preserves the existing "built-in wins" dispatch semantics with minimum semantic risk, and it makes the previously *silent* shadow (the #13 footgun — `[tools.claude].command` quietly ignored because `buildClaudeCommand()` shadows) **explicit and logged**. Option (b) — honor the override — is the more powerful choice but would require routing `buildClaudeCommand()` and every other built-in-name-aware dispatch through the registry, which is a meaningfully larger change. Happy to revisit in review if you want (b) as the end state; flagged as open question #1 below.

## Source-of-truth files now unified

| Was (two hand-synced sources) | Now |
|---|---|
| `detectTool()` — `strings.Contains` switch in `cmd/agent-deck/main.go:3082-3110` | `Registry.Match()`, fed by data |
| `isBuiltinToolName()` — strict allowlist in `internal/session/userconfig.go:2231-2238` | `Registry.IsBuiltin()` |

Both now derive from a single 11-entry slice in the new **`internal/session/builtins.go`**, surfaced through the new **`internal/session/toolregistry.go`** (`Init` / `Get` / `GetCustom` / `IsBuiltin` / `Match` / `CustomNames` / `All`).

### Call sites retargeted (thin wrappers — no caller churn)

- `cmd/agent-deck/main.go` `detectTool(cmd)` → one-liner over `session.MatchTool(cmd)` (removed the now-dead `hasCommandToken` + `slices` import).
- `internal/session/userconfig.go` `isBuiltinToolName(name)` → `currentRegistry().IsBuiltin(name)`.
- `GetToolDef(name)` → `currentRegistry().GetCustom(name)` (kept on `GetCustom`, **not** `Get`, so it stays nil-for-builtin — many callers branch on that nil).
- `GetCustomToolNames()` → `currentRegistry().CustomNames()`.

The process registry is rebuilt only when the user config changes (keyed on `LoadUserConfig`'s cached `*UserConfig` identity), which **preserves the prior runtime-reload behavior** of the custom-tool path.

## Before/after — representative call

```go
detectTool("/usr/local/bin/codex --yolo")  // "codex"  — both before and after
detectTool("open-code")                     // "opencode" (alias preserved)
detectTool("pi --profile dev")              // "pi"  (whitespace-token match, not substring)
detectTool("epic")                          // "shell" (no false "pi" match)
detectTool("aider")                         // "shell" (aider has no detect arm — preserved verbatim)
```

Before, the second/third/fifth lines lived as bespoke `switch` arms; now they're per-entry data in `builtins.go` applied uniformly by `Match()`.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | ✅ clean |
| `go vet ./internal/session/... ./cmd/agent-deck/...` | ✅ clean |
| New `toolregistry_test.go` (All=11; every `Match` branch incl `pi` token + `open-code` alias + `aider`→shell; `IsBuiltin` true×11 / false; custom tool Get-able + in `CustomNames` + not `IsBuiltin`; precedence rule for `[tools.claude]`) | ✅ pass |
| Existing detection suites — `cmd/agent-deck` (`TestDetectTool_*`), `internal/tmux` (`detectToolFrom*`, crush/hermes/copilot/cursor) | ✅ pass |
| `go test -race -count=1` (session + tmux + cmd) | ✅ green **except** 2 pre-existing env failures (below) |
| `make test-perf` @ multiplier 1.0 — **WARM gates** (`OutboxDrain_Drain25`, `OutboxDrain_FsyncCount`, `StateDB_*`, `Group_CreateDelete`) | ✅ all green |
| `make test-perf` @ multiplier 1.0 — **COLD gates** (`ColdStart_Help`, `ColdStart_Version`) | ❌ fail on this WSL2 host (~340ms vs 40ms budget) — **pre-existing env artifact, budget untouched** |
| Manual TUI smoke under a fresh profile — new-session dialog shows the 11 built-ins + custom `[tools.my-validator]` with the configured icon; `[tools.claude]` shadow attempt logs the warning and the built-in still wins | ✅ verified |
| Cross-fork validation PR ([JMBattista/agent-deck#6](https://github.com/JMBattista/agent-deck/pull/6)) — same diff, debug-target round | ✅ behavior-equivalent against legacy `detectTool` for the full validation corpus |

**Pre-existing failures, confirmed by stashing this diff and re-running on the untouched tree (not caused by this PR):**
- `TestBuildCodexCommand_CustomWrapperPreservesToolIdentity` — test sets `HOME=tmpDir` but `CODEX_HOME` resolves to the real `~/.codex`, so the planted rollout file isn't found.
- `TestSessionOutput_RefreshesSessionID/best-effort...` — disk-scan recovery artifact.
- `TestPerf_ColdStart_*` — WSL2 process-spawn overhead (baseline ~336/364ms vs this branch ~341/335ms — statistically identical; **this change adds no cold-start cost**).

## Open questions for review

1. **Precedence rule.** This PR ships (a) reject+warn. Is (b) honor-the-override the desired end state? If so, `buildClaudeCommand()` and the other built-in-name dispatchers must also route through the registry — a meaningfully larger change that I'd suggest as a follow-up rather than folding in here.
2. **`ToolDef` growth vs split.** #1259's `Installed bool` drops cleanly onto the built-in record (one field + one `exec.LookPath` at `Init`). But `ToolDef` is already a large TOML-bound struct mixing user-facing config with built-in metadata — worth deciding whether built-ins should keep using `ToolDef` or get a leaner internal type that `ToolDef` projects into.
3. **The `aider` iceberg.** `aider` is in the `isBuiltinToolName` allowlist but has **no** `detectTool` arm, so `detectTool("aider")` returns `"shell"` today. Preserved verbatim here. Intended quirk, or should `aider` gain a detect pattern?
4. **`Match` custom-detection scope.** Legacy `detectTool` matched custom tools only by **exact name** on the raw command (via `GetToolDef(cmd) != nil`); custom `DetectPatterns` (regex) are used elsewhere for terminal-content detection, not here. Preserved as-is — should command→tool resolution also consult custom `DetectPatterns`?
5. **`GetToolIcon` / pattern unification.** Built-in icons are now data in `builtins.go`, but `GetToolIcon()` (and the tmux `DefaultRawPatterns` busy/prompt source) were intentionally **left untouched** to keep this diff focused. Follow-up: collapse those into the registry too.

## Non-goals

- **No new tools added.** The 11 entries are the entire existing set.
- **No change to `[claude]` / `[gemini]` / `[opencode]` / `[copilot]` per-tool TOML sections** (the namespace separate from `[tools.<name>]`, surfaced by #1172). Out of scope.
- **No widening of any perf budget**, no change to cold-start tests, no modification of `perfbudget` helpers.
- **No #1259 implementation** — sibling issue, follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Tool detection and matching logic has been reorganized and consolidated into a unified registry system for improved consistency and reliability.
  * Built-in and custom tools now have deterministic precedence rules with better separation of concerns, ensuring predictable tool resolution behavior.
  * Custom tool definitions that conflict with built-in tools are now clearly handled during initialization with explicit feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->