### PR TITLE
ci(release): use gotestsum to retry flaky test packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
           zoxide --version
 
       - name: Install gotestsum
+        timeout-minutes: 5
         run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,14 @@ jobs:
           sudo apt-get install -y zoxide
           zoxide --version
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
+
       - name: Run tests
         timeout-minutes: 25
         env:
           PERF_BUDGET_MULTIPLIER: '2.0'
-        run: go test -race -timeout 20m ./...
+        run: gotestsum --rerun-fails=2 --rerun-fails-max-failures=3 --format=testdox -- -race -timeout 20m ./...
 
       # Evaluator harness full tier. Blocking — a release that fails eval
       # does not get a tag. See docs/rfc/EVALUATOR_HARNESS.md (#37).


### PR DESCRIPTION
## Summary

- Replace `go test -race ./...` with `gotestsum --rerun-fails=2 --rerun-fails-max-failures=3` in the release workflow
- Only failing packages are retried (not the full suite), capped at 3 total package failures before hard-failing

## Motivation

The v1.9.50 release was blocked by three transient test failures:
- `TestResponseRoutingNoXTalk` (mcppool — stdin write race, fixed in #1329)
- `TestTestMainDoesNotLeakBootstrapServer` (testutil — fixed in 3acaa58d)
- `TestPipeManager_ConnectPreservesLiveSibling` / `TestTmuxBootstrap_ServerIsRunning` (tmux — process state timing)

These are timing-dependent tests that pass on retry. The current all-or-nothing `go test ./...` blocks the entire release pipeline when any single test hits a transient failure.

## How it works

`gotestsum --rerun-fails=2` captures per-test JSON output, identifies failing packages, and re-invokes only those packages (up to 2 retries). A test must fail all retries to be considered a real failure. `--rerun-fails-max-failures=3` ensures that if many packages fail simultaneously (indicating a real regression rather than flakes), the retry logic gives up early.

## Supply chain note

`gotestsum` is installed via `go install gotest.tools/gotestsum@v1.13.0` (pinned version). This is consistent with the existing pattern of installing external tools in this workflow (`sudo apt-get install -y zoxide`). The tool runs in the test step only — it does not influence the GoReleaser build, attestation, or any artifact-producing step.

## Test plan

- [x] Verify `gotestsum` flags are correct per [documentation](https://github.com/gotestyourself/gotestsum#re-running-failed-tests)
- [ ] Release workflow passes on next tag push

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow's test execution to improve reliability and consistency, including automatic retries for transient failures and enhanced test reporting.
  * Preserved existing performance-related settings and timeouts to maintain stable release validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->