### PR TITLE
test(tmux): fix macOS sun_path socket-length failures in tmux tests

### DIFF
--- a/internal/testutil/multiclienttmux/multiclienttmux.go
+++ b/internal/testutil/multiclienttmux/multiclienttmux.go
@@ -3,8 +3,8 @@
 // sizes — the harness from TEST-PLAN.md §6.1 / TUI-TEST-PLAN.md §6.8
 // for the "two web clients hijacking pane size" regression (J4 / F2).
 //
-// Every harness instance gets its own socket under t.TempDir(), never
-// touching the user's real tmux server. Cleanup tears down the server,
+// Every harness instance gets its own socket under a short isolated temp
+// dir, never touching the user's real tmux server. Cleanup tears down the server,
 // kills all spawned client processes, and removes the socket.
 //
 // Usage:
@@ -18,13 +18,13 @@ package multiclienttmux
 import (
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
 	"github.com/creack/pty"
 )
 
@@ -55,8 +55,11 @@ func New(t *testing.T, sessionName string) *Harness {
 		t.Skip("multiclienttmux: tmux binary not available")
 	}
 
-	socketDir := t.TempDir()
-	socketPath := filepath.Join(socketDir, "sock")
+	// Use a short /tmp-based socket path: t.TempDir() on darwin resolves under
+	// /var/folders/<hash>/T/<TestName>... and overshoots the sun_path 104-byte
+	// limit for long test names ("File name too long").
+	socketPath, sockCleanup := testutil.ShortTmuxSocket()
+	t.Cleanup(sockCleanup)
 
 	// Detached new-session on the isolated socket. -x/-y set the initial
 	// window size; clients attaching later may shrink it depending on

--- a/internal/testutil/multiclienttmux/testmain_test.go
+++ b/internal/testutil/multiclienttmux/testmain_test.go
@@ -1,0 +1,23 @@
+package multiclienttmux_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
+)
+
+// TestMain isolates HOME+XDG and the tmux socket for this package so spawning
+// real tmux servers from tests never touches the user's ~/.agent-deck or their
+// live default tmux socket (2026-06-04 data-loss and 2026-04-17 session-kill
+// incidents). Required by TestAllTestMainsIsolateTmuxSocket, which mandates
+// both IsolateHome and IsolateTmuxSocket in every TestMain. os.Exit skips
+// deferred calls, so cleanups run explicitly before it.
+func TestMain(m *testing.M) {
+	cleanupHome := testutil.IsolateHome()
+	cleanupTmux := testutil.IsolateTmuxSocket()
+	code := m.Run()
+	cleanupTmux()
+	cleanupHome()
+	os.Exit(code)
+}

--- a/internal/testutil/tmuxenv.go
+++ b/internal/testutil/tmuxenv.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // Name of the marker env var set during test isolation. Runtime guards in
@@ -81,6 +82,26 @@ func IsolateTmuxSocket() func() {
 		// the kernel removes them when the bound tmux server exits.
 		_ = os.RemoveAll(dir)
 	}
+}
+
+// ShortTmuxSocket returns a tmux -S socket path under a short base dir (/tmp
+// when writable, via shortTmuxTmpBase) that fits the darwin sun_path 104-byte
+// limit regardless of $TMPDIR length or test name, plus a cleanup func that
+// removes the dir. Use for any test that passes its own `tmux -S <path>`;
+// t.TempDir() on darwin resolves under /var/folders/<hash>/T/<TestName>... and
+// overshoots the limit for long test names ("File name too long").
+//
+//	socket, cleanup := testutil.ShortTmuxSocket()
+//	t.Cleanup(cleanup)
+func ShortTmuxSocket() (socket string, cleanup func()) {
+	dir, err := os.MkdirTemp(shortTmuxTmpBase(), "ad-sock-")
+	if err != nil {
+		// Mirror IsolateTmuxSocket's failure-mode fallback: a short,
+		// PID-keyed path that still fits sun_path and won't collide.
+		dir = fmt.Sprintf("/tmp/agent-deck-test-sock-%d", os.Getpid())
+		_ = os.MkdirAll(dir, 0o700)
+	}
+	return filepath.Join(dir, "s"), func() { _ = os.RemoveAll(dir) }
 }
 
 // shortTmuxTmpBase returns a short base directory for the per-test TMUX_TMPDIR.

--- a/internal/testutil/tmuxenv.go
+++ b/internal/testutil/tmuxenv.go
@@ -96,10 +96,15 @@ func IsolateTmuxSocket() func() {
 func ShortTmuxSocket() (socket string, cleanup func()) {
 	dir, err := os.MkdirTemp(shortTmuxTmpBase(), "ad-sock-")
 	if err != nil {
-		// Mirror IsolateTmuxSocket's failure-mode fallback: a short,
-		// PID-keyed path that still fits sun_path and won't collide.
-		dir = fmt.Sprintf("/tmp/agent-deck-test-sock-%d", os.Getpid())
-		_ = os.MkdirAll(dir, 0o700)
+		// Primary MkdirTemp failed. Retry directly under /tmp so each call
+		// still gets a UNIQUE dir (MkdirTemp's random suffix) that fits
+		// sun_path; a PID-keyed path would be process-constant and collide
+		// across calls, racing one call's cleanup against another's socket.
+		// A static PID path remains only as an absolute last resort.
+		if dir, err = os.MkdirTemp("/tmp", "agent-deck-test-sock-"); err != nil {
+			dir = fmt.Sprintf("/tmp/agent-deck-test-sock-%d", os.Getpid())
+			_ = os.MkdirAll(dir, 0o700)
+		}
 	}
 	return filepath.Join(dir, "s"), func() { _ = os.RemoveAll(dir) }
 }

--- a/internal/tmux/issue1167_attach_width_test.go
+++ b/internal/tmux/issue1167_attach_width_test.go
@@ -6,8 +6,9 @@ package tmux
 import (
 	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/testutil"
 )
 
 // Regression tests for #1167: opening/attaching a claude session renders the
@@ -45,7 +46,10 @@ func newDetachedSession1167(t *testing.T, name string) string {
 	if _, err := exec.LookPath("tmux"); err != nil {
 		t.Skip("tmux binary not available")
 	}
-	socket := filepath.Join(t.TempDir(), "sock")
+	// Short /tmp-based socket: t.TempDir() on darwin overshoots the sun_path
+	// 104-byte limit for this long test name ("File name too long").
+	socket, sockCleanup := testutil.ShortTmuxSocket()
+	t.Cleanup(sockCleanup)
 	tmuxCtl1167(t, socket, "new-session", "-d", "-s", name)
 	tmuxCtl1167(t, socket, "set-option", "-t", name, "window-size", "largest")
 	tmuxCtl1167(t, socket, "set-window-option", "-t", name, "aggressive-resize", "on")


### PR DESCRIPTION
## Problem

`go test ./...` fails on macOS in `internal/tmux` and
`internal/testutil/multiclienttmux`:

    tmux new-session ... error connecting to <dir>/sock (File name too long)

## Root cause

Tests that pass their own `tmux -S <socket>` build the path from `t.TempDir()`.
On macOS that resolves under `/var/folders/<32-char-hash>/T/<TestName><rand>/001/`,
about 56 bytes before the test name. Long test names (e.g.
`TestStartAttachPTY_FallsBackWhenSizeUnavailable`) push the socket path past the
darwin `sockaddr_un.sun_path` 104-byte limit, so tmux cannot bind/connect. The
existing `IsolateTmuxSocket` helper only shortens `TMUX_TMPDIR` (used by `-L` /
default-socket tests); it does not help tests that pass an explicit `-S` path.

Linux uses a short `$TMPDIR` (`/tmp`) and a 108-byte limit, so it never hit this.

## Fix

- Add `testutil.ShortTmuxSocket()` returning a `/tmp`-based socket path (reusing
  the existing `shortTmuxTmpBase()`), plus a cleanup func.
- Route the two `-S` socket-construction sites through it: `multiclienttmux.New`
  and `internal/tmux`'s `newDetachedSession1167` (which also feeds the
  `tmux_timing`-tagged width tests).
- Add a `TestMain` to `multiclienttmux` (it had none) calling `IsolateHome` and
  `IsolateTmuxSocket`, satisfying the `TestAllTestMainsIsolateTmuxSocket` lint.

Every other tmux test already uses `-L` named sockets (short via `TMUX_TMPDIR`)
or `NewSession` workdirs, so no other sites needed changes.

## Validation

- macOS, default `$TMPDIR`: `go test ./...` -> 44 ok, 0 fail (previously 2
  packages failed with "File name too long").
- `go build ./...`, `go vet`, `gofmt -l`: clean.
- Linux: behavioral no-op; affected tests pass as before, or skip without the
  tmux binary.

Pure test-infrastructure change. No production code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Use shorter, /tmp-based tmux socket paths with automatic cleanup.
  * Added a reusable helper that provides a socket path plus cleanup.
  * Test setup updated to isolate environments and invoke explicit cleanup after running tests.
  * Result: more reliable test execution and resource cleanup across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->