### PR TITLE
feat(session): switch-account — move a session to another Claude account, conversation included (#924 follow-up)

### DIFF
--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -67,6 +67,8 @@ func handleSession(profile string, args []string) {
 		handleSessionSetTitleLock(profile, args[1:])
 	case "set":
 		handleSessionSet(profile, args[1:])
+	case "switch-account":
+		handleSessionSwitchAccount(profile, args[1:])
 	case "move", "mv":
 		handleSessionMove(profile, args[1:])
 	case "send":
@@ -103,6 +105,7 @@ func printSessionHelp() {
 	fmt.Println("  show [id]               Show session details (auto-detect current if no id)")
 	fmt.Println("  current                 Show current session and profile (auto-detect)")
 	fmt.Println("  set <id> <field> <value>  Update session property")
+	fmt.Println("  switch-account <id> <account>  Switch Claude account and migrate the conversation")
 	fmt.Println("  move <id> <path>        Move session to a new path (migrates Claude history)")
 	fmt.Println("  send <id> <message>     Send a message to a running session")
 	fmt.Println("  output <id>             Get the last response from a session")
@@ -1406,6 +1409,13 @@ func handleSessionSet(profile string, args []string) {
 		return // unreachable, satisfies staticcheck SA5011
 	}
 
+	// #924 follow-up: the conversation follows the account. Capture the old
+	// account's config dir before SetField mutates resolution.
+	var preAccountConfigDir string
+	if field == session.FieldAccount && inst.Tool == "claude" {
+		preAccountConfigDir = session.GetClaudeConfigDirForInstance(inst)
+	}
+
 	// Delegate to session.SetField so CLI and TUI share validation. The
 	// extraArgTokens slice carries pre-tokenized argv for extra-args (CLI
 	// preserves values with spaces); SetField ignores it for other fields.
@@ -1419,6 +1429,20 @@ func handleSessionSet(profile string, args []string) {
 	// until after instancesMu.Unlock.
 	if postCommit != nil {
 		postCommit()
+	}
+
+	// Copy the conversation into the new account's config dir so the
+	// restart-required switch resumes with full context. Copy-only; a fresh
+	// session (no conversation yet) is not an error.
+	if preAccountConfigDir != "" {
+		targetDir := session.GetClaudeConfigDirForInstance(inst)
+		if migrated, merr := session.MigrateConversationFrom(inst, preAccountConfigDir, targetDir); merr != nil {
+			if !errors.Is(merr, session.ErrNoConversation) {
+				fmt.Fprintf(os.Stderr, "Warning: account set, but conversation not migrated: %v\n", merr)
+			}
+		} else if migrated != "" && !quietMode && !*jsonOutput {
+			fmt.Printf("Conversation migrated to %s\n", migrated)
+		}
 	}
 
 	// Save

--- a/cmd/agent-deck/session_switch_account.go
+++ b/cmd/agent-deck/session_switch_account.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// handleSessionSwitchAccount switches a Claude session to another named
+// account (#924) and migrates the conversation file into the target account's
+// config dir, so the restarted session resumes with full context. The
+// migration is copy-only: the old account keeps its copy.
+func handleSessionSwitchAccount(profile string, args []string) {
+	fs := flag.NewFlagSet("session switch-account", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	noRestart := fs.Bool("no-restart", false, "Do not restart a running session after the switch")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session switch-account <id|title> <account> [options]")
+		fmt.Println()
+		fmt.Println("Switch a Claude session to another account and carry the conversation over.")
+		fmt.Println()
+		fmt.Printf("<account> must have a [profiles.<account>.claude].config_dir block in %s.\n", effectiveUserConfigPathForHelp())
+		fmt.Println("The conversation file is COPIED into the target account's config dir (the")
+		fmt.Println("source account keeps its copy), the session's account field is updated, and")
+		fmt.Println("a running session is restarted so `claude --resume` continues the")
+		fmt.Println("conversation under the new account.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck session switch-account my-project work")
+		fmt.Println("  agent-deck session switch-account my-project personal --no-restart")
+	}
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+	if fs.NArg() < 2 {
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	identifier := fs.Arg(0)
+	account := strings.TrimSpace(fs.Arg(1))
+	quietMode := *quiet || *quietShort
+	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	userConfig, _ := session.LoadUserConfig()
+	targetDir := userConfig.GetProfileClaudeConfigDir(account)
+	if targetDir == "" {
+		available := configuredAccountNames(userConfig)
+		hint := "none configured"
+		if len(available) > 0 {
+			hint = strings.Join(available, ", ")
+		}
+		out.Error(fmt.Sprintf("account %q has no [profiles.%s.claude].config_dir in %s (configured accounts: %s)",
+			account, account, effectiveUserConfigPathForHelp(), hint), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	storage, instances, groups, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+	inst, errMsg, errCode := ResolveSession(identifier, instances)
+	if inst == nil {
+		out.Error(errMsg, errCode)
+		if errCode == ErrCodeNotFound {
+			os.Exit(2)
+		}
+		os.Exit(1)
+		return // unreachable, satisfies staticcheck SA5011
+	}
+	if inst.Tool != "claude" {
+		out.Error(fmt.Sprintf("switch-account only supports claude sessions (tool: %s)", inst.Tool), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	// Stop a running session first so its conversation file is final before
+	// the copy. IDs are synced from tmux beforehand (same pattern as `stop`).
+	wasRunning := inst.Exists()
+	if wasRunning {
+		inst.SyncSessionIDsFromTmux()
+		if err := inst.Kill(); err != nil {
+			out.Error(fmt.Sprintf("failed to stop session before switch: %v", err), ErrCodeInvalidOperation)
+			os.Exit(1)
+		}
+	}
+
+	// Capture the source dir BEFORE mutating the account field — afterwards
+	// the resolver would already return the target.
+	srcDir := session.GetClaudeConfigDirForInstance(inst)
+	migrated, migErr := session.MigrateConversationFrom(inst, srcDir, targetDir)
+	if migErr != nil && !errors.Is(migErr, session.ErrNoConversation) {
+		// Conversation intact in the source account; account field unchanged.
+		out.Error(fmt.Sprintf("conversation migration failed, account not switched: %v", migErr), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	oldAccount, postCommit, setErr := session.SetField(inst, session.FieldAccount, account, nil)
+	if setErr != nil {
+		out.Error(setErr.Error(), ErrCodeInvalidOperation)
+		os.Exit(1)
+		return // unreachable, satisfies staticcheck SA5011
+	}
+	if postCommit != nil {
+		postCommit()
+	}
+
+	restarted := false
+	var startErr error
+	if wasRunning && !*noRestart {
+		if startErr = inst.Start(); startErr == nil {
+			inst.LastStartedAt = time.Now()
+			restarted = true
+		}
+	}
+
+	if err := saveSessionData(storage, instances, groups); err != nil {
+		out.Error(fmt.Sprintf("failed to save session state: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	if startErr != nil {
+		out.Error(fmt.Sprintf("account switched to %q and conversation migrated, but restart failed: %v (start it manually with: agent-deck session start %s)",
+			account, startErr, inst.Title), ErrCodeInvalidOperation)
+		os.Exit(1)
+	}
+
+	conversation := "no conversation to migrate (fresh session)"
+	if migrated != "" {
+		conversation = fmt.Sprintf("conversation migrated to %s", migrated)
+	} else if migErr == nil {
+		conversation = "source and target accounts share a config dir (nothing to migrate)"
+	}
+	out.Success(fmt.Sprintf("Switched %s: account %q -> %q; %s", inst.Title, oldAccount, account, conversation), map[string]interface{}{
+		"success":           true,
+		"id":                inst.ID,
+		"title":             inst.Title,
+		"old_account":       oldAccount,
+		"new_account":       account,
+		"migrated_path":     migrated,
+		"claude_session_id": inst.ClaudeSessionID,
+		"restarted":         restarted,
+	})
+}
+
+// configuredAccountNames lists profile names that have a Claude config_dir —
+// i.e. the valid <account> values for switch-account / `set account`.
+func configuredAccountNames(cfg *session.UserConfig) []string {
+	if cfg == nil {
+		return nil
+	}
+	var names []string
+	for name := range cfg.Profiles {
+		if cfg.GetProfileClaudeConfigDir(name) != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/docs/specs/SESSION-SWITCH-ACCOUNT-SPEC.md
+++ b/docs/specs/SESSION-SWITCH-ACCOUNT-SPEC.md
@@ -1,0 +1,85 @@
+# Session Account Switch with Conversation Migration
+
+**Status:** Approved design (2026-06-10)
+**Branch:** `feat/session-switch-account-conversation` (off origin/main v1.9.55)
+
+## Problem
+
+agent-deck sessions have a per-session `Account` field (#924) that selects a Claude
+config dir via `[profiles.<name>.claude].config_dir`. Switching account today loses
+the conversation: Claude stores history at
+`<config-dir>/projects/<encoded-project-path>/<session-id>.jsonl`, so after a switch
+`--resume` looks in the new config dir and finds nothing.
+
+## Empirically validated mechanism (2026-06-10, two real accounts)
+
+1. Conversation created under account A (`~/.claude-work`), codeword planted.
+2. `.jsonl` copied to account B's config dir (`~/.claude-buddii`), same encoded
+   project folder, same filename.
+3. `claude --resume <id>` under B recalled the codeword. Conversation continued and
+   evolved under B.
+4. Evolved file copied back to A; resume under A recalled both codewords.
+
+Findings that constrain the design:
+
+- The session id is account-independent; `--resume` is a pure file lookup.
+- **Resume can assign a new session id** (observed: print-mode resume renamed the
+  conversation file to a new UUID). The stored `ClaudeSessionID` may therefore be
+  stale; migration must locate the newest conversation file for the project, the
+  same way `ensureClaudeSessionIDFromDisk` does.
+- The encoded project dir name (`ConvertToClaudeDirName`) depends only on the
+  project path, so it is identical across config dirs.
+- MCP/plugin availability and usage limits follow the new account; history follows
+  the file.
+
+## Design
+
+### Core: `MigrateConversation` (internal/session)
+
+`MigrateConversation(inst *Instance, targetConfigDir string) (migratedPath string, err error)`
+
+1. Resolve source config dir with the existing resolver
+   (`GetClaudeConfigDirForInstance`).
+2. No-op (nil error, empty path) if source and target resolve to the same dir.
+3. Locate the conversation file: `<src>/projects/<ConvertToClaudeDirName(ProjectPath)>/`,
+   prefer `<ClaudeSessionID>.jsonl`; if missing or stale, fall back to the newest
+   `.jsonl` in that dir (existing disk-scan behavior). Update `inst.ClaudeSessionID`
+   if the newest file's id differs.
+4. **Copy-only. Never delete the source.**
+5. If the destination file already exists and differs, back it up first as
+   `<name>.jsonl.bak-<unix-ts>` before overwriting.
+6. Verify the copy (size match) before reporting success.
+
+### CLI: `agent-deck session switch-account <session> <account>`
+
+1. Validate `<account>` exists as `[profiles.<account>.claude]` with a `config_dir`;
+   on failure list available accounts.
+2. If running: stop the session.
+3. `MigrateConversation` to the target account's config dir.
+4. `SetField(inst, FieldAccount, <account>)`.
+5. Restart (existing `--resume` path picks up the migrated file). `--no-restart`
+   skips step 5; a stopped session is not started.
+
+### `session set <s> account <name>`
+
+After the existing field update, also run `MigrateConversation`. Copy failure does
+not roll back the field; it prints a warning that the conversation will not follow
+until migrated.
+
+### Out of scope (v1)
+
+TUI picker; `--move` (delete source after verify); cross-machine transfer.
+
+## Safety (post-incident rules apply)
+
+- Copy-only with pre-overwrite backup; no destructive operation anywhere.
+- All tests run under sandboxed `HOME` + cleared `XDG_*`; no test may touch a real
+  config dir (`isolatePackageHome` pattern).
+
+## Tests
+
+- Unit: path resolution; same-dir no-op; missing source error; stale-id fallback to
+  newest file; backup-on-conflict; size verification.
+- CLI: switch-account happy path, unknown account, `--no-restart`.
+- E2E (manual/smoke, already executed by hand 2026-06-10): codeword round-trip
+  between two real accounts.

--- a/internal/session/migrate.go
+++ b/internal/session/migrate.go
@@ -1,0 +1,159 @@
+package session
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ErrNoConversation reports that the session has no conversation file on disk
+// yet (e.g. a fresh session that never exchanged a message). Callers switching
+// accounts should treat this as non-fatal: there is simply nothing to migrate.
+var ErrNoConversation = errors.New("no conversation file found")
+
+// MigrateConversation copies the session's Claude conversation file from its
+// currently resolved config dir into targetConfigDir, so `claude --resume`
+// finds the history after an account switch (#924 follow-up). Copy-only: the
+// source is never modified or deleted. Returns the destination path, or ""
+// when source and target resolve to the same directory (no-op).
+//
+// Validated against two real accounts (2026-06-10): `--resume <id>` is a pure
+// file lookup under <config-dir>/projects/<encoded-path>/<id>.jsonl; the id is
+// not bound to the logged-in account.
+func MigrateConversation(inst *Instance, targetConfigDir string) (string, error) {
+	if inst == nil {
+		return "", fmt.Errorf("nil instance")
+	}
+	return MigrateConversationFrom(inst, GetClaudeConfigDirForInstance(inst), targetConfigDir)
+}
+
+// MigrateConversationFrom is MigrateConversation with an explicit source
+// config dir. Callers that mutate inst.Account before migrating must capture
+// the old account's dir first — after the mutation the resolver returns the
+// new dir.
+//
+// When the stored ClaudeSessionID has no file on disk (resume renames
+// conversations to a fresh UUID), it falls back to the newest conversation
+// file in the project dir and updates inst.ClaudeSessionID accordingly; the
+// caller is responsible for persisting the instance.
+func MigrateConversationFrom(inst *Instance, srcConfigDir, targetConfigDir string) (string, error) {
+	if inst == nil {
+		return "", fmt.Errorf("nil instance")
+	}
+	if inst.Tool != "claude" {
+		return "", fmt.Errorf("conversation migration is only supported for claude sessions (tool: %s)", inst.Tool)
+	}
+	src := ExpandPath(strings.TrimSpace(srcConfigDir))
+	dst := ExpandPath(strings.TrimSpace(targetConfigDir))
+	if src == "" || dst == "" {
+		return "", fmt.Errorf("source and target config dirs must be non-empty")
+	}
+	if filepath.Clean(src) == filepath.Clean(dst) {
+		return "", nil
+	}
+
+	projDirName := ConvertToClaudeDirName(inst.ProjectPath)
+	srcProjDir := filepath.Join(src, "projects", projDirName)
+
+	sid := inst.ClaudeSessionID
+	srcFile := ""
+	if sid != "" {
+		if candidate := filepath.Join(srcProjDir, sid+".jsonl"); fileIsRegular(candidate) {
+			srcFile = candidate
+		}
+	}
+	if srcFile == "" {
+		// Stored id stale (resume renamed the file) or never captured: take
+		// the newest conversation file in the project dir.
+		newestFile, newestID := newestConversationFile(srcProjDir)
+		if newestFile == "" {
+			return "", fmt.Errorf("%w under %s", ErrNoConversation, srcProjDir)
+		}
+		srcFile, sid = newestFile, newestID
+		inst.ClaudeSessionID = newestID
+	}
+
+	dstProjDir := filepath.Join(dst, "projects", projDirName)
+	if err := os.MkdirAll(dstProjDir, 0o700); err != nil {
+		return "", fmt.Errorf("create target project dir: %w", err)
+	}
+	dstFile := filepath.Join(dstProjDir, sid+".jsonl")
+	if fileIsRegular(dstFile) {
+		// Backup before any destructive write (2026-06-04 incident, S2).
+		bak := fmt.Sprintf("%s.bak-%d", dstFile, time.Now().Unix())
+		if err := os.Rename(dstFile, bak); err != nil {
+			return "", fmt.Errorf("backup existing conversation: %w", err)
+		}
+	}
+	if err := copyFileVerified(srcFile, dstFile); err != nil {
+		return "", err
+	}
+	return dstFile, nil
+}
+
+// newestConversationFile returns the most recently modified UUID-named
+// conversation file in projDir (and its session id), skipping agent-*.jsonl.
+// Unlike findActiveSessionIDExcluding it has no recency cutoff: a conversation
+// being migrated may be arbitrarily old.
+func newestConversationFile(projDir string) (path, sessionID string) {
+	files, err := filepath.Glob(filepath.Join(projDir, "*.jsonl"))
+	if err != nil {
+		return "", ""
+	}
+	var newest time.Time
+	for _, file := range files {
+		base := filepath.Base(file)
+		if strings.HasPrefix(base, "agent-") || !uuidSessionFileRegex.MatchString(base) {
+			continue
+		}
+		info, err := os.Stat(file)
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
+			path = file
+			sessionID = strings.TrimSuffix(base, ".jsonl")
+		}
+	}
+	return path, sessionID
+}
+
+// copyFileVerified copies src to dst (0600, matching Claude's conversation
+// files) and verifies the written size matches the source.
+func copyFileVerified(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open conversation: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create target conversation: %w", err)
+	}
+	written, copyErr := io.Copy(out, in)
+	if closeErr := out.Close(); copyErr == nil {
+		copyErr = closeErr
+	}
+	if copyErr != nil {
+		return fmt.Errorf("copy conversation: %w", copyErr)
+	}
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+	if written != srcInfo.Size() {
+		return fmt.Errorf("size mismatch after copy: wrote %d bytes, source has %d", written, srcInfo.Size())
+	}
+	return nil
+}
+
+func fileIsRegular(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}

--- a/internal/session/migrate_test.go
+++ b/internal/session/migrate_test.go
@@ -1,0 +1,203 @@
+package session
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func futureTime(t *testing.T) time.Time {
+	t.Helper()
+	return time.Now().Add(time.Hour)
+}
+
+// Tests for MigrateConversation / MigrateConversationFrom — the
+// conversation-follows-account half of the #924 account switch.
+// Empirical ground truth (2026-06-10, two real accounts): Claude's
+// `--resume <id>` is a pure file lookup under
+// <config-dir>/projects/<encoded-path>/<id>.jsonl, and resuming can RENAME
+// the file to a fresh UUID, so the stored ClaudeSessionID may be stale.
+
+const (
+	migTestSID   = "51d58f67-5c46-437c-bfb4-645d27406c9a"
+	migTestSID2  = "479b92a9-19f8-43e4-9d98-fbba200b5820"
+	migTestLines = "{\"type\":\"user\",\"sessionId\":\"" + migTestSID + "\"}\n"
+)
+
+// migTestInstance builds a minimal Claude instance rooted in a temp project.
+func migTestInstance(t *testing.T, projectPath string) *Instance {
+	t.Helper()
+	return &Instance{
+		ID:              "mig-test",
+		Title:           "mig-test",
+		ProjectPath:     projectPath,
+		Tool:            "claude",
+		ClaudeSessionID: migTestSID,
+	}
+}
+
+// writeConversation creates <cfgDir>/projects/<encoded>/<sid>.jsonl.
+func writeConversation(t *testing.T, cfgDir, projectPath, sid, content string) string {
+	t.Helper()
+	dir := filepath.Join(cfgDir, "projects", ConvertToClaudeDirName(projectPath))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, sid+".jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestMigrateConversationFrom_HappyPath(t *testing.T) {
+	src, dst, project := t.TempDir(), t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+	writeConversation(t, src, project, migTestSID, migTestLines)
+
+	migrated, err := MigrateConversationFrom(inst, src, dst)
+	if err != nil {
+		t.Fatalf("MigrateConversationFrom: %v", err)
+	}
+	want := filepath.Join(dst, "projects", ConvertToClaudeDirName(project), migTestSID+".jsonl")
+	if migrated != want {
+		t.Errorf("migrated path = %q, want %q", migrated, want)
+	}
+	got, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("destination not readable: %v", err)
+	}
+	if string(got) != migTestLines {
+		t.Errorf("destination content mismatch")
+	}
+	// Copy-only: source must be untouched.
+	srcFile := filepath.Join(src, "projects", ConvertToClaudeDirName(project), migTestSID+".jsonl")
+	if b, err := os.ReadFile(srcFile); err != nil || string(b) != migTestLines {
+		t.Errorf("source file was modified or removed (err=%v)", err)
+	}
+}
+
+func TestMigrateConversationFrom_SameDirNoOp(t *testing.T) {
+	src, project := t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+	writeConversation(t, src, project, migTestSID, migTestLines)
+
+	migrated, err := MigrateConversationFrom(inst, src, src)
+	if err != nil {
+		t.Fatalf("same-dir migration should be a silent no-op, got %v", err)
+	}
+	if migrated != "" {
+		t.Errorf("no-op should return empty path, got %q", migrated)
+	}
+}
+
+func TestMigrateConversationFrom_MissingSourceErrors(t *testing.T) {
+	src, dst, project := t.TempDir(), t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+
+	_, err := MigrateConversationFrom(inst, src, dst)
+	if err == nil {
+		t.Fatal("expected error when no conversation file exists")
+	}
+	if !errors.Is(err, ErrNoConversation) {
+		t.Errorf("error should wrap ErrNoConversation, got: %v", err)
+	}
+}
+
+func TestMigrateConversationFrom_StaleIDFallsBackToNewest(t *testing.T) {
+	// Resume renamed the conversation to a new UUID: the stored
+	// ClaudeSessionID file is gone, only the renamed file remains.
+	src, dst, project := t.TempDir(), t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+	writeConversation(t, src, project, migTestSID2, migTestLines)
+	// Distractor that must be ignored by the fallback scan.
+	writeConversation(t, src, project, "agent-deadbeef", "agent file\n")
+
+	migrated, err := MigrateConversationFrom(inst, src, dst)
+	if err != nil {
+		t.Fatalf("MigrateConversationFrom: %v", err)
+	}
+	if !strings.HasSuffix(migrated, migTestSID2+".jsonl") {
+		t.Errorf("expected fallback to newest conversation %s, got %q", migTestSID2, migrated)
+	}
+	if inst.ClaudeSessionID != migTestSID2 {
+		t.Errorf("ClaudeSessionID not updated after fallback: %q", inst.ClaudeSessionID)
+	}
+}
+
+func TestMigrateConversationFrom_PrefersStoredIDOverNewer(t *testing.T) {
+	// Two sessions can share a project dir. When the stored id's file still
+	// exists it is THIS session's conversation — a newer sibling file must
+	// not be picked up.
+	src, dst, project := t.TempDir(), t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+	writeConversation(t, src, project, migTestSID, migTestLines)
+	other := writeConversation(t, src, project, migTestSID2, "other session\n")
+	// Make the sibling strictly newer.
+	if err := os.Chtimes(other, futureTime(t), futureTime(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := MigrateConversationFrom(inst, src, dst)
+	if err != nil {
+		t.Fatalf("MigrateConversationFrom: %v", err)
+	}
+	if !strings.HasSuffix(migrated, migTestSID+".jsonl") {
+		t.Errorf("expected stored id %s to win, got %q", migTestSID, migrated)
+	}
+	if inst.ClaudeSessionID != migTestSID {
+		t.Errorf("ClaudeSessionID must not change when stored file exists: %q", inst.ClaudeSessionID)
+	}
+}
+
+func TestMigrateConversationFrom_BacksUpConflictingDestination(t *testing.T) {
+	src, dst, project := t.TempDir(), t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+	writeConversation(t, src, project, migTestSID, migTestLines)
+	writeConversation(t, dst, project, migTestSID, "older divergent copy\n")
+
+	if _, err := MigrateConversationFrom(inst, src, dst); err != nil {
+		t.Fatalf("MigrateConversationFrom: %v", err)
+	}
+	dstDir := filepath.Join(dst, "projects", ConvertToClaudeDirName(project))
+	got, err := os.ReadFile(filepath.Join(dstDir, migTestSID+".jsonl"))
+	if err != nil || string(got) != migTestLines {
+		t.Fatalf("destination should hold migrated content (err=%v)", err)
+	}
+	baks, _ := filepath.Glob(filepath.Join(dstDir, migTestSID+".jsonl.bak-*"))
+	if len(baks) != 1 {
+		t.Fatalf("expected exactly one backup of the clobbered file, found %d", len(baks))
+	}
+	if b, _ := os.ReadFile(baks[0]); string(b) != "older divergent copy\n" {
+		t.Errorf("backup does not preserve the previous destination content")
+	}
+}
+
+func TestMigrateConversationFrom_NonClaudeToolRejected(t *testing.T) {
+	src, dst, project := t.TempDir(), t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+	inst.Tool = "gemini"
+
+	if _, err := MigrateConversationFrom(inst, src, dst); err == nil {
+		t.Fatal("expected error for non-claude tool")
+	}
+}
+
+func TestMigrateConversation_ResolvesSourceFromInstance(t *testing.T) {
+	src, dst, project := t.TempDir(), t.TempDir(), t.TempDir()
+	inst := migTestInstance(t, project)
+	writeConversation(t, src, project, migTestSID, migTestLines)
+	// Instance chain: account/conductor/group unset → env wins.
+	t.Setenv("CLAUDE_CONFIG_DIR", src)
+
+	migrated, err := MigrateConversation(inst, dst)
+	if err != nil {
+		t.Fatalf("MigrateConversation: %v", err)
+	}
+	if !strings.HasSuffix(migrated, migTestSID+".jsonl") {
+		t.Errorf("unexpected migrated path %q", migrated)
+	}
+}

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -372,12 +372,82 @@ func (i *Instance) EnsureWorkerScratchConfigDir(sourceProfileDir string) (string
 	}
 
 	if sourceProfileDir != "" {
+		resetScratchOnSourceChange(scratch, sourceProfileDir)
 		if err := mirrorProfileEntries(scratch, sourceProfileDir); err != nil {
 			return "", err
 		}
 	}
 
 	return scratch, nil
+}
+
+// scratchSourceMarker records which profile the scratch was last seeded
+// from, so a source change (account switch, #924) is detectable even for
+// entries claude has clobbered into real files.
+const scratchSourceMarker = ".agentdeck-scratch-source"
+
+// resetScratchOnSourceChange detects that the scratch was previously seeded
+// from a DIFFERENT profile and removes real-file entries that shadow the new
+// source's entries — most importantly .claude.json, which claude rewrites
+// via rename-on-write (turning the mirror symlink into a real file holding
+// the old account's oauthAccount/MCP state). Symlinked entries are handled
+// by mirrorProfileEntries/sweepForeignSymlinks; settings.json and
+// .credentials.json keep their dedicated handling. Best-effort: a failure
+// leaves the old behavior (stale state) rather than blocking the spawn.
+//
+// Pre-marker scratches infer the previous source from an existing symlink's
+// target (it must run BEFORE mirrorProfileEntries repoints them).
+func resetScratchOnSourceChange(scratch, source string) {
+	markerPath := filepath.Join(scratch, scratchSourceMarker)
+	prevData, _ := os.ReadFile(markerPath)
+	prevSource := strings.TrimSpace(string(prevData))
+	if prevSource == "" {
+		prevSource = inferScratchSource(scratch)
+	}
+	defer func() {
+		_ = os.WriteFile(markerPath, []byte(source+"\n"), 0o600)
+	}()
+	if prevSource == "" || filepath.Clean(prevSource) == filepath.Clean(source) {
+		return
+	}
+
+	sourceEntries, err := os.ReadDir(source)
+	if err != nil {
+		return
+	}
+	for _, entry := range sourceEntries {
+		name := entry.Name()
+		if name == "settings.json" || name == credentialsFileName {
+			continue
+		}
+		scratchPath := filepath.Join(scratch, name)
+		li, lerr := os.Lstat(scratchPath)
+		if lerr != nil || li.Mode()&os.ModeSymlink != 0 || li.IsDir() {
+			// Absent (mirror will link it), symlink (mirror repoints it),
+			// or a real DIR (scratch-local state, e.g. logs) — leave alone.
+			continue
+		}
+		// Real file shadowing a new-source entry: stale old-account state.
+		_ = os.Remove(scratchPath)
+	}
+}
+
+// inferScratchSource derives the profile a pre-marker scratch was seeded
+// from by reading an existing mirror symlink's target directory.
+func inferScratchSource(scratch string) string {
+	entries, err := os.ReadDir(scratch)
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink == 0 {
+			continue
+		}
+		if target, err := os.Readlink(filepath.Join(scratch, entry.Name())); err == nil {
+			return filepath.Dir(target)
+		}
+	}
+	return ""
 }
 
 // credentialsFileName is the profile's OAuth credentials file. It is the one

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -416,10 +416,21 @@ func mirrorProfileEntries(dest, source string) error {
 			continue
 		}
 		linkPath := filepath.Join(dest, name)
-		if _, statErr := os.Lstat(linkPath); statErr == nil {
+		target := filepath.Join(source, name)
+		if li, statErr := os.Lstat(linkPath); statErr == nil {
+			// Existing symlink pointing elsewhere — e.g. the previous
+			// account's profile after `session switch-account` (#924
+			// follow-up): repoint it. Real files/dirs are scratch-local
+			// state and are left alone.
+			if li.Mode()&os.ModeSymlink != 0 {
+				if cur, rerr := os.Readlink(linkPath); rerr == nil && cur != target {
+					if err := symlinkReplace(target, linkPath); err != nil {
+						return fmt.Errorf("repoint %s: %w", name, err)
+					}
+				}
+			}
 			continue
 		}
-		target := filepath.Join(source, name)
 		if err := os.Symlink(target, linkPath); err != nil {
 			if os.IsExist(err) {
 				continue
@@ -427,7 +438,44 @@ func mirrorProfileEntries(dest, source string) error {
 			return fmt.Errorf("symlink %s: %w", name, err)
 		}
 	}
+	if err := sweepForeignSymlinks(dest, source); err != nil {
+		return err
+	}
 	return reassertCredentialSymlink(dest, source)
+}
+
+// sweepForeignSymlinks removes scratch symlinks that point outside the
+// current source profile. After an account switch the old profile may have
+// entries the new one lacks; the loop above never visits those names, so a
+// stale-but-resolvable symlink into the OLD profile would silently expose
+// the previous account's state (#924 follow-up). Only symlinks are touched —
+// real files/dirs in scratch are local state and stay. settings.json and
+// .credentials.json keep their dedicated handling.
+func sweepForeignSymlinks(dest, source string) error {
+	destEntries, err := os.ReadDir(dest)
+	if err != nil {
+		return fmt.Errorf("read scratch dir: %w", err)
+	}
+	for _, entry := range destEntries {
+		name := entry.Name()
+		if name == "settings.json" || name == credentialsFileName {
+			continue
+		}
+		if entry.Type()&os.ModeSymlink == 0 {
+			continue
+		}
+		linkPath := filepath.Join(dest, name)
+		cur, rerr := os.Readlink(linkPath)
+		if rerr != nil {
+			continue
+		}
+		if filepath.Dir(cur) != filepath.Clean(source) {
+			if err := os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove foreign symlink %s: %w", name, err)
+			}
+		}
+	}
+	return nil
 }
 
 // reassertCredentialSymlink guarantees dest/.credentials.json is a clean symlink

--- a/internal/session/worker_scratch_account_switch_test.go
+++ b/internal/session/worker_scratch_account_switch_test.go
@@ -1,0 +1,109 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Account-switch staleness (#924 follow-up, found live 2026-06-11):
+// EnsureWorkerScratchConfigDir is idempotent per instance ID, but the
+// symlink mirror was skip-if-exists. After `session set <s> account <b>` /
+// `session switch-account`, the respawn reused the scratch dir whose
+// symlinks still pointed at the OLD account's profile — so the switch
+// silently didn't apply (conversation, auth, projects all stayed on the
+// previous account). The mirror must repoint stale symlinks to the new
+// source and sweep entries the new source doesn't have.
+
+// scratchSwitchInstance returns a worker instance that needs a scratch dir.
+func scratchSwitchInstance(t *testing.T, id string) *Instance {
+	t.Helper()
+	withTelegramConductorPresent(t)
+	return &Instance{
+		ID:    id,
+		Title: "scratch-switch-worker",
+		Tool:  "claude",
+	}
+}
+
+// makeProfileDir creates a fake Claude profile with the given top-level
+// entries (as real files) plus a settings.json.
+func makeProfileDir(t *testing.T, entries ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range entries {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestEnsureWorkerScratchConfigDir_RepointsSymlinksOnSourceChange(t *testing.T) {
+	inst := scratchSwitchInstance(t, "scratch-switch-1")
+	srcA := makeProfileDir(t, ".claude.json", "projects", "only-in-a")
+	srcB := makeProfileDir(t, ".claude.json", "projects", "only-in-b")
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(srcA)
+	if err != nil {
+		t.Fatalf("seed from srcA: %v", err)
+	}
+	t.Cleanup(inst.CleanupWorkerScratchConfigDir)
+
+	// Simulate the account switch: same instance respawns from srcB.
+	scratch2, err := inst.EnsureWorkerScratchConfigDir(srcB)
+	if err != nil {
+		t.Fatalf("reseed from srcB: %v", err)
+	}
+	if scratch2 != scratch {
+		t.Fatalf("scratch dir should be stable per instance: %q vs %q", scratch, scratch2)
+	}
+
+	for _, name := range []string{".claude.json", "projects"} {
+		target, rerr := os.Readlink(filepath.Join(scratch, name))
+		if rerr != nil {
+			t.Fatalf("readlink %s: %v", name, rerr)
+		}
+		if want := filepath.Join(srcB, name); target != want {
+			t.Errorf("%s still points at the old profile: %s (want %s)", name, target, want)
+		}
+	}
+
+	// Entry only in B must be linked in.
+	if target, rerr := os.Readlink(filepath.Join(scratch, "only-in-b")); rerr != nil || target != filepath.Join(srcB, "only-in-b") {
+		t.Errorf("only-in-b not linked to new source (target=%q err=%v)", target, rerr)
+	}
+
+	// Leftover symlink to the old profile must be swept — a dangling-but-
+	// valid link into srcA would silently expose the old account's state.
+	if _, lerr := os.Lstat(filepath.Join(scratch, "only-in-a")); !os.IsNotExist(lerr) {
+		t.Errorf("only-in-a leftover from old profile not removed (err=%v)", lerr)
+	}
+}
+
+func TestEnsureWorkerScratchConfigDir_SameSourceLeavesRealFilesAlone(t *testing.T) {
+	inst := scratchSwitchInstance(t, "scratch-switch-2")
+	src := makeProfileDir(t, ".claude.json")
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(src)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	t.Cleanup(inst.CleanupWorkerScratchConfigDir)
+
+	// A REAL file in scratch (e.g. state claude wrote locally) must survive a
+	// same-source respawn — the sweep may only touch symlinks.
+	realFile := filepath.Join(scratch, "scratch-local-state")
+	if err := os.WriteFile(realFile, []byte("keep me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := inst.EnsureWorkerScratchConfigDir(src); err != nil {
+		t.Fatalf("respawn: %v", err)
+	}
+	if b, err := os.ReadFile(realFile); err != nil || string(b) != "keep me" {
+		t.Errorf("real scratch-local file was disturbed (err=%v)", err)
+	}
+}

--- a/internal/session/worker_scratch_clobber_switch_test.go
+++ b/internal/session/worker_scratch_clobber_switch_test.go
@@ -1,0 +1,118 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Claude rewrites .claude.json via write-temp+rename, which CLOBBERS the
+// scratch symlink into a real file. Found live (2026-06-11): after
+// switch-account, a long-lived conductor kept a 586KB real .claude.json
+// carrying the OLD account's oauthAccount/MCP state even though
+// .credentials.json and projects had been repointed. On a source-profile
+// change the stale real file must be replaced with a fresh symlink to the
+// new source; on a same-source respawn the clobber must be left alone
+// (it is claude's newest local state).
+
+func TestEnsureWorkerScratchConfigDir_ReplacesClobberedClaudeJSONOnSourceChange(t *testing.T) {
+	inst := scratchSwitchInstance(t, "scratch-clobber-1")
+	srcA := makeProfileDir(t, ".claude.json")
+	srcB := makeProfileDir(t, ".claude.json")
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(srcA)
+	if err != nil {
+		t.Fatalf("seed from srcA: %v", err)
+	}
+	t.Cleanup(inst.CleanupWorkerScratchConfigDir)
+
+	// Simulate claude's rename-on-write clobber: symlink becomes a real file
+	// holding old-account state.
+	clobbered := filepath.Join(scratch, ".claude.json")
+	if err := os.Remove(clobbered); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(clobbered, []byte(`{"oauthAccount":"old-account"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := inst.EnsureWorkerScratchConfigDir(srcB); err != nil {
+		t.Fatalf("reseed from srcB: %v", err)
+	}
+
+	li, err := os.Lstat(clobbered)
+	if err != nil {
+		t.Fatalf("lstat .claude.json: %v", err)
+	}
+	if li.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf(".claude.json still a real file after source change — stale old-account state survives the switch")
+	}
+	if target, _ := os.Readlink(clobbered); target != filepath.Join(srcB, ".claude.json") {
+		t.Errorf(".claude.json points at %q, want new source", target)
+	}
+}
+
+func TestEnsureWorkerScratchConfigDir_KeepsClobberedClaudeJSONOnSameSource(t *testing.T) {
+	inst := scratchSwitchInstance(t, "scratch-clobber-2")
+	src := makeProfileDir(t, ".claude.json")
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(src)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	t.Cleanup(inst.CleanupWorkerScratchConfigDir)
+
+	clobbered := filepath.Join(scratch, ".claude.json")
+	if err := os.Remove(clobbered); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(clobbered, []byte(`{"local":"newest state"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := inst.EnsureWorkerScratchConfigDir(src); err != nil {
+		t.Fatalf("respawn: %v", err)
+	}
+	b, err := os.ReadFile(clobbered)
+	if err != nil || string(b) != `{"local":"newest state"}` {
+		t.Errorf("same-source respawn must not disturb claude's local .claude.json (err=%v got=%s)", err, b)
+	}
+}
+
+// Scratches created before the source marker existed must still reset when
+// the source changes — the previous source is inferred from an existing
+// symlink's target (e.g. projects).
+func TestEnsureWorkerScratchConfigDir_InfersPreviousSourceWithoutMarker(t *testing.T) {
+	inst := scratchSwitchInstance(t, "scratch-clobber-3")
+	srcA := makeProfileDir(t, ".claude.json", "projects")
+	srcB := makeProfileDir(t, ".claude.json", "projects")
+
+	scratch, err := inst.EnsureWorkerScratchConfigDir(srcA)
+	if err != nil {
+		t.Fatalf("seed from srcA: %v", err)
+	}
+	t.Cleanup(inst.CleanupWorkerScratchConfigDir)
+
+	// Pre-marker scratch: marker absent, .claude.json clobbered to real file.
+	if err := os.Remove(filepath.Join(scratch, scratchSourceMarker)); err != nil {
+		t.Fatal(err)
+	}
+	clobbered := filepath.Join(scratch, ".claude.json")
+	if err := os.Remove(clobbered); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(clobbered, []byte(`{"oauthAccount":"old"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := inst.EnsureWorkerScratchConfigDir(srcB); err != nil {
+		t.Fatalf("reseed from srcB: %v", err)
+	}
+	li, err := os.Lstat(clobbered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if li.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("marker-less scratch did not reset clobbered .claude.json on source change")
+	}
+}

--- a/skills/agent-deck/SKILL.md
+++ b/skills/agent-deck/SKILL.md
@@ -89,6 +89,7 @@ Status legend: ✅ verified, 🟡 partial, 🔴 known broken, ⚪ unknown. To up
 | `agent-deck session output <name>` | Get last response |
 | `agent-deck session current [-q\|--json]` | Auto-detect current session |
 | `agent-deck session fork <name>` | Fork Claude/Pi conversation |
+| `agent-deck session switch-account <name> <account>` | Switch Claude account, conversation follows |
 | `agent-deck mcp list` | List available MCPs |
 | `agent-deck mcp attach <name> <mcp>` | Attach MCP (then restart) |
 | `agent-deck status` | Quick status summary |
@@ -718,6 +719,44 @@ $SKILL_DIR/../session-share/scripts/import.sh ~/Downloads/session-file.json
 ```
 
 **See:** [session-share skill](../session-share/SKILL.md) for full documentation.
+
+## Switch a Session to Another Claude Account
+
+Move a session — conversation included — to a different Claude account (work/personal/client) and continue exactly where it left off.
+
+**Use when:** User says "switch account", "move this conversation to my other account", "continue this session on account X", "this session should use the <name> account".
+
+**One-time setup** — name each account in `~/.agent-deck/config.toml` (the target profile must already be logged in: `CLAUDE_CONFIG_DIR=<dir> claude` → `/login`):
+
+```toml
+[profiles.personal.claude]
+  config_dir = "~/.claude"
+[profiles.work.claude]
+  config_dir = "~/.claude-work"
+```
+
+**Commands:**
+
+```bash
+# Full flow: stop → copy conversation into the target account → set account → restart with --resume
+agent-deck session switch-account <session> <account>
+
+# Skip the restart (e.g. switch several sessions, restart later)
+agent-deck session switch-account <session> <account> --no-restart
+
+# Equivalent low-level form — also migrates the conversation; restart required
+agent-deck session set <session> account <account>
+```
+
+**How it works / guarantees:**
+
+- The conversation `.jsonl` is **copied** into `<target-config-dir>/projects/<encoded-path>/` — the old account keeps its copy; a conflicting file in the target is backed up as `.bak-<timestamp>` first. The session id does not change.
+- `claude --resume` is a pure file lookup, so the restarted session continues with full history under the new account's auth.
+- Tools/MCPs/plugins and usage limits follow the **new** account; enable any needed plugins in the target profile (e.g. `CLAUDE_CONFIG_DIR=<dir> claude plugin enable telegram@claude-plugins-official` for channel owners).
+- A fresh session with no conversation yet switches cleanly (nothing to migrate).
+- Unknown account names error and list the configured ones.
+
+**Make a whole group/conductor use the account going forward:** set `[groups.<name>.claude].config_dir` / `[conductors.<name>.claude].config_dir` to the same dir in config.toml — new sessions there spawn on that account; `switch-account` is what carries existing conversations over.
 
 ## Critical Rules
 


### PR DESCRIPTION
## What

`agent-deck session switch-account <session> <account>` switches a Claude session to another named account (#924 `Account` field) **and carries the conversation over**, so the restarted session resumes with full context under the new account.

Previously, switching the account lost the conversation: Claude stores history at `<config-dir>/projects/<encoded-path>/<session-id>.jsonl`, and after a switch `--resume` looked in the new config dir and found nothing.

## How

- **`session.MigrateConversationFrom`** copies the conversation file into the target account's config dir. Copy-only (source account keeps its copy), backs up a conflicting destination file as `.jsonl.bak-<ts>`, verifies size after copy. Falls back to the newest conversation file when the stored `ClaudeSessionID` is stale (resume renames conversation files) and updates the instance. Fresh sessions (no conversation yet) switch cleanly via an `ErrNoConversation` sentinel.
- **New CLI** `session switch-account <id|title> <account>`: stop → migrate → set account → restart with `--resume` (`--no-restart` to skip). Unknown accounts error with the configured list.
- **`session set <s> account <name>`** now auto-migrates the conversation as well.
- **Skill docs**: new 'Switch a Session to Another Claude Account' section in the agent-deck skill.

## Two worker-scratch bugs found and fixed along the way

Live testing on a long-running conductor showed account switches silently **not applying** for any session with a worker-scratch config dir (#59):

1. `mirrorProfileEntries` was skip-if-exists, so a reused scratch kept symlinks (auth, projects, .claude.json) pointing at the OLD account's profile. Now repoints stale symlinks and sweeps ones the new source doesn't have.
2. claude rewrites `.claude.json` via rename-on-write, clobbering the mirror symlink into a real file that carries the old account's oauthAccount/MCP state across a switch. A `.agentdeck-scratch-source` marker detects the source change and resets such files (settings.json / .credentials.json keep their dedicated handling; #1222 invariants preserved).

These affect upstream `session set account` (#924) independently of the new command.

## Validation

- Mechanism proven against **two real Claude accounts**: conversation created under account A, copied to B, resumed there with full recall, continued under B, moved back — both directions, session id unchanged. `--resume` is a pure file lookup; the id is not bound to the logged-in account.
- 13 new unit tests (migration semantics, scratch repoint/sweep/clobber-reset); `internal/session` and `cmd/agent-deck` suites pass.
- CLI end-to-end in a sandboxed HOME, plus a live end-to-end on a real deck: running session switched accounts and answered a pre-switch codeword from the other account, with new turns landing in the new account's conversation file.

Spec: `docs/specs/SESSION-SWITCH-ACCOUNT-SPEC.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `session switch-account` subcommand to switch between configured accounts
  * Automatic conversation migration when changing accounts

* **Improvements**
  * Enhanced configuration cleanup during account switches to prevent stale state persistence
  * Improved symlink management to ensure correct profile references after account transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->