### PR TITLE
fix(config): preserve symlinked config.toml on durable atomic write

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -38,7 +38,21 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	return writeAtomic(target, data, perm)
+	return writeAtomic(target, data, perm, false)
+}
+
+// WriteFileDurable behaves like WriteFile but adds crash durability: the temp
+// file is fsync'd before the rename and the target's parent directory is
+// best-effort fsync'd after, so both the file contents and the rename survive a
+// power loss. Use it for files where a torn or lost write on crash matters (for
+// example agent-deck's own config.toml). The symlink-preserving resolution is
+// identical to WriteFile.
+func WriteFileDurable(path string, data []byte, perm os.FileMode) error {
+	target, err := resolveTarget(path)
+	if err != nil {
+		return err
+	}
+	return writeAtomic(target, data, perm, true)
 }
 
 // resolveTarget returns the real file path that should be written. For a regular
@@ -109,8 +123,10 @@ func resolveDanglingLeaf(path string) (string, error) {
 
 // writeAtomic writes data to target via a uniquely-named temp file in target's
 // directory, then renames it onto target. The temp lives in the target's
-// directory so the rename stays on one filesystem.
-func writeAtomic(target string, data []byte, perm os.FileMode) error {
+// directory so the rename stays on one filesystem. When durable is set the temp
+// is fsync'd before the rename and the parent directory is best-effort fsync'd
+// after, so the contents and the rename survive a crash.
+func writeAtomic(target string, data []byte, perm os.FileMode, durable bool) error {
 	dir := filepath.Dir(target)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("atomicfile: mkdir %s: %w", dir, err)
@@ -136,6 +152,12 @@ func writeAtomic(target string, data []byte, perm os.FileMode) error {
 		_ = tmp.Close()
 		return fmt.Errorf("atomicfile: write temp: %w", err)
 	}
+	if durable {
+		if err := tmp.Sync(); err != nil {
+			_ = tmp.Close()
+			return fmt.Errorf("atomicfile: fsync temp: %w", err)
+		}
+	}
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("atomicfile: close temp: %w", err)
 	}
@@ -147,5 +169,15 @@ func writeAtomic(target string, data []byte, perm os.FileMode) error {
 		return fmt.Errorf("atomicfile: rename to %s: %w", target, err)
 	}
 	committed = true
+
+	if durable {
+		// Best-effort directory fsync so the rename itself is durable. Some
+		// filesystems reject directory fsync (EINVAL/ENOTSUP); the data fsync +
+		// atomic rename already give the core guarantee, so ignore the error.
+		if d, derr := os.Open(dir); derr == nil {
+			_ = d.Sync()
+			_ = d.Close()
+		}
+	}
 	return nil
 }

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -247,6 +247,54 @@ func TestWriteFile_RelativeDanglingChain(t *testing.T) {
 	}
 }
 
+func TestWriteFileDurable_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.toml")
+
+	if err := atomicfile.WriteFileDurable(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("WriteFileDurable: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("data = %q, want %q", got, "hello")
+	}
+	if fi, _ := os.Stat(path); fi.Mode().Perm() != 0o600 {
+		t.Fatalf("perm = %o, want 600", fi.Mode().Perm())
+	}
+}
+
+func TestWriteFileDurable_PreservesSymlink(t *testing.T) {
+	dir := t.TempDir()
+	realPath := filepath.Join(dir, "real.toml")
+	if err := os.WriteFile(realPath, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "config.toml")
+	if err := os.Symlink(realPath, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicfile.WriteFileDurable(link, []byte("durable"), 0o600); err != nil {
+		t.Fatalf("WriteFileDurable: %v", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("symlink was clobbered into a regular file")
+	}
+	direct, _ := os.ReadFile(realPath)
+	if string(direct) != "durable" {
+		t.Fatalf("data at target = %q, want %q", direct, "durable")
+	}
+}
+
 func TestWriteFile_NoTempLeftBehind(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.json")

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -19,6 +19,7 @@ import (
 	dark "github.com/thiagokokada/dark-mode-go"
 
 	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/platform"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
@@ -2373,30 +2374,14 @@ func SaveUserConfigWithIntent(config *UserConfig, allowSectionDrop bool) error {
 	}
 
 	// ═══════════════════════════════════════════════════════════════════
-	// ATOMIC WRITE PATTERN: Prevents data corruption on crash/power loss
-	// 1. Write to temporary file with 0600 permissions
-	// 2. fsync the temp file (ensures data reaches disk)
-	// 3. Atomic rename temp to final
+	// ATOMIC + DURABLE WRITE: Prevents data corruption on crash/power loss
+	// and preserves a dotfiles-managed config.toml symlink. The temp file is
+	// fsync'd before the rename and the parent dir is fsync'd after (see
+	// internal/atomicfile.WriteFileDurable). A symlinked config.toml is written
+	// through to its real target rather than replaced with a regular file.
 	// ═══════════════════════════════════════════════════════════════════
 
-	tmpPath := configPath + ".tmp"
-
-	// Step 1: Write to temporary file (0600 = owner read/write only for security)
-	if err := os.WriteFile(tmpPath, buf.Bytes(), 0o600); err != nil {
-		return fmt.Errorf("failed to write temp file: %w", err)
-	}
-
-	// Step 2: fsync the temp file to ensure data reaches disk before rename
-	if err := syncConfigFile(tmpPath); err != nil {
-		// Log but don't fail - atomic rename still provides some safety
-		// Note: We don't have access to log package here, so we just continue
-		_ = err
-	}
-
-	// Step 3: Atomic rename (this is atomic on POSIX systems)
-	if err := os.Rename(tmpPath, configPath); err != nil {
-		// Clean up temp file on failure
-		os.Remove(tmpPath)
+	if err := atomicfile.WriteFileDurable(configPath, buf.Bytes(), 0o600); err != nil {
 		return fmt.Errorf("failed to finalize config save: %w", err)
 	}
 
@@ -2462,16 +2447,6 @@ func backupConfigFile(configPath string) error {
 		return err
 	}
 	return nil
-}
-
-// syncConfigFile calls fsync on a file to ensure data is written to disk
-func syncConfigFile(path string) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	return f.Sync()
 }
 
 // ClearUserConfigCache clears the cached user config, allowing tests to reset state.

--- a/internal/session/userconfig_symlink_write_regression_test.go
+++ b/internal/session/userconfig_symlink_write_regression_test.go
@@ -1,0 +1,37 @@
+package session_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// This regression test pins the symlink-preserving durable write for agent-deck's
+// own config.toml: a dotfiles-managed ~/.config/agent-deck/config.toml that is a
+// symlink must be updated through the link, leaving the symlink intact. See
+// internal/atomicfile.WriteFileDurable.
+
+func TestSaveUserConfig_PreservesSymlink(t *testing.T) {
+	configPath, err := session.GetUserConfigPath()
+	if err != nil {
+		t.Fatalf("GetUserConfigPath: %v", err)
+	}
+	realPath := symlinkedFile(t, configPath, "")
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	if err := session.SaveUserConfig(&session.UserConfig{}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	assertStillSymlink(t, configPath)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "Agent Deck Configuration") {
+		t.Fatalf("config not written through symlink to target; got: %s", data)
+	}
+}


### PR DESCRIPTION
Adds atomicfile.WriteFileDurable, a symlink-preserving variant of WriteFile
(#1314) that keeps the fsync-temp + fsync-dir durability, and adopts it in
SaveUserConfigWithIntent so a dotfiles-managed ~/.config/agent-deck/config.toml
symlink is written through rather than replaced with a regular file.

Closes #1321. Follows #1313 / #1314, which migrated the Claude writers.

Changes:
- atomicfile: new WriteFileDurable; writeAtomic gains a durable flag that fsyncs
  the temp before rename and best-effort fsyncs the parent dir after (mirrors the
  existing inbox.go writeFileDurable durability)
- userconfig.go: SaveUserConfigWithIntent uses atomicfile.WriteFileDurable;
  removed the now-dead syncConfigFile helper. backupConfigFile (writes .bak) and
  CreateExampleConfig (plain not-exists write) are unchanged
- new atomicfile unit tests for WriteFileDurable, plus a session_test config.toml
  regression reusing the symlinkedFile / assertStillSymlink helpers from #1314

Verification:
- gofmt clean, go vet clean, go build ./... ok
- go test ./internal/atomicfile/... ./internal/session/ -race
  -run 'WriteFileDurable|SaveUserConfig_PreservesSymlink|WriteFile_' -count=2 green
- make test-perf: config and statedb gates pass. The OutboxDrain walltime gate is
  unrelated to this change (the drain path does not touch config saving); a
  confound-free A/B over 6 isolated runs each shows this branch at parity with
  main (means 6.27ms vs 6.49ms), and that gate flakes on clean main too under
  full-suite -race


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented durable file-writing mechanism with enhanced crash-recovery protection for critical files.
  * Added proper handling for symbolic links in user configuration paths—symlinks are now preserved during updates.

* **Bug Fixes**
  * Increased reliability of user configuration persistence through safer write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->