### PR TITLE
fix(git): materialize fork state from repo root

### DIFF
--- a/internal/git/issue1029_with_state_test.go
+++ b/internal/git/issue1029_with_state_test.go
@@ -103,9 +103,7 @@ func TestMaterializeWipFromParent_FromSubdirectoryKeepsRepoRelativeUntrackedPath
 
 	mustHaveWipFile(t, child, "a/new-a.txt", "untracked a\n")
 	mustHaveWipFile(t, child, "b/new-b.txt", "untracked b\n")
-	if _, err := os.Stat(filepath.Join(child, "new-a.txt")); !os.IsNotExist(err) {
-		t.Fatalf("subdir-relative untracked file was copied to worktree root: %v", err)
-	}
+	mustNotHaveWipFile(t, child, "new-a.txt")
 }
 
 func TestMaterializeWipFromParent_FromSubdirectoryKeepsRepoRelativeIgnoredPaths(t *testing.T) {
@@ -133,9 +131,7 @@ func TestMaterializeWipFromParent_FromSubdirectoryKeepsRepoRelativeIgnoredPaths(
 
 	mustHaveWipFile(t, child, "a/secrets.env", "ignored a\n")
 	mustHaveWipFile(t, child, "b/secrets.env", "ignored b\n")
-	if _, err := os.Stat(filepath.Join(child, "secrets.env")); !os.IsNotExist(err) {
-		t.Fatalf("subdir-relative ignored file was copied to worktree root: %v", err)
-	}
+	mustNotHaveWipFile(t, child, "secrets.env")
 }
 
 func writeWipFile(t *testing.T, dir, rel, content string) {
@@ -175,6 +171,15 @@ func mustHaveWipFile(t *testing.T, dir, rel, want string) {
 	t.Helper()
 	if got := readWipFile(t, dir, rel); got != want {
 		t.Fatalf("%s content mismatch.\nwant: %q\ngot:  %q", rel, want, got)
+	}
+}
+
+func mustNotHaveWipFile(t *testing.T, dir, rel string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(dir, rel)); err == nil {
+		t.Fatalf("%s unexpectedly exists in %s", rel, dir)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat %s in %s: %v", rel, dir, err)
 	}
 }
 

--- a/internal/git/issue1029_with_state_test.go
+++ b/internal/git/issue1029_with_state_test.go
@@ -71,6 +71,73 @@ func TestMaterializeWipFromParent_CopiesStagedUnstagedUntracked_RegressionFor102
 	}
 }
 
+func TestMaterializeWipFromParent_FromSubdirectoryKeepsRepoRelativeUntrackedPaths(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	writeWipFile(t, parent, "a/tracked.txt", "tracked a\n")
+	writeWipFile(t, parent, "b/tracked.txt", "tracked b\n")
+	gitMustRun(t, parent, "add", ".")
+	gitMustRun(t, parent, "commit", "-m", "add tracked")
+
+	parentSubdir := filepath.Join(parent, "a")
+	writeWipFile(t, parent, "a/new-a.txt", "untracked a\n")
+	writeWipFile(t, parent, "b/new-b.txt", "untracked b\n")
+
+	parentStatusBefore := gitPorcelain(t, parent)
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-1029-subdir"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	if err := MaterializeWipFromParent(parentSubdir, child, false /* includeIgnored */); err != nil {
+		t.Fatalf("MaterializeWipFromParent: %v", err)
+	}
+
+	childStatus := gitPorcelain(t, child)
+	if childStatus != parentStatusBefore {
+		t.Fatalf("child status must mirror parent repo WIP when parent path is a subdirectory.\nparent:\n%s\nchild:\n%s",
+			parentStatusBefore, childStatus)
+	}
+
+	mustHaveWipFile(t, child, "a/new-a.txt", "untracked a\n")
+	mustHaveWipFile(t, child, "b/new-b.txt", "untracked b\n")
+	if _, err := os.Stat(filepath.Join(child, "new-a.txt")); !os.IsNotExist(err) {
+		t.Fatalf("subdir-relative untracked file was copied to worktree root: %v", err)
+	}
+}
+
+func TestMaterializeWipFromParent_FromSubdirectoryKeepsRepoRelativeIgnoredPaths(t *testing.T) {
+	parent := t.TempDir()
+	createTestRepo(t, parent)
+
+	writeWipFile(t, parent, ".gitignore", "*.env\n")
+	writeWipFile(t, parent, "a/tracked.txt", "tracked a\n")
+	writeWipFile(t, parent, "b/tracked.txt", "tracked b\n")
+	gitMustRun(t, parent, "add", ".")
+	gitMustRun(t, parent, "commit", "-m", "add tracked and ignore")
+
+	parentSubdir := filepath.Join(parent, "a")
+	writeWipFile(t, parent, "a/secrets.env", "ignored a\n")
+	writeWipFile(t, parent, "b/secrets.env", "ignored b\n")
+
+	child := filepath.Join(t.TempDir(), "child")
+	if err := CreateWorktree(parent, child, "fork-1029-subdir-ignored"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	if err := MaterializeWipFromParent(parentSubdir, child, true /* includeIgnored */); err != nil {
+		t.Fatalf("MaterializeWipFromParent: %v", err)
+	}
+
+	mustHaveWipFile(t, child, "a/secrets.env", "ignored a\n")
+	mustHaveWipFile(t, child, "b/secrets.env", "ignored b\n")
+	if _, err := os.Stat(filepath.Join(child, "secrets.env")); !os.IsNotExist(err) {
+		t.Fatalf("subdir-relative ignored file was copied to worktree root: %v", err)
+	}
+}
+
 func writeWipFile(t *testing.T, dir, rel, content string) {
 	t.Helper()
 	full := filepath.Join(dir, rel)

--- a/internal/git/materialize_wip.go
+++ b/internal/git/materialize_wip.go
@@ -13,8 +13,10 @@ import (
 
 // MaterializeWipFromParent copies the working-tree state of parentDir (staged
 // changes, unstaged edits, and untracked files) into childDir, which must be a
-// freshly-created worktree pointing at parentDir's HEAD. When includeIgnored
-// is true, gitignored files are also copied.
+// freshly-created worktree pointing at parentDir's HEAD. parentDir may be any
+// path inside the parent worktree; state is materialized from the worktree root
+// so copied paths remain repository-relative. When includeIgnored is true,
+// gitignored files are also copied.
 //
 // Contract:
 //   - parentDir is treated read-only — no stash push, no add, no index mutation.
@@ -25,23 +27,28 @@ import (
 //
 // Implements issue #1029 (--with-state / --with-state-and-gitignored).
 func MaterializeWipFromParent(parentDir, childDir string, includeIgnored bool) error {
-	if err := refuseUnsafeParentState(parentDir); err != nil {
+	parentRoot, err := GetRepoRoot(parentDir)
+	if err != nil {
+		return fmt.Errorf("resolve parent worktree root: %w", err)
+	}
+
+	if err := refuseUnsafeParentState(parentRoot); err != nil {
 		return err
 	}
 
 	// 1. Apply parent's STAGED diff (vs HEAD) into child's index + working tree.
-	if err := applyDiffFromParent(parentDir, childDir, true /* cached */); err != nil {
+	if err := applyDiffFromParent(parentRoot, childDir, true /* cached */); err != nil {
 		return fmt.Errorf("materialize staged: %w", err)
 	}
 
 	// 2. Apply parent's UNSTAGED diff (working tree vs index) into child's
 	//    working tree only.
-	if err := applyDiffFromParent(parentDir, childDir, false /* cached */); err != nil {
+	if err := applyDiffFromParent(parentRoot, childDir, false /* cached */); err != nil {
 		return fmt.Errorf("materialize unstaged: %w", err)
 	}
 
 	// 3. Copy untracked files (and gitignored on opt-in).
-	if err := copyUntrackedFromParent(parentDir, childDir, includeIgnored); err != nil {
+	if err := copyUntrackedFromParent(parentRoot, childDir, includeIgnored); err != nil {
 		return fmt.Errorf("materialize untracked: %w", err)
 	}
 


### PR DESCRIPTION
## Background

This bug was found while reviewing the fork-with-state work for PR #1263 and then revalidating the finding on current `main`.

The fork-with-state feature is supposed to let a user fork a Claude session into a new worktree that starts from the same working state as the parent session:

- staged changes
- unstaged tracked changes
- untracked files
- optionally gitignored files via `--with-state-and-gitignored`

During review, the suspicious path was the CLI handler passing the parent session's `ProjectPath` directly into state materialization:

```go
git.MaterializeWipFromParent(inst.ProjectPath, worktreePath, *withStateGitignored)
```

That is fine when `ProjectPath` is the repository root. It is not fine when the session was added from a subdirectory such as `repo/a`.

I verified the underlying Git behavior with a scratch repository. From a repo shaped like:

```text
repo/
  a/new-a.txt      untracked
  b/new-b.txt      untracked
```

this command:

```bash
git -C repo/a ls-files --others --exclude-standard
```

returns:

```text
new-a.txt
```

It does not return `a/new-a.txt`, and it does not list sibling-directory files such as `b/new-b.txt`.

## What is the bug?

`MaterializeWipFromParent` accepted `parentDir` and used that same path for both Git enumeration and file copying.

For untracked and ignored files, it ran:

```go
git -C parentDir ls-files --others ...
```

and then copied each returned relative path like this:

```go
src := filepath.Join(parentDir, rel)
dst := filepath.Join(childDir, rel)
```

When `parentDir` is a subdirectory, Git returns paths relative to that subdirectory. The copy destination is still the new worktree root, so paths are no longer repository-relative.

## Effect of the bug

For a parent session rooted at `repo/a`, the old behavior was:

```text
repo/a/new-a.txt  ->  fork/new-a.txt       (wrong location)
repo/b/new-b.txt  ->  not copied at all    (missing)
```

The same bug affected `--with-state-and-gitignored` for ignored files such as `.env` files.

That means a fork could start with an incomplete or incorrectly shaped working tree even though the user explicitly asked Agent Deck to carry parent state. Setup hooks and the forked agent would then see files in the wrong location or not see them at all.

## How this PR fixes it

This PR resolves `parentDir` to the parent worktree root at the start of `MaterializeWipFromParent`:

```go
parentRoot, err := GetRepoRoot(parentDir)
```

It then uses that root for:

- in-progress operation checks
- staged diff materialization
- unstaged diff materialization
- untracked file copying
- ignored file copying when opted in

That keeps every copied file path repository-relative, regardless of whether the parent session was created from the repo root or from a nested directory.

## Regression coverage

This PR adds two regression tests:

- `TestMaterializeWipFromParent_FromSubdirectoryKeepsRepoRelativeUntrackedPaths`
- `TestMaterializeWipFromParent_FromSubdirectoryKeepsRepoRelativeIgnoredPaths`

The untracked-file test creates a parent repo with untracked files under both `a/` and `b/`, then calls `MaterializeWipFromParent` with `parentDir = repo/a`.

Before the fix, this failed with:

```text
parent:
?? a/new-a.txt
?? b/new-b.txt
child:
?? new-a.txt
```

The ignored-file test covers the same shape for `--with-state-and-gitignored`: ignored files under both `a/` and `b/` must land in the child at their repo-relative paths, and no subdirectory-relative `fork/secrets.env` copy may appear at the worktree root.

## Test Plan

- `GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go GOCACHE=/private/tmp/agent-deck-go-build-cache GOMODCACHE=/private/tmp/agent-deck-go/pkg/mod GOTMPDIR=/private/tmp go test ./internal/git -count=1`
- `GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go GOCACHE=/private/tmp/agent-deck-go-build-cache GOMODCACHE=/private/tmp/agent-deck-go/pkg/mod GOTMPDIR=/private/tmp go test ./cmd/agent-deck -run 'TestSessionFork_WithState|TestBranchCleanupHint' -count=1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed work-in-progress materialization to correctly handle subdirectory sources, ensuring untracked and ignored files maintain their repository-relative paths rather than being placed at the worktree root.

* **Tests**
  * Added comprehensive regression tests validating work-in-progress materialization from subdirectory sources, including scenarios with untracked files and ignored files under multiple subdirectories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->