### PR TITLE
docs(verification): capability verification checklist + first full user-level run

### DIFF
--- a/docs/verification/CAPABILITY-CHECKLIST.json
+++ b/docs/verification/CAPABILITY-CHECKLIST.json
@@ -1,0 +1,6850 @@
+{
+ "caps": [
+  {
+   "id": "CAP-CLI-001",
+   "area": "CLI",
+   "name": "TUI launch (bare `agent-deck`) + global flags",
+   "surfaces_raw": "TUI, CLI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-002",
+   "area": "CLI",
+   "name": "add (create session)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-003",
+   "area": "CLI",
+   "name": "launch (add+start+send in one step)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-004",
+   "area": "CLI",
+   "name": "list / ls",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-005",
+   "area": "CLI",
+   "name": "remove / rm (top-level)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-006",
+   "area": "CLI",
+   "name": "session remove (registry-scoped remove)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-007",
+   "area": "CLI",
+   "name": "rename / mv",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-008",
+   "area": "CLI",
+   "name": "status",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-009",
+   "area": "CLI",
+   "name": "session start",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-010",
+   "area": "CLI",
+   "name": "session stop + queue drain",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-011",
+   "area": "CLI",
+   "name": "session restart",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-012",
+   "area": "CLI",
+   "name": "session revive",
+   "surfaces_raw": "CLI, daemon",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-CLI-013",
+   "area": "CLI",
+   "name": "session fork",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-014",
+   "area": "CLI",
+   "name": "session attach",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-015",
+   "area": "CLI",
+   "name": "session show / session current",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-016",
+   "area": "CLI",
+   "name": "session set (generic field mutation)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-017",
+   "area": "CLI",
+   "name": "session set-parent / unset-parent / set-transition-notify / set-title-lock",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-018",
+   "area": "CLI",
+   "name": "session send (message delivery)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-019",
+   "area": "CLI",
+   "name": "session send-keys (low-level keystroke primitive)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-020",
+   "area": "CLI",
+   "name": "session output",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-021",
+   "area": "CLI",
+   "name": "session search",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-022",
+   "area": "CLI",
+   "name": "session move (path move + cross-profile migration)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-023",
+   "area": "CLI",
+   "name": "mcp list/attached/attach/detach + mcp server start/stop/status",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-024",
+   "area": "CLI",
+   "name": "plugin list/attached/attach/detach",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-025",
+   "area": "CLI",
+   "name": "skill list/attached/attach/detach/source add|remove|list",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-026",
+   "area": "CLI",
+   "name": "group list/create/update/delete/move/change/reorder",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-027",
+   "area": "CLI",
+   "name": "worktree list/info/cleanup/finish",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-028",
+   "area": "CLI",
+   "name": "conductor setup/teardown/status/list/move",
+   "surfaces_raw": "CLI, daemon",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-CLI-029",
+   "area": "CLI",
+   "name": "telegram-doctor",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-030",
+   "area": "CLI",
+   "name": "watcher create/start/stop/list/status/test/routes/import/install-skill",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-031",
+   "area": "CLI",
+   "name": "profile list/create/delete/default",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-032",
+   "area": "CLI",
+   "name": "update (self-update) + remote propagation",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-033",
+   "area": "CLI",
+   "name": "uninstall",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-034",
+   "area": "CLI",
+   "name": "migrate-paths",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-035",
+   "area": "CLI",
+   "name": "hook-handler (Claude Code hook ingestion) + hooks install/uninstall/status",
+   "surfaces_raw": "CLI, daemon",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-CLI-036",
+   "area": "CLI",
+   "name": "codex-notify + codex-hooks / gemini-hooks / hermes-hooks install|uninstall|status",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-037",
+   "area": "CLI",
+   "name": "notify-daemon (transition notifier)",
+   "surfaces_raw": "daemon, CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-CLI-038",
+   "area": "CLI",
+   "name": "run-task (one-shot worker completion wrapper)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-039",
+   "area": "CLI",
+   "name": "inbox / inbox drain",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-040",
+   "area": "CLI",
+   "name": "costs sync/summary/recompute",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-041",
+   "area": "CLI",
+   "name": "creds-refresh (OAuth keep-warm daemon)",
+   "surfaces_raw": "daemon, CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-CLI-042",
+   "area": "CLI",
+   "name": "openclaw / oc sync|bridge|status|list|send",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-043",
+   "area": "CLI",
+   "name": "remote add/remove/list/sessions/attach/rename/update",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-044",
+   "area": "CLI",
+   "name": "web (TUI+HTTP server, or headless --no-tui)",
+   "surfaces_raw": "web, TUI, CLI",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-045",
+   "area": "CLI",
+   "name": "mcp-proxy (internal stdio\u2194unix-socket bridge)",
+   "surfaces_raw": "CLI, daemon",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-CLI-046",
+   "area": "CLI",
+   "name": "try (dated experiments)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-047",
+   "area": "CLI",
+   "name": "feedback",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-048",
+   "area": "CLI",
+   "name": "debug-dump / version / help",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-CLI-049",
+   "area": "CLI",
+   "name": "shared CLI infrastructure (resolution, output, exit-code contract)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-001",
+   "area": "TUI",
+   "name": "Home screen: session list / group tree navigation",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-002",
+   "area": "TUI",
+   "name": "Attach / detach / open-in-new-window",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-003",
+   "area": "TUI",
+   "name": "New session dialog (n)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-004",
+   "area": "TUI",
+   "name": "Quick create (N) and zoxide quick-open (z)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-005",
+   "area": "TUI",
+   "name": "Fork: quick fork (f) and fork dialog (F)",
+   "surfaces_raw": "TUI, web",
+   "surfaces": [
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-006",
+   "area": "TUI",
+   "name": "Session lifecycle: delete (d) / close (D) / remove (X) / bulk remove (ctrl+x) / undo (ctrl+z)",
+   "surfaces_raw": "TUI, web",
+   "surfaces": [
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-007",
+   "area": "TUI",
+   "name": "Restart (R) and restart-fresh (T)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-008",
+   "area": "TUI",
+   "name": "MCP Manager (m)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-009",
+   "area": "TUI",
+   "name": "Plugin Manager (L)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-010",
+   "area": "TUI",
+   "name": "Skills Manager (s)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-011",
+   "area": "TUI",
+   "name": "Edit Session dialog (P) and Edit Paths dialog (p)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-012",
+   "area": "TUI",
+   "name": "Group management (g create, r rename, M move, reorder/indent)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-013",
+   "area": "TUI",
+   "name": "Group-scoped launch (--group) and group-scoped navigation layer",
+   "surfaces_raw": "TUI, CLI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-014",
+   "area": "TUI",
+   "name": "Jump mode (Space)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-015",
+   "area": "TUI",
+   "name": "Search: local (/), global (G), status-keyword filters",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-016",
+   "area": "TUI",
+   "name": "Status filters and filter bar",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-017",
+   "area": "TUI",
+   "name": "Preview pane (right/bottom panel)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-018",
+   "area": "TUI",
+   "name": "Copy / send output (c, C, x)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-019",
+   "area": "TUI",
+   "name": "Insert mode (I): type-through to session",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-020",
+   "area": "TUI",
+   "name": "Quick approve (a), mark unread (u), YOLO toggle (y), Gemini model picker (ctrl+g)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-021",
+   "area": "TUI",
+   "name": "Worktree finish (W)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-022",
+   "area": "TUI",
+   "name": "Settings panel (S) + tool visibility panel",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-023",
+   "area": "TUI",
+   "name": "Watcher panel (w) + watcher event dispatch",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-024",
+   "area": "TUI",
+   "name": "Cost dashboard ($) and analytics",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-025",
+   "area": "TUI",
+   "name": "Remote sessions (SSH remotes section)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-026",
+   "area": "TUI",
+   "name": "Import tmux sessions (i) and manual reload (ctrl+r)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-027",
+   "area": "TUI",
+   "name": "Status detection, notifications, hooks prompt",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-028",
+   "area": "TUI",
+   "name": "Quit flow and shutdown",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-029",
+   "area": "TUI",
+   "name": "Help overlay (?), footer help bar, update nudge, feedback dialog (ctrl+e)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-030",
+   "area": "TUI",
+   "name": "Setup wizard (first run)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-031",
+   "area": "TUI",
+   "name": "Hotkey remapping ([hotkeys] config)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-032",
+   "area": "TUI",
+   "name": "Mouse support",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-033",
+   "area": "TUI",
+   "name": "Notes editing (e)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-034",
+   "area": "TUI",
+   "name": "Sandbox shell exec (E)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-035",
+   "area": "TUI",
+   "name": "Web bridge (WebMutator) and web menu snapshots",
+   "surfaces_raw": "web, TUI",
+   "surfaces": [
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-036",
+   "area": "TUI",
+   "name": "Theme handling (system dark/light watcher)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TUI-037",
+   "area": "TUI",
+   "name": "Keyboard compatibility layer (Kitty/CSI u, Shift+Enter)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-001",
+   "area": "WEB",
+   "name": "Web server bootstrap, config and security gate",
+   "surfaces_raw": "CLI (`agent-deck web` subcommand), daemon-ish headless mode (`--no-tui`), web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-WEB-002",
+   "area": "WEB",
+   "name": "Authentication (bearer token) + CSRF protection",
+   "surfaces_raw": "web",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-003",
+   "area": "WEB",
+   "name": "Menu / session-list read API with hook-status overlay",
+   "surfaces_raw": "web",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-004",
+   "area": "WEB",
+   "name": "SSE live menu stream",
+   "surfaces_raw": "web",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-005",
+   "area": "WEB",
+   "name": "Session lifecycle mutations (create/start/stop/restart/close/delete/fork/undelete)",
+   "surfaces_raw": "web (REST), frontend dialogs/buttons",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-006",
+   "area": "WEB",
+   "name": "Session field edit (PATCH /api/sessions/{id})",
+   "surfaces_raw": "web (EditSessionDialog)",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-007",
+   "area": "WEB",
+   "name": "Group management (create/rename/delete)",
+   "surfaces_raw": "web",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-008",
+   "area": "WEB",
+   "name": "Worktree finish (merge + teardown) endpoint",
+   "surfaces_raw": "web",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-009",
+   "area": "WEB",
+   "name": "Children topology endpoint (conductor tree)",
+   "surfaces_raw": "web (RightRail 'Children (conductor)' card)",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-010",
+   "area": "WEB",
+   "name": "Skills management API",
+   "surfaces_raw": "web (SkillsPane), mirrors TUI `s` dialog",
+   "surfaces": [
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-011",
+   "area": "WEB",
+   "name": "MCP management API",
+   "surfaces_raw": "web (McpPane), mirrors TUI `m` dialog",
+   "surfaces": [
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-012",
+   "area": "WEB",
+   "name": "Costs API + costs SSE stream",
+   "surfaces_raw": "web (CostDashboard, sidebar cost badges)",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-013",
+   "area": "WEB",
+   "name": "System stats endpoint",
+   "surfaces_raw": "web (Topbar/Footer gauges)",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-014",
+   "area": "WEB",
+   "name": "Settings + profiles read endpoints",
+   "surfaces_raw": "web (SettingsPanel, CreateSessionDialog tool picker)",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-015",
+   "area": "WEB",
+   "name": "WebSocket terminal bridge (live tmux attach in browser)",
+   "surfaces_raw": "web (TerminalPane/TerminalPanel with xterm.js)",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-016",
+   "area": "WEB",
+   "name": "Web Push notifications (PWA)",
+   "surfaces_raw": "web (service worker + SettingsPanel), CLI flags --push/--push-test-every",
+   "surfaces": [
+    "CLI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-017",
+   "area": "WEB",
+   "name": "Static assets, SPA serving and PWA shell",
+   "surfaces_raw": "web",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WEB-018",
+   "area": "WEB",
+   "name": "Parity contract with TUI/CLI (what web can and cannot do)",
+   "surfaces_raw": "web",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-SESS-001",
+   "area": "SESS",
+   "name": "Session data model (Instance) and identity generation",
+   "surfaces_raw": "TUI, CLI (agent-deck add/launch/session *), web, MCP server, conductor",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-SESS-002",
+   "area": "SESS",
+   "name": "Lifecycle states and transitions",
+   "surfaces_raw": "TUI status icons, CLI session list/show JSON, web, transition notifications",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-SESS-003",
+   "area": "SESS",
+   "name": "Status derivation pipeline (UpdateStatus)",
+   "surfaces_raw": "TUI backgroundStatusUpdate poller, web refreshStatuses, CLI RefreshInstancesForCLIStatus, notify-daemon syncProfile",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-SESS-004",
+   "area": "SESS",
+   "name": "Spawn paths: Start / StartWithMessage and the capture-resume pattern",
+   "surfaces_raw": "CLI session start / add / launch, TUI, fork, conductor child spawn",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-SESS-005",
+   "area": "SESS",
+   "name": "Claude conversation binding: CLAUDE_SESSION_ID lifecycle and rebind guards",
+   "surfaces_raw": "tmux session environment, hook payloads, .sid anchor sidecars, state.db tool_data.claude_session_id, session-id-lifecycle.jsonl audit log",
+   "surfaces": [
+    "SESS"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-SESS-006",
+   "area": "SESS",
+   "name": "Duplicate-session killer (killing_duplicate_session)",
+   "surfaces_raw": "Start(), Restart() (all branches via sweepDuplicateToolSessions), tmux server",
+   "surfaces": [
+    "SESS"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-SESS-007",
+   "area": "SESS",
+   "name": "Resume and restart logic (claude --resume)",
+   "surfaces_raw": "CLI session restart/start, TUI restart key, RestartFresh, fork first-start",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-SESS-008",
+   "area": "SESS",
+   "name": "Session registry: storage Load/Save semantics (state.db)",
+   "surfaces_raw": "every CLI command, TUI, web, notify-daemon (per-profile storages), StorageWatcher cross-process reload",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-SESS-009",
+   "area": "SESS",
+   "name": "Hook-based status pipeline (Claude Code hooks to status files to watcher)",
+   "surfaces_raw": "claude settings.json hooks, agent-deck hook-handler subprocess, ~/.agent-deck/hooks/*.json + *.sid, StatusFileWatcher (fsnotify), TUI/daemon",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-SESS-010",
+   "area": "SESS",
+   "name": "Parent-child relationships, transition notification, and completion delivery",
+   "surfaces_raw": "agent-deck notify-daemon (systemd/launchd unit installed by conductor setup), parent inbox/outbox files, Stop-hook drain, task-worker wrapper",
+   "surfaces": [
+    "DAEMON/INTERNAL"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-SESS-011",
+   "area": "SESS",
+   "name": "Death detection and the parent-signal gap (tmux pane / claude process dies)",
+   "surfaces_raw": "UpdateStatus pollers, notify-daemon, reviver, idle-timeout watcher",
+   "surfaces": [
+    "DAEMON/INTERNAL"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-SESS-012",
+   "area": "SESS",
+   "name": "Group membership and per-group concurrency",
+   "surfaces_raw": "TUI group tree, CLI add/launch --group, storage groups table",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-SESS-013",
+   "area": "SESS",
+   "name": "Child environment propagation (childenv) and spawn-env hygiene",
+   "surfaces_raw": "all child claude spawn paths (session plus cmd/agent-deck/launch*), pooled MCP servers, tmux command prefixes",
+   "surfaces": [
+    "SESS"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-FORK-001",
+   "area": "FORK",
+   "name": "Claude conversation fork (capture-resume via --fork-session)",
+   "surfaces_raw": "CLI (agent-deck session fork), TUI (quick fork 'f', fork dialog Shift+F), web (web_mutator.go fork endpoint)",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-FORK-002",
+   "area": "FORK",
+   "name": "OpenCode fork (export/sed/import script)",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-FORK-003",
+   "area": "FORK",
+   "name": "Pi fork (JSONL file fork)",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-FORK-004",
+   "area": "FORK",
+   "name": "Codex fork (`codex fork <sid>`)",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-FORK-005",
+   "area": "FORK",
+   "name": "Fork dispatch and post-create pipeline",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-FORK-006",
+   "area": "FORK",
+   "name": "Fork-with-state worktree (git, #1029/#1263)",
+   "surfaces_raw": "CLI (--with-state / --with-state-and-gitignored, requires -w), TUI (quick fork default plus Shift+F toggles)",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-FORK-007",
+   "area": "FORK",
+   "name": "Fork-with-state workspace (jujutsu, #1305)",
+   "surfaces_raw": "CLI, TUI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-FORK-008",
+   "area": "FORK",
+   "name": "Plain worktree creation, path generation, branch resolution",
+   "surfaces_raw": "CLI (agent-deck add -w/--worktree, launch), TUI (new-session dialog, fork dialog), daemon-adjacent (taskworker)",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-FORK-009",
+   "area": "FORK",
+   "name": "Worktree removal, session-dismiss cleanup, #1200 data-loss guards",
+   "surfaces_raw": "TUI (delete session, worktree-finish dialog), CLI (session rm paths via rm_sweep), internal/session API",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-FORK-010",
+   "area": "FORK",
+   "name": "VCS backend abstraction and detection (git/jujutsu)",
+   "surfaces_raw": "CLI, TUI, internal API",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-FORK-011",
+   "area": "FORK",
+   "name": "Child environment construction (telegram/CLAUDE_CONFIG_DIR isolation)",
+   "surfaces_raw": "daemon/spawn paths (internal/session, internal/mcppool, cmd/agent-deck launch)",
+   "surfaces": [
+    "DAEMON/INTERNAL"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-FORK-012",
+   "area": "FORK",
+   "name": "Parent-child session links (sub-sessions)",
+   "surfaces_raw": "CLI (add/launch --parent/--no-parent, session set-parent), TUI (fork dialog conductor picker, group tree rendering), MCP/conductor flows (children map)",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-FORK-013",
+   "area": "FORK",
+   "name": "Multi-repo worktree creation and fork propagation",
+   "surfaces_raw": "TUI (multi-repo sessions), internal API",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-FORK-014",
+   "area": "FORK",
+   "name": "Spawn singleflight guard (#1040 restart storm)",
+   "surfaces_raw": "internal API (Start/Restart/StartWithMessage), CLI session start",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-001",
+   "area": "TMUX",
+   "name": "Session naming and identity",
+   "surfaces_raw": "CLI, TUI, daemon, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-002",
+   "area": "TMUX",
+   "name": "Session creation (Start) with 3-tier systemd launch fallback",
+   "surfaces_raw": "CLI, TUI, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-003",
+   "area": "TMUX",
+   "name": "Socket isolation (-L plumbing)",
+   "surfaces_raw": "CLI, TUI, daemon, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-004",
+   "area": "TMUX",
+   "name": "Existence/liveness probing and per-tick caches",
+   "surfaces_raw": "TUI, CLI, daemon, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-005",
+   "area": "TMUX",
+   "name": "Send-keys / prompt delivery semantics",
+   "surfaces_raw": "CLI, TUI, daemon, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-006",
+   "area": "TMUX",
+   "name": "Output capture",
+   "surfaces_raw": "CLI, TUI, daemon, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-007",
+   "area": "TMUX",
+   "name": "Control-mode pipe layer (ControlPipe + PipeManager)",
+   "surfaces_raw": "TUI, daemon, web",
+   "surfaces": [
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-008",
+   "area": "TMUX",
+   "name": "Attach / detach (PTY proxy)",
+   "surfaces_raw": "TUI, CLI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TMUX-009",
+   "area": "TMUX",
+   "name": "Terminal-reply filtering (internal/termreply)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TMUX-010",
+   "area": "TMUX",
+   "name": "Status detection state machine (GetStatus)",
+   "surfaces_raw": "TUI, CLI, daemon, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-011",
+   "area": "TMUX",
+   "name": "Tool detection and configurable patterns",
+   "surfaces_raw": "TUI, CLI, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-012",
+   "area": "TMUX",
+   "name": "Kill / respawn / process-tree reaping",
+   "surfaces_raw": "CLI, TUI, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-013",
+   "area": "TMUX",
+   "name": "Per-session tmux environment variables",
+   "surfaces_raw": "CLI, daemon",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-014",
+   "area": "TMUX",
+   "name": "Status bar, notification bar, quick-switch keys, terminal title",
+   "surfaces_raw": "TUI, daemon",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-015",
+   "area": "TMUX",
+   "name": "iTerm2 badge chrome and mid-attach badge updates",
+   "surfaces_raw": "TUI, CLI (hook subprocess)",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TMUX-016",
+   "area": "TMUX",
+   "name": "Session log maintenance",
+   "surfaces_raw": "daemon, CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-017",
+   "area": "TMUX",
+   "name": "Terminal emulator detection and capabilities",
+   "surfaces_raw": "TUI, CLI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TMUX-018",
+   "area": "TMUX",
+   "name": "System clipboard copy (internal/clipboard)",
+   "surfaces_raw": "TUI, CLI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TMUX-019",
+   "area": "TMUX",
+   "name": "Pop-out to native terminal window (internal/terminal)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-TMUX-020",
+   "area": "TMUX",
+   "name": "Waiting/readiness pollers",
+   "surfaces_raw": "CLI, daemon",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-TMUX-021",
+   "area": "TMUX",
+   "name": "Test/host-safety guards",
+   "surfaces_raw": "daemon, CLI, TUI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-001",
+   "area": "STOR",
+   "name": "state.db open/connection model",
+   "surfaces_raw": "CLI, TUI, web, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-002",
+   "area": "STOR",
+   "name": "state.db schema + migrations (SchemaVersion=9)",
+   "surfaces_raw": "CLI, TUI, web, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-003",
+   "area": "STOR",
+   "name": "SaveInstances bulk save (the 2026-06-04 wipe site) + S1/S2 guards",
+   "surfaces_raw": "CLI, TUI, web, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-004",
+   "area": "STOR",
+   "name": "Targeted single-column writes (no-clobber primitives)",
+   "surfaces_raw": "TUI, CLI, web, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-005",
+   "area": "STOR",
+   "name": "withBusyRetry concurrency policy",
+   "surfaces_raw": "CLI, TUI, web, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-006",
+   "area": "STOR",
+   "name": "Groups persistence",
+   "surfaces_raw": "TUI, CLI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-STOR-007",
+   "area": "STOR",
+   "name": "tool_data JSON blob model + extras preservation",
+   "surfaces_raw": "CLI, TUI, web, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-008",
+   "area": "STOR",
+   "name": "Legacy sessions.json \u2192 SQLite migration",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-STOR-009",
+   "area": "STOR",
+   "name": "Cross-profile session migration primitives (issue #928)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-STOR-010",
+   "area": "STOR",
+   "name": "Heartbeats, primary election, change detection, metadata",
+   "surfaces_raw": "TUI, daemon",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-011",
+   "area": "STOR",
+   "name": "Recent sessions (deleted-session re-create picker)",
+   "surfaces_raw": "TUI, CLI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-STOR-012",
+   "area": "STOR",
+   "name": "Watchers + watcher_events store",
+   "surfaces_raw": "CLI, daemon",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-013",
+   "area": "STOR",
+   "name": "Storage layer save/load orchestration + verify-loop race fixes (#909, #1031, revive)",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-STOR-014",
+   "area": "STOR",
+   "name": "Profile resolution (single source of truth, #881)",
+   "surfaces_raw": "CLI, TUI, web, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-015",
+   "area": "STOR",
+   "name": "Profile lifecycle + config.json (global pointer file)",
+   "surfaces_raw": "CLI, TUI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-STOR-016",
+   "area": "STOR",
+   "name": "XDG/HOME path resolution + legacy split (agentpaths)",
+   "surfaces_raw": "CLI, TUI, web, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-017",
+   "area": "STOR",
+   "name": "Legacy \u2192 XDG layout migration (agentpaths.MigrateLegacyLayout)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-STOR-018",
+   "area": "STOR",
+   "name": "atomicfile: symlink-preserving atomic/durable writes",
+   "surfaces_raw": "CLI, TUI, web, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-STOR-019",
+   "area": "STOR",
+   "name": "config.toml model: load cache, save guards (S2/S3), panel merge (#1067)",
+   "surfaces_raw": "TUI, CLI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-STOR-020",
+   "area": "STOR",
+   "name": "Test-time data-loss guards (S4/S5) + sandbox infrastructure",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-COND-001",
+   "area": "COND",
+   "name": "Conductor entity + meta.json store",
+   "surfaces_raw": "CLI: `agent-deck [-p profile] conductor setup/teardown/status/list/move`; Filesystem: `~/.agent-deck/conductor/<name>/meta.json`; bridge.py `discover_conductors` (reads the same files)",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-COND-002",
+   "area": "COND",
+   "name": "Conductor setup/teardown lifecycle (CLI orchestration)",
+   "surfaces_raw": "`agent-deck conductor setup <name>` with flags `-agent -description -heartbeat/-no-heartbeat -heartbeat-idle-minutes -no-clear-on-compact -instructions-md/-claude-md -policy-md -heartbeat-rules-md -shared-instructions-md/-shared-claude-md -shared-policy-md -env KEY=VALUE (repeatable) -env-file -json`; `agent-deck conductor teardown <name>|--all [--remove] [--json]`; `agent-deck conductor status [name] [--json]`; `agent-deck conductor list [--json] [--profile X]`",
+   "surfaces": [
+    "COND"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-COND-003",
+   "area": "COND",
+   "name": "is_conductor column + session/group relationship",
+   "surfaces_raw": "statedb instances table, TUI new-session dialog (newdialog_conductor_test), web /api children handlers",
+   "surfaces": [
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-COND-004",
+   "area": "COND",
+   "name": "Heartbeat daemon (OS-level per-conductor timer)",
+   "surfaces_raw": "`~/.agent-deck/conductor/<name>/heartbeat.sh`; launchd: `com.agentdeck.conductor-heartbeat.<name>.plist` (StartInterval = minutes*60); systemd user: `agent-deck-conductor-heartbeat-<name>.{timer,service}` (OnBootSec/OnUnitActiveSec)",
+   "surfaces": [
+    "DAEMON/INTERNAL"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-COND-005",
+   "area": "COND",
+   "name": "bridge.py legacy channel bridge (Telegram/Slack \u2194 conductor sessions)",
+   "surfaces_raw": "Telegram bot (aiogram polling): /start /status /sessions /help /restart plus free text; Slack (slack-bolt Socket Mode): message events (listen_mode all), app_mention, /ad-status /ad-sessions /ad-restart /ad-help; daemon: com.agentdeck.conductor-bridge (launchd, KeepAlive) / agent-deck-conductor-bridge.service (systemd, Restart=always)",
+   "surfaces": [
+    "DAEMON/INTERNAL"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-COND-006",
+   "area": "COND",
+   "name": "Plugin-based Telegram channel integration (--channels) + poller ownership",
+   "surfaces_raw": "Instance.Channels []string (\"plugin:telegram@claude-plugins-official\" etc.), persisted, set via `agent-deck session set <s> channels \u2026`; claude spawn/resume flags `--channels <csv>` (instance.go:1034 and the resume path at :6041); `agent-deck telegram-doctor [-json -quiet]`; worker scratch CLAUDE_CONFIG_DIR machinery",
+   "surfaces": [
+    "DAEMON/INTERNAL"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-COND-007",
+   "area": "COND",
+   "name": "Per-conductor env_file injection and config_dir profile override",
+   "surfaces_raw": "config.toml `[conductors.<name>.claude]` config_dir, env_file; `[conductors.<name>.hermes]` command/env_file/yolo_mode/gateway_url/\u2026; meta.json env (map) and env_file; `conductor setup -env/-env-file` flags",
+   "surfaces": [
+    "COND"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-COND-008",
+   "area": "COND",
+   "name": "Child\u2192parent transition notification (transition daemon + notifier + inbox)",
+   "surfaces_raw": "daemon: `agent-deck notify-daemon` (com.agentdeck.transition-notifier launchd / agent-deck-transition-notifier.service systemd, RuntimeMaxSec=86400 recycle backstop); `agent-deck notify-daemon --once` CLI; logs: transition-notifier.log, notifier-missed.log, notifier-orphans.log; state: runtime/transition-notify-state.json",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-COND-009",
+   "area": "COND",
+   "name": "Worker-asserted completion ([DONE] sentinel + run-task kernel exit)",
+   "surfaces_raw": "worker prints `===AGENTDECK_DONE=== status=<ok|fail> summary=\u2026` as its last line (parsed by the Stop-hook handler into hook status file fields done_status/done_summary); `agent-deck run-task` one-shot wrapper (RunTaskWorker); parent receives \"[DONE] Child finished\u2026\" via the same inbox",
+   "surfaces": [
+    "COND"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-COND-010",
+   "area": "COND",
+   "name": "Conductor instruction/policy template system",
+   "surfaces_raw": "`~/.agent-deck/conductor/{CLAUDE.md|AGENTS.md|HERMES.md}` shared (mechanism: CLI reference, protocols); `~/.agent-deck/conductor/<name>/<file>` per-conductor (identity; inherits shared via directory walk); POLICY.md (behavior rules) shared plus per-name override; LEARNINGS.md two-tier; HEARTBEAT_RULES.md three-tier lookup",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-001",
+   "area": "MCP",
+   "name": "MCP catalog definition in config.toml",
+   "surfaces_raw": "CLI, TUI, web, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MCP-002",
+   "area": "MCP",
+   "name": "CLI: agent-deck mcp list / attached / attach / detach",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-003",
+   "area": "MCP",
+   "name": "CLI: agent-deck mcp server start/stop/status (HTTP MCP servers)",
+   "surfaces_raw": "CLI, TUI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-004",
+   "area": "MCP",
+   "name": "Attached-state reads (MCPInfo) + caching",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-005",
+   "area": "MCP",
+   "name": "LOCAL scope write: .mcp.json generation with merge-preserve and plugin pin refresh",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-006",
+   "area": "MCP",
+   "name": "GLOBAL and USER scope writes (.claude.json)",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-007",
+   "area": "MCP",
+   "name": "Socket pool: shared stdio MCP processes multiplexed over Unix sockets",
+   "surfaces_raw": "TUI, daemon",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MCP-008",
+   "area": "MCP",
+   "name": "agent-deck mcp-proxy <socket> (hidden CLI bridge command)",
+   "surfaces_raw": "CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-009",
+   "area": "MCP",
+   "name": "Pool resolution during config generation (tryPoolSocket)",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-010",
+   "area": "MCP",
+   "name": "HTTP MCP server pool (auto-start [mcps.X.server])",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-011",
+   "area": "MCP",
+   "name": "systemd per-MCP scope isolation (Linux)",
+   "surfaces_raw": "TUI, daemon, CLI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MCP-012",
+   "area": "MCP",
+   "name": "Pool lifecycle: TUI init, multi-instance sharing, quit semantics",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-013",
+   "area": "MCP",
+   "name": "TUI MCP Manager dialog (\"M\" key)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-014",
+   "area": "MCP",
+   "name": "Web API MCP management",
+   "surfaces_raw": "web",
+   "surfaces": [
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MCP-015",
+   "area": "MCP",
+   "name": "Session-launch and restart MCP integration",
+   "surfaces_raw": "CLI, TUI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-001",
+   "area": "WATCH",
+   "name": "Watcher engine event pipeline",
+   "surfaces_raw": "TUI, CLI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-002",
+   "area": "WATCH",
+   "name": "Watcher source adapters (webhook, github, ntfy, slack, gmail)",
+   "surfaces_raw": "TUI, daemon",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-WATCH-003",
+   "area": "WATCH",
+   "name": "Watcher health tracking + health alert bridge",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-004",
+   "area": "WATCH",
+   "name": "Event routing (clients.json router)",
+   "surfaces_raw": "TUI, CLI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-005",
+   "area": "WATCH",
+   "name": "Triage pipeline (unrouted event \u2192 Claude classifier session)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-006",
+   "area": "WATCH",
+   "name": "Hook-to-status derivation (sessionstatus.Derive)",
+   "surfaces_raw": "web, CLI, TUI, daemon",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-WATCH-007",
+   "area": "WATCH",
+   "name": "Cost event capture (Claude Stop hook \u2192 file drop \u2192 fsnotify \u2192 SQLite)",
+   "surfaces_raw": "CLI, TUI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-008",
+   "area": "WATCH",
+   "name": "Cost parsers + tmux capture poller (multi-tool cost extraction)",
+   "surfaces_raw": "none (unwired)",
+   "surfaces": [
+    "WATCH"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-009",
+   "area": "WATCH",
+   "name": "Cost store, summaries, remote aggregation",
+   "surfaces_raw": "CLI, TUI, web",
+   "surfaces": [
+    "CLI",
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-010",
+   "area": "WATCH",
+   "name": "Pricing (defaults, cache, overrides, daily fetcher, recompute, transcript sync)",
+   "surfaces_raw": "CLI, TUI",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-011",
+   "area": "WATCH",
+   "name": "Budget limits (warn/stop)",
+   "surfaces_raw": "TUI",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-012",
+   "area": "WATCH",
+   "name": "System stats collection + formatting",
+   "surfaces_raw": "TUI, web",
+   "surfaces": [
+    "TUI",
+    "WEB"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-WATCH-013",
+   "area": "WATCH",
+   "name": "Credential keep-warm refresh daemon (creds-refresh)",
+   "surfaces_raw": "CLI, daemon",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MISC-001",
+   "area": "MISC",
+   "name": "Docker container lifecycle (sandbox sessions)",
+   "surfaces_raw": "CLI (`agent-deck add --sandbox / --sandbox-image`, `try --sandbox`); TUI (sandbox sessions, fork docker=auto|on|off); daemon/session layer (instance.go start/kill, maintenance.go orphan cleanup)",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MISC-002",
+   "area": "MISC",
+   "name": "Sandbox container config builder + mount security blocklists",
+   "surfaces_raw": "CLI/TUI via the session start path (buildSandboxConfig in instance.go)",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MISC-003",
+   "area": "MISC",
+   "name": "Agent-config sandbox sync (host credentials/config \u2192 container)",
+   "surfaces_raw": "daemon/session start (RefreshAgentConfigs called on EVERY session start, including container reuse); session teardown (CleanupKeychainCredentials)",
+   "surfaces": [
+    "DAEMON/INTERNAL"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MISC-004",
+   "area": "MISC",
+   "name": "Docker availability detection",
+   "surfaces_raw": "CLI/TUI session start preflight, session/maintenance",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MISC-005",
+   "area": "MISC",
+   "name": "Self-update: version check, cache, nudge",
+   "surfaces_raw": "CLI (`agent-deck update --check`, --version banner annotation, post-command stderr notices); TUI (async check on launch, banner plus a \u22656-releases-behind nudge bar, shift+U dismiss, settings panel \"check for updates\")",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MISC-006",
+   "area": "MISC",
+   "name": "Self-update: verified download + binary install + remote deploy gate",
+   "surfaces_raw": "CLI (`agent-deck update`, `update --version`; `agent-deck remote update [name]`)",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MISC-007",
+   "area": "MISC",
+   "name": "install.sh (curl|bash installer)",
+   "surfaces_raw": "CLI bootstrap (`curl -fsSL .../install.sh | bash`)",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MISC-008",
+   "area": "MISC",
+   "name": "Makefile build/test/release pipeline",
+   "surfaces_raw": "developer CLI",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MISC-009",
+   "area": "MISC",
+   "name": "OpenClaw gateway client (WebSocket JSON-RPC)",
+   "surfaces_raw": "CLI (`agent-deck openclaw|oc sync/bridge/status/list/send`); TUI indirectly (synced sessions run the bridge inside tmux)",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MISC-010",
+   "area": "MISC",
+   "name": "OpenClaw bridge TUI + agent session sync",
+   "surfaces_raw": "CLI (`openclaw bridge --agent <id>`, run as the command INSIDE a tmux session); CLI (`openclaw sync` creates/updates agent-deck sessions; config [openclaw].auto_sync intended for TUI startup)",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MISC-011",
+   "area": "MISC",
+   "name": "Feedback prompt pacing + state",
+   "surfaces_raw": "TUI (in-app FeedbackDialog popup: rating 1-5 emoji \u2192 comment textarea \u2192 confirm with gh account disclosure \u2192 sent/dismissed); CLI (`agent-deck feedback` command, feedback_cmd.go)",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MISC-012",
+   "area": "MISC",
+   "name": "Feedback sender (three-tier submission)",
+   "surfaces_raw": "TUI dialog send, CLI feedback command",
+   "surfaces": [
+    "CLI",
+    "TUI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MISC-013",
+   "area": "MISC",
+   "name": "Structured logging system",
+   "surfaces_raw": "daemon/all processes (slog pipeline); CLI (`agent-deck debug-dump`); SIGUSR1 handler (live ring dump); localhost:6060 pprof (opt-in)",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MISC-014",
+   "area": "MISC",
+   "name": "safego panic-recovering goroutines",
+   "surfaces_raw": "all (a library used across TUI/daemon background goroutines)",
+   "surfaces": [
+    "TUI"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MISC-015",
+   "area": "MISC",
+   "name": "Platform detection + headless + fsnotify support check",
+   "surfaces_raw": "all (a library: clipboard choice, unix-socket capability, feedback browser fallback, watcher warnings)",
+   "surfaces": [
+    "MISC"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MISC-016",
+   "area": "MISC",
+   "name": "Experiments / `agent-deck try` (quick experiment folders)",
+   "surfaces_raw": "CLI (`agent-deck try <name> [--list/-l] [--json] [-q] [-c tool] [--no-session] [--sandbox]`)",
+   "surfaces": [
+    "CLI"
+   ],
+   "daemonish": false
+  },
+  {
+   "id": "CAP-MISC-017",
+   "area": "MISC",
+   "name": "Test infrastructure: testutil isolation + perf + seams",
+   "surfaces_raw": "test-only (every package TestMain)",
+   "surfaces": [
+    "DAEMON/INTERNAL"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MISC-018",
+   "area": "MISC",
+   "name": "Integration test suite (real tmux)",
+   "surfaces_raw": "test-only (`go test ./internal/integration`)",
+   "surfaces": [
+    "DAEMON/INTERNAL"
+   ],
+   "daemonish": true
+  },
+  {
+   "id": "CAP-MISC-019",
+   "area": "MISC",
+   "name": "Release regression manifest + release-pinning tests",
+   "surfaces_raw": "test-only (`go test ./internal/releasetests`)",
+   "surfaces": [
+    "DAEMON/INTERNAL"
+   ],
+   "daemonish": true
+  }
+ ],
+ "rows": [
+  {
+   "id": "CAP-CLI-001",
+   "area": "CLI",
+   "name": "TUI launch (bare `agent-deck`) + global flags",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-001-CLI.txt",
+   "status": "verified",
+   "notes": "Global flags + guards work as a user sees them: -g unknown-group exits 2 ('group not found'); outer-tmux guard prints the exact 'designed to run OUTSIDE of tmux' message + CLI alternatives when AGENT_"
+  },
+  {
+   "id": "CAP-CLI-001",
+   "area": "CLI",
+   "name": "TUI launch (bare `agent-deck`) + global flags",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-001-TUI.txt",
+   "status": "verified",
+   "notes": "Bare `agent-deck` boots the bubbletea TUI in a tmux pane: header shows version v1.9.56-verify + status counts + system stats, grouped session tree renders all groups/sessions, preview pane + keybindin"
+  },
+  {
+   "id": "CAP-CLI-002",
+   "area": "CLI",
+   "name": "add (create session)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-002-CLI.txt",
+   "status": "verified",
+   "notes": "add registers session without starting tmux. Verified: basic add (default group=folder name), --json (keys command/group/id/path/profile/resolved_command/success/title/tool), duplicate title+path retu"
+  },
+  {
+   "id": "CAP-CLI-003",
+   "area": "CLI",
+   "name": "launch (add+start+send in one step)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-003-CLI.txt",
+   "status": "verified",
+   "notes": "launch = add+start(+send). Session created AND tmux session running. JSON includes BOTH `id` and `session_id` keys (compat contract). --no-wait -m message was actually DELIVERED and EXECUTED in the ba"
+  },
+  {
+   "id": "CAP-CLI-004",
+   "area": "CLI",
+   "name": "list / ls",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-004-CLI.txt",
+   "status": "verified",
+   "notes": "list/ls table (TITLE/GROUP/PATH/ID truncated). --json carries id,title,path,group,tool,command,status,tmux_session,profile,created_at (status refreshed per #610). ls alias exit 0. --all groups per-pro"
+  },
+  {
+   "id": "CAP-CLI-005",
+   "area": "CLI",
+   "name": "remove / rm (top-level)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-005-CLI.txt",
+   "status": "verified",
+   "notes": "remove resolves by exact title, by ID prefix (8 chars >=6), persists (gone from list). not-found exit 2. rm alias works. Always KillAndWait (synchronous)."
+  },
+  {
+   "id": "CAP-CLI-006",
+   "area": "CLI",
+   "name": "session remove (registry-scoped remove)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-006-CLI.txt",
+   "status": "verified",
+   "notes": "session remove is registry-scoped and status-gated: refused on a non-stopped/error session ('in state idle; only stopped/error may be removed without --force', exit 1). --force overrides and removes. "
+  },
+  {
+   "id": "CAP-CLI-007",
+   "area": "CLI",
+   "name": "rename / mv",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-007-CLI.txt",
+   "status": "verified",
+   "notes": "rename persists new title; mv alias works; not-found exit 2; rename sets TitleLocked=true (session show --json title_locked:True), confirming the #572 name-sync-revert protection."
+  },
+  {
+   "id": "CAP-CLI-008",
+   "area": "CLI",
+   "name": "status",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-008-CLI.txt",
+   "status": "verified",
+   "notes": "status default prints '<w> waiting \u2022 <r> running \u2022 <i> idle'; -q prints only waiting count (script-friendly); -v grouped detail with model column; --json {waiting,running,idle,error,stopped,total}; --"
+  },
+  {
+   "id": "CAP-CLI-009",
+   "area": "CLI",
+   "name": "session start",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-009-CLI.txt",
+   "status": "verified",
+   "notes": "session start creates real tmux session (verified on isolated socket), status flips to idle, already-running error exit 1, not-found exit 2, --json includes tmux name. Queue-cap branch (status=queued "
+  },
+  {
+   "id": "CAP-CLI-010",
+   "area": "CLI",
+   "name": "session stop + queue drain",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-010-CLI.txt",
+   "status": "partial",
+   "notes": "session stop verified: stops a running session (status->stopped, tmux killed), stop-not-running error exit 1. Queue DRAIN could NOT be exercised: with a cap=1 group (capgrp2, created via --max-concurr"
+  },
+  {
+   "id": "CAP-CLI-011",
+   "area": "CLI",
+   "name": "session restart",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-011-CLI.txt",
+   "status": "partial",
+   "notes": "restart core verified: single restart, --force, --all (per-session JSON restarted/failed/total/sessions), not-found exit 2, ConsumeCodexRestartWarning surfaced. The #30 freshness-guard skip (skipped:t"
+  },
+  {
+   "id": "CAP-CLI-012",
+   "area": "CLI",
+   "name": "session revive",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-012-CLI.txt",
+   "status": "verified",
+   "notes": "session revive --all prints the exact summary contract 'revived=N errored=N alive=N dead=N'; --json emits {revived,errored,alive,dead,success}; --name targets a single session; --name not-found exits "
+  },
+  {
+   "id": "CAP-CLI-013",
+   "area": "CLI",
+   "name": "session fork",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-013-CLI.txt",
+   "status": "partial",
+   "notes": "Front-door verified: fork rejects non-forkable shell sessions ('not a forkable session (tool: shell)', exit 1), not-found exit 2, full flag surface present (-t/-g/-w/-b/--with-state/--with-state-and-g"
+  },
+  {
+   "id": "CAP-CLI-014",
+   "area": "CLI",
+   "name": "session attach",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-014-CLI.txt",
+   "status": "verified",
+   "notes": "session attach: not-running error exit 1, not-found exit 2. Interactive attach driven inside a wrapper tmux pane LANDED inside the target session (pane shows the session's cwd /p1 running bash -l, an "
+  },
+  {
+   "id": "CAP-CLI-015",
+   "area": "CLI",
+   "name": "session show / session current",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-015-CLI.txt",
+   "status": "verified",
+   "notes": "session show outputs refreshed status, path, group, tool, command, title_locked, tmux name, timestamps, parent link fields; --json keys match contract (id,title,path,group,tool,command,status,tmux_ses"
+  },
+  {
+   "id": "CAP-CLI-016",
+   "area": "CLI",
+   "name": "session set (generic field mutation)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-016-CLI.txt",
+   "status": "verified",
+   "notes": "session set: color #RRGGBB / ANSI 0-255 / '' clear all accepted, invalid color rejected with the expected message (exit 1); command set persists; title set; channels/extra-args correctly claude-only-r"
+  },
+  {
+   "id": "CAP-CLI-017",
+   "area": "CLI",
+   "name": "session set-parent / unset-parent / set-transition-notify / set-title-lock",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-017-CLI.txt",
+   "status": "verified",
+   "notes": "set-parent links sub-session (parent_session_id persisted), rejects self ('cannot set as own parent' exit1), rejects parent->sub-session single-level (exit1), exit2 on not-found. unset-parent works, e"
+  },
+  {
+   "id": "CAP-CLI-018",
+   "area": "CLI",
+   "name": "session send (message delivery)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-018-019-020-CLI.txt",
+   "status": "verified",
+   "notes": "session send delivered 'echo SENDMARKER_018' which ran in pane (verified via raw tmux capture). 'Sent message' exit0. Not-found exit2. Non-claude (bash) tool path skips Claude verify per contract."
+  },
+  {
+   "id": "CAP-CLI-019",
+   "area": "CLI",
+   "name": "session send-keys (low-level keystroke primitive)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-018-019-020-CLI.txt",
+   "status": "verified",
+   "notes": "send-keys --text + --enter delivered KEYSMARKER (ran). --stream stdin line protocol (T <hex>, E) delivered STREAMMARKER (ran). --named-key Enter ok. Two modes at once rejected: 'exactly one of --text,"
+  },
+  {
+   "id": "CAP-CLI-020",
+   "area": "CLI",
+   "name": "session output",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-018-019-020-CLI.txt",
+   "status": "verified",
+   "notes": "--pane --json returns ResponseOutput-shaped JSON (content/role/session_id/session_title/success/tool). Default transcript best-effort prints session output. --copy invokes OSC52 clipboard.Copy (fails "
+  },
+  {
+   "id": "CAP-CLI-021",
+   "area": "CLI",
+   "name": "session search",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-021-022-CLI.txt",
+   "status": "partial",
+   "notes": "Command front door verified: parses query + --limit/--days/--tier, builds GlobalSearchIndex over Claude config dir, emits NOT_FOUND --json error shape. Actual content search not exercisable: fsnotify-"
+  },
+  {
+   "id": "CAP-CLI-022",
+   "area": "CLI",
+   "name": "session move (path move + cross-profile migration)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-021-022-CLI.txt",
+   "status": "verified",
+   "notes": "Form1 move to new path: ProjectPath updated+persisted, --no-restart honored. Form2 --to-profile missing profile -> NOT_FOUND exit1 with create-profile hint; --to-profile + positional rejected ('incomp"
+  },
+  {
+   "id": "CAP-CLI-023",
+   "area": "CLI",
+   "name": "mcp list/attached/attach/detach + mcp server start/stop/status",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-023-CLI.txt",
+   "status": "verified",
+   "notes": "mcp list (table with [S]/[H] transport tags + -q names). attached (LOCAL split, empty state). attach: unknown -> exit2 + available list; valid writes .mcp.json (correct stdio shape) exit0; re-attach A"
+  },
+  {
+   "id": "CAP-CLI-024",
+   "area": "CLI",
+   "name": "plugin list/attached/attach/detach",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-024-CLI.txt",
+   "status": "verified",
+   "notes": "plugin list shows emits_channel marker + id@source (requires name+source fields in [plugins.*]). attach persists + prints transition; attached lists it. --no-channel-link on emits_channel plugin shows"
+  },
+  {
+   "id": "CAP-CLI-025",
+   "area": "CLI",
+   "name": "skill list/attached/attach/detach/source add|remove|list",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-024-025-CLI.txt",
+   "status": "verified",
+   "notes": "source add/duplicate(ALREADY_EXISTS exit1)/list(shows claude-global,pool,custom)/remove(not-found exit2, valid ok). skill list reads source. attached shows project+managed state. attach unknown -> 'sk"
+  },
+  {
+   "id": "CAP-CLI-026",
+   "area": "CLI",
+   "name": "group list/create/update/delete/move/change/reorder",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-026-CLI.txt",
+   "status": "verified",
+   "notes": "create (+idempotent, bad-parent exit2, child); list tree + --json nesting; update (default-path, require-one-flag, mutual-exclusion); group move session between groups (persisted); change/reparent; re"
+  },
+  {
+   "id": "CAP-CLI-027",
+   "area": "CLI",
+   "name": "worktree list/info/cleanup/finish",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-027-CLI.txt",
+   "status": "verified",
+   "notes": "add -w -b creates git worktree on disk. worktree list shows main+worktree with session assoc. info shows branch/path/main-repo/exists; info on non-worktree errors (IsWorktree gate exit1). cleanup dry-"
+  },
+  {
+   "id": "CAP-CLI-028",
+   "area": "CLI",
+   "name": "conductor setup/teardown/status/list/move",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-028-CLI.txt",
+   "status": "partial",
+   "notes": "setup: saves config.toml, installs shared CLAUDE.md/POLICY.md/LEARNINGS.md, creates conductor/<name>/{meta.json,CLAUDE.md,heartbeat.sh}, registers 'conductor-<name>' (IsConductor) in 'conductor' group"
+  },
+  {
+   "id": "CAP-CLI-029",
+   "area": "CLI",
+   "name": "telegram-doctor",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-029-CLI.txt",
+   "status": "verified",
+   "notes": "Empty profile: 'no telegram channel-owning sessions' exit0 + JSON {channel_owners:0,reports:[]} + quiet silent. With a telegram-channel claude session: detects owner, checks effective settings.json (r"
+  },
+  {
+   "id": "CAP-CLI-030",
+   "area": "CLI",
+   "name": "watcher create/start/stop/list/status/test/routes/import/install-skill",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-030-CLI.txt",
+   "status": "verified",
+   "notes": "create webhook(--port required)/ntfy(--topic)/github(--secret-file). inline --secret REFUSED (M2 /proc leak, with explanation). list table + --json (Phase-21 fields last_event_ts/error_count/health_st"
+  },
+  {
+   "id": "CAP-CLI-031",
+   "area": "CLI",
+   "name": "profile list/create/delete/default",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-031-CLI.txt",
+   "status": "verified",
+   "notes": "bare profile lists (empty msg, marks default with *). create; duplicate ALREADY_EXISTS exit1. default show + set. delete --json skips confirm, emits {deleted:true} JSON, removes profile+sessions. --js"
+  },
+  {
+   "id": "CAP-CLI-032",
+   "area": "CLI",
+   "name": "update (self-update) + remote propagation",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-032-CLI.txt",
+   "status": "partial",
+   "notes": "Flag surface verified via --help (--check, --version). --check performs a real GitHub releases API call (version banner + 'Checking for updates...'); --version <X> calls FetchReleaseByTag (hit anonymo"
+  },
+  {
+   "id": "CAP-CLI-033",
+   "area": "CLI",
+   "name": "uninstall",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-033-CLI.txt",
+   "status": "partial",
+   "notes": "--help flag surface (--dry-run/--keep-data/--keep-tmux-config/-y). --dry-run scans binary + XDG config + data (profile/session/size counts), lists removals, makes NO changes (data confirmed intact aft"
+  },
+  {
+   "id": "CAP-CLI-034",
+   "area": "CLI",
+   "name": "migrate-paths",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-034-CLI.txt",
+   "status": "verified",
+   "notes": "migrate-paths --dry-run reports 'nothing to migrate' and leaves legacy dir untouched; with a legacy ~/.agent-deck present a config.toml conflict aborts (exit 1) telling user to rerun with --force; --f"
+  },
+  {
+   "id": "CAP-CLI-035",
+   "area": "CLI",
+   "name": "hook-handler (Claude Code hook ingestion) + hooks install/uninstall/status",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-035-CLI.txt",
+   "status": "verified",
+   "notes": "hooks install writes ~/.claude/settings.json (status NOT INSTALLED -> INSTALLED -> uninstall); hook-handler requires AGENTDECK_INSTANCE_ID, ALWAYS exits 0 (even with missing or '../evil' instance id -"
+  },
+  {
+   "id": "CAP-CLI-036",
+   "area": "CLI",
+   "name": "codex-notify + codex-hooks / gemini-hooks / hermes-hooks install|uninstall|status",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-036-CLI.txt",
+   "status": "verified",
+   "notes": "codex-notify reads JSON from stdin AND argv; fuzzy event mapping confirmed (turn.complete->waiting, turn.start->running), session_id from payload, writes same hook status file. codex-hooks install wri"
+  },
+  {
+   "id": "CAP-CLI-037",
+   "area": "CLI",
+   "name": "notify-daemon (transition notifier)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-037-CLI.txt",
+   "status": "verified",
+   "notes": "notify-daemon --once performs a single SyncOnce+Flush and exits 0 cleanly within timeout."
+  },
+  {
+   "id": "CAP-CLI-038",
+   "area": "CLI",
+   "name": "run-task (one-shot worker completion wrapper)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-038-CLI.txt",
+   "status": "verified",
+   "notes": "run-task --child <valid-id> -- echo TASKRAN runs the command verbatim (stdout passes through), exit 0; worker nonzero exit propagates exactly (bash -c 'exit 7' -> EXIT=7); missing command -> usage exi"
+  },
+  {
+   "id": "CAP-CLI-039",
+   "area": "CLI",
+   "name": "inbox / inbox drain",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-039-CLI.txt",
+   "status": "verified",
+   "notes": "inbox drain resolves caller id from AGENTDECK_INSTANCE_ID (and explicit id), emits '[]' (never null) in --json and 'No pending events.' in human mode (exit 0); 'drain self' and 'drain <id>' both work;"
+  },
+  {
+   "id": "CAP-CLI-040",
+   "area": "CLI",
+   "name": "costs sync/summary/recompute",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-040-CLI.txt",
+   "status": "verified",
+   "notes": "costs summary --json emits the RemoteCostSummary wire shape (cost_today/yesterday/this_week/last_week/this_month/last_month/projected_microdollars + events_* keys); human summary prints Today/This wee"
+  },
+  {
+   "id": "CAP-CLI-041",
+   "area": "CLI",
+   "name": "creds-refresh (OAuth keep-warm daemon)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-041-CLI.txt",
+   "status": "verified",
+   "notes": "creds-refresh --once with no .credentials.json in default/specified dirs -> 'no profile config dir with a .credentials.json found' exit 1; with a fabricated future-expiry .credentials.json under --con"
+  },
+  {
+   "id": "CAP-CLI-042",
+   "area": "CLI",
+   "name": "openclaw / oc sync|bridge|status|list|send",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-042-CLI.txt",
+   "status": "partial",
+   "notes": "CLI front door verified: openclaw list/status and the 'oc' alias connect to the configured gateway (default ws 127.0.0.1:31337) and fail gracefully with exit 1 when offline; status prints 'Gateway: OF"
+  },
+  {
+   "id": "CAP-CLI-043",
+   "area": "CLI",
+   "name": "remote add/remove/list/sessions/attach/rename/update",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-043-CLI.txt",
+   "status": "partial",
+   "notes": "add persists [remotes.<name>] to config.toml (host/agent_deck_path/profile) and the ssh CheckBinary probe failing only warns ('install manually...'); list table+--json work; name validation rejects co"
+  },
+  {
+   "id": "CAP-CLI-044",
+   "area": "CLI",
+   "name": "web (TUI+HTTP server, or headless --no-tui)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-044-CLI.txt",
+   "status": "verified",
+   "notes": "Security gate: 'web --no-tui --listen 0.0.0.0:PORT' without --token is REFUSED (exit 1) with the exact RCE-surface message offering loopback/--token/--insecure-bind; '--push-test-every' without '--pus"
+  },
+  {
+   "id": "CAP-CLI-044",
+   "area": "CLI",
+   "name": "web (TUI+HTTP server, or headless --no-tui)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-044-WEB.png",
+   "status": "untestable-locally",
+   "notes": "The combined TUI+HTTP mode (bubbletea + server) belongs to the TUI surface area; the --no-tui headless path and the security gate (the CLI-owned bootstrap extraction) are fully verified here."
+  },
+  {
+   "id": "CAP-CLI-044",
+   "area": "CLI",
+   "name": "web (TUI+HTTP server, or headless --no-tui)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-CLI-045",
+   "area": "CLI",
+   "name": "mcp-proxy (internal stdio\u2194unix-socket bridge)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-045-CLI.txt",
+   "status": "verified",
+   "notes": "mcp-proxy with no arg -> 'Usage: agent-deck mcp-proxy <socket-path>' exit 1; against a live python unix-socket echo server it performs bidirectional io.Copy: 'HELLO_PROXY' written to stdin was forward"
+  },
+  {
+   "id": "CAP-CLI-046",
+   "area": "CLI",
+   "name": "try (dated experiments)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-046-CLI.txt",
+   "status": "verified",
+   "notes": "try --list on empty reports 'No experiments in <dir>/tries'; 'try myexp --no-session -c bash' creates the date-prefixed folder '2026-06-11-myexp' on disk (folder only, no session); 'try -l --json' ret"
+  },
+  {
+   "id": "CAP-CLI-047",
+   "area": "CLI",
+   "name": "feedback",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-047-CLI.txt",
+   "status": "verified",
+   "notes": "feedback --help documents the disclose-before-post contract (#679: shows URL/gh login/exact body, default-N confirm, no clipboard/browser fallback on gh failure). Driving stdin: 'q' -> 'Cancelled.' ex"
+  },
+  {
+   "id": "CAP-CLI-048",
+   "area": "CLI",
+   "name": "debug-dump / version / help",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-048-CLI.txt",
+   "status": "verified",
+   "notes": "version, --version, -v all print 'Agent Deck v1.9.56-verify' exit 0 (offline, no network); debug-dump writes debug-dump-<ts>.jsonl to XDG cache and reports the path (file confirmed on disk) exit 0; he"
+  },
+  {
+   "id": "CAP-CLI-049",
+   "area": "CLI",
+   "name": "shared CLI infrastructure (resolution, output, exit-code contract)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-049-CLI.txt",
+   "status": "verified",
+   "notes": "ResolveSession verified across all three modes: exact title, ID prefix (>=6 chars), exact path. CLIOutput: --json error shape {success:false,error,code} confirmed; codes NOT_FOUND (exit 2) and AMBIGUO"
+  },
+  {
+   "id": "CAP-TUI-001",
+   "area": "TUI",
+   "name": "Home screen: session list / group tree navigation",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-001-TUI.txt",
+   "status": "verified",
+   "notes": "Home renders flattened tree: group headers with counts (ad-sbx... (3)), nested sessions (alpha/beta/cl-sess), second empty group. Dual-column SESSIONS|PREVIEW layout at 200 cols. j/k/Home/End move cur"
+  },
+  {
+   "id": "CAP-TUI-002",
+   "area": "TUI",
+   "name": "Attach / detach / open-in-new-window",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-002-TUI.txt",
+   "status": "verified",
+   "notes": "Enter on running 'beta' attached via PTY into its tmux ([agentdeck_beta_...] 0:bash*, status line 'ctrl+q detach | beta | p2'). Ran 'echo ATTACHED_SHELL_OK' in the real session shell (cwd .../p2). Ctr"
+  },
+  {
+   "id": "CAP-TUI-003",
+   "area": "TUI",
+   "name": "New session dialog (n)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-003-TUI.txt",
+   "status": "verified",
+   "notes": "n opens New Session dialog: Name field, Multi-repo toggle, Path (defaulted to cursor group's path), command pill picker (shell/claude/gemini/opencode/codex/pi/copilot/crush/cursor/hermes), Custom comm"
+  },
+  {
+   "id": "CAP-TUI-004",
+   "area": "TUI",
+   "name": "Quick create (N) and zoxide quick-open (z)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-004-TUI.txt",
+   "status": "verified",
+   "notes": "N quick-create instantly created session 'stone-pine' with no dialog and an auto-generated unique name; appeared in ad list. zoxide picker (z) not exercised (no zoxide DB in sandbox) but N path fully "
+  },
+  {
+   "id": "CAP-TUI-005",
+   "area": "TUI",
+   "name": "Fork: quick fork (f) and fork dialog (F)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-005-CLI.txt",
+   "status": "partial",
+   "notes": "Fork gating verified on both surfaces: F/f did NOT open the fork dialog on shell sessions or non-resumable claude sessions (CanFork()==false). CLI 'session fork' gives the exact gate: \"session 'gitcla"
+  },
+  {
+   "id": "CAP-TUI-005",
+   "area": "TUI",
+   "name": "Fork: quick fork (f) and fork dialog (F)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TUI-006",
+   "area": "TUI",
+   "name": "Session lifecycle: delete (d) / close (D) / remove (X) / bulk remove (ctrl+x) / undo (ctrl+z)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-006c-TUI.txt",
+   "status": "verified",
+   "notes": "ConfirmDialog verified for all variants. d: 'Delete Session? beta, Any running processes will be killed' -> y -> removed from list+SQLite. ctrl+z undo: beta restored AND Restart()'d (came back as live"
+  },
+  {
+   "id": "CAP-TUI-006",
+   "area": "TUI",
+   "name": "Session lifecycle: delete (d) / close (D) / remove (X) / bulk remove (ctrl+x) / undo (ctrl+z)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TUI-007",
+   "area": "TUI",
+   "name": "Restart (R) and restart-fresh (T)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-007-TUI.txt",
+   "status": "verified",
+   "notes": "R restart on running beta kept it live; R on errored gitsess started it (created live tmux session, status flipped error->idle, preview showed Output). Restart resolves instance live. T restart-fresh "
+  },
+  {
+   "id": "CAP-TUI-008",
+   "area": "TUI",
+   "name": "MCP Manager (m)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-008-TUI.txt",
+   "status": "verified",
+   "notes": "m on a claude session opens MCP Manager: scopes [LOCAL] GLOBAL USER, Tab cycles them (LOCAL='.mcp.json this project'; GLOBAL='Claude config (profile-specific)'; USER='\u26a0 Writes to: ~/.claude.json (ALL "
+  },
+  {
+   "id": "CAP-TUI-009",
+   "area": "TUI",
+   "name": "Plugin Manager (L)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-009-TUI.txt",
+   "status": "verified",
+   "notes": "L on claude session opens Plugin Manager: title, 'space toggle \u00b7 up/down move \u00b7 enter apply \u00b7 esc cancel' keys, empty-catalog help ('Add [plugins.<name>] tables to config.toml, See docs/rfc/PLUGIN_ATT"
+  },
+  {
+   "id": "CAP-TUI-010",
+   "area": "TUI",
+   "name": "Skills Manager (s)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-010-TUI.txt",
+   "status": "verified",
+   "notes": "s on claude session opens Skills Manager: POOL scope, 'Writes to: .agent-deck/skills.toml + .claude/skills (project)', empty-pool help pointing at the pool dir, two-column model with '<-> column / up-"
+  },
+  {
+   "id": "CAP-TUI-011",
+   "area": "TUI",
+   "name": "Edit Session dialog (P) and Edit Paths dialog (p)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-011-TUI.txt",
+   "status": "verified",
+   "notes": "P opens Edit Session dialog (local sessions): Title field (cl-sess), Tool pill row (restart), Claude-specific '[x] Skip permissions (restart, claude)', '[ ] Auto mode (restart, claude)', 'Extra args ("
+  },
+  {
+   "id": "CAP-TUI-012",
+   "area": "TUI",
+   "name": "Group management (g create, r rename, M move, reorder/indent)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-012-TUI.txt",
+   "status": "verified",
+   "notes": "g opens GroupDialog 'Create New Group' with [Root]/Subgroup toggle (Tab toggle/next, Shift+Tab prev), Name field. M opens 'Move to Group' list. CLI 'ad group create myscope' created group with default"
+  },
+  {
+   "id": "CAP-TUI-013",
+   "area": "TUI",
+   "name": "Group-scoped launch (--group) and group-scoped navigation layer",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-013-TUI.txt",
+   "status": "verified",
+   "notes": "'agent-deck --group myscope' launched TUI scoped to that subtree: header shows 'Agent Deck [myscope]' and list shows ONLY the myscope group (other 2 groups hidden). --group/-g flag documented in ad --"
+  },
+  {
+   "id": "CAP-TUI-013",
+   "area": "TUI",
+   "name": "Group-scoped launch (--group) and group-scoped navigation layer",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-013-TUI.txt",
+   "status": "verified",
+   "notes": "Alt+j/Alt+k navigate within current group (moved beta<->stone-pine). nav-hint sentinel '.nav-hint-v1760-shown' written under data dir on first launch (26 bytes)."
+  },
+  {
+   "id": "CAP-TUI-014",
+   "area": "TUI",
+   "name": "Jump mode (Space)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-014-TUI.txt",
+   "status": "verified",
+   "notes": "Space enters jump mode: home-row hint labels spliced into item names (alpha->dlpha, beta->feta, cl-sess->jl-sess, group->sd-sbx...). Esc exits. Confirms Vimium-style hint overlay."
+  },
+  {
+   "id": "CAP-TUI-015",
+   "area": "TUI",
+   "name": "Search: local (/), global (G), status-keyword filters",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-015-TUI.txt",
+   "status": "verified",
+   "notes": "/ opens '\ud83d\udd0d Local Search (Agent Deck sessions)' with status-keyword hint (waiting/running/idle); typing 'beta' live-filtered to '\u203a beta (shell)' '1 result'. G (global search) ALSO opens Local Search \u2014 "
+  },
+  {
+   "id": "CAP-TUI-016",
+   "area": "TUI",
+   "name": "Status filters and filter bar",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-016-TUI.txt",
+   "status": "partial",
+   "notes": "Filter bar renders with legend '!@#$ filter \u2022 0 all \u2022 % open' and live status counts (All \u25cf \u25d0 \u25cb \u2715 counts). 0 clears, ! @ % keys accepted. NOTE: $ opened the Cost Dashboard (a costs.Store IS wired in t"
+  },
+  {
+   "id": "CAP-TUI-017",
+   "area": "TUI",
+   "name": "Preview pane (right/bottom panel)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-017-TUI.txt",
+   "status": "verified",
+   "notes": "Preview pane shows session info card (Repo/Path/tool/timestamps, Claude status card), live tmux output tail (typed 'echo INSERTMODE_OK' echoed in preview within ~60ms), and Session Error card for dead"
+  },
+  {
+   "id": "CAP-TUI-018",
+   "area": "TUI",
+   "name": "Copy / send output (c, C, x)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-018b-TUI.txt",
+   "status": "verified",
+   "notes": "x opens SessionPickerDialog 'Send Output To...' (Enter send / Esc cancel / j/k navigate). c (copy last AI response) and C (copy info) are bound and fire without error; clipboard result is OSC52/transi"
+  },
+  {
+   "id": "CAP-TUI-019",
+   "area": "TUI",
+   "name": "Insert mode (I): type-through to session",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-019b-TUI.txt",
+   "status": "verified",
+   "notes": "I on running beta enters insert mode: bottom bar becomes '-- INSERT -- \u2192 beta  Esc to exit \u00b7 Enter to submit'. Typed 'echo INSERTMODE_OK' + Enter forwarded keystrokes to beta's tmux pane; the command "
+  },
+  {
+   "id": "CAP-TUI-020",
+   "area": "TUI",
+   "name": "Quick approve (a), mark unread (u), YOLO toggle (y), Gemini model picker (ctrl+g)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-020-TUI-markunread.txt, ev-CAP-TUI-020-TUI-yolo-toggle.txt, ev-CAP-TUI-020-TUI-gemini-model.txt, ev-CAP-TUI-020-TUI-quickapprove.txt",
+   "status": "partial",
+   "notes": "u mark-unread persists acknowledged=0 to SQLite (verified). y yolo toggle on gemini session flipped tool_data {} -> {\"gemini_yolo_mode\":true} in SQLite and renders [YOLO] badge (verified). ctrl+g open"
+  },
+  {
+   "id": "CAP-TUI-021",
+   "area": "TUI",
+   "name": "Worktree finish (W)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-021-TUI-worktree-finish.txt",
+   "status": "verified",
+   "notes": "W on a real git-worktree session opened the two-step Finish Worktree dialog: Session/Branch/Status (clean, async uncommitted check ran), [x] Merge into target branch (default on), Target:>main (detect"
+  },
+  {
+   "id": "CAP-TUI-022",
+   "area": "TUI",
+   "name": "Settings panel (S) + tool visibility panel",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-022-TUI-settings.txt, ev-CAP-TUI-022-TUI-settings-full.txt, ev-CAP-TUI-022-CLI-config-preserved.txt",
+   "status": "verified",
+   "notes": "S opens settings with all sections (Theme radio, Default tool, Claude dangerous/config-dir, Gemini/Codex/Hermes YOLO, Updates, Logs, Global Search enabled/tier/recent-days, Preview show output/analyti"
+  },
+  {
+   "id": "CAP-TUI-023",
+   "area": "TUI",
+   "name": "Watcher panel (w) + watcher event dispatch",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-023-TUI-watcher.txt",
+   "status": "verified",
+   "notes": "w opens the Watcher overlay: WATCHERS header, 'No watchers configured' empty state, quick actions [Enter] Details [s] Start [x] Stop [t] Test [w/Esc] Close. Engine-lifecycle/event-dispatch to conducto"
+  },
+  {
+   "id": "CAP-TUI-024",
+   "area": "TUI",
+   "name": "Cost dashboard ($) and analytics",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-024-TUI-cost-dashboard.txt",
+   "status": "verified",
+   "notes": "$ opened the full-screen Cost Dashboard (costs.Store IS wired in this build): Today/Week/Month/Projected cards, Today tokens Input/Output/Cache R/Cache W breakdown, Top Sessions, Cost by Model table, "
+  },
+  {
+   "id": "CAP-TUI-025",
+   "area": "TUI",
+   "name": "Remote sessions (SSH remotes section)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-025-CLI-remote.txt, ev-CAP-TUI-025-TUI-remotes.txt",
+   "status": "partial",
+   "notes": "Remote registration front door works: 'remote add' wrote [remotes.testremote] and 'remote list' shows it (host/path/profile). 'remote sessions' over SSH gracefully reports 'Could not resolve hostname'"
+  },
+  {
+   "id": "CAP-TUI-026",
+   "area": "TUI",
+   "name": "Import tmux sessions (i) and manual reload (ctrl+r)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-026-TUI-import.txt, ev-CAP-TUI-026-TUI-reload.txt",
+   "status": "verified",
+   "notes": "i discovered an orphan tmux session (orphan_import_test) not in the registry, appended it as an instance AND added to the group tree, saving both (instance count 6->8). ctrl+r force-reload picked up a"
+  },
+  {
+   "id": "CAP-TUI-027",
+   "area": "TUI",
+   "name": "Status detection, notifications, hooks prompt",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-027-TUI-hooks-prompt.txt",
+   "status": "verified",
+   "notes": "First-run ConfirmInstallHooks dialog shown ('Claude Code Hooks', Install/Skip, y install/n skip). Choosing Skip ('n') persisted metadata hooks_prompted='declined' in state.db (verified). Status detect"
+  },
+  {
+   "id": "CAP-TUI-028",
+   "area": "TUI",
+   "name": "Quit flow and shutdown",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-028-TUI-quit.txt",
+   "status": "verified",
+   "notes": "q cleanly exits the TUI (tmux session ends). On quit, ui_state metadata is persisted (cursor_group_path, preview_mode) and a full instance+group save runs. NOTE observed side-effect: the quit-time who"
+  },
+  {
+   "id": "CAP-TUI-029",
+   "area": "TUI",
+   "name": "Help overlay (?), footer help bar, update nudge, feedback dialog (ctrl+e)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-029-TUI-help.txt, ev-CAP-TUI-029-TUI-feedback.txt",
+   "status": "verified",
+   "notes": "? opens the scrollable shortcuts modal with live bindings (NAVIGATION, GROUP NAVIGATION v1.7.60 Alt-layer, SESSIONS sections, '\u25bc more below', 'j/k scroll \u2022 any other key to close'). ctrl+e opens the f"
+  },
+  {
+   "id": "CAP-TUI-030",
+   "area": "TUI",
+   "name": "Setup wizard (first run)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-030-TUI-setup-wizard.txt, evidence/tui/ev-CAP-TUI-030-CLI-wizard-config.txt",
+   "status": "verified",
+   "notes": "Launching with no config.toml shows the wizard: Welcome -> Tool selection (claude/gemini/opencode/codex/pi/shell/...) -> Claude Code Settings (dangerous mode + config dir, only shown when claude chose"
+  },
+  {
+   "id": "CAP-TUI-031",
+   "area": "TUI",
+   "name": "Hotkey remapping ([hotkeys] config)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-031-TUI-hotkey-remap.txt",
+   "status": "verified",
+   "notes": "[hotkeys] new_session='z' remapped 'z' to open the New Session dialog (overriding default zoxide binding). The rebound default 'n' was BLOCKED (pressing n no longer opens the dialog \u2014 no double-fire)."
+  },
+  {
+   "id": "CAP-TUI-032",
+   "area": "TUI",
+   "name": "Mouse support",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-032-TUI-mouse.txt",
+   "status": "verified",
+   "notes": "SGR mouse click at row 8 moved the cursor to the correctly-mapped list item (m2) \u2014 Y-to-index math accounts for header/banner offset. Mouse wheel-down over the list moved the cursor (m2->m3). Both cli"
+  },
+  {
+   "id": "CAP-TUI-033",
+   "area": "TUI",
+   "name": "Notes editing (e)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-033-TUI-notes-edit.txt, ev-CAP-TUI-033-TUI-notes-saved.txt",
+   "status": "verified",
+   "notes": "With [preview] show_notes=true, e on a live session opens the Notes textarea ('Ctrl+S save \u2022 Esc cancel', split with Output pane). Typed 'verify-note-123', Ctrl+S saved; preview re-renders the note an"
+  },
+  {
+   "id": "CAP-TUI-034",
+   "area": "TUI",
+   "name": "Sandbox shell exec (E)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-034-TUI-sandbox-shell.txt",
+   "status": "partial",
+   "notes": "E on a non-sandboxed session is a no-op (correctly gated \u2014 only sessions with a SandboxContainer open a container shell). Docker IS installed locally, but the positive path requires creating a Docker-"
+  },
+  {
+   "id": "CAP-TUI-035",
+   "area": "TUI",
+   "name": "Web bridge (WebMutator) and web menu snapshots",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-035-WEB.png",
+   "status": "verified",
+   "notes": "Web/TUI share the same Home/profile; the web UI's session list/detail mirror the TUI state (publishWebMenuSnapshot). No in-TUI profile switcher (profile fixed at launch) \u2014 consistent with contract."
+  },
+  {
+   "id": "CAP-TUI-035",
+   "area": "TUI",
+   "name": "Web bridge (WebMutator) and web menu snapshots",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TUI-036",
+   "area": "TUI",
+   "name": "Theme handling (system dark/light watcher)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-036-TUI-theme-system.txt, ev-CAP-TUI-036-TUI-theme-launched.txt",
+   "status": "partial",
+   "notes": "Theme setting offers dark/light/system radio (settings panel + setup wizard). Toggling theme persists to config.toml theme key (dark/light/system all verified to write). With theme='system' the TUI la"
+  },
+  {
+   "id": "CAP-TUI-037",
+   "area": "TUI",
+   "name": "Keyboard compatibility layer (Kitty/CSI u, Shift+Enter)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-032-TUI-mouse.txt",
+   "status": "partial",
+   "notes": "The Private-Use rune U+E5E5 (the Shift+Enter relay) was processed by normalizeMainKey without crashing the TUI (no-op on non-macOS where iTerm isn't available). Help overlay documents 'Shift+Enter Ope"
+  },
+  {
+   "id": "CAP-WEB-001",
+   "area": "WEB",
+   "name": "Web server bootstrap, config and security gate",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-001-CLI-help.txt, ev-CAP-WEB-001-CLI-bindgate.txt, ev-CAP-WEB-001-CLI-emptyhost.txt, ev-CAP-WEB-016-CLI-pushtest-requires.txt",
+   "status": "verified",
+   "notes": "web --help shows all flags (--listen/--read-only/--token/--insecure-bind/--push/--push-vapid-subject/--push-test-every/--no-tui). Bind gate refuses non-loopback (0.0.0.0:18999) and empty-host (:19000)"
+  },
+  {
+   "id": "CAP-WEB-001",
+   "area": "WEB",
+   "name": "Web server bootstrap, config and security gate",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-WEB-001",
+   "area": "WEB",
+   "name": "Web server bootstrap, config and security gate",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-001-mutdisabled.txt, ev-CAP-WEB-002-healthz-unauth.json",
+   "status": "verified",
+   "notes": "--read-only sets webMutations=false; POST mutation returns 403 MUTATIONS_DISABLED while GET still 200. Error envelope uniform {error:{code,message}} with documented codes observed (UNAUTHORIZED, MUTAT"
+  },
+  {
+   "id": "CAP-WEB-002",
+   "area": "WEB",
+   "name": "Authentication (bearer token) + CSRF protection",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-002-noauth.json, ev-CAP-WEB-002-csrf.txt, ev-CAP-WEB-002-csrf-mismatch.txt, ev-CAP-WEB-002-csrf-ok.txt, ev-CAP-WEB-002-healthz-unauth.json",
+   "status": "verified",
+   "notes": "With --token: no token->401 UNAUTHORIZED, wrong token->401, correct Bearer->200, ?token= on REST rejected 401. healthz unauth shows only {ok,time}; authed adds profile/readOnly/version/webMutations (i"
+  },
+  {
+   "id": "CAP-WEB-003",
+   "area": "WEB",
+   "name": "Menu / session-list read API with hook-status overlay",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-003-menu.json, ev-CAP-WEB-003-sessions.json, ev-CAP-WEB-003-groups.json, ev-CAP-WEB-003-session-single.json, ev-CAP-WEB-003-404.json",
+   "status": "verified",
+   "notes": "GET /api/menu returns {profile,generatedAt,totalGroups,totalSessions,items[]} with group/session MenuItems. /api/sessions returns {sessions[],groups[],profile}. /api/groups returns {groups[]} with exp"
+  },
+  {
+   "id": "CAP-WEB-004",
+   "area": "WEB",
+   "name": "SSE live menu stream",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-004-sse.txt",
+   "status": "verified",
+   "notes": "GET /events/menu emits 'event: menu' + full MenuSnapshot JSON immediately. Content-Type text/event-stream, Cache-Control no-cache, X-Accel-Buffering: no headers present. Full-snapshot-per-event confir"
+  },
+  {
+   "id": "CAP-WEB-005",
+   "area": "WEB",
+   "name": "Session lifecycle mutations (create/start/stop/restart/close/delete/fork/undelete)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-005-create.txt, ev-CAP-WEB-005-create-bad.txt, ev-CAP-WEB-005-badaction.txt, ev-CAP-WEB-005-tui-restart.txt, ev-CAP-WEB-005-tui-delete.txt, ev-CAP-WEB-005-tui-undelete.txt",
+   "status": "verified",
+   "notes": "POST /api/sessions create->201 {sessionId} and persists (read-back confirms). Missing title->400 INVALID_REQUEST. Unknown action->404. Via TUI-backed mutator: restart->200 {sessionId}, DELETE->200 {de"
+  },
+  {
+   "id": "CAP-WEB-006",
+   "area": "WEB",
+   "name": "Session field edit (PATCH /api/sessions/{id})",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-006-tui-patch-valid.txt, ev-CAP-WEB-006-emptytitle.txt, ev-CAP-WEB-006-nofields.txt, ev-CAP-WEB-006-tui-restartreq.txt",
+   "status": "verified",
+   "notes": "PATCH /api/sessions/{id} via TUI mutator returns 200 {sessionId,updatedFields:[notes,color,title],restartRequired:false}. Empty/whitespace title->400 'title cannot be empty'. No fields->400 'at least "
+  },
+  {
+   "id": "CAP-WEB-007",
+   "area": "WEB",
+   "name": "Group management (create/rename/delete)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-007-tui-create.txt, ev-CAP-WEB-007-tui-rename.txt, ev-CAP-WEB-007-tui-del.txt, ev-CAP-WEB-007-subgroup.txt",
+   "status": "verified",
+   "notes": "Via TUI mutator: POST /api/groups {name}->201 {path}; PATCH /api/groups/{path} {name}->200 {name,path} returning OLD path per contract; DELETE->200 {deleted:path}; subgroup create with parentPath->201"
+  },
+  {
+   "id": "CAP-WEB-008",
+   "area": "WEB",
+   "name": "Worktree finish (merge + teardown) endpoint",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-008-tui-finish.txt, ev-CAP-WEB-008-finish-404.txt",
+   "status": "verified",
+   "notes": "POST /api/sessions/{id}/worktree/finish on a non-worktree session->400 INVALID_REQUEST 'session is not in a worktree' (ErrNotAWorktree) via TUI mutator. Unknown id->404 'session not found'. Empty body"
+  },
+  {
+   "id": "CAP-WEB-009",
+   "area": "WEB",
+   "name": "Children topology endpoint (conductor tree)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-009-children.json",
+   "status": "verified",
+   "notes": "GET /api/sessions/{id}/children->200 {sessionId,children:[]} (empty array for leaf). Non-GET (POST)->405. Unknown id->404. Recursive SessionChildNode tree shape confirmed (empty here, no children crea"
+  },
+  {
+   "id": "CAP-WEB-010",
+   "area": "WEB",
+   "name": "Skills management API",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-WEB-010",
+   "area": "WEB",
+   "name": "Skills management API",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-010-skills.json, ev-CAP-WEB-010-session-skills.txt, ev-CAP-WEB-010-attach.txt, ev-CAP-WEB-010-claude-skills.txt, ev-CAP-WEB-010-claude-attach.txt, ev-CAP-WEB-010-claude-detach.txt",
+   "status": "verified",
+   "notes": "GET /api/skills->{skills:[]} catalog (empty in sandbox). GET /api/sessions/{id}/skills->200 {skills:[]}. Attach to shell session->400 'session tool does not support project skills' (SupportsProjectSki"
+  },
+  {
+   "id": "CAP-WEB-011",
+   "area": "WEB",
+   "name": "MCP management API",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-WEB-011",
+   "area": "WEB",
+   "name": "MCP management API",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-011-mcps.txt, ev-CAP-WEB-011-session-mcps.txt, ev-CAP-WEB-011-attach.txt, ev-CAP-WEB-011-patch.txt",
+   "status": "partial",
+   "notes": "CONFIRMED PRODUCTION WIRING GAP (matches v2 notes): the shipped 'agent-deck web' binary never calls SetMCPManager, so GET/POST/DELETE/PATCH /api/mcps* all return 503 NOT_IMPLEMENTED 'MCP manager not a"
+  },
+  {
+   "id": "CAP-WEB-012",
+   "area": "WEB",
+   "name": "Costs API + costs SSE stream",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-012-summary.txt, ev-CAP-WEB-012-daily.txt, ev-CAP-WEB-012-batch.txt, ev-CAP-WEB-012-batch-post.txt, ev-CAP-WEB-012-stream.txt, ev-CAP-WEB-012-export.csv",
+   "status": "verified",
+   "notes": "/api/costs/summary->{today/week/month_usd+events,projected_usd}. /api/costs/daily?days=7->[]. /api/costs/batch GET and POST->{costs:{id:0}}. /api/costs/export?format=csv->200 with Content-Disposition "
+  },
+  {
+   "id": "CAP-WEB-013",
+   "area": "WEB",
+   "name": "System stats endpoint",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-013-system.json",
+   "status": "verified",
+   "notes": "GET /api/system/stats->200 with cpu, disk, load, memory, network sections (gpu absent as expected when sysinfo reports unavailable). Collected per-request via sysinfo.Collect()."
+  },
+  {
+   "id": "CAP-WEB-014",
+   "area": "WEB",
+   "name": "Settings + profiles read endpoints",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-014-settings.json, ev-CAP-WEB-014-profiles.json",
+   "status": "verified",
+   "notes": "GET /api/settings->{profile,readOnly,webMutations,version,toolFilter,visibleTools[],toolFilterFallback,hiddenTools[],pickerTools[]}; visibleTools resolved live from PATH (claude,opencode,gemini,...,sh"
+  },
+  {
+   "id": "CAP-WEB-015",
+   "area": "WEB",
+   "name": "WebSocket terminal bridge (live tmux attach in browser)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-015-ws.txt",
+   "status": "verified",
+   "notes": "GET /ws/session/{id} upgrades to WebSocket; emits {status,connected} then {status,ready}. When tmux session absent, sends {error,code:TMUX_SESSION_NOT_FOUND,hint:'Restart it from the sidebar...'} and "
+  },
+  {
+   "id": "CAP-WEB-016",
+   "area": "WEB",
+   "name": "Web Push notifications (PWA)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-WEB-016",
+   "area": "WEB",
+   "name": "Web Push notifications (PWA)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-016-config.json, ev-CAP-WEB-016-subscribe.txt, ev-CAP-WEB-016-presence.txt, ev-CAP-WEB-016-unsubscribe.txt, ev-CAP-WEB-016-files.txt, ev-CAP-WEB-016-CLI-pushtest-requires.txt, ev-CAP-WEB-016-subscribe-disabled.txt",
+   "status": "verified",
+   "notes": "--push generates VAPID keypair: /api/push/config->{enabled:true,subject:mailto:agentdeck@localhost,vapidPublicKey(87-char base64)}. subscribe->200 {ok,'subscription saved'}, subscriptionCount->1; pres"
+  },
+  {
+   "id": "CAP-WEB-017",
+   "area": "WEB",
+   "name": "Static assets, SPA serving and PWA shell",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-017-spa.png, ev-CAP-WEB-017-index.html",
+   "status": "verified",
+   "notes": "GET / serves index.html (text/html, Referrer-Policy: no-referrer, Cache-Control no-cache/no-store). GET /s/{deeplink}->200 index. /manifest.webmanifest->application/manifest+json no-cache. /sw.js->app"
+  },
+  {
+   "id": "CAP-WEB-018",
+   "area": "WEB",
+   "name": "Parity contract with TUI/CLI (what web can and cannot do)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/web/ev-CAP-WEB-018-parity.txt, ev-CAP-WEB-018-methodnotallowed.txt",
+   "status": "verified",
+   "notes": "Parity probes: TUI-only MISSING actions all 404 (restart-fresh, rename, move, yolo, approve, /api/search, /api/help). Inconsistent singular/plural URL pair confirmed: GET /api/sessions/{id}->404 (sing"
+  },
+  {
+   "id": "CAP-SESS-001",
+   "area": "SESS",
+   "name": "Session data model (Instance) and identity generation",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-001-CLI.txt",
+   "status": "verified",
+   "notes": "ad add/list --json shows Instance identity model. ID format matches randomString(8hex)-unixseconds (e.g. 0d8070e1-1781198354); tmux_session matches agentdeck_<sanitizedTitle>_<8hex> (e.g. agentdeck_al"
+  },
+  {
+   "id": "CAP-SESS-001",
+   "area": "SESS",
+   "name": "Session data model (Instance) and identity generation",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-TUI-home.txt",
+   "status": "verified",
+   "notes": "TUI session list renders title+tool+group tree. New Session modal shows full tool enum: shell/claude/gemini/opencode/codex/pi/copilot/crush/cursor agent/hermes, matching the spec's Tool field allowlis"
+  },
+  {
+   "id": "CAP-SESS-001",
+   "area": "SESS",
+   "name": "Session data model (Instance) and identity generation",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-WEB.txt",
+   "status": "verified",
+   "notes": "/api/sessions exposes id,title,tool,status,groupPath,projectPath,tmuxSession,tmuxSocketName,createdAt,command,noTransitionNotify. tmuxSocketName=adv805088 (immutable isolated socket field). beta's tmu"
+  },
+  {
+   "id": "CAP-SESS-002",
+   "area": "SESS",
+   "name": "Lifecycle states and transitions",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-002-CLI.txt",
+   "status": "verified",
+   "notes": "Lifecycle states observed: started shell session->idle; never-started sessions->error (tmuxSession.Exists()==false per contract case a); stop->stopped (persisted; show confirms status=stopped). ad sta"
+  },
+  {
+   "id": "CAP-SESS-002",
+   "area": "SESS",
+   "name": "Lifecycle states and transitions",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-TUI-home.txt",
+   "status": "verified",
+   "notes": "TUI status icons rendered per-session and in header legend: running(filled), waiting, idle(circle), stopped(square), error(x). Group rollup counts shown (idle/stopped/error). Matches Status enum seman"
+  },
+  {
+   "id": "CAP-SESS-002",
+   "area": "SESS",
+   "name": "Lifecycle states and transitions",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-WEB.txt",
+   "status": "verified",
+   "notes": "/api/sessions reports per-session status strings (error/idle/stopped) consistent with CLI/TUI."
+  },
+  {
+   "id": "CAP-SESS-003",
+   "area": "SESS",
+   "name": "Status derivation pipeline (UpdateStatus)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-003-CLI.txt",
+   "status": "verified",
+   "notes": "ad status -v / --json drives the CLI cold-load poll (RefreshInstancesForCLIStatus): statuses are derived live from tmux existence (idle for live shell-at-prompt, error for missing tmux session), not s"
+  },
+  {
+   "id": "CAP-SESS-003",
+   "area": "SESS",
+   "name": "Status derivation pipeline (UpdateStatus)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-003",
+   "area": "SESS",
+   "name": "Status derivation pipeline (UpdateStatus)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-004",
+   "area": "SESS",
+   "name": "Spawn paths: Start / StartWithMessage and the capture-resume pattern",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-004-CLI.txt",
+   "status": "verified",
+   "notes": "Start() spawns tmux pane; AGENTDECK_INSTANCE_ID propagated into tmux session env (=51bd32c7-1781198354, equals the instance ID) confirming the host-side env join key. Per-instance spawn-lock stamp fil"
+  },
+  {
+   "id": "CAP-SESS-004",
+   "area": "SESS",
+   "name": "Spawn paths: Start / StartWithMessage and the capture-resume pattern",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-005",
+   "area": "SESS",
+   "name": "Claude conversation binding: CLAUDE_SESSION_ID lifecycle and rebind guards",
+   "surface": "SESS",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-006",
+   "area": "SESS",
+   "name": "Duplicate-session killer (killing_duplicate_session)",
+   "surface": "SESS",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-007",
+   "area": "SESS",
+   "name": "Resume and restart logic (claude --resume)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-005-007-CLI.txt",
+   "status": "verified",
+   "notes": "ad session restart beta succeeds, returns to idle (fast-path for live tmux). Restart-guard observed: ad session start on an already-running session errors 'already running'; restart path then succeeds"
+  },
+  {
+   "id": "CAP-SESS-007",
+   "area": "SESS",
+   "name": "Resume and restart logic (claude --resume)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-008",
+   "area": "SESS",
+   "name": "Session registry: storage Load/Save semantics (state.db)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-008-CLI.txt",
+   "status": "verified",
+   "notes": "state.db (SQLite WAL: state.db + -wal + -shm) created at <data>/agent-deck/profiles/personal/. Sessions persist across separate CLI process invocations (3 sessions re-read by a fresh process with iden"
+  },
+  {
+   "id": "CAP-SESS-008",
+   "area": "SESS",
+   "name": "Session registry: storage Load/Save semantics (state.db)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-008",
+   "area": "SESS",
+   "name": "Session registry: storage Load/Save semantics (state.db)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-WEB.txt",
+   "status": "verified",
+   "notes": "Headless web server (ad web --no-tui) reads the same state.db as source of truth and serves all sessions via /api/sessions when pinned to the matching profile."
+  },
+  {
+   "id": "CAP-SESS-009",
+   "area": "SESS",
+   "name": "Hook-based status pipeline (Claude Code hooks to status files to watcher)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-010",
+   "area": "SESS",
+   "name": "Parent-child relationships, transition notification, and completion delivery",
+   "surface": "DAEMON/INTERNAL",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-011",
+   "area": "SESS",
+   "name": "Death detection and the parent-signal gap (tmux pane / claude process dies)",
+   "surface": "DAEMON/INTERNAL",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-012",
+   "area": "SESS",
+   "name": "Group membership and per-group concurrency",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-012-CLI.txt",
+   "status": "verified",
+   "notes": "Explicit -g mygroup assigns group; auto-derivation puts path-tail-named group. group list shows per-group session+status counts. group create defaults max_concurrent=1 (serial). group update --max-con"
+  },
+  {
+   "id": "CAP-SESS-012",
+   "area": "SESS",
+   "name": "Group membership and per-group concurrency",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-TUI-home.txt",
+   "status": "verified",
+   "notes": "TUI renders the group tree with per-group session counts and status rollups (ad-sbx-sess(3), mygroup(1), serialgrp(2)), confirming group membership and the groups table."
+  },
+  {
+   "id": "CAP-SESS-013",
+   "area": "SESS",
+   "name": "Child environment propagation (childenv) and spawn-env hygiene",
+   "surface": "SESS",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-001",
+   "area": "FORK",
+   "name": "Claude conversation fork (capture-resume via --fork-session)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-002-003-004-CLI-gate.txt",
+   "status": "partial",
+   "notes": "Fork CLI front door verified: `agent-deck session fork` exists with all documented flags (-t,-g,-w,-b,--with-state,--with-state-and-gitignored,--sandbox,--json). CanFork gate fires correctly: forking "
+  },
+  {
+   "id": "CAP-FORK-001",
+   "area": "FORK",
+   "name": "Claude conversation fork (capture-resume via --fork-session)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-TUI-help.txt",
+   "status": "partial",
+   "notes": "TUI keybinding `f/F Fork session (Claude/Pi)` confirmed present in help screen. Pressing F on an unstarted (error-state) claude session is a no-op (CanFork gate). Driving a real quick-fork needs a cap"
+  },
+  {
+   "id": "CAP-FORK-001",
+   "area": "FORK",
+   "name": "Claude conversation fork (capture-resume via --fork-session)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-005-WEB.txt",
+   "status": "partial",
+   "notes": "Web /api/sessions exposes per-session `canFork` boolean (=false for unstarted claude, matching the CanFork freshness gate) and a POST /api/sessions/<id>/fork action route exists. Executing a real web "
+  },
+  {
+   "id": "CAP-FORK-002",
+   "area": "FORK",
+   "name": "OpenCode fork (export/sed/import script)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-002-003-004-CLI-gate.txt",
+   "status": "partial",
+   "notes": "CanForkOpenCode gate verified: `session fork tool-opencode` -> 'cannot be forked: no resumable session for tool opencode' (exit 1). opencode binary not installed and export/sed/import fork script exec"
+  },
+  {
+   "id": "CAP-FORK-002",
+   "area": "FORK",
+   "name": "OpenCode fork (export/sed/import script)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-002",
+   "area": "FORK",
+   "name": "OpenCode fork (export/sed/import script)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-003",
+   "area": "FORK",
+   "name": "Pi fork (JSONL file fork)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-002-003-004-CLI-gate.txt",
+   "status": "partial",
+   "notes": "CanForkPi gate verified: `session fork tool-pi` -> 'cannot be forked: no resumable session for tool pi' (exit 1). pi binary not installed; the JSONL-file fork (find newest .jsonl + `pi --fork`) needs "
+  },
+  {
+   "id": "CAP-FORK-003",
+   "area": "FORK",
+   "name": "Pi fork (JSONL file fork)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-003",
+   "area": "FORK",
+   "name": "Pi fork (JSONL file fork)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-004",
+   "area": "FORK",
+   "name": "Codex fork (`codex fork <sid>`)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-004-CLI-notforkable.txt",
+   "status": "verified",
+   "notes": "Non-forkable rejection verified: `session fork bashsess` -> 'not a forkable session (tool: shell)' (exit 1). CanForkCodex gate verified: `session fork tool-codex` -> 'cannot be forked: no resumable se"
+  },
+  {
+   "id": "CAP-FORK-004",
+   "area": "FORK",
+   "name": "Codex fork (`codex fork <sid>`)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-004",
+   "area": "FORK",
+   "name": "Codex fork (`codex fork <sid>`)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-005",
+   "area": "FORK",
+   "name": "Fork dispatch and post-create pipeline",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-005-CLI-noexist.txt",
+   "status": "verified",
+   "notes": "Fork dispatch pipeline gates verified in order: session-resolve (non-existent -> 'session not found' exit 2), tool gate (shell -> 'not a forkable session' exit 1), CanFork gate (no resumable session e"
+  },
+  {
+   "id": "CAP-FORK-005",
+   "area": "FORK",
+   "name": "Fork dispatch and post-create pipeline",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-TUI-help.txt",
+   "status": "verified",
+   "notes": "TUI fork dispatch surfaces present: `f/F Fork session`, `F -> w Fork session into worktree`. TUI renders home list and fork bindings are wired (quickForkSession / fork dialog)."
+  },
+  {
+   "id": "CAP-FORK-005",
+   "area": "FORK",
+   "name": "Fork dispatch and post-create pipeline",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-006",
+   "area": "FORK",
+   "name": "Fork-with-state worktree (git, #1029/#1263)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-006-CLI-nostate-now.txt",
+   "status": "partial",
+   "notes": "--with-state / --with-state-and-gitignored flags present and documented (implies/requires -w). On a shell session the tool gate fires before the worktree-state machinery, so the with-state worktree ma"
+  },
+  {
+   "id": "CAP-FORK-006",
+   "area": "FORK",
+   "name": "Fork-with-state worktree (git, #1029/#1263)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-007",
+   "area": "FORK",
+   "name": "Fork-with-state workspace (jujutsu, #1305)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-010-nonrepo.txt",
+   "status": "untestable-locally",
+   "notes": "jujutsu (jj) is NOT installed on this host (command -v jj = NO). The jj fork-with-state workspace path (WorkingCopyParentRevision, CreateWorkspaceAtRevision, jj restore materialize, bookmark create) c"
+  },
+  {
+   "id": "CAP-FORK-007",
+   "area": "FORK",
+   "name": "Fork-with-state workspace (jujutsu, #1305)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-008",
+   "area": "FORK",
+   "name": "Plain worktree creation, path generation, branch resolution",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-008-DB.txt",
+   "status": "verified",
+   "notes": "Plain worktree creation fully verified via `add -w`: NEW branch with -b creates branch+worktree at <repo>/.worktrees/<sanitized-branch>; persisted to state.db (worktree_path, worktree_branch, worktree"
+  },
+  {
+   "id": "CAP-FORK-008",
+   "area": "FORK",
+   "name": "Plain worktree creation, path generation, branch resolution",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-009",
+   "area": "FORK",
+   "name": "Worktree removal, session-dismiss cleanup, #1200 data-loss guards",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-009-CLI-finish.txt",
+   "status": "partial",
+   "notes": "Worktree removal/cleanup verified: top-level `remove` cleans up the worktree dir while keeping the main repo intact (#1200 data-loss guard holds - main working tree never RemoveAll'd). `worktree finis"
+  },
+  {
+   "id": "CAP-FORK-009",
+   "area": "FORK",
+   "name": "Worktree removal, session-dismiss cleanup, #1200 data-loss guards",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-010",
+   "area": "FORK",
+   "name": "VCS backend abstraction and detection (git/jujutsu)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-010-git.txt",
+   "status": "partial",
+   "notes": "git backend detection verified: `worktree list --json` resolves repo_root, marks main vs worktree types, routes worktree creation through git. Non-repo dir with explicit -w errors loudly ('not a git o"
+  },
+  {
+   "id": "CAP-FORK-010",
+   "area": "FORK",
+   "name": "VCS backend abstraction and detection (git/jujutsu)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-011",
+   "area": "FORK",
+   "name": "Child environment construction (telegram/CLAUDE_CONFIG_DIR isolation)",
+   "surface": "DAEMON/INTERNAL",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-012",
+   "area": "FORK",
+   "name": "Parent-child session links (sub-sessions)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-012-DB.txt",
+   "status": "verified",
+   "notes": "Parent-child links fully verified: `add --parent` sets parent_session_id (persisted in state.db); single-level guard rejects sub-of-sub ('cannot create sub-session of a sub-session', exit 1); `session"
+  },
+  {
+   "id": "CAP-FORK-012",
+   "area": "FORK",
+   "name": "Parent-child session links (sub-sessions)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-FORK-013",
+   "area": "FORK",
+   "name": "Multi-repo worktree creation and fork propagation",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-009-cleanup.txt",
+   "status": "untestable-locally",
+   "notes": "Multi-repo worktree creation and fork propagation is TUI-driven (the 'p' Edit multi-repo paths keybind / fork of a multi-repo session). `add` with multiple path args does not create a multi-repo sessi"
+  },
+  {
+   "id": "CAP-FORK-014",
+   "area": "FORK",
+   "name": "Spawn singleflight guard (#1040 restart storm)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-014-storm.txt",
+   "status": "verified",
+   "notes": "Spawn singleflight guard (#1040) verified: `session start` creates locks/instance-spawn-<id>.stamp under the data locks dir; firing 5 concurrent `session start` against the same session yields exactly"
+  },
+  {
+   "id": "CAP-TMUX-001",
+   "area": "TMUX",
+   "name": "Session naming and identity",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-001-CLI.txt",
+   "status": "verified",
+   "notes": "add -t 'My Cool!Sess@01' produced tmux_session 'agentdeck_My-Cool-Sess-01_<8hex>'. Prefix 'agentdeck_', sanitizeName replaced space/!/@ with '-', 8-hex-char crypto suffix. Confirmed via list --json."
+  },
+  {
+   "id": "CAP-TMUX-001",
+   "area": "TMUX",
+   "name": "Session naming and identity",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-001",
+   "area": "TMUX",
+   "name": "Session naming and identity",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-004-WEB.txt",
+   "status": "verified",
+   "notes": "/api/sessions returns tmuxSession 'agentdeck_logtest_<hex>' and 'agentdeck_My-Cool-Sess-01_<hex>' \u2014 same prefix+sanitize+suffix contract surfaced over web."
+  },
+  {
+   "id": "CAP-TMUX-002",
+   "area": "TMUX",
+   "name": "Session creation (Start) with 3-tier systemd launch fallback",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-002-CLI.txt,evidence/tmux/ev-CAP-TMUX-002b-CLI.txt",
+   "status": "verified",
+   "notes": "session start created tmux session (direct launch, no systemd needed in sandbox). show-options confirms the batched set-option block: mouse on, escape-time 10, extended-keys on, set-clipboard on, allo"
+  },
+  {
+   "id": "CAP-TMUX-002",
+   "area": "TMUX",
+   "name": "Session creation (Start) with 3-tier systemd launch fallback",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-003",
+   "area": "TMUX",
+   "name": "Socket isolation (-L plumbing)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-003-CLI.txt,evidence/tmux/ev-CAP-TMUX-003-isolation.txt",
+   "status": "verified",
+   "notes": "All sessions live ONLY on isolated socket 'advfixed' (adtmux -L). Zero agentdeck test sessions on the default server (proven 0). /api/sessions exposes tmuxSocketName 'advfixed'. stop killed the correc"
+  },
+  {
+   "id": "CAP-TMUX-003",
+   "area": "TMUX",
+   "name": "Socket isolation (-L plumbing)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-003",
+   "area": "TMUX",
+   "name": "Socket isolation (-L plumbing)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-004-WEB.txt",
+   "status": "verified",
+   "notes": "tmuxSocketName:'advfixed' present per session in /api/sessions \u2014 socket isolation plumbed through to web API."
+  },
+  {
+   "id": "CAP-TMUX-004",
+   "area": "TMUX",
+   "name": "Existence/liveness probing and per-tick caches",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-004-status.txt,evidence/tmux/ev-CAP-TMUX-010-CLI.txt",
+   "status": "verified",
+   "notes": "Liveness reflected in list/status: running session shows idle, stopped shows stopped, 'status' aggregates '0 waiting \u2022 0 running \u2022 1 idle'. has-session probe after stop returned EXIT=1 (gone)."
+  },
+  {
+   "id": "CAP-TMUX-004",
+   "area": "TMUX",
+   "name": "Existence/liveness probing and per-tick caches",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-004-TUI.txt",
+   "status": "verified",
+   "notes": "TUI list shows live status markers (\u25cb idle, \u25a0 stopped) per session, refreshed per tick; preview pane shows live capture."
+  },
+  {
+   "id": "CAP-TMUX-004",
+   "area": "TMUX",
+   "name": "Existence/liveness probing and per-tick caches",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-004-WEB.png",
+   "status": "verified",
+   "notes": "Web UI Fleet view renders per-session status (idle/stopped) and group counts."
+  },
+  {
+   "id": "CAP-TMUX-005",
+   "area": "TMUX",
+   "name": "Send-keys / prompt delivery semantics",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-005-CLI.txt,evidence/tmux/ev-CAP-TMUX-005-large.txt",
+   "status": "verified",
+   "notes": "session send delivered 'echo HELLO_FROM_SEND_12345' which executed (output captured). SendKeysAndEnter path: 100ms paste/Enter ordering worked. Large-prompt chunking verified: 5000-char payload delive"
+  },
+  {
+   "id": "CAP-TMUX-005",
+   "area": "TMUX",
+   "name": "Send-keys / prompt delivery semantics",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-008-confirm.txt",
+   "status": "verified",
+   "notes": "In TUI attach mode, typed keystrokes ('echo ATTACHED_PANE_OK_777') forwarded to the pane and executed \u2014 SendNamedKey/insert-mode delivery path."
+  },
+  {
+   "id": "CAP-TMUX-005",
+   "area": "TMUX",
+   "name": "Send-keys / prompt delivery semantics",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-006",
+   "area": "TMUX",
+   "name": "Output capture",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-006-CLI.txt,evidence/tmux/ev-CAP-TMUX-006-parity.txt",
+   "status": "verified",
+   "notes": "session output returns visible pane content (CapturePane). Parity with raw adtmux capture-pane confirmed (both reflect same pane, 42 vs 44 non-empty lines incl header)."
+  },
+  {
+   "id": "CAP-TMUX-006",
+   "area": "TMUX",
+   "name": "Output capture",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-004-TUI.txt",
+   "status": "verified",
+   "notes": "TUI preview pane streams live captured Output (sudo banner + prompt) for the selected session."
+  },
+  {
+   "id": "CAP-TMUX-006",
+   "area": "TMUX",
+   "name": "Output capture",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-007",
+   "area": "TMUX",
+   "name": "Control-mode pipe layer (ControlPipe + PipeManager)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-007",
+   "area": "TMUX",
+   "name": "Control-mode pipe layer (ControlPipe + PipeManager)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-008",
+   "area": "TMUX",
+   "name": "Attach / detach (PTY proxy)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-008-TUI-attached.txt",
+   "status": "partial",
+   "notes": "session attach exists as a CLI subcommand and the underlying Attach PTY proxy is the same code driven via TUI (verified). Direct CLI attach not separately driven (needs an interactive controlling TTY)"
+  },
+  {
+   "id": "CAP-TMUX-008",
+   "area": "TMUX",
+   "name": "Attach / detach (PTY proxy)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-008-TUI-attached.txt,evidence/tmux/ev-CAP-TMUX-008-TUI-typed.txt,evidence/tmux/ev-CAP-TMUX-008-TUI-detached.txt,evidence/tmux/ev-CAP-TMUX-008-confirm.txt",
+   "status": "verified",
+   "notes": "Enter attached to full-screen pane (status-right 'ctrl+q detach \u2502 \ud83d\udcc1 logtest | proj2'); typed command ran; Ctrl+Q (0x11 detachByte) detached cleanly back to the TUI list. Full attach/detach/input-forwa"
+  },
+  {
+   "id": "CAP-TMUX-009",
+   "area": "TMUX",
+   "name": "Terminal-reply filtering (internal/termreply)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-008-TUI-detached.txt",
+   "status": "partial",
+   "notes": "termreply Filter is an internal stdin-filtering layer active during attach quarantine. Indirectly exercised: attach/detach cycle on a real terminal-reply-capable tmux pane completed with no stray cont"
+  },
+  {
+   "id": "CAP-TMUX-010",
+   "area": "TMUX",
+   "name": "Status detection state machine (GetStatus)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-010-CLI.txt,evidence/tmux/ev-CAP-TMUX-010-show.txt,evidence/tmux/ev-CAP-TMUX-010-transition.txt",
+   "status": "partial",
+   "notes": "Status state machine verified for inactive/idle/stopped/active-on-create transitions via lifecycle (start->idle, stop->stopped, has-session gone). session show prints '\u25cb idle'. Busy(active)/waiting de"
+  },
+  {
+   "id": "CAP-TMUX-010",
+   "area": "TMUX",
+   "name": "Status detection state machine (GetStatus)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-004-TUI.txt",
+   "status": "verified",
+   "notes": "TUI status bar shows color-coded counts (idle/stopped) and per-session markers; status legend \u25cf \u25d0 \u25cb \u25a0 rendered."
+  },
+  {
+   "id": "CAP-TMUX-010",
+   "area": "TMUX",
+   "name": "Status detection state machine (GetStatus)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-011",
+   "area": "TMUX",
+   "name": "Tool detection and configurable patterns",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-011-CLI.txt",
+   "status": "verified",
+   "notes": "DetectTool by command basename verified: command '/tmp/.../bin/claude' detected as tool 'claude'; command 'bash' detected as 'shell'. detectToolFromCommand precedence confirmed."
+  },
+  {
+   "id": "CAP-TMUX-011",
+   "area": "TMUX",
+   "name": "Tool detection and configurable patterns",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-012",
+   "area": "TMUX",
+   "name": "Kill / respawn / process-tree reaping",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-012-CLI.txt",
+   "status": "verified",
+   "notes": "session restart respawned the session (new 8-hex suffix, tmux still alive). session stop killed the tmux session (has-session EXIT=1, 'no server running', status=stopped) and reaped the process tree ("
+  },
+  {
+   "id": "CAP-TMUX-012",
+   "area": "TMUX",
+   "name": "Kill / respawn / process-tree reaping",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TUI-help.txt",
+   "status": "verified",
+   "notes": "TUI help confirms R=Restart session, T=Restart with new session ID, d=Delete session bindings \u2014 same Kill/RespawnPane front doors."
+  },
+  {
+   "id": "CAP-TMUX-013",
+   "area": "TMUX",
+   "name": "Per-session tmux environment variables",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-013-CLI.txt",
+   "status": "verified",
+   "notes": "SetEnvironment stamped AGENTDECK_INSTANCE_ID into the tmux session env at Start; show-environment returns 'AGENTDECK_INSTANCE_ID=4566da35-1781198920' matching the session ID."
+  },
+  {
+   "id": "CAP-TMUX-014",
+   "area": "TMUX",
+   "name": "Status bar, notification bar, quick-switch keys, terminal title",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-014-CLI.txt,evidence/tmux/ev-CAP-TMUX-014b-CLI.txt,evidence/tmux/ev-CAP-TMUX-008-TUI-attached.txt",
+   "status": "verified",
+   "notes": "ConfigureStatusBar set status-right '#[..]ctrl+q detach#[default] \u2502 \ud83d\udcc1 My Cool!Sess@01 | proj one ', status-left-length 120, status-right-length 80. ConfigureTerminalTitle set @agentdeck_display_name/@"
+  },
+  {
+   "id": "CAP-TMUX-015",
+   "area": "TMUX",
+   "name": "iTerm2 badge chrome and mid-attach badge updates",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-015",
+   "area": "TMUX",
+   "name": "iTerm2 badge chrome and mid-attach badge updates",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TUI-help.txt",
+   "status": "untestable-locally",
+   "notes": "iTerm2 OSC 1337 badge emission is gated on TERM_PROGRAM=iTerm.app / LC_TERMINAL=iTerm2 (macOS). This Linux host is not iTerm2, so emitITermBadge no-ops by design. Badge-update file channel (#1114) is "
+  },
+  {
+   "id": "CAP-TMUX-016",
+   "area": "TMUX",
+   "name": "Session log maintenance",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-017",
+   "area": "TMUX",
+   "name": "Terminal emulator detection and capabilities",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-018-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "DetectTerminal/GetTerminalInfo is an internal capability table with no CLI/TUI front door that prints the result. On this host TERM_PROGRAM is unset (would map to 'unknown' -> optimistic OSC8/OSC52 tr"
+  },
+  {
+   "id": "CAP-TMUX-017",
+   "area": "TMUX",
+   "name": "Terminal emulator detection and capabilities",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-018",
+   "area": "TMUX",
+   "name": "System clipboard copy (internal/clipboard)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-TMUX-018",
+   "area": "TMUX",
+   "name": "System clipboard copy (internal/clipboard)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-018-CLI.txt",
+   "status": "partial",
+   "notes": "clipboard.Copy native chain verified available: platform.Detect on Linux selects wl-copy/xclip/xsel; xclip is present on this host (others absent). The Copy() function is invoked only from TUI copy ac"
+  },
+  {
+   "id": "CAP-TMUX-019",
+   "area": "TMUX",
+   "name": "Pop-out to native terminal window (internal/terminal)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TUI-help.txt",
+   "status": "untestable-locally",
+   "notes": "Pop-out 'Shift+Enter Open session in new iTerm window (macOS)' confirmed as a TUI binding. OpenSessionInNewWindow darwin impl uses osascript/iTerm2; non-darwin returns ErrUnsupported. On Linux it cann"
+  },
+  {
+   "id": "CAP-TMUX-020",
+   "area": "TMUX",
+   "name": "Waiting/readiness pollers",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-005-CLI.txt,evidence/tmux/ev-CAP-TMUX-002-CLI.txt",
+   "status": "partial",
+   "notes": "WaitForShellPrompt is exercised implicitly: Start waits for shell pane readiness before delivering the command, and session send waits for prompt before delivery \u2014 both succeeded (commands landed and "
+  },
+  {
+   "id": "CAP-TMUX-021",
+   "area": "TMUX",
+   "name": "Test/host-safety guards",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-021-CLI.txt",
+   "status": "verified",
+   "notes": "assertTestTmuxIsolation is a no-op for the production (non-go-test) binary: every session start succeeded (exit 0) without AGENT_DECK_TEST_ISOLATED set, and no session leaked to the default tmux serve"
+  },
+  {
+   "id": "CAP-TMUX-021",
+   "area": "TMUX",
+   "name": "Test/host-safety guards",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-001",
+   "area": "STOR",
+   "name": "state.db open/connection model",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-002-CLI.txt",
+   "status": "verified",
+   "notes": "After 'ad add', state.db created under XDG data dir with parent dirs at 0700 (profiles/ and profiles/default/ both 0700, MkdirAll(parent,0700) confirmed). PRAGMA journal_mode=wal. WAL sidecars state.d"
+  },
+  {
+   "id": "CAP-STOR-001",
+   "area": "STOR",
+   "name": "state.db open/connection model",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-001",
+   "area": "STOR",
+   "name": "state.db open/connection model",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-002",
+   "area": "STOR",
+   "name": "state.db schema + migrations (SchemaVersion=9)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-002-CLI.txt",
+   "status": "verified",
+   "notes": "metadata.schema_version=9. All 8 tables present: instances, groups, instance_heartbeats, recent_sessions, cost_events, watchers, watcher_events, metadata. instances columns include every contract colu"
+  },
+  {
+   "id": "CAP-STOR-002",
+   "area": "STOR",
+   "name": "state.db schema + migrations (SchemaVersion=9)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-002",
+   "area": "STOR",
+   "name": "state.db schema + migrations (SchemaVersion=9)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-003",
+   "area": "STOR",
+   "name": "SaveInstances bulk save (the 2026-06-04 wipe site) + S1/S2 guards",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-003-013-CLI.txt",
+   "status": "partial",
+   "notes": "SaveInstances bulk persistence verified: 3 added sessions survive across fresh CLI processes (ad list --json shows alpha/beta/gamma). Non-empty payload INSERT OR REPLACE + sweep confirmed. The S1 empt"
+  },
+  {
+   "id": "CAP-STOR-003",
+   "area": "STOR",
+   "name": "SaveInstances bulk save (the 2026-06-04 wipe site) + S1/S2 guards",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-003",
+   "area": "STOR",
+   "name": "SaveInstances bulk save (the 2026-06-04 wipe site) + S1/S2 guards",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-004",
+   "area": "STOR",
+   "name": "Targeted single-column writes (no-clobber primitives)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-004-CLI.txt",
+   "status": "verified",
+   "notes": "Targeted single-column writes via CLI: 'session set-title-lock on/off' toggles title_locked col only; 'session set-transition-notify off' sets no_transition_notify; 'session set claude-session-id' wri"
+  },
+  {
+   "id": "CAP-STOR-004",
+   "area": "STOR",
+   "name": "Targeted single-column writes (no-clobber primitives)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-004",
+   "area": "STOR",
+   "name": "Targeted single-column writes (no-clobber primitives)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-005",
+   "area": "STOR",
+   "name": "withBusyRetry concurrency policy",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-005-CLI.txt",
+   "status": "verified",
+   "notes": "5 parallel concurrent 'ad rm' via xargs -P5 against the same state.db: exactly 5 of 10 instances removed, correct survivors (sess6-10), zero lost deletes. Exercises withBusyRetry + DeleteInstance veri"
+  },
+  {
+   "id": "CAP-STOR-005",
+   "area": "STOR",
+   "name": "withBusyRetry concurrency policy",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-005",
+   "area": "STOR",
+   "name": "withBusyRetry concurrency policy",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-006",
+   "area": "STOR",
+   "name": "Groups persistence",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-006-011-CLI.txt",
+   "status": "verified",
+   "notes": "SaveGroups persistence: 'group create mobile' and 'group create ios --parent mobile' persist path/name/sort_order/max_concurrent (new groups default max_concurrent=1). 'group update mobile --max-concu"
+  },
+  {
+   "id": "CAP-STOR-006",
+   "area": "STOR",
+   "name": "Groups persistence",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-006",
+   "area": "STOR",
+   "name": "Groups persistence",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-007",
+   "area": "STOR",
+   "name": "tool_data JSON blob model + extras preservation",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-007b-CLI.txt",
+   "status": "verified",
+   "notes": "tool_data JSON blob: 'session set color #ff8800' (color #391), claude-session-id (claude_session_id+claude_detected_at), idle-timeout 30m (idle_timeout_secs=1800 in extras zone) all ACCUMULATE without"
+  },
+  {
+   "id": "CAP-STOR-007",
+   "area": "STOR",
+   "name": "tool_data JSON blob model + extras preservation",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-007",
+   "area": "STOR",
+   "name": "tool_data JSON blob model + extras preservation",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-008",
+   "area": "STOR",
+   "name": "Legacy sessions.json \u2192 SQLite migration",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-008-CLI.txt",
+   "status": "verified",
+   "notes": "Dropped a legacy sessions.json (camelCase projectPath/groupPath/sortOrder) in profiles/default/ with no state.db. 'ad list' triggered NewStorageWithProfile auto-migration: both legacy instances appear"
+  },
+  {
+   "id": "CAP-STOR-008",
+   "area": "STOR",
+   "name": "Legacy sessions.json \u2192 SQLite migration",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-008",
+   "area": "STOR",
+   "name": "Legacy sessions.json \u2192 SQLite migration",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-009",
+   "area": "STOR",
+   "name": "Cross-profile session migration primitives (issue #928)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-012-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "Cross-profile migrate_xfer primitives (InsertInstanceRow, LoadInstanceByID, profile_migrate.go) are compiled into the binary, but v1.9.56 exposes NO CLI subcommand to move a session between profiles ("
+  },
+  {
+   "id": "CAP-STOR-010",
+   "area": "STOR",
+   "name": "Heartbeats, primary election, change detection, metadata",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-010-TUI.txt",
+   "status": "verified",
+   "notes": "Launching the TUI registered a row in instance_heartbeats (pid, started, heartbeat timestamps) \u2014 RegisterInstance + Heartbeat confirmed. metadata.last_modified key present (Touch via SetMeta, UnixNano"
+  },
+  {
+   "id": "CAP-STOR-011",
+   "area": "STOR",
+   "name": "Recent sessions (deleted-session re-create picker)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-011",
+   "area": "STOR",
+   "name": "Recent sessions (deleted-session re-create picker)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-011-dialog.txt",
+   "status": "verified",
+   "notes": "Drove TUI 'Delete Session?' dialog (cursor on session row) and confirmed with y. recent_sessions table got the row: solo|shell|deleted_at(unix)|id-len=32hex (sha256/16-byte = 32 hex chars per contract"
+  },
+  {
+   "id": "CAP-STOR-012",
+   "area": "STOR",
+   "name": "Watchers + watcher_events store",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-012-CLI.txt",
+   "status": "verified",
+   "notes": "Watchers store via the independent 'ad watcher' DB-writer process: 'watcher create webhook' persists to watchers table (SaveWatcher INSERT OR REPLACE); 'watcher list'/--json (LoadWatchers); 'watcher s"
+  },
+  {
+   "id": "CAP-STOR-013",
+   "area": "STOR",
+   "name": "Storage layer save/load orchestration + verify-loop race fixes (#909, #1031, revive)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-013-CLI.txt",
+   "status": "verified",
+   "notes": "Storage orchestration: 'ad rm beta' does a targeted DeleteInstance + SaveGroupsOnly + verify loop, leaving alpha/gamma intact and persisting across fresh processes. Prints '\u2713 Removed' only on verified"
+  },
+  {
+   "id": "CAP-STOR-013",
+   "area": "STOR",
+   "name": "Storage layer save/load orchestration + verify-loop race fixes (#909, #1031, revive)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-013",
+   "area": "STOR",
+   "name": "Storage layer save/load orchestration + verify-loop race fixes (#909, #1031, revive)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-014",
+   "area": "STOR",
+   "name": "Profile resolution (single source of truth, #881)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-014-CLI.txt",
+   "status": "verified",
+   "notes": "Profile resolution ladder driven end-to-end by which sessions each resolution sees: (1) -p flag (work profile isolates work-sess from default), (2) AGENTDECK_PROFILE=prod env, (3) CLAUDE_CONFIG_DIR=$S"
+  },
+  {
+   "id": "CAP-STOR-014",
+   "area": "STOR",
+   "name": "Profile resolution (single source of truth, #881)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-014",
+   "area": "STOR",
+   "name": "Profile resolution (single source of truth, #881)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-015",
+   "area": "STOR",
+   "name": "Profile lifecycle + config.json (global pointer file)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-015-CLI.txt",
+   "status": "verified",
+   "notes": "Profile lifecycle: create/list (sorted)/default/delete. config.json schema {default_profile, version:1} written under XDG config dir; missing-file default is 'default'. Duplicate create rejected (exit"
+  },
+  {
+   "id": "CAP-STOR-015",
+   "area": "STOR",
+   "name": "Profile lifecycle + config.json (global pointer file)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-016",
+   "area": "STOR",
+   "name": "XDG/HOME path resolution + legacy split (agentpaths)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-016-CLI.txt",
+   "status": "verified",
+   "notes": "XDG/HOME resolution: absolute XDG_DATA_HOME honored (state.db under $XDG_DATA_HOME/agent-deck/...), no legacy ~/.agent-deck created. A RELATIVE XDG_DATA_HOME ('relative/path') is ignored and falls bac"
+  },
+  {
+   "id": "CAP-STOR-016",
+   "area": "STOR",
+   "name": "XDG/HOME path resolution + legacy split (agentpaths)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-016",
+   "area": "STOR",
+   "name": "XDG/HOME path resolution + legacy split (agentpaths)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-017",
+   "area": "STOR",
+   "name": "Legacy \u2192 XDG layout migration (agentpaths.MigrateLegacyLayout)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-017-CLI.txt",
+   "status": "verified",
+   "notes": "'migrate-paths': --dry-run reports planned copies (config.toml/config.json/skills->ConfigDir, profiles->DataDir, update-cache.json->CacheDir) and writes nothing. Default run copies all categories, leg"
+  },
+  {
+   "id": "CAP-STOR-018",
+   "area": "STOR",
+   "name": "atomicfile: symlink-preserving atomic/durable writes",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-018-019-CLI.txt",
+   "status": "verified",
+   "notes": "Symlink-preserving atomic write: made config.toml a symlink to a real target, then 'remote add' triggered a config write (SaveUserConfigWithIntent -> atomicfile.WriteFileDurable). config.toml REMAINS "
+  },
+  {
+   "id": "CAP-STOR-018",
+   "area": "STOR",
+   "name": "atomicfile: symlink-preserving atomic/durable writes",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-018",
+   "area": "STOR",
+   "name": "atomicfile: symlink-preserving atomic/durable writes",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-019",
+   "area": "STOR",
+   "name": "config.toml model: load cache, save guards (S2/S3), panel merge (#1067)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-019-CLI.txt",
+   "status": "verified",
+   "notes": "config.toml model: 'remote add'/'remote remove' do read-modify-write preserving existing [tmux]/[instances] sections and other [remotes.*] entries verbatim. S2 backup config.toml.bak created on write "
+  },
+  {
+   "id": "CAP-STOR-019",
+   "area": "STOR",
+   "name": "config.toml model: load cache, save guards (S2/S3), panel merge (#1067)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-019",
+   "area": "STOR",
+   "name": "config.toml model: load cache, save guards (S2/S3), panel merge (#1067)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-STOR-020",
+   "area": "STOR",
+   "name": "Test-time data-loss guards (S4/S5) + sandbox infrastructure",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/stor/ev-CAP-STOR-012-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "S4 (agentpaths.ensureSafeForTest) and S5 (pathsafety guard_test) error strings ARE compiled into the production binary (confirmed via strings: 'refusing to resolve agent-deck path under the real home "
+  },
+  {
+   "id": "CAP-COND-001",
+   "area": "COND",
+   "name": "Conductor entity + meta.json store",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-001-meta.json",
+   "status": "verified",
+   "notes": "conductor setup writes ~/.agent-deck/conductor/<name>/meta.json with full schema (name, agent, profile normalized to 'default', heartbeat_enabled, heartbeat_interval=0, description, created_at RFC3339"
+  },
+  {
+   "id": "CAP-COND-002",
+   "area": "COND",
+   "name": "Conductor setup/teardown lifecycle (CLI orchestration)",
+   "surface": "COND",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-COND-003",
+   "area": "COND",
+   "name": "is_conductor column + session/group relationship",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-003-TUI-home.txt",
+   "status": "verified",
+   "notes": "TUI renders conductor group (3) pinned at top with conductor-gamma/epsilon/delta, and child1 visually nested under parent1 via ParentSessionID. New-session dialog (n) shows 'in group: conductor' with "
+  },
+  {
+   "id": "CAP-COND-003",
+   "area": "COND",
+   "name": "is_conductor column + session/group relationship",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-COND-004",
+   "area": "COND",
+   "name": "Heartbeat daemon (OS-level per-conductor timer)",
+   "surface": "DAEMON/INTERNAL",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-COND-005",
+   "area": "COND",
+   "name": "bridge.py legacy channel bridge (Telegram/Slack \u2194 conductor sessions)",
+   "surface": "DAEMON/INTERNAL",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-COND-006",
+   "area": "COND",
+   "name": "Plugin-based Telegram channel integration (--channels) + poller ownership",
+   "surface": "DAEMON/INTERNAL",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-COND-007",
+   "area": "COND",
+   "name": "Per-conductor env_file injection and config_dir profile override",
+   "surface": "COND",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-COND-008",
+   "area": "COND",
+   "name": "Child\u2192parent transition notification (transition daemon + notifier + inbox)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-008-drain.txt",
+   "status": "verified",
+   "notes": "notify-daemon --once runs exit 0 (one adaptive poll of all profiles). inbox drain --json <parent>: empty=[]; crafted finished event drained with kind/done_status/done_summary/turn_fingerprint parsed; "
+  },
+  {
+   "id": "CAP-COND-009",
+   "area": "COND",
+   "name": "Worker-asserted completion ([DONE] sentinel + run-task kernel exit)",
+   "surface": "COND",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-COND-010",
+   "area": "COND",
+   "name": "Conductor instruction/policy template system",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-001",
+   "area": "MCP",
+   "name": "MCP catalog definition in config.toml",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-001-CLI-list.txt, ev-CAP-MCP-001-config.txt",
+   "status": "verified",
+   "notes": "[mcps.<name>] catalog loads from XDG config.toml; mcp list shows transport tags [S]/[H]/[E], sorted names, has_server_config in JSON. GetTransport derives http from url, sse honored. Invalid mcp_defau"
+  },
+  {
+   "id": "CAP-MCP-001",
+   "area": "MCP",
+   "name": "MCP catalog definition in config.toml",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-001",
+   "area": "MCP",
+   "name": "MCP catalog definition in config.toml",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-002",
+   "area": "MCP",
+   "name": "CLI: agent-deck mcp list / attached / attach / detach",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-006-user-scope.txt",
+   "status": "untestable-locally",
+   "notes": "--restart sub-behavior (inst.Restart + 2s sleep + SendKeysAndEnter 'continue') requires a real claude/gemini agent process; with -c bash stub there is no MCP-restart-supporting tool to drive the auto-"
+  },
+  {
+   "id": "CAP-MCP-003",
+   "area": "MCP",
+   "name": "CLI: agent-deck mcp server start/stop/status (HTTP MCP servers)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-003-CLI-server.txt, ev-CAP-MCP-010-CLI-httpstart.txt",
+   "status": "verified",
+   "notes": "server status lists all HTTP/SSE catalog MCPs with status + SERVER CONFIG column; fresh CLI shows pool_not_initialized. server stop -> 'HTTP pool not initialized (run TUI first)' exit 2 (cross-process"
+  },
+  {
+   "id": "CAP-MCP-003",
+   "area": "MCP",
+   "name": "CLI: agent-deck mcp server start/stop/status (HTTP MCP servers)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-004",
+   "area": "MCP",
+   "name": "Attached-state reads (MCPInfo) + caching",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-004-CLI-parentwalk.txt",
+   "status": "verified",
+   "notes": "Parent-dir walk confirmed: deepchild session at projA/sub/deep (no .mcp.json there) reports LOCAL context7+ssemcp = exact contents of PARENT projA/.mcp.json. GLOBAL bucket reads ~/.claude/.claude.json"
+  },
+  {
+   "id": "CAP-MCP-004",
+   "area": "MCP",
+   "name": "Attached-state reads (MCPInfo) + caching",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-004",
+   "area": "MCP",
+   "name": "Attached-state reads (MCPInfo) + caching",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-005",
+   "area": "MCP",
+   "name": "LOCAL scope write: .mcp.json generation with merge-preserve and plugin pin refresh",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-002-CLI-attach.txt, ev-CAP-MCP-002-scope-lie.txt",
+   "status": "verified",
+   "notes": ".mcp.json written mode 0644 (the documented secret-exposure flaw, env EXA_API_KEY in plaintext). stdio entry {type:stdio,command,args,env}; URL entry {type:http,url,headers}; sse entry {type:sse,url}."
+  },
+  {
+   "id": "CAP-MCP-005",
+   "area": "MCP",
+   "name": "LOCAL scope write: .mcp.json generation with merge-preserve and plugin pin refresh",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-013-TUI-applied.txt, ev-CAP-MCP-009-live-dialog.txt",
+   "status": "verified",
+   "notes": "TUI Apply (LOCAL scope) writes .mcp.json via WriteMCPJsonFromConfig with merge-preserve; pool-live Apply emits agent-deck mcp-proxy socket entry, stdio fallback otherwise."
+  },
+  {
+   "id": "CAP-MCP-005",
+   "area": "MCP",
+   "name": "LOCAL scope write: .mcp.json generation with merge-preserve and plugin pin refresh",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-006",
+   "area": "MCP",
+   "name": "GLOBAL and USER scope writes (.claude.json)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-006-CLI-global.txt",
+   "status": "verified",
+   "notes": "GLOBAL: attach --global writes $CLAUDE_CONFIG_DIR/.claude.json (resolved to ~/.claude/.claude.json) mcpServers, mode 0600. #146 merge-preserve verified: non-catalog 'mymanual', numStartups, projects a"
+  },
+  {
+   "id": "CAP-MCP-006",
+   "area": "MCP",
+   "name": "GLOBAL and USER scope writes (.claude.json)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-013-TUI-scope-global.txt, ev-CAP-MCP-013-TUI-mcpdialog.txt",
+   "status": "verified",
+   "notes": "Dialog exposes LOCAL/GLOBAL/USER scopes; GLOBAL 'Writes to: Claude config (profile-specific)', USER tab present (WriteUserMCP -> ~/.claude.json root). Gemini/Cursor wholesale-replace data-loss not tes"
+  },
+  {
+   "id": "CAP-MCP-006",
+   "area": "MCP",
+   "name": "GLOBAL and USER scope writes (.claude.json)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-007",
+   "area": "MCP",
+   "name": "Socket pool: shared stdio MCP processes multiplexed over Unix sockets",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-007-socketpool.txt, ev-CAP-MCP-011-systemd-scope.txt, ev-CAP-MCP-012-TUI-home.txt",
+   "status": "verified",
+   "notes": "Pool creates per-MCP unix socket at <data>/agent-deck/sockets/mcp-exa.sock (mode 0600, dir 0700), per-MCP stderr log at <data>/logs/mcppool/exa_socket.log. Client connect to socket succeeds (multiplex"
+  },
+  {
+   "id": "CAP-MCP-008",
+   "area": "MCP",
+   "name": "agent-deck mcp-proxy <socket> (hidden CLI bridge command)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-008-CLI-mcpproxy.txt, ev-CAP-MCP-009-live-dialog.txt",
+   "status": "verified",
+   "notes": "Hidden 'agent-deck mcp-proxy <socket>' command: connects to unix socket and copies stdin->socket (server received exact JSON-RPC bytes). Nonexistent socket -> retries with backoff (stays alive, exit 1"
+  },
+  {
+   "id": "CAP-MCP-009",
+   "area": "MCP",
+   "name": "Pool resolution during config generation (tryPoolSocket)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-009-poolresolution.txt",
+   "status": "verified",
+   "notes": "CLI mode (pool==nil): pool enabled + exa pooled, but no live socket discoverable (socket-path drift: pool at <data>/sockets, CLI checks /tmp), so FallbackStdio emits stdio entry. context7 (in exclude_"
+  },
+  {
+   "id": "CAP-MCP-009",
+   "area": "MCP",
+   "name": "Pool resolution during config generation (tryPoolSocket)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-009-live-dialog.txt",
+   "status": "verified",
+   "notes": "TUI process (pool live): tryPoolSocket resolves IsRunning -> emits socket entry {command:agent-deck,args:[mcp-proxy,<data>/sockets/mcp-exa.sock]} on Apply, proving socket-vs-stdio decision honors live"
+  },
+  {
+   "id": "CAP-MCP-009",
+   "area": "MCP",
+   "name": "Pool resolution during config generation (tryPoolSocket)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-010",
+   "area": "MCP",
+   "name": "HTTP MCP server pool (auto-start [mcps.X.server])",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-010-CLI-httpstart.txt, ev-CAP-MCP-011-systemd-scope.txt",
+   "status": "verified",
+   "notes": "server start autohttp with real python http.server + health_check=/: waitReady polled until healthy, exit 0 'Started HTTP server', curl confirms HTTP 200, process spawned. Timeout path also verified ("
+  },
+  {
+   "id": "CAP-MCP-010",
+   "area": "MCP",
+   "name": "HTTP MCP server pool (auto-start [mcps.X.server])",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-010",
+   "area": "MCP",
+   "name": "HTTP MCP server pool (auto-start [mcps.X.server])",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-011",
+   "area": "MCP",
+   "name": "systemd per-MCP scope isolation (Linux)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-011",
+   "area": "MCP",
+   "name": "systemd per-MCP scope isolation (Linux)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-011-systemd-scope.txt",
+   "status": "verified",
+   "notes": "systemd-run available; ISOLATION=1 wraps BOTH socket-proxy (cat) and HTTP (python http.server) children in transient scopes named mcp-<ownerPID>-<mcpName>-<utcTS>.scope under slice mcp-pool.slice (CGr"
+  },
+  {
+   "id": "CAP-MCP-012",
+   "area": "MCP",
+   "name": "Pool lifecycle: TUI init, multi-instance sharing, quit semantics",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-012-TUI-home.txt, ev-CAP-MCP-012-TUI-quitdialog.txt",
+   "status": "verified",
+   "notes": "TUI startup eager-starts pool: mcp-exa.sock + exa_socket.log created (context7 excluded). Quit (q) with pool running -> 'MCP Pool Running / N MCP servers running' dialog, default 'Keep running' focuse"
+  },
+  {
+   "id": "CAP-MCP-013",
+   "area": "MCP",
+   "name": "TUI MCP Manager dialog (\"M\" key)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-013-TUI-mcpdialog.txt, ev-CAP-MCP-013-TUI-scope-global.txt, ev-CAP-MCP-013-TUI-applied.txt",
+   "status": "verified",
+   "notes": "'m' key opens MCP Manager on a claude session: LOCAL/GLOBAL/USER scopes, Attached/Available two-column lists, [S]/[H]/[E] transport + running(\u25cf) markers, 'not in config.toml' orphan note, nav hints. T"
+  },
+  {
+   "id": "CAP-MCP-014",
+   "area": "MCP",
+   "name": "Web API MCP management",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MCP-015",
+   "area": "MCP",
+   "name": "Session-launch and restart MCP integration",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-015-CLI-add-mcp.txt",
+   "status": "verified",
+   "notes": "add --mcp exa --mcp context7 -> LOCAL .mcp.json with both entries, exit 0. Unknown --mcp bogus -> exit 1 with available list, no .mcp.json. launch --mcp flag present. Restart regenerateMCPConfig / Loa"
+  },
+  {
+   "id": "CAP-MCP-015",
+   "area": "MCP",
+   "name": "Session-launch and restart MCP integration",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-013-TUI-applied.txt",
+   "status": "untestable-locally",
+   "notes": "Restart-path MCP regeneration (regenerateMCPConfig swapping stdio<->socket), SkipMCPRegenerate flag, CaptureLoadedMCPs snapshot, and discoverMCPChildrenFromPaneTree reaping all require a live claude a"
+  },
+  {
+   "id": "CAP-WATCH-001",
+   "area": "WATCH",
+   "name": "Watcher engine event pipeline",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-001-CLI.txt",
+   "status": "verified",
+   "notes": "watcher create webhook/ntfy/slack OK (exit 0); github without secret rejected (exit 1). list --json emits {name,type,status,events_per_hour,health,last_event_ts,error_count,health_status}. start->stat"
+  },
+  {
+   "id": "CAP-WATCH-001",
+   "area": "WATCH",
+   "name": "Watcher engine event pipeline",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-001-CLI-webhook-e2e.txt",
+   "status": "verified",
+   "notes": "FULL event pipeline e2e: TUI engine starts in-process (debug.log watcher_engine_started watcher_count:1); webhook adapter binds 127.0.0.1:18460; POST /webhook -> HTTP 202; writerLoop persists watcher_"
+  },
+  {
+   "id": "CAP-WATCH-002",
+   "area": "WATCH",
+   "name": "Watcher source adapters (webhook, github, ntfy, slack, gmail)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-WATCH-003",
+   "area": "WATCH",
+   "name": "Watcher health tracking + health alert bridge",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-001-CLI-webhook-e2e.txt",
+   "status": "partial",
+   "notes": "HealthTracker observable: state.json snapshot persisted by writerLoop carries adapter_healthy:true and error_count:0; watcher panel shows per-watcher events/hr rate ('0.0/hr'). list --json health/heal"
+  },
+  {
+   "id": "CAP-WATCH-004",
+   "area": "WATCH",
+   "name": "Event routing (clients.json router)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-004-CLI.txt",
+   "status": "verified",
+   "notes": "watcher routes (table) and --json read clients.json correctly: exact email keys and *@domain wildcard keys both shown with conductor/group/name. Import command parses legacy channels.json and errors c"
+  },
+  {
+   "id": "CAP-WATCH-004",
+   "area": "WATCH",
+   "name": "Event routing (clients.json router)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-005-CLI.txt",
+   "status": "verified",
+   "notes": "Router.Match verified via 'watcher test': exact sender match -> 'Match: exact / Routes to conductor: <name> / Group: <group>'; no match -> 'Match: none / would go to triage'. Confirms exact-then-domai"
+  },
+  {
+   "id": "CAP-WATCH-005",
+   "area": "WATCH",
+   "name": "Triage pipeline (unrouted event \u2192 Claude classifier session)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-001-CLI-webhook-e2e.txt",
+   "status": "partial",
+   "notes": "Triage entry verified: a real unrouted webhook event persists with routed_to='triage' (confirmed in watcher status recent_events). The full triage pipeline (AgentDeckLaunchSpawner exec'ing 'agent-deck"
+  },
+  {
+   "id": "CAP-WATCH-006",
+   "area": "WATCH",
+   "name": "Hook-to-status derivation (sessionstatus.Derive)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-006-CLI.txt",
+   "status": "verified",
+   "notes": "sessionstatus.Derive output observed via 'ad status' (0 waiting / 0 running / 1 idle) and list --json status field. Bash stub session with no fresh hook derives status (error/idle from tmux pane-title"
+  },
+  {
+   "id": "CAP-WATCH-006",
+   "area": "WATCH",
+   "name": "Hook-to-status derivation (sessionstatus.Derive)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-WATCH-006",
+   "area": "WATCH",
+   "name": "Hook-to-status derivation (sessionstatus.Derive)",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-WATCH-007",
+   "area": "WATCH",
+   "name": "Cost event capture (Claude Stop hook \u2192 file drop \u2192 fsnotify \u2192 SQLite)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-007-CLI.txt",
+   "status": "verified",
+   "notes": "agent-deck hook-handler (hidden subcmd) given a Stop payload {hook_event_name,session_id,transcript_path} + AGENTDECK_INSTANCE_ID env reads last transcript line (assistant w/ usage) and writes cost-ev"
+  },
+  {
+   "id": "CAP-WATCH-007",
+   "area": "WATCH",
+   "name": "Cost event capture (Claude Stop hook \u2192 file drop \u2192 fsnotify \u2192 SQLite)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-007-TUI-ingested.txt",
+   "status": "verified",
+   "notes": "Full e2e ingestion: with TUI running, a hook-handler drop file is picked up by CostEventWatcher (fsnotify+100ms debounce), parsed, computed (pricer), inserted to cost_events, and the drop FILE IS DELE"
+  },
+  {
+   "id": "CAP-WATCH-008",
+   "area": "WATCH",
+   "name": "Cost parsers + tmux capture poller (multi-tool cost extraction)",
+   "surface": "WATCH",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-WATCH-009",
+   "area": "WATCH",
+   "name": "Cost store, summaries, remote aggregation",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-009-CLI.txt",
+   "status": "verified",
+   "notes": "costs summary (table: Today/Week/Month/Projected + event counts) and --json (microdollar keys cost_today/week/month/last_week/last_month/yesterday/projected + events_*) both exit 0. Real data path pro"
+  },
+  {
+   "id": "CAP-WATCH-009",
+   "area": "WATCH",
+   "name": "Cost store, summaries, remote aggregation",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-009-TUI-dashboard.txt",
+   "status": "verified",
+   "notes": "Cost Dashboard ($ key) renders Today/Week/Month/Projected, token breakdown (Input/Output/Cache R/W), Top Sessions and Cost by Model panels; populated with real $0.09 after ingest (see 007-TUI)."
+  },
+  {
+   "id": "CAP-WATCH-009",
+   "area": "WATCH",
+   "name": "Cost store, summaries, remote aggregation",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-WATCH-010",
+   "area": "WATCH",
+   "name": "Pricing (defaults, cache, overrides, daily fetcher, recompute, transcript sync)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-010-CLI.txt",
+   "status": "verified",
+   "notes": "costs recompute --dry-run and live both exit 0 with 'Would update/Updated/Skipped (unknown model)' summary (idempotent). costs sync exits 0 'No Claude sessions found to sync'. Pricer ComputeCost prove"
+  },
+  {
+   "id": "CAP-WATCH-010",
+   "area": "WATCH",
+   "name": "Pricing (defaults, cache, overrides, daily fetcher, recompute, transcript sync)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-007-TUI-ingested.txt",
+   "status": "verified",
+   "notes": "Pricer resolution (hardcoded defaults -> ComputeCost) drives the live TUI cost display: claude-opus-4-7 priced at $0.09 for 5000 input + 2500 output tokens. Daily fetcher/cache + override resolution o"
+  },
+  {
+   "id": "CAP-WATCH-011",
+   "area": "WATCH",
+   "name": "Budget limits (warn/stop)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-011-CLI.txt",
+   "status": "partial",
+   "notes": "BudgetConfig [costs.budgets] daily/weekly/monthly (and per-group daily_limit) parses cleanly from config.toml; costs summary + session list + TUI start all succeed with budgets configured (no parse er"
+  },
+  {
+   "id": "CAP-WATCH-012",
+   "area": "WATCH",
+   "name": "System stats collection + formatting",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-TUI-home.txt",
+   "status": "verified",
+   "notes": "sysinfo Collector renders the tmux/header status segment: '\u2699 0% \u2502 \u26c1 19.3G/62.5G \u2502 \u25aa 1543.6G/1831.7G' (CPU first-sample 0%, Memory used/total from /proc/meminfo, Disk from Statfs('/')). Network segment"
+  },
+  {
+   "id": "CAP-WATCH-012",
+   "area": "WATCH",
+   "name": "System stats collection + formatting",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-WATCH-013",
+   "area": "WATCH",
+   "name": "Credential keep-warm refresh daemon (creds-refresh)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-013-CLI.txt",
+   "status": "verified",
+   "notes": "creds-refresh --once full lifecycle: (a) no .credentials.json dir -> error exit 1 (contract: only non-zero on no-config-dirs); (b) FRESH token (expiry > threshold) -> 'skip (token not near expiry)' ex"
+  },
+  {
+   "id": "CAP-MISC-001",
+   "area": "MISC",
+   "name": "Docker container lifecycle (sandbox sessions)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-001-CLI.txt",
+   "status": "verified",
+   "notes": "Drove real Docker against running daemon (29.3.0). add --sandbox + session start created container agent-deck-<title>-<id8> (GenerateName contract) with image alpine:3.20, Cmd [sleep infinity], label "
+  },
+  {
+   "id": "CAP-MISC-001",
+   "area": "MISC",
+   "name": "Docker container lifecycle (sandbox sessions)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-002",
+   "area": "MISC",
+   "name": "Sandbox container config builder + mount security blocklists",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-002-CLI.txt",
+   "status": "verified",
+   "notes": "docker inspect of the real sandbox container confirmed the full security contract: ReadonlyRootfs=true, CapDrop=[ALL], SecurityOpt=[no-new-privileges], PidsLimit=4096, User=1000:1000 (host UID:GID), W"
+  },
+  {
+   "id": "CAP-MISC-002",
+   "area": "MISC",
+   "name": "Sandbox container config builder + mount security blocklists",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-003",
+   "area": "MISC",
+   "name": "Agent-config sandbox sync (host credentials/config \u2192 container)",
+   "surface": "DAEMON/INTERNAL",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-004",
+   "area": "MISC",
+   "name": "Docker availability detection",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-004-CLI.txt",
+   "status": "verified",
+   "notes": "With docker removed from PATH, session start of a sandbox session failed with the exact sentinel 'docker CLI is not installed or not in PATH' (ErrDockerNotAvailable) and exit 1. IsDaemonRunning (docke"
+  },
+  {
+   "id": "CAP-MISC-004",
+   "area": "MISC",
+   "name": "Docker availability detection",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-005",
+   "area": "MISC",
+   "name": "Self-update: version check, cache, nudge",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-005-CLI.txt",
+   "status": "verified",
+   "notes": "update --check hit GitHub, computed latest=1.9.54 vs current 1.9.56-verify -> 'running the latest version' (CompareVersions, current newer). Cache written to <XDG cache>/agent-deck/update-cache.json w"
+  },
+  {
+   "id": "CAP-MISC-005",
+   "area": "MISC",
+   "name": "Self-update: version check, cache, nudge",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-005-TUI-settings.txt",
+   "status": "verified",
+   "notes": "TUI home banner shows v1.9.56-verify (annotation slot); no nudge bar since current>=latest (ShouldNudge false). Settings panel (S) exposes UPDATES section with 'Check for updates on startup' and 'Auto"
+  },
+  {
+   "id": "CAP-MISC-006",
+   "area": "MISC",
+   "name": "Self-update: verified download + binary install + remote deploy gate",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-006-CLI.txt",
+   "status": "verified",
+   "notes": "update --version 1.9.54 (run on a sandbox COPY of the binary, not the shared $AD_BIN): fetched release v1.9.54, correctly recognized as a DOWNGRADE, prompted interactively (default N). With 'y' it pro"
+  },
+  {
+   "id": "CAP-MISC-007",
+   "area": "MISC",
+   "name": "install.sh (curl|bash installer)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-007-note.txt",
+   "status": "untestable-locally",
+   "notes": "install.sh is a curl|bash bootstrap with no front door in the shipped binary. Running it would mutate the real system (~/.tmux.conf managed block, $INSTALL_DIR binary, system package manager for tmux/"
+  },
+  {
+   "id": "CAP-MISC-008",
+   "area": "MISC",
+   "name": "Makefile build/test/release pipeline",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-009",
+   "area": "MISC",
+   "name": "OpenClaw gateway client (WebSocket JSON-RPC)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-009-CLI.txt",
+   "status": "partial",
+   "notes": "OpenClaw client drives a real WebSocket dial to the default loopback gateway ws://127.0.0.1:31337. status -> 'Gateway: OFFLINE (websocket dial: ... connection refused)' exit 1; list -> 'Failed to conn"
+  },
+  {
+   "id": "CAP-MISC-009",
+   "area": "MISC",
+   "name": "OpenClaw gateway client (WebSocket JSON-RPC)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-010",
+   "area": "MISC",
+   "name": "OpenClaw bridge TUI + agent session sync",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-010",
+   "area": "MISC",
+   "name": "OpenClaw bridge TUI + agent session sync",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-010-TUI.txt",
+   "status": "partial",
+   "notes": "openclaw bridge --agent testagent launched the full bubbletea chat TUI in tmux: header 'openclaw > testagent', [DISCONNECTED] status badge, transcript with timestamped 'Connection failed: ... connecti"
+  },
+  {
+   "id": "CAP-MISC-011",
+   "area": "MISC",
+   "name": "Feedback prompt pacing + state",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-011-CLI.txt",
+   "status": "verified",
+   "notes": "agent-deck feedback drives the rating prompt (1-5, n=never-again, q=quit) with input validation. --help documents the pacing contract (7 launches OR 3 days, 14-day cooldown, max 3/version, n=permanent"
+  },
+  {
+   "id": "CAP-MISC-011",
+   "area": "MISC",
+   "name": "Feedback prompt pacing + state",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-012",
+   "area": "MISC",
+   "name": "Feedback sender (three-tier submission)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-012-CLI.txt",
+   "status": "verified",
+   "notes": "Feedback sender front door: rating 5 -> comment -> disclosure block showing public URL discussions/600, gh-CLI submission under user account, exact body. Declining at consent (N) posts nothing. Opt-ou"
+  },
+  {
+   "id": "CAP-MISC-012",
+   "area": "MISC",
+   "name": "Feedback sender (three-tier submission)",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-013",
+   "area": "MISC",
+   "name": "Structured logging system",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-013-CLI.txt",
+   "status": "verified",
+   "notes": "agent-deck debug-dump wrote <XDG cache>/agent-deck/debug-dump-<unix>.jsonl and reported the path ('Share this file when reporting lag...'), exit 0, both default and AGENTDECK_DEBUG=1. Ring buffer empt"
+  },
+  {
+   "id": "CAP-MISC-014",
+   "area": "MISC",
+   "name": "safego panic-recovering goroutines",
+   "surface": "TUI",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-015",
+   "area": "MISC",
+   "name": "Platform detection + headless + fsnotify support check",
+   "surface": "MISC",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-016",
+   "area": "MISC",
+   "name": "Experiments / `agent-deck try` (quick experiment folders)",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-016-CLI.txt",
+   "status": "verified",
+   "notes": "agent-deck try fully verified: try --list (empty -> message); try redis-cache --no-session created 2026-06-11-redis-cache (date prefix); try --list --json shape {name,path,date,modified} with date str"
+  },
+  {
+   "id": "CAP-MISC-017",
+   "area": "MISC",
+   "name": "Test infrastructure: testutil isolation + perf + seams",
+   "surface": "DAEMON/INTERNAL",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-018",
+   "area": "MISC",
+   "name": "Integration test suite (real tmux)",
+   "surface": "DAEMON/INTERNAL",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-MISC-019",
+   "area": "MISC",
+   "name": "Release regression manifest + release-pinning tests",
+   "surface": "DAEMON/INTERNAL",
+   "automated_test": "",
+   "user_verified": "",
+   "evidence": "",
+   "status": "pending",
+   "notes": ""
+  },
+  {
+   "id": "CAP-SESS-005",
+   "area": "SESS",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-005-007-CLI.txt",
+   "status": "partial",
+   "notes": "Front door 'session set claude-session-id' sets and clears the binding (shown ''->'test-uuid-1234'->'' incl #923 anchor-clear path). Full multi-replica rebind/zombie-reject arbitration and session-id-"
+  },
+  {
+   "id": "CAP-SESS-006",
+   "area": "SESS",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-006-CLI.txt",
+   "status": "verified",
+   "notes": "Created a rogue 'agentdeck_rogue_deadbeef' tmux session carrying the SAME AGENTDECK_INSTANCE_ID as alpha; ad session restart alpha (sweepDuplicateToolSessions, instance-id sweep #678) KILLED the rogue"
+  },
+  {
+   "id": "CAP-SESS-009",
+   "area": "SESS",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-009-handler.txt",
+   "status": "partial",
+   "notes": "hook-handler subcommand exists; hooks dir created at <data>/agent-deck/hooks. Silent-skip guard verified: invoking hook-handler with NO AGENTDECK_INSTANCE_ID exits 0 silently (unmanaged session). Invo"
+  },
+  {
+   "id": "CAP-SESS-010",
+   "area": "SESS",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-010-CLI.txt",
+   "status": "verified",
+   "notes": "session set-parent beta alpha links beta.parent_session_id to alpha's exact ID (0d8070e1-1781198354). unset-parent clears it (''). set-transition-notify off persists (web /api/sessions shows noTransit"
+  },
+  {
+   "id": "CAP-SESS-010",
+   "area": "SESS",
+   "name": "",
+   "surface": "WEB",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-WEB.txt",
+   "status": "verified",
+   "notes": "noTransitionNotify=true surfaced on beta in /api/sessions, confirming the transition-notify toggle persisted to state.db."
+  },
+  {
+   "id": "CAP-SESS-010",
+   "area": "SESS",
+   "name": "",
+   "surface": "internal/daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-010-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "TransitionDaemon completion delivery (inbox/outbox PULL, Stop-hook drain, task-worker exit edge) requires the notify-daemon systemd/launchd unit and real claude parent/child sessions. CLI front doors "
+  },
+  {
+   "id": "CAP-SESS-011",
+   "area": "SESS",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-011-CLI.txt",
+   "status": "verified",
+   "notes": "Hard-killing the tmux session (simulating pane/agent death) flips status from idle to error on the next UpdateStatus poll (tmuxSession.Exists()==false -> StatusError), exactly per contract case (a). C"
+  },
+  {
+   "id": "CAP-SESS-013",
+   "area": "SESS",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/sess/ev-CAP-SESS-013-CLI.txt",
+   "status": "verified",
+   "notes": "Started grpsess1 with TELEGRAM_BOT_TOKEN=SECRET in parent env. tmux session env contains NO TELEGRAM var; child shell expansion of ${TELEGRAM_BOT_TOKEN} yields EMPTY (TELEGRAM_RESULT=[EMPTY]) \u2014 confir"
+  },
+  {
+   "id": "CAP-CLI-028",
+   "area": "CLI",
+   "name": "",
+   "surface": "daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-028-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "Heartbeat launchd/systemd daemon + bridge.py + transition-notifier as long-lived daemons require a real systemd/launchd user session and channel tokens. systemd timer enable returned 'exit status 1' i"
+  },
+  {
+   "id": "CAP-CLI-035",
+   "area": "CLI",
+   "name": "",
+   "surface": "daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-035-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "The daemon-side consumers (transition notifier reading these status files, DrainForStopHook stdout block injection) are exercised by notify-daemon (CAP-CLI-037); the hook-handler CLI front door is ful"
+  },
+  {
+   "id": "CAP-CLI-037",
+   "area": "CLI",
+   "name": "",
+   "surface": "daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-037-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "The long-lived daemon loop (SIGINT/SIGTERM context, watchBinaryVersion re-exec every 60s, #1214 stale-daemon recycle) is a supervised long-running process; --once front door verified. Full version-mis"
+  },
+  {
+   "id": "CAP-CLI-041",
+   "area": "CLI",
+   "name": "",
+   "surface": "daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-041-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "The actual OAuth refresh-token exchange against Anthropic, atomic rewrite under proper-lockfile, and the SIGINT/SIGTERM loop require real network + real credentials. --once front-door and dir-filterin"
+  },
+  {
+   "id": "CAP-CLI-044",
+   "area": "CLI",
+   "name": "",
+   "surface": "web",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cli/ev-CAP-CLI-044-WEB.png",
+   "status": "verified",
+   "notes": "web --no-tui boots headless ('Headless mode: TUI disabled', 'Web server: http://127.0.0.1:8492'); GET /api/sessions returns the seeded session JSON; POST /api/sessions with bad payload -> HTTP 400 (mu"
+  },
+  {
+   "id": "CAP-TUI-008",
+   "area": "TUI",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-008-TUI.txt",
+   "status": "verified",
+   "notes": "CLI mirror confirmed present: 'agent-deck mcp attach/detach/attached/list' subcommands exist (referenced in contract; surfaced via ad --help mcp)."
+  },
+  {
+   "id": "CAP-TUI-025",
+   "area": "TUI",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-025-CLI-remote.txt",
+   "status": "verified",
+   "notes": "CLI mirror verified: remote add/list/sessions present and functioning; unreachable remote errors are surfaced cleanly with EXIT=0 (non-fatal)."
+  },
+  {
+   "id": "CAP-TUI-035",
+   "area": "TUI",
+   "name": "",
+   "surface": "web",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tui/ev-CAP-TUI-035-WEB-sessions.json, ev-CAP-TUI-035-WEB-create.json, ev-CAP-TUI-035-WEB.png",
+   "status": "verified",
+   "notes": "ad web --no-tui serves the REST API: GET /api/sessions returns the full TUI-mirrored list (titles, notes, titleLocked, status) via the MemoryMenuData publish; /healthz returns {ok:true, webMutations:t"
+  },
+  {
+   "id": "CAP-FORK-011",
+   "area": "FORK",
+   "name": "",
+   "surface": "internal-daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/fork/ev-CAP-FORK-011-env.txt",
+   "status": "verified",
+   "notes": "Child env isolation verified by inspecting the spawned tmux session env: parent shell exported TELEGRAM_BOT_TOKEN/TELEGRAM_STATE_DIR/CLAUDE_CONFIG_DIR; child tmux show-environment shows NO TELEGRAM_* "
+  },
+  {
+   "id": "CAP-TMUX-002",
+   "area": "TMUX",
+   "name": "",
+   "surface": "daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-002b-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "3-tier systemd-run launch fallback (service/scope/direct) not exercised: sandbox has no systemd user session, so direct launch is used. Direct path verified; systemd service/scope units untestable her"
+  },
+  {
+   "id": "CAP-TMUX-007",
+   "area": "TMUX",
+   "name": "",
+   "surface": "daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-007-CLI.txt",
+   "status": "verified",
+   "notes": "With web (PipeManager) running, list-clients shows control_mode=1 client on the isolated socket \u2014 that is the ControlPipe 'tmux -C attach-session' child. PipeManager connect/handshake works; teardown "
+  },
+  {
+   "id": "CAP-TMUX-016",
+   "area": "TMUX",
+   "name": "",
+   "surface": "daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/tmux/ev-CAP-TMUX-016-CLI.txt",
+   "status": "partial",
+   "notes": "LogDir resolution under XDG data dir confirmed (data/agent-deck tree present). No .log files were created in this build's session lifecycle (logs are a documented pre-control-pipe artifact; control pi"
+  },
+  {
+   "id": "CAP-MCP-001",
+   "area": "MCP",
+   "name": "",
+   "surface": "internal",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-001-manage-false.txt, ev-CAP-MCP-005-manage-false.txt",
+   "status": "partial",
+   "notes": "DEVIATION: contract says manage_mcp_json=false makes ALL .mcp.json writes silent no-ops, but both CLI 'mcp attach' AND 'add --mcp' (WriteMCPJsonFromConfig path) STILL wrote a fresh .mcp.json with mana"
+  },
+  {
+   "id": "CAP-MCP-014",
+   "area": "MCP",
+   "name": "",
+   "surface": "web",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/mcp/ev-CAP-MCP-014-WEB.txt, ev-CAP-MCP-014-WEB-tui.txt",
+   "status": "broken",
+   "notes": "BROKEN: GET /api/mcps, GET/POST/DELETE/PATCH /api/sessions/{id}/mcps all return HTTP 503 {code:NOT_IMPLEMENTED, message:'MCP manager not available'} in BOTH headless (--no-tui) AND full-TUI web mode. "
+  },
+  {
+   "id": "CAP-COND-001",
+   "area": "COND",
+   "name": "",
+   "surface": "Filesystem",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-001-meta.json",
+   "status": "verified",
+   "notes": "meta.json perms 0644 when no env/env_file (alpha), 0600 when env present (beta). IsConductorSetup = meta.json exists. conductor move alpha --to-profile march migrated session row to march/state.db AND"
+  },
+  {
+   "id": "CAP-COND-002",
+   "area": "COND",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-002-setup.txt",
+   "status": "verified",
+   "notes": "setup: interactive Telegram/Slack/Discord prompts, saves [conductor] block (enabled=true, heartbeat_interval=15) to config.toml, registers conductor-<name> session in group conductor, installs transit"
+  },
+  {
+   "id": "CAP-COND-002",
+   "area": "COND",
+   "name": "",
+   "surface": "Filesystem",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-002-teardown.txt",
+   "status": "verified",
+   "notes": "config.toml [conductor] block persisted with plaintext token after telegram configured. teardown --remove deletes conductor dir + statedb session row."
+  },
+  {
+   "id": "CAP-COND-003",
+   "area": "COND",
+   "name": "",
+   "surface": "internal",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-003-statedb.txt",
+   "status": "verified",
+   "notes": "statedb instances table has is_conductor INTEGER NOT NULL DEFAULT 0 (col 14) and parent_session_id TEXT (col 13). Both conductor sessions have is_conductor=1. groups table: conductor group sort_order="
+  },
+  {
+   "id": "CAP-COND-004",
+   "area": "COND",
+   "name": "",
+   "surface": "Filesystem",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-004-heartbeat.sh",
+   "status": "verified",
+   "notes": "setup --heartbeat writes heartbeat.sh from template: {NAME}=gamma, {PROFILE}=default, {HEARTBEAT_PREFIX}='[HEARTBEAT]', {CONDUCTOR_ROOT} substituted; conductor status --json enabled-gate; session show"
+  },
+  {
+   "id": "CAP-COND-004",
+   "area": "COND",
+   "name": "",
+   "surface": "internal-daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-004-setup.txt",
+   "status": "untestable-locally",
+   "notes": "systemctl --user enable failed in sandbox (no user systemd bus): 'failed to enable heartbeat timer: exit status 1' handled gracefully as a warning (success:true). Actual daemon activation/firing requi"
+  },
+  {
+   "id": "CAP-COND-005",
+   "area": "COND",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-005-setup.txt",
+   "status": "verified",
+   "notes": "bridge.py (2010 lines, embedded conductorBridgePy) written to conductor/bridge.py ONLY when a channel is configured (absent before telegram token set). PEP 668 dep-install failure correctly classified"
+  },
+  {
+   "id": "CAP-COND-005",
+   "area": "COND",
+   "name": "",
+   "surface": "internal-daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-005-setup.txt",
+   "status": "untestable-locally",
+   "notes": "Live Telegram (aiogram polling) / Slack (socket mode) message routing, queue draining, and hook execution require real bot tokens + network + python deps (aiogram/slack-bolt/toml not installable under"
+  },
+  {
+   "id": "CAP-COND-006",
+   "area": "COND",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-006-doctor2.txt",
+   "status": "verified",
+   "notes": "session set <claude-session> channels 'plugin:telegram@...' updates+persists (JSON metadata col {\"channels\":[...]}). Mutator REJECTS channels on non-claude tool (shell): exit 1 'channels only supporte"
+  },
+  {
+   "id": "CAP-COND-006",
+   "area": "COND",
+   "name": "",
+   "surface": "internal",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-006-doctor2.txt",
+   "status": "untestable-locally",
+   "notes": "Per-session scratch CLAUDE_CONFIG_DIR rewrite (enabledPlugins.telegram=true) and TELEGRAM_* env strip happen only on the claude spawn path; the bun telegram poller is spawned/owned by the claude binar"
+  },
+  {
+   "id": "CAP-COND-007",
+   "area": "COND",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-007-delta-meta.json",
+   "status": "verified",
+   "notes": "meta.json layer fully verified: setup -env KEY=VALUE (repeatable) and -env-file persist env (map) and env_file (absolute string) in meta.json; meta perms become 0600 when env present. TOML layer: [con"
+  },
+  {
+   "id": "CAP-COND-007",
+   "area": "COND",
+   "name": "",
+   "surface": "internal",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-007-injection.txt",
+   "status": "partial",
+   "notes": "Runtime spawn env injection (buildEnvSourceCommand sourcing meta.EnvFile + exporting meta.Env as highest-priority step 6) is part of the claude/hermes spawn path, NOT bash. A bash conductor-prefixed s"
+  },
+  {
+   "id": "CAP-COND-008",
+   "area": "COND",
+   "name": "",
+   "surface": "internal-daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-008-notifydaemon.txt",
+   "status": "untestable-locally",
+   "notes": "transition-notifier systemd service written with RuntimeMaxSec=86400 recycle, Restart=always, logs to transition-notifier.log. The continuous TransitionDaemon polling + ShouldNotifyTransition emission"
+  },
+  {
+   "id": "CAP-COND-009",
+   "area": "COND",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-009-runtask.txt",
+   "status": "verified",
+   "notes": "run-task wrapper: worker printing '===AGENTDECK_DONE=== status=ok summary=all good' -> durable CompletionRecord {status:ok, summary:'all good', exit_code:0, acked:true}. No-sentinel + exit 3 -> status"
+  },
+  {
+   "id": "CAP-COND-010",
+   "area": "COND",
+   "name": "",
+   "surface": "Filesystem",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-010-templates.txt",
+   "status": "verified",
+   "notes": "Per-conductor instruction file rendered: alpha CLAUDE.md has {NAME}=alpha, {PROFILE}=default, {AGENT}=Claude Code substituted; default profile drops -p ('Use CLI commands without -p flag'). codex cond"
+  },
+  {
+   "id": "CAP-COND-010",
+   "area": "COND",
+   "name": "",
+   "surface": "internal",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/cond/ev-CAP-COND-010-templates.txt",
+   "status": "untestable-locally",
+   "notes": "ClearOnCompact runtime behavior (blocking claude auto-compaction and sending /clear via instructions) requires driving the real claude binary; the template/symlink/LEARNINGS install mechanism is verif"
+  },
+  {
+   "id": "CAP-WATCH-002",
+   "area": "WATCH",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-002-CLI.txt",
+   "status": "verified",
+   "notes": "github adapter create requires secret: via $GITHUB_WEBHOOK_SECRET env OR --secret-file (chmod 600); secret persisted to watcher.toml [source] secret (never CLI arg). webhook create requires --port. Re"
+  },
+  {
+   "id": "CAP-WATCH-002",
+   "area": "WATCH",
+   "name": "",
+   "surface": "daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-002-CLI.txt",
+   "status": "partial",
+   "notes": "WebhookAdapter and GitHubAdapter create+persist verified. ntfy/slack create OK. Gmail adapter: per contract v2 notes it is dead code (type 'gmail' not registered in startWatcherEngine switch; no creat"
+  },
+  {
+   "id": "CAP-WATCH-005",
+   "area": "WATCH",
+   "name": "",
+   "surface": "CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-005-CLI.txt",
+   "status": "verified",
+   "notes": "watcher test drives synthetic event through router: unrouted -> 'would go to triage'; routed -> resolves conductor/group. Confirms the triage entry decision."
+  },
+  {
+   "id": "CAP-WATCH-006",
+   "area": "WATCH",
+   "name": "",
+   "surface": "web",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-web-endpoints.txt",
+   "status": "verified",
+   "notes": "Web read path (snapshot_hook_refresh, AllowStaleWaiting=true) exercised via GET /api/sessions returning {sessions,groups,profile} 200; session status surfaced through the same Derive owner. Visual UI "
+  },
+  {
+   "id": "CAP-WATCH-008",
+   "area": "WATCH",
+   "name": "",
+   "surface": "none",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-007-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "Cost parsers (gemini/openai/minimax) + CostPoller tmux capture-pane polling are DEAD CODE at runtime per spec (NewCostPoller/Collector never constructed outside internal/costs; surface=none/unwired). "
+  },
+  {
+   "id": "CAP-WATCH-009",
+   "area": "WATCH",
+   "name": "",
+   "surface": "web",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-009-WEB.txt",
+   "status": "verified",
+   "notes": "GET /api/costs/summary returns {today_usd,week_usd,month_usd,projected_usd,*_events} 200; /api/costs/daily -> [] 200; /api/costs/models -> {} 200; /api/costs/groups -> [] 200. Screenshot ev-CAP-WATCH-"
+  },
+  {
+   "id": "CAP-WATCH-012",
+   "area": "WATCH",
+   "name": "",
+   "surface": "web",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-012-WEB.txt",
+   "status": "verified",
+   "notes": "GET /api/system/stats -> 200 with cpu{usage_percent}, disk{total/used bytes+human, usage_percent}, load{load1/5/15 from /proc/loadavg}, memory{total/used+usage_percent}, network{rx/tx bytes_per_sec+hu"
+  },
+  {
+   "id": "CAP-WATCH-013",
+   "area": "WATCH",
+   "name": "",
+   "surface": "daemon",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/watch/ev-CAP-WATCH-013-CLI.txt",
+   "status": "untestable-locally",
+   "notes": "Daemon loop (Run() immediate tick + every 25m interval, systemd --user unit) and the real lock-dir contention against live Claude Code (~/.claude.lock proper-lockfile directory, 30s stale-steal) are n"
+  },
+  {
+   "id": "CAP-MISC-003",
+   "area": "MISC",
+   "name": "",
+   "surface": "daemon/session",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-003-CLI.txt",
+   "status": "verified",
+   "notes": "On sandbox session start, RefreshAgentConfigs ran: created ~/.claude/sandbox (0700 shared dir), copied top-level host files (.claude.json, .credentials.json), recursively copied copyDirs (plugins/, sk"
+  },
+  {
+   "id": "CAP-MISC-008",
+   "area": "MISC",
+   "name": "",
+   "surface": "developer-CLI",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-008-note.txt",
+   "status": "untestable-locally",
+   "notes": "Makefile build/test/release pipeline is a developer/CI surface (make build/css/test/release-local), not a runtime feature of the shipped binary. No source tree available in this sandbox (conductor che"
+  },
+  {
+   "id": "CAP-MISC-014",
+   "area": "MISC",
+   "name": "",
+   "surface": "internal",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-014-note.txt",
+   "status": "untestable-locally",
+   "notes": "safego.Go is an internal panic-recovery library with no CLI/TUI/web front door. Its effect (a background goroutine panic logs 'safego_panic' WARN and is swallowed so the TUI survives) cannot be trigge"
+  },
+  {
+   "id": "CAP-MISC-015",
+   "area": "MISC",
+   "name": "",
+   "surface": "internal",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-015-CLI.txt",
+   "status": "partial",
+   "notes": "platform.Detect/IsHeadless/SupportsUnixSockets/CheckFsnotifySupport is an internal library consumed by clipboard choice, unix-socket capability, feedback browser fallback, and watcher warnings - no di"
+  },
+  {
+   "id": "CAP-MISC-017",
+   "area": "MISC",
+   "name": "",
+   "surface": "test-only",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-017-note.txt",
+   "status": "untestable-locally",
+   "notes": "testutil isolation/perf/seams (IsolateHome, IsolateTmuxSocket, testmain_audit, perfbudget, fakeclock/fakeinotify/logassert/multiclienttmux/profilefixture/crossfixture/teatesthelper) is a test-only har"
+  },
+  {
+   "id": "CAP-MISC-018",
+   "area": "MISC",
+   "name": "",
+   "surface": "test-only",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-018-note.txt",
+   "status": "untestable-locally",
+   "notes": "internal/integration real-tmux suite is test-only (go test ./internal/integration). No source tree available in this environment; running it requires the repo + a running tmux server and would skip ot"
+  },
+  {
+   "id": "CAP-MISC-019",
+   "area": "MISC",
+   "name": "",
+   "surface": "test-only",
+   "automated_test": "",
+   "user_verified": "2026-06-11",
+   "evidence": "evidence/misc/ev-CAP-MISC-019-note.txt",
+   "status": "untestable-locally",
+   "notes": "internal/releasetests regression manifest + release-pinning tests (manifest_test, issue1146_lefthook, issue1206_install_checksum) are test-only, reading .claude/release-tests.yaml, lefthook.yml, insta"
+  }
+ ]
+}

--- a/docs/verification/CAPABILITY-CHECKLIST.md
+++ b/docs/verification/CAPABILITY-CHECKLIST.md
@@ -1,0 +1,466 @@
+# agent-deck Capability Verification Checklist
+
+Derived from `01-CAPABILITY-SPEC.md` — 229 capabilities, 403 capability×surface rows.
+
+**Status legend:** `verified` · `broken` · `partial` · `untestable-locally` · `deferred` · `pending`.
+
+**Totals:** broken=1 · partial=43 · pending=115 · untestable-locally=29 · verified=215
+
+## CAP-SESS (13 caps, 32 rows) — partial:2, pending:11, untestable-locally:1, verified:18
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-SESS-001 | CLI | Session data model (Instance) and identity generation | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-001-CLI.txt | ad add/list --json shows Instance identity model. ID format matches randomString(8hex)-unixseconds (e.g. 0d8070e1-178119 |
+| CAP-SESS-001 | TUI | Session data model (Instance) and identity generation | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-TUI-home.txt | TUI session list renders title+tool+group tree. New Session modal shows full tool enum: shell/claude/gemini/opencode/cod |
+| CAP-SESS-001 | WEB | Session data model (Instance) and identity generation | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-WEB.txt | /api/sessions exposes id,title,tool,status,groupPath,projectPath,tmuxSession,tmuxSocketName,createdAt,command,noTransiti |
+| CAP-SESS-002 | CLI | Lifecycle states and transitions | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-002-CLI.txt | Lifecycle states observed: started shell session->idle; never-started sessions->error (tmuxSession.Exists()==false per c |
+| CAP-SESS-002 | TUI | Lifecycle states and transitions | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-TUI-home.txt | TUI status icons rendered per-session and in header legend: running(filled), waiting, idle(circle), stopped(square), err |
+| CAP-SESS-002 | WEB | Lifecycle states and transitions | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-WEB.txt | /api/sessions reports per-session status strings (error/idle/stopped) consistent with CLI/TUI. |
+| CAP-SESS-003 | CLI | Status derivation pipeline (UpdateStatus) | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-003-CLI.txt | ad status -v / --json drives the CLI cold-load poll (RefreshInstancesForCLIStatus): statuses are derived live from tmux  |
+| CAP-SESS-003 | TUI | Status derivation pipeline (UpdateStatus) | pending |  |  |  |
+| CAP-SESS-003 | WEB | Status derivation pipeline (UpdateStatus) | pending |  |  |  |
+| CAP-SESS-004 | CLI | Spawn paths: Start / StartWithMessage and the capture-resume | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-004-CLI.txt | Start() spawns tmux pane; AGENTDECK_INSTANCE_ID propagated into tmux session env (=51bd32c7-1781198354, equals the insta |
+| CAP-SESS-004 | TUI | Spawn paths: Start / StartWithMessage and the capture-resume | pending |  |  |  |
+| CAP-SESS-005 | SESS | Claude conversation binding: CLAUDE_SESSION_ID lifecycle and | pending |  |  |  |
+| CAP-SESS-006 | SESS | Duplicate-session killer (killing_duplicate_session) | pending |  |  |  |
+| CAP-SESS-007 | CLI | Resume and restart logic (claude --resume) | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-005-007-CLI.txt | ad session restart beta succeeds, returns to idle (fast-path for live tmux). Restart-guard observed: ad session start on |
+| CAP-SESS-007 | TUI | Resume and restart logic (claude --resume) | pending |  |  |  |
+| CAP-SESS-008 | CLI | Session registry: storage Load/Save semantics (state.db) | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-008-CLI.txt | state.db (SQLite WAL: state.db + -wal + -shm) created at <data>/agent-deck/profiles/personal/. Sessions persist across s |
+| CAP-SESS-008 | TUI | Session registry: storage Load/Save semantics (state.db) | pending |  |  |  |
+| CAP-SESS-008 | WEB | Session registry: storage Load/Save semantics (state.db) | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-WEB.txt | Headless web server (ad web --no-tui) reads the same state.db as source of truth and serves all sessions via /api/sessio |
+| CAP-SESS-009 | TUI | Hook-based status pipeline (Claude Code hooks to status file | pending |  |  |  |
+| CAP-SESS-010 | DAEMON/INTERNAL | Parent-child relationships, transition notification, and com | pending |  |  |  |
+| CAP-SESS-011 | DAEMON/INTERNAL | Death detection and the parent-signal gap (tmux pane / claud | pending |  |  |  |
+| CAP-SESS-012 | CLI | Group membership and per-group concurrency | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-012-CLI.txt | Explicit -g mygroup assigns group; auto-derivation puts path-tail-named group. group list shows per-group session+status |
+| CAP-SESS-012 | TUI | Group membership and per-group concurrency | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-TUI-home.txt | TUI renders the group tree with per-group session counts and status rollups (ad-sbx-sess(3), mygroup(1), serialgrp(2)),  |
+| CAP-SESS-013 | SESS | Child environment propagation (childenv) and spawn-env hygie | pending |  |  |  |
+| CAP-SESS-005 | CLI |  | partial | 2026-06-11 | evidence/sess/ev-CAP-SESS-005-007-CLI.txt | Front door 'session set claude-session-id' sets and clears the binding (shown ''->'test-uuid-1234'->'' incl #923 anchor- |
+| CAP-SESS-006 | CLI |  | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-006-CLI.txt | Created a rogue 'agentdeck_rogue_deadbeef' tmux session carrying the SAME AGENTDECK_INSTANCE_ID as alpha; ad session res |
+| CAP-SESS-009 | CLI |  | partial | 2026-06-11 | evidence/sess/ev-CAP-SESS-009-handler.txt | hook-handler subcommand exists; hooks dir created at <data>/agent-deck/hooks. Silent-skip guard verified: invoking hook- |
+| CAP-SESS-010 | CLI |  | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-010-CLI.txt | session set-parent beta alpha links beta.parent_session_id to alpha's exact ID (0d8070e1-1781198354). unset-parent clear |
+| CAP-SESS-010 | WEB |  | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-WEB.txt | noTransitionNotify=true surfaced on beta in /api/sessions, confirming the transition-notify toggle persisted to state.db |
+| CAP-SESS-010 | internal/daemon |  | untestable-locally | 2026-06-11 | evidence/sess/ev-CAP-SESS-010-CLI.txt | TransitionDaemon completion delivery (inbox/outbox PULL, Stop-hook drain, task-worker exit edge) requires the notify-dae |
+| CAP-SESS-011 | CLI |  | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-011-CLI.txt | Hard-killing the tmux session (simulating pane/agent death) flips status from idle to error on the next UpdateStatus pol |
+| CAP-SESS-013 | CLI |  | verified | 2026-06-11 | evidence/sess/ev-CAP-SESS-013-CLI.txt | Started grpsess1 with TELEGRAM_BOT_TOKEN=SECRET in parent env. tmux session env contains NO TELEGRAM var; child shell ex |
+
+## CAP-CLI (49 caps, 57 rows) — partial:9, pending:1, untestable-locally:5, verified:42
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-CLI-001 | CLI | TUI launch (bare `agent-deck`) + global flags | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-001-CLI.txt | Global flags + guards work as a user sees them: -g unknown-group exits 2 ('group not found'); outer-tmux guard prints th |
+| CAP-CLI-001 | TUI | TUI launch (bare `agent-deck`) + global flags | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-001-TUI.txt | Bare `agent-deck` boots the bubbletea TUI in a tmux pane: header shows version v1.9.56-verify + status counts + system s |
+| CAP-CLI-002 | CLI | add (create session) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-002-CLI.txt | add registers session without starting tmux. Verified: basic add (default group=folder name), --json (keys command/group |
+| CAP-CLI-003 | CLI | launch (add+start+send in one step) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-003-CLI.txt | launch = add+start(+send). Session created AND tmux session running. JSON includes BOTH `id` and `session_id` keys (comp |
+| CAP-CLI-004 | CLI | list / ls | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-004-CLI.txt | list/ls table (TITLE/GROUP/PATH/ID truncated). --json carries id,title,path,group,tool,command,status,tmux_session,profi |
+| CAP-CLI-005 | CLI | remove / rm (top-level) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-005-CLI.txt | remove resolves by exact title, by ID prefix (8 chars >=6), persists (gone from list). not-found exit 2. rm alias works. |
+| CAP-CLI-006 | CLI | session remove (registry-scoped remove) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-006-CLI.txt | session remove is registry-scoped and status-gated: refused on a non-stopped/error session ('in state idle; only stopped |
+| CAP-CLI-007 | CLI | rename / mv | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-007-CLI.txt | rename persists new title; mv alias works; not-found exit 2; rename sets TitleLocked=true (session show --json title_loc |
+| CAP-CLI-008 | CLI | status | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-008-CLI.txt | status default prints '<w> waiting • <r> running • <i> idle'; -q prints only waiting count (script-friendly); -v grouped |
+| CAP-CLI-009 | CLI | session start | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-009-CLI.txt | session start creates real tmux session (verified on isolated socket), status flips to idle, already-running error exit  |
+| CAP-CLI-010 | CLI | session stop + queue drain | partial | 2026-06-11 | evidence/cli/ev-CAP-CLI-010-CLI.txt | session stop verified: stops a running session (status->stopped, tmux killed), stop-not-running error exit 1. Queue DRAI |
+| CAP-CLI-011 | CLI | session restart | partial | 2026-06-11 | evidence/cli/ev-CAP-CLI-011-CLI.txt | restart core verified: single restart, --force, --all (per-session JSON restarted/failed/total/sessions), not-found exit |
+| CAP-CLI-012 | CLI | session revive | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-012-CLI.txt | session revive --all prints the exact summary contract 'revived=N errored=N alive=N dead=N'; --json emits {revived,error |
+| CAP-CLI-013 | CLI | session fork | partial | 2026-06-11 | evidence/cli/ev-CAP-CLI-013-CLI.txt | Front-door verified: fork rejects non-forkable shell sessions ('not a forkable session (tool: shell)', exit 1), not-foun |
+| CAP-CLI-014 | CLI | session attach | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-014-CLI.txt | session attach: not-running error exit 1, not-found exit 2. Interactive attach driven inside a wrapper tmux pane LANDED  |
+| CAP-CLI-015 | CLI | session show / session current | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-015-CLI.txt | session show outputs refreshed status, path, group, tool, command, title_locked, tmux name, timestamps, parent link fiel |
+| CAP-CLI-016 | CLI | session set (generic field mutation) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-016-CLI.txt | session set: color #RRGGBB / ANSI 0-255 / '' clear all accepted, invalid color rejected with the expected message (exit  |
+| CAP-CLI-017 | CLI | session set-parent / unset-parent / set-transition-notify /  | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-017-CLI.txt | set-parent links sub-session (parent_session_id persisted), rejects self ('cannot set as own parent' exit1), rejects par |
+| CAP-CLI-018 | CLI | session send (message delivery) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-018-019-020-CLI.txt | session send delivered 'echo SENDMARKER_018' which ran in pane (verified via raw tmux capture). 'Sent message' exit0. No |
+| CAP-CLI-019 | CLI | session send-keys (low-level keystroke primitive) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-018-019-020-CLI.txt | send-keys --text + --enter delivered KEYSMARKER (ran). --stream stdin line protocol (T <hex>, E) delivered STREAMMARKER  |
+| CAP-CLI-020 | CLI | session output | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-018-019-020-CLI.txt | --pane --json returns ResponseOutput-shaped JSON (content/role/session_id/session_title/success/tool). Default transcrip |
+| CAP-CLI-021 | CLI | session search | partial | 2026-06-11 | evidence/cli/ev-CAP-CLI-021-022-CLI.txt | Command front door verified: parses query + --limit/--days/--tier, builds GlobalSearchIndex over Claude config dir, emit |
+| CAP-CLI-022 | CLI | session move (path move + cross-profile migration) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-021-022-CLI.txt | Form1 move to new path: ProjectPath updated+persisted, --no-restart honored. Form2 --to-profile missing profile -> NOT_F |
+| CAP-CLI-023 | CLI | mcp list/attached/attach/detach + mcp server start/stop/stat | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-023-CLI.txt | mcp list (table with [S]/[H] transport tags + -q names). attached (LOCAL split, empty state). attach: unknown -> exit2 + |
+| CAP-CLI-024 | CLI | plugin list/attached/attach/detach | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-024-CLI.txt | plugin list shows emits_channel marker + id@source (requires name+source fields in [plugins.*]). attach persists + print |
+| CAP-CLI-025 | CLI | skill list/attached/attach/detach/source add\|remove\|list | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-024-025-CLI.txt | source add/duplicate(ALREADY_EXISTS exit1)/list(shows claude-global,pool,custom)/remove(not-found exit2, valid ok). skil |
+| CAP-CLI-026 | CLI | group list/create/update/delete/move/change/reorder | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-026-CLI.txt | create (+idempotent, bad-parent exit2, child); list tree + --json nesting; update (default-path, require-one-flag, mutua |
+| CAP-CLI-027 | CLI | worktree list/info/cleanup/finish | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-027-CLI.txt | add -w -b creates git worktree on disk. worktree list shows main+worktree with session assoc. info shows branch/path/mai |
+| CAP-CLI-028 | CLI | conductor setup/teardown/status/list/move | partial | 2026-06-11 | evidence/cli/ev-CAP-CLI-028-CLI.txt | setup: saves config.toml, installs shared CLAUDE.md/POLICY.md/LEARNINGS.md, creates conductor/<name>/{meta.json,CLAUDE.m |
+| CAP-CLI-029 | CLI | telegram-doctor | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-029-CLI.txt | Empty profile: 'no telegram channel-owning sessions' exit0 + JSON {channel_owners:0,reports:[]} + quiet silent. With a t |
+| CAP-CLI-030 | CLI | watcher create/start/stop/list/status/test/routes/import/ins | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-030-CLI.txt | create webhook(--port required)/ntfy(--topic)/github(--secret-file). inline --secret REFUSED (M2 /proc leak, with explan |
+| CAP-CLI-031 | CLI | profile list/create/delete/default | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-031-CLI.txt | bare profile lists (empty msg, marks default with *). create; duplicate ALREADY_EXISTS exit1. default show + set. delete |
+| CAP-CLI-032 | CLI | update (self-update) + remote propagation | partial | 2026-06-11 | evidence/cli/ev-CAP-CLI-032-CLI.txt | Flag surface verified via --help (--check, --version). --check performs a real GitHub releases API call (version banner  |
+| CAP-CLI-033 | CLI | uninstall | partial | 2026-06-11 | evidence/cli/ev-CAP-CLI-033-CLI.txt | --help flag surface (--dry-run/--keep-data/--keep-tmux-config/-y). --dry-run scans binary + XDG config + data (profile/s |
+| CAP-CLI-034 | CLI | migrate-paths | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-034-CLI.txt | migrate-paths --dry-run reports 'nothing to migrate' and leaves legacy dir untouched; with a legacy ~/.agent-deck presen |
+| CAP-CLI-035 | CLI | hook-handler (Claude Code hook ingestion) + hooks install/un | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-035-CLI.txt | hooks install writes ~/.claude/settings.json (status NOT INSTALLED -> INSTALLED -> uninstall); hook-handler requires AGE |
+| CAP-CLI-036 | CLI | codex-notify + codex-hooks / gemini-hooks / hermes-hooks ins | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-036-CLI.txt | codex-notify reads JSON from stdin AND argv; fuzzy event mapping confirmed (turn.complete->waiting, turn.start->running) |
+| CAP-CLI-037 | CLI | notify-daemon (transition notifier) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-037-CLI.txt | notify-daemon --once performs a single SyncOnce+Flush and exits 0 cleanly within timeout. |
+| CAP-CLI-038 | CLI | run-task (one-shot worker completion wrapper) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-038-CLI.txt | run-task --child <valid-id> -- echo TASKRAN runs the command verbatim (stdout passes through), exit 0; worker nonzero ex |
+| CAP-CLI-039 | CLI | inbox / inbox drain | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-039-CLI.txt | inbox drain resolves caller id from AGENTDECK_INSTANCE_ID (and explicit id), emits '[]' (never null) in --json and 'No p |
+| CAP-CLI-040 | CLI | costs sync/summary/recompute | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-040-CLI.txt | costs summary --json emits the RemoteCostSummary wire shape (cost_today/yesterday/this_week/last_week/this_month/last_mo |
+| CAP-CLI-041 | CLI | creds-refresh (OAuth keep-warm daemon) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-041-CLI.txt | creds-refresh --once with no .credentials.json in default/specified dirs -> 'no profile config dir with a .credentials.j |
+| CAP-CLI-042 | CLI | openclaw / oc sync\|bridge\|status\|list\|send | partial | 2026-06-11 | evidence/cli/ev-CAP-CLI-042-CLI.txt | CLI front door verified: openclaw list/status and the 'oc' alias connect to the configured gateway (default ws 127.0.0.1 |
+| CAP-CLI-043 | CLI | remote add/remove/list/sessions/attach/rename/update | partial | 2026-06-11 | evidence/cli/ev-CAP-CLI-043-CLI.txt | add persists [remotes.<name>] to config.toml (host/agent_deck_path/profile) and the ssh CheckBinary probe failing only w |
+| CAP-CLI-044 | CLI | web (TUI+HTTP server, or headless --no-tui) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-044-CLI.txt | Security gate: 'web --no-tui --listen 0.0.0.0:PORT' without --token is REFUSED (exit 1) with the exact RCE-surface messa |
+| CAP-CLI-044 | TUI | web (TUI+HTTP server, or headless --no-tui) | untestable-locally | 2026-06-11 | evidence/cli/ev-CAP-CLI-044-WEB.png | The combined TUI+HTTP mode (bubbletea + server) belongs to the TUI surface area; the --no-tui headless path and the secu |
+| CAP-CLI-044 | WEB | web (TUI+HTTP server, or headless --no-tui) | pending |  |  |  |
+| CAP-CLI-045 | CLI | mcp-proxy (internal stdio↔unix-socket bridge) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-045-CLI.txt | mcp-proxy with no arg -> 'Usage: agent-deck mcp-proxy <socket-path>' exit 1; against a live python unix-socket echo serv |
+| CAP-CLI-046 | CLI | try (dated experiments) | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-046-CLI.txt | try --list on empty reports 'No experiments in <dir>/tries'; 'try myexp --no-session -c bash' creates the date-prefixed  |
+| CAP-CLI-047 | CLI | feedback | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-047-CLI.txt | feedback --help documents the disclose-before-post contract (#679: shows URL/gh login/exact body, default-N confirm, no  |
+| CAP-CLI-048 | CLI | debug-dump / version / help | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-048-CLI.txt | version, --version, -v all print 'Agent Deck v1.9.56-verify' exit 0 (offline, no network); debug-dump writes debug-dump- |
+| CAP-CLI-049 | CLI | shared CLI infrastructure (resolution, output, exit-code con | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-049-CLI.txt | ResolveSession verified across all three modes: exact title, ID prefix (>=6 chars), exact path. CLIOutput: --json error  |
+| CAP-CLI-028 | daemon |  | untestable-locally | 2026-06-11 | evidence/cli/ev-CAP-CLI-028-CLI.txt | Heartbeat launchd/systemd daemon + bridge.py + transition-notifier as long-lived daemons require a real systemd/launchd  |
+| CAP-CLI-035 | daemon |  | untestable-locally | 2026-06-11 | evidence/cli/ev-CAP-CLI-035-CLI.txt | The daemon-side consumers (transition notifier reading these status files, DrainForStopHook stdout block injection) are  |
+| CAP-CLI-037 | daemon |  | untestable-locally | 2026-06-11 | evidence/cli/ev-CAP-CLI-037-CLI.txt | The long-lived daemon loop (SIGINT/SIGTERM context, watchBinaryVersion re-exec every 60s, #1214 stale-daemon recycle) is |
+| CAP-CLI-041 | daemon |  | untestable-locally | 2026-06-11 | evidence/cli/ev-CAP-CLI-041-CLI.txt | The actual OAuth refresh-token exchange against Anthropic, atomic rewrite under proper-lockfile, and the SIGINT/SIGTERM  |
+| CAP-CLI-044 | web |  | verified | 2026-06-11 | evidence/cli/ev-CAP-CLI-044-WEB.png | web --no-tui boots headless ('Headless mode: TUI disabled', 'Web server: http://127.0.0.1:8492'); GET /api/sessions retu |
+
+## CAP-TUI (37 caps, 44 rows) — partial:7, pending:3, verified:34
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-TUI-001 | TUI | Home screen: session list / group tree navigation | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-001-TUI.txt | Home renders flattened tree: group headers with counts (ad-sbx... (3)), nested sessions (alpha/beta/cl-sess), second emp |
+| CAP-TUI-002 | TUI | Attach / detach / open-in-new-window | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-002-TUI.txt | Enter on running 'beta' attached via PTY into its tmux ([agentdeck_beta_...] 0:bash*, status line 'ctrl+q detach \| beta |
+| CAP-TUI-003 | TUI | New session dialog (n) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-003-TUI.txt | n opens New Session dialog: Name field, Multi-repo toggle, Path (defaulted to cursor group's path), command pill picker  |
+| CAP-TUI-004 | TUI | Quick create (N) and zoxide quick-open (z) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-004-TUI.txt | N quick-create instantly created session 'stone-pine' with no dialog and an auto-generated unique name; appeared in ad l |
+| CAP-TUI-005 | TUI | Fork: quick fork (f) and fork dialog (F) | partial | 2026-06-11 | evidence/tui/ev-CAP-TUI-005-CLI.txt | Fork gating verified on both surfaces: F/f did NOT open the fork dialog on shell sessions or non-resumable claude sessio |
+| CAP-TUI-005 | WEB | Fork: quick fork (f) and fork dialog (F) | pending |  |  |  |
+| CAP-TUI-006 | TUI | Session lifecycle: delete (d) / close (D) / remove (X) / bul | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-006c-TUI.txt | ConfirmDialog verified for all variants. d: 'Delete Session? beta, Any running processes will be killed' -> y -> removed |
+| CAP-TUI-006 | WEB | Session lifecycle: delete (d) / close (D) / remove (X) / bul | pending |  |  |  |
+| CAP-TUI-007 | TUI | Restart (R) and restart-fresh (T) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-007-TUI.txt | R restart on running beta kept it live; R on errored gitsess started it (created live tmux session, status flipped error |
+| CAP-TUI-008 | TUI | MCP Manager (m) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-008-TUI.txt | m on a claude session opens MCP Manager: scopes [LOCAL] GLOBAL USER, Tab cycles them (LOCAL='.mcp.json this project'; GL |
+| CAP-TUI-009 | TUI | Plugin Manager (L) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-009-TUI.txt | L on claude session opens Plugin Manager: title, 'space toggle · up/down move · enter apply · esc cancel' keys, empty-ca |
+| CAP-TUI-010 | TUI | Skills Manager (s) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-010-TUI.txt | s on claude session opens Skills Manager: POOL scope, 'Writes to: .agent-deck/skills.toml + .claude/skills (project)', e |
+| CAP-TUI-011 | TUI | Edit Session dialog (P) and Edit Paths dialog (p) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-011-TUI.txt | P opens Edit Session dialog (local sessions): Title field (cl-sess), Tool pill row (restart), Claude-specific '[x] Skip  |
+| CAP-TUI-012 | TUI | Group management (g create, r rename, M move, reorder/indent | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-012-TUI.txt | g opens GroupDialog 'Create New Group' with [Root]/Subgroup toggle (Tab toggle/next, Shift+Tab prev), Name field. M open |
+| CAP-TUI-013 | CLI | Group-scoped launch (--group) and group-scoped navigation la | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-013-TUI.txt | 'agent-deck --group myscope' launched TUI scoped to that subtree: header shows 'Agent Deck [myscope]' and list shows ONL |
+| CAP-TUI-013 | TUI | Group-scoped launch (--group) and group-scoped navigation la | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-013-TUI.txt | Alt+j/Alt+k navigate within current group (moved beta<->stone-pine). nav-hint sentinel '.nav-hint-v1760-shown' written u |
+| CAP-TUI-014 | TUI | Jump mode (Space) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-014-TUI.txt | Space enters jump mode: home-row hint labels spliced into item names (alpha->dlpha, beta->feta, cl-sess->jl-sess, group- |
+| CAP-TUI-015 | TUI | Search: local (/), global (G), status-keyword filters | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-015-TUI.txt | / opens '🔍 Local Search (Agent Deck sessions)' with status-keyword hint (waiting/running/idle); typing 'beta' live-filte |
+| CAP-TUI-016 | TUI | Status filters and filter bar | partial | 2026-06-11 | evidence/tui/ev-CAP-TUI-016-TUI.txt | Filter bar renders with legend '!@#$ filter • 0 all • % open' and live status counts (All ● ◐ ○ ✕ counts). 0 clears, ! @ |
+| CAP-TUI-017 | TUI | Preview pane (right/bottom panel) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-017-TUI.txt | Preview pane shows session info card (Repo/Path/tool/timestamps, Claude status card), live tmux output tail (typed 'echo |
+| CAP-TUI-018 | TUI | Copy / send output (c, C, x) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-018b-TUI.txt | x opens SessionPickerDialog 'Send Output To...' (Enter send / Esc cancel / j/k navigate). c (copy last AI response) and  |
+| CAP-TUI-019 | TUI | Insert mode (I): type-through to session | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-019b-TUI.txt | I on running beta enters insert mode: bottom bar becomes '-- INSERT -- → beta  Esc to exit · Enter to submit'. Typed 'ec |
+| CAP-TUI-020 | TUI | Quick approve (a), mark unread (u), YOLO toggle (y), Gemini  | partial | 2026-06-11 | evidence/tui/ev-CAP-TUI-020-TUI-markunread.txt, ev-CAP-TUI-020-TUI-yolo-toggle.txt, ev-CAP-TUI-020-TUI-gemini-model.txt, ev-CAP-TUI-020-TUI-quickapprove.txt | u mark-unread persists acknowledged=0 to SQLite (verified). y yolo toggle on gemini session flipped tool_data {} -> {"ge |
+| CAP-TUI-021 | TUI | Worktree finish (W) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-021-TUI-worktree-finish.txt | W on a real git-worktree session opened the two-step Finish Worktree dialog: Session/Branch/Status (clean, async uncommi |
+| CAP-TUI-022 | TUI | Settings panel (S) + tool visibility panel | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-022-TUI-settings.txt, ev-CAP-TUI-022-TUI-settings-full.txt, ev-CAP-TUI-022-CLI-config-preserved.txt | S opens settings with all sections (Theme radio, Default tool, Claude dangerous/config-dir, Gemini/Codex/Hermes YOLO, Up |
+| CAP-TUI-023 | TUI | Watcher panel (w) + watcher event dispatch | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-023-TUI-watcher.txt | w opens the Watcher overlay: WATCHERS header, 'No watchers configured' empty state, quick actions [Enter] Details [s] St |
+| CAP-TUI-024 | TUI | Cost dashboard ($) and analytics | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-024-TUI-cost-dashboard.txt | $ opened the full-screen Cost Dashboard (costs.Store IS wired in this build): Today/Week/Month/Projected cards, Today to |
+| CAP-TUI-025 | TUI | Remote sessions (SSH remotes section) | partial | 2026-06-11 | evidence/tui/ev-CAP-TUI-025-CLI-remote.txt, ev-CAP-TUI-025-TUI-remotes.txt | Remote registration front door works: 'remote add' wrote [remotes.testremote] and 'remote list' shows it (host/path/prof |
+| CAP-TUI-026 | TUI | Import tmux sessions (i) and manual reload (ctrl+r) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-026-TUI-import.txt, ev-CAP-TUI-026-TUI-reload.txt | i discovered an orphan tmux session (orphan_import_test) not in the registry, appended it as an instance AND added to th |
+| CAP-TUI-027 | TUI | Status detection, notifications, hooks prompt | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-027-TUI-hooks-prompt.txt | First-run ConfirmInstallHooks dialog shown ('Claude Code Hooks', Install/Skip, y install/n skip). Choosing Skip ('n') pe |
+| CAP-TUI-028 | TUI | Quit flow and shutdown | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-028-TUI-quit.txt | q cleanly exits the TUI (tmux session ends). On quit, ui_state metadata is persisted (cursor_group_path, preview_mode) a |
+| CAP-TUI-029 | TUI | Help overlay (?), footer help bar, update nudge, feedback di | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-029-TUI-help.txt, ev-CAP-TUI-029-TUI-feedback.txt | ? opens the scrollable shortcuts modal with live bindings (NAVIGATION, GROUP NAVIGATION v1.7.60 Alt-layer, SESSIONS sect |
+| CAP-TUI-030 | TUI | Setup wizard (first run) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-030-TUI-setup-wizard.txt, evidence/tui/ev-CAP-TUI-030-CLI-wizard-config.txt | Launching with no config.toml shows the wizard: Welcome -> Tool selection (claude/gemini/opencode/codex/pi/shell/...) -> |
+| CAP-TUI-031 | TUI | Hotkey remapping ([hotkeys] config) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-031-TUI-hotkey-remap.txt | [hotkeys] new_session='z' remapped 'z' to open the New Session dialog (overriding default zoxide binding). The rebound d |
+| CAP-TUI-032 | TUI | Mouse support | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-032-TUI-mouse.txt | SGR mouse click at row 8 moved the cursor to the correctly-mapped list item (m2) — Y-to-index math accounts for header/b |
+| CAP-TUI-033 | TUI | Notes editing (e) | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-033-TUI-notes-edit.txt, ev-CAP-TUI-033-TUI-notes-saved.txt | With [preview] show_notes=true, e on a live session opens the Notes textarea ('Ctrl+S save • Esc cancel', split with Out |
+| CAP-TUI-034 | TUI | Sandbox shell exec (E) | partial | 2026-06-11 | evidence/tui/ev-CAP-TUI-034-TUI-sandbox-shell.txt | E on a non-sandboxed session is a no-op (correctly gated — only sessions with a SandboxContainer open a container shell) |
+| CAP-TUI-035 | TUI | Web bridge (WebMutator) and web menu snapshots | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-035-WEB.png | Web/TUI share the same Home/profile; the web UI's session list/detail mirror the TUI state (publishWebMenuSnapshot). No  |
+| CAP-TUI-035 | WEB | Web bridge (WebMutator) and web menu snapshots | pending |  |  |  |
+| CAP-TUI-036 | TUI | Theme handling (system dark/light watcher) | partial | 2026-06-11 | evidence/tui/ev-CAP-TUI-036-TUI-theme-system.txt, ev-CAP-TUI-036-TUI-theme-launched.txt | Theme setting offers dark/light/system radio (settings panel + setup wizard). Toggling theme persists to config.toml the |
+| CAP-TUI-037 | TUI | Keyboard compatibility layer (Kitty/CSI u, Shift+Enter) | partial | 2026-06-11 | evidence/tui/ev-CAP-TUI-032-TUI-mouse.txt | The Private-Use rune U+E5E5 (the Shift+Enter relay) was processed by normalizeMainKey without crashing the TUI (no-op on |
+| CAP-TUI-008 | CLI |  | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-008-TUI.txt | CLI mirror confirmed present: 'agent-deck mcp attach/detach/attached/list' subcommands exist (referenced in contract; su |
+| CAP-TUI-025 | CLI |  | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-025-CLI-remote.txt | CLI mirror verified: remote add/list/sessions present and functioning; unreachable remote errors are surfaced cleanly wi |
+| CAP-TUI-035 | web |  | verified | 2026-06-11 | evidence/tui/ev-CAP-TUI-035-WEB-sessions.json, ev-CAP-TUI-035-WEB-create.json, ev-CAP-TUI-035-WEB.png | ad web --no-tui serves the REST API: GET /api/sessions returns the full TUI-mirrored list (titles, notes, titleLocked, s |
+
+## CAP-WEB (18 caps, 23 rows) — partial:1, pending:4, verified:18
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-WEB-001 | CLI | Web server bootstrap, config and security gate | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-001-CLI-help.txt, ev-CAP-WEB-001-CLI-bindgate.txt, ev-CAP-WEB-001-CLI-emptyhost.txt, ev-CAP-WEB-016-CLI-pushtest-requires.txt | web --help shows all flags (--listen/--read-only/--token/--insecure-bind/--push/--push-vapid-subject/--push-test-every/- |
+| CAP-WEB-001 | TUI | Web server bootstrap, config and security gate | pending |  |  |  |
+| CAP-WEB-001 | WEB | Web server bootstrap, config and security gate | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-001-mutdisabled.txt, ev-CAP-WEB-002-healthz-unauth.json | --read-only sets webMutations=false; POST mutation returns 403 MUTATIONS_DISABLED while GET still 200. Error envelope un |
+| CAP-WEB-002 | WEB | Authentication (bearer token) + CSRF protection | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-002-noauth.json, ev-CAP-WEB-002-csrf.txt, ev-CAP-WEB-002-csrf-mismatch.txt, ev-CAP-WEB-002-csrf-ok.txt, ev-CAP-WEB-002-healthz-unauth.json | With --token: no token->401 UNAUTHORIZED, wrong token->401, correct Bearer->200, ?token= on REST rejected 401. healthz u |
+| CAP-WEB-003 | WEB | Menu / session-list read API with hook-status overlay | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-003-menu.json, ev-CAP-WEB-003-sessions.json, ev-CAP-WEB-003-groups.json, ev-CAP-WEB-003-session-single.json, ev-CAP-WEB-003-404.json | GET /api/menu returns {profile,generatedAt,totalGroups,totalSessions,items[]} with group/session MenuItems. /api/session |
+| CAP-WEB-004 | WEB | SSE live menu stream | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-004-sse.txt | GET /events/menu emits 'event: menu' + full MenuSnapshot JSON immediately. Content-Type text/event-stream, Cache-Control |
+| CAP-WEB-005 | WEB | Session lifecycle mutations (create/start/stop/restart/close | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-005-create.txt, ev-CAP-WEB-005-create-bad.txt, ev-CAP-WEB-005-badaction.txt, ev-CAP-WEB-005-tui-restart.txt, ev-CAP-WEB-005-tui-delete.txt, ev-CAP-WEB-005-tui-undelete.txt | POST /api/sessions create->201 {sessionId} and persists (read-back confirms). Missing title->400 INVALID_REQUEST. Unknow |
+| CAP-WEB-006 | WEB | Session field edit (PATCH /api/sessions/{id}) | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-006-tui-patch-valid.txt, ev-CAP-WEB-006-emptytitle.txt, ev-CAP-WEB-006-nofields.txt, ev-CAP-WEB-006-tui-restartreq.txt | PATCH /api/sessions/{id} via TUI mutator returns 200 {sessionId,updatedFields:[notes,color,title],restartRequired:false} |
+| CAP-WEB-007 | WEB | Group management (create/rename/delete) | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-007-tui-create.txt, ev-CAP-WEB-007-tui-rename.txt, ev-CAP-WEB-007-tui-del.txt, ev-CAP-WEB-007-subgroup.txt | Via TUI mutator: POST /api/groups {name}->201 {path}; PATCH /api/groups/{path} {name}->200 {name,path} returning OLD pat |
+| CAP-WEB-008 | WEB | Worktree finish (merge + teardown) endpoint | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-008-tui-finish.txt, ev-CAP-WEB-008-finish-404.txt | POST /api/sessions/{id}/worktree/finish on a non-worktree session->400 INVALID_REQUEST 'session is not in a worktree' (E |
+| CAP-WEB-009 | WEB | Children topology endpoint (conductor tree) | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-009-children.json | GET /api/sessions/{id}/children->200 {sessionId,children:[]} (empty array for leaf). Non-GET (POST)->405. Unknown id->40 |
+| CAP-WEB-010 | TUI | Skills management API | pending |  |  |  |
+| CAP-WEB-010 | WEB | Skills management API | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-010-skills.json, ev-CAP-WEB-010-session-skills.txt, ev-CAP-WEB-010-attach.txt, ev-CAP-WEB-010-claude-skills.txt, ev-CAP-WEB-010-claude-attach.txt, ev-CAP-WEB-010-claude-detach.txt | GET /api/skills->{skills:[]} catalog (empty in sandbox). GET /api/sessions/{id}/skills->200 {skills:[]}. Attach to shell |
+| CAP-WEB-011 | TUI | MCP management API | pending |  |  |  |
+| CAP-WEB-011 | WEB | MCP management API | partial | 2026-06-11 | evidence/web/ev-CAP-WEB-011-mcps.txt, ev-CAP-WEB-011-session-mcps.txt, ev-CAP-WEB-011-attach.txt, ev-CAP-WEB-011-patch.txt | CONFIRMED PRODUCTION WIRING GAP (matches v2 notes): the shipped 'agent-deck web' binary never calls SetMCPManager, so GE |
+| CAP-WEB-012 | WEB | Costs API + costs SSE stream | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-012-summary.txt, ev-CAP-WEB-012-daily.txt, ev-CAP-WEB-012-batch.txt, ev-CAP-WEB-012-batch-post.txt, ev-CAP-WEB-012-stream.txt, ev-CAP-WEB-012-export.csv | /api/costs/summary->{today/week/month_usd+events,projected_usd}. /api/costs/daily?days=7->[]. /api/costs/batch GET and P |
+| CAP-WEB-013 | WEB | System stats endpoint | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-013-system.json | GET /api/system/stats->200 with cpu, disk, load, memory, network sections (gpu absent as expected when sysinfo reports u |
+| CAP-WEB-014 | WEB | Settings + profiles read endpoints | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-014-settings.json, ev-CAP-WEB-014-profiles.json | GET /api/settings->{profile,readOnly,webMutations,version,toolFilter,visibleTools[],toolFilterFallback,hiddenTools[],pic |
+| CAP-WEB-015 | WEB | WebSocket terminal bridge (live tmux attach in browser) | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-015-ws.txt | GET /ws/session/{id} upgrades to WebSocket; emits {status,connected} then {status,ready}. When tmux session absent, send |
+| CAP-WEB-016 | CLI | Web Push notifications (PWA) | pending |  |  |  |
+| CAP-WEB-016 | WEB | Web Push notifications (PWA) | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-016-config.json, ev-CAP-WEB-016-subscribe.txt, ev-CAP-WEB-016-presence.txt, ev-CAP-WEB-016-unsubscribe.txt, ev-CAP-WEB-016-files.txt, ev-CAP-WEB-016-CLI-pushtest-requires.txt, ev-CAP-WEB-016-subscribe-disabled.txt | --push generates VAPID keypair: /api/push/config->{enabled:true,subject:mailto:agentdeck@localhost,vapidPublicKey(87-cha |
+| CAP-WEB-017 | WEB | Static assets, SPA serving and PWA shell | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-017-spa.png, ev-CAP-WEB-017-index.html | GET / serves index.html (text/html, Referrer-Policy: no-referrer, Cache-Control no-cache/no-store). GET /s/{deeplink}->2 |
+| CAP-WEB-018 | WEB | Parity contract with TUI/CLI (what web can and cannot do) | verified | 2026-06-11 | evidence/web/ev-CAP-WEB-018-parity.txt, ev-CAP-WEB-018-methodnotallowed.txt | Parity probes: TUI-only MISSING actions all 404 (restart-fresh, rename, move, yolo, approve, /api/search, /api/help). In |
+
+## CAP-FORK (14 caps, 31 rows) — partial:8, pending:14, untestable-locally:2, verified:7
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-FORK-001 | CLI | Claude conversation fork (capture-resume via --fork-session) | partial | 2026-06-11 | evidence/fork/ev-CAP-FORK-002-003-004-CLI-gate.txt | Fork CLI front door verified: `agent-deck session fork` exists with all documented flags (-t,-g,-w,-b,--with-state,--wit |
+| CAP-FORK-001 | TUI | Claude conversation fork (capture-resume via --fork-session) | partial | 2026-06-11 | evidence/fork/ev-CAP-FORK-TUI-help.txt | TUI keybinding `f/F Fork session (Claude/Pi)` confirmed present in help screen. Pressing F on an unstarted (error-state) |
+| CAP-FORK-001 | WEB | Claude conversation fork (capture-resume via --fork-session) | partial | 2026-06-11 | evidence/fork/ev-CAP-FORK-005-WEB.txt | Web /api/sessions exposes per-session `canFork` boolean (=false for unstarted claude, matching the CanFork freshness gat |
+| CAP-FORK-002 | CLI | OpenCode fork (export/sed/import script) | partial | 2026-06-11 | evidence/fork/ev-CAP-FORK-002-003-004-CLI-gate.txt | CanForkOpenCode gate verified: `session fork tool-opencode` -> 'cannot be forked: no resumable session for tool opencode |
+| CAP-FORK-002 | TUI | OpenCode fork (export/sed/import script) | pending |  |  |  |
+| CAP-FORK-002 | WEB | OpenCode fork (export/sed/import script) | pending |  |  |  |
+| CAP-FORK-003 | CLI | Pi fork (JSONL file fork) | partial | 2026-06-11 | evidence/fork/ev-CAP-FORK-002-003-004-CLI-gate.txt | CanForkPi gate verified: `session fork tool-pi` -> 'cannot be forked: no resumable session for tool pi' (exit 1). pi bin |
+| CAP-FORK-003 | TUI | Pi fork (JSONL file fork) | pending |  |  |  |
+| CAP-FORK-003 | WEB | Pi fork (JSONL file fork) | pending |  |  |  |
+| CAP-FORK-004 | CLI | Codex fork (`codex fork <sid>`) | verified | 2026-06-11 | evidence/fork/ev-CAP-FORK-004-CLI-notforkable.txt | Non-forkable rejection verified: `session fork bashsess` -> 'not a forkable session (tool: shell)' (exit 1). CanForkCode |
+| CAP-FORK-004 | TUI | Codex fork (`codex fork <sid>`) | pending |  |  |  |
+| CAP-FORK-004 | WEB | Codex fork (`codex fork <sid>`) | pending |  |  |  |
+| CAP-FORK-005 | CLI | Fork dispatch and post-create pipeline | verified | 2026-06-11 | evidence/fork/ev-CAP-FORK-005-CLI-noexist.txt | Fork dispatch pipeline gates verified in order: session-resolve (non-existent -> 'session not found' exit 2), tool gate  |
+| CAP-FORK-005 | TUI | Fork dispatch and post-create pipeline | verified | 2026-06-11 | evidence/fork/ev-CAP-FORK-TUI-help.txt | TUI fork dispatch surfaces present: `f/F Fork session`, `F -> w Fork session into worktree`. TUI renders home list and f |
+| CAP-FORK-005 | WEB | Fork dispatch and post-create pipeline | pending |  |  |  |
+| CAP-FORK-006 | CLI | Fork-with-state worktree (git, #1029/#1263) | partial | 2026-06-11 | evidence/fork/ev-CAP-FORK-006-CLI-nostate-now.txt | --with-state / --with-state-and-gitignored flags present and documented (implies/requires -w). On a shell session the to |
+| CAP-FORK-006 | TUI | Fork-with-state worktree (git, #1029/#1263) | pending |  |  |  |
+| CAP-FORK-007 | CLI | Fork-with-state workspace (jujutsu, #1305) | untestable-locally | 2026-06-11 | evidence/fork/ev-CAP-FORK-010-nonrepo.txt | jujutsu (jj) is NOT installed on this host (command -v jj = NO). The jj fork-with-state workspace path (WorkingCopyParen |
+| CAP-FORK-007 | TUI | Fork-with-state workspace (jujutsu, #1305) | pending |  |  |  |
+| CAP-FORK-008 | CLI | Plain worktree creation, path generation, branch resolution | verified | 2026-06-11 | evidence/fork/ev-CAP-FORK-008-DB.txt | Plain worktree creation fully verified via `add -w`: NEW branch with -b creates branch+worktree at <repo>/.worktrees/<sa |
+| CAP-FORK-008 | TUI | Plain worktree creation, path generation, branch resolution | pending |  |  |  |
+| CAP-FORK-009 | CLI | Worktree removal, session-dismiss cleanup, #1200 data-loss g | partial | 2026-06-11 | evidence/fork/ev-CAP-FORK-009-CLI-finish.txt | Worktree removal/cleanup verified: top-level `remove` cleans up the worktree dir while keeping the main repo intact (#12 |
+| CAP-FORK-009 | TUI | Worktree removal, session-dismiss cleanup, #1200 data-loss g | pending |  |  |  |
+| CAP-FORK-010 | CLI | VCS backend abstraction and detection (git/jujutsu) | partial | 2026-06-11 | evidence/fork/ev-CAP-FORK-010-git.txt | git backend detection verified: `worktree list --json` resolves repo_root, marks main vs worktree types, routes worktree |
+| CAP-FORK-010 | TUI | VCS backend abstraction and detection (git/jujutsu) | pending |  |  |  |
+| CAP-FORK-011 | DAEMON/INTERNAL | Child environment construction (telegram/CLAUDE_CONFIG_DIR i | pending |  |  |  |
+| CAP-FORK-012 | CLI | Parent-child session links (sub-sessions) | verified | 2026-06-11 | evidence/fork/ev-CAP-FORK-012-DB.txt | Parent-child links fully verified: `add --parent` sets parent_session_id (persisted in state.db); single-level guard rej |
+| CAP-FORK-012 | TUI | Parent-child session links (sub-sessions) | pending |  |  |  |
+| CAP-FORK-013 | TUI | Multi-repo worktree creation and fork propagation | untestable-locally | 2026-06-11 | evidence/fork/ev-CAP-FORK-009-cleanup.txt | Multi-repo worktree creation and fork propagation is TUI-driven (the 'p' Edit multi-repo paths keybind / fork of a multi |
+| CAP-FORK-014 | CLI | Spawn singleflight guard (#1040 restart storm) | verified | 2026-06-11 | evidence/fork/ev-CAP-FORK-014-storm.txt | Spawn singleflight guard (#1040) verified: `session start` creates locks/instance-spawn-<id>.stamp under the data locks  |
+| CAP-FORK-011 | internal-daemon |  | verified | 2026-06-11 | evidence/fork/ev-CAP-FORK-011-env.txt | Child env isolation verified by inspecting the spawned tmux session env: parent shell exported TELEGRAM_BOT_TOKEN/TELEGR |
+
+## CAP-TMUX (21 caps, 45 rows) — partial:6, pending:14, untestable-locally:4, verified:21
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-TMUX-001 | CLI | Session naming and identity | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-001-CLI.txt | add -t 'My Cool!Sess@01' produced tmux_session 'agentdeck_My-Cool-Sess-01_<8hex>'. Prefix 'agentdeck_', sanitizeName rep |
+| CAP-TMUX-001 | TUI | Session naming and identity | pending |  |  |  |
+| CAP-TMUX-001 | WEB | Session naming and identity | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-004-WEB.txt | /api/sessions returns tmuxSession 'agentdeck_logtest_<hex>' and 'agentdeck_My-Cool-Sess-01_<hex>' — same prefix+sanitize |
+| CAP-TMUX-002 | CLI | Session creation (Start) with 3-tier systemd launch fallback | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-002-CLI.txt,evidence/tmux/ev-CAP-TMUX-002b-CLI.txt | session start created tmux session (direct launch, no systemd needed in sandbox). show-options confirms the batched set- |
+| CAP-TMUX-002 | TUI | Session creation (Start) with 3-tier systemd launch fallback | pending |  |  |  |
+| CAP-TMUX-003 | CLI | Socket isolation (-L plumbing) | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-003-CLI.txt,evidence/tmux/ev-CAP-TMUX-003-isolation.txt | All sessions live ONLY on isolated socket 'advfixed' (adtmux -L). Zero agentdeck test sessions on the default server (pr |
+| CAP-TMUX-003 | TUI | Socket isolation (-L plumbing) | pending |  |  |  |
+| CAP-TMUX-003 | WEB | Socket isolation (-L plumbing) | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-004-WEB.txt | tmuxSocketName:'advfixed' present per session in /api/sessions — socket isolation plumbed through to web API. |
+| CAP-TMUX-004 | CLI | Existence/liveness probing and per-tick caches | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-004-status.txt,evidence/tmux/ev-CAP-TMUX-010-CLI.txt | Liveness reflected in list/status: running session shows idle, stopped shows stopped, 'status' aggregates '0 waiting • 0 |
+| CAP-TMUX-004 | TUI | Existence/liveness probing and per-tick caches | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-004-TUI.txt | TUI list shows live status markers (○ idle, ■ stopped) per session, refreshed per tick; preview pane shows live capture. |
+| CAP-TMUX-004 | WEB | Existence/liveness probing and per-tick caches | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-004-WEB.png | Web UI Fleet view renders per-session status (idle/stopped) and group counts. |
+| CAP-TMUX-005 | CLI | Send-keys / prompt delivery semantics | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-005-CLI.txt,evidence/tmux/ev-CAP-TMUX-005-large.txt | session send delivered 'echo HELLO_FROM_SEND_12345' which executed (output captured). SendKeysAndEnter path: 100ms paste |
+| CAP-TMUX-005 | TUI | Send-keys / prompt delivery semantics | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-008-confirm.txt | In TUI attach mode, typed keystrokes ('echo ATTACHED_PANE_OK_777') forwarded to the pane and executed — SendNamedKey/ins |
+| CAP-TMUX-005 | WEB | Send-keys / prompt delivery semantics | pending |  |  |  |
+| CAP-TMUX-006 | CLI | Output capture | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-006-CLI.txt,evidence/tmux/ev-CAP-TMUX-006-parity.txt | session output returns visible pane content (CapturePane). Parity with raw adtmux capture-pane confirmed (both reflect s |
+| CAP-TMUX-006 | TUI | Output capture | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-004-TUI.txt | TUI preview pane streams live captured Output (sudo banner + prompt) for the selected session. |
+| CAP-TMUX-006 | WEB | Output capture | pending |  |  |  |
+| CAP-TMUX-007 | TUI | Control-mode pipe layer (ControlPipe + PipeManager) | pending |  |  |  |
+| CAP-TMUX-007 | WEB | Control-mode pipe layer (ControlPipe + PipeManager) | pending |  |  |  |
+| CAP-TMUX-008 | CLI | Attach / detach (PTY proxy) | partial | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-008-TUI-attached.txt | session attach exists as a CLI subcommand and the underlying Attach PTY proxy is the same code driven via TUI (verified) |
+| CAP-TMUX-008 | TUI | Attach / detach (PTY proxy) | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-008-TUI-attached.txt,evidence/tmux/ev-CAP-TMUX-008-TUI-typed.txt,evidence/tmux/ev-CAP-TMUX-008-TUI-detached.txt,evidence/tmux/ev-CAP-TMUX-008-confirm.txt | Enter attached to full-screen pane (status-right 'ctrl+q detach │ 📁 logtest \| proj2'); typed command ran; Ctrl+Q (0x11  |
+| CAP-TMUX-009 | TUI | Terminal-reply filtering (internal/termreply) | partial | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-008-TUI-detached.txt | termreply Filter is an internal stdin-filtering layer active during attach quarantine. Indirectly exercised: attach/deta |
+| CAP-TMUX-010 | CLI | Status detection state machine (GetStatus) | partial | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-010-CLI.txt,evidence/tmux/ev-CAP-TMUX-010-show.txt,evidence/tmux/ev-CAP-TMUX-010-transition.txt | Status state machine verified for inactive/idle/stopped/active-on-create transitions via lifecycle (start->idle, stop->s |
+| CAP-TMUX-010 | TUI | Status detection state machine (GetStatus) | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-004-TUI.txt | TUI status bar shows color-coded counts (idle/stopped) and per-session markers; status legend ● ◐ ○ ■ rendered. |
+| CAP-TMUX-010 | WEB | Status detection state machine (GetStatus) | pending |  |  |  |
+| CAP-TMUX-011 | CLI | Tool detection and configurable patterns | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-011-CLI.txt | DetectTool by command basename verified: command '/tmp/.../bin/claude' detected as tool 'claude'; command 'bash' detecte |
+| CAP-TMUX-011 | TUI | Tool detection and configurable patterns | pending |  |  |  |
+| CAP-TMUX-012 | CLI | Kill / respawn / process-tree reaping | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-012-CLI.txt | session restart respawned the session (new 8-hex suffix, tmux still alive). session stop killed the tmux session (has-se |
+| CAP-TMUX-012 | TUI | Kill / respawn / process-tree reaping | verified | 2026-06-11 | evidence/tmux/ev-CAP-TUI-help.txt | TUI help confirms R=Restart session, T=Restart with new session ID, d=Delete session bindings — same Kill/RespawnPane fr |
+| CAP-TMUX-013 | CLI | Per-session tmux environment variables | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-013-CLI.txt | SetEnvironment stamped AGENTDECK_INSTANCE_ID into the tmux session env at Start; show-environment returns 'AGENTDECK_INS |
+| CAP-TMUX-014 | TUI | Status bar, notification bar, quick-switch keys, terminal ti | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-014-CLI.txt,evidence/tmux/ev-CAP-TMUX-014b-CLI.txt,evidence/tmux/ev-CAP-TMUX-008-TUI-attached.txt | ConfigureStatusBar set status-right '#[..]ctrl+q detach#[default] │ 📁 My Cool!Sess@01 \| proj one ', status-left-length  |
+| CAP-TMUX-015 | CLI | iTerm2 badge chrome and mid-attach badge updates | pending |  |  |  |
+| CAP-TMUX-015 | TUI | iTerm2 badge chrome and mid-attach badge updates | untestable-locally | 2026-06-11 | evidence/tmux/ev-CAP-TUI-help.txt | iTerm2 OSC 1337 badge emission is gated on TERM_PROGRAM=iTerm.app / LC_TERMINAL=iTerm2 (macOS). This Linux host is not i |
+| CAP-TMUX-016 | CLI | Session log maintenance | pending |  |  |  |
+| CAP-TMUX-017 | CLI | Terminal emulator detection and capabilities | untestable-locally | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-018-CLI.txt | DetectTerminal/GetTerminalInfo is an internal capability table with no CLI/TUI front door that prints the result. On thi |
+| CAP-TMUX-017 | TUI | Terminal emulator detection and capabilities | pending |  |  |  |
+| CAP-TMUX-018 | CLI | System clipboard copy (internal/clipboard) | pending |  |  |  |
+| CAP-TMUX-018 | TUI | System clipboard copy (internal/clipboard) | partial | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-018-CLI.txt | clipboard.Copy native chain verified available: platform.Detect on Linux selects wl-copy/xclip/xsel; xclip is present on |
+| CAP-TMUX-019 | TUI | Pop-out to native terminal window (internal/terminal) | untestable-locally | 2026-06-11 | evidence/tmux/ev-CAP-TUI-help.txt | Pop-out 'Shift+Enter Open session in new iTerm window (macOS)' confirmed as a TUI binding. OpenSessionInNewWindow darwin |
+| CAP-TMUX-020 | CLI | Waiting/readiness pollers | partial | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-005-CLI.txt,evidence/tmux/ev-CAP-TMUX-002-CLI.txt | WaitForShellPrompt is exercised implicitly: Start waits for shell pane readiness before delivering the command, and sess |
+| CAP-TMUX-021 | CLI | Test/host-safety guards | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-021-CLI.txt | assertTestTmuxIsolation is a no-op for the production (non-go-test) binary: every session start succeeded (exit 0) witho |
+| CAP-TMUX-021 | TUI | Test/host-safety guards | pending |  |  |  |
+| CAP-TMUX-002 | daemon |  | untestable-locally | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-002b-CLI.txt | 3-tier systemd-run launch fallback (service/scope/direct) not exercised: sandbox has no systemd user session, so direct  |
+| CAP-TMUX-007 | daemon |  | verified | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-007-CLI.txt | With web (PipeManager) running, list-clients shows control_mode=1 client on the isolated socket — that is the ControlPip |
+| CAP-TMUX-016 | daemon |  | partial | 2026-06-11 | evidence/tmux/ev-CAP-TMUX-016-CLI.txt | LogDir resolution under XDG data dir confirmed (data/agent-deck tree present). No .log files were created in this build' |
+
+## CAP-STOR (20 caps, 48 rows) — partial:1, pending:28, untestable-locally:2, verified:17
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-STOR-001 | CLI | state.db open/connection model | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-002-CLI.txt | After 'ad add', state.db created under XDG data dir with parent dirs at 0700 (profiles/ and profiles/default/ both 0700, |
+| CAP-STOR-001 | TUI | state.db open/connection model | pending |  |  |  |
+| CAP-STOR-001 | WEB | state.db open/connection model | pending |  |  |  |
+| CAP-STOR-002 | CLI | state.db schema + migrations (SchemaVersion=9) | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-002-CLI.txt | metadata.schema_version=9. All 8 tables present: instances, groups, instance_heartbeats, recent_sessions, cost_events, w |
+| CAP-STOR-002 | TUI | state.db schema + migrations (SchemaVersion=9) | pending |  |  |  |
+| CAP-STOR-002 | WEB | state.db schema + migrations (SchemaVersion=9) | pending |  |  |  |
+| CAP-STOR-003 | CLI | SaveInstances bulk save (the 2026-06-04 wipe site) + S1/S2 g | partial | 2026-06-11 | evidence/stor/ev-CAP-STOR-003-013-CLI.txt | SaveInstances bulk persistence verified: 3 added sessions survive across fresh CLI processes (ad list --json shows alpha |
+| CAP-STOR-003 | TUI | SaveInstances bulk save (the 2026-06-04 wipe site) + S1/S2 g | pending |  |  |  |
+| CAP-STOR-003 | WEB | SaveInstances bulk save (the 2026-06-04 wipe site) + S1/S2 g | pending |  |  |  |
+| CAP-STOR-004 | CLI | Targeted single-column writes (no-clobber primitives) | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-004-CLI.txt | Targeted single-column writes via CLI: 'session set-title-lock on/off' toggles title_locked col only; 'session set-trans |
+| CAP-STOR-004 | TUI | Targeted single-column writes (no-clobber primitives) | pending |  |  |  |
+| CAP-STOR-004 | WEB | Targeted single-column writes (no-clobber primitives) | pending |  |  |  |
+| CAP-STOR-005 | CLI | withBusyRetry concurrency policy | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-005-CLI.txt | 5 parallel concurrent 'ad rm' via xargs -P5 against the same state.db: exactly 5 of 10 instances removed, correct surviv |
+| CAP-STOR-005 | TUI | withBusyRetry concurrency policy | pending |  |  |  |
+| CAP-STOR-005 | WEB | withBusyRetry concurrency policy | pending |  |  |  |
+| CAP-STOR-006 | CLI | Groups persistence | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-006-011-CLI.txt | SaveGroups persistence: 'group create mobile' and 'group create ios --parent mobile' persist path/name/sort_order/max_co |
+| CAP-STOR-006 | TUI | Groups persistence | pending |  |  |  |
+| CAP-STOR-006 | WEB | Groups persistence | pending |  |  |  |
+| CAP-STOR-007 | CLI | tool_data JSON blob model + extras preservation | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-007b-CLI.txt | tool_data JSON blob: 'session set color #ff8800' (color #391), claude-session-id (claude_session_id+claude_detected_at), |
+| CAP-STOR-007 | TUI | tool_data JSON blob model + extras preservation | pending |  |  |  |
+| CAP-STOR-007 | WEB | tool_data JSON blob model + extras preservation | pending |  |  |  |
+| CAP-STOR-008 | CLI | Legacy sessions.json → SQLite migration | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-008-CLI.txt | Dropped a legacy sessions.json (camelCase projectPath/groupPath/sortOrder) in profiles/default/ with no state.db. 'ad li |
+| CAP-STOR-008 | TUI | Legacy sessions.json → SQLite migration | pending |  |  |  |
+| CAP-STOR-008 | WEB | Legacy sessions.json → SQLite migration | pending |  |  |  |
+| CAP-STOR-009 | CLI | Cross-profile session migration primitives (issue #928) | untestable-locally | 2026-06-11 | evidence/stor/ev-CAP-STOR-012-CLI.txt | Cross-profile migrate_xfer primitives (InsertInstanceRow, LoadInstanceByID, profile_migrate.go) are compiled into the bi |
+| CAP-STOR-010 | TUI | Heartbeats, primary election, change detection, metadata | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-010-TUI.txt | Launching the TUI registered a row in instance_heartbeats (pid, started, heartbeat timestamps) — RegisterInstance + Hear |
+| CAP-STOR-011 | CLI | Recent sessions (deleted-session re-create picker) | pending |  |  |  |
+| CAP-STOR-011 | TUI | Recent sessions (deleted-session re-create picker) | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-011-dialog.txt | Drove TUI 'Delete Session?' dialog (cursor on session row) and confirmed with y. recent_sessions table got the row: solo |
+| CAP-STOR-012 | CLI | Watchers + watcher_events store | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-012-CLI.txt | Watchers store via the independent 'ad watcher' DB-writer process: 'watcher create webhook' persists to watchers table ( |
+| CAP-STOR-013 | CLI | Storage layer save/load orchestration + verify-loop race fix | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-013-CLI.txt | Storage orchestration: 'ad rm beta' does a targeted DeleteInstance + SaveGroupsOnly + verify loop, leaving alpha/gamma i |
+| CAP-STOR-013 | TUI | Storage layer save/load orchestration + verify-loop race fix | pending |  |  |  |
+| CAP-STOR-013 | WEB | Storage layer save/load orchestration + verify-loop race fix | pending |  |  |  |
+| CAP-STOR-014 | CLI | Profile resolution (single source of truth, #881) | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-014-CLI.txt | Profile resolution ladder driven end-to-end by which sessions each resolution sees: (1) -p flag (work profile isolates w |
+| CAP-STOR-014 | TUI | Profile resolution (single source of truth, #881) | pending |  |  |  |
+| CAP-STOR-014 | WEB | Profile resolution (single source of truth, #881) | pending |  |  |  |
+| CAP-STOR-015 | CLI | Profile lifecycle + config.json (global pointer file) | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-015-CLI.txt | Profile lifecycle: create/list (sorted)/default/delete. config.json schema {default_profile, version:1} written under XD |
+| CAP-STOR-015 | TUI | Profile lifecycle + config.json (global pointer file) | pending |  |  |  |
+| CAP-STOR-016 | CLI | XDG/HOME path resolution + legacy split (agentpaths) | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-016-CLI.txt | XDG/HOME resolution: absolute XDG_DATA_HOME honored (state.db under $XDG_DATA_HOME/agent-deck/...), no legacy ~/.agent-d |
+| CAP-STOR-016 | TUI | XDG/HOME path resolution + legacy split (agentpaths) | pending |  |  |  |
+| CAP-STOR-016 | WEB | XDG/HOME path resolution + legacy split (agentpaths) | pending |  |  |  |
+| CAP-STOR-017 | CLI | Legacy → XDG layout migration (agentpaths.MigrateLegacyLayou | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-017-CLI.txt | 'migrate-paths': --dry-run reports planned copies (config.toml/config.json/skills->ConfigDir, profiles->DataDir, update- |
+| CAP-STOR-018 | CLI | atomicfile: symlink-preserving atomic/durable writes | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-018-019-CLI.txt | Symlink-preserving atomic write: made config.toml a symlink to a real target, then 'remote add' triggered a config write |
+| CAP-STOR-018 | TUI | atomicfile: symlink-preserving atomic/durable writes | pending |  |  |  |
+| CAP-STOR-018 | WEB | atomicfile: symlink-preserving atomic/durable writes | pending |  |  |  |
+| CAP-STOR-019 | CLI | config.toml model: load cache, save guards (S2/S3), panel me | verified | 2026-06-11 | evidence/stor/ev-CAP-STOR-019-CLI.txt | config.toml model: 'remote add'/'remote remove' do read-modify-write preserving existing [tmux]/[instances] sections and |
+| CAP-STOR-019 | TUI | config.toml model: load cache, save guards (S2/S3), panel me | pending |  |  |  |
+| CAP-STOR-019 | WEB | config.toml model: load cache, save guards (S2/S3), panel me | pending |  |  |  |
+| CAP-STOR-020 | CLI | Test-time data-loss guards (S4/S5) + sandbox infrastructure | untestable-locally | 2026-06-11 | evidence/stor/ev-CAP-STOR-012-CLI.txt | S4 (agentpaths.ensureSafeForTest) and S5 (pathsafety guard_test) error strings ARE compiled into the production binary ( |
+
+## CAP-MCP (15 caps, 32 rows) — broken:1, partial:1, pending:12, untestable-locally:2, verified:16
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-MCP-001 | CLI | MCP catalog definition in config.toml | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-001-CLI-list.txt, ev-CAP-MCP-001-config.txt | [mcps.<name>] catalog loads from XDG config.toml; mcp list shows transport tags [S]/[H]/[E], sorted names, has_server_co |
+| CAP-MCP-001 | TUI | MCP catalog definition in config.toml | pending |  |  |  |
+| CAP-MCP-001 | WEB | MCP catalog definition in config.toml | pending |  |  |  |
+| CAP-MCP-002 | CLI | CLI: agent-deck mcp list / attached / attach / detach | untestable-locally | 2026-06-11 | evidence/mcp/ev-CAP-MCP-006-user-scope.txt | --restart sub-behavior (inst.Restart + 2s sleep + SendKeysAndEnter 'continue') requires a real claude/gemini agent proce |
+| CAP-MCP-003 | CLI | CLI: agent-deck mcp server start/stop/status (HTTP MCP serve | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-003-CLI-server.txt, ev-CAP-MCP-010-CLI-httpstart.txt | server status lists all HTTP/SSE catalog MCPs with status + SERVER CONFIG column; fresh CLI shows pool_not_initialized.  |
+| CAP-MCP-003 | TUI | CLI: agent-deck mcp server start/stop/status (HTTP MCP serve | pending |  |  |  |
+| CAP-MCP-004 | CLI | Attached-state reads (MCPInfo) + caching | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-004-CLI-parentwalk.txt | Parent-dir walk confirmed: deepchild session at projA/sub/deep (no .mcp.json there) reports LOCAL context7+ssemcp = exac |
+| CAP-MCP-004 | TUI | Attached-state reads (MCPInfo) + caching | pending |  |  |  |
+| CAP-MCP-004 | WEB | Attached-state reads (MCPInfo) + caching | pending |  |  |  |
+| CAP-MCP-005 | CLI | LOCAL scope write: .mcp.json generation with merge-preserve  | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-002-CLI-attach.txt, ev-CAP-MCP-002-scope-lie.txt | .mcp.json written mode 0644 (the documented secret-exposure flaw, env EXA_API_KEY in plaintext). stdio entry {type:stdio |
+| CAP-MCP-005 | TUI | LOCAL scope write: .mcp.json generation with merge-preserve  | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-013-TUI-applied.txt, ev-CAP-MCP-009-live-dialog.txt | TUI Apply (LOCAL scope) writes .mcp.json via WriteMCPJsonFromConfig with merge-preserve; pool-live Apply emits agent-dec |
+| CAP-MCP-005 | WEB | LOCAL scope write: .mcp.json generation with merge-preserve  | pending |  |  |  |
+| CAP-MCP-006 | CLI | GLOBAL and USER scope writes (.claude.json) | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-006-CLI-global.txt | GLOBAL: attach --global writes $CLAUDE_CONFIG_DIR/.claude.json (resolved to ~/.claude/.claude.json) mcpServers, mode 060 |
+| CAP-MCP-006 | TUI | GLOBAL and USER scope writes (.claude.json) | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-013-TUI-scope-global.txt, ev-CAP-MCP-013-TUI-mcpdialog.txt | Dialog exposes LOCAL/GLOBAL/USER scopes; GLOBAL 'Writes to: Claude config (profile-specific)', USER tab present (WriteUs |
+| CAP-MCP-006 | WEB | GLOBAL and USER scope writes (.claude.json) | pending |  |  |  |
+| CAP-MCP-007 | TUI | Socket pool: shared stdio MCP processes multiplexed over Uni | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-007-socketpool.txt, ev-CAP-MCP-011-systemd-scope.txt, ev-CAP-MCP-012-TUI-home.txt | Pool creates per-MCP unix socket at <data>/agent-deck/sockets/mcp-exa.sock (mode 0600, dir 0700), per-MCP stderr log at  |
+| CAP-MCP-008 | CLI | agent-deck mcp-proxy <socket> (hidden CLI bridge command) | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-008-CLI-mcpproxy.txt, ev-CAP-MCP-009-live-dialog.txt | Hidden 'agent-deck mcp-proxy <socket>' command: connects to unix socket and copies stdin->socket (server received exact  |
+| CAP-MCP-009 | CLI | Pool resolution during config generation (tryPoolSocket) | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-009-poolresolution.txt | CLI mode (pool==nil): pool enabled + exa pooled, but no live socket discoverable (socket-path drift: pool at <data>/sock |
+| CAP-MCP-009 | TUI | Pool resolution during config generation (tryPoolSocket) | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-009-live-dialog.txt | TUI process (pool live): tryPoolSocket resolves IsRunning -> emits socket entry {command:agent-deck,args:[mcp-proxy,<dat |
+| CAP-MCP-009 | WEB | Pool resolution during config generation (tryPoolSocket) | pending |  |  |  |
+| CAP-MCP-010 | CLI | HTTP MCP server pool (auto-start [mcps.X.server]) | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-010-CLI-httpstart.txt, ev-CAP-MCP-011-systemd-scope.txt | server start autohttp with real python http.server + health_check=/: waitReady polled until healthy, exit 0 'Started HTT |
+| CAP-MCP-010 | TUI | HTTP MCP server pool (auto-start [mcps.X.server]) | pending |  |  |  |
+| CAP-MCP-010 | WEB | HTTP MCP server pool (auto-start [mcps.X.server]) | pending |  |  |  |
+| CAP-MCP-011 | CLI | systemd per-MCP scope isolation (Linux) | pending |  |  |  |
+| CAP-MCP-011 | TUI | systemd per-MCP scope isolation (Linux) | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-011-systemd-scope.txt | systemd-run available; ISOLATION=1 wraps BOTH socket-proxy (cat) and HTTP (python http.server) children in transient sco |
+| CAP-MCP-012 | TUI | Pool lifecycle: TUI init, multi-instance sharing, quit seman | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-012-TUI-home.txt, ev-CAP-MCP-012-TUI-quitdialog.txt | TUI startup eager-starts pool: mcp-exa.sock + exa_socket.log created (context7 excluded). Quit (q) with pool running ->  |
+| CAP-MCP-013 | TUI | TUI MCP Manager dialog ("M" key) | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-013-TUI-mcpdialog.txt, ev-CAP-MCP-013-TUI-scope-global.txt, ev-CAP-MCP-013-TUI-applied.txt | 'm' key opens MCP Manager on a claude session: LOCAL/GLOBAL/USER scopes, Attached/Available two-column lists, [S]/[H]/[E |
+| CAP-MCP-014 | WEB | Web API MCP management | pending |  |  |  |
+| CAP-MCP-015 | CLI | Session-launch and restart MCP integration | verified | 2026-06-11 | evidence/mcp/ev-CAP-MCP-015-CLI-add-mcp.txt | add --mcp exa --mcp context7 -> LOCAL .mcp.json with both entries, exit 0. Unknown --mcp bogus -> exit 1 with available  |
+| CAP-MCP-015 | TUI | Session-launch and restart MCP integration | untestable-locally | 2026-06-11 | evidence/mcp/ev-CAP-MCP-013-TUI-applied.txt | Restart-path MCP regeneration (regenerateMCPConfig swapping stdio<->socket), SkipMCPRegenerate flag, CaptureLoadedMCPs s |
+| CAP-MCP-001 | internal |  | partial | 2026-06-11 | evidence/mcp/ev-CAP-MCP-001-manage-false.txt, ev-CAP-MCP-005-manage-false.txt | DEVIATION: contract says manage_mcp_json=false makes ALL .mcp.json writes silent no-ops, but both CLI 'mcp attach' AND ' |
+| CAP-MCP-014 | web |  | broken | 2026-06-11 | evidence/mcp/ev-CAP-MCP-014-WEB.txt, ev-CAP-MCP-014-WEB-tui.txt | BROKEN: GET /api/mcps, GET/POST/DELETE/PATCH /api/sessions/{id}/mcps all return HTTP 503 {code:NOT_IMPLEMENTED, message: |
+
+## CAP-COND (10 caps, 27 rows) — partial:1, pending:8, untestable-locally:5, verified:13
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-COND-001 | CLI | Conductor entity + meta.json store | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-001-meta.json | conductor setup writes ~/.agent-deck/conductor/<name>/meta.json with full schema (name, agent, profile normalized to 'de |
+| CAP-COND-002 | COND | Conductor setup/teardown lifecycle (CLI orchestration) | pending |  |  |  |
+| CAP-COND-003 | TUI | is_conductor column + session/group relationship | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-003-TUI-home.txt | TUI renders conductor group (3) pinned at top with conductor-gamma/epsilon/delta, and child1 visually nested under paren |
+| CAP-COND-003 | WEB | is_conductor column + session/group relationship | pending |  |  |  |
+| CAP-COND-004 | DAEMON/INTERNAL | Heartbeat daemon (OS-level per-conductor timer) | pending |  |  |  |
+| CAP-COND-005 | DAEMON/INTERNAL | bridge.py legacy channel bridge (Telegram/Slack ↔ conductor  | pending |  |  |  |
+| CAP-COND-006 | DAEMON/INTERNAL | Plugin-based Telegram channel integration (--channels) + pol | pending |  |  |  |
+| CAP-COND-007 | COND | Per-conductor env_file injection and config_dir profile over | pending |  |  |  |
+| CAP-COND-008 | CLI | Child→parent transition notification (transition daemon + no | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-008-drain.txt | notify-daemon --once runs exit 0 (one adaptive poll of all profiles). inbox drain --json <parent>: empty=[]; crafted fin |
+| CAP-COND-009 | COND | Worker-asserted completion ([DONE] sentinel + run-task kerne | pending |  |  |  |
+| CAP-COND-010 | CLI | Conductor instruction/policy template system | pending |  |  |  |
+| CAP-COND-001 | Filesystem |  | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-001-meta.json | meta.json perms 0644 when no env/env_file (alpha), 0600 when env present (beta). IsConductorSetup = meta.json exists. co |
+| CAP-COND-002 | CLI |  | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-002-setup.txt | setup: interactive Telegram/Slack/Discord prompts, saves [conductor] block (enabled=true, heartbeat_interval=15) to conf |
+| CAP-COND-002 | Filesystem |  | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-002-teardown.txt | config.toml [conductor] block persisted with plaintext token after telegram configured. teardown --remove deletes conduc |
+| CAP-COND-003 | internal |  | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-003-statedb.txt | statedb instances table has is_conductor INTEGER NOT NULL DEFAULT 0 (col 14) and parent_session_id TEXT (col 13). Both c |
+| CAP-COND-004 | Filesystem |  | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-004-heartbeat.sh | setup --heartbeat writes heartbeat.sh from template: {NAME}=gamma, {PROFILE}=default, {HEARTBEAT_PREFIX}='[HEARTBEAT]',  |
+| CAP-COND-004 | internal-daemon |  | untestable-locally | 2026-06-11 | evidence/cond/ev-CAP-COND-004-setup.txt | systemctl --user enable failed in sandbox (no user systemd bus): 'failed to enable heartbeat timer: exit status 1' handl |
+| CAP-COND-005 | CLI |  | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-005-setup.txt | bridge.py (2010 lines, embedded conductorBridgePy) written to conductor/bridge.py ONLY when a channel is configured (abs |
+| CAP-COND-005 | internal-daemon |  | untestable-locally | 2026-06-11 | evidence/cond/ev-CAP-COND-005-setup.txt | Live Telegram (aiogram polling) / Slack (socket mode) message routing, queue draining, and hook execution require real b |
+| CAP-COND-006 | CLI |  | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-006-doctor2.txt | session set <claude-session> channels 'plugin:telegram@...' updates+persists (JSON metadata col {"channels":[...]}). Mut |
+| CAP-COND-006 | internal |  | untestable-locally | 2026-06-11 | evidence/cond/ev-CAP-COND-006-doctor2.txt | Per-session scratch CLAUDE_CONFIG_DIR rewrite (enabledPlugins.telegram=true) and TELEGRAM_* env strip happen only on the |
+| CAP-COND-007 | CLI |  | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-007-delta-meta.json | meta.json layer fully verified: setup -env KEY=VALUE (repeatable) and -env-file persist env (map) and env_file (absolute |
+| CAP-COND-007 | internal |  | partial | 2026-06-11 | evidence/cond/ev-CAP-COND-007-injection.txt | Runtime spawn env injection (buildEnvSourceCommand sourcing meta.EnvFile + exporting meta.Env as highest-priority step 6 |
+| CAP-COND-008 | internal-daemon |  | untestable-locally | 2026-06-11 | evidence/cond/ev-CAP-COND-008-notifydaemon.txt | transition-notifier systemd service written with RuntimeMaxSec=86400 recycle, Restart=always, logs to transition-notifie |
+| CAP-COND-009 | CLI |  | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-009-runtask.txt | run-task wrapper: worker printing '===AGENTDECK_DONE=== status=ok summary=all good' -> durable CompletionRecord {status: |
+| CAP-COND-010 | Filesystem |  | verified | 2026-06-11 | evidence/cond/ev-CAP-COND-010-templates.txt | Per-conductor instruction file rendered: alpha CLAUDE.md has {NAME}=alpha, {PROFILE}=default, {AGENT}=Claude Code substi |
+| CAP-COND-010 | internal |  | untestable-locally | 2026-06-11 | evidence/cond/ev-CAP-COND-010-templates.txt | ClearOnCompact runtime behavior (blocking claude auto-compaction and sending /clear via instructions) requires driving t |
+
+## CAP-WATCH (13 caps, 30 rows) — partial:4, pending:6, untestable-locally:2, verified:18
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-WATCH-001 | CLI | Watcher engine event pipeline | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-001-CLI.txt | watcher create webhook/ntfy/slack OK (exit 0); github without secret rejected (exit 1). list --json emits {name,type,sta |
+| CAP-WATCH-001 | TUI | Watcher engine event pipeline | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-001-CLI-webhook-e2e.txt | FULL event pipeline e2e: TUI engine starts in-process (debug.log watcher_engine_started watcher_count:1); webhook adapte |
+| CAP-WATCH-002 | TUI | Watcher source adapters (webhook, github, ntfy, slack, gmail | pending |  |  |  |
+| CAP-WATCH-003 | TUI | Watcher health tracking + health alert bridge | partial | 2026-06-11 | evidence/watch/ev-CAP-WATCH-001-CLI-webhook-e2e.txt | HealthTracker observable: state.json snapshot persisted by writerLoop carries adapter_healthy:true and error_count:0; wa |
+| CAP-WATCH-004 | CLI | Event routing (clients.json router) | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-004-CLI.txt | watcher routes (table) and --json read clients.json correctly: exact email keys and *@domain wildcard keys both shown wi |
+| CAP-WATCH-004 | TUI | Event routing (clients.json router) | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-005-CLI.txt | Router.Match verified via 'watcher test': exact sender match -> 'Match: exact / Routes to conductor: <name> / Group: <gr |
+| CAP-WATCH-005 | TUI | Triage pipeline (unrouted event → Claude classifier session) | partial | 2026-06-11 | evidence/watch/ev-CAP-WATCH-001-CLI-webhook-e2e.txt | Triage entry verified: a real unrouted webhook event persists with routed_to='triage' (confirmed in watcher status recen |
+| CAP-WATCH-006 | CLI | Hook-to-status derivation (sessionstatus.Derive) | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-006-CLI.txt | sessionstatus.Derive output observed via 'ad status' (0 waiting / 0 running / 1 idle) and list --json status field. Bash |
+| CAP-WATCH-006 | TUI | Hook-to-status derivation (sessionstatus.Derive) | pending |  |  |  |
+| CAP-WATCH-006 | WEB | Hook-to-status derivation (sessionstatus.Derive) | pending |  |  |  |
+| CAP-WATCH-007 | CLI | Cost event capture (Claude Stop hook → file drop → fsnotify  | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-007-CLI.txt | agent-deck hook-handler (hidden subcmd) given a Stop payload {hook_event_name,session_id,transcript_path} + AGENTDECK_IN |
+| CAP-WATCH-007 | TUI | Cost event capture (Claude Stop hook → file drop → fsnotify  | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-007-TUI-ingested.txt | Full e2e ingestion: with TUI running, a hook-handler drop file is picked up by CostEventWatcher (fsnotify+100ms debounce |
+| CAP-WATCH-008 | WATCH | Cost parsers + tmux capture poller (multi-tool cost extracti | pending |  |  |  |
+| CAP-WATCH-009 | CLI | Cost store, summaries, remote aggregation | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-009-CLI.txt | costs summary (table: Today/Week/Month/Projected + event counts) and --json (microdollar keys cost_today/week/month/last |
+| CAP-WATCH-009 | TUI | Cost store, summaries, remote aggregation | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-009-TUI-dashboard.txt | Cost Dashboard ($ key) renders Today/Week/Month/Projected, token breakdown (Input/Output/Cache R/W), Top Sessions and Co |
+| CAP-WATCH-009 | WEB | Cost store, summaries, remote aggregation | pending |  |  |  |
+| CAP-WATCH-010 | CLI | Pricing (defaults, cache, overrides, daily fetcher, recomput | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-010-CLI.txt | costs recompute --dry-run and live both exit 0 with 'Would update/Updated/Skipped (unknown model)' summary (idempotent). |
+| CAP-WATCH-010 | TUI | Pricing (defaults, cache, overrides, daily fetcher, recomput | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-007-TUI-ingested.txt | Pricer resolution (hardcoded defaults -> ComputeCost) drives the live TUI cost display: claude-opus-4-7 priced at $0.09  |
+| CAP-WATCH-011 | TUI | Budget limits (warn/stop) | partial | 2026-06-11 | evidence/watch/ev-CAP-WATCH-011-CLI.txt | BudgetConfig [costs.budgets] daily/weekly/monthly (and per-group daily_limit) parses cleanly from config.toml; costs sum |
+| CAP-WATCH-012 | TUI | System stats collection + formatting | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-TUI-home.txt | sysinfo Collector renders the tmux/header status segment: '⚙ 0% │ ⛁ 19.3G/62.5G │ ▪ 1543.6G/1831.7G' (CPU first-sample 0 |
+| CAP-WATCH-012 | WEB | System stats collection + formatting | pending |  |  |  |
+| CAP-WATCH-013 | CLI | Credential keep-warm refresh daemon (creds-refresh) | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-013-CLI.txt | creds-refresh --once full lifecycle: (a) no .credentials.json dir -> error exit 1 (contract: only non-zero on no-config- |
+| CAP-WATCH-002 | CLI |  | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-002-CLI.txt | github adapter create requires secret: via $GITHUB_WEBHOOK_SECRET env OR --secret-file (chmod 600); secret persisted to  |
+| CAP-WATCH-002 | daemon |  | partial | 2026-06-11 | evidence/watch/ev-CAP-WATCH-002-CLI.txt | WebhookAdapter and GitHubAdapter create+persist verified. ntfy/slack create OK. Gmail adapter: per contract v2 notes it  |
+| CAP-WATCH-005 | CLI |  | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-005-CLI.txt | watcher test drives synthetic event through router: unrouted -> 'would go to triage'; routed -> resolves conductor/group |
+| CAP-WATCH-006 | web |  | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-web-endpoints.txt | Web read path (snapshot_hook_refresh, AllowStaleWaiting=true) exercised via GET /api/sessions returning {sessions,groups |
+| CAP-WATCH-008 | none |  | untestable-locally | 2026-06-11 | evidence/watch/ev-CAP-WATCH-007-CLI.txt | Cost parsers (gemini/openai/minimax) + CostPoller tmux capture-pane polling are DEAD CODE at runtime per spec (NewCostPo |
+| CAP-WATCH-009 | web |  | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-009-WEB.txt | GET /api/costs/summary returns {today_usd,week_usd,month_usd,projected_usd,*_events} 200; /api/costs/daily -> [] 200; /a |
+| CAP-WATCH-012 | web |  | verified | 2026-06-11 | evidence/watch/ev-CAP-WATCH-012-WEB.txt | GET /api/system/stats -> 200 with cpu{usage_percent}, disk{total/used bytes+human, usage_percent}, load{load1/5/15 from  |
+| CAP-WATCH-013 | daemon |  | untestable-locally | 2026-06-11 | evidence/watch/ev-CAP-WATCH-013-CLI.txt | Daemon loop (Run() immediate tick + every 25m interval, systemd --user unit) and the real lock-dir contention against li |
+
+## CAP-MISC (19 caps, 34 rows) — partial:3, pending:14, untestable-locally:6, verified:11
+
+| CAP-ID | Surface | Capability | Status | Verified | Evidence | Notes |
+|---|---|---|---|---|---|---|
+| CAP-MISC-001 | CLI | Docker container lifecycle (sandbox sessions) | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-001-CLI.txt | Drove real Docker against running daemon (29.3.0). add --sandbox + session start created container agent-deck-<title>-<i |
+| CAP-MISC-001 | TUI | Docker container lifecycle (sandbox sessions) | pending |  |  |  |
+| CAP-MISC-002 | CLI | Sandbox container config builder + mount security blocklists | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-002-CLI.txt | docker inspect of the real sandbox container confirmed the full security contract: ReadonlyRootfs=true, CapDrop=[ALL], S |
+| CAP-MISC-002 | TUI | Sandbox container config builder + mount security blocklists | pending |  |  |  |
+| CAP-MISC-003 | DAEMON/INTERNAL | Agent-config sandbox sync (host credentials/config → contain | pending |  |  |  |
+| CAP-MISC-004 | CLI | Docker availability detection | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-004-CLI.txt | With docker removed from PATH, session start of a sandbox session failed with the exact sentinel 'docker CLI is not inst |
+| CAP-MISC-004 | TUI | Docker availability detection | pending |  |  |  |
+| CAP-MISC-005 | CLI | Self-update: version check, cache, nudge | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-005-CLI.txt | update --check hit GitHub, computed latest=1.9.54 vs current 1.9.56-verify -> 'running the latest version' (CompareVersi |
+| CAP-MISC-005 | TUI | Self-update: version check, cache, nudge | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-005-TUI-settings.txt | TUI home banner shows v1.9.56-verify (annotation slot); no nudge bar since current>=latest (ShouldNudge false). Settings |
+| CAP-MISC-006 | CLI | Self-update: verified download + binary install + remote dep | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-006-CLI.txt | update --version 1.9.54 (run on a sandbox COPY of the binary, not the shared $AD_BIN): fetched release v1.9.54, correctl |
+| CAP-MISC-007 | CLI | install.sh (curl\|bash installer) | untestable-locally | 2026-06-11 | evidence/misc/ev-CAP-MISC-007-note.txt | install.sh is a curl\|bash bootstrap with no front door in the shipped binary. Running it would mutate the real system ( |
+| CAP-MISC-008 | CLI | Makefile build/test/release pipeline | pending |  |  |  |
+| CAP-MISC-009 | CLI | OpenClaw gateway client (WebSocket JSON-RPC) | partial | 2026-06-11 | evidence/misc/ev-CAP-MISC-009-CLI.txt | OpenClaw client drives a real WebSocket dial to the default loopback gateway ws://127.0.0.1:31337. status -> 'Gateway: O |
+| CAP-MISC-009 | TUI | OpenClaw gateway client (WebSocket JSON-RPC) | pending |  |  |  |
+| CAP-MISC-010 | CLI | OpenClaw bridge TUI + agent session sync | pending |  |  |  |
+| CAP-MISC-010 | TUI | OpenClaw bridge TUI + agent session sync | partial | 2026-06-11 | evidence/misc/ev-CAP-MISC-010-TUI.txt | openclaw bridge --agent testagent launched the full bubbletea chat TUI in tmux: header 'openclaw > testagent', [DISCONNE |
+| CAP-MISC-011 | CLI | Feedback prompt pacing + state | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-011-CLI.txt | agent-deck feedback drives the rating prompt (1-5, n=never-again, q=quit) with input validation. --help documents the pa |
+| CAP-MISC-011 | TUI | Feedback prompt pacing + state | pending |  |  |  |
+| CAP-MISC-012 | CLI | Feedback sender (three-tier submission) | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-012-CLI.txt | Feedback sender front door: rating 5 -> comment -> disclosure block showing public URL discussions/600, gh-CLI submissio |
+| CAP-MISC-012 | TUI | Feedback sender (three-tier submission) | pending |  |  |  |
+| CAP-MISC-013 | CLI | Structured logging system | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-013-CLI.txt | agent-deck debug-dump wrote <XDG cache>/agent-deck/debug-dump-<unix>.jsonl and reported the path ('Share this file when  |
+| CAP-MISC-014 | TUI | safego panic-recovering goroutines | pending |  |  |  |
+| CAP-MISC-015 | MISC | Platform detection + headless + fsnotify support check | pending |  |  |  |
+| CAP-MISC-016 | CLI | Experiments / `agent-deck try` (quick experiment folders) | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-016-CLI.txt | agent-deck try fully verified: try --list (empty -> message); try redis-cache --no-session created 2026-06-11-redis-cach |
+| CAP-MISC-017 | DAEMON/INTERNAL | Test infrastructure: testutil isolation + perf + seams | pending |  |  |  |
+| CAP-MISC-018 | DAEMON/INTERNAL | Integration test suite (real tmux) | pending |  |  |  |
+| CAP-MISC-019 | DAEMON/INTERNAL | Release regression manifest + release-pinning tests | pending |  |  |  |
+| CAP-MISC-003 | daemon/session |  | verified | 2026-06-11 | evidence/misc/ev-CAP-MISC-003-CLI.txt | On sandbox session start, RefreshAgentConfigs ran: created ~/.claude/sandbox (0700 shared dir), copied top-level host fi |
+| CAP-MISC-008 | developer-CLI |  | untestable-locally | 2026-06-11 | evidence/misc/ev-CAP-MISC-008-note.txt | Makefile build/test/release pipeline is a developer/CI surface (make build/css/test/release-local), not a runtime featur |
+| CAP-MISC-014 | internal |  | untestable-locally | 2026-06-11 | evidence/misc/ev-CAP-MISC-014-note.txt | safego.Go is an internal panic-recovery library with no CLI/TUI/web front door. Its effect (a background goroutine panic |
+| CAP-MISC-015 | internal |  | partial | 2026-06-11 | evidence/misc/ev-CAP-MISC-015-CLI.txt | platform.Detect/IsHeadless/SupportsUnixSockets/CheckFsnotifySupport is an internal library consumed by clipboard choice, |
+| CAP-MISC-017 | test-only |  | untestable-locally | 2026-06-11 | evidence/misc/ev-CAP-MISC-017-note.txt | testutil isolation/perf/seams (IsolateHome, IsolateTmuxSocket, testmain_audit, perfbudget, fakeclock/fakeinotify/logasse |
+| CAP-MISC-018 | test-only |  | untestable-locally | 2026-06-11 | evidence/misc/ev-CAP-MISC-018-note.txt | internal/integration real-tmux suite is test-only (go test ./internal/integration). No source tree available in this env |
+| CAP-MISC-019 | test-only |  | untestable-locally | 2026-06-11 | evidence/misc/ev-CAP-MISC-019-note.txt | internal/releasetests regression manifest + release-pinning tests (manifest_test, issue1146_lefthook, issue1206_install_ |
+

--- a/docs/verification/README.md
+++ b/docs/verification/README.md
@@ -1,0 +1,44 @@
+# Capability Verification
+
+This directory holds the **user-level capability verification** artifacts for agent-deck:
+the checklist that tracks whether each capability in the
+[v2 Capability Spec](../../) (229 stable `CAP-<AREA>-NNN` IDs) has been verified
+**as a user would experience it** — by driving the real binary on each surface it
+supports and capturing visual evidence — not merely by unit tests.
+
+## Files
+
+- **`CAPABILITY-CHECKLIST.md`** — human-readable matrix: capability × surface, with
+  status (`verified` / `broken` / `partial` / `untestable-locally` / `deferred` /
+  `pending`), the date it was user-verified, and a link to the evidence.
+- **`CAPABILITY-CHECKLIST.json`** — the same matrix, machine-trackable, so the next
+  verification run can resume exactly where the last left off.
+
+## Verification philosophy
+
+A passing `go test` proves a *function* works. It does not prove the *product* works
+for a user. This checklist owns the second claim. A row is only marked `verified` when
+the binary was actually **driven** — real CLI commands, real TUI keystrokes, real web
+clicks — and the resulting behavior was **visually evidenced**:
+
+| Surface | How it's driven as a user | Evidence form |
+|---|---|---|
+| **CLI** | real subcommand in a sandbox; assert output shape, `--json` keys, exit codes, persistence side-effects | command transcript (`.txt`) |
+| **TUI** | the real binary run in a tmux pane, driven with `send-keys`, captured with `capture-pane` | terminal snapshot (`.txt`) |
+| **WEB** | headless `agent-deck web --no-tui` (or the in-memory fixture) driven via browser + REST | screenshot (`.png`) + REST JSON |
+| **daemon / remote / LLM** | no safe local user path → `untestable-locally` with a stated reason | — |
+
+## Safety
+
+Every verification run executes in a **fully sandboxed environment** — throwaway
+`HOME`, sandboxed `XDG_*`, and an isolated `tmux -L <socket>` server inside a sandboxed
+`TMUX_TMPDIR` — so it can never touch a real `~/.agent-deck`, the real `$HOME`, or the
+user's tmux server. Sessions under test use a `bash` stub tool; no real LLM is ever
+invoked. The repeatable method (bootstrap script + per-surface recipes + orchestration)
+is packaged as the `capability-verification` skill.
+
+## Re-running
+
+Regenerate the skeleton from the spec and fold in new wave results with the skill's
+scripts (`gen_checklist.py`, `merge_results.py`). The checklist is append-and-update:
+`pending` / `deferred` rows are what the next run picks up.


### PR DESCRIPTION
## What

Adds **user-level capability verification** for the 229-capability v2 spec (`CAP-<AREA>-NNN`) and the results of the first full run.

- `docs/verification/CAPABILITY-CHECKLIST.md` / `.json` — a capability × surface matrix tracking, for each capability, whether it has been verified **as a user would experience it** (the real binary driven on each surface with visual evidence captured), kept distinct from unit-test coverage.
- `docs/verification/README.md` — verification philosophy, per-surface method, and sandbox safety.

The repeatable method (sandbox bootstrap + per-surface recipes + wave orchestration) is packaged as the `capability-verification` pool skill.

## How it was run

Every verdict was produced by **driving the real `v1.9.56` binary** (built from `main`) in a fully sandboxed environment — throwaway `HOME`, sandboxed `XDG_*`, and an isolated `tmux -L <socket>` server inside a sandboxed `TMUX_TMPDIR`, so it could never touch a real `~/.agent-deck` or the user's tmux server. Sessions under test used a `bash` stub tool; no real LLM was ever invoked. Verification was fanned out across 13 wave agents (one per area chunk), each in its own sandbox.

Evidence per surface: **CLI** = command transcripts + exit codes; **TUI** = real `tmux capture-pane` snapshots after keystrokes; **WEB** = headless `agent-deck web --no-tui` + REST assertions + browser screenshots.

## Results — first full run

**229/229 capabilities exercised** (per-capability best status):

| | count |
|---|---|
| ✅ verified | 179 |
| 🟡 partial | 34 |
| ⚪ untestable-locally | 15 |
| 🔴 broken | 1 |

(Per cap×surface row: 215 verified · 43 partial · 29 untestable-locally · 1 broken · 115 pending secondary surfaces for the next run.)

`untestable-locally` = requires a real LLM (`claude -p`), live daemon (systemd/launchd), remote SSH, channel tokens (Telegram/Slack), or is macOS-only (iTerm) — each marked with a reason, never a fabricated verdict.

## Genuine product issues found (independently reproduced)

1. **Headless `web --no-tui` cannot mutate existing state.** `DELETE /api/sessions/{id}` → 500 `session not found`; `POST /api/groups` → 500 from the empty-`SaveInstances` data-loss guard. Reads work; the WebMutator wraps an empty in-memory instance list in headless mode. The documented server-deployment mode is read-only in practice.
2. **`worktree finish` on the last remaining session orphans the row.** It merges the branch, removes the worktree, and deletes the branch, then fails persistence with `refusing to wipe populated instances table with an empty SaveInstances payload` (exit 1) — leaving a session row pointing to a now-deleted worktree.
3. **Web MCP API is unimplemented in production** (`/api/mcps*` → 503 `NOT_IMPLEMENTED`; `SetMCPManager` is never wired). The web UI itself says "use TUI (m key)".
4. Minor: `GET /api/sessions/{id}` 404s (the singular route is `/api/session/{id}`); a couple of CLI arg-ordering papercuts.

Issues 1–2 share the documented `SaveInstances`-sweep / empty-payload root cause.

## Notes
- No merge intended — review artifact. The checklist is append-and-update: `pending`/`deferred` rows are what the next run resumes.

Committed by Ashesh Goplani