### PR TITLE
fix(config): preserve symlinked Gemini config files on atomic write

### DIFF
--- a/internal/session/gemini_hooks.go
+++ b/internal/session/gemini_hooks.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 )
 
 const agentDeckGeminiHookCommand = "agent-deck hook-handler"
@@ -95,13 +97,8 @@ func InjectGeminiHooks(configDir string) (bool, error) {
 		return false, fmt.Errorf("create config dir: %w", err)
 	}
 
-	tmpPath := settingsPath + ".tmp"
-	if err := os.WriteFile(tmpPath, finalData, 0644); err != nil {
-		return false, fmt.Errorf("write settings.json.tmp: %w", err)
-	}
-	if err := os.Rename(tmpPath, settingsPath); err != nil {
-		_ = os.Remove(tmpPath)
-		return false, fmt.Errorf("rename settings.json: %w", err)
+	if err := atomicfile.WriteFile(settingsPath, finalData, 0644); err != nil {
+		return false, fmt.Errorf("write settings.json: %w", err)
 	}
 
 	sessionLog.Info("gemini_hooks_installed", slog.String("config_dir", configDir))
@@ -166,13 +163,8 @@ func RemoveGeminiHooks(configDir string) (bool, error) {
 		return false, fmt.Errorf("marshal settings: %w", err)
 	}
 
-	tmpPath := settingsPath + ".tmp"
-	if err := os.WriteFile(tmpPath, finalData, 0644); err != nil {
-		return false, fmt.Errorf("write settings.json.tmp: %w", err)
-	}
-	if err := os.Rename(tmpPath, settingsPath); err != nil {
-		_ = os.Remove(tmpPath)
-		return false, fmt.Errorf("rename settings.json: %w", err)
+	if err := atomicfile.WriteFile(settingsPath, finalData, 0644); err != nil {
+		return false, fmt.Errorf("write settings.json: %w", err)
 	}
 
 	sessionLog.Info("gemini_hooks_removed", slog.String("config_dir", configDir))

--- a/internal/session/gemini_mcp.go
+++ b/internal/session/gemini_mcp.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 )
 
 // GeminiMCPConfig represents settings.json structure
@@ -45,7 +47,7 @@ func GetGeminiMCPInfo(projectPath string) *MCPInfo {
 
 // WriteGeminiMCPSettings writes MCPs to ~/.gemini/settings.json
 // Preserves existing config fields (security, theme, etc.)
-// Uses atomic write with .tmp file for safety
+// Uses a symlink-preserving atomic write (see internal/atomicfile)
 func WriteGeminiMCPSettings(enabledNames []string) error {
 	configFile := filepath.Join(GetGeminiConfigDir(), "settings.json")
 
@@ -101,13 +103,7 @@ func WriteGeminiMCPSettings(enabledNames []string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	tmpPath := configFile + ".tmp"
-	if err := os.WriteFile(tmpPath, newData, 0600); err != nil {
-		return fmt.Errorf("failed to write config: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, configFile); err != nil {
-		os.Remove(tmpPath)
+	if err := atomicfile.WriteFile(configFile, newData, 0600); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 

--- a/internal/session/gemini_symlink_write_regression_test.go
+++ b/internal/session/gemini_symlink_write_regression_test.go
@@ -1,0 +1,66 @@
+package session_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// These regression tests pin the symlink-preserving write for the Gemini config
+// writers: a dotfiles-managed ~/.gemini/settings.json that is a symlink must be
+// updated through the link, leaving the symlink intact. See internal/atomicfile.
+
+func TestInjectGeminiHooks_PreservesSymlink(t *testing.T) {
+	configDir := t.TempDir()
+	link := filepath.Join(configDir, "settings.json")
+	realPath := symlinkedFile(t, link, "{}")
+
+	if _, err := session.InjectGeminiHooks(configDir); err != nil {
+		t.Fatalf("InjectGeminiHooks: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "hook-handler") {
+		t.Fatalf("hooks not written through symlink to target; got: %s", data)
+	}
+}
+
+func TestRemoveGeminiHooks_PreservesSymlink(t *testing.T) {
+	configDir := t.TempDir()
+	link := filepath.Join(configDir, "settings.json")
+	symlinkedFile(t, link, "{}")
+
+	if _, err := session.InjectGeminiHooks(configDir); err != nil {
+		t.Fatalf("InjectGeminiHooks: %v", err)
+	}
+	if _, err := session.RemoveGeminiHooks(configDir); err != nil {
+		t.Fatalf("RemoveGeminiHooks: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+}
+
+func TestWriteGeminiMCPSettings_PreservesSymlink(t *testing.T) {
+	configFile := filepath.Join(session.GetGeminiConfigDir(), "settings.json")
+	realPath := symlinkedFile(t, configFile, "{}")
+
+	if err := session.WriteGeminiMCPSettings(nil); err != nil {
+		t.Fatalf("WriteGeminiMCPSettings: %v", err)
+	}
+
+	assertStillSymlink(t, configFile)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "mcpServers") {
+		t.Fatalf("mcpServers not written through symlink to target; got: %s", data)
+	}
+}

--- a/internal/session/gemini_symlink_write_regression_test.go
+++ b/internal/session/gemini_symlink_write_regression_test.go
@@ -13,6 +13,9 @@ import (
 // writers: a dotfiles-managed ~/.gemini/settings.json that is a symlink must be
 // updated through the link, leaving the symlink intact. See internal/atomicfile.
 
+// TestInjectGeminiHooks_PreservesSymlink verifies InjectGeminiHooks writes
+// through a symlinked settings.json: the link survives and the real target
+// receives the hook command.
 func TestInjectGeminiHooks_PreservesSymlink(t *testing.T) {
 	configDir := t.TempDir()
 	link := filepath.Join(configDir, "settings.json")
@@ -32,21 +35,38 @@ func TestInjectGeminiHooks_PreservesSymlink(t *testing.T) {
 	}
 }
 
+// TestRemoveGeminiHooks_PreservesSymlink verifies RemoveGeminiHooks writes
+// through a symlinked settings.json: the link survives, removal reports work
+// done, and the hook command is gone from the real target (not just a no-op).
 func TestRemoveGeminiHooks_PreservesSymlink(t *testing.T) {
 	configDir := t.TempDir()
 	link := filepath.Join(configDir, "settings.json")
-	symlinkedFile(t, link, "{}")
+	realPath := symlinkedFile(t, link, "{}")
 
 	if _, err := session.InjectGeminiHooks(configDir); err != nil {
 		t.Fatalf("InjectGeminiHooks: %v", err)
 	}
-	if _, err := session.RemoveGeminiHooks(configDir); err != nil {
+	removed, err := session.RemoveGeminiHooks(configDir)
+	if err != nil {
 		t.Fatalf("RemoveGeminiHooks: %v", err)
+	}
+	if !removed {
+		t.Fatal("expected hooks to be removed")
 	}
 
 	assertStillSymlink(t, link)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "hook-handler") {
+		t.Fatalf("hooks not removed from symlink target; got: %s", data)
+	}
 }
 
+// TestWriteGeminiMCPSettings_PreservesSymlink verifies WriteGeminiMCPSettings
+// writes through a symlinked settings.json: the link survives and the real
+// target receives the mcpServers block.
 func TestWriteGeminiMCPSettings_PreservesSymlink(t *testing.T) {
 	configFile := filepath.Join(session.GetGeminiConfigDir(), "settings.json")
 	realPath := symlinkedFile(t, configFile, "{}")


### PR DESCRIPTION
Adopts internal/atomicfile.WriteFile (added in #1314) in the Gemini config
writers so a dotfiles-managed ~/.gemini/settings.json symlink is written through
rather than replaced with a regular file.

Closes #1315. Follows #1313 / #1314, which did the same for the Claude writers.

Changes:
- gemini_hooks.go: InjectGeminiHooks and RemoveGeminiHooks use atomicfile.WriteFile
- gemini_mcp.go: WriteGeminiMCPSettings uses atomicfile.WriteFile
- new session_test regression coverage for all three writers, reusing the
  symlinkedFile / assertStillSymlink helpers from #1314

Verification:
- gofmt clean, go vet clean, go build ./... ok
- go test ./internal/session/ -race -run 'Gemini.*PreservesSymlink' -count=2 green
- existing Gemini tests (go test -run Gemini) green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of configuration updates by switching to atomic write operations that preserve symlinks, reducing risk of partial writes or lost changes.

* **Tests**
  * Added regression tests verifying symlink integrity and correct content changes when configuration is updated or hooks are added/removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->