### PR TITLE
fix(conductor): only add /opt/homebrew/bin to generated unit PATH on macOS

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -868,7 +869,12 @@ func isExecutablePath(path string) bool {
 // processes (launchd, systemd) that don't inherit the user's shell PATH can
 // still find the agent-deck binary.
 func buildDaemonPath(agentDeckPath string) string {
-	baseEntries := []string{"/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"}
+	baseEntries := []string{"/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"}
+	if runtime.GOOS == "darwin" {
+		// Homebrew on Apple Silicon installs to /opt/homebrew/bin; that path
+		// does not exist on Linux, so only include it on macOS.
+		baseEntries = []string{"/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"}
+	}
 	ordered := make([]string, 0, len(baseEntries)+1)
 	seen := map[string]struct{}{}
 

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -1317,7 +1318,7 @@ func TestBuildDaemonPath(t *testing.T) {
 			name:          "custom path included",
 			agentDeckPath: "/custom/tools/bin/agent-deck",
 			wantPrefix:    "/custom/tools/bin",
-			wantContains:  "/opt/homebrew/bin",
+			wantContains:  "/usr/local/bin",
 		},
 	}
 
@@ -1335,6 +1336,21 @@ func TestBuildDaemonPath(t *testing.T) {
 				t.Errorf("buildDaemonPath(%q) = %q, contains double colon", tt.agentDeckPath, result)
 			}
 		})
+	}
+}
+
+// TestBuildDaemonPath_HomebrewDarwinOnly verifies that /opt/homebrew/bin is
+// only injected into the daemon PATH base entries on macOS. On Linux the path
+// does not exist, so generated systemd units must not reference it.
+func TestBuildDaemonPath_HomebrewDarwinOnly(t *testing.T) {
+	// Use a non-homebrew agent-deck path so the only way /opt/homebrew/bin can
+	// appear is via the base entries.
+	result := buildDaemonPath("/custom/tools/bin/agent-deck")
+	hasHomebrew := strings.Contains(result, "/opt/homebrew/bin")
+	wantHomebrew := runtime.GOOS == "darwin"
+	if hasHomebrew != wantHomebrew {
+		t.Errorf("buildDaemonPath on GOOS=%q = %q; homebrew present=%v, want %v",
+			runtime.GOOS, result, hasHomebrew, wantHomebrew)
 	}
 }
 


### PR DESCRIPTION
## What

`buildDaemonPath` hardcodes `/opt/homebrew/bin` unconditionally in the base PATH entries baked into generated daemon units. `/opt/homebrew/bin` is an Apple-Silicon Homebrew path that does not exist on Linux, so Linux units get a bogus PATH entry. (It also means a bare command a unit shells out to could resolve unexpectedly.)

## Fix

Only include `/opt/homebrew/bin` when `runtime.GOOS == "darwin"`. macOS ordering is preserved exactly; no other entries are reordered and no new paths are added (kept intentionally minimal).

## Testing

- `go build ./...` — passes
- `go test ./internal/session/...` — passes (`ok`, ~47s)
- Updated `TestBuildDaemonPath` (the `custom path included` case previously asserted `/opt/homebrew/bin` is always present, which is no longer true off macOS).
- Added `TestBuildDaemonPath_HomebrewDarwinOnly` to lock in the platform-gated behavior (`/opt/homebrew/bin` present iff `GOOS == "darwin"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Adjusted daemon PATH configuration to conditionally include Homebrew-specific directory paths based on operating system, preventing unnecessary path references on non-macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->