### PR TITLE
feat(session): show running indicator for shell sessions with a foreground process

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3501,6 +3501,33 @@ func hookFastPathFreshnessForTool(tool, hookStatus string) time.Duration {
 	}
 }
 
+// shellForegroundRunning reports whether a "shell" tool session currently has a
+// genuine non-interactive foreground process running (e.g. "node" from
+// `yarn dev`, "java" from `mvn spring-boot:run`). It returns false for the
+// interactive shell itself and for interactive foreground programs (editors,
+// pagers, system monitors, remote shells, multiplexers) that are really waiting
+// for the user rather than doing background work — otherwise opening vim or
+// sitting at an ssh prompt would show a perpetual running indicator.
+//
+// It relies on the pane-info cache warmed once per tick by RefreshPaneInfoCache
+// (TUI backgroundStatusUpdate / Web refreshStatuses / CLI status refresh). When
+// the cache is cold the lookup misses and this returns false, preserving the
+// historical "shell maps to idle" behavior. Caller must hold i.mu.
+func (i *Instance) shellForegroundRunning() bool {
+	if i.tmuxSession == nil {
+		return false
+	}
+	paneInfo, ok := tmux.GetCachedPaneInfo(i.tmuxSession.Name)
+	if !ok || paneInfo.CurrentCommand == "" {
+		return false
+	}
+	cmd := paneInfo.CurrentCommand
+	if isShellBinary(cmd) || isInteractiveForegroundProgram(cmd) {
+		return false
+	}
+	return true
+}
+
 // UpdateStatus updates the session status by checking tmux.
 // Thread-safe: acquires write lock to protect Status, Tool, and internal cache fields.
 func (i *Instance) UpdateStatus() error {
@@ -3698,12 +3725,11 @@ func (i *Instance) UpdateStatus() error {
 	case "active":
 		i.Status = StatusRunning
 	case "waiting":
+		// tmux reports a shell prompt ("waiting"), but a non-interactive foreground
+		// process may still be running (e.g. "yarn dev", "mvn spring-boot:run").
+		// shellForegroundRunning() inspects the cached pane command to tell them apart.
 		if i.Tool == "shell" {
-			// tmux sees a shell prompt ("waiting") but a foreground process may still be
-			// running (e.g. "yarn dev", "mvn spring-boot:run"). pane_current_command is
-			// already cached by RefreshPaneInfoCache so this lookup is free.
-			if paneInfo, ok := tmux.GetCachedPaneInfo(i.tmuxSession.Name); ok &&
-				paneInfo.CurrentCommand != "" && !isShellBinary(paneInfo.CurrentCommand) {
+			if i.shellForegroundRunning() {
 				i.Status = StatusRunning
 			} else {
 				i.Status = StatusIdle
@@ -3712,15 +3738,10 @@ func (i *Instance) UpdateStatus() error {
 			i.Status = StatusWaiting
 		}
 	case "idle":
-		// For acknowledged shell sessions, a foreground process may still be running
-		// even though the user has already attached. Keep showing running in that case.
-		if i.Tool == "shell" {
-			if paneInfo, ok := tmux.GetCachedPaneInfo(i.tmuxSession.Name); ok &&
-				paneInfo.CurrentCommand != "" && !isShellBinary(paneInfo.CurrentCommand) {
-				i.Status = StatusRunning
-			} else {
-				i.Status = StatusIdle
-			}
+		// Acknowledged shell sessions can still have a foreground process running
+		// even after the user has attached; keep surfacing that as running.
+		if i.Tool == "shell" && i.shellForegroundRunning() {
+			i.Status = StatusRunning
 		} else {
 			i.Status = StatusIdle
 		}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3699,12 +3699,31 @@ func (i *Instance) UpdateStatus() error {
 		i.Status = StatusRunning
 	case "waiting":
 		if i.Tool == "shell" {
-			i.Status = StatusIdle
+			// tmux sees a shell prompt ("waiting") but a foreground process may still be
+			// running (e.g. "yarn dev", "mvn spring-boot:run"). pane_current_command is
+			// already cached by RefreshPaneInfoCache so this lookup is free.
+			if paneInfo, ok := tmux.GetCachedPaneInfo(i.tmuxSession.Name); ok &&
+				paneInfo.CurrentCommand != "" && !isShellBinary(paneInfo.CurrentCommand) {
+				i.Status = StatusRunning
+			} else {
+				i.Status = StatusIdle
+			}
 		} else {
 			i.Status = StatusWaiting
 		}
 	case "idle":
-		i.Status = StatusIdle
+		// For acknowledged shell sessions, a foreground process may still be running
+		// even though the user has already attached. Keep showing running in that case.
+		if i.Tool == "shell" {
+			if paneInfo, ok := tmux.GetCachedPaneInfo(i.tmuxSession.Name); ok &&
+				paneInfo.CurrentCommand != "" && !isShellBinary(paneInfo.CurrentCommand) {
+				i.Status = StatusRunning
+			} else {
+				i.Status = StatusIdle
+			}
+		} else {
+			i.Status = StatusIdle
+		}
 	case "starting":
 		i.Status = StatusStarting
 	case "inactive":

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3513,12 +3513,30 @@ func hookFastPathFreshnessForTool(tool, hookStatus string) time.Duration {
 // (TUI backgroundStatusUpdate / Web refreshStatuses / CLI status refresh). When
 // the cache is cold the lookup misses and this returns false, preserving the
 // historical "shell maps to idle" behavior. Caller must hold i.mu.
+//
+// The feature is opt-in via [status] shell_running_indicator (default false):
+// the interactive-program denylist cannot be complete, so without the flag a
+// shell sitting at a psql/REPL/fzf prompt would flip everyone's historical
+// "shell → idle" default to running.
+//
+// Staleness guards — only fresh pane info may promote idle→running:
+//   - GetCachedPaneInfoSnapshot enforces the cache-wide 4s TTL (2 ticks).
+//   - A dead pane (#{pane_dead}) means the command already exited.
+//   - A snapshot taken before this instance's last start describes a previous
+//     same-name session (kill+recreate within the TTL), not this one.
 func (i *Instance) shellForegroundRunning() bool {
 	if i.tmuxSession == nil {
 		return false
 	}
-	paneInfo, ok := tmux.GetCachedPaneInfo(i.tmuxSession.Name)
-	if !ok || paneInfo.CurrentCommand == "" {
+	cfg, _ := LoadUserConfig()
+	if cfg == nil || !cfg.Status.ShellRunningIndicator {
+		return false
+	}
+	paneInfo, snapshotAt, ok := tmux.GetCachedPaneInfoSnapshot(i.tmuxSession.Name)
+	if !ok || paneInfo.Dead || paneInfo.CurrentCommand == "" {
+		return false
+	}
+	if !i.lastStartTime.IsZero() && snapshotAt.Before(i.lastStartTime) {
 		return false
 	}
 	cmd := paneInfo.CurrentCommand

--- a/internal/session/shell_foreground_status_test.go
+++ b/internal/session/shell_foreground_status_test.go
@@ -1,0 +1,101 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// These tests cover the shell foreground-process status detection added so that
+// a shell session running `yarn dev` / `mvn spring-boot:run` shows a running
+// indicator instead of idle, while interactive programs (editors, pagers, ssh)
+// keep showing idle.
+
+func TestIsShellBinary(t *testing.T) {
+	for _, s := range []string{
+		"bash", "zsh", "sh", "fish", "dash", "ksh", "tcsh", "csh",
+		"nu", "nushell", "pwsh", "powershell",
+		"BASH", "Zsh", // case-insensitive
+	} {
+		assert.Truef(t, isShellBinary(s), "%q should be classified as a shell", s)
+	}
+	for _, s := range []string{"node", "java", "python", "ssh", "vim", "sleep", ""} {
+		assert.Falsef(t, isShellBinary(s), "%q should not be classified as a shell", s)
+	}
+}
+
+func TestIsInteractiveForegroundProgram(t *testing.T) {
+	for _, c := range []string{
+		"ssh", "mosh", "mosh-client", "et", "tmux", "screen", "zellij",
+		"vi", "vim", "nvim", "nano", "emacs", "emacsclient", "helix", "hx", "micro", "kak",
+		"less", "more", "most", "man", "bat",
+		"top", "htop", "btop", "btm", "glances", "atop",
+		"SSH", "Vim", // case-insensitive
+	} {
+		assert.Truef(t, isInteractiveForegroundProgram(c), "%q should be treated as interactive", c)
+	}
+
+	// REPLs/interpreters/servers must NOT be denylisted: they share a process
+	// name with the long-running commands this feature targets (yarn dev -> node,
+	// runserver -> python). Denylisting them would defeat the feature.
+	for _, c := range []string{
+		"node", "python", "python3", "ruby", "java", "go", "deno", "bun",
+		"sleep", "make", "cargo", "gradle", "mvn", "",
+	} {
+		assert.Falsef(t, isInteractiveForegroundProgram(c),
+			"%q must not be treated as interactive (would mask a running process)", c)
+	}
+}
+
+func TestShellForegroundRunning(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{"node dev server (yarn dev)", "node", true},
+		{"java spring boot (mvn spring-boot:run)", "java", true},
+		{"python runserver", "python", true},
+		{"sleep / generic process", "sleep", true},
+		{"idle bash prompt", "bash", false},
+		{"idle zsh prompt", "zsh", false},
+		{"ssh remote shell", "ssh", false},
+		{"vim editor", "vim", false},
+		{"less pager", "less", false},
+		{"htop monitor", "htop", false},
+		{"empty command", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := NewInstance("fg-test", "/tmp")
+			inst.Tool = "shell"
+			inst.tmuxSession = tmux.NewSession("fg-test", "/tmp")
+			tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+				inst.tmuxSession.Name: {CurrentCommand: tc.command},
+			})
+			assert.Equal(t, tc.want, inst.shellForegroundRunning())
+		})
+	}
+}
+
+// A cold pane-info cache (no RefreshPaneInfoCache / seed) must preserve the
+// historical "shell maps to idle" behavior — shellForegroundRunning returns
+// false when the foreground command for the pane is unknown.
+func TestShellForegroundRunning_ColdCacheReturnsFalse(t *testing.T) {
+	inst := NewInstance("cold-test", "/tmp")
+	inst.Tool = "shell"
+	inst.tmuxSession = tmux.NewSession("cold-test", "/tmp")
+	// Intentionally no SeedPaneInfoCacheForTest: the cache holds no entry for
+	// this session's unique name, so the lookup misses.
+	assert.False(t, inst.shellForegroundRunning())
+}
+
+// Defensive: a nil tmuxSession must not panic.
+func TestShellForegroundRunning_NilSession(t *testing.T) {
+	inst := NewInstance("nil-test", "/tmp")
+	inst.Tool = "shell"
+	inst.tmuxSession = nil
+	assert.False(t, inst.shellForegroundRunning())
+}

--- a/internal/session/shell_foreground_status_test.go
+++ b/internal/session/shell_foreground_status_test.go
@@ -1,9 +1,13 @@
 package session
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
@@ -11,7 +15,40 @@ import (
 // These tests cover the shell foreground-process status detection added so that
 // a shell session running `yarn dev` / `mvn spring-boot:run` shows a running
 // indicator instead of idle, while interactive programs (editors, pagers, ssh)
-// keep showing idle.
+// keep showing idle. The feature is opt-in via [status] shell_running_indicator
+// (default false) and only fresh pane-cache snapshots may promote idle→running.
+
+// setShellRunningIndicatorForTest writes a config.toml with the
+// shell_running_indicator flag into the TestMain-isolated HOME and clears the
+// user-config cache. The previous file contents (if any) are restored on
+// cleanup. TestMain's IsolateHome guarantees this never touches the real
+// ~/.agent-deck (2026-06-04 data-loss incident, S5).
+func setShellRunningIndicatorForTest(t testing.TB, enabled bool) {
+	t.Helper()
+
+	path, err := GetUserConfigPath()
+	require.NoError(t, err)
+
+	prev, prevErr := os.ReadFile(path)
+	hadPrev := prevErr == nil
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	content := "[status]\nshell_running_indicator = false\n"
+	if enabled {
+		content = "[status]\nshell_running_indicator = true\n"
+	}
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	ClearUserConfigCache()
+
+	t.Cleanup(func() {
+		if hadPrev {
+			_ = os.WriteFile(path, prev, 0o644)
+		} else {
+			_ = os.Remove(path)
+		}
+		ClearUserConfigCache()
+	})
+}
 
 func TestIsShellBinary(t *testing.T) {
 	for _, s := range []string{
@@ -50,6 +87,8 @@ func TestIsInteractiveForegroundProgram(t *testing.T) {
 }
 
 func TestShellForegroundRunning(t *testing.T) {
+	setShellRunningIndicatorForTest(t, true)
+
 	tests := []struct {
 		name    string
 		command string
@@ -80,10 +119,38 @@ func TestShellForegroundRunning(t *testing.T) {
 	}
 }
 
+// The indicator is opt-in. With no config (or the flag explicitly false) a
+// running foreground process must NOT promote the session — this preserves the
+// historical "shell maps to idle" default for everyone who has not opted in
+// (a shell sitting in psql/a REPL/fzf would otherwise read running).
+func TestShellForegroundRunning_OptInDefaultOff(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(t *testing.T)
+	}{
+		{"no config file (defaults)", func(t *testing.T) { t.Helper(); ClearUserConfigCache() }},
+		{"flag explicitly false", func(t *testing.T) { t.Helper(); setShellRunningIndicatorForTest(t, false) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.configure(t)
+			inst := NewInstance("optin-test", "/tmp")
+			inst.Tool = "shell"
+			inst.tmuxSession = tmux.NewSession("optin-test", "/tmp")
+			tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+				inst.tmuxSession.Name: {CurrentCommand: "node"},
+			})
+			assert.False(t, inst.shellForegroundRunning(),
+				"foreground process must not promote status unless shell_running_indicator is opted in")
+		})
+	}
+}
+
 // A cold pane-info cache (no RefreshPaneInfoCache / seed) must preserve the
 // historical "shell maps to idle" behavior — shellForegroundRunning returns
 // false when the foreground command for the pane is unknown.
 func TestShellForegroundRunning_ColdCacheReturnsFalse(t *testing.T) {
+	setShellRunningIndicatorForTest(t, true)
+
 	inst := NewInstance("cold-test", "/tmp")
 	inst.Tool = "shell"
 	inst.tmuxSession = tmux.NewSession("cold-test", "/tmp")
@@ -92,10 +159,122 @@ func TestShellForegroundRunning_ColdCacheReturnsFalse(t *testing.T) {
 	assert.False(t, inst.shellForegroundRunning())
 }
 
+// A warm-but-stale cache must not promote idle→running: a snapshot past the
+// freshness TTL can describe a command that has since completed.
+func TestShellForegroundRunning_StaleCacheReturnsFalse(t *testing.T) {
+	setShellRunningIndicatorForTest(t, true)
+
+	inst := NewInstance("stale-test", "/tmp")
+	inst.Tool = "shell"
+	inst.tmuxSession = tmux.NewSession("stale-test", "/tmp")
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+		inst.tmuxSession.Name: {CurrentCommand: "node"},
+	})
+	require.True(t, inst.shellForegroundRunning(), "fresh seed should promote")
+
+	tmux.ExpirePaneInfoCacheForTest(t)
+	assert.False(t, inst.shellForegroundRunning(),
+		"stale pane info must not drive the idle→running transition")
+}
+
+// A dead pane (#{pane_dead}) means the foreground command already exited —
+// never promote from it, no matter how fresh the snapshot is.
+func TestShellForegroundRunning_DeadPaneReturnsFalse(t *testing.T) {
+	setShellRunningIndicatorForTest(t, true)
+
+	inst := NewInstance("dead-test", "/tmp")
+	inst.Tool = "shell"
+	inst.tmuxSession = tmux.NewSession("dead-test", "/tmp")
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+		inst.tmuxSession.Name: {CurrentCommand: "node", Dead: true},
+	})
+	assert.False(t, inst.shellForegroundRunning())
+}
+
+// A snapshot taken BEFORE the instance's last start describes a previous
+// same-name session (kill + recreate within the freshness TTL), not this one.
+// It must not promote the freshly started session to running.
+func TestShellForegroundRunning_SnapshotPredatingStartReturnsFalse(t *testing.T) {
+	setShellRunningIndicatorForTest(t, true)
+
+	inst := NewInstance("recreate-test", "/tmp")
+	inst.Tool = "shell"
+	inst.tmuxSession = tmux.NewSession("recreate-test", "/tmp")
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+		inst.tmuxSession.Name: {CurrentCommand: "node"},
+	})
+
+	// Control: snapshot taken after the last start may promote.
+	inst.lastStartTime = time.Now().Add(-time.Minute)
+	require.True(t, inst.shellForegroundRunning())
+
+	// The session was (re)started after the snapshot was taken: reject.
+	inst.lastStartTime = time.Now().Add(time.Minute)
+	assert.False(t, inst.shellForegroundRunning(),
+		"pane snapshot predating the session start belongs to the previous same-name session")
+}
+
 // Defensive: a nil tmuxSession must not panic.
 func TestShellForegroundRunning_NilSession(t *testing.T) {
+	setShellRunningIndicatorForTest(t, true)
+
 	inst := NewInstance("nil-test", "/tmp")
 	inst.Tool = "shell"
 	inst.tmuxSession = nil
 	assert.False(t, inst.shellForegroundRunning())
+}
+
+// End-to-end coverage of the changed UpdateStatus path (not just the
+// classifiers): a real tmux-backed shell session whose tmux-derived status is
+// idle/waiting gets promoted to StatusRunning only when (a) the opt-in flag is
+// set AND (b) the pane-info cache holds a fresh non-interactive foreground
+// command — and falls back to StatusIdle when the cache goes stale or the
+// flag is off. Mirrors the issue-953 test setup: `sleep 60` keeps the pane
+// quiet so the tmux status settles on waiting/idle past the 1.5s grace period.
+func TestUpdateStatus_ShellForegroundPromotion(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	setShellRunningIndicatorForTest(t, true)
+
+	inst := NewInstance("test-shell-fg-e2e", "/tmp")
+	inst.Tool = "shell"
+	inst.Command = "sleep 60"
+
+	require.NoError(t, inst.Start())
+	defer func() { _ = inst.Kill() }()
+
+	// Wait past the 1.5s grace period so UpdateStatus does real detection.
+	time.Sleep(2 * time.Second)
+
+	// Fresh cache + flag on: the foreground process promotes idle→running.
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+		inst.tmuxSession.Name: {CurrentCommand: "node"},
+	})
+	require.NoError(t, inst.UpdateStatus())
+	assert.Equal(t, StatusRunning, inst.GetStatusThreadSafe(),
+		"fresh foreground command with opt-in flag should report running")
+
+	// Stale cache: the promotion must drop back to the historical idle.
+	tmux.ExpirePaneInfoCacheForTest(t)
+	require.NoError(t, inst.UpdateStatus())
+	assert.Equal(t, StatusIdle, inst.GetStatusThreadSafe(),
+		"stale pane info must not keep the session promoted")
+
+	// Interactive foreground program: stays idle even with a fresh cache.
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+		inst.tmuxSession.Name: {CurrentCommand: "vim"},
+	})
+	require.NoError(t, inst.UpdateStatus())
+	assert.Equal(t, StatusIdle, inst.GetStatusThreadSafe(),
+		"interactive foreground programs must not promote")
+
+	// Flag off: identical fresh cache, no promotion — the gate holds the
+	// historical shell→idle default for non-opted-in users.
+	setShellRunningIndicatorForTest(t, false)
+	tmux.SeedPaneInfoCacheForTest(t, map[string]tmux.PaneInfo{
+		inst.tmuxSession.Name: {CurrentCommand: "node"},
+	})
+	require.NoError(t, inst.UpdateStatus())
+	assert.Equal(t, StatusIdle, inst.GetStatusThreadSafe(),
+		"without the opt-in flag the running indicator must stay off")
 }

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2582,6 +2582,33 @@ func isShellBinary(cmd string) bool {
 	return false
 }
 
+// isInteractiveForegroundProgram returns true for foreground commands that are
+// interactive and effectively waiting for the user rather than doing background
+// work: editors, pagers, system monitors, remote shells, and terminal
+// multiplexers. A shell session sitting in one of these should NOT show a
+// "running" indicator (an idle ssh prompt or an open editor is not busy work).
+//
+// REPLs and interpreters (node, python, ruby, …) are deliberately NOT listed:
+// they share a process name with the long-running servers this feature targets
+// (`yarn dev` runs as "node", `python manage.py runserver` runs as "python"),
+// so denylisting them would defeat the primary use case. The rare REPL false
+// positive is the lesser evil versus failing to flag a running dev server.
+func isInteractiveForegroundProgram(cmd string) bool {
+	switch strings.ToLower(cmd) {
+	case
+		// remote shells / terminal multiplexers
+		"ssh", "mosh", "mosh-client", "et", "tmux", "screen", "zellij",
+		// editors
+		"vi", "vim", "nvim", "nano", "emacs", "emacsclient", "helix", "hx", "micro", "kak",
+		// pagers / viewers
+		"less", "more", "most", "man", "bat",
+		// system monitors
+		"top", "htop", "btop", "btm", "glances", "atop":
+		return true
+	}
+	return false
+}
+
 // GetCodexCommand returns the configured Codex command/alias.
 func GetCodexCommand() string {
 	userConfig, _ := LoadUserConfig()

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2571,6 +2571,17 @@ func IsCodexCompatible(toolName string) bool {
 	return false
 }
 
+// isShellBinary returns true if cmd is a known interactive shell process name.
+// Used to distinguish "shell at a prompt" from "shell running a foreground command"
+// (e.g. "node" from "yarn dev", "java" from "mvn spring-boot:run").
+func isShellBinary(cmd string) bool {
+	switch strings.ToLower(cmd) {
+	case "bash", "zsh", "sh", "fish", "dash", "ksh", "tcsh", "csh", "nu", "nushell", "pwsh", "powershell":
+		return true
+	}
+	return false
+}
+
 // GetCodexCommand returns the configured Codex command/alias.
 func GetCodexCommand() string {
 	userConfig, _ := LoadUserConfig()

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2121,6 +2121,18 @@ func (f ForkSettings) Resolve(parentSandboxed bool) ResolvedForkPlan {
 type StatusSettings struct {
 	// Reserved for future status detection settings.
 	// Control mode pipes are always enabled (no longer configurable).
+
+	// ShellRunningIndicator promotes "shell" tool sessions from idle to
+	// running when the pane's foreground command is a genuine non-interactive
+	// process (e.g. "node" from `yarn dev`, "java" from `mvn spring-boot:run`).
+	// Opt-in (default false): the interactive-program denylist is necessarily
+	// incomplete, so a shell sitting at a psql/REPL/fzf prompt would otherwise
+	// read "running" while the user is idle. Users who want dev-server
+	// detection accept that tradeoff explicitly:
+	//
+	//	[status]
+	//	shell_running_indicator = true
+	ShellRunningIndicator bool `toml:"shell_running_indicator"`
 }
 
 // MaintenanceSettings controls the automatic maintenance worker

--- a/internal/tmux/title_detection.go
+++ b/internal/tmux/title_detection.go
@@ -193,15 +193,26 @@ func RefreshPaneInfoCache() {
 // GetCachedPaneInfo returns cached pane info for a session.
 // Returns (info, true) if found and cache is fresh, (zero, false) otherwise.
 func GetCachedPaneInfo(sessionName string) (PaneInfo, bool) {
+	info, _, ok := GetCachedPaneInfoSnapshot(sessionName)
+	return info, ok
+}
+
+// GetCachedPaneInfoSnapshot is GetCachedPaneInfo plus the time the cache
+// snapshot was taken. Callers that promote state based on pane info (e.g. the
+// shell foreground running indicator) use the snapshot time to reject entries
+// that predate an event of interest — a pane snapshot taken before a session
+// was (re)started describes the previous same-name session, not the current
+// one. The same 4s freshness window applies (2 refresh ticks).
+func GetCachedPaneInfoSnapshot(sessionName string) (PaneInfo, time.Time, bool) {
 	paneCacheMu.RLock()
 	defer paneCacheMu.RUnlock()
 
 	if paneCacheData == nil || time.Since(paneCacheTime) > 4*time.Second {
-		return PaneInfo{}, false
+		return PaneInfo{}, time.Time{}, false
 	}
 
 	info, ok := paneCacheData[sessionName]
-	return info, ok
+	return info, paneCacheTime, ok
 }
 
 // AnalyzePaneTitle determines session state from the pane title.


### PR DESCRIPTION
## Summary

Shell sessions now show a **running** indicator when a non-interactive foreground process is active (e.g. `yarn dev` → `node`, `mvn spring-boot:run` → `java`), instead of always mapping to idle. When the command returns to the shell prompt, the indicator goes back to idle.

Previously, a `shell` tool session at a prompt was unconditionally mapped to `idle`, and tmux's content-based busy detection (`hasBusyIndicator`) only recognizes agent-style spinners / "ctrl+c to interrupt", so a plain `yarn dev` / `mvn spring-boot:run` never surfaced as running.

## How it works

`pane_current_command` is already cached once per tick by `RefreshPaneInfoCache` (TUI `backgroundStatusUpdate` / Web `refreshStatuses` / CLI status refresh), so this adds **no new tmux queries**. In the `waiting`/`idle` arms of `UpdateStatus`, shell sessions consult the cached foreground command:

- shell binary (`bash`, `zsh`, …) → **idle**
- interactive program (`ssh`, `vim`, `less`, `man`, `top`, `tmux`, …) → **idle** (an idle ssh prompt or open editor is not busy work)
- anything else (`node`, `java`, `python`, …) → **running**

REPLs/interpreters are intentionally **not** denylisted: they share a process name with the long-running servers this targets (`yarn dev` → `node`, `runserver` → `python`), so denylisting them would defeat the feature. The rare REPL false positive is the lesser evil versus missing a running dev server.

When the pane-info cache is cold the lookup misses and the session falls back to the historical idle mapping, so behavior is unchanged where the cache isn't warmed.

## Changes

- `internal/session/instance.go` — `shellForegroundRunning()` helper (nil-guarded, cold-cache safe); `waiting`/`idle` switch arms use it
- `internal/session/userconfig.go` — `isShellBinary()` and `isInteractiveForegroundProgram()` classifiers
- `internal/session/shell_foreground_status_test.go` — unit coverage for both classifiers and `shellForegroundRunning` (warm cache, cold cache, nil session)

## Testing

- `make fmt` — clean
- `make lint` (golangci-lint v2) — 0 issues
- `go test -race ./internal/session/ ./internal/git/` — pass (new tests + git-dependent tests green)

No new tmux subprocesses; relies entirely on the existing pane-info cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in setting to treat shell sessions as "running" when foreground non-interactive work is detected.

* **Bug Fixes**
  * More accurate shell session status: distinguishes idle prompts from real foreground work and safely treats sessions as idle if pane info is missing or stale.

* **Tests**
  * Expanded test suite for process classification, cache freshness/expiry, dead-pane and snapshot-timing scenarios, and end-to-end status promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->