### PR TITLE
fix(session): restore conductor telegram channel from config when persisted Channels is lost

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1030,6 +1030,10 @@ func (i *Instance) buildClaudeExtraFlags(opts *ClaudeOptions) string {
 	// Plugin channels: subscribe the claude session to inbound messages from
 	// each listed plugin channel. Persisted on Instance.Channels and refreshed
 	// on every Start/Restart/resume because every command-build flows here.
+	// Heal first: a conductor whose persisted Channels lost the telegram
+	// entry (index wipe, record rebuild) is restored from conductor config
+	// so the wiring can't silently disappear (telegram_reliability.go).
+	reconcileConductorTelegramChannel(i)
 	if len(i.Channels) > 0 {
 		flags = append(flags, "--channels "+shellescape.Quote(strings.Join(i.Channels, ","))) // audit F1
 	}

--- a/internal/session/telegram_channel_restore_test.go
+++ b/internal/session/telegram_channel_restore_test.go
@@ -1,0 +1,194 @@
+// Package session — regression suite for the lost-channels conductor drop.
+//
+// Background. Every telegram defense added by #1136/#1137/#1163 keys off
+// Instance.Channels containing "plugin:telegram@…": the channel-owner
+// scratch gate (needsScratchForTelegramChannelOwner), the `--channels`
+// flag emission (buildClaudeExtraFlags), the force-correct scratch pass,
+// and the drift warning (VerifyTelegramChannelEnabled returns vacuously
+// OK when Channels is empty). The persisted Channels list is therefore a
+// single upstream point of failure: when a conductor's DB record loses
+// the field — index wipe + manual rebuild, migration, hand edit — the
+// conductor silently respawns as a plain `claude --resume` with no
+// channel wiring at all, and every downstream defense disarms without a
+// single warning.
+//
+// Observed live 2026-06-11: 4 of 7 conductor records (si, sherif,
+// innotrade, opengraphdb) had no "channels" key in tool_data after the
+// 2026-06-04 index wipe + rebuild; their claude processes ran without
+// --channels and without a scratch CLAUDE_CONFIG_DIR, while the three
+// records that kept the field (agent-deck, personal, ryan) spawned
+// correctly. The deaf bots were then "revived" by flipping the global
+// antipattern (enabledPlugins.telegram=true in the shared profile, #941)
+// back on, recreating the duplicate-poller 409 class.
+//
+// Fix under test. The conductor's config — an env_file declaring
+// TELEGRAM_STATE_DIR under [conductors.<name>].claude — is the durable
+// source of truth for channel ownership; the persisted Channels list is
+// a cache. reconcileConductorTelegramChannel restores the telegram
+// channel id onto conductor-titled claude instances whose Channels lost
+// it, and is wired into prepareWorkerScratchConfigDirForSpawn and
+// buildClaudeExtraFlags so the heal runs on every spawn path.
+//
+// All tests in this file MUST fail on the pre-fix tree and pass after
+// the fix lands. Grep tag: telegram-channel-restore.
+
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withConductorEnvFile points the conductorTelegramEnvFile seam at a temp
+// .envrc with the given content for the named conductor, restoring the
+// real loader on cleanup. Empty content means "conductor has no env_file".
+func withConductorEnvFile(t *testing.T, conductor, content string) {
+	t.Helper()
+	orig := conductorTelegramEnvFile
+	t.Cleanup(func() { conductorTelegramEnvFile = orig })
+
+	if content == "" {
+		conductorTelegramEnvFile = func(name string) string { return "" }
+		return
+	}
+	path := filepath.Join(t.TempDir(), ".envrc")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp envrc: %v", err)
+	}
+	conductorTelegramEnvFile = func(name string) string {
+		if name != conductor {
+			return ""
+		}
+		return path
+	}
+}
+
+// lostChannelsConductor reproduces the live regression shape: a conductor
+// record whose tool_data lost the "channels" key (si/sherif/innotrade/
+// opengraphdb after the 2026-06-04 index wipe).
+func lostChannelsConductor(name string) *Instance {
+	return &Instance{
+		ID:          name + "-test",
+		Tool:        "claude",
+		Title:       "conductor-" + name,
+		IsConductor: true,
+		Channels:    nil, // the lost field
+	}
+}
+
+// TestReconcileRestoresLostConductorChannel is the core regression test:
+// conductor config declares TELEGRAM_STATE_DIR, persisted Channels is
+// empty → the channel id must be restored.
+func TestReconcileRestoresLostConductorChannel(t *testing.T) {
+	withConductorEnvFile(t, "si",
+		"export TELEGRAM_STATE_DIR=/home/u/.claude-work/channels/telegram-si\n")
+	inst := lostChannelsConductor("si")
+
+	if !reconcileConductorTelegramChannel(inst) {
+		t.Fatal("reconcileConductorTelegramChannel returned false; want restore")
+	}
+	want := "plugin:" + telegramPluginID
+	if len(inst.Channels) != 1 || inst.Channels[0] != want {
+		t.Fatalf("Channels = %v; want [%s]", inst.Channels, want)
+	}
+
+	// Idempotent: a second pass must not duplicate.
+	if reconcileConductorTelegramChannel(inst) {
+		t.Fatal("second reconcile reported a restore; want no-op")
+	}
+	if len(inst.Channels) != 1 {
+		t.Fatalf("Channels after second pass = %v; want exactly 1", inst.Channels)
+	}
+}
+
+// TestReconcileSkipsNonConductorAndUnconfigured pins the negative space:
+// no restore for worker sessions, conductors without env_file, env_files
+// without TELEGRAM_STATE_DIR, non-claude tools, or explicit opt-out.
+func TestReconcileSkipsNonConductorAndUnconfigured(t *testing.T) {
+	cases := []struct {
+		name string
+		inst *Instance
+		env  string // envrc content; "" = no env_file
+	}{
+		{
+			name: "worker session title",
+			inst: &Instance{ID: "w1", Tool: "claude", Title: "fix-telegram-drops"},
+			env:  "export TELEGRAM_STATE_DIR=/tmp/x\n",
+		},
+		{
+			name: "conductor without env_file",
+			inst: lostChannelsConductor("si"),
+			env:  "",
+		},
+		{
+			name: "env_file without TELEGRAM_STATE_DIR",
+			inst: lostChannelsConductor("si"),
+			env:  "export RAILWAY_API_TOKEN=abc\n",
+		},
+		{
+			name: "non-claude tool",
+			inst: &Instance{ID: "h1", Tool: "hermes", Title: "conductor-si"},
+			env:  "export TELEGRAM_STATE_DIR=/tmp/x\n",
+		},
+		{
+			name: "explicit opt-out",
+			inst: func() *Instance {
+				i := lostChannelsConductor("si")
+				i.PluginChannelLinkDisabled = true
+				return i
+			}(),
+			env: "export TELEGRAM_STATE_DIR=/tmp/x\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withConductorEnvFile(t, "si", tc.env)
+			if reconcileConductorTelegramChannel(tc.inst) {
+				t.Fatalf("reconcile restored a channel for %q; want skip", tc.name)
+			}
+			if len(tc.inst.Channels) != 0 {
+				t.Fatalf("Channels = %v; want empty", tc.inst.Channels)
+			}
+		})
+	}
+}
+
+// TestBuildClaudeExtraFlagsEmitsRestoredChannel verifies the heal is
+// wired into the command-build chokepoint: a lost-channels conductor
+// must still get `--channels plugin:telegram@…` on every Start/Restart/
+// resume, because every command build flows through
+// buildClaudeExtraFlags.
+func TestBuildClaudeExtraFlagsEmitsRestoredChannel(t *testing.T) {
+	withConductorEnvFile(t, "sherif",
+		"export TELEGRAM_STATE_DIR=/home/u/.claude-work/channels/telegram-sherif\n")
+	inst := lostChannelsConductor("sherif")
+
+	flags := inst.buildClaudeExtraFlags(nil)
+	want := "--channels plugin:" + telegramPluginID
+	if !strings.Contains(flags, want) {
+		t.Fatalf("buildClaudeExtraFlags = %q; want it to contain %q", flags, want)
+	}
+}
+
+// TestScratchGateArmsAfterRestore verifies the restored channel re-arms
+// the #1138 channel-owner scratch gate, so the conductor regains its
+// force-corrected scratch CLAUDE_CONFIG_DIR instead of trusting the
+// ambient profile (the topology that pushed the operator back to the
+// #941 global antipattern).
+func TestScratchGateArmsAfterRestore(t *testing.T) {
+	withConductorEnvFile(t, "innotrade",
+		"export TELEGRAM_STATE_DIR=/home/u/.claude-work/channels/telegram-innotrade\n")
+	inst := lostChannelsConductor("innotrade")
+
+	if needsScratchForTelegramChannelOwner(inst) {
+		t.Fatal("gate armed before restore; test precondition broken")
+	}
+	if !reconcileConductorTelegramChannel(inst) {
+		t.Fatal("reconcile did not restore the channel")
+	}
+	if !needsScratchForTelegramChannelOwner(inst) {
+		t.Fatal("channel-owner scratch gate did not arm after restore")
+	}
+}

--- a/internal/session/telegram_reliability.go
+++ b/internal/session/telegram_reliability.go
@@ -195,3 +195,87 @@ func EmitTelegramChannelDriftWarning(title, instanceID, configDir string, channe
 		slog.String("hint", "agent-deck telegram-doctor reports per-conductor health; the scratch CLAUDE_CONFIG_DIR is rewritten on every restart and should heal this drift on the next session restart."),
 	)
 }
+
+// conductorTelegramEnvFile resolves the [conductors.<name>].claude.env_file
+// path for a conductor name. Package var so tests can override (mirrors
+// hostHasTelegramConductor in worker_scratch.go).
+var conductorTelegramEnvFile = func(name string) string {
+	cfg, err := LoadUserConfig()
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return cfg.GetConductorClaudeEnvFile(name)
+}
+
+// envFileDeclaresTelegram reports whether the env_file at path exports
+// TELEGRAM_STATE_DIR. Same detection idiom as configDeclaresTelegram —
+// a missing or unreadable env_file is not a telegram declaration.
+func envFileDeclaresTelegram(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	data, err := os.ReadFile(ExpandPath(path))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "TELEGRAM_STATE_DIR")
+}
+
+// reconcileConductorTelegramChannel restores the telegram channel id onto
+// a conductor whose persisted Channels list lost it.
+//
+// Why. Every telegram defense keys off Instance.Channels containing
+// "plugin:telegram@…": the channel-owner scratch gate, the `--channels`
+// flag, the force-correct scratch pass, and the drift warning
+// (VerifyTelegramChannelEnabled is vacuously OK when Channels is empty).
+// That makes the persisted Channels list a single upstream point of
+// failure: lose the field — index wipe + manual record rebuild, migration,
+// hand edit — and the conductor silently respawns as a plain
+// `claude --resume` with no channel wiring while every defense disarms
+// without a warning. Observed live 2026-06-11: 4 of 7 conductor records
+// lost the field after the 2026-06-04 index wipe; the deaf bots were then
+// "revived" by re-flipping the #941 global antipattern, which recreated
+// the duplicate-poller 409 class.
+//
+// Contract. The conductor's config is the durable source of truth for
+// channel ownership; the persisted Channels list is a cache. A session
+// qualifies for restore when ALL hold:
+//   - claude tool, conductor-titled (conductorNameFromInstance != "")
+//   - [conductors.<name>].claude.env_file exports TELEGRAM_STATE_DIR
+//   - Channels has no plugin:telegram@… entry already
+//   - PluginChannelLinkDisabled is false (explicit opt-out wins)
+//
+// To intentionally run a conductor without telegram, remove
+// TELEGRAM_STATE_DIR from its env_file (or set PluginChannelLinkDisabled).
+//
+// In-memory only: callers on the spawn path get the healed Channels for
+// this spawn; the heal re-runs on every subsequent spawn, so a stale DB
+// record can never silently disarm the channel wiring again.
+//
+// Returns true when a channel was restored.
+func reconcileConductorTelegramChannel(i *Instance) bool {
+	if i == nil || i.Tool != "claude" || i.PluginChannelLinkDisabled {
+		return false
+	}
+	if sessionHasTelegramChannel(i) {
+		return false // cache is intact; nothing to heal
+	}
+	name := conductorNameFromInstance(i)
+	if name == "" {
+		return false // not a conductor
+	}
+	if !envFileDeclaresTelegram(conductorTelegramEnvFile(name)) {
+		return false // config does not declare telegram for this conductor
+	}
+
+	i.Channels = append(i.Channels, "plugin:"+telegramPluginID)
+	sessionLog.Warn("telegram_channel_restored_from_config",
+		slog.String("instance_id", i.ID),
+		slog.String("title", i.Title),
+		slog.String("conductor", name),
+		slog.String("channel", "plugin:"+telegramPluginID),
+		slog.String("reason", "persisted Channels lost the telegram entry but [conductors."+name+"].claude.env_file declares TELEGRAM_STATE_DIR; restoring so --channels, the scratch gate, and drift detection re-arm"),
+		slog.String("hint", "persist the repair with: agent-deck session set "+i.Title+" channels plugin:"+telegramPluginID),
+	)
+	return true
+}

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -568,6 +568,11 @@ func (i *Instance) applyWorkerScratchOverride(resolvedConfigDir string) string {
 // claude would start with enabledPlugins[<id>]=true but without the
 // plugin code reachable, until the next restart rebuilt scratch.
 func (i *Instance) prepareWorkerScratchConfigDirForSpawn() {
+	// Heal lost channel wiring BEFORE evaluating the scratch gates: a
+	// conductor whose persisted Channels lost the telegram entry must
+	// re-arm needsScratchForTelegramChannelOwner on this very spawn
+	// (telegram_reliability.go, telegram-channel-restore).
+	reconcileConductorTelegramChannel(i)
 	if !i.NeedsWorkerScratchConfigDir() {
 		return
 	}


### PR DESCRIPTION
## The current drop mechanism (evidenced 2026-06-11)

Root-cause investigation of the recurring "bots stop working while sessions keep running" complaint. **All seven bot tokens are healthy (`getMe` ok)** — the drops are wiring, not Telegram.

### Evidence chain

1. **4 of 7 conductor DB records lost the `channels` field.** In `profiles/personal/state.db` `tool_data`: four conductors (two client conductors, two project conductors) have **no `"channels"` key**; `conductor-agent-deck`, `conductor-personal`, and one project conductor still have it. Timing is consistent with the 2026-06-04 `SaveInstances([])` index wipe + manual record rebuild.
2. **Perfect live correlation:** the three conductors with the field run `claude … --channels plugin:telegram@…` on a worker-scratch `CLAUDE_CONFIG_DIR`; the three running without it run plain `claude --resume` on the **raw profile** — no `--channels`, no scratch (one project conductor's session is down entirely).
3. **Silent disarm by design gap:** every defense from #1136/#1137/#1163 keys off `Instance.Channels` — the channel-owner scratch gate, `--channels` emission, the force-correct pass, and the drift warning (`VerifyTelegramChannelEnabled` returns *vacuously OK* when `Channels` is empty). Lose the field → all defenses switch off with zero warnings.
4. **The compensating workaround recreated #941:** the deaf bots were revived by flipping `enabledPlugins.telegram=true` globally in two profiles' `~/.claude-<profile>/settings.json`. That makes **every** child claude in those profiles spawn a poller; TSD-stripped children default to `~/.claude/channels/telegram` (the agent-deck bot) → 409 single-consumer contention. A transient rogue poller with empty `TELEGRAM_STATE_DIR` was observed live during the investigation.

## The fix

Conductor config is the durable source of truth for channel ownership; the persisted `Channels` list is a cache.

`reconcileConductorTelegramChannel` (telegram_reliability.go) restores `plugin:telegram@claude-plugins-official` onto a conductor-titled claude instance when:
- `[conductors.<name>].claude.env_file` exports `TELEGRAM_STATE_DIR` (same detection idiom as `configDeclaresTelegram`), and
- `Channels` has no telegram entry, and
- `PluginChannelLinkDisabled` is false (explicit opt-out wins; removing `TELEGRAM_STATE_DIR` from the env_file also opts out).

Wired into both spawn chokepoints:
- `prepareWorkerScratchConfigDirForSpawn` — **before** the scratch gates, so `needsScratchForTelegramChannelOwner` re-arms on the same spawn;
- `buildClaudeExtraFlags` — so `--channels` re-emits on every Start/Restart/resume.

Emits structured `telegram_channel_restored_from_config` WARN with a hint to persist the repair via `agent-deck session set <title> channels plugin:telegram@claude-plugins-official`.

## Tests

`telegram_channel_restore_test.go` — 4 tests reproducing the live lost-channels shape (TDD: all fail pre-fix):
- restore + idempotency
- negative space (worker titles, no env_file, env_file without TSD, non-claude tool, opt-out)
- `--channels` emission from `buildClaudeExtraFlags` on a lost-channels conductor
- scratch gate re-arms after restore

Full `./internal/session` suite run sandboxed (`HOME=$(mktemp -d)`, XDG cleared): no new failures (11 pre-existing, environment-dependent failures fail identically on clean HEAD).

## Not fixed here (documented for follow-up)

- **Upstream plugin (anthropics/claude-plugins-official#1378):** `server.ts` poll loop retries only 409s; any other transient error permanently exits `getUpdates` with no reconnect — and nothing respawns a dead poller until full session restart. Fix PR #1377 was closed unmerged. This host runs plugin v0.0.4.
- The global `enabledPlugins.telegram=true` flips in the affected `~/.claude-<profile>` dirs should be reverted once conductor records are repaired (this PR makes the workaround unnecessary).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System now automatically detects and restores missing Telegram channel connections for conductor sessions that lose their wiring due to index rebuilds or record resets. Recovery occurs automatically during session startup, restart, and resume phases.

* **Tests**
  * Added comprehensive regression test suite covering Telegram channel restoration, idempotence, eligibility checks, and integration with command building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
