### PR TITLE
fix(mcppool): serialize stdin writes to prevent JSON-RPC framing corruption

### DIFF
--- a/internal/mcppool/socket_proxy.go
+++ b/internal/mcppool/socket_proxy.go
@@ -60,6 +60,11 @@ type SocketProxy struct {
 	// Key type: int64; value type: idMapping.
 	idMap sync.Map
 
+	// stdinMu serializes writes to mcpStdin. Each request must be written as
+	// a complete JSON line (payload + newline) atomically; without this, concurrent
+	// handleClient goroutines can interleave their writes and corrupt the framing.
+	stdinMu sync.Mutex
+
 	ctx    context.Context
 	cancel context.CancelFunc
 
@@ -413,8 +418,10 @@ func (p *SocketProxy) handleClient(sessionID string, conn net.Conn) {
 			}
 		}
 
+		p.stdinMu.Lock()
 		_, _ = p.mcpStdin.Write(line)
 		_, _ = p.mcpStdin.Write([]byte("\n"))
+		p.stdinMu.Unlock()
 
 		logging.Aggregate(logging.CompPool, "mcp_request",
 			slog.String("mcp", p.name),


### PR DESCRIPTION
## Summary

- Add `stdinMu` mutex around the two `mcpStdin.Write` calls in `handleClient` to ensure each request is written as an atomic JSON line

## Problem

Multiple `handleClient` goroutines write to `mcpStdin` concurrently — first the JSON payload, then the newline delimiter, as two separate `Write` calls. Under concurrent load, these interleave, producing concatenated JSON objects on a single line (`{...}{...}\n`) that the MCP process cannot parse:

```
invalid character '{' after top-level value
```

This is the root cause of the flaky `TestResponseRoutingNoXTalk` failure that blocked the v1.9.50 release.

## Test plan

- [x] `go test -race -run TestResponseRoutingNoXTalk -count=100 ./internal/mcppool/` — 100/100 passes
- [x] `go test -race ./internal/mcppool/` — full package passes

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system stability by ensuring message writes are properly serialized in concurrent scenarios, preventing potential data corruption that could occur when multiple requests are processed simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->