### PR TITLE
fix(title): stop claude name sync from clobbering renames and fork titles

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -2239,8 +2239,13 @@ func handleRename(profile string, args []string) {
 		}
 	}
 
-	inst.Title = newTitle
-	inst.SyncTmuxDisplayName()
+	// Route through SetField so the rename also sets TitleLocked — a direct
+	// Title assignment would be reverted by the #572 Claude-name sync on the
+	// next hook event.
+	if _, _, err := session.SetField(inst, session.FieldTitle, newTitle, nil); err != nil {
+		out.Error(fmt.Sprintf("failed to rename: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
 
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
 	if err := storage.SaveWithGroups(instances, groupTree); err != nil {

--- a/cmd/agent-deck/rename_title_lock_test.go
+++ b/cmd/agent-deck/rename_title_lock_test.go
@@ -1,0 +1,62 @@
+// rename_title_lock_test.go — CLI contract tests for title locking on
+// explicit renames and explicitly titled forks (PR #1355 review follow-up).
+//
+// An explicit rename or fork title is user intent: it must set TitleLocked so
+// the #572 Claude-name sync (e.g. an auto-assigned plan title) can't revert
+// it on the next hook event. Direct `inst.Title = ...` assignments bypass the
+// SetField mutator that applies the lock.
+//
+// Why structural assertions instead of end-to-end handler invocation:
+// handleRename and handleSessionFork call os.Exit on every error path, and
+// there is no runMain/TestHelperProcess subprocess harness in this package.
+// We follow the extractFuncBody precedent from session_remove_kill_test.go.
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func mustExtractFuncBody(t *testing.T, file, funcName string) string {
+	t.Helper()
+	src, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	body := extractFuncBody(string(src), funcName)
+	if body == "" {
+		t.Fatalf("could not extract %s body from %s — file layout changed?", funcName, file)
+	}
+	return body
+}
+
+// TestHandleRename_RoutesThroughSetField: `agent-deck rename` must apply the
+// title via session.SetField (which sets TitleLocked), not by assigning
+// inst.Title directly.
+func TestHandleRename_RoutesThroughSetField(t *testing.T) {
+	body := foldSpaces(mustExtractFuncBody(t, "main.go", "handleRename"))
+
+	if !strings.Contains(body, "session.SetField(inst, session.FieldTitle, newTitle, nil)") {
+		t.Error("handleRename must route the rename through session.SetField(FieldTitle) so TitleLocked is set")
+	}
+	if strings.Contains(body, "inst.Title = newTitle") {
+		t.Error("handleRename must not assign inst.Title directly — that bypasses the TitleLocked mutator")
+	}
+}
+
+// TestHandleSessionFork_LocksExplicitTitle: `agent-deck session fork -t X`
+// must lock the fork's title, while the auto-generated "<title>-fork" default
+// keeps the #572 name sync enabled (mirrors the TUI dialog-vs-quick-fork
+// split).
+func TestHandleSessionFork_LocksExplicitTitle(t *testing.T) {
+	body := foldSpaces(mustExtractFuncBody(t, "session_cmd.go", "handleSessionFork"))
+
+	if !strings.Contains(body, `explicitTitle := forkTitle != ""`) {
+		t.Error("handleSessionFork must record whether -t/--title was explicitly passed before applying the default")
+	}
+	if !strings.Contains(body, "if explicitTitle { forkedInst.TitleLocked = true }") {
+		t.Error("handleSessionFork must set forkedInst.TitleLocked when -t/--title was explicitly passed")
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -709,8 +709,12 @@ func handleSessionFork(profile string, args []string) {
 		os.Exit(1)
 	}
 
-	// Default title if not provided
-	if forkTitle == "" {
+	// Default title if not provided. An explicitly passed -t/--title is user
+	// intent and gets TitleLocked below (mirrors the TUI fork dialog); the
+	// auto-generated "<title>-fork" default keeps the #572 name sync enabled
+	// (mirrors quick fork).
+	explicitTitle := forkTitle != ""
+	if !explicitTitle {
 		forkTitle = inst.Title + "-fork"
 	}
 
@@ -968,6 +972,9 @@ func handleSessionFork(profile string, args []string) {
 	if err != nil {
 		out.Error(fmt.Sprintf("failed to create fork: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
+	}
+	if explicitTitle {
+		forkedInst.TitleLocked = true
 	}
 
 	if worktreeType != "" {

--- a/internal/session/claude_title_reconcile.go
+++ b/internal/session/claude_title_reconcile.go
@@ -14,11 +14,18 @@ import (
 type claudeSessionMeta struct {
 	SessionID string `json:"sessionId"`
 	Name      string `json:"name"`
+	UpdatedAt int64  `json:"updatedAt"` // unix ms; 0 when absent
 }
 
 // ClaudeSessionNameIn scans claudeDir/sessions/*.json and returns the trimmed
 // `name` of the entry whose sessionId matches. Empty string when there's no
 // match, no name, or the sessions dir is unreadable.
+//
+// The files are per-PID, so a resumed session can match several entries — the
+// live process plus stale files left by earlier runs. The freshest entry (by
+// updatedAt, falling back to file mtime) is authoritative, even when its name
+// is empty: returning a stale file's old name would re-sync a title the user
+// has since changed or cleared.
 //
 // Issue #572: Claude Code writes per-process metadata here when the user starts
 // with `claude --name X` or runs `/rename X` mid-session. claudeDir is an
@@ -33,6 +40,8 @@ func ClaudeSessionNameIn(claudeDir, sessionID string) string {
 	if err != nil {
 		return ""
 	}
+	bestName := ""
+	bestTime := int64(-1)
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
 			continue
@@ -45,11 +54,21 @@ func ClaudeSessionNameIn(claudeDir, sessionID string) string {
 		if err := json.Unmarshal(data, &meta); err != nil {
 			continue
 		}
-		if meta.SessionID == sessionID {
-			return strings.TrimSpace(meta.Name)
+		if meta.SessionID != sessionID {
+			continue
+		}
+		ts := meta.UpdatedAt
+		if ts == 0 {
+			if info, err := entry.Info(); err == nil {
+				ts = info.ModTime().UnixMilli()
+			}
+		}
+		if ts > bestTime {
+			bestTime = ts
+			bestName = strings.TrimSpace(meta.Name)
 		}
 	}
-	return ""
+	return bestName
 }
 
 // ClaudeSessionName resolves the user's ~/.claude and returns the Claude

--- a/internal/session/claude_title_reconcile.go
+++ b/internal/session/claude_title_reconcile.go
@@ -14,7 +14,7 @@ import (
 type claudeSessionMeta struct {
 	SessionID string `json:"sessionId"`
 	Name      string `json:"name"`
-	UpdatedAt int64  `json:"updatedAt"` // unix ms; 0 when absent
+	UpdatedAt *int64 `json:"updatedAt"` // unix ms; nil when absent
 }
 
 // ClaudeSessionNameIn scans claudeDir/sessions/*.json and returns the trimmed
@@ -57,11 +57,11 @@ func ClaudeSessionNameIn(claudeDir, sessionID string) string {
 		if meta.SessionID != sessionID {
 			continue
 		}
-		ts := meta.UpdatedAt
-		if ts == 0 {
-			if info, err := entry.Info(); err == nil {
-				ts = info.ModTime().UnixMilli()
-			}
+		var ts int64
+		if meta.UpdatedAt != nil {
+			ts = *meta.UpdatedAt
+		} else if info, err := entry.Info(); err == nil {
+			ts = info.ModTime().UnixMilli()
 		}
 		if ts > bestTime {
 			bestTime = ts

--- a/internal/session/claude_title_reconcile_test.go
+++ b/internal/session/claude_title_reconcile_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 )
@@ -107,6 +108,77 @@ func TestReconcileTitleFromClaude_NoopWhenSyncDisabled(t *testing.T) {
 	}
 	if inst.Title != "loupe" {
 		t.Errorf("Title = %q, want unchanged loupe", inst.Title)
+	}
+}
+
+// seedClaudeSessionFile writes ~/.claude/sessions/<file> with explicit fields,
+// for tests that need several per-PID entries for the same sessionId.
+func seedClaudeSessionFile(t *testing.T, home, file string, fields map[string]any) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude", "sessions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	b, _ := json.Marshal(fields)
+	if err := os.WriteFile(filepath.Join(dir, file), b, 0o644); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
+}
+
+// TestClaudeSessionNameIn_FreshestEntryWins: a resumed session leaves one
+// per-PID file per run, all sharing the sessionId. The entry with the highest
+// updatedAt is authoritative — not whichever sorts first in the directory.
+func TestClaudeSessionNameIn_FreshestEntryWins(t *testing.T) {
+	home := t.TempDir()
+	// "1111.json" sorts before "2222.json"; the old behavior returned its name.
+	seedClaudeSessionFile(t, home, "1111.json", map[string]any{
+		"sessionId": "sid-x", "name": "stale plan title", "updatedAt": int64(1000),
+	})
+	seedClaudeSessionFile(t, home, "2222.json", map[string]any{
+		"sessionId": "sid-x", "name": "current name", "updatedAt": int64(2000),
+	})
+
+	got := ClaudeSessionNameIn(filepath.Join(home, ".claude"), "sid-x")
+	if got != "current name" {
+		t.Errorf("ClaudeSessionNameIn = %q, want %q", got, "current name")
+	}
+}
+
+// TestClaudeSessionNameIn_FreshestUnnamedSuppressesStaleName: when the live
+// (freshest) process has no name, a stale named entry must not resurrect the
+// old name.
+func TestClaudeSessionNameIn_FreshestUnnamedSuppressesStaleName(t *testing.T) {
+	home := t.TempDir()
+	seedClaudeSessionFile(t, home, "1111.json", map[string]any{
+		"sessionId": "sid-y", "name": "old name", "updatedAt": int64(1000),
+	})
+	seedClaudeSessionFile(t, home, "2222.json", map[string]any{
+		"sessionId": "sid-y", "updatedAt": int64(2000),
+	})
+
+	if got := ClaudeSessionNameIn(filepath.Join(home, ".claude"), "sid-y"); got != "" {
+		t.Errorf("ClaudeSessionNameIn = %q, want empty (freshest entry has no name)", got)
+	}
+}
+
+// TestClaudeSessionNameIn_MtimeFallbackWhenNoUpdatedAt: entries without
+// updatedAt (older Claude versions) fall back to file mtime for ordering.
+func TestClaudeSessionNameIn_MtimeFallbackWhenNoUpdatedAt(t *testing.T) {
+	home := t.TempDir()
+	seedClaudeSessionFile(t, home, "1111.json", map[string]any{
+		"sessionId": "sid-z", "name": "older",
+	})
+	seedClaudeSessionFile(t, home, "2222.json", map[string]any{
+		"sessionId": "sid-z", "name": "newer",
+	})
+	dir := filepath.Join(home, ".claude", "sessions")
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(filepath.Join(dir, "1111.json"), old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	if got := ClaudeSessionNameIn(filepath.Join(home, ".claude"), "sid-z"); got != "newer" {
+		t.Errorf("ClaudeSessionNameIn = %q, want %q", got, "newer")
 	}
 }
 

--- a/internal/session/claude_title_reconcile_test.go
+++ b/internal/session/claude_title_reconcile_test.go
@@ -18,7 +18,10 @@ func seedClaudeSession(t *testing.T, home, sessionID, name string) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir sessions: %v", err)
 	}
-	b, _ := json.Marshal(map[string]any{"sessionId": sessionID, "name": name})
+	b, err := json.Marshal(map[string]any{"sessionId": sessionID, "name": name})
+	if err != nil {
+		t.Fatalf("marshal session fields: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, "1234.json"), b, 0o644); err != nil {
 		t.Fatalf("write session file: %v", err)
 	}
@@ -119,7 +122,10 @@ func seedClaudeSessionFile(t *testing.T, home, file string, fields map[string]an
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir sessions: %v", err)
 	}
-	b, _ := json.Marshal(fields)
+	b, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal session fields: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(dir, file), b, 0o644); err != nil {
 		t.Fatalf("write session file: %v", err)
 	}

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -129,6 +129,10 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 	case FieldTitle:
 		oldValue = inst.Title
 		inst.Title = value
+		// An explicit rename is user intent: lock the title so the #572
+		// Claude-name sync (plan titles, /rename) can't revert it on the
+		// next hook event. Unlock via `session set <id> title-locked false`.
+		inst.TitleLocked = true
 		inst.SyncTmuxDisplayName()
 
 	case FieldPath:

--- a/internal/session/mutators_test.go
+++ b/internal/session/mutators_test.go
@@ -21,6 +21,27 @@ func TestSetField_Title_UpdatesAndReturnsOldValue(t *testing.T) {
 	}
 }
 
+// An explicit rename must lock the title, otherwise the #572 Claude-name sync
+// (e.g. an auto-assigned plan title) reverts it on the next hook event.
+func TestSetField_Title_LocksTitle(t *testing.T) {
+	inst := &Instance{Title: "old-title"}
+
+	if _, _, err := SetField(inst, FieldTitle, "my-rename", nil); err != nil {
+		t.Fatalf("SetField returned error: %v", err)
+	}
+	if !inst.TitleLocked {
+		t.Error("TitleLocked = false after explicit rename, want true")
+	}
+
+	// The lock stays user-controllable: title-locked=false re-enables sync.
+	if _, _, err := SetField(inst, FieldTitleLocked, "false", nil); err != nil {
+		t.Fatalf("SetField(title-locked) returned error: %v", err)
+	}
+	if inst.TitleLocked {
+		t.Error("TitleLocked = true after explicit unlock, want false")
+	}
+}
+
 func TestSetField_Color_Valid(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/internal/ui/fork_state_submit_test.go
+++ b/internal/ui/fork_state_submit_test.go
@@ -339,7 +339,7 @@ func TestCompleteFork_RollsBackOnInstanceCreateFailure(t *testing.T) {
 		rollback:           rec.fn,
 	}
 
-	inst, err := completeFork(source, "title", "group", false, opts, false, "", "", true, deps)
+	inst, err := completeFork(source, "title", "group", forkToggles{}, opts, "", "", true, deps)
 	if inst != nil {
 		t.Fatalf("expected nil instance on create failure, got %v", inst)
 	}
@@ -370,7 +370,7 @@ func TestCompleteFork_RollsBackOnMultiRepoDirFailure(t *testing.T) {
 		rollback:           rec.fn,
 	}
 
-	inst, err := completeFork(source, "title", "group", false, opts, false, "", "", true, deps)
+	inst, err := completeFork(source, "title", "group", forkToggles{}, opts, "", "", true, deps)
 	if inst != nil {
 		t.Fatalf("expected nil instance on multi-repo-dir failure, got %v", inst)
 	}
@@ -401,7 +401,7 @@ func TestCompleteFork_RollsBackOnStartFailure(t *testing.T) {
 		rollback:           rec.fn,
 	}
 
-	inst, err := completeFork(source, "title", "group", false, opts, false, "", "", true, deps)
+	inst, err := completeFork(source, "title", "group", forkToggles{}, opts, "", "", true, deps)
 	if inst != nil {
 		t.Fatalf("expected nil instance on start failure, got %v", inst)
 	}
@@ -431,7 +431,7 @@ func TestCompleteFork_NoRollbackOnSuccess(t *testing.T) {
 		rollback:           rec.fn,
 	}
 
-	inst, err := completeFork(source, "title", "group", false, opts, false, "", "", true, deps)
+	inst, err := completeFork(source, "title", "group", forkToggles{}, opts, "", "", true, deps)
 	if err != nil {
 		t.Fatalf("expected no error on success, got %v", err)
 	}
@@ -459,7 +459,7 @@ func TestCompleteFork_NoRollbackWhenWorktreeNotCreated(t *testing.T) {
 
 	// withStateWorktreeCreated=false and a nil opts: the rollback gate must not
 	// fire, so opts is never dereferenced.
-	inst, err := completeFork(source, "title", "group", false, nil, false, "", "", false, deps)
+	inst, err := completeFork(source, "title", "group", forkToggles{}, nil, "", "", false, deps)
 	if inst != nil {
 		t.Fatalf("expected nil instance on create failure, got %v", inst)
 	}

--- a/internal/ui/fork_state_submit_test.go
+++ b/internal/ui/fork_state_submit_test.go
@@ -339,7 +339,7 @@ func TestCompleteFork_RollsBackOnInstanceCreateFailure(t *testing.T) {
 		rollback:           rec.fn,
 	}
 
-	inst, err := completeFork(source, "title", "group", opts, false, "", "", true, deps)
+	inst, err := completeFork(source, "title", "group", false, opts, false, "", "", true, deps)
 	if inst != nil {
 		t.Fatalf("expected nil instance on create failure, got %v", inst)
 	}
@@ -370,7 +370,7 @@ func TestCompleteFork_RollsBackOnMultiRepoDirFailure(t *testing.T) {
 		rollback:           rec.fn,
 	}
 
-	inst, err := completeFork(source, "title", "group", opts, false, "", "", true, deps)
+	inst, err := completeFork(source, "title", "group", false, opts, false, "", "", true, deps)
 	if inst != nil {
 		t.Fatalf("expected nil instance on multi-repo-dir failure, got %v", inst)
 	}
@@ -401,7 +401,7 @@ func TestCompleteFork_RollsBackOnStartFailure(t *testing.T) {
 		rollback:           rec.fn,
 	}
 
-	inst, err := completeFork(source, "title", "group", opts, false, "", "", true, deps)
+	inst, err := completeFork(source, "title", "group", false, opts, false, "", "", true, deps)
 	if inst != nil {
 		t.Fatalf("expected nil instance on start failure, got %v", inst)
 	}
@@ -431,7 +431,7 @@ func TestCompleteFork_NoRollbackOnSuccess(t *testing.T) {
 		rollback:           rec.fn,
 	}
 
-	inst, err := completeFork(source, "title", "group", opts, false, "", "", true, deps)
+	inst, err := completeFork(source, "title", "group", false, opts, false, "", "", true, deps)
 	if err != nil {
 		t.Fatalf("expected no error on success, got %v", err)
 	}
@@ -459,7 +459,7 @@ func TestCompleteFork_NoRollbackWhenWorktreeNotCreated(t *testing.T) {
 
 	// withStateWorktreeCreated=false and a nil opts: the rollback gate must not
 	// fire, so opts is never dereferenced.
-	inst, err := completeFork(source, "title", "group", nil, false, "", "", false, deps)
+	inst, err := completeFork(source, "title", "group", false, nil, false, "", "", false, deps)
 	if inst != nil {
 		t.Fatalf("expected nil instance on create failure, got %v", inst)
 	}

--- a/internal/ui/fork_title_lock_test.go
+++ b/internal/ui/fork_title_lock_test.go
@@ -25,7 +25,7 @@ func forkTitleLockDeps(fake *session.Instance) forkInstanceDeps {
 
 func TestCompleteFork_LockTitleSetsTitleLocked(t *testing.T) {
 	fake := &session.Instance{}
-	inst, err := completeFork(&session.Instance{}, "my fork", "group", true, nil, false, "", "", false, forkTitleLockDeps(fake))
+	inst, err := completeFork(&session.Instance{}, "my fork", "group", forkToggles{LockTitle: true}, nil, "", "", false, forkTitleLockDeps(fake))
 	if err != nil {
 		t.Fatalf("completeFork: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestCompleteFork_LockTitleSetsTitleLocked(t *testing.T) {
 
 func TestCompleteFork_NoLockKeepsTitleSyncEnabled(t *testing.T) {
 	fake := &session.Instance{}
-	inst, err := completeFork(&session.Instance{}, "parent (fork)", "group", false, nil, false, "", "", false, forkTitleLockDeps(fake))
+	inst, err := completeFork(&session.Instance{}, "parent (fork)", "group", forkToggles{}, nil, "", "", false, forkTitleLockDeps(fake))
 	if err != nil {
 		t.Fatalf("completeFork: %v", err)
 	}

--- a/internal/ui/fork_title_lock_test.go
+++ b/internal/ui/fork_title_lock_test.go
@@ -1,0 +1,46 @@
+package ui
+
+// A forked Claude session inherits the parent's session name (e.g. an
+// auto-assigned plan title), so the #572 name sync clobbers the title the
+// user typed in the fork dialog on the fork's first hook event. Dialog forks
+// therefore lock the title; quick forks keep the auto-generated
+// "<title> (fork)" name sync-enabled.
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func forkTitleLockDeps(fake *session.Instance) forkInstanceDeps {
+	return forkInstanceDeps{
+		createInstance: func(_ *session.Instance, _, _ string, _ *session.ClaudeOptions) (*session.Instance, error) {
+			return fake, nil
+		},
+		createMultiRepoDir: func(_, _ *session.Instance) error { return nil },
+		startInstance:      func(_ *session.Instance) error { return nil },
+		rollback:           func(_, _, _ string) {},
+	}
+}
+
+func TestCompleteFork_LockTitleSetsTitleLocked(t *testing.T) {
+	fake := &session.Instance{}
+	inst, err := completeFork(&session.Instance{}, "my fork", "group", true, nil, false, "", "", false, forkTitleLockDeps(fake))
+	if err != nil {
+		t.Fatalf("completeFork: %v", err)
+	}
+	if !inst.TitleLocked {
+		t.Error("TitleLocked = false for dialog fork, want true")
+	}
+}
+
+func TestCompleteFork_NoLockKeepsTitleSyncEnabled(t *testing.T) {
+	fake := &session.Instance{}
+	inst, err := completeFork(&session.Instance{}, "parent (fork)", "group", false, nil, false, "", "", false, forkTitleLockDeps(fake))
+	if err != nil {
+		t.Fatalf("completeFork: %v", err)
+	}
+	if inst.TitleLocked {
+		t.Error("TitleLocked = true for quick fork, want false (name sync stays enabled)")
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8714,12 +8714,15 @@ func (h *Home) handleForkDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				parentPath := h.forkDialog.GetParentProjectPath()
 				result := h.buildForkCmd(
 					source, title, groupPath, branchName,
-					worktreeEnabled,
-					h.forkDialog.IsWithStateEnabled(),
-					h.forkDialog.IsWithStateAndGitignoredEnabled(),
-					h.forkDialog.IsSandboxEnabled(),
-					h.forkDialog.IsWorktreeExplicit(),
-					true, // dialog title is explicit user intent: lock against #572 name sync
+					forkToggles{
+						Worktree:         worktreeEnabled,
+						WithState:        h.forkDialog.IsWithStateEnabled(),
+						WithIgnored:      h.forkDialog.IsWithStateAndGitignoredEnabled(),
+						Sandbox:          h.forkDialog.IsSandboxEnabled(),
+						ExplicitWorktree: h.forkDialog.IsWorktreeExplicit(),
+						// Dialog title is explicit user intent: lock against #572 name sync.
+						LockTitle: true,
+					},
 					opts,
 					parentID, parentPath,
 				)
@@ -9357,9 +9360,16 @@ func (h *Home) quickForkSession(source *session.Instance) tea.Cmd {
 
 	result := h.buildForkCmd(
 		source, in.Title, in.GroupPath, in.Branch,
-		in.Plan.Worktree, in.Plan.WithState, in.Plan.WithIgnored, in.Plan.Sandbox,
-		false, // quick fork worktree is config-default, not an explicit toggle (#1185)
-		false, // auto-generated "<title> (fork)" name is not user intent: keep name sync
+		forkToggles{
+			Worktree:    in.Plan.Worktree,
+			WithState:   in.Plan.WithState,
+			WithIgnored: in.Plan.WithIgnored,
+			Sandbox:     in.Plan.Sandbox,
+			// ExplicitWorktree stays false: quick fork worktree is
+			// config-default, not an explicit toggle (#1185). LockTitle stays
+			// false: the auto-generated "<title> (fork)" name is not user
+			// intent, so the #572 name sync stays enabled.
+		},
 		opts,
 		source.ParentSessionID, source.ParentProjectPath,
 	)
@@ -9750,17 +9760,16 @@ func defaultForkInstanceDeps() forkInstanceDeps {
 // it rolls back the new worktree+branch. Free function: it needs nothing from
 // *Home.
 //
-// lockTitle marks the new instance TitleLocked: a forked Claude session
-// inherits the parent's session name (e.g. an auto-assigned plan title), so
-// without the lock the #572 name sync clobbers the title the user typed in
-// the fork dialog on the fork's first hook event. Quick fork passes false —
-// its "<title> (fork)" name is auto-generated, not user intent.
+// toggles.LockTitle marks the new instance TitleLocked: a forked Claude
+// session inherits the parent's session name (e.g. an auto-assigned plan
+// title), so without the lock the #572 name sync clobbers the title the user
+// typed in the fork dialog on the fork's first hook event. Quick fork leaves
+// it false — its "<title> (fork)" name is auto-generated, not user intent.
 func completeFork(
 	source *session.Instance,
 	title, groupPath string,
-	lockTitle bool,
+	toggles forkToggles,
 	opts *session.ClaudeOptions,
-	sandboxEnabled bool,
 	parentSessionID, parentProjectPath string,
 	withStateWorktreeCreated bool,
 	deps forkInstanceDeps,
@@ -9772,12 +9781,12 @@ func completeFork(
 		}
 		return nil, fmt.Errorf("cannot create forked instance: %w", err)
 	}
-	if lockTitle {
+	if toggles.LockTitle {
 		inst.TitleLocked = true
 	}
 
 	// Apply sandbox config to forked instance.
-	if sandboxEnabled {
+	if toggles.Sandbox {
 		inst.Sandbox = session.NewSandboxConfig("")
 	}
 
@@ -9814,6 +9823,25 @@ type forkBuildResult struct {
 	errMsg          string
 }
 
+// forkToggles groups the fork pipeline's boolean knobs so call sites stay
+// self-documenting instead of a positional true/false list.
+type forkToggles struct {
+	// Worktree creates the fork in a new worktree on a new branch.
+	Worktree bool
+	// WithState materializes the parent's working-tree state into the worktree.
+	WithState bool
+	// WithIgnored also copies gitignored files (implies WithState).
+	WithIgnored bool
+	// Sandbox runs the forked session in a Docker sandbox.
+	Sandbox bool
+	// ExplicitWorktree marks Worktree as an explicit user toggle rather than a
+	// config default, gating the #1185 non-repo fallback.
+	ExplicitWorktree bool
+	// LockTitle sets TitleLocked on the fork: the title is explicit user
+	// intent (fork dialog), so the #572 Claude-name sync must not clobber it.
+	LockTitle bool
+}
+
 // buildForkCmd resolves the worktree target (when requested + git-capable),
 // populates the worktree fields on opts, builds WorktreeStateOptions, and
 // returns the async fork command plus any non-fatal success notice. Shared by
@@ -9824,14 +9852,14 @@ type forkBuildResult struct {
 func (h *Home) buildForkCmd(
 	source *session.Instance,
 	title, groupPath, branchName string,
-	worktreeEnabled, withState, withIgnored, sandboxEnabled, explicitWorktree, lockTitle bool,
+	toggles forkToggles,
 	opts *session.ClaudeOptions,
 	parentSessionID, parentProjectPath string,
 ) forkBuildResult {
 	worktreeApplied := false
 	notice := ""
-	if worktreeEnabled && branchName != "" {
-		worktreePath, repoRoot, fallback, errMsg := resolveWorktreeTarget(source.ProjectPath, branchName, explicitWorktree)
+	if toggles.Worktree && branchName != "" {
+		worktreePath, repoRoot, fallback, errMsg := resolveWorktreeTarget(source.ProjectPath, branchName, toggles.ExplicitWorktree)
 		if errMsg != "" {
 			return forkBuildResult{errMsg: errMsg}
 		}
@@ -9848,13 +9876,13 @@ func (h *Home) buildForkCmd(
 			notice = "forked without worktree: not a git or jujutsu repo"
 		}
 	}
-	forkState := git.WorktreeStateOptions{WithState: withState, WithIgnored: withIgnored}
+	forkState := git.WorktreeStateOptions{WithState: toggles.WithState, WithIgnored: toggles.WithIgnored}
 	if !worktreeApplied {
 		// State materialization requires a freshly created worktree.
 		forkState = git.WorktreeStateOptions{}
 	}
 	return forkBuildResult{
-		cmd:             h.forkSessionCmdWithOptions(source, title, groupPath, lockTitle, opts, sandboxEnabled, forkState, parentSessionID, parentProjectPath, notice),
+		cmd:             h.forkSessionCmdWithOptions(source, title, groupPath, toggles, opts, forkState, parentSessionID, parentProjectPath, notice),
 		worktreeApplied: worktreeApplied,
 		notice:          notice,
 	}
@@ -9888,9 +9916,8 @@ func noticeError(existing error, notice string) error {
 func (h *Home) forkSessionCmdWithOptions(
 	source *session.Instance,
 	title, groupPath string,
-	lockTitle bool,
+	toggles forkToggles,
 	opts *session.ClaudeOptions,
-	sandboxEnabled bool,
 	forkState git.WorktreeStateOptions,
 	parentSessionID, parentProjectPath string,
 	notice string,
@@ -9914,11 +9941,11 @@ func (h *Home) forkSessionCmdWithOptions(
 			return sessionForkedMsg{err: fmt.Errorf("cannot fork session: %w", err), sourceID: sourceID}
 		}
 
-		effectiveSandbox := sandboxEnabled
+		// toggles is a value copy, so degrading Sandbox here is local to this fork.
 		forkNotice := notice
-		if effectiveSandbox {
+		if toggles.Sandbox {
 			if err := docker.CheckAvailability(context.Background()); err != nil {
-				effectiveSandbox = false
+				toggles.Sandbox = false
 				forkNotice = joinForkNotices(forkNotice, "forked without Docker: not available")
 			}
 		}
@@ -9988,7 +10015,7 @@ func (h *Home) forkSessionCmdWithOptions(
 			}
 		}
 
-		inst, err := completeFork(source, title, groupPath, lockTitle, opts, effectiveSandbox, parentSessionID, parentProjectPath, withStateWorktreeCreated, defaultForkInstanceDeps())
+		inst, err := completeFork(source, title, groupPath, toggles, opts, parentSessionID, parentProjectPath, withStateWorktreeCreated, defaultForkInstanceDeps())
 		if err != nil {
 			return sessionForkedMsg{err: err, sourceID: sourceID}
 		}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8719,6 +8719,7 @@ func (h *Home) handleForkDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					h.forkDialog.IsWithStateAndGitignoredEnabled(),
 					h.forkDialog.IsSandboxEnabled(),
 					h.forkDialog.IsWorktreeExplicit(),
+					true, // dialog title is explicit user intent: lock against #572 name sync
 					opts,
 					parentID, parentPath,
 				)
@@ -9358,6 +9359,7 @@ func (h *Home) quickForkSession(source *session.Instance) tea.Cmd {
 		source, in.Title, in.GroupPath, in.Branch,
 		in.Plan.Worktree, in.Plan.WithState, in.Plan.WithIgnored, in.Plan.Sandbox,
 		false, // quick fork worktree is config-default, not an explicit toggle (#1185)
+		false, // auto-generated "<title> (fork)" name is not user intent: keep name sync
 		opts,
 		source.ParentSessionID, source.ParentProjectPath,
 	)
@@ -9747,9 +9749,16 @@ func defaultForkInstanceDeps() forkInstanceDeps {
 // failure after a with-state worktree was created (withStateWorktreeCreated),
 // it rolls back the new worktree+branch. Free function: it needs nothing from
 // *Home.
+//
+// lockTitle marks the new instance TitleLocked: a forked Claude session
+// inherits the parent's session name (e.g. an auto-assigned plan title), so
+// without the lock the #572 name sync clobbers the title the user typed in
+// the fork dialog on the fork's first hook event. Quick fork passes false —
+// its "<title> (fork)" name is auto-generated, not user intent.
 func completeFork(
 	source *session.Instance,
 	title, groupPath string,
+	lockTitle bool,
 	opts *session.ClaudeOptions,
 	sandboxEnabled bool,
 	parentSessionID, parentProjectPath string,
@@ -9762,6 +9771,9 @@ func completeFork(
 			deps.rollback(opts.WorktreeRepoRoot, opts.WorktreePath, opts.WorktreeBranch)
 		}
 		return nil, fmt.Errorf("cannot create forked instance: %w", err)
+	}
+	if lockTitle {
+		inst.TitleLocked = true
 	}
 
 	// Apply sandbox config to forked instance.
@@ -9812,7 +9824,7 @@ type forkBuildResult struct {
 func (h *Home) buildForkCmd(
 	source *session.Instance,
 	title, groupPath, branchName string,
-	worktreeEnabled, withState, withIgnored, sandboxEnabled, explicitWorktree bool,
+	worktreeEnabled, withState, withIgnored, sandboxEnabled, explicitWorktree, lockTitle bool,
 	opts *session.ClaudeOptions,
 	parentSessionID, parentProjectPath string,
 ) forkBuildResult {
@@ -9842,7 +9854,7 @@ func (h *Home) buildForkCmd(
 		forkState = git.WorktreeStateOptions{}
 	}
 	return forkBuildResult{
-		cmd:             h.forkSessionCmdWithOptions(source, title, groupPath, opts, sandboxEnabled, forkState, parentSessionID, parentProjectPath, notice),
+		cmd:             h.forkSessionCmdWithOptions(source, title, groupPath, lockTitle, opts, sandboxEnabled, forkState, parentSessionID, parentProjectPath, notice),
 		worktreeApplied: worktreeApplied,
 		notice:          notice,
 	}
@@ -9876,6 +9888,7 @@ func noticeError(existing error, notice string) error {
 func (h *Home) forkSessionCmdWithOptions(
 	source *session.Instance,
 	title, groupPath string,
+	lockTitle bool,
 	opts *session.ClaudeOptions,
 	sandboxEnabled bool,
 	forkState git.WorktreeStateOptions,
@@ -9975,7 +9988,7 @@ func (h *Home) forkSessionCmdWithOptions(
 			}
 		}
 
-		inst, err := completeFork(source, title, groupPath, opts, effectiveSandbox, parentSessionID, parentProjectPath, withStateWorktreeCreated, defaultForkInstanceDeps())
+		inst, err := completeFork(source, title, groupPath, lockTitle, opts, effectiveSandbox, parentSessionID, parentProjectPath, withStateWorktreeCreated, defaultForkInstanceDeps())
 		if err != nil {
 			return sessionForkedMsg{err: err, sourceID: sourceID}
 		}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8646,10 +8646,14 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					}
 				} else {
 					// Local session rename
-					// Find and rename the session (O(1) lookup)
+					// Find and rename the session (O(1) lookup). Route through
+					// SetField so the rename also sets TitleLocked — a direct
+					// Title assignment would be reverted by the #572
+					// Claude-name sync on the next hook event.
 					if inst := h.getInstanceByID(sessionID); inst != nil {
-						inst.Title = newName
-						inst.SyncTmuxDisplayName()
+						if _, _, err := session.SetField(inst, session.FieldTitle, newName, nil); err != nil {
+							h.setError(err)
+						}
 					}
 					// Store pending title change so it survives reload races.
 					// If saveInstances() is skipped (isReloading=true), the reload

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -482,6 +482,11 @@ func TestHomeRenameSessionComplete(t *testing.T) {
 	if h.instances[0].Title != "new-name" {
 		t.Errorf("Session title = %s, want new-name", h.instances[0].Title)
 	}
+	// The r-hotkey rename must lock the title so the #572 Claude-name sync
+	// (e.g. an auto-assigned plan title) can't revert it on the next hook event.
+	if !h.instances[0].TitleLocked {
+		t.Error("TitleLocked = false after r-hotkey rename, want true")
+	}
 }
 
 func TestHomeMoveSessionWithDuplicateGroupNamesUsesSelectedPath(t *testing.T) {


### PR DESCRIPTION
## Problem

Claude Code auto-names sessions after an accepted plan, and a forked session (`--fork-session`) inherits that name. The #572 name sync then overwrites the agent-deck title on every hook event and on attach, which causes two confusing behaviors:

1. **Fork titles don't survive**: the title typed in the fork dialog flips to the parent's plan name as soon as the fork's first hook event fires.
2. **Renames don't stick**: renaming a session in the TUI (or via web/CLI) gets reverted within one turn, because nothing sets `TitleLocked` — the #697 escape hatch only fires for `launch --title`.

## Changes

- **`SetField(title)` now sets `TitleLocked`** — an explicit rename (TUI edit dialog, web PATCH, `session set title`) is user intent and must survive the sync, matching what `launch --title` already does. Sync can be re-enabled per session with `session set <id> title-locked false`.
- **Dialog forks lock the title they were given** (`completeFork` gains a `lockTitle` flag) for the same reason. Quick forks (`f`) keep sync enabled: their auto-generated `"<title> (fork)"` name is not user intent, so Claude's name can still flow in.
- **`ClaudeSessionNameIn` picks the freshest matching entry** (`updatedAt`, file-mtime fallback) instead of the first directory match. The `~/.claude/sessions/*.json` files are per-PID, so a resumed session can match several entries; previously a stale file from an earlier run could resurrect an old name — including returning a stale name when the live process has none.

## Testing

- New: `TestSetField_Title_LocksTitle`, `TestCompleteFork_LockTitleSetsTitleLocked`, `TestCompleteFork_NoLockKeepsTitleSyncEnabled`, `TestClaudeSessionNameIn_FreshestEntryWins`, `TestClaudeSessionNameIn_FreshestUnnamedSuppressesStaleName`, `TestClaudeSessionNameIn_MtimeFallbackWhenNoUpdatedAt`
- `go test ./internal/session ./internal/ui ./internal/web ./cmd/agent-deck` passes (the two `TestGetJSONLPathChecked_*` failures in `internal/session` are environment-dependent and reproduce on a clean checkout of main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fork dialogs can lock the forked session title to preserve user-entered names; quick-forks keep auto-generated names.
  * Renames invoked via CLI or UI now go through the centralized title-update flow so locking behavior is applied.

* **Bug Fixes**
  * Session names now choose the most recent entry (uses an update timestamp, falls back to file modification time).
  * Explicit title changes are protected from being overwritten by automatic title sync.

* **Tests**
  * Added tests validating freshest-session-name selection, title-locking on renames/forks, and rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->