### PR TITLE
fix(ui): report error when deleting the default group instead of silent no-op

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7133,12 +7133,16 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				h.confirmDialog.ShowDeleteSession(item.Session.ID, item.Session.Title, item.Session.IsSandboxed(), item.Session.IsWorktree())
 			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
 				h.confirmDialog.ShowDeleteRemoteSession(item.RemoteName, item.RemoteSession.ID, item.RemoteSession.Title)
-			} else if item.Type == session.ItemTypeGroup && item.Path != session.DefaultGroupPath && item.Path != h.groupScope {
+			} else if item.Type == session.ItemTypeGroup && item.Path == session.DefaultGroupPath {
+				// Protected default group: report instead of silently doing nothing.
+				// Checked before the scoped-root case so the message stays specific
+				// even when the TUI is scoped to the default group
+				// (groupScope == DefaultGroupPath), where both conditions would match.
+				h.setError(fmt.Errorf("cannot delete the default %q group", session.DefaultGroupName))
+			} else if item.Type == session.ItemTypeGroup && item.Path != h.groupScope {
 				h.confirmDialog.ShowDeleteGroup(item.Path, item.Group.Name)
 			} else if item.Type == session.ItemTypeGroup && item.Path == h.groupScope {
 				h.setError(fmt.Errorf("cannot delete the scoped root group"))
-			} else if item.Type == session.ItemTypeGroup && item.Path == session.DefaultGroupPath {
-				h.setError(fmt.Errorf("cannot delete the default %q group", session.DefaultGroupName))
 			}
 		}
 		return h, nil

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7137,6 +7137,8 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				h.confirmDialog.ShowDeleteGroup(item.Path, item.Group.Name)
 			} else if item.Type == session.ItemTypeGroup && item.Path == h.groupScope {
 				h.setError(fmt.Errorf("cannot delete the scoped root group"))
+			} else if item.Type == session.ItemTypeGroup && item.Path == session.DefaultGroupPath {
+				h.setError(fmt.Errorf("cannot delete the default %q group", session.DefaultGroupName))
 			}
 		}
 		return h, nil

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -3459,3 +3459,63 @@ func TestHome_TerminalNavigationKeys(t *testing.T) {
 		}
 	})
 }
+
+// TestDeleteKeyOnDefaultGroupReportsError guards against the silent no-op where
+// pressing the delete key on the protected "My Sessions" default group did
+// nothing: no dialog, no message. The handler must surface an explanatory error
+// (mirroring the scoped-root case) and must not open the delete-group dialog.
+func TestDeleteKeyOnDefaultGroupReportsError(t *testing.T) {
+	items := []session.Item{
+		{
+			Type:  session.ItemTypeGroup,
+			Path:  session.DefaultGroupPath,
+			Level: 0,
+			Group: &session.Group{
+				Name:     session.DefaultGroupName,
+				Path:     session.DefaultGroupPath,
+				Expanded: true,
+			},
+		},
+	}
+	home := newTestHomeWithItems(100, 30, items)
+	home.cursor = 0
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	h := model.(*Home)
+
+	if h.err == nil {
+		t.Fatal("pressing 'd' on the default group must set an error, got nil (silent no-op)")
+	}
+	if !strings.Contains(h.err.Error(), session.DefaultGroupName) {
+		t.Errorf("error %q must name the default group %q", h.err.Error(), session.DefaultGroupName)
+	}
+	if h.confirmDialog.IsVisible() {
+		t.Error("delete-group confirmation must not open for the protected default group")
+	}
+}
+
+// TestDeleteKeyOnNonDefaultGroupOpensDialog is the positive counterpart: a
+// regular group still opens the delete confirmation, so the new default-group
+// branch does not shadow normal group deletion.
+func TestDeleteKeyOnNonDefaultGroupOpensDialog(t *testing.T) {
+	items := []session.Item{
+		{
+			Type:  session.ItemTypeGroup,
+			Path:  "work",
+			Level: 0,
+			Group: &session.Group{Name: "Work", Path: "work", Expanded: true},
+		},
+	}
+	home := newTestHomeWithItems(100, 30, items)
+	home.cursor = 0
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	h := model.(*Home)
+
+	if !h.confirmDialog.IsVisible() {
+		t.Error("delete-group confirmation must open for a non-default group")
+	}
+	if h.err != nil {
+		t.Errorf("non-default group delete must not set an error, got %v", h.err)
+	}
+}

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -3460,31 +3460,34 @@ func TestHome_TerminalNavigationKeys(t *testing.T) {
 	})
 }
 
-// TestDeleteKeyOnDefaultGroupReportsError guards against the silent no-op where
-// pressing the delete key on the protected "My Sessions" default group did
-// nothing: no dialog, no message. The handler must surface an explanatory error
-// (mirroring the scoped-root case) and must not open the delete-group dialog.
-func TestDeleteKeyOnDefaultGroupReportsError(t *testing.T) {
-	items := []session.Item{
-		{
-			Type:  session.ItemTypeGroup,
-			Path:  session.DefaultGroupPath,
-			Level: 0,
-			Group: &session.Group{
-				Name:     session.DefaultGroupName,
-				Path:     session.DefaultGroupPath,
-				Expanded: true,
-			},
+// defaultGroupItem returns a flat item for the protected "My Sessions" group.
+func defaultGroupItem() session.Item {
+	return session.Item{
+		Type:  session.ItemTypeGroup,
+		Path:  session.DefaultGroupPath,
+		Level: 0,
+		Group: &session.Group{
+			Name:     session.DefaultGroupName,
+			Path:     session.DefaultGroupPath,
+			Expanded: true,
 		},
 	}
-	home := newTestHomeWithItems(100, 30, items)
+}
+
+// TestDeleteBindingOnDefaultGroupReportsError guards against the silent no-op
+// where pressing the delete binding ('d') on the protected "My Sessions"
+// default group did nothing: no dialog, no message. The handler must surface an
+// explanatory error (mirroring the scoped-root case) and must not open the
+// delete-group dialog.
+func TestDeleteBindingOnDefaultGroupReportsError(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, []session.Item{defaultGroupItem()})
 	home.cursor = 0
 
 	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	h := model.(*Home)
 
 	if h.err == nil {
-		t.Fatal("pressing 'd' on the default group must set an error, got nil (silent no-op)")
+		t.Fatal("'d' on the default group must set an error, got nil (silent no-op)")
 	}
 	if !strings.Contains(h.err.Error(), session.DefaultGroupName) {
 		t.Errorf("error %q must name the default group %q", h.err.Error(), session.DefaultGroupName)
@@ -3494,10 +3497,31 @@ func TestDeleteKeyOnDefaultGroupReportsError(t *testing.T) {
 	}
 }
 
-// TestDeleteKeyOnNonDefaultGroupOpensDialog is the positive counterpart: a
+// TestDeleteBindingOnDefaultGroupWhenScopedNamesDefault locks in the ordering of
+// the delete handler: when the TUI is scoped to the default group itself
+// (groupScope == DefaultGroupPath), both the default-group and scoped-root
+// conditions match. The default-group message must win so the feedback stays
+// specific.
+func TestDeleteBindingOnDefaultGroupWhenScopedNamesDefault(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, []session.Item{defaultGroupItem()})
+	home.cursor = 0
+	home.groupScope = session.DefaultGroupPath
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	h := model.(*Home)
+
+	if h.err == nil {
+		t.Fatal("'d' on the scoped default group must set an error, got nil")
+	}
+	if !strings.Contains(h.err.Error(), session.DefaultGroupName) {
+		t.Errorf("scoped default group error %q must name the default group, not the scoped-root message", h.err.Error())
+	}
+}
+
+// TestDeleteBindingOnNonDefaultGroupOpensDialog is the positive counterpart: a
 // regular group still opens the delete confirmation, so the new default-group
 // branch does not shadow normal group deletion.
-func TestDeleteKeyOnNonDefaultGroupOpensDialog(t *testing.T) {
+func TestDeleteBindingOnNonDefaultGroupOpensDialog(t *testing.T) {
 	items := []session.Item{
 		{
 			Type:  session.ItemTypeGroup,


### PR DESCRIPTION
## Problem

Pressing the delete key (`d`) on the default **"My Sessions"** group in the TUI does nothing: no confirmation dialog, no error, no toast. It looks broken.

The group is intentionally protected from deletion (it's the fallback container for ungrouped sessions, and the CLI blocks it too), but the TUI handler swallows the keypress silently. In `internal/ui/home.go` the `d` handler has branches for a normal group (open confirm dialog) and the scoped-root group (show `cannot delete the scoped root group`), but the default group matches **neither**, so it falls through with no `else` branch.

## Repro

1. Put the cursor on the "My Sessions" group header in the TUI.
2. Press `d`.
3. Nothing happens. Compare to pressing `d` on a scoped root group, which shows an explanatory error.

## Fix

Add the missing `else if` so the default group surfaces an error, mirroring the existing scoped-root case:

```go
} else if item.Type == session.ItemTypeGroup && item.Path == session.DefaultGroupPath {
    h.setError(fmt.Errorf("cannot delete the default %q group", session.DefaultGroupName))
}
```

Now `d` on "My Sessions" reports `cannot delete the default "My Sessions" group` instead of doing nothing. Behavior is unchanged otherwise (the group is still protected; this only adds feedback).

## Tests

- `TestDeleteKeyOnDefaultGroupReportsError`: pressing `d` on the default group sets an error naming the group and does **not** open the delete dialog.
- `TestDeleteKeyOnNonDefaultGroupOpensDialog`: a regular group still opens the confirm dialog and sets no error, so the new branch doesn't shadow normal deletion.

Note: I could not run `make test` locally in my environment; relying on CI to validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Protected the default group from being deleted. When users attempt to delete it, an error message is displayed, preventing the action from proceeding.

* **Tests**
  * Added test coverage to verify group deletion protection and confirm the deletion dialog behavior works correctly for non-protected groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->