### PR TITLE
fix(config): preserve symlinked Cursor mcp.json on atomic write

### DIFF
--- a/internal/session/cursor_mcp.go
+++ b/internal/session/cursor_mcp.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 )
 
 // GetCursorConfigDir returns ~/.cursor (Cursor IDE / Agent CLI config).
@@ -242,13 +244,7 @@ func WriteCursorGlobalMCP(enabledNames []string) error {
 		return fmt.Errorf("marshal cursor mcp.json: %w", err)
 	}
 
-	tmpPath := configFile + ".tmp"
-	if err := os.WriteFile(tmpPath, newData, 0o600); err != nil {
-		return fmt.Errorf("write cursor mcp.json: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, configFile); err != nil {
-		_ = os.Remove(tmpPath)
+	if err := atomicfile.WriteFile(configFile, newData, 0o600); err != nil {
 		return fmt.Errorf("save cursor mcp.json: %w", err)
 	}
 

--- a/internal/session/cursor_symlink_write_regression_test.go
+++ b/internal/session/cursor_symlink_write_regression_test.go
@@ -1,0 +1,33 @@
+package session_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// This regression test pins the symlink-preserving write for the Cursor MCP
+// writer: a dotfiles-managed ~/.cursor/mcp.json that is a symlink must be updated
+// through the link, leaving the symlink intact. See internal/atomicfile.
+
+func TestWriteCursorGlobalMCP_PreservesSymlink(t *testing.T) {
+	configFile := filepath.Join(session.GetCursorConfigDir(), "mcp.json")
+	realPath := symlinkedFile(t, configFile, "{}")
+
+	if err := session.WriteCursorGlobalMCP(nil); err != nil {
+		t.Fatalf("WriteCursorGlobalMCP: %v", err)
+	}
+	session.ClearAllCursorMCPInfoCache()
+
+	assertStillSymlink(t, configFile)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "mcpServers") {
+		t.Fatalf("mcpServers not written through symlink to target; got: %s", data)
+	}
+}


### PR DESCRIPTION
Adopts internal/atomicfile.WriteFile (added in #1314) in WriteCursorGlobalMCP so
a dotfiles-managed ~/.cursor/mcp.json symlink is written through rather than
replaced with a regular file.

Closes #1319. Follows #1313 / #1314, which did the same for the Claude writers.

Changes:
- cursor_mcp.go: WriteCursorGlobalMCP uses atomicfile.WriteFile
- new session_test regression coverage, reusing the symlinkedFile /
  assertStillSymlink helpers from #1314

Verification:
- gofmt clean, go vet clean, go build ./... ok
- go test ./internal/session/ -race -run Cursor -count=2 green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Enhanced file writing safety and reliability for MCP configuration updates with improved operation methods and safeguards
- Fixed an issue where symbolic links in the configuration directory were not being properly preserved when MCP configuration files were updated
- Added regression test to ensure symlink integrity is maintained during future configuration file updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->