### PR TITLE
fix(conductor): create notifier/bridge log dir before start to avoid 209/STDOUT crash-loop

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -1590,6 +1590,7 @@ After=network.target
 
 [Service]
 Type=simple
+ExecStartPre=-/bin/mkdir -p __LOG_DIR__
 ExecStart=__PYTHON3__ __BRIDGE_PATH__
 Restart=always
 RestartSec=10
@@ -1615,6 +1616,7 @@ After=network.target
 
 [Service]
 Type=simple
+ExecStartPre=-/bin/mkdir -p __LOG_DIR__
 ExecStart=__AGENT_DECK__ notify-daemon
 Restart=always
 RestartSec=5
@@ -1733,6 +1735,7 @@ func GenerateSystemdBridgeService() (string, error) {
 	unit := strings.ReplaceAll(systemdBridgeServiceTemplate, "__PYTHON3__", python3Path)
 	unit = strings.ReplaceAll(unit, "__BRIDGE_PATH__", bridgePath)
 	unit = strings.ReplaceAll(unit, "__LOG_PATH__", logPath)
+	unit = strings.ReplaceAll(unit, "__LOG_DIR__", filepath.Dir(logPath))
 	unit = strings.ReplaceAll(unit, "__HOME__", homeDir)
 	agentDeckPath := FindAgentDeck()
 	unit = strings.ReplaceAll(unit, "__PATH__", buildDaemonPath(agentDeckPath))
@@ -1789,6 +1792,7 @@ func GenerateSystemdTransitionNotifierService() (string, error) {
 
 	unit := strings.ReplaceAll(systemdTransitionNotifierServiceTemplate, "__AGENT_DECK__", execPath)
 	unit = strings.ReplaceAll(unit, "__LOG_PATH__", logPath)
+	unit = strings.ReplaceAll(unit, "__LOG_DIR__", filepath.Dir(logPath))
 	unit = strings.ReplaceAll(unit, "__HOME__", homeDir)
 	unit = strings.ReplaceAll(unit, "__PATH__", buildDaemonPath(agentDeckPath))
 	return unit, nil


### PR DESCRIPTION
## What

Generated systemd units use `StandardOutput=append:<logpath>` (and `StandardError=append:<logpath>`), but nothing creates the parent directory. systemd's `append:` does **not** create the directory, so if the log dir does not yet exist, the unit fails before the binary runs:

```
Failed to set up standard output: No such file or directory
... status=209/STDOUT
```

With `Restart=always`, this becomes a crash-loop (observed restart counter > 120). It only "self-heals" if some other invocation happens to create the logs dir first — so it recurs on a fresh boot or whenever the dir is absent.

## Fix

Add a `__LOG_DIR__` placeholder substituted with `filepath.Dir(logPath)`, and emit `ExecStartPre=-/bin/mkdir -p __LOG_DIR__` in the affected systemd unit templates (both the conductor bridge and the transition-notifier), so the log directory is created before `ExecStart`. The leading `-` makes the step non-fatal. launchd/macOS plists are unchanged.

## Testing

- `go build ./...` — passes
- `go test ./internal/session/...` — passes (`ok`, ~47s)

## Notes

Affects Linux/systemd `--user` deployments. Verified by reproducing the `209/STDOUT` loop on a host whose `…/logs/` dir did not exist, and confirming a clean start after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed service startup reliability by automatically creating log directories before the conductor bridge and transition notifier services start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->