### PR TITLE
fix(openclaw): bump bridge protocol version 3 -> 4 to match gateway

### DIFF
--- a/internal/openclaw/types.go
+++ b/internal/openclaw/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Protocol version supported by this client.
-const ProtocolVersion = 3
+const ProtocolVersion = 4
 
 // Frame types for the gateway WebSocket protocol.
 const (


### PR DESCRIPTION
## Problem

The OpenClaw gateway advanced to `PROTOCOL_VERSION = 4`. Its connect handshake requires non-probe clients to support the gateway's *current* protocol (`src/gateway/server/ws-connection/message-handler.ts`: `maxProtocol >= PROTOCOL_VERSION && minProtocol <= PROTOCOL_VERSION`).

agent-deck's openclaw bridge advertises `minProtocol = maxProtocol = 3` (`internal/openclaw/types.go: ProtocolVersion = 3`), so against a protocol-4 gateway every connect is rejected:

```
[ws] protocol mismatch ... client=gateway-client backend v1.0.0 ua=Go-http-client/1.1
```

The bridge then loops on reconnect (~every 3s), and `agent-deck openclaw …` shows `Gateway: OFFLINE (connect rejected: INVALID_REQUEST: protocol mismatch)`.

## Fix

Bump `ProtocolVersion` to 4 to match the gateway.

## Verified

With the bump, `agent-deck openclaw status` connects and reports `Protocol: 4` and the agent list, where before it failed with the rejection; a live `openclaw bridge` then connects cleanly (no more `protocol mismatch` in the gateway log). The connect frame schema is unchanged between 3 and 4, so this is purely the version number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal protocol version to enhance system compatibility and connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->