### PR TITLE
feat: support Pi session forking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pi session forking**. `agent-deck session fork` and the TUI `f`/`F` fork shortcuts now support built-in Pi sessions by launching `pi --fork <source-jsonl> --session-dir <child-dir>` from Agent Deck's per-instance Pi session directories.
+
 ## [1.9.47] - 2026-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ One terminal. All your agents. Complete visibility.
 
 ### Fork Sessions
 
-Try different approaches without losing context. Fork any Claude conversation instantly. Each fork inherits the full conversation history.
+Try different approaches without losing context. Fork Claude conversations and Pi sessions instantly. Each fork inherits the parent conversation history through the tool's native fork support.
 
 - Press `f` for quick fork, `F` to customize name/group
 - Fork your forks to explore as many branches as you need
@@ -779,7 +779,7 @@ See [Troubleshooting](skills/agent-deck/references/troubleshooting.md#uninstalli
 ```bash
 agent-deck                        # Launch TUI
 agent-deck add . -c claude        # Add current dir with Claude
-agent-deck session fork my-proj   # Fork a Claude session
+agent-deck session fork my-proj   # Fork a Claude/Pi session
 agent-deck session remove my-proj # Remove stopped/errored session from registry (transcripts preserved)
 agent-deck mcp attach my-proj exa # Attach MCP to session
 agent-deck skill attach my-proj docs --source pool --restart # Attach skill + restart

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2979,7 +2979,7 @@ func printHelp() {
 	fmt.Println("  session start <id>        Start a session's tmux process")
 	fmt.Println("  session stop <id>         Stop session process")
 	fmt.Println("  session restart <id>      Restart session (reload MCPs)")
-	fmt.Println("  session fork <id>         Fork Claude session with context")
+	fmt.Println("  session fork <id>         Fork Claude or Pi session with context")
 	fmt.Println("  session attach <id>       Attach to session interactively")
 	fmt.Println("  session show [id]         Show session details")
 	fmt.Println()

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -97,7 +97,7 @@ func printSessionHelp() {
 	fmt.Println("  remove <id>             Remove session from registry (stopped/error only; --force to bypass)")
 	fmt.Println("  restart [id] [--all]    Restart session (Claude: reload MCPs)")
 	fmt.Println("  revive [--all|--name]   Rebuild dead control pipes for errored sessions")
-	fmt.Println("  fork <id>               Fork Claude session with context")
+	fmt.Println("  fork <id>               Fork Claude or Pi session with context")
 	fmt.Println("  attach <id>             Attach to session interactively")
 	fmt.Println("  show [id]               Show session details (auto-detect current if no id)")
 	fmt.Println("  current                 Show current session and profile (auto-detect)")
@@ -614,7 +614,7 @@ func branchCleanupHint(createdBranch bool, repoRoot, branchName string) string {
 	return fmt.Sprintf(" && git -C %s branch -D %s", shellescape.Quote(repoRoot), shellescape.Quote(branchName))
 }
 
-// handleSessionFork forks a Claude session
+// handleSessionFork forks a Claude or Pi session
 func handleSessionFork(profile string, args []string) {
 	fs := flag.NewFlagSet("session fork", flag.ExitOnError)
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
@@ -636,7 +636,7 @@ func handleSessionFork(profile string, args []string) {
 	fs.Usage = func() {
 		fmt.Println("Usage: agent-deck session fork <id|title> [options]")
 		fmt.Println()
-		fmt.Println("Fork a Claude session with conversation context.")
+		fmt.Println("Fork a Claude or Pi session with conversation context.")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -681,24 +681,30 @@ func handleSessionFork(profile string, args []string) {
 		return // unreachable, satisfies staticcheck SA5011
 	}
 
-	// Verify it's a Claude session
-	if !session.IsClaudeCompatible(inst.Tool) {
+	// Verify this tool has a session-fork implementation.
+	isClaudeFork := session.IsClaudeCompatible(inst.Tool)
+	isPiFork := inst.Tool == "pi"
+	if !isClaudeFork && !isPiFork {
 		out.Error(
-			fmt.Sprintf("session '%s' is not a Claude session (tool: %s)", inst.Title, inst.Tool),
+			fmt.Sprintf("session '%s' is not a Claude session or Pi session (tool: %s)", inst.Title, inst.Tool),
 			ErrCodeInvalidOperation,
 		)
 		os.Exit(1)
 	}
 
-	// Try to capture session ID from tmux if missing (handles pre-fix sessions)
-	if inst.ClaudeSessionID == "" && inst.Exists() {
+	// Try to capture Claude session ID from tmux if missing (handles pre-fix sessions).
+	if isClaudeFork && inst.ClaudeSessionID == "" && inst.Exists() {
 		inst.PostStartSync(2 * time.Second)
 	}
 
-	// Verify it can be forked
+	// Verify it can be forked.
 	if !inst.CanFork() {
+		reason := "no active Claude session ID"
+		if isPiFork {
+			reason = "no Agent Deck Pi session directory"
+		}
 		out.Error(
-			fmt.Sprintf("session '%s' cannot be forked: no active Claude session ID", inst.Title),
+			fmt.Sprintf("session '%s' cannot be forked: %s", inst.Title, reason),
 			ErrCodeInvalidOperation,
 		)
 		os.Exit(1)
@@ -917,7 +923,13 @@ func handleSessionFork(profile string, args []string) {
 	}
 
 	// Create the forked instance
-	forkedInst, _, err := inst.CreateForkedInstanceWithOptions(forkTitle, forkGroup, opts)
+	var forkedInst *session.Instance
+	switch {
+	case isPiFork:
+		forkedInst, _, err = inst.CreateForkedPiInstanceWithOptions(forkTitle, forkGroup, opts)
+	default:
+		forkedInst, _, err = inst.CreateForkedInstanceWithOptions(forkTitle, forkGroup, opts)
+	}
 	if err != nil {
 		out.Error(fmt.Sprintf("failed to create fork: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)

--- a/cmd/agent-deck/session_cmd_pi_fork_test.go
+++ b/cmd/agent-deck/session_cmd_pi_fork_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestSessionFork_PiUsesNativeForkBeforeStart(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	parent := session.NewInstanceWithGroupAndTool("pi-parent", home, "pi-group", "pi")
+	parent.Command = "pi"
+	parentSessionDir := filepath.Join(home, ".pi", "agent-deck", parent.ID)
+	if err := os.MkdirAll(parentSessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir parent Pi session dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(parentSessionDir, "session.jsonl"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write parent Pi JSONL: %v", err)
+	}
+
+	profile := "pi_fork_hook"
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+	if err := storage.SaveWithGroups([]*session.Instance{parent}, session.NewGroupTreeWithGroups([]*session.Instance{parent}, nil)); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	var capturedParent *session.Instance
+	var capturedFork *session.Instance
+	oldHook := sessionForkBeforeStartHook
+	sessionForkBeforeStartHook = func(parent *session.Instance, forked *session.Instance, _ git.WorktreeStateOptions) {
+		capturedParent = parent
+		capturedFork = forked
+	}
+	t.Cleanup(func() { sessionForkBeforeStartHook = oldHook })
+
+	handleSessionFork(profile, []string{"pi-parent", "-t", "pi-child"})
+
+	if capturedParent == nil || capturedParent.ID != parent.ID {
+		t.Fatalf("hook captured parent = %+v, want parent %s", capturedParent, parent.ID)
+	}
+	if capturedFork == nil {
+		t.Fatal("hook did not capture forked instance")
+	}
+	if capturedFork.Tool != "pi" {
+		t.Fatalf("capturedFork.Tool = %q, want pi", capturedFork.Tool)
+	}
+	if capturedFork.Command != "pi" {
+		t.Fatalf("capturedFork.Command = %q, want base pi command", capturedFork.Command)
+	}
+	if !capturedFork.IsForkAwaitingStart || capturedFork.ForkStartCommand == "" {
+		t.Fatalf("captured Pi fork should carry first-start command, got awaiting=%v command=%q", capturedFork.IsForkAwaitingStart, capturedFork.ForkStartCommand)
+	}
+	for _, want := range []string{
+		"parent_session_dir=${HOME}/.pi/agent-deck/" + parent.ID,
+		"session_dir=${HOME}/.pi/agent-deck/" + capturedFork.ID,
+		`pi --fork "$source_file" --session-dir "$session_dir"`,
+	} {
+		if !strings.Contains(capturedFork.ForkStartCommand, want) {
+			t.Fatalf("Pi fork first-start command = %q, want to contain %q", capturedFork.ForkStartCommand, want)
+		}
+	}
+	if strings.Contains(capturedFork.ForkStartCommand, "--continue") {
+		t.Fatalf("Pi fork first-start command must not include --continue: %s", capturedFork.ForkStartCommand)
+	}
+}

--- a/docs/status/capability-dashboard.html
+++ b/docs/status/capability-dashboard.html
@@ -173,8 +173,8 @@ ECHO:PINGLAUNCH-cap-e2e-token</pre></div>
   <div class="card green">
     <div class="status"><span class="dot green"></span>PASS</div>
     <h3>Fork guard</h3>
-    <p class="how">Forking is only valid for a Claude session with live context. We confirm forking a non-Claude session is cleanly refused and creates no orphan child row. The full context-inheriting fork is a documented nightly gap.</p>
-    <p class="assert">Pass when: forking a non-Claude session is refused and no child row is created</p>
+    <p class="how">Forking is only valid for supported tools with live context (Claude session ID or Pi JSONL). We confirm forking an unsupported session is cleanly refused and creates no orphan child row. The full context-inheriting fork is a documented nightly gap.</p>
+    <p class="assert">Pass when: forking an unsupported session is refused and no child row is created</p>
     <div class="meta">Tier F . Runtime: 0.1s . TestCapability_Lifecycle_Fork</div>
     <div class="chips"><span class="chip">Local-isolated</span></div>
     <div class="term"><div class="term-label">What the terminal showed at verification</div><pre class="terminal">$ agent-deck session fork cap-fork
@@ -209,8 +209,8 @@ ECHO:PING-TestCapability_Agent_EchoRoundTrip</pre></div>
   
   <div class="card grey">
     <div class="status"><span class="dot grey"></span>NIGHTLY</div>
-    <h3>Fork inherits Claude context</h3>
-    <p class="how">We fork a live Claude session and confirm the child inherits the conversation with a distinct id and a parent link. This needs a real Claude session id from a live transcript, so it runs nightly.</p>
+    <h3>Fork inherits tool context</h3>
+    <p class="how">We fork a live Claude or Pi session and confirm the child inherits the conversation with a distinct id and a parent link. This needs real tool session data from a live transcript, so it runs nightly.</p>
     <p class="assert">Pass when: child session links the parent and inherits conversation context</p>
     <div class="meta">Tier N . Runtime: not measured</div>
     <div class="chips"><span class="chip">Real-agent</span><span class="chip">Needs-creds</span><span class="chip">Needs-network</span></div>

--- a/docs/status/capability-e2e-manifest.json
+++ b/docs/status/capability-e2e-manifest.json
@@ -103,8 +103,8 @@
       "id": "fork",
       "group": "Session lifecycle",
       "title": "Fork guard",
-      "how_we_test": "Forking is only valid for a Claude session with live context. We confirm forking a non-Claude session is cleanly refused and creates no orphan child row. The full context-inheriting fork is a documented nightly gap.",
-      "assertion": "forking a non-Claude session is refused and no child row is created",
+      "how_we_test": "Forking is only valid for supported tools with live context (Claude session ID or Pi JSONL). We confirm forking an unsupported session is cleanly refused and creates no orphan child row. The full context-inheriting fork is a documented nightly gap.",
+      "assertion": "forking an unsupported session is refused and no child row is created",
       "tier": "F",
       "chips": [
         "Local-isolated"
@@ -112,7 +112,7 @@
       "test_name": "TestCapability_Lifecycle_Fork",
       "status": "pass",
       "runtime_seconds": 0.15,
-      "snapshot": "$ agent-deck session fork cap-fork\nError: session 'cap-fork' is not a Claude session (tool: shell)"
+      "snapshot": "$ agent-deck session fork cap-fork\nError: session 'cap-fork' is not a Claude session or Pi session (tool: shell)"
     },
     {
       "id": "send-output-echo",
@@ -148,8 +148,8 @@
     {
       "id": "fork-context",
       "group": "Agent interaction",
-      "title": "Fork inherits Claude context",
-      "how_we_test": "We fork a live Claude session and confirm the child inherits the conversation with a distinct id and a parent link. This needs a real Claude session id from a live transcript, so it runs nightly.",
+      "title": "Fork inherits tool context",
+      "how_we_test": "We fork a live Claude or Pi session and confirm the child inherits the conversation with a distinct id and a parent link. This needs real tool session data from a live transcript, so it runs nightly.",
       "assertion": "child session links the parent and inherits conversation context",
       "tier": "N",
       "chips": [

--- a/docs/status/capability-videos.html
+++ b/docs/status/capability-videos.html
@@ -84,7 +84,7 @@
 <section class="clip lifecycle">
   <span class="badge">Lifecycle</span>
   <h2>Fork precondition guard</h2>
-  <p class="caption">Forking a non Claude session is refused with a clear error and creates no child row. The full fork happy path needs a real Claude transcript and is a documented nightly gap.</p>
+  <p class="caption">Forking an unsupported session is refused with a clear error and creates no child row. The full fork happy paths need real Claude or Pi session data and are documented nightly gaps.</p>
   <video controls loop muted playsinline preload="metadata">
     <source src="videos/lifecycle-fork.webm" type="video/webm">
     Your browser cannot play WebM. <a href="videos/lifecycle-fork.gif">View the GIF instead.</a>

--- a/docs/testing/capability-gaps.md
+++ b/docs/testing/capability-gaps.md
@@ -11,15 +11,15 @@ exercise the capability.
 
 ## Wave 1 gaps
 
-### Fork that inherits Claude context
-`session fork` only fully works for a Claude-compatible session that has a live
-`ClaudeSessionID` captured from a real claude transcript (see
-`internal/session/instance.go` `CanFork`). That id is non-deterministic and
-key-gated, and the fork itself runs `claude --resume`, which needs the real CLI
-and auth. Wave 1 therefore tests the deterministic half of the capability: the
-precondition guard refuses to fork a non-Claude session and creates no orphan
-child row (`TestCapability_Lifecycle_Fork`). The context-inheriting happy path
-is Tier N.
+### Fork that inherits tool context
+`session fork` happy paths depend on real tool session data. Claude-compatible
+sessions need a live `ClaudeSessionID` captured from a real claude transcript;
+Pi sessions need a real JSONL in Agent Deck's per-instance Pi session directory
+so `pi --fork <jsonl>` can branch it. Those inputs are non-deterministic and
+key/tool-gated, and the fork itself needs the real CLI and auth. Wave 1
+therefore tests the deterministic half of the capability: the precondition guard
+refuses to fork an unsupported session and creates no orphan child row
+(`TestCapability_Lifecycle_Fork`). The context-inheriting happy paths are Tier N.
 
 ### Real agent round trips (claude, codex, gemini, opencode)
 The backbone send-and-reply round trip is verified offline against a

--- a/docs/testing/capability-video-gaps.md
+++ b/docs/testing/capability-video-gaps.md
@@ -19,17 +19,17 @@ live with `session output`, not typed into the tape.
 | `echo-roundtrip` | launch, send token, read reply, teardown | the real `ECHO:PING-DEMO-7f3a` reply from the echobot |
 | `lifecycle-launch` | atomic add + start + send in one command | the registry row plus the echoed launch token |
 | `lifecycle-stop` | start, stop, state flips to stopped | `list` before and after the real `session stop` |
-| `lifecycle-fork` | fork precondition guard | the real refusal error for a non-Claude session |
+| `lifecycle-fork` | fork precondition guard | the real refusal error for an unsupported session |
 
 ## Gaps (not recorded, by design)
 
-### Fork that inherits Claude context
-`lifecycle-fork.tape` shows the precondition guard refusing to fork a non-Claude
+### Fork that inherits tool context
+`lifecycle-fork.tape` shows the precondition guard refusing to fork an unsupported
 session, which is the deterministic half of the capability. The
-context-inheriting happy path needs a real `ClaudeSessionID` from a live,
-key-gated claude transcript and runs `claude --resume`, so it cannot be recorded
-offline. This is the same Tier N gap documented for the asserting test in
-`docs/testing/capability-gaps.md` (Fork that inherits Claude context).
+context-inheriting happy paths need real tool session data — a live
+`ClaudeSessionID` for Claude or a Pi JSONL for `pi --fork` — so they cannot be
+recorded offline. This is the same Tier N gap documented for the asserting test
+in `docs/testing/capability-gaps.md` (Fork that inherits tool context).
 
 ### Real agent round trips (claude, codex, gemini, opencode)
 The `echo-roundtrip` clip uses the deterministic echobot so the reply is stable

--- a/internal/session/command_override_test.go
+++ b/internal/session/command_override_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -10,6 +11,17 @@ import (
 
 // Tests for the uniform command/env_file override layer.
 // Verifies GetToolCommand, buildCopilotCommand, and getToolEnvFile wiring.
+
+func seedLocalPiSessionFile(t *testing.T, inst *Instance) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("HOME"), ".pi", "agent-deck", inst.ID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir Pi session dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "session.jsonl"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write Pi session file: %v", err)
+	}
+}
 
 func TestGetToolCommand_NoConfig(t *testing.T) {
 	// With no config file on disk, GetToolCommand should return the bare tool name.
@@ -200,6 +212,83 @@ func TestBuildPiCommand_WrongTool(t *testing.T) {
 	got := inst.buildPiCommand("some-command")
 	if got != "some-command" {
 		t.Errorf("buildPiCommand with wrong tool = %q, want %q", got, "some-command")
+	}
+}
+
+func TestCreateForkedPiInstance_UsesNativeForkAndPersistsBaseCommand(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	parent := NewInstanceWithTool("parent", "/tmp/project", "pi")
+	parent.ID = "parent-pi-id"
+	parent.GroupPath = "projects/pi"
+	parent.Command = "pi"
+	seedLocalPiSessionFile(t, parent)
+
+	forked, cmd, err := parent.CreateForkedPiInstance("forked", "")
+	if err != nil {
+		t.Fatalf("CreateForkedPiInstance() failed: %v", err)
+	}
+
+	if forked.Tool != "pi" {
+		t.Fatalf("forked.Tool = %q, want pi", forked.Tool)
+	}
+	if forked.GroupPath != "projects/pi" {
+		t.Fatalf("forked.GroupPath = %q, want inherited group", forked.GroupPath)
+	}
+	if forked.Command != "pi" {
+		t.Fatalf("forked.Command = %q, want base command for later --continue restarts", forked.Command)
+	}
+	if !forked.IsForkAwaitingStart {
+		t.Fatal("forked Pi instance should carry IsForkAwaitingStart for first launch")
+	}
+	if forked.ForkStartCommand != cmd {
+		t.Fatalf("ForkStartCommand should hold the first-start fork command")
+	}
+
+	for _, want := range []string{
+		"parent_session_dir=${HOME}/.pi/agent-deck/parent-pi-id",
+		"session_dir=${HOME}/.pi/agent-deck/" + forked.ID,
+		`source_file=$(find "$parent_session_dir" -type f -name '*.jsonl' -exec ls -t {} +`,
+		`AGENTDECK_INSTANCE_ID=` + forked.ID,
+		`pi --fork "$source_file" --session-dir "$session_dir"`,
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("Pi fork command = %q, want to contain %q", cmd, want)
+		}
+	}
+	if strings.Contains(cmd, "--continue") {
+		t.Fatalf("Pi fork command must not include --continue: %s", cmd)
+	}
+
+	resumeCmd := forked.buildPiCommand(forked.Command)
+	if !strings.Contains(resumeCmd, `pi --continue --session-dir "$session_dir"`) {
+		t.Fatalf("Pi forked instance restart command should resume with --continue, got: %s", resumeCmd)
+	}
+	if strings.Contains(resumeCmd, "--fork") {
+		t.Fatalf("Pi forked instance restart command must not replay --fork, got: %s", resumeCmd)
+	}
+}
+
+func TestCreateForkedPiInstance_WorktreeOptions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	parent := NewInstanceWithTool("parent", "/tmp/project", "pi")
+	parent.ID = "parent-pi-id"
+	seedLocalPiSessionFile(t, parent)
+
+	opts := &ClaudeOptions{
+		WorkDir:          "/tmp/project-wt",
+		WorktreePath:     "/tmp/project-wt",
+		WorktreeRepoRoot: "/tmp/project",
+		WorktreeBranch:   "fork/pi",
+	}
+	forked, _, err := parent.CreateForkedPiInstanceWithOptions("forked", "custom", opts)
+	if err != nil {
+		t.Fatalf("CreateForkedPiInstanceWithOptions() failed: %v", err)
+	}
+	if forked.ProjectPath != "/tmp/project-wt" {
+		t.Fatalf("forked.ProjectPath = %q, want worktree path", forked.ProjectPath)
+	}
+	if forked.WorktreePath != "/tmp/project-wt" || forked.WorktreeRepoRoot != "/tmp/project" || forked.WorktreeBranch != "fork/pi" {
+		t.Fatalf("forked worktree fields not copied: %+v", forked)
 	}
 }
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -279,19 +279,22 @@ type Instance struct {
 	// so existing sessions are unaffected on upgrade.
 	IdleTimeoutSecs int64 `json:"idle_timeout_secs,omitempty"`
 
-	// IsForkAwaitingStart signals that this instance was produced by
-	// CreateForkedInstanceWithOptions and holds a pre-built fork command
-	// in Command that must be run verbatim on the first Start() (#745).
-	// Without this flag, Start()'s claude-compatible dispatch sees the
-	// pre-populated ClaudeSessionID (the new fork UUID), routes to
-	// buildClaudeResumeCommand, which fails to find a JSONL for a
-	// brand-new UUID and falls back to a plain --session-id fresh
-	// command — stripping --resume <parent-id> / --fork-session and
-	// dropping all conversation history from the parent. Transient
-	// (json:"-"): persisting this would cause a restart of the forked
-	// session to re-emit --fork-session and double-count the parent
-	// transcript.
+	// IsForkAwaitingStart signals that this instance was produced by a
+	// fork builder and must run a pre-built fork command verbatim on the
+	// first Start() (#745). Claude fork targets usually store that command
+	// in Command. Pi fork targets keep Command as the normal restart
+	// command (so later restarts use --continue) and store the first-start
+	// command in ForkStartCommand instead.
+	//
+	// Transient (json:"-"): persisting this would cause a restart of the
+	// forked session to re-emit the tool-specific fork command and
+	// double-count the parent transcript.
 	IsForkAwaitingStart bool `json:"-"`
+
+	// ForkStartCommand optionally carries the pre-built command to run while
+	// IsForkAwaitingStart is true. When empty, Start() falls back to Command
+	// for backwards compatibility with Claude fork targets.
+	ForkStartCommand string `json:"-"`
 
 	// ExtraArgs are user-supplied claude CLI tokens appended verbatim to every
 	// start/resume/fork command (e.g. ["--agent","reviewer","--model","opus"]).
@@ -1376,6 +1379,14 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	return envPrefix + command + yoloFlag + modelFlag
 }
 
+// piAgentDeckSessionDirExpr returns a target-shell expression for the Pi session
+// directory Agent Deck owns for an instance. It intentionally uses target-side
+// $HOME rather than resolving the Agent Deck process' home directory, keeping
+// local, SSH, and sandbox launch paths consistent.
+func piAgentDeckSessionDirExpr(instanceID string) string {
+	return "${HOME}/.pi/agent-deck/" + shellescape.Quote(instanceID)
+}
+
 // buildPiCommand builds the command for the Pi CLI.
 // Pi sessions are JSONL files, not externally named sessions like Claude/Codex.
 // Scope Pi's session directory to the Agent Deck instance and always launch
@@ -1392,9 +1403,7 @@ func (i *Instance) buildPiCommand(baseCommand string) string {
 		cmd = "pi"
 	}
 
-	// Use target-side $HOME rather than resolving the Agent Deck process' home
-	// directory. This keeps local, SSH, and sandbox launch paths consistent.
-	sessionDir := "${HOME}/.pi/agent-deck/" + shellescape.Quote(i.ID)
+	sessionDir := piAgentDeckSessionDirExpr(i.ID)
 	quotedInstanceID := shellescape.Quote(i.ID)
 
 	return envPrefix + fmt.Sprintf(
@@ -1403,6 +1412,43 @@ func (i *Instance) buildPiCommand(baseCommand string) string {
 		quotedInstanceID,
 		cmd,
 	)
+}
+
+func (i *Instance) buildPiForkCommandForTarget(target *Instance, baseCommand string) (string, error) {
+	if target == nil {
+		return "", fmt.Errorf("cannot build Pi fork command: target instance is nil")
+	}
+	if !i.CanForkPi() {
+		return "", fmt.Errorf("cannot fork: no Agent Deck Pi session directory")
+	}
+
+	envPrefix := target.buildEnvSourceCommand()
+	cmd := strings.TrimSpace(baseCommand)
+	if cmd == "" {
+		cmd = "pi"
+	}
+
+	parentSessionDir := piAgentDeckSessionDirExpr(i.ID)
+	sessionDir := piAgentDeckSessionDirExpr(target.ID)
+	quotedInstanceID := shellescape.Quote(target.ID)
+
+	return envPrefix + fmt.Sprintf(
+		"parent_session_dir=%s; session_dir=%s; mkdir -p \"$session_dir\" && source_file=$(find \"$parent_session_dir\" -type f -name '*.jsonl' -exec ls -t {} + 2>/dev/null | head -n 1); if [ -z \"$source_file\" ]; then echo \"No Pi session file found in $parent_session_dir\" >&2; exit 1; fi; AGENTDECK_INSTANCE_ID=%s %s --fork \"$source_file\" --session-dir \"$session_dir\"",
+		parentSessionDir,
+		sessionDir,
+		quotedInstanceID,
+		cmd,
+	), nil
+}
+
+func (i *Instance) consumeForkStartCommand() string {
+	command := i.Command
+	if i.ForkStartCommand != "" {
+		command = i.ForkStartCommand
+		i.ForkStartCommand = ""
+	}
+	i.IsForkAwaitingStart = false
+	return command
 }
 
 // buildCursorCommand builds the command for the Cursor CLI (`cursor agent`).
@@ -2785,17 +2831,15 @@ func (i *Instance) Start() error {
 	var command string
 	switch {
 	case IsClaudeCompatible(i.Tool):
-		// #745 fork guard: a fork target arrives here with i.Command
-		// already populated with the exact `claude --session-id <new>
-		// --resume <parent> --fork-session` command built by
-		// buildClaudeForkCommandForTarget. It also carries a pre-assigned
-		// ClaudeSessionID (the new fork UUID), which would otherwise send
-		// us into buildClaudeResumeCommand and silently drop --resume /
-		// --fork-session. Run the fork command verbatim and clear the
-		// sentinel so a subsequent Restart() takes the normal resume path.
+		// #745 fork guard: a fork target arrives here with a pre-built
+		// first-start command (`claude --session-id <new> --resume <parent>
+		// --fork-session`) and a pre-assigned ClaudeSessionID (the new fork
+		// UUID), which would otherwise send us into buildClaudeResumeCommand
+		// and silently drop --resume / --fork-session. Run the fork command
+		// verbatim and clear the sentinel so a subsequent Restart() takes the
+		// normal resume path.
 		if i.IsForkAwaitingStart {
-			command = i.Command
-			i.IsForkAwaitingStart = false
+			command = i.consumeForkStartCommand()
 			sessionLog.Info("resume: none reason=fork_awaiting_start",
 				slog.String("instance_id", i.ID),
 				slog.String("path", i.ProjectPath),
@@ -2843,6 +2887,14 @@ func (i *Instance) Start() error {
 		// Record start time for session ID detection (Unix millis)
 		i.CodexStartedAt = time.Now().UnixMilli()
 	case i.Tool == "pi":
+		if i.IsForkAwaitingStart {
+			command = i.consumeForkStartCommand()
+			sessionLog.Info("resume: none reason=fork_awaiting_start",
+				slog.String("instance_id", i.ID),
+				slog.String("path", i.ProjectPath),
+				slog.String("reason", "fork_awaiting_start"))
+			break
+		}
 		command = i.buildPiCommand(i.Command)
 	case i.Tool == "copilot":
 		command = i.buildCopilotCommand(i.Command)
@@ -3001,11 +3053,10 @@ func (i *Instance) StartWithMessage(message string) error {
 	case IsClaudeCompatible(i.Tool):
 		// #745 fork guard: mirrors the Start() branch above. A fork target
 		// that arrives through StartWithMessage must also bypass the
-		// resume/fresh dispatch and run i.Command verbatim, or the
-		// --resume <parent>/--fork-session flags are silently dropped.
+		// resume/fresh dispatch and run its first-start command verbatim, or
+		// the --resume <parent>/--fork-session flags are silently dropped.
 		if i.IsForkAwaitingStart {
-			command = i.Command
-			i.IsForkAwaitingStart = false
+			command = i.consumeForkStartCommand()
 			sessionLog.Info("resume: none reason=fork_awaiting_start",
 				slog.String("instance_id", i.ID),
 				slog.String("path", i.ProjectPath),
@@ -3047,6 +3098,14 @@ func (i *Instance) StartWithMessage(message string) error {
 		command = i.buildCodexCommand(i.Command)
 		i.CodexStartedAt = time.Now().UnixMilli()
 	case i.Tool == "pi":
+		if i.IsForkAwaitingStart {
+			command = i.consumeForkStartCommand()
+			sessionLog.Info("resume: none reason=fork_awaiting_start",
+				slog.String("instance_id", i.ID),
+				slog.String("path", i.ProjectPath),
+				slog.String("reason", "fork_awaiting_start"))
+			break
+		}
 		command = i.buildPiCommand(i.Command)
 	case i.Tool == "copilot":
 		command = i.buildCopilotCommand(i.Command)
@@ -6005,6 +6064,12 @@ func (i *Instance) CanFork() bool {
 		return i.CanForkOpenCode()
 	}
 
+	// Pi sessions fork by source JSONL path under Agent Deck's per-instance
+	// Pi session directory. The launch command validates that a JSONL exists.
+	if i.Tool == "pi" {
+		return i.CanForkPi()
+	}
+
 	// Claude sessions can fork if session ID is recent
 	if i.ClaudeSessionID == "" {
 		return false
@@ -6015,6 +6080,41 @@ func (i *Instance) CanFork() bool {
 // CanForkOpenCode returns true if this OpenCode session can be forked
 func (i *Instance) CanForkOpenCode() bool {
 	return i.Tool == "opencode" && i.OpenCodeSessionID != "" && time.Since(i.OpenCodeDetectedAt) < 5*time.Minute
+}
+
+// CanForkPi returns true if this Pi session can be forked by Agent Deck.
+func (i *Instance) CanForkPi() bool {
+	if i.Tool != "pi" || i.ID == "" {
+		return false
+	}
+	// For local non-sandboxed Pi sessions, require an actual source JSONL so
+	// CLI/TUI fork attempts fail before creating an immediately-dead child tmux
+	// pane. Remote/sandboxed sessions use target-side $HOME, which this process
+	// cannot inspect, so the launch command performs the runtime validation.
+	if i.SSHHost == "" && !i.IsSandboxed() {
+		return i.hasLocalPiSessionFile()
+	}
+	return true
+}
+
+func (i *Instance) hasLocalPiSessionFile() bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	sessionDir := filepath.Join(home, ".pi", "agent-deck", i.ID)
+	found := false
+	_ = filepath.WalkDir(sessionDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d == nil || d.IsDir() {
+			return nil
+		}
+		if strings.EqualFold(filepath.Ext(path), ".jsonl") {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return found
 }
 
 // Fork returns the command to create a forked Claude session
@@ -6273,6 +6373,55 @@ func (i *Instance) CreateForkedOpenCodeInstanceWithOptions(
 		if err := forked.SetOpenCodeOptions(opts); err != nil {
 			sessionLog.Warn("set_opencode_options_failed", slog.String("error", err.Error()))
 		}
+	}
+
+	return forked, cmd, nil
+}
+
+// CreateForkedPiInstance creates a new Instance configured for forking a Pi session.
+// Deprecated: Use CreateForkedPiInstanceWithOptions instead.
+func (i *Instance) CreateForkedPiInstance(newTitle, newGroupPath string) (*Instance, string, error) {
+	return i.CreateForkedPiInstanceWithOptions(newTitle, newGroupPath, nil)
+}
+
+// CreateForkedPiInstanceWithOptions creates a new Instance configured for forking a Pi session.
+// The opts parameter is accepted for the shared fork worktree flow; only WorkDir
+// and Worktree* fields are consumed for Pi.
+func (i *Instance) CreateForkedPiInstanceWithOptions(
+	newTitle, newGroupPath string,
+	opts *ClaudeOptions,
+) (*Instance, string, error) {
+	projectPath := i.ProjectPath
+	if opts != nil && opts.WorkDir != "" {
+		projectPath = opts.WorkDir
+	}
+
+	forked := NewInstance(newTitle, projectPath)
+	if newGroupPath != "" {
+		forked.GroupPath = newGroupPath
+	} else {
+		forked.GroupPath = i.GroupPath
+	}
+	forked.Tool = "pi"
+	forked.Wrapper = i.Wrapper
+
+	baseCommand := strings.TrimSpace(i.Command)
+	if baseCommand == "" {
+		baseCommand = "pi"
+	}
+	forked.Command = baseCommand
+
+	cmd, err := i.buildPiForkCommandForTarget(forked, baseCommand)
+	if err != nil {
+		return nil, "", err
+	}
+	forked.ForkStartCommand = cmd
+	forked.IsForkAwaitingStart = true
+
+	if opts != nil && opts.WorktreePath != "" {
+		forked.WorktreePath = opts.WorktreePath
+		forked.WorktreeRepoRoot = opts.WorktreeRepoRoot
+		forked.WorktreeBranch = opts.WorktreeBranch
 	}
 
 	return forked, cmd, nil

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -2234,6 +2234,24 @@ func TestInstance_CanFork_OpenCode(t *testing.T) {
 	}
 }
 
+func TestInstance_CanFork_Pi(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	inst := NewInstanceWithTool("test", "/tmp/test", "pi")
+	if inst.CanFork() {
+		t.Error("CanFork() should be false for local Pi sessions before a source JSONL exists")
+	}
+
+	seedLocalPiSessionFile(t, inst)
+	if !inst.CanFork() {
+		t.Error("CanFork() should be true for Pi sessions with Agent Deck Pi JSONL history")
+	}
+
+	inst.ID = ""
+	if inst.CanFork() {
+		t.Error("CanFork() should be false for Pi without an Agent Deck instance ID")
+	}
+}
+
 func TestInstance_CanRestartFresh(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -254,7 +254,7 @@ func (h *HelpOverlay) View() string {
 				{reorderUpKeys, "Reorder up (auto-promote at edge)"},
 				{reorderDownKeys, "Reorder down (auto-promote at edge)"},
 				{indentKeys, "Indent / outdent (in group)"},
-				{forkKeys, "Fork session (Claude only)"},
+				{forkKeys, "Fork session (Claude/Pi)"},
 				{copyKey, "Copy output to clipboard"},
 				{"C", "Copy preview info (Repo / Path / Branch)"},
 				{sendKey, "Send output to session"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6756,7 +6756,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "f":
 		// Quick fork session (same title with " (fork)" suffix)
-		// Only available when session has a valid Claude session ID
+		// Only available when the selected tool supports Agent Deck forking
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil {
@@ -6774,7 +6774,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "F", "shift+f":
 		// Fork with dialog (customize title and group)
-		// Only available when session has a valid Claude session ID
+		// Only available when the selected tool supports Agent Deck forking
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil {
@@ -9399,7 +9399,7 @@ func (h *Home) forkSessionCmd(source *session.Instance, title, groupPath, parent
 	return h.forkSessionCmdWithOptions(source, title, groupPath, nil, false, parentSessionID, parentProjectPath)
 }
 
-// forkSessionCmdWithOptions creates a forked session with the given title, group, Claude options, and optional sandbox.
+// forkSessionCmdWithOptions creates a forked session with the given title, group, shared fork options, and optional sandbox.
 // Shows immediate UI feedback by tracking the source session in forkingSessions.
 func (h *Home) forkSessionCmdWithOptions(
 	source *session.Instance,
@@ -9453,6 +9453,8 @@ func (h *Home) forkSessionCmdWithOptions(
 		switch source.Tool {
 		case "opencode":
 			inst, _, err = source.CreateForkedOpenCodeInstance(title, groupPath)
+		case "pi":
+			inst, _, err = source.CreateForkedPiInstanceWithOptions(title, groupPath, opts)
 		default:
 			inst, _, err = source.CreateForkedInstanceWithOptions(title, groupPath, opts)
 		}
@@ -11817,7 +11819,7 @@ func (h *Home) renderHelpBarFull() string {
 			if item.Session != nil && item.Session.CanRestartFresh() && restartFreshKey != "" {
 				primaryHints = append(primaryHints, h.helpKey(restartFreshKey, "Restart Fresh"))
 			}
-			// Only show fork hints if session has a valid Claude session ID
+			// Only show fork hints when the selected tool supports Agent Deck forking.
 			if item.Session != nil && item.Session.CanFork() {
 				if forkKeys != "" {
 					primaryHints = append(primaryHints, h.helpKey(forkKeys, "Fork"))

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -229,9 +229,7 @@ func (m *WebMutator) pushUndo(inst *session.Instance) {
 	}
 }
 
-// ForkSession forks an existing session using the proper Claude resume command.
-// It uses CreateForkedInstanceWithOptions which builds "claude --resume <session-id>"
-// via buildClaudeForkCommandForTarget, ensuring the fork resumes the parent conversation.
+// ForkSession forks an existing session using the proper tool-specific fork command.
 func (m *WebMutator) ForkSession(id string) (string, error) {
 	m.h.instancesMu.RLock()
 	parent := m.h.instanceByID[id]
@@ -240,9 +238,18 @@ func (m *WebMutator) ForkSession(id string) (string, error) {
 		return "", fmt.Errorf("session not found: %s", id)
 	}
 
-	forked, _, err := parent.CreateForkedInstanceWithOptions(
-		parent.Title+" (fork)", parent.GroupPath, nil,
-	)
+	var forked *session.Instance
+	var err error
+	switch parent.Tool {
+	case "opencode":
+		forked, _, err = parent.CreateForkedOpenCodeInstance(parent.Title+" (fork)", parent.GroupPath)
+	case "pi":
+		forked, _, err = parent.CreateForkedPiInstance(parent.Title+" (fork)", parent.GroupPath)
+	default:
+		forked, _, err = parent.CreateForkedInstanceWithOptions(
+			parent.Title+" (fork)", parent.GroupPath, nil,
+		)
+	}
 	if err != nil {
 		return "", fmt.Errorf("fork session: %w", err)
 	}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -82,7 +82,7 @@ One terminal. All your agents. Complete visibility.
 
 ### Fork Sessions
 
-Try different approaches without losing context. Fork any Claude conversation instantly. Each fork inherits the full conversation history.
+Try different approaches without losing context. Fork Claude conversations and Pi sessions instantly. Each fork inherits the parent conversation history through the tool's native fork support.
 
 - Press `f` for quick fork, `F` to customize name/group
 - Fork your forks to explore as many branches as you need
@@ -207,7 +207,7 @@ See [Troubleshooting](skills/agent-deck/references/troubleshooting.md#uninstalli
 ```bash
 agent-deck                        # Launch TUI
 agent-deck add . -c claude        # Add current dir with Claude
-agent-deck session fork my-proj   # Fork a Claude session
+agent-deck session fork my-proj   # Fork a Claude/Pi session
 agent-deck mcp attach my-proj exa # Attach MCP to session
 ```
 
@@ -364,7 +364,7 @@ agent-deck session output "Project"
 | `agent-deck session send <name> "message"` | Send message |
 | `agent-deck session output <name>` | Get last response |
 | `agent-deck session current [-q\|--json]` | Auto-detect current session |
-| `agent-deck session fork <name>` | Fork Claude conversation |
+| `agent-deck session fork <name>` | Fork Claude/Pi conversation |
 | `agent-deck mcp list` | List available MCPs |
 | `agent-deck mcp attach <name> <mcp>` | Attach MCP (then restart) |
 | `agent-deck status` | Quick status summary |
@@ -487,7 +487,7 @@ agent-deck remove "Codex Review" && agent-deck remove "Gemini Arch"
 | `r/R` | Restart (reloads MCPs) |
 | `m` | MCP Manager |
 | `s` | Skills Manager (Claude) |
-| `f/F` | Fork Claude session |
+| `f/F` | Fork Claude/Pi session |
 | `d` | Delete |
 | `M` | Move to group |
 
@@ -755,17 +755,17 @@ agent-deck session restart <id|title>
 
 Reloads MCPs without losing conversation (Claude/Gemini).
 
-### session fork (Claude only)
+### session fork (Claude and Pi)
 
 ```bash
 agent-deck session fork <id|title> [-t "title"] [-g "group"]
 ```
 
-Creates new session with same Claude conversation.
+Creates a new session with the same conversation context for supported tools.
 
 **Requirements:**
-- Session must be Claude tool
-- Must have valid Claude session ID
+- Claude sessions must have a valid Claude session ID
+- Pi sessions use Agent Deck's per-instance Pi session directory and Pi's native `pi --fork`
 
 ### session attach
 
@@ -1293,7 +1293,7 @@ Common issues and solutions for agent-deck.
 | MCPs not loading | `agent-deck session restart <name>` |
 | CLI changes not in TUI | Press `Ctrl+R` to refresh |
 | Flag not working | Put flags BEFORE arguments |
-| Fork fails | Check session has valid Claude session ID |
+| Fork fails | Check Claude session has a valid session ID, or Pi session has JSONL history under Agent Deck's Pi session dir |
 | Status stuck | Wait 2 seconds or press `u` to mark unread |
 
 ## Common Issues
@@ -1569,8 +1569,8 @@ Complete reference for agent-deck Terminal UI features.
 | `s` | Open Skills Manager (Claude) |
 | `d` | Delete session or group |
 | `u` | Mark unread (idle -> waiting) |
-| `f` | Quick fork (Claude only) |
-| `F` | Fork with options (Claude only) |
+| `f` | Quick fork (Claude/Pi) |
+| `F` | Fork with options (Claude/Pi) |
 
 ### Group Actions
 

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -88,7 +88,7 @@ Status legend: ✅ verified, 🟡 partial, 🔴 known broken, ⚪ unknown. To up
 | `agent-deck session send <name> "message"` | Send message |
 | `agent-deck session output <name>` | Get last response |
 | `agent-deck session current [-q\|--json]` | Auto-detect current session |
-| `agent-deck session fork <name>` | Fork Claude conversation |
+| `agent-deck session fork <name>` | Fork Claude/Pi conversation |
 | `agent-deck mcp list` | List available MCPs |
 | `agent-deck mcp attach <name> <mcp>` | Attach MCP (then restart) |
 | `agent-deck status` | Quick status summary |
@@ -346,7 +346,7 @@ Key constraints:
 | `r/R` | Restart (reloads MCPs) |
 | `m` | MCP Manager |
 | `s` | Skills Manager |
-| `f/F` | Fork Claude session |
+| `f/F` | Fork Claude/Pi session |
 | `d` | Delete |
 | `M` | Move to group |
 

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -146,17 +146,17 @@ agent-deck session restart <id|title>
 
 Reloads MCPs without losing conversation (Claude/Gemini).
 
-### session fork (Claude only)
+### session fork (Claude and Pi)
 
 ```bash
 agent-deck session fork <id|title> [-t "title"] [-g "group"]
 ```
 
-Creates new session with same Claude conversation.
+Creates a new session with the same conversation context for supported tools.
 
 **Requirements:**
-- Session must be Claude tool
-- Must have valid Claude session ID
+- Claude sessions must have a valid Claude session ID
+- Pi sessions use Agent Deck's per-instance Pi session directory and Pi's native `pi --fork`
 
 ### session attach
 

--- a/skills/agent-deck/references/troubleshooting.md
+++ b/skills/agent-deck/references/troubleshooting.md
@@ -10,7 +10,7 @@ Common issues and solutions for agent-deck.
 | MCPs not loading | `agent-deck session restart <name>` |
 | CLI changes not in TUI | Press `Ctrl+R` to refresh |
 | Flag not working | Put flags BEFORE arguments |
-| Fork fails | Check session has valid Claude session ID |
+| Fork fails | Check Claude session has a valid session ID, or Pi session has JSONL history under Agent Deck's Pi session dir |
 | Status stuck | Wait 2 seconds or press `u` to mark unread |
 
 ## Common Issues

--- a/skills/agent-deck/references/tui-reference.md
+++ b/skills/agent-deck/references/tui-reference.md
@@ -30,8 +30,8 @@ Complete reference for agent-deck Terminal UI features.
 | `s` | Open Skills Manager |
 | `d` | Delete session or group |
 | `u` | Mark unread (idle -> waiting) |
-| `f` | Quick fork (Claude only) |
-| `F` | Fork with options (Claude only) |
+| `f` | Quick fork (Claude/Pi) |
+| `F` | Fork with options (Claude/Pi) |
 
 ### Group Actions
 

--- a/tests/capability/lifecycle_test.go
+++ b/tests/capability/lifecycle_test.go
@@ -178,13 +178,13 @@ func TestCapability_Lifecycle_Rm(t *testing.T) {
 		c.run(t, "list"))
 }
 
-// TestCapability_Lifecycle_Fork proves the fork precondition guard: forking a
-// non-Claude session is refused with a clear error and creates no child row.
+// TestCapability_Lifecycle_Fork proves the fork precondition guard: forking an
+// unsupported session is refused with a clear error and creates no child row.
 //
-// The full happy path (a fork that inherits a real Claude conversation, gets a
-// distinct id, and links ParentSessionID) needs a real ClaudeSessionID from a
-// live claude transcript, which is non-deterministic and key-gated. That path
-// is a documented Tier N gap. See docs/testing/capability-gaps.md.
+// The full happy paths (forks that inherit real Claude/Pi conversations, get a
+// distinct id, and link ParentSessionID) need real tool session data, which is
+// non-deterministic and key/tool-gated. Those paths are documented Tier N gaps.
+// See docs/testing/capability-gaps.md.
 func TestCapability_Lifecycle_Fork(t *testing.T) {
 	c := newCapSandbox(t)
 	c.run(t, "add", "-c", "bash", "-t", "cap-fork", c.WorkDir)
@@ -200,7 +200,7 @@ func TestCapability_Lifecycle_Fork(t *testing.T) {
 		t.Fatalf("a refused fork must not create a child registry row")
 	}
 
-	// Display proof: the precondition guard refusing to fork a non-Claude
+	// Display proof: the precondition guard refusing to fork an unsupported
 	// session.
 	snapshot(t, "fork", "$ agent-deck session fork cap-fork\n"+strings.TrimRight(out, "\n"))
 }


### PR DESCRIPTION
## Summary

Adds native Pi session forking to Agent Deck. Previously, the TUI and CLI fork flows only reached Claude/OpenCode-specific implementations, so built-in Pi sessions could resume via `--continue` but could not branch conversation history. This changes the shared fork paths to support Pi by locating the parent Agent Deck Pi JSONL and launching the child with `pi --fork <source-jsonl> --session-dir <child-dir>`.

## Change log

- Pi fork support: `agent-deck session fork` now accepts built-in Pi sessions and creates forked Pi instances with native `pi --fork` semantics.
- TUI/Web routing: fork shortcuts and web fork actions route Pi sessions through the Pi fork builder while preserving existing Claude/OpenCode behavior.
- Restart safety: forked Pi sessions persist the normal base Pi command so the first launch forks, while later restarts use Agent Deck's existing `--continue --session-dir` flow instead of replaying `--fork`.
- Docs/tests: updated fork documentation and capability gap wording for Claude/Pi support, plus regression coverage for Pi fork command construction, forkability, and CLI routing.

## Tests

- `go test -race ./internal/session ./cmd/agent-deck ./internal/ui -run 'Test(CreateForkedPi|BuildPi|CanRestartPi|Instance_CanFork_Pi|SessionFork_Pi|Regression745|RenderHelpBarCompactWithSession)' -count=1`
- `go test ./cmd/agent-deck -run 'TestSessionFork' -count=1`
- `go test ./internal/session -run 'Test(CreateForkedPi|BuildPi|CanRestartPi|Instance_CanFork_Pi|Regression745)' -count=1`
- `go test ./internal/ui -run 'Fork|TestRenderHelpBarCompactWithSession' -count=1`
- `go test -tags capability_e2e ./tests/capability -run TestCapability_Lifecycle_Fork -count=1`
- `make build`


- Sent by Denis' Pi agent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session forking now supports both Claude and Pi tools (previously Claude-only).
  * Tool-specific fork handling tailored for each session type.

* **Documentation**
  * Updated help text and UI overlays to reflect Claude/Pi fork support.
  * Clarified fork requirements and error messaging for unsupported session types.
  * Expanded capability documentation with Pi-specific fork prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->