### PR TITLE
fix(send): submit reliably when Claude Code is in vim normal mode (closes #1264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`session send` silently failing in Claude Code vim normal mode** ([#1264](https://github.com/asheshgoplani/agent-deck/issues/1264)). When Claude Code's prompt was in vim NORMAL mode (the default state after a turn finishes with `"editorMode": "vim"`), the trailing Enter was interpreted as a navigation keystroke instead of submit, so messages were typed but never sent — and the send-verify retry loop's bare Enter nudges all no-op'd for the same reason. A new opt-in `[claude].vim_mode` knob gates an Escape + `i` insert-mode guarantee at the keysender layer, so every `SendEnter` / `SendKeysAndEnter` against a vim-mode target submits reliably. Off by default; non-vim Claude sessions and other tools are unaffected.
+
 ## [1.9.46] - 2026-06-02
 
 ### Added

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -623,6 +623,23 @@ func (i *Instance) applyLaunchSettingsFromConfig() {
 	settings := GetTmuxSettings()
 	i.tmuxSession.LaunchInUserScope = settings.GetLaunchInUserScope()
 	i.tmuxSession.LaunchAs = settings.GetLaunchAs()
+	i.applyVimModeFromConfig()
+}
+
+// applyVimModeFromConfig copies [claude].vim_mode onto the tmux session so the
+// keysender prepends an Escape + `i` insert-mode guarantee before each send.
+// Only meaningful for Claude-compatible tools; other tools never sit in a vim
+// composer, so we leave the flag at its zero value (false) for them to keep
+// their send path byte-identical (issue #1264).
+func (i *Instance) applyVimModeFromConfig() {
+	if i.tmuxSession == nil || !IsClaudeCompatible(i.Tool) {
+		return
+	}
+	cfg, _ := LoadUserConfig()
+	if cfg == nil {
+		return
+	}
+	i.tmuxSession.VimMode = cfg.Claude.GetVimMode()
 }
 
 // NewInstanceWithGroup creates a new session instance with explicit group

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -916,6 +916,24 @@ type ClaudeSettings struct {
 	// otherwise sit frozen on the picker forever (closes #67).
 	// Default: true (nil = use default true, set false to disable).
 	AutoResumeSummary *bool `toml:"auto_resume_summary"`
+
+	// VimMode tells agent-deck the inner Claude Code prompt uses vim keybindings
+	// ("editorMode": "vim"). When true, every message send guarantees the
+	// composer is in insert mode (Escape + `i`) before delivering text/Enter, so
+	// a message sent while the prompt sits in vim NORMAL mode (the default state
+	// after a turn finishes) actually submits instead of being typed-but-unsent
+	// (issue #1264). Off by default — only enable for sessions running Claude
+	// Code with vim editor mode. Other tools and non-vim Claude are unaffected.
+	VimMode bool `toml:"vim_mode"`
+}
+
+// GetVimMode reports whether vim-mode insert-guard sends are enabled. Off by
+// default (issue #1264).
+func (c *ClaudeSettings) GetVimMode() bool {
+	if c == nil {
+		return false
+	}
+	return c.VimMode
 }
 
 // GetProfileClaudeConfigDir returns the profile-specific Claude config directory, if configured.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -824,6 +824,20 @@ type Session struct {
 	// Sandbox sessions enable this so pane-dead detection can restart exited tools.
 	RunCommandAsInitialProcess bool
 
+	// VimMode guarantees the inner agent's input composer is in insert mode
+	// before any text/Enter is delivered. When the inner tool (Claude Code with
+	// `"editorMode": "vim"`) leaves its prompt in vim NORMAL mode — the default
+	// state after a turn finishes — a bracketed paste still lands in the input
+	// widget, but the trailing Enter is interpreted as a navigation keystroke
+	// instead of submit, so the message is typed but never sent (issue #1264).
+	// When true, SendEnter and SendKeysAndEnter prepend an Escape + `i` sequence
+	// so the prompt is guaranteed to be in insert mode. The sequence is
+	// idempotent: Escape always lands in normal mode and `i` always enters
+	// insert, so it is safe even when the prompt is already in insert mode.
+	// Off by default (zero value) — non-vim sessions and other tools are
+	// unaffected. Populated at session-creation time from [claude].vim_mode.
+	VimMode bool
+
 	// LaunchInUserScope starts the tmux server through systemd-run --user --scope
 	// so the server is owned by the user's systemd manager instead of the current
 	// login session scope.
@@ -3987,6 +4001,13 @@ func (s *Session) hashContent(content string) string {
 	return hex.EncodeToString(h[:])
 }
 
+// keySenderExec is a swappable seam for the tmux subprocesses spawned by the
+// SendKeys / SendEnter / SendNamedKey key-delivery primitives. It defaults to
+// tmuxExec (the real `tmux` binary) in production; tests override it to record
+// the exact key sequence emitted without standing up a real tmux server. See
+// the vim-mode regression test in tmux_vim_mode_test.go (issue #1264).
+var keySenderExec = tmuxExec
+
 // SendKeys sends keys to the tmux session
 // Uses -l flag to treat keys as literal text, preventing tmux special key interpretation
 func (s *Session) SendKeys(keys string) error {
@@ -3994,15 +4015,44 @@ func (s *Session) SendKeys(keys string) error {
 	// The -l flag makes tmux treat the string as literal text, not key names
 	// This prevents issues like "Enter" being interpreted as the Enter key
 	// and provides a layer of safety against tmux special sequences
-	cmd := s.tmuxCmd("send-keys", "-l", "-t", s.Name, "--", keys)
+	cmd := keySenderExec(s.SocketName, "send-keys", "-l", "-t", s.Name, "--", keys)
 	return cmd.Run()
 }
 
-// SendEnter sends an Enter key to the tmux session
-func (s *Session) SendEnter() error {
+// ensureInsertMode prepends an Escape + `i` sequence so a vim-mode composer
+// (Claude Code with "editorMode": "vim") is guaranteed to be in insert mode
+// before text or Enter is delivered. No-op unless VimMode is set. The sequence
+// is idempotent — Escape lands in normal mode, `i` enters insert — so it is
+// safe to call when the prompt is already in insert mode. See issue #1264.
+func (s *Session) ensureInsertMode() {
+	if !s.VimMode {
+		return
+	}
+	// Escape: guarantee normal mode regardless of current state.
+	_ = keySenderExec(s.SocketName, "send-keys", "-t", s.Name, "Escape").Run()
+	// i: enter insert mode so the following paste/Enter are taken literally.
+	_ = keySenderExec(s.SocketName, "send-keys", "-t", s.Name, "i").Run()
+}
+
+// sendEnterRaw emits a single Enter keystroke without the vim-mode insert
+// guard. Used internally by SendKeysAndEnter, which has already guaranteed
+// insert mode before the paste — re-escaping before the trailing Enter would
+// drop the prompt back to normal mode and swallow the submit.
+func (s *Session) sendEnterRaw() error {
 	s.invalidateCache()
-	cmd := s.tmuxCmd("send-keys", "-t", s.Name, "Enter")
+	cmd := keySenderExec(s.SocketName, "send-keys", "-t", s.Name, "Enter")
 	return cmd.Run()
+}
+
+// SendEnter sends an Enter key to the tmux session. When VimMode is set it
+// first guarantees the composer is in insert mode (issue #1264) so the Enter
+// submits the message instead of being consumed as a vim normal-mode motion.
+// This covers the bare-Enter nudges the send-verify retry loop fires against a
+// detected unsent prompt (cmd/agent-deck/session_cmd.go), which would
+// otherwise all no-op in normal mode.
+func (s *Session) SendEnter() error {
+	s.ensureInsertMode()
+	return s.sendEnterRaw()
 }
 
 // OpenKeySender opens a persistent tmux control-mode client bound to this
@@ -4021,7 +4071,7 @@ func (s *Session) OpenKeySender() (KeySender, error) {
 // Backspace, arrow keys, Tab, and Ctrl-{C,D} from the TUI to the focused pane.
 func (s *Session) SendNamedKey(key string) error {
 	s.invalidateCache()
-	cmd := s.tmuxCmd("send-keys", "-t", s.Name, key)
+	cmd := keySenderExec(s.SocketName, "send-keys", "-t", s.Name, key)
 	return cmd.Run()
 }
 
@@ -4032,6 +4082,10 @@ func (s *Session) SendNamedKey(key string) error {
 // marker and gets swallowed by async TUI frameworks (Ink/Node.js, curses).
 func (s *Session) SendKeysAndEnter(keys string) error {
 	s.invalidateCache()
+	// Guarantee the composer is in insert mode BEFORE the paste so a vim
+	// normal-mode prompt doesn't interpret the message body as motion/command
+	// keystrokes (issue #1264). No-op unless VimMode is set.
+	s.ensureInsertMode()
 	// Use chunked sending for large messages to avoid tmux buffer limits
 	if err := s.SendKeysChunked(keys); err != nil {
 		return err
@@ -4040,7 +4094,10 @@ func (s *Session) SendKeysAndEnter(keys string) error {
 	// before Enter arrives. Without this, tmux 3.2+ paste sequences cause
 	// the immediately-following Enter to be swallowed by the paste handler.
 	time.Sleep(100 * time.Millisecond)
-	return s.SendEnter()
+	// sendEnterRaw (not SendEnter): we already guaranteed insert mode above and
+	// the paste keeps us in insert; re-escaping here would drop back to normal
+	// mode and swallow the submit.
+	return s.sendEnterRaw()
 }
 
 // SendKeysChunked sends large content to the tmux session in chunks to avoid

--- a/internal/tmux/tmux_vim_mode_test.go
+++ b/internal/tmux/tmux_vim_mode_test.go
@@ -1,0 +1,166 @@
+// Regression tests for issue #1264: `session send` silently fails to submit
+// when Claude Code's prompt is in vim NORMAL mode.
+//
+// Failure mechanism (confirmed from the issue + the send path): a bracketed
+// paste lands in the input widget regardless of vim mode, but the trailing
+// `Enter` in normal mode is a navigation keystroke, not submit — so the
+// message is typed but never sent, and the send-verify retry loop's bare
+// `SendEnter()` nudges all no-op for the same reason.
+//
+// The fix gates an Escape + `i` insert-mode guarantee at the keysender layer
+// (Session.VimMode), so every SendEnter / SendKeysAndEnter issued against a
+// vim-mode target is preceded by a guarantee-insert sequence. These tests
+// record the exact key sequence emitted via the keySenderExec seam, so they
+// run deterministically without standing up a real tmux server.
+package tmux
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordKeySender swaps keySenderExec for a recorder that captures each tmux
+// send-keys invocation's argv and returns a no-op command that exits 0, so the
+// production .Run() succeeds without a real tmux server. Returns a pointer to
+// the recorded calls slice (each entry is the full argv after the socket name)
+// and registers cleanup to restore the original seam.
+func recordKeySender(t *testing.T) *[]string {
+	t.Helper()
+	original := keySenderExec
+	var mu sync.Mutex
+	var calls []string
+	keySenderExec = func(socketName string, args ...string) *exec.Cmd {
+		mu.Lock()
+		calls = append(calls, strings.Join(args, " "))
+		mu.Unlock()
+		// `true` is a tiny binary that exits 0 — keeps .Run() happy without
+		// touching tmux. It exists on every POSIX host the suite runs on.
+		return exec.Command("true")
+	}
+	t.Cleanup(func() { keySenderExec = original })
+	return &calls
+}
+
+// sentKey extracts the trailing key token from a recorded `send-keys ... <key>`
+// argv string.
+func sentKey(call string) string {
+	fields := strings.Fields(call)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[len(fields)-1]
+}
+
+// TestSendEnter_VimMode_PrependsInsertGuard is the core #1264 regression: a
+// bare SendEnter against a vim-mode target must first force insert mode
+// (Escape then `i`) so the Enter actually submits instead of being consumed as
+// a normal-mode motion. This is the exact path the retry loop's nudges take.
+//
+// Pre-fix: SendEnter emits only `Enter` → test FAILS (no Escape/`i` guard).
+func TestSendEnter_VimMode_PrependsInsertGuard(t *testing.T) {
+	calls := recordKeySender(t)
+
+	s := &Session{Name: "vim-enter", VimMode: true}
+	if err := s.SendEnter(); err != nil {
+		t.Fatalf("SendEnter returned error: %v", err)
+	}
+
+	keys := []string{}
+	for _, c := range *calls {
+		keys = append(keys, sentKey(c))
+	}
+	want := []string{"Escape", "i", "Enter"}
+	if len(keys) != len(want) {
+		t.Fatalf("vim-mode SendEnter emitted %v, want %v", keys, want)
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("vim-mode SendEnter emitted %v, want %v", keys, want)
+		}
+	}
+}
+
+// TestSendEnter_NonVim_Unchanged guards against regressing the default path:
+// when VimMode is false the bare Enter must be emitted alone, with no Escape/i
+// prefix that would corrupt a normal (non-vim) Claude composer or other tools.
+func TestSendEnter_NonVim_Unchanged(t *testing.T) {
+	calls := recordKeySender(t)
+
+	s := &Session{Name: "plain-enter"} // VimMode defaults to false
+	if err := s.SendEnter(); err != nil {
+		t.Fatalf("SendEnter returned error: %v", err)
+	}
+
+	if len(*calls) != 1 || sentKey((*calls)[0]) != "Enter" {
+		t.Fatalf("non-vim SendEnter must emit exactly [Enter], got %v", *calls)
+	}
+}
+
+// TestSendKeysAndEnter_VimMode_InsertThenPasteThenEnter verifies the full send
+// path: insert guard fires BEFORE the paste (so the message body isn't eaten
+// as vim commands), and the trailing Enter is NOT re-escaped (re-escaping
+// would drop back to normal mode and swallow the submit).
+//
+// Pre-fix: emits only `<paste> Enter` with no leading Escape/`i` → test FAILS.
+func TestSendKeysAndEnter_VimMode_InsertThenPasteThenEnter(t *testing.T) {
+	calls := recordKeySender(t)
+
+	s := &Session{Name: "vim-send", VimMode: true}
+	if err := s.SendKeysAndEnter("hello world"); err != nil {
+		t.Fatalf("SendKeysAndEnter returned error: %v", err)
+	}
+
+	c := *calls
+	// Expected: Escape, i (insert guard), literal paste, Enter — 4 calls.
+	if len(c) != 4 {
+		t.Fatalf("vim-mode SendKeysAndEnter expected 4 tmux calls (Escape, i, paste, Enter)\n got %d: %v", len(c), c)
+	}
+
+	if sentKey(c[0]) != "Escape" {
+		t.Fatalf("first key must be Escape, got %q (%v)", sentKey(c[0]), c)
+	}
+	if sentKey(c[1]) != "i" {
+		t.Fatalf("second key must be i, got %q (%v)", sentKey(c[1]), c)
+	}
+	// Remaining calls must contain the literal paste and a trailing Enter, with
+	// NO additional Escape after the paste (would un-insert before submit).
+	rest := c[2:]
+	var sawPaste, sawEnter bool
+	for _, call := range rest {
+		if strings.Contains(call, "-l") && strings.Contains(call, "hello world") {
+			sawPaste = true
+		}
+		if sentKey(call) == "Enter" {
+			sawEnter = true
+		}
+		if strings.Contains(call, " Escape") || call == "Escape" {
+			t.Fatalf("no Escape allowed after the paste (would swallow submit): %v", c)
+		}
+	}
+	if !sawPaste {
+		t.Fatalf("literal paste of message body not emitted: %v", c)
+	}
+	if !sawEnter {
+		t.Fatalf("trailing Enter not emitted: %v", c)
+	}
+}
+
+// TestSendKeysAndEnter_NonVim_NoInsertGuard guards the default path: a non-vim
+// send must NOT inject Escape/`i` (which would be typed as literal characters
+// into a non-vim composer or break other tools like codex/gemini/opencode).
+func TestSendKeysAndEnter_NonVim_NoInsertGuard(t *testing.T) {
+	calls := recordKeySender(t)
+
+	s := &Session{Name: "plain-send"} // VimMode defaults to false
+	if err := s.SendKeysAndEnter("hello"); err != nil {
+		t.Fatalf("SendKeysAndEnter returned error: %v", err)
+	}
+
+	for _, call := range *calls {
+		if sentKey(call) == "Escape" || sentKey(call) == "i" {
+			t.Fatalf("non-vim SendKeysAndEnter must not emit Escape/i guard: %v", *calls)
+		}
+	}
+}

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -76,6 +76,7 @@ auto_mode = false                  # Enable --permission-mode auto (classifier-b
 allow_dangerous_mode = false       # Enable --allow-dangerously-skip-permissions
 use_chrome = false                 # Enable --chrome
 use_teammate_mode = false          # Enable --teammate-mode tmux
+vim_mode = false                   # Force insert mode before each send (Claude Code "editorMode": "vim")
 extra_args = ["--agent", "reviewer"] # Extra Claude CLI flags
 env_file = "~/.claude.env"         # .env file specific to Claude sessions
 
@@ -92,6 +93,7 @@ config_dir = "~/.claude-work"      # Optional override for profile "work"
 | `allow_dangerous_mode` | bool | `false` | Adds `--allow-dangerously-skip-permissions`. Unlocks bypass as an option without activating it. Ignored when `dangerous_mode` or `auto_mode` is true. |
 | `use_chrome` | bool | `false` | Adds `--chrome` to Claude sessions and is remembered from the New Session dialog. |
 | `use_teammate_mode` | bool | `false` | Adds `--teammate-mode tmux` to Claude sessions and is remembered from the New Session dialog. |
+| `vim_mode` | bool | `false` | Set when the inner Claude Code prompt uses vim keybindings (`"editorMode": "vim"`). Each `session send` then prepends an Escape + `i` insert-mode guarantee so a message sent while the prompt is in vim NORMAL mode actually submits instead of being typed-but-unsent (issue #1264). Only affects Claude-compatible tools. |
 | `extra_args` | array of strings | `[]` | Extra Claude CLI flags remembered from the New Session dialog and appended to new/restarted Claude sessions. Do not store secrets here. |
 | `env_file` | string | `""` | A .env file sourced for Claude sessions only. Sourced after global `[shell].env_files`. See [Path Resolution](#path-resolution). |
 | `command` | string | `"claude"` | Override the binary/invocation (e.g., `"cdw"` for a wrapper that sets `CLAUDE_CONFIG_DIR`). |


### PR DESCRIPTION
Closes #1264. Thanks to @dariocc for the precise report and the keysender-layer fix direction (including the follow-up note that the bare-Enter nudges in `sendWithRetryTarget` need the same treatment).

## Root cause (confirmed)

When Claude Code's prompt is in vim **normal** mode (the default state after a turn finishes with `"editorMode": "vim"`), `session send` types the message but the trailing `Enter` is interpreted as a navigation keystroke, not submit. The bracketed paste lands in the input widget regardless of vim mode, but nothing in the send path guarantees insert mode before the `Enter` arrives. The send-verify retry loop (`cmd/agent-deck/session_cmd.go`) then fires bare `target.SendEnter()` nudges to re-submit the detected unsent prompt — those no-op for the exact same reason, and the full-resend path re-types the message (doubling it) without ever submitting.

## Fix

Gate an `Escape` + `i` insert-mode guarantee at the **keysender layer** (`internal/tmux/tmux.go`), driven by a new `Session.VimMode` flag, exactly as the reporter suggested. Every `SendEnter` / `SendKeysAndEnter` issued against a vim-mode target is now preceded by a guarantee-insert sequence, so **both** the initial send and the retry loop's bare-Enter nudges submit correctly — without touching the three nudge call sites individually.

- `SendKeysAndEnter`: `ensureInsertMode()` runs **before** the paste (so the message body isn't eaten as vim motions), and the trailing Enter uses a new internal `sendEnterRaw()` that does **not** re-escape (re-escaping after the paste would drop back to normal mode and swallow the submit).
- `SendEnter`: ensures insert mode, then emits Enter — covering the retry-loop nudges.

### Why it's safe

- **Off by default.** `VimMode` is the zero value (false). When false, `ensureInsertMode()` is a no-op and the send path is byte-identical to before — so non-vim Claude sessions and **other tools (codex / gemini / opencode / hermes / copilot)** are completely unaffected.
- **Gated to Claude only.** The config flag is wired onto the session only for Claude-compatible tools (`applyVimModeFromConfig`); other tools never sit in a vim composer.
- **Idempotent even in insert mode.** `Escape` always lands in normal mode and `i` always enters insert, so the guard is safe whether the prompt was in normal or insert mode when the send fired.

### Config

Opt in per the reporter's option (a): `[claude]` `vim_mode = true`. Documented in `config-reference.md` and `CHANGELOG.md`.

## TDD (test added first, proven fail → pass)

New `internal/tmux/tmux_vim_mode_test.go` records the exact key sequence via a `keySenderExec` test seam (deterministic, no real tmux server):

- `TestSendEnter_VimMode_PrependsInsertGuard` — bare Enter emits `Escape, i, Enter`.
- `TestSendKeysAndEnter_VimMode_InsertThenPasteThenEnter` — `Escape, i, <paste>, Enter`; asserts NO Escape after the paste.
- `TestSendEnter_NonVim_Unchanged` / `TestSendKeysAndEnter_NonVim_NoInsertGuard` — default path emits no guard (regression pins for other tools / non-vim Claude).

Proven the vim tests **FAIL** against pre-fix behavior (guard disabled: `emitted [Enter], want [Escape i Enter]`) and **PASS** with the fix, while the non-vim tests pass in both states.

## Verification

- `go build ./...` — clean
- `go test -race ./internal/tmux/...` — pass
- `go test -race ./internal/session/...` — pass (excluding host-flaky `TestPerf_OutboxDrain_*`, which passes in isolation and fails on clean main under load)
- cmd send tests pass (excluding host-flaky `TestSessionOutput_RefreshesSessionID`, which fails on clean main too)

Part of the send-verify silent-drop family (#876 / #1205 / #1238 / #616) — same symptom (typed-but-unsent), distinct cause (vim normal mode rather than a launch/init race).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added vim mode configuration support for Claude environments
  * Enhanced keyboard handling in vim mode to ensure proper keystroke submission
  * Fixed vim-mode key input regression affecting insert mode behavior

* **Tests**
  * Added comprehensive regression tests for vim mode keyboard submission

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asheshgoplani/agent-deck/pull/1271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->