### PR TITLE
ci: enable gofmt linter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 linters:
   enable:
+    - gofmt
     - gosec
     - forbidigo
   settings:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 version: "2"
 linters:
   enable:
-    - gofmt
     - gosec
     - forbidigo
   settings:
@@ -110,6 +109,8 @@ linters:
       - builtin$
       - examples$
 formatters:
+  enable:
+    - gofmt
   exclusions:
     generated: lax
     paths:

--- a/internal/session/builtins.go
+++ b/internal/session/builtins.go
@@ -5,10 +5,10 @@ package session
 // Before this file, the built-in list lived split across two hand-synced
 // functions (issue #1258):
 //   - detectTool()        in cmd/agent-deck/main.go  — the strings.Contains
-//                          heuristic dispatcher (command string -> tool name).
+//     heuristic dispatcher (command string -> tool name).
 //   - isBuiltinToolName()  in internal/session/userconfig.go — the strict
-//                          allowlist used to stop custom [tools.<name>] entries
-//                          from shadowing a built-in.
+//     allowlist used to stop custom [tools.<name>] entries
+//     from shadowing a built-in.
 //
 // Both are now derived from the single builtinTools() slice below.
 //

--- a/internal/session/hermes.go
+++ b/internal/session/hermes.go
@@ -190,4 +190,3 @@ func GetHermesGatewayURL() string {
 	}
 	return DiscoverHermesGatewayURL()
 }
-

--- a/internal/session/issue962_target_busy_ttl_test.go
+++ b/internal/session/issue962_target_busy_ttl_test.go
@@ -18,7 +18,6 @@ import (
 // entries spanning 4 days (7 unique children) growing unbounded on every
 // busy day.
 
-
 // TestTransitionNotifier_TargetBusyEntries_TTLEnforced_RegressionFor962Variant
 // asserts: inbox entries persisted longer ago than the configured TTL
 // are removed by the TTL sweep. Without this, even a fixed cleanup-on-

--- a/internal/ui/settings_panel.go
+++ b/internal/ui/settings_panel.go
@@ -101,10 +101,10 @@ type SettingsPanel struct {
 	statsShowGPU        bool
 	statsShowLoad       bool
 
-	showSessionTimestamps   bool
-	showPaneTitles          bool
-	showOnlyInstalledTools  bool
-	pendingToolVisibility   bool
+	showSessionTimestamps  bool
+	showPaneTitles         bool
+	showOnlyInstalledTools bool
+	pendingToolVisibility  bool
 
 	// Text input state
 	editingText bool

--- a/tests/capability/issue1225_busy_parent_test.go
+++ b/tests/capability/issue1225_busy_parent_test.go
@@ -91,14 +91,14 @@ func TestCapability_Issue1225_BusyParentReceivesCompletionAtTurnBoundary(t *test
 
 	// PHASE 1: the child finishes WHILE the parent is busy → durable commit only.
 	c.commitToParentInbox(t, parent.ID, map[string]any{
-		"child_session_id": child.ID,
-		"child_title":      "busy-child",
-		"profile":          "default",
-		"from_status":      "running",
-		"to_status":        "waiting",
-		"timestamp":        time.Now().Format(time.RFC3339Nano),
+		"child_session_id":  child.ID,
+		"child_title":       "busy-child",
+		"profile":           "default",
+		"from_status":       "running",
+		"to_status":         "waiting",
+		"timestamp":         time.Now().Format(time.RFC3339Nano),
 		"target_session_id": parent.ID,
-		"turn_fingerprint": child.ID + "@turn-busy-1",
+		"turn_fingerprint":  child.ID + "@turn-busy-1",
 	})
 
 	// DURABILITY: while the parent stays busy, the record persists on disk.


### PR DESCRIPTION
Formatting violations can currently slip through CI undetected — caught
one during PR #1383 review. Adding gofmt to the explicit linter list
ensures struct field alignment and other formatting issues are flagged
before merge.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled the Go source formatter in the linting/formatting configuration to enforce consistent formatting.

* **Style**
  * Reformatted struct field alignment and adjusted various whitespace/line endings across the codebase; no behavior changes.

* **Tests**
  * Updated test file formatting and comment layout without altering assertions or logic.

* **Documentation**
  * Clarified an internal comment describing a consolidation of builtin tool handling; no API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->