### PR TITLE
fix(git): stop worktreeinclude walk from recursing into nested worktrees

### DIFF
--- a/internal/git/worktreeinclude.go
+++ b/internal/git/worktreeinclude.go
@@ -96,8 +96,19 @@ func findCandidates(repoDir string, matcher *ignore.GitIgnore) ([]string, error)
 		if rel == "." {
 			return nil
 		}
-		if info.IsDir() && rel == ".git" {
-			return filepath.SkipDir
+		if info.IsDir() {
+			if rel == ".git" {
+				return filepath.SkipDir
+			}
+			// Don't descend into nested worktrees or submodules — each has its
+			// own .git entry. Otherwise the walk recurses into agent-deck's own
+			// worktree output dir (e.g. .worktrees/) and copies an ever-growing
+			// nested forest of every other worktree's files into the new one.
+			if path != repoDir {
+				if _, statErr := os.Stat(filepath.Join(path, ".git")); statErr == nil {
+					return filepath.SkipDir
+				}
+			}
 		}
 		if matcher.MatchesPath(rel) {
 			candidates = append(candidates, rel)

--- a/internal/git/worktreeinclude_test.go
+++ b/internal/git/worktreeinclude_test.go
@@ -290,6 +290,52 @@ func TestProcessWorktreeInclude_MissingSourceSkipped(t *testing.T) {
 	}
 }
 
+// Regression: the include walk must not descend into nested worktrees living
+// under the repo (e.g. agent-deck's own .worktrees/ output). Otherwise it finds
+// every other worktree's gitignored .env, recreates the full nested path, and
+// the .worktrees forest grows one level deeper on every spawn — eventually
+// gigabytes of duplicated skeletons that make each new spawn crawl.
+func TestProcessWorktreeInclude_DoesNotDescendIntoNestedWorktrees(t *testing.T) {
+	repoDir := t.TempDir()
+	initGitRepo(t, repoDir)
+
+	writeFile(t, filepath.Join(repoDir, ".gitignore"), ".env\n.worktrees/\n")
+	gitAdd(t, repoDir, ".gitignore")
+
+	writeFile(t, filepath.Join(repoDir, ".env"), "ROOT")
+	writeFile(t, filepath.Join(repoDir, ".worktreeinclude"), ".env\n")
+	gitAdd(t, repoDir, ".worktreeinclude")
+	gitCommit(t, repoDir, "setup")
+
+	// A real linked worktree under .worktrees/ — it has its own .git pointer
+	// file, marking a worktree boundary the walk must stop at.
+	nested := filepath.Join(repoDir, ".worktrees", "other")
+	cmd := exec.Command("git", "worktree", "add", "-b", "other", nested)
+	cmd.Dir = repoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v\n%s", err, out)
+	}
+	writeFile(t, filepath.Join(nested, ".env"), "NESTED")
+
+	worktreeDir := t.TempDir()
+
+	var stderr bytes.Buffer
+	if err := ProcessWorktreeInclude(repoDir, worktreeDir, &stderr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The repo's own .env is copied.
+	got, err := os.ReadFile(filepath.Join(worktreeDir, ".env"))
+	if err != nil || string(got) != "ROOT" {
+		t.Fatalf("expected root .env to be copied, got %q (err=%v)", got, err)
+	}
+
+	// The nested worktree's .env must NOT be reconstructed under the new worktree.
+	if _, err := os.Stat(filepath.Join(worktreeDir, ".worktrees")); !os.IsNotExist(err) {
+		t.Errorf(".worktrees forest was copied into the new worktree (err=%v)", err)
+	}
+}
+
 func TestProcessWorktreeInclude_NoFileIsNoop(t *testing.T) {
 	repoDir := t.TempDir()
 	initGitRepo(t, repoDir)


### PR DESCRIPTION
## Problem

`ProcessWorktreeInclude` walks the **entire** repo to find gitignored files matching `.worktreeinclude`, skipping only `.git` (`findCandidates` in `internal/git/worktreeinclude.go`). When the repo's own worktree output directory lives inside the repo (e.g. `.worktrees/`, the default for worktree-based sessions), the walk descends into **every sibling worktree**, matches each one's gitignored file (e.g. `.env`), and recreates its full nested path under the new worktree via `os.MkdirAll(filepath.Dir(dst))`.

Two consequences, both compounding on every spawn:

1. **Combinatorial disk blowup.** Each new worktree gets a skeleton of *every other* worktree, so the repo's `.worktrees/` gains one more level of nesting per spawn: `.worktrees/A/.worktrees/B/.worktrees/C/…`. In a repo with ~20 worktrees this reached **multiple GB** of duplicated empty directory trees and copied `.env` files (observed 3.3 GB under a *single* worktree, nesting ≥4 levels deep).
2. **Slow worktree creation.** `findCandidates` runs a `filepath.Walk` over that exploding tree on *every* worktree creation, before copying anything — so each new session got progressively slower as the forest grew.

Plain `git worktree add` never exhibits this: it checks out only tracked files and copies nothing gitignored, so it never descends into sibling worktrees. The recursion is purely in the include-copy layer.

## Fix

Stop the walk at worktree/submodule boundaries: skip any directory (other than the repo root) that has its own `.git` entry. Linked worktrees and submodules each carry a `.git` file/dir — exactly the boundaries git itself refuses to descend into. The walk now copies the repo's own top-level gitignored files and nothing from sibling worktrees.

```go
if info.IsDir() {
    if rel == ".git" {
        return filepath.SkipDir
    }
    // Don't descend into nested worktrees or submodules — each has its
    // own .git entry. Otherwise the walk recurses into the worktree
    // output dir (e.g. .worktrees/) and copies an ever-growing nested
    // forest of every other worktree's files into the new one.
    if path != repoDir {
        if _, statErr := os.Stat(filepath.Join(path, ".git")); statErr == nil {
            return filepath.SkipDir
        }
    }
}
```

## Test

Adds `TestProcessWorktreeInclude_DoesNotDescendIntoNestedWorktrees`: creates a real linked worktree under `.worktrees/` with its own `.env`, runs the include, and asserts (a) the repo's own `.env` *is* copied and (b) the new worktree does **not** reconstruct a `.worktrees/` forest. Verified failing before the fix (`.worktrees forest was copied into the new worktree`) and passing after.

## Verification

- `go build ./...` — clean
- `go test -race ./internal/git/` — all worktree-include tests pass (incl. the new regression)
- `gofmt`, `go vet`, `golangci-lint run ./internal/git/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed worktree include processing to correctly stop at nested worktree and submodule boundaries, preventing unintended file traversal into nested repositories.

* **Tests**
  * Added regression test to ensure nested worktrees are properly excluded during file processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->