### PR TITLE
fix(tui): pressing n on a remote group opens the new-session dialog (fixes #1353)

### DIFF
--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -688,8 +688,35 @@ func (r *SSHRunner) buildAttachArgs(sessionID string) []string {
 // It runs "add --quick --json" to create the session, then "session start" to
 // launch the tmux process, so the session is ready to attach.
 func (r *SSHRunner) CreateSession(ctx context.Context) (string, error) {
+	return r.CreateSessionWithOptions(ctx, "", "", "")
+}
+
+// remoteAddArgs builds the `agent-deck add` argument list for creating a
+// session on a remote with an explicit tool/title/path (#1353). Empty values
+// fall back to remote defaults: no -c means shell, no -t means --quick
+// (auto-generated name), and an empty or "." path means the remote CWD.
+func remoteAddArgs(tool, title, path string) []string {
+	args := []string{"add", "--json"}
+	if t := strings.TrimSpace(title); t != "" {
+		args = append(args, "-t", t)
+	} else {
+		args = append(args, "--quick")
+	}
+	if c := strings.TrimSpace(tool); c != "" {
+		args = append(args, "-c", c)
+	}
+	if p := strings.TrimSpace(path); p != "" && p != "." {
+		args = append(args, p)
+	}
+	return args
+}
+
+// CreateSessionWithOptions creates and starts a new session on the remote with
+// an explicit tool/title/path from the new-session dialog (#1353), returning
+// its ID. Empty values fall back to remote defaults (see remoteAddArgs).
+func (r *SSHRunner) CreateSessionWithOptions(ctx context.Context, tool, title, path string) (string, error) {
 	// Step 1: Create the session
-	output, err := r.Run(ctx, "add", "--quick", "--json")
+	output, err := r.Run(ctx, remoteAddArgs(tool, title, path)...)
 	if err != nil {
 		return "", fmt.Errorf("failed to create remote session: %w", err)
 	}

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -162,3 +162,56 @@ func TestSSHRunnerCreateSession_NoCleanupOnSuccess(t *testing.T) {
 		}
 	}
 }
+
+// TestRemoteAddArgs covers the `agent-deck add` argument builder used when the
+// new-session dialog targets a remote (#1353): the chosen tool must be passed
+// via -c (previously every remote `n` create was a bare `add --quick` shell),
+// an explicit title uses -t while an empty one falls back to --quick, and the
+// "." / empty path means "remote CWD" so no path argument is sent.
+func TestRemoteAddArgs(t *testing.T) {
+	cases := []struct {
+		name              string
+		tool, title, path string
+		want              []string
+	}{
+		{
+			name: "defaults (quick shell, remote CWD)",
+			want: []string{"add", "--json", "--quick"},
+		},
+		{
+			name: "tool and title from dialog",
+			tool: "claude", title: "my task", path: ".",
+			want: []string{"add", "--json", "-t", "my task", "-c", "claude"},
+		},
+		{
+			name: "explicit remote path",
+			tool: "codex", title: "fix", path: "/srv/project",
+			want: []string{"add", "--json", "-t", "fix", "-c", "codex", "/srv/project"},
+		},
+		{
+			name: "tool without title auto-names via --quick",
+			tool: "pi",
+			want: []string{"add", "--json", "--quick", "-c", "pi"},
+		},
+		{
+			name:  "whitespace-only values fall back to defaults",
+			tool:  "  ",
+			title: " ",
+			path:  " . ",
+			want:  []string{"add", "--json", "--quick"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := remoteAddArgs(tc.tool, tc.title, tc.path)
+			if len(got) != len(tc.want) {
+				t.Fatalf("remoteAddArgs(%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("remoteAddArgs(%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -207,6 +207,7 @@ type Home struct {
 	globalSearch         *GlobalSearch              // Global session search across all Claude conversations
 	globalSearchIndex    *session.GlobalSearchIndex // Search index (nil if disabled)
 	newDialog            *NewDialog
+	pendingRemoteName    string                // #1353: remote target for the open new-session dialog ("" = local)
 	groupDialog          *GroupDialog          // For creating/renaming groups
 	forkDialog           *ForkDialog           // For forking sessions
 	confirmDialog        *ConfirmDialog        // For confirming destructive actions
@@ -5846,6 +5847,20 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		// Get values including worktree settings.
 		name, path, command, branchName, worktreeEnabled := h.newDialog.GetValuesWithWorktree()
+
+		// #1353: when the dialog was opened on a remote group/session, create
+		// the session on that remote via SSH with the chosen tool. All
+		// local-only logic below (worktree resolution, directory-exists
+		// check, local create) must be skipped — it would act on the LOCAL
+		// filesystem (#743).
+		if h.pendingRemoteName != "" {
+			remoteName := h.pendingRemoteName
+			h.pendingRemoteName = ""
+			h.newDialog.Hide()
+			h.clearError()
+			return h, h.createRemoteSessionWithOptions(remoteName, command, name, path)
+		}
+
 		groupPath := h.newDialog.GetSelectedGroup()
 		claudeOpts := h.newDialog.GetClaudeOptions() // Get Claude options if applicable.
 		launchModelID := h.newDialog.GetLaunchModelID()
@@ -5971,7 +5986,8 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return h, cmd
 		}
 		h.newDialog.Hide()
-		h.clearError() // Clear any validation error
+		h.clearError()           // Clear any validation error
+		h.pendingRemoteName = "" // #1353: drop the remote target on cancel
 		return h, nil
 	}
 
@@ -7066,16 +7082,26 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case "n":
-		// If the cursor is on a remote group/session, quick-create on the
-		// remote instead of opening the local new-session dialog (#743).
-		// Pre-v1.7.68 behaviour that d9a5de8 accidentally removed: the local
-		// dialog has no remote awareness, so falling through to it created
-		// the session on localhost even though the user was clearly operating
-		// in the Remotes section.
+		// Reset any stale remote target from a previously abandoned flow.
+		h.pendingRemoteName = ""
+		// If the cursor is on a remote group/session, open the same
+		// new-session dialog as for local items but remember the remote
+		// target (#1353). The submit handler routes the create to the remote
+		// via SSH with the chosen tool, so the #743 invariant still holds:
+		// the session is never created on localhost. (Previously this
+		// quick-created a shell on the remote with no tool selection.)
 		if h.cursor >= 0 && h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeRemoteGroup || item.Type == session.ItemTypeRemoteSession {
-				return h, h.createRemoteSession(item.RemoteName)
+				h.pendingRemoteName = item.RemoteName
+				// Local path suggestions and recent sessions don't apply on
+				// the remote filesystem; default the path to "." (remote CWD)
+				// so no local path leaks into the SSH create.
+				h.newDialog.SetPathSuggestions(nil)
+				h.newDialog.SetRecentSessions(nil)
+				h.newDialog.SetDefaultTool(session.GetDefaultTool())
+				h.newDialog.ShowInGroup("remotes/"+item.RemoteName, "remotes/"+item.RemoteName, ".", nil, "")
+				return h, nil
 			}
 		}
 
@@ -10661,7 +10687,16 @@ func (a attachCmd) SetStdout(w io.Writer) {}
 func (a attachCmd) SetStderr(w io.Writer) {}
 
 // createRemoteSession creates a new session on a remote and auto-attaches to it.
+// Used by quick-create (N): auto-generated name, remote defaults (shell).
 func (h *Home) createRemoteSession(remoteName string) tea.Cmd {
+	return h.createRemoteSessionWithOptions(remoteName, "", "", "")
+}
+
+// createRemoteSessionWithOptions creates a new session on a remote with an
+// explicit tool/title/path from the new-session dialog (#1353), then
+// auto-attaches to it. Empty values fall back to remote defaults (shell,
+// auto-generated name, remote CWD).
+func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path string) tea.Cmd {
 	config, err := session.LoadUserConfig()
 	if err != nil || config == nil || config.Remotes == nil {
 		return func() tea.Msg {
@@ -10676,7 +10711,7 @@ func (h *Home) createRemoteSession(remoteName string) tea.Cmd {
 	}
 	runner := session.NewSSHRunner(remoteName, rc)
 	h.isAttaching.Store(true)
-	return tea.Exec(remoteCreateAndAttachCmd{runner: runner}, func(err error) tea.Msg {
+	return tea.Exec(remoteCreateAndAttachCmd{runner: runner, tool: tool, title: title, path: path}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
 		if err != nil {
 			return sessionCreatedMsg{err: fmt.Errorf("failed to create remote session: %w", err)}
@@ -10686,13 +10721,18 @@ func (h *Home) createRemoteSession(remoteName string) tea.Cmd {
 }
 
 // remoteCreateAndAttachCmd creates a session on the remote, then attaches to it.
+// tool/title/path are optional overrides from the new-session dialog (#1353);
+// empty values use remote defaults.
 type remoteCreateAndAttachCmd struct {
 	runner *session.SSHRunner
+	tool   string
+	title  string
+	path   string
 }
 
 func (r remoteCreateAndAttachCmd) Run() error {
 	ctx := context.Background()
-	sessionID, err := r.runner.CreateSession(ctx)
+	sessionID, err := r.runner.CreateSessionWithOptions(ctx, r.tool, r.title, r.path)
 	if err != nil {
 		return err
 	}

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -3329,13 +3329,16 @@ func TestHandleMainKeyQuickApproveSkipsNonClaudeTool(t *testing.T) {
 	}
 }
 
-// TestRegression743_NOnRemoteSession_QuickCreatesNoDialog guards #743.
+// TestRegression743_NOnRemoteSession_NeverCreatesLocally guards #743.
 // v1.7.68 shipped d9a5de8 which removed the remote early-return from the `n`
 // key handler, so pressing `n` on a remote session opened the local
-// newDialog and created a LOCAL session instead of a remote one. Restoring
-// the pre-d9a5de8 behavior: `n` on a remote-session cursor issues the remote
-// quick-create command and does NOT open the local new-session dialog.
-func TestRegression743_NOnRemoteSession_QuickCreatesNoDialog(t *testing.T) {
+// newDialog and created a LOCAL session instead of a remote one. Since #1353
+// the dialog DOES open for remote targets (so the user can pick a tool), but
+// the remote target must be recorded so submit routes the create to the
+// remote over SSH — the #743 invariant ("never create on localhost") is now
+// enforced at submit time. See issue1353_remote_new_dialog_test.go for the
+// submit-routing coverage.
+func TestRegression743_NOnRemoteSession_NeverCreatesLocally(t *testing.T) {
 	home := NewHome()
 	home.width = 100
 	home.height = 30
@@ -3344,22 +3347,22 @@ func TestRegression743_NOnRemoteSession_QuickCreatesNoDialog(t *testing.T) {
 	home.flatItems = []session.Item{{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "myserver"}}
 	home.cursor = 0
 
-	model, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	h, ok := model.(*Home)
 	if !ok {
 		t.Fatal("handleMainKey should return *Home")
 	}
-	if cmd == nil {
-		t.Fatal("pressing n on a remote session must issue the remote quick-create command (was local dialog)")
+	if !h.newDialog.IsVisible() {
+		t.Fatal("pressing n on a remote session must open the new-session dialog (#1353)")
 	}
-	if h.newDialog.IsVisible() {
-		t.Fatal("pressing n on a remote session must NOT open the local new-session dialog")
+	if h.pendingRemoteName != "myserver" {
+		t.Fatalf("remote target must be recorded so submit creates on the remote, not localhost (#743); got %q", h.pendingRemoteName)
 	}
 }
 
-// TestRegression743_NOnRemoteGroup_QuickCreatesNoDialog — same contract for
+// TestRegression743_NOnRemoteGroup_NeverCreatesLocally — same contract for
 // cursor on a remote group header row.
-func TestRegression743_NOnRemoteGroup_QuickCreatesNoDialog(t *testing.T) {
+func TestRegression743_NOnRemoteGroup_NeverCreatesLocally(t *testing.T) {
 	home := NewHome()
 	home.width = 100
 	home.height = 30
@@ -3367,16 +3370,16 @@ func TestRegression743_NOnRemoteGroup_QuickCreatesNoDialog(t *testing.T) {
 	home.flatItems = []session.Item{{Type: session.ItemTypeRemoteGroup, RemoteName: "myserver", Path: "remotes/myserver"}}
 	home.cursor = 0
 
-	model, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	h, ok := model.(*Home)
 	if !ok {
 		t.Fatal("handleMainKey should return *Home")
 	}
-	if cmd == nil {
-		t.Fatal("pressing n on a remote group must issue the remote quick-create command")
+	if !h.newDialog.IsVisible() {
+		t.Fatal("pressing n on a remote group must open the new-session dialog (#1353)")
 	}
-	if h.newDialog.IsVisible() {
-		t.Fatal("pressing n on a remote group must NOT open the local new-session dialog")
+	if h.pendingRemoteName != "myserver" {
+		t.Fatalf("remote target must be recorded so submit creates on the remote, not localhost (#743); got %q", h.pendingRemoteName)
 	}
 }
 

--- a/internal/ui/issue1353_remote_new_dialog_test.go
+++ b/internal/ui/issue1353_remote_new_dialog_test.go
@@ -1,0 +1,197 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Issue #1353: pressing `n` while the cursor is on a remote group/session used
+// to silently quick-create a SHELL session on the remote (`add --quick --json`,
+// no -c flag) with no tool-selection dialog. The user got a shell regardless of
+// the tool they wanted (claude, codex, pi, ...).
+//
+// New contract: `n` on a remote item opens the same new-session dialog as for
+// local items, with the remote target remembered (Home.pendingRemoteName).
+// Submitting routes the create to the remote via SSH with the chosen tool
+// (`add --json -c <tool> -t <title> [path]`) — the local-only paths (worktree
+// resolution, directory-exists check, local create) are all skipped, which
+// preserves the #743 invariant that the session must NOT be created on
+// localhost.
+//
+// `N` (quick create) on a remote is intentionally unchanged: it still
+// quick-creates on the remote without a dialog.
+
+func remoteGroupItem(name string) session.Item {
+	return session.Item{Type: session.ItemTypeRemoteGroup, RemoteName: name, Path: "remotes/" + name}
+}
+
+func remoteSessionItem(name string) session.Item {
+	rs := session.RemoteSessionInfo{ID: "remote-123", Title: "remote-session", RemoteName: name}
+	return session.Item{Type: session.ItemTypeRemoteSession, RemoteSession: &rs, RemoteName: name}
+}
+
+func pressN(t *testing.T, h *Home) *Home {
+	t.Helper()
+	model, _ := h.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	home, ok := model.(*Home)
+	if !ok {
+		t.Fatal("handleMainKey should return *Home")
+	}
+	return home
+}
+
+// TestIssue1353_NOnRemoteGroup_OpensDialog: `n` on a remote group header must
+// open the new-session dialog (tool selection included) instead of silently
+// quick-creating a shell on the remote.
+func TestIssue1353_NOnRemoteGroup_OpensDialog(t *testing.T) {
+	setXDGTestHome(t)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteGroupItem("myserver")}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	if !h.newDialog.IsVisible() {
+		t.Fatal("pressing n on a remote group must open the new-session dialog (#1353)")
+	}
+	if h.pendingRemoteName != "myserver" {
+		t.Fatalf("pendingRemoteName = %q, want %q", h.pendingRemoteName, "myserver")
+	}
+}
+
+// TestIssue1353_NOnRemoteSession_OpensDialog: same contract when the cursor is
+// on a remote session row.
+func TestIssue1353_NOnRemoteSession_OpensDialog(t *testing.T) {
+	setXDGTestHome(t)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteSessionItem("myserver")}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	if !h.newDialog.IsVisible() {
+		t.Fatal("pressing n on a remote session must open the new-session dialog (#1353)")
+	}
+	if h.pendingRemoteName != "myserver" {
+		t.Fatalf("pendingRemoteName = %q, want %q", h.pendingRemoteName, "myserver")
+	}
+}
+
+// TestIssue1353_RemoteDialogDefaults: for a remote target the path field
+// defaults to "." (remote CWD) so a local filesystem path is never sent to the
+// remote, and the dialog is parented under the remote's group label.
+func TestIssue1353_RemoteDialogDefaults(t *testing.T) {
+	setXDGTestHome(t)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteGroupItem("myserver")}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	_, path, _ := h.newDialog.GetValues()
+	if path != "." {
+		t.Fatalf("remote dialog path default = %q, want %q (remote CWD)", path, ".")
+	}
+	if got := h.newDialog.GetSelectedGroup(); got != "remotes/myserver" {
+		t.Fatalf("remote dialog group = %q, want %q", got, "remotes/myserver")
+	}
+}
+
+// TestIssue1353_EscClearsPendingRemote: cancelling the dialog must clear the
+// remote target so a later local `n` does not accidentally create remotely.
+func TestIssue1353_EscClearsPendingRemote(t *testing.T) {
+	setXDGTestHome(t)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteGroupItem("myserver")}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	if h.pendingRemoteName == "" {
+		t.Fatal("precondition: pendingRemoteName must be set after n on remote")
+	}
+	h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if h.newDialog.IsVisible() {
+		t.Fatal("Esc must close the dialog")
+	}
+	if h.pendingRemoteName != "" {
+		t.Fatalf("Esc must clear pendingRemoteName, got %q", h.pendingRemoteName)
+	}
+}
+
+// TestIssue1353_SubmitRoutesToRemote: submitting the dialog for a remote
+// target must route to the remote-create path (never the local create). The
+// sandboxed test config has no [remotes.myserver], so the returned command
+// resolves to a remote-lookup error — proof the submit took the remote branch
+// instead of creating a local session.
+func TestIssue1353_SubmitRoutesToRemote(t *testing.T) {
+	setXDGTestHome(t)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{remoteGroupItem("myserver")}
+	home.cursor = 0
+
+	h := pressN(t, home)
+	// Type a session name (focus starts on the Name field).
+	for _, r := range "my-remote-task" {
+		h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	model, cmd := h.handleNewDialogKey(tea.KeyMsg{Type: tea.KeyEnter})
+	h = model.(*Home)
+
+	if h.newDialog.IsVisible() {
+		t.Fatal("submit must close the dialog")
+	}
+	if h.pendingRemoteName != "" {
+		t.Fatalf("submit must consume pendingRemoteName, got %q", h.pendingRemoteName)
+	}
+	if cmd == nil {
+		t.Fatal("submit must return a command (remote create)")
+	}
+	msg := cmd()
+	created, ok := msg.(sessionCreatedMsg)
+	if !ok {
+		t.Fatalf("expected sessionCreatedMsg from remote-create path, got %T", msg)
+	}
+	if created.err == nil || !strings.Contains(created.err.Error(), "remote") {
+		t.Fatalf("expected remote-lookup error (proves remote routing), got %v", created.err)
+	}
+	// The local create path must not have run: no instances created.
+	if len(h.instances) != 0 {
+		t.Fatalf("local create must not run for remote targets; got %d instances", len(h.instances))
+	}
+}
+
+// TestIssue1353_LocalNUnaffected: `n` on a local group keeps the existing
+// behavior and must not leave any stale remote target around.
+func TestIssue1353_LocalNUnaffected(t *testing.T) {
+	setXDGTestHome(t)
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+	home.flatItems = []session.Item{{
+		Type:  session.ItemTypeGroup,
+		Group: &session.Group{Name: "proj", Path: "proj"},
+		Path:  "proj",
+	}}
+	home.cursor = 0
+	// Simulate a previous remote flow that was abandoned without Esc.
+	home.pendingRemoteName = "stale-remote"
+
+	h := pressN(t, home)
+	if !h.newDialog.IsVisible() {
+		t.Fatal("n on a local group must open the dialog")
+	}
+	if h.pendingRemoteName != "" {
+		t.Fatalf("n on a local group must clear pendingRemoteName, got %q", h.pendingRemoteName)
+	}
+}


### PR DESCRIPTION
Fixes #1353 (reported by @barjatiyasaurabh).

## Root cause

The `case "n":` handler in `internal/ui/home.go` early-returned for `ItemTypeRemoteGroup` / `ItemTypeRemoteSession` and called `createRemoteSession()`, which runs `agent-deck add --quick --json` on the remote — no `-c` flag, so every remote `n` silently produced a **shell** session with no tool-selection dialog, regardless of what the user wanted (claude, codex, pi, ...). The early return existed to protect the #743 invariant: the local dialog had no remote awareness, so letting it open used to create the session on **localhost**.

## Behavior change

`n` on a remote group/session now opens the same new-session dialog as for local items:

- The remote target is stored in `Home.pendingRemoteName` when the dialog opens.
- On submit, the create is routed to the remote over SSH with the chosen tool/title/path: `add --json -c <tool> -t <title> [path]`. All local-only logic (worktree resolution, directory-exists check, local create) is skipped — the #743 "never create on localhost" invariant is now enforced at submit time instead of by suppressing the dialog.
- The path field defaults to `.` (remote CWD); `.`/empty is not sent, so no local path leaks to the remote. Local path suggestions and recent-session presets are not offered for remote targets.
- An empty title falls back to `--quick` (auto-generated name on the remote).
- Esc clears the pending remote target; a later local `n` resets any stale one.
- `SSHRunner.CreateSessionWithOptions` reuses the existing `add` → `session start` → compensating-delete flow, so a tool that is missing on the remote surfaces as a create error rather than an orphan remote DB row. Args go through the existing `shellQuote` path (titles with spaces/quotes are safe).
- `N` (quick create) on a remote is unchanged: remote defaults, no dialog.

### Known constraints (documented, intentionally out of scope)

- The dialog's local-only extras (worktree, sandbox, multi-repo, model/tool options panels, conductor parent) are visible but **ignored** for remote targets — only tool/title/path cross the SSH boundary. Plumbing those would require remote capability discovery.
- A `~/...` path typed for a remote is expanded against the *local* home (pre-existing `GetValues` behavior); explicit absolute paths work as expected.

## Tests (TDD — written first, failed, then fixed)

`internal/ui/issue1353_remote_new_dialog_test.go`:
- `TestIssue1353_NOnRemoteGroup_OpensDialog` / `TestIssue1353_NOnRemoteSession_OpensDialog` — `n` opens the dialog with the remote target recorded.
- `TestIssue1353_RemoteDialogDefaults` — path defaults to `.`, dialog parented under `remotes/<name>`.
- `TestIssue1353_EscClearsPendingRemote` — cancel lifecycle.
- `TestIssue1353_SubmitRoutesToRemote` — submit takes the remote branch (and never the local create).
- `TestIssue1353_LocalNUnaffected` — local `n` unchanged + stale-target reset.

`internal/session/ssh_test.go`:
- `TestRemoteAddArgs` — argument builder (tool/title/path × defaults/whitespace/`.`).

The two #743 regression tests (`TestRegression743_*`) are updated to assert the new contract: the dialog opens AND the remote target is recorded so submit creates on the remote, not localhost.

## Verification

- `go build ./...` clean; `go vet` clean; touched files gofmt-clean.
- Sandboxed (`HOME=$(mktemp -d) XDG_*=`): `go test ./internal/ui/` and `./internal/session/` — new + updated tests green. (Full-suite runs on this host hit the known inotify `max_user_instances` exhaustion in unrelated global-search tests; they pass in isolation and on CI.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote sessions can now be created through an interactive dialog with customizable tool, title, and path settings.
  * Pressing "n" on a remote group or session now opens the new session dialog for flexible remote session configuration.

* **Tests**
  * Added comprehensive test coverage for remote session dialog behavior and custom remote session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->