### PR TITLE
fix(statedb): refuse empty-payload SaveInstances sweep on populated table (S1)

### DIFF
--- a/internal/statedb/save_instances_empty_guard_test.go
+++ b/internal/statedb/save_instances_empty_guard_test.go
@@ -1,0 +1,132 @@
+package statedb
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// S1 data-loss safeguard (2026-06-04 incident, third of its class).
+//
+// Root cause: SaveInstances([]) ran an unconditional `DELETE FROM instances`
+// inside its DELETE+re-insert sweep. A stray empty-payload save therefore wiped
+// the live personal-profile index. These tests pin the guarded behavior:
+//
+//	(a) SaveInstances([]) on a POPULATED table refuses (returns
+//	    ErrRefusingEmptySweep) and leaves every row intact.
+//	(b) SaveInstances([]) on an ALREADY-EMPTY table is a no-op (no error).
+//	(c) ClearAllInstances() is the explicit escape hatch and DOES empty a
+//	    populated table.
+//	(d) A normal non-empty SaveInstances still replaces the set correctly.
+
+func seedInstances(t *testing.T, db *StateDB, ids ...string) {
+	t.Helper()
+	now := time.Now()
+	rows := make([]*InstanceRow, 0, len(ids))
+	for i, id := range ids {
+		rows = append(rows, &InstanceRow{
+			ID:          id,
+			Title:       id,
+			ProjectPath: "/" + id,
+			GroupPath:   "grp",
+			Order:       i,
+			Tool:        "claude",
+			Status:      "idle",
+			CreatedAt:   now,
+			ToolData:    json.RawMessage("{}"),
+		})
+	}
+	if err := db.SaveInstances(rows); err != nil {
+		t.Fatalf("seed SaveInstances: %v", err)
+	}
+}
+
+func countInstances(t *testing.T, db *StateDB) int {
+	t.Helper()
+	loaded, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	return len(loaded)
+}
+
+// (a) Empty payload on a populated table must be refused, rows preserved.
+func TestSaveInstances_EmptyPayloadOnPopulatedTable_Refused(t *testing.T) {
+	db := newTestDB(t)
+	seedInstances(t, db, "a", "b", "c")
+
+	err := db.SaveInstances(nil)
+	if err == nil {
+		t.Fatalf("expected SaveInstances([]) on populated table to return an error, got nil (rows would be wiped)")
+	}
+	if !errors.Is(err, ErrRefusingEmptySweep) {
+		t.Fatalf("expected ErrRefusingEmptySweep, got %v", err)
+	}
+
+	if n := countInstances(t, db); n != 3 {
+		t.Fatalf("expected 3 rows preserved after refused sweep, got %d", n)
+	}
+}
+
+// (b) Empty payload on an already-empty table is a benign no-op.
+func TestSaveInstances_EmptyPayloadOnEmptyTable_NoOp(t *testing.T) {
+	db := newTestDB(t)
+
+	if n := countInstances(t, db); n != 0 {
+		t.Fatalf("expected empty table to start, got %d rows", n)
+	}
+	if err := db.SaveInstances(nil); err != nil {
+		t.Fatalf("expected no-op (nil error) on empty table, got %v", err)
+	}
+	if n := countInstances(t, db); n != 0 {
+		t.Fatalf("expected table to remain empty, got %d rows", n)
+	}
+}
+
+// (c) The explicit escape hatch DOES empty a populated table.
+func TestClearAllInstances_EmptiesPopulatedTable(t *testing.T) {
+	db := newTestDB(t)
+	seedInstances(t, db, "a", "b")
+
+	if err := db.ClearAllInstances(); err != nil {
+		t.Fatalf("ClearAllInstances: %v", err)
+	}
+	if n := countInstances(t, db); n != 0 {
+		t.Fatalf("expected table emptied by ClearAllInstances, got %d rows", n)
+	}
+
+	// And on an already-empty table it's a clean no-op.
+	if err := db.ClearAllInstances(); err != nil {
+		t.Fatalf("ClearAllInstances on empty table: %v", err)
+	}
+}
+
+// (d) Normal non-empty saves still replace the set (delete-not-in semantics).
+func TestSaveInstances_NonEmpty_StillReplaces(t *testing.T) {
+	db := newTestDB(t)
+	seedInstances(t, db, "a", "b", "c")
+
+	// Save a set that drops "c" and keeps a, b — c should be swept.
+	now := time.Now()
+	rows := []*InstanceRow{
+		{ID: "a", Title: "a", ProjectPath: "/a", GroupPath: "grp", Order: 0, Tool: "claude", Status: "idle", CreatedAt: now, ToolData: json.RawMessage("{}")},
+		{ID: "b", Title: "b", ProjectPath: "/b", GroupPath: "grp", Order: 1, Tool: "claude", Status: "idle", CreatedAt: now, ToolData: json.RawMessage("{}")},
+	}
+	if err := db.SaveInstances(rows); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+
+	loaded, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Fatalf("expected 2 rows after replace, got %d", len(loaded))
+	}
+	for _, r := range loaded {
+		if r.ID == "c" {
+			t.Fatalf("expected row c to be swept, but it survived")
+		}
+	}
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,6 +17,17 @@ import (
 
 	_ "modernc.org/sqlite"
 )
+
+// ErrRefusingEmptySweep is returned by SaveInstances when it is asked to
+// persist an EMPTY instance set while the instances table still holds rows.
+//
+// S1 data-loss safeguard (added after the 2026-06-04 incident, the third of
+// its class): SaveInstances' DELETE+re-insert sweep used to run an
+// unconditional `DELETE FROM instances` for an empty payload, so a stray
+// SaveInstances([]) wiped the live profile index. Refusing the destructive
+// empty sweep turns silent data loss into a loud, recoverable error. Callers
+// that genuinely intend to empty the table must use ClearAllInstances.
+var ErrRefusingEmptySweep = errors.New("statedb: refusing to wipe populated instances table with an empty SaveInstances payload (use ClearAllInstances to intentionally clear)")
 
 // withBusyRetry runs op with linear backoff (10ms, 20ms, 30ms, 40ms, 50ms;
 // ~150ms total) when op fails with SQLITE_BUSY. Non-BUSY errors are returned
@@ -623,9 +635,21 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 
 	// Delete rows not in the new list to prevent deleted sessions from reappearing.
 	if len(insts) == 0 {
-		if _, err := tx.Exec("DELETE FROM instances"); err != nil {
+		// S1 guard: an empty payload would `DELETE FROM instances`, wiping the
+		// whole table. If rows already exist this is almost certainly a bug in
+		// the caller (a stray empty save), not an intentional clear — refuse it
+		// rather than silently destroying the index. Intentional clears go
+		// through ClearAllInstances. An empty payload on an already-empty table
+		// is a benign no-op.
+		var existing int
+		if err := tx.QueryRow("SELECT COUNT(*) FROM instances").Scan(&existing); err != nil {
 			return err
 		}
+		if existing > 0 {
+			return ErrRefusingEmptySweep
+		}
+		// Already empty: nothing to delete, nothing to insert.
+		return tx.Commit()
 	} else {
 		placeholders := make([]string, len(insts))
 		args := make([]any, len(insts))
@@ -689,6 +713,18 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 	}
 
 	return tx.Commit()
+}
+
+// ClearAllInstances is the explicit escape hatch for intentionally emptying the
+// instances table. SaveInstances([]) refuses to wipe a populated table (S1
+// data-loss safeguard, ErrRefusingEmptySweep); callers that truly mean to clear
+// every row must call this method so the destructive intent is unambiguous and
+// greppable. It is a no-op on an already-empty table.
+func (s *StateDB) ClearAllInstances() error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec("DELETE FROM instances")
+		return err
+	})
 }
 
 // LoadInstances returns all instances ordered by sort_order.


### PR DESCRIPTION
## What

Safeguard **S1**: make \`SaveInstances\` refuse a destructive empty-payload sweep on a populated instances table.

## Why — 2026-06-04 data-loss incident (third of its class)

\`internal/statedb/statedb.go\` ran an **unconditional** \`DELETE FROM instances\` whenever the payload was empty:

\`\`\`go
if len(insts) == 0 {
    tx.Exec("DELETE FROM instances")   // wipes the whole table
}
\`\`\`

A stray \`SaveInstances([])\` therefore wiped the live personal-profile session index. This is the #1 fix for that incident.

## The guard

When the payload is **empty** but the table still holds rows, \`SaveInstances\` now returns a clear sentinel error (\`ErrRefusingEmptySweep\`) **without deleting** — turning silent data loss into a loud, recoverable error.

- Empty payload on an **already-empty** table stays a benign no-op (no error).
- Intentional "clear everything" goes through a new explicit escape hatch, \`StateDB.ClearAllInstances()\`, so the destructive intent is unambiguous and greppable.

## Callers

No legitimate caller passes an empty set against a populated table:
- Removals use targeted \`DeleteInstance(id)\`, not \`SaveInstances\`.
- Bulk saves (TUI/CLI/web mutator) always pass the full current instance list.
- The JSON→SQLite \`migrate\` path runs against a fresh/empty DB.

So the guard is **pure protection** with no behavior change for real callers — no caller edits were needed.

## Tests (TDD — written first, proven fail→pass)

\`internal/statedb/save_instances_empty_guard_test.go\`:
- (a) \`SaveInstances([])\` on a populated table returns \`ErrRefusingEmptySweep\` and leaves all rows intact.
- (b) \`SaveInstances([])\` on an already-empty table is a no-op (no error).
- (c) \`ClearAllInstances()\` does empty a populated table (and is a no-op when already empty).
- (d) Normal non-empty \`SaveInstances\` still replaces the set correctly (delete-not-in semantics).

Pre-fix these failed to compile (undefined \`ErrRefusingEmptySweep\` / \`ClearAllInstances\`); post-fix all four pass under \`-race\`.

## Verification (sandboxed HOME/XDG — this repo doubles as the live data dir)

\`\`\`
HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go build ./...                    # green
HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test -race ./internal/statedb/...  # ok
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Introduced safeguard to prevent accidental data loss when clearing stored instances—operations are now blocked unless using the explicit method

* **New Features**
  * Added dedicated method to intentionally clear all stored instances from the database

* **Tests**
  * Added comprehensive tests for instance persistence behavior and safeguards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->