### PR TITLE
fix(tui): quick-approve targets the highlighted window, not the session (#1369)

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -4039,11 +4039,25 @@ var keySenderExec = tmuxExec
 // SendKeys sends keys to the tmux session
 // Uses -l flag to treat keys as literal text, preventing tmux special key interpretation
 func (s *Session) SendKeys(keys string) error {
+	return s.sendKeysToTarget(s.Name, keys)
+}
+
+// windowTarget returns the tmux target addressing a specific window index
+// within this session (e.g. "agentdeck_foo_ab12:2"), mirroring the format used
+// by CaptureWindowFullHistory.
+func (s *Session) windowTarget(windowIndex int) string {
+	return fmt.Sprintf("%s:%d", s.Name, windowIndex)
+}
+
+// sendKeysToTarget sends literal text to an explicit tmux target — either the
+// session name (active window) or a "<session>:<windowIndex>" window target.
+// SendKeys delegates here against the active window.
+func (s *Session) sendKeysToTarget(target, keys string) error {
 	s.invalidateCache()
 	// The -l flag makes tmux treat the string as literal text, not key names
 	// This prevents issues like "Enter" being interpreted as the Enter key
 	// and provides a layer of safety against tmux special sequences
-	cmd := keySenderExec(s.SocketName, "send-keys", "-l", "-t", s.Name, "--", keys)
+	cmd := keySenderExec(s.SocketName, "send-keys", "-l", "-t", target, "--", keys)
 	return cmd.Run()
 }
 
@@ -4053,13 +4067,18 @@ func (s *Session) SendKeys(keys string) error {
 // is idempotent — Escape lands in normal mode, `i` enters insert — so it is
 // safe to call when the prompt is already in insert mode. See issue #1264.
 func (s *Session) ensureInsertMode() {
+	s.ensureInsertModeOnTarget(s.Name)
+}
+
+// ensureInsertModeOnTarget is ensureInsertMode against an explicit tmux target.
+func (s *Session) ensureInsertModeOnTarget(target string) {
 	if !s.VimMode {
 		return
 	}
 	// Escape: guarantee normal mode regardless of current state.
-	_ = keySenderExec(s.SocketName, "send-keys", "-t", s.Name, "Escape").Run()
+	_ = keySenderExec(s.SocketName, "send-keys", "-t", target, "Escape").Run()
 	// i: enter insert mode so the following paste/Enter are taken literally.
-	_ = keySenderExec(s.SocketName, "send-keys", "-t", s.Name, "i").Run()
+	_ = keySenderExec(s.SocketName, "send-keys", "-t", target, "i").Run()
 }
 
 // sendEnterRaw emits a single Enter keystroke without the vim-mode insert
@@ -4067,8 +4086,13 @@ func (s *Session) ensureInsertMode() {
 // insert mode before the paste — re-escaping before the trailing Enter would
 // drop the prompt back to normal mode and swallow the submit.
 func (s *Session) sendEnterRaw() error {
+	return s.sendEnterRawToTarget(s.Name)
+}
+
+// sendEnterRawToTarget is sendEnterRaw against an explicit tmux target.
+func (s *Session) sendEnterRawToTarget(target string) error {
 	s.invalidateCache()
-	cmd := keySenderExec(s.SocketName, "send-keys", "-t", s.Name, "Enter")
+	cmd := keySenderExec(s.SocketName, "send-keys", "-t", target, "Enter")
 	return cmd.Run()
 }
 
@@ -4109,13 +4133,27 @@ func (s *Session) SendNamedKey(key string) error {
 // Without the delay, Enter arrives in the same PTY buffer as the paste-end
 // marker and gets swallowed by async TUI frameworks (Ink/Node.js, curses).
 func (s *Session) SendKeysAndEnter(keys string) error {
+	return s.sendKeysAndEnterToTarget(s.Name, keys)
+}
+
+// SendKeysAndEnterToWindow is SendKeysAndEnter aimed at a specific tmux window
+// index rather than the session's active window. Quick-approve (#1369) uses it
+// to deliver "1"+Enter to the exact window showing a Claude prompt, which is
+// often not the active one in a multi-window session.
+func (s *Session) SendKeysAndEnterToWindow(windowIndex int, keys string) error {
+	return s.sendKeysAndEnterToTarget(s.windowTarget(windowIndex), keys)
+}
+
+// sendKeysAndEnterToTarget is the shared implementation behind SendKeysAndEnter
+// (active window) and SendKeysAndEnterToWindow (explicit window).
+func (s *Session) sendKeysAndEnterToTarget(target, keys string) error {
 	s.invalidateCache()
 	// Guarantee the composer is in insert mode BEFORE the paste so a vim
 	// normal-mode prompt doesn't interpret the message body as motion/command
 	// keystrokes (issue #1264). No-op unless VimMode is set.
-	s.ensureInsertMode()
+	s.ensureInsertModeOnTarget(target)
 	// Use chunked sending for large messages to avoid tmux buffer limits
-	if err := s.SendKeysChunked(keys); err != nil {
+	if err := s.sendKeysChunkedToTarget(target, keys); err != nil {
 		return err
 	}
 	// Delay for TUI apps (Ink, curses) to finish processing bracketed paste
@@ -4125,23 +4163,28 @@ func (s *Session) SendKeysAndEnter(keys string) error {
 	// sendEnterRaw (not SendEnter): we already guaranteed insert mode above and
 	// the paste keeps us in insert; re-escaping here would drop back to normal
 	// mode and swallow the submit.
-	return s.sendEnterRaw()
+	return s.sendEnterRawToTarget(target)
 }
 
 // SendKeysChunked sends large content to the tmux session in chunks to avoid
 // tmux/OS buffer limits. Content ≤4KB is sent directly via SendKeys.
 // Larger content is split at newline boundaries with a short delay between chunks.
 func (s *Session) SendKeysChunked(content string) error {
+	return s.sendKeysChunkedToTarget(s.Name, content)
+}
+
+// sendKeysChunkedToTarget is SendKeysChunked against an explicit tmux target.
+func (s *Session) sendKeysChunkedToTarget(target, content string) error {
 	const chunkSize = 4096
 	const chunkDelay = 50 * time.Millisecond
 
 	if len(content) <= chunkSize {
-		return s.SendKeys(content)
+		return s.sendKeysToTarget(target, content)
 	}
 
 	chunks := splitIntoChunks(content, chunkSize)
 	for i, chunk := range chunks {
-		if err := s.SendKeys(chunk); err != nil {
+		if err := s.sendKeysToTarget(target, chunk); err != nil {
 			return fmt.Errorf("failed to send chunk %d/%d: %w", i+1, len(chunks), err)
 		}
 		if i < len(chunks)-1 {

--- a/internal/tmux/tmux_send_window_test.go
+++ b/internal/tmux/tmux_send_window_test.go
@@ -1,0 +1,90 @@
+// Regression tests for issue #1369: quick-approve (`a`) must be able to deliver
+// "1"+Enter to a SPECIFIC tmux window — the one showing the Claude prompt —
+// not just the session's active window. SendKeysAndEnterToWindow targets
+// "<session>:<windowIndex>"; the existing SendKeysAndEnter keeps targeting the
+// session's active window (no window suffix). These tests record the exact
+// send-keys argv via the keySenderExec seam (see recordKeySender in
+// tmux_vim_mode_test.go), so they run without a real tmux server.
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSendKeysAndEnterToWindow_TargetsWindowIndex: the non-vim window send must
+// emit exactly the literal paste then Enter, both aimed at "<session>:<idx>".
+func TestSendKeysAndEnterToWindow_TargetsWindowIndex(t *testing.T) {
+	calls := recordKeySender(t)
+
+	s := &Session{Name: "multiwin"} // VimMode defaults to false
+	if err := s.SendKeysAndEnterToWindow(3, "1"); err != nil {
+		t.Fatalf("SendKeysAndEnterToWindow returned error: %v", err)
+	}
+
+	c := *calls
+	if len(c) != 2 {
+		t.Fatalf("expected 2 tmux calls (paste, Enter), got %d: %v", len(c), c)
+	}
+	for _, call := range c {
+		if !strings.Contains(call, "-t multiwin:3") {
+			t.Fatalf("call not targeted at window multiwin:3: %q", call)
+		}
+	}
+	if !strings.Contains(c[0], "-l") || !strings.Contains(c[0], "-- 1") {
+		t.Fatalf("first call must be the literal paste of \"1\": %q", c[0])
+	}
+	if sentKey(c[1]) != "Enter" {
+		t.Fatalf("second call must be Enter, got %q (%v)", sentKey(c[1]), c)
+	}
+}
+
+// TestSendKeysAndEnter_ActiveWindow_NoWindowSuffix locks the existing behavior:
+// the active-window send must target the bare session name with NO ":<idx>"
+// suffix, so the window-targeted variant is the only thing that addresses a
+// specific window.
+func TestSendKeysAndEnter_ActiveWindow_NoWindowSuffix(t *testing.T) {
+	calls := recordKeySender(t)
+
+	s := &Session{Name: "activewin"}
+	if err := s.SendKeysAndEnter("1"); err != nil {
+		t.Fatalf("SendKeysAndEnter returned error: %v", err)
+	}
+
+	for _, call := range *calls {
+		if strings.Contains(call, "activewin:") {
+			t.Fatalf("active-window send must not carry a window suffix: %q", call)
+		}
+		if !strings.Contains(call, "-t activewin") {
+			t.Fatalf("call must target the session: %q", call)
+		}
+	}
+}
+
+// TestSendKeysAndEnterToWindow_VimMode_GuardsThenTargetsWindow verifies the
+// window send still honors the #1264 vim insert-guard (Escape, i) and that the
+// guard, paste, and Enter are ALL aimed at the window target.
+func TestSendKeysAndEnterToWindow_VimMode_GuardsThenTargetsWindow(t *testing.T) {
+	calls := recordKeySender(t)
+
+	s := &Session{Name: "vimwin", VimMode: true}
+	if err := s.SendKeysAndEnterToWindow(2, "1"); err != nil {
+		t.Fatalf("SendKeysAndEnterToWindow returned error: %v", err)
+	}
+
+	c := *calls
+	if len(c) != 4 {
+		t.Fatalf("expected 4 calls (Escape, i, paste, Enter), got %d: %v", len(c), c)
+	}
+	for _, call := range c {
+		if !strings.Contains(call, "-t vimwin:2") {
+			t.Fatalf("vim window send not targeted at vimwin:2: %q", call)
+		}
+	}
+	if sentKey(c[0]) != "Escape" || sentKey(c[1]) != "i" {
+		t.Fatalf("vim guard must be Escape then i first: %v", c)
+	}
+	if sentKey(c[3]) != "Enter" {
+		t.Fatalf("final key must be Enter, got %q (%v)", sentKey(c[3]), c)
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -581,6 +581,12 @@ type Home struct {
 	// nil, the dispatch calls terminal.OpenSessionInNewWindow directly.
 	// See issue #1093.
 	openInNewWindowSink func(req terminal.AttachRequest) error
+	// quickApproveSink is an optional override used by tests to capture the
+	// quick-approve (`a`) dispatch — the (instance, windowIndex) it would send
+	// "1"+Enter to — without driving real tmux. windowIndex < 0 means the
+	// session's active window; >= 0 targets that specific window. When nil, the
+	// dispatch calls the tmux session directly. See issue #1369.
+	quickApproveSink func(inst *session.Instance, windowIndex int) error
 }
 
 // reloadState preserves UI state during storage reload
@@ -656,6 +662,30 @@ func (h *Home) openInNewWindow(req terminal.AttachRequest, sessionExists bool) e
 		return nil
 	}
 	return terminal.OpenSessionInNewWindow(req)
+}
+
+// quickApprove delivers "1"+Enter to approve a Claude permission prompt without
+// attaching. windowIndex < 0 targets the session's active window (the
+// session-row path); >= 0 targets that specific tmux window (the window-row
+// path, #1369). Routed through quickApproveSink in tests. A nil instance or
+// absent tmux session is a silent no-op.
+func (h *Home) quickApprove(inst *session.Instance, windowIndex int) {
+	if inst == nil {
+		return
+	}
+	if h.quickApproveSink != nil {
+		_ = h.quickApproveSink(inst, windowIndex)
+		return
+	}
+	tmuxSess := inst.GetTmuxSession()
+	if tmuxSess == nil {
+		return
+	}
+	if windowIndex < 0 {
+		_ = tmuxSess.SendKeysAndEnter("1")
+		return
+	}
+	_ = tmuxSess.SendKeysAndEnterToWindow(windowIndex, "1")
 }
 
 // resolveITermOpenAs reads the [ui] iterm_open_as setting from the user
@@ -7340,17 +7370,11 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				// session-level gate would wrongly reject it. Target the window by
 				// index so a prompt in a non-active window is reachable. (#1369)
 				if session.IsClaudeCompatible(item.WindowTool) {
-					if inst := h.getInstanceByID(item.WindowSessionID); inst != nil {
-						if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
-							_ = tmuxSess.SendKeysAndEnterToWindow(item.WindowIndex, "1")
-						}
-					}
+					h.quickApprove(h.getInstanceByID(item.WindowSessionID), item.WindowIndex)
 				}
 			case session.ItemTypeSession:
 				if item.Session != nil && session.IsClaudeCompatible(item.Session.Tool) {
-					if tmuxSess := item.Session.GetTmuxSession(); tmuxSess != nil {
-						_ = tmuxSess.SendKeysAndEnter("1")
-					}
+					h.quickApprove(item.Session, -1)
 				}
 			}
 		}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -7322,7 +7322,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return h, nil
 
 	case defaultHotkeyBindings[hotkeyQuickApprove]:
-		// Quick approve: send "1" + Enter to the highlighted Claude session
+		// Quick approve: send "1" + Enter to the highlighted Claude session/window
 		// without attaching. Gated to Claude-compatible tools so a stray press
 		// on a vim/shell session cannot dump a "1" into the buffer. No status
 		// guard - Bash-tool permission prompts in Claude Code don't transition
@@ -7331,10 +7331,26 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// CLI, which has no status guard either.
 		if h.cursor < len(h.flatItems) {
 			item := h.flatItems[h.cursor]
-			if item.Type == session.ItemTypeSession && item.Session != nil &&
-				session.IsClaudeCompatible(item.Session.Tool) {
-				if tmuxSess := item.Session.GetTmuxSession(); tmuxSess != nil {
-					_ = tmuxSess.SendKeysAndEnter("1")
+			switch item.Type {
+			case session.ItemTypeWindow:
+				// On a window sub-row, approve the window the cursor is on. Gate
+				// on that window's detected tool (WindowTool) rather than the
+				// session's stored Tool — a session created as "shell" that later
+				// runs claude in an added window keeps Tool="shell", so the
+				// session-level gate would wrongly reject it. Target the window by
+				// index so a prompt in a non-active window is reachable. (#1369)
+				if session.IsClaudeCompatible(item.WindowTool) {
+					if inst := h.getInstanceByID(item.WindowSessionID); inst != nil {
+						if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
+							_ = tmuxSess.SendKeysAndEnterToWindow(item.WindowIndex, "1")
+						}
+					}
+				}
+			case session.ItemTypeSession:
+				if item.Session != nil && session.IsClaudeCompatible(item.Session.Tool) {
+					if tmuxSess := item.Session.GetTmuxSession(); tmuxSess != nil {
+						_ = tmuxSess.SendKeysAndEnter("1")
+					}
 				}
 			}
 		}

--- a/internal/ui/issue1369_quick_approve_window_test.go
+++ b/internal/ui/issue1369_quick_approve_window_test.go
@@ -1,0 +1,107 @@
+// Issue #1369: quick-approve (`a`) must act on the window the cursor is on,
+// gating on that window's detected tool (WindowTool) rather than the session's
+// stored Tool, and delivering to that specific window index. These tests pin
+// the dispatch at the handleMainKey boundary with an injected sink, mirroring
+// the insert-mode tests in issue1069_type_through_test.go — no real tmux.
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+type quickApproveCall struct {
+	sessionID   string
+	windowIndex int
+}
+
+// quickApproveCapture records every quick-approve dispatch so assertions can
+// observe the targeted (instance, windowIndex).
+type quickApproveCapture struct {
+	calls []quickApproveCall
+}
+
+func (c *quickApproveCapture) sink(inst *session.Instance, windowIndex int) error {
+	c.calls = append(c.calls, quickApproveCall{sessionID: inst.ID, windowIndex: windowIndex})
+	return nil
+}
+
+// armHomeWithOneWindowRow builds a Home whose cursor sits on a single window
+// sub-row of a "shell"-tool session — the #1369 case where the session Tool is
+// non-claude but the window runs claude. windowTool is the detected tool for
+// that window. flatItems is synthesized directly so it isn't rebuilt away.
+func armHomeWithOneWindowRow(t *testing.T, windowTool string, windowIndex int) (*Home, *session.Instance, *quickApproveCapture) {
+	t.Helper()
+
+	home := NewHome()
+	home.width = 120
+	home.height = 40
+	home.initialLoading = false
+
+	inst := session.NewInstanceWithTool("multiwin-session", "/tmp/multiwin", "shell")
+
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID = map[string]*session.Instance{inst.ID: inst}
+	home.instancesMu.Unlock()
+
+	home.flatItems = []session.Item{
+		{
+			Type:            session.ItemTypeWindow,
+			WindowIndex:     windowIndex,
+			WindowTool:      windowTool,
+			WindowSessionID: inst.ID,
+		},
+	}
+	home.cursor = 0
+
+	capture := &quickApproveCapture{}
+	home.quickApproveSink = capture.sink
+
+	return home, inst, capture
+}
+
+// TestQuickApprove_ClaudeWindowRow_TargetsThatWindow: pressing `a` on a window
+// sub-row whose WindowTool is claude must dispatch to that exact window index —
+// even though the parent session's Tool is "shell".
+func TestQuickApprove_ClaudeWindowRow_TargetsThatWindow(t *testing.T) {
+	home, inst, capture := armHomeWithOneWindowRow(t, "claude", 3)
+
+	home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+
+	if len(capture.calls) != 1 {
+		t.Fatalf("expected exactly 1 quick-approve dispatch, got %d: %+v", len(capture.calls), capture.calls)
+	}
+	got := capture.calls[0]
+	if got.sessionID != inst.ID {
+		t.Fatalf("dispatch targeted session %q, want %q", got.sessionID, inst.ID)
+	}
+	if got.windowIndex != 3 {
+		t.Fatalf("dispatch targeted window %d, want 3", got.windowIndex)
+	}
+}
+
+// TestQuickApprove_NonClaudeWindowRow_NoOp: pressing `a` on a window sub-row
+// whose WindowTool is not Claude-compatible must NOT dispatch — the gate keys
+// off the window's tool, so a stray press on e.g. a shell window is inert.
+func TestQuickApprove_NonClaudeWindowRow_NoOp(t *testing.T) {
+	home, _, capture := armHomeWithOneWindowRow(t, "shell", 2)
+
+	home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+
+	if len(capture.calls) != 0 {
+		t.Fatalf("expected no dispatch for a non-claude window, got %+v", capture.calls)
+	}
+}
+
+// TestQuickApprove_RemoteSession_NotHandled documents that quick-approve does
+// not act on remote sessions. This predates #1369 — the original handler only
+// matched ItemTypeSession — and remains out of scope here: remote key delivery
+// goes through the SSH/remote send path, not *tmux.Session. Tracked as a
+// possible follow-up.
+func TestQuickApprove_RemoteSession_NotHandled(t *testing.T) {
+	t.Skip("remote quick-approve is unsupported (pre-existing); out of scope for #1369")
+}


### PR DESCRIPTION
Fixes #1369.

## Problem

`a` (quick_approve) resolved its target from the **session** record, not the window the cursor is on:

- It gated on `item.Session.Tool`. A session created as `shell` that later runs `claude` in a hand-added tmux window keeps `Tool: "shell"`, so the key silently no-op'd even though the window was running Claude.
- The send went to `send-keys -t <session>` (the session's **active** window), so a prompt in any non-active window was unreachable.

Both bite the common "start a session, then open extra tmux windows and run claude in some of them" workflow — the windows show `cmd=claude` and even carry a detected per-window tool, but quick-approve never consulted either.

## Fix (layer 1 — window-accurate targeting)

Handle `ItemTypeWindow` rows in the quick-approve branch:

- Gate on the **window's** `WindowTool` (already populated from the pane) instead of the session's stored `Tool`.
- Deliver to that window by index via a new `Session.SendKeysAndEnterToWindow`.

The tmux send helpers are refactored to thread an explicit target through (`sendKeysToTarget` / `sendEnterRawToTarget` / `ensureInsertModeOnTarget` / `sendKeysChunkedToTarget`). `SendKeysAndEnter` delegates against the session name, so the active-window path — and the #1264 vim insert-guard — are unchanged.

## Scope notes

- **Still Claude-compatible only, by design.** The `1`-to-approve keystroke is Claude Code's numbered-permission-menu semantic; sending `1` to opencode/codex/gemini would just dump a stray character. The `IsClaudeCompatible` gate is preserved — the bug was that it read the wrong tool field, not that it existed. Generalizing approve to other agents (per-tool approve keystrokes, wired to the existing `PromptDetector`) is a separate follow-up.
- **`WindowTool` caveat:** it's detected from `pane_current_command`/title, which is reliable at the moment a permission prompt is showing (Claude is the foreground process then) but can read empty while Claude is mid-tool (`cmd=bash`). Harmless for approve, since you only approve at the prompt. A future option is to fall back to the title's "Claude Code" / spinner / done-marker signals for tool detection.

## Tests

`internal/tmux/tmux_send_window_test.go`:
- window send targets `<session>:<idx>` (paste + Enter);
- active-window `SendKeysAndEnter` carries **no** window suffix (locks the delegation);
- vim-mode window send still emits the Escape/`i` guard, all aimed at the window.

`go test ./internal/tmux/... ./internal/ui/...` green; `go vet` and `gofmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send keys to a specific window within a tmux session (not just the active pane), preserving vim-mode insert handling.
  * Quick-approve hotkey now targets the window under the cursor and respects the window’s configured tool.

* **Tests**
  * Added regression tests covering window-targeted key delivery in normal and vim modes and quick-approve behavior for window rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->