### PR TITLE
ci: run full go test suite on PRs (#1363)

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,81 @@
+# Full Go test suite as a PR gate (#1363, proposed by @spawnia).
+#
+# Why this exists: the per-package PR smoke gates (perf-smoke,
+# session-persistence, eval-smoke, golangci-lint) each run a SUBSET of the
+# suite, so a regression that only manifests when the WHOLE suite runs
+# together — shared global state, cross-package ordering, data races surfaced
+# only under `-race ./...` — slips past PR review and is caught for the first
+# time at the release gate. That happened four times: it broke the
+# v1.9.49 / v1.9.50 / v1.9.51 / v1.9.53 releases.
+#
+# This workflow closes that gap by running the EXACT proven release-gate test
+# step (release.yml "Run tests") on every PR, so full-suite-only regressions
+# fail at PR time instead of blocking a release.
+#
+# Steel-thread parity: the toolchain setup, the zoxide dependency, the
+# PERF_BUDGET_MULTIPLIER env, and the gotestsum invocation are copied verbatim
+# from .github/workflows/release.yml. Keep them in lockstep — if the release
+# gate's test step changes, mirror it here.
+
+name: Go tests
+
+on:
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/go-test.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/go-test.yml'
+
+# One in-flight run per PR (or per branch on push). Rapid follow-up pushes
+# cancel the stale run instead of stacking 20-minute jobs.
+concurrency:
+  group: go-test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  full-test-suite:
+    name: Full test suite (PR gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      # tmux + zoxide back the session and quick-open picker tests that the
+      # full `./...` run exercises. tmux is preinstalled on ubuntu-latest (the
+      # release gate relies on that); install both explicitly here so this gate
+      # is never weaker than the release gate it mirrors.
+      - name: Install tmux and zoxide
+        timeout-minutes: 5
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y tmux zoxide
+          tmux -V
+          zoxide --version
+
+      # Mirrors release.yml "Run tests" exactly — same gotestsum flags, same
+      # -race, same 20m per-package timeout, same PERF_BUDGET_MULTIPLIER.
+      - name: Run tests
+        timeout-minutes: 30
+        env:
+          PERF_BUDGET_MULTIPLIER: '2.0'
+        run: |
+          go install gotest.tools/gotestsum@v1.13.0
+          gotestsum --rerun-fails=2 --rerun-fails-abort-on-data-race --packages="./..." -- -race -timeout 20m


### PR DESCRIPTION
## What

Adds `.github/workflows/go-test.yml` — a CI gate that runs the **full** Go test suite on every PR (and on pushes to `main`), closing #1363.

## Why

The release gate (`release.yml`) already runs the whole suite under `-race`, but PR CI only ran **subsets** (perf-smoke, session-persistence, eval-smoke, golangci-lint). So regressions that only manifest when the *whole* suite runs together — shared global state, cross-package test ordering, data races surfaced only under `-race ./...` — sailed past PR review and were caught for the first time at the **release** gate.

That has now broken **four** releases:

- **v1.9.49**
- **v1.9.50**
- **v1.9.51**
- **v1.9.53**

Each time the fix was a scramble *after* tagging. This workflow moves that signal left: the same failure now blocks the PR instead of the release.

## How — steel-thread parity with the release gate

The test step is copied **verbatim** from `release.yml`'s proven `Run tests` step, so the PR gate and the release gate exercise the identical code path (no semantic drift):

- toolchain via `go-version-file: go.mod` (same pinned `setup-go`/`checkout` SHAs)
- `PERF_BUDGET_MULTIPLIER: '2.0'`
- `go install gotest.tools/gotestsum@v1.13.0`
- `gotestsum --rerun-fails=2 --rerun-fails-abort-on-data-race --packages="./..." -- -race -timeout 20m`

`tmux` + `zoxide` are installed explicitly (the release gate relies on tmux being preinstalled on `ubuntu-latest`) so this gate is **never weaker** than the one it mirrors. `timeout-minutes: 30`, and a **per-PR `concurrency` group with `cancel-in-progress: true`** so rapid follow-up pushes cancel the stale run instead of stacking 20-minute jobs.

## Cost

~10–15 CI-minutes per PR (one `ubuntu-latest` job). The cancel-in-progress concurrency keeps that bounded under rapid pushes. Cheap insurance against another post-tag release scramble.

## Validation

- `python yaml.safe_load` — parses clean
- `actionlint` — passes (semantic GitHub Actions lint)

This is a `pull_request` workflow, so it can't be fully exercised until it's *on* a PR — **this PR's own CI run is the live validation.** Since the workflow is added in this branch, the `pull_request` trigger runs it here.

---

Proposed by @spawnia in #1363. Closes #1363.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Continuous automated testing has been established and is now configured to run on all pull requests and pushes to the main branch. The comprehensive test suite executes with race condition detection, performance budgets, and concurrency controls to ensure consistent code quality and prevent potential regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->