### PR TITLE
feat: support a global default_path config key for agent-deck add

### DIFF
--- a/cmd/agent-deck/add_test.go
+++ b/cmd/agent-deck/add_test.go
@@ -567,3 +567,183 @@ func TestResolveAddPath(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleAddUsesGlobalDefaultPath(t *testing.T) {
+	home, _, profile := setupAddDefaultPathTest(t)
+	defaultPath := filepath.Join(home, "workspace")
+	if err := os.MkdirAll(defaultPath, 0o755); err != nil {
+		t.Fatalf("mkdir default path: %v", err)
+	}
+	writeAddUserConfig(t, home, `default_path = "`+defaultPath+`"`+"\n")
+
+	handleAdd(profile, []string{"--title", "global-default", "--quiet"})
+
+	if got := onlyAddedSessionPath(t, profile); got != defaultPath {
+		t.Fatalf("added path = %q, want global default_path %q", got, defaultPath)
+	}
+}
+
+func TestHandleAddExplicitPathIgnoresGlobalDefaultPath(t *testing.T) {
+	home, _, profile := setupAddDefaultPathTest(t)
+	defaultPath := filepath.Join(home, "workspace")
+	explicitPath := filepath.Join(home, "explicit")
+	for _, dir := range []string{defaultPath, explicitPath} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeAddUserConfig(t, home, `default_path = "`+defaultPath+`"`+"\n")
+
+	handleAdd(profile, []string{"--title", "explicit", "--quiet", explicitPath})
+
+	if got := onlyAddedSessionPath(t, profile); got != explicitPath {
+		t.Fatalf("added path = %q, want explicit path %q", got, explicitPath)
+	}
+}
+
+func TestHandleAddGroupDefaultPathPrecedesGlobalDefaultPath(t *testing.T) {
+	home, _, profile := setupAddDefaultPathTest(t)
+	globalPath := filepath.Join(home, "global")
+	groupPath := filepath.Join(home, "group")
+	for _, dir := range []string{globalPath, groupPath} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeAddUserConfig(t, home, `default_path = "`+globalPath+`"`+"\n")
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	groupTree := session.NewGroupTreeWithGroups(nil, []*session.GroupData{
+		{Name: "Work", Path: "work", Expanded: true, DefaultPath: groupPath},
+	})
+	if err := storage.SaveWithGroups(nil, groupTree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+	if err := storage.Close(); err != nil {
+		t.Fatalf("Close storage: %v", err)
+	}
+
+	handleAdd(profile, []string{"--group", "work", "--title", "group-default", "--quiet"})
+
+	if got := onlyAddedSessionPath(t, profile); got != groupPath {
+		t.Fatalf("added path = %q, want group default_path %q", got, groupPath)
+	}
+}
+
+func TestHandleAddFallsBackToCwdWithoutGlobalDefaultPath(t *testing.T) {
+	_, cwd, profile := setupAddDefaultPathTest(t)
+
+	handleAdd(profile, []string{"--title", "cwd-default", "--quiet"})
+
+	if got := onlyAddedSessionPath(t, profile); got != cwd {
+		t.Fatalf("added path = %q, want cwd %q", got, cwd)
+	}
+}
+
+func TestHandleAddExpandsGlobalDefaultPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		configValue func(t *testing.T, home string) (string, string)
+	}{
+		{
+			name: "tilde",
+			configValue: func(t *testing.T, home string) (string, string) {
+				want := filepath.Join(home, "workspace")
+				return "~/workspace", want
+			},
+		},
+		{
+			name: "env var",
+			configValue: func(t *testing.T, home string) (string, string) {
+				root := filepath.Join(home, "env-root")
+				t.Setenv("AGENT_DECK_TEST_ROOT", root)
+				want := filepath.Join(root, "workspace")
+				return "$AGENT_DECK_TEST_ROOT/workspace", want
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home, _, profile := setupAddDefaultPathTest(t)
+			configPath, want := tt.configValue(t, home)
+			if err := os.MkdirAll(want, 0o755); err != nil {
+				t.Fatalf("mkdir default path: %v", err)
+			}
+			writeAddUserConfig(t, home, `default_path = "`+configPath+`"`+"\n")
+
+			handleAdd(profile, []string{"--title", tt.name, "--quiet"})
+
+			if got := onlyAddedSessionPath(t, profile); got != want {
+				t.Fatalf("added path = %q, want expanded default_path %q", got, want)
+			}
+		})
+	}
+}
+
+func TestHandleAddFallsBackToCwdWhenGlobalDefaultPathMissing(t *testing.T) {
+	home, cwd, profile := setupAddDefaultPathTest(t)
+	missingPath := filepath.Join(home, "missing")
+	writeAddUserConfig(t, home, `default_path = "`+missingPath+`"`+"\n")
+
+	handleAdd(profile, []string{"--title", "missing-default", "--quiet"})
+
+	if got := onlyAddedSessionPath(t, profile); got != cwd {
+		t.Fatalf("added path = %q, want cwd %q", got, cwd)
+	}
+}
+
+func setupAddDefaultPathTest(t *testing.T) (home, cwd, profile string) {
+	t.Helper()
+
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	cwd = filepath.Join(home, "cwd")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir cwd: %v", err)
+	}
+	t.Chdir(cwd)
+
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	return home, cwd, "add_default_path"
+}
+
+func writeAddUserConfig(t *testing.T, home, content string) {
+	t.Helper()
+
+	configDir := filepath.Join(home, ".config", "agent-deck")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	session.ClearUserConfigCache()
+}
+
+func onlyAddedSessionPath(t *testing.T, profile string) string {
+	t.Helper()
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	defer storage.Close()
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+	if len(instances) != 1 {
+		t.Fatalf("loaded %d sessions, want 1", len(instances))
+	}
+	return instances[0].ProjectPath
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1350,9 +1350,15 @@ func handleAdd(profile string, args []string) {
 			os.Exit(1)
 		}
 	} else {
-		// No explicit path provided: use group default path first, then cwd fallback.
+		// No explicit path provided: use group default path first, then global
+		// config default_path, then cwd fallback.
 		if sessionGroup != "" {
 			path = groupTree.DefaultPathForGroup(sessionGroup)
+		}
+		if path == "" {
+			if userCfg, cfgErr := session.LoadUserConfig(); cfgErr == nil {
+				path = resolveConfiguredDefaultPath(userCfg.DefaultPath)
+			}
 		}
 		if path == "" {
 			path, err = os.Getwd()
@@ -1772,6 +1778,24 @@ func handleAdd(profile string, args []string) {
 			fmt.Println(line)
 		}
 	}
+}
+
+func resolveConfiguredDefaultPath(defaultPath string) string {
+	defaultPath = strings.TrimSpace(defaultPath)
+	if defaultPath == "" {
+		return ""
+	}
+
+	resolved, err := resolveAddPath(defaultPath)
+	if err != nil {
+		return ""
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+	return resolved
 }
 
 // handleList lists all sessions

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -47,6 +47,10 @@ type UserConfig struct {
 	// If empty or invalid, defaults to "shell" (no pre-selection)
 	DefaultTool string `toml:"default_tool"`
 
+	// DefaultPath is the global fallback project directory for `agent-deck add`
+	// when no explicit path or group default_path is provided.
+	DefaultPath string `toml:"default_path"`
+
 	// Hotkeys overrides default keyboard shortcuts in the TUI.
 	// Keys are action names, values are key bindings (e.g., "delete" = "backspace").
 	// Set an action to "" to explicitly unbind it.

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -39,6 +39,16 @@ func TestDisplaySettings_IncludeCwdPrefix_TOML(t *testing.T) {
 	}
 }
 
+func TestUserConfig_DefaultPathTOML(t *testing.T) {
+	var cfg UserConfig
+	if _, err := toml.Decode(`default_path = "~/workspace"`+"\n", &cfg); err != nil {
+		t.Fatalf("toml decode: %v", err)
+	}
+	if got, want := cfg.DefaultPath, "~/workspace"; got != want {
+		t.Fatalf("DefaultPath = %q, want %q", got, want)
+	}
+}
+
 func TestGetCodexCommand_DefaultAndConfig(t *testing.T) {
 	tempDir := t.TempDir()
 	originalHome := os.Getenv("HOME")


### PR DESCRIPTION
## Summary

`agent-deck add` now honors a global `default_path` key in `config.toml`, requested in #1297. Users who always work from the same root (a monorepo, a worktree root) can set it once instead of passing the path on every `add`. Precedence is unchanged where it matters: an explicit path argument always wins, then the group's `default_path`, then the new global key, then the existing cwd fallback.

## Why this matters

#1297 describes the friction directly: without this, `add` from anywhere outside the project root either needs the path typed every time or silently registers the wrong directory. The global key closes that gap with the smallest possible surface: one new optional TOML field (`internal/session/userconfig.go`), resolved through the same `resolveAddPath` tilde/relative handling the explicit argument uses, and validated as an existing directory before use (a bad value falls through to cwd rather than erroring the add).

## Changes

- `resolveConfiguredDefaultPath` in `cmd/agent-deck/main.go` trims, resolves, and stat-validates the configured value; anything invalid returns the empty string so the existing fallback chain proceeds untouched.
- Precedence covered by regression tests: explicit path beats global, group `default_path` beats global, global beats cwd, absent global falls back to cwd.

## Testing

`gofmt`, `go vet ./...`, and `go build ./...` clean. New tests in `cmd/agent-deck/add_test.go` (4 precedence cases) and `internal/session/userconfig_test.go` (TOML decode) all pass. Note: `go test ./internal/session/` has a pre-existing host-environment flake (`TestPerGroupConfig_NoScratchWhenNoTelegramConductor`, fails identically on a clean upstream/main checkout); it is unrelated to this change.

AI was used for assistance.

Fixes #1297


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `default_path` global configuration option to set a default project directory for `agent-deck add`. Supports `~` and environment variable expansion. Group-specific defaults take precedence over the global setting.

* **Tests**
  * Added comprehensive test coverage for default path resolution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->