### PR TITLE
fix(ci): pin GitHub Actions to commit SHAs in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       REF_NAME: ${{ inputs.tag || github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Check out the tag itself so GoReleaser sees the version tag at HEAD,
           # even when dispatched against main.
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           # Disable the module cache in this write-permission workflow: a
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run GoReleaser
         timeout-minutes: 15
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:
           version: '~> v2'
           args: release --clean
@@ -228,6 +228,6 @@ jobs:
 
       - name: Attest build provenance
         timeout-minutes: 10
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-path: 'dist-attest/*'


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions in the release workflow to immutable commit SHAs, mitigating supply chain attacks via compromised mutable tags.

## Motivation

SECURITY.md states: _"GitHub Actions are pinned by SHA where third-party."_ The release workflow — the most security-critical pipeline, with `contents: write`, `id-token: write`, and `attestations: write` permissions — still used mutable `@vN` tags. A compromised maintainer account could move a tag to inject code into the signed release build.

## Changes

| Action | Before | After (commit SHA) |
|--------|--------|-------------------|
| `actions/checkout` | `@v6` | `@df4cb1c0...` (v6) |
| `actions/setup-go` | `@v6` | `@4a360112...` (v6) |
| `goreleaser/goreleaser-action` | `@v7` | `@5daf1e91...` (v7) |
| `actions/attest-build-provenance` | `@v4` | `@a2bbfa25...` (v4) |

## Keeping SHAs up to date

The `# vN` annotations on each `uses:` line are [recognized by Dependabot](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#keeping-the-actions-in-your-workflows-secure-and-up-to-date) — it will propose PRs when new commits appear under the tracked major tag.

To verify manually:
```bash
git ls-remote https://github.com/actions/checkout.git "refs/tags/v6" "refs/tags/v6^{}"
```
Use the `^{}` line (dereferenced commit) for annotated tags, or the single SHA for lightweight tags.

## Context

Supersedes https://github.com/asheshgoplani/agent-deck/pull/1160, which rotted after `goreleaser-action` was upgraded to v7 in #1249.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure to use immutable action references for improved security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->