### PR TITLE
feat(paths): respect XDG base directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Runtime and watcher durable state paths now use `$XDG_DATA_HOME/agent-deck` for new installs, with category-specific legacy fallback for existing `~/.agent-deck` state. Hooks, events, inboxes, runtime ledgers, logs, locks, conductor state, watcher state, triage output, and worker scratch no longer fall back to legacy just because an unrelated legacy marker exists.
+
 ## [1.9.47] - 2026-06-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- New installs now use the XDG Base Directory layout: config under `$XDG_CONFIG_HOME/agent-deck` (default `~/.config/agent-deck`), durable state under `$XDG_DATA_HOME/agent-deck` (default `~/.local/share/agent-deck`), and cache/debug files under `$XDG_CACHE_HOME/agent-deck` (default `~/.cache/agent-deck`). Existing `~/.agent-deck` installs continue to work through category-specific legacy fallback.
+- Added `agent-deck migrate-paths [--dry-run] [--force]` to copy known legacy `~/.agent-deck` files into the split XDG layout without deleting or renaming the legacy directory.
 - Runtime and watcher durable state paths now use `$XDG_DATA_HOME/agent-deck` for new installs, with category-specific legacy fallback for existing `~/.agent-deck` state. Hooks, events, inboxes, runtime ledgers, logs, locks, conductor state, watcher state, triage output, and worker scratch no longer fall back to legacy just because an unrelated legacy marker exists.
 
 ## [1.9.47] - 2026-06-03

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ agent-deck watcher status <name>       # detail view including recent events
 agent-deck watcher test   <name>       # fire a synthetic event to verify routing
 ```
 
-Routing rules live under `~/.agent-deck/watcher/<name>/clients.json` — edit to pick which conductor/group receives which events. Use `agent-deck watcher routes` to see the currently-loaded rules across all watchers.
+Routing rules live in the effective watcher data dir (`$XDG_DATA_HOME/agent-deck/watcher/clients.json` for new users, or legacy `~/.agent-deck/watcher/clients.json` when existing watcher state is present). Edit it to pick which conductor/group receives which events. Use `agent-deck watcher routes` to see the currently-loaded rules across all watchers.
 
 **Conversational setup (recommended for first-time use):**
 
@@ -541,7 +541,7 @@ Then, inside a Claude Code session started by agent-deck, ask: *"Use the watcher
 Safety notes:
 - The GitHub adapter enforces HMAC-SHA256 signature verification on every webhook — a missing/invalid signature drops the event.
 - Events are deduplicated in SQLite by `(watcher_name, event_id)`, so retries from the sender do not double-fire the conductor.
-- Watchers keep per-adapter health in `~/.agent-deck/watcher/<name>/state.json`; the TUI watcher panel (press `w`) surfaces this in real time.
+- Watchers keep per-adapter health in `<effective watcher data dir>/<name>/state.json`; the TUI watcher panel (press `w`) surfaces this in real time.
 
 **Doorbell rule:** watchers are triggers, not launchers. They forward a short event string to the conductor and let the conductor decide what to do. A watcher should never call `agent-deck launch` or `agent-deck add` directly — those calls run outside any conductor's process and have no `$AGENTDECK_INSTANCE_ID`, so the spawned session becomes an orphan whose status events never route back. Use `agent-deck session send <conductor> "[event] hint"` from the watcher and let the conductor fan out from there.
 

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ agent-deck watcher status <name>       # detail view including recent events
 agent-deck watcher test   <name>       # fire a synthetic event to verify routing
 ```
 
-Routing rules live in the effective watcher data dir (`$XDG_DATA_HOME/agent-deck/watcher/clients.json` for new users, or legacy `~/.agent-deck/watcher/clients.json` when existing watcher state is present). Edit it to pick which conductor/group receives which events. Use `agent-deck watcher routes` to see the currently-loaded rules across all watchers.
+Routing rules live in the effective watcher data dir (`${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher/clients.json` for new users, or legacy `~/.agent-deck/watcher/clients.json` when existing watcher state is present). Edit it to pick which conductor/group receives which events. Use `agent-deck watcher routes` to see the currently-loaded rules across all watchers.
 
 **Conversational setup (recommended for first-time use):**
 

--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ Try different approaches without losing context. Fork any Claude conversation in
 Attach MCP servers without touching config files. Need web search? Browser automation? Toggle them on per project or globally. Agent Deck handles the restart automatically.
 
 - Press `m` to open, `Space` to toggle, `Tab` to cycle scope (LOCAL/GLOBAL), type to jump
-- Define your MCPs once in `~/.agent-deck/config.toml`, then toggle per session — see [Configuration Reference](skills/agent-deck/references/config-reference.md)
+- Define your MCPs once in `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/agent-deck/config.toml`), then toggle per session — see [Configuration Reference](skills/agent-deck/references/config-reference.md)
 
 ### Skills Manager
 
 Attach/detach Claude skills per project with a managed pool workflow.
 
 - Press `s` to open Skills Manager for a Claude session
-- Available list is pool-only (`~/.agent-deck/skills/pool`) to keep attach/detach deterministic
+- Available list is pool-only (`$XDG_CONFIG_HOME/agent-deck/skills/pool`, default `~/.config/agent-deck/skills/pool`) to keep attach/detach deterministic
 - Apply writes project state to `.agent-deck/skills.toml` and materializes into `.claude/skills`
 - Type-to-jump is supported in the dialog (same pattern as MCP Manager)
 
@@ -125,7 +125,7 @@ Attach/detach Claude skills per project with a managed pool workflow.
 
 Agent Deck supports per-group `CLAUDE_CONFIG_DIR` and `env_file` overrides. Useful when a single profile hosts groups that should authenticate against different Claude accounts — for example, a personal profile hosting a `conductor` group pinned to `~/.claude-work` while other groups stay on `~/.claude`.
 
-Override any group by adding a `[groups."<name>".claude]` table to `~/.agent-deck/config.toml`:
+Override any group by adding a `[groups."<name>".claude]` table to `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/agent-deck/config.toml`):
 
 ```toml
 [groups."conductor".claude]
@@ -218,7 +218,7 @@ Multiple agents can work on the same repo without conflicts. Each worktree is an
 - `agent-deck worktree finish "My Session"` merges the branch, removes the worktree, and deletes the session
 - `agent-deck worktree cleanup` finds and removes orphaned worktrees
 
-Configure the default worktree location in `~/.agent-deck/config.toml`:
+Configure the default worktree location in `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/agent-deck/config.toml`):
 
 ```toml
 [worktree]
@@ -377,10 +377,11 @@ agent-deck conductor setup glm-bot \
 agent-deck conductor setup glm-bot -env-file ~/.conductor.env
 ```
 
-Each conductor gets its own directory, identity, and settings:
+Each conductor gets its own directory, identity, and settings under the XDG data
+root (default `~/.local/share/agent-deck/conductor/`):
 
 ```
-~/.agent-deck/conductor/
+~/.local/share/agent-deck/conductor/
 ├── CLAUDE.md           # Shared knowledge for Claude conductors
 ├── AGENTS.md           # Shared knowledge for Codex conductors
 ├── bridge.py           # Bridge daemon (Telegram/Slack, if configured)
@@ -446,7 +447,8 @@ Both Telegram and Slack can run simultaneously — the bridge daemon handles bot
 Dispatch can be suppressed at two scopes (PR #580, v1.7.34):
 
 ```toml
-# Global kill switch in ~/.agent-deck/config.toml (default: true)
+# Global kill switch in $XDG_CONFIG_HOME/agent-deck/config.toml
+# (default ~/.config/agent-deck/config.toml)
 [notifications]
 transition_events = false
 ```
@@ -465,9 +467,9 @@ Suppression only affects dispatch — the parent link itself is unchanged. Defer
 
 **Heartbeat-driven monitoring**: heartbeats still run on the configured interval (default 15 minutes) as a secondary safety net. If a conductor response includes `NEED:`, the bridge forwards that alert to Telegram and/or Slack.
 
-**Telegram conductor topology (v1.7.22+)**: each conductor bot must own exactly one channel-owning session. Activate telegram per-session via `--channels plugin:telegram@claude-plugins-official` and inject `TELEGRAM_STATE_DIR` via `[conductors.<name>.claude].env_file` in `~/.agent-deck/config.toml`. Do NOT set `enabledPlugins."telegram@claude-plugins-official"=true` in a profile's `settings.json` — that leaks a poller to every claude session under the profile. agent-deck emits warnings (`GLOBAL_ANTIPATTERN`, `DOUBLE_LOAD`, `WRAPPER_DEPRECATED`) when it detects these setups. Full guidance: [Telegram conductor topology](skills/agent-deck/SKILL.md#telegram-conductor-topology-v1722).
+**Telegram conductor topology (v1.7.22+)**: each conductor bot must own exactly one channel-owning session. Activate telegram per-session via `--channels plugin:telegram@claude-plugins-official` and inject `TELEGRAM_STATE_DIR` via `[conductors.<name>.claude].env_file` in `$XDG_CONFIG_HOME/agent-deck/config.toml`. Do NOT set `enabledPlugins."telegram@claude-plugins-official"=true` in a profile's `settings.json` — that leaks a poller to every claude session under the profile. agent-deck emits warnings (`GLOBAL_ANTIPATTERN`, `DOUBLE_LOAD`, `WRAPPER_DEPRECATED`) when it detects these setups. Full guidance: [Telegram conductor topology](skills/agent-deck/SKILL.md#telegram-conductor-topology-v1722).
 
-**Permission prompts during automation**: if a conductor keeps pausing on permission requests, set `[claude].allow_dangerous_mode = true` (or `dangerous_mode = true`) in `~/.agent-deck/config.toml`, then run `agent-deck session restart conductor-<name>`. See [Troubleshooting](skills/agent-deck/references/troubleshooting.md#conductor-keeps-asking-for-permissions).
+**Permission prompts during automation**: if a conductor keeps pausing on permission requests, set `[claude].allow_dangerous_mode = true` (or `dangerous_mode = true`) in `$XDG_CONFIG_HOME/agent-deck/config.toml`, then run `agent-deck session restart conductor-<name>`. See [Troubleshooting](skills/agent-deck/references/troubleshooting.md#conductor-keeps-asking-for-permissions).
 
 **Legacy external watcher scripts**: optional only. `~/.agent-deck/events/` is not required for notification routing.
 
@@ -579,7 +581,8 @@ Track token usage and costs across all your AI agent sessions in real-time.
 - **Export** — CSV/JSON export from web dashboard
 
 ```toml
-# Optional config (~/.agent-deck/config.toml)
+# Optional config ($XDG_CONFIG_HOME/agent-deck/config.toml;
+# default ~/.config/agent-deck/config.toml)
 [costs]
 retention_days = 90
 
@@ -621,7 +624,8 @@ Resolution chain: `profiles.<active>.costs.cost_line_template > [costs].cost_lin
 Run agent-deck on its own tmux server so it never touches your interactive tmux's config, bindings, or sessions. Opt-in via a single config line:
 
 ```toml
-# ~/.agent-deck/config.toml
+# $XDG_CONFIG_HOME/agent-deck/config.toml
+# default ~/.config/agent-deck/config.toml
 [tmux]
 socket_name = "agent-deck"
 ```
@@ -654,7 +658,7 @@ Precedence at session creation: `--tmux-socket` flag > `[tmux].socket_name` > em
 
 1. Set `[tmux].socket_name = "agent-deck"` in your config.
 2. Stop the session (`agent-deck session stop <name>`) — this kills the tmux pane on the old server.
-3. Restart it (`agent-deck session start <name>`) — agent-deck will see TmuxSocketName=`""` on the stored Instance, spawn a fresh pane on the old server, and keep it there. To force it onto the new socket, edit `~/.agent-deck/<profile>/state.db`:
+3. Restart it (`agent-deck session start <name>`) — agent-deck will see TmuxSocketName=`""` on the stored Instance, spawn a fresh pane on the old server, and keep it there. To force it onto the new socket, edit the effective profile database (`~/.local/share/agent-deck/<profile>/state.db` for new users, or `~/.agent-deck/<profile>/state.db` for legacy profiles):
    ```sql
    UPDATE instances SET tmux_socket_name = 'agent-deck' WHERE id = '<session-id>';
    ```
@@ -705,7 +709,7 @@ agent-deck remote update          # all remotes
 agent-deck remote update dev      # specific remote
 ```
 
-Remote configuration is stored under `[remotes]` in `~/.agent-deck/config.toml`. All `remote` subcommands support `--json` output for scripting. Run `agent-deck remote --help` for the full flag reference.
+Remote configuration is stored under `[remotes]` in `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/agent-deck/config.toml`). All `remote` subcommands support `--json` output for scripting. Run `agent-deck remote --help` for the full flag reference.
 
 #### Security
 
@@ -893,7 +897,7 @@ Yes, via WSL (Windows Subsystem for Linux). [Install WSL](https://learn.microsof
 <details>
 <summary><b>Can I use different Claude accounts/configs per profile?</b></summary>
 
-Yes. Set a global Claude config dir, then add optional per-profile overrides in `~/.agent-deck/config.toml`:
+Yes. Set a global Claude config dir, then add optional per-profile overrides in `$XDG_CONFIG_HOME/agent-deck/config.toml` (default `~/.config/agent-deck/config.toml`):
 
 ```toml
 [claude]

--- a/cmd/agent-deck/assets/skills/watcher-creator/README.md
+++ b/cmd/agent-deck/assets/skills/watcher-creator/README.md
@@ -1,1 +1,1 @@
-Hand-authored skill for conversational watcher setup. Install via `agent-deck watcher install-skill watcher-creator`. Source of truth — runtime copy lives at ~/.agent-deck/skills/pool/watcher-creator/.
+Hand-authored skill for conversational watcher setup. Install via `agent-deck watcher install-skill watcher-creator`. Source of truth: the runtime copy lives at `$XDG_CONFIG_HOME/agent-deck/skills/pool/watcher-creator/` (default `~/.config/agent-deck/skills/pool/watcher-creator/`).

--- a/cmd/agent-deck/assets/skills/watcher-creator/SKILL.md
+++ b/cmd/agent-deck/assets/skills/watcher-creator/SKILL.md
@@ -35,13 +35,13 @@ Ask the user which source they want to receive events from. Present the five opt
 Once the user picks a type, ask for the settings specific to that adapter (see the per-type sections below). Ask for each required setting one at a time to avoid overwhelming the user.
 
 Also ask:
-- **Watcher name**: A short lowercase identifier (e.g., `my-webhook`, `github-alerts`). This becomes the directory name under `~/.agent-deck/watcher/`.
+- **Watcher name**: A short lowercase identifier (e.g., `my-webhook`, `github-alerts`). This becomes the directory name under the effective watcher data dir (`$XDG_DATA_HOME/agent-deck/watcher` for new users; legacy `~/.agent-deck/watcher` remains in use when existing watcher state is present).
 - **Conductor**: Which conductor session this watcher should route events to by default (the `conductor` field in `clients.json`).
 - **Group**: Which group the conductor session lives in (the `group` field in `clients.json`).
 
 ### Step 3: Generate a watcher.toml block
 
-Produce a TOML configuration block for the user to save as `~/.agent-deck/watcher/<name>/watcher.toml`.
+Produce a TOML configuration block for the user to save as `$XDG_DATA_HOME/agent-deck/watcher/<name>/watcher.toml`, or the legacy `~/.agent-deck/watcher/<name>/watcher.toml` if agent-deck is already using legacy watcher state.
 
 Example for webhook:
 ```toml
@@ -165,8 +165,8 @@ The Gmail adapter delivers normalized events from a Gmail account via Google Clo
 - `subscription` (string): Full Pub/Sub subscription resource name: `projects/<project-id>/subscriptions/<sub-name>`.
 
 **Optional settings:**
-- `credentials_path` (string): Path to the OAuth client credentials JSON file (downloaded from Google Cloud Console). Default: `~/.agent-deck/watcher/<name>/credentials.json`.
-- `token_path` (string): Path to the persisted OAuth token JSON. Default: `~/.agent-deck/watcher/<name>/token.json`.
+- `credentials_path` (string): Path to the OAuth client credentials JSON file (downloaded from Google Cloud Console). Default: `<effective watcher data dir>/<name>/credentials.json`.
+- `token_path` (string): Path to the persisted OAuth token JSON. Default: `<effective watcher data dir>/<name>/token.json`.
 - `labels` (string): Comma-separated Gmail label filter (e.g., `"INBOX,UNREAD"`). If absent, all messages pass through.
 - `account` (string): Informational Gmail address for display purposes.
 
@@ -212,7 +212,7 @@ Great, let me help you set up a GitHub watcher.
 **Skill response:**
 Here is your configuration.
 
-Save this as `~/.agent-deck/watcher/github-myrepo/watcher.toml`:
+Save this as `$XDG_DATA_HOME/agent-deck/watcher/github-myrepo/watcher.toml` for a new install, or under legacy `~/.agent-deck/watcher/github-myrepo/watcher.toml` if agent-deck is already using legacy watcher state:
 ```toml
 [watcher]
 name = "github-myrepo"
@@ -228,7 +228,7 @@ conductor = "main-conductor"
 group = "dev"
 ```
 
-Add this entry to `~/.agent-deck/watcher/clients.json` (key is `<your-github-username>@github.com`):
+Add this entry to `$XDG_DATA_HOME/agent-deck/watcher/clients.json` (key is `<your-github-username>@github.com`), or the legacy watcher `clients.json` if that is the effective watcher data dir:
 ```json
 {
   "octocat@github.com": {
@@ -255,7 +255,7 @@ Configure GitHub to send webhooks to `http://<your-server>:18461/github`.
 
 This skill is read-only (D-22): it guides you through configuration and emits commands to run, but it does NOT execute `agent-deck watcher create` itself. Copy and run the commands shown above in your terminal.
 
-All five adapter types (webhook, ntfy, github, slack, gmail) route incoming events through the same engine. Events are matched against `~/.agent-deck/watcher/clients.json` by sender. Unknown senders are sent to triage in Phase 18+.
+All five adapter types (webhook, ntfy, github, slack, gmail) route incoming events through the same engine. Events are matched against `<effective watcher data dir>/clients.json` by sender. Unknown senders are sent to triage in Phase 18+.
 
 Install this skill to your pool with:
 ```

--- a/cmd/agent-deck/assets/skills/watcher-creator/SKILL.md
+++ b/cmd/agent-deck/assets/skills/watcher-creator/SKILL.md
@@ -35,13 +35,13 @@ Ask the user which source they want to receive events from. Present the five opt
 Once the user picks a type, ask for the settings specific to that adapter (see the per-type sections below). Ask for each required setting one at a time to avoid overwhelming the user.
 
 Also ask:
-- **Watcher name**: A short lowercase identifier (e.g., `my-webhook`, `github-alerts`). This becomes the directory name under the effective watcher data dir (`$XDG_DATA_HOME/agent-deck/watcher` for new users; legacy `~/.agent-deck/watcher` remains in use when existing watcher state is present).
+- **Watcher name**: A short lowercase identifier (e.g., `my-webhook`, `github-alerts`). This becomes the directory name under the effective watcher data dir (`${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher` for new users; legacy `~/.agent-deck/watcher` remains in use when existing watcher state is present).
 - **Conductor**: Which conductor session this watcher should route events to by default (the `conductor` field in `clients.json`).
 - **Group**: Which group the conductor session lives in (the `group` field in `clients.json`).
 
 ### Step 3: Generate a watcher.toml block
 
-Produce a TOML configuration block for the user to save as `$XDG_DATA_HOME/agent-deck/watcher/<name>/watcher.toml`, or the legacy `~/.agent-deck/watcher/<name>/watcher.toml` if agent-deck is already using legacy watcher state.
+Produce a TOML configuration block for the user to save as `${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher/<name>/watcher.toml`, or the legacy `~/.agent-deck/watcher/<name>/watcher.toml` if agent-deck is already using legacy watcher state.
 
 Example for webhook:
 ```toml
@@ -212,7 +212,7 @@ Great, let me help you set up a GitHub watcher.
 **Skill response:**
 Here is your configuration.
 
-Save this as `$XDG_DATA_HOME/agent-deck/watcher/github-myrepo/watcher.toml` for a new install, or under legacy `~/.agent-deck/watcher/github-myrepo/watcher.toml` if agent-deck is already using legacy watcher state:
+Save this as `${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher/github-myrepo/watcher.toml` for a new install, or under legacy `~/.agent-deck/watcher/github-myrepo/watcher.toml` if agent-deck is already using legacy watcher state:
 ```toml
 [watcher]
 name = "github-myrepo"
@@ -228,7 +228,7 @@ conductor = "main-conductor"
 group = "dev"
 ```
 
-Add this entry to `$XDG_DATA_HOME/agent-deck/watcher/clients.json` (key is `<your-github-username>@github.com`), or the legacy watcher `clients.json` if that is the effective watcher data dir:
+Add this entry to `${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher/clients.json` (key is `<your-github-username>@github.com`), or the legacy watcher `clients.json` if that is the effective watcher data dir:
 ```json
 {
   "octocat@github.com": {

--- a/cmd/agent-deck/cgroup_isolation_wiring_test.go
+++ b/cmd/agent-deck/cgroup_isolation_wiring_test.go
@@ -42,7 +42,10 @@ func TestLogCgroupIsolationDecision_WiredIntoBootstrap(t *testing.T) {
 			t.Skip("skipping subprocess integration test in short mode")
 		}
 		tmpHome := t.TempDir()
-		if err := os.MkdirAll(filepath.Join(tmpHome, ".agent-deck"), 0o755); err != nil {
+		xdgConfigHome := filepath.Join(tmpHome, ".config")
+		xdgDataHome := filepath.Join(tmpHome, ".local", "share")
+		xdgCacheHome := filepath.Join(tmpHome, ".cache")
+		if err := os.MkdirAll(filepath.Join(xdgCacheHome, "agent-deck"), 0o755); err != nil {
 			t.Fatal(err)
 		}
 		binPath := filepath.Join(t.TempDir(), "agent-deck-test")
@@ -72,6 +75,9 @@ func TestLogCgroupIsolationDecision_WiredIntoBootstrap(t *testing.T) {
 		}
 		env = append(env,
 			"HOME="+tmpHome,
+			"XDG_CONFIG_HOME="+xdgConfigHome,
+			"XDG_DATA_HOME="+xdgDataHome,
+			"XDG_CACHE_HOME="+xdgCacheHome,
 			"AGENTDECK_DEBUG=1",
 			"AGENTDECK_PROFILE=test-obs01",
 			"TERM=dumb",
@@ -91,7 +97,7 @@ func TestLogCgroupIsolationDecision_WiredIntoBootstrap(t *testing.T) {
 		// Allow lumberjack to flush after SIGTERM.
 		time.Sleep(200 * time.Millisecond)
 
-		logPath := filepath.Join(tmpHome, ".agent-deck", "debug.log")
+		logPath := filepath.Join(xdgCacheHome, "agent-deck", "debug.log")
 		data, err := os.ReadFile(logPath)
 		if err != nil {
 			t.Fatalf("OBS-01-WIRE-UP-MISSING: read debug.log at %s: %v", logPath, err)

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -809,7 +809,7 @@ func logCostDebug(format string, args ...any) {
 func getCostEventsDir() string {
 	path, err := agentpaths.EffectiveDataPath("cost-events", "cost-events")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "cost-events")
+		return filepath.Join(os.TempDir(), "agent-deck", "cost-events")
 	}
 	return path
 }

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -385,11 +386,7 @@ func warnProjectDirMissingOnce(instanceID, cwd string) {
 
 // getHooksDir returns the path to the hooks status directory.
 func getHooksDir() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "hooks")
-	}
-	return filepath.Join(home, ".agent-deck", "hooks")
+	return session.GetHooksDir()
 }
 
 // cleanStaleHookFiles removes hook status files older than 24 hours.
@@ -786,17 +783,19 @@ func readLastLine(path string) (string, error) {
 	return strings.TrimSpace(string(buf)), nil
 }
 
-// logCostDebug writes debug messages to ~/.agent-deck/cost-debug.log
+// logCostDebug writes debug messages to the XDG cache cost-debug.log.
 // Only active when AGENTDECK_DEBUG is set.
 func logCostDebug(format string, args ...any) {
 	if os.Getenv("AGENTDECK_DEBUG") == "" {
 		return
 	}
-	home, err := os.UserHomeDir()
+	logPath, err := effectiveCachePath("cost-debug.log")
 	if err != nil {
 		return
 	}
-	logPath := filepath.Join(home, ".agent-deck", "cost-debug.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		return
+	}
 	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return
@@ -808,11 +807,11 @@ func logCostDebug(format string, args ...any) {
 
 // getCostEventsDir returns the path to the cost events directory.
 func getCostEventsDir() string {
-	home, err := os.UserHomeDir()
+	path, err := agentpaths.EffectiveDataPath("cost-events", "cost-events")
 	if err != nil {
 		return filepath.Join(os.TempDir(), ".agent-deck", "cost-events")
 	}
-	return filepath.Join(home, ".agent-deck", "cost-events")
+	return path
 }
 
 // getClaudeConfigDirForHooks returns the Claude config directory for hook operations.

--- a/cmd/agent-deck/issue1233_projectdir_degrade_test.go
+++ b/cmd/agent-deck/issue1233_projectdir_degrade_test.go
@@ -92,7 +92,7 @@ func TestHookHandler_MissingProjectDir_DegradesNotFatal(t *testing.T) {
 	}
 
 	// (3) Soft-skip: no status file is written for the broken session.
-	statusFile := filepath.Join(home, ".agent-deck", "hooks", "inst-1233.json")
+	statusFile := filepath.Join(getHooksDir(), "inst-1233.json")
 	if _, err := os.Stat(statusFile); err == nil {
 		t.Errorf("expected soft-skip (no status file) when project dir is missing, but %s exists", statusFile)
 	}
@@ -122,7 +122,7 @@ func TestHookHandler_PresentProjectDir_NotDegraded(t *testing.T) {
 		t.Errorf("did not expect a missing-project-dir WARN when cwd exists; log:\n%s", body)
 	}
 
-	statusFile := filepath.Join(home, ".agent-deck", "hooks", "inst-ok.json")
+	statusFile := filepath.Join(getHooksDir(), "inst-ok.json")
 	if _, err := os.Stat(statusFile); err != nil {
 		t.Errorf("expected status file to be written when project dir exists: %v", err)
 	}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -654,7 +654,10 @@ func main() {
 		if cacheErr != nil {
 			cacheDir = ""
 		}
-		pricerCfg := costs.PricerConfig{CachePath: cacheDir}
+		pricerCfg := costs.PricerConfig{}
+		if cacheDir != "" {
+			pricerCfg.CachePath = cacheDir
+		}
 		if userCfg != nil && len(userCfg.Costs.Pricing.Overrides) > 0 {
 			pricerCfg.Overrides = make(map[string]costs.PriceOverride)
 			for model, ov := range userCfg.Costs.Pricing.Overrides {
@@ -667,13 +670,15 @@ func main() {
 			}
 		}
 		pricer := costs.NewPricer(pricerCfg)
-		_ = pricer.LoadCache()
+		if cacheDir != "" {
+			_ = pricer.LoadCache()
 
-		// Start daily price fetcher
-		fetchCtx, fetchCancel := context.WithCancel(context.Background())
-		defer fetchCancel()
-		fetcher := &costs.Fetcher{CachePath: filepath.Join(cacheDir, "pricing.json"), Pricer: pricer}
-		go fetcher.StartDaily(fetchCtx)
+			// Start daily price fetcher
+			fetchCtx, fetchCancel := context.WithCancel(context.Background())
+			defer fetchCancel()
+			fetcher := &costs.Fetcher{CachePath: filepath.Join(cacheDir, "pricing.json"), Pricer: pricer}
+			go fetcher.StartDaily(fetchCtx)
+		}
 
 		// Set up budget checker
 		var budgetCfg costs.BudgetConfig

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -325,6 +325,9 @@ func main() {
 		case "uninstall":
 			handleUninstall(args[1:])
 			return
+		case "migrate-paths":
+			handleMigratePaths(args[1:])
+			return
 		case "hook-handler":
 			handleHookHandler()
 			return
@@ -2974,6 +2977,7 @@ func printHelp() {
 	fmt.Println("  profile          Manage profiles")
 	fmt.Println("  update           Check for and install updates")
 	fmt.Println("  debug-dump       Dump debug ring buffer to file for sharing")
+	fmt.Println("  migrate-paths    Copy legacy ~/.agent-deck files into XDG paths")
 	fmt.Println("  uninstall        Uninstall Agent Deck")
 	fmt.Println("  version          Show version")
 	fmt.Println("  help             Show this help")

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/muesli/termenv"
 	"golang.org/x/term"
 
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/asheshgoplani/agent-deck/internal/costs"
 	"github.com/asheshgoplani/agent-deck/internal/feedback"
 	"github.com/asheshgoplani/agent-deck/internal/git"
@@ -3186,7 +3187,7 @@ func handleUninstall(args []string) {
 	}
 
 	homeDir, _ := os.UserHomeDir()
-	legacyDir := filepath.Join(homeDir, ".agent-deck")
+	legacyDir, _ := agentpaths.LegacyDir()
 	var foundItems []uninstallFoundItem
 
 	// Check for Homebrew installation

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -57,6 +57,7 @@ func init() {
 func initUpdateSettings() {
 	settings := session.GetUpdateSettings()
 	update.SetCheckInterval(settings.CheckIntervalHours)
+	update.SetBridgeScriptInstaller(session.InstallBridgeScript)
 }
 
 // writeVersionOutput prints `Agent Deck vX.Y.Z` to `w`, appending

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -480,13 +480,13 @@ func main() {
 	}()
 
 	// Set up structured logging (JSONL format with rotation)
-	// When AGENTDECK_DEBUG is set, logs go to ~/.agent-deck/debug.log
+	// When AGENTDECK_DEBUG is set, logs go to the XDG cache debug.log.
 	// When not set, logs are discarded to avoid TUI interference
 	debugMode := os.Getenv("AGENTDECK_DEBUG") != ""
-	if baseDir, err := session.GetAgentDeckDir(); err == nil {
+	if cacheDir, err := ensureEffectiveCacheDir(); err == nil {
 		logCfg := logging.Config{
 			Debug:                 debugMode,
-			LogDir:                baseDir,
+			LogDir:                cacheDir,
 			Level:                 "debug",
 			Format:                "json",
 			MaxSizeMB:             10,
@@ -533,7 +533,7 @@ func main() {
 		defer logging.Shutdown()
 
 		// OBS-01: emit the cgroup-isolation decision exactly once on TUI
-		// startup. The line lands in ~/.agent-deck/debug.log via the
+		// startup. The line lands in the XDG cache debug.log via the
 		// dynamicHandler + lumberjack pipeline that logging.Init wires up.
 		// See internal/session/userconfig.go LogCgroupIsolationDecision.
 		session.LogCgroupIsolationDecision()
@@ -548,7 +548,7 @@ func main() {
 		signal.Notify(usr1Chan, syscall.SIGUSR1)
 		go func() {
 			for range usr1Chan {
-				dumpPath := filepath.Join(baseDir, fmt.Sprintf("crash-dump-%d.jsonl", time.Now().Unix()))
+				dumpPath := filepath.Join(cacheDir, fmt.Sprintf("crash-dump-%d.jsonl", time.Now().Unix()))
 				if err := logging.DumpRingBuffer(dumpPath); err != nil {
 					logging.ForComponent(logging.CompUI).Error("crash_dump_failed",
 						slog.String("error", err.Error()))
@@ -646,8 +646,10 @@ func main() {
 		userCfg, _ := session.LoadUserConfig()
 
 		// Set up pricer with overrides
-		homeDir, _ := os.UserHomeDir()
-		cacheDir := filepath.Join(homeDir, ".agent-deck")
+		cacheDir, cacheErr := effectiveCacheDir()
+		if cacheErr != nil {
+			cacheDir = ""
+		}
 		pricerCfg := costs.PricerConfig{CachePath: cacheDir}
 		if userCfg != nil && len(userCfg.Costs.Pricing.Overrides) > 0 {
 			pricerCfg.Overrides = make(map[string]costs.PriceOverride)
@@ -691,7 +693,7 @@ func main() {
 		homeModel.SetCostBudget(budgetChecker)
 
 		// Start cost event watcher (for Claude hook events)
-		costEventsDir := filepath.Join(homeDir, ".agent-deck", "cost-events")
+		costEventsDir := getCostEventsDir()
 		costWatcher, watchErr := costs.NewCostEventWatcher(costEventsDir)
 		if watchErr == nil {
 			go costWatcher.Start()
@@ -1156,10 +1158,10 @@ func handleAdd(profile string, args []string) {
 
 	// Plugin enablement flag — repeatable, catalog-only, claude-only.
 	// Persisted on Instance.Plugins; resolved at spawn through
-	// [plugins.<name>] in ~/.agent-deck/config.toml and applied via the
+	// [plugins.<name>] in the user config and applied via the
 	// per-session scratch settings.json (RFC docs/rfc/PLUGIN_ATTACH.md).
 	var pluginFlags []string
-	fs.Func("plugin", "Catalog plugin to enable for this session (can specify multiple times); requires -c claude; configure in [plugins.<name>] in ~/.agent-deck/config.toml", func(s string) error {
+	fs.Func("plugin", fmt.Sprintf("Catalog plugin to enable for this session (can specify multiple times); requires -c claude; configure in [plugins.<name>] in %s", effectiveUserConfigPathForHelp()), func(s string) error {
 		pluginFlags = append(pluginFlags, s)
 		return nil
 	})
@@ -3111,28 +3113,28 @@ func detectTool(cmd string) string {
 
 // handleUninstall removes agent-deck from the system
 func handleDebugDump() {
-	baseDir, err := session.GetAgentDeckDir()
+	cacheDir, err := ensureEffectiveCacheDir()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: cannot determine agent-deck dir: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error: cannot determine agent-deck cache dir: %v\n", err)
 		os.Exit(1)
 	}
 
 	// Initialize logging just enough to populate the ring buffer from the log file
 	logging.Init(logging.Config{
 		Debug:  true,
-		LogDir: baseDir,
+		LogDir: cacheDir,
 		Level:  "debug",
 	})
 	defer logging.Shutdown()
 
-	dumpPath := filepath.Join(baseDir, fmt.Sprintf("debug-dump-%d.jsonl", time.Now().Unix()))
+	dumpPath := filepath.Join(cacheDir, fmt.Sprintf("debug-dump-%d.jsonl", time.Now().Unix()))
 	if err := logging.DumpRingBuffer(dumpPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to dump ring buffer: %v\n", err)
 		os.Exit(1)
 	}
 
 	// Also check if the debug.log file exists and report its path
-	debugLogPath := filepath.Join(baseDir, "debug.log")
+	debugLogPath := filepath.Join(cacheDir, "debug.log")
 	if info, statErr := os.Stat(debugLogPath); statErr == nil {
 		fmt.Printf("Debug log: %s (%.1f MB)\n", debugLogPath, float64(info.Size())/(1024*1024))
 	}
@@ -3142,7 +3144,7 @@ func handleDebugDump() {
 
 func handleUninstall(args []string) {
 	fs := flag.NewFlagSet("uninstall", flag.ExitOnError)
-	keepData := fs.Bool("keep-data", false, "Keep ~/.agent-deck/ (sessions, config, logs)")
+	keepData := fs.Bool("keep-data", false, "Keep XDG config/data/cache locations and legacy ~/.agent-deck/")
 	keepTmuxConfig := fs.Bool("keep-tmux-config", false, "Keep tmux configuration")
 	dryRun := fs.Bool("dry-run", false, "Show what would be removed without removing")
 	yes := fs.Bool("y", false, "Skip confirmation prompts")
@@ -3154,7 +3156,7 @@ func handleUninstall(args []string) {
 		fmt.Println()
 		fmt.Println("Options:")
 		fmt.Println("  --dry-run           Show what would be removed without removing")
-		fmt.Println("  --keep-data         Keep ~/.agent-deck/ (sessions, config, logs)")
+		fmt.Println("  --keep-data         Keep XDG config/data/cache locations and legacy ~/.agent-deck/")
 		fmt.Println("  --keep-tmux-config  Keep tmux configuration")
 		fmt.Println("  -y                  Skip confirmation prompts")
 		fmt.Println()
@@ -3180,15 +3182,8 @@ func handleUninstall(args []string) {
 	}
 
 	homeDir, _ := os.UserHomeDir()
-	dataDir := filepath.Join(homeDir, ".agent-deck")
-
-	// Track what we find
-	type foundItem struct {
-		itemType    string
-		path        string
-		description string
-	}
-	var foundItems []foundItem
+	legacyDir := filepath.Join(homeDir, ".agent-deck")
+	var foundItems []uninstallFoundItem
 
 	// Check for Homebrew installation
 	homebrewInstalled := false
@@ -3196,7 +3191,7 @@ func handleUninstall(args []string) {
 		cmd := exec.Command("brew", "list", "agent-deck")
 		if cmd.Run() == nil {
 			homebrewInstalled = true
-			foundItems = append(foundItems, foundItem{"homebrew", "", "Homebrew package: agent-deck"})
+			foundItems = append(foundItems, uninstallFoundItem{"homebrew", "", "Homebrew package: agent-deck"})
 			fmt.Println("Found: Homebrew installation")
 		}
 	}
@@ -3218,70 +3213,23 @@ func handleUninstall(args []string) {
 			target, _ := os.Readlink(loc)
 			foundItems = append(
 				foundItems,
-				foundItem{"binary-symlink", loc, fmt.Sprintf("Binary (symlink) → %s", target)},
+				uninstallFoundItem{"binary-symlink", loc, fmt.Sprintf("Binary (symlink) → %s", target)},
 			)
 			fmt.Printf("Found: Binary (symlink) at %s\n", loc)
 			fmt.Printf("       → %s\n", target)
 		} else {
-			foundItems = append(foundItems, foundItem{"binary", loc, "Binary"})
+			foundItems = append(foundItems, uninstallFoundItem{"binary", loc, "Binary"})
 			fmt.Printf("Found: Binary at %s\n", loc)
 		}
 	}
 
-	// Check for data directory
-	if info, err := os.Stat(dataDir); err == nil && info.IsDir() {
-		// Count sessions and profiles
-		sessionCount := 0
-		profileCount := 0
-		profilesDir := filepath.Join(dataDir, "profiles")
-		if entries, err := os.ReadDir(profilesDir); err == nil {
-			for _, entry := range entries {
-				if entry.IsDir() {
-					// Check for state.db (SQLite, v0.11.0+) or sessions.json (legacy)
-					dbFile := filepath.Join(profilesDir, entry.Name(), "state.db")
-					jsonFile := filepath.Join(profilesDir, entry.Name(), "sessions.json")
-					if _, err := os.Stat(dbFile); err == nil {
-						profileCount++
-						if s, err := session.NewStorageWithProfile(entry.Name()); err == nil {
-							if instances, _, err := s.LoadWithGroups(); err == nil {
-								sessionCount += len(instances)
-							}
-						}
-					} else if data, err := os.ReadFile(jsonFile); err == nil {
-						profileCount++
-						sessionCount += strings.Count(string(data), `"id"`)
-					}
-				}
-			}
-		}
-
-		// Get total size
-		var totalSize int64
-		_ = filepath.Walk(dataDir, func(_ string, info os.FileInfo, err error) error {
-			if err == nil && !info.IsDir() {
-				totalSize += info.Size()
-			}
-			return nil
-		})
-		sizeStr := formatSize(totalSize)
-
-		foundItems = append(
-			foundItems,
-			foundItem{
-				"data",
-				dataDir,
-				fmt.Sprintf("%d profiles, %d sessions, %s", profileCount, sessionCount, sizeStr),
-			},
-		)
-		fmt.Printf("Found: Data directory at %s\n", dataDir)
-		fmt.Printf("       %d profiles, %d sessions, %s\n", profileCount, sessionCount, sizeStr)
-	}
+	foundItems = append(foundItems, collectUninstallDataLocations()...)
 
 	// Check for tmux config
 	tmuxConf := filepath.Join(homeDir, ".tmux.conf")
 	if data, err := os.ReadFile(tmuxConf); err == nil {
 		if strings.Contains(string(data), "# agent-deck configuration") {
-			foundItems = append(foundItems, foundItem{"tmux", tmuxConf, "tmux configuration block"})
+			foundItems = append(foundItems, uninstallFoundItem{"tmux", tmuxConf, "tmux configuration block"})
 			fmt.Println("Found: tmux configuration in ~/.tmux.conf")
 		}
 	}
@@ -3296,7 +3244,7 @@ func handleUninstall(args []string) {
 		for _, loc := range binaryLocations {
 			fmt.Printf("  - %s\n", loc)
 		}
-		fmt.Printf("  - %s\n", dataDir)
+		fmt.Printf("  - %s\n", legacyDir)
 		fmt.Printf("  - %s (for agent-deck config)\n", tmuxConf)
 		return
 	}
@@ -3311,12 +3259,31 @@ func handleUninstall(args []string) {
 			fmt.Println("  • Homebrew package: agent-deck")
 		case "binary", "binary-symlink":
 			fmt.Printf("  • Binary: %s\n", item.path)
+		case "config":
+			if *keepData {
+				fmt.Printf("  ○ Config directory: %s (keeping)\n", item.path)
+			} else {
+				fmt.Printf("  • Config directory: %s\n", item.path)
+			}
 		case "data":
 			if *keepData {
 				fmt.Printf("  ○ Data directory: %s (keeping)\n", item.path)
 			} else {
 				fmt.Printf("  • Data directory: %s\n", item.path)
-				fmt.Println("    Including: sessions, logs, config")
+				fmt.Println("    Including: sessions, logs, runtime state")
+			}
+		case "cache":
+			if *keepData {
+				fmt.Printf("  ○ Cache directory: %s (keeping)\n", item.path)
+			} else {
+				fmt.Printf("  • Cache directory: %s\n", item.path)
+			}
+		case "legacy":
+			if *keepData {
+				fmt.Printf("  ○ Legacy directory: %s (keeping)\n", item.path)
+			} else {
+				fmt.Printf("  • Legacy directory: %s\n", item.path)
+				fmt.Println("    Including: pre-XDG sessions, config, logs, cache")
 			}
 		case "tmux":
 			if *keepTmuxConfig {
@@ -3465,16 +3432,20 @@ func handleUninstall(args []string) {
 		}
 	}
 
-	// 4. Data directory
+	// 4. XDG and legacy data locations
 	if !*keepData {
+		offeredBackup := false
 		for _, item := range foundItems {
-			if item.itemType != "data" {
+			if !isUninstallDataLocation(item.itemType) {
 				continue
 			}
 
-			// Offer backup unless -y flag
-			if !*yes {
-				fmt.Print("Create backup of data before removing? [Y/n] ")
+			// Offer the legacy backup once unless -y flag. XDG locations are
+			// listed and removed below, but this tarball only archives
+			// ~/.agent-deck.
+			if !*yes && !offeredBackup {
+				offeredBackup = true
+				fmt.Print("Create backup of legacy ~/.agent-deck only before removing all listed data locations? [Y/n] ")
 				var response string
 				_, _ = fmt.Scanln(&response)
 				if strings.ToLower(response) != "n" {
@@ -3482,22 +3453,22 @@ func handleUninstall(args []string) {
 						homeDir,
 						fmt.Sprintf("agent-deck-backup-%s.tar.gz", time.Now().Format("20060102-150405")),
 					)
-					fmt.Printf("Creating backup at %s...\n", backupFile)
+					fmt.Printf("Creating legacy ~/.agent-deck backup at %s...\n", backupFile)
 
 					cmd := exec.Command("tar", "-czf", backupFile, "-C", homeDir, ".agent-deck")
 					if err := cmd.Run(); err != nil {
 						fmt.Printf("Warning: failed to create backup: %v\n", err)
 					} else {
-						fmt.Printf("✓ Backup created: %s\n", backupFile)
+						fmt.Printf("✓ Legacy backup created: %s\n", backupFile)
 					}
 				}
 			}
 
-			fmt.Println("Removing data directory...")
-			if err := os.RemoveAll(dataDir); err != nil {
-				fmt.Printf("Warning: failed to remove data directory: %v\n", err)
+			fmt.Printf("Removing %s...\n", item.path)
+			if err := removeUninstallLocation(item.path); err != nil {
+				fmt.Printf("Warning: failed to remove %s: %v\n", item.path, err)
 			} else {
-				fmt.Printf("✓ Data directory removed: %s\n", dataDir)
+				fmt.Printf("✓ Removed: %s\n", item.path)
 			}
 		}
 	}
@@ -3509,8 +3480,8 @@ func handleUninstall(args []string) {
 	fmt.Println()
 
 	if *keepData {
-		fmt.Printf("Note: Data directory preserved at %s\n", dataDir)
-		fmt.Println("      Remove manually with: rm -rf ~/.agent-deck")
+		fmt.Println("Note: XDG config/data/cache locations and legacy ~/.agent-deck/ were preserved.")
+		fmt.Println("      Remove them manually with trash after reviewing their contents.")
 	}
 
 	if *keepTmuxConfig {

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -114,6 +114,13 @@ func TestNestedSessionAllowsCLICommands(t *testing.T) {
 // guard warns and exits unless the user opts in via AGENT_DECK_ALLOW_OUTER_TMUX=1.
 func TestOuterTmuxGuard(t *testing.T) {
 	// Setup: snapshot env, restore on exit
+	fakeBin := t.TempDir()
+	fakeTmux := filepath.Join(fakeBin, "tmux")
+	if err := os.WriteFile(fakeTmux, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	origTmux := os.Getenv("TMUX")
 	origOptIn := os.Getenv("AGENT_DECK_ALLOW_OUTER_TMUX")
 	t.Cleanup(func() {

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -76,7 +76,7 @@ func TestNestedSessionAllowsCLICommands(t *testing.T) {
 		subcommands := []string{
 			"add", "list", "ls", "remove", "rm", "status",
 			"session", "mcp", "skill", "group", "try", "worktree", "wt",
-			"profile", "update", "mcp-proxy", "web", "uninstall", "hooks", "codex-hooks", "codex-notify", "gemini-hooks",
+			"profile", "update", "mcp-proxy", "web", "uninstall", "migrate-paths", "hooks", "codex-hooks", "codex-notify", "gemini-hooks",
 			"version", "--version", "-v",
 			"help", "--help", "-h",
 		}

--- a/cmd/agent-deck/mcp_cmd.go
+++ b/cmd/agent-deck/mcp_cmd.go
@@ -96,7 +96,8 @@ func handleMCPList(args []string) {
 		} else if !quietMode {
 			fmt.Println("No MCPs configured.")
 			fmt.Println()
-			fmt.Println("Define MCPs in ~/.agent-deck/config.toml:")
+			configPath, _ := session.GetUserConfigPath()
+			fmt.Printf("Define MCPs in %s:\n", FormatPath(configPath))
 			fmt.Println()
 			fmt.Println("  [mcps.exa]")
 			fmt.Println("  command = \"npx\"")

--- a/cmd/agent-deck/migrate_paths_cmd.go
+++ b/cmd/agent-deck/migrate_paths_cmd.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+)
+
+func handleMigratePaths(args []string) {
+	if code := runMigratePaths(args, os.Stdout, os.Stderr); code != 0 {
+		os.Exit(code)
+	}
+}
+
+func runMigratePaths(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("migrate-paths", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	dryRun := fs.Bool("dry-run", false, "Show what would be copied without writing files")
+	force := fs.Bool("force", false, "Overwrite existing XDG destination files")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: agent-deck migrate-paths [--dry-run] [--force]")
+		fmt.Fprintln(stderr)
+		fmt.Fprintln(stderr, "Copy legacy ~/.agent-deck files into the XDG config/data/cache layout.")
+		fmt.Fprintln(stderr, "The legacy directory is left untouched.")
+		fmt.Fprintln(stderr)
+		fmt.Fprintln(stderr, "Options:")
+		fmt.Fprintln(stderr, "  --dry-run  Show what would be copied without writing files")
+		fmt.Fprintln(stderr, "  --force    Overwrite existing XDG destination files")
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "unexpected argument: %s\n", fs.Arg(0))
+		fs.Usage()
+		return 2
+	}
+
+	legacyDir, err := agentpaths.LegacyDir()
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to resolve legacy directory: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintln(stdout, "Migrating legacy ~/.agent-deck paths to XDG layout")
+	result, err := agentpaths.MigrateLegacyLayout(agentpaths.MigrationOptions{
+		DryRun: *dryRun,
+		Force:  *force,
+	})
+	if result != nil {
+		printMigrationResult(stdout, result)
+	}
+	if err != nil {
+		if errors.Is(err, agentpaths.ErrMigrationConflict) {
+			fmt.Fprintln(stderr, "rerun with --force to overwrite destination files")
+		} else {
+			fmt.Fprintf(stderr, "migration failed: %v\n", err)
+		}
+		return 1
+	}
+	if result == nil || (len(result.Copied) == 0 && len(result.Skipped) == 0) {
+		fmt.Fprintln(stdout, "nothing to migrate")
+	}
+	fmt.Fprintf(stdout, "legacy directory left untouched: %s\n", legacyDir)
+	return 0
+}
+
+func printMigrationResult(stdout io.Writer, result *agentpaths.MigrationResult) {
+	action := "copied"
+	if result.DryRun {
+		action = "would copy"
+	}
+	for _, item := range result.Copied {
+		fmt.Fprintf(stdout, "%s %s %s -> %s\n", action, item.Category, item.Name, item.Destination)
+	}
+	for _, item := range result.Skipped {
+		fmt.Fprintf(stdout, "skipped %s %s\n", item.Category, item.Name)
+	}
+	for _, item := range result.Conflicts {
+		fmt.Fprintf(stdout, "conflict %s %s already exists at %s\n", item.Category, item.Name, item.Destination)
+	}
+}

--- a/cmd/agent-deck/migrate_paths_cmd.go
+++ b/cmd/agent-deck/migrate_paths_cmd.go
@@ -32,6 +32,9 @@ func runMigratePaths(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "  --force    Overwrite existing XDG destination files")
 	}
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		return 2
 	}
 	if fs.NArg() != 0 {

--- a/cmd/agent-deck/migrate_paths_cmd_test.go
+++ b/cmd/agent-deck/migrate_paths_cmd_test.go
@@ -82,3 +82,16 @@ func TestMigratePathsCommand_ConflictReportsForceHint(t *testing.T) {
 		t.Fatalf("conflict output missing force hint:\n%s", combined)
 	}
 }
+
+func TestMigratePathsCommand_HelpExitsSuccess(t *testing.T) {
+	setupMigratePathsCommandHome(t)
+
+	var stdout, stderr bytes.Buffer
+	code := runMigratePaths([]string{"--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runMigratePaths --help exit = %d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Usage: agent-deck migrate-paths") {
+		t.Fatalf("help output missing usage:\n%s", stderr.String())
+	}
+}

--- a/cmd/agent-deck/migrate_paths_cmd_test.go
+++ b/cmd/agent-deck/migrate_paths_cmd_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupMigratePathsCommandHome(t *testing.T) (home, legacy string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	legacy = filepath.Join(home, ".agent-deck")
+	return home, legacy
+}
+
+func TestMigratePathsCommand_DryRunReportsPlannedCopiesAndDoesNotCopy(t *testing.T) {
+	home, legacy := setupMigratePathsCommandHome(t)
+	if err := os.MkdirAll(filepath.Join(legacy, "profiles", "default"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.toml"), []byte("theme = \"dark\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "profiles", "default", "state.db"), []byte("db"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runMigratePaths([]string{"--dry-run"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runMigratePaths exit = %d\nstdout:\n%s\nstderr:\n%s", code, stdout.String(), stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Migrating legacy ~/.agent-deck paths to XDG layout",
+		"would copy config config.toml",
+		"would copy data profiles",
+		"legacy directory left untouched: " + legacy,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "agent-deck", "config.toml")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run should not create config destination, stat err=%v", err)
+	}
+}
+
+func TestMigratePathsCommand_ConflictReportsForceHint(t *testing.T) {
+	home, legacy := setupMigratePathsCommandHome(t)
+	legacyConfig := filepath.Join(legacy, "config.toml")
+	xdgConfig := filepath.Join(home, ".config", "agent-deck", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(legacyConfig), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(xdgConfig), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyConfig, []byte("legacy\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(xdgConfig, []byte("existing\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runMigratePaths(nil, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected conflict exit\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	combined := stdout.String() + stderr.String()
+	if !strings.Contains(combined, "conflict config config.toml already exists at "+xdgConfig) {
+		t.Fatalf("conflict output missing destination:\n%s", combined)
+	}
+	if !strings.Contains(combined, "rerun with --force to overwrite destination files") {
+		t.Fatalf("conflict output missing force hint:\n%s", combined)
+	}
+}

--- a/cmd/agent-deck/plugin_cli.go
+++ b/cmd/agent-deck/plugin_cli.go
@@ -27,9 +27,9 @@ func validatePluginFlags(names []string) error {
 			available := session.GetAvailablePluginNames()
 			sort.Strings(available)
 			if len(available) == 0 {
-				return fmt.Errorf("--plugin %q: catalog is empty. Add a [plugins.%s] table to ~/.agent-deck/config.toml", raw, name)
+				return fmt.Errorf("--plugin %q: catalog is empty. Add a [plugins.%s] table to %s", raw, name, effectiveUserConfigPathForHelp())
 			}
-			return fmt.Errorf("--plugin %q: not in catalog. Available: %s. Add new entries via [plugins.<name>] in ~/.agent-deck/config.toml", raw, strings.Join(available, ", "))
+			return fmt.Errorf("--plugin %q: not in catalog. Available: %s. Add new entries via [plugins.<name>] in %s", raw, strings.Join(available, ", "), effectiveUserConfigPathForHelp())
 		}
 	}
 	return nil

--- a/cmd/agent-deck/plugin_cmd.go
+++ b/cmd/agent-deck/plugin_cmd.go
@@ -39,13 +39,14 @@ func handlePlugin(profile string, args []string) {
 }
 
 func printPluginHelp() {
+	configPath := effectiveUserConfigPathForHelp()
 	fmt.Println("Usage: agent-deck plugin <command> [options]")
 	fmt.Println()
 	fmt.Println("Manage Claude Code plugins (per-session enabledPlugins) for sessions.")
 	fmt.Println("RFC: docs/rfc/PLUGIN_ATTACH.md")
 	fmt.Println()
 	fmt.Println("Commands:")
-	fmt.Println("  list                   List available plugins from [plugins.<name>] in ~/.agent-deck/config.toml")
+	fmt.Printf("  list                   List available plugins from [plugins.<name>] in %s\n", configPath)
 	fmt.Println("  attached [id]          Show plugins enabled on a session")
 	fmt.Println("  attach <id> <name>     Enable a catalog plugin on a session")
 	fmt.Println("  detach <id> <name>     Disable a catalog plugin on a session")
@@ -89,7 +90,7 @@ func handlePluginList(args []string) {
 	}
 
 	if len(names) == 0 {
-		fmt.Println("No plugins configured. Add [plugins.<name>] tables to ~/.agent-deck/config.toml")
+		fmt.Printf("No plugins configured. Add [plugins.<name>] tables to %s\n", effectiveUserConfigPathForHelp())
 		fmt.Println("RFC: docs/rfc/PLUGIN_ATTACH.md §4.1")
 		return
 	}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1293,7 +1293,7 @@ func handleSessionSet(profile string, args []string) {
 		fmt.Println("  tool               Tool type (claude, gemini, shell, etc.)")
 		fmt.Println("  wrapper            Wrapper command (use {command} to include tool command)")
 		fmt.Println("  channels           Comma-separated plugin channel ids (claude only)")
-		fmt.Println("  plugins            Comma-separated plugin catalog names (claude only) — see [plugins.<name>] in ~/.agent-deck/config.toml")
+		fmt.Printf("  plugins            Comma-separated plugin catalog names (claude only) — see [plugins.<name>] in %s\n", effectiveUserConfigPathForHelp())
 		fmt.Println("  extra-args         Extra claude CLI tokens (claude only; use `-- --flag value` for tokens starting with -; persisted plaintext — no secrets)")
 		fmt.Println("  color              Optional TUI row tint: '#RRGGBB' or ANSI '0'..'255' or '' (issue #391)")
 		fmt.Println("  claude-session-id  Claude conversation ID")

--- a/cmd/agent-deck/testmain_test.go
+++ b/cmd/agent-deck/testmain_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,6 +17,9 @@ func TestMain(m *testing.M) {
 	// Git hooks export GIT_DIR/GIT_WORK_TREE; clear them so test subprocess git
 	// commands operate on their temp repos instead of the real repository.
 	testutil.UnsetGitRepoEnv()
+	if os.Getenv("AGENT_DECK_TASK6_HELPER_PROCESS") == "" {
+		isolatePackageHome("agent-deck-cmd-tests-home-*")
+	}
 
 	// Isolate the tmux socket. Without this, cmd-level tests spawn tmux
 	// sessions on the user's default socket and destabilize live agent-deck
@@ -37,6 +41,17 @@ func TestMain(m *testing.M) {
 	cleanupTestSessions()
 
 	os.Exit(code)
+}
+
+func isolatePackageHome(pattern string) {
+	home, err := os.MkdirTemp("", pattern)
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("HOME", home)
+	os.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	os.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	os.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
 }
 
 // cleanupTestSessions kills any tmux sessions created during testing.

--- a/cmd/agent-deck/try_cmd.go
+++ b/cmd/agent-deck/try_cmd.go
@@ -43,7 +43,7 @@ func handleTry(profile string, args []string) {
 		fmt.Println("  agent-deck try myproject -c gemini  # Use Gemini instead of Claude")
 		fmt.Println("  agent-deck try myproject --no-session  # Just create folder")
 		fmt.Println()
-		fmt.Println("Config (~/.agent-deck/config.toml):")
+		fmt.Printf("Config (%s):\n", effectiveUserConfigPathForHelp())
 		fmt.Println("  [experiments]")
 		fmt.Println("  directory = \"~/src/tries\"    # Base directory for experiments")
 		fmt.Println("  date_prefix = true           # Add YYYY-MM-DD- prefix")

--- a/cmd/agent-deck/uninstall_paths.go
+++ b/cmd/agent-deck/uninstall_paths.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+)
+
+type uninstallFoundItem struct {
+	itemType    string
+	path        string
+	description string
+}
+
+func collectUninstallDataLocations() []uninstallFoundItem {
+	type candidate struct {
+		itemType string
+		label    string
+		path     string
+	}
+
+	var candidates []candidate
+	if path, err := agentpaths.ConfigDir(); err == nil {
+		candidates = append(candidates, candidate{itemType: "config", label: "Config directory", path: path})
+	}
+	if path, err := agentpaths.DataDir(); err == nil {
+		candidates = append(candidates, candidate{itemType: "data", label: "Data directory", path: path})
+	}
+	if path, err := agentpaths.CacheDir(); err == nil {
+		candidates = append(candidates, candidate{itemType: "cache", label: "Cache directory", path: path})
+	}
+	if path, err := agentpaths.LegacyDir(); err == nil {
+		candidates = append(candidates, candidate{itemType: "legacy", label: "Legacy directory", path: path})
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	items := make([]uninstallFoundItem, 0, len(candidates))
+	for _, c := range candidates {
+		cleanPath := filepath.Clean(c.path)
+		if _, ok := seen[cleanPath]; ok {
+			continue
+		}
+		seen[cleanPath] = struct{}{}
+
+		info, err := os.Lstat(cleanPath)
+		if err != nil {
+			continue
+		}
+		desc := describeUninstallLocation(cleanPath, info)
+		items = append(items, uninstallFoundItem{
+			itemType:    c.itemType,
+			path:        cleanPath,
+			description: desc,
+		})
+		fmt.Printf("Found: %s at %s\n", c.label, cleanPath)
+		if desc != "" {
+			fmt.Printf("       %s\n", desc)
+		}
+	}
+	return items
+}
+
+func describeUninstallLocation(path string, info os.FileInfo) string {
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(path)
+		if err != nil {
+			return "symlink"
+		}
+		return fmt.Sprintf("symlink -> %s", target)
+	}
+
+	sessionCount := 0
+	profileCount := 0
+	profilesDir := filepath.Join(path, "profiles")
+	if entries, err := os.ReadDir(profilesDir); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			dbFile := filepath.Join(profilesDir, entry.Name(), "state.db")
+			jsonFile := filepath.Join(profilesDir, entry.Name(), "sessions.json")
+			if _, err := os.Stat(dbFile); err == nil {
+				profileCount++
+			} else if data, err := os.ReadFile(jsonFile); err == nil {
+				profileCount++
+				sessionCount += strings.Count(string(data), `"id"`)
+			}
+		}
+	}
+
+	var totalSize int64
+	_ = filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() {
+			totalSize += info.Size()
+		}
+		return nil
+	})
+
+	if profileCount > 0 || sessionCount > 0 {
+		return fmt.Sprintf("%d profiles, %d sessions, %s", profileCount, sessionCount, formatSize(totalSize))
+	}
+	return formatSize(totalSize)
+}
+
+func isUninstallDataLocation(itemType string) bool {
+	return itemType == "config" || itemType == "data" || itemType == "cache" || itemType == "legacy"
+}
+
+func removeUninstallLocation(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return os.Remove(path)
+	}
+	return os.RemoveAll(path)
+}

--- a/cmd/agent-deck/version_nudge_test.go
+++ b/cmd/agent-deck/version_nudge_test.go
@@ -16,11 +16,7 @@ import (
 // than exporting internals.
 func writeTestCache(t *testing.T, cache *update.UpdateCache) error {
 	t.Helper()
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-	dir := filepath.Join(home, ".agent-deck")
+	dir := filepath.Join(os.Getenv("XDG_CACHE_HOME"), "agent-deck")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
@@ -31,14 +27,20 @@ func writeTestCache(t *testing.T, cache *update.UpdateCache) error {
 	return os.WriteFile(filepath.Join(dir, update.CacheFileName), data, 0o644)
 }
 
+func isolateVersionUpdatePaths(t *testing.T) {
+	t.Helper()
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(tmpHome, "xdg-cache"))
+}
+
 // Conductor task #45 — `agent-deck --version` should append
 // "(update available: vX.Y.Z)" when the disk cache shows the user is
 // behind. The annotation must be cache-only (no network hit — --version
 // should stay instant).
 
 func TestVersionOutput_AppendsUpdateAnnotationWhenBehind(t *testing.T) {
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	isolateVersionUpdatePaths(t)
 
 	// Seed a cache entry claiming 1.7.20 is well behind 1.7.58.
 	cache := &update.UpdateCache{
@@ -62,8 +64,7 @@ func TestVersionOutput_AppendsUpdateAnnotationWhenBehind(t *testing.T) {
 }
 
 func TestVersionOutput_NoAnnotationWhenUpToDate(t *testing.T) {
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	isolateVersionUpdatePaths(t)
 
 	cache := &update.UpdateCache{
 		CheckedAt:      time.Now(),
@@ -88,8 +89,7 @@ func TestVersionOutput_NoAnnotationWhenUpToDate(t *testing.T) {
 func TestVersionOutput_NoAnnotationWhenNoCache(t *testing.T) {
 	// Fresh install: no cache file yet. --version must still print
 	// cleanly — we never hit the network on --version.
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	isolateVersionUpdatePaths(t)
 
 	var buf bytes.Buffer
 	writeVersionOutput(&buf, "1.7.20")
@@ -104,8 +104,7 @@ func TestVersionOutput_NoAnnotationWhenNoCache(t *testing.T) {
 func TestVersionOutput_NoAnnotationWhenEnvSkipped(t *testing.T) {
 	// AGENTDECK_SKIP_UPDATE_CHECK must strip the annotation too — some
 	// users export this to silence all update nagging.
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	isolateVersionUpdatePaths(t)
 	t.Setenv("AGENTDECK_SKIP_UPDATE_CHECK", "1")
 
 	cache := &update.UpdateCache{

--- a/cmd/agent-deck/watcher_cmd.go
+++ b/cmd/agent-deck/watcher_cmd.go
@@ -305,8 +305,8 @@ func readSecretFile(path string) (string, error) {
 }
 
 // writeGithubWatcherSecret writes the HMAC secret into the [source] table of
-// ~/.agent-deck/watcher/<name>/watcher.toml at 0600 — the location the runtime
-// engine loads it from (internal/ui/home.go loadWatcherSourceSettings). Written
+// the effective watcher/<name>/watcher.toml at 0600, which is the location the
+// runtime engine loads it from (internal/ui/home.go loadWatcherSourceSettings). Written
 // atomically (temp + rename). Port is stored as a TOML string so it decodes into
 // the engine's map[string]string Settings. Audit M2.
 func writeGithubWatcherSecret(dir, secret string, port int) error {
@@ -647,7 +647,7 @@ func handleWatcherTest(profile string, args []string) {
 	router, err := watcher.LoadFromWatcherDir()
 	if err != nil {
 		fmt.Printf("Routing config: not available (%v)\n", err)
-		fmt.Println("  Create ~/.agent-deck/watcher/clients.json to enable routing.")
+		fmt.Printf("  Create %s to enable routing.\n", watcherClientsPathForDisplay())
 		return
 	}
 
@@ -942,7 +942,8 @@ func printWatcherHelp() {
 	fmt.Println("  test <name>                   Route a synthetic event to verify routing config")
 	fmt.Println("  routes [--json]               Show all routing rules from clients.json")
 	fmt.Println("  import <path>                 Migrate bash issue-watcher channels.json to Go watcher config")
-	fmt.Println("  install-skill <skill-name>    Install a skill to ~/.agent-deck/skills/pool/ (e.g. watcher-creator)")
+	skillPoolPath, _ := session.GetSkillPoolPath()
+	fmt.Printf("  install-skill <skill-name>    Install a skill to %s (e.g. watcher-creator)\n", FormatPath(skillPoolPath))
 	fmt.Println()
 	fmt.Println("Examples (one per adapter type):")
 	fmt.Println()
@@ -965,7 +966,7 @@ func printWatcherHelp() {
 	fmt.Println("  agent-deck watcher list              # see health + events/hour")
 	fmt.Println("  agent-deck watcher test <name>       # fire a synthetic event")
 	fmt.Println()
-	fmt.Println("Routing: edit ~/.agent-deck/watcher/<name>/clients.json to pick which")
+	fmt.Printf("Routing: edit %s to pick which\n", watcherClientsPathForDisplay())
 	fmt.Println("conductor / group receives events. See `agent-deck watcher routes` for")
 	fmt.Println("the currently-loaded rules across all watchers.")
 	fmt.Println()
@@ -975,4 +976,12 @@ func printWatcherHelp() {
 	fmt.Println("  # \"Use the watcher-creator skill to set up a GitHub watcher\"")
 	fmt.Println()
 	fmt.Println("Full reference: https://github.com/asheshgoplani/agent-deck#watchers")
+}
+
+func watcherClientsPathForDisplay() string {
+	watcherDir, err := session.WatcherDir()
+	if err != nil {
+		return "${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher/clients.json"
+	}
+	return FormatPath(filepath.Join(watcherDir, "clients.json"))
 }

--- a/cmd/agent-deck/watcher_cmd.go
+++ b/cmd/agent-deck/watcher_cmd.go
@@ -942,8 +942,12 @@ func printWatcherHelp() {
 	fmt.Println("  test <name>                   Route a synthetic event to verify routing config")
 	fmt.Println("  routes [--json]               Show all routing rules from clients.json")
 	fmt.Println("  import <path>                 Migrate bash issue-watcher channels.json to Go watcher config")
-	skillPoolPath, _ := session.GetSkillPoolPath()
-	fmt.Printf("  install-skill <skill-name>    Install a skill to %s (e.g. watcher-creator)\n", FormatPath(skillPoolPath))
+	skillPoolPath, err := session.GetSkillPoolPath()
+	displaySkillPoolPath := "${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/skills/pool"
+	if err == nil {
+		displaySkillPoolPath = FormatPath(skillPoolPath)
+	}
+	fmt.Printf("  install-skill <skill-name>    Install a skill to %s (e.g. watcher-creator)\n", displaySkillPoolPath)
 	fmt.Println()
 	fmt.Println("Examples (one per adapter type):")
 	fmt.Println()

--- a/cmd/agent-deck/watcher_cmd_skills.go
+++ b/cmd/agent-deck/watcher_cmd_skills.go
@@ -6,6 +6,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 // watcherCreatorSkillFS holds the embedded watcher-creator skill files.
@@ -23,7 +25,7 @@ var supportedSkills = map[string]struct{}{
 }
 
 // handleWatcherInstallSkill copies an embedded skill to
-// $HOME/.agent-deck/skills/pool/<skill-name>/.
+// the configured Agent Deck skill pool.
 //
 // Security:
 //   - skill name must be in supportedSkills whitelist (string equality, no regex).
@@ -41,12 +43,12 @@ func handleWatcherInstallSkill(_ string, args []string) error {
 		return fmt.Errorf("unsupported skill %q: only %v are available in this release", skillName, keys(supportedSkills))
 	}
 
-	homeDir, err := os.UserHomeDir()
+	poolDir, err := session.GetSkillPoolPath()
 	if err != nil {
-		return fmt.Errorf("resolve home dir: %w", err)
+		return fmt.Errorf("resolve skill pool path: %w", err)
 	}
 
-	targetDir := filepath.Join(homeDir, ".agent-deck", "skills", "pool", skillName)
+	targetDir := filepath.Join(poolDir, skillName)
 
 	// Create the full directory hierarchy with mode 0o700 (T-18-21).
 	// MkdirAll is used for each step so that each segment gets the correct
@@ -54,8 +56,8 @@ func handleWatcherInstallSkill(_ string, args []string) error {
 	// given permission for newly created directories only — existing dirs are
 	// left untouched, which is the desired behaviour.
 	for _, dir := range []string{
-		filepath.Join(homeDir, ".agent-deck", "skills"),
-		filepath.Join(homeDir, ".agent-deck", "skills", "pool"),
+		filepath.Dir(poolDir),
+		poolDir,
 		targetDir,
 	} {
 		if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/cmd/agent-deck/watcher_cmd_test.go
+++ b/cmd/agent-deck/watcher_cmd_test.go
@@ -440,16 +440,19 @@ func TestWatcherCreatorSkill_DocsMatchesAssets(t *testing.T) {
 }
 
 // TestWatcherInstallSkill verifies that handleWatcherInstallSkill copies both
-// SKILL.md and README.md to $HOME/.agent-deck/skills/pool/watcher-creator/.
+// SKILL.md and README.md to the XDG config skill pool.
 func TestWatcherInstallSkill(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	home := filepath.Join(tmp, "home")
+	xdgConfigHome := filepath.Join(tmp, "xdg-config")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
 
 	if err := handleWatcherInstallSkill("default", []string{"watcher-creator"}); err != nil {
 		t.Fatalf("handleWatcherInstallSkill: %v", err)
 	}
 
-	poolDir := filepath.Join(tmp, ".agent-deck", "skills", "pool", "watcher-creator")
+	poolDir := filepath.Join(xdgConfigHome, "agent-deck", "skills", "pool", "watcher-creator")
 
 	// Both files should exist in pool dir.
 	for _, f := range []string{"SKILL.md", "README.md"} {
@@ -478,16 +481,19 @@ func TestWatcherInstallSkill(t *testing.T) {
 // directory hierarchy with mode 0o700 (T-18-21).
 func TestWatcherInstallSkill_DirMode(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	home := filepath.Join(tmp, "home")
+	xdgConfigHome := filepath.Join(tmp, "xdg-config")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
 
 	if err := handleWatcherInstallSkill("default", []string{"watcher-creator"}); err != nil {
 		t.Fatalf("handleWatcherInstallSkill: %v", err)
 	}
 
 	dirs := []string{
-		filepath.Join(tmp, ".agent-deck", "skills"),
-		filepath.Join(tmp, ".agent-deck", "skills", "pool"),
-		filepath.Join(tmp, ".agent-deck", "skills", "pool", "watcher-creator"),
+		filepath.Join(xdgConfigHome, "agent-deck", "skills"),
+		filepath.Join(xdgConfigHome, "agent-deck", "skills", "pool"),
+		filepath.Join(xdgConfigHome, "agent-deck", "skills", "pool", "watcher-creator"),
 	}
 	for _, d := range dirs {
 		info, err := os.Stat(d)
@@ -501,7 +507,7 @@ func TestWatcherInstallSkill_DirMode(t *testing.T) {
 	}
 
 	// Installed files should be readable (0o644).
-	poolDir := filepath.Join(tmp, ".agent-deck", "skills", "pool", "watcher-creator")
+	poolDir := filepath.Join(xdgConfigHome, "agent-deck", "skills", "pool", "watcher-creator")
 	for _, f := range []string{"SKILL.md", "README.md"} {
 		info, err := os.Stat(filepath.Join(poolDir, f))
 		if err != nil {

--- a/cmd/agent-deck/xdg_paths.go
+++ b/cmd/agent-deck/xdg_paths.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func effectiveUserConfigPathForHelp() string {
+	path, err := session.GetUserConfigPath()
+	if err != nil {
+		return "config.toml"
+	}
+	return path
+}
+
+func effectiveCacheDir() (string, error) {
+	return agentpaths.CacheDir()
+}
+
+func ensureEffectiveCacheDir() (string, error) {
+	dir, err := effectiveCacheDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func effectiveCachePath(name string) (string, error) {
+	return agentpaths.CachePath(name)
+}

--- a/cmd/agent-deck/xdg_task6_test.go
+++ b/cmd/agent-deck/xdg_task6_test.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func setupTask6XDGEnv(t *testing.T) (home, xdgConfigHome, xdgDataHome, xdgCacheHome string) {
+	t.Helper()
+
+	root := t.TempDir()
+	home = filepath.Join(root, "home")
+	xdgConfigHome = filepath.Join(root, "xdg-config")
+	xdgDataHome = filepath.Join(root, "xdg-data")
+	xdgCacheHome = filepath.Join(root, "xdg-cache")
+
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	pathDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(pathDir, 0o755); err != nil {
+		t.Fatalf("mkdir path dir: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	t.Setenv("XDG_CACHE_HOME", xdgCacheHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("PATH", pathDir)
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	return home, xdgConfigHome, xdgDataHome, xdgCacheHome
+}
+
+func captureStdoutForTask6(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return buf.String()
+}
+
+func TestXDGTask6_HookStatusUsesXDGDataAndLegacyFallback(t *testing.T) {
+	home, _, xdgDataHome, _ := setupTask6XDGEnv(t)
+
+	wantXDG := filepath.Join(xdgDataHome, "agent-deck", "hooks")
+	if got := getHooksDir(); got != wantXDG {
+		t.Fatalf("getHooksDir() = %q, want %q", got, wantXDG)
+	}
+
+	writeHookStatus("xdg-hook", "waiting", "sess-xdg", "SessionStart")
+	if _, err := os.Stat(filepath.Join(wantXDG, "xdg-hook.json")); err != nil {
+		t.Fatalf("status file should be written under XDG data: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".agent-deck", "hooks", "xdg-hook.json")); !os.IsNotExist(err) {
+		t.Fatalf("status file should not be written under legacy hooks for new XDG user, stat err=%v", err)
+	}
+
+	legacyHooks := filepath.Join(home, ".agent-deck", "hooks")
+	if err := os.MkdirAll(legacyHooks, 0o700); err != nil {
+		t.Fatalf("mkdir legacy hooks: %v", err)
+	}
+	if got := getHooksDir(); got != wantXDG {
+		t.Fatalf("XDG hooks should continue to win after XDG marker exists: got %q want %q", got, wantXDG)
+	}
+}
+
+func TestXDGTask6_HookStatusUsesLegacyHooksWhenOnlyLegacyExists(t *testing.T) {
+	home, _, _, _ := setupTask6XDGEnv(t)
+	legacyHooks := filepath.Join(home, ".agent-deck", "hooks")
+	if err := os.MkdirAll(legacyHooks, 0o700); err != nil {
+		t.Fatalf("mkdir legacy hooks: %v", err)
+	}
+
+	if got := getHooksDir(); got != legacyHooks {
+		t.Fatalf("getHooksDir() = %q, want legacy %q", got, legacyHooks)
+	}
+}
+
+func TestXDGTask6_CostEventsUseXDGDataAndLegacyFallback(t *testing.T) {
+	home, _, _, _ := setupTask6XDGEnv(t)
+	legacyCostEvents := filepath.Join(home, ".agent-deck", "cost-events")
+	if err := os.MkdirAll(legacyCostEvents, 0o700); err != nil {
+		t.Fatalf("mkdir legacy cost-events: %v", err)
+	}
+
+	if got := getCostEventsDir(); got != legacyCostEvents {
+		t.Fatalf("getCostEventsDir() = %q, want legacy %q", got, legacyCostEvents)
+	}
+
+	_, _, xdgDataHome, _ := setupTask6XDGEnv(t)
+	wantXDG := filepath.Join(xdgDataHome, "agent-deck", "cost-events")
+	if got := getCostEventsDir(); got != wantXDG {
+		t.Fatalf("getCostEventsDir() = %q, want XDG %q", got, wantXDG)
+	}
+}
+
+func TestXDGTask6_CostDebugUsesXDGCache(t *testing.T) {
+	home, _, _, xdgCacheHome := setupTask6XDGEnv(t)
+	t.Setenv("AGENTDECK_DEBUG", "1")
+	legacyPath := filepath.Join(home, ".agent-deck", "cost-debug.log")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o700); err != nil {
+		t.Fatalf("mkdir legacy cache debug dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("legacy\n"), 0o600); err != nil {
+		t.Fatalf("write legacy cost debug log: %v", err)
+	}
+
+	logCostDebug("cache path probe")
+
+	want := filepath.Join(xdgCacheHome, "agent-deck", "cost-debug.log")
+	data, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("cost debug log should be written under XDG cache: %v", err)
+	}
+	if !strings.Contains(string(data), "cache path probe") {
+		t.Fatalf("cost debug log missing message, got %q", string(data))
+	}
+	legacyData, err := os.ReadFile(legacyPath)
+	if err != nil {
+		t.Fatalf("read legacy cost debug log: %v", err)
+	}
+	if strings.Contains(string(legacyData), "cache path probe") {
+		t.Fatalf("cost debug should not append to legacy cache log, got %q", string(legacyData))
+	}
+}
+
+func TestXDGTask6_PricingCacheUsesXDGCacheDespiteLegacyFile(t *testing.T) {
+	home, _, _, xdgCacheHome := setupTask6XDGEnv(t)
+	legacyPath := filepath.Join(home, ".agent-deck", "pricing.json")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o700); err != nil {
+		t.Fatalf("mkdir legacy pricing cache dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write legacy pricing cache: %v", err)
+	}
+
+	got, err := effectiveCacheDir()
+	if err != nil {
+		t.Fatalf("effectiveCacheDir: %v", err)
+	}
+	want := filepath.Join(xdgCacheHome, "agent-deck")
+	if got != want {
+		t.Fatalf("pricing cache dir = %q, want XDG cache dir %q", got, want)
+	}
+	if filepath.Join(got, "pricing.json") == legacyPath {
+		t.Fatalf("pricing cache should not use legacy file %q", legacyPath)
+	}
+}
+
+func TestXDGTask6_DebugDumpUsesXDGCacheDespiteLegacyLog(t *testing.T) {
+	home, _, _, xdgCacheHome := setupTask6XDGEnv(t)
+	legacyPath := filepath.Join(home, ".agent-deck", "debug.log")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o700); err != nil {
+		t.Fatalf("mkdir legacy debug dir: %v", err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("legacy\n"), 0o600); err != nil {
+		t.Fatalf("write legacy debug log: %v", err)
+	}
+
+	got, err := effectiveCacheDir()
+	if err != nil {
+		t.Fatalf("effectiveCacheDir: %v", err)
+	}
+	want := filepath.Join(xdgCacheHome, "agent-deck")
+	if got != want {
+		t.Fatalf("debug cache dir = %q, want %q", got, want)
+	}
+	if filepath.Join(got, "debug.log") == legacyPath {
+		t.Fatalf("debug log should not use legacy path %q", legacyPath)
+	}
+	if filepath.Dir(filepath.Join(got, "debug-dump-123.jsonl")) != want {
+		t.Fatalf("debug dump should be written under %q", want)
+	}
+	if filepath.Dir(filepath.Join(got, "crash-dump-123.jsonl")) != want {
+		t.Fatalf("crash dump should be written under %q", want)
+	}
+}
+
+func TestXDGTask6_DebugDumpCommandWritesToXDGCache(t *testing.T) {
+	_, _, _, xdgCacheHome := setupTask6XDGEnv(t)
+
+	out := captureStdoutForTask6(t, handleDebugDump)
+	wantDir := filepath.Join(xdgCacheHome, "agent-deck")
+	if !strings.Contains(out, wantDir) {
+		t.Fatalf("debug-dump output should mention XDG cache dir %q, got:\n%s", wantDir, out)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(wantDir, "debug-dump-*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob debug dumps: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatalf("expected debug dump under %s", wantDir)
+	}
+}
+
+func TestXDGTask6_WatcherInstallSkillUsesConfiguredPoolPath(t *testing.T) {
+	_, xdgConfigHome, _, _ := setupTask6XDGEnv(t)
+
+	if err := handleWatcherInstallSkill("default", []string{"watcher-creator"}); err != nil {
+		t.Fatalf("handleWatcherInstallSkill: %v", err)
+	}
+
+	want := filepath.Join(xdgConfigHome, "agent-deck", "skills", "pool", "watcher-creator", "SKILL.md")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("watcher skill should be installed under configured pool path: %v", err)
+	}
+}
+
+func TestXDGTask6_PluginHelpAndErrorsUseEffectiveConfigPath(t *testing.T) {
+	_, xdgConfigHome, _, _ := setupTask6XDGEnv(t)
+	wantConfig := filepath.Join(xdgConfigHome, "agent-deck", "config.toml")
+
+	helpOut := captureStdoutForTask6(t, printPluginHelp)
+	if !strings.Contains(helpOut, wantConfig) {
+		t.Fatalf("plugin help should mention effective config path %q, got:\n%s", wantConfig, helpOut)
+	}
+	if strings.Contains(helpOut, "~/.agent-deck/config.toml") {
+		t.Fatalf("plugin help should not hard-code legacy config path, got:\n%s", helpOut)
+	}
+
+	err := validatePluginFlags([]string{"octopus"})
+	if err == nil {
+		t.Fatal("expected empty catalog error")
+	}
+	if !strings.Contains(err.Error(), wantConfig) {
+		t.Fatalf("plugin empty catalog error should mention %q, got %v", wantConfig, err)
+	}
+}
+
+func TestXDGTask6_TryAndSessionHelpUseEffectiveConfigPath(t *testing.T) {
+	_, xdgConfigHome, _, _ := setupTask6XDGEnv(t)
+	wantConfig := filepath.Join(xdgConfigHome, "agent-deck", "config.toml")
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "try", args: []string{"try-help"}},
+		{name: "session set", args: []string{"session-set-help"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := runTask6HelperProcess(t, tc.args...)
+			if !strings.Contains(out, wantConfig) {
+				t.Fatalf("%s help should mention effective config path %q, got:\n%s", tc.name, wantConfig, out)
+			}
+			if strings.Contains(out, "~/.agent-deck/config.toml") {
+				t.Fatalf("%s help should not hard-code legacy config path, got:\n%s", tc.name, out)
+			}
+		})
+	}
+}
+
+func runTask6HelperProcess(t *testing.T, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], append([]string{"-test.run=TestXDGTask6HelperProcess", "--"}, args...)...)
+	cmd.Env = append(os.Environ(), "AGENT_DECK_TASK6_HELPER_PROCESS=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper process failed: %v\n%s", err, string(out))
+	}
+	return string(out)
+}
+
+func TestXDGTask6HelperProcess(t *testing.T) {
+	if os.Getenv("AGENT_DECK_TASK6_HELPER_PROCESS") != "1" {
+		return
+	}
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) > 0 {
+		args = args[1:]
+	}
+	if len(args) != 1 {
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "try-help":
+		handleTry("default", []string{"--help"})
+	case "session-set-help":
+		handleSessionSet("default", []string{"--help"})
+	default:
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func TestXDGTask6_UninstallDryRunListsExistingXDGAndLegacyLocations(t *testing.T) {
+	home, xdgConfigHome, xdgDataHome, xdgCacheHome := setupTask6XDGEnv(t)
+	for _, dir := range []string{
+		filepath.Join(xdgConfigHome, "agent-deck"),
+		filepath.Join(xdgDataHome, "agent-deck"),
+		filepath.Join(xdgCacheHome, "agent-deck"),
+		filepath.Join(home, ".agent-deck"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	out := captureStdoutForTask6(t, func() {
+		handleUninstall([]string{"--dry-run", "--keep-tmux-config"})
+	})
+
+	for _, want := range []string{
+		"Config directory",
+		filepath.Join(xdgConfigHome, "agent-deck"),
+		"Data directory",
+		filepath.Join(xdgDataHome, "agent-deck"),
+		"Cache directory",
+		filepath.Join(xdgCacheHome, "agent-deck"),
+		"Legacy directory",
+		filepath.Join(home, ".agent-deck"),
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestXDGTask6_UninstallKeepDataPreservesAllLocations(t *testing.T) {
+	home, xdgConfigHome, xdgDataHome, xdgCacheHome := setupTask6XDGEnv(t)
+	locations := []string{
+		filepath.Join(xdgConfigHome, "agent-deck"),
+		filepath.Join(xdgDataHome, "agent-deck"),
+		filepath.Join(xdgCacheHome, "agent-deck"),
+		filepath.Join(home, ".agent-deck"),
+	}
+	for _, dir := range locations {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	_ = captureStdoutForTask6(t, func() {
+		handleUninstall([]string{"-y", "--keep-data", "--keep-tmux-config"})
+	})
+
+	for _, dir := range locations {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("--keep-data should preserve %s: %v", dir, err)
+		}
+	}
+}
+
+func TestXDGTask6_UninstallRemovesXDGAndLegacyLocations(t *testing.T) {
+	home, xdgConfigHome, xdgDataHome, xdgCacheHome := setupTask6XDGEnv(t)
+	locations := []string{
+		filepath.Join(xdgConfigHome, "agent-deck"),
+		filepath.Join(xdgDataHome, "agent-deck"),
+		filepath.Join(xdgCacheHome, "agent-deck"),
+		filepath.Join(home, ".agent-deck"),
+	}
+	for _, dir := range locations {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	_ = captureStdoutForTask6(t, func() {
+		handleUninstall([]string{"-y", "--keep-tmux-config"})
+	})
+
+	for _, dir := range locations {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Fatalf("uninstall should remove %s, stat err=%v", dir, err)
+		}
+	}
+}
+
+func TestXDGTask6_UninstallRemovesXDGCacheSymlinkWithoutFollowingEscape(t *testing.T) {
+	home, _, _, xdgCacheHome := setupTask6XDGEnv(t)
+
+	if err := os.MkdirAll(filepath.Join(home, ".agent-deck"), 0o700); err != nil {
+		t.Fatalf("mkdir legacy dir: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside-cache")
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	marker := filepath.Join(outside, "marker.txt")
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	cacheLink := filepath.Join(xdgCacheHome, "agent-deck")
+	if err := os.MkdirAll(filepath.Dir(cacheLink), 0o700); err != nil {
+		t.Fatalf("mkdir xdg cache home: %v", err)
+	}
+	if err := os.Symlink(outside, cacheLink); err != nil {
+		t.Fatalf("symlink cache: %v", err)
+	}
+
+	_ = captureStdoutForTask6(t, func() {
+		handleUninstall([]string{"-y", "--keep-tmux-config"})
+	})
+
+	if _, err := os.Lstat(cacheLink); !os.IsNotExist(err) {
+		t.Fatalf("cache symlink should be removed without following target, lstat err=%v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("symlink target marker should remain: %v", err)
+	}
+}

--- a/docs/CONDUCTOR-SETUP.md
+++ b/docs/CONDUCTOR-SETUP.md
@@ -134,15 +134,16 @@ Conductor setup complete!
 Next steps:
   agent-deck -p personal session start conductor-work
   Test from Telegram: send /status to your bot
-  View bridge logs:   tail -f ~/.agent-deck/conductor/bridge.log
+  View bridge logs:   tail -f ~/.local/share/agent-deck/conductor/bridge.log
 ```
 
 That single command:
 
-- Created `~/.agent-deck/conductor/<name>/` with `CLAUDE.md`, `POLICY.md`,
-  `LEARNINGS.md`, `meta.json`, `state.json`, `task-log.md`.
-- Stored the Telegram token in `~/.agent-deck/conductor/<name>/.env`
-  (chmod 600). **Never commit this file.**
+- Created `$XDG_DATA_HOME/agent-deck/conductor/<name>/` (default
+  `~/.local/share/agent-deck/conductor/<name>/`) with `CLAUDE.md`,
+  `POLICY.md`, `LEARNINGS.md`, `meta.json`, `state.json`, `task-log.md`.
+- Stored the Telegram token in the conductor `.env` file (chmod 600).
+  **Never commit this file.**
 - Registered a session called `conductor-<name>` in the profile's
   agent-deck database.
 - Installed a heartbeat daemon (launchd on macOS, systemd on Linux) that
@@ -262,12 +263,13 @@ pgrep -af "bun.*telegram" | wc -l
 ### 2. "My token disappears across session restarts"
 
 The token is in `<conductor-dir>/.env`. agent-deck loads it via `env_file`
-in `~/.agent-deck/config.toml`:
+in `$XDG_CONFIG_HOME/agent-deck/config.toml` (default
+`~/.config/agent-deck/config.toml`):
 
 ```toml
 [conductors.work.claude]
 config_dir = "~/.claude"
-env_file = "~/.agent-deck/conductor/work/.env"
+env_file = "~/.local/share/agent-deck/conductor/work/.env"
 ```
 
 If you renamed or moved the conductor dir, this block points at the wrong
@@ -360,7 +362,8 @@ multiplexes across N bots.
 
 ## After setup: making the conductor smarter
 
-Two files in `~/.agent-deck/conductor/<name>/` are worth knowing:
+Two files in `$XDG_DATA_HOME/agent-deck/conductor/<name>/` (default
+`~/.local/share/agent-deck/conductor/<name>/`) are worth knowing:
 
 - **`POLICY.md`** — rules for what the conductor should auto-answer vs
   escalate. The starting template includes "if a worker asks whether to
@@ -400,7 +403,7 @@ agent-deck conductor move <name> --to-profile <other>
 agent-deck session start conductor-<name>
 agent-deck session restart conductor-<name>
 agent-deck session output conductor-<name> -q
-tail -f ~/.agent-deck/conductor/bridge.log
+tail -f ~/.local/share/agent-deck/conductor/bridge.log
 ```
 
 If anything in this guide didn't work for you, please open an issue — the

--- a/docs/WATCHER-SETUP.md
+++ b/docs/WATCHER-SETUP.md
@@ -107,7 +107,7 @@ Four adapter types ship in the box:
 ### Example: a GitHub watcher in three commands
 
 ```bash
-# 1. Create the watcher (writes $XDG_DATA_HOME/agent-deck/watcher/gh-alerts/ on new installs).
+# 1. Create the watcher (writes ${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher/gh-alerts/ on new installs).
 agent-deck watcher create github --name gh-alerts \
   --secret "$GITHUB_WEBHOOK_SECRET"
 
@@ -161,7 +161,7 @@ agent-deck watcher create slack --name team-slack --topic <random-long-string>
 ## Routing: telling the watcher which conductor to ring
 
 Watcher routing rules live in the effective watcher data dir
-(`$XDG_DATA_HOME/agent-deck/watcher/clients.json` for new users, or legacy
+(`${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher/clients.json` for new users, or legacy
 `~/.agent-deck/watcher/clients.json` when existing watcher state is present):
 
 ```json

--- a/docs/WATCHER-SETUP.md
+++ b/docs/WATCHER-SETUP.md
@@ -107,7 +107,7 @@ Four adapter types ship in the box:
 ### Example: a GitHub watcher in three commands
 
 ```bash
-# 1. Create the watcher (writes ~/.agent-deck/watcher/gh-alerts/).
+# 1. Create the watcher (writes $XDG_DATA_HOME/agent-deck/watcher/gh-alerts/ on new installs).
 agent-deck watcher create github --name gh-alerts \
   --secret "$GITHUB_WEBHOOK_SECRET"
 
@@ -160,8 +160,9 @@ agent-deck watcher create slack --name team-slack --topic <random-long-string>
 
 ## Routing: telling the watcher which conductor to ring
 
-Every watcher writes its routing rules to
-`~/.agent-deck/watcher/<name>/clients.json`:
+Watcher routing rules live in the effective watcher data dir
+(`$XDG_DATA_HOME/agent-deck/watcher/clients.json` for new users, or legacy
+`~/.agent-deck/watcher/clients.json` when existing watcher state is present):
 
 ```json
 {
@@ -253,11 +254,10 @@ credentials. They are the canonical examples of the polling pattern:
   conductor pre-loads the docs / attendees / Slack channel for the
   meeting and hands you the briefing on Telegram.
 
-The full identities live in `~/.agent-deck/watcher/gmail-watcher/` and
-`~/.agent-deck/watcher/meeting-watcher/` on the maintainer's machine —
-copy the layout (`meta.json`, `state.json`, `task-log.md`,
-`LEARNINGS.md`), substitute your own credentials, point at your own
-conductor.
+The full identities live under the maintainer's effective watcher data dir
+(`watcher/gmail-watcher/` and `watcher/meeting-watcher/`) — copy the layout
+(`meta.json`, `state.json`, `task-log.md`, `LEARNINGS.md`), substitute your own
+credentials, point at your own conductor.
 
 ---
 
@@ -304,7 +304,7 @@ wedges too. Cascading failure. Always use `--no-wait` in a polling loop.
 ### 4. "ntfy topic leaked into a public config"
 
 ntfy has no auth beyond topic-secrecy. Keep topic names in
-`~/.agent-deck/watcher/<name>/watcher.toml` or env vars — never in
+`<effective watcher data dir>/<name>/watcher.toml` or env vars — never in
 tracked files.
 
 ### 5. "GitHub watcher silently drops events"

--- a/docs/superpowers/plans/2026-06-04-xdg-base-dirs.md
+++ b/docs/superpowers/plans/2026-06-04-xdg-base-dirs.md
@@ -1,0 +1,1038 @@
+# XDG Base Dirs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #1272 so new installs respect the XDG Base Directory layout while existing `~/.agent-deck` users keep working until they explicitly migrate.
+
+**Architecture:** Add a small import-safe `internal/agentpaths` package for XDG and legacy path resolution, then route `session`, `tmux`, `feedback`, `update`, watcher, and CLI call sites through it. New installs use XDG paths; existing users continue reading legacy paths when the relevant XDG path does not exist. `agent-deck migrate-paths` copies legacy files into the split XDG layout and never deletes the original.
+
+**Tech Stack:** Go 1.25.11, standard library `os`/`filepath`/`io/fs`, existing `flag` CLI style, existing Go test suites.
+
+---
+
+## Design Decisions
+
+- Config files live under `$XDG_CONFIG_HOME/agent-deck`, or `~/.config/agent-deck` when `XDG_CONFIG_HOME` is unset.
+- Durable application state lives under `$XDG_DATA_HOME/agent-deck`, or `~/.local/share/agent-deck` when `XDG_DATA_HOME` is unset.
+- Cache/debug/update/pricing files live under `$XDG_CACHE_HOME/agent-deck`, or `~/.cache/agent-deck` when `XDG_CACHE_HOME` is unset.
+- `profiles/` is state, not config, because profile directories contain `state.db` session history.
+- Existing users keep working through legacy fallback. If the XDG target for a category is absent and `~/.agent-deck` contains that category's legacy markers, the resolver returns the legacy path.
+- New users with no legacy markers write to XDG paths immediately.
+- Migration is opt-in only. Startup may log a one-line hint, but it must not copy, move, or delete user files automatically.
+- Keep `~/.agent-deck` strings in user-facing migration/help text where they refer to legacy paths. Remove direct production path construction that builds `HOME/.agent-deck`.
+
+## Target Mapping
+
+| Legacy item | New category | New path |
+|---|---|---|
+| `config.toml` | config | `$XDG_CONFIG_HOME/agent-deck/config.toml` |
+| `config.json` | config | `$XDG_CONFIG_HOME/agent-deck/config.json` |
+| `skills/` | config | `$XDG_CONFIG_HOME/agent-deck/skills/` |
+| `profiles/` | data | `$XDG_DATA_HOME/agent-deck/profiles/` |
+| `sessions.json*` legacy profile files | data | `$XDG_DATA_HOME/agent-deck/sessions.json*` before existing profile migration runs |
+| `hooks/` | data | `$XDG_DATA_HOME/agent-deck/hooks/` |
+| `locks/` | data | `$XDG_DATA_HOME/agent-deck/locks/` |
+| `cost-events/` | data | `$XDG_DATA_HOME/agent-deck/cost-events/` |
+| `events/` | data | `$XDG_DATA_HOME/agent-deck/events/` |
+| `runtime/` | data | `$XDG_DATA_HOME/agent-deck/runtime/` |
+| `inboxes/` | data | `$XDG_DATA_HOME/agent-deck/inboxes/` |
+| `conductor/` | data | `$XDG_DATA_HOME/agent-deck/conductor/` |
+| `watcher/`, `watchers/`, `triage/` | data | `$XDG_DATA_HOME/agent-deck/...` |
+| `logs/` session and transition logs | data | `$XDG_DATA_HOME/agent-deck/logs/` |
+| `feedback-state.json` | data | `$XDG_DATA_HOME/agent-deck/feedback-state.json` |
+| `ack-signal`, `badge-updates/` | data | `$XDG_DATA_HOME/agent-deck/...` |
+| `debug.log`, `cost-debug.log` | cache | `$XDG_CACHE_HOME/agent-deck/...` |
+| `update-cache.json`, `pricing.json` | cache | `$XDG_CACHE_HOME/agent-deck/...` |
+| `debug-dump-*.jsonl`, `crash-dump-*.jsonl` | cache | `$XDG_CACHE_HOME/agent-deck/...` |
+
+## Files
+
+- Create: `internal/agentpaths/paths.go` - XDG/legacy path resolver.
+- Create: `internal/agentpaths/paths_test.go` - resolver unit tests.
+- Create: `internal/agentpaths/migrate.go` - migration planning and copy implementation.
+- Create: `internal/agentpaths/migrate_test.go` - migration tests.
+- Modify: `internal/session/config.go` - wrap config/data path APIs and legacy profile migration.
+- Modify: `internal/session/userconfig.go` - load/save user config through config path API.
+- Modify: `internal/session/{hook_watcher,event_writer,inbox,inbox_consumer,inbox_stophook,transition_notifier,session_id_event_log,maintenance,plugin_install,skills_catalog,taskworker,worker_scratch,watcher_meta,conductor,instance_spawn_guard,idle_timeout_watcher}.go` - route runtime/data paths through the data API.
+- Modify: `internal/tmux/{tmux,badge_update}.go` - route logs, ack-signal, and badge update files through `internal/agentpaths`.
+- Modify: `internal/feedback/state.go` - route feedback state through the data API.
+- Modify: `internal/update/update.go` - route update cache through the cache API.
+- Modify: `cmd/agent-deck/{main,hook_handler,watcher_cmd_skills,plugin_cmd,plugin_cli,try_cmd,session_cmd}.go` - route CLI paths and update help strings.
+- Modify: `internal/watcher/{engine,layout}.go` - route watcher default dirs through session/agentpaths APIs.
+- Modify: selected tests under `internal/session`, `internal/tmux`, `internal/feedback`, `internal/update`, `cmd/agent-deck`, `internal/watcher`, and `tests/eval/session` that seed `~/.agent-deck`.
+- Modify: `README.md`, `CHANGELOG.md`, and watcher embedded docs only where user-facing default path text changes.
+
+---
+
+### Task 1: Add Core Path Resolver Tests
+
+**Files:**
+- Create: `internal/agentpaths/paths_test.go`
+- Create: `internal/agentpaths/paths.go`
+
+- [ ] **Step 1: Create a compiling stub package**
+
+Create `internal/agentpaths/paths.go` with only the public surface used by the tests:
+
+```go
+package agentpaths
+
+import "fmt"
+
+const AppDirName = "agent-deck"
+
+func LegacyDir() (string, error) { return "", fmt.Errorf("not implemented") }
+func ConfigDir() (string, error) { return "", fmt.Errorf("not implemented") }
+func DataDir() (string, error) { return "", fmt.Errorf("not implemented") }
+func CacheDir() (string, error) { return "", fmt.Errorf("not implemented") }
+func EffectiveConfigPath(name string) (string, error) { return "", fmt.Errorf("not implemented") }
+func EffectiveDataDir(markers ...string) (string, error) { return "", fmt.Errorf("not implemented") }
+```
+
+- [ ] **Step 2: Write failing XDG default and env override tests**
+
+Create `internal/agentpaths/paths_test.go` with these tests:
+
+```go
+package agentpaths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	return home
+}
+
+func TestXDGDirs_DefaultToHomeFallbacks(t *testing.T) {
+	home := isolateHome(t)
+	wantConfig := filepath.Join(home, ".config", "agent-deck")
+	wantData := filepath.Join(home, ".local", "share", "agent-deck")
+	wantCache := filepath.Join(home, ".cache", "agent-deck")
+
+	if got, _ := ConfigDir(); got != wantConfig {
+		t.Fatalf("ConfigDir() = %q, want %q", got, wantConfig)
+	}
+	if got, _ := DataDir(); got != wantData {
+		t.Fatalf("DataDir() = %q, want %q", got, wantData)
+	}
+	if got, _ := CacheDir(); got != wantCache {
+		t.Fatalf("CacheDir() = %q, want %q", got, wantCache)
+	}
+}
+
+func TestXDGDirs_EnvOverrides(t *testing.T) {
+	home := isolateHome(t)
+	cfg := filepath.Join(home, "xdg-config")
+	data := filepath.Join(home, "xdg-data")
+	cache := filepath.Join(home, "xdg-cache")
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	t.Setenv("XDG_DATA_HOME", data)
+	t.Setenv("XDG_CACHE_HOME", cache)
+
+	if got, _ := ConfigDir(); got != filepath.Join(cfg, "agent-deck") {
+		t.Fatalf("ConfigDir() = %q", got)
+	}
+	if got, _ := DataDir(); got != filepath.Join(data, "agent-deck") {
+		t.Fatalf("DataDir() = %q", got)
+	}
+	if got, _ := CacheDir(); got != filepath.Join(cache, "agent-deck") {
+		t.Fatalf("CacheDir() = %q", got)
+	}
+}
+
+func TestEffectiveConfigPath_LegacyWinsOnlyWhenXDGFileMissing(t *testing.T) {
+	home := isolateHome(t)
+	legacy := filepath.Join(home, ".agent-deck")
+	xdg := filepath.Join(home, ".config", "agent-deck")
+	if err := os.MkdirAll(legacy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.toml"), []byte("theme = \"dark\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := EffectiveConfigPath("config.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Join(legacy, "config.toml") {
+		t.Fatalf("legacy fallback path = %q", got)
+	}
+
+	if err := os.MkdirAll(xdg, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(xdg, "config.toml"), []byte("theme = \"light\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err = EffectiveConfigPath("config.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != filepath.Join(xdg, "config.toml") {
+		t.Fatalf("xdg path = %q", got)
+	}
+}
+
+func TestEffectiveDataDir_LegacyWinsOnlyWhenXDGDataMissing(t *testing.T) {
+	home := isolateHome(t)
+	legacy := filepath.Join(home, ".agent-deck")
+	xdg := filepath.Join(home, ".local", "share", "agent-deck")
+	if err := os.MkdirAll(filepath.Join(legacy, "profiles", "default"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := EffectiveDataDir("profiles")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != legacy {
+		t.Fatalf("legacy data fallback = %q, want %q", got, legacy)
+	}
+
+	if err := os.MkdirAll(filepath.Join(xdg, "profiles"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	got, err = EffectiveDataDir("profiles")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != xdg {
+		t.Fatalf("xdg data path = %q, want %q", got, xdg)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests and verify they fail**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./internal/agentpaths -run 'TestXDGDirs|TestEffective' -count=1
+```
+
+Expected: tests fail with `not implemented`.
+
+### Task 2: Implement `internal/agentpaths`
+
+**Files:**
+- Modify: `internal/agentpaths/paths.go`
+- Test: `internal/agentpaths/paths_test.go`
+
+- [ ] **Step 1: Implement path resolution**
+
+Replace the stub with an implementation matching this API:
+
+```go
+package agentpaths
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const AppDirName = "agent-deck"
+
+func homeDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home dir: %w", err)
+	}
+	return home, nil
+}
+
+func LegacyDir() (string, error) {
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".agent-deck"), nil
+}
+
+func xdgDir(envName string, fallbackParts ...string) (string, error) {
+	if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
+		return filepath.Join(v, AppDirName), nil
+	}
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+	parts := append([]string{home}, fallbackParts...)
+	parts = append(parts, AppDirName)
+	return filepath.Join(parts...), nil
+}
+
+func ConfigDir() (string, error) {
+	return xdgDir("XDG_CONFIG_HOME", ".config")
+}
+
+func DataDir() (string, error) {
+	return xdgDir("XDG_DATA_HOME", ".local", "share")
+}
+
+func CacheDir() (string, error) {
+	return xdgDir("XDG_CACHE_HOME", ".cache")
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func EffectiveConfigPath(name string) (string, error) {
+	cfg, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	xdgPath := filepath.Join(cfg, filepath.Base(name))
+	if exists(xdgPath) {
+		return xdgPath, nil
+	}
+	legacy, err := LegacyDir()
+	if err != nil {
+		return "", err
+	}
+	legacyPath := filepath.Join(legacy, filepath.Base(name))
+	if exists(legacyPath) {
+		return legacyPath, nil
+	}
+	return xdgPath, nil
+}
+
+func EffectiveDataDir(markers ...string) (string, error) {
+	data, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	if exists(data) {
+		return data, nil
+	}
+	legacy, err := LegacyDir()
+	if err != nil {
+		return "", err
+	}
+	for _, marker := range markers {
+		if marker == "" {
+			continue
+		}
+		if exists(filepath.Join(legacy, marker)) {
+			return legacy, nil
+		}
+	}
+	return data, nil
+}
+
+func EffectiveDataPath(name string, markers ...string) (string, error) {
+	dir, err := EffectiveDataDir(markers...)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, filepath.Clean(name)), nil
+}
+
+func CachePath(name string) (string, error) {
+	dir, err := CacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, filepath.Clean(name)), nil
+}
+```
+
+- [ ] **Step 2: Run resolver tests**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./internal/agentpaths -count=1
+```
+
+Expected: `ok github.com/asheshgoplani/agent-deck/internal/agentpaths`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/agentpaths/paths.go internal/agentpaths/paths_test.go
+git commit -m "feat(paths): add XDG base directory resolver"
+```
+
+### Task 3: Route Session Config and Profile Storage
+
+**Files:**
+- Modify: `internal/session/config.go`
+- Modify: `internal/session/userconfig.go`
+- Modify: `internal/session/config_test.go`
+- Modify: `internal/session/userconfig_test.go`
+- Modify: `internal/session/storage_test.go`
+
+- [ ] **Step 1: Add failing session path tests**
+
+Add tests that assert:
+
+```go
+func TestGetUserConfigPath_UsesXDGConfigHome(t *testing.T) {
+	home := t.TempDir()
+	xdg := filepath.Join(home, "cfg")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	got, err := session.GetUserConfigPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(xdg, "agent-deck", "config.toml")
+	if got != want {
+		t.Fatalf("GetUserConfigPath() = %q, want %q", got, want)
+	}
+}
+```
+
+Add a storage test with `NewStorageWithProfile("default")` and assert `storage.Path()` is under `$XDG_DATA_HOME/agent-deck/profiles/default/state.db`.
+
+- [ ] **Step 2: Verify tests fail**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./internal/session -run 'TestGetUserConfigPath_UsesXDGConfigHome|TestNewStorageWithProfile_UsesXDGDataHome' -count=1
+```
+
+Expected: tests fail because current code returns `HOME/.agent-deck`.
+
+- [ ] **Step 3: Implement session wrappers**
+
+Update `internal/session/config.go` to import `internal/agentpaths` and define:
+
+```go
+func GetAgentDeckDir() (string, error) {
+	return agentpaths.EffectiveDataDir(
+		ProfilesDirName,
+		"sessions.json",
+		"hooks",
+		"events",
+		"inboxes",
+		"conductor",
+		"watcher",
+	)
+}
+
+func GetConfigPath() (string, error) {
+	return agentpaths.EffectiveConfigPath(ConfigFileName)
+}
+
+func GetProfilesDir() (string, error) {
+	dir, err := agentpaths.EffectiveDataDir(ProfilesDirName, "sessions.json")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ProfilesDirName), nil
+}
+```
+
+Update `internal/session/userconfig.go`:
+
+```go
+func GetUserConfigPath() (string, error) {
+	return agentpaths.EffectiveConfigPath(UserConfigFileName)
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./internal/session -run 'TestGetUserConfigPath|TestUserConfig|TestNewStorageWithProfile|TestPersistence_' -count=1
+```
+
+Expected: focused session tests pass, except any known pre-existing `TestPersistence_CustomCommandResumesFromLatestJSONL` failure should be reported separately and not hidden.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/session/config.go internal/session/userconfig.go internal/session/*_test.go
+git commit -m "feat(session): route config and profile storage through XDG paths"
+```
+
+### Task 4: Route Runtime and Durable State Paths
+
+**Files:**
+- Modify: `internal/session/hook_watcher.go`
+- Modify: `internal/session/event_writer.go`
+- Modify: `internal/session/inbox.go`
+- Modify: `internal/session/inbox_consumer.go`
+- Modify: `internal/session/inbox_stophook.go`
+- Modify: `internal/session/transition_notifier.go`
+- Modify: `internal/session/session_id_event_log.go`
+- Modify: `internal/session/maintenance.go`
+- Modify: `internal/session/plugin_install.go`
+- Modify: `internal/session/skills_catalog.go`
+- Modify: `internal/session/taskworker.go`
+- Modify: `internal/session/worker_scratch.go`
+- Modify: `internal/session/watcher_meta.go`
+- Modify: `internal/session/conductor.go`
+- Modify: `internal/session/instance_spawn_guard.go`
+- Modify: `internal/session/idle_timeout_watcher.go`
+- Modify: corresponding tests in `internal/session`
+
+- [ ] **Step 1: Add failing focused path tests**
+
+Add tests for representative public path functions:
+
+```go
+func TestRuntimeStateDirs_UseXDGDataHome(t *testing.T) {
+	home := t.TempDir()
+	data := filepath.Join(home, "data")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", data)
+
+	if got := GetHooksDir(); got != filepath.Join(data, "agent-deck", "hooks") {
+		t.Fatalf("GetHooksDir() = %q", got)
+	}
+	if got := GetEventsDir(); got != filepath.Join(data, "agent-deck", "events") {
+		t.Fatalf("GetEventsDir() = %q", got)
+	}
+	if got := InboxDir(); got != filepath.Join(data, "agent-deck", "inboxes") {
+		t.Fatalf("InboxDir() = %q", got)
+	}
+}
+```
+
+Add `WatcherDir` and `ConductorDir` assertions in their existing test files.
+
+- [ ] **Step 2: Implement path helpers for state subdirectories**
+
+Use `agentpaths.EffectiveDataPath` or a small session wrapper:
+
+```go
+func dataSubdir(name string, legacyMarkers ...string) string {
+	p, err := agentpaths.EffectiveDataPath(name, append([]string{name}, legacyMarkers...)...)
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".agent-deck", name)
+	}
+	return p
+}
+```
+
+Route existing functions:
+
+```go
+func GetHooksDir() string { return dataSubdir("hooks") }
+func GetEventsDir() string { return dataSubdir("events") }
+func InboxDir() string { return dataSubdir("inboxes") }
+func WatcherDir() (string, error) { return agentpaths.EffectiveDataPath("watcher", "watcher", "watchers") }
+```
+
+- [ ] **Step 3: Run focused state tests**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./internal/session ./internal/watcher -run 'HooksDir|EventsDir|InboxDir|WatcherDir|ConductorDir|Transition|Maintenance|SpawnLock' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/session internal/watcher
+git commit -m "feat(paths): route runtime state through XDG data dir"
+```
+
+### Task 5: Route Independent Packages Without Import Cycles
+
+**Files:**
+- Modify: `internal/tmux/tmux.go`
+- Modify: `internal/tmux/badge_update.go`
+- Modify: `internal/feedback/state.go`
+- Modify: `internal/update/update.go`
+- Modify: tests in `internal/tmux`, `internal/feedback`, `internal/update`
+
+- [ ] **Step 1: Add package-specific failing tests**
+
+Add or update tests for:
+
+```go
+func TestFeedbackStatePath_UsesXDGDataHome(t *testing.T) {
+	home := t.TempDir()
+	data := filepath.Join(home, "data")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", data)
+	st := &feedback.State{FeedbackEnabled: true, MaxShows: 3}
+	if err := feedback.SaveState(st); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(data, "agent-deck", "feedback-state.json")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("state not written to XDG data path %s: %v", want, err)
+	}
+}
+```
+
+Add `internal/tmux` assertions that `LogDir()`, `GetAckSignalPath()`, and `BadgeUpdatesDir()` use `$XDG_DATA_HOME/agent-deck/...`.
+
+Add `internal/update` assertions that cache reads and writes use `$XDG_CACHE_HOME/agent-deck/update-cache.json`.
+
+- [ ] **Step 2: Implement imports through `internal/agentpaths`**
+
+Use `internal/agentpaths` directly in these packages. Do not import `internal/session` into `internal/tmux` or `internal/feedback`.
+
+Examples:
+
+```go
+func LogDir() string {
+	path, err := agentpaths.EffectiveDataPath("logs", "logs")
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".agent-deck", "logs")
+	}
+	return path
+}
+```
+
+```go
+func statePath() (string, error) {
+	return agentpaths.EffectiveDataPath("feedback-state.json", "feedback-state.json")
+}
+```
+
+```go
+func getCacheDir() (string, error) {
+	return agentpaths.CacheDir()
+}
+```
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./internal/tmux ./internal/feedback ./internal/update -run 'XDG|StatePath|LogDir|AckSignal|Badge|Cache' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/tmux internal/feedback internal/update
+git commit -m "feat(paths): route tmux feedback and update paths through XDG"
+```
+
+### Task 6: Route CLI Entrypoints and Hook Handler
+
+**Files:**
+- Modify: `cmd/agent-deck/main.go`
+- Modify: `cmd/agent-deck/hook_handler.go`
+- Modify: `cmd/agent-deck/watcher_cmd_skills.go`
+- Modify: `cmd/agent-deck/plugin_cmd.go`
+- Modify: `cmd/agent-deck/plugin_cli.go`
+- Modify: `cmd/agent-deck/try_cmd.go`
+- Modify: `cmd/agent-deck/session_cmd.go`
+- Modify: corresponding tests in `cmd/agent-deck`
+
+- [ ] **Step 1: Add failing CLI path tests**
+
+Add tests that run the binary helper with isolated `HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_CACHE_HOME`:
+
+```go
+func TestCLI_ReadsXDGConfigForTmuxSocket(t *testing.T) {
+	home := t.TempDir()
+	cfg := filepath.Join(home, "cfg")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	configDir := filepath.Join(cfg, "agent-deck")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("[tmux]\nsocket_name = \"agentdeck\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := session.GetTmuxSettings().SocketName
+	if got != "agentdeck" {
+		t.Fatalf("socket_name = %q, want agentdeck", got)
+	}
+}
+```
+
+Add hook handler tests for `getHooksDir()` and `getCostEventsDir()` using XDG data.
+
+- [ ] **Step 2: Replace direct CLI path construction**
+
+Update:
+
+```go
+cacheDir, _ := agentpaths.CacheDir()
+costEventsDir, _ := agentpaths.EffectiveDataPath("cost-events", "cost-events")
+debugDir, _ := agentpaths.CacheDir()
+```
+
+Use config path display helpers for user-facing text:
+
+```go
+func displayUserConfigPath() string {
+	p, err := session.GetUserConfigPath()
+	if err != nil {
+		return "$XDG_CONFIG_HOME/agent-deck/config.toml"
+	}
+	return p
+}
+```
+
+- [ ] **Step 3: Keep uninstall explicit**
+
+Update `handleUninstall` so `--keep-data` describes and preserves all three XDG locations plus legacy. Dry-run should list every existing location:
+
+```text
+Config: <xdg config dir>
+Data: <xdg data dir>
+Cache: <xdg cache dir>
+Legacy: ~/.agent-deck
+```
+
+When deleting, delete only paths that exist and are not symlinks escaping the user's home. Keep the existing confirmation flow.
+
+- [ ] **Step 4: Run CLI tests**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./cmd/agent-deck -run 'XDG|HookHandler|Uninstall|Plugin|Try|SessionFork|Config' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/agent-deck
+git commit -m "feat(cli): use XDG paths in commands and hook handlers"
+```
+
+### Task 7: Add `agent-deck migrate-paths`
+
+**Files:**
+- Create: `internal/agentpaths/migrate.go`
+- Create: `internal/agentpaths/migrate_test.go`
+- Modify: `cmd/agent-deck/main.go`
+- Create: `cmd/agent-deck/migrate_paths_cmd_test.go`
+
+- [ ] **Step 1: Add failing migration library tests**
+
+Tests should cover:
+
+```go
+func TestMigrateLegacyLayout_CopiesSplitCategories(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	legacy := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(filepath.Join(legacy, "profiles", "default"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.toml"), []byte("theme = \"dark\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "profiles", "default", "state.db"), []byte("db"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "update-cache.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := MigrateLegacyLayout(MigrationOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Copied) == 0 {
+		t.Fatal("expected copied items")
+	}
+	assertFileExists(t, filepath.Join(home, ".config", "agent-deck", "config.toml"))
+	assertFileExists(t, filepath.Join(home, ".local", "share", "agent-deck", "profiles", "default", "state.db"))
+	assertFileExists(t, filepath.Join(home, ".cache", "agent-deck", "update-cache.json"))
+	assertFileExists(t, filepath.Join(legacy, "config.toml"))
+}
+```
+
+Add a conflict test where the XDG destination already exists and `Force` is false. Expected: return a conflict error and leave both files unchanged.
+
+- [ ] **Step 2: Implement migration library**
+
+Use these public types:
+
+```go
+type PathCategory string
+
+const (
+	CategoryConfig PathCategory = "config"
+	CategoryData   PathCategory = "data"
+	CategoryCache  PathCategory = "cache"
+)
+
+type MigrationOptions struct {
+	DryRun bool
+	Force  bool
+}
+
+type MigrationItem struct {
+	Name        string
+	Category    PathCategory
+	Source      string
+	Destination string
+	Directory   bool
+}
+
+type MigrationResult struct {
+	DryRun    bool
+	Copied    []MigrationItem
+	Skipped   []MigrationItem
+	Conflicts []MigrationItem
+}
+```
+
+Implement `MigrateLegacyLayout(opts MigrationOptions) (*MigrationResult, error)` using copy-only semantics:
+
+- Create destination parent dirs with `0o700`.
+- Copy files with source mode preserved where possible.
+- Copy directories recursively.
+- Refuse destination overwrite unless `opts.Force` is true.
+- Do not delete, rename, or mutate `~/.agent-deck`.
+
+- [ ] **Step 3: Add CLI command**
+
+Add `migrate-paths` to `cmd/agent-deck/main.go` command dispatch and help:
+
+```text
+agent-deck migrate-paths [--dry-run] [--force]
+```
+
+Output format:
+
+```text
+Migrating legacy ~/.agent-deck paths to XDG layout
+copied config config.toml -> /.../.config/agent-deck/config.toml
+copied data profiles -> /.../.local/share/agent-deck/profiles
+copied cache update-cache.json -> /.../.cache/agent-deck/update-cache.json
+legacy directory left untouched: /.../.agent-deck
+```
+
+For conflicts:
+
+```text
+conflict config config.toml already exists at /.../.config/agent-deck/config.toml
+rerun with --force to overwrite destination files
+```
+
+- [ ] **Step 4: Run migration tests**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./internal/agentpaths ./cmd/agent-deck -run 'MigrateLegacyLayout|migrate-paths|MigratePaths' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/agentpaths cmd/agent-deck/main.go cmd/agent-deck/migrate_paths_cmd_test.go
+git commit -m "feat(paths): add explicit XDG migration command"
+```
+
+### Task 8: Update User-Facing Text, Docs, and Scripts
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Modify: `cmd/agent-deck/plugin_cmd.go`
+- Modify: `cmd/agent-deck/plugin_cli.go`
+- Modify: `cmd/agent-deck/try_cmd.go`
+- Modify: `cmd/agent-deck/session_cmd.go`
+- Modify: `internal/ui/settings_panel.go`
+- Modify: `internal/ui/mcp_dialog.go`
+- Modify: `internal/ui/plugin_dialog.go`
+- Modify: `internal/ui/skill_dialog.go`
+- Modify: scripts that seed config under `$HOME/.agent-deck`
+- Modify: eval/capability tests that seed config under `$HOME/.agent-deck`
+
+- [ ] **Step 1: Update visible path strings**
+
+Replace static path text like:
+
+```text
+~/.agent-deck/config.toml
+```
+
+with:
+
+```text
+$XDG_CONFIG_HOME/agent-deck/config.toml
+```
+
+When space allows, include the fallback:
+
+```text
+$XDG_CONFIG_HOME/agent-deck/config.toml (default ~/.config/agent-deck/config.toml)
+```
+
+Keep legacy text only when describing migration or backward compatibility.
+
+- [ ] **Step 2: Update test harness config seeds**
+
+For tests/scripts that should exercise new installs, seed:
+
+```bash
+export XDG_CONFIG_HOME="$HOME/.config"
+mkdir -p "$XDG_CONFIG_HOME/agent-deck"
+cat > "$XDG_CONFIG_HOME/agent-deck/config.toml" <<'EOF'
+...
+EOF
+```
+
+For tests that intentionally exercise legacy fallback, keep `HOME/.agent-deck` and name the test/comment as legacy fallback.
+
+- [ ] **Step 3: Run docs and drift tests**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./cmd/agent-deck ./internal/ui ./tests/eval/... -run 'XDG|Config|Plugin|Skill|Watcher|Update' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md cmd/agent-deck internal/ui scripts tests
+git commit -m "docs(paths): document XDG base directory layout"
+```
+
+### Task 9: Add Regression Guard Against Direct Legacy Path Construction
+
+**Files:**
+- Create: `internal/agentpaths/direct_legacy_path_lint_test.go`
+
+- [ ] **Step 1: Write AST lint test**
+
+Create a test that parses production `.go` files and fails on `filepath.Join(..., ".agent-deck", ...)` unless the file is in an allowlist:
+
+```go
+var allowedLegacyPathFiles = map[string]bool{
+	"internal/agentpaths/paths.go":   true,
+	"internal/agentpaths/migrate.go": true,
+}
+```
+
+Use AST inspection of `ast.CallExpr` so comments, help strings, and migration text do not fail the test.
+
+- [ ] **Step 2: Run lint test and fix remaining production constructors**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./internal/agentpaths -run TestNoDirectHomeAgentDeckPathConstruction -count=1
+```
+
+Expected: fail first if any production direct constructors remain, then pass after routing those call sites through `agentpaths`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/agentpaths/direct_legacy_path_lint_test.go internal cmd
+git commit -m "test(paths): guard against direct legacy path construction"
+```
+
+### Task 10: Full Verification and PR Prep
+
+**Files:**
+- No new source files unless fixing verification failures.
+
+- [ ] **Step 1: Run focused required suites**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./internal/agentpaths ./internal/session ./internal/tmux ./internal/feedback ./internal/update ./internal/watcher ./cmd/agent-deck -count=1
+```
+
+Expected: pass, except document any already-known unrelated failures with reproduction on `upstream/main`.
+
+- [ ] **Step 2: Run full suite**
+
+Run:
+
+```bash
+GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go \
+GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
+go test ./... -count=1
+```
+
+Expected: pass or produce a clearly triaged list of pre-existing failures.
+
+- [ ] **Step 3: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+Expected: no whitespace errors; branch contains only intended feature changes.
+
+- [ ] **Step 4: Prepare PR description**
+
+Include:
+
+- Issue link: `Fixes #1272`.
+- Before: config and state were hardcoded under `~/.agent-deck`.
+- After: new installs use XDG config/data/cache dirs; legacy installs continue to work; explicit migration command copies data.
+- Path mapping table.
+- Verification commands and results.
+- Note that `profiles/` was placed under data because it contains `state.db`.
+
+## Self-Review
+
+- Issue #1272 coverage: config path support, state/data support, cache support, direct bypass audit, UI/help text, conductor/watcher/templates, migration command, and tests are covered.
+- Placeholder scan: no plan step relies on unresolved placeholders, unspecified tests, or vague error handling.
+- Type consistency: `internal/agentpaths` owns path primitives; `internal/session` keeps compatibility wrappers; independent lower-level packages import `internal/agentpaths` directly to avoid import cycles.

--- a/internal/agentpaths/direct_legacy_path_lint_test.go
+++ b/internal/agentpaths/direct_legacy_path_lint_test.go
@@ -1,0 +1,186 @@
+package agentpaths
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+var allowedLegacyPathFiles = map[string]bool{
+	"internal/agentpaths/paths.go":   true,
+	"internal/agentpaths/migrate.go": true,
+}
+
+func TestNoDirectHomeAgentDeckPathConstruction(t *testing.T) {
+	root := findModuleRoot(t)
+	fset := token.NewFileSet()
+	var failures []string
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".worktrees", "node_modules", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		rel := slashRelPath(t, root, path)
+		if allowedLegacyPathFiles[rel] {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+
+		filepathAliases := importedFilepathAliases(file)
+		if len(filepathAliases) == 0 {
+			return nil
+		}
+
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok || !isFilepathJoin(call, filepathAliases) {
+				return true
+			}
+			for idx, arg := range call.Args {
+				if stringLiteralValue(arg) == ".agent-deck" {
+					if !hasLegacyHomeRoot(call.Args[:idx]) {
+						continue
+					}
+					pos := fset.Position(arg.Pos())
+					failures = append(failures, pos.String())
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk production Go files: %v", err)
+	}
+
+	if len(failures) > 0 {
+		t.Fatalf("direct filepath.Join(..., %q, ...) legacy path construction found outside agentpaths:\n%s",
+			".agent-deck", strings.Join(failures, "\n"))
+	}
+}
+
+func findModuleRoot(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.mod above %s", file)
+		}
+		dir = parent
+	}
+}
+
+func slashRelPath(t *testing.T, root, path string) string {
+	t.Helper()
+
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		t.Fatalf("rel path for %q: %v", path, err)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func importedFilepathAliases(file *ast.File) map[string]bool {
+	aliases := make(map[string]bool)
+	for _, imp := range file.Imports {
+		if stringLiteralValue(imp.Path) != "path/filepath" {
+			continue
+		}
+		if imp.Name != nil {
+			if imp.Name.Name != "_" && imp.Name.Name != "." {
+				aliases[imp.Name.Name] = true
+			}
+			continue
+		}
+		aliases["filepath"] = true
+	}
+	return aliases
+}
+
+func isFilepathJoin(call *ast.CallExpr, filepathAliases map[string]bool) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Join" {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	return ok && filepathAliases[ident.Name]
+}
+
+func hasLegacyHomeRoot(args []ast.Expr) bool {
+	for _, arg := range args {
+		if isLegacyHomeRoot(arg) {
+			return true
+		}
+	}
+	return false
+}
+
+func isLegacyHomeRoot(expr ast.Expr) bool {
+	switch value := expr.(type) {
+	case *ast.Ident:
+		name := strings.ToLower(value.Name)
+		return strings.Contains(name, "home") || strings.Contains(name, "tmp")
+	case *ast.CallExpr:
+		return isOSCall(value, "TempDir") || isOSGetenvHome(value)
+	}
+	return false
+}
+
+func isOSCall(call *ast.CallExpr, method string) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != method {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	return ok && ident.Name == "os"
+}
+
+func isOSGetenvHome(call *ast.CallExpr) bool {
+	if !isOSCall(call, "Getenv") || len(call.Args) != 1 {
+		return false
+	}
+	return stringLiteralValue(call.Args[0]) == "HOME"
+}
+
+func stringLiteralValue(expr ast.Expr) string {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return ""
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return ""
+	}
+	return value
+}

--- a/internal/agentpaths/migrate.go
+++ b/internal/agentpaths/migrate.go
@@ -1,0 +1,274 @@
+package agentpaths
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+type PathCategory string
+
+const (
+	CategoryConfig PathCategory = "config"
+	CategoryData   PathCategory = "data"
+	CategoryCache  PathCategory = "cache"
+)
+
+var ErrMigrationConflict = errors.New("migration destination conflict")
+
+type MigrationOptions struct {
+	DryRun bool
+	Force  bool
+}
+
+type MigrationItem struct {
+	Name        string
+	Category    PathCategory
+	Source      string
+	Destination string
+	Directory   bool
+}
+
+type MigrationResult struct {
+	DryRun    bool
+	Copied    []MigrationItem
+	Skipped   []MigrationItem
+	Conflicts []MigrationItem
+}
+
+func MigrateLegacyLayout(opts MigrationOptions) (*MigrationResult, error) {
+	result := &MigrationResult{DryRun: opts.DryRun}
+	items, err := migrationItems()
+	if err != nil {
+		return result, err
+	}
+
+	var ready []MigrationItem
+	for _, item := range items {
+		if exists, err := pathExists(item.Destination); err != nil {
+			return result, err
+		} else if exists && !opts.Force {
+			result.Conflicts = append(result.Conflicts, item)
+			continue
+		}
+		ready = append(ready, item)
+	}
+	if len(result.Conflicts) > 0 {
+		return result, ErrMigrationConflict
+	}
+
+	for _, item := range ready {
+		result.Copied = append(result.Copied, item)
+		if opts.DryRun {
+			continue
+		}
+		if err := copyMigrationPath(item.Source, item.Destination); err != nil {
+			return result, err
+		}
+	}
+
+	return result, nil
+}
+
+func migrationItems() ([]MigrationItem, error) {
+	legacyDir, err := LegacyDir()
+	if err != nil {
+		return nil, err
+	}
+	configDir, err := ConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	dataDir, err := DataDir()
+	if err != nil {
+		return nil, err
+	}
+	cacheDir, err := CacheDir()
+	if err != nil {
+		return nil, err
+	}
+
+	var items []MigrationItem
+	seen := make(map[string]struct{})
+	add := func(category PathCategory, root, name string) error {
+		source := filepath.Join(legacyDir, name)
+		info, err := os.Lstat(source)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("stat legacy item %q: %w", source, err)
+		}
+		destination := filepath.Join(root, name)
+		key := string(category) + "\x00" + name
+		if _, ok := seen[key]; ok {
+			return nil
+		}
+		seen[key] = struct{}{}
+		items = append(items, MigrationItem{
+			Name:        name,
+			Category:    category,
+			Source:      source,
+			Destination: destination,
+			Directory:   info.IsDir(),
+		})
+		return nil
+	}
+	addGlob := func(category PathCategory, root, pattern string) error {
+		matches, err := filepath.Glob(filepath.Join(legacyDir, pattern))
+		if err != nil {
+			return err
+		}
+		for _, match := range matches {
+			if err := add(category, root, filepath.Base(match)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, name := range []string{"config.toml", "config.json", "skills"} {
+		if err := add(CategoryConfig, configDir, name); err != nil {
+			return nil, err
+		}
+	}
+	for _, name := range []string{
+		"profiles",
+		"sessions.json",
+		"hooks",
+		"locks",
+		"cost-events",
+		"events",
+		"runtime",
+		"inboxes",
+		"conductor",
+		"watcher",
+		"watchers",
+		"triage",
+		"logs",
+		"feedback-state.json",
+		"ack-signal",
+		".ack-signal-legacy",
+		"badge-updates",
+		"worker-scratch",
+	} {
+		if err := add(CategoryData, dataDir, name); err != nil {
+			return nil, err
+		}
+	}
+	if err := addGlob(CategoryData, dataDir, "sessions.json*"); err != nil {
+		return nil, err
+	}
+	for _, name := range []string{"update-cache.json", "pricing.json", "debug.log", "cost-debug.log"} {
+		if err := add(CategoryCache, cacheDir, name); err != nil {
+			return nil, err
+		}
+	}
+	for _, pattern := range []string{"debug-dump-*.jsonl", "crash-dump-*.jsonl"} {
+		if err := addGlob(CategoryCache, cacheDir, pattern); err != nil {
+			return nil, err
+		}
+	}
+
+	return items, nil
+}
+
+func pathExists(path string) (bool, error) {
+	_, err := os.Lstat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat %q: %w", path, err)
+}
+
+func copyMigrationPath(source, destination string) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return fmt.Errorf("stat source %q: %w", source, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return copyMigrationSymlink(source, destination)
+	}
+	if info.IsDir() {
+		return copyMigrationDir(source, destination)
+	}
+	return copyMigrationFile(source, destination, info.Mode().Perm())
+}
+
+func copyMigrationDir(source, destination string) error {
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		return fmt.Errorf("create destination parent %q: %w", filepath.Dir(destination), err)
+	}
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		destPath := destination
+		if rel != "." {
+			destPath = filepath.Join(destination, rel)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return copyMigrationSymlink(path, destPath)
+		}
+		if entry.IsDir() {
+			if err := os.MkdirAll(destPath, info.Mode().Perm()); err != nil {
+				return fmt.Errorf("create directory %q: %w", destPath, err)
+			}
+			return nil
+		}
+		return copyMigrationFile(path, destPath, info.Mode().Perm())
+	})
+}
+
+func copyMigrationFile(source, destination string, mode fs.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		return fmt.Errorf("create destination parent %q: %w", filepath.Dir(destination), err)
+	}
+	src, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open source %q: %w", source, err)
+	}
+	defer src.Close()
+
+	dst, err := os.OpenFile(destination, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("open destination %q: %w", destination, err)
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		_ = dst.Close()
+		return fmt.Errorf("copy %q to %q: %w", source, destination, err)
+	}
+	if err := dst.Close(); err != nil {
+		return fmt.Errorf("close destination %q: %w", destination, err)
+	}
+	_ = os.Chmod(destination, mode)
+	return nil
+}
+
+func copyMigrationSymlink(source, destination string) error {
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		return fmt.Errorf("create destination parent %q: %w", filepath.Dir(destination), err)
+	}
+	target, err := os.Readlink(source)
+	if err != nil {
+		return fmt.Errorf("read symlink %q: %w", source, err)
+	}
+	if err := os.Symlink(target, destination); err != nil {
+		return fmt.Errorf("create symlink %q: %w", destination, err)
+	}
+	return nil
+}

--- a/internal/agentpaths/migrate.go
+++ b/internal/agentpaths/migrate.go
@@ -61,13 +61,19 @@ func MigrateLegacyLayout(opts MigrationOptions) (*MigrationResult, error) {
 	}
 
 	for _, item := range ready {
-		result.Copied = append(result.Copied, item)
 		if opts.DryRun {
+			result.Copied = append(result.Copied, item)
 			continue
+		}
+		if opts.Force {
+			if err := removeExistingDestination(item.Destination); err != nil {
+				return result, err
+			}
 		}
 		if err := copyMigrationPath(item.Source, item.Destination); err != nil {
 			return result, err
 		}
+		result.Copied = append(result.Copied, item)
 	}
 
 	return result, nil
@@ -185,6 +191,18 @@ func pathExists(path string) (bool, error) {
 		return false, nil
 	}
 	return false, fmt.Errorf("stat %q: %w", path, err)
+}
+
+func removeExistingDestination(path string) error {
+	if exists, err := pathExists(path); err != nil {
+		return err
+	} else if !exists {
+		return nil
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("remove existing destination %q: %w", path, err)
+	}
+	return nil
 }
 
 func copyMigrationPath(source, destination string) error {

--- a/internal/agentpaths/migrate_test.go
+++ b/internal/agentpaths/migrate_test.go
@@ -90,31 +90,70 @@ func TestMigrateLegacyLayout_ConflictRequiresForceAndLeavesFilesUntouched(t *tes
 }
 
 func TestMigrateLegacyLayout_ForceOverwritesConflict(t *testing.T) {
-	home, legacy := setupMigrationHome(t)
-	legacyConfig := filepath.Join(legacy, "config.toml")
-	xdgConfig := filepath.Join(home, ".config", "agent-deck", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(legacyConfig), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Dir(xdgConfig), 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(legacyConfig, []byte("legacy\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(xdgConfig, []byte("existing\n"), 0o600); err != nil {
-		t.Fatal(err)
+	cases := []struct {
+		name string
+		seed func(t *testing.T, path string)
+	}{
+		{
+			name: "file",
+			seed: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte("existing\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "directory",
+			seed: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.MkdirAll(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "symlink",
+			seed: func(t *testing.T, path string) {
+				t.Helper()
+				target := filepath.Join(t.TempDir(), "existing-target")
+				if err := os.WriteFile(target, []byte("existing\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
 	}
 
-	result, err := MigrateLegacyLayout(MigrationOptions{Force: true})
-	if err != nil {
-		t.Fatal(err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home, legacy := setupMigrationHome(t)
+			legacyConfig := filepath.Join(legacy, "config.toml")
+			xdgConfig := filepath.Join(home, ".config", "agent-deck", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(legacyConfig), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Dir(xdgConfig), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(legacyConfig, []byte("legacy\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			tc.seed(t, xdgConfig)
+
+			result, err := MigrateLegacyLayout(MigrationOptions{Force: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(result.Conflicts) != 0 {
+				t.Fatalf("force migration should not leave conflicts: %#v", result.Conflicts)
+			}
+			assertMigrationFile(t, xdgConfig, "legacy\n")
+			assertMigrationFile(t, legacyConfig, "legacy\n")
+		})
 	}
-	if len(result.Conflicts) != 0 {
-		t.Fatalf("force migration should not leave conflicts: %#v", result.Conflicts)
-	}
-	assertMigrationFile(t, xdgConfig, "legacy\n")
-	assertMigrationFile(t, legacyConfig, "legacy\n")
 }
 
 func TestMigrateLegacyLayout_DryRunDoesNotCopy(t *testing.T) {

--- a/internal/agentpaths/migrate_test.go
+++ b/internal/agentpaths/migrate_test.go
@@ -1,0 +1,142 @@
+package agentpaths
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupMigrationHome(t *testing.T) (home, legacy string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	legacy = filepath.Join(home, ".agent-deck")
+	return home, legacy
+}
+
+func assertMigrationFile(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(data) != want {
+		t.Fatalf("%s = %q, want %q", path, string(data), want)
+	}
+}
+
+func TestMigrateLegacyLayout_CopiesSplitCategories(t *testing.T) {
+	home, legacy := setupMigrationHome(t)
+	if err := os.MkdirAll(filepath.Join(legacy, "profiles", "default"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.toml"), []byte("theme = \"dark\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "profiles", "default", "state.db"), []byte("db"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "update-cache.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := MigrateLegacyLayout(MigrationOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Copied) == 0 {
+		t.Fatal("expected copied items")
+	}
+
+	assertMigrationFile(t, filepath.Join(home, ".config", "agent-deck", "config.toml"), "theme = \"dark\"\n")
+	assertMigrationFile(t, filepath.Join(home, ".local", "share", "agent-deck", "profiles", "default", "state.db"), "db")
+	assertMigrationFile(t, filepath.Join(home, ".cache", "agent-deck", "update-cache.json"), "{}")
+	assertMigrationFile(t, filepath.Join(legacy, "config.toml"), "theme = \"dark\"\n")
+}
+
+func TestMigrateLegacyLayout_ConflictRequiresForceAndLeavesFilesUntouched(t *testing.T) {
+	home, legacy := setupMigrationHome(t)
+	legacyConfig := filepath.Join(legacy, "config.toml")
+	xdgConfig := filepath.Join(home, ".config", "agent-deck", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(legacyConfig), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(xdgConfig), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyConfig, []byte("legacy\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(xdgConfig, []byte("existing\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := MigrateLegacyLayout(MigrationOptions{})
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !errors.Is(err, ErrMigrationConflict) {
+		t.Fatalf("error = %v, want ErrMigrationConflict", err)
+	}
+	if result == nil || len(result.Conflicts) != 1 {
+		t.Fatalf("expected one conflict in result, got %#v", result)
+	}
+	assertMigrationFile(t, legacyConfig, "legacy\n")
+	assertMigrationFile(t, xdgConfig, "existing\n")
+}
+
+func TestMigrateLegacyLayout_ForceOverwritesConflict(t *testing.T) {
+	home, legacy := setupMigrationHome(t)
+	legacyConfig := filepath.Join(legacy, "config.toml")
+	xdgConfig := filepath.Join(home, ".config", "agent-deck", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(legacyConfig), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(xdgConfig), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyConfig, []byte("legacy\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(xdgConfig, []byte("existing\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := MigrateLegacyLayout(MigrationOptions{Force: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("force migration should not leave conflicts: %#v", result.Conflicts)
+	}
+	assertMigrationFile(t, xdgConfig, "legacy\n")
+	assertMigrationFile(t, legacyConfig, "legacy\n")
+}
+
+func TestMigrateLegacyLayout_DryRunDoesNotCopy(t *testing.T) {
+	home, legacy := setupMigrationHome(t)
+	if err := os.MkdirAll(legacy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.toml"), []byte("legacy\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := MigrateLegacyLayout(MigrationOptions{DryRun: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.DryRun {
+		t.Fatal("result should record dry-run mode")
+	}
+	if len(result.Copied) != 1 {
+		t.Fatalf("dry-run should plan one copy, got %#v", result.Copied)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "agent-deck", "config.toml")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run should not create config destination, stat err=%v", err)
+	}
+}

--- a/internal/agentpaths/paths.go
+++ b/internal/agentpaths/paths.go
@@ -1,12 +1,121 @@
 package agentpaths
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 const AppDirName = "agent-deck"
 
-func LegacyDir() (string, error)                         { return "", fmt.Errorf("not implemented") }
-func ConfigDir() (string, error)                         { return "", fmt.Errorf("not implemented") }
-func DataDir() (string, error)                           { return "", fmt.Errorf("not implemented") }
-func CacheDir() (string, error)                          { return "", fmt.Errorf("not implemented") }
-func EffectiveConfigPath(name string) (string, error)    { return "", fmt.Errorf("not implemented") }
-func EffectiveDataDir(markers ...string) (string, error) { return "", fmt.Errorf("not implemented") }
+func homeDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home dir: %w", err)
+	}
+	return home, nil
+}
+
+func LegacyDir() (string, error) {
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".agent-deck"), nil
+}
+
+func xdgDir(envName string, fallbackParts ...string) (string, error) {
+	if value := strings.TrimSpace(os.Getenv(envName)); value != "" {
+		return filepath.Join(value, AppDirName), nil
+	}
+
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+
+	parts := append([]string{home}, fallbackParts...)
+	parts = append(parts, AppDirName)
+	return filepath.Join(parts...), nil
+}
+
+func ConfigDir() (string, error) {
+	return xdgDir("XDG_CONFIG_HOME", ".config")
+}
+
+func DataDir() (string, error) {
+	return xdgDir("XDG_DATA_HOME", ".local", "share")
+}
+
+func CacheDir() (string, error) {
+	return xdgDir("XDG_CACHE_HOME", ".cache")
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func EffectiveConfigPath(name string) (string, error) {
+	configDir, err := ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	xdgPath := filepath.Join(configDir, filepath.Base(name))
+	if exists(xdgPath) {
+		return xdgPath, nil
+	}
+
+	legacyDir, err := LegacyDir()
+	if err != nil {
+		return "", err
+	}
+	legacyPath := filepath.Join(legacyDir, filepath.Base(name))
+	if exists(legacyPath) {
+		return legacyPath, nil
+	}
+
+	return xdgPath, nil
+}
+
+func EffectiveDataDir(markers ...string) (string, error) {
+	dataDir, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	if exists(dataDir) {
+		return dataDir, nil
+	}
+
+	legacyDir, err := LegacyDir()
+	if err != nil {
+		return "", err
+	}
+	for _, marker := range markers {
+		if marker == "" {
+			continue
+		}
+		if exists(filepath.Join(legacyDir, filepath.Clean(marker))) {
+			return legacyDir, nil
+		}
+	}
+
+	return dataDir, nil
+}
+
+func EffectiveDataPath(name string, markers ...string) (string, error) {
+	dataDir, err := EffectiveDataDir(markers...)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dataDir, filepath.Clean(name)), nil
+}
+
+func CachePath(name string) (string, error) {
+	cacheDir, err := CacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cacheDir, filepath.Clean(name)), nil
+}

--- a/internal/agentpaths/paths.go
+++ b/internal/agentpaths/paths.go
@@ -115,11 +115,13 @@ func LegacyDir() (string, error) {
 
 func xdgDir(envName string, fallbackParts ...string) (string, error) {
 	if value := strings.TrimSpace(os.Getenv(envName)); value != "" {
-		dir := filepath.Join(value, AppDirName)
-		if err := ensureSafeForTest(dir); err != nil {
-			return "", err
+		if filepath.IsAbs(value) {
+			dir := filepath.Join(value, AppDirName)
+			if err := ensureSafeForTest(dir); err != nil {
+				return "", err
+			}
+			return dir, nil
 		}
-		return dir, nil
 	}
 
 	home, err := homeDir()

--- a/internal/agentpaths/paths.go
+++ b/internal/agentpaths/paths.go
@@ -1,7 +1,9 @@
 package agentpaths
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,9 +54,23 @@ func CacheDir() (string, error) {
 	return xdgDir("XDG_CACHE_HOME", ".cache")
 }
 
-func exists(path string) bool {
+func statExists(path string) (bool, error) {
 	_, err := os.Stat(path)
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat %q: %w", path, err)
+}
+
+func cleanLocal(name string) (string, error) {
+	cleaned := filepath.Clean(name)
+	if cleaned == "." || !filepath.IsLocal(cleaned) {
+		return "", fmt.Errorf("path must be local: %q", name)
+	}
+	return cleaned, nil
 }
 
 func EffectiveConfigPath(name string) (string, error) {
@@ -62,8 +78,13 @@ func EffectiveConfigPath(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// Config paths are leaf filenames; callers should not pass nested paths here.
 	xdgPath := filepath.Join(configDir, filepath.Base(name))
-	if exists(xdgPath) {
+	ok, err := statExists(xdgPath)
+	if err != nil {
+		return "", err
+	}
+	if ok {
 		return xdgPath, nil
 	}
 
@@ -72,7 +93,11 @@ func EffectiveConfigPath(name string) (string, error) {
 		return "", err
 	}
 	legacyPath := filepath.Join(legacyDir, filepath.Base(name))
-	if exists(legacyPath) {
+	ok, err = statExists(legacyPath)
+	if err != nil {
+		return "", err
+	}
+	if ok {
 		return legacyPath, nil
 	}
 
@@ -84,19 +109,42 @@ func EffectiveDataDir(markers ...string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if exists(dataDir) {
+
+	cleanMarkers := make([]string, 0, len(markers))
+	for _, marker := range markers {
+		if marker == "" {
+			continue
+		}
+		cleanMarker, err := cleanLocal(marker)
+		if err != nil {
+			return "", err
+		}
+		cleanMarkers = append(cleanMarkers, cleanMarker)
+	}
+	if len(cleanMarkers) == 0 {
 		return dataDir, nil
+	}
+
+	for _, marker := range cleanMarkers {
+		ok, err := statExists(filepath.Join(dataDir, marker))
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return dataDir, nil
+		}
 	}
 
 	legacyDir, err := LegacyDir()
 	if err != nil {
 		return "", err
 	}
-	for _, marker := range markers {
-		if marker == "" {
-			continue
+	for _, marker := range cleanMarkers {
+		ok, err := statExists(filepath.Join(legacyDir, marker))
+		if err != nil {
+			return "", err
 		}
-		if exists(filepath.Join(legacyDir, filepath.Clean(marker))) {
+		if ok {
 			return legacyDir, nil
 		}
 	}
@@ -105,17 +153,25 @@ func EffectiveDataDir(markers ...string) (string, error) {
 }
 
 func EffectiveDataPath(name string, markers ...string) (string, error) {
+	cleanName, err := cleanLocal(name)
+	if err != nil {
+		return "", err
+	}
 	dataDir, err := EffectiveDataDir(markers...)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dataDir, filepath.Clean(name)), nil
+	return filepath.Join(dataDir, cleanName), nil
 }
 
 func CachePath(name string) (string, error) {
+	cleanName, err := cleanLocal(name)
+	if err != nil {
+		return "", err
+	}
 	cacheDir, err := CacheDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(cacheDir, filepath.Clean(name)), nil
+	return filepath.Join(cacheDir, cleanName), nil
 }

--- a/internal/agentpaths/paths.go
+++ b/internal/agentpaths/paths.go
@@ -1,0 +1,12 @@
+package agentpaths
+
+import "fmt"
+
+const AppDirName = "agent-deck"
+
+func LegacyDir() (string, error)                         { return "", fmt.Errorf("not implemented") }
+func ConfigDir() (string, error)                         { return "", fmt.Errorf("not implemented") }
+func DataDir() (string, error)                           { return "", fmt.Errorf("not implemented") }
+func CacheDir() (string, error)                          { return "", fmt.Errorf("not implemented") }
+func EffectiveConfigPath(name string) (string, error)    { return "", fmt.Errorf("not implemented") }
+func EffectiveDataDir(markers ...string) (string, error) { return "", fmt.Errorf("not implemented") }

--- a/internal/agentpaths/paths_test.go
+++ b/internal/agentpaths/paths_test.go
@@ -86,6 +86,37 @@ func TestXDGDirs_EnvOverrides(t *testing.T) {
 	}
 }
 
+func TestXDGDirs_RelativeEnvValuesFallBackToHome(t *testing.T) {
+	home := setupHome(t)
+	t.Setenv("XDG_CONFIG_HOME", "relative-config")
+	t.Setenv("XDG_DATA_HOME", "relative-data")
+	t.Setenv("XDG_CACHE_HOME", "relative-cache")
+
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir() error = %v", err)
+	}
+	if want := filepath.Join(home, ".config", AppDirName); configDir != want {
+		t.Fatalf("ConfigDir() = %q, want fallback %q", configDir, want)
+	}
+
+	dataDir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir() error = %v", err)
+	}
+	if want := filepath.Join(home, ".local", "share", AppDirName); dataDir != want {
+		t.Fatalf("DataDir() = %q, want fallback %q", dataDir, want)
+	}
+
+	cacheDir, err := CacheDir()
+	if err != nil {
+		t.Fatalf("CacheDir() error = %v", err)
+	}
+	if want := filepath.Join(home, ".cache", AppDirName); cacheDir != want {
+		t.Fatalf("CacheDir() = %q, want fallback %q", cacheDir, want)
+	}
+}
+
 func osRealHome(t *testing.T) string {
 	t.Helper()
 	u, err := user.Current()

--- a/internal/agentpaths/paths_test.go
+++ b/internal/agentpaths/paths_test.go
@@ -6,6 +6,18 @@ import (
 	"testing"
 )
 
+func TestLegacyDir_DefaultsToHomeAgentDeck(t *testing.T) {
+	home := setupHome(t)
+
+	legacyDir, err := LegacyDir()
+	if err != nil {
+		t.Fatalf("LegacyDir() error = %v", err)
+	}
+	if want := filepath.Join(home, ".agent-deck"); legacyDir != want {
+		t.Fatalf("LegacyDir() = %q, want %q", legacyDir, want)
+	}
+}
+
 func TestXDGDirs_DefaultToHomeFallbacks(t *testing.T) {
 	home := setupHome(t)
 	t.Setenv("XDG_CONFIG_HOME", "")
@@ -79,6 +91,14 @@ func TestEffectiveConfigPath_LegacyWinsOnlyWhenXDGFileMissing(t *testing.T) {
 	legacyPath := filepath.Join(home, ".agent-deck", "config.toml")
 	xdgPath := filepath.Join(home, ".config", AppDirName, "config.toml")
 
+	got, err := EffectiveConfigPath("config.toml")
+	if err != nil {
+		t.Fatalf("EffectiveConfigPath() error = %v", err)
+	}
+	if got != xdgPath {
+		t.Fatalf("EffectiveConfigPath() = %q, want XDG path %q", got, xdgPath)
+	}
+
 	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
 		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(legacyPath), err)
 	}
@@ -86,7 +106,7 @@ func TestEffectiveConfigPath_LegacyWinsOnlyWhenXDGFileMissing(t *testing.T) {
 		t.Fatalf("WriteFile(%q) error = %v", legacyPath, err)
 	}
 
-	got, err := EffectiveConfigPath("config.toml")
+	got, err = EffectiveConfigPath("config.toml")
 	if err != nil {
 		t.Fatalf("EffectiveConfigPath() error = %v", err)
 	}
@@ -119,11 +139,19 @@ func TestEffectiveDataDir_LegacyWinsOnlyWhenXDGDataMissing(t *testing.T) {
 	legacyMarker := filepath.Join(legacyDir, "profiles", "default")
 	xdgMarker := filepath.Join(xdgDataDir, "profiles")
 
+	got, err := EffectiveDataDir("profiles")
+	if err != nil {
+		t.Fatalf("EffectiveDataDir() error = %v", err)
+	}
+	if got != xdgDataDir {
+		t.Fatalf("EffectiveDataDir() = %q, want XDG data dir %q", got, xdgDataDir)
+	}
+
 	if err := os.MkdirAll(legacyMarker, 0o755); err != nil {
 		t.Fatalf("MkdirAll(%q) error = %v", legacyMarker, err)
 	}
 
-	got, err := EffectiveDataDir("profiles")
+	got, err = EffectiveDataDir("profiles")
 	if err != nil {
 		t.Fatalf("EffectiveDataDir() error = %v", err)
 	}

--- a/internal/agentpaths/paths_test.go
+++ b/internal/agentpaths/paths_test.go
@@ -1,0 +1,153 @@
+package agentpaths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestXDGDirs_DefaultToHomeFallbacks(t *testing.T) {
+	home := setupHome(t)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir() error = %v", err)
+	}
+	if want := filepath.Join(home, ".config", AppDirName); configDir != want {
+		t.Fatalf("ConfigDir() = %q, want %q", configDir, want)
+	}
+
+	dataDir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir() error = %v", err)
+	}
+	if want := filepath.Join(home, ".local", "share", AppDirName); dataDir != want {
+		t.Fatalf("DataDir() = %q, want %q", dataDir, want)
+	}
+
+	cacheDir, err := CacheDir()
+	if err != nil {
+		t.Fatalf("CacheDir() error = %v", err)
+	}
+	if want := filepath.Join(home, ".cache", AppDirName); cacheDir != want {
+		t.Fatalf("CacheDir() = %q, want %q", cacheDir, want)
+	}
+}
+
+func TestXDGDirs_EnvOverrides(t *testing.T) {
+	setupHome(t)
+	root := t.TempDir()
+	configHome := filepath.Join(root, "config")
+	dataHome := filepath.Join(root, "data")
+	cacheHome := filepath.Join(root, "cache")
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir() error = %v", err)
+	}
+	if want := filepath.Join(configHome, AppDirName); configDir != want {
+		t.Fatalf("ConfigDir() = %q, want %q", configDir, want)
+	}
+
+	dataDir, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir() error = %v", err)
+	}
+	if want := filepath.Join(dataHome, AppDirName); dataDir != want {
+		t.Fatalf("DataDir() = %q, want %q", dataDir, want)
+	}
+
+	cacheDir, err := CacheDir()
+	if err != nil {
+		t.Fatalf("CacheDir() error = %v", err)
+	}
+	if want := filepath.Join(cacheHome, AppDirName); cacheDir != want {
+		t.Fatalf("CacheDir() = %q, want %q", cacheDir, want)
+	}
+}
+
+func TestEffectiveConfigPath_LegacyWinsOnlyWhenXDGFileMissing(t *testing.T) {
+	home := setupHome(t)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	legacyPath := filepath.Join(home, ".agent-deck", "config.toml")
+	xdgPath := filepath.Join(home, ".config", AppDirName, "config.toml")
+
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(legacyPath), err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("legacy = true\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", legacyPath, err)
+	}
+
+	got, err := EffectiveConfigPath("config.toml")
+	if err != nil {
+		t.Fatalf("EffectiveConfigPath() error = %v", err)
+	}
+	if got != legacyPath {
+		t.Fatalf("EffectiveConfigPath() = %q, want legacy path %q", got, legacyPath)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(xdgPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(xdgPath), err)
+	}
+	if err := os.WriteFile(xdgPath, []byte("xdg = true\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", xdgPath, err)
+	}
+
+	got, err = EffectiveConfigPath("config.toml")
+	if err != nil {
+		t.Fatalf("EffectiveConfigPath() error = %v", err)
+	}
+	if got != xdgPath {
+		t.Fatalf("EffectiveConfigPath() = %q, want XDG path %q", got, xdgPath)
+	}
+}
+
+func TestEffectiveDataDir_LegacyWinsOnlyWhenXDGDataMissing(t *testing.T) {
+	home := setupHome(t)
+	t.Setenv("XDG_DATA_HOME", "")
+
+	legacyDir := filepath.Join(home, ".agent-deck")
+	xdgDataDir := filepath.Join(home, ".local", "share", AppDirName)
+	legacyMarker := filepath.Join(legacyDir, "profiles", "default")
+	xdgMarker := filepath.Join(xdgDataDir, "profiles")
+
+	if err := os.MkdirAll(legacyMarker, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", legacyMarker, err)
+	}
+
+	got, err := EffectiveDataDir("profiles")
+	if err != nil {
+		t.Fatalf("EffectiveDataDir() error = %v", err)
+	}
+	if got != legacyDir {
+		t.Fatalf("EffectiveDataDir() = %q, want legacy dir %q", got, legacyDir)
+	}
+
+	if err := os.MkdirAll(xdgMarker, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", xdgMarker, err)
+	}
+
+	got, err = EffectiveDataDir("profiles")
+	if err != nil {
+		t.Fatalf("EffectiveDataDir() error = %v", err)
+	}
+	if got != xdgDataDir {
+		t.Fatalf("EffectiveDataDir() = %q, want XDG data dir %q", got, xdgDataDir)
+	}
+}
+
+func setupHome(t *testing.T) string {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}

--- a/internal/agentpaths/paths_test.go
+++ b/internal/agentpaths/paths_test.go
@@ -130,6 +130,31 @@ func TestEffectiveConfigPath_LegacyWinsOnlyWhenXDGFileMissing(t *testing.T) {
 	}
 }
 
+func TestEffectiveConfigPath_XDGStatErrorDoesNotFallBackToLegacy(t *testing.T) {
+	home := setupHome(t)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	legacyPath := filepath.Join(home, ".agent-deck", "config.toml")
+	xdgPath := filepath.Join(home, ".config", AppDirName, "config.toml")
+
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(legacyPath), err)
+	}
+	if err := os.WriteFile(legacyPath, []byte("legacy = true\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q) error = %v", legacyPath, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(xdgPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", filepath.Dir(xdgPath), err)
+	}
+	if err := os.Symlink("config.toml", xdgPath); err != nil {
+		t.Fatalf("Symlink(%q) error = %v", xdgPath, err)
+	}
+
+	if got, err := EffectiveConfigPath("config.toml"); err == nil {
+		t.Fatalf("EffectiveConfigPath() = %q, want stat error", got)
+	}
+}
+
 func TestEffectiveDataDir_LegacyWinsOnlyWhenXDGDataMissing(t *testing.T) {
 	home := setupHome(t)
 	t.Setenv("XDG_DATA_HOME", "")
@@ -169,6 +194,57 @@ func TestEffectiveDataDir_LegacyWinsOnlyWhenXDGDataMissing(t *testing.T) {
 	}
 	if got != xdgDataDir {
 		t.Fatalf("EffectiveDataDir() = %q, want XDG data dir %q", got, xdgDataDir)
+	}
+}
+
+func TestEffectiveDataDir_LegacyMarkerWinsWhenXDGBaseExistsWithoutMarker(t *testing.T) {
+	home := setupHome(t)
+	t.Setenv("XDG_DATA_HOME", "")
+
+	legacyDir := filepath.Join(home, ".agent-deck")
+	xdgDataDir := filepath.Join(home, ".local", "share", AppDirName)
+	legacyMarker := filepath.Join(legacyDir, "profiles", "default")
+
+	if err := os.MkdirAll(xdgDataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", xdgDataDir, err)
+	}
+	if err := os.MkdirAll(legacyMarker, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", legacyMarker, err)
+	}
+
+	got, err := EffectiveDataDir("profiles")
+	if err != nil {
+		t.Fatalf("EffectiveDataDir() error = %v", err)
+	}
+	if got != legacyDir {
+		t.Fatalf("EffectiveDataDir() = %q, want legacy dir %q", got, legacyDir)
+	}
+}
+
+func TestEffectiveDataDir_RejectsNonLocalMarkers(t *testing.T) {
+	setupHome(t)
+	t.Setenv("XDG_DATA_HOME", "")
+
+	if got, err := EffectiveDataDir("../profiles"); err == nil {
+		t.Fatalf("EffectiveDataDir() = %q, want error", got)
+	}
+}
+
+func TestEffectiveDataPath_RejectsNonLocalName(t *testing.T) {
+	setupHome(t)
+	t.Setenv("XDG_DATA_HOME", "")
+
+	if got, err := EffectiveDataPath("../escape"); err == nil {
+		t.Fatalf("EffectiveDataPath() = %q, want error", got)
+	}
+}
+
+func TestCachePath_RejectsNonLocalName(t *testing.T) {
+	setupHome(t)
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	if got, err := CachePath("../escape"); err == nil {
+		t.Fatalf("CachePath() = %q, want error", got)
 	}
 }
 

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -20,8 +20,7 @@ func oldShouldShowBypass(s *feedback.State) *feedback.State {
 
 // TEST-01: ShouldShow returns true when this is a new version
 func TestShouldShow_NewVersion(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	st := oldShouldShowBypass(&feedback.State{
 		LastRatedVersion: "1.0.0",
@@ -38,8 +37,7 @@ func TestShouldShow_NewVersion(t *testing.T) {
 
 // TEST-02: ShouldShow returns false when already rated this version
 func TestShouldShow_AlreadyRated(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	st := oldShouldShowBypass(&feedback.State{
 		LastRatedVersion: "1.5.1",
@@ -56,8 +54,7 @@ func TestShouldShow_AlreadyRated(t *testing.T) {
 
 // TEST-03: ShouldShow returns false when user opted out
 func TestShouldShow_OptedOut(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	st := oldShouldShowBypass(&feedback.State{
 		LastRatedVersion: "1.0.0",
@@ -74,8 +71,7 @@ func TestShouldShow_OptedOut(t *testing.T) {
 
 // TEST-04: ShouldShow returns false when shown_count >= max_shows
 func TestShouldShow_MaxShows(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	st := oldShouldShowBypass(&feedback.State{
 		LastRatedVersion: "1.0.0",
@@ -92,8 +88,7 @@ func TestShouldShow_MaxShows(t *testing.T) {
 
 // TEST-05: RecordRating sets last_rated_version and resets shown_count
 func TestRecordRating_Valid(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	st := &feedback.State{
 		LastRatedVersion: "1.0.0",
@@ -112,8 +107,7 @@ func TestRecordRating_Valid(t *testing.T) {
 
 // TEST-06: RecordOptOut sets feedback_enabled to false (persisted)
 func TestRecordOptOut(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	st := &feedback.State{
 		LastRatedVersion: "1.0.0",
@@ -131,8 +125,7 @@ func TestRecordOptOut(t *testing.T) {
 
 // TEST-07: RecordShown increments shown_count (persisted)
 func TestRecordShown(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	st := &feedback.State{
 		LastRatedVersion: "1.0.0",
@@ -171,8 +164,7 @@ func (e *fakeExitError) ExitCode() int { return e.code }
 
 // TEST-10: TestSend_GhAuthFailure verifies non-headless fallback copies to clipboard AND opens browser
 func TestSend_GhAuthFailure(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	clipboardCalled := false
 	clipboardText := ""
@@ -207,8 +199,7 @@ func TestSend_GhAuthFailure(t *testing.T) {
 
 // TEST-11: TestSend_Headless verifies headless mode copies to clipboard only (no browser)
 func TestSend_Headless(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	clipboardCalled := false
 	browserCalled := false
@@ -247,8 +238,7 @@ func TestSend_Headless(t *testing.T) {
 // dismissed; ShouldShow only honors the opt-out while the current version is
 // still on that same series.
 func TestUpgradeFeedback_ShownPerMajorVersion_RegressionFor967(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	// Seed the state so pacing gates pass — the test is about version-scoped
 	// opt-out, not pacing.
@@ -285,8 +275,7 @@ func TestUpgradeFeedback_ShownPerMajorVersion_RegressionFor967(t *testing.T) {
 // (cmd/agent-deck/main.go) right after LoadState — this test mirrors that
 // shape so the contract is pinned at the package boundary.
 func TestUpgradeFeedback_LegacyForeverOptOut_MigratesGracefully(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	// Legacy state: FeedbackEnabled=false, no OptOutVersion. This is what a
 	// pre-#967 user has on disk after clicking "no thanks" once.

--- a/internal/feedback/pacing_v1741_test.go
+++ b/internal/feedback/pacing_v1741_test.go
@@ -38,8 +38,7 @@ func baseEnabled() *feedback.State {
 // TEST-P1: brand new state (FirstSeenAt zero, LaunchCount zero) must block
 // ShouldShow. RecordLaunch must set FirstSeenAt to now and bump LaunchCount.
 func TestPacing_NewUser_FirstSeenSetOnRecordLaunch(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	st := baseEnabled()
 	now := time.Now()
@@ -60,8 +59,7 @@ func TestPacing_NewUser_FirstSeenSetOnRecordLaunch(t *testing.T) {
 // TEST-P2: RecordLaunch must NOT overwrite a pre-existing FirstSeenAt.
 // (Pacing decision must persist across restarts.)
 func TestPacing_RecordLaunch_DoesNotOverwriteFirstSeenAt(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	original := time.Now().Add(-10 * 24 * time.Hour)
 	st := baseEnabled()
@@ -230,8 +228,7 @@ func TestPacing_RecordRating_PreservesPacingFields(t *testing.T) {
 // TEST-P14: state round-trip through SaveState/LoadState must preserve
 // the new pacing fields (RFC3339 JSON serialization).
 func TestPacing_StateRoundtrip(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	isolateFeedbackPaths(t)
 
 	now := time.Now().UTC().Truncate(time.Second)
 	st := &feedback.State{

--- a/internal/feedback/state.go
+++ b/internal/feedback/state.go
@@ -8,10 +8,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 )
 
 // State holds the persisted feedback preferences for a user.
-// File: ~/.agent-deck/feedback-state.json. Always serializes all fields (D-05).
+// File: feedback-state.json in the XDG data directory, with legacy fallback.
+// Always serializes all fields (D-05).
 //
 // v1.7.41 added LaunchCount, FirstSeenAt, LastPromptedAt to pace the first
 // prompt for new users. Serialized via RFC3339 through time.Time's MarshalJSON.
@@ -60,27 +63,12 @@ func defaultState() *State {
 	}
 }
 
-// agentDeckDir returns the base agent-deck directory (~/.agent-deck).
-// Inlined here to avoid importing internal/session, which is a heavyweight
-// package and would create a circular import risk if session ever imports feedback.
-func agentDeckDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("feedback: get home dir: %w", err)
-	}
-	return filepath.Join(home, ".agent-deck"), nil
-}
-
 // statePath returns the absolute path to the feedback state file.
 func statePath() (string, error) {
-	dir, err := agentDeckDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "feedback-state.json"), nil
+	return agentpaths.EffectiveDataPath("feedback-state.json", "feedback-state.json")
 }
 
-// LoadState reads ~/.agent-deck/feedback-state.json and returns the state.
+// LoadState reads feedback-state.json and returns the state.
 // If the file does not exist, it returns a default State (FeedbackEnabled=true, MaxShows=3).
 // A missing file is NOT an error. A malformed file returns a default state to prevent crashes.
 func LoadState() (*State, error) {
@@ -105,13 +93,14 @@ func LoadState() (*State, error) {
 	return &s, nil
 }
 
-// SaveState atomically writes the state to ~/.agent-deck/feedback-state.json.
+// SaveState atomically writes the feedback state file.
 // Uses tmp+rename to prevent partial writes (T-01-01).
 func SaveState(s *State) error {
-	dir, err := agentDeckDir()
+	path, err := statePath()
 	if err != nil {
-		return fmt.Errorf("feedback: get agent-deck dir: %w", err)
+		return fmt.Errorf("feedback: get state path: %w", err)
 	}
+	dir := filepath.Dir(path)
 
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return fmt.Errorf("feedback: create dir: %w", err)
@@ -122,7 +111,6 @@ func SaveState(s *State) error {
 		return fmt.Errorf("feedback: marshal state: %w", err)
 	}
 
-	path := filepath.Join(dir, "feedback-state.json")
 	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
 		return fmt.Errorf("feedback: write tmp: %w", err)

--- a/internal/feedback/state_xdg_test.go
+++ b/internal/feedback/state_xdg_test.go
@@ -1,0 +1,69 @@
+package feedback_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/feedback"
+	"github.com/stretchr/testify/require"
+)
+
+func isolateFeedbackPaths(t *testing.T) (home string, data string) {
+	t.Helper()
+
+	root := t.TempDir()
+	home = filepath.Join(root, "home")
+	data = filepath.Join(root, "xdg-data")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", data)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "xdg-cache"))
+	return home, data
+}
+
+func TestStatePath_XDGDataHomeSaveNewUser(t *testing.T) {
+	home, data := isolateFeedbackPaths(t)
+
+	state := &feedback.State{
+		LastRatedVersion: "1.2.3",
+		FeedbackEnabled:  true,
+		ShownCount:       1,
+		MaxShows:         3,
+	}
+	require.NoError(t, feedback.SaveState(state))
+
+	xdgPath := filepath.Join(data, "agent-deck", "feedback-state.json")
+	legacyPath := filepath.Join(home, ".agent-deck", "feedback-state.json")
+
+	require.FileExists(t, xdgPath)
+	require.NoFileExists(t, legacyPath)
+
+	loaded, err := feedback.LoadState()
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3", loaded.LastRatedVersion)
+	require.True(t, loaded.FeedbackEnabled)
+	require.Equal(t, 1, loaded.ShownCount)
+	require.Equal(t, 3, loaded.MaxShows)
+}
+
+func TestStatePath_LegacyFallbackLoadsWhenXDGAbsent(t *testing.T) {
+	home, data := isolateFeedbackPaths(t)
+
+	legacyPath := filepath.Join(home, ".agent-deck", "feedback-state.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyPath), 0o700))
+	require.NoError(t, os.WriteFile(legacyPath, []byte(`{
+  "last_rated_version": "0.9.0",
+  "feedback_enabled": false,
+  "shown_count": 2,
+  "max_shows": 3
+}`), 0o600))
+
+	require.NoFileExists(t, filepath.Join(data, "agent-deck", "feedback-state.json"))
+
+	loaded, err := feedback.LoadState()
+	require.NoError(t, err)
+	require.Equal(t, "0.9.0", loaded.LastRatedVersion)
+	require.False(t, loaded.FeedbackEnabled)
+	require.Equal(t, 2, loaded.ShownCount)
+	require.Equal(t, 3, loaded.MaxShows)
+}

--- a/internal/mcppool/fd_leak_test.go
+++ b/internal/mcppool/fd_leak_test.go
@@ -54,7 +54,7 @@ func TestSocketProxy_Start_FailingCommand_NoFDLeak(t *testing.T) {
 	defer cancel()
 
 	const cycles = 200
-	const logSubstring = ".agent-deck/logs/mcppool/"
+	const logSubstring = "agent-deck/logs/mcppool/"
 
 	// Prime once so any one-shot Go runtime FDs (proc readers, etc.) settle.
 	primer, _ := NewSocketProxy(ctx, "fdleak-prime", "/no/such/binary-prime", nil, nil)
@@ -101,7 +101,7 @@ func TestHTTPServer_Start_FailingCommand_NoFDLeak(t *testing.T) {
 	defer cancel()
 
 	const cycles = 200
-	const logSubstring = ".agent-deck/logs/http-servers/"
+	const logSubstring = "agent-deck/logs/http-servers/"
 
 	// Prime to settle any one-shot runtime FDs.
 	primer := NewHTTPServer(ctx, "fdleak-http-prime", "http://127.0.0.1:1", "http://127.0.0.1:1", "/no/such/binary-prime", nil, nil, 100*time.Millisecond)

--- a/internal/mcppool/http_server.go
+++ b/internal/mcppool/http_server.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/asheshgoplani/agent-deck/internal/childenv"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 )
@@ -217,7 +218,10 @@ func (s *HTTPServer) Start() error {
 	s.mu.Unlock()
 
 	// Create log file
-	logDir := filepath.Join(os.Getenv("HOME"), ".agent-deck", "logs", "http-servers")
+	logDir, err := agentpaths.EffectiveDataPath(filepath.Join("logs", "http-servers"), "logs")
+	if err != nil {
+		logDir = filepath.Join(os.TempDir(), "agent-deck", "logs", "http-servers")
+	}
 	_ = os.MkdirAll(logDir, 0700)
 	s.logFile = filepath.Join(logDir, fmt.Sprintf("%s.log", s.name))
 

--- a/internal/mcppool/socket_proxy.go
+++ b/internal/mcppool/socket_proxy.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/asheshgoplani/agent-deck/internal/childenv"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 )
@@ -150,11 +151,11 @@ var dangerousEnvVars = map[string]bool{
 
 // mcpSocketDir returns a user-private directory for MCP sockets instead of /tmp.
 func mcpSocketDir() string {
-	home, err := os.UserHomeDir()
+	dir, err := agentpaths.EffectiveDataPath("sockets", "sockets")
 	if err != nil {
 		return filepath.Join(os.TempDir(), fmt.Sprintf("agentdeck-%d", os.Getuid()))
 	}
-	return filepath.Join(home, ".agent-deck", "sockets")
+	return dir
 }
 
 func NewSocketProxy(ctx context.Context, name, command string, args []string, env map[string]string) (*SocketProxy, error) {
@@ -215,7 +216,10 @@ func (p *SocketProxy) Start() error {
 		return err
 	}
 
-	logDir := filepath.Join(os.Getenv("HOME"), ".agent-deck", "logs", "mcppool")
+	logDir, err := agentpaths.EffectiveDataPath(filepath.Join("logs", "mcppool"), "logs")
+	if err != nil {
+		logDir = filepath.Join(os.TempDir(), "agent-deck", "logs", "mcppool")
+	}
 	_ = os.MkdirAll(logDir, 0700)
 	p.logFile = filepath.Join(logDir, fmt.Sprintf("%s_socket.log", p.name))
 

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -1731,7 +1731,10 @@ func GenerateTransitionNotifierLaunchdPlist() (string, error) {
 	if agentDeckPath != "" {
 		execPath = agentDeckPath
 	}
-	logPath := transitionNotifyLogPath()
+	logPath, err := logDataPath("transition-notifier.log")
+	if err != nil {
+		return "", fmt.Errorf("transition notifier log path: %w", err)
+	}
 
 	plist := strings.ReplaceAll(transitionNotifierPlistTemplate, "__AGENT_DECK__", execPath)
 	plist = strings.ReplaceAll(plist, "__LOG_PATH__", logPath)
@@ -1760,7 +1763,10 @@ func GenerateSystemdTransitionNotifierService() (string, error) {
 	if agentDeckPath != "" {
 		execPath = agentDeckPath
 	}
-	logPath := transitionNotifyLogPath()
+	logPath, err := logDataPath("transition-notifier.log")
+	if err != nil {
+		return "", fmt.Errorf("transition notifier log path: %w", err)
+	}
 
 	unit := strings.ReplaceAll(systemdTransitionNotifierServiceTemplate, "__AGENT_DECK__", execPath)
 	unit = strings.ReplaceAll(unit, "__LOG_PATH__", logPath)

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -360,11 +360,7 @@ func normalizeConductorProfile(profile string) string {
 
 // ConductorDir returns the base conductor directory (~/.agent-deck/conductor)
 func ConductorDir() (string, error) {
-	dir, err := GetAgentDeckDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "conductor"), nil
+	return dataPath("conductor", "conductor")
 }
 
 // ConductorNameDir returns the directory for a named conductor (~/.agent-deck/conductor/<name>)
@@ -1451,8 +1447,8 @@ func LaunchdPlistPath() (string, error) {
 // PATH (so pyenv/asdf-selected interpreters win), then common absolute paths.
 func findPython3() string {
 	// Prefer the conductor venv python which has bridge dependencies installed.
-	if homeDir, err := os.UserHomeDir(); err == nil {
-		venvPython := filepath.Join(homeDir, ".agent-deck", "conductor", "venv", "bin", "python3")
+	if conductorDir, err := ConductorDir(); err == nil {
+		venvPython := filepath.Join(conductorDir, "venv", "bin", "python3")
 		if _, err := os.Stat(venvPython); err == nil {
 			return venvPython
 		}
@@ -1730,16 +1726,12 @@ func GenerateTransitionNotifierLaunchdPlist() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	agentDeckDir, err := GetAgentDeckDir()
-	if err != nil {
-		return "", err
-	}
 	agentDeckPath := FindAgentDeck()
 	execPath := "agent-deck"
 	if agentDeckPath != "" {
 		execPath = agentDeckPath
 	}
-	logPath := filepath.Join(agentDeckDir, "logs", "transition-notifier.log")
+	logPath := transitionNotifyLogPath()
 
 	plist := strings.ReplaceAll(transitionNotifierPlistTemplate, "__AGENT_DECK__", execPath)
 	plist = strings.ReplaceAll(plist, "__LOG_PATH__", logPath)
@@ -1763,16 +1755,12 @@ func GenerateSystemdTransitionNotifierService() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	agentDeckDir, err := GetAgentDeckDir()
-	if err != nil {
-		return "", err
-	}
 	agentDeckPath := FindAgentDeck()
 	execPath := "agent-deck"
 	if agentDeckPath != "" {
 		execPath = agentDeckPath
 	}
-	logPath := filepath.Join(agentDeckDir, "logs", "transition-notifier.log")
+	logPath := transitionNotifyLogPath()
 
 	unit := strings.ReplaceAll(systemdTransitionNotifierServiceTemplate, "__AGENT_DECK__", execPath)
 	unit = strings.ReplaceAll(unit, "__LOG_PATH__", logPath)

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -698,11 +698,26 @@ func renderConductorHeartbeatScript(name, profile string) string {
 	script := strings.ReplaceAll(conductorHeartbeatScript, "{NAME}", name)
 	script = strings.ReplaceAll(script, "{PROFILE}", profile)
 	script = strings.ReplaceAll(script, "{HEARTBEAT_PREFIX}", ConductorBridgeHeartbeatPrefix)
+	conductorRoot := "$HOME/.agent-deck/conductor"
+	if dir, err := ConductorDir(); err == nil {
+		conductorRoot = shellDoubleQuotedValue(dir)
+	}
+	script = strings.ReplaceAll(script, "{CONDUCTOR_ROOT}", conductorRoot)
 	if profile == DefaultProfile {
 		// For default profile, omit -p flag entirely
 		script = strings.ReplaceAll(script, `-p "$PROFILE" `, "")
 	}
 	return script
+}
+
+func shellDoubleQuotedValue(value string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		`$`, `\$`,
+		"`", "\\`",
+	)
+	return replacer.Replace(value)
 }
 
 // HeartbeatPlistLabel returns the launchd label for a conductor's heartbeat
@@ -901,8 +916,12 @@ STATUS=$(agent-deck -p "$PROFILE" session show "$SESSION" --json 2>/dev/null | a
 
 # Resolve HEARTBEAT_RULES.md (per-conductor, then per-profile, then global fallback).
 # Mirrors the lookup order used by conductor/bridge.py since PR #218.
+CONDUCTOR_ROOT="{CONDUCTOR_ROOT}"
 RULES_FILE=""
 for candidate in \
+    "$CONDUCTOR_ROOT/{NAME}/HEARTBEAT_RULES.md" \
+    "$CONDUCTOR_ROOT/{PROFILE}/HEARTBEAT_RULES.md" \
+    "$CONDUCTOR_ROOT/HEARTBEAT_RULES.md" \
     "$HOME/.agent-deck/conductor/{NAME}/HEARTBEAT_RULES.md" \
     "$HOME/.agent-deck/conductor/{PROFILE}/HEARTBEAT_RULES.md" \
     "$HOME/.agent-deck/conductor/HEARTBEAT_RULES.md"; do

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -1333,9 +1333,10 @@ func TestCreateSymlinkWithExpansion_MissingSourceError(t *testing.T) {
 // --- Policy MD tests ---
 
 func TestInstallPolicyMD_Default(t *testing.T) {
-	// Use actual conductor directory (cleanup after test)
-	homeDir, _ := os.UserHomeDir()
-	conductorDir := filepath.Join(homeDir, ".agent-deck", "conductor")
+	conductorDir, err := ConductorDir()
+	if err != nil {
+		t.Fatalf("ConductorDir: %v", err)
+	}
 	policyPath := filepath.Join(conductorDir, "POLICY.md")
 
 	// Backup existing file if present
@@ -1348,8 +1349,7 @@ func TestInstallPolicyMD_Default(t *testing.T) {
 	}
 
 	// Test installing default template
-	err := InstallPolicyMD("")
-	if err != nil {
+	if err := InstallPolicyMD(""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -1616,13 +1616,18 @@ func TestMigrateConductorPolicySplit_PreservesCustomClaudeMD(t *testing.T) {
 func TestInstallLearningsMD(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmpHome, ".local", "share"))
 
 	err := InstallLearningsMD()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	learningsPath := filepath.Join(tmpHome, ".agent-deck", "conductor", "LEARNINGS.md")
+	conductorDir, err := ConductorDir()
+	if err != nil {
+		t.Fatalf("ConductorDir: %v", err)
+	}
+	learningsPath := filepath.Join(conductorDir, "LEARNINGS.md")
 	content, err := os.ReadFile(learningsPath)
 	if err != nil {
 		t.Fatalf("LEARNINGS.md not created: %v", err)

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -687,7 +687,9 @@ func TestConductorStatusJSON_ZeroActivityOmitted(t *testing.T) {
 // --- Symlink-based CLAUDE.md tests ---
 
 func TestInstallSharedClaudeMD_Default(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg-data"))
 	conductorDir, err := ConductorDir()
 	if err != nil {
 		t.Fatalf("ConductorDir: %v", err)
@@ -737,7 +739,9 @@ func TestInstallSharedClaudeMD_Default(t *testing.T) {
 }
 
 func TestInstallSharedClaudeMD_CustomSymlink(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg-data"))
 	tmpDir := t.TempDir()
 	customPath := filepath.Join(tmpDir, "my-shared-claude.md")
 
@@ -779,6 +783,7 @@ func TestInstallSharedClaudeMD_CustomSymlink(t *testing.T) {
 func TestInstallSharedClaudeMD_CustomSymlinkCreatesConductorDir(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmpHome, "xdg-data"))
 
 	customPath := filepath.Join(t.TempDir(), "my-shared-claude.md")
 	if err := os.WriteFile(customPath, []byte("# shared rules\n"), 0o644); err != nil {
@@ -800,6 +805,23 @@ func TestInstallSharedClaudeMD_CustomSymlinkCreatesConductorDir(t *testing.T) {
 	}
 	if linkDest != customPath {
 		t.Fatalf("symlink destination = %q, want %q", linkDest, customPath)
+	}
+}
+
+func TestGenerateTransitionNotifierDaemons_SurfaceLogPathErrors(t *testing.T) {
+	home := t.TempDir()
+	badXDGDataHome := filepath.Join(home, "xdg-data-file")
+	if err := os.WriteFile(badXDGDataHome, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", badXDGDataHome, err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", badXDGDataHome)
+
+	if _, err := GenerateTransitionNotifierLaunchdPlist(); err == nil {
+		t.Fatal("GenerateTransitionNotifierLaunchdPlist() error = nil, want log path lookup error")
+	}
+	if _, err := GenerateSystemdTransitionNotifierService(); err == nil {
+		t.Fatal("GenerateSystemdTransitionNotifierService() error = nil, want log path lookup error")
 	}
 }
 

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -687,22 +687,15 @@ func TestConductorStatusJSON_ZeroActivityOmitted(t *testing.T) {
 // --- Symlink-based CLAUDE.md tests ---
 
 func TestInstallSharedClaudeMD_Default(t *testing.T) {
-	// Use actual conductor directory (cleanup after test)
-	homeDir, _ := os.UserHomeDir()
-	conductorDir := filepath.Join(homeDir, ".agent-deck", "conductor")
+	t.Setenv("HOME", t.TempDir())
+	conductorDir, err := ConductorDir()
+	if err != nil {
+		t.Fatalf("ConductorDir: %v", err)
+	}
 	claudeMDPath := filepath.Join(conductorDir, "CLAUDE.md")
 
-	// Backup existing file if present
-	var backup []byte
-	if content, err := os.ReadFile(claudeMDPath); err == nil {
-		backup = content
-		defer func() { _ = os.WriteFile(claudeMDPath, backup, 0o644) }()
-	} else {
-		defer os.Remove(claudeMDPath)
-	}
-
 	// Test installing default template
-	err := InstallSharedClaudeMD("")
+	err = InstallSharedClaudeMD("")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -744,6 +737,7 @@ func TestInstallSharedClaudeMD_Default(t *testing.T) {
 }
 
 func TestInstallSharedClaudeMD_CustomSymlink(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	tmpDir := t.TempDir()
 	customPath := filepath.Join(tmpDir, "my-shared-claude.md")
 
@@ -752,30 +746,14 @@ func TestInstallSharedClaudeMD_CustomSymlink(t *testing.T) {
 		t.Fatalf("failed to create custom file: %v", err)
 	}
 
-	// Use actual conductor directory (cleanup after test)
-	homeDir, _ := os.UserHomeDir()
-	conductorDir := filepath.Join(homeDir, ".agent-deck", "conductor")
+	conductorDir, err := ConductorDir()
+	if err != nil {
+		t.Fatalf("ConductorDir: %v", err)
+	}
 	claudeMDPath := filepath.Join(conductorDir, "CLAUDE.md")
 
-	// Backup existing file/symlink if present
-	var backupContent []byte
-	var backupLink string
-	if linkDest, err := os.Readlink(claudeMDPath); err == nil {
-		backupLink = linkDest
-	} else if content, err := os.ReadFile(claudeMDPath); err == nil {
-		backupContent = content
-	}
-	t.Cleanup(func() {
-		os.Remove(claudeMDPath) // Remove whatever the test created (symlink or file)
-		if backupLink != "" {
-			_ = os.Symlink(backupLink, claudeMDPath)
-		} else if backupContent != nil {
-			_ = os.WriteFile(claudeMDPath, backupContent, 0o644)
-		}
-	})
-
 	// Test installing with custom path (creates symlink)
-	err := InstallSharedClaudeMD(customPath)
+	err = InstallSharedClaudeMD(customPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -811,7 +789,11 @@ func TestInstallSharedClaudeMD_CustomSymlinkCreatesConductorDir(t *testing.T) {
 		t.Fatalf("InstallSharedClaudeMD returned error: %v", err)
 	}
 
-	target := filepath.Join(tmpHome, ".agent-deck", "conductor", "CLAUDE.md")
+	conductorDir, err := ConductorDir()
+	if err != nil {
+		t.Fatalf("ConductorDir: %v", err)
+	}
+	target := filepath.Join(conductorDir, "CLAUDE.md")
 	linkDest, err := os.Readlink(target)
 	if err != nil {
 		t.Fatalf("expected symlink at %q: %v", target, err)

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -638,8 +638,11 @@ func TestConductorHeartbeatScript_InjectsHeartbeatRules(t *testing.T) {
 	if !strings.Contains(conductorHeartbeatScript, "{PROFILE}/HEARTBEAT_RULES.md") {
 		t.Fatal("heartbeat script should look up per-profile HEARTBEAT_RULES.md")
 	}
+	if !strings.Contains(conductorHeartbeatScript, "$CONDUCTOR_ROOT/HEARTBEAT_RULES.md") {
+		t.Fatal("heartbeat script should look up global HEARTBEAT_RULES.md under the effective conductor root")
+	}
 	if !strings.Contains(conductorHeartbeatScript, "/.agent-deck/conductor/HEARTBEAT_RULES.md") {
-		t.Fatal("heartbeat script should fall back to the global HEARTBEAT_RULES.md")
+		t.Fatal("heartbeat script should fall back to the legacy global HEARTBEAT_RULES.md")
 	}
 	// The rendered (not raw) script should carry the bridge-style prefix so the
 	// idle-pause matcher (IsConductorHeartbeatMessage) can recognise heartbeat
@@ -647,6 +650,26 @@ func TestConductorHeartbeatScript_InjectsHeartbeatRules(t *testing.T) {
 	rendered := renderConductorHeartbeatScript("alpha", "default")
 	if !strings.Contains(rendered, ConductorBridgeHeartbeatPrefix) {
 		t.Fatalf("rendered heartbeat script should emit %q prefix (matches bridge.py)", ConductorBridgeHeartbeatPrefix)
+	}
+}
+
+func TestRenderConductorHeartbeatScript_UsesXDGConductorRoot(t *testing.T) {
+	home := t.TempDir()
+	xdgData := filepath.Join(home, "xdg data")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", xdgData)
+
+	wantRoot := filepath.Join(xdgData, "agent-deck", "conductor")
+	script := renderConductorHeartbeatScript("alpha", "work")
+
+	if !strings.Contains(script, `CONDUCTOR_ROOT="`+wantRoot+`"`) {
+		t.Fatalf("heartbeat script should render XDG conductor root %q:\n%s", wantRoot, script)
+	}
+	if !strings.Contains(script, `"$CONDUCTOR_ROOT/alpha/HEARTBEAT_RULES.md"`) {
+		t.Fatalf("heartbeat script should check per-conductor rules under XDG root:\n%s", script)
+	}
+	if !strings.Contains(script, `"$HOME/.agent-deck/conductor/alpha/HEARTBEAT_RULES.md"`) {
+		t.Fatalf("heartbeat script should retain legacy fallback:\n%s", script)
 	}
 }
 

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -828,12 +828,17 @@ func TestGenerateTransitionNotifierDaemons_SurfaceLogPathErrors(t *testing.T) {
 func TestInstallSharedConductorInstructions_CodexDefault(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmpHome, "xdg-data"))
 
 	if err := InstallSharedConductorInstructions(ConductorAgentCodex, ""); err != nil {
 		t.Fatalf("InstallSharedConductorInstructions returned error: %v", err)
 	}
 
-	target := filepath.Join(tmpHome, ".agent-deck", "conductor", "AGENTS.md")
+	conductorDir, err := ConductorDir()
+	if err != nil {
+		t.Fatalf("ConductorDir: %v", err)
+	}
+	target := filepath.Join(conductorDir, "AGENTS.md")
 	content, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatalf("failed to read AGENTS.md: %v", err)
@@ -849,6 +854,7 @@ func TestInstallSharedConductorInstructions_CodexDefault(t *testing.T) {
 func TestInstallSharedConductorInstructions_AgentsCoexist(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmpHome, "xdg-data"))
 
 	if err := InstallSharedConductorInstructions(ConductorAgentClaude, ""); err != nil {
 		t.Fatalf("InstallSharedConductorInstructions(claude) returned error: %v", err)
@@ -857,7 +863,10 @@ func TestInstallSharedConductorInstructions_AgentsCoexist(t *testing.T) {
 		t.Fatalf("InstallSharedConductorInstructions(codex) returned error: %v", err)
 	}
 
-	base := filepath.Join(tmpHome, ".agent-deck", "conductor")
+	base, err := ConductorDir()
+	if err != nil {
+		t.Fatalf("ConductorDir: %v", err)
+	}
 	for _, file := range []string{"CLAUDE.md", "AGENTS.md"} {
 		if _, err := os.Stat(filepath.Join(base, file)); err != nil {
 			t.Fatalf("%s should exist: %v", file, err)

--- a/internal/session/config.go
+++ b/internal/session/config.go
@@ -35,6 +35,8 @@ type Config struct {
 }
 
 // GetAgentDeckDir returns the effective agent-deck data directory.
+// It is a broad compatibility wrapper for data/runtime callers, not the
+// config root. Profile/session migrations must use profileDataRootDir().
 func GetAgentDeckDir() (string, error) {
 	return agentpaths.EffectiveDataDir(
 		ProfilesDirName,
@@ -52,6 +54,10 @@ func GetAgentDeckDir() (string, error) {
 	)
 }
 
+func profileDataRootDir() (string, error) {
+	return agentpaths.EffectiveDataDir(ProfilesDirName, "sessions.json")
+}
+
 // GetConfigPath returns the path to the global config file
 func GetConfigPath() (string, error) {
 	return agentpaths.EffectiveConfigPath(ConfigFileName)
@@ -59,7 +65,7 @@ func GetConfigPath() (string, error) {
 
 // GetProfilesDir returns the path to the profiles directory
 func GetProfilesDir() (string, error) {
-	dir, err := agentpaths.EffectiveDataDir(ProfilesDirName, "sessions.json")
+	dir, err := profileDataRootDir()
 	if err != nil {
 		return "", err
 	}

--- a/internal/session/config.go
+++ b/internal/session/config.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 )
 
 const (
@@ -32,27 +34,32 @@ type Config struct {
 	Version int `json:"version"`
 }
 
-// GetAgentDeckDir returns the base agent-deck directory (~/.agent-deck)
+// GetAgentDeckDir returns the effective agent-deck data directory.
 func GetAgentDeckDir() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get home directory: %w", err)
-	}
-	return filepath.Join(homeDir, ".agent-deck"), nil
+	return agentpaths.EffectiveDataDir(
+		ProfilesDirName,
+		"sessions.json",
+		"hooks",
+		"events",
+		"inboxes",
+		"conductor",
+		"watcher",
+		"watchers",
+		"locks",
+		"runtime",
+		"logs",
+		"cost-events",
+	)
 }
 
 // GetConfigPath returns the path to the global config file
 func GetConfigPath() (string, error) {
-	dir, err := GetAgentDeckDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, ConfigFileName), nil
+	return agentpaths.EffectiveConfigPath(ConfigFileName)
 }
 
 // GetProfilesDir returns the path to the profiles directory
 func GetProfilesDir() (string, error) {
-	dir, err := GetAgentDeckDir()
+	dir, err := agentpaths.EffectiveDataDir(ProfilesDirName, "sessions.json")
 	if err != nil {
 		return "", err
 	}

--- a/internal/session/data_paths.go
+++ b/internal/session/data_paths.go
@@ -1,0 +1,33 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+)
+
+func dataPath(name string, markers ...string) (string, error) {
+	if len(markers) == 0 {
+		markers = []string{name}
+	}
+	return agentpaths.EffectiveDataPath(name, markers...)
+}
+
+func runtimeDataPath(name string) (string, error) {
+	return dataPath(filepath.Join("runtime", name), "runtime")
+}
+
+func logDataPath(name string) (string, error) {
+	return dataPath(filepath.Join("logs", name), "logs")
+}
+
+func tempAgentDeckPath(parts ...string) string {
+	all := append([]string{os.TempDir(), ".agent-deck"}, parts...)
+	return filepath.Join(all...)
+}
+
+// TriageDir returns the directory used for watcher triage session results.
+func TriageDir() (string, error) {
+	return dataPath("triage", "triage")
+}

--- a/internal/session/event_writer.go
+++ b/internal/session/event_writer.go
@@ -23,11 +23,11 @@ type StatusEvent struct {
 
 // GetEventsDir returns the path to the events directory.
 func GetEventsDir() string {
-	home, err := os.UserHomeDir()
+	path, err := dataPath("events", "events")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "events")
+		return tempAgentDeckPath("events")
 	}
-	return filepath.Join(home, ".agent-deck", "events")
+	return path
 }
 
 // WriteStatusEvent atomically writes a status event to the events directory.

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -325,9 +325,9 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 
 // GetHooksDir returns the path to the hooks status directory.
 func GetHooksDir() string {
-	home, err := os.UserHomeDir()
+	path, err := dataPath("hooks", "hooks")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "hooks")
+		return tempAgentDeckPath("hooks")
 	}
-	return filepath.Join(home, ".agent-deck", "hooks")
+	return path
 }

--- a/internal/session/idle_timeout_watcher.go
+++ b/internal/session/idle_timeout_watcher.go
@@ -48,11 +48,11 @@ var sessionLifecycleLogMu sync.Mutex
 // Distinct from session-id-lifecycle.jsonl (which logs bind/rebind), this
 // covers process-level lifecycle decisions like idle-timeout-expired.
 func GetSessionLifecycleLogPath() string {
-	agentDeckDir, err := GetAgentDeckDir()
+	path, err := logDataPath("session-lifecycle.jsonl")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "logs", "session-lifecycle.jsonl")
+		return tempAgentDeckPath("logs", "session-lifecycle.jsonl")
 	}
-	return filepath.Join(agentDeckDir, "logs", "session-lifecycle.jsonl")
+	return path
 }
 
 // WriteSessionLifecycleEvent appends a single JSONL row.

--- a/internal/session/inbox.go
+++ b/internal/session/inbox.go
@@ -134,11 +134,11 @@ var inboxFingerprintCache = map[string]map[string]struct{}{}
 
 // InboxDir returns the directory that holds per-parent inbox files.
 func InboxDir() string {
-	dir, err := GetAgentDeckDir()
+	dir, err := dataPath("inboxes", "inboxes")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "inboxes")
+		return tempAgentDeckPath("inboxes")
 	}
-	return filepath.Join(dir, "inboxes")
+	return dir
 }
 
 // InboxPathFor returns the absolute inbox path for a given parent session id.

--- a/internal/session/inbox_consumer.go
+++ b/internal/session/inbox_consumer.go
@@ -41,11 +41,11 @@ var consumedTurnsMu sync.Mutex
 
 // ConsumedTurnsDir holds per-parent consumed-fingerprint ledgers.
 func ConsumedTurnsDir() string {
-	dir, err := GetAgentDeckDir()
+	dir, err := runtimeDataPath("consumed-turns")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "runtime", "consumed-turns")
+		return tempAgentDeckPath("runtime", "consumed-turns")
 	}
-	return filepath.Join(dir, "runtime", "consumed-turns")
+	return dir
 }
 
 func consumedTurnsPathFor(parentID string) string {
@@ -217,11 +217,11 @@ func fileHasContent(path string) bool {
 // records staged for a drain, written before the inbox is truncated and dropped
 // only after the consumed ledger is finalized.
 func inboxInflightDir() string {
-	dir, err := GetAgentDeckDir()
+	dir, err := runtimeDataPath("inbox-inflight")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "runtime", "inbox-inflight")
+		return tempAgentDeckPath("runtime", "inbox-inflight")
 	}
-	return filepath.Join(dir, "runtime", "inbox-inflight")
+	return dir
 }
 
 func inboxInflightPathFor(parentID string) string {

--- a/internal/session/inbox_stophook.go
+++ b/internal/session/inbox_stophook.go
@@ -44,11 +44,11 @@ type StopHookDecision struct {
 }
 
 func stopBlocksDir() string {
-	dir, err := GetAgentDeckDir()
+	dir, err := runtimeDataPath("stop-blocks")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "runtime", "stop-blocks")
+		return tempAgentDeckPath("runtime", "stop-blocks")
 	}
-	return filepath.Join(dir, "runtime", "stop-blocks")
+	return dir
 }
 
 func stopBlocksPathFor(instanceID string) string {

--- a/internal/session/instance_spawn_guard.go
+++ b/internal/session/instance_spawn_guard.go
@@ -41,8 +41,8 @@ import (
 
 // agentDeckDirOverride lets tests redirect ~/.agent-deck without colliding
 // with the user's real install. Production code reads it via
-// resolveAgentDeckDirForSpawnLock(), which falls back to GetAgentDeckDir
-// when the override is empty.
+// resolveLocksDirForSpawnLock(), which falls back to the effective XDG data
+// locks dir when the override is empty.
 var agentDeckDirOverride string
 
 // SpawnAttempt is the single-flight wrapper used by Restart(), Start(),
@@ -143,11 +143,10 @@ func recordInstanceSpawn(instanceID string) {
 // instanceSpawnStampPath sits next to the lock file. Same dir, "-stamp"
 // suffix so an `ls` triages spawn activity per instance.
 func instanceSpawnStampPath(instanceID string) (string, error) {
-	dir, err := resolveAgentDeckDirForSpawnLock()
+	locks, err := resolveLocksDirForSpawnLock()
 	if err != nil {
 		return "", err
 	}
-	locks := filepath.Join(dir, "locks")
 	if err := os.MkdirAll(locks, 0o700); err != nil {
 		return "", err
 	}
@@ -203,11 +202,10 @@ func defaultAcquireInstanceSpawnLock(instanceID string) (func(), error) {
 // The directory is created with 0700 (same permission as plugin_install
 // uses for the same locks/ dir).
 func instanceSpawnLockPath(instanceID string) (string, error) {
-	dir, err := resolveAgentDeckDirForSpawnLock()
+	locks, err := resolveLocksDirForSpawnLock()
 	if err != nil {
 		return "", err
 	}
-	locks := filepath.Join(dir, "locks")
 	if err := os.MkdirAll(locks, 0o700); err != nil {
 		return "", err
 	}
@@ -239,11 +237,11 @@ func spawnLockSafeID(id string) string {
 	return mapped
 }
 
-func resolveAgentDeckDirForSpawnLock() (string, error) {
+func resolveLocksDirForSpawnLock() (string, error) {
 	if agentDeckDirOverride != "" {
-		return agentDeckDirOverride, nil
+		return filepath.Join(agentDeckDirOverride, "locks"), nil
 	}
-	return GetAgentDeckDir()
+	return dataPath("locks", "locks")
 }
 
 // reclaimStaleInstanceSpawnLock mirrors reclaimStalePluginLock — older

--- a/internal/session/maintenance.go
+++ b/internal/session/maintenance.go
@@ -29,7 +29,7 @@ type MaintenanceResult struct {
 func RunMaintenance(ctx context.Context) MaintenanceResult {
 	start := time.Now()
 
-	deckDir, err := GetAgentDeckDir()
+	profileRoot, err := profileDataRootDir()
 	if err != nil {
 		maintLog.Warn("maintenance_dir_lookup_failed", slog.String("error", err.Error()))
 		return MaintenanceResult{Duration: time.Since(start)}
@@ -37,8 +37,8 @@ func RunMaintenance(ctx context.Context) MaintenanceResult {
 	geminiDir := GetGeminiConfigDir()
 
 	prunedLogs := pruneGeminiLogs(geminiDir)
-	prunedBackups := cleanupDeckBackups(filepath.Join(deckDir, "profiles"))
-	archivedSessions := archiveBloatedSessions(deckDir)
+	prunedBackups := cleanupDeckBackups(filepath.Join(profileRoot, "profiles"))
+	archivedSessions := archiveBloatedSessions(profileRoot)
 	orphanContainers := cleanupOrphanContainers(ctx)
 
 	return MaintenanceResult{

--- a/internal/session/migration.go
+++ b/internal/session/migration.go
@@ -39,7 +39,7 @@ type MigrationResult struct {
 //	~/.agent-deck/profiles/default/sessions.json.bak.2
 //	~/.agent-deck/logs/ (unchanged)
 func MigrateToProfiles() (*MigrationResult, error) {
-	agentDeckDir, err := GetAgentDeckDir()
+	agentDeckDir, err := profileDataRootDir()
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func MigrateToProfiles() (*MigrationResult, error) {
 
 // NeedsMigration checks if migration from old layout is needed
 func NeedsMigration() (bool, error) {
-	agentDeckDir, err := GetAgentDeckDir()
+	agentDeckDir, err := profileDataRootDir()
 	if err != nil {
 		return false, err
 	}

--- a/internal/session/plugin_install.go
+++ b/internal/session/plugin_install.go
@@ -238,11 +238,10 @@ func pluginLockPath(sourceProfileDir string, def *PluginDef) (string, error) {
 	if def == nil {
 		return "", fmt.Errorf("nil PluginDef")
 	}
-	dir, err := GetAgentDeckDir()
+	locks, err := dataPath("locks", "locks")
 	if err != nil {
 		return "", err
 	}
-	locks := filepath.Join(dir, "locks")
 	if err := os.MkdirAll(locks, 0o700); err != nil {
 		return "", err
 	}

--- a/internal/session/plugins_catalog_test.go
+++ b/internal/session/plugins_catalog_test.go
@@ -27,9 +27,9 @@ import (
 func withTempHome(t *testing.T) string {
 	t.Helper()
 	temp := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", temp)
-	t.Cleanup(func() { os.Setenv("HOME", originalHome) })
+	t.Setenv("HOME", temp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(temp, "xdg-config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(temp, "xdg-data"))
 	ClearUserConfigCache()
 	t.Cleanup(ClearUserConfigCache)
 	return temp

--- a/internal/session/plugins_catalog_test.go
+++ b/internal/session/plugins_catalog_test.go
@@ -35,11 +35,15 @@ func withTempHome(t *testing.T) string {
 	return temp
 }
 
-// writeConfig drops a config.toml with the given content into the test
-// HOME's .agent-deck dir.
+// writeConfig drops a config.toml with the given content into the test XDG
+// config dir.
 func writeConfig(t *testing.T, home, content string) {
 	t.Helper()
-	dir := filepath.Join(home, ".agent-deck")
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		configHome = filepath.Join(home, ".config")
+	}
+	dir := filepath.Join(configHome, "agent-deck")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("mkdir agent-deck: %v", err)
 	}

--- a/internal/session/session_id_event_log.go
+++ b/internal/session/session_id_event_log.go
@@ -28,11 +28,11 @@ var sessionIDLifecycleLogMu sync.Mutex
 
 // GetSessionIDLifecycleLogPath returns ~/.agent-deck/logs/session-id-lifecycle.jsonl.
 func GetSessionIDLifecycleLogPath() string {
-	agentDeckDir, err := GetAgentDeckDir()
+	path, err := logDataPath("session-id-lifecycle.jsonl")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "logs", "session-id-lifecycle.jsonl")
+		return tempAgentDeckPath("logs", "session-id-lifecycle.jsonl")
 	}
-	return filepath.Join(agentDeckDir, "logs", "session-id-lifecycle.jsonl")
+	return path
 }
 
 // WriteSessionIDLifecycleEvent appends a single JSONL event.

--- a/internal/session/skills_catalog.go
+++ b/internal/session/skills_catalog.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 )
 
 const (
@@ -238,16 +240,34 @@ func isContainedIn(basePath, targetPath string) bool {
 	return strings.HasPrefix(normalizedTarget, normalizedBase+string(os.PathSeparator))
 }
 
-// GetSkillsRootPath returns ~/.agent-deck/skills.
+// GetSkillsRootPath returns the Agent Deck skills config directory, falling back
+// to the legacy ~/.agent-deck/skills tree when it already exists.
 func GetSkillsRootPath() (string, error) {
-	base, err := GetAgentDeckDir()
+	configDir, err := agentpaths.ConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, skillsDirName), nil
+	xdgPath := filepath.Join(configDir, skillsDirName)
+	if _, err := os.Stat(xdgPath); err == nil {
+		return xdgPath, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+
+	legacyDir, err := agentpaths.LegacyDir()
+	if err != nil {
+		return xdgPath, nil
+	}
+	legacyPath := filepath.Join(legacyDir, skillsDirName)
+	if _, err := os.Stat(legacyPath); err == nil {
+		return legacyPath, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	return xdgPath, nil
 }
 
-// GetSkillSourcesPath returns ~/.agent-deck/skills/sources.toml.
+// GetSkillSourcesPath returns the skill source registry path.
 func GetSkillSourcesPath() (string, error) {
 	root, err := GetSkillsRootPath()
 	if err != nil {
@@ -256,7 +276,7 @@ func GetSkillSourcesPath() (string, error) {
 	return filepath.Join(root, skillSourcesFileName), nil
 }
 
-// GetSkillPoolPath returns ~/.agent-deck/skills/pool.
+// GetSkillPoolPath returns the managed skill pool path.
 func GetSkillPoolPath() (string, error) {
 	root, err := GetSkillsRootPath()
 	if err != nil {

--- a/internal/session/skills_catalog_test.go
+++ b/internal/session/skills_catalog_test.go
@@ -110,6 +110,54 @@ func TestLoadSkillSources_DefaultsWhenMissing(t *testing.T) {
 	}
 }
 
+func TestGetSkillPoolPath_UsesXDGConfigForNewInstall(t *testing.T) {
+	homeDir, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+	xdgConfigHome := filepath.Join(homeDir, "xdg-config")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+	got, err := GetSkillPoolPath()
+	if err != nil {
+		t.Fatalf("GetSkillPoolPath failed: %v", err)
+	}
+	want := filepath.Join(xdgConfigHome, "agent-deck", "skills", "pool")
+	if got != want {
+		t.Fatalf("GetSkillPoolPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGetSkillPoolPath_LegacySkillsFallback(t *testing.T) {
+	homeDir, cleanup := setupSkillTestEnv(t)
+	defer cleanup()
+	xdgConfigHome := filepath.Join(homeDir, "xdg-config")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+	legacySkills := filepath.Join(homeDir, ".agent-deck", "skills")
+	if err := os.MkdirAll(filepath.Join(legacySkills, "pool"), 0o700); err != nil {
+		t.Fatalf("mkdir legacy skills pool: %v", err)
+	}
+
+	got, err := GetSkillPoolPath()
+	if err != nil {
+		t.Fatalf("GetSkillPoolPath failed: %v", err)
+	}
+	want := filepath.Join(legacySkills, "pool")
+	if got != want {
+		t.Fatalf("GetSkillPoolPath() = %q, want legacy %q", got, want)
+	}
+
+	if err := os.MkdirAll(filepath.Join(xdgConfigHome, "agent-deck", "skills"), 0o700); err != nil {
+		t.Fatalf("mkdir XDG skills root: %v", err)
+	}
+	got, err = GetSkillPoolPath()
+	if err != nil {
+		t.Fatalf("GetSkillPoolPath with XDG marker failed: %v", err)
+	}
+	want = filepath.Join(xdgConfigHome, "agent-deck", "skills", "pool")
+	if got != want {
+		t.Fatalf("XDG skills root should win once present: got %q want %q", got, want)
+	}
+}
+
 func TestExpandSkillPath_DollarHome(t *testing.T) {
 	homeDir, cleanup := setupSkillTestEnv(t)
 	defer cleanup()

--- a/internal/session/taskworker.go
+++ b/internal/session/taskworker.go
@@ -50,11 +50,7 @@ type CompletionRecord struct {
 }
 
 func completionsDir() (string, error) {
-	dir, err := GetAgentDeckDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "runtime", "completions"), nil
+	return runtimeDataPath("completions")
 }
 
 // safeRecordName keeps a child id usable as a single path segment, defending the

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -129,6 +130,7 @@ func TestMain(m *testing.M) {
 	// Git hooks export GIT_DIR/GIT_WORK_TREE; clear them so test subprocess git
 	// commands operate on their temp repos instead of the real repository.
 	testutil.UnsetGitRepoEnv()
+	isolatePackageHome("agent-deck-session-tests-home-*")
 
 	// Isolate the tmux socket. Without this, tests spawn tmux sessions on the
 	// user's default socket and destabilize live agent-deck sessions.
@@ -160,6 +162,17 @@ func TestMain(m *testing.M) {
 	cleanupTestSessions()
 
 	os.Exit(code)
+}
+
+func isolatePackageHome(pattern string) {
+	home, err := os.MkdirTemp("", pattern)
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("HOME", home)
+	os.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	os.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	os.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
 }
 
 // cleanupTestSessions kills any tmux sessions created during testing.

--- a/internal/session/transition_notifier.go
+++ b/internal/session/transition_notifier.go
@@ -598,35 +598,35 @@ func (n *TransitionNotifier) logMissed(event TransitionNotificationEvent, reason
 // --- paths -------------------------------------------------------------------
 
 func transitionNotifyStatePath() string {
-	dir, err := GetAgentDeckDir()
+	path, err := runtimeDataPath("transition-notify-state.json")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "runtime", "transition-notify-state.json")
+		return tempAgentDeckPath("runtime", "transition-notify-state.json")
 	}
-	return filepath.Join(dir, "runtime", "transition-notify-state.json")
+	return path
 }
 
 func transitionNotifyLogPath() string {
-	dir, err := GetAgentDeckDir()
+	path, err := logDataPath("transition-notifier.log")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "logs", "transition-notifier.log")
+		return tempAgentDeckPath("logs", "transition-notifier.log")
 	}
-	return filepath.Join(dir, "logs", "transition-notifier.log")
+	return path
 }
 
 func transitionNotifierMissedPath() string {
-	dir, err := GetAgentDeckDir()
+	path, err := logDataPath("notifier-missed.log")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "logs", "notifier-missed.log")
+		return tempAgentDeckPath("logs", "notifier-missed.log")
 	}
-	return filepath.Join(dir, "logs", "notifier-missed.log")
+	return path
 }
 
 func transitionNotifierOrphanLogPath() string {
-	dir, err := GetAgentDeckDir()
+	path, err := logDataPath("notifier-orphans.log")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "logs", "notifier-orphans.log")
+		return tempAgentDeckPath("logs", "notifier-orphans.log")
 	}
-	return filepath.Join(dir, "logs", "notifier-orphans.log")
+	return path
 }
 
 // --- orphan WARN -------------------------------------------------------------

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -18,6 +18,7 @@ import (
 
 	dark "github.com/thiagokokada/dark-mode-go"
 
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/platform"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
@@ -2043,11 +2044,7 @@ var (
 
 // GetUserConfigPath returns the path to the user config file
 func GetUserConfigPath() (string, error) {
-	dir, err := GetAgentDeckDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, UserConfigFileName), nil
+	return agentpaths.EffectiveConfigPath(UserConfigFileName)
 }
 
 // LoadUserConfig loads the user configuration from TOML file.

--- a/internal/session/watcher_meta.go
+++ b/internal/session/watcher_meta.go
@@ -19,11 +19,7 @@ type WatcherMeta struct {
 
 // WatcherDir returns the base directory for all watchers (~/.agent-deck/watcher).
 func WatcherDir() (string, error) {
-	dir, err := GetAgentDeckDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "watcher"), nil
+	return dataPath("watcher", "watcher", "watchers")
 }
 
 // WatcherNameDir returns the directory for a named watcher (~/.agent-deck/watcher/<name>).

--- a/internal/session/watcher_meta.go
+++ b/internal/session/watcher_meta.go
@@ -8,7 +8,7 @@ import (
 )
 
 // WatcherMeta holds metadata for a named watcher instance.
-// Persisted as meta.json in ~/.agent-deck/watcher/<name>/.
+// Persisted as meta.json in the effective watcher/<name> data directory.
 type WatcherMeta struct {
 	Name           string `json:"name"`
 	Type           string `json:"type"`                       // adapter type: "webhook", "ntfy", "github", "slack", "gmail"
@@ -17,12 +17,12 @@ type WatcherMeta struct {
 	WatchHistoryID string `json:"watch_history_id,omitempty"` // uint64 as string (gmail only) — last processed Gmail history ID
 }
 
-// WatcherDir returns the base directory for all watchers (~/.agent-deck/watcher).
+// WatcherDir returns the effective base directory for all watchers.
 func WatcherDir() (string, error) {
 	return dataPath("watcher", "watcher", "watchers")
 }
 
-// WatcherNameDir returns the directory for a named watcher (~/.agent-deck/watcher/<name>).
+// WatcherNameDir returns the effective directory for a named watcher.
 func WatcherNameDir(name string) (string, error) {
 	base, err := WatcherDir()
 	if err != nil {

--- a/internal/session/watcher_meta_test.go
+++ b/internal/session/watcher_meta_test.go
@@ -7,6 +7,15 @@ import (
 	"time"
 )
 
+func testWatcherNameDir(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := WatcherNameDir(name)
+	if err != nil {
+		t.Fatalf("WatcherNameDir(%q): %v", name, err)
+	}
+	return dir
+}
+
 func TestWatcherMetaRoundTrip(t *testing.T) {
 	// Use a temp HOME directory to avoid touching real ~/.agent-deck
 	tmpDir := t.TempDir()
@@ -23,7 +32,7 @@ func TestWatcherMetaRoundTrip(t *testing.T) {
 	}
 
 	// Verify file was created at expected path
-	expectedPath := filepath.Join(tmpDir, ".agent-deck", "watcher", "test-watcher", "meta.json")
+	expectedPath := filepath.Join(testWatcherNameDir(t, "test-watcher"), "meta.json")
 	if _, err := os.Stat(expectedPath); os.IsNotExist(err) {
 		t.Fatalf("meta.json not created at expected path: %s", expectedPath)
 	}
@@ -74,7 +83,7 @@ func TestWatcherMetaLoadBackfillsName(t *testing.T) {
 	}
 
 	// Overwrite with JSON missing the name field
-	metaPath := filepath.Join(tmpDir, ".agent-deck", "watcher", "backfill-test", "meta.json")
+	metaPath := filepath.Join(testWatcherNameDir(t, "backfill-test"), "meta.json")
 	if err := os.WriteFile(metaPath, []byte(`{"type":"ntfy","created_at":"2026-04-10T12:00:00Z"}`), 0o644); err != nil {
 		t.Fatalf("overwrite meta.json: %v", err)
 	}
@@ -154,7 +163,7 @@ func TestSaveWatcherMeta_AtomicWrite(t *testing.T) {
 		t.Fatalf("SaveWatcherMeta: %v", err)
 	}
 
-	dir := filepath.Join(tmpDir, ".agent-deck", "watcher", "atomic-test")
+	dir := testWatcherNameDir(t, "atomic-test")
 	finalPath := filepath.Join(dir, "meta.json")
 	tmpPath := finalPath + ".tmp"
 
@@ -197,7 +206,7 @@ func TestWatcherDirHelpers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WatcherDir: %v", err)
 	}
-	expected := filepath.Join(tmpDir, ".agent-deck", "watcher")
+	expected := filepath.Join(tmpDir, ".local", "share", "agent-deck", "watcher")
 	if dir != expected {
 		t.Errorf("WatcherDir() = %q, want %q", dir, expected)
 	}
@@ -206,7 +215,7 @@ func TestWatcherDirHelpers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WatcherNameDir: %v", err)
 	}
-	expectedName := filepath.Join(tmpDir, ".agent-deck", "watcher", "my-watcher")
+	expectedName := filepath.Join(expected, "my-watcher")
 	if nameDir != expectedName {
 		t.Errorf("WatcherNameDir() = %q, want %q", nameDir, expectedName)
 	}

--- a/internal/session/watcher_meta_test.go
+++ b/internal/session/watcher_meta_test.go
@@ -7,6 +7,14 @@ import (
 	"time"
 )
 
+func testWatcherHome(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("XDG_DATA_HOME", "")
+	return tmpDir
+}
+
 func testWatcherNameDir(t *testing.T, name string) string {
 	t.Helper()
 	dir, err := WatcherNameDir(name)
@@ -18,8 +26,7 @@ func testWatcherNameDir(t *testing.T, name string) string {
 
 func TestWatcherMetaRoundTrip(t *testing.T) {
 	// Use a temp HOME directory to avoid touching real ~/.agent-deck
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testWatcherHome(t)
 
 	meta := &WatcherMeta{
 		Name:      "test-watcher",
@@ -54,8 +61,7 @@ func TestWatcherMetaRoundTrip(t *testing.T) {
 }
 
 func TestWatcherMetaSaveValidation(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testWatcherHome(t)
 
 	// nil meta should error
 	if err := SaveWatcherMeta(nil); err == nil {
@@ -69,8 +75,7 @@ func TestWatcherMetaSaveValidation(t *testing.T) {
 }
 
 func TestWatcherMetaLoadBackfillsName(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testWatcherHome(t)
 
 	// Save a meta with a name, then manually edit to remove the name field
 	meta := &WatcherMeta{
@@ -101,8 +106,7 @@ func TestWatcherMetaLoadBackfillsName(t *testing.T) {
 // round-trip through Save/Load and that empty values omit from JSON so that
 // legacy Phase 13/14 watchers (webhook, ntfy, github, slack) still parse cleanly.
 func TestWatcherMetaRoundTrip_GmailFields(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testWatcherHome(t)
 
 	expiry := time.Now().Add(7 * 24 * time.Hour).UTC().Format(time.RFC3339)
 	meta := &WatcherMeta{
@@ -151,8 +155,7 @@ func TestWatcherMetaRoundTrip_GmailFields(t *testing.T) {
 // exactly meta.json on disk with no .tmp file remnant, and that a stale
 // .tmp file left behind by a previous crashed run is overwritten cleanly.
 func TestSaveWatcherMeta_AtomicWrite(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	testWatcherHome(t)
 
 	meta := &WatcherMeta{
 		Name:      "atomic-test",
@@ -199,8 +202,7 @@ func TestSaveWatcherMeta_AtomicWrite(t *testing.T) {
 }
 
 func TestWatcherDirHelpers(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
+	tmpDir := testWatcherHome(t)
 
 	dir, err := WatcherDir()
 	if err != nil {

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -27,7 +27,7 @@
 //
 // Cleanup. `CleanupWorkerScratchConfigDir` removes the dir on
 // session stop/remove — best-effort, no-op on first-time misses. The
-// scratch dir lives under `~/.agent-deck/worker-scratch/<instance-id>/`.
+// scratch dir lives under the effective worker-scratch data directory.
 
 package session
 
@@ -261,7 +261,7 @@ func computeAllowList(i *Instance) []string {
 func workerScratchDirRoot(home string) string {
 	dir, err := dataPath("worker-scratch", "worker-scratch")
 	if err != nil {
-		return filepath.Join(home, ".agent-deck", "worker-scratch")
+		return filepath.Join(os.TempDir(), "agent-deck", "worker-scratch")
 	}
 	return dir
 }
@@ -630,9 +630,8 @@ var macOSScratchWarningEmitter func(sourceProfileDir string) = emitMacOSScratchW
 
 // maybeEmitMacOSScratchWarning is a no-op on non-darwin and a one-shot
 // per-(host, sourceProfileDir) pair on darwin. Cache lives in
-// `~/.agent-deck/state.json` under the key
-// `macos_plugin_scratch_warning_shown[<sourceProfileDir>]` so a second
-// session re-using the same source profile silently skips the warning.
+// the effective data directory so a second session re-using the same
+// source profile silently skips the warning.
 //
 // Best-effort: state-file errors (read or write) do NOT block the
 // session. Worst case: warning is shown twice.
@@ -659,7 +658,7 @@ func goosNative() string { return runtime.GOOS }
 
 // macOSWarningStateFile is the single-flag JSON state file recording
 // which source profile dirs already showed the macOS plugin-scratch
-// warning. Lives at `~/.agent-deck/macos-plugin-warning-state.json`.
+// warning. Lives in the effective data directory.
 //
 // Schema: { "shown": { "<source-profile-dir>": true, ... } }
 //

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -259,7 +259,11 @@ func computeAllowList(i *Instance) []string {
 // workerScratchDirFor below which derives this from the effective
 // HOME at call time.
 func workerScratchDirRoot(home string) string {
-	return filepath.Join(home, ".agent-deck", "worker-scratch")
+	dir, err := dataPath("worker-scratch", "worker-scratch")
+	if err != nil {
+		return filepath.Join(home, ".agent-deck", "worker-scratch")
+	}
+	return dir
 }
 
 func workerScratchDirFor(home, instanceID string) string {
@@ -662,11 +666,7 @@ func goosNative() string { return runtime.GOOS }
 // Best-effort everywhere — read errors degrade to "not yet shown",
 // write errors degrade to "may show twice". No mandate-level guard.
 func macOSWarningStateFile() (string, error) {
-	dir, err := GetAgentDeckDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "macos-plugin-warning-state.json"), nil
+	return dataPath("macos-plugin-warning-state.json", "macos-plugin-warning-state.json")
 }
 
 type macosWarningState struct {

--- a/internal/session/worker_scratch_test.go
+++ b/internal/session/worker_scratch_test.go
@@ -68,6 +68,7 @@ func TestEnsureWorkerScratchConfigDir_DisablesTelegramPlugin(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg-data"))
 
 	inst := &Instance{
 		ID:    "00000000-0000-0000-0000-000000000001",
@@ -166,6 +167,7 @@ func TestEnsureWorkerScratchConfigDir_ChannelOwner_AlwaysGetsScratch(t *testing.
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg-data"))
 	t.Setenv("CLAUDE_CONFIG_DIR", source)
 
 	inst := &Instance{
@@ -218,6 +220,7 @@ func TestEnsureWorkerScratchConfigDir_ChannelOwner_GlobalAntipattern_GetsScratch
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg-data"))
 	t.Setenv("CLAUDE_CONFIG_DIR", source)
 
 	inst := &Instance{
@@ -303,6 +306,7 @@ func TestBuildClaudeCommand_UsesWorkerScratchConfigDir(t *testing.T) {
 	withTelegramConductorPresent(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg-data"))
 	profile := filepath.Join(home, ".claude")
 	if err := os.MkdirAll(profile, 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/session/worker_scratch_test.go
+++ b/internal/session/worker_scratch_test.go
@@ -272,6 +272,9 @@ func TestEnsureWorkerScratchConfigDir_NonClaudeToolSkipped(t *testing.T) {
 // setup. The scratch settings.json always pins it false.
 func TestEnsureWorkerScratchConfigDir_TelegramAbsentStillPinsDisabled(t *testing.T) {
 	withTelegramConductorPresent(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg-data"))
 	source := t.TempDir()
 	_ = os.WriteFile(filepath.Join(source, "settings.json"), []byte(`{"enabledPlugins":{"superpowers@claude-plugins-official":true}}`), 0o644)
 

--- a/internal/session/xdg_paths_test.go
+++ b/internal/session/xdg_paths_test.go
@@ -185,6 +185,24 @@ func TestGetProfilesDir_XDGWinsWhenProfileMarkerExists(t *testing.T) {
 	}
 }
 
+func TestNeedsMigration_LegacySessionsJSONWinsOverBroadXDGDataMarker(t *testing.T) {
+	home, _, xdgDataHome := setupSessionXDGPathEnv(t)
+	xdgLogsDir := filepath.Join(xdgDataHome, "agent-deck", "logs")
+	if err := os.MkdirAll(xdgLogsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", xdgLogsDir, err)
+	}
+	legacySessionsPath := filepath.Join(home, ".agent-deck", "sessions.json")
+	writeSessionPathFile(t, legacySessionsPath)
+
+	needsMigration, err := NeedsMigration()
+	if err != nil {
+		t.Fatalf("NeedsMigration(): %v", err)
+	}
+	if !needsMigration {
+		t.Fatalf("NeedsMigration() = false, want true for legacy sessions.json even when XDG data has logs marker")
+	}
+}
+
 func TestGetDBPathForProfile_UsesXDGDataHomeForNewUser(t *testing.T) {
 	_, _, xdgDataHome := setupSessionXDGPathEnv(t)
 

--- a/internal/session/xdg_paths_test.go
+++ b/internal/session/xdg_paths_test.go
@@ -1,0 +1,222 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupSessionXDGPathEnv(t *testing.T) (home string, xdgConfigHome string, xdgDataHome string) {
+	t.Helper()
+
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	root := t.TempDir()
+	home = filepath.Join(root, "home")
+	xdgConfigHome = filepath.Join(root, "xdg-config")
+	xdgDataHome = filepath.Join(root, "xdg-data")
+
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", home, err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	return home, xdgConfigHome, xdgDataHome
+}
+
+func writeSessionPathFile(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+func TestGetUserConfigPath_UsesXDGConfigHomeForNewUser(t *testing.T) {
+	_, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
+
+	got, err := GetUserConfigPath()
+	if err != nil {
+		t.Fatalf("GetUserConfigPath(): %v", err)
+	}
+
+	want := filepath.Join(xdgConfigHome, "agent-deck", UserConfigFileName)
+	if got != want {
+		t.Fatalf("GetUserConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGetUserConfigPath_LegacyFallbackWhenXDGMissing(t *testing.T) {
+	home, _, _ := setupSessionXDGPathEnv(t)
+	legacyPath := filepath.Join(home, ".agent-deck", UserConfigFileName)
+	writeSessionPathFile(t, legacyPath)
+
+	got, err := GetUserConfigPath()
+	if err != nil {
+		t.Fatalf("GetUserConfigPath(): %v", err)
+	}
+
+	if got != legacyPath {
+		t.Fatalf("GetUserConfigPath() = %q, want %q", got, legacyPath)
+	}
+}
+
+func TestGetUserConfigPath_XDGWinsWhenBothExist(t *testing.T) {
+	home, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
+	legacyPath := filepath.Join(home, ".agent-deck", UserConfigFileName)
+	xdgPath := filepath.Join(xdgConfigHome, "agent-deck", UserConfigFileName)
+	writeSessionPathFile(t, legacyPath)
+	writeSessionPathFile(t, xdgPath)
+
+	got, err := GetUserConfigPath()
+	if err != nil {
+		t.Fatalf("GetUserConfigPath(): %v", err)
+	}
+
+	if got != xdgPath {
+		t.Fatalf("GetUserConfigPath() = %q, want %q", got, xdgPath)
+	}
+}
+
+func TestGetConfigPath_UsesXDGConfigHomeForNewUser(t *testing.T) {
+	_, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
+
+	got, err := GetConfigPath()
+	if err != nil {
+		t.Fatalf("GetConfigPath(): %v", err)
+	}
+
+	want := filepath.Join(xdgConfigHome, "agent-deck", ConfigFileName)
+	if got != want {
+		t.Fatalf("GetConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGetConfigPath_XDGWinsWhenBothExist(t *testing.T) {
+	home, xdgConfigHome, _ := setupSessionXDGPathEnv(t)
+	legacyPath := filepath.Join(home, ".agent-deck", ConfigFileName)
+	xdgPath := filepath.Join(xdgConfigHome, "agent-deck", ConfigFileName)
+	writeSessionPathFile(t, legacyPath)
+	writeSessionPathFile(t, xdgPath)
+
+	got, err := GetConfigPath()
+	if err != nil {
+		t.Fatalf("GetConfigPath(): %v", err)
+	}
+
+	if got != xdgPath {
+		t.Fatalf("GetConfigPath() = %q, want %q", got, xdgPath)
+	}
+}
+
+func TestGetProfilesDir_UsesXDGDataHomeForNewUser(t *testing.T) {
+	_, _, xdgDataHome := setupSessionXDGPathEnv(t)
+
+	got, err := GetProfilesDir()
+	if err != nil {
+		t.Fatalf("GetProfilesDir(): %v", err)
+	}
+
+	want := filepath.Join(xdgDataHome, "agent-deck", ProfilesDirName)
+	if got != want {
+		t.Fatalf("GetProfilesDir() = %q, want %q", got, want)
+	}
+}
+
+func TestGetProfilesDir_LegacyFallbackWhenProfilesExist(t *testing.T) {
+	home, _, _ := setupSessionXDGPathEnv(t)
+	legacyProfilesDir := filepath.Join(home, ".agent-deck", ProfilesDirName)
+	if err := os.MkdirAll(legacyProfilesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyProfilesDir, err)
+	}
+
+	got, err := GetProfilesDir()
+	if err != nil {
+		t.Fatalf("GetProfilesDir(): %v", err)
+	}
+
+	if got != legacyProfilesDir {
+		t.Fatalf("GetProfilesDir() = %q, want %q", got, legacyProfilesDir)
+	}
+}
+
+func TestGetProfilesDir_LegacyFallbackWhenSessionsJSONExists(t *testing.T) {
+	home, _, _ := setupSessionXDGPathEnv(t)
+	legacySessionsPath := filepath.Join(home, ".agent-deck", "sessions.json")
+	writeSessionPathFile(t, legacySessionsPath)
+
+	got, err := GetProfilesDir()
+	if err != nil {
+		t.Fatalf("GetProfilesDir(): %v", err)
+	}
+
+	want := filepath.Join(home, ".agent-deck", ProfilesDirName)
+	if got != want {
+		t.Fatalf("GetProfilesDir() = %q, want %q", got, want)
+	}
+}
+
+func TestGetProfilesDir_XDGWinsWhenProfileMarkerExists(t *testing.T) {
+	home, _, xdgDataHome := setupSessionXDGPathEnv(t)
+	legacyProfilesDir := filepath.Join(home, ".agent-deck", ProfilesDirName)
+	xdgProfilesDir := filepath.Join(xdgDataHome, "agent-deck", ProfilesDirName)
+	if err := os.MkdirAll(legacyProfilesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyProfilesDir, err)
+	}
+	if err := os.MkdirAll(xdgProfilesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", xdgProfilesDir, err)
+	}
+
+	got, err := GetProfilesDir()
+	if err != nil {
+		t.Fatalf("GetProfilesDir(): %v", err)
+	}
+
+	if got != xdgProfilesDir {
+		t.Fatalf("GetProfilesDir() = %q, want %q", got, xdgProfilesDir)
+	}
+}
+
+func TestGetDBPathForProfile_UsesXDGDataHomeForNewUser(t *testing.T) {
+	_, _, xdgDataHome := setupSessionXDGPathEnv(t)
+
+	got, err := GetDBPathForProfile("project/work")
+	if err != nil {
+		t.Fatalf("GetDBPathForProfile(): %v", err)
+	}
+
+	want := filepath.Join(xdgDataHome, "agent-deck", ProfilesDirName, "work", "state.db")
+	if got != want {
+		t.Fatalf("GetDBPathForProfile() = %q, want %q", got, want)
+	}
+}
+
+func TestNewStorageWithProfile_UsesXDGDataHome(t *testing.T) {
+	_, _, xdgDataHome := setupSessionXDGPathEnv(t)
+
+	storage, err := NewStorageWithProfile("xdg-profile")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := storage.Close(); err != nil {
+			t.Fatalf("Close(): %v", err)
+		}
+	})
+
+	want := filepath.Join(xdgDataHome, "agent-deck", ProfilesDirName, "xdg-profile", "state.db")
+	if got := storage.dbPath; got != want {
+		t.Fatalf("NewStorageWithProfile db path = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("Stat(%q): %v", want, err)
+	}
+}

--- a/internal/session/xdg_paths_test.go
+++ b/internal/session/xdg_paths_test.go
@@ -238,3 +238,155 @@ func TestNewStorageWithProfile_UsesXDGDataHome(t *testing.T) {
 		t.Fatalf("Stat(%q): %v", want, err)
 	}
 }
+
+func TestXDGDataTask4_RuntimeStateDirsUseXDGDataHomeForNewUser(t *testing.T) {
+	home, _, xdgDataHome := setupSessionXDGPathEnv(t)
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "hooks",
+			got:  GetHooksDir(),
+			want: filepath.Join(xdgDataHome, "agent-deck", "hooks"),
+		},
+		{
+			name: "events",
+			got:  GetEventsDir(),
+			want: filepath.Join(xdgDataHome, "agent-deck", "events"),
+		},
+		{
+			name: "inboxes",
+			got:  InboxDir(),
+			want: filepath.Join(xdgDataHome, "agent-deck", "inboxes"),
+		},
+		{
+			name: "transition state",
+			got:  transitionNotifyStatePath(),
+			want: filepath.Join(xdgDataHome, "agent-deck", "runtime", "transition-notify-state.json"),
+		},
+		{
+			name: "transition log",
+			got:  transitionNotifyLogPath(),
+			want: filepath.Join(xdgDataHome, "agent-deck", "logs", "transition-notifier.log"),
+		},
+		{
+			name: "session lifecycle log",
+			got:  GetSessionLifecycleLogPath(),
+			want: filepath.Join(xdgDataHome, "agent-deck", "logs", "session-lifecycle.jsonl"),
+		},
+		{
+			name: "session id lifecycle log",
+			got:  GetSessionIDLifecycleLogPath(),
+			want: filepath.Join(xdgDataHome, "agent-deck", "logs", "session-id-lifecycle.jsonl"),
+		},
+		{
+			name: "worker scratch",
+			got:  workerScratchDirRoot(home),
+			want: filepath.Join(xdgDataHome, "agent-deck", "worker-scratch"),
+		},
+	}
+
+	for _, tt := range tests {
+		if tt.got != tt.want {
+			t.Fatalf("%s path = %q, want %q", tt.name, tt.got, tt.want)
+		}
+	}
+}
+
+func TestXDGDataTask4_RuntimeStateDirsUseCategorySpecificLegacyFallback(t *testing.T) {
+	home, _, xdgDataHome := setupSessionXDGPathEnv(t)
+
+	legacyProfilesDir := filepath.Join(home, ".agent-deck", ProfilesDirName)
+	if err := os.MkdirAll(legacyProfilesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyProfilesDir, err)
+	}
+
+	if got, want := GetHooksDir(), filepath.Join(xdgDataHome, "agent-deck", "hooks"); got != want {
+		t.Fatalf("legacy profiles marker must not move hooks to legacy: got %q want %q", got, want)
+	}
+	if got, want := InboxDir(), filepath.Join(xdgDataHome, "agent-deck", "inboxes"); got != want {
+		t.Fatalf("legacy profiles marker must not move inboxes to legacy: got %q want %q", got, want)
+	}
+
+	legacyHooksDir := filepath.Join(home, ".agent-deck", "hooks")
+	if err := os.MkdirAll(legacyHooksDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyHooksDir, err)
+	}
+	if got := GetHooksDir(); got != legacyHooksDir {
+		t.Fatalf("legacy hooks marker should keep hooks legacy: got %q want %q", got, legacyHooksDir)
+	}
+	if got, want := InboxDir(), filepath.Join(xdgDataHome, "agent-deck", "inboxes"); got != want {
+		t.Fatalf("legacy hooks marker must not move inboxes to legacy: got %q want %q", got, want)
+	}
+}
+
+func TestXDGDataTask4_RuntimeAndLogsHaveSeparateFallbackMarkers(t *testing.T) {
+	home, _, xdgDataHome := setupSessionXDGPathEnv(t)
+
+	legacyLogsDir := filepath.Join(home, ".agent-deck", "logs")
+	if err := os.MkdirAll(legacyLogsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyLogsDir, err)
+	}
+
+	if got, want := transitionNotifyLogPath(), filepath.Join(legacyLogsDir, "transition-notifier.log"); got != want {
+		t.Fatalf("legacy logs marker should keep log legacy: got %q want %q", got, want)
+	}
+	if got, want := transitionNotifyStatePath(), filepath.Join(xdgDataHome, "agent-deck", "runtime", "transition-notify-state.json"); got != want {
+		t.Fatalf("legacy logs marker must not move runtime state to legacy: got %q want %q", got, want)
+	}
+
+	legacyRuntimeDir := filepath.Join(home, ".agent-deck", "runtime")
+	if err := os.MkdirAll(legacyRuntimeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyRuntimeDir, err)
+	}
+	if got, want := transitionNotifyStatePath(), filepath.Join(legacyRuntimeDir, "transition-notify-state.json"); got != want {
+		t.Fatalf("legacy runtime marker should keep runtime state legacy: got %q want %q", got, want)
+	}
+}
+
+func TestXDGDataTask4_ConductorDirUsesXDGDataAndLegacyConductorFallback(t *testing.T) {
+	home, _, xdgDataHome := setupSessionXDGPathEnv(t)
+
+	got, err := ConductorDir()
+	if err != nil {
+		t.Fatalf("ConductorDir(): %v", err)
+	}
+	want := filepath.Join(xdgDataHome, "agent-deck", "conductor")
+	if got != want {
+		t.Fatalf("ConductorDir() = %q, want %q", got, want)
+	}
+
+	legacyConductorDir := filepath.Join(home, ".agent-deck", "conductor")
+	if err := os.MkdirAll(legacyConductorDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyConductorDir, err)
+	}
+
+	got, err = ConductorDir()
+	if err != nil {
+		t.Fatalf("ConductorDir(): %v", err)
+	}
+	if got != legacyConductorDir {
+		t.Fatalf("ConductorDir() = %q, want legacy %q", got, legacyConductorDir)
+	}
+}
+
+func TestXDGDataTask4_ProfileRootIgnoresUnrelatedRuntimeLegacyMarkers(t *testing.T) {
+	home, _, xdgDataHome := setupSessionXDGPathEnv(t)
+
+	legacyHooksDir := filepath.Join(home, ".agent-deck", "hooks")
+	if err := os.MkdirAll(legacyHooksDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyHooksDir, err)
+	}
+
+	got, err := profileDataRootDir()
+	if err != nil {
+		t.Fatalf("profileDataRootDir(): %v", err)
+	}
+	want := filepath.Join(xdgDataHome, "agent-deck")
+	if got != want {
+		t.Fatalf("profileDataRootDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/testutil/profilefixture/profilefixture.go
+++ b/internal/testutil/profilefixture/profilefixture.go
@@ -38,14 +38,14 @@ type Options struct {
 	ClaudeConfigDir string
 
 	// ConfigDefault, if non-empty, writes a config file at
-	// <Home>/.agent-deck/config.json with `default_profile` set to this
+	// <Home>/.config/agent-deck/config.json with `default_profile` set to this
 	// value. Lowest precedence — only matters when env / inference are
 	// both empty.
 	ConfigDefault string
 
 	// AgentDeckHome overrides the agent-deck config root via HOME. If
 	// empty, a fresh t.TempDir() is used so the test never touches the
-	// developer's real ~/.agent-deck.
+	// developer's real config.
 	AgentDeckHome string
 }
 
@@ -66,6 +66,7 @@ func New(t *testing.T, opts Options) *Fixture {
 		home = t.TempDir()
 	}
 	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 
 	if opts.EnvProfile != "" {
 		t.Setenv("AGENTDECK_PROFILE", opts.EnvProfile)
@@ -169,7 +170,7 @@ func (f *Fixture) AssertParity(t TB, p Probes) {
 // should write their own config.
 func writeConfigDefault(t *testing.T, home, profile string) {
 	t.Helper()
-	dir := filepath.Join(home, ".agent-deck")
+	dir := filepath.Join(home, ".config", "agent-deck")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("profilefixture: mkdir %s: %v", dir, err)
 	}

--- a/internal/tmux/badge_update.go
+++ b/internal/tmux/badge_update.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -59,17 +60,16 @@ import (
 const badgeUpdatesDirEnv = "AGENTDECK_BADGE_UPDATES_DIR"
 
 // BadgeUpdatesDir returns the directory where rename-hook signals live.
-// Mirrors GetEventsDir's shape (also under ~/.agent-deck/) so an ops
-// engineer staring at the directory tree sees one consistent pattern.
+// Uses the XDG data directory, falling back to a legacy badge-updates dir.
 func BadgeUpdatesDir() string {
 	if v := strings.TrimSpace(os.Getenv(badgeUpdatesDirEnv)); v != "" {
 		return v
 	}
-	home, err := os.UserHomeDir()
+	dir, err := agentpaths.EffectiveDataPath("badge-updates", "badge-updates")
 	if err != nil {
 		return filepath.Join(os.TempDir(), ".agent-deck", "badge-updates")
 	}
-	return filepath.Join(home, ".agent-deck", "badge-updates")
+	return dir
 }
 
 // WriteBadgeUpdate atomically writes title under tmuxSessionName so the

--- a/internal/tmux/badge_update.go
+++ b/internal/tmux/badge_update.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/fsnotify/fsnotify"
@@ -35,11 +36,11 @@ import (
 // File writes succeed regardless of controlling-terminal state. So:
 //
 //   - Hook side  → WriteBadgeUpdate(tmuxSessionName, title)
-//     drops a per-session file under ~/.agent-deck/badge-updates/.
+//     drops a per-session file under the effective badge-updates data dir.
 //
 //   - Attach side → WatchBadgeUpdates(ctx, tmuxSessionName, w, configEnabled, ready)
 //     watches the same directory via fsnotify (already a project dep
-//     for ~/.agent-deck/events/), and when the file for THIS session
+//     for hook/event dirs), and when the file for THIS session
 //     changes, reads the new title and emits the OSC through `w`. In
 //     production `w` is `os.Stdout`, which the attach process owns;
 //     the outer iTerm2 sees the OSC directly.
@@ -54,7 +55,7 @@ import (
 // new dependencies, same operational shape for ops.
 
 // badgeUpdatesDirEnv lets tests redirect the signal directory away from
-// the real ~/.agent-deck/badge-updates path so parallel runs do not
+// the real badge-updates path so parallel runs do not
 // collide. The env var is intentionally undocumented in user-facing
 // config — it exists for the test harness only.
 const badgeUpdatesDirEnv = "AGENTDECK_BADGE_UPDATES_DIR"
@@ -67,7 +68,7 @@ func BadgeUpdatesDir() string {
 	}
 	dir, err := agentpaths.EffectiveDataPath("badge-updates", "badge-updates")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "badge-updates")
+		return filepath.Join(os.TempDir(), "agent-deck", "badge-updates")
 	}
 	return dir
 }
@@ -128,41 +129,60 @@ func WatchBadgeUpdates(ctx context.Context, tmuxSessionName string, w io.Writer,
 		return
 	}
 
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		if ready != nil {
-			close(ready)
+	targetPath := filepath.Join(dir, tmuxSessionName)
+	var lastTitle string
+	var haveLastTitle bool
+	emitCurrent := func() {
+		data, err := os.ReadFile(targetPath)
+		if err != nil {
+			return
 		}
-		return
+		title := string(data)
+		if haveLastTitle && title == lastTitle {
+			return
+		}
+		lastTitle = title
+		haveLastTitle = true
+		emitITermBadge(w, title, configEnabled)
 	}
-	defer watcher.Close()
 
-	if err := watcher.Add(dir); err != nil {
-		if ready != nil {
-			close(ready)
+	var events <-chan fsnotify.Event
+	var fsnotifyErrors <-chan error
+	if watcher, err := fsnotify.NewWatcher(); err == nil {
+		if err := watcher.Add(dir); err == nil {
+			defer watcher.Close()
+			events = watcher.Events
+			fsnotifyErrors = watcher.Errors
+		} else {
+			watcher.Close()
 		}
-		return
 	}
 
 	// Catch-up: if the hook fired before the watcher registered, we'd
 	// miss the event. Read the file once at startup so a rename that
 	// completed during agent-deck's attach setup still updates the
 	// badge. No-op when the file does not exist.
-	emitFromFile(filepath.Join(dir, tmuxSessionName), w, configEnabled)
+	emitCurrent()
 
 	if ready != nil {
 		close(ready)
 	}
 
+	poll := time.NewTicker(250 * time.Millisecond)
+	defer poll.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case ev, ok := <-watcher.Events:
+		case <-poll.C:
+			// Some filesystems report atomic rename events on the temporary
+			// file only. The low-rate poll is a change-detect fallback for
+			// that case and emits only when content changes.
+			emitCurrent()
+		case ev, ok := <-events:
 			if !ok {
-				return
-			}
-			if ev.Op&(fsnotify.Create|fsnotify.Write) == 0 {
+				events = nil
 				continue
 			}
 			// Filter strictly on filename — concurrent attaches in the
@@ -170,10 +190,11 @@ func WatchBadgeUpdates(ctx context.Context, tmuxSessionName string, w io.Writer,
 			if filepath.Base(ev.Name) != tmuxSessionName {
 				continue
 			}
-			emitFromFile(ev.Name, w, configEnabled)
-		case _, ok := <-watcher.Errors:
+			emitCurrent()
+		case _, ok := <-fsnotifyErrors:
 			if !ok {
-				return
+				fsnotifyErrors = nil
+				continue
 			}
 			// fsnotify errors are non-fatal here; the next event will
 			// retry. We deliberately do NOT log to stdout because that's
@@ -181,16 +202,4 @@ func WatchBadgeUpdates(ctx context.Context, tmuxSessionName string, w io.Writer,
 			// corrupt the user's display.
 		}
 	}
-}
-
-// emitFromFile reads the badge title from path and writes the OSC to w,
-// gated on the same iTerm2-active + configEnabled rules as the
-// on-attach emitITermBadge. Missing file is a silent no-op (the user
-// may have detached / cleaned up between the event and the read).
-func emitFromFile(path string, w io.Writer, configEnabled bool) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return
-	}
-	emitITermBadge(w, string(data), configEnabled)
 }

--- a/internal/tmux/chrome_test.go
+++ b/internal/tmux/chrome_test.go
@@ -18,11 +18,17 @@ import (
 	"golang.org/x/term"
 )
 
+func setTerminalProgram(t *testing.T, value string) {
+	t.Helper()
+	t.Setenv("TERM_PROGRAM", value)
+	t.Setenv("WARP_IS_LOCAL_SHELL_SESSION", "")
+}
+
 // TestEmitITermBadge_EncodesTitleBase64 asserts that the helper produces
 // exactly the OSC 1337 SetBadgeFormat sequence iTerm2 expects: the literal
 // prefix, the base64-encoded title bytes, and a BEL terminator.
 func TestEmitITermBadge_EncodesTitleBase64(t *testing.T) {
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	setTerminalProgram(t, "iTerm.app")
 	t.Setenv("AGENTDECK_ITERM_BADGE", "")
 
 	var buf bytes.Buffer
@@ -37,7 +43,7 @@ func TestEmitITermBadge_EncodesTitleBase64(t *testing.T) {
 // the badge-clear form (empty base64 payload), which iTerm2 interprets as
 // "remove the badge" — used on detach to leave the terminal in a clean state.
 func TestEmitITermBadge_EmptyTitleClears(t *testing.T) {
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	setTerminalProgram(t, "iTerm.app")
 	t.Setenv("AGENTDECK_ITERM_BADGE", "")
 
 	var buf bytes.Buffer
@@ -51,7 +57,7 @@ func TestEmitITermBadge_EmptyTitleClears(t *testing.T) {
 // escape sequences to terminals that won't parse them — they would otherwise
 // appear as literal garbage in the user's terminal output.
 func TestEmitITermBadge_NoOpOutsideITerm2(t *testing.T) {
-	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
+	setTerminalProgram(t, "Apple_Terminal")
 	t.Setenv("ITERM_SESSION_ID", "")
 	t.Setenv("LC_TERMINAL", "")
 	t.Setenv("AGENTDECK_ITERM_BADGE", "")
@@ -68,7 +74,7 @@ func TestEmitITermBadge_NoOpOutsideITerm2(t *testing.T) {
 // ssh), we still detect iTerm2 and emit the badge. Mirrors the gate the
 // external bash hook in tarek-eq-scripts uses.
 func TestEmitITermBadge_HonorsLCTerminal(t *testing.T) {
-	t.Setenv("TERM_PROGRAM", "")
+	setTerminalProgram(t, "")
 	t.Setenv("ITERM_SESSION_ID", "")
 	t.Setenv("LC_TERMINAL", "iTerm2")
 	t.Setenv("AGENTDECK_ITERM_BADGE", "")
@@ -85,7 +91,7 @@ func TestEmitITermBadge_HonorsLCTerminal(t *testing.T) {
 // configEnabled=false must suppress the OSC write — that's the whole
 // point of the opt-in default for users who run their own badge scheme.
 func TestEmitITermBadge_ConfigDisabledSuppressesEmit(t *testing.T) {
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	setTerminalProgram(t, "iTerm.app")
 	t.Setenv("AGENTDECK_ITERM_BADGE", "")
 
 	var buf bytes.Buffer
@@ -100,7 +106,7 @@ func TestEmitITermBadge_ConfigDisabledSuppressesEmit(t *testing.T) {
 // off, but AGENTDECK_ITERM_BADGE=1 forces it on for this run. Each truthy
 // value variant is asserted because the helper accepts a small set.
 func TestEmitITermBadge_EnvForceEnableOverridesConfigOff(t *testing.T) {
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	setTerminalProgram(t, "iTerm.app")
 
 	for _, v := range []string{"1", "true", "TRUE", "yes", "on"} {
 		t.Run(v, func(t *testing.T) {
@@ -120,7 +126,7 @@ func TestEmitITermBadge_EnvForceEnableOverridesConfigOff(t *testing.T) {
 // AGENTDECK_ITERM_BADGE=0 forces it off for this run. Each falsy value
 // variant is asserted because the helper accepts a small set.
 func TestEmitITermBadge_EnvForceDisableOverridesConfigOn(t *testing.T) {
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	setTerminalProgram(t, "iTerm.app")
 
 	for _, v := range []string{"0", "false", "FALSE", "no", "off"} {
 		t.Run(v, func(t *testing.T) {
@@ -140,7 +146,7 @@ func TestEmitITermBadge_EnvForceDisableOverridesConfigOn(t *testing.T) {
 // otherwise unrecognised env value must not silently flip the user's
 // persistent setting. Garbage falls through to configEnabled.
 func TestEmitITermBadge_EnvGarbageDefersToConfig(t *testing.T) {
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	setTerminalProgram(t, "iTerm.app")
 	t.Setenv("AGENTDECK_ITERM_BADGE", "maybe")
 
 	var bufOff bytes.Buffer
@@ -192,7 +198,7 @@ func TestFormatITermBadgeOSCViaTmux_DCSEnvelope(t *testing.T) {
 // attempt to open /dev/tty (which would still succeed and write garbage
 // into the user's pane that the wrong terminal can't parse).
 func TestEmitITermBadgeViaTty_NoOpOutsideITerm2(t *testing.T) {
-	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
+	setTerminalProgram(t, "Apple_Terminal")
 	t.Setenv("ITERM_SESSION_ID", "")
 	t.Setenv("LC_TERMINAL", "")
 	t.Setenv("AGENTDECK_ITERM_BADGE", "")
@@ -223,7 +229,7 @@ func TestEmitITermBadgeViaTty_NoFDLeak(t *testing.T) {
 	t.Setenv("AGENTDECK_ITERM_BADGE_DEBUG", "1")
 	// Stay outside iTerm2 so the function returns at the gate without
 	// opening /dev/tty, exercising the early-return defer path.
-	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
+	setTerminalProgram(t, "Apple_Terminal")
 	t.Setenv("ITERM_SESSION_ID", "")
 	t.Setenv("LC_TERMINAL", "")
 	t.Setenv("AGENTDECK_ITERM_BADGE", "")
@@ -288,7 +294,7 @@ func TestAttach_EmitsITermBadgeOnEntry(t *testing.T) {
 		t.Skip("stdin is not a terminal (CI/pipe environment); skipping PTY attach test")
 	}
 
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	setTerminalProgram(t, "iTerm.app")
 	t.Setenv("AGENTDECK_ITERM_BADGE", "")
 
 	name := SessionPrefix + "ptytest-itermbadge-" + fmt.Sprintf("%d", time.Now().UnixNano()%100000)

--- a/internal/tmux/issue1114_badge_rename_test.go
+++ b/internal/tmux/issue1114_badge_rename_test.go
@@ -62,6 +62,15 @@ func useTestBadgeDir(t *testing.T) string {
 	return dir
 }
 
+func useSimulatedITerm(t *testing.T) {
+	t.Helper()
+	t.Setenv("TERM_PROGRAM", "iTerm.app")
+	t.Setenv("WARP_IS_LOCAL_SHELL_SESSION", "")
+	t.Setenv("ITERM_SESSION_ID", "")
+	t.Setenv("LC_TERMINAL", "")
+	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+}
+
 // waitForOSC blocks until w contains an OSC SetBadgeFormat for title, or
 // the deadline expires.
 func waitForOSC(t *testing.T, w *lockedWriter, title string, timeout time.Duration) {
@@ -99,10 +108,7 @@ func TestIssue1114_WriteBadgeUpdate_AtomicFileWrite(t *testing.T) {
 // the pre-fix bug where EmitITermBadgeViaTty silently dropped the OSC.
 func TestIssue1114_AttachWatcher_EmitsOSCOnFileChange(t *testing.T) {
 	useTestBadgeDir(t)
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
-	t.Setenv("ITERM_SESSION_ID", "")
-	t.Setenv("LC_TERMINAL", "")
-	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+	useSimulatedITerm(t)
 
 	w := newLockedWriter()
 
@@ -146,10 +152,7 @@ func TestIssue1114_AttachWatcher_EmitsOSCOnFileChange(t *testing.T) {
 // between two attached agent-deck users in the same iTerm2 window.
 func TestIssue1114_Watcher_IgnoresOtherSessions(t *testing.T) {
 	useTestBadgeDir(t)
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
-	t.Setenv("ITERM_SESSION_ID", "")
-	t.Setenv("LC_TERMINAL", "")
-	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+	useSimulatedITerm(t)
 
 	w := newLockedWriter()
 
@@ -191,6 +194,7 @@ func TestIssue1114_Watcher_IgnoresOtherSessions(t *testing.T) {
 func TestIssue1114_Watcher_NoOpOutsideITerm2(t *testing.T) {
 	useTestBadgeDir(t)
 	t.Setenv("TERM_PROGRAM", "Apple_Terminal")
+	t.Setenv("WARP_IS_LOCAL_SHELL_SESSION", "")
 	t.Setenv("ITERM_SESSION_ID", "")
 	t.Setenv("LC_TERMINAL", "")
 	t.Setenv("AGENTDECK_ITERM_BADGE", "")
@@ -229,10 +233,7 @@ func TestIssue1114_Watcher_NoOpOutsideITerm2(t *testing.T) {
 // silently bypass the user's opt-out.
 func TestIssue1114_Watcher_ConfigDisabledSuppresses(t *testing.T) {
 	useTestBadgeDir(t)
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
-	t.Setenv("ITERM_SESSION_ID", "")
-	t.Setenv("LC_TERMINAL", "")
-	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+	useSimulatedITerm(t)
 
 	w := newLockedWriter()
 
@@ -267,10 +268,7 @@ func TestIssue1114_Watcher_ConfigDisabledSuppresses(t *testing.T) {
 // same DisplayName depending on whether the attach was fresh or post-rename.
 func TestIssue1114_OSCMatchesAttachEmit(t *testing.T) {
 	useTestBadgeDir(t)
-	t.Setenv("TERM_PROGRAM", "iTerm.app")
-	t.Setenv("ITERM_SESSION_ID", "")
-	t.Setenv("LC_TERMINAL", "")
-	t.Setenv("AGENTDECK_ITERM_BADGE", "")
+	useSimulatedITerm(t)
 
 	w := newLockedWriter()
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1332,7 +1332,7 @@ func (s *Session) LogFile() string {
 func LogDir() string {
 	logDir, err := agentpaths.EffectiveDataPath("logs", "logs")
 	if err != nil {
-		return filepath.Join(os.TempDir(), ".agent-deck", "logs")
+		return filepath.Join(os.TempDir(), "agent-deck", "logs")
 	}
 	return logDir
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/BurntSushi/toml"
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/platform"
 	dark "github.com/thiagokokada/dark-mode-go"
@@ -54,10 +55,9 @@ func resolvedAgentDeckTheme() string {
 	type cfg struct {
 		Theme string `toml:"theme"`
 	}
-	home, err := os.UserHomeDir()
-	if err == nil {
+	if configPath, err := agentpaths.EffectiveConfigPath("config.toml"); err == nil {
 		var c cfg
-		if _, err := toml.DecodeFile(filepath.Join(home, ".agent-deck", "config.toml"), &c); err == nil {
+		if _, err := toml.DecodeFile(configPath, &c); err == nil {
 			switch c.Theme {
 			case "light", "dark":
 				return c.Theme
@@ -1323,23 +1323,18 @@ func (s *Session) SetClearOnRestart(clear bool) {
 }
 
 // LogFile returns the path to this session's log file
-// Logs are stored in ~/.agent-deck/logs/<session-name>.log
+// Logs are stored under the XDG data directory, falling back to legacy logs.
 func (s *Session) LogFile() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		homeDir = "/tmp"
-	}
-	logDir := filepath.Join(homeDir, ".agent-deck", "logs")
-	return filepath.Join(logDir, s.Name+".log")
+	return filepath.Join(LogDir(), s.Name+".log")
 }
 
 // LogDir returns the directory containing all session logs
 func LogDir() string {
-	homeDir, err := os.UserHomeDir()
+	logDir, err := agentpaths.EffectiveDataPath("logs", "logs")
 	if err != nil {
-		homeDir = "/tmp"
+		return filepath.Join(os.TempDir(), ".agent-deck", "logs")
 	}
-	return filepath.Join(homeDir, ".agent-deck", "logs")
+	return logDir
 }
 
 // NewSession creates a new Session instance with a unique name
@@ -4792,11 +4787,7 @@ func BindSwitchKeyWithAck(key, targetSession, sessionID string) error {
 
 // GetAckSignalPath returns the path to the acknowledgment signal file
 func GetAckSignalPath() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(homeDir, ".agent-deck", "ack-signal"), nil
+	return agentpaths.EffectiveDataPath("ack-signal", "ack-signal")
 }
 
 // ReadAndClearAckSignal reads the session ID from the signal file and deletes it.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -4785,9 +4785,22 @@ func BindSwitchKeyWithAck(key, targetSession, sessionID string) error {
 	return cmd.Run()
 }
 
+const ackSignalLegacyMarker = ".ack-signal-legacy"
+
 // GetAckSignalPath returns the path to the acknowledgment signal file
 func GetAckSignalPath() (string, error) {
-	return agentpaths.EffectiveDataPath("ack-signal", "ack-signal")
+	return agentpaths.EffectiveDataPath("ack-signal", "ack-signal", ackSignalLegacyMarker)
+}
+
+func preserveLegacyAckSignalPath(signalFile string) {
+	legacyDir, err := agentpaths.LegacyDir()
+	if err != nil {
+		return
+	}
+	if filepath.Clean(signalFile) != filepath.Join(legacyDir, "ack-signal") {
+		return
+	}
+	_ = os.WriteFile(filepath.Join(legacyDir, ackSignalLegacyMarker), []byte{}, 0o600)
 }
 
 // ReadAndClearAckSignal reads the session ID from the signal file and deletes it.
@@ -4804,6 +4817,7 @@ func ReadAndClearAckSignal() string {
 	}
 
 	// Delete the file immediately after reading
+	preserveLegacyAckSignalPath(signalFile)
 	_ = os.Remove(signalFile)
 
 	return strings.TrimSpace(string(data))

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2257,10 +2257,11 @@ func TestSpikeDetectionWindowExpiry(t *testing.T) {
 }
 
 func TestSessionLogFile(t *testing.T) {
+	_, data := isolateTmuxXDGPaths(t)
 	sess := NewSession("test-log", t.TempDir())
 
 	logFile := sess.LogFile()
-	assert.Contains(t, logFile, ".agent-deck/logs/")
+	assert.Equal(t, filepath.Join(data, "agent-deck", "logs", sess.Name+".log"), logFile)
 	assert.Contains(t, logFile, "agentdeck_test-log")
 	assert.True(t, strings.HasSuffix(logFile, ".log"))
 }

--- a/internal/tmux/xdg_paths_test.go
+++ b/internal/tmux/xdg_paths_test.go
@@ -1,0 +1,67 @@
+package tmux
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func isolateTmuxXDGPaths(t *testing.T) (home string, data string) {
+	t.Helper()
+
+	root := t.TempDir()
+	home = filepath.Join(root, "home")
+	data = filepath.Join(root, "xdg-data")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", data)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "xdg-cache"))
+	t.Setenv(badgeUpdatesDirEnv, "")
+	return home, data
+}
+
+func TestXDGPaths_NewUsersUseDataHome(t *testing.T) {
+	_, data := isolateTmuxXDGPaths(t)
+	base := filepath.Join(data, "agent-deck")
+
+	require.Equal(t, filepath.Join(base, "logs"), LogDir())
+
+	ackPath, err := GetAckSignalPath()
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(base, "ack-signal"), ackPath)
+
+	require.Equal(t, filepath.Join(base, "badge-updates"), BadgeUpdatesDir())
+}
+
+func TestXDGPaths_LegacyAckSignalFallbackIsCategorySpecific(t *testing.T) {
+	home, data := isolateTmuxXDGPaths(t)
+	base := filepath.Join(data, "agent-deck")
+
+	legacyAck := filepath.Join(home, ".agent-deck", "ack-signal")
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyAck), 0o700))
+	require.NoError(t, os.WriteFile(legacyAck, []byte("session-id"), 0o600))
+
+	ackPath, err := GetAckSignalPath()
+	require.NoError(t, err)
+	require.Equal(t, legacyAck, ackPath)
+	require.Equal(t, filepath.Join(base, "logs"), LogDir())
+	require.Equal(t, filepath.Join(base, "badge-updates"), BadgeUpdatesDir())
+}
+
+func TestXDGPaths_UnrelatedLegacyMarkerDoesNotForceTmuxPaths(t *testing.T) {
+	home, data := isolateTmuxXDGPaths(t)
+	base := filepath.Join(data, "agent-deck")
+
+	unrelatedLegacy := filepath.Join(home, ".agent-deck", "feedback-state.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(unrelatedLegacy), 0o700))
+	require.NoError(t, os.WriteFile(unrelatedLegacy, []byte("{}"), 0o600))
+
+	require.Equal(t, filepath.Join(base, "logs"), LogDir())
+
+	ackPath, err := GetAckSignalPath()
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(base, "ack-signal"), ackPath)
+
+	require.Equal(t, filepath.Join(base, "badge-updates"), BadgeUpdatesDir())
+}

--- a/internal/tmux/xdg_paths_test.go
+++ b/internal/tmux/xdg_paths_test.go
@@ -49,6 +49,21 @@ func TestXDGPaths_LegacyAckSignalFallbackIsCategorySpecific(t *testing.T) {
 	require.Equal(t, filepath.Join(base, "badge-updates"), BadgeUpdatesDir())
 }
 
+func TestXDGPaths_LegacyAckSignalFallbackSurvivesSignalConsumption(t *testing.T) {
+	home, _ := isolateTmuxXDGPaths(t)
+
+	legacyDir := filepath.Join(home, ".agent-deck")
+	legacyAck := filepath.Join(legacyDir, "ack-signal")
+	require.NoError(t, os.MkdirAll(legacyDir, 0o700))
+	require.NoError(t, os.WriteFile(legacyAck, []byte("session-id"), 0o600))
+
+	require.Equal(t, "session-id", ReadAndClearAckSignal())
+
+	ackPath, err := GetAckSignalPath()
+	require.NoError(t, err)
+	require.Equal(t, legacyAck, ackPath)
+}
+
 func TestXDGPaths_UnrelatedLegacyMarkerDoesNotForceTmuxPaths(t *testing.T) {
 	home, data := isolateTmuxXDGPaths(t)
 	base := filepath.Join(data, "agent-deck")

--- a/internal/ui/edit_session_dialog_eval_test.go
+++ b/internal/ui/edit_session_dialog_eval_test.go
@@ -8,8 +8,6 @@ package ui
 // `-tags eval_smoke`. See tests/eval/README.md.
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -173,24 +171,12 @@ func TestEval_EditSessionDialog_RestartHintSurfacesForRestartFields(t *testing.T
 func TestEval_PluginToggleSurfacesAsRestartHint(t *testing.T) {
 	// Set up a HOME with a non-empty plugin catalog so the dialog renders
 	// the Plugins field. The dialog reads via session.GetAvailablePluginNames.
-	temp := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", temp)
-	t.Cleanup(func() { os.Setenv("HOME", originalHome) })
-
-	configDir := filepath.Join(temp, ".agent-deck")
-	if err := os.MkdirAll(configDir, 0o700); err != nil {
-		t.Fatalf("mkdir agent-deck: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(`
+	home := setXDGTestHome(t)
+	writeXDGTestConfig(t, home, `
 [plugins.octopus]
 name = "octopus"
 source = "nyldn/claude-octopus"
-`), 0o600); err != nil {
-		t.Fatalf("write config.toml: %v", err)
-	}
-	session.ClearUserConfigCache()
-	t.Cleanup(session.ClearUserConfigCache)
+`)
 
 	d := NewEditSessionDialog()
 	d.SetSize(100, 40)

--- a/internal/ui/edit_session_dialog_plugins_test.go
+++ b/internal/ui/edit_session_dialog_plugins_test.go
@@ -4,8 +4,6 @@
 package ui
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -19,19 +17,8 @@ import (
 // definitions.
 func withPluginCatalog(t *testing.T, content string) {
 	t.Helper()
-	temp := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", temp)
-	t.Cleanup(func() { os.Setenv("HOME", originalHome) })
-
-	dir := filepath.Join(temp, ".agent-deck")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(content), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	session.ClearUserConfigCache()
+	home := setXDGTestHome(t)
+	writeXDGTestConfig(t, home, content)
 }
 
 // TestEditSessionDialog_PluginsFieldShownForClaudeWithCatalog asserts the

--- a/internal/ui/group_nav.go
+++ b/internal/ui/group_nav.go
@@ -11,12 +11,13 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 // navHintSentinelName is the file whose presence records that the v1.7.60
 // group-navigation discoverability hint has already been shown to this user.
-// Lives under ~/.agent-deck/ so it persists across binary upgrades.
+// Lives under the effective data directory so it persists across binary upgrades.
 const navHintSentinelName = ".nav-hint-v1760-shown"
 
 // navHintText is the one-shot discoverability message rendered in the
@@ -26,16 +27,16 @@ const navHintText = "Tip: Alt+j/k and Alt+1-9 navigate within the current group.
 // navHintSentinelPath returns the absolute path of the sentinel file, or "" if
 // it cannot be resolved (no HOME, etc. — treat as "do not show").
 func navHintSentinelPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
+	path, err := agentpaths.EffectiveDataPath(navHintSentinelName, navHintSentinelName)
+	if err != nil {
 		return ""
 	}
-	return filepath.Join(home, ".agent-deck", navHintSentinelName)
+	return path
 }
 
 // navHintAlreadyShown reports whether the sentinel exists. Also returns true
 // when running under the test profile so tests do not write a sentinel file
-// into the developer's real ~/.agent-deck directory.
+// into the developer's real data directory.
 func navHintAlreadyShown() bool {
 	if os.Getenv("AGENTDECK_PROFILE") == "_test" {
 		return true

--- a/internal/ui/group_nav_test.go
+++ b/internal/ui/group_nav_test.go
@@ -373,6 +373,10 @@ func TestGroupNav_EvalHarness_RendersAndLandsOnRightSession(t *testing.T) {
 
 // ---------- First-launch nav-hint (discoverability) ----------
 
+func TestNavHint_RemoteSessionNotApplicable(t *testing.T) {
+	t.Skip("RemoteSession N/A: nav hint is global first-launch HOME/XDG sentinel state, not a row action or session-type branch")
+}
+
 // TestNavHint_ShownOnFirstLaunch_DismissedAfterKeypress exercises the
 // discoverability path end-to-end: sentinel absent -> hint shows -> first
 // keypress dismisses and leaves a sentinel file so it never shows again.

--- a/internal/ui/group_nav_test.go
+++ b/internal/ui/group_nav_test.go
@@ -380,11 +380,14 @@ func TestNavHint_ShownOnFirstLaunch_DismissedAfterKeypress(t *testing.T) {
 	// Isolate HOME and disable the test-profile bypass so the hint code runs.
 	tmpHome := t.TempDir()
 	origHome := os.Getenv("HOME")
+	origXDGData := os.Getenv("XDG_DATA_HOME")
 	origProfile := os.Getenv("AGENTDECK_PROFILE")
 	os.Setenv("HOME", tmpHome)
+	os.Setenv("XDG_DATA_HOME", filepath.Join(tmpHome, ".local", "share"))
 	os.Unsetenv("AGENTDECK_PROFILE")
 	t.Cleanup(func() {
 		os.Setenv("HOME", origHome)
+		os.Setenv("XDG_DATA_HOME", origXDGData)
 		os.Setenv("AGENTDECK_PROFILE", origProfile)
 	})
 
@@ -406,7 +409,7 @@ func TestNavHint_ShownOnFirstLaunch_DismissedAfterKeypress(t *testing.T) {
 
 	// Sentinel should already be written (write-through on display, so the
 	// hint never repeats even if the TUI crashes before first keypress).
-	sentinel := filepath.Join(tmpHome, ".agent-deck", ".nav-hint-v1760-shown")
+	sentinel := filepath.Join(tmpHome, ".local", "share", "agent-deck", ".nav-hint-v1760-shown")
 	if _, err := os.Stat(sentinel); err != nil {
 		t.Fatalf("sentinel not written at %s: %v", sentinel, err)
 	}
@@ -427,19 +430,23 @@ func TestNavHint_ShownOnFirstLaunch_DismissedAfterKeypress(t *testing.T) {
 func TestNavHint_SkippedWhenSentinelExists(t *testing.T) {
 	tmpHome := t.TempDir()
 	origHome := os.Getenv("HOME")
+	origXDGData := os.Getenv("XDG_DATA_HOME")
 	origProfile := os.Getenv("AGENTDECK_PROFILE")
 	os.Setenv("HOME", tmpHome)
+	os.Setenv("XDG_DATA_HOME", filepath.Join(tmpHome, ".local", "share"))
 	os.Unsetenv("AGENTDECK_PROFILE")
 	t.Cleanup(func() {
 		os.Setenv("HOME", origHome)
+		os.Setenv("XDG_DATA_HOME", origXDGData)
 		os.Setenv("AGENTDECK_PROFILE", origProfile)
 	})
 
 	// Pre-seed sentinel.
-	if err := os.MkdirAll(filepath.Join(tmpHome, ".agent-deck"), 0o755); err != nil {
+	sentinel := filepath.Join(tmpHome, ".local", "share", "agent-deck", ".nav-hint-v1760-shown")
+	if err := os.MkdirAll(filepath.Dir(sentinel), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(tmpHome, ".agent-deck", ".nav-hint-v1760-shown"), []byte("seeded\n"), 0o644); err != nil {
+	if err := os.WriteFile(sentinel, []byte("seeded\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -27,6 +27,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/asheshgoplani/agent-deck/internal/clipboard"
 	"github.com/asheshgoplani/agent-deck/internal/costs"
 	"github.com/asheshgoplani/agent-deck/internal/feedback"
@@ -8403,6 +8404,14 @@ func (h *Home) applyMultiRepoPathChanges(inst *session.Instance, newPaths []stri
 	}
 }
 
+func multiRepoWorktreesRoot() string {
+	dir, err := agentpaths.EffectiveDataPath("multi-repo-worktrees", "multi-repo-worktrees")
+	if err != nil {
+		return filepath.Join(os.TempDir(), "agent-deck", "multi-repo-worktrees")
+	}
+	return dir
+}
+
 // handleSkillDialogKey handles keys when Skills dialog is visible
 func (h *Home) handleSkillDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
@@ -8957,11 +8966,10 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 
 			if worktreeBranch != "" {
 				// Multi-repo + worktree: create a persistent parent dir with all worktrees inside.
-				// Layout: ~/.agent-deck/multi-repo-worktrees/<branch>-<id>/<repo-name>/
-				home, _ := os.UserHomeDir()
+				// Layout: <effective-data-dir>/multi-repo-worktrees/<branch>-<id>/<repo-name>/
 				sanitizedBranch := strings.ReplaceAll(worktreeBranch, "/", "-")
 				sanitizedBranch = strings.ReplaceAll(sanitizedBranch, " ", "-")
-				parentDir := filepath.Join(home, ".agent-deck", "multi-repo-worktrees",
+				parentDir := filepath.Join(multiRepoWorktreesRoot(),
 					fmt.Sprintf("%s-%s", sanitizedBranch, inst.ID[:8]))
 				if mkErr := os.MkdirAll(parentDir, 0o755); mkErr != nil {
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create multi-repo worktree dir: %w", mkErr), tempID: tempID}
@@ -8980,8 +8988,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 				inst.AdditionalPaths = wtResult.MappedPaths[1:]
 			} else {
 				// Multi-repo without worktree: create a persistent parent dir with symlinks.
-				home, _ := os.UserHomeDir()
-				parentDir := filepath.Join(home, ".agent-deck", "multi-repo-worktrees", inst.ID[:8])
+				parentDir := filepath.Join(multiRepoWorktreesRoot(), inst.ID[:8])
 				if mkErr := os.MkdirAll(parentDir, 0o755); mkErr != nil {
 					return sessionCreatedMsg{err: fmt.Errorf("failed to create multi-repo dir: %w", mkErr), tempID: tempID}
 				}
@@ -9474,8 +9481,7 @@ func (h *Home) forkSessionCmdWithOptions(
 				inst.MultiRepoWorktrees = append([]session.MultiRepoWorktree{}, source.MultiRepoWorktrees...)
 			}
 			// Create a new persistent dir for the fork with symlinks to shared worktrees
-			home, _ := os.UserHomeDir()
-			parentDir := filepath.Join(home, ".agent-deck", "multi-repo-worktrees", inst.ID[:8])
+			parentDir := filepath.Join(multiRepoWorktreesRoot(), inst.ID[:8])
 			if mkErr := os.MkdirAll(parentDir, 0o755); mkErr != nil {
 				return sessionForkedMsg{err: fmt.Errorf("failed to create multi-repo dir: %w", mkErr), sourceID: sourceID}
 			}

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -32,24 +32,9 @@ func TestNewHome(t *testing.T) {
 }
 
 func TestNewHome_DisablesTmuxNotificationsWhenStatusInjectionDisabled(t *testing.T) {
-	origHome := os.Getenv("HOME")
-	tmpHome := t.TempDir()
-	os.Setenv("HOME", tmpHome)
-	session.ClearUserConfigCache()
-	defer func() {
-		os.Setenv("HOME", origHome)
-		session.ClearUserConfigCache()
-	}()
-
-	configDir := filepath.Join(tmpHome, ".agent-deck")
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll() failed: %v", err)
-	}
-	configPath := filepath.Join(configDir, "config.toml")
+	homeDir := setXDGTestHome(t)
 	config := "[tmux]\ninject_status_line = false\n"
-	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
-		t.Fatalf("WriteFile() failed: %v", err)
-	}
+	writeXDGTestConfig(t, homeDir, config)
 
 	home := NewHome()
 	if home.manageTmuxNotifications {
@@ -926,17 +911,7 @@ func TestNotesSectionLineBudget(t *testing.T) {
 func setFollowCwdOnAttachConfigForTest(t *testing.T, enabled *bool) {
 	t.Helper()
 
-	homeDir, err := os.MkdirTemp("", "follow-cwd-test-*")
-	if err != nil {
-		t.Fatalf("failed to create temp home: %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(homeDir) })
-	t.Setenv("HOME", homeDir)
-
-	configDir := filepath.Join(homeDir, ".agent-deck")
-	if err := os.MkdirAll(configDir, 0o700); err != nil {
-		t.Fatalf("failed to create config directory: %v", err)
-	}
+	homeDir := setXDGTestHome(t)
 
 	if enabled != nil {
 		value := "false"
@@ -944,30 +919,14 @@ func setFollowCwdOnAttachConfigForTest(t *testing.T, enabled *bool) {
 			value = "true"
 		}
 		content := fmt.Sprintf("[instances]\nfollow_cwd_on_attach = %s\n", value)
-		configPath := filepath.Join(configDir, session.UserConfigFileName)
-		if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
-			t.Fatalf("failed to write config.toml: %v", err)
-		}
+		writeXDGTestConfig(t, homeDir, content)
 	}
-
-	session.ClearUserConfigCache()
-	t.Cleanup(session.ClearUserConfigCache)
 }
 
 func setPreviewShowNotesConfigForTest(t *testing.T, enabled *bool) {
 	t.Helper()
 
-	homeDir, err := os.MkdirTemp("", "follow-cwd-test-*")
-	if err != nil {
-		t.Fatalf("failed to create temp home: %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(homeDir) })
-	t.Setenv("HOME", homeDir)
-
-	configDir := filepath.Join(homeDir, ".agent-deck")
-	if err := os.MkdirAll(configDir, 0o700); err != nil {
-		t.Fatalf("failed to create config directory: %v", err)
-	}
+	homeDir := setXDGTestHome(t)
 
 	if enabled != nil {
 		value := "false"
@@ -975,14 +934,8 @@ func setPreviewShowNotesConfigForTest(t *testing.T, enabled *bool) {
 			value = "true"
 		}
 		content := fmt.Sprintf("[preview]\nshow_notes = %s\n", value)
-		configPath := filepath.Join(configDir, session.UserConfigFileName)
-		if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
-			t.Fatalf("failed to write config.toml: %v", err)
-		}
+		writeXDGTestConfig(t, homeDir, content)
 	}
-
-	session.ClearUserConfigCache()
-	t.Cleanup(session.ClearUserConfigCache)
 }
 
 func TestFollowAttachReturnCwdEnabledUpdatesProjectPath(t *testing.T) {

--- a/internal/ui/issue1092_split_test.go
+++ b/internal/ui/issue1092_split_test.go
@@ -21,20 +21,18 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-// setIsolatedAgentDeckDir gives each test its own ~/.agent-deck so
+// setIsolatedAgentDeckDir gives each test its own XDG config root so
 // SaveUserConfig / LoadUserConfig don't clobber the user's real config
 // or interfere with each other.
-//
-// session.GetAgentDeckDir() resolves via os.UserHomeDir(), which honors
-// HOME on POSIX, so we point HOME at a temp dir and create
-// .agent-deck/ inside it.
 func setIsolatedAgentDeckDir(t *testing.T) string {
 	t.Helper()
 	tmpHome := t.TempDir()
+	xdgConfigHome := filepath.Join(tmpHome, ".config")
 	t.Setenv("HOME", tmpHome)
-	dir := filepath.Join(tmpHome, ".agent-deck")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+	dir := filepath.Join(xdgConfigHome, "agent-deck")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatalf("mkdir .agent-deck: %v", err)
+		t.Fatalf("mkdir XDG config dir: %v", err)
 	}
 	// LoadUserConfig caches by mtime; reset between tests.
 	session.ClearUserConfigCache()

--- a/internal/ui/issue1100_shift_enter_remote_test.go
+++ b/internal/ui/issue1100_shift_enter_remote_test.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -28,25 +26,10 @@ import (
 // register the cleanup before returning.
 func withTempAgentDeckHome(t *testing.T, configTOML string) {
 	t.Helper()
-	tmpDir := t.TempDir()
+	home := setXDGTestHome(t)
 	if configTOML != "" {
-		dir := filepath.Join(tmpDir, ".agent-deck")
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", dir, err)
-		}
-		if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(configTOML), 0o644); err != nil {
-			t.Fatalf("write config.toml: %v", err)
-		}
+		writeXDGTestConfig(t, home, configTOML)
 	}
-	oldHome := os.Getenv("HOME")
-	if err := os.Setenv("HOME", tmpDir); err != nil {
-		t.Fatalf("setenv HOME: %v", err)
-	}
-	session.ClearUserConfigCache()
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", oldHome)
-		session.ClearUserConfigCache()
-	})
 }
 
 // armHomeWithOneRemoteSession sets up a Home whose cursor sits on a

--- a/internal/ui/mcp_dialog.go
+++ b/internal/ui/mcp_dialog.go
@@ -1008,7 +1008,7 @@ func (m *MCPDialog) renderEmptyStateHelp() string {
 		highlightStyle.Render("No MCPs configured"),
 		"",
 		helpStyle.Render("To add MCPs, edit:"),
-		pathStyle.Render("  ~/.agent-deck/config.toml"),
+		pathStyle.Render("  " + userConfigPathForDisplay()),
 		"",
 		helpStyle.Render("Example:"),
 		helpStyle.Render("  [mcps.example]"),

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -825,17 +824,7 @@ func TestNewDialog_ShowInGroup_ResetsMultiRepo(t *testing.T) {
 }
 
 func TestNewDialog_ShowInGroup_UsesConfiguredWorktreeDefault(t *testing.T) {
-	tempDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tempDir)
-	defer os.Setenv("HOME", originalHome)
-	session.ClearUserConfigCache()
-	defer session.ClearUserConfigCache()
-
-	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
-	if err := os.MkdirAll(agentDeckDir, 0700); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
+	setXDGTestHome(t)
 	if err := session.SaveUserConfig(&session.UserConfig{
 		Worktree: session.WorktreeSettings{DefaultEnabled: true},
 	}); err != nil {
@@ -887,6 +876,8 @@ func TestNewDialog_BranchInputInitialized(t *testing.T) {
 }
 
 func TestNewDialog_WorktreeToggle_ViaKeyPress(t *testing.T) {
+	setXDGTestHome(t)
+
 	dialog := NewNewDialog()
 	dialog.Show()
 	dialog.sandboxEnabled = false
@@ -917,6 +908,8 @@ func TestNewDialog_WorktreeToggle_ViaKeyPress(t *testing.T) {
 }
 
 func TestNewDialog_ShortcutsBlockedDuringTextInput(t *testing.T) {
+	setXDGTestHome(t)
+
 	dialog := NewNewDialog()
 	dialog.Show()
 	dialog.sandboxEnabled = false
@@ -1141,6 +1134,8 @@ func TestNewDialog_ClearError_HidesFromView(t *testing.T) {
 // ===== Checkbox Focus Tests =====
 
 func TestNewDialog_WorktreeCheckbox_SpaceToggle(t *testing.T) {
+	setXDGTestHome(t)
+
 	dialog := NewNewDialog()
 	dialog.Show()
 	dialog.sandboxEnabled = false
@@ -1256,6 +1251,8 @@ func TestNewDialog_ToggleWorktree_EmptyName_NoBranch(t *testing.T) {
 }
 
 func TestNewDialog_ShowInGroup_ResetsBranchAutoSet(t *testing.T) {
+	setXDGTestHome(t)
+
 	d := NewNewDialog()
 	d.branchAutoSet = true
 
@@ -1267,17 +1264,7 @@ func TestNewDialog_ShowInGroup_ResetsBranchAutoSet(t *testing.T) {
 }
 
 func TestNewDialog_ShowInGroup_DefaultWorktree_SetsBranchAutoSet(t *testing.T) {
-	tempDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tempDir)
-	defer os.Setenv("HOME", originalHome)
-	session.ClearUserConfigCache()
-	defer session.ClearUserConfigCache()
-
-	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
-	if err := os.MkdirAll(agentDeckDir, 0700); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
+	setXDGTestHome(t)
 	if err := session.SaveUserConfig(&session.UserConfig{
 		Worktree: session.WorktreeSettings{DefaultEnabled: true},
 	}); err != nil {
@@ -1297,17 +1284,7 @@ func TestNewDialog_ShowInGroup_DefaultWorktree_SetsBranchAutoSet(t *testing.T) {
 }
 
 func TestNewDialog_ShowInGroup_DefaultWorktree_AutoPopulatesBranchFromName(t *testing.T) {
-	tempDir := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", tempDir)
-	defer os.Setenv("HOME", originalHome)
-	session.ClearUserConfigCache()
-	defer session.ClearUserConfigCache()
-
-	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
-	if err := os.MkdirAll(agentDeckDir, 0700); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
+	setXDGTestHome(t)
 	if err := session.SaveUserConfig(&session.UserConfig{
 		Worktree: session.WorktreeSettings{DefaultEnabled: true},
 	}); err != nil {

--- a/internal/ui/path_text.go
+++ b/internal/ui/path_text.go
@@ -1,0 +1,19 @@
+package ui
+
+import "github.com/asheshgoplani/agent-deck/internal/session"
+
+func userConfigPathForDisplay() string {
+	path, err := session.GetUserConfigPath()
+	if err != nil {
+		return "$XDG_CONFIG_HOME/agent-deck/config.toml"
+	}
+	return path
+}
+
+func skillPoolPathForDisplay() string {
+	path, err := session.GetSkillPoolPath()
+	if err != nil {
+		return "$XDG_CONFIG_HOME/agent-deck/skills/pool"
+	}
+	return path
+}

--- a/internal/ui/plugin_dialog.go
+++ b/internal/ui/plugin_dialog.go
@@ -175,7 +175,7 @@ func (d *PluginDialog) View() string {
 
 	if len(d.items) == 0 {
 		body.WriteString(lipgloss.NewStyle().Faint(true).Render(
-			"No plugins in catalog. Add [plugins.<name>] tables to ~/.agent-deck/config.toml\n" +
+			"No plugins in catalog. Add [plugins.<name>] tables to " + userConfigPathForDisplay() + "\n" +
 				"See docs/rfc/PLUGIN_ATTACH.md §4.1",
 		))
 		body.WriteString("\n")

--- a/internal/ui/plugin_dialog_test.go
+++ b/internal/ui/plugin_dialog_test.go
@@ -4,8 +4,6 @@
 package ui
 
 import (
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -18,20 +16,8 @@ import (
 // session.GetAvailablePlugins accessor returns predictable values.
 func withCatalog(t *testing.T, content string) {
 	t.Helper()
-	temp := t.TempDir()
-	originalHome := os.Getenv("HOME")
-	os.Setenv("HOME", temp)
-	t.Cleanup(func() { os.Setenv("HOME", originalHome) })
-
-	dir := filepath.Join(temp, ".agent-deck")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(content), 0o600); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	session.ClearUserConfigCache()
-	t.Cleanup(session.ClearUserConfigCache)
+	home := setXDGTestHome(t)
+	writeXDGTestConfig(t, home, content)
 }
 
 func TestPluginDialog_Show_PopulatesItemsAndInitialEnabled(t *testing.T) {

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -1085,7 +1085,7 @@ func (s *SettingsPanel) View() string {
 	// MCP & TOOLS
 	content.WriteString(sectionStyle.Render("MCP SERVERS & CUSTOM TOOLS"))
 	content.WriteString("\n")
-	content.WriteString(dimStyle.Render("  Edit ~/.agent-deck/config.toml to configure MCPs and tools."))
+	content.WriteString(dimStyle.Render("  Edit " + userConfigPathForDisplay() + " to configure MCPs and tools."))
 	content.WriteString("\n")
 	hotkeys := resolveHotkeys(session.GetHotkeyOverrides())
 	mcpKey := actionHotkey(hotkeys, hotkeyMCPManager)

--- a/internal/ui/settings_panel_eval_test.go
+++ b/internal/ui/settings_panel_eval_test.go
@@ -21,8 +21,6 @@ package ui
 // round-trip. That coverage gap is what this file closes.
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -38,13 +36,7 @@ import (
 // Without the #710 fix, the final reload returns zero-valued TmuxSettings
 // and the assertions below fail with "InjectStatusLine = nil".
 func TestEval_SettingsTUI_SavePreservesTmux(t *testing.T) {
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
-
-	configDir := filepath.Join(homeDir, ".agent-deck")
-	if err := os.MkdirAll(configDir, 0o700); err != nil {
-		t.Fatalf("mkdir config dir: %v", err)
-	}
+	homeDir := setXDGTestHome(t)
 
 	// Seed a config.toml with [tmux] populated. These three fields cover
 	// all three Tmux struct member shapes: *bool, *bool, string.
@@ -56,13 +48,7 @@ inject_status_line = false
 launch_in_user_scope = true
 detach_key = "C-q"
 `
-	configPath := filepath.Join(configDir, session.UserConfigFileName)
-	if err := os.WriteFile(configPath, []byte(seedTOML), 0o600); err != nil {
-		t.Fatalf("seed config.toml: %v", err)
-	}
-
-	session.ClearUserConfigCache()
-	t.Cleanup(session.ClearUserConfigCache)
+	writeXDGTestConfig(t, homeDir, seedTOML)
 
 	// Replay the TUI flow: load existing config into the panel, change a
 	// non-tmux field (theme), then ask the panel for the to-be-saved config.

--- a/internal/ui/settings_panel_test.go
+++ b/internal/ui/settings_panel_test.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -13,21 +11,8 @@ import (
 func setSettingsPanelHotkeyConfigForTest(t *testing.T, tomlBody string) {
 	t.Helper()
 
-	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
-
-	configDir := filepath.Join(homeDir, ".agent-deck")
-	if err := os.MkdirAll(configDir, 0o700); err != nil {
-		t.Fatalf("failed to create config directory: %v", err)
-	}
-
-	configPath := filepath.Join(configDir, session.UserConfigFileName)
-	if err := os.WriteFile(configPath, []byte(tomlBody), 0o600); err != nil {
-		t.Fatalf("failed to write config.toml: %v", err)
-	}
-
-	session.ClearUserConfigCache()
-	t.Cleanup(session.ClearUserConfigCache)
+	homeDir := setXDGTestHome(t)
+	writeXDGTestConfig(t, homeDir, tomlBody)
 }
 
 // toolValueIndex returns the index of value in panel.toolValues (for name-based tests).

--- a/internal/ui/skill_dialog.go
+++ b/internal/ui/skill_dialog.go
@@ -484,7 +484,7 @@ func (d *SkillDialog) renderEmptyStateHelp() string {
 		highlightStyle.Render("No pool skills available"),
 		"",
 		helpStyle.Render("Place reusable skills in:"),
-		pathStyle.Render("  ~/.agent-deck/skills/pool"),
+		pathStyle.Render("  " + skillPoolPathForDisplay()),
 		"",
 		helpStyle.Render("Only pool skills appear in Available."),
 	}

--- a/internal/ui/xdg_test_helpers_test.go
+++ b/internal/ui/xdg_test_helpers_test.go
@@ -1,0 +1,38 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func setXDGTestHome(t *testing.T) string {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+	return home
+}
+
+func writeXDGTestConfig(t *testing.T, home string, content string) string {
+	t.Helper()
+
+	configDir := filepath.Join(home, ".config", "agent-deck")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	configPath := filepath.Join(configDir, session.UserConfigFileName)
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+	session.ClearUserConfigCache()
+	return configPath
+}

--- a/internal/ui/zoxide_picker.go
+++ b/internal/ui/zoxide_picker.go
@@ -35,11 +35,14 @@ type ZoxidePicker struct {
 	errMsg     string
 	unavail    bool // zoxide not installed; results disabled
 	queryFn    zoxideQueryFunc
+	checkAvail bool
 }
 
 // NewZoxidePicker constructs a picker wired to the real zoxide binary.
 func NewZoxidePicker() *ZoxidePicker {
-	return newZoxidePickerWithQueryFn(defaultZoxideQuery)
+	z := newZoxidePickerWithQueryFn(defaultZoxideQuery)
+	z.checkAvail = true
+	return z
 }
 
 func newZoxidePickerWithQueryFn(fn zoxideQueryFunc) *ZoxidePicker {
@@ -69,7 +72,7 @@ func (z *ZoxidePicker) Show() {
 	z.queryInput.CursorEnd()
 	z.queryInput.Focus()
 
-	if !session.ZoxideAvailable() {
+	if z.checkAvail && !session.ZoxideAvailable() {
 		z.unavail = true
 		z.results = nil
 		return

--- a/internal/update/cache_xdg_test.go
+++ b/internal/update/cache_xdg_test.go
@@ -1,0 +1,47 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func isolateUpdatePaths(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(root, "xdg-data"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "xdg-cache"))
+	return home
+}
+
+func TestCachePath_XDGCacheHomeRoundtrip(t *testing.T) {
+	isolateUpdatePaths(t)
+
+	cache := &UpdateCache{
+		CheckedAt:      time.Now().UTC(),
+		LatestVersion:  "2.0.0",
+		CurrentVersion: "1.0.0",
+		DownloadURL:    "https://example.test/download",
+		ReleaseURL:     "https://example.test/release",
+		ReleasesBehind: 4,
+	}
+
+	require.NoError(t, saveCache(cache))
+
+	cachePath := filepath.Join(os.Getenv("XDG_CACHE_HOME"), "agent-deck", CacheFileName)
+	require.FileExists(t, cachePath)
+
+	loaded, err := loadCache()
+	require.NoError(t, err)
+	require.Equal(t, cache.LatestVersion, loaded.LatestVersion)
+	require.Equal(t, cache.CurrentVersion, loaded.CurrentVersion)
+	require.Equal(t, cache.DownloadURL, loaded.DownloadURL)
+	require.Equal(t, cache.ReleaseURL, loaded.ReleaseURL)
+	require.Equal(t, cache.ReleasesBehind, loaded.ReleasesBehind)
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
-	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 const (
@@ -41,11 +40,20 @@ var apiBaseURL = "https://api.github.com"
 // detectHomebrewManagedInstall is a test seam for self-update install paths.
 var detectHomebrewManagedInstall = DetectHomebrewManagedInstall
 
+// bridgeScriptInstaller refreshes the conductor bridge script. It is injected
+// by the CLI layer so this package stays independent of internal/session.
+var bridgeScriptInstaller func() error
+
 // SetCheckInterval sets the update check interval from config
 func SetCheckInterval(hours int) {
 	if hours > 0 {
 		checkInterval = time.Duration(hours) * time.Hour
 	}
+}
+
+// SetBridgeScriptInstaller configures the bridge.py installer used after updates.
+func SetBridgeScriptInstaller(installer func() error) {
+	bridgeScriptInstaller = installer
 }
 
 // Release represents a GitHub release
@@ -851,13 +859,10 @@ func extractBinaryFromTarGzReader(r io.Reader) ([]byte, error) {
 // UpdateBridgePy refreshes the installed bridge.py from the embedded runtime template.
 // This keeps bridge behavior in sync with the currently running binary.
 func UpdateBridgePy() error {
-	// Get the conductor directory
-	home, err := os.UserHomeDir()
+	conductorDir, err := agentpaths.EffectiveDataPath("conductor", "conductor")
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return fmt.Errorf("failed to resolve conductor directory: %w", err)
 	}
-
-	conductorDir := filepath.Join(home, ".agent-deck", "conductor")
 	bridgePath := filepath.Join(conductorDir, "bridge.py")
 
 	// Check if conductor directory exists
@@ -880,7 +885,10 @@ func UpdateBridgePy() error {
 	}
 
 	// Install latest bridge template from embedded runtime.
-	if err := session.InstallBridgeScript(); err != nil {
+	if bridgeScriptInstaller == nil {
+		return fmt.Errorf("bridge.py installer is not configured")
+	}
+	if err := bridgeScriptInstaller(); err != nil {
 		return fmt.Errorf("failed to install bridge.py: %w", err)
 	}
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
@@ -113,11 +114,7 @@ func isUpdateCheckSkipped() bool {
 
 // getCacheDir returns the cache directory path
 func getCacheDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".agent-deck"), nil
+	return agentpaths.CacheDir()
 }
 
 // loadCache loads the update cache from disk

--- a/internal/update/update_nudge_test.go
+++ b/internal/update/update_nudge_test.go
@@ -141,7 +141,7 @@ func TestCheckForUpdate_PopulatesReleasesBehind(t *testing.T) {
 	t.Cleanup(func() { apiBaseURL = origURL })
 
 	// Isolate disk cache so a stale entry on the dev machine doesn't skip the fetch.
-	t.Setenv("HOME", t.TempDir())
+	isolateUpdatePaths(t)
 
 	info, err := CheckForUpdate("1.7.50", true)
 	require.NoError(t, err)
@@ -155,8 +155,7 @@ func TestCheckForUpdate_PopulatesReleasesBehind(t *testing.T) {
 func TestCachedUpdateInfo_OfflineReadFromCache(t *testing.T) {
 	// `agent-deck --version` must be instant — never hit the network.
 	// CachedUpdateInfo reads the on-disk cache directly.
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	isolateUpdatePaths(t)
 
 	// No cache yet → (nil, nil).
 	info, err := CachedUpdateInfo("1.7.20")
@@ -187,8 +186,7 @@ func TestCachedUpdateInfo_OfflineReadFromCache(t *testing.T) {
 }
 
 func TestCachedUpdateInfo_EnvSkipReturnsNil(t *testing.T) {
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	isolateUpdatePaths(t)
 	t.Setenv("AGENTDECK_SKIP_UPDATE_CHECK", "1")
 
 	// Even with a populated cache, env var suppresses the result so the
@@ -240,7 +238,7 @@ func TestCheckForUpdate_ReleasesBehindSurvivesCacheRoundtrip(t *testing.T) {
 	origURL := apiBaseURL
 	apiBaseURL = srv.URL
 	t.Cleanup(func() { apiBaseURL = origURL })
-	t.Setenv("HOME", t.TempDir())
+	isolateUpdatePaths(t)
 
 	// Seed cache by a force-check.
 	first, err := CheckForUpdate("1.7.51", true)

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -166,7 +166,7 @@ func TestUpdateBridgePy_NoConductorDir(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "conductor dir should not be created when not installed")
 }
 
-func TestUpdateBridgePy_UsesEmbeddedTemplateAndBacksUpExistingFile(t *testing.T) {
+func TestUpdateBridgePy_UsesInjectedInstallerAndBacksUpExistingFile(t *testing.T) {
 	tmpHome := isolateUpdatePaths(t)
 
 	condDir := filepath.Join(tmpHome, ".agent-deck", "conductor")
@@ -175,6 +175,13 @@ func TestUpdateBridgePy_UsesEmbeddedTemplateAndBacksUpExistingFile(t *testing.T)
 	bridgePath := filepath.Join(condDir, "bridge.py")
 	legacyContent := "# legacy bridge\nprint('old bridge')\n"
 	require.NoError(t, os.WriteFile(bridgePath, []byte(legacyContent), 0o755))
+
+	SetBridgeScriptInstaller(func() error {
+		return os.WriteFile(bridgePath, []byte("# injected bridge\n"), 0o755)
+	})
+	t.Cleanup(func() {
+		SetBridgeScriptInstaller(nil)
+	})
 
 	err := UpdateBridgePy()
 	require.NoError(t, err)
@@ -186,8 +193,7 @@ func TestUpdateBridgePy_UsesEmbeddedTemplateAndBacksUpExistingFile(t *testing.T)
 
 	newContent, err := os.ReadFile(bridgePath)
 	require.NoError(t, err)
-	assert.True(t, strings.Contains(string(newContent), "Conductor Bridge: Telegram & Slack"),
-		"bridge.py should be refreshed from the embedded multi-platform template")
+	assert.Equal(t, "# injected bridge\n", string(newContent))
 }
 
 func TestNormalizeReleaseTag(t *testing.T) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -161,9 +161,12 @@ func TestUpdateBridgePy_NoConductorDir(t *testing.T) {
 	err := UpdateBridgePy()
 	require.NoError(t, err)
 
-	condDir := filepath.Join(tmpHome, ".agent-deck", "conductor")
-	_, statErr := os.Stat(condDir)
-	assert.True(t, os.IsNotExist(statErr), "conductor dir should not be created when not installed")
+	legacyCondDir := filepath.Join(tmpHome, ".agent-deck", "conductor")
+	xdgCondDir := filepath.Join(os.Getenv("XDG_DATA_HOME"), "agent-deck", "conductor")
+	_, legacyErr := os.Stat(legacyCondDir)
+	_, xdgErr := os.Stat(xdgCondDir)
+	assert.True(t, os.IsNotExist(legacyErr), "legacy conductor dir should not be created when not installed")
+	assert.True(t, os.IsNotExist(xdgErr), "XDG conductor dir should not be created when not installed")
 }
 
 func TestUpdateBridgePy_UsesInjectedInstallerAndBacksUpExistingFile(t *testing.T) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -156,8 +156,7 @@ func TestFormatChangelogForDisplay(t *testing.T) {
 }
 
 func TestUpdateBridgePy_NoConductorDir(t *testing.T) {
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	tmpHome := isolateUpdatePaths(t)
 
 	err := UpdateBridgePy()
 	require.NoError(t, err)
@@ -168,8 +167,7 @@ func TestUpdateBridgePy_NoConductorDir(t *testing.T) {
 }
 
 func TestUpdateBridgePy_UsesEmbeddedTemplateAndBacksUpExistingFile(t *testing.T) {
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	tmpHome := isolateUpdatePaths(t)
 
 	condDir := filepath.Join(tmpHome, ".agent-deck", "conductor")
 	require.NoError(t, os.MkdirAll(condDir, 0o755))
@@ -340,7 +338,7 @@ func TestPerformVerifiedUpdate_ChecksumsDownloadFailureLeavesBinaryUntouched(t *
 func selfUpdateTestTarget(t *testing.T, initial []byte) string {
 	t.Helper()
 
-	t.Setenv("HOME", t.TempDir())
+	isolateUpdatePaths(t)
 	execPath := filepath.Join(t.TempDir(), "agent-deck")
 	require.NoError(t, os.WriteFile(execPath, initial, 0o755))
 

--- a/internal/watcher/assets/watcher-templates/HERMES.md
+++ b/internal/watcher/assets/watcher-templates/HERMES.md
@@ -6,10 +6,12 @@ Agent sessions inspecting this directory will find the layout and CLI reference 
 
 ## Layout
 
-The singular watcher root mirrors `~/.agent-deck/conductor/`:
+The singular watcher root mirrors the conductor data directory. New installs use
+`$XDG_DATA_HOME/agent-deck/watcher/`; hosts with existing watcher state keep the
+legacy `~/.agent-deck/watcher/` root.
 
 ```
-~/.agent-deck/watcher/
+$XDG_DATA_HOME/agent-deck/watcher/
   HERMES.md        — this file (shared knowledge base)
   POLICY.md        — behavior rules (escalation, dedup, retry, health thresholds)
   LEARNINGS.md     — cross-watcher patterns accumulated over time
@@ -50,10 +52,10 @@ agent-deck watcher test <name>
 
 ## Why This Folder Shape
 
-Watcher state mirrors the conductor pattern (`~/.agent-deck/conductor/`) for consistency:
+Watcher state mirrors the conductor data-directory pattern for consistency:
 both subsystems use a singular directory root with shared top-level files and
 per-instance subdirectories. This makes the layout predictable and tooling reusable.
 
 The legacy `~/.agent-deck/watchers/` path is preserved as a relative compatibility
-symlink pointing to `watcher/`. Existing tooling that reads `watchers/` continues
-to work without modification.
+symlink pointing to `watcher/` when legacy watcher state is in use. Existing
+tooling that reads `watchers/` continues to work without modification.

--- a/internal/watcher/assets/watcher-templates/HERMES.md
+++ b/internal/watcher/assets/watcher-templates/HERMES.md
@@ -7,11 +7,11 @@ Agent sessions inspecting this directory will find the layout and CLI reference 
 ## Layout
 
 The singular watcher root mirrors the conductor data directory. New installs use
-`$XDG_DATA_HOME/agent-deck/watcher/`; hosts with existing watcher state keep the
+`${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher/`; hosts with existing watcher state keep the
 legacy `~/.agent-deck/watcher/` root.
 
 ```
-$XDG_DATA_HOME/agent-deck/watcher/
+${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher/
   HERMES.md        — this file (shared knowledge base)
   POLICY.md        — behavior rules (escalation, dedup, retry, health thresholds)
   LEARNINGS.md     — cross-watcher patterns accumulated over time

--- a/internal/watcher/assets/watcher-templates/POLICY.md
+++ b/internal/watcher/assets/watcher-templates/POLICY.md
@@ -12,7 +12,7 @@ Defaults:
 - Triage sessions are rate-limited to 5 per hour per engine instance.
 - Events exceeding the rate limit are queued (capacity 16); excess events are
   marked `triage-dropped` in the event log.
-- Triage results are written to `$XDG_DATA_HOME/agent-deck/triage/<dedup_key>/result.json`
+- Triage results are written to `${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/triage/<dedup_key>/result.json`
   on new installs (or legacy `~/.agent-deck/triage/...` when existing triage
   state is present)
   and applied to `clients.json` by the triage reaper.

--- a/internal/watcher/assets/watcher-templates/POLICY.md
+++ b/internal/watcher/assets/watcher-templates/POLICY.md
@@ -12,7 +12,9 @@ Defaults:
 - Triage sessions are rate-limited to 5 per hour per engine instance.
 - Events exceeding the rate limit are queued (capacity 16); excess events are
   marked `triage-dropped` in the event log.
-- Triage results are written to `~/.agent-deck/triage/<dedup_key>/result.json`
+- Triage results are written to `$XDG_DATA_HOME/agent-deck/triage/<dedup_key>/result.json`
+  on new installs (or legacy `~/.agent-deck/triage/...` when existing triage
+  state is present)
   and applied to `clients.json` by the triage reaper.
 
 ## Deduplication

--- a/internal/watcher/engine.go
+++ b/internal/watcher/engine.go
@@ -136,7 +136,7 @@ func NewEngine(cfg EngineConfig) *Engine {
 			cfg.TriageDir = dir
 		} else {
 			logger.Warn("watcher_triage_dir_lookup_failed", slog.String("error", err.Error()))
-			cfg.TriageDir = filepath.Join(os.TempDir(), ".agent-deck", "triage")
+			cfg.TriageDir = filepath.Join(os.TempDir(), "agent-deck", "triage")
 		}
 	}
 	if cfg.ClientsPath == "" {
@@ -145,7 +145,7 @@ func NewEngine(cfg EngineConfig) *Engine {
 			cfg.ClientsPath = filepath.Join(dir, "clients.json")
 		} else {
 			logger.Warn("watcher_clients_path_lookup_failed", slog.String("error", err.Error()))
-			cfg.ClientsPath = filepath.Join(os.TempDir(), ".agent-deck", "watcher", "clients.json")
+			cfg.ClientsPath = filepath.Join(os.TempDir(), "agent-deck", "watcher", "clients.json")
 		}
 	}
 	if cfg.Profile == "" {

--- a/internal/watcher/engine.go
+++ b/internal/watcher/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/logging"
+	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/statedb"
 )
 
@@ -40,11 +41,11 @@ type EngineConfig struct {
 	Clock Clock
 
 	// TriageDir is the directory where triage session results are written.
-	// Defaults to $HOME/.agent-deck/triage/ when empty.
+	// Defaults to the effective agent-deck XDG data triage dir when empty.
 	TriageDir string
 
 	// ClientsPath is the path to clients.json for triage hot-reload.
-	// Defaults to $HOME/.agent-deck/watcher/clients.json when empty.
+	// Defaults to the effective agent-deck XDG data watcher clients.json when empty.
 	ClientsPath string
 
 	// Profile is the agent-deck profile flag passed to spawned triage sessions.
@@ -131,14 +132,14 @@ func NewEngine(cfg EngineConfig) *Engine {
 		cfg.Clock = realClock{}
 	}
 	if cfg.TriageDir == "" {
-		if home, err := os.UserHomeDir(); err == nil {
-			cfg.TriageDir = filepath.Join(home, ".agent-deck", "triage")
+		if dir, err := session.TriageDir(); err == nil {
+			cfg.TriageDir = dir
 		}
 	}
 	if cfg.ClientsPath == "" {
-		if home, err := os.UserHomeDir(); err == nil {
+		if dir, err := LayoutDir(); err == nil {
 			// Singular "watcher" per REQ-WF-6. Legacy "watchers/" is served via compatibility symlink created by MigrateLegacyWatchersDir.
-			cfg.ClientsPath = filepath.Join(home, ".agent-deck", "watcher", "clients.json")
+			cfg.ClientsPath = filepath.Join(dir, "clients.json")
 		}
 	}
 	if cfg.Profile == "" {

--- a/internal/watcher/engine.go
+++ b/internal/watcher/engine.go
@@ -134,12 +134,18 @@ func NewEngine(cfg EngineConfig) *Engine {
 	if cfg.TriageDir == "" {
 		if dir, err := session.TriageDir(); err == nil {
 			cfg.TriageDir = dir
+		} else {
+			logger.Warn("watcher_triage_dir_lookup_failed", slog.String("error", err.Error()))
+			cfg.TriageDir = filepath.Join(os.TempDir(), ".agent-deck", "triage")
 		}
 	}
 	if cfg.ClientsPath == "" {
 		if dir, err := LayoutDir(); err == nil {
 			// Singular "watcher" per REQ-WF-6. Legacy "watchers/" is served via compatibility symlink created by MigrateLegacyWatchersDir.
 			cfg.ClientsPath = filepath.Join(dir, "clients.json")
+		} else {
+			logger.Warn("watcher_clients_path_lookup_failed", slog.String("error", err.Error()))
+			cfg.ClientsPath = filepath.Join(os.TempDir(), ".agent-deck", "watcher", "clients.json")
 		}
 	}
 	if cfg.Profile == "" {

--- a/internal/watcher/layout.go
+++ b/internal/watcher/layout.go
@@ -43,12 +43,12 @@ func validateWatcherName(name string) error {
 	return nil
 }
 
-// LayoutDir returns the root watcher dir (~/.agent-deck/watcher). Delegates to session.WatcherDir for single-source-of-truth.
+// LayoutDir returns the effective root watcher dir. Delegates to session.WatcherDir for single-source-of-truth.
 func LayoutDir() (string, error) {
 	return session.WatcherDir()
 }
 
-// WatcherDir returns ~/.agent-deck/watcher/<name> after validating name. T-21-PI mitigation.
+// WatcherDir returns the effective watcher/<name> dir after validating name. T-21-PI mitigation.
 func WatcherDir(name string) (string, error) {
 	if err := validateWatcherName(name); err != nil {
 		return "", err
@@ -100,16 +100,16 @@ func writeIfAbsent(path string, content []byte) error {
 // and creates a relative compatibility symlink watchers -> watcher. Single-shot; subsequent calls no-op.
 // SECURITY T-21-SL: uses os.Lstat (not os.Stat) and refuses if watcher/ is a symlink targeting outside the deck root.
 func MigrateLegacyWatchersDir() error {
-	deck, err := session.GetAgentDeckDir()
+	current, err := LayoutDir()
 	if err != nil {
 		return err
 	}
+	deck := filepath.Dir(current)
 	absDeck, err := filepath.Abs(deck)
 	if err != nil {
 		return err
 	}
 	legacy := filepath.Join(deck, "watchers")
-	current := filepath.Join(deck, "watcher")
 
 	curInfo, curErr := os.Lstat(current)      // Lstat: do NOT follow symlink
 	legacyInfo, legacyErr := os.Lstat(legacy) // Lstat: do NOT follow symlink

--- a/internal/watcher/layout_test.go
+++ b/internal/watcher/layout_test.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 // restoreDefaultLogger restores the default slog logger after test-local capture.
@@ -33,8 +35,8 @@ func captureLog(t *testing.T) *bytes.Buffer {
 	return &buf
 }
 
-// agentDeckDir returns ~/.agent-deck for the current HOME (which is t.TempDir in tests).
-func agentDeckDir(t *testing.T) string {
+// legacyAgentDeckDir returns ~/.agent-deck for the current HOME.
+func legacyAgentDeckDir(t *testing.T) string {
 	t.Helper()
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -43,9 +45,18 @@ func agentDeckDir(t *testing.T) string {
 	return filepath.Join(home, ".agent-deck")
 }
 
+func effectiveAgentDeckDir(t *testing.T) string {
+	t.Helper()
+	watcherDir, err := session.WatcherDir()
+	if err != nil {
+		t.Fatalf("WatcherDir: %v", err)
+	}
+	return filepath.Dir(watcherDir)
+}
+
 // TestLayout_FreshInstallCreatesLayout verifies that ScaffoldWatcherLayout creates
-// ~/.agent-deck/watcher/{CLAUDE.md, POLICY.md, LEARNINGS.md, clients.json} when the
-// directory does not yet exist.
+// watcher/{CLAUDE.md, POLICY.md, LEARNINGS.md, clients.json} under the effective
+// XDG data dir when the directory does not yet exist.
 func TestLayout_FreshInstallCreatesLayout(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
@@ -53,7 +64,7 @@ func TestLayout_FreshInstallCreatesLayout(t *testing.T) {
 		t.Fatalf("ScaffoldWatcherLayout: %v", err)
 	}
 
-	deck := agentDeckDir(t)
+	deck := effectiveAgentDeckDir(t)
 	for _, name := range []string{"CLAUDE.md", "POLICY.md", "LEARNINGS.md", "clients.json"} {
 		path := filepath.Join(deck, "watcher", name)
 		info, err := os.Stat(path)
@@ -75,7 +86,7 @@ func TestLayout_LegacyMigrationAtomic(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
 		buf := captureLog(t)
 
-		deck := agentDeckDir(t)
+		deck := legacyAgentDeckDir(t)
 		// Seed legacy directory with sub-dir + file.
 		legacyDir := filepath.Join(deck, "watchers", "alpha")
 		if err := os.MkdirAll(legacyDir, 0o755); err != nil {
@@ -139,7 +150,7 @@ func TestLayout_LegacyMigrationAtomic(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
 		buf := captureLog(t)
 
-		deck := agentDeckDir(t)
+		deck := legacyAgentDeckDir(t)
 		// Seed both as real directories.
 		if err := os.MkdirAll(filepath.Join(deck, "watchers"), 0o755); err != nil {
 			t.Fatalf("MkdirAll watchers: %v", err)
@@ -170,7 +181,7 @@ func TestLayout_LegacyMigrationAtomic(t *testing.T) {
 	t.Run("symlink_attack", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
 
-		deck := agentDeckDir(t)
+		deck := legacyAgentDeckDir(t)
 		if err := os.MkdirAll(deck, 0o755); err != nil {
 			t.Fatalf("MkdirAll deck: %v", err)
 		}
@@ -193,7 +204,7 @@ func TestLayout_LegacyMigrationAtomic(t *testing.T) {
 	t.Run("idempotent", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
 
-		deck := agentDeckDir(t)
+		deck := legacyAgentDeckDir(t)
 		legacyDir := filepath.Join(deck, "watchers")
 		if err := os.MkdirAll(legacyDir, 0o755); err != nil {
 			t.Fatalf("MkdirAll legacy: %v", err)
@@ -216,7 +227,7 @@ func TestLayout_LegacyMigrationAtomic(t *testing.T) {
 func TestLayout_SymlinkResolves(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	deck := agentDeckDir(t)
+	deck := legacyAgentDeckDir(t)
 	// Seed clients.json in the legacy location.
 	legacyDir := filepath.Join(deck, "watchers")
 	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
@@ -311,7 +322,7 @@ func TestLayout_EventLogAppendAtomic(t *testing.T) {
 		}
 	}
 
-	deck := agentDeckDir(t)
+	deck := effectiveAgentDeckDir(t)
 	logPath := filepath.Join(deck, "watcher", "alpha", "task-log.md")
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -363,7 +374,7 @@ func TestLayout_EventLogAppendAtomic(t *testing.T) {
 		}
 		wg.Wait()
 
-		deck2 := agentDeckDir(t)
+		deck2 := effectiveAgentDeckDir(t)
 		logPath2 := filepath.Join(deck2, "watcher", "beta", "task-log.md")
 		data2, err := os.ReadFile(logPath2)
 		if err != nil {
@@ -422,7 +433,7 @@ func TestLayout_Integration_ThreeEvents(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	// Seed meta.json for "alpha".
-	deck := agentDeckDir(t)
+	deck := effectiveAgentDeckDir(t)
 	alphaDir := filepath.Join(deck, "watcher", "alpha")
 	if err := os.MkdirAll(alphaDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll alpha: %v", err)

--- a/internal/watcher/layout_test.go
+++ b/internal/watcher/layout_test.go
@@ -54,11 +54,18 @@ func effectiveAgentDeckDir(t *testing.T) string {
 	return filepath.Dir(watcherDir)
 }
 
+func isolateWatcherLayoutHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg-data"))
+}
+
 // TestLayout_FreshInstallCreatesLayout verifies that ScaffoldWatcherLayout creates
 // watcher/{CLAUDE.md, POLICY.md, LEARNINGS.md, clients.json} under the effective
 // XDG data dir when the directory does not yet exist.
 func TestLayout_FreshInstallCreatesLayout(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateWatcherLayoutHome(t)
 
 	if err := ScaffoldWatcherLayout(); err != nil {
 		t.Fatalf("ScaffoldWatcherLayout: %v", err)
@@ -83,7 +90,7 @@ func TestLayout_FreshInstallCreatesLayout(t *testing.T) {
 // and idempotent re-run.
 func TestLayout_LegacyMigrationAtomic(t *testing.T) {
 	t.Run("happy_path", func(t *testing.T) {
-		t.Setenv("HOME", t.TempDir())
+		isolateWatcherLayoutHome(t)
 		buf := captureLog(t)
 
 		deck := legacyAgentDeckDir(t)
@@ -147,7 +154,7 @@ func TestLayout_LegacyMigrationAtomic(t *testing.T) {
 	})
 
 	t.Run("collision", func(t *testing.T) {
-		t.Setenv("HOME", t.TempDir())
+		isolateWatcherLayoutHome(t)
 		buf := captureLog(t)
 
 		deck := legacyAgentDeckDir(t)
@@ -179,7 +186,7 @@ func TestLayout_LegacyMigrationAtomic(t *testing.T) {
 	})
 
 	t.Run("symlink_attack", func(t *testing.T) {
-		t.Setenv("HOME", t.TempDir())
+		isolateWatcherLayoutHome(t)
 
 		deck := legacyAgentDeckDir(t)
 		if err := os.MkdirAll(deck, 0o755); err != nil {
@@ -202,7 +209,7 @@ func TestLayout_LegacyMigrationAtomic(t *testing.T) {
 	})
 
 	t.Run("idempotent", func(t *testing.T) {
-		t.Setenv("HOME", t.TempDir())
+		isolateWatcherLayoutHome(t)
 
 		deck := legacyAgentDeckDir(t)
 		legacyDir := filepath.Join(deck, "watchers")
@@ -225,7 +232,7 @@ func TestLayout_LegacyMigrationAtomic(t *testing.T) {
 // TestLayout_SymlinkResolves verifies that after migration, the compatibility symlink
 // allows reads through watchers/clients.json that resolve to watcher/clients.json.
 func TestLayout_SymlinkResolves(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateWatcherLayoutHome(t)
 
 	deck := legacyAgentDeckDir(t)
 	// Seed clients.json in the legacy location.
@@ -259,7 +266,7 @@ func TestLayout_SymlinkResolves(t *testing.T) {
 // TestLayout_StateRoundtrip verifies SaveState/LoadState round-trip all WatcherState fields,
 // and that LoadState returns (nil, nil) when state.json is absent.
 func TestLayout_StateRoundtrip(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateWatcherLayoutHome(t)
 
 	t0 := time.Now().UTC().Truncate(time.Second)
 	original := &WatcherState{
@@ -309,7 +316,7 @@ func TestLayout_StateRoundtrip(t *testing.T) {
 // TestLayout_EventLogAppendAtomic verifies AppendEventLog writes complete lines,
 // and that concurrent appends do not produce torn lines.
 func TestLayout_EventLogAppendAtomic(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateWatcherLayoutHome(t)
 
 	entries := []string{
 		"## 2026-04-16T12:00:00Z - webhook: evt1",
@@ -351,7 +358,7 @@ func TestLayout_EventLogAppendAtomic(t *testing.T) {
 
 	// Concurrency sub-test: 2 goroutines × 50 appends = 100 total lines, no torn lines.
 	t.Run("concurrent", func(t *testing.T) {
-		t.Setenv("HOME", t.TempDir())
+		isolateWatcherLayoutHome(t)
 
 		lineRe := regexp.MustCompile(`^## .+$`)
 		var wg sync.WaitGroup
@@ -397,7 +404,7 @@ func TestLayout_EventLogAppendAtomic(t *testing.T) {
 
 // TestLayout_HotReloadSafe verifies LoadState always reads from disk (no in-process cache).
 func TestLayout_HotReloadSafe(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateWatcherLayoutHome(t)
 
 	t0 := time.Now().UTC().Truncate(time.Second)
 	stateV1 := &WatcherState{LastEventTS: t0, ErrorCount: 1, AdapterHealthy: true}
@@ -430,7 +437,7 @@ func TestLayout_HotReloadSafe(t *testing.T) {
 // TestLayout_Integration_ThreeEvents simulates writerLoop calling AppendEventLog + SaveState
 // three times and checks that task-log.md has 3 lines and LastEventTS equals the third event's ts.
 func TestLayout_Integration_ThreeEvents(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateWatcherLayoutHome(t)
 
 	// Seed meta.json for "alpha".
 	deck := effectiveAgentDeckDir(t)
@@ -486,7 +493,7 @@ func TestLayout_Integration_ThreeEvents(t *testing.T) {
 
 // TestLayout_WatcherDir_RejectsMaliciousNames verifies T-21-PI: path traversal names are rejected.
 func TestLayout_WatcherDir_RejectsMaliciousNames(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	isolateWatcherLayoutHome(t)
 
 	cases := []struct {
 		name    string

--- a/internal/watcher/router.go
+++ b/internal/watcher/router.go
@@ -93,8 +93,8 @@ func LoadClientsJSON(path string) (map[string]ClientEntry, error) {
 	return entries, nil
 }
 
-// LoadFromWatcherDir loads clients.json from the standard watcher directory
-// (~/.agent-deck/watcher/clients.json) and returns a ready-to-use Router.
+// LoadFromWatcherDir loads clients.json from the effective watcher data
+// directory and returns a ready-to-use Router.
 func LoadFromWatcherDir() (*Router, error) {
 	base, err := session.WatcherDir()
 	if err != nil {

--- a/internal/watcher/xdg_paths_test.go
+++ b/internal/watcher/xdg_paths_test.go
@@ -1,0 +1,102 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func setupWatcherXDGPathEnv(t *testing.T) (home string, xdgDataHome string) {
+	t.Helper()
+
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	root := t.TempDir()
+	home = filepath.Join(root, "home")
+	xdgConfigHome := filepath.Join(root, "xdg-config")
+	xdgDataHome = filepath.Join(root, "xdg-data")
+
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", home, err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+	t.Setenv("XDG_DATA_HOME", xdgDataHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	return home, xdgDataHome
+}
+
+func TestXDGDataTask4_WatcherLayoutUsesXDGDataHomeForNewUser(t *testing.T) {
+	_, xdgDataHome := setupWatcherXDGPathEnv(t)
+
+	got, err := LayoutDir()
+	if err != nil {
+		t.Fatalf("LayoutDir(): %v", err)
+	}
+	want := filepath.Join(xdgDataHome, "agent-deck", "watcher")
+	if got != want {
+		t.Fatalf("LayoutDir() = %q, want %q", got, want)
+	}
+
+	gotName, err := WatcherDir("my-watcher")
+	if err != nil {
+		t.Fatalf("WatcherDir(): %v", err)
+	}
+	wantName := filepath.Join(want, "my-watcher")
+	if gotName != wantName {
+		t.Fatalf("WatcherDir() = %q, want %q", gotName, wantName)
+	}
+}
+
+func TestXDGDataTask4_WatcherLayoutUsesCategorySpecificLegacyFallback(t *testing.T) {
+	home, xdgDataHome := setupWatcherXDGPathEnv(t)
+
+	legacyProfilesDir := filepath.Join(home, ".agent-deck", session.ProfilesDirName)
+	if err := os.MkdirAll(legacyProfilesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyProfilesDir, err)
+	}
+
+	got, err := LayoutDir()
+	if err != nil {
+		t.Fatalf("LayoutDir(): %v", err)
+	}
+	wantXDG := filepath.Join(xdgDataHome, "agent-deck", "watcher")
+	if got != wantXDG {
+		t.Fatalf("legacy profiles marker must not move watcher layout to legacy: got %q want %q", got, wantXDG)
+	}
+
+	legacyPluralDir := filepath.Join(home, ".agent-deck", "watchers")
+	if err := os.MkdirAll(legacyPluralDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", legacyPluralDir, err)
+	}
+
+	got, err = LayoutDir()
+	if err != nil {
+		t.Fatalf("LayoutDir(): %v", err)
+	}
+	wantLegacy := filepath.Join(home, ".agent-deck", "watcher")
+	if got != wantLegacy {
+		t.Fatalf("legacy watchers marker should keep watcher layout legacy: got %q want %q", got, wantLegacy)
+	}
+}
+
+func TestXDGDataTask4_WatcherEngineDefaultsUseXDGDataHome(t *testing.T) {
+	_, xdgDataHome := setupWatcherXDGPathEnv(t)
+
+	engine := NewEngine(EngineConfig{})
+
+	wantTriage := filepath.Join(xdgDataHome, "agent-deck", "triage")
+	if engine.cfg.TriageDir != wantTriage {
+		t.Fatalf("Engine TriageDir = %q, want %q", engine.cfg.TriageDir, wantTriage)
+	}
+
+	wantClients := filepath.Join(xdgDataHome, "agent-deck", "watcher", "clients.json")
+	if engine.cfg.ClientsPath != wantClients {
+		t.Fatalf("Engine ClientsPath = %q, want %q", engine.cfg.ClientsPath, wantClients)
+	}
+}

--- a/internal/watcher/xdg_paths_test.go
+++ b/internal/watcher/xdg_paths_test.go
@@ -100,3 +100,27 @@ func TestXDGDataTask4_WatcherEngineDefaultsUseXDGDataHome(t *testing.T) {
 		t.Fatalf("Engine ClientsPath = %q, want %q", engine.cfg.ClientsPath, wantClients)
 	}
 }
+
+func TestXDGDataTask4_WatcherEngineDefaultsUseExplicitFallbackOnPathErrors(t *testing.T) {
+	home, _ := setupWatcherXDGPathEnv(t)
+	badXDGDataHome := filepath.Join(home, "xdg-data-file")
+	if err := os.WriteFile(badXDGDataHome, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", badXDGDataHome, err)
+	}
+	t.Setenv("XDG_DATA_HOME", badXDGDataHome)
+
+	engine := NewEngine(EngineConfig{})
+
+	if engine.cfg.TriageDir == "" {
+		t.Fatal("Engine TriageDir must not be empty when XDG path resolution fails")
+	}
+	if engine.cfg.ClientsPath == "" {
+		t.Fatal("Engine ClientsPath must not be empty when XDG path resolution fails")
+	}
+	if got, want := engine.cfg.TriageDir, filepath.Join(os.TempDir(), ".agent-deck", "triage"); got != want {
+		t.Fatalf("Engine TriageDir fallback = %q, want %q", got, want)
+	}
+	if got, want := engine.cfg.ClientsPath, filepath.Join(os.TempDir(), ".agent-deck", "watcher", "clients.json"); got != want {
+		t.Fatalf("Engine ClientsPath fallback = %q, want %q", got, want)
+	}
+}

--- a/internal/watcher/xdg_paths_test.go
+++ b/internal/watcher/xdg_paths_test.go
@@ -117,10 +117,10 @@ func TestXDGDataTask4_WatcherEngineDefaultsUseExplicitFallbackOnPathErrors(t *te
 	if engine.cfg.ClientsPath == "" {
 		t.Fatal("Engine ClientsPath must not be empty when XDG path resolution fails")
 	}
-	if got, want := engine.cfg.TriageDir, filepath.Join(os.TempDir(), ".agent-deck", "triage"); got != want {
+	if got, want := engine.cfg.TriageDir, filepath.Join(os.TempDir(), "agent-deck", "triage"); got != want {
 		t.Fatalf("Engine TriageDir fallback = %q, want %q", got, want)
 	}
-	if got, want := engine.cfg.ClientsPath, filepath.Join(os.TempDir(), ".agent-deck", "watcher", "clients.json"); got != want {
+	if got, want := engine.cfg.ClientsPath, filepath.Join(os.TempDir(), "agent-deck", "watcher", "clients.json"); got != want {
 		t.Fatalf("Engine ClientsPath fallback = %q, want %q", got, want)
 	}
 }

--- a/scripts/verify-command-override.sh
+++ b/scripts/verify-command-override.sh
@@ -71,7 +71,8 @@ log "tmux socket: ${TMUX_SOCKET}"
 log "test home: ${TEST_HOME}"
 
 # ---------- setup isolated environment ----------
-mkdir -p "${TEST_HOME}/.agent-deck"
+export XDG_CONFIG_HOME="${TEST_HOME}/.config"
+mkdir -p "${XDG_CONFIG_HOME}/agent-deck"
 mkdir -p "${TMPROOT}/bin"
 mkdir -p "${TMPROOT}/project"
 
@@ -84,7 +85,7 @@ ln -sf "${AGENT_DECK_BIN}" "${TMPROOT}/bin/agent-deck"
 
 # ---------- helpers ----------
 write_config() {
-  cat > "${TEST_HOME}/.agent-deck/config.toml" <<EOF
+  cat > "${XDG_CONFIG_HOME}/agent-deck/config.toml" <<EOF
 [tmux]
 socket_name = "${TMUX_SOCKET}"
 

--- a/scripts/verify-per-group-claude-config.sh
+++ b/scripts/verify-per-group-claude-config.sh
@@ -40,7 +40,8 @@ else
 fi
 
 # --- Config ---
-CONFIG_FILE="${HOME}/.agent-deck/config.toml"
+export XDG_CONFIG_HOME="${HOME}/.config"
+CONFIG_FILE="${XDG_CONFIG_HOME}/agent-deck/config.toml"
 BACKUP_FILE=""
 GROUP_A="verify-group-a"
 GROUP_B="verify-group-b"

--- a/scripts/verify-preview-ansi-bleed.sh
+++ b/scripts/verify-preview-ansi-bleed.sh
@@ -76,8 +76,9 @@ echo
 echo "--- Seam C (tmux) ---"
 command -v tmux >/dev/null || { skip "tmux not installed — Seam C skipped"; exit 0; }
 
-mkdir -p "$TMPHOME/.agent-deck"
-cat > "$TMPHOME/.agent-deck/config.toml" <<'EOF'
+export XDG_CONFIG_HOME="$TMPHOME/.config"
+mkdir -p "$XDG_CONFIG_HOME/agent-deck"
+cat > "$XDG_CONFIG_HOME/agent-deck/config.toml" <<'EOF'
 [tmux]
 inject_status_line = false
 EOF

--- a/scripts/verify-select-flag.sh
+++ b/scripts/verify-select-flag.sh
@@ -39,8 +39,9 @@ command -v tmux >/dev/null || { skip "tmux not installed"; exit 0; }
 [[ -x "$BIN" ]] || { fail "binary not found at $BIN (run: go build -o agent-deck ./cmd/agent-deck)"; exit 1; }
 
 # ---- seed three sessions in three groups so we can verify all groups remain visible
-mkdir -p "$TMPHOME/.agent-deck"
-cat > "$TMPHOME/.agent-deck/config.toml" <<'EOF'
+export XDG_CONFIG_HOME="$TMPHOME/.config"
+mkdir -p "$XDG_CONFIG_HOME/agent-deck"
+cat > "$XDG_CONFIG_HOME/agent-deck/config.toml" <<'EOF'
 [tmux]
 inject_status_line = false
 EOF

--- a/scripts/verify-tui-eval-seam-c.sh
+++ b/scripts/verify-tui-eval-seam-c.sh
@@ -51,8 +51,9 @@ command -v tmux >/dev/null || { skip "tmux not installed"; exit 0; }
 [[ -x "$BIN" ]] || { fail "binary not found at $BIN (run: go build -o agent-deck ./cmd/agent-deck)"; exit 1; }
 
 # Isolate state: fresh HOME so we don't touch the user's sessions / config.
-mkdir -p "$TMPHOME/.agent-deck"
-cat > "$TMPHOME/.agent-deck/config.toml" <<'EOF'
+export XDG_CONFIG_HOME="$TMPHOME/.config"
+mkdir -p "$XDG_CONFIG_HOME/agent-deck"
+cat > "$XDG_CONFIG_HOME/agent-deck/config.toml" <<'EOF'
 [tmux]
 inject_status_line = false
 EOF

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -450,7 +450,7 @@ Full conversational setup flow is available as a separate skill:
 agent-deck watcher install-skill watcher-creator
 ```
 
-After running the install command, read the installed `watcher-creator/SKILL.md` to walk the user through adapter selection, required settings, and configuring the effective watcher data dir's `clients.json` routing (`$XDG_DATA_HOME/agent-deck/watcher/clients.json` for new users; legacy `~/.agent-deck/watcher/clients.json` when existing watcher state is present).
+After running the install command, read the installed `watcher-creator/SKILL.md` to walk the user through adapter selection, required settings, and configuring the effective watcher data dir's `clients.json` routing (`${XDG_DATA_HOME:-$HOME/.local/share}/agent-deck/watcher/clients.json` for new users; legacy `~/.agent-deck/watcher/clients.json` when existing watcher state is present).
 
 See `agent-deck watcher --help` for the full command surface and per-adapter examples.
 

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -450,7 +450,7 @@ Full conversational setup flow is available as a separate skill:
 agent-deck watcher install-skill watcher-creator
 ```
 
-After running the install command, read `~/.agent-deck/skills/pool/watcher-creator/SKILL.md` to walk the user through adapter selection, required settings, and configuring `~/.agent-deck/watcher/<name>/clients.json` routing.
+After running the install command, read the installed `watcher-creator/SKILL.md` to walk the user through adapter selection, required settings, and configuring the effective watcher data dir's `clients.json` routing (`$XDG_DATA_HOME/agent-deck/watcher/clients.json` for new users; legacy `~/.agent-deck/watcher/clients.json` when existing watcher state is present).
 
 See `agent-deck watcher --help` for the full command surface and per-adapter examples.
 

--- a/tests/capability/vhs/lib/sandbox.sh
+++ b/tests/capability/vhs/lib/sandbox.sh
@@ -81,12 +81,13 @@ export PATH="$_capvid_bindir:$PATH"
 # Same stand-in the Go suite uses (tests/capability/testdata/echobot.sh): prints
 # a ready marker, echoes each line back as ECHO:<line>. prompt_patterns wires it
 # into agent-deck's readiness gate exactly as a real claude prompt would be.
-mkdir -p "$HOME/.agent-deck"
-cp "$_capvid_repo/tests/capability/testdata/echobot.sh" "$HOME/.agent-deck/echobot.sh"
-chmod +x "$HOME/.agent-deck/echobot.sh"
-cat > "$HOME/.agent-deck/config.toml" <<TOML
+_capvid_tooldir="$HOME/tools"
+mkdir -p "$_capvid_tooldir" "$XDG_CONFIG_HOME/agent-deck"
+cp "$_capvid_repo/tests/capability/testdata/echobot.sh" "$_capvid_tooldir/echobot.sh"
+chmod +x "$_capvid_tooldir/echobot.sh"
+cat > "$XDG_CONFIG_HOME/agent-deck/config.toml" <<TOML
 [tools.echobot]
-command = "$HOME/.agent-deck/echobot.sh"
+command = "$_capvid_tooldir/echobot.sh"
 icon = "E"
 prompt_patterns = ["ECHOBOT READY"]
 busy_patterns = ["WORKING"]

--- a/tests/eval/session/update_nudge_test.go
+++ b/tests/eval/session/update_nudge_test.go
@@ -38,9 +38,9 @@ func TestEval_VersionFlag_ShowsUpdateAnnotationFromCache(t *testing.T) {
 	// shape mirrors internal/update.UpdateCache; hand-written here so the
 	// eval package doesn't depend on internal/update (which it could not
 	// import under Go's internal-package rule anyway).
-	cacheDir := filepath.Join(sb.Home, ".agent-deck")
+	cacheDir := filepath.Join(sb.Home, ".cache", "agent-deck")
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		t.Fatalf("mkdir .agent-deck: %v", err)
+		t.Fatalf("mkdir update cache dir: %v", err)
 	}
 	// 9.9.99 is an impossible-future sentinel; using a real near-future
 	// version (e.g., 1.8.99) silently flips this test once the binary
@@ -93,9 +93,9 @@ func TestEval_VersionFlag_ShowsUpdateAnnotationFromCache(t *testing.T) {
 func TestEval_VersionFlag_EnvSkipSuppressesAnnotation(t *testing.T) {
 	sb := harness.NewSandbox(t)
 
-	cacheDir := filepath.Join(sb.Home, ".agent-deck")
+	cacheDir := filepath.Join(sb.Home, ".cache", "agent-deck")
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		t.Fatalf("mkdir .agent-deck: %v", err)
+		t.Fatalf("mkdir update cache dir: %v", err)
 	}
 	cache := map[string]any{
 		"checked_at":      time.Now().Format(time.RFC3339Nano),


### PR DESCRIPTION
## What

Closes #1272.

This adds XDG Base Directory support for agent-deck paths while preserving existing `~/.agent-deck` installs.

Before this change, agent-deck used `~/.agent-deck` as the single hardcoded root for config, profiles, hooks, logs, debug state, update cache, watcher state, and related runtime files. As reported in #1272, that meant edits to `$XDG_CONFIG_HOME/agent-deck/config.toml` or the default `~/.config/agent-deck/config.toml` were silently ignored.

After this change, new installs use category-specific XDG locations:

- Config: `$XDG_CONFIG_HOME/agent-deck`, defaulting to `~/.config/agent-deck`
- Data/state: `$XDG_DATA_HOME/agent-deck`, defaulting to `~/.local/share/agent-deck`
- Cache: `$XDG_CACHE_HOME/agent-deck`, defaulting to `~/.cache/agent-deck`

Existing users keep working through category-specific legacy fallback to `~/.agent-deck` when the corresponding XDG location is absent.

## Why

Issue #1272 identified two related problems:

- agent-deck ignored XDG config entirely, so dotfile-managed config under `~/.config/agent-deck` had no effect.
- several call sites bypassed the existing path funnel and constructed `~/.agent-deck` directly, so a partial path fix would leave config, uninstall, hook, cache, and update behavior inconsistent.

The goal here is to make path behavior predictable and XDG-compliant without breaking existing users or silently moving their data.

## How

- Added `internal/agentpaths` as the central resolver for config, data, cache, and legacy paths.
- Routed config, user config, profiles, skills, session/runtime state, hooks, locks, cost events, logs, watcher state, conductor state, tmux paths, feedback state, debug logs, update cache, CLI help text, and hook handlers through the resolver.
- Added category-specific legacy fallback so an existing `~/.agent-deck` install still reads its existing files, but unrelated legacy files do not force every category back to the legacy root.
- Added `agent-deck migrate-paths` with `--dry-run` and `--force` so migration is explicit, inspectable, and non-destructive. The command copies into the XDG split layout and leaves the legacy directory in place.
- Updated uninstall path handling so dry-run/removal accounts for both XDG and legacy locations without following cache symlink escapes.
- Added a regression guard that rejects direct `os.UserHomeDir()` + `.agent-deck` path construction in Go source.
- Updated README, CHANGELOG, watcher docs, embedded watcher skill docs, and verification scripts that referenced the legacy layout.

## Size

- 100 files changed
- 4,420 insertions, 619 deletions
- 33 test files touched
- 10 new `_test.go` files
- 65 new top-level Go `Test...` functions, including one helper-process harness

## Verification

Passed:

```bash
GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
  go test ./internal/agentpaths ./internal/session ./internal/tmux ./internal/update ./internal/feedback ./cmd/agent-deck \
  -run 'XDG|MigratePaths|MigrateLegacyLayout|NoDirectHomeAgentDeckPathConstruction|CachePath|StatePath|Effective|LegacyDir|GetUserConfigPath|GetConfigPath|GetProfilesDir|GetDBPathForProfile|NewStorageWithProfile|GenerateTransitionNotifierDaemons|GetSkillPoolPath|WatcherMeta|UpdateBridgePy' \
  -count=1

GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
  go test ./cmd/agent-deck/... -run 'Watcher' -race -count=1

GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
  go test ./internal/watcher/... -race -count=1 -timeout 120s
```

Known unrelated failure:

```bash
GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go GOCACHE=/private/tmp/agent-deck-go-build-cache GOTMPDIR=/private/tmp \
  go test ./internal/session -run '^TestPersistence_CustomCommandResumesFromLatestJSONL$' -count=1 -v
```

That focused persistence test fails on this branch and also fails on the pre-change merge-base `2c90c0899d81691f8ce093903a353bf25e3bfa57` with the same assertion: `inst.ClaudeSessionID=""`, expected the newer JSONL UUID. I treated it as pre-existing and unrelated to the XDG path changes.

Not run locally:

- `bash scripts/verify-session-persistence.sh`, because it requires a Linux + systemd host and this verification was performed on macOS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a migrate-paths CLI command (dry-run and force) to move legacy data into XDG-configured locations.

* **Improvements**
  * App now prefers XDG config/data/cache locations with legacy fallbacks.
  * Help, error, CLI and UI text now display effective XDG paths; uninstall reporting and --keep-data behavior clarified.
  * Watcher/skill installs, logs, caches, debug/crash dumps, and various runtime directories are XDG-aware.

* **Tests**
  * Extensive new and updated tests covering XDG behavior, migration, conflicts, and legacy fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->