### PR TITLE
fix(tui): address PR #1291 review feedback (fork-with-state)

### DIFF
--- a/internal/ui/fork_state_submit_test.go
+++ b/internal/ui/fork_state_submit_test.go
@@ -139,8 +139,8 @@ func TestForkWithStateWorktree_ReportsManualCleanupWhenCleanupFails(t *testing.T
 	if err == nil || !strings.Contains(err.Error(), "manual cleanup required") {
 		t.Fatalf("error = %v, want manual cleanup hint", err)
 	}
-	if !strings.Contains(err.Error(), "git -C repo branch -D fork/state") {
-		t.Fatalf("error = %v, want branch deletion hint", err)
+	if !strings.Contains(err.Error(), `git -C "repo" branch -D "fork/state"`) {
+		t.Fatalf("error = %v, want quoted branch deletion hint", err)
 	}
 }
 
@@ -229,5 +229,74 @@ func TestForkSessionCmdWithOptions_WithStateRejectsNonGitBeforeGitDirectCalls(t 
 	}
 	if reject > validate {
 		t.Fatalf("non-git rejection must happen before git-direct helper call; reject=%d helper=%d", reject, validate)
+	}
+}
+
+func TestForkWithStateWorktree_FailsClosedWhenDetectErrors(t *testing.T) {
+	var created bool
+	deps := defaultForkWithStateWorktreeDeps()
+	deps.statPath = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	deps.mkdirAll = func(string, os.FileMode) error { return nil }
+	deps.validateDestination = func(string, string) error { return nil }
+	deps.detectInProgressOperation = func(string) (string, error) {
+		return "", errors.New("probe boom")
+	}
+	deps.createAtStartPoint = func(string, string, string, string) (bool, error) {
+		created = true
+		return true, nil
+	}
+
+	err := forkWithStateWorktree("parent", "repo", "fork-path", "fork/state", git.WorktreeStateOptions{WithState: true}, deps)
+	if err == nil || !strings.Contains(err.Error(), "failed to inspect parent session state") {
+		t.Fatalf("error = %v, want fail-closed inspect error", err)
+	}
+	if created {
+		t.Fatal("CreateWorktreeAtStartPoint must not run when the mid-op probe errors")
+	}
+}
+
+func TestForkSessionCmdWithOptions_RollsBackWorktreeOnPostHelperFailure(t *testing.T) {
+	srcBytes, err := os.ReadFile("home.go")
+	if err != nil {
+		t.Fatalf("read home.go: %v", err)
+	}
+	src := string(srcBytes)
+
+	helper := strings.Index(src, "if err := forkWithStateWorktree(")
+	rollbackHelperDef := strings.Index(src, "func rollbackForkWithStateWorktree(")
+	if helper < 0 {
+		t.Fatal("with-state path must call forkWithStateWorktree")
+	}
+	if rollbackHelperDef < 0 {
+		t.Fatal("rollbackForkWithStateWorktree helper must exist")
+	}
+
+	// The instance-create failure return and the Start() failure return both
+	// live after the helper succeeds; each must roll back the new worktree+branch
+	// when forkState.WithState is set. Search within the post-helper tail so we
+	// don't match identical strings from unrelated earlier functions.
+	tail := src[helper:]
+	if !strings.Contains(tail, "cannot create forked instance") {
+		t.Fatal("post-helper instance-create failure path must exist after the helper call")
+	}
+	if !strings.Contains(tail, "if err := inst.Start(); err != nil {") {
+		t.Fatal("post-helper Start failure path must exist after the helper call")
+	}
+	if !strings.Contains(tail, "failed to create multi-repo dir") {
+		t.Fatal("post-helper multi-repo-dir failure path must exist after the helper call")
+	}
+
+	// Count rollback invocations after the helper call, excluding the helper's
+	// own definition. Every post-helper early return that leaves the new worktree
+	// behind must roll it back: instance-create, multi-repo-dir, and Start — three.
+	invocations := strings.Count(tail, "rollbackForkWithStateWorktree(opts.WorktreeRepoRoot")
+	if invocations < 3 {
+		t.Fatalf("rollbackForkWithStateWorktree must be invoked on all three post-helper failure paths (instance-create, multi-repo-dir, Start); found %d invocation(s)", invocations)
+	}
+	// Rollback must be gated on a flag set only after the helper actually creates
+	// the worktree, so the fallback path (with-state true but no worktree
+	// created) never dereferences empty opts fields.
+	if !strings.Contains(tail, "if withStateWorktreeCreated {") {
+		t.Fatal("rollback must be gated on withStateWorktreeCreated (only when a worktree was created)")
 	}
 }

--- a/internal/ui/forkdialog.go
+++ b/internal/ui/forkdialog.go
@@ -98,7 +98,7 @@ func (d *ForkDialog) focusTargets() []forkFocusTarget {
 	if d.hasConductors() {
 		targets = append(targets, forkFocusConductor)
 	}
-	if d.worktreeEnabled {
+	if d.worktreeCapable && d.worktreeEnabled {
 		targets = append(targets, forkFocusBranch, forkFocusCarryState)
 		if d.withStateEnabled {
 			targets = append(targets, forkFocusGitignored)
@@ -225,7 +225,7 @@ func (d *ForkDialog) Show(originalName, projectPath, groupPath string, conductor
 	if config, err := session.LoadUserConfig(); err == nil {
 		d.optionsPanel.SetDefaults(config)
 		d.sandboxEnabled = config.Docker.DefaultEnabled
-		d.worktreeEnabled = config.Worktree.DefaultEnabled
+		d.worktreeEnabled = d.worktreeCapable && config.Worktree.DefaultEnabled
 	}
 }
 
@@ -447,6 +447,20 @@ func (d *ForkDialog) Update(msg tea.Msg) (*ForkDialog, tea.Cmd) {
 			return d, nil
 
 		case "enter":
+			// Enter toggles a focused with-state checkbox (matches Space); on any
+			// other focus it submits.
+			switch d.currentFocus() {
+			case forkFocusCarryState:
+				d.ToggleWithState()
+				d.clampFocus()
+				d.updateFocus()
+				return d, nil
+			case forkFocusGitignored:
+				d.ToggleWithStateAndGitignored()
+				d.clampFocus()
+				d.updateFocus()
+				return d, nil
+			}
 			if d.nameInput.Value() != "" {
 				return d, nil // Signal completion
 			}

--- a/internal/ui/forkdialog_test.go
+++ b/internal/ui/forkdialog_test.go
@@ -68,6 +68,10 @@ func TestForkDialog_Show(t *testing.T) {
 }
 
 func TestForkDialog_Show_UsesConfiguredWorktreeDefault(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
 	tempDir := t.TempDir()
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tempDir)
@@ -86,8 +90,18 @@ func TestForkDialog_Show_UsesConfiguredWorktreeDefault(t *testing.T) {
 	}
 	session.ClearUserConfigCache()
 
+	// The config default only applies when the project is worktree-capable
+	// (F6), so use a real git repo as the project path.
+	projectPath := filepath.Join(tempDir, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll project: %v", err)
+	}
+	if err := exec.Command("git", "init", projectPath).Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
 	d := NewForkDialog()
-	d.Show("Original Session", "/path/to/project", "group/path", nil, "")
+	d.Show("Original Session", projectPath, "group/path", nil, "")
 
 	if !d.worktreeEnabled {
 		t.Error("worktreeEnabled should default to true from config on Show")
@@ -375,6 +389,7 @@ func TestForkDialog_Space_TogglesFocusedCarryState(t *testing.T) {
 	d := NewForkDialog()
 	d.SetSize(80, 40)
 	d.Show("T", "/p", "g", nil, "")
+	d.worktreeCapable = true
 	d.worktreeEnabled = true
 	d.setFocus(forkFocusCarryState)
 	if d.currentFocusName() != "carryState" {
@@ -390,6 +405,7 @@ func TestForkDialog_Space_TogglesFocusedGitignored(t *testing.T) {
 	d := NewForkDialog()
 	d.SetSize(80, 40)
 	d.Show("T", "/p", "g", nil, "")
+	d.worktreeCapable = true
 	d.worktreeEnabled = true
 	d.ToggleWithState()
 	d.setFocus(forkFocusGitignored)
@@ -429,6 +445,7 @@ func TestForkDialog_I_TypeableInBranchField(t *testing.T) {
 	d := NewForkDialog()
 	d.SetSize(80, 40)
 	d.Show("T", "/p", "g", nil, "")
+	d.worktreeCapable = true
 	d.worktreeEnabled = true
 	d.setFocus(forkFocusBranch)
 	d.branchInput.SetValue("")
@@ -529,6 +546,7 @@ func TestForkDialog_Focus_WorktreeOff_ShiftTabReverses(t *testing.T) {
 func TestForkDialog_Focus_WorktreeOn_WithStateOff_TabOrder(t *testing.T) {
 	d := NewForkDialog()
 	d.Show("Test", "/path", "group", nil, "")
+	d.worktreeCapable = true
 	d.worktreeEnabled = true
 
 	tab := tea.KeyMsg{Type: tea.KeyTab}
@@ -542,6 +560,7 @@ func TestForkDialog_Focus_WorktreeOn_WithStateOff_TabOrder(t *testing.T) {
 func TestForkDialog_Focus_WorktreeOn_WithStateOn_TabOrder(t *testing.T) {
 	d := NewForkDialog()
 	d.Show("Test", "/path", "group", nil, "")
+	d.worktreeCapable = true
 	d.worktreeEnabled = true
 	d.ToggleWithState()
 	if !d.IsWithStateEnabled() {
@@ -574,6 +593,7 @@ func TestForkDialog_Focus_Conductor_WorktreeOn_Order(t *testing.T) {
 	cs := []*session.Instance{forkConductorInstance("id-1", "alpha", "/a")}
 	d := NewForkDialog()
 	d.Show("Test", "/path", "group", cs, "")
+	d.worktreeCapable = true
 	d.worktreeEnabled = true
 
 	tab := tea.KeyMsg{Type: tea.KeyTab}
@@ -587,6 +607,7 @@ func TestForkDialog_Focus_Conductor_WorktreeOn_Order(t *testing.T) {
 func TestForkDialog_Focus_DanglingIndexReadsSafely(t *testing.T) {
 	d := NewForkDialog()
 	d.Show("Test", "/path", "group", nil, "")
+	d.worktreeCapable = true
 	d.worktreeEnabled = true
 
 	// Land focus on carryState (a worktree-only target).
@@ -637,4 +658,89 @@ func equalStrs(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// F6: a dialog that is not worktree-capable must never expose worktree focus
+// stops, even if worktreeEnabled was somehow set true.
+func TestForkDialog_Focus_NonCapableHidesWorktreeTargets(t *testing.T) {
+	d := NewForkDialog()
+	d.Show("Test", "/path", "group", nil, "")
+	d.worktreeCapable = false
+	d.worktreeEnabled = true
+	d.withStateEnabled = true
+
+	for _, target := range d.focusTargets() {
+		switch target {
+		case forkFocusBranch, forkFocusCarryState, forkFocusGitignored:
+			t.Fatalf("non-capable dialog exposed worktree focus target %v", target)
+		}
+	}
+
+	// Tab-walking must also never land on a worktree stop.
+	tab := tea.KeyMsg{Type: tea.KeyTab}
+	got := tabOrder(d, tab, len(d.focusTargets()))
+	for _, name := range got {
+		if name == "branch" || name == "carryState" || name == "gitignored" {
+			t.Fatalf("tab walk reached worktree stop %q on non-capable dialog: %v", name, got)
+		}
+	}
+}
+
+// F7/F10: Enter on a focused carry-state checkbox toggles it (does not submit).
+func TestForkDialog_Enter_TogglesFocusedCarryState(t *testing.T) {
+	d := NewForkDialog()
+	d.SetSize(80, 40)
+	d.Show("T", "/p", "g", nil, "")
+	d.worktreeCapable = true
+	d.worktreeEnabled = true
+	d.setFocus(forkFocusCarryState)
+	if d.currentFocusName() != "carryState" {
+		t.Fatalf("precondition: focus should be carryState, got %s", d.currentFocusName())
+	}
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !d.IsWithStateEnabled() {
+		t.Error("Enter on carryState should enable with-state")
+	}
+}
+
+// F7/F10: Enter on a focused include-gitignored checkbox toggles it.
+func TestForkDialog_Enter_TogglesFocusedGitignored(t *testing.T) {
+	d := NewForkDialog()
+	d.SetSize(80, 40)
+	d.Show("T", "/p", "g", nil, "")
+	d.worktreeCapable = true
+	d.worktreeEnabled = true
+	d.ToggleWithState()
+	d.setFocus(forkFocusGitignored)
+	if d.currentFocusName() != "gitignored" {
+		t.Fatalf("precondition: focus should be gitignored, got %s", d.currentFocusName())
+	}
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !d.IsWithStateAndGitignoredEnabled() {
+		t.Error("Enter on gitignored should enable gitignored")
+	}
+}
+
+// F7/F10: Enter on the name field still submits and does not toggle with-state.
+func TestForkDialog_Enter_OnNameStillSubmits(t *testing.T) {
+	d := NewForkDialog()
+	d.SetSize(80, 40)
+	d.Show("T", "/p", "g", nil, "")
+	d.worktreeCapable = true
+	d.worktreeEnabled = true
+	d.setFocus(forkFocusName)
+
+	updated, cmd := d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if updated == nil {
+		t.Fatal("Enter on name must return a non-nil model (signal completion)")
+	}
+	if cmd != nil {
+		t.Error("Enter on name should signal completion with a nil cmd, as before")
+	}
+	if updated.IsWithStateEnabled() {
+		t.Error("Enter on name must not toggle with-state")
+	}
+	if !updated.IsVisible() {
+		t.Error("Enter on name must not hide the dialog (submit is handled by the caller)")
+	}
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9466,6 +9466,11 @@ func (h *Home) forkSessionCmdWithOptions(
 			return sessionForkedMsg{err: fmt.Errorf("cannot fork session: %w", err), sourceID: sourceID}
 		}
 
+		// withStateWorktreeCreated tracks whether forkWithStateWorktree actually
+		// created a new worktree+branch, so later failures can roll it back
+		// without dereferencing opts when no worktree was created (e.g. the
+		// #1185 config-default fallback leaves the worktree fields empty).
+		withStateWorktreeCreated := false
 		if opts != nil && opts.WorktreePath != "" && opts.WorktreeRepoRoot != "" && opts.WorktreeBranch != "" {
 			// Worktree creation can be slow on large repos; keep it in async cmd path
 			// so the TUI remains responsive.
@@ -9493,6 +9498,7 @@ func (h *Home) forkSessionCmdWithOptions(
 				); err != nil {
 					return sessionForkedMsg{err: err, sourceID: sourceID}
 				}
+				withStateWorktreeCreated = true
 			} else if existingPath, err := backend.GetWorktreeForBranch(opts.WorktreeBranch); err == nil && existingPath != "" {
 				uiLog.Info("worktree_reuse", slog.String("branch", opts.WorktreeBranch), slog.String("path", existingPath))
 				opts.WorktreePath = existingPath
@@ -9518,6 +9524,9 @@ func (h *Home) forkSessionCmdWithOptions(
 			inst, _, err = source.CreateForkedInstanceWithOptions(title, groupPath, opts)
 		}
 		if err != nil {
+			if withStateWorktreeCreated {
+				rollbackForkWithStateWorktree(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
+			}
 			return sessionForkedMsg{err: fmt.Errorf("cannot create forked instance: %w", err), sourceID: sourceID}
 		}
 
@@ -9538,6 +9547,9 @@ func (h *Home) forkSessionCmdWithOptions(
 			home, _ := os.UserHomeDir()
 			parentDir := filepath.Join(home, ".agent-deck", "multi-repo-worktrees", inst.ID[:8])
 			if mkErr := os.MkdirAll(parentDir, 0o755); mkErr != nil {
+				if withStateWorktreeCreated {
+					rollbackForkWithStateWorktree(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
+				}
 				return sessionForkedMsg{err: fmt.Errorf("failed to create multi-repo dir: %w", mkErr), sourceID: sourceID}
 			}
 			if resolved, evalErr := filepath.EvalSymlinks(parentDir); evalErr == nil {
@@ -9570,6 +9582,9 @@ func (h *Home) forkSessionCmdWithOptions(
 		}
 
 		if err := inst.Start(); err != nil {
+			if withStateWorktreeCreated {
+				rollbackForkWithStateWorktree(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
+			}
 			return sessionForkedMsg{err: err, sourceID: sourceID}
 		}
 
@@ -9579,6 +9594,19 @@ func (h *Home) forkSessionCmdWithOptions(
 		}
 
 		return sessionForkedMsg{instance: inst, sourceID: sourceID}
+	}
+}
+
+// rollbackForkWithStateWorktree best-effort removes a worktree and deletes the
+// branch created by forkWithStateWorktree, used when a later step (instance
+// create or start) fails after the helper already succeeded. Failures are
+// logged, not returned, so the caller's original error is preserved.
+func rollbackForkWithStateWorktree(repoRoot, worktreePath, branch string) {
+	if err := git.RemoveWorktree(repoRoot, worktreePath, true); err != nil {
+		uiLog.Warn("fork_with_state_rollback_worktree_failed", slog.String("path", worktreePath), slog.String("err", err.Error()))
+	}
+	if err := git.DeleteBranch(repoRoot, branch, true); err != nil {
+		uiLog.Warn("fork_with_state_rollback_branch_failed", slog.String("branch", branch), slog.String("err", err.Error()))
 	}
 }
 
@@ -9612,7 +9640,11 @@ func forkWithStateWorktree(parentPath, repoRoot, worktreePath, branch string, st
 	} else if !errors.Is(statErr, os.ErrNotExist) {
 		return fmt.Errorf("failed to stat worktree path: %w", statErr)
 	}
-	if kind, detectErr := deps.detectInProgressOperation(parentPath); detectErr == nil && kind != "" {
+	kind, detectErr := deps.detectInProgressOperation(parentPath)
+	if detectErr != nil {
+		return fmt.Errorf("failed to inspect parent session state: %w", detectErr)
+	}
+	if kind != "" {
 		abortCmd := map[string]string{
 			"rebase":      "git rebase --abort",
 			"merge":       "git merge --abort",
@@ -9620,7 +9652,7 @@ func forkWithStateWorktree(parentPath, repoRoot, worktreePath, branch string, st
 			"revert":      "git revert --abort",
 			"bisect":      "git bisect reset",
 		}[kind]
-		return fmt.Errorf("parent session is mid-%s; finish or abort the %s before forking with state (cd %s && %s)", kind, kind, parentPath, abortCmd)
+		return fmt.Errorf("parent session is mid-%s; finish or abort the %s before forking with state (cd %q && %s)", kind, kind, parentPath, abortCmd)
 	}
 	if err := deps.mkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
@@ -9651,9 +9683,9 @@ func forkWithStateWorktree(parentPath, repoRoot, worktreePath, branch string, st
 		}
 		branchHint := ""
 		if createdBranch {
-			branchHint = fmt.Sprintf(" && git -C %s branch -D %s", repoRoot, branch)
+			branchHint = fmt.Sprintf(" && git -C %q branch -D %q", repoRoot, branch)
 		}
-		return fmt.Errorf("failed to materialize parent state: %w; cleanup also failed (%s); manual cleanup required: rm -rf %s%s", err, strings.Join(cleanupErrs, "; "), worktreePath, branchHint)
+		return fmt.Errorf("failed to materialize parent state: %w; cleanup also failed (%s); manual cleanup required: rm -rf %q%s", err, strings.Join(cleanupErrs, "; "), worktreePath, branchHint)
 	}
 	if err := deps.processInclude(repoRoot, worktreePath, io.Discard); err != nil {
 		uiLog.Warn("fork_with_state_worktreeinclude_failed", slog.String("path", worktreePath), slog.String("err", err.Error()))


### PR DESCRIPTION
Follow-up to #1291 (fork-with-state TUI / PR-B), addressing the automated review (GitHub Copilot + CodeRabbit). Each finding was validated against the actual code; only genuine issues are fixed, the rest skipped with a reason.

## Fixed
- **Worktree leak on later failure** *(CodeRabbit, medium)* — `forkWithStateWorktree` creates the new worktree+branch, but a subsequent `CreateForkedInstanceWithOptions` / multi-repo-dir / `inst.Start()` failure returned without cleanup, leaking state (and colliding on retry). Added `rollbackForkWithStateWorktree`, gated on a `withStateWorktreeCreated` flag set only after the helper succeeds (so the #1185 config-default fallback, where `opts` worktree fields are empty, can't nil-deref). Wired into **all three** post-helper failure paths.
- **Invisible focus stops** *(CodeRabbit, medium)* — `Show()` default-enabled worktree from config even on non-worktree-capable repos, and `focusTargets()` then added branch/carry/gitignored stops the `View` never renders. Both now gated on `worktreeCapable && worktreeEnabled`.
- **Enter doesn't toggle a focused checkbox** *(CodeRabbit, medium)* — Enter now toggles a focused `carryState`/`gitignored` checkbox before submit, matching the Space/Enter design contract; Enter elsewhere still submits.
- **Fail closed on probe error** *(Copilot + CodeRabbit, low)* — return an error when `DetectInProgressOperation` fails instead of proceeding as if the parent repo were clean.
- **Copy/paste-safe error hints** *(Copilot, low)* — `%q`-quote `parentPath` / `repoRoot` / `worktreePath` / `branch` in the mid-op and manual-cleanup hint strings.

## Skipped (validated as not actionable)
- **`focusTargets()` allocation** *(Copilot)* — immaterial for a modal dialog that only renders while visible; no hot loop.
- **Empty `abortCmd` → "&& "** *(Copilot)* — unreachable: `DetectInProgressOperation` only ever returns the five kinds the `abortCmd` map covers.
- **RemoteSession coverage guideline** *(CodeRabbit)* — no such guideline exists in the repo, and the fork path only acts on `ItemTypeSession`, never remote sessions (hallucinated rule).

## Testing
TDD throughout: `NonCapableHidesWorktreeTargets`, `Enter_TogglesFocused{CarryState,Gitignored}`, `Enter_OnNameStillSubmits`, `FailsClosedWhenDetectErrors`, `RollsBackWorktreeOnPostHelperFailure` (asserts all 3 rollback paths), plus updated cleanup-hint / worktree-default assertions. Full `internal/ui` suite + `eval_smoke` TUI eval green with `-race`; `go build ./...`, `go vet`, `gofmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added rollback mechanism for incomplete with-state forks, automatically removing worktrees when subsequent fork steps fail
  * Improved detection of in-progress repository operations that would block forking

* **Enhancements**
  * With-state fork functionality now requires both project capability and user configuration to be enabled
  * Enter key in fork dialog now toggles carry-state and gitignored checkboxes instead of immediately submitting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->