### PR TITLE
fix(tmux): stop badge-watcher goroutine/fd leak on every attach

### DIFF
--- a/internal/tmux/issue1114_badge_rename_test.go
+++ b/internal/tmux/issue1114_badge_rename_test.go
@@ -299,3 +299,39 @@ func TestIssue1114_OSCMatchesAttachEmit(t *testing.T) {
 	cancel()
 	<-done
 }
+
+// TestIssue1114_AttachLaunchesWatcherWithCancelableCtx is the structural
+// regression test for the badge-watcher resource leak: Attach() used to
+// launch `go WatchBadgeUpdates(ctx, ...)` BEFORE the
+// `ctx, cancel := context.WithCancel(ctx)` line, so the goroutine
+// captured the caller's context — context.Background() on the TUI path
+// (attachCmd.Run) — and was never stopped. Every attach leaked one
+// goroutine (250 ms poll ticker) plus one fsnotify watcher (an inotify
+// fd + an epoll fd on Linux), all watching the same badge-updates
+// directory inode. A day of deck hopping accumulated ~400 watchers and
+// double-digit sustained CPU.
+//
+// Attach itself needs a live tmux server, so — same pattern as the
+// PERF-E / mobile-input structural specs — this asserts on the source:
+// inside Attach(), the WithCancel call must precede the
+// WatchBadgeUpdates launch so the watcher receives the context that the
+// deferred cancel actually cancels on detach.
+func TestIssue1114_AttachLaunchesWatcherWithCancelableCtx(t *testing.T) {
+	src, err := os.ReadFile("pty.go")
+	require.NoError(t, err)
+
+	attachIdx := strings.Index(string(src), "func (s *Session) Attach(")
+	require.GreaterOrEqual(t, attachIdx, 0, "Attach() not found in pty.go")
+	body := string(src)[attachIdx:]
+
+	withCancelIdx := strings.Index(body, "context.WithCancel(")
+	watchIdx := strings.Index(body, "go WatchBadgeUpdates(")
+	require.GreaterOrEqual(t, withCancelIdx, 0, "context.WithCancel not found in Attach()")
+	require.GreaterOrEqual(t, watchIdx, 0, "go WatchBadgeUpdates not found in Attach()")
+
+	require.Less(t, withCancelIdx, watchIdx,
+		"WatchBadgeUpdates must be launched AFTER context.WithCancel in Attach(); "+
+			"launching it before hands it the caller's non-cancellable context "+
+			"(context.Background() on the TUI attach path) and leaks one goroutine + "+
+			"one fsnotify watcher per attach")
+}

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -164,18 +164,26 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 	// it off at runtime. AGENTDECK_ITERM_BADGE=1 ad-hoc enables.
 	emitITermBadge(os.Stdout, s.DisplayName, s.terminalChromeIsEnabled())
 
+	// Create context with cancel for detach
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// #1114: subscribe to mid-attach badge updates from the Claude
 	// rename hook. The hook subprocess has no controlling tty (Claude
 	// spawns hooks detached via setsid), so its EmitITermBadgeViaTty
 	// path silently no-ops. Instead, the hook drops a file under
 	// ~/.agent-deck/badge-updates/ and this goroutine — which DOES own
 	// the outer iTerm2 tty via os.Stdout — re-emits the OSC. Stopped
-	// by the ctx cancel that fires in cleanupAttach.
+	// by the deferred cancel above when Attach returns (detach).
+	//
+	// MUST be launched AFTER the context.WithCancel call: the TUI's
+	// attachCmd.Run passes context.Background(), so a goroutine started
+	// with the pre-WithCancel ctx is never stopped. That ordering bug
+	// leaked one goroutine (250ms poll ticker) plus one fsnotify
+	// watcher (inotify fd + epoll fd on Linux) per attach — hundreds
+	// of watchers on the badge-updates dir inode and double-digit
+	// sustained CPU after a day of deck hopping.
 	go WatchBadgeUpdates(ctx, s.Name, os.Stdout, s.terminalChromeIsEnabled(), nil)
-
-	// Create context with cancel for detach
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	// Start tmux attach command with PTY.
 	// Routes through s.attachCmd → s.tmuxCmdContext so the -L <SocketName>


### PR DESCRIPTION
Closes #1374.

## What

`Attach()` launched `go WatchBadgeUpdates(ctx, ...)` two lines **before** `ctx, cancel := context.WithCancel(ctx)`, so the watcher goroutine captured the caller's context instead of the cancellable detach context. The TUI attach path (`attachCmd.Run` in `internal/ui/home.go`) passes `context.Background()` — never cancelled — so every attach permanently leaked:

- one goroutine running a 250 ms poll ticker (a file read 4×/sec), and
- one fsnotify watcher (on Linux: 1 inotify fd + 1 epoll fd) on the shared `badge-updates` directory.

Observed in production (WSL2, 26-hour TUI session, heavy deck switching): **862 open fds** on the agent-deck process — 400 inotify + 399 eventpoll, with 398 of the inotify watches stacked on the `badge-updates` dir inode — and ~70% of a core burned by ~400 leaked tickers. Full evidence in #1374.

## Fix

Move the goroutine launch after the `WithCancel` call so the watcher receives the context that the deferred cancel actually fires on detach. `WatchBadgeUpdates` already honors ctx cancellation and closes its fsnotify watcher via defer — the wiring order was the only bug. The launch-site comment now documents why the ordering is load-bearing.

## Test

`TestIssue1114_AttachLaunchesWatcherWithCancelableCtx` — structural source assert (same pattern as the PERF-E / mobile-input specs) pinning the WithCancel-before-WatchBadgeUpdates ordering inside `Attach()`, since `Attach` itself needs a live tmux server unit CI doesn't have.

TDD-verified per the repo mandate: with the fix temporarily reverted, the test fails with `WatchBadgeUpdates must be launched AFTER context.WithCancel in Attach(); ...`; with the fix restored, all 7 `Issue1114` tests pass (`go test ./internal/tmux/ -run Issue1114 -count=1`).

## Notes

- No user-observable behavior change: badge updates during attach work exactly as before; the watcher now just dies on detach as the original comment already claimed it did.
- Possible follow-up (separate PR, mentioned in #1374): early-return in `WatchBadgeUpdates` when the badge can never render (non-iTerm2 terminal or chrome disabled), so non-iTerm2 users don't pay for the goroutine+watcher+ticker at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved iTerm2 badge updater not properly terminating on session detach.

* **Tests**
  * Added regression test to prevent this issue from recurring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->