### PR TITLE
fix: close tmux control pipes on signal exit to prevent orphaned clients

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -470,11 +470,24 @@ func main() {
 		}
 	}
 
-	// Set up signal handling for graceful shutdown and crash dumps
+	// Set up signal handling for graceful shutdown and crash dumps.
+	// SIGHUP is included so closing the terminal window/tab also runs cleanup;
+	// without it the default action is an abrupt terminate that leaks every
+	// `tmux -C attach-session` control client (they reparent to launchd and
+	// pile up against the single-threaded tmux server).
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	go func() {
 		<-sigChan
+		// Close control-mode pipes so their tmux clients detach cleanly instead
+		// of orphaning. PipeManager.Close drives the staged EOF teardown, which
+		// avoids the signal-driven detach that races tmux/tmux#4980. The clean
+		// in-app quit path already does this via performFinalShutdown; the
+		// signal path must too, or the clients leak (killStaleControlClients
+		// only sweeps them up on a later Connect).
+		if pm := tmux.GetPipeManager(); pm != nil {
+			pm.Close()
+		}
 		if db := statedb.GetGlobal(); db != nil {
 			_ = db.ResignPrimary()
 			_ = db.UnregisterInstance()


### PR DESCRIPTION
## Problem

agent-deck spawns one `tmux -C attach-session` control client per session, each in its own process group (`Setpgid`), so they only detach when something closes them. The clean in-app quit path (`performFinalShutdown`) closes them via `PipeManager.Close`, but the signal path doesn't:

- the `SIGINT`/`SIGTERM` handler calls `os.Exit(0)` **without** closing the `PipeManager`, leaking every control client
- **`SIGHUP` (closing the terminal window/tab) isn't handled at all**, so the default terminate runs zero cleanup

Leaked clients reparent to launchd (PPID 1) and pile up against the single-threaded tmux server. `killStaleControlClients` (#595) sweeps them up on a *later* `Connect`, but until then they accumulate and can wedge the server's event loop (observed: `tmux ls` stretching to tens of seconds with dozens of orphaned clients).

## Fix

Add `SIGHUP` to `signal.Notify`, and close the `PipeManager` in the signal handler before exiting — so the signal/terminal-close path cleans up the same way the in-app quit already does. Closing via `PipeManager.Close` uses the staged EOF teardown, which detaches clients through tmux's orderly `%exit` path and avoids the signal-driven detach that races tmux/tmux#4980.

This complements #595 (which reaps orphans on a later `Connect`) by preventing the leak at the source on exit.

## Scope note

An earlier revision of this PR also added a startup `ps`-based orphan reaper. I dropped it: it overlapped with the existing `killStaleControlClients` / `isControlClientOrphan` path from #595, and its blunt `SIGKILL` was unsafe on macOS tmux 3.6a (the very tmux/tmux#4980 server-crash hazard the codebase already engineers around with `softKillProcess`). This PR is now just the signal-handler fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced signal handling to support additional termination signals and added cleanup procedures for tmux connections during shutdown, ensuring graceful termination of the agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->