### PR TITLE
fix(creds-refresh): OAuth refresh must be JSON, not form-urlencoded (fixes recurring /login outage)

### DIFF
--- a/internal/credrefresh/refresh.go
+++ b/internal/credrefresh/refresh.go
@@ -23,12 +23,12 @@
 package credrefresh
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,6 +40,12 @@ const (
 	// `claudeAiOauth` subscription flow), read from the shipped binary.
 	// #nosec G101 -- this is a public OAuth endpoint URL, not a credential.
 	DefaultTokenEndpoint = "https://platform.claude.com/v1/oauth/token"
+
+	// ClaudeCodeClientID is Claude Code's well-known public OAuth client_id,
+	// used as a fallback when the stored credentials omit `clientId`. The
+	// token endpoint rejects refresh requests without a client_id.
+	// #nosec G101 -- public OAuth client identifier, not a secret.
+	ClaudeCodeClientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 
 	// DefaultThreshold is the early-refresh window: refresh when the access
 	// token expires within this much time. Access tokens live ~1h.
@@ -214,27 +220,32 @@ func readCredentials(path string) (map[string]any, map[string]any, error) {
 }
 
 // requestRefresh POSTs the rotating refresh token to the OAuth token endpoint
-// and returns the rotated tokens. It mirrors Claude's subscription refresh:
-// form-urlencoded grant_type/refresh_token/client_id/scope.
-func requestRefresh(cfg RefreshConfig, refreshToken, clientID string, scopes []string) (tokenResponse, error) {
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", refreshToken)
-	if clientID != "" {
-		form.Set("client_id", clientID)
+// and returns the rotated tokens. Anthropic's token endpoint requires a JSON
+// body (grant_type/refresh_token/client_id); a form-urlencoded body is
+// rejected with 400 "Invalid request format". The scopes argument is unused —
+// the refresh grant does not re-scope.
+func requestRefresh(cfg RefreshConfig, refreshToken, clientID string, _ []string) (tokenResponse, error) {
+	if clientID == "" {
+		clientID = ClaudeCodeClientID
 	}
-	if len(scopes) > 0 {
-		form.Set("scope", strings.Join(scopes, " "))
+
+	payload, err := json.Marshal(map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+		"client_id":     clientID,
+	})
+	if err != nil {
+		return tokenResponse{}, fmt.Errorf("marshal token request: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.endpoint(), strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.endpoint(), bytes.NewReader(payload))
 	if err != nil {
 		return tokenResponse{}, fmt.Errorf("build token request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := cfg.httpClient().Do(req)

--- a/internal/credrefresh/refresh_test.go
+++ b/internal/credrefresh/refresh_test.go
@@ -9,6 +9,7 @@ package credrefresh
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -82,19 +83,33 @@ func readOAuth(t *testing.T, path string) map[string]any {
 // mockTokenServer returns an httptest server that rotates the token, recording
 // every request it received so tests can assert the request shape (and that it
 // was or was not called).
+//
+// It mirrors Anthropic's real token endpoint: the body MUST be JSON. A
+// form-urlencoded body (the shipped-but-broken format) is rejected with a 400
+// "Invalid request format", so a regression to form encoding fails loudly
+// instead of silently succeeding (the original ParseForm mock accepted both).
 func mockTokenServer(t *testing.T, newAccess, newRefresh string, expiresIn int) (*httptest.Server, *callRecorder) {
 	t.Helper()
 	rec := &callRecorder{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseForm(); err != nil {
-			http.Error(w, "bad form", http.StatusBadRequest)
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error":             "invalid_request",
+				"error_description": "Invalid request format",
+			})
+			return
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
 			return
 		}
 		rec.add(map[string]string{
-			"grant_type":    r.Form.Get("grant_type"),
-			"refresh_token": r.Form.Get("refresh_token"),
-			"client_id":     r.Form.Get("client_id"),
-			"scope":         r.Form.Get("scope"),
+			"grant_type":    body["grant_type"],
+			"refresh_token": body["refresh_token"],
+			"client_id":     body["client_id"],
 		})
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token":  newAccess,
@@ -153,9 +168,6 @@ func TestRefreshIfNeeded_RefreshesWhenNearExpiry(t *testing.T) {
 	if c["client_id"] != "client-xyz" {
 		t.Fatalf("client_id = %q; want client-xyz", c["client_id"])
 	}
-	if c["scope"] != "user:inference user:profile" {
-		t.Fatalf("scope = %q; want space-joined scopes", c["scope"])
-	}
 
 	// Canonical now holds the rotated tokens + recomputed expiry.
 	oauth := readOAuth(t, credPath)
@@ -168,6 +180,87 @@ func TestRefreshIfNeeded_RefreshesWhenNearExpiry(t *testing.T) {
 	wantExpiry := float64(now().Add(3600 * time.Second).UnixMilli())
 	if oauth["expiresAt"] != wantExpiry {
 		t.Fatalf("expiresAt = %v; want %v", oauth["expiresAt"], wantExpiry)
+	}
+}
+
+// (1b) Contract regression: requestRefresh MUST send a JSON body with
+// Content-Type: application/json and the three required fields. Anthropic's
+// token endpoint rejects a form-urlencoded body with 400 "Invalid request
+// format" (the shipped-but-inert v1.9.46 bug). This test captures the raw
+// outgoing request and asserts the wire format directly, so a regression to
+// form encoding fails here regardless of how a mock parses the body.
+func TestRequestRefresh_SendsJSONBody(t *testing.T) {
+	var (
+		gotContentType string
+		gotRawBody     []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotRawBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "a",
+			"refresh_token": "r",
+			"expires_in":    3600,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	tok, err := requestRefresh(
+		RefreshConfig{TokenEndpoint: srv.URL, HTTPClient: srv.Client()},
+		"my-refresh-token", "client-abc", nil,
+	)
+	if err != nil {
+		t.Fatalf("requestRefresh: %v", err)
+	}
+	if tok.AccessToken != "a" || tok.RefreshToken != "r" {
+		t.Fatalf("unexpected token response: %+v", tok)
+	}
+
+	if gotContentType != "application/json" {
+		t.Fatalf("Content-Type = %q; want application/json", gotContentType)
+	}
+
+	// Body must be parseable JSON (a form-urlencoded body would not be) with
+	// all three required fields populated.
+	var body map[string]string
+	if err := json.Unmarshal(gotRawBody, &body); err != nil {
+		t.Fatalf("request body is not JSON (%q): %v", string(gotRawBody), err)
+	}
+	if body["grant_type"] != "refresh_token" {
+		t.Fatalf("grant_type = %q; want refresh_token", body["grant_type"])
+	}
+	if body["refresh_token"] != "my-refresh-token" {
+		t.Fatalf("refresh_token = %q; want my-refresh-token", body["refresh_token"])
+	}
+	if body["client_id"] != "client-abc" {
+		t.Fatalf("client_id = %q; want client-abc", body["client_id"])
+	}
+}
+
+// (1c) When the stored credentials omit clientId, requestRefresh falls back to
+// the well-known Claude Code public client_id — the endpoint requires one.
+func TestRequestRefresh_FallsBackToDefaultClientID(t *testing.T) {
+	var gotClientID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotClientID = body["client_id"]
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "a", "refresh_token": "r", "expires_in": 3600,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := requestRefresh(
+		RefreshConfig{TokenEndpoint: srv.URL, HTTPClient: srv.Client()},
+		"rt", "", nil,
+	); err != nil {
+		t.Fatalf("requestRefresh: %v", err)
+	}
+	if gotClientID != ClaudeCodeClientID {
+		t.Fatalf("client_id = %q; want fallback %q", gotClientID, ClaudeCodeClientID)
 	}
 }
 


### PR DESCRIPTION
## The load-bearing fix for the recurring work-profile 401 / "Please run /login"

### Root cause (confirmed live)
The keep-warm OAuth refresh daemon (`internal/credrefresh`, shipped in #1253 / v1.9.46) sent its token-refresh request as `application/x-www-form-urlencoded`. Anthropic's OAuth token endpoint **requires a JSON body** and rejects the form-encoded request with:

```
400 {"error":"invalid_request","error_description":"Invalid request format"}
```

So every keep-warm refresh silently failed. The canonical `.credentials.json` was never rotated, the access token lapsed, and the host fell back into the exact recurring `/login` outage the daemon was built to prevent.

### Why it shipped invisible
Two reasons it passed CI and went unnoticed:
1. **The daemon is disabled-by-default**, so the broken request never fired in normal runs.
2. **The test mock used `r.ParseForm()`**, which silently succeeds on a JSON body — so the test never distinguished "correct JSON" from "wrong form encoding". The contract was never actually asserted on the wire.

The conductor verified the JSON form works live: both canonical credentials rotated successfully against the real endpoint.

### The fix (minimal, scoped to `internal/credrefresh`)
- `requestRefresh` now marshals a **JSON body** `{grant_type, refresh_token, client_id}` and sends `Content-Type: application/json`.
- Added `ClaudeCodeClientID` (Claude Code's well-known public OAuth client_id) as a **fallback** when stored credentials omit `clientId` — the endpoint requires a client_id.
- Swapped imports (`net/url` → `bytes`); the `scopes` argument is now unused (the refresh grant does not re-scope).

### The guard so this can't regress
- The mock token endpoint now **rejects any non-JSON body with the real 400 "Invalid request format"** instead of permissively parsing it. A regression to form encoding now fails loudly.
- New focused contract test `TestRequestRefresh_SendsJSONBody` captures the raw outgoing request and asserts `Content-Type: application/json` + a parseable JSON body with all three fields. Plus `TestRequestRefresh_FallsBackToDefaultClientID` covers the fallback.

**Test proof (failed-on-old / passes-on-new):** against the old form-urlencoded code these three tests fail —
- `TestRefreshIfNeeded_RefreshesWhenNearExpiry` → mock returns `400 Invalid request format`
- `TestRequestRefresh_SendsJSONBody` → `Content-Type = "application/x-www-form-urlencoded"; want application/json`
- `TestRequestRefresh_FallsBackToDefaultClientID` → `client_id = ""; want fallback`

With the JSON fix, all 12 package tests pass.

### Dual-profile credential design
This is Part B of the subscription-safe keep-warm fix. The daemon reads the single canonical `.credentials.json` per profile, holds the same proper-lockfile lock Claude Code uses (`realpath(CONFIG_DIR)+".lock"`) so the daemon and any running session never refresh simultaneously and burn the single-use rotating refresh token, then atomically rewrites canonical. Workers that symlink their scratch `.credentials.json` to the canonical file pick up the rotated token on their next disk read — no API key, no per-worker restart.

### Verification
- `go build ./...` ✓
- `go test ./internal/credrefresh/...` ✓ (12/12 pass)
- `go vet ./internal/credrefresh/...` ✓

No workflow files touched. Does not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OAuth token refresh request format from form-encoded to JSON for proper endpoint compatibility

* **Improvements**
  * Added fallback client ID handling to ensure token refresh works with credentials missing this value

* **Tests**
  * Enhanced token refresh test suite to verify JSON request format and default client ID behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->