### PR TITLE
fix(ui): show default-group delete block in a modal so it survives the viewport clamp

### DIFF
--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -25,7 +25,7 @@ const (
 	ConfirmBulkRemoveErrored // bulk remove of all errored sessions (TUI Ctrl+X)
 	ConfirmArchiveSession
 	ConfirmUnarchiveSession
-	ConfirmNotice            // acknowledge-only message (single OK button), e.g. protected-action blocks
+	ConfirmNotice // acknowledge-only message (single OK button), e.g. protected-action blocks
 )
 
 // ConfirmDialog handles confirmation for destructive actions

--- a/internal/ui/confirm_dialog.go
+++ b/internal/ui/confirm_dialog.go
@@ -25,6 +25,7 @@ const (
 	ConfirmBulkRemoveErrored // bulk remove of all errored sessions (TUI Ctrl+X)
 	ConfirmArchiveSession
 	ConfirmUnarchiveSession
+	ConfirmNotice            // acknowledge-only message (single OK button), e.g. protected-action blocks
 )
 
 // ConfirmDialog handles confirmation for destructive actions
@@ -40,6 +41,10 @@ type ConfirmDialog struct {
 	worktree    bool // Whether the session has an associated git worktree.
 
 	remoteName string // Remote name for remote session confirmations.
+
+	// Notice (ConfirmNotice) carries an acknowledge-only title/body.
+	noticeTitle string
+	noticeBody  string
 
 	// focusedButton tracks which button has arrow-key focus.
 	// 0 = confirm (left), 1 = cancel (right).
@@ -166,6 +171,22 @@ func (c *ConfirmDialog) ShowDeleteGroup(groupPath, groupName string) {
 	c.focusedButton = 1
 }
 
+// ShowNotice shows an acknowledge-only message in the same centered modal used
+// for confirmations. Unlike a transient bottom-of-screen error banner (which the
+// final viewport clamp can truncate when the panel fills the height), this dialog
+// replaces the whole view while visible, so the message is always seen. Dismissed
+// with Enter/Esc/o.
+func (c *ConfirmDialog) ShowNotice(title, body string) {
+	c.visible = true
+	c.confirmType = ConfirmNotice
+	c.noticeTitle = title
+	c.noticeBody = body
+	c.targetID = ""
+	c.targetName = ""
+	c.buttonCount = 1
+	c.focusedButton = 0
+}
+
 // ShowQuitWithPool shows confirmation for quitting with MCP pool running
 func (c *ConfirmDialog) ShowQuitWithPool(mcpCount int) {
 	c.visible = true
@@ -230,6 +251,8 @@ func (c *ConfirmDialog) Hide() {
 	c.targetName = ""
 	c.sandboxed = false
 	c.remoteName = ""
+	c.noticeTitle = ""
+	c.noticeBody = ""
 }
 
 // IsVisible returns whether the dialog is visible
@@ -444,6 +467,14 @@ func (c *ConfirmDialog) View() string {
 			renderButton("Cancel", ColorRed, c.focusedButton == 1))
 		buttons = lipgloss.JoinVertical(lipgloss.Left, buttonRow,
 			hintStyle.Render("y create · n cancel · ←/→ navigate · Enter select · Esc"))
+
+	case ConfirmNotice:
+		title = c.noticeTitle
+		warning = c.noticeBody
+		borderColor = ColorYellow
+		buttons = lipgloss.JoinVertical(lipgloss.Left,
+			renderButton("OK", ColorAccent, true),
+			hintStyle.Render("Enter / Esc / o dismiss"))
 
 	case ConfirmInstallHooks:
 		title = "Claude Code Hooks"

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7459,11 +7459,16 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			} else if item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil {
 				h.confirmDialog.ShowDeleteRemoteSession(item.RemoteName, item.RemoteSession.ID, item.RemoteSession.Title)
 			} else if item.Type == session.ItemTypeGroup && item.Path == session.DefaultGroupPath {
-				// Protected default group: report instead of silently doing nothing.
-				// Checked before the scoped-root case so the message stays specific
-				// even when the TUI is scoped to the default group
-				// (groupScope == DefaultGroupPath), where both conditions would match.
-				h.setError(fmt.Errorf("cannot delete the default %q group", session.DefaultGroupName))
+				// Protected default group: surface the block in the same centered modal
+				// used for the delete confirmation, so it can't be clamped off the bottom
+				// of the viewport like a transient error banner. Checked before the
+				// scoped-root case so the message stays specific even when the TUI is
+				// scoped to the default group (groupScope == DefaultGroupPath), where both
+				// conditions would match.
+				h.confirmDialog.ShowNotice(
+					"⚠  Can't Delete Group",
+					fmt.Sprintf("%q is the default\ngroup and can't be deleted.\n\nSessions always need a home.", session.DefaultGroupName),
+				)
 			} else if item.Type == session.ItemTypeGroup && item.Path != h.groupScope {
 				h.confirmDialog.ShowDeleteGroup(item.Path, item.Group.Name)
 			} else if item.Type == session.ItemTypeGroup && item.Path == h.groupScope {
@@ -7964,6 +7969,15 @@ func (h *Home) handleConfirmDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			h.confirmDialog.Hide()
 			return h, nil
 		case "n", "N", "esc":
+			h.confirmDialog.Hide()
+			return h, nil
+		}
+		return h, nil
+
+	case ConfirmNotice:
+		// Acknowledge-only: any of the usual dismiss keys closes it.
+		switch msg.String() {
+		case "enter", "esc", "o", "O", "y", "Y", "n", "N", " ":
 			h.confirmDialog.Hide()
 			return h, nil
 		}

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -3638,35 +3638,86 @@ func defaultGroupItem() session.Item {
 	}
 }
 
-// TestDeleteBindingOnDefaultGroupReportsError guards against the silent no-op
-// where pressing the delete binding ('d') on the protected "My Sessions"
-// default group did nothing: no dialog, no message. The handler must surface an
-// explanatory error (mirroring the scoped-root case) and must not open the
-// delete-group dialog.
-func TestDeleteBindingOnDefaultGroupReportsError(t *testing.T) {
+// TestDeleteBindingOnDefaultGroupShowsNotice guards against the silent no-op
+// where pressing the delete binding ('d') on the protected "My Sessions" default
+// group did nothing: no dialog, no message. The handler must open the
+// acknowledge-only notice modal (the same centered modal used for the delete
+// confirmation, so it can't be clamped off the viewport) and must not set a
+// transient error banner.
+func TestDeleteBindingOnDefaultGroupShowsNotice(t *testing.T) {
 	home := newTestHomeWithItems(100, 30, []session.Item{defaultGroupItem()})
 	home.cursor = 0
 
 	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	h := model.(*Home)
 
-	if h.err == nil {
-		t.Fatal("'d' on the default group must set an error, got nil (silent no-op)")
+	if !h.confirmDialog.IsVisible() {
+		t.Fatal("'d' on the default group must open the notice modal, got nothing (silent no-op)")
 	}
-	if !strings.Contains(h.err.Error(), session.DefaultGroupName) {
-		t.Errorf("error %q must name the default group %q", h.err.Error(), session.DefaultGroupName)
+	if got := h.confirmDialog.GetConfirmType(); got != ConfirmNotice {
+		t.Errorf("default-group block must use ConfirmNotice, got %v", got)
 	}
-	if h.confirmDialog.IsVisible() {
-		t.Error("delete-group confirmation must not open for the protected default group")
+	if h.err != nil {
+		t.Errorf("notice modal must not also set a transient error banner, got %v", h.err)
 	}
 }
 
-// TestDeleteBindingOnDefaultGroupWhenScopedNamesDefault locks in the ordering of
+// TestDeleteBindingOnDefaultGroupRendersNotice closes the gap left by #1334: the
+// handler set h.err, but the error banner is appended below a full-height panel
+// and clampViewToViewport sliced it off the bottom of the viewport, so the user
+// saw nothing - the no-op stayed silent in practice. Routing through the modal
+// fixes that. Assert the rendered View actually contains the message.
+func TestDeleteBindingOnDefaultGroupRendersNotice(t *testing.T) {
+	home := newTestHomeWithItems(100, 30, []session.Item{defaultGroupItem()})
+	home.cursor = 0
+
+	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	h := model.(*Home)
+
+	out := h.View()
+	if !strings.Contains(out, session.DefaultGroupName) {
+		t.Errorf("rendered View must show the default-group notice naming %q; got none", session.DefaultGroupName)
+	}
+	if !strings.Contains(out, "can't be deleted") {
+		t.Error("rendered View must explain the group can't be deleted")
+	}
+}
+
+// TestNoticeModalDismisses verifies the acknowledge-only modal closes on the
+// usual dismiss keys and leaves no lingering error state.
+func TestNoticeModalDismisses(t *testing.T) {
+	for _, key := range []rune{'\r', '\x1b', 'o'} { // Enter, Esc, o
+		home := newTestHomeWithItems(100, 30, []session.Item{defaultGroupItem()})
+		home.cursor = 0
+		model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+		h := model.(*Home)
+		if !h.confirmDialog.IsVisible() {
+			t.Fatal("precondition: notice modal must be open")
+		}
+
+		var msg tea.KeyMsg
+		switch key {
+		case '\r':
+			msg = tea.KeyMsg{Type: tea.KeyEnter}
+		case '\x1b':
+			msg = tea.KeyMsg{Type: tea.KeyEsc}
+		default:
+			msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}}
+		}
+		model, _ = h.Update(msg)
+		h = model.(*Home)
+		if h.confirmDialog.IsVisible() {
+			t.Errorf("notice modal must close after dismiss key %q", string(key))
+		}
+	}
+}
+
+// TestDeleteBindingOnDefaultGroupWhenScopedShowsNotice locks in the ordering of
 // the delete handler: when the TUI is scoped to the default group itself
 // (groupScope == DefaultGroupPath), both the default-group and scoped-root
-// conditions match. The default-group message must win so the feedback stays
+// conditions match. The default-group notice must win so the feedback stays
 // specific.
-func TestDeleteBindingOnDefaultGroupWhenScopedNamesDefault(t *testing.T) {
+func TestDeleteBindingOnDefaultGroupWhenScopedShowsNotice(t *testing.T) {
 	home := newTestHomeWithItems(100, 30, []session.Item{defaultGroupItem()})
 	home.cursor = 0
 	home.groupScope = session.DefaultGroupPath
@@ -3674,11 +3725,15 @@ func TestDeleteBindingOnDefaultGroupWhenScopedNamesDefault(t *testing.T) {
 	model, _ := home.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	h := model.(*Home)
 
-	if h.err == nil {
-		t.Fatal("'d' on the scoped default group must set an error, got nil")
+	if got := h.confirmDialog.GetConfirmType(); got != ConfirmNotice {
+		t.Fatalf("scoped default group must show the default-group notice, got type %v", got)
 	}
-	if !strings.Contains(h.err.Error(), session.DefaultGroupName) {
-		t.Errorf("scoped default group error %q must name the default group, not the scoped-root message", h.err.Error())
+	out := h.View()
+	if !strings.Contains(out, session.DefaultGroupName) {
+		t.Error("scoped default-group notice must name the default group, not the scoped-root message")
+	}
+	if h.err != nil {
+		t.Errorf("notice path must not set a transient error, got %v", h.err)
 	}
 }
 
@@ -3702,6 +3757,9 @@ func TestDeleteBindingOnNonDefaultGroupOpensDialog(t *testing.T) {
 
 	if !h.confirmDialog.IsVisible() {
 		t.Error("delete-group confirmation must open for a non-default group")
+	}
+	if got := h.confirmDialog.GetConfirmType(); got != ConfirmDeleteGroup {
+		t.Errorf("non-default group must open the real delete confirmation, got type %v", got)
 	}
 	if h.err != nil {
 		t.Errorf("non-default group delete must not set an error, got %v", h.err)


### PR DESCRIPTION
## Sorry: #1334 didn't actually fix this

My earlier PR #1334 was supposed to stop the protected "My Sessions" default group from silently doing nothing on delete. It set an error via `setError`, the tests went green, and it merged. But it still fails silently in real use, and the tests passed for the wrong reason. Apologies for the noise. This is the correct fix.

## Why #1334 looked fixed but wasn't

`setError` renders the message as a transient banner appended to the very bottom of the view, below the session panel and help bar. The final `clampViewToViewport` keeps only the top `h.height` lines:

```go
if len(lines) > height {
    lines = lines[:height] // drops the bottom, i.e. the error banner
}
```

On a full-height panel the banner is sliced off the bottom. So `h.err` is set but never drawn: the message is real, the user sees nothing, and the no-op stays silent. The #1334 regression tests only asserted `h.err != nil`, never that the banner survived rendering, so they passed while the live TUI showed nothing.

## The fix

Route the block through the same centered confirm-dialog modal already used for the delete confirmation, via a new acknowledge-only `ConfirmNotice` type. While any dialog is visible, `View` returns just the dialog and bypasses the viewport clamp, so the message is always shown. Dismiss with Enter/Esc/o.

```
╭─ ⚠  Can't Delete Group ─────────╮
│  "My Sessions" is the default   │
│  group and can't be deleted.    │
│                                 │
│  Sessions always need a home.   │
│           ▸ OK                  │
│  Enter / Esc / o dismiss        │
╰─────────────────────────────────╯
```

## Tests

The new tests assert the rendered `View`, not just the field that #1334 checked:

- `TestDeleteBindingOnDefaultGroupRendersNotice` renders `View()` and asserts the message text is present.
- `TestDeleteBindingOnDefaultGroupShowsNotice` asserts the handler opens `ConfirmNotice` and sets no transient error.
- `TestNoticeModalDismisses` covers Enter/Esc/o dismissal.
- `TestDeleteBindingOnDefaultGroupWhenScopedShowsNotice` keeps the default-before-scoped-root ordering.
- `TestDeleteBindingOnNonDefaultGroupOpensDialog` now also asserts the type is `ConfirmDeleteGroup`, so the notice branch does not shadow real group deletion.

## Notes / follow-ups

- The scoped-root group block (`home.go`) still uses `setError` and is subject to the same clamp. Left out of this PR to keep it focused; happy to route it through `ShowNotice` too.
- `GroupTree.DeleteGroup` still returns `nil` for the default group at the model layer. It is masked by the UI guard, but it is the original silent swallow if a new caller ever hits it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an acknowledge-only notice dialog with a single “OK” button and keyboard dismiss shortcuts (Enter/Escape/o).
* **Bug Fixes**
  * Default/home group deletion now shows an in-dialog notice explaining it can’t be removed, instead of surfacing an error.
* **Tests**
  * Updated tests to require the notice modal for the default group, verify rendered notice text and dismiss behavior, and tighten non-default delete confirmation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->