### PR TITLE
fix(statedb,userconfig): backup-before-destructive-write + refuse config section-drop (S2+S3)

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -26,6 +26,19 @@ import (
 // UserConfigFileName is the TOML config file for user preferences
 const UserConfigFileName = "config.toml"
 
+// ErrRefusingConfigSectionDrop is returned by SaveUserConfig when the config it
+// is asked to write would empty an entire top-level section ([mcps] or [groups])
+// that currently has entries on disk. These are the exact sections lost in the
+// 2026-06-04 data-loss incident: a partially-constructed config saved over the
+// live file silently dropped the whole MCP catalog and group overrides.
+//
+// S3 data-loss safeguard: a save that zeroes a populated section is almost
+// always a bug in the caller (it built a config without loading the existing
+// one), not a deliberate "clear everything". Refuse it. A caller that genuinely
+// means to clear all MCPs/groups must go through SaveUserConfigWithIntent with
+// allowSectionDrop=true so the destructive intent is explicit and greppable.
+var ErrRefusingConfigSectionDrop = fmt.Errorf("session: refusing to save config.toml that would drop a populated [mcps] or [groups] section to empty (use SaveUserConfigWithIntent to intentionally clear)")
+
 // UserConfig represents user-facing configuration in TOML format
 type UserConfig struct {
 	// DefaultTool is the pre-selected AI tool when creating new sessions
@@ -2131,9 +2144,28 @@ func ReloadUserConfig() (*UserConfig, error) {
 	return LoadUserConfig()
 }
 
-// SaveUserConfig writes the config to config.toml using atomic write pattern
-// This clears the cache so next LoadUserConfig() reads fresh values
+// SaveUserConfig writes the config to config.toml using atomic write pattern.
+// This clears the cache so next LoadUserConfig() reads fresh values.
+//
+// Guarded path: it backs up the existing config.toml to config.toml.bak before
+// overwriting (S2) and REFUSES a save that would drop a populated [mcps] or
+// [groups] section to empty (S3, ErrRefusingConfigSectionDrop). Both are
+// data-loss safeguards from the 2026-06-04 incident. Callers that genuinely
+// intend to clear all MCPs/groups must use SaveUserConfigWithIntent.
 func SaveUserConfig(config *UserConfig) error {
+	return SaveUserConfigWithIntent(config, false)
+}
+
+// SaveUserConfigWithIntent is SaveUserConfig with an explicit opt-out of the S3
+// section-drop guard. Pass allowSectionDrop=true only when the user genuinely
+// wants to clear all [mcps] or [groups] entries; the default false path refuses
+// such a save (ErrRefusingConfigSectionDrop) because zeroing a populated section
+// is almost always a partially-built-config bug, not deliberate intent.
+//
+// The S2 config.toml.bak backup is taken on BOTH paths: the atomic rename
+// prevents torn writes but not semantic clobbering, so the .bak is the recovery
+// net regardless of intent.
+func SaveUserConfigWithIntent(config *UserConfig, allowSectionDrop bool) error {
 	configPath, err := GetUserConfigPath()
 	if err != nil {
 		return fmt.Errorf("failed to get config path: %w", err)
@@ -2160,6 +2192,33 @@ func SaveUserConfig(config *UserConfig) error {
 	encoder := toml.NewEncoder(&buf)
 	if err := encoder.Encode(config); err != nil {
 		return fmt.Errorf("failed to encode config: %w", err)
+	}
+
+	// ═══════════════════════════════════════════════════════════════════
+	// S3 data-loss safeguard (2026-06-04 incident): refuse a save that would
+	// drop a populated [mcps] or [groups] section to empty. We round-trip the
+	// content we are ABOUT to write (decode buf) and compare its section counts
+	// against what is currently on disk. The guard fires ONLY when disk had
+	// entries and the new content has zero — a normal edit that loads the
+	// config, removes ONE group, and saves still carries the rest of the map,
+	// so its count stays > 0 and is unaffected. allowSectionDrop=true (the
+	// explicit-intent path) skips the refusal but still backs up.
+	// ═══════════════════════════════════════════════════════════════════
+	if !allowSectionDrop {
+		if err := guardConfigSectionDrop(configPath, buf.Bytes()); err != nil {
+			return err
+		}
+	}
+
+	// S2 data-loss safeguard: copy the existing config.toml to config.toml.bak
+	// BEFORE the atomic rename. Atomic rename prevents torn writes but NOT
+	// semantic clobbering (e.g. saving a config missing whole sections); the
+	// .bak is the recovery net. Best-effort: a failed backup is logged, never
+	// fatal — the caller asked to save, and the insurance copy must not become
+	// a new failure mode. No-op when config.toml does not exist yet.
+	if err := backupConfigFile(configPath); err != nil {
+		slog.Warn("session: pre-save config backup failed (continuing with save)",
+			"path", configPath, "err", err)
 	}
 
 	// ═══════════════════════════════════════════════════════════════════
@@ -2193,6 +2252,64 @@ func SaveUserConfig(config *UserConfig) error {
 	// Clear cache so next load picks up changes
 	ClearUserConfigCache()
 
+	return nil
+}
+
+// guardConfigSectionDrop implements the S3 refusal: it decodes the on-disk
+// config and the about-to-be-written content, and returns
+// ErrRefusingConfigSectionDrop if either [mcps] or [groups] had entries on disk
+// but would become empty. A missing/unparseable on-disk file means there is
+// nothing populated to protect, so the guard passes (first write, or a file the
+// loader would have replaced with defaults anyway).
+func guardConfigSectionDrop(configPath string, newContent []byte) error {
+	// Nothing on disk yet → nothing to lose.
+	if _, statErr := os.Stat(configPath); os.IsNotExist(statErr) {
+		return nil
+	}
+
+	var onDisk UserConfig
+	if _, err := toml.DecodeFile(configPath, &onDisk); err != nil {
+		// Can't read the old file to know what's populated; don't block the
+		// save (the loader treats an unparseable file as defaults anyway).
+		return nil
+	}
+
+	var next UserConfig
+	if _, err := toml.Decode(string(newContent), &next); err != nil {
+		// We just encoded this from a *UserConfig, so a decode failure is
+		// unexpected — surface it rather than silently writing.
+		return fmt.Errorf("session: failed to round-trip new config for section-drop guard: %w", err)
+	}
+
+	if len(onDisk.MCPs) > 0 && len(next.MCPs) == 0 {
+		return fmt.Errorf("%w: [mcps] had %d entries on disk, new config has none", ErrRefusingConfigSectionDrop, len(onDisk.MCPs))
+	}
+	if len(onDisk.Groups) > 0 && len(next.Groups) == 0 {
+		return fmt.Errorf("%w: [groups] had %d entries on disk, new config has none", ErrRefusingConfigSectionDrop, len(onDisk.Groups))
+	}
+	return nil
+}
+
+// backupConfigFile copies config.toml to config.toml.bak (write-temp + rename
+// so the .bak is never torn). No-op when the source does not exist yet (first
+// save). Part of the S2 data-loss safeguard.
+func backupConfigFile(configPath string) error {
+	src, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // nothing to back up yet
+		}
+		return err
+	}
+	bak := configPath + ".bak"
+	tmp := bak + ".tmp"
+	if err := os.WriteFile(tmp, src, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, bak); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
 	return nil
 }
 

--- a/internal/session/userconfig_section_guard_test.go
+++ b/internal/session/userconfig_section_guard_test.go
@@ -1,0 +1,233 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// S2 + S3 data-loss safeguards for config.toml (2026-06-04 incident).
+//
+// Incident: a partially-constructed UserConfig saved over the live config.toml
+// silently dropped the whole [mcps] catalog and [groups] overrides. The atomic
+// rename prevented torn writes but not this SEMANTIC clobber.
+//
+// S2: SaveUserConfig copies config.toml -> config.toml.bak before overwriting.
+// S3: SaveUserConfig REFUSES (ErrRefusingConfigSectionDrop) a save that would
+//     drop a populated [mcps] or [groups] section to empty, unless the explicit
+//     SaveUserConfigWithIntent(cfg, true) path is used.
+//
+// CRITICAL: a NORMAL edit that legitimately removes ONE group (or one MCP) must
+// still succeed — the guard fires only when a populated section goes to ZERO.
+
+// seedConfigWithSections writes an initial config.toml (via the intent path so
+// no guard interferes) carrying populated [mcps] and [groups] sections.
+func seedConfigWithSections(t *testing.T) *UserConfig {
+	t.Helper()
+	cfg := cloneDefaultUserConfig()
+	cfg.MCPs = map[string]MCPDef{
+		"context7": {Command: "npx", Args: []string{"-y", "context7"}},
+		"github":   {Command: "npx", Args: []string{"-y", "gh-mcp"}},
+	}
+	cfg.Groups = map[string]GroupSettings{
+		"work":     {Claude: GroupClaudeSettings{ConfigDir: "~/.claude-work"}},
+		"personal": {Claude: GroupClaudeSettings{ConfigDir: "~/.claude"}},
+	}
+	// Use the intent path to lay down the baseline without tripping the guard.
+	if err := SaveUserConfigWithIntent(&cfg, true); err != nil {
+		t.Fatalf("seed SaveUserConfigWithIntent: %v", err)
+	}
+	ReloadUserConfig()
+	return &cfg
+}
+
+// (a) S2: config.toml.bak is created before an overwrite.
+func TestSaveUserConfig_CreatesBackupBeforeOverwrite(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedConfigWithSections(t)
+
+	configPath, err := GetUserConfigPath()
+	if err != nil {
+		t.Fatalf("GetUserConfigPath: %v", err)
+	}
+	bakPath := configPath + ".bak"
+	if _, err := os.Stat(bakPath); err == nil {
+		t.Fatalf("precondition: %s should not exist after first (intent) seed if no prior file", bakPath)
+	}
+
+	// A normal, non-shrinking edit: change theme, keep both sections.
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	cfg.Theme = "light"
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig (normal edit): %v", err)
+	}
+
+	if _, err := os.Stat(bakPath); err != nil {
+		t.Fatalf("expected %s to be created before overwrite, stat err: %v", bakPath, err)
+	}
+}
+
+// (c) S3: refuses to drop a populated [mcps] to empty without intent.
+func TestSaveUserConfig_RefusesDroppingMCPsToEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedConfigWithSections(t)
+
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	// Simulate the incident: a config that zeroes the MCP catalog.
+	cfg.MCPs = map[string]MCPDef{}
+
+	err = SaveUserConfig(cfg)
+	if err == nil {
+		t.Fatalf("expected SaveUserConfig to refuse dropping populated [mcps] to empty, got nil")
+	}
+	if !errors.Is(err, ErrRefusingConfigSectionDrop) {
+		t.Fatalf("expected ErrRefusingConfigSectionDrop, got %v", err)
+	}
+
+	// And the on-disk MCPs must be intact (refusal happened before any write).
+	reloaded, err := ReloadUserConfig()
+	if err != nil {
+		t.Fatalf("ReloadUserConfig: %v", err)
+	}
+	if len(reloaded.MCPs) != 2 {
+		t.Fatalf("expected 2 MCPs preserved after refused save, got %d", len(reloaded.MCPs))
+	}
+}
+
+// (c') S3: same protection for [groups].
+func TestSaveUserConfig_RefusesDroppingGroupsToEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedConfigWithSections(t)
+
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	cfg.Groups = map[string]GroupSettings{}
+
+	err = SaveUserConfig(cfg)
+	if err == nil {
+		t.Fatalf("expected SaveUserConfig to refuse dropping populated [groups] to empty, got nil")
+	}
+	if !errors.Is(err, ErrRefusingConfigSectionDrop) {
+		t.Fatalf("expected ErrRefusingConfigSectionDrop, got %v", err)
+	}
+}
+
+// (d) THE KEY ANTI-FALSE-POSITIVE TEST: removing ONE group (of two) succeeds.
+func TestSaveUserConfig_SingleGroupRemoval_StillSucceeds(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedConfigWithSections(t)
+
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	// Legit edit: delete just "personal", keep "work". Section still populated.
+	delete(cfg.Groups, "personal")
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("expected single-group removal to succeed, got %v", err)
+	}
+
+	reloaded, err := ReloadUserConfig()
+	if err != nil {
+		t.Fatalf("ReloadUserConfig: %v", err)
+	}
+	if len(reloaded.Groups) != 1 {
+		t.Fatalf("expected 1 group after single removal, got %d", len(reloaded.Groups))
+	}
+	if _, ok := reloaded.Groups["work"]; !ok {
+		t.Fatalf("expected remaining group 'work' to survive the edit")
+	}
+	// Same for MCPs: removing one of two must work.
+	cfg2, _ := LoadUserConfig()
+	delete(cfg2.MCPs, "github")
+	if err := SaveUserConfig(cfg2); err != nil {
+		t.Fatalf("expected single-MCP removal to succeed, got %v", err)
+	}
+	reloaded2, _ := ReloadUserConfig()
+	if len(reloaded2.MCPs) != 1 {
+		t.Fatalf("expected 1 MCP after single removal, got %d", len(reloaded2.MCPs))
+	}
+}
+
+// (e) Normal non-shrinking save (no sections touched, unrelated field changed)
+// is unaffected.
+func TestSaveUserConfig_NormalSave_Unaffected(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedConfigWithSections(t)
+
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	cfg.DefaultTool = "codex"
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("expected normal save to succeed, got %v", err)
+	}
+	reloaded, _ := ReloadUserConfig()
+	if reloaded.DefaultTool != "codex" {
+		t.Fatalf("expected default_tool=codex persisted, got %q", reloaded.DefaultTool)
+	}
+	if len(reloaded.MCPs) != 2 || len(reloaded.Groups) != 2 {
+		t.Fatalf("expected both sections intact, got mcps=%d groups=%d", len(reloaded.MCPs), len(reloaded.Groups))
+	}
+}
+
+// (f) The explicit-intent escape hatch DOES allow clearing a populated section.
+func TestSaveUserConfigWithIntent_AllowsSectionClear(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedConfigWithSections(t)
+
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	cfg.MCPs = map[string]MCPDef{}
+	cfg.Groups = map[string]GroupSettings{}
+	if err := SaveUserConfigWithIntent(cfg, true); err != nil {
+		t.Fatalf("expected intent path to allow clearing sections, got %v", err)
+	}
+	reloaded, _ := ReloadUserConfig()
+	if len(reloaded.MCPs) != 0 || len(reloaded.Groups) != 0 {
+		t.Fatalf("expected both sections cleared via intent path, got mcps=%d groups=%d", len(reloaded.MCPs), len(reloaded.Groups))
+	}
+}
+
+// (b for config) S2: the .bak holds the PRE-save (populated) content even when
+// the new save is the intent-cleared one — so the catalog is recoverable.
+func TestSaveUserConfig_BackupHoldsPreSaveSections(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedConfigWithSections(t)
+
+	configPath, _ := GetUserConfigPath()
+	bakPath := configPath + ".bak"
+
+	cfg, _ := LoadUserConfig()
+	cfg.MCPs = map[string]MCPDef{}
+	cfg.Groups = map[string]GroupSettings{}
+	if err := SaveUserConfigWithIntent(cfg, true); err != nil {
+		t.Fatalf("SaveUserConfigWithIntent: %v", err)
+	}
+
+	// The .bak should still contain the two MCPs + two groups from before.
+	data, err := os.ReadFile(bakPath)
+	if err != nil {
+		t.Fatalf("read .bak: %v", err)
+	}
+	var fromBak UserConfig
+	if _, err := toml.Decode(string(data), &fromBak); err != nil {
+		t.Fatalf("decode .bak: %v", err)
+	}
+	if len(fromBak.MCPs) != 2 || len(fromBak.Groups) != 2 {
+		t.Fatalf("expected .bak to preserve pre-save sections, got mcps=%d groups=%d", len(fromBak.MCPs), len(fromBak.Groups))
+	}
+}

--- a/internal/statedb/save_instances_backup_test.go
+++ b/internal/statedb/save_instances_backup_test.go
@@ -1,0 +1,114 @@
+package statedb
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// S2 data-loss safeguard (2026-06-04 incident).
+//
+// S1 refuses the fully-EMPTY sweep. S2 covers the large-but-NOT-empty replace
+// that S1 cannot catch: before saveInstancesOnce DELETEs a meaningful number of
+// on-disk rows, it snapshots the DB file to "<path>.bak" so the destructive
+// replace stays recoverable. These tests pin:
+//
+//	(a) a save that drops >= backupRowDropThreshold rows creates state.db.bak;
+//	(b) a save that drops fewer than the threshold does NOT create the backup
+//	    (routine session churn must not thrash the disk);
+//	(c) the .bak is a usable snapshot of the PRE-sweep state (still contains the
+//	    rows the sweep removed).
+
+// newTestDBAtPath opens a StateDB at a known file path (not t.TempDir's hidden
+// path) so the test can assert on the sibling state.db.bak file.
+func newTestDBAtPath(t *testing.T) (*StateDB, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db, dbPath
+}
+
+// (a) A destructive replace dropping >= threshold rows backs up first.
+func TestSaveInstances_LargeDrop_CreatesBackup(t *testing.T) {
+	db, dbPath := newTestDBAtPath(t)
+	seedInstances(t, db, "a", "b", "c", "d", "e")
+
+	bakPath := dbPath + ".bak"
+	if _, err := os.Stat(bakPath); err == nil {
+		t.Fatalf("precondition: %s should not exist yet", bakPath)
+	}
+
+	// Replace the set with just "a" — this DELETEs b,c,d,e (4 rows >= threshold 3).
+	now := time.Now()
+	rows := []*InstanceRow{
+		{ID: "a", Title: "a", ProjectPath: "/a", GroupPath: "grp", Order: 0, Tool: "claude", Status: "idle", CreatedAt: now, ToolData: json.RawMessage("{}")},
+	}
+	if err := db.SaveInstances(rows); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+
+	if _, err := os.Stat(bakPath); err != nil {
+		t.Fatalf("expected %s to be created before the large sweep, stat err: %v", bakPath, err)
+	}
+}
+
+// (b) A small drop (1 row) below the threshold does NOT create the backup.
+func TestSaveInstances_SmallDrop_NoBackup(t *testing.T) {
+	db, dbPath := newTestDBAtPath(t)
+	seedInstances(t, db, "a", "b", "c")
+
+	bakPath := dbPath + ".bak"
+
+	// Drop just "c" (1 row < threshold 3).
+	now := time.Now()
+	rows := []*InstanceRow{
+		{ID: "a", Title: "a", ProjectPath: "/a", GroupPath: "grp", Order: 0, Tool: "claude", Status: "idle", CreatedAt: now, ToolData: json.RawMessage("{}")},
+		{ID: "b", Title: "b", ProjectPath: "/b", GroupPath: "grp", Order: 1, Tool: "claude", Status: "idle", CreatedAt: now, ToolData: json.RawMessage("{}")},
+	}
+	if err := db.SaveInstances(rows); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+
+	if _, err := os.Stat(bakPath); err == nil {
+		t.Fatalf("expected NO backup for a sub-threshold drop, but %s exists", bakPath)
+	}
+}
+
+// (c) The .bak captures PRE-sweep state: it must still contain the swept rows.
+func TestSaveInstances_Backup_CapturesPreSweepState(t *testing.T) {
+	db, dbPath := newTestDBAtPath(t)
+	seedInstances(t, db, "a", "b", "c", "d")
+
+	now := time.Now()
+	rows := []*InstanceRow{
+		{ID: "a", Title: "a", ProjectPath: "/a", GroupPath: "grp", Order: 0, Tool: "claude", Status: "idle", CreatedAt: now, ToolData: json.RawMessage("{}")},
+	}
+	if err := db.SaveInstances(rows); err != nil {
+		t.Fatalf("SaveInstances: %v", err)
+	}
+
+	// Open the backup as a separate DB and confirm it still holds all 4 rows.
+	bakPath := dbPath + ".bak"
+	bak, err := Open(bakPath)
+	if err != nil {
+		t.Fatalf("Open backup: %v", err)
+	}
+	defer bak.Close()
+
+	loaded, err := bak.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances from backup: %v", err)
+	}
+	if len(loaded) != 4 {
+		t.Fatalf("expected backup to hold the 4 pre-sweep rows, got %d", len(loaded))
+	}
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -29,6 +29,43 @@ import (
 // that genuinely intend to empty the table must use ClearAllInstances.
 var ErrRefusingEmptySweep = errors.New("statedb: refusing to wipe populated instances table with an empty SaveInstances payload (use ClearAllInstances to intentionally clear)")
 
+// backupDBFile copies the live SQLite database file to "<path>.bak" so a
+// destructive sweep is recoverable (S2 data-loss safeguard, 2026-06-04
+// incident). It is best-effort: a failed backup must NOT abort the save (the
+// save is the operation the caller actually asked for; the backup is an
+// insurance copy). To capture a consistent snapshot we checkpoint the WAL into
+// the main file first, then copy. Errors are returned so callers can log them,
+// but the only current caller intentionally ignores the error.
+//
+// No-op (nil) when path is empty (in-memory DB) — there is no file to copy.
+func (s *StateDB) backupDBFile() error {
+	if s.path == "" {
+		return nil
+	}
+	// Fold the WAL back into the main db file so the .bak is self-contained and
+	// doesn't depend on a sidecar -wal that the next write will overwrite.
+	_, _ = s.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+
+	src, err := os.ReadFile(s.path)
+	if err != nil {
+		// Nothing to back up (file not created yet) or unreadable; either way,
+		// don't block the save.
+		return err
+	}
+	bak := s.path + ".bak"
+	// 0600: the db may carry session metadata; keep the backup as private as
+	// the original. Write+rename to avoid leaving a torn .bak.
+	tmp := bak + ".tmp"
+	if err := os.WriteFile(tmp, src, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, bak); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
 // withBusyRetry runs op with linear backoff (10ms, 20ms, 30ms, 40ms, 50ms;
 // ~150ms total) when op fails with SQLITE_BUSY. Non-BUSY errors are returned
 // immediately; the final BUSY error is returned if every attempt fails.
@@ -74,7 +111,21 @@ const SchemaVersion = 9
 type StateDB struct {
 	db  *sql.DB
 	pid int
+	// path is the on-disk path of the SQLite database file. Retained so
+	// destructive write paths can snapshot the file to "<path>.bak" before a
+	// large DELETE+re-insert sweep (S2 data-loss safeguard, 2026-06-04
+	// incident). Empty for in-memory databases (no file to back up).
+	path string
 }
+
+// backupRowDropThreshold is the minimum number of rows a single
+// saveInstancesOnce sweep must DELETE before it is worth snapshotting the DB
+// file to "<path>.bak". A sweep that drops one or two rows is routine session
+// churn (a session was removed/renamed); backing the file up on every such save
+// would thrash the disk. The 2026-06-04 incident wiped the entire populated
+// table at once, so a meaningful-drop gate catches the catastrophic case while
+// staying quiet during normal operation.
+const backupRowDropThreshold = 3
 
 // InstanceRow represents a session row in the database.
 type InstanceRow struct {
@@ -235,7 +286,7 @@ func Open(dbPath string) (*StateDB, error) {
 		return nil, fmt.Errorf("statedb: wal mode: %w", err)
 	}
 
-	return &StateDB{db: db, pid: os.Getpid()}, nil
+	return &StateDB{db: db, pid: os.Getpid(), path: dbPath}, nil
 }
 
 // Close checkpoints WAL and closes the database.
@@ -624,6 +675,36 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 				}
 			}
 			_ = rows.Close()
+		}
+	}
+
+	// S2 data-loss safeguard (2026-06-04 incident): for a NON-empty payload,
+	// the sweep below DELETEs every on-disk row whose id is absent from the new
+	// set. Count that drop FIRST (on the raw handle, before opening the write
+	// transaction — running a wal_checkpoint backup inside an open tx on the
+	// same pool would deadlock). When the drop is meaningful
+	// (>= backupRowDropThreshold), snapshot the DB file to "<path>.bak" so a
+	// buggy-but-non-empty replace (the incident dropped most of the table at
+	// once) stays recoverable. S1 already refuses the fully-empty sweep; S2
+	// covers the large-but-not-empty replaces S1 cannot catch. The backup is
+	// best-effort: a failed copy is logged, never fatal — the caller asked to
+	// save, and the insurance copy must not become a new failure mode.
+	if len(insts) > 0 && s.path != "" {
+		placeholders := make([]string, len(insts))
+		args := make([]any, len(insts))
+		for i, inst := range insts {
+			placeholders[i] = "?"
+			args[i] = inst.ID
+		}
+		var dropCount int
+		// #nosec G202 -- placeholders is a fixed sequence of "?" tokens generated
+		// from len(insts); all values flow through args[], never the SQL string.
+		countQuery := "SELECT COUNT(*) FROM instances WHERE id NOT IN (" + strings.Join(placeholders, ",") + ")"
+		if err := s.db.QueryRow(countQuery, args...).Scan(&dropCount); err == nil && dropCount >= backupRowDropThreshold {
+			if bErr := s.backupDBFile(); bErr != nil {
+				slog.Warn("statedb: pre-sweep backup failed (continuing with save)",
+					"path", s.path, "drop_count", dropCount, "err", bErr)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Context: 2026-06-04 data-loss incident

This is the next pair of chain-links from the 2026-06-04 data-loss incident, where a destructive write wiped the live profile index and a partially-constructed config saved over `config.toml` silently dropped the whole `[mcps]` catalog and `[groups]` overrides.

Builds on what already merged:
- **S1** (#1283) — `SaveInstances([])` now refuses to wipe a populated table (`ErrRefusingEmptySweep`).
- **S5** (#1284) — mandatory HOME+XDG sandbox in path-touching `TestMain`.

This PR adds **S2** (backup-before-destructive-write) and **S3** (refuse config section-drop). Both are destructive-write protections, shipped together.

## S2 — backup-before-destructive-write

**`internal/statedb/statedb.go` `saveInstancesOnce`:** before the non-empty `DELETE`+re-insert sweep, count how many on-disk rows the save would delete. When the drop is meaningful (`>= backupRowDropThreshold`, currently 3), snapshot the DB file to `state.db.bak` first (WAL-checkpoint + atomic copy). S1 already refuses the fully-empty sweep; S2 covers the large-but-not-empty replace S1 cannot catch. Routine 1–2 row churn is left alone so we don't thrash the disk. The count runs on the raw handle *before* opening the write transaction (a `wal_checkpoint` inside an open tx on the same pool would deadlock). Backup is best-effort: a failed copy is logged, never fatal.

**`internal/session/userconfig.go` `SaveUserConfig`:** copies the existing `config.toml` to `config.toml.bak` before the atomic rename. The atomic rename prevents torn writes but **not** semantic clobbering — the `.bak` is the recovery net.

## S3 — refuse-to-shrink config.toml

`SaveUserConfig` now refuses (`ErrRefusingConfigSectionDrop`) a save that would drop a populated `[mcps]` or `[groups]` section to empty — the exact sections lost on 2026-06-04. It round-trips the about-to-be-written content (decode) and compares section counts against disk.

**Anti-false-positive design (the main risk):** the guard fires **only** when a section that had entries on disk would become entirely empty. A normal edit loads the full config, removes one group/MCP, and saves — the rest of the map is still present, so the count stays `> 0` and the save proceeds untouched. The legitimate "user really cleared everything" case goes through the explicit `SaveUserConfigWithIntent(cfg, true)` path. `SaveUserConfig` is a thin wrapper for `SaveUserConfigWithIntent(cfg, false)`, so every existing caller keeps working.

## Tests (TDD, sandboxed, per-package)

`internal/statedb/save_instances_backup_test.go`:
- large drop (≥3 rows) creates `state.db.bak`
- small drop (1 row) does **not** create a backup
- `.bak` captures pre-sweep state (still holds the swept rows)

`internal/session/userconfig_section_guard_test.go`:
- `config.toml.bak` created before overwrite (S2)
- refuses dropping populated `[mcps]` to empty; on-disk MCPs preserved (S3)
- refuses dropping populated `[groups]` to empty (S3)
- **single-group removal still succeeds** (anti-false-positive) — and single-MCP removal too
- normal non-shrinking save unaffected
- `SaveUserConfigWithIntent(cfg, true)` allows clearing sections
- `.bak` holds pre-save (populated) sections so the catalog is recoverable

Fail→pass proven: reverting only the source changes makes the new statedb tests fail (no `.bak`) and the userconfig test package fail to compile (undefined `ErrRefusingConfigSectionDrop` / `SaveUserConfigWithIntent`).

## Verification (sandboxed, isolated clone, per-package — never ./...)

```
HOME=$(mktemp -d) XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_CACHE_HOME= \
  go test -race ./internal/statedb/... ./internal/session/...
```

Green excluding the documented host-flaky perf tests (`TestPerf_StateDB_List`, `TestPerf_OutboxDrain_*` — timing-budget tests that flake under the full `-race` suite and pass in isolation / on clean `main`; unrelated to these changes). `go build ./...` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection to prevent accidental clearing of configuration sections during updates
  * Configuration files are now automatically backed up before being saved
  * Database files are automatically backed up when performing large-scale data replacements

* **Tests**
  * Comprehensive test coverage added for configuration backup safety and database deletion safeguards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->