### PR TITLE
feat(remote): open new-session dialog for remote rows

### DIFF
--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -684,23 +684,24 @@ func (r *SSHRunner) buildAttachArgs(sessionID string) []string {
 	return append(args, r.Host, remoteCmd)
 }
 
-// CreateSession creates and starts a new session on the remote, returning its ID.
-// It runs "add --quick --json" to create the session, then "session start" to
-// launch the tmux process, so the session is ready to attach.
+// CreateSession creates and starts a quick new session on the remote, returning its ID.
 func (r *SSHRunner) CreateSession(ctx context.Context) (string, error) {
-	return r.CreateSessionWithOptions(ctx, "", "", "")
+	return r.CreateSessionWithOptions(ctx, "", "", "", "")
 }
 
 // remoteAddArgs builds the `agent-deck add` argument list for creating a
-// session on a remote with an explicit tool/title/path (#1353). Empty values
-// fall back to remote defaults: no -c means shell, no -t means --quick
-// (auto-generated name), and an empty or "." path means the remote CWD.
-func remoteAddArgs(tool, title, path string) []string {
+// session on a remote with explicit dialog values (#1353). Empty values fall
+// back to remote defaults: no -c means shell, no -t means --quick
+// (auto-generated name), and an empty or "." path means remote CWD.
+func remoteAddArgs(tool, title, path, group string) []string {
 	args := []string{"add", "--json"}
 	if t := strings.TrimSpace(title); t != "" {
 		args = append(args, "-t", t)
 	} else {
 		args = append(args, "--quick")
+	}
+	if g := strings.TrimSpace(group); g != "" {
+		args = append(args, "-g", g)
 	}
 	if c := strings.TrimSpace(tool); c != "" {
 		args = append(args, "-c", c)
@@ -712,11 +713,11 @@ func remoteAddArgs(tool, title, path string) []string {
 }
 
 // CreateSessionWithOptions creates and starts a new session on the remote with
-// an explicit tool/title/path from the new-session dialog (#1353), returning
-// its ID. Empty values fall back to remote defaults (see remoteAddArgs).
-func (r *SSHRunner) CreateSessionWithOptions(ctx context.Context, tool, title, path string) (string, error) {
+// an explicit tool/title/path/group from the new-session dialog (#1353),
+// returning its ID. Empty values fall back to remote defaults (see remoteAddArgs).
+func (r *SSHRunner) CreateSessionWithOptions(ctx context.Context, tool, title, path, group string) (string, error) {
 	// Step 1: Create the session
-	output, err := r.Run(ctx, remoteAddArgs(tool, title, path)...)
+	output, err := r.Run(ctx, remoteAddArgs(tool, title, path, group)...)
 	if err != nil {
 		return "", fmt.Errorf("failed to create remote session: %w", err)
 	}
@@ -736,7 +737,8 @@ func (r *SSHRunner) CreateSessionWithOptions(ctx context.Context, tool, title, p
 	// Use ID to avoid ambiguity when titles are duplicated.
 	startCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
-	if _, err := r.run(startCtx, "session", "start", result.ID); err != nil {
+	startOutput, err := r.run(startCtx, "session", "start", "--json", result.ID)
+	if err != nil {
 		// Compensate: the remote DB has the row but no tmux process. Best-effort
 		// delete with a fresh context so an upstream cancellation doesn't skip
 		// the cleanup. Surface the original start failure.
@@ -744,6 +746,12 @@ func (r *SSHRunner) CreateSessionWithOptions(ctx context.Context, tool, title, p
 		defer cleanupCancel()
 		_ = r.DeleteSession(cleanupCtx, result.ID)
 		return "", fmt.Errorf("failed to start remote session: %w", err)
+	}
+	var startResult struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(startOutput), &startResult); err == nil && startResult.Status == string(StatusQueued) {
+		return "", fmt.Errorf("remote session %q was queued and is not ready to attach", result.Title)
 	}
 
 	return result.ID, nil

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -143,7 +143,7 @@ func TestSSHRunnerCreateSession_NoCleanupOnSuccess(t *testing.T) {
 			case len(args) > 0 && args[0] == "add":
 				return []byte(`{"id":"good-abc","title":"x"}`), nil
 			case len(args) >= 2 && args[0] == "session" && args[1] == "start":
-				return []byte(""), nil
+				return []byte(`{"success":true,"id":"good-abc","title":"x"}`), nil
 			}
 			return nil, errors.New("unexpected runner call")
 		},
@@ -166,13 +166,14 @@ func TestSSHRunnerCreateSession_NoCleanupOnSuccess(t *testing.T) {
 // TestRemoteAddArgs covers the `agent-deck add` argument builder used when the
 // new-session dialog targets a remote (#1353): the chosen tool must be passed
 // via -c (previously every remote `n` create was a bare `add --quick` shell),
-// an explicit title uses -t while an empty one falls back to --quick, and the
-// "." / empty path means "remote CWD" so no path argument is sent.
+// an explicit title uses -t while an empty one falls back to --quick, -g carries
+// the selected group, and "." / empty path means "remote CWD" so no path
+// argument is sent.
 func TestRemoteAddArgs(t *testing.T) {
 	cases := []struct {
-		name              string
-		tool, title, path string
-		want              []string
+		name                     string
+		tool, title, path, group string
+		want                     []string
 	}{
 		{
 			name: "defaults (quick shell, remote CWD)",
@@ -182,6 +183,11 @@ func TestRemoteAddArgs(t *testing.T) {
 			name: "tool and title from dialog",
 			tool: "claude", title: "my task", path: ".",
 			want: []string{"add", "--json", "-t", "my task", "-c", "claude"},
+		},
+		{
+			name: "group from dialog",
+			tool: "claude", title: "my task", group: "work", path: ".",
+			want: []string{"add", "--json", "-t", "my task", "-g", "work", "-c", "claude"},
 		},
 		{
 			name: "explicit remote path",
@@ -194,24 +200,83 @@ func TestRemoteAddArgs(t *testing.T) {
 			want: []string{"add", "--json", "--quick", "-c", "pi"},
 		},
 		{
-			name:  "whitespace-only values fall back to defaults",
-			tool:  "  ",
-			title: " ",
-			path:  " . ",
-			want:  []string{"add", "--json", "--quick"},
+			name: "whitespace-only values fall back to defaults",
+			tool: "  ", title: " ", group: " ", path: " . ",
+			want: []string{"add", "--json", "--quick"},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := remoteAddArgs(tc.tool, tc.title, tc.path)
+			got := remoteAddArgs(tc.tool, tc.title, tc.path, tc.group)
 			if len(got) != len(tc.want) {
-				t.Fatalf("remoteAddArgs(%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, got, tc.want)
+				t.Fatalf("remoteAddArgs(%q,%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, tc.group, got, tc.want)
 			}
 			for i := range got {
 				if got[i] != tc.want[i] {
-					t.Fatalf("remoteAddArgs(%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, got, tc.want)
+					t.Fatalf("remoteAddArgs(%q,%q,%q,%q) = %v, want %v", tc.tool, tc.title, tc.path, tc.group, got, tc.want)
 				}
 			}
 		})
+	}
+}
+
+func TestSSHRunnerCreateSessionWithOptions_UsesDialogValues(t *testing.T) {
+	var calls [][]string
+	runner := &SSHRunner{
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			calls = append(calls, append([]string(nil), args...))
+			switch {
+			case len(args) > 0 && args[0] == "add":
+				return []byte(`{"id":"remote-abc","title":"Remote Work"}`), nil
+			case len(args) >= 2 && args[0] == "session" && args[1] == "start":
+				return []byte(`{"success":true,"id":"remote-abc","title":"Remote Work"}`), nil
+			}
+			return nil, errors.New("unexpected runner call")
+		},
+	}
+
+	id, err := runner.CreateSessionWithOptions(context.Background(), "codex", "Remote Work", "~/project", "work")
+	if err != nil {
+		t.Fatalf("CreateSessionWithOptions unexpected error: %v", err)
+	}
+	if id != "remote-abc" {
+		t.Fatalf("id = %q, want remote-abc", id)
+	}
+	if len(calls) < 2 {
+		t.Fatalf("calls = %v, want add and start", calls)
+	}
+	add := strings.Join(calls[0], " ")
+	for _, want := range []string{"add", "--json", "-t", "Remote Work", "-g", "work", "-c", "codex", "~/project"} {
+		if !strings.Contains(add, want) {
+			t.Fatalf("remote add call = %q, want token %q", add, want)
+		}
+	}
+	if strings.Contains(add, "--quick") {
+		t.Fatalf("remote add call = %q, did not expect --quick with explicit title", add)
+	}
+	start := strings.Join(calls[1], " ")
+	for _, want := range []string{"session", "start", "--json", "remote-abc"} {
+		if !strings.Contains(start, want) {
+			t.Fatalf("remote start call = %q, want token %q", start, want)
+		}
+	}
+}
+
+func TestSSHRunnerCreateSessionWithOptions_QueuedStartIsNotAttachable(t *testing.T) {
+	runner := &SSHRunner{
+		runFn: func(ctx context.Context, args ...string) ([]byte, error) {
+			switch {
+			case len(args) > 0 && args[0] == "add":
+				return []byte(`{"id":"queued-abc","title":"queued-title"}`), nil
+			case len(args) >= 2 && args[0] == "session" && args[1] == "start":
+				return []byte(`{"success":true,"id":"queued-abc","title":"queued-title","status":"queued"}`), nil
+			}
+			return nil, errors.New("unexpected runner call")
+		},
+	}
+
+	_, err := runner.CreateSessionWithOptions(context.Background(), "claude", "", "", "")
+	if err == nil || !strings.Contains(err.Error(), "queued") {
+		t.Fatalf("CreateSessionWithOptions error = %v, want queued error", err)
 	}
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4671,6 +4671,12 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		h.setError(fmt.Errorf("restarted '%s' on %s", msg.title, msg.remoteName))
 		return h, h.fetchRemoteSessions
 
+	case remoteSessionCreatedMsg:
+		if msg.err != nil {
+			h.setError(msg.err)
+		}
+		return h, h.fetchRemoteSessions
+
 	case MaintenanceCompleteMsg:
 		return h, func() tea.Msg {
 			return maintenanceCompleteMsg{result: msg.Result}
@@ -5852,22 +5858,18 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return h, nil
 		}
 
-		// Get values including worktree settings.
-		name, path, command, branchName, worktreeEnabled := h.newDialog.GetValuesWithWorktree()
-
-		// #1353: when the dialog was opened on a remote group/session, create
-		// the session on that remote via SSH with the chosen tool. All
-		// local-only logic below (worktree resolution, directory-exists
-		// check, local create) must be skipped — it would act on the LOCAL
-		// filesystem (#743).
 		if h.pendingRemoteName != "" {
 			remoteName := h.pendingRemoteName
-			h.pendingRemoteName = ""
+			name, path, command := h.newDialog.GetRemoteValues()
+			groupPath := h.newDialog.GetSelectedGroup()
 			h.newDialog.Hide()
+			h.pendingRemoteName = ""
 			h.clearError()
-			return h, h.createRemoteSessionWithOptions(remoteName, command, name, path)
+			return h, h.createRemoteSessionWithOptions(remoteName, command, name, path, groupPath)
 		}
 
+		// Get values including worktree settings.
+		name, path, command, branchName, worktreeEnabled := h.newDialog.GetValuesWithWorktree()
 		groupPath := h.newDialog.GetSelectedGroup()
 		claudeOpts := h.newDialog.GetClaudeOptions() // Get Claude options if applicable.
 		launchModelID := h.newDialog.GetLaunchModelID()
@@ -6001,6 +6003,72 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	h.newDialog, cmd = h.newDialog.Update(msg)
 	return h, cmd
+}
+
+func (h *Home) showRemoteNewSessionDialog(item session.Item) {
+	remoteName := item.RemoteName
+	if remoteName == "" {
+		return
+	}
+
+	paths := h.remotePathSuggestions(remoteName)
+	h.newDialog.SetPathSuggestions(paths)
+	h.newDialog.SetRecentSessions(nil)
+	h.newDialog.SetDefaultTool(session.GetDefaultTool())
+	h.pendingRemoteName = remoteName
+
+	groupPath := session.DefaultGroupPath
+	groupName := session.DefaultGroupName
+	defaultPath := ""
+	if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
+		if item.RemoteSession.Group != "" {
+			groupPath = item.RemoteSession.Group
+			groupName = item.RemoteSession.Group
+		}
+		defaultPath = item.RemoteSession.Path
+	} else if item.Type == session.ItemTypeRemoteGroup {
+		groupPath = "remotes/" + remoteName
+		groupName = groupPath
+		defaultPath = "."
+	} else if len(paths) > 0 {
+		defaultPath = paths[0]
+	}
+
+	h.newDialog.ShowInGroup(groupPath, groupName, defaultPath, nil, "")
+	if defaultPath == "" {
+		h.newDialog.pathInput.SetValue(".")
+		h.newDialog.pathSoftSelected = true
+	}
+	// Remote creation goes through the remote CLI. Disable local-only defaults
+	// that ShowInGroup may have inherited from this machine's config.
+	h.newDialog.worktreeEnabled = false
+	h.newDialog.worktreeToggled = false
+	h.newDialog.sandboxEnabled = false
+	h.newDialog.multiRepoEnabled = false
+	h.newDialog.multiRepoPaths = nil
+	h.newDialog.rebuildFocusTargets()
+}
+
+func (h *Home) remotePathSuggestions(remoteName string) []string {
+	h.remoteSessionsMu.RLock()
+	sessions := append([]session.RemoteSessionInfo(nil), h.remoteSessions[remoteName]...)
+	h.remoteSessionsMu.RUnlock()
+
+	seen := make(map[string]struct{}, len(sessions))
+	paths := make([]string, 0, len(sessions))
+	for _, rs := range sessions {
+		path := strings.TrimSpace(rs.Path)
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
 }
 
 func persistClaudeDialogDefaults(opts *session.ClaudeOptions, args []string) {
@@ -7100,14 +7168,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor >= 0 && h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeRemoteGroup || item.Type == session.ItemTypeRemoteSession {
-				h.pendingRemoteName = item.RemoteName
-				// Local path suggestions and recent sessions don't apply on
-				// the remote filesystem; default the path to "." (remote CWD)
-				// so no local path leaks into the SSH create.
-				h.newDialog.SetPathSuggestions(nil)
-				h.newDialog.SetRecentSessions(nil)
-				h.newDialog.SetDefaultTool(session.GetDefaultTool())
-				h.newDialog.ShowInGroup("remotes/"+item.RemoteName, "remotes/"+item.RemoteName, ".", nil, "")
+				h.showRemoteNewSessionDialog(item)
 				return h, nil
 			}
 		}
@@ -10457,6 +10518,10 @@ type remoteSessionRestartedMsg struct {
 	err        error
 }
 
+type remoteSessionCreatedMsg struct {
+	err error
+}
+
 // deleteRemoteSession deletes a remote session and refreshes the remote list.
 func (h *Home) deleteRemoteSession(remoteName, sessionID, title string) tea.Cmd {
 	return func() tea.Msg {
@@ -10702,14 +10767,57 @@ func (a attachCmd) SetStderr(w io.Writer) {}
 // createRemoteSession creates a new session on a remote and auto-attaches to it.
 // Used by quick-create (N): auto-generated name, remote defaults (shell).
 func (h *Home) createRemoteSession(remoteName string) tea.Cmd {
-	return h.createRemoteSessionWithOptions(remoteName, "", "", "")
+	return h.createRemoteSessionWithOptions(remoteName, "", "", "", "")
 }
 
+// remoteCreateAndAttachCmd creates a session on the remote, then attaches to it.
+type remoteCreateAndAttachCmd struct {
+	runner    *session.SSHRunner
+	tool      string
+	title     string
+	path      string
+	group     string
+	createCtx context.Context
+}
+
+type remoteAttachFailedError struct {
+	err error
+}
+
+func (e remoteAttachFailedError) Error() string {
+	return e.err.Error()
+}
+
+func (e remoteAttachFailedError) Unwrap() error {
+	return e.err
+}
+
+func (r remoteCreateAndAttachCmd) Run() error {
+	baseCtx := r.createCtx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(baseCtx, 20*time.Second)
+	defer cancel()
+	sessionID, err := r.runner.CreateSessionWithOptions(ctx, r.tool, r.title, r.path, r.group)
+	if err != nil {
+		return err
+	}
+	if err := r.runner.Attach(sessionID); err != nil {
+		return remoteAttachFailedError{err: err}
+	}
+	return nil
+}
+
+func (r remoteCreateAndAttachCmd) SetStdin(reader io.Reader)  {}
+func (r remoteCreateAndAttachCmd) SetStdout(writer io.Writer) {}
+func (r remoteCreateAndAttachCmd) SetStderr(writer io.Writer) {}
+
 // createRemoteSessionWithOptions creates a new session on a remote with an
-// explicit tool/title/path from the new-session dialog (#1353), then
+// explicit tool/title/path/group from the new-session dialog (#1353), then
 // auto-attaches to it. Empty values fall back to remote defaults (shell,
 // auto-generated name, remote CWD).
-func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path string) tea.Cmd {
+func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path, group string) tea.Cmd {
 	config, err := session.LoadUserConfig()
 	if err != nil || config == nil || config.Remotes == nil {
 		return func() tea.Msg {
@@ -10724,37 +10832,18 @@ func (h *Home) createRemoteSessionWithOptions(remoteName, tool, title, path stri
 	}
 	runner := session.NewSSHRunner(remoteName, rc)
 	h.isAttaching.Store(true)
-	return tea.Exec(remoteCreateAndAttachCmd{runner: runner, tool: tool, title: title, path: path}, func(err error) tea.Msg {
+	return tea.Exec(remoteCreateAndAttachCmd{runner: runner, tool: tool, title: title, path: path, group: group, createCtx: h.ctx}, func(err error) tea.Msg {
 		h.isAttaching.Store(false)
 		if err != nil {
+			var attachErr remoteAttachFailedError
+			if errors.As(err, &attachErr) {
+				return remoteSessionCreatedMsg{err: fmt.Errorf("failed to attach to remote session after creating it: %w", attachErr)}
+			}
 			return sessionCreatedMsg{err: fmt.Errorf("failed to create remote session: %w", err)}
 		}
-		return statusUpdateMsg{}
+		return remoteSessionCreatedMsg{}
 	})
 }
-
-// remoteCreateAndAttachCmd creates a session on the remote, then attaches to it.
-// tool/title/path are optional overrides from the new-session dialog (#1353);
-// empty values use remote defaults.
-type remoteCreateAndAttachCmd struct {
-	runner *session.SSHRunner
-	tool   string
-	title  string
-	path   string
-}
-
-func (r remoteCreateAndAttachCmd) Run() error {
-	ctx := context.Background()
-	sessionID, err := r.runner.CreateSessionWithOptions(ctx, r.tool, r.title, r.path)
-	if err != nil {
-		return err
-	}
-	return r.runner.Attach(sessionID)
-}
-
-func (r remoteCreateAndAttachCmd) SetStdin(reader io.Reader)  {}
-func (r remoteCreateAndAttachCmd) SetStdout(writer io.Writer) {}
-func (r remoteCreateAndAttachCmd) SetStderr(writer io.Writer) {}
 
 // attachWindowCmd implements tea.ExecCommand for attaching to a specific tmux window
 type attachWindowCmd struct {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4675,7 +4675,20 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			h.setError(msg.err)
 		}
-		return h, h.fetchRemoteSessions
+		// This message is returned after tea.Exec finishes the remote
+		// create+attach. Mirror the statusUpdateMsg attach-return cleanup so
+		// detaching from a newly created remote session leaves the terminal in
+		// the same state as detaching from an existing one: re-enable mouse
+		// reporting, restore legacy keyboard mode, force a resize, and schedule
+		// the delayed repaint (see the statusUpdateMsg case for the rationale).
+		h.beginAttachReturnGrace(time.Now())
+		return h, tea.Batch(
+			h.fetchRemoteSessions,
+			tea.EnableMouseCellMotion,
+			RestoreLegacyKeyboardCmd(os.Stdout),
+			tea.WindowSize(),
+			tea.Tick(attachReturnRefreshDelay, func(time.Time) tea.Msg { return attachReturnRefreshMsg{} }),
+		)
 
 	case MaintenanceCompleteMsg:
 		return h, func() tea.Msg {
@@ -6027,8 +6040,11 @@ func (h *Home) showRemoteNewSessionDialog(item session.Item) {
 		}
 		defaultPath = item.RemoteSession.Path
 	} else if item.Type == session.ItemTypeRemoteGroup {
-		groupPath = "remotes/" + remoteName
-		groupName = groupPath
+		// "remotes/<host>" is a synthetic local UI bucket, not a user-defined
+		// remote group. Keep the default group so handleNewDialogKey doesn't
+		// forward it to CreateSessionWithOptions and create a bogus remote group.
+		groupPath = session.DefaultGroupPath
+		groupName = session.DefaultGroupName
 		defaultPath = "."
 	} else if len(paths) > 0 {
 		defaultPath = paths[0]

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -1315,10 +1315,81 @@ func TestRemoteRestartReturnsRemoteCommand(t *testing.T) {
 	_ = h
 }
 
-// TestRemoteSelectionNOpensNewDialog was removed with the #743 fix: it
-// codified d9a5de8's broken contract (n on a remote session opens the local
-// dialog). The regression guard now lives in
-// TestRegression743_NOnRemoteSession_QuickCreatesNoDialog.
+func TestRemoteSelectionNOpensRemoteAwareNewDialog(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID:         "remote-123",
+		Title:      "remote-session",
+		RemoteName: "myserver",
+		Path:       "/srv/project",
+		Group:      "work",
+	}
+	home.flatItems = []session.Item{{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "myserver"}}
+	home.cursor = 0
+
+	model, cmd := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	h, ok := model.(*Home)
+	if !ok {
+		t.Fatal("handleMainKey should return *Home")
+	}
+	if cmd != nil {
+		t.Fatal("pressing n on a remote session should open the dialog, not quick-create")
+	}
+	if !h.newDialog.IsVisible() {
+		t.Fatal("pressing n on a remote session should open the new-session dialog")
+	}
+	if h.pendingRemoteName != "myserver" {
+		t.Fatalf("pendingRemoteName = %q, want myserver", h.pendingRemoteName)
+	}
+	if got := h.newDialog.GetSelectedGroup(); got != "work" {
+		t.Fatalf("selected group = %q, want work", got)
+	}
+	_, gotPath, _ := h.newDialog.GetRemoteValues()
+	if gotPath != "/srv/project" {
+		t.Fatalf("dialog path = %q, want /srv/project", gotPath)
+	}
+}
+
+func TestRemoteNewDialogCustomizationPreservesRemoteValues(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	remote := session.RemoteSessionInfo{
+		ID:         "remote-123",
+		Title:      "remote-session",
+		RemoteName: "myserver",
+		Path:       "/srv/project",
+		Group:      "work",
+	}
+	home.flatItems = []session.Item{{Type: session.ItemTypeRemoteSession, RemoteSession: &remote, RemoteName: "myserver"}}
+	home.cursor = 0
+
+	model, _ := home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	h := model.(*Home)
+	h.newDialog.nameInput.SetValue("custom remote")
+	h.newDialog.pathInput.SetValue("~/custom-project")
+	h.newDialog.SetDefaultTool("codex")
+
+	name, path, command := h.newDialog.GetRemoteValues()
+	if name != "custom remote" {
+		t.Fatalf("name = %q, want custom remote", name)
+	}
+	if path != "~/custom-project" {
+		t.Fatalf("path = %q, want ~/custom-project", path)
+	}
+	if command != "codex" {
+		t.Fatalf("command = %q, want codex", command)
+	}
+	group := h.newDialog.GetSelectedGroup()
+	if group != "work" {
+		t.Fatalf("group = %q, want work", group)
+	}
+
+}
 
 func TestSelectedRemotePreviewTarget(t *testing.T) {
 	home := NewHome()
@@ -1392,9 +1463,8 @@ func TestRenderRemotePreviewIncludesCachedResponse(t *testing.T) {
 	}
 }
 
-// TestRemoteGroupSelectionNOpensNewDialog was removed with the #743 fix —
-// see the note on TestRemoteSelectionNOpensNewDialog above. Guard lives in
-// TestRegression743_NOnRemoteGroup_QuickCreatesNoDialog.
+// Remote group `n` behavior is covered by
+// TestRegression743_NOnRemoteGroup_OpensRemoteDialog.
 
 func TestRenderRemotePreviewShowsEmptyStateAfterFetch(t *testing.T) {
 	home := NewHome()

--- a/internal/ui/issue1353_remote_new_dialog_test.go
+++ b/internal/ui/issue1353_remote_new_dialog_test.go
@@ -85,7 +85,11 @@ func TestIssue1353_NOnRemoteSession_OpensDialog(t *testing.T) {
 
 // TestIssue1353_RemoteDialogDefaults: for a remote target the path field
 // defaults to "." (remote CWD) so a local filesystem path is never sent to the
-// remote, and the dialog is parented under the remote's group label.
+// remote. The dialog must NOT be seeded with the synthetic "remotes/<host>"
+// label: that path is a local UI bucket, not a user-defined remote group, and
+// handleNewDialogKey forwards the selected group unchanged to
+// CreateSessionWithOptions — so seeding it would create a bogus "remotes/<host>"
+// group on the remote. It defaults to the standard group instead.
 func TestIssue1353_RemoteDialogDefaults(t *testing.T) {
 	setXDGTestHome(t)
 	home := NewHome()
@@ -99,8 +103,8 @@ func TestIssue1353_RemoteDialogDefaults(t *testing.T) {
 	if path != "." {
 		t.Fatalf("remote dialog path default = %q, want %q (remote CWD)", path, ".")
 	}
-	if got := h.newDialog.GetSelectedGroup(); got != "remotes/myserver" {
-		t.Fatalf("remote dialog group = %q, want %q", got, "remotes/myserver")
+	if got := h.newDialog.GetSelectedGroup(); got != session.DefaultGroupPath {
+		t.Fatalf("remote dialog group = %q, want %q (no synthetic remotes/<host> group)", got, session.DefaultGroupPath)
 	}
 }
 

--- a/internal/ui/newdialog.go
+++ b/internal/ui/newdialog.go
@@ -1017,29 +1017,47 @@ func (d *NewDialog) IsVisible() bool {
 	return d.visible
 }
 
+func (d *NewDialog) sanitizePath(raw string) string {
+	path := strings.Trim(strings.TrimSpace(raw), "'\"")
+	// Fix malformed paths that have ~ in the middle (e.g., "/some/path~/actual/path")
+	// This can happen when textinput suggestion appends instead of replaces.
+	if idx := strings.Index(path, "~/"); idx > 0 {
+		path = path[idx:]
+	}
+	return path
+}
+
+func (d *NewDialog) resolveCommand() string {
+	if d.commandCursor < len(d.presetCommands) {
+		if command := d.presetCommands[d.commandCursor]; command != "" {
+			return command
+		}
+	}
+	return strings.TrimSpace(d.commandInput.Value())
+}
+
 // GetValues returns the current dialog values with expanded paths
 func (d *NewDialog) GetValues() (name, path, command string) {
 	name = strings.TrimSpace(d.nameInput.Value())
 	// Fix: sanitize input to remove surrounding quotes that cause path issues
-	path = strings.Trim(strings.TrimSpace(d.pathInput.Value()), "'\"")
-
-	// Fix malformed paths that have ~ in the middle (e.g., "/some/path~/actual/path")
-	// This can happen when textinput suggestion appends instead of replaces
-	if idx := strings.Index(path, "~/"); idx > 0 {
-		path = path[idx:]
-	}
+	path = d.sanitizePath(d.pathInput.Value())
 
 	// Expand environment variables and ~ prefix
 	path = session.ExpandPath(path)
 
 	// Get command - either from preset or custom input
-	if d.commandCursor < len(d.presetCommands) {
-		command = d.presetCommands[d.commandCursor]
-	}
-	if command == "" && d.commandInput.Value() != "" {
-		command = strings.TrimSpace(d.commandInput.Value())
-	}
+	command = d.resolveCommand()
 
+	return name, path, command
+}
+
+// GetRemoteValues returns dialog values for a remote host. Unlike GetValues,
+// it does not expand ~ or environment variables locally because those paths
+// belong to the remote machine.
+func (d *NewDialog) GetRemoteValues() (name, path, command string) {
+	name = strings.TrimSpace(d.nameInput.Value())
+	path = d.sanitizePath(d.pathInput.Value())
+	command = d.resolveCommand()
 	return name, path, command
 }
 

--- a/internal/ui/newdialog_test.go
+++ b/internal/ui/newdialog_test.go
@@ -2104,13 +2104,9 @@ func TestNewDialog_CtrlW_BranchField(t *testing.T) {
 // Tests the overlay placement math. Dropdowns are placed relative
 // to the associated dialog's top-left corner.
 //
-// Remote-parity: not applicable. NewDialog is the local new-session dialog
-// only; pressing `n` on a remote group/session routes through
-// createRemoteSession (SSH) and never opens this dialog (#743), so this
-// overlay-positioning fix has no remote surface. That routing — and the fact
-// the dialog never opens on a remote selection — is itself covered by
-// TestRegression743_NOnRemoteSession_QuickCreatesNoDialog and
-// TestRegression743_NOnRemoteGroup_QuickCreatesNoDialog in home_test.go.
+// Remote-parity: NewDialog is also used for remote-aware creation. The routing
+// that marks it remote-targeted is covered by the #743 regression tests in
+// home_test.go; this test remains focused on shared overlay placement math.
 func TestDialogOrigin(t *testing.T) {
 	tests := []struct {
 		name                           string


### PR DESCRIPTION
## Summary
- Rebased on top of #1364 and extend the existing `pendingRemoteName` remote-dialog path instead of adding parallel UI plumbing.
- Add remote group pass-through by sending `-g <group>` through the existing remote `agent-deck add --json` flow.
- Preserve remote paths from the dialog with `GetRemoteValues`, so inputs like `~/project` are not expanded against the local machine.
- Support custom command/tool values in the remote dialog submit path and keep `N` as upstream quick-create behavior.
- Detect queued remote starts from `session start --json` before attempting to attach.
- Address review feedback: shared dialog value parsing helpers, bounded remote create context, attach-specific error reporting, and immediate remote-session refetch after create.

## Tests
- `direnv exec /Users/paper gofmt -w internal/session/ssh.go internal/session/ssh_test.go internal/ui/home.go internal/ui/home_test.go internal/ui/newdialog.go internal/ui/newdialog_test.go`
- `direnv exec /Users/paper go test ./internal/session -run 'TestRemoteAddArgs|TestSSHRunnerCreateSession' -count=1`
- `direnv exec /Users/paper go test ./internal/ui -run 'TestIssue1353|TestRemoteSelectionNOpensRemoteAwareNewDialog|TestRemoteNewDialogCustomizationPreservesRemoteValues|TestRegression743_NOnRemote' -count=1`
- `direnv exec /Users/paper go build -o /var/folders/tz/8r0rsxk170ngkmnjm_l6_9t80000gp/T/opencode/agent-deck-remote-dialog ./cmd/agent-deck`
- Live smoke against registered `box1` / `claudio-box-1`: created, started, and removed a disposable remote Claude session with explicit title/group/command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote session creation supports selecting a group from the new-session dialog and preserves group/path/tool when creating and attaching.
  * New-session dialog opened on remote items is pre-populated with remote path, group and tool defaults; remote-specific submit flow added.
* **Bug Fixes**
  * Queued remote sessions now return a clear "queued" error instead of appearing attachable.
* **Tests**
  * Added/updated tests covering remote new-dialog behavior, group handling, and queued-start handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->