### PR TITLE
fix: reset gg-detection timer when group dialog closes

### DIFF
--- a/internal/ui/group_dialog_reopen_test.go
+++ b/internal/ui/group_dialog_reopen_test.go
@@ -1,0 +1,76 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestGroupDialogReopensAfterClose is a regression guard for the gg-detection
+// collision: pressing the create-group key ('g') arms the Vi-style "gg"
+// double-tap timer. After the dialog closes, a second 'g' pressed within the
+// 500ms window used to be swallowed as a gg-jump-to-top instead of reopening
+// the dialog — so the group appeared to need a "second try" to create.
+//
+// The two key presses in this test are microseconds apart (well inside the
+// 500ms window), so without the lastGTime reset on close the second press
+// jumps to top and the dialog stays hidden.
+func TestGroupDialogReopensAfterClose(t *testing.T) {
+	pressG := func(h *Home) *Home {
+		model, _ := h.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+		h2, ok := model.(*Home)
+		if !ok {
+			t.Fatal("handleMainKey should return *Home")
+		}
+		return h2
+	}
+
+	for _, tc := range []struct {
+		name  string
+		close func(h *Home) *Home
+	}{
+		{
+			name: "after esc cancel",
+			close: func(h *Home) *Home {
+				model, _ := h.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEsc})
+				return model.(*Home)
+			},
+		},
+		{
+			name: "after enter create",
+			close: func(h *Home) *Home {
+				h.groupDialog.nameInput.SetValue("alpha")
+				model, _ := h.handleGroupDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+				return model.(*Home)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHome()
+			h.width, h.height = 100, 30
+			h.groupTree = session.NewGroupTree([]*session.Instance{})
+			h.rebuildFlatItems()
+
+			// First 'g' opens the dialog and arms the gg timer.
+			h = pressG(h)
+			if !h.groupDialog.IsVisible() {
+				t.Fatal("first 'g' should open the group dialog")
+			}
+
+			// Close it (esc or enter).
+			h = tc.close(h)
+			if h.groupDialog.IsVisible() {
+				t.Fatal("dialog should be hidden after close")
+			}
+
+			// Second 'g', microseconds later, must reopen the dialog — NOT be
+			// eaten as a gg-jump-to-top.
+			h = pressG(h)
+			if !h.groupDialog.IsVisible() {
+				t.Error("second 'g' right after close should reopen the dialog, not jump to top")
+			}
+		})
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8595,10 +8595,12 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 		h.groupDialog.Hide()
+		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
 		return h, nil
 	case "esc":
 		h.groupDialog.Hide()
-		h.clearError() // Clear any validation error
+		h.clearError()            // Clear any validation error
+		h.lastGTime = time.Time{} // Reset gg-detection so next 'g' opens dialog, not jump-to-top
 		return h, nil
 	}
 


### PR DESCRIPTION
## Problem

Creating a root group with the `g` shortcut appears to require a **second press** — the first `g` after a prior group interaction does nothing visible. Most reproducible as: press `g` → `Esc` → `g` (the second `g` is swallowed).

## Root cause

The `g` key is overloaded. It opens the group-creation dialog **and** arms the Vi-style `gg` double-tap timer (`lastGTime`, `home.go:6878`). When the dialog closed, `lastGTime` was left armed, so a `g` pressed within the 500 ms window was interpreted as `gg` (jump-to-top) instead of reopening the dialog.

## Fix

Zero out `lastGTime` when the group dialog closes (both the `enter` and `esc` paths in `handleGroupDialogKey`) so the next `g` always opens a fresh dialog.

## Tests

Adds `TestGroupDialogReopensAfterClose`, covering both close paths. The two key presses are microseconds apart (inside the 500 ms window), so the test fails without the reset and passes with it.

- `go build ./...`, `go vet ./internal/ui/`, `gofmt -l` — clean
- New regression test passes

## Note (out of scope)

Because the first `g` always opens the dialog, the documented `gg → jump to top` (`help.go:217`) is effectively unreachable in normal use today — the second `g` is captured by the dialog. This PR removes the harmful side-effect; making `gg` actually work would require decoupling the create-group binding and is left for a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed group dialog reopening behavior after closure. The group shortcut now correctly reopens the dialog when pressed shortly after closing it, instead of triggering alternate commands.

* **Tests**
  * Added regression test to verify group dialog reopens properly after being dismissed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->