### PR TITLE
feat(ui): log footer errors and session-create flow

### DIFF
--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2553,6 +2553,9 @@ func (h *Home) setError(err error) {
 	h.err = err
 	if err != nil {
 		h.errTime = time.Now()
+		// Footer errors are otherwise invisible in debug.log, making
+		// post-hoc diagnosis of failed UI actions impossible.
+		uiLog.Error("ui_error", slog.String("err", err.Error()))
 	}
 }
 
@@ -4224,6 +4227,10 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case sessionCreatedMsg:
+		uiLog.Info("session_created_msg",
+			slog.Bool("has_err", msg.err != nil),
+			slog.String("temp_id", msg.tempID),
+			slog.Bool("has_instance", msg.instance != nil))
 		// Remove the creating placeholder (if any) — always, on success or error
 		if msg.tempID != "" {
 			delete(h.creatingSessions, msg.tempID)
@@ -8994,6 +9001,12 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 	tempID string,
 ) tea.Cmd {
 	return func() tea.Msg {
+		uiLog.Info("create_session_start",
+			slog.String("name", name),
+			slog.String("path", path),
+			slog.String("worktree_branch", worktreeBranch),
+			slog.String("temp_id", tempID))
+
 		// Check tmux availability before creating session
 		if err := tmux.IsTmuxAvailable(); err != nil {
 			return sessionCreatedMsg{err: fmt.Errorf("cannot create session: %w", err), tempID: tempID}


### PR DESCRIPTION
## What

Three log points in the TUI:

- `setError` now logs the error at ERROR level (`ui_error`). Footer errors were render-only — they left no trace in `debug.log`, so any failure surfaced this way was undiagnosable after the fact.
- `sessionCreatedMsg` handling logs an INFO breadcrumb (`session_created_msg`) with `has_err`/`temp_id`/`has_instance`.
- `createSessionInGroupWithWorktreeAndOptions` logs an INFO breadcrumb (`create_session_start`) with name/path/worktree branch.

Together the two breadcrumbs bracket the create flow: `create_session_start` present but no `session_created_msg` means the create goroutine died or the message was dropped; neither present means the dialog submit never fired.

## Why

While debugging a session-creation failure (#1376), the error never appeared in `debug.log` — `setError` only set a field for rendering. Reproducing with these log points immediately produced the root cause:

```
{"level":"ERROR","msg":"ui_error","err":"failed to create worktree: fatal: invalid reference: git@github.com:<fork>/<repo>.git/main: exit status 128"}
```

## Testing

Built and ran locally; verified all three log points appear in `debug.log` during a session-create attempt and that the ERROR line captures the failure that was previously silent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging to capture detailed information during session operations and error handling for improved troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->