### PR TITLE
fix(session): reconcile session title/badge on attach

### DIFF
--- a/cmd/agent-deck/hook_name_sync.go
+++ b/cmd/agent-deck/hook_name_sync.go
@@ -1,78 +1,45 @@
 package main
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
 
-// claudeSessionMetaFile is the subset of ~/.claude/sessions/<PID>.json that
-// agent-deck cares about for issue #572 title sync.
-type claudeSessionMetaFile struct {
-	SessionID string `json:"sessionId"`
-	Name      string `json:"name"`
-}
-
-// findClaudeSessionName scans claudeDir/sessions/*.json and returns the
-// `name` field of the entry whose `sessionId` matches. Empty string if no
-// match, no name, or the sessions dir doesn't exist.
+// findClaudeSessionName scans claudeDir/sessions/*.json and returns the `name`
+// field of the entry whose `sessionId` matches. Empty string if no match, no
+// name, or the sessions dir doesn't exist.
 //
-// Issue #572: Claude Code writes per-process metadata here when the user
-// starts with `claude --name X` or runs `/rename X` mid-session.
+// Thin wrapper over session.ClaudeSessionNameIn so the hook path and the
+// on-attach reconcile (internal/session) share one scanner implementation.
 func findClaudeSessionName(claudeDir, sessionID string) string {
-	if claudeDir == "" || sessionID == "" {
-		return ""
-	}
-	entries, err := os.ReadDir(filepath.Join(claudeDir, "sessions"))
-	if err != nil {
-		return ""
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(claudeDir, "sessions", entry.Name()))
-		if err != nil {
-			continue
-		}
-		var meta claudeSessionMetaFile
-		if err := json.Unmarshal(data, &meta); err != nil {
-			continue
-		}
-		if meta.SessionID == sessionID {
-			return strings.TrimSpace(meta.Name)
-		}
-	}
-	return ""
+	return session.ClaudeSessionNameIn(claudeDir, sessionID)
 }
 
-// applyClaudeTitleSync looks up the Claude session name for sessionID and,
-// if non-empty and different from the current agent-deck session title for
+// applyClaudeTitleSync looks up the Claude session name for sessionID and, if
+// non-empty and different from the current agent-deck session title for
 // instanceID, updates the title in storage.
 //
 // No-op (and silent) when:
 //   - instance can't be resolved across profiles
 //   - Claude session file doesn't exist or has no name
 //   - the stored title already matches
+//   - sync_title is disabled, or the instance is TitleLocked (both enforced by
+//     Instance.ReconcileTitleFromClaude)
 //
-// Scans profiles in order so the first match wins. This is the right shape
-// for hook_handler which doesn't know which profile owns the session — the
-// instance ID is globally unique.
+// Scans profiles in order so the first match wins. This is the right shape for
+// hook_handler which doesn't know which profile owns the session — the instance
+// ID is globally unique.
 func applyClaudeTitleSync(instanceID, sessionID string) {
 	if instanceID == "" || sessionID == "" {
 		return
 	}
 
-	// Global, tool-agnostic switch (config: sync_title = false). When the user
-	// has disabled title sync, agent-deck never overwrites a session Title with
-	// the agent's own session-name — for any tool. The per-session TitleLocked
-	// flag (checked below) stays as a finer-grained override.
-	// NOTE: this is currently the only title-sync path; any future non-Claude
-	// session-name sync MUST honor GetSyncTitle() the same way.
+	// Global, tool-agnostic switch (config: sync_title = false). Short-circuit
+	// before touching storage; ReconcileTitleFromClaude enforces it too, so
+	// this is purely to skip the profile scan when sync is off.
 	if cfg, err := session.LoadUserConfig(); err == nil && cfg != nil && !cfg.GetSyncTitle() {
 		return
 	}
@@ -81,8 +48,10 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 	if err != nil {
 		return
 	}
-	name := findClaudeSessionName(filepath.Join(home, ".claude"), sessionID)
-	if name == "" {
+	// Cheap pre-check: if Claude has no name for this session at all, skip the
+	// profile scan entirely (the common case for sessions started without
+	// --name). ReconcileTitleFromClaude re-reads it authoritatively below.
+	if findClaudeSessionName(filepath.Join(home, ".claude"), sessionID) == "" {
 		return
 	}
 
@@ -116,39 +85,23 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 			_ = storage.Close()
 			continue
 		}
-		// #697: TitleLocked blocks Claude's session name from overwriting the
-		// agent-deck title. Conductors rely on semantic titles (e.g.
-		// "SCRUM-351") surviving Claude's own /rename.
-		if target.TitleLocked {
-			_ = storage.Close()
-			return
+
+		// Instance IDs are globally unique: once found, this profile owns the
+		// session — act and stop, never fall through to another profile.
+		newName, changed := target.ReconcileTitleFromClaude(sessionID)
+		if changed {
+			groupTree := session.NewGroupTreeWithGroups(instances, groups)
+			_ = storage.SaveWithGroups(instances, groupTree)
 		}
-		if target.Title == name {
-			_ = storage.Close()
-			return
-		}
-		target.Title = name
-		target.SyncTmuxDisplayName()
-		groupTree := session.NewGroupTreeWithGroups(instances, groups)
-		_ = storage.SaveWithGroups(instances, groupTree)
 		_ = storage.Close()
 
-		// #1114: signal the attached agent-deck process to re-emit the
-		// iTerm2 badge for the new title. This hook subprocess is
-		// spawned detached (setsid) by Claude Code, so it has no
-		// controlling tty — the previous EmitITermBadgeViaTty path
-		// silently no-op'd because /dev/tty returned ENXIO. Writing a
-		// per-tmux-session file succeeds without a tty; the attach
-		// process (which owns the outer iTerm2 tty via os.Stdout)
-		// picks it up via fsnotify and emits the OSC.
-		//
-		// Also keep the via-tty emit for the rare case where the hook
-		// does happen to have a tty (e.g. a future Claude that doesn't
-		// setsid its hooks) — it's a silent no-op when it doesn't.
-		if tmuxSess := target.GetTmuxSession(); tmuxSess != nil && tmuxSess.Name != "" {
-			_ = tmux.WriteBadgeUpdate(tmuxSess.Name, name)
+		if changed {
+			// #1114: ReconcileTitleFromClaude already wrote the badge-update
+			// file the attached process watches (the path that works without a
+			// controlling tty). Also attempt the direct via-tty emit for the
+			// rare hook that DOES own a tty — silent no-op otherwise.
+			tmux.EmitITermBadgeViaTty(newName, session.GetTerminalSettings().GetITermBadge())
 		}
-		tmux.EmitITermBadgeViaTty(name, session.GetTerminalSettings().GetITermBadge())
 		return
 	}
 }

--- a/internal/session/claude_title_reconcile.go
+++ b/internal/session/claude_title_reconcile.go
@@ -1,0 +1,97 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// claudeSessionMeta is the subset of ~/.claude/sessions/<PID>.json that
+// agent-deck reads for title sync (issue #572).
+type claudeSessionMeta struct {
+	SessionID string `json:"sessionId"`
+	Name      string `json:"name"`
+}
+
+// ClaudeSessionNameIn scans claudeDir/sessions/*.json and returns the trimmed
+// `name` of the entry whose sessionId matches. Empty string when there's no
+// match, no name, or the sessions dir is unreadable.
+//
+// Issue #572: Claude Code writes per-process metadata here when the user starts
+// with `claude --name X` or runs `/rename X` mid-session. claudeDir is an
+// explicit parameter so tests can point it at a temp dir.
+func ClaudeSessionNameIn(claudeDir, sessionID string) string {
+	claudeDir = strings.TrimSpace(claudeDir)
+	sessionID = strings.TrimSpace(sessionID)
+	if claudeDir == "" || sessionID == "" {
+		return ""
+	}
+	entries, err := os.ReadDir(filepath.Join(claudeDir, "sessions"))
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(claudeDir, "sessions", entry.Name()))
+		if err != nil {
+			continue
+		}
+		var meta claudeSessionMeta
+		if err := json.Unmarshal(data, &meta); err != nil {
+			continue
+		}
+		if meta.SessionID == sessionID {
+			return strings.TrimSpace(meta.Name)
+		}
+	}
+	return ""
+}
+
+// ClaudeSessionName resolves the user's ~/.claude and returns the Claude
+// session name for sessionID. Empty string on any error or no match.
+func ClaudeSessionName(sessionID string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return ClaudeSessionNameIn(filepath.Join(home, ".claude"), sessionID)
+}
+
+// ReconcileTitleFromClaude refreshes i.Title from the agent's current Claude
+// session name. It is the shared core behind both the hook-event sync (#572)
+// and the on-attach reconcile (#1114 follow-up): Claude's /rename fires no
+// agent-deck hook, so an idle session's title and iTerm2 badge stay stale until
+// the next turn boundary — reconciling on attach makes detach/reattach a
+// reliable manual refresh.
+//
+// Honors the global sync_title switch and the per-session TitleLocked flag (so
+// conductor titles like "SCRUM-351" survive Claude's own /rename). On a real
+// change it mutates the in-memory instance (Title + tmux display name) and
+// drops the iTerm2 badge-update signal so the attach-side WatchBadgeUpdates
+// catch-up re-emits the fresh name instead of clobbering it with the old one.
+//
+// Returns the new name and true iff the title changed; the CALLER is
+// responsible for persisting the instance to storage.
+func (i *Instance) ReconcileTitleFromClaude(sessionID string) (string, bool) {
+	if i == nil || i.TitleLocked {
+		return "", false
+	}
+	if cfg, err := LoadUserConfig(); err == nil && cfg != nil && !cfg.GetSyncTitle() {
+		return "", false
+	}
+	name := ClaudeSessionName(sessionID)
+	if name == "" || name == i.Title {
+		return "", false
+	}
+	i.Title = name
+	i.SyncTmuxDisplayName()
+	if tmuxSess := i.GetTmuxSession(); tmuxSess != nil && tmuxSess.Name != "" {
+		_ = tmux.WriteBadgeUpdate(tmuxSess.Name, name)
+	}
+	return name, true
+}

--- a/internal/session/claude_title_reconcile_test.go
+++ b/internal/session/claude_title_reconcile_test.go
@@ -1,0 +1,125 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// seedClaudeSession writes ~/.claude/sessions/<pid>.json under home with the
+// given sessionId/name so ClaudeSessionName can resolve it.
+func seedClaudeSession(t *testing.T, home, sessionID, name string) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude", "sessions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	b, _ := json.Marshal(map[string]any{"sessionId": sessionID, "name": name})
+	if err := os.WriteFile(filepath.Join(dir, "1234.json"), b, 0o644); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+}
+
+// TestReconcileTitleFromClaude_UpdatesAndWritesBadge: when Claude's name differs
+// from the instance Title, reconcile updates Title, returns (name,true), and
+// drops the badge-update file the attach-side watcher reads (#1114 on-attach).
+func TestReconcileTitleFromClaude_UpdatesAndWritesBadge(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	badgeDir := t.TempDir()
+	t.Setenv("AGENTDECK_BADGE_UPDATES_DIR", badgeDir)
+
+	seedClaudeSession(t, home, "sid-1", "Conduit Federation 2SP")
+
+	inst := &Instance{ID: "i1", Title: "rustic-island", Tool: "claude"}
+	inst.tmuxSession = &tmux.Session{Name: "agentdeck_rustic_abcd1234"}
+
+	name, changed := inst.ReconcileTitleFromClaude("sid-1")
+	if !changed || name != "Conduit Federation 2SP" {
+		t.Fatalf("ReconcileTitleFromClaude = (%q,%v), want (%q,true)", name, changed, "Conduit Federation 2SP")
+	}
+	if inst.Title != "Conduit Federation 2SP" {
+		t.Errorf("Title = %q, want %q", inst.Title, "Conduit Federation 2SP")
+	}
+	got, err := os.ReadFile(filepath.Join(badgeDir, "agentdeck_rustic_abcd1234"))
+	if err != nil {
+		t.Fatalf("badge-update file missing: %v", err)
+	}
+	if string(got) != "Conduit Federation 2SP" {
+		t.Errorf("badge-update file = %q, want %q", got, "Conduit Federation 2SP")
+	}
+}
+
+// TestReconcileTitleFromClaude_NoopWhenEqual: a matching name is a no-op, with
+// no badge-update file written (avoids a redundant OSC on every attach).
+func TestReconcileTitleFromClaude_NoopWhenEqual(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	badgeDir := t.TempDir()
+	t.Setenv("AGENTDECK_BADGE_UPDATES_DIR", badgeDir)
+
+	seedClaudeSession(t, home, "sid-2", "already-set")
+	inst := &Instance{ID: "i2", Title: "already-set", Tool: "claude"}
+	inst.tmuxSession = &tmux.Session{Name: "agentdeck_x"}
+
+	if name, changed := inst.ReconcileTitleFromClaude("sid-2"); changed || name != "" {
+		t.Errorf("got (%q,%v), want no-op", name, changed)
+	}
+	if _, err := os.Stat(filepath.Join(badgeDir, "agentdeck_x")); !os.IsNotExist(err) {
+		t.Errorf("badge-update file written for unchanged title")
+	}
+}
+
+// TestReconcileTitleFromClaude_NoopWhenLocked: TitleLocked blocks the sync (#697).
+func TestReconcileTitleFromClaude_NoopWhenLocked(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	seedClaudeSession(t, home, "sid-3", "auto-name")
+
+	inst := &Instance{ID: "i3", Title: "SCRUM-351", TitleLocked: true, Tool: "claude"}
+	if _, changed := inst.ReconcileTitleFromClaude("sid-3"); changed {
+		t.Errorf("locked title changed")
+	}
+	if inst.Title != "SCRUM-351" {
+		t.Errorf("Title = %q, want unchanged SCRUM-351", inst.Title)
+	}
+}
+
+// TestReconcileTitleFromClaude_NoopWhenSyncDisabled: sync_title=false opts out.
+func TestReconcileTitleFromClaude_NoopWhenSyncDisabled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfgDir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte("sync_title = false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedClaudeSession(t, home, "sid-4", "should-not-apply")
+
+	inst := &Instance{ID: "i4", Title: "loupe", Tool: "claude"}
+	if _, changed := inst.ReconcileTitleFromClaude("sid-4"); changed {
+		t.Errorf("title changed despite sync_title=false")
+	}
+	if inst.Title != "loupe" {
+		t.Errorf("Title = %q, want unchanged loupe", inst.Title)
+	}
+}
+
+// TestReconcileTitleFromClaude_NoopWhenNoName: no Claude session file → no-op.
+func TestReconcileTitleFromClaude_NoopWhenNoName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	inst := &Instance{ID: "i5", Title: "keep-me", Tool: "claude"}
+	if _, changed := inst.ReconcileTitleFromClaude("no-such-sid"); changed {
+		t.Errorf("title changed with no Claude name available")
+	}
+	if inst.Title != "keep-me" {
+		t.Errorf("Title = %q, want unchanged keep-me", inst.Title)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9833,6 +9833,27 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 	// visible blank-screen delay before tmux attach starts.
 	inst.MarkAccessed()
 
+	// #1114 follow-up: Claude's /rename fires no agent-deck hook, so an idle
+	// session's title and iTerm2 badge can be stale at attach time (the
+	// hook-driven sync only runs on the next turn boundary). Reconcile from the
+	// agent's current Claude session name here — before tmuxSess.Attach() emits
+	// the badge from DisplayName — so detach/reattach reliably refreshes it.
+	if session.IsClaudeCompatible(inst.Tool) {
+		sessionID := session.ReadHookSessionAnchor(inst.ID)
+		if sessionID == "" {
+			sessionID = inst.ClaudeSessionID
+		}
+		if newName, changed := inst.ReconcileTitleFromClaude(sessionID); changed {
+			h.pendingTitleChanges[inst.ID] = newName
+			h.invalidatePreviewCache(inst.ID)
+			h.rebuildFlatItems()
+			h.saveInstances()
+			uiLog.Info("title_reconciled_on_attach",
+				slog.String("session_id", inst.ID),
+				slog.String("title", newName))
+		}
+	}
+
 	// Acknowledge on ATTACH (not detach) - but ONLY if session is waiting (yellow)
 	// This ensures:
 	// - GREEN (running) sessions stay green when attached/detached


### PR DESCRIPTION
## Problem

Renaming a Claude session (`/rename` or `claude --name`) doesn't reach the iTerm2 badge until the *next agent turn* — and detach/reattach doesn't fix it either. Root cause: the only code that copies a name from Claude into agent-deck (`applyClaudeTitleSync`) runs solely from the Claude hook handler, but `/rename` is a local slash command that fires no hook — it just writes `~/.claude/sessions/<pid>.json`. So the DB title, the tmux display-name option, and the badge all stay stale until the next `UserPromptSubmit`/`Stop`. Reattach doesn't help because the on-attach badge is emitted from `Instance.Title` → `DisplayName`, downstream of that same hook-gated sync.

## Fix

Reconcile the title from Claude's current session name **on attach**, making detach/reattach a reliable refresh. The reconcile runs in `attachSession` just before `Attach()`, mutating the same `tmux.Session` the badge emit reads, and also writes the badge-update file as a backstop for the watcher catch-up.

Shared logic is factored into `internal/session` so the hook and attach paths use one implementation:

- **`claude_title_reconcile.go`** (new) — the `~/.claude/sessions` scanner plus `(*Instance).ReconcileTitleFromClaude`, which honors `sync_title` and `TitleLocked` and, on a real change, updates `Title`, calls `SyncTmuxDisplayName()`, and writes the badge-update file.
- **`hook_name_sync.go`** — `applyClaudeTitleSync` now delegates to the shared method (behavior-preserving across all branches).
- **`home.go`** — `attachSession` reconciles for Claude-compatible tools, then persists + rebuilds on a change.

## Testing

5 new reconcile tests (change/no-op/`TitleLocked`/`sync_title=false`/no-name); all existing hook-sync tests pass; `go build`, `go vet`, `gofmt` clean.

## Limitations

A session left **attached and idle** after `/rename` still won't refresh until the next turn or re-attach — no hook, no attach event to trigger it. Zero-lag-while-attached would need a periodic reconciler (possible follow-up).

The hook path scans `~/.claude/sessions` twice (a cheap pre-check to skip the SQLite load for unnamed sessions, plus the shared method's internal rescan). Each scan is sub-millisecond and dwarfed by agent-deck's own `state.db` load between them; it can be collapsed later with an apply-with-name variant if it ever matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Claude session title synchronization with added safety guards for locked titles and configurable sync settings.

* **Tests**
  * Added comprehensive test coverage for title reconciliation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->