### PR TITLE
refactor(tui): behavioral coverage for fork rollback paths (PR #1292 review)

### DIFF
--- a/internal/ui/fork_state_submit_test.go
+++ b/internal/ui/fork_state_submit_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
+	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
 func TestForkDialogSubmitCapturesWithStateBeforeHide(t *testing.T) {
@@ -255,48 +256,178 @@ func TestForkWithStateWorktree_FailsClosedWhenDetectErrors(t *testing.T) {
 	}
 }
 
-func TestForkSessionCmdWithOptions_RollsBackWorktreeOnPostHelperFailure(t *testing.T) {
-	srcBytes, err := os.ReadFile("home.go")
+// --- Behavioral tests for completeFork (review finding G1) ---
+//
+// These exercise the three post-helper rollback paths via the forkInstanceDeps
+// DI seam, replacing the brittle source-scanning rollback test. Fakes use a
+// source whose Tool is "" and sandboxEnabled=false / parentSessionID="" so no
+// real *session.Instance behavior runs.
+
+func newForkStateOpts() *session.ClaudeOptions {
+	return &session.ClaudeOptions{
+		WorktreeRepoRoot: "/repo/root",
+		WorktreePath:     "/repo/root/.worktrees/feature",
+		WorktreeBranch:   "feature",
+	}
+}
+
+type rollbackRecorder struct {
+	calls    int
+	repoRoot string
+	wtPath   string
+	branch   string
+}
+
+func (r *rollbackRecorder) fn(repoRoot, worktreePath, branch string) {
+	r.calls++
+	r.repoRoot = repoRoot
+	r.wtPath = worktreePath
+	r.branch = branch
+}
+
+func TestCompleteFork_RollsBackOnInstanceCreateFailure(t *testing.T) {
+	source := &session.Instance{}
+	opts := newForkStateOpts()
+	rec := &rollbackRecorder{}
+	createErr := errors.New("boom")
+
+	deps := forkInstanceDeps{
+		createInstance: func(_ *session.Instance, _, _ string, _ *session.ClaudeOptions) (*session.Instance, error) {
+			return nil, createErr
+		},
+		createMultiRepoDir: func(_, _ *session.Instance) error { return nil },
+		startInstance:      func(_ *session.Instance) error { return nil },
+		rollback:           rec.fn,
+	}
+
+	inst, err := completeFork(source, "title", "group", opts, false, "", "", true, deps)
+	if inst != nil {
+		t.Fatalf("expected nil instance on create failure, got %v", inst)
+	}
+	if err == nil || !strings.Contains(err.Error(), "cannot create forked instance") {
+		t.Fatalf("expected wrapped 'cannot create forked instance' error, got %v", err)
+	}
+	if rec.calls != 1 {
+		t.Fatalf("expected exactly one rollback, got %d", rec.calls)
+	}
+	if rec.repoRoot != opts.WorktreeRepoRoot || rec.wtPath != opts.WorktreePath || rec.branch != opts.WorktreeBranch {
+		t.Fatalf("rollback args mismatch: got (%q,%q,%q)", rec.repoRoot, rec.wtPath, rec.branch)
+	}
+}
+
+func TestCompleteFork_RollsBackOnMultiRepoDirFailure(t *testing.T) {
+	source := &session.Instance{}
+	opts := newForkStateOpts()
+	rec := &rollbackRecorder{}
+	fake := &session.Instance{}
+	mrErr := errors.New("failed to create multi-repo dir: disk full")
+
+	deps := forkInstanceDeps{
+		createInstance: func(_ *session.Instance, _, _ string, _ *session.ClaudeOptions) (*session.Instance, error) {
+			return fake, nil
+		},
+		createMultiRepoDir: func(_, _ *session.Instance) error { return mrErr },
+		startInstance:      func(_ *session.Instance) error { return nil },
+		rollback:           rec.fn,
+	}
+
+	inst, err := completeFork(source, "title", "group", opts, false, "", "", true, deps)
+	if inst != nil {
+		t.Fatalf("expected nil instance on multi-repo-dir failure, got %v", inst)
+	}
+	if err != mrErr {
+		t.Fatalf("expected bare multi-repo-dir error, got %v", err)
+	}
+	if rec.calls != 1 {
+		t.Fatalf("expected exactly one rollback, got %d", rec.calls)
+	}
+	if rec.repoRoot != opts.WorktreeRepoRoot || rec.wtPath != opts.WorktreePath || rec.branch != opts.WorktreeBranch {
+		t.Fatalf("rollback args mismatch: got (%q,%q,%q)", rec.repoRoot, rec.wtPath, rec.branch)
+	}
+}
+
+func TestCompleteFork_RollsBackOnStartFailure(t *testing.T) {
+	source := &session.Instance{}
+	opts := newForkStateOpts()
+	rec := &rollbackRecorder{}
+	fake := &session.Instance{}
+	startErr := errors.New("start failed")
+
+	deps := forkInstanceDeps{
+		createInstance: func(_ *session.Instance, _, _ string, _ *session.ClaudeOptions) (*session.Instance, error) {
+			return fake, nil
+		},
+		createMultiRepoDir: func(_, _ *session.Instance) error { return nil },
+		startInstance:      func(_ *session.Instance) error { return startErr },
+		rollback:           rec.fn,
+	}
+
+	inst, err := completeFork(source, "title", "group", opts, false, "", "", true, deps)
+	if inst != nil {
+		t.Fatalf("expected nil instance on start failure, got %v", inst)
+	}
+	if err != startErr {
+		t.Fatalf("expected bare start error, got %v", err)
+	}
+	if rec.calls != 1 {
+		t.Fatalf("expected exactly one rollback, got %d", rec.calls)
+	}
+	if rec.repoRoot != opts.WorktreeRepoRoot || rec.wtPath != opts.WorktreePath || rec.branch != opts.WorktreeBranch {
+		t.Fatalf("rollback args mismatch: got (%q,%q,%q)", rec.repoRoot, rec.wtPath, rec.branch)
+	}
+}
+
+func TestCompleteFork_NoRollbackOnSuccess(t *testing.T) {
+	source := &session.Instance{}
+	opts := newForkStateOpts()
+	rec := &rollbackRecorder{}
+	fake := &session.Instance{}
+
+	deps := forkInstanceDeps{
+		createInstance: func(_ *session.Instance, _, _ string, _ *session.ClaudeOptions) (*session.Instance, error) {
+			return fake, nil
+		},
+		createMultiRepoDir: func(_, _ *session.Instance) error { return nil },
+		startInstance:      func(_ *session.Instance) error { return nil },
+		rollback:           rec.fn,
+	}
+
+	inst, err := completeFork(source, "title", "group", opts, false, "", "", true, deps)
 	if err != nil {
-		t.Fatalf("read home.go: %v", err)
+		t.Fatalf("expected no error on success, got %v", err)
 	}
-	src := string(srcBytes)
+	if inst != fake {
+		t.Fatalf("expected returned instance to be the createInstance fake")
+	}
+	if rec.calls != 0 {
+		t.Fatalf("expected no rollback on success, got %d", rec.calls)
+	}
+}
 
-	helper := strings.Index(src, "if err := forkWithStateWorktree(")
-	rollbackHelperDef := strings.Index(src, "func rollbackForkWithStateWorktree(")
-	if helper < 0 {
-		t.Fatal("with-state path must call forkWithStateWorktree")
-	}
-	if rollbackHelperDef < 0 {
-		t.Fatal("rollbackForkWithStateWorktree helper must exist")
-	}
+func TestCompleteFork_NoRollbackWhenWorktreeNotCreated(t *testing.T) {
+	source := &session.Instance{}
+	rec := &rollbackRecorder{}
+	createErr := errors.New("boom")
 
-	// The instance-create failure return and the Start() failure return both
-	// live after the helper succeeds; each must roll back the new worktree+branch
-	// when forkState.WithState is set. Search within the post-helper tail so we
-	// don't match identical strings from unrelated earlier functions.
-	tail := src[helper:]
-	if !strings.Contains(tail, "cannot create forked instance") {
-		t.Fatal("post-helper instance-create failure path must exist after the helper call")
-	}
-	if !strings.Contains(tail, "if err := inst.Start(); err != nil {") {
-		t.Fatal("post-helper Start failure path must exist after the helper call")
-	}
-	if !strings.Contains(tail, "failed to create multi-repo dir") {
-		t.Fatal("post-helper multi-repo-dir failure path must exist after the helper call")
+	deps := forkInstanceDeps{
+		createInstance: func(_ *session.Instance, _, _ string, _ *session.ClaudeOptions) (*session.Instance, error) {
+			return nil, createErr
+		},
+		createMultiRepoDir: func(_, _ *session.Instance) error { return nil },
+		startInstance:      func(_ *session.Instance) error { return nil },
+		rollback:           rec.fn,
 	}
 
-	// Count rollback invocations after the helper call, excluding the helper's
-	// own definition. Every post-helper early return that leaves the new worktree
-	// behind must roll it back: instance-create, multi-repo-dir, and Start — three.
-	invocations := strings.Count(tail, "rollbackForkWithStateWorktree(opts.WorktreeRepoRoot")
-	if invocations < 3 {
-		t.Fatalf("rollbackForkWithStateWorktree must be invoked on all three post-helper failure paths (instance-create, multi-repo-dir, Start); found %d invocation(s)", invocations)
+	// withStateWorktreeCreated=false and a nil opts: the rollback gate must not
+	// fire, so opts is never dereferenced.
+	inst, err := completeFork(source, "title", "group", nil, false, "", "", false, deps)
+	if inst != nil {
+		t.Fatalf("expected nil instance on create failure, got %v", inst)
 	}
-	// Rollback must be gated on a flag set only after the helper actually creates
-	// the worktree, so the fallback path (with-state true but no worktree
-	// created) never dereferences empty opts fields.
-	if !strings.Contains(tail, "if withStateWorktreeCreated {") {
-		t.Fatal("rollback must be gated on withStateWorktreeCreated (only when a worktree was created)")
+	if err == nil || !strings.Contains(err.Error(), "cannot create forked instance") {
+		t.Fatalf("expected wrapped 'cannot create forked instance' error, got %v", err)
+	}
+	if rec.calls != 0 {
+		t.Fatalf("expected no rollback when worktree not created, got %d", rec.calls)
 	}
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9431,6 +9431,130 @@ func defaultForkWithStateWorktreeDeps() forkWithStateWorktreeDeps {
 	}
 }
 
+// forkInstanceDeps injects the post-helper instance-create/start/multi-repo and
+// rollback steps of forkSessionCmdWithOptions so the three rollback paths are
+// behaviorally testable (review finding G1).
+type forkInstanceDeps struct {
+	createInstance     func(source *session.Instance, title, groupPath string, opts *session.ClaudeOptions) (*session.Instance, error)
+	createMultiRepoDir func(inst, source *session.Instance) error
+	startInstance      func(inst *session.Instance) error
+	rollback           func(repoRoot, worktreePath, branch string)
+}
+
+func defaultForkInstanceDeps() forkInstanceDeps {
+	return forkInstanceDeps{
+		createInstance: func(source *session.Instance, title, groupPath string, opts *session.ClaudeOptions) (*session.Instance, error) {
+			var inst *session.Instance
+			var err error
+			switch source.Tool {
+			case "opencode":
+				inst, _, err = source.CreateForkedOpenCodeInstance(title, groupPath)
+			case "pi":
+				inst, _, err = source.CreateForkedPiInstanceWithOptions(title, groupPath, opts)
+			default:
+				inst, _, err = source.CreateForkedInstanceWithOptions(title, groupPath, opts)
+			}
+			return inst, err
+		},
+		createMultiRepoDir: func(inst, source *session.Instance) error {
+			// Propagate multi-repo config from source.
+			if source.IsMultiRepo() {
+				inst.MultiRepoEnabled = true
+				inst.AdditionalPaths = append([]string{}, source.AdditionalPaths...)
+				// Copy worktree tracking from source (shared worktrees)
+				if len(source.MultiRepoWorktrees) > 0 {
+					inst.MultiRepoWorktrees = append([]session.MultiRepoWorktree{}, source.MultiRepoWorktrees...)
+				}
+				// Create a new persistent dir for the fork with symlinks to shared worktrees
+				home, _ := os.UserHomeDir()
+				parentDir := filepath.Join(home, ".agent-deck", "multi-repo-worktrees", inst.ID[:8])
+				if mkErr := os.MkdirAll(parentDir, 0o755); mkErr != nil {
+					return fmt.Errorf("failed to create multi-repo dir: %w", mkErr)
+				}
+				if resolved, evalErr := filepath.EvalSymlinks(parentDir); evalErr == nil {
+					parentDir = resolved
+				}
+				inst.MultiRepoTempDir = parentDir
+				if inst.GetTmuxSession() != nil {
+					inst.GetTmuxSession().WorkDir = parentDir
+				}
+				// Recreate symlinks/entries in new parent dir pointing to source worktree paths
+				allPaths := inst.AllProjectPaths()
+				dirnames := session.DeduplicateDirnames(allPaths)
+				var newProjectPath string
+				var newAdditionalPaths []string
+				for i, p := range allPaths {
+					linkPath := filepath.Join(parentDir, dirnames[i])
+					_ = os.Symlink(p, linkPath)
+					if i == 0 {
+						newProjectPath = linkPath
+					} else {
+						newAdditionalPaths = append(newAdditionalPaths, linkPath)
+					}
+				}
+				inst.ProjectPath = newProjectPath
+				inst.AdditionalPaths = newAdditionalPaths
+			}
+			return nil
+		},
+		startInstance: func(inst *session.Instance) error { return inst.Start() },
+		rollback:      rollbackForkWithStateWorktree,
+	}
+}
+
+// completeFork performs the post-forkWithStateWorktree sequence: create the
+// forked instance, apply sandbox/multi-repo/parent config, and start it. On any
+// failure after a with-state worktree was created (withStateWorktreeCreated),
+// it rolls back the new worktree+branch. Free function: it needs nothing from
+// *Home.
+func completeFork(
+	source *session.Instance,
+	title, groupPath string,
+	opts *session.ClaudeOptions,
+	sandboxEnabled bool,
+	parentSessionID, parentProjectPath string,
+	withStateWorktreeCreated bool,
+	deps forkInstanceDeps,
+) (*session.Instance, error) {
+	inst, err := deps.createInstance(source, title, groupPath, opts)
+	if err != nil {
+		if withStateWorktreeCreated {
+			deps.rollback(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
+		}
+		return nil, fmt.Errorf("cannot create forked instance: %w", err)
+	}
+
+	// Apply sandbox config to forked instance.
+	if sandboxEnabled {
+		inst.Sandbox = session.NewSandboxConfig("")
+	}
+
+	if err := deps.createMultiRepoDir(inst, source); err != nil {
+		if withStateWorktreeCreated {
+			deps.rollback(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
+		}
+		return nil, err
+	}
+
+	if parentSessionID != "" {
+		inst.SetParentWithPath(parentSessionID, parentProjectPath)
+	}
+
+	if err := deps.startInstance(inst); err != nil {
+		if withStateWorktreeCreated {
+			deps.rollback(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
+		}
+		return nil, err
+	}
+
+	switch inst.Tool {
+	case "opencode":
+		go inst.DetectOpenCodeSession()
+	}
+
+	return inst, nil
+}
+
 // forkSessionCmd creates a forked session with the given title and group
 // Shows immediate UI feedback by tracking the source session in forkingSessions
 func (h *Home) forkSessionCmd(source *session.Instance, title, groupPath, parentSessionID, parentProjectPath string) tea.Cmd {
@@ -9512,85 +9636,9 @@ func (h *Home) forkSessionCmdWithOptions(
 			}
 		}
 
-		var inst *session.Instance
-		var err error
-
-		switch source.Tool {
-		case "opencode":
-			inst, _, err = source.CreateForkedOpenCodeInstance(title, groupPath)
-		case "pi":
-			inst, _, err = source.CreateForkedPiInstanceWithOptions(title, groupPath, opts)
-		default:
-			inst, _, err = source.CreateForkedInstanceWithOptions(title, groupPath, opts)
-		}
+		inst, err := completeFork(source, title, groupPath, opts, sandboxEnabled, parentSessionID, parentProjectPath, withStateWorktreeCreated, defaultForkInstanceDeps())
 		if err != nil {
-			if withStateWorktreeCreated {
-				rollbackForkWithStateWorktree(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
-			}
-			return sessionForkedMsg{err: fmt.Errorf("cannot create forked instance: %w", err), sourceID: sourceID}
-		}
-
-		// Apply sandbox config to forked instance.
-		if sandboxEnabled {
-			inst.Sandbox = session.NewSandboxConfig("")
-		}
-
-		// Propagate multi-repo config from source.
-		if source.IsMultiRepo() {
-			inst.MultiRepoEnabled = true
-			inst.AdditionalPaths = append([]string{}, source.AdditionalPaths...)
-			// Copy worktree tracking from source (shared worktrees)
-			if len(source.MultiRepoWorktrees) > 0 {
-				inst.MultiRepoWorktrees = append([]session.MultiRepoWorktree{}, source.MultiRepoWorktrees...)
-			}
-			// Create a new persistent dir for the fork with symlinks to shared worktrees
-			home, _ := os.UserHomeDir()
-			parentDir := filepath.Join(home, ".agent-deck", "multi-repo-worktrees", inst.ID[:8])
-			if mkErr := os.MkdirAll(parentDir, 0o755); mkErr != nil {
-				if withStateWorktreeCreated {
-					rollbackForkWithStateWorktree(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
-				}
-				return sessionForkedMsg{err: fmt.Errorf("failed to create multi-repo dir: %w", mkErr), sourceID: sourceID}
-			}
-			if resolved, evalErr := filepath.EvalSymlinks(parentDir); evalErr == nil {
-				parentDir = resolved
-			}
-			inst.MultiRepoTempDir = parentDir
-			if inst.GetTmuxSession() != nil {
-				inst.GetTmuxSession().WorkDir = parentDir
-			}
-			// Recreate symlinks/entries in new parent dir pointing to source worktree paths
-			allPaths := inst.AllProjectPaths()
-			dirnames := session.DeduplicateDirnames(allPaths)
-			var newProjectPath string
-			var newAdditionalPaths []string
-			for i, p := range allPaths {
-				linkPath := filepath.Join(parentDir, dirnames[i])
-				_ = os.Symlink(p, linkPath)
-				if i == 0 {
-					newProjectPath = linkPath
-				} else {
-					newAdditionalPaths = append(newAdditionalPaths, linkPath)
-				}
-			}
-			inst.ProjectPath = newProjectPath
-			inst.AdditionalPaths = newAdditionalPaths
-		}
-
-		if parentSessionID != "" {
-			inst.SetParentWithPath(parentSessionID, parentProjectPath)
-		}
-
-		if err := inst.Start(); err != nil {
-			if withStateWorktreeCreated {
-				rollbackForkWithStateWorktree(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
-			}
 			return sessionForkedMsg{err: err, sourceID: sourceID}
-		}
-
-		switch inst.Tool {
-		case "opencode":
-			go inst.DetectOpenCodeSession()
 		}
 
 		return sessionForkedMsg{instance: inst, sourceID: sourceID}


### PR DESCRIPTION
Addresses the automated review of #1292 (GitHub Copilot + CodeRabbit). Each of the 6 findings was validated against the actual code via a sub-agent pipeline (validate → explore solution → revalidate). **Only one was valid; the other five are false positives**, refuted with convention evidence below.

## Fixed — G1 (valid): behavioral coverage for the fork rollback paths
The rollback test asserted behavior by **scanning `home.go` source text** (brittle), and — more importantly — the three post-helper rollback paths had **no behavioral coverage**. They can't be tested through `forkSessionCmdWithOptions` because its `tea.Cmd` closure is gated on `tmux.IsTmuxAvailable()`.

Extracted a free function **`completeFork(...)`** with an injected **`forkInstanceDeps`** struct (`createInstance` / `createMultiRepoDir` / `startInstance` / `rollback`), mirroring the existing `forkWithStateWorktreeDeps` DI pattern in the same file. The extraction is **verbatim and behavior-preserving**: identical error wording, the multi-repo block and `opencode`/`pi`/`default` tool switch moved unchanged, `forkingSessions` untouched, zero runtime change.

Replaced the source-scan test with **five behavioral tests** proving rollback fires on each failure path (instance-create, multi-repo-dir, Start) with the correct `(repoRoot, worktreePath, branch)` args and `withStateWorktreeCreated` gating — and **not** on success or when no worktree was created. They use in-package fakes; no tmux/git/real fork.

## Validated as false positives (no change)
- **Stale-focus Enter toggle** *(Copilot)* — structurally unreachable: `currentFocus()` re-derives from `focusTargets()`, which only includes the with-state targets under `worktreeCapable && worktreeEnabled`; already covered by passing tests.
- **`slog.String` → `slog.Any`** *(Copilot)* — `slog.String("err", err.Error())` is the established convention (19:1); changing only these would *reduce* consistency.
- **External `git` in tests + skip** *(Copilot)* — capability detection (`IsGitRepoOrBareProjectRoot` → `git rev-parse`) shells out to real git; ~14 test files do the same; there is **no Go git library** in `go.mod` (only a gitignore parser). The `t.Skip` when git is missing is *more* defensive than the codebase norm.
- **RemoteSession skip-test "precedent"** *(CodeRabbit)* — the cited pattern is **n=1 and self-referential** (it exists only inside that one test's own comment; zero docs); the fork path is correctly `ItemTypeSession`-gated.

## Testing
TDD for `completeFork`; full `internal/ui` fork/dialog suite + `eval_smoke` TUI eval green with `-race`; `go build ./...`, `go vet`, `gofmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved fork rollback behavior testing using a more reliable approach, replacing brittle source-code scanning methods to accurately verify rollback scenarios.

* **Refactor**
  * Reorganized fork instance creation, configuration, and execution workflow into focused helper functions for improved code maintainability and clearer separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->