### PR TITLE
fix(web): restore skills-pane attached list on deep-link (regression)

### DIFF
--- a/internal/web/static/app/panes/SkillsPane.js
+++ b/internal/web/static/app/panes/SkillsPane.js
@@ -44,7 +44,13 @@ export function SkillsPane() {
     }
   }
 
-  useEffect(() => { refresh() }, [selectedId])
+  // Depend on the *resolved* session id, not the raw selectedId. The menu
+  // model arrives via WebSocket after this pane mounts, so on a deep-link
+  // (/s/<id>) selectedId is set synchronously but `session` is still
+  // undefined on first render — refresh() would then fetch the catalog but
+  // skip the attached list (guarded by `if (session)`). Keying the effect
+  // on session?.id re-fires once the session resolves, mirroring McpPane.
+  useEffect(() => { refresh() }, [session && session.id])
 
   if (!session) {
     return html`


### PR DESCRIPTION
## What

The Skills tab UI specs (\`tests/web/e2e/skills.spec.js:79/:94/:106\`) were failing on \`main\`. This is a **real regression**, not CI flake — they fail locally on clean main too.

## Root cause

\`SkillsPane.js\` keyed its load effect on \`[selectedId]\`:

\`\`\`js
useEffect(() => { refresh() }, [selectedId])
\`\`\`

\`selectedId\` is set **synchronously** from the \`/s/<id>\` URL on mount and never changes. But the menu model (session list) arrives **later via WebSocket**. So on a deep-link / first render, \`session\` is still \`undefined\`, and \`refresh()\` fetches the catalog but **skips the attached list** (it is guarded by \`if (session)\`). The effect never re-fires when the session resolves, so ATTACHED stays permanently empty.

Result: the pane renders, the API is fine (\`GET /api/sessions/sess-001/skills\` returns \`['alpha']\`), but the UI shows ATTACHED (0) — and the row-click/detach specs time out waiting for an attached row.

Confirmed via a debug spec: the pane fired **no** \`/api/sessions/.../skills\` request at all on deep-link, while a direct fetch from the page returned the seeded attachment.

This is unrelated to the #1132 pointer-events fix (that was not reverted). The bug has existed since SkillsPane was introduced in #1122; it surfaces on the normal async WS load path.

## Fix

Key the effect on the **resolved** session id, mirroring \`McpPane.js\` (which keys on \`[session && session.id]\`):

\`\`\`js
useEffect(() => { refresh() }, [session && session.id])
\`\`\`

The effect re-fires once the session resolves, so the attached list loads.

## Verification

All 8 \`skills.spec.js\` specs pass locally on \`chromium-desktop\`, in both serving modes:
- **dev mode** (no dist manifest — the path CI uses): 8 passed
- **bundle mode** (fresh \`go generate\` dist): 8 passed

The 3 previously-failing UI specs (:79, :94, :106) now pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of skills loading by ensuring proper session initialization before fetching attached skills.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->