### PR TITLE
fix(remote): parse remote's current version, not its advertised update

### DIFF
--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"regexp"
 	"strings"
 	"sync"
 	"syscall"
@@ -472,12 +473,30 @@ func (r *SSHRunner) remoteExec(ctx context.Context, remoteCmd string, stdin []by
 	return stdout.Bytes(), nil
 }
 
-// parseRemoteVersion extracts the version from `agent-deck version` output,
-// e.g. "Agent Deck v0.20.2" -> "0.20.2".
+// remoteVersionRe matches the first semver-looking token (with optional
+// dotted/pre-release tail) in `agent-deck version` output. The leading "v" is
+// optional and not captured.
+var remoteVersionRe = regexp.MustCompile(`v?(\d+\.\d+\.\d+(?:[.\-+][0-9A-Za-z.\-]+)?)`)
+
+// parseRemoteVersion extracts the binary's ACTUAL current version from
+// `agent-deck version` output, e.g. "Agent Deck v0.20.2" -> "0.20.2".
+//
+// It returns the FIRST semver token, which is the real current version right
+// after "Agent Deck v". This matters because a binary one release behind prints
+// its version with an "(update available: vNEWER)" suffix, e.g.
+// "Agent Deck v1.9.49 (update available: v1.9.55)". A naive
+// strings.LastIndex(out, "v") landed on the advertised newer version and
+// returned "1.9.55)" (trailing paren and all), so callers mis-read the remote
+// as already up to date and skipped the update — a catch-22 where a remote
+// could never be updated while it advertised one. Anchoring on the first
+// semver token fixes that and is robust to trailing punctuation/whitespace.
+//
+// Falls back to the trimmed raw input when no semver token is found so callers
+// still behave.
 func parseRemoteVersion(raw string) string {
 	out := strings.TrimSpace(raw)
-	if idx := strings.LastIndex(out, "v"); idx >= 0 {
-		return strings.TrimSpace(out[idx+1:])
+	if m := remoteVersionRe.FindStringSubmatch(out); m != nil {
+		return m[1]
 	}
 	return out
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -280,3 +280,60 @@ func TestSSHRunnerCreateSessionWithOptions_QueuedStartIsNotAttachable(t *testing
 		t.Fatalf("CreateSessionWithOptions error = %v, want queued error", err)
 	}
 }
+
+func TestParseRemoteVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			// The bug: a binary one release behind advertises an available
+			// update, and LastIndex("v") used to return "1.9.55)" instead of the
+			// real current version "1.9.49".
+			name: "update available suffix returns current version",
+			raw:  "Agent Deck v1.9.49 (update available: v1.9.55)",
+			want: "1.9.49",
+		},
+		{
+			name: "plain version",
+			raw:  "Agent Deck v1.9.55",
+			want: "1.9.55",
+		},
+		{
+			name: "trailing newline",
+			raw:  "Agent Deck v1.9.55\n",
+			want: "1.9.55",
+		},
+		{
+			name: "bare v-prefixed version",
+			raw:  "v1.9.55",
+			want: "1.9.55",
+		},
+		{
+			name: "bare version",
+			raw:  "1.9.55",
+			want: "1.9.55",
+		},
+		{
+			name: "pre-release tail",
+			raw:  "Agent Deck v1.9.55-rc.1",
+			want: "1.9.55-rc.1",
+		},
+		{
+			// No semver token: fall back to the trimmed raw input so callers
+			// still behave.
+			name: "garbage falls back to trimmed raw",
+			raw:  "  no version here  ",
+			want: "no version here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseRemoteVersion(tt.raw); got != tt.want {
+				t.Errorf("parseRemoteVersion(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`agent-deck remote update <name>` could never update a remote that was advertising an available update — a catch-22.

`parseRemoteVersion` in `internal/session/ssh.go` read the remote's version out of `agent-deck version` output using `strings.LastIndex(out, "v")`. A binary one release behind prints:

```
Agent Deck v1.9.49 (update available: v1.9.55)
```

so the **last** `v` landed on the advertised newer version and the function returned `"1.9.55)"` (trailing paren and all) instead of the real current version `"1.9.49"`.

Real-world symptom: a master on v1.9.55 ran `remote update box1`; box1 was actually v1.9.49 but advertised `(update available: v1.9.55)`, so it printed:

```
Current version: v1.9.55)
✓ Up to date
```

and never updated.

### Root cause / impact

`remote update` reads the remote's current version via `CheckBinary` → `versionAt` → `parseRemoteVersion`, then skips the update when `CompareVersions(remoteVersion, localVersion) >= 0`. Because the advertised "update available: vNEWER" string was mis-read as the remote's *current* version, the master concluded the remote was already up to date and skipped it. A remote could never be remote-updated while it advertised an available update.

## The fix

Anchor on the **first** semver token in the output (the real version, right after `Agent Deck v`) with a small regex instead of `LastIndex("v")`. It is robust to the optional `(update available: …)` suffix and trailing punctuation/whitespace, handles bare `1.9.55` / `v1.9.55` and pre-release tails, and falls back to the trimmed raw input when no semver is found so callers still behave. The call-site contract is unchanged (still returns the version string without a leading `v`).

## Tests

Adds a table-driven `TestParseRemoteVersion` in `internal/session/ssh_test.go`:

- `"Agent Deck v1.9.49 (update available: v1.9.55)"` → `"1.9.49"` (the bug case)
- `"Agent Deck v1.9.55"` → `"1.9.55"`
- `"Agent Deck v1.9.55\n"` (trailing newline) → `"1.9.55"`
- `"v1.9.55"` → `"1.9.55"`
- `"1.9.55"` → `"1.9.55"`
- `"Agent Deck v1.9.55-rc.1"` → `"1.9.55-rc.1"`
- garbage with no version → trimmed-raw fallback

Validated locally: `go build ./internal/session/`, `go vet ./internal/session/`, `gofmt -l`, and `go test ./internal/session/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved version detection to correctly extract the agent's actual current version from agent output, ensuring accurate version information is displayed.

* **Tests**
  * Added comprehensive test suite covering version parsing scenarios, including handling of update notifications, prerelease versions, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->