### PR TITLE
test(session): partial XDG config-home isolation for cross-test contamination (pre-existing #1294 regression)

### DIFF
--- a/docs/rfc/SESSION_TEST_XDG_ISOLATION.md
+++ b/docs/rfc/SESSION_TEST_XDG_ISOLATION.md
@@ -1,0 +1,99 @@
+# Maintainer note: `internal/session` test-isolation regression from the XDG migration (#1294)
+
+**Status:** rebased onto `main` as of 2026-06-07 and reconciled with the mainline
+XDG isolation fix. The local macOS `internal/session` suite is green again
+without re-pinning package-level XDG defaults.
+
+**Author context:** surfaced while merging upstream `main` into a feature branch
+(PR #1299). The contamination is **pre-existing on `main`** (reproduces on the
+`v1.9.49` release commit `b555774a` with no feature-branch changes), not
+introduced by that PR.
+
+## Symptom
+
+Before the mainline fix, running the full session package locally on macOS
+failed ~66 tests:
+
+```bash
+GOTOOLCHAIN=go1.25.11 go test ./internal/session/... -count=1   # ~66 failures
+```
+
+Most failures passed in isolation (`-run TestX$`) and only appeared in a
+full-package run, which made this look like ordinary test flake until the XDG
+config path change was traced.
+
+## Why CI is green (and this went unnoticed)
+
+- The per-PR check (`.github/workflows/session-persistence.yml`) runs a
+  **filtered** suite: `go test -run TestPersistence_ ./internal/session/...`.
+  A filtered run doesn't trigger the polluters, so it stays green.
+- The full `go test ./...` only runs at the **release gate**
+  (`.github/workflows/release.yml`) on `ubuntu-latest`. On headless Linux the
+  polluting tests (which need tmux/claude panes, gated by
+  `skipIfClaudePaneUnreliable`) **skip**, so they never write the shared config
+  and the gate passes — which is how `v1.9.49` shipped.
+- The breakage therefore surfaces only in a **local full-package run on macOS**,
+  where tmux/pane tests actually run. The local **pre-push hook**
+  (`lefthook.yml` → `go test -race ./...`) hits it.
+
+## Root cause
+
+`#1294` moved user config from `$HOME`-relative paths to
+`$XDG_CONFIG_HOME/agent-deck/config.toml` (`agentpaths.EffectiveConfigPath` /
+`ConfigDir`). The first version of this branch was based on `v1.9.49`
+(`b555774a`), where package-level HOME/XDG isolation still allowed a shared
+XDG config location to leak between tests.
+
+Most session tests predate the migration and isolate by overriding **only**
+`HOME`. If `XDG_CONFIG_HOME` is pinned independently of that temp HOME, a test's
+`SaveUserConfig` (or direct `os.WriteFile` to the legacy dir) and its config
+**reads** can resolve against different config roots. So:
+
+- A test that calls `SaveUserConfig` without overriding an inherited
+  `XDG_CONFIG_HOME` can write to a foreign `config.toml` and leak into later
+  tests (**polluter**).
+- A test that writes config to its own legacy `$HOME/.agent-deck/config.toml`
+  and reads it back can get a polluted or foreign XDG config instead, because
+  `EffectiveConfigPath` prefers an existing XDG path (**victim**).
+
+## What changed after rebase
+
+- Current `main` now clears XDG base-dir env vars in `internal/testutil/homeenv.go`
+  and in `internal/session/testmain_test.go`, so package-level defaults track
+  the current temp `HOME` instead of pinning a shared XDG config root.
+- This branch keeps that mainline strategy. It does **not** re-pin global
+  `IsolateHome` behavior.
+- The per-test `isolateConfigHomeXDG(t)` helper remains only for tests that
+  write config through XDG-aware APIs (`SaveUserConfig`, `CreateExampleConfig`)
+  and should make the scope explicit.
+- The four legacy config-writing helpers still set `XDG_CONFIG_HOME` inside
+  their temp HOME, so they remain isolated even if a caller or future test adds
+  an XDG override.
+- `TestCreateExampleConfigDocumentsCompatibleWith` now has the same explicit
+  XDG isolation as its sibling config-writing tests.
+
+## Additional macOS test-fixture fixes
+
+After rebasing, the old XDG failure set was gone, but macOS still exposed
+standalone test-fixture problems:
+
+- JSONL resume fixtures wrote transcripts under hand-built project paths that
+  could drift from production lookup rules. They now use a shared helper that
+  mirrors production's Claude project-dir encoding.
+- `TestSessionStop_ReapsMcpChildren_RegressionFor965` used `kill(pid, 0)` as
+  the only death signal for a child owned by the Go test process. On macOS a
+  killed child can remain waitable as a zombie until the parent calls `Wait`, so
+  the test now waits on its owned fake child while keeping PID polling for the
+  tmux-owned child in the wiring test.
+
+## Remaining scope
+
+No known local macOS `internal/session` failures remain on this branch after the
+rebase and fixture fixes. The Linux+systemd end-to-end persistence harness is
+still the separate host-specific gate for session lifecycle behavior.
+
+## Repro / verification
+
+```bash
+GOTOOLCHAIN=go1.25.11 go test ./internal/session/... -count=1
+```

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1394,6 +1394,7 @@ func TestBuildCodexCommand_CustomWrapperPreservesToolIdentity(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
 	ClearUserConfigCache()
 
 	agentDeckDir := filepath.Join(tmpDir, ".agent-deck")
@@ -1441,6 +1442,7 @@ func TestBuildCodexCommand_UsesConfiguredCommandForBuiltinCodex(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
 	ClearUserConfigCache()
 	defer ClearUserConfigCache()
 
@@ -1553,6 +1555,7 @@ func TestBuildCodexCommand_ConfiguredCommandResume(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
 	originalCodexHome := os.Getenv("CODEX_HOME")
 	os.Unsetenv("CODEX_HOME")
 	defer func() {
@@ -1585,6 +1588,7 @@ func TestBuildCodexCommand_ExplicitCommandBeatsConfiguredCommand(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
 	ClearUserConfigCache()
 	defer ClearUserConfigCache()
 
@@ -1609,6 +1613,7 @@ func TestBuildCodexCommand_InlineCodexHomeForRolloutCheck(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
 	originalCodexHome := os.Getenv("CODEX_HOME")
 	os.Unsetenv("CODEX_HOME")
 	defer func() {
@@ -1642,6 +1647,7 @@ func TestBuildCodexCommand_QuotedInlineCodexHomeWithSpaces(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
 	originalCodexHome := os.Getenv("CODEX_HOME")
 	os.Unsetenv("CODEX_HOME")
 	defer func() {
@@ -1693,6 +1699,7 @@ func TestBuildCodexCommand_InlineCodexHomeDropsStaleID(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
 	originalCodexHome := os.Getenv("CODEX_HOME")
 	os.Unsetenv("CODEX_HOME")
 	defer func() {
@@ -1902,6 +1909,7 @@ func TestBuildCodexCommand_UsesProfileCodexConfigDirAsCodexHome(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	_ = os.Setenv("HOME", tmpDir)
 	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	isolateConfigHomeXDG(t)
 	originalCodexHome := os.Getenv("CODEX_HOME")
 	_ = os.Unsetenv("CODEX_HOME")
 	defer func() {
@@ -1949,6 +1957,7 @@ func TestBuildCodexCommand_CreatesMissingExplicitCodexHomeDir(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	_ = os.Setenv("HOME", tmpDir)
 	defer func() { _ = os.Setenv("HOME", originalHome) }()
+	isolateConfigHomeXDG(t)
 	originalCodexHome := os.Getenv("CODEX_HOME")
 	_ = os.Unsetenv("CODEX_HOME")
 	defer func() {
@@ -2005,6 +2014,7 @@ func TestCanRestart_CustomCodexWrapperWithKnownID(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
 	ClearUserConfigCache()
 
 	agentDeckDir := filepath.Join(tmpDir, ".agent-deck")

--- a/internal/session/issue1147_multi_session_cwd_test.go
+++ b/internal/session/issue1147_multi_session_cwd_test.go
@@ -56,7 +56,7 @@ import (
 // stage deterministic mtime ordering across multiple files.
 func stageJSONL(t *testing.T, home, projectPath, uuid string, mtime time.Time) {
 	t.Helper()
-	projectDir := filepath.Join(home, ".claude", "projects", ConvertToClaudeDirName(projectPath))
+	projectDir := claudeProjectDirForTest(t, filepath.Join(home, ".claude"), projectPath)
 	require.NoError(t, os.MkdirAll(projectDir, 0o755))
 	path := filepath.Join(projectDir, uuid+".jsonl")
 	body := []byte(`{"sessionId":"` + uuid + `","role":"user","content":"hi"}` + "\n")

--- a/internal/session/issue1187_dedup_key_test.go
+++ b/internal/session/issue1187_dedup_key_test.go
@@ -45,8 +45,7 @@ func setupClaudeTranscript(t *testing.T, initialLine string) (*Instance, string)
 	t.Cleanup(ClearUserConfigCache)
 
 	const sessionID = "sess-1187-aaaa-bbbb-cccc"
-	projectDirName := ConvertToClaudeDirName(projectPath)
-	projectDir := filepath.Join(configDir, "projects", projectDirName)
+	projectDir := claudeProjectDirForTest(t, configDir, projectPath)
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
 		t.Fatalf("mkdir projectDir: %v", err)
 	}

--- a/internal/session/issue924_account_switch_test.go
+++ b/internal/session/issue924_account_switch_test.go
@@ -48,6 +48,9 @@ func withTempAgentDeckHome(t *testing.T, tomlBody string) (tmpHome string) {
 	_ = os.Setenv("HOME", tmpHome)
 	_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
 	_ = os.Unsetenv("AGENTDECK_PROFILE")
+	// Keep XDG_CONFIG_HOME inside this temp HOME too. Empty XDG dir means reads
+	// fall back to the legacy config.toml written below.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
 
 	agentDeckDir := filepath.Join(tmpHome, ".agent-deck")
 	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {

--- a/internal/session/issue956_chat_history_restart_test.go
+++ b/internal/session/issue956_chat_history_restart_test.go
@@ -82,7 +82,7 @@ func TestConductor_Restart_PreservesChatHistory_RegressionFor956(t *testing.T) {
 	// Now write a JSONL on disk — simulating the live conversation Claude
 	// just had. This is the state at the moment the user runs `restart`.
 	const jsonlUUID = "9560ab10-9560-9560-9560-956000000956"
-	projectDir := filepath.Join(home, ".claude", "projects", ConvertToClaudeDirName(inst.ProjectPath))
+	projectDir := claudeProjectDirForTest(t, filepath.Join(home, ".claude"), inst.ProjectPath)
 	require.NoError(t, os.MkdirAll(projectDir, 0o755))
 	jsonlPath := filepath.Join(projectDir, jsonlUUID+".jsonl")
 	body := []byte(`{"sessionId":"` + jsonlUUID + `","role":"user","content":"remember my favorite color is blue"}` + "\n" +

--- a/internal/session/issue965_mcp_reap_test.go
+++ b/internal/session/issue965_mcp_reap_test.go
@@ -7,7 +7,7 @@
 package session
 
 import (
-	"os"
+	"errors"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -43,11 +43,6 @@ func TestSessionStop_ReapsMcpChildren_RegressionFor965(t *testing.T) {
 		_, _ = cmd.Process.Wait()
 	})
 
-	// Sanity: the child is alive before stop.
-	if err := syscall.Kill(pid, syscall.Signal(0)); err != nil {
-		t.Fatalf("fake MCP child PID %d not alive after Start: %v", pid, err)
-	}
-
 	inst := &Instance{ID: "test-965", Title: "issue965"}
 	inst.RegisterMCPChild(pid)
 
@@ -55,43 +50,60 @@ func TestSessionStop_ReapsMcpChildren_RegressionFor965(t *testing.T) {
 		t.Fatalf("Instance.Kill: %v", err)
 	}
 
-	// After Kill(), the child must be dead within a short window.
-	// Acceptable terminal states: ESRCH (gone), zombie ('Z'), exiting ('X').
-	if !waitChildDead(t, pid, 5*time.Second) {
-		t.Fatalf("fake MCP child PID %d still alive after Instance.Kill — orphan reap regression for #965", pid)
+	// After Kill(), the child must be waitable within a short window. This test
+	// owns the fake child process, so waiting is the portable way to distinguish
+	// a successfully-signaled zombie from a still-running process on macOS.
+	if err := waitCmdExited(cmd, 5*time.Second); err != nil {
+		t.Fatalf("fake MCP child PID %d still alive after Instance.Kill — orphan reap regression for #965: %v", pid, err)
 	}
-
-	// Reap the zombie if any so cleanup is clean.
-	_, _ = cmd.Process.Wait()
 }
 
-// waitChildDead polls until syscall.Kill(pid, 0) returns ESRCH (or the
-// process is in a zombie state). Returns true on death within the deadline.
+func waitCmdExited(cmd *exec.Cmd, within time.Duration) error {
+	done := make(chan error, 1)
+	go func() {
+		_, err := cmd.Process.Wait()
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil || errors.Is(err, syscall.ECHILD) {
+			return nil
+		}
+		return err
+	case <-time.After(within):
+		return errors.New("timed out waiting for command exit")
+	}
+}
+
+// waitChildDead polls until syscall.Kill(pid, 0) returns ESRCH or the process
+// is in a terminal zombie/exiting state. It is for children owned by tmux/init,
+// where the Go test process cannot call Wait.
 func waitChildDead(t *testing.T, pid int, within time.Duration) bool {
 	t.Helper()
 	deadline := time.Now().Add(within)
 	for time.Now().Before(deadline) {
 		if err := syscall.Kill(pid, syscall.Signal(0)); err != nil {
-			// ESRCH or EPERM → not addressable as a live process.
 			return true
 		}
-		// On Linux, a zombie still responds to Kill(0). Probe /proc.
-		if runtime.GOOS == "linux" {
-			data, rerr := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/status")
-			if rerr != nil {
-				return true
-			}
-			for _, line := range strings.Split(string(data), "\n") {
-				if strings.HasPrefix(line, "State:") {
-					fields := strings.Fields(line)
-					if len(fields) >= 2 && (fields[1] == "Z" || fields[1] == "X") {
-						return true
-					}
-					break
-				}
-			}
+		if childIsZombieOrExiting(pid) {
+			return true
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
 	return false
+}
+
+func TestChildIsZombieOrExitingDoesNotTreatPsLookupFailureAsTerminal(t *testing.T) {
+	if childIsZombieOrExiting(99999999) {
+		t.Fatal("nonexistent PID was classified as zombie/exiting")
+	}
+}
+
+func childIsZombieOrExiting(pid int) bool {
+	out, err := exec.Command("ps", "-o", "state=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return false
+	}
+	state := strings.TrimSpace(string(out))
+	return strings.HasPrefix(state, "Z") || strings.HasPrefix(state, "X")
 }

--- a/internal/session/pergroupconfig_nested_test.go
+++ b/internal/session/pergroupconfig_nested_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // withIsolatedHomeAndConfig sets HOME to a temp dir, writes config.toml with
-// the supplied body, unsets CLAUDE_CONFIG_DIR + AGENTDECK_PROFILE, and clears
+// the supplied body, clears CLAUDE_CONFIG_DIR + AGENTDECK_PROFILE, and clears
 // the user-config cache. It restores everything on test cleanup. Returns the
 // temp HOME path so tests can build expected absolute paths.
 //
@@ -19,27 +19,13 @@ import (
 func withIsolatedHomeAndConfig(t *testing.T, configBody string) string {
 	t.Helper()
 	tmpHome := t.TempDir()
-	origHome := os.Getenv("HOME")
-	origProfile := os.Getenv("AGENTDECK_PROFILE")
-	origClaudeDir := os.Getenv("CLAUDE_CONFIG_DIR")
-	t.Cleanup(func() {
-		_ = os.Setenv("HOME", origHome)
-		if origProfile != "" {
-			_ = os.Setenv("AGENTDECK_PROFILE", origProfile)
-		} else {
-			_ = os.Unsetenv("AGENTDECK_PROFILE")
-		}
-		if origClaudeDir != "" {
-			_ = os.Setenv("CLAUDE_CONFIG_DIR", origClaudeDir)
-		} else {
-			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
-		}
-		ClearUserConfigCache()
-	})
-
-	_ = os.Setenv("HOME", tmpHome)
-	_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
-	_ = os.Unsetenv("AGENTDECK_PROFILE")
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("AGENTDECK_PROFILE", "")
+	// Keep XDG_CONFIG_HOME inside this temp HOME too. Empty XDG dir means reads
+	// fall back to the legacy config.toml written below.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
+	t.Cleanup(ClearUserConfigCache)
 
 	agentDeckDir := filepath.Join(tmpHome, ".agent-deck")
 	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {

--- a/internal/session/session_persistence_test.go
+++ b/internal/session/session_persistence_test.go
@@ -139,6 +139,19 @@ func isolatedHomeDir(t *testing.T) string {
 	return home
 }
 
+func claudeProjectDirForTest(t *testing.T, configDir, projectPath string) string {
+	t.Helper()
+	resolvedPath := projectPath
+	if resolved, err := filepath.EvalSymlinks(projectPath); err == nil {
+		resolvedPath = resolved
+	}
+	encoded := ConvertToClaudeDirName(resolvedPath)
+	if encoded == "" {
+		encoded = "-"
+	}
+	return filepath.Join(configDir, "projects", encoded)
+}
+
 // TestPersistence_LinuxDefaultIsUserScope pins REQ-1: on a Linux host where
 // systemd-run is available and no config.toml overrides it, the default
 // MUST be launch_in_user_scope=true. Phase 2 will flip the default; this
@@ -1262,16 +1275,7 @@ func TestPersistence_CustomCommandResumesFromLatestJSONL(t *testing.T) {
 		olderUUID = "11111111-1111-1111-1111-111111111111"
 		newerUUID = "22222222-2222-2222-2222-222222222222"
 	)
-	// Production discovery (findLatestClaudeTranscriptOnDisk) derives the
-	// Claude projects dir from filepath.EvalSymlinks(ProjectPath); mirror that
-	// so the fixture lands in the dir Start() actually reads. On macOS
-	// t.TempDir() lives under the /var -> /private/var symlink, so the raw and
-	// resolved paths produce different ConvertToClaudeDirName values.
-	resolvedProjectPath := inst.ProjectPath
-	if resolved, err := filepath.EvalSymlinks(inst.ProjectPath); err == nil {
-		resolvedProjectPath = resolved
-	}
-	projectDir := filepath.Join(home, ".claude", "projects", ConvertToClaudeDirName(resolvedProjectPath))
+	projectDir := claudeProjectDirForTest(t, filepath.Join(home, ".claude"), inst.ProjectPath)
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
 		t.Fatalf("mkdir projectDir: %v", err)
 	}
@@ -1348,7 +1352,7 @@ func TestPersistence_DiscoverLatestClaudeJSONL_Unit(t *testing.T) {
 
 	stage := func(t *testing.T, home, name string, mtime time.Time) {
 		t.Helper()
-		dir := filepath.Join(home, ".claude", "projects", ConvertToClaudeDirName(projectPath))
+		dir := claudeProjectDirForTest(t, filepath.Join(home, ".claude"), projectPath)
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
@@ -1459,7 +1463,7 @@ func TestEnsureClaudeSessionIDFromDisk_NewSessionSkipsDiscovery(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 
 	// Stage a JSONL from an existing session in this directory.
-	dir := filepath.Join(home, ".claude", "projects", ConvertToClaudeDirName(projectPath))
+	dir := claudeProjectDirForTest(t, filepath.Join(home, ".claude"), projectPath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -1499,7 +1503,7 @@ func TestEnsureClaudeSessionIDFromDisk_RestartDoesDiscovery(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
 
 	// Stage a JSONL from this session's previous run.
-	dir := filepath.Join(home, ".claude", "projects", ConvertToClaudeDirName(projectPath))
+	dir := claudeProjectDirForTest(t, filepath.Join(home, ".claude"), projectPath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}

--- a/internal/session/userconfig_section_guard_test.go
+++ b/internal/session/userconfig_section_guard_test.go
@@ -46,6 +46,7 @@ func seedConfigWithSections(t *testing.T) *UserConfig {
 // (a) S2: config.toml.bak is created before an overwrite.
 func TestSaveUserConfig_CreatesBackupBeforeOverwrite(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	isolateConfigHomeXDG(t)
 	seedConfigWithSections(t)
 
 	configPath, err := GetUserConfigPath()
@@ -75,6 +76,7 @@ func TestSaveUserConfig_CreatesBackupBeforeOverwrite(t *testing.T) {
 // (c) S3: refuses to drop a populated [mcps] to empty without intent.
 func TestSaveUserConfig_RefusesDroppingMCPsToEmpty(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	isolateConfigHomeXDG(t)
 	seedConfigWithSections(t)
 
 	cfg, err := LoadUserConfig()
@@ -105,6 +107,7 @@ func TestSaveUserConfig_RefusesDroppingMCPsToEmpty(t *testing.T) {
 // (c') S3: same protection for [groups].
 func TestSaveUserConfig_RefusesDroppingGroupsToEmpty(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	isolateConfigHomeXDG(t)
 	seedConfigWithSections(t)
 
 	cfg, err := LoadUserConfig()
@@ -125,6 +128,7 @@ func TestSaveUserConfig_RefusesDroppingGroupsToEmpty(t *testing.T) {
 // (d) THE KEY ANTI-FALSE-POSITIVE TEST: removing ONE group (of two) succeeds.
 func TestSaveUserConfig_SingleGroupRemoval_StillSucceeds(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	isolateConfigHomeXDG(t)
 	seedConfigWithSections(t)
 
 	cfg, err := LoadUserConfig()
@@ -163,6 +167,7 @@ func TestSaveUserConfig_SingleGroupRemoval_StillSucceeds(t *testing.T) {
 // is unaffected.
 func TestSaveUserConfig_NormalSave_Unaffected(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	isolateConfigHomeXDG(t)
 	seedConfigWithSections(t)
 
 	cfg, err := LoadUserConfig()
@@ -185,6 +190,7 @@ func TestSaveUserConfig_NormalSave_Unaffected(t *testing.T) {
 // (f) The explicit-intent escape hatch DOES allow clearing a populated section.
 func TestSaveUserConfigWithIntent_AllowsSectionClear(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	isolateConfigHomeXDG(t)
 	seedConfigWithSections(t)
 
 	cfg, err := LoadUserConfig()
@@ -206,6 +212,7 @@ func TestSaveUserConfigWithIntent_AllowsSectionClear(t *testing.T) {
 // the new save is the intent-cleared one — so the catalog is recoverable.
 func TestSaveUserConfig_BackupHoldsPreSaveSections(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	isolateConfigHomeXDG(t)
 	seedConfigWithSections(t)
 
 	configPath, _ := GetUserConfigPath()

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -10,6 +10,18 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+// isolateConfigHomeXDG redirects XDG_CONFIG_HOME at the test's already-set HOME
+// so XDG-aware config writes stay inside the same temp tree as HOME. Package
+// TestMain clears XDG by default so ordinary HOME-only tests track HOME; this
+// helper is for tests that write config through SaveUserConfig/CreateExampleConfig
+// and should make that scope explicit. Call it AFTER setting HOME.
+func isolateConfigHomeXDG(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(os.Getenv("HOME"), ".config"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+}
+
 func TestDisplaySettings_GetIncludeCwdPrefix(t *testing.T) {
 	var d DisplaySettings
 	if !d.GetIncludeCwdPrefix() {
@@ -44,8 +56,7 @@ func TestGetCodexCommand_DefaultAndConfig(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tempDir)
 	defer os.Setenv("HOME", originalHome)
-	ClearUserConfigCache()
-	defer ClearUserConfigCache()
+	isolateConfigHomeXDG(t)
 
 	if got := GetCodexCommand(); got != "codex" {
 		t.Fatalf("GetCodexCommand() without config = %q, want codex", got)
@@ -286,7 +297,7 @@ func TestIsClaudeCompatible_CustomToolCommands(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
-	ClearUserConfigCache()
+	isolateConfigHomeXDG(t)
 
 	agentDeckDir := filepath.Join(tmpDir, ".agent-deck")
 	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
@@ -338,7 +349,7 @@ func TestIsCodexCompatible_CustomToolCommands(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
-	ClearUserConfigCache()
+	isolateConfigHomeXDG(t)
 
 	agentDeckDir := filepath.Join(tmpDir, ".agent-deck")
 	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
@@ -384,6 +395,7 @@ func TestCreateExampleConfigDocumentsCompatibleWith(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
 
 	if err := CreateExampleConfig(); err != nil {
 		t.Fatalf("CreateExampleConfig: %v", err)
@@ -509,9 +521,7 @@ func TestSaveUserConfig(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tempDir)
 	defer os.Setenv("HOME", originalHome)
-
-	// Clear cache
-	ClearUserConfigCache()
+	isolateConfigHomeXDG(t)
 
 	// Create agent-deck directory
 	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
@@ -565,8 +575,7 @@ func TestClaudeExtraArgsConfigRoundTrip(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tempDir)
 	defer os.Setenv("HOME", originalHome)
-	ClearUserConfigCache()
-	defer ClearUserConfigCache()
+	isolateConfigHomeXDG(t)
 
 	config := &UserConfig{
 		Claude: ClaudeSettings{
@@ -619,7 +628,7 @@ func TestGetTheme_Light(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tempDir)
 	defer os.Setenv("HOME", originalHome)
-	ClearUserConfigCache()
+	isolateConfigHomeXDG(t)
 
 	// Create config with light theme
 	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
@@ -639,7 +648,7 @@ func TestResolveTheme_COLORFGBGOverridesOS(t *testing.T) {
 	// auto-detection where COLORFGBG should be checked.
 	tempDir := t.TempDir()
 	t.Setenv("HOME", tempDir)
-	ClearUserConfigCache()
+	isolateConfigHomeXDG(t)
 
 	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
 	_ = os.MkdirAll(agentDeckDir, 0700)
@@ -751,7 +760,7 @@ func TestGetWorktreeSettings_FromConfig(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tempDir)
 	defer os.Setenv("HOME", originalHome)
-	ClearUserConfigCache()
+	isolateConfigHomeXDG(t)
 
 	// Create config with custom worktree settings
 	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
@@ -806,7 +815,7 @@ func TestGetWorktreeSettings_BranchPrefix(t *testing.T) {
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tempDir)
 	defer os.Setenv("HOME", originalHome)
-	ClearUserConfigCache()
+	isolateConfigHomeXDG(t)
 
 	// Create config with custom branch_prefix
 	agentDeckDir := filepath.Join(tempDir, ".agent-deck")

--- a/internal/session/userconfig_web_test.go
+++ b/internal/session/userconfig_web_test.go
@@ -15,6 +15,11 @@ func withTempHomeAndConfig(t *testing.T, contents string) string {
 	tempDir := t.TempDir()
 	originalHome := os.Getenv("HOME")
 	os.Setenv("HOME", tempDir)
+	// Keep XDG_CONFIG_HOME inside this temp HOME too. TestMain clears XDG so
+	// HOME-only isolation usually works, but this helper writes legacy config
+	// files and should stay isolated even if a caller adds an XDG override.
+	// An empty XDG config dir makes reads fall back to the legacy file below.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tempDir, ".config"))
 	t.Cleanup(func() {
 		os.Setenv("HOME", originalHome)
 		ClearUserConfigCache()

--- a/internal/session/worker_scratch_telegram_gate_test.go
+++ b/internal/session/worker_scratch_telegram_gate_test.go
@@ -31,6 +31,9 @@ import (
 // MUST already point at home for the helper to take effect.
 func writeUserConfigForTest(t *testing.T, home, body string) {
 	t.Helper()
+	// Keep XDG_CONFIG_HOME inside this temp HOME too. Empty XDG dir means reads
+	// fall back to the legacy config.toml written below.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	dir := filepath.Join(home, ".agent-deck")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("mkdir .agent-deck: %v", err)


### PR DESCRIPTION
## Summary

Fixes and documents the `internal/session` XDG test-isolation fallout from #1294 after rebasing onto current `main`.

- Keeps the mainline cleared-XDG `IsolateHome` / `TestMain` behavior intact; this PR does not re-pin package-level XDG defaults.
- Adds targeted per-test `isolateConfigHomeXDG(t)` coverage for config-writing tests, including `TestCreateExampleConfigDocumentsCompatibleWith`.
- Aligns macOS Claude JSONL transcript fixtures with production project-dir encoding.
- Makes the issue #965 fake-child reap test use a portable wait path on macOS.
- Addresses the Copilot review comments by tightening process-helper false positives, removing redundant cache clears next to `isolateConfigHomeXDG(t)`, switching the touched per-group env helper to `t.Setenv`, and replacing stale RFC status wording.

Full maintainer note: `docs/rfc/SESSION_TEST_XDG_ISOLATION.md`.

## Current status

Rebased on `f209d41b` (`main`, #1299). Current head is `21d8f10f`.

## Test plan

```bash
GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go-path GOCACHE=/private/tmp/agent-deck-go-cache GOMODCACHE=/private/tmp/agent-deck-go-modcache go test ./internal/session -run "Test(SessionStop_ReapsMcpChildren_RegressionFor965|ChildIsZombieOrExitingDoesNotTreatPsLookupFailureAsTerminal|GetCodexCommand_DefaultAndConfig|IsClaudeCompatible_CustomToolCommands|IsCodexCompatible_CustomToolCommands|CreateExampleConfigDocumentsCompatibleWith|SaveUserConfig|ClaudeExtraArgsConfigRoundTrip|GetTheme_Light|ResolveTheme_COLORFGBGOverridesOS|GetWorktreeSettings_FromConfig|GetWorktreeSettings_BranchPrefix|PerGroupConfig_)" -count=1
# PASS: ok github.com/asheshgoplani/agent-deck/internal/session 3.455s

GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go-path GOCACHE=/private/tmp/agent-deck-go-cache GOMODCACHE=/private/tmp/agent-deck-go-modcache go test ./internal/session/... -count=1
# PASS: ok github.com/asheshgoplani/agent-deck/internal/session 50.975s

GOTOOLCHAIN=go1.25.11 GOPATH=/private/tmp/agent-deck-go-path GOCACHE=/private/tmp/agent-deck-go-cache GOMODCACHE=/private/tmp/agent-deck-go-modcache go test -run TestPersistence_ ./internal/session/... -race -count=1
# PASS: ok github.com/asheshgoplani/agent-deck/internal/session 4.386s

git diff --check HEAD
# PASS
```

Not run locally:

```bash
bash scripts/verify-session-persistence.sh
# Requires Linux+systemd host.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by ensuring XDG-based config paths are scoped to temporary homes and config caches are consistently reset.
  * Centralized helper for computing external tool project directories so test fixtures match on-disk discovery.
  * Enhanced process-reaping tests with robust waiting for child termination and clearer zombie/exiting detection to reduce flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->