### PR TITLE
feat(tui): present Maestro as the fleet supervisor

### DIFF
--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -111,10 +111,15 @@ func actionablePriority(s Status) int {
 // pinZone maps a session to its outermost sort band (pin-sessions feature).
 // Lower bands surface higher in the group's list.
 //
+//	-1 maestro      the fleet supervisor — a fixed point of reference that
+//	                surfaces above everything, including pin-top
 //	0  pin-top      fixed at the top, exempt from status/recency
 //	1  normal       the existing actionable sort (status → recency → Order)
 //	2  pin-bottom   fixed at the bottom, exempt from status/recency
 func pinZone(inst *Instance) int {
+	if inst.IsMaestro() {
+		return -1
+	}
 	switch inst.Pin {
 	case PinTop:
 		return 0
@@ -138,11 +143,11 @@ func stablePinPartition(insts []*Instance) {
 		if zi != zj {
 			return zi < zj
 		}
-		// Pin-top (0) and pin-bottom (2) bands are fully fixed by Order, matching
-		// the load-time SortInstancesByActionable. Ordering them here means a
-		// freshly pinned row lands in its correct Order slot live — not wherever
-		// it happened to sit in slice order before the pin edit.
-		if zi == 0 || zi == 2 {
+		// Maestro (-1), pin-top (0), and pin-bottom (2) bands are fully fixed by
+		// Order, matching the load-time SortInstancesByActionable. Ordering them
+		// here means a freshly pinned row lands in its correct Order slot live —
+		// not wherever it happened to sit in slice order before the pin edit.
+		if zi != 1 {
 			return insts[i].Order < insts[j].Order
 		}
 		// Normal (1) band is already actionable-sorted at load; return false so
@@ -169,12 +174,16 @@ func stablePinPartition(insts []*Instance) {
 //     TestSessionOrderMigration)
 func SortInstancesByActionable(insts []*Instance) {
 	sort.SliceStable(insts, func(i, j int) bool {
+		// The outermost key is the band: maestro (the fleet supervisor, a fixed
+		// point of reference that surfaces first regardless of status), then
+		// pin-top, normal, and pin-bottom (see pinZone).
 		zi, zj := pinZone(insts[i]), pinZone(insts[j])
 		if zi != zj {
 			return zi < zj
 		}
-		// Pin-top (0) and pin-bottom (2) bands are fully fixed: Order only.
-		if zi == 0 || zi == 2 {
+		// Maestro (-1), pin-top (0), and pin-bottom (2) bands are fully fixed:
+		// Order only.
+		if zi != 1 {
 			return insts[i].Order < insts[j].Order
 		}
 		// Normal (1) band keeps the actionable tiers.
@@ -323,6 +332,16 @@ func (t *GroupTree) rebuildGroupList() {
 		// Always pin the "conductor" group to the top
 		if g.Path == "conductor" && g.Order >= 0 {
 			g.Order = -1
+		}
+		// The group holding the fleet supervisor (Maestro) pins above
+		// everything, including the legacy "conductor" pin.
+		if g.Order >= -1 {
+			for _, inst := range g.Sessions {
+				if inst.IsMaestro() {
+					g.Order = -2
+					break
+				}
+			}
 		}
 		t.GroupList = append(t.GroupList, g)
 	}

--- a/internal/session/maestro.go
+++ b/internal/session/maestro.go
@@ -1,0 +1,18 @@
+package session
+
+// MaestroSessionTitle is the exact title of the fleet-supervisor session.
+//
+// Maestro is the orchestrator-of-orchestrators: it sits one level above
+// conductors, exactly as conductors sit above child sessions (see
+// conductor/agent-deck/maestro-design.md). Phase-1 identification is by
+// exact title — the same convention conductors used before graduating to
+// the is_conductor column in the v4 schema migration. When the is_maestro
+// column ships (Phase 2), IsMaestro is the single seam to swap.
+const MaestroSessionTitle = "conductor-maestro"
+
+// IsMaestro reports whether this instance is the fleet supervisor.
+// Exact match only: worker sessions titled "maestro-<something>" are
+// regular sessions and must not be detected as the supervisor.
+func (i *Instance) IsMaestro() bool {
+	return i.Title == MaestroSessionTitle
+}

--- a/internal/session/maestro_test.go
+++ b/internal/session/maestro_test.go
@@ -1,0 +1,104 @@
+package session
+
+// Maestro fleet-supervisor presentation (TUI Phase 1).
+//
+// Maestro is the orchestrator-of-orchestrators: it sits one level above
+// conductors (see ~/.agent-deck/conductor/agent-deck/maestro-design.md).
+// Phase-1 identification is by EXACT session title — the same convention
+// conductors used before graduating to the is_conductor column in the v4
+// schema migration. Exact match is load-bearing: regular worker sessions
+// titled "maestro-<something>" must NOT be detected as the supervisor.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsMaestro_ExactTitleOnly(t *testing.T) {
+	cases := []struct {
+		title string
+		want  bool
+	}{
+		{"conductor-maestro", true},
+		{"conductor-agent-deck", false},
+		{"maestro-user-test", false}, // worker session, not the supervisor
+		{"maestro", false},
+		{"", false},
+		{"conductor-maestro-2", false},
+	}
+	for _, c := range cases {
+		inst := &Instance{Title: c.title}
+		if got := inst.IsMaestro(); got != c.want {
+			t.Errorf("IsMaestro() for title %q = %v, want %v", c.title, got, c.want)
+		}
+	}
+}
+
+// The maestro must surface first within its group regardless of status:
+// a stopped supervisor still outranks a running worker, because the row is
+// a fixed point of reference (the fleet supervisor), not an activity item.
+func TestSortInstancesByActionable_MaestroFirst(t *testing.T) {
+	now := time.Now()
+	maestro := &Instance{Title: "conductor-maestro", Status: StatusStopped, LastAccessedAt: now.Add(-24 * time.Hour), Order: 5}
+	worker := &Instance{Title: "busy-worker", Status: StatusRunning, LastAccessedAt: now, Order: 0}
+	conductor := &Instance{Title: "conductor-agent-deck", Status: StatusWaiting, LastAccessedAt: now, Order: 1}
+
+	insts := []*Instance{worker, conductor, maestro}
+	SortInstancesByActionable(insts)
+
+	if insts[0].Title != "conductor-maestro" {
+		t.Fatalf("maestro must sort first within its group; got order: %s, %s, %s",
+			insts[0].Title, insts[1].Title, insts[2].Title)
+	}
+	// Non-maestro relative order must keep issue #857 semantics
+	// (error/waiting before running? no — waiting outranks running).
+	if insts[1].Title != "conductor-agent-deck" || insts[2].Title != "busy-worker" {
+		t.Fatalf("non-maestro rows must keep actionable sort; got: %s, %s",
+			insts[1].Title, insts[2].Title)
+	}
+}
+
+// The group containing the maestro must be pinned to the very top of the
+// group list — above even the legacy "conductor" group pin (Order=-1).
+func TestGroupTree_MaestroGroupPinnedFirst(t *testing.T) {
+	insts := []*Instance{
+		{Title: "some-app", GroupPath: "alpha"},
+		{Title: "conductor-legacy", GroupPath: "conductor"},
+		{Title: "conductor-maestro", GroupPath: "conductors"},
+		{Title: "conductor-agent-deck", GroupPath: "conductors"},
+	}
+	tree := NewGroupTree(insts)
+
+	if len(tree.GroupList) < 3 {
+		t.Fatalf("expected at least 3 groups, got %d", len(tree.GroupList))
+	}
+	if tree.GroupList[0].Path != "conductors" {
+		var order []string
+		for _, g := range tree.GroupList {
+			order = append(order, g.Path)
+		}
+		t.Fatalf("group containing the maestro must be first; got group order: %v", order)
+	}
+	if tree.GroupList[1].Path != "conductor" {
+		t.Fatalf("legacy conductor group must keep its pin right below the maestro group; got %q", tree.GroupList[1].Path)
+	}
+}
+
+// Without a maestro anywhere, group ordering must be unchanged
+// (legacy "conductor" pin still first).
+func TestGroupTree_NoMaestro_LegacyPinUnchanged(t *testing.T) {
+	insts := []*Instance{
+		{Title: "some-app", GroupPath: "alpha"},
+		{Title: "conductor-legacy", GroupPath: "conductor"},
+		{Title: "maestro-user-test", GroupPath: "workers"}, // worker, not supervisor
+	}
+	tree := NewGroupTree(insts)
+
+	if tree.GroupList[0].Path != "conductor" {
+		var order []string
+		for _, g := range tree.GroupList {
+			order = append(order, g.Path)
+		}
+		t.Fatalf("legacy conductor pin regressed; got group order: %v", order)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -13882,6 +13882,14 @@ func (h *Home) renderSessionItem(
 		titleStyle = titleStyle.Foreground(lipgloss.Color(inst.Color))
 	}
 
+	// Maestro (fleet supervisor): gold title by default. An explicit
+	// Instance.Color stays the stronger signal (issue #391 opt-in wins);
+	// the ⬢ glyph and [SUPERVISOR] badge below render unconditionally.
+	isMaestro := inst.IsMaestro()
+	if isMaestro && inst.Color == "" {
+		titleStyle = titleStyle.Foreground(ColorYellow)
+	}
+
 	// Tool badge with brand-specific color
 	// Claude=orange, Gemini=purple, Codex=cyan, Aider=red
 	toolStyle := GetToolStyle(instTool)
@@ -13912,8 +13920,22 @@ func (h *Home) renderSessionItem(
 	if inst.Pin != session.PinNone {
 		displayTitle = "📌 " + displayTitle
 	}
+	// Maestro (fleet supervisor): ⬢ glyph leads the title.
+	if isMaestro {
+		displayTitle = "⬢ " + displayTitle
+	}
 	title := titleStyle.Render(displayTitle)
 	tool := toolStyle.Render(" " + instTool)
+
+	// Supervisor badge for the maestro row.
+	maestroBadge := ""
+	if isMaestro {
+		mStyle := lipgloss.NewStyle().Foreground(ColorYellow).Bold(true)
+		if selected {
+			mStyle = SessionStatusSelStyle
+		}
+		maestroBadge = mStyle.Render(" [SUPERVISOR]")
+	}
 
 	// YOLO badge for Gemini/Codex sessions with YOLO mode enabled
 	yoloBadge := ""
@@ -14026,7 +14048,7 @@ func (h *Home) renderSessionItem(
 
 	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [badges]
 	row := fmt.Sprintf(
-		"%s%s%s%s%s %s%s%s%s%s%s%s%s",
+		"%s%s%s%s%s %s%s%s%s%s%s%s%s%s",
 		baseIndent,
 		selectionPrefix,
 		treeStyle.Render(treeConnector),
@@ -14034,6 +14056,7 @@ func (h *Home) renderSessionItem(
 		status,
 		title,
 		tool,
+		maestroBadge,
 		yoloBadge,
 		worktreeBadge,
 		sandboxBadge,

--- a/internal/ui/maestro_tui_test.go
+++ b/internal/ui/maestro_tui_test.go
@@ -1,0 +1,87 @@
+package ui
+
+// Maestro fleet-supervisor row presentation (Seam A, model-level — see
+// internal/ui/TUI_TESTS.md and issue391_tui_test.go for the seam choice).
+//
+// The maestro session (exact title "conductor-maestro") is THE fleet
+// supervisor: its row must be visually distinct from regular conductor
+// rows — a gold ⬢ glyph before the title, a gold title, and a gold
+// [SUPERVISOR] badge after the tool name. Regular sessions, including
+// workers titled "maestro-*", must render exactly as before.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// goldFgSig is the TrueColor escape payload for ColorYellow in the dark
+// theme (#e0af68 → 224;175;104). Tests force the TrueColor profile via
+// forceTrueColorProfile (issue391_tui_test.go).
+const goldFgSig = "38;2;224;175;104"
+
+func TestMaestro_SessionRow_SupervisorPresentation(t *testing.T) {
+	inst := &session.Instance{
+		ID:    "sess-maestro",
+		Title: "conductor-maestro",
+	}
+
+	row := renderSingleSessionRow(t, inst)
+
+	if !strings.Contains(row, "⬢") {
+		t.Fatalf("maestro row must carry the ⬢ supervisor glyph; got: %q", row)
+	}
+	if !strings.Contains(row, "[SUPERVISOR]") {
+		t.Fatalf("maestro row must carry the [SUPERVISOR] badge; got: %q", row)
+	}
+	if !strings.Contains(row, goldFgSig) {
+		t.Fatalf("maestro row must be tinted gold (ColorYellow %s); got: %q", goldFgSig, row)
+	}
+}
+
+func TestMaestro_RegularConductorRow_NoSupervisorMarker(t *testing.T) {
+	inst := &session.Instance{
+		ID:    "sess-conductor",
+		Title: "conductor-agent-deck",
+	}
+
+	row := renderSingleSessionRow(t, inst)
+
+	if strings.Contains(row, "⬢") || strings.Contains(row, "[SUPERVISOR]") {
+		t.Fatalf("regular conductor row must NOT carry supervisor markers; got: %q", row)
+	}
+}
+
+func TestMaestro_WorkerWithMaestroPrefix_NoSupervisorMarker(t *testing.T) {
+	inst := &session.Instance{
+		ID:    "sess-worker",
+		Title: "maestro-user-test",
+	}
+
+	row := renderSingleSessionRow(t, inst)
+
+	if strings.Contains(row, "⬢") || strings.Contains(row, "[SUPERVISOR]") {
+		t.Fatalf("worker sessions titled maestro-* must NOT carry supervisor markers; got: %q", row)
+	}
+}
+
+// Issue #391 user tint stays the stronger signal: an explicit
+// Instance.Color must override the maestro gold on the title, while the
+// glyph and badge remain.
+func TestMaestro_ExplicitColorOverridesGoldTitle(t *testing.T) {
+	inst := &session.Instance{
+		ID:    "sess-maestro-tinted",
+		Title: "conductor-maestro",
+		Color: "#FF0000",
+	}
+
+	row := renderSingleSessionRow(t, inst)
+
+	if !strings.Contains(row, "38;2;255;0;0") {
+		t.Fatalf("explicit Instance.Color must still tint the maestro title; got: %q", row)
+	}
+	if !strings.Contains(row, "[SUPERVISOR]") {
+		t.Fatalf("badge must survive an explicit color tint; got: %q", row)
+	}
+}


### PR DESCRIPTION
## What

Present the Maestro session — the fleet supervisor (orchestrator-of-orchestrators, see `conductor/agent-deck/maestro-design.md`) — as visually distinct from regular conductor rows in the TUI:

- **Pinned group**: the group containing the maestro is pinned above every other group, one slot above the legacy `conductor` group pin (`Order=-2` vs `-1`), via the existing `rebuildGroupList` idiom.
- **Pinned row**: the maestro always sorts first within its group, ahead of the issue #857 actionable sort (a stopped supervisor still outranks a running worker — the row is a fixed point of reference, not an activity item).
- **Distinct row**: gold `⬢ ` glyph prefix on the title, gold title (theme `ColorYellow`, light/dark aware), and a gold bold `[SUPERVISOR]` badge after the tool name. An explicit `Instance.Color` keeps winning over the gold default (issue #391 opt-in semantics preserved).

```
1·▾ conductors (3)
 ├─ ◐ ⬢ conductor-maestro claude [SUPERVISOR]
 ├─ ● conductor-agent-deck claude
 └─ ◐ conductor-acme claude
```

## How maestro is detected (zero schema)

`Instance.IsMaestro()` — **exact** title match on `conductor-maestro` (`internal/session/maestro.go`). Exact match is load-bearing: live worker sessions titled `maestro-*` exist today and must not be badged. This is deliberately the same Phase-1 convention conductors used before graduating to the `is_conductor` column (schema v4 backfill); when the `is_maestro` column ships (Phase 2 per maestro-design.md decision #1), `IsMaestro()` is the single seam to swap. No migration, no statedb change, no live-data tweak needed — the live session's title already matches.

## Tests (TDD, RED watched before GREEN)

- `internal/session/maestro_test.go`: exact-title detection (incl. `maestro-*` worker negative cases), maestro-first sort, maestro-group pin, legacy `conductor`-pin regression guard.
- `internal/ui/maestro_tui_test.go` (Seam A, per `TUI_TESTS.md`, modeled on the issue #391 tint tests): glyph + badge + gold escape present on the maestro row; absent on regular conductors and on `maestro-*` workers; explicit Color overrides gold.

Verified visually by driving both the pre-change and post-change binaries in a fully sandboxed environment (throwaway HOME/XDG, isolated tmux socket, seeded profile) and capturing the rendered panes; the raw ANSI capture shows the gold `38;2;224;175;104` foreground on the maestro row.

Full `./internal/session` + `./internal/ui` suites pass (sandboxed HOME). Note: `TestGlobalSearchIndex*` / `TestHomeGlobalSearch*` can flake on heavily loaded hosts with `couldn't initialize inotify: too many open files` — reproduced identically on unmodified `origin/main`, environmental and unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fleet Supervisor session type: distinctive gold title color, supervisor glyph, and [SUPERVISOR] badge; explicit color overrides respected.
  * Supervisor sessions are pinned and sorted to the top of session lists and group order for prioritized visibility.

* **Bug Fixes**
  * Fixes to pinning/sorting ensure newly pinned supervisor rows land in the correct band immediately.

* **Tests**
  * Added UI and unit tests covering supervisor identification, presentation, sorting, and group pinning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
