### PR TITLE
feat(tui): smoother keyboard navigation in the new-session dialog

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -242,6 +242,15 @@ type UISettings struct {
 	// display filter only — `agent-deck launch -c <tool>` still spawns a hidden
 	// tool.
 	ShowOnlyInstalledTools bool `toml:"show_only_installed_tools"`
+
+	// NewSessionEnterAdvances controls what Enter does on the free-text
+	// Name/Branch fields of the new-session dialog (PR #1295). Default false
+	// preserves today's behavior: Enter from Name/Branch submits the form. When
+	// true, Enter advances focus to the next field instead (so typing a name and
+	// pressing Enter no longer silently creates a session with all defaults), and
+	// Ctrl+S becomes the explicit submit shortcut. Ctrl+S submits in BOTH modes —
+	// it is strictly additive and always available regardless of this toggle.
+	NewSessionEnterAdvances bool `toml:"new_session_enter_advances"`
 }
 
 // DefaultPreviewPct is the default preview-pane width percentage.
@@ -316,6 +325,14 @@ func (u UISettings) GetRemoteSessionRefreshSecs() int {
 		return MaxRemoteSessionRefreshSecs
 	}
 	return val
+}
+
+// GetNewSessionEnterAdvances reports whether Enter on the new-session dialog's
+// free-text Name/Branch fields should advance focus (true) instead of
+// submitting the form (false). Default false preserves today's behavior
+// (Enter submits). Ctrl+S submits in both modes. See PR #1295.
+func (u UISettings) GetNewSessionEnterAdvances() bool {
+	return u.NewSessionEnterAdvances
 }
 
 // GetRemoteLatencyRefreshSecs returns the remote latency refresh interval

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5737,9 +5737,15 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, cmd
 	}
 
-	switch msg.String() {
-	case "enter":
-		if h.newDialog.shouldHandleEnterLocally() {
+	// Ctrl+S is an explicit "create now" shortcut that submits from any field,
+	// including Name/Branch where Enter advances focus instead of submitting.
+	// Route it through the same path as a submitting Enter by falling through to
+	// the submit block below.
+	submitNow := h.newDialog.WantsSubmit(msg)
+
+	switch {
+	case msg.String() == "enter" || submitNow:
+		if !submitNow && h.newDialog.shouldHandleEnterLocally() {
 			var cmd tea.Cmd
 			h.newDialog, cmd = h.newDialog.Update(msg)
 			return h, cmd
@@ -5867,7 +5873,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			tempID,
 		)
 
-	case "esc":
+	case msg.String() == "esc":
 		// #1162: when the model picker dropdown is open, Esc dismisses only the
 		// picker and keeps the new-session form alive (focus stays on the model
 		// field) rather than cancelling the whole flow. Forward to the dialog so

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -5751,6 +5751,13 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return h, cmd
 		}
 
+		// Ctrl+S can fire mid-edit of a multi-repo path. The in-flight text
+		// lives only in pathInput (Enter is the sole committer), so flush it
+		// into multiRepoPaths first; otherwise submit would use stale data.
+		if submitNow {
+			h.newDialog.CommitInFlightMultiRepoEdit()
+		}
+
 		// Validate before creating session
 		if validationErr := h.newDialog.Validate(); validationErr != "" {
 			h.newDialog.SetError(validationErr)

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -214,6 +214,12 @@ type NewDialog struct {
 	// Conducting parent selector.
 	conductorSessions []*session.Instance // nil when no conductors; populated by ShowInGroup
 	conductorCursor   int                 // 0 = "None", 1..N index into conductorSessions
+
+	// enterAdvances mirrors config.toml [ui] new_session_enter_advances (PR
+	// #1295). False (default) preserves today's behavior: Enter on the free-text
+	// Name/Branch fields submits the form. True makes Enter advance focus
+	// instead, with Ctrl+S as the explicit submit. Ctrl+S submits in both modes.
+	enterAdvances bool
 }
 
 // dialogSnapshot captures form state so the recent picker can restore on cancel.
@@ -260,6 +266,17 @@ func buildPresetCommands() []string {
 		presets = append(presets, customTools...)
 	}
 	return session.FilterVisibleToolNames(presets)
+}
+
+// newSessionEnterAdvancesFromConfig reads config.toml [ui]
+// new_session_enter_advances (PR #1295). Default false (config missing or
+// unset) preserves today's behavior: Enter on Name/Branch submits the form.
+func newSessionEnterAdvancesFromConfig() bool {
+	cfg, err := session.LoadUserConfig()
+	if err != nil || cfg == nil {
+		return false
+	}
+	return cfg.UI.GetNewSessionEnterAdvances()
 }
 
 // buildInheritedSettings returns display pairs for non-default Docker config values.
@@ -346,6 +363,7 @@ func NewNewDialog() *NewDialog {
 		parentGroupName: "default",
 		worktreeEnabled: false,
 		branchPrefix:    "feature/",
+		enterAdvances:   newSessionEnterAdvancesFromConfig(),
 	}
 	dlg.syncInputWidths()
 	dlg.updateToolOptions() // Also calls rebuildFocusTargets.
@@ -594,14 +612,17 @@ func (d *NewDialog) shouldHandleEnterLocally() bool {
 	// Path/Model open their own dropdown on Enter.
 	case focusPath, focusModel:
 		return true
-	// Name/Branch are free-text fields: Enter advances to the next field rather
-	// than submitting the whole form. Pressing Enter right after typing the
-	// session name is the most common keystroke; it used to silently submit
-	// (path defaults to cwd), skipping path/tool/model selection entirely.
-	// Keeping Enter local here lets the dialog advance focus instead. Submit is
-	// still reachable from non-text rows (checkboxes/conductor) and via Ctrl+S.
+	// Name/Branch are free-text fields. When the opt-in
+	// [ui].new_session_enter_advances toggle is on, Enter advances to the next
+	// field rather than submitting the whole form: pressing Enter right after
+	// typing the session name used to silently submit (path defaults to cwd),
+	// skipping path/tool/model selection entirely. Handling Enter locally lets
+	// the dialog advance focus instead. Submit stays reachable from non-text
+	// rows (checkboxes/conductor) and via Ctrl+S (additive, always available).
+	// Default (toggle off) preserves today's behavior: Enter here submits, so we
+	// must NOT claim it locally.
 	case focusName, focusBranch:
-		return true
+		return d.enterAdvances
 	case focusMultiRepo:
 		return d.multiRepoEnabled
 	default:
@@ -1879,12 +1900,14 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			return d, nil
 
 		case "enter":
-			// Name/Branch are free-text fields: Enter advances to the next field
-			// instead of submitting the form, so typing a name + Enter no longer
-			// silently creates a session with all defaults. See
-			// shouldHandleEnterLocally for the rationale; home.go forwards Enter
-			// here when that returns true.
-			if cur == focusName || cur == focusBranch {
+			// Name/Branch are free-text fields: when the opt-in
+			// [ui].new_session_enter_advances toggle is on, Enter advances to the
+			// next field instead of submitting the form, so typing a name + Enter
+			// no longer silently creates a session with all defaults. With the
+			// toggle off (default) home.go never forwards Enter here for these
+			// fields (shouldHandleEnterLocally returns false), so this branch is
+			// only reached in opt-in mode; the guard keeps it correct regardless.
+			if d.enterAdvances && (cur == focusName || cur == focusBranch) {
 				d.moveFocus(1)
 				return d, nil
 			}
@@ -2577,7 +2600,14 @@ func (d *NewDialog) View() string {
 	if len(d.recentSessions) > 0 {
 		recentPrefix = "^R recent │ "
 	}
-	helpText := recentPrefix + "Tab next │ ↑↓ navigate │ ^S create │ Esc cancel"
+	// createHint reflects the active Enter mode on free-text fields. With the
+	// opt-in toggle on, Enter advances and Ctrl+S creates; with it off (default),
+	// Enter still creates (Ctrl+S also works, but Enter is the legacy primary).
+	createHint := "Enter create"
+	if d.enterAdvances {
+		createHint = "^S create"
+	}
+	helpText := recentPrefix + "Tab next │ ↑↓ navigate │ " + createHint + " │ Esc cancel"
 	if cur == focusPath {
 		if d.suggestionsActive {
 			helpText = "↑/↓ navigate │ Space/Enter select │ Tab next │ Esc back"
@@ -2589,8 +2619,10 @@ func (d *NewDialog) View() string {
 	} else if cur == focusBranch {
 		if d.branchPicker != nil && d.branchPicker.IsVisible() {
 			helpText = "Type filter │ ↑↓ navigate │ Enter select │ Esc close"
-		} else {
+		} else if d.enterAdvances {
 			helpText = "^F branch search │ Tab/Enter next │ ^S create │ Esc cancel"
+		} else {
+			helpText = "^F branch search │ Tab next │ Enter create │ Esc cancel"
 		}
 	} else if cur == focusCommand {
 		selectedCmd := d.GetSelectedCommand()

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -653,6 +653,14 @@ func (d *NewDialog) WantsSubmit(msg tea.KeyMsg) bool {
 // pathInput (the Enter handler is the sole place that writes it back), so
 // submitting mid-edit would persist stale data. Safe to call when not editing:
 // it is a no-op unless an active multi-repo path edit is in progress.
+//
+// After flushing, pathInput is reset to the PRIMARY path (multiRepoPaths[0]).
+// The submit path in home.go reads `path` from pathInput via GetValuesWithWorktree
+// and runs worktree resolution + the create-directory check against it BEFORE
+// path is reassigned to multiRepoPaths[0]. If pathInput were left holding the
+// secondary path being edited, those pre-create checks would run against the
+// wrong repo. Resetting to the primary keeps pathInput consistent with the
+// session that will actually be created.
 func (d *NewDialog) CommitInFlightMultiRepoEdit() {
 	if !d.multiRepoEnabled || !d.multiRepoEditing {
 		return
@@ -664,6 +672,12 @@ func (d *NewDialog) CommitInFlightMultiRepoEdit() {
 	d.multiRepoEditing = false
 	d.pathInput.Blur()
 	d.pathCycler.Reset()
+	// Reset pathInput to the primary path so the caller's pre-create checks
+	// (worktree resolution, create-directory) run against the primary repo, not
+	// the secondary entry that was just being edited.
+	if len(d.multiRepoPaths) > 0 {
+		d.pathInput.SetValue(d.multiRepoPaths[0])
+	}
 }
 
 func (d *NewDialog) ApplyHighlightedModelSuggestion() {

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -591,13 +591,39 @@ func (d *NewDialog) IsModelTypeCustomHighlighted() bool {
 
 func (d *NewDialog) shouldHandleEnterLocally() bool {
 	switch d.currentTarget() {
+	// Path/Model open their own dropdown on Enter.
 	case focusPath, focusModel:
+		return true
+	// Name/Branch are free-text fields: Enter advances to the next field rather
+	// than submitting the whole form. Pressing Enter right after typing the
+	// session name is the most common keystroke; it used to silently submit
+	// (path defaults to cwd), skipping path/tool/model selection entirely.
+	// Keeping Enter local here lets the dialog advance focus instead. Submit is
+	// still reachable from non-text rows (checkboxes/conductor) and via Ctrl+S.
+	case focusName, focusBranch:
 		return true
 	case focusMultiRepo:
 		return d.multiRepoEnabled
 	default:
 		return d.suggestionsActive || d.modelSuggestionActive
 	}
+}
+
+// WantsSubmit reports whether the given key is an explicit "create now"
+// shortcut (Ctrl+S) that should submit the form from any field, including the
+// free-text Name/Branch fields where Enter now advances focus instead of
+// submitting. It is intentionally inert while a sub-picker (recent sessions,
+// branch search, path/model dropdowns) is open so the shortcut never fires mid
+// selection.
+func (d *NewDialog) WantsSubmit(msg tea.KeyMsg) bool {
+	if msg.Type != tea.KeyCtrlS {
+		return false
+	}
+	if d.IsRecentPickerOpen() || d.IsBranchPickerOpen() ||
+		d.suggestionsActive || d.modelSuggestionActive {
+		return false
+	}
+	return true
 }
 
 func (d *NewDialog) ApplyHighlightedModelSuggestion() {
@@ -1853,6 +1879,15 @@ func (d *NewDialog) Update(msg tea.Msg) (*NewDialog, tea.Cmd) {
 			return d, nil
 
 		case "enter":
+			// Name/Branch are free-text fields: Enter advances to the next field
+			// instead of submitting the form, so typing a name + Enter no longer
+			// silently creates a session with all defaults. See
+			// shouldHandleEnterLocally for the rationale; home.go forwards Enter
+			// here when that returns true.
+			if cur == focusName || cur == focusBranch {
+				d.moveFocus(1)
+				return d, nil
+			}
 			if cur == focusPath {
 				d.suggestionsActive = true
 				d.suggestionsHidden = false
@@ -2542,7 +2577,7 @@ func (d *NewDialog) View() string {
 	if len(d.recentSessions) > 0 {
 		recentPrefix = "^R recent │ "
 	}
-	helpText := recentPrefix + "Tab next/accept │ ↑↓ navigate │ Enter create │ Esc cancel"
+	helpText := recentPrefix + "Tab next │ ↑↓ navigate │ ^S create │ Esc cancel"
 	if cur == focusPath {
 		if d.suggestionsActive {
 			helpText = "↑/↓ navigate │ Space/Enter select │ Tab next │ Esc back"
@@ -2555,14 +2590,14 @@ func (d *NewDialog) View() string {
 		if d.branchPicker != nil && d.branchPicker.IsVisible() {
 			helpText = "Type filter │ ↑↓ navigate │ Enter select │ Esc close"
 		} else {
-			helpText = "^F branch search │ Tab next │ Enter create │ Esc cancel"
+			helpText = "^F branch search │ Tab/Enter next │ ^S create │ Esc cancel"
 		}
 	} else if cur == focusCommand {
 		selectedCmd := d.GetSelectedCommand()
 		if selectedCmd == "gemini" || selectedCmd == "codex" || selectedCmd == "hermes" {
-			helpText = "←→ command │ w worktree │ s sandbox │ y yolo │ Tab next │ Enter create │ Esc cancel"
+			helpText = "←→ command │ w worktree │ s sandbox │ y yolo │ Tab next │ ^S create │ Esc cancel"
 		} else {
-			helpText = "←→ command │ w worktree │ s sandbox │ Tab next │ Enter create │ Esc cancel"
+			helpText = "←→ command │ w worktree │ s sandbox │ Tab next │ ^S create │ Esc cancel"
 		}
 	} else if cur == focusModel {
 		if d.modelSuggestionActive {
@@ -2571,13 +2606,13 @@ func (d *NewDialog) View() string {
 			helpText = "Type custom model ID │ Enter browse known IDs │ Tab next"
 		}
 	} else if cur == focusConductor {
-		helpText = "↑↓ select parent │ Tab next │ Enter create │ Esc cancel"
+		helpText = "↑↓ select parent │ Tab next │ Enter/^S create │ Esc cancel"
 	} else if cur == focusWorktree || cur == focusSandbox {
-		helpText = "Space toggle │ ↑↓ navigate │ Enter create │ Esc cancel"
+		helpText = "Space toggle │ ↑↓ navigate │ Enter/^S create │ Esc cancel"
 	} else if cur == focusInherited {
-		helpText = "Space expand/collapse │ ↑↓ navigate │ Enter create │ Esc cancel"
+		helpText = "Space expand/collapse │ ↑↓ navigate │ Enter/^S create │ Esc cancel"
 	} else if cur == focusOptions && d.toolOptions != nil {
-		helpText = "Space/y toggle │ ↑↓ navigate │ Enter create │ Esc cancel"
+		helpText = "Space/y toggle │ ↑↓ navigate │ Enter/^S create │ Esc cancel"
 	}
 	content.WriteString(helpStyle.Render(helpText))
 

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -647,6 +647,25 @@ func (d *NewDialog) WantsSubmit(msg tea.KeyMsg) bool {
 	return true
 }
 
+// CommitInFlightMultiRepoEdit flushes an in-progress multi-repo path edit into
+// multiRepoPaths so a Ctrl+S submit uses the edited value rather than the
+// previously-committed one. Without this, the in-flight text lives only in
+// pathInput (the Enter handler is the sole place that writes it back), so
+// submitting mid-edit would persist stale data. Safe to call when not editing:
+// it is a no-op unless an active multi-repo path edit is in progress.
+func (d *NewDialog) CommitInFlightMultiRepoEdit() {
+	if !d.multiRepoEnabled || !d.multiRepoEditing {
+		return
+	}
+	if d.multiRepoPathCursor < 0 || d.multiRepoPathCursor >= len(d.multiRepoPaths) {
+		return
+	}
+	d.multiRepoPaths[d.multiRepoPathCursor] = strings.TrimSpace(d.pathInput.Value())
+	d.multiRepoEditing = false
+	d.pathInput.Blur()
+	d.pathCycler.Reset()
+}
+
 func (d *NewDialog) ApplyHighlightedModelSuggestion() {
 	if d.modelSuggestionActive && d.modelSuggestionCursor > 0 {
 		suggestionIdx := d.modelSuggestionCursor - 1

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2156,3 +2156,105 @@ func TestDialogOrigin(t *testing.T) {
 		})
 	}
 }
+
+// --- Keyboard navigation improvements (Feedback Hub: smoother new-session nav) ---
+
+// Enter on the Name field must advance focus to the next field, NOT submit the
+// form. shouldHandleEnterLocally must report true so home.go forwards Enter to
+// the dialog rather than running its submit path.
+func TestNewDialog_EnterOnNameAdvancesFocus(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(100, 50)
+	d.Show()
+
+	if d.currentTarget() != focusName {
+		t.Fatalf("default focus = %v, want focusName", d.currentTarget())
+	}
+	if !d.shouldHandleEnterLocally() {
+		t.Fatal("shouldHandleEnterLocally on Name = false, want true (Enter must advance, not submit)")
+	}
+
+	before := d.currentTarget()
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if d.currentTarget() == before {
+		t.Fatalf("Enter on Name did not advance focus (still %v)", d.currentTarget())
+	}
+	if d.currentTarget() != focusMultiRepo {
+		t.Fatalf("focus after Enter on Name = %v, want focusMultiRepo (next field)", d.currentTarget())
+	}
+}
+
+// Enter on the Branch field (worktree enabled) advances focus instead of
+// submitting, matching the Name-field behavior for free-text inputs.
+func TestNewDialog_EnterOnBranchAdvancesFocus(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(100, 50)
+	d.Show()
+	d.nameInput.SetValue("demo")
+	d.ToggleWorktree() // enables worktree -> branch field appears
+
+	idx := d.indexOf(focusBranch)
+	if idx < 0 {
+		t.Fatal("focusBranch should be present when worktree enabled")
+	}
+	d.focusIndex = idx
+	d.updateFocus()
+
+	if !d.shouldHandleEnterLocally() {
+		t.Fatal("shouldHandleEnterLocally on Branch = false, want true")
+	}
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if d.currentTarget() == focusBranch {
+		t.Fatal("Enter on Branch did not advance focus")
+	}
+}
+
+// Ctrl+S is recognized as an explicit submit shortcut from a plain text field.
+func TestNewDialog_CtrlSWantsSubmit(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(100, 50)
+	d.Show()
+	d.nameInput.SetValue("demo")
+
+	if !d.WantsSubmit(tea.KeyMsg{Type: tea.KeyCtrlS}) {
+		t.Fatal("WantsSubmit(Ctrl+S) on Name = false, want true")
+	}
+	// A non-Ctrl+S key must not be treated as submit.
+	if d.WantsSubmit(tea.KeyMsg{Type: tea.KeyEnter}) {
+		t.Fatal("WantsSubmit(Enter) = true, want false")
+	}
+}
+
+// Ctrl+S must be inert while a sub-picker is open so it never fires mid
+// selection (it would otherwise create a session from a half-picked state).
+func TestNewDialog_CtrlSInertWhileDropdownActive(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(100, 50)
+	d.Show()
+	d.SetPathSuggestions([]string{"/tmp/a", "/tmp/b"})
+
+	// Open the path suggestions dropdown.
+	d.focusIndex = d.indexOf(focusPath)
+	d.updateFocus()
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter}) // focusPath Enter opens dropdown
+	if !d.IsSuggestionsActive() {
+		t.Fatal("path dropdown should be active after Enter on Path")
+	}
+	if d.WantsSubmit(tea.KeyMsg{Type: tea.KeyCtrlS}) {
+		t.Fatal("WantsSubmit(Ctrl+S) while path dropdown active = true, want false")
+	}
+}
+
+// Regression: Tab still advances Name -> next field (unchanged behavior).
+func TestNewDialog_TabFromNameStillAdvances(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(100, 50)
+	d.Show()
+	if d.currentTarget() != focusName {
+		t.Fatalf("default focus = %v, want focusName", d.currentTarget())
+	}
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if d.currentTarget() == focusName {
+		t.Fatal("Tab on Name did not advance focus")
+	}
+}

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2298,6 +2298,54 @@ func TestNewDialog_CtrlSDuringMultiRepoEditSubmitsEditedPath(t *testing.T) {
 	}
 }
 
+// Regression (Codex round-2 P2): Ctrl+S submitted while editing a NON-primary
+// multi-repo entry must leave pathInput holding the PRIMARY path. The submit
+// path in home.go reads `path` from pathInput (via GetValuesWithWorktree) and
+// runs worktree resolution + the create-directory check against it BEFORE path
+// is reassigned to multiRepoPaths[0]. If pathInput were left on the secondary
+// entry being edited, those pre-create checks would run against the WRONG repo.
+func TestNewDialog_CtrlSEditingSecondaryEntry_PreCreateChecksUsePrimaryPath(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(100, 50)
+	d.Show()
+
+	// Two committed multi-repo paths: primary = /primary/repo, secondary = /secondary/repo.
+	d.pathInput.SetValue("/primary/repo")
+	d.ToggleMultiRepo()
+	d.multiRepoPaths = []string{"/primary/repo", "/secondary/repo"}
+	d.rebuildFocusTargets()
+
+	// Begin editing the SECONDARY entry (index 1), mirroring the Enter handler.
+	d.multiRepoPathCursor = 1
+	d.multiRepoEditing = true
+	d.pathInput.SetValue("/secondary/repo-edited")
+	d.pathInput.Focus()
+
+	// Sanity: before the commit, pathInput holds the secondary edit, so a naive
+	// GetValuesWithWorktree would resolve against the wrong repo.
+	if _, p, _, _, _ := d.GetValuesWithWorktree(); p != "/secondary/repo-edited" {
+		t.Fatalf("setup: GetValuesWithWorktree path = %q, want /secondary/repo-edited", p)
+	}
+
+	// Ctrl+S submit path: WantsSubmit true, then flush the in-flight edit.
+	if !d.WantsSubmit(tea.KeyMsg{Type: tea.KeyCtrlS}) {
+		t.Fatal("WantsSubmit(Ctrl+S) while editing secondary = false, want true")
+	}
+	d.CommitInFlightMultiRepoEdit()
+
+	// The edited secondary value must be flushed into multiRepoPaths[1]...
+	got, ok := d.GetMultiRepoPaths()
+	if !ok || len(got) != 2 || got[0] != "/primary/repo" || got[1] != "/secondary/repo-edited" {
+		t.Fatalf("post-commit: GetMultiRepoPaths = %v (ok=%v), want [/primary/repo /secondary/repo-edited]", got, ok)
+	}
+
+	// ...AND pathInput must now hold the PRIMARY path so the caller's pre-create
+	// checks (worktree resolution, create-directory) run against the primary repo.
+	if _, p, _, _, _ := d.GetValuesWithWorktree(); p != "/primary/repo" {
+		t.Fatalf("post-commit: GetValuesWithWorktree path = %q, want /primary/repo (primary), not the secondary entry", p)
+	}
+}
+
 // CommitInFlightMultiRepoEdit must be a safe no-op when no multi-repo edit is in
 // progress (the normal Ctrl+S-from-any-field case).
 func TestNewDialog_CommitInFlightMultiRepoEdit_NoopWhenNotEditing(t *testing.T) {

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2159,11 +2159,12 @@ func TestDialogOrigin(t *testing.T) {
 
 // --- Keyboard navigation improvements (Feedback Hub: smoother new-session nav) ---
 
-// Enter on the Name field must advance focus to the next field, NOT submit the
-// form. shouldHandleEnterLocally must report true so home.go forwards Enter to
-// the dialog rather than running its submit path.
+// Opt-in mode: Enter on the Name field must advance focus to the next field,
+// NOT submit the form. shouldHandleEnterLocally must report true so home.go
+// forwards Enter to the dialog rather than running its submit path.
 func TestNewDialog_EnterOnNameAdvancesFocus(t *testing.T) {
 	d := NewNewDialog()
+	d.enterAdvances = true // opt in: [ui].new_session_enter_advances = true
 	d.SetSize(100, 50)
 	d.Show()
 
@@ -2184,10 +2185,11 @@ func TestNewDialog_EnterOnNameAdvancesFocus(t *testing.T) {
 	}
 }
 
-// Enter on the Branch field (worktree enabled) advances focus instead of
-// submitting, matching the Name-field behavior for free-text inputs.
+// Opt-in mode: Enter on the Branch field (worktree enabled) advances focus
+// instead of submitting, matching the Name-field behavior for free-text inputs.
 func TestNewDialog_EnterOnBranchAdvancesFocus(t *testing.T) {
 	d := NewNewDialog()
+	d.enterAdvances = true // opt in: [ui].new_session_enter_advances = true
 	d.SetSize(100, 50)
 	d.Show()
 	d.nameInput.SetValue("demo")
@@ -2245,7 +2247,8 @@ func TestNewDialog_CtrlSInertWhileDropdownActive(t *testing.T) {
 	}
 }
 
-// Regression: Tab still advances Name -> next field (unchanged behavior).
+// Regression: Tab still advances Name -> next field (unchanged behavior,
+// independent of the Enter-mode toggle).
 func TestNewDialog_TabFromNameStillAdvances(t *testing.T) {
 	d := NewNewDialog()
 	d.SetSize(100, 50)
@@ -2256,5 +2259,80 @@ func TestNewDialog_TabFromNameStillAdvances(t *testing.T) {
 	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyTab})
 	if d.currentTarget() == focusName {
 		t.Fatal("Tab on Name did not advance focus")
+	}
+}
+
+// --- Default-preserving behavior (PR #1295: toggle defaults OFF) ---
+
+// DEFAULT (toggle off): Enter on the Name field must NOT be handled locally, so
+// home.go runs its submit path — i.e. today's behavior (Enter from Name
+// submits) is preserved. This is the core default-preserving guarantee.
+func TestNewDialog_DefaultEnterOnNameSubmits(t *testing.T) {
+	d := NewNewDialog()
+	// enterAdvances defaults to false (no config → newSessionEnterAdvancesFromConfig
+	// returns false). Assert it explicitly so the default is load-bearing here.
+	if d.enterAdvances {
+		t.Fatal("enterAdvances default = true, want false (must preserve today's behavior)")
+	}
+	d.SetSize(100, 50)
+	d.Show()
+
+	if d.currentTarget() != focusName {
+		t.Fatalf("default focus = %v, want focusName", d.currentTarget())
+	}
+	// shouldHandleEnterLocally must be false on Name so home.go submits.
+	if d.shouldHandleEnterLocally() {
+		t.Fatal("default mode: shouldHandleEnterLocally on Name = true, want false (Enter must submit, not advance)")
+	}
+	// Even if Enter were forwarded to the dialog, the advance guard must not fire
+	// in default mode: focus must stay on Name.
+	before := d.currentTarget()
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if d.currentTarget() != before {
+		t.Fatalf("default mode: Enter on Name advanced focus to %v, want unchanged %v", d.currentTarget(), before)
+	}
+}
+
+// DEFAULT (toggle off): Enter on the Branch field must NOT advance — today's
+// behavior (Enter submits) is preserved.
+func TestNewDialog_DefaultEnterOnBranchSubmits(t *testing.T) {
+	d := NewNewDialog()
+	if d.enterAdvances {
+		t.Fatal("enterAdvances default = true, want false")
+	}
+	d.SetSize(100, 50)
+	d.Show()
+	d.nameInput.SetValue("demo")
+	d.ToggleWorktree()
+
+	idx := d.indexOf(focusBranch)
+	if idx < 0 {
+		t.Fatal("focusBranch should be present when worktree enabled")
+	}
+	d.focusIndex = idx
+	d.updateFocus()
+
+	if d.shouldHandleEnterLocally() {
+		t.Fatal("default mode: shouldHandleEnterLocally on Branch = true, want false (Enter must submit)")
+	}
+	before := d.currentTarget()
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if d.currentTarget() != before {
+		t.Fatalf("default mode: Enter on Branch advanced focus to %v, want unchanged %v", d.currentTarget(), before)
+	}
+}
+
+// Ctrl+S is additive: WantsSubmit(Ctrl+S) is true regardless of the toggle, so
+// the explicit-create shortcut works in BOTH default and opt-in modes.
+func TestNewDialog_CtrlSSubmitsInBothModes(t *testing.T) {
+	for _, advance := range []bool{false, true} {
+		d := NewNewDialog()
+		d.enterAdvances = advance
+		d.SetSize(100, 50)
+		d.Show()
+		d.nameInput.SetValue("demo")
+		if !d.WantsSubmit(tea.KeyMsg{Type: tea.KeyCtrlS}) {
+			t.Fatalf("WantsSubmit(Ctrl+S) with enterAdvances=%v = false, want true (additive in both modes)", advance)
+		}
 	}
 }

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2247,6 +2247,78 @@ func TestNewDialog_CtrlSInertWhileDropdownActive(t *testing.T) {
 	}
 }
 
+// Regression (Codex P2): Ctrl+S submitted while a multi-repo path is being
+// edited inline must use the in-flight edited value, not the stale
+// previously-committed path. The edited text lives only in pathInput until the
+// Enter handler writes it back, so the submit path must flush it first via
+// CommitInFlightMultiRepoEdit.
+func TestNewDialog_CtrlSDuringMultiRepoEditSubmitsEditedPath(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(100, 50)
+	d.Show()
+
+	// Enable multi-repo with one committed path and focus the multi-repo row.
+	d.pathInput.SetValue("/old/path")
+	d.ToggleMultiRepo()
+	d.rebuildFocusTargets()
+	d.focusIndex = d.indexOf(focusMultiRepo)
+	d.updateFocus()
+	if got, _ := d.GetMultiRepoPaths(); len(got) != 1 || got[0] != "/old/path" {
+		t.Fatalf("setup: GetMultiRepoPaths = %v, want [/old/path]", got)
+	}
+
+	// Enter edit mode for the path (mirrors the Enter handler entering edit).
+	d, _ = d.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !d.multiRepoEditing {
+		t.Fatal("expected multiRepoEditing=true after Enter on multi-repo path")
+	}
+
+	// User edits the path in-flight: clear and type a new value into pathInput.
+	d.pathInput.SetValue("/edited/path")
+
+	// Before the fix, GetMultiRepoPaths still returns the stale committed value
+	// because the edit lives only in pathInput.
+	if got, _ := d.GetMultiRepoPaths(); len(got) != 1 || got[0] != "/old/path" {
+		t.Fatalf("pre-commit: GetMultiRepoPaths = %v, want stale [/old/path]", got)
+	}
+
+	// Ctrl+S submit path: WantsSubmit must be true (no dropdown open), then the
+	// submit handler flushes the in-flight edit.
+	if !d.WantsSubmit(tea.KeyMsg{Type: tea.KeyCtrlS}) {
+		t.Fatal("WantsSubmit(Ctrl+S) during multi-repo edit = false, want true")
+	}
+	d.CommitInFlightMultiRepoEdit()
+
+	if d.multiRepoEditing {
+		t.Fatal("multiRepoEditing should be false after CommitInFlightMultiRepoEdit")
+	}
+	got, ok := d.GetMultiRepoPaths()
+	if !ok || len(got) != 1 || got[0] != "/edited/path" {
+		t.Fatalf("post-commit: GetMultiRepoPaths = %v (ok=%v), want [/edited/path]", got, ok)
+	}
+}
+
+// CommitInFlightMultiRepoEdit must be a safe no-op when no multi-repo edit is in
+// progress (the normal Ctrl+S-from-any-field case).
+func TestNewDialog_CommitInFlightMultiRepoEdit_NoopWhenNotEditing(t *testing.T) {
+	d := NewNewDialog()
+	d.SetSize(100, 50)
+	d.Show()
+	// Not in multi-repo mode at all.
+	d.CommitInFlightMultiRepoEdit() // must not panic
+
+	// Multi-repo enabled but not editing.
+	d.pathInput.SetValue("/a")
+	d.ToggleMultiRepo()
+	d.CommitInFlightMultiRepoEdit()
+	if d.multiRepoEditing {
+		t.Fatal("multiRepoEditing flipped true unexpectedly")
+	}
+	if got, _ := d.GetMultiRepoPaths(); len(got) != 1 || got[0] != "/a" {
+		t.Fatalf("GetMultiRepoPaths = %v, want [/a] (unchanged)", got)
+	}
+}
+
 // Regression: Tab still advances Name -> next field (unchanged behavior,
 // independent of the Enter-mode toggle).
 func TestNewDialog_TabFromNameStillAdvances(t *testing.T) {


### PR DESCRIPTION
Addresses Feedback Hub item (PaulGrimshaw, v1.9.47, 4/5): _"new-session UI is a bit clunky. Could be cleaner and easier to navigate with keyboard."_ TUI only — the web CreateSessionDialog is untouched.

## Concrete clunk points found (TUI new-session dialog, `internal/ui/newdialog.go`)

1. **Enter from the Name field submitted the whole form prematurely.** `shouldHandleEnterLocally()` excluded `focusName`, so Enter fell through to `home.go`'s submit path. Since the path field defaults to the cwd and the tool defaults too, pressing Enter right after typing a name **silently created a session** — skipping path, tool, and model selection entirely. The single most common keystroke was a trap.
2. **Enter semantics were inconsistent across fields.** On Path/Model, Enter opens a dropdown; on Name/Branch/checkboxes it submitted. Unpredictable.
3. **No explicit, discoverable submit affordance** from a text field other than the ambiguous Enter above.

## Improvements

- **Enter on the Name and Branch free-text fields now advances focus** to the next field instead of submitting.
- **Added Ctrl+S as an explicit "create now" shortcut** that submits from any field. It is inert while a sub-picker (recent sessions, branch search, path/model dropdowns) is open, so it never fires mid-selection.
- **Enter still submits from the non-text rows** (command, conductor, worktree, sandbox, options) — existing muscle memory there is preserved; this is better-not-different.
- **Path/Model Enter-opens-dropdown is unchanged.**
- Footer help text updated to teach the flow: `Tab next │ ↑↓ navigate │ ^S create │ Esc cancel`.

## Before / after keyboard flow

Before:
- Type name → **Enter** → ⚠️ session created immediately with default path/tool (path/model never seen).
- Submit only reachable via Enter from a non-Path/Model field — the same ambiguous key.

After:
- Type name → **Enter** → focus advances to the next field; **Tab** also advances (unchanged).
- Press **Ctrl+S** at any point → validates + creates. Clear, single submit shortcut.
- Enter on Path/Model still opens their pickers; Enter on checkbox/toggle rows still submits.

## Tests added (`internal/ui/newdialog_test.go`)

- `TestNewDialog_EnterOnNameAdvancesFocus` — Enter on Name advances, does not submit.
- `TestNewDialog_EnterOnBranchAdvancesFocus` — same for Branch (worktree enabled).
- `TestNewDialog_CtrlSWantsSubmit` — Ctrl+S recognized as submit; Enter is not.
- `TestNewDialog_CtrlSInertWhileDropdownActive` — Ctrl+S inert while a picker is open.
- `TestNewDialog_TabFromNameStillAdvances` — Tab regression guard.

## Verification (sandboxed, per-package)

- `go build ./...` — clean.
- `HOME=$(mktemp -d) XDG_*= go test -race ./internal/ui/` — green (38.8s).

Scope is limited to the new-session dialog's input handling + its help text. Submit/validation semantics and what a session _is_ are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ctrl+S now acts as an explicit submit shortcut for the new-session dialog; Enter can optionally advance focus for Name/Branch when enabled.

* **Configuration**
  * New toggle to opt into Enter-advances behavior for the new-session dialog (opt-in, preserves prior submit-by-Enter default).

* **Bug Fixes**
  * Submitting via shortcut now commits in-flight multi-repo edits to avoid stale values.

* **Documentation**
  * Dialog help text updated to reflect Enter vs ^S submit semantics.

* **Tests**
  * Added comprehensive keyboard/navigation and multi-repo submit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->