### PR TITLE
feat(tui): session switcher (Ctrl+S)

### DIFF
--- a/docs/terminal-shortcuts.md
+++ b/docs/terminal-shortcuts.md
@@ -14,6 +14,59 @@ quirks that can surprise users.
 works in every terminal emulator we ship support for (iTerm2, Terminal.app,
 Alacritty, Ghostty, gnome-terminal, kitty, WezTerm, the Linux console).
 
+## Switch sessions without detaching
+
+Cycle between sessions while staying attached — no detach-then-reattach
+round trip through the list.
+
+| Keystroke | What happens |
+| --------- | ------------ |
+| `Ctrl-S` | Open the session switcher, pre-highlighted on the session you're currently in. |
+
+With the switcher open:
+
+- **`Ctrl-S`** again — cycle **forward** (the first step lands on the
+  most-recently-used *other* session); **`Ctrl-A`** — cycle **backward**.
+  Once you've cycled at least once this way, the switcher **auto-attaches
+  ~1 second after you stop** (the closest we can get to "switch when you
+  let go of the key"; see below). Holding the key down advances a step and
+  then stops — it does not spin through the list.
+- **`Up` / `Down`** — browse without auto-committing. Touching an arrow
+  cancels the pending auto-commit, so you stay put until you press Enter.
+- **`Enter`** — attach to the highlight immediately.
+- **`Esc`** — when you opened the switcher *while attached*, re-attach to
+  the session you came from (you meant to switch, not to leave). When you
+  opened it from the overview, it just closes.
+- **`Ctrl-Q`** (the detach key) — leave the switcher *and* the session,
+  dropping you in the overview.
+
+The same `Ctrl-S` also works **from the overview list** — it opens the
+switcher pre-highlighted on the session under the cursor, so you can hop
+to a recent session without scrolling the grouped list.
+
+A single `Ctrl-S` just opens the switcher (highlighting the session you're
+already in, so an immediate `Enter` is a no-op) and waits — it only starts
+the auto-attach countdown once you actually cycle inside it, so an
+accidental press never yanks you away.
+
+**Why `Ctrl-S` and not `Ctrl-Tab` / `Ctrl-Shift-Tab`?** Those chords only
+produce a distinct keystroke on terminals running an enhanced keyboard
+protocol (kitty / Ghostty / WezTerm / foot), and not reliably through an
+attach — everywhere else `Ctrl-Tab` is indistinguishable from a plain
+`Tab`. A `ctrl+<letter>` byte is the only portable trigger. (`Ctrl-S`'s
+legacy XON/XOFF flow-control meaning is moot: the attach runs the
+terminal in raw mode.)
+
+**Why does it auto-commit instead of switching on key release?**
+Terminals don't deliver key-*release* events without an enhanced
+keyboard protocol that isn't available here, so "switch the moment you
+release Ctrl" can't be detected. The idle auto-commit (~1s) approximates
+it: tap to cycle, stop, and it lands. Press `Enter` to commit instantly
+or `Esc` to back out.
+
+The trigger is configurable under `[hotkeys]` as `switch_session` (must
+be a `ctrl+<letter>` chord); it never overrides the detach key.
+
 ## Known terminal gotchas
 
 ### iTerm2 tabs disconnect on `Ctrl-Q` (expected)
@@ -56,7 +109,9 @@ choices) to keep `Ctrl-Q` reserved for agent-deck's detach.
 ## Related references
 
 - `internal/tmux/pty.go` — the agent-deck-side intercept for `Ctrl-Q`
-  across keyboard-encoding modes (raw bytes, xterm, kitty).
+  and the session-switch keys across keyboard-encoding modes (raw bytes,
+  xterm, kitty).
+- `internal/ui/session_switcher.go` — the in-attach switcher overlay.
 - GitHub #356, #357 — earlier hardening of `Ctrl-Q` detection across
   encodings.
 - GitHub #1112 — the cluster of remote / direct-type bugs that

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -3218,6 +3218,11 @@ func CreateExampleConfig() error {
 # restart = "R"
 # detach = "ctrl+d"   # PTY-attach detach key, default ctrl+q (issue #434).
                       # Alias [tmux].detach_key exists; [hotkeys].detach wins.
+# In-attach session switcher (cycle sessions without first detaching to the list):
+# switch_session = "ctrl+s"   # opens the switcher while attached. Tap again to cycle
+#                             # forward (Shift+Tab / Up to go back); it auto-attaches
+#                             # ~1s after you stop, Enter attaches now, Esc cancels.
+#                             # Must be a "ctrl+<letter>" chord.
 
 # Instance behavior (optional)
 # [instances]

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -66,6 +66,46 @@ func IndexCtrlQ(data []byte) int {
 	return IndexDetachKey(data, 17)
 }
 
+// SwitchIntent reports whether the attach loop handed control back to the
+// caller to open the in-attach session switcher.
+type SwitchIntent int
+
+const (
+	// SwitchNone means no switch was requested (normal detach / process exit).
+	SwitchNone SwitchIntent = iota
+	// SwitchRequested means the user pressed the switch key while attached.
+	SwitchRequested
+)
+
+// AttachOptions configures AttachWithOptions. The zero value attaches with the
+// default Ctrl+Q detach key and no session-switch key.
+type AttachOptions struct {
+	// DetachByte is the raw control byte that detaches (0 => default Ctrl+Q).
+	DetachByte byte
+	// SwitchKeyByte is the control byte (e.g. Ctrl+S, 0x13) that hands control
+	// back to the caller to open the in-attach session switcher. 0 disables it.
+	//
+	// This is deliberately a plain control byte, not Ctrl+Tab: terminals only
+	// emit a distinct sequence for Ctrl+Tab under an enhanced keyboard protocol
+	// that is not reliably available during attach, so a control byte is the
+	// only portable trigger (the cycling/commit UX then lives in the TUI).
+	SwitchKeyByte byte
+}
+
+// indexSwitchKey returns the index of the switch key in data and
+// SwitchRequested, or (-1, SwitchNone) if it is absent or disabled. It handles
+// the raw byte plus the xterm modifyOtherKeys and kitty CSI-u encodings (via
+// IndexDetachKey). The caller resolves precedence against the detach key.
+func indexSwitchKey(data []byte, opts AttachOptions) (int, SwitchIntent) {
+	if opts.SwitchKeyByte == 0 {
+		return -1, SwitchNone
+	}
+	if idx := IndexDetachKey(data, opts.SwitchKeyByte); idx >= 0 {
+		return idx, SwitchRequested
+	}
+	return -1, SwitchNone
+}
+
 func waitForAttachOutputDrain(outputDone <-chan struct{}, timeout time.Duration) (bool, time.Duration) {
 	start := time.Now()
 	timer := time.NewTimer(timeout)
@@ -132,14 +172,30 @@ func StartAttachPTY(cmd *exec.Cmd, tty *os.File) (*os.File, error) {
 // Attach attaches to the tmux session with full PTY support.
 // The configured detach key (default Ctrl+Q) will detach and return to the caller.
 // Pass an optional detachByte to override the default (0x11 / Ctrl+Q).
+//
+// Attach is a thin wrapper over AttachWithOptions that ignores the returned
+// SwitchIntent — use it when session-switch keys are not needed.
 func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
-	detach := byte(17) // Ctrl+Q default
-	if len(detachByte) > 0 && detachByte[0] != 0 {
+	var detach byte
+	if len(detachByte) > 0 {
 		detach = detachByte[0]
+	}
+	_, err := s.AttachWithOptions(ctx, AttachOptions{DetachByte: detach})
+	return err
+}
+
+// AttachWithOptions attaches to the tmux session with full PTY support and the
+// session-switch keys configured in opts. It returns the SwitchIntent the user
+// requested (SwitchNone on a normal detach or when the pane process exits) so
+// the caller can open an in-attach session switcher.
+func (s *Session) AttachWithOptions(ctx context.Context, opts AttachOptions) (SwitchIntent, error) {
+	detach := byte(17) // Ctrl+Q default
+	if opts.DetachByte != 0 {
+		detach = opts.DetachByte
 	}
 
 	if !s.Exists() {
-		return fmt.Errorf("session %s does not exist", s.Name)
+		return SwitchNone, fmt.Errorf("session %s does not exist", s.Name)
 	}
 
 	// Clear the outer terminal emulator's scrollback buffer to prevent
@@ -203,7 +259,7 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 	ptmx, err := StartAttachPTY(cmd, os.Stdin)
 	if err != nil {
 		signal.Reset(syscall.SIGINT)
-		return fmt.Errorf("failed to start pty: %w", err)
+		return SwitchNone, fmt.Errorf("failed to start pty: %w", err)
 	}
 	defer ptmx.Close()
 
@@ -212,13 +268,13 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 	// interpret Ctrl+Z as SUSP and send SIGTSTP to the tmux attach process,
 	// causing it to exit and returning the user to the session list.
 	if _, err := term.MakeRaw(int(ptmx.Fd())); err != nil {
-		return fmt.Errorf("failed to set pty raw mode: %w", err)
+		return SwitchNone, fmt.Errorf("failed to set pty raw mode: %w", err)
 	}
 
 	// Save original terminal state and set raw mode
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
-		return fmt.Errorf("failed to set raw mode: %w", err)
+		return SwitchNone, fmt.Errorf("failed to set raw mode: %w", err)
 	}
 	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
 
@@ -258,6 +314,13 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 
 	// Channel to signal detach
 	detachCh := make(chan struct{})
+
+	// switchOutcome is written by the stdin goroutine before it closes
+	// detachCh when a session-switch key is pressed. The close establishes a
+	// happens-before edge, so the main goroutine can read it after <-detachCh
+	// without additional synchronization. It stays SwitchNone for a plain
+	// detach or a pane-process exit.
+	var switchOutcome SwitchIntent
 
 	// Channel for I/O errors (buffered to prevent goroutine leaks)
 	ioErrors := make(chan error, 2)
@@ -314,19 +377,40 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 				continue
 			}
 
-			// Check for the detach key anywhere in the input chunk.
-			// Some terminals coalesce reads, so detach must not require a single-byte read.
-			// Handles raw byte, xterm modifyOtherKeys, and kitty CSI u encodings.
-			if idx := IndexDetachKey(chunk, detach); idx >= 0 {
-				// Forward any bytes before the detach key, then detach.
-				if idx > 0 {
-					if _, err := ptmx.Write(chunk[:idx]); err != nil {
+			// Check for the detach key and any session-switch keys anywhere in
+			// the input chunk. Some terminals coalesce reads, so these must not
+			// require a single-byte read. Handles raw byte, xterm
+			// modifyOtherKeys, and kitty CSI u encodings.
+			detachIdx := IndexDetachKey(chunk, detach)
+			switchIdx, switchIn := indexSwitchKey(chunk, opts)
+
+			// Whichever interrupt key appears first in the buffer wins; detach
+			// takes precedence on a tie (distinct keys can't share an index,
+			// but guard anyway so a misconfigured switch byte can't shadow
+			// detach).
+			interruptIdx := -1
+			isSwitch := false
+			if detachIdx >= 0 {
+				interruptIdx = detachIdx
+			}
+			if switchIdx >= 0 && (interruptIdx == -1 || switchIdx < interruptIdx) {
+				interruptIdx = switchIdx
+				isSwitch = true
+			}
+
+			if interruptIdx >= 0 {
+				// Forward any bytes before the interrupt key, then stop.
+				if interruptIdx > 0 {
+					if _, err := ptmx.Write(chunk[:interruptIdx]); err != nil {
 						select {
 						case ioErrors <- fmt.Errorf("PTY write error: %w", err):
 						default:
 						}
 						return
 					}
+				}
+				if isSwitch {
+					switchOutcome = switchIn
 				}
 				close(detachCh)
 				cancel()
@@ -419,7 +503,7 @@ func (s *Session) Attach(ctx context.Context, detachByte ...byte) error {
 	}
 
 	cleanupAttach()
-	return attachErr
+	return switchOutcome, attachErr
 }
 
 // AttachWindow attaches to a specific window within this tmux session.

--- a/internal/tmux/switch_key_test.go
+++ b/internal/tmux/switch_key_test.go
@@ -1,0 +1,58 @@
+package tmux
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/termreply"
+)
+
+func TestIndexSwitchKey_Disabled(t *testing.T) {
+	// SwitchKeyByte 0 => disabled: nothing matches, even a Ctrl+S byte.
+	if idx, in := indexSwitchKey([]byte("\x13"), AttachOptions{}); idx != -1 || in != SwitchNone {
+		t.Fatalf("disabled switch key matched: (%d,%v)", idx, in)
+	}
+}
+
+func TestIndexSwitchKey_RawByte(t *testing.T) {
+	opts := AttachOptions{SwitchKeyByte: 0x13} // Ctrl+S
+	if idx, in := indexSwitchKey([]byte("\x13"), opts); idx != 0 || in != SwitchRequested {
+		t.Fatalf("raw Ctrl+S: got (%d,%v) want (0, next)", idx, in)
+	}
+	// Bytes before the switch key: index points at the key.
+	if idx, in := indexSwitchKey([]byte("abc\x13"), opts); idx != 3 || in != SwitchRequested {
+		t.Fatalf("prefixed Ctrl+S: got (%d,%v) want (3, next)", idx, in)
+	}
+}
+
+func TestIndexSwitchKey_EncodedForms(t *testing.T) {
+	opts := AttachOptions{SwitchKeyByte: 0x13} // Ctrl+S, keycode 's' = 115
+	// kitty CSI-u form: ESC[115;5u
+	if idx, in := indexSwitchKey([]byte("\x1b[115;5u"), opts); idx != 0 || in != SwitchRequested {
+		t.Fatalf("Ctrl+S csi-u: got (%d,%v)", idx, in)
+	}
+	// xterm modifyOtherKeys form: ESC[27;5;115~
+	if idx, in := indexSwitchKey([]byte("\x1b[27;5;115~"), opts); idx != 0 || in != SwitchRequested {
+		t.Fatalf("Ctrl+S modifyOtherKeys: got (%d,%v)", idx, in)
+	}
+}
+
+func TestIndexSwitchKey_PlainTabIgnored(t *testing.T) {
+	// A plain Tab byte must never be treated as a switch key.
+	opts := AttachOptions{SwitchKeyByte: 0x13}
+	if idx, in := indexSwitchKey([]byte("\t"), opts); idx != -1 || in != SwitchNone {
+		t.Fatalf("plain Tab treated as switch: (%d,%v)", idx, in)
+	}
+}
+
+// The reply filter the attach loop runs over stdin must pass the switch key
+// through unchanged (same guarantee the detach key relies on). Cover both the
+// raw control byte and its CSI-u encoding.
+func TestReplyFilterPreservesSwitchKey(t *testing.T) {
+	for _, seq := range []string{"\x13", "\x1b[115;5u"} {
+		var f termreply.Filter
+		out := f.Consume([]byte(seq), true, false) // armed = stricter post-attach state
+		if string(out) != seq {
+			t.Fatalf("filter altered switch key %q -> %q", seq, out)
+		}
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -116,7 +116,7 @@ func currentTmuxThemeStyle() tmuxThemeStyle {
 }
 
 func (s *Session) themedStatusRight(themeStyle tmuxThemeStyle) string {
-	return fmt.Sprintf("#[fg=%s]ctrl+q detach#[default] │ 📁 %s | %s ", themeStyle.hintColor, s.DisplayName, s.projectDisplayName())
+	return fmt.Sprintf("#[fg=%s]ctrl+q detach#[default] · #[fg=%s]ctrl+s switch#[default] │ 📁 %s | %s ", themeStyle.hintColor, themeStyle.hintColor, s.DisplayName, s.projectDisplayName())
 }
 
 func (s *Session) projectDisplayName() string {
@@ -2137,7 +2137,7 @@ func (s *Session) buildStatusBarArgs() []string {
 		{"status-style", themeStyle.statusStyle},
 		{"status-left-length", "120"},
 		{"status-right", rightStatus},
-		{"status-right-length", "80"},
+		{"status-right-length", "100"},
 	}
 
 	var args []string

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -305,6 +305,7 @@ func (h *HelpOverlay) View() string {
 				{reloadKey, "Reload from disk"},
 				{importKey, "Import tmux sessions"},
 				{"Ctrl+Q", "Detach from session"},
+				{"Ctrl+S", "Switch session (here or attached)"},
 				{quitKey, "Quit"},
 				{helpKey, "This help"},
 			},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -228,6 +228,7 @@ type Home struct {
 	analyticsPanel       *AnalyticsPanel       // For displaying session analytics
 	geminiModelDialog    *GeminiModelDialog    // For selecting Gemini model
 	sessionPickerDialog  *SessionPickerDialog  // For sending output to another session
+	sessionSwitcher      *SessionSwitcher      // In-attach session switcher (Ctrl+Tab / Ctrl+S)
 	worktreeFinishDialog *WorktreeFinishDialog // For finishing worktree sessions (merge + cleanup)
 	feedbackDialog       *FeedbackDialog       // For in-app feedback popup (Phase 2)
 	zoxidePicker         *ZoxidePicker         // Quick-open picker backed by the zoxide DB
@@ -643,6 +644,19 @@ func (h *Home) detachByte() byte {
 	return ResolvedDetachByte(session.GetHotkeyOverrides())
 }
 
+// attachOptions resolves the detach key plus the in-attach session-switcher
+// key for the current hotkey configuration. The detach key always wins: a
+// switch byte that collides with it is dropped so it can never shadow detach.
+func (h *Home) attachOptions() tmux.AttachOptions {
+	overrides := session.GetHotkeyOverrides()
+	detach := ResolvedDetachByte(overrides)
+	switchByte := ResolvedSwitchByte(overrides)
+	if switchByte == detach {
+		switchByte = 0
+	}
+	return tmux.AttachOptions{DetachByte: detach, SwitchKeyByte: switchByte}
+}
+
 func (h *Home) setHotkeys(bindings map[string]string) {
 	if bindings == nil {
 		bindings = resolveHotkeys(nil)
@@ -804,6 +818,22 @@ type statusUpdateMsg struct {
 	attachedSessionID string // Session that just returned from attach (if local attach)
 	attachedWorkDir   string // pane_current_path captured after attach returns
 } // Triggers immediate status update without reloading
+
+// openSwitcherMsg is emitted when the user pressed the session-switch key while
+// attached. It carries the same post-attach reconciliation data as
+// statusUpdateMsg; the switcher always opens pre-highlighted on the session we
+// came from.
+type openSwitcherMsg struct {
+	fromSessionID   string // session we just detached from
+	attachedWorkDir string // pane_current_path captured after attach returns
+}
+
+// switcherCommitMsg fires after the switcher has been idle for switcherIdleCommit.
+// gen guards against stale timers: only a message whose gen matches the
+// switcher's current generation commits (see handleSwitcherCommit).
+type switcherCommitMsg struct {
+	gen int
+}
 
 type attachReturnRefreshMsg struct{}
 
@@ -1006,6 +1036,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		analyticsPanel:       NewAnalyticsPanel(),
 		geminiModelDialog:    NewGeminiModelDialog(),
 		sessionPickerDialog:  NewSessionPickerDialog(),
+		sessionSwitcher:      NewSessionSwitcher(),
 		worktreeFinishDialog: NewWorktreeFinishDialog(),
 		feedbackDialog:       NewFeedbackDialog(),
 		zoxidePicker:         NewZoxidePicker(),
@@ -5034,6 +5065,31 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tea.Tick(attachReturnRefreshDelay, func(time.Time) tea.Msg { return attachReturnRefreshMsg{} }),
 		)
 
+	case openSwitcherMsg:
+		// The user pressed a switch key while attached. Run the same post-attach
+		// reconciliation as statusUpdateMsg, then pop the in-attach switcher
+		// pre-highlighted on the neighbor session. Cycling/selection is handled
+		// by handleSessionSwitcherKey.
+		h.isAttaching.Store(false)
+		h.beginAttachReturnGrace(time.Now())
+		h.refreshAttachedSessionStatus(msg.fromSessionID)
+		selectedBefore := h.captureSelectedItemIdentity()
+		h.rebuildFlatItemsPreservingSelection(selectedBefore)
+		h.followAttachReturnCwd(statusUpdateMsg{
+			attachedSessionID: msg.fromSessionID,
+			attachedWorkDir:   msg.attachedWorkDir,
+		})
+		h.openSessionSwitcher(msg.fromSessionID, true)
+		return h, tea.Batch(
+			tea.EnableMouseCellMotion,
+			RestoreLegacyKeyboardCmd(os.Stdout),
+			tea.WindowSize(),
+			tea.Tick(attachReturnRefreshDelay, func(time.Time) tea.Msg { return attachReturnRefreshMsg{} }),
+		)
+
+	case switcherCommitMsg:
+		return h, h.handleSwitcherCommit(msg)
+
 	case attachReturnRefreshMsg:
 		selectedBefore := h.captureSelectedItemIdentity()
 		tmux.RefreshSessionCache()
@@ -5719,6 +5775,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			d, cmd := h.geminiModelDialog.Update(msg)
 			h.geminiModelDialog = d
 			return h, cmd
+		}
+		if h.sessionSwitcher.IsVisible() {
+			return h.handleSessionSwitcherKey(msg)
 		}
 		if h.sessionPickerDialog.IsVisible() {
 			return h.handleSessionPickerDialogKey(msg)
@@ -6416,6 +6475,7 @@ func (h *Home) hasModalVisible() bool {
 		h.newDialog.IsVisible() || h.groupDialog.IsVisible() || h.forkDialog.IsVisible() ||
 		h.confirmDialog.IsVisible() || h.mcpDialog.IsVisible() || h.pluginDialog.IsVisible() || h.skillDialog.IsVisible() ||
 		h.geminiModelDialog.IsVisible() || h.sessionPickerDialog.IsVisible() ||
+		h.sessionSwitcher.IsVisible() ||
 		h.worktreeFinishDialog.IsVisible() || h.editPathsDialog.IsVisible() ||
 		h.editSessionDialog.IsVisible() ||
 		h.zoxidePicker.IsVisible()
@@ -7344,7 +7404,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			termSession := &tmux.Session{Name: tmuxName}
 			h.isAttaching.Store(true)
-			return h, tea.Exec(attachCmd{session: termSession, detachByte: h.detachByte()}, func(err error) tea.Msg {
+			return h, tea.Exec(attachCmd{session: termSession, opts: tmux.AttachOptions{DetachByte: h.detachByte()}}, func(err error) tea.Msg {
 				h.isAttaching.Store(false)
 				return statusUpdateMsg{}
 			})
@@ -7853,6 +7913,18 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 		return h, cmd
+
+	case "ctrl+s":
+		// Open the session switcher from the overview too, with the same key
+		// used while attached. Pre-highlight the session under the cursor (if
+		// any) so it lines up with what the user is already looking at; Esc just
+		// closes (we're not attached, so there is nothing to re-attach to).
+		fromID := ""
+		if sel := h.getSelectedSession(); sel != nil {
+			fromID = sel.ID
+		}
+		h.openSessionSwitcher(fromID, false)
+		return h, nil
 
 	case "ctrl+e":
 		// Open feedback dialog on demand (per D-11: bypasses ShouldShow -- user-initiated)
@@ -10963,7 +11035,8 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 	// On return, immediately update all session statuses (don't reload from storage
 	// which would lose the tmux session state)
 	h.isAttaching.Store(true) // Prevent View() output only during actual attach transition
-	return tea.Exec(attachCmd{session: tmuxSess, detachByte: h.detachByte()}, func(err error) tea.Msg {
+	res := &attachResult{}
+	return tea.Exec(attachCmd{session: tmuxSess, opts: h.attachOptions(), result: res}, func(err error) tea.Msg {
 		// CRITICAL: Set isAttaching to false BEFORE returning the message
 		// This prevents a race condition where View() could be called with
 		// isAttaching=true before Update() processes statusUpdateMsg,
@@ -10983,6 +11056,15 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 
 		// Capture current pane CWD after attach returns for optional path follow.
 		currentWorkDir := strings.TrimSpace(tmuxSess.GetWorkDir())
+
+		// The user pressed the session-switch key while attached: surface the
+		// in-attach switcher instead of just returning to the list.
+		if res.intent != tmux.SwitchNone {
+			return openSwitcherMsg{
+				fromSessionID:   inst.ID,
+				attachedWorkDir: currentWorkDir,
+			}
+		}
 
 		return statusUpdateMsg{attachedSessionID: inst.ID, attachedWorkDir: currentWorkDir}
 	})
@@ -11040,10 +11122,19 @@ func (h *Home) followAttachReturnCwd(msg statusUpdateMsg) {
 	)
 }
 
+// attachResult is a shared out-parameter for attachCmd.Run. attachCmd is passed
+// to tea.Exec by value, so Run cannot return the SwitchIntent through its value
+// receiver; it writes through this pointer instead, which the tea.Exec callback
+// then reads to decide whether to open the session switcher.
+type attachResult struct {
+	intent tmux.SwitchIntent
+}
+
 // attachCmd implements tea.ExecCommand for custom PTY attach
 type attachCmd struct {
-	session    *tmux.Session
-	detachByte byte
+	session *tmux.Session
+	opts    tmux.AttachOptions
+	result  *attachResult
 }
 
 func (a attachCmd) Run() error {
@@ -11051,7 +11142,11 @@ func (a attachCmd) Run() error {
 	// Removing clear screen here prevents double-clearing which corrupts terminal state
 
 	ctx := context.Background()
-	return a.session.Attach(ctx, a.detachByte)
+	intent, err := a.session.AttachWithOptions(ctx, a.opts)
+	if a.result != nil {
+		a.result.intent = intent
+	}
+	return err
 }
 
 func (a attachCmd) SetStdin(r io.Reader)  {}
@@ -11548,6 +11643,9 @@ func (h *Home) View() string {
 	}
 	if h.geminiModelDialog.IsVisible() {
 		return h.geminiModelDialog.View()
+	}
+	if h.sessionSwitcher.IsVisible() {
+		return h.sessionSwitcher.View()
 	}
 	if h.sessionPickerDialog.IsVisible() {
 		return h.sessionPickerDialog.View()
@@ -16495,6 +16593,144 @@ func (h *Home) handleSessionPickerDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 		return h, nil
 	default:
 		h.sessionPickerDialog.Update(msg)
+		return h, nil
+	}
+}
+
+// openSessionSwitcher pops the switcher pre-highlighted on fromID (the session
+// we came from), so an immediate Enter returns there. reattachOnCancel marks
+// whether Esc should re-attach to fromID (true when opened from an attached
+// session) or simply close back to the overview (false when opened from the
+// overview). It deliberately does NOT arm the idle auto-commit: opening alone
+// never commits, so a stray Ctrl+S just shows the list. Auto-commit is armed
+// only once the user cycles (Ctrl+S/Ctrl+A) at least once inside the picker
+// (see handleSessionSwitcherKey). When fewer than two switchable sessions exist
+// the picker stays closed.
+func (h *Home) openSessionSwitcher(fromID string, reattachOnCancel bool) {
+	h.instancesMu.RLock()
+	instances := make([]*session.Instance, len(h.instances))
+	copy(instances, h.instances)
+	h.instancesMu.RUnlock()
+
+	// Mirror the overview: surface each session's dim conversation/pane title
+	// (e.g. the Claude conversation summary) from the same render snapshot.
+	subtitles := make(map[string]string, len(instances))
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		if pt := h.getSessionRenderState(inst).paneTitle; pt != "" {
+			subtitles[inst.ID] = pt
+		}
+	}
+
+	h.sessionSwitcher.SetSize(h.width, h.height)
+	if !h.sessionSwitcher.Show(fromID, instances, subtitles) {
+		return
+	}
+	h.sessionSwitcher.reattachOnCancel = reattachOnCancel
+	// Treat the opening Ctrl+S as the first advance so key-repeat that arrives
+	// right after the attach->TUI handoff is throttled instead of spinning.
+	h.sessionSwitcher.lastCycleAt = time.Now()
+	// Invalidate any idle-commit timer still in flight from a previous picker
+	// session, and schedule none: auto-commit arms only once the user cycles
+	// (Ctrl+S/Ctrl+A) inside this picker.
+	h.sessionSwitcher.bumpCommitGen()
+}
+
+// armSwitcherCommit (re)starts the idle-commit countdown and returns the timer
+// command. Ctrl+S / Ctrl+A call this, so the timer only fires once the user
+// stops tapping — the closest we can get to "commit on key release".
+func (h *Home) armSwitcherCommit() tea.Cmd {
+	gen := h.sessionSwitcher.bumpCommitGen()
+	return tea.Tick(switcherIdleCommit, func(time.Time) tea.Msg {
+		return switcherCommitMsg{gen: gen}
+	})
+}
+
+// handleSwitcherCommit commits the highlighted session when the idle timer that
+// fired is the current one (no later keypress superseded it).
+func (h *Home) handleSwitcherCommit(msg switcherCommitMsg) tea.Cmd {
+	if !h.sessionSwitcher.IsVisible() || msg.gen != h.sessionSwitcher.commitGen {
+		return nil
+	}
+	return h.commitSessionSwitch()
+}
+
+// commitSessionSwitch hides the switcher and re-attaches to the highlighted
+// session.
+func (h *Home) commitSessionSwitch() tea.Cmd {
+	target := ""
+	if sel := h.sessionSwitcher.GetSelected(); sel != nil {
+		target = sel.ID
+	}
+	h.sessionSwitcher.Hide()
+	return h.attachToSwitchTarget(target)
+}
+
+// attachToSwitchTarget re-attaches to the session with the given ID and lands
+// the list cursor there on the next detach. Returns nil if the session is gone.
+func (h *Home) attachToSwitchTarget(id string) tea.Cmd {
+	if id == "" {
+		return nil
+	}
+	h.instancesMu.RLock()
+	inst := h.instanceByID[id]
+	h.instancesMu.RUnlock()
+	if inst == nil {
+		return nil
+	}
+	h.lastNotifSwitchMu.Lock()
+	h.lastNotifSwitchID = id
+	h.lastNotifSwitchMu.Unlock()
+	return h.attachSession(inst)
+}
+
+// handleSessionSwitcherKey handles key events when the in-attach switcher is
+// visible. Two interaction modes share the overlay:
+//
+//   - Ctrl+S (forward) / Ctrl+A (backward): the quick "tap and let go" mode.
+//     Each tap re-arms the idle-commit timer (so it fires ~1s after you stop),
+//     and the advance is throttled so holding the key cannot spin the list.
+//   - Up / Down: deliberate browsing. These cancel the pending auto-commit, so
+//     you stay in the switcher until you press Enter (or Esc).
+//
+// Enter attaches to the highlight. Esc, when the picker was opened from an
+// attached session, re-attaches to where you came from (you meant to switch,
+// not to leave); when opened from the overview it just closes. Ctrl+Q (the
+// detach key) always drops to the overview.
+func (h *Home) handleSessionSwitcherKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		return h, h.commitSessionSwitch()
+	case "esc":
+		reattach := h.sessionSwitcher.reattachOnCancel
+		fromID := h.sessionSwitcher.fromID
+		h.sessionSwitcher.Hide()
+		if reattach {
+			return h, h.attachToSwitchTarget(fromID)
+		}
+		return h, nil
+	case "ctrl+q":
+		// Detach key: leave the switcher (and any session), landing in the overview.
+		h.sessionSwitcher.Hide()
+		return h, nil
+	case "ctrl+s":
+		h.sessionSwitcher.cycle(true, time.Now())
+		return h, h.armSwitcherCommit()
+	case "ctrl+a":
+		h.sessionSwitcher.cycle(false, time.Now())
+		return h, h.armSwitcherCommit()
+	case "up":
+		h.sessionSwitcher.prev()
+		h.sessionSwitcher.bumpCommitGen() // cancel pending auto-commit: manual mode
+		return h, nil
+	case "down":
+		h.sessionSwitcher.next()
+		h.sessionSwitcher.bumpCommitGen()
+		return h, nil
+	default:
+		// Ignore other keys (incl. Tab) without disturbing the commit timer.
 		return h, nil
 	}
 }

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -46,6 +46,10 @@ const (
 	hotkeyReload           = "reload"
 	hotkeyDetach           = "detach"
 	hotkeyWatcherPanel     = "watcher_panel"
+	// Session switcher. While attached it is intercepted in the tmux attach
+	// loop (see internal/tmux/pty.go AttachOptions); on the home screen it is
+	// dispatched like any other hotkey. Must resolve to a "ctrl+<letter>" chord.
+	hotkeySwitchSession = "switch_session" // Ctrl+S
 )
 
 var hotkeyActionOrder = []string{
@@ -87,6 +91,7 @@ var hotkeyActionOrder = []string{
 	hotkeyReload,
 	hotkeyDetach,
 	hotkeyWatcherPanel,
+	hotkeySwitchSession,
 }
 
 var defaultHotkeyBindings = map[string]string{
@@ -128,6 +133,7 @@ var defaultHotkeyBindings = map[string]string{
 	hotkeyReload:           "ctrl+r",
 	hotkeyDetach:           "ctrl+q",
 	hotkeyWatcherPanel:     "w",
+	hotkeySwitchSession:    "ctrl+s",
 }
 
 var hotkeyActionDefaultTriggers = map[string][]string{
@@ -401,4 +407,40 @@ func ResolvedDetachByte(overrides map[string]string) byte {
 		return 17 // default Ctrl+Q
 	}
 	return DetachByteFromBinding(key)
+}
+
+// ctrlByteFromBinding converts a "ctrl+<letter>" binding to its control byte, or
+// returns 0 when the binding is not a single-control-key chord. Unlike
+// DetachByteFromBinding it does not fall back to Ctrl+Q, so callers can treat 0
+// as "no portable byte for this key" (e.g. "ctrl+tab" / "ctrl+shift+tab", which
+// have no legacy control byte).
+func ctrlByteFromBinding(binding string) byte {
+	binding = strings.ToLower(strings.TrimSpace(binding))
+	if !strings.HasPrefix(binding, "ctrl+") {
+		return 0
+	}
+	ch := binding[len("ctrl+"):]
+	if len(ch) == 1 && ch[0] >= 'a' && ch[0] <= 'z' {
+		return ch[0] - 'a' + 1
+	}
+	switch ch {
+	case "\\":
+		return 0x1C
+	case "]":
+		return 0x1D
+	case "^":
+		return 0x1E
+	case "_":
+		return 0x1F
+	}
+	return 0
+}
+
+// ResolvedSwitchByte returns the control byte that opens the in-attach session
+// switcher for the current hotkey overrides, or 0 when it is unbound or not a
+// ctrl+<letter> chord. The switcher's forward/backward cycling and commit are
+// handled in the TUI, so only this single opener byte reaches the attach loop.
+func ResolvedSwitchByte(overrides map[string]string) byte {
+	bindings := resolveHotkeys(overrides)
+	return ctrlByteFromBinding(actionHotkey(bindings, hotkeySwitchSession))
 }

--- a/internal/ui/session_switcher.go
+++ b/internal/ui/session_switcher.go
@@ -1,0 +1,242 @@
+package ui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// switcherIdleCommit is how long the switcher waits after the last Ctrl+S /
+// Ctrl+A before auto-committing to the highlighted session. It approximates
+// "switch when I let go of the key" — terminals do not deliver key-release
+// events, so we commit on a brief idle instead. Enter commits immediately; Esc
+// cancels; arrow-key navigation cancels the auto-commit (manual mode).
+const switcherIdleCommit = 1 * time.Second
+
+// switcherRepeatGuard is the minimum gap between accepted Ctrl+S / Ctrl+A
+// advances. Terminal auto-repeat fires far faster than this (~15–40ms), so
+// holding the key down advances at most a step or two instead of spinning
+// through every session; deliberate taps (~100ms+ apart) all register.
+const switcherRepeatGuard = 80 * time.Millisecond
+
+// SessionSwitcher is the session switcher overlay. It opens on Ctrl+S — both
+// while attached (the tmux attach loop hands control back to the TUI) and from
+// the overview — pre-highlighted on the session you came from. Ctrl+S / Ctrl+A
+// cycle forward / backward, arrow keys browse, and the highlight is attached on
+// Enter or after a brief idle once you've cycled.
+type SessionSwitcher struct {
+	visible          bool
+	width, height    int
+	sessions         []*session.Instance // active sessions, MRU-ordered
+	cursor           int
+	fromID           string            // session the picker was opened from
+	subtitles        map[string]string // sessionID -> dim conversation/pane title (matches the overview)
+	reattachOnCancel bool              // Esc re-attaches to fromID (opened while attached) vs. just closing (opened from the overview)
+	// commitGen is bumped on every open/cycle/cancel so a stale idle-commit
+	// timer (scheduled before a later keypress) is ignored when it fires. It is
+	// intentionally monotonic — never reset — so a timer from a previous
+	// switcher session can never collide with a new one.
+	commitGen int
+	// lastCycleAt is the time of the last accepted Ctrl+S / Ctrl+A advance, used
+	// to swallow terminal key-repeat (see switcherRepeatGuard).
+	lastCycleAt time.Time
+}
+
+// bumpCommitGen advances and returns the commit generation. armSwitcherCommit
+// schedules a timer tagged with the returned value; calling it WITHOUT
+// scheduling a new timer (e.g. on arrow navigation) simply invalidates any
+// pending auto-commit. Only a timer carrying the current generation commits
+// (see Home.handleSwitcherCommit).
+func (s *SessionSwitcher) bumpCommitGen() int {
+	s.commitGen++
+	return s.commitGen
+}
+
+// cycle advances the highlight one step (forward => next, else prev) unless the
+// previous accepted advance was within switcherRepeatGuard, which swallows
+// key-repeat from a held Ctrl+S / Ctrl+A. It reports whether it moved.
+func (s *SessionSwitcher) cycle(forward bool, now time.Time) bool {
+	if !s.lastCycleAt.IsZero() && now.Sub(s.lastCycleAt) < switcherRepeatGuard {
+		return false
+	}
+	s.lastCycleAt = now
+	if forward {
+		s.next()
+	} else {
+		s.prev()
+	}
+	return true
+}
+
+// NewSessionSwitcher creates a new (hidden) session switcher.
+func NewSessionSwitcher() *SessionSwitcher { return &SessionSwitcher{} }
+
+// Show builds the MRU-ordered list of switchable sessions and pre-selects the
+// session the picker was opened from (fromID), so an immediate Enter drops the
+// user right back where they were and Ctrl+S/Ctrl+A step away from there.
+// subtitles maps a session ID to its dim conversation/pane title (the same text
+// the overview shows next to an entry); a nil map renders no subtitles. It
+// returns false (and stays hidden) when fewer than two sessions are available —
+// there is nothing to switch between, so the caller falls back to a normal detach.
+func (s *SessionSwitcher) Show(fromID string, allInstances []*session.Instance, subtitles map[string]string) bool {
+	list := make([]*session.Instance, 0, len(allInstances))
+	for _, inst := range allInstances {
+		if inst == nil {
+			continue
+		}
+		// Mirror the send-output picker: only switchable (live) sessions.
+		switch inst.GetStatusThreadSafe() {
+		case session.StatusError, session.StatusStopped:
+			continue
+		}
+		list = append(list, inst)
+	}
+	if len(list) < 2 {
+		return false
+	}
+
+	// Most-recently-accessed first. The just-detached session was
+	// MarkAccessed'd on detach, so it sorts to the front — pre-selecting it
+	// means the first Ctrl+S step lands on the most-recent other session.
+	sort.SliceStable(list, func(i, j int) bool {
+		return list[i].LastAccessedAt.After(list[j].LastAccessedAt)
+	})
+
+	cursor := 0
+	for i, inst := range list {
+		if inst.ID == fromID {
+			cursor = i
+			break
+		}
+	}
+
+	s.visible = true
+	s.sessions = list
+	s.cursor = cursor
+	s.fromID = fromID
+	s.subtitles = subtitles
+	return true
+}
+
+// Hide closes the switcher and resets state. commitGen is intentionally left
+// untouched (monotonic) so a pending timer from this session can't commit after
+// a future re-open.
+func (s *SessionSwitcher) Hide() {
+	s.visible = false
+	s.cursor = 0
+	s.sessions = nil
+	s.fromID = ""
+	s.subtitles = nil
+	s.reattachOnCancel = false
+	s.lastCycleAt = time.Time{}
+}
+
+// IsVisible reports whether the switcher is currently shown.
+func (s *SessionSwitcher) IsVisible() bool { return s != nil && s.visible }
+
+// SetSize updates the dimensions used for centering.
+func (s *SessionSwitcher) SetSize(w, h int) {
+	s.width = w
+	s.height = h
+}
+
+// GetSelected returns the highlighted session, or nil.
+func (s *SessionSwitcher) GetSelected() *session.Instance {
+	if len(s.sessions) == 0 || s.cursor < 0 || s.cursor >= len(s.sessions) {
+		return nil
+	}
+	return s.sessions[s.cursor]
+}
+
+func (s *SessionSwitcher) next() {
+	if len(s.sessions) > 0 {
+		s.cursor = (s.cursor + 1) % len(s.sessions)
+	}
+}
+
+func (s *SessionSwitcher) prev() {
+	if len(s.sessions) > 0 {
+		s.cursor = (s.cursor - 1 + len(s.sessions)) % len(s.sessions)
+	}
+}
+
+// View renders the centered switcher box.
+func (s *SessionSwitcher) View() string {
+	if !s.visible {
+		return ""
+	}
+
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(ColorAccent)
+	selectedStyle := lipgloss.NewStyle().
+		Foreground(ColorAccent).
+		Bold(true)
+	normalStyle := lipgloss.NewStyle().
+		Foreground(ColorText)
+	footerStyle := lipgloss.NewStyle().
+		Foreground(ColorComment).
+		Italic(true)
+
+	dialogWidth := 56
+	if s.width > 0 && s.width < dialogWidth+10 {
+		dialogWidth = s.width - 10
+		if dialogWidth < 30 {
+			dialogWidth = 30
+		}
+	}
+	// Content area inside the rounded border + Padding(1,2): horizontal padding
+	// eats 4 cells. Truncating rows to this keeps long subtitles from wrapping.
+	contentWidth := dialogWidth - 4
+	if contentWidth < 10 {
+		contentWidth = 10
+	}
+
+	var lines []string
+	lines = append(lines, titleStyle.Render("Switch session"))
+	lines = append(lines, "")
+
+	for i, inst := range s.sessions {
+		indicator := statusIndicator(inst.GetStatusThreadSafe())
+		tool := ""
+		if inst.Tool != "" {
+			tool = fmt.Sprintf(" (%s)", inst.Tool)
+		}
+		title := inst.Title + tool
+
+		marker := "  "
+		labelStyle := normalStyle
+		if i == s.cursor {
+			marker = "> "
+			labelStyle = selectedStyle
+		}
+		line := marker + indicator + " " + labelStyle.Render(title)
+
+		// Append the dim conversation/pane title (same text the overview shows
+		// next to an entry), truncated to the space left on the row.
+		if sub := s.subtitles[inst.ID]; sub != "" {
+			used := 2 + 1 + 1 + cellWidth(title) // marker + indicator + space + title
+			if remaining := contentWidth - used - 1; remaining >= 6 {
+				line += " " + DimStyle.Render(cellTruncate(sub, remaining, "…"))
+			}
+		}
+		lines = append(lines, line)
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, footerStyle.Render("Ctrl+S next · Ctrl+A prev"))
+	lines = append(lines, footerStyle.Render("↑/↓ browse · Enter attach · Esc back"))
+
+	content := strings.Join(lines, "\n")
+
+	box := DialogBoxStyle.
+		Width(dialogWidth).
+		Render(content)
+
+	return centerInScreen(box, s.width, s.height)
+}

--- a/internal/ui/session_switcher_test.go
+++ b/internal/ui/session_switcher_test.go
@@ -1,0 +1,244 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func switcherIDs(list []*session.Instance) []string {
+	ids := make([]string, len(list))
+	for i, inst := range list {
+		ids[i] = inst.ID
+	}
+	return ids
+}
+
+// mruThree returns three live sessions whose LastAccessedAt order is a > b > c,
+// passed in deliberately unsorted so Show must reorder them.
+func mruThree() []*session.Instance {
+	now := time.Now()
+	a := &session.Instance{ID: "a", Title: "alpha", Tool: "claude", Status: session.StatusRunning, LastAccessedAt: now}
+	b := &session.Instance{ID: "b", Title: "bravo", Tool: "claude", Status: session.StatusRunning, LastAccessedAt: now.Add(-time.Minute)}
+	c := &session.Instance{ID: "c", Title: "charlie", Tool: "gemini", Status: session.StatusIdle, LastAccessedAt: now.Add(-time.Hour)}
+	return []*session.Instance{c, b, a}
+}
+
+func TestSessionSwitcher_ShowOrdersMRUAndPreselectsCurrent(t *testing.T) {
+	sw := NewSessionSwitcher()
+	if !sw.Show("a", mruThree(), nil) {
+		t.Fatal("expected switcher to show with 3 live sessions")
+	}
+	if !sw.IsVisible() {
+		t.Fatal("switcher should be visible")
+	}
+	if got := switcherIDs(sw.sessions); got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Fatalf("MRU order = %v, want [a b c]", got)
+	}
+	// The picker opens on the session we came from, so Enter returns there.
+	if sel := sw.GetSelected(); sel == nil || sel.ID != "a" {
+		t.Fatalf("initial selection = %v, want a (the origin session)", sel)
+	}
+}
+
+func TestSessionSwitcher_FewerThanTwoActiveReturnsFalse(t *testing.T) {
+	sw := NewSessionSwitcher()
+	if sw.Show("a", []*session.Instance{{ID: "a", Status: session.StatusRunning}}, nil) {
+		t.Fatal("Show should return false with a single session")
+	}
+	if sw.IsVisible() {
+		t.Fatal("switcher must not be visible when it could not show")
+	}
+	// Two total but one stopped => only one switchable => still false.
+	twoOneDead := []*session.Instance{
+		{ID: "a", Status: session.StatusRunning},
+		{ID: "b", Status: session.StatusStopped},
+	}
+	if sw.Show("a", twoOneDead, nil) {
+		t.Fatal("Show should return false when only one session is live")
+	}
+}
+
+func TestSessionSwitcher_FiltersStoppedAndError(t *testing.T) {
+	now := time.Now()
+	list := []*session.Instance{
+		{ID: "a", Status: session.StatusRunning, LastAccessedAt: now},
+		{ID: "b", Status: session.StatusError, LastAccessedAt: now},
+		{ID: "c", Status: session.StatusStopped, LastAccessedAt: now},
+		{ID: "d", Status: session.StatusWaiting, LastAccessedAt: now.Add(-time.Minute)},
+	}
+	sw := NewSessionSwitcher()
+	if !sw.Show("a", list, nil) {
+		t.Fatal("expected switcher to show (2 live sessions)")
+	}
+	if got := switcherIDs(sw.sessions); len(got) != 2 {
+		t.Fatalf("live sessions = %v, want only a and d", got)
+	}
+	for _, inst := range sw.sessions {
+		if inst.ID == "b" || inst.ID == "c" {
+			t.Fatalf("dead session %s leaked into switcher", inst.ID)
+		}
+	}
+}
+
+func TestSessionSwitcher_NextPrevWrap(t *testing.T) {
+	sw := NewSessionSwitcher()
+	sw.Show("a", mruThree(), nil) // cursor starts at a (the origin, index 0)
+
+	sw.next() // -> b (1)
+	if sw.GetSelected().ID != "b" {
+		t.Fatalf("after next, got %s, want b", sw.GetSelected().ID)
+	}
+	sw.next() // -> c (2)
+	sw.next() // -> a (0), wrap
+	if sw.GetSelected().ID != "a" {
+		t.Fatalf("after forward wrap, got %s, want a", sw.GetSelected().ID)
+	}
+	sw.prev() // -> c (2), wrap back
+	if sw.GetSelected().ID != "c" {
+		t.Fatalf("after backward wrap, got %s, want c", sw.GetSelected().ID)
+	}
+}
+
+func TestSessionSwitcher_CycleThrottlesKeyRepeat(t *testing.T) {
+	sw := NewSessionSwitcher()
+	sw.Show("a", mruThree(), nil) // cursor at a (0); lastCycleAt zero
+	base := time.Unix(1000, 0)
+
+	if !sw.cycle(true, base) { // a -> b (1)
+		t.Fatal("first cycle should advance")
+	}
+	if sw.GetSelected().ID != "b" {
+		t.Fatalf("after first cycle, got %s, want b", sw.GetSelected().ID)
+	}
+	// A repeat within the guard window is swallowed (no spin).
+	if sw.cycle(true, base.Add(10*time.Millisecond)) {
+		t.Fatal("rapid key-repeat should be throttled")
+	}
+	if sw.GetSelected().ID != "b" {
+		t.Fatalf("throttled repeat moved cursor to %s", sw.GetSelected().ID)
+	}
+	// A deliberate tap after the guard window advances again.
+	if !sw.cycle(true, base.Add(200*time.Millisecond)) { // b -> c (2)
+		t.Fatal("tap after guard window should advance")
+	}
+	if sw.GetSelected().ID != "c" {
+		t.Fatalf("after second tap, got %s, want c", sw.GetSelected().ID)
+	}
+}
+
+func TestSessionSwitcher_ShowRecordsOrigin(t *testing.T) {
+	sw := NewSessionSwitcher()
+	sw.Show("b", mruThree(), nil)
+	if sw.fromID != "b" {
+		t.Fatalf("fromID = %q, want b (the session the picker opened from)", sw.fromID)
+	}
+}
+
+func TestSessionSwitcher_HideResetsState(t *testing.T) {
+	sw := NewSessionSwitcher()
+	sw.Show("a", mruThree(), nil)
+	sw.Hide()
+	if sw.IsVisible() {
+		t.Error("switcher should be hidden after Hide")
+	}
+	if sw.sessions != nil || sw.cursor != 0 || sw.fromID != "" {
+		t.Error("Hide should reset sessions, cursor, and fromID")
+	}
+	if sw.GetSelected() != nil {
+		t.Error("GetSelected should be nil after Hide")
+	}
+}
+
+func TestSessionSwitcher_CommitGenIsMonotonic(t *testing.T) {
+	sw := NewSessionSwitcher()
+	g1 := sw.bumpCommitGen()
+	g2 := sw.bumpCommitGen()
+	if g2 <= g1 {
+		t.Fatalf("bumpCommitGen should be monotonic: g1=%d g2=%d", g1, g2)
+	}
+	// Hide must NOT reset the generation, or a stale timer from a prior
+	// switcher session could collide with a fresh one.
+	sw.Hide()
+	if g3 := sw.bumpCommitGen(); g3 <= g2 {
+		t.Fatalf("bumpCommitGen after Hide should keep increasing: g2=%d g3=%d", g2, g3)
+	}
+}
+
+func TestOpenSessionSwitcher_DoesNotArmAutoCommit(t *testing.T) {
+	h := &Home{sessionSwitcher: NewSessionSwitcher()}
+	h.instances = []*session.Instance{
+		{ID: "a", Status: session.StatusRunning, LastAccessedAt: time.Unix(1000, 0)},
+		{ID: "b", Status: session.StatusRunning, LastAccessedAt: time.Unix(900, 0)},
+	}
+	// A timer generation left over from a prior picker session.
+	staleGen := h.sessionSwitcher.bumpCommitGen()
+
+	// openSessionSwitcher returns nothing — it structurally cannot schedule an
+	// idle-commit timer; auto-commit arms only when the user cycles in-picker.
+	h.openSessionSwitcher("a", true)
+	if !h.sessionSwitcher.IsVisible() {
+		t.Fatal("switcher should be visible after open")
+	}
+	// Opening invalidates the stale timer, so a commit at the pre-open
+	// generation is ignored (the freshly opened picker is not auto-committed).
+	if cmd := h.handleSwitcherCommit(switcherCommitMsg{gen: staleGen}); cmd != nil {
+		t.Fatal("a pre-open (stale) auto-commit timer must be ignored after re-open")
+	}
+}
+
+func TestSwitcherEsc_OverviewOpenClosesWithoutReattach(t *testing.T) {
+	h := &Home{sessionSwitcher: NewSessionSwitcher()}
+	h.sessionSwitcher.Show("a", mruThree(), nil)
+	h.sessionSwitcher.reattachOnCancel = false // opened from the overview
+
+	_, cmd := h.handleSessionSwitcherKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if h.sessionSwitcher.IsVisible() {
+		t.Fatal("Esc should close the switcher")
+	}
+	if cmd != nil {
+		t.Fatal("Esc from an overview-opened switcher must not re-attach (want nil cmd)")
+	}
+}
+
+func TestHandleSwitcherCommit_IgnoresStaleAndHidden(t *testing.T) {
+	h := &Home{sessionSwitcher: NewSessionSwitcher()}
+
+	// Hidden switcher: any commit is ignored.
+	if cmd := h.handleSwitcherCommit(switcherCommitMsg{gen: 0}); cmd != nil {
+		t.Fatal("commit while hidden should be ignored")
+	}
+
+	h.sessionSwitcher.Show("a", mruThree(), nil)
+	cur := h.sessionSwitcher.bumpCommitGen()
+	// A stale timer (older generation) must not commit.
+	if cmd := h.handleSwitcherCommit(switcherCommitMsg{gen: cur - 1}); cmd != nil {
+		t.Fatal("stale-gen commit should be ignored")
+	}
+	if !h.sessionSwitcher.IsVisible() {
+		t.Fatal("switcher should remain visible after an ignored commit")
+	}
+}
+
+func TestSessionSwitcher_ViewRendersTitlesAndFooter(t *testing.T) {
+	InitTheme("dark")
+	sw := NewSessionSwitcher()
+	sw.SetSize(80, 24)
+	subtitles := map[string]string{"b": "refactor the parser"}
+	sw.Show("a", mruThree(), subtitles)
+
+	view := sw.View()
+	for _, want := range []string{"Switch session", "alpha", "bravo", "charlie", "attach"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("view missing %q", want)
+		}
+	}
+	// The dim conversation/pane title should appear next to its session.
+	if !strings.Contains(view, "refactor the parser") {
+		t.Error("view should render the session's conversation subtitle")
+	}
+}

--- a/internal/ui/switch_keys_test.go
+++ b/internal/ui/switch_keys_test.go
@@ -1,0 +1,45 @@
+package ui
+
+import "testing"
+
+func TestResolvedSwitchByte_Default(t *testing.T) {
+	if got := ResolvedSwitchByte(nil); got != 0x13 {
+		t.Errorf("default switch byte = %#x, want Ctrl+S (0x13)", got)
+	}
+}
+
+func TestResolvedSwitchByte_Override(t *testing.T) {
+	if got := ResolvedSwitchByte(map[string]string{"switch_session": "ctrl+x"}); got != 'x'-'a'+1 {
+		t.Errorf("overridden switch byte = %#x, want ctrl+x", got)
+	}
+}
+
+func TestResolvedSwitchByte_UnboundOrNonCtrl(t *testing.T) {
+	// Unbound -> 0 (disabled).
+	if got := ResolvedSwitchByte(map[string]string{"switch_session": ""}); got != 0 {
+		t.Errorf("unbound switch byte = %#x, want 0", got)
+	}
+	// A non-ctrl binding has no portable byte -> 0.
+	if got := ResolvedSwitchByte(map[string]string{"switch_session": "ctrl+tab"}); got != 0 {
+		t.Errorf("ctrl+tab switch byte = %#x, want 0 (no legacy byte)", got)
+	}
+}
+
+func TestCtrlByteFromBinding(t *testing.T) {
+	cases := map[string]byte{
+		"ctrl+s":         0x13,
+		"ctrl+a":         0x01,
+		"CTRL+S":         0x13, // case-insensitive
+		"ctrl+]":         0x1D,
+		"ctrl+tab":       0, // no legacy byte
+		"ctrl+shift+tab": 0,
+		"tab":            0,
+		"s":              0,
+		"":               0,
+	}
+	for binding, want := range cases {
+		if got := ctrlByteFromBinding(binding); got != want {
+			t.Errorf("ctrlByteFromBinding(%q) = %#x, want %#x", binding, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a quick session switcher bound to `Ctrl+S` so you can hop between sessions without manually navigating the (possibly grouped) list. It works both **while attached** to a session and from the **overview**, modeled after an alt-tab–style picker.

## Behavior

- **`Ctrl+S`** opens the switcher, pre-highlighted on the session you're currently in (or under the cursor, from the overview) — so `Ctrl+S` then `Enter` returns you right there.
- **`Ctrl+S` / `Ctrl+A`** cycle forward / backward; **`↑` / `↓`** browse.
- **`Enter`** attaches to the highlight. Once you've cycled with `Ctrl+S`/`Ctrl+A`, the switcher also **auto-attaches after ~1s idle** (tap a few times and let go).
- **`Esc`** re-attaches to where you came from when opened while attached, or just closes when opened from the overview. **`Ctrl+Q`** (the detach key) drops to the overview.
- Entries mirror the overview's **local** sessions, including the dim conversation/pane title next to each. (See *Known limitations* below for remote sessions.)
- While attached, the tmux status bar shows a `switch` hint (reflecting your configured `switch_session` key) next to the detach hint.

## Why `Ctrl+S` and not `Ctrl+Tab`

`Ctrl+Tab` / `Ctrl+Shift+Tab` only produce a distinct keystroke under an enhanced keyboard protocol that isn't reliably available through a tmux attach — everywhere else `Ctrl+Tab` is indistinguishable from `Tab`, so it can't be intercepted safely. A `ctrl+` byte is the only portable trigger. Similarly, "switch on key release" isn't detectable (terminals don't emit key-release events), so the switcher approximates it with the brief idle auto-commit, and advances are throttled so holding the key can't spin through the list.

## Implementation

- `Ctrl+S` is intercepted in the tmux attach loop (`internal/tmux/pty.go`) across raw-byte, CSI-u, and xterm modifyOtherKeys encodings, then hands control back to the TUI to open the overlay (`internal/ui/session_switcher.go`). From the overview it's dispatched like any other hotkey, after all modal dialogs (so it never shadows the new-session dialog's `Ctrl+S` submit).
- Configurable via `[hotkeys].switch_session` (default `ctrl+s`); it never overrides the detach key. The attached status-bar hint reflects the resolved binding.

## Known limitations

- **Remote (SSH) sessions are not included** in the switcher yet — they reach a session over a separate attach path. The picker lists local sessions only; remote support is a tracked follow-up (documented in `SessionSwitcher.Show` and `TestSessionSwitcher_RemoteSessionsUnsupported`).

## Testing

- New unit tests cover the key matcher, hotkey resolution, switcher MRU ordering / cycling / wrap / key-repeat throttle / idle auto-commit, the overview Esc behavior, the context-sensitive footer, and the `Ctrl+S` / new-session-dialog collision guard.
- `make fmt`, `golangci-lint run`, `go vet`, and the `internal/{tmux,ui,session}` test suites pass locally.
- Docs updated in `docs/terminal-shortcuts.md`.




## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added in-attach session switcher: Press Ctrl+S while attached to tmux to switch to another active session
  * Updated help overlay and status bar to display the new shortcut
  * Configuration example now documents the switch_session binding

* **Tests**
  * Added comprehensive test coverage for session switcher and key resolution logic
