### PR TITLE
fix(session): use RemoveWorktree for fork-state cleanup

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -859,7 +859,7 @@ func handleSessionFork(profile string, args []string) {
 				// Materialize parent state, with cleanup-on-error.
 				if matErr := git.MaterializeWipFromParent(inst.ProjectPath, worktreePath, *withStateGitignored); matErr != nil {
 					var cleanupErrs []string
-					if rmErr := exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", worktreePath).Run(); rmErr != nil {
+					if rmErr := git.RemoveWorktree(repoRoot, worktreePath, true); rmErr != nil {
 						cleanupErrs = append(cleanupErrs, fmt.Sprintf("worktree remove failed: %v", rmErr))
 					}
 					if createdBranch {

--- a/cmd/agent-deck/session_cmd_fork_state_test.go
+++ b/cmd/agent-deck/session_cmd_fork_state_test.go
@@ -31,9 +31,13 @@
 package main
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -60,6 +64,97 @@ func mustExtractHandleSessionFork(t *testing.T) string {
 		t.Fatalf("could not extract handleSessionFork body — file layout changed?")
 	}
 	return body
+}
+
+func mustParseHandleSessionFork(t *testing.T) (*token.FileSet, *ast.FuncDecl) {
+	t.Helper()
+	src, err := os.ReadFile("session_cmd.go")
+	if err != nil {
+		t.Fatalf("read session_cmd.go: %v", err)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "session_cmd.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse session_cmd.go: %v", err)
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == "handleSessionFork" {
+			return fset, fn
+		}
+	}
+	t.Fatal("handleSessionFork function not declared in session_cmd.go")
+	return nil, nil
+}
+
+func isSelectorCall(call *ast.CallExpr, receiver, method string) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != method {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	return ok && ident.Name == receiver
+}
+
+func isIdentArg(expr ast.Expr, name string) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == name
+}
+
+func isBoolArg(expr ast.Expr, want bool) bool {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	if want {
+		return ident.Name == "true"
+	}
+	return ident.Name == "false"
+}
+
+func stringLiteralArg(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	s, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+func isRemoveWorktreeCleanupCall(call *ast.CallExpr) bool {
+	return isSelectorCall(call, "git", "RemoveWorktree") &&
+		len(call.Args) == 3 &&
+		isIdentArg(call.Args[0], "repoRoot") &&
+		isIdentArg(call.Args[1], "worktreePath") &&
+		isBoolArg(call.Args[2], true)
+}
+
+func isGitWorktreeRemoveExecCommand(call *ast.CallExpr) bool {
+	if !isSelectorCall(call, "exec", "Command") {
+		return false
+	}
+	if len(call.Args) == 0 {
+		return false
+	}
+	first, ok := stringLiteralArg(call.Args[0])
+	if !ok || first != "git" {
+		return false
+	}
+	previousWasWorktree := false
+	for _, arg := range call.Args[1:] {
+		value, ok := stringLiteralArg(arg)
+		if !ok {
+			continue
+		}
+		if previousWasWorktree && value == "remove" {
+			return true
+		}
+		previousWasWorktree = value == "worktree"
+	}
+	return false
 }
 
 func initGitRepoForForkStateTest(t *testing.T, dir string) {
@@ -327,14 +422,29 @@ func TestSessionFork_WithState_RefusesMidOpWithActionableHint_StructuralGuard(t 
 // helper instead of shelling out directly to `git worktree remove --force`.
 // The helper owns force-mode fallback cleanup, prune, and data-loss guards.
 func TestSessionFork_WithStateCleanupUsesGitRemoveWorktree(t *testing.T) {
-	body := mustExtractHandleSessionFork(t)
-	folded := foldSpaces(body)
+	fset, fn := mustParseHandleSessionFork(t)
 
-	if !strings.Contains(folded, "git.RemoveWorktree(repoRoot, worktreePath, true)") {
-		t.Errorf("handleSessionFork materialization cleanup must use git.RemoveWorktree(repoRoot, worktreePath, true); folded body:\n%s", folded)
+	foundRemoveWorktree := false
+	var rawWorktreeRemoveCalls []token.Position
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if isRemoveWorktreeCleanupCall(call) {
+			foundRemoveWorktree = true
+		}
+		if isGitWorktreeRemoveExecCommand(call) {
+			rawWorktreeRemoveCalls = append(rawWorktreeRemoveCalls, fset.Position(call.Pos()))
+		}
+		return true
+	})
+
+	if !foundRemoveWorktree {
+		t.Error("handleSessionFork materialization cleanup must call git.RemoveWorktree(repoRoot, worktreePath, true)")
 	}
-	if strings.Contains(folded, `exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", worktreePath)`) {
-		t.Errorf("handleSessionFork materialization cleanup must not shell out directly to git worktree remove; folded body:\n%s", folded)
+	for _, pos := range rawWorktreeRemoveCalls {
+		t.Errorf("handleSessionFork materialization cleanup must not shell out directly to git worktree remove; found raw call at %s", pos)
 	}
 }
 

--- a/cmd/agent-deck/session_cmd_fork_state_test.go
+++ b/cmd/agent-deck/session_cmd_fork_state_test.go
@@ -322,6 +322,22 @@ func TestSessionFork_WithState_RefusesMidOpWithActionableHint_StructuralGuard(t 
 	}
 }
 
+// TestSessionFork_WithStateCleanupUsesGitRemoveWorktree pins N1: the
+// fork-with-state CLI cleanup path must use the centralized git.RemoveWorktree
+// helper instead of shelling out directly to `git worktree remove --force`.
+// The helper owns force-mode fallback cleanup, prune, and data-loss guards.
+func TestSessionFork_WithStateCleanupUsesGitRemoveWorktree(t *testing.T) {
+	body := mustExtractHandleSessionFork(t)
+	folded := foldSpaces(body)
+
+	if !strings.Contains(folded, "git.RemoveWorktree(repoRoot, worktreePath, true)") {
+		t.Errorf("handleSessionFork materialization cleanup must use git.RemoveWorktree(repoRoot, worktreePath, true); folded body:\n%s", folded)
+	}
+	if strings.Contains(folded, `exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", worktreePath)`) {
+		t.Errorf("handleSessionFork materialization cleanup must not shell out directly to git worktree remove; folded body:\n%s", folded)
+	}
+}
+
 // TestSessionForkBeforeStartHook_NilInProduction is a belt-and-braces check:
 // the production binary must leave the hook nil so accidental test imports
 // can't inject behavior into a real fork. Tests that need the hook assign


### PR DESCRIPTION
## Summary

Fixes N1: `session fork --with-state` cleanup now uses the centralized `git.RemoveWorktree` helper instead of shelling out directly to `git worktree remove --force`.

## Context

When `session fork --with-state` creates a new worktree and then `MaterializeWipFromParent` fails, the CLI attempts cleanup before returning the error.

Before this change, that cleanup path called:

```go
exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", worktreePath)
```

That bypassed `internal/git.RemoveWorktree`, which already owns force-mode cleanup behavior, fallback removal, stale worktree pruning, and data-loss guards.

## Impact

This was not validated as a main-repo deletion/data-loss path because the cleanup target is a freshly-created worktree. The real impact is cleanup correctness: raw `git worktree remove --force` can fail in cases where `git.RemoveWorktree` can complete cleanup through its fallback/prune path.

## Why This Matters

The fork-with-state failure path should use the same cleanup abstraction as the rest of the worktree lifecycle. Keeping this centralized avoids drift in force cleanup behavior and keeps future safety changes in `git.RemoveWorktree` effective for this CLI path too.

## Changes

- Replaced the raw `git worktree remove --force` cleanup call in `cmd/agent-deck/session_cmd.go` with:

```go
git.RemoveWorktree(repoRoot, worktreePath, true)
```

- Added a focused regression test that pins the CLI cleanup contract:
  - cleanup must use `git.RemoveWorktree(repoRoot, worktreePath, true)`
  - cleanup must not shell out directly to `git worktree remove --force`

## Verification

Passed:

```bash
GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
go test ./cmd/agent-deck -run 'TestSessionFork_|TestBranchCleanupHint' -race -count=1
```

Result:

```text
ok github.com/asheshgoplani/agent-deck/cmd/agent-deck 1.988s
```

Also passed:

```bash
git diff --check HEAD
```

## Full-Suite Note

I also ran:

```bash
GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
go test ./... -count=1
```

The full suite did not pass due to existing failures outside this change. The required persistence failure `TestPersistence_CustomCommandResumesFromLatestJSONL` was checked separately and reproduced on:

- this N1 branch
- the clean base commit before this N1 change
- current `upstream/main`

So that failure predates this PR and is not caused by the N1 cleanup change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of session fork cleanup by routing worktree removal through the centralized removal utility and consolidating cleanup error handling.

* **Tests**
  * Added structural test coverage to verify the session fork cleanup path uses the centralized removal utility rather than ad-hoc removal commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->