### PR TITLE
fix(config): preserve symlinked Claude config files on atomic write

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -60,17 +60,51 @@ func resolveTarget(path string) (string, error) {
 	// (including intermediate symlinked directories) when the target exists.
 	if resolved, evalErr := filepath.EvalSymlinks(path); evalErr == nil {
 		return resolved, nil
+	} else if !os.IsNotExist(evalErr) {
+		// A non-"not exist" failure (symlink loop / ELOOP, permission, ...) must
+		// NOT fall through to a write that could clobber a link. Refuse instead.
+		return "", fmt.Errorf("atomicfile: resolve symlink %s: %w", path, evalErr)
 	}
-	// Dangling symlink (target does not exist yet): resolve the raw link value
-	// relative to the link's own directory.
-	link, err := os.Readlink(path)
-	if err != nil {
-		return "", fmt.Errorf("atomicfile: readlink %s: %w", path, err)
+	// Dangling chain: the chain ends at a missing leaf. Walk it hop-by-hop to
+	// that leaf so the write lands past every symlink — a single Readlink would
+	// stop at an intermediate link and the rename would clobber it.
+	return resolveDanglingLeaf(path)
+}
+
+// resolveDanglingLeaf walks a chain of symlinks whose final target does not yet
+// exist, following each hop (relative links resolved against the link's own
+// directory) until it reaches a non-symlink or a missing leaf. It refuses
+// symlink loops rather than clobbering a link.
+func resolveDanglingLeaf(path string) (string, error) {
+	const maxHops = 40
+	current := path
+	visited := make(map[string]bool, maxHops)
+	for hop := 0; hop < maxHops; hop++ {
+		info, err := os.Lstat(current)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return current, nil // missing leaf — safe to create here
+			}
+			return "", fmt.Errorf("atomicfile: lstat %s: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return current, nil // real non-symlink leaf
+		}
+		if visited[current] {
+			return "", fmt.Errorf("atomicfile: symlink loop at %s", current)
+		}
+		visited[current] = true
+
+		next, err := os.Readlink(current)
+		if err != nil {
+			return "", fmt.Errorf("atomicfile: readlink %s: %w", current, err)
+		}
+		if !filepath.IsAbs(next) {
+			next = filepath.Join(filepath.Dir(current), next)
+		}
+		current = next
 	}
-	if !filepath.IsAbs(link) {
-		link = filepath.Join(filepath.Dir(path), link)
-	}
-	return link, nil
+	return "", fmt.Errorf("atomicfile: too many symlink hops resolving %s", path)
 }
 
 // writeAtomic writes data to target via a uniquely-named temp file in target's

--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,117 @@
+// Package atomicfile provides symlink-preserving atomic file writes for
+// user-managed config files.
+//
+// WriteFile writes to a temp file in the destination's directory and renames it
+// into place. When the destination path is a symlink, the real target is
+// resolved first and the write lands on that target, so the symlink itself is
+// preserved — a dotfiles-managed ~/.claude/settings.json stays a symlink.
+//
+// This is the OPPOSITE of the intentional behavior in
+// internal/credrefresh.atomicWriteFile, internal/session.atomicWriteFile
+// (worker_scratch.go), and internal/session.writeFileDurable (inbox.go), which
+// replace a symlink at the path with a regular file. Those helpers target
+// agent-deck's own internal state and must not be consolidated here.
+//
+// The package imports only the standard library so any internal package can
+// depend on it without import cycles.
+package atomicfile
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// WriteFile atomically writes data to path, preserving a symlink AT path. If
+// path is a symlink, the write targets the resolved real file and the link is
+// left intact. For a regular or new file it behaves like a temp-file + rename.
+// perm is applied to the written file.
+//
+// Writing across filesystems via a symlink is unsupported: os.Rename cannot
+// cross filesystems, so a symlink whose target lives on a different filesystem
+// than the link returns an explicit error rather than silently falling back to
+// a non-atomic write.
+func WriteFile(path string, data []byte, perm os.FileMode) error {
+	target, err := resolveTarget(path)
+	if err != nil {
+		return err
+	}
+	return writeAtomic(target, data, perm)
+}
+
+// resolveTarget returns the real file path that should be written. For a regular
+// or non-existent path it returns the path unchanged. For a symlink it returns
+// the resolved target so the link is preserved by a later rename onto the
+// target (rename onto the link itself would replace the link).
+func resolveTarget(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return path, nil
+		}
+		return "", fmt.Errorf("atomicfile: lstat %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return path, nil
+	}
+	// Symlink: resolve to the real target. EvalSymlinks follows the full chain
+	// (including intermediate symlinked directories) when the target exists.
+	if resolved, evalErr := filepath.EvalSymlinks(path); evalErr == nil {
+		return resolved, nil
+	}
+	// Dangling symlink (target does not exist yet): resolve the raw link value
+	// relative to the link's own directory.
+	link, err := os.Readlink(path)
+	if err != nil {
+		return "", fmt.Errorf("atomicfile: readlink %s: %w", path, err)
+	}
+	if !filepath.IsAbs(link) {
+		link = filepath.Join(filepath.Dir(path), link)
+	}
+	return link, nil
+}
+
+// writeAtomic writes data to target via a uniquely-named temp file in target's
+// directory, then renames it onto target. The temp lives in the target's
+// directory so the rename stays on one filesystem.
+func writeAtomic(target string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(target)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("atomicfile: mkdir %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".atomicfile-*")
+	if err != nil {
+		return fmt.Errorf("atomicfile: create temp in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("atomicfile: chmod temp: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("atomicfile: write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("atomicfile: close temp: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, target); err != nil {
+		if errors.Is(err, syscall.EXDEV) {
+			return fmt.Errorf("atomicfile: cross-filesystem symlink not supported for %s: %w", target, err)
+		}
+		return fmt.Errorf("atomicfile: rename to %s: %w", target, err)
+	}
+	committed = true
+	return nil
+}

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -211,6 +211,42 @@ func TestWriteFile_SymlinkLoop(t *testing.T) {
 	}
 }
 
+func TestWriteFile_RelativeDanglingChain(t *testing.T) {
+	dir := t.TempDir()
+	leaf := filepath.Join(dir, "leaf.json") // missing target
+	mid := filepath.Join(dir, "mid.json")
+	top := filepath.Join(dir, "top.json")
+	// Relative link values, resolved against each link's own directory — the
+	// common dotfiles-manager shape (e.g. GNU Stow).
+	if err := os.Symlink("leaf.json", mid); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("mid.json", top); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicfile.WriteFile(top, []byte("relative"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	for _, l := range []string{top, mid} {
+		fi, err := os.Lstat(l)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("%s was clobbered into a regular file", l)
+		}
+	}
+	got, err := os.ReadFile(leaf)
+	if err != nil {
+		t.Fatalf("leaf not created: %v", err)
+	}
+	if string(got) != "relative" {
+		t.Fatalf("data = %q, want %q", got, "relative")
+	}
+}
+
 func TestWriteFile_NoTempLeftBehind(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.json")

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -149,6 +149,68 @@ func TestWriteFile_DanglingSymlink(t *testing.T) {
 	}
 }
 
+func TestWriteFile_MultiHopDanglingChain(t *testing.T) {
+	dir := t.TempDir()
+	leaf := filepath.Join(dir, "leaf.json") // missing target
+	mid := filepath.Join(dir, "mid.json")
+	top := filepath.Join(dir, "top.json")
+	if err := os.Symlink(leaf, mid); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(mid, top); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicfile.WriteFile(top, []byte("multi"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Both intermediate links must survive — the write must land on the leaf.
+	for _, l := range []string{top, mid} {
+		fi, err := os.Lstat(l)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("%s was clobbered into a regular file", l)
+		}
+	}
+	got, err := os.ReadFile(leaf)
+	if err != nil {
+		t.Fatalf("leaf not created: %v", err)
+	}
+	if string(got) != "multi" {
+		t.Fatalf("data = %q, want %q", got, "multi")
+	}
+}
+
+func TestWriteFile_SymlinkLoop(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.json")
+	b := filepath.Join(dir, "b.json")
+	if err := os.Symlink(b, a); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(a, b); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicfile.WriteFile(a, []byte("x"), 0o600); err == nil {
+		t.Fatal("expected an error writing through a symlink loop, got nil")
+	}
+
+	// Neither link may be clobbered into a regular file.
+	for _, l := range []string{a, b} {
+		fi, err := os.Lstat(l)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("%s was clobbered into a regular file", l)
+		}
+	}
+}
+
 func TestWriteFile_NoTempLeftBehind(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.json")

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,169 @@
+package atomicfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
+)
+
+func TestWriteFile_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.json")
+
+	if err := atomicfile.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("data = %q, want %q", got, "hello")
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("perm = %o, want 600", fi.Mode().Perm())
+	}
+}
+
+func TestWriteFile_OverwriteRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.json")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicfile.WriteFile(path, []byte("new"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, _ := os.ReadFile(path)
+	if string(got) != "new" {
+		t.Fatalf("data = %q, want %q", got, "new")
+	}
+	if fi, _ := os.Lstat(path); fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("regular file became a symlink")
+	}
+}
+
+func TestWriteFile_PreservesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "real.json")
+	if err := os.WriteFile(realPath, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "settings.json")
+	if err := os.Symlink(realPath, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicfile.WriteFile(link, []byte("updated"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// The link must still be a symlink.
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("symlink was clobbered into a regular file")
+	}
+	// The real target must hold the new data, reachable through the link.
+	viaLink, _ := os.ReadFile(link)
+	if string(viaLink) != "updated" {
+		t.Fatalf("data via link = %q, want %q", viaLink, "updated")
+	}
+	direct, _ := os.ReadFile(realPath)
+	if string(direct) != "updated" {
+		t.Fatalf("data at target = %q, want %q", direct, "updated")
+	}
+}
+
+func TestWriteFile_PreservesSymlinkChain(t *testing.T) {
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "real.json")
+	if err := os.WriteFile(realPath, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mid := filepath.Join(dir, "mid.json")
+	if err := os.Symlink(realPath, mid); err != nil {
+		t.Fatal(err)
+	}
+	top := filepath.Join(dir, "top.json")
+	if err := os.Symlink(mid, top); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicfile.WriteFile(top, []byte("chain"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	for _, l := range []string{top, mid} {
+		fi, err := os.Lstat(l)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("%s is no longer a symlink", l)
+		}
+	}
+	got, _ := os.ReadFile(realPath)
+	if string(got) != "chain" {
+		t.Fatalf("data = %q, want %q", got, "chain")
+	}
+}
+
+func TestWriteFile_DanglingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "absent.json")
+	link := filepath.Join(dir, "settings.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicfile.WriteFile(link, []byte("revived"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("dangling symlink was replaced by a regular file")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("target not created: %v", err)
+	}
+	if string(got) != "revived" {
+		t.Fatalf("data = %q, want %q", got, "revived")
+	}
+}
+
+func TestWriteFile_NoTempLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.json")
+
+	if err := atomicfile.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".atomicfile-") {
+			t.Fatalf("temp file left behind: %s", e.Name())
+		}
+	}
+}

--- a/internal/atomicfile/testmain_test.go
+++ b/internal/atomicfile/testmain_test.go
@@ -1,0 +1,16 @@
+package atomicfile_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	cleanupHome := testutil.IsolateHome()
+	defer cleanupHome()
+	cleanupTmux := testutil.IsolateTmuxSocket()
+	defer cleanupTmux()
+	os.Exit(m.Run())
+}

--- a/internal/session/claude_hooks.go
+++ b/internal/session/claude_hooks.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 )
 
 // agentDeckHookCommand is the marker command used to identify agent-deck hooks in settings.json.
@@ -122,13 +124,8 @@ func InjectClaudeHooks(configDir string) (bool, error) {
 		return false, fmt.Errorf("create config dir: %w", err)
 	}
 
-	tmpPath := settingsPath + ".tmp"
-	if err := os.WriteFile(tmpPath, finalData, 0644); err != nil {
-		return false, fmt.Errorf("write settings.json.tmp: %w", err)
-	}
-	if err := os.Rename(tmpPath, settingsPath); err != nil {
-		os.Remove(tmpPath)
-		return false, fmt.Errorf("rename settings.json: %w", err)
+	if err := atomicfile.WriteFile(settingsPath, finalData, 0644); err != nil {
+		return false, fmt.Errorf("write settings.json: %w", err)
 	}
 
 	sessionLog.Info("claude_hooks_installed", slog.String("config_dir", configDir))
@@ -195,13 +192,8 @@ func RemoveClaudeHooks(configDir string) (bool, error) {
 		return false, fmt.Errorf("marshal settings: %w", err)
 	}
 
-	tmpPath := settingsPath + ".tmp"
-	if err := os.WriteFile(tmpPath, finalData, 0644); err != nil {
-		return false, fmt.Errorf("write settings.json.tmp: %w", err)
-	}
-	if err := os.Rename(tmpPath, settingsPath); err != nil {
-		os.Remove(tmpPath)
-		return false, fmt.Errorf("rename settings.json: %w", err)
+	if err := atomicfile.WriteFile(settingsPath, finalData, 0644); err != nil {
+		return false, fmt.Errorf("write settings.json: %w", err)
 	}
 
 	sessionLog.Info("claude_hooks_removed", slog.String("config_dir", configDir))

--- a/internal/session/claude_trust.go
+++ b/internal/session/claude_trust.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 )
 
 // PreAcceptClaudeTrust adds a `projects[parentDir].hasTrustDialogAccepted = true`
@@ -61,13 +63,8 @@ func PreAcceptClaudeTrust(claudeJSONPath, parentDir string) error {
 	if err != nil {
 		return fmt.Errorf("marshal claude config: %w", err)
 	}
-	tmp := claudeJSONPath + ".tmp"
-	if err := os.WriteFile(tmp, out, 0o600); err != nil {
-		return fmt.Errorf("write %s: %w", tmp, err)
-	}
-	if err := os.Rename(tmp, claudeJSONPath); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("rename %s: %w", claudeJSONPath, err)
+	if err := atomicfile.WriteFile(claudeJSONPath, out, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", claudeJSONPath, err)
 	}
 	return nil
 }

--- a/internal/session/mcp_catalog.go
+++ b/internal/session/mcp_catalog.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/mcppool"
 )
@@ -344,13 +345,7 @@ func WriteGlobalMCP(enabledNames []string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	tmpPath := configFile + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
-		return fmt.Errorf("failed to write config: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, configFile); err != nil {
-		os.Remove(tmpPath)
+	if err := atomicfile.WriteFile(configFile, data, 0600); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 
@@ -451,13 +446,7 @@ func ClearProjectMCPs(projectPath string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	tmpPath := configFile + ".tmp"
-	if err := os.WriteFile(tmpPath, newData, 0600); err != nil {
-		return fmt.Errorf("failed to write config: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, configFile); err != nil {
-		os.Remove(tmpPath)
+	if err := atomicfile.WriteFile(configFile, newData, 0600); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 
@@ -568,13 +557,7 @@ func WriteUserMCP(enabledNames []string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	tmpPath := configFile + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
-		return fmt.Errorf("failed to write config: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, configFile); err != nil {
-		os.Remove(tmpPath)
+	if err := atomicfile.WriteFile(configFile, data, 0600); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 

--- a/internal/session/symlink_write_regression_test.go
+++ b/internal/session/symlink_write_regression_test.go
@@ -24,9 +24,14 @@ func symlinkedFile(t *testing.T, linkPath, contents string) (realPath string) {
 	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// linkPath may be a process-global path (e.g. GetClaudeConfigDir()/.claude.json)
+	// shared across tests in this package's isolated HOME. Clear any leftover and
+	// remove ours on cleanup so tests don't collide.
+	_ = os.Remove(linkPath)
 	if err := os.Symlink(realPath, linkPath); err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = os.Remove(linkPath) })
 	return realPath
 }
 
@@ -95,5 +100,58 @@ func TestPreAcceptClaudeTrust_PreservesSymlink(t *testing.T) {
 	}
 	if !strings.Contains(string(data), parentDir) {
 		t.Fatalf("parentDir key missing from target; got: %s", data)
+	}
+}
+
+func TestWriteGlobalMCP_PreservesSymlink(t *testing.T) {
+	configFile := filepath.Join(session.GetClaudeConfigDir(), ".claude.json")
+	realPath := symlinkedFile(t, configFile, "{}")
+
+	if err := session.WriteGlobalMCP(nil); err != nil {
+		t.Fatalf("WriteGlobalMCP: %v", err)
+	}
+
+	assertStillSymlink(t, configFile)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "mcpServers") {
+		t.Fatalf("mcpServers not written through symlink to target; got: %s", data)
+	}
+}
+
+func TestWriteUserMCP_PreservesSymlink(t *testing.T) {
+	configFile := session.GetUserMCPRootPath()
+	if configFile == "" {
+		t.Skip("no user MCP root path resolved")
+	}
+	realPath := symlinkedFile(t, configFile, "{}")
+
+	if err := session.WriteUserMCP(nil); err != nil {
+		t.Fatalf("WriteUserMCP: %v", err)
+	}
+
+	assertStillSymlink(t, configFile)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "mcpServers") {
+		t.Fatalf("mcpServers not written through symlink to target; got: %s", data)
+	}
+}
+
+func TestClearProjectMCPs_PreservesSymlink(t *testing.T) {
+	configFile := filepath.Join(session.GetClaudeConfigDir(), ".claude.json")
+	realPath := symlinkedFile(t, configFile, `{"projects":{"/tmp/p":{"mcpServers":{"x":{}}}}}`)
+
+	if err := session.ClearProjectMCPs("/tmp/p"); err != nil {
+		t.Fatalf("ClearProjectMCPs: %v", err)
+	}
+
+	assertStillSymlink(t, configFile)
+	if _, err := os.Stat(realPath); err != nil {
+		t.Fatalf("target missing after write: %v", err)
 	}
 }

--- a/internal/session/symlink_write_regression_test.go
+++ b/internal/session/symlink_write_regression_test.go
@@ -1,0 +1,99 @@
+package session_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// These regression tests pin the fix for the symlink-clobber bug: writing a
+// Claude config file that is a dotfiles-managed symlink must update the real
+// target and leave the symlink intact (previously os.Rename replaced the link
+// with a regular file). See internal/atomicfile.
+
+func symlinkedFile(t *testing.T, linkPath, contents string) (realPath string) {
+	t.Helper()
+	realDir := t.TempDir()
+	realPath = filepath.Join(realDir, "real"+filepath.Ext(linkPath))
+	if err := os.WriteFile(realPath, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+	return realPath
+}
+
+func assertStillSymlink(t *testing.T, linkPath string) {
+	t.Helper()
+	fi, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s was clobbered into a regular file", linkPath)
+	}
+}
+
+func TestInjectClaudeHooks_PreservesSymlink(t *testing.T) {
+	configDir := t.TempDir()
+	link := filepath.Join(configDir, "settings.json")
+	realPath := symlinkedFile(t, link, "{}")
+
+	if _, err := session.InjectClaudeHooks(configDir); err != nil {
+		t.Fatalf("InjectClaudeHooks: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "hook-handler") {
+		t.Fatalf("hooks not written through symlink to target; got: %s", data)
+	}
+}
+
+func TestRemoveClaudeHooks_PreservesSymlink(t *testing.T) {
+	configDir := t.TempDir()
+	link := filepath.Join(configDir, "settings.json")
+	symlinkedFile(t, link, "{}")
+
+	if _, err := session.InjectClaudeHooks(configDir); err != nil {
+		t.Fatalf("InjectClaudeHooks: %v", err)
+	}
+	if _, err := session.RemoveClaudeHooks(configDir); err != nil {
+		t.Fatalf("RemoveClaudeHooks: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+}
+
+func TestPreAcceptClaudeTrust_PreservesSymlink(t *testing.T) {
+	linkDir := t.TempDir()
+	link := filepath.Join(linkDir, ".claude.json")
+	realPath := symlinkedFile(t, link, "{}")
+
+	parentDir := "/tmp/agent-deck-trust-test-parent"
+	if err := session.PreAcceptClaudeTrust(link, parentDir); err != nil {
+		t.Fatalf("PreAcceptClaudeTrust: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "hasTrustDialogAccepted") {
+		t.Fatalf("trust entry not written through symlink to target; got: %s", data)
+	}
+	if !strings.Contains(string(data), parentDir) {
+		t.Fatalf("parentDir key missing from target; got: %s", data)
+	}
+}


### PR DESCRIPTION
## Problem
When `~/.claude/settings.json` or `~/.claude.json` is a symlink (dotfiles
managers), agent-deck's temp-file + `os.Rename` writers replace the symlink with
a regular file. `rename(2)` acts on the destination directory entry, so it
clobbers the link instead of writing through to its target. Hit live: installing
Claude hooks converted a dotfiles `settings.json` symlink into a plain file.

## Fix
New leaf package `internal/atomicfile` with a symlink-preserving atomic write:

```go
func WriteFile(path string, data []byte, perm os.FileMode) error
```

It resolves a symlinked `path` to its real target (following chains; handling
dangling links), writes a uniquely-named temp in the target's directory, and
renames onto the target so the link is preserved. For regular/new files it
behaves like the previous temp+rename. Cross-filesystem symlinks return an
explicit error rather than a silent non-atomic fallback.

Stdlib-only imports, so `internal/session` adopts it with no import cycle. The
package is deliberately the opposite of the existing internal-state helpers
(`credrefresh.atomicWriteFile`, `session.atomicWriteFile`,
`session.writeFileDurable`), which intentionally replace symlinks and are left
untouched.

## Scope
Adopted in the Claude `settings.json` / `.claude.json` writers only:
`InjectClaudeHooks`, `RemoveClaudeHooks` (claude_hooks.go);
`PreAcceptClaudeTrust` (claude_trust.go);
`WriteGlobalMCP`, `WriteUserMCP`, `ClearProjectMCPs` (mcp_catalog.go).

Other agents (gemini, hermes, cursor), project-local `.mcp.json`, `config.toml`
(needs an fsync/durable variant), and `feedback-state.json` will follow in
separate per-writer PRs reusing this helper.

## Tests
- `internal/atomicfile`: new file, overwrite, symlink preserved + target
  updated, symlink chain, dangling symlink, no temp left behind.
- `internal/session` regression: `InjectClaudeHooks` / `RemoveClaudeHooks` /
  `PreAcceptClaudeTrust` keep a symlinked target a symlink and write through.
- Full `internal/session` suite green (excluding the pre-existing flaky
  `TestPerf_OutboxDrain_Drain25` walltime gate, which passes in isolation).

Fixes #1313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safer atomic writes for config and session files using temp-then-rename semantics to avoid stray temp files and handle cross-filesystem rename failures.

* **Bug Fixes**
  * Config/session writes now preserve user-managed symlinks (including multi-hop and dangling-link cases) instead of replacing them with regular files.

* **Tests**
  * Added comprehensive tests for atomic writes, symlink preservation, multi-hop/dangling/link-loop edge cases, and temp-file cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->