### PR TITLE
fix(tui): don't send literal "shell" command on quick-create shell sessions

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -9260,7 +9260,7 @@ func (h *Home) quickCreateSession() tea.Cmd {
 	if tool == "" {
 		tool = "claude"
 	}
-	if command == "" {
+	if command == "" && tool != "shell" {
 		if tool == "cursor" {
 			command = "cursor agent"
 		} else {
@@ -9345,6 +9345,9 @@ func (h *Home) quickCreateSessionAt(projectPath string) tea.Cmd {
 		tool = "claude"
 	}
 	command := tool
+	if tool == "shell" {
+		command = ""
+	}
 
 	preferred := deriveSessionNameFromPath(projectPath)
 	h.instancesMu.RLock()


### PR DESCRIPTION
Quick-create (`N`) resolved the spawn command to the tool name for every tool
except cursor, so a `shell` session ran `bash -c 'shell'` and failed with
`shell: command not found`. Shell sessions should carry no command and drop into
the interactive shell, same as the normal `n` dialog.

Leaves the command empty when the tool is `shell` in both quick-create paths
(`quickCreateSession`, `quickCreateSessionAt`).

Fixes #1306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session creation defaults for the shell tool to properly manage command settings in both quick-create and quick-create-at-path workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->