### PR TITLE
fix(notify-daemon): don't rebind stopped/removed sessions from stale SessionEnd hook (fixes #1349)

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2938,14 +2938,27 @@ func streamSessionSend(inst *session.Instance, sessionRef, profile string, sentA
 	}
 
 	var jsonlPath string
+	// peers carries the latest profile snapshot so the resolve can refuse a
+	// transcript path that collides with another live instance's session id
+	// (issue #1349 defense-in-depth #2): streaming the wrong transcript is one
+	// of the corruption symptoms the rebind bug caused.
+	var peers []*session.Instance
+	if _, initial, _, loadErr := loadSessionData(profile); loadErr == nil {
+		peers = initial
+	}
 	deadline := time.Now().Add(opts.timeout)
 	for time.Now().Before(deadline) {
-		jsonlPath = resolvedInst.GetJSONLPath()
+		p, resolveErr := resolvedInst.GetJSONLPathChecked(peers)
+		if resolveErr != nil {
+			return fmt.Errorf("refusing to stream a colliding transcript: %w", resolveErr)
+		}
+		jsonlPath = p
 		if jsonlPath != "" {
 			break
 		}
 		// Refresh from DB in case the session was just created.
 		if _, freshInstances, _, loadErr := loadSessionData(profile); loadErr == nil {
+			peers = freshInstances
 			if fi, _, _ := ResolveSession(sessionRef, freshInstances); fi != nil {
 				resolvedInst = fi
 			}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3895,6 +3895,22 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		}
 	}
 
+	// Issue #1349 defense-in-depth #1: never bind a session id from a terminal
+	// hook event (e.g. SessionEnd). The status/event/ack bookkeeping above still
+	// applies, but a terminal payload's session_id is stale by definition and
+	// must not become a bind source — that is exactly what re-binds a
+	// stopped/removed session every poll cycle and collides session ids.
+	//
+	// Accepted tradeoff: if the daemon's first-ever observation of a session is
+	// a SessionEnd (e.g. it was down during the SessionStart/UserPromptSubmit
+	// edges and only the latest event survives in the hook file), the bind is
+	// skipped and the prior ClaudeSessionID stays. That is the correct call —
+	// the session is already gone, so binding its (possibly reused) id onto a
+	// now-dead instance is the corruption we are preventing, not a feature.
+	if isTerminalHookEvent(status.Event) {
+		return
+	}
+
 	// Resolve session ID from hook payload first, then sidecar anchor.
 	sessionID := strings.TrimSpace(status.SessionID)
 	hookSource := "hook_payload"
@@ -4691,6 +4707,67 @@ func (i *Instance) GetLastResponseBestEffort() (*ResponseOutput, error) {
 	}
 
 	return nil, err
+}
+
+// ClaudeSessionIDCollidesWith reports whether another LIVE instance in peers
+// would resolve to the SAME transcript as this instance: it shares this
+// instance's (non-empty) ClaudeSessionID AND resolves to the same transcript
+// directory (same Claude config dir + same encoded project path). A many-to-one
+// session-id → live-instance mapping on one transcript is the data-integrity
+// hazard #1349 describes: two live instances pointed at one transcript would
+// cross-route input/output. Two instances that happen to share a session id but
+// resolve to different transcript dirs (different project/config) are NOT a
+// collision and are not blocked.
+func (i *Instance) ClaudeSessionIDCollidesWith(peers []*Instance) bool {
+	if i.ClaudeSessionID == "" {
+		return false
+	}
+	mine := i.claudeTranscriptDir()
+	for _, p := range peers {
+		if p == nil || p.ID == i.ID {
+			continue
+		}
+		if p.ClaudeSessionID != i.ClaudeSessionID || !isLiveSessionStatus(p.Status) {
+			continue
+		}
+		if p.claudeTranscriptDir() == mine {
+			return true
+		}
+	}
+	return false
+}
+
+// claudeTranscriptDir returns the directory that GetJSONLPath would place this
+// instance's transcript in (config dir + encoded project path), used to decide
+// whether two instances would collide on the same transcript file. It mirrors
+// GetJSONLPath's resolution (GetClaudeConfigDir + i.ProjectPath) exactly, so the
+// collision verdict matches the path the guard protects.
+func (i *Instance) claudeTranscriptDir() string {
+	configDir := GetClaudeConfigDir()
+	resolvedPath := i.ProjectPath
+	if resolved, err := filepath.EvalSymlinks(i.ProjectPath); err == nil {
+		resolvedPath = resolved
+	}
+	return filepath.Join(configDir, "projects", ConvertToClaudeDirName(resolvedPath))
+}
+
+// GetJSONLPathChecked is the collision-aware variant of GetJSONLPath (issue
+// #1349 defense-in-depth #2). Given the set of instances it shares a profile
+// with, it refuses to resolve a transcript path when this instance's
+// ClaudeSessionID collides with another LIVE instance's ClaudeSessionID —
+// because two live instances mapped to one session-id would otherwise read the
+// same transcript, corrupting routing. When there is no collision it delegates
+// to GetJSONLPath.
+func (i *Instance) GetJSONLPathChecked(peers []*Instance) (string, error) {
+	if i.ClaudeSessionIDCollidesWith(peers) {
+		_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
+			InstanceID: i.ID, Tool: i.Tool, Action: "reject",
+			Source: "jsonl_resolve", OldID: i.ClaudeSessionID, Candidate: i.ClaudeSessionID,
+			Reason: "claude_session_id_collision_across_live_instances",
+		})
+		return "", fmt.Errorf("claude_session_id %q is shared by more than one live instance; refusing to resolve a colliding transcript path for instance %s", i.ClaudeSessionID, i.ID)
+	}
+	return i.GetJSONLPath(), nil
 }
 
 // GetJSONLPath returns the path to the Claude session JSONL file for analytics

--- a/internal/session/issue1349_rebind_guard_test.go
+++ b/internal/session/issue1349_rebind_guard_test.go
@@ -1,0 +1,487 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Issue #1349 (High-severity data-integrity bug): the notify-daemon rebinds
+// STOPPED/REMOVED sessions' Claude session-ids every poll cycle from a stale
+// SessionEnd hook file, causing session-id collisions that corrupt routing.
+//
+// These three regression tests pin the three guards of the fix:
+//   1. TestSyncOnce_DoesNotRebindStoppedSession  — liveness gate in the daemon.
+//   2. TestUpdateHookStatus_IgnoresSessionEndEvent — terminal-event guard.
+//   3. TestGetJSONLPath_NoCollisionAcrossInstances — collision guard.
+//
+// Written test-first: each must FAIL on pre-#1349 main.
+
+// seedHookStatusFile writes a <instanceID>.json hook status file into the
+// hooks dir that readHookStatusFile / hookStatusForInstance reads, modelling
+// the stale SessionEnd record that lingers for 24h after a session ends.
+func seedHookStatusFile(t *testing.T, instanceID, event, sessionID, status string) {
+	t.Helper()
+	dir := GetHooksDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	payload := map[string]any{
+		"status":     status,
+		"session_id": sessionID,
+		"event":      event,
+		"ts":         time.Now().Unix(),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal hook payload: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, instanceID+".json"), data, 0o644); err != nil {
+		t.Fatalf("write hook file: %v", err)
+	}
+}
+
+// readLifecycleEventsFor returns every session-id-lifecycle event recorded for
+// the given instance id.
+func readLifecycleEventsFor(t *testing.T, instanceID string) []SessionIDLifecycleEvent {
+	t.Helper()
+	path := GetSessionIDLifecycleLogPath()
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("open lifecycle log: %v", err)
+	}
+	defer f.Close()
+
+	var out []SessionIDLifecycleEvent
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev SessionIDLifecycleEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+		if ev.InstanceID == instanceID {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// bootstrapDaemonProfile sets up an isolated HOME + agent-deck profile and
+// returns a daemon wired to that profile's storage, plus the storage.
+func bootstrapDaemonProfile(t *testing.T, profile string) (*TransitionDaemon, *Storage) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("AGENT_DECK_PROFILE", profile)
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+	if err := os.MkdirAll(filepath.Join(home, ".agent-deck"), 0o700); err != nil {
+		t.Fatalf("mkdir agent-deck: %v", err)
+	}
+
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+
+	// Wire the global DB so bindClaudeSessionFromHook's WriteClaudeSessionBinding
+	// persists into the same DB we read back from.
+	statedb.SetGlobal(storage.GetDB())
+	t.Cleanup(func() { statedb.SetGlobal(nil) })
+
+	d := NewTransitionDaemon()
+	d.storages[profile] = storage
+	return d, storage
+}
+
+// writeTranscript1349 materializes a Claude transcript jsonl for the given instance
+// + session id with `n` conversation records (each containing a "sessionId"
+// field, which is what sessionHasConversationData detects). Larger n => larger
+// byte size, so it can win the v1.7.23 size guard during a rebind.
+func writeTranscript1349(t *testing.T, inst *Instance, sessionID string, n int) {
+	t.Helper()
+	configDir := GetClaudeConfigDirForInstance(inst)
+	projDir := filepath.Join(configDir, "projects", ConvertToClaudeDirName(inst.EffectiveWorkingDir()))
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir transcript dir: %v", err)
+	}
+	f, err := os.Create(filepath.Join(projDir, sessionID+".jsonl"))
+	if err != nil {
+		t.Fatalf("create transcript: %v", err)
+	}
+	defer f.Close()
+	for i := 0; i < n; i++ {
+		rec := map[string]any{
+			"sessionId": sessionID,
+			"type":      "user",
+			"message":   map[string]any{"role": "user", "content": "hello world record padding"},
+		}
+		b, _ := json.Marshal(rec)
+		if _, err := f.Write(append(b, '\n')); err != nil {
+			t.Fatalf("write transcript record: %v", err)
+		}
+	}
+}
+
+// TestSyncOnce_DoesNotRebindStoppedSession is the PRIMARY regression test for
+// #1349. A stopped Claude instance bound to session "X" has a lingering stale
+// SessionEnd hook file naming session "Y". Session "Y" even has richer
+// conversation data than "X" (so the size-based rebind guard would NOT block
+// it). The daemon poll must STILL NOT rebind it, because a stopped session is
+// not live — its session id must never change from a stale terminal hook.
+func TestSyncOnce_DoesNotRebindStoppedSession(t *testing.T) {
+	const profile = "_test_issue1349_stopped"
+	d, storage := bootstrapDaemonProfile(t, profile)
+
+	const sessX = "11111111-1111-1111-1111-111111111111"
+	const sessY = "22222222-2222-2222-2222-222222222222"
+
+	inst := &Instance{
+		ID:              "stopped-inst-1349",
+		Title:           "stopped",
+		ProjectPath:     filepath.Join(os.Getenv("HOME"), "issue1349-stopped"),
+		GroupPath:       DefaultGroupPath,
+		Tool:            "claude",
+		Status:          StatusStopped,
+		ClaudeSessionID: sessX,
+		CreatedAt:       time.Now(),
+	}
+	if err := os.MkdirAll(inst.ProjectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := storage.SaveWithGroups([]*Instance{inst}, nil); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// X is the bound session; Y is the stale-hook candidate with MORE data, so
+	// the size/data guards in UpdateHookStatus would otherwise allow the rebind.
+	writeTranscript1349(t, inst, sessX, 1)
+	writeTranscript1349(t, inst, sessY, 50)
+
+	// Lingering stale terminal hook record naming the DIFFERENT session id.
+	seedHookStatusFile(t, inst.ID, "SessionEnd", sessY, "dead")
+
+	// Run several poll cycles.
+	for i := 0; i < 3; i++ {
+		d.syncProfile(profile)
+	}
+
+	// Assert: no bind/rebind lifecycle event for this instance.
+	for _, ev := range readLifecycleEventsFor(t, inst.ID) {
+		if ev.Action == "bind" || ev.Action == "rebind" {
+			t.Fatalf("stopped session was rebound: got lifecycle action %q (old=%q new=%q event=%q)",
+				ev.Action, ev.OldID, ev.NewID, ev.HookEvent)
+		}
+	}
+
+	// Assert: DB claude_session_id stays "X".
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	var got string
+	for _, in := range instances {
+		if in.ID == inst.ID {
+			got = in.ClaudeSessionID
+		}
+	}
+	if got != sessX {
+		t.Fatalf("stopped session claude_session_id changed: want %q, got %q", sessX, got)
+	}
+}
+
+// TestUpdateHookStatus_IgnoresSessionEndEvent is DEFENSE-IN-DEPTH #1: even when
+// UpdateHookStatus is invoked directly with a terminal SessionEnd payload, it
+// must never bind the session id from that payload.
+func TestUpdateHookStatus_IgnoresSessionEndEvent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	const sessX = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	const sessY = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+	inst := &Instance{
+		ID:              "sessionend-inst-1349",
+		Title:           "ended",
+		ProjectPath:     filepath.Join(home, "issue1349-ended"),
+		GroupPath:       DefaultGroupPath,
+		Tool:            "claude",
+		Status:          StatusStopped,
+		ClaudeSessionID: sessX,
+		CreatedAt:       time.Now(),
+	}
+	if err := os.MkdirAll(inst.ProjectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	// Give the SessionEnd candidate (Y) richer data than the bound session (X)
+	// so the size/data guards in UpdateHookStatus would otherwise permit the
+	// rebind. The terminal-event guard must reject it regardless.
+	writeTranscript1349(t, inst, sessX, 1)
+	writeTranscript1349(t, inst, sessY, 50)
+
+	inst.UpdateHookStatus(&HookStatus{
+		Event:     "SessionEnd",
+		SessionID: sessY,
+		Status:    "dead",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.ClaudeSessionID != sessX {
+		t.Fatalf("SessionEnd payload rebound the session id: want %q, got %q", sessX, inst.ClaudeSessionID)
+	}
+}
+
+// TestGetJSONLPath_NoCollisionAcrossInstances is DEFENSE-IN-DEPTH #2: two live
+// instances forced to share the same claude_session_id (and project path) must
+// not silently resolve to the same transcript path — the resolver must refuse
+// or flag the collision.
+func TestGetJSONLPath_NoCollisionAcrossInstances(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	projectPath := filepath.Join(home, "proj1349")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+
+	// Materialize a transcript file so a naive GetJSONLPath would return it.
+	configDir := GetClaudeConfigDir()
+	projDir := filepath.Join(configDir, "projects", ConvertToClaudeDirName(projectPath))
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir claude project dir: %v", err)
+	}
+	sharedID := "SHARED-SESSION-ID"
+	jsonl := filepath.Join(projDir, sharedID+".jsonl")
+	if err := os.WriteFile(jsonl, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	mk := func(id string) *Instance {
+		return &Instance{
+			ID:              id,
+			Title:           id,
+			ProjectPath:     projectPath,
+			GroupPath:       DefaultGroupPath,
+			Tool:            "claude",
+			Status:          StatusRunning,
+			ClaudeSessionID: sharedID,
+			CreatedAt:       time.Now(),
+		}
+	}
+	a := mk("inst-a-1349")
+	b := mk("inst-b-1349")
+
+	// The collision-aware resolver must refuse rather than silently return the
+	// same transcript path for two distinct live instances.
+	pathA, errA := a.GetJSONLPathChecked([]*Instance{a, b})
+	if errA == nil {
+		t.Fatalf("expected collision error for instance a, got path %q", pathA)
+	}
+	pathB, errB := b.GetJSONLPathChecked([]*Instance{a, b})
+	if errB == nil {
+		t.Fatalf("expected collision error for instance b, got path %q", pathB)
+	}
+}
+
+// TestGetJSONLPathChecked_NoCollisionResolvesNormally guards against the
+// collision check over-blocking: a unique session id (no other live instance
+// shares it) must resolve to its real transcript path, identical to GetJSONLPath.
+func TestGetJSONLPathChecked_NoCollisionResolvesNormally(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	projectPath := filepath.Join(home, "proj1349-unique")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := &Instance{
+		ID:              "inst-unique-1349",
+		Title:           "unique",
+		ProjectPath:     projectPath,
+		GroupPath:       DefaultGroupPath,
+		Tool:            "claude",
+		Status:          StatusRunning,
+		ClaudeSessionID: "UNIQUE-SESSION-ID",
+		CreatedAt:       time.Now(),
+	}
+	writeTranscript1349(t, inst, inst.ClaudeSessionID, 3)
+
+	// A sibling with a DIFFERENT session id must not trip the collision guard.
+	sibling := &Instance{
+		ID:              "sibling-1349",
+		ProjectPath:     projectPath,
+		GroupPath:       DefaultGroupPath,
+		Tool:            "claude",
+		Status:          StatusRunning,
+		ClaudeSessionID: "OTHER-SESSION-ID",
+		CreatedAt:       time.Now(),
+	}
+
+	got, err := inst.GetJSONLPathChecked([]*Instance{inst, sibling})
+	if err != nil {
+		t.Fatalf("unique session id was wrongly flagged as a collision: %v", err)
+	}
+	if want := inst.GetJSONLPath(); got != want || got == "" {
+		t.Fatalf("checked resolve mismatch: got %q, want %q", got, want)
+	}
+}
+
+// TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision is the Codex
+// medium-finding guard: two live instances that share a session id but resolve
+// to DIFFERENT transcript directories (different project paths) do not collide
+// on one transcript file, so the guard must not block either.
+func TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	const sharedID = "SAME-ID-DIFFERENT-PROJECT"
+
+	mk := func(id, sub string) *Instance {
+		pp := filepath.Join(home, sub)
+		if err := os.MkdirAll(pp, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+		inst := &Instance{
+			ID:              id,
+			Title:           id,
+			ProjectPath:     pp,
+			GroupPath:       DefaultGroupPath,
+			Tool:            "claude",
+			Status:          StatusRunning,
+			ClaudeSessionID: sharedID,
+			CreatedAt:       time.Now(),
+		}
+		writeTranscript1349(t, inst, sharedID, 2)
+		return inst
+	}
+	a := mk("inst-a-diffproj", "projA")
+	b := mk("inst-b-diffproj", "projB")
+
+	gotA, errA := a.GetJSONLPathChecked([]*Instance{a, b})
+	if errA != nil {
+		t.Fatalf("same id but different project wrongly flagged as collision for a: %v", errA)
+	}
+	gotB, errB := b.GetJSONLPathChecked([]*Instance{a, b})
+	if errB != nil {
+		t.Fatalf("same id but different project wrongly flagged as collision for b: %v", errB)
+	}
+	if gotA == "" || gotB == "" || gotA == gotB {
+		t.Fatalf("expected two distinct non-empty transcript paths, got a=%q b=%q", gotA, gotB)
+	}
+}
+
+// TestSyncOnce_StillRebindsLiveSession guards against the liveness gate
+// over-blocking: a genuinely LIVE Claude session (running status + a real tmux
+// session) MUST still rebind from a fresh non-terminal hook (e.g. SessionStart
+// after /clear). This is the legitimate path #1349's fix must preserve.
+func TestSyncOnce_StillRebindsLiveSession(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	const profile = "_test_issue1349_live"
+	d, storage := bootstrapDaemonProfile(t, profile)
+
+	const sessOld = "33333333-3333-3333-3333-333333333333"
+	const sessNew = "44444444-4444-4444-4444-444444444444"
+
+	// Start a real tmux session so inst.Exists() is true.
+	sessName := tmux.SessionPrefix + "issue1349-live-" + strconv.Itoa(int(time.Now().UnixNano()))
+	if err := exec.Command("tmux", "new-session", "-d", "-s", sessName, "sh", "-c", "sleep 3600").Run(); err != nil {
+		t.Fatalf("create tmux session: %v", err)
+	}
+	t.Cleanup(func() { _ = exec.Command("tmux", "kill-session", "-t", sessName).Run() })
+
+	projectPath := filepath.Join(os.Getenv("HOME"), "issue1349-live")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	inst := &Instance{
+		ID:              "live-inst-1349",
+		Title:           "live",
+		ProjectPath:     projectPath,
+		GroupPath:       DefaultGroupPath,
+		Tool:            "claude",
+		Status:          StatusRunning,
+		ClaudeSessionID: sessOld,
+		CreatedAt:       time.Now(),
+	}
+	// Attach the live tmux session the same way the TUI does on cold start, so
+	// inst.Exists() resolves true against the real tmux server.
+	inst.SetTmuxSessionForTest(tmux.ReconnectSessionLazy(sessName, inst.ID, projectPath, "claude", "running"))
+	if err := storage.SaveWithGroups([]*Instance{inst}, nil); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Fresh /clear: new session has strictly more data, non-terminal event.
+	writeTranscript1349(t, inst, sessOld, 1)
+	writeTranscript1349(t, inst, sessNew, 50)
+	seedHookStatusFile(t, inst.ID, "SessionStart", sessNew, "running")
+
+	for i := 0; i < 2; i++ {
+		d.syncProfile(profile)
+	}
+
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	var got string
+	for _, in := range instances {
+		if in.ID == inst.ID {
+			got = in.ClaudeSessionID
+		}
+	}
+	if got != sessNew {
+		t.Fatalf("live session failed to rebind: want %q, got %q (the liveness gate over-blocked a legit rebind)", sessNew, got)
+	}
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -191,7 +191,18 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 		byID[inst.ID] = inst
 		if IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" {
 			if hs := d.hookStatusForInstance(inst.ID); hs != nil {
-				inst.UpdateHookStatus(hs)
+				// Issue #1349: only let a hook status rebind the session id when
+				// the instance is actually LIVE (running/waiting/idle with a real
+				// tmux session). A stopped/removed session keeps a stale
+				// SessionEnd hook file for up to 24h; without this gate the daemon
+				// rebinds its session id every poll cycle from that stale record,
+				// colliding two ids onto one session-id and corrupting routing
+				// (wrong transcript, dropped completions, mis-delivered input).
+				// Done-signal / transition-candidate handling stays unguarded so
+				// terminal completions are still observed.
+				if isLiveSessionStatus(inst.Status) && inst.Exists() {
+					inst.UpdateHookStatus(hs)
+				}
 				hookStatuses[inst.ID] = hs
 				if candidate, ok := terminalHookTransitionCandidate(inst.Tool, hs); ok {
 					hookCandidates[inst.ID] = candidate
@@ -551,6 +562,30 @@ func terminalHookTransitionCandidate(tool string, hs *HookStatus) (hookTransitio
 		}
 	}
 	return hookTransitionCandidate{}, false
+}
+
+// isTerminalHookEvent reports whether a hook event name denotes session/thread
+// termination (issue #1349). It mirrors the allowlist in
+// cmd/agent-deck/hook_handler.go:isTerminalHookEvent (kept in the main package
+// for the hook writer); this copy lets the session package refuse to bind a
+// session id from a terminal payload. A SessionEnd record must never be a bind
+// source — by the time it fires the session is gone, so its session_id is at
+// best stale and at worst belongs to a different live session after id reuse.
+func isTerminalHookEvent(event string) bool {
+	norm := strings.ToLower(strings.TrimSpace(event))
+	if norm == "" {
+		return false
+	}
+	norm = strings.NewReplacer(".", "", "-", "", "_", "", "/", "", " ", "").Replace(norm)
+	switch norm {
+	case "sessionend", "sessionended", "sessionclose", "sessionclosed", "sessiondone", "sessionexit", "sessionexited",
+		"onsessionend",
+		"threadend", "threadended", "threadterminate", "threadterminated", "threadclose", "threadclosed",
+		"threaddone", "threadexit", "threadexited":
+		return true
+	default:
+		return false
+	}
 }
 
 func isCodexTerminalHookEvent(event string) bool {


### PR DESCRIPTION
## Root cause (#1349, confirmed on main / v1.9.52)

`agent-deck notify-daemon` rebound STOPPED/REMOVED sessions' Claude session-ids on every ~3s poll cycle from a stale `SessionEnd` hook file, causing session-id collisions that corrupt routing (wrong `session output` transcript, dropped child completions, dead-letters with empty target, mis-delivered input).

The chain:
1. On `SessionEnd` the hook handler writes a `<instanceID>.json` status file carrying a `session_id` and only clears the sidecar anchor, so a stale terminal record lingers for ~24h.
2. The daemon poll loop (`transition_daemon.syncProfile`) called `inst.UpdateHookStatus(hs)` for **every** claude/codex/gemini instance regardless of status, with no liveness/freshness guard.
3. `UpdateHookStatus` -> `bindClaudeSessionFromHook` wrote a `rebind` lifecycle event + DB binding every cycle. Since the transcript path is derived from `ClaudeSessionID`, two ids colliding on one session-id resolve to one transcript -> corruption.

## The fix (primary + two defense-in-depth guards)

- **PRIMARY — liveness-gate the rebind.** In `transition_daemon.syncProfile`, only call `inst.UpdateHookStatus(hs)` when `isLiveSessionStatus(inst.Status) && inst.Exists()`. A stopped/removed session is never rebound from a stale hook. Done-signal / transition-candidate handling stays unguarded so terminal completions are still observed.
- **DEFENSE #1 — never bind from a terminal event.** `UpdateHookStatus` returns before the session-id bind when `isTerminalHookEvent(status.Event)` (covers `SessionEnd` and friends). A terminal payload's `session_id` is stale by definition and must never be a bind source. Status/event/ack bookkeeping still applies.
- **DEFENSE #2 — collision guard.** `GetJSONLPathChecked(peers)` refuses to resolve a transcript path (and logs a `reject` lifecycle event) when a `claude_session_id` would resolve to the same transcript dir for more than one **live** instance. The check is path-aware: instances that share an id but resolve to different project/config dirs are NOT blocked. Wired into the `session output --stream` resolve loop (the routing-critical path).

## Regression tests (`internal/session/issue1349_rebind_guard_test.go`)

All three primary tests fail on main first, pass after the fix:
- `TestSyncOnce_DoesNotRebindStoppedSession` — primary: stopped session with a richer-data stale `SessionEnd` candidate is NOT rebound.
- `TestUpdateHookStatus_IgnoresSessionEndEvent` — defense #1: a `SessionEnd` payload never rebinds.
- `TestGetJSONLPath_NoCollisionAcrossInstances` — defense #2: two live instances sharing a session-id + transcript dir are refused.

Plus two over-blocking guards proving the fix preserves legitimate behavior:
- `TestSyncOnce_StillRebindsLiveSession` — a genuinely live session (running + real tmux) STILL rebinds from a fresh non-terminal hook.
- `TestGetJSONLPathChecked_NoCollisionResolvesNormally` / `TestGetJSONLPathChecked_SameIDDifferentProjectIsNotCollision` — unique ids and same-id-different-project resolve normally.

## Verification

- All 6 issue-1349 tests pass (sandboxed HOME+XDG).
- Affected packages green: `./internal/session/`, `./cmd/agent-deck/`.
- Full `go test -race ./...` green: 44 packages OK, 0 FAIL, 0 DATA RACE.
- Dual-reviewed with Codex; its High finding (guard not wired into a production call site) and Medium finding (path-aware collision) are both addressed in this PR.

Closes #1349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential issue where incorrect transcripts could be streamed when multiple instances are running simultaneously.
  * Added guards to prevent session state corruption from stale session records.
  * Improved collision detection to prevent transcript path conflicts when multiple instances target the same directory.

* **Tests**
  * Added comprehensive regression test suite covering session rebinding guards, transcript collision detection, and liveness validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->