### PR TITLE
feat(ui): add show_pane_titles display toggle

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2106,6 +2106,11 @@ type DisplaySettings struct {
 	// Default: false — opt-in to avoid crowding existing badges. See
 	// renderSessionItem for the timestamp source.
 	ShowSessionTimestamps bool `toml:"show_session_timestamps"`
+
+	// ShowPaneTitles shows the dim tmux pane-title (task description) suffix on
+	// every session row, not just the selected one. Default: false — opt-in to
+	// avoid crowding narrow sidebars. See renderSessionItem for the source.
+	ShowPaneTitles bool `toml:"show_pane_titles"`
 }
 
 // GetActiveFilterExcludes returns the resolved set of statuses the % filter

--- a/internal/session/userconfig_merge.go
+++ b/internal/session/userconfig_merge.go
@@ -90,6 +90,7 @@ func MergePanelConfigOntoDisk(panel *UserConfig) (*UserConfig, error) {
 	// ── Display subset (panel manages ShowSessionTimestamps; FullRepaint
 	//    and filter prefs stay from disk) ───────────────────────────────
 	merged.Display.ShowSessionTimestamps = panel.Display.ShowSessionTimestamps
+	merged.Display.ShowPaneTitles = panel.Display.ShowPaneTitles
 
 	// ── SystemStats subset ─────────────────────────────────────────────
 	if panel.SystemStats.Enabled != nil {

--- a/internal/session/userconfig_merge_pane_titles_test.go
+++ b/internal/session/userconfig_merge_pane_titles_test.go
@@ -6,7 +6,9 @@ import "testing"
 // field omitted from the function silently fails to persist. This test
 // pins the Display.ShowPaneTitles overlay so the wiring can't regress to
 // "toggle does nothing" behavior.
-
+//
+// TestMergePanelConfigOntoDisk_PropagatesShowPaneTitles pins the
+// Display.ShowPaneTitles overlay for both the on and off transitions.
 func TestMergePanelConfigOntoDisk_PropagatesShowPaneTitles(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ClearUserConfigCache()

--- a/internal/session/userconfig_merge_pane_titles_test.go
+++ b/internal/session/userconfig_merge_pane_titles_test.go
@@ -1,0 +1,38 @@
+package session
+
+import "testing"
+
+// MergePanelConfigOntoDisk is an allowlist-style merger: any panel-managed
+// field omitted from the function silently fails to persist. This test
+// pins the Display.ShowPaneTitles overlay so the wiring can't regress to
+// "toggle does nothing" behavior.
+
+func TestMergePanelConfigOntoDisk_PropagatesShowPaneTitles(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	// Toggle on via panel input.
+	panel := &UserConfig{
+		Display: DisplaySettings{ShowPaneTitles: true},
+	}
+	merged, err := MergePanelConfigOntoDisk(panel)
+	if err != nil {
+		t.Fatalf("MergePanelConfigOntoDisk returned error: %v", err)
+	}
+	if !merged.Display.ShowPaneTitles {
+		t.Fatal("merge dropped Display.ShowPaneTitles=true — toggle would never persist to disk")
+	}
+
+	// Toggle back off must also propagate (zero-value bool, easy to drop accidentally).
+	panel2 := &UserConfig{
+		Display: DisplaySettings{ShowPaneTitles: false},
+	}
+	merged2, err := MergePanelConfigOntoDisk(panel2)
+	if err != nil {
+		t.Fatalf("MergePanelConfigOntoDisk returned error: %v", err)
+	}
+	if merged2.Display.ShowPaneTitles {
+		t.Fatal("merge failed to propagate Display.ShowPaneTitles=false — toggle would be stuck on")
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -423,6 +423,11 @@ type Home struct {
 	// the user toggles the setting mid-frame. Reloaded after the panel saves.
 	showSessionTimestamps bool
 
+	// showPaneTitles, when true, renders the dim tmux pane-title (task
+	// description) suffix on every session row instead of only the selected
+	// one. Cached here so all rows of a frame agree; reloaded after panel save.
+	showPaneTitles bool
+
 	// Sessions/Preview split (issue #1092): percentage of width allocated to
 	// preview pane. Loaded from config.toml [ui] preview_pct, adjustable
 	// live via < and > keybindings, persisted back to config on adjustment.
@@ -997,6 +1002,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		h.activeFilterExcludes = cfg.Display.GetActiveFilterExcludes()
 		tmux.SetHideCwdPrefixInTitle(!cfg.Display.GetIncludeCwdPrefix())
 		h.showSessionTimestamps = cfg.Display.ShowSessionTimestamps
+		h.showPaneTitles = cfg.Display.ShowPaneTitles
 		h.sysStatsConfig = cfg.SystemStats
 		h.costLineTemplate, h.costLineHideWhenZero = session.ResolveCostLineTemplate(cfg, actualProfile)
 		h.previewPct = cfg.UI.GetPreviewPct()
@@ -5419,6 +5425,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				_, _ = session.ReloadUserConfig()
 				h.reloadHotkeysFromConfig()
 				h.showSessionTimestamps = config.Display.ShowSessionTimestamps
+				h.showPaneTitles = config.Display.ShowPaneTitles
 
 				// Apply theme changes live
 				h.stopThemeWatcher()
@@ -13377,7 +13384,7 @@ func (h *Home) renderSessionItem(
 	// so the prior measurement let the trailing pane-title text overflow
 	// the panel and shove subsequent rows down by one cell. See
 	// internal/ui/cellwidth.go for the upstream disagreement.
-	if selected && instState.paneTitle != "" {
+	if (selected || h.showPaneTitles) && instState.paneTitle != "" {
 		// Dual layout: sidebar is narrower than h.width (#937). Using full
 		// terminal width here overflows the SESSIONS pane, then lipgloss
 		// truncation disagrees from terminal cells — wrapped lines duplicate

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3848,6 +3848,10 @@ func appendClearScreen(cmd tea.Cmd) tea.Cmd {
 	return tea.Batch(cmd, tea.ClearScreen)
 }
 
+// updateInner is the core Bubble Tea update routine for Home. It dispatches a
+// single tea.Msg (key, mouse, tick, or async command result) to the focused
+// component or the appropriate handler and returns the updated model plus any
+// commands to run. Update wraps it to add cross-cutting concerns.
 func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 
@@ -13118,6 +13122,11 @@ func (h *Home) renderCreatingSessionItem(
 	b.WriteString("\n")
 }
 
+// renderSessionItem renders a single session row into b, including the tree
+// connector, status badge, tool label, and the dim tmux pane-title suffix.
+// The pane-title suffix appears on the selected row, or on every row when
+// show_pane_titles is enabled, and is truncated to listWidth so it never
+// overflows the SESSIONS panel.
 func (h *Home) renderSessionItem(
 	b *strings.Builder,
 	item session.Item,

--- a/internal/ui/remote_session_pane_titles_test.go
+++ b/internal/ui/remote_session_pane_titles_test.go
@@ -1,0 +1,68 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// RemoteSession pane-title parity is intentionally deferred.
+//
+// The session.RemoteSessionInfo struct (internal/session/ssh.go) carries
+// only ID, Title, Path, Group, Tool, Status, CreatedAt, and a locally-set
+// RemoteName. It does NOT carry a pane title. The dim pane-title suffix is
+// derived from per-session tmux state (sessionRenderState.paneTitle) that
+// lives on the remote machine and is never shipped over the wire to the
+// local TUI.
+//
+// The local suffix in renderSessionItem is gated on
+// (selected || h.showPaneTitles) && instState.paneTitle != "". The remote
+// renderer renderRemoteSessionItem takes no snapshot and has no paneTitle
+// source, so enabling [display] show_pane_titles cannot surface a pane
+// title on a remote row.
+//
+// Until the remote protocol is extended to ship pane-title state, pane
+// titles stay local-only. This test pins that decision: it confirms the
+// suffix does NOT leak into remote rows when the flag is on, so a future
+// change that silently adds it here is forced through a conscious
+// re-review. It mirrors remote_session_timestamps_test.go.
+//
+// Tracking note for follow-up: extending the wire format / RemoteSessionInfo
+// to carry the tmux pane title would be the minimum needed to make remote
+// pane-title parity meaningful.
+func TestRemoteSession_PaneTitleIsLocalOnly(t *testing.T) {
+	forceTrueColorProfile()
+
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.showPaneTitles = true // would emit the suffix on local rows
+
+	const sentinelPaneTitle = "Explore messaging support features"
+
+	remote := session.RemoteSessionInfo{
+		ID:         "remote-test",
+		Title:      "remote-session",
+		Status:     "running",
+		Tool:       "claude",
+		RemoteName: "myserver",
+	}
+	item := session.Item{
+		Type:          session.ItemTypeRemoteSession,
+		RemoteSession: &remote,
+		RemoteName:    "myserver",
+	}
+
+	var b strings.Builder
+	home.renderRemoteSessionItem(&b, item, false)
+	rendered := b.String()
+
+	if !strings.Contains(rendered, "remote-session") {
+		t.Fatalf("expected the remote row to render its title; got: %q", rendered)
+	}
+	if strings.Contains(rendered, sentinelPaneTitle) {
+		t.Fatalf("remote session row must not render a pane-title suffix "+
+			"(parity deferred — see file-level comment). Found %q in: %q", sentinelPaneTitle, rendered)
+	}
+}

--- a/internal/ui/session_pane_titles_test.go
+++ b/internal/ui/session_pane_titles_test.go
@@ -12,7 +12,9 @@ import (
 // not just the selected one. With the flag off it stays selected-only — the
 // original hardcoded behavior. The flag is cached on Home at startup and
 // refreshed when the settings panel saves.
-
+//
+// renderRowWithPaneTitle renders one session row with the given selection and
+// show_pane_titles flag and returns the rendered string for assertions.
 func renderRowWithPaneTitle(t *testing.T, selected, showAll bool, paneTitle string) string {
 	t.Helper()
 	forceTrueColorProfile()
@@ -44,6 +46,8 @@ func renderRowWithPaneTitle(t *testing.T, selected, showAll bool, paneTitle stri
 
 const sampleTaskTitle = "Explore messaging support features"
 
+// TestPaneTitle_ShowAllRendersOnUnselectedRow verifies show_pane_titles=true
+// renders the pane-title suffix on an unselected row.
 func TestPaneTitle_ShowAllRendersOnUnselectedRow(t *testing.T) {
 	row := renderRowWithPaneTitle(t, false, true, sampleTaskTitle)
 	if !strings.Contains(row, sampleTaskTitle) {
@@ -52,6 +56,8 @@ func TestPaneTitle_ShowAllRendersOnUnselectedRow(t *testing.T) {
 	}
 }
 
+// TestPaneTitle_ShowAllOffOmitsOnUnselectedRow verifies show_pane_titles=false
+// keeps the pane-title suffix off an unselected row.
 func TestPaneTitle_ShowAllOffOmitsOnUnselectedRow(t *testing.T) {
 	row := renderRowWithPaneTitle(t, false, false, sampleTaskTitle)
 	if strings.Contains(row, sampleTaskTitle) {
@@ -60,6 +66,8 @@ func TestPaneTitle_ShowAllOffOmitsOnUnselectedRow(t *testing.T) {
 	}
 }
 
+// TestPaneTitle_SelectedRowAlwaysRenders verifies the selected row renders its
+// pane-title suffix even when show_pane_titles is off.
 func TestPaneTitle_SelectedRowAlwaysRenders(t *testing.T) {
 	// Selected-only behavior must be preserved when the toggle is off.
 	row := renderRowWithPaneTitle(t, true, false, sampleTaskTitle)

--- a/internal/ui/session_pane_titles_test.go
+++ b/internal/ui/session_pane_titles_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Session row pane-title suffix. The dim task-description suffix (the tmux
+// pane title) appears on every row when [display] show_pane_titles = true,
+// not just the selected one. With the flag off it stays selected-only — the
+// original hardcoded behavior. The flag is cached on Home at startup and
+// refreshed when the settings panel saves.
+
+func renderRowWithPaneTitle(t *testing.T, selected, showAll bool, paneTitle string) string {
+	t.Helper()
+	forceTrueColorProfile()
+
+	h := &Home{width: 140, showPaneTitles: showAll}
+	inst := &session.Instance{
+		ID:    "sess-pane-title",
+		Title: "with-pane-title",
+	}
+	item := session.Item{
+		Type:          session.ItemTypeSession,
+		Session:       inst,
+		Level:         1,
+		Path:          "test",
+		IsLastInGroup: true,
+	}
+	snapshot := map[string]sessionRenderState{
+		inst.ID: {
+			status:    session.StatusRunning,
+			tool:      "claude",
+			paneTitle: paneTitle,
+		},
+	}
+
+	var b strings.Builder
+	h.renderSessionItem(&b, item, selected, snapshot, h.width)
+	return b.String()
+}
+
+const sampleTaskTitle = "Explore messaging support features"
+
+func TestPaneTitle_ShowAllRendersOnUnselectedRow(t *testing.T) {
+	row := renderRowWithPaneTitle(t, false, true, sampleTaskTitle)
+	if !strings.Contains(row, sampleTaskTitle) {
+		t.Fatalf("show_pane_titles=true must render the pane-title suffix on an unselected row, "+
+			"but %q was not found. Got: %q", sampleTaskTitle, row)
+	}
+}
+
+func TestPaneTitle_ShowAllOffOmitsOnUnselectedRow(t *testing.T) {
+	row := renderRowWithPaneTitle(t, false, false, sampleTaskTitle)
+	if strings.Contains(row, sampleTaskTitle) {
+		t.Fatalf("show_pane_titles=false must not render the pane-title suffix on an unselected row, "+
+			"but %q leaked into the default path. Got: %q", sampleTaskTitle, row)
+	}
+}
+
+func TestPaneTitle_SelectedRowAlwaysRenders(t *testing.T) {
+	// Selected-only behavior must be preserved when the toggle is off.
+	row := renderRowWithPaneTitle(t, true, false, sampleTaskTitle)
+	if !strings.Contains(row, sampleTaskTitle) {
+		t.Fatalf("the selected row must always render its pane-title suffix regardless of "+
+			"show_pane_titles, but %q was not found. Got: %q", sampleTaskTitle, row)
+	}
+}

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -47,10 +47,11 @@ const (
 	SettingStatsShowLoad
 	SettingSyncTitle
 	SettingShowSessionTimestamps
+	SettingShowPaneTitles
 )
 
 // Total number of navigable settings.
-const settingsCount = 31
+const settingsCount = 32
 
 // SettingsPanel displays and edits user configuration
 type SettingsPanel struct {
@@ -99,6 +100,7 @@ type SettingsPanel struct {
 	statsShowLoad       bool
 
 	showSessionTimestamps bool
+	showPaneTitles        bool
 
 	// Text input state
 	editingText bool
@@ -331,6 +333,7 @@ func (s *SettingsPanel) LoadConfig(config *session.UserConfig) {
 
 	// Display settings
 	s.showSessionTimestamps = config.Display.ShowSessionTimestamps
+	s.showPaneTitles = config.Display.ShowPaneTitles
 }
 
 func (s *SettingsPanel) buildToolLists(config *session.UserConfig) {
@@ -460,6 +463,7 @@ func (s *SettingsPanel) GetConfig() *session.UserConfig {
 
 	// Display settings
 	config.Display.ShowSessionTimestamps = s.showSessionTimestamps
+	config.Display.ShowPaneTitles = s.showPaneTitles
 
 	// Preserve original MCPs, Tools, and Docker settings.
 	if s.originalConfig != nil {
@@ -711,6 +715,10 @@ func (s *SettingsPanel) toggleValue() bool {
 
 	case SettingShowSessionTimestamps:
 		s.showSessionTimestamps = !s.showSessionTimestamps
+		return true
+
+	case SettingShowPaneTitles:
+		s.showPaneTitles = !s.showPaneTitles
 		return true
 	}
 
@@ -1085,6 +1093,12 @@ func (s *SettingsPanel) View() string {
 	}
 	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
 
+	line = s.renderCheckbox("Show pane titles", s.showPaneTitles) + " - Task description per row"
+	if s.cursor == int(SettingShowPaneTitles) {
+		line = highlightStyle.Render(line)
+	}
+	content.WriteString("  " + labelStyle.Render(line) + "\n\n")
+
 	// MCP & TOOLS
 	content.WriteString(sectionStyle.Render("MCP SERVERS & CUSTOM TOOLS"))
 	content.WriteString("\n")
@@ -1149,6 +1163,7 @@ func (s *SettingsPanel) View() string {
 			51, // SettingStatsShowLoad
 			54, // SettingSyncTitle (SESSIONS section, after stats)
 			57, // SettingShowSessionTimestamps (DISPLAY section, after SESSIONS)
+			59, // SettingShowPaneTitles (DISPLAY section, after timestamps)
 		}
 		cursorLine := cursorToLine[s.cursor]
 

--- a/internal/ui/settings_panel_pane_titles_test.go
+++ b/internal/ui/settings_panel_pane_titles_test.go
@@ -10,7 +10,9 @@ import (
 // Settings panel wiring for [display] show_pane_titles. The toggle must load
 // from the on-disk Display struct, flip on space, and round-trip back through
 // GetConfig() unchanged.
-
+//
+// TestSettingsPanel_ShowPaneTitles_LoadConfig verifies the panel mirrors
+// Display.ShowPaneTitles on load and defaults to false for an empty config.
 func TestSettingsPanel_ShowPaneTitles_LoadConfig(t *testing.T) {
 	panel := NewSettingsPanel()
 
@@ -33,6 +35,9 @@ func TestSettingsPanel_ShowPaneTitles_LoadConfig(t *testing.T) {
 	}
 }
 
+// TestSettingsPanel_ShowPaneTitles_ToggleAndPersist verifies that Space flips
+// the setting, reports changed=true, and round-trips through GetConfig() so
+// SaveUserConfig persists it.
 func TestSettingsPanel_ShowPaneTitles_ToggleAndPersist(t *testing.T) {
 	// Isolate from the real ~/.agent-deck/config.toml — Show() would otherwise
 	// load the developer's actual setting and the precondition below would

--- a/internal/ui/settings_panel_pane_titles_test.go
+++ b/internal/ui/settings_panel_pane_titles_test.go
@@ -1,0 +1,103 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Settings panel wiring for [display] show_pane_titles. The toggle must load
+// from the on-disk Display struct, flip on space, and round-trip back through
+// GetConfig() unchanged.
+
+func TestSettingsPanel_ShowPaneTitles_LoadConfig(t *testing.T) {
+	panel := NewSettingsPanel()
+
+	config := &session.UserConfig{
+		Display: session.DisplaySettings{
+			ShowPaneTitles: true,
+		},
+	}
+	panel.LoadConfig(config)
+
+	if !panel.showPaneTitles {
+		t.Errorf("showPaneTitles should be true after loading config with Display.ShowPaneTitles=true")
+	}
+
+	// Default (zero-value) config should leave the panel value at false.
+	panel2 := NewSettingsPanel()
+	panel2.LoadConfig(&session.UserConfig{})
+	if panel2.showPaneTitles {
+		t.Errorf("showPaneTitles should default to false for an empty config")
+	}
+}
+
+func TestSettingsPanel_ShowPaneTitles_ToggleAndPersist(t *testing.T) {
+	// Isolate from the real ~/.agent-deck/config.toml — Show() would otherwise
+	// load the developer's actual setting and the precondition below would
+	// be non-deterministic.
+	t.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	panel := NewSettingsPanel()
+	panel.Show()
+	panel.cursor = int(SettingShowPaneTitles)
+
+	if panel.showPaneTitles {
+		t.Fatal("precondition: showPaneTitles must start false")
+	}
+
+	_, _, changed := panel.Update(tea.KeyMsg{Type: tea.KeySpace})
+	if !changed {
+		t.Error("Space on SettingShowPaneTitles must report changed=true")
+	}
+	if !panel.showPaneTitles {
+		t.Error("Space on SettingShowPaneTitles must flip showPaneTitles to true")
+	}
+
+	// GetConfig must mirror the toggled state back into Display so SaveUserConfig persists it.
+	got := panel.GetConfig()
+	if !got.Display.ShowPaneTitles {
+		t.Error("GetConfig() must propagate showPaneTitles into Display.ShowPaneTitles")
+	}
+
+	// Flip again and confirm the round trip back to false.
+	_, _, _ = panel.Update(tea.KeyMsg{Type: tea.KeySpace})
+	got = panel.GetConfig()
+	if got.Display.ShowPaneTitles {
+		t.Error("second toggle must flip showPaneTitles back to false")
+	}
+}
+
+// Pins the cursorToLine[SettingShowPaneTitles] mapping in settings_panel.go:
+// View() — if the value is off, the cursor's auto-scroll stops bringing the
+// new setting into the visible window. Render the panel at a height short
+// enough to force scroll mode, point the cursor at our setting, and assert it
+// appears in the rendered output.
+func TestSettingsPanel_ShowPaneTitles_ScrollMappingBringsRowIntoView(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	session.ClearUserConfigCache()
+	t.Cleanup(session.ClearUserConfigCache)
+
+	panel := NewSettingsPanel()
+	// Width comfortable, height short enough to force scroll-windowing in View().
+	panel.SetSize(100, 20)
+	panel.Show()
+	panel.cursor = int(SettingShowPaneTitles)
+
+	view := panel.View()
+
+	if !containsString(view, "Show pane titles") {
+		t.Fatalf("cursorToLine[SettingShowPaneTitles] must map to a line that scrolls the setting into view. "+
+			"View did not contain the row. Got:\n%s", view)
+	}
+	// Sanity: the panel must have actually entered scroll mode (otherwise this
+	// test passes trivially because the whole panel fits). Look for one of the
+	// scroll indicators.
+	if !containsString(view, "more above") && !containsString(view, "more below") {
+		t.Fatal("test must run with a small enough height to force scroll mode; " +
+			"neither '▲ more above' nor '▼ more below' appeared in the view")
+	}
+}

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -380,6 +380,7 @@ full_repaint = false                              # Force full screen clear ever
 default_filter = "active"                         # Initial status filter: "", "active", "running", "waiting", "idle", "error"
 active_filter_label = "Open"                      # Label for the active filter pill (default: "Open")
 active_filter_excludes = ["error", "stopped"]     # Statuses the % "Open" filter hides (default: ["error", "stopped"])
+show_pane_titles = false                          # Show the pane title (task description) on every row, not just the selected one
 ```
 
 | Key | Type | Default | Description |
@@ -388,6 +389,7 @@ active_filter_excludes = ["error", "stopped"]     # Statuses the % "Open" filter
 | `default_filter` | string | `""` | Status filter applied on TUI startup. `"active"` engages the configurable Open filter. Auto-clears if no sessions match. |
 | `active_filter_label` | string | `"Open"` | Label shown on the filter pill when active filter is engaged (e.g., "Active", "Live", "Open"). |
 | `active_filter_excludes` | []string | `["error", "stopped"]` | Statuses hidden when the `%` "Open" filter is engaged. Default matches the original hardcoded behavior. Valid values: `running`, `waiting`, `idle`, `error`, `starting`, `stopped`. Unknown entries are dropped silently; if the resulting list is empty the default applies. **Set to `["error"]`** to keep stopped/closed sessions visible while still hiding errors — fixes the over-broad "Open" semantics where closed sessions disappeared from view. Extend with `idle` for an aggressive "show only running/waiting" definition of open. |
+| `show_pane_titles` | bool | `false` | Shows the dim tmux pane-title (task description) suffix on every session row instead of only the selected row. Also toggleable in the TUI Settings panel (`S`) under **DISPLAY**. |
 
 ## [global_search] Section
 


### PR DESCRIPTION
## What
Adds an opt-in `[display].show_pane_titles` toggle (default `false`). When on,
every session row in the TUI list shows its dim tmux pane-title suffix (the
running tool's current task), not just the selected row.

## Why
The pane title is already computed and cached for every row, but one hardcoded
condition in `renderSessionItem` restricts the suffix to the selected row. There
was no way to keep all rows' task descriptions visible at a glance.

## How
Mirrors the existing `show_session_timestamps` toggle end to end:
- `[display].show_pane_titles` in `DisplaySettings` (`internal/session/userconfig.go`).
- Render gate in `renderSessionItem` (`internal/ui/home.go`): `selected` -> `(selected || h.showPaneTitles)`. Render-only; no extra tmux polling.
- Settings panel "Show pane titles" checkbox under DISPLAY, with load/save and the panel-config merge (`internal/ui/settings_panel.go`, `internal/session/userconfig_merge.go`).
- Documented in `skills/agent-deck/references/config-reference.md`.

Default `false` keeps current behavior unchanged.

## Tests
Three tests mirroring the `show_session_timestamps` trio:
- render gate: on/off x selected/unselected
- settings panel load, toggle round-trip, cursor scroll mapping
- panel-config merge persists true and false

## Verification
- `go test ./internal/ui/ ./internal/session/`: green.
- `go build ./...`, `gofmt -l`, `go vet`: clean.
- Manual: with `show_pane_titles = true`, each active session row shows its
  task-description suffix in the running TUI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-configurable display setting to show tmux pane titles for all session rows (defaults off). The toggle is exposed in the display settings, persists when saved, and continues to treat remote session pane titles as local-only.

* **Tests**
  * Added comprehensive tests covering pane-title rendering, settings panel loading/toggling/persistence, scroll mapping, and remote-session behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->