### PR TITLE
fix: conductor bridge restart registers duplicate phantom conductor instance

### DIFF
--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -571,6 +571,19 @@ def get_sessions_list_all(profiles: list[str]) -> list[tuple[str, dict]]:
     return all_sessions
 
 
+def _find_session_by_title(sessions: list, title: str, profile: str) -> dict | None:
+    """Find an exact title match from a profile-scoped session list."""
+    for session in sessions:
+        if not isinstance(session, dict):
+            continue
+        if session.get("title") != title:
+            continue
+        session_profile = session.get("profile")
+        if session_profile in (None, "", profile):
+            return session
+    return None
+
+
 async def ensure_conductor_running(name: str, profile: str) -> bool:
     """Ensure the conductor session exists and is running."""
     session_title = conductor_session_title(name)
@@ -588,33 +601,70 @@ async def ensure_conductor_running(name: str, profile: str) -> bool:
             )
         )
         if result.returncode != 0:
-            # Session might not exist, try creating it
-            log.info("Creating conductor session for %s...", name)
-            session_path = str(CONDUCTOR_DIR / name)
-            result = await loop.run_in_executor(
-                None, functools.partial(
-                    run_cli,
-                    "add", session_path,
-                    "-t", session_title,
-                    "-c", "claude",
-                    "-g", "conductor",
-                    profile=profile,
-                    timeout=60,
-                )
+            log.warning(
+                "Failed to start conductor %s before dedupe: %s",
+                name,
+                result.stderr.strip(),
             )
-            if result.returncode != 0:
-                log.error(
-                    "Failed to create conductor %s: %s",
-                    name,
-                    result.stderr.strip(),
-                )
-                return False
-            # Start the newly created session
-            await loop.run_in_executor(
-                None, functools.partial(
-                    run_cli, "session", "start", session_title, profile=profile, timeout=60
-                )
+            sessions = await loop.run_in_executor(
+                None, functools.partial(get_sessions_list, profile=profile)
             )
+            existing = _find_session_by_title(sessions, session_title, profile)
+            if existing is not None:
+                log.info(
+                    "Reusing existing conductor session %s in profile %s",
+                    session_title,
+                    profile,
+                )
+                retry = await loop.run_in_executor(
+                    None, functools.partial(
+                        run_cli,
+                        "session",
+                        "start",
+                        session_title,
+                        profile=profile,
+                        timeout=60,
+                    )
+                )
+                if retry.returncode != 0:
+                    log.warning(
+                        "Failed to start existing conductor %s: %s",
+                        name,
+                        retry.stderr.strip(),
+                    )
+            else:
+                # Session is absent from this profile, so create it.
+                log.info("Creating conductor session for %s...", name)
+                session_path = str(CONDUCTOR_DIR / name)
+                result = await loop.run_in_executor(
+                    None, functools.partial(
+                        run_cli,
+                        "add", session_path,
+                        "-t", session_title,
+                        "-c", "claude",
+                        "-g", "conductor",
+                        profile=profile,
+                        timeout=60,
+                    )
+                )
+                if result.returncode != 0:
+                    log.error(
+                        "Failed to create conductor %s: %s",
+                        name,
+                        result.stderr.strip(),
+                    )
+                    return False
+                # Start the newly created session
+                await loop.run_in_executor(
+                    None, functools.partial(
+                        run_cli,
+                        "session",
+                        "start",
+                        session_title,
+                        profile=profile,
+                        timeout=60,
+                    )
+                )
 
         # Wait a moment for the session to initialize (non-blocking)
         await asyncio.sleep(5)

--- a/conductor/tests/test_issue1351_conductor_dedupe.py
+++ b/conductor/tests/test_issue1351_conductor_dedupe.py
@@ -1,0 +1,132 @@
+"""Regression tests for issue #1351.
+
+Restarting the conductor bridge must not register a duplicate conductor row
+when a same-title conductor already exists in the requested profile.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+try:
+    import toml  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["toml"] = types.SimpleNamespace(load=lambda *_args, **_kwargs: {})
+
+from bridge import ensure_conductor_running  # noqa: E402
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+def _completed(returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(["agent-deck"], returncode, "", stderr)
+
+
+def _run(coro):
+    with mock.patch("bridge.asyncio.sleep", new=_no_sleep):
+        return asyncio.run(coro)
+
+
+def _calls_for(mock_cli: mock.Mock, *prefix: str) -> list[tuple]:
+    return [
+        call.args
+        for call in mock_cli.call_args_list
+        if call.args[:len(prefix)] == prefix
+    ]
+
+
+def test_existing_conductor_title_retries_start_without_add():
+    with mock.patch(
+        "bridge.get_session_status",
+        side_effect=["unknown", "running"],
+    ), mock.patch(
+        "bridge.get_sessions_list",
+        return_value=[{"title": "conductor-ops", "profile": "work", "id": "existing"}],
+    ) as mock_sessions, mock.patch(
+        "bridge.run_cli",
+        side_effect=[_completed(1, "not found"), _completed(0)],
+    ) as mock_cli:
+        assert _run(ensure_conductor_running("ops", "work")) is True
+
+    mock_sessions.assert_called_once_with(profile="work")
+    assert _calls_for(mock_cli, "add") == []
+    assert len(_calls_for(mock_cli, "session", "start", "conductor-ops")) == 2
+
+
+def test_fresh_setup_creates_session_then_starts_it():
+    with mock.patch(
+        "bridge.get_session_status",
+        side_effect=["unknown", "running"],
+    ), mock.patch(
+        "bridge.get_sessions_list",
+        return_value=[],
+    ), mock.patch(
+        "bridge.run_cli",
+        side_effect=[_completed(1, "not found"), _completed(0), _completed(0)],
+    ) as mock_cli:
+        assert _run(ensure_conductor_running("ops", "work")) is True
+
+    commands = [call.args[:3] for call in mock_cli.call_args_list]
+    assert commands == [
+        ("session", "start", "conductor-ops"),
+        ("add", str(Path.home() / ".agent-deck" / "conductor" / "ops"), "-t"),
+        ("session", "start", "conductor-ops"),
+    ]
+    assert len(_calls_for(mock_cli, "add")) == 1
+
+
+def test_running_status_fast_path_has_no_cli_mutations():
+    running_statuses = ("waiting", "running", "idle", "active", "starting")
+
+    for status in running_statuses:
+        with mock.patch(
+            "bridge.get_session_status",
+            return_value=status,
+        ), mock.patch("bridge.get_sessions_list") as mock_sessions, mock.patch(
+            "bridge.run_cli"
+        ) as mock_cli:
+            assert _run(ensure_conductor_running("ops", "work")) is True
+
+        mock_sessions.assert_not_called()
+        mock_cli.assert_not_called()
+
+
+def test_same_title_in_different_profile_does_not_suppress_creation():
+    with mock.patch(
+        "bridge.get_session_status",
+        side_effect=["unknown", "running"],
+    ), mock.patch(
+        "bridge.get_sessions_list",
+        return_value=[{"title": "conductor-ops", "profile": "personal"}],
+    ), mock.patch(
+        "bridge.run_cli",
+        side_effect=[_completed(1, "not found"), _completed(0), _completed(0)],
+    ) as mock_cli:
+        assert _run(ensure_conductor_running("ops", "work")) is True
+
+    assert len(_calls_for(mock_cli, "add")) == 1
+
+
+def test_existing_conductor_start_failure_returns_false_without_add():
+    with mock.patch(
+        "bridge.get_session_status",
+        side_effect=["unknown", "unknown"],
+    ), mock.patch(
+        "bridge.get_sessions_list",
+        return_value=[{"title": "conductor-ops", "profile": "work", "id": "existing"}],
+    ), mock.patch(
+        "bridge.run_cli",
+        side_effect=[_completed(1, "not found"), _completed(1, "still not found")],
+    ) as mock_cli:
+        assert _run(ensure_conductor_running("ops", "work")) is False
+
+    assert _calls_for(mock_cli, "add") == []
+    assert len(_calls_for(mock_cli, "session", "start", "conductor-ops")) == 2

--- a/internal/session/conductor_templates.go
+++ b/internal/session/conductor_templates.go
@@ -796,6 +796,19 @@ def get_sessions_list_all(profiles: list[str]) -> list[tuple[str, dict]]:
     return all_sessions
 
 
+def _find_session_by_title(sessions: list, title: str, profile: str) -> dict | None:
+    """Find an exact title match from a profile-scoped session list."""
+    for session in sessions:
+        if not isinstance(session, dict):
+            continue
+        if session.get("title") != title:
+            continue
+        session_profile = session.get("profile")
+        if session_profile in (None, "", profile):
+            return session
+    return None
+
+
 def ensure_conductor_running(name: str, profile: str) -> bool:
     """Ensure the conductor session exists and is running."""
     profile = profile or "default"
@@ -811,29 +824,52 @@ def ensure_conductor_running(name: str, profile: str) -> bool:
             "session", "start", session_title, profile=profile, timeout=60
         )
         if result.returncode != 0:
-            # Session might not exist, try creating it
-            log.info("Creating conductor session for %s...", name)
-            session_path = str(CONDUCTOR_DIR / name)
-            result = run_cli(
-                "add", session_path,
-                "-t", session_title,
-                "-c", "claude",
-                "-g", "conductor",
-                profile=profile,
-                timeout=60,
+            log.warning(
+                "Failed to start conductor %s before dedupe: %s",
+                name,
+                result.stderr.strip(),
             )
-            if result.returncode != 0:
-                log.error(
-                    "Failed to create conductor %s: %s",
-                    name,
-                    result.stderr.strip(),
+            sessions = get_sessions_list(profile=profile)
+            existing = _find_session_by_title(sessions, session_title, profile)
+            if existing is not None:
+                log.info(
+                    "Reusing existing conductor session %s in profile %s",
+                    session_title,
+                    profile,
                 )
-                return False
-            # Start the newly created session
-            run_cli(
-                "session", "start", session_title,
-                profile=profile, timeout=60,
-            )
+                retry = run_cli(
+                    "session", "start", session_title, profile=profile, timeout=60
+                )
+                if retry.returncode != 0:
+                    log.warning(
+                        "Failed to start existing conductor %s: %s",
+                        name,
+                        retry.stderr.strip(),
+                    )
+            else:
+                # Session is absent from this profile, so create it.
+                log.info("Creating conductor session for %s...", name)
+                session_path = str(CONDUCTOR_DIR / name)
+                result = run_cli(
+                    "add", session_path,
+                    "-t", session_title,
+                    "-c", "claude",
+                    "-g", "conductor",
+                    profile=profile,
+                    timeout=60,
+                )
+                if result.returncode != 0:
+                    log.error(
+                        "Failed to create conductor %s: %s",
+                        name,
+                        result.stderr.strip(),
+                    )
+                    return False
+                # Start the newly created session
+                run_cli(
+                    "session", "start", session_title,
+                    profile=profile, timeout=60,
+                )
 
         # Wait a moment for the session to initialize
         time.sleep(5)


### PR DESCRIPTION
## Summary

Restarting the conductor bridge no longer registers a duplicate phantom conductor instance. On start, the bridge now dedupes by `(title, profile)`: when a matching conductor row already exists, it reuses that instance instead of creating a new id and a never-live tmux session. The same change is applied to the embedded bridge template in `internal/session/conductor_templates.go`, so users installing or upgrading via `agent-deck conductor setup` get the fixed behavior too.

## Why this matters

#1351 reports that `systemctl --user restart agent-deck-conductor-bridge.service` creates a second conductor row with the same title, a new instance id, and a dead tmux session about 2 seconds after restart. The consequences are user-visible: input gets mis-delivered to the wrong pane, and `agent-deck list` can report the live conductor as `error` while it is healthy until the phantom row is deleted. The issue is labeled `bug` + `accepted`, and the dedupe-by-title-and-profile approach implemented here is the one endorsed in the issue thread.

## Changes

- Bridge start checks for an existing conductor instance with the same title and profile before registering; a failed `session start` no longer falls straight through to `add`.
- The fix lands in both `conductor/bridge.py` (standalone script) and the embedded template in `internal/session/conductor_templates.go` (the copy `InstallBridgeScript` actually installs), keeping the two in sync.

## Testing

- New regression tests in `conductor/tests/test_issue1351_conductor_dedupe.py` (5 tests) cover: restart reuses the existing instance, no duplicate row on failed session start, dedupe keyed on title+profile, and distinct profiles still get distinct instances. All pass.
- `go build ./...` passes with the updated embedded template.

Fixes #1351


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duplicate conductor session creation when restarting the conductor bridge. The system now reuses existing sessions with matching titles instead of always creating new ones.

* **Tests**
  * Added regression tests for conductor session deduplication to prevent duplicate entries during restart operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->