### PR TITLE
fix(fork-with-state): reconcile #1029 correctness batch onto vcs backend abstraction (reopens #1051)

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"al.essio.dev/pkg/shellescape"
+
 	"github.com/asheshgoplani/agent-deck/internal/clipboard"
 	"github.com/asheshgoplani/agent-deck/internal/git"
 	"github.com/asheshgoplani/agent-deck/internal/profile"
@@ -609,7 +611,7 @@ func branchCleanupHint(createdBranch bool, repoRoot, branchName string) string {
 	if !createdBranch {
 		return ""
 	}
-	return fmt.Sprintf(" && git -C %s branch -D %s", repoRoot, branchName)
+	return fmt.Sprintf(" && git -C %s branch -D %s", shellescape.Quote(repoRoot), shellescape.Quote(branchName))
 }
 
 // handleSessionFork forks a Claude session
@@ -871,7 +873,7 @@ func handleSessionFork(profile string, args []string) {
 						out.Error(fmt.Sprintf("failed to materialize parent state: %v; cleanup also failed (%s); manual cleanup required: rm -rf %s%s",
 							matErr,
 							strings.Join(cleanupErrs, "; "),
-							worktreePath,
+							shellescape.Quote(worktreePath),
 							branchCleanupHint(createdBranch, repoRoot, wtBranch),
 						), ErrCodeInvalidOperation)
 					}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -594,6 +595,23 @@ func restartAllSessions(out *CLIOutput, storage *session.Storage, instances []*s
 	}
 }
 
+// sessionForkBeforeStartHook is nil in production. Tests assign it to inspect
+// the fully-prepared fork before tmux Start() mutates the environment. When
+// the hook is set, handleSessionFork invokes it and returns immediately —
+// no tmux session, no persistence, no Start(). This lets contract tests
+// assert option propagation without spawning real sessions.
+var sessionForkBeforeStartHook func(parent *session.Instance, forked *session.Instance, state git.WorktreeStateOptions)
+
+// branchCleanupHint builds the trailing "&& git branch -D ..." fragment of
+// the manual-cleanup hint shown when fork-with-state cleanup partially fails.
+// Returns empty string when the branch wasn't created by this operation.
+func branchCleanupHint(createdBranch bool, repoRoot, branchName string) string {
+	if !createdBranch {
+		return ""
+	}
+	return fmt.Sprintf(" && git -C %s branch -D %s", repoRoot, branchName)
+}
+
 // handleSessionFork forks a Claude session
 func handleSessionFork(profile string, args []string) {
 	fs := flag.NewFlagSet("session fork", flag.ExitOnError)
@@ -720,11 +738,47 @@ func handleSessionFork(profile string, args []string) {
 		worktreeType = string(backend.Type())
 		repoRoot := backend.RepoDir()
 
+		// --with-state* is git-specific: it anchors the new worktree at the
+		// parent's HEAD and materializes the parent's index/stash. Enforce the
+		// git requirement HERE, before the git-direct collision gate and the
+		// parent-HEAD anchoring below. This early guard — not the call routing —
+		// is what makes those git-direct calls jujutsu-safe: a jujutsu backend
+		// can never reach them. (The late jujutsu branch below keeps a
+		// belt-and-suspenders rejection for non-state paths.)
+		if wantState && backend.Type() != vcs.TypeGit {
+			out.Error("--with-state is only supported for git repositories", ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+
 		// Apply configured branch prefix before validation/existence checks
 		wtSettings := session.GetWorktreeSettings()
 		wtBranch = wtSettings.ApplyBranchPrefix(wtBranch)
 
-		if !createNewBranch && !backend.BranchExists(wtBranch) {
+		// Destination gate (BUG-01/08). With-state forks create a NEW branch
+		// anchored at the parent's HEAD, so they must refuse any pre-existing
+		// branch or worktree — one well-defined collision gate, evaluated before
+		// path computation and the legacy reuse check. Non-with-state forks keep
+		// upstream's "branch must already exist (use -b to create)" contract.
+		// These two are mutually exclusive: with-state requires the branch ABSENT,
+		// the else-branch requires it PRESENT — never flatten them.
+		if wantState {
+			if err := git.ValidateForkWithStateDestination(repoRoot, wtBranch); err != nil {
+				var collErr *git.DestinationCollisionError
+				if errors.As(err, &collErr) {
+					switch collErr.Kind {
+					case git.CollisionWorktreeExists:
+						out.Error(fmt.Sprintf("branch '%s' already has a worktree at %s; choose a new destination branch for --with-state", collErr.Branch, collErr.Path), ErrCodeInvalidOperation)
+					case git.CollisionBranchExists:
+						out.Error(fmt.Sprintf("branch '%s' already exists; choose a new destination branch for --with-state", collErr.Branch), ErrCodeInvalidOperation)
+					default:
+						out.Error(collErr.Error(), ErrCodeInvalidOperation)
+					}
+					os.Exit(1)
+				}
+				out.Error(fmt.Sprintf("failed to validate destination: %v", err), ErrCodeInvalidOperation)
+				os.Exit(1)
+			}
+		} else if !createNewBranch && !backend.BranchExists(wtBranch) {
 			out.Error(fmt.Sprintf("branch '%s' does not exist (use -b to create)", wtBranch), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
@@ -736,11 +790,19 @@ func handleSessionFork(profile string, args []string) {
 			Template:  wtSettings.Template(),
 		})
 
-		// Check for an existing worktree for this branch before creating a new one
-		if existingPath, err := backend.GetWorktreeForBranch(wtBranch); err == nil && existingPath != "" {
-			fmt.Fprintf(os.Stderr, "Reusing existing worktree at %s for branch %s\n", existingPath, wtBranch)
-			worktreePath = existingPath
-		} else {
+		// Check for an existing worktree for this branch before creating a new
+		// one. Routed through the backend so jujutsu reuse keeps working. The
+		// with-state path is validated above and must NEVER reuse a worktree, so
+		// the reuse assignment is gated on !wantState (BUG-01/08).
+		reuseExistingWorktree := false
+		if !wantState {
+			if existingPath, err := backend.GetWorktreeForBranch(wtBranch); err == nil && existingPath != "" {
+				fmt.Fprintf(os.Stderr, "Reusing existing worktree at %s for branch %s\n", existingPath, wtBranch)
+				worktreePath = existingPath
+				reuseExistingWorktree = true
+			}
+		}
+		if !reuseExistingWorktree {
 			if _, statErr := os.Stat(worktreePath); statErr == nil {
 				out.Error(fmt.Sprintf("worktree path already exists: %s", worktreePath), ErrCodeInvalidOperation)
 				os.Exit(1)
@@ -751,28 +813,96 @@ func handleSessionFork(profile string, args []string) {
 				os.Exit(1)
 			}
 
-			// --with-state* is git-specific (uses index/stash). Reject for jujutsu.
-			if backend.Type() == vcs.TypeGit {
-				setupErr, err := git.CreateWorktreeWithStateAndSetup(
-					repoRoot, worktreePath, wtBranch,
-					git.WorktreeStateOptions{WithState: wantState, WithIgnored: *withStateGitignored},
-					os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
-				if err != nil {
-					out.Error(fmt.Sprintf("worktree creation failed: %v", err), ErrCodeInvalidOperation)
+			var setupErr error
+			if wantState {
+				// git-only, guaranteed by the early guard above.
+				//
+				// Mid-op refusal: surface an actionable error BEFORE creating the
+				// worktree, so the user sees the exact abort command for their
+				// parent instead of MaterializeWipFromParent's terse backstop
+				// wording (which fires AFTER worktree creation and triggers
+				// cleanup-on-error). The backstop in materialize_wip.go's
+				// refuseUnsafeParentState still covers detectErr != nil cases — we
+				// fall through silently there.
+				if kind, detectErr := git.DetectInProgressOperation(inst.ProjectPath); detectErr == nil && kind != "" {
+					abortCmd := map[string]string{
+						"rebase":      "git rebase --abort",
+						"merge":       "git merge --abort",
+						"cherry-pick": "git cherry-pick --abort",
+						"revert":      "git revert --abort",
+						"bisect":      "git bisect reset",
+					}[kind]
+					out.Error(fmt.Sprintf("parent session is mid-%s; finish or abort the %s before forking with state (cd %s && %s)",
+						kind, kind, inst.ProjectPath, abortCmd), ErrCodeInvalidOperation)
 					os.Exit(1)
 				}
-				if setupErr != nil {
-					fmt.Fprintf(os.Stderr, "Warning: worktree setup script failed: %v\n", setupErr)
+
+				if git.HasSubmodules(inst.ProjectPath) {
+					fmt.Fprintln(os.Stderr, "Warning: submodules detected — copied as files, not recursed (parent's submodule states preserved)")
+				}
+
+				// Capture parent's HEAD so linked-worktree parents anchor correctly.
+				parentHead, hcErr := git.HeadCommit(inst.ProjectPath)
+				if hcErr != nil {
+					out.Error(fmt.Sprintf("failed to resolve parent session HEAD: %v", hcErr), ErrCodeInvalidOperation)
+					os.Exit(1)
+				}
+
+				createdBranch, cwErr := git.CreateWorktreeAtStartPoint(repoRoot, worktreePath, wtBranch, parentHead)
+				if cwErr != nil {
+					out.Error(fmt.Sprintf("worktree creation failed: %v", cwErr), ErrCodeInvalidOperation)
+					os.Exit(1)
+				}
+
+				// Materialize parent state, with cleanup-on-error.
+				if matErr := git.MaterializeWipFromParent(inst.ProjectPath, worktreePath, *withStateGitignored); matErr != nil {
+					var cleanupErrs []string
+					if rmErr := exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", worktreePath).Run(); rmErr != nil {
+						cleanupErrs = append(cleanupErrs, fmt.Sprintf("worktree remove failed: %v", rmErr))
+					}
+					if createdBranch {
+						if brErr := exec.Command("git", "-C", repoRoot, "branch", "-D", wtBranch).Run(); brErr != nil {
+							cleanupErrs = append(cleanupErrs, fmt.Sprintf("branch delete failed: %v", brErr))
+						}
+					}
+					if len(cleanupErrs) == 0 {
+						out.Error(fmt.Sprintf("failed to materialize parent state: %v; new worktree cleaned up", matErr), ErrCodeInvalidOperation)
+					} else {
+						out.Error(fmt.Sprintf("failed to materialize parent state: %v; cleanup also failed (%s); manual cleanup required: rm -rf %s%s",
+							matErr,
+							strings.Join(cleanupErrs, "; "),
+							worktreePath,
+							branchCleanupHint(createdBranch, repoRoot, wtBranch),
+						), ErrCodeInvalidOperation)
+					}
+					os.Exit(1)
+				}
+
+				// Continue upstream's wrapper tail: worktreeinclude + setup hook.
+				if inclErr := git.ProcessWorktreeInclude(repoRoot, worktreePath, os.Stderr); inclErr != nil {
+					fmt.Fprintf(os.Stderr, "worktreeinclude: %v\n", inclErr)
+				}
+				setupErr = git.RunWorktreeSetupAfterCreate(repoRoot, worktreePath, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+			} else if backend.Type() == vcs.TypeGit {
+				// Non-with-state git path: upstream's combined wrapper unchanged.
+				var cwErr error
+				setupErr, cwErr = git.CreateWorktreeWithStateAndSetup(
+					repoRoot, worktreePath, wtBranch,
+					git.WorktreeStateOptions{},
+					os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+				if cwErr != nil {
+					out.Error(fmt.Sprintf("worktree creation failed: %v", cwErr), ErrCodeInvalidOperation)
+					os.Exit(1)
 				}
 			} else {
-				if wantState {
-					out.Error("--with-state is only supported for git repositories", ErrCodeInvalidOperation)
-					os.Exit(1)
-				}
+				// Non-git backend (jujutsu): with-state already rejected above.
 				if err := backend.CreateWorktree(worktreePath, wtBranch); err != nil {
 					out.Error(fmt.Sprintf("worktree creation failed: %v", err), ErrCodeInvalidOperation)
 					os.Exit(1)
 				}
+			}
+			if setupErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: worktree setup script failed: %v\n", setupErr)
 			}
 		}
 
@@ -798,6 +928,14 @@ func handleSessionFork(profile string, args []string) {
 	// Apply sandbox config if requested.
 	if *sandbox {
 		forkedInst.Sandbox = session.NewSandboxConfig(*sandboxImage)
+	}
+
+	// Test seam: when set, capture the fully-prepared fork before tmux Start()
+	// mutates the environment and return early. Production runs leave the hook
+	// nil, so this is a no-op outside of tests.
+	if sessionForkBeforeStartHook != nil {
+		sessionForkBeforeStartHook(inst, forkedInst, git.WorktreeStateOptions{WithState: wantState, WithIgnored: *withStateGitignored})
+		return
 	}
 
 	// Start the forked session

--- a/cmd/agent-deck/session_cmd_fork_state_test.go
+++ b/cmd/agent-deck/session_cmd_fork_state_test.go
@@ -332,3 +332,27 @@ func TestSessionForkBeforeStartHook_NilInProduction(t *testing.T) {
 			"(a previous test leaked an assignment without restoring nil)")
 	}
 }
+
+// TestBranchCleanupHint_ShellQuotesPathAndBranch guards that the manual-cleanup
+// hint is copy-paste-safe: repo root and branch names containing spaces or
+// shell metacharacters must be quoted so the printed `git -C ... branch -D ...`
+// fragment runs as a single argument each rather than word-splitting.
+func TestBranchCleanupHint_ShellQuotesPathAndBranch(t *testing.T) {
+	if got := branchCleanupHint(false, "/repo", "feature/x"); got != "" {
+		t.Fatalf("expected empty hint when branch was not created, got %q", got)
+	}
+
+	got := branchCleanupHint(true, "/home/u/my repo", "feature/has space")
+	if strings.Contains(got, "git -C /home/u/my repo ") {
+		t.Errorf("repo root with a space was not quoted in hint: %q", got)
+	}
+	if strings.Contains(got, "branch -D feature/has space") {
+		t.Errorf("branch name with a space was not quoted in hint: %q", got)
+	}
+	if !strings.Contains(got, "'/home/u/my repo'") {
+		t.Errorf("expected repo root single-quoted, got %q", got)
+	}
+	if !strings.Contains(got, "'feature/has space'") {
+		t.Errorf("expected branch name single-quoted, got %q", got)
+	}
+}

--- a/cmd/agent-deck/session_cmd_fork_state_test.go
+++ b/cmd/agent-deck/session_cmd_fork_state_test.go
@@ -1,0 +1,334 @@
+// session_cmd_fork_state_test.go — CLI contract tests for
+// `agent-deck session fork --with-state` (Task A4, closing gap 9 of the
+// post-#1029 followup).
+//
+// These tests guard:
+//
+//  1. The four destination-rejection branches in handleSessionFork — the
+//     "requires an explicit worktree branch" check for both --with-state
+//     and --with-state-and-gitignored, plus the two
+//     DestinationCollisionError surfaces ("already exists" and
+//     "already has a worktree"). Each must be present and worded to give
+//     the user an actionable next step ("choose a new destination branch
+//     for --with-state").
+//
+//  2. The propagation contract — opts.WorktreeBranch carries the resolved
+//     branch into ClaudeOptions, MaterializeWipFromParent is called with
+//     the gitignored flag wired through, and the
+//     sessionForkBeforeStartHook is invoked with the resolved
+//     git.WorktreeStateOptions before forkedInst.Start() so tests can capture
+//     the prepared fork without spawning a real tmux session.
+//
+// Why structural assertions instead of end-to-end handler invocation:
+// handleSessionFork calls os.Exit on every error path, and there is no
+// runMain/TestHelperProcess subprocess harness in this package. The
+// existing precedent for cmd-level invariant assertions is
+// session_remove_kill_test.go's extractFuncBody approach — we follow it.
+// session.ClaudeOptions also doesn't carry WithState / IncludeGitignored
+// fields (upstream routes those through git.WorktreeStateOptions), so the
+// hook exposes the resolved git-layer state directly.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// foldSpaces collapses runs of whitespace so multi-line source can be matched
+// with a single literal substring.
+func foldSpaces(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func mustExtractHandleSessionFork(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile("session_cmd.go")
+	if err != nil {
+		t.Fatalf("read session_cmd.go: %v", err)
+	}
+	body := extractFuncBody(string(src), "handleSessionFork")
+	if body == "" {
+		t.Fatalf("could not extract handleSessionFork body — file layout changed?")
+	}
+	return body
+}
+
+func initGitRepoForForkStateTest(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	for _, args := range [][]string{
+		{"init"},
+		{"commit", "--allow-empty", "-m", "init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(testutil.CleanGitEnv(os.Environ()),
+			"GIT_AUTHOR_NAME=Test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=Test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, string(out))
+		}
+	}
+}
+
+// TestSessionFork_WithStateRequiresExplicitDestinationBranch locks in the
+// validation that --with-state without -w / --worktree is rejected with a
+// user-actionable message. Without this, the handler would silently fall
+// into the no-worktree path and materialize nothing.
+func TestSessionFork_WithStateRequiresExplicitDestinationBranch(t *testing.T) {
+	body := mustExtractHandleSessionFork(t)
+	folded := foldSpaces(body)
+
+	// Both --with-state and --with-state-and-gitignored share the same
+	// wantState gate, so a single check covers both flags' behavior.
+	if !strings.Contains(folded, "wantState := *withState || *withStateGitignored") {
+		t.Errorf("handleSessionFork must compute wantState as the union of "+
+			"--with-state and --with-state-and-gitignored; body did not contain "+
+			"the expected expression. Body (folded):\n%s", folded)
+	}
+	if !strings.Contains(folded, `--with-state requires an explicit worktree branch (-w/--worktree)`) {
+		t.Errorf("handleSessionFork must reject --with-state without a worktree "+
+			"branch with a user-actionable error. Body (folded):\n%s", folded)
+	}
+}
+
+// TestSessionFork_WithStateAndGitignoredRequiresExplicitDestinationBranch —
+// the implies-wantState union (above) means the same check guards
+// --with-state-and-gitignored. We assert it explicitly so a future split of
+// the two paths must also split the test.
+func TestSessionFork_WithStateAndGitignoredRequiresExplicitDestinationBranch(t *testing.T) {
+	body := mustExtractHandleSessionFork(t)
+	folded := foldSpaces(body)
+
+	// The withStateGitignored flag must be referenced inside the wantState
+	// expression, which then drives the explicit-branch check.
+	if !strings.Contains(folded, "*withStateGitignored") {
+		t.Errorf("handleSessionFork must reference the withStateGitignored flag; "+
+			"folded body:\n%s", folded)
+	}
+	if !strings.Contains(folded, "wantState && wtBranch ==") {
+		t.Errorf("handleSessionFork must gate explicit-branch enforcement on "+
+			"wantState (so --with-state-and-gitignored takes the same path); "+
+			"folded body:\n%s", folded)
+	}
+}
+
+// TestSessionFork_WithState_RejectsExistingDestinationBranch — the
+// DestinationCollisionError(BranchExists) branch must produce a message
+// that names the branch and tells the user what to do.
+func TestSessionFork_WithState_RejectsExistingDestinationBranch(t *testing.T) {
+	body := mustExtractHandleSessionFork(t)
+	folded := foldSpaces(body)
+
+	if !strings.Contains(folded, "git.CollisionBranchExists") {
+		t.Errorf("handleSessionFork must handle CollisionBranchExists explicitly; "+
+			"folded body:\n%s", folded)
+	}
+	if !strings.Contains(folded, "already exists") {
+		t.Errorf("handleSessionFork must mention 'already exists' on branch collision; "+
+			"folded body:\n%s", folded)
+	}
+	if !strings.Contains(folded, "choose a new destination branch for --with-state") {
+		t.Errorf("handleSessionFork must give actionable guidance "+
+			"('choose a new destination branch for --with-state') on collision; "+
+			"folded body:\n%s", folded)
+	}
+}
+
+// TestSessionFork_WithState_RejectsExistingDestinationWorktree — the
+// DestinationCollisionError(WorktreeExists) branch must produce a message
+// that names the existing worktree path and tells the user what to do.
+func TestSessionFork_WithState_RejectsExistingDestinationWorktree(t *testing.T) {
+	body := mustExtractHandleSessionFork(t)
+	folded := foldSpaces(body)
+
+	if !strings.Contains(folded, "git.CollisionWorktreeExists") {
+		t.Errorf("handleSessionFork must handle CollisionWorktreeExists explicitly; "+
+			"folded body:\n%s", folded)
+	}
+	if !strings.Contains(folded, "already has a worktree") {
+		t.Errorf("handleSessionFork must mention 'already has a worktree' on "+
+			"worktree collision; folded body:\n%s", folded)
+	}
+	if !strings.Contains(folded, "choose a new destination branch for --with-state") {
+		t.Errorf("handleSessionFork must give actionable guidance on worktree "+
+			"collision; folded body:\n%s", folded)
+	}
+}
+
+// TestSessionFork_WithStateOptionsPropagatedBeforeStart locks in three
+// invariants of the with-state path's wiring into ClaudeOptions,
+// git.WorktreeStateOptions, and the MaterializeWipFromParent call site:
+//
+//  1. opts.WorktreeBranch is set to the resolved wtBranch so the forked
+//     session knows which branch it lives on.
+//  2. MaterializeWipFromParent is called with *withStateGitignored as the
+//     includeIgnored argument, so --with-state-and-gitignored actually
+//     flips on ignored-file inclusion.
+//  3. The sessionForkBeforeStartHook is invoked with the resolved
+//     git.WorktreeStateOptions before forkedInst.Start(), so contract tests can
+//     short-circuit before tmux mutation.
+//
+// (ClaudeOptions has no WithState / IncludeGitignored fields; the with-state
+// behavior is expressed at the call site of MaterializeWipFromParent.)
+func TestSessionFork_WithStateOptionsPropagatedBeforeStart(t *testing.T) {
+	body := mustExtractHandleSessionFork(t)
+	folded := foldSpaces(body)
+
+	if !strings.Contains(folded, "opts.WorktreeBranch = wtBranch") {
+		t.Errorf("handleSessionFork must propagate the resolved branch into "+
+			"opts.WorktreeBranch; folded body:\n%s", folded)
+	}
+
+	// MaterializeWipFromParent must be called with the gitignored flag —
+	// that's how `--with-state-and-gitignored` becomes observable behavior.
+	if !strings.Contains(folded, "git.MaterializeWipFromParent(inst.ProjectPath, worktreePath, *withStateGitignored)") {
+		t.Errorf("handleSessionFork must wire *withStateGitignored as the "+
+			"includeIgnored argument to MaterializeWipFromParent; folded body:\n%s",
+			folded)
+	}
+
+	// The hook must fire BEFORE forkedInst.Start() so tests can capture the
+	// prepared fork without spawning a real tmux session.
+	hookIdx := strings.Index(folded, "sessionForkBeforeStartHook(inst, forkedInst, git.WorktreeStateOptions{WithState: wantState, WithIgnored: *withStateGitignored})")
+	if hookIdx < 0 {
+		t.Fatalf("handleSessionFork must invoke sessionForkBeforeStartHook(inst, "+
+			"forkedInst, git.WorktreeStateOptions{WithState: wantState, "+
+			"WithIgnored: *withStateGitignored}); folded body:\n%s", folded)
+	}
+	startIdx := strings.Index(folded, "forkedInst.Start()")
+	if startIdx < 0 {
+		t.Fatalf("handleSessionFork must call forkedInst.Start(); folded body:\n%s",
+			folded)
+	}
+	if hookIdx > startIdx {
+		t.Errorf("sessionForkBeforeStartHook must be invoked BEFORE "+
+			"forkedInst.Start() (hook idx %d > start idx %d); folded body:\n%s",
+			hookIdx, startIdx, folded)
+	}
+
+	// The hook path must short-circuit (return) so persistence and tmux
+	// mutation never run when the hook is set.
+	hookBlock := folded[hookIdx:]
+	cutEnd := len(hookBlock)
+	if idx := strings.Index(hookBlock, "forkedInst.Start()"); idx >= 0 {
+		cutEnd = idx
+	}
+	if !strings.Contains(hookBlock[:cutEnd], "return") {
+		t.Errorf("handleSessionFork must return immediately after invoking "+
+			"sessionForkBeforeStartHook to short-circuit the Start() path; "+
+			"folded segment:\n%s", hookBlock[:cutEnd])
+	}
+}
+
+func TestSessionFork_WithStateHookCapturesResolvedStateBeforeStart(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	configDir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[worktree]\nbranch_prefix = \"\"\ndefault_location = \"sibling\"\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	session.ClearUserConfigCache()
+
+	repo := filepath.Join(home, "repo")
+	initGitRepoForForkStateTest(t, repo)
+
+	parent := session.NewInstanceWithGroupAndTool("parent", repo, "evalgrp", "claude")
+	parent.ClaudeSessionID = "00000000-0000-4000-8000-000000000001"
+	parent.ClaudeDetectedAt = time.Now()
+
+	profile := "fork_state_hook"
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	if err := storage.SaveWithGroups([]*session.Instance{parent}, session.NewGroupTreeWithGroups([]*session.Instance{parent}, nil)); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	var capturedParent *session.Instance
+	var capturedFork *session.Instance
+	var capturedState git.WorktreeStateOptions
+	oldHook := sessionForkBeforeStartHook
+	sessionForkBeforeStartHook = func(parent *session.Instance, forked *session.Instance, state git.WorktreeStateOptions) {
+		capturedParent = parent
+		capturedFork = forked
+		capturedState = state
+	}
+	t.Cleanup(func() { sessionForkBeforeStartHook = oldHook })
+
+	handleSessionFork(profile, []string{
+		"parent",
+		"--with-state-and-gitignored",
+		"-w", "fork/hook-state",
+		"-t", "forked",
+	})
+
+	if capturedParent == nil || capturedParent.ID != parent.ID {
+		t.Fatalf("hook captured parent = %+v, want parent %s", capturedParent, parent.ID)
+	}
+	if capturedFork == nil {
+		t.Fatal("hook did not capture forked instance")
+	}
+	if capturedFork.WorktreeBranch != "fork/hook-state" {
+		t.Fatalf("forked WorktreeBranch = %q, want fork/hook-state", capturedFork.WorktreeBranch)
+	}
+	if !capturedState.WithState || !capturedState.WithIgnored {
+		t.Fatalf("captured state = %+v, want WithState and WithIgnored true", capturedState)
+	}
+}
+
+// TestSessionFork_WithState_RefusesMidOpWithActionableHint_StructuralGuard
+// pins the gap 6 flow: handler must call git.DetectInProgressOperation on the
+// parent's ProjectPath, build a map of abort commands covering all 5 in-flight
+// operation kinds, and emit the actionable "finish or abort" message before
+// worktree creation. If a future contributor drops a kind from the abortCmd
+// map, this test fails so the regression cannot land silently.
+func TestSessionFork_WithState_RefusesMidOpWithActionableHint_StructuralGuard(t *testing.T) {
+	body := mustExtractHandleSessionFork(t)
+	for _, marker := range []string{
+		"git.DetectInProgressOperation(inst.ProjectPath)",
+		`abortCmd := map[string]string`,
+		"git rebase --abort",
+		"git merge --abort",
+		"git cherry-pick --abort",
+		"git revert --abort",
+		"git bisect reset",
+		"parent session is mid-%s; finish or abort the %s before forking with state",
+	} {
+		if !strings.Contains(body, marker) {
+			t.Errorf("handleSessionFork missing required marker: %q", marker)
+		}
+	}
+}
+
+// TestSessionForkBeforeStartHook_NilInProduction is a belt-and-braces check:
+// the production binary must leave the hook nil so accidental test imports
+// can't inject behavior into a real fork. Tests that need the hook assign
+// it inside a t.Cleanup that restores nil.
+func TestSessionForkBeforeStartHook_NilInProduction(t *testing.T) {
+	if sessionForkBeforeStartHook != nil {
+		t.Fatal("sessionForkBeforeStartHook must be nil at package init " +
+			"(a previous test leaked an assignment without restoring nil)")
+	}
+}

--- a/docs/superpowers/discussions/2026-05-17-item-4-collision-check.html
+++ b/docs/superpowers/discussions/2026-05-17-item-4-collision-check.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Item 4: Redundant existing-worktree check in Task 13</title>
+<style>
+  :root {
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --muted: #555;
+    --border: #d0d7de;
+    --code-bg: #f6f8fa;
+    --accent: #2563eb;
+    --accent-hover: #1d4ed8;
+    --success: #16a34a;
+    --warn-bg: #fff8e1;
+    --warn-border: #f9c74f;
+    --rec: #2a9d8f;
+  }
+  * { box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    max-width: 960px;
+    margin: 2rem auto;
+    padding: 0 1.25rem 4rem;
+    line-height: 1.6;
+    color: var(--fg);
+    background: var(--bg);
+  }
+  h1 { font-size: 1.8rem; margin-bottom: 0.25rem; }
+  .subtitle { color: var(--muted); margin-top: 0; margin-bottom: 1.5rem; font-size: 0.95rem; }
+  h2 { font-size: 1.3rem; border-bottom: 1px solid var(--border); padding-bottom: 0.3rem; margin-top: 2.5rem; }
+  h3 { font-size: 1.05rem; margin-top: 1.5rem; }
+  p { margin: 0.7rem 0; }
+  pre {
+    background: var(--code-bg);
+    padding: 1rem;
+    border-radius: 6px;
+    overflow-x: auto;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 12.5px;
+    line-height: 1.45;
+    border: 1px solid var(--border);
+  }
+  code {
+    background: #eef0f2;
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.88em;
+  }
+  pre code { background: none; padding: 0; }
+  .ascii { white-space: pre; line-height: 1.25; font-size: 12px; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid var(--border); padding: 0.55rem 0.7rem; text-align: left; vertical-align: top; font-size: 0.95em; }
+  th { background: var(--code-bg); }
+  .toc {
+    background: #f0f4f8;
+    padding: 0.9rem 1rem;
+    border-radius: 6px;
+    margin: 1rem 0 1.5rem;
+    font-size: 0.95em;
+  }
+  .toc strong { display: block; margin-bottom: 0.3rem; }
+  .toc ul { margin: 0; padding-left: 1.25rem; }
+  .toc li { margin: 0.2rem 0; }
+  .toc a { color: var(--accent); text-decoration: none; }
+  .toc a:hover { text-decoration: underline; }
+
+  .decision {
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-border);
+    padding: 1.25rem 1.5rem;
+    border-radius: 8px;
+    margin: 2rem 0;
+  }
+  .decision h2 { border: none; margin-top: 0; padding-bottom: 0; }
+  .options { display: flex; flex-direction: column; gap: 0.7rem; margin-top: 1rem; }
+  .option-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 1rem;
+    align-items: center;
+    padding: 0.9rem 1rem;
+    background: white;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+  }
+  .option-row.recommended {
+    border-color: var(--rec);
+    box-shadow: 0 0 0 2px rgba(42, 157, 143, 0.15);
+  }
+  .option-label { font-weight: 600; }
+  .recommended-badge {
+    display: inline-block;
+    font-size: 0.7em;
+    background: var(--rec);
+    color: white;
+    padding: 0.12rem 0.55rem;
+    border-radius: 999px;
+    margin-left: 0.5rem;
+    vertical-align: middle;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 700;
+  }
+  .option-summary {
+    color: var(--muted);
+    font-size: 0.9em;
+    margin-top: 0.2rem;
+  }
+  button.copy {
+    background: var(--accent);
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: 500;
+    min-width: 130px;
+    font-size: 0.9em;
+    transition: background-color 0.15s;
+  }
+  button.copy:hover { background: var(--accent-hover); }
+  button.copy.copied { background: var(--success); }
+  .toast {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #111;
+    color: white;
+    padding: 0.75rem 1.25rem;
+    border-radius: 6px;
+    opacity: 0;
+    transition: opacity 0.2s;
+    pointer-events: none;
+    z-index: 10;
+    font-size: 0.9em;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  }
+  .toast.visible { opacity: 1; }
+  .note { background: var(--code-bg); border-left: 3px solid var(--accent); padding: 0.7rem 1rem; margin: 1rem 0; font-size: 0.92em; }
+  hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+</style>
+</head>
+<body>
+
+<h1>Item 4: Redundant existing-worktree check in Task 13</h1>
+<p class="subtitle">Decision document · fork-with-state · 2026-05-17</p>
+
+<div class="toc">
+  <strong>Contents</strong>
+  <ul>
+    <li><a href="#background">Background: existing worktrees in git</a></li>
+    <li><a href="#today">Today&rsquo;s behavior (pre-feature)</a></li>
+    <li><a href="#feature">What this feature adds, and where collision matters</a></li>
+    <li><a href="#workflows">Workflow walkthroughs</a></li>
+    <li><a href="#cli-vs-tui">CLI vs TUI architectural comparison</a></li>
+    <li><a href="#decision">Decision &mdash; four options</a></li>
+  </ul>
+</div>
+
+<h2 id="background">Background: existing worktrees in git</h2>
+<p>
+  <code>git worktree add &lt;path&gt; &lt;branch&gt;</code> creates a directory checked out to <code>&lt;branch&gt;</code>.
+  Once created, git refuses any future <code>git worktree add</code> for that same branch (the
+  one-branch-one-worktree rule). The branch is &ldquo;claimed&rdquo; by the worktree.
+</p>
+<p>
+  <code>git worktree list --porcelain</code> reports each branch and the path of its worktree.
+  The helper <code>git.GetWorktreeForBranch(repoRoot, branch)</code> wraps this &mdash; returns the path if a
+  worktree exists for that branch, empty string otherwise.
+</p>
+
+<h2 id="today">Today&rsquo;s behavior (pre-feature)</h2>
+<p>
+  Today, <code>session fork -w &lt;branch&gt;</code> has a <strong>reuse-on-collision</strong>
+  behavior at <code>session_cmd.go:721-723</code>:
+</p>
+<pre><code>// Check for an existing worktree for this branch before creating a new one
+if existingPath, err := git.GetWorktreeForBranch(repoRoot, wtBranch); err == nil &amp;&amp; existingPath != "" {
+    fmt.Fprintf(os.Stderr, "Reusing existing worktree at %s for branch %s\n", existingPath, wtBranch)
+    worktreePath = existingPath
+} else {
+    // create new worktree...
+}</code></pre>
+<p>
+  This is intentional: if you keep forking sessions for the same experiment branch, you want them all
+  to land in the same workspace, not stamp out N copies.
+</p>
+
+<div class="ascii">
+USER: agent-deck session fork my-session -w fork/exp
+                                            │
+                                            ▼
+                                  ┌─────────────────────────────┐
+                                  │ Does branch fork/exp exist? │
+                                  └─────────────────────────────┘
+                                  no, no -b  │      │ yes
+                                             ▼      ▼
+                                          ERROR    Continue
+                                             │
+                                             ▼
+                            ┌────────────────────────────────────────┐
+                            │ Does fork/exp already have a worktree? │
+                            └────────────────────────────────────────┘
+                                  yes  │             │ no
+                                       ▼             ▼
+                              REUSE that worktree   Create new worktree
+                                       │             │
+                                       └──────┬──────┘
+                                              ▼
+                                  Fork Claude into worktree
+</div>
+
+<h2 id="feature">What this feature adds, and where collision matters</h2>
+<p>
+  Fork-with-state <strong>must not reuse</strong> an existing worktree: materialization would overwrite or
+  interleave with whatever state is already there. A user who runs
+  <code>session fork --with-state -w fork/exp</code> and finds an existing <code>fork/exp</code> worktree
+  must get an error, not a silent reuse.
+</p>
+<p>
+  So the new with-state path needs a refusal that today&rsquo;s path doesn&rsquo;t have. Where to put that
+  refusal is the architectural question.
+</p>
+
+<h2 id="workflows">Workflow walkthroughs</h2>
+
+<h3>Workflow A &mdash; Happy path: <code>--with-state -w fork/new</code>, no conflicts</h3>
+<div class="ascii">
+1. resolveForkStateFlags → stateFlags.WithState=true, Branch="fork/new"
+2. Refuse if --with-state but no -w (passes)
+3. Enter `if stateFlags.WithState {...}` early gate (plan line 1742):
+     ├── GetWorktreeForBranch("fork/new")          → empty   ✓ (Check #1a)
+     ├── BranchExists("fork/new")                  → false   ✓ (Check #1b)
+     └── PreflightForkWithState(parent)            → ok      ✓
+4. Exit early gate; compute worktreePath
+5. Enter existing-worktree reuse block (plan line 1785):
+     └── GetWorktreeForBranch("fork/new")          → empty   ✓ (Check #2)
+        → fall into the "create new" branch
+6. CreateWorktreeAtStartPoint → ok
+7. MaterializeParentState → ok
+8. RunWorktreeSetup → ok
+9. Start fork
+</div>
+<p>
+  Note that <strong>GetWorktreeForBranch is called twice</strong> at steps 3a and 5. Both return empty.
+  Step 5&rsquo;s redundancy is benign here.
+</p>
+
+<h3>Workflow B &mdash; <code>--with-state -w fork/exp</code> where <code>fork/exp</code> already has a worktree</h3>
+<div class="ascii">
+1. resolveForkStateFlags → stateFlags.WithState=true, Branch="fork/exp"
+2. Refuse if --with-state but no -w (passes)
+3. Enter early gate:
+     ├── GetWorktreeForBranch("fork/exp") → "/x/fork-exp" (non-empty)
+     │    → out.Error("branch 'fork/exp' already has a worktree at /x/fork-exp; ...")
+     │    → os.Exit(1)                                                        ← EXIT HERE
+     ...
+   (Check #2 in the reuse block is never reached)
+</div>
+
+<h3>Workflow C &mdash; The imagined &ldquo;the early gate got refactored&rdquo; scenario</h3>
+<p>The plan author&rsquo;s defensive justification: imagine a future refactor that moves preflight elsewhere and accidentally drops Check #1a:</p>
+<div class="ascii">
+1-3. (modified) early gate runs preflight only, no GetWorktreeForBranch
+4. Compute worktreePath
+5. Enter reuse block:
+     └── GetWorktreeForBranch("fork/exp") → "/x/fork-exp"
+        ├── (with the redundant guard): if stateFlags.WithState → out.Error → os.Exit
+        └── (without the redundant guard): print "Reusing existing worktree..."
+                                            → worktreePath = "/x/fork-exp"  ← would be a BUG
+6. CreateWorktreeAtStartPoint runs against the existing branch
+   → CreateWorktreeAtStartPoint refuses (BranchExists check inside it)
+   → out.Error("worktree creation failed...") → os.Exit
+</div>
+<div class="note">
+  <strong>Important:</strong> even in the &ldquo;refactored-away&rdquo; scenario,
+  <code>CreateWorktreeAtStartPoint</code> at step 6 itself rejects the existing branch (per Task 4A line 564:
+  <code>if BranchExists(...) { return false, fmt.Errorf("branch %q already exists", ...) }</code>).
+  The defense isn&rsquo;t doing what the plan author thought &mdash; the bottom-of-stack check catches the slip.
+</div>
+
+<h2 id="cli-vs-tui">CLI vs TUI architectural comparison</h2>
+<p>Here are the two handlers side by side, schematically:</p>
+
+<pre class="ascii">                 CLI: handleSessionFork                   TUI: forkSessionCmdWithOptions
+                 ─────────────────────                    ──────────────────────────────
+                                                          (dialog has already validated
+                                                           user input via ForkDialog.Validate
+                                                           before this cmd is dispatched)
+
+  ┌─ Parse flags ─────────────────────────┐               ┌─ Receive pre-built opts ─────┐
+  │   wtBranch, withState, etc.           │               │   from dialog submit         │
+  └───────────────────────────────────────┘               └──────────────────────────────┘
+                  │                                                       │
+                  ▼                                                       ▼
+  ┌─ All-validation block ────────────────┐               ┌─ Existing-worktree reuse ────┐
+  │   refuse --with-state without -w      │               │   if GetWorktreeForBranch:   │
+  │   if WithState {                      │               │     if opts.WithState:       │
+  │     Check #1a: GetWorktreeForBranch ──┼──┐            │       return error           │ ← (only collision check)
+  │     Check #1b: BranchExists           │  │            │     else: reuse it           │
+  │     Preflight                         │  │            │   else: continue             │
+  │   } else if !createNewBranch:         │  │            └──────────────────────────────┘
+  │     BranchExists                      │  │                            │
+  └───────────────────────────────────────┘  │                            ▼
+                  │                          │            ┌─ Git-ops block ──────────────┐
+                  ▼                          │            │   if WithState:              │
+  ┌─ Compute worktree path ───────────────┐  │            │     Preflight                │
+  └───────────────────────────────────────┘  │            │     CreateWorktreeAtStartPoint
+                  │                          │            │   else:                      │
+                  ▼                          │            │     CreateWorktree           │
+  ┌─ Existing-worktree reuse ─────────────┐  │            │   if WithState:              │
+  │   if GetWorktreeForBranch:            │  │            │     MaterializeParentState   │
+  │     if WithState: error  ─────────────┼──┤            │   RunWorktreeSetup           │
+  │     else: reuse                       │  │ redundant  └──────────────────────────────┘
+  │   else: continue                      │  │            │
+  └───────────────────────────────────────┘  │            │
+                  │                          │            ▼
+                  ▼                          │        (return msg)
+  ┌─ Create / Materialize / Setup ────────┐  │
+  │   ...                                 │  │
+  └───────────────────────────────────────┘  │
+                                             │
+                                             └─ This is the redundant pair (CLI only)</pre>
+
+<h3>Key structural differences</h3>
+<table>
+  <thead>
+    <tr><th>Aspect</th><th>CLI</th><th>TUI</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Where validation lives</td>
+      <td>One big &ldquo;all-validation&rdquo; block early (plan line 1742-1779); flags and validation tightly coupled in one function.</td>
+      <td>Input validation in the dialog (<code>ForkDialog.Validate()</code>); the cmd handler does git work.</td>
+    </tr>
+    <tr>
+      <td>Error idiom</td>
+      <td><code>os.Exit(1)</code> after <code>out.Error(...)</code>.</td>
+      <td>Return <code>sessionForkedMsg{err, sourceID}</code> for the update loop to display.</td>
+    </tr>
+    <tr>
+      <td>Reuse-block ancestry</td>
+      <td>Inherited from today&rsquo;s code at <code>session_cmd.go:721</code> → plan line 1785-1796.</td>
+      <td>Inherited from today&rsquo;s code at <code>home.go:8499-8501</code> → plan line 2960-2968.</td>
+    </tr>
+    <tr>
+      <td>Where the new with-state collision check was added</td>
+      <td>In <em>both</em> the early validation block (Check #1a) <em>and</em> the reuse block (Check #2).</td>
+      <td>Only in the reuse block (line 2960-2968), the sole collision check.</td>
+    </tr>
+  </tbody>
+</table>
+<p>
+  The asymmetry happened because the CLI plan author wrote the gate first and then &ldquo;defensively&rdquo;
+  mirrored into the reuse block, while the TUI plan author saw the existing reuse block as the
+  natural insertion point and stopped there.
+</p>
+
+<h2 id="decision">Decision &mdash; four options</h2>
+
+<div class="decision">
+  <h2>Choose how to resolve the redundancy</h2>
+  <p>Pick an option to copy a decision string back to chat.</p>
+
+  <div class="options">
+
+    <div class="option-row">
+      <div>
+        <span class="option-label">Option A &mdash; Remove CLI Check #2&rsquo;s with-state branch</span>
+        <div class="option-summary">
+          Surfaces stay asymmetric (CLI checks early; TUI in reuse block); each has a single source of truth.
+          Simplest change. ~10 plan lines.
+        </div>
+      </div>
+      <button class="copy" data-decision="Option A: Remove CLI Check #2's with-state branch. Restore CLI's existing-worktree reuse block to today's exact behavior (no with-state awareness). CLI Check #1a in the early gate is the sole with-state collision check. TUI plan unchanged. ~10 plan lines.">Copy decision</button>
+    </div>
+
+    <div class="option-row">
+      <div>
+        <span class="option-label">Option B &mdash; Make TUI symmetric to CLI</span>
+        <div class="option-summary">
+          Add an early collision check to TUI; remove TUI&rsquo;s reuse-block with-state branch. Imposes
+          symmetry where the surfaces have legitimately different shapes. Not recommended.
+        </div>
+      </div>
+      <button class="copy" data-decision="Option B: Add an early collision check to TUI's forkSessionCmdWithOptions (before the existing reuse block). Remove TUI's reuse-block with-state branch. Surfaces become symmetric: both validate collision early, both have unchanged reuse blocks.">Copy decision</button>
+    </div>
+
+    <div class="option-row">
+      <div>
+        <span class="option-label">Option C &mdash; Keep the redundancy (status quo)</span>
+        <div class="option-summary">
+          Defense-in-depth that doesn&rsquo;t actually defend (the <code>CreateWorktreeAtStartPoint</code>
+          internal check already catches the slip). Adds reader confusion. Not recommended.
+        </div>
+      </div>
+      <button class="copy" data-decision="Option C: Leave the plan as-is. Keep CLI's redundant Check #2 with-state branch and the &quot;defensive if refactored&quot; comment. No changes to either CLI or TUI plan.">Copy decision</button>
+    </div>
+
+    <div class="option-row recommended">
+      <div>
+        <span class="option-label">
+          Option D &mdash; Extract shared <code>git.ValidateForkWithStateDestination</code> helper
+          <span class="recommended-badge">Recommended</span>
+        </span>
+        <div class="option-summary">
+          Mirrors the FWS-009 <code>PreflightForkWithState</code> pattern: git-fact validation lives in
+          <code>internal/git</code>, CLI and TUI both call it. Eliminates CLI redundancy, removes the
+          inline with-state branch from TUI&rsquo;s reuse block, gives one source of truth.
+          ~30 plan lines + 2-3 helper tests.
+        </div>
+      </div>
+      <button class="copy" data-decision="Option D: Extract a shared helper git.ValidateForkWithStateDestination(repoRoot, branch) in internal/git/worktree_with_state.go that wraps GetWorktreeForBranch and BranchExists with a typed DestinationCollisionError. CLI calls it before PreflightForkWithState in the early gate; restore CLI's reuse block to today's exact behavior. TUI calls it before its reuse block; restore TUI's reuse block to today's exact behavior. Add 2-3 helper unit tests. Mirrors the FWS-009 PreflightForkWithState architectural pattern.">Copy decision</button>
+    </div>
+
+  </div>
+</div>
+
+<h2>Why D is best for maintainability</h2>
+<ul>
+  <li><strong>Single source of truth</strong> for git-fact validation. Both surfaces call the same helper. If validation needs to add another check (e.g., branch name length, reserved-prefix policy), one place to edit.</li>
+  <li><strong>Mirrors the existing FWS-009 architecture pattern.</strong> The codebase already established that &ldquo;git facts shared by CLI and TUI live in <code>internal/git</code>.&rdquo; Adding a second helper (collision) alongside the first (preflight) is consistent.</li>
+  <li><strong>Spec line 174 is honored literally</strong>: both surfaces&rsquo; reuse blocks revert to today&rsquo;s unchanged behavior. The with-state refusal lives in the shared helper, not interleaved into legacy code paths.</li>
+  <li><strong>Eliminates the CLI redundancy</strong> without imposing symmetry on TUI&rsquo;s cmd shape.</li>
+  <li><strong>Removes reader confusion</strong>: no dead-code branches, no &ldquo;why is this check here twice?&rdquo; moments.</li>
+  <li><strong>Testable in isolation</strong>: unit tests for <code>ValidateForkWithStateDestination</code> cover the validation logic once.</li>
+</ul>
+
+<h2>Why D is best for user experience</h2>
+<p>
+  UX is unaffected by any of these options &mdash; the user gets the same error messages regardless.
+  CLI prints via <code>out.Error</code>, TUI returns the error from the cmd handler.
+  The shared helper returns a typed error; each surface formats it appropriately.
+</p>
+
+<h2>Argument against D</h2>
+<p>
+  D is the biggest change: touches <code>internal/git/worktree_with_state.go</code> (add helper + new error
+  type + 2-3 tests), <code>cmd/agent-deck/session_cmd.go</code> (replace 2 inline checks with 1 helper call),
+  <code>internal/ui/home.go</code> (replace inline check with 1 helper call), and the spec
+  (update test inventory + architecture description).
+</p>
+<p>
+  Extracting helpers prematurely is a real anti-pattern. Two callers is the minimum threshold for DRY;
+  if a third use case never materializes, the indirection added cost without payoff. Here we have
+  exactly two callers (CLI and TUI), and the FWS-009 precedent says this is the time to extract.
+</p>
+
+<div class="toast" id="toast">Decision copied to clipboard</div>
+
+<script>
+(function () {
+  const toast = document.getElementById('toast');
+  let toastTimer;
+
+  document.querySelectorAll('button.copy').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      const decision = btn.getAttribute('data-decision') || '';
+      const originalLabel = btn.textContent;
+
+      const showCopied = function () {
+        btn.classList.add('copied');
+        btn.textContent = 'Copied!';
+        toast.classList.add('visible');
+        if (toastTimer) { clearTimeout(toastTimer); }
+        toastTimer = setTimeout(function () {
+          btn.classList.remove('copied');
+          btn.textContent = originalLabel;
+          toast.classList.remove('visible');
+        }, 2000);
+      };
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(decision).then(showCopied, function () {
+          fallbackCopy(decision, showCopied);
+        });
+      } else {
+        fallbackCopy(decision, showCopied);
+      }
+    });
+  });
+
+  function fallbackCopy(text, onDone) {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      document.execCommand('copy');
+      onDone();
+    } catch (e) {
+      // no-op
+    } finally {
+      document.body.removeChild(ta);
+    }
+  }
+})();
+</script>
+
+</body>
+</html>

--- a/docs/superpowers/discussions/2026-05-17-track-b-runbook.md
+++ b/docs/superpowers/discussions/2026-05-17-track-b-runbook.md
@@ -1,0 +1,318 @@
+# Track B Runbook — Parallel Comparative Analysis vs Upstream's #1029 Implementation
+
+**Date:** 2026-05-17
+**Status:** Settled — ready for manual execution
+
+## Situation
+
+Issue #1029 (filed by @smorin) requested a fork-with-WIP-state feature. Upstream maintainer @asheshgoplani has implemented a working core on branch `upstream/feat/v1.9.x-1029-fork-carry-wip` (commit `02b6e5c4`, May 18 2026). In parallel, smorin had drafted a much more comprehensive design + plan in this clone (`/Users/stevemorin/c/agent-deck`, branch `feature/fork-worktree-with-state`).
+
+The two implementations have the same flag names (`--with-state`, `--with-state-and-gitignored`), same core approach (diff-based + parent-read-only), and same edge-case philosophy (refuse mid-rebase/merge/cherry-pick/bisect, materialize before setup hook). But smorin's plan appears to be a substantial superset, particularly around TUI integration, linked-worktree parent-HEAD correctness, shared CLI/TUI validators, and test coverage breadth.
+
+This runbook coordinates three parallel tracks of work.
+
+## Tracks
+
+| Track | Where | What | Status |
+|---|---|---|---|
+| **A** | This clone — `/Users/stevemorin/c/agent-deck`, branch `feature/fork-worktree-with-state` | Smorin's independent design and plan | In hand, 3 commits ahead of upstream/main, NOT pushed yet |
+| **B** | New worktree — `/Users/stevemorin/c/agent-deck-1029`, branch `review/feat-v1.9.x-1029-fork-carry-wip` | Comparative analysis of upstream's commit vs Track A | To create + populate via a new Claude Code session |
+| **C** | GitHub — Issue #1029 + any upstream PR | Public coordination with @asheshgoplani | Comment goes out **after** Track B's analysis lands |
+
+Tracks A and B share the same `.git` directory via `git worktree add`, so refs / exclude / hooks are common. Each worktree has its own HEAD and working tree.
+
+---
+
+## Section 1 — Create the parallel worktree (Track B)
+
+**Run from this clone:** `/Users/stevemorin/c/agent-deck`
+
+### 1a. Create the worktree
+
+```bash
+git worktree add /Users/stevemorin/c/agent-deck-1029 upstream/feat/v1.9.x-1029-fork-carry-wip
+```
+
+This:
+- Creates `/Users/stevemorin/c/agent-deck-1029` as a sibling directory
+- Checks out upstream's branch tip in detached HEAD state
+- Leaves Track A (`feature/fork-worktree-with-state` in this clone) unaffected
+
+### 1b. Create the review branch in the new worktree
+
+```bash
+cd /Users/stevemorin/c/agent-deck-1029
+git switch -c review/feat-v1.9.x-1029-fork-carry-wip
+git log --oneline -5
+# Expected top line: 02b6e5c4 feat(fork): --with-state and --with-state-and-gitignored ...
+```
+
+### 1c. Make per-developer files available
+
+The `.git/info/exclude` from Track A is shared (since `.git` is shared). `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md` are already ignored.
+
+Symlink the actual files in so Claude Code / Codex find their guidance:
+
+```bash
+ln -s /Users/stevemorin/c/agent-deck/CLAUDE.local.md CLAUDE.local.md
+ln -s /Users/stevemorin/c/agent-deck/AGENTS.md AGENTS.md
+ls -la CLAUDE.local.md AGENTS.md
+```
+
+### 1d. Sanity check
+
+```bash
+git worktree list
+# Expected:
+#   /Users/stevemorin/c/agent-deck            <HEAD>  [feature/fork-worktree-with-state]
+#   /Users/stevemorin/c/agent-deck-1029       <HEAD>  [review/feat-v1.9.x-1029-fork-carry-wip]
+```
+
+---
+
+## Section 2 — Launch the parallel Claude Code session in Track B
+
+Open a fresh terminal tab/window so the existing session in `/Users/stevemorin/c/agent-deck` keeps running independently.
+
+Pick one option below. **Option A is the preferred default** because it gives you a complete parallel environment (conversation + files), not just files. Option B is the alternative if you want a clean session.
+
+### Option A — Fork the parent Claude Code session into the worktree (preferred default)
+
+Dogfood the now-merged `--with-state-and-gitignored` flag to fork BOTH the Claude conversation AND the working-tree state into the parallel worktree. The new session inherits the full conversation history from the parent (so you don't need a long bootstrap prompt), plus all of the parent's tracked + staged + untracked + gitignored files (so `CLAUDE.local.md`, `AGENTS.md`, `.env`, etc. carry over automatically).
+
+**Caveat:** `--with-state` creates the destination worktree branched off the *parent session's HEAD* (i.e., your `feature/fork-worktree-with-state`), not off upstream's `feat/v1.9.x-1029-fork-carry-wip`. For the analysis task, this doesn't matter — the analyzer reads upstream's code via `git show 6a1645eb` or `git diff upstream/main~1..upstream/main` rather than relying on a checkout of upstream's branch.
+
+If you do want upstream's code checked out instead, use Option B.
+
+**From this clone**, find the current session's ID/title and fork it:
+
+```bash
+cd /Users/stevemorin/c/agent-deck
+
+# Find the current session — look for the one running this Claude Code instance
+agent-deck session list
+
+# Replace <SESSION> with the matching id or title:
+agent-deck session fork <SESSION> \
+    --with-state-and-gitignored \
+    -w review/feat-v1.9.x-1029-fork-carry-wip \
+    -t track-b-analysis \
+    -g experiments
+```
+
+This will:
+- Refuse early if parent is mid-rebase/merge/cherry-pick/revert/bisect (shared preflight from upstream's commit)
+- Create a new branch `review/feat-v1.9.x-1029-fork-carry-wip` from your current HEAD
+- Compute a destination worktree path per your worktree settings (typically a sibling dir; the exact path is logged on success)
+- Materialize parent's staged + unstaged + untracked + gitignored files into the new worktree
+- Run any setup hook
+- Start the forked Claude Code session in the new worktree with the parent's session as resume context
+
+**After the fork succeeds**, switch your terminal to the new worktree, attach to the new session, and paste this short focus prompt (much shorter than the clean-session bootstrap because the new session already has full context):
+
+```
+We just forked this session into a parallel worktree to do a comparative
+analysis of upstream's #1029 implementation vs my spec/plan.
+
+Your task: produce the comparative analysis described in
+docs/superpowers/discussions/2026-05-17-track-b-runbook.md and save it to
+docs/superpowers/discussions/2026-05-18-upstream-comparison.md.
+
+Read upstream's commit 6a1645eb files first (now in upstream/main):
+    git show 6a1645eb -- cmd/agent-deck/session_cmd.go
+    git show 6a1645eb -- internal/git/materialize_wip.go
+    git show 6a1645eb -- internal/git/issue1029_with_state_test.go
+    git show 6a1645eb -- internal/git/issue1029_edge_test.go
+    git show 6a1645eb -- internal/git/setup.go
+
+Then compare against the spec and plan you already know from this
+conversation. Cite file:line for every claim. Don't push or open a PR
+when done; just commit the analysis doc.
+```
+
+### Option B — Clean Claude Code session with full bootstrap prompt (alternative)
+
+Use this if you want upstream's code physically checked out in the worktree (better for IDE-style exploration), or if you don't want to fork the conversation (for a fresh independent context).
+
+This option uses the manual worktree from Section 1.
+
+```bash
+cd /Users/stevemorin/c/agent-deck-1029
+claude    # or however you launch Claude Code locally
+```
+
+### Bootstrap prompt for Option B (paste verbatim into the new session)
+
+```
+I'm starting a new Claude Code session in this worktree to do a comparative analysis.
+
+CONTEXT:
+- This worktree is /Users/stevemorin/c/agent-deck-1029, checked out to branch
+  review/feat-v1.9.x-1029-fork-carry-wip, which is based on upstream's branch
+  feat/v1.9.x-1029-fork-carry-wip (commit 02b6e5c4, now merged to upstream/main
+  as 6a1645eb in PR #1030 by @asheshgoplani).
+- Ashesh has implemented Issue #1029 (fork session with WIP state) with these files:
+    cmd/agent-deck/session_cmd.go             |  16 +-
+    internal/git/issue1029_edge_test.go       | 233 +
+    internal/git/issue1029_with_state_test.go | 133 +
+    internal/git/materialize_wip.go           | 224 +
+    internal/git/setup.go                     |  26 +
+- I (Steve, the issue author) independently designed and planned this feature
+  in much more detail in a sibling clone at /Users/stevemorin/c/agent-deck,
+  on branch feature/fork-worktree-with-state. My design lives at:
+    ../agent-deck/docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md
+    ../agent-deck/docs/superpowers/plans/2026-05-14-fork-worktree-with-state.md
+    ../agent-deck/docs/superpowers/discussions/2026-05-17-item-4-collision-check.html
+
+YOUR TASK:
+Produce a comprehensive comparative analysis between Ashesh's implementation
+(on this branch) and my design (in ../agent-deck/docs/superpowers/). Save it to:
+    docs/superpowers/discussions/2026-05-18-upstream-comparison.md
+
+The analysis should cover, with file:line citations:
+1. What Ashesh's commit implements correctly that matches my spec
+2. What Ashesh's commit implements differently from my spec (and which is better)
+3. What my spec specifies that Ashesh's commit does NOT implement (the gaps)
+4. What Ashesh's commit covers that my spec did NOT anticipate
+5. Risk assessment per gap: which gaps are correctness bugs vs nice-to-haves
+6. Recommended path forward (specific follow-up PR scope, or fold-in suggestions)
+
+Focus areas (from my prior review):
+- TUI integration (Ashesh's commit appears to only touch cmd/, not internal/ui/)
+- Parent-HEAD start point for linked parent worktrees (my design's FWS-002)
+- Shared CLI/TUI validators (PreflightForkWithState, ValidateForkWithStateDestination)
+- createdBranch proof for cleanup (FWS-003)
+- Test coverage breadth: parent-untouched invariant, bare-repo, setup-hook
+  ordering, CLI contract via before-start hook, behavioral eval
+
+GROUND RULES:
+- Read ALL of Ashesh's files in full before drawing conclusions:
+    cmd/agent-deck/session_cmd.go (focus on the diff vs upstream/main~1)
+    internal/git/materialize_wip.go
+    internal/git/issue1029_with_state_test.go
+    internal/git/issue1029_edge_test.go
+    internal/git/setup.go (diff vs upstream/main~1)
+- Be specific: cite file:line for every claim.
+- Don't write production code in this session — analysis only. Implementation
+  happens in a follow-up PR.
+- When the analysis doc is ready, commit it on review/feat-v1.9.x-1029-fork-carry-wip
+  and STOP. Do not push, do not open a PR.
+- The conclusion section of the analysis should be paste-ready for a GitHub
+  comment on Issue #1029 (collaborative tone, not adversarial).
+
+Start by:
+1. Listing the files you'll read
+2. Reading them
+3. Reading my spec and plan from ../agent-deck/docs/superpowers/
+4. Producing the analysis doc
+
+The output document at docs/superpowers/discussions/2026-05-18-upstream-comparison.md
+will be referenced from a GitHub comment posted by me (smorin) after you're
+done.
+```
+
+The Option B session has no memory of this conversation — the bootstrap is self-contained.
+
+### Which to pick
+
+| Use case | Pick |
+|---|---|
+| You want the new session to "feel like" the same conversation continuing in a parallel place | **Option A** |
+| Per-developer files (`CLAUDE.local.md`, `AGENTS.md`, `.env`) should auto-carry over | **Option A** (the gitignored flag handles it) |
+| You want upstream's branch physically checked out in the worktree | **Option B** |
+| You want a clean independent context (e.g., the new session shouldn't be biased by prior reasoning) | **Option B** |
+| You want to dogfood the merged feature on a real workflow | **Option A** |
+
+---
+
+## Section 3 — GitHub coordination (Track C)
+
+**Run from any worktree once `gh` rate limit resets** (`gh api rate_limit --jq .resources.core` to check).
+
+### 3a. Verify state of upstream issue / PR
+
+```bash
+gh issue view 1029 --comments
+gh pr list --repo asheshgoplani/agent-deck --search "head:feat/v1.9.x-1029-fork-carry-wip" --state all
+```
+
+Note any PR number for cross-posting.
+
+### 3b. Wait for Track B's analysis to land
+
+Comment timing decision: post **after** Track B completes its `docs/superpowers/discussions/2026-05-18-upstream-comparison.md`. Don't post sooner.
+
+### 3c. Post the comment
+
+Template (edit before posting):
+
+```markdown
+Hi @asheshgoplani — thanks for the quick turnaround on #1029!
+
+I had been working in parallel on a more detailed design and plan for this feature in my fork. Now that your implementation is on `feat/v1.9.x-1029-fork-carry-wip`, I ran a comparative analysis and wanted to share what I found.
+
+**Common ground (great work):**
+- Flag names match exactly: `--with-state`, `--with-state-and-gitignored`
+- Diff-based approach with parent-read-only
+- Refuses mid-rebase/merge/cherry-pick/bisect (you also added revert — nice catch)
+- Materialize before setup hook
+- Binary + symlink handling
+
+**Gaps I identified (need confirmation whether intended or follow-up scope):**
+- TUI integration — your commit appears to only touch `cmd/`, no changes under `internal/ui/`. My design has matching `ForkDialog` sub-checkboxes (`y` for with-state, `i` for gitignored) with nested-state invariants and a target-based focus order.
+- Parent-HEAD start point — when the parent session lives in a linked worktree whose HEAD differs from the main/base worktree, the fork should start from the parent's HEAD, not the invocation repo's HEAD. My design adds `git.CreateWorktreeAtStartPoint` for this.
+- Shared CLI validators — my design extracts `PreflightForkWithState` and `ValidateForkWithStateDestination` so CLI and TUI can't drift.
+- `createdBranch` proof for cleanup — so future refactors of the early-gate code can't accidentally `git branch -D` a pre-existing branch.
+- Test coverage: parent-untouched invariant, mid-rebase refusal with destination-absence assertion, bare-repo-layout with linked parent worktree, setup-hook ordering with parent-WIP-aware script, CLI contract tests via a before-start hook, behavioral eval smoke for the visible TUI flow.
+
+Full design and plan are in my fork:
+- Spec: `docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md`
+- Plan: `docs/superpowers/plans/2026-05-14-fork-worktree-with-state.md`
+- Item-4 decision exploration: `docs/superpowers/discussions/2026-05-17-item-4-collision-check.html`
+- **Comparative gap analysis (this is the detailed one):** `docs/superpowers/discussions/2026-05-18-upstream-comparison.md`
+
+How would you like to proceed? Options I see:
+1. Land your PR as-is; I open follow-up PRs for the gaps (smallest blast radius for your merge)
+2. I rebase my work onto your branch and submit a combined PR
+3. You pick the top N gaps you want folded in before merge and I push fixes to your branch
+
+Happy to do any of these. Let me know which fits best.
+```
+
+Cross-post the same comment to the upstream PR (if one exists).
+
+---
+
+## Section 4 — What to do in the original session (Track A)
+
+While Track B's session runs:
+
+- Do not push `feature/fork-worktree-with-state`. Hold for upstream coordination.
+- Wait for Track B to finish.
+- When Track B's analysis doc is ready, copy it back into Track A's clone (or just reference it via the shared `.git` — the branch is in the same repo, just check out the file from the analysis branch).
+- Use Track A's session to draft and refine the GitHub comment using Track B's findings.
+
+**Status update (2026-05-18):** Track B's analysis landed as [`2026-05-18-post-merge-gap-analysis.md`](2026-05-18-post-merge-gap-analysis.md) (committed to the feature branch). Upstream PR #1030 has since been merged at commit `6a1645eb`. The next move is now: execute the followup plan at [`../plans/2026-05-18-fork-with-state-followup.md`](../plans/2026-05-18-fork-with-state-followup.md), which scopes the gaps into PR-A (correctness + CLI tests) and PR-B (TUI). The active spec is [`../specs/2026-05-18-fork-with-state-followup-design.md`](../specs/2026-05-18-fork-with-state-followup-design.md). The GitHub comment template in Section 3 of this runbook stays valid; post it after PR-A is ready to push.
+
+---
+
+## Recovery scenarios
+
+| What if | Recovery |
+|---|---|
+| Track B's worktree gets corrupted | `git worktree remove /Users/stevemorin/c/agent-deck-1029 --force` from Track A, then re-run Section 1 |
+| Track A's branch needs updating | Track A and Track B's branches are independent; no cross-impact |
+| Upstream merges their PR while Track B is running | Track B's analysis is still valuable; the recommendation section pivots from "fold-in" to "follow-up PR scope" |
+| `claude` in the new session loses context | Re-paste the bootstrap prompt; the prompt is self-contained |
+
+## Cleanup when Track B is done
+
+After the GitHub comment lands and the analysis is shared:
+
+```bash
+# Optionally remove the parallel worktree (preserves the branch in .git):
+cd /Users/stevemorin/c/agent-deck
+git worktree remove ../agent-deck-1029
+# The review/feat-v1.9.x-1029-fork-carry-wip branch still exists; can be pushed
+# to origin later if needed for collaborator visibility.
+```

--- a/docs/superpowers/discussions/2026-05-18-followup-meta-plan.md
+++ b/docs/superpowers/discussions/2026-05-18-followup-meta-plan.md
@@ -1,0 +1,163 @@
+# Fork-with-State Followup Meta-Plan
+
+**Date:** 2026-05-18
+**Branch:** `feature/fork-worktree-with-state`
+**Status:** Complete (2026-05-18)
+**Purpose:** Plan the creation of a new followup spec + plan (replacing the deprecated ground-up spec + plan) that scopes the work to close 11 gaps identified after upstream merged #1029 (PR #1030, commit `6a1645eb`).
+
+This document is meta — it's the runbook for creating the followup plan files, not the plan files themselves.
+
+## Background
+
+- Original spec: `docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md` (449 lines, written before #1030 merged)
+- Original plan: `docs/superpowers/plans/2026-05-14-fork-worktree-with-state.md` (~3700 lines, from-scratch implementation)
+- Gap analysis: `docs/superpowers/discussions/2026-05-18-post-merge-gap-analysis.md` (identified 11 gaps after the merge)
+- Decision: keep originals as deprecated/archived (banner only, no moves); create new followup spec + plan that build ON TOP of upstream's merged implementation.
+
+## Gap → PR mapping (locked contract)
+
+| Gap | PR | Why |
+|---|---|---|
+| 2. Parent-HEAD start point | **PR-A** | Correctness for linked-worktree parents |
+| 3. Destination collision validation | **PR-A** | Correctness/UX for existing-branch case |
+| 4. Cleanup-on-error (CLI) | **PR-A** | CLI surface |
+| 4. Cleanup-on-error (TUI) | **PR-B** | TUI surface |
+| 5. Parent-untouched invariant test | **PR-A** | Tests materialization contract PR-A relies on |
+| 6. Bare-repo + linked parent worktree test | **PR-A** | Tests parent-HEAD path (gap 2) |
+| 7. Setup-hook observation test | **PR-A** | Tests orchestration ordering |
+| 8. 4 missing mid-op refusal tests | **PR-A** | General hardening |
+| 9. CLI before-start hook contract test | **PR-A** | Verifies option propagation |
+| 10. Behavioral eval smoke (CLI) | **PR-A** | CLAUDE.md eval mandate (CLI) |
+| 1. TUI integration | **PR-B** | TUI surface |
+| 10. Behavioral eval smoke (TUI) | **PR-B** | CLAUDE.md eval mandate (TUI) |
+| 11. Shared `PreflightForkWithState` extraction | **Deferred PR-C** | RFC-required; refactors upstream's just-merged code |
+
+## Locked decisions
+
+| Decision | Value |
+|---|---|
+| New spec filename | `docs/superpowers/specs/2026-05-18-fork-with-state-followup-design.md` |
+| New plan filename | `docs/superpowers/plans/2026-05-18-fork-with-state-followup.md` |
+| Old-file deprecation | Banner at top, no file moves |
+| Test scope | All 11 gaps mapped (functional + test coverage) |
+| PR shape | 2 PRs: PR-A (correctness + tests, CLI) + PR-B (TUI) |
+| `ValidateForkWithStateDestination` scope | Shared `internal/git` helper added in PR-A; used by both surfaces |
+| Validator file location | New `internal/git/fork_with_state_destination.go` (avoids touching upstream's just-merged `materialize_wip.go`) |
+| Gap 11 documentation | One-paragraph "Out of scope (deferred)" mention pointing at future PR-C |
+| Output of this meta-plan | One commit on `feature/fork-worktree-with-state`, no push yet |
+
+## Execution checklist
+
+Update each checkbox as the corresponding work completes. Parallel TaskTool entries (tasks #21-#25) track the same items in the harness's task system.
+
+### Step 1 — Add deprecation banners to old files
+
+- [x] **Step 1 complete** (both banners applied)
+  - [x] `docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md` — banner added at line 1
+  - [x] `docs/superpowers/plans/2026-05-14-fork-worktree-with-state.md` — banner added at line 1
+
+Banner content (identical, with file-specific link):
+
+```markdown
+> **⚠ DEPRECATED — superseded by [`<followup-file>`](<relative-path>)**
+>
+> This document was written as a ground-up design before upstream merged #1029
+> (commit 6a1645eb). It remains as historical reference for the design
+> reasoning, decision log, and FWS-001 through FWS-018 entries. The active
+> design and plan are now in the followup files. See also the post-merge gap
+> analysis at [`2026-05-18-post-merge-gap-analysis.md`](../discussions/2026-05-18-post-merge-gap-analysis.md).
+```
+
+### Step 2 — Draft the followup spec
+
+- [x] **Step 2 complete** (new spec file created)
+  - [x] `docs/superpowers/specs/2026-05-18-fork-with-state-followup-design.md` written
+
+Sections in the new spec:
+- Status / date / author / related code
+- Premise (upstream's merged state)
+- Goal (close 4 functional gaps + 7 test-coverage gaps; layer on top, don't replace)
+- Non-goals (no upstream API refactor; no replacement of `MaterializeWipFromParent`)
+- What upstream merged (short summary)
+- Functional gaps to close (4) — each with PR target
+- Test-coverage hardening (7) — each with PR target
+- New code surfaces (file map summary)
+- Mandate (Option B housing, single tracked section)
+- References (original spec, original plan, gap analysis, runbook, upstream commit/PR)
+- Out of scope (deferred PR-C for shared preflight helpers)
+- Review change log (starts fresh; first entry "FUS-001 spec drafted as followup")
+
+### Step 3 — Draft the followup plan
+
+- [x] **Step 3 complete** (new plan file created)
+  - [x] `docs/superpowers/plans/2026-05-18-fork-with-state-followup.md` written
+
+Top-level structure:
+- Standard header (goal, architecture, tech stack, spec pointer, pre-flight)
+- File map (~10 entries, labeled PR-A / PR-B)
+- **PR-A tasks** (Tasks 1-10):
+  - T1: `HeadCommit` + `CreateWorktreeAtStartPoint` helpers (gap 2)
+  - T2: `ValidateForkWithStateDestination` + `DestinationCollisionError` (gap 3, shared `internal/git`)
+  - T3: Wire parent-HEAD + collision check + cleanup into `handleSessionFork` (gaps 2, 3, 4-CLI)
+  - T4: CLI before-start hook + contract tests (gaps 8, 9)
+  - T5: Parent-untouched invariant test (gap 5)
+  - T6: Bare-repo + linked parent worktree test (gap 6)
+  - T7: Setup-hook observation test (gap 7)
+  - T8: CLI behavioral eval (gap 10-CLI)
+  - T9: Verification (`make fmt`/`lint`/`test` + mandate suite)
+  - T10: PR-A push + open
+- **PR-B tasks** (Tasks 11-17):
+  - T11: `ForkDialog` sub-checkbox state + getters (gap 1)
+  - T12: `ForkDialog` focus-target refactor (gap 1)
+  - T13: `ForkDialog` rendering + key handlers + tests (gap 1)
+  - T14: TUI submit handler wires through `CreateWorktreeWithStateAndSetup` + collision check + cleanup (gaps 1, 3-TUI, 4-TUI)
+  - T15: TUI behavioral eval (gap 10-TUI)
+  - T16: Verification
+  - T17: PR-B push + open (depends on PR-A merge)
+- Spec coverage check table mapping every gap to its task(s)
+- Out of scope: gap 11 (deferred PR-C with RFC)
+
+### Step 4 — Cross-link
+
+- [x] **Step 4 complete** (both cross-links applied)
+  - [x] `docs/superpowers/discussions/2026-05-18-post-merge-gap-analysis.md` — "Now planned in" pointer added near the top
+  - [x] `docs/superpowers/discussions/2026-05-17-track-b-runbook.md` — Section 4 updated with status note pointing at followup plan
+
+### Step 5 — Commit
+
+- [x] **Step 5 complete** (single commit landed on `feature/fork-worktree-with-state`)
+
+Commit covers:
+- Deprecation banners (Step 1)
+- Followup spec (Step 2)
+- Followup plan (Step 3)
+- Cross-links (Step 4)
+- This meta-plan doc itself
+
+Commit message template:
+
+```
+docs: followup spec + plan for closing post-#1030 functional and test-coverage gaps
+
+- Deprecate the original spec + plan (banners, left in place for history)
+- Add followup spec scoped to deltas on top of upstream/main 6a1645eb
+- Add followup plan with PR-A (correctness + test hardening, CLI) and
+  PR-B (TUI) task lists
+- Cross-link the gap analysis and runbook to the new files
+- Gap 11 (shared preflight helpers) explicitly deferred to PR-C with RFC
+
+This makes the next move: execute the followup plan to produce PR-A then PR-B.
+```
+
+## After this meta-plan executes
+
+Branch state will be 7 commits ahead of upstream/main. The next decision is:
+- Squash + push to `origin` and start PR-A code work?
+- Or iterate on the followup plan first?
+
+## Explicitly NOT doing in this meta-plan
+
+- Writing PR-A or PR-B code (the followup plan drives that)
+- Touching upstream's `MaterializeWipFromParent` or `CreateWorktreeWithStateAndSetup`
+- Implementing the shared preflight helpers (gap 11, deferred PR-C)
+- Posting the GitHub comment on Issue #1029 (still pending per runbook timing)

--- a/docs/superpowers/discussions/2026-05-18-post-merge-gap-analysis.md
+++ b/docs/superpowers/discussions/2026-05-18-post-merge-gap-analysis.md
@@ -1,0 +1,178 @@
+# Post-Merge Gap Analysis vs Our Spec
+
+**Date:** 2026-05-18
+**Compared:** upstream/main commit `6a1645eb` (PR #1030, closes #1029) ↔ `docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md` (now deprecated)
+**Author:** Track A session (post-FWS-017 + FWS-018)
+**Now planned in:** [`../plans/2026-05-18-fork-with-state-followup.md`](../plans/2026-05-18-fork-with-state-followup.md) — the 11 gaps are mapped to PR-A (correctness + CLI test hardening) and PR-B (TUI integration). Active spec is [`../specs/2026-05-18-fork-with-state-followup-design.md`](../specs/2026-05-18-fork-with-state-followup-design.md).
+
+## Sanity check first
+
+- Track B analyzed snapshot `02b6e5c4`.
+- Upstream merged version is `6a1645eb`.
+- `git diff --stat 02b6e5c4 6a1645eb` → empty. Trees are identical.
+- Track B's FWS-017 findings are still 100% accurate against the merged state.
+- Two post-merge commits touch `internal/ui/home.go` (#1034 emacs nav, #1035 reorder keys) but neither touches the fork submit handler or `forkdialog.go`. Implementation-time line-number drift only.
+
+All four FWS-017 corrections are present in upstream:
+1. ✓ `revert` in refusal list (`REVERT_HEAD` check)
+2. ✓ NUL-safe listing (`runListZ` with `-z`)
+3. ✓ Two-pass union for gitignored (non-ignored + ignored)
+4. ✓ Materialize before ProcessWorktreeInclude before setup hook
+
+## What upstream merged (architecture)
+
+### Files added
+- `internal/git/materialize_wip.go` (224 lines, single file)
+- `internal/git/issue1029_edge_test.go` (233 lines)
+- `internal/git/issue1029_with_state_test.go` (133 lines)
+
+### Files modified
+- `internal/git/setup.go` (+26 lines): adds `WorktreeStateOptions` struct + `CreateWorktreeWithStateAndSetup` wrapper; `CreateWorktreeWithSetup` becomes a thin pass-through.
+- `cmd/agent-deck/session_cmd.go` (+16 lines): two flags, validation, wires to new wrapper.
+
+### Public API
+```go
+// internal/git/materialize_wip.go
+func MaterializeWipFromParent(parentDir, childDir string, includeIgnored bool) error
+
+// internal/git/setup.go
+type WorktreeStateOptions struct {
+    WithState   bool
+    WithIgnored bool
+}
+func CreateWorktreeWithStateAndSetup(
+    repoDir, worktreePath, branchName string,
+    state WorktreeStateOptions,
+    stdout, stderr io.Writer, setupTimeout time.Duration,
+) (setupErr, err error)
+
+// Original signature preserved as thin wrapper:
+func CreateWorktreeWithSetup(...) // calls CreateWorktreeWithStateAndSetup with empty state
+```
+
+### Architectural pattern
+Upstream uses a **wrapper-and-recompose** pattern: `CreateWorktreeWithStateAndSetup` orchestrates Create → Materialize → ProcessWorktreeInclude → Setup all inside one helper. Caller (CLI) just calls the wrapper with options.
+
+Our spec uses a **split-and-recompose** pattern: `CreateWorktree` + `RunWorktreeSetup` exposed separately so callers can interleave materialization between them. Each surface (CLI, TUI) does its own orchestration.
+
+Both are valid. Upstream's is simpler caller code; ours allows surface-specific variation (which we use for TUI's different error handling). Going forward, the right move is to **adopt upstream's wrapper pattern as the base** and add our extras on top (typed errors, parent-HEAD start point, destination validator, TUI integration).
+
+### Internal helpers (not exported)
+- `refuseUnsafeParentState(parentDir)` — preflight, returns plain `error` formatted with parent kind. Not typed; no shared CLI/TUI use.
+- `gitDirOf(dir)`
+- `applyDiffFromParent(parentDir, childDir, cached bool)` — uses `git apply --index` (not `--cached`)
+- `copyUntrackedFromParent(parentDir, childDir, includeIgnored bool)` — two-pass for gitignored
+- `runListZ(args...)` — NUL-safe ls-files
+- `copyEachFile`, `copyOneFile` — symlink-aware, mode-preserving
+
+### Tests in upstream
+Per the merged commit message:
+1. canonical staged+unstaged+untracked
+2. empty WIP (no-op)
+3. binary file
+4. symlink
+5. ignored opt-in
+6. mid-merge refusal
+7. deleted-in-parent tracked file
+8. `CreateWorktreeWithStateAndSetup` wiring
+
+## Gap table (severity-sorted)
+
+| # | Gap | Severity | Status in upstream | Effort to fix |
+|---|---|---|---|---|
+| **1** | **TUI integration** — no `ForkDialog` sub-checkboxes, no `internal/ui/` changes | High — user-facing parity | Missing | Medium (Tasks 15, 15A, 16, 17, 17A) |
+| **2** | **Parent-HEAD start point for linked parent worktrees** — upstream uses `CreateWorktree(repoDir, ...)`, which creates from invocation dir's HEAD, not the parent session's HEAD. When parent is in a linked worktree whose HEAD differs from main, fork starts from wrong commit and materialization produces wrong-base diffs | High — silent correctness bug for linked-worktree parents | Missing | Small (Task 4A — new `HeadCommit` + `CreateWorktreeAtStartPoint`) |
+| **3** | **Destination collision validation** — upstream has no check before materialization. If `-w <existing-branch>` is passed with `--with-state`, behavior is undefined: either git refuses worktree add (if branch already has a worktree elsewhere) or silently creates a new worktree on the existing branch, then materializes on top. No "branch already has a worktree at X" error. No "branch already exists" error | High — silent reuse / cryptic error | Missing | Small (Task 4C — new `ValidateForkWithStateDestination`) |
+| **4** | **Cleanup-on-error** — if `MaterializeWipFromParent` fails, upstream leaves the partially-created worktree on disk. The user must manually `git worktree remove` and `git branch -D` to recover | Medium — leaves orphaned state | Missing | Small (a `defer` cleanup block in the CLI handler or wrapper) |
+| **5** | **Parent-untouched invariant test** — no test asserts that parent's `git status --porcelain`, index, and stash list are byte-identical after materialize | Medium — would catch regressions to parent-read-only contract | Missing | Small (one test) |
+| **6** | **Bare-repo + linked parent worktree test** — covers the layout where the project root is `.bare/` and the parent session is in a linked worktree | Medium — common agent-deck layout | Missing | Small (one test) |
+| **7** | **Setup-hook ordering test with parent-WIP observation** — upstream has a "wiring" test but it doesn't explicitly assert the setup hook OBSERVES the materialized WIP (e.g., by writing a fingerprint of a parent's WIP file into a marker) | Medium — ordering contract | Wiring test exists; observation not verified | Small (one test, refine existing) |
+| **8** | **Mid-op refusal tests for all five kinds** — upstream tests only mid-merge refusal. Mid-rebase, mid-cherry-pick, mid-revert, mid-bisect refusals are implemented but not regression-tested | Low | Partially tested (1 of 5) | Trivial (4 tests) |
+| **9** | **CLI contract test via before-start hook** — upstream has no test that runs the actual CLI command path with a hook to inspect option propagation (e.g., that `ClaudeOptions.WithState` is true before `Start()`) | Low | Missing | Small (Task 12A) |
+| **10** | **Behavioral eval smoke (CLI + TUI)** — no eval-tagged tests for the user-visible CLI fork or the TUI ForkDialog visible interaction | Medium — CLAUDE.md eval-harness mandate class | Missing | Small (Task 17A: 2 eval tests) |
+| **11** | **Shared `PreflightForkWithState` typed-error helper** — upstream's `refuseUnsafeParentState` is internal, lowercase, returns formatted `error`. CLI and TUI can't share it as a separate preflight gate with typed `InProgressOperationError` | Medium — prevents CLI/TUI drift; lets surfaces customize error rendering | Equivalent inline behavior exists; not extracted/shared | Medium (Task 4B, RFC-required structural change per our spec) |
+
+## Things upstream has that our spec did NOT anticipate
+
+| What | Worth absorbing into our spec? |
+|---|---|
+| `CreateWorktreeWithStateAndSetup` wrapper pattern (vs our split pattern) | Yes — adopt as the base for our follow-up, simplifies caller code |
+| `WorktreeStateOptions{WithState, WithIgnored}` options struct | Yes — cleaner than passing two booleans |
+| Internal `applyDiffFromParent` factoring (passes cached as a bool parameter, single function for both staged + unstaged) | Yes — simpler than our spec's two-step inline approach |
+| `gitDirOf` helper (vs our `resolveGitDir`) | Equivalent; pick one name |
+| `copyEachFile` / `copyOneFile` split | Yes — readable |
+
+## Implications for our plan
+
+Our plan was written assuming a from-scratch implementation. With upstream's PR merged, large chunks of the plan are now either **duplicate** or **rebase-target** rather than **net-new work**.
+
+### Tasks that mostly duplicate upstream
+- **Task 5-11** (MaterializeParentState + all scenarios) — upstream's `MaterializeWipFromParent` covers most of this. Repurpose these as test-additions (parent-untouched invariant, partial-staged-with-deletion, etc.) rather than implementation.
+- **Task 2, 3** (DetectInProgressOperation, HasSubmodules) — upstream has equivalent inline `refuseUnsafeParentState`. Our extraction is part of the FWS-009 shared-preflight goal (still valuable but RFC-gated per our spec).
+- **Task 4** (split `CreateWorktreeWithSetup`) — superseded by upstream's `CreateWorktreeWithStateAndSetup` wrapper. Our split would be a structural change requiring an RFC per upstream's design.
+
+### Tasks that remain net-new work (real follow-up scope)
+- **Task 4A** (parent-HEAD start point) — fixes gap 2. **High priority.**
+- **Task 4C** (destination collision validator) — fixes gap 3. **High priority.**
+- **Task 12A, 13 partial** (CLI before-start hook, refusal-message refinement) — fixes gap 9.
+- **Tasks 14 partial** (parent-untouched, bare-repo, setup-hook-observation) — fixes gaps 5, 6, 7.
+- **Tasks 15, 15A, 16, 17** (TUI integration) — fixes gap 1. **High priority.**
+- **Task 17A** (behavioral eval smoke) — fixes gap 10.
+
+### Tasks that need re-anchoring to upstream's API
+- **Task 13** (CLI wiring) — already done by upstream's commit. Our follow-up changes the CLI handler to add cleanup-on-error, the parent-HEAD start point, the destination validator call. ~10-20 lines, not the 150+ in our current Task 13.
+- **Task 17** (TUI submit handler) — wraps upstream's `CreateWorktreeWithStateAndSetup` instead of orchestrating Create/Materialize/Setup ourselves.
+
+## Recommended follow-up PR shape
+
+Three small PRs, in priority order:
+
+### PR-A: Correctness fixes (gaps 1, 2, 3, 4)
+- TUI integration (gap 1)
+- Parent-HEAD start point via `CreateWorktreeAtStartPoint` (gap 2)
+- Destination collision validation via `ValidateForkWithStateDestination` (gap 3)
+- Cleanup-on-error guard in the CLI handler and TUI submit (gap 4)
+- Wraps upstream's `CreateWorktreeWithStateAndSetup`; does not replace it
+
+Estimated size: ~600 lines of code (mostly TUI), ~12 tests.
+
+### PR-B: Test coverage (gaps 5, 6, 7, 8, 9, 10)
+- Parent-untouched invariant
+- Bare-repo + linked parent worktree
+- Setup-hook observation
+- All four missing mid-op refusal tests (rebase, cherry-pick, revert, bisect)
+- CLI before-start hook
+- Behavioral eval smoke (CLI + TUI)
+
+Estimated size: ~300 lines of tests + 1 small helper.
+
+### PR-C: Shared preflight helpers (gap 11) — RFC required
+- Extract `PreflightForkWithState` and `ValidateForkWithStateDestination` as public API
+- Add typed `InProgressOperationError` and `DestinationCollisionError`
+- Promote `refuseUnsafeParentState` to `DetectInProgressOperation` + `PreflightForkWithState`
+- Migrate CLI and TUI to use the shared helpers
+- Per our spec's "Structural changes requiring RFC", this needs upstream RFC approval
+
+PR-C is the most invasive — it changes upstream's just-merged internal API. Best discussed via RFC issue first.
+
+## What to do with our current spec/plan
+
+Our spec and plan stay valuable as the **target architecture** (what fork-with-state SHOULD look like long-term). They're not the implementation blueprint anymore. Two paths:
+
+1. **Keep them as-is** and treat them as the architectural reference. PR-A, PR-B, PR-C cite the spec for design rationale. The plan's tasks get reorganized into the three PRs (some dropped, some kept).
+
+2. **Refactor the plan** into PR-shaped task lists. More work upfront but easier execution.
+
+Recommend (1) for now, refactor only if we commit to the PR-A scope.
+
+## Quick action items if user picks PR-A
+
+1. Squash our current 5-commit `feature/fork-worktree-with-state` branch into ONE commit: "design and plan for fork-with-state follow-up work" (a docs-only commit).
+2. Create a new branch off `upstream/main` for PR-A.
+3. Cherry-pick relevant plan tasks (4A, 4C, 12A partial, 13 partial, 14 partial, 15, 15A, 16, 17, 17A) into the new branch — but write the code on top of upstream's `MaterializeWipFromParent` / `CreateWorktreeWithStateAndSetup` rather than the from-scratch versions in the plan.
+4. Push to `origin` (smorin/agent-deck).
+5. Open PR-A against `upstream/main` referencing #1029, #1030, and the spec/plan.
+
+## Note on FWS-017's claims
+
+Our spec's FWS-017 review log entry says the corrections were "folded back from upstream's implementation." That phrasing is accurate. The spec is now consistent with the merged state on those four dimensions (revert, NUL-safe, two-pass ignored, materialize-before-include).

--- a/docs/superpowers/discussions/fork-worktree-with-state-pr-body.md
+++ b/docs/superpowers/discussions/fork-worktree-with-state-pr-body.md
@@ -1,0 +1,241 @@
+# PR-A: fork-with-state hardening — correctness gaps + test coverage on top of #1030
+
+**Related:** closes (partially) #1029, follows up #1030
+**Branch:** `feature/fork-worktree-with-state` → `upstream/main`
+**Spec:** [`docs/superpowers/specs/2026-05-18-fork-with-state-followup-design.md`](../specs/2026-05-18-fork-with-state-followup-design.md)
+**Plan:** [`docs/superpowers/plans/2026-05-18-fork-with-state-followup.md`](../plans/2026-05-18-fork-with-state-followup.md)
+**Manual verification:** [`fork-worktree-with-state-testing.md`](fork-worktree-with-state-testing.md)
+**Post-merge gap analysis:** [`docs/superpowers/discussions/2026-05-18-post-merge-gap-analysis.md`](2026-05-18-post-merge-gap-analysis.md)
+
+## Summary
+
+`agent-deck session fork --with-state` shipped in #1030 but has four user-facing correctness gaps and several missing test guards. This PR (PR-A) closes the CLI-side of those gaps without modifying upstream's `MaterializeWipFromParent` or `CreateWorktreeWithStateAndSetup`. A follow-up (PR-B) will close the TUI side.
+
+The framing below uses **user-feature capability gaps** — what would a real user try, what does the spec promise, what do they actually get today, and where does this PR land. Eight gaps were identified. **PR-A closes 6 fully (CLI surface), 1 partially (gap 5: file half), 1 deferred (gap 4: TUI → PR-B).** The remaining items are listed under "Not in this PR" with their disposition.
+
+---
+
+## Acknowledgement
+
+Big thanks to @asheshgoplani for landing #1030 quickly. The diff-based, parent-read-only approach is exactly right, and `CreateWorktreeWithStateAndSetup` is a clean orchestration shape. This PR adds the hardening that the original issue (#1029) implicitly asked for — its phrasing around "Refuse unsafe parent states with actionable errors," "Existing destination branches/worktrees are refused," and "Fork starts from the parent session's actual `HEAD`" describes correctness contracts that the merge addressed in spirit but not in every corner.
+
+---
+
+## What this PR closes
+
+### Gap 1 — Linked-worktree parents anchored at the wrong commit ✅ closed (CLI)
+
+**User experience pre-PR:** You're in `~/myproject-worktrees/feature-x` with WIP, run `session fork --with-state -w fork/explore`. Spec promised the new worktree forks from `feature-x`'s HEAD. **Actually got:** the new worktree forks from the main repo's HEAD (probably `main`, not `feature-x`) and carries the main worktree's WIP, not yours. The fork looks plausibly successful — no error — but you're now in a parallel agent against the wrong baseline.
+
+**Fix:** New `git.HeadCommit(repoDir)` resolves the parent session's HEAD; new `git.CreateWorktreeAtStartPoint(repoDir, worktreePath, branch, startPoint)` creates the new worktree branched off that explicit start point. The CLI handler captures parent's HEAD and threads it through. `HeadCommit` captures stdout only and includes stderr only on the error path, so ambient Git warnings cannot be prepended to the commit hash. Integration tests pin the linked-worktree contract, and a focused unit regression pins the stdout-only behavior.
+
+**Files:** `internal/git/git.go`, `internal/git/git_test.go`, `internal/git/fork_with_state_integration_test.go`, `cmd/agent-deck/session_cmd.go`.
+
+### Gap 2 — Destination collision is a silent footgun ✅ closed (CLI)
+
+**User experience pre-PR:** Run `--with-state -w fork/explore` after a previous fork with the same name, or against a branch a teammate already has a worktree for. Spec promised a refusal. **Actually got:** a "Reusing existing worktree at …" log line, materialization **doesn't run at all**, and the forked session starts in the pre-existing worktree — sharing disk with whatever was already there. Strictly worse than the silent-shared-worktree footgun this feature was supposed to fix.
+
+**Fix:** New shared helper `git.ValidateForkWithStateDestination(repoRoot, branch)` returns a typed `*DestinationCollisionError` with exported `Kind` constants (`CollisionWorktreeExists` / `CollisionBranchExists`). The CLI handler calls it immediately after branch-prefix resolution, before the legacy branch-existence gate, existing-worktree reuse, or destination-directory creation. In `--with-state` mode, `-w` is the fresh destination branch and `-b` is not required; existing branches/worktrees are always refused rather than reused. Refusal messages include the conflicting path so the user can `cd` to it. A precedence test pins that worktree-existence wins over branch-existence when both conditions are true, and eval coverage drives both the no-`-b` happy path and the existing-worktree refusal through the real binary.
+
+**Files:** `internal/git/fork_with_state_destination.go` (new), `internal/git/fork_with_state_destination_test.go` (new), `cmd/agent-deck/session_cmd.go`.
+
+### Gap 3 — Failed forks leave junk on disk ✅ closed (CLI)
+
+**User experience pre-PR:** Materialization fails mid-flight (mid-rebase parent, weird patch, etc.). Spec promised: "fork either happens or it doesn't" — partially-created worktree removed, branch deleted. **Actually got:** the new worktree directory and the new branch are left orphaned. You have to `git worktree remove --force` and `git branch -D` by hand. And if you don't notice, you've set yourself up to trip over gap 2 on the next try.
+
+**Fix:** The CLI handler now wraps the `MaterializeWipFromParent` call. On error: `git worktree remove --force <path>`, then `git branch -D <branch>` only if `CreateWorktreeAtStartPoint` returned `createdBranch=true` (proof-based cleanup — never deletes a pre-existing branch). The error message gets `; new worktree cleaned up` appended so the user knows the state.
+
+**Files:** `cmd/agent-deck/session_cmd.go`.
+
+### Gap 5 (file half) ✅ closed; conversation half NOT verified by this PR
+
+**User experience pre-PR:** No automated test pins that a real `agent-deck session fork --with-state` against a real binary produces the right files on disk. The spec carved out a `TestEval_SessionForkWithState_CreatesMaterializedWorktree` eval that was never written.
+
+**Fix (file half):** New `tests/eval/session/fork_with_state_test.go` (`//go:build eval_smoke`) drives the compiled `agent-deck` binary against a scratch HOME with a real git repo. Seeds staged + unstaged + untracked + gitignored WIP, runs `agent-deck session fork --with-state-and-gitignored -w fork/eval-state`, and asserts:
+- Parent's `git status --porcelain` is byte-identical before/after (read-only invariant)
+- Destination is on the requested branch
+- Destination's porcelain mirrors parent's
+- Gitignored file is present at destination (the `-and-gitignored` discriminator)
+
+**What's still NOT verified:** the conversation-continuity half — that `claude --resume <parent-id> --fork-session` actually composes with the materialization to produce a parallel agent that knows the parent's history. The eval test stubs `claude` out, so the Claude session flow is structurally exercised (`Start()` is called, options propagated) but not end-to-end. See "Not in this PR" below.
+
+**Files:** `tests/eval/session/fork_with_state_test.go` (new).
+
+### Gap 6 ✅ closed (both destination collision and mid-op portions)
+
+**User experience pre-PR:** Refusal messages aren't actionable. For destination collision, you get git's native refusal passed through. For mid-rebase, you get "parent is in mid-rebase; resolve it before forking with --with-state" — no copy-pasteable `cd && git rebase --abort` hint.
+
+**Fix (destination collision):** `DestinationCollisionError` formatting in the CLI handler now produces the spec's wording verbatim:
+- `branch 'fork/X' already has a worktree at <path>; choose a new destination branch for --with-state`
+- `branch 'fork/X' already exists; choose a new destination branch for --with-state`
+
+**Fix (mid-op refusal):** New exported `git.DetectInProgressOperation(repoDir)` helper mirrors upstream's internal `refuseUnsafeParentState` check table. The CLI handler calls it BEFORE worktree creation, so mid-op refusals happen without first creating a worktree. The actionable message now includes the parent path and the right abort command per kind:
+- `parent session is mid-rebase; finish or abort the rebase before forking with state (cd <parent-path> && git rebase --abort)`
+- ... and equivalents for `merge`, `cherry-pick`, `revert`, `bisect`.
+
+A structural-guard test pins the new flow so future refactors can't silently drop a kind. Upstream's `refuseUnsafeParentState` remains as a backstop.
+
+**Files:** `internal/git/fork_with_state_destination.go` (+ `_test.go`), `cmd/agent-deck/session_cmd.go`, `cmd/agent-deck/session_cmd_fork_state_test.go`, `tests/eval/session/fork_with_state_test.go`.
+
+### Gap 7 — Submodule warning ✅ closed
+
+**User experience pre-PR:** Repo with `.gitmodules` forks silently. Submodule directory contents get copied as plain files (the materialization contract), but you get no signal that the submodule's internal `.git` state isn't recursed. If you then run something inside the fork that touches the submodule, you'll discover the lossy copy at the worst moment.
+
+**Fix:** New exported `git.HasSubmodules(repoDir)` helper checks for a regular `.gitmodules` file. CLI handler emits the spec-promised stderr warning before doing any fork work:
+
+> `Warning: submodules detected — copied as files, not recursed (parent's submodule states preserved)`
+
+PR-B (TUI) will reuse the same helper for the TUI submit path. Pinned by an eval test (`TestEval_SessionForkWithState_SubmoduleWarning`) that drives the real binary against a `.gitmodules`-bearing repo.
+
+**Files:** `internal/git/fork_with_state_destination.go` (+ `_test.go`), `cmd/agent-deck/session_cmd.go`, `tests/eval/session/fork_with_state_test.go`.
+
+### Gap 8 — Setup hook ordering is now protected ✅ closed
+
+**User experience pre-PR:** Setup hook fires after materialize today (good), but no test pinned this. A future refactor swapping the order would silently regress; the only signal would be "my new dependency from parent's WIP isn't installed in the fork."
+
+**Fix:** New `TestForkWithState_SetupHookObservesMaterializedState` installs a setup script that reads parent's WIP file and writes a fingerprint to a marker outside the worktree. Asserts the marker contains the materialized content. Mutation-tested by the implementer (swapping the order in production code correctly flips the test to `NO_WIP_OBSERVED`).
+
+**Files:** `internal/git/fork_with_state_integration_test.go` (extended with the new test).
+
+---
+
+## Other test coverage added
+
+Beyond the user-feature gaps above, this PR adds five test-coverage gaps from the gap analysis:
+
+- **`TestMaterializeWipFromParent_ParentUntouched`** — asserts parent's `git status`, both diffs, stash list, and raw `.git/index` bytes are identical after materialization. Catches future regressions where someone changes materialization to use `git stash`, `git add`, `git update-index`, or other parent-mutating operations.
+- **Four mid-op refusal regressions** — upstream only tested mid-merge. Added `_Rebase`, `_CherryPick`, `_Revert`, `_Bisect` mirroring the same pattern; these will fail if any of the five `refuseUnsafeParentState` sentinels stops being checked.
+- **CLI contract tests** via a new `sessionForkBeforeStartHook` test seam — verifies explicit-destination refusal, both collision error messages, and that the resolved `git.WorktreeStateOptions` + `MaterializeWipFromParent(..., *withStateGitignored)` wiring fires in the right order before `forkedInst.Start()`. The real-binary eval suite also covers the contracts source-grep tests previously missed: `--with-state -w <fresh-branch>` does not require `-b`, existing branches are refused, and existing worktrees are refused before session start.
+- **`TestForkWithState_BareRepoLayoutLinkedParentWorktree`** — the bare-repo + linked-parent layout integration test (also pins gap 1).
+- **`TestForkWithState_SetupHookObservesMaterializedState`** — the setup-hook ordering test (gap 8).
+
+---
+
+## Not in this PR (with disposition)
+
+### Gap 4 — TUI users have no access to `--with-state` → PR-B
+
+The `ForkDialog` is unchanged. TUI users still have to drop to the CLI. Full sub-checkbox integration (`Carry parent state (press y)` / `Include gitignored files (press i)` under the existing "Create in worktree" checkbox), focus order, behavioral eval — all live in PR-B. Will land as a follow-up PR after this one.
+
+### Gap 5 conversation half — verification of `claude --resume --fork-session` continuity
+
+The eval test stubs `claude`, so we exercise the spawn path structurally but don't prove the new session shares conversation history with the parent. Closing this would require either (a) a richer fake-claude that stores/echoes conversation state, or (b) running against a real Claude install in a CI lane. Not blocked on PR-A; worth a small follow-up.
+
+### Gap 11 (from the 11-gap analysis) — Shared `PreflightForkWithState` extraction → deferred PR-C, RFC-required
+
+Upstream's `refuseUnsafeParentState` is internal (lowercase) to `materialize_wip.go`. Promoting it to an exported `PreflightForkWithState` with typed `InProgressOperationError` would let CLI and TUI share a preflight gate with surface-specific error rendering (and would also enable cleaner gap 6 wording). This refactors upstream's just-merged file; it deserves an RFC discussion. Not in PR-A or PR-B; would land as a separate PR-C.
+
+---
+
+## File changes
+
+| File | Change | Lines |
+|---|---|---|
+| `internal/git/git.go` | + `HeadCommit`, `CreateWorktreeAtStartPoint` | +38 |
+| `internal/git/git_test.go` | + 2 tests | +62 |
+| `internal/git/fork_with_state_destination.go` | new: `ValidateForkWithStateDestination`, `DestinationCollisionError`, `HasSubmodules`, `DetectInProgressOperation` + helper | +120 |
+| `internal/git/fork_with_state_destination_test.go` | new: 11 tests (3 validator + 2 submodule + 6 in-progress detection) | +220 |
+| `internal/git/materialize_wip_invariant_test.go` | new | +73 |
+| `internal/git/fork_with_state_integration_test.go` | new | +266 |
+| `internal/git/issue1029_edge_test.go` | + 4 refusal tests | +101 |
+| `internal/git/setup.go` | + `RunWorktreeSetupAfterCreate`; wrapper tail deduped to delegate | +10 |
+| `cmd/agent-deck/session_cmd.go` | with-state branch: collision validation → mid-op refusal (actionable) → submodule warning → parent-HEAD + CreateWorktreeAtStartPoint → materialize → cleanup-on-error (with honest failure-reporting); before-start hook seam | +135 |
+| `cmd/agent-deck/session_cmd_fork_state_test.go` | new: 7 source-introspection contract tests incl. mid-op structural guard | +260 |
+| `tests/eval/session/fork_with_state_test.go` | new (eval_smoke tagged): happy path + 3 error-path subprocess tests | +430 |
+| `docs/superpowers/specs/2026-05-18-fork-with-state-followup-design.md` | new (followup design) | +160 |
+| `docs/superpowers/plans/2026-05-18-fork-with-state-followup.md` | new (followup plan) | +700 |
+| `docs/superpowers/discussions/2026-05-18-post-merge-gap-analysis.md` | new (gap analysis) | +180 |
+
+Total: ~2800 lines (about half are tests + docs).
+
+---
+
+## Test plan
+
+### Mandate suite (must pass)
+
+```bash
+GOTOOLCHAIN=go1.24.0 go test ./internal/git/... -run "Materialize|RefuseUnsafeParentState|ValidateForkWithStateDestination|HasSubmodules|DetectInProgressOperation|CreateWorktreeAtStartPoint|HeadCommit|ForkWithState|Issue1029" -race -count=1
+
+GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/... -run "SessionFork_WithState" -race -count=1
+
+GOTOOLCHAIN=go1.24.0 go test -tags eval_smoke ./tests/eval/session/... -run "TestEval_SessionForkWithState" -race -count=1
+```
+
+### Regression check (upstream's #1030 tests still pass)
+
+```bash
+GOTOOLCHAIN=go1.24.0 go test ./internal/git/... -run "RegressionFor1029|Issue1029" -race -count=1
+```
+
+### Local verification done
+
+- [x] `make fmt` clean (one upstream file reformatted by gofmt; committed as `chore: gofmt run`)
+- [x] `make lint` clean — no PR-A-introduced warnings
+- [x] Mandate suite: 19 + 5 + 1 tests matched, all pass
+- [x] Regression suite: 8 tests pass
+- [x] Full `go test ./...` — PR-A-touched packages clean; remaining failures are environmental (tmux/zoxide/Linux-systemd suites; pre-existing)
+- [x] Review-fix focused checks:
+  - `GOTOOLCHAIN=go1.24.0 go test ./internal/git -run TestHeadCommit_IgnoresGitWarningsOnStderr -count=1`
+  - `GOTOOLCHAIN=go1.24.0 go test -tags eval_smoke ./tests/eval/session -run 'TestEval_SessionForkWithState_(RealBinary|RejectsExistingWorktree|RejectsExistingBranch)' -count=1 -timeout 120s`
+  - `GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck -run 'TestSessionFork_WithState(HookCapturesResolvedStateBeforeStart|OptionsPropagatedBeforeStart)|TestSessionForkBeforeStartHook_NilInProduction' -count=1`
+  - `GOTOOLCHAIN=go1.24.0 go test ./internal/git -run 'TestValidateForkWithStateDestination_(PropagatesWorktreeCheckError|Clean|BranchExists|WorktreeExists_TakesPrecedence)' -count=1`
+  - `GOTOOLCHAIN=go1.24.0 go test ./internal/git -run 'TestCreateWorktreeWithStateAndSetup_(CleansUpOnMaterializeFailure|WiresMaterialization_RegressionFor1029)' -count=1`
+  - `GOTOOLCHAIN=go1.24.0 go test ./internal/git -run TestMaterializeWipFromParent_ParentUntouched -count=1`
+  - `GOTOOLCHAIN=go1.24.0 go test ./internal/git/... -run 'Materialize|RefuseUnsafeParentState|ValidateForkWithStateDestination|HasSubmodules|DetectInProgressOperation|CreateWorktreeAtStartPoint|HeadCommit|ForkWithState|Issue1029' -race -count=1`
+  - `GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/... -run 'SessionFork_WithState' -race -count=1`
+  - `GOTOOLCHAIN=go1.24.0 go test -tags eval_smoke ./tests/eval/session/... -run 'TestEval_SessionForkWithState' -race -count=1 -timeout 180s`
+- [x] Full eval-smoke attempted:
+  - `GOTOOLCHAIN=go1.24.0 go test -tags eval_smoke ./tests/eval/... ./internal/ui/... -count=1 -timeout 15m`
+  - Result: fails outside the fork-with-state path. I reproduced the failing subsets from a detached `main` worktree at `a02a30f3db27d1142b45222a827d0a59ab7dad99`, so these are not introduced by this branch's `handleSessionFork` changes.
+  - Real-tmux evals (`TestEval_Session_AttachRestart_SocketIsolation_RealTmux`, `_ITermBadge_RealAttach`, `_InjectStatusLine_RealTmux`) fail before any fork code. With the default macOS temp dir, the harness socket path can exceed the Unix socket path limit (`File name too long`). With `TMPDIR=/private/tmp`, that symptom goes away, but local `tmux 3.6a` still fails during `session start` at the send-keys step (`failed to send command`). Track as tmux/harness environment work, not fork-with-state.
+  - `TestEval_Session_StatusUnderBridgedStdio_NoHang` fails on `main` too. The unit WaitDelay contracts pass, but the real-binary eval's lingering-child shim also affects startup tmux probes such as `tmux -V`; those use raw `exec.Command(...).CombinedOutput()` and can consume the test's 10s budget before the status path under test finishes. Track separately as eval/shim coverage drift.
+  - `TestEval_SelectFlag_GroupScopeWarning` hangs on `main` too. Re-running with `-timeout 30m -v` confirms the test blocks in `runBinStderrShort` at `cmd.CombinedOutput()` after printing only `=== RUN`; the helper assumes the no-PTY TUI exits on its own, but the current binary stays alive. Track as a select-flag eval harness bug.
+  - The three `internal/ui` zoxide picker failures reproduce on `main`. Root cause in this environment: `zoxide` is not installed, and `Show()` checks real availability before using the injected query function, so the tests never populate results. Track as zoxide test-seam/env drift.
+- [ ] Manual TUI walkthrough — NOT applicable, no TUI changes in PR-A (gap 4 → PR-B)
+- [ ] Manual CLI walkthroughs — see [`fork-worktree-with-state-testing.md`](fork-worktree-with-state-testing.md) for scenario-by-scenario steps mapping to each of the 8 capability gaps
+
+### Reviewer-friendly verification
+
+Cherry-pick scenarios from the testing doc; each closes-by-PR-A scenario is a self-contained `mktemp -d` setup and a small `agent-deck session fork ...` invocation with copy-pasteable assertions.
+
+---
+
+## Reviewer notes
+
+### Polish landed in PR-A (was previously flagged as follow-ups)
+
+1. **Cleanup-error logging now honest.** `_ = exec.Command(...).Run()` replaced with captured errors. When cleanup actually fails (concurrent process holds the path, etc.), the user gets a precise "cleanup also failed (…); manual cleanup required: rm -rf <path> && git -C <repo> branch -D <branch>" message instead of the false "new worktree cleaned up." Commit `a7837cf6`.
+2. **Setup-hook tail deduped.** `CreateWorktreeWithStateAndSetup` now delegates to `RunWorktreeSetupAfterCreate` for its setup-hook portion — eliminates the 15-line duplication. Wrapper signature unchanged; upstream's progress-message tests confirm byte-identical stderr output. Commit `9100ef23`.
+3. **Subprocess error-path tests added.** Eval-tagged tests drive the real binary against destination-collision, existing-worktree, and mid-rebase parent states, asserting exact user-facing wording. The happy-path eval now intentionally omits `-b` to pin the CLI contract that `--with-state` requires `-w`, not `-b`. Augments the source-introspection contract tests; doesn't replace them. Commit `8646d2a2` plus the latest review-fix commit.
+4. **Follow-up bug batch triaged and fixed where narrow.** BUG-01/BUG-08 were already covered by the hoisted destination validator. BUG-02/BUG-05 changed the before-start hook to pass `git.WorktreeStateOptions` by value and added a runtime handler-path test for resolved state propagation. BUG-03 now propagates `GetWorktreeForBranch` failures instead of treating them as "no collision." BUG-06 now cleans up the shared helper's created worktree and branch when materialization fails. BUG-07 extends the parent-read-only invariant to raw index bytes. BUG-09 trims the setup-hook test comment to the scope the test actually proves.
+
+### Design decisions worth a second look
+
+- **`CreateWorktreeAtStartPoint` is a new helper, not an extension of `CreateWorktreeWithStateAndSetup`.** The followup spec discusses two options for anchoring parent's HEAD: (a) new helper + the CLI handler orchestrates Create → Materialize → ProcessWorktreeInclude → Setup manually, or (b) extend the wrapper to accept an optional start point. Picked (a) to avoid touching upstream's just-merged wrapper. Open to revisiting if (b) is preferred.
+- **`ValidateForkWithStateDestination` is a shared `internal/git` helper rather than inline checks.** Both CLI and TUI need to call it (TUI is PR-B). Extracting now prevents drift between the two surfaces.
+- **`DestinationCollisionError.Kind` is a string with exported constants** (`CollisionWorktreeExists`, `CollisionBranchExists`). Considered using `iota` typed enum; chose strings for `errors.As`-friendliness and zero-ceremony switch arms. Two values today; constants reserved for future expansion.
+- **Post-start cleanup remains a product/behavior decision (BUG-04), not a narrow correctness fix in this PR.** The current cleanup guarantee is scoped to materialization failure before the session starts. Extending cleanup across `forkedInst.Start()` or `storage.SaveWithGroups()` failures would change observable behavior and needs a separate design call: after `Start()` succeeds, a tmux process may already be running in the new worktree, so safe cleanup would also need session termination semantics. Current eval coverage intentionally inspects the materialized worktree after a downstream start failure; changing that contract should be done deliberately, with a new test shape.
+
+### Hot takes I'd appreciate guidance on
+
+1. **`DetectInProgressOperation` duplicates upstream's `refuseUnsafeParentState` check table.** The two functions are intentionally kept in sync — comments on both reference each other and ask future contributors to update both. The alternative is promoting `refuseUnsafeParentState` to a shared exported helper, which is gap 11 / PR-C territory and needs an RFC. For now, two sources of truth is the lesser evil. Open to other suggestions.
+2. **PR-C (shared preflight extraction) is the natural next architectural step.** Would let CLI and TUI share typed preflight errors instead of having parallel detection helpers (`DetectInProgressOperation` here, `HasSubmodules` here, upstream's `refuseUnsafeParentState`). Worth scoping as a separate issue + RFC rather than slipping into PR-A. Reasonable?
+3. **PR-B (TUI) is sized for a separate PR.** ~600 LOC for `ForkDialog` integration + behavioral eval. Will reuse `git.HasSubmodules`, `git.DetectInProgressOperation`, `git.ValidateForkWithStateDestination`, `git.HeadCommit`, `git.CreateWorktreeAtStartPoint`, and the actionable-message formatting patterns from this PR. Reviewable in parallel after this lands.
+
+---
+
+## Out of scope (explicit non-goals)
+
+- Replacing upstream's `MaterializeWipFromParent` or `CreateWorktreeWithStateAndSetup`. They work; we wrap.
+- Refactoring upstream's wrapper pattern into a split (`CreateWorktree` + `RunWorktreeSetup`) — the deprecated original spec called for this; the followup adopted the wrapper as base.
+- Renaming any upstream-introduced symbols.
+- Touching `internal/git/materialize_wip.go` directly. All new helpers live in new files.
+
+---
+
+## Final notes
+
+- This PR was scoped via a comparative analysis against `02b6e5c4` / `6a1645eb` — see [`2026-05-18-post-merge-gap-analysis.md`](2026-05-18-post-merge-gap-analysis.md) for the full deltas walk-through.
+- The 8-capability-gap framing in this PR body is the user-experience lens; the 11-gap framing in the analysis doc is the implementation lens. They overlap but aren't 1:1 — gap 11 (shared preflight extraction) is implementation-only and doesn't appear in the 8-gap framing.
+- Branch is currently 18 commits ahead of `upstream/main`: 6 docs/spec/plan commits, 9 code/test commits, 2 housekeeping (gofmt + spec-drift fix), 1 wip preserving Items 1-5 of earlier review history. Open to squash-on-merge or rebase-and-merge — both work.

--- a/docs/superpowers/discussions/fork-worktree-with-state-testing.md
+++ b/docs/superpowers/discussions/fork-worktree-with-state-testing.md
@@ -1,0 +1,303 @@
+# Fork-with-State PR-A — Manual Verification & Testing
+
+**Date:** 2026-05-19
+**Branch:** `feature/fork-worktree-with-state` (pre-push)
+**Last commit:** `35b815af`
+**Spec:** [`../specs/2026-05-18-fork-with-state-followup-design.md`](../specs/2026-05-18-fork-with-state-followup-design.md)
+**Plan:** [`../plans/2026-05-18-fork-with-state-followup.md`](../plans/2026-05-18-fork-with-state-followup.md)
+**Capability-gap framing:** the 8 user-feature gaps captured in [`fork-worktree-with-state-pr-body.md`](fork-worktree-with-state-pr-body.md)
+
+## Test environment
+
+Required:
+- `GOTOOLCHAIN=go1.24.0` exported in shell
+- `git` 2.30+
+- `make`
+- For eval suite: `bash`, `sh`
+- For full sweep: `tmux` (some env tests will skip without it; PR-A code doesn't depend on tmux)
+
+```bash
+export GOTOOLCHAIN=go1.24.0
+cd /Users/stevemorin/c/agent-deck
+git status   # should show clean working tree on feature/fork-worktree-with-state
+```
+
+## Quick smoke (5 minutes) — run the mandate suite
+
+This is the contract PR-A's followup spec asserts. All four commands must pass with no "no tests to run" output:
+
+```bash
+go test ./internal/git/... -run "Materialize|RefuseUnsafeParentState|ValidateForkWithStateDestination|HasSubmodules|DetectInProgressOperation|CreateWorktreeAtStartPoint|HeadCommit|ForkWithState|Issue1029" -race -count=1
+
+go test ./cmd/agent-deck/... -run "SessionFork_WithState" -race -count=1
+
+go test -tags eval_smoke ./tests/eval/session/... -run "TestEval_SessionForkWithState" -race -count=1
+
+go test ./internal/git/... -run "RegressionFor1029|Issue1029" -race -count=1   # upstream regression check
+```
+
+Expected: 19 + 5 + 1 + 8 tests pass.
+
+---
+
+## Manual verification scenarios
+
+Each scenario maps to one of the 8 capability gaps from the PR body. For each: setup steps, the command to run, the expected outcome, and whether PR-A actually closes the gap.
+
+### Scenario 1 — Linked-worktree parent forks from the right commit (gap 1, CLOSED by PR-A CLI)
+
+This is the headline regression — pre-PR-A, the fork silently anchors at the main worktree's HEAD instead of your parent worktree's HEAD.
+
+```bash
+# Setup: scratch project with a linked parent worktree
+cd $(mktemp -d) && PROJ=$(pwd)
+git init --bare .bare
+git -C .bare worktree add -b main seed-wt
+git -C seed-wt config user.email t@t && git -C seed-wt config user.name t
+echo "seed" > seed-wt/README.md
+git -C seed-wt add . && git -C seed-wt commit -m seed
+
+git -C .bare worktree add -b parent-branch parent-wt
+git -C parent-wt config user.email t@t && git -C parent-wt config user.name t
+echo "parent change" > parent-wt/README.md
+git -C parent-wt commit -am "parent commit"
+
+# Sanity: seed HEAD ≠ parent HEAD
+diff <(git -C seed-wt rev-parse HEAD) <(git -C parent-wt rev-parse HEAD) || echo "OK: HEADs differ"
+
+# Dirty parent's WIP
+echo "wip-content" > parent-wt/wip.txt
+
+# Build the binary and seed a fake agent-deck session pointing at parent-wt
+make build
+export PATH=$PWD/build:$PATH
+export HOME=$PROJ/home && mkdir -p $HOME
+agent-deck session add -c claude -t parent-session "$PROJ/parent-wt"
+agent-deck session set parent-session claude-session-id "fake-uuid-12345"
+
+# The thing under test
+agent-deck session fork parent-session --with-state -w fork/linked-test
+```
+
+**Expected (PR-A behavior):**
+- Fork worktree created as a sibling of `parent-wt` (path computed per your worktree settings)
+- Fork worktree's HEAD == parent-wt's HEAD (NOT seed-wt's HEAD)
+- `wip.txt` present in the fork worktree with content `wip-content`
+
+```bash
+# Verify
+FORK_PATH=$(git -C "$PROJ/.bare" worktree list --porcelain | awk '/^worktree/{p=$2} /^branch refs\/heads\/fork\/linked-test$/{print p}')
+git -C "$FORK_PATH" rev-parse HEAD                   # should match parent-wt's HEAD
+git -C "$PROJ/parent-wt" rev-parse HEAD              # parent's HEAD
+diff <(git -C "$FORK_PATH" rev-parse HEAD) <(git -C "$PROJ/parent-wt" rev-parse HEAD) && echo "PASS: fork anchored at parent HEAD"
+cat "$FORK_PATH/wip.txt"                             # should print wip-content
+```
+
+**Failure (the bug this gap describes):** fork's HEAD matches `seed-wt`'s, not `parent-wt`'s. Pre-PR-A code does this silently.
+
+### Scenario 2 — Destination collision is refused, not silently reused (gap 2, CLOSED by PR-A CLI)
+
+```bash
+# Setup (assumes the same $PROJ + seeded session from Scenario 1)
+# Pre-create the destination branch
+git -C "$PROJ/.bare" branch fork/already-here main
+
+# The thing under test
+agent-deck session fork parent-session --with-state -w fork/already-here
+# OR alternatively pre-create a worktree:
+# git -C "$PROJ/.bare" worktree add -b fork/another-used "$PROJ/another-used-wt"
+# agent-deck session fork parent-session --with-state -w fork/another-used
+```
+
+**Expected (PR-A behavior):** non-zero exit. Error message exactly:
+
+> `branch 'fork/already-here' already exists; choose a new destination branch for --with-state`
+
+For the worktree-collision variant:
+
+> `branch 'fork/another-used' already has a worktree at <path>; choose a new destination branch for --with-state`
+
+The message must include the conflicting path so you can `cd` to it.
+
+**Failure (pre-PR-A):** "Reusing existing worktree at … for branch fork/already-here" is printed and the fork proceeds into the pre-existing worktree without running materialization. Strictly worse than the silent-shared-worktree footgun this feature was supposed to fix.
+
+### Scenario 3 — Failed forks clean up (gap 3, CLOSED by PR-A CLI)
+
+The hardest scenario to trigger by hand because materialization rarely fails on a normal repo. Two practical ways:
+
+**Method A: Corrupt the parent's HEAD ref after worktree creation.** This requires injecting a fault between `CreateWorktreeAtStartPoint` and `MaterializeWipFromParent`. Not externally observable; covered by `TestSessionFork_WithState_RejectsExistingDestinationBranch` indirectly.
+
+**Method B: Trigger a clean materialize failure via mid-rebase parent.**
+
+```bash
+# In parent-wt, induce a rebase conflict (will leave .git/rebase-merge state)
+cd "$PROJ/parent-wt"
+git checkout -b conflict-branch
+echo "first" > README.md && git commit -am "first"
+git checkout parent-branch
+echo "second" > README.md && git commit -am "second"
+git rebase conflict-branch || true   # expected to leave conflict state
+
+agent-deck session fork parent-session --with-state -w fork/cleanup-test
+```
+
+**Expected (PR-A behavior):**
+- Exits non-zero
+- Error message mentions `mid-rebase` (note: not the actionable-text version — see gap 6)
+- After the error, `git -C "$PROJ/.bare" worktree list` does NOT contain `fork/cleanup-test`
+- `git -C "$PROJ/.bare" branch --list fork/cleanup-test` returns empty (branch deleted because `createdBranch` proof said this operation created it)
+
+**Failure (pre-PR-A):** the half-baked worktree and branch stay on disk, requiring manual `git worktree remove --force` + `git branch -D`.
+
+### Scenario 4 — TUI dialog (gap 4, NOT CLOSED by PR-A — flagged here so testers don't miss it)
+
+```bash
+# Launch agent-deck TUI
+agent-deck
+
+# Press 'f' on a Claude session to open Fork dialog
+# Press 'w' to enable "Create in worktree"
+# Look for: a nested checkbox "Carry parent state (press y)"
+```
+
+**Expected (PR-A behavior):** NO such checkbox appears. The TUI dialog is unchanged from upstream — TUI users still have to drop to the CLI.
+
+This is the entire scope of **PR-B**. Re-test this scenario after PR-B lands.
+
+### Scenario 5 — Full dirty-state materialization (gap 5 file half, CLOSED by PR-A; conversation half NOT verified)
+
+```bash
+# In a fresh parent-wt
+cd "$PROJ/parent-wt"
+echo "*.env" > .gitignore
+git add .gitignore && git commit -m gitignore
+
+# Staged change
+echo "staged" > README.md
+git add README.md
+
+# Unstaged change on top of staged
+echo "staged-then-unstaged" > README.md
+
+# Untracked file
+echo "new-untracked" > new.txt
+
+# Gitignored file
+echo "API_KEY=secret" > local.env
+
+agent-deck session fork parent-session --with-state-and-gitignored -w fork/full-test
+```
+
+**Expected (PR-A behavior):**
+- Fork worktree has `README.md` showing the staged-then-unstaged content
+- `git -C <fork-path> diff --cached` matches parent's `git diff --cached`
+- `git -C <fork-path> diff` matches parent's `git diff`
+- `new.txt` present in fork with `new-untracked`
+- `local.env` present in fork with `API_KEY=secret` (this is the `-and-gitignored` discriminator)
+
+**Without `-and-gitignored`:** `local.env` should NOT be in the fork.
+
+**Conversation continuity (NOT VERIFIED by PR-A):** the new Claude Code session is started via `claude --resume <parent-id> --fork-session`. PR-A's eval test stubs out `claude` so this codepath is not actually exercised end-to-end. To manually test: install a real fake-claude or run against a real Claude install and visually confirm the new session shares conversation history with the parent.
+
+### Scenario 6 — Error message quality (gap 6, CLOSED by PR-A)
+
+Both destination collision AND mid-op refusal messages now include actionable hints.
+
+```bash
+# From Scenario 3 mid-rebase state, observe the exact error:
+agent-deck session fork parent-session --with-state -w fork/midrebase-msg
+```
+
+**Expected (PR-A behavior):** the error message exactly matches:
+
+> `parent session is mid-rebase; finish or abort the rebase before forking with state (cd <parent-path> && git rebase --abort)`
+
+Equivalents for the other four kinds (replace `rebase` and `git rebase --abort`):
+- `merge` → `git merge --abort`
+- `cherry-pick` → `git cherry-pick --abort`
+- `revert` → `git revert --abort`
+- `bisect` → `git bisect reset`
+
+Refusal now happens BEFORE worktree creation — no orphan worktree to clean up on this path. Pinned by `TestEval_SessionForkWithState_RefusesMidRebaseParent` against the real binary.
+
+### Scenario 7 — Submodule warning (gap 7, CLOSED by PR-A)
+
+```bash
+# In parent-wt, create a fake submodule entry
+cd "$PROJ/parent-wt"
+cat > .gitmodules <<'EOF'
+[submodule "lib"]
+  path = lib
+  url = https://example.invalid/lib.git
+EOF
+git add .gitmodules && git commit -m submodule
+
+agent-deck session fork parent-session --with-state -w fork/submodule-test 2>&1 | head
+```
+
+**Expected (PR-A behavior):** stderr contains the line:
+
+> `Warning: submodules detected — copied as files, not recursed (parent's submodule states preserved)`
+
+Emitted exactly once, before any worktree creation. Doesn't block the operation — fork proceeds normally; submodule files are copied as plain files (the submodule's internal `.git` state isn't recursed, as the warning says). Pinned by `TestEval_SessionForkWithState_SubmoduleWarning` against the real binary.
+
+### Scenario 8 — Setup hook ordering (gap 8, CLOSED by PR-A)
+
+```bash
+# In parent-wt, install a setup hook that reads a WIP file
+mkdir -p "$PROJ/.agent-deck"
+cat > "$PROJ/.agent-deck/worktree-setup.sh" <<'EOF'
+#!/bin/sh
+set -e
+if [ -f wip.txt ]; then
+  echo "OBSERVED:$(cat wip.txt)" > /tmp/fork-setup-marker.txt
+else
+  echo "NO_WIP" > /tmp/fork-setup-marker.txt
+fi
+EOF
+chmod +x "$PROJ/.agent-deck/worktree-setup.sh"
+
+# Dirty parent with a WIP file
+echo "wip-after-pra" > "$PROJ/parent-wt/wip.txt"
+
+rm -f /tmp/fork-setup-marker.txt
+agent-deck session fork parent-session --with-state -w fork/hook-order
+cat /tmp/fork-setup-marker.txt
+```
+
+**Expected:** `/tmp/fork-setup-marker.txt` contains `OBSERVED:wip-after-pra`.
+
+**Failure (pre-fix):** `NO_WIP`, proving the setup hook ran before materialization.
+
+PR-A's automated test (`TestForkWithState_SetupHookObservesMaterializedState`) pins this; this manual scenario is for sanity.
+
+---
+
+## Cleanup after testing
+
+```bash
+# Remove any worktrees/branches you created during testing
+cd "$PROJ/.bare" && git worktree list
+# git worktree remove --force <path>
+# git branch -D fork/<name>
+
+# Remove scratch projects
+rm -rf "$PROJ"
+
+# Remove the marker file from Scenario 8
+rm -f /tmp/fork-setup-marker.txt
+```
+
+## Stale-tmux-session caveat
+
+The eval test `TestEval_SessionForkWithState_RealBinary` can leave `agentdeck_fork-eval_*` sessions on your default tmux socket. If you see `TestOuterTmuxGuard` failing after running PR-A tests, kill those stragglers:
+
+```bash
+tmux ls 2>/dev/null | grep agentdeck_fork-eval | awk -F: '{print $1}' | xargs -I{} tmux kill-session -t {} 2>/dev/null
+```
+
+## What this doc does NOT cover
+
+- TUI integration — PR-B
+- Conversation-continuity end-to-end (gap 5 conversation half) — needs a real `claude` binary or richer fake
+- Shared `PreflightForkWithState` typed-error extraction (gap 11) — deferred to PR-C with RFC

--- a/docs/superpowers/plans/2026-05-14-fork-worktree-with-state.md
+++ b/docs/superpowers/plans/2026-05-14-fork-worktree-with-state.md
@@ -1,0 +1,4056 @@
+# Fork-with-State Implementation Plan
+
+> **⚠ DEPRECATED — superseded by [`2026-05-18-fork-with-state-followup.md`](2026-05-18-fork-with-state-followup.md)**
+>
+> This plan was written as a ground-up implementation roadmap before upstream
+> merged #1029 (commit 6a1645eb). It remains as historical reference for the
+> 21-task TDD breakdown and the FWS-001 through FWS-018 review log. The active
+> plan (scoped to closing the 11 gaps identified after the upstream merge) is
+> in the followup file. See also the post-merge gap analysis at
+> [`../discussions/2026-05-18-post-merge-gap-analysis.md`](../discussions/2026-05-18-post-merge-gap-analysis.md).
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--with-state` and `--with-state-and-gitignored` opt-in flags to `agent-deck session fork` (CLI and TUI) that materialize the parent session's working-tree state into a freshly-created destination branch and worktree branched off the parent's HEAD.
+
+**Architecture:** A new `internal/git/worktree_with_state.go` exposes `MaterializeParentState`, `DetectInProgressOperation`, `HasSubmodules`, and a shared `PreflightForkWithState` gate used by both CLI and TUI. The existing `CreateWorktreeWithSetup` is split into `CreateWorktree` (already in `git.go`) + a new `RunWorktreeSetup`, and `git.go` gains a start-point-aware `CreateWorktreeAtStartPoint` helper so fork-with-state can create the new worktree from the parent session's HEAD. The fork-with-state path sequences `PreflightForkWithState → CreateWorktreeAtStartPoint → MaterializeParentState → RunWorktreeSetup`. The CLI handler in `session_cmd.go` and the TUI `ForkDialog` gain new flags/checkboxes that propagate two new transient fields on `ClaudeOptions` (`WithState`, `IncludeGitignored`).
+
+**Tech Stack:** Go 1.24.0 (pinned via `GOTOOLCHAIN`), bubbletea/lipgloss for TUI, shelling out to `git` for diff/apply/ls-files.
+
+**Spec:** `docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md`
+
+**Pre-flight (one-time, before Task 1):**
+
+```bash
+export GOTOOLCHAIN=go1.24.0
+git checkout -b feature/fork-worktree-with-state
+```
+
+Per `CONTRIBUTING.md`, this branch will be pushed to your personal fork (`smorin/agent-deck`) when you open the PR. Do not push to upstream `asheshgoplani/agent-deck`.
+
+---
+
+## File map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `internal/session/tooloptions.go` | Modify | Add `WithState` + `IncludeGitignored` transient fields |
+| `internal/git/worktree_with_state.go` | Create | `MaterializeParentState`, `DetectInProgressOperation`, `HasSubmodules`, `PreflightForkWithState`, internal helpers |
+| `internal/git/worktree_with_state_test.go` | Create | Unit tests for the above, including the shared CLI/TUI preflight helper |
+| `internal/git/worktree_with_state_integration_test.go` | Create | Git-side fork-with-state sequence integration tests |
+| `internal/git/git.go` | Modify | Add `HeadCommit` and `CreateWorktreeAtStartPoint` for parent-HEAD worktree creation |
+| `internal/git/setup.go` | Modify | Extract `RunWorktreeSetup`; `CreateWorktreeWithSetup` becomes a wrapper |
+| `cmd/agent-deck/session_cmd.go` | Modify | New flags, implication resolution, sequence Create→Materialize→Setup with cleanup-on-error |
+| `cmd/agent-deck/session_cmd_fork_state_test.go` | Create | CLI/handler contract tests for fork-with-state |
+| `internal/ui/forkdialog.go` | Modify | Two new sub-checkboxes, state guards, focus-target extension, getters |
+| `internal/ui/forkdialog_test.go` | Modify | TUI tests for visibility, focus order, getters |
+| `internal/ui/home_fork_state_test.go` | Create | Structural guard that TUI fork-with-state uses shared `git.PreflightForkWithState` before worktree creation |
+| `tests/eval/session/fork_with_state_test.go` | Create | Behavioral eval smoke test for the real CLI fork-with-state flow |
+| `internal/ui/forkdialog_eval_test.go` | Create | Behavioral eval smoke test for the visible TUI ForkDialog with-state interaction |
+| `CLAUDE.md` | Modify | Add fork-with-state mandatory test coverage section |
+| `README.md` | Modify | Add `--with-state` example |
+| `CHANGELOG.md` | Modify | Entry for the version this ships in |
+
+---
+
+## Task 1: Add transient fields to ClaudeOptions
+
+**Files:**
+- Modify: `internal/session/tooloptions.go:37-42`
+
+- [ ] **Step 1: Add fields after the existing worktree transient block**
+
+Open `internal/session/tooloptions.go` and replace lines 37-42 (the comment + four worktree fields) with:
+
+```go
+	// Transient fields for worktree fork (not persisted)
+	WorkDir          string `json:"-"`
+	WorktreePath     string `json:"-"`
+	WorktreeRepoRoot string `json:"-"`
+	WorktreeBranch   string `json:"-"`
+
+	// Transient fields for fork-with-state (not persisted).
+	// Consumed by the fork CLI/TUI handler to drive MaterializeParentState.
+	WithState         bool `json:"-"`
+	IncludeGitignored bool `json:"-"`
+```
+
+- [ ] **Step 2: Verify package compiles**
+
+Run: `GOTOOLCHAIN=go1.24.0 go build ./internal/session/...`
+Expected: exits 0, no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/session/tooloptions.go
+git commit -m "feat(session): add WithState/IncludeGitignored transient options for fork-with-state"
+```
+
+---
+
+## Task 2: DetectInProgressOperation
+
+**Files:**
+- Create: `internal/git/worktree_with_state.go`
+- Create: `internal/git/worktree_with_state_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/git/worktree_with_state_test.go`:
+
+```go
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// runGit is a test helper that runs a git command in dir and fails the
+// test if it exits non-zero. Returns combined output for assertions.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s failed: %v\noutput: %s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+// runGitAllowFail runs a git command and returns output + error without
+// failing the test. Used when we expect a conflict / non-zero exit.
+func runGitAllowFail(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// initRepo creates a fresh git repo with one initial commit on main.
+// Returns the repo dir.
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("init\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "init")
+	return dir
+}
+
+func TestDetectInProgressOperation_Clean(t *testing.T) {
+	dir := initRepo(t)
+	got, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("clean repo returned %q, want empty", got)
+	}
+}
+
+func TestDetectInProgressOperation_Rebase(t *testing.T) {
+	dir := initRepo(t)
+	// Create two diverging commits on a side branch and main so rebase produces a conflict.
+	runGit(t, dir, "checkout", "-b", "side")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("side\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "commit", "-am", "side change")
+	runGit(t, dir, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "commit", "-am", "main change")
+	// Attempt rebase; expect conflict so rebase stays in progress.
+	_, _ = runGitAllowFail(dir, "rebase", "side")
+
+	got, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "rebase" {
+		t.Fatalf("mid-rebase returned %q, want %q", got, "rebase")
+	}
+}
+
+func TestDetectInProgressOperation_Merge(t *testing.T) {
+	dir := initRepo(t)
+	runGit(t, dir, "checkout", "-b", "side")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("side\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "commit", "-am", "side")
+	runGit(t, dir, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "commit", "-am", "main")
+	_, _ = runGitAllowFail(dir, "merge", "side")
+
+	got, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "merge" {
+		t.Fatalf("mid-merge returned %q, want %q", got, "merge")
+	}
+}
+
+func TestDetectInProgressOperation_CherryPick(t *testing.T) {
+	dir := initRepo(t)
+	runGit(t, dir, "checkout", "-b", "side")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("side\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "commit", "-am", "side")
+	sideSha := runGit(t, dir, "rev-parse", "HEAD")
+	runGit(t, dir, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "commit", "-am", "main")
+	_, _ = runGitAllowFail(dir, "cherry-pick", sideSha[:8])
+
+	got, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "cherry-pick" {
+		t.Fatalf("mid-cherry-pick returned %q, want %q", got, "cherry-pick")
+	}
+}
+
+func TestDetectInProgressOperation_Bisect(t *testing.T) {
+	dir := initRepo(t)
+	// Three commits to give bisect something to walk.
+	for i := 0; i < 3; i++ {
+		if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte{byte('a' + i)}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, dir, "add", "f.txt")
+		runGit(t, dir, "commit", "-m", "c")
+	}
+	runGit(t, dir, "bisect", "start")
+	runGit(t, dir, "bisect", "bad")
+	runGit(t, dir, "bisect", "good", "HEAD~2")
+
+	got, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "bisect" {
+		t.Fatalf("active bisect returned %q, want %q", got, "bisect")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail (no implementation yet)**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestDetectInProgressOperation -v`
+Expected: FAIL — `undefined: DetectInProgressOperation`
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `internal/git/worktree_with_state.go`:
+
+```go
+package git
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// DetectInProgressOperation returns "rebase", "merge", "cherry-pick", "bisect",
+// or "" depending on what (if any) operation is currently in progress in the
+// repository at repoDir. Errors only on inability to locate the git dir.
+func DetectInProgressOperation(repoDir string) (string, error) {
+	gitDir, err := resolveGitDir(repoDir)
+	if err != nil {
+		return "", err
+	}
+	if pathExists(filepath.Join(gitDir, "rebase-merge")) || pathExists(filepath.Join(gitDir, "rebase-apply")) {
+		return "rebase", nil
+	}
+	if pathExists(filepath.Join(gitDir, "CHERRY_PICK_HEAD")) {
+		return "cherry-pick", nil
+	}
+	if pathExists(filepath.Join(gitDir, "MERGE_HEAD")) {
+		return "merge", nil
+	}
+	if pathExists(filepath.Join(gitDir, "BISECT_LOG")) {
+		return "bisect", nil
+	}
+	return "", nil
+}
+
+// resolveGitDir returns the absolute path to the .git directory for repoDir.
+// Handles worktrees (where .git is a file containing "gitdir: ..."), bare repos,
+// and plain repos uniformly via `git rev-parse --git-dir`.
+func resolveGitDir(repoDir string) (string, error) {
+	cmd := exec.Command("git", "-C", repoDir, "rev-parse", "--git-dir")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("rev-parse --git-dir in %s: %s: %w", repoDir, strings.TrimSpace(stderr.String()), err)
+	}
+	gd := strings.TrimSpace(stdout.String())
+	if !filepath.IsAbs(gd) {
+		gd = filepath.Join(repoDir, gd)
+	}
+	return gd, nil
+}
+
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// HasSubmodules returns true if the repo has a .gitmodules file. Used to warn
+// (not refuse) before MaterializeParentState — submodule contents are copied
+// as plain files; their internal git state is not recursed into.
+func HasSubmodules(repoDir string) (bool, error) {
+	info, err := os.Stat(filepath.Join(repoDir, ".gitmodules"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return !info.IsDir(), nil
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestDetectInProgressOperation -v`
+Expected: PASS (5 subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/git/worktree_with_state.go internal/git/worktree_with_state_test.go
+git commit -m "feat(git): add DetectInProgressOperation for fork-with-state pre-flight"
+```
+
+---
+
+## Task 3: HasSubmodules
+
+**Files:**
+- Modify: `internal/git/worktree_with_state_test.go`
+
+`HasSubmodules` was implemented in Task 2's same file. This task only adds tests.
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `internal/git/worktree_with_state_test.go`:
+
+```go
+func TestHasSubmodules_None(t *testing.T) {
+	dir := initRepo(t)
+	got, err := HasSubmodules(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Fatal("plain repo reported HasSubmodules=true")
+	}
+}
+
+func TestHasSubmodules_Present(t *testing.T) {
+	dir := initRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, ".gitmodules"), []byte("# fake\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := HasSubmodules(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got {
+		t.Fatal("repo with .gitmodules reported HasSubmodules=false")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestHasSubmodules -v`
+Expected: PASS (2 subtests). (Implementation was added in Task 2; tests are independent.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/git/worktree_with_state_test.go
+git commit -m "test(git): add HasSubmodules unit tests"
+```
+
+---
+
+## Task 4: Split CreateWorktreeWithSetup → extract RunWorktreeSetup
+
+**Files:**
+- Modify: `internal/git/setup.go:89-120`
+- Test: existing tests in `internal/git/setup_test.go`, `internal/git/setup_progress_test.go`, `internal/git/bare_repo_test.go`
+
+This task is a pure refactor: behavior of `CreateWorktreeWithSetup` is unchanged, but `RunWorktreeSetup` is extracted as a separately-exported function. Existing tests must continue to pass without modification.
+
+- [ ] **Step 1: Replace the body of CreateWorktreeWithSetup and add RunWorktreeSetup**
+
+In `internal/git/setup.go`, replace the function `CreateWorktreeWithSetup` (lines 100-120) with:
+
+```go
+func CreateWorktreeWithSetup(repoDir, worktreePath, branchName string, stdout, stderr io.Writer, setupTimeout time.Duration) (setupErr error, err error) {
+	if err = CreateWorktree(repoDir, worktreePath, branchName); err != nil {
+		return nil, err
+	}
+	return RunWorktreeSetup(repoDir, worktreePath, stdout, stderr, setupTimeout), nil
+}
+
+// RunWorktreeSetup runs the worktree setup script (if any) against an
+// existing worktree. Returns the script's exit error (non-fatal — callers
+// treat it as a warning); a nil return means "no script" or "script
+// succeeded."
+//
+// Extracted from CreateWorktreeWithSetup so the fork-with-state path can
+// sequence: CreateWorktree → MaterializeParentState → RunWorktreeSetup.
+// The materialization must run before the setup hook so the hook sees the
+// final file contents (e.g., a parent's WIP package.json drives npm install).
+func RunWorktreeSetup(repoDir, worktreePath string, stdout, stderr io.Writer, setupTimeout time.Duration) error {
+	scriptPath, scriptMode := FindWorktreeSetupScript(repoDir)
+	if scriptPath == "" {
+		return nil
+	}
+	fmt.Fprintln(stderr, "Running worktree setup script...")
+	start := time.Now()
+	setupErr := RunWorktreeSetupScript(scriptPath, scriptMode, repoDir, worktreePath, stdout, stderr, setupTimeout)
+	elapsed := time.Since(start).Round(100 * time.Millisecond)
+	if setupErr != nil {
+		fmt.Fprintf(stderr, "Worktree setup script failed after %s: %v\n", elapsed, setupErr)
+	} else {
+		fmt.Fprintf(stderr, "Worktree setup script completed in %s\n", elapsed)
+	}
+	return setupErr
+}
+```
+
+- [ ] **Step 2: Run existing setup tests to confirm no regression**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/... -run "Setup|Worktree" -race -count=1`
+Expected: PASS — all existing tests still green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/git/setup.go
+git commit -m "refactor(git): extract RunWorktreeSetup from CreateWorktreeWithSetup"
+```
+
+---
+
+## Task 4A: Add start-point-aware worktree creation for parent-HEAD forks
+
+**Files:**
+- Modify: `internal/git/git.go`
+- Modify: `internal/git/git_test.go`
+
+Fork-with-state's product contract is that the fork starts from the parent session's HEAD. This matters when the parent session already lives in a linked worktree whose HEAD differs from the main/base worktree. Existing `CreateWorktree(repoRoot, ...)` creates a new branch from the invocation repo's current HEAD and cannot express an explicit start point.
+
+- [ ] **Step 1: Add the failing linked-worktree regression**
+
+Append to `internal/git/git_test.go`:
+
+```go
+func TestCreateWorktreeAtStartPoint_UsesExplicitParentHead(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createTestRepo(t, base)
+
+	parentWT := filepath.Join(root, "parent-wt")
+	if err := CreateWorktree(base, parentWT, "parent-branch"); err != nil {
+		t.Fatalf("CreateWorktree parent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(parentWT, "README.md"), []byte("# Parent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, parentWT, "commit", "-am", "parent change")
+
+	baseHead := runGit(t, base, "rev-parse", "HEAD")
+	parentHead := runGit(t, parentWT, "rev-parse", "HEAD")
+	if baseHead == parentHead {
+		t.Fatal("setup invalid: base and parent worktree HEAD should differ")
+	}
+
+	forkWT := filepath.Join(root, "fork-wt")
+	createdBranch, err := CreateWorktreeAtStartPoint(base, forkWT, "fork/from-parent", parentHead)
+	if err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	}
+	if !createdBranch {
+		t.Fatal("CreateWorktreeAtStartPoint returned createdBranch=false for a new branch")
+	}
+	forkHead := runGit(t, forkWT, "rev-parse", "HEAD")
+	if forkHead != parentHead {
+		t.Fatalf("fork HEAD = %s, want parent HEAD %s (base HEAD %s)", forkHead, parentHead, baseHead)
+	}
+}
+
+func TestCreateWorktreeAtStartPoint_RejectsExistingBranch(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createTestRepo(t, base)
+	parentHead := runGit(t, base, "rev-parse", "HEAD")
+	runGit(t, base, "branch", "fork/existing")
+
+	createdBranch, err := CreateWorktreeAtStartPoint(base, filepath.Join(root, "fork-wt"), "fork/existing", parentHead)
+	if err == nil {
+		t.Fatal("expected existing branch to be rejected")
+	}
+	if createdBranch {
+		t.Fatal("createdBranch should be false when branch already existed")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected already-exists error, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestCreateWorktreeAtStartPoint_UsesExplicitParentHead -v`
+Expected: FAIL — `undefined: CreateWorktreeAtStartPoint`.
+
+- [ ] **Step 3: Add the minimal helper**
+
+In `internal/git/git.go`, add near `CreateWorktree`:
+
+```go
+// HeadCommit returns the commit currently checked out at repoDir. It accepts
+// normal repositories, linked worktrees, and bare-repo project roots.
+func HeadCommit(repoDir string) (string, error) {
+	repoDir = resolveGitInvocationDir(repoDir)
+	cmd := exec.Command("git", "-C", repoDir, "rev-parse", "--verify", "HEAD^{commit}")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve HEAD commit: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// CreateWorktreeAtStartPoint creates a new branch worktree from an explicit
+// start point. It returns createdBranch=true only after git successfully
+// creates the branch for this call. Fork-with-state cleanup uses that proof
+// before deleting a branch after materialization failure.
+func CreateWorktreeAtStartPoint(repoDir, worktreePath, branchName, startPoint string) (createdBranch bool, err error) {
+	if err := ValidateBranchName(branchName); err != nil {
+		return false, fmt.Errorf("invalid branch name: %w", err)
+	}
+	if strings.TrimSpace(startPoint) == "" {
+		return false, errors.New("start point cannot be empty")
+	}
+	repoDir = resolveGitInvocationDir(repoDir)
+	if !IsGitRepo(repoDir) {
+		return false, errors.New("not a git repository")
+	}
+	if BranchExists(repoDir, branchName) {
+		return false, fmt.Errorf("branch %q already exists", branchName)
+	}
+	cmd := exec.Command("git", "-C", repoDir, "worktree", "add", "-b", branchName, worktreePath, startPoint)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("failed to create worktree at start point: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return true, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run "TestCreateWorktreeAtStartPoint|TestCreateWorktree" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/git/git.go internal/git/git_test.go
+git commit -m "feat(git): create fork worktrees from explicit parent HEAD"
+```
+
+---
+
+## Task 4B: Add shared fork-with-state preflight helper
+
+**Files:**
+- Modify: `internal/git/worktree_with_state_test.go`
+- Modify: `internal/git/worktree_with_state.go`
+
+The CLI and TUI must not each own their own fork-with-state safety checks. Keep git facts in `internal/git`: detect unsupported in-progress operations, capture the parent HEAD start point, and return submodule presence as a warning fact. CLI and TUI remain responsible for rendering those facts as surface-appropriate errors or warnings.
+
+- [ ] **Step 1: Add failing tests for the shared helper**
+
+In `internal/git/worktree_with_state_test.go`, add `errors` and `strings` to the imports, then append:
+
+```go
+func TestPreflightForkWithState_ReturnsParentHeadAndSubmoduleFact(t *testing.T) {
+	dir := initRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, ".gitmodules"), []byte("[submodule \"lib\"]\n\tpath = lib\n\turl = https://example.invalid/lib.git\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := PreflightForkWithState(dir)
+	if err != nil {
+		t.Fatalf("PreflightForkWithState: %v", err)
+	}
+	wantHead := strings.TrimSpace(runGit(t, dir, "rev-parse", "--verify", "HEAD^{commit}"))
+	if got.ParentHead != wantHead {
+		t.Fatalf("ParentHead = %q, want %q", got.ParentHead, wantHead)
+	}
+	if !got.HasSubmodules {
+		t.Fatal("HasSubmodules = false, want true")
+	}
+}
+
+func TestPreflightForkWithState_RefusesInProgressOperation(t *testing.T) {
+	dir := initRepo(t)
+	runGit(t, dir, "checkout", "-b", "side")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("side\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "commit", "-am", "side change")
+	runGit(t, dir, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "commit", "-am", "main change")
+	_, _ = runGitAllowFail(dir, "rebase", "side")
+
+	_, err := PreflightForkWithState(dir)
+	if err == nil {
+		t.Fatal("expected in-progress operation error")
+	}
+	var opErr *InProgressOperationError
+	if !errors.As(err, &opErr) {
+		t.Fatalf("error = %T %v, want InProgressOperationError", err, err)
+	}
+	if opErr.Kind != "rebase" {
+		t.Fatalf("operation kind = %q, want rebase", opErr.Kind)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestPreflightForkWithState -v`
+Expected: FAIL — `undefined: PreflightForkWithState` / `undefined: InProgressOperationError`.
+
+- [ ] **Step 3: Add the shared helper**
+
+Append to `internal/git/worktree_with_state.go`:
+
+```go
+type ForkWithStatePreflight struct {
+	ParentHead    string
+	HasSubmodules bool
+}
+
+// InProgressOperationError is returned when the parent repo has an unsupported
+// operation in progress. Callers own the final user-facing wording.
+type InProgressOperationError struct {
+	Kind    string
+	RepoDir string
+}
+
+func (e *InProgressOperationError) Error() string {
+	return fmt.Sprintf("parent repository is mid-%s", e.Kind)
+}
+
+// PreflightForkWithState is the shared CLI/TUI preflight gate for fork-with-state.
+// It returns git facts only: parent HEAD and whether submodules are present.
+// Callers render warnings and errors according to their surface.
+func PreflightForkWithState(parentWorktree string) (*ForkWithStatePreflight, error) {
+	op, err := DetectInProgressOperation(parentWorktree)
+	if err != nil {
+		return nil, fmt.Errorf("detect in-progress operation: %w", err)
+	}
+	if op != "" {
+		return nil, &InProgressOperationError{Kind: op, RepoDir: parentWorktree}
+	}
+
+	hasSubmodules, err := HasSubmodules(parentWorktree)
+	if err != nil {
+		return nil, fmt.Errorf("inspect submodules: %w", err)
+	}
+
+	parentHead, err := HeadCommit(parentWorktree)
+	if err != nil {
+		return nil, fmt.Errorf("resolve parent HEAD: %w", err)
+	}
+
+	return &ForkWithStatePreflight{
+		ParentHead:    parentHead,
+		HasSubmodules: hasSubmodules,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run "TestPreflightForkWithState|TestDetectInProgressOperation|TestHasSubmodules|TestCreateWorktreeAtStartPoint" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/git/worktree_with_state.go internal/git/worktree_with_state_test.go
+git commit -m "feat(git): add shared fork-with-state preflight"
+```
+
+---
+
+## Task 4C: Add shared fork-with-state destination collision validator
+
+**Files:**
+- Modify: `internal/git/worktree_with_state_test.go`
+- Modify: `internal/git/worktree_with_state.go`
+
+Mirrors the FWS-009 `PreflightForkWithState` pattern for destination-collision git facts. CLI and TUI both call this validator once before their respective worktree-creation paths; the inline collision checks in both surfaces' existing-worktree reuse blocks are removed in Task 13 and Task 17.
+
+Worktree-collision is checked first so the more specific error (with path) is surfaced when both conditions are true.
+
+- [ ] **Step 1: Add failing tests for the shared validator**
+
+Append to `internal/git/worktree_with_state_test.go`:
+
+```go
+func TestValidateForkWithStateDestination_Clean(t *testing.T) {
+	dir := initRepo(t)
+	if err := ValidateForkWithStateDestination(dir, "fork/new"); err != nil {
+		t.Fatalf("clean repo + fresh branch should pass, got %v", err)
+	}
+}
+
+func TestValidateForkWithStateDestination_BranchExists(t *testing.T) {
+	dir := initRepo(t)
+	runGit(t, dir, "branch", "fork/existing")
+
+	err := ValidateForkWithStateDestination(dir, "fork/existing")
+	if err == nil {
+		t.Fatal("expected DestinationCollisionError for existing branch")
+	}
+	var collErr *DestinationCollisionError
+	if !errors.As(err, &collErr) {
+		t.Fatalf("error = %T %v, want *DestinationCollisionError", err, err)
+	}
+	if collErr.Kind != "branch_exists" {
+		t.Fatalf("Kind = %q, want branch_exists", collErr.Kind)
+	}
+	if collErr.Branch != "fork/existing" {
+		t.Fatalf("Branch = %q, want fork/existing", collErr.Branch)
+	}
+}
+
+func TestValidateForkWithStateDestination_WorktreeExists(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createTestRepo(t, base)
+	wtPath := filepath.Join(root, "fork-wt")
+	if err := CreateWorktree(base, wtPath, "fork/used"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	err := ValidateForkWithStateDestination(base, "fork/used")
+	if err == nil {
+		t.Fatal("expected DestinationCollisionError for branch with worktree")
+	}
+	var collErr *DestinationCollisionError
+	if !errors.As(err, &collErr) {
+		t.Fatalf("error = %T %v, want *DestinationCollisionError", err, err)
+	}
+	if collErr.Kind != "worktree_exists" {
+		t.Fatalf("Kind = %q, want worktree_exists", collErr.Kind)
+	}
+	if collErr.Branch != "fork/used" {
+		t.Fatalf("Branch = %q, want fork/used", collErr.Branch)
+	}
+	if collErr.Path == "" {
+		t.Fatalf("Path should be populated for worktree_exists, got empty")
+	}
+}
+```
+
+`errors` should already be in the imports from Task 4B. `createTestRepo` already exists in `internal/git/git_test.go` from Task 4A.
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestValidateForkWithStateDestination -v`
+Expected: FAIL — `undefined: ValidateForkWithStateDestination` / `undefined: DestinationCollisionError`.
+
+- [ ] **Step 3: Add the helper and typed error**
+
+Append to `internal/git/worktree_with_state.go`:
+
+```go
+// DestinationCollisionError is returned by ValidateForkWithStateDestination
+// when the requested destination branch already has a worktree or already
+// exists as a local branch. Callers own the final user-facing wording.
+type DestinationCollisionError struct {
+	Kind   string // "worktree_exists" or "branch_exists"
+	Branch string
+	Path   string // populated when Kind == "worktree_exists"
+}
+
+func (e *DestinationCollisionError) Error() string {
+	switch e.Kind {
+	case "worktree_exists":
+		return fmt.Sprintf("branch %q already has a worktree at %s", e.Branch, e.Path)
+	case "branch_exists":
+		return fmt.Sprintf("branch %q already exists", e.Branch)
+	default:
+		return fmt.Sprintf("destination collision for branch %q", e.Branch)
+	}
+}
+
+// ValidateForkWithStateDestination is the shared CLI/TUI destination-collision
+// gate for fork-with-state. It refuses a destination branch that already has
+// a worktree (preferred error: more specific, includes path) or that already
+// exists as a local branch. Both checks are git facts; the caller decides
+// how to render them.
+func ValidateForkWithStateDestination(repoRoot, branch string) error {
+	if path, err := GetWorktreeForBranch(repoRoot, branch); err == nil && path != "" {
+		return &DestinationCollisionError{Kind: "worktree_exists", Branch: branch, Path: path}
+	}
+	if BranchExists(repoRoot, branch) {
+		return &DestinationCollisionError{Kind: "branch_exists", Branch: branch}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run "TestValidateForkWithStateDestination|TestPreflightForkWithState|TestDetectInProgressOperation|TestHasSubmodules|TestCreateWorktreeAtStartPoint" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/git/worktree_with_state.go internal/git/worktree_with_state_test.go
+git commit -m "feat(git): add shared fork-with-state destination collision validator"
+```
+
+---
+
+## Task 5: MaterializeParentState scaffold + clean-parent case
+
+**Files:**
+- Modify: `internal/git/worktree_with_state.go`
+- Modify: `internal/git/worktree_with_state_test.go`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `internal/git/worktree_with_state_test.go`:
+
+```go
+// makeWorktree creates a new worktree of repoDir at <repoDir>-wt with branch
+// "fork/test" branched off HEAD. Returns the worktree path. Mirrors what
+// the production fork code does (CreateWorktree) so unit tests exercise the
+// same git invariants.
+func makeWorktree(t *testing.T, repoDir string) string {
+	t.Helper()
+	wtPath := repoDir + "-wt"
+	if err := CreateWorktree(repoDir, wtPath, "fork/test"); err != nil {
+		t.Fatalf("CreateWorktree failed: %v", err)
+	}
+	return wtPath
+}
+
+func TestMaterializeParentState_CleanParent(t *testing.T) {
+	parent := initRepo(t)
+	wt := makeWorktree(t, parent)
+	res, err := MaterializeParentState(parent, wt, StateCopyOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.TrackedFilesPatched != 0 || res.UntrackedFilesCopied != 0 || res.GitignoredFilesCopied != 0 {
+		t.Fatalf("clean parent produced non-zero result: %+v", res)
+	}
+	// New worktree must remain clean.
+	out := runGit(t, wt, "status", "--porcelain")
+	if out != "" {
+		t.Fatalf("new worktree dirty after materializing clean parent:\n%s", out)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestMaterializeParentState_CleanParent -v`
+Expected: FAIL — `undefined: MaterializeParentState` / `undefined: StateCopyOptions`.
+
+- [ ] **Step 3: Add the implementation scaffold**
+
+Append to `internal/git/worktree_with_state.go`:
+
+```go
+// StateCopyOptions controls what MaterializeParentState copies. Tracked
+// modifications (staged + unstaged) and untracked non-ignored files are
+// always copied. IncludeGitignored opts in to copying gitignored files too.
+type StateCopyOptions struct {
+	IncludeGitignored bool
+}
+
+// StateCopyResult reports the count of changes applied by
+// MaterializeParentState. Returned even on partial failure so callers can
+// include the count in error messages.
+type StateCopyResult struct {
+	TrackedFilesPatched   int
+	UntrackedFilesCopied  int
+	GitignoredFilesCopied int
+}
+
+// MaterializeParentState copies parent's working-tree state (staged diff,
+// unstaged diff, untracked files, and optionally gitignored files) into
+// newWorktree. Read-only on parentWorktree — does not mutate the parent's
+// index, working tree, or stash list.
+//
+// Caller is responsible for the worktree already existing at newWorktree
+// (typically via CreateWorktree branched off parent's HEAD). Caller is also
+// responsible for cleanup on error.
+func MaterializeParentState(parentWorktree, newWorktree string, opts StateCopyOptions) (*StateCopyResult, error) {
+	res := &StateCopyResult{}
+
+	// 1. Apply staged changes via `git apply --index`.
+	// `--index` updates both the index and working tree. A cached-only
+	// apply leaves partially-staged files at their base content in the
+	// working tree, causing the later unstaged patch to fail; it also
+	// leaves staged deletions present as untracked files.
+	stagedPatch, err := captureDiff(parentWorktree, true)
+	if err != nil {
+		return res, fmt.Errorf("capture staged diff: %w", err)
+	}
+	if len(stagedPatch) > 0 {
+		if err := applyPatch(newWorktree, stagedPatch, true); err != nil {
+			return res, fmt.Errorf("apply parent's staged changes: %w", err)
+		}
+		res.TrackedFilesPatched += countFilesInPatch(stagedPatch)
+	}
+
+	// 2. Apply unstaged changes via plain `git apply`.
+	unstagedPatch, err := captureDiff(parentWorktree, false)
+	if err != nil {
+		return res, fmt.Errorf("capture unstaged diff: %w", err)
+	}
+	if len(unstagedPatch) > 0 {
+		if err := applyPatch(newWorktree, unstagedPatch, false); err != nil {
+			return res, fmt.Errorf("apply parent's unstaged changes: %w", err)
+		}
+		res.TrackedFilesPatched += countFilesInPatch(unstagedPatch)
+	}
+
+	// 3. Copy untracked non-gitignored files.
+	n, err := copyUntracked(parentWorktree, newWorktree, false)
+	res.UntrackedFilesCopied = n
+	if err != nil {
+		return res, fmt.Errorf("copy untracked files: %w", err)
+	}
+
+	// 4. Optionally copy gitignored files.
+	if opts.IncludeGitignored {
+		n, err := copyUntracked(parentWorktree, newWorktree, true)
+		res.GitignoredFilesCopied = n
+		if err != nil {
+			return res, fmt.Errorf("copy gitignored files: %w", err)
+		}
+	}
+
+	return res, nil
+}
+
+// captureDiff returns the binary patch for parent's staged (if staged=true)
+// or unstaged changes. Empty patch means "no changes of that kind."
+func captureDiff(repoDir string, staged bool) ([]byte, error) {
+	args := []string{"-C", repoDir, "diff", "--binary"}
+	if staged {
+		args = append(args, "--cached")
+	}
+	cmd := exec.Command("git", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git diff (staged=%v): %s: %w", staged, strings.TrimSpace(stderr.String()), err)
+	}
+	return stdout.Bytes(), nil
+}
+
+// applyPatch applies a binary patch to repoDir. If staged=true, the patch is
+// applied with `git apply --index`, updating both the index and working tree
+// to the parent's staged state. Otherwise it applies to the working tree only.
+func applyPatch(repoDir string, patch []byte, staged bool) error {
+	args := []string{"-C", repoDir, "apply"}
+	if staged {
+		args = append(args, "--index")
+	}
+	cmd := exec.Command("git", args...)
+	cmd.Stdin = bytes.NewReader(patch)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git apply (staged=%v): %s: %w", staged, strings.TrimSpace(stderr.String()), err)
+	}
+	return nil
+}
+
+// copyUntracked enumerates parent's untracked files via `git ls-files
+// --others`. When gitignored=true, only files matched by .gitignore are
+// listed; otherwise only non-ignored untracked files are listed. Each file
+// is copied to newWorktree preserving mode bits and symlinks.
+func copyUntracked(parentWorktree, newWorktree string, gitignored bool) (int, error) {
+	args := []string{"-C", parentWorktree, "ls-files", "--others"}
+	if gitignored {
+		args = append(args, "--ignored", "--exclude-standard")
+	} else {
+		args = append(args, "--exclude-standard")
+	}
+	cmd := exec.Command("git", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return 0, fmt.Errorf("git ls-files (gitignored=%v): %s: %w", gitignored, strings.TrimSpace(stderr.String()), err)
+	}
+
+	count := 0
+	for _, rel := range strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n") {
+		if rel == "" {
+			continue
+		}
+		src := filepath.Join(parentWorktree, rel)
+		dst := filepath.Join(newWorktree, rel)
+		if err := copyFilePreservingMode(src, dst); err != nil {
+			return count, fmt.Errorf("copy %s: %w", rel, err)
+		}
+		count++
+	}
+	return count, nil
+}
+
+// copyFilePreservingMode copies a single file from src to dst. Symlinks are
+// recreated as symlinks (target preserved); regular files keep their
+// permission bits including the executable bit. Parent directories are
+// created as needed.
+func copyFilePreservingMode(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(src)
+		if err != nil {
+			return err
+		}
+		_ = os.Remove(dst)
+		return os.Symlink(target, dst)
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return os.Chmod(dst, info.Mode().Perm())
+}
+
+// countFilesInPatch counts `diff --git ` headers in a patch. Used for
+// reporting only — not for correctness.
+func countFilesInPatch(patch []byte) int {
+	n := 0
+	for _, line := range bytes.Split(patch, []byte{'\n'}) {
+		if bytes.HasPrefix(line, []byte("diff --git ")) {
+			n++
+		}
+	}
+	return n
+}
+```
+
+Add `"io"` to the file's import block alongside `bytes`, `errors`, `fmt`, `os`, `os/exec`, `path/filepath`, `strings`.
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestMaterializeParentState_CleanParent -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/git/worktree_with_state.go internal/git/worktree_with_state_test.go
+git commit -m "feat(git): MaterializeParentState scaffold + clean-parent case"
+```
+
+---
+
+## Task 6: MaterializeParentState — staged + unstaged + partial-staged (index fidelity)
+
+**Files:**
+- Modify: `internal/git/worktree_with_state_test.go`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `internal/git/worktree_with_state_test.go`:
+
+```go
+// writeFile is a test helper that writes content to dir/path, creating
+// parent directories as needed.
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMaterializeParentState_StagedOnly(t *testing.T) {
+	parent := initRepo(t)
+	writeFile(t, parent, "a.txt", "staged\n")
+	runGit(t, parent, "add", "a.txt")
+	// Note: a.txt is staged-new (not yet committed) — appears only in --cached diff.
+
+	wt := makeWorktree(t, parent)
+	if _, err := MaterializeParentState(parent, wt, StateCopyOptions{}); err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+	// New worktree's `git diff --cached` should match parent's.
+	gotCached := runGit(t, wt, "diff", "--cached")
+	wantCached := runGit(t, parent, "diff", "--cached")
+	if gotCached != wantCached {
+		t.Fatalf("staged diff mismatch:\nparent:\n%s\nnew:\n%s", wantCached, gotCached)
+	}
+}
+
+func TestMaterializeParentState_UnstagedOnly(t *testing.T) {
+	parent := initRepo(t)
+	writeFile(t, parent, "README.md", "modified\n")
+	// Modify a tracked file without staging.
+
+	wt := makeWorktree(t, parent)
+	if _, err := MaterializeParentState(parent, wt, StateCopyOptions{}); err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+	gotUnstaged := runGit(t, wt, "diff")
+	wantUnstaged := runGit(t, parent, "diff")
+	if gotUnstaged != wantUnstaged {
+		t.Fatalf("unstaged diff mismatch:\nparent:\n%s\nnew:\n%s", wantUnstaged, gotUnstaged)
+	}
+}
+
+func TestMaterializeParentState_PartiallyStaged(t *testing.T) {
+	parent := initRepo(t)
+	// Add a multi-line tracked file and commit it as baseline.
+	writeFile(t, parent, "data.txt", "line1\nline2\nline3\n")
+	runGit(t, parent, "add", "data.txt")
+	runGit(t, parent, "commit", "-m", "baseline")
+
+	// Stage one change, then add a second unstaged change to the same file.
+	writeFile(t, parent, "data.txt", "line1-staged\nline2\nline3\n")
+	runGit(t, parent, "add", "data.txt")
+	writeFile(t, parent, "data.txt", "line1-staged\nline2\nline3-unstaged\n")
+
+	wt := makeWorktree(t, parent)
+	if _, err := MaterializeParentState(parent, wt, StateCopyOptions{}); err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+
+	gotCached := runGit(t, wt, "diff", "--cached")
+	wantCached := runGit(t, parent, "diff", "--cached")
+	if gotCached != wantCached {
+		t.Fatalf("staged diff mismatch:\nparent:\n%s\nnew:\n%s", wantCached, gotCached)
+	}
+	gotUnstaged := runGit(t, wt, "diff")
+	wantUnstaged := runGit(t, parent, "diff")
+	if gotUnstaged != wantUnstaged {
+		t.Fatalf("unstaged diff mismatch:\nparent:\n%s\nnew:\n%s", wantUnstaged, gotUnstaged)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run "TestMaterializeParentState_(StagedOnly|UnstagedOnly|PartiallyStaged)" -v`
+Expected: PASS (3 subtests). Implementation from Task 5 already handles all three cases.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/git/worktree_with_state_test.go
+git commit -m "test(git): cover staged + unstaged + partial-staged materialize cases"
+```
+
+---
+
+## Task 7: MaterializeParentState — untracked + symlinks + exec bit
+
+**Files:**
+- Modify: `internal/git/worktree_with_state_test.go`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `internal/git/worktree_with_state_test.go`:
+
+```go
+func TestMaterializeParentState_Untracked(t *testing.T) {
+	parent := initRepo(t)
+	writeFile(t, parent, "new.txt", "new content\n")
+	writeFile(t, parent, "sub/nested.txt", "nested\n")
+
+	wt := makeWorktree(t, parent)
+	res, err := MaterializeParentState(parent, wt, StateCopyOptions{})
+	if err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+	if res.UntrackedFilesCopied != 2 {
+		t.Fatalf("expected 2 untracked copied, got %d", res.UntrackedFilesCopied)
+	}
+	for _, rel := range []string{"new.txt", "sub/nested.txt"} {
+		b, err := os.ReadFile(filepath.Join(wt, rel))
+		if err != nil {
+			t.Fatalf("missing %s in new worktree: %v", rel, err)
+		}
+		want, _ := os.ReadFile(filepath.Join(parent, rel))
+		if !bytes.Equal(b, want) {
+			t.Fatalf("contents mismatch for %s", rel)
+		}
+	}
+}
+
+func TestMaterializeParentState_PreservesExecBit(t *testing.T) {
+	parent := initRepo(t)
+	scriptPath := filepath.Join(parent, "run.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	wt := makeWorktree(t, parent)
+	if _, err := MaterializeParentState(parent, wt, StateCopyOptions{}); err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(wt, "run.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("exec bit not preserved: mode=%o", info.Mode().Perm())
+	}
+}
+
+func TestMaterializeParentState_Symlink(t *testing.T) {
+	parent := initRepo(t)
+	if err := os.Symlink("README.md", filepath.Join(parent, "link-to-readme")); err != nil {
+		t.Skipf("symlinks unsupported in this filesystem: %v", err)
+	}
+
+	wt := makeWorktree(t, parent)
+	if _, err := MaterializeParentState(parent, wt, StateCopyOptions{}); err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+	got, err := os.Readlink(filepath.Join(wt, "link-to-readme"))
+	if err != nil {
+		t.Fatalf("expected symlink in new worktree: %v", err)
+	}
+	if got != "README.md" {
+		t.Fatalf("symlink target mismatch: got %q want %q", got, "README.md")
+	}
+}
+```
+
+Also ensure `bytes` is in the file's import block.
+
+- [ ] **Step 2: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run "TestMaterializeParentState_(Untracked|PreservesExecBit|Symlink)" -v`
+Expected: PASS (3 subtests; Symlink may SKIP on filesystems without symlink support).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/git/worktree_with_state_test.go
+git commit -m "test(git): cover untracked + exec-bit + symlink materialize cases"
+```
+
+---
+
+## Task 8: MaterializeParentState — binary file modification
+
+**Files:**
+- Modify: `internal/git/worktree_with_state_test.go`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `internal/git/worktree_with_state_test.go`:
+
+```go
+func TestMaterializeParentState_BinaryFile(t *testing.T) {
+	parent := initRepo(t)
+	// Commit a baseline binary file.
+	bin1 := []byte{0x00, 0x01, 0x02, 0x03, 0xff, 0xfe}
+	if err := os.WriteFile(filepath.Join(parent, "img.bin"), bin1, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, parent, "add", "img.bin")
+	runGit(t, parent, "commit", "-m", "baseline binary")
+
+	// Modify the binary.
+	bin2 := []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01}
+	if err := os.WriteFile(filepath.Join(parent, "img.bin"), bin2, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wt := makeWorktree(t, parent)
+	if _, err := MaterializeParentState(parent, wt, StateCopyOptions{}); err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(wt, "img.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, bin2) {
+		t.Fatalf("binary content mismatch:\ngot:  %x\nwant: %x", got, bin2)
+	}
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestMaterializeParentState_BinaryFile -v`
+Expected: PASS. (`git diff --binary` produces binary deltas that `git apply` reconstructs exactly.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/git/worktree_with_state_test.go
+git commit -m "test(git): cover binary file materialize"
+```
+
+---
+
+## Task 9: MaterializeParentState — gitignored opt-in
+
+**Files:**
+- Modify: `internal/git/worktree_with_state_test.go`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `internal/git/worktree_with_state_test.go`:
+
+```go
+func TestMaterializeParentState_GitignoredExcludedByDefault(t *testing.T) {
+	parent := initRepo(t)
+	writeFile(t, parent, ".gitignore", "*.env\n")
+	runGit(t, parent, "add", ".gitignore")
+	runGit(t, parent, "commit", "-m", "gitignore")
+	writeFile(t, parent, "secret.env", "API_KEY=xyz\n")
+
+	wt := makeWorktree(t, parent)
+	if _, err := MaterializeParentState(parent, wt, StateCopyOptions{}); err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wt, "secret.env")); !os.IsNotExist(err) {
+		t.Fatalf("gitignored file was copied by default: err=%v", err)
+	}
+}
+
+func TestMaterializeParentState_GitignoredIncludedWhenOptedIn(t *testing.T) {
+	parent := initRepo(t)
+	writeFile(t, parent, ".gitignore", "*.env\n")
+	runGit(t, parent, "add", ".gitignore")
+	runGit(t, parent, "commit", "-m", "gitignore")
+	writeFile(t, parent, "secret.env", "API_KEY=xyz\n")
+
+	wt := makeWorktree(t, parent)
+	res, err := MaterializeParentState(parent, wt, StateCopyOptions{IncludeGitignored: true})
+	if err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+	if res.GitignoredFilesCopied != 1 {
+		t.Fatalf("expected 1 gitignored copied, got %d", res.GitignoredFilesCopied)
+	}
+	got, err := os.ReadFile(filepath.Join(wt, "secret.env"))
+	if err != nil {
+		t.Fatalf("expected gitignored file in new worktree: %v", err)
+	}
+	if string(got) != "API_KEY=xyz\n" {
+		t.Fatalf("gitignored content mismatch: %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run "TestMaterializeParentState_Gitignored" -v`
+Expected: PASS (2 subtests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/git/worktree_with_state_test.go
+git commit -m "test(git): cover gitignored exclude-by-default + opt-in"
+```
+
+---
+
+## Task 10: MaterializeParentState — parent-untouched invariant + staged deletion
+
+**Files:**
+- Modify: `internal/git/worktree_with_state_test.go`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `internal/git/worktree_with_state_test.go`:
+
+```go
+func TestMaterializeParentState_ParentUntouched(t *testing.T) {
+	parent := initRepo(t)
+	writeFile(t, parent, "tracked.txt", "tracked\n")
+	runGit(t, parent, "add", "tracked.txt")
+	runGit(t, parent, "commit", "-m", "tracked")
+	// Make a complex parent state: staged, unstaged, untracked.
+	writeFile(t, parent, "tracked.txt", "staged-edit\n")
+	runGit(t, parent, "add", "tracked.txt")
+	writeFile(t, parent, "tracked.txt", "staged-edit\nunstaged-more\n")
+	writeFile(t, parent, "new-untracked.txt", "untracked\n")
+
+	statusBefore := runGit(t, parent, "status", "--porcelain")
+	diffCachedBefore := runGit(t, parent, "diff", "--cached")
+	diffBefore := runGit(t, parent, "diff")
+	stashBefore := runGit(t, parent, "stash", "list")
+
+	wt := makeWorktree(t, parent)
+	if _, err := MaterializeParentState(parent, wt, StateCopyOptions{}); err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+
+	if got := runGit(t, parent, "status", "--porcelain"); got != statusBefore {
+		t.Fatalf("parent status changed:\nbefore:\n%s\nafter:\n%s", statusBefore, got)
+	}
+	if got := runGit(t, parent, "diff", "--cached"); got != diffCachedBefore {
+		t.Fatalf("parent staged diff changed")
+	}
+	if got := runGit(t, parent, "diff"); got != diffBefore {
+		t.Fatalf("parent unstaged diff changed")
+	}
+	if got := runGit(t, parent, "stash", "list"); got != stashBefore {
+		t.Fatalf("parent stash list changed:\nbefore:\n%s\nafter:\n%s", stashBefore, got)
+	}
+}
+
+func TestMaterializeParentState_StagedDeletion(t *testing.T) {
+	parent := initRepo(t)
+	writeFile(t, parent, "doomed.txt", "delete me\n")
+	runGit(t, parent, "add", "doomed.txt")
+	runGit(t, parent, "commit", "-m", "add doomed")
+	runGit(t, parent, "rm", "doomed.txt")
+	// doomed.txt is now staged-for-deletion in parent.
+
+	wt := makeWorktree(t, parent)
+	if _, err := MaterializeParentState(parent, wt, StateCopyOptions{}); err != nil {
+		t.Fatalf("materialize failed: %v", err)
+	}
+	gotCached := runGit(t, wt, "diff", "--cached")
+	wantCached := runGit(t, parent, "diff", "--cached")
+	if gotCached != wantCached {
+		t.Fatalf("staged deletion mismatch:\nparent:\n%s\nnew:\n%s", wantCached, gotCached)
+	}
+	if _, err := os.Stat(filepath.Join(wt, "doomed.txt")); !os.IsNotExist(err) {
+		t.Fatalf("doomed.txt should not exist in new worktree's working tree: err=%v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run "TestMaterializeParentState_(ParentUntouched|StagedDeletion)" -v`
+Expected: PASS (2 subtests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/git/worktree_with_state_test.go
+git commit -m "test(git): cover parent-untouched invariant + staged deletion"
+```
+
+---
+
+## Task 11: Run full git test suite
+
+- [ ] **Step 1: Race-checked full run**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/... -race -count=1`
+Expected: PASS — all existing and new tests green.
+
+- [ ] **Step 2: Commit (no-op unless something needs fixing)**
+
+If failures appear, fix them inline and re-run. No commit unless fixes were made.
+
+---
+
+## Task 12: CLI flag parsing + implication helper
+
+**Files:**
+- Modify: `cmd/agent-deck/session_cmd.go` (the `handleSessionFork` function and a new helper near it)
+- Create: `cmd/agent-deck/session_cmd_fork_state_test.go`
+
+The implication chain is unit-testable in isolation. We add a small pure-function helper and test it before wiring it into the handler.
+
+- [ ] **Step 1: Add failing tests**
+
+Create `cmd/agent-deck/session_cmd_fork_state_test.go`:
+
+```go
+package main
+
+import "testing"
+
+func TestResolveForkStateFlags_AllOff(t *testing.T) {
+	r := resolveForkStateFlags(false, false, "", false)
+	if r.WorktreeEnabled || r.WithState || r.IncludeGitignored {
+		t.Fatalf("all-off should yield all-false, got %+v", r)
+	}
+}
+
+func TestResolveForkStateFlags_GitignoredImpliesWithStateOnly(t *testing.T) {
+	r := resolveForkStateFlags(false, true, "", false)
+	if !r.WithState || !r.IncludeGitignored {
+		t.Fatalf("--with-state-and-gitignored should imply --with-state, got %+v", r)
+	}
+	if r.WorktreeEnabled || r.Branch != "" {
+		t.Fatalf("CLI should not auto-enable or auto-name worktree for gitignored-only flag, got %+v", r)
+	}
+}
+
+func TestResolveForkStateFlags_WithStateDoesNotAutoNameOrEnableWorktree(t *testing.T) {
+	r := resolveForkStateFlags(true, false, "", false)
+	if !r.WithState {
+		t.Fatalf("--with-state should be preserved, got %+v", r)
+	}
+	if r.WorktreeEnabled || r.Branch != "" {
+		t.Fatalf("CLI should not auto-enable or auto-name worktree for --with-state, got %+v", r)
+	}
+	if r.IncludeGitignored {
+		t.Fatalf("--with-state alone should not enable gitignored, got %+v", r)
+	}
+}
+
+func TestResolveForkStateFlags_ExplicitBranchPreserved(t *testing.T) {
+	r := resolveForkStateFlags(true, false, "my-branch", true)
+	if !r.WorktreeEnabled {
+		t.Fatalf("explicit -w should enable worktree, got %+v", r)
+	}
+	if r.Branch != "my-branch" {
+		t.Fatalf("explicit branch lost: %+v", r)
+	}
+}
+
+func TestResolveForkStateFlags_WorktreeOnlyNoStateNoGitignored(t *testing.T) {
+	r := resolveForkStateFlags(false, false, "feat", true)
+	if !r.WorktreeEnabled {
+		t.Fatalf("explicit -w should enable worktree, got %+v", r)
+	}
+	if r.WithState || r.IncludeGitignored {
+		t.Fatalf("-w alone should not enable state/gitignored, got %+v", r)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/ -run TestResolveForkStateFlags -v`
+Expected: FAIL — `undefined: resolveForkStateFlags`.
+
+- [ ] **Step 3: Add the helper in session_cmd.go**
+
+In `cmd/agent-deck/session_cmd.go`, add this helper just before `handleSessionFork` (around line 587):
+
+```go
+// forkStateFlags is the resolved fork-with-state configuration after
+// applying the CLI implication chain: --with-state-and-gitignored implies
+// --with-state. The CLI does not auto-enable or auto-name worktrees; callers
+// must reject --with-state unless -w/--worktree supplied an explicit branch.
+type forkStateFlags struct {
+	WorktreeEnabled   bool
+	WithState         bool
+	IncludeGitignored bool
+	Branch            string
+}
+
+// resolveForkStateFlags applies the implication chain. The branch name is
+// propagated unchanged. CLI callers must not auto-name; --with-state without
+// an explicit worktree branch is rejected in handleSessionFork.
+func resolveForkStateFlags(withState, gitignored bool, branch string, worktreeExplicit bool) forkStateFlags {
+	r := forkStateFlags{Branch: branch, WorktreeEnabled: worktreeExplicit}
+	if gitignored {
+		r.IncludeGitignored = true
+		r.WithState = true
+		return r
+	}
+	if withState {
+		r.WithState = true
+		return r
+	}
+	return r
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/ -run TestResolveForkStateFlags -v`
+Expected: PASS (5 subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/agent-deck/session_cmd.go cmd/agent-deck/session_cmd_fork_state_test.go
+git commit -m "feat(cli): resolveForkStateFlags helper for --with-state implication chain"
+```
+
+---
+
+## Task 12A: CLI contract tests for fork-with-state handler
+
+**Files:**
+- Modify: `cmd/agent-deck/session_cmd.go`
+- Modify: `cmd/agent-deck/session_cmd_fork_state_test.go`
+
+Task 14 below is git-side integration coverage. This task adds the missing real CLI/handler contract coverage so flag registration, refusal messages, destination validation, and option propagation cannot regress while helper tests stay green.
+
+- [ ] **Step 1: Add a test-only before-start hook**
+
+In `cmd/agent-deck/session_cmd.go`, near `handleSessionFork`, add:
+
+```go
+// sessionForkBeforeStartHook is nil in production. Tests use it to inspect the
+// fully prepared fork and options after CLI parsing/worktree preparation, but
+// before tmux Start() mutates the environment.
+var sessionForkBeforeStartHook func(parent *session.Instance, forked *session.Instance, opts *session.ClaudeOptions)
+```
+
+Then in `handleSessionFork`, after sandbox config is applied and immediately before `forkedInst.Start()`, add:
+
+```go
+	if sessionForkBeforeStartHook != nil {
+		sessionForkBeforeStartHook(inst, forkedInst, opts)
+		return
+	}
+```
+
+- [ ] **Step 2: Add CLI-contract helpers and tests**
+
+In `cmd/agent-deck/session_cmd_fork_state_test.go`, replace the single `testing` import with:
+
+```go
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+```
+
+Then append:
+
+```go
+const forkStateCLIProfile = "ch_support_test"
+
+func seedForkableCLISession(t *testing.T, home, title string) string {
+	t.Helper()
+	t.Setenv("HOME", home)
+
+	repo := filepath.Join(home, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-b", "main")
+	runGit("config", "user.email", "t@t")
+	runGit("config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "README.md")
+	runGit("commit", "-m", "init")
+
+	storage, err := session.NewStorageWithProfile(forkStateCLIProfile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+
+	inst := session.NewInstance(title, repo)
+	inst.Tool = "claude"
+	inst.ClaudeSessionID = "parent-session-id"
+	inst.ClaudeDetectedAt = time.Now()
+	if err := storage.SaveWithGroups([]*session.Instance{inst}, nil); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+	return repo
+}
+
+func TestSessionFork_WithStateRequiresExplicitDestinationBranch(t *testing.T) {
+	home := t.TempDir()
+	seedForkableCLISession(t, home, "parent")
+
+	stdout, stderr, code := runAgentDeck(t, home, "session", "fork", "parent", "--with-state")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	if !strings.Contains(stderr+stdout, "--with-state requires --worktree <new-branch>") {
+		t.Fatalf("missing explicit-branch error\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+}
+
+func TestSessionFork_WithStateAndGitignoredRequiresExplicitDestinationBranch(t *testing.T) {
+	home := t.TempDir()
+	seedForkableCLISession(t, home, "parent")
+
+	stdout, stderr, code := runAgentDeck(t, home, "session", "fork", "parent", "--with-state-and-gitignored")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	if !strings.Contains(stderr+stdout, "--with-state requires --worktree <new-branch>") {
+		t.Fatalf("missing explicit-branch error\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+}
+
+func TestSessionFork_WithState_RejectsExistingDestinationBranch(t *testing.T) {
+	home := t.TempDir()
+	repo := seedForkableCLISession(t, home, "parent")
+	if out, err := exec.Command("git", "-C", repo, "branch", "fork/existing").CombinedOutput(); err != nil {
+		t.Fatalf("create branch: %v\n%s", err, out)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home, "session", "fork", "parent", "--with-state", "-w", "fork/existing")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	if !strings.Contains(stderr+stdout, "branch 'fork/existing' already exists") {
+		t.Fatalf("missing existing-branch error\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+}
+
+func TestSessionFork_WithState_RejectsExistingDestinationWorktree(t *testing.T) {
+	home := t.TempDir()
+	repo := seedForkableCLISession(t, home, "parent")
+	existingWT := filepath.Join(home, "existing-wt")
+	if out, err := exec.Command("git", "-C", repo, "worktree", "add", "-b", "fork/used", existingWT).CombinedOutput(); err != nil {
+		t.Fatalf("create worktree: %v\n%s", err, out)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home, "session", "fork", "parent", "--with-state", "-w", "fork/used")
+	if code == 0 {
+		t.Fatalf("expected non-zero exit\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	if !strings.Contains(stderr+stdout, "branch 'fork/used' already has a worktree") {
+		t.Fatalf("missing existing-worktree error\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+}
+
+func TestSessionFork_WithStateAndGitignored_PropagatesOptionsBeforeStart(t *testing.T) {
+	home := t.TempDir()
+	seedForkableCLISession(t, home, "parent")
+
+	var captured *session.ClaudeOptions
+	oldHook := sessionForkBeforeStartHook
+	sessionForkBeforeStartHook = func(_ *session.Instance, _ *session.Instance, opts *session.ClaudeOptions) {
+		copied := *opts
+		captured = &copied
+	}
+	t.Cleanup(func() { sessionForkBeforeStartHook = oldHook })
+
+	handleSessionFork(forkStateCLIProfile, []string{"parent", "--with-state-and-gitignored", "-w", "fork/with-env"})
+
+	if captured == nil {
+		t.Fatal("before-start hook did not capture options")
+	}
+	if !captured.WithState || !captured.IncludeGitignored {
+		t.Fatalf("state flags not propagated: %+v", captured)
+	}
+	if captured.WorktreeBranch != "fork/with-env" || captured.WorktreePath == "" {
+		t.Fatalf("worktree destination not propagated: %+v", captured)
+	}
+}
+```
+
+- [ ] **Step 3: Run the CLI refusal tests and confirm they fail before Task 13**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/ -run "TestSessionFork_WithState(RequiresExplicitDestinationBranch|AndGitignoredRequiresExplicitDestinationBranch|_RejectsExistingDestination(Branch|Worktree))" -v
+```
+
+Expected before Task 13: FAIL, proving the current CLI does not yet provide the new contract. After Task 13, the same command must pass.
+
+---
+
+## Task 13: CLI fork handler — wire new flags, sequence Create→Materialize→Setup with cleanup
+
+**Files:**
+- Modify: `cmd/agent-deck/session_cmd.go:587-799` (the `handleSessionFork` function)
+
+- [ ] **Step 1: Add the new flags to the flagset**
+
+In `handleSessionFork`, after the existing flag declarations (around line 602, just after `sandboxImage`), add:
+
+```go
+	withState := fs.Bool("with-state", false, "Carry parent's tracked + staged + untracked state into a new worktree. Requires --worktree <new-branch>.")
+	withStateAndGitignored := fs.Bool("with-state-and-gitignored", false, "Also copy gitignored files. Implies --with-state.")
+```
+
+Also extend the `fs.Usage` example block (around line 612-617) by adding two lines after the existing examples:
+
+```go
+		fmt.Println("  agent-deck session fork my-project --with-state -w fork/my-project-wip")
+		fmt.Println("  agent-deck session fork my-project --with-state-and-gitignored -w fork/my-fork-with-env -t \"my-fork-with-env\"")
+```
+
+- [ ] **Step 2: Apply the implication chain after parsing**
+
+Inside `handleSessionFork`, just after the existing `wtBranch` and `createNewBranch` resolution block (around line 684-688), insert:
+
+```go
+	// Apply implication chain: --with-state-and-gitignored → --with-state.
+	// The CLI does not auto-name the destination branch. Users must provide
+	// -w/--worktree <new-branch>; the TUI is the surface that suggests names.
+	stateFlags := resolveForkStateFlags(*withState, *withStateAndGitignored, wtBranch, wtBranch != "")
+	if stateFlags.WithState && wtBranch == "" {
+		out.Error("--with-state requires --worktree <new-branch>", ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+	// Fork-with-state uses CreateWorktreeAtStartPoint, which always creates the
+	// branch and returns createdBranch as proof for cleanup. The legacy
+	// createNewBranch intent flag is not consulted on the with-state path; the
+	// branch-existence guard below is unreachable from this branch.
+```
+
+No new import is required for this step.
+
+- [ ] **Step 3: Add destination validation and shared pre-flight refusal of in-progress operations**
+
+Add `errors` to the imports in `cmd/agent-deck/session_cmd.go`. Inside the `if wtBranch != "" { ... }` block, after `repoRoot` is resolved and after `wtBranch = wtSettings.ApplyBranchPrefix(wtBranch)`, replace the existing branch-existence validation with:
+
+```go
+		parentHead := ""
+		if stateFlags.WithState {
+			if err := git.ValidateForkWithStateDestination(repoRoot, wtBranch); err != nil {
+				var collErr *git.DestinationCollisionError
+				if errors.As(err, &collErr) {
+					switch collErr.Kind {
+					case "worktree_exists":
+						out.Error(fmt.Sprintf("branch '%s' already has a worktree at %s; choose a new destination branch for --with-state", collErr.Branch, collErr.Path), ErrCodeInvalidOperation)
+					case "branch_exists":
+						out.Error(fmt.Sprintf("branch '%s' already exists; choose a new destination branch for --with-state", collErr.Branch), ErrCodeInvalidOperation)
+					default:
+						out.Error(collErr.Error(), ErrCodeInvalidOperation)
+					}
+					os.Exit(1)
+				}
+				out.Error(fmt.Sprintf("failed to validate destination: %v", err), ErrCodeInvalidOperation)
+				os.Exit(1)
+			}
+			preflight, err := git.PreflightForkWithState(inst.ProjectPath)
+			if err != nil {
+				var opErr *git.InProgressOperationError
+				if errors.As(err, &opErr) {
+					hint := ""
+					switch opErr.Kind {
+					case "rebase":
+						hint = fmt.Sprintf("finish or abort the rebase before forking with state (cd %s && git rebase --abort)", inst.ProjectPath)
+					case "merge":
+						hint = "resolve or abort the merge before forking with state"
+					case "cherry-pick":
+						hint = "finish or abort the cherry-pick before forking with state"
+					case "bisect":
+						hint = fmt.Sprintf("run 'git bisect reset' in %s before forking with state", inst.ProjectPath)
+					}
+					out.Error(fmt.Sprintf("parent session is mid-%s; %s", opErr.Kind, hint), ErrCodeInvalidOperation)
+					os.Exit(1)
+				}
+				out.Error(fmt.Sprintf("failed to inspect parent's git state: %v", err), ErrCodeInvalidOperation)
+				os.Exit(1)
+			}
+			if preflight.HasSubmodules {
+				fmt.Fprintln(os.Stderr, "Warning: submodules detected — copied as files, not recursed (parent's submodule states preserved)")
+			}
+			parentHead = preflight.ParentHead
+		} else if !createNewBranch && !git.BranchExists(repoRoot, wtBranch) {
+			out.Error(fmt.Sprintf("branch '%s' does not exist (use -b to create)", wtBranch), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+```
+
+Leave the existing-worktree reuse block (today's `session_cmd.go:720-743`) **unchanged**. With-state cannot reach it because `ValidateForkWithStateDestination` already refused above; for non-with-state, today's reuse behavior is preserved exactly. No edits to that block in this step.
+
+- [ ] **Step 4: Replace the CreateWorktreeWithSetup call with Create → Materialize → Setup**
+
+In the same `if wtBranch != "" { ... }` block, find the existing call to `git.CreateWorktreeWithSetup` (around line 735) and the warning print on line 740-742. Replace those lines with:
+
+```go
+			var createErr error
+			createdBranch := false
+			if stateFlags.WithState {
+				createdBranch, createErr = git.CreateWorktreeAtStartPoint(repoRoot, worktreePath, wtBranch, parentHead)
+			} else {
+				createErr = git.CreateWorktree(repoRoot, worktreePath, wtBranch)
+			}
+			if createErr != nil {
+				out.Error(fmt.Sprintf("worktree creation failed: %v", createErr), ErrCodeInvalidOperation)
+				os.Exit(1)
+			}
+
+			if stateFlags.WithState {
+				_, materializeErr := git.MaterializeParentState(
+					inst.ProjectPath,
+					worktreePath,
+					git.StateCopyOptions{IncludeGitignored: stateFlags.IncludeGitignored},
+				)
+				if materializeErr != nil {
+					// Cleanup: remove the half-baked worktree. Delete the branch only
+					// when creation returned proof that this operation created it.
+					_ = exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", worktreePath).Run()
+					if createdBranch {
+						_ = exec.Command("git", "-C", repoRoot, "branch", "-D", wtBranch).Run()
+					}
+					out.Error(fmt.Sprintf("failed to materialize parent state: %v; new worktree cleaned up", materializeErr), ErrCodeInvalidOperation)
+					os.Exit(1)
+				}
+			}
+
+			setupErr := git.RunWorktreeSetup(repoRoot, worktreePath, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+			if setupErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: worktree setup script failed: %v\n", setupErr)
+			}
+```
+
+Make sure `"os/exec"` is in the imports at the top of `cmd/agent-deck/session_cmd.go`. If not, add it.
+
+- [ ] **Step 5: Propagate WithState and IncludeGitignored to ClaudeOptions**
+
+In the same block, find where `opts` is set (around line 745-750) and add the two new fields at the end:
+
+```go
+			opts = session.NewClaudeOptions(userConfig)
+			opts.WorkDir = worktreePath
+			opts.WorktreePath = worktreePath
+			opts.WorktreeRepoRoot = repoRoot
+			opts.WorktreeBranch = wtBranch
+			opts.WithState = stateFlags.WithState
+			opts.IncludeGitignored = stateFlags.IncludeGitignored
+```
+
+- [ ] **Step 6: Verify the package compiles**
+
+Run: `GOTOOLCHAIN=go1.24.0 go build ./cmd/agent-deck/...`
+Expected: exits 0, no output.
+
+- [ ] **Step 7: Run CLI contract tests and existing fork tests**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/ -run "TestSessionFork_WithState(RequiresExplicitDestinationBranch|AndGitignoredRequiresExplicitDestinationBranch|_RejectsExistingDestination(Branch|Worktree)|AndGitignored_PropagatesOptionsBeforeStart)" -race -count=1
+GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/ -run "Fork|fork" -race -count=1
+```
+
+Expected: PASS — Task 12A's CLI contract tests now pass and existing fork tests remain green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/agent-deck/session_cmd.go cmd/agent-deck/session_cmd_fork_state_test.go
+git commit -m "feat(cli): wire --with-state[-and-gitignored] flags through fork handler with cleanup"
+```
+
+---
+
+## Task 14: Git-side integration tests — materialization sequence for fork-with-state
+
+**Files:**
+- Create: `internal/git/worktree_with_state_integration_test.go`
+
+The real CLI/handler contract is covered in Task 12A and Task 13. This task covers the *git-side* end-to-end behavior: simulate the sequence of git calls the handler makes (`CreateWorktreeAtStartPoint → MaterializeParentState → RunWorktreeSetup`) against a real repo and verify the resulting worktree contents.
+
+This follows the existing `internal/git/setup_progress_test.go`, `internal/git/setup_test.go`, and `internal/git/bare_repo_test.go` pattern: direct git-helper integration lives in `internal/git`, while `cmd/agent-deck/session_cmd_fork_state_test.go` stays focused on CLI/handler contract tests.
+
+- [ ] **Step 1: Add the failing git-side integration tests**
+
+Create `internal/git/worktree_with_state_integration_test.go`:
+
+```go
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// integrationFork sets up a parent repo with mixed state, then runs the
+// same git sequence the CLI handler runs: CreateWorktreeAtStartPoint →
+// MaterializeParentState → RunWorktreeSetup. Returns the worktree path so
+// the test can assert on it.
+func integrationFork(t *testing.T, gitignored bool) (parent, worktree string) {
+	t.Helper()
+	parent = t.TempDir()
+	runShell := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = parent
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	runShell("git", "init", "-b", "main")
+	runShell("git", "config", "user.email", "t@t")
+	runShell("git", "config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(parent, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runShell("git", "add", "README.md")
+	runShell("git", "commit", "-m", "init")
+	// Dirty state: tracked edit + untracked + gitignored.
+	if err := os.WriteFile(filepath.Join(parent, "README.md"), []byte("edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "new.txt"), []byte("untracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, ".gitignore"), []byte("*.env\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runShell("git", "add", ".gitignore")
+	runShell("git", "commit", "-m", "gi")
+	if err := os.WriteFile(filepath.Join(parent, "secret.env"), []byte("KEY=1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	worktree = parent + "-wt"
+	parentHead, err := HeadCommit(parent)
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+	if createdBranch, err := CreateWorktreeAtStartPoint(parent, worktree, "fork/test", parentHead); err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	} else if !createdBranch {
+		t.Fatal("CreateWorktreeAtStartPoint returned createdBranch=false")
+	}
+	if _, err := MaterializeParentState(parent, worktree, StateCopyOptions{IncludeGitignored: gitignored}); err != nil {
+		t.Fatalf("MaterializeParentState: %v", err)
+	}
+	if err := RunWorktreeSetup(parent, worktree, os.Stdout, os.Stderr, 0); err != nil {
+		t.Fatalf("RunWorktreeSetup: %v", err)
+	}
+	return parent, worktree
+}
+
+func TestForkWithStateGitSequence_DirtyParent(t *testing.T) {
+	_, wt := integrationFork(t, false)
+
+	got, err := os.ReadFile(filepath.Join(wt, "README.md"))
+	if err != nil || string(got) != "edited\n" {
+		t.Fatalf("tracked edit not materialized: %q err=%v", got, err)
+	}
+	got, err = os.ReadFile(filepath.Join(wt, "new.txt"))
+	if err != nil || string(got) != "untracked\n" {
+		t.Fatalf("untracked not materialized: %q err=%v", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(wt, "secret.env")); !os.IsNotExist(err) {
+		t.Fatalf("gitignored file leaked without opt-in: err=%v", err)
+	}
+}
+
+func TestForkWithStateGitSequence_CleanParent(t *testing.T) {
+	parent := t.TempDir()
+	runShell := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = parent
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	runShell("git", "init", "-b", "main")
+	runShell("git", "config", "user.email", "t@t")
+	runShell("git", "config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(parent, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runShell("git", "add", "README.md")
+	runShell("git", "commit", "-m", "init")
+
+	worktree := parent + "-clean-wt"
+	parentHead, err := HeadCommit(parent)
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+	if _, err := CreateWorktreeAtStartPoint(parent, worktree, "fork/clean", parentHead); err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	}
+	if _, err := MaterializeParentState(parent, worktree, StateCopyOptions{}); err != nil {
+		t.Fatalf("MaterializeParentState: %v", err)
+	}
+	out, err := exec.Command("git", "-C", worktree, "status", "--short").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git status: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("clean parent produced dirty fork:\n%s", out)
+	}
+}
+
+func TestForkWithStateGitSequence_WithGitignored(t *testing.T) {
+	_, wt := integrationFork(t, true)
+	got, err := os.ReadFile(filepath.Join(wt, "secret.env"))
+	if err != nil {
+		t.Fatalf("gitignored file missing: %v", err)
+	}
+	if string(got) != "KEY=1\n" {
+		t.Fatalf("gitignored content mismatch: %q", got)
+	}
+}
+
+func TestForkWithStateGitSequence_CleansUpOnMaterializeFailure(t *testing.T) {
+	parent := t.TempDir()
+	runShell := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = parent
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	runShell("git", "init", "-b", "main")
+	runShell("git", "config", "user.email", "t@t")
+	runShell("git", "config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(parent, "f.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runShell("git", "add", "f.txt")
+	runShell("git", "commit", "-m", "init")
+
+	worktree := parent + "-wt"
+	parentHead, err := HeadCommit(parent)
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+	createdBranch, err := CreateWorktreeAtStartPoint(parent, worktree, "fork/test", parentHead)
+	if err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	}
+	// Force a materialize failure: corrupt parent's git dir so `git diff` errors.
+	// Replace the parent's HEAD ref with garbage.
+	if err := os.WriteFile(filepath.Join(parent, ".git", "HEAD"), []byte("garbage\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MaterializeParentState(parent, worktree, StateCopyOptions{}); err == nil {
+		t.Fatal("expected MaterializeParentState to fail with corrupt parent HEAD")
+	}
+	// Simulate the handler's cleanup: remove the worktree and branch.
+	_ = exec.Command("git", "-C", parent, "worktree", "remove", "--force", worktree).Run()
+	if createdBranch {
+		_ = exec.Command("git", "-C", parent, "branch", "-D", "fork/test").Run()
+	}
+
+	if _, err := os.Stat(worktree); !os.IsNotExist(err) {
+		t.Fatalf("worktree directory not cleaned up: err=%v", err)
+	}
+	branches := func() string {
+		out, _ := exec.Command("git", "-C", parent, "branch").CombinedOutput()
+		return string(out)
+	}()
+	if strings.Contains(branches, "fork/test") {
+		t.Fatalf("branch fork/test not cleaned up:\n%s", branches)
+	}
+}
+
+func TestForkWithStateGitSequence_FailsWhenMidRebase(t *testing.T) {
+	parent := t.TempDir()
+	runShell := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = parent
+		_, _ = cmd.CombinedOutput()
+	}
+	mustShell := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = parent
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	mustShell("git", "init", "-b", "main")
+	mustShell("git", "config", "user.email", "t@t")
+	mustShell("git", "config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(parent, "f.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustShell("git", "add", "f.txt")
+	mustShell("git", "commit", "-m", "init")
+	mustShell("git", "checkout", "-b", "side")
+	if err := os.WriteFile(filepath.Join(parent, "f.txt"), []byte("side\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustShell("git", "commit", "-am", "s")
+	mustShell("git", "checkout", "main")
+	if err := os.WriteFile(filepath.Join(parent, "f.txt"), []byte("main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustShell("git", "commit", "-am", "m")
+	runShell("git", "rebase", "side") // expected to conflict
+
+	op, err := DetectInProgressOperation(parent)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if op != "rebase" {
+		t.Fatalf("expected mid-rebase, got %q", op)
+	}
+	worktree := parent + "-rebase-wt"
+	if _, err := os.Stat(worktree); !os.IsNotExist(err) {
+		t.Fatalf("mid-rebase path should not create worktree, stat err=%v", err)
+	}
+}
+
+func TestForkWithStateGitSequence_UsesParentWorktreeHead(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runIn := func(dir string, args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s %v: %v\n%s", dir, args, err, out)
+		}
+	}
+	outputIn := func(dir string, args ...string) string {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s %v: %v\n%s", dir, args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	runIn(base, "git", "init", "-b", "main")
+	runIn(base, "git", "config", "user.email", "t@t")
+	runIn(base, "git", "config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(base, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runIn(base, "git", "add", "README.md")
+	runIn(base, "git", "commit", "-m", "base")
+
+	parentWT := filepath.Join(root, "parent-wt")
+	if err := CreateWorktree(base, parentWT, "parent-branch"); err != nil {
+		t.Fatalf("CreateWorktree parent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(parentWT, "README.md"), []byte("parent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runIn(parentWT, "git", "commit", "-am", "parent")
+
+	baseHead := outputIn(base, "git", "rev-parse", "HEAD")
+	parentHead, err := HeadCommit(parentWT)
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+	if parentHead == baseHead {
+		t.Fatal("setup invalid: parent and base HEAD should differ")
+	}
+
+	forkWT := filepath.Join(root, "fork-wt")
+	if createdBranch, err := CreateWorktreeAtStartPoint(base, forkWT, "fork/from-parent", parentHead); err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	} else if !createdBranch {
+		t.Fatal("CreateWorktreeAtStartPoint returned createdBranch=false")
+	}
+	forkHead := outputIn(forkWT, "git", "rev-parse", "HEAD")
+	if forkHead != parentHead {
+		t.Fatalf("fork HEAD = %s, want parent HEAD %s (base HEAD %s)", forkHead, parentHead, baseHead)
+	}
+}
+
+func TestForkWithStateGitSequence_BareRepoLayoutLinkedParentWorktree(t *testing.T) {
+	root := t.TempDir()
+	bareDir := filepath.Join(root, ".bare")
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "--bare", "-b", "main", bareDir)
+
+	seed := filepath.Join(root, "seed")
+	run("clone", bareDir, seed)
+	runIn := func(dir string, args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s %v: %v\n%s", dir, args, err, out)
+		}
+	}
+	runIn(seed, "git", "config", "user.email", "t@t")
+	runIn(seed, "git", "config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runIn(seed, "git", "add", "README.md")
+	runIn(seed, "git", "commit", "-m", "init")
+	runIn(seed, "git", "push", "origin", "main")
+
+	// The bare repo/project root is metadata only. Fork-with-state still
+	// materializes from a checked-out parent worktree because that is where
+	// staged, unstaged, and untracked state exists.
+	parentWT := filepath.Join(root, "parent-wt")
+	run("-C", bareDir, "worktree", "add", parentWT, "main")
+	if err := os.WriteFile(filepath.Join(parentWT, "wip.txt"), []byte("bare-layout-wip\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repoRoot, err := GetWorktreeBaseRoot(root)
+	if err != nil {
+		t.Fatalf("GetWorktreeBaseRoot: %v", err)
+	}
+	parentHead, err := HeadCommit(parentWT)
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+	forkWT := filepath.Join(root, "fork-wt")
+	if _, err := CreateWorktreeAtStartPoint(repoRoot, forkWT, "fork/bare", parentHead); err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	}
+	if _, err := MaterializeParentState(parentWT, forkWT, StateCopyOptions{}); err != nil {
+		t.Fatalf("MaterializeParentState: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(forkWT, "wip.txt"))
+	if err != nil || string(got) != "bare-layout-wip\n" {
+		t.Fatalf("bare-layout WIP not materialized: %q err=%v", got, err)
+	}
+}
+
+func TestForkWithStateGitSequence_MaterializesBeforeSetupHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell setup hook test uses /bin/sh")
+	}
+	parent := t.TempDir()
+	runShell := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = parent
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	runShell("git", "init", "-b", "main")
+	runShell("git", "config", "user.email", "t@t")
+	runShell("git", "config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(parent, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runShell("git", "add", "README.md")
+	runShell("git", "commit", "-m", "init")
+
+	scriptDir := filepath.Join(parent, ".agent-deck")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	observed := filepath.Join(parent, "setup-observed.txt")
+	script := fmt.Sprintf("#!/bin/sh\npwd > %q\ncat wip.txt >> %q\n", observed, observed)
+	if err := os.WriteFile(filepath.Join(scriptDir, "worktree-setup.sh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "wip.txt"), []byte("from-parent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	worktree := parent + "-setup-wt"
+	parentHead, err := HeadCommit(parent)
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+	if _, err := CreateWorktreeAtStartPoint(parent, worktree, "fork/setup", parentHead); err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	}
+	if _, err := MaterializeParentState(parent, worktree, StateCopyOptions{}); err != nil {
+		t.Fatalf("MaterializeParentState: %v", err)
+	}
+	if err := RunWorktreeSetup(parent, worktree, os.Stdout, os.Stderr, 0); err != nil {
+		t.Fatalf("RunWorktreeSetup: %v", err)
+	}
+	got, err := os.ReadFile(observed)
+	if err != nil {
+		t.Fatalf("setup output missing: %v", err)
+	}
+	if !strings.HasPrefix(string(got), worktree+"\n") || !strings.Contains(string(got), "from-parent\n") {
+		t.Fatalf("setup did not run in materialized worktree, got:\n%s", got)
+	}
+}
+
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run "TestForkWithStateGitSequence" -race -count=1 -v`
+Expected: PASS (8 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/git/worktree_with_state_integration_test.go
+git commit -m "test(git): cover fork-with-state materialization sequence"
+```
+
+---
+
+## Task 15: TUI — add WithState and IncludeGitignored fields + checkbox rendering
+
+**Files:**
+- Modify: `internal/ui/forkdialog.go`
+
+- [ ] **Step 1: Add fields to the ForkDialog struct**
+
+In `internal/ui/forkdialog.go`, find the `ForkDialog` struct definition (around line 17-40) and add two fields just after `sandboxEnabled bool`:
+
+```go
+	// State-carrying support for fork-with-state
+	withStateEnabled       bool
+	withStateAndGitignored bool
+```
+
+- [ ] **Step 2: Add exported getters**
+
+First update the existing `ToggleWorktree` method so turning worktree mode off also clears the nested fork-with-state flags:
+
+```go
+// ToggleWorktree toggles the worktree checkbox.
+func (d *ForkDialog) ToggleWorktree() {
+	d.worktreeEnabled = !d.worktreeEnabled
+	if !d.worktreeEnabled {
+		d.withStateEnabled = false
+		d.withStateAndGitignored = false
+	}
+}
+```
+
+After the existing `IsSandboxEnabled` and `ToggleSandbox` methods (around line 202-209), add:
+
+```go
+// IsWithStateEnabled returns whether fork-with-state mode is enabled.
+func (d *ForkDialog) IsWithStateEnabled() bool {
+	return d.withStateEnabled
+}
+
+// ToggleWithState toggles fork-with-state mode. Has no effect unless the
+// worktree checkbox is on (the surface only exposes this when worktree is on).
+func (d *ForkDialog) ToggleWithState() {
+	if !d.worktreeEnabled {
+		return
+	}
+	d.withStateEnabled = !d.withStateEnabled
+	if !d.withStateEnabled {
+		// Turning off with-state also turns off its nested gitignored opt-in.
+		d.withStateAndGitignored = false
+	}
+}
+
+// IsWithStateAndGitignoredEnabled returns whether the gitignored opt-in
+// is enabled.
+func (d *ForkDialog) IsWithStateAndGitignoredEnabled() bool {
+	return d.withStateAndGitignored
+}
+
+// ToggleWithStateAndGitignored toggles the gitignored sub-option. Has no
+// effect unless with-state is already on.
+func (d *ForkDialog) ToggleWithStateAndGitignored() {
+	if !d.withStateEnabled {
+		return
+	}
+	d.withStateAndGitignored = !d.withStateAndGitignored
+}
+```
+
+- [ ] **Step 3: Reset fields in Show() and Hide()**
+
+In the `Show` method (around line 97), after the existing `d.sandboxEnabled = false` line, add:
+
+```go
+	d.withStateEnabled = false
+	d.withStateAndGitignored = false
+```
+
+- [ ] **Step 4: Render the new checkboxes inside the worktree section**
+
+In the `View` method, find the worktree-section rendering block (around line 568-582). After the existing branch input rendering, before the closing brace of `if d.worktreeEnabled {`, add:
+
+```go
+			// With-state nested checkbox.
+			withStateCb := "[ ]"
+			if d.withStateEnabled {
+				withStateCb = "[x]"
+			}
+			worktreeSection += "\n  " + checkboxStyle.Render(fmt.Sprintf("%s Carry parent state (press y)", withStateCb)) + "\n"
+
+			// Gitignored sub-checkbox, only when with-state is on.
+			if d.withStateEnabled {
+				gitignoredCb := "[ ]"
+				if d.withStateAndGitignored {
+					gitignoredCb = "[x]"
+				}
+				worktreeSection += "    " + checkboxStyle.Render(fmt.Sprintf("%s Include gitignored files (press i)", gitignoredCb)) + "\n"
+			}
+```
+
+- [ ] **Step 5: Wire the `y` and `i` key handlers**
+
+In the `Update` method's `switch msg.String()` block (around line 397, after the existing `"s"` case), add:
+
+```go
+		case "y":
+			// Toggle with-state when worktree is on.
+			if d.worktreeEnabled {
+				d.ToggleWithState()
+				return d, nil
+			}
+
+		case "i":
+			// Toggle gitignored sub-option when with-state is on.
+			if d.worktreeEnabled && d.withStateEnabled {
+				d.ToggleWithStateAndGitignored()
+				return d, nil
+			}
+```
+
+- [ ] **Step 6: Verify the package compiles**
+
+Run: `GOTOOLCHAIN=go1.24.0 go build ./internal/ui/...`
+Expected: exits 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/ui/forkdialog.go
+git commit -m "feat(tui): add fork-with-state sub-checkboxes to ForkDialog"
+```
+
+---
+
+## Task 15A: TUI — make fork-with-state controls real focus targets
+
+**Files:**
+- Modify: `internal/ui/forkdialog.go`
+
+`NewDialog` already uses an explicit ordered `focusTargets` slice for dynamic focusable UI. Apply that same pattern to `ForkDialog` instead of extending the current numeric `focusIndex` special cases. The resulting focus order must match the spec:
+
+- Git repo, worktree off: name -> group -> worktree -> conductor -> options
+- Git repo, worktree on, with-state off: name -> group -> worktree -> branch -> with-state -> conductor -> options
+- Git repo, worktree on, with-state on: name -> group -> worktree -> branch -> with-state -> gitignored -> conductor -> options
+- Non-git repo: name -> group -> conductor -> options
+
+- [ ] **Step 1: Add explicit fork focus targets**
+
+Near the `ForkDialog` struct, add:
+
+```go
+type forkFocusTarget int
+
+const (
+	forkFocusName forkFocusTarget = iota
+	forkFocusGroup
+	forkFocusWorktree
+	forkFocusBranch
+	forkFocusWithState
+	forkFocusGitignored
+	forkFocusConductor
+	forkFocusOptions
+)
+```
+
+Then update the focus fields on `ForkDialog`:
+
+```go
+	focusTargets []forkFocusTarget
+	focusIndex   int // Index into focusTargets.
+```
+
+- [ ] **Step 2: Replace numeric focus helpers with target helpers**
+
+Remove `conductorFocusIndex()` and `optionsStartIndex()`. Add these helpers, modeled after `NewDialog`:
+
+```go
+func (d *ForkDialog) currentTarget() forkFocusTarget {
+	if d.focusIndex < 0 || d.focusIndex >= len(d.focusTargets) {
+		return forkFocusName
+	}
+	return d.focusTargets[d.focusIndex]
+}
+
+func (d *ForkDialog) indexOf(target forkFocusTarget) int {
+	for i, t := range d.focusTargets {
+		if t == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func (d *ForkDialog) rebuildFocusTargets() {
+	targets := []forkFocusTarget{forkFocusName, forkFocusGroup}
+	if d.isGitRepo {
+		targets = append(targets, forkFocusWorktree)
+		if d.worktreeEnabled {
+			targets = append(targets, forkFocusBranch, forkFocusWithState)
+			if d.withStateEnabled {
+				targets = append(targets, forkFocusGitignored)
+			}
+		}
+	}
+	if d.hasConductors() {
+		targets = append(targets, forkFocusConductor)
+	}
+	targets = append(targets, forkFocusOptions)
+	d.focusTargets = targets
+	if d.focusIndex >= len(d.focusTargets) {
+		d.focusIndex = len(d.focusTargets) - 1
+	}
+	if d.focusIndex < 0 {
+		d.focusIndex = 0
+	}
+}
+```
+
+- [ ] **Step 3: Rebuild focus targets when conditional controls change**
+
+At the end of `Show`, after config defaults and conductor setup are applied, rebuild focus targets and refocus the name input:
+
+```go
+	d.rebuildFocusTargets()
+	d.focusIndex = d.indexOf(forkFocusName)
+	d.updateFocus()
+```
+
+Update the state toggles from Task 15 so they rebuild dynamic targets:
+
+```go
+func (d *ForkDialog) ToggleWorktree() {
+	d.worktreeEnabled = !d.worktreeEnabled
+	if !d.worktreeEnabled {
+		d.withStateEnabled = false
+		d.withStateAndGitignored = false
+	}
+	d.rebuildFocusTargets()
+}
+
+func (d *ForkDialog) ToggleWithState() {
+	if !d.worktreeEnabled {
+		return
+	}
+	d.withStateEnabled = !d.withStateEnabled
+	if !d.withStateEnabled {
+		d.withStateAndGitignored = false
+	}
+	d.rebuildFocusTargets()
+}
+```
+
+- [ ] **Step 4: Update navigation and focused-input dispatch**
+
+In `Update`, replace `optStart := d.optionsStartIndex()` and the numeric tab/up/down branch-skipping logic with target-based navigation:
+
+```go
+	cur := d.currentTarget()
+	switch msg.String() {
+	case "tab", "down":
+		if msg.String() == "down" && cur == forkFocusConductor {
+			if d.conductorCursor < len(d.conductorSessions) {
+				d.conductorCursor++
+				return d, nil
+			}
+		}
+		if cur == forkFocusOptions {
+			return d, d.optionsPanel.Update(msg)
+		}
+		if d.focusIndex < len(d.focusTargets)-1 {
+			d.focusIndex++
+			d.updateFocus()
+		}
+		return d, nil
+
+	case "shift+tab", "up":
+		if msg.String() == "up" && cur == forkFocusConductor {
+			if d.conductorCursor > 0 {
+				d.conductorCursor--
+				return d, nil
+			}
+		}
+		if cur == forkFocusOptions && !d.optionsPanel.AtTop() {
+			return d, d.optionsPanel.Update(msg)
+		}
+		if d.focusIndex > 0 {
+			d.focusIndex--
+			d.updateFocus()
+		}
+		return d, nil
+```
+
+Update the control handlers so text fields keep receiving normal letters:
+
+```go
+	case "w":
+		if cur == forkFocusWorktree {
+			d.ToggleWorktree()
+			if d.worktreeEnabled {
+				d.focusIndex = d.indexOf(forkFocusBranch)
+			}
+			d.updateFocus()
+			return d, nil
+		}
+
+	case "ctrl+f":
+		if cur == forkFocusBranch && d.worktreeEnabled {
+			// Existing branch picker code stays here.
+		}
+
+	case "y":
+		if cur == forkFocusWithState {
+			d.ToggleWithState()
+			d.updateFocus()
+			return d, nil
+		}
+
+	case "i":
+		if cur == forkFocusGitignored {
+			d.ToggleWithStateAndGitignored()
+			return d, nil
+		}
+
+	case " ", "left", "right":
+		switch cur {
+		case forkFocusWorktree:
+			d.ToggleWorktree()
+			if d.worktreeEnabled {
+				d.focusIndex = d.indexOf(forkFocusBranch)
+			}
+			d.updateFocus()
+			return d, nil
+		case forkFocusWithState:
+			d.ToggleWithState()
+			d.updateFocus()
+			return d, nil
+		case forkFocusGitignored:
+			d.ToggleWithStateAndGitignored()
+			return d, nil
+		case forkFocusOptions:
+			return d, d.optionsPanel.Update(msg)
+		}
+```
+
+Finally, update the focused input dispatch:
+
+```go
+	switch d.currentTarget() {
+	case forkFocusName:
+		d.nameInput, cmd = d.nameInput.Update(msg)
+	case forkFocusGroup:
+		d.groupInput, cmd = d.groupInput.Update(msg)
+	case forkFocusBranch:
+		oldBranch := d.branchInput.Value()
+		d.branchInput, cmd = d.branchInput.Update(msg)
+		if d.branchInput.Value() != oldBranch && d.branchPicker != nil && d.branchPicker.IsVisible() {
+			d.branchPicker.SetQuery(d.branchInput.Value())
+		}
+	case forkFocusOptions:
+		cmd = d.optionsPanel.Update(msg)
+	}
+```
+
+- [ ] **Step 5: Update focus application and active rendering**
+
+Replace `updateFocus()` with target-based focus:
+
+```go
+func (d *ForkDialog) updateFocus() {
+	d.nameInput.Blur()
+	d.groupInput.Blur()
+	d.branchInput.Blur()
+	d.optionsPanel.Blur()
+
+	switch d.currentTarget() {
+	case forkFocusName:
+		d.nameInput.Focus()
+	case forkFocusGroup:
+		d.groupInput.Focus()
+	case forkFocusBranch:
+		d.branchInput.Focus()
+	case forkFocusOptions:
+		d.optionsPanel.Focus()
+	}
+}
+```
+
+In `View`, drive active checkbox styling from `currentTarget()`:
+
+```go
+	cur := d.currentTarget()
+...
+	if cur == forkFocusWorktree {
+		worktreeSection += checkboxActiveStyle.Render(fmt.Sprintf("  %s Create in worktree (press w)", checkbox))
+	} else {
+		worktreeSection += checkboxStyle.Render(fmt.Sprintf("  %s Create in worktree", checkbox))
+	}
+...
+	if cur == forkFocusBranch {
+		worktreeSection += activeLabelStyle.Render("▶ Branch:")
+	} else {
+		worktreeSection += labelStyle.Render("  Branch:")
+	}
+...
+	withStateStyle := checkboxStyle
+	withStateLabel := "Carry parent state"
+	if cur == forkFocusWithState {
+		withStateStyle = checkboxActiveStyle
+		withStateLabel += " (press y)"
+	}
+	worktreeSection += "\n  " + withStateStyle.Render(fmt.Sprintf("%s %s", withStateCb, withStateLabel)) + "\n"
+```
+
+Use the same pattern for `forkFocusGitignored`, appending `(press i)` only when that target is focused.
+
+- [ ] **Step 6: Verify and commit**
+
+Run: `GOTOOLCHAIN=go1.24.0 go build ./internal/ui/...`
+Expected: exits 0.
+
+```bash
+git add internal/ui/forkdialog.go
+git commit -m "refactor(tui): make ForkDialog focus order target-based"
+```
+
+---
+
+## Task 16: TUI test — checkbox visibility, toggling, and focus order
+
+**Files:**
+- Modify: `internal/ui/forkdialog_test.go`
+
+- [ ] **Step 1: Add failing tests**
+
+Add `reflect` to the imports in `internal/ui/forkdialog_test.go`, then append:
+
+```go
+func TestForkDialog_WithStateCheckbox_DefaultsOff(t *testing.T) {
+	d := NewForkDialog()
+	d.Show("parent-session", t.TempDir(), "", nil, "")
+	if d.IsWithStateEnabled() {
+		t.Fatal("with-state should default to off")
+	}
+	if d.IsWithStateAndGitignoredEnabled() {
+		t.Fatal("with-state-gitignored should default to off")
+	}
+}
+
+func TestForkDialog_ToggleWithState(t *testing.T) {
+	d := NewForkDialog()
+	d.Show("parent-session", t.TempDir(), "", nil, "")
+	d.ToggleWorktree()
+	d.ToggleWithState()
+	if !d.IsWithStateEnabled() {
+		t.Fatal("ToggleWithState did not enable")
+	}
+	d.ToggleWithState()
+	if d.IsWithStateEnabled() {
+		t.Fatal("ToggleWithState did not disable on second call")
+	}
+}
+
+func TestForkDialog_ToggleWithStateRequiresWorktree(t *testing.T) {
+	d := NewForkDialog()
+	d.Show("parent-session", t.TempDir(), "", nil, "")
+	d.ToggleWithState()
+	if d.IsWithStateEnabled() {
+		t.Fatal("ToggleWithState should be a no-op while worktree is off")
+	}
+}
+
+func TestForkDialog_GitignoredRequiresWithState(t *testing.T) {
+	d := NewForkDialog()
+	d.Show("parent-session", t.TempDir(), "", nil, "")
+	// Without with-state enabled, gitignored toggle is a no-op.
+	d.ToggleWithStateAndGitignored()
+	if d.IsWithStateAndGitignoredEnabled() {
+		t.Fatal("gitignored toggled without with-state on")
+	}
+	// With with-state on, it toggles.
+	d.ToggleWorktree()
+	d.ToggleWithState()
+	d.ToggleWithStateAndGitignored()
+	if !d.IsWithStateAndGitignoredEnabled() {
+		t.Fatal("gitignored did not toggle with with-state on")
+	}
+}
+
+func TestForkDialog_TogglingWithStateOffClearsGitignored(t *testing.T) {
+	d := NewForkDialog()
+	d.Show("parent-session", t.TempDir(), "", nil, "")
+	d.ToggleWorktree()
+	d.ToggleWithState()
+	d.ToggleWithStateAndGitignored()
+	if !d.IsWithStateAndGitignoredEnabled() {
+		t.Fatal("setup: gitignored should be on")
+	}
+	d.ToggleWithState() // turn off
+	if d.IsWithStateAndGitignoredEnabled() {
+		t.Fatal("turning off with-state should also clear gitignored")
+	}
+}
+
+func TestForkDialog_TogglingWorktreeOffClearsWithState(t *testing.T) {
+	d := NewForkDialog()
+	d.Show("parent-session", t.TempDir(), "", nil, "")
+	d.ToggleWorktree()
+	d.ToggleWithState()
+	d.ToggleWithStateAndGitignored()
+
+	d.ToggleWorktree() // turn worktree off
+	if d.IsWithStateEnabled() {
+		t.Fatal("turning off worktree should clear with-state")
+	}
+	if d.IsWithStateAndGitignoredEnabled() {
+		t.Fatal("turning off worktree should clear gitignored")
+	}
+}
+
+func TestForkDialog_WithStateSuggestsEditableDestinationBranch(t *testing.T) {
+	d := NewForkDialog()
+	d.Show("Parent Session", t.TempDir(), "", nil, "")
+	_, _, branch, _ := d.GetValuesWithWorktree()
+	if branch != "fork/parent-session" {
+		t.Fatalf("suggested destination branch = %q, want fork/parent-session", branch)
+	}
+}
+
+func TestForkDialog_FocusOrder(t *testing.T) {
+	conductors := []*session.Instance{{
+		ID:          "conductor-1",
+		Title:       "conductor-main",
+		ProjectPath: "/tmp/main",
+	}}
+
+	d := NewForkDialog()
+	d.Show("parent-session", t.TempDir(), "", conductors, "")
+
+	// Avoid a filesystem git fixture here; this is a structural focus-target
+	// test, and Show already covers git repository detection separately.
+	d.isGitRepo = true
+	d.worktreeEnabled = false
+	d.rebuildFocusTargets()
+	assertForkFocusTargets(t, d, []forkFocusTarget{
+		forkFocusName,
+		forkFocusGroup,
+		forkFocusWorktree,
+		forkFocusConductor,
+		forkFocusOptions,
+	})
+
+	d.ToggleWorktree()
+	assertForkFocusTargets(t, d, []forkFocusTarget{
+		forkFocusName,
+		forkFocusGroup,
+		forkFocusWorktree,
+		forkFocusBranch,
+		forkFocusWithState,
+		forkFocusConductor,
+		forkFocusOptions,
+	})
+
+	d.ToggleWithState()
+	assertForkFocusTargets(t, d, []forkFocusTarget{
+		forkFocusName,
+		forkFocusGroup,
+		forkFocusWorktree,
+		forkFocusBranch,
+		forkFocusWithState,
+		forkFocusGitignored,
+		forkFocusConductor,
+		forkFocusOptions,
+	})
+
+	d.isGitRepo = false
+	d.rebuildFocusTargets()
+	assertForkFocusTargets(t, d, []forkFocusTarget{
+		forkFocusName,
+		forkFocusGroup,
+		forkFocusConductor,
+		forkFocusOptions,
+	})
+}
+
+func assertForkFocusTargets(t *testing.T, d *ForkDialog, want []forkFocusTarget) {
+	t.Helper()
+	if !reflect.DeepEqual(d.focusTargets, want) {
+		t.Fatalf("focusTargets = %#v, want %#v", d.focusTargets, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/ui/ -run "TestForkDialog_(WithState|ToggleWithState|GitignoredRequires|Toggling|FocusOrder)" -race -count=1 -v`
+Expected: PASS (8 tests; method names match Task 15 and Task 15A helpers).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/ui/forkdialog_test.go
+git commit -m "test(tui): cover with-state checkbox visibility + toggling"
+```
+
+---
+
+## Task 17: TUI — submit handler propagates to ClaudeOptions
+
+**Files:**
+- Modify: `internal/ui/home.go` (the place where the fork dialog's submit creates `opts`)
+- Create: `internal/ui/home_fork_state_test.go` (structural guard for the submit path)
+
+The TUI submit path is in `internal/ui/home.go`. We need to copy the dialog's new bool getters into the `ClaudeOptions` it builds.
+
+The fork dialog already suggests an editable destination branch (`fork/<sanitized-session>`) in the visible branch input. That suggestion is TUI-only; the CLI must not auto-name. Regardless of whether the user accepts or edits the suggestion, fork-with-state treats the submitted branch as a new destination branch from the parent session's HEAD.
+
+- [ ] **Step 1: Locate the fork submit path**
+
+Run: `grep -n "ForkDialog\|forkDialog\|GetOptions\|WorktreePath = " internal/ui/home.go | head -30`
+
+Find the block where, after the fork dialog returns Enter, the code constructs a `*session.ClaudeOptions` for the new instance. Look for the surrounding context that sets `opts.WorktreePath`, `opts.WorktreeBranch`, and similar — the same place needs `opts.WithState` and `opts.IncludeGitignored`.
+
+- [ ] **Step 2: Add the two assignments where the fork-submit handler builds `opts`**
+
+Run: `grep -n "forkDialog\|ForkDialog\|opts.WorktreePath\s*=" internal/ui/home.go | head -20`
+
+Find the spot where the fork-submit path constructs `opts *session.ClaudeOptions` and sets `opts.WorktreePath = ...` / `opts.WorktreeBranch = ...`. Immediately after those assignments, append:
+
+```go
+opts.WithState = m.forkDialog.IsWithStateEnabled()
+opts.IncludeGitignored = m.forkDialog.IsWithStateAndGitignoredEnabled()
+```
+
+If the surrounding code uses a different receiver name for the dialog (e.g., `m.fork` or just `forkDialog`), use that — grep output from Step 2 tells you which.
+
+- [ ] **Step 3: In the same submit handler, use the shared preflight helper and sequence Create→Materialize→Setup**
+
+In `internal/ui/home.go`, add `errors` to the imports. Before the existing-worktree reuse block, gate fork-with-state with the shared destination validator:
+
+```go
+						if opts.WithState {
+							if err := git.ValidateForkWithStateDestination(opts.WorktreeRepoRoot, opts.WorktreeBranch); err != nil {
+								var collErr *git.DestinationCollisionError
+								if errors.As(err, &collErr) {
+									switch collErr.Kind {
+									case "worktree_exists":
+										return sessionForkedMsg{err: fmt.Errorf("branch %q already has a worktree at %s; choose a new destination branch for --with-state", collErr.Branch, collErr.Path), sourceID: sourceID}
+									case "branch_exists":
+										return sessionForkedMsg{err: fmt.Errorf("branch %q already exists; choose a new destination branch for --with-state", collErr.Branch), sourceID: sourceID}
+									default:
+										return sessionForkedMsg{err: collErr, sourceID: sourceID}
+									}
+								}
+								return sessionForkedMsg{err: fmt.Errorf("failed to validate destination: %w", err), sourceID: sourceID}
+							}
+						}
+```
+
+Leave the existing-worktree reuse block (today's `home.go:8499-8514`) **unchanged**. With-state cannot reach it because `ValidateForkWithStateDestination` already refused above; for non-with-state, today's reuse behavior is preserved exactly.
+
+Then add this local presentation helper near `forkSessionCmdWithOptions`:
+
+```go
+func forkWithStateOperationHint(kind, repoPath string) string {
+	switch kind {
+	case "rebase":
+		return fmt.Sprintf("finish or abort the rebase before forking with state (cd %s && git rebase --abort)", repoPath)
+	case "merge":
+		return "resolve or abort the merge before forking with state"
+	case "cherry-pick":
+		return "finish or abort the cherry-pick before forking with state"
+	case "bisect":
+		return fmt.Sprintf("run 'git bisect reset' in %s before forking with state", repoPath)
+	default:
+		return "finish or abort the in-progress git operation before forking with state"
+	}
+}
+```
+
+Then replace lines 8506-8513 (the `var setupBuf bytes.Buffer ... if setupErr != nil { ... }` block). The surrounding code uses `source` for the parent `*session.Instance`, `opts` for the new `*session.ClaudeOptions`, and returns `sessionForkedMsg{err: ..., sourceID: sourceID}` on failure.
+
+```go
+				var setupBuf bytes.Buffer
+				var createErr error
+				createdBranch := false
+				if opts.WithState {
+					preflight, preflightErr := git.PreflightForkWithState(source.ProjectPath)
+					if preflightErr != nil {
+						var opErr *git.InProgressOperationError
+						if errors.As(preflightErr, &opErr) {
+							return sessionForkedMsg{err: fmt.Errorf("parent session is mid-%s; %s", opErr.Kind, forkWithStateOperationHint(opErr.Kind, source.ProjectPath)), sourceID: sourceID}
+						}
+						return sessionForkedMsg{err: fmt.Errorf("failed to inspect parent's git state: %w", preflightErr), sourceID: sourceID}
+					}
+					if preflight.HasSubmodules {
+						uiLog.Warn("fork_with_state_submodules_detected", slog.String("source_path", source.ProjectPath), slog.String("message", "submodules detected; copied as files, not recursed"))
+					}
+					createdBranch, createErr = git.CreateWorktreeAtStartPoint(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch, preflight.ParentHead)
+				} else {
+					createErr = git.CreateWorktree(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
+				}
+				if createErr != nil {
+					return sessionForkedMsg{err: fmt.Errorf("worktree creation failed: %w", createErr), sourceID: sourceID}
+				}
+				if opts.WithState {
+					if _, mErr := git.MaterializeParentState(
+						source.ProjectPath,
+						opts.WorktreePath,
+						git.StateCopyOptions{IncludeGitignored: opts.IncludeGitignored},
+					); mErr != nil {
+						_ = exec.Command("git", "-C", opts.WorktreeRepoRoot, "worktree", "remove", "--force", opts.WorktreePath).Run()
+						if createdBranch {
+							_ = exec.Command("git", "-C", opts.WorktreeRepoRoot, "branch", "-D", opts.WorktreeBranch).Run()
+						}
+						return sessionForkedMsg{err: fmt.Errorf("failed to materialize parent state: %w; new worktree cleaned up", mErr), sourceID: sourceID}
+					}
+				}
+				setupErr := git.RunWorktreeSetup(opts.WorktreeRepoRoot, opts.WorktreePath, &setupBuf, &setupBuf, session.GetWorktreeSettings().SetupTimeout())
+				if setupErr != nil {
+					uiLog.Warn("worktree_setup_script_failed", slog.String("error", setupErr.Error()), slog.String("output", setupBuf.String()))
+				}
+```
+
+Also ensure `"os/exec"` is in the imports at the top of `internal/ui/home.go`. The other imports (`fmt`, `bytes`, `slog`, etc.) are already present.
+
+- [ ] **Step 4: Add a structural guard for the TUI submit path**
+
+Create `internal/ui/home_fork_state_test.go`:
+
+```go
+package ui
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func extractHomeFuncBody(src, fnName string) string {
+	re := regexp.MustCompile(`(?m)^func\s+\(h \*Home\)\s+` + regexp.QuoteMeta(fnName) + `\s*\(`)
+	loc := re.FindStringIndex(src)
+	if loc == nil {
+		return ""
+	}
+	i := loc[1]
+	for i < len(src) && src[i] != '{' {
+		i++
+	}
+	if i == len(src) {
+		return ""
+	}
+	start := i + 1
+	depth := 1
+	for j := start; j < len(src); j++ {
+		switch src[j] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[start:j]
+			}
+		}
+	}
+	return ""
+}
+
+func TestForkSessionCmdWithOptions_WithStateUsesSharedPreflight(t *testing.T) {
+	data, err := os.ReadFile("home.go")
+	if err != nil {
+		t.Fatalf("read home.go: %v", err)
+	}
+	body := extractHomeFuncBody(string(data), "forkSessionCmdWithOptions")
+	if body == "" {
+		t.Fatal("forkSessionCmdWithOptions body not found")
+	}
+
+	preflight := strings.Index(body, "git.PreflightForkWithState(source.ProjectPath)")
+	create := strings.Index(body, "git.CreateWorktreeAtStartPoint(")
+	if preflight == -1 {
+		t.Fatal("TUI fork-with-state path must call git.PreflightForkWithState(source.ProjectPath)")
+	}
+	if create == -1 {
+		t.Fatal("TUI fork-with-state path must call git.CreateWorktreeAtStartPoint")
+	}
+	if preflight > create {
+		t.Fatal("TUI fork-with-state preflight must run before CreateWorktreeAtStartPoint")
+	}
+	if strings.Contains(body, "git.DetectInProgressOperation(source.ProjectPath)") ||
+		strings.Contains(body, "git.HasSubmodules(source.ProjectPath)") {
+		t.Fatal("TUI path should use shared PreflightForkWithState, not duplicate lower-level preflight calls")
+	}
+}
+```
+
+- [ ] **Step 5: Verify the package compiles**
+
+Run: `GOTOOLCHAIN=go1.24.0 go build ./internal/ui/...`
+Expected: exits 0.
+
+- [ ] **Step 6: Run TUI tests to confirm no regression**
+
+Run: `GOTOOLCHAIN=go1.24.0 go test ./internal/ui/... -run "ForkDialog_(WithState|ToggleWithState|GitignoredRequires|Toggling|FocusOrder)|ForkSessionCmdWithOptions_WithStateUsesSharedPreflight" -race -count=1`
+Expected: PASS — no test regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/ui/home.go internal/ui/home_fork_state_test.go
+git commit -m "feat(tui): wire fork-with-state through submit handler with cleanup"
+```
+
+---
+
+## Task 17A: Behavioral eval smoke coverage for fork-with-state
+
+**Files:**
+- Create: `tests/eval/session/fork_with_state_test.go`
+- Create: `internal/ui/forkdialog_eval_test.go`
+
+This task satisfies the existing evaluator-harness mandate for user-observable behavior. The unit, handler, and structural tests above are still required, but they do not prove the real binary and rendered TUI interaction behave the way a user sees them.
+
+- [ ] **Step 1: Add a real-binary CLI eval**
+
+Create `tests/eval/session/fork_with_state_test.go`:
+
+```go
+//go:build eval_smoke
+
+package session_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	decksession "github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/tests/eval/harness"
+)
+
+func TestEval_SessionForkWithState_CreatesMaterializedWorktree(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not on PATH")
+	}
+
+	sb := harness.NewSandbox(t)
+	sb.InstallTmuxShim(t)
+	installEvalClaudeShim(t, sb)
+
+	parent := initForkStateEvalRepo(t, sb.Home)
+	seedForkableClaudeSession(t, sb, "parent", parent)
+
+	cwdFile := filepath.Join(sb.Home, "claude-cwd.txt")
+	out, err := runBinWithEnv(sb, []string{"AGENTDECK_EVAL_CLAUDE_CWD=" + cwdFile},
+		"session", "fork", "parent",
+		"--with-state-and-gitignored",
+		"-w", "fork/eval-state",
+		"-t", "forked",
+	)
+	if err != nil {
+		t.Fatalf("session fork --with-state-and-gitignored failed: %v\n%s", err, out)
+	}
+
+	dest := worktreeForBranch(t, parent, "fork/eval-state")
+	assertFile(t, filepath.Join(dest, "untracked.txt"), "untracked parent\n")
+	assertFile(t, filepath.Join(dest, "ignored.txt"), "ignored parent\n")
+
+	if got := runGitOut(t, dest, "diff", "--cached", "--name-only"); !strings.Contains(got, "staged.txt") {
+		t.Fatalf("destination missing staged diff for staged.txt; git diff --cached --name-only:\n%s", got)
+	}
+	if got := runGitOut(t, dest, "diff", "--name-only"); !strings.Contains(got, "unstaged.txt") {
+		t.Fatalf("destination missing unstaged diff for unstaged.txt; git diff --name-only:\n%s", got)
+	}
+	if got := waitForFile(t, cwdFile, 5*time.Second); strings.TrimSpace(got) != dest {
+		t.Fatalf("forked claude started in cwd %q, want destination worktree %q", strings.TrimSpace(got), dest)
+	}
+}
+
+func initForkStateEvalRepo(t *testing.T, root string) string {
+	t.Helper()
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "init", "-b", "main")
+	runGit(t, repo, "config", "user.email", "eval@example.com")
+	runGit(t, repo, "config", "user.name", "Eval")
+	writeFile(t, filepath.Join(repo, ".gitignore"), "ignored.txt\n")
+	writeFile(t, filepath.Join(repo, "staged.txt"), "base staged\n")
+	writeFile(t, filepath.Join(repo, "unstaged.txt"), "base unstaged\n")
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "base")
+
+	writeFile(t, filepath.Join(repo, "staged.txt"), "staged parent\n")
+	runGit(t, repo, "add", "staged.txt")
+	writeFile(t, filepath.Join(repo, "unstaged.txt"), "unstaged parent\n")
+	writeFile(t, filepath.Join(repo, "untracked.txt"), "untracked parent\n")
+	writeFile(t, filepath.Join(repo, "ignored.txt"), "ignored parent\n")
+	return repo
+}
+
+func seedForkableClaudeSession(t *testing.T, sb *harness.Sandbox, title, projectPath string) {
+	t.Helper()
+	t.Setenv("HOME", sb.Home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(sb.Home, ".config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(sb.Home, ".local", "state"))
+
+	storage, err := decksession.NewStorageWithProfile("")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+
+	inst := decksession.NewInstanceWithGroupAndTool(title, projectPath, decksession.DefaultGroupPath, "claude")
+	inst.Command = "claude"
+	inst.ClaudeSessionID = "parent-eval-session"
+	inst.Status = decksession.StatusStopped
+	instances := []*decksession.Instance{inst}
+	if err := storage.SaveWithGroups(instances, decksession.NewGroupTree(instances)); err != nil {
+		t.Fatalf("seed storage: %v", err)
+	}
+}
+
+func installEvalClaudeShim(t *testing.T, sb *harness.Sandbox) {
+	t.Helper()
+	shim := filepath.Join(sb.ShimDir, "claude")
+	script := `#!/usr/bin/env bash
+printf '%s\n' "$PWD" > "$AGENTDECK_EVAL_CLAUDE_CWD"
+sleep 30
+`
+	if err := os.WriteFile(shim, []byte(script), 0o755); err != nil {
+		t.Fatalf("write claude shim: %v", err)
+	}
+}
+
+func runBinWithEnv(sb *harness.Sandbox, extraEnv []string, args ...string) (string, error) {
+	cmd := exec.Command(sb.BinPath, args...)
+	cmd.Env = append(sb.Env(), extraEnv...)
+	cmd.Dir = sb.Home
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s failed: %v\n%s", args, dir, err, out)
+	}
+}
+
+func runGitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s failed: %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+func worktreeForBranch(t *testing.T, repo, branch string) string {
+	t.Helper()
+	out := runGitOut(t, repo, "worktree", "list", "--porcelain")
+	var current string
+	for _, line := range strings.Split(out, "\n") {
+		if path, ok := strings.CutPrefix(line, "worktree "); ok {
+			current = path
+		}
+		if b, ok := strings.CutPrefix(line, "branch refs/heads/"); ok && b == branch {
+			return current
+		}
+	}
+	t.Fatalf("branch %q not found in git worktree list:\n%s", branch, out)
+	return ""
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func assertFile(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("%s = %q, want %q", path, got, want)
+	}
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			return string(data)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+	return ""
+}
+```
+
+- [ ] **Step 2: Add a colocated TUI eval**
+
+Create `internal/ui/forkdialog_eval_test.go`:
+
+```go
+//go:build eval_smoke
+
+package ui
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestEval_ForkDialog_WithStateVisibleInteraction(t *testing.T) {
+	repo := t.TempDir()
+	runForkDialogEvalGit(t, repo, "init", "-b", "main")
+
+	d := NewForkDialog()
+	d.SetSize(80, 24)
+	d.Show("parent session", repo, "", nil, "")
+
+	if got := stripForkDialogEvalANSI(d.View()); strings.Contains(got, "Carry parent state") {
+		t.Fatalf("with-state control visible before worktree toggle:\n%s", got)
+	}
+
+	sendForkDialogEvalKey(t, d, 'w')
+	if !d.IsWorktreeEnabled() {
+		t.Fatal("pressing w should enable worktree mode")
+	}
+	if got := stripForkDialogEvalANSI(d.View()); !strings.Contains(got, "Carry parent state") {
+		t.Fatalf("with-state control missing after worktree toggle:\n%s", got)
+	}
+
+	sendForkDialogEvalKey(t, d, 'y')
+	if !d.IsWithStateEnabled() {
+		t.Fatal("pressing y should enable carry-parent-state")
+	}
+	if got := stripForkDialogEvalANSI(d.View()); !strings.Contains(got, "Include gitignored files") {
+		t.Fatalf("gitignored control missing after with-state toggle:\n%s", got)
+	}
+
+	sendForkDialogEvalKey(t, d, 'i')
+	if !d.IsWithStateAndGitignoredEnabled() {
+		t.Fatal("pressing i should enable include-gitignored")
+	}
+}
+
+func sendForkDialogEvalKey(t *testing.T, d *ForkDialog, r rune) {
+	t.Helper()
+	_, _ = d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+}
+
+func runForkDialogEvalGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func stripForkDialogEvalANSI(s string) string {
+	var out strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b && i+1 < len(s) {
+			switch s[i+1] {
+			case '[':
+				j := i + 2
+				for j < len(s) && !((s[j] >= 'A' && s[j] <= 'Z') || (s[j] >= 'a' && s[j] <= 'z')) {
+					j++
+				}
+				i = j
+				continue
+			case ']':
+				j := i + 2
+				for j < len(s) && s[j] != 0x07 && !(s[j] == 0x1b && j+1 < len(s) && s[j+1] == '\\') {
+					j++
+				}
+				if j < len(s) && s[j] == 0x1b {
+					j++
+				}
+				i = j
+				continue
+			}
+		}
+		out.WriteByte(s[i])
+	}
+	return out.String()
+}
+```
+
+- [ ] **Step 3: Run the targeted eval smoke tests**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.24.0 go test -tags eval_smoke ./tests/eval/session/... ./internal/ui/... -run "TestEval_SessionForkWithState|TestEval_ForkDialog_WithState" -race -count=1 -v
+```
+
+Expected: PASS. The CLI eval may take a few seconds because it builds the real binary and starts an isolated tmux-backed fork with a fake `claude` shim.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/eval/session/fork_with_state_test.go internal/ui/forkdialog_eval_test.go
+git commit -m "test(eval): cover fork-with-state user-visible flows"
+```
+
+---
+
+## Task 18: Verify the mandate lives in the tracked spec (no CLAUDE.md edit)
+
+**Files:**
+- Verify: `docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md` (`## Mandatory test coverage` section)
+
+Per CONTRIBUTING.md (and PR #1002), `CLAUDE.md` is intentionally untracked and per-developer. The mandate is housed in the tracked spec instead — `## Mandatory test coverage` section. This task is a verification step that the section is current and the regexes haven't drifted from the actual test names.
+
+- [ ] **Step 1: Verify the spec section exists and is current**
+
+Run:
+
+```bash
+grep -A2 "^## Mandatory test coverage" docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md | head
+```
+
+Expected: shows the heading and the first lines of the section.
+
+- [ ] **Step 2: Verify the regexes match the actual test names**
+
+Run (after Tasks 2-17 have landed their tests):
+
+```bash
+go test ./internal/git/... -run "Materialize|DetectInProgress|HasSubmodules|PreflightForkWithState|ValidateForkWithStateDestination|CreateWorktreeAtStartPoint|HeadCommit|ForkWithStateGitSequence" -race -count=1
+go test ./cmd/agent-deck/... -run "SessionFork_WithState|ResolveForkStateFlags" -race -count=1
+go test ./internal/ui/... -run "ForkDialog_(WithState|ToggleWithState|GitignoredRequires|Toggling|FocusOrder)|ForkSessionCmdWithOptions_WithStateUsesSharedPreflight" -race -count=1
+go test -tags eval_smoke ./tests/eval/session/... ./internal/ui/... -run "TestEval_SessionForkWithState|TestEval_ForkDialog_WithState" -race -count=1
+```
+
+Expected: every command matches at least one test (no "warning: no tests to run" output). If a regex matches zero tests, the spec's regex is stale — fix the spec, not the test names.
+
+- [ ] **Step 3: No commit unless Step 2 surfaced a regex fix**
+
+If Step 2 was clean, no action. If the spec needed a regex update to match actual test names, commit just the spec change:
+
+```bash
+git add docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md
+git commit -m "docs(spec): align mandate regex with actual test names"
+```
+
+### Why this changed from "edit CLAUDE.md"
+
+The original plan added a section to `CLAUDE.md`. After CONTRIBUTING.md was re-read during the post-plan review (Item 4 of the review pass), the team confirmed that PR #1002 intentionally made `CLAUDE.md` per-developer / untracked. The mandate therefore must live in a tracked file. The tracked spec already houses the full test inventory in its `## Testing` section; promoting the mandate text alongside it (in `## Mandatory test coverage`) keeps the mandate enforceable by CI without depending on a per-developer file. See spec review log entry FWS-018.
+
+---
+
+## Task 19: README + CHANGELOG entries
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Expand the README Fork Sessions section**
+
+Run: `grep -n "### Fork Sessions\|### Git Worktrees" README.md`
+
+In `README.md`, find `### Fork Sessions` near the top-level feature list. Replace that short section with:
+
+````markdown
+### Fork Sessions
+
+Try different approaches without losing context. Fork any Claude conversation instantly. Each fork inherits the full conversation history.
+
+- Press `f` for quick fork, `F` to customize name/group
+- Fork your forks to explore as many branches as you need
+- Use `--with-state` when you want the fork to start in a new worktree that includes the parent's current working-tree edits
+
+```bash
+agent-deck session fork my-project
+agent-deck session fork my-project -t "my-project-fork"
+
+# Carry parent's tracked + staged + untracked edits into a new destination branch/worktree.
+agent-deck session fork my-project --with-state -w fork/my-project-wip
+
+# Also copy gitignored files (e.g., .env, build caches).
+agent-deck session fork my-project --with-state-and-gitignored -w fork/my-project-with-env
+```
+
+On the CLI, `--with-state` requires `-w/--worktree <new-branch>` and does not auto-name the destination branch. `--with-state-and-gitignored` implies `--with-state`. Parent's index, working tree, and stash list are left byte-identical after the fork. The fork captures parent state at the moment of fork; later parent edits are not reflected. Mid-rebase/merge/cherry-pick/bisect parents are refused with an actionable error.
+````
+
+- [ ] **Step 2: Cross-reference fork-with-state from Git Worktrees**
+
+In `README.md`, find `### Git Worktrees`. After the existing initial worktree bullets and before `Configure the default worktree location...`, insert:
+
+````markdown
+Forking can also create a new worktree from a parent Claude session:
+
+```bash
+agent-deck session fork my-project --with-state -w fork/my-project-wip
+```
+
+Use this when the parent has useful in-progress edits that should move into a parallel branch without mutating the parent checkout.
+````
+
+- [ ] **Step 3: Add a CHANGELOG entry**
+
+Add the following `### Added` entry under `## [Unreleased]` in `CHANGELOG.md`. If `## [Unreleased]` has no subsections yet, create `### Added` directly beneath it. Use the repo's Keep a Changelog prose style:
+
+```markdown
+### Added
+- **Forked Claude sessions can now carry the parent's working-tree state into a new worktree.** `agent-deck session fork --with-state -w <new-branch>` and `--with-state-and-gitignored -w <new-branch>` materialize the parent session's staged, unstaged, untracked, and optionally gitignored files into a freshly-created destination branch/worktree branched off the parent's HEAD. The parent checkout stays read-only; existing destination branches/worktrees and mid-rebase/merge/cherry-pick/bisect parents are refused. The TUI fork dialog gains matching sub-checkboxes (`y` for with-state, `i` for gitignored) plus an editable suggested destination branch.
+
+### Changed
+- **Internal worktree setup now has an explicit materialization point.** `internal/git/CreateWorktreeWithSetup` is split into `CreateWorktree` + `RunWorktreeSetup`, with the original function preserved as a wrapper so existing direct callers remain unchanged.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "docs: add --with-state[-and-gitignored] fork examples to README and CHANGELOG"
+```
+
+---
+
+## Pre-execution verification scenarios
+
+These probes are run before implementation to validate tricky git semantics in isolated scratch repositories. Create all scratch repositories under `/private/tmp` or `/tmp`; do not use repo-local temporary directories.
+
+### PEV-001: staged materialization uses `git apply --index`
+
+Purpose: prove the implementation sequence preserves partially-staged files and staged deletions before writing production code.
+
+Manual probe:
+
+1. Create a temp repo with one committed multi-line tracked file.
+2. Modify one line and stage it, then modify another line in the same file without staging.
+3. Create a new worktree from the same commit.
+4. Capture `git diff --binary --cached` and `git diff --binary` from the parent.
+5. Apply the staged patch to the new worktree with `git apply --index`, then apply the unstaged patch with plain `git apply`.
+6. Verify `git diff --cached` and `git diff` match between parent and new worktree.
+7. Repeat with a committed file removed via `git rm`; verify the new worktree reports `D  <file>` and the file is absent from disk.
+
+Failure mode this prevents: `git apply --cached` updates only the index, leaving partially-staged working-tree content at the base version and leaving staged deletions on disk as untracked files.
+
+### PEV-002: linked parent worktree forks from parent HEAD
+
+Purpose: prove the fork-with-state start point is the parent session's HEAD, not the main/base worktree's HEAD.
+
+Manual probe:
+
+1. Create a temp repo under `/private/tmp` or `/tmp` with an initial commit on `main`.
+2. Create a linked worktree on `parent-branch` and add one commit there.
+3. Verify `git -C <base> rev-parse HEAD` differs from `git -C <parent-wt> rev-parse HEAD`.
+4. Create a new fork worktree using the proposed helper shape: `git -C <base> worktree add -b fork/from-parent <fork-wt> <parent-head>`.
+5. Verify `git -C <fork-wt> rev-parse HEAD` equals the parent worktree HEAD and does not equal the base worktree HEAD.
+
+Failure mode this prevents: creating the fork with `git -C <base> worktree add -b <branch> <path>` silently starts the fork at the base worktree HEAD when the parent session already lives in a linked worktree.
+
+### PEV-003: source shape matrix always creates a new destination
+
+Purpose: prove source branch/worktree shape is independent from the destination contract. Fork-with-state may read from several source shapes, but it always creates a new destination branch and worktree with the requested destination name.
+
+Manual probe:
+
+1. Create a temp repo under `/private/tmp` or `/tmp` with an initial commit on `main`.
+2. Source shape A: create a linked source worktree on `source/a`, add a commit, dirty the source worktree, then create `fork/a-new` with `git worktree add -b fork/a-new <dest-a> <source-a-head>` and materialize source state. Verify `fork/a-new` is a separate branch/worktree and source worktree state remains unchanged.
+3. Source shape B: use the main worktree on an existing branch with no separate source worktree, dirty it, then create `fork/b-new` from that source `HEAD`. Verify the destination branch/worktree is new.
+4. Source shape C: create a linked source worktree in detached HEAD state, dirty it, then create `fork/c-new` from that detached `HEAD`. Verify the destination branch/worktree is new.
+5. Destination collision: pre-create branch/worktree `fork/existing`, then attempt fork-with-state to `fork/existing`. Verify the planned handler refuses before materialization instead of reusing the existing worktree.
+
+Failure mode this prevents: treating the source branch/worktree as the destination, silently reusing an existing destination worktree, or making CLI hidden auto-names that differ from the user's requested destination.
+
+### PEV-004: CLI contract tests exercise the actual command path
+
+Purpose: prove the plan's CLI claims are covered through the real CLI/handler path, not only through direct git helper calls.
+
+Manual probe:
+
+1. Build the `agent-deck` binary in a temp output path under `/private/tmp` or `/tmp`.
+2. Create an isolated temp `HOME` and seed a forkable Claude session in that profile with a temp git repo as its project path.
+3. Run `agent-deck session fork <session> --with-state`; verify it exits non-zero and prints `--with-state requires --worktree <new-branch>`.
+4. Run `agent-deck session fork <session> --with-state-and-gitignored`; verify the same explicit-destination refusal.
+5. Pre-create destination branch `fork/existing`, then run `agent-deck session fork <session> --with-state -w fork/existing`; verify it refuses the existing branch before materialization.
+6. Pre-create destination branch/worktree `fork/used`, then run `agent-deck session fork <session> --with-state -w fork/used`; verify it refuses existing worktree reuse.
+7. Run the handler-level before-start hook test for `--with-state-and-gitignored -w fork/with-env`; verify `ClaudeOptions.WithState` and `IncludeGitignored` are true before `Start()`.
+
+Failure mode this prevents: green git helper tests masking broken CLI flag registration, missing refusal paths, wrong error text, or dropped `ClaudeOptions` propagation.
+
+### PEV-005: setup hook discovery uses repo root and execution uses worktree
+
+Purpose: prove setup-hook discovery and execution use different paths. The setup script is found under the repo root, but it runs with the new worktree as cwd after parent state is materialized.
+
+Manual probe:
+
+1. Create a temp repo under `/private/tmp` or `/tmp` with `.agent-deck/worktree-setup.sh` committed or present in the repo root.
+2. Make the setup script write `pwd` and the contents of a parent-WIP file to a temp output file.
+3. Dirty the parent by adding the parent-WIP file without committing it.
+4. Create the destination worktree, materialize parent state, then run `RunWorktreeSetup(<repo-root>, <dest-worktree>, ...)`.
+5. Verify the setup script was discovered from `<repo-root>/.agent-deck/worktree-setup.sh`, ran with `<dest-worktree>` as cwd, and observed the materialized parent-WIP file.
+
+Failure mode this prevents: implementing the spec with a worktree-only setup API that looks for `.agent-deck/worktree-setup.sh` in the new worktree or fails to expose `AGENT_DECK_REPO_ROOT` correctly.
+
+### PEV-006: shared preflight keeps CLI and TUI parity
+
+Purpose: prove the safety checks are centralized before implementation and that both user surfaces call the same fork-with-state preflight contract.
+
+Manual probe:
+
+1. Create a temp repo under `/private/tmp` or `/tmp` with an initial commit.
+2. Force a rebase conflict in that repo and verify `DetectInProgressOperation(<repo>)` returns `rebase`.
+3. Verify the planned `PreflightForkWithState(<repo>)` shape returns `InProgressOperationError{Kind: "rebase"}` before any destination worktree is created.
+4. Abort the rebase, add a `.gitmodules` file, and verify `PreflightForkWithState(<repo>)` returns the current `HEAD` plus `HasSubmodules=true`.
+5. After implementation, inspect the CLI and TUI fork-with-state paths and verify both call `git.PreflightForkWithState(...)` before `CreateWorktreeAtStartPoint`.
+6. Verify neither path duplicates `DetectInProgressOperation(...)` and `HasSubmodules(...)` inline.
+
+Failure mode this prevents: CLI refusing mid-operation parents while the TUI creates a fork anyway, or one surface warning about submodules while the other silently proceeds.
+
+---
+
+## Task 20: Full repo verification
+
+- [ ] **Step 1: Run formatter, linter, and full test suite**
+
+Run:
+```bash
+GOTOOLCHAIN=go1.24.0 make fmt
+GOTOOLCHAIN=go1.24.0 make lint
+GOTOOLCHAIN=go1.24.0 make test
+```
+Expected: all three succeed.
+
+- [ ] **Step 2: Run the new mandate suite**
+
+Run:
+```bash
+GOTOOLCHAIN=go1.24.0 go test ./internal/git/... -run "Materialize|DetectInProgress|HasSubmodules|PreflightForkWithState|ValidateForkWithStateDestination|CreateWorktreeAtStartPoint|HeadCommit|ForkWithStateGitSequence" -race -count=1
+GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/... -run "SessionFork_WithState|ResolveForkStateFlags" -race -count=1
+GOTOOLCHAIN=go1.24.0 go test ./internal/ui/... -run "ForkDialog_(WithState|ToggleWithState|GitignoredRequires|Toggling|FocusOrder)|ForkSessionCmdWithOptions_WithStateUsesSharedPreflight" -race -count=1
+GOTOOLCHAIN=go1.24.0 go test -tags eval_smoke ./tests/eval/session/... ./internal/ui/... -run "TestEval_SessionForkWithState|TestEval_ForkDialog_WithState" -race -count=1
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Re-run existing mandate suites to confirm no regression**
+
+Run:
+```bash
+GOTOOLCHAIN=go1.24.0 go test -run TestPersistence_ ./internal/session/... -race -count=1
+GOTOOLCHAIN=go1.24.0 go test ./internal/feedback/... ./internal/ui/... ./cmd/agent-deck/... -run "Feedback|Sender_" -race -count=1
+GOTOOLCHAIN=go1.24.0 go test ./internal/watcher/... -race -count=1 -timeout 120s
+```
+Expected: all PASS — none of these touch fork code so they should be unaffected.
+
+- [ ] **Step 4: Commit (no-op unless fixes were needed)**
+
+If any of the above turned up fixes, commit them with a tight scope:
+
+```bash
+git add -A
+git commit -m "fix: address <specific issue surfaced by verification>"
+```
+
+---
+
+## Task 21: Open PR against upstream
+
+- [ ] **Step 1: Push to your fork**
+
+```bash
+# One-time setup if not already done:
+gh repo fork asheshgoplani/agent-deck --remote=true
+git remote rename origin upstream    # if origin still points at asheshgoplani
+git remote add origin git@github.com:smorin/agent-deck.git  # only if rename was needed
+
+git push -u origin feature/fork-worktree-with-state
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "feat: fork --with-state[-and-gitignored] — carry parent working tree into new worktree" --body "$(cat <<'EOF'
+## Summary
+- Adds opt-in `--with-state` and `--with-state-and-gitignored` flags to `agent-deck session fork` (and matching TUI sub-checkboxes) that materialize the parent session's working-tree state into a freshly-created destination branch/worktree branched off parent's HEAD.
+- Read-only on parent: parent's index, working tree, and stash list are byte-identical after the fork.
+- Refuses mid-rebase / mid-merge / mid-cherry-pick / mid-bisect with an actionable error through a shared CLI/TUI preflight helper.
+- Materialization runs *before* the setup hook so user setup scripts see parent's WIP.
+
+## Design and plan
+- Spec: `docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md`
+- Plan: `docs/superpowers/plans/2026-05-14-fork-worktree-with-state.md`
+
+## Test plan
+- [ ] `go test ./internal/git/... -run "Materialize|DetectInProgress|HasSubmodules|PreflightForkWithState|ValidateForkWithStateDestination|CreateWorktreeAtStartPoint|HeadCommit|ForkWithStateGitSequence" -race`
+- [ ] `go test ./cmd/agent-deck/... -run "SessionFork_WithState|ResolveForkStateFlags" -race`
+- [ ] `go test ./internal/ui/... -run "ForkDialog_(WithState|ToggleWithState|GitignoredRequires|Toggling|FocusOrder)|ForkSessionCmdWithOptions_WithStateUsesSharedPreflight" -race`
+- [ ] `go test -tags eval_smoke ./tests/eval/session/... ./internal/ui/... -run "TestEval_SessionForkWithState|TestEval_ForkDialog_WithState" -race`
+- [ ] Existing session-persistence, feedback, watcher mandate suites all pass
+- [ ] Manual TUI walkthrough: open fork dialog on a dirty parent, toggle `w` → `y` → `i`, submit, verify new worktree contains parent's WIP including gitignored files
+- [ ] Manual CLI walkthrough: `agent-deck session fork <dirty-session> --with-state-and-gitignored -w fork/test-fork -t test-fork`
+EOF
+)"
+```
+
+- [ ] **Step 3: Report PR URL**
+
+The previous command prints a PR URL on success. Copy it into the conversation for review.
+
+---
+
+## Post-plan author review PR proposal draft
+
+Before opening or finalizing the PR, send the author a short proposal that highlights the design decisions most likely to matter during review. This is a review note, not a substitute for tests.
+
+Draft:
+
+```markdown
+## Proposal: fork-with-state destination, start point, materialization, and cleanup design
+
+This PR adds opt-in `agent-deck session fork --with-state` and `--with-state-and-gitignored`.
+
+### Design decision: source is flexible, destination is always new
+
+Fork-with-state reads from the selected parent session regardless of whether that source is a normal branch checkout, a linked worktree, or detached HEAD. What it creates is always a new destination branch and a new destination worktree.
+
+On CLI, the destination branch must be explicit:
+
+```bash
+agent-deck session fork <session> --with-state -w fork/my-session-wip
+```
+
+The CLI does not auto-suggest or auto-name hidden branches. In the TUI, the visible branch field may be prefilled with `fork/<sanitized-session>` because the user can inspect and edit it before submit.
+
+If you prefer CLI parity with the TUI, the alternative is to allow CLI auto-naming when `--with-state` is supplied without `-w`. I did not choose that in this plan because hidden destination names are easier to miss in scripts and logs.
+
+### Design decision: fork from the parent session's HEAD
+
+For fork-with-state, the new worktree is born from the parent session's current `HEAD`, then the parent's staged, unstaged, untracked, and optionally gitignored state is materialized into it.
+
+This is intentional for parent sessions that already live in linked worktrees. If the main/base worktree is at commit `M` and the parent session worktree is at commit `P`, fork-with-state starts from `P`, not `M`.
+
+Recommended implementation in this plan:
+
+- capture `parentHead` with `git -C <parent-worktree> rev-parse --verify HEAD^{commit}`
+- create the new worktree with an explicit start point via `CreateWorktreeAtStartPoint(repoRoot, worktreePath, branch, parentHead)`
+- keep existing `CreateWorktree(...)` behavior unchanged for normal worktree creation paths
+
+Alternative if you prefer a broader API:
+
+- replace the narrow helper with an options-style API, for example `CreateWorktreeWithOptions(CreateWorktreeOptions{RepoDir, WorktreePath, BranchName, StartPoint})`
+- route both existing and fork-with-state callers through that API
+- preserve the same behavioral contract: fork-with-state must still start from parent session `HEAD`
+
+I chose the narrow helper in the plan to minimize blast radius. The options-style API is reasonable if you want this to become the general worktree creation surface now.
+
+### Design decision: shared fork-with-state preflight
+
+Both CLI and TUI call `git.PreflightForkWithState(parentWorktree)` before creating the destination worktree.
+
+That helper owns git facts only:
+
+- refuse in-progress rebase, merge, cherry-pick, or bisect with `InProgressOperationError`
+- capture the parent session's `HEAD`
+- return `HasSubmodules=true` as a warning fact
+
+The CLI and TUI still own presentation. CLI prints the refusal or warning through the CLI output path; TUI returns `sessionForkedMsg` errors or logs the submodule warning through the TUI logging path.
+
+The alternative is to duplicate `DetectInProgressOperation`, `HasSubmodules`, and `HeadCommit` calls in both surfaces, or to add a TUI-only helper. I did not choose that because it makes future CLI/TUI drift more likely. The shared helper follows the existing `internal/git` worktree-helper pattern while keeping UI wording out of the git package.
+
+### Testing decision: CLI contract coverage is separate from git-side integration
+
+The plan now separates two kinds of tests:
+
+- CLI/handler contract tests run the compiled command or the actual `handleSessionFork` path with a before-start hook. These cover flag registration, refusal messages, destination validation, and `ClaudeOptions` propagation.
+- Git-side integration tests live in `internal/git/worktree_with_state_integration_test.go` and call the git helpers directly. These remain useful for materialization semantics, but they do not count as proof that the CLI surface works.
+
+This split keeps the heavy tmux start path out of unit tests while still preventing helper-only tests from masking a broken user-facing command.
+
+### Testing decision: bounded behavioral eval coverage
+
+The repo already requires evaluator-harness coverage for user-observable behavior that pure Go tests cannot structurally express. This PR therefore includes a small eval layer in addition to unit, handler, and git-helper integration tests:
+
+- `tests/eval/session/fork_with_state_test.go` drives the real `agent-deck` binary with a scratch HOME, fake `claude`, isolated tmux socket, and real git repo. It proves the visible CLI command creates a materialized destination worktree and starts the forked session in that worktree.
+- `internal/ui/forkdialog_eval_test.go` is colocated with `internal/ui` because of Go's `internal/` import rule. It drives the rendered `ForkDialog` through `w -> y -> i` and proves the nested controls are visible only through the user-facing interaction path.
+
+The alternative is to rely only on handler and structural tests. I did not choose that because this feature changes a real CLI command and visible TUI controls, and the repo has had prior regressions where those exact classes of behavior passed ordinary Go tests but failed for users.
+
+### Documentation decision: dedicated fork docs plus worktree cross-reference
+
+The README change expands the existing `### Fork Sessions` feature section with the new `--with-state` examples and CLI contract. The `### Git Worktrees` section also gets a short cross-reference because the feature creates a worktree, but the full explanation stays in the fork section where users looking for fork behavior are most likely to read first.
+
+The alternative is to put the main docs only under `### Git Worktrees`. I did not choose that for this plan because fork-with-state is invoked through `agent-deck session fork`, and README already introduces forking as a first-class feature near the top of the page. The changelog entry follows the existing Keep a Changelog prose style under `## [Unreleased]`, not conventional-commit wording.
+
+### Design decision: branch cleanup requires creation proof
+
+Materialization failure cleans up the half-created worktree. The branch is deleted only if the worktree creation helper returned proof that this operation created the branch.
+
+This is defensive hardening for the new cleanup path. The current `CreateWorktreeAtStartPoint(... -b <branch> <startPoint>)` shape rejects an already-existing branch before materialization can run, but cleanup still should not key branch deletion off intent flags like `createNewBranch`. If this helper is refactored later, existing branches must remain protected.
+
+### Design decision: setup hook discovery root and execution cwd are separate
+
+The split setup API keeps both `repoDir` and `worktreePath`:
+
+- `repoDir` is where `.agent-deck/worktree-setup.sh` is discovered and what the script receives as `AGENT_DECK_REPO_ROOT`
+- `worktreePath` is the cwd where the script runs and what the script receives as `AGENT_DECK_WORKTREE_PATH`
+
+This preserves current setup semantics while allowing fork-with-state to materialize parent WIP before the hook runs. The alternative is a worktree-only setup API, but that risks discovering setup scripts from the wrong location in linked-worktree and bare-layout projects.
+
+### Design decision: bare repositories are metadata, not state sources
+
+Fork-with-state materializes from a checked-out parent working tree. That source can be:
+
+- a normal repo checkout on the default branch
+- a normal repo checkout on any other branch
+- a linked worktree
+- a detached-HEAD checkout with a working tree
+
+A bare repository directory, or a bare-layout project root that only contains `.bare/`, is not itself a valid source for `--with-state` because there are no checked-out files, unstaged edits, or untracked files to copy. The bare-layout integration test therefore uses a linked parent worktree as the source while using the bare project root for repository-level operations.
+
+```
+
+---
+
+## Spec coverage check
+
+Each spec requirement maps to at least one task:
+
+| Spec requirement | Task(s) |
+|---|---|
+| CLI `--with-state` and `--with-state-and-gitignored` flags | 12, 12A, 13 |
+| CLI explicit destination branch, no auto-name | 12, 12A, 13, 19 |
+| CLI refusal messages and destination collision behavior | 12A, 13, PEV-004 |
+| Implication chain | 12, 13 |
+| TUI sub-checkboxes with `y`/`i` toggles | 15, 16 |
+| TUI nested state invariant: with-state requires worktree and clears when worktree turns off | 15, 16 |
+| TUI editable destination-branch suggestion | 15, 16, 17 |
+| TUI focus order extension | 15A, 16 |
+| `ClaudeOptions.WithState` / `IncludeGitignored` | 1, 12A, 13 |
+| Parent session HEAD used as fork start point | 4A, 4B, 13, 14, 17, PEV-002 |
+| Proof-based branch cleanup on materialization failure | 4A, 13, 17 |
+| Fresh destination branch/worktree; no with-state reuse | 4A, 4C, 12A, 13, 17, PEV-003 |
+| Shared fork-with-state destination collision validator | 4C, 13, 17 |
+| `MaterializeParentState` covering staged + unstaged + untracked + gitignored | 5, 6, 7, 8, 9 |
+| Parent-untouched invariant | 10 |
+| Staged-deletion preserved | 10 |
+| Binary/symlink/exec-bit | 7, 8 |
+| `DetectInProgressOperation` | 2, 4B |
+| Shared fork-with-state preflight helper | 4B, 13, 17, PEV-006 |
+| `HasSubmodules` warning | 3, 4B, 13, 17, PEV-006 |
+| Split `CreateWorktreeWithSetup` → `RunWorktreeSetup` | 4 |
+| Materialize-before-setup-hook ordering | 13, 17 |
+| Cleanup-on-error (worktree remove + branch delete) | 13, 14, 17 |
+| Refuse mid-rebase/merge/cherry-pick/bisect | 4B, 13, 14, 17, PEV-006 |
+| CLAUDE.md mandate section | 18 |
+| Behavioral eval smoke coverage | 17A, 18, 20 |
+| README + CHANGELOG | 19 |
+| Pre-execution verification probes | PEV-001, PEV-002, PEV-003, PEV-004, PEV-005, PEV-006 |
+| Post-plan author PR proposal draft | Post-plan author review PR proposal draft |
+| Full verification | 20 |
+| PR opened against upstream | 21 |
+
+No spec requirements without a task; no orphan tasks.
+
+## Review change log
+
+- 2026-05-15: Accepted FWS-001 after clean-context verification. Changed `MaterializeParentState` staged patch application from `git apply --cached` to `git apply --index`, and added PEV-001 to pre-execution verification so partially-staged edits and staged deletions are probed in temp repositories before implementation.
+- 2026-05-15: Accepted FWS-002 after clean-context verification. Added the parent-HEAD start-point contract to the plan with `HeadCommit`, `CreateWorktreeAtStartPoint`, linked-worktree regression coverage, TUI/CLI parent-head creation paths, PEV-002, and a post-plan author PR proposal draft that offers the narrower helper or a broader options-style API while preserving the same behavior.
+- 2026-05-15: Accepted FWS-003 after clean-context verification as new-code hardening. The plan now has `CreateWorktreeAtStartPoint` return `createdBranch`, rejects pre-existing branches on the fork-with-state start-point path, and gates branch deletion during materialization cleanup on that proof. The author PR proposal draft now calls out the cleanup design decision.
+- 2026-05-15: Accepted FWS-004 after clean-context verification. The plan now states that source sessions may be normal branch checkouts, linked worktrees, or detached HEAD, but fork-with-state always creates a new destination branch/worktree. CLI requires explicit `-w/--worktree <new-branch>` with no hidden suggestion; TUI keeps an editable suggested destination name. Added PEV-003 and author-review notes for the destination contract.
+- 2026-05-15: Accepted FWS-005 after clean-context verification. Renamed Task 14 to git-side integration coverage, added Task 12A for real CLI/handler contract tests, added a before-start test hook for option propagation, added PEV-004, and documented the testing split in the author-review proposal.
+- 2026-05-16: Accepted FWS-006 after clean-context verification. Aligned setup-hook wording with the existing `RunWorktreeSetup(repoDir, worktreePath, ...)` contract, added PEV-005 to verify script discovery from repo root and execution in the new worktree, and documented the design decision for author review.
+- 2026-05-16: Accepted FWS-007 after clean-context verification. Task 14 now includes the spec-promised clean-parent, bare-repo-layout, and materialize-before-setup-hook automated git-side integration tests, strengthens the mid-rebase test with a destination-absence assertion, and raises the expected fork-with-state integration count from 5 to 8.
+- 2026-05-16: Accepted FWS-008 after clean-context verification. Updated the CLAUDE.md mandate draft so it preserves the valid `--with-state-and-gitignored` to `--with-state` implication while explicitly forbidding CLI with-state flags from auto-creating or auto-naming worktrees.
+- 2026-05-17: Accepted FWS-009 after clean-context verification and option comparison. Added shared `git.PreflightForkWithState` coverage in Task 4B, rewired the planned CLI and TUI paths through that helper, added PEV-006, extended the TUI structural guard, and documented the shared-preflight design decision for author review.
+- 2026-05-17: Accepted FWS-010 after clean-context verification. Hardened the ForkDialog plan so `ToggleWithState` is a no-op unless worktree mode is enabled, `ToggleWorktree` clears nested state when turning worktree off, and Task 16 tests lock that invariant in.
+- 2026-05-17: Accepted FWS-011 after clean-context verification and codebase-pattern comparison. Added Task 15A so ForkDialog adopts the existing `NewDialog` focus-target architecture for dynamic focus order, added `TestForkDialog_FocusOrder`, and updated the fork-with-state TUI mandate regexes to include that regression.
+- 2026-05-17: Accepted FWS-012 after clean-context verification and terminology review. Renamed the bare-layout integration case to `TestForkWithStateGitSequence_BareRepoLayoutLinkedParentWorktree`, clarified that a bare repo/project root is metadata rather than a fork-with-state source, and added an author-review design note preserving support for normal checkouts, linked worktrees, and detached-HEAD working trees.
+- 2026-05-17: Accepted FWS-013 after clean-context verification. Fixed the plan file map to point at the dedicated `cmd/agent-deck/session_cmd_fork_state_test.go` file used by the spec and detailed tasks for fork-with-state CLI/handler coverage.
+- 2026-05-17: Accepted ADP-007 codebase-pattern audit recommendation. Moved Task 14's direct git-helper sequence tests into `internal/git/worktree_with_state_integration_test.go`, leaving `cmd/agent-deck/session_cmd_fork_state_test.go` focused on CLI/handler contracts and updating the mandate/test-plan regexes to include `ForkWithStateGitSequence`.
+- 2026-05-17: Accepted ADP-008 codebase-pattern audit recommendation. Reworked the planned TUI structural guard to extract `forkSessionCmdWithOptions` with a brace-counting helper, matching the existing structural-test pattern instead of depending on a neighboring `deleteSession` boundary.
+- 2026-05-17: Accepted ADP-010 codebase-pattern audit recommendation. Added Task 17A with bounded behavioral eval smoke coverage: a real-binary CLI fork-with-state eval under `tests/eval/session` and a colocated `internal/ui` ForkDialog eval for the visible `w -> y -> i` interaction path. Added the eval command and paths to the mandate, full verification, PR test plan, spec coverage check, and author-review proposal.
+- 2026-05-17: Accepted ADP-011 codebase-pattern audit recommendation with Option 2. Task 19 now expands the README's dedicated `### Fork Sessions` section with fork-with-state examples and contract text, adds a short `### Git Worktrees` cross-reference, and changes the CHANGELOG instructions to the repo's Keep a Changelog prose style under `## [Unreleased]`.
+- 2026-05-17: Accepted FWS-016 after the Item 4 discussion document and option comparison. Added new Task 4C to extract a shared `git.ValidateForkWithStateDestination(repoRoot, branch)` helper with a typed `DestinationCollisionError` (worktree_exists / branch_exists). Rewrote Task 13 Step 3 (CLI) to call the helper before `PreflightForkWithState` and leave the existing-worktree reuse block exactly as today's code. Rewrote Task 17 Step 3 (TUI) to call the helper before the reuse block and leave the reuse block exactly as today's code. Updated mandate regexes (Task 18, Task 20, Task 21 test plan) to include `ValidateForkWithStateDestination`. Added structural-change RFC requirement for the new helper. Added three helper unit tests in Task 4C. Eliminates the CLI redundancy without imposing symmetry on TUI; mirrors the FWS-009 architectural pattern.
+- 2026-05-18: Accepted FWS-018 plan-side. Rewrote Task 18 to verify the spec's `## Mandatory test coverage` section is current with the actual test names (regex sanity check), instead of editing the now-untracked `CLAUDE.md`. Per CONTRIBUTING.md and PR #1002, `CLAUDE.md` is intentionally per-developer; the mandate must live in a tracked file. The spec is that file. Task 18 no longer creates a commit unless the regex drifted.

--- a/docs/superpowers/plans/2026-05-18-fork-with-state-followup.md
+++ b/docs/superpowers/plans/2026-05-18-fork-with-state-followup.md
@@ -1,0 +1,725 @@
+# Fork-with-State Followup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the 11 gaps identified after upstream merged #1030 (commit `6a1645eb`) into the fork-with-state feature, split across two PRs.
+
+**Architecture:** Layer on top of upstream's merged API (`MaterializeWipFromParent`, `CreateWorktreeWithStateAndSetup`). Add new helpers in new files; modify the CLI and TUI handlers to wrap upstream's wrapper with our pre-checks and cleanup. Do not refactor or replace upstream's just-merged code.
+
+**Tech Stack:** Go 1.24.0 (pinned via `GOTOOLCHAIN`), bubbletea/lipgloss for TUI, shelling out to `git` for diff/apply/ls-files/worktree/branch ops.
+
+**Spec:** [`docs/superpowers/specs/2026-05-18-fork-with-state-followup-design.md`](../specs/2026-05-18-fork-with-state-followup-design.md)
+**Gap analysis:** [`docs/superpowers/discussions/2026-05-18-post-merge-gap-analysis.md`](../discussions/2026-05-18-post-merge-gap-analysis.md)
+**Deprecated original plan:** [`2026-05-14-fork-worktree-with-state.md`](2026-05-14-fork-worktree-with-state.md)
+
+## Pre-flight (one-time, before Task 1)
+
+```bash
+export GOTOOLCHAIN=go1.24.0
+# Verify local main is current with upstream's #1030 merge
+git fetch upstream
+git log --oneline upstream/main | grep -E "1029|1030" | head
+# Expected: 6a1645eb feat(fork): --with-state and --with-state-and-gitignored ...
+
+# Sanity-check upstream's tests pass on local clone
+GOTOOLCHAIN=go1.24.0 go test ./internal/git/... -run "RegressionFor1029|WithState" -race -count=1
+```
+
+Per `CONTRIBUTING.md`, PR-A branches from `main` and is pushed to `smorin/agent-deck` (origin); PR-B does the same but rebases onto `main` after PR-A merges.
+
+---
+
+## File map
+
+| File | Action | PR |
+|---|---|---|
+| `internal/git/git.go` | Modify — add `HeadCommit`, `CreateWorktreeAtStartPoint` | A |
+| `internal/git/git_test.go` | Modify — add `TestCreateWorktreeAtStartPoint_*` tests | A |
+| `internal/git/fork_with_state_destination.go` | Create — `ValidateForkWithStateDestination`, `DestinationCollisionError` | A |
+| `internal/git/fork_with_state_destination_test.go` | Create — validator tests | A |
+| `internal/git/materialize_wip_invariant_test.go` | Create — parent-untouched invariant test | A |
+| `internal/git/fork_with_state_integration_test.go` | Create — bare-repo + setup-hook observation tests | A |
+| `internal/git/issue1029_edge_test.go` | Modify — add 4 missing mid-op refusal tests | A |
+| `cmd/agent-deck/session_cmd.go` | Modify — parent-HEAD + destination validation + cleanup-on-error + before-start hook | A |
+| `cmd/agent-deck/session_cmd_fork_state_test.go` | Create — CLI contract tests | A |
+| `tests/eval/session/fork_with_state_test.go` | Create — eval smoke for CLI | A |
+| `internal/ui/forkdialog.go` | Modify — sub-checkboxes, focus order, getters | B |
+| `internal/ui/forkdialog_test.go` | Modify — state-machine tests | B |
+| `internal/ui/forkdialog_eval_test.go` | Create — TUI behavioral eval | B |
+| `internal/ui/home.go` | Modify — TUI submit wires collision check + cleanup-on-error | B |
+
+---
+
+# PR-A — Correctness fixes + test hardening (CLI surface)
+
+Closes gaps 2, 3, 4 (CLI portion), 5, 6, 7, 8, 9, 10 (CLI portion).
+
+## Task A1 — `HeadCommit` + `CreateWorktreeAtStartPoint` helpers (gap 2)
+
+**Files:**
+- Modify: `internal/git/git.go`
+- Modify: `internal/git/git_test.go`
+
+Upstream's `CreateWorktree(repoDir, ...)` creates from invocation dir's HEAD, which is wrong when the parent session lives in a linked worktree. Add two helpers: `HeadCommit(repoDir)` returns the resolved commit at `repoDir`'s HEAD (works for normal repos, linked worktrees, and bare-repo project roots via `resolveGitInvocationDir`); `CreateWorktreeAtStartPoint(repoDir, worktreePath, branch, startPoint)` creates a new branch worktree from an explicit commit, and returns `createdBranch=true` only when git actually created the branch (so cleanup can be proof-based, not intent-based).
+
+- [ ] **Step 1: Write failing tests in `internal/git/git_test.go`**
+
+```go
+func TestCreateWorktreeAtStartPoint_UsesExplicitParentHead(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	if err := os.MkdirAll(base, 0o755); err != nil { t.Fatal(err) }
+	createTestRepo(t, base)
+
+	parentWT := filepath.Join(root, "parent-wt")
+	if err := CreateWorktree(base, parentWT, "parent-branch"); err != nil {
+		t.Fatalf("CreateWorktree parent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(parentWT, "README.md"), []byte("parent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, parentWT, "commit", "-am", "parent change")
+
+	baseHead := strings.TrimSpace(runGit(t, base, "rev-parse", "HEAD"))
+	parentHead, err := HeadCommit(parentWT)
+	if err != nil { t.Fatalf("HeadCommit: %v", err) }
+	if baseHead == parentHead {
+		t.Fatal("setup invalid: base and parent HEAD should differ")
+	}
+
+	forkWT := filepath.Join(root, "fork-wt")
+	createdBranch, err := CreateWorktreeAtStartPoint(base, forkWT, "fork/from-parent", parentHead)
+	if err != nil { t.Fatalf("CreateWorktreeAtStartPoint: %v", err) }
+	if !createdBranch {
+		t.Fatal("CreateWorktreeAtStartPoint returned createdBranch=false for a new branch")
+	}
+	forkHead := strings.TrimSpace(runGit(t, forkWT, "rev-parse", "HEAD"))
+	if forkHead != parentHead {
+		t.Fatalf("fork HEAD = %s, want parent HEAD %s (base HEAD %s)", forkHead, parentHead, baseHead)
+	}
+}
+
+func TestCreateWorktreeAtStartPoint_RejectsExistingBranch(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	if err := os.MkdirAll(base, 0o755); err != nil { t.Fatal(err) }
+	createTestRepo(t, base)
+	parentHead, _ := HeadCommit(base)
+	runGit(t, base, "branch", "fork/existing")
+
+	createdBranch, err := CreateWorktreeAtStartPoint(base, filepath.Join(root, "fork-wt"), "fork/existing", parentHead)
+	if err == nil {
+		t.Fatal("expected existing branch to be rejected")
+	}
+	if createdBranch {
+		t.Fatal("createdBranch should be false when branch already existed")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected already-exists error, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run, confirm FAIL** — `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestCreateWorktreeAtStartPoint -v` should fail with `undefined: HeadCommit`, `undefined: CreateWorktreeAtStartPoint`.
+
+- [ ] **Step 3: Add helpers in `internal/git/git.go`** (near `CreateWorktree`):
+
+```go
+// HeadCommit returns the commit currently checked out at repoDir. Works for
+// normal repos, linked worktrees, and bare-repo project roots.
+func HeadCommit(repoDir string) (string, error) {
+	repoDir = resolveGitInvocationDir(repoDir)
+	cmd := exec.Command("git", "-C", repoDir, "rev-parse", "--verify", "HEAD^{commit}")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve HEAD commit: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// CreateWorktreeAtStartPoint creates a new branch worktree from an explicit
+// start point. Returns createdBranch=true only after git successfully creates
+// the branch for this call. Used by fork-with-state to anchor the new worktree
+// at the parent session's HEAD instead of the invocation repo's HEAD.
+func CreateWorktreeAtStartPoint(repoDir, worktreePath, branchName, startPoint string) (createdBranch bool, err error) {
+	if err := ValidateBranchName(branchName); err != nil {
+		return false, fmt.Errorf("invalid branch name: %w", err)
+	}
+	if strings.TrimSpace(startPoint) == "" {
+		return false, errors.New("start point cannot be empty")
+	}
+	repoDir = resolveGitInvocationDir(repoDir)
+	if !IsGitRepo(repoDir) {
+		return false, errors.New("not a git repository")
+	}
+	if BranchExists(repoDir, branchName) {
+		return false, fmt.Errorf("branch %q already exists", branchName)
+	}
+	cmd := exec.Command("git", "-C", repoDir, "worktree", "add", "-b", branchName, worktreePath, startPoint)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("failed to create worktree at start point: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return true, nil
+}
+```
+
+- [ ] **Step 4: Run, confirm PASS** — `GOTOOLCHAIN=go1.24.0 go test ./internal/git/ -run TestCreateWorktreeAtStartPoint -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/git/git.go internal/git/git_test.go
+git commit -m "feat(git): HeadCommit + CreateWorktreeAtStartPoint for fork-with-state parent HEAD anchoring"
+```
+
+---
+
+## Task A2 — `ValidateForkWithStateDestination` + `DestinationCollisionError` (gap 3)
+
+**Files:**
+- Create: `internal/git/fork_with_state_destination.go`
+- Create: `internal/git/fork_with_state_destination_test.go`
+
+Shared `internal/git` helper that returns typed collision errors. Both CLI and TUI handlers call this before invoking upstream's `CreateWorktreeWithStateAndSetup`. Worktree-existence is checked first (more specific error, includes path).
+
+- [ ] **Step 1: Write failing tests in `internal/git/fork_with_state_destination_test.go`**
+
+```go
+package git
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateForkWithStateDestination_Clean(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	if err := ValidateForkWithStateDestination(dir, "fork/new"); err != nil {
+		t.Fatalf("clean repo + fresh branch should pass, got %v", err)
+	}
+}
+
+func TestValidateForkWithStateDestination_BranchExists(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	runGit(t, dir, "branch", "fork/existing")
+
+	err := ValidateForkWithStateDestination(dir, "fork/existing")
+	if err == nil { t.Fatal("expected DestinationCollisionError") }
+	var collErr *DestinationCollisionError
+	if !errors.As(err, &collErr) {
+		t.Fatalf("error = %T %v, want *DestinationCollisionError", err, err)
+	}
+	if collErr.Kind != "branch_exists" || collErr.Branch != "fork/existing" {
+		t.Fatalf("unexpected error: %+v", collErr)
+	}
+}
+
+func TestValidateForkWithStateDestination_WorktreeExists(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	if err := os.MkdirAll(base, 0o755); err != nil { t.Fatal(err) }
+	createTestRepo(t, base)
+	wtPath := filepath.Join(root, "fork-wt")
+	if err := CreateWorktree(base, wtPath, "fork/used"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	err := ValidateForkWithStateDestination(base, "fork/used")
+	if err == nil { t.Fatal("expected DestinationCollisionError") }
+	var collErr *DestinationCollisionError
+	if !errors.As(err, &collErr) {
+		t.Fatalf("error = %T %v, want *DestinationCollisionError", err, err)
+	}
+	if collErr.Kind != "worktree_exists" || collErr.Path == "" {
+		t.Fatalf("unexpected error: %+v", collErr)
+	}
+}
+```
+
+- [ ] **Step 2: Run, confirm FAIL** — `undefined: ValidateForkWithStateDestination`.
+
+- [ ] **Step 3: Write `internal/git/fork_with_state_destination.go`**
+
+```go
+package git
+
+import "fmt"
+
+// DestinationCollisionError is returned by ValidateForkWithStateDestination
+// when the requested destination branch already has a worktree or already
+// exists as a local branch. Callers own user-facing wording.
+type DestinationCollisionError struct {
+	Kind   string // "worktree_exists" or "branch_exists"
+	Branch string
+	Path   string // populated when Kind == "worktree_exists"
+}
+
+func (e *DestinationCollisionError) Error() string {
+	switch e.Kind {
+	case "worktree_exists":
+		return fmt.Sprintf("branch %q already has a worktree at %s", e.Branch, e.Path)
+	case "branch_exists":
+		return fmt.Sprintf("branch %q already exists", e.Branch)
+	default:
+		return fmt.Sprintf("destination collision for branch %q", e.Branch)
+	}
+}
+
+// ValidateForkWithStateDestination is the shared CLI/TUI destination-collision
+// gate for fork-with-state. Worktree-collision is checked first so the more
+// specific error (with path) is surfaced when both conditions are true.
+func ValidateForkWithStateDestination(repoRoot, branch string) error {
+	if path, err := GetWorktreeForBranch(repoRoot, branch); err == nil && path != "" {
+		return &DestinationCollisionError{Kind: "worktree_exists", Branch: branch, Path: path}
+	}
+	if BranchExists(repoRoot, branch) {
+		return &DestinationCollisionError{Kind: "branch_exists", Branch: branch}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run, confirm PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/git/fork_with_state_destination.go internal/git/fork_with_state_destination_test.go
+git commit -m "feat(git): shared ValidateForkWithStateDestination + typed DestinationCollisionError"
+```
+
+---
+
+## Task A3 — Wire parent-HEAD + collision check + cleanup-on-error into `handleSessionFork` (gaps 2, 3, 4-CLI)
+
+**Files:**
+- Modify: `cmd/agent-deck/session_cmd.go`
+
+Upstream's CLI handler currently calls `CreateWorktreeWithStateAndSetup` directly. We pre-empt with validation, anchor the worktree at parent's HEAD via `CreateWorktreeAtStartPoint`, then drive the rest of upstream's wrapper steps manually (materialize + worktreeinclude + setup) so we can guard each with cleanup. This keeps upstream's `MaterializeWipFromParent`, `ProcessWorktreeInclude`, and the setup-script logic untouched.
+
+Strategy: when `wantState` is true, take a custom flow; when false, delegate to upstream's existing wrapper for backward compatibility.
+
+- [ ] **Step 1: Add imports** — ensure `"errors"` is imported.
+
+- [ ] **Step 2: Inside `handleSessionFork`, after the existing `if wantState && wtBranch == "" { ... }` validation upstream added, insert the with-state custom path**
+
+Replace the existing call:
+
+```go
+setupErr, err := git.CreateWorktreeWithStateAndSetup(
+    repoRoot, worktreePath, wtBranch,
+    git.WorktreeStateOptions{WithState: wantState, WithIgnored: *withStateGitignored},
+    os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+```
+
+with:
+
+```go
+var setupErr error
+if wantState {
+    // Pre-flight: destination collision check using the shared validator.
+    if err := git.ValidateForkWithStateDestination(repoRoot, wtBranch); err != nil {
+        var collErr *git.DestinationCollisionError
+        if errors.As(err, &collErr) {
+            switch collErr.Kind {
+            case "worktree_exists":
+                out.Error(fmt.Sprintf("branch '%s' already has a worktree at %s; choose a new destination branch for --with-state", collErr.Branch, collErr.Path), ErrCodeInvalidOperation)
+            case "branch_exists":
+                out.Error(fmt.Sprintf("branch '%s' already exists; choose a new destination branch for --with-state", collErr.Branch), ErrCodeInvalidOperation)
+            default:
+                out.Error(collErr.Error(), ErrCodeInvalidOperation)
+            }
+            os.Exit(1)
+        }
+        out.Error(fmt.Sprintf("failed to validate destination: %v", err), ErrCodeInvalidOperation)
+        os.Exit(1)
+    }
+
+    // Capture parent's HEAD so linked-worktree parents anchor correctly.
+    parentHead, hcErr := git.HeadCommit(inst.ProjectPath)
+    if hcErr != nil {
+        out.Error(fmt.Sprintf("failed to resolve parent session HEAD: %v", hcErr), ErrCodeInvalidOperation)
+        os.Exit(1)
+    }
+
+    createdBranch, cwErr := git.CreateWorktreeAtStartPoint(repoRoot, worktreePath, wtBranch, parentHead)
+    if cwErr != nil {
+        out.Error(fmt.Sprintf("worktree creation failed: %v", cwErr), ErrCodeInvalidOperation)
+        os.Exit(1)
+    }
+
+    // Materialize parent state, with cleanup-on-error.
+    if matErr := git.MaterializeWipFromParent(inst.ProjectPath, worktreePath, *withStateGitignored); matErr != nil {
+        _ = exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", worktreePath).Run()
+        if createdBranch {
+            _ = exec.Command("git", "-C", repoRoot, "branch", "-D", wtBranch).Run()
+        }
+        out.Error(fmt.Sprintf("failed to materialize parent state: %v; new worktree cleaned up", matErr), ErrCodeInvalidOperation)
+        os.Exit(1)
+    }
+
+    // Continue the upstream wrapper's tail: worktreeinclude + setup hook.
+    if inclErr := git.ProcessWorktreeInclude(repoRoot, worktreePath, os.Stderr); inclErr != nil {
+        fmt.Fprintf(os.Stderr, "worktreeinclude: %v\n", inclErr)
+    }
+    setupErr = git.RunWorktreeSetupAfterCreate(repoRoot, worktreePath, os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+} else {
+    // Legacy path: no with-state. Delegate to upstream's wrapper unchanged.
+    setupErr, err = git.CreateWorktreeWithStateAndSetup(
+        repoRoot, worktreePath, wtBranch,
+        git.WorktreeStateOptions{},
+        os.Stdout, os.Stderr, session.GetWorktreeSettings().SetupTimeout())
+    if err != nil {
+        out.Error(fmt.Sprintf("worktree creation failed: %v", err), ErrCodeInvalidOperation)
+        os.Exit(1)
+    }
+}
+```
+
+**Note:** `git.RunWorktreeSetupAfterCreate` may need to be a small new exported helper that runs only the setup-hook portion of `CreateWorktreeWithStateAndSetup`. If it doesn't exist, define it in this task as a 10-line wrapper around the existing setup-hook code in `internal/git/setup.go`. Alternatively, the with-state path can call `CreateWorktreeWithStateAndSetup` AFTER `CreateWorktreeAtStartPoint` removed the worktree it already created — but that's awkward. Defining `RunWorktreeSetupAfterCreate` is cleaner.
+
+- [ ] **Step 3: If needed, add `RunWorktreeSetupAfterCreate` to `internal/git/setup.go`**
+
+```go
+// RunWorktreeSetupAfterCreate runs the worktree setup script for an
+// already-created worktree. Extracted from CreateWorktreeWithStateAndSetup so
+// the fork-with-state path can sequence Create → Materialize → Setup with
+// per-step error handling. Returns the script's exit error; nil if no script.
+func RunWorktreeSetupAfterCreate(repoDir, worktreePath string, stdout, stderr io.Writer, setupTimeout time.Duration) error {
+	scriptPath, scriptMode := FindWorktreeSetupScript(repoDir)
+	if scriptPath == "" { return nil }
+	fmt.Fprintln(stderr, "Running worktree setup script...")
+	start := time.Now()
+	setupErr := RunWorktreeSetupScript(scriptPath, scriptMode, repoDir, worktreePath, stdout, stderr, setupTimeout)
+	elapsed := time.Since(start).Round(100 * time.Millisecond)
+	if setupErr != nil {
+		fmt.Fprintf(stderr, "Worktree setup script failed after %s: %v\n", elapsed, setupErr)
+	} else {
+		fmt.Fprintf(stderr, "Worktree setup script completed in %s\n", elapsed)
+	}
+	return setupErr
+}
+```
+
+- [ ] **Step 4: Verify the package compiles** — `GOTOOLCHAIN=go1.24.0 go build ./cmd/agent-deck/...`
+
+- [ ] **Step 5: Run upstream's existing fork tests** — `GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/... ./internal/git/... -run "Fork|WithState|RegressionFor1029" -race -count=1`. Should still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/agent-deck/session_cmd.go internal/git/setup.go
+git commit -m "feat(cli): parent-HEAD + destination collision + cleanup-on-error for fork --with-state"
+```
+
+---
+
+## Task A4 — CLI before-start hook + contract tests (gaps 8, 9)
+
+**Files:**
+- Modify: `cmd/agent-deck/session_cmd.go` (add `sessionForkBeforeStartHook` test seam)
+- Create: `cmd/agent-deck/session_cmd_fork_state_test.go`
+
+Add a test-only `sessionForkBeforeStartHook` variable that lets contract tests inspect the prepared `Instance` and the resolved `git.WorktreeStateOptions` before `Start()` is called. (Upstream's #1030 did **not** add with-state fields to `session.ClaudeOptions`; the flags flow through the git layer, so the hook surfaces them directly.) Then write contract tests for the explicit-destination refusal, collision refusal, and option propagation.
+
+- [ ] **Step 1: Add the hook variable in `cmd/agent-deck/session_cmd.go`**
+
+```go
+// sessionForkBeforeStartHook is nil in production. Tests assign it to inspect
+// the fully-prepared fork before tmux Start() mutates the environment. The
+// with-state flag values are captured separately because upstream's #1030
+// wired them through git.WorktreeStateOptions, not session.ClaudeOptions.
+var sessionForkBeforeStartHook func(parent *session.Instance, forked *session.Instance, state git.WorktreeStateOptions)
+```
+
+In `handleSessionFork`, immediately before `forkedInst.Start()`, add:
+
+```go
+if sessionForkBeforeStartHook != nil {
+    sessionForkBeforeStartHook(inst, forkedInst, git.WorktreeStateOptions{WithState: wantState, WithIgnored: *withStateGitignored})
+    return
+}
+```
+
+- [ ] **Step 2: Write `cmd/agent-deck/session_cmd_fork_state_test.go`**
+
+(Full test file — uses `runAgentDeck` test helper from existing tests if available; otherwise inline shell-out to the built binary. Covers:)
+- `TestSessionFork_WithStateRequiresExplicitDestinationBranch` — `--with-state` without `-w` → exit non-zero, error message
+- `TestSessionFork_WithStateAndGitignoredRequiresExplicitDestinationBranch` — same for `--with-state-and-gitignored`
+- `TestSessionFork_WithState_RejectsExistingDestinationBranch` — `-w fork/existing --with-state` → error mentions "already exists"
+- `TestSessionFork_WithState_RejectsExistingDestinationWorktree` — pre-create worktree, then `-w fork/used --with-state` → error mentions "already has a worktree"
+- `TestSessionFork_WithStateOptionsPropagatedBeforeStart` — uses `sessionForkBeforeStartHook` to capture the resolved `git.WorktreeStateOptions` plus the forked `*session.Instance`, asserts `state.WithState && state.WithIgnored` and that the forked instance was created on the requested worktree branch (e.g. `fork/with-env`). The flags do **not** live on `session.ClaudeOptions` — upstream's #1030 routes them through the git layer.
+
+- [ ] **Step 3: Add 4 missing mid-op refusal tests in `internal/git/issue1029_edge_test.go`**
+
+Upstream has `TestRefuseUnsafeParentState_Merge` (or similar). Add `_Rebase`, `_CherryPick`, `_Revert`, `_Bisect` — each forces the corresponding mid-op state then asserts `MaterializeWipFromParent` returns an error mentioning the kind.
+
+- [ ] **Step 4: Run** — `GOTOOLCHAIN=go1.24.0 go test ./cmd/agent-deck/... ./internal/git/... -run "SessionFork_WithState|RefuseUnsafeParentState" -race -count=1`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/agent-deck/session_cmd.go cmd/agent-deck/session_cmd_fork_state_test.go internal/git/issue1029_edge_test.go
+git commit -m "test(cli): contract tests for --with-state + 4 missing mid-op refusal regressions"
+```
+
+---
+
+## Task A5 — Parent-untouched invariant test (gap 5)
+
+**Files:**
+- Create: `internal/git/materialize_wip_invariant_test.go`
+
+```go
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMaterializeWipFromParent_ParentUntouched(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+	// Build a complex WIP state on parent: staged + unstaged + untracked.
+	writeFile(t, parent, "tracked.txt", "tracked\n")
+	runGit(t, parent, "add", "tracked.txt")
+	runGit(t, parent, "commit", "-m", "tracked")
+	writeFile(t, parent, "tracked.txt", "staged\n")
+	runGit(t, parent, "add", "tracked.txt")
+	writeFile(t, parent, "tracked.txt", "staged\nunstaged\n")
+	writeFile(t, parent, "new-untracked.txt", "untracked\n")
+
+	statusBefore := runGit(t, parent, "status", "--porcelain")
+	diffCachedBefore := runGit(t, parent, "diff", "--cached")
+	diffBefore := runGit(t, parent, "diff")
+	stashBefore := runGit(t, parent, "stash", "list")
+
+	parentHead, err := HeadCommit(parent)
+	if err != nil { t.Fatal(err) }
+	child := parent + "-fork"
+	if _, err := CreateWorktreeAtStartPoint(parent, child, "fork/inv", parentHead); err != nil { t.Fatal(err) }
+	if err := MaterializeWipFromParent(parent, child, false); err != nil { t.Fatal(err) }
+
+	if got := runGit(t, parent, "status", "--porcelain"); got != statusBefore {
+		t.Fatalf("parent status changed:\nbefore:\n%s\nafter:\n%s", statusBefore, got)
+	}
+	if got := runGit(t, parent, "diff", "--cached"); got != diffCachedBefore {
+		t.Fatalf("parent staged diff changed")
+	}
+	if got := runGit(t, parent, "diff"); got != diffBefore {
+		t.Fatalf("parent unstaged diff changed")
+	}
+	if got := runGit(t, parent, "stash", "list"); got != stashBefore {
+		t.Fatalf("parent stash list changed:\nbefore:\n%s\nafter:\n%s", stashBefore, got)
+	}
+}
+```
+
+`writeFile` and `runGit` are shared test helpers from the existing `internal/git/*_test.go` files.
+
+- [ ] **Step 1: Add the test, run, expect PASS** (upstream's implementation already satisfies this invariant; this is a regression test against future changes)
+
+- [ ] **Step 2: Commit** — `git commit -m "test(git): assert MaterializeWipFromParent leaves parent byte-identical"`
+
+---
+
+## Task A6 — Bare-repo + linked parent worktree test (gap 6)
+
+**Files:**
+- Create: `internal/git/fork_with_state_integration_test.go`
+
+Test that fork-with-state works when:
+- The repository is a bare-layout project (`.bare/` directory inside the project root)
+- The parent session lives in a linked worktree (not in the bare dir itself)
+- The fork is anchored at the parent worktree's HEAD via `CreateWorktreeAtStartPoint`
+
+- [ ] **Step 1: Write `TestForkWithState_BareRepoLayoutLinkedParentWorktree`** — initialize bare repo, create seed clone, push initial commit, create parent linked worktree from bare, dirty parent (WIP), capture parent HEAD, create fork worktree via `CreateWorktreeAtStartPoint(GetWorktreeBaseRoot(root), fork-path, "fork/bare", parentHead)`, materialize, assert fork's WIP matches parent's.
+
+- [ ] **Step 2: Run, commit**
+
+---
+
+## Task A7 — Setup-hook observation test (gap 7)
+
+**Files:**
+- Modify: `internal/git/fork_with_state_integration_test.go`
+
+Setup script writes the SHA of a parent-WIP file into a marker. Test asserts the marker contains the parent-WIP content's SHA, proving setup ran AFTER materialization.
+
+- [ ] **Step 1: Add `TestForkWithState_SetupHookObservesMaterializedState`** — places `.agent-deck/worktree-setup.sh` in parent that does `sha256sum wip.txt > /tmp/marker.txt`; dirty parent with `wip.txt`; run the full A3 sequence; assert `/tmp/marker.txt` contains the SHA of "wip-content".
+
+- [ ] **Step 2: Commit**
+
+---
+
+## Task A8 — CLI behavioral eval (gap 10 CLI)
+
+**Files:**
+- Create: `tests/eval/session/fork_with_state_test.go`
+
+Eval-tagged (`//go:build eval_smoke`) test that runs the compiled `agent-deck` binary against a scratch HOME, a fake `claude` script, and a real git repo. Asserts that `agent-deck session fork <parent> --with-state-and-gitignored -w fork/eval` creates a new destination worktree at the correct path with parent's WIP materialized.
+
+- [ ] **Step 1: Write the eval test** — model after existing evals in `tests/eval/session/`
+- [ ] **Step 2: Run with `-tags eval_smoke`, commit**
+
+---
+
+## Task A9 — PR-A verification
+
+- [ ] **Step 1: Run formatter + linter + tests**
+
+```bash
+GOTOOLCHAIN=go1.24.0 make fmt
+GOTOOLCHAIN=go1.24.0 make lint
+GOTOOLCHAIN=go1.24.0 make test
+```
+
+- [ ] **Step 2: Run the mandate suite** — from the followup spec's `## Mandatory test coverage` section.
+
+- [ ] **Step 3: Re-run upstream's existing tests to confirm no regression**
+
+```bash
+GOTOOLCHAIN=go1.24.0 go test ./internal/git/... -run "Issue1029|RegressionFor1029" -race -count=1
+```
+
+- [ ] **Step 4: Commit fixes if any**
+
+---
+
+## Task A10 — Open PR-A
+
+- [ ] **Step 1: Push** — `git push -u origin feature/fork-worktree-with-state` (or a sub-branch named `feature/fork-with-state-pr-a` if PR-A is on a different branch from PR-B)
+- [ ] **Step 2: Open PR-A** via `gh pr create` against `upstream/main`. Reference issue #1029 and PR #1030. Body cites the followup spec, the gap analysis, and lists the gaps PR-A closes.
+- [ ] **Step 3: Report PR-A URL**
+
+---
+
+# PR-B — TUI integration (depends on PR-A merge)
+
+Closes gap 1, plus the TUI portions of gaps 3, 4, and 10.
+
+## Task B1 — `ForkDialog` state + getters (gap 1)
+
+**Files:**
+- Modify: `internal/ui/forkdialog.go`
+
+Add `withStateEnabled bool` and `withStateAndGitignored bool` fields. Exported getters: `IsWithStateEnabled()`, `IsWithStateAndGitignoredEnabled()`. Toggle methods: `ToggleWithState()`, `ToggleWithStateAndGitignored()`. Nested-state invariants: `ToggleWithState` is a no-op unless worktree is on; `ToggleWorktree` clears with-state if turning off; `ToggleWithStateAndGitignored` is a no-op unless with-state is on; `ToggleWithState` clears gitignored if turning off.
+
+- [ ] **Step 1: Add fields, exported getters, and toggle methods**
+- [ ] **Step 2: Reset fields in `Show()` and `Hide()`**
+- [ ] **Step 3: Verify compile** — `GOTOOLCHAIN=go1.24.0 go build ./internal/ui/...`
+- [ ] **Step 4: Commit** — `git commit -m "feat(tui): ForkDialog state + getters for fork-with-state"`
+
+## Task B2 — `ForkDialog` focus targets (gap 1)
+
+**Files:**
+- Modify: `internal/ui/forkdialog.go`
+
+Refactor to use the existing `NewDialog` focus-target pattern: declare `forkFocusTarget` enum, ordered `focusTargets` slice rebuilt on conditional toggles. Replace numeric `focusIndex` arithmetic.
+
+- [ ] **Step 1-5: Apply focus-target refactor as documented in the deprecated plan's Task 15A**
+- [ ] **Step 6: Commit**
+
+## Task B3 — `ForkDialog` rendering + key handlers + tests (gap 1)
+
+**Files:**
+- Modify: `internal/ui/forkdialog.go`
+- Modify: `internal/ui/forkdialog_test.go`
+
+Render the two new checkboxes when worktree is on; render the gitignored checkbox nested when with-state is on. Wire `y` and `i` key handlers. Add state-machine tests (toggle requires worktree, toggling worktree off clears with-state, etc.).
+
+- [ ] **Step 1: Add checkbox rendering in `View()`**
+- [ ] **Step 2: Add `y`/`i` key handlers in `Update()`**
+- [ ] **Step 3: Add state-machine tests in `forkdialog_test.go`**
+- [ ] **Step 4: Run, commit**
+
+## Task B4 — TUI submit wires collision check + cleanup-on-error (gaps 1, 3-TUI, 4-TUI)
+
+**Files:**
+- Modify: `internal/ui/home.go`
+
+In `forkSessionCmdWithOptions`, read the with-state booleans from the dialog getters (`IsWithStateEnabled`, `IsWithStateAndGitignoredEnabled`) and build a local `stateOpts := git.WorktreeStateOptions{WithState: ..., WithIgnored: ...}`. (Named `stateOpts` rather than `opts` to avoid collision with the `opts *session.ClaudeOptions` convention used throughout this package; these flags are **not** carried on `session.ClaudeOptions` — upstream wired them through the git layer in #1030.) Replace the existing `CreateWorktreeWithSetup` call with a flow that:
+1. Calls `ValidateForkWithStateDestination` first (if `stateOpts.WithState`)
+2. Calls `HeadCommit(source.ProjectPath)` for parent-HEAD anchoring (if `stateOpts.WithState`)
+3. Calls `CreateWorktreeAtStartPoint` (with-state) or `CreateWorktree` (legacy)
+4. Calls `MaterializeWipFromParent(source.ProjectPath, worktreePath, stateOpts.WithIgnored)` (with-state) with cleanup-on-error
+5. Calls `ProcessWorktreeInclude` + setup hook
+
+Returns `sessionForkedMsg{err: ..., sourceID: ...}` on error.
+
+- [ ] **Step 1-5: Implement, test, commit**
+
+## Task B5 — TUI behavioral eval (gap 10 TUI)
+
+**Files:**
+- Create: `internal/ui/forkdialog_eval_test.go`
+
+Eval-tagged test that renders `ForkDialog`, drives `w → y → i` keystrokes, asserts visible checkbox text appears via substring checks on `View()` output, and asserts the getters report submitted values.
+
+- [ ] **Step 1: Write `TestEval_ForkDialog_WithStateVisibleInteraction`**
+- [ ] **Step 2: Commit**
+
+## Task B6 — PR-B verification
+
+- [ ] Same as A9: fmt, lint, test, mandate suite, regression check.
+
+## Task B7 — Open PR-B
+
+- [ ] **Step 1: Rebase onto upstream/main** (which should now include PR-A after merge)
+- [ ] **Step 2: Push + open PR-B** referencing PR-A and the followup spec.
+
+---
+
+## Mandate verification (post-implementation)
+
+After Tasks A1-A10 and B1-B7 are all complete, run the followup spec's mandate suite:
+
+```bash
+go test ./internal/git/... -run "Materialize|RefuseUnsafeParentState|ValidateForkWithStateDestination|CreateWorktreeAtStartPoint|HeadCommit|ForkWithState|Issue1029" -race -count=1
+go test ./cmd/agent-deck/... -run "SessionFork_WithState" -race -count=1
+go test ./internal/ui/... -run "ForkDialog_(WithState|ToggleWithState|GitignoredRequires|Toggling|FocusOrder)" -race -count=1
+go test -tags eval_smoke ./tests/eval/session/... ./internal/ui/... -run "TestEval_SessionForkWithState|TestEval_ForkDialog_WithState" -race -count=1
+```
+
+Each command must match at least one test. If any returns "no tests to run," update the spec's regex to match the actual test names.
+
+---
+
+## Spec coverage check
+
+| Gap | Spec section | Plan task(s) |
+|---|---|---|
+| 1. TUI integration | G1 | B1, B2, B3, B4 |
+| 2. Parent-HEAD start point | G2 | A1, A3 |
+| 3. Destination collision validation | G3 | A2, A3, B4 |
+| 4. Cleanup-on-error (CLI) | G4 | A3 |
+| 4. Cleanup-on-error (TUI) | G4 | B4 |
+| 5. Parent-untouched invariant | G5 | A5 |
+| 6. Bare-repo + linked parent worktree | G6 | A6 |
+| 7. Setup-hook observation | G7 | A7 |
+| 8. 4 missing mid-op refusal tests | G8 | A4 (step 3) |
+| 9. CLI before-start hook contract test | G9 | A4 (steps 1-2) |
+| 10. Behavioral eval smoke (CLI) | G10 CLI | A8 |
+| 10. Behavioral eval smoke (TUI) | G10 TUI | B5 |
+| 11. Shared `PreflightForkWithState` extraction | Out of scope | Deferred PR-C |
+
+No gap without a task (except gap 11 by explicit design).
+
+---
+
+## Out of scope (deferred PR-C)
+
+**Gap 11 — Shared `PreflightForkWithState` extraction.** Upstream's `refuseUnsafeParentState` is internal/lowercase and returns a plain formatted `error`. Promoting it to an exported helper that returns typed `InProgressOperationError` is a structural change to upstream's just-merged code; it deserves an RFC discussion with @asheshgoplani before implementation. PR-A and PR-B leave `refuseUnsafeParentState` alone — they call into `MaterializeWipFromParent` which has the refusal baked in. The price is that the CLI and TUI can't share a single explicit preflight gate with surface-specific error rendering; the refusal happens inside materialize. Acceptable for the user-visible behavior of PR-A and PR-B.
+
+---
+
+## Review change log
+
+- 2026-05-19: FUS-002 — Removed stale references to ClaudeOptions.WithState/IncludeGitignored fields. Upstream's #1030 chose a different architecture (flags flow through git.WorktreeStateOptions, not ClaudeOptions). Plan corrected to reflect upstream's actual wiring; A4's CLI contract tests already adapted to the real shape. Dropped the `internal/session/tooloptions.go` file-map row and rewrote the A4 before-start hook signature + the propagation assertion to use `git.WorktreeStateOptions` instead of `*session.ClaudeOptions`.

--- a/docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md
+++ b/docs/superpowers/specs/2026-05-14-fork-worktree-with-state-design.md
@@ -1,0 +1,473 @@
+# Fork-with-State: Carry Parent Working-Tree Contents into a New Worktree
+
+> **⚠ DEPRECATED — superseded by [`2026-05-18-fork-with-state-followup-design.md`](2026-05-18-fork-with-state-followup-design.md)**
+>
+> This document was written as a ground-up design before upstream merged #1029
+> (commit 6a1645eb). It remains as historical reference for the design
+> reasoning, decision log, and FWS-001 through FWS-018 entries. The active
+> design is now in the followup file. See also the post-merge gap analysis at
+> [`../discussions/2026-05-18-post-merge-gap-analysis.md`](../discussions/2026-05-18-post-merge-gap-analysis.md).
+
+**Status:** Deprecated 2026-05-18 — historical reference only
+**Date:** 2026-05-14
+**Author:** Steve Morin (steve.morin@gmail.com)
+**Related code:**
+- `cmd/agent-deck/session_cmd.go` (fork CLI handler)
+- `internal/ui/forkdialog.go` (TUI fork dialog)
+- `internal/git/git.go`, `internal/git/setup.go` (worktree plumbing)
+- `internal/session/instance.go` (`CreateForkedInstanceWithOptions`)
+
+## Problem
+
+Today `agent-deck session fork` has two modes:
+
+1. **Without `-w`:** the forked Claude session inherits the parent's `ProjectPath` verbatim. Two Claude sessions end up sharing the same working directory — a silent footgun, especially when the parent already lives in a worktree.
+2. **With `-w <branch>`:** a new worktree is created at the tip of the named branch (or off the default branch with `-b`). The new worktree is **clean** — none of the parent's uncommitted changes, staged hunks, or untracked files are carried over.
+
+For active development sessions, the second mode misses what users usually want: forking the parent *as it currently looks on disk*, including in-progress edits, staged hunks, and new untracked files Claude just created.
+
+## Goal
+
+Add an opt-in mode that creates a **complete parallel agent environment**: a new destination branch/worktree whose working tree exactly mirrors the parent's at the moment of fork — preserving the staged/unstaged split, untracked files, and (optionally) gitignored files — AND a forked Claude Code session whose conversation history continues from the parent session via the existing `agent-deck session fork` mechanism. The parent repo must be left byte-identical after the operation.
+
+The two pieces compose: file materialization (this feature's new code) sits on top of session forking (the existing `agent-deck session fork` flow that calls `claude --resume <parent-id> --fork-session`). Together they let a user reach an interesting point in a task, then explore multiple agent paths in parallel from the exact same WIP baseline with full conversation continuity — not just file copies started from a blank session.
+
+## Non-goals
+
+- Replacing the existing `-w` behavior. The clean-branch path stays as-is for users who want it.
+- Auto-detecting "parent is in a worktree" and forcing the new mode. Behavior is purely opt-in.
+- Supporting parent repos in mid-rebase / mid-merge / mid-cherry-pick / mid-revert / mid-bisect. These are refused with actionable errors.
+- Submodule recursion. Submodule states are copied as files, not recursed into.
+- Quiescing parent's tmux session during materialization. Parent edits during the fork are accepted as staleness.
+- Size caps on gitignored copies. If the user typed `--with-state-and-gitignored`, we trust them.
+
+## User-facing surface
+
+### CLI
+
+```
+agent-deck session fork <id|title> [existing options] \
+    -w, --worktree <new-branch>      (existing) create a worktree; required destination branch for --with-state
+    -b, --new-branch                 (existing) create the branch if it doesn't exist; not required for --with-state
+    --with-state                     NEW: carry parent's tracked + staged + untracked state.
+                                          CLI requires --worktree <new-branch>; no hidden branch suggestion.
+    --with-state-and-gitignored      NEW: also copy gitignored files. Implies --with-state.
+```
+
+**CLI destination contract:** `--with-state-and-gitignored` → `--with-state`, and `--with-state` requires `-w/--worktree <new-branch>`. The CLI does not auto-name the destination branch. In fork-with-state mode, the `-w` value names a new destination branch from the parent session's HEAD; `-b` is not required and existing destination branches/worktrees are refused.
+
+### TUI (`ForkDialog`)
+
+Under the existing "Create in worktree" checkbox, two new nested checkboxes appear when the worktree checkbox is on:
+
+```
+[x] Create in worktree (press w)
+    Branch: fork/my-session
+    [ ] Carry parent state (press y)
+        [ ] Include gitignored files (press i)    ← only visible when "Carry parent state" is on
+```
+
+The TUI may suggest/prefill `fork/<sanitized-session>` in the branch field because the user can see and edit it before submit. That field is always the destination branch name, not the source branch.
+
+Focus order: name → group → wt-checkbox → branch → with-state-checkbox → with-state-gitignored-checkbox → conductor → options panel.
+
+## Design
+
+### Architecture
+
+| Layer | New | Notes |
+|---|---|---|
+| CLI handler (`session_cmd.go`) | New flag parsing + implication resolution + cleanup-on-error guard | |
+| TUI dialog (`forkdialog.go`) | Two new bool fields, two new checkboxes, two new exported getters | |
+| Session options (`session.ClaudeOptions`) | Two new transient fields `WithState`, `IncludeGitignored` | Not persisted to disk; consumed during fork startup only |
+| Git plumbing (`internal/git/`) | New file `worktree_with_state.go` with shared `PreflightForkWithState` and `ValidateForkWithStateDestination` helpers; start-point-aware worktree helper; split of `CreateWorktreeWithSetup` into `CreateWorktree` + `RunWorktreeSetup`; integration with existing `ProcessWorktreeInclude` (PR #890) preserves the materialize → worktreeinclude → setup ordering | |
+| `Instance.CreateForkedInstanceWithOptions` | No signature change | Materialization happens in the CLI/TUI handler, before this is called |
+
+### New git helper layer (`internal/git/worktree_with_state.go`)
+
+```go
+type StateCopyOptions struct {
+    IncludeGitignored bool
+}
+
+type StateCopyResult struct {
+    TrackedFilesPatched   int
+    UntrackedFilesCopied  int
+    GitignoredFilesCopied int
+}
+
+// MaterializeParentState copies parent's staged + unstaged + untracked
+// (and optionally gitignored) into newWorktree. Read-only on parentWorktree.
+// Caller is responsible for the worktree already existing at newWorktree.
+func MaterializeParentState(parentWorktree, newWorktree string, opts StateCopyOptions) (*StateCopyResult, error)
+
+// DetectInProgressOperation returns "rebase", "merge", "cherry-pick", "revert",
+// "bisect", or "". Used as a pre-flight refusal check. Each kind is detected via
+// the presence of the corresponding state file in .git: MERGE_HEAD,
+// CHERRY_PICK_HEAD, REVERT_HEAD, BISECT_LOG, or the rebase-merge/rebase-apply
+// directories.
+func DetectInProgressOperation(repoDir string) (kind string, err error)
+
+// HasSubmodules returns true if .gitmodules exists. Used to emit a warning,
+// not to refuse the operation.
+func HasSubmodules(repoDir string) (bool, error)
+
+type ForkWithStatePreflight struct {
+    ParentHead    string
+    HasSubmodules bool
+}
+
+// InProgressOperationError is returned by PreflightForkWithState when the
+// parent is mid-rebase, mid-merge, mid-cherry-pick, mid-revert, or mid-bisect.
+// CLI and TUI callers own the final user-facing wording.
+type InProgressOperationError struct {
+    Kind    string
+    RepoDir string
+}
+
+func (e *InProgressOperationError) Error() string
+
+// PreflightForkWithState is the shared CLI/TUI fork-with-state gate. It
+// refuses unsupported in-progress operations, captures the parent HEAD start
+// point, and returns submodule presence as a warning fact for callers to render.
+func PreflightForkWithState(parentWorktree string) (*ForkWithStatePreflight, error)
+
+// DestinationCollisionError is returned by ValidateForkWithStateDestination when
+// the requested destination branch already exists locally or already has a
+// worktree. CLI and TUI callers own the final user-facing wording.
+type DestinationCollisionError struct {
+    Kind   string // "worktree_exists" or "branch_exists"
+    Branch string
+    Path   string // populated when Kind == "worktree_exists"
+}
+
+func (e *DestinationCollisionError) Error() string
+
+// ValidateForkWithStateDestination is the shared CLI/TUI destination collision
+// gate for fork-with-state. It returns a typed DestinationCollisionError when
+// the destination branch already has a worktree or already exists as a local
+// branch. Both checks are git facts; callers format the error appropriately.
+// Order matters: worktree-collision is checked first so the more specific error
+// (with path) is surfaced when both conditions are true.
+func ValidateForkWithStateDestination(repoRoot, branch string) error
+```
+
+### Split of `CreateWorktreeWithSetup`
+
+The existing `internal/git/setup.go:CreateWorktreeWithSetup` is currently atomic: it runs `git worktree add` then the setup hook. To slot materialization between these steps, we split it:
+
+```go
+// Existing: creates a worktree from the invocation repo's current HEAD, no setup.
+func CreateWorktree(repoDir, worktreePath, branch string) error
+
+// New: creates a worktree from an explicit start point, no setup.
+// The fork-with-state path passes the parent session's HEAD here so linked
+// parent worktrees fork from the parent worktree commit, not the main worktree.
+func CreateWorktreeAtStartPoint(repoDir, worktreePath, branch, startPoint string) (createdBranch bool, err error)
+
+// New: discovers the user's setup hook from repoDir, then runs it against an
+// existing worktree. Returns the script's exit error; callers keep treating
+// setup failures as warnings.
+func RunWorktreeSetup(repoDir, worktreePath string, stdout, stderr io.Writer, timeout time.Duration) error
+
+// Existing function becomes a thin wrapper preserving backward compatibility:
+func CreateWorktreeWithSetup(...) (setupErr error, err error) {
+    if err := CreateWorktree(...); err != nil { return nil, err }
+    return RunWorktreeSetup(repoDir, worktreePath, stdout, stderr, timeout), nil
+}
+```
+
+The fork-with-state path calls `CreateWorktreeAtStartPoint` → `MaterializeParentState` → `RunWorktreeSetup(repoRoot, worktreePath, ...)` directly. All other existing callers keep using `CreateWorktreeWithSetup`.
+
+**Rationale:** the setup hook (e.g., `npm install`, `uv sync`) is the user's "prepare this worktree for work" script. It needs to see the final file contents — including parent's WIP. If we materialized *after* setup, a parent with a new dependency in `package.json` would yield a worktree with new `package.json` but old `node_modules`. The API keeps both `repoDir` and `worktreePath` because setup scripts are discovered from `<repoDir>/.agent-deck/worktree-setup.sh`, but executed with the new worktree as the current working directory.
+
+### Data flow
+
+```
+Step 1. Parse + resolve
+  - Resolve session id/title → *session.Instance (parent)
+  - Apply implication chain: gitignored → with-state
+  - CLI: if with-state is set and no `-w/--worktree <new-branch>` was supplied, refuse with an actionable error
+  - TUI: use the visible/editable branch-field suggestion as the destination branch
+  - Validate parent is a Claude session and CanFork()
+
+Step 2. Resolve branch + path and run destination collision checks
+  - Apply wtSettings.ApplyBranchPrefix() to the destination branch
+  - If with-state: call git.ValidateForkWithStateDestination(repoRoot, branch); refuse with a typed DestinationCollisionError if the destination branch already has a worktree or already exists
+  - Compute worktree path via git.WorktreePath() with wtSettings.Template
+  - Existing worktree reuse remains unchanged for normal, non-with-state `-w` (with-state cannot reach the reuse block because the shared validator refused first)
+
+Step 3. Pre-flight on parent's git state
+  - Call git.PreflightForkWithState(parent.ProjectPath)
+  - If it returns InProgressOperationError for rebase, merge, cherry-pick, revert, or bisect: refuse with an actionable error
+  - If it returns another error: refuse before creating the destination worktree
+  - If preflight.HasSubmodules is true: log a warning ("submodules will be copied as-is, not recursed")
+  - Use preflight.ParentHead as the worktree start point
+  - Step 2 runs before Step 3 because destination collision validation is local-state (cheap) and preflight shells out to git; the structural-guard test only enforces preflight before CreateWorktreeAtStartPoint, not before the collision check
+
+Step 4. Create worktree (no setup yet)
+  - git.CreateWorktreeAtStartPoint(repoRoot, worktreePath, branch, parentHead)
+  - This is required when the parent session already lives in a linked worktree whose HEAD differs from the main/base worktree.
+  - On error: abort, nothing to clean up
+
+Step 5. Materialize parent state                                        NEW
+  - git.MaterializeParentState(parent.ProjectPath, worktreePath, opts)
+    Internally:
+      a. git -C parent diff --cached --binary | git -C newWorktree apply --index
+         (updates the new worktree's index and working tree to the parent's staged state)
+      b. git -C parent diff --binary          | git -C newWorktree apply
+         (applies the parent's unstaged delta on top of the staged working-tree content)
+      c. git -C parent ls-files --others -z --exclude-standard
+         (NUL-separated to safely handle paths with embedded newlines)
+         → copy each parent/<f> → newWorktree/<f> preserving mode
+      d. if IncludeGitignored, run a SECOND pass and union with the first:
+         git -C parent ls-files --others -z --ignored --exclude-standard
+         (Important: `--ignored` is a FILTER on the listing, not additive. With
+          `--exclude-standard`, the flag flips the listing to ONLY ignored files
+          and excludes non-ignored ones. To capture non-ignored untracked AND
+          ignored untracked, two passes must be run and unioned.)
+         → copy with mode preserved, no size cap
+  - On any failure: return error to caller (cleanup happens in Step 7)
+
+Step 5.5. Run worktreeinclude file copying (existing feature from PR #890)
+  - git.ProcessWorktreeInclude(repoRoot, worktreePath, stderr)
+  - Reads `.worktreeinclude` (or `.agent-deck/worktreeinclude`) from `repoRoot` and copies the listed files into `worktreePath`.
+  - Today this runs unconditionally as part of the worktree-creation flow; the fork-with-state sequence must preserve that ordering: materialize FIRST so worktreeinclude sees the materialized parent state, then setup script sees the result of both.
+  - worktreeinclude failures are warnings, not errors (matches existing behavior).
+
+Step 6. Run setup hook                                                  CHANGED
+  - git.RunWorktreeSetup(repoRoot, worktreePath, stdout, stderr, timeout)
+  - `repoRoot` is used for setup-script discovery; `worktreePath` is the execution cwd
+  - Setup-hook failures stay warnings (matches current session_cmd.go:740)
+
+Step 7. Cleanup-on-error guard                                          NEW
+  - If steps 4-6 succeed, no-op.
+  - If step 5 fails:
+      git -C repoRoot worktree remove --force worktreePath
+      git -C repoRoot branch -D <branch>   (only if branch creation is proven for this operation)
+    Then surface the original error to the user.
+
+Step 8. Construct in-memory forked Instance
+  - opts.WorkDir / WorktreePath / WorktreeRepoRoot / WorktreeBranch set as today
+  - opts.WithState / opts.IncludeGitignored remain in-memory only
+  - inst.CreateForkedInstanceWithOptions(forkTitle, forkGroup, opts)
+
+Step 9. Start + capture session id + persist
+  - Unchanged from today (forkedInst.Start + PostStartSync + SaveWithGroups)
+```
+
+### Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Default behavior | Opt-in only | Don't change existing fork semantics. Footgun in current code (silent shared worktree) is not addressed by this feature; out of scope. |
+| Destination branch | CLI requires explicit `-w/--worktree <new-branch>`; TUI may prefill `fork/<sanitized-session>` | CLI should not create a hidden name. TUI suggestions are visible and editable before submit. |
+| Source shape | Parent session may be on an existing branch, a linked worktree, or detached HEAD | Fork-with-state uses the parent session's resolved `HEAD` commit as the start point, independent of source branch/worktree shape. |
+| Existing worktree reuse | Refuse for with-state; unchanged for normal `-w` | A with-state fork must create a fresh destination branch/worktree. Reusing an existing worktree can silently skip materialization or overwrite unrelated state. |
+| State scope | tracked-modified + staged + untracked, gitignored opt-in | Most-common need. Gitignored often means node_modules / .env — opt-in protects against accidents. |
+| Index fidelity | Preserve staged vs. unstaged split | Two-stage `git apply --index` then `git apply`. The staged patch must update both the index and working tree so partially-staged files and staged deletions remain faithful before the unstaged patch is applied. |
+| In-progress ops | Refuse rebase, merge, cherry-pick, revert, bisect | Cleanest semantics; ship v1 smaller. Revert leaves `REVERT_HEAD` and conflicted files exactly like merge does, so it gets the same refusal. |
+| Submodules | Best-effort copy, no recursion | Warn but don't refuse. |
+| LFS | Treat as regular file copy (LFS pointer files self-handle) | Standard LFS behavior. |
+| Gitignored size cap | None | User who typed `--with-state-and-gitignored` opted in explicitly. Cap can be added later if needed. |
+| Failure handling | Abort + cleanup | Atomic mental model: fork either happens or it doesn't. |
+| Branch cleanup proof | Delete branch only when this operation proves it created the branch | The new cleanup path must not key off intent flags alone; an existing branch must never be deleted after a materialization failure. |
+| Parent safety | Read-only on parent (`git diff`, `ls-files`, file reads — no `git stash`, no `git add`) | Parent's index, working tree, stash list, and `.git` must be byte-identical after fork. |
+| Race vs. parent writes | Accept staleness, document it | Materialization is not atomic. Fork captures parent state at moment-of-fork. |
+| Setup-hook ordering | Materialize → worktreeinclude → setup script | Setup hook sees parent's final state and can react to it (e.g., install new deps from WIP package.json). `ProcessWorktreeInclude` from PR #890 also runs after materialization so it can copy auto-included files on top of the materialized state without losing parent WIP. The chain is: `CreateWorktree → MaterializeParentState → ProcessWorktreeInclude → RunWorktreeSetup`. |
+
+## Errors and cleanup
+
+### Cleanup matrix
+
+| Failure point | Cleanup action |
+|---|---|
+| Destination collision check (Step 2) | None — early exit |
+| Pre-flight (Step 3) | None — early exit |
+| `CreateWorktree` (Step 4) | None — git rolls back its own failed `worktree add` |
+| Materialization (Step 5) | `git worktree remove --force <path>`, then `git branch -D <branch>` only when branch creation is proven for this operation |
+| `ProcessWorktreeInclude` (Step 5.5) | None — already a non-fatal warning today (matches existing PR #890 behavior) |
+| Setup hook (Step 6) | None — already a non-fatal warning today |
+| `Instance.Start` (Step 9) | None — leave worktree for inspection (matches today's behavior) |
+
+### Error message catalog
+
+```
+"parent session is mid-rebase; finish or abort the rebase before forking with state (cd <parent-path> && git rebase --abort)"
+"parent session is mid-merge; resolve or abort the merge before forking with state"
+"parent session is mid-cherry-pick; finish or abort before forking with state"
+"parent session is mid-revert; finish or abort the revert before forking with state (cd <parent-path> && git revert --abort)"
+"parent session is mid-bisect; run 'git bisect reset' in <parent-path> before forking with state"
+"--with-state requires --worktree <new-branch>"
+"branch '<branch>' already exists; choose a new destination branch for --with-state"
+"branch '<branch>' already has a worktree at <path>; choose a new destination branch for --with-state"
+"failed to apply parent's staged changes: <git error>; new worktree cleaned up"
+"failed to apply parent's unstaged changes: <git error>; new worktree cleaned up"
+"failed to copy untracked file <path>: <error>; new worktree cleaned up"
+```
+
+Warnings (non-fatal, written to stderr, fork proceeds):
+
+```
+"submodules detected — copied as files, not recursed (parent's submodule states preserved)"
+"setup script failed: <error>" (existing behavior)
+```
+
+## Testing
+
+Following CLAUDE.md "TDD always" — regression tests for the contract land before implementation.
+
+### Unit tests — `internal/git/worktree_with_state_test.go` (new)
+
+| Test | Asserts |
+|---|---|
+| `TestMaterialize_TrackedUnstaged` | new worktree has same file contents; `git status` shows unstaged |
+| `TestMaterialize_TrackedStaged` | new worktree's index matches; `git diff --cached` reproduces parent's patch |
+| `TestMaterialize_PartiallyStaged` | partial staging preserved exactly |
+| `TestMaterialize_Untracked` | untracked files present in new worktree with mode preserved (incl. exec bit) |
+| `TestMaterialize_UntrackedGitignored_Excluded` | default opts → gitignored files NOT copied |
+| `TestMaterialize_UntrackedGitignored_Included` | with `IncludeGitignored: true` → gitignored files copied |
+| `TestMaterialize_BinaryFiles` | modified binary file bytes match (verified via sha256) |
+| `TestMaterialize_DeletedFromIndex` | staged deletion preserved in new index |
+| `TestMaterialize_NoChanges` | clean parent → clean new worktree, no error |
+| `TestMaterialize_ParentUntouched` | after materialize, parent's `git status`, index, stash list byte-identical |
+| `TestMaterialize_SymlinkInWorkingTree` | symlinks copied as symlinks with correct target |
+| `TestMaterialize_FileWithExecBit` | exec bit preserved |
+| `TestDetect_Rebase` | mid-rebase parent → returns "rebase" |
+| `TestDetect_Merge` | mid-merge parent → returns "merge" |
+| `TestDetect_CherryPick` | mid-cherry-pick parent → returns "cherry-pick" |
+| `TestDetect_Revert` | mid-revert parent (REVERT_HEAD present) → returns "revert" |
+| `TestDetect_Bisect` | active bisect → returns "bisect" |
+| `TestDetect_Clean` | normal repo → returns "" |
+| `TestPreflightForkWithState_RefusesInProgressOperation` | shared CLI/TUI preflight returns `InProgressOperationError` before a destination worktree can be created |
+| `TestPreflightForkWithState_ReturnsParentHeadAndSubmoduleFact` | shared preflight captures parent HEAD and returns submodule presence as a warning fact |
+| `TestValidateForkWithStateDestination_Clean` | clean repo + fresh branch name → returns nil |
+| `TestValidateForkWithStateDestination_BranchExists` | existing local branch with no worktree → returns `DestinationCollisionError{Kind: "branch_exists"}` |
+| `TestValidateForkWithStateDestination_WorktreeExists` | branch already has a worktree → returns `DestinationCollisionError{Kind: "worktree_exists", Path: <worktree-path>}` |
+
+### CLI contract tests — `cmd/agent-deck/session_cmd_fork_state_test.go`
+
+| Test | Asserts |
+|---|---|
+| `TestSessionFork_WithStateRequiresExplicitDestinationBranch` | CLI `--with-state` without `-w <new-branch>` is refused; no auto-name |
+| `TestSessionFork_WithStateAndGitignoredRequiresExplicitDestinationBranch` | CLI `--with-state-and-gitignored` also requires explicit `-w <new-branch>` |
+| `TestSessionFork_WithState_RejectsExistingDestinationBranch` | with-state refuses an existing destination branch before materialization |
+| `TestSessionFork_WithState_RejectsExistingDestinationWorktree` | with-state refuses destination branches that already have a worktree; normal `-w` reuse is unchanged |
+| `TestSessionFork_WithStateAndGitignored_PropagatesOptionsBeforeStart` | actual handler path sets `ClaudeOptions.WithState` and `IncludeGitignored` before `Start()` |
+
+### Git-side integration tests — `internal/git/worktree_with_state_integration_test.go`
+
+| Test | Asserts |
+|---|---|
+| `TestForkWithStateGitSequence_CleanParent` | clean parent → clean new worktree, no error |
+| `TestForkWithStateGitSequence_DirtyParent` | parent has staged + unstaged + untracked → fork mirrors all three |
+| `TestForkWithStateGitSequence_WithGitignored` | parent has gitignored content → fork has it |
+| `TestForkWithStateGitSequence_FailsWhenMidRebase` | parent mid-rebase → error, no worktree created |
+| `TestForkWithStateGitSequence_CleansUpOnMaterializeFailure` | injected materialize failure → worktree and branch removed |
+| `TestForkWithStateGitSequence_UsesParentWorktreeHead` | parent session in linked worktree with a different HEAD than main → fork HEAD equals parent HEAD |
+| `TestForkWithStateGitSequence_BareRepoLayoutLinkedParentWorktree` | bare-repo layout with a linked parent worktree source → works; the bare repo/project root is repository metadata, not the state source |
+| `TestForkWithStateGitSequence_MaterializesBeforeSetupHook` | setup hook sees materialized files (verified via a hook that reads a parent-WIP file) |
+
+### TUI tests — `internal/ui/forkdialog_test.go` extension
+
+State-machine tests (always-on, run via `go test ./internal/ui/...`):
+
+| Test |
+|---|
+| `TestForkDialog_ToggleWithStateRequiresWorktree` |
+| `TestForkDialog_TogglingWorktreeOffClearsWithState` |
+| `TestForkDialog_WithStateSuggestsEditableDestinationBranch` |
+| `TestForkDialog_FocusOrder` |
+
+Rendering coverage (visible-checkbox, hidden-checkbox, nested-checkbox) is provided by the eval-tagged `TestEval_ForkDialog_WithStateVisibleInteraction` in `internal/ui/forkdialog_eval_test.go` (see "Behavioral eval smoke tests" below). That test drives the dialog through the `w → y → i` keystroke sequence and asserts `View()` output via substring checks against `"Carry parent state"` and `"Include gitignored files"`, covering all three render conditions in a single visible-interaction flow. The eval suite runs on every PR via `.github/workflows/eval-smoke.yml`; local TDD requires `-tags eval_smoke`.
+
+### TUI submit-path tests — `internal/ui/home_fork_state_test.go` (new)
+
+| Test | Asserts |
+|---|---|
+| `TestForkSessionCmdWithOptions_WithStateUsesSharedPreflight` | TUI fork-with-state submit path calls `git.PreflightForkWithState(source.ProjectPath)` before `CreateWorktreeAtStartPoint`, using a brace-counted structural guard that does not duplicate the lower-level preflight calls inline |
+
+### Behavioral eval smoke tests
+
+These cases satisfy the existing evaluator-harness mandate for user-observable behavior that ordinary Go unit tests cannot fully express.
+
+| File | Test | Asserts |
+|---|---|---|
+| `tests/eval/session/fork_with_state_test.go` | `TestEval_SessionForkWithState_CreatesMaterializedWorktree` | Real `agent-deck` binary, scratch HOME, fake `claude`, and real git repo: `session fork --with-state-and-gitignored -w <new-branch>` creates a new destination worktree whose files on disk mirror the parent's staged/unstaged/untracked/gitignored state and starts the forked session in that destination cwd. |
+| `internal/ui/forkdialog_eval_test.go` | `TestEval_ForkDialog_WithStateVisibleInteraction` | Colocated eval for the TUI-only surface: rendered `ForkDialog` shows the nested with-state and gitignored controls only after the user-visible `w -> y -> i` interaction path, and the getters report the submitted values. |
+
+## Mandatory test coverage
+
+This is the authoritative mandate for fork-with-state. Per CONTRIBUTING.md, `CLAUDE.md` is per-developer and not tracked in the repo, so the mandate is housed here (the tracked spec) and referenced by CI workflows. Test names are stable contracts; any PR that changes a path under the mandate MUST run and pass all four commands below.
+
+```bash
+go test ./internal/git/... -run "Materialize|DetectInProgress|HasSubmodules|PreflightForkWithState|ValidateForkWithStateDestination|CreateWorktreeAtStartPoint|HeadCommit|ForkWithStateGitSequence" -race -count=1
+go test ./cmd/agent-deck/... -run "SessionFork_WithState|ResolveForkStateFlags" -race -count=1
+go test ./internal/ui/... -run "ForkDialog_(WithState|ToggleWithState|GitignoredRequires|Toggling|FocusOrder)|ForkSessionCmdWithOptions_WithStateUsesSharedPreflight" -race -count=1
+go test -tags eval_smoke ./tests/eval/session/... ./internal/ui/... -run "TestEval_SessionForkWithState|TestEval_ForkDialog_WithState" -race -count=1
+```
+
+### Paths under the mandate
+
+- `internal/git/worktree_with_state.go` (+ `_test.go`)
+- `internal/git/worktree_with_state_integration_test.go`
+- `internal/git/git.go` — `HeadCommit` and `CreateWorktreeAtStartPoint`
+- `internal/git/setup.go` — the `CreateWorktree` / `RunWorktreeSetup` / `CreateWorktreeWithSetup` split
+- `cmd/agent-deck/session_cmd.go` — fork handler, `resolveForkStateFlags`
+- `internal/ui/forkdialog.go` — with-state sub-checkboxes
+- `internal/ui/home.go` — TUI fork submit handler
+- `internal/ui/home_fork_state_test.go` — structural guard for shared TUI preflight
+- `tests/eval/session/fork_with_state_test.go` — real-binary CLI behavioral eval
+- `internal/ui/forkdialog_eval_test.go` — visible TUI ForkDialog behavioral eval
+- `internal/session/tooloptions.go` — `WithState` / `IncludeGitignored` fields
+
+### Structural changes requiring RFC
+
+- Re-collapsing `CreateWorktree` + `RunWorktreeSetup` back into the old monolithic `CreateWorktreeWithSetup` (breaks materialization-before-setup ordering)
+- Replacing shared `git.PreflightForkWithState` with separate CLI/TUI preflight implementations
+- Replacing shared `git.ValidateForkWithStateDestination` with inline CLI/TUI collision checks, or reintroducing a with-state branch into the existing-worktree reuse blocks in `session_cmd.go` / `home.go`
+- Mutating parent's index, working tree, or stash list as part of materialization (`git stash`, `git add`, etc.)
+- Changing `--with-state-and-gitignored` so it no longer automatically enables `--with-state`
+- Making CLI `--with-state` or `--with-state-and-gitignored` automatically create or name a worktree without explicit `-w/--worktree <new-branch>`
+- Adding silent fallbacks when materialization fails (must always cleanup + error)
+- Decoupling the Claude session fork from file materialization, or shipping `--with-state` without `--fork-session` semantics
+
+## Documentation impact
+
+- `README.md` — expand the `### Fork Sessions` section with the new CLI examples and add a short cross-reference in `### Git Worktrees`
+- `cmd/agent-deck/session_cmd.go` fork usage block — add examples and document that CLI `--with-state` requires explicit `-w/--worktree <new-branch>`
+- `CHANGELOG.md` — add a `### Added` entry under `## [Unreleased]` using the repo's Keep a Changelog prose style
+
+## Out of scope (for follow-up tickets)
+
+- Changing normal fork behavior to auto-create a worktree when the parent is already in a worktree (the existing silent-shared-worktree footgun). Tracked separately.
+- Gitignored size caps. Add if real usage shows it's needed.
+- Quiescing parent's tmux session for atomic snapshots.
+- Submodule recursion.
+- Rebase/merge/cherry-pick state replay.
+- TUI pre-flight size estimate (`Will copy ~X GB`) for the gitignored checkbox.
+
+## Review change log
+
+- 2026-05-15: Accepted FWS-001 after clean-context verification. Changed staged patch materialization from `git apply --cached` to `git apply --index` so partially-staged edits and staged deletions are preserved correctly.
+- 2026-05-15: Accepted FWS-002 after clean-context verification. Made the fork-with-state worktree creation path explicitly start from the parent session's HEAD so linked parent worktrees do not accidentally fork from the main/base worktree HEAD.
+- 2026-05-15: Accepted FWS-003 after clean-context verification as new-code hardening. Cleanup now requires proof that the fork-with-state operation created the branch before running `git branch -D`.
+- 2026-05-15: Accepted FWS-004 after clean-context verification. Fork-with-state now has an explicit destination contract: source sessions may have any branch/worktree shape, but the operation always creates a new destination branch and worktree; CLI requires `-w/--worktree <new-branch>` while TUI may show an editable suggested name.
+- 2026-05-15: Accepted FWS-005 after clean-context verification. Split real CLI contract tests from git-side integration tests so flag registration, refusal messages, destination validation, and `ClaudeOptions` propagation are covered through the actual CLI/handler path.
+- 2026-05-16: Accepted FWS-006 after clean-context verification. Aligned the spec's `RunWorktreeSetup` contract with existing setup-hook behavior: discover scripts from `repoDir`, execute in `worktreePath`, and return a single setup warning error.
+- 2026-05-16: Accepted FWS-007 after clean-context verification. Kept the spec-promised clean-parent, bare-repo-layout, and setup-hook ordering integration tests and aligned the plan to implement them.
+- 2026-05-16: Accepted FWS-008 after clean-context verification. Confirmed the explicit CLI destination contract remains the spec contract: gitignored may imply with-state, but CLI with-state flags must not auto-create or auto-name worktrees.
+- 2026-05-17: Accepted FWS-009 after clean-context verification and option comparison. Fork-with-state preflight is now a shared `internal/git` contract used by both CLI and TUI: git facts are centralized, while each surface keeps responsibility for rendering warnings and errors.
+- 2026-05-17: Accepted FWS-010 after clean-context verification. Clarified the TUI nested-state invariant: with-state cannot be enabled unless worktree mode is on, and turning worktree mode off clears both with-state and gitignored state.
+- 2026-05-17: Accepted FWS-011 after clean-context verification and codebase-pattern comparison. Clarified that ForkDialog should use the existing `NewDialog` focus-target architecture for dynamic focus order, and added `TestForkDialog_FocusOrder` to the required TUI mandate.
+- 2026-05-17: Accepted FWS-012 after clean-context verification and terminology review. Renamed/reworded the bare-layout integration case so it covers a linked parent worktree inside a bare-repo layout, while preserving the global contract that fork-with-state sources must be checked-out working trees.
+- 2026-05-17: Accepted FWS-013 after clean-context verification. Confirmed the spec already uses the dedicated `cmd/agent-deck/session_cmd_fork_state_test.go` path; the matching plan file-map row was updated to align with it.
+- 2026-05-17: Accepted ADP-007 codebase-pattern audit recommendation. Moved the documented git-side sequence integration tests to `internal/git/worktree_with_state_integration_test.go`, keeping `cmd/agent-deck/session_cmd_fork_state_test.go` focused on CLI/handler contract coverage.
+- 2026-05-17: Accepted ADP-008 codebase-pattern audit recommendation. Clarified that the TUI shared-preflight structural guard should use brace-counted function extraction, matching existing source-level guard patterns and avoiding a brittle neighboring-function boundary.
+- 2026-05-17: Accepted ADP-010 codebase-pattern audit recommendation. Added bounded behavioral eval smoke coverage for the real CLI fork-with-state flow and the visible TUI ForkDialog interaction path, and included those evals in the fork-with-state mandate.
+- 2026-05-17: Accepted ADP-011 codebase-pattern audit recommendation. Documentation impact now calls for expanding the README's dedicated `### Fork Sessions` section, cross-referencing the behavior from `### Git Worktrees`, and writing the changelog entry in the repo's Keep a Changelog style.
+- 2026-05-17: Accepted FWS-014 after clean-context verification and option comparison. Reordered data-flow Steps 2 and 3 so destination collision checks run before parent preflight, matching the implementation plan's order and saving git invocations on the common "user reuses a branch name" failure path. The structural-guard test enforces only `PreflightForkWithState` before `CreateWorktreeAtStartPoint`; the relative order of preflight and collision check is now documented as intentionally not enforced. Cleanup matrix updated to reflect the renumbered steps.
+- 2026-05-17: Accepted FWS-015 after clean-context verification. Removed the three drift-only TUI test names (`TestForkDialog_WithStateCheckbox_VisibleWhenWorktreeEnabled`, `..._HiddenWhenWorktreeOff`, `TestForkDialog_GitignoredSubCheckbox_NestedUnderWithState`) from the state-machine test inventory and added a pointer to the existing `TestEval_ForkDialog_WithStateVisibleInteraction` eval test that already covers all three render conditions. Local TDD requires `-tags eval_smoke`; the eval suite runs on every PR via the existing eval-smoke workflow.
+- 2026-05-17: Accepted FWS-016 after clean-context verification, asymmetry analysis, and option comparison via the Item 4 discussion document. Extracted a shared `git.ValidateForkWithStateDestination(repoRoot, branch)` helper with a typed `DestinationCollisionError` so CLI and TUI both call one validator for destination-collision facts (worktree-exists, branch-exists). Removes CLI's redundant inline collision check from the existing-worktree reuse block, removes TUI's inline `if opts.WithState` branch from its reuse block, and restores both reuse blocks to today's exact behavior. Mirrors the FWS-009 `PreflightForkWithState` architectural pattern: git facts live in `internal/git`; CLI and TUI own surface-appropriate error rendering. Added three helper unit tests (`TestValidateForkWithStateDestination_Clean`, `_BranchExists`, `_WorktreeExists`) and extended the mandate regex to include the new helper.
+- 2026-05-18: Accepted FWS-017 after Track B comparative analysis vs upstream's fork-carry-wip branch (commit 02b6e5c4). Four corrections folded back from upstream's implementation: (1) Added revert to the in-progress-ops refusal list — REVERT_HEAD leaves the same half-done state as MERGE_HEAD; updated DetectInProgressOperation docstring, InProgressOperationError docstring, data flow Step 3, Decisions table, error catalog, and added TestDetect_Revert. (2) Data flow Step 5c now uses `git ls-files --others -z` so paths with embedded newlines are handled safely. (3) Data flow Step 5d now does a SECOND pass with `--ignored --exclude-standard` and unions with the first — `--ignored` is a filter, not additive; the prior single-pass version was a latent bug that would have copied only ignored files. (4) Added Step 5.5 for ProcessWorktreeInclude (PR #890) so the materialize → worktreeinclude → setup ordering is documented as a contract. Full analysis at `docs/superpowers/discussions/2026-05-18-upstream-comparison.md` on review/feat-v1.9.x-1029-fork-carry-wip.
+- 2026-05-18: Accepted FWS-018 after CONTRIBUTING.md re-read and confirmation that `CLAUDE.md` is intentionally untracked per PR #1002. Promoted the previously-collapsed "CLAUDE.md mandate (new section to add)" subsection into a top-level `## Mandatory test coverage` section in the spec itself (Option B from the post-plan review). Removed the literal text-to-copy-into-CLAUDE.md fence. Updated "Documentation impact" to drop the CLAUDE.md target. Added a new RFC-required structural-change item that protects the coupling between `--with-state` and the Claude session fork. Goal section rewritten to make explicit that `--with-state` delivers a complete parallel agent environment — the Claude Code session conversation history forked via the existing `agent-deck session fork` flow (which invokes `claude --resume <parent-id> --fork-session`) PLUS the materialized working-tree files. The two pieces compose; the new code in this feature is the file half, but the user-visible value is the combined parallel environment.

--- a/docs/superpowers/specs/2026-05-18-fork-with-state-followup-design.md
+++ b/docs/superpowers/specs/2026-05-18-fork-with-state-followup-design.md
@@ -1,0 +1,176 @@
+# Fork-with-State Followup: Close Post-#1030 Gaps
+
+**Status:** Draft — pending implementation plan
+**Date:** 2026-05-18
+**Author:** Steve Morin (steve.morin@gmail.com)
+**Supersedes:** [`2026-05-14-fork-worktree-with-state-design.md`](2026-05-14-fork-worktree-with-state-design.md) (deprecated)
+**Related code (upstream/main):**
+- `internal/git/materialize_wip.go` — `MaterializeWipFromParent` (added by #1030)
+- `internal/git/setup.go` — `WorktreeStateOptions`, `CreateWorktreeWithStateAndSetup` (added by #1030)
+- `cmd/agent-deck/session_cmd.go` — `--with-state[-and-gitignored]` flag wiring (added by #1030)
+- `internal/git/issue1029_with_state_test.go` and `internal/git/issue1029_edge_test.go` — upstream's test coverage
+
+## Premise
+
+Upstream merged PR #1030 (commit `6a1645eb`) on 2026-05-18, implementing the core ask of issue #1029: `agent-deck session fork --with-state` and `--with-state-and-gitignored` carry the parent session's staged + unstaged + untracked files (and optionally gitignored files) into a freshly-created worktree on a new branch. The diff-based, parent-read-only approach matches what was designed in the deprecated original spec.
+
+The post-merge gap analysis at [`../discussions/2026-05-18-post-merge-gap-analysis.md`](../discussions/2026-05-18-post-merge-gap-analysis.md) identified 11 deltas between upstream's merged implementation and the deprecated design:
+- 4 functional gaps (user-visible behavior the merged code doesn't provide)
+- 7 test-coverage gaps (hardening that upstream didn't add)
+
+This followup spec scopes the work to close those 11 gaps as a layer ON TOP of upstream's merged code. Upstream's `MaterializeWipFromParent` and `CreateWorktreeWithStateAndSetup` API stays untouched. The new code in this followup adds capabilities the merged code lacks; it does not refactor or replace what's there.
+
+## Goal
+
+Close the 11 gaps from the analysis, split across two PRs:
+
+- **PR-A (correctness + test hardening, CLI surface):** parent-HEAD start point for linked-worktree parents, destination collision validation, cleanup-on-error in the CLI fork handler, and the test coverage that verifies those properties.
+- **PR-B (TUI surface):** `ForkDialog` integration so users can trigger `--with-state` without dropping to the CLI, plus the TUI submit path's collision check + cleanup + behavioral eval.
+
+## Non-goals
+
+- Replacing upstream's `MaterializeWipFromParent` or `CreateWorktreeWithStateAndSetup`. They work; we wrap.
+- Refactoring upstream's wrapper pattern into the deprecated spec's split pattern (`CreateWorktree` + `RunWorktreeSetup`). The wrapper is simpler caller code; we adopt it.
+- Extracting `refuseUnsafeParentState` into a shared, exported `PreflightForkWithState` with typed `InProgressOperationError`. This is gap 11 — deferred to a separate PR-C with RFC discussion. PR-A and PR-B inline their refusals against upstream's existing internal helper instead.
+- Renaming any upstream-introduced symbols. We add new symbols; we don't rename `MaterializeWipFromParent` to match the deprecated spec's `MaterializeParentState`.
+- Touching upstream's `internal/git/materialize_wip.go` file directly. New helpers live in new files.
+
+## What upstream merged (summary)
+
+```go
+// internal/git/materialize_wip.go
+func MaterializeWipFromParent(parentDir, childDir string, includeIgnored bool) error
+// Internal: refuseUnsafeParentState, gitDirOf, applyDiffFromParent (uses --index for staged),
+//           copyUntrackedFromParent (two-pass for gitignored), runListZ (NUL-safe ls-files),
+//           copyEachFile, copyOneFile (symlink + mode preserving)
+
+// internal/git/setup.go
+type WorktreeStateOptions struct {
+    WithState   bool
+    WithIgnored bool
+}
+func CreateWorktreeWithStateAndSetup(
+    repoDir, worktreePath, branchName string,
+    state WorktreeStateOptions,
+    stdout, stderr io.Writer, setupTimeout time.Duration,
+) (setupErr, err error)
+// Orchestrates: CreateWorktree → MaterializeWipFromParent (if state.WithState)
+//               → ProcessWorktreeInclude → setup hook.
+
+// CreateWorktreeWithSetup remains as a thin pass-through with empty state.
+
+// cmd/agent-deck/session_cmd.go: --with-state and --with-state-and-gitignored
+// flags; validation that --with-state requires -w; wires to CreateWorktreeWithStateAndSetup.
+```
+
+Tests in upstream: canonical staged+unstaged+untracked, empty WIP, binary file, symlink, ignored opt-in, mid-merge refusal, deleted-in-parent tracked file, `CreateWorktreeWithStateAndSetup` wiring (8 tests).
+
+## Functional gaps to close (4)
+
+### G1 — TUI integration (PR-B)
+**Symptom:** TUI users can't trigger `--with-state` from the `ForkDialog`. They must drop to the CLI.
+**Fix:** Add two nested checkboxes ("Carry parent state" press `y`, "Include gitignored files" press `i`) under the existing "Create in worktree" checkbox. Wire the TUI submit handler to call `CreateWorktreeWithStateAndSetup` with the resolved `WorktreeStateOptions`.
+**Lives in:** `internal/ui/forkdialog.go`, `internal/ui/home.go`.
+
+### G2 — Parent-HEAD start point for linked parent worktrees (PR-A)
+**Symptom:** When the parent session lives in a linked worktree whose HEAD differs from the invocation repo's HEAD (i.e., from main worktree's HEAD), upstream's `CreateWorktree(repoDir, ...)` creates the new fork worktree at the WRONG commit. Materialization then applies parent's diffs onto the wrong base, producing files that don't match what the parent session sees.
+**Fix:** Add `HeadCommit(repoDir)` and `CreateWorktreeAtStartPoint(repoDir, worktreePath, branch, startPoint)` helpers. In the CLI fork handler, when `--with-state` is set, capture the parent session's HEAD and pass it as the start point. (This pre-empts upstream's `CreateWorktreeWithStateAndSetup` — we call `CreateWorktreeAtStartPoint` then `MaterializeWipFromParent` then `RunWorktreeSetup` manually, OR we extend the wrapper to accept an optional start point. PR-A picks one — see the followup plan.)
+**Lives in:** `internal/git/git.go`, `cmd/agent-deck/session_cmd.go`.
+
+### G3 — Destination collision validation (PR-A; also used by PR-B)
+**Symptom:** If a user passes `-w <existing-branch> --with-state`, upstream has no early refusal. Either git refuses worktree-add cryptically deep in the stack, or it succeeds and creates a second worktree on the existing branch, polluting it.
+**Fix:** Add a shared `ValidateForkWithStateDestination(repoRoot, branch)` in `internal/git/fork_with_state_destination.go` (new file, separate from upstream's `materialize_wip.go`). Returns typed `DestinationCollisionError{Kind: "worktree_exists"|"branch_exists", Branch, Path}`. CLI handler calls it before invoking the upstream wrapper; TUI submit handler calls it before its wrapper invocation. Both surfaces format the typed error their own way.
+**Lives in:** `internal/git/fork_with_state_destination.go` (new), `cmd/agent-deck/session_cmd.go`, `internal/ui/home.go`.
+
+### G4 — Cleanup-on-error (PR-A CLI portion + PR-B TUI portion)
+**Symptom:** If `MaterializeWipFromParent` errors inside `CreateWorktreeWithStateAndSetup`, the partially-created worktree stays on disk. User must `git worktree remove --force` and `git branch -D` manually.
+**Fix:** In both surfaces, wrap the call to `CreateWorktreeWithStateAndSetup`. On error, `git worktree remove --force <path>` and `git branch -D <branch>` (only if `CreateWorktreeAtStartPoint` returned proof of branch creation, per the deprecated spec's FWS-003 reasoning). Surface the original error to the user with `; new worktree cleaned up` appended.
+**Lives in:** `cmd/agent-deck/session_cmd.go` (CLI), `internal/ui/home.go` (TUI).
+
+## Test-coverage hardening to add (7)
+
+| Gap | Test | PR |
+|---|---|---|
+| G5 | `TestMaterialize_ParentUntouched_RegressionForFollowup` — assert parent's `git status --porcelain`, index, and stash list byte-identical after `MaterializeWipFromParent` | **PR-A** |
+| G6 | `TestForkWithState_BareRepoLayoutLinkedParentWorktree` — bare-repo project root with linked parent worktree as source; assert the fork is created at the parent's HEAD, not main's HEAD | **PR-A** |
+| G7 | `TestForkWithState_SetupHookObservesMaterializedState` — setup script writes a fingerprint of a parent-WIP file; assert the fingerprint is in the marker file (proves materialize ran before setup) | **PR-A** |
+| G8 | `TestRefuseUnsafeParentState_Rebase`, `_CherryPick`, `_Revert`, `_Bisect` — upstream only has `_Merge` for the refusal path; add the four missing kinds | **PR-A** |
+| G9 | `TestSessionFork_WithStateOptionsPropagatedBeforeStart` — CLI before-start hook captures the prepared fork instance and verifies the with-state flags resolved by the handler match the user's request before `Start()` (the flags flow through `git.WorktreeStateOptions`, not `session.ClaudeOptions` — upstream did not extend `ClaudeOptions`) | **PR-A** |
+| G10 CLI | `TestEval_SessionForkWithState_RealBinary` — eval-tagged smoke test: real `agent-deck` binary, scratch HOME, fake `claude`, real git repo; `session fork --with-state-and-gitignored -w <new-branch>` creates a new destination worktree whose files mirror the parent's WIP | **PR-A** |
+| G10 TUI | `TestEval_ForkDialog_WithStateVisibleInteraction` — eval-tagged: render `ForkDialog`, drive `w → y → i`, assert visible checkbox text appears; assert getters report submitted values | **PR-B** |
+
+## New code surfaces (file map summary)
+
+| File | Action | Owner PR |
+|---|---|---|
+| `internal/git/git.go` | Modify — add `HeadCommit`, `CreateWorktreeAtStartPoint` | PR-A |
+| `internal/git/git_test.go` | Modify — add `TestCreateWorktreeAtStartPoint_*` tests | PR-A |
+| `internal/git/fork_with_state_destination.go` | Create — `ValidateForkWithStateDestination`, `DestinationCollisionError` | PR-A |
+| `internal/git/fork_with_state_destination_test.go` | Create — validator tests | PR-A |
+| `internal/git/materialize_wip_invariant_test.go` | Create — `TestMaterialize_ParentUntouched_RegressionForFollowup` | PR-A |
+| `internal/git/issue1029_edge_test.go` | Modify — add 4 missing mid-op refusal tests | PR-A |
+| `internal/git/fork_with_state_integration_test.go` | Create — bare-repo + setup-hook observation tests | PR-A |
+| `cmd/agent-deck/session_cmd.go` | Modify — wire parent-HEAD + destination validation + cleanup-on-error + before-start hook | PR-A |
+| `cmd/agent-deck/session_cmd_fork_state_test.go` | Create — CLI contract tests | PR-A |
+| `tests/eval/session/fork_with_state_test.go` | Create — eval smoke for CLI | PR-A |
+| `internal/ui/forkdialog.go` | Modify — sub-checkboxes, focus order, getters | PR-B |
+| `internal/ui/forkdialog_test.go` | Modify — state-machine tests | PR-B |
+| `internal/ui/forkdialog_eval_test.go` | Create — TUI behavioral eval | PR-B |
+| `internal/ui/home.go` | Modify — TUI submit wires `CreateWorktreeWithStateAndSetup` with collision check + cleanup | PR-B |
+| Session options (`session.ClaudeOptions`) | Not modified — upstream wired the with-state flags directly through `git.WorktreeStateOptions`, not via `ClaudeOptions`. PR-A's CLI handler builds the `WorktreeStateOptions` from the flag values and passes it straight to the git layer. | n/a |
+
+## Mandatory test coverage
+
+After PR-A and PR-B land, any PR modifying the following paths MUST pass:
+
+```bash
+go test ./internal/git/... -run "Materialize|RefuseUnsafeParentState|ValidateForkWithStateDestination|CreateWorktreeAtStartPoint|HeadCommit|ForkWithState|Issue1029" -race -count=1
+go test ./cmd/agent-deck/... -run "SessionFork_WithState" -race -count=1
+go test ./internal/ui/... -run "ForkDialog_(WithState|ToggleWithState|GitignoredRequires|Toggling|FocusOrder)" -race -count=1
+go test -tags eval_smoke ./tests/eval/session/... ./internal/ui/... -run "TestEval_SessionForkWithState|TestEval_ForkDialog_WithState" -race -count=1
+```
+
+### Paths under the mandate
+
+- `internal/git/materialize_wip.go` (upstream-owned; modifications require coordination)
+- `internal/git/setup.go` — `WorktreeStateOptions`, `CreateWorktreeWithStateAndSetup` (upstream-owned)
+- `internal/git/fork_with_state_destination.go` (new; PR-A)
+- `internal/git/fork_with_state_destination_test.go` (new; PR-A)
+- `internal/git/materialize_wip_invariant_test.go` (new; PR-A)
+- `internal/git/fork_with_state_integration_test.go` (new; PR-A)
+- `internal/git/issue1029_edge_test.go` (upstream-owned; extended in PR-A)
+- `internal/git/git.go` — `HeadCommit`, `CreateWorktreeAtStartPoint` (PR-A)
+- `cmd/agent-deck/session_cmd.go` fork handler (PR-A)
+- `cmd/agent-deck/session_cmd_fork_state_test.go` (new; PR-A)
+- `internal/ui/forkdialog.go` (PR-B)
+- `internal/ui/home.go` TUI submit (PR-B)
+- `internal/ui/forkdialog_eval_test.go` (new; PR-B)
+- `tests/eval/session/fork_with_state_test.go` (new; PR-A)
+
+### Structural changes requiring RFC
+
+- Reverting upstream's `CreateWorktreeWithStateAndSetup` wrapper pattern back to the split pattern in the deprecated original spec
+- Removing or weakening `ValidateForkWithStateDestination` once it lands
+- Removing the parent-HEAD start-point capture and reverting to invocation-repo-HEAD behavior
+- Removing the cleanup-on-error guards
+- Removing `--with-state` from the TUI `ForkDialog` once it lands
+
+## Out of scope (deferred PR-C)
+
+**Gap 11 — Shared `PreflightForkWithState` extraction.** Upstream's `refuseUnsafeParentState` is internal (lowercase) to `materialize_wip.go` and returns a plain formatted `error`. The deprecated original spec called for promoting this to an exported `PreflightForkWithState` that returns a typed `InProgressOperationError`, so CLI and TUI could share a single preflight gate with surface-specific error rendering. This refactor touches upstream's just-merged code in a structurally significant way; it deserves its own RFC discussion with @asheshgoplani before implementation. Tracked as a future PR-C. The followup plan does NOT include implementation tasks for gap 11 — PR-A and PR-B inline their refusals against `refuseUnsafeParentState`'s implicit behavior.
+
+## References
+
+- Deprecated original spec: [`2026-05-14-fork-worktree-with-state-design.md`](2026-05-14-fork-worktree-with-state-design.md) (449 lines, FWS-001 through FWS-018)
+- Deprecated original plan: [`../plans/2026-05-14-fork-worktree-with-state.md`](../plans/2026-05-14-fork-worktree-with-state.md) (~3700 lines, 21-task TDD breakdown)
+- Followup implementation plan: [`../plans/2026-05-18-fork-with-state-followup.md`](../plans/2026-05-18-fork-with-state-followup.md) — task list for PR-A and PR-B
+- Post-merge gap analysis: [`../discussions/2026-05-18-post-merge-gap-analysis.md`](../discussions/2026-05-18-post-merge-gap-analysis.md) — origin of the 11-gap framing
+- Track B runbook: [`../discussions/2026-05-17-track-b-runbook.md`](../discussions/2026-05-17-track-b-runbook.md) — parallel-worktree comparative analysis flow
+- Upstream PR: <https://github.com/asheshgoplani/agent-deck/pull/1030>
+- Upstream merge commit: `6a1645eb` on `upstream/main`
+- Issue: <https://github.com/asheshgoplani/agent-deck/issues/1029>
+
+## Review change log
+
+- 2026-05-18: FUS-001 — Spec drafted as followup to the deprecated 2026-05-14 design. Premise: upstream's #1030 is merged; scope this work to closing the 11 gaps identified in the post-merge gap analysis. Two-PR split (PR-A correctness + CLI tests; PR-B TUI). `ValidateForkWithStateDestination` extracted as a shared `internal/git` helper (avoiding upstream's `materialize_wip.go` file). Gap 11 (shared `PreflightForkWithState` extraction) explicitly deferred to PR-C with RFC.
+- 2026-05-19: FUS-002 — Removed stale references to ClaudeOptions.WithState/IncludeGitignored fields. Upstream's #1030 chose a different architecture (flags flow through git.WorktreeStateOptions, not ClaudeOptions). Spec corrected to reflect upstream's actual wiring; A4's CLI contract tests already adapted to the real shape.

--- a/internal/git/fork_with_state_destination.go
+++ b/internal/git/fork_with_state_destination.go
@@ -1,0 +1,117 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Recognized values for DestinationCollisionError.Kind.
+const (
+	CollisionWorktreeExists = "worktree_exists"
+	CollisionBranchExists   = "branch_exists"
+)
+
+// DestinationCollisionError is returned by ValidateForkWithStateDestination
+// when the requested destination branch already has a worktree or already
+// exists as a local branch. Callers own user-facing wording.
+type DestinationCollisionError struct {
+	Kind   string // CollisionWorktreeExists or CollisionBranchExists
+	Branch string
+	Path   string // populated when Kind == CollisionWorktreeExists
+}
+
+func (e *DestinationCollisionError) Error() string {
+	switch e.Kind {
+	case CollisionWorktreeExists:
+		return fmt.Sprintf("branch %q already has a worktree at %s", e.Branch, e.Path)
+	case CollisionBranchExists:
+		return fmt.Sprintf("branch %q already exists", e.Branch)
+	default:
+		return fmt.Sprintf("destination collision for branch %q", e.Branch)
+	}
+}
+
+// ValidateForkWithStateDestination is the shared CLI/TUI destination-collision
+// gate for fork-with-state. Worktree-collision is checked first so the more
+// specific error (with path) is surfaced when both conditions are true.
+func ValidateForkWithStateDestination(repoRoot, branch string) error {
+	path, err := GetWorktreeForBranch(repoRoot, branch)
+	if err != nil {
+		return fmt.Errorf("checking existing worktrees: %w", err)
+	}
+	if path != "" {
+		return &DestinationCollisionError{Kind: CollisionWorktreeExists, Branch: branch, Path: path}
+	}
+	if BranchExists(repoRoot, branch) {
+		return &DestinationCollisionError{Kind: CollisionBranchExists, Branch: branch}
+	}
+	return nil
+}
+
+// HasSubmodules returns true if repoDir contains a .gitmodules file (regular
+// file, not directory). Used by fork-with-state callers to emit a warning
+// that submodules will be copied as files, not recursed into. Submodule
+// detection is intentionally minimal — just checks for the canonical
+// .gitmodules file at the repo root. No parsing.
+func HasSubmodules(repoDir string) bool {
+	info, err := os.Stat(filepath.Join(repoDir, ".gitmodules"))
+	return err == nil && !info.IsDir()
+}
+
+// DetectInProgressOperation returns the in-progress operation kind ("rebase",
+// "merge", "cherry-pick", "revert", "bisect") if the parent's git directory
+// shows an unsafe in-progress operation, or empty string if clean. Returns an
+// error only if the git directory cannot be resolved.
+//
+// This duplicates the check table used internally by materialize_wip.go's
+// refuseUnsafeParentState. We do our own check so fork-with-state callers can
+// surface actionable error messages BEFORE creating a worktree, instead of
+// letting MaterializeWipFromParent return upstream's terser wording AFTER the
+// worktree exists. Upstream's check remains as a backstop.
+//
+// Keep this check table aligned with refuseUnsafeParentState in
+// internal/git/materialize_wip.go. If upstream adds a new operation kind,
+// add it here too.
+func DetectInProgressOperation(repoDir string) (string, error) {
+	gitDir, err := resolveGitDirForDetection(repoDir)
+	if err != nil {
+		return "", err
+	}
+	checks := []struct {
+		path string
+		kind string
+	}{
+		{filepath.Join(gitDir, "rebase-merge"), "rebase"},
+		{filepath.Join(gitDir, "rebase-apply"), "rebase"},
+		{filepath.Join(gitDir, "MERGE_HEAD"), "merge"},
+		{filepath.Join(gitDir, "CHERRY_PICK_HEAD"), "cherry-pick"},
+		{filepath.Join(gitDir, "REVERT_HEAD"), "revert"},
+		{filepath.Join(gitDir, "BISECT_LOG"), "bisect"},
+	}
+	for _, c := range checks {
+		if _, err := os.Stat(c.path); err == nil {
+			return c.kind, nil
+		}
+	}
+	return "", nil
+}
+
+// resolveGitDirForDetection resolves repoDir to its .git directory via
+// `git rev-parse --git-dir`. Works for normal repos, linked worktrees, and
+// bare-repo project roots. Named distinctly from materialize_wip.go's
+// internal gitDirOf to avoid same-package naming collision.
+func resolveGitDirForDetection(repoDir string) (string, error) {
+	cmd := exec.Command("git", "-C", repoDir, "rev-parse", "--git-dir")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("rev-parse --git-dir: %w", err)
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(repoDir, gitDir)
+	}
+	return gitDir, nil
+}

--- a/internal/git/fork_with_state_destination_test.go
+++ b/internal/git/fork_with_state_destination_test.go
@@ -1,0 +1,196 @@
+package git
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateForkWithStateDestination_Clean(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	if err := ValidateForkWithStateDestination(dir, "fork/new"); err != nil {
+		t.Fatalf("clean repo + fresh branch should pass, got %v", err)
+	}
+}
+
+func TestValidateForkWithStateDestination_BranchExists(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	runGit(t, dir, "branch", "fork/existing")
+
+	err := ValidateForkWithStateDestination(dir, "fork/existing")
+	if err == nil {
+		t.Fatal("expected DestinationCollisionError")
+	}
+	var collErr *DestinationCollisionError
+	if !errors.As(err, &collErr) {
+		t.Fatalf("error = %T %v, want *DestinationCollisionError", err, err)
+	}
+	if collErr.Kind != CollisionBranchExists || collErr.Branch != "fork/existing" {
+		t.Fatalf("unexpected error: %+v", collErr)
+	}
+}
+
+func TestValidateForkWithStateDestination_WorktreeExists_TakesPrecedence(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createTestRepo(t, base)
+	wtPath := filepath.Join(root, "fork-wt")
+	if err := CreateWorktree(base, wtPath, "fork/used"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	if !BranchExists(base, "fork/used") {
+		t.Fatal("setup invariant: branch should also exist (CreateWorktree creates it); test cannot prove precedence otherwise")
+	}
+
+	err := ValidateForkWithStateDestination(base, "fork/used")
+	if err == nil {
+		t.Fatal("expected DestinationCollisionError")
+	}
+	var collErr *DestinationCollisionError
+	if !errors.As(err, &collErr) {
+		t.Fatalf("error = %T %v, want *DestinationCollisionError", err, err)
+	}
+	if collErr.Kind != CollisionWorktreeExists || collErr.Path == "" {
+		t.Fatalf("unexpected error: %+v", collErr)
+	}
+}
+
+func TestValidateForkWithStateDestination_PropagatesWorktreeCheckError(t *testing.T) {
+	dir := t.TempDir()
+
+	err := ValidateForkWithStateDestination(dir, "fork/new")
+	if err == nil {
+		t.Fatal("expected worktree check error for non-git repo, got nil")
+	}
+	var collErr *DestinationCollisionError
+	if errors.As(err, &collErr) {
+		t.Fatalf("error = %+v, want underlying worktree check error", collErr)
+	}
+	if !strings.Contains(err.Error(), "checking existing worktrees") {
+		t.Fatalf("error = %q, want checking existing worktrees context", err.Error())
+	}
+}
+
+func TestHasSubmodules_None(t *testing.T) {
+	dir := t.TempDir()
+	if HasSubmodules(dir) {
+		t.Fatal("empty dir should report HasSubmodules=false")
+	}
+}
+
+func TestHasSubmodules_Present(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitmodules"), []byte("[submodule \"lib\"]\n\tpath = lib\n\turl = https://example.invalid/lib.git\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !HasSubmodules(dir) {
+		t.Fatal("dir with .gitmodules should report HasSubmodules=true")
+	}
+}
+
+// TestDetectInProgressOperation_Clean — a freshly-initialized repo with no
+// in-flight state files must return "" and no error.
+func TestDetectInProgressOperation_Clean(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	kind, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("clean repo: unexpected error %v", err)
+	}
+	if kind != "" {
+		t.Fatalf("clean repo: expected empty kind, got %q", kind)
+	}
+}
+
+// TestDetectInProgressOperation_Rebase — .git/rebase-merge is a directory git
+// creates during an interactive rebase; presence must return "rebase".
+func TestDetectInProgressOperation_Rebase(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".git", "rebase-merge"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	kind, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if kind != "rebase" {
+		t.Fatalf("expected kind=rebase, got %q", kind)
+	}
+}
+
+// TestDetectInProgressOperation_Merge — .git/MERGE_HEAD is a file containing
+// the SHA of the commit being merged; presence must return "merge".
+func TestDetectInProgressOperation_Merge(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, ".git", "MERGE_HEAD"), []byte("deadbeef\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	kind, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if kind != "merge" {
+		t.Fatalf("expected kind=merge, got %q", kind)
+	}
+}
+
+// TestDetectInProgressOperation_CherryPick — .git/CHERRY_PICK_HEAD is a file
+// containing the SHA being cherry-picked; presence must return "cherry-pick".
+func TestDetectInProgressOperation_CherryPick(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, ".git", "CHERRY_PICK_HEAD"), []byte("deadbeef\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	kind, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if kind != "cherry-pick" {
+		t.Fatalf("expected kind=cherry-pick, got %q", kind)
+	}
+}
+
+// TestDetectInProgressOperation_Revert — .git/REVERT_HEAD is a file containing
+// the SHA being reverted; presence must return "revert".
+func TestDetectInProgressOperation_Revert(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, ".git", "REVERT_HEAD"), []byte("deadbeef\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	kind, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if kind != "revert" {
+		t.Fatalf("expected kind=revert, got %q", kind)
+	}
+}
+
+// TestDetectInProgressOperation_Bisect — .git/BISECT_LOG is the bisect log
+// file; presence must return "bisect".
+func TestDetectInProgressOperation_Bisect(t *testing.T) {
+	dir := t.TempDir()
+	createTestRepo(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, ".git", "BISECT_LOG"), []byte("git bisect start\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	kind, err := DetectInProgressOperation(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if kind != "bisect" {
+		t.Fatalf("expected kind=bisect, got %q", kind)
+	}
+}

--- a/internal/git/fork_with_state_integration_test.go
+++ b/internal/git/fork_with_state_integration_test.go
@@ -1,0 +1,197 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// bareLayoutWithDivergentParent builds the canonical agent-deck bare-repo
+// layout used in production and seeds it with a parent worktree whose HEAD
+// has diverged from main:
+//
+//	projectRoot/
+//	├── .bare/              (the bare repo, seeded with one commit on main)
+//	├── worktree1/          (linked worktree on main — the "seed" HEAD)
+//	└── parent-wt/          (linked worktree on parent-branch — the divergent parent)
+//
+// The parent worktree has one extra commit on top of main and (optionally)
+// some dirty WIP. Returns project root, parent worktree path, seed HEAD,
+// and parent HEAD (already verified to differ).
+//
+// Shared by both A6 (fork-with-state correctness) and A7 (setup-hook
+// observation) — keep changes here aware of both call sites.
+func bareLayoutWithDivergentParent(t *testing.T, withWIP bool) (projectRoot, parentDir, seedHead, parentHead string) {
+	t.Helper()
+
+	projectRoot, bareDir, worktrees := createBareRepoLayout(t, "worktree1")
+	seedDir := worktrees[0]
+	seedHead = strings.TrimSpace(runGit(t, seedDir, "rev-parse", "HEAD"))
+
+	// Create a linked parent worktree on a fresh branch off main, then add a
+	// commit so its HEAD diverges from main. The project root has no .git;
+	// invoke worktree add from inside .bare/ (the actual git dir).
+	parentDir = filepath.Join(projectRoot, "parent-wt")
+	runGit(t, bareDir, "worktree", "add", "-b", "parent-branch", parentDir, "main")
+	// Per-worktree identity (the bare repo has none configured).
+	runGit(t, parentDir, "config", "user.email", "test@test.com")
+	runGit(t, parentDir, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(parentDir, "README.md"), []byte("parent change\n"), 0o644); err != nil {
+		t.Fatalf("write parent README: %v", err)
+	}
+	runGit(t, parentDir, "commit", "-am", "parent commit")
+
+	parentHead = strings.TrimSpace(runGit(t, parentDir, "rev-parse", "HEAD"))
+	if seedHead == parentHead {
+		t.Fatal("setup invariant: seed and parent HEAD should differ after parent commit")
+	}
+
+	if withWIP {
+		// Untracked WIP file — exercises the copyUntrackedFromParent path of
+		// MaterializeWipFromParent.
+		if err := os.WriteFile(filepath.Join(parentDir, "wip.txt"), []byte("parent-wip\n"), 0o644); err != nil {
+			t.Fatalf("write parent WIP: %v", err)
+		}
+	}
+
+	return projectRoot, parentDir, seedHead, parentHead
+}
+
+// TestForkWithState_BareRepoLayoutLinkedParentWorktree is an integration test
+// for the bare-repo project layout: the project root contains `.bare/` (the
+// actual bare repository), and the parent agent-deck session lives in a
+// LINKED worktree (a sibling directory pointing into .bare). When the user
+// runs `agent-deck session fork --with-state`, the new fork worktree MUST be
+// anchored at the parent worktree's HEAD, NOT at the bare repo's default
+// branch HEAD or any other worktree's HEAD.
+//
+// Closes gap 6 from the post-merge gap analysis.
+func TestForkWithState_BareRepoLayoutLinkedParentWorktree(t *testing.T) {
+	projectRoot, parentDir, seedHead, parentHead := bareLayoutWithDivergentParent(t, true /* withWIP */)
+
+	// Resolve parent HEAD via the production helper (mirrors handleSessionFork).
+	parentHeadResolved, err := HeadCommit(parentDir)
+	if err != nil {
+		t.Fatalf("HeadCommit(parentDir): %v", err)
+	}
+	if parentHeadResolved != parentHead {
+		t.Fatalf("HeadCommit returned %s, want %s", parentHeadResolved, parentHead)
+	}
+
+	// handleSessionFork calls git.GetWorktreeBaseRoot first to find the repo
+	// root for the fork — mirror that resolution explicitly so the test fails
+	// loudly if the layout convention shifts.
+	baseRoot, err := GetWorktreeBaseRoot(parentDir)
+	if err != nil {
+		t.Fatalf("GetWorktreeBaseRoot(parentDir): %v", err)
+	}
+	resolvedProjectRoot, _ := filepath.EvalSymlinks(projectRoot)
+	resolvedBaseRoot, _ := filepath.EvalSymlinks(baseRoot)
+	if resolvedBaseRoot != resolvedProjectRoot {
+		t.Fatalf("GetWorktreeBaseRoot(parentDir) = %q, want project root %q", resolvedBaseRoot, resolvedProjectRoot)
+	}
+
+	// Create the fork worktree anchored at the parent HEAD via the new helper.
+	forkDir := filepath.Join(projectRoot, "fork-wt")
+	createdBranch, err := CreateWorktreeAtStartPoint(baseRoot, forkDir, "fork/bare-layout", parentHeadResolved)
+	if err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	}
+	if !createdBranch {
+		t.Fatal("CreateWorktreeAtStartPoint returned createdBranch=false for a new branch")
+	}
+
+	// Materialize parent's WIP into the fork.
+	if err := MaterializeWipFromParent(parentDir, forkDir, false); err != nil {
+		t.Fatalf("MaterializeWipFromParent: %v", err)
+	}
+
+	// CONTRACT 1: fork HEAD must equal parent HEAD, NOT seed HEAD.
+	// This is the bug class — fork being anchored at the bare repo's default
+	// branch (seed HEAD) instead of the parent worktree's HEAD.
+	forkHead := strings.TrimSpace(runGit(t, forkDir, "rev-parse", "HEAD"))
+	if forkHead != parentHead {
+		t.Fatalf("fork HEAD = %s, want parent HEAD %s (seed HEAD %s)\nfork was anchored at wrong commit",
+			forkHead, parentHead, seedHead)
+	}
+
+	// CONTRACT 2: parent WIP must be present in the fork worktree.
+	wipBytes, err := os.ReadFile(filepath.Join(forkDir, "wip.txt"))
+	if err != nil {
+		t.Fatalf("fork missing parent WIP file: %v", err)
+	}
+	if string(wipBytes) != "parent-wip\n" {
+		t.Fatalf("fork WIP content mismatch: got %q, want %q", string(wipBytes), "parent-wip\n")
+	}
+}
+
+// TestForkWithState_SetupHookObservesMaterializedState verifies the
+// orchestration order: setup hook runs AFTER MaterializeWipFromParent, so the
+// hook sees the realized working tree (parent's WIP). This pins the git-layer
+// helper sequence used by the CLI handler; command-layer ordering is covered by
+// the eval tests in tests/eval/session/fork_with_state_test.go.
+//
+// Closes gap 7 from the post-merge gap analysis.
+func TestForkWithState_SetupHookObservesMaterializedState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("setup hook test uses /bin/sh")
+	}
+
+	projectRoot, parentDir, _, parentHead := bareLayoutWithDivergentParent(t, true /* withWIP */)
+
+	// Install a setup hook at <projectRoot>/.agent-deck/worktree-setup.sh —
+	// the canonical location FindWorktreeSetupScript looks at when repoDir
+	// is the project root (mirrors what handleSessionFork passes).
+	scriptDir := filepath.Join(projectRoot, ".agent-deck")
+	if err := os.MkdirAll(scriptDir, 0o755); err != nil {
+		t.Fatalf("mkdir setup-script dir: %v", err)
+	}
+
+	// Marker lives outside the worktree so materialization can't accidentally
+	// create or clobber it.
+	marker := filepath.Join(t.TempDir(), "setup-observed.txt")
+
+	// Setup script (cwd = worktree per RunWorktreeSetupScript) reads parent's
+	// WIP file from the materialized tree and writes its content to the marker.
+	// If the hook ran BEFORE materialization, wip.txt would not exist yet and
+	// the script would write NO_WIP_OBSERVED instead.
+	script := fmt.Sprintf("#!/bin/sh\nset -e\nif [ -f wip.txt ]; then\n  cat wip.txt > %q\nelse\n  echo NO_WIP_OBSERVED > %q\nfi\n", marker, marker)
+	scriptPath := filepath.Join(scriptDir, "worktree-setup.sh")
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write setup script: %v", err)
+	}
+
+	// Run the full fork-with-state sequence in handleSessionFork's order:
+	// CreateWorktreeAtStartPoint → MaterializeWipFromParent →
+	// ProcessWorktreeInclude → RunWorktreeSetupAfterCreate.
+	forkDir := filepath.Join(projectRoot, "fork-observation-wt")
+
+	if _, err := CreateWorktreeAtStartPoint(projectRoot, forkDir, "fork/observation", parentHead); err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	}
+	if err := MaterializeWipFromParent(parentDir, forkDir, false); err != nil {
+		t.Fatalf("MaterializeWipFromParent: %v", err)
+	}
+	if err := ProcessWorktreeInclude(projectRoot, forkDir, os.Stderr); err != nil {
+		t.Logf("ProcessWorktreeInclude (non-fatal): %v", err)
+	}
+	if err := RunWorktreeSetupAfterCreate(projectRoot, forkDir, os.Stdout, os.Stderr, 0 /* unlimited */); err != nil {
+		t.Fatalf("RunWorktreeSetupAfterCreate: %v", err)
+	}
+
+	// The marker must contain the materialized WIP content. If the hook ran
+	// before materialization, the marker would be missing, empty, or contain
+	// NO_WIP_OBSERVED.
+	observed, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("marker missing: %v (setup hook may not have run)", err)
+	}
+	wantContent := "parent-wip\n" // from bareLayoutWithDivergentParent(withWIP=true)
+	if string(observed) != wantContent {
+		t.Fatalf("setup hook observed wrong content:\ngot:  %q\nwant: %q\n(this means the hook ran before MaterializeWipFromParent)", observed, wantContent)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -425,6 +425,46 @@ func CreateWorktree(repoDir, worktreePath, branchName string) error {
 	return nil
 }
 
+// HeadCommit returns the commit currently checked out at repoDir. Works for
+// normal repos, linked worktrees, and bare-repo project roots.
+func HeadCommit(repoDir string) (string, error) {
+	repoDir = resolveGitInvocationDir(repoDir)
+	cmd := exec.Command("git", "-C", repoDir, "rev-parse", "--verify", "HEAD^{commit}")
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve HEAD commit: %s: %w", strings.TrimSpace(stderr.String()), err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// CreateWorktreeAtStartPoint creates a new branch worktree from an explicit
+// start point. Returns createdBranch=true only after git successfully creates
+// the branch for this call. Used by fork-with-state to anchor the new worktree
+// at the parent session's HEAD instead of the invocation repo's HEAD.
+func CreateWorktreeAtStartPoint(repoDir, worktreePath, branchName, startPoint string) (createdBranch bool, err error) {
+	if err := ValidateBranchName(branchName); err != nil {
+		return false, fmt.Errorf("invalid branch name: %w", err)
+	}
+	if strings.TrimSpace(startPoint) == "" {
+		return false, errors.New("start point cannot be empty")
+	}
+	repoDir = resolveGitInvocationDir(repoDir)
+	if !IsGitRepo(repoDir) {
+		return false, errors.New("not a git repository")
+	}
+	if BranchExists(repoDir, branchName) {
+		return false, fmt.Errorf("branch %q already exists", branchName)
+	}
+	cmd := exec.Command("git", "-C", repoDir, "worktree", "add", "-b", branchName, worktreePath, startPoint)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("failed to create worktree at start point: %s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return true, nil
+}
+
 // ListWorktrees returns all worktrees for the repository at repoDir
 func ListWorktrees(repoDir string) ([]Worktree, error) {
 	repoDir = resolveGitInvocationDir(repoDir)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1270,3 +1270,98 @@ func TestIntegration_WorktreeNesting(t *testing.T) {
 	t.Logf("Correct path:  %s", actualWt2)
 	t.Logf("Wrong path:    %s (would have been nested)", wrongWt2)
 }
+
+func TestCreateWorktreeAtStartPoint_UsesExplicitParentHead(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createTestRepo(t, base)
+
+	parentWT := filepath.Join(root, "parent-wt")
+	if err := CreateWorktree(base, parentWT, "parent-branch"); err != nil {
+		t.Fatalf("CreateWorktree parent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(parentWT, "README.md"), []byte("parent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, parentWT, "commit", "-am", "parent change")
+
+	baseHead := strings.TrimSpace(runGit(t, base, "rev-parse", "HEAD"))
+	parentHead, err := HeadCommit(parentWT)
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+	if baseHead == parentHead {
+		t.Fatal("setup invalid: base and parent HEAD should differ")
+	}
+
+	forkWT := filepath.Join(root, "fork-wt")
+	createdBranch, err := CreateWorktreeAtStartPoint(base, forkWT, "fork/from-parent", parentHead)
+	if err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	}
+	if !createdBranch {
+		t.Fatal("CreateWorktreeAtStartPoint returned createdBranch=false for a new branch")
+	}
+	forkHead := strings.TrimSpace(runGit(t, forkWT, "rev-parse", "HEAD"))
+	if forkHead != parentHead {
+		t.Fatalf("fork HEAD = %s, want parent HEAD %s (base HEAD %s)", forkHead, parentHead, baseHead)
+	}
+}
+
+func TestHeadCommit_IgnoresGitWarningsOnStderr(t *testing.T) {
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	const want = "0123456789abcdef0123456789abcdef01234567"
+	script := `#!/bin/sh
+if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ] && [ "$4" = "--git-dir" ]; then
+  printf '.git\n'
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ] && [ "$4" = "--verify" ]; then
+  printf '` + want + `\n'
+  printf 'git: warning: confstr() failed; using /tmp instead\n' >&2
+  exit 0
+fi
+printf 'unexpected git invocation: %s\n' "$*" >&2
+exit 1
+`
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+
+	got, err := HeadCommit(t.TempDir())
+	if err != nil {
+		t.Fatalf("HeadCommit returned error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("HeadCommit returned %q, want stdout-only commit %q", got, want)
+	}
+}
+
+func TestCreateWorktreeAtStartPoint_RejectsExistingBranch(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createTestRepo(t, base)
+	parentHead, _ := HeadCommit(base)
+	runGit(t, base, "branch", "fork/existing")
+
+	createdBranch, err := CreateWorktreeAtStartPoint(base, filepath.Join(root, "fork-wt"), "fork/existing", parentHead)
+	if err == nil {
+		t.Fatal("expected existing branch to be rejected")
+	}
+	if createdBranch {
+		t.Fatal("createdBranch should be false when branch already existed")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected already-exists error, got %v", err)
+	}
+}

--- a/internal/git/issue1029_edge_test.go
+++ b/internal/git/issue1029_edge_test.go
@@ -40,6 +40,38 @@ func TestCreateWorktreeWithStateAndSetup_WiresMaterialization_RegressionFor1029(
 	}
 }
 
+func TestCreateWorktreeWithStateAndSetup_CleansUpOnMaterializeFailure(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+	gitDir := strings.TrimSpace(runGit(t, parent, "rev-parse", "--git-dir"))
+	if err := os.MkdirAll(filepath.Join(parent, gitDir, "rebase-merge"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	child := filepath.Join(t.TempDir(), "child-cleanup")
+	branch := "fork-1029-cleanup"
+	var stdout, stderr bytes.Buffer
+	_, err := CreateWorktreeWithStateAndSetup(
+		parent, child, branch,
+		WorktreeStateOptions{WithState: true},
+		&stdout, &stderr, 0,
+	)
+	if err == nil {
+		t.Fatal("expected materialization failure from mid-rebase parent, got nil")
+	}
+	if _, statErr := os.Stat(child); !os.IsNotExist(statErr) {
+		t.Fatalf("child worktree still exists after materialize failure: stat err=%v", statErr)
+	}
+	if path, wtErr := GetWorktreeForBranch(parent, branch); wtErr != nil {
+		t.Fatalf("GetWorktreeForBranch: %v", wtErr)
+	} else if path != "" {
+		t.Fatalf("worktree registration still exists after cleanup: %s", path)
+	}
+	if BranchExists(parent, branch) {
+		t.Fatalf("branch %q still exists after cleanup", branch)
+	}
+}
+
 // TestMaterializeWipFromParent_Empty_NoOp_RegressionFor1029 ensures a clean
 // parent (no WIP) produces a clean child with no error — the boundary case
 // where every diff is empty and ls-files returns nothing.
@@ -194,6 +226,107 @@ func TestMaterializeWipFromParent_RefusesMidMerge_RegressionFor1029(t *testing.T
 	}
 	if !strings.Contains(err.Error(), "merge") {
 		t.Fatalf("expected error to mention 'merge'; got: %v", err)
+	}
+}
+
+// TestRefuseUnsafeParentState_Rebase_RegressionForFollowup — mid-rebase must
+// be refused. refuseUnsafeParentState checks for BOTH rebase-merge and
+// rebase-apply directories (not files — git creates them as directories
+// during interactive and apply-style rebases respectively). We exercise the
+// rebase-merge form here; rebase-apply uses the same code path.
+func TestRefuseUnsafeParentState_Rebase_RegressionForFollowup(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	gitDir := filepath.Join(parent, ".git")
+	if err := os.MkdirAll(filepath.Join(gitDir, "rebase-merge"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-followup-rebase"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	err := MaterializeWipFromParent(parent, child, false)
+	if err == nil {
+		t.Fatal("expected refusal during mid-rebase, got nil")
+	}
+	if !strings.Contains(err.Error(), "rebase") {
+		t.Fatalf("expected error to mention 'rebase'; got: %v", err)
+	}
+}
+
+// TestRefuseUnsafeParentState_CherryPick_RegressionForFollowup — mid
+// cherry-pick must be refused. CHERRY_PICK_HEAD is a file containing the
+// commit SHA being cherry-picked.
+func TestRefuseUnsafeParentState_CherryPick_RegressionForFollowup(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	gitDir := filepath.Join(parent, ".git")
+	if err := os.WriteFile(filepath.Join(gitDir, "CHERRY_PICK_HEAD"), []byte("deadbeef\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-followup-cherry"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	err := MaterializeWipFromParent(parent, child, false)
+	if err == nil {
+		t.Fatal("expected refusal during mid-cherry-pick, got nil")
+	}
+	if !strings.Contains(err.Error(), "cherry-pick") {
+		t.Fatalf("expected error to mention 'cherry-pick'; got: %v", err)
+	}
+}
+
+// TestRefuseUnsafeParentState_Revert_RegressionForFollowup — mid-revert must
+// be refused. REVERT_HEAD is a file containing the commit SHA being reverted.
+func TestRefuseUnsafeParentState_Revert_RegressionForFollowup(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	gitDir := filepath.Join(parent, ".git")
+	if err := os.WriteFile(filepath.Join(gitDir, "REVERT_HEAD"), []byte("deadbeef\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-followup-revert"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	err := MaterializeWipFromParent(parent, child, false)
+	if err == nil {
+		t.Fatal("expected refusal during mid-revert, got nil")
+	}
+	if !strings.Contains(err.Error(), "revert") {
+		t.Fatalf("expected error to mention 'revert'; got: %v", err)
+	}
+}
+
+// TestRefuseUnsafeParentState_Bisect_RegressionForFollowup — active bisect
+// must be refused. BISECT_LOG is a file that git creates and appends to for
+// the duration of a `git bisect` run.
+func TestRefuseUnsafeParentState_Bisect_RegressionForFollowup(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	gitDir := filepath.Join(parent, ".git")
+	if err := os.WriteFile(filepath.Join(gitDir, "BISECT_LOG"), []byte("git bisect start\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-followup-bisect"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	err := MaterializeWipFromParent(parent, child, false)
+	if err == nil {
+		t.Fatal("expected refusal during active bisect, got nil")
+	}
+	if !strings.Contains(err.Error(), "bisect") {
+		t.Fatalf("expected error to mention 'bisect'; got: %v", err)
 	}
 }
 

--- a/internal/git/materialize_wip_invariant_test.go
+++ b/internal/git/materialize_wip_invariant_test.go
@@ -1,0 +1,89 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMaterializeWipFromParent_ParentUntouched is a regression test that
+// pins MaterializeWipFromParent's parent-read-only contract: after the call,
+// parent's git status, staged diff, unstaged diff, and stash list must be
+// byte-identical to their pre-call state. Catches future regressions where
+// someone changes the materialization to use git stash, git add, or any
+// other parent-mutating operation.
+func TestMaterializeWipFromParent_ParentUntouched(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	// Build a complex WIP state on parent: staged + unstaged + untracked.
+	// tracked.txt is committed first, then re-staged with edits, then has
+	// additional unstaged edits on top of the staged version. Plus a new
+	// untracked file.
+	if err := os.WriteFile(filepath.Join(parent, "tracked.txt"), []byte("tracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, parent, "add", "tracked.txt")
+	runGit(t, parent, "commit", "-m", "tracked")
+
+	if err := os.WriteFile(filepath.Join(parent, "tracked.txt"), []byte("staged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, parent, "add", "tracked.txt")
+
+	if err := os.WriteFile(filepath.Join(parent, "tracked.txt"), []byte("staged\nunstaged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(parent, "new-untracked.txt"), []byte("untracked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	statusBefore := runGit(t, parent, "status", "--porcelain")
+	diffCachedBefore := runGit(t, parent, "diff", "--cached")
+	diffBefore := runGit(t, parent, "diff")
+	stashBefore := runGit(t, parent, "stash", "list")
+	gitDir := runGit(t, parent, "rev-parse", "--git-dir")
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(parent, gitDir)
+	}
+	indexBefore, err := os.ReadFile(filepath.Join(gitDir, "index"))
+	if err != nil {
+		t.Fatalf("read parent index before materialize: %v", err)
+	}
+
+	parentHead, err := HeadCommit(parent)
+	if err != nil {
+		t.Fatalf("HeadCommit: %v", err)
+	}
+
+	child := parent + "-fork"
+	if _, err := CreateWorktreeAtStartPoint(parent, child, "fork/inv", parentHead); err != nil {
+		t.Fatalf("CreateWorktreeAtStartPoint: %v", err)
+	}
+
+	if err := MaterializeWipFromParent(parent, child, false); err != nil {
+		t.Fatalf("MaterializeWipFromParent: %v", err)
+	}
+
+	if got := runGit(t, parent, "status", "--porcelain"); got != statusBefore {
+		t.Fatalf("parent status changed:\nbefore:\n%s\nafter:\n%s", statusBefore, got)
+	}
+	if got := runGit(t, parent, "diff", "--cached"); got != diffCachedBefore {
+		t.Fatalf("parent staged diff changed:\nbefore:\n%s\nafter:\n%s", diffCachedBefore, got)
+	}
+	if got := runGit(t, parent, "diff"); got != diffBefore {
+		t.Fatalf("parent unstaged diff changed:\nbefore:\n%s\nafter:\n%s", diffBefore, got)
+	}
+	if got := runGit(t, parent, "stash", "list"); got != stashBefore {
+		t.Fatalf("parent stash list changed:\nbefore:\n%s\nafter:\n%s", stashBefore, got)
+	}
+	indexAfter, err := os.ReadFile(filepath.Join(gitDir, "index"))
+	if err != nil {
+		t.Fatalf("read parent index after materialize: %v", err)
+	}
+	if !bytes.Equal(indexBefore, indexAfter) {
+		t.Fatal("parent .git/index bytes changed")
+	}
+}

--- a/internal/git/setup.go
+++ b/internal/git/setup.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -118,12 +119,25 @@ type WorktreeStateOptions struct {
 // Materialization happens BEFORE worktreeinclude processing and the setup
 // script so both observe the realized state, per @smorin's spec.
 func CreateWorktreeWithStateAndSetup(repoDir, worktreePath, branchName string, state WorktreeStateOptions, stdout, stderr io.Writer, setupTimeout time.Duration) (setupErr error, err error) {
+	createdBranch := !BranchExists(repoDir, branchName)
 	if err = CreateWorktree(repoDir, worktreePath, branchName); err != nil {
 		return nil, err
 	}
 
 	if state.WithState {
 		if matErr := MaterializeWipFromParent(repoDir, worktreePath, state.WithIgnored); matErr != nil {
+			var cleanupErrs []string
+			if rmErr := RemoveWorktree(repoDir, worktreePath, true); rmErr != nil {
+				cleanupErrs = append(cleanupErrs, fmt.Sprintf("worktree remove failed: %v", rmErr))
+			}
+			if createdBranch {
+				if brErr := DeleteBranch(resolveGitInvocationDir(repoDir), branchName, true); brErr != nil {
+					cleanupErrs = append(cleanupErrs, fmt.Sprintf("branch delete failed: %v", brErr))
+				}
+			}
+			if len(cleanupErrs) > 0 {
+				return nil, fmt.Errorf("materialize parent state: %w; cleanup failed: %s", matErr, strings.Join(cleanupErrs, "; "))
+			}
 			return nil, fmt.Errorf("materialize parent state: %w", matErr)
 		}
 	}
@@ -132,19 +146,27 @@ func CreateWorktreeWithStateAndSetup(repoDir, worktreePath, branchName string, s
 		fmt.Fprintf(stderr, "worktreeinclude: %v\n", inclErr)
 	}
 
+	return RunWorktreeSetupAfterCreate(repoDir, worktreePath, stdout, stderr, setupTimeout), nil
+}
+
+// RunWorktreeSetupAfterCreate runs the worktree setup script for an
+// already-created worktree. Extracted from CreateWorktreeWithStateAndSetup
+// so the fork-with-state path can sequence Create → Materialize → Setup
+// with per-step error handling. Returns the script's exit error; nil if no
+// script. Caller is responsible for ProcessWorktreeInclude if desired.
+func RunWorktreeSetupAfterCreate(repoDir, worktreePath string, stdout, stderr io.Writer, setupTimeout time.Duration) error {
 	scriptPath, scriptMode := FindWorktreeSetupScript(repoDir)
 	if scriptPath == "" {
-		return nil, nil
+		return nil
 	}
-
 	fmt.Fprintln(stderr, "Running worktree setup script...")
 	start := time.Now()
-	setupErr = RunWorktreeSetupScript(scriptPath, scriptMode, repoDir, worktreePath, stdout, stderr, setupTimeout)
+	setupErr := RunWorktreeSetupScript(scriptPath, scriptMode, repoDir, worktreePath, stdout, stderr, setupTimeout)
 	elapsed := time.Since(start).Round(100 * time.Millisecond)
 	if setupErr != nil {
 		fmt.Fprintf(stderr, "Worktree setup script failed after %s: %v\n", elapsed, setupErr)
 	} else {
 		fmt.Fprintf(stderr, "Worktree setup script completed in %s\n", elapsed)
 	}
-	return setupErr, nil
+	return setupErr
 }

--- a/tests/eval/session/fork_with_state_test.go
+++ b/tests/eval/session/fork_with_state_test.go
@@ -1,0 +1,539 @@
+//go:build eval_smoke
+
+// Behavioral eval for `agent-deck session fork --with-state-and-gitignored`
+// (issue #1029, Task A8 in the post-merge gap analysis).
+//
+// Closes gap 10 (CLI portion): a real-binary end-to-end test that proves the
+// CLI handler in cmd/agent-deck/session_cmd.go actually wires
+// MaterializeWipFromParent's includeIgnored=true through to disk when the
+// user passes `--with-state-and-gitignored`. The companion unit tests in
+// cmd/agent-deck/session_cmd_fork_state_test.go assert the source-level wiring
+// (via extractFuncBody) but cannot prove the resulting binary actually
+// materializes a gitignored file in the destination worktree — that is a
+// behavioral disclosure contract, exactly what the eval harness exists to
+// catch (RFC docs/rfc/EVALUATOR_HARNESS.md).
+//
+// Strategy notes:
+//
+//   - We seed a parent session via `add -c claude` and inject a fake
+//     ClaudeSessionID via `session set <id> claude-session-id <uuid>`. The
+//     SetField mutator at internal/session/mutators.go:228 sets
+//     ClaudeDetectedAt = time.Now(), which satisfies CanFork()'s recency gate
+//     without ever starting a real Claude process.
+//   - The fork handler's worktree creation + MaterializeWipFromParent run
+//     BEFORE forkedInst.Start() (see session_cmd.go:762-823 vs 855), so
+//     destination worktree state exists on disk regardless of whether the
+//     downstream Start() succeeds. We assert directly on the filesystem and
+//     git state and tolerate a non-zero exit from the binary (Start() likely
+//     fails because no real claude binary is on PATH). This isolates the test
+//     to gap 10's actual contract — materialize wiring — and stays robust to
+//     drift in unrelated Start() plumbing.
+//   - We pin `[worktree] branch_prefix = ""` so the requested `-w` value is
+//     used verbatim, not auto-prefixed with the default "feature/".
+package session_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/tests/eval/harness"
+)
+
+// TestEval_SessionForkWithState_RealBinary is the gap-10 CLI eval. Drives the
+// compiled agent-deck binary against a scratch HOME and a real seeded git
+// repo, runs `session fork ... --with-state-and-gitignored -w fork/eval-state`,
+// and asserts the destination worktree exists with parent's full WIP
+// (staged + unstaged + untracked + gitignored) materialized.
+func TestEval_SessionForkWithState_RealBinary(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	sb := harness.NewSandbox(t)
+
+	// Pin worktree config so `-w fork/eval-state` is not auto-prefixed and
+	// lands at <repo>/.worktrees/fork-eval-state by default.
+	cfgDir := filepath.Join(sb.Home, ".agent-deck")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent-deck config dir: %v", err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config.toml")
+	// `sibling` keeps the destination worktree OUT of the parent repo, so
+	// our "parent must remain read-only" porcelain assertion doesn't have to
+	// special-case a freshly-created .worktrees/ directory inside the repo.
+	if err := os.WriteFile(cfgPath, []byte(`[worktree]
+branch_prefix = ""
+default_location = "sibling"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Set up a real git repo as the parent session's ProjectPath. The repo
+	// needs a seed commit so HEAD resolves, and per-repo identity so commits
+	// don't fail under sandboxed git.
+	repoDir := filepath.Join(sb.Home, "proj")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	gitInit(t, repoDir)
+
+	// .gitignore so `secrets.env` is a real gitignored file (not just
+	// untracked). MaterializeWipFromParent must copy it ONLY when
+	// includeIgnored=true.
+	writeFile(t, repoDir, ".gitignore", "secrets.env\n")
+	writeFile(t, repoDir, "README.md", "seed\n")
+	gitMust(t, repoDir, "add", ".")
+	gitMust(t, repoDir, "commit", "-m", "seed")
+
+	// Build parent WIP: staged + unstaged + untracked + gitignored.
+	writeFile(t, repoDir, "staged.txt", "staged content\n")
+	gitMust(t, repoDir, "add", "staged.txt")
+
+	appendFile(t, repoDir, "README.md", "\nunstaged edit\n")
+
+	writeFile(t, repoDir, "untracked.txt", "untracked content\n")
+
+	writeFile(t, repoDir, "secrets.env", "API_KEY=parent-secret\n")
+
+	parentStatusBefore := gitPorcelain(t, repoDir)
+
+	// Register parent session with the claude tool. The binary is never
+	// invoked — we synthesize ClaudeSessionID below to satisfy CanFork().
+	runBin(t, sb, "add", "-c", "claude", "-t", "parent", "-g", "evalgrp", repoDir)
+
+	// Inject a fake but well-formed ClaudeSessionID so CanFork() returns true.
+	// SetField also stamps ClaudeDetectedAt = time.Now() so the 5-minute
+	// recency window in CanFork() is satisfied.
+	runBin(t, sb, "session", "set", "parent", "claude-session-id",
+		"00000000-0000-4000-8000-000000000001")
+
+	// Run the fork. Per the fork-with-state contract, `-w` names the fresh
+	// destination branch; `-b` is not required for with-state mode. We
+	// tolerate non-zero exit because forkedInst.Start() at session_cmd.go:855
+	// will try to spawn `claude` in tmux — that's downstream of gap 10's
+	// contract (worktree creation + materialize, which run at 762-823).
+	forkOut, forkErr := runBinTry(sb, "session", "fork", "parent",
+		"--with-state-and-gitignored", "-w", "fork/eval-state",
+		"-t", "fork-eval")
+
+	// Parent invariant: read-only. MaterializeWipFromParent must not mutate
+	// parent's index or working tree.
+	parentStatusAfter := gitPorcelain(t, repoDir)
+	if parentStatusAfter != parentStatusBefore {
+		t.Fatalf("fork --with-state-and-gitignored mutated parent WIP.\nbefore:\n%s\nafter:\n%s",
+			parentStatusBefore, parentStatusAfter)
+	}
+
+	// Destination worktree path. With default_location="sibling" and branch
+	// sanitization (/ -> -), `fork/eval-state` lands at
+	// `<repo>-fork-eval-state` alongside the parent repo. We verify via
+	// `git worktree list` instead of recomputing the template so the
+	// assertion stays robust to future template changes.
+	forkPath := worktreePathForBranch(t, repoDir, "fork/eval-state")
+	if forkPath == "" {
+		// Surface the fork's combined output to make triage easy when the
+		// destination is missing (e.g. validator rejected, branch collision).
+		t.Fatalf("destination worktree for branch 'fork/eval-state' not found.\n"+
+			"fork err: %v\nfork combined output:\n%s", forkErr, forkOut)
+	}
+
+	// 1. Branch invariant: destination is on `fork/eval-state`.
+	gotBranch := strings.TrimSpace(gitOut(t, forkPath, "rev-parse", "--abbrev-ref", "HEAD"))
+	if gotBranch != "fork/eval-state" {
+		t.Errorf("destination HEAD branch: got %q, want %q", gotBranch, "fork/eval-state")
+	}
+
+	// 2. Materialize invariant: tracked WIP (staged, unstaged, untracked)
+	// reproduced. Comparing porcelain status against parent's pre-fork
+	// snapshot is the strongest single assertion — it covers byte-identity
+	// of the index and working tree.
+	childStatus := gitPorcelain(t, forkPath)
+	if childStatus != parentStatusBefore {
+		t.Errorf("destination status must mirror parent WIP.\nparent (before):\n%s\nchild:\n%s",
+			parentStatusBefore, childStatus)
+	}
+
+	// 3. File-content sanity: spot-check that staged/untracked content
+	// actually landed on disk. Catches a porcelain-equal-but-empty-file
+	// regression that a status-only assertion would miss.
+	mustHaveFile(t, forkPath, "staged.txt", "staged content\n")
+	mustHaveFile(t, forkPath, "untracked.txt", "untracked content\n")
+	if got := readFile(t, forkPath, "README.md"); !strings.Contains(got, "unstaged edit") {
+		t.Errorf("destination README.md missing unstaged edit; got %q", got)
+	}
+
+	// 4. The discriminating assertion for --with-state-and-gitignored vs
+	// --with-state: the gitignored file MUST be present. Without the
+	// includeIgnored=true wiring, secrets.env would not be copied.
+	mustHaveFile(t, forkPath, "secrets.env", "API_KEY=parent-secret\n")
+}
+
+// TestEval_SessionForkWithState_RejectsExistingBranch drives the real binary
+// against a pre-existing destination branch and asserts the user-facing error
+// text matches the spec's wording from ValidateForkWithStateDestination.
+//
+// This is the subprocess counterpart to
+// TestSessionFork_WithState_RejectsExistingDestinationBranch in
+// cmd/agent-deck/session_cmd_fork_state_test.go (source-introspection-based).
+// Pinning the exact wording here guarantees the validator's user-facing
+// message survives binary-level wiring (out.Error formatting, stderr routing).
+func TestEval_SessionForkWithState_RejectsExistingBranch(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	sb := harness.NewSandbox(t)
+
+	// Pin worktree settings so `-w fork/collision-test` is used verbatim and
+	// destination resolution matches what the validator will check.
+	cfgDir := filepath.Join(sb.Home, ".agent-deck")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent-deck config dir: %v", err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[worktree]
+branch_prefix = ""
+default_location = "sibling"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	repoDir := filepath.Join(sb.Home, "proj")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	gitInit(t, repoDir)
+	writeFile(t, repoDir, "README.md", "seed\n")
+	gitMust(t, repoDir, "add", ".")
+	gitMust(t, repoDir, "commit", "-m", "seed")
+
+	// Pre-create the destination branch in the seed repo BEFORE running the
+	// fork. The validator must trip on this and refuse.
+	gitMust(t, repoDir, "branch", "fork/collision-test")
+
+	// Register parent session and inject fake claude session id so CanFork()
+	// is satisfied (same trick as the happy-path test).
+	runBin(t, sb, "add", "-c", "claude", "-t", "parent", "-g", "evalgrp", repoDir)
+	runBin(t, sb, "session", "set", "parent", "claude-session-id",
+		"00000000-0000-4000-8000-000000000001")
+
+	out, err := runBinTry(sb, "session", "fork", "parent",
+		"--with-state", "-w", "fork/collision-test",
+		"-t", "fork-collision")
+	if err == nil {
+		t.Fatalf("expected non-zero exit on destination-branch collision, got success.\noutput:\n%s", out)
+	}
+
+	wantMsg := "branch 'fork/collision-test' already exists; choose a new destination branch for --with-state"
+	if !strings.Contains(out, wantMsg) {
+		t.Fatalf("collision error wording mismatch.\nwant substring: %q\ngot stderr+stdout:\n%s", wantMsg, out)
+	}
+}
+
+// TestEval_SessionForkWithState_RejectsExistingWorktree drives the real binary
+// against a branch that already has a linked worktree. With-state must refuse
+// this destination before the legacy reuse path; otherwise materialization is
+// skipped and the fork may point at an unrelated existing worktree.
+func TestEval_SessionForkWithState_RejectsExistingWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	sb := harness.NewSandbox(t)
+
+	cfgDir := filepath.Join(sb.Home, ".agent-deck")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent-deck config dir: %v", err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[worktree]
+branch_prefix = ""
+default_location = "sibling"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	repoDir := filepath.Join(sb.Home, "proj")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	gitInit(t, repoDir)
+	writeFile(t, repoDir, "README.md", "seed\n")
+	gitMust(t, repoDir, "add", ".")
+	gitMust(t, repoDir, "commit", "-m", "seed")
+
+	existingWT := filepath.Join(sb.Home, "existing-wt")
+	gitMust(t, repoDir, "worktree", "add", "-b", "fork/used", existingWT)
+	existingWT = worktreePathForBranch(t, repoDir, "fork/used")
+	if existingWT == "" {
+		t.Fatal("setup invariant: expected pre-created worktree for fork/used")
+	}
+
+	runBin(t, sb, "add", "-c", "claude", "-t", "parent", "-g", "evalgrp", repoDir)
+	runBin(t, sb, "session", "set", "parent", "claude-session-id",
+		"00000000-0000-4000-8000-000000000001")
+
+	out, err := runBinTry(sb, "session", "fork", "parent",
+		"--with-state", "-w", "fork/used",
+		"-t", "fork-used")
+	if err == nil {
+		t.Fatalf("expected non-zero exit on destination-worktree collision, got success.\noutput:\n%s", out)
+	}
+
+	wantMsg := fmt.Sprintf("branch 'fork/used' already has a worktree at %s; choose a new destination branch for --with-state", existingWT)
+	if !strings.Contains(out, wantMsg) {
+		t.Fatalf("worktree collision error wording mismatch.\nwant substring: %q\ngot stderr+stdout:\n%s", wantMsg, out)
+	}
+}
+
+// TestEval_SessionForkWithState_RefusesMidRebaseParent drives the real binary
+// against a parent in mid-rebase state and asserts the actionable error
+// wording from gap 6: "parent session is mid-rebase; finish or abort the
+// rebase before forking with state (cd <parent> && git rebase --abort)".
+// This refusal now happens BEFORE worktree creation (via the exported
+// git.DetectInProgressOperation helper), so there is no worktree to clean up
+// on this code path. The cleanup-on-error assertions below additionally
+// guard against regressions where a future contributor moves the detection
+// AFTER CreateWorktreeAtStartPoint.
+func TestEval_SessionForkWithState_RefusesMidRebaseParent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	sb := harness.NewSandbox(t)
+
+	cfgDir := filepath.Join(sb.Home, ".agent-deck")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent-deck config dir: %v", err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[worktree]
+branch_prefix = ""
+default_location = "sibling"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	repoDir := filepath.Join(sb.Home, "proj")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	gitInit(t, repoDir)
+	writeFile(t, repoDir, "README.md", "seed\n")
+	gitMust(t, repoDir, "add", ".")
+	gitMust(t, repoDir, "commit", "-m", "seed")
+
+	// Force the parent's working tree into mid-rebase state. The plain-file
+	// `mkdir .git/rebase-merge` trick exercises the same refuseUnsafeParentState
+	// path that a real conflicted rebase would (see
+	// TestRefuseUnsafeParentState_Rebase_RegressionForFollowup in
+	// internal/git/issue1029_edge_test.go for the same trick). We pick this
+	// over a real conflict because real rebases are flaky across git versions
+	// (conflict marker variance, interactive editor prompts).
+	gitDir := filepath.Join(repoDir, ".git")
+	if err := os.MkdirAll(filepath.Join(gitDir, "rebase-merge"), 0o755); err != nil {
+		t.Fatalf("mkdir rebase-merge: %v", err)
+	}
+
+	runBin(t, sb, "add", "-c", "claude", "-t", "parent", "-g", "evalgrp", repoDir)
+	runBin(t, sb, "session", "set", "parent", "claude-session-id",
+		"00000000-0000-4000-8000-000000000001")
+
+	out, err := runBinTry(sb, "session", "fork", "parent",
+		"--with-state", "-w", "fork/midrebase", "-b",
+		"-t", "fork-midrebase")
+	if err == nil {
+		t.Fatalf("expected non-zero exit when parent is mid-rebase, got success.\noutput:\n%s", out)
+	}
+	// Gap 6: handler must surface the full actionable wording with the parent
+	// path and exact abort command, not just a "mid-rebase" substring.
+	expected := fmt.Sprintf("parent session is mid-rebase; finish or abort the rebase before forking with state (cd %s && git rebase --abort)", repoDir)
+	if !strings.Contains(out, expected) {
+		t.Fatalf("expected actionable mid-rebase error %q, got:\n%s", expected, out)
+	}
+
+	// Cleanup-on-error: the destination branch must not have been left
+	// behind. CreateWorktreeAtStartPoint creates the branch as a side-effect
+	// of `git worktree add -b`, and the followup MaterializeWipFromParent
+	// failure triggers `branch -D` cleanup at session_cmd.go:801.
+	branchList := strings.TrimSpace(gitOut(t, repoDir, "branch", "--list", "fork/midrebase"))
+	if branchList != "" {
+		t.Errorf("destination branch must be cleaned up after mid-rebase refusal; git branch --list returned: %q", branchList)
+	}
+
+	// Cleanup-on-error: no linked worktree for fork/midrebase must remain.
+	if leakedPath := worktreePathForBranch(t, repoDir, "fork/midrebase"); leakedPath != "" {
+		t.Errorf("destination worktree must be cleaned up after mid-rebase refusal; found leaked worktree at: %s", leakedPath)
+	}
+}
+
+// TestEval_SessionForkWithState_SubmoduleWarning drives the real binary
+// against a parent repo that has .gitmodules and asserts the stderr warning
+// is emitted. Pins gap 7's user-visible signal: callers must know that
+// submodules under the parent's ProjectPath will be copied as files (not
+// recursed into) by MaterializeWipFromParent.
+//
+// The fork itself may or may not fully succeed (downstream Start() needs a
+// real claude binary), but the warning is emitted BEFORE worktree creation,
+// so it is independent of exit code. We assert only on the warning text.
+func TestEval_SessionForkWithState_SubmoduleWarning(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	sb := harness.NewSandbox(t)
+
+	cfgDir := filepath.Join(sb.Home, ".agent-deck")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir agent-deck config dir: %v", err)
+	}
+	cfgPath := filepath.Join(cfgDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`[worktree]
+branch_prefix = ""
+default_location = "sibling"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	repoDir := filepath.Join(sb.Home, "proj")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	gitInit(t, repoDir)
+	writeFile(t, repoDir, "README.md", "seed\n")
+	// .gitmodules at repo root is the canonical signal HasSubmodules looks for.
+	// We don't actually init a submodule — the warning fires purely on file
+	// presence, matching the helper's intentional minimalism.
+	writeFile(t, repoDir, ".gitmodules", "[submodule \"lib\"]\n\tpath = lib\n\turl = https://example.invalid/lib.git\n")
+	gitMust(t, repoDir, "add", ".")
+	gitMust(t, repoDir, "commit", "-m", "seed")
+
+	runBin(t, sb, "add", "-c", "claude", "-t", "parent", "-g", "evalgrp", repoDir)
+	runBin(t, sb, "session", "set", "parent", "claude-session-id",
+		"00000000-0000-4000-8000-000000000001")
+
+	out, _ := runBinTry(sb, "session", "fork", "parent",
+		"--with-state", "-w", "fork/submodule-test", "-b",
+		"-t", "fork-submodule")
+
+	wantMsg := "submodules detected — copied as files, not recursed"
+	if !strings.Contains(out, wantMsg) {
+		t.Fatalf("submodule warning missing.\nwant substring: %q\ngot stderr+stdout:\n%s", wantMsg, out)
+	}
+}
+
+// ---- file/git helpers (local to keep the eval package self-contained) ----
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	gitMust(t, dir, "init", "-q", "-b", "main")
+	gitMust(t, dir, "config", "user.email", "eval@test")
+	gitMust(t, dir, "config", "user.name", "Eval Test")
+}
+
+func gitMust(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Eval Test",
+		"GIT_AUTHOR_EMAIL=eval@test",
+		"GIT_COMMITTER_NAME=Eval Test",
+		"GIT_COMMITTER_EMAIL=eval@test",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, string(out))
+	}
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, string(out))
+	}
+	return string(out)
+}
+
+// gitPorcelain returns `git status --porcelain` with lines sorted for stable
+// comparison across runs (the order isn't guaranteed across git versions).
+func gitPorcelain(t *testing.T, dir string) string {
+	t.Helper()
+	raw := gitOut(t, dir, "status", "--porcelain")
+	lines := strings.Split(strings.TrimSpace(raw), "\n")
+	// Sort for stable comparison.
+	for i := 0; i < len(lines); i++ {
+		for j := i + 1; j < len(lines); j++ {
+			if lines[j] < lines[i] {
+				lines[i], lines[j] = lines[j], lines[i]
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// worktreePathForBranch returns the absolute path of the linked worktree
+// checked out on branch `refs/heads/<branch>`, or "" if no such worktree
+// exists. Uses `git worktree list --porcelain` for robustness.
+func worktreePathForBranch(t *testing.T, repoDir, branch string) string {
+	t.Helper()
+	out := gitOut(t, repoDir, "worktree", "list", "--porcelain")
+	wantRef := "branch refs/heads/" + branch
+	var currentPath string
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			currentPath = strings.TrimPrefix(line, "worktree ")
+		case line == wantRef:
+			return currentPath
+		}
+	}
+	return ""
+}
+
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func appendFile(t *testing.T, dir, rel, suffix string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	f, err := os.OpenFile(full, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open %s for append: %v", rel, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(suffix); err != nil {
+		t.Fatalf("append %s: %v", rel, err)
+	}
+}
+
+func readFile(t *testing.T, dir, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, rel))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return string(b)
+}
+
+func mustHaveFile(t *testing.T, dir, rel, want string) {
+	t.Helper()
+	got := readFile(t, dir, rel)
+	if got != want {
+		t.Errorf("file %s in %s: got %q, want %q", rel, dir, got, want)
+	}
+}


### PR DESCRIPTION
## What this is

Reopens the fork-with-state correctness work from #1051 (closes **#1029**), **rebased onto current `main`'s `internal/vcs` backend abstraction** as requested. #1051 was ~165 commits behind and conflicted with main's git→backend migration; rather than a 25-commit rebase against a feature core that already landed via #1030, this reconstructs the *net delta* on top of current main.

## The design decision you flagged

> whether the moved-up collision check + the `reuseExistingWorktree` guard route through backend (jujutsu-safe) or stay git-direct

Resolved as follows:

- **Reuse guard → backend.** Routes through `backend.GetWorktreeForBranch(...)`; the reuse *assignment* is gated on `!wantState`. Jujutsu reuse keeps working; with-state never reuses a worktree.
- **Collision gate → git-direct, behind an early git guard.** `git.ValidateForkWithStateDestination` stays git-direct because `--with-state` is git-only. The safety comes from an **early `wantState && backend.Type() != vcs.TypeGit` rejection placed *before* the gate** — a jujutsu backend can never reach the git-direct collision check or the parent-HEAD anchoring. Main's late jujutsu rejection is kept as a backstop.
- **With-state creation stays decomposed git-direct** (`HeadCommit` + `CreateWorktreeAtStartPoint` + `MaterializeWipFromParent` + cleanup-on-error) to preserve parent-HEAD anchoring for linked-worktree parents. Non-state and jujutsu paths route through the backend / upstream's `CreateWorktreeWithStateAndSetup` unchanged.

The collision/`else if` branches are kept **mutually exclusive** (with-state requires the branch *absent* and creates it; non-state requires it *present*) so with-state-without-`-b` cannot trip "branch does not exist".

## Ports the BUG-01..09 batch

One collision gate before path computation (BUG-01/08), `reuseExistingWorktree` flag, `WorktreeStateOptions` test seam (BUG-02/05), `GetWorktreeForBranch` error propagation (BUG-03), wrapper cleanup-on-error (BUG-06), parent-`.git/index` byte-identity assertion (BUG-07), `HeadCommit` stdout-only.

## Verification

- `cmd/agent-deck` fork contract tests (source-pinned + runtime hook): **pass** `-race`
- `internal/git` fork-with-state + #1029 + worktree suite: **pass** `-race`
- `tests/eval/session` real-binary `eval_smoke` (5 cases — happy path, branch collision, worktree collision, mid-rebase refusal, submodule warning): **pass**
- `go build ./...`, `go vet ./...`, `gofmt` on touched files: clean


Pre-existing main-sweep failures (`internal/session` persistence suite, `TestOuterTmuxGuard`, two gofmt-dirty test files) are unrelated and reproduce on clean `upstream/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safer `session fork --with-state` workflow: clearer, actionable validation for destination collisions, refusal when parent repo has in-progress git operations, preserved parent state in forks, and safer cleanup with manual cleanup hints.
  * Submodule-aware forking with a warning when present.
  * Worktree setup now surfaces setup warnings instead of hard failures.

* **Documentation**
  * Added decision document on fork destination collision handling.

* **Tests**
  * Expanded unit, integration, and end-to-end tests covering fork-with-state flows and error/cleanup scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->