### PR TITLE
fix(tmux): deliver modified keys in csi-u so Shift+Enter works in kitty

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -626,7 +626,7 @@ configure_tmux() {
     local TMUX_CONF="$HOME/.tmux.conf"
     local MARKER="# agent-deck configuration"
     local VERSION_MARKER="# agent-deck-tmux-config-version:"
-    local CURRENT_VERSION="3"  # Bump this when config changes
+    local CURRENT_VERSION="4"  # Bump this when config changes
     local NEEDS_UPDATE=false
     local HAS_CONFIG=false
 
@@ -646,6 +646,7 @@ configure_tmux() {
             fi
             echo ""
             echo -e "${BLUE}What's new in this update:${NC}"
+            echo "  • Deliver modified keys in csi-u form so Shift+Enter works (kitty etc.)"
             echo "  • Added extended-keys for Shift+Enter support (tmux 3.2+)"
             echo "  • Fixed mouse scrolling issues on WSL"
             echo "  • Added auto-enter copy-mode on scroll up"
@@ -746,6 +747,9 @@ set -g history-limit 50000
 
 # Extended keys: forward Shift+Enter and other modified keys to apps (tmux 3.2+)
 set -s extended-keys on
+# Deliver them as ESC[13;2u (the kitty keyboard-protocol form Claude Code reads)
+# rather than xterm modifyOtherKeys ESC[27;2;13~, which Claude Code ignores.
+set -s extended-keys-format csi-u
 set -as terminal-features 'tmux-256color:extkeys'
 
 # Mouse support (scroll + drag-to-copy)
@@ -771,6 +775,16 @@ bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel \"$CLI
     echo "$CONFIG_BLOCK" >> "$TMUX_CONF"
 
     echo -e "${GREEN}tmux configured successfully!${NC}"
+
+    # kitty ignores xterm modifyOtherKeys (it only speaks its own CSI-u keyboard
+    # protocol), so tmux can't negotiate Shift+Enter with it. kitty must emit the
+    # sequence itself — we can't edit kitty.conf for the user, so just point it out.
+    if [[ -n "$KITTY_WINDOW_ID" || "$TERM" == "xterm-kitty" || "$TERM_PROGRAM" == "kitty" ]]; then
+        echo ""
+        echo -e "${YELLOW}kitty detected:${NC} for Shift+Enter to insert a newline, add to ~/.config/kitty/kitty.conf:"
+        echo "    map shift+enter send_text all \\x1b[13;2u"
+        echo "  then reload kitty (Ctrl+Shift+F5). See troubleshooting.md."
+    fi
 
     # Reload tmux config if tmux is running
     if tmux list-sessions &> /dev/null; then

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1934,6 +1934,7 @@ func (s *Session) Start(command string) error {
 	// Note: history-limit is NOT set here — the user's tmux.conf value is respected.
 	// Users can override via [tmux] options = { "history-limit" = "50000" } in config.toml.
 	// - extended-keys on: Forward Shift+Enter and other modified keys to apps (tmux 3.2+)
+	// - extended-keys-format csi-u: Deliver them as ESC[13;2u (kitty form Claude Code reads), not xterm ESC[27;2;13~ (tmux 3.4+)
 	// - terminal-features hyperlinks+extkeys: Track hyperlinks and enable extended key reporting (tmux 3.4+, server-wide)
 	//
 	// Note: remain-on-exit is NOT set here — it is only enabled for sandbox sessions
@@ -1958,6 +1959,11 @@ func (s *Session) Start(command string) error {
 		"set-option", "-t", s.Name, "set-clipboard", "on", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
 		"set", "-sq", "extended-keys", "on", ";",
+		// csi-u so modified keys reach the pane as ESC[13;2u (the kitty
+		// keyboard-protocol form Claude Code reads) rather than the default
+		// xterm modifyOtherKeys ESC[27;2;13~, which Claude Code ignores —
+		// otherwise Shift+Enter collapses to a bare Enter and submits.
+		"set", "-sq", "extended-keys-format", "csi-u", ";",
 		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys")
 	// Multi-client size negotiation. Web's xterm.js connects via a tmux -C
 	// control client (controlpipe.go) at the same time as native `tmux attach`
@@ -2258,6 +2264,7 @@ func (s *Session) EnableMouseMode() error {
 	// - set-clipboard on: OSC 52 clipboard integration (Warp, iTerm2, kitty, etc.)
 	// - allow-passthrough on: OSC 8 hyperlinks, advanced escape sequences (tmux 3.2+)
 	// - extended-keys on: Forward Shift+Enter and other modified keys to apps (tmux 3.2+)
+	// - extended-keys-format csi-u: Deliver them as ESC[13;2u (kitty form Claude Code reads), not xterm ESC[27;2;13~ (tmux 3.4+)
 	// - terminal-features hyperlinks+extkeys: Track hyperlinks and enable extended key reporting (tmux 3.4+)
 	// - escape-time 10: Fast Vim/editor responsiveness (default 500ms is too slow)
 	//
@@ -2267,6 +2274,11 @@ func (s *Session) EnableMouseMode() error {
 		"set-option", "-t", s.Name, "-q", "allow-passthrough", "on", ";",
 		"set-option", "-t", s.Name, "escape-time", "10", ";",
 		"set", "-sq", "extended-keys", "on", ";",
+		// csi-u so modified keys reach the pane as ESC[13;2u (the kitty
+		// keyboard-protocol form Claude Code reads) rather than the default
+		// xterm modifyOtherKeys ESC[27;2;13~, which Claude Code ignores —
+		// otherwise Shift+Enter collapses to a bare Enter and submits.
+		"set", "-sq", "extended-keys-format", "csi-u", ";",
 		"set", "-asq", "terminal-features", ",*:hyperlinks:extkeys")
 	// Ignore errors - all these are non-fatal enhancements
 	// Older tmux versions may not support some options

--- a/skills/agent-deck/references/troubleshooting.md
+++ b/skills/agent-deck/references/troubleshooting.md
@@ -98,6 +98,29 @@ enabled = true
 
 Also verify `~/.claude/projects/` exists and has content.
 
+### Shift+Enter Submits Instead of Inserting a Newline (Kitty)
+
+In **kitty**, Shift+Enter (and other modified keys) may submit immediately
+inside agent-deck even though they insert a newline when the agent runs
+natively. This is a kitty-specific quirk: tmux negotiates extended keys with
+the outer terminal using xterm's *modifyOtherKeys* protocol, which kitty does
+not implement (kitty only speaks its own CSI-u keyboard protocol). So kitty
+keeps sending a bare carriage return and the agent submits.
+
+agent-deck already sets `extended-keys-format csi-u` on its tmux sessions so
+that, *once the terminal sends a distinct Shift+Enter*, it reaches the agent in
+the form Claude Code understands. The remaining piece must be set in kitty
+itself — make kitty emit the CSI-u Shift+Enter unconditionally:
+
+```conf
+# ~/.config/kitty/kitty.conf
+map shift+enter send_text all \x1b[13;2u
+```
+
+Reload kitty's config (`Ctrl+Shift+F5`) and Shift+Enter will insert a newline,
+both natively and inside agent-deck. iTerm2, Ghostty, WezTerm and xterm honor
+modifyOtherKeys and do not need this mapping.
+
 ## Debugging
 
 Enable debug logging:


### PR DESCRIPTION
## Problem

Inside agent-deck, **Shift+Enter submits immediately** in Claude Code instead of inserting a newline — even though it works when the agent runs natively in the same terminal. Reproduced in **kitty**; the fix also helps other terminals.

## Root cause

Two independent issues on the path `terminal → tmux → agent`:

1. **Wrong delivery format.** tmux defaults `extended-keys-format` to `xterm` (modifyOtherKeys, `ESC[27;2;13~`). Claude Code negotiates the kitty keyboard protocol and only reads the **CSI-u** form `ESC[13;2u`, so the modified key is delivered in a dialect the agent ignores → it sees a bare `\r` → submits.

2. **kitty ↔ tmux outer negotiation (kitty-specific).** To get a distinct Shift+Enter from the outer terminal, tmux enables extended keys using xterm **modifyOtherKeys** (`ESC[>4;1m`). kitty deliberately does not implement modifyOtherKeys (it only speaks its own CSI-u protocol), and stock tmux never sends the kitty enable (`ESC[>1u`). So kitty keeps sending a bare `\r` and there is nothing for tmux to forward. No tmux setting alone can fix this — kitty has to emit the sequence itself.

Verified end-to-end with a PTY harness: tmux *does* forward a distinct Shift+Enter when it receives one (and re-encodes modifyOtherKeys→csi-u), confirming the break is the format (1) and the outer kitty negotiation (2), not the inner forwarding.

## Fix

- Add `set -sq extended-keys-format csi-u` to both tmux session-setup paths (`Session.Start` and `EnableMouseMode`) in `internal/tmux/tmux.go`, so modified keys reach the agent as `ESC[13;2u`.
- Add the same line to the installer's `~/.tmux.conf` template and bump the config version `3 → 4` so existing users get re-patched.
- The installer now prints the required kitty.conf mapping when kitty is detected (agent-deck can't edit kitty.conf for the user):
  ```conf
  map shift+enter send_text all \x1b[13;2u
  ```
- Documented in `troubleshooting.md`.

iTerm2 / Ghostty / WezTerm / xterm honor modifyOtherKeys, so for them the format change (1) is sufficient and no terminal mapping is needed.

## Testing

- `go build ./...`, `go vet ./internal/tmux/`, `bash -n install.sh` — pass.
- tmux option/session-setup tests pass.
- Manually confirmed on macOS + kitty + tmux 3.6: with `extended-keys-format csi-u` and the kitty.conf mapping, Shift+Enter inserts a newline in Claude Code inside agent-deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced keyboard support in tmux environments with improved handling of Shift+Enter and other modified-key combinations using the CSI-u protocol format for better terminal compatibility
  * Added automatic kitty terminal detection and configuration instructions to streamline setup for users working with kitty terminal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->