### PR TITLE
test(claude): strengthen remove-hooks symlink regression assertion

### DIFF
--- a/internal/session/symlink_write_regression_test.go
+++ b/internal/session/symlink_write_regression_test.go
@@ -68,16 +68,27 @@ func TestInjectClaudeHooks_PreservesSymlink(t *testing.T) {
 func TestRemoveClaudeHooks_PreservesSymlink(t *testing.T) {
 	configDir := t.TempDir()
 	link := filepath.Join(configDir, "settings.json")
-	symlinkedFile(t, link, "{}")
+	realPath := symlinkedFile(t, link, "{}")
 
 	if _, err := session.InjectClaudeHooks(configDir); err != nil {
 		t.Fatalf("InjectClaudeHooks: %v", err)
 	}
-	if _, err := session.RemoveClaudeHooks(configDir); err != nil {
+	removed, err := session.RemoveClaudeHooks(configDir)
+	if err != nil {
 		t.Fatalf("RemoveClaudeHooks: %v", err)
+	}
+	if !removed {
+		t.Fatal("expected hooks to be removed")
 	}
 
 	assertStillSymlink(t, link)
+	data, err := os.ReadFile(realPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "hook-handler") {
+		t.Fatalf("hooks not removed from symlink target; got: %s", data)
+	}
 }
 
 func TestPreAcceptClaudeTrust_PreservesSymlink(t *testing.T) {


### PR DESCRIPTION
TestRemoveClaudeHooks_PreservesSymlink (added in #1314) only asserted the
symlink survived, so it would still pass if RemoveClaudeHooks were a silent
no-op. Assert that removal reports work done and that the hook command is gone
from the real target.

This mirrors the same test strengthening applied to the Gemini (#1316) and
Hermes (#1318) remove-hooks regression tests from the atomicfile follow-up
series.

Verification:
- gofmt clean, go build ./... ok
- go test ./internal/session/ -race
  -run 'TestRemoveClaudeHooks_PreservesSymlink|TestInjectClaudeHooks_PreservesSymlink'
  -count=2 green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced regression test to improve validation of symlink-safe behavior when removing hooks, including verification of removal success and confirmation that hook content is properly cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->