### PR TITLE
feat(ui): optional last-update timestamp badge on session rows

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -536,6 +536,18 @@ func (inst *Instance) GetLastActivityTime() time.Time {
 	return inst.CreatedAt
 }
 
+// LastObservedActivity returns the last time the tmux tracker confirmed a
+// real busy spike for this session, and a bool that is false when no
+// confirmation has happened (the instance has no tmux session, or the
+// tracker has never observed activity). When the bool is false the time
+// value is zero.
+func (inst *Instance) LastObservedActivity() (time.Time, bool) {
+	if inst.tmuxSession == nil {
+		return time.Time{}, false
+	}
+	return inst.tmuxSession.LastObservedActivity()
+}
+
 // GetWaitingSince returns when the session transitioned to waiting status
 // Used for sorting notification bar (newest waiting sessions first)
 func (inst *Instance) GetWaitingSince() time.Time {

--- a/internal/session/instance_last_observed_activity_test.go
+++ b/internal/session/instance_last_observed_activity_test.go
@@ -1,0 +1,20 @@
+package session
+
+import "testing"
+
+// Instance.LastObservedActivity must be safe to call when the instance
+// has no live tmux session (freshly loaded, never started, or stopped).
+// Returning (zero, false) is the load-bearing contract — callers in the
+// render path lean on the bool to decide whether to consult the time
+// value, and the zero time gives a safe sentinel for callers that don't.
+
+func TestInstance_LastObservedActivity_NilTmuxSession(t *testing.T) {
+	inst := &Instance{ID: "sess-no-tmux"}
+	ts, observed := inst.LastObservedActivity()
+	if observed {
+		t.Errorf("Instance with nil tmuxSession must return observed=false, got %v", ts)
+	}
+	if !ts.IsZero() {
+		t.Errorf("Instance with nil tmuxSession must return zero time, got %v", ts)
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1923,6 +1923,11 @@ type DisplaySettings struct {
 	// preserves the historical format; set false to show only the session
 	// title. Consumed by the tmux set-titles-string builder.
 	IncludeCwdPrefix *bool `toml:"include_cwd_prefix"`
+
+	// ShowSessionTimestamps appends a dim "Nm ago" badge to every session row.
+	// Default: false — opt-in to avoid crowding existing badges. See
+	// renderSessionItem for the timestamp source.
+	ShowSessionTimestamps bool `toml:"show_session_timestamps"`
 }
 
 // GetActiveFilterExcludes returns the resolved set of statuses the % filter

--- a/internal/session/userconfig_merge.go
+++ b/internal/session/userconfig_merge.go
@@ -87,6 +87,10 @@ func MergePanelConfigOntoDisk(panel *UserConfig) (*UserConfig, error) {
 		merged.Preview.NotesOutputSplit = panel.Preview.NotesOutputSplit
 	}
 
+	// ── Display subset (panel manages ShowSessionTimestamps; FullRepaint
+	//    and filter prefs stay from disk) ───────────────────────────────
+	merged.Display.ShowSessionTimestamps = panel.Display.ShowSessionTimestamps
+
 	// ── SystemStats subset ─────────────────────────────────────────────
 	if panel.SystemStats.Enabled != nil {
 		merged.SystemStats.Enabled = panel.SystemStats.Enabled

--- a/internal/session/userconfig_merge_timestamps_test.go
+++ b/internal/session/userconfig_merge_timestamps_test.go
@@ -1,0 +1,38 @@
+package session
+
+import "testing"
+
+// MergePanelConfigOntoDisk is an allowlist-style merger: any panel-managed
+// field omitted from the function silently fails to persist. This test
+// pins the Display.ShowSessionTimestamps overlay so the wiring can't
+// regress to "toggle does nothing" behavior again.
+
+func TestMergePanelConfigOntoDisk_PropagatesShowSessionTimestamps(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	// Toggle on via panel input.
+	panel := &UserConfig{
+		Display: DisplaySettings{ShowSessionTimestamps: true},
+	}
+	merged, err := MergePanelConfigOntoDisk(panel)
+	if err != nil {
+		t.Fatalf("MergePanelConfigOntoDisk returned error: %v", err)
+	}
+	if !merged.Display.ShowSessionTimestamps {
+		t.Fatal("merge dropped Display.ShowSessionTimestamps=true — toggle would never persist to disk")
+	}
+
+	// Toggle back off must also propagate (zero-value bool, easy to drop accidentally).
+	panel2 := &UserConfig{
+		Display: DisplaySettings{ShowSessionTimestamps: false},
+	}
+	merged2, err := MergePanelConfigOntoDisk(panel2)
+	if err != nil {
+		t.Fatalf("MergePanelConfigOntoDisk returned error: %v", err)
+	}
+	if merged2.Display.ShowSessionTimestamps {
+		t.Fatal("merge failed to propagate Display.ShowSessionTimestamps=false — toggle would be stuck on")
+	}
+}

--- a/internal/tmux/real_activity_test.go
+++ b/internal/tmux/real_activity_test.go
@@ -1,0 +1,66 @@
+package tmux
+
+import (
+	"testing"
+	"time"
+)
+
+// realActivityConfirmed must default to false at tracker construction —
+// even though lastChangeTime is initialized to time.Now(), we don't yet
+// know whether the underlying pane has actually done anything. Callers
+// (the TUI timestamp badge) rely on this gating to avoid showing every
+// session as "just now" right after agent-deck starts.
+
+func TestStateTracker_RealActivity_FalseAtConstruction(t *testing.T) {
+	tracker := &StateTracker{
+		lastChangeTime: time.Now(),
+	}
+	if tracker.realActivityConfirmed {
+		t.Fatal("freshly-constructed tracker must NOT report realActivityConfirmed=true; " +
+			"that flag is what callers use to distinguish 'we've never observed activity' " +
+			"from 'we observed activity at lastChangeTime'")
+	}
+}
+
+func TestSession_LastObservedActivity_FalseWhenNoTracker(t *testing.T) {
+	s := &Session{}
+	ts, observed := s.LastObservedActivity()
+	if observed {
+		t.Errorf("Session with nil stateTracker must return observed=false, got %v", ts)
+	}
+	if !ts.IsZero() {
+		t.Errorf("Session with nil stateTracker must return zero time, got %v", ts)
+	}
+}
+
+func TestSession_LastObservedActivity_FalseAtInit(t *testing.T) {
+	s := &Session{
+		stateTracker: &StateTracker{
+			lastChangeTime: time.Now(),
+		},
+	}
+	ts, observed := s.LastObservedActivity()
+	if observed {
+		t.Fatal("Session whose tracker has never confirmed real activity must return observed=false")
+	}
+	if !ts.IsZero() {
+		t.Errorf("must return zero time when !realActivityConfirmed so callers that miss the bool check get a sentinel, got %v", ts)
+	}
+}
+
+func TestSession_LastObservedActivity_TrueAfterConfirmation(t *testing.T) {
+	want := time.Now().Add(-3 * time.Minute)
+	s := &Session{
+		stateTracker: &StateTracker{
+			lastChangeTime:        want,
+			realActivityConfirmed: true,
+		},
+	}
+	got, observed := s.LastObservedActivity()
+	if !observed {
+		t.Fatal("after the tracker flips realActivityConfirmed=true, LastObservedActivity must report observed=true")
+	}
+	if !got.Equal(want) {
+		t.Errorf("LastObservedActivity returned %v, want %v", got, want)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -679,6 +679,8 @@ type StateTracker struct {
 	activityCheckStart  time.Time // When we started tracking for sustained activity
 	activityChangeCount int       // How many timestamp changes seen in current window
 
+	realActivityConfirmed bool // true once a real busy spike has been observed (not just tracker init)
+
 	// Spinner activity tracking: grace period between tool calls
 	spinnerTracker *SpinnerActivityTracker
 }
@@ -2907,6 +2909,7 @@ func (s *Session) GetStatus() (string, error) {
 			s.mu.Lock()
 			s.ensureStateTrackerLocked()
 			s.stateTracker.lastChangeTime = time.Now()
+			s.stateTracker.realActivityConfirmed = true
 			s.stateTracker.acknowledged = false
 			s.resetPromptNoBusyHoldLocked()
 			s.stateTracker.spinnerTracker.MarkBusy()
@@ -3003,6 +3006,7 @@ func (s *Session) GetStatus() (string, error) {
 			// false "waiting" detection during tool transitions.
 			if isExplicitlyBusy {
 				s.stateTracker.lastChangeTime = time.Now()
+				s.stateTracker.realActivityConfirmed = true
 				s.stateTracker.acknowledged = false
 				s.resetPromptNoBusyHoldLocked()
 				s.stateTracker.lastActivityTimestamp = currentTS
@@ -3149,6 +3153,7 @@ func (s *Session) GetStatus() (string, error) {
 					// terminal redraws, and status bar updates can cause hash changes
 					if isExplicitlyBusy {
 						s.stateTracker.lastChangeTime = now
+						s.stateTracker.realActivityConfirmed = true
 						s.stateTracker.acknowledged = false
 						s.resetPromptNoBusyHoldLocked()
 						s.stateTracker.activityCheckStart = time.Time{} // Reset window
@@ -3350,6 +3355,7 @@ func (s *Session) getStatusFallback() (string, error) {
 		defer s.mu.Unlock()
 		s.ensureStateTrackerLocked()
 		s.stateTracker.lastChangeTime = time.Now()
+		s.stateTracker.realActivityConfirmed = true
 		s.stateTracker.acknowledged = false
 		s.resetPromptNoBusyHoldLocked()
 		s.lastStableStatus = "active"
@@ -3539,6 +3545,21 @@ func (s *Session) GetLastActivityTime() time.Time {
 		return time.Time{}
 	}
 	return s.stateTracker.lastChangeTime
+}
+
+// LastObservedActivity returns the last time a real busy spike was
+// observed for this tracker, plus a bool reporting whether such a spike
+// has ever happened in this tracker's lifetime. When the bool is false
+// the time is the zero value, so callers that miss the bool check still
+// get a sentinel they can detect.
+func (s *Session) LastObservedActivity() (time.Time, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.stateTracker == nil || !s.stateTracker.realActivityConfirmed {
+		return time.Time{}, false
+	}
+	return s.stateTracker.lastChangeTime, true
 }
 
 // GetWaitingSince returns when the session transitioned to waiting status

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -415,6 +415,11 @@ type Home struct {
 	activeFilterLabel    string                  // from config.toml [display] active_filter_label
 	activeFilterExcludes map[session.Status]bool // from config.toml [display] active_filter_excludes; default {error}
 
+	// showSessionTimestamps gates the dim "Nm ago" badge on each session row.
+	// Cached here so all rows of a single frame see the same value even if
+	// the user toggles the setting mid-frame. Reloaded after the panel saves.
+	showSessionTimestamps bool
+
 	// Sessions/Preview split (issue #1092): percentage of width allocated to
 	// preview pane. Loaded from config.toml [ui] preview_pct, adjustable
 	// live via < and > keybindings, persisted back to config on adjustment.
@@ -981,6 +986,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.activeFilterLabel = cfg.Display.ActiveFilterLabel
 		h.activeFilterExcludes = cfg.Display.GetActiveFilterExcludes()
 		tmux.SetHideCwdPrefixInTitle(!cfg.Display.GetIncludeCwdPrefix())
+		h.showSessionTimestamps = cfg.Display.ShowSessionTimestamps
 		h.sysStatsConfig = cfg.SystemStats
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(cfg, actualProfile)
 		h.previewPct = cfg.UI.GetPreviewPct()
@@ -5393,6 +5399,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				_, _ = session.ReloadUserConfig()
 				h.reloadHotkeysFromConfig()
+				h.showSessionTimestamps = config.Display.ShowSessionTimestamps
 
 				// Apply theme changes live
 				h.stopThemeWatcher()
@@ -12569,6 +12576,24 @@ func (h *Home) renderSessionItem(
 		sshBadge = sshStyle.Render(" [ssh:" + host + "]")
 	}
 
+	// Last-update timestamp badge — see pickBadgeTime for the formula.
+	// Selected rows reuse the selection-bar style instead of dim, so the
+	// badge stays legible inside the highlight.
+	timestampBadge := ""
+	if h.showSessionTimestamps {
+		tsStyle := DimStyle
+		if selected {
+			tsStyle = SessionStatusSelStyle
+		}
+		var hookStatus *session.HookStatus
+		if h.hookWatcher != nil {
+			hookStatus = h.hookWatcher.GetHookStatus(inst.ID)
+		}
+		confirmedTs, confirmedObserved := inst.LastObservedActivity()
+		ts := pickBadgeTime(inst.CreatedAt, inst.LastStartedAt, hookStatus, confirmedTs, confirmedObserved)
+		timestampBadge = tsStyle.Render(" " + formatRelativeTime(ts))
+	}
+
 	// Window expand/collapse chevron for sessions with 2+ windows
 	windowChevron := " " // space placeholder to keep status icons aligned
 	if h.sessionHasWindows(item) {
@@ -12585,7 +12610,7 @@ func (h *Home) renderSessionItem(
 
 	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [badges]
 	row := fmt.Sprintf(
-		"%s%s%s%s%s %s%s%s%s%s%s%s",
+		"%s%s%s%s%s %s%s%s%s%s%s%s%s",
 		baseIndent,
 		selectionPrefix,
 		treeStyle.Render(treeConnector),
@@ -12598,6 +12623,7 @@ func (h *Home) renderSessionItem(
 		sandboxBadge,
 		multiRepoBadge,
 		sshBadge,
+		timestampBadge,
 	)
 
 	// Append pane title filling remaining row space (only for the selected item).
@@ -14598,6 +14624,27 @@ func truncatePath(path string, maxLen int) string {
 		return cellTruncate(path, maxLen-3, "...")
 	}
 	return string(runes[:startLen]) + "..." + string(runes[len(runes)-endLen:])
+}
+
+// pickBadgeTime returns the most recent of the four signals the session-row
+// timestamp badge layers over, ignoring any signal that is unset / not
+// observed. Pure function — kept out of renderSessionItem so the 4-layer
+// composition can be unit-tested without faking renderer dependencies.
+//
+// LastAccessedAt is deliberately not a parameter: peeking at a quiet
+// session isn't an "update".
+func pickBadgeTime(createdAt, lastStartedAt time.Time, hookEvent *session.HookStatus, confirmedActivity time.Time, confirmedObserved bool) time.Time {
+	ts := createdAt
+	if lastStartedAt.After(ts) {
+		ts = lastStartedAt
+	}
+	if hookEvent != nil && hookEvent.UpdatedAt.After(ts) {
+		ts = hookEvent.UpdatedAt
+	}
+	if confirmedObserved && confirmedActivity.After(ts) {
+		ts = confirmedActivity
+	}
+	return ts
 }
 
 // formatRelativeTime formats a time as a human-readable relative string

--- a/internal/ui/pick_badge_time_test.go
+++ b/internal/ui/pick_badge_time_test.go
@@ -1,0 +1,122 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// pickBadgeTime composes the 4-layer "most recent" formula that drives the
+// session-row timestamp badge. Extracting it from renderSessionItem lets
+// us pin the composition without faking unexported Home/Instance fields.
+// Layers, in newest-wins order:
+//
+//	1. CreatedAt              (always set)
+//	2. LastStartedAt          (zero if never started)
+//	3. hookEvent.UpdatedAt    (nil if no hooks installed)
+//	4. confirmedActivity      (bool gates use — false means "ignore")
+
+func TestPickBadgeTime_PicksCreatedAtFloor(t *testing.T) {
+	created := time.Now().Add(-2 * time.Hour)
+	got := pickBadgeTime(created, time.Time{}, nil, time.Time{}, false)
+	if !got.Equal(created) {
+		t.Errorf("with only CreatedAt set, expected %v, got %v", created, got)
+	}
+}
+
+func TestPickBadgeTime_LastStartedBeatsCreatedAt(t *testing.T) {
+	created := time.Now().Add(-5 * 24 * time.Hour)
+	started := time.Now().Add(-10 * time.Minute)
+	got := pickBadgeTime(created, started, nil, time.Time{}, false)
+	if !got.Equal(started) {
+		t.Errorf("LastStartedAt should beat older CreatedAt, expected %v, got %v", started, got)
+	}
+}
+
+func TestPickBadgeTime_HookEventBeatsLifecycle(t *testing.T) {
+	created := time.Now().Add(-5 * 24 * time.Hour)
+	started := time.Now().Add(-2 * time.Hour)
+	hookAt := time.Now().Add(-30 * time.Second)
+	hook := &session.HookStatus{UpdatedAt: hookAt}
+
+	got := pickBadgeTime(created, started, hook, time.Time{}, false)
+	if !got.Equal(hookAt) {
+		t.Errorf("newer hook event should beat lifecycle floor, expected %v, got %v", hookAt, got)
+	}
+}
+
+func TestPickBadgeTime_NilHookIgnored(t *testing.T) {
+	created := time.Now().Add(-2 * time.Hour)
+	started := time.Now().Add(-1 * time.Hour)
+	got := pickBadgeTime(created, started, nil, time.Time{}, false)
+	if !got.Equal(started) {
+		t.Errorf("nil hookEvent must be ignored, expected %v, got %v", started, got)
+	}
+}
+
+func TestPickBadgeTime_StaleHookIgnored(t *testing.T) {
+	// A hook event from a previous process can be stale relative to the
+	// lifecycle floor (session restarted after the hook). Older events
+	// must not pull the badge backwards.
+	created := time.Now().Add(-5 * 24 * time.Hour)
+	started := time.Now().Add(-5 * time.Minute)
+	staleHook := &session.HookStatus{UpdatedAt: time.Now().Add(-3 * time.Hour)}
+
+	got := pickBadgeTime(created, started, staleHook, time.Time{}, false)
+	if !got.Equal(started) {
+		t.Errorf("stale hook older than LastStartedAt must not win, expected %v, got %v", started, got)
+	}
+}
+
+func TestPickBadgeTime_ConfirmedActivityBeatsHook(t *testing.T) {
+	created := time.Now().Add(-5 * 24 * time.Hour)
+	started := time.Now().Add(-2 * time.Hour)
+	hook := &session.HookStatus{UpdatedAt: time.Now().Add(-1 * time.Minute)}
+	confirmed := time.Now().Add(-3 * time.Second)
+
+	got := pickBadgeTime(created, started, hook, confirmed, true)
+	if !got.Equal(confirmed) {
+		t.Errorf("newer tmux-confirmed activity should beat hook event, expected %v, got %v", confirmed, got)
+	}
+}
+
+func TestPickBadgeTime_ConfirmedActivityBeatsLifecycleWithoutHooks(t *testing.T) {
+	// Production path for users who haven't installed agent-deck hooks:
+	// no hook event is ever present, the tmux confirmed-activity layer is
+	// the only thing that can move the badge past LastStartedAt. Covered
+	// transitively by other cases (confirmed-beats-hook + hook-beats-
+	// lifecycle), but this is *the* hot path so it deserves a direct pin.
+	created := time.Now().Add(-5 * 24 * time.Hour)
+	started := time.Now().Add(-2 * time.Hour)
+	confirmed := time.Now().Add(-15 * time.Second)
+
+	got := pickBadgeTime(created, started, nil, confirmed, true)
+	if !got.Equal(confirmed) {
+		t.Errorf("with no hook installed, tmux confirmed activity should beat LastStartedAt, "+
+			"expected %v, got %v", confirmed, got)
+	}
+}
+
+func TestPickBadgeTime_UnobservedConfirmedIgnored(t *testing.T) {
+	// When the tracker has never observed real activity, the confirmed
+	// timestamp is meaningless (would be tracker-init time.Now). The bool
+	// gates use — false must cause the value to be ignored even if it's
+	// "newer" than everything else.
+	created := time.Now().Add(-2 * time.Hour)
+	started := time.Now().Add(-1 * time.Hour)
+	confirmedButUnobserved := time.Now() // would dominate if not gated
+
+	got := pickBadgeTime(created, started, nil, confirmedButUnobserved, false)
+	if !got.Equal(started) {
+		t.Fatalf("confirmedObserved=false must cause the timestamp to be ignored, "+
+			"expected %v (LastStartedAt), got %v", started, got)
+	}
+}
+
+func TestPickBadgeTime_AllLayersZero(t *testing.T) {
+	got := pickBadgeTime(time.Time{}, time.Time{}, nil, time.Time{}, false)
+	if !got.IsZero() {
+		t.Errorf("with no signals at all, the function must return the zero time, got %v", got)
+	}
+}

--- a/internal/ui/remote_session_timestamps_test.go
+++ b/internal/ui/remote_session_timestamps_test.go
@@ -1,0 +1,66 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// RemoteSession timestamp-badge parity is intentionally deferred.
+//
+// The session.RemoteSessionInfo struct (internal/session/ssh.go) carries
+// only Tool, Status, CreatedAt (as a string), Title, Path, Group, and
+// RemoteName. It does NOT carry LastStartedAt, hook events, or any
+// per-session tmux state — those live on the remote machine, not over
+// the wire to the local TUI.
+//
+// The local badge formula in pickBadgeTime layers over four signals:
+// CreatedAt, LastStartedAt, hook UpdatedAt, and tmux-confirmed activity.
+// For a remote row, three of those four are permanently unavailable.
+// Wiring the badge with only CreatedAt would produce a "session age"
+// readout that never updates — inconsistent with what users see for
+// local rows and likely to be read as broken rather than helpful.
+//
+// Until the remote protocol is extended to ship at least one live
+// activity signal (LastStartedAt or hook events), the badge stays
+// local-only. This test pins that decision: it confirms the new
+// timestamp output does NOT leak into remote rows, so a future change
+// that silently adds the badge here will be forced through a
+// conscious re-review.
+//
+// Tracking note for follow-up: extending wire format / RemoteSessionInfo
+// to carry LastStartedAt + last hook event would be the minimum needed
+// to make remote parity meaningful.
+func TestRemoteSession_TimestampBadgeIsLocalOnly(t *testing.T) {
+	forceTrueColorProfile()
+
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.showSessionTimestamps = true // would emit badge on local rows
+
+	remote := session.RemoteSessionInfo{
+		ID:         "remote-test",
+		Title:      "remote-session",
+		Status:     "running",
+		Tool:       "claude",
+		RemoteName: "myserver",
+	}
+	item := session.Item{
+		Type:          session.ItemTypeRemoteSession,
+		RemoteSession: &remote,
+		RemoteName:    "myserver",
+	}
+
+	var b strings.Builder
+	home.renderRemoteSessionItem(&b, item, false)
+	rendered := b.String()
+
+	for _, sig := range []string{"ago", "just now"} {
+		if strings.Contains(rendered, sig) {
+			t.Fatalf("remote session row must not render the local-only timestamp badge "+
+				"(parity deferred — see file-level comment). Found %q in: %q", sig, rendered)
+		}
+	}
+}

--- a/internal/ui/session_timestamps_test.go
+++ b/internal/ui/session_timestamps_test.go
@@ -1,0 +1,185 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Session row timestamp badge. The "5m ago" / "1h ago" suffix appears on
+// every row when [display] show_session_timestamps = true, and is absent
+// otherwise. The flag is cached on Home at startup and refreshed when the
+// settings panel saves.
+
+func renderRowWithTimestamps(t *testing.T, inst *session.Instance, enabled bool) string {
+	t.Helper()
+	forceTrueColorProfile()
+
+	h := &Home{width: 140, showSessionTimestamps: enabled}
+	item := session.Item{
+		Type:          session.ItemTypeSession,
+		Session:       inst,
+		Level:         1,
+		Path:          "test",
+		IsLastInGroup: true,
+	}
+	snapshot := map[string]sessionRenderState{
+		inst.ID: {
+			status:    session.StatusRunning,
+			tool:      "claude",
+			paneTitle: "",
+		},
+	}
+
+	var b strings.Builder
+	h.renderSessionItem(&b, item, false, snapshot, h.width)
+	return b.String()
+}
+
+func TestSessionTimestamp_EnabledShowsAgoBadge(t *testing.T) {
+	inst := &session.Instance{
+		ID:        "sess-ts-on",
+		Title:     "with-timestamp",
+		CreatedAt: time.Now().Add(-90 * time.Minute), // 1h ago
+	}
+
+	row := renderRowWithTimestamps(t, inst, true)
+
+	if !strings.Contains(row, "ago") {
+		t.Fatalf("show_session_timestamps=true should append a relative-time badge to the row, "+
+			"but no 'ago' suffix was found. Got: %q", row)
+	}
+}
+
+func TestSessionTimestamp_DisabledOmitsBadge(t *testing.T) {
+	inst := &session.Instance{
+		ID:        "sess-ts-off",
+		Title:     "without-timestamp",
+		CreatedAt: time.Now().Add(-90 * time.Minute),
+	}
+
+	row := renderRowWithTimestamps(t, inst, false)
+
+	// The relative-time output is "1h ago" / "5m ago" / "just now". None
+	// of those substrings should appear when the toggle is off — they're
+	// the load-bearing signal that the badge leaked into the default path.
+	for _, sig := range []string{"ago", "just now"} {
+		if strings.Contains(row, sig) {
+			t.Fatalf("show_session_timestamps=false must not emit a timestamp badge, "+
+				"but row contains %q. Got: %q", sig, row)
+		}
+	}
+}
+
+func TestSessionTimestamp_JustNowForFreshSession(t *testing.T) {
+	inst := &session.Instance{
+		ID:        "sess-ts-fresh",
+		Title:     "fresh-session",
+		CreatedAt: time.Now(), // < 1 minute → "just now"
+	}
+
+	row := renderRowWithTimestamps(t, inst, true)
+
+	if !strings.Contains(row, "just now") {
+		t.Fatalf("freshly-created session should render with 'just now' badge. Got: %q", row)
+	}
+}
+
+// Old data source (Instance.GetLastActivityTime) returned tmuxSession.lastChangeTime
+// which is initialized to time.Now() the first time the StateTracker is built
+// for that session inside the running process. That made every session report
+// "just now" right after agent-deck started — the exact bug surfaced in
+// manual testing. This test pins the new contract: the badge reads from the
+// SQLite-persisted timestamps so an idle session with an old CreatedAt and no
+// LastAccessedAt/LastStartedAt updates does NOT collapse to "just now".
+func TestSessionTimestamp_OldSessionDoesNotRenderJustNow(t *testing.T) {
+	old := time.Now().Add(-3 * time.Hour)
+	inst := &session.Instance{
+		ID:             "sess-ts-stale",
+		Title:          "stale-session",
+		CreatedAt:      old,
+		LastAccessedAt: old,
+		LastStartedAt:  old,
+	}
+
+	row := renderRowWithTimestamps(t, inst, true)
+
+	if strings.Contains(row, "just now") {
+		t.Fatalf("session with all timestamps ~3h old must not render as 'just now'. Got: %q", row)
+	}
+	if !strings.Contains(row, "h ago") {
+		t.Fatalf("expected '%dh ago' style badge for 3-hour-old session. Got: %q", 3, row)
+	}
+}
+
+// Pins the max() across CreatedAt / LastStartedAt — the newest persisted
+// lifecycle touchpoint should win. LastAccessedAt is intentionally NOT in
+// the formula: attaching to a quiet session isn't an "update".
+func TestSessionTimestamp_PicksMostRecentLifecycleTimestamp(t *testing.T) {
+	now := time.Now()
+	inst := &session.Instance{
+		ID:            "sess-ts-recent",
+		Title:         "recently-started",
+		CreatedAt:     now.Add(-5 * 24 * time.Hour), // 5d ago
+		LastStartedAt: now.Add(-90 * time.Second),   // 1m ago — newest
+	}
+
+	row := renderRowWithTimestamps(t, inst, true)
+
+	if !strings.Contains(row, "1m ago") {
+		t.Fatalf("badge should pick the newest of CreatedAt/LastStartedAt = 1m ago. Got: %q", row)
+	}
+}
+
+// Regression pin: an Instance with nil tmuxSession (e.g. just loaded
+// from disk, never started in this process) must not crash the badge
+// path. Calling LastObservedActivity returns observed=false, so the
+// badge falls back to the lifecycle floor — the original "all sessions
+// show just now" bug surfaced exactly here, because the old code consumed
+// the time value without checking observed.
+func TestSessionTimestamp_HandlesNilTmuxSessionWithoutCrash(t *testing.T) {
+	old := time.Now().Add(-2 * time.Hour)
+	inst := &session.Instance{
+		ID:        "sess-no-tmux",
+		Title:     "loaded-from-disk",
+		CreatedAt: old,
+		// tmuxSession is unexported and stays nil — this is the realistic
+		// state for any Instance that has just been loaded but not started.
+	}
+
+	row := renderRowWithTimestamps(t, inst, true)
+
+	if strings.Contains(row, "just now") {
+		t.Fatalf("an instance with no live tmux session must not be rendered as 'just now' "+
+			"just because the tracker default leaked into the badge. Got: %q", row)
+	}
+	if !strings.Contains(row, "h ago") {
+		t.Fatalf("expected '2h ago' fallback from CreatedAt. Got: %q", row)
+	}
+}
+
+// Regression pin: LastAccessedAt must NOT influence the badge. A session
+// created 5 days ago that the user just attached to is still "5d ago" by
+// the badge's definition of update — opening the session isn't itself
+// an update event.
+func TestSessionTimestamp_LastAccessedAtIgnored(t *testing.T) {
+	now := time.Now()
+	inst := &session.Instance{
+		ID:             "sess-ts-attached",
+		Title:          "just-peeked",
+		CreatedAt:      now.Add(-5 * 24 * time.Hour),
+		LastAccessedAt: now.Add(-30 * time.Second), // would say "just now" if included
+	}
+
+	row := renderRowWithTimestamps(t, inst, true)
+
+	if strings.Contains(row, "just now") {
+		t.Fatalf("attaching to a stale session must not reset the badge to 'just now'. "+
+			"LastAccessedAt was deliberately removed from the formula. Got: %q", row)
+	}
+	if !strings.Contains(row, "5d ago") {
+		t.Fatalf("expected 5d ago (CreatedAt floor). Got: %q", row)
+	}
+}

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -46,10 +46,11 @@ const (
 	SettingStatsShowGPU
 	SettingStatsShowLoad
 	SettingSyncTitle
+	SettingShowSessionTimestamps
 )
 
 // Total number of navigable settings.
-const settingsCount = 30
+const settingsCount = 31
 
 // SettingsPanel displays and edits user configuration
 type SettingsPanel struct {
@@ -96,6 +97,8 @@ type SettingsPanel struct {
 	statsShowNetwork    bool
 	statsShowGPU        bool
 	statsShowLoad       bool
+
+	showSessionTimestamps bool
 
 	// Text input state
 	editingText bool
@@ -325,6 +328,9 @@ func (s *SettingsPanel) LoadConfig(config *session.UserConfig) {
 	s.statsShowNetwork = showSet["network"]
 	s.statsShowGPU = showSet["gpu"]
 	s.statsShowLoad = showSet["load"]
+
+	// Display settings
+	s.showSessionTimestamps = config.Display.ShowSessionTimestamps
 }
 
 func (s *SettingsPanel) buildToolLists(config *session.UserConfig) {
@@ -451,6 +457,9 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 		showStats = append(showStats, "load")
 	}
 	config.SystemStats.Show = showStats
+
+	// Display settings
+	config.Display.ShowSessionTimestamps = s.showSessionTimestamps
 
 	// Preserve original MCPs, Tools, and Docker settings.
 	if s.originalConfig != nil {
@@ -695,6 +704,10 @@ func (s *SettingsPanel) toggleValue() bool {
 
 	case SettingStatsShowLoad:
 		s.statsShowLoad = !s.statsShowLoad
+		return true
+
+	case SettingShowSessionTimestamps:
+		s.showSessionTimestamps = !s.showSessionTimestamps
 		return true
 	}
 
@@ -1059,6 +1072,16 @@ func (s *SettingsPanel) View() string {
 	}
 	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
 
+	// DISPLAY
+	content.WriteString(sectionStyle.Render("DISPLAY"))
+	content.WriteString("\n")
+
+	line = s.renderCheckbox("Show session timestamps", s.showSessionTimestamps) + " - Last activity per row"
+	if s.cursor == int(SettingShowSessionTimestamps) {
+		line = highlightStyle.Render(line)
+	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
+
 	// MCP & TOOLS
 	content.WriteString(sectionStyle.Render("MCP SERVERS & CUSTOM TOOLS"))
 	content.WriteString("\n")
@@ -1122,6 +1145,7 @@ func (s *SettingsPanel) View() string {
 			51, // SettingStatsShowGPU
 			51, // SettingStatsShowLoad
 			54, // SettingSyncTitle (SESSIONS section, after stats)
+			57, // SettingShowSessionTimestamps (DISPLAY section, after SESSIONS)
 		}
 		cursorLine := cursorToLine[s.cursor]
 

--- a/internal/ui/settings_panel_timestamps_test.go
+++ b/internal/ui/settings_panel_timestamps_test.go
@@ -1,0 +1,103 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Settings panel wiring for [display] show_session_timestamps. The toggle
+// must load from the on-disk Display struct, flip on space, and round-trip
+// back through GetConfig() unchanged.
+
+func TestSettingsPanel_ShowSessionTimestamps_LoadConfig(t *testing.T) {
+	panel := NewSettingsPanel()
+
+	config := &session.UserConfig{
+		Display: session.DisplaySettings{
+			ShowSessionTimestamps: true,
+		},
+	}
+	panel.LoadConfig(config)
+
+	if !panel.showSessionTimestamps {
+		t.Errorf("showSessionTimestamps should be true after loading config with Display.ShowSessionTimestamps=true")
+	}
+
+	// Default (zero-value) config should leave the panel value at false.
+	panel2 := NewSettingsPanel()
+	panel2.LoadConfig(&session.UserConfig{})
+	if panel2.showSessionTimestamps {
+		t.Errorf("showSessionTimestamps should default to false for an empty config")
+	}
+}
+
+func TestSettingsPanel_ShowSessionTimestamps_ToggleAndPersist(t *testing.T) {
+	// Isolate from the real ~/.agent-deck/config.toml — Show() would otherwise
+	// load the developer's actual setting and the precondition below would
+	// be non-deterministic.
+	t.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	panel := NewSettingsPanel()
+	panel.Show()
+	panel.cursor = int(SettingShowSessionTimestamps)
+
+	if panel.showSessionTimestamps {
+		t.Fatal("precondition: showSessionTimestamps must start false")
+	}
+
+	_, _, changed := panel.Update(tea.KeyMsg{Type: tea.KeySpace})
+	if !changed {
+		t.Error("Space on SettingShowSessionTimestamps must report changed=true")
+	}
+	if !panel.showSessionTimestamps {
+		t.Error("Space on SettingShowSessionTimestamps must flip showSessionTimestamps to true")
+	}
+
+	// GetConfig must mirror the toggled state back into Display so SaveUserConfig persists it.
+	got := panel.GetConfig()
+	if !got.Display.ShowSessionTimestamps {
+		t.Error("GetConfig() must propagate showSessionTimestamps into Display.ShowSessionTimestamps")
+	}
+
+	// Flip again and confirm the round trip back to false.
+	_, _, _ = panel.Update(tea.KeyMsg{Type: tea.KeySpace})
+	got = panel.GetConfig()
+	if got.Display.ShowSessionTimestamps {
+		t.Error("second toggle must flip showSessionTimestamps back to false")
+	}
+}
+
+// Pins the cursorToLine[SettingShowSessionTimestamps] mapping in
+// settings_panel.go: View() — if the value is off, the cursor's auto-scroll
+// stops bringing the new setting into the visible window. Render the panel
+// at a height short enough to force scroll mode, point the cursor at our
+// setting, and assert it appears in the rendered output.
+func TestSettingsPanel_ShowSessionTimestamps_ScrollMappingBringsRowIntoView(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	panel := NewSettingsPanel()
+	// Width comfortable, height short enough to force scroll-windowing in View().
+	panel.SetSize(100, 20)
+	panel.Show()
+	panel.cursor = int(SettingShowSessionTimestamps)
+
+	view := panel.View()
+
+	if !containsString(view, "Show session timestamps") {
+		t.Fatalf("cursorToLine[SettingShowSessionTimestamps] must map to a line that scrolls the setting into view. "+
+			"View did not contain the row. Got:\n%s", view)
+	}
+	// Sanity: the panel must have actually entered scroll mode (otherwise this
+	// test passes trivially because the whole panel fits). Look for one of the
+	// scroll indicators.
+	if !containsString(view, "more above") && !containsString(view, "more below") {
+		t.Fatal("test must run with a small enough height to force scroll mode; " +
+			"neither '▲ more above' nor '▼ more below' appeared in the view")
+	}
+}


### PR DESCRIPTION
Replaces #1165 (closed by maintainer for queue hygiene). This PR is the same content, rebased onto current `main` and with the remote-session-parity item from review addressed.

## Summary

Adds an opt-in dim `Nm ago` / `Nh ago` / `Nd ago` badge after each session row, showing the most recent of:

1. `Instance.CreatedAt` (SQLite, persisted floor)
2. `Instance.LastStartedAt` (SQLite, lifecycle restart)
3. Latest hook event `UpdatedAt` (StatusFileWatcher, present when agent-deck hooks are installed in Claude/Codex settings)
4. Confirmed tmux activity time (`StateTracker.lastChangeTime`, gated on a new `realActivityConfirmed` flag so freshly-built trackers don't falsely report "just now" for every session after restart)

`LastAccessedAt` is deliberately excluded — attaching to a quiet session to peek at it isn't an "update", and including it made the badge lie.

## Screenshots
### Settings menu — toggle on (off by default)
<img width="488" height="113" alt="image" src="https://github.com/user-attachments/assets/547b5b96-f92f-434a-b3eb-cb8a6f2f9631" />

### Sessions list with the badge enabled
<img width="488" alt="image" src="https://github.com/user-attachments/assets/36137a3a-cb97-44ae-8df1-c292ba192106" />

## Why a new `realActivityConfirmed` flag in `tmux.StateTracker`?

Naively reading `lastChangeTime` is the obvious first attempt and was where I started. It doesn't work because `tmux.go` initializes `lastChangeTime = time.Now()` at tracker construction — so right after agent-deck starts, every session reports "just now" regardless of how long it's actually been idle.

The flag flips `true` only at the explicit-busy confirmation paths inside `Session.GetStatus` and `Session.getStatusFallback` (`git grep 'realActivityConfirmed = true'`), never at construction. Callers consult the bool before consuming the time value, so the "never observed" case falls back to the lifecycle floor.

## Remote-session parity (deferred with documented rationale)

Per @asheshgoplani's review on #1165 and the `internal/ui/**` parity guideline, the badge is **local-only** in this PR, with the deferral pinned by `internal/ui/remote_session_timestamps_test.go`. Reasoning: `session.RemoteSessionInfo` ships only `CreatedAt` to the local TUI — `LastStartedAt`, hook events, and tmux-confirmed activity all live on the remote machine and aren't currently sent over the wire. Three of the four signals the badge layers over would be permanently missing for remote rows, producing a "session age" readout that never updates — inconsistent with what users see locally and likely to read as broken. Full reasoning in the file-level comment of the new test, including what would be needed to make remote parity meaningful (extending the wire format).

## How to enable

Settings → DISPLAY → **Show session timestamps** (default off). Persisted as `[display] show_session_timestamps = true`. Toggle takes effect immediately, no restart.

## Test plan

- [x] `go build ./...` clean
- [x] New unit tests pin: the `realActivityConfirmed` flag (false at init, true after confirmation, zero-time sentinel when unobserved), the full `pickBadgeTime` formula across all 4 layers with nil/zero/unobserved edges, `LastAccessedAt` exclusion, nil `tmuxSession` safety, merge round-trip, settings-panel scroll mapping reaches the new row, **remote-session row does NOT receive the badge**
- [x] Manual verification: badge ticks live during an active Claude answer, freezes at last-active timestamp when Claude finishes, no false "just now" mass reset across an agent-deck process restart
- [ ] Maintainer manual verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now display relative time badges showing when they were last active, drawing from creation time, start time, recent activity, and hook updates
  * Added "Show session timestamps" toggle in Settings panel to control whether timestamp badges appear next to session rows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->