### PR TITLE
test(testmain): stop os.Exit skipping defer cleanups (tmux/pty leak)

### DIFF
--- a/cmd/agent-deck/testmain_test.go
+++ b/cmd/agent-deck/testmain_test.go
@@ -13,6 +13,16 @@ import (
 // accidental modification of production data.
 // CRITICAL: This was missing and caused test data to overwrite production sessions!
 func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body. It exists so the cleanup defers
+// below actually run: TestMain calls os.Exit, which does NOT run deferred
+// functions, so registering them here and returning the exit code is the only
+// way to guarantee the isolated TMUX_TMPDIR and HOME temp dirs are removed.
+// Skipping this leaked per-run temp dirs on every run — the 2026-06-07
+// pty-exhaustion incident class.
+func runTestMain(m *testing.M) int {
 	// Helper subprocesses (e.g. the Task6 XDG help-path test) are spawned by a
 	// parent test that has ALREADY exported a safe, sandboxed HOME+XDG and set
 	// the specific XDG_*_HOME values the subprocess must observe. Re-running
@@ -56,7 +66,7 @@ func TestMain(m *testing.M) {
 	// See CLAUDE.md: "2026-01-20 Incident: 20+ Test-Skip-Regen sessions orphaned, wasting ~3GB RAM"
 	cleanupTestSessions()
 
-	os.Exit(code)
+	return code
 }
 
 func isolatePackageHome(pattern string) {

--- a/internal/experiments/experiments_test.go
+++ b/internal/experiments/experiments_test.go
@@ -12,6 +12,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body so the deferred cleanup below
+// actually runs: TestMain calls os.Exit, which does NOT run deferred functions,
+// so registering the HOME-restore defer here and returning the exit code is the
+// only way to guarantee the temp dir is removed (2026-06-07 pty-exhaustion
+// incident class).
+func runTestMain(m *testing.M) int {
 	// Isolate HOME+XDG so agent-deck path resolution lands in a temp dir, never
 	// the real ~/.agent-deck (2026-06-04 data-loss incident, S5).
 	// See internal/testutil/homeenv.go for the postmortem.
@@ -28,7 +37,7 @@ func TestMain(m *testing.M) {
 	// See CLAUDE.md: "2026-01-20 Incident: 20+ Test-Skip-Regen sessions orphaned, wasting ~3GB RAM"
 	cleanupTestSessions()
 
-	os.Exit(code)
+	return code
 }
 
 // cleanupTestSessions kills any tmux sessions created during testing.

--- a/internal/feedback/testmain_test.go
+++ b/internal/feedback/testmain_test.go
@@ -8,6 +8,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body so the cleanup defers below actually
+// run: TestMain calls os.Exit, which does NOT run deferred functions, so
+// registering them here and returning the exit code is the only way to guarantee
+// the isolated TMUX_TMPDIR and HOME temp dirs are removed (2026-06-07
+// pty-exhaustion incident class).
+func runTestMain(m *testing.M) int {
 	// Isolate HOME+XDG so agent-deck path resolution lands in a temp dir, never
 	// the real ~/.agent-deck (2026-06-04 data-loss incident, S5).
 	// See internal/testutil/homeenv.go for the postmortem.
@@ -24,5 +33,5 @@ func TestMain(m *testing.M) {
 	// Force test profile to prevent production data corruption.
 	// See CLAUDE.md: "2025-12-11 Incident: Tests with AGENTDECK_PROFILE=work overwrote ALL 36 production sessions"
 	os.Setenv("AGENTDECK_PROFILE", "_test")
-	os.Exit(m.Run())
+	return m.Run()
 }

--- a/internal/git/testmain_test.go
+++ b/internal/git/testmain_test.go
@@ -8,6 +8,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body so the cleanup defers below actually
+// run: TestMain calls os.Exit, which does NOT run deferred functions, so
+// registering them here and returning the exit code is the only way to guarantee
+// the isolated TMUX_TMPDIR and HOME temp dirs are removed (2026-06-07
+// pty-exhaustion incident class).
+func runTestMain(m *testing.M) int {
 	// Isolate HOME+XDG so any agent-deck path resolution lands in a temp dir,
 	// never the real ~/.agent-deck (2026-06-04 data-loss incident, S5).
 	// See internal/testutil/homeenv.go for the postmortem.
@@ -26,5 +35,5 @@ func TestMain(m *testing.M) {
 	cleanupTmux := testutil.IsolateTmuxSocket()
 	defer cleanupTmux()
 
-	os.Exit(m.Run())
+	return m.Run()
 }

--- a/internal/integration/testmain_test.go
+++ b/internal/integration/testmain_test.go
@@ -10,6 +10,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body so the cleanup defers below actually
+// run: TestMain calls os.Exit, which does NOT run deferred functions, so
+// registering them here and returning the exit code is the only way to guarantee
+// the isolated TMUX_TMPDIR and HOME temp dirs are removed (2026-06-07
+// pty-exhaustion incident class).
+func runTestMain(m *testing.M) int {
 	// Isolate HOME+XDG so agent-deck path resolution lands in a temp dir, never
 	// the real ~/.agent-deck (2026-06-04 data-loss incident, S5).
 	// See internal/testutil/homeenv.go for the postmortem.
@@ -35,7 +44,7 @@ func TestMain(m *testing.M) {
 	// Cleanup: Kill any orphaned integration test sessions after tests complete.
 	cleanupIntegrationSessions()
 
-	os.Exit(code)
+	return code
 }
 
 // cleanupIntegrationSessions kills tmux sessions with the integration test prefix.

--- a/internal/pathsafety/guard_test.go
+++ b/internal/pathsafety/guard_test.go
@@ -27,13 +27,21 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body so the deferred HOME-restore below
+// actually runs: TestMain calls os.Exit, which does NOT run deferred functions,
+// so registering the defer here and returning the exit code is the only way to
+// guarantee the temp dir is removed (2026-06-07 pty-exhaustion incident class).
+func runTestMain(m *testing.M) int {
 	// This package's OWN tests must be sandboxed too — IsolateHome points
 	// HOME+XDG at a temp dir. The guard below then proves the sandbox is real
 	// by comparing resolved paths against the OS-level real home (read from
 	// the user database, which IsolateHome does NOT touch).
 	cleanupHome := testutil.IsolateHome()
 	defer cleanupHome()
-	os.Exit(m.Run())
+	return m.Run()
 }
 
 // realHome returns the developer's actual home directory, independent of the

--- a/internal/session/testmain_test.go
+++ b/internal/session/testmain_test.go
@@ -126,6 +126,16 @@ func skipIfNoClaudeBinary(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body. It exists so the cleanup defers
+// below actually run: TestMain calls os.Exit, which does NOT run deferred
+// functions, so registering them here and returning the exit code is the only
+// way to guarantee the bootstrap tmux server is killed and the isolated
+// TMUX_TMPDIR is removed. Skipping this leaked a tmux server (1 pty) on every
+// run — the 2026-06-07 pty-exhaustion incident.
+func runTestMain(m *testing.M) int {
 	// Isolate HOME+XDG FIRST so every path this package resolves (config.json,
 	// profiles/<p>/state.db, worker-scratch, logs) lands in a temp dir, never
 	// the real ~/.agent-deck (2026-06-04 data-loss incident, S5).
@@ -167,7 +177,7 @@ func TestMain(m *testing.M) {
 	// See CLAUDE.md: "2026-01-20 Incident: 20+ Test-Skip-Regen sessions orphaned, wasting ~3GB RAM"
 	cleanupTestSessions()
 
-	os.Exit(code)
+	return code
 }
 
 func isolatePackageHome(pattern string) {

--- a/internal/testutil/bootstrap_leak_sentinel_test.go
+++ b/internal/testutil/bootstrap_leak_sentinel_test.go
@@ -1,0 +1,135 @@
+package testutil_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestTestMainDoesNotLeakBootstrapServer is the behavioral guard for the
+// 2026-06-07 macOS pty-exhaustion incident.
+//
+// internal/tmux and internal/session TestMains bootstrap a detached tmux server
+// (a `sleep 3600` pane = one pty) so `tmux list-sessions` succeeds for the
+// lifetime of the test binary, and register `defer kill-server` to tear it down.
+// Because those TestMains ended in os.Exit(code), the defer never ran — os.Exit
+// does not run deferred functions — so EVERY `go test` of those packages leaked
+// the server. Accumulated across runs this exhausted the pty pool
+// (kern.tty.ptmx_max=511) and denied new terminals.
+//
+// A pure unit test of the cleanup function cannot catch this: calling cleanup()
+// directly passes green while the real exit path still leaks (the "unit green,
+// reality broken" trap). This test instead spawns the REAL package TestMain as a
+// child process and asserts that no bootstrap server survives on the isolated
+// socket it created. -count=1 forces the child to actually run; a cached result
+// would execute no TestMain and leak nothing, passing falsely.
+func TestTestMainDoesNotLeakBootstrapServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns child `go test`; skipped in -short")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not on PATH")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not on PATH")
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed — cannot locate repo root")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+
+	// Both packages call bootstrapTmuxServer() and both define the fast
+	// TestTmuxBootstrap_ServerIsRunning test, which still drives the full
+	// TestMain exit path.
+	for _, pkg := range []string{"./internal/tmux/", "./internal/session/"} {
+		pkg := pkg
+		t.Run(pkg, func(t *testing.T) {
+			before := snapshotADTmuxDirs()
+
+			cmd := exec.Command("go", "test", "-count=1",
+				"-run", "TestTmuxBootstrap_ServerIsRunning", pkg)
+			cmd.Dir = repoRoot
+			cmd.Env = os.Environ()
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("child `go test %s` failed: %v\n%s", pkg, err, out)
+			}
+
+			// CombinedOutput has returned, so the child test binary has fully
+			// exited. The bootstrap tmux server is a separate daemon: if the
+			// kill-server defer ran it is gone; if os.Exit skipped it, it is
+			// still alive on its isolated socket.
+			newDirs := diffDirs(before, snapshotADTmuxDirs())
+
+			var leaked []string
+			for _, dir := range newDirs {
+				for _, sock := range socketsUnder(dir) {
+					out, err := exec.Command("tmux", "-S", sock,
+						"list-sessions", "-F", "#{session_name}").Output()
+					if err != nil {
+						continue // server already gone — not a leak
+					}
+					if strings.Contains(string(out), "bootstrap") {
+						leaked = append(leaked, sock)
+						// Never let the guard itself leak: tear down what we found.
+						_ = exec.Command("tmux", "-S", sock, "kill-server").Run()
+					}
+				}
+			}
+			if len(leaked) > 0 {
+				t.Fatalf("%s leaked %d bootstrap tmux server(s) that survived TestMain "+
+					"exit (os.Exit skipped the kill-server defer): %s\n\n"+
+					"Fix: route TestMain through "+
+					"`func runTestMain(m *testing.M) int { defer cleanup(); return m.Run() }` "+
+					"so the cleanup defers actually run.",
+					pkg, len(leaked), strings.Join(leaked, ", "))
+			}
+		})
+	}
+}
+
+// adTmuxBases returns the candidate base dirs where IsolateTmuxSocket creates
+// its per-run TMUX_TMPDIR (shortTmuxTmpBase prefers /tmp, else os.TempDir()).
+func adTmuxBases() []string {
+	bases := map[string]struct{}{"/tmp": {}, os.TempDir(): {}}
+	out := make([]string, 0, len(bases))
+	for b := range bases {
+		out = append(out, b)
+	}
+	return out
+}
+
+// snapshotADTmuxDirs returns the set of existing ad-tmux-* dirs across the
+// candidate bases.
+func snapshotADTmuxDirs() map[string]struct{} {
+	set := map[string]struct{}{}
+	for _, base := range adTmuxBases() {
+		matches, _ := filepath.Glob(filepath.Join(base, "ad-tmux-*"))
+		for _, m := range matches {
+			set[m] = struct{}{}
+		}
+	}
+	return set
+}
+
+// diffDirs returns dirs present in after but not before.
+func diffDirs(before, after map[string]struct{}) []string {
+	var out []string
+	for d := range after {
+		if _, seen := before[d]; !seen {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// socketsUnder returns the tmux socket paths a server would bind under an
+// isolated TMUX_TMPDIR: <dir>/tmux-<uid>/<sock>.
+func socketsUnder(dir string) []string {
+	matches, _ := filepath.Glob(filepath.Join(dir, "tmux-*", "*"))
+	return matches
+}

--- a/internal/testutil/bootstrap_leak_sentinel_test.go
+++ b/internal/testutil/bootstrap_leak_sentinel_test.go
@@ -1,12 +1,14 @@
 package testutil_test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestTestMainDoesNotLeakBootstrapServer is the behavioral guard for the
@@ -51,11 +53,22 @@ func TestTestMainDoesNotLeakBootstrapServer(t *testing.T) {
 		t.Run(pkg, func(t *testing.T) {
 			before := snapshotADTmuxDirs()
 
-			cmd := exec.Command("go", "test", "-count=1",
+			// Bound the child run so a hung child (e.g. a stalled tmux call)
+			// fails this guard with a clear message instead of pinning the
+			// whole suite until the parent `go test` timeout. -timeout makes
+			// the child itself fail fast; the context is the outer backstop
+			// (it also covers the one-time compile).
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "go", "test", "-count=1", "-timeout", "60s",
 				"-run", "TestTmuxBootstrap_ServerIsRunning", pkg)
 			cmd.Dir = repoRoot
 			cmd.Env = os.Environ()
-			if out, err := cmd.CombinedOutput(); err != nil {
+			out, err := cmd.CombinedOutput()
+			if ctx.Err() == context.DeadlineExceeded {
+				t.Fatalf("child `go test %s` did not finish within 2m (hung?); output:\n%s", pkg, out)
+			}
+			if err != nil {
 				t.Fatalf("child `go test %s` failed: %v\n%s", pkg, err, out)
 			}
 
@@ -65,18 +78,30 @@ func TestTestMainDoesNotLeakBootstrapServer(t *testing.T) {
 			// still alive on its isolated socket.
 			newDirs := diffDirs(before, snapshotADTmuxDirs())
 
+			// Defense-in-depth: strip TMUX/TMUX_PANE from the probe/kill calls.
+			// `-S <path>` already pins the socket (verified: it is NOT overridden
+			// by an ambient $TMUX, unlike the bare/`-L` discovery documented in
+			// tmuxenv.go), but `go test` is routinely run from inside a tmux pane,
+			// so we belt-and-suspender against any tmux-version edge case ever
+			// letting these calls touch the developer's live server.
+			probeEnv := envWithoutTmux()
+
 			var leaked []string
 			for _, dir := range newDirs {
 				for _, sock := range socketsUnder(dir) {
-					out, err := exec.Command("tmux", "-S", sock,
-						"list-sessions", "-F", "#{session_name}").Output()
+					list := exec.Command("tmux", "-S", sock,
+						"list-sessions", "-F", "#{session_name}")
+					list.Env = probeEnv
+					out, err := list.Output()
 					if err != nil {
 						continue // server already gone — not a leak
 					}
 					if strings.Contains(string(out), "bootstrap") {
 						leaked = append(leaked, sock)
 						// Never let the guard itself leak: tear down what we found.
-						_ = exec.Command("tmux", "-S", sock, "kill-server").Run()
+						kill := exec.Command("tmux", "-S", sock, "kill-server")
+						kill.Env = probeEnv
+						_ = kill.Run()
 					}
 				}
 			}
@@ -90,6 +115,21 @@ func TestTestMainDoesNotLeakBootstrapServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// envWithoutTmux returns os.Environ() with TMUX and TMUX_PANE removed, mirroring
+// what testutil.IsolateTmuxSocket does so socket-scoped tmux calls can never be
+// influenced by an ambient tmux client.
+func envWithoutTmux() []string {
+	env := os.Environ()
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "TMUX=") || strings.HasPrefix(kv, "TMUX_PANE=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
 }
 
 // adTmuxBases returns the candidate base dirs where IsolateTmuxSocket creates

--- a/internal/testutil/testmain_audit_test.go
+++ b/internal/testutil/testmain_audit_test.go
@@ -1,6 +1,9 @@
 package testutil_test
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -95,4 +98,112 @@ func TestAllTestMainsIsolateTmuxSocket(t *testing.T) {
 			strings.Join(homeOffenders, "\n  - "),
 		)
 	}
+}
+
+// TestNoTestMainLeaksCleanupBehindOsExit guards the 2026-06-07 pty-exhaustion
+// incident. A package TestMain that registers `defer cleanup()` (e.g.
+// bootstrapTmuxServer's kill-server, IsolateTmuxSocket's RemoveAll, IsolateHome's
+// restore) and then ends with os.Exit(code) leaks on every run: os.Exit does NOT
+// run deferred functions, so the bootstrap tmux server (holding a pty) and the
+// per-run ad-tmux-*/home temp dirs survive the test binary. Accumulated across
+// runs this exhausted the macOS pty pool (kern.tty.ptmx_max=511) and denied new
+// terminals.
+//
+// This audit parses every *_test.go, finds the TestMain FuncDecl, and fails when
+// its OWN body contains both a defer statement and an os.Exit call — the
+// defer-never-runs anti-pattern. The required fix moves the defers into a
+// separate function so they actually run:
+//
+//	func TestMain(m *testing.M) { os.Exit(runTestMain(m)) }
+//	func runTestMain(m *testing.M) int {
+//	    cleanup := testutil.IsolateTmuxSocket(); defer cleanup()
+//	    return m.Run()
+//	}
+//
+// After that refactor TestMain's body holds only os.Exit(runTestMain(m)) with no
+// defer, so it passes.
+func TestNoTestMainLeaksCleanupBehindOsExit(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed — cannot locate repo root")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+
+	var offenders []string
+	err := filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".claude", ".worktrees", ".planning", "vendor", "node_modules", "testdata":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		for _, decl := range file.Decls {
+			fn, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || fn.Name.Name != "TestMain" || fn.Body == nil {
+				continue
+			}
+			if testMainBodyDefersBehindOsExit(fn.Body) {
+				rel, _ := filepath.Rel(repoRoot, path)
+				offenders = append(offenders, rel)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo root %q: %v", repoRoot, err)
+	}
+
+	if len(offenders) > 0 {
+		t.Fatalf(
+			"The following TestMain functions register a `defer` AND call os.Exit() in the "+
+				"same body. os.Exit does not run deferred functions, so cleanups (tmux "+
+				"kill-server, RemoveAll of the isolated TMUX_TMPDIR, HOME restore) NEVER run "+
+				"— leaking a tmux server (1 pty) and temp dirs on every test run. This is the "+
+				"2026-06-07 macOS pty-exhaustion incident.\n\n"+
+				"Offending files:\n  - %s\n\n"+
+				"Fix: move setup+defers into `func runTestMain(m *testing.M) int { ... return "+
+				"m.Run() }` and make TestMain `os.Exit(runTestMain(m))`. See the pattern in "+
+				"internal/tmux/testmain_test.go.",
+			strings.Join(offenders, "\n  - "),
+		)
+	}
+}
+
+// testMainBodyDefersBehindOsExit reports whether a TestMain body contains both a
+// defer statement and a call to os.Exit(...). Either alone is fine; together they
+// are the leak anti-pattern, because os.Exit skips deferred functions. Nested
+// function literals are ignored — a defer inside a closure is unrelated to the
+// TestMain-level exit path.
+func testMainBodyDefersBehindOsExit(body *ast.BlockStmt) bool {
+	var hasDefer, hasOsExit bool
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.FuncLit:
+			// Don't descend into closures; their defers run when the closure
+			// returns, independent of os.Exit.
+			return false
+		case *ast.DeferStmt:
+			hasDefer = true
+		case *ast.CallExpr:
+			if sel, ok := node.Fun.(*ast.SelectorExpr); ok {
+				if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "os" && sel.Sel.Name == "Exit" {
+					hasOsExit = true
+				}
+			}
+		}
+		return true
+	})
+	return hasDefer && hasOsExit
 }

--- a/internal/testutil/testmain_audit_test.go
+++ b/internal/testutil/testmain_audit_test.go
@@ -144,8 +144,20 @@ func TestNoTestMainLeaksCleanupBehindOsExit(t *testing.T) {
 		if !strings.HasSuffix(d.Name(), "_test.go") {
 			return nil
 		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		// Cheap prefilter: only the handful of files that define TestMain need
+		// AST parsing. This keeps full-repo coverage (TestMain also lives in
+		// tests/ and in non-testmain_test.go files like experiments_test.go and
+		// guard_test.go, so we can't restrict by directory or filename) while
+		// avoiding the cost of parsing every *_test.go in the repo.
+		if !strings.Contains(string(data), "func TestMain") {
+			return nil
+		}
 		fset := token.NewFileSet()
-		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		file, parseErr := parser.ParseFile(fset, path, data, 0)
 		if parseErr != nil {
 			return parseErr
 		}

--- a/internal/tmux/testmain_test.go
+++ b/internal/tmux/testmain_test.go
@@ -79,6 +79,16 @@ func TestMain(m *testing.M) {
 		return
 	}
 
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body. It exists so the cleanup defers
+// below actually run: TestMain calls os.Exit, which does NOT run deferred
+// functions, so registering them here and returning the exit code is the only
+// way to guarantee the bootstrap tmux server is killed and the isolated
+// TMUX_TMPDIR is removed. Skipping this leaked a tmux server (1 pty) on every
+// run — the 2026-06-07 pty-exhaustion incident.
+func runTestMain(m *testing.M) int {
 	// Isolate HOME+XDG so agent-deck path resolution lands in a temp dir, never
 	// the real ~/.agent-deck (2026-06-04 data-loss incident, S5). Placed after
 	// the child-helper guards above (those re-exec as subprocess tools and must
@@ -97,7 +107,9 @@ func TestMain(m *testing.M) {
 
 	// Bootstrap an idle tmux server in the isolated socket so the tests that
 	// depend on `tmux list-sessions` succeeding (#618 cleanup-attach OSC,
-	// etc.) actively run rather than silent-skipping on cold-boot.
+	// etc.) actively run rather than silent-skipping on cold-boot. Registered
+	// last so its kill-server defer runs FIRST — while TMUX_TMPDIR still points
+	// at the isolated socket, before cleanupTmux restores the env.
 	cleanupBootstrap := bootstrapTmuxServer()
 	defer cleanupBootstrap()
 
@@ -112,7 +124,7 @@ func TestMain(m *testing.M) {
 	// See CLAUDE.md: "2026-01-20 Incident: 20+ Test-Skip-Regen sessions orphaned, wasting ~3GB RAM"
 	cleanupTestSessions()
 
-	os.Exit(code)
+	return code
 }
 
 // cleanupTestSessions kills any tmux sessions created during testing.

--- a/internal/tuitest/testmain_test.go
+++ b/internal/tuitest/testmain_test.go
@@ -13,6 +13,15 @@ import (
 // accidental modification of production session data.
 // See CLAUDE.md: "Never delete these TestMain files."
 func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body so the cleanup defers below actually
+// run: TestMain calls os.Exit, which does NOT run deferred functions, so
+// registering them here and returning the exit code is the only way to guarantee
+// the isolated TMUX_TMPDIR and HOME temp dirs are removed (2026-06-07
+// pty-exhaustion incident class).
+func runTestMain(m *testing.M) int {
 	// Isolate HOME+XDG so agent-deck path resolution lands in a temp dir, never
 	// the real ~/.agent-deck (2026-06-04 data-loss incident, S5).
 	// See internal/testutil/homeenv.go for the postmortem.
@@ -32,7 +41,7 @@ func TestMain(m *testing.M) {
 
 	cleanupTestSessions()
 
-	os.Exit(code)
+	return code
 }
 
 // cleanupTestSessions kills tmux sessions created by smoke tests.

--- a/internal/ui/testmain_test.go
+++ b/internal/ui/testmain_test.go
@@ -13,6 +13,15 @@ import (
 // accidental modification of production data.
 // CRITICAL: This was missing and caused test data to overwrite production sessions!
 func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body so the cleanup defers below actually
+// run: TestMain calls os.Exit, which does NOT run deferred functions, so
+// registering them here and returning the exit code is the only way to guarantee
+// the isolated TMUX_TMPDIR and HOME temp dirs are removed (2026-06-07
+// pty-exhaustion incident class).
+func runTestMain(m *testing.M) int {
 	// Isolate HOME+XDG FIRST. This package was the concrete trigger of the
 	// 2026-06-04 data-loss incident (S5): it set AGENTDECK_PROFILE=_test but did
 	// NOT override HOME/XDG, so an un-sandboxed `go test ./internal/ui/...`
@@ -46,7 +55,7 @@ func TestMain(m *testing.M) {
 	// See CLAUDE.md: "2026-01-20 Incident: 20+ Test-Skip-Regen sessions orphaned, wasting ~3GB RAM"
 	cleanupTestSessions()
 
-	os.Exit(code)
+	return code
 }
 
 // cleanupTestSessions kills any tmux sessions created during testing.

--- a/internal/web/testmain_test.go
+++ b/internal/web/testmain_test.go
@@ -12,6 +12,15 @@ import (
 // running under the active production profile and corrupting session data.
 // CRITICAL: Do not remove — see CLAUDE.md test isolation rules.
 func TestMain(m *testing.M) {
+	os.Exit(runTestMain(m))
+}
+
+// runTestMain holds the real TestMain body so the cleanup defers below actually
+// run: TestMain calls os.Exit, which does NOT run deferred functions, so
+// registering them here and returning the exit code is the only way to guarantee
+// the isolated TMUX_TMPDIR and HOME temp dirs are removed (2026-06-07
+// pty-exhaustion incident class).
+func runTestMain(m *testing.M) int {
 	// Isolate HOME+XDG so agent-deck path resolution lands in a temp dir, never
 	// the real ~/.agent-deck (2026-06-04 data-loss incident, S5).
 	// See internal/testutil/homeenv.go for the postmortem.
@@ -26,5 +35,5 @@ func TestMain(m *testing.M) {
 	defer cleanupTmux()
 
 	os.Setenv("AGENTDECK_PROFILE", "_test")
-	os.Exit(m.Run())
+	return m.Run()
 }


### PR DESCRIPTION
## Why — what motivated this

On a developer machine, terminals suddenly stopped launching:

```
openpty failed: ENXIO: No such device or address        (Warp)
Your system cannot allocate any more pty devices …        (Ghostty)
```

macOS allocates pseudo-terminals from a fixed kernel pool:

```
$ sysctl kern.tty.ptmx_max
kern.tty.ptmx_max: 511
```

At the time of the incident there were **527** pty device nodes — already past the cap — so *every* `openpty()` from *any* app failed until ptys were freed. The pool was held by **~158 leaked `tmux` processes**, and tracing them showed they all came from **agent-deck's own test suite**: each held a `sleep 3600` pane on an isolated socket, with session names `agent-deck-test-bootstrap` / `agent-deck-tmux-test-bootstrap`. They had been quietly accumulating for *weeks* (oldest processes were 50+ days old).

In short: **running `go test` on this repo slowly leaks pty handles, and on a long-lived machine that eventually exhausts the OS pty pool and blocks all new terminals.** This PR fixes the leak at the source and adds guards so it can't come back silently.

## What was actually wrong

The `agent-deck-*-bootstrap` sessions are created *only* by test code — `bootstrapTmuxServer()` in the `internal/session` and `internal/tmux` `TestMain`s (the names live in `_test.go`, so the production binary can't create them). Each affected `TestMain` did this:

```go
func TestMain(m *testing.M) {
    cleanupTmux := testutil.IsolateTmuxSocket(); defer cleanupTmux()
    cleanupBootstrap := bootstrapTmuxServer();   defer cleanupBootstrap() // kill-server
    code := m.Run()
    os.Exit(code)   // <-- bug
}
```

**`os.Exit` does not run deferred functions.** So `cleanupBootstrap()` (the `kill-server`) and `cleanupTmux()` (the socket-dir `RemoveAll`) never ran. Every `go test` of those packages leaked one detached tmux server (a `sleep 3600` pane = **1 pty**) plus its temp dir. The same `os.Exit`-skips-`defer` pattern existed in **11** package `TestMain`s.

Reproduced before fixing: one *passing* run of `./internal/tmux/` left a live `agent-deck-tmux-test-bootstrap` server on a fresh `ad-tmux-*` socket; the machine had **767** accumulated `ad-tmux-*` skeleton dirs, **26** still holding live servers. (Corroborating the diagnosis: those leftover dirs are exactly `IsolateTmuxSocket`'s `MkdirTemp("ad-tmux-")` dirs whose `RemoveAll` defer never ran.)

## How it's fixed

Route each `TestMain` through a helper that returns the code so the defers actually run, preserving defer order (so `kill-server` runs while `TMUX_TMPDIR` is still isolated, before the env is restored):

```go
func TestMain(m *testing.M) { os.Exit(runTestMain(m)) }

func runTestMain(m *testing.M) int {
    cleanupTmux := testutil.IsolateTmuxSocket(); defer cleanupTmux()
    cleanupBootstrap := bootstrapTmuxServer();   defer cleanupBootstrap()
    return m.Run()   // defers now fire on return
}
```

Applied to all 11: `session`, `tmux`, `cmd/agent-deck`, `ui`, `integration`, `tuitest`, `experiments`, `feedback`, `git`, `pathsafety`, `web`. **Production code is untouched** — this is a test-infrastructure fix.

## What guards it from regressing

Two defensive tests, both verified RED before the fix and GREEN after:

- **AST audit** (`internal/testutil/testmain_audit_test.go`) — fails if any `TestMain` body contains both a `defer` and an `os.Exit` call. Func-scoped AST (not a regex), so it doesn't false-positive on the fix and catches the same class in any future `TestMain`.
- **Behavioral sentinel** (`internal/testutil/bootstrap_leak_sentinel_test.go`) — spawns the *real* `internal/tmux` and `internal/session` `TestMain` as a child process (`-count=1`) and asserts no bootstrap server survives exit. This is the key test: a unit test that just calls the cleanup function would pass green *with the bug present* — only driving the real exit path proves the cleanup is actually called.

## Scope (deliberately limited)

This fixes the dominant, every-run leak. Two related items are intentionally out of scope:

- **`agentdeck_launch-*` leaks** — cleanup there is already correct; it only leaks when a test process is hard-killed (timeout / Ctrl-C), which skips `t.Cleanup`. No useful guard exists (each run gets a fresh empty isolated socket dir and structurally can't see prior runs' debris).
- **Orphaned eval `agent-deck` binaries** — deferred pending a confirmed reproduction; a "kill the process group" hardening would pass vacuously without one.

## Test plan
- [x] AST audit + behavioral sentinel: RED before fix, GREEN after (`go test ./internal/testutil/`, incl. `-race`)
- [x] All 11 changed packages pass
- [x] Session-persistence gate: `go test -run TestPersistence_ ./internal/session/... -race -count=1`
- [x] Feedback gate: `go test ./internal/feedback/... ./internal/ui/... ./cmd/agent-deck/... -run "Feedback|Sender_" -race -count=1`
- [x] `go vet` + `go build ./...` clean; end-to-end recheck shows zero new `ad-tmux-*` dirs and zero leaked servers post-fix
- [ ] `bash scripts/verify-session-persistence.sh` on a Linux+systemd host (mandated for `internal/tmux/**` + `internal/session` changes; **not runnable on darwin** — needs a maintainer run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed test cleanup operations not executing properly before process termination, preventing resource leaks.
  * Added validation tests to detect and prevent future cleanup issues.

* **Tests**
  * Refactored test initialization patterns across the test suite to ensure proper cleanup of temporary environments and external services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->