### PR TITLE
fix: preserve nested group paths when creating sessions (#1357)

### DIFF
--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -438,7 +438,7 @@ func handleLaunch(profile string, args []string) {
 
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
 	if newInstance.GroupPath != "" {
-		groupTree.CreateGroup(newInstance.GroupPath)
+		groupTree.CreateGroupPath(newInstance.GroupPath)
 	}
 
 	// v1.9.x issue #1031: targeted single-row insert + verify, NOT the
@@ -540,7 +540,7 @@ func handleLaunch(profile string, args []string) {
 	// `DELETE FROM instances WHERE id NOT IN (...)` step.
 	postStartTree := session.NewGroupTreeWithGroups(instances, groups)
 	if newInstance.GroupPath != "" {
-		postStartTree.CreateGroup(newInstance.GroupPath)
+		postStartTree.CreateGroupPath(newInstance.GroupPath)
 	}
 	if err := storage.InsertSessionAndVerify(newInstance, postStartTree); err != nil {
 		out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1660,7 +1660,7 @@ func handleAdd(profile string, args []string) {
 	groupTree = session.NewGroupTreeWithGroups(instances, groups)
 	// Ensure the session's group exists
 	if newInstance.GroupPath != "" {
-		groupTree.CreateGroup(newInstance.GroupPath)
+		groupTree.CreateGroupPath(newInstance.GroupPath)
 	}
 
 	if err := storage.SaveWithGroups(instances, groupTree); err != nil {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1009,7 +1009,7 @@ func handleSessionFork(profile string, args []string) {
 	// Rebuild group tree and ensure group exists
 	groupTree := session.NewGroupTreeWithGroups(instances, groupsData)
 	if forkedInst.GroupPath != "" {
-		groupTree.CreateGroup(forkedInst.GroupPath)
+		groupTree.CreateGroupPath(forkedInst.GroupPath)
 	}
 
 	// Save

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -943,6 +943,32 @@ func (t *GroupTree) CreateSubgroup(parentPath, name string) *Group {
 	return group
 }
 
+// CreateGroupPath ensures every level of a (possibly nested) group path exists,
+// creating any missing intermediate groups, and returns the leaf group.
+//
+// Unlike CreateGroup, it treats "/" as a path separator instead of letting
+// sanitizeGroupName flatten it into a hyphen, so "work/bar" creates "work" and
+// "work/bar" rather than a single flat "work-bar" group (see issue #1357).
+func (t *GroupTree) CreateGroupPath(path string) *Group {
+	var parentPath string
+	var leaf *Group
+	for _, segment := range strings.Split(path, "/") {
+		if strings.TrimSpace(segment) == "" {
+			continue // tolerate leading/trailing/duplicate separators
+		}
+		if parentPath == "" {
+			leaf = t.CreateGroup(segment)
+		} else {
+			leaf = t.CreateSubgroup(parentPath, segment)
+		}
+		if leaf == nil {
+			return nil
+		}
+		parentPath = leaf.Path
+	}
+	return leaf
+}
+
 // RenameGroup renames a group and updates all subgroups
 func (t *GroupTree) RenameGroup(oldPath, newName string) {
 	group, exists := t.Groups[oldPath]

--- a/internal/session/groups_test.go
+++ b/internal/session/groups_test.go
@@ -38,6 +38,46 @@ func TestNewGroupTree(t *testing.T) {
 	}
 }
 
+// TestCreateGroupPathNestedPreservesHierarchy guards against issue #1357: a
+// nested group path must create the intermediate group(s) and the leaf, and
+// must NOT create a flattened "work-bar" root group.
+func TestCreateGroupPathNestedPreservesHierarchy(t *testing.T) {
+	tree := NewGroupTree(nil)
+
+	leaf := tree.CreateGroupPath("work/bar")
+
+	if leaf == nil {
+		t.Fatal("CreateGroupPath returned nil leaf group")
+	}
+	if leaf.Path != "work/bar" {
+		t.Errorf("leaf group path = %q, want %q", leaf.Path, "work/bar")
+	}
+	if _, ok := tree.Groups["work"]; !ok {
+		t.Errorf("parent group %q was not created", "work")
+	}
+	if _, ok := tree.Groups["work/bar"]; !ok {
+		t.Errorf("nested group %q was not created", "work/bar")
+	}
+	if g, ok := tree.Groups["work-bar"]; ok {
+		t.Errorf("regression #1357: phantom flat group %q was created (%+v)", "work-bar", g)
+	}
+}
+
+// TestCreateGroupPathSingleLevel confirms the helper is a safe drop-in for flat
+// names: a path with no separator behaves exactly like CreateGroup.
+func TestCreateGroupPathSingleLevel(t *testing.T) {
+	tree := NewGroupTree(nil)
+
+	leaf := tree.CreateGroupPath("work")
+
+	if leaf == nil || leaf.Path != "work" {
+		t.Fatalf("CreateGroupPath(\"work\") = %+v, want path %q", leaf, "work")
+	}
+	if _, ok := tree.Groups["work"]; !ok {
+		t.Errorf("group %q was not created", "work")
+	}
+}
+
 func TestNewGroupTreeEmptyGroupPath(t *testing.T) {
 	instances := []*Instance{
 		{ID: "1", Title: "session-1", GroupPath: ""},


### PR DESCRIPTION
Fixes #1357.

**Problem:** `agent-deck add -g work/bar` created the correct nested `work/bar` group *and* a spurious empty `work-bar` group at the root.

**Cause:** `handleAdd` passed a nested path into `CreateGroup`, whose `sanitizeGroupName` replaces `/` with `-` (a path-traversal guard) before anything splits on `/`.

**Fix:** a new `CreateGroupPath` helper splits on `/` and chains `CreateGroup`/`CreateSubgroup` so each level is created properly. Applied to the session-creation sites that propagate a possibly-nested `GroupPath`: `add`, `launch` (×2: initial + post-start save), and `fork`. It's a safe drop-in for flat names.

**Scope:** left `group_cmd.go` (the `group create` command), `session_move.go`, and the conductor/openclaw/web/UI group creators untouched, since those take an explicit group *name* with different intent — happy to extend if you'd prefer.

**Testing:**
- Added `TestCreateGroupPathNestedPreservesHierarchy` (asserts `work` + `work/bar` exist and `work-bar` does not) and `TestCreateGroupPathSingleLevel`.
- `go build ./...`, `go vet` on the changed packages, and the `internal/session` group suite all pass. golangci-lint wasn't available locally, so `gofmt -l` + `go vet` were run as substitutes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced hierarchical group path handling to properly create and preserve nested group structures with intermediate levels.

* **Tests**
  * Added test coverage for hierarchical group path creation and single-level group behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->