### PR TITLE
feat(session): show_only_installed_tools config flag (#1259)

### DIFF
--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -33,6 +33,13 @@ type builtinTool struct {
 	// for short ambiguous names like "pi" where Contains would false-match
 	// "epic"/"tapioca". Mirrors detectTool()'s hasCommandToken() arm.
 	detectTokens []string
+
+	// Installed reports whether this tool's command resolved on the host PATH at
+	// registry-init time. It is ONLY populated when the show_only_installed_tools
+	// filter is on (issue #1259); with the filter off the probe is skipped
+	// entirely and this stays false (unused), so the default path is byte-identical
+	// to before. "shell" is always marked installed regardless of the probe.
+	Installed bool
 }
 
 // builtinTools returns the canonical built-ins in the EXACT precedence order of

--- a/internal/session/toolregistry.go
+++ b/internal/session/toolregistry.go
@@ -1,6 +1,9 @@
 package session
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -32,17 +35,73 @@ type Registry struct {
 	order    []string               // built-in precedence order, drives Match()
 	builtins map[string]builtinTool // name -> built-in record
 	custom   map[string]ToolDef     // name -> user-defined tool (shadows dropped)
+
+	// --- show_only_installed_tools filter state (issue #1259) ---
+	// These are populated ONLY when the filter is enabled at Init. With the
+	// filter off they stay zero-valued and every visibility method short-circuits
+	// to "show everything", so the default path is byte-identical to before.
+	filterInstalled bool            // the flag was on at Init (probe ran)
+	installed       map[string]bool // name -> command resolved on PATH (shell always true)
+	fallback        bool            // filter on AND nothing but shell resolved -> show all + hint
 }
 
 var registryLog = logging.ForComponent(logging.CompSession)
+
+// lookPathFn and statFn are indirections over exec.LookPath / os.Stat so tests
+// can simulate a host where specific commands are (or are not) on PATH without
+// mutating the real environment. Production code uses the real implementations.
+var (
+	lookPathFn = exec.LookPath
+	statFn     = os.Stat
+)
+
+// probeInstalled reports whether a tool command resolves on the host.
+//
+//   - Absolute paths are checked with os.Stat (the binary must exist on disk).
+//   - Commands that contain whitespace and are NOT absolute paths are inline
+//     shell expressions or wrapper invocations (e.g. `bash -c "..."` or
+//     `my-wrapper claude`); splitting and probing the wrapper is more work than
+//     it's worth and would surprise users with intentional wrapper setups, so we
+//     treat them as installed (issue #1259).
+//   - Everything else is a bare command name, resolved with exec.LookPath.
+func probeInstalled(command string) bool {
+	cmd := strings.TrimSpace(command)
+	if cmd == "" {
+		return false
+	}
+	if filepath.IsAbs(cmd) {
+		_, err := statFn(cmd)
+		return err == nil
+	}
+	if strings.ContainsAny(cmd, " \t") {
+		return true
+	}
+	_, err := lookPathFn(cmd)
+	return err == nil
+}
 
 // Init builds a Registry from the static built-ins plus the supplied custom
 // tools (typically config.Tools from LoadUserConfig). Custom entries whose name
 // shadows a built-in are dropped with a warning (precedence rule (a)).
 //
 // Init is the single explicit constructor — tests build registries directly via
-// Init(map[string]ToolDef{...}) rather than poking package globals.
+// Init(map[string]ToolDef{...}) rather than poking package globals. It builds an
+// UNFILTERED registry (show_only_installed_tools off): no PATH probing happens,
+// so behavior is byte-identical to before issue #1259.
 func Init(custom map[string]ToolDef) *Registry {
+	return InitFiltered(custom, false)
+}
+
+// InitFiltered builds a Registry, optionally running the show_only_installed_tools
+// probe (issue #1259). When showOnlyInstalled is false the probe is skipped
+// ENTIRELY — not "probe then ignore" — so the default path makes zero LookPath
+// calls and is byte-identical to Init's prior behavior.
+//
+// Caching policy: the probe runs only here, at construction time. The process
+// registry (currentRegistry) rebuilds whenever the cached *UserConfig pointer
+// changes, so a mid-session config edit re-probes on the next dialog open. There
+// is deliberately no separate timer/refresh path (issue #1259 caching note).
+func InitFiltered(custom map[string]ToolDef, showOnlyInstalled bool) *Registry {
 	r := &Registry{
 		builtins: make(map[string]builtinTool),
 		custom:   make(map[string]ToolDef),
@@ -60,7 +119,47 @@ func Init(custom map[string]ToolDef) *Registry {
 		}
 		r.custom[name] = def
 	}
+
+	if showOnlyInstalled {
+		r.runInstalledProbe()
+	}
 	return r
+}
+
+// runInstalledProbe resolves every registered tool's command against the host
+// PATH and records the result. It is the only place the probe runs. shell is
+// hardcoded installed (the catch-all; bash/sh is universal and we never want to
+// trap users with an empty dialog). When nothing but shell resolves the empty
+// fallback engages and visibility reverts to "show all" + a hint.
+func (r *Registry) runInstalledProbe() {
+	r.filterInstalled = true
+	r.installed = make(map[string]bool, len(r.order)+len(r.custom))
+	nonShellInstalled := 0
+
+	for _, name := range r.order {
+		if name == "shell" {
+			r.installed[name] = true // shell is always shown
+			continue
+		}
+		// A built-in's command is its bare name (matches Registry.All / detectTool).
+		ok := probeInstalled(name)
+		r.installed[name] = ok
+		if ok {
+			nonShellInstalled++
+		}
+	}
+	for name, def := range r.custom {
+		// Probe the custom entry's OWN command. For compatible_with tools this is
+		// the user's wrapper binary, NOT the parent built-in — a missing wrapper is
+		// hidden even though the built-in it's compatible with resolves.
+		ok := probeInstalled(def.Command)
+		r.installed[name] = ok
+		if ok {
+			nonShellInstalled++
+		}
+	}
+
+	r.fallback = nonShellInstalled == 0
 }
 
 // IsBuiltin reports whether name is one of the canonical built-in tools.
@@ -157,6 +256,68 @@ func (r *Registry) All() []ToolDef {
 	return out
 }
 
+// --- show_only_installed_tools visibility surface (issue #1259) --------------
+//
+// This is a PRESENTATION-layer concern applied AFTER Match()/All() resolve. The
+// match/resolution logic from #1261 is untouched; the CLI dispatch path never
+// consults these methods, so `agent-deck launch -c <hidden-tool>` still works.
+
+// IsVisible reports whether a tool name should appear in the new-session dialogs.
+// It returns true (show everything) when the filter is off or the empty-fallback
+// is active. "shell" (and its empty-command alias "") is always visible.
+func (r *Registry) IsVisible(name string) bool {
+	if !r.filterInstalled || r.fallback {
+		return true
+	}
+	if name == "" || name == "shell" {
+		return true
+	}
+	return r.installed[name]
+}
+
+// FilterActive reports whether the show_only_installed_tools filter is on,
+// regardless of whether the empty-fallback engaged.
+func (r *Registry) FilterActive() bool {
+	return r.filterInstalled
+}
+
+// FilterFallback reports the empty-fallback state: the filter is on but nothing
+// other than shell resolved on PATH, so the dialogs show the full list plus a
+// one-line hint instead of trapping the user with an empty selection.
+func (r *Registry) FilterFallback() bool {
+	return r.fallback
+}
+
+// Visible returns the built-in ToolDefs that should be shown in dialogs, in
+// precedence order. With the filter off (or in fallback) it equals All().
+func (r *Registry) Visible() []ToolDef {
+	out := make([]ToolDef, 0, len(r.order))
+	for _, name := range r.order {
+		if !r.IsVisible(name) {
+			continue
+		}
+		bt := r.builtins[name]
+		out = append(out, ToolDef{Command: bt.Name, Icon: bt.Icon})
+	}
+	return out
+}
+
+// FilterVisibleNames returns names with hidden tools removed. The empty command
+// "" (shell) is always kept. With the filter off (or in fallback) the input is
+// returned unchanged, preserving each call site's existing ordering byte-for-byte.
+func (r *Registry) FilterVisibleNames(names []string) []string {
+	if !r.filterInstalled || r.fallback {
+		return names
+	}
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if r.IsVisible(n) {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
 // --- process-wide accessor ---------------------------------------------------
 //
 // The package-level helpers below back the retargeted call sites. The registry
@@ -185,16 +346,63 @@ func currentRegistry() *Registry {
 	}
 
 	var custom map[string]ToolDef
+	showOnlyInstalled := false
 	if cfg != nil {
 		custom = cfg.Tools
+		showOnlyInstalled = cfg.UI.ShowOnlyInstalledTools
 	}
-	registryCache = Init(custom)
+	registryCache = InitFiltered(custom, showOnlyInstalled)
 	registryCacheCfg = cfg
 	return registryCache
 }
 
 // MatchTool resolves a command string to a tool name using the process
 // registry. It is the exported seam that cmd/agent-deck's detectTool() wraps.
+//
+// NOTE: Match never consults the show_only_installed_tools filter — resolution
+// is display-independent, so the CLI dispatch path keeps spawning tools that the
+// dialogs would hide (issue #1259 non-goal: display filter only, not a gate).
 func MatchTool(cmd string) string {
 	return currentRegistry().Match(cmd)
+}
+
+// --- process-wide show_only_installed_tools accessors (issue #1259) ----------
+//
+// These back the new-session dialog call sites. They read the cached registry,
+// so they reflect the current config and re-probe only when config changes.
+
+// FilterVisibleToolNames removes tools hidden by show_only_installed_tools from
+// names. The empty command "" (shell) is always kept. With the flag off it
+// returns names unchanged (byte-identical default behavior).
+func FilterVisibleToolNames(names []string) []string {
+	return currentRegistry().FilterVisibleNames(names)
+}
+
+// VisibleToolNames returns the names of every tool (built-in + custom) that
+// passes the show_only_installed_tools filter, in built-in-precedence order then
+// sorted custom names. With the flag off it returns the full set. Used by the
+// web new-session dialog to intersect its static tool list.
+func VisibleToolNames() []string {
+	r := currentRegistry()
+	names := make([]string, 0, len(r.order)+len(r.custom))
+	for _, d := range r.Visible() {
+		names = append(names, d.Command)
+	}
+	for _, n := range r.CustomNames() {
+		if r.IsVisible(n) {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+// ToolFilterActive reports whether show_only_installed_tools is enabled.
+func ToolFilterActive() bool {
+	return currentRegistry().FilterActive()
+}
+
+// ToolFilterFallbackActive reports whether the empty-fallback engaged (filter on,
+// nothing but shell resolved) so dialogs can surface the "showing all" hint.
+func ToolFilterFallbackActive() bool {
+	return currentRegistry().FilterFallback()
 }

--- a/internal/session/toolregistry_installed_test.go
+++ b/internal/session/toolregistry_installed_test.go
@@ -1,0 +1,245 @@
+package session
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// withStubbedProbe swaps the package-level lookPathFn/statFn indirections for the
+// duration of fn, so a test can simulate exactly which commands resolve on the
+// host without touching the real environment. installed lists the bare command
+// names that LookPath should succeed for; everything else fails.
+func withStubbedProbe(t *testing.T, installed []string, fn func()) {
+	t.Helper()
+	set := make(map[string]bool, len(installed))
+	for _, name := range installed {
+		set[name] = true
+	}
+
+	origLookPath, origStat := lookPathFn, statFn
+	t.Cleanup(func() { lookPathFn, statFn = origLookPath, origStat })
+
+	lookPathFn = func(file string) (string, error) {
+		if set[file] {
+			return "/usr/bin/" + file, nil
+		}
+		return "", exec.ErrNotFound
+	}
+	statFn = func(name string) (os.FileInfo, error) {
+		if set[name] {
+			return nil, nil
+		}
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: errors.New("no such file or directory")}
+	}
+	fn()
+}
+
+func commands(defs []ToolDef) []string {
+	out := make([]string, len(defs))
+	for i, d := range defs {
+		out[i] = d.Command
+	}
+	return out
+}
+
+// TestInstalled_FilterOffNoProbe pins the core guardrail: with the flag off the
+// probe never runs and All() is unchanged. We make EVERY LookPath/Stat fail; if
+// the probe leaked into the default path, All() would drop entries.
+func TestInstalled_FilterOffNoProbe(t *testing.T) {
+	probeCalls := 0
+	origLookPath, origStat := lookPathFn, statFn
+	t.Cleanup(func() { lookPathFn, statFn = origLookPath, origStat })
+	lookPathFn = func(string) (string, error) { probeCalls++; return "", exec.ErrNotFound }
+	statFn = func(string) (os.FileInfo, error) { probeCalls++; return nil, fs.ErrNotExist }
+
+	r := Init(nil) // filter off
+	if got := len(r.All()); got != len(canonicalBuiltins) {
+		t.Fatalf("All() with filter off = %d entries, want %d", got, len(canonicalBuiltins))
+	}
+	if got := commands(r.Visible()); !reflect.DeepEqual(got, canonicalBuiltins) {
+		t.Errorf("Visible() with filter off = %v, want full %v", got, canonicalBuiltins)
+	}
+	if r.FilterActive() {
+		t.Error("FilterActive() = true with filter off")
+	}
+	if probeCalls != 0 {
+		t.Errorf("probe ran %d times with filter off, want 0 (probe must be gated)", probeCalls)
+	}
+}
+
+// TestInstalled_FilterDropsMissing covers the happy path: with the flag on, tools
+// whose command resolves are kept and missing ones are dropped — except shell.
+func TestInstalled_FilterDropsMissing(t *testing.T) {
+	withStubbedProbe(t, []string{"claude", "codex"}, func() {
+		r := InitFiltered(nil, true)
+
+		// All() is the UNFILTERED data view — still the full 11.
+		if got := len(r.All()); got != len(canonicalBuiltins) {
+			t.Errorf("All() = %d, want %d (All must stay unfiltered)", got, len(canonicalBuiltins))
+		}
+
+		// Visible() drops everything that didn't resolve, keeps shell + resolved.
+		want := []string{"claude", "codex", "shell"}
+		if got := commands(r.Visible()); !reflect.DeepEqual(got, want) {
+			t.Errorf("Visible() = %v, want %v", got, want)
+		}
+		if !r.IsVisible("claude") {
+			t.Error("IsVisible(claude) = false, want true (resolved)")
+		}
+		if r.IsVisible("gemini") {
+			t.Error("IsVisible(gemini) = true, want false (not resolved)")
+		}
+		if r.FilterFallback() {
+			t.Error("FilterFallback() = true, want false (claude/codex resolved)")
+		}
+	})
+}
+
+// TestInstalled_ShellAlwaysShown is the shell invariant: even when shell's own
+// name would not resolve via LookPath, it is hardcoded visible.
+func TestInstalled_ShellAlwaysShown(t *testing.T) {
+	withStubbedProbe(t, []string{"claude"}, func() { // note: "shell" NOT in the set
+		r := InitFiltered(nil, true)
+		if !r.IsVisible("shell") {
+			t.Error("IsVisible(shell) = false, want true (shell is always shown)")
+		}
+		if !r.IsVisible("") {
+			t.Error("IsVisible(\"\") = false, want true (empty command is shell)")
+		}
+		vis := commands(r.Visible())
+		if vis[len(vis)-1] != "shell" {
+			t.Errorf("Visible() = %v, want shell present", vis)
+		}
+	})
+}
+
+// TestInstalled_CustomWrapperTreatedInstalled covers the wrapper heuristic: a
+// custom command containing whitespace (and not absolute) is treated as installed
+// without probing, so intentional wrapper setups are never hidden.
+func TestInstalled_CustomWrapperTreatedInstalled(t *testing.T) {
+	withStubbedProbe(t, []string{"claude"}, func() { // wrapper's words are NOT on PATH
+		r := InitFiltered(map[string]ToolDef{
+			"wrapped": {Command: "my-wrapper claude"},
+			"inline":  {Command: `bash -c "exec claude"`},
+		}, true)
+		if !r.IsVisible("wrapped") {
+			t.Error("IsVisible(wrapped) = false, want true (whitespace wrapper -> installed)")
+		}
+		if !r.IsVisible("inline") {
+			t.Error("IsVisible(inline) = false, want true (inline shell -> installed)")
+		}
+	})
+}
+
+// TestInstalled_CompatibleWithOwnCommand pins the compatible_with rule: the custom
+// entry's OWN command is probed, NOT the parent built-in's. A compatible_with =
+// "claude" tool whose wrapper binary is missing is dropped even though claude
+// itself resolves.
+func TestInstalled_CompatibleWithOwnCommand(t *testing.T) {
+	withStubbedProbe(t, []string{"claude"}, func() {
+		r := InitFiltered(map[string]ToolDef{
+			"myclaude": {Command: "my-missing-claude", CompatibleWith: "claude"},
+		}, true)
+		if r.IsVisible("myclaude") {
+			t.Error("IsVisible(myclaude) = true, want false (own command missing; must NOT inherit claude)")
+		}
+		// Sanity: the built-in claude it is compatible with DID resolve.
+		if !r.IsVisible("claude") {
+			t.Error("IsVisible(claude) = false, want true")
+		}
+	})
+}
+
+// TestInstalled_EmptyFallback covers the empty-fallback safety net: when nothing
+// but shell resolves, Visible()/All() return the full list (never empty) and the
+// fallback signal the dialogs read is set.
+func TestInstalled_EmptyFallback(t *testing.T) {
+	withStubbedProbe(t, nil, func() { // nothing resolves
+		r := InitFiltered(nil, true)
+		if !r.FilterFallback() {
+			t.Fatal("FilterFallback() = false, want true (nothing but shell resolved)")
+		}
+		// Fallback shows everything, not an empty selection.
+		if got := commands(r.Visible()); !reflect.DeepEqual(got, canonicalBuiltins) {
+			t.Errorf("Visible() in fallback = %v, want full %v", got, canonicalBuiltins)
+		}
+		if !r.IsVisible("gemini") {
+			t.Error("IsVisible(gemini) = false in fallback, want true (show all)")
+		}
+	})
+}
+
+// TestInstalled_FilterVisibleNames covers the TUI call-site helper: hidden names
+// are dropped, "" (shell) is always kept, and with the filter off the input is
+// returned byte-identically.
+func TestInstalled_FilterVisibleNames(t *testing.T) {
+	presets := []string{"", "claude", "gemini", "codex"}
+
+	// Filter off: identity.
+	if got := Init(nil).FilterVisibleNames(presets); !reflect.DeepEqual(got, presets) {
+		t.Errorf("FilterVisibleNames (off) = %v, want identity %v", got, presets)
+	}
+
+	withStubbedProbe(t, []string{"claude"}, func() {
+		r := InitFiltered(nil, true)
+		want := []string{"", "claude"} // "" kept (shell), gemini/codex dropped
+		if got := r.FilterVisibleNames(presets); !reflect.DeepEqual(got, want) {
+			t.Errorf("FilterVisibleNames (on) = %v, want %v", got, want)
+		}
+	})
+}
+
+// TestInstalled_DispatchIgnoresFilter is deliverable #5: the resolution path the
+// CLI dispatch uses (Match) must still resolve a tool the filter would hide. We
+// build a filtered registry where gemini did NOT resolve, then confirm Match
+// still maps a gemini command to "gemini".
+func TestInstalled_DispatchIgnoresFilter(t *testing.T) {
+	withStubbedProbe(t, nil, func() { // gemini (and everything) hidden
+		r := InitFiltered(nil, true)
+		if r.IsVisible("gemini") && !r.FilterFallback() {
+			t.Fatal("precondition: gemini should be hidden by the filter")
+		}
+		// Dispatch resolution is display-independent: Match still returns gemini.
+		if got := r.Match("gemini --yolo"); got != "gemini" {
+			t.Errorf("Match(\"gemini --yolo\") = %q, want %q (filter must not gate dispatch)", got, "gemini")
+		}
+	})
+}
+
+// TestInstalled_AbsolutePathCustom covers the os.Stat arm for absolute-path custom
+// commands: present on disk -> visible, absent -> hidden.
+func TestInstalled_AbsolutePathCustom(t *testing.T) {
+	withStubbedProbe(t, []string{"/opt/bin/real-tool"}, func() {
+		r := InitFiltered(map[string]ToolDef{
+			"real":  {Command: "/opt/bin/real-tool"},
+			"ghost": {Command: "/opt/bin/missing-tool"},
+		}, true)
+		if !r.IsVisible("real") {
+			t.Error("IsVisible(real) = false, want true (absolute path exists)")
+		}
+		if r.IsVisible("ghost") {
+			t.Error("IsVisible(ghost) = true, want false (absolute path missing)")
+		}
+	})
+}
+
+// TestInstalled_CustomNamesUnaffectedByFilter confirms CustomNames() (the data
+// view) is unfiltered; only the visibility surface filters.
+func TestInstalled_CustomNamesUnaffectedByFilter(t *testing.T) {
+	withStubbedProbe(t, nil, func() {
+		r := InitFiltered(map[string]ToolDef{
+			"a": {Command: "missing-a"},
+			"b": {Command: "missing-b"},
+		}, true)
+		got := r.CustomNames()
+		sort.Strings(got)
+		if !reflect.DeepEqual(got, []string{"a", "b"}) {
+			t.Errorf("CustomNames() = %v, want [a b] (data view unfiltered)", got)
+		}
+	})
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -220,6 +220,15 @@ type UISettings struct {
 	// cadence that reconciles the list. Valid range: 5-300. Default: 15s,
 	// tightening the visibility latency reported on v1.9.30.
 	RemoteSessionRefreshSecs int `toml:"remote_session_refresh_secs"`
+
+	// ShowOnlyInstalledTools, when true, hides tools from the new-session
+	// dialogs (TUI + web) whose command does not resolve on the host PATH
+	// (issue #1259). Default false: no PATH probing happens and the dialogs are
+	// byte-identical to before. shell is always shown; if nothing else resolves
+	// the dialog falls back to showing all tools plus a one-line hint. This is a
+	// display filter only — `agent-deck launch -c <tool>` still spawns a hidden
+	// tool.
+	ShowOnlyInstalledTools bool `toml:"show_only_installed_tools"`
 }
 
 // DefaultPreviewPct is the default preview-pane width percentage.

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -249,12 +249,17 @@ func displayCommandPreset(cmd string) string {
 
 // buildPresetCommands returns the list of commands for the picker,
 // including any custom tools from config.toml.
+//
+// When show_only_installed_tools is on (issue #1259) the list is filtered down
+// to tools whose command resolves on PATH; "" (shell) is always kept. With the
+// flag off FilterVisibleToolNames is a no-op, so the list is byte-identical to
+// before.
 func buildPresetCommands() []string {
 	presets := []string{"", "claude", "gemini", "opencode", "codex", "pi", "copilot", "crush", "cursor", "hermes"}
 	if customTools := session.GetCustomToolNames(); len(customTools) > 0 {
 		presets = append(presets, customTools...)
 	}
-	return presets
+	return session.FilterVisibleToolNames(presets)
 }
 
 // buildInheritedSettings returns display pairs for non-default Docker config values.
@@ -2348,7 +2353,18 @@ func (d *NewDialog) View() string {
 		cmdButtons = append(cmdButtons, btnStyle.Render(displayName))
 	}
 	content.WriteString(lipgloss.JoinHorizontal(lipgloss.Left, cmdButtons...))
-	content.WriteString("\n\n")
+	content.WriteString("\n")
+
+	// show_only_installed_tools empty-fallback hint (issue #1259): when the
+	// filter is on but nothing other than shell resolved on PATH we show the full
+	// list instead of trapping the user, and explain why here.
+	if session.ToolFilterFallbackActive() {
+		hintStyle := lipgloss.NewStyle().Foreground(ColorTextDim).Italic(true)
+		content.WriteString("  ")
+		content.WriteString(hintStyle.Render("No tools matched PATH; showing all. Set show_only_installed_tools = false to silence."))
+		content.WriteString("\n")
+	}
+	content.WriteString("\n")
 
 	// Custom command input (only if shell is selected)
 	if d.commandCursor == 0 {

--- a/internal/web/api_types.go
+++ b/internal/web/api_types.go
@@ -97,6 +97,15 @@ type SettingsResponse struct {
 	ReadOnly     bool   `json:"readOnly"`
 	WebMutations bool   `json:"webMutations"`
 	Version      string `json:"version"`
+
+	// show_only_installed_tools filter (issue #1259). ToolFilter reports the
+	// flag is on; VisibleTools lists the tool names that resolved on PATH (the
+	// web dialog intersects its static list against this); ToolFilterFallback
+	// reports the empty-fallback so the dialog shows a "showing all" hint. With
+	// the flag off ToolFilter is false and the dialog ignores the other fields.
+	ToolFilter         bool     `json:"toolFilter"`
+	VisibleTools       []string `json:"visibleTools"`
+	ToolFilterFallback bool     `json:"toolFilterFallback"`
 }
 
 // ProfilesResponse is returned by GET /api/profiles.

--- a/internal/web/handlers_settings.go
+++ b/internal/web/handlers_settings.go
@@ -17,11 +17,17 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Tool-visibility filter (issue #1259) is read from the process registry at
+	// request time, so it reflects the current config (re-probed only when config
+	// changes — see currentRegistry). It is a display filter only.
 	writeJSON(w, http.StatusOK, SettingsResponse{
-		Profile:      s.cfg.Profile,
-		ReadOnly:     s.cfg.ReadOnly,
-		WebMutations: s.cfg.WebMutations,
-		Version:      buildVersion(),
+		Profile:            s.cfg.Profile,
+		ReadOnly:           s.cfg.ReadOnly,
+		WebMutations:       s.cfg.WebMutations,
+		Version:            buildVersion(),
+		ToolFilter:         session.ToolFilterActive(),
+		VisibleTools:       session.VisibleToolNames(),
+		ToolFilterFallback: session.ToolFilterFallbackActive(),
 	})
 }
 

--- a/internal/web/static/app/AppShell.js
+++ b/internal/web/static/app/AppShell.js
@@ -28,6 +28,7 @@ import {
   selectedIdSignal, createSessionDialogSignal, confirmDialogSignal,
   groupNameDialogSignal, mutationsEnabledSignal, infoDrawerOpenSignal,
   profilesSignal, systemStatsSignal,
+  toolFilterSignal, visibleToolsSignal, toolFilterFallbackSignal,
 } from './state.js'
 import {
   activeTabSignal, paletteOpenSignal, tweaksOpenSignal,
@@ -127,12 +128,24 @@ export function AppShell() {
   }, [])
 
   // WEB-P0-4 prevention layer: hydrate webMutations gate from /api/settings.
+  // Also hydrates the show_only_installed_tools filter (issue #1259) so the
+  // new-session dialog can hide tools whose command is not on PATH.
   useEffect(() => {
     fetch('/api/settings')
       .then(r => r.ok ? r.json() : null)
       .then(data => {
-        if (data && typeof data.webMutations === 'boolean') {
+        if (!data) return
+        if (typeof data.webMutations === 'boolean') {
           mutationsEnabledSignal.value = data.webMutations
+        }
+        if (typeof data.toolFilter === 'boolean') {
+          toolFilterSignal.value = data.toolFilter
+        }
+        if (Array.isArray(data.visibleTools)) {
+          visibleToolsSignal.value = data.visibleTools
+        }
+        if (typeof data.toolFilterFallback === 'boolean') {
+          toolFilterFallbackSignal.value = data.toolFilterFallback
         }
       })
       .catch(() => {})

--- a/internal/web/static/app/CreateSessionDialog.js
+++ b/internal/web/static/app/CreateSessionDialog.js
@@ -3,7 +3,10 @@
 // `.field` / `.seg-row` / `.btn` classes from app.css.
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
-import { createSessionDialogSignal, mutationsEnabledSignal } from './state.js'
+import {
+  createSessionDialogSignal, mutationsEnabledSignal,
+  toolFilterSignal, visibleToolsSignal, toolFilterFallbackSignal,
+} from './state.js'
 import { Icon, ICONS } from './icons.js'
 import { apiFetch } from './api.js'
 
@@ -118,6 +121,15 @@ export function CreateSessionDialog() {
   const close = () => (createSessionDialogSignal.value = false)
   const handleBackdropClick = (e) => { if (e.target === e.currentTarget) close() }
   const modelIDs = modelIDsForTool(tool)
+  // show_only_installed_tools filter (issue #1259): when the flag is on (and the
+  // empty-fallback did NOT engage), intersect the static tool list against the
+  // server's PATH-resolved set. shell is always kept. With the flag off, or in
+  // fallback, every tool is shown — byte-identical to before.
+  const toolFilterOn = toolFilterSignal.value && !toolFilterFallbackSignal.value
+  const visibleToolSet = new Set(visibleToolsSignal.value)
+  const shownTools = toolFilterOn
+    ? TOOLS.filter(t => t === 'shell' || visibleToolSet.has(t))
+    : TOOLS
   const needsCustomModel = modelId === CUSTOM_MODEL
   const submitDisabled = submitting || !title || !path || (needsCustomModel && !customModel.trim())
 
@@ -143,12 +155,18 @@ export function CreateSessionDialog() {
           <div class="field">
             <label>TOOL</label>
             <div class="seg-row">
-              ${TOOLS.map(t => html`
+              ${shownTools.map(t => html`
                 <button type="button" key=${t}
                         class=${`seg-btn ${tool === t ? 'on' : ''}`}
                         onClick=${() => selectTool(t)}>${TOOL_LABELS[t] || t}</button>
               `)}
             </div>
+            ${toolFilterFallbackSignal.value && html`
+              <div style="font-family: var(--mono); font-size: 11px; color: var(--tn-comment, #888);
+                          margin-top: 6px;">
+                No tools matched PATH; showing all. Set <code>show_only_installed_tools = false</code> to silence.
+              </div>
+            `}
           </div>
           ${modelIDs.length > 0 && html`
             <div class="field">

--- a/internal/web/static/app/state.js
+++ b/internal/web/static/app/state.js
@@ -139,6 +139,16 @@ export const toastHistoryOpenSignal = signal(false)
 // /api/settings and assigns the real value.
 export const mutationsEnabledSignal = signal(true)
 
+// show_only_installed_tools filter (issue #1259), hydrated from /api/settings
+// alongside webMutations. toolFilterSignal: the flag is on. visibleToolsSignal:
+// the set of tool names that resolved on PATH; the new-session dialog intersects
+// its static tool list against this when the filter is on. toolFilterFallback:
+// nothing but shell resolved, so the dialog shows all tools plus a hint. Defaults
+// keep the dialog showing every tool until the real values arrive.
+export const toolFilterSignal = signal(false)
+export const visibleToolsSignal = signal([])
+export const toolFilterFallbackSignal = signal(false)
+
 // POL-1 (Phase 9, plan 01): sidebar load state for skeleton render gate.
 // Initialized false; flipped to true on the first /api/menu response OR the
 // first SSE `menu` snapshot in main.js. Never flips back — once the sidebar


### PR DESCRIPTION
Implements #1259 — an opt-in `[ui].show_only_installed_tools` flag that hides tools from the new-session dialogs (TUI + web) whose `command` does not resolve on the host PATH. Composes directly onto the unified tool registry from #1261 (issue #1258), where `Installed`/the probe were explicitly designed in as a trivial follow-up.

Prototyped and validated on my fork (JMBattista/agent-deck#7) before opening here.

## TOML

```toml
[ui]
show_only_installed_tools = false   # default; preserves current behavior exactly
```

When `true`, a tool only appears in the picker if its command resolves:

```
TUI command picker, flag = false:    [ shell  claude  gemini  opencode  codex  pi  copilot  crush  cursor  hermes ]
TUI command picker, flag = true,
 host has only claude + codex:        [ shell  claude  codex ]      ← gemini/opencode/pi/… hidden
```

`shell` is always shown.

## Behavior (per the issue's table)

- **`false` (default):** the probe is skipped **entirely** — zero `LookPath` calls, dialogs byte-identical to today. `Init()` stays the unfiltered constructor; a new `InitFiltered(custom, showOnlyInstalled)` runs the probe only when asked.
- **`shell`:** hardcoded visible regardless of probe (catch-all; `bash`/`sh` is universal).
- **Custom wrappers / inline shell** (contains whitespace, not absolute, e.g. `my-wrapper claude` or `bash -c "…"`): treated as installed — we don't split-and-probe wrappers.
- **Absolute paths:** probed with `os.Stat`.
- **`compatible_with = "claude"`:** probes the custom entry's **own** command, not the parent built-in — a missing wrapper is hidden even though `claude` itself resolves.
- **Empty-fallback:** if nothing but `shell` resolves, show the **full** list plus a one-line hint (`"No tools matched PATH; showing all. Set show_only_installed_tools = false to silence."`) — never trap the user with an empty dialog.
- **Caching:** probe runs only at registry init; `currentRegistry()` rebuilds when the cached `*UserConfig` pointer changes, so a mid-session config edit re-probes on next dialog open. No timer/refresh path.

## Display filter only — NOT a dispatch gate

`MatchTool` / `detectTool` (the CLI dispatch resolution seam) never consults the filter, so `agent-deck launch -c <hidden-tool>` and `agent-deck add -c <hidden-tool>` still spawn. Pinned by `TestInstalled_DispatchIgnoresFilter`.

## How it surfaces in both dialogs

- **TUI:** `buildPresetCommands()` runs its list through `session.FilterVisibleToolNames()` (a no-op when the flag is off); the picker view shows the fallback hint when `session.ToolFilterFallbackActive()`.
- **Web:** `GET /api/settings` now returns `toolFilter` / `visibleTools` / `toolFilterFallback`; `AppShell` hydrates signals and `CreateSessionDialog` intersects its static tool list against `visibleTools` (shell always kept) and renders the fallback hint.

## Verification

| Check | Result |
|---|---|
| `go build ./...` | ✅ clean |
| `go vet ./internal/session/… ./internal/web/… ./internal/ui/…` | ✅ clean |
| New `toolregistry_installed_test.go` (11 cases) | ✅ pass |
| Existing `toolregistry_test.go` (registry/Match/precedence) | ✅ pass (unchanged, flag=false byte-identical) |
| Flag=false ⇒ **0** probe calls | ✅ asserted in `TestInstalled_FilterOffNoProbe` (mocks LookPath/Stat to fail; `All()` still 11) |
| CLI-dispatch-still-works for a hidden tool | ✅ `TestInstalled_DispatchIgnoresFilter` |
| Web JS bundles (esbuild `go run bundle.go`) | ✅ clean |
| Manual TUI smoke, flag off / on / empty-fallback | ✅ validated locally via `make build` |
| Web `/api/settings` + dialog filter | ✅ validated locally |

Scope respects the non-goals: the registry match/resolution logic from #1261 is untouched (filter is presentation-layer, applied after `Match()`); no new built-ins; `[claude]`/`[gemini]`/… per-tool sections and the `[tools.<builtin>]` reject+warn precedence are left alone; cold-start budgets unchanged (the probe is gated off by default and the registry is lazy, so `--help`/`--version` do zero extra work).

## Open questions

1. **Probe-cache policy:** currently init-only (re-probes when config changes). The issue floats "no cache, `LookPath` is microseconds." Init-only already reflects mid-session installs on the next dialog open via the config-pointer rebuild — is that enough, or do we want a per-open probe / periodic refresh?
2. **Wrapper-detection heuristic:** "contains whitespace and not absolute ⇒ installed" is the simplest rule, but it misclassifies **absolute paths with spaces** (e.g. `/Applications/My Tool.app/bin/cli` on macOS) — those fall to `os.Stat` of the whole string and would be hidden. Worth a smarter split?
3. **Empty-fallback hint:** one-time toast vs the persistent banner implemented here?
4. Built-ins are probed by bare name; a `[claude].command = /custom/path` override is not consulted (kept out of scope per #1172). Should the built-in probe honor `GetToolCommand()`?

Closes #1259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new configuration option to filter tools based on installation status on your system.
  * When enabled, only tools with resolvable commands appear in tool selection dialogs.
  * Tools remain launchable via command line even when filtered from dialogs.
  * Shell tool is always available; a helpful message appears when no other tools match your environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->