### PR TITLE
fix(agentpaths): warn/refuse on silent legacy ~/.agent-deck fallback (S4, data-loss safeguard)

### DIFF
--- a/internal/session/config.go
+++ b/internal/session/config.go
@@ -3,10 +3,14 @@ package session
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"os/user"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
+	"testing"
 )
 
 const (
@@ -32,13 +36,121 @@ type Config struct {
 	Version int `json:"version"`
 }
 
-// GetAgentDeckDir returns the base agent-deck directory (~/.agent-deck)
+// --- S4 data-loss safeguard (2026-06-04 incident, chain-link #2) -------------
+//
+// GetAgentDeckDir() is the single chokepoint every other agent-deck path
+// function (config.json, profiles/<p>/state.db, worker-scratch, logs) builds
+// on. It resolves via os.UserHomeDir(), which reads $HOME. When $HOME points at
+// the developer's real home (e.g. a test that forgot testutil.IsolateHome(), or
+// any caller running without an XDG/sandbox dir present) the resolver used to
+// hand back the live ~/.agent-deck with no signal at all — so an un-isolated
+// test silently touched real user data.
+//
+// S4 makes that chain-link fail closed *in the production resolver itself*,
+// complementing S5's opt-in IsolateHome() + pathsafety guard test:
+//
+//   - When running under test (testing.Testing()==true) AND resolution lands
+//     under the real OS-user home, GetAgentDeckDir() REFUSES (returns an error)
+//     instead of returning the live path, and emits a loud one-time warning.
+//   - The real binary (testing.Testing()==false) is UNCHANGED: it still
+//     resolves ~/.agent-deck normally and silently.
+//
+// The real home is read from the OS user database (os/user), NOT $HOME, so the
+// guard can tell a sandboxed HOME from the real home even after $HOME is
+// overridden — mirroring internal/pathsafety's realHome().
+
+var (
+	legacyFallbackWarnOnce sync.Once
+	legacyFallbackWarnMu   sync.Mutex
+	legacyFallbackWarnSink io.Writer = os.Stderr
+)
+
+// setLegacyFallbackWarnSink redirects the S4 warning (test hook). Returns a
+// restore func.
+func setLegacyFallbackWarnSink(w io.Writer) func() {
+	legacyFallbackWarnMu.Lock()
+	prev := legacyFallbackWarnSink
+	legacyFallbackWarnSink = w
+	legacyFallbackWarnMu.Unlock()
+	return func() {
+		legacyFallbackWarnMu.Lock()
+		legacyFallbackWarnSink = prev
+		legacyFallbackWarnMu.Unlock()
+	}
+}
+
+// resetLegacyFallbackWarnOnce re-arms the debounce (test hook).
+func resetLegacyFallbackWarnOnce() {
+	legacyFallbackWarnMu.Lock()
+	legacyFallbackWarnOnce = sync.Once{}
+	legacyFallbackWarnMu.Unlock()
+}
+
+// osUserRealHome returns the developer's actual home from the OS user database,
+// independent of $HOME. Empty string if it cannot be determined (in which case
+// the guard cannot prove a real-home hit and stays out of the way).
+func osUserRealHome() string {
+	if u, err := user.Current(); err == nil && u.HomeDir != "" {
+		return filepath.Clean(u.HomeDir)
+	}
+	return ""
+}
+
+// pathUnderReal reports whether p is the real home (or its ~/.agent-deck) or
+// lives beneath it.
+func pathUnderReal(p, realHome string) bool {
+	if realHome == "" {
+		return false
+	}
+	clean := filepath.Clean(p)
+	if clean == realHome || strings.HasPrefix(clean, realHome+string(os.PathSeparator)) {
+		return true
+	}
+	realAgentDeck := filepath.Join(realHome, ".agent-deck")
+	return clean == realAgentDeck || strings.HasPrefix(clean, realAgentDeck+string(os.PathSeparator))
+}
+
+// warnLegacyFallbackOnce emits the S4 legacy-fallback warning exactly once.
+func warnLegacyFallbackOnce(resolved string) {
+	legacyFallbackWarnMu.Lock()
+	once := &legacyFallbackWarnOnce
+	sink := legacyFallbackWarnSink
+	legacyFallbackWarnMu.Unlock()
+	once.Do(func() {
+		fmt.Fprintf(sink,
+			"agentpaths: resolved to legacy ~/.agent-deck (%s) (no XDG dir present); "+
+				"this touches REAL user data. If this is a test, it is NOT sandboxed — "+
+				"call testutil.IsolateHome() in TestMain and run with a temp HOME+XDG "+
+				"(2026-06-04 data-loss incident, S4).\n",
+			resolved)
+	})
+}
+
+// GetAgentDeckDir returns the base agent-deck directory (~/.agent-deck).
+//
+// See the S4 block above: under test it refuses (and warns) when resolution
+// lands under the real OS-user home; the real binary is unchanged.
 func GetAgentDeckDir() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
-	return filepath.Join(homeDir, ".agent-deck"), nil
+	resolved := filepath.Join(homeDir, ".agent-deck")
+
+	// S4 fail-closed guard: only active under `go test`. The real binary keeps
+	// the original behavior exactly.
+	if testing.Testing() {
+		if realHome := osUserRealHome(); pathUnderReal(resolved, realHome) {
+			warnLegacyFallbackOnce(resolved)
+			return "", fmt.Errorf(
+				"agentpaths: refusing to resolve agent-deck dir under the real home %q "+
+					"(resolved %q) while running under test — the suite is NOT sandboxed; "+
+					"call testutil.IsolateHome() in TestMain (2026-06-04 data-loss incident, S4)",
+				realHome, resolved)
+		}
+	}
+
+	return resolved, nil
 }
 
 // GetConfigPath returns the path to the global config file

--- a/internal/session/config_pathguard_test.go
+++ b/internal/session/config_pathguard_test.go
@@ -1,0 +1,130 @@
+package session
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// S4 data-loss safeguard tests.
+//
+// Chain-link #2 of the 2026-06-04 incident: GetAgentDeckDir() silently resolved
+// to the real legacy ~/.agent-deck whenever HOME pointed at the real OS-user
+// home (e.g. a test that forgot testutil.IsolateHome()). No signal was emitted,
+// so an un-isolated test silently touched live user data.
+//
+// S4 closes the gap inside the production resolver itself:
+//   - under test (testing.Testing()==true) it REFUSES (returns an error) when
+//     resolution lands under the real OS-user home, and emits a loud one-time
+//     warning to stderr;
+//   - the real binary's behavior is unchanged.
+//
+// These tests build on S1 (statedb) and S5 (testutil.IsolateHome + pathsafety
+// guard). The package TestMain already calls IsolateHome(), so the sandboxed
+// happy-path is the default; the real-home cases simulate the un-isolated
+// failure by pointing HOME back at the real home.
+
+// osRealHome returns the developer's actual home directory from the OS user
+// database, independent of $HOME. Mirrors internal/pathsafety's realHome().
+func osRealHome(t *testing.T) string {
+	t.Helper()
+	u, err := user.Current()
+	if err != nil || u.HomeDir == "" {
+		t.Skip("cannot determine real home directory from OS user database")
+	}
+	return filepath.Clean(u.HomeDir)
+}
+
+// TestGetAgentDeckDir_SandboxedResolvesSilently confirms the normal, sandboxed
+// path is unchanged and silent: it returns a dir under the (isolated) HOME and
+// no error. This is the behavior every correctly-isolated test relies on.
+func TestGetAgentDeckDir_SandboxedResolvesSilently(t *testing.T) {
+	// TestMain already isolated HOME. Sanity-check we are not on the real home.
+	home, _ := os.UserHomeDir()
+	if home == osRealHome(t) {
+		t.Fatalf("precondition: HOME (%s) must be sandboxed, not the real home", home)
+	}
+
+	dir, err := GetAgentDeckDir()
+	if err != nil {
+		t.Fatalf("GetAgentDeckDir under sandbox returned error: %v", err)
+	}
+	want := filepath.Join(home, ".agent-deck")
+	if filepath.Clean(dir) != filepath.Clean(want) {
+		t.Fatalf("GetAgentDeckDir = %s, want %s", dir, want)
+	}
+}
+
+// TestGetAgentDeckDir_RefusesUnderTestOnRealHome is the core S4 guard. When the
+// resolver would land under the real OS-user home WHILE running under test, it
+// must return an error rather than silently handing back the live path.
+func TestGetAgentDeckDir_RefusesUnderTestOnRealHome(t *testing.T) {
+	real := osRealHome(t)
+
+	// Simulate an un-isolated test: point HOME back at the real home.
+	t.Setenv("HOME", real)
+
+	dir, err := GetAgentDeckDir()
+	if err == nil {
+		t.Fatalf("expected refusal error when resolving under real home, got dir=%s nil error", dir)
+	}
+	if !strings.Contains(err.Error(), ".agent-deck") {
+		t.Fatalf("error should mention the legacy path; got: %v", err)
+	}
+}
+
+// TestGetConfigPath_RefusesUnderTestOnRealHome proves the refusal propagates
+// through the dependent resolvers (GetConfigPath builds on GetAgentDeckDir).
+func TestGetConfigPath_RefusesUnderTestOnRealHome(t *testing.T) {
+	real := osRealHome(t)
+	t.Setenv("HOME", real)
+
+	if p, err := GetConfigPath(); err == nil {
+		t.Fatalf("GetConfigPath should refuse under real home; got %s nil error", p)
+	}
+}
+
+// TestGetAgentDeckDir_WarnsOnRealHomeFallback verifies the one-time stderr
+// warning fires when resolution lands on the real legacy path under test.
+func TestGetAgentDeckDir_WarnsOnRealHomeFallback(t *testing.T) {
+	real := osRealHome(t)
+	t.Setenv("HOME", real)
+
+	var buf strings.Builder
+	restore := setLegacyFallbackWarnSink(&buf)
+	defer restore()
+	resetLegacyFallbackWarnOnce()
+
+	_, _ = GetAgentDeckDir() // refuses, but must also warn
+
+	got := buf.String()
+	if !strings.Contains(got, "legacy ~/.agent-deck") {
+		t.Fatalf("expected legacy-fallback warning, got: %q", got)
+	}
+	if !strings.Contains(got, "no XDG dir present") {
+		t.Fatalf("warning should explain the no-XDG-dir fallback condition, got: %q", got)
+	}
+}
+
+// TestGetAgentDeckDir_WarnDebounced verifies the warning is emitted once, not
+// per call, even across many resolutions.
+func TestGetAgentDeckDir_WarnDebounced(t *testing.T) {
+	real := osRealHome(t)
+	t.Setenv("HOME", real)
+
+	var buf strings.Builder
+	restore := setLegacyFallbackWarnSink(&buf)
+	defer restore()
+	resetLegacyFallbackWarnOnce()
+
+	for i := 0; i < 5; i++ {
+		_, _ = GetAgentDeckDir()
+	}
+
+	got := buf.String()
+	if n := strings.Count(got, "legacy ~/.agent-deck"); n != 1 {
+		t.Fatalf("warning should be debounced to exactly 1 emission, got %d:\n%s", n, got)
+	}
+}


### PR DESCRIPTION
## S4 — fail-closed on silent legacy `~/.agent-deck` fallback

Chain-link #2 of the **2026-06-04 data-loss incident** (third of its class).

### The gap
`session.GetAgentDeckDir()` is the single chokepoint every agent-deck path resolver builds on (`config.json`, `profiles/<p>/state.db`, worker-scratch, logs). It resolves via `os.UserHomeDir()` (reads `$HOME`). When `$HOME` points at the developer's **real** home — e.g. a test that forgot `testutil.IsolateHome()`, or any caller running without a sandbox — it silently handed back the live `~/.agent-deck` with **no signal**. That's how an un-isolated `go test` silently touched (and could wipe) real user data.

> Note: the incident write-up referenced an `internal/agentpaths` package, but no such package exists in the tree. The actual resolver chokepoint is `internal/session/config.go:GetAgentDeckDir()`, so the guard lives there.

### The fix
Make the chain-link fail closed **in the production resolver itself**:

- **Refuse under test:** when `testing.Testing()==true` AND resolution lands under the real OS-user home (read from `os/user`, **not** `$HOME` — mirroring `internal/pathsafety`'s `realHome()`), `GetAgentDeckDir()` returns an error instead of the live path. The error propagates through all dependent resolvers (`GetConfigPath`, `GetProfilesDir`, …).
- **Loud one-time warning:** a debounced stderr warning (`agentpaths: resolved to legacy ~/.agent-deck … (no XDG dir present)`) so CI surfaces the touch even if the refuse path is ever relaxed.
- **Real binary unchanged:** `testing.Testing()==false` keeps the exact original behavior — resolves `~/.agent-deck` normally and silently.

### Builds on S1 + S5
- **S1** (#1283): statedb empty-sweep guard.
- **S5** (#1284): `testutil.IsolateHome()` + `internal/pathsafety` guard **test**. That guard is **opt-in** per package `TestMain`. S4 makes the **resolver** fail closed even when a package forgets to isolate — defense in depth, not a duplicate.

### TDD
`internal/session/config_pathguard_test.go`:
- sandboxed resolution is unchanged + silent;
- refuses under simulated real-home + test;
- refusal propagates through `GetConfigPath`;
- the legacy-fallback warning fires and is debounced to exactly one emission.

Proven red (undefined helpers) → green.

### Verification (all sandboxed, per-package)
```
HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= go test -race ./internal/session/...   # green (only known host-flaky TestPerf_OutboxDrain_Drain25)
HOME=$(mktemp -d) … go test -race ./internal/pathsafety/...   # ok
HOME=$(mktemp -d) … go test -race ./internal/statedb/... -skip TestPerf   # ok
go build ./...   # ok
```
The only failures observed were known host-flaky perf-budget tests (`TestPerf_StateDB_*`, `TestPerf_OutboxDrain_Drain25`) documented in repo guidance as rerun-don't-fix; they're unrelated to path resolution.

Does not change real-binary path behavior — only adds warn + test-refuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration path resolution to detect and safely handle edge cases where system directories might be accessed incorrectly, with warnings for fallback scenarios.

* **Tests**
  * Added comprehensive regression test coverage for configuration path handling, including sandboxed and edge-case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->