### PR TITLE
fix(ui): cut tmux subprocess load behind TUI lag at scale (#1366)

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2872,6 +2872,12 @@ func (h *Home) selectedRemotePreviewTarget() (string, string, string, bool) {
 // fetchSelectedPreview debounces a preview fetch for the currently selected item.
 // Handles both session and window items transparently.
 func (h *Home) fetchSelectedPreview() tea.Cmd {
+	// Issue #1366: in single-column layout there is no preview pane, so there is
+	// nothing to fill — skip the `tmux capture-pane` entirely. The preview is
+	// re-fetched on resize back into a preview layout (see WindowSizeMsg).
+	if h.getLayoutMode() == LayoutModeSingle {
+		return nil
+	}
 	inst, _, winIdx := h.selectedPreviewTarget()
 	if inst == nil {
 		remoteName, remoteSessionID, _, ok := h.selectedRemotePreviewTarget()
@@ -3151,25 +3157,56 @@ func (h *Home) getDefaultPathForGroup(groupPath string) string {
 	return p
 }
 
-// statusWorker runs in a background goroutine with its own ticker
+// Status-sweep cadence (issue #1366). The sweep normally runs every
+// baseStatusInterval. When a sweep overruns that interval — which happens at
+// large session counts when the tmux control-mode pipe is unavailable/degraded
+// and capture-pane falls back to subprocesses — sweeps would otherwise pile up
+// and pin the tmux server. nextStatusInterval backs the cadence off so the
+// gap between sweeps is at least twice the last sweep's duration (≈50% duty
+// cycle), capped at maxStatusInterval. Fast sweeps keep the base cadence, so
+// there is no behaviour change in the common (piped) case.
+const (
+	baseStatusInterval = 2 * time.Second
+	maxStatusInterval  = 10 * time.Second
+)
+
+// nextStatusInterval returns how long to wait before the next status sweep,
+// given how long the last sweep took. It returns base when the sweep finished
+// within base, otherwise 2×lastSweep capped at max.
+func nextStatusInterval(lastSweep, base, ceiling time.Duration) time.Duration {
+	if lastSweep <= base {
+		return base
+	}
+	next := 2 * lastSweep
+	if next > ceiling {
+		return ceiling
+	}
+	return next
+}
+
+// statusWorker runs in a background goroutine with its own timer
 // This ensures status updates continue even when TUI is paused (tea.Exec)
 func (h *Home) statusWorker() {
 	defer close(h.statusWorkerDone)
 
-	// Internal ticker - independent of Bubble Tea event loop
+	// Internal timer - independent of Bubble Tea event loop
 	// This is the key insight: when tea.Exec suspends the TUI (user attaches to session),
-	// the Bubble Tea tick messages stop firing, but this goroutine keeps running
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
+	// the Bubble Tea tick messages stop firing, but this goroutine keeps running.
+	// A timer (reset after each sweep) rather than a fixed ticker lets the cadence
+	// adapt when a sweep overruns the interval (#1366).
+	timer := time.NewTimer(baseStatusInterval)
+	defer timer.Stop()
 
 	for {
 		select {
 		case <-h.ctx.Done():
 			return
 
-		case <-ticker.C:
+		case <-timer.C:
 			// Self-triggered update - runs even when TUI is paused
+			sweepStart := time.Now()
 			h.backgroundStatusUpdate()
+			timer.Reset(nextStatusInterval(time.Since(sweepStart), baseStatusInterval, maxStatusInterval))
 			// Coalesce a queued immediate request after full sweep.
 			select {
 			case <-h.statusTrigger:
@@ -3891,7 +3928,10 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.toolVisibilityPanel.SetSize(msg.Width, msg.Height)
 		}
 		h.geminiModelDialog.SetSize(msg.Width, msg.Height)
-		return h, nil
+		// Issue #1366: a resize can reveal the preview pane (single -> stacked/dual).
+		// fetchSelectedPreview self-guards to nil in single-column, so this only
+		// fetches when a preview pane is actually visible.
+		return h, h.fetchSelectedPreview()
 
 	case tea.MouseMsg:
 		// Route mouse wheel events to the active scrollable area.

--- a/internal/ui/issue1366_preview_fetch_layout_test.go
+++ b/internal/ui/issue1366_preview_fetch_layout_test.go
@@ -1,0 +1,58 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// armHomeOneSessionForPreview builds a Home with a single selected session,
+// suitable for exercising the preview-fetch path. No tmux is started.
+func armHomeOneSessionForPreview(t *testing.T) *Home {
+	t.Helper()
+	h := NewHome()
+	h.height = 40
+	h.initialLoading = false
+
+	inst := session.NewInstanceWithTool("preview-sess", "/tmp/grp/proj", "claude")
+	h.instancesMu.Lock()
+	h.instances = []*session.Instance{inst}
+	h.instanceByID = map[string]*session.Instance{inst.ID: inst}
+	h.instancesMu.Unlock()
+	h.groupTree = session.NewGroupTree(h.instances)
+	h.rebuildFlatItems()
+	for i, item := range h.flatItems {
+		if item.Type == session.ItemTypeSession && item.Session != nil && item.Session.ID == inst.ID {
+			h.cursor = i
+			break
+		}
+	}
+	return h
+}
+
+// Issue #1366: navigating in a layout with no preview pane (single-column,
+// width < 50) must NOT schedule a `tmux capture-pane` for a preview nobody
+// renders. Today fetchSelectedPreview fires unconditionally — wasted subprocess.
+func TestIssue1366_NoPreviewFetchInSingleColumnLayout(t *testing.T) {
+	h := armHomeOneSessionForPreview(t)
+	h.width = 45 // < 50 => LayoutModeSingle (list only, no preview pane)
+	if got := h.getLayoutMode(); got != LayoutModeSingle {
+		t.Fatalf("setup: layout = %q, want %q", got, LayoutModeSingle)
+	}
+	if cmd := h.fetchSelectedPreview(); cmd != nil {
+		t.Fatal("fetchSelectedPreview must return nil in single-column layout (no preview pane) — issue #1366")
+	}
+}
+
+// Regression guard: when the preview pane IS visible (dual layout), navigation
+// must still schedule the fetch.
+func TestIssue1366_PreviewFetchInDualLayout(t *testing.T) {
+	h := armHomeOneSessionForPreview(t)
+	h.width = 120 // dual layout: preview pane visible
+	if got := h.getLayoutMode(); got != LayoutModeDual {
+		t.Fatalf("setup: layout = %q, want %q", got, LayoutModeDual)
+	}
+	if cmd := h.fetchSelectedPreview(); cmd == nil {
+		t.Fatal("fetchSelectedPreview must schedule a fetch when the preview pane is visible")
+	}
+}

--- a/internal/ui/issue1366_status_backoff_test.go
+++ b/internal/ui/issue1366_status_backoff_test.go
@@ -1,0 +1,35 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+// Issue #1366: the status worker ticks on a FIXED 2s interval with no
+// protection against a sweep that overruns the interval. When tmux is under
+// load (e.g. no/degraded control-mode pipe at ~100 sessions) a sweep can take
+// longer than 2s, so sweeps pile up and pin the tmux server. nextStatusInterval
+// keeps the base cadence when sweeps are fast and backs off (bounding the duty
+// cycle to ~50%) when a sweep overruns, capped at max.
+func TestNextStatusInterval(t *testing.T) {
+	base := 2 * time.Second
+	max := 10 * time.Second
+	cases := []struct {
+		name      string
+		lastSweep time.Duration
+		want      time.Duration
+	}{
+		{"fast sweep keeps base", 100 * time.Millisecond, base},
+		{"just under base keeps base", 1900 * time.Millisecond, base},
+		{"equal to base keeps base", base, base},
+		{"overrun backs off to 2x", 3 * time.Second, 6 * time.Second},
+		{"large overrun caps at max", 20 * time.Second, max},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nextStatusInterval(tc.lastSweep, base, max); got != tc.want {
+				t.Errorf("nextStatusInterval(%v) = %v, want %v", tc.lastSweep, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue
Fixes part of #1366 — TUI lag at ~100 sessions (reporter sees 10–15 s/keystroke with ~20 active agents).

## What the profiling showed
- **The synchronous keystroke→render path is *not* the bottleneck.** At 100 sessions (across ~10 groups), `Update(down)` + full `View()` is **~4 ms** in pure Go — the list renders only visible rows, status counts are 500 ms-cached, the preview reads an in-memory cache. A 10–15 s freeze can't come from rendering.
- **What scales with session count is tmux subprocess volume** — the per-navigation preview `capture-pane` and the every-2 s status sweep. The status path is already well-optimised (control-mode pipe → zero-subprocess capture; cached/pipe-first activity; visible-pane-only status capture), so the subprocess *storm* is the **no-/degraded-pipe fallback** at scale.

> Note: I could **not** reproduce the 10–15 s freeze on idle 24-core hardware, so these are deliberately **load-independent correctness/efficiency wins** rather than a claimed “Xs → Yms”. The reporter's CPU profile (requested on the issue) will guide any further tuning.

## Changes
**1. Don't fetch a preview nobody renders.** Navigation fired `tmux capture-pane -S -2000` for the highlighted session on every cursor move — even in single-column layout (terminal width < 50), which has no preview pane. `fetchSelectedPreview()` now returns `nil` in single-column layout; `WindowSizeMsg` re-fetches when a resize reveals the pane again. Pure waste elimination — there is no layout where fetching an unrendered preview is correct.

**2. Adaptive status-sweep cadence.** The status worker ticked on a **fixed 2 s** interval with no protection against a sweep that overruns it. Under the degraded-pipe fallback at ~100 sessions a sweep can exceed 2 s, so sweeps pile up and pin the tmux server. The worker now uses a resettable timer driven by `nextStatusInterval`: base 2 s when sweeps are fast (**no behaviour change in the common piped case**), backing off to 2× the last sweep duration (capped 10 s) when a sweep overruns — bounding the duty cycle to ~50 %.

## Tests (TDD — written first, watched fail, then implemented)
- `TestIssue1366_NoPreviewFetchInSingleColumnLayout` — no preview fetch when there's no preview pane.
- `TestIssue1366_PreviewFetchInDualLayout` — regression guard: fetch still happens when the pane is visible.
- `TestNextStatusInterval` — base cadence for fast sweeps; back-off + cap on overrun.

## Verification
- `go build ./...` ✅ · `go vet ./internal/ui/` ✅
- New tests pass; full `internal/ui` suite green in isolation. (One unrelated failure in this sandbox, `TestHomeGlobalSearchEscape`, is `inotify: too many open files` — host inotify-instance exhaustion from other running agents; passes in isolation and is untouched by this change.)

## Scope / follow-ups (intentionally deferred)
- A user-facing **toggle to disable the preview pane** and **status monitoring** entirely (the reporter's explicit ask) — worth adding for very large fleets once the dominant cost is confirmed from the profile.
- Batching window-activity into the bulk `list-panes` pass to shave the degraded-pipe fallback further.

Do not merge yet — pending the reporter's profile and the conductor's Codex pass + CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preview fetching to skip unnecessary work in single-column layout mode.
  * Improved status refresh behavior to dynamically adapt timing under degraded conditions, preventing system overload.
  * Ensured preview content fetches promptly when window resizing reveals a preview pane.

* **Tests**
  * Added regression tests for layout-dependent preview fetch behavior and status interval backoff logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->