### PR TITLE
fix(session): avoid codex history scan after binding

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2394,7 +2394,16 @@ func (i *Instance) updateCodexSession(excludeIDs map[string]bool, forceProbe boo
 		}
 	}
 
-	// 3. Detect same-project session rotation (e.g. /new) from disk.
+	// 3. Use disk scan only as a bootstrap fallback. Once a session ID is
+	// known, rotation must come from authoritative live evidence above (tmux
+	// env, hook payload, or the Codex process' open rollout file). Polling the
+	// full historical $CODEX_HOME/sessions tree for every active Codex session
+	// burns CPU on large histories and has no stronger ownership signal than the
+	// current binding.
+	if i.CodexSessionID != "" {
+		return missingProbeDep
+	}
+
 	// Only allow unscoped fallback when we don't have a known session ID yet.
 	allowUnscoped := envSessionID == "" && i.CodexSessionID == "" && i.CodexStartedAt > 0
 	if !i.shouldScanCodexSession(allowUnscoped) {

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -3337,11 +3337,22 @@ func TestInstance_UpdateCodexSession_ScanCooldown(t *testing.T) {
 		t.Fatalf("cooldown should keep %q, got %q", sessionID1, inst.CodexSessionID)
 	}
 
-	// After cooldown, scan should run and pick the newer rotated session.
+	// After cooldown, a known session ID should still not trigger historical
+	// disk-scan rebinding. Rotation is handled by hook payloads or live process
+	// file probes, not by periodically walking all old Codex transcripts.
+	inst.lastCodexScanAt = time.Now().Add(-codexRotationScanInterval - time.Second)
+	inst.UpdateCodexSession(nil)
+	if inst.CodexSessionID != sessionID1 {
+		t.Fatalf("post-cooldown known ID should keep %q, got %q", sessionID1, inst.CodexSessionID)
+	}
+
+	// If the binding is genuinely missing, bootstrap scan still works and picks
+	// the newest matching session.
+	inst.CodexSessionID = ""
 	inst.lastCodexScanAt = time.Now().Add(-codexRotationScanInterval - time.Second)
 	inst.UpdateCodexSession(nil)
 	if inst.CodexSessionID != sessionID2 {
-		t.Fatalf("post-cooldown scan picked %q, want %q", inst.CodexSessionID, sessionID2)
+		t.Fatalf("bootstrap scan picked %q, want %q", inst.CodexSessionID, sessionID2)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop periodic full-history Codex session scans once a CodexSessionID is already bound
- keep disk scanning as a bootstrap fallback when no Codex session binding exists
- update Codex session scan coverage for the new behavior

## Tests
- go test ./internal/session -run 'TestInstance_UpdateCodexSession_ScanCooldown|TestInstance_CodexSessionExclusion_SameProjectPath'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Codex session stability by ensuring that once a session is established, updates are sourced only from current live application state rather than historical filesystem data. This makes session management more reliable and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->