### PR TITLE
feat(tui): cycle group view modes — active-on-top / populated-on-top (#1415)

### DIFF
--- a/internal/session/group_view_mode.go
+++ b/internal/session/group_view_mode.go
@@ -1,0 +1,210 @@
+package session
+
+import "strings"
+
+// GroupViewMode controls how the flattened session list is partitioned into a
+// "top" section and a "bottom" section, separated by a divider. It is toggled
+// from the TUI (cycled by a hotkey) and persisted across restarts.
+type GroupViewMode int
+
+const (
+	// GroupViewNormal renders the list as-is (no partitioning).
+	GroupViewNormal GroupViewMode = iota
+	// GroupViewActiveTop hoists groups/subgroups that contain an active
+	// (running/waiting/starting) session to the top, showing only their active
+	// sessions there; the same group re-appears below the divider with its
+	// remaining sessions.
+	GroupViewActiveTop
+	// GroupViewPopulatedTop hoists groups that contain any session to the top
+	// (with all their sessions, unsplit) and sinks empty groups below the
+	// divider.
+	GroupViewPopulatedTop
+)
+
+// GroupViewModeCount is the number of cycle-able modes (used for "(mode+1)%N").
+const GroupViewModeCount = 3
+
+// Label returns a short human-readable name for the mode (for status hints).
+func (m GroupViewMode) Label() string {
+	switch m {
+	case GroupViewActiveTop:
+		return "Active on top"
+	case GroupViewPopulatedTop:
+		return "Populated on top"
+	default:
+		return "Normal"
+	}
+}
+
+// dividerLabel returns the caption shown on the section divider for a mode.
+func (m GroupViewMode) dividerLabel() string {
+	switch m {
+	case GroupViewActiveTop:
+		return "idle / done"
+	case GroupViewPopulatedTop:
+		return "empty groups"
+	default:
+		return ""
+	}
+}
+
+// GroupActivity summarizes, for a single group path, whether it contains any
+// sessions and whether any of them are active — computed over the full tree
+// (direct + descendant sessions), independent of expand/collapse state. This is
+// what lets PartitionByViewMode place a *collapsed* group's header correctly:
+// the flattened list omits a collapsed group's session rows, so header
+// placement cannot be derived from rows alone.
+type GroupActivity struct {
+	HasAny    bool // group (or a descendant) has at least one session
+	HasActive bool // group (or a descendant) has at least one active session
+}
+
+// GroupActivityMap returns per-group-path activity aggregated over all sessions
+// in the tree (collapse-agnostic), propagated to ancestor paths.
+func (t *GroupTree) GroupActivityMap() map[string]GroupActivity {
+	m := make(map[string]GroupActivity)
+	mark := func(path string, active bool) {
+		if path == "" {
+			return
+		}
+		parts := strings.Split(path, "/")
+		for i := range parts {
+			p := strings.Join(parts[:i+1], "/")
+			a := m[p]
+			a.HasAny = true
+			if active {
+				a.HasActive = true
+			}
+			m[p] = a
+		}
+	}
+	for _, g := range t.Groups {
+		for _, s := range g.Sessions {
+			mark(g.Path, isActiveStatus(s.Status))
+		}
+	}
+	return m
+}
+
+// isActiveStatus reports whether a status counts as "active" (attention-worthy)
+// for GroupViewActiveTop: running, waiting, or starting.
+func isActiveStatus(s Status) bool {
+	switch s {
+	case StatusRunning, StatusWaiting, StatusStarting:
+		return true
+	}
+	return false
+}
+
+// markAncestorPaths marks path and every ancestor path (split on "/") in m.
+func markAncestorPaths(m map[string]bool, path string) {
+	if path == "" {
+		return
+	}
+	parts := strings.Split(path, "/")
+	for i := range parts {
+		m[strings.Join(parts[:i+1], "/")] = true
+	}
+}
+
+// PartitionByViewMode re-orders an already-flattened item list into a top
+// section and a bottom section separated by an ItemTypeDivider row.
+//
+// Session-row placement is derived from the flattened items (mirroring the
+// post-flatten filtering the "!" status filter uses, so tree-connector
+// rendering stays consistent). Group-header placement, however, is derived from
+// `activity` — a collapse-agnostic per-group summary built from the full tree
+// (see GroupTree.GroupActivityMap). This matters because a *collapsed* group
+// contributes a header row but no session rows; without the tree view it would
+// be misread as empty and sink to the bottom even when it holds running work.
+//
+// `activity` may be nil (e.g. in pure tests over fully-expanded lists): then
+// header placement falls back to the visible session rows, and groups with no
+// visible rows are treated as empty.
+//
+// If the mode is GroupViewNormal, or if either section would be empty, the
+// original slice is returned unchanged (no divider).
+func PartitionByViewMode(items []Item, mode GroupViewMode, activity map[string]GroupActivity) []Item {
+	if mode == GroupViewNormal {
+		return items
+	}
+
+	// sessionGoesTop classifies a single session item.
+	sessionGoesTop := func(it Item) bool {
+		if it.Session == nil {
+			return true
+		}
+		switch mode {
+		case GroupViewActiveTop:
+			return isActiveStatus(it.Session.Status)
+		case GroupViewPopulatedTop:
+			return true // every real session is "top"; only empty groups sink
+		}
+		return true
+	}
+
+	// Pass 1: which group paths have a visible top/bottom *session row*.
+	hasTopRow := make(map[string]bool)
+	hasBottomRow := make(map[string]bool)
+	for _, it := range items {
+		if it.Type != ItemTypeSession || it.Session == nil {
+			continue
+		}
+		if sessionGoesTop(it) {
+			markAncestorPaths(hasTopRow, it.Path)
+		} else {
+			markAncestorPaths(hasBottomRow, it.Path)
+		}
+	}
+
+	// Pass 2: split items into the two sections.
+	top := make([]Item, 0, len(items))
+	bottom := make([]Item, 0, len(items))
+	for _, it := range items {
+		switch it.Type {
+		case ItemTypeGroup:
+			inTop := hasTopRow[it.Path]
+			inBottom := hasBottomRow[it.Path]
+			if !inTop && !inBottom {
+				// No visible session rows: the group is either collapsed (rows
+				// hidden) or genuinely empty. Decide from the tree-wide activity.
+				act := activity[it.Path]
+				switch {
+				case !act.HasAny:
+					bottom = append(bottom, it) // genuinely empty -> sink
+				case mode == GroupViewActiveTop && !act.HasActive:
+					bottom = append(bottom, it) // collapsed, all-inactive -> sink
+				default:
+					top = append(top, it) // collapsed populated (active, or populated-top)
+				}
+				continue
+			}
+			if inTop {
+				top = append(top, it)
+			}
+			if inBottom {
+				bottom = append(bottom, it)
+			}
+		case ItemTypeSession:
+			if sessionGoesTop(it) {
+				top = append(top, it)
+			} else {
+				bottom = append(bottom, it)
+			}
+		default:
+			// Windows/remote/etc. — keep with the top section to avoid dropping.
+			top = append(top, it)
+		}
+	}
+
+	// Nothing to partition: one side empty -> behave like normal view.
+	if len(top) == 0 || len(bottom) == 0 {
+		return items
+	}
+
+	out := make([]Item, 0, len(top)+1+len(bottom))
+	out = append(out, top...)
+	out = append(out, Item{Type: ItemTypeDivider, DividerLabel: mode.dividerLabel()})
+	out = append(out, bottom...)
+	return out
+}

--- a/internal/session/group_view_mode.go
+++ b/internal/session/group_view_mode.go
@@ -107,6 +107,18 @@ func markAncestorPaths(m map[string]bool, path string) {
 	}
 }
 
+// hasMarkedAncestor reports whether any strict ancestor of path (its proper
+// prefixes, split on "/") is marked in m. Excludes path itself.
+func hasMarkedAncestor(m map[string]bool, path string) bool {
+	parts := strings.Split(path, "/")
+	for i := 1; i < len(parts); i++ {
+		if m[strings.Join(parts[:i], "/")] {
+			return true
+		}
+	}
+	return false
+}
+
 // PartitionByViewMode re-orders an already-flattened item list into a top
 // section and a bottom section separated by an ItemTypeDivider row.
 //
@@ -171,7 +183,24 @@ func PartitionByViewMode(items []Item, mode GroupViewMode, activity map[string]G
 				act := activity[it.Path]
 				switch {
 				case !act.HasAny:
-					bottom = append(bottom, it) // genuinely empty -> sink
+					// Genuinely empty group (no sessions in its subtree). It must
+					// render nested under a parent header, never orphaned with an
+					// indent but nothing above it. Place it in whichever section its
+					// nearest populated ancestor lives:
+					//   - active-on-top: the parent re-appears in the BOTTOM with its
+					//     idle remainder, so nest there (check bottom first).
+					//   - populated-on-top: the parent is unsplit in the TOP ("all its
+					//     contents, unsplit"), so nest there.
+					//   - no populated ancestor (whole top-level subtree empty): sink
+					//     to the bottom "empty groups" section.
+					switch {
+					case hasMarkedAncestor(hasBottomRow, it.Path):
+						bottom = append(bottom, it)
+					case hasMarkedAncestor(hasTopRow, it.Path):
+						top = append(top, it)
+					default:
+						bottom = append(bottom, it)
+					}
 				case mode == GroupViewActiveTop && !act.HasActive:
 					bottom = append(bottom, it) // collapsed, all-inactive -> sink
 				default:

--- a/internal/session/group_view_mode.go
+++ b/internal/session/group_view_mode.go
@@ -146,6 +146,15 @@ func PartitionByViewMode(items []Item, mode GroupViewMode, activity map[string]G
 		if it.Session == nil {
 			return true
 		}
+		// Pin overrides the status split (pin-sessions, requirement 3 "fully
+		// fixed"): a pin-top session stays in the top section even when idle, a
+		// pin-bottom session sinks even when active.
+		switch it.Session.Pin {
+		case PinTop:
+			return true
+		case PinBottom:
+			return false
+		}
 		switch mode {
 		case GroupViewActiveTop:
 			return isActiveStatus(it.Session.Status)

--- a/internal/session/group_view_mode.go
+++ b/internal/session/group_view_mode.go
@@ -252,6 +252,16 @@ func PartitionByViewMode(items []Item, mode GroupViewMode, activity map[string]G
 		}
 	}
 
+	// Invariant: every group placed in the bottom section must have its full
+	// ancestor chain present above it in that section, or it renders orphaned —
+	// indented under nothing (the "flat" symptom). Pass 1.5 re-shows ancestors
+	// only when the empty child has a *visible-row* (hasTopRow) ancestor; a parent
+	// populated solely via the activity map (sessions hidden by collapse or a
+	// status filter) is hoisted to the top but never re-shown in the bottom,
+	// leaving its empty children stranded. Normalize here rather than extending
+	// the hasTopRow-vs-activity detection piecemeal.
+	bottom = ensureBottomAncestorsPresent(bottom, items)
+
 	// Nothing to partition: one side empty -> behave like normal view.
 	if len(top) == 0 || len(bottom) == 0 {
 		return items
@@ -261,5 +271,43 @@ func PartitionByViewMode(items []Item, mode GroupViewMode, activity map[string]G
 	out = append(out, top...)
 	out = append(out, Item{Type: ItemTypeDivider, DividerLabel: mode.dividerLabel()})
 	out = append(out, bottom...)
+	return out
+}
+
+// ensureBottomAncestorsPresent walks the bottom-section rows in order and, before
+// each group whose ancestor path-chain is incomplete, re-inserts the missing
+// ancestor group headers (top-down, at their real Level) taken from the original
+// flattened list. This duplicates an ancestor header that already lives in the
+// top section — the intended design for view-mode partitioning — so every nested
+// group renders under its parent. Ancestors already present in the bottom are
+// left untouched (no duplication); ancestors absent from the source list (e.g.
+// nil activity in pure tests) are skipped.
+func ensureBottomAncestorsPresent(bottom, source []Item) []Item {
+	groupByPath := make(map[string]Item, len(source))
+	for _, it := range source {
+		if it.Type == ItemTypeGroup {
+			groupByPath[it.Path] = it
+		}
+	}
+
+	out := make([]Item, 0, len(bottom))
+	seen := make(map[string]bool, len(bottom))
+	for _, it := range bottom {
+		if it.Type == ItemTypeGroup {
+			parts := strings.Split(it.Path, "/")
+			for i := 1; i < len(parts); i++ {
+				anc := strings.Join(parts[:i], "/")
+				if seen[anc] {
+					continue
+				}
+				if ancItem, ok := groupByPath[anc]; ok {
+					out = append(out, ancItem)
+					seen[anc] = true
+				}
+			}
+			seen[it.Path] = true
+		}
+		out = append(out, it)
+	}
 	return out
 }

--- a/internal/session/group_view_mode.go
+++ b/internal/session/group_view_mode.go
@@ -169,6 +169,32 @@ func PartitionByViewMode(items []Item, mode GroupViewMode, activity map[string]G
 		}
 	}
 
+	// Pass 1.5 (populated-on-top only): sink genuinely-empty subgroups of a
+	// populated parent into the bottom "empty groups" section. The parent's
+	// sessions stay on top, but the empty subgroup belongs with the other empties
+	// below the divider. To keep it from rendering orphaned (indented with no
+	// header above it), mark its full populated-ancestor chain as having a bottom
+	// row so each ancestor header is re-shown (duplicated) in the bottom, nesting
+	// the subgroup under a real parent. Empties with no populated ancestor are left
+	// untouched and fall through to the Pass 2 default (sink as a lone header).
+	if mode == GroupViewPopulatedTop {
+		var sink []string
+		for _, it := range items {
+			if it.Type != ItemTypeGroup {
+				continue
+			}
+			if hasTopRow[it.Path] || hasBottomRow[it.Path] || activity[it.Path].HasAny {
+				continue // has rows, or collapsed-but-populated -> not empty
+			}
+			if hasMarkedAncestor(hasTopRow, it.Path) {
+				sink = append(sink, it.Path)
+			}
+		}
+		for _, p := range sink {
+			markAncestorPaths(hasBottomRow, p)
+		}
+	}
+
 	// Pass 2: split items into the two sections.
 	top := make([]Item, 0, len(items))
 	bottom := make([]Item, 0, len(items))

--- a/internal/session/group_view_mode_test.go
+++ b/internal/session/group_view_mode_test.go
@@ -150,13 +150,14 @@ func TestPartitionPopulatedTopParentOfPopulatedSubgroupStaysTop(t *testing.T) {
 	}
 }
 
-func TestPartitionPopulatedTopEmptySubgroupStaysNestedUnderPopulatedParent(t *testing.T) {
+func TestPartitionPopulatedTopEmptySubgroupSinksWithDuplicatedParent(t *testing.T) {
 	// "proj" has a direct session AND an empty subgroup "proj/scratch".
-	// The populated parent stays on top "with all its contents, unsplit", so the
-	// empty subgroup must stay nested under it — NOT get ripped out and dumped in
-	// the bottom "empty groups" section, where it would render indented (level 1)
-	// with no parent header above it (orphaned, grouping lost). Only the
-	// genuinely-empty top-level group "trash" sinks.
+	// In populated-on-top the populated parent's sessions stay on top, but its
+	// empty subgroup belongs in the bottom "empty groups" section alongside other
+	// empties. To keep the empty subgroup from rendering orphaned (indented with
+	// no header above it), the populated parent header is re-shown (duplicated) in
+	// the bottom so the subgroup nests under a real parent. The genuinely-empty
+	// top-level group "trash" sinks as its own header.
 	items := []Item{
 		groupItem("proj"),
 		sessItem("1", StatusIdle, "proj"),
@@ -165,12 +166,35 @@ func TestPartitionPopulatedTopEmptySubgroupStaysNestedUnderPopulatedParent(t *te
 	}
 	got := summarize(PartitionByViewMode(items, GroupViewPopulatedTop, nil))
 	want := []string{
-		"G:proj", "S:1", "G:proj/scratch",
+		"G:proj", "S:1",
 		"---",
+		"G:proj", "G:proj/scratch", // parent duplicated as header, subgroup nested
 		"G:trash",
 	}
 	if !eqSlice(got, want) {
-		t.Fatalf("empty subgroup must stay nested under populated parent:\n got=%v\nwant=%v", got, want)
+		t.Fatalf("empty subgroup must sink with duplicated parent:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestPartitionPopulatedTopEmptySubgroupDuplicatesFullAncestorChain(t *testing.T) {
+	// Deeper nesting: "a/b" is populated (holds the only session); "a/b/c" is an
+	// empty subgroup. The empty subgroup sinks to the bottom, and the entire
+	// populated ancestor chain ("a" then "a/b") is re-shown as headers so "a/b/c"
+	// nests correctly rather than rendering at level 2 with nothing above it.
+	items := []Item{
+		groupItem("a"),
+		groupItem("a/b"),
+		sessItem("1", StatusIdle, "a/b"),
+		{Type: ItemTypeGroup, Path: "a/b/c", Level: 2}, // empty subgroup
+	}
+	got := summarize(PartitionByViewMode(items, GroupViewPopulatedTop, nil))
+	want := []string{
+		"G:a", "G:a/b", "S:1",
+		"---",
+		"G:a", "G:a/b", "G:a/b/c",
+	}
+	if !eqSlice(got, want) {
+		t.Fatalf("full ancestor chain must be duplicated in bottom:\n got=%v\nwant=%v", got, want)
 	}
 }
 

--- a/internal/session/group_view_mode_test.go
+++ b/internal/session/group_view_mode_test.go
@@ -1,0 +1,209 @@
+package session
+
+import "testing"
+
+// helper: build a session item
+func sessItem(id string, status Status, path string) Item {
+	return Item{
+		Type:    ItemTypeSession,
+		Session: &Instance{ID: id, Status: status, GroupPath: path},
+		Path:    path,
+	}
+}
+
+func groupItem(path string) Item {
+	return Item{Type: ItemTypeGroup, Path: path}
+}
+
+// summarize renders a partitioned list into a compact, assertable form.
+// Group rows -> "G:<path>", session rows -> "S:<id>", divider -> "---".
+func summarize(items []Item) []string {
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		switch it.Type {
+		case ItemTypeGroup:
+			out = append(out, "G:"+it.Path)
+		case ItemTypeSession:
+			out = append(out, "S:"+it.Session.ID)
+		case ItemTypeDivider:
+			out = append(out, "---")
+		}
+	}
+	return out
+}
+
+func eqSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPartitionNormalIsIdentity(t *testing.T) {
+	items := []Item{
+		groupItem("a"),
+		sessItem("1", StatusRunning, "a"),
+	}
+	got := PartitionByViewMode(items, GroupViewNormal, nil)
+	if len(got) != len(items) {
+		t.Fatalf("normal mode must be identity, got %d items", len(got))
+	}
+}
+
+func TestPartitionActiveTopSplitsGroup(t *testing.T) {
+	// proj-a has one running + one idle; proj-b has only idle.
+	items := []Item{
+		groupItem("proj-a"),
+		sessItem("1", StatusRunning, "proj-a"),
+		sessItem("2", StatusIdle, "proj-a"),
+		groupItem("proj-b"),
+		sessItem("3", StatusIdle, "proj-b"),
+	}
+	got := summarize(PartitionByViewMode(items, GroupViewActiveTop, nil))
+	want := []string{
+		"G:proj-a", "S:1", // top: only the active session, with its group
+		"---",
+		"G:proj-a", "S:2", // bottom: the idle remainder, group re-shown
+		"G:proj-b", "S:3",
+	}
+	if !eqSlice(got, want) {
+		t.Fatalf("active-top mismatch:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestPartitionActiveTopWaitingAndStartingCountAsActive(t *testing.T) {
+	items := []Item{
+		groupItem("a"),
+		sessItem("1", StatusWaiting, "a"),
+		groupItem("b"),
+		sessItem("2", StatusStarting, "b"),
+		groupItem("c"),
+		sessItem("3", StatusIdle, "c"),
+	}
+	got := summarize(PartitionByViewMode(items, GroupViewActiveTop, nil))
+	want := []string{
+		"G:a", "S:1", "G:b", "S:2",
+		"---",
+		"G:c", "S:3",
+	}
+	if !eqSlice(got, want) {
+		t.Fatalf("waiting/starting should be active:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestPartitionActiveTopNothingActiveIsIdentity(t *testing.T) {
+	items := []Item{
+		groupItem("a"),
+		sessItem("1", StatusIdle, "a"),
+		sessItem("2", StatusStopped, "a"),
+	}
+	got := PartitionByViewMode(items, GroupViewActiveTop, nil)
+	if len(got) != len(items) {
+		t.Fatalf("no active sessions => identity (no divider), got %d", len(got))
+	}
+	for _, it := range got {
+		if it.Type == ItemTypeDivider {
+			t.Fatal("did not expect a divider when nothing is active")
+		}
+	}
+}
+
+func TestPartitionPopulatedTopSinksEmptyGroups(t *testing.T) {
+	// proj-a has a session; proj-b is empty. Sessions are NOT split by status.
+	items := []Item{
+		groupItem("proj-a"),
+		sessItem("1", StatusIdle, "proj-a"),
+		groupItem("proj-b"), // empty
+	}
+	got := summarize(PartitionByViewMode(items, GroupViewPopulatedTop, nil))
+	want := []string{
+		"G:proj-a", "S:1",
+		"---",
+		"G:proj-b",
+	}
+	if !eqSlice(got, want) {
+		t.Fatalf("populated-top mismatch:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestPartitionPopulatedTopParentOfPopulatedSubgroupStaysTop(t *testing.T) {
+	// "proj" has no direct sessions but a populated subgroup; "scratch" is empty.
+	items := []Item{
+		groupItem("proj"),
+		groupItem("proj/api"),
+		sessItem("1", StatusIdle, "proj/api"),
+		groupItem("scratch"), // empty
+	}
+	got := summarize(PartitionByViewMode(items, GroupViewPopulatedTop, nil))
+	want := []string{
+		"G:proj", "G:proj/api", "S:1",
+		"---",
+		"G:scratch",
+	}
+	if !eqSlice(got, want) {
+		t.Fatalf("nested populated mismatch:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestPartitionPopulatedTopNoEmptyGroupsIsIdentity(t *testing.T) {
+	items := []Item{
+		groupItem("a"),
+		sessItem("1", StatusIdle, "a"),
+		groupItem("b"),
+		sessItem("2", StatusRunning, "b"),
+	}
+	got := PartitionByViewMode(items, GroupViewPopulatedTop, nil)
+	if len(got) != len(items) {
+		t.Fatalf("no empty groups => identity, got %d", len(got))
+	}
+}
+
+func TestPartitionActiveTopCollapsedRunningGroupStaysTop(t *testing.T) {
+	// "proj-a" is COLLAPSED: its header is present but its (running) session row
+	// is not flattened. The tree-derived activity map must keep it on top.
+	// "proj-b" is expanded with only an idle session.
+	items := []Item{
+		groupItem("proj-a"), // collapsed: no session rows follow
+		groupItem("proj-b"),
+		sessItem("2", StatusIdle, "proj-b"),
+	}
+	activity := map[string]GroupActivity{
+		"proj-a": {HasAny: true, HasActive: true}, // collapsed, holds a runner
+		"proj-b": {HasAny: true, HasActive: false},
+	}
+	got := summarize(PartitionByViewMode(items, GroupViewActiveTop, activity))
+	want := []string{
+		"G:proj-a", // collapsed running group hoisted to top (header only)
+		"---",
+		"G:proj-b", "S:2",
+	}
+	if !eqSlice(got, want) {
+		t.Fatalf("collapsed running group must stay top:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestPartitionActiveTopCollapsedIdleGroupSinks(t *testing.T) {
+	items := []Item{
+		groupItem("proj-a"), // expanded, running
+		sessItem("1", StatusRunning, "proj-a"),
+		groupItem("proj-b"), // collapsed, all idle
+	}
+	activity := map[string]GroupActivity{
+		"proj-a": {HasAny: true, HasActive: true},
+		"proj-b": {HasAny: true, HasActive: false}, // collapsed, nothing active
+	}
+	got := summarize(PartitionByViewMode(items, GroupViewActiveTop, activity))
+	want := []string{
+		"G:proj-a", "S:1",
+		"---",
+		"G:proj-b", // collapsed all-idle group sinks below the divider
+	}
+	if !eqSlice(got, want) {
+		t.Fatalf("collapsed idle group must sink:\n got=%v\nwant=%v", got, want)
+	}
+}

--- a/internal/session/group_view_mode_test.go
+++ b/internal/session/group_view_mode_test.go
@@ -150,6 +150,53 @@ func TestPartitionPopulatedTopParentOfPopulatedSubgroupStaysTop(t *testing.T) {
 	}
 }
 
+func TestPartitionPopulatedTopEmptySubgroupStaysNestedUnderPopulatedParent(t *testing.T) {
+	// "proj" has a direct session AND an empty subgroup "proj/scratch".
+	// The populated parent stays on top "with all its contents, unsplit", so the
+	// empty subgroup must stay nested under it — NOT get ripped out and dumped in
+	// the bottom "empty groups" section, where it would render indented (level 1)
+	// with no parent header above it (orphaned, grouping lost). Only the
+	// genuinely-empty top-level group "trash" sinks.
+	items := []Item{
+		groupItem("proj"),
+		sessItem("1", StatusIdle, "proj"),
+		{Type: ItemTypeGroup, Path: "proj/scratch", Level: 1}, // empty subgroup
+		groupItem("trash"),                                    // empty top-level
+	}
+	got := summarize(PartitionByViewMode(items, GroupViewPopulatedTop, nil))
+	want := []string{
+		"G:proj", "S:1", "G:proj/scratch",
+		"---",
+		"G:trash",
+	}
+	if !eqSlice(got, want) {
+		t.Fatalf("empty subgroup must stay nested under populated parent:\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestPartitionActiveTopEmptySubgroupNestsUnderReshownParent(t *testing.T) {
+	// "p" has one running + one idle session AND an empty subgroup "p/empty".
+	// Active-top splits "p": running session up top, idle remainder + the empty
+	// subgroup down in the "idle / done" section, both nested under the re-shown
+	// "p" header. The empty subgroup must follow its parent into the bottom — not
+	// get hoisted to the top away from any header.
+	items := []Item{
+		groupItem("p"),
+		sessItem("1", StatusRunning, "p"),
+		sessItem("2", StatusIdle, "p"),
+		{Type: ItemTypeGroup, Path: "p/empty", Level: 1}, // empty subgroup
+	}
+	got := summarize(PartitionByViewMode(items, GroupViewActiveTop, nil))
+	want := []string{
+		"G:p", "S:1",
+		"---",
+		"G:p", "S:2", "G:p/empty",
+	}
+	if !eqSlice(got, want) {
+		t.Fatalf("empty subgroup must nest under re-shown parent in bottom:\n got=%v\nwant=%v", got, want)
+	}
+}
+
 func TestPartitionPopulatedTopNoEmptyGroupsIsIdentity(t *testing.T) {
 	items := []Item{
 		groupItem("a"),

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -26,6 +26,7 @@ const (
 	ItemTypeRemoteGroup
 	ItemTypeRemoteSession
 	ItemTypeWindow
+	ItemTypeDivider // Non-selectable separator between view-mode sections (running-on-top, etc.)
 )
 
 // Item represents a single item in the flattened group tree view
@@ -51,6 +52,7 @@ type Item struct {
 	CreatingID          string             // Non-empty for placeholder items (worktree creation in progress)
 	CreatingTitle       string             // Display title for creating placeholder
 	CreatingTool        string             // Tool for creating placeholder
+	DividerLabel        string             // Label shown on an ItemTypeDivider row (e.g. "idle / done")
 }
 
 // Group represents a group of sessions

--- a/internal/session/partition_empty_nesting_test.go
+++ b/internal/session/partition_empty_nesting_test.go
@@ -1,0 +1,82 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// assertBottomAncestorsNested verifies the partition invariant: every group row
+// in the bottom section (after the divider) has its full ancestor-path chain
+// present as group rows earlier in that same section. A nested empty group must
+// never render orphaned with an indent but no parent header above it.
+func assertBottomAncestorsNested(t *testing.T, out []Item) {
+	t.Helper()
+	seenBottom := map[string]bool{}
+	inBottom := false
+	for _, it := range out {
+		if it.Type == ItemTypeDivider {
+			inBottom = true
+			continue
+		}
+		if !inBottom || it.Type != ItemTypeGroup {
+			continue
+		}
+		// Every strict ancestor must already have appeared in the bottom.
+		parts := strings.Split(it.Path, "/")
+		for i := 1; i < len(parts); i++ {
+			anc := strings.Join(parts[:i], "/")
+			if !seenBottom[anc] {
+				t.Errorf("bottom group %q is orphaned: ancestor %q not shown above it", it.Path, anc)
+			}
+		}
+		seenBottom[it.Path] = true
+	}
+}
+
+// TestPartitionEmptyChildOfActivityPopulatedParentNestsUnderParent reproduces
+// the image bug: a parent (fjordbyte) is populated only via sessions that are
+// NOT visible rows in the flattened list (e.g. stopped/filtered/collapsed), so
+// it is "populated" via the activity map but has no hasTopRow marker. Its empty
+// child (canvas-azure) must still sink to the bottom NESTED under a re-shown
+// fjordbyte header, not orphaned.
+func TestPartitionEmptyChildOfActivityPopulatedParentNestsUnderParent(t *testing.T) {
+	items := []Item{
+		{Type: ItemTypeGroup, Path: "doozyx", Level: 0},
+		{Type: ItemTypeGroup, Path: "doozyx/agent-deck", Level: 1},
+		sessItem("a1", StatusRunning, "doozyx/agent-deck"),
+		// fjordbyte's only sessions are stopped -> filtered out of the visible
+		// list, so no session row appears here. Its empty child follows.
+		{Type: ItemTypeGroup, Path: "fjordbyte", Level: 0},
+		{Type: ItemTypeGroup, Path: "fjordbyte/canvas-azure", Level: 1},
+	}
+	activity := map[string]GroupActivity{
+		"doozyx":            {HasAny: true, HasActive: true},
+		"doozyx/agent-deck": {HasAny: true, HasActive: true},
+		// Populated via stopped sessions: HasAny true, HasActive false.
+		"fjordbyte": {HasAny: true},
+	}
+	out := PartitionByViewMode(items, GroupViewPopulatedTop, activity)
+	assertBottomAncestorsNested(t, out)
+}
+
+// TestPartitionEmptyChildOfCollapsedPopulatedParentNestsUnderParent covers the
+// collapsed-populated-parent variant: doozyx is populated only through a
+// collapsed subgroup (doozyx/core: header present, sessions hidden). Its empty
+// siblings baba/infra must nest under a re-shown doozyx header in the bottom.
+func TestPartitionEmptyChildOfCollapsedPopulatedParentNestsUnderParent(t *testing.T) {
+	items := []Item{
+		{Type: ItemTypeGroup, Path: "doozyx", Level: 0},
+		{Type: ItemTypeGroup, Path: "doozyx/core", Level: 1}, // collapsed populated: header only
+		{Type: ItemTypeGroup, Path: "doozyx/baba", Level: 1},
+		{Type: ItemTypeGroup, Path: "doozyx/infra", Level: 1},
+		{Type: ItemTypeGroup, Path: "adaptam", Level: 0},
+		sessItem("1", StatusIdle, "adaptam"),
+	}
+	activity := map[string]GroupActivity{
+		"doozyx":      {HasAny: true, HasActive: true},
+		"doozyx/core": {HasAny: true, HasActive: true},
+		"adaptam":     {HasAny: true},
+	}
+	out := PartitionByViewMode(items, GroupViewPopulatedTop, activity)
+	assertBottomAncestorsNested(t, out)
+}

--- a/internal/ui/group_nesting_render_test.go
+++ b/internal/ui/group_nesting_render_test.go
@@ -1,0 +1,94 @@
+package ui
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+var ansiStripRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripANSI(s string) string { return ansiStripRe.ReplaceAllString(s, "") }
+
+// triangleCol returns the rune column of the first expand triangle (▾/▸) on a
+// rendered group line, or -1 if none.
+func triangleCol(line string) int {
+	clean := stripANSI(line)
+	for _, marker := range []string{"▾", "▸"} {
+		if i := strings.Index(clean, marker); i >= 0 {
+			return len([]rune(clean[:i]))
+		}
+	}
+	return -1
+}
+
+// TestGroupNestingIndent verifies that a group's expand-triangle column reflects
+// its nesting level regardless of whether the root carries a hotkey number.
+// Before the hotkey-gutter fix, a numbered root group ("N·▾") put its triangle
+// at the same column as its (indented) child, rendering the subtree flat. The
+// fix reserves a fixed-width gutter so triangle column == gutter + level*indent.
+func TestGroupNestingIndent(t *testing.T) {
+	inst := session.NewInstanceWithTool("Add copy session", "/tmp/doozyx/agent-deck", "claude")
+	inst.GroupPath = "doozyx/agent-deck"
+	instances := []*session.Instance{inst}
+
+	groups := []*session.GroupData{
+		{Name: "doozyx", Path: "doozyx", Expanded: true, Order: 0},
+		{Name: "agent-deck", Path: "doozyx/agent-deck", Expanded: true, Order: 0},
+		{Name: "baba", Path: "doozyx/baba", Expanded: true, Order: 1},
+		{Name: "infra", Path: "doozyx/infra", Expanded: true, Order: 2},
+	}
+
+	home := NewHome()
+	home.width = 120
+	home.height = 60
+	home.initialLoading = false
+	home.instancesMu.Lock()
+	home.instances = instances
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTreeWithGroups(instances, groups)
+	home.groupViewMode = session.GroupViewPopulatedTop
+	home.cursor = -1 // nothing selected, so root hotkeys render
+	home.rebuildFlatItems()
+
+	rendered := home.renderSessionList(120, 60)
+
+	// Focus on the bottom ("empty groups") section, where the numbered root
+	// doozyx and its empty children baba/infra appear. This is where a numbered
+	// root previously rendered flat. Collect triangle columns there.
+	cols := map[string]int{}
+	belowDivider := false
+	for _, line := range strings.Split(rendered, "\n") {
+		clean := stripANSI(line)
+		if strings.Contains(clean, "empty groups") {
+			belowDivider = true
+			continue
+		}
+		if !belowDivider {
+			continue
+		}
+		for _, name := range []string{"doozyx", "baba", "infra"} {
+			if !strings.Contains(clean, name+" (") {
+				continue
+			}
+			if _, seen := cols[name]; seen {
+				continue
+			}
+			if c := triangleCol(line); c >= 0 {
+				cols[name] = c
+			}
+		}
+	}
+
+	// A numbered level-0 root and its level-1 children must NOT share a triangle
+	// column — children must be visibly nested (indented further right).
+	root := cols["doozyx"]
+	for _, child := range []string{"baba", "infra"} {
+		if cols[child] <= root {
+			t.Errorf("child %q triangle col %d should be > root doozyx col %d (nested, not flat)\n--- render ---\n%s",
+				child, cols[child], root, stripANSI(rendered))
+		}
+	}
+}

--- a/internal/ui/group_nesting_render_test.go
+++ b/internal/ui/group_nesting_render_test.go
@@ -8,14 +8,16 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-var ansiStripRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
+var groupNestingANSIStripRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
-func stripANSI(s string) string { return ansiStripRe.ReplaceAllString(s, "") }
+func stripANSIForGroupNesting(s string) string {
+	return groupNestingANSIStripRe.ReplaceAllString(s, "")
+}
 
 // triangleCol returns the rune column of the first expand triangle (▾/▸) on a
 // rendered group line, or -1 if none.
 func triangleCol(line string) int {
-	clean := stripANSI(line)
+	clean := stripANSIForGroupNesting(line)
 	for _, marker := range []string{"▾", "▸"} {
 		if i := strings.Index(clean, marker); i >= 0 {
 			return len([]rune(clean[:i]))
@@ -61,7 +63,7 @@ func TestGroupNestingIndent(t *testing.T) {
 	cols := map[string]int{}
 	belowDivider := false
 	for _, line := range strings.Split(rendered, "\n") {
-		clean := stripANSI(line)
+		clean := stripANSIForGroupNesting(line)
 		if strings.Contains(clean, "empty groups") {
 			belowDivider = true
 			continue
@@ -84,11 +86,55 @@ func TestGroupNestingIndent(t *testing.T) {
 
 	// A numbered level-0 root and its level-1 children must NOT share a triangle
 	// column — children must be visibly nested (indented further right).
-	root := cols["doozyx"]
+	root, ok := cols["doozyx"]
+	if !ok {
+		t.Fatalf("missing row doozyx\n--- render ---\n%s", stripANSIForGroupNesting(rendered))
+	}
 	for _, child := range []string{"baba", "infra"} {
+		if _, ok := cols[child]; !ok {
+			t.Fatalf("missing row %s\n--- render ---\n%s", child, stripANSIForGroupNesting(rendered))
+		}
 		if cols[child] <= root {
 			t.Errorf("child %q triangle col %d should be > root doozyx col %d (nested, not flat)\n--- render ---\n%s",
-				child, cols[child], root, stripANSI(rendered))
+				child, cols[child], root, stripANSIForGroupNesting(rendered))
+		}
+	}
+}
+
+func TestDuplicateRootHeadersReuseRootGroupNumber(t *testing.T) {
+	inst := session.NewInstanceWithTool("Add copy session", "/tmp/doozyx/agent-deck", "claude")
+	inst.GroupPath = "doozyx/agent-deck"
+	instances := []*session.Instance{inst}
+
+	groups := []*session.GroupData{
+		{Name: "doozyx", Path: "doozyx", Expanded: true, Order: 0},
+		{Name: "agent-deck", Path: "doozyx/agent-deck", Expanded: true, Order: 0},
+		{Name: "baba", Path: "doozyx/baba", Expanded: true, Order: 1},
+	}
+
+	home := NewHome()
+	home.width = 120
+	home.height = 60
+	home.initialLoading = false
+	home.instancesMu.Lock()
+	home.instances = instances
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTreeWithGroups(instances, groups)
+	home.groupViewMode = session.GroupViewPopulatedTop
+	home.rebuildFlatItems()
+
+	var nums []int
+	for _, it := range home.flatItems {
+		if it.Type == session.ItemTypeGroup && it.Level == 0 && it.Path == "doozyx" {
+			nums = append(nums, it.RootGroupNum)
+		}
+	}
+	if len(nums) < 2 {
+		t.Fatalf("expected duplicate doozyx headers in partitioned view, got %v", nums)
+	}
+	for _, n := range nums[1:] {
+		if n != nums[0] {
+			t.Fatalf("duplicate root headers must reuse root number, got %v", nums)
 		}
 	}
 }

--- a/internal/ui/group_view_mode_wiring_test.go
+++ b/internal/ui/group_view_mode_wiring_test.go
@@ -31,19 +31,44 @@ func sessionIndexByTitle(h *Home, title string) int {
 	return -1
 }
 
-func TestActiveTopWiringSplitsList(t *testing.T) {
-	home, _ := buildTwoGroupHome(t)
+func setOnlySessionRunning(t *testing.T, h *Home, title string) {
+	t.Helper()
 
-	// a1 is the only active session; everything else is inactive.
-	home.instancesMu.RLock()
-	for _, inst := range home.instances {
-		if inst.Title == "a1" {
+	h.instancesMu.Lock()
+	defer h.instancesMu.Unlock()
+	for _, inst := range h.instances {
+		if inst.Title == title {
 			inst.Status = session.StatusRunning
 		} else {
 			inst.Status = session.StatusIdle
 		}
 	}
-	home.instancesMu.RUnlock()
+}
+
+func addRemoteFixture(h *Home) {
+	h.remoteSessionsMu.Lock()
+	defer h.remoteSessionsMu.Unlock()
+	h.remoteSessions = map[string][]session.RemoteSessionInfo{
+		"dev": {
+			{ID: "remote-1", Title: "remote one", RemoteName: "dev", Status: string(session.StatusRunning)},
+		},
+	}
+}
+
+func remoteSessionIndexByID(h *Home, id string) int {
+	for i, it := range h.flatItems {
+		if it.Type == session.ItemTypeRemoteSession && it.RemoteSession != nil && it.RemoteSession.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestActiveTopWiringSplitsList(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+
+	// a1 is the only active session; everything else is inactive.
+	setOnlySessionRunning(t, home, "a1")
 
 	home.groupViewMode = session.GroupViewActiveTop
 	home.rebuildFlatItems()
@@ -99,15 +124,7 @@ func TestActiveTopWiringCollapsedRunningGroupStaysTop(t *testing.T) {
 	// alpha holds a running session but is COLLAPSED (its session rows are not
 	// flattened). beta is expanded and idle. Regression guard: a collapsed group
 	// with running work must NOT sink below the "idle / done" divider.
-	home.instancesMu.RLock()
-	for _, inst := range home.instances {
-		if inst.Title == "a1" {
-			inst.Status = session.StatusRunning
-		} else {
-			inst.Status = session.StatusIdle
-		}
-	}
-	home.instancesMu.RUnlock()
+	setOnlySessionRunning(t, home, "a1")
 	home.groupTree.Groups["alpha"].Expanded = false
 
 	home.groupViewMode = session.GroupViewActiveTop
@@ -155,15 +172,7 @@ func TestCycleGroupViewKeyTogglesMode(t *testing.T) {
 
 func TestSkipDividerNavigationGlidesPast(t *testing.T) {
 	home, _ := buildTwoGroupHome(t)
-	home.instancesMu.RLock()
-	for _, inst := range home.instances {
-		if inst.Title == "a1" {
-			inst.Status = session.StatusRunning
-		} else {
-			inst.Status = session.StatusIdle
-		}
-	}
-	home.instancesMu.RUnlock()
+	setOnlySessionRunning(t, home, "a1")
 	home.groupViewMode = session.GroupViewActiveTop
 	home.rebuildFlatItems()
 
@@ -187,4 +196,83 @@ func TestSkipDividerNavigationGlidesPast(t *testing.T) {
 	if home.cursor != div-1 {
 		t.Fatalf("up across divider: cursor=%d, want %d", home.cursor, div-1)
 	}
+}
+
+func TestCycleGroupViewPreservesRemoteSessionSelection(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+	setOnlySessionRunning(t, home, "a1")
+	addRemoteFixture(home)
+	home.rebuildFlatItems()
+
+	remoteIdx := remoteSessionIndexByID(home, "remote-1")
+	if remoteIdx < 0 {
+		t.Fatalf("remote session missing before cycle; flatItems=%v", len(home.flatItems))
+	}
+	home.cursor = remoteIdx
+
+	home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+
+	if got := remoteSessionIndexByID(home, "remote-1"); got < 0 || home.cursor != got {
+		t.Fatalf("remote selection not preserved after view-mode cycle: cursor=%d remoteIdx=%d", home.cursor, got)
+	}
+}
+
+func TestMouseWheelSkipsDividerRows(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+	setOnlySessionRunning(t, home, "a1")
+	home.groupViewMode = session.GroupViewActiveTop
+	home.rebuildFlatItems()
+
+	div := dividerIndex(home)
+	if div <= 0 || div >= len(home.flatItems)-1 {
+		t.Fatalf("divider should be interior, got %d of %d", div, len(home.flatItems))
+	}
+	home.cursor = div - 1
+	home.width = 80
+
+	home.Update(tea.MouseMsg{Button: tea.MouseButtonWheelDown, Action: tea.MouseActionPress})
+
+	if home.cursor != div+1 {
+		t.Fatalf("mouse wheel down across divider: cursor=%d, want %d", home.cursor, div+1)
+	}
+	if home.flatItems[home.cursor].Type == session.ItemTypeDivider {
+		t.Fatal("mouse wheel navigation landed on divider")
+	}
+}
+
+func TestTickRepartitionsActiveTopAfterStatusChange(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+	setOnlySessionRunning(t, home, "a1")
+	home.groupViewMode = session.GroupViewActiveTop
+	home.rebuildFlatItems()
+
+	div := dividerIndex(home)
+	if div < 0 {
+		t.Fatalf("expected divider before status flip")
+	}
+	a2 := sessionIndexByTitle(home, "a2")
+	if a2 <= div {
+		t.Fatalf("a2 should start below divider: a2=%d divider=%d", a2, div)
+	}
+
+	home.instancesMu.Lock()
+	for _, inst := range home.instances {
+		if inst.Title == "a2" {
+			inst.Status = session.StatusRunning
+			break
+		}
+	}
+	home.instancesMu.Unlock()
+
+	home.Update(tickMsg{})
+
+	div = dividerIndex(home)
+	a2 = sessionIndexByTitle(home, "a2")
+	if div < 0 || a2 < 0 || a2 >= div {
+		t.Fatalf("a2 should move above divider after tick repartition: a2=%d divider=%d", a2, div)
+	}
+}
+
+func TestViewModePartitionRemoteSessionNotApplicable(t *testing.T) {
+	t.Skip("RemoteSession N/A: group view-mode partitioning runs before remote rows are appended; remote parity is selection preservation across rebuilds.")
 }

--- a/internal/ui/group_view_mode_wiring_test.go
+++ b/internal/ui/group_view_mode_wiring_test.go
@@ -1,0 +1,190 @@
+package ui
+
+// Wiring tests for the group view-mode partition (running-on-top / populated-on-top).
+// These exercise the real Home.rebuildFlatItems integration, the `t` keypress
+// dispatch, and divider-skip navigation — beyond the pure PartitionByViewMode
+// unit tests in the session package.
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func dividerIndex(h *Home) int {
+	for i, it := range h.flatItems {
+		if it.Type == session.ItemTypeDivider {
+			return i
+		}
+	}
+	return -1
+}
+
+func sessionIndexByTitle(h *Home, title string) int {
+	for i, it := range h.flatItems {
+		if it.Type == session.ItemTypeSession && it.Session != nil && it.Session.Title == title {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestActiveTopWiringSplitsList(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+
+	// a1 is the only active session; everything else is inactive.
+	home.instancesMu.RLock()
+	for _, inst := range home.instances {
+		if inst.Title == "a1" {
+			inst.Status = session.StatusRunning
+		} else {
+			inst.Status = session.StatusIdle
+		}
+	}
+	home.instancesMu.RUnlock()
+
+	home.groupViewMode = session.GroupViewActiveTop
+	home.rebuildFlatItems()
+
+	div := dividerIndex(home)
+	if div < 0 {
+		t.Fatalf("expected a divider when active and inactive sessions coexist; flatItems=%d", len(home.flatItems))
+	}
+	a1 := sessionIndexByTitle(home, "a1")
+	if a1 < 0 || a1 >= div {
+		t.Fatalf("active session a1 must be above the divider: a1=%d divider=%d", a1, div)
+	}
+	for _, title := range []string{"a2", "a3", "b1", "b2"} {
+		if idx := sessionIndexByTitle(home, title); idx < div {
+			t.Fatalf("inactive session %q must be below the divider: idx=%d divider=%d", title, idx, div)
+		}
+	}
+}
+
+func TestPopulatedTopWiringSinksEmptyGroup(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+
+	// Add an empty group with no sessions.
+	home.groupTree.CreateGroup("empties")
+	home.groupViewMode = session.GroupViewPopulatedTop
+	home.rebuildFlatItems()
+
+	div := dividerIndex(home)
+	if div < 0 {
+		t.Fatalf("expected a divider when an empty group exists alongside populated ones")
+	}
+	// All sessions must be above the divider (populated mode never splits sessions).
+	for _, title := range []string{"a1", "a2", "a3", "b1", "b2"} {
+		if idx := sessionIndexByTitle(home, title); idx < 0 || idx >= div {
+			t.Fatalf("session %q must be above the divider in populated mode: idx=%d divider=%d", title, idx, div)
+		}
+	}
+	// The empty group header must be below the divider.
+	emptyBelow := false
+	for i := div + 1; i < len(home.flatItems); i++ {
+		if home.flatItems[i].Type == session.ItemTypeGroup && home.flatItems[i].Path == "empties" {
+			emptyBelow = true
+		}
+	}
+	if !emptyBelow {
+		t.Fatal("empty group 'empties' must appear below the divider")
+	}
+}
+
+func TestActiveTopWiringCollapsedRunningGroupStaysTop(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+
+	// alpha holds a running session but is COLLAPSED (its session rows are not
+	// flattened). beta is expanded and idle. Regression guard: a collapsed group
+	// with running work must NOT sink below the "idle / done" divider.
+	home.instancesMu.RLock()
+	for _, inst := range home.instances {
+		if inst.Title == "a1" {
+			inst.Status = session.StatusRunning
+		} else {
+			inst.Status = session.StatusIdle
+		}
+	}
+	home.instancesMu.RUnlock()
+	home.groupTree.Groups["alpha"].Expanded = false
+
+	home.groupViewMode = session.GroupViewActiveTop
+	home.rebuildFlatItems()
+
+	div := dividerIndex(home)
+	if div < 0 {
+		t.Fatalf("expected a divider; flatItems=%d", len(home.flatItems))
+	}
+	alphaIdx := -1
+	for i, it := range home.flatItems {
+		if it.Type == session.ItemTypeGroup && it.Path == "alpha" {
+			alphaIdx = i
+		}
+	}
+	if alphaIdx < 0 {
+		t.Fatal("collapsed alpha header missing from flatItems")
+	}
+	if alphaIdx >= div {
+		t.Fatalf("collapsed running group 'alpha' must stay ABOVE the divider: alpha=%d divider=%d", alphaIdx, div)
+	}
+}
+
+func TestCycleGroupViewKeyTogglesMode(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+	if home.groupViewMode != session.GroupViewNormal {
+		t.Fatalf("expected initial mode Normal, got %v", home.groupViewMode)
+	}
+	press := func() {
+		home.handleMainKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	}
+	press()
+	if home.groupViewMode != session.GroupViewActiveTop {
+		t.Fatalf("after 1 press expected ActiveTop, got %v", home.groupViewMode)
+	}
+	press()
+	if home.groupViewMode != session.GroupViewPopulatedTop {
+		t.Fatalf("after 2 presses expected PopulatedTop, got %v", home.groupViewMode)
+	}
+	press()
+	if home.groupViewMode != session.GroupViewNormal {
+		t.Fatalf("after 3 presses expected Normal again, got %v", home.groupViewMode)
+	}
+}
+
+func TestSkipDividerNavigationGlidesPast(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+	home.instancesMu.RLock()
+	for _, inst := range home.instances {
+		if inst.Title == "a1" {
+			inst.Status = session.StatusRunning
+		} else {
+			inst.Status = session.StatusIdle
+		}
+	}
+	home.instancesMu.RUnlock()
+	home.groupViewMode = session.GroupViewActiveTop
+	home.rebuildFlatItems()
+
+	div := dividerIndex(home)
+	if div <= 0 || div >= len(home.flatItems)-1 {
+		t.Fatalf("divider should be interior, got %d of %d", div, len(home.flatItems))
+	}
+
+	// Cursor immediately above the divider; pressing down must skip onto div+1.
+	home.cursor = div - 1
+	home.handleMainKey(tea.KeyMsg{Type: tea.KeyDown})
+	if home.cursor != div+1 {
+		t.Fatalf("down across divider: cursor=%d, want %d (skipping divider at %d)", home.cursor, div+1, div)
+	}
+	if home.flatItems[home.cursor].Type == session.ItemTypeDivider {
+		t.Fatal("cursor landed on a divider after navigating down")
+	}
+
+	// And back up must skip onto div-1.
+	home.handleMainKey(tea.KeyMsg{Type: tea.KeyUp})
+	if home.cursor != div-1 {
+		t.Fatalf("up across divider: cursor=%d, want %d", home.cursor, div-1)
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -185,6 +185,7 @@ func (h *HelpOverlay) View() string {
 	pluginKey := h.key(hotkeyPluginManager, "L")
 	skillsKey := h.key(hotkeySkillsManager, "s")
 	previewKey := h.key(hotkeyTogglePreview, "v")
+	groupViewKey := h.key(hotkeyCycleGroupView, "t")
 	unreadKey := h.key(hotkeyMarkUnread, "u")
 	quickApproveKey := h.key(hotkeyQuickApprove, "a")
 	copyKey := h.key(hotkeyCopyOutput, "c")
@@ -296,6 +297,7 @@ func (h *HelpOverlay) View() string {
 				{"/waiting", "Filter waiting"},
 				{"/running", "Filter running"},
 				{"/idle", "Filter idle"},
+				{groupViewKey, "Cycle view: active-on-top / populated-on-top"},
 			},
 		},
 		{

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -129,6 +129,14 @@ const (
 	spacingLarge  = 4 // Between major areas (e.g., info sections in preview)
 )
 
+// leftGutterWidth is the fixed cell width reserved at the start of every
+// left-panel row for a root group's hotkey number ("N·"). Reserving it on all
+// rows — even those without a number — keeps per-level indentation honest: a
+// numbered root no longer steals an indent level from its children, so nesting
+// reads consistently whether or not the root carries a hotkey. Must equal the
+// rendered width of the "N·" hotkey label.
+const leftGutterWidth = 2
+
 // Minimum terminal size requirements (reduced for mobile support)
 const (
 	minTerminalWidth  = 40 // Reduced from 80 - supports mobile terminals
@@ -1592,6 +1600,11 @@ func (h *Home) restoreState(state reloadState) {
 			h.cursor = 0
 		}
 	}
+
+	// The clamp above can land the cursor on a non-selectable divider row
+	// (dividers carry a nil Session). Nudge off it so the initial preview shows
+	// a real session rather than the empty state, mirroring j/k navigation.
+	h.skipDivider(1)
 
 	// Restore scroll position (clamped to valid range)
 	if len(h.flatItems) > 0 {
@@ -4360,6 +4373,13 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 							}
 						}
 					}
+					// The restored/leftover cursor can sit on a non-selectable
+					// divider row (present only in non-Normal view modes) — e.g.
+					// when the persisted session no longer exists and no group
+					// path matched, leaving the cursor at a stale index. Nudge
+					// off it so the first preview shows a real session. No-op
+					// when already on a selectable row.
+					h.skipDivider(1)
 					h.pendingCursorRestore = nil
 					h.syncViewport()
 				}
@@ -13735,8 +13755,18 @@ func (h *Home) renderGroupItem(
 ) {
 	group := item.Group
 
-	// Calculate indentation based on nesting level (no tree lines, just spaces)
-	// Uses spacingNormal (2 chars) per level for consistent hierarchy visualization
+	// Fixed-width hotkey gutter, reserved on every row (see leftGutterWidth). It
+	// holds the root group's hotkey number ("N·") when present; otherwise blanks.
+	// Keeping it a constant width means the number no longer eats a level of
+	// indentation, so a numbered root and its children stay properly nested.
+	gutter := strings.Repeat(" ", leftGutterWidth)
+	if item.Level == 0 && !selected && item.RootGroupNum >= 1 && item.RootGroupNum <= 9 {
+		gutter = GroupHotkeyStyle.Render(fmt.Sprintf("%d·", item.RootGroupNum))
+	}
+
+	// Calculate indentation based on nesting level (no tree lines, just spaces).
+	// Uses spacingNormal (2 chars) per level for consistent hierarchy
+	// visualization, applied after the hotkey gutter.
 	indent := strings.Repeat(strings.Repeat(" ", spacingNormal), max(0, item.Level))
 
 	// Expand/collapse indicator with filled triangles (using cached styles)
@@ -13752,15 +13782,6 @@ func (h *Home) renderGroupItem(
 			expandIcon = GroupExpandStyle.Render("▾") // Filled triangle for expanded
 		} else {
 			expandIcon = GroupExpandStyle.Render("▸") // Filled triangle for collapsed
-		}
-	}
-
-	// Hotkey indicator (subtle, only for root groups, hidden when selected)
-	// Uses pre-computed RootGroupNum from rebuildFlatItems() - O(1) lookup instead of O(n) loop
-	hotkeyStr := ""
-	if item.Level == 0 && !selected {
-		if item.RootGroupNum >= 1 && item.RootGroupNum <= 9 {
-			hotkeyStr = GroupHotkeyStyle.Render(fmt.Sprintf("%d·", item.RootGroupNum))
 		}
 	}
 
@@ -13784,11 +13805,11 @@ func (h *Home) renderGroupItem(
 		statusStr += " " + GroupStatusWaiting.Render(fmt.Sprintf("◐ %d", stats.waiting))
 	}
 
-	// Build the row: [indent][hotkey][expand] [name](count) [status]
+	// Build the row: [hotkey gutter][indent][expand] [name](count) [status]
 	row := fmt.Sprintf(
 		"%s%s%s %s%s%s",
+		gutter,
 		indent,
-		hotkeyStr,
 		expandIcon,
 		nameStyle.Render(group.Name),
 		countStr,
@@ -13865,6 +13886,9 @@ func (h *Home) renderCreatingSessionItem(
 ) {
 	spinnerFrames := []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 	spinner := spinnerFrames[h.animationFrame]
+
+	// Leading hotkey gutter so creating rows align with group/session rows.
+	b.WriteString(strings.Repeat(" ", leftGutterWidth))
 
 	// Selection styling
 	if selected {
@@ -14164,9 +14188,12 @@ func (h *Home) renderSessionItem(
 		windowChevron = chevronStyle.Render(chevronChar)
 	}
 
-	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [badges]
+	// Build row: [gutter][baseIndent][selection][tree][chevron][status] [title] [tool] [badges]
+	// The leading gutter (leftGutterWidth) keeps sessions aligned with group
+	// rows, which reserve the same gutter for root hotkey numbers.
 	row := fmt.Sprintf(
-		"%s%s%s%s%s %s%s%s%s%s%s%s%s%s",
+		"%s%s%s%s%s%s %s%s%s%s%s%s%s%s%s",
+		strings.Repeat(" ", leftGutterWidth),
 		baseIndent,
 		selectionPrefix,
 		treeStyle.Render(treeConnector),
@@ -14264,7 +14291,8 @@ func (h *Home) renderWindowItem(b *strings.Builder, item session.Item, selected 
 	}
 
 	row := fmt.Sprintf(
-		"%s%s%s %s%s%s",
+		"%s%s%s%s %s%s%s",
+		strings.Repeat(" ", leftGutterWidth), // align with group/session hotkey gutter
 		baseIndent,
 		selectionPrefix,
 		treeStyle.Render(treeConnector),
@@ -14390,7 +14418,8 @@ func (h *Home) renderRemoteGroupItem(b *strings.Builder, item session.Item, sele
 		selPrefix = "▶ "
 	}
 
-	b.WriteString(fmt.Sprintf("%s%s %s%s%s\n",
+	b.WriteString(fmt.Sprintf("%s%s%s %s%s%s\n",
+		strings.Repeat(" ", leftGutterWidth), // align with group hotkey gutter
 		selPrefix,
 		expandIcon,
 		nameStyle.Render("remotes/"+item.RemoteName),
@@ -14499,7 +14528,8 @@ func (h *Home) renderRemoteSessionItem(b *strings.Builder, item session.Item, se
 		selPrefix = "▶ "
 	}
 
-	b.WriteString(fmt.Sprintf("%s  %s %s %s%s\n",
+	b.WriteString(fmt.Sprintf("%s%s  %s %s %s%s\n",
+		strings.Repeat(" ", leftGutterWidth), // align with group/session hotkey gutter
 		selPrefix,
 		DimStyle.Render(treeConnector),
 		sStyle.Render(statusIcon),
@@ -14935,6 +14965,24 @@ func (h *Home) renderPreviewPane(width, height int) string {
 			return h.renderCreatingPreview(creating, width, height)
 		}
 		return ""
+	}
+
+	// Defensive: dividers and any other non-session rows carry a nil Session.
+	// The cursor should never come to rest on one (skipDivider on navigation,
+	// and the restore/clamp below nudges off dividers), but View() must be total
+	// over every flatItems state and must never panic. Mirror the "No Selection"
+	// empty state used when the cursor is out of range.
+	if item.Session == nil {
+		content := renderEmptyStateResponsive(EmptyStateConfig{
+			Icon:     "◇",
+			Title:    "No Selection",
+			Subtitle: "Select a session to preview",
+			Hints:    nil,
+		}, width, height)
+		if statsBlock := h.renderSystemStatsBlock(width); statsBlock != "" {
+			content += "\n" + statsBlock
+		}
+		return content
 	}
 
 	// Session preview

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -627,6 +627,9 @@ type selectedItemIdentity struct {
 	sessionID       string
 	windowSessionID string
 	windowIndex     int
+	remoteName      string
+	remoteSessionID string
+	remoteGroupPath string
 }
 
 func (h *Home) saveToolVisibilityConfig() error {
@@ -1699,6 +1702,14 @@ func (h *Home) captureSelectedItemIdentity() selectedItemIdentity {
 	case session.ItemTypeWindow:
 		identity.windowSessionID = item.WindowSessionID
 		identity.windowIndex = item.WindowIndex
+	case session.ItemTypeRemoteGroup:
+		identity.remoteName = item.RemoteName
+		identity.remoteGroupPath = item.Path
+	case session.ItemTypeRemoteSession:
+		if item.RemoteSession != nil {
+			identity.remoteName = item.RemoteName
+			identity.remoteSessionID = item.RemoteSession.ID
+		}
 	}
 	return identity
 }
@@ -1713,6 +1724,12 @@ func (h *Home) restoreSelectedItemIdentity(identity selectedItemIdentity) bool {
 			h.cursor = i
 			return true
 		case identity.groupPath != "" && item.Type == session.ItemTypeGroup && item.Path == identity.groupPath:
+			h.cursor = i
+			return true
+		case identity.remoteSessionID != "" && item.Type == session.ItemTypeRemoteSession && item.RemoteSession != nil && item.RemoteName == identity.remoteName && item.RemoteSession.ID == identity.remoteSessionID:
+			h.cursor = i
+			return true
+		case identity.remoteGroupPath != "" && item.Type == session.ItemTypeRemoteGroup && item.RemoteName == identity.remoteName && item.Path == identity.remoteGroupPath:
 			h.cursor = i
 			return true
 		}
@@ -1906,11 +1923,23 @@ func (h *Home) rebuildFlatItems() {
 		}
 	}
 
-	// Pre-compute root group numbers for O(1) hotkey lookup (replaces O(n) loop in renderGroupItem)
+	// Pre-compute root group numbers for O(1) hotkey lookup (replaces O(n) loop in renderGroupItem).
+	// View-mode partitioning can duplicate root headers; every copy of the same
+	// logical root reuses the same digit.
 	rootNum := 0
+	rootNums := make(map[string]int)
 	for i := range h.flatItems {
 		if h.flatItems[i].Type == session.ItemTypeGroup && h.flatItems[i].Level == 0 {
+			rootKey := h.flatItems[i].Path
+			if rootKey == "" && h.flatItems[i].Group != nil {
+				rootKey = h.flatItems[i].Group.Path
+			}
+			if n, ok := rootNums[rootKey]; ok {
+				h.flatItems[i].RootGroupNum = n
+				continue
+			}
 			rootNum++
+			rootNums[rootKey] = rootNum
 			h.flatItems[i].RootGroupNum = rootNum
 		}
 	}
@@ -4127,6 +4156,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.Button == tea.MouseButtonWheelUp {
 				if h.cursor > 0 {
 					h.cursor--
+					h.skipDivider(-1)
 					h.previewScrollOffset = 0
 					h.syncViewport()
 					h.markNavigationActivity()
@@ -4135,6 +4165,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				if h.cursor < len(h.flatItems)-1 {
 					h.cursor++
+					h.skipDivider(1)
 					h.previewScrollOffset = 0
 					h.syncViewport()
 					h.markNavigationActivity()
@@ -5439,6 +5470,11 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var remoteFetchCmd tea.Cmd
 		var remoteLatencyCmd tea.Cmd
 
+		if h.groupViewMode != session.GroupViewNormal {
+			selectedBefore := h.captureSelectedItemIdentity()
+			h.rebuildFlatItemsPreservingSelection(selectedBefore)
+		}
+
 		// Auto-dismiss errors after 5 seconds
 		if h.err != nil && !h.errTime.IsZero() && time.Since(h.errTime) > 5*time.Second {
 			h.clearError()
@@ -6432,6 +6468,16 @@ func jumpItemName(item session.Item) string {
 	return ""
 }
 
+func selectableItemIndices(items []session.Item) []int {
+	indices := make([]int, 0, len(items))
+	for i, item := range items {
+		if item.Type != session.ItemTypeDivider {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}
+
 // handleJumpKey processes key input during jump mode.
 func (h *Home) handleJumpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
@@ -6444,11 +6490,12 @@ func (h *Home) handleJumpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case len(key) == 1 && key[0] >= 'a' && key[0] <= 'z':
 		h.jumpBuffer += key
-		hints := generateJumpHints(len(h.flatItems))
+		selectable := selectableItemIndices(h.flatItems)
+		hints := generateJumpHints(len(selectable))
 		result := matchJumpHint(hints, h.jumpBuffer)
 
 		if result.matched {
-			h.cursor = result.index
+			h.cursor = selectable[result.index]
 			h.skipDivider(1) // never land on a non-selectable divider
 			h.syncViewport()
 			h.jumpMode = false
@@ -7730,27 +7777,10 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "t":
 		// Cycle list partition: normal → active-on-top → populated-on-top → normal.
-		// Preserve the cursor's session/group across the rebuild.
-		var keepSessionID, keepGroupPath string
-		if h.cursor >= 0 && h.cursor < len(h.flatItems) {
-			switch it := h.flatItems[h.cursor]; it.Type {
-			case session.ItemTypeSession:
-				if it.Session != nil {
-					keepSessionID = it.Session.ID
-				}
-			case session.ItemTypeWindow:
-				keepSessionID = it.WindowSessionID
-			case session.ItemTypeGroup:
-				keepGroupPath = it.Path
-			}
-		}
+		// Preserve the cursor's row identity across the rebuild.
+		selectedBefore := h.captureSelectedItemIdentity()
 		h.groupViewMode = session.GroupViewMode((int(h.groupViewMode) + 1) % session.GroupViewModeCount)
-		h.rebuildFlatItems()
-		if keepSessionID != "" {
-			h.moveCursorToSession(keepSessionID)
-		} else if keepGroupPath != "" {
-			h.moveCursorToGroup(keepGroupPath)
-		}
+		h.rebuildFlatItemsPreservingSelection(selectedBefore)
 		h.skipDivider(1)
 		h.syncViewport()
 		h.saveUIState()
@@ -13592,19 +13622,29 @@ func (h *Home) renderSessionList(width, height int) string {
 
 	snapshot := h.getSessionRenderSnapshot()
 	groupStats := h.buildGroupRenderStats(snapshot)
-	var jumpHints []string
+	var jumpHintByItemIndex map[int]string
 	if h.jumpMode {
-		jumpHints = generateJumpHints(len(h.flatItems))
+		selectable := selectableItemIndices(h.flatItems)
+		jumpHints := generateJumpHints(len(selectable))
+		jumpHintByItemIndex = make(map[int]string, len(selectable))
+		for hintIndex, itemIndex := range selectable {
+			jumpHintByItemIndex[itemIndex] = jumpHints[hintIndex]
+		}
 	}
 
 	for i := h.viewOffset; i < len(h.flatItems) && visibleCount < maxVisible; i++ {
 		item := h.flatItems[i]
-		if h.jumpMode && i < len(jumpHints) && item.Type != session.ItemTypeDivider {
+		if h.jumpMode && item.Type != session.ItemTypeDivider {
+			hint, ok := jumpHintByItemIndex[i]
+			if !ok {
+				h.renderItem(&b, item, i == h.cursor, i, groupStats, snapshot, width)
+				visibleCount++
+				continue
+			}
 			// Render item to temp buffer, then overlay hint badge at name position
 			var itemBuf strings.Builder
 			h.renderItem(&itemBuf, item, i == h.cursor, i, groupStats, snapshot, width)
 			raw := itemBuf.String()
-			hint := jumpHints[i]
 			isMatch := h.jumpBuffer == "" || strings.HasPrefix(hint, h.jumpBuffer)
 
 			if isMatch {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -258,15 +258,16 @@ type Home struct {
 	analyticsCacheTime     map[string]time.Time                       // TTL cache: sessionID -> cache timestamp
 
 	// State
-	cursor              int            // Selected item index in flatItems
-	viewOffset          int            // First visible item index (for scrolling)
-	previewScrollOffset int            // Lines scrolled up from tail in the preview pane (#574). 0 = tail (default). Reset on cursor move.
-	isAttaching         atomic.Bool    // Prevents View() output during attach (fixes Bubble Tea Issue #431) - atomic for thread safety
-	statusFilter        session.Status // Filter sessions by status ("" = all, or specific status)
-	groupScope          string         // Limit TUI to a specific group path ("" = all groups)
-	initialSelect       string         // Session ID or title to preselect on first load (#709). Does NOT scope groups.
-	initialSelectDone   bool           // Guard so preselection only fires once
-	previewMode         PreviewMode    // What to show in preview pane (both, output-only, analytics-only)
+	cursor              int                   // Selected item index in flatItems
+	viewOffset          int                   // First visible item index (for scrolling)
+	previewScrollOffset int                   // Lines scrolled up from tail in the preview pane (#574). 0 = tail (default). Reset on cursor move.
+	isAttaching         atomic.Bool           // Prevents View() output during attach (fixes Bubble Tea Issue #431) - atomic for thread safety
+	statusFilter        session.Status        // Filter sessions by status ("" = all, or specific status)
+	groupScope          string                // Limit TUI to a specific group path ("" = all groups)
+	initialSelect       string                // Session ID or title to preselect on first load (#709). Does NOT scope groups.
+	initialSelectDone   bool                  // Guard so preselection only fires once
+	previewMode         PreviewMode           // What to show in preview pane (both, output-only, analytics-only)
+	groupViewMode       session.GroupViewMode // List partition: normal, active-on-top, populated-on-top (cycled by hotkey 't')
 	err                 error
 	errTime             time.Time  // When error occurred (for auto-dismiss)
 	isReloading         bool       // Visual feedback during auto-reload
@@ -610,6 +611,7 @@ type uiState struct {
 	CursorGroupPath string `json:"cursor_group_path,omitempty"`
 	PreviewMode     int    `json:"preview_mode"`
 	StatusFilter    string `json:"status_filter,omitempty"`
+	GroupViewMode   int    `json:"group_view_mode,omitempty"`
 }
 
 type selectedItemIdentity struct {
@@ -1622,6 +1624,41 @@ func (h *Home) moveCursorToSession(sessionID string) {
 	}
 }
 
+// skipDivider nudges the cursor off a non-selectable divider row in the given
+// direction (+1 = down, -1 = up). Dividers only ever sit between two non-empty
+// sections, so they are never at a list edge nor adjacent to another divider;
+// a single step in the travel direction always lands on a selectable row. The
+// extra scan is defensive only.
+func (h *Home) skipDivider(dir int) {
+	n := len(h.flatItems)
+	if n == 0 {
+		return
+	}
+	if h.cursor < 0 {
+		h.cursor = 0
+	}
+	if h.cursor >= n {
+		h.cursor = n - 1
+	}
+	if h.flatItems[h.cursor].Type != session.ItemTypeDivider {
+		return
+	}
+	h.cursor += dir
+	if h.cursor < 0 {
+		h.cursor = 0
+	}
+	if h.cursor >= n {
+		h.cursor = n - 1
+	}
+	// Defensive: if somehow still on a divider, scan toward a selectable row.
+	for h.cursor < n-1 && h.flatItems[h.cursor].Type == session.ItemTypeDivider {
+		h.cursor++
+	}
+	for h.cursor > 0 && h.flatItems[h.cursor].Type == session.ItemTypeDivider {
+		h.cursor--
+	}
+}
+
 // moveCursorToGroup moves the cursor to the flat item matching the given group path.
 func (h *Home) moveCursorToGroup(path string) {
 	for i, fi := range h.flatItems {
@@ -1772,6 +1809,17 @@ func (h *Home) rebuildFlatItems() {
 			}
 		}
 		h.flatItems = scoped
+	}
+
+	// Partition into top/bottom sections by view mode (active-on-top / populated-on-top).
+	// Runs after filtering/scoping but before window injection so windows follow
+	// their parent session into whichever section it lands in.
+	if h.groupViewMode != session.GroupViewNormal {
+		// Activity is computed from the full tree (collapse-agnostic) so a
+		// collapsed-but-populated group's header is placed by its real contents,
+		// not by the (absent) session rows under a collapsed header.
+		activity := h.groupTree.GroupActivityMap()
+		h.flatItems = session.PartitionByViewMode(h.flatItems, h.groupViewMode, activity)
 	}
 
 	// Inject window items after sessions that have 2+ windows
@@ -6381,12 +6429,13 @@ func (h *Home) handleJumpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		if result.matched {
 			h.cursor = result.index
+			h.skipDivider(1) // never land on a non-selectable divider
 			h.syncViewport()
 			h.jumpMode = false
 			h.jumpBuffer = ""
 			// For sessions/windows/remotes: attach directly.
 			// For groups: just move cursor (user can press Enter to toggle).
-			item := h.flatItems[result.index]
+			item := h.flatItems[h.cursor]
 			if item.Type != session.ItemTypeGroup && item.Type != session.ItemTypeRemoteGroup {
 				return h.handleMainKey(tea.KeyMsg{Type: tea.KeyEnter})
 			}
@@ -6465,6 +6514,10 @@ func (h *Home) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 		itemIndex := h.mouseYToItemIndex(msg.Y)
 		if itemIndex < 0 || itemIndex >= len(h.flatItems) {
+			return h, nil
+		}
+		// Dividers are non-selectable: clicking one does nothing.
+		if h.flatItems[itemIndex].Type == session.ItemTypeDivider {
 			return h, nil
 		}
 
@@ -6634,6 +6687,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.previewScrollOffset = 0
 		if h.cursor > 0 {
 			h.cursor--
+			h.skipDivider(-1)
 			h.syncViewport()
 			h.markNavigationActivity()
 			// PERFORMANCE: Debounced preview fetch - waits 150ms for navigation to settle
@@ -6646,6 +6700,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		h.previewScrollOffset = 0
 		if h.cursor < len(h.flatItems)-1 {
 			h.cursor++
+			h.skipDivider(1)
 			h.syncViewport()
 			h.markNavigationActivity()
 			// PERFORMANCE: Debounced preview fetch - waits 150ms for navigation to settle
@@ -6664,6 +6719,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < 0 {
 			h.cursor = 0
 		}
+		h.skipDivider(-1)
 		h.previewScrollOffset = 0
 		h.syncViewport()
 		h.markNavigationActivity()
@@ -6681,6 +6737,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < 0 {
 			h.cursor = 0
 		}
+		h.skipDivider(1)
 		h.previewScrollOffset = 0
 		h.syncViewport()
 		h.markNavigationActivity()
@@ -6695,6 +6752,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < 0 {
 			h.cursor = 0
 		}
+		h.skipDivider(-1)
 		h.previewScrollOffset = 0
 		h.syncViewport()
 		h.markNavigationActivity()
@@ -6712,6 +6770,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < 0 {
 			h.cursor = 0
 		}
+		h.skipDivider(1)
 		h.previewScrollOffset = 0
 		h.syncViewport()
 		h.markNavigationActivity()
@@ -6719,6 +6778,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "home": // Jump to first item
 		h.cursor = 0
+		h.skipDivider(1)
 		h.previewScrollOffset = 0
 		h.syncViewport()
 		h.markNavigationActivity()
@@ -6729,6 +6789,7 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if h.cursor < 0 {
 			h.cursor = 0
 		}
+		h.skipDivider(-1)
 		h.previewScrollOffset = 0
 		h.syncViewport()
 		h.markNavigationActivity()
@@ -7646,6 +7707,34 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Toggle preview mode (cycle: both → output-only → analytics-only → both)
 		h.previewMode = (h.previewMode + 1) % 3
 		return h, nil
+
+	case "t":
+		// Cycle list partition: normal → active-on-top → populated-on-top → normal.
+		// Preserve the cursor's session/group across the rebuild.
+		var keepSessionID, keepGroupPath string
+		if h.cursor >= 0 && h.cursor < len(h.flatItems) {
+			switch it := h.flatItems[h.cursor]; it.Type {
+			case session.ItemTypeSession:
+				if it.Session != nil {
+					keepSessionID = it.Session.ID
+				}
+			case session.ItemTypeWindow:
+				keepSessionID = it.WindowSessionID
+			case session.ItemTypeGroup:
+				keepGroupPath = it.Path
+			}
+		}
+		h.groupViewMode = session.GroupViewMode((int(h.groupViewMode) + 1) % session.GroupViewModeCount)
+		h.rebuildFlatItems()
+		if keepSessionID != "" {
+			h.moveCursorToSession(keepSessionID)
+		} else if keepGroupPath != "" {
+			h.moveCursorToGroup(keepGroupPath)
+		}
+		h.skipDivider(1)
+		h.syncViewport()
+		h.saveUIState()
+		return h, h.fetchSelectedPreview()
 
 	case "y":
 		// Toggle YOLO mode for Gemini or Codex sessions (requires restart)
@@ -9277,8 +9366,9 @@ func (h *Home) saveUIState() {
 	}
 
 	state := uiState{
-		PreviewMode:  int(h.previewMode),
-		StatusFilter: string(h.statusFilter),
+		PreviewMode:   int(h.previewMode),
+		StatusFilter:  string(h.statusFilter),
+		GroupViewMode: int(h.groupViewMode),
 	}
 
 	// Capture cursor position
@@ -9329,9 +9419,13 @@ func (h *Home) loadUIState() {
 		return
 	}
 
-	// Apply preview mode and status filter immediately
+	// Apply preview mode, status filter, and group view mode immediately
 	h.previewMode = PreviewMode(state.PreviewMode)
 	h.statusFilter = session.Status(state.StatusFilter)
+	h.groupViewMode = session.GroupViewMode(state.GroupViewMode)
+	if h.groupViewMode < session.GroupViewNormal || h.groupViewMode >= session.GroupViewModeCount {
+		h.groupViewMode = session.GroupViewNormal
+	}
 
 	// Defer cursor restoration until flatItems are populated
 	h.pendingCursorRestore = &state
@@ -13485,7 +13579,7 @@ func (h *Home) renderSessionList(width, height int) string {
 
 	for i := h.viewOffset; i < len(h.flatItems) && visibleCount < maxVisible; i++ {
 		item := h.flatItems[i]
-		if h.jumpMode && i < len(jumpHints) {
+		if h.jumpMode && i < len(jumpHints) && item.Type != session.ItemTypeDivider {
 			// Render item to temp buffer, then overlay hint badge at name position
 			var itemBuf strings.Builder
 			h.renderItem(&itemBuf, item, i == h.cursor, i, groupStats, snapshot, width)
@@ -13603,7 +13697,31 @@ func (h *Home) renderItem(
 		h.renderRemoteGroupItem(b, item, selected)
 	case session.ItemTypeRemoteSession:
 		h.renderRemoteSessionItem(b, item, selected)
+	case session.ItemTypeDivider:
+		h.renderDivider(b, item)
 	}
+}
+
+// renderDivider renders the non-selectable separator between view-mode sections
+// (e.g. running-on-top). It draws a dim horizontal rule with an optional caption.
+func (h *Home) renderDivider(b *strings.Builder, item session.Item) {
+	width := h.sessionsPaneWidth() - 4
+	if width < 12 {
+		width = 12
+	}
+	var line string
+	if item.DividerLabel != "" {
+		text := "─ " + item.DividerLabel + " "
+		remaining := width - cellWidth(text)
+		if remaining < 0 {
+			remaining = 0
+		}
+		line = "  " + text + strings.Repeat("─", remaining)
+	} else {
+		line = "  " + strings.Repeat("─", width)
+	}
+	b.WriteString(DimStyle.Render(line))
+	b.WriteString("\n")
 }
 
 // renderGroupItem renders a group header
@@ -16841,7 +16959,7 @@ func (h *Home) renderFilterBarHint() string {
 		return dim.Render(c)
 	}
 
-	return dim.Render("  ") +
+	hint := dim.Render("  ") +
 		mark("!", h.statusFilter == session.StatusRunning) +
 		mark("@", h.statusFilter == session.StatusWaiting) +
 		mark("#", h.statusFilter == session.StatusIdle) +
@@ -16853,4 +16971,12 @@ func (h *Home) renderFilterBarHint() string {
 		dim.Render(" open • ") +
 		mark(FilterKeyArchived, h.statusFilter == FilterModeArchived) +
 		dim.Render(" archived")
+
+	// View-mode indicator (running-on-top / populated-on-top), only when active.
+	if h.groupViewMode != session.GroupViewNormal {
+		hint += dim.Render(" • ") + mark("t", true) + dim.Render(" "+h.groupViewMode.Label())
+	} else {
+		hint += dim.Render(" • ") + mark("t", false) + dim.Render(" view")
+	}
+	return hint
 }

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -25,6 +25,7 @@ const (
 	hotkeyPluginManager    = "plugin_manager"
 	hotkeySkillsManager    = "skills_manager"
 	hotkeyTogglePreview    = "toggle_preview"
+	hotkeyCycleGroupView   = "cycle_group_view"
 	hotkeyMarkUnread       = "mark_unread"
 	hotkeyQuickApprove     = "quick_approve"
 	hotkeyToggleYolo       = "toggle_yolo"
@@ -66,6 +67,7 @@ var hotkeyActionOrder = []string{
 	hotkeyPluginManager,
 	hotkeySkillsManager,
 	hotkeyTogglePreview,
+	hotkeyCycleGroupView,
 	hotkeyMarkUnread,
 	hotkeyQuickApprove,
 	hotkeyToggleYolo,
@@ -107,6 +109,7 @@ var defaultHotkeyBindings = map[string]string{
 	hotkeyPluginManager:    "L",
 	hotkeySkillsManager:    "s",
 	hotkeyTogglePreview:    "v",
+	hotkeyCycleGroupView:   "t",
 	hotkeyMarkUnread:       "u",
 	hotkeyQuickApprove:     "a",
 	hotkeyToggleYolo:       "y",

--- a/internal/ui/jump_test.go
+++ b/internal/ui/jump_test.go
@@ -1,7 +1,10 @@
 package ui
 
 import (
+	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
@@ -168,6 +171,50 @@ func TestJumpHintMatchAllSingleChar(t *testing.T) {
 		if !got.matched || got.index != i {
 			t.Errorf("matchJumpHint(%q) with 5 hints = %+v, want match at %d", h, got, i)
 		}
+	}
+}
+
+func TestJumpModeRenderDoesNotSpendHintOnDivider(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 20
+	home.initialLoading = false
+	home.jumpMode = true
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeGroup, Group: &session.Group{Name: "alpha", Path: "alpha"}, Path: "alpha", Level: 0},
+		{Type: session.ItemTypeDivider, DividerLabel: "idle / done"},
+		{Type: session.ItemTypeGroup, Group: &session.Group{Name: "beta", Path: "beta"}, Path: "beta", Level: 0},
+	}
+
+	rendered := home.renderSessionList(120, 20)
+	selectableHints := generateJumpHints(2)
+	allRowHints := generateJumpHints(3)
+
+	if !strings.Contains(rendered, selectableHints[1]) {
+		t.Fatalf("rendered jump hints should include second selectable hint %q\n--- render ---\n%s", selectableHints[1], rendered)
+	}
+	if selectableHints[1] != allRowHints[2] && strings.Contains(rendered, allRowHints[2]) {
+		t.Fatalf("rendered jump hints consumed divider row hint %q\n--- render ---\n%s", allRowHints[2], rendered)
+	}
+}
+
+func TestJumpKeyDoesNotSpendHintOnDivider(t *testing.T) {
+	home := NewHome()
+	home.width = 120
+	home.height = 20
+	home.initialLoading = false
+	home.jumpMode = true
+	home.flatItems = []session.Item{
+		{Type: session.ItemTypeGroup, Group: &session.Group{Name: "alpha", Path: "alpha"}, Path: "alpha", Level: 0},
+		{Type: session.ItemTypeDivider, DividerLabel: "idle / done"},
+		{Type: session.ItemTypeGroup, Group: &session.Group{Name: "beta", Path: "beta"}, Path: "beta", Level: 0},
+	}
+	hint := generateJumpHints(2)[1]
+
+	home.handleJumpKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(hint)})
+
+	if home.cursor != 2 {
+		t.Fatalf("second selectable jump hint should land on beta at index 2, got cursor=%d", home.cursor)
 	}
 }
 

--- a/internal/ui/preview_divider_test.go
+++ b/internal/ui/preview_divider_test.go
@@ -1,0 +1,81 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Regression: the preview pane must not panic when the cursor lands on a
+// non-selectable divider row (ItemTypeDivider carries a nil Session). Dividers
+// are injected by the view-mode partition feature and the cursor can come to
+// rest on one after a state-restore/clamp (e.g. when the previously-selected
+// session is now hidden by the archive filter), before any j/k navigation runs
+// skipDivider. renderPreviewPane previously fell through every type check to
+// `selected := item.Session` and dereferenced nil. See startup panic at
+// home.go:13362.
+func TestPreviewPane_DividerAtCursor_NoPanic(t *testing.T) {
+	h := NewHome()
+	h.width = 120
+	h.height = 40
+	h.initialLoading = false
+
+	h.flatItems = []session.Item{
+		{Type: session.ItemTypeDivider, DividerLabel: "idle / done"},
+	}
+	h.cursor = 0
+	h.setHotkeys(resolveHotkeys(nil))
+
+	// Must not panic.
+	_ = h.renderPreviewPane(80, 30)
+}
+
+// Regression: when the cursor-restore fallback clamps onto a divider (the
+// previously-selected session is gone — e.g. archive-hidden — so no session/
+// group match, and a divider exists because a non-Normal view mode is active),
+// restoreState must nudge the cursor onto a real selectable row rather than
+// leaving it parked on the non-selectable divider. This both exercises the
+// skipDivider(1) call and reproduces the startup condition that triggered the
+// home.go:13362 panic.
+func TestRestoreState_FallbackOntoDivider_LandsOnSession(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+
+	// One running session + the rest idle so ActiveTop splits the list with a
+	// divider between the active and idle sections.
+	home.instancesMu.RLock()
+	for _, inst := range home.instances {
+		if inst.Title == "a1" {
+			inst.Status = session.StatusRunning
+		} else {
+			inst.Status = session.StatusIdle
+		}
+	}
+	home.instancesMu.RUnlock()
+	home.groupViewMode = session.GroupViewActiveTop
+	home.rebuildFlatItems()
+
+	div := dividerIndex(home)
+	if div < 0 {
+		t.Fatalf("expected a divider in ActiveTop mode; flatItems=%d", len(home.flatItems))
+	}
+
+	// Park the cursor on the divider, then restore with a session ID that no
+	// longer exists (mimicking an archived/removed session). The fallback clamp
+	// keeps the cursor at the divider index; skipDivider(1) must move it off.
+	home.cursor = div
+	home.restoreState(reloadState{
+		cursorSessionID: "no-such-session-id",
+		expandedGroups:  map[string]bool{},
+	})
+
+	if home.cursor < 0 || home.cursor >= len(home.flatItems) {
+		t.Fatalf("cursor out of range after restore: %d of %d", home.cursor, len(home.flatItems))
+	}
+	if home.flatItems[home.cursor].Type == session.ItemTypeDivider {
+		t.Fatalf("cursor must not rest on a divider after restore: cursor=%d", home.cursor)
+	}
+	if home.flatItems[home.cursor].Type == session.ItemTypeSession &&
+		home.flatItems[home.cursor].Session == nil {
+		t.Fatalf("cursor rests on a session row with nil Session: cursor=%d", home.cursor)
+	}
+}

--- a/internal/ui/preview_divider_test.go
+++ b/internal/ui/preview_divider_test.go
@@ -42,15 +42,7 @@ func TestRestoreState_FallbackOntoDivider_LandsOnSession(t *testing.T) {
 
 	// One running session + the rest idle so ActiveTop splits the list with a
 	// divider between the active and idle sections.
-	home.instancesMu.RLock()
-	for _, inst := range home.instances {
-		if inst.Title == "a1" {
-			inst.Status = session.StatusRunning
-		} else {
-			inst.Status = session.StatusIdle
-		}
-	}
-	home.instancesMu.RUnlock()
+	setOnlySessionRunning(t, home, "a1")
 	home.groupViewMode = session.GroupViewActiveTop
 	home.rebuildFlatItems()
 
@@ -78,4 +70,8 @@ func TestRestoreState_FallbackOntoDivider_LandsOnSession(t *testing.T) {
 		home.flatItems[home.cursor].Session == nil {
 		t.Fatalf("cursor rests on a session row with nil Session: cursor=%d", home.cursor)
 	}
+}
+
+func TestRestoreState_RemoteSessionNotApplicable(t *testing.T) {
+	t.Skip("RemoteSession N/A: restoreState persists local session/group IDs only; remote rows are rebuilt from live SSH fetches and covered by t-cycle selection preservation.")
 }


### PR DESCRIPTION
Closes #1415.

## What

A `t` hotkey cycles the session list through three view modes:

- **normal** — existing tree, unchanged (default; zero behavior change until `t` is pressed).
- **active-on-top** — running/waiting/starting sessions surface at the top of each group; idle/done sink below a dim, non-selectable divider row.
- **populated-on-top** — groups that contain sessions surface above empty groups; empty subgroups sink below the divider nested under a duplicated parent header so hierarchy stays readable.

The filter bar shows the current mode next to the existing filters.

## How

- `internal/session/group_view_mode.go`: pure partition layer (`PartitionByViewMode` + `GroupActivityMap`) that reorders the already-flattened item slice — sorting and flattening stay untouched, so K/J manual order, collapse state, and the actionable sort all behave exactly as before inside each section.
- Pin interplay (#1336): a pin-top session stays in the top section even when idle, pin-bottom sinks even when active — pins stay fully fixed across view modes.
- Divider rows carry a nil Session: navigation skips them (`skipDivider`), cursor restore nudges off them, and the preview pane renders the No-Selection empty state defensively instead of panicking.
- Rendering: a fixed-width hotkey gutter is now reserved on every row so a numbered root group no longer steals an indent level from its children — without this, the duplicated parent chain in the empty-groups section rendered flat.

## Testing

- New: partition unit tests, empty-subgroup nesting tests, TUI wiring tests, nesting-indent render test, divider preview/restore regression tests (`go test ./internal/session/ ./internal/ui/` green).
- Full `go build ./... && go vet ./...` clean; web tests untouched and green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cycle group view modes with the 't' hotkey (Normal / Active-on-Top / Populated-on-Top)
  * Visual divider separates top/bottom sections; divider rows are non-selectable
  * Help screen and filter hint show the new view-mode shortcut; UI saves/restores selected view mode
  * Stabilized left-column alignment for consistent hotkey/indent layout

* **Bug Fixes**
  * Cursor and preview avoid landing on dividers; selection preserved across mode changes; no-preview panics

* **Tests**
  * Expanded tests for partitioning, wiring, rendering, navigation, and divider behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->