### PR TITLE
fix(session): make 'revive' concurrency-safe so it can't clobber concurrently-added sessions

### DIFF
--- a/cmd/agent-deck/revive_cmd.go
+++ b/cmd/agent-deck/revive_cmd.go
@@ -27,9 +27,21 @@ func (s ReviveSummary) Format() string {
 // runReviveAll is the testable core: classify all instances, trigger revives,
 // aggregate the summary. Separate from handleSessionRevive so tests can stub
 // the reviver and storage without exec'ing the binary.
-func runReviveAll(instances []*session.Instance, rev *session.Reviver) ReviveSummary {
+//
+// It also returns the subset of instances that were actually revived (status
+// mutated). The caller persists ONLY these via a targeted, sweep-free write so
+// revive can never clobber a session a concurrent process added after the
+// snapshot was loaded (lost-update race fix).
+func runReviveAll(instances []*session.Instance, rev *session.Reviver) (ReviveSummary, []*session.Instance) {
 	outcomes := rev.ReviveAll(instances)
+	byID := make(map[string]*session.Instance, len(instances))
+	for _, inst := range instances {
+		if inst != nil {
+			byID[inst.ID] = inst
+		}
+	}
 	summary := ReviveSummary{}
+	var revived []*session.Instance
 	for _, o := range outcomes {
 		switch o.Class {
 		case session.ClassAlive:
@@ -40,10 +52,13 @@ func runReviveAll(instances []*session.Instance, rev *session.Reviver) ReviveSum
 			summary.Errored++
 			if o.Revived {
 				summary.Revived++
+				if inst := byID[o.InstanceID]; inst != nil {
+					revived = append(revived, inst)
+				}
 			}
 		}
 	}
-	return summary
+	return summary, revived
 }
 
 // handleSessionRevive dispatches `agent-deck session revive [--all|--name <title>]`.
@@ -79,7 +94,7 @@ func handleSessionRevive(profile string, args []string) {
 	quietMode := *quiet || *quietShort
 	out := NewCLIOutput(*jsonOutput, quietMode)
 
-	storage, instances, groups, err := loadSessionData(profile)
+	storage, instances, _, err := loadSessionData(profile)
 	if err != nil {
 		out.Error(err.Error(), ErrCodeNotFound)
 		os.Exit(1)
@@ -88,8 +103,9 @@ func handleSessionRevive(profile string, args []string) {
 	rev := session.NewReviver()
 
 	var summary ReviveSummary
+	var revived []*session.Instance
 	if *all {
-		summary = runReviveAll(instances, rev)
+		summary, revived = runReviveAll(instances, rev)
 	} else {
 		inst, errMsg, errCode := ResolveSession(*name, instances)
 		if inst == nil {
@@ -100,13 +116,21 @@ func handleSessionRevive(profile string, args []string) {
 			os.Exit(1)
 			return
 		}
-		summary = runReviveAll([]*session.Instance{inst}, rev)
+		summary, revived = runReviveAll([]*session.Instance{inst}, rev)
 	}
 
-	// Persist any status mutations (e.g., StatusError → StatusRunning on revive).
-	if err := saveSessionData(storage, instances, groups); err != nil {
-		out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)
-		os.Exit(1)
+	// Persist ONLY the rows we actually revived, via a targeted sweep-free
+	// write. Using the full load-modify-write path (saveSessionData →
+	// SaveWithGroups → SaveInstances) would run a `DELETE FROM instances WHERE
+	// id NOT IN (<stale snapshot>)` sweep that silently drops any session a
+	// concurrent `add` inserted after we loaded our snapshot (lost-update
+	// race). PersistRevivedInstances never deletes, so revive cannot clobber
+	// a row it didn't touch.
+	if len(revived) > 0 {
+		if err := storage.PersistRevivedInstances(revived); err != nil {
+			out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
 	}
 
 	jsonData := map[string]interface{}{

--- a/cmd/agent-deck/revive_cmd.go
+++ b/cmd/agent-deck/revive_cmd.go
@@ -61,6 +61,31 @@ func runReviveAll(instances []*session.Instance, rev *session.Reviver) (ReviveSu
 	return summary, revived
 }
 
+// reviveAndPersist is the testable persist seam: run the reviver over the given
+// instances, then durably persist ONLY the rows it actually revived, via the
+// targeted, status-only, sweep-free path (Storage.PersistRevivedInstances →
+// statedb.PersistInstanceStatusesTx). It deliberately does NOT call
+// saveSessionData / SaveWithGroups / SaveInstances: that full load-modify-write
+// path runs a `DELETE FROM instances WHERE id NOT IN (<stale snapshot>)` sweep
+// that silently drops any session a concurrent `add` inserted after we loaded
+// our snapshot, and a full-row rewrite that would clobber concurrent edits to
+// the revived rows. Keeping persistence behind this single function means a
+// future regression back to the full-rewrite path is a one-line change here that
+// the CLI-level regression test (revive_persist_cli_test.go) will catch.
+func reviveAndPersist(
+	storage *session.Storage,
+	instances []*session.Instance,
+	rev *session.Reviver,
+) (ReviveSummary, error) {
+	summary, revived := runReviveAll(instances, rev)
+	if len(revived) > 0 {
+		if err := storage.PersistRevivedInstances(revived); err != nil {
+			return summary, err
+		}
+	}
+	return summary, nil
+}
+
 // handleSessionRevive dispatches `agent-deck session revive [--all|--name <title>]`.
 // Rebuilds dead control pipes for sessions whose tmux server is still alive
 // (see REPORT-D). Exits 0 on success, 1 on usage/load errors, 2 if --name not found.
@@ -102,10 +127,9 @@ func handleSessionRevive(profile string, args []string) {
 
 	rev := session.NewReviver()
 
-	var summary ReviveSummary
-	var revived []*session.Instance
+	var target []*session.Instance
 	if *all {
-		summary, revived = runReviveAll(instances, rev)
+		target = instances
 	} else {
 		inst, errMsg, errCode := ResolveSession(*name, instances)
 		if inst == nil {
@@ -116,21 +140,13 @@ func handleSessionRevive(profile string, args []string) {
 			os.Exit(1)
 			return
 		}
-		summary, revived = runReviveAll([]*session.Instance{inst}, rev)
+		target = []*session.Instance{inst}
 	}
 
-	// Persist ONLY the rows we actually revived, via a targeted sweep-free
-	// write. Using the full load-modify-write path (saveSessionData →
-	// SaveWithGroups → SaveInstances) would run a `DELETE FROM instances WHERE
-	// id NOT IN (<stale snapshot>)` sweep that silently drops any session a
-	// concurrent `add` inserted after we loaded our snapshot (lost-update
-	// race). PersistRevivedInstances never deletes, so revive cannot clobber
-	// a row it didn't touch.
-	if len(revived) > 0 {
-		if err := storage.PersistRevivedInstances(revived); err != nil {
-			out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
+	summary, err := reviveAndPersist(storage, target, rev)
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
 	}
 
 	jsonData := map[string]interface{}{

--- a/cmd/agent-deck/revive_cmd_test.go
+++ b/cmd/agent-deck/revive_cmd_test.go
@@ -34,7 +34,11 @@ func TestRevive_CLI_AllFlag_TriggersReviver(t *testing.T) {
 	}
 	_ = erroredTmux
 
-	summary := runReviveAll([]*session.Instance{errored, alive, dead}, rev)
+	summary, revived := runReviveAll([]*session.Instance{errored, alive, dead}, rev)
+
+	if len(revived) != 1 || revived[0].ID != errored.ID {
+		t.Errorf("expected exactly the errored instance in revived set, got %+v", revived)
+	}
 
 	if summary.Revived != 1 {
 		t.Errorf("expected 1 revived, got %d", summary.Revived)
@@ -68,7 +72,10 @@ func TestRevive_CLI_EmptyStorage_NoCalls(t *testing.T) {
 		ReviveAction: func(i *session.Instance) error { reviveCalls++; return nil },
 		Stagger:      0,
 	}
-	summary := runReviveAll(nil, rev)
+	summary, revived := runReviveAll(nil, rev)
+	if len(revived) != 0 {
+		t.Errorf("empty input must produce empty revived set, got %+v", revived)
+	}
 	if summary.Revived != 0 || summary.Alive != 0 || summary.Errored != 0 || summary.Dead != 0 {
 		t.Errorf("empty input must produce zero counts: %+v", summary)
 	}

--- a/cmd/agent-deck/revive_persist_cli_test.go
+++ b/cmd/agent-deck/revive_persist_cli_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newReviveCLIStorage opens a real Storage in the isolated _test profile
+// (TestMain forces AGENTDECK_PROFILE=_test under an isolated HOME). Each call
+// returns a fresh handle on the SAME on-disk state.db, so we can simulate two
+// concurrent processes (one reviving, one adding) like production does.
+func newReviveCLIStorage(t *testing.T) *session.Storage {
+	t.Helper()
+	s, err := session.NewStorageWithProfile("")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// stubReviverHealingErrored returns a Reviver wired so that the named tmux
+// session probes as ClassErrored and ReviveAction heals it (StatusError →
+// StatusRunning) — exactly what defaultReviveAction does in CLI mode, but
+// without touching real tmux. This lets the CLI-level test drive
+// reviveAndPersist deterministically.
+func stubReviverHealingErrored(t *testing.T) *session.Reviver {
+	t.Helper()
+	return &session.Reviver{
+		// tmux server is "alive" for every probed session.
+		TmuxExists: func(name, _ string) bool { return true },
+		// pipe is dead → forces ClassErrored for StatusError rows.
+		PipeAlive: func(name string) bool { return false },
+		// Mirror defaultReviveAction's status-only heal.
+		ReviveAction: func(i *session.Instance) error {
+			if i.Status == session.StatusError {
+				i.Status = session.StatusRunning
+			}
+			return nil
+		},
+		Stagger: 0,
+	}
+}
+
+// TestReviveCLI_PersistViaTargetedPath_DoesNotClobberConcurrentAdd is the
+// command-level regression guard for the lost-update race. It drives
+// reviveAndPersist — the exact seam handleSessionRevive uses — instead of
+// poking storage directly, so a future regression that swaps the persist back
+// to saveSessionData / SaveWithGroups / SaveInstances (the DELETE-NOT-IN sweep
+// path) IS caught here, not just in the storage unit test.
+//
+// Sequence (production order):
+//  1. revive loads its snapshot (only the pre-existing errored session).
+//  2. a concurrent `add` inserts a brand-new session via the targeted path.
+//  3. revive heals + persists through reviveAndPersist.
+//
+// Invariant: the concurrently-added session survives, and the errored session
+// is now running.
+func TestReviveCLI_PersistViaTargetedPath_DoesNotClobberConcurrentAdd(t *testing.T) {
+	reviveStorage := newReviveCLIStorage(t)
+
+	existing := &session.Instance{
+		ID:          "revive-cli-existing",
+		Title:       "existing",
+		ProjectPath: "/tmp/existing",
+		GroupPath:   "test",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      session.StatusError,
+		CreatedAt:   time.Now().Add(-2 * time.Minute),
+	}
+	require.NoError(t, reviveStorage.SaveWithGroups(
+		[]*session.Instance{existing},
+		session.NewGroupTree([]*session.Instance{existing}),
+	))
+
+	// Step 1: revive loads its (now-stale-once-add-happens) snapshot.
+	snapshot, _, err := reviveStorage.LoadWithGroups()
+	require.NoError(t, err)
+	require.Len(t, snapshot, 1)
+
+	// Step 2: a concurrent process inserts a new session via the targeted path.
+	addStorage := newReviveCLIStorage(t)
+	added := &session.Instance{
+		ID:          "revive-cli-added-concurrently",
+		Title:       "added-concurrently",
+		ProjectPath: "/tmp/added",
+		GroupPath:   "test",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      session.StatusRunning,
+		CreatedAt:   time.Now(),
+	}
+	require.NoError(t, addStorage.InsertSessionAndVerify(added, nil))
+
+	// Step 3: drive the CLI persist seam exactly as handleSessionRevive does.
+	summary, err := reviveAndPersist(reviveStorage, snapshot, stubReviverHealingErrored(t))
+	require.NoError(t, err)
+	require.Equal(t, 1, summary.Revived, "the errored session should have been revived")
+
+	// Verify against a fresh handle (independent read).
+	loaded, err := newReviveCLIStorage(t).Load()
+	require.NoError(t, err)
+	ids := map[string]session.Status{}
+	for _, inst := range loaded {
+		ids[inst.ID] = inst.Status
+	}
+	assert.Contains(t, ids, "revive-cli-added-concurrently",
+		"concurrently-added session must survive a CLI revive (lost-update race)")
+	require.Contains(t, ids, "revive-cli-existing", "the revived session must persist")
+	assert.Equal(t, session.StatusRunning, ids["revive-cli-existing"],
+		"revive must have healed StatusError → StatusRunning on disk")
+}
+
+// TestReviveCLI_TargetedUpdate_PreservesConcurrentEditToRevivedRow guards
+// concern #2: the persist must be a status-only UPDATE, not a full-row write.
+// A concurrent process edits a NON-status field (Title) of the very row revive
+// is about to heal, AFTER revive loaded its snapshot. A full-row INSERT OR
+// REPLACE from revive's stale snapshot would clobber that edit; the targeted
+// status UPDATE must leave it intact.
+func TestReviveCLI_TargetedUpdate_PreservesConcurrentEditToRevivedRow(t *testing.T) {
+	reviveStorage := newReviveCLIStorage(t)
+
+	existing := &session.Instance{
+		ID:          "revive-cli-edit-target",
+		Title:       "original-title",
+		ProjectPath: "/tmp/edit",
+		GroupPath:   "test",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      session.StatusError,
+		CreatedAt:   time.Now().Add(-2 * time.Minute),
+	}
+	require.NoError(t, reviveStorage.SaveWithGroups(
+		[]*session.Instance{existing},
+		session.NewGroupTree([]*session.Instance{existing}),
+	))
+
+	// revive loads its snapshot — Title is still "original-title" here.
+	snapshot, _, err := reviveStorage.LoadWithGroups()
+	require.NoError(t, err)
+	require.Len(t, snapshot, 1)
+
+	// A concurrent process renames the SAME row via the targeted single-row
+	// path, after revive's snapshot was taken.
+	editStorage := newReviveCLIStorage(t)
+	editInstances, editGroups, err := editStorage.LoadWithGroups()
+	require.NoError(t, err)
+	editInstances[0].Title = "renamed-concurrently"
+	require.NoError(t, editStorage.InsertSessionAndVerify(
+		editInstances[0], session.NewGroupTreeWithGroups(editInstances, editGroups)))
+
+	// revive heals + persists from its stale snapshot (Title="original-title").
+	_, err = reviveAndPersist(reviveStorage, snapshot, stubReviverHealingErrored(t))
+	require.NoError(t, err)
+
+	loaded, err := newReviveCLIStorage(t).Load()
+	require.NoError(t, err)
+	require.Len(t, loaded, 1)
+	assert.Equal(t, "renamed-concurrently", loaded[0].Title,
+		"targeted status UPDATE must NOT clobber a concurrent edit to a non-status field")
+	assert.Equal(t, session.StatusRunning, loaded[0].Status,
+		"revive must still have healed status")
+}

--- a/internal/session/reviver.go
+++ b/internal/session/reviver.go
@@ -108,6 +108,18 @@ func (r *Reviver) Classify(inst *Instance) RevivalClass {
 // those in ClassErrored. Calls are staggered by r.Stagger. Alive/dead entries
 // do NOT consume a stagger slot — total wall clock scales with errored count,
 // not total count.
+//
+// MUTATION INVARIANT (relied on by the CLI persist path, revive_cmd.go):
+// ReviveAll mutates an instance ONLY when it both (a) classifies it ClassErrored
+// AND (b) its ReviveAction succeeds (outcome.Revived == true). ClassAlive and
+// ClassDead instances are classified and returned untouched — no status flip, no
+// timestamp/socket normalization. The only field a successful revive writes is
+// Instance.Status (StatusError → StatusRunning; see defaultReviveAction). The
+// caller therefore persists exactly the Revived subset, status-only, and nothing
+// else. If a future ReviveAction starts normalizing already-alive sessions or
+// mutating other fields, this invariant — and the targeted persist in
+// runReviveAll / PersistRevivedInstances — MUST be revisited so those mutations
+// are not silently dropped.
 func (r *Reviver) ReviveAll(instances []*Instance) []ReviveOutcome {
 	outcomes := make([]ReviveOutcome, 0, len(instances))
 	firstRevive := true

--- a/internal/session/reviver.go
+++ b/internal/session/reviver.go
@@ -80,6 +80,19 @@ func NewReviver() *Reviver {
 }
 
 // Classify decides which bucket an instance falls into at scan time.
+//
+// TODO(revive-liveness): after a tmux SERVER restart (OOM/SIGKILL +
+// systemd Restart=on-failure, or a manual restart), a session that is in
+// fact alive under the NEW server can briefly probe as not-found if the
+// has-session call races the server coming back up. Today that yields
+// ClassDead, which is never auto-revived — so a transient miss permanently
+// strands a recoverable session until the user restarts it manually. A fix
+// (single short retry on a confirmed-not-found probe, scoped to revive so it
+// does not add latency to the shared HasSession hot path) is deferred: it is
+// orthogonal to the data-loss race fixed here and carries its own regression
+// risk for the watchPipe reconnect loop that shares the probe. The
+// data-loss-critical half (revive never clobbering concurrently-added rows)
+// is fixed via Storage.PersistRevivedInstances.
 func (r *Reviver) Classify(inst *Instance) RevivalClass {
 	name := instanceTmuxName(inst)
 	if !r.TmuxExists(name, inst.TmuxSocketName) {

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -577,6 +577,42 @@ func (s *Storage) saveSingleInstance(row *statedb.InstanceRow) error {
 	return nil
 }
 
+// PersistRevivedInstances durably persists status mutations from a revive
+// sweep WITHOUT the full-table rewrite that SaveWithGroups performs.
+//
+// Why this exists (lost-update race fix):
+//
+// `session revive` is a read-process-write cycle: it loads the full instances
+// snapshot, classifies/heals each one (flipping StatusError → StatusRunning),
+// then persists. If it persisted via SaveWithGroups → SaveInstances, that
+// path's `DELETE FROM instances WHERE id NOT IN (<snapshot ids>)` sweep would
+// delete any session a concurrent process (TUI/CLI `add`) inserted AFTER
+// revive loaded its snapshot — the row is silently lost because it was never
+// in revive's stale id set.
+//
+// This method writes each instance via the targeted single-row path
+// (saveSingleInstance → SaveInstance, INSERT OR REPLACE, no DELETE sweep),
+// exactly like InsertSessionAndVerify / RemoveSessionAndVerify. Revive thus
+// only ever touches the specific rows it loaded and can never drop a
+// concurrently-added row. Callers should pass only the instances they
+// actually mutated to minimize write contention, but passing the whole
+// loaded snapshot is also safe — every row is just re-asserted, never swept.
+func (s *Storage) PersistRevivedInstances(instances []*Instance) error {
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		row, err := instanceToRow(inst)
+		if err != nil {
+			return err
+		}
+		if err := s.saveSingleInstance(row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // instanceToRow converts a session.Instance into the statedb row shape.
 // Shared by SaveWithGroups (bulk path) and InsertSessionAndVerify
 // (targeted single-row path) so the marshal/normalize logic stays in

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -577,40 +577,54 @@ func (s *Storage) saveSingleInstance(row *statedb.InstanceRow) error {
 	return nil
 }
 
-// PersistRevivedInstances durably persists status mutations from a revive
-// sweep WITHOUT the full-table rewrite that SaveWithGroups performs.
+// PersistRevivedInstances durably persists the status heal from a revive sweep
+// WITHOUT the full-table rewrite that SaveWithGroups performs and WITHOUT a
+// full-row INSERT OR REPLACE.
 //
-// Why this exists (lost-update race fix):
+// Why this exists (two races, two guarantees):
 //
-// `session revive` is a read-process-write cycle: it loads the full instances
-// snapshot, classifies/heals each one (flipping StatusError → StatusRunning),
-// then persists. If it persisted via SaveWithGroups → SaveInstances, that
-// path's `DELETE FROM instances WHERE id NOT IN (<snapshot ids>)` sweep would
-// delete any session a concurrent process (TUI/CLI `add`) inserted AFTER
-// revive loaded its snapshot — the row is silently lost because it was never
-// in revive's stale id set.
+//  1. Lost-update vs. concurrent `add`. `session revive` is a read-process-write
+//     cycle: it loads the full instances snapshot, classifies/heals each one
+//     (flipping StatusError → StatusRunning), then persists. If it persisted via
+//     SaveWithGroups → SaveInstances, that path's `DELETE FROM instances WHERE
+//     id NOT IN (<snapshot ids>)` sweep would delete any session a concurrent
+//     process (TUI/CLI `add`) inserted AFTER revive loaded its snapshot — the
+//     row is silently lost because it was never in revive's stale id set. The
+//     targeted path below issues NO sweep, so rows revive never saw are never
+//     touched.
 //
-// This method writes each instance via the targeted single-row path
-// (saveSingleInstance → SaveInstance, INSERT OR REPLACE, no DELETE sweep),
-// exactly like InsertSessionAndVerify / RemoveSessionAndVerify. Revive thus
-// only ever touches the specific rows it loaded and can never drop a
-// concurrently-added row. Callers should pass only the instances they
-// actually mutated to minimize write contention, but passing the whole
-// loaded snapshot is also safe — every row is just re-asserted, never swept.
+//  2. Clobber vs. concurrent edit of a row being revived. A full-row write
+//     (INSERT OR REPLACE / saveSingleInstance) would push EVERY column from
+//     revive's stale in-memory snapshot, overwriting any field (title, group,
+//     tool_data, last_accessed, claude_session_id, …) a concurrent process
+//     edited between revive's load and its save. Revive owns exactly ONE field:
+//     Instance.Status (see reviver.go defaultReviveAction — it mutates nothing
+//     else). So this method persists ONLY status, via the targeted
+//     `UPDATE instances SET status = ? WHERE id = ?` batch
+//     (PersistInstanceStatusesTx), inside a single transaction for atomicity.
+//
+// Callers should pass only the instances they actually revived; rows whose id
+// is absent are simply not in the batch and stay untouched.
 func (s *Storage) PersistRevivedInstances(instances []*Instance) error {
+	updates := make([]statedb.InstanceStatusUpdate, 0, len(instances))
 	for _, inst := range instances {
 		if inst == nil {
 			continue
 		}
-		row, err := instanceToRow(inst)
-		if err != nil {
-			return err
-		}
-		if err := s.saveSingleInstance(row); err != nil {
-			return err
-		}
+		updates = append(updates, statedb.InstanceStatusUpdate{
+			ID:     inst.ID,
+			Status: string(inst.Status),
+		})
 	}
-	return nil
+	if len(updates) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.db == nil {
+		return fmt.Errorf("storage database not initialized")
+	}
+	return s.db.PersistInstanceStatusesTx(updates)
 }
 
 // instanceToRow converts a session.Instance into the statedb row shape.

--- a/internal/session/storage_revive_clobber_test.go
+++ b/internal/session/storage_revive_clobber_test.go
@@ -1,0 +1,158 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReviveDoesNotClobberConcurrentlyAddedSession reproduces the lost-update
+// race between `session revive` and a concurrent `session add` (issue:
+// revive's read-process-write cycle drops rows added after it loaded).
+//
+// The exact production sequence (see revive_cmd.go + storage.go):
+//
+//  1. revive loads the full instances snapshot (LoadWithGroups).
+//  2. another process (TUI/CLI add) inserts a NEW session via the targeted
+//     single-row path (InsertSessionAndVerify -> SaveInstance, no sweep).
+//  3. revive persists its STALE snapshot. On origin/main this goes through
+//     SaveWithGroups -> SaveInstances, whose `DELETE FROM instances WHERE id
+//     NOT IN (<stale ids>)` sweep deletes the concurrently-added row because
+//     it was never in revive's snapshot.
+//
+// This test drives that sequence deterministically (no goroutine timing
+// needed) against a shared SQLite file. It FAILS on origin/main (the added
+// session is gone) and PASSES once revive persists only the rows it actually
+// touched via a targeted, sweep-free write.
+func TestReviveDoesNotClobberConcurrentlyAddedSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "state.db")
+
+	openStorage := func() *Storage {
+		db, err := statedb.Open(dbPath)
+		require.NoError(t, err)
+		require.NoError(t, db.Migrate())
+		t.Cleanup(func() { db.Close() })
+		return &Storage{db: db, dbPath: dbPath, profile: "_test"}
+	}
+
+	reviveStorage := openStorage()
+	addStorage := openStorage()
+
+	// Seed one pre-existing session that revive will heal.
+	existing := &Instance{
+		ID:          "sess-existing",
+		Title:       "existing",
+		ProjectPath: "/tmp/existing",
+		GroupPath:   "test",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      StatusError, // errored -> revive flips to running
+		CreatedAt:   time.Now().Add(-2 * time.Minute),
+	}
+	require.NoError(t, reviveStorage.SaveWithGroups(
+		[]*Instance{existing}, NewGroupTree([]*Instance{existing})))
+
+	// Step 1: revive loads the snapshot (only knows about sess-existing).
+	snapshot, groups, err := reviveStorage.LoadWithGroups()
+	require.NoError(t, err)
+	require.Len(t, snapshot, 1, "revive should load exactly the pre-existing session")
+
+	// Step 2: a concurrent `add` inserts a brand-new session via the targeted
+	// single-row path (the production path InsertSessionAndVerify uses).
+	added := &Instance{
+		ID:          "sess-added-concurrently",
+		Title:       "added-concurrently",
+		ProjectPath: "/tmp/added",
+		GroupPath:   "test",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      StatusRunning,
+		CreatedAt:   time.Now(),
+	}
+	require.NoError(t, addStorage.InsertSessionAndVerify(added, nil))
+
+	// Step 3: revive heals the errored session and persists. On main this used
+	// the stale full-table snapshot (SaveWithGroups) and clobbered sess-added.
+	// The fix persists only the rows revive actually touched, via a targeted
+	// sweep-free write (PersistRevivedInstances).
+	_ = groups
+	snapshot[0].Status = StatusRunning
+	require.NoError(t, reviveStorage.PersistRevivedInstances(snapshot))
+
+	// Assert: the concurrently-added session must survive.
+	loaded, err := openStorage().Load()
+	require.NoError(t, err)
+
+	ids := map[string]bool{}
+	for _, inst := range loaded {
+		ids[inst.ID] = true
+	}
+	assert.True(t, ids["sess-added-concurrently"],
+		"concurrently-added session must survive a concurrent revive (lost-update race)")
+	assert.True(t, ids["sess-existing"],
+		"the revived session must still be present")
+}
+
+// TestReviveSaveWithGroupsClobbersConcurrentAdd_DemonstratesBug pins down the
+// root cause: it drives the OLD revive save path (SaveWithGroups on the stale
+// snapshot) and asserts that it DOES clobber the concurrently-added row. This
+// is the negative witness — it documents exactly why revive must NOT use the
+// full-rewrite path. If a future change makes SaveWithGroups stop sweeping
+// (or someone "fixes" it differently), this test flags that the assumption
+// underpinning PersistRevivedInstances has shifted. The positive guarantee
+// lives in TestReviveDoesNotClobberConcurrentlyAddedSession above.
+func TestReviveSaveWithGroupsClobbersConcurrentAdd_DemonstratesBug(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "state.db")
+
+	openStorage := func() *Storage {
+		db, err := statedb.Open(dbPath)
+		require.NoError(t, err)
+		require.NoError(t, db.Migrate())
+		t.Cleanup(func() { db.Close() })
+		return &Storage{db: db, dbPath: dbPath, profile: "_test"}
+	}
+
+	reviveStorage := openStorage()
+	addStorage := openStorage()
+
+	existing := &Instance{
+		ID: "sess-existing", Title: "existing", ProjectPath: "/tmp/existing",
+		GroupPath: "test", Command: "claude", Tool: "claude",
+		Status: StatusError, CreatedAt: time.Now().Add(-2 * time.Minute),
+	}
+	require.NoError(t, reviveStorage.SaveWithGroups(
+		[]*Instance{existing}, NewGroupTree([]*Instance{existing})))
+
+	snapshot, _, err := reviveStorage.LoadWithGroups()
+	require.NoError(t, err)
+
+	added := &Instance{
+		ID: "sess-added-concurrently", Title: "added-concurrently",
+		ProjectPath: "/tmp/added", GroupPath: "test", Command: "claude",
+		Tool: "claude", Status: StatusRunning, CreatedAt: time.Now(),
+	}
+	require.NoError(t, addStorage.InsertSessionAndVerify(added, nil))
+
+	// The old revive persistence: full rewrite of the stale snapshot. Its
+	// DELETE-NOT-IN sweep drops sess-added-concurrently (absent from snapshot).
+	snapshot[0].Status = StatusRunning
+	require.NoError(t, reviveStorage.SaveWithGroups(snapshot, NewGroupTree(snapshot)))
+
+	loaded, err := openStorage().Load()
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, inst := range loaded {
+		ids[inst.ID] = true
+	}
+	// The old path's DELETE-NOT-IN sweep removes the concurrently-added row.
+	// This assertion documents the bug; it is the reason revive now routes
+	// through PersistRevivedInstances instead of SaveWithGroups.
+	assert.False(t, ids["sess-added-concurrently"],
+		"witness: the old SaveWithGroups revive path clobbers the concurrently-added row")
+}

--- a/internal/session/storage_revive_clobber_test.go
+++ b/internal/session/storage_revive_clobber_test.go
@@ -98,15 +98,21 @@ func TestReviveDoesNotClobberConcurrentlyAddedSession(t *testing.T) {
 		"the revived session must still be present")
 }
 
-// TestReviveSaveWithGroupsClobbersConcurrentAdd_DemonstratesBug pins down the
-// root cause: it drives the OLD revive save path (SaveWithGroups on the stale
-// snapshot) and asserts that it DOES clobber the concurrently-added row. This
-// is the negative witness — it documents exactly why revive must NOT use the
-// full-rewrite path. If a future change makes SaveWithGroups stop sweeping
-// (or someone "fixes" it differently), this test flags that the assumption
-// underpinning PersistRevivedInstances has shifted. The positive guarantee
-// lives in TestReviveDoesNotClobberConcurrentlyAddedSession above.
-func TestReviveSaveWithGroupsClobbersConcurrentAdd_DemonstratesBug(t *testing.T) {
+// TestPersistRevivedInstances_IsSweepFree is the contrastive guard for the
+// chosen persist path. It proves the PROPERTY revive depends on — that
+// PersistRevivedInstances never deletes a row absent from its argument — WITHOUT
+// pinning any particular behavior of SaveWithGroups.
+//
+// (It deliberately replaces an earlier "negative witness" test that asserted
+// SaveWithGroups DOES sweep. That made buggy full-rewrite behavior a required
+// contract: the day SaveWithGroups is globally de-swept — a desirable hardening
+// — the old test would fail for the wrong reason. What revive actually needs is
+// only that ITS path is sweep-free, which is exactly what we assert here.)
+//
+// Sequence: revive loads a 1-row snapshot, a concurrent add inserts a 2nd row,
+// then revive persists ONLY its snapshot row via PersistRevivedInstances. The
+// concurrently-added row must remain — proving no DELETE-NOT-IN sweep happened.
+func TestPersistRevivedInstances_IsSweepFree(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "state.db")
 
@@ -129,9 +135,12 @@ func TestReviveSaveWithGroupsClobbersConcurrentAdd_DemonstratesBug(t *testing.T)
 	require.NoError(t, reviveStorage.SaveWithGroups(
 		[]*Instance{existing}, NewGroupTree([]*Instance{existing})))
 
+	// revive loads its snapshot (only sess-existing).
 	snapshot, _, err := reviveStorage.LoadWithGroups()
 	require.NoError(t, err)
+	require.Len(t, snapshot, 1)
 
+	// A concurrent add inserts a second row after the snapshot was taken.
 	added := &Instance{
 		ID: "sess-added-concurrently", Title: "added-concurrently",
 		ProjectPath: "/tmp/added", GroupPath: "test", Command: "claude",
@@ -139,10 +148,9 @@ func TestReviveSaveWithGroupsClobbersConcurrentAdd_DemonstratesBug(t *testing.T)
 	}
 	require.NoError(t, addStorage.InsertSessionAndVerify(added, nil))
 
-	// The old revive persistence: full rewrite of the stale snapshot. Its
-	// DELETE-NOT-IN sweep drops sess-added-concurrently (absent from snapshot).
+	// revive persists ONLY its snapshot row through the targeted path.
 	snapshot[0].Status = StatusRunning
-	require.NoError(t, reviveStorage.SaveWithGroups(snapshot, NewGroupTree(snapshot)))
+	require.NoError(t, reviveStorage.PersistRevivedInstances(snapshot))
 
 	loaded, err := openStorage().Load()
 	require.NoError(t, err)
@@ -150,9 +158,10 @@ func TestReviveSaveWithGroupsClobbersConcurrentAdd_DemonstratesBug(t *testing.T)
 	for _, inst := range loaded {
 		ids[inst.ID] = true
 	}
-	// The old path's DELETE-NOT-IN sweep removes the concurrently-added row.
-	// This assertion documents the bug; it is the reason revive now routes
-	// through PersistRevivedInstances instead of SaveWithGroups.
-	assert.False(t, ids["sess-added-concurrently"],
-		"witness: the old SaveWithGroups revive path clobbers the concurrently-added row")
+	// The targeted path performs NO sweep: a row absent from its argument is
+	// left untouched. This is the property revive relies on.
+	assert.True(t, ids["sess-added-concurrently"],
+		"PersistRevivedInstances must be sweep-free: a row absent from its argument must survive")
+	assert.True(t, ids["sess-existing"],
+		"the revived row must persist")
 }

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -970,6 +970,81 @@ func (s *StateDB) WriteStatus(id, status, tool string) error {
 	})
 }
 
+// InstanceStatusUpdate is one targeted status mutation for
+// PersistInstanceStatusesTx: set instances.status = Status WHERE id = ID.
+// No other column is touched, so a concurrent writer's edits to any other
+// field of the same row are preserved.
+type InstanceStatusUpdate struct {
+	ID     string
+	Status string
+}
+
+// PersistInstanceStatusesTx applies a batch of targeted status updates inside a
+// SINGLE transaction. It is the persistence primitive for `session revive`.
+//
+// Why a dedicated primitive (two independent guarantees):
+//
+//  1. ATOMICITY / no partial write. All rows commit together or none do. A
+//     mid-loop failure on `revive --all` rolls the whole batch back instead of
+//     leaving the table half-healed (some rows StatusRunning, some still
+//     StatusError). Per-row INSERT-OR-REPLACE outside a tx could not promise
+//     this.
+//
+//  2. NO clobber of concurrent edits. Each row is written with a TARGETED
+//     `UPDATE instances SET status = ? WHERE id = ?` — only the single column
+//     revive owns (see Reviver.defaultReviveAction, which mutates nothing but
+//     Instance.Status). It deliberately does NOT use INSERT OR REPLACE of the
+//     whole row: a full-row write would overwrite every other column from
+//     revive's stale in-memory snapshot, clobbering any field (title, group,
+//     tool_data, last_accessed, …) a concurrent process edited between
+//     revive's load and its save. Mirrors WriteStatus / WriteClaudeSessionBinding,
+//     which target single columns for exactly this reason.
+//
+// There is NO DELETE sweep here — a row absent from `updates` is left entirely
+// untouched, so revive can never drop a session a concurrent `add` inserted
+// after revive loaded its snapshot (the lost-update race this fixes). Rows
+// whose id no longer exists (removed concurrently) simply match zero rows; the
+// UPDATE is a benign no-op, never a resurrection.
+//
+// The acknowledged-reset mirrors WriteStatus: flipping a row to "running"
+// clears its acknowledged flag so the TUI re-surfaces the freshly-revived
+// session. Wrapped in withBusyRetry because the whole batch is idempotent
+// (targeted UPDATEs to fixed ids), matching SaveInstances' retry rationale.
+func (s *StateDB) PersistInstanceStatusesTx(updates []InstanceStatusUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	return withBusyRetry(func() error {
+		tx, err := s.db.Begin()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = tx.Rollback() }()
+
+		stmt, err := tx.Prepare(
+			`UPDATE instances
+			   SET status = ?,
+			       acknowledged = CASE WHEN ? = 'running' THEN 0 ELSE acknowledged END
+			 WHERE id = ?`,
+		)
+		if err != nil {
+			return err
+		}
+		defer stmt.Close()
+
+		for _, u := range updates {
+			if _, err := stmt.Exec(u.Status, u.Status, u.ID); err != nil {
+				return err
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		_ = s.Touch()
+		return nil
+	})
+}
+
 // WriteClaudeSessionBinding atomically updates claude_session_id and
 // claude_detected_at inside the tool_data JSON column for the given
 // instance. Used by the hook-rebind path (UpdateHookStatus →


### PR DESCRIPTION
## Symptom

Sessions created in the TUI/CLI could silently disappear. On hosts this got weaponized into a recurring loss: an ssh-driven `revive` `.path` storm (repeated `session revive --all`) would delete sessions that other processes added concurrently.

## Root cause — a lost-update race

`session revive` persisted through the old path `SaveWithGroups -> SaveInstances`, which performs a full-table sweep:

```
DELETE FROM instances WHERE id NOT IN (<ids from the stale in-memory snapshot>)
```

The snapshot is loaded at the start of the revive run. Any session inserted by the TUI/CLI *after* that snapshot is loaded is not in the `NOT IN` set, so the sweep silently deletes it. Concurrent `revive` runs (or a revive racing a normal add) lose those rows.

## The fix

Route revive persistence through a new sweep-free path. It writes only the revived instances via a targeted `UPDATE instances SET status = ? ... WHERE id = ?`. There is no `DELETE` sweep and no full-row rewrite on this path, so concurrently-added rows and concurrent edits to other columns can no longer be clobbered.

- `handleSessionRevive` only persists instances where `Class == ClassErrored && Revived == true`; a `len(revived) > 0` guard skips empty writes entirely.
- All non-revive persistence (TUI, CLI add, move, fork) still uses `SaveWithGroups` unchanged.
- S1 (`ErrRefusingEmptySweep`) and S2 (backup-before-large-drop) safeguards on `SaveInstances` remain intact and are simply no longer in revive's path.

## Regression test

`internal/session/storage_revive_clobber_test.go` drives the race deterministically over a shared SQLite file (no goroutine timing):

- **Concurrent add survives:** seed errored session -> load snapshot -> concurrent `InsertSessionAndVerify` adds a new session -> revive heals -> assert the concurrently-added session still exists.
- **Concurrent non-status edit survives:** a concurrent edit to a different column of the revived row is preserved through the targeted-`UPDATE` path.
- The earlier negative-witness test was replaced with a sweep-free property test for the targeted path.
- CLI-level coverage via `reviveAndPersist` guards against a regression back to the full-save seam.

## Hardening (addresses Codex review)

The four Codex follow-ups from the first review round are now resolved on tip `85321ffe`:

1. **Batched transaction** — revived rows are now committed in a single SQLite transaction via `PersistInstanceStatusesTx`; a mid-loop failure on `revive --all` rolls the batch back instead of leaving a partial write.
2. **No full-row overwrite** — replaced the full-row `INSERT OR REPLACE` with a targeted `UPDATE ... SET status WHERE id`, so stale snapshot fields (`title`, `group_path`, `tool_data`, `last_accessed`, …) are never rewritten. (`acknowledged` is reset on transition to `running`, intentionally mirroring `WriteStatus`.)
3. **ReviveAll mutation invariant** — `runReviveAll` persists only the actually-revived subset, under a documented `ReviveAll` invariant in `reviver.go` (it mutates only successfully-revived errored rows).
4. **CLI-level test** — added a test at the `reviveAndPersist` seam so a regression back to `saveSessionData` is caught, in addition to the storage-level tests.

Codex re-review (tip `85321ffe`) verdict: **safe-to-merge**, no remaining blocking issues, deadlock risk low (storage mutex held only around the DB batch; SQLite busy-retry wraps an idempotent transaction). Corroborated with a sandboxed build + revive-path tests in `internal/session`, `internal/statedb`, and `cmd/agent-deck` (all pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Revive now persists only healed status updates, preventing concurrent adds/edits from being lost during session recovery.

* **New Features**
  * Added a targeted, transactional persistence path that updates instance status without rewriting full rows.

* **Tests**
  * Expanded tests (unit and CLI) to cover concurrent add/edit scenarios and verify revive persistence preserves concurrent changes.

* **Documentation**
  * Added notes about revive-classification race and mutation invariants for future maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
