### PR TITLE
fix(fork): make gitignored-copy opt-in (with_ignored default off)

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2028,7 +2028,9 @@ type ForkSettings struct {
 	Worktree *bool `toml:"worktree"`
 	// WithState carries the parent's tracked uncommitted changes. nil => true.
 	WithState *bool `toml:"with_state"`
-	// WithIgnored also copies gitignored files (implies WithState). nil => true.
+	// WithIgnored also copies gitignored files (implies WithState). nil => false:
+	// the gitignored tree is unbounded (data sets, virtual envs, node_modules)
+	// and may carry secrets (.env), so copying it is opt-in. See GetWithIgnored.
 	WithIgnored *bool `toml:"with_ignored"`
 	// Docker selects sandbox behavior: "auto" (match parent) | "on" | "off".
 	// nil/unknown => "auto". Mirrors the [tmux].launch_as string-enum convention.
@@ -2043,8 +2045,13 @@ func (f ForkSettings) GetWorktree() bool { return f.Worktree == nil || *f.Worktr
 // GetWithState reports whether forks carry tracked state (default ON).
 func (f ForkSettings) GetWithState() bool { return f.WithState == nil || *f.WithState }
 
-// GetWithIgnored reports whether forks copy gitignored files (default ON).
-func (f ForkSettings) GetWithIgnored() bool { return f.WithIgnored == nil || *f.WithIgnored }
+// GetWithIgnored reports whether forks copy gitignored files (default OFF).
+// Off by default because the gitignored tree is unbounded (data sets, virtual
+// envs, node_modules) and can carry secrets (.env); copying it silently blocks
+// the fork with no size cap or progress. Opt in per fork via the Shift+F
+// dialog, globally via [fork].with_ignored = true, or wholesale via
+// inherit_from_parent.
+func (f ForkSettings) GetWithIgnored() bool { return f.WithIgnored != nil && *f.WithIgnored }
 
 // GetDocker returns the canonical docker mode: "auto" | "on" | "off".
 // Mirrors GetLaunchAs: lowercase/trim, unknown/nil -> "auto".

--- a/internal/session/userconfig_fork_test.go
+++ b/internal/session/userconfig_fork_test.go
@@ -20,7 +20,7 @@ func TestForkSettings_StructuralDefaults_WhenSectionAbsent(t *testing.T) {
 	cfg := decodeForkConfig(t, ``)
 	assert.True(t, cfg.Fork.GetWorktree(), "worktree default ON when unset")
 	assert.True(t, cfg.Fork.GetWithState(), "with_state default ON when unset")
-	assert.True(t, cfg.Fork.GetWithIgnored(), "with_ignored default ON when unset")
+	assert.False(t, cfg.Fork.GetWithIgnored(), "with_ignored default OFF when unset (opt-in: unbounded copy + may carry secrets)")
 	assert.Equal(t, "auto", cfg.Fork.GetDocker(), "docker default 'auto' when unset")
 	assert.Equal(t, "fork/", cfg.Fork.GetBranchPrefix(), "branch_prefix default when unset")
 	assert.False(t, cfg.Fork.InheritFromParent, "inherit_from_parent default false")
@@ -61,9 +61,10 @@ func TestForkSettings_GetBranchPrefix_TrimsWhitespace(t *testing.T) {
 
 func TestForkSettings_Resolve_ComprehensiveDefault_DockerAuto(t *testing.T) {
 	cfg := decodeForkConfig(t, ``) // all defaults
-	// parent NOT sandboxed -> auto resolves sandbox off
+	// parent NOT sandboxed -> auto resolves sandbox off. with_ignored is opt-in,
+	// so the default plan carries tracked state but not the gitignored tree.
 	p := cfg.Fork.Resolve(false)
-	assert.Equal(t, ResolvedForkPlan{Worktree: true, WithState: true, WithIgnored: true, Sandbox: false}, p)
+	assert.Equal(t, ResolvedForkPlan{Worktree: true, WithState: true, WithIgnored: false, Sandbox: false}, p)
 	// parent sandboxed -> auto resolves sandbox on
 	p = cfg.Fork.Resolve(true)
 	assert.True(t, p.Sandbox, "docker=auto with sandboxed parent -> sandbox on")

--- a/internal/ui/fork_quick_test.go
+++ b/internal/ui/fork_quick_test.go
@@ -20,7 +20,7 @@ func TestQuickForkInputs_DefaultsAndBranchSlug(t *testing.T) {
 	assert.Equal(t, "fork/my-feature", in.Branch)
 	assert.True(t, in.Plan.Worktree)
 	assert.True(t, in.Plan.WithState)
-	assert.True(t, in.Plan.WithIgnored)
+	assert.False(t, in.Plan.WithIgnored, "with_ignored is opt-in; off by default")
 	assert.False(t, in.Plan.Sandbox)
 }
 

--- a/internal/ui/fork_state_gate_test.go
+++ b/internal/ui/fork_state_gate_test.go
@@ -21,7 +21,7 @@ func TestGateForkStateForBackend_NonGitDegradesWithState(t *testing.T) {
 	src := session.NewInstanceWithTool("feat", t.TempDir(), "claude")
 	in := quickForkInputs(src, session.ForkSettings{}, false)
 	require.True(t, in.Plan.WithState, "precondition: comprehensive default forces with-state")
-	require.True(t, in.Plan.WithIgnored, "precondition: comprehensive default forces with-ignored")
+	require.False(t, in.Plan.WithIgnored, "precondition: with-ignored is opt-in (off by default)")
 
 	out := gateForkStateForBackend(in, src.ProjectPath)
 
@@ -57,7 +57,7 @@ func TestResolveQuickForkSpec_GitRepoKeepsWithState(t *testing.T) {
 	spec := resolveQuickForkSpec(src, session.ForkSettings{})
 
 	assert.True(t, spec.Plan.WithState, "git repos keep the with-state default through the f path")
-	assert.True(t, spec.Plan.WithIgnored)
+	assert.False(t, spec.Plan.WithIgnored, "with-ignored is opt-in; off by default even on git")
 }
 
 // A real git repo must keep the with-state default untouched.
@@ -74,7 +74,7 @@ func TestGateForkStateForBackend_GitRepoKeepsWithState(t *testing.T) {
 	out := gateForkStateForBackend(in, repo)
 
 	assert.True(t, out.Plan.WithState, "git repos keep the with-state default")
-	assert.True(t, out.Plan.WithIgnored, "git repos keep the with-ignored default")
+	assert.False(t, out.Plan.WithIgnored, "with-ignored stays off by default (opt-in) even on git")
 }
 
 // A colocated jujutsu repo is state-capable as of #1305 (jj-native with-state
@@ -99,6 +99,6 @@ func TestGateForkStateForBackend_JujutsuKeepsWithState(t *testing.T) {
 	out := gateForkStateForBackend(in, repo)
 
 	assert.True(t, out.Plan.WithState, "jujutsu is state-capable (#1305) — with-state must be kept")
-	assert.True(t, out.Plan.WithIgnored, "with-ignored follows with-state on jj")
+	assert.False(t, out.Plan.WithIgnored, "with-ignored is opt-in; off by default on jj")
 	assert.True(t, out.Plan.Worktree)
 }

--- a/internal/ui/forkdialog_fork_defaults_test.go
+++ b/internal/ui/forkdialog_fork_defaults_test.go
@@ -34,7 +34,7 @@ func forkDefaultsGitRepo(t *testing.T) string {
 
 // With no [fork] config present, the dialog opens reflecting the built-in
 // defaults: worktree + with-state ON, gitignored OFF (opt-in).
-func TestForkDialog_Show_SeedsComprehensiveWithStateDefault(t *testing.T) {
+func TestForkDialog_Show_SeedsWithStateDefaultGitignoredOff(t *testing.T) {
 	repo := forkDefaultsGitRepo(t)
 
 	d := NewForkDialog()

--- a/internal/ui/forkdialog_fork_defaults_test.go
+++ b/internal/ui/forkdialog_fork_defaults_test.go
@@ -32,8 +32,8 @@ func forkDefaultsGitRepo(t *testing.T) string {
 	return repo
 }
 
-// With no [fork] config present, the dialog opens reflecting the comprehensive
-// built-in defaults: with-state ON and (in a git repo) gitignored ON.
+// With no [fork] config present, the dialog opens reflecting the built-in
+// defaults: worktree + with-state ON, gitignored OFF (opt-in).
 func TestForkDialog_Show_SeedsComprehensiveWithStateDefault(t *testing.T) {
 	repo := forkDefaultsGitRepo(t)
 
@@ -42,7 +42,7 @@ func TestForkDialog_Show_SeedsComprehensiveWithStateDefault(t *testing.T) {
 
 	assert.True(t, d.IsWorktreeEnabled(), "worktree seeded ON in a git repo")
 	assert.True(t, d.IsWithStateEnabled(), "with_state seeded ON from [fork] comprehensive default")
-	assert.True(t, d.IsWithStateAndGitignoredEnabled(), "with_ignored seeded ON from [fork] comprehensive default")
+	assert.False(t, d.IsWithStateAndGitignoredEnabled(), "with_ignored seeded OFF by default (opt-in)")
 }
 
 // A jujutsu repo is state-capable as of #1305, so Shift+F must present a

--- a/internal/ui/quick_fork_defaults_eval_test.go
+++ b/internal/ui/quick_fork_defaults_eval_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-// TestEval_ForkDialog_ComprehensiveDefaultsVisibleOnOpen proves that, with NO
+// TestEval_ForkDialog_BuiltInDefaultsVisibleOnOpen proves that, with NO
 // [fork] config present, the fork dialog opens on a git project with the
 // built-in defaults (worktree + carry-state) ALREADY checked while
 // include-gitignored renders unchecked — i.e. the user SEES the safe default
 // and can opt into the unbounded gitignored copy without it firing silently.
 // This is the disclosure-visible contract that pure getter tests can't express.
-func TestEval_ForkDialog_ComprehensiveDefaultsVisibleOnOpen(t *testing.T) {
+func TestEval_ForkDialog_BuiltInDefaultsVisibleOnOpen(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not on PATH")
 	}

--- a/internal/ui/quick_fork_defaults_eval_test.go
+++ b/internal/ui/quick_fork_defaults_eval_test.go
@@ -14,8 +14,9 @@ import (
 
 // TestEval_ForkDialog_ComprehensiveDefaultsVisibleOnOpen proves that, with NO
 // [fork] config present, the fork dialog opens on a git project with the
-// comprehensive defaults (worktree + carry-state + gitignored) ALREADY checked
-// — i.e. the user SEES "comprehensive, tweak down" without pressing a key.
+// built-in defaults (worktree + carry-state) ALREADY checked while
+// include-gitignored renders unchecked — i.e. the user SEES the safe default
+// and can opt into the unbounded gitignored copy without it firing silently.
 // This is the disclosure-visible contract that pure getter tests can't express.
 func TestEval_ForkDialog_ComprehensiveDefaultsVisibleOnOpen(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
@@ -47,22 +48,25 @@ func TestEval_ForkDialog_ComprehensiveDefaultsVisibleOnOpen(t *testing.T) {
 	d.SetSize(90, 40)
 	d.Show("Eval Parent", repo, "", nil, "")
 
-	// State getters: comprehensive defaults seeded with zero interaction.
+	// State getters: defaults seeded with zero interaction. Worktree +
+	// carry-parent-state default ON; include-gitignored is opt-in (off).
 	if !d.IsWorktreeEnabled() {
 		t.Error("worktree must default ON in a git repo with no [fork] config")
 	}
 	if !d.IsWithStateEnabled() {
 		t.Error("carry-parent-state must default ON with no [fork] config")
 	}
-	if !d.IsWithStateAndGitignoredEnabled() {
-		t.Error("include-gitignored must default ON with no [fork] config")
+	if d.IsWithStateAndGitignoredEnabled() {
+		t.Error("include-gitignored must default OFF with no [fork] config (opt-in)")
 	}
 
-	// Rendered, user-visible disclosure: the checked boxes appear on open.
+	// Rendered, user-visible disclosure: carry-state is checked on open;
+	// include-gitignored renders unchecked so its cost is opt-in.
 	view := d.View()
-	for _, want := range []string{"[x] Carry parent state", "[x] Include gitignored files"} {
-		if !strings.Contains(view, want) {
-			t.Errorf("dialog must render %q checked on open; view:\n%s", want, view)
-		}
+	if !strings.Contains(view, "[x] Carry parent state") {
+		t.Errorf("dialog must render %q checked on open; view:\n%s", "[x] Carry parent state", view)
+	}
+	if !strings.Contains(view, "[ ] Include gitignored files") {
+		t.Errorf("dialog must render %q unchecked on open; view:\n%s", "[ ] Include gitignored files", view)
 	}
 }

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -310,24 +310,24 @@ branch_prefix = ""                # "my-session" -> "my-session"
 
 ## [fork] Section
 
-Defaults for forking a session — the TUI quick fork (`f`) and the `Shift+F` dialog. Quick fork is **comprehensive by default**: a new git worktree + branch, the parent's uncommitted working-tree state, matched Docker isolation, and inherited Claude launch options. Unset keys default to the comprehensive behavior. These settings are **independent** of `[worktree].default_enabled` / `[docker].default_enabled` (which govern non-fork session creation).
+Defaults for forking a session — the TUI quick fork (`f`) and the `Shift+F` dialog. By default a fork creates a new git worktree + branch, carries the parent's tracked uncommitted state, matches Docker isolation, and inherits the Claude launch options. Copying **gitignored** files is **opt-in** (`with_ignored = false`): that tree is unbounded (data sets, virtual envs, `node_modules`) and can carry secrets, so it would otherwise block the fork silently. These settings are **independent** of `[worktree].default_enabled` / `[docker].default_enabled` (which govern non-fork session creation).
 
 ```toml
 [fork]
 inherit_from_parent = false   # Mirror the parent and ignore the keys below
 worktree            = true    # Create a new worktree + branch for the fork
 with_state          = true    # Carry the parent's uncommitted changes into the fork
-with_ignored        = true    # Also copy gitignored files (implies with_state)
+with_ignored        = false   # Also copy gitignored files (implies with_state); opt-in
 docker              = "auto"  # "auto" (match parent) | "on" | "off"
 branch_prefix       = "fork/" # Auto branch name = <branch_prefix><sanitized-title>
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `inherit_from_parent` | bool | `false` | When `true`, the fork mirrors the parent (worktree + state on, Docker matches parent) and the individual keys below are ignored. |
+| `inherit_from_parent` | bool | `false` | When `true`, the fork mirrors the parent (worktree + state + gitignored on, Docker matches parent) and the individual keys below are ignored. |
 | `worktree` | bool | `true` | Create a new git worktree + branch for the fork. |
 | `with_state` | bool | `true` | Carry the parent's tracked uncommitted changes (staged/unstaged/untracked) into the fork's worktree. |
-| `with_ignored` | bool | `true` | Also copy gitignored files (e.g. `.env`, `node_modules`) into the worktree. Implies `with_state`. Can be large — set `false` to skip. |
+| `with_ignored` | bool | `false` | Also copy gitignored files (e.g. `.env`, `node_modules`) into the worktree. Implies `with_state`. **Opt-in:** the gitignored tree is unbounded and may contain secrets, and the copy is blocking with no size cap. Set `true` to include it, or use `inherit_from_parent` to mirror the parent wholesale. |
 | `docker` | string | `"auto"` | Docker isolation for the fork: `"auto"` matches the parent (sandboxed parent → a fresh container; otherwise none), `"on"` always sandboxes, `"off"` never. |
 | `branch_prefix` | string | `"fork/"` | Prefix for the auto-suggested fork branch name. Applies to both quick fork and the `Shift+F` dialog. |
 

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -310,7 +310,7 @@ branch_prefix = ""                # "my-session" -> "my-session"
 
 ## [fork] Section
 
-Defaults for forking a session — the TUI quick fork (`f`) and the `Shift+F` dialog. By default a fork creates a new git worktree + branch, carries the parent's tracked uncommitted state, matches Docker isolation, and inherits the Claude launch options. Copying **gitignored** files is **opt-in** (`with_ignored = false`): that tree is unbounded (data sets, virtual envs, `node_modules`) and can carry secrets, so it would otherwise block the fork silently. These settings are **independent** of `[worktree].default_enabled` / `[docker].default_enabled` (which govern non-fork session creation).
+Defaults for forking a session — the TUI quick fork (`f`) and the `Shift+F` dialog. By default a fork creates a new git worktree + branch, carries the parent's uncommitted working-tree changes (staged, unstaged, and untracked files), matches Docker isolation, and inherits the Claude launch options. Copying **gitignored** files is **opt-in** (`with_ignored = false`): that tree is unbounded (data sets, virtual envs, `node_modules`) and can carry secrets, so it would otherwise block the fork silently. These settings are **independent** of `[worktree].default_enabled` / `[docker].default_enabled` (which govern non-fork session creation).
 
 ```toml
 [fork]
@@ -326,7 +326,7 @@ branch_prefix       = "fork/" # Auto branch name = <branch_prefix><sanitized-tit
 |-----|------|---------|-------------|
 | `inherit_from_parent` | bool | `false` | When `true`, the fork mirrors the parent (worktree + state + gitignored on, Docker matches parent) and the individual keys below are ignored. |
 | `worktree` | bool | `true` | Create a new git worktree + branch for the fork. |
-| `with_state` | bool | `true` | Carry the parent's tracked uncommitted changes (staged/unstaged/untracked) into the fork's worktree. |
+| `with_state` | bool | `true` | Carry the parent's uncommitted working-tree changes (staged, unstaged, and untracked files; gitignored excluded unless `with_ignored`) into the fork's worktree. |
 | `with_ignored` | bool | `false` | Also copy gitignored files (e.g. `.env`, `node_modules`) into the worktree. Implies `with_state`. **Opt-in:** the gitignored tree is unbounded and may contain secrets, and the copy is blocking with no size cap. Set `true` to include it, or use `inherit_from_parent` to mirror the parent wholesale. |
 | `docker` | string | `"auto"` | Docker isolation for the fork: `"auto"` matches the parent (sandboxed parent → a fresh container; otherwise none), `"on"` always sandboxes, `"off"` never. |
 | `branch_prefix` | string | `"fork/"` | Prefix for the auto-suggested fork branch name. Applies to both quick fork and the `Shift+F` dialog. |


### PR DESCRIPTION
## Problem

Quick fork (`f`) is unusable on heavy repos since v1.9.49. Pressing `f` shows `🔀 Forking Session … Creating a new Claude session … Loading…` and hangs indefinitely — no session is ever created, no error, no progress.

### Root cause

#1299 (v1.9.49) reworked quick fork to be "comprehensive by default", which set **`with_ignored = true`** as a built-in default (`ForkSettings.GetWithIgnored`). With it on, every fork deep-copies the parent's **entire gitignored tree** into the new worktree *before* the session starts:

- It's **unbounded** — gitignored means data sets, virtual envs, `node_modules`, build artifacts. On an ML repo that's gigabytes.
- The copy is **blocking with no size cap and no progress**, inside the async fork command. `Start()` is never reached (no `fork_awaiting_start` log line is ever emitted), so the UI just spins.
- It can copy **secrets** (`.env`, credential files) into a new on-disk location the user didn't choose.

So a single keystroke with no confirmation silently triggers an unbounded, secret-copying, blocking filesystem operation. That's a bad default for the *default* fork action.

## Fix

Flip the built-in default of `with_ignored` to **off**. A fork now carries the parent's **tracked** uncommitted state (bounded, useful) but not the gitignored tree. `worktree` and `with_state` defaults are unchanged (still on).

Gitignored copy remains fully available, just opt-in:
- per fork via the `Shift+F` dialog (the `Include gitignored files` checkbox),
- globally via `[fork]\nwith_ignored = true`,
- or wholesale via `inherit_from_parent = true`.

This also brings the TUI in line with the **CLI**, where `--with-state-and-gitignored` is already an explicit opt-in flag (`cmd/agent-deck/session_cmd.go:633`) — the TUI was the only path forcing it on.

## Changes

- `internal/session/userconfig.go` — `GetWithIgnored()` defaults to `false`; documented why.
- Tests updated to assert the new default (config resolution, quick-fork inputs, backend gate, dialog seeding).
- `skills/agent-deck/references/config-reference.md` — `[fork]` section reflects `with_ignored = false` and explains the opt-in.

`inherit_from_parent` still mirrors the parent fully (gitignored included) — that path is unchanged.

## Notes

- No Go toolchain in my environment, so I could not run `make test` / `gofmt` locally — relying on CI. Please flag any fmt/vet nits.
- Two related issues I did **not** change here, happy to follow up if wanted: (1) the gitignored copy should arguably be bounded/backgrounded with progress rather than blocking regardless of default; (2) a worktree fork lands in a new same-named group instead of the parent's group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changed fork defaults: "Include gitignored files" is now disabled by default (opt-in). "Worktree" and "Carry parent state" remain enabled. Fork dialogs and quick-fork UI now show "Include gitignored files" unchecked when no fork config is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->