### PR TITLE
feat(ui): lighter curated TUI footer (opt-in [ui] footer) — supersedes #1289

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -242,6 +242,20 @@ type UISettings struct {
 	// display filter only — `agent-deck launch -c <tool>` still spawns a hidden
 	// tool.
 	ShowOnlyInstalledTools bool `toml:"show_only_installed_tools"`
+
+	// Footer controls the style of the bottom hint bar. Valid values:
+	//   "curated" (default) — lighter, dim inline text advertising only the
+	//                         actions relevant to the selected row, with the
+	//                         settings and help keys always last.
+	//   "full"              — the historic verbose bar: filled key chips,
+	//                         width-adaptive, advertising every action.
+	//   "compact"           — force the abbreviated chip tier regardless of width.
+	//   "minimal"           — force the keys-only tier regardless of width.
+	// Empty or unknown values fall back to "curated". This is purely a
+	// rendering preference (TUI UX initiative, item 1): no keybinding is
+	// added, removed, or changed — only what the footer advertises. Every
+	// action remains reachable by its key and is fully listed under help (?).
+	Footer string `toml:"footer"`
 }
 
 // DefaultPreviewPct is the default preview-pane width percentage.
@@ -261,6 +275,33 @@ const (
 	ITermOpenAsWindow  = "window"
 	DefaultITermOpenAs = ITermOpenAsTab
 )
+
+// Footer hint-bar styles. See UISettings.Footer.
+const (
+	FooterCurated = "curated"
+	FooterFull    = "full"
+	FooterCompact = "compact"
+	FooterMinimal = "minimal"
+	DefaultFooter = FooterCurated
+)
+
+// GetFooter returns the configured footer style, normalized to one of the
+// known values. Empty or unknown input falls back to DefaultFooter
+// ("curated"). Matching is case-insensitive so users may write "Full" or
+// "MINIMAL" in TOML.
+func (u UISettings) GetFooter() string {
+	switch strings.ToLower(strings.TrimSpace(u.Footer)) {
+	case FooterFull:
+		return FooterFull
+	case FooterCompact:
+		return FooterCompact
+	case FooterMinimal:
+		return FooterMinimal
+	case FooterCurated:
+		return FooterCurated
+	}
+	return DefaultFooter
+}
 
 // GetPreviewPct returns the configured preview percentage, clamped to
 // [MinPreviewPct, MaxPreviewPct]. Falls back to DefaultPreviewPct when

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -244,14 +244,16 @@ type UISettings struct {
 	ShowOnlyInstalledTools bool `toml:"show_only_installed_tools"`
 
 	// Footer controls the style of the bottom hint bar. Valid values:
-	//   "curated" (default) — lighter, dim inline text advertising only the
+	//   "full" (default)    — the historic verbose bar: filled key chips,
+	//                         width-adaptive, advertising every action. This is
+	//                         today's behavior and stays the default so the look
+	//                         never changes without an explicit opt-in.
+	//   "curated"           — lighter, dim inline text advertising only the
 	//                         actions relevant to the selected row, with the
-	//                         settings and help keys always last.
-	//   "full"              — the historic verbose bar: filled key chips,
-	//                         width-adaptive, advertising every action.
+	//                         settings and help keys always last (opt-in).
 	//   "compact"           — force the abbreviated chip tier regardless of width.
 	//   "minimal"           — force the keys-only tier regardless of width.
-	// Empty or unknown values fall back to "curated". This is purely a
+	// Empty or unknown values fall back to "full". This is purely a
 	// rendering preference (TUI UX initiative, item 1): no keybinding is
 	// added, removed, or changed — only what the footer advertises. Every
 	// action remains reachable by its key and is fully listed under help (?).
@@ -282,12 +284,15 @@ const (
 	FooterFull    = "full"
 	FooterCompact = "compact"
 	FooterMinimal = "minimal"
-	DefaultFooter = FooterCurated
+	// DefaultFooter is the historic verbose bar ("full"). Keeping it as the
+	// default preserves today's look; curated/compact/minimal are opt-in via
+	// config.toml [ui] footer.
+	DefaultFooter = FooterFull
 )
 
 // GetFooter returns the configured footer style, normalized to one of the
 // known values. Empty or unknown input falls back to DefaultFooter
-// ("curated"). Matching is case-insensitive so users may write "Full" or
+// ("full"). Matching is case-insensitive so users may write "Full" or
 // "MINIMAL" in TOML.
 func (u UISettings) GetFooter() string {
 	switch strings.ToLower(strings.TrimSpace(u.Footer)) {

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -2120,22 +2120,23 @@ active_filter_excludes = ["error", "stopped"]
 }
 
 // TestUISettings_GetFooter covers the [ui] footer style knob (TUI UX
-// initiative, item 1). Unset/unknown values fall back to the curated default;
-// known values are normalized case-insensitively.
+// initiative, item 1). Unset/unknown values fall back to the "full" default
+// (today's verbose bar — default-preserving); curated/compact/minimal are
+// opt-in. Known values are normalized case-insensitively.
 func TestUISettings_GetFooter(t *testing.T) {
 	cases := []struct {
 		name string
 		ui   UISettings
 		want string
 	}{
-		{"unset uses curated default", UISettings{}, FooterCurated},
-		{"explicit curated", UISettings{Footer: "curated"}, FooterCurated},
+		{"unset uses full default (preserve today's look)", UISettings{}, FooterFull},
+		{"explicit curated (opt-in)", UISettings{Footer: "curated"}, FooterCurated},
 		{"full", UISettings{Footer: "full"}, FooterFull},
 		{"compact", UISettings{Footer: "compact"}, FooterCompact},
 		{"minimal", UISettings{Footer: "minimal"}, FooterMinimal},
 		{"case-insensitive", UISettings{Footer: "FULL"}, FooterFull},
 		{"trimmed", UISettings{Footer: "  minimal  "}, FooterMinimal},
-		{"unknown falls back to curated", UISettings{Footer: "bogus"}, FooterCurated},
+		{"unknown falls back to full", UISettings{Footer: "bogus"}, FooterFull},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2143,6 +2144,18 @@ func TestUISettings_GetFooter(t *testing.T) {
 				t.Fatalf("GetFooter() on %+v = %q, want %q", tc.ui, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestUISettings_GetFooter_DefaultIsFull is the focused default-preserving
+// guarantee for PR #1289: with no config, the footer is the historic verbose
+// "full" bar, so nobody's UI changes without an explicit opt-in.
+func TestUISettings_GetFooter_DefaultIsFull(t *testing.T) {
+	if got := (UISettings{}).GetFooter(); got != FooterFull {
+		t.Fatalf("default GetFooter() = %q, want %q (must preserve today's verbose bar)", got, FooterFull)
+	}
+	if DefaultFooter != FooterFull {
+		t.Fatalf("DefaultFooter = %q, want %q", DefaultFooter, FooterFull)
 	}
 }
 

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -2118,3 +2118,45 @@ active_filter_excludes = ["error", "stopped"]
 		t.Errorf("running should not be excluded, got %v", got)
 	}
 }
+
+// TestUISettings_GetFooter covers the [ui] footer style knob (TUI UX
+// initiative, item 1). Unset/unknown values fall back to the curated default;
+// known values are normalized case-insensitively.
+func TestUISettings_GetFooter(t *testing.T) {
+	cases := []struct {
+		name string
+		ui   UISettings
+		want string
+	}{
+		{"unset uses curated default", UISettings{}, FooterCurated},
+		{"explicit curated", UISettings{Footer: "curated"}, FooterCurated},
+		{"full", UISettings{Footer: "full"}, FooterFull},
+		{"compact", UISettings{Footer: "compact"}, FooterCompact},
+		{"minimal", UISettings{Footer: "minimal"}, FooterMinimal},
+		{"case-insensitive", UISettings{Footer: "FULL"}, FooterFull},
+		{"trimmed", UISettings{Footer: "  minimal  "}, FooterMinimal},
+		{"unknown falls back to curated", UISettings{Footer: "bogus"}, FooterCurated},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ui.GetFooter(); got != tc.want {
+				t.Fatalf("GetFooter() on %+v = %q, want %q", tc.ui, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUISettings_GetFooter_TomlRoundtrip verifies the toml tag wires up.
+func TestUISettings_GetFooter_TomlRoundtrip(t *testing.T) {
+	const cfg = `
+[ui]
+footer = "full"
+`
+	var c UserConfig
+	if _, err := toml.Decode(cfg, &c); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := c.UI.GetFooter(); got != FooterFull {
+		t.Errorf("GetFooter() = %q, want %q", got, FooterFull)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12043,27 +12043,40 @@ func (h *Home) curatedHint(hint footerHint) string {
 	return keyStyle.Render(hint.key) + " " + labelStyle.Render(hint.label)
 }
 
-// curatedContextHints returns the context-relevant hints for the selected row.
-// It advertises only the primary action(s) for the current selection; rarer
-// and global actions stay under help (?). The settings and help keys are added
-// separately by renderHelpBarCurated so they always remain last.
+// maxCuratedContextHints caps how many context-relevant shortcuts the curated
+// footer advertises for the selected row. The settings and help keys are added
+// on top of these by renderHelpBarCurated, so the bar stays short while still
+// surfacing the two or three most useful actions for what is highlighted.
+const maxCuratedContextHints = 3
+
+// curatedContextHints returns up to maxCuratedContextHints context-relevant
+// hints for the selected row, in priority order. It advertises the actions most
+// likely to be wanted for the current selection; rarer and global actions stay
+// under help (?). The settings and help keys are added separately by
+// renderHelpBarCurated so they always remain last.
 func (h *Home) curatedContextHints(item session.Item) []footerHint {
 	var hints []footerHint
 	add := func(key, label string) {
+		if len(hints) >= maxCuratedContextHints {
+			return
+		}
 		if strings.TrimSpace(key) != "" {
 			hints = append(hints, footerHint{key: key, label: label})
 		}
 	}
 
+	newQuick := joinHotkeyLabels(h.actionKey(hotkeyNewSession), h.actionKey(hotkeyQuickCreate))
+
 	switch item.Type {
 	case session.ItemTypeGroup:
-		// Group row: the relevant action is collapse/expand. The toggle key is
-		// Tab (also l/h); advertise the direction that matches current state.
+		// Group row: collapse/expand first (Tab; also l/h), then create/manage.
 		if item.Group != nil && item.Group.Expanded {
 			add("Tab", "collapse")
 		} else {
 			add("Tab", "expand")
 		}
+		add(newQuick, "new")
+		add(h.actionKey(hotkeyRename), "rename")
 
 	case session.ItemTypeSession:
 		s := item.Session
@@ -12071,15 +12084,24 @@ func (h *Home) curatedContextHints(item session.Item) []footerHint {
 			return hints
 		}
 		if sessionIsDead(s) {
-			// Dead (stopped or error): the useful actions are restart and,
-			// when the tool tracks a session id, restart-fresh.
+			// Dead (stopped or error): restart, then restart-fresh when the
+			// tool tracks a session id, then delete — the actions for a session
+			// that broke or was parked, in order of likely intent.
 			add(h.actionKey(hotkeyRestart), "restart")
 			if s.CanRestartFresh() {
 				add(h.actionKey(hotkeyRestartFresh), "restart fresh")
 			}
+			add(h.actionKey(hotkeyDelete), "delete")
 		} else {
-			// Live/attachable session: Enter attaches.
+			// Live/attachable session: attach first, then restart, then the
+			// most relevant follow-up (fork while forkable, else new).
 			add("⏎", "attach")
+			add(h.actionKey(hotkeyRestart), "restart")
+			if s.CanFork() {
+				add(h.actionKey(hotkeyQuickFork), "fork")
+			} else {
+				add(newQuick, "new")
+			}
 		}
 
 	case session.ItemTypeWindow:
@@ -12111,10 +12133,19 @@ func (h *Home) renderHelpBarCurated() string {
 	case h.jumpMode:
 		hints = append(hints, footerHint{key: "a-z", label: "jump"}, footerHint{key: "esc", label: "cancel"})
 	case len(h.flatItems) == 0:
-		// Empty list: the only useful action is creating a session.
-		if newQuick := joinHotkeyLabels(h.actionKey(hotkeyNewSession), h.actionKey(hotkeyQuickCreate)); newQuick != "" {
-			hints = append(hints, footerHint{key: newQuick, label: "new"})
+		// Empty list: the useful actions all create something — new session,
+		// import, or a group. Cap at the same budget as context hints.
+		add := func(key, label string) {
+			if len(hints) >= maxCuratedContextHints {
+				return
+			}
+			if strings.TrimSpace(key) != "" {
+				hints = append(hints, footerHint{key: key, label: label})
+			}
 		}
+		add(joinHotkeyLabels(h.actionKey(hotkeyNewSession), h.actionKey(hotkeyQuickCreate)), "new")
+		add(h.actionKey(hotkeyImport), "import")
+		add(h.actionKey(hotkeyCreateGroup), "group")
 	case h.cursor < len(h.flatItems):
 		hints = append(hints, h.curatedContextHints(h.flatItems[h.cursor])...)
 	}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12048,6 +12048,50 @@ func (h *Home) curatedHint(hint footerHint) string {
 	return keyStyle.Render(hint.key) + " " + labelStyle.Render(hint.label)
 }
 
+// fitCuratedHints returns the global hints (settings/help) preceded by as many
+// of the context hints as fit within h.width, dropping the lowest-priority
+// context hints (those at the end of the slice) first. The global hints are
+// always kept, even if that means dropping every context hint, so the curated
+// footer never loses the settings and help keys to right-edge truncation on a
+// narrow terminal. Widths are measured with lipgloss.Width to match how the
+// joined content is rendered, including the two-space separators.
+func (h *Home) fitCuratedHints(contextHints, globalHints []footerHint) []footerHint {
+	const sepWidth = 2 // the "  " separator between rendered hints
+
+	width := func(hint footerHint) int {
+		return lipgloss.Width(h.curatedHint(hint))
+	}
+
+	// Baseline: the global hints always render. Their combined width is the
+	// floor we cannot trim below.
+	used := 0
+	for i, hint := range globalHints {
+		used += width(hint)
+		if i > 0 {
+			used += sepWidth
+		}
+	}
+
+	// Greedily keep context hints from the front (highest priority) while each
+	// still fits. h.width <= 0 (uninitialized) means "no constraint" — keep all.
+	rendered := used > 0 // whether anything has been counted yet (for separators)
+	kept := make([]footerHint, 0, len(contextHints)+len(globalHints))
+	for _, hint := range contextHints {
+		next := used + width(hint)
+		if rendered {
+			next += sepWidth
+		}
+		if h.width > 0 && next > h.width {
+			break
+		}
+		kept = append(kept, hint)
+		used = next
+		rendered = true
+	}
+
+	return append(kept, globalHints...)
+}
+
 // maxCuratedContextHints caps how many context-relevant shortcuts the curated
 // footer advertises for the selected row. The settings and help keys are added
 // on top of these by renderHelpBarCurated, so the bar stays short while still
@@ -12088,7 +12132,16 @@ func (h *Home) curatedContextHints(item session.Item) []footerHint {
 		if s == nil {
 			return hints
 		}
-		if sessionIsDead(s) {
+		if sessionIsQueued(s) {
+			// Queued: waiting for a group slot, no tmux yet — so it is neither
+			// attachable (no pane to enter) nor restartable (nothing running to
+			// restart). The only meaningful actions are dropping it from the
+			// queue or creating something else. Without this branch the curated
+			// footer advertised "⏎ attach"+restart for a session that has no
+			// tmux (PR #1289 review nit 2b).
+			add(h.actionKey(hotkeyDelete), "delete")
+			add(newQuick, "new")
+		} else if sessionIsDead(s) {
 			// Dead (stopped or error): restart, then restart-fresh when the
 			// tool tracks a session id, then delete — the actions for a session
 			// that broke or was parked, in order of likely intent.
@@ -12132,6 +12185,13 @@ func sessionIsDead(s *session.Instance) bool {
 	return status == session.StatusStopped || status == session.StatusError
 }
 
+// sessionIsQueued reports whether a session is waiting for a group slot and has
+// no tmux yet — so it is neither attachable nor restartable. Reads the status
+// via the thread-safe getter for the same concurrency reason as sessionIsDead.
+func sessionIsQueued(s *session.Instance) bool {
+	return s.GetStatusThreadSafe() == session.StatusQueued
+}
+
 // renderHelpBarCurated renders the lighter, context-aware footer (the default
 // "curated" style). It shows dim, plain inline hints for only the actions
 // relevant to the selected row, and always keeps the settings key then the help
@@ -12141,36 +12201,45 @@ func (h *Home) renderHelpBarCurated() string {
 	borderStyle := lipgloss.NewStyle().Foreground(ColorBorder)
 	border := borderStyle.Render(strings.Repeat("─", max(0, h.width)))
 
-	var hints []footerHint
+	// Context hints (jump / empty-list / selected-row actions) are
+	// lower-priority and listed in descending priority order, so they are the
+	// ones dropped first when the bar is too narrow.
+	var contextHints []footerHint
 
 	switch {
 	case h.jumpMode:
-		hints = append(hints, footerHint{key: "a-z", label: "jump"}, footerHint{key: "esc", label: "cancel"})
+		contextHints = append(contextHints, footerHint{key: "a-z", label: "jump"}, footerHint{key: "esc", label: "cancel"})
 	case len(h.flatItems) == 0:
 		// Empty list: the useful actions all create something — new session,
 		// import, or a group. Cap at the same budget as context hints.
 		add := func(key, label string) {
-			if len(hints) >= maxCuratedContextHints {
+			if len(contextHints) >= maxCuratedContextHints {
 				return
 			}
 			if strings.TrimSpace(key) != "" {
-				hints = append(hints, footerHint{key: key, label: label})
+				contextHints = append(contextHints, footerHint{key: key, label: label})
 			}
 		}
 		add(joinHotkeyLabels(h.actionKey(hotkeyNewSession), h.actionKey(hotkeyQuickCreate)), "new")
 		add(h.actionKey(hotkeyImport), "import")
 		add(h.actionKey(hotkeyCreateGroup), "group")
 	case h.cursor >= 0 && h.cursor < len(h.flatItems):
-		hints = append(hints, h.curatedContextHints(h.flatItems[h.cursor])...)
+		contextHints = append(contextHints, h.curatedContextHints(h.flatItems[h.cursor])...)
 	}
 
-	// Always keep settings then help as the LAST two items, in that order.
+	// Settings then help are the always-kept global hints, in that order. They
+	// are never dropped: when the terminal is too narrow, lower-priority context
+	// hints are trimmed from the right instead so these two always survive
+	// (PR #1289 review nit 2a — previously MaxWidth truncation could clip them).
+	var globalHints []footerHint
 	if key := h.actionKey(hotkeySettings); key != "" {
-		hints = append(hints, footerHint{key: key, label: "settings"})
+		globalHints = append(globalHints, footerHint{key: key, label: "settings"})
 	}
 	if key := h.actionKey(hotkeyHelp); key != "" {
-		hints = append(hints, footerHint{key: key, label: "help"})
+		globalHints = append(globalHints, footerHint{key: key, label: "help"})
 	}
+
+	hints := h.fitCuratedHints(contextHints, globalHints)
 
 	parts := make([]string, 0, len(hints))
 	for _, hint := range hints {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -12107,15 +12107,24 @@ func (h *Home) curatedContextHints(item session.Item) []footerHint {
 	case session.ItemTypeWindow:
 		// A tmux window row attaches just like its session.
 		add("⏎", "attach")
+
+	case session.ItemTypeRemoteSession:
+		// A remote session row attaches over SSH just like a local session;
+		// without this case the curated footer dropped the attach hint for
+		// remote rows (PR #1289 review nit 1).
+		add("⏎", "attach")
 	}
 
 	return hints
 }
 
 // sessionIsDead reports whether a session is stopped or errored — the states
-// for which restart, rather than attach, is the relevant footer action.
+// for which restart, rather than attach, is the relevant footer action. Reads
+// the status via the thread-safe getter since the render goroutine runs
+// concurrently with backgroundStatusUpdate (PR #1289 review nit 2).
 func sessionIsDead(s *session.Instance) bool {
-	return s.Status == session.StatusStopped || s.Status == session.StatusError
+	status := s.GetStatusThreadSafe()
+	return status == session.StatusStopped || status == session.StatusError
 }
 
 // renderHelpBarCurated renders the lighter, context-aware footer (the default

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -426,6 +426,12 @@ type Home struct {
 	previewPct          int       // 10-90, default 65
 	previewPctOverlayAt time.Time // when to hide the split overlay (zero = hidden)
 
+	// footerMode selects the bottom hint-bar style (config.toml [ui] footer).
+	// One of session.FooterCurated (default), FooterFull, FooterCompact, or
+	// FooterMinimal. Cached so every render of a frame agrees. Additive/opt-in:
+	// it only changes WHAT the footer advertises, never a keybinding.
+	footerMode string
+
 	// Performance observability (debug mode only, zero cost when off)
 	debugMode          bool         // true when AGENTDECK_DEBUG=1, enables perf overlay
 	lastRenderDuration atomic.Int64 // microseconds, for debug status bar
@@ -992,6 +998,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.previewPct = cfg.UI.GetPreviewPct()
 		h.remoteLatencyRefreshSec = cfg.UI.GetRemoteLatencyRefreshSecs(cfg.SystemStats.GetRefreshSeconds())
 		h.remoteSessionRefreshSec = cfg.UI.GetRemoteSessionRefreshSecs()
+		h.footerMode = cfg.UI.GetFooter()
 	} else {
 		h.fullRepaint = (session.DisplaySettings{}).GetFullRepaint()
 		h.activeFilterExcludes = (session.DisplaySettings{}).GetActiveFilterExcludes()
@@ -999,6 +1006,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.previewPct = session.DefaultPreviewPct
 		h.remoteLatencyRefreshSec = (session.UISettings{}).GetRemoteLatencyRefreshSecs(0)
 		h.remoteSessionRefreshSec = (session.UISettings{}).GetRemoteSessionRefreshSecs()
+		h.footerMode = (session.UISettings{}).GetFooter()
 	}
 	h.remoteLatency = make(map[string]session.RemoteLatency)
 
@@ -11461,12 +11469,39 @@ func renderSimpleMCPLine(b *strings.Builder, mcpInfo *session.MCPInfo, width int
 	b.WriteString("\n")
 }
 
-// renderHelpBar renders context-aware keyboard shortcuts, adapting to terminal width
+// renderHelpBar renders context-aware keyboard shortcuts. The style is
+// selected by config.toml [ui] footer (cached in h.footerMode):
+//
+//   - "curated" (default): a lighter, dim inline bar that advertises only the
+//     actions relevant to the selected row, with the settings and help keys
+//     always last. Rarer/global actions live under help (?).
+//   - "full": the historic verbose bar with filled key chips, adapting to
+//     terminal width across the tiny/minimal/compact/full tiers.
+//   - "compact" / "minimal": force a single verbose tier regardless of width.
+//
+// The very-narrow tiny tier is always used below layoutBreakpointSingle so the
+// bar never overflows, whatever the configured style.
 func (h *Home) renderHelpBar() string {
-	// Route to appropriate tier based on width
-	switch {
-	case h.width < layoutBreakpointSingle:
+	if h.width < layoutBreakpointSingle {
 		return h.renderHelpBarTiny()
+	}
+
+	switch h.footerMode {
+	case session.FooterFull:
+		return h.renderHelpBarWidthAdaptive()
+	case session.FooterCompact:
+		return h.renderHelpBarCompact()
+	case session.FooterMinimal:
+		return h.renderHelpBarMinimal()
+	default:
+		return h.renderHelpBarCurated()
+	}
+}
+
+// renderHelpBarWidthAdaptive routes to the historic width-based tiers used by
+// the "full" footer style.
+func (h *Home) renderHelpBarWidthAdaptive() string {
+	switch {
 	case h.width < 70:
 		return h.renderHelpBarMinimal()
 	case h.width < 100:
@@ -11991,6 +12026,116 @@ func (h *Home) helpKey(key, desc string) string {
 		Padding(0, 1)
 	descStyle := lipgloss.NewStyle().Foreground(ColorText)
 	return keyStyle.Render(key) + " " + descStyle.Render(desc)
+}
+
+// footerHint is one rendered key/label pair for the curated footer.
+type footerHint struct {
+	key   string
+	label string
+}
+
+// curatedHint formats a single footer hint as dim, plain inline text — the key
+// in a slightly emphasized dim, the label in the same dim tone. No filled chip:
+// the curated bar should recede rather than compete for attention.
+func (h *Home) curatedHint(hint footerHint) string {
+	keyStyle := lipgloss.NewStyle().Foreground(ColorComment).Bold(true)
+	labelStyle := lipgloss.NewStyle().Foreground(ColorComment)
+	return keyStyle.Render(hint.key) + " " + labelStyle.Render(hint.label)
+}
+
+// curatedContextHints returns the context-relevant hints for the selected row.
+// It advertises only the primary action(s) for the current selection; rarer
+// and global actions stay under help (?). The settings and help keys are added
+// separately by renderHelpBarCurated so they always remain last.
+func (h *Home) curatedContextHints(item session.Item) []footerHint {
+	var hints []footerHint
+	add := func(key, label string) {
+		if strings.TrimSpace(key) != "" {
+			hints = append(hints, footerHint{key: key, label: label})
+		}
+	}
+
+	switch item.Type {
+	case session.ItemTypeGroup:
+		// Group row: the relevant action is collapse/expand. The toggle key is
+		// Tab (also l/h); advertise the direction that matches current state.
+		if item.Group != nil && item.Group.Expanded {
+			add("Tab", "collapse")
+		} else {
+			add("Tab", "expand")
+		}
+
+	case session.ItemTypeSession:
+		s := item.Session
+		if s == nil {
+			return hints
+		}
+		if sessionIsDead(s) {
+			// Dead (stopped or error): the useful actions are restart and,
+			// when the tool tracks a session id, restart-fresh.
+			add(h.actionKey(hotkeyRestart), "restart")
+			if s.CanRestartFresh() {
+				add(h.actionKey(hotkeyRestartFresh), "restart fresh")
+			}
+		} else {
+			// Live/attachable session: Enter attaches.
+			add("⏎", "attach")
+		}
+
+	case session.ItemTypeWindow:
+		// A tmux window row attaches just like its session.
+		add("⏎", "attach")
+	}
+
+	return hints
+}
+
+// sessionIsDead reports whether a session is stopped or errored — the states
+// for which restart, rather than attach, is the relevant footer action.
+func sessionIsDead(s *session.Instance) bool {
+	return s.Status == session.StatusStopped || s.Status == session.StatusError
+}
+
+// renderHelpBarCurated renders the lighter, context-aware footer (the default
+// "curated" style). It shows dim, plain inline hints for only the actions
+// relevant to the selected row, and always keeps the settings key then the help
+// key as the last two items. It advertises nothing that the verbose bar bound —
+// every action remains reachable by its key and is fully listed under help (?).
+func (h *Home) renderHelpBarCurated() string {
+	borderStyle := lipgloss.NewStyle().Foreground(ColorBorder)
+	border := borderStyle.Render(strings.Repeat("─", max(0, h.width)))
+
+	var hints []footerHint
+
+	switch {
+	case h.jumpMode:
+		hints = append(hints, footerHint{key: "a-z", label: "jump"}, footerHint{key: "esc", label: "cancel"})
+	case len(h.flatItems) == 0:
+		// Empty list: the only useful action is creating a session.
+		if newQuick := joinHotkeyLabels(h.actionKey(hotkeyNewSession), h.actionKey(hotkeyQuickCreate)); newQuick != "" {
+			hints = append(hints, footerHint{key: newQuick, label: "new"})
+		}
+	case h.cursor < len(h.flatItems):
+		hints = append(hints, h.curatedContextHints(h.flatItems[h.cursor])...)
+	}
+
+	// Always keep settings then help as the LAST two items, in that order.
+	if key := h.actionKey(hotkeySettings); key != "" {
+		hints = append(hints, footerHint{key: key, label: "settings"})
+	}
+	if key := h.actionKey(hotkeyHelp); key != "" {
+		hints = append(hints, footerHint{key: key, label: "help"})
+	}
+
+	parts := make([]string, 0, len(hints))
+	for _, hint := range hints {
+		parts = append(parts, h.curatedHint(hint))
+	}
+	sepStyle := lipgloss.NewStyle().Foreground(ColorBorder)
+	content := strings.Join(parts, sepStyle.Render("  "))
+
+	raw := lipgloss.JoinVertical(lipgloss.Left, border, content)
+	return lipgloss.NewStyle().MaxWidth(h.width).Render(raw)
 }
 
 // renderDebugBar renders a compact performance overlay for debug mode.

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -11472,11 +11472,13 @@ func renderSimpleMCPLine(b *strings.Builder, mcpInfo *session.MCPInfo, width int
 // renderHelpBar renders context-aware keyboard shortcuts. The style is
 // selected by config.toml [ui] footer (cached in h.footerMode):
 //
-//   - "curated" (default): a lighter, dim inline bar that advertises only the
+//   - "full" (default): the historic verbose bar with filled key chips, adapting
+//     to terminal width across the tiny/minimal/compact/full tiers. This is also
+//     the fallback for any unset or unrecognized footerMode, so the historic look
+//     is never silently replaced.
+//   - "curated" (opt-in): a lighter, dim inline bar that advertises only the
 //     actions relevant to the selected row, with the settings and help keys
 //     always last. Rarer/global actions live under help (?).
-//   - "full": the historic verbose bar with filled key chips, adapting to
-//     terminal width across the tiny/minimal/compact/full tiers.
 //   - "compact" / "minimal": force a single verbose tier regardless of width.
 //
 // The very-narrow tiny tier is always used below layoutBreakpointSingle so the
@@ -11487,14 +11489,17 @@ func (h *Home) renderHelpBar() string {
 	}
 
 	switch h.footerMode {
-	case session.FooterFull:
-		return h.renderHelpBarWidthAdaptive()
+	case session.FooterCurated:
+		return h.renderHelpBarCurated()
 	case session.FooterCompact:
 		return h.renderHelpBarCompact()
 	case session.FooterMinimal:
 		return h.renderHelpBarMinimal()
 	default:
-		return h.renderHelpBarCurated()
+		// FooterFull, plus any unset ("") or unrecognized mode, routes to the
+		// historic width-adaptive bar. Only an explicit curated setting selects
+		// the curated bar, so the pre-PR default behavior is preserved.
+		return h.renderHelpBarWidthAdaptive()
 	}
 }
 
@@ -11585,7 +11590,7 @@ func (h *Home) renderHelpBarMinimal() string {
 		}
 	} else if len(h.flatItems) == 0 {
 		contextKeys = renderKeys(newKey, quickKey, importKey, groupKey)
-	} else if h.cursor < len(h.flatItems) {
+	} else if h.cursor >= 0 && h.cursor < len(h.flatItems) {
 		item := h.flatItems[h.cursor]
 		if item.Type == session.ItemTypeGroup {
 			contextKeys = renderKeys("⏎", newKey, quickKey, groupKey)
@@ -11680,7 +11685,7 @@ func (h *Home) renderHelpBarCompact() string {
 		if key := h.actionKey(hotkeyImport); key != "" {
 			contextHints = append(contextHints, h.helpKeyShort(key, "Import"))
 		}
-	} else if h.cursor < len(h.flatItems) {
+	} else if h.cursor >= 0 && h.cursor < len(h.flatItems) {
 		item := h.flatItems[h.cursor]
 		if item.Type == session.ItemTypeGroup {
 			contextHints = append(contextHints, h.helpKeyShort("⏎", "Toggle"))
@@ -11843,7 +11848,7 @@ func (h *Home) renderHelpBarFull() string {
 		if groupKey != "" {
 			primaryHints = append(primaryHints, h.helpKey(groupKey, "Group"))
 		}
-	} else if h.cursor < len(h.flatItems) {
+	} else if h.cursor >= 0 && h.cursor < len(h.flatItems) {
 		item := h.flatItems[h.cursor]
 		if item.Type == session.ItemTypeGroup {
 			contextTitle = "Group"
@@ -12155,7 +12160,7 @@ func (h *Home) renderHelpBarCurated() string {
 		add(joinHotkeyLabels(h.actionKey(hotkeyNewSession), h.actionKey(hotkeyQuickCreate)), "new")
 		add(h.actionKey(hotkeyImport), "import")
 		add(h.actionKey(hotkeyCreateGroup), "group")
-	case h.cursor < len(h.flatItems):
+	case h.cursor >= 0 && h.cursor < len(h.flatItems):
 		hints = append(hints, h.curatedContextHints(h.flatItems[h.cursor])...)
 	}
 

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2239,6 +2239,79 @@ func TestFooterDefaultIsFull(t *testing.T) {
 	}
 }
 
+// TestFooterUnsetOrUnknownModeRendersHistoricBar guards the renderHelpBar
+// routing directly: a truly-unset ("") or unrecognized footerMode must render
+// the HISTORIC width-adaptive bar, NOT the curated bar. Only an explicit
+// curated setting selects curated. This covers the path that
+// TestFooterDefaultIsFull masks by hard-setting the normalized GetFooter value;
+// here we set footerMode to raw values that bypass GetFooter normalization.
+func TestFooterUnsetOrUnknownModeRendersHistoricBar(t *testing.T) {
+	mkHome := func(mode string) *Home {
+		home := NewHome()
+		home.width = 120
+		home.height = 30
+		home.footerMode = mode
+		home.flatItems = []session.Item{
+			{Type: session.ItemTypeSession, Session: &session.Instance{ID: "s1", Tool: "claude", Status: session.StatusRunning}},
+		}
+		home.cursor = 0
+		return home
+	}
+
+	// The verbose width-adaptive bar (full tier at width 120) renders a
+	// capitalized context title ("Session:") that the curated bar never emits;
+	// the curated bar uses lowercase inline labels ("attach", "settings"). Use
+	// the "Session:" prefix as the distinguishing marker.
+	const historicMarker = "Session:"
+	curated := mkHome(session.FooterCurated).renderHelpBar()
+	if strings.Contains(curated, historicMarker) {
+		t.Fatalf("precondition failed: curated bar unexpectedly contains %q; marker invalid", historicMarker)
+	}
+
+	for _, mode := range []string{"", "bogus", "FULL-ish", "default"} {
+		got := mkHome(mode).renderHelpBar()
+		if got == curated {
+			t.Errorf("footerMode=%q rendered the curated bar; unset/unknown must route to the historic bar", mode)
+		}
+		if !strings.Contains(got, historicMarker) {
+			t.Errorf("footerMode=%q did not render the historic verbose bar (no %q marker)", mode, historicMarker)
+		}
+	}
+}
+
+// TestRenderHelpBarCursorNegativeNoPanic guards against a negative-index panic:
+// with items present but cursor == -1 (e.g. a transient state before cursor is
+// restored), the help-bar renderers must not index flatItems[-1]. Exercises
+// every footer mode that has a cursor-indexed context branch.
+func TestRenderHelpBarCursorNegativeNoPanic(t *testing.T) {
+	modes := []string{
+		session.FooterCurated,
+		session.FooterFull,
+		session.FooterCompact,
+		session.FooterMinimal,
+		"", // unset → historic width-adaptive
+	}
+	for _, mode := range modes {
+		home := NewHome()
+		home.width = 120
+		home.height = 30
+		home.footerMode = mode
+		home.flatItems = []session.Item{
+			{Type: session.ItemTypeSession, Session: &session.Instance{ID: "s1", Tool: "claude", Status: session.StatusRunning}},
+		}
+		home.cursor = -1 // items present, but no valid selection
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("footerMode=%q: renderHelpBar panicked with cursor=-1: %v", mode, r)
+				}
+			}()
+			_ = home.renderHelpBar()
+		}()
+	}
+}
+
 // newTestHomeWithItems creates a Home with flatItems populated, initial loading disabled, and sized.
 func newTestHomeWithItems(width, height int, items []session.Item) *Home {
 	home := NewHome()

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -1591,6 +1591,7 @@ func TestRenderHelpBarMinimal(t *testing.T) {
 	home := NewHome()
 	home.width = 55 // Minimal mode (50-69)
 	home.height = 30
+	home.footerMode = session.FooterFull // verbose width-adaptive tiers
 
 	result := home.renderHelpBar()
 
@@ -1611,6 +1612,7 @@ func TestRenderHelpBarMinimalWithSession(t *testing.T) {
 	home := NewHome()
 	home.width = 55 // Minimal mode (50-69)
 	home.height = 30
+	home.footerMode = session.FooterFull // verbose width-adaptive tiers
 
 	// Add a session to test context-specific keys
 	testSession := &session.Instance{
@@ -1642,6 +1644,7 @@ func TestRenderHelpBarMinimalWithFreshRestartableSession(t *testing.T) {
 	home := NewHome()
 	home.width = 55
 	home.height = 30
+	home.footerMode = session.FooterFull // verbose width-adaptive tiers
 
 	testSession := &session.Instance{
 		ID:              "test-456",
@@ -1663,6 +1666,7 @@ func TestRenderHelpBarCompact(t *testing.T) {
 	home := NewHome()
 	home.width = 85 // Compact mode (70-99)
 	home.height = 30
+	home.footerMode = session.FooterFull // verbose width-adaptive tiers
 
 	result := home.renderHelpBar()
 
@@ -1680,6 +1684,7 @@ func TestRenderHelpBarCompactWithSession(t *testing.T) {
 	home := NewHome()
 	home.width = 85 // Compact mode (70-99)
 	home.height = 30
+	home.footerMode = session.FooterFull // verbose width-adaptive tiers
 
 	// Add a session with fork capability
 	// ClaudeDetectedAt must be recent for CanFork() to return true
@@ -1718,6 +1723,7 @@ func TestRenderHelpBarCompactWithGroup(t *testing.T) {
 	home := NewHome()
 	home.width = 85 // Compact mode (70-99)
 	home.height = 30
+	home.footerMode = session.FooterFull // verbose width-adaptive tiers
 
 	// Add a group
 	home.flatItems = []session.Item{
@@ -1958,6 +1964,7 @@ func TestUndoHintInHelpBar(t *testing.T) {
 	home := NewHome()
 	home.width = 200 // Wide terminal to fit all hints including Undo
 	home.height = 30
+	home.footerMode = session.FooterFull // Undo lives in the verbose bar's secondary hints
 
 	// Add a session to have context (non-Claude to reduce hint count)
 	inst := &session.Instance{ID: "test-1", Title: "Test", Tool: "other"}
@@ -1977,6 +1984,151 @@ func TestUndoHintInHelpBar(t *testing.T) {
 	result = home.renderHelpBar()
 	if !strings.Contains(result, "Undo") {
 		t.Errorf("Help bar should show Undo when undo stack is non-empty\nGot: %q", result)
+	}
+}
+
+// ── Curated footer (default [ui] footer = curated) ─────────────────────────
+
+// curatedHome builds a Home in the curated footer style at a comfortable width.
+func curatedHome() *Home {
+	home := NewHome()
+	home.width = 120
+	home.height = 30
+	home.footerMode = session.FooterCurated
+	return home
+}
+
+func TestCuratedFooterAlwaysEndsWithSettingsThenHelp(t *testing.T) {
+	home := curatedHome()
+	// Live session selected so there is a context hint before settings/help.
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: &session.Instance{ID: "s1", Tool: "claude", Status: session.StatusRunning}},
+	}
+	home.cursor = 0
+
+	result := home.renderHelpBar()
+
+	settingsKey := home.actionKey(hotkeySettings)
+	helpKey := home.actionKey(hotkeyHelp)
+	si := strings.LastIndex(result, settingsKey+" ")
+	hi := strings.LastIndex(result, helpKey+" ")
+	if si == -1 {
+		t.Fatalf("curated footer should advertise settings key %q\nGot: %q", settingsKey, result)
+	}
+	if hi == -1 {
+		t.Fatalf("curated footer should advertise help key %q\nGot: %q", helpKey, result)
+	}
+	if !(si < hi) {
+		t.Errorf("settings must come before help as the last two items\nGot: %q", result)
+	}
+	if !strings.Contains(result, "attach") {
+		t.Errorf("curated footer for a live session should show attach\nGot: %q", result)
+	}
+}
+
+func TestCuratedFooterLiveSessionShowsAttach(t *testing.T) {
+	home := curatedHome()
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: &session.Instance{ID: "s1", Tool: "claude", Status: session.StatusRunning}},
+	}
+	home.cursor = 0
+
+	result := home.renderHelpBar()
+	if !strings.Contains(result, "⏎ attach") {
+		t.Errorf("live session should advertise Enter attach\nGot: %q", result)
+	}
+	if strings.Contains(result, "restart") {
+		t.Errorf("live session should not advertise restart in curated footer\nGot: %q", result)
+	}
+}
+
+func TestCuratedFooterDeadSessionShowsRestart(t *testing.T) {
+	home := curatedHome()
+	// Stopped Claude session with a known session id → restart + restart fresh.
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: &session.Instance{
+			ID:              "s1",
+			Tool:            "claude",
+			Status:          session.StatusStopped,
+			ClaudeSessionID: "abc",
+		}},
+	}
+	home.cursor = 0
+
+	result := home.renderHelpBar()
+	if !strings.Contains(result, "restart") {
+		t.Errorf("dead session should advertise restart\nGot: %q", result)
+	}
+	if !strings.Contains(result, "restart fresh") {
+		t.Errorf("dead restartable session should advertise restart fresh\nGot: %q", result)
+	}
+	if strings.Contains(result, "attach") {
+		t.Errorf("dead session should not advertise attach\nGot: %q", result)
+	}
+}
+
+func TestCuratedFooterErrorSessionShowsRestart(t *testing.T) {
+	home := curatedHome()
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: &session.Instance{ID: "s1", Tool: "other", Status: session.StatusError}},
+	}
+	home.cursor = 0
+
+	result := home.renderHelpBar()
+	if !strings.Contains(result, "restart") {
+		t.Errorf("errored session should advertise restart\nGot: %q", result)
+	}
+}
+
+func TestCuratedFooterGroupShowsCollapseExpand(t *testing.T) {
+	home := curatedHome()
+
+	// Expanded group → collapse hint.
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeGroup, Path: "g", Group: &session.Group{Name: "g", Path: "g", Expanded: true}},
+	}
+	home.cursor = 0
+	if result := home.renderHelpBar(); !strings.Contains(result, "Tab collapse") {
+		t.Errorf("expanded group should advertise Tab collapse\nGot: %q", result)
+	}
+
+	// Collapsed group → expand hint.
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeGroup, Path: "g", Group: &session.Group{Name: "g", Path: "g", Expanded: false}},
+	}
+	if result := home.renderHelpBar(); !strings.Contains(result, "Tab expand") {
+		t.Errorf("collapsed group should advertise Tab expand\nGot: %q", result)
+	}
+}
+
+func TestCuratedFooterEmptyListShowsNew(t *testing.T) {
+	home := curatedHome()
+	home.flatItems = nil
+
+	result := home.renderHelpBar()
+	if !strings.Contains(result, "new") {
+		t.Errorf("empty list should advertise new\nGot: %q", result)
+	}
+	// settings + help must still be present and last.
+	if !strings.Contains(result, "help") {
+		t.Errorf("curated footer should always include help\nGot: %q", result)
+	}
+}
+
+func TestCuratedFooterJumpMode(t *testing.T) {
+	home := curatedHome()
+	home.jumpMode = true
+
+	result := home.renderHelpBar()
+	if !strings.Contains(result, "jump") || !strings.Contains(result, "cancel") {
+		t.Errorf("jump mode should advertise jump and cancel\nGot: %q", result)
+	}
+}
+
+func TestCuratedFooterIsDefault(t *testing.T) {
+	// A fresh Home with no [ui] footer config defaults to the curated style.
+	if got := (session.UISettings{}).GetFooter(); got != session.FooterCurated {
+		t.Fatalf("default footer = %q, want %q", got, session.FooterCurated)
 	}
 }
 

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2037,8 +2037,42 @@ func TestCuratedFooterLiveSessionShowsAttach(t *testing.T) {
 	if !strings.Contains(result, "⏎ attach") {
 		t.Errorf("live session should advertise Enter attach\nGot: %q", result)
 	}
-	if strings.Contains(result, "restart") {
-		t.Errorf("live session should not advertise restart in curated footer\nGot: %q", result)
+	// Live session shows up to 3 context hints (attach first, then restart, …).
+	if !strings.Contains(result, "restart") {
+		t.Errorf("live session should advertise restart after attach\nGot: %q", result)
+	}
+	// Attach must be the first context hint.
+	ai := strings.Index(result, "attach")
+	ri := strings.Index(result, "restart")
+	if ai == -1 || ri == -1 || ai > ri {
+		t.Errorf("attach should come before restart\nGot: %q", result)
+	}
+}
+
+func TestCuratedFooterCapsContextHints(t *testing.T) {
+	home := curatedHome()
+	// A forkable live session would offer attach/restart/fork; verify the
+	// curated footer caps context hints at maxCuratedContextHints and never
+	// exceeds it once settings/help are appended.
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: &session.Instance{
+			ID:               "s1",
+			Tool:             "claude",
+			Status:           session.StatusRunning,
+			ClaudeSessionID:  "abc",
+			ClaudeDetectedAt: time.Now(), // recent → CanFork() true
+		}},
+	}
+	home.cursor = 0
+
+	hints := home.curatedContextHints(home.flatItems[0])
+	if len(hints) != maxCuratedContextHints {
+		t.Fatalf("forkable live session should yield %d context hints, got %d: %+v",
+			maxCuratedContextHints, len(hints), hints)
+	}
+	result := home.renderHelpBar()
+	if !strings.Contains(result, "fork") {
+		t.Errorf("forkable live session should advertise fork\nGot: %q", result)
 	}
 }
 
@@ -2062,8 +2096,40 @@ func TestCuratedFooterDeadSessionShowsRestart(t *testing.T) {
 	if !strings.Contains(result, "restart fresh") {
 		t.Errorf("dead restartable session should advertise restart fresh\nGot: %q", result)
 	}
+	if !strings.Contains(result, "delete") {
+		t.Errorf("dead session should advertise delete as the third action\nGot: %q", result)
+	}
 	if strings.Contains(result, "attach") {
 		t.Errorf("dead session should not advertise attach\nGot: %q", result)
+	}
+}
+
+func TestCuratedFooterErrorSessionShowsRestartRestartFreshDelete(t *testing.T) {
+	home := curatedHome()
+	// Errored Claude session with a session id → R / T / d, in that order.
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: &session.Instance{
+			ID:              "s1",
+			Tool:            "claude",
+			Status:          session.StatusError,
+			ClaudeSessionID: "abc",
+		}},
+	}
+	home.cursor = 0
+
+	hints := home.curatedContextHints(home.flatItems[0])
+	got := make([]string, len(hints))
+	for i, hint := range hints {
+		got[i] = hint.label
+	}
+	want := []string{"restart", "restart fresh", "delete"}
+	if len(got) != len(want) {
+		t.Fatalf("errored session context hints = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("errored session context hints = %v, want %v", got, want)
+		}
 	}
 }
 

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -1987,7 +1987,7 @@ func TestUndoHintInHelpBar(t *testing.T) {
 	}
 }
 
-// ── Curated footer (default [ui] footer = curated) ─────────────────────────
+// ── Curated footer (opt-in via [ui] footer = curated) ──────────────────────
 
 // curatedHome builds a Home in the curated footer style at a comfortable width.
 func curatedHome() *Home {
@@ -2191,10 +2191,51 @@ func TestCuratedFooterJumpMode(t *testing.T) {
 	}
 }
 
-func TestCuratedFooterIsDefault(t *testing.T) {
-	// A fresh Home with no [ui] footer config defaults to the curated style.
-	if got := (session.UISettings{}).GetFooter(); got != session.FooterCurated {
-		t.Fatalf("default footer = %q, want %q", got, session.FooterCurated)
+// TestCuratedFooterRemoteSessionShowsAttach covers PR #1289 review nit 1: a
+// remote-session row must still advertise the attach hint in the curated
+// footer (it attaches over SSH just like a local session).
+func TestCuratedFooterRemoteSessionShowsAttach(t *testing.T) {
+	home := curatedHome()
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeRemoteSession, RemoteSession: &session.RemoteSessionInfo{}},
+	}
+	home.cursor = 0
+
+	result := home.renderHelpBar()
+	if !strings.Contains(result, "⏎ attach") {
+		t.Errorf("curated footer for a remote session should advertise Enter attach\nGot: %q", result)
+	}
+}
+
+// TestFooterDefaultIsFull is the default-preserving guarantee for PR #1289:
+// with no [ui] footer config the footer is the historic verbose "full" bar,
+// not curated — so nobody's UI changes without an explicit opt-in.
+func TestFooterDefaultIsFull(t *testing.T) {
+	// Config layer: unset → full.
+	if got := (session.UISettings{}).GetFooter(); got != session.FooterFull {
+		t.Fatalf("default footer = %q, want %q (must preserve today's verbose bar)", got, session.FooterFull)
+	}
+
+	// Render layer: a Home seeded with the default footerMode must route to the
+	// verbose width-adaptive bar, not the curated bar. The verbose bar uses
+	// filled key chips and advertises many actions; a reliable distinguishing
+	// marker is the "quit" hint, which the curated bar never shows.
+	home := NewHome()
+	home.width = 120
+	home.height = 30
+	home.footerMode = (session.UISettings{}).GetFooter() // simulate default load
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: &session.Instance{ID: "s1", Tool: "claude", Status: session.StatusRunning}},
+	}
+	home.cursor = 0
+
+	full := home.renderHelpBar()
+
+	home.footerMode = session.FooterCurated
+	curated := home.renderHelpBar()
+
+	if full == curated {
+		t.Fatal("default (full) footer render is identical to curated render; default did not select the verbose bar")
 	}
 }
 

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -2207,6 +2207,89 @@ func TestCuratedFooterRemoteSessionShowsAttach(t *testing.T) {
 	}
 }
 
+// TestCuratedFooterQueuedSessionNotAttachable covers PR #1289 review nit 2b: a
+// queued session has no tmux yet, so the curated footer must not advertise
+// "⏎ attach" or "restart" for it — only delete and new make sense.
+func TestCuratedFooterQueuedSessionNotAttachable(t *testing.T) {
+	home := curatedHome()
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: &session.Instance{ID: "s1", Tool: "claude", Status: session.StatusQueued}},
+	}
+	home.cursor = 0
+
+	result := home.renderHelpBar()
+	if strings.Contains(result, "attach") {
+		t.Errorf("queued session (no tmux yet) must not advertise attach\nGot: %q", result)
+	}
+	if strings.Contains(result, "restart") {
+		t.Errorf("queued session (nothing running) must not advertise restart\nGot: %q", result)
+	}
+	if !strings.Contains(result, "delete") {
+		t.Errorf("queued session should advertise delete\nGot: %q", result)
+	}
+}
+
+// TestCuratedFooterNarrowKeepsSettingsAndHelp covers PR #1289 review nit 2a: on
+// a narrow terminal the curated footer drops lower-priority CONTEXT hints by
+// width rather than letting MaxWidth truncate the always-last settings/help
+// global hints off the right edge.
+func TestCuratedFooterNarrowKeepsSettingsAndHelp(t *testing.T) {
+	home := curatedHome()
+	home.width = 50 // narrow, but still >= layoutBreakpointSingle (curated, not tiny)
+	// Forkable live session → three context hints (attach/restart/fork) that
+	// would, together with settings+help, overflow 50 columns.
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeSession, Session: &session.Instance{
+			ID:               "s1",
+			Tool:             "claude",
+			Status:           session.StatusRunning,
+			ClaudeSessionID:  "abc",
+			ClaudeDetectedAt: time.Now(),
+		}},
+	}
+	home.cursor = 0
+
+	result := home.renderHelpBar()
+	settingsKey := home.actionKey(hotkeySettings)
+	helpKey := home.actionKey(hotkeyHelp)
+	if !strings.Contains(result, settingsKey+" settings") {
+		t.Errorf("narrow curated footer must keep the settings hint\nGot: %q", result)
+	}
+	if !strings.Contains(result, helpKey+" help") {
+		t.Errorf("narrow curated footer must keep the help hint\nGot: %q", result)
+	}
+}
+
+// TestFitCuratedHintsAlwaysKeepsGlobals exercises the width-fitting helper
+// directly: even when the bar is too narrow for any context hint, the global
+// hints survive; and context hints are kept front-to-back (highest priority
+// first) when there is room.
+func TestFitCuratedHintsAlwaysKeepsGlobals(t *testing.T) {
+	home := curatedHome()
+	globals := []footerHint{{key: "s", label: "settings"}, {key: "?", label: "help"}}
+	ctx := []footerHint{{key: "a", label: "attach"}, {key: "r", label: "restart"}, {key: "f", label: "fork"}}
+
+	// Width too small for any context hint: only globals remain.
+	home.width = 1
+	got := home.fitCuratedHints(ctx, globals)
+	if len(got) != len(globals) {
+		t.Fatalf("at width=1 expected only the %d global hints, got %d: %+v", len(globals), len(got), got)
+	}
+	if got[len(got)-1].label != "help" {
+		t.Errorf("help must remain the last hint, got %+v", got)
+	}
+
+	// Generous width: everything fits, context first then globals.
+	home.width = 200
+	got = home.fitCuratedHints(ctx, globals)
+	if len(got) != len(ctx)+len(globals) {
+		t.Fatalf("at width=200 expected all %d hints, got %d: %+v", len(ctx)+len(globals), len(got), got)
+	}
+	if got[0].label != "attach" || got[len(got)-1].label != "help" {
+		t.Errorf("expected attach first and help last, got %+v", got)
+	}
+}
+
 // TestFooterDefaultIsFull is the default-preserving guarantee for PR #1289:
 // with no [ui] footer config the footer is the historic verbose "full" bar,
 // not curated — so nobody's UI changes without an explicit opt-in.


### PR DESCRIPTION
Opt-in curated footer for the TUI bottom hint bar, selectable via `config.toml` `[ui] footer = "curated"`. **Default behavior is unchanged**: an unset or unknown value routes to the historic width-adaptive bar, so nobody's UI changes without an explicit opt-in.

### Why a new PR
This supersedes #1289. The two High-severity issues from #1289's review were fixed, but #1289's head points at the contributor's fork, so the fixes could not be pushed to the PR. This PR carries the same feature with the review fixes applied on a maintainer branch, rebased on current `main`.

### Fixes the 2 High issues from #1289's review
- **Negative-index panic guard**: `renderHelpBarCurated` only indexes `flatItems[cursor]` under `cursor >= 0 && cursor < len`; a transient `cursor == -1` falls through to settings/help only (regression test added).
- **Default-routing regression**: unset/unknown `footerMode` routes to the historic width-adaptive bar; only an explicit `curated` selects the curated bar (regression test added).

### Plus the 2 P2 nits Codex flagged
- **(a) Narrow footer keeps globals**: on a narrow terminal (~50 cols), lower-priority CONTEXT hints are now dropped by available width before render (new `fitCuratedHints`) so the always-last settings/help hints are never truncated off the right edge.
- **(b) Queued sessions not attachable**: `StatusQueued` sessions (no tmux yet) no longer fall into the live/attachable branch advertising attach+restart; they show delete + new only.

### Verification
- Sandboxed build: `go build ./...` exit 0.
- `go test ./internal/ui/ -run 'Footer|HelpBar|Curated|FitCurated'` green (includes the new regression tests).
- Dual-reviewed: Codex (no actionable P0/P1) + the review fixes carried from #1289.

Credit @JMBattista for the original footer feature (#1289).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four customizable footer styles: full (default with comprehensive hints), curated (context-aware hints), compact (condensed), and minimal (ultra-compact). Users can select their preferred footer style in the UI settings configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->