### PR TITLE
fix(config): preserve symlinked Hermes config file on atomic write

### DIFF
--- a/internal/session/hermes_hooks.go
+++ b/internal/session/hermes_hooks.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 )
 
 // hermesConfigMu serializes mutations to a given Hermes config.yaml within
@@ -65,16 +66,6 @@ func acquireHermesConfigLock(configPath string) (*hermesConfigLock, error) {
 		return nil, fmt.Errorf("flock hermes config: %w", err)
 	}
 	return &hermesConfigLock{inProc: m, file: f}, nil
-}
-
-// uniqueHermesConfigTmpPath returns a per-writer temp filename so two
-// concurrent writers can't rename-clobber each other's in-flight payload even
-// if the locking layer above is bypassed for any reason. PID + nanosecond
-// timestamp is sufficient: only one writer in any given process can be at this
-// point at a time (we hold the in-process mutex), and nanosecond timestamps
-// don't collide across processes within a 1ns window in practice.
-func uniqueHermesConfigTmpPath(target string) string {
-	return fmt.Sprintf("%s.%d.%d.tmp", target, os.Getpid(), time.Now().UnixNano())
 }
 
 // agentDeckHermesHookCommand is the exact command string we write into
@@ -156,13 +147,8 @@ func InjectHermesHooks(configDir string) (bool, error) {
 		return false, fmt.Errorf("marshal config.yaml: %w", err)
 	}
 
-	tmpPath := uniqueHermesConfigTmpPath(configPath)
-	if err := os.WriteFile(tmpPath, out, 0600); err != nil {
-		return false, fmt.Errorf("write config.yaml tmp: %w", err)
-	}
-	if err := os.Rename(tmpPath, configPath); err != nil {
-		_ = os.Remove(tmpPath)
-		return false, fmt.Errorf("rename config.yaml: %w", err)
+	if err := atomicfile.WriteFile(configPath, out, 0600); err != nil {
+		return false, fmt.Errorf("write config.yaml: %w", err)
 	}
 
 	sessionLog.Info("hermes_hooks_installed", slog.String("config_dir", configDir))
@@ -264,13 +250,8 @@ func RemoveHermesHooks(configDir string) (bool, error) {
 		return false, fmt.Errorf("marshal config.yaml: %w", err)
 	}
 
-	tmpPath := uniqueHermesConfigTmpPath(configPath)
-	if err := os.WriteFile(tmpPath, out, 0600); err != nil {
-		return false, fmt.Errorf("write config.yaml tmp: %w", err)
-	}
-	if err := os.Rename(tmpPath, configPath); err != nil {
-		_ = os.Remove(tmpPath)
-		return false, fmt.Errorf("rename config.yaml: %w", err)
+	if err := atomicfile.WriteFile(configPath, out, 0600); err != nil {
+		return false, fmt.Errorf("write config.yaml: %w", err)
 	}
 
 	sessionLog.Info("hermes_hooks_removed", slog.String("config_dir", configDir))

--- a/internal/session/hermes_symlink_write_regression_test.go
+++ b/internal/session/hermes_symlink_write_regression_test.go
@@ -35,14 +35,25 @@ func TestInjectHermesHooks_PreservesSymlink(t *testing.T) {
 func TestRemoveHermesHooks_PreservesSymlink(t *testing.T) {
 	configDir := t.TempDir()
 	link := filepath.Join(configDir, "config.yaml")
-	symlinkedFile(t, link, "{}\n")
+	realPath := symlinkedFile(t, link, "{}\n")
 
 	if _, err := session.InjectHermesHooks(configDir); err != nil {
 		t.Fatalf("InjectHermesHooks: %v", err)
 	}
-	if _, err := session.RemoveHermesHooks(configDir); err != nil {
+	removed, err := session.RemoveHermesHooks(configDir)
+	if err != nil {
 		t.Fatalf("RemoveHermesHooks: %v", err)
+	}
+	if !removed {
+		t.Fatal("expected hooks to be removed")
 	}
 
 	assertStillSymlink(t, link)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "hook-handler") {
+		t.Fatalf("hooks not removed from symlink target; got: %s", data)
+	}
 }

--- a/internal/session/hermes_symlink_write_regression_test.go
+++ b/internal/session/hermes_symlink_write_regression_test.go
@@ -1,0 +1,48 @@
+package session_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// These regression tests pin the symlink-preserving write for the Hermes hook
+// writers: a dotfiles-managed ~/.hermes/config.yaml that is a symlink must be
+// updated through the link, leaving the symlink intact. See internal/atomicfile.
+
+func TestInjectHermesHooks_PreservesSymlink(t *testing.T) {
+	configDir := t.TempDir()
+	link := filepath.Join(configDir, "config.yaml")
+	realPath := symlinkedFile(t, link, "{}\n")
+
+	if _, err := session.InjectHermesHooks(configDir); err != nil {
+		t.Fatalf("InjectHermesHooks: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "hook-handler") {
+		t.Fatalf("hooks not written through symlink to target; got: %s", data)
+	}
+}
+
+func TestRemoveHermesHooks_PreservesSymlink(t *testing.T) {
+	configDir := t.TempDir()
+	link := filepath.Join(configDir, "config.yaml")
+	symlinkedFile(t, link, "{}\n")
+
+	if _, err := session.InjectHermesHooks(configDir); err != nil {
+		t.Fatalf("InjectHermesHooks: %v", err)
+	}
+	if _, err := session.RemoveHermesHooks(configDir); err != nil {
+		t.Fatalf("RemoveHermesHooks: %v", err)
+	}
+
+	assertStillSymlink(t, link)
+}


### PR DESCRIPTION
Adopts internal/atomicfile.WriteFile (added in #1314) in the Hermes hook writers
so a dotfiles-managed ~/.hermes/config.yaml symlink is written through rather
than replaced with a regular file.

Closes #1317. Follows #1313 / #1314, which did the same for the Claude writers.

Changes:
- hermes_hooks.go: InjectHermesHooks and RemoveHermesHooks use atomicfile.WriteFile
- removed uniqueHermesConfigTmpPath: atomicfile uses os.CreateTemp, which gives a
  kernel-unique temp name, so the per-writer uniqueness it provided still holds
  (the in-process mutex + flock serialization in this file is unchanged)
- dropped the now-unused time import
- new session_test regression coverage for both writers, reusing the
  symlinkedFile / assertStillSymlink helpers from #1314

Verification:
- gofmt clean, go vet clean, go build ./... ok
- go test ./internal/session/ -race -run Hermes -count=2 green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests ensuring symlinked configuration files remain symlinks when hook configuration is written and removed.

* **Refactor**
  * Switched to an atomic write approach for updating hook configuration to improve reliability and avoid partial writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->