### PR TITLE
fix(tmux): ensure ack-signal dir exists so quick-switch works on XDG layout (#1327)

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -4796,9 +4796,18 @@ func BindSwitchKeyWithAck(key, targetSession, sessionID string) error {
 // The inner `tmux switch-client` runs inside the tmux server that fired the
 // run-shell hook, so it targets the correct socket automatically — no need to
 // thread -L through the shell string.
+//
+// Every interpolated value is shell-escaped via shellescape.Quote. targetSession
+// derives from the user-controlled session title, so raw single-quote wrapping
+// ('%s') would break — or be exploited — by a title containing a quote, space,
+// or shell metacharacter. The dir is created 0700 (matching the bind-time
+// os.MkdirAll) so the ack-signal dir/file is not exposed to other local users.
 func buildAckSwitchScript(signalFile, sessionID, targetSession string) string {
-	return fmt.Sprintf("mkdir -p '%s' && echo '%s' > '%s' && tmux switch-client -t '%s'",
-		filepath.Dir(signalFile), sessionID, signalFile, targetSession)
+	return fmt.Sprintf("mkdir -p -m 700 %s && echo %s > %s && tmux switch-client -t %s",
+		shellescape.Quote(filepath.Dir(signalFile)),
+		shellescape.Quote(sessionID),
+		shellescape.Quote(signalFile),
+		shellescape.Quote(targetSession))
 }
 
 const ackSignalLegacyMarker = ".ack-signal-legacy"

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -4772,17 +4772,33 @@ func BindSwitchKeyWithAck(key, targetSession, sessionID string) error {
 		return BindSwitchKey(key, targetSession)
 	}
 
-	// Create a compound command that:
-	// 1. Writes the session ID to a signal file (for agent-deck to acknowledge)
-	// 2. Switches to the target session
-	//
-	// The inner `tmux switch-client` runs inside the tmux server that fired
-	// the run-shell hook, so it targets the correct socket automatically —
-	// no need to thread -L through the shell string.
-	script := fmt.Sprintf("echo '%s' > '%s' && tmux switch-client -t '%s'",
-		sessionID, signalFile, targetSession)
+	// Ensure the signal directory exists at bind time as defense-in-depth.
+	// On the XDG layout the data dir (~/.local/share/agent-deck) may not exist
+	// yet, unlike the legacy ~/.agent-deck which was always present.
+	_ = os.MkdirAll(filepath.Dir(signalFile), 0o700)
+
+	script := buildAckSwitchScript(signalFile, sessionID, targetSession)
 	cmd := tmuxExec(DefaultSocketName(), "bind-key", key, "run-shell", script)
 	return cmd.Run()
+}
+
+// buildAckSwitchScript builds the run-shell command bound to a quick-switch key.
+//
+// It must:
+//  1. Ensure the signal directory exists. On the XDG layout the data dir
+//     (~/.local/share/agent-deck) may not exist when the key fires, unlike the
+//     legacy ~/.agent-deck which was always present. Without this mkdir the
+//     echo below fails and the `&&` short-circuits, so `tmux switch-client`
+//     never runs and the user sees "...returned 1" with no switch (#1327).
+//  2. Write the session ID to the signal file (for agent-deck to acknowledge).
+//  3. Switch to the target session.
+//
+// The inner `tmux switch-client` runs inside the tmux server that fired the
+// run-shell hook, so it targets the correct socket automatically — no need to
+// thread -L through the shell string.
+func buildAckSwitchScript(signalFile, sessionID, targetSession string) string {
+	return fmt.Sprintf("mkdir -p '%s' && echo '%s' > '%s' && tmux switch-client -t '%s'",
+		filepath.Dir(signalFile), sessionID, signalFile, targetSession)
 }
 
 const ackSignalLegacyMarker = ".ack-signal-legacy"

--- a/internal/tmux/xdg_paths_test.go
+++ b/internal/tmux/xdg_paths_test.go
@@ -1,8 +1,10 @@
 package tmux
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,6 +64,32 @@ func TestXDGPaths_LegacyAckSignalFallbackSurvivesSignalConsumption(t *testing.T)
 	ackPath, err := GetAckSignalPath()
 	require.NoError(t, err)
 	require.Equal(t, legacyAck, ackPath)
+}
+
+// TestQuickSwitchScript_EnsuresAckSignalDir is a regression test for #1327.
+//
+// The quick-switch bind (Ctrl+b <number>) runs a run-shell script that echoes
+// the session ID into the ack-signal file and then `tmux switch-client`s. On
+// the XDG layout the ack-signal dir (~/.local/share/agent-deck) may not exist,
+// so the echo fails, the `&&` short-circuits, and the switch never happens.
+// The bind script must `mkdir -p` the ack-signal dir first so the switch always
+// runs. This test fails on main (no mkdir) and passes with the fix.
+func TestQuickSwitchScript_EnsuresAckSignalDir(t *testing.T) {
+	_, data := isolateTmuxXDGPaths(t)
+	signalFile := filepath.Join(data, "agent-deck", "ack-signal")
+
+	script := buildAckSwitchScript(signalFile, "session-123", "agentdeck_demo")
+
+	signalDir := filepath.Dir(signalFile)
+	require.Contains(t, script, fmt.Sprintf("mkdir -p '%s'", signalDir),
+		"quick-switch script must ensure the ack-signal dir exists before writing (#1327)")
+
+	// The mkdir must precede (guard) the echo so the && chain can't short-circuit
+	// the switch-client when the dir is missing.
+	require.True(t,
+		strings.Index(script, "mkdir -p") < strings.Index(script, "echo "),
+		"mkdir must run before echo: %q", script)
+	require.Contains(t, script, "tmux switch-client -t 'agentdeck_demo'")
 }
 
 func TestXDGPaths_UnrelatedLegacyMarkerDoesNotForceTmuxPaths(t *testing.T) {

--- a/internal/tmux/xdg_paths_test.go
+++ b/internal/tmux/xdg_paths_test.go
@@ -1,12 +1,12 @@
 package tmux
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"al.essio.dev/pkg/shellescape"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,15 +81,54 @@ func TestQuickSwitchScript_EnsuresAckSignalDir(t *testing.T) {
 	script := buildAckSwitchScript(signalFile, "session-123", "agentdeck_demo")
 
 	signalDir := filepath.Dir(signalFile)
-	require.Contains(t, script, fmt.Sprintf("mkdir -p '%s'", signalDir),
-		"quick-switch script must ensure the ack-signal dir exists before writing (#1327)")
+	// The mkdir must reference the (shell-escaped) signal dir and create it 0700
+	// so the ack-signal dir is not exposed to other local users (P2).
+	require.Contains(t, script, "mkdir -p -m 700 "+shellescape.Quote(signalDir),
+		"quick-switch script must ensure the ack-signal dir exists 0700 before writing (#1327)")
 
 	// The mkdir must precede (guard) the echo so the && chain can't short-circuit
 	// the switch-client when the dir is missing.
 	require.True(t,
 		strings.Index(script, "mkdir -p") < strings.Index(script, "echo "),
 		"mkdir must run before echo: %q", script)
-	require.Contains(t, script, "tmux switch-client -t 'agentdeck_demo'")
+	require.Contains(t, script, "tmux switch-client -t "+shellescape.Quote("agentdeck_demo"))
+}
+
+// TestQuickSwitchScript_EscapesSingleQuotes guards against the shell-quoting /
+// injection hazard found in dual-review: targetSession (and the signal paths)
+// derive from the user-controlled session title, so a title containing a single
+// quote must be safely escaped rather than breaking out of the quoting.
+func TestQuickSwitchScript_EscapesSingleQuotes(t *testing.T) {
+	_, data := isolateTmuxXDGPaths(t)
+	// A path segment and a session name that both contain a single quote.
+	signalFile := filepath.Join(data, "agent-deck", "it's-data", "ack-signal")
+	sessionID := "id's-123"
+	targetSession := "agentdeck_it's-a-test"
+
+	script := buildAckSwitchScript(signalFile, sessionID, targetSession)
+
+	// Every interpolated value must appear as its shellescape.Quote'd form.
+	// shellescape wraps single-quote-containing values as e.g. 'it'"'"'s-...'
+	// which is a single safe shell word — the bare quote never appears unescaped.
+	require.Contains(t, script, shellescape.Quote(filepath.Dir(signalFile)),
+		"signal dir must be shell-escaped: %q", script)
+	require.Contains(t, script, shellescape.Quote(sessionID),
+		"session ID must be shell-escaped: %q", script)
+	require.Contains(t, script, shellescape.Quote(signalFile),
+		"signal file must be shell-escaped: %q", script)
+	require.Contains(t, script, shellescape.Quote(targetSession),
+		"target session must be shell-escaped: %q", script)
+
+	// Sanity: the dangerous "broken-out" pattern from raw '%s' interpolation —
+	// a bare single quote immediately followed by shell-significant text — must
+	// not appear. With shellescape the only quotes are part of '"'"' sequences.
+	require.NotContains(t, script, "'it's-a-test'",
+		"single quote in session title must not break out of quoting: %q", script)
+
+	// mkdir-before-echo guard still holds even with special characters.
+	require.True(t,
+		strings.Index(script, "mkdir -p") < strings.Index(script, "echo "),
+		"mkdir must run before echo even with quoted values: %q", script)
 }
 
 func TestXDGPaths_UnrelatedLegacyMarkerDoesNotForceTmuxPaths(t *testing.T) {


### PR DESCRIPTION
## Bug

Quick-switch (tmux `ctrl+b <number>`) silently fails on the XDG layout — the user sees `...returned 1` and the client never switches. Manual `ctrl+q` switching works because it bypasses the ack-signal write.

## Root cause

The quick-switch key is bound to a run-shell script:

```
echo '<uuid>' > '<ack-signal-path>' && tmux switch-client -t '<session>'
```

The ack-signal path resolves to `~/.local/share/agent-deck/ack-signal` (XDG data dir). Nothing ensures that directory exists. On the post-#1294 XDG layout `~/.local/share/agent-deck/` is often absent, so the `echo >` fails, the `&&` short-circuits, and `tmux switch-client` never runs. The legacy `~/.agent-deck/` dir always existed, so this only regressed with the XDG migration (v1.9.49).

## Fix

- Prepend `mkdir -p '<dir>'` to the bind script. This runs at key-press, so it's correct even if the dir is removed after the key was bound.
- Add a Go-side `os.MkdirAll(filepath.Dir(signalFile), 0o700)` at bind time as defense-in-depth.
- Extract the script construction into `buildAckSwitchScript` so it's unit-testable.
- The ack-signal path resolution and legacy-marker behavior are unchanged.

## Regression test

`TestQuickSwitchScript_EnsuresAckSignalDir` (in `internal/tmux/xdg_paths_test.go`) asserts the generated bind script `mkdir -p`s the ack-signal dir before the echo. Verified fails-on-main / passes-with-fix.

Fixes #1327. Credit @tomasaschan for the precise repro and error output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of session switching by ensuring acknowledgement signal directories are created before use and by robustly escaping values to prevent shell-related failures with special characters.
* **Tests**
  * Added regression tests verifying the script creates the signal directory first and correctly escapes interpolated values to prevent quoting/escape breakouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->