### PR TITLE
fix(git): ignore URL in branch.<name>.remote when resolving default remote

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -831,7 +832,11 @@ func getDefaultRemote(repoDir string) (string, error) {
 		output, err := cmd.Output()
 		if err == nil {
 			remote := strings.TrimSpace(string(output))
-			if remote != "" {
+			// branch.<name>.remote may hold a bare URL (e.g. after pulling a
+			// PR branch directly from a fork URL). A URL is fetchable but is
+			// not a remote-tracking ref prefix, so "<url>/main" later fails
+			// with "invalid reference" — only accept configured remote names.
+			if remote != "" && slices.Contains(remotes, remote) {
 				return remote, nil
 			}
 		}

--- a/internal/git/url_branch_remote_test.go
+++ b/internal/git/url_branch_remote_test.go
@@ -1,0 +1,82 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCreateWorktree_NewBranch_URLInBranchRemoteConfig pins the fix for
+// worktree creation failing with "fatal: invalid reference: <url>/main".
+//
+// Bug: git permits `branch.<name>.remote` to hold a bare URL instead of a
+// remote name (this is what `git pull <fork-url> <branch>` leaves behind when
+// checking out a PR branch directly from a fork). getDefaultRemote returned
+// that URL verbatim, and freshOriginDefaultBranchRef happily fetched from it
+// (fetching by URL is valid git), then handed callers "<url>/<default>" as a
+// base ref — which is not a ref at all, so `git worktree add` died with
+// "invalid reference" and session creation failed.
+//
+// Invariant pinned here: a URL in branch.<name>.remote must not be treated as
+// the default remote; resolution falls through to the configured "origin",
+// and a brand-new branch worktree is rooted at fresh origin/<default>.
+func TestCreateWorktree_NewBranch_URLInBranchRemoteConfig(t *testing.T) {
+	tmp := t.TempDir()
+
+	remoteDir := filepath.Join(tmp, "origin.git")
+	if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	runGit(t, remoteDir, "init", "--bare", "-b", "main")
+
+	// A second bare repo standing in for the fork URL. It must be fetchable:
+	// in the real incident `git fetch <url> main` succeeded, which is exactly
+	// why the broken "<url>/main" base ref made it through to worktree add.
+	forkDir := filepath.Join(tmp, "fork.git")
+	if err := os.MkdirAll(forkDir, 0o755); err != nil {
+		t.Fatalf("mkdir fork: %v", err)
+	}
+	runGit(t, forkDir, "init", "--bare", "-b", "main")
+
+	localDir := filepath.Join(tmp, "local")
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatalf("mkdir local: %v", err)
+	}
+	runGit(t, localDir, "init", "-b", "main")
+	runGit(t, localDir, "config", "user.email", "test@test.com")
+	runGit(t, localDir, "config", "user.name", "Test User")
+	runGit(t, localDir, "remote", "add", "origin", remoteDir)
+
+	// C1 on main, pushed to both origin and the fork.
+	if err := os.WriteFile(filepath.Join(localDir, "README.md"), []byte("c1"), 0o644); err != nil {
+		t.Fatalf("write c1: %v", err)
+	}
+	runGit(t, localDir, "add", ".")
+	runGit(t, localDir, "commit", "-m", "c1")
+	runGit(t, localDir, "push", "-u", "origin", "main")
+	runGit(t, localDir, "push", forkDir, "main")
+
+	// C2 advances origin/main only — lets the assertion distinguish "rooted
+	// at fresh origin/main" from "rooted at the fork or stale local state".
+	if err := os.WriteFile(filepath.Join(localDir, "README.md"), []byte("c2"), 0o644); err != nil {
+		t.Fatalf("write c2: %v", err)
+	}
+	runGit(t, localDir, "commit", "-am", "c2")
+	runGit(t, localDir, "push", "origin", "main")
+	c2 := runGit(t, localDir, "rev-parse", "HEAD")
+
+	// The incident state: current branch's remote config is a URL, not a
+	// remote name.
+	runGit(t, localDir, "checkout", "-b", "pr-from-fork")
+	runGit(t, localDir, "config", "branch.pr-from-fork.remote", forkDir)
+
+	worktreePath := filepath.Join(tmp, "new-feature-wt")
+	if err := CreateWorktree(localDir, worktreePath, "feature/new-thing"); err != nil {
+		t.Fatalf("CreateWorktree failed (URL in branch.<name>.remote leaked into base ref?): %v", err)
+	}
+
+	headSHA := runGit(t, worktreePath, "rev-parse", "HEAD")
+	if headSHA != c2 {
+		t.Fatalf("worktree not rooted at fresh origin/main: got HEAD %s, want %s", headSHA, c2)
+	}
+}


### PR DESCRIPTION
## What

Worktree creation for a new branch failed with:

```
failed to create worktree: fatal: invalid reference: git@github.com:<fork>/<repo>.git/main: exit status 128
```

git permits `branch.<name>.remote` to hold a bare URL instead of a remote name — this is what `git pull <fork-url> <branch>` leaves behind after checking out a PR branch directly from a fork. `getDefaultRemote` returned that URL verbatim, and `freshOriginDefaultBranchRef` fetched from it successfully (fetching by URL is valid git), then handed `<url>/<default-branch>` to `git worktree add` as the base ref. That string is not a ref, so worktree creation — and with it new-session creation in the TUI — failed.

## Fix

`getDefaultRemote` now only accepts the `branch.<name>.remote` value when it matches a configured remote name; otherwise resolution falls through to the existing origin/single-remote logic.

## Testing

Added `TestCreateWorktree_NewBranch_URLInBranchRemoteConfig`, which mirrors the incident (fetchable fork URL in the current branch's remote config) and asserts the new worktree is rooted at fresh `origin/<default>`. Fails with the exact incident error without the fix, passes with it.

## Notes

Found while debugging silent session-creation failures: the error never reached the debug log because `setError` is render-only. A follow-up adding logging there may be worth it — happy to open one if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced branch remote configuration validation. The system now verifies that branch remote configuration values correspond to actual repository remotes, preventing invalid or malformed specifications from being used incorrectly.

* **Tests**
  * Added test coverage for branch remote configuration validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->