### PR TITLE
fix(conductor): pre-accept Claude trust dialog for conductor dir (#1359)

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -602,6 +602,24 @@ func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool,
 		return fmt.Errorf("failed to create conductor dir: %w", err)
 	}
 
+	// Pre-accept the Claude trust dialog for the conductor directory (#1359).
+	// conductor setup just created this directory, so there is nothing to
+	// vet — yet on first launch Claude Code would prompt "do you trust the
+	// files in this folder?" and the conductor would stall there, defeating
+	// autonomous/heartbeat operation. This reuses the same mechanism added
+	// for multi-repo worktree parents in #1149: seed
+	// projects[dir].hasTrustDialogAccepted = true in the user's root
+	// ~/.claude.json (where Claude keys trust, regardless of profile).
+	// Claude-only; failures are logged but non-fatal so setup still succeeds.
+	if spec.Agent == ConductorAgentClaude {
+		if err := PreAcceptClaudeTrust(GetUserMCPRootPath(), dir); err != nil {
+			sessionLog.Warn("conductor_preaccept_trust_failed",
+				slog.String("conductor", name),
+				slog.String("dir", dir),
+				slog.String("error", err.Error()))
+		}
+	}
+
 	targetPath := filepath.Join(dir, spec.InstructionsFileName)
 
 	if customInstructionsMD != "" {

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -2981,3 +2981,59 @@ func TestBridgeXDGEnv_AgreesWithConductorDir(t *testing.T) {
 		t.Errorf("bridge-computed config path %q != GetUserConfigPath() %q", bridgeCfg, cfgPath)
 	}
 }
+
+// conductorTrustEntry reads the root ~/.claude.json and returns the trust
+// entry for dir, or nil if there is none.
+func conductorTrustEntry(t *testing.T, dir string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(GetUserMCPRootPath())
+	if err != nil {
+		return nil
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal ~/.claude.json: %v", err)
+	}
+	projects, _ := cfg["projects"].(map[string]any)
+	entry, _ := projects[dir].(map[string]any)
+	return entry
+}
+
+// Issue #1359: setting up a Claude conductor must pre-accept the trust dialog
+// for the just-created conductor directory, so first boot (and heartbeat) does
+// not stall on Claude Code's "do you trust the files in this folder?" prompt.
+func TestSetupConductorWithAgent_PreAcceptsClaudeTrust(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "trust-claude"
+	if err := SetupConductorWithAgent(name, "default", ConductorAgentClaude, true, true, "", "", "", "", nil, ""); err != nil {
+		t.Fatalf("SetupConductorWithAgent: %v", err)
+	}
+
+	dir, _ := ConductorNameDir(name)
+	entry := conductorTrustEntry(t, dir)
+	if entry == nil {
+		t.Fatalf("no trust entry for conductor dir %q in %s", dir, GetUserMCPRootPath())
+	}
+	if entry["hasTrustDialogAccepted"] != true {
+		t.Fatalf("hasTrustDialogAccepted = %v, want true", entry["hasTrustDialogAccepted"])
+	}
+}
+
+// Non-Claude conductors (e.g. Codex) must not get a Claude trust entry — the
+// pre-accept is Claude-specific.
+func TestSetupConductorWithAgent_NoClaudeTrustForCodex(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "trust-codex"
+	if err := SetupConductorWithAgent(name, "default", ConductorAgentCodex, true, true, "", "", "", "", nil, ""); err != nil {
+		t.Fatalf("SetupConductorWithAgent: %v", err)
+	}
+
+	dir, _ := ConductorNameDir(name)
+	if entry := conductorTrustEntry(t, dir); entry != nil {
+		t.Fatalf("unexpected Claude trust entry for Codex conductor dir %q: %v", dir, entry)
+	}
+}


### PR DESCRIPTION
## What changed

`SetupConductorWithAgent` now pre-accepts the Claude trust dialog for the conductor directory immediately after creating it. For Claude conductors it calls the existing `PreAcceptClaudeTrust(GetUserMCPRootPath(), dir)`, which seeds `projects[dir].hasTrustDialogAccepted = true` into the user's root `~/.claude.json` (where Claude Code keys trust state, regardless of profile).

## Why

When a conductor session starts for the first time, Claude Code prompts *"Do you trust the files in this folder?"* for `~/.agent-deck/conductor/<name>/`. That directory was just created by `conductor setup`, so there is nothing to vet — yet the conductor stalls at the prompt until someone manually approves it, defeating autonomous and heartbeat operation.

This reuses the exact mechanism added for multi-repo worktree parent directories in #1149. The call is Claude-only and best-effort: failures are logged via `sessionLog.Warn` but are non-fatal, so `conductor setup` still succeeds if the trust file can't be written.

This enables first-boot autonomous/heartbeat operation per #1359.

## Tests

Added `TestSetupConductorWithAgent_PreAcceptsClaudeTrust` (asserts the trust entry is written for a Claude conductor) and `TestSetupConductorWithAgent_NoClaudeTrustForCodex` (asserts no Claude trust entry for a Codex conductor). Both pass, alongside the existing `TestSetupConductorWithAgent_Codex`. `go vet ./internal/session/` is clean.

## Notes

Pairs with #1358 (auto-allow CLI commands) for full first-boot autonomy, but does not depend on it.

Closes #1359

Merge bar: Claude+Codex review + CI green; conductor merges. Do not merge — leaving for the conductor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude conductors now automatically pre-accept the trust dialog for newly created conductor directories, streamlining setup.

* **Tests**
  * Added tests to verify automatic trust pre-acceptance for Claude conductors and to confirm non-Claude conductors do not create Claude trust entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->