### PR TITLE
feat(sessions): pin sessions to fixed top/bottom of group

### DIFF
--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -108,9 +108,45 @@ func actionablePriority(s Status) int {
 	return 5
 }
 
+// pinZone maps a session to its outermost sort band (pin-sessions feature).
+// Lower bands surface higher in the group's list.
+//
+//	0  pin-top      fixed at the top, exempt from status/recency
+//	1  normal       the existing actionable sort (status → recency → Order)
+//	2  pin-bottom   fixed at the bottom, exempt from status/recency
+func pinZone(inst *Instance) int {
+	switch inst.Pin {
+	case PinTop:
+		return 0
+	case PinBottom:
+		return 2
+	default:
+		return 1
+	}
+}
+
+// stablePinPartition reorders insts in place into pin-top, normal, and
+// pin-bottom bands (pinZone), preserving the relative order of sessions within
+// each band. Unlike SortInstancesByActionable it never reorders by
+// status/recency, so it is safe to run on every render (Flatten): it moves only
+// pinned rows, leaving the load-time actionable order — and any live K/J manual
+// order — of the normal band untouched. This is what makes a pin edit take
+// effect live instead of only after a restart.
+func stablePinPartition(insts []*Instance) {
+	sort.SliceStable(insts, func(i, j int) bool {
+		return pinZone(insts[i]) < pinZone(insts[j])
+	})
+}
+
 // SortInstancesByActionable sorts the given slice in place so the most
-// recently actionable sessions surface first within a group (issue #857).
-// Key precedence:
+// recently actionable sessions surface first within a group (issue #857),
+// while honoring per-session pins (pin-sessions feature). The outermost key is
+// the pin zone (see pinZone); within the normal zone the existing actionable
+// tiers apply, and within the pin-top/pin-bottom bands sessions are ordered by
+// Order alone (fully fixed — status and recency are ignored, so K/J reordering
+// still works inside a band).
+//
+// Normal zone key precedence:
 //
 //  1. actionablePriority(Status)   asc  — error/waiting/running first
 //  2. LastAccessedAt              desc  — recent attention first
@@ -120,6 +156,15 @@ func actionablePriority(s Status) int {
 //     TestSessionOrderMigration)
 func SortInstancesByActionable(insts []*Instance) {
 	sort.SliceStable(insts, func(i, j int) bool {
+		zi, zj := pinZone(insts[i]), pinZone(insts[j])
+		if zi != zj {
+			return zi < zj
+		}
+		// Pin-top (0) and pin-bottom (2) bands are fully fixed: Order only.
+		if zi == 0 || zi == 2 {
+			return insts[i].Order < insts[j].Order
+		}
+		// Normal (1) band keeps the actionable tiers.
 		pi, pj := actionablePriority(insts[i].Status), actionablePriority(insts[j].Status)
 		if pi != pj {
 			return pi < pj
@@ -462,6 +507,18 @@ func (t *GroupTree) Flatten() []Item {
 				} else {
 					parentSessions = append(parentSessions, sess)
 				}
+			}
+
+			// Apply pin ordering live (pin-sessions): a pin edit mutates
+			// Instance.Pin but does not rebuild the tree, so the load-time
+			// SortInstancesByActionable has not re-run. Stable-partition the
+			// display slices by pin zone here so a pinned session moves to the
+			// top/bottom of its group immediately — without this, the pin only
+			// takes effect after a restart. Operates on Flatten's local copies,
+			// never the tree's group.Sessions, and preserves unpinned order.
+			stablePinPartition(parentSessions)
+			for parentID := range subSessionsByParent {
+				stablePinPartition(subSessionsByParent[parentID])
 			}
 
 			// Count total top-level items (parent sessions + orphan sub-sessions whose parent is in different group)

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -134,7 +134,20 @@ func pinZone(inst *Instance) int {
 // effect live instead of only after a restart.
 func stablePinPartition(insts []*Instance) {
 	sort.SliceStable(insts, func(i, j int) bool {
-		return pinZone(insts[i]) < pinZone(insts[j])
+		zi, zj := pinZone(insts[i]), pinZone(insts[j])
+		if zi != zj {
+			return zi < zj
+		}
+		// Pin-top (0) and pin-bottom (2) bands are fully fixed by Order, matching
+		// the load-time SortInstancesByActionable. Ordering them here means a
+		// freshly pinned row lands in its correct Order slot live — not wherever
+		// it happened to sit in slice order before the pin edit.
+		if zi == 0 || zi == 2 {
+			return insts[i].Order < insts[j].Order
+		}
+		// Normal (1) band is already actionable-sorted at load; return false so
+		// SliceStable leaves its relative order untouched.
+		return false
 	})
 }
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -59,6 +59,17 @@ const (
 
 const wrapperPlaceholder = "{command}"
 
+// PinMode anchors a session to a fixed slot within its group, exempt from the
+// status/recency actionable sort (pin-sessions feature). The empty value is the
+// default so existing rows migrate cleanly through the `pin` column default.
+type PinMode string
+
+const (
+	PinNone   PinMode = ""       // default; not pinned, participates in the normal sort
+	PinTop    PinMode = "top"    // fixed at the top of the group's session list
+	PinBottom PinMode = "bottom" // fixed at the bottom of the group's session list
+)
+
 const (
 	hookFastPathWindow             = 2 * time.Minute
 	codexHookRunningFastPathWindow = 20 * time.Second
@@ -76,15 +87,18 @@ const (
 
 // Instance represents a single agent/shell session
 type Instance struct {
-	ID                 string `json:"id"`
-	Title              string `json:"title"`
-	ProjectPath        string `json:"project_path"`
-	GroupPath          string `json:"group_path"`                     // e.g., "projects/devops"
-	Order              int    `json:"order"`                          // Position within group (for reorder persistence)
-	ParentSessionID    string `json:"parent_session_id,omitempty"`    // Links to parent session (makes this a sub-session)
-	ParentProjectPath  string `json:"parent_project_path,omitempty"`  // Parent's project path (for --add-dir access)
-	IsConductor        bool   `json:"is_conductor,omitempty"`         // True if this session is a conductor orchestrator
-	NoTransitionNotify bool   `json:"no_transition_notify,omitempty"` // Suppress transition event dispatch for this session
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	ProjectPath string `json:"project_path"`
+	GroupPath   string `json:"group_path"` // e.g., "projects/devops"
+	Order       int    `json:"order"`      // Position within group (for reorder persistence)
+	// Pin anchors this session to the top or bottom of its group, exempt from
+	// the status/recency sort (pin-sessions feature). PinNone is the default.
+	Pin                PinMode `json:"pin,omitempty"`
+	ParentSessionID    string  `json:"parent_session_id,omitempty"`    // Links to parent session (makes this a sub-session)
+	ParentProjectPath  string  `json:"parent_project_path,omitempty"`  // Parent's project path (for --add-dir access)
+	IsConductor        bool    `json:"is_conductor,omitempty"`         // True if this session is a conductor orchestrator
+	NoTransitionNotify bool    `json:"no_transition_notify,omitempty"` // Suppress transition event dispatch for this session
 
 	// TitleLocked, when true, blocks Claude's session name from syncing into
 	// the agent-deck Title (issue #697). Conductors launch workers with a

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -34,6 +34,7 @@ const (
 	FieldAutoMode           = "auto-mode"
 	FieldAccount            = "account"      // #924 per-session named account slot
 	FieldIdleTimeout        = "idle-timeout" // #1143 auto-stop dormant sessions
+	FieldPin                = "pin"          // pin-sessions: anchor top/bottom of group
 )
 
 var ValidMutableFields = []string{
@@ -57,6 +58,7 @@ var ValidMutableFields = []string{
 	FieldAutoMode,
 	FieldAccount,
 	FieldIdleTimeout,
+	FieldPin,
 }
 
 type FieldRestartPolicy int
@@ -354,6 +356,21 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 			return oldValue, nil, &MutationError{Field: field, Msg: perr.Error()}
 		}
 		inst.IdleTimeoutSecs = secs
+
+	case FieldPin:
+		// pin-sessions: anchor the session to the top/bottom of its group,
+		// exempt from the status/recency sort. "" clears the pin. Live: the
+		// next rebuildFlatItems re-sorts and the row lands in its band.
+		oldValue = string(inst.Pin)
+		switch PinMode(strings.TrimSpace(value)) {
+		case PinNone, PinTop, PinBottom:
+			inst.Pin = PinMode(strings.TrimSpace(value))
+		default:
+			return oldValue, nil, &MutationError{
+				Field: field,
+				Msg:   fmt.Sprintf("invalid pin %q — expected 'top', 'bottom', or '' to unpin", value),
+			}
+		}
 
 	default:
 		return "", nil, &MutationError{

--- a/internal/session/pin_test.go
+++ b/internal/session/pin_test.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"os"
 	"testing"
 	"time"
 )
@@ -107,13 +106,9 @@ func TestValidMutableFields_IncludesPin(t *testing.T) {
 // SaveWithGroups/LoadWithGroups, and that an unpinned session defaults to
 // PinNone after reload (the empty-string column default).
 func TestPin_SurvivesSaveLoad(t *testing.T) {
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
 	ClearUserConfigCache()
-	t.Cleanup(func() {
-		os.Setenv("HOME", origHome)
-		ClearUserConfigCache()
-	})
+	t.Cleanup(ClearUserConfigCache)
 
 	storage, err := NewStorageWithProfile("_pin_roundtrip")
 	if err != nil {
@@ -143,6 +138,9 @@ func TestPin_SurvivesSaveLoad(t *testing.T) {
 		t.Fatalf("pinned session did not round-trip Pin=top; got %+v", got)
 	}
 	if got := byID[plain.ID]; got == nil || got.Pin != PinNone {
+		if got == nil {
+			t.Fatalf("unpinned session missing after reload")
+		}
 		t.Fatalf("unpinned session must default to PinNone; got pin=%q", got.Pin)
 	}
 }
@@ -180,6 +178,28 @@ func TestFlatten_LivePinBottomMovesToBottom(t *testing.T) {
 	got := sessionIDsInItems(tree.Flatten())
 	if len(got) == 0 || got[len(got)-1] != "a" {
 		t.Fatalf("pin-bottom session must sink to the end of its group live; got %v", got)
+	}
+}
+
+// TestFlatten_LiveMultiPinOrderedByOrder is the regression test for the
+// pinned-band drift bug: when a session is pinned live into a band that already
+// holds a pinned session, the band must stay ordered by Order (matching the
+// load-time SortInstancesByActionable), not by pre-pin slice order. Without the
+// Order comparator in stablePinPartition, the freshly pinned lower-Order row
+// would sit behind the already-pinned higher-Order row.
+func TestFlatten_LiveMultiPinOrderedByOrder(t *testing.T) {
+	// p1 is pinned at build time, so it lands in the pin-top band by Order.
+	p1 := &Instance{ID: "p1", Title: "p1", GroupPath: "g", Status: StatusIdle, Pin: PinTop, Order: 5}
+	x := &Instance{ID: "x", Title: "x", GroupPath: "g", Status: StatusIdle, Order: 1}
+	tree := NewGroupTree([]*Instance{p1, x})
+
+	// Simulate a live pin edit: x joins the pin-top band with a lower Order.
+	x.Pin = PinTop
+
+	got := sessionIDsInItems(tree.Flatten())
+	want := []string{"x", "p1"}
+	if !equalStrings(got, want) {
+		t.Fatalf("pin-top band must order by Order live; got %v want %v", got, want)
 	}
 }
 

--- a/internal/session/pin_test.go
+++ b/internal/session/pin_test.go
@@ -1,0 +1,206 @@
+package session
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestSortInstancesByActionable_PinZones verifies the zoned sort: pin-top
+// sessions first, then normal (status/recency), then pin-bottom — regardless
+// of each session's status. The pin bands are "fully fixed".
+func TestSortInstancesByActionable_PinZones(t *testing.T) {
+	now := time.Now()
+	// A pin-bottom session in error state would, under the plain status sort,
+	// jump to the very top. It must instead sink to the pin-bottom band.
+	pinBottom := &Instance{ID: "pb", Status: StatusError, Pin: PinBottom, LastAccessedAt: now}
+	// A pin-top session that is merely idle/stopped must still lead the list.
+	pinTop := &Instance{ID: "pt", Status: StatusStopped, Pin: PinTop, LastAccessedAt: now.Add(-time.Hour)}
+	normalErr := &Instance{ID: "ne", Status: StatusError, LastAccessedAt: now}
+	normalIdle := &Instance{ID: "ni", Status: StatusIdle, LastAccessedAt: now}
+
+	insts := []*Instance{normalIdle, pinBottom, normalErr, pinTop}
+	SortInstancesByActionable(insts)
+
+	want := []string{"pt", "ne", "ni", "pb"}
+	got := ids(insts)
+	if !equalStrings(got, want) {
+		t.Fatalf("pin zone order wrong:\n got  %v\n want %v", got, want)
+	}
+}
+
+// TestSortInstancesByActionable_PinnedErrorStaysFixed proves a pinned session
+// in an error state does not get surfaced by the actionable sort — it stays in
+// its pin band ("fully fixed", requirement 3).
+func TestSortInstancesByActionable_PinnedErrorStaysFixed(t *testing.T) {
+	now := time.Now()
+	normal := &Instance{ID: "n", Status: StatusIdle, LastAccessedAt: now}
+	pinnedErr := &Instance{ID: "p", Status: StatusError, Pin: PinBottom, LastAccessedAt: now}
+
+	insts := []*Instance{pinnedErr, normal}
+	SortInstancesByActionable(insts)
+
+	if insts[0].ID != "n" || insts[1].ID != "p" {
+		t.Fatalf("pinned error session must stay in pin-bottom band; got %v", ids(insts))
+	}
+}
+
+// TestSortInstancesByActionable_MultiplePinnedOrderedByOrder verifies that
+// within a pin band, K/J reordering (Order) still controls relative position —
+// status and recency are ignored inside the band.
+func TestSortInstancesByActionable_MultiplePinnedOrderedByOrder(t *testing.T) {
+	now := time.Now()
+	// Higher Order should sort after lower Order, independent of status/recency.
+	a := &Instance{ID: "a", Status: StatusError, Pin: PinTop, Order: 2, LastAccessedAt: now}
+	b := &Instance{ID: "b", Status: StatusIdle, Pin: PinTop, Order: 0, LastAccessedAt: now.Add(-time.Hour)}
+	c := &Instance{ID: "c", Status: StatusWaiting, Pin: PinTop, Order: 1, LastAccessedAt: now}
+
+	insts := []*Instance{a, b, c}
+	SortInstancesByActionable(insts)
+
+	want := []string{"b", "c", "a"}
+	if got := ids(insts); !equalStrings(got, want) {
+		t.Fatalf("pin-top band must order by Order; got %v want %v", got, want)
+	}
+}
+
+// TestSetField_Pin verifies the pin mutator accepts top/bottom/empty and
+// rejects anything else.
+func TestSetField_Pin(t *testing.T) {
+	inst := &Instance{ID: "1", Tool: "shell"}
+
+	for _, val := range []string{"top", "bottom", ""} {
+		if _, _, err := SetField(inst, FieldPin, val, nil); err != nil {
+			t.Fatalf("SetField pin=%q: unexpected error %v", val, err)
+		}
+		if string(inst.Pin) != val {
+			t.Fatalf("SetField pin=%q: inst.Pin = %q", val, inst.Pin)
+		}
+	}
+
+	if _, _, err := SetField(inst, FieldPin, "sideways", nil); err == nil {
+		t.Fatal("SetField pin=sideways: expected validation error, got nil")
+	}
+	// A rejected value must not mutate the field.
+	if inst.Pin != PinNone {
+		t.Fatalf("rejected pin value mutated the field: %q", inst.Pin)
+	}
+
+	// pin is a live edit (no restart).
+	if RestartPolicyFor(FieldPin) != FieldLive {
+		t.Fatal("FieldPin should be a live edit (no restart required)")
+	}
+}
+
+// TestValidMutableFields_IncludesPin locks that the field is listed so the
+// CLI/TUI surfaces it.
+func TestValidMutableFields_IncludesPin(t *testing.T) {
+	for _, f := range ValidMutableFields {
+		if f == FieldPin {
+			return
+		}
+	}
+	t.Errorf("FieldPin missing from ValidMutableFields; CLI/TUI surfaces won't list it")
+}
+
+// TestPin_SurvivesSaveLoad confirms the pin column round-trips through
+// SaveWithGroups/LoadWithGroups, and that an unpinned session defaults to
+// PinNone after reload (the empty-string column default).
+func TestPin_SurvivesSaveLoad(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	ClearUserConfigCache()
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	})
+
+	storage, err := NewStorageWithProfile("_pin_roundtrip")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { storage.Close() })
+
+	pinned := NewInstanceWithTool("launcher", "/tmp/p", "shell")
+	pinned.Pin = PinTop
+	plain := NewInstanceWithTool("worker", "/tmp/w", "shell")
+
+	insts := []*Instance{pinned, plain}
+	tree := NewGroupTree(insts)
+	if err := storage.SaveWithGroups(insts, tree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	loaded, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+	byID := map[string]*Instance{}
+	for _, in := range loaded {
+		byID[in.ID] = in
+	}
+	if got := byID[pinned.ID]; got == nil || got.Pin != PinTop {
+		t.Fatalf("pinned session did not round-trip Pin=top; got %+v", got)
+	}
+	if got := byID[plain.ID]; got == nil || got.Pin != PinNone {
+		t.Fatalf("unpinned session must default to PinNone; got pin=%q", got.Pin)
+	}
+}
+
+// TestFlatten_LivePinMovesToTop is the regression test for the reported bug:
+// pinning a session live (without rebuilding the group tree, as a dialog/CLI
+// edit does) must move it to the top of its group immediately, not only after
+// a restart. Flatten reads group.Sessions in slice order, so it must apply the
+// pin partition itself.
+func TestFlatten_LivePinMovesToTop(t *testing.T) {
+	a := &Instance{ID: "a", Title: "a", GroupPath: "g", Status: StatusIdle}
+	b := &Instance{ID: "b", Title: "b", GroupPath: "g", Status: StatusIdle}
+	c := &Instance{ID: "c", Title: "c", GroupPath: "g", Status: StatusIdle}
+	tree := NewGroupTree([]*Instance{a, b, c})
+
+	// Simulate a live pin edit: mutate Pin without rebuilding the tree.
+	c.Pin = PinTop
+
+	got := sessionIDsInItems(tree.Flatten())
+	if len(got) == 0 || got[0] != "c" {
+		t.Fatalf("pinned session must lead its group live; got %v", got)
+	}
+}
+
+// TestFlatten_LivePinBottomMovesToBottom is the mirror: a live pin-bottom edit
+// must sink the session to the end of its group's session list.
+func TestFlatten_LivePinBottomMovesToBottom(t *testing.T) {
+	a := &Instance{ID: "a", Title: "a", GroupPath: "g", Status: StatusIdle}
+	b := &Instance{ID: "b", Title: "b", GroupPath: "g", Status: StatusIdle}
+	c := &Instance{ID: "c", Title: "c", GroupPath: "g", Status: StatusIdle}
+	tree := NewGroupTree([]*Instance{a, b, c})
+
+	a.Pin = PinBottom
+
+	got := sessionIDsInItems(tree.Flatten())
+	if len(got) == 0 || got[len(got)-1] != "a" {
+		t.Fatalf("pin-bottom session must sink to the end of its group live; got %v", got)
+	}
+}
+
+func sessionIDsInItems(items []Item) []string {
+	var out []string
+	for _, it := range items {
+		if it.Type == ItemTypeSession && it.Session != nil {
+			out = append(out, it.Session.ID)
+		}
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -68,6 +68,10 @@ type InstanceData struct {
 	// Instance.Account for full semantics.
 	Account string `json:"account,omitempty"`
 
+	// Pin anchors the session to the top/bottom of its group (pin-sessions).
+	// Round-trips through the pin column. Empty = not pinned.
+	Pin PinMode `json:"pin,omitempty"`
+
 	// Claude session (persisted for resume after app restart)
 	ClaudeSessionID  string    `json:"claude_session_id,omitempty"`
 	ClaudeDetectedAt time.Time `json:"claude_detected_at,omitempty"`
@@ -717,6 +721,7 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 		WorktreeBranch:     inst.WorktreeBranch,
 		Account:            inst.Account,
 		ArchivedAt:         inst.ArchivedAt,
+		Pin:                string(inst.Pin),
 		ToolData:           toolData,
 	}, nil
 }
@@ -829,6 +834,7 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			WorktreeRepoRoot:          r.WorktreeRepo,
 			WorktreeBranch:            r.WorktreeBranch,
 			Account:                   r.Account,
+			Pin:                       PinMode(r.Pin),
 			ClaudeSessionID:           claudeSID,
 			ClaudeDetectedAt:          claudeAt,
 			GeminiSessionID:           geminiSID,
@@ -945,6 +951,7 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			WorktreeRepoRoot:          r.WorktreeRepo,
 			WorktreeBranch:            r.WorktreeBranch,
 			Account:                   r.Account,
+			Pin:                       PinMode(r.Pin),
 			ClaudeSessionID:           claudeSID,
 			ClaudeDetectedAt:          claudeAt,
 			GeminiSessionID:           geminiSID,
@@ -1195,6 +1202,7 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			WorktreeRepoRoot:          instData.WorktreeRepoRoot,
 			WorktreeBranch:            instData.WorktreeBranch,
 			Account:                   instData.Account,
+			Pin:                       instData.Pin,
 			TmuxSocketName:            instData.TmuxSocketName,
 			ClaudeSessionID:           instData.ClaudeSessionID,
 			ClaudeDetectedAt:          instData.ClaudeDetectedAt,

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -103,7 +103,7 @@ func withBusyRetry(op func() error) error {
 
 // SchemaVersion tracks the current database schema version.
 // Bump this when adding migrations.
-const SchemaVersion = 10
+const SchemaVersion = 11
 
 // StateDB wraps a SQLite database for session/group persistence.
 // Thread-safe for concurrent use from multiple goroutines within one process.
@@ -157,7 +157,11 @@ type InstanceRow struct {
 	// `[profiles.<account>.claude].config_dir` at spawn time and becomes the
 	// most-specific level in the CLAUDE_CONFIG_DIR resolution chain. Empty
 	// means "fall through to conductor/group/env/profile/global/default".
-	Account  string
+	Account string
+	// Pin anchors the session to the top/bottom of its group (pin-sessions
+	// feature). "", "top", or "bottom"; empty (the column default) means not
+	// pinned, so legacy rows need no backfill.
+	Pin      string
 	ToolData json.RawMessage // JSON blob for tool-specific data
 	// ArchivedAt is non-zero when the session is archived (hidden from active lists).
 	ArchivedAt time.Time
@@ -346,6 +350,7 @@ func (s *StateDB) Migrate() error {
 			worktree_branch   TEXT NOT NULL DEFAULT '',
 			account           TEXT NOT NULL DEFAULT '',
 			archived_at       INTEGER NOT NULL DEFAULT 0,
+			pin               TEXT NOT NULL DEFAULT '',
 			tool_data       TEXT NOT NULL DEFAULT '{}',
 			acknowledged    INTEGER NOT NULL DEFAULT 0
 		)
@@ -500,6 +505,9 @@ func (s *StateDB) Migrate() error {
 		"ALTER TABLE instances ADD COLUMN account TEXT NOT NULL DEFAULT ''",
 		// v10: user-archived sessions (hidden from active lists; 0 = active).
 		"ALTER TABLE instances ADD COLUMN archived_at INTEGER NOT NULL DEFAULT 0",
+		// v11 (pin-sessions): per-session pin to top/bottom of group. Default ''
+		// means "not pinned" for all pre-existing rows.
+		"ALTER TABLE instances ADD COLUMN pin TEXT NOT NULL DEFAULT ''",
 	}
 	for _, stmt := range alterMigrations {
 		if _, err := tx.Exec(stmt); err != nil {
@@ -567,6 +575,13 @@ func (s *StateDB) Migrate() error {
 				}
 			}
 		}
+		if oldVer < 11 {
+			if _, err := tx.Exec(`ALTER TABLE instances ADD COLUMN pin TEXT NOT NULL DEFAULT ''`); err != nil {
+				if !strings.Contains(err.Error(), "duplicate column") {
+					return fmt.Errorf("statedb: migrate v11 pin: %w", err)
+				}
+			}
+		}
 		if _, err := tx.Exec(`
 			UPDATE metadata SET value = ? WHERE key = 'schema_version'
 		`, schemaVersion); err != nil {
@@ -630,15 +645,15 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch, account,
-			archived_at, tool_data, title_locked
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			archived_at, pin, tool_data, title_locked
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		inst.ID, inst.Title, inst.ProjectPath, inst.GroupPath, inst.Order,
 		inst.Command, inst.Wrapper, inst.Tool, inst.Status, inst.TmuxSession, inst.TmuxSocketName,
 		inst.CreatedAt.Unix(), inst.LastAccessed.Unix(),
 		inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
 		inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch, inst.Account,
-		archivedAtUnix(inst.ArchivedAt), string(toolData), titleLockedInt,
+		archivedAtUnix(inst.ArchivedAt), inst.Pin, string(toolData), titleLockedInt,
 	)
 	return err
 }
@@ -772,8 +787,8 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch, account,
-			archived_at, tool_data, title_locked
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			archived_at, pin, tool_data, title_locked
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return err
@@ -806,7 +821,7 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 			inst.CreatedAt.Unix(), inst.LastAccessed.Unix(),
 			inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
 			inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch, inst.Account,
-			archivedAtUnix(inst.ArchivedAt), string(toolData), titleLockedInt,
+			archivedAtUnix(inst.ArchivedAt), inst.Pin, string(toolData), titleLockedInt,
 		); err != nil {
 			return err
 		}
@@ -835,7 +850,7 @@ func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch, account,
-			archived_at, tool_data, title_locked
+			archived_at, pin, tool_data, title_locked
 		FROM instances ORDER BY sort_order
 	`)
 	if err != nil {
@@ -855,7 +870,7 @@ func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
 			&createdUnix, &accessedUnix,
 			&r.ParentSessionID, &isConductorInt, &noTransitionNotifyInt,
 			&r.WorktreePath, &r.WorktreeRepo, &r.WorktreeBranch, &r.Account,
-			&archivedUnix, &toolDataStr, &titleLockedInt,
+			&archivedUnix, &r.Pin, &toolDataStr, &titleLockedInt,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/ui/edit_session_dialog.go
+++ b/internal/ui/edit_session_dialog.go
@@ -440,7 +440,7 @@ func (d *EditSessionDialog) View() string {
 	}
 
 	content.WriteString("\n")
-	content.WriteString(helpStyle.Render("Enter save │ Esc cancel │ Tab next │ ←/→ tool │ Space toggle"))
+	content.WriteString(helpStyle.Render("Enter save │ Esc cancel │ Tab next │ ←/→ options │ Space toggle"))
 
 	dialog := dialogStyle.Render(content.String())
 	return lipgloss.Place(d.width, d.height, lipgloss.Center, lipgloss.Center, dialog)

--- a/internal/ui/edit_session_dialog.go
+++ b/internal/ui/edit_session_dialog.go
@@ -25,8 +25,13 @@ type editField struct {
 	kind        editFieldKind
 	input       textinput.Model
 	pillOptions []string
-	pillCursor  int
-	checked     bool
+	// pillLabels, when set, supplies human display text for each pillOption
+	// (e.g. "Off"/"Top"/"Bottom" for the pin field). The committed value is
+	// still pillOptions[cursor]; only the rendering differs. nil = render the
+	// pillOptions verbatim as tool pills.
+	pillLabels []string
+	pillCursor int
+	checked    bool
 }
 
 // EditSessionDialog edits the slim set of session fields users iterate on
@@ -65,6 +70,13 @@ func (d *EditSessionDialog) Show(inst *session.Instance) {
 			input: mkInput("Session title", MaxNameLength, inst.Title)},
 		{key: session.FieldTool, label: "Tool (restart)", kind: editFieldPills,
 			pillOptions: tools, pillCursor: toolCursor},
+		// Pin position — anchors the session to the top/bottom of its group,
+		// exempt from the status/recency sort (pin-sessions feature). Applies
+		// to every tool, so it lives in the shared field block.
+		{key: session.FieldPin, label: "Pin position", kind: editFieldPills,
+			pillOptions: []string{string(session.PinNone), string(session.PinTop), string(session.PinBottom)},
+			pillLabels:  []string{"Off", "Top", "Bottom"},
+			pillCursor:  pinCursorFor(inst.Pin)},
 	}
 	if session.IsClaudeCompatible(inst.Tool) {
 		skip, auto := readClaudeFlags(inst)
@@ -124,6 +136,19 @@ func displayGroupName(groupPath string) string {
 		return groupPath[idx+1:]
 	}
 	return groupPath
+}
+
+// pinCursorFor maps the session's current pin mode to its pill index so the
+// dialog opens with the active option highlighted.
+func pinCursorFor(pin session.PinMode) int {
+	switch pin {
+	case session.PinTop:
+		return 1
+	case session.PinBottom:
+		return 2
+	default:
+		return 0
+	}
 }
 
 // toolPillsForInstance returns the pill list + cursor index for `tool`.
@@ -254,6 +279,8 @@ func fieldInitialValue(inst *session.Instance, field string) string {
 	case session.FieldAutoMode:
 		_, auto := readClaudeFlags(inst)
 		return strconv.FormatBool(auto)
+	case session.FieldPin:
+		return string(inst.Pin)
 	}
 	return ""
 }
@@ -396,7 +423,11 @@ func (d *EditSessionDialog) View() string {
 		case editFieldText:
 			content.WriteString(f.input.View())
 		case editFieldPills:
-			content.WriteString(renderToolPills(f.pillOptions, f.pillCursor))
+			if f.pillLabels != nil {
+				content.WriteString(renderLabelPills(f.pillLabels, f.pillCursor))
+			} else {
+				content.WriteString(renderToolPills(f.pillOptions, f.pillCursor))
+			}
 		}
 		content.WriteString("\n")
 	}
@@ -413,6 +444,26 @@ func (d *EditSessionDialog) View() string {
 
 	dialog := dialogStyle.Render(content.String())
 	return lipgloss.Place(d.width, d.height, lipgloss.Center, lipgloss.Center, dialog)
+}
+
+// renderLabelPills renders a row of plain-text pills (no tool icons) for
+// fields whose options are simple labels, e.g. the pin position. Visual
+// styling matches renderToolPills so the two pill kinds read identically.
+func renderLabelPills(labels []string, cursor int) string {
+	if len(labels) == 0 {
+		return ""
+	}
+	selected := lipgloss.NewStyle().Foreground(ColorBg).Background(ColorAccent).Bold(true).Padding(0, 2)
+	idle := lipgloss.NewStyle().Foreground(ColorTextDim).Background(ColorSurface).Padding(0, 2)
+	buttons := make([]string, len(labels))
+	for i, label := range labels {
+		if i == cursor {
+			buttons[i] = selected.Render(label)
+		} else {
+			buttons[i] = idle.Render(label)
+		}
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Left, buttons...)
 }
 
 // renderToolPills mirrors newdialog's command pills (selected =

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -13852,7 +13852,13 @@ func (h *Home) renderSessionItem(
 		}
 	}
 
-	title := titleStyle.Render(inst.Title)
+	// Pin marker (pin-sessions): a 📌 prefix flags any pinned row. Position in
+	// the list conveys top vs bottom; the emoji conveys "this is pinned".
+	displayTitle := inst.Title
+	if inst.Pin != session.PinNone {
+		displayTitle = "📌 " + displayTitle
+	}
+	title := titleStyle.Render(displayTitle)
 	tool := toolStyle.Render(" " + instTool)
 
 	// YOLO badge for Gemini/Codex sessions with YOLO mode enabled


### PR DESCRIPTION
Closes #1335.

## What

Adds an explicit per-session **Pin** (`top` / `bottom` / off) that anchors a session to a fixed slot within its group, exempt from the status/recency actionable sort (#857).

Motivation: long-running app-launcher shell sessions (`npm run dev`, dev servers, log followers) keep getting reshuffled by the actionable sort, and manual `K`/`J` ordering doesn't stick because the persisted `Order` is only the last tie-breaker. A pin keeps them put.

## How

- **Data model** — `PinMode` (`""`/`top`/`bottom`) + `Instance.Pin` (`internal/session/instance.go`).
- **Sort** — `SortInstancesByActionable` becomes zoned: **pin-top → normal → pin-bottom**. The pin bands order by `Order` alone (fully fixed; status/recency ignored, so `K`/`J` still reorders within a band). The normal band keeps the existing `actionablePriority → LastAccessedAt → Order` tiers, so unpinned behavior is unchanged.
- **Live re-order** — `SortInstancesByActionable` only runs at tree build, and `Flatten()` walks `group.Sessions` in slice order, so a live pin edit wouldn't move the row until restart. `Flatten` now stable-partitions its local display slices by pin zone (`stablePinPartition`), moving only pinned rows and preserving unpinned order — so a pin takes effect immediately. Operates on Flatten's copies, never the tree's slices. This also covers the shared web menu snapshot.
- **Mutator** — `FieldPin` (`"pin"`) in `SetField` + `ValidMutableFields`, so the TUI and `agent-deck session set <id> pin top|bottom|""` share validation. Pin is a **live** edit (no restart).
- **Persistence** — `pin TEXT NOT NULL DEFAULT ''` column + schema **v11** migration; round-trips through `InstanceRow`/`InstanceData` and the storage conversions. Empty default means legacy rows need no backfill.
- **UI** — Pin-position pills (Off/Top/Bottom) in the Edit Session dialog, plus a 📌 prefix marker on pinned rows.

## Tests

New `internal/session/pin_test.go`:

- Zoned sort ordering (pin-top/normal/pin-bottom; `Order`-only within pin bands; status/recency within the normal band).
- A pinned error session stays in its band (not surfaced by status).
- `SetField` pin validation (accepts `top`/`bottom`/`""`, rejects garbage without mutating; live policy).
- `ValidMutableFields` includes the field.
- statedb round-trip through Save/Load (pinned survives, unpinned defaults to `PinNone`).
- Live `Flatten` partition moves a freshly-pinned row to top/bottom without a rebuild.

`go build ./...`, `go vet ./...`, and the `internal/session` / `internal/statedb` / `internal/ui` suites pass. (Two pre-existing tmux/JSONL tests fail only under this sandbox's PTY exhaustion — `fork failed: Device not configured` — unrelated to this change; verified against a clean baseline of the same base commit.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pin sessions to the top or bottom of their group for fixed positioning.
  * Pin/unpin sessions from the session editor using a new keyboard-accessible "Pin position" control (pills).
  * Pinned sessions show a 📌 marker in session lists and move immediately when edited.

* **Chores**
  * Pin state is persisted across saves/reloads and migrated for existing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
