### PR TITLE
feat(ui): include session ID in preview copy

### DIFF
--- a/internal/session/display_session_id_test.go
+++ b/internal/session/display_session_id_test.go
@@ -1,0 +1,54 @@
+package session
+
+import "testing"
+
+// TestDisplaySessionID mirrors the PREVIEW pane's per-tool branching: the
+// value DisplaySessionID returns must match the "Session:" line the right
+// pane renders for each tool, so a copy of the preview info carries the same
+// ID the user sees.
+func TestDisplaySessionID(t *testing.T) {
+	tests := []struct {
+		name string
+		inst *Instance
+		want string
+	}{
+		{
+			name: "claude",
+			inst: &Instance{Tool: "claude", ClaudeSessionID: "claude-abc"},
+			want: "claude-abc",
+		},
+		{
+			name: "gemini",
+			inst: &Instance{Tool: "gemini", GeminiSessionID: "gem-123"},
+			want: "gem-123",
+		},
+		{
+			name: "opencode",
+			inst: &Instance{Tool: "opencode", OpenCodeSessionID: "oc-456"},
+			want: "oc-456",
+		},
+		{
+			name: "codex",
+			inst: &Instance{Tool: "codex", CodexSessionID: "cdx-789"},
+			want: "cdx-789",
+		},
+		{
+			name: "claude without id",
+			inst: &Instance{Tool: "claude"},
+			want: "",
+		},
+		{
+			name: "unknown tool, no tmux session",
+			inst: &Instance{Tool: "mystery-tool"},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.inst.DisplaySessionID(); got != tc.want {
+				t.Errorf("DisplaySessionID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2584,6 +2584,25 @@ func (i *Instance) GetGenericSessionID() string {
 	return sessionID
 }
 
+// DisplaySessionID returns the session ID the PREVIEW pane surfaces for this
+// instance's tool, mirroring the per-tool branching in the right-pane render
+// so a copy of the preview info carries the same ID the user sees. Returns ""
+// when no session ID is known for the tool.
+func (i *Instance) DisplaySessionID() string {
+	switch {
+	case IsClaudeCompatible(i.Tool):
+		return i.ClaudeSessionID
+	case i.Tool == "gemini":
+		return i.GeminiSessionID
+	case i.Tool == "opencode":
+		return i.OpenCodeSessionID
+	case i.Tool == "codex":
+		return i.CodexSessionID
+	default:
+		return i.GetGenericSessionID()
+	}
+}
+
 // CanRestartGeneric returns true if a custom tool can be restarted with session resume
 func (i *Instance) CanRestartGeneric() bool {
 	toolDef := GetToolDef(i.Tool)

--- a/internal/ui/preview_copy.go
+++ b/internal/ui/preview_copy.go
@@ -47,6 +47,13 @@ func buildSessionInfoForCopy(inst *session.Instance) string {
 		fmt.Fprintf(&b, "Path: %s\n", inst.ProjectPath)
 	}
 
+	// Session ID line (matches the "Session:" value shown in the preview pane),
+	// emitted only when the tool has a detected session so empty sessions don't
+	// produce a dangling label.
+	if id := inst.DisplaySessionID(); id != "" {
+		fmt.Fprintf(&b, "Session: %s\n", id)
+	}
+
 	return strings.TrimRight(b.String(), "\n")
 }
 

--- a/internal/ui/preview_copy_test.go
+++ b/internal/ui/preview_copy_test.go
@@ -56,6 +56,40 @@ func TestBuildSessionInfoForCopy_PlainSession(t *testing.T) {
 	}
 }
 
+// TestBuildSessionInfoForCopy_IncludesSessionID verifies the copied payload
+// carries the same session ID the PREVIEW pane shows, so the user can yank it
+// with the existing C / shift+C shortcut.
+func TestBuildSessionInfoForCopy_IncludesSessionID(t *testing.T) {
+	inst := &session.Instance{
+		Title:           "steady-oak",
+		ProjectPath:     "/Users/doozyx/DoozyX/Adaptam/ui",
+		Tool:            "claude",
+		ClaudeSessionID: "cabd9818-a55c-4f87-bdb2-ebfc4cf7d947",
+	}
+
+	got := buildSessionInfoForCopy(inst)
+
+	if !strings.Contains(got, "Session: cabd9818-a55c-4f87-bdb2-ebfc4cf7d947") {
+		t.Errorf("expected payload to contain the session ID line, got:\n%s", got)
+	}
+}
+
+// TestBuildSessionInfoForCopy_NoSessionIDLine verifies sessions without a
+// detected ID don't emit an empty "Session:" line.
+func TestBuildSessionInfoForCopy_NoSessionIDLine(t *testing.T) {
+	inst := &session.Instance{
+		Title:       "scratch",
+		ProjectPath: "/tmp/scratch",
+		Tool:        "claude",
+	}
+
+	got := buildSessionInfoForCopy(inst)
+
+	if strings.Contains(got, "Session:") {
+		t.Errorf("session without an ID should not emit a Session line, got:\n%s", got)
+	}
+}
+
 // TestBuildSessionInfoForCopy_MultiRepo verifies that multi-repo sessions
 // surface every project path so the user can paste the full set.
 func TestBuildSessionInfoForCopy_MultiRepo(t *testing.T) {


### PR DESCRIPTION
## What

When copying session info from the preview pane, include a `Session:` line carrying the same session ID the preview pane already displays.

## Why

The preview pane shows a per-tool session ID, but copying the session info omitted it — so a pasted copy didn't carry the ID the user was looking at. This closes that gap.

## How

- Add `Instance.DisplaySessionID()` which mirrors the preview pane's per-tool branching (Claude-compatible / gemini / opencode / codex / generic) so the copied ID always matches what's rendered.
- Emit a `Session: <id>` line in `buildSessionInfoForCopy`, only when a session ID is detected (empty sessions don't produce a dangling `Session:` label).

## Tests

Additive only (+114 lines, all tests). New coverage:
- `internal/session`: `TestDisplaySessionID` — per-tool ID resolution.
- `internal/ui`: `TestBuildSessionInfoForCopy_IncludesSessionID` and `_NoSessionIDLine`, plus existing Worktree/PlainSession/MultiRepo cases still pass.

No behavior change beyond the added copy line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The copy-to-clipboard feature now includes the session ID in copied session information when available, providing complete session details for sharing and reference.

* **Tests**
  * Added test coverage for session ID handling in copy operations, verifying correct inclusion when session IDs are present and proper handling when absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->