### PR TITLE
fix(verify-persistence): harden cross-platform degradation of the persistence harness

### DIFF
--- a/.github/workflows/session-persistence.yml
+++ b/.github/workflows/session-persistence.yml
@@ -1,14 +1,15 @@
 # Session persistence CI gate for v1.5.2.
 #
 # Runs on every PR that touches any file under the v1.5.2 mandate (see
-# CLAUDE.md "Session persistence: mandatory test coverage" section). Two
-# jobs, both required:
-#   1. tests        — go test -run TestPersistence_ -race -count=1
+# CLAUDE.md "Session persistence: mandatory test coverage" section). Three
+# jobs, all required:
+#   1. tests         — go test -run TestPersistence_ -race -count=1
 #   2. verify-script — bash scripts/verify-session-persistence.sh
+#   3. unit-xplat    — go test ./scripts/... on macOS + Linux
 #
 # Either red blocks the PR. Branch protection rules are user-managed and
 # not part of this workflow; the CLAUDE.md mandate instructs reviewers to
-# require both jobs green plus the test output (or CI link) in the PR body.
+# require all jobs green plus the test output (or CI link) in the PR body.
 #
 # Do NOT modify .github/workflows/release.yml. This workflow is strictly
 # additive.
@@ -49,8 +50,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: Install tmux and jq
+        run: sudo apt-get update && sudo apt-get install -y tmux jq
 
       - name: Enable user lingering (systemd user scope)
         run: loginctl enable-linger "$USER" || true

--- a/.github/workflows/session-persistence.yml
+++ b/.github/workflows/session-persistence.yml
@@ -27,6 +27,7 @@ on:
       - 'cmd/restart_cmd.go'
       - 'scripts/verify-session-persistence.sh'
       - 'scripts/verify-session-persistence.d/**'
+      - 'scripts/verify-session-persistence_test.go'
       - 'internal/session/session_persistence_test.go'
       - 'CLAUDE.md'
       - '.github/workflows/session-persistence.yml'
@@ -84,3 +85,33 @@ jobs:
         env:
           AGENT_DECK_VERIFY_USE_STUB: '1'
         run: bash scripts/verify-session-persistence.sh
+
+  unit-xplat:
+    name: harness unit tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Ensure jq present
+        # Only jq is needed: the unit tests stub the tmux-calling helper and
+        # never invoke real tmux. (Don't install tmux here — wasted brew time.)
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            command -v jq >/dev/null || brew install jq
+          else
+            command -v jq >/dev/null || sudo apt-get install -y jq
+          fi
+
+      - name: go test ./scripts/...
+        run: go test ./scripts/... -count=1 -v

--- a/.github/workflows/session-persistence.yml
+++ b/.github/workflows/session-persistence.yml
@@ -41,6 +41,7 @@ jobs:
   tests:
     name: TestPersistence_ suite (-race)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -62,6 +63,7 @@ jobs:
   verify-script:
     name: scripts/verify-session-persistence.sh
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -71,8 +73,8 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: Install tmux and jq
+        run: sudo apt-get update && sudo apt-get install -y tmux jq
 
       - name: Enable user lingering (systemd user scope)
         run: loginctl enable-linger "$USER" || true
@@ -89,6 +91,7 @@ jobs:
 
   unit-xplat:
     name: harness unit tests (${{ matrix.os }})
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/session-persistence.yml
+++ b/.github/workflows/session-persistence.yml
@@ -111,7 +111,7 @@ jobs:
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             command -v jq >/dev/null || brew install jq
           else
-            command -v jq >/dev/null || sudo apt-get install -y jq
+            command -v jq >/dev/null || { sudo apt-get update && sudo apt-get install -y jq; }
           fi
 
       - name: go test ./scripts/...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `verify-session-persistence.sh` now degrades truthfully on macOS/non-systemd
   hosts: scenarios 3/4 `[SKIP]` instead of false `[FAIL]` when claude argv is
   unobservable, scenario 5 resolves its tmux name via `session show --json`, and
-  the harness cleans up its own tempdir. Gated by new macOS + Linux unit tests.
+  the harness cleans up its own tempdir and sessions by full JSON title. The
+  harness now requires `jq` explicitly and the fake Claude stub no longer relies
+  on GNU-only `sleep infinity`. Gated by new macOS + Linux unit tests.
 
 ## [1.9.49] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `verify-session-persistence.sh` now degrades truthfully on macOS/non-systemd
+  hosts: scenarios 3/4 `[SKIP]` when claude argv is unobservable on non-stub
+  hosts — but `[FAIL]` in stub mode (`AGENT_DECK_VERIFY_USE_STUB=1`, i.e. CI),
+  where the stub must record args and a `[SKIP]` would be a false-green on the
+  mandatory gate. Scenario 5 resolves its tmux name via `session show --json`,
+  and a malformed-JSON payload from a successful `session show --json` is
+  surfaced (loud error) rather than masked as an empty name; likewise any
+  non-not-found error from `session show --json` (exit 1 = DB/load/permission)
+  now surfaces instead of degrading to a false-green `[SKIP]` — including down
+  the argv-capture path, where scenarios 3/4 now `[FAIL]` on a real resolver
+  error regardless of stub mode (vs flattening it to empty→`[SKIP]`). Cleanup removes
+  ONLY the exact session titles this invocation created (tracked as each is
+  created) — never a `verify-persist-${PID}` prefix match on `agent-deck list`
+  output, which collided with foreign runs and fired even on a failed preflight
+  (data-loss risks). `RUN_ID` is now per-invocation unique (PID + epoch seconds
+  + `${RANDOM}`) rather than a bare reusable PID, so two runs can never generate
+  identical titles and cleanup can only match its own sessions even across a
+  reused PID. The harness cleans up its own tempdir, requires `jq` explicitly,
+  and the fake Claude stub no longer relies on GNU-only `sleep infinity`. Gated
+  by new macOS + Linux unit tests.
+
 ## [1.9.53] - 2026-06-09
 
 ### Fixed
@@ -60,26 +83,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Pin GitHub Actions to commit SHAs in the release workflow** ([#1326](https://github.com/asheshgoplani/agent-deck/pull/1326)). Supply-chain hardening: third-party actions in `release.yml` are pinned to immutable commit SHAs.
 - **Reconcile XDG test isolation after rebase** ([#1304](https://github.com/asheshgoplani/agent-deck/pull/1304)).
-
-### Fixed
-
-- `verify-session-persistence.sh` now degrades truthfully on macOS/non-systemd
-  hosts: scenarios 3/4 `[SKIP]` when claude argv is unobservable on non-stub
-  hosts — but `[FAIL]` in stub mode (`AGENT_DECK_VERIFY_USE_STUB=1`, i.e. CI),
-  where the stub must record args and a `[SKIP]` would be a false-green on the
-  mandatory gate. Scenario 5 resolves its tmux name via `session show --json`,
-  and a malformed-JSON payload from a successful `session show --json` is
-  surfaced (loud error) rather than masked as an empty name; likewise any
-  non-not-found error from `session show --json` (exit 1 = DB/load/permission)
-  now surfaces instead of degrading to a false-green `[SKIP]` — including down
-  the argv-capture path, where scenarios 3/4 now `[FAIL]` on a real resolver
-  error regardless of stub mode (vs flattening it to empty→`[SKIP]`). Cleanup removes
-  ONLY the exact session titles this invocation created (tracked as each is
-  created) — never a `verify-persist-${PID}` prefix match on `agent-deck list`
-  output, which collided with foreign runs and fired even on a failed preflight
-  (data-loss risks). The harness cleans up its own tempdir, requires `jq`
-  explicitly, and the fake Claude stub no longer relies on GNU-only
-  `sleep infinity`. Gated by new macOS + Linux unit tests.
 
 ## [1.9.49] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where the stub must record args and a `[SKIP]` would be a false-green on the
   mandatory gate. Scenario 5 resolves its tmux name via `session show --json`,
   and a malformed-JSON payload from a successful `session show --json` is
-  surfaced (loud error) rather than masked as an empty name. The harness cleans
-  up its own tempdir and sessions by full JSON title, requires `jq` explicitly,
-  and the fake Claude stub no longer relies on GNU-only `sleep infinity`. Gated
-  by new macOS + Linux unit tests.
+  surfaced (loud error) rather than masked as an empty name; likewise any
+  non-not-found error from `session show --json` (exit 1 = DB/load/permission)
+  now surfaces instead of degrading to a false-green `[SKIP]`. Cleanup removes
+  ONLY the exact session titles this invocation created (tracked as each is
+  created) — never a `verify-persist-${PID}` prefix match on `agent-deck list`
+  output, which collided with foreign runs and fired even on a failed preflight
+  (data-loss risks). The harness cleans up its own tempdir, requires `jq`
+  explicitly, and the fake Claude stub no longer relies on GNU-only
+  `sleep infinity`. Gated by new macOS + Linux unit tests.
 
 ## [1.9.49] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pin GitHub Actions to commit SHAs in the release workflow** ([#1326](https://github.com/asheshgoplani/agent-deck/pull/1326)). Supply-chain hardening: third-party actions in `release.yml` are pinned to immutable commit SHAs.
 - **Reconcile XDG test isolation after rebase** ([#1304](https://github.com/asheshgoplani/agent-deck/pull/1304)).
 
+### Fixed
+
+- `verify-session-persistence.sh` now degrades truthfully on macOS/non-systemd
+  hosts: scenarios 3/4 `[SKIP]` instead of false `[FAIL]` when claude argv is
+  unobservable, scenario 5 resolves its tmux name via `session show --json`, and
+  the harness cleans up its own tempdir. Gated by new macOS + Linux unit tests.
+
 ## [1.9.49] - 2026-06-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,11 +64,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `verify-session-persistence.sh` now degrades truthfully on macOS/non-systemd
-  hosts: scenarios 3/4 `[SKIP]` instead of false `[FAIL]` when claude argv is
-  unobservable, scenario 5 resolves its tmux name via `session show --json`, and
-  the harness cleans up its own tempdir and sessions by full JSON title. The
-  harness now requires `jq` explicitly and the fake Claude stub no longer relies
-  on GNU-only `sleep infinity`. Gated by new macOS + Linux unit tests.
+  hosts: scenarios 3/4 `[SKIP]` when claude argv is unobservable on non-stub
+  hosts — but `[FAIL]` in stub mode (`AGENT_DECK_VERIFY_USE_STUB=1`, i.e. CI),
+  where the stub must record args and a `[SKIP]` would be a false-green on the
+  mandatory gate. Scenario 5 resolves its tmux name via `session show --json`,
+  and a malformed-JSON payload from a successful `session show --json` is
+  surfaced (loud error) rather than masked as an empty name. The harness cleans
+  up its own tempdir and sessions by full JSON title, requires `jq` explicitly,
+  and the fake Claude stub no longer relies on GNU-only `sleep infinity`. Gated
+  by new macOS + Linux unit tests.
 
 ## [1.9.49] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a malformed-JSON payload from a successful `session show --json` is
   surfaced (loud error) rather than masked as an empty name; likewise any
   non-not-found error from `session show --json` (exit 1 = DB/load/permission)
-  now surfaces instead of degrading to a false-green `[SKIP]`. Cleanup removes
+  now surfaces instead of degrading to a false-green `[SKIP]` — including down
+  the argv-capture path, where scenarios 3/4 now `[FAIL]` on a real resolver
+  error regardless of stub mode (vs flattening it to empty→`[SKIP]`). Cleanup removes
   ONLY the exact session titles this invocation created (tracked as each is
   created) — never a `verify-persist-${PID}` prefix match on `agent-deck list`
   output, which collided with foreign runs and fired even on a failed preflight

--- a/docs/SESSION-PERSISTENCE-SPEC.md
+++ b/docs/SESSION-PERSISTENCE-SPEC.md
@@ -169,6 +169,20 @@ The session-id binding contract is documented at `docs/session-id-lifecycle.md` 
 - No scope creep — if a plan wants to refactor code outside the paths named above, stop and escalate to the conductor.
 - No mocking of tmux or systemd in the persistence tests — use the real binaries; skip on hosts that don't have them.
 
+### Cross-platform degradation contract (v1.5.2 harness hardening)
+
+`scripts/verify-session-persistence.sh` MUST run cleanly on non-systemd hosts:
+
+- Scenario 2 (login-teardown) and the cgroup branch of scenario 1 `[SKIP]` on
+  non-Linux — unchanged; these gate a Linux+systemd-only contract.
+- Scenarios 3/4 `[SKIP]` (never `[FAIL]`) when claude argv is unobservable for
+  the managed session (stub bypassed by a pre-existing shared tmux daemon, or
+  empty `pane_start_command`). The harness never asserts on host-wide processes.
+- Scenario 5 resolves its tmux session name via `session show --json`.
+- The harness removes its own `${TMPDIR}/adeck-verify.*` tempdir on exit.
+
+Unit-gated by `scripts/verify-session-persistence_test.go` on macOS + Linux CI.
+
 ## Success criteria for the milestone
 
 1. On the user's conductor host, after installing v1.5.2, `launch_in_user_scope` is effectively `true` without any config edit. Proof: `systemctl --user status` shows `agentdeck-tmux-*.scope` units.

--- a/docs/SESSION-PERSISTENCE-SPEC.md
+++ b/docs/SESSION-PERSISTENCE-SPEC.md
@@ -182,6 +182,10 @@ The session-id binding contract is documented at `docs/session-id-lifecycle.md` 
 - In **stub mode** (`AGENT_DECK_VERIFY_USE_STUB=1`, i.e. CI) an unobservable
   argv is a `[FAIL]`, not a `[SKIP]`: the stub is installed and MUST record
   args, so a `[SKIP]` there would be a false-green on the mandatory gate.
+- "Unobservable" (degrade) is distinct from a real resolver error: if argv
+  capture hits a genuine `session show` error (the nonzero cases below, not
+  not-found), scenarios 3/4 `[FAIL]` regardless of stub mode — the capture path
+  propagates the resolver's nonzero rather than flattening it to empty→`[SKIP]`.
 - Scenario 5 resolves its tmux session name via `session show --json`.
 - `jq` is an explicit harness dependency; missing `jq` is a preflight error, not
   a silent `[SKIP]`. For `session show --json`, only the EXPECTED not-found

--- a/docs/SESSION-PERSISTENCE-SPEC.md
+++ b/docs/SESSION-PERSISTENCE-SPEC.md
@@ -179,7 +179,10 @@ The session-id binding contract is documented at `docs/session-id-lifecycle.md` 
   the managed session (stub bypassed by a pre-existing shared tmux daemon, or
   empty `pane_start_command`). The harness never asserts on host-wide processes.
 - Scenario 5 resolves its tmux session name via `session show --json`.
-- The harness removes its own `${TMPDIR}/adeck-verify.*` tempdir on exit.
+- `jq` is an explicit harness dependency; missing `jq` is a preflight error, not
+  a silent `[SKIP]`.
+- The harness removes its own `${TMPDIR}/adeck-verify.*` tempdir and
+  `verify-persist-*` sessions by full JSON title on exit.
 
 Unit-gated by `scripts/verify-session-persistence_test.go` on macOS + Linux CI.
 

--- a/docs/SESSION-PERSISTENCE-SPEC.md
+++ b/docs/SESSION-PERSISTENCE-SPEC.md
@@ -201,6 +201,10 @@ The session-id binding contract is documented at `docs/session-id-lifecycle.md` 
   path fired even on a failed preflight that created nothing — both data-loss
   risks. Empty created-list ⇒ no-op (e.g. failed preflight). Trade-off: a
   hard-killed run's sessions are not swept by a later run.
+- `RUN_ID` (hence every session title) is per-invocation unique — PID + epoch
+  seconds + `${RANDOM}`, not a bare reusable PID — so two runs can never
+  generate identical titles, and the exact-title cleanup can only ever match its
+  own sessions even if the OS reuses a PID across a hard-killed prior run.
 
 Unit-gated by `scripts/verify-session-persistence_test.go` on macOS + Linux CI.
 

--- a/docs/SESSION-PERSISTENCE-SPEC.md
+++ b/docs/SESSION-PERSISTENCE-SPEC.md
@@ -175,12 +175,18 @@ The session-id binding contract is documented at `docs/session-id-lifecycle.md` 
 
 - Scenario 2 (login-teardown) and the cgroup branch of scenario 1 `[SKIP]` on
   non-Linux — unchanged; these gate a Linux+systemd-only contract.
-- Scenarios 3/4 `[SKIP]` (never `[FAIL]`) when claude argv is unobservable for
-  the managed session (stub bypassed by a pre-existing shared tmux daemon, or
-  empty `pane_start_command`). The harness never asserts on host-wide processes.
+- Scenarios 3/4 `[SKIP]` on **non-stub hosts** (real `claude`, e.g.
+  macOS/no-systemd dev) when claude argv is unobservable for the managed session
+  (stub bypassed by a pre-existing shared tmux daemon, or empty
+  `pane_start_command`). The harness never asserts on host-wide processes.
+- In **stub mode** (`AGENT_DECK_VERIFY_USE_STUB=1`, i.e. CI) an unobservable
+  argv is a `[FAIL]`, not a `[SKIP]`: the stub is installed and MUST record
+  args, so a `[SKIP]` there would be a false-green on the mandatory gate.
 - Scenario 5 resolves its tmux session name via `session show --json`.
 - `jq` is an explicit harness dependency; missing `jq` is a preflight error, not
-  a silent `[SKIP]`.
+  a silent `[SKIP]`. A malformed-JSON payload from a SUCCESSFUL
+  `session show --json` is surfaced (loud error + nonzero), not degraded to an
+  empty name — only the EXPECTED not-found nonzero is swallowed.
 - The harness removes its own `${TMPDIR}/adeck-verify.*` tempdir and
   `verify-persist-*` sessions by full JSON title on exit.
 

--- a/docs/SESSION-PERSISTENCE-SPEC.md
+++ b/docs/SESSION-PERSISTENCE-SPEC.md
@@ -184,11 +184,19 @@ The session-id binding contract is documented at `docs/session-id-lifecycle.md` 
   args, so a `[SKIP]` there would be a false-green on the mandatory gate.
 - Scenario 5 resolves its tmux session name via `session show --json`.
 - `jq` is an explicit harness dependency; missing `jq` is a preflight error, not
-  a silent `[SKIP]`. A malformed-JSON payload from a SUCCESSFUL
-  `session show --json` is surfaced (loud error + nonzero), not degraded to an
-  empty name — only the EXPECTED not-found nonzero is swallowed.
-- The harness removes its own `${TMPDIR}/adeck-verify.*` tempdir and
-  `verify-persist-*` sessions by full JSON title on exit.
+  a silent `[SKIP]`. For `session show --json`, only the EXPECTED not-found
+  (`exit 2`, `ErrCodeNotFound`) is swallowed → unresolved/empty; ANY other
+  nonzero (`exit 1` = DB/load/permission/crash) and a malformed-JSON payload
+  from a SUCCESSFUL call are SURFACED (loud error + nonzero), never degraded to
+  an empty name and a false-green `[SKIP]`.
+- Cleanup removes ONLY the exact session titles this invocation created (tracked
+  in `CREATED_SESSIONS` as each is created) and its own
+  `${TMPDIR}/adeck-verify.*` tempdir. It NEVER prefix/text-parses
+  `agent-deck list`: `SESSION_PREFIX="verify-persist-${PID}"` is a bare prefix
+  that collides (PID `123` matches a foreign `verify-persist-1234-*`), and that
+  path fired even on a failed preflight that created nothing — both data-loss
+  risks. Empty created-list ⇒ no-op (e.g. failed preflight). Trade-off: a
+  hard-killed run's sessions are not swept by a later run.
 
 Unit-gated by `scripts/verify-session-persistence_test.go` on macOS + Linux CI.
 

--- a/docs/superpowers/plans/2026-06-07-harden-verify-persistence-xplat.md
+++ b/docs/superpowers/plans/2026-06-07-harden-verify-persistence-xplat.md
@@ -1,0 +1,759 @@
+# Harden verify-session-persistence.sh Cross-Platform Degradation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `scripts/verify-session-persistence.sh` degrade *truthfully* on non-systemd hosts (macOS, BSD, any dev box with a real `claude` running) — emitting `[SKIP]` instead of false `[FAIL]`, resolving its tmux session name via the authoritative path, and cleaning up its own temp dir — without touching the Linux+systemd contract (scenario 2) it exists to gate.
+
+**Architecture:** The harness is a Bash script with zero automated tests. We introduce a one-line `AGENT_DECK_VERIFY_LIB_ONLY` guard so its functions can be *sourced* without running the imperative dispatch, then extract three thin, pure-ish predicates (`is_own_tmproot`, `resolve_tmux_session`, `capture_claude_argv`) that become the TDD seams. A new Go test package (`scripts`, matching the repo convention of `exec.Command("bash", ...)`) drives red→green on each fix and runs identically on macOS and Linux CI. Scenario 2 and the cgroup half of scenario 1 stay Linux-gated and untouched.
+
+**Tech Stack:** Bash 3.2+ (macOS ships 3.2 — no associative arrays, no `${x^^}`), Go `testing` + `os/exec`, `jq`, `tmux`, GitHub Actions.
+
+---
+
+## Why these three fixes (evidence)
+
+Confirmed empirically on a macOS dev host (build `agent-deck` → run harness):
+
+| ID | Symptom | Root cause | Fix |
+|----|---------|-----------|-----|
+| **A** | Scenarios 3 & 4 emit false `[FAIL]` | Stub bypassed by a pre-existing shared tmux daemon → `ARGV_OUT` empty → tier-2 `pane_start_command` empty → fell to tier-3 `ps -ef \| grep '[c]laude'`, which matched an unrelated real Claude process. | Remove the host-wide `ps` tier; capture from session-scoped sources only; empty argv ⇒ `[SKIP]`, never `[FAIL]`. |
+| **B** | Temp dir leaks on macOS | `mktemp -d -t adeck-verify.XXXXXX` resolves under `$TMPDIR` (`/var/folders/...`), but the cleanup guard is `"${TMPROOT}" == /tmp/adeck-verify.*` — never matches → `rm -rf` skipped. | Portable explicit-template `mktemp`; guard on basename, not a hardcoded `/tmp` prefix. |
+| **C** | Scenario 5 silently `[SKIP]`s | Resolver greps `agent-deck list` for `/^adeck_/`, but `list` never prints the tmux session name **and** the real prefix is `agentdeck_`. | Resolve via `agent-deck session show --json \| jq -r '.tmux_session'` — the path the other helpers already use and which is verified to work. |
+
+Out of scope (do NOT touch): scenario 2 login-teardown logic, the cgroup branch of scenario 1, `internal/**` product code, the `launch_in_user_scope` defaults.
+
+---
+
+## File Structure
+
+- **Modify** `scripts/verify-session-persistence.sh`
+  - Add `is_own_tmproot`, `resolve_tmux_session`, `capture_claude_argv`, `classify_argv` helpers.
+  - Wrap all imperative top-level code in `main()`; gate it behind `AGENT_DECK_VERIFY_LIB_ONLY`.
+  - Portable `mktemp`; consolidate `tmux_pid_for_session` / `tmux_pane_start_command_for_session` / scenario 5 onto `resolve_tmux_session`; scenario 3/4 onto `capture_claude_argv`.
+- **Create** `scripts/verify-session-persistence_test.go` (package `scripts`) — bash-sourcing unit tests for A/B/C plus the source-guard.
+- **Modify** `.github/workflows/session-persistence.yml` — add a `unit-xplat` job matrix (`ubuntu-latest`, `macos-latest`) running `go test ./scripts/...`.
+- **Modify** `docs/SESSION-PERSISTENCE-SPEC.md`, `CHANGELOG.md` — record the degradation-path contract (skills/docs sync discipline).
+
+**Mandate note (CLAUDE.md):** `scripts/verify-session-persistence.sh` is under the v1.5.2 session-persistence mandate. Every commit here MUST keep `go test -run TestPersistence_ ./internal/session/... -race -count=1` green, and the final verification (Task 6) MUST run `bash scripts/verify-session-persistence.sh` end-to-end on a Linux+systemd host. `git commit --no-verify` is FORBIDDEN on these source commits.
+
+---
+
+## Task 1: Make the harness sourceable (the TDD seam)
+
+**Files:**
+- Modify: `scripts/verify-session-persistence.sh`
+- Create: `scripts/verify-session-persistence_test.go`
+
+The harness currently runs everything at top level — sourcing it would `mktemp`, install traps, `exit 2` on missing `agent-deck`, and run all scenarios. We wrap the imperative tail in `main()` and call it only when not in lib-only mode, leaving function definitions and `readonly` constants importable.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/verify-session-persistence_test.go`:
+
+```go
+package scripts
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scriptPath returns the absolute path to the harness under test. Go test runs
+// with CWD = package dir (scripts/), so the script is a sibling.
+func scriptPath(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	p := filepath.Join(wd, "verify-session-persistence.sh")
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("harness not found at %s: %v", p, err)
+	}
+	return p
+}
+
+// sourceAndRun sources the harness in lib-only mode and runs a bash snippet.
+// Returns combined stdout+stderr. `set -e` is active (the harness sets it), so
+// snippets must guard non-zero returns with `if`/`||` rather than bare calls.
+func sourceAndRun(t *testing.T, env []string, snippet string) (string, error) {
+	t.Helper()
+	full := "AGENT_DECK_VERIFY_LIB_ONLY=1 source '" + scriptPath(t) + "'\n" + snippet
+	cmd := exec.Command("bash", "-c", full)
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func TestLibOnly_SourcesWithoutSideEffects(t *testing.T) {
+	// Sourcing with LIB_ONLY=1 must NOT run preflight/dispatch: no scenarios,
+	// no mktemp side effects, clean exit even with agent-deck absent from PATH.
+	out, err := sourceAndRun(t, []string{"PATH=/usr/bin:/bin"},
+		`echo "SOURCED_OK"; type -t main >/dev/null && echo "MAIN_DEFINED"`)
+	if err != nil {
+		t.Fatalf("sourcing failed (expected clean source): %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "SOURCED_OK") {
+		t.Fatalf("snippet did not run; got:\n%s", out)
+	}
+	if !strings.Contains(out, "MAIN_DEFINED") {
+		t.Fatalf("main() not defined after source; got:\n%s", out)
+	}
+	if strings.Contains(out, "persistence harness") || strings.Contains(out, "[PASS]") {
+		t.Fatalf("dispatch ran during source (should be gated by LIB_ONLY); got:\n%s", out)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `GOTOOLCHAIN=go1.25.11 go test ./scripts/ -run TestLibOnly_SourcesWithoutSideEffects -v`
+Expected: FAIL — sourcing runs the full harness (prints the "persistence harness" banner / `[PASS]` lines, or exits non-zero on missing `agent-deck`), so the `dispatch ran during source` or non-zero-exit assertion trips.
+
+- [ ] **Step 3: Wrap the imperative tail in `main()` and gate it**
+
+In `scripts/verify-session-persistence.sh`, move every imperative top-level statement into a new `main()` function. Concretely: the runtime state init (`FAILED=0`, `RUN_ID`, `TMPROOT`, `SESSION_PREFIX`, `LOGINSIM_SCOPE`, `ARGV_OUT`, the `export`), the `trap cleanup ...` line, the preflight `command -v` checks, the stub-install block, the checklist `cat`, and the `want_scenario N && scenario_N` dispatch including the final `FAILED`/exit logic. Assignments inside `main()` are intentionally left WITHOUT `local` so `cleanup`/scenario functions still see them as globals.
+
+Replace the original dispatch tail (currently lines ~347-359) and relocate setup into:
+
+```bash
+# ---------- entrypoint ----------
+main() {
+  FAILED=0
+  RUN_ID="$$"
+  TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/adeck-verify.XXXXXX")"
+  SESSION_PREFIX="verify-persist-${RUN_ID}"
+  LOGINSIM_SCOPE="adeck-verify-loginsim-${RUN_ID}"
+  ARGV_OUT="${TMPROOT}/argv.log"
+  export AGENT_DECK_VERIFY_ARGV_OUT="${ARGV_OUT}"
+
+  trap cleanup EXIT INT TERM
+
+  # ----- preflight -----
+  if ! command -v agent-deck >/dev/null 2>&1; then
+    printf "${C_RED}ERROR${C_RESET}: agent-deck binary not on PATH.\n" >&2
+    exit 2
+  fi
+  if ! command -v tmux >/dev/null 2>&1; then
+    printf "${C_RED}ERROR${C_RESET}: tmux binary not on PATH.\n" >&2
+    exit 2
+  fi
+
+  # ----- claude stub decision (unchanged logic) -----
+  USE_STUB=0
+  if [[ "${AGENT_DECK_VERIFY_USE_STUB:-0}" == "1" ]]; then
+    USE_STUB=1
+  elif ! command -v claude >/dev/null 2>&1; then
+    USE_STUB=1
+  fi
+  if [[ "${USE_STUB}" == "1" ]]; then
+    STUB_DIR="$(cd "$(dirname "$0")/verify-session-persistence.d" && pwd)"
+    mkdir -p "${TMPROOT}/bin"
+    ln -sf "${STUB_DIR}/fake-claude.sh" "${TMPROOT}/bin/claude"
+    export PATH="${TMPROOT}/bin:${PATH}"
+    log "claude stub: ${STUB_DIR}/fake-claude.sh (argv -> ${ARGV_OUT})"
+  else
+    log "claude: $(command -v claude) (real)"
+  fi
+
+  # ----- checklist -----
+  cat <<EOF
+==========================================================
+verify-session-persistence.sh — v1.5.2 persistence harness
+==========================================================
+${CHECKLIST}
+==========================================================
+Each scenario ends with one [PASS], [FAIL], or [SKIP] line.
+EOF
+
+  # ----- dispatch -----
+  want_scenario 1 && scenario_1_live_session_cgroup
+  want_scenario 2 && scenario_2_login_teardown
+  want_scenario 3 && scenario_3_restart_resume
+  want_scenario 4 && scenario_4_fresh_session_shape
+  want_scenario 5 && scenario_5_reviver_respawns_killed_pipe
+
+  if [[ "${FAILED}" -ne 0 ]]; then
+    printf "${C_RED}OVERALL: FAIL${C_RESET}\n" >&2
+    exit 1
+  fi
+  printf "${C_GREEN}OVERALL: PASS${C_RESET}\n"
+  exit 0
+}
+
+# Run only when executed directly. When sourced for unit tests with
+# AGENT_DECK_VERIFY_LIB_ONLY=1, expose functions without side effects.
+if [[ "${AGENT_DECK_VERIFY_LIB_ONLY:-0}" != "1" ]]; then
+  main "$@"
+fi
+```
+
+Delete the now-relocated original lines: the runtime-state block (orig. 30-36), the `trap` (orig. 58), the preflight (orig. 60-68), the stub block (orig. 70-86), the checklist `cat` (orig. 88-96), and the dispatch/exit tail (orig. 347-359). Leave `set -euo pipefail`, all `readonly` constants, `banner_*`/`log`, `cleanup`, and every `scenario_*`/helper definition at top level.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `GOTOOLCHAIN=go1.25.11 go test ./scripts/ -run TestLibOnly_SourcesWithoutSideEffects -v`
+Expected: PASS — `SOURCED_OK` + `MAIN_DEFINED` present, no banner/`[PASS]` leakage.
+
+Also confirm the script still executes normally end-to-end is deferred to Task 6; a quick syntax check now:
+Run: `bash -n scripts/verify-session-persistence.sh`
+Expected: no output, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/verify-session-persistence.sh scripts/verify-session-persistence_test.go
+git commit -m "test(verify-persistence): make harness sourceable via LIB_ONLY guard"
+```
+
+---
+
+## Task 2: Fix B — temp-dir cleanup guard (macOS leak)
+
+**Files:**
+- Modify: `scripts/verify-session-persistence.sh` (`cleanup`, and the `mktemp` line added in Task 1)
+- Modify: `scripts/verify-session-persistence_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/verify-session-persistence_test.go`:
+
+```go
+func TestIsOwnTmproot_MatchesMktempOutputAnyParent(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/tmp/adeck-verify.AbC123", true},                       // Linux mktemp
+		{"/var/folders/23/xxxx/T/adeck-verify.AbC123", true},     // macOS $TMPDIR
+		{"/private/var/folders/q/y/T/adeck-verify.Z9", true},     // macOS realpath
+		{"/tmp", false},                                          // bare tmp — never rm
+		{"/home/user/important", false},                          // unrelated dir
+		{"", false},                                              // empty
+		{"/tmp/other-prefix.123", false},                         // wrong prefix
+	}
+	for _, c := range cases {
+		snippet := `if is_own_tmproot "` + c.path + `"; then echo YES; else echo NO; fi`
+		out, err := sourceAndRun(t, nil, snippet)
+		if err != nil {
+			t.Fatalf("path %q: bash error: %v\n%s", c.path, err, out)
+		}
+		got := strings.Contains(out, "YES")
+		if got != c.want {
+			t.Errorf("is_own_tmproot(%q) = %v, want %v (out: %s)", c.path, got, c.want, strings.TrimSpace(out))
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `GOTOOLCHAIN=go1.25.11 go test ./scripts/ -run TestIsOwnTmproot -v`
+Expected: FAIL — `is_own_tmproot: command not found` (function doesn't exist yet).
+
+- [ ] **Step 3: Add `is_own_tmproot` and rewire `cleanup`**
+
+In `scripts/verify-session-persistence.sh`, add near the other helpers (after `log()`):
+
+```bash
+# is_own_tmproot returns 0 iff $1 is a tempdir THIS harness created via mktemp.
+# Matches on the leaf name (prefix adeck-verify.), NOT a hardcoded /tmp parent,
+# so it works on macOS where mktemp resolves under $TMPDIR (/var/folders/...).
+# Uses pure-bash parameter expansion (${p##*/}) — no fork, no BSD-vs-GNU
+# `basename --` portability question, works on bash 3.2. Callers add the `-d`
+# existence test before rm.
+is_own_tmproot() {
+  local p="$1"
+  [[ -n "$p" && "${p##*/}" == adeck-verify.* ]]
+}
+```
+
+In `cleanup()`, replace the final guarded `rm` block:
+
+```bash
+  # Remove the script's OWN tempdir only (per CLAUDE.md, never rm user state).
+  if is_own_tmproot "${TMPROOT:-}" && [[ -d "${TMPROOT}" ]]; then
+    rm -rf "${TMPROOT}" 2>/dev/null || true
+  fi
+```
+
+(The portable `mktemp "${TMPDIR:-/tmp}/adeck-verify.XXXXXX"` was already introduced in Task 1, Step 3.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `GOTOOLCHAIN=go1.25.11 go test ./scripts/ -run TestIsOwnTmproot -v`
+Expected: PASS (all 7 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/verify-session-persistence.sh scripts/verify-session-persistence_test.go
+git commit -m "fix(verify-persistence): clean up tempdir on macOS (basename guard, portable mktemp)"
+```
+
+---
+
+## Task 3: Fix C — scenario 5 tmux-name resolver
+
+**Files:**
+- Modify: `scripts/verify-session-persistence.sh` (`resolve_tmux_session`, `tmux_pid_for_session`, `tmux_pane_start_command_for_session`, `scenario_5_*`)
+- Modify: `scripts/verify-session-persistence_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/verify-session-persistence_test.go`:
+
+```go
+// writeFakeAgentDeck installs a stub `agent-deck` on PATH that answers
+// `session show --json <name>` with a fixed payload. Returns the dir to prepend.
+func writeFakeAgentDeck(t *testing.T, tmuxSession string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/usr/bin/env bash
+if [[ "$1" == "session" && "$2" == "show" ]]; then
+  cat <<'JSON'
+{ "title": "foo", "tmux_session": "` + tmuxSession + `" }
+JSON
+  exit 0
+fi
+exit 0
+`
+	p := filepath.Join(dir, "agent-deck")
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake agent-deck: %v", err)
+	}
+	return dir
+}
+
+func TestResolveTmuxSession_UsesShowJson(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; resolver depends on jq")
+	}
+	const want = "agentdeck_foo_410a3758" // real prefix is agentdeck_, NOT adeck_
+	bin := writeFakeAgentDeck(t, want)
+	out, err := sourceAndRun(t,
+		[]string{"PATH=" + bin + ":" + os.Getenv("PATH")},
+		`resolve_tmux_session foo`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("resolve_tmux_session = %q, want %q", strings.TrimSpace(out), want)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `GOTOOLCHAIN=go1.25.11 go test ./scripts/ -run TestResolveTmuxSession -v`
+Expected: FAIL — `resolve_tmux_session: command not found`.
+
+- [ ] **Step 3: Add `resolve_tmux_session`, consolidate callers, fix scenario 5**
+
+In `scripts/verify-session-persistence.sh`, add (after `is_own_tmproot`):
+
+```bash
+# resolve_tmux_session prints the tmux session name agent-deck assigned to the
+# managed session $1, via the authoritative `session show --json` path. Empty
+# output means unresolved. This is the ONE resolver; helpers and scenario 5 all
+# use it (the old `agent-deck list | awk /^adeck_/` parse was doubly wrong: list
+# never prints the tmux name, and the real prefix is `agentdeck_`).
+resolve_tmux_session() {
+  agent-deck session show --json "$1" 2>/dev/null | jq -r '.tmux_session // empty' 2>/dev/null
+}
+```
+
+Rewrite `tmux_pid_for_session` to use it:
+
+```bash
+tmux_pid_for_session() {
+  local name="$1"
+  local tsess
+  tsess="$(resolve_tmux_session "${name}")"
+  if [[ -z "${tsess}" || "${tsess}" == "null" ]]; then
+    pgrep -f "tmux.*${name}" | head -1 || true
+    return
+  fi
+  tmux display-message -t "${tsess}" -p -F '#{pid}' 2>/dev/null || true
+}
+```
+
+Rewrite `tmux_pane_start_command_for_session` to use it:
+
+```bash
+tmux_pane_start_command_for_session() {
+  local name="$1"
+  local tsess
+  tsess="$(resolve_tmux_session "${name}")"
+  if [[ -z "${tsess}" || "${tsess}" == "null" ]]; then
+    return 1
+  fi
+  tmux list-panes -t "${tsess}" -F '#{pane_start_command}' 2>/dev/null | head -1 || true
+}
+```
+
+In `scenario_5_reviver_respawns_killed_pipe`, replace the `agent-deck list | awk` block:
+
+```bash
+  # Resolve via the authoritative path (was: list|awk /^adeck_/ — never matched).
+  local tmux_name
+  tmux_name="$(resolve_tmux_session "${name}")"
+  if [[ -z "${tmux_name}" || "${tmux_name}" == "null" ]]; then
+    banner_skip "[5] could not resolve tmux session name for ${name} — skipping reviver scenario"
+    agent-deck session stop "${name}" >/dev/null 2>&1 || true
+    return
+  fi
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `GOTOOLCHAIN=go1.25.11 go test ./scripts/ -run TestResolveTmuxSession -v`
+Expected: PASS.
+
+Regression-guard the whole file:
+Run: `bash -n scripts/verify-session-persistence.sh`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/verify-session-persistence.sh scripts/verify-session-persistence_test.go
+git commit -m "fix(verify-persistence): resolve tmux session via show --json (scenario 5)"
+```
+
+---
+
+## Task 4: Fix A — argv capture never false-FAILs
+
+**Files:**
+- Modify: `scripts/verify-session-persistence.sh` (`capture_claude_argv`, `scenario_3_*`, `scenario_4_*`)
+- Modify: `scripts/verify-session-persistence_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+This task has two seams: `capture_claude_argv` (where argv comes from) and
+`classify_argv` (the pass/fail/skip verdict). The `classify_argv` test is the
+one that maps directly to the user's reported symptom — *scenario 3/4 emitting
+`[FAIL]`* — by asserting that an empty (unobservable) argv yields `skip`, never
+`fail`.
+
+Append to `scripts/verify-session-persistence_test.go`:
+
+```go
+func TestClassifyArgv_VerdictsIncludingEmptyIsSkip(t *testing.T) {
+	// Regression for the reported bug: empty argv (claude unobservable for this
+	// session) MUST classify as "skip", not "fail".
+	cases := []struct{ mode, argv, want string }{
+		{"resume", "", "skip"},
+		{"fresh", "", "skip"},
+		{"resume", "claude --resume abc", "pass"},
+		{"resume", "claude --session-id abc", "pass"},
+		{"resume", "claude --foo", "fail"},
+		{"fresh", "claude --session-id abc", "pass"},
+		{"fresh", "claude --session-id abc --resume x", "fail"}, // both -> wrong shape
+		{"fresh", "claude --resume x", "fail"},
+	}
+	for _, c := range cases {
+		snippet := `classify_argv ` + c.mode + ` "` + c.argv + `"`
+		out, err := sourceAndRun(t, nil, snippet)
+		if err != nil {
+			t.Fatalf("mode=%s argv=%q: bash error: %v\n%s", c.mode, c.argv, err, out)
+		}
+		if strings.TrimSpace(out) != c.want {
+			t.Errorf("classify_argv(%s, %q) = %q, want %q", c.mode, c.argv, strings.TrimSpace(out), c.want)
+		}
+	}
+}
+
+func TestCaptureClaudeArgv_PrefersStubFile(t *testing.T) {
+	argvFile := filepath.Join(t.TempDir(), "argv.log")
+	if err := os.WriteFile(argvFile, []byte("claude --session-id ABC123\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := sourceAndRun(t, []string{"ARGV_OUT=" + argvFile},
+		`capture_claude_argv ignored-name`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "--session-id ABC123") {
+		t.Fatalf("capture did not return stub argv; got: %q", strings.TrimSpace(out))
+	}
+}
+
+func TestCaptureClaudeArgv_NeverScansHostWideProcesses(t *testing.T) {
+	// Regression for the false-FAIL bug: with the stub file empty AND no pane
+	// resolution, capture MUST return empty — never a host-wide `ps|grep claude`
+	// match. We plant a live foreign process whose argv contains "claude".
+	emptyArgv := filepath.Join(t.TempDir(), "argv.log") // exists, zero bytes
+	if err := os.WriteFile(emptyArgv, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Foreign process: argv0 = "claude-foreign-decoy", lives for the test.
+	foreign := exec.Command("bash", "-c", `exec -a claude-foreign-decoy sleep 30`)
+	if err := foreign.Start(); err != nil {
+		t.Fatalf("start foreign decoy: %v", err)
+	}
+	defer func() { _ = foreign.Process.Kill() }()
+
+	// Force pane resolution to yield nothing (no real tmux session named this).
+	out, err := sourceAndRun(t,
+		[]string{"ARGV_OUT=" + emptyArgv, "PATH=/usr/bin:/bin"},
+		`tmux_pane_start_command_for_session() { return 1; }
+		 r="$(capture_claude_argv nonexistent-session)"
+		 echo "CAPTURED=[$r]"`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "CAPTURED=[]") {
+		t.Fatalf("capture returned non-empty (host-wide scan leaked?): %s", strings.TrimSpace(out))
+	}
+	if strings.Contains(out, "claude-foreign-decoy") {
+		t.Fatalf("capture matched a FOREIGN process — false-FAIL bug present: %s", strings.TrimSpace(out))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `GOTOOLCHAIN=go1.25.11 go test ./scripts/ -run 'TestClassifyArgv|TestCaptureClaudeArgv' -v`
+Expected: FAIL — `classify_argv: command not found` and `capture_claude_argv: command not found`.
+
+- [ ] **Step 3: Add `capture_claude_argv` + `classify_argv`; rewire scenarios 3 & 4**
+
+In `scripts/verify-session-persistence.sh`, add (after `resolve_tmux_session`):
+
+```bash
+# capture_claude_argv prints the claude argv for managed session $1 using ONLY
+# session-scoped sources: (1) the stub's ARGV_OUT file when populated, else
+# (2) the tmux pane_start_command for this session. It NEVER scans host-wide
+# `ps` — that matched unrelated claude processes and produced false FAILs.
+# Empty output means "unobservable for THIS session"; callers MUST treat that
+# as SKIP, not FAIL.
+capture_claude_argv() {
+  local name="$1"
+  if [[ -s "${ARGV_OUT:-/dev/null}" ]]; then
+    cat "${ARGV_OUT}"
+    return 0
+  fi
+  tmux_pane_start_command_for_session "${name}" 2>/dev/null || true
+}
+
+# classify_argv echoes the verdict (skip|pass|fail) for a captured argv under a
+# given mode. Empty argv (the session's claude was unobservable) is ALWAYS skip
+# — never fail; that is the cross-platform-degradation contract. Extracted so
+# the verdict is unit-testable in isolation and shared by scenarios 3 and 4.
+#   mode=resume: pass iff argv has --resume OR --session-id.
+#   mode=fresh : pass iff argv has --session-id AND NOT --resume.
+classify_argv() {
+  local mode="$1" argv="$2"
+  if [[ -z "${argv}" ]]; then echo skip; return; fi
+  case "${mode}" in
+    resume)
+      if echo "${argv}" | grep -qE -- '--resume|--session-id'; then echo pass; else echo fail; fi
+      ;;
+    fresh)
+      if echo "${argv}" | grep -qE -- '--session-id' && ! echo "${argv}" | grep -qE -- '--resume'; then
+        echo pass
+      else
+        echo fail
+      fi
+      ;;
+  esac
+}
+```
+
+In `scenario_3_restart_resume`, replace the argv-capture block (the `local argv=""` … fallback chain) and its assertion:
+
+```bash
+  local argv verdict
+  argv="$(capture_claude_argv "${name}")"
+  log "captured claude argv: ${argv}"
+  verdict="$(classify_argv resume "${argv}")"
+  case "${verdict}" in
+    skip) banner_skip "[3] argv unobservable for ${name} (stub not exercised / empty pane_start_command — e.g. pre-existing tmux daemon); cannot assert resume shape" ;;
+    pass) banner_pass "[3] restart spawned claude with --resume or --session-id" ;;
+    fail) banner_fail "[3] restart spawned claude WITHOUT --resume or --session-id: ${argv}" ;;
+  esac
+```
+
+In `scenario_4_fresh_session_shape`, replace its argv-capture block and assertion:
+
+```bash
+  local argv verdict
+  argv="$(capture_claude_argv "${name}")"
+  log "captured claude argv: ${argv}"
+  verdict="$(classify_argv fresh "${argv}")"
+  case "${verdict}" in
+    skip) banner_skip "[4] argv unobservable for ${name} (stub not exercised / empty pane_start_command); cannot assert fresh-session shape" ;;
+    pass) banner_pass "[4] fresh session uses --session-id without --resume" ;;
+    fail) banner_fail "[4] fresh session argv shape wrong: ${argv}" ;;
+  esac
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `GOTOOLCHAIN=go1.25.11 go test ./scripts/ -run 'TestClassifyArgv|TestCaptureClaudeArgv' -v`
+Expected: PASS — `TestClassifyArgv_VerdictsIncludingEmptyIsSkip` (8 cases, incl. empty→skip), both `TestCaptureClaudeArgv_*` subtests.
+
+Full unit suite + syntax:
+Run: `GOTOOLCHAIN=go1.25.11 go test ./scripts/ -v && bash -n scripts/verify-session-persistence.sh`
+Expected: all PASS, syntax exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/verify-session-persistence.sh scripts/verify-session-persistence_test.go
+git commit -m "fix(verify-persistence): SKIP not FAIL when claude argv is unobservable"
+```
+
+---
+
+## Task 5: Cross-platform CI + docs/spec sync
+
+**Files:**
+- Modify: `.github/workflows/session-persistence.yml`
+- Modify: `docs/SESSION-PERSISTENCE-SPEC.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the `unit-xplat` job (no test to write — CI config)**
+
+In `.github/workflows/session-persistence.yml`, add a third job. Add the test path to the `paths:` trigger list first:
+
+```yaml
+      - 'scripts/verify-session-persistence_test.go'
+```
+
+Then append the job:
+
+```yaml
+  unit-xplat:
+    name: harness unit tests (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Ensure jq present
+        # Only jq is needed: the unit tests stub the tmux-calling helper and
+        # never invoke real tmux. (Don't install tmux here — wasted brew time.)
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            command -v jq >/dev/null || brew install jq
+          else
+            command -v jq >/dev/null || sudo apt-get install -y jq
+          fi
+
+      - name: go test ./scripts/...
+        run: go test ./scripts/... -count=1 -v
+```
+
+- [ ] **Step 2: Verify the workflow is valid YAML / actionlint-clean**
+
+Run: `command -v actionlint >/dev/null && actionlint .github/workflows/session-persistence.yml || echo "actionlint not installed — skipping"`
+Expected: no errors (or skip notice).
+
+- [ ] **Step 3: Record the degradation-path contract in the spec**
+
+In `docs/SESSION-PERSISTENCE-SPEC.md`, add to the verification section a note documenting the hardened behavior:
+
+```markdown
+### Cross-platform degradation contract (v1.5.2 harness hardening)
+
+`scripts/verify-session-persistence.sh` MUST run cleanly on non-systemd hosts:
+
+- Scenario 2 (login-teardown) and the cgroup branch of scenario 1 `[SKIP]` on
+  non-Linux — unchanged; these gate a Linux+systemd-only contract.
+- Scenarios 3/4 `[SKIP]` (never `[FAIL]`) when claude argv is unobservable for
+  the managed session (stub bypassed by a pre-existing shared tmux daemon, or
+  empty `pane_start_command`). The harness never asserts on host-wide processes.
+- Scenario 5 resolves its tmux session name via `session show --json`.
+- The harness removes its own `${TMPDIR}/adeck-verify.*` tempdir on exit.
+
+Unit-gated by `scripts/verify-session-persistence_test.go` on macOS + Linux CI.
+```
+
+- [ ] **Step 4: Add a CHANGELOG entry**
+
+In `CHANGELOG.md`, under the Unreleased/next section, add:
+
+```markdown
+### Fixed
+- `verify-session-persistence.sh` now degrades truthfully on macOS/non-systemd
+  hosts: scenarios 3/4 `[SKIP]` instead of false `[FAIL]` when claude argv is
+  unobservable, scenario 5 resolves its tmux name via `session show --json`, and
+  the harness cleans up its own tempdir. Gated by new macOS + Linux unit tests.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/session-persistence.yml docs/SESSION-PERSISTENCE-SPEC.md CHANGELOG.md
+git commit -m "ci(verify-persistence): unit-test harness on macOS + Linux; doc sync"
+```
+
+---
+
+## Task 6: Mandated verification (v1.5.2 gate)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full harness unit suite, both behaviors**
+
+Run: `GOTOOLCHAIN=go1.25.11 go test ./scripts/... -count=1 -v`
+Expected: PASS — `TestLibOnly_*`, `TestIsOwnTmproot_*`, `TestResolveTmuxSession_*`, `TestCaptureClaudeArgv_*`.
+
+- [ ] **Step 2: Persistence regression suite (mandate)**
+
+Run: `GOTOOLCHAIN=go1.25.11 go test -run TestPersistence_ ./internal/session/... -race -count=1`
+Expected: PASS (8 `TestPersistence_*` tests — proves the script changes didn't disturb the contract).
+
+- [ ] **Step 3: macOS end-to-end smoke (this dev host)**
+
+Run:
+```bash
+go build -o /tmp/agent-deck ./cmd/agent-deck && export PATH="/tmp:$PATH"
+AGENT_DECK_VERIFY_USE_STUB=1 bash scripts/verify-session-persistence.sh; echo "exit=$?"
+```
+Expected: `OVERALL: PASS`, `exit=0` — scenarios 1 PASS, 2 SKIP (no systemd), 3/4 PASS *or* SKIP (never FAIL), 5 PASS or SKIP. Then confirm no tempdir leak:
+Run: `ls -d "${TMPDIR:-/tmp}"/adeck-verify.* 2>/dev/null && echo LEAK || echo CLEAN`
+Expected: `CLEAN`.
+
+- [ ] **Step 4: Linux+systemd end-to-end (REQUIRED by CLAUDE.md before merge)**
+
+On a Linux+systemd host (or the `session-persistence.yml` CI run / `workflow_dispatch`):
+```bash
+GOTOOLCHAIN=go1.25.11 go build -o /tmp/agent-deck ./cmd/agent-deck && export PATH="/tmp:$PATH"
+AGENT_DECK_VERIFY_USE_STUB=1 bash scripts/verify-session-persistence.sh; echo "exit=$?"
+```
+Expected: `OVERALL: PASS`, scenario 2 actually executes (not skipped) and PASSes. Capture this output (or the CI link) for the PR body — the mandate requires it.
+
+- [ ] **Step 5: Finalize**
+
+Use `superpowers:finishing-a-development-branch` to choose merge/PR. Do NOT `git push`, `gh pr create`, or tag without explicit user approval (CLAUDE.md). No `--no-verify` on any commit in this branch.
+
+---
+
+## Self-Review
+
+**Spec coverage:** A → Task 4 (`capture_claude_argv` + `classify_argv`; the `classify_argv` empty→skip test maps to the reported FAIL symptom). B → Task 2 (`is_own_tmproot`, portable mktemp). C → Task 3 (`resolve_tmux_session`, scenario 5). Source-guard prerequisite → Task 1. Cross-platform regression prevention → Task 5 CI. Mandate gates → Task 6. All covered.
+
+**Placeholder scan:** No TBD/“add error handling”/“similar to Task N”. Every code step shows full code.
+
+**Type/name consistency:** Function names used consistently across tasks — `is_own_tmproot` (T2, used in `cleanup`), `resolve_tmux_session` (T3, used by `tmux_pid_for_session`, `tmux_pane_start_command_for_session`, scenario 5), `capture_claude_argv` + `classify_argv` (T4, used by scenarios 3 & 4), `main` (T1, gated by `AGENT_DECK_VERIFY_LIB_ONLY`). Go helpers `sourceAndRun`/`scriptPath`/`writeFakeAgentDeck` defined once (T1/T3) and reused. Env seam `ARGV_OUT` matches the script global.
+
+**Verified assumptions:** A test-only `scripts` package (`*_test.go` with no non-test `.go`) compiles and is picked up by both `go test ./scripts/` and `go test ./...` — confirmed empirically in this repo before handoff. `${p##*/}` and the explicit-template `mktemp` form both behave correctly on macOS bash 3.2. This repo has no `PROJECTS.md` trunk, so the global PROJECTS.md process does not apply.
+
+**Bash 3.2 / `set -e` caveats honored:** no associative arrays; test snippets gate non-zero returns with `if`/`||` so the harness's `set -e` doesn't abort them.

--- a/docs/superpowers/plans/2026-06-07-harden-verify-persistence-xplat.md
+++ b/docs/superpowers/plans/2026-06-07-harden-verify-persistence-xplat.md
@@ -757,3 +757,21 @@ Use `superpowers:finishing-a-development-branch` to choose merge/PR. Do NOT `git
 **Verified assumptions:** A test-only `scripts` package (`*_test.go` with no non-test `.go`) compiles and is picked up by both `go test ./scripts/` and `go test ./...` — confirmed empirically in this repo before handoff. `${p##*/}` and the explicit-template `mktemp` form both behave correctly on macOS bash 3.2. This repo has no `PROJECTS.md` trunk, so the global PROJECTS.md process does not apply.
 
 **Bash 3.2 / `set -e` caveats honored:** no associative arrays; test snippets gate non-zero returns with `if`/`||` so the harness's `set -e` doesn't abort them.
+
+## Post-review hardening follow-up
+
+Final review found additional false-green and cross-platform gaps. These
+supersede the earlier illustrative snippets where they differ:
+
+- `resolve_tmux_session` now treats missing `jq` as an explicit status-2 error,
+  and the workflow installs `jq` for the Linux end-to-end job.
+- Scenario 3 fails when `agent-deck session start` fails; empty argv is only a
+  skip after the restart command itself succeeds.
+- Scenario 5 fails when `agent-deck session revive` fails; "no new pipe" remains
+  a skip only after a successful revive command.
+- Cleanup uses `agent-deck list --json` plus full titles, not truncated table
+  output.
+- The fake Claude stub uses a portable long-sleep loop instead of
+  GNU-only `sleep infinity`.
+- `classify_argv` has a default `fail` arm so unknown modes cannot silently
+  produce no verdict.

--- a/scripts/verify-session-persistence.d/fake-claude.sh
+++ b/scripts/verify-session-persistence.d/fake-claude.sh
@@ -4,7 +4,7 @@
 # Contract:
 #   - Writes the full argv ("$@") as one line to $AGENT_DECK_VERIFY_ARGV_OUT
 #     (default: /tmp/adeck-verify-argv.$PPID). One invocation appends one line.
-#   - Then execs `sleep infinity` so the tmux pane stays alive while the
+#   - Then sleeps in a portable loop so the tmux pane stays alive while the
 #     harness runs its assertions.
 #   - Never mutates user state. Never needs network.
 #
@@ -22,4 +22,6 @@ mkdir -p "$(dirname "$OUT")"
 # required here — the harness only greps for --resume / --session-id tokens.
 printf '%s\n' "$*" >> "$OUT"
 
-exec sleep infinity
+while :; do
+  sleep 86400
+done

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Numbered scenario checklist (printed at startup, also parseable via head -30).
-readonly CHECKLIST="$(cat <<'EOF'
+CHECKLIST="$(cat <<'EOF'
 [1] Live session + cgroup inspection
 [2] Login-session teardown survival (Linux+systemd only)
 [3] Stop -> restart resume (--resume or --session-id in argv)
@@ -15,6 +15,7 @@ readonly CHECKLIST="$(cat <<'EOF'
 [5] Reviver respawns a killed control pipe without breaking tmux (v1.7.8+)
 EOF
 )"
+readonly CHECKLIST
 
 # ---------- color + logging ----------
 readonly C_RED='\033[31m'
@@ -42,12 +43,20 @@ is_own_tmproot() {
 cleanup() {
   set +e
   # Stop any sessions we created. agent-deck has no `session ls` subcommand;
-  # use the top-level `agent-deck list` (TITLE is col 1, ID is last column).
-  if command -v agent-deck >/dev/null 2>&1; then
-    for n in $(agent-deck list 2>/dev/null | awk -v P="${SESSION_PREFIX}" '$1 ~ "^"P {print $1}' || true); do
-      agent-deck session stop "$n" >/dev/null 2>&1 || true
-      agent-deck remove "$n" >/dev/null 2>&1 || true
-    done
+  # use the top-level `agent-deck list --json` so long titles are not truncated.
+  if [[ -n "${SESSION_PREFIX:-}" ]] && command -v agent-deck >/dev/null 2>&1; then
+    if command -v jq >/dev/null 2>&1; then
+      while IFS= read -r n; do
+        [[ -n "${n}" ]] || continue
+        agent-deck session stop "$n" >/dev/null 2>&1 || true
+        agent-deck remove "$n" >/dev/null 2>&1 || true
+      done < <(agent-deck list --json 2>/dev/null | jq -r --arg P "${SESSION_PREFIX}" '.[]? | select(.title | startswith($P)) | .title' 2>/dev/null || true)
+    else
+      for n in $(agent-deck list 2>/dev/null | awk -v P="${SESSION_PREFIX}" '$1 ~ "^"P {print $1}' || true); do
+        agent-deck session stop "$n" >/dev/null 2>&1 || true
+        agent-deck remove "$n" >/dev/null 2>&1 || true
+      done
+    fi
   fi
   # Tear down any lingering login-sim scope.
   if command -v systemctl >/dev/null 2>&1; then
@@ -72,6 +81,10 @@ resolve_tmux_session() {
   # assignments via set -e. Callers all degrade on empty output. Single-point
   # fix shared by tmux_pid_for_session, tmux_pane_start_command_for_session,
   # and scenario 5.
+  if ! command -v jq >/dev/null 2>&1; then
+    printf '%sERROR%s: jq binary not on PATH.\n' "${C_RED}" "${C_RESET}" >&2
+    return 2
+  fi
   agent-deck session show --json "$1" 2>/dev/null | jq -r '.tmux_session // empty' 2>/dev/null || true
 }
 
@@ -149,6 +162,9 @@ classify_argv() {
       else
         echo fail
       fi
+      ;;
+    *)
+      echo fail
       ;;
   esac
 }
@@ -261,7 +277,11 @@ scenario_3_restart_resume() {
   sleep 1
   : > "${ARGV_OUT}"
   log "restarting session: agent-deck session start ${name}"
-  agent-deck session start "${name}" >/dev/null || true
+  if ! agent-deck session start "${name}" >/dev/null; then
+    banner_fail "[3] restart command failed for ${name}"
+    agent-deck session stop "${name}" >/dev/null 2>&1 || true
+    return
+  fi
   sleep 2
   local argv verdict
   argv="$(capture_claude_argv "${name}")"
@@ -326,7 +346,11 @@ scenario_5_reviver_respawns_killed_pipe() {
   sleep 2
 
   # Trigger revive. Tmux session should still exist; reviver must respawn the pipe.
-  agent-deck session revive --name "${name}" >/dev/null 2>&1 || true
+  if ! agent-deck session revive --name "${name}" >/dev/null 2>&1; then
+    banner_fail "[5] revive command failed for ${name}"
+    agent-deck session stop "${name}" >/dev/null 2>&1 || true
+    return
+  fi
   sleep 2
 
   local new_pipe_pid
@@ -355,11 +379,15 @@ main() {
 
   # ----- preflight -----
   if ! command -v agent-deck >/dev/null 2>&1; then
-    printf "${C_RED}ERROR${C_RESET}: agent-deck binary not on PATH.\n" >&2
+    printf '%sERROR%s: agent-deck binary not on PATH.\n' "${C_RED}" "${C_RESET}" >&2
     exit 2
   fi
   if ! command -v tmux >/dev/null 2>&1; then
-    printf "${C_RED}ERROR${C_RESET}: tmux binary not on PATH.\n" >&2
+    printf '%sERROR%s: tmux binary not on PATH.\n' "${C_RED}" "${C_RESET}" >&2
+    exit 2
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    printf '%sERROR%s: jq binary not on PATH.\n' "${C_RED}" "${C_RESET}" >&2
     exit 2
   fi
 
@@ -398,10 +426,10 @@ EOF
   want_scenario 5 && scenario_5_reviver_respawns_killed_pipe
 
   if [[ "${FAILED}" -ne 0 ]]; then
-    printf "${C_RED}OVERALL: FAIL${C_RESET}\n" >&2
+    printf '%sOVERALL: FAIL%s\n' "${C_RED}" "${C_RESET}" >&2
     exit 1
   fi
-  printf "${C_GREEN}OVERALL: PASS${C_RESET}\n"
+  printf '%sOVERALL: PASS%s\n' "${C_GREEN}" "${C_RESET}"
   exit 0
 }
 

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -110,6 +110,44 @@ tmux_pane_start_command_for_session() {
   tmux list-panes -t "${tsess}" -F '#{pane_start_command}' 2>/dev/null | head -1 || true
 }
 
+# capture_claude_argv prints the claude argv for managed session $1 using ONLY
+# session-scoped sources: (1) the stub's ARGV_OUT file when populated, else
+# (2) the tmux pane_start_command for this session. It NEVER scans host-wide
+# `ps` — that matched unrelated claude processes and produced false FAILs.
+# Empty output means "unobservable for THIS session"; callers MUST treat that
+# as SKIP, not FAIL.
+capture_claude_argv() {
+  local name="$1"
+  if [[ -s "${ARGV_OUT:-/dev/null}" ]]; then
+    cat "${ARGV_OUT}"
+    return 0
+  fi
+  tmux_pane_start_command_for_session "${name}" 2>/dev/null || true
+}
+
+# classify_argv echoes the verdict (skip|pass|fail) for a captured argv under a
+# given mode. Empty argv (the session's claude was unobservable) is ALWAYS skip
+# — never fail; that is the cross-platform-degradation contract. Extracted so
+# the verdict is unit-testable in isolation and shared by scenarios 3 and 4.
+#   mode=resume: pass iff argv has --resume OR --session-id.
+#   mode=fresh : pass iff argv has --session-id AND NOT --resume.
+classify_argv() {
+  local mode="$1" argv="$2"
+  if [[ -z "${argv}" ]]; then echo skip; return; fi
+  case "${mode}" in
+    resume)
+      if echo "${argv}" | grep -qE -- '--resume|--session-id'; then echo pass; else echo fail; fi
+      ;;
+    fresh)
+      if echo "${argv}" | grep -qE -- '--session-id' && ! echo "${argv}" | grep -qE -- '--resume'; then
+        echo pass
+      else
+        echo fail
+      fi
+      ;;
+  esac
+}
+
 want_scenario() {
   local n="$1"
   if [[ -z "${SCENARIO:-}" ]]; then return 0; fi
@@ -220,27 +258,15 @@ scenario_3_restart_resume() {
   log "restarting session: agent-deck session start ${name}"
   agent-deck session start "${name}" >/dev/null || true
   sleep 2
-  # Read captured argv. Preferred order:
-  #  1) stub tempfile (AGENT_DECK_VERIFY_USE_STUB=1 path)
-  #  2) tmux pane_start_command for the session's tmux_session (authoritative:
-  #     this is exactly what agent-deck handed to tmux new-session)
-  #  3) ps -ef grep fallback (last-resort; ambiguous on hosts with many
-  #     concurrent claude processes)
-  local argv=""
-  if [[ -s "${ARGV_OUT}" ]]; then
-    argv="$(cat "${ARGV_OUT}")"
-  else
-    argv="$(tmux_pane_start_command_for_session "${name}" || true)"
-    if [[ -z "${argv}" ]]; then
-      argv="$(ps -ef | grep -E '[c]laude' | head -1 || true)"
-    fi
-  fi
+  local argv verdict
+  argv="$(capture_claude_argv "${name}")"
   log "captured claude argv: ${argv}"
-  if echo "${argv}" | grep -qE -- '--resume|--session-id'; then
-    banner_pass "[3] restart spawned claude with --resume or --session-id"
-  else
-    banner_fail "[3] restart spawned claude WITHOUT --resume or --session-id: ${argv}"
-  fi
+  verdict="$(classify_argv resume "${argv}")"
+  case "${verdict}" in
+    skip) banner_skip "[3] argv unobservable for ${name} (stub not exercised / empty pane_start_command — e.g. pre-existing tmux daemon); cannot assert resume shape" ;;
+    pass) banner_pass "[3] restart spawned claude with --resume or --session-id" ;;
+    fail) banner_fail "[3] restart spawned claude WITHOUT --resume or --session-id: ${argv}" ;;
+  esac
   agent-deck session stop "${name}" >/dev/null 2>&1 || true
 }
 
@@ -252,23 +278,15 @@ scenario_4_fresh_session_shape() {
   agent-deck add -t "${name}" -c claude -Q "${TMPROOT}" >/dev/null
   agent-deck session start "${name}" >/dev/null
   sleep 2
-  local argv=""
-  if [[ -s "${ARGV_OUT}" ]]; then
-    argv="$(cat "${ARGV_OUT}")"
-  else
-    argv="$(tmux_pane_start_command_for_session "${name}" || true)"
-    if [[ -z "${argv}" ]]; then
-      argv="$(ps -ef | grep -E '[c]laude' | head -1 || true)"
-    fi
-  fi
+  local argv verdict
+  argv="$(capture_claude_argv "${name}")"
   log "captured claude argv: ${argv}"
-  if echo "${argv}" | grep -qE -- '--session-id' && ! echo "${argv}" | grep -qE -- '--resume'; then
-    banner_pass "[4] fresh session uses --session-id without --resume"
-  elif [[ -z "${argv}" ]]; then
-    banner_skip "[4] no argv captured (real claude without stub); cannot assert fresh-session shape"
-  else
-    banner_fail "[4] fresh session argv shape wrong: ${argv}"
-  fi
+  verdict="$(classify_argv fresh "${argv}")"
+  case "${verdict}" in
+    skip) banner_skip "[4] argv unobservable for ${name} (stub not exercised / empty pane_start_command); cannot assert fresh-session shape" ;;
+    pass) banner_pass "[4] fresh session uses --session-id without --resume" ;;
+    fail) banner_fail "[4] fresh session argv shape wrong: ${argv}" ;;
+  esac
   agent-deck session stop "${name}" >/dev/null 2>&1 || true
 }
 

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -85,7 +85,12 @@ resolve_tmux_session() {
     printf '%sERROR%s: jq binary not on PATH.\n' "${C_RED}" "${C_RESET}" >&2
     return 2
   fi
-  agent-deck session show --json "$1" 2>/dev/null | jq -r '.tmux_session // empty' 2>/dev/null || true
+  # agent-deck's stderr is suppressed (its "not found" message is expected
+  # noise), but jq's is NOT: a real malformed-JSON breakage surfaces loudly on
+  # stderr while `|| true` still degrades stdout to empty (caller SKIPs) and
+  # keeps set -e from aborting. We deliberately do NOT propagate jq's nonzero —
+  # that would re-introduce the silent set -e abort this `|| true` exists to fix.
+  agent-deck session show --json "$1" 2>/dev/null | jq -r '.tmux_session // empty' || true
 }
 
 tmux_pid_for_session() {
@@ -154,10 +159,10 @@ classify_argv() {
   if [[ -z "${argv}" ]]; then echo skip; return; fi
   case "${mode}" in
     resume)
-      if echo "${argv}" | grep -qE -- '--resume|--session-id'; then echo pass; else echo fail; fi
+      if printf '%s\n' "${argv}" | grep -qE -- '--resume|--session-id'; then echo pass; else echo fail; fi
       ;;
     fresh)
-      if echo "${argv}" | grep -qE -- '--session-id' && ! echo "${argv}" | grep -qE -- '--resume'; then
+      if printf '%s\n' "${argv}" | grep -qE -- '--session-id' && ! printf '%s\n' "${argv}" | grep -qE -- '--resume'; then
         echo pass
       else
         echo fail

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -60,13 +60,23 @@ cleanup() {
 }
 
 # ---------- helpers ----------
+
+# resolve_tmux_session prints the tmux session name agent-deck assigned to the
+# managed session $1, via the authoritative `session show --json` path. Empty
+# output means unresolved. This is the ONE resolver; helpers and scenario 5 all
+# use it (the old `agent-deck list | awk /^adeck_/` parse was doubly wrong: list
+# never prints the tmux name, and the real prefix is `agentdeck_`).
+resolve_tmux_session() {
+  agent-deck session show --json "$1" 2>/dev/null | jq -r '.tmux_session // empty' 2>/dev/null
+}
+
 tmux_pid_for_session() {
   # Prints the PID of the tmux server hosting the agent-deck session $1.
-  # Uses `session show --json` to resolve the tmux session name, then asks
-  # tmux itself for the server PID via `display-message -p -F '#{pid}'`.
+  # Uses resolve_tmux_session to get the tmux session name, then asks tmux
+  # itself for the server PID via `display-message -p -F '#{pid}'`.
   local name="$1"
   local tsess
-  tsess=$(agent-deck session show --json "${name}" 2>/dev/null | jq -r '.tmux_session // empty' 2>/dev/null)
+  tsess="$(resolve_tmux_session "${name}")"
   if [[ -z "${tsess}" || "${tsess}" == "null" ]]; then
     pgrep -f "tmux.*${name}" | head -1 || true
     return
@@ -93,7 +103,7 @@ tmux_pane_start_command_for_session() {
   # claude processes sharing the same tmux daemon.
   local name="$1"
   local tsess
-  tsess=$(agent-deck session show --json "${name}" 2>/dev/null | jq -r '.tmux_session // empty' 2>/dev/null)
+  tsess="$(resolve_tmux_session "${name}")"
   if [[ -z "${tsess}" || "${tsess}" == "null" ]]; then
     return 1
   fi
@@ -270,10 +280,10 @@ scenario_5_reviver_respawns_killed_pipe() {
   agent-deck session start "${name}" >/dev/null
   sleep 1
 
-  # Find the tmux session name agent-deck actually assigned
+  # Resolve via the authoritative path (was: list|awk /^adeck_/ — never matched).
   local tmux_name
-  tmux_name="$(agent-deck list 2>/dev/null | awk -v P="${name}" '$1 == P {for(i=1;i<=NF;i++) if ($i ~ /^adeck_/) {print $i; exit}}')"
-  if [[ -z "${tmux_name}" ]]; then
+  tmux_name="$(resolve_tmux_session "${name}")"
+  if [[ -z "${tmux_name}" || "${tmux_name}" == "null" ]]; then
     banner_skip "[5] could not resolve tmux session name for ${name} — skipping reviver scenario"
     agent-deck session stop "${name}" >/dev/null 2>&1 || true
     return

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -140,11 +140,18 @@ tmux_pane_start_command_for_session() {
   # with (quoted exactly as agent-deck constructed it). Preferred over
   # `ps -ef | grep claude` which is ambiguous on hosts with many live
   # claude processes sharing the same tmux daemon.
-  local name="$1"
-  local tsess
-  tsess="$(resolve_tmux_session "${name}")"
+  local name="$1" tsess rc=0
+  tsess="$(resolve_tmux_session "${name}")" || rc=$?
+  # resolve_tmux_session returns 0 for resolved OR not-found (empty), and
+  # nonzero ONLY for a real error/breakage (jq missing=2, DB/load=1, malformed
+  # JSON=3). Propagate that nonzero so capture_claude_argv -> the scenario can
+  # FAIL loudly (review line-164); an unresolved session yields empty output at
+  # exit 0 (degrade -> SKIP), which is NOT an error.
+  if [[ "${rc}" -ne 0 ]]; then
+    return "${rc}"
+  fi
   if [[ -z "${tsess}" || "${tsess}" == "null" ]]; then
-    return 1
+    return 0
   fi
   tmux list-panes -t "${tsess}" -F '#{pane_start_command}' 2>/dev/null | head -1 || true
 }
@@ -153,15 +160,16 @@ tmux_pane_start_command_for_session() {
 # session-scoped sources: (1) the stub's ARGV_OUT file when populated, else
 # (2) the tmux pane_start_command for this session. It NEVER scans host-wide
 # `ps` — that matched unrelated claude processes and produced false FAILs.
-# Empty output means "unobservable for THIS session"; callers MUST treat that
-# as SKIP, not FAIL.
+# Empty output at exit 0 means "unobservable for THIS session" (caller degrades
+# to SKIP per stub mode). A NONZERO exit means a real resolver error/breakage
+# propagated (review line-164) — the caller MUST FAIL, not SKIP.
 capture_claude_argv() {
   local name="$1"
   if [[ -s "${ARGV_OUT:-/dev/null}" ]]; then
     cat "${ARGV_OUT}"
     return 0
   fi
-  tmux_pane_start_command_for_session "${name}" 2>/dev/null || true
+  tmux_pane_start_command_for_session "${name}"
 }
 
 # classify_argv echoes the verdict (skip|pass|fail) for a captured argv under a
@@ -342,8 +350,13 @@ scenario_3_restart_resume() {
     return
   fi
   sleep 2
-  local argv verdict
-  argv="$(capture_claude_argv "${name}")"
+  local argv verdict rc=0
+  argv="$(capture_claude_argv "${name}")" || rc=$?
+  if [[ "${rc}" -ne 0 ]]; then
+    banner_fail "[3] real error resolving session ${name} during argv capture (exit ${rc}); see error above"
+    agent-deck session stop "${name}" >/dev/null 2>&1 || true
+    return
+  fi
   log "captured claude argv: ${argv}"
   verdict="$(classify_argv resume "${argv}")"
   case "${verdict}" in
@@ -364,8 +377,13 @@ scenario_4_fresh_session_shape() {
     return
   fi
   sleep 2
-  local argv verdict
-  argv="$(capture_claude_argv "${name}")"
+  local argv verdict rc=0
+  argv="$(capture_claude_argv "${name}")" || rc=$?
+  if [[ "${rc}" -ne 0 ]]; then
+    banner_fail "[4] real error resolving session ${name} during argv capture (exit ${rc}); see error above"
+    agent-deck session stop "${name}" >/dev/null 2>&1 || true
+    return
+  fi
   log "captured claude argv: ${argv}"
   verdict="$(classify_argv fresh "${argv}")"
   case "${verdict}" in

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -27,14 +27,6 @@ banner_fail() { printf "${C_RED}[FAIL]${C_RESET} %s\n" "$*" >&2; FAILED=1; }
 banner_skip() { printf "${C_YELLOW}[SKIP]${C_RESET} %s\n" "$*"; }
 log() { printf '    %s\n' "$*"; }
 
-FAILED=0
-RUN_ID="$$"
-TMPROOT="$(mktemp -d -t adeck-verify.XXXXXX)"
-SESSION_PREFIX="verify-persist-${RUN_ID}"
-LOGINSIM_SCOPE="adeck-verify-loginsim-${RUN_ID}"
-ARGV_OUT="${TMPROOT}/argv.log"
-export AGENT_DECK_VERIFY_ARGV_OUT="${ARGV_OUT}"
-
 # ---------- cleanup ----------
 cleanup() {
   set +e
@@ -55,45 +47,6 @@ cleanup() {
     rm -rf "${TMPROOT}" 2>/dev/null || true
   fi
 }
-trap cleanup EXIT INT TERM
-
-# ---------- preflight ----------
-if ! command -v agent-deck >/dev/null 2>&1; then
-  printf "${C_RED}ERROR${C_RESET}: agent-deck binary not on PATH.\n" >&2
-  exit 2
-fi
-if ! command -v tmux >/dev/null 2>&1; then
-  printf "${C_RED}ERROR${C_RESET}: tmux binary not on PATH.\n" >&2
-  exit 2
-fi
-
-# Decide whether to install the claude stub.
-USE_STUB=0
-if [[ "${AGENT_DECK_VERIFY_USE_STUB:-0}" == "1" ]]; then
-  USE_STUB=1
-elif ! command -v claude >/dev/null 2>&1; then
-  USE_STUB=1
-fi
-if [[ "${USE_STUB}" == "1" ]]; then
-  STUB_DIR="$(cd "$(dirname "$0")/verify-session-persistence.d" && pwd)"
-  # Provide a `claude` alias by symlinking the stub into a PATH-controlled dir.
-  mkdir -p "${TMPROOT}/bin"
-  ln -sf "${STUB_DIR}/fake-claude.sh" "${TMPROOT}/bin/claude"
-  export PATH="${TMPROOT}/bin:${PATH}"
-  log "claude stub: ${STUB_DIR}/fake-claude.sh (argv -> ${ARGV_OUT})"
-else
-  log "claude: $(command -v claude) (real)"
-fi
-
-# ---------- checklist ----------
-cat <<EOF
-==========================================================
-verify-session-persistence.sh — v1.5.2 persistence harness
-==========================================================
-${CHECKLIST}
-==========================================================
-Each scenario ends with one [PASS], [FAIL], or [SKIP] line.
-EOF
 
 # ---------- helpers ----------
 tmux_pid_for_session() {
@@ -344,16 +297,72 @@ scenario_5_reviver_respawns_killed_pipe() {
   agent-deck session stop "${name}" >/dev/null 2>&1 || true
 }
 
-# ---------- dispatch ----------
-want_scenario 1 && scenario_1_live_session_cgroup
-want_scenario 2 && scenario_2_login_teardown
-want_scenario 3 && scenario_3_restart_resume
-want_scenario 4 && scenario_4_fresh_session_shape
-want_scenario 5 && scenario_5_reviver_respawns_killed_pipe
+# ---------- entrypoint ----------
+main() {
+  FAILED=0
+  RUN_ID="$$"
+  TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/adeck-verify.XXXXXX")"
+  SESSION_PREFIX="verify-persist-${RUN_ID}"
+  LOGINSIM_SCOPE="adeck-verify-loginsim-${RUN_ID}"
+  ARGV_OUT="${TMPROOT}/argv.log"
+  export AGENT_DECK_VERIFY_ARGV_OUT="${ARGV_OUT}"
 
-if [[ "${FAILED}" -ne 0 ]]; then
-  printf "${C_RED}OVERALL: FAIL${C_RESET}\n" >&2
-  exit 1
+  trap cleanup EXIT INT TERM
+
+  # ----- preflight -----
+  if ! command -v agent-deck >/dev/null 2>&1; then
+    printf "${C_RED}ERROR${C_RESET}: agent-deck binary not on PATH.\n" >&2
+    exit 2
+  fi
+  if ! command -v tmux >/dev/null 2>&1; then
+    printf "${C_RED}ERROR${C_RESET}: tmux binary not on PATH.\n" >&2
+    exit 2
+  fi
+
+  # ----- claude stub decision (unchanged logic) -----
+  USE_STUB=0
+  if [[ "${AGENT_DECK_VERIFY_USE_STUB:-0}" == "1" ]]; then
+    USE_STUB=1
+  elif ! command -v claude >/dev/null 2>&1; then
+    USE_STUB=1
+  fi
+  if [[ "${USE_STUB}" == "1" ]]; then
+    STUB_DIR="$(cd "$(dirname "$0")/verify-session-persistence.d" && pwd)"
+    mkdir -p "${TMPROOT}/bin"
+    ln -sf "${STUB_DIR}/fake-claude.sh" "${TMPROOT}/bin/claude"
+    export PATH="${TMPROOT}/bin:${PATH}"
+    log "claude stub: ${STUB_DIR}/fake-claude.sh (argv -> ${ARGV_OUT})"
+  else
+    log "claude: $(command -v claude) (real)"
+  fi
+
+  # ----- checklist -----
+  cat <<EOF
+==========================================================
+verify-session-persistence.sh — v1.5.2 persistence harness
+==========================================================
+${CHECKLIST}
+==========================================================
+Each scenario ends with one [PASS], [FAIL], or [SKIP] line.
+EOF
+
+  # ----- dispatch -----
+  want_scenario 1 && scenario_1_live_session_cgroup
+  want_scenario 2 && scenario_2_login_teardown
+  want_scenario 3 && scenario_3_restart_resume
+  want_scenario 4 && scenario_4_fresh_session_shape
+  want_scenario 5 && scenario_5_reviver_respawns_killed_pipe
+
+  if [[ "${FAILED}" -ne 0 ]]; then
+    printf "${C_RED}OVERALL: FAIL${C_RESET}\n" >&2
+    exit 1
+  fi
+  printf "${C_GREEN}OVERALL: PASS${C_RESET}\n"
+  exit 0
+}
+
+# Run only when executed directly. When sourced for unit tests with
+# AGENT_DECK_VERIFY_LIB_ONLY=1, expose functions without side effects.
+if [[ "${AGENT_DECK_VERIFY_LIB_ONLY:-0}" != "1" ]]; then
+  main "$@"
 fi
-printf "${C_GREEN}OVERALL: PASS${C_RESET}\n"
-exit 0

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -50,7 +50,7 @@ cleanup() {
         [[ -n "${n}" ]] || continue
         agent-deck session stop "$n" >/dev/null 2>&1 || true
         agent-deck remove "$n" >/dev/null 2>&1 || true
-      done < <(agent-deck list --json 2>/dev/null | jq -r --arg P "${SESSION_PREFIX}" '.[]? | select(.title | startswith($P)) | .title' 2>/dev/null || true)
+      done < <(agent-deck list --json 2>/dev/null | jq -r --arg P "${SESSION_PREFIX}" '.[]? | select((.title // "") | startswith($P)) | .title' 2>/dev/null || true)
     else
       for n in $(agent-deck list 2>/dev/null | awk -v P="${SESSION_PREFIX}" '$1 ~ "^"P {print $1}' || true); do
         agent-deck session stop "$n" >/dev/null 2>&1 || true
@@ -175,12 +175,25 @@ want_scenario() {
   [[ "${SCENARIO}" == "${n}" ]]
 }
 
+# create_and_start_session runs `agent-deck add` + `agent-deck session start`
+# for managed session $1 (tool $2) under TMPROOT. Returns nonzero WITHOUT
+# aborting under `set -e` when either command fails, so scenario callers can
+# emit a diagnostic [FAIL] and return instead of the harness aborting silently
+# with no banner.
+create_and_start_session() {
+  local name="$1" tool="$2"
+  agent-deck add -t "${name}" -c "${tool}" -Q "${TMPROOT}" >/dev/null || return 1
+  agent-deck session start "${name}" >/dev/null || return 1
+}
+
 # ---------- Scenario 1 ----------
 scenario_1_live_session_cgroup() {
   local name="${SESSION_PREFIX}-s1"
   log "creating session: ${name}"
-  agent-deck add -t "${name}" -c claude -Q "${TMPROOT}" >/dev/null
-  agent-deck session start "${name}" >/dev/null
+  if ! create_and_start_session "${name}" claude; then
+    banner_fail "[1] could not create/start session ${name}"
+    return
+  fi
   sleep 2
   local pid
   pid="$(tmux_pid_for_session "${name}")"
@@ -232,8 +245,11 @@ scenario_2_login_teardown() {
   local scope_pid=$!
   sleep 1
   log "creating session inside simulated login scope: ${name}"
-  agent-deck add -t "${name}" -c claude -Q "${TMPROOT}" >/dev/null
-  agent-deck session start "${name}" >/dev/null
+  if ! create_and_start_session "${name}" claude; then
+    banner_fail "[2] could not create/start session ${name}"
+    systemctl --user stop "${LOGINSIM_SCOPE}.scope" >/dev/null 2>&1 || true
+    return
+  fi
   sleep 2
   local pid
   pid="$(tmux_pid_for_session "${name}")"
@@ -267,8 +283,10 @@ scenario_2_login_teardown() {
 scenario_3_restart_resume() {
   local name="${SESSION_PREFIX}-s3"
   log "creating session: ${name}"
-  agent-deck add -t "${name}" -c claude -Q "${TMPROOT}" >/dev/null
-  agent-deck session start "${name}" >/dev/null
+  if ! create_and_start_session "${name}" claude; then
+    banner_fail "[3] could not create/start session ${name}"
+    return
+  fi
   sleep 2
   # Seed a non-empty ClaudeSessionID via the state-set command if available;
   # otherwise rely on the natural first-start minting one. We want a restart
@@ -300,8 +318,10 @@ scenario_4_fresh_session_shape() {
   local name="${SESSION_PREFIX}-s4"
   : > "${ARGV_OUT}"
   log "creating fresh session: ${name}"
-  agent-deck add -t "${name}" -c claude -Q "${TMPROOT}" >/dev/null
-  agent-deck session start "${name}" >/dev/null
+  if ! create_and_start_session "${name}" claude; then
+    banner_fail "[4] could not create/start session ${name}"
+    return
+  fi
   sleep 2
   local argv verdict
   argv="$(capture_claude_argv "${name}")"
@@ -319,8 +339,10 @@ scenario_4_fresh_session_shape() {
 scenario_5_reviver_respawns_killed_pipe() {
   local name="${SESSION_PREFIX}-s5"
   log "creating session for reviver test: ${name}"
-  agent-deck add -t "${name}" -c shell -Q "${TMPROOT}" >/dev/null
-  agent-deck session start "${name}" >/dev/null
+  if ! create_and_start_session "${name}" shell; then
+    banner_fail "[5] could not create/start session ${name}"
+    return
+  fi
   sleep 1
 
   # Resolve via the authoritative path (was: list|awk /^adeck_/ — never matched).

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -28,6 +28,16 @@ banner_fail() { printf "${C_RED}[FAIL]${C_RESET} %s\n" "$*" >&2; FAILED=1; }
 banner_skip() { printf "${C_YELLOW}[SKIP]${C_RESET} %s\n" "$*"; }
 log() { printf '    %s\n' "$*"; }
 
+# make_run_id returns a per-invocation identifier that is NOT a bare (OS-
+# reusable) PID. SESSION_PREFIX is built from it, so a unique RUN_ID guarantees
+# no two harness runs ever generate identical session titles — closing a
+# PID-reuse identity collision where cleanup (remove-by-exact-title) could match
+# a hard-killed prior run's leftover session. PID + epoch seconds + ${RANDOM};
+# all portable on macOS bash 3.2 (no GNU-only `date %N`).
+make_run_id() {
+  printf '%s-%s-%s' "$$" "$(date +%s)" "${RANDOM}"
+}
+
 # is_own_tmproot returns 0 iff $1 is a tempdir THIS harness created via mktemp.
 # Matches on the leaf name (prefix adeck-verify.), NOT a hardcoded /tmp parent,
 # so it works on macOS where mktemp resolves under $TMPDIR (/var/folders/...).
@@ -449,7 +459,7 @@ scenario_5_reviver_respawns_killed_pipe() {
 # ---------- entrypoint ----------
 main() {
   FAILED=0
-  RUN_ID="$$"
+  RUN_ID="$(make_run_id)"
   TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/adeck-verify.XXXXXX")"
   SESSION_PREFIX="verify-persist-${RUN_ID}"
   LOGINSIM_SCOPE="adeck-verify-loginsim-${RUN_ID}"

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -76,21 +76,29 @@ cleanup() {
 # use it (the old `agent-deck list | awk /^adeck_/` parse was doubly wrong: list
 # never prints the tmux name, and the real prefix is `agentdeck_`).
 resolve_tmux_session() {
-  # `|| true` so a nonzero `agent-deck session show` (e.g. exit 2 not-found)
-  # under `set -o pipefail` does NOT abort callers' `var="$(resolve_tmux_session)"`
-  # assignments via set -e. Callers all degrade on empty output. Single-point
-  # fix shared by tmux_pid_for_session, tmux_pane_start_command_for_session,
-  # and scenario 5.
+  # Single-point resolver shared by tmux_pid_for_session,
+  # tmux_pane_start_command_for_session, and scenario 5. Distinguishes EXPECTED
+  # degradation (swallow) from a real broken interface (surface) — review P2:
+  #   - jq missing      -> explicit error, return 2 (preflight already gates this)
+  #   - session not-found / nonzero `session show` -> EXPECTED: return empty,
+  #     no set -e abort (its stderr "not found" message is just noise)
+  #   - empty output    -> unresolved, return empty
+  #   - malformed JSON from a SUCCESSFUL `session show` -> a real interface
+  #     breakage: surface it (loud error + nonzero) rather than mask it as an
+  #     empty name that would degrade to a false-green [SKIP].
   if ! command -v jq >/dev/null 2>&1; then
     printf '%sERROR%s: jq binary not on PATH.\n' "${C_RED}" "${C_RESET}" >&2
     return 2
   fi
-  # agent-deck's stderr is suppressed (its "not found" message is expected
-  # noise), but jq's is NOT: a real malformed-JSON breakage surfaces loudly on
-  # stderr while `|| true` still degrades stdout to empty (caller SKIPs) and
-  # keeps set -e from aborting. We deliberately do NOT propagate jq's nonzero —
-  # that would re-introduce the silent set -e abort this `|| true` exists to fix.
-  agent-deck session show --json "$1" 2>/dev/null | jq -r '.tmux_session // empty' || true
+  local json
+  json="$(agent-deck session show --json "$1" 2>/dev/null)" || return 0
+  [[ -z "${json}" ]] && return 0
+  local tsess
+  if ! tsess="$(printf '%s' "${json}" | jq -r '.tmux_session // empty')"; then
+    printf '%sERROR%s: malformed JSON from "agent-deck session show --json %s"\n' "${C_RED}" "${C_RESET}" "$1" >&2
+    return 3
+  fi
+  printf '%s\n' "${tsess}"
 }
 
 tmux_pid_for_session() {
@@ -189,6 +197,22 @@ create_and_start_session() {
   local name="$1" tool="$2"
   agent-deck add -t "${name}" -c "${tool}" -Q "${TMPROOT}" >/dev/null || return 1
   agent-deck session start "${name}" >/dev/null || return 1
+}
+
+# argv_unobservable emits the right outcome for scenario $1 when the launched
+# claude argv could not be captured (empty). Review P1: in stub mode the stub is
+# installed and MUST record args, so an empty capture means the gate could not
+# verify restart/fresh behavior — that is a real FAILURE (a [SKIP] there would
+# be a false-green on the mandatory gate, the #1294 class). On non-stub hosts
+# (macOS / no-systemd dev) an empty capture is EXPECTED degradation -> [SKIP].
+# $2 = scenario-specific contract description.
+argv_unobservable() {
+  local n="$1" ctx="$2"
+  if [[ "${USE_STUB:-0}" == "1" ]]; then
+    banner_fail "[${n}] stub mode but claude argv unobservable — stub never recorded args (never launched / died before write); gate cannot verify ${ctx}"
+  else
+    banner_skip "[${n}] argv unobservable (stub not exercised / empty pane_start_command — e.g. pre-existing tmux daemon); cannot assert ${ctx}"
+  fi
 }
 
 # ---------- Scenario 1 ----------
@@ -311,7 +335,7 @@ scenario_3_restart_resume() {
   log "captured claude argv: ${argv}"
   verdict="$(classify_argv resume "${argv}")"
   case "${verdict}" in
-    skip) banner_skip "[3] argv unobservable for ${name} (stub not exercised / empty pane_start_command — e.g. pre-existing tmux daemon); cannot assert resume shape" ;;
+    skip) argv_unobservable 3 "resume shape" ;;
     pass) banner_pass "[3] restart spawned claude with --resume or --session-id" ;;
     fail) banner_fail "[3] restart spawned claude WITHOUT --resume or --session-id: ${argv}" ;;
   esac
@@ -333,7 +357,7 @@ scenario_4_fresh_session_shape() {
   log "captured claude argv: ${argv}"
   verdict="$(classify_argv fresh "${argv}")"
   case "${verdict}" in
-    skip) banner_skip "[4] argv unobservable for ${name} (stub not exercised / empty pane_start_command); cannot assert fresh-session shape" ;;
+    skip) argv_unobservable 4 "fresh-session shape" ;;
     pass) banner_pass "[4] fresh session uses --session-id without --resume" ;;
     fail) banner_fail "[4] fresh session argv shape wrong: ${argv}" ;;
   esac

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -67,7 +67,12 @@ cleanup() {
 # use it (the old `agent-deck list | awk /^adeck_/` parse was doubly wrong: list
 # never prints the tmux name, and the real prefix is `agentdeck_`).
 resolve_tmux_session() {
-  agent-deck session show --json "$1" 2>/dev/null | jq -r '.tmux_session // empty' 2>/dev/null
+  # `|| true` so a nonzero `agent-deck session show` (e.g. exit 2 not-found)
+  # under `set -o pipefail` does NOT abort callers' `var="$(resolve_tmux_session)"`
+  # assignments via set -e. Callers all degrade on empty output. Single-point
+  # fix shared by tmux_pid_for_session, tmux_pane_start_command_for_session,
+  # and scenario 5.
+  agent-deck session show --json "$1" 2>/dev/null | jq -r '.tmux_session // empty' 2>/dev/null || true
 }
 
 tmux_pid_for_session() {

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -42,21 +42,22 @@ is_own_tmproot() {
 # ---------- cleanup ----------
 cleanup() {
   set +e
-  # Stop any sessions we created. agent-deck has no `session ls` subcommand;
-  # use the top-level `agent-deck list --json` so long titles are not truncated.
-  if [[ -n "${SESSION_PREFIX:-}" ]] && command -v agent-deck >/dev/null 2>&1; then
-    if command -v jq >/dev/null 2>&1; then
-      while IFS= read -r n; do
-        [[ -n "${n}" ]] || continue
-        agent-deck session stop "$n" >/dev/null 2>&1 || true
-        agent-deck remove "$n" >/dev/null 2>&1 || true
-      done < <(agent-deck list --json 2>/dev/null | jq -r --arg P "${SESSION_PREFIX}" '.[]? | select((.title // "") | startswith($P)) | .title' 2>/dev/null || true)
-    else
-      for n in $(agent-deck list 2>/dev/null | awk -v P="${SESSION_PREFIX}" '$1 ~ "^"P {print $1}' || true); do
-        agent-deck session stop "$n" >/dev/null 2>&1 || true
-        agent-deck remove "$n" >/dev/null 2>&1 || true
-      done
-    fi
+  # Stop+remove ONLY the exact sessions THIS invocation created, tracked in
+  # CREATED_SESSIONS. We do NOT parse `agent-deck list`: a prefix/text match on
+  # SESSION_PREFIX="verify-persist-${PID}" collides (PID 123 matches a foreign
+  # verify-persist-1234-*) and that fallback fired even on a failed preflight
+  # that created nothing — both data-loss risks (review B1 + B2). Trade-off: a
+  # hard-killed run's sessions are no longer swept by a later run; we accept
+  # that for collision-safety. Empty array => no-op (bash 3.2 set -u safe).
+  if command -v agent-deck >/dev/null 2>&1; then
+    # `${arr[@]+"${arr[@]}"}` is bash 3.2 + set -u safe for an unset OR empty
+    # array (expands to nothing -> no-op); avoids the `${#arr[@]}` unbound crash.
+    local n
+    for n in ${CREATED_SESSIONS[@]+"${CREATED_SESSIONS[@]}"}; do
+      [[ -n "${n}" ]] || continue
+      agent-deck session stop "$n" >/dev/null 2>&1 || true
+      agent-deck remove "$n" >/dev/null 2>&1 || true
+    done
   fi
   # Tear down any lingering login-sim scope.
   if command -v systemctl >/dev/null 2>&1; then
@@ -78,20 +79,27 @@ cleanup() {
 resolve_tmux_session() {
   # Single-point resolver shared by tmux_pid_for_session,
   # tmux_pane_start_command_for_session, and scenario 5. Distinguishes EXPECTED
-  # degradation (swallow) from a real broken interface (surface) — review P2:
-  #   - jq missing      -> explicit error, return 2 (preflight already gates this)
-  #   - session not-found / nonzero `session show` -> EXPECTED: return empty,
-  #     no set -e abort (its stderr "not found" message is just noise)
-  #   - empty output    -> unresolved, return empty
-  #   - malformed JSON from a SUCCESSFUL `session show` -> a real interface
-  #     breakage: surface it (loud error + nonzero) rather than mask it as an
-  #     empty name that would degrade to a false-green [SKIP].
+  # degradation (swallow) from a real error (surface) — review P2 + ALSO:
+  #   - jq missing       -> explicit error, return 2 (preflight already gates it)
+  #   - `session show` exit 2 (ErrCodeNotFound) -> EXPECTED: return empty, no
+  #     set -e abort (its stderr "not found" message is just noise)
+  #   - `session show` ANY OTHER nonzero (exit 1 = DB/load/permission/crash) ->
+  #     a REAL error: surface it (loud error + that exit code), do NOT mask it
+  #     as empty -> false-green [SKIP]
+  #   - empty output     -> unresolved, return empty
+  #   - malformed JSON from a SUCCESSFUL `session show` -> real interface
+  #     breakage: surface it (loud error + nonzero)
   if ! command -v jq >/dev/null 2>&1; then
     printf '%sERROR%s: jq binary not on PATH.\n' "${C_RED}" "${C_RESET}" >&2
     return 2
   fi
-  local json
-  json="$(agent-deck session show --json "$1" 2>/dev/null)" || return 0
+  local json rc=0
+  json="$(agent-deck session show --json "$1" 2>/dev/null)" || rc=$?
+  if [[ "${rc}" -ne 0 ]]; then
+    [[ "${rc}" -eq 2 ]] && return 0
+    printf '%sERROR%s: "agent-deck session show --json %s" failed (exit %s)\n' "${C_RED}" "${C_RESET}" "$1" "${rc}" >&2
+    return "${rc}"
+  fi
   [[ -z "${json}" ]] && return 0
   local tsess
   if ! tsess="$(printf '%s' "${json}" | jq -r '.tmux_session // empty')"; then
@@ -196,6 +204,10 @@ want_scenario() {
 create_and_start_session() {
   local name="$1" tool="$2"
   agent-deck add -t "${name}" -c "${tool}" -Q "${TMPROOT}" >/dev/null || return 1
+  # Track the exact title the moment `add` succeeds (the session record now
+  # exists) so cleanup removes it even if `start` below fails. Direct (non-
+  # subshell) call site, so this append reaches the global CREATED_SESSIONS.
+  CREATED_SESSIONS+=("${name}")
   agent-deck session start "${name}" >/dev/null || return 1
 }
 
@@ -425,6 +437,11 @@ main() {
   LOGINSIM_SCOPE="adeck-verify-loginsim-${RUN_ID}"
   ARGV_OUT="${TMPROOT}/argv.log"
   export AGENT_DECK_VERIFY_ARGV_OUT="${ARGV_OUT}"
+  # Exact titles this invocation created, in creation order. cleanup removes
+  # ONLY these — never a prefix/list-parse match (review B1) — and is a no-op
+  # when empty, e.g. when a failed preflight fires the trap having created
+  # nothing (review B2).
+  CREATED_SESSIONS=()
 
   trap cleanup EXIT INT TERM
 

--- a/scripts/verify-session-persistence.sh
+++ b/scripts/verify-session-persistence.sh
@@ -27,6 +27,17 @@ banner_fail() { printf "${C_RED}[FAIL]${C_RESET} %s\n" "$*" >&2; FAILED=1; }
 banner_skip() { printf "${C_YELLOW}[SKIP]${C_RESET} %s\n" "$*"; }
 log() { printf '    %s\n' "$*"; }
 
+# is_own_tmproot returns 0 iff $1 is a tempdir THIS harness created via mktemp.
+# Matches on the leaf name (prefix adeck-verify.), NOT a hardcoded /tmp parent,
+# so it works on macOS where mktemp resolves under $TMPDIR (/var/folders/...).
+# Uses pure-bash parameter expansion (${p##*/}) — no fork, no BSD-vs-GNU
+# `basename --` portability question, works on bash 3.2. Callers add the `-d`
+# existence test before rm.
+is_own_tmproot() {
+  local p="$1"
+  [[ -n "$p" && "${p##*/}" == adeck-verify.* ]]
+}
+
 # ---------- cleanup ----------
 cleanup() {
   set +e
@@ -43,7 +54,7 @@ cleanup() {
     systemctl --user stop "${LOGINSIM_SCOPE}.scope" >/dev/null 2>&1 || true
   fi
   # Remove the script's OWN tempdir only (per CLAUDE.md, never rm user state).
-  if [[ -n "${TMPROOT}" && "${TMPROOT}" == /tmp/adeck-verify.* ]]; then
+  if is_own_tmproot "${TMPROOT:-}" && [[ -d "${TMPROOT}" ]]; then
     rm -rf "${TMPROOT}" 2>/dev/null || true
   fi
 }

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -488,3 +488,37 @@ if [[ -f "${RECORD}" ]]; then cat "${RECORD}"; fi
 		t.Fatalf("cleanup must skip null titles and still remove matching session; got:\n%s", out)
 	}
 }
+
+func TestResolveTmuxSession_MalformedJSONSurfacesErrorWithoutAbort(t *testing.T) {
+	// Copilot review (PR #1309): a real malformed-JSON breakage from
+	// `agent-deck session show --json` must surface loudly (jq's stderr is no
+	// longer suppressed) — NOT silently degrade to an empty [SKIP]. It must
+	// still NOT abort the caller under set -e (|| true keeps the resolver at
+	// exit 0 and stdout empty so the caller degrades gracefully).
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; resolver depends on jq")
+	}
+	dir := t.TempDir()
+	fake := `#!/usr/bin/env bash
+if [[ "$1" == "session" && "$2" == "show" ]]; then
+  printf '{ this is not valid json\n'
+  exit 0
+fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "agent-deck"), []byte(fake), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, err := sourceAndRun(t,
+		[]string{"PATH=" + dir + ":" + os.Getenv("PATH")},
+		`tsess="$(resolve_tmux_session foo)"; echo "REACHED tsess=[${tsess}]"`)
+	if err != nil {
+		t.Fatalf("malformed JSON must not abort the caller under set -e: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "REACHED tsess=[]") {
+		t.Fatalf("resolver must degrade to empty without abort; got:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "error") {
+		t.Fatalf("malformed JSON must surface a jq error on stderr (not be silenced); got:\n%s", out)
+	}
+}

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -489,12 +489,13 @@ if [[ -f "${RECORD}" ]]; then cat "${RECORD}"; fi
 	}
 }
 
-func TestResolveTmuxSession_MalformedJSONSurfacesErrorWithoutAbort(t *testing.T) {
-	// Copilot review (PR #1309): a real malformed-JSON breakage from
-	// `agent-deck session show --json` must surface loudly (jq's stderr is no
-	// longer suppressed) — NOT silently degrade to an empty [SKIP]. It must
-	// still NOT abort the caller under set -e (|| true keeps the resolver at
-	// exit 0 and stdout empty so the caller degrades gracefully).
+func TestResolveTmuxSession_MalformedJSONSurfacesAsError(t *testing.T) {
+	// Repo-owner review P2 (PR #1309): when `agent-deck session show --json`
+	// SUCCEEDS but returns malformed JSON, that is a real broken-interface
+	// breakage. The resolver must SURFACE it (nonzero status + explicit error)
+	// rather than swallow it into an empty name that degrades to a false-green
+	// [SKIP]. Only the EXPECTED agent-deck not-found nonzero is swallowed
+	// (covered by TestResolveTmuxSession_NonzeroAgentDeckDoesNotAbortUnderSetE).
 	if _, err := exec.LookPath("jq"); err != nil {
 		t.Skip("jq not installed; resolver depends on jq")
 	}
@@ -511,14 +512,69 @@ exit 0
 	}
 	out, err := sourceAndRun(t,
 		[]string{"PATH=" + dir + ":" + os.Getenv("PATH")},
-		`tsess="$(resolve_tmux_session foo)"; echo "REACHED tsess=[${tsess}]"`)
+		`if msg="$(resolve_tmux_session foo 2>&1)"; then
+		   echo "UNEXPECTED_OK=[$msg]"
+		 else
+		   echo "STATUS=$? MSG=[$msg]"
+		 fi`)
 	if err != nil {
-		t.Fatalf("malformed JSON must not abort the caller under set -e: %v\n%s", err, out)
+		t.Fatalf("bash error: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "REACHED tsess=[]") {
-		t.Fatalf("resolver must degrade to empty without abort; got:\n%s", out)
+	if strings.Contains(out, "UNEXPECTED_OK") {
+		t.Fatalf("malformed JSON was silently swallowed as success (false-green):\n%s", out)
 	}
-	if !strings.Contains(strings.ToLower(out), "error") {
-		t.Fatalf("malformed JSON must surface a jq error on stderr (not be silenced); got:\n%s", out)
+	if !strings.Contains(out, "STATUS=3") || !strings.Contains(strings.ToLower(out), "malformed json") {
+		t.Fatalf("malformed JSON must surface as an explicit nonzero error; got:\n%s", out)
+	}
+}
+
+func TestArgvUnobservable_FailsInStubModeSkipsOtherwise(t *testing.T) {
+	// Repo-owner review P1 (PR #1309): an unobservable (empty) claude argv is
+	// expected degradation on non-stub hosts (macOS/no-systemd) -> [SKIP], but
+	// in stub mode (AGENT_DECK_VERIFY_USE_STUB=1 / USE_STUB=1) the stub MUST
+	// have recorded args, so empty means the gate could not verify -> [FAIL].
+	// A [SKIP] there would be a false-green on the mandatory gate.
+	stub, err := sourceAndRun(t, nil,
+		`FAILED=0; USE_STUB=1; argv_unobservable 3 "resume shape"; echo "FAILED=${FAILED}"`)
+	if err != nil {
+		t.Fatalf("bash error (stub): %v\n%s", err, stub)
+	}
+	if !strings.Contains(stub, "[FAIL]") || !strings.Contains(stub, "FAILED=1") {
+		t.Fatalf("stub mode + empty argv must FAIL (false-green guard); got:\n%s", stub)
+	}
+
+	nonstub, err := sourceAndRun(t, nil,
+		`FAILED=0; USE_STUB=0; argv_unobservable 3 "resume shape"; echo "FAILED=${FAILED}"`)
+	if err != nil {
+		t.Fatalf("bash error (non-stub): %v\n%s", err, nonstub)
+	}
+	if !strings.Contains(nonstub, "[SKIP]") || !strings.Contains(nonstub, "FAILED=0") {
+		t.Fatalf("non-stub + empty argv must SKIP (expected degradation); got:\n%s", nonstub)
+	}
+}
+
+func TestScenario3_StubModeUnobservableArgvFailsViaDispatch(t *testing.T) {
+	// P1 wiring: proves argv_unobservable actually fires inside the real
+	// scenario_3 dispatch path (the helper-only test above doesn't). In stub
+	// mode with an unobservable (empty) argv — all agent-deck calls succeed,
+	// only the capture comes back empty — scenario 3 must FAIL, not SKIP.
+	out, err := sourceAndRun(t, []string{"S3_TMPROOT=" + t.TempDir()}, `
+FAILED=0
+USE_STUB=1
+SESSION_PREFIX=verify-persist-test
+TMPROOT="${S3_TMPROOT}"
+ARGV_OUT="${TMPROOT}/argv.log"
+agent-deck() { return 0; }
+tmux() { return 0; }
+sleep() { :; }
+capture_claude_argv() { :; }   # empty argv -> classify=skip -> argv_unobservable
+scenario_3_restart_resume
+echo "FAILED=${FAILED}"
+`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "[FAIL]") || !strings.Contains(out, "FAILED=1") {
+		t.Fatalf("stub-mode unobservable argv must FAIL via scenario_3 dispatch; got:\n%s", out)
 	}
 }

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -61,6 +61,44 @@ func TestIsOwnTmproot_MatchesMktempOutputAnyParent(t *testing.T) {
 	}
 }
 
+// writeFakeAgentDeck installs a stub `agent-deck` on PATH that answers
+// `session show --json <name>` with a fixed payload. Returns the dir to prepend.
+func writeFakeAgentDeck(t *testing.T, tmuxSession string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/usr/bin/env bash
+if [[ "$1" == "session" && "$2" == "show" ]]; then
+  cat <<'JSON'
+{ "title": "foo", "tmux_session": "` + tmuxSession + `" }
+JSON
+  exit 0
+fi
+exit 0
+`
+	p := filepath.Join(dir, "agent-deck")
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake agent-deck: %v", err)
+	}
+	return dir
+}
+
+func TestResolveTmuxSession_UsesShowJson(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; resolver depends on jq")
+	}
+	const want = "agentdeck_foo_410a3758" // real prefix is agentdeck_, NOT adeck_
+	bin := writeFakeAgentDeck(t, want)
+	out, err := sourceAndRun(t,
+		[]string{"PATH=" + bin + ":" + os.Getenv("PATH")},
+		`resolve_tmux_session foo`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(out) != want {
+		t.Fatalf("resolve_tmux_session = %q, want %q", strings.TrimSpace(out), want)
+	}
+}
+
 func TestLibOnly_SourcesWithoutSideEffects(t *testing.T) {
 	// Sourcing with LIB_ONLY=1 must NOT run preflight/dispatch: no scenarios,
 	// no mktemp side effects, clean exit even with agent-deck absent from PATH.

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -171,6 +171,34 @@ func TestCaptureClaudeArgv_NeverScansHostWideProcesses(t *testing.T) {
 	}
 }
 
+func TestResolveTmuxSession_NonzeroAgentDeckDoesNotAbortUnderSetE(t *testing.T) {
+	// Regression: agent-deck `session show` exits 2 on not-found. Under the
+	// harness's `set -euo pipefail`, a bare `tsess="$(resolve_tmux_session ...)"`
+	// in a caller would abort the function instead of degrading to empty/SKIP.
+	// resolve_tmux_session must swallow the nonzero exit and yield empty.
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; resolver depends on jq")
+	}
+	dir := t.TempDir()
+	// Fake agent-deck that always exits 2 with no output (simulates not-found).
+	fake := "#!/usr/bin/env bash\nexit 2\n"
+	if err := os.WriteFile(filepath.Join(dir, "agent-deck"), []byte(fake), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Mimic a caller's bare assignment under set -e, then a marker line. If
+	// resolve_tmux_session propagates the nonzero exit, set -e aborts before
+	// the marker and `err` is non-nil.
+	out, err := sourceAndRun(t,
+		[]string{"PATH=" + dir + ":" + os.Getenv("PATH")},
+		`tsess="$(resolve_tmux_session somesession)"; echo "REACHED=[$tsess]"`)
+	if err != nil {
+		t.Fatalf("set -e aborted before marker (regression present): %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "REACHED=[]") {
+		t.Fatalf("expected empty resolution without abort; got: %s", strings.TrimSpace(out))
+	}
+}
+
 func TestLibOnly_SourcesWithoutSideEffects(t *testing.T) {
 	// Sourcing with LIB_ONLY=1 must NOT run preflight/dispatch: no scenarios,
 	// no mktemp side effects, clean exit even with agent-deck absent from PATH.

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -99,6 +99,78 @@ func TestResolveTmuxSession_UsesShowJson(t *testing.T) {
 	}
 }
 
+func TestClassifyArgv_VerdictsIncludingEmptyIsSkip(t *testing.T) {
+	// Regression for the reported bug: empty argv (claude unobservable for this
+	// session) MUST classify as "skip", not "fail".
+	cases := []struct{ mode, argv, want string }{
+		{"resume", "", "skip"},
+		{"fresh", "", "skip"},
+		{"resume", "claude --resume abc", "pass"},
+		{"resume", "claude --session-id abc", "pass"},
+		{"resume", "claude --foo", "fail"},
+		{"fresh", "claude --session-id abc", "pass"},
+		{"fresh", "claude --session-id abc --resume x", "fail"}, // both -> wrong shape
+		{"fresh", "claude --resume x", "fail"},
+	}
+	for _, c := range cases {
+		snippet := `classify_argv ` + c.mode + ` "` + c.argv + `"`
+		out, err := sourceAndRun(t, nil, snippet)
+		if err != nil {
+			t.Fatalf("mode=%s argv=%q: bash error: %v\n%s", c.mode, c.argv, err, out)
+		}
+		if strings.TrimSpace(out) != c.want {
+			t.Errorf("classify_argv(%s, %q) = %q, want %q", c.mode, c.argv, strings.TrimSpace(out), c.want)
+		}
+	}
+}
+
+func TestCaptureClaudeArgv_PrefersStubFile(t *testing.T) {
+	argvFile := filepath.Join(t.TempDir(), "argv.log")
+	if err := os.WriteFile(argvFile, []byte("claude --session-id ABC123\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := sourceAndRun(t, []string{"ARGV_OUT=" + argvFile},
+		`capture_claude_argv ignored-name`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "--session-id ABC123") {
+		t.Fatalf("capture did not return stub argv; got: %q", strings.TrimSpace(out))
+	}
+}
+
+func TestCaptureClaudeArgv_NeverScansHostWideProcesses(t *testing.T) {
+	// Regression for the false-FAIL bug: with the stub file empty AND no pane
+	// resolution, capture MUST return empty — never a host-wide `ps|grep claude`
+	// match. We plant a live foreign process whose argv contains "claude".
+	emptyArgv := filepath.Join(t.TempDir(), "argv.log") // exists, zero bytes
+	if err := os.WriteFile(emptyArgv, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Foreign process: argv0 = "claude-foreign-decoy", lives for the test.
+	foreign := exec.Command("bash", "-c", `exec -a claude-foreign-decoy sleep 30`)
+	if err := foreign.Start(); err != nil {
+		t.Fatalf("start foreign decoy: %v", err)
+	}
+	defer func() { _ = foreign.Process.Kill() }()
+
+	// Force pane resolution to yield nothing (no real tmux session named this).
+	out, err := sourceAndRun(t,
+		[]string{"ARGV_OUT=" + emptyArgv, "PATH=/usr/bin:/bin"},
+		`tmux_pane_start_command_for_session() { return 1; }
+		 r="$(capture_claude_argv nonexistent-session)"
+		 echo "CAPTURED=[$r]"`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "CAPTURED=[]") {
+		t.Fatalf("capture returned non-empty (host-wide scan leaked?): %s", strings.TrimSpace(out))
+	}
+	if strings.Contains(out, "claude-foreign-decoy") {
+		t.Fatalf("capture matched a FOREIGN process — false-FAIL bug present: %s", strings.TrimSpace(out))
+	}
+}
+
 func TestLibOnly_SourcesWithoutSideEffects(t *testing.T) {
 	// Sourcing with LIB_ONLY=1 must NOT run preflight/dispatch: no scenarios,
 	// no mktemp side effects, clean exit even with agent-deck absent from PATH.

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -202,10 +202,10 @@ func TestCaptureClaudeArgv_NeverScansHostWideProcesses(t *testing.T) {
 	}
 	defer func() { _ = foreign.Process.Kill() }()
 
-	// Force pane resolution to yield nothing (no real tmux session named this).
+	// Pane resolution yields nothing (unresolved -> empty, exit 0 — NOT an error).
 	out, err := sourceAndRun(t,
 		[]string{"ARGV_OUT=" + emptyArgv, "PATH=/usr/bin:/bin"},
-		`tmux_pane_start_command_for_session() { return 1; }
+		`tmux_pane_start_command_for_session() { return 0; }
 		 r="$(capture_claude_argv nonexistent-session)"
 		 echo "CAPTURED=[$r]"`)
 	if err != nil {
@@ -216,6 +216,51 @@ func TestCaptureClaudeArgv_NeverScansHostWideProcesses(t *testing.T) {
 	}
 	if strings.Contains(out, "claude-foreign-decoy") {
 		t.Fatalf("capture matched a FOREIGN process — false-FAIL bug present: %s", strings.TrimSpace(out))
+	}
+}
+
+func TestCaptureClaudeArgv_RealResolverErrorPropagates(t *testing.T) {
+	// Owner review (line 164): a REAL resolver error (nonzero from
+	// tmux_pane_start_command_for_session — e.g. resolve_tmux_session hit a DB
+	// error / malformed JSON, exit 1/3) must PROPAGATE out of capture so the
+	// scenario can FAIL loudly — not be flattened to empty/exit-0 (which would
+	// degrade to [SKIP] on non-stub hosts).
+	out, err := sourceAndRun(t, []string{"ARGV_OUT=/dev/null"},
+		`tmux_pane_start_command_for_session() { return 7; }
+		 rc=0; argv="$(capture_claude_argv s)" || rc=$?
+		 echo "rc=${rc} argv=[${argv}]"`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "rc=7") {
+		t.Fatalf("capture must propagate a real resolver error code; got:\n%s", out)
+	}
+}
+
+func TestScenario3_RealResolverErrorFailsEvenNonStub(t *testing.T) {
+	// Owner review (line 164): a real resolver/interface error during argv
+	// capture must FAIL scenario 3 even on a NON-stub host — not degrade to a
+	// [SKIP], which would contradict the "non-not-found errors fail loudly"
+	// contract. (Unresolved/empty argv still SKIPs on non-stub; see
+	// TestArgvUnobservable_FailsInStubModeSkipsOtherwise.)
+	out, err := sourceAndRun(t, []string{"S3_TMPROOT=" + t.TempDir()}, `
+FAILED=0
+USE_STUB=0
+SESSION_PREFIX=verify-persist-test
+TMPROOT="${S3_TMPROOT}"
+ARGV_OUT="${TMPROOT}/argv.log"
+agent-deck() { return 0; }
+tmux() { return 0; }
+sleep() { :; }
+capture_claude_argv() { printf 'ERROR: db locked\n' >&2; return 1; }
+scenario_3_restart_resume
+echo "FAILED=${FAILED}"
+`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "[FAIL]") || !strings.Contains(out, "FAILED=1") {
+		t.Fatalf("real resolver error must FAIL scenario 3 even non-stub; got:\n%s", out)
 	}
 }
 

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -420,3 +420,71 @@ func TestLibOnly_SourcesWithoutSideEffects(t *testing.T) {
 		t.Fatalf("dispatch ran during source (should be gated by LIB_ONLY); got:\n%s", out)
 	}
 }
+
+func TestScenario_InitialStartFailureMarksFailureNotAbort(t *testing.T) {
+	// F2 regression: when a scenario's INITIAL `agent-deck session start` fails,
+	// the scenario must banner_fail and return — NOT abort the harness under
+	// `set -e` with no diagnostic banner. Exercised via scenario 4 (simplest).
+	out, err := sourceAndRun(t, []string{"S4_TMPROOT=" + t.TempDir()}, `
+FAILED=0
+SESSION_PREFIX=verify-persist-test
+TMPROOT="${S4_TMPROOT}"
+ARGV_OUT="${TMPROOT}/argv.log"
+agent-deck() {
+  if [[ "$1" == "session" && "$2" == "start" ]]; then
+    return 9
+  fi
+  return 0
+}
+tmux() { return 0; }
+sleep() { :; }
+scenario_4_fresh_session_shape
+echo "REACHED_AFTER FAILED=${FAILED}"
+`)
+	if err != nil {
+		t.Fatalf("harness aborted under set -e instead of bannering (F2): %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "[FAIL]") || !strings.Contains(out, "REACHED_AFTER FAILED=1") {
+		t.Fatalf("initial start failure must mark [FAIL] and not abort; got:\n%s", out)
+	}
+}
+
+func TestCleanup_HandlesNullTitleInJSONList(t *testing.T) {
+	// F4 regression: a session entry with a null `.title` must not error the jq
+	// filter (startswith on null) and abort the cleanup pass — matching sessions
+	// must still be removed. Null entry FIRST so the unguarded filter errors
+	// before reaching the matching one.
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; cleanup JSON path depends on jq")
+	}
+	record := filepath.Join(t.TempDir(), "calls.log")
+	out, err := sourceAndRun(t, []string{"RECORD=" + record}, `
+SESSION_PREFIX=verify-persist-123456
+LOGINSIM_SCOPE=adeck-verify-loginsim-test
+TMPROOT=""
+agent-deck() {
+  if [[ "$1" == "list" && "${2:-}" == "--json" ]]; then
+    cat <<'JSON'
+[
+  {"title":null,"id":"id-null"},
+  {"title":"verify-persist-123456-s1","id":"id-1"}
+]
+JSON
+    return 0
+  fi
+  if [[ "$1" == "session" && "$2" == "stop" ]]; then printf 'stop:%s\n' "$3" >> "${RECORD}"; return 0; fi
+  if [[ "$1" == "remove" ]]; then printf 'remove:%s\n' "$2" >> "${RECORD}"; return 0; fi
+  return 0
+}
+systemctl() { return 0; }
+cleanup
+if [[ -f "${RECORD}" ]]; then cat "${RECORD}"; fi
+`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "stop:verify-persist-123456-s1") ||
+		!strings.Contains(out, "remove:verify-persist-123456-s1") {
+		t.Fatalf("cleanup must skip null titles and still remove matching session; got:\n%s", out)
+	}
+}

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -317,50 +317,120 @@ echo "FAILED=${FAILED}"
 	}
 }
 
-func TestCleanup_RemovesFullTitlesFromJSONList(t *testing.T) {
-	if _, err := exec.LookPath("jq"); err != nil {
-		t.Skip("jq not installed; cleanup JSON path depends on jq")
-	}
+func TestCleanup_RemovesOnlyTrackedCreatedSessions(t *testing.T) {
+	// Review B1: cleanup must remove ONLY the exact titles this invocation
+	// created (tracked in CREATED_SESSIONS) — never a prefix/list-parse match. A
+	// bare prefix collides (verify-persist-123 matches a foreign
+	// verify-persist-1234-*). cleanup must also never call `agent-deck list`
+	// (the unsafe text-parse path is removed entirely).
 	record := filepath.Join(t.TempDir(), "calls.log")
 	out, err := sourceAndRun(t, []string{"RECORD=" + record}, `
-SESSION_PREFIX=verify-persist-123456
 LOGINSIM_SCOPE=adeck-verify-loginsim-test
 TMPROOT=""
+CREATED_SESSIONS=("verify-persist-123-s1" "verify-persist-123-s5")
 agent-deck() {
-  if [[ "$1" == "list" && "${2:-}" == "--json" ]]; then
-    cat <<'JSON'
-[
-  {"title":"verify-persist-123456-s1","id":"id-1"},
-  {"title":"unrelated","id":"id-2"}
-]
-JSON
-    return 0
-  fi
-  if [[ "$1" == "list" ]]; then
-    printf 'TITLE                GROUP           PATH                                     ID\n'
-    printf 'verify-persist-12... T               /tmp/path                                id-1\n'
-    return 0
-  fi
-  if [[ "$1" == "session" && "$2" == "stop" ]]; then
-    printf 'stop:%s\n' "$3" >> "${RECORD}"
-    return 0
-  fi
-  if [[ "$1" == "remove" ]]; then
-    printf 'remove:%s\n' "$2" >> "${RECORD}"
-    return 0
-  fi
+  printf '%s\n' "$*" >> "${RECORD}.all"
+  if [[ "$1" == "session" && "$2" == "stop" ]]; then printf 'stop:%s\n' "$3" >> "${RECORD}"; return 0; fi
+  if [[ "$1" == "remove" ]]; then printf 'remove:%s\n' "$2" >> "${RECORD}"; return 0; fi
   return 0
 }
 systemctl() { return 0; }
 cleanup
-if [[ -f "${RECORD}" ]]; then cat "${RECORD}"; fi
+echo "---REMOVED---"; [[ -f "${RECORD}" ]] && cat "${RECORD}" || true
+echo "---ALLCALLS---"; [[ -f "${RECORD}.all" ]] && cat "${RECORD}.all" || true
 `)
 	if err != nil {
 		t.Fatalf("bash error: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "stop:verify-persist-123456-s1") ||
-		!strings.Contains(out, "remove:verify-persist-123456-s1") {
-		t.Fatalf("cleanup must use full JSON titles instead of truncated table output; got:\n%s", out)
+	for _, want := range []string{
+		"stop:verify-persist-123-s1", "remove:verify-persist-123-s1",
+		"stop:verify-persist-123-s5", "remove:verify-persist-123-s5",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("cleanup must remove tracked session %q; got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "list") {
+		t.Fatalf("cleanup must NOT call `agent-deck list` (unsafe prefix-parse path removed); got:\n%s", out)
+	}
+}
+
+func TestCleanup_NoOpWhenNothingCreated(t *testing.T) {
+	// Review B2: on a failed preflight (e.g. missing jq) the EXIT trap fires
+	// having created nothing — CREATED_SESSIONS is empty, so cleanup must remove
+	// NO sessions (no false-deletion of pre-existing matching sessions).
+	record := filepath.Join(t.TempDir(), "calls.log")
+	out, err := sourceAndRun(t, []string{"RECORD=" + record}, `
+LOGINSIM_SCOPE=adeck-verify-loginsim-test
+TMPROOT=""
+CREATED_SESSIONS=()
+agent-deck() { printf 'CALLED:%s\n' "$*" >> "${RECORD}"; return 0; }
+systemctl() { return 0; }
+cleanup
+echo "DONE"; [[ -f "${RECORD}" ]] && cat "${RECORD}" || true
+`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "DONE") {
+		t.Fatalf("cleanup did not complete; got:\n%s", out)
+	}
+	if strings.Contains(out, "CALLED:") {
+		t.Fatalf("cleanup with empty CREATED_SESSIONS must remove nothing; got:\n%s", out)
+	}
+}
+
+func TestCreateAndStartSession_TracksCreatedTitle(t *testing.T) {
+	// Wiring: a successful `agent-deck add` records the exact title in
+	// CREATED_SESSIONS so cleanup can later remove exactly it.
+	out, err := sourceAndRun(t, []string{"S_TMPROOT=" + t.TempDir()}, `
+CREATED_SESSIONS=()
+TMPROOT="${S_TMPROOT}"
+agent-deck() { return 0; }
+create_and_start_session "verify-persist-999-s1" claude
+printf 'TRACKED=[%s]\n' "${CREATED_SESSIONS[*]:-}"
+`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "TRACKED=[verify-persist-999-s1]") {
+		t.Fatalf("create_and_start_session must track the created title; got:\n%s", out)
+	}
+}
+
+func TestResolveTmuxSession_RealErrorSurfaces(t *testing.T) {
+	// Review ALSO: `session show` exits 2 for genuine not-found (swallow) but
+	// exit 1 for a real error (DB/load/permission). A real error must SURFACE
+	// (nonzero + message), not silently degrade to empty -> false-green [SKIP].
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; resolver depends on jq")
+	}
+	dir := t.TempDir()
+	fake := `#!/usr/bin/env bash
+if [[ "$1" == "session" && "$2" == "show" ]]; then
+  echo "load error: database is locked" >&2
+  exit 1
+fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "agent-deck"), []byte(fake), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, err := sourceAndRun(t,
+		[]string{"PATH=" + dir + ":" + os.Getenv("PATH")},
+		`if msg="$(resolve_tmux_session foo 2>&1)"; then
+		   echo "UNEXPECTED_OK=[$msg]"
+		 else
+		   echo "STATUS=$? MSG=[$msg]"
+		 fi`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "UNEXPECTED_OK") {
+		t.Fatalf("a real session-show error was swallowed as success (false-green):\n%s", out)
+	}
+	if !strings.Contains(out, "STATUS=1") || !strings.Contains(strings.ToLower(out), "failed") {
+		t.Fatalf("real session-show error must surface as nonzero + message; got:\n%s", out)
 	}
 }
 
@@ -446,46 +516,6 @@ echo "REACHED_AFTER FAILED=${FAILED}"
 	}
 	if !strings.Contains(out, "[FAIL]") || !strings.Contains(out, "REACHED_AFTER FAILED=1") {
 		t.Fatalf("initial start failure must mark [FAIL] and not abort; got:\n%s", out)
-	}
-}
-
-func TestCleanup_HandlesNullTitleInJSONList(t *testing.T) {
-	// F4 regression: a session entry with a null `.title` must not error the jq
-	// filter (startswith on null) and abort the cleanup pass — matching sessions
-	// must still be removed. Null entry FIRST so the unguarded filter errors
-	// before reaching the matching one.
-	if _, err := exec.LookPath("jq"); err != nil {
-		t.Skip("jq not installed; cleanup JSON path depends on jq")
-	}
-	record := filepath.Join(t.TempDir(), "calls.log")
-	out, err := sourceAndRun(t, []string{"RECORD=" + record}, `
-SESSION_PREFIX=verify-persist-123456
-LOGINSIM_SCOPE=adeck-verify-loginsim-test
-TMPROOT=""
-agent-deck() {
-  if [[ "$1" == "list" && "${2:-}" == "--json" ]]; then
-    cat <<'JSON'
-[
-  {"title":null,"id":"id-null"},
-  {"title":"verify-persist-123456-s1","id":"id-1"}
-]
-JSON
-    return 0
-  fi
-  if [[ "$1" == "session" && "$2" == "stop" ]]; then printf 'stop:%s\n' "$3" >> "${RECORD}"; return 0; fi
-  if [[ "$1" == "remove" ]]; then printf 'remove:%s\n' "$2" >> "${RECORD}"; return 0; fi
-  return 0
-}
-systemctl() { return 0; }
-cleanup
-if [[ -f "${RECORD}" ]]; then cat "${RECORD}"; fi
-`)
-	if err != nil {
-		t.Fatalf("bash error: %v\n%s", err, out)
-	}
-	if !strings.Contains(out, "stop:verify-persist-123456-s1") ||
-		!strings.Contains(out, "remove:verify-persist-123456-s1") {
-		t.Fatalf("cleanup must skip null titles and still remove matching session; got:\n%s", out)
 	}
 }
 

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -23,6 +23,19 @@ func scriptPath(t *testing.T) string {
 	return p
 }
 
+func fakeClaudePath(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	p := filepath.Join(wd, "verify-session-persistence.d", "fake-claude.sh")
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("fake claude not found at %s: %v", p, err)
+	}
+	return p
+}
+
 // sourceAndRun sources the harness in lib-only mode and runs a bash snippet.
 // Returns combined stdout+stderr. `set -e` is active (the harness sets it), so
 // snippets must guard non-zero returns with `if`/`||` rather than bare calls.
@@ -40,13 +53,13 @@ func TestIsOwnTmproot_MatchesMktempOutputAnyParent(t *testing.T) {
 		path string
 		want bool
 	}{
-		{"/tmp/adeck-verify.AbC123", true},                       // Linux mktemp
-		{"/var/folders/23/xxxx/T/adeck-verify.AbC123", true},     // macOS $TMPDIR
-		{"/private/var/folders/q/y/T/adeck-verify.Z9", true},     // macOS realpath
-		{"/tmp", false},                                          // bare tmp — never rm
-		{"/home/user/important", false},                          // unrelated dir
-		{"", false},                                              // empty
-		{"/tmp/other-prefix.123", false},                         // wrong prefix
+		{"/tmp/adeck-verify.AbC123", true},                   // Linux mktemp
+		{"/var/folders/23/xxxx/T/adeck-verify.AbC123", true}, // macOS $TMPDIR
+		{"/private/var/folders/q/y/T/adeck-verify.Z9", true}, // macOS realpath
+		{"/tmp", false},                  // bare tmp — never rm
+		{"/home/user/important", false},  // unrelated dir
+		{"", false},                      // empty
+		{"/tmp/other-prefix.123", false}, // wrong prefix
 	}
 	for _, c := range cases {
 		snippet := `if is_own_tmproot "` + c.path + `"; then echo YES; else echo NO; fi`
@@ -111,6 +124,7 @@ func TestClassifyArgv_VerdictsIncludingEmptyIsSkip(t *testing.T) {
 		{"fresh", "claude --session-id abc", "pass"},
 		{"fresh", "claude --session-id abc --resume x", "fail"}, // both -> wrong shape
 		{"fresh", "claude --resume x", "fail"},
+		{"unknown", "claude --session-id abc", "fail"}, // no silent empty verdict
 	}
 	for _, c := range cases {
 		snippet := `classify_argv ` + c.mode + ` "` + c.argv + `"`
@@ -121,6 +135,40 @@ func TestClassifyArgv_VerdictsIncludingEmptyIsSkip(t *testing.T) {
 		if strings.TrimSpace(out) != c.want {
 			t.Errorf("classify_argv(%s, %q) = %q, want %q", c.mode, c.argv, strings.TrimSpace(out), c.want)
 		}
+	}
+}
+
+func TestResolveTmuxSession_MissingJqIsExplicitError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink("/bin/cat", filepath.Join(dir, "cat")); err != nil {
+		t.Fatal(err)
+	}
+	fake := `#!/bin/bash
+if [[ "$1" == "session" && "$2" == "show" ]]; then
+  printf '{ "tmux_session": "agentdeck_missing_jq" }\n'
+  exit 0
+fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(dir, "agent-deck"), []byte(fake), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out, err := sourceAndRun(t,
+		[]string{"PATH=" + dir},
+		`if msg="$(resolve_tmux_session foo 2>&1)"; then
+		   echo "UNEXPECTED_OK=[$msg]"
+		 else
+		   echo "STATUS=$?"
+		   echo "MSG=[$msg]"
+		 fi`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "UNEXPECTED_OK") {
+		t.Fatalf("missing jq was silently treated as success:\n%s", out)
+	}
+	if !strings.Contains(out, "STATUS=2") || !strings.Contains(out, "jq binary not on PATH") {
+		t.Fatalf("missing jq must be explicit status 2 error; got:\n%s", out)
 	}
 }
 
@@ -196,6 +244,161 @@ func TestResolveTmuxSession_NonzeroAgentDeckDoesNotAbortUnderSetE(t *testing.T) 
 	}
 	if !strings.Contains(out, "REACHED=[]") {
 		t.Fatalf("expected empty resolution without abort; got: %s", strings.TrimSpace(out))
+	}
+}
+
+func TestScenario3_RestartFailureMarksFailure(t *testing.T) {
+	out, err := sourceAndRun(t, nil, `
+FAILED=0
+SESSION_PREFIX=verify-persist-test
+TMPROOT="${TMPDIR:-/tmp}/adeck-verify-test-s3"
+mkdir -p "${TMPROOT}"
+ARGV_OUT="${TMPROOT}/argv.log"
+start_count=0
+agent-deck() {
+  if [[ "$1" == "session" && "$2" == "start" ]]; then
+    start_count=$((start_count + 1))
+    if [[ "${start_count}" -eq 2 ]]; then
+      return 42
+    fi
+  fi
+  return 0
+}
+sleep() { :; }
+capture_claude_argv() { :; }
+scenario_3_restart_resume
+echo "FAILED=${FAILED}"
+`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "[FAIL]") || !strings.Contains(out, "FAILED=1") {
+		t.Fatalf("restart command failure must mark scenario failed; got:\n%s", out)
+	}
+}
+
+func TestScenario5_ReviveFailureMarksFailure(t *testing.T) {
+	counter := filepath.Join(t.TempDir(), "pgrep-count")
+	if err := os.WriteFile(counter, []byte("0"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := sourceAndRun(t, []string{"COUNT_FILE=" + counter}, `
+FAILED=0
+SESSION_PREFIX=verify-persist-test
+TMPROOT="${TMPDIR:-/tmp}/adeck-verify-test-s5"
+ARGV_OUT="${TMPROOT}/argv.log"
+agent-deck() {
+  if [[ "$1" == "session" && "$2" == "revive" ]]; then
+    return 42
+  fi
+  return 0
+}
+resolve_tmux_session() { printf 'agentdeck_fake_session\n'; }
+pgrep() {
+  c="$(cat "${COUNT_FILE}")"
+  c=$((c + 1))
+  printf '%s' "${c}" > "${COUNT_FILE}"
+  if [[ "${c}" -eq 1 ]]; then
+    printf '12345\n'
+    return 0
+  fi
+  return 1
+}
+kill() { return 0; }
+sleep() { :; }
+scenario_5_reviver_respawns_killed_pipe
+echo "FAILED=${FAILED}"
+`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "[FAIL]") || !strings.Contains(out, "FAILED=1") {
+		t.Fatalf("revive command failure must mark scenario failed; got:\n%s", out)
+	}
+}
+
+func TestCleanup_RemovesFullTitlesFromJSONList(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not installed; cleanup JSON path depends on jq")
+	}
+	record := filepath.Join(t.TempDir(), "calls.log")
+	out, err := sourceAndRun(t, []string{"RECORD=" + record}, `
+SESSION_PREFIX=verify-persist-123456
+LOGINSIM_SCOPE=adeck-verify-loginsim-test
+TMPROOT=""
+agent-deck() {
+  if [[ "$1" == "list" && "${2:-}" == "--json" ]]; then
+    cat <<'JSON'
+[
+  {"title":"verify-persist-123456-s1","id":"id-1"},
+  {"title":"unrelated","id":"id-2"}
+]
+JSON
+    return 0
+  fi
+  if [[ "$1" == "list" ]]; then
+    printf 'TITLE                GROUP           PATH                                     ID\n'
+    printf 'verify-persist-12... T               /tmp/path                                id-1\n'
+    return 0
+  fi
+  if [[ "$1" == "session" && "$2" == "stop" ]]; then
+    printf 'stop:%s\n' "$3" >> "${RECORD}"
+    return 0
+  fi
+  if [[ "$1" == "remove" ]]; then
+    printf 'remove:%s\n' "$2" >> "${RECORD}"
+    return 0
+  fi
+  return 0
+}
+systemctl() { return 0; }
+cleanup
+if [[ -f "${RECORD}" ]]; then cat "${RECORD}"; fi
+`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "stop:verify-persist-123456-s1") ||
+		!strings.Contains(out, "remove:verify-persist-123456-s1") {
+		t.Fatalf("cleanup must use full JSON titles instead of truncated table output; got:\n%s", out)
+	}
+}
+
+func TestFakeClaudeStub_UsesPortableSleepDuration(t *testing.T) {
+	dir := t.TempDir()
+	sleepArg := filepath.Join(dir, "sleep-arg.log")
+	fakeSleep := `#!/usr/bin/env bash
+printf '%s\n' "$*" > "${SLEEP_ARG_OUT}"
+exit 33
+`
+	if err := os.WriteFile(filepath.Join(dir, "sleep"), []byte(fakeSleep), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	argvFile := filepath.Join(dir, "argv.log")
+	cmd := exec.Command(fakeClaudePath(t), "--session-id", "abc")
+	cmd.Env = append(os.Environ(),
+		"PATH="+dir+":"+os.Getenv("PATH"),
+		"SLEEP_ARG_OUT="+sleepArg,
+		"AGENT_DECK_VERIFY_ARGV_OUT="+argvFile,
+	)
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("fake sleep should stop the stub after the first sleep call")
+	}
+	data, readErr := os.ReadFile(sleepArg)
+	if readErr != nil {
+		t.Fatalf("fake sleep was not invoked: %v", readErr)
+	}
+	got := strings.TrimSpace(string(data))
+	if got == "" || strings.Contains(got, "infinity") {
+		t.Fatalf("stub must not rely on non-portable 'sleep infinity'; sleep arg = %q", got)
+	}
+	argv, readErr := os.ReadFile(argvFile)
+	if readErr != nil {
+		t.Fatalf("argv log was not written: %v", readErr)
+	}
+	if strings.TrimSpace(string(argv)) != "--session-id abc" {
+		t.Fatalf("argv log = %q, want --session-id abc", strings.TrimSpace(string(argv)))
 	}
 }
 

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -653,3 +653,44 @@ echo "FAILED=${FAILED}"
 		t.Fatalf("stub-mode unobservable argv must FAIL via scenario_3 dispatch; got:\n%s", out)
 	}
 }
+
+func TestMakeRunID_IsCollisionProofNotBarePID(t *testing.T) {
+	// Review: RUN_ID was a bare `$$` (an OS-reusable PID). Since
+	// SESSION_PREFIX="verify-persist-${RUN_ID}", a later run that gets a
+	// hard-killed prior run's PID would generate identical session titles, and
+	// cleanup (remove-by-exact-title) could then match the stale prior session.
+	// make_run_id must be per-invocation unique, not the bare PID.
+	out, err := sourceAndRun(t, nil, `
+ids=""
+for i in 1 2 3 4 5; do ids="${ids}${ids:+ }$(make_run_id)"; done
+printf 'IDS=%s\n' "${ids}"
+printf 'ONE=%s\n' "$(make_run_id)"
+printf 'PID=%s\n' "$$"
+`)
+	if err != nil {
+		t.Fatalf("bash error: %v\n%s", err, out)
+	}
+	var ids, one, pid string
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.HasPrefix(line, "IDS="):
+			ids = strings.TrimPrefix(line, "IDS=")
+		case strings.HasPrefix(line, "ONE="):
+			one = strings.TrimPrefix(line, "ONE=")
+		case strings.HasPrefix(line, "PID="):
+			pid = strings.TrimPrefix(line, "PID=")
+		}
+	}
+	// Not the bare PID, and composite (PID-epoch-RANDOM => >= 2 dashes).
+	if one == pid || strings.Count(one, "-") < 2 {
+		t.Fatalf("run id %q must be composite (not the bare PID %q)", one, pid)
+	}
+	// Uniqueness: 5 invocations must not all collide (would-be title collision).
+	seen := map[string]bool{}
+	for _, id := range strings.Fields(ids) {
+		seen[id] = true
+	}
+	if len(seen) < 2 {
+		t.Fatalf("make_run_id must vary per invocation; 5 calls gave %d distinct: %q", len(seen), ids)
+	}
+}

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -35,6 +35,32 @@ func sourceAndRun(t *testing.T, env []string, snippet string) (string, error) {
 	return string(out), err
 }
 
+func TestIsOwnTmproot_MatchesMktempOutputAnyParent(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/tmp/adeck-verify.AbC123", true},                       // Linux mktemp
+		{"/var/folders/23/xxxx/T/adeck-verify.AbC123", true},     // macOS $TMPDIR
+		{"/private/var/folders/q/y/T/adeck-verify.Z9", true},     // macOS realpath
+		{"/tmp", false},                                          // bare tmp — never rm
+		{"/home/user/important", false},                          // unrelated dir
+		{"", false},                                              // empty
+		{"/tmp/other-prefix.123", false},                         // wrong prefix
+	}
+	for _, c := range cases {
+		snippet := `if is_own_tmproot "` + c.path + `"; then echo YES; else echo NO; fi`
+		out, err := sourceAndRun(t, nil, snippet)
+		if err != nil {
+			t.Fatalf("path %q: bash error: %v\n%s", c.path, err, out)
+		}
+		got := strings.Contains(out, "YES")
+		if got != c.want {
+			t.Errorf("is_own_tmproot(%q) = %v, want %v (out: %s)", c.path, got, c.want, strings.TrimSpace(out))
+		}
+	}
+}
+
 func TestLibOnly_SourcesWithoutSideEffects(t *testing.T) {
 	// Sourcing with LIB_ONLY=1 must NOT run preflight/dispatch: no scenarios,
 	// no mktemp side effects, clean exit even with agent-deck absent from PATH.

--- a/scripts/verify-session-persistence_test.go
+++ b/scripts/verify-session-persistence_test.go
@@ -1,0 +1,55 @@
+package scripts
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scriptPath returns the absolute path to the harness under test. Go test runs
+// with CWD = package dir (scripts/), so the script is a sibling.
+func scriptPath(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	p := filepath.Join(wd, "verify-session-persistence.sh")
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("harness not found at %s: %v", p, err)
+	}
+	return p
+}
+
+// sourceAndRun sources the harness in lib-only mode and runs a bash snippet.
+// Returns combined stdout+stderr. `set -e` is active (the harness sets it), so
+// snippets must guard non-zero returns with `if`/`||` rather than bare calls.
+func sourceAndRun(t *testing.T, env []string, snippet string) (string, error) {
+	t.Helper()
+	full := "AGENT_DECK_VERIFY_LIB_ONLY=1 source '" + scriptPath(t) + "'\n" + snippet
+	cmd := exec.Command("bash", "-c", full)
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func TestLibOnly_SourcesWithoutSideEffects(t *testing.T) {
+	// Sourcing with LIB_ONLY=1 must NOT run preflight/dispatch: no scenarios,
+	// no mktemp side effects, clean exit even with agent-deck absent from PATH.
+	out, err := sourceAndRun(t, []string{"PATH=/usr/bin:/bin"},
+		`echo "SOURCED_OK"; type -t main >/dev/null && echo "MAIN_DEFINED"`)
+	if err != nil {
+		t.Fatalf("sourcing failed (expected clean source): %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(out, "SOURCED_OK") {
+		t.Fatalf("snippet did not run; got:\n%s", out)
+	}
+	if !strings.Contains(out, "MAIN_DEFINED") {
+		t.Fatalf("main() not defined after source; got:\n%s", out)
+	}
+	if strings.Contains(out, "persistence harness") || strings.Contains(out, "[PASS]") {
+		t.Fatalf("dispatch ran during source (should be gated by LIB_ONLY); got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Hardens `scripts/verify-session-persistence.sh` so it degrades **truthfully** on non-systemd hosts (macOS, BSD, any dev box with a real `claude` running) — emitting `[SKIP]`/diagnostic `[FAIL]` instead of false `[FAIL]`s or silent aborts — **without touching the Linux+systemd contract** (scenario 2 / cgroup branch of scenario 1) it exists to gate. The harness was previously a Bash script with zero automated tests; this PR makes its logic sourceable and adds 14 unit tests that run on macOS **and** Linux CI.

Originally a false-`FAIL` on macOS (`exit=1`); now `OVERALL: PASS` with honest `[PASS]`/`[SKIP]` lines and self-cleaning temp dirs. Rebased onto the latest `main`.

### What changed
- **Sourceable seam:** an `AGENT_DECK_VERIFY_LIB_ONLY` guard wraps the imperative tail in `main()` so helpers can be unit-tested.
- **Fix A — argv capture:** scenarios 3/4 `[SKIP]` (never false-`[FAIL]`) when claude argv is unobservable; removed the host-wide `ps | grep claude` tier that matched unrelated processes. (`capture_claude_argv` + `classify_argv`)
- **Fix B — temp dir:** portable `mktemp` + basename cleanup guard (`is_own_tmproot`) so macOS `$TMPDIR` dirs are actually reclaimed.
- **Fix C — scenario 5:** resolve the tmux session via `session show --json` (`resolve_tmux_session`), replacing a broken `list | awk /^adeck_/` parse; `|| true` so a not-found `session show` can't abort callers under `set -e`.
- **Portability:** `fake-claude.sh` no longer uses GNU-only `sleep infinity` (rejected by BSD `sleep` on macOS); side benefit — the stub stays alive, so scenarios 3/4 now actually PASS on macOS instead of skipping.
- **Robustness:** explicit `jq` preflight; `cleanup` uses `list --json` (full titles, no truncation) hardened against a null `.title`; scenarios `banner_fail`+return on a genuine `add`/`start`/`restart`/`revive` failure instead of aborting `set -e` with no banner.
- **CI:** new `unit-xplat` matrix job (ubuntu-latest + macos-latest) runs `go test ./scripts/...`; Linux jobs now install `jq`.

## Test plan
- [ ] `tests` job — `go test -run TestPersistence_ ./internal/session/... -race -count=1` green (mandate suite)
- [ ] `verify-script` job — `bash scripts/verify-session-persistence.sh` runs **end-to-end on Linux+systemd** (scenario 2 executes, not skipped) — the mandated gate that can't run on macOS
- [ ] `unit-xplat` job — `go test ./scripts/...` green on **both** ubuntu-latest and macos-latest (14 tests)
- [x] Local macOS (rebased base): scripts suite 14/14, `shellcheck` + `bash -n` clean, e2e `OVERALL: PASS` with 0 temp-dir leftovers, `TestPersistence_ -race` + `TestTmuxBootstrap` green

## Notes for reviewers
- The Linux+systemd contract (scenario 2, cgroup branch of scenario 1) is intentionally **unchanged** — verified byte-for-byte; all `TestPersistence_*` tests preserved.
- Known pre-existing, out-of-scope item (separate fix): the package's persistence/bootstrap Go suite is non-deterministic on a *constrained local sandbox* when the isolated `tmux new-session` bootstrap can't start (it fails rather than skips) — `internal/session/testmain_test.go`. It is deterministic on a clean CI runner.
- No Claude attribution; no `--no-verify` on source commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive cross-platform test suite exercising session persistence, argv classification, JSON error handling, cleanup safety, stub portability, and failure-paths.

* **Bug Fixes**
  * More reliable session resolution, scoped cleanup, and clearer PASS/FAIL behavior for start/restart/revive cases.
  * Eliminates host-wide process-scanning false positives.

* **Chores**
  * CI now requires an additional cross-platform unit job and ensures jq and tmux are installed; workflow triggers updated to run when the related test changes.

* **Documentation**
  * Stub updated to use a more portable keep-alive approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->