### PR TITLE
fix(web): render profile selector as static text (#1365)

### DIFF
--- a/internal/web/static/app/Topbar.js
+++ b/internal/web/static/app/Topbar.js
@@ -69,16 +69,22 @@ export function Topbar() {
         ${(() => {
           const p = profilesSignal.value
           const list = p && Array.isArray(p.profiles) ? p.profiles : null
-          // Hold the dropdown until /api/profiles resolves so we never
-          // flash a hardcoded default on cold load.
+          // Hold until /api/profiles resolves so we never flash a hardcoded
+          // default on cold load.
           if (!list || list.length === 0) return null
+          // The profile is bound once at server startup (buildWebServer); the
+          // web UI has no server-side switch endpoint. Render the current
+          // profile as static, read-only text rather than an interactive
+          // <select> so users aren't misled into thinking a switch silently
+          // failed (issue #1365). The breadcrumb label still reads
+          // profileSignal, which AppShell seeds from /api/profiles' `current`.
+          const current = profileSignal.value || p.current || list[0]
           return html`
-            <select class="icon-btn"
-              style=${{ width: 'auto', padding: '0 8px', fontFamily: 'var(--mono)', fontSize: '11px' }}
-              value=${profileSignal.value || (p.current || list[0])}
-              onChange=${e => (profileSignal.value = e.target.value)}>
-              ${list.map(name => html`<option key=${name} value=${name}>${name}</option>`)}
-            </select>
+            <span class="icon-btn"
+              style=${{ width: 'auto', padding: '0 8px', fontFamily: 'var(--mono)', fontSize: '11px', cursor: 'default' }}
+              title="Active profile (bound at startup; not switchable from the web UI)">
+              ${current}
+            </span>
           `
         })()}
         <${ToastHistoryDrawerToggle}/>


### PR DESCRIPTION
## What changed

The web UI Topbar rendered the active profile as an interactive `<select>`, but choosing a different option did **not** switch anything. The `onChange` handler only wrote a client-side signal (`profileSignal`) used to render the breadcrumb label. There is no server-side profile-switch endpoint:

- `internal/web/static/app/Topbar.js` — `onChange` wrote `profileSignal.value` only; no API call.
- `internal/web/static/app/AppShell.js` — `profileSignal` is consumed only for the breadcrumb label `${profile} /`.
- `internal/web/handlers_settings.go` — `/api/profiles` is GET-only (list + current); no switch endpoint.
- `cmd/agent-deck/web_cmd.go` — one profile is bound at startup via `buildWebServer(profile, ...)`.

This made the control misleading: users could pick a profile and believe a switch silently failed.

## The fix (issue #1365, option 1)

Implementing real server-side profile switching is out of scope. Per the issue's option 1, the selector is changed from an interactive `<select>` to read-only **static text** showing the current profile, with a `title` explaining it is bound at startup and not switchable from the web UI.

The breadcrumb label keeps working unchanged: `AppShell.js` still seeds `profileSignal` from `/api/profiles`' `current` field on load, independent of the Topbar control. No server, build, or API changes — the static asset is served raw in dev mode (no committed `static/dist/` bundle; `/dist` is gitignored), so the source edit ships directly.

Verified: `go build ./internal/web/...` passes (sandboxed HOME/XDG).

Closes #1365

---

**Merge bar: Claude+Codex review + CI green; conductor merges. Do not merge — leaving for the conductor.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* The profile selector in the top navigation has been changed from an interactive dropdown menu to a static, read-only text display. This update clarifies that your active profile cannot be modified from the web interface. Your selected profile will remain fixed throughout your session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->