### PR TITLE
fix(conductor): async-deliver reply when an idle conductor's turn outruns RESPONSE_TIMEOUT

### DIFF
--- a/conductor/bridge.py
+++ b/conductor/bridge.py
@@ -317,6 +317,20 @@ def get_session_output(session: str, profile: str | None = None) -> str:
 ReplyCallback = Callable[[str], Coroutine[Any, Any, None]]
 
 
+def _is_still_running_timeout(stderr: str) -> bool:
+    """True when a blocking `--wait` failed *only* because the turn outran the
+    timeout while the agent keeps working — the message WAS delivered.
+
+    The CLI reports this with stderr like:
+        "timeout waiting for completion: agent still running after 5m0s"
+
+    Distinguishing this benign case from a genuine send failure lets callers
+    deliver the reply asynchronously instead of reporting a false failure.
+    """
+    s = stderr.lower()
+    return "timeout waiting for completion" in s or "still running" in s
+
+
 def send_to_conductor(
     session: str,
     message: str,
@@ -325,10 +339,14 @@ def send_to_conductor(
     response_timeout: int = RESPONSE_TIMEOUT,
     reply_callback: ReplyCallback | None = None,
     force_queue: bool = False,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, bool]:
     """Send a message to the conductor session.
 
-    Returns (success, response_text). When wait_for_reply=False, response_text is "".
+    Returns (success, response_text, still_running). When wait_for_reply=False,
+    response_text is "". still_running is True only on the wait path when the
+    blocking `--wait` timed out because the agent is still working (the message
+    was delivered and the reply should be awaited asynchronously); it is False
+    in every other case.
 
     When wait_for_reply=False and the conductor is busy (running/active/starting),
     the message is queued in-memory and delivered automatically once the conductor
@@ -344,7 +362,7 @@ def send_to_conductor(
         if force_queue:
             log.info("Conductor %s: force-queueing message", session)
             _enqueue_message(session, message, profile, reply_callback)
-            return True, ""
+            return True, "", False
 
         # For non-blocking sends (user messages), check if conductor is busy
         # and queue instead of dropping.
@@ -354,7 +372,7 @@ def send_to_conductor(
                 "Conductor %s is busy (%s), queueing message", session, status,
             )
             _enqueue_message(session, message, profile, reply_callback)
-            return True, ""  # queued, not failed
+            return True, "", False  # queued, not failed
 
         result = run_cli(
             "session", "send", session, message, "--no-wait",
@@ -370,13 +388,13 @@ def send_to_conductor(
                     session,
                 )
                 _enqueue_message(session, message, profile, reply_callback)
-                return True, ""
+                return True, "", False
             log.error("Failed to send to conductor: %s", stderr)
-            return False, ""
-        return True, ""
+            return False, "", False
+        return True, "", False
 
-    # wait_for_reply=True: single-call flow used by heartbeats.
-    # Send + wait + capture raw response. Avoids extra polling round-trips.
+    # wait_for_reply=True: single-call flow used by heartbeats and the idle
+    # user-message path. Send + wait + capture raw response.
     result = run_cli(
         "session", "send", session, message,
         "--wait", "--timeout", f"{response_timeout}s", "-q",
@@ -384,11 +402,20 @@ def send_to_conductor(
         timeout=max(response_timeout + 30, 60),
     )
     if result.returncode != 0:
-        log.error(
-            "Failed to send to conductor: %s", result.stderr.strip()
-        )
-        return False, ""
-    return True, result.stdout.strip()
+        stderr = result.stderr.strip()
+        # The turn outran --timeout but the message was delivered and the agent
+        # is still working. Signal still_running so the caller can await the
+        # reply asynchronously rather than reporting a false failure.
+        if _is_still_running_timeout(stderr):
+            log.info(
+                "Conductor %s: --wait timed out but agent still running "
+                "(message delivered, reply pending): %s",
+                session, stderr,
+            )
+            return False, "", True
+        log.error("Failed to send to conductor: %s", stderr)
+        return False, "", False
+    return True, result.stdout.strip(), False
 
 
 # ---------------------------------------------------------------------------
@@ -572,6 +599,100 @@ async def _drain_queue() -> None:
         if not _message_queue:
             log.info("Queue drain task finished (queue empty)")
             return
+
+
+# ---------------------------------------------------------------------------
+# Pending reply watchers for in-flight turns
+# ---------------------------------------------------------------------------
+#
+# When the conductor is IDLE on arrival the handler delivers the message with a
+# blocking `session send --wait --timeout {RESPONSE_TIMEOUT}s`. If that single
+# turn outruns the timeout the message is already delivered and the agent keeps
+# working — only the synchronous reply is lost. send_to_conductor flags this
+# (still_running=True); the handler then registers a reply-only watcher here.
+#
+# Unlike _drain_queue this NEVER sends a message — the message is already
+# in-flight, so re-sending would double-process it. The watcher only polls
+# until the turn finishes and delivers the captured output via reply_callback.
+
+# Generous ceiling: the whole point is the turn already outran RESPONSE_TIMEOUT,
+# so wait well beyond it before giving up.
+PENDING_REPLY_MAX_WAIT = 3600  # seconds
+PENDING_REPLY_POLL_INTERVAL = 5  # seconds
+
+# Keeps watcher tasks referenced so the event loop doesn't GC them mid-flight.
+_pending_reply_tasks: set[asyncio.Task] = set()
+
+
+async def _watch_pending_reply(
+    session: str,
+    profile: str | None,
+    reply_callback: ReplyCallback,
+) -> None:
+    """Wait for an in-flight conductor turn to finish, then deliver its output.
+
+    Used when a blocking `--wait` send timed out because the agent is still
+    running (not a send failure). The message was already delivered, so this
+    does NOT re-send — it polls until the conductor leaves the busy state and
+    then fires reply_callback exactly once with the captured output.
+
+    Mirrors _drain_queue's polling/backoff but never sends a message. Caps the
+    total wait at PENDING_REPLY_MAX_WAIT and logs if it gives up.
+    """
+    loop = asyncio.get_running_loop()
+    max_polls = max(1, PENDING_REPLY_MAX_WAIT // PENDING_REPLY_POLL_INTERVAL)
+    for _ in range(max_polls):
+        status = await loop.run_in_executor(
+            None, functools.partial(get_session_status, session, profile=profile),
+        )
+        # Still working, or a transient CLI failure — keep waiting. This also
+        # naturally handles the race where the conductor finishes between the
+        # timeout and this first poll: a non-busy status falls straight through
+        # to fetching the output below.
+        if status in ("running", "active", "starting", "unknown"):
+            await asyncio.sleep(PENDING_REPLY_POLL_INTERVAL)
+            continue
+        # The turn is no longer running (idle/waiting/error/...) — fetch whatever
+        # output is available and deliver it once.
+        output = await loop.run_in_executor(
+            None, functools.partial(get_session_output, session, profile=profile),
+        )
+        text = output.strip() or "[No output from conductor.]"
+        await _fire_callback(reply_callback, text)
+        log.info(
+            "Pending reply for %s delivered after in-flight turn finished", session,
+        )
+        return
+
+    log.warning(
+        "Pending reply watcher for %s gave up after %ds — turn still running",
+        session, PENDING_REPLY_MAX_WAIT,
+    )
+    await _fire_callback(
+        reply_callback,
+        "[Conductor is still working after a long time — reply not captured. "
+        "Check the session directly.]",
+    )
+
+
+def _register_pending_reply(
+    session: str,
+    profile: str | None,
+    reply_callback: ReplyCallback,
+) -> None:
+    """Schedule a reply-only watcher for an in-flight turn (no message re-send).
+
+    Safe to call from a running-loop context; skips with a warning if there is
+    no event loop (e.g. called from a bare sync context).
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        log.warning("No running event loop — cannot watch for pending reply on %s", session)
+        return
+    task = loop.create_task(_watch_pending_reply(session, profile, reply_callback))
+    _pending_reply_tasks.add(task)
+    task.add_done_callback(_pending_reply_tasks.discard)
 
 
 def get_status_summary(profile: str | None = None) -> dict:
@@ -1262,7 +1383,7 @@ def create_telegram_bot(config: dict):
                 for chunk in split_message(html):
                     await tg_bot.send_message(tg_chat_id, chunk, parse_mode="HTML")
 
-            ok, _ = send_to_conductor(
+            ok, _, _ = send_to_conductor(
                 session_title,
                 cleaned_msg,
                 profile=target_profile,
@@ -1282,7 +1403,8 @@ def create_telegram_bot(config: dict):
 
         # Conductor is free — send and wait for reply (non-blocking via executor)
         await message.answer(f"{profile_tag}\u23f3")  # typing indicator before blocking
-        ok, response = await loop.run_in_executor(
+        wait_started_at = time.monotonic()
+        ok, response, still_running = await loop.run_in_executor(
             None,
             functools.partial(
                 send_to_conductor,
@@ -1294,6 +1416,31 @@ def create_telegram_bot(config: dict):
             ),
         )
         if not ok:
+            if still_running:
+                # The message WAS delivered; the single turn just outran the
+                # blocking wait. Don't report a false failure and don't re-send
+                # (that would double-process) — watch for the reply async-ly.
+                tg_bot = message.bot
+                tg_chat_id = message.chat.id
+                profile_tag_captured = profile_tag
+
+                async def _tg_late_reply(response_text: str):
+                    elapsed = int(time.monotonic() - wait_started_at)
+                    waited = f"{elapsed // 60}m {elapsed % 60}s" if elapsed >= 60 else f"{elapsed}s"
+                    header = (
+                        f"{profile_tag_captured}Queued response (waited {waited}):\n"
+                        if profile_tag_captured
+                        else f"Queued response (waited {waited}):\n"
+                    )
+                    html = md_to_tg_html(f"{header}{response_text}")
+                    for chunk in split_message(html):
+                        await tg_bot.send_message(tg_chat_id, chunk, parse_mode="HTML")
+
+                _register_pending_reply(session_title, target_profile, _tg_late_reply)
+                await message.answer(
+                    f"{profile_tag}⏳ Still working — will reply here when done."
+                )
+                return
             await message.answer(
                 f"[Failed to send message to conductor [{target_profile}].]"
             )
@@ -1457,7 +1604,7 @@ def create_slack_app(config: dict):
                     text = f"{header}{chunk}" if i == 0 else chunk
                     await _safe_say(say, text=text, thread_ts=thread_ts)
 
-            ok, _ = send_to_conductor(
+            ok, _, _ = send_to_conductor(
                 session_title, cleaned_msg, profile=profile,
                 wait_for_reply=False, reply_callback=_slack_reply,
                 force_queue=True,
@@ -1477,7 +1624,8 @@ def create_slack_app(config: dict):
             return
 
         await _safe_say(say, text=f"{name_tag}\u23f3", thread_ts=thread_ts)  # before blocking
-        ok, response = await loop.run_in_executor(
+        wait_started_at = time.monotonic()
+        ok, response, still_running = await loop.run_in_executor(
             None,
             functools.partial(
                 send_to_conductor,
@@ -1486,6 +1634,32 @@ def create_slack_app(config: dict):
             ),
         )
         if not ok:
+            if still_running:
+                # The message WAS delivered; the single turn just outran the
+                # blocking wait. Don't report a false failure and don't re-send
+                # (that would double-process) \u2014 watch for the reply async-ly.
+                name_tag_captured = name_tag
+
+                async def _slack_late_reply(response_text: str):
+                    elapsed = int(time.monotonic() - wait_started_at)
+                    waited = f"{elapsed // 60}m {elapsed % 60}s" if elapsed >= 60 else f"{elapsed}s"
+                    header = (
+                        f"{name_tag_captured}Queued response (waited {waited}):\n"
+                        if name_tag_captured
+                        else f"Queued response (waited {waited}):\n"
+                    )
+                    chunks = split_message(response_text, max_len=SLACK_MAX_LENGTH)
+                    for i, chunk in enumerate(chunks):
+                        text = f"{header}{chunk}" if i == 0 else chunk
+                        await _safe_say(say, text=text, thread_ts=thread_ts)
+
+                _register_pending_reply(session_title, profile, _slack_late_reply)
+                await _safe_say(
+                    say,
+                    text=f"{name_tag}\u23f3 Still working \u2014 will reply here when done.",
+                    thread_ts=thread_ts,
+                )
+                return
             await _safe_say(
                 say,
                 text=f"[Failed to send message to conductor {target['name']}.]",
@@ -1854,7 +2028,7 @@ async def heartbeat_loop(config: dict, telegram_bot=None, slack_app=None, slack_
                 # Send heartbeat to conductor (wrapped in executor — blocks up to
                 # RESPONSE_TIMEOUT seconds and must not freeze the event loop)
                 loop = asyncio.get_running_loop()
-                ok, response = await loop.run_in_executor(
+                ok, response, _ = await loop.run_in_executor(
                     None,
                     functools.partial(
                         send_to_conductor,

--- a/conductor/tests/test_async_reply_on_idle_timeout.py
+++ b/conductor/tests/test_async_reply_on_idle_timeout.py
@@ -1,0 +1,222 @@
+"""Tests for the timeout -> async-reply fallback on the idle send path.
+
+Background: when the conductor is IDLE on arrival, the handler delivers the
+message with a blocking ``session send --wait --timeout {RESPONSE_TIMEOUT}s``.
+If that single turn outruns the timeout, the CLI exits non-zero with stderr
+like ``timeout waiting for completion: agent still running after 5m0s``. The
+message was already delivered and the conductor keeps working — only the
+synchronous reply is lost. Previously this surfaced as a FALSE
+"[Failed to send message to conductor]".
+
+The fix:
+  * ``send_to_conductor`` distinguishes this case and returns
+    ``(False, "", True)`` (still_running) instead of ``(False, "", False)``.
+  * the handler registers a reply-only watcher (``_watch_pending_reply``) that
+    polls until the turn finishes and delivers the captured output via the
+    reply_callback — WITHOUT re-sending the message (no double-processing).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+try:
+    import toml  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["toml"] = types.SimpleNamespace(load=lambda *_a, **_k: {})
+
+import bridge  # noqa: E402
+from bridge import (  # noqa: E402
+    _is_still_running_timeout,
+    _register_pending_reply,
+    _watch_pending_reply,
+    send_to_conductor,
+)
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(["agent-deck"], returncode, stdout, stderr)
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+def _run(coro):
+    with mock.patch("bridge.asyncio.sleep", new=_no_sleep):
+        return asyncio.run(coro)
+
+
+# --- stderr classification -------------------------------------------------
+
+def test_is_still_running_timeout_matches_cli_phrasings():
+    assert _is_still_running_timeout(
+        "timeout waiting for completion: agent still running after 5m0s"
+    )
+    assert _is_still_running_timeout("agent still running after 5m0s")
+    assert _is_still_running_timeout("TIMEOUT WAITING FOR COMPLETION")
+
+
+def test_is_still_running_timeout_rejects_genuine_failures():
+    assert not _is_still_running_timeout("session not found")
+    assert not _is_still_running_timeout("connection refused")
+    assert not _is_still_running_timeout("")
+
+
+# --- send_to_conductor wait-path signalling --------------------------------
+
+def test_wait_timeout_still_running_signals_third_tuple():
+    with mock.patch(
+        "bridge.run_cli",
+        return_value=_completed(
+            1, stderr="timeout waiting for completion: agent still running after 5m0s"
+        ),
+    ):
+        ok, response, still_running = send_to_conductor(
+            "conductor-ops", "hi", profile="work", wait_for_reply=True,
+        )
+    assert ok is False
+    assert response == ""
+    assert still_running is True
+
+
+def test_wait_genuine_failure_is_not_still_running():
+    with mock.patch(
+        "bridge.run_cli", return_value=_completed(1, stderr="session not found"),
+    ):
+        ok, response, still_running = send_to_conductor(
+            "conductor-ops", "hi", profile="work", wait_for_reply=True,
+        )
+    assert ok is False
+    assert still_running is False
+
+
+def test_wait_success_returns_output():
+    with mock.patch(
+        "bridge.run_cli", return_value=_completed(0, stdout="the answer\n"),
+    ):
+        ok, response, still_running = send_to_conductor(
+            "conductor-ops", "hi", profile="work", wait_for_reply=True,
+        )
+    assert (ok, response, still_running) == (True, "the answer", False)
+
+
+# --- the reply-only watcher ------------------------------------------------
+
+def test_watcher_waits_then_delivers_output_without_resending():
+    delivered: list[str] = []
+
+    async def cb(text: str) -> None:
+        delivered.append(text)
+
+    # busy on first poll, then finished; output fetched once.
+    with mock.patch(
+        "bridge.get_session_status", side_effect=["running", "waiting"],
+    ) as status, mock.patch(
+        "bridge.get_session_output", return_value="investigation result",
+    ) as output, mock.patch("bridge.run_cli") as run_cli:
+        _run(_watch_pending_reply("conductor-ops", "work", cb))
+
+    assert delivered == ["investigation result"]
+    assert status.call_count == 2
+    output.assert_called_once()
+    # Critically: the watcher must NOT re-send the message (no double-process).
+    run_cli.assert_not_called()
+
+
+def test_watcher_handles_race_already_idle_on_first_poll():
+    """Conductor finishes between the timeout and the first status poll."""
+    delivered: list[str] = []
+
+    async def cb(text: str) -> None:
+        delivered.append(text)
+
+    with mock.patch(
+        "bridge.get_session_status", return_value="idle",
+    ), mock.patch(
+        "bridge.get_session_output", return_value="done already",
+    ), mock.patch("bridge.run_cli") as run_cli:
+        _run(_watch_pending_reply("conductor-ops", "work", cb))
+
+    assert delivered == ["done already"]
+    run_cli.assert_not_called()
+
+
+def test_watcher_empty_output_uses_placeholder():
+    delivered: list[str] = []
+
+    async def cb(text: str) -> None:
+        delivered.append(text)
+
+    with mock.patch(
+        "bridge.get_session_status", return_value="waiting",
+    ), mock.patch(
+        "bridge.get_session_output", return_value="   ",
+    ):
+        _run(_watch_pending_reply("conductor-ops", "work", cb))
+
+    assert delivered == ["[No output from conductor.]"]
+
+
+def test_watcher_gives_up_after_ceiling_and_notifies():
+    delivered: list[str] = []
+
+    async def cb(text: str) -> None:
+        delivered.append(text)
+
+    # Always busy -> exhaust max_polls, then notify the user it gave up.
+    with mock.patch(
+        "bridge.get_session_status", return_value="running",
+    ), mock.patch(
+        "bridge.get_session_output",
+    ) as output, mock.patch.object(bridge, "PENDING_REPLY_MAX_WAIT", 0):
+        _run(_watch_pending_reply("conductor-ops", "work", cb))
+
+    assert len(delivered) == 1
+    assert "still working" in delivered[0].lower()
+    output.assert_not_called()  # never finished -> nothing to fetch
+
+
+def test_register_pending_reply_schedules_and_fires():
+    """End-to-end: registering a watcher eventually fires the reply_callback
+    exactly once and never re-sends the message."""
+    delivered: list[str] = []
+
+    async def cb(text: str) -> None:
+        delivered.append(text)
+
+    async def driver() -> None:
+        with mock.patch(
+            "bridge.get_session_status", side_effect=["running", "waiting"],
+        ), mock.patch(
+            "bridge.get_session_output", return_value="late answer",
+        ), mock.patch("bridge.run_cli") as run_cli:
+            _register_pending_reply("conductor-ops", "work", cb)
+            # Drain scheduled tasks until the watcher completes.
+            for _ in range(10):
+                pending = [
+                    t for t in asyncio.all_tasks()
+                    if t is not asyncio.current_task()
+                ]
+                if not pending:
+                    break
+                await asyncio.gather(*pending)
+            run_cli.assert_not_called()
+
+    _run(driver())
+    assert delivered == ["late answer"]
+
+
+def test_register_pending_reply_no_event_loop_is_safe():
+    """Called from a bare sync context it logs and returns without raising."""
+    async def cb(_text: str) -> None:  # pragma: no cover - never invoked
+        pass
+
+    # No running loop here -> must not raise.
+    _register_pending_reply("conductor-ops", "work", cb)


### PR DESCRIPTION
## The residual gap

The conductor bridge relays a user's Telegram/Slack message to the conductor
session. **#452** already handles the case where the conductor is **busy when
the message arrives**: it queues the message and delivers the reply
asynchronously via `_enqueue_message` + the background `_drain_queue` loop +
`reply_callback` (posting "Queued response (waited Xm Ys): …").

But a residual gap remained on the **idle** path. When the conductor is idle at
arrival, both handlers fall through to a **blocking** call:

```python
send_to_conductor(..., wait_for_reply=True, response_timeout=RESPONSE_TIMEOUT)
```

which runs `agent-deck session send --wait --timeout {RESPONSE_TIMEOUT}s` (300s).
If that **single turn** takes longer than the timeout, the CLI returns non-zero
with stderr like:

```
timeout waiting for completion: agent still running after 5m0s
```

`send_to_conductor` then returned `(False, "")` and the handler posted:

```
[Failed to send message to conductor …]
```

— a **false failure**. The message *was* delivered and the conductor keeps
working; only the synchronous reply was lost, yet the user was told it failed.

**Real-world repro:** a user message that triggers a long investigation (>5 min)
from an idle conductor reliably produces "Failed to send" even though the work
runs to completion.

This complements #452 rather than replacing it — same machinery, the other half
of the problem.

## The fix (reuse #452's machinery — no timeout bump)

- `send_to_conductor` now distinguishes an "agent still running" timeout from a
  genuine send failure by matching stderr (`timeout waiting for completion` /
  `still running`) and returns a third `still_running` flag — the wait-path
  result is now `(success, response, still_running)`.
- A new **reply-only** watcher (`_watch_pending_reply` / `_register_pending_reply`)
  polls until the in-flight turn finishes, then delivers the captured output via
  the **same `reply_callback`** the busy path uses ("Queued response
  (waited Xm Ys): …"). Crucially it **never re-sends the message** (the message
  is already in-flight), so there is no double-processing — this is the key
  difference from `_drain_queue`.
- Handles the race where the turn finishes between the timeout and the first
  poll (fetches output anyway), caps the total wait (`PENDING_REPLY_MAX_WAIT`,
  with `get_session_status`/`get_session_output` polling), and logs if it gives
  up.
- The user is now told **"Still working — will reply here when done"** instead
  of a false failure.

Applied to **both** the Telegram and Slack idle paths (they mirror each other).
Heartbeats keep their existing behavior — a still-running timeout is treated as
a skipped cycle, not an async wait.

> Note: this residual gap also affects the released **v1.9.49** line; the branch
> is based on the latest `main` so the PR stays current.

On the timeout itself: a modest `RESPONSE_TIMEOUT` bump could also be argued for,
but that is only a band-aid — the async fallback is the real fix and is kept
separable. No timeout change is included here.

## Validation

- `python3 -c "import ast; ast.parse(open('conductor/bridge.py').read())"` — clean.
- Full `conductor/tests/` suite: **52 passed, 8 skipped**. (Two unrelated tests —
  `test_hooks.py::test_env_vars_set` and
  `test_issue1351_conductor_dedupe.py::test_fresh_setup_creates_session_then_starts_it` —
  fail identically on a clean checkout of `main` in this environment due to
  XDG/`$HOME` path assumptions; they are not touched by this change.)
- Added a focused test module
  `conductor/tests/test_async_reply_on_idle_timeout.py` (11 tests) covering:
  the stderr classification, the new `still_running` tuple signalling, and the
  watcher — delivery after the turn finishes, the already-idle race, the
  empty-output placeholder, the give-up ceiling + notification, end-to-end
  registration firing the callback exactly once, and **assertions that the
  watcher never re-sends the message** (no duplicate delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced timeout handling: distinguishes between genuine send failures and cases where messages are successfully delivered but conductor processing continues.

* **Bug Fixes**
  * Eliminated duplicate message sends when conductor communication times out during active processing.
  * Results now delivered exactly once when the conductor completes its work.

* **Tests**
  * Added comprehensive test coverage for timeout classification and async reply delivery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->