### PR TITLE
fix: restart requires pkill — ElectPrimary now checks PID liveness, not just heartbeat freshness

### DIFF
--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -1227,7 +1228,7 @@ func (s *StateDB) ElectPrimary(timeout time.Duration) (bool, error) {
 		return false, fmt.Errorf("statedb: clear stale primary: %w", err)
 	}
 
-	// Check if any alive instance already has is_primary=1
+	// Find a candidate primary that is still fresh by heartbeat.
 	var existingPID int
 	err = tx.QueryRow(
 		"SELECT pid FROM instance_heartbeats WHERE is_primary = 1 AND heartbeat >= ? LIMIT 1",
@@ -1235,14 +1236,32 @@ func (s *StateDB) ElectPrimary(timeout time.Duration) (bool, error) {
 	).Scan(&existingPID)
 
 	if err == nil {
-		// An alive primary exists
-		if err := tx.Commit(); err != nil {
-			return false, fmt.Errorf("statedb: commit elect: %w", err)
+		// A fresh-by-heartbeat primary row exists. Trust it as a live owner only
+		// if it is our own process OR the recorded PID is actually alive. A row
+		// left behind by an unclean exit (SIGKILL, OOM, terminal force-close,
+		// crash/panic) never ran ResignPrimary, so its heartbeat can stay within
+		// `timeout` for up to the full window after the process is gone. Without
+		// the liveness check, the next start sees that ghost as a live primary
+		// and exits "already running" — which is why users had to pkill (or wait
+		// out the window) before a restart would take. Verifying liveness here
+		// reclaims a dead primary immediately. The time-based clear above remains
+		// as a safety net against PID reuse.
+		if existingPID == s.pid || pidAlive(existingPID) {
+			if err := tx.Commit(); err != nil {
+				return false, fmt.Errorf("statedb: commit elect: %w", err)
+			}
+			return existingPID == s.pid, nil
 		}
-		return existingPID == s.pid, nil
+		// Dead primary: clear its flag and fall through to claim.
+		if _, err := tx.Exec(
+			"UPDATE instance_heartbeats SET is_primary = 0 WHERE pid = ?",
+			existingPID,
+		); err != nil {
+			return false, fmt.Errorf("statedb: clear dead primary: %w", err)
+		}
 	}
 
-	// No alive primary exists: claim it
+	// No live primary exists: claim it
 	if _, err := tx.Exec(
 		"UPDATE instance_heartbeats SET is_primary = 1 WHERE pid = ?",
 		s.pid,
@@ -1254,6 +1273,23 @@ func (s *StateDB) ElectPrimary(timeout time.Duration) (bool, error) {
 		return false, fmt.Errorf("statedb: commit elect: %w", err)
 	}
 	return true, nil
+}
+
+// pidAlive reports whether pid refers to a live process on this host. It uses
+// the kill -0 idiom (signal 0 performs permission/existence checks only and is
+// never delivered), mirroring filterAliveOurProcesses in
+// internal/tmux/ensure_pids_dead.go. A dead or reaped PID returns false so a
+// crashed primary is reclaimed immediately by ElectPrimary instead of lingering
+// for the full heartbeat-staleness window.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
 }
 
 // ResignPrimary clears the is_primary flag for this process.

--- a/internal/statedb/statedb_test.go
+++ b/internal/statedb/statedb_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -486,28 +487,91 @@ func TestElectPrimary_FirstInstance(t *testing.T) {
 func TestElectPrimary_SecondInstance(t *testing.T) {
 	db := newTestDB(t)
 
-	// Simulate first instance (PID 10001) as primary with fresh heartbeat
+	// Simulate first instance as primary with a fresh heartbeat. Use the test
+	// process's own PID so it is a genuinely *live* owner: ElectPrimary now
+	// verifies process liveness, so a fabricated dead PID would no longer count
+	// as an active primary (see TestElectPrimary_DeadPrimaryFreshHeartbeat).
+	ownerPID := os.Getpid()
 	now := time.Now().Unix()
 	_, err := db.DB().Exec(
 		"INSERT INTO instance_heartbeats (pid, started, heartbeat, is_primary) VALUES (?, ?, ?, ?)",
-		10001, now, now, 1,
+		ownerPID, now, now, 1,
 	)
 	if err != nil {
 		t.Fatalf("Insert primary: %v", err)
 	}
 
-	// Register our process (not primary yet)
-	if err := db.RegisterInstance(false); err != nil {
-		t.Fatalf("RegisterInstance: %v", err)
+	// Electing instance is a *different* pid than the live owner.
+	db.pid = pickDeadPID(ownerPID)
+	if _, err := db.DB().Exec(
+		"INSERT INTO instance_heartbeats (pid, started, heartbeat, is_primary) VALUES (?, ?, ?, ?)",
+		db.pid, now, now, 0,
+	); err != nil {
+		t.Fatalf("Insert second instance: %v", err)
 	}
 
-	// Try to elect: should fail because PID 10001 is alive and primary
+	// Try to elect: should fail because the owner PID is alive and primary.
 	isPrimary, err := db.ElectPrimary(30 * time.Second)
 	if err != nil {
 		t.Fatalf("ElectPrimary: %v", err)
 	}
 	if isPrimary {
 		t.Error("Second instance should NOT become primary while first is alive")
+	}
+}
+
+// pickDeadPID returns a positive PID that is not alive and not equal to avoid.
+// Used to model a primary left behind by a crashed/killed process.
+func pickDeadPID(avoid int) int {
+	for pid := 2147480000; pid > 1; pid-- {
+		if pid == avoid {
+			continue
+		}
+		if !pidAlive(pid) {
+			return pid
+		}
+	}
+	return 99999
+}
+
+// TestElectPrimary_DeadPrimaryFreshHeartbeat is the regression test for the
+// "restart requires manual pkill" bug. A primary row whose PID is dead but
+// whose heartbeat is still within the staleness window must NOT block a new
+// instance from becoming primary — otherwise an unclean exit leaves agent-deck
+// unstartable until the window elapses or the user pkills.
+func TestElectPrimary_DeadPrimaryFreshHeartbeat(t *testing.T) {
+	db := newTestDB(t)
+
+	deadPID := pickDeadPID(os.Getpid())
+	now := time.Now().Unix() // fresh: NOT stale by time
+	if _, err := db.DB().Exec(
+		"INSERT INTO instance_heartbeats (pid, started, heartbeat, is_primary) VALUES (?, ?, ?, ?)",
+		deadPID, now, now, 1,
+	); err != nil {
+		t.Fatalf("Insert dead primary: %v", err)
+	}
+
+	if err := db.RegisterInstance(false); err != nil {
+		t.Fatalf("RegisterInstance: %v", err)
+	}
+
+	isPrimary, err := db.ElectPrimary(30 * time.Second)
+	if err != nil {
+		t.Fatalf("ElectPrimary: %v", err)
+	}
+	if !isPrimary {
+		t.Error("New instance should become primary when the prior primary's PID is dead, even with a fresh heartbeat")
+	}
+
+	// The dead PID must have been demoted.
+	var deadIsPrimary int
+	if err := db.DB().QueryRow(
+		"SELECT is_primary FROM instance_heartbeats WHERE pid = ?", deadPID,
+	).Scan(&deadIsPrimary); err != nil {
+		t.Fatalf("Query dead PID: %v", err)
+	}
+	if deadIsPrimary != 0 {
+		t.Error("Dead PID should have is_primary=0 after reclaim")
 	}
 }
 


### PR DESCRIPTION
## Root cause

The single-instance gate at `cmd/agent-deck/main.go:460-471` calls `StateDB.ElectPrimary(30s)` and prints "agent-deck is already running for this profile" + exits when it returns `isFirst=false`.

`ElectPrimary` (`internal/statedb/statedb.go`) decided whether a primary already exists using **only the heartbeat staleness window** — it never checked whether the recorded primary PID was actually alive. The clean shutdown paths (`performFinalShutdown` and the SIGINT/SIGTERM/SIGHUP handler) call `ResignPrimary`/`UnregisterInstance`, but any **unclean** exit (`SIGKILL`, OOM killer, terminal force-close that doesn't deliver SIGHUP, a panic) leaves the `is_primary=1` row behind with a heartbeat that is still within the 30 s window. The next start then sees that ghost as a live primary and refuses to start — so the user had to `pkill` (or wait out the window) before a restart would take. The existing `TestElectPrimary_SecondInstance` even used a fabricated dead PID (`10001`) as a stand-in for a "live" owner, baking the bug into the test suite.

## The fix

`ElectPrimary` now verifies process liveness for the candidate primary using the `kill -0` idiom (`os.FindProcess` + `proc.Signal(syscall.Signal(0))`) — the same primitive already used by `filterAliveOurProcesses` in `internal/tmux/ensure_pids_dead.go`. A primary row whose PID is dead is demoted (`is_primary = 0`) and the starting instance claims primary **immediately**, eliminating the up-to-30 s "already running" window after a crash. The existing time-based stale clear is kept as a safety net against PID reuse, so behavior under PID reuse is no worse than before.

Tests:
- `TestElectPrimary_SecondInstance` updated to use a genuinely **live** PID (the test process) as the owner, so it still verifies that a live primary blocks a second instance.
- New `TestElectPrimary_DeadPrimaryFreshHeartbeat` regression test: a dead PID with a fresh heartbeat must NOT block election, and the dead row must be demoted.

## Verification

- `gofmt -l` / `gofmt -e` clean on both modified files.
- The exact `ElectPrimary` + `pidAlive` logic (same SQL, same `syscall.Signal(0)` primitive, against `modernc.org/sqlite`) was exercised in an isolated harness:
  - PASS: dead-but-fresh primary reclaimed immediately, restart succeeds.
  - PASS: live primary still blocks a second instance (single-instance preserved).
- Full-repo `go build ./...` / `go test ./internal/statedb/` should be run by CI on this branch (the investigation environment had a severely rate-limited network that stalled the full module dependency fetch; the change itself is localized and self-contained).

Closes #1391

Merge bar: Claude+Codex review + CI green; conductor merges. Do not merge — leaving for the conductor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Primary election now validates that primary processes with fresh heartbeats are actually running before accepting them. Dead primary processes are properly cleared to allow new instances to claim leadership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->