### PR TITLE
fix(session): stop nested-scratch credential chaining (401s persisting across restarts)

### DIFF
--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -351,13 +351,13 @@ func resolveClaudeConfigDir(opts resolveOpts) (path, source string) {
 				return groupDir, "group"
 			}
 		}
-		if envDir := os.Getenv("CLAUDE_CONFIG_DIR"); envDir != "" {
-			return ExpandPath(envDir), "env"
+		if envDir := envClaudeConfigDirIgnoringScratchLeak(); envDir != "" {
+			return envDir, "env"
 		}
 	} else {
 		// Group chain: env wins.
-		if envDir := os.Getenv("CLAUDE_CONFIG_DIR"); envDir != "" {
-			return ExpandPath(envDir), "env"
+		if envDir := envClaudeConfigDirIgnoringScratchLeak(); envDir != "" {
+			return envDir, "env"
 		}
 		if userConfig != nil {
 			if groupDir := userConfig.GetGroupClaudeConfigDir(groupPath); groupDir != "" {
@@ -378,6 +378,33 @@ func resolveClaudeConfigDir(opts resolveOpts) (path, source string) {
 
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".claude"), "default"
+}
+
+// envClaudeConfigDirIgnoringScratchLeak returns the expanded CLAUDE_CONFIG_DIR
+// env var, or "" when it is unset OR points inside the worker-scratch root.
+//
+// Nested-scratch credential chain (successor to #1222/#1224): when agent-deck
+// runs INSIDE a scratch-pinned worker (a session that itself spawns children),
+// the parent's scratch CLAUDE_CONFIG_DIR is the ambient env value. Honoring it
+// as the "env" priority level makes children inherit ANOTHER WORKER'S scratch
+// dir as their source profile, so their credentials symlink lands on the
+// parent's scratch entry — possibly a forked real-file copy (post-/login
+// clobber) that reassertCredentialSymlink can then never collapse to the real
+// canonical. A worker-scratch dir is an ephemeral, agent-deck-owned mirror; it
+// is never a legitimate user profile, so it is never a legitimate env
+// override. Ignoring it falls through to profile/global/default — the real
+// canonical chain. ChildLaunchEnv (#1163) already strips the var from child
+// envs; this guards the resolver itself for in-process resolution paths.
+func envClaudeConfigDirIgnoringScratchLeak() string {
+	envDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	if envDir == "" {
+		return ""
+	}
+	expanded := ExpandPath(envDir)
+	if pathUnderWorkerScratch(expanded) {
+		return ""
+	}
+	return expanded
 }
 
 // GetClaudeConfigDir returns the Claude config directory for the active profile.

--- a/internal/session/nested_scratch_credential_chain_test.go
+++ b/internal/session/nested_scratch_credential_chain_test.go
@@ -1,0 +1,203 @@
+// Package session — regression tests for the nested-scratch credential chain.
+//
+// Successor to issue #1222 (single-source-of-truth credential symlink). #1222
+// healed the case where a worker's OWN scratch .credentials.json was clobbered
+// into a real-file copy by an in-session /login. This file covers the residual
+// 401 class it does NOT cover: NESTED scratch.
+//
+// When agent-deck runs INSIDE a scratch-pinned worker (a conductor/worker that
+// itself spawns children via `agent-deck add/launch`), the parent's
+// CLAUDE_CONFIG_DIR — a worker-scratch path — leaks into the agent-deck process
+// env. resolveClaudeConfigDir then resolves the CHILD's source profile to the
+// PARENT's scratch dir (env priority). The child's scratch credentials are
+// symlinked to `<parent-scratch>/.credentials.json`, which may itself be a
+// forked real-file copy (post-/login clobber). The child inherits a
+// non-canonical token that its OWN reassert can never collapse to the real
+// profile canonical — so it 401s, and the 401 PERSISTS ACROSS RESTARTS because
+// every restart re-links to the same forked parent copy.
+//
+// Two layers, both preserving the #1222 no-promote invariant (canonical is
+// NEVER written):
+//
+//	A. resolveClaudeConfigDir ignores a leaked worker-scratch CLAUDE_CONFIG_DIR
+//	   so children resolve the real profile, not a parent scratch.
+//	B. reassertCredentialSymlink collapses a nested-scratch credential chain to
+//	   the true profile canonical instead of linking to a forked scratch copy.
+
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// nestedScratchSandbox sandboxes HOME + XDG so workerScratchDirRoot resolves
+// under a temp dir, and returns the resolved worker-scratch root.
+func nestedScratchSandbox(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	root, err := WorkerScratchDirRoot()
+	if err != nil {
+		t.Fatalf("resolve worker-scratch root: %v", err)
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir worker-scratch root: %v", err)
+	}
+	return root
+}
+
+// LAYER B (b1): source is a NESTED scratch dir whose .credentials.json is a
+// forked real-file copy. reassert must collapse to the TRUE profile canonical
+// (recovered from a mirrored sibling symlink), never to the forked copy, and
+// must never write canonical.
+func TestReassertCredentialSymlink_SourceIsNestedScratch_CollapsesToProfileCanonical(t *testing.T) {
+	scratchRoot := nestedScratchSandbox(t)
+
+	// Real profile (OUTSIDE the scratch tree) — the single source of truth.
+	profileRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(profileRoot, "projects"), 0o700); err != nil {
+		t.Fatalf("mkdir profile projects: %v", err)
+	}
+	canonToken := `{"token":"true-canonical"}`
+	writeCredFile(t, filepath.Join(profileRoot, ".credentials.json"), canonToken, time.Now())
+
+	// Parent scratch dir (a nested source), seeded from profileRoot: a sibling
+	// symlink reveals the profile root; its credentials are a FORKED real-file
+	// copy (the in-session /login clobber that #1222 only heals on the parent's
+	// own restart).
+	parentScratch := filepath.Join(scratchRoot, "parent-worker-scratch")
+	if err := os.MkdirAll(parentScratch, 0o700); err != nil {
+		t.Fatalf("mkdir parent scratch: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(profileRoot, "projects"), filepath.Join(parentScratch, "projects")); err != nil {
+		t.Fatalf("seed parent sibling symlink: %v", err)
+	}
+	forkedToken := `{"token":"forked-parent-copy"}`
+	writeCredFile(t, filepath.Join(parentScratch, ".credentials.json"), forkedToken, time.Now())
+
+	// Child scratch (the worker we are seeding) sourced from the PARENT scratch.
+	childScratch := filepath.Join(scratchRoot, "child-worker-scratch")
+	if err := os.MkdirAll(childScratch, 0o700); err != nil {
+		t.Fatalf("mkdir child scratch: %v", err)
+	}
+
+	if err := mirrorProfileEntries(childScratch, parentScratch); err != nil {
+		t.Fatalf("mirrorProfileEntries: %v", err)
+	}
+
+	// Child credentials must be a symlink to the TRUE profile canonical, not the
+	// forked parent copy.
+	childCred := filepath.Join(childScratch, ".credentials.json")
+	assertIsSymlinkTo(t, childCred, filepath.Join(profileRoot, ".credentials.json"))
+	viaLink, err := os.ReadFile(childCred)
+	if err != nil {
+		t.Fatalf("read child cred via link: %v", err)
+	}
+	if string(viaLink) != canonToken {
+		t.Fatalf("child must resolve to the true canonical token; got %q want %q", string(viaLink), canonToken)
+	}
+
+	// No-promote invariant: the forked parent copy and the canonical are both
+	// untouched.
+	if got, _ := os.ReadFile(filepath.Join(parentScratch, ".credentials.json")); string(got) != forkedToken {
+		t.Fatalf("parent forked copy must be untouched; got %q", string(got))
+	}
+	if got, _ := os.ReadFile(filepath.Join(profileRoot, ".credentials.json")); string(got) != canonToken {
+		t.Fatalf("canonical must NEVER be written; got %q", string(got))
+	}
+}
+
+// LAYER B (b2): nested scratch with a forked real-file copy but NO sibling that
+// reveals a real profile. reassert must refuse to propagate the forked copy —
+// the child must not end up with a credentials symlink pointing into the
+// scratch tree (a poisoned, un-healable token). Better a clean login prompt
+// than a forked token.
+func TestReassertCredentialSymlink_NestedScratchNoSibling_DoesNotPropagateForkedCopy(t *testing.T) {
+	scratchRoot := nestedScratchSandbox(t)
+
+	parentScratch := filepath.Join(scratchRoot, "parent-worker-scratch")
+	if err := os.MkdirAll(parentScratch, 0o700); err != nil {
+		t.Fatalf("mkdir parent scratch: %v", err)
+	}
+	// Forked real-file copy, and NO sibling symlink to a real profile.
+	writeCredFile(t, filepath.Join(parentScratch, ".credentials.json"), `{"token":"forked"}`, time.Now())
+
+	childScratch := filepath.Join(scratchRoot, "child-worker-scratch")
+	if err := os.MkdirAll(childScratch, 0o700); err != nil {
+		t.Fatalf("mkdir child scratch: %v", err)
+	}
+
+	if err := mirrorProfileEntries(childScratch, parentScratch); err != nil {
+		t.Fatalf("mirrorProfileEntries: %v", err)
+	}
+
+	childCred := filepath.Join(childScratch, ".credentials.json")
+	fi, err := os.Lstat(childCred)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return // acceptable: no poisoned link created
+		}
+		t.Fatalf("lstat child cred: %v", err)
+	}
+	// If anything exists, it must NOT be a symlink resolving into the scratch tree.
+	if fi.Mode()&os.ModeSymlink != 0 {
+		resolved, _ := filepath.EvalSymlinks(childCred)
+		if pathUnderWorkerScratch(resolved) {
+			t.Fatalf("child credentials must not point at a forked scratch copy; resolves to %q (under scratch root)", resolved)
+		}
+	}
+}
+
+// LAYER A (a1): a leaked worker-scratch CLAUDE_CONFIG_DIR must NOT be used as a
+// profile source — resolveClaudeConfigDir falls through to the real profile
+// (default ~/.claude in a clean sandbox), so children seed from canonical.
+func TestResolveClaudeConfigDir_LeakedWorkerScratchEnv_FallsThroughToProfile(t *testing.T) {
+	scratchRoot := nestedScratchSandbox(t)
+	home := os.Getenv("HOME")
+
+	leaked := filepath.Join(scratchRoot, "some-parent-worker")
+	if err := os.MkdirAll(leaked, 0o700); err != nil {
+		t.Fatalf("mkdir leaked scratch: %v", err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", leaked)
+
+	inst := &Instance{ID: "00000000-0000-0000-0000-000000001377", Tool: "claude", Title: "child-worker"}
+	path, source := GetClaudeConfigDirSourceForInstance(inst)
+	if source == "env" || path == leaked {
+		t.Fatalf("leaked worker-scratch CLAUDE_CONFIG_DIR must be ignored; got path=%q source=%q", path, source)
+	}
+	if want := filepath.Join(home, ".claude"); path != want {
+		t.Fatalf("must fall through to default profile; got path=%q want %q (source=%q)", path, want, source)
+	}
+
+	// Group chain (env-wins branch) must also ignore the leaked scratch.
+	gpath, gsource := GetClaudeConfigDirSourceForGroup("")
+	if gsource == "env" || gpath == leaked {
+		t.Fatalf("group chain must also ignore leaked scratch env; got path=%q source=%q", gpath, gsource)
+	}
+}
+
+// LAYER A (a2) CONTROL: a NORMAL (non-scratch) CLAUDE_CONFIG_DIR must still be
+// honored — we only ignore the leaked-scratch case.
+func TestResolveClaudeConfigDir_NormalEnv_StillHonored(t *testing.T) {
+	nestedScratchSandbox(t)
+	home := os.Getenv("HOME")
+
+	normal := filepath.Join(home, ".claude-work")
+	if err := os.MkdirAll(normal, 0o700); err != nil {
+		t.Fatalf("mkdir normal config dir: %v", err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", normal)
+
+	inst := &Instance{ID: "00000000-0000-0000-0000-000000001378", Tool: "claude", Title: "child-worker"}
+	path, source := GetClaudeConfigDirSourceForInstance(inst)
+	if source != "env" || path != normal {
+		t.Fatalf("normal CLAUDE_CONFIG_DIR must be honored as env; got path=%q source=%q want %q/env", path, source, normal)
+	}
+}

--- a/internal/session/worker_scratch.go
+++ b/internal/session/worker_scratch.go
@@ -279,6 +279,81 @@ func workerScratchDirFor(instanceID string) string {
 	return filepath.Join(workerScratchDirRoot(), instanceID)
 }
 
+// pathUnderWorkerScratch reports whether p resolves inside the worker-scratch
+// root. Both p and the root are resolved through symlinks first so a /tmp →
+// /private/tmp style indirection (or a symlinked HOME) does not defeat the
+// prefix check. Used to detect (a) a leaked worker-scratch CLAUDE_CONFIG_DIR
+// masquerading as a profile source and (b) a nested-scratch credential chain
+// that would otherwise propagate a forked, non-canonical token.
+func pathUnderWorkerScratch(p string) bool {
+	if p == "" {
+		return false
+	}
+	root := workerScratchDirRoot()
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		p = resolved
+	}
+	root = filepath.Clean(root)
+	p = filepath.Clean(p)
+	return p == root || strings.HasPrefix(p, root+string(os.PathSeparator))
+}
+
+// profileCanonicalFromNestedScratch recovers the real profile's credentials
+// path from a worker-scratch dir that was (wrongly) used as a credential
+// source. A scratch dir is a shallow mirror: every entry except settings.json
+// and .credentials.json is a symlink into the profile it was seeded from, so
+// the parent directory of any sibling symlink's target IS the source profile.
+// Follows nested chains (scratch seeded from scratch) up to a small depth
+// bound; returns "" when no non-scratch profile holding a regular
+// .credentials.json can be found. Read-only — never creates or writes.
+func profileCanonicalFromNestedScratch(scratchDir string) string {
+	dir := scratchDir
+	for depth := 0; depth < 5; depth++ {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return ""
+		}
+		next := ""
+		for _, e := range entries {
+			name := e.Name()
+			if name == "settings.json" || name == credentialsFileName {
+				continue
+			}
+			p := filepath.Join(dir, name)
+			fi, lerr := os.Lstat(p)
+			if lerr != nil || fi.Mode()&os.ModeSymlink == 0 {
+				continue
+			}
+			tgt, rerr := os.Readlink(p)
+			if rerr != nil {
+				continue
+			}
+			if !filepath.IsAbs(tgt) {
+				tgt = filepath.Join(dir, tgt)
+			}
+			candidate := filepath.Dir(tgt)
+			if pathUnderWorkerScratch(candidate) {
+				// Deeper nesting — remember the next scratch hop and keep
+				// scanning this level for a direct profile link first.
+				next = candidate
+				continue
+			}
+			canon := filepath.Join(candidate, credentialsFileName)
+			if cfi, serr := os.Stat(canon); serr == nil && cfi.Mode().IsRegular() {
+				return canon
+			}
+		}
+		if next == "" {
+			return ""
+		}
+		dir = next
+	}
+	return ""
+}
+
 // EnsureWorkerScratchConfigDir idempotently prepares the scratch
 // CLAUDE_CONFIG_DIR. Returns "" (no error) when no scratch is needed —
 // callers treat that as "use the ambient profile". The scratch mirrors
@@ -467,6 +542,25 @@ func mirrorProfileEntries(dest, source string) error {
 func reassertCredentialSymlink(dest, source string) error {
 	target := filepath.Join(source, credentialsFileName)
 	linkPath := filepath.Join(dest, credentialsFileName)
+
+	// Nested-scratch collapse (successor to #1222): when source is ITSELF a
+	// worker-scratch dir (a parent worker's scratch leaked into this child's
+	// source resolution), target would be another worker's scratch credentials
+	// — possibly a forked real-file copy that this child's reassert could
+	// never heal (it re-links to the same forked copy on every restart, the
+	// "401 persists across restarts" signature). Recover the TRUE profile
+	// canonical from the nested scratch's own mirrored symlinks and collapse
+	// to it. If no canonical is recoverable, refuse to link into the scratch
+	// tree at all: leave any existing entry intact and create nothing — a
+	// clean login prompt beats inheriting a forked rotation chain. Canonical
+	// is never written either way (the no-promote invariant).
+	if pathUnderWorkerScratch(target) {
+		canon := profileCanonicalFromNestedScratch(source)
+		if canon == "" {
+			return nil
+		}
+		target = canon
+	}
 
 	li, lerr := os.Lstat(linkPath)
 	switch {


### PR DESCRIPTION
## Problem

Successor to #1222 / #1224. The symlink re-assert shipped in #1224 heals a worker whose **own** scratch `.credentials.json` was clobbered into a real-file copy — but it cannot heal **nested scratch**: when agent-deck runs *inside* a scratch-pinned worker that spawns children, the parent's worker-scratch `CLAUDE_CONFIG_DIR` leaks into config resolution (env priority level), so the child's *source profile* resolves to **another worker's scratch dir**. The child's credentials get symlinked to `<parent-scratch>/.credentials.json` — possibly a forked real-file token copy (post-`/login` clobber). The child's own re-assert is then *locally satisfied* ("I'm a symlink to my source") while never collapsing to the real profile canonical, and every restart re-links to the same forked copy.

That is the **"401 persists across restarts"** signature.

## Evidence (production box, 2026-06-11)

Forensic sweep of `~/.agent-deck/worker-scratch` on `<host>` (443 credential entries):

- 439 symlinks / 4 real-file copies; **4 live workers** (`f191db98`, `41c25721`, `e02fc8f6`, `d6267126`) had `plugins → <parent-scratch>/plugins` **and** `.credentials.json → <parent-scratch>/.credentials.json`, where the parent scratch (`c3a19cb1`, sourced from a real profile) held a forked real-file copy from an 08:25 in-session `/login`.
- The morning's new-worker 401s persisted across restarts despite #1224 being live in v1.9.55 — exactly the gap this PR closes.

Full forensic report: `/tmp/exec-auth401-0611/RESULTS.md` on the box (mtime mystery, token-lifetime math, copies-vs-symlinks map, timeline).

## Fix (two layers, both preserving the #1222 no-promote invariant — canonical is never written)

**Layer A — resolver guard** (`claude.go`): `envClaudeConfigDirIgnoringScratchLeak()` — a `CLAUDE_CONFIG_DIR` pointing inside the worker-scratch root is never a legitimate profile source; ignore it and fall through to profile/global/default. Complements the #1163 `childenv` strip at the launch chokepoint by guarding **in-process** resolution too (the leak path the chokepoint can't see).

**Layer B — reassert collapse** (`worker_scratch.go`): when a credential source is itself a worker-scratch dir, `profileCanonicalFromNestedScratch()` recovers the true profile canonical from the nested scratch's mirrored sibling symlinks (depth-bounded) and the chain collapses to it. If no canonical is recoverable, **refuse to link into the scratch tree at all** — a clean login prompt beats inheriting a forked rotation chain.

## Tests (TDD — all written first, watched fail)

New `nested_scratch_credential_chain_test.go`:
- `TestReassertCredentialSymlink_SourceIsNestedScratch_CollapsesToProfileCanonical` — chain collapses to true canonical; forked copy and canonical both untouched
- `TestReassertCredentialSymlink_NestedScratchNoSibling_DoesNotPropagateForkedCopy` — no poisoned link created when no canonical is recoverable
- `TestResolveClaudeConfigDir_LeakedWorkerScratchEnv_FallsThroughToProfile` — instance + group chains ignore a leaked scratch env
- `TestResolveClaudeConfigDir_NormalEnv_StillHonored` — control: normal env override unaffected

All six existing `issue1222_credentials_symlink_reassert_test.go` regressions still pass (incl. `NewerScratchCredentials_NeverPromoted`).

Sandboxed (`HOME=$(mktemp -d)`, XDG cleared) `go test -race` on `internal/session` + `internal/childenv`: the only failures are pre-existing/environmental on the test box (inotify exhaustion at 126/128 instances from the live agent fleet, plus one perf-budget test) — verified to fail identically on unmodified `main`. `golangci-lint`: 0 issues.

## Notes

- Adjacent to #1377 (related credential/config-dir resolution surface) — flagging for the reviewer to assess interaction.
- **Do not merge yet** — opened for review per the investigation hand-off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential handling in nested sandbox environments to prevent configuration directory leaks.
  * Enhanced configuration directory resolution to properly fall back to profile defaults when necessary.

* **Tests**
  * Added comprehensive regression tests for credential symlink reassertion and configuration directory source resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
