### PR TITLE
fix(remote): deploy via temp file + atomic rename to avoid ETXTBSY on update

### DIFF
--- a/internal/session/deploy_atomic_test.go
+++ b/internal/session/deploy_atomic_test.go
@@ -1,0 +1,48 @@
+package session
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// `agent-deck remote update` deployed the new binary with `cat > <path>`, which
+// truncates the destination in place. But agent-deck always keeps a long-lived
+// `agent-deck session attach …` process running from that same <path>, so the
+// kernel refused to reopen the live executable for writing and returned ETXTBSY
+// — `bash: line 1: /home/.../agent-deck: Text file busy` — on every update.
+//
+// The fix stages the bytes to a sibling temp file and atomically renames it into
+// place. rename(2) only repoints the directory entry, so it succeeds while the
+// old binary is still executing (the running process keeps the unlinked inode);
+// the next launch picks up the new binary. This test pins that behavior.
+//
+// The SSH layer is stubbed via remoteExecFn (see recordingRunner) so no real
+// remote is required.
+func TestDeployBinary_StagesAndRenames_NeverTruncatesLiveBinary(t *testing.T) {
+	const target = "/home/daniel/agent-deck"
+
+	r, calls := recordingRunner(func(string) (string, error) { return "", nil })
+
+	if err := r.DeployBinary(context.Background(), []byte("new-binary-bytes"), target); err != nil {
+		t.Fatalf("DeployBinary returned error: %v", err)
+	}
+
+	if len(*calls) != 1 {
+		t.Fatalf("expected exactly one remote command, got %d: %v", len(*calls), *calls)
+	}
+	cmd := (*calls)[0]
+
+	// Must NOT redirect the new bytes straight onto the live binary (ETXTBSY).
+	if strings.Contains(cmd, "cat > "+shellQuote(target)) {
+		t.Fatalf("deploy truncates the live binary in place (would hit ETXTBSY):\n%s", cmd)
+	}
+
+	// Must stage to a temp path and atomically rename it onto the target.
+	if !strings.Contains(cmd, "mv -f ") {
+		t.Fatalf("deploy must atomically `mv -f` the staged binary into place; got:\n%s", cmd)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(cmd), shellQuote(target)) {
+		t.Fatalf("the rename destination must be the final target %s; got:\n%s", target, cmd)
+	}
+}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -573,8 +573,17 @@ func (r *SSHRunner) DeployBinary(ctx context.Context, binaryData []byte, remoteP
 		dir = remotePath[:idx]
 	}
 
-	cmd := fmt.Sprintf("mkdir -p %s && cat > %s && chmod +x %s",
-		shellQuote(dir), shellQuote(remotePath), shellQuote(remotePath))
+	// Stage to a sibling temp file and atomically rename it into place rather
+	// than redirecting onto remotePath directly. agent-deck keeps a long-lived
+	// `session attach` process running from remotePath, so truncating it in
+	// place (`cat > remotePath`) makes the kernel reject the write with ETXTBSY
+	// ("text file busy"). rename(2) only repoints the directory entry, so it
+	// succeeds while the old binary is still executing (the running process
+	// keeps the now-unlinked inode); the next launch picks up the new binary.
+	tmpPath := remotePath + ".new"
+	cmd := fmt.Sprintf("mkdir -p %s && cat > %s && chmod +x %s && mv -f %s %s",
+		shellQuote(dir), shellQuote(tmpPath), shellQuote(tmpPath),
+		shellQuote(tmpPath), shellQuote(remotePath))
 
 	deployCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Problem

`agent-deck remote update` fails **every time** with `Text file busy` (ETXTBSY) on any host that has a running remote session:

```
═══ Remote: xaid ═══
  ✗ Failed: deploy failed: failed to deploy binary to /home/daniel/agent-deck: remote command failed: exit status 1: bash: line 1: /home/daniel/agent-deck: Text file busy

═══ Remote: dev-vm ═══
  ✗ Failed: deploy failed: failed to deploy binary to /home/dn/agent-deck: remote command failed: exit status 1: zsh:1: text file busy: /home/dn/agent-deck
```

## Root cause

`SSHRunner.DeployBinary` writes the new binary with:

```go
cmd := fmt.Sprintf("mkdir -p %s && cat > %s && chmod +x %s",
    shellQuote(dir), shellQuote(remotePath), shellQuote(remotePath))
```

`cat > <remotePath>` opens the destination with `O_WRONLY|O_TRUNC` and streams the new bytes into the **same inode in place**. But agent-deck always keeps a long-lived `agent-deck session attach …` process running from that exact path — confirmed on the affected hosts:

```
xaid:  daniel  63259  /home/daniel/agent-deck session attach …
       lsof → agent-dec 63259 ... txt REG ... /home/daniel/agent-deck   (held as executable text)
dev:   dn      918723  /home/dn/agent-deck session attach …
```

Linux returns `ETXTBSY` when you open a running executable for writing, so the redirect fails and the update never lands. Because the session manager is always running (and on systemd-linger hosts it survives SSH disconnects), it fails on every attempt.

## Fix

Stage the bytes to a sibling temp file and **atomically rename** it into place:

```go
tmpPath := remotePath + ".new"
cmd := fmt.Sprintf("mkdir -p %s && cat > %s && chmod +x %s && mv -f %s %s",
    shellQuote(dir), shellQuote(tmpPath), shellQuote(tmpPath),
    shellQuote(tmpPath), shellQuote(remotePath))
```

`rename(2)`/`mv -f` only repoints the directory entry, so it succeeds while the old binary is still executing — the running process keeps the now-unlinked inode and the next launch picks up the new binary. This is the standard "replace a running executable" idiom. Same-directory temp keeps the rename on one filesystem (truly atomic).

## Test

`internal/session/deploy_atomic_test.go` pins the behavior: the deploy command must never redirect onto the live target and must `mv -f` the staged file into place. The SSH layer is stubbed via `remoteExecFn` (existing `recordingRunner` seam), so no real remote is needed. Verified failing on the old `cat > <target>` code and passing after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue where live binary deployments could be corrupted during updates. Deployment operations now use atomic file operations to prevent executable truncation and ensure stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->