### PR TITLE
feat(sessions): auto-named quick sessions show Claude's live task description (#1416)

### DIFF
--- a/cmd/agent-deck/hook_name_sync.go
+++ b/cmd/agent-deck/hook_name_sync.go
@@ -90,6 +90,7 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 		// session — act and stop, never fall through to another profile.
 		newName, changed := target.ReconcileTitleFromClaude(sessionID)
 		if changed {
+			target.AutoName = false // Claude/user-chosen name replaces the auto handle
 			groupTree := session.NewGroupTreeWithGroups(instances, groups)
 			_ = storage.SaveWithGroups(instances, groupTree)
 		}

--- a/cmd/agent-deck/hook_name_sync.go
+++ b/cmd/agent-deck/hook_name_sync.go
@@ -90,7 +90,7 @@ func applyClaudeTitleSync(instanceID, sessionID string) {
 		// session — act and stop, never fall through to another profile.
 		newName, changed := target.ReconcileTitleFromClaude(sessionID)
 		if changed {
-			target.AutoName = false // Claude/user-chosen name replaces the auto handle
+			target.SetAutoName(false) // Claude/user-chosen name replaces the auto handle
 			groupTree := session.NewGroupTreeWithGroups(instances, groups)
 			_ = storage.SaveWithGroups(instances, groupTree)
 		}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1515,6 +1515,13 @@ func handleAdd(profile string, args []string) {
 		newInstance = session.NewInstance(sessionTitle, path)
 	}
 
+	// Quick mode generated a machine-named adjective-noun handle; mark it so the
+	// TUI shows Claude's live task description in place of the random name. This
+	// mirrors the exact condition used above to generate sessionTitle.
+	if isQuick && !userProvidedTitle {
+		newInstance.AutoName = true
+	}
+
 	// Socket-isolation CLI override (issue #687 phase 1, v1.7.50). The
 	// `--tmux-socket` flag beats `[tmux].socket_name`. Whitespace-only
 	// values fall back to the config default via the GetSocketName trim

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1148,8 +1148,8 @@ func handleAdd(profile string, args []string) {
 	// is an alias for discoverability.
 	titleLock := fs.Bool("title-lock", false, "Lock session title so Claude's session name never overrides it (#697)")
 	noTitleSync := fs.Bool("no-title-sync", false, "Alias for --title-lock")
-	quickCreate := fs.Bool("quick", false, "Auto-generate session name (adjective-noun)")
-	quickCreateShort := fs.Bool("Q", false, "Auto-generate session name (short)")
+	quickCreate := fs.Bool("quick", false, "Create a quick session with a machine-generated handle; TUI shows Claude's live task description when available")
+	quickCreateShort := fs.Bool("Q", false, "Create a quick session (short)")
 	jsonOutput := fs.Bool("json", false, "Output as JSON")
 	quiet := fs.Bool("quiet", false, "Minimal output")
 	quietShort := fs.Bool("q", false, "Minimal output (short)")
@@ -1252,7 +1252,7 @@ func handleAdd(profile string, args []string) {
 		fmt.Println("  agent-deck add -c gemini --yolo .")
 		fmt.Println("  agent-deck add -c claude -g work .   # -c is shorthand for --cmd")
 		fmt.Println("  agent-deck add -g ard --no-parent -c claude .")
-		fmt.Println("  agent-deck add --quick -c claude .   # Auto-generated name")
+		fmt.Println("  agent-deck add --quick -c claude .   # Quick session; TUI shows Claude's live task description")
 		fmt.Println()
 		fmt.Println("Worktree Examples:")
 		fmt.Println("  agent-deck add -w feature/login .    # Create worktree for existing branch")
@@ -1519,7 +1519,7 @@ func handleAdd(profile string, args []string) {
 	// TUI shows Claude's live task description in place of the random name. This
 	// mirrors the exact condition used above to generate sessionTitle.
 	if isQuick && !userProvidedTitle {
-		newInstance.AutoName = true
+		newInstance.SetAutoName(true)
 	}
 
 	// Socket-isolation CLI override (issue #687 phase 1, v1.7.50). The

--- a/cmd/agent-deck/openclaw_cmd.go
+++ b/cmd/agent-deck/openclaw_cmd.go
@@ -128,6 +128,7 @@ func handleOpenClawSync(profile string, args []string) {
 			// Update title if agent name changed
 			if existing.Title != agentDisplayName {
 				existing.Title = agentDisplayName
+				existing.AutoName = false // openclaw assigns a real agent name
 				updated++
 			}
 		}

--- a/cmd/agent-deck/openclaw_cmd.go
+++ b/cmd/agent-deck/openclaw_cmd.go
@@ -128,9 +128,9 @@ func handleOpenClawSync(profile string, args []string) {
 			// Update title if agent name changed
 			if existing.Title != agentDisplayName {
 				existing.Title = agentDisplayName
-				existing.AutoName = false // openclaw assigns a real agent name
 				updated++
 			}
+			existing.SetAutoName(false) // openclaw assigns a real agent name
 		}
 	}
 

--- a/internal/session/autoname_archive_roundtrip_test.go
+++ b/internal/session/autoname_archive_roundtrip_test.go
@@ -1,0 +1,59 @@
+package session
+
+import (
+	"os"
+	"testing"
+)
+
+// TestAutoNameDescription_SurvivesSaveLoad confirms the auto_name_description
+// column round-trips through SaveWithGroups/LoadWithGroups. If this regresses,
+// an archived auto-named session would reload wearing its bare random handle
+// instead of the captured Claude task description (the user-reported "loses the
+// auto generated name").
+func TestAutoNameDescription_SurvivesSaveLoad(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	ClearUserConfigCache()
+	t.Cleanup(func() {
+		os.Setenv("HOME", origHome)
+		ClearUserConfigCache()
+	})
+
+	storage, err := NewStorageWithProfile("_autoname_roundtrip")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { storage.Close() })
+
+	const desc = "Refactoring the auth module"
+	inst := NewInstanceWithTool("q-7f3a", "/tmp/q", "claude")
+	inst.AutoName = true
+	inst.SetAutoNameDescription(desc)
+
+	insts := []*Instance{inst}
+	tree := NewGroupTree(insts)
+	if err := storage.SaveWithGroups(insts, tree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	loaded, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+	var got *Instance
+	for _, in := range loaded {
+		if in.ID == inst.ID {
+			got = in
+		}
+	}
+	if got == nil {
+		t.Fatal("instance missing after reload")
+	}
+	if !got.AutoName {
+		t.Fatal("AutoName flag did not survive save/load")
+	}
+	if got.GetAutoNameDescription() != desc {
+		t.Fatalf("auto_name_description did not survive save/load: got %q want %q",
+			got.GetAutoNameDescription(), desc)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -107,6 +107,13 @@ type Instance struct {
 	// `--title-lock` on add/launch or `session set-title-lock`.
 	TitleLocked bool `json:"title_locked,omitempty"`
 
+	// AutoName, when true, marks Title as a machine-generated adjective-noun
+	// handle (from a --quick / TUI-Q create). The TUI then displays the
+	// session's live Claude task description (tmux pane title) in place of the
+	// handle. Any explicit rename clears this so the user-chosen name is shown
+	// verbatim. See docs/superpowers/specs/2026-06-01-quick-session-claude-name-design.md.
+	AutoName bool `json:"auto_name,omitempty"`
+
 	// Git worktree support
 	WorktreePath     string `json:"worktree_path,omitempty"`      // Path to worktree (if session is in worktree)
 	WorktreeRepoRoot string `json:"worktree_repo_root,omitempty"` // Original repo root

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -114,6 +114,16 @@ type Instance struct {
 	// verbatim. See docs/superpowers/specs/2026-06-01-quick-session-claude-name-design.md.
 	AutoName bool `json:"auto_name,omitempty"`
 
+	// autoNameDescription is the last non-empty Claude task description (the
+	// cleaned tmux pane title) captured for an AutoName session. It is persisted
+	// via the auto_name_description column so the meaningful name survives an
+	// app reopen even when the session is stopped/idle and no live pane title is
+	// available — render order is live pane title → this saved description →
+	// handle. Guarded by i.mu: written from the background status loop, read
+	// during render. Unexported because persistence flows through InstanceData,
+	// not Instance's own JSON tags.
+	autoNameDescription string
+
 	// Git worktree support
 	WorktreePath     string `json:"worktree_path,omitempty"`      // Path to worktree (if session is in worktree)
 	WorktreeRepoRoot string `json:"worktree_repo_root,omitempty"` // Original repo root
@@ -4121,6 +4131,22 @@ func (i *Instance) GetHookStatus() (string, bool) {
 	}
 	fresh := time.Since(i.hookLastUpdate) < hookFastPathFreshnessForTool(i.Tool, i.hookStatus)
 	return i.hookStatus, fresh
+}
+
+// GetAutoNameDescription returns the last captured Claude task description for
+// an AutoName session (empty if none captured yet). Thread-safe.
+func (i *Instance) GetAutoNameDescription() string {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.autoNameDescription
+}
+
+// SetAutoNameDescription records the latest Claude task description for an
+// AutoName session so it can be persisted and shown on reopen. Thread-safe.
+func (i *Instance) SetAutoNameDescription(desc string) {
+	i.mu.Lock()
+	i.autoNameDescription = desc
+	i.mu.Unlock()
 }
 
 // ClearHookStatus resets the hook-based status and removes the persisted hook

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -112,6 +112,8 @@ type Instance struct {
 	// session's live Claude task description (tmux pane title) in place of the
 	// handle. Any explicit rename clears this so the user-chosen name is shown
 	// verbatim. See docs/superpowers/specs/2026-06-01-quick-session-claude-name-design.md.
+	// Guarded by i.mu for runtime reads/writes; use GetAutoName/SetAutoName once
+	// an Instance is shared with background workers or the TUI render loop.
 	AutoName bool `json:"auto_name,omitempty"`
 
 	// autoNameDescription is the last non-empty Claude task description (the
@@ -4141,11 +4143,29 @@ func (i *Instance) GetAutoNameDescription() string {
 	return i.autoNameDescription
 }
 
+// GetAutoName reports whether this session should display a captured/live task
+// description instead of its machine-generated handle. Thread-safe.
+func (i *Instance) GetAutoName() bool {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.AutoName
+}
+
+// SetAutoName updates whether this session should display a captured/live task
+// description instead of its machine-generated handle. Thread-safe.
+func (i *Instance) SetAutoName(autoName bool) {
+	i.mu.Lock()
+	i.AutoName = autoName
+	i.mu.Unlock()
+}
+
 // SetAutoNameDescription records the latest Claude task description for an
 // AutoName session so it can be persisted and shown on reopen. Thread-safe.
 func (i *Instance) SetAutoNameDescription(desc string) {
 	i.mu.Lock()
-	i.autoNameDescription = desc
+	if strings.TrimSpace(desc) != "" {
+		i.autoNameDescription = desc
+	}
 	i.mu.Unlock()
 }
 

--- a/internal/session/instance_autoname_test.go
+++ b/internal/session/instance_autoname_test.go
@@ -1,0 +1,44 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestAutoNameRoundTrip pins that AutoName persists through the same
+// json.Marshal → json.Unmarshal path Storage.Save/Load uses.
+func TestAutoNameRoundTrip(t *testing.T) {
+	inst := NewInstance("lively-fjord", t.TempDir())
+	inst.AutoName = true
+
+	data, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatalf("json.Marshal(inst): %v", err)
+	}
+	if !strings.Contains(string(data), `"auto_name":true`) {
+		t.Errorf("marshalled instance missing \"auto_name\":true; got:\n%s", string(data))
+	}
+
+	revived := &Instance{}
+	if err := json.Unmarshal(data, revived); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if !revived.AutoName {
+		t.Errorf("revived AutoName = false, want true")
+	}
+}
+
+// TestAutoNameOmitemptyZeroValue pins that an unset AutoName is omitted from
+// JSON, keeping existing state.json files byte-identical until the flag is set.
+func TestAutoNameOmitemptyZeroValue(t *testing.T) {
+	inst := NewInstance("plain-session", t.TempDir())
+
+	data, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatalf("json.Marshal(inst): %v", err)
+	}
+	if strings.Contains(string(data), "auto_name") {
+		t.Errorf("zero-value AutoName should be omitted (omitempty); got:\n%s", string(data))
+	}
+}

--- a/internal/session/instance_autoname_test.go
+++ b/internal/session/instance_autoname_test.go
@@ -6,8 +6,14 @@ import (
 	"testing"
 )
 
-// TestAutoNameRoundTrip pins that AutoName persists through the same
-// json.Marshal → json.Unmarshal path Storage.Save/Load uses.
+// TestAutoNameRoundTrip pins that AutoName survives a json.Marshal →
+// json.Unmarshal round-trip of the Instance struct itself.
+//
+// NOTE: this is NOT the persistence path. Storage.Save/Load go through
+// InstanceData → statedb.InstanceRow → SQLite columns, not Instance's own JSON
+// tags. This test passing while that SQLite path dropped the field is exactly
+// how the "auto name lost on reopen" bug shipped. The real persistence
+// round-trip is covered by TestStorageSaveWithGroups_PersistsAutoName.
 func TestAutoNameRoundTrip(t *testing.T) {
 	inst := NewInstance("lively-fjord", t.TempDir())
 	inst.AutoName = true

--- a/internal/session/instance_autoname_test.go
+++ b/internal/session/instance_autoname_test.go
@@ -48,3 +48,14 @@ func TestAutoNameOmitemptyZeroValue(t *testing.T) {
 		t.Errorf("zero-value AutoName should be omitted (omitempty); got:\n%s", string(data))
 	}
 }
+
+func TestSetAutoNameDescriptionIgnoresEmptyInput(t *testing.T) {
+	inst := NewInstance("lively-fjord", t.TempDir())
+	inst.SetAutoNameDescription("Review and improve SketchUp house models")
+
+	inst.SetAutoNameDescription(" \t\n")
+
+	if got := inst.GetAutoNameDescription(); got != "Review and improve SketchUp house models" {
+		t.Errorf("description after empty update = %q, want previous meaningful title", got)
+	}
+}

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -131,6 +131,7 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 	case FieldTitle:
 		oldValue = inst.Title
 		inst.Title = value
+		inst.AutoName = false // a user/explicit name replaces the auto handle
 		// An explicit rename is user intent: lock the title so the #572
 		// Claude-name sync (plan titles, /rename) can't revert it on the
 		// next hook event. Unlock via `session set <id> title-locked false`.

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -131,7 +131,7 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 	case FieldTitle:
 		oldValue = inst.Title
 		inst.Title = value
-		inst.AutoName = false // a user/explicit name replaces the auto handle
+		inst.SetAutoName(false) // a user/explicit name replaces the auto handle
 		// An explicit rename is user intent: lock the title so the #572
 		// Claude-name sync (plan titles, /rename) can't revert it on the
 		// next hook event. Unlock via `session set <id> title-locked false`.

--- a/internal/session/mutators_autoname_test.go
+++ b/internal/session/mutators_autoname_test.go
@@ -1,0 +1,22 @@
+package session
+
+import "testing"
+
+// TestSetFieldTitleClearsAutoName pins that renaming via the central SetField
+// mutator clears the AutoName flag, so a user-chosen name sticks (the TUI then
+// shows the typed name verbatim instead of the live pane title).
+func TestSetFieldTitleClearsAutoName(t *testing.T) {
+	inst := NewInstance("lively-fjord", t.TempDir())
+	inst.AutoName = true
+
+	if _, _, err := SetField(inst, FieldTitle, "my-feature", nil); err != nil {
+		t.Fatalf("SetField(title): %v", err)
+	}
+
+	if inst.Title != "my-feature" {
+		t.Errorf("Title = %q, want %q", inst.Title, "my-feature")
+	}
+	if inst.AutoName {
+		t.Errorf("AutoName = true after rename, want false")
+	}
+}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -37,23 +37,25 @@ type StorageData struct {
 
 // InstanceData represents the serializable session data
 type InstanceData struct {
-	ID                 string    `json:"id"`
-	Title              string    `json:"title"`
-	ProjectPath        string    `json:"project_path"`
-	GroupPath          string    `json:"group_path"`
-	Order              int       `json:"order"`
-	ParentSessionID    string    `json:"parent_session_id,omitempty"`    // Links to parent session (sub-session support)
-	IsConductor        bool      `json:"is_conductor,omitempty"`         // True if this session is a conductor orchestrator
-	NoTransitionNotify bool      `json:"no_transition_notify,omitempty"` // Suppress transition event dispatch
-	TitleLocked        bool      `json:"title_locked,omitempty"`         // #697: block Claude session-name sync into Title
-	Command            string    `json:"command"`
-	Wrapper            string    `json:"wrapper,omitempty"`
-	Tool               string    `json:"tool"`
-	Status             Status    `json:"status"`
-	CreatedAt          time.Time `json:"created_at"`
-	LastAccessedAt     time.Time `json:"last_accessed_at,omitempty"`
-	ArchivedAt         time.Time `json:"archived_at,omitempty"`
-	TmuxSession        string    `json:"tmux_session"`
+	ID                  string    `json:"id"`
+	Title               string    `json:"title"`
+	ProjectPath         string    `json:"project_path"`
+	GroupPath           string    `json:"group_path"`
+	Order               int       `json:"order"`
+	ParentSessionID     string    `json:"parent_session_id,omitempty"`     // Links to parent session (sub-session support)
+	IsConductor         bool      `json:"is_conductor,omitempty"`          // True if this session is a conductor orchestrator
+	NoTransitionNotify  bool      `json:"no_transition_notify,omitempty"`  // Suppress transition event dispatch
+	TitleLocked         bool      `json:"title_locked,omitempty"`          // #697: block Claude session-name sync into Title
+	AutoName            bool      `json:"auto_name,omitempty"`             // marks Title as a machine-generated quick-session handle
+	AutoNameDescription string    `json:"auto_name_description,omitempty"` // last captured Claude task description for an AutoName session
+	Command             string    `json:"command"`
+	Wrapper             string    `json:"wrapper,omitempty"`
+	Tool                string    `json:"tool"`
+	Status              Status    `json:"status"`
+	CreatedAt           time.Time `json:"created_at"`
+	LastAccessedAt      time.Time `json:"last_accessed_at,omitempty"`
+	ArchivedAt          time.Time `json:"archived_at,omitempty"`
+	TmuxSession         string    `json:"tmux_session"`
 	// TmuxSocketName is the tmux -L selector captured at Instance creation
 	// (issue #687, v1.7.50). Empty for pre-v1.7.50 rows — those keep hitting
 	// the default server after upgrade.
@@ -699,30 +701,32 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 	toolData = WriteIdleTimeoutSecsToToolData(toolData, inst.IdleTimeoutSecs)
 
 	return &statedb.InstanceRow{
-		ID:                 inst.ID,
-		Title:              inst.Title,
-		ProjectPath:        inst.ProjectPath,
-		GroupPath:          inst.GroupPath,
-		Order:              inst.Order,
-		Command:            inst.Command,
-		Wrapper:            inst.Wrapper,
-		Tool:               inst.Tool,
-		Status:             string(inst.Status),
-		TmuxSession:        tmuxName,
-		TmuxSocketName:     inst.TmuxSocketName,
-		CreatedAt:          inst.CreatedAt,
-		LastAccessed:       inst.LastAccessedAt,
-		ParentSessionID:    inst.ParentSessionID,
-		IsConductor:        inst.IsConductor,
-		NoTransitionNotify: inst.NoTransitionNotify,
-		TitleLocked:        inst.TitleLocked,
-		WorktreePath:       inst.WorktreePath,
-		WorktreeRepo:       inst.WorktreeRepoRoot,
-		WorktreeBranch:     inst.WorktreeBranch,
-		Account:            inst.Account,
-		ArchivedAt:         inst.ArchivedAt,
-		Pin:                string(inst.Pin),
-		ToolData:           toolData,
+		ID:                  inst.ID,
+		Title:               inst.Title,
+		ProjectPath:         inst.ProjectPath,
+		GroupPath:           inst.GroupPath,
+		Order:               inst.Order,
+		Command:             inst.Command,
+		Wrapper:             inst.Wrapper,
+		Tool:                inst.Tool,
+		Status:              string(inst.Status),
+		TmuxSession:         tmuxName,
+		TmuxSocketName:      inst.TmuxSocketName,
+		CreatedAt:           inst.CreatedAt,
+		LastAccessed:        inst.LastAccessedAt,
+		ParentSessionID:     inst.ParentSessionID,
+		IsConductor:         inst.IsConductor,
+		NoTransitionNotify:  inst.NoTransitionNotify,
+		TitleLocked:         inst.TitleLocked,
+		AutoName:            inst.AutoName,
+		AutoNameDescription: inst.GetAutoNameDescription(),
+		WorktreePath:        inst.WorktreePath,
+		WorktreeRepo:        inst.WorktreeRepoRoot,
+		WorktreeBranch:      inst.WorktreeBranch,
+		Account:             inst.Account,
+		ArchivedAt:          inst.ArchivedAt,
+		Pin:                 string(inst.Pin),
+		ToolData:            toolData,
 	}, nil
 }
 
@@ -821,6 +825,8 @@ func (s *Storage) LoadLite() ([]*InstanceData, []*GroupData, error) {
 			IsConductor:               r.IsConductor,
 			NoTransitionNotify:        r.NoTransitionNotify,
 			TitleLocked:               r.TitleLocked,
+			AutoName:                  r.AutoName,
+			AutoNameDescription:       r.AutoNameDescription,
 			Command:                   r.Command,
 			Wrapper:                   r.Wrapper,
 			Tool:                      r.Tool,
@@ -938,6 +944,8 @@ func (s *Storage) LoadWithGroups() ([]*Instance, []*GroupData, error) {
 			IsConductor:               r.IsConductor,
 			NoTransitionNotify:        r.NoTransitionNotify,
 			TitleLocked:               r.TitleLocked,
+			AutoName:                  r.AutoName,
+			AutoNameDescription:       r.AutoNameDescription,
 			Command:                   r.Command,
 			Wrapper:                   r.Wrapper,
 			Tool:                      r.Tool,
@@ -1191,6 +1199,8 @@ func (s *Storage) convertToInstances(data *StorageData) ([]*Instance, []*GroupDa
 			IsConductor:               instData.IsConductor,
 			NoTransitionNotify:        instData.NoTransitionNotify,
 			TitleLocked:               instData.TitleLocked,
+			AutoName:                  instData.AutoName,
+			autoNameDescription:       instData.AutoNameDescription,
 			Command:                   instData.Command,
 			Wrapper:                   instData.Wrapper,
 			Tool:                      instData.Tool,

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -738,7 +738,7 @@ func instanceToRow(inst *Instance) (*statedb.InstanceRow, error) {
 		IsConductor:         inst.IsConductor,
 		NoTransitionNotify:  inst.NoTransitionNotify,
 		TitleLocked:         inst.TitleLocked,
-		AutoName:            inst.AutoName,
+		AutoName:            inst.GetAutoName(),
 		AutoNameDescription: inst.GetAutoNameDescription(),
 		WorktreePath:        inst.WorktreePath,
 		WorktreeRepo:        inst.WorktreeRepoRoot,

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -370,6 +370,26 @@ func (s *Storage) DeleteInstance(id string) error {
 	return nil
 }
 
+// WriteAutoNameDescription persists a single auto-named session's last captured
+// Claude task description via a targeted column update — no whole-row rewrite,
+// no full-table reconcile (see statedb.WriteAutoNameDescription). This lets the
+// archive path snapshot the display name without a full save.
+func (s *Storage) WriteAutoNameDescription(id, description string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return fmt.Errorf("storage database not initialized")
+	}
+
+	if err := s.db.WriteAutoNameDescription(id, description); err != nil {
+		return fmt.Errorf("failed to persist auto-name description for %s: %w", id, err)
+	}
+
+	_ = s.db.Touch()
+	return nil
+}
+
 // InstanceExists returns true iff a row with the given id is currently
 // persisted. Used by RemoveSessionAndVerify to confirm a DELETE actually
 // landed (issue #909).

--- a/internal/session/storage_test.go
+++ b/internal/session/storage_test.go
@@ -385,6 +385,81 @@ func TestStorageSaveWithGroups_PersistsTitleLocked(t *testing.T) {
 	}
 }
 
+// TestStorageSaveWithGroups_PersistsAutoName locks that the AutoName flag and
+// its captured description survive Save → Load via the real SQLite path (the
+// path the app actually uses on reopen), through both LoadWithGroups (canonical)
+// and LoadLite (CLI fast-path). This is the regression that made auto-named
+// quick sessions revert to their random handle on reopen: the flag and
+// description lived only in memory and were never written to / read from the DB.
+func TestStorageSaveWithGroups_PersistsAutoName(t *testing.T) {
+	s := newTestStorage(t)
+
+	auto := &Instance{
+		ID:          "auto-1",
+		Title:       "lively-fjord",
+		ProjectPath: "/tmp/auto",
+		GroupPath:   "grp",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      StatusIdle,
+		CreatedAt:   time.Now(),
+		AutoName:    true,
+	}
+	auto.SetAutoNameDescription("Review and improve SketchUp house models")
+
+	plain := &Instance{
+		ID:          "plain-1",
+		Title:       "Auth",
+		ProjectPath: "/tmp/plain",
+		GroupPath:   "grp",
+		Command:     "claude",
+		Tool:        "claude",
+		Status:      StatusIdle,
+		CreatedAt:   time.Now(),
+	}
+
+	if err := s.SaveWithGroups([]*Instance{auto, plain}, nil); err != nil {
+		t.Fatalf("SaveWithGroups failed: %v", err)
+	}
+
+	loaded, _, err := s.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups failed: %v", err)
+	}
+	byID := map[string]*Instance{}
+	for _, inst := range loaded {
+		byID[inst.ID] = inst
+	}
+	if !byID["auto-1"].AutoName {
+		t.Errorf("auto-1.AutoName = false after round-trip, want true")
+	}
+	if got := byID["auto-1"].GetAutoNameDescription(); got != "Review and improve SketchUp house models" {
+		t.Errorf("auto-1 description = %q after round-trip, want the saved task title", got)
+	}
+	if byID["plain-1"].AutoName {
+		t.Errorf("plain-1.AutoName = true after round-trip, want false (default must not leak)")
+	}
+	if got := byID["plain-1"].GetAutoNameDescription(); got != "" {
+		t.Errorf("plain-1 description = %q, want empty", got)
+	}
+
+	// LoadLite (CLI fast-path) must preserve both fields too.
+	lite, _, err := s.LoadLite()
+	if err != nil {
+		t.Fatalf("LoadLite failed: %v", err)
+	}
+	liteByID := map[string]*InstanceData{}
+	for _, d := range lite {
+		liteByID[d.ID] = d
+	}
+	if !liteByID["auto-1"].AutoName {
+		t.Errorf("LoadLite auto-1.AutoName = false, want true")
+	}
+	if got := liteByID["auto-1"].AutoNameDescription; got != "Review and improve SketchUp house models" {
+		t.Errorf("LoadLite auto-1.AutoNameDescription = %q, want the saved task title", got)
+	}
+}
+
 // TestSaveSessionData_PreservesGroupSortOrder verifies that saving session data
 // with stored groups preserves the sort_order, matching the fix in #465.
 func TestSaveSessionData_PreservesGroupSortOrder(t *testing.T) {

--- a/internal/session/storage_test.go
+++ b/internal/session/storage_test.go
@@ -458,6 +458,12 @@ func TestStorageSaveWithGroups_PersistsAutoName(t *testing.T) {
 	if got := liteByID["auto-1"].AutoNameDescription; got != "Review and improve SketchUp house models" {
 		t.Errorf("LoadLite auto-1.AutoNameDescription = %q, want the saved task title", got)
 	}
+	if liteByID["plain-1"].AutoName {
+		t.Errorf("LoadLite plain-1.AutoName = true, want false")
+	}
+	if got := liteByID["plain-1"].AutoNameDescription; got != "" {
+		t.Errorf("LoadLite plain-1.AutoNameDescription = %q, want empty", got)
+	}
 }
 
 // TestSaveSessionData_PreservesGroupSortOrder verifies that saving session data

--- a/internal/statedb/migrate_xfer.go
+++ b/internal/statedb/migrate_xfer.go
@@ -20,14 +20,14 @@ func (s *StateDB) LoadInstanceByID(id string) (*InstanceRow, error) {
 	row := &InstanceRow{}
 	var createdUnix, accessedUnix, archivedUnix int64
 	var toolDataStr string
-	var isConductorInt, noTransitionNotifyInt, titleLockedInt int
+	var isConductorInt, noTransitionNotifyInt, titleLockedInt, autoNameInt int
 	err := s.db.QueryRow(`
 		SELECT id, title, project_path, group_path, sort_order,
 			command, wrapper, tool, status, tmux_session, tmux_socket_name,
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch, account,
-			archived_at, tool_data, title_locked
+			archived_at, tool_data, title_locked, auto_name, auto_name_description, pin
 		FROM instances WHERE id = ?
 	`, id).Scan(
 		&row.ID, &row.Title, &row.ProjectPath, &row.GroupPath, &row.Order,
@@ -35,7 +35,7 @@ func (s *StateDB) LoadInstanceByID(id string) (*InstanceRow, error) {
 		&createdUnix, &accessedUnix,
 		&row.ParentSessionID, &isConductorInt, &noTransitionNotifyInt,
 		&row.WorktreePath, &row.WorktreeRepo, &row.WorktreeBranch, &row.Account,
-		&archivedUnix, &toolDataStr, &titleLockedInt,
+		&archivedUnix, &toolDataStr, &titleLockedInt, &autoNameInt, &row.AutoNameDescription, &row.Pin,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -53,6 +53,7 @@ func (s *StateDB) LoadInstanceByID(id string) (*InstanceRow, error) {
 	row.IsConductor = isConductorInt != 0
 	row.NoTransitionNotify = noTransitionNotifyInt != 0
 	row.TitleLocked = titleLockedInt != 0
+	row.AutoName = autoNameInt != 0
 	row.ToolData = json.RawMessage(toolDataStr)
 	return row, nil
 }
@@ -65,7 +66,7 @@ func (s *StateDB) LoadInstanceChildren(parentID string) ([]*InstanceRow, error) 
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch, account,
-			archived_at, tool_data, title_locked
+			archived_at, tool_data, title_locked, auto_name, auto_name_description, pin
 		FROM instances WHERE parent_session_id = ? ORDER BY sort_order
 	`, parentID)
 	if err != nil {
@@ -91,7 +92,7 @@ func (s *StateDB) LoadInstancesByGroup(groupPath string) ([]*InstanceRow, error)
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch, account,
-			archived_at, tool_data, title_locked
+			archived_at, tool_data, title_locked, auto_name, auto_name_description, pin
 		FROM instances WHERE group_path = ? ORDER BY sort_order
 	`, groupPath)
 	if err != nil {
@@ -114,14 +115,14 @@ func scanInstanceRow(rows *sql.Rows) (*InstanceRow, error) {
 	r := &InstanceRow{}
 	var createdUnix, accessedUnix, archivedUnix int64
 	var toolDataStr string
-	var isConductorInt, noTransitionNotifyInt, titleLockedInt int
+	var isConductorInt, noTransitionNotifyInt, titleLockedInt, autoNameInt int
 	if err := rows.Scan(
 		&r.ID, &r.Title, &r.ProjectPath, &r.GroupPath, &r.Order,
 		&r.Command, &r.Wrapper, &r.Tool, &r.Status, &r.TmuxSession, &r.TmuxSocketName,
 		&createdUnix, &accessedUnix,
 		&r.ParentSessionID, &isConductorInt, &noTransitionNotifyInt,
 		&r.WorktreePath, &r.WorktreeRepo, &r.WorktreeBranch, &r.Account,
-		&archivedUnix, &toolDataStr, &titleLockedInt,
+		&archivedUnix, &toolDataStr, &titleLockedInt, &autoNameInt, &r.AutoNameDescription, &r.Pin,
 	); err != nil {
 		return nil, err
 	}
@@ -135,6 +136,7 @@ func scanInstanceRow(rows *sql.Rows) (*InstanceRow, error) {
 	r.IsConductor = isConductorInt != 0
 	r.NoTransitionNotify = noTransitionNotifyInt != 0
 	r.TitleLocked = titleLockedInt != 0
+	r.AutoName = autoNameInt != 0
 	r.ToolData = json.RawMessage(toolDataStr)
 	return r, nil
 }
@@ -159,6 +161,10 @@ func (s *StateDB) InsertInstanceRow(inst *InstanceRow) error {
 	if inst.TitleLocked {
 		titleLockedInt = 1
 	}
+	autoNameInt := 0
+	if inst.AutoName {
+		autoNameInt = 1
+	}
 	return withBusyRetry(func() error {
 		_, err := s.db.Exec(`
 			INSERT OR REPLACE INTO instances (
@@ -167,15 +173,15 @@ func (s *StateDB) InsertInstanceRow(inst *InstanceRow) error {
 				created_at, last_accessed,
 				parent_session_id, is_conductor, no_transition_notify,
 				worktree_path, worktree_repo, worktree_branch, account,
-				archived_at, tool_data, title_locked
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				archived_at, tool_data, title_locked, auto_name, auto_name_description, pin
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`,
 			inst.ID, inst.Title, inst.ProjectPath, inst.GroupPath, inst.Order,
 			inst.Command, inst.Wrapper, inst.Tool, inst.Status, inst.TmuxSession, inst.TmuxSocketName,
 			inst.CreatedAt.Unix(), instLastAccessedUnix(inst),
 			inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
 			inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch, inst.Account,
-			archivedAtUnix(inst.ArchivedAt), string(toolData), titleLockedInt,
+			archivedAtUnix(inst.ArchivedAt), string(toolData), titleLockedInt, autoNameInt, inst.AutoNameDescription, inst.Pin,
 		)
 		return err
 	})

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -174,6 +174,34 @@ type InstanceRow struct {
 	ArchivedAt time.Time
 }
 
+type existingAutoNameFields struct {
+	found       bool
+	autoName    bool
+	description string
+}
+
+func mergeAutoNameFields(inst *InstanceRow, existing existingAutoNameFields) (bool, string) {
+	if !existing.found {
+		return inst.AutoName, inst.AutoNameDescription
+	}
+
+	autoName := inst.AutoName
+	if !existing.autoName && inst.AutoName {
+		// A stale full-row save must not resurrect AutoName after a newer writer
+		// cleared it through an explicit rename/title sync.
+		autoName = false
+	}
+
+	description := inst.AutoNameDescription
+	if description == "" && existing.description != "" {
+		// The capture path writes non-empty descriptions with a targeted UPDATE.
+		// Keep that fresher value when a stale snapshot still has the old empty
+		// column value.
+		description = existing.description
+	}
+	return autoName, description
+}
+
 // WatcherRow represents a watcher row in the database.
 type WatcherRow struct {
 	ID         string
@@ -649,8 +677,14 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 	// manually-set clear_on_compact). Without this merge, every
 	// INSERT OR REPLACE silently drops user-managed extras.
 	var existingToolData []byte
+	existingAutoName := existingAutoNameFields{}
 	if err := s.db.QueryRow("SELECT tool_data FROM instances WHERE id = ?", inst.ID).Scan(&existingToolData); err == nil {
 		toolData = MergeToolDataExtras(json.RawMessage(existingToolData), toolData)
+	}
+	var existingAutoNameInt int
+	if err := s.db.QueryRow("SELECT auto_name, auto_name_description FROM instances WHERE id = ?", inst.ID).Scan(&existingAutoNameInt, &existingAutoName.description); err == nil {
+		existingAutoName.found = true
+		existingAutoName.autoName = existingAutoNameInt != 0
 	}
 
 	isConductorInt := 0
@@ -665,8 +699,9 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 	if inst.TitleLocked {
 		titleLockedInt = 1
 	}
+	autoName, autoNameDescription := mergeAutoNameFields(inst, existingAutoName)
 	autoNameInt := 0
-	if inst.AutoName {
+	if autoName {
 		autoNameInt = 1
 	}
 	_, err := s.db.Exec(`
@@ -684,7 +719,7 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 		inst.CreatedAt.Unix(), inst.LastAccessed.Unix(),
 		inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
 		inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch, inst.Account,
-		archivedAtUnix(inst.ArchivedAt), string(toolData), titleLockedInt, autoNameInt, inst.AutoNameDescription, inst.Pin,
+		archivedAtUnix(inst.ArchivedAt), string(toolData), titleLockedInt, autoNameInt, autoNameDescription, inst.Pin,
 	)
 	return err
 }
@@ -704,11 +739,9 @@ func (s *StateDB) SaveInstances(insts []*InstanceRow) error {
 }
 
 func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
-	// Pre-fetch existing tool_data per instance ID so we can preserve any
-	// keys not modeled by the typed schema (e.g., manually-set
-	// clear_on_compact). Without this merge, every INSERT OR REPLACE
-	// silently drops user-managed extras. One batch SELECT instead of N
-	// individual reads.
+	// Pre-fetch existing mutable columns per instance ID so we can preserve state
+	// written by targeted UPDATE paths. Without this merge, every INSERT OR
+	// REPLACE can silently drop fresher data from another process.
 	//
 	// IMPORTANT: this read runs OUTSIDE the write transaction below.
 	// In SQLite WAL mode, beginning a transaction with a read and then
@@ -720,6 +753,7 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 	// extras keys are rarely-mutated user-managed flags and the worst-case
 	// outcome is one stale-overlay save, recoverable on next save.
 	existingToolData := make(map[string]json.RawMessage, len(insts))
+	existingAutoNames := make(map[string]existingAutoNameFields, len(insts))
 	if len(insts) > 0 {
 		placeholders := make([]string, len(insts))
 		args := make([]any, len(insts))
@@ -729,14 +763,21 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 		}
 		// #nosec G202 -- placeholders is a fixed sequence of "?" tokens generated
 		// from len(insts); all values flow through args[], never the SQL string.
-		query := "SELECT id, tool_data FROM instances WHERE id IN (" + strings.Join(placeholders, ",") + ")"
+		query := "SELECT id, tool_data, auto_name, auto_name_description FROM instances WHERE id IN (" + strings.Join(placeholders, ",") + ")"
 		rows, queryErr := s.db.Query(query, args...)
 		if queryErr == nil {
 			for rows.Next() {
 				var id string
 				var td []byte
-				if scanErr := rows.Scan(&id, &td); scanErr == nil {
+				var autoNameInt int
+				var autoNameDescription string
+				if scanErr := rows.Scan(&id, &td, &autoNameInt, &autoNameDescription); scanErr == nil {
 					existingToolData[id] = json.RawMessage(td)
+					existingAutoNames[id] = existingAutoNameFields{
+						found:       true,
+						autoName:    autoNameInt != 0,
+						description: autoNameDescription,
+					}
 				}
 			}
 			_ = rows.Close()
@@ -846,8 +887,9 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 		if inst.TitleLocked {
 			titleLockedInt = 1
 		}
+		autoName, autoNameDescription := mergeAutoNameFields(inst, existingAutoNames[inst.ID])
 		autoNameInt := 0
-		if inst.AutoName {
+		if autoName {
 			autoNameInt = 1
 		}
 		if _, err := stmt.Exec(
@@ -856,7 +898,7 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 			inst.CreatedAt.Unix(), inst.LastAccessed.Unix(),
 			inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
 			inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch, inst.Account,
-			archivedAtUnix(inst.ArchivedAt), string(toolData), titleLockedInt, autoNameInt, inst.AutoNameDescription, inst.Pin,
+			archivedAtUnix(inst.ArchivedAt), string(toolData), titleLockedInt, autoNameInt, autoNameDescription, inst.Pin,
 		); err != nil {
 			return err
 		}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -104,7 +104,7 @@ func withBusyRetry(op func() error) error {
 
 // SchemaVersion tracks the current database schema version.
 // Bump this when adding migrations.
-const SchemaVersion = 11
+const SchemaVersion = 12
 
 // StateDB wraps a SQLite database for session/group persistence.
 // Thread-safe for concurrent use from multiple goroutines within one process.
@@ -150,10 +150,16 @@ type InstanceRow struct {
 	// after upgrade.
 	TmuxSocketName string
 	// TitleLocked blocks Claude session-name sync into Title (v1.7.52+, issue #697).
-	TitleLocked    bool
-	WorktreePath   string
-	WorktreeRepo   string
-	WorktreeBranch string
+	TitleLocked bool
+	// AutoName marks Title as a machine-generated quick-session handle (v12).
+	// AutoNameDescription holds the last captured Claude task description so an
+	// auto-named session can show its meaningful name on reopen even when
+	// stopped/idle (no live pane title). Both default to zero for legacy rows.
+	AutoName            bool
+	AutoNameDescription string
+	WorktreePath        string
+	WorktreeRepo        string
+	WorktreeBranch      string
 	// Account is the per-session named account (v1.9.22+, issue #924). Maps to
 	// `[profiles.<account>.claude].config_dir` at spawn time and becomes the
 	// most-specific level in the CLAUDE_CONFIG_DIR resolution chain. Empty
@@ -351,7 +357,9 @@ func (s *StateDB) Migrate() error {
 			worktree_branch   TEXT NOT NULL DEFAULT '',
 			account           TEXT NOT NULL DEFAULT '',
 			archived_at       INTEGER NOT NULL DEFAULT 0,
-			pin               TEXT NOT NULL DEFAULT '',
+			auto_name              INTEGER NOT NULL DEFAULT 0,
+			auto_name_description  TEXT NOT NULL DEFAULT '',
+			pin             TEXT NOT NULL DEFAULT '',
 			tool_data       TEXT NOT NULL DEFAULT '{}',
 			acknowledged    INTEGER NOT NULL DEFAULT 0
 		)
@@ -504,11 +512,17 @@ func (s *StateDB) Migrate() error {
 		// the pre-v1.9.22 behavior for legacy rows (fall through to
 		// conductor/group/env/profile/global/default).
 		"ALTER TABLE instances ADD COLUMN account TEXT NOT NULL DEFAULT ''",
-		// v10: user-archived sessions (hidden from active lists; 0 = active).
+		// v10 (archive-sessions): ArchivedAt timestamp. Default 0 means
+		// "not archived" for all pre-existing rows.
 		"ALTER TABLE instances ADD COLUMN archived_at INTEGER NOT NULL DEFAULT 0",
 		// v11 (pin-sessions): per-session pin to top/bottom of group. Default ''
 		// means "not pinned" for all pre-existing rows.
 		"ALTER TABLE instances ADD COLUMN pin TEXT NOT NULL DEFAULT ''",
+		// v12 (quick-session Claude-name display): AutoName flag + the last
+		// captured task description. Defaults (0, '') keep legacy rows showing
+		// their handle until they are recreated as quick sessions.
+		"ALTER TABLE instances ADD COLUMN auto_name INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE instances ADD COLUMN auto_name_description TEXT NOT NULL DEFAULT ''",
 	}
 	for _, stmt := range alterMigrations {
 		if _, err := tx.Exec(stmt); err != nil {
@@ -583,6 +597,18 @@ func (s *StateDB) Migrate() error {
 				}
 			}
 		}
+		if oldVer < 12 {
+			if _, err := tx.Exec(`ALTER TABLE instances ADD COLUMN auto_name INTEGER NOT NULL DEFAULT 0`); err != nil {
+				if !strings.Contains(err.Error(), "duplicate column") {
+					return fmt.Errorf("statedb: migrate v12 auto_name: %w", err)
+				}
+			}
+			if _, err := tx.Exec(`ALTER TABLE instances ADD COLUMN auto_name_description TEXT NOT NULL DEFAULT ''`); err != nil {
+				if !strings.Contains(err.Error(), "duplicate column") {
+					return fmt.Errorf("statedb: migrate v12 auto_name_description: %w", err)
+				}
+			}
+		}
 		if _, err := tx.Exec(`
 			UPDATE metadata SET value = ? WHERE key = 'schema_version'
 		`, schemaVersion); err != nil {
@@ -639,6 +665,10 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 	if inst.TitleLocked {
 		titleLockedInt = 1
 	}
+	autoNameInt := 0
+	if inst.AutoName {
+		autoNameInt = 1
+	}
 	_, err := s.db.Exec(`
 		INSERT OR REPLACE INTO instances (
 			id, title, project_path, group_path, sort_order,
@@ -646,15 +676,15 @@ func (s *StateDB) SaveInstance(inst *InstanceRow) error {
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch, account,
-			archived_at, pin, tool_data, title_locked
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			archived_at, tool_data, title_locked, auto_name, auto_name_description, pin
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		inst.ID, inst.Title, inst.ProjectPath, inst.GroupPath, inst.Order,
 		inst.Command, inst.Wrapper, inst.Tool, inst.Status, inst.TmuxSession, inst.TmuxSocketName,
 		inst.CreatedAt.Unix(), inst.LastAccessed.Unix(),
 		inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
 		inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch, inst.Account,
-		archivedAtUnix(inst.ArchivedAt), inst.Pin, string(toolData), titleLockedInt,
+		archivedAtUnix(inst.ArchivedAt), string(toolData), titleLockedInt, autoNameInt, inst.AutoNameDescription, inst.Pin,
 	)
 	return err
 }
@@ -788,8 +818,8 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch, account,
-			archived_at, pin, tool_data, title_locked
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			archived_at, tool_data, title_locked, auto_name, auto_name_description, pin
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return err
@@ -816,13 +846,17 @@ func (s *StateDB) saveInstancesOnce(insts []*InstanceRow) error {
 		if inst.TitleLocked {
 			titleLockedInt = 1
 		}
+		autoNameInt := 0
+		if inst.AutoName {
+			autoNameInt = 1
+		}
 		if _, err := stmt.Exec(
 			inst.ID, inst.Title, inst.ProjectPath, inst.GroupPath, inst.Order,
 			inst.Command, inst.Wrapper, inst.Tool, inst.Status, inst.TmuxSession, inst.TmuxSocketName,
 			inst.CreatedAt.Unix(), inst.LastAccessed.Unix(),
 			inst.ParentSessionID, isConductorInt, noTransitionNotifyInt,
 			inst.WorktreePath, inst.WorktreeRepo, inst.WorktreeBranch, inst.Account,
-			archivedAtUnix(inst.ArchivedAt), inst.Pin, string(toolData), titleLockedInt,
+			archivedAtUnix(inst.ArchivedAt), string(toolData), titleLockedInt, autoNameInt, inst.AutoNameDescription, inst.Pin,
 		); err != nil {
 			return err
 		}
@@ -851,7 +885,7 @@ func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
 			created_at, last_accessed,
 			parent_session_id, is_conductor, no_transition_notify,
 			worktree_path, worktree_repo, worktree_branch, account,
-			archived_at, pin, tool_data, title_locked
+			archived_at, tool_data, title_locked, auto_name, auto_name_description, pin
 		FROM instances ORDER BY sort_order
 	`)
 	if err != nil {
@@ -864,14 +898,14 @@ func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
 		r := &InstanceRow{}
 		var createdUnix, accessedUnix, archivedUnix int64
 		var toolDataStr string
-		var isConductorInt, noTransitionNotifyInt, titleLockedInt int
+		var isConductorInt, noTransitionNotifyInt, titleLockedInt, autoNameInt int
 		if err := rows.Scan(
 			&r.ID, &r.Title, &r.ProjectPath, &r.GroupPath, &r.Order,
 			&r.Command, &r.Wrapper, &r.Tool, &r.Status, &r.TmuxSession, &r.TmuxSocketName,
 			&createdUnix, &accessedUnix,
 			&r.ParentSessionID, &isConductorInt, &noTransitionNotifyInt,
 			&r.WorktreePath, &r.WorktreeRepo, &r.WorktreeBranch, &r.Account,
-			&archivedUnix, &r.Pin, &toolDataStr, &titleLockedInt,
+			&archivedUnix, &toolDataStr, &titleLockedInt, &autoNameInt, &r.AutoNameDescription, &r.Pin,
 		); err != nil {
 			return nil, err
 		}
@@ -885,6 +919,7 @@ func (s *StateDB) LoadInstances() ([]*InstanceRow, error) {
 		r.IsConductor = isConductorInt != 0
 		r.NoTransitionNotify = noTransitionNotifyInt != 0
 		r.TitleLocked = titleLockedInt != 0
+		r.AutoName = autoNameInt != 0
 		r.ToolData = json.RawMessage(toolDataStr)
 		result = append(result, r)
 	}
@@ -1003,6 +1038,26 @@ func (s *StateDB) WriteStatus(id, status, tool string) error {
 			     acknowledged = CASE WHEN ? = 'running' THEN 0 ELSE acknowledged END
 			 WHERE id = ?`,
 			status, tool, status, id,
+		)
+		return err
+	})
+}
+
+// WriteAutoNameDescription persists the latest Claude task description for an
+// auto-named session into the auto_name_description column without a whole-row
+// INSERT OR REPLACE. The background status loop captures the live pane title on
+// its own cadence; none of those ticks run a full Save, so without this targeted
+// write the description would only reach disk on the next user-triggered save —
+// and an app exit before then would lose the name on reopen (the bug this fixes).
+//
+// Wrapped in withBusyRetry for the same reason as WriteStatus: SQLite serializes
+// writers, so under contention a transient SQLITE_BUSY would otherwise silently
+// drop the update.
+func (s *StateDB) WriteAutoNameDescription(id, description string) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(
+			`UPDATE instances SET auto_name_description = ? WHERE id = ?`,
+			description, id,
 		)
 		return err
 	})

--- a/internal/statedb/statedb_test.go
+++ b/internal/statedb/statedb_test.go
@@ -107,6 +107,61 @@ func TestSaveLoadInstances(t *testing.T) {
 	}
 }
 
+func TestSaveInstancesPreservesFreshAutoNameFieldsFromStaleSnapshot(t *testing.T) {
+	db := newTestDB(t)
+	now := time.Now()
+	row := &InstanceRow{
+		ID:          "auto-1",
+		Title:       "lively-fjord",
+		ProjectPath: "/tmp/project",
+		GroupPath:   "grp",
+		Tool:        "claude",
+		Status:      "idle",
+		CreatedAt:   now,
+		ToolData:    json.RawMessage("{}"),
+		AutoName:    true,
+	}
+	if err := db.SaveInstances([]*InstanceRow{row}); err != nil {
+		t.Fatalf("seed SaveInstances: %v", err)
+	}
+
+	if err := db.WriteAutoNameDescription(row.ID, "Review SketchUp house models"); err != nil {
+		t.Fatalf("WriteAutoNameDescription: %v", err)
+	}
+
+	stale := *row
+	stale.AutoNameDescription = ""
+	if err := db.SaveInstances([]*InstanceRow{&stale}); err != nil {
+		t.Fatalf("stale SaveInstances: %v", err)
+	}
+
+	loaded, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("loaded %d rows, want 1", len(loaded))
+	}
+	if got := loaded[0].AutoNameDescription; got != "Review SketchUp house models" {
+		t.Errorf("AutoNameDescription after stale SaveInstances = %q, want fresh DB value", got)
+	}
+
+	if _, err := db.DB().Exec(`UPDATE instances SET auto_name = 0 WHERE id = ?`, row.ID); err != nil {
+		t.Fatalf("clear auto_name directly: %v", err)
+	}
+	stale.AutoName = true
+	if err := db.SaveInstances([]*InstanceRow{&stale}); err != nil {
+		t.Fatalf("stale AutoName SaveInstances: %v", err)
+	}
+	loaded, err = db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances after stale AutoName save: %v", err)
+	}
+	if loaded[0].AutoName {
+		t.Error("AutoName resurrected after stale SaveInstances, want cleared DB value preserved")
+	}
+}
+
 func TestSaveLoadGroups(t *testing.T) {
 	db := newTestDB(t)
 

--- a/internal/tmux/clean_pane_title_test.go
+++ b/internal/tmux/clean_pane_title_test.go
@@ -1,0 +1,63 @@
+package tmux
+
+import (
+	"testing"
+)
+
+func TestCleanPaneTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// Empty string stays empty
+		{"empty string", "", ""},
+
+		// Generic tool titles collapse to empty
+		{"Claude Code title", "Claude Code", ""},
+		{"Gemini CLI title", "Gemini CLI", ""},
+		{"Codex CLI title", "Codex CLI", ""},
+
+		// Braille spinner prefix is stripped, leaving the description
+		{"braille spinner ⠋ + description", "⠋ Refactoring auth", "Refactoring auth"},
+		{"braille spinner ⠙ + description", "⠙ Building tests", "Building tests"},
+		{"braille spinner multiple + text", "⠋⠙ Running migrations", "Running migrations"},
+
+		// Done-marker prefix (StripSpinnerRunes strips ✳ ✽ ✶ ✻ ✢ ·)
+		{"done marker ✳ + description", "✳ Worked for 54s", "Worked for 54s"},
+		{"done marker ✻ + description", "✻ Task complete", "Task complete"},
+		{"done marker ✽ + description", "✽ Finished", "Finished"},
+		{"done marker ✶ + description", "✶ Done patching", "Done patching"},
+		{"done marker ✢ + description", "✢ Committed changes", "Committed changes"},
+		{"middle-dot marker · + description", "· Something done", "Something done"},
+
+		// Braille char outside SpinnerRuneSet (U+2800-28FF range): stripped by TrimLeftFunc
+		{"U+2800 braille space prefix", string(rune(0x2800)) + " Some task", "Some task"},
+		{"U+28FF high braille prefix", string(rune(0x28FF)) + " Other task", "Other task"},
+
+		// Plain description with no markers → unchanged
+		{"plain description", "Implement login flow", "Implement login flow"},
+		{"plain with numbers", "Fix issue #42", "Fix issue #42"},
+
+		// Leading/trailing whitespace trimmed
+		{"leading whitespace", "   my task", "my task"},
+		{"trailing whitespace", "my task   ", "my task"},
+		{"both sides whitespace", "  do something  ", "do something"},
+
+		// After stripping markers, if only whitespace remains → empty
+		{"only whitespace", "   ", ""},
+
+		// A title that becomes one of the generic names after stripping is untouched
+		// (the generic names don't have markers, so they hit the switch directly)
+		{"generic title with trailing space", "Claude Code ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CleanPaneTitle(tt.input)
+			if got != tt.want {
+				t.Errorf("CleanPaneTitle(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/title_detection.go
+++ b/internal/tmux/title_detection.go
@@ -231,6 +231,32 @@ func AnalyzePaneTitle(title, _ string) TitleState {
 	return TitleStateUnknown
 }
 
+// CleanPaneTitle strips spinner/done-marker characters from a tmux pane title
+// and returns the task description. Returns "" for empty or generic tool titles
+// ("Claude Code", "Gemini CLI", "Codex CLI").
+//
+// This is the canonical implementation shared by internal/ui (TUI) and
+// internal/web (web server). Both packages import internal/tmux, so placing
+// the logic here avoids a circular dependency.
+func CleanPaneTitle(title string) string {
+	if title == "" {
+		return ""
+	}
+	// Strip known spinner/done-marker runes (·✳✽✶✻✢ and braille ⠋⠙⠹…).
+	cleaned := StripSpinnerRunes(title)
+	// Also strip any remaining Braille characters (U+2800-28FF) that Claude Code
+	// may use as spinner frames beyond the canonical set.
+	cleaned = strings.TrimLeftFunc(cleaned, func(r rune) bool {
+		return r >= 0x2800 && r <= 0x28FF
+	})
+	cleaned = strings.TrimSpace(cleaned)
+	switch cleaned {
+	case "", "Claude Code", "Gemini CLI", "Codex CLI":
+		return ""
+	}
+	return cleaned
+}
+
 // containsBrailleChar returns true if the string contains any Unicode Braille
 // character (U+2800 to U+28FF). Claude Code uses these as spinner frames
 // in the pane title while actively processing.

--- a/internal/ui/autoname_capture_test.go
+++ b/internal/ui/autoname_capture_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import "testing"
+
+// TestShouldPersistAutoNameDesc locks the decision the background status loop
+// makes before writing an auto-named session's task description to SQLite. This
+// is the capture half of the reopen fix: the read/round-trip halves are tested
+// elsewhere, but the live-pane → disk path runs only on a background tick with a
+// real DB, so its branching is pinned here as a pure function.
+func TestShouldPersistAutoNameDesc(t *testing.T) {
+	cases := []struct {
+		name          string
+		autoName      bool
+		paneTitle     string
+		lastPersisted string
+		wantDesc      string
+		wantWrite     bool
+	}{
+		{"not auto-named: never write", false, "Some task", "", "", false},
+		{"auto-named, new description: write", true, "Review SketchUp models", "", "Review SketchUp models", true},
+		{"auto-named, changed description: write", true, "New task", "Old task", "New task", true},
+		{"auto-named, empty pane must not clobber saved desc", true, "", "Old task", "", false},
+		{"auto-named, unchanged: skip to avoid write pressure", true, "Same task", "Same task", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			desc, write := shouldPersistAutoNameDesc(tc.autoName, tc.paneTitle, tc.lastPersisted)
+			if write != tc.wantWrite || desc != tc.wantDesc {
+				t.Errorf("shouldPersistAutoNameDesc(%v, %q, %q) = (%q, %v), want (%q, %v)",
+					tc.autoName, tc.paneTitle, tc.lastPersisted, desc, write, tc.wantDesc, tc.wantWrite)
+			}
+		})
+	}
+}

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -298,6 +298,11 @@ type Home struct {
 	statusWorkerDone    chan struct{}            // Signals worker has stopped
 	lastFullStatusSweep atomic.Int64             // UnixNano timestamp of last full background status sweep
 	lastPersistedStatus map[string]string        // instanceID -> last status written to SQLite
+	// lastPersistedAutoNameDesc tracks the last auto-name description written to
+	// SQLite per instance, so the background loop only issues a targeted write
+	// when the live Claude task description actually changes (mirrors
+	// lastPersistedStatus). Keyed by instance ID.
+	lastPersistedAutoNameDesc map[string]string
 
 	// Issue #1143: auto-stop dormant child sessions via central poll.
 	// Coalesced into the existing 2-second statusWorker tick by way of
@@ -987,71 +992,72 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 	}
 
 	h := &Home{
-		profile:              actualProfile,
-		storage:              storage,
-		storageWarning:       storageWarning,
-		search:               NewSearch(),
-		newDialog:            NewNewDialog(),
-		groupDialog:          NewGroupDialog(),
-		forkDialog:           NewForkDialog(),
-		confirmDialog:        NewConfirmDialog(),
-		helpOverlay:          NewHelpOverlay(),
-		mcpDialog:            NewMCPDialog(),
-		pluginDialog:         NewPluginDialog(),
-		editPathsDialog:      NewEditPathsDialog(),
-		editSessionDialog:    NewEditSessionDialog(),
-		skillDialog:          NewSkillDialog(),
-		setupWizard:          NewSetupWizard(),
-		settingsPanel:        NewSettingsPanel(),
-		analyticsPanel:       NewAnalyticsPanel(),
-		geminiModelDialog:    NewGeminiModelDialog(),
-		sessionPickerDialog:  NewSessionPickerDialog(),
-		worktreeFinishDialog: NewWorktreeFinishDialog(),
-		feedbackDialog:       NewFeedbackDialog(),
-		zoxidePicker:         NewZoxidePicker(),
-		feedbackSender:       feedback.NewSender(),
-		watcherPanel:         NewWatcherPanel(),
-		toolVisibilityPanel:  NewToolVisibilityPanel(),
-		insertBatchDuration:  defaultInsertBatchDuration,
-		insertOpenKeySender:  defaultInsertOpenKeySender,
-		cursor:               0,
-		initialLoading:       true, // Show splash until sessions load
-		ctx:                  ctx,
-		cancel:               cancel,
-		instances:            []*session.Instance{},
-		instanceByID:         make(map[string]*session.Instance),
-		groupTree:            session.NewGroupTree([]*session.Instance{}),
-		flatItems:            []session.Item{},
-		previewCache:         make(map[string]string),
-		previewCacheTime:     make(map[string]time.Time),
-		analyticsCache:       make(map[string]*session.SessionAnalytics),
-		geminiAnalyticsCache: make(map[string]*session.GeminiSessionAnalytics),
-		analyticsCacheTime:   make(map[string]time.Time),
-		clearOnCompactSent:   make(map[string]time.Time),
-		launchingSessions:    make(map[string]time.Time),
-		resumingSessions:     make(map[string]time.Time),
-		mcpLoadingSessions:   make(map[string]time.Time),
-		forkingSessions:      make(map[string]time.Time),
-		setupRunningSessions: make(map[string]time.Time),
-		creatingSessions:     make(map[string]*CreatingSession),
-		lastLogActivity:      make(map[string]time.Time),
-		windowsCollapsed:     make(map[string]bool),
-		worktreeDirtyCache:   make(map[string]bool),
-		worktreeDirtyCacheTs: make(map[string]time.Time),
-		statusTrigger:        make(chan statusUpdateRequest, 1), // Buffered to avoid blocking
-		statusWorkerDone:     make(chan struct{}),
-		idleTimeoutWatcher:   session.NewIdleTimeoutWatcher(session.IdleTimeoutWatcherConfig{}),
-		lastPersistedStatus:  make(map[string]string),
-		logUpdateChan:        make(chan *session.Instance, 100), // Buffered to absorb bursts
-		hotkeys:              make(map[string]string),
-		hotkeyLookup:         make(map[string]string),
-		blockedHotkeys:       make(map[string]bool),
-		notesEditor:          newNotesEditor(),
-		boundKeys:            make(map[string]string),
-		undoStack:            make([]deletedSessionEntry, 0, 10),
-		pendingTitleChanges:  make(map[string]string),
-		debugMode:            logging.IsDebugEnabled(),
-		lastClickIndex:       -1,
+		profile:                   actualProfile,
+		storage:                   storage,
+		storageWarning:            storageWarning,
+		search:                    NewSearch(),
+		newDialog:                 NewNewDialog(),
+		groupDialog:               NewGroupDialog(),
+		forkDialog:                NewForkDialog(),
+		confirmDialog:             NewConfirmDialog(),
+		helpOverlay:               NewHelpOverlay(),
+		mcpDialog:                 NewMCPDialog(),
+		pluginDialog:              NewPluginDialog(),
+		editPathsDialog:           NewEditPathsDialog(),
+		editSessionDialog:         NewEditSessionDialog(),
+		skillDialog:               NewSkillDialog(),
+		setupWizard:               NewSetupWizard(),
+		settingsPanel:             NewSettingsPanel(),
+		analyticsPanel:            NewAnalyticsPanel(),
+		geminiModelDialog:         NewGeminiModelDialog(),
+		sessionPickerDialog:       NewSessionPickerDialog(),
+		worktreeFinishDialog:      NewWorktreeFinishDialog(),
+		feedbackDialog:            NewFeedbackDialog(),
+		zoxidePicker:              NewZoxidePicker(),
+		feedbackSender:            feedback.NewSender(),
+		watcherPanel:              NewWatcherPanel(),
+		toolVisibilityPanel:       NewToolVisibilityPanel(),
+		insertBatchDuration:       defaultInsertBatchDuration,
+		insertOpenKeySender:       defaultInsertOpenKeySender,
+		cursor:                    0,
+		initialLoading:            true, // Show splash until sessions load
+		ctx:                       ctx,
+		cancel:                    cancel,
+		instances:                 []*session.Instance{},
+		instanceByID:              make(map[string]*session.Instance),
+		groupTree:                 session.NewGroupTree([]*session.Instance{}),
+		flatItems:                 []session.Item{},
+		previewCache:              make(map[string]string),
+		previewCacheTime:          make(map[string]time.Time),
+		analyticsCache:            make(map[string]*session.SessionAnalytics),
+		geminiAnalyticsCache:      make(map[string]*session.GeminiSessionAnalytics),
+		analyticsCacheTime:        make(map[string]time.Time),
+		clearOnCompactSent:        make(map[string]time.Time),
+		launchingSessions:         make(map[string]time.Time),
+		resumingSessions:          make(map[string]time.Time),
+		mcpLoadingSessions:        make(map[string]time.Time),
+		forkingSessions:           make(map[string]time.Time),
+		setupRunningSessions:      make(map[string]time.Time),
+		creatingSessions:          make(map[string]*CreatingSession),
+		lastLogActivity:           make(map[string]time.Time),
+		windowsCollapsed:          make(map[string]bool),
+		worktreeDirtyCache:        make(map[string]bool),
+		worktreeDirtyCacheTs:      make(map[string]time.Time),
+		statusTrigger:             make(chan statusUpdateRequest, 1), // Buffered to avoid blocking
+		statusWorkerDone:          make(chan struct{}),
+		idleTimeoutWatcher:        session.NewIdleTimeoutWatcher(session.IdleTimeoutWatcherConfig{}),
+		lastPersistedStatus:       make(map[string]string),
+		lastPersistedAutoNameDesc: make(map[string]string),
+		logUpdateChan:             make(chan *session.Instance, 100), // Buffered to absorb bursts
+		hotkeys:                   make(map[string]string),
+		hotkeyLookup:              make(map[string]string),
+		blockedHotkeys:            make(map[string]bool),
+		notesEditor:               newNotesEditor(),
+		boundKeys:                 make(map[string]string),
+		undoStack:                 make([]deletedSessionEntry, 0, 10),
+		pendingTitleChanges:       make(map[string]string),
+		debugMode:                 logging.IsDebugEnabled(),
+		lastClickIndex:            -1,
 	}
 	h.sessionRenderSnapshot.Store(make(map[string]sessionRenderState))
 
@@ -3084,15 +3090,40 @@ type sessionRenderState struct {
 }
 
 // displaySessionTitle returns the label to render for a session row. For an
-// auto-named quick session (AutoName) with a non-empty pane title, it returns
-// the live Claude task description; otherwise it returns the session's own
-// Title (the CLI handle or a user/Claude-chosen name).
+// auto-named quick session (AutoName) it returns, in order of preference: the
+// live Claude task description (paneTitle), the last description we persisted,
+// then the session's own Title. Non-auto-named sessions always return Title
+// (the CLI handle or a user/Claude-chosen name).
 //
 // paneTitle must already be cleaned by cleanPaneTitle: an empty paneTitle means
-// idle/just-started, so the session falls back to its handle.
+// idle/just-started. The persisted-description fallback keeps the meaningful
+// name visible on reopen before the session resumes and re-emits a live title.
+// shouldPersistAutoNameDesc decides whether the background status loop should
+// write a new task description for an auto-named session, given the live
+// (already-cleaned) pane title and the value last persisted for it. It returns
+// the description to write and whether to write at all. Kept as a pure function
+// so the capture branching is testable without a live DB/tmux: the loop itself
+// only runs on a background tick. Rules: only auto-named sessions; never write
+// an empty pane (idle/just-started must not clobber a saved description); skip
+// when unchanged to avoid SQLite write pressure (mirrors the status loop).
+func shouldPersistAutoNameDesc(autoName bool, paneTitle, lastPersisted string) (string, bool) {
+	if !autoName || paneTitle == "" || paneTitle == lastPersisted {
+		return "", false
+	}
+	return paneTitle, true
+}
+
 func displaySessionTitle(inst *session.Instance, paneTitle string) string {
-	if inst.AutoName && paneTitle != "" {
-		return paneTitle
+	if inst.AutoName {
+		// Prefer the live task description; fall back to the last one we
+		// persisted so the name still shows on reopen when the session is
+		// stopped/idle (no live pane title); finally fall back to the handle.
+		if paneTitle != "" {
+			return paneTitle
+		}
+		if desc := inst.GetAutoNameDescription(); desc != "" {
+			return desc
+		}
 	}
 	return inst.Title
 }
@@ -3581,6 +3612,31 @@ func (h *Home) backgroundStatusUpdate() {
 		for id := range h.lastPersistedStatus {
 			if _, ok := currentIDs[id]; !ok {
 				delete(h.lastPersistedStatus, id)
+			}
+		}
+
+		// Persist the live Claude task description for auto-named sessions so the
+		// meaningful name survives an app reopen (it would otherwise live only in
+		// the in-memory render snapshot). The snapshot was refreshed just above,
+		// so getSessionRenderState returns the freshly-cleaned pane title. Only
+		// write on change (mirrors the status loop) and only when non-empty — an
+		// empty/idle pane must not clobber a previously captured description.
+		for _, inst := range instances {
+			desc, write := shouldPersistAutoNameDesc(
+				inst.AutoName,
+				h.getSessionRenderState(inst).paneTitle,
+				h.lastPersistedAutoNameDesc[inst.ID],
+			)
+			if !write {
+				continue
+			}
+			inst.SetAutoNameDescription(desc)
+			_ = db.WriteAutoNameDescription(inst.ID, desc)
+			h.lastPersistedAutoNameDesc[inst.ID] = desc
+		}
+		for id := range h.lastPersistedAutoNameDesc {
+			if _, ok := currentIDs[id]; !ok {
+				delete(h.lastPersistedAutoNameDesc, id)
 			}
 		}
 
@@ -8160,7 +8216,7 @@ func (h *Home) confirmCreateDirectory() tea.Cmd {
 		nil,
 		parentSessionID,
 		parentProjectPath,
-		"", // no placeholder — non-worktree sessions are fast
+		"",    // no placeholder — non-worktree sessions are fast
 		false, // not auto-named
 	)
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4268,6 +4268,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				for id, title := range h.pendingTitleChanges {
 					if inst := h.getInstanceByID(id); inst != nil && inst.Title != title {
 						inst.Title = title
+						inst.AutoName = false // re-applied pending title is a genuine rename; keep the user-chosen name
 						inst.SyncTmuxDisplayName()
 						applied = true
 						uiLog.Info("pending_rename_reapplied",

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3114,7 +3114,7 @@ func shouldPersistAutoNameDesc(autoName bool, paneTitle, lastPersisted string) (
 }
 
 func displaySessionTitle(inst *session.Instance, paneTitle string) string {
-	if inst.AutoName {
+	if inst.GetAutoName() {
 		// Prefer the live task description; fall back to the last one we
 		// persisted so the name still shows on reopen when the session is
 		// stopped/idle (no live pane title); finally fall back to the handle.
@@ -3623,7 +3623,7 @@ func (h *Home) backgroundStatusUpdate() {
 		// empty/idle pane must not clobber a previously captured description.
 		for _, inst := range instances {
 			desc, write := shouldPersistAutoNameDesc(
-				inst.AutoName,
+				inst.GetAutoName(),
 				h.getSessionRenderState(inst).paneTitle,
 				h.lastPersistedAutoNameDesc[inst.ID],
 			)
@@ -3631,7 +3631,12 @@ func (h *Home) backgroundStatusUpdate() {
 				continue
 			}
 			inst.SetAutoNameDescription(desc)
-			_ = db.WriteAutoNameDescription(inst.ID, desc)
+			if err := db.WriteAutoNameDescription(inst.ID, desc); err != nil {
+				uiLog.Warn("autoname_persist_failed",
+					slog.String("id", inst.ID),
+					slog.String("error", err.Error()))
+				continue
+			}
 			h.lastPersistedAutoNameDesc[inst.ID] = desc
 		}
 		for id := range h.lastPersistedAutoNameDesc {
@@ -4322,14 +4327,16 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(h.pendingTitleChanges) > 0 {
 				applied := false
 				for id, title := range h.pendingTitleChanges {
-					if inst := h.getInstanceByID(id); inst != nil && inst.Title != title {
-						inst.Title = title
-						inst.AutoName = false // re-applied pending title is a genuine rename; keep the user-chosen name
-						inst.SyncTmuxDisplayName()
-						applied = true
-						uiLog.Info("pending_rename_reapplied",
-							slog.String("session_id", id),
-							slog.String("title", title))
+					if inst := h.getInstanceByID(id); inst != nil {
+						if inst.Title != title {
+							inst.Title = title
+							inst.SyncTmuxDisplayName()
+							applied = true
+							uiLog.Info("pending_rename_reapplied",
+								slog.String("session_id", id),
+								slog.String("title", title))
+						}
+						inst.SetAutoName(false) // pending title is a genuine rename; keep the user-chosen name
 					}
 				}
 				// Clear pending changes and persist if any were re-applied
@@ -9472,7 +9479,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			inst = session.NewInstanceWithTool(name, path, tool)
 		}
 		inst.Command = command
-		inst.AutoName = autoName // quick-create paths pass true; see render substitution
+		inst.SetAutoName(autoName) // quick-create paths pass true; see render substitution
 
 		// Set worktree fields if provided
 		if worktreePath != "" {
@@ -10744,10 +10751,19 @@ func (h *Home) deleteSession(inst *session.Instance) tea.Cmd {
 // the statusWorker goroutine — writing it from the UI goroutine would be a
 // data race.
 func (h *Home) captureAutoNameBeforeStop(inst *session.Instance) {
-	if inst == nil || !inst.AutoName {
+	if inst == nil || !inst.GetAutoName() {
 		return
 	}
-	live := h.getSessionRenderState(inst).paneTitle
+	live := ""
+	if tmuxSess := inst.GetTmuxSession(); tmuxSess != nil {
+		tmux.RefreshPaneInfoCache()
+		if paneInfo, ok := tmux.GetCachedPaneInfo(tmuxSess.Name); ok {
+			live = cleanPaneTitle(paneInfo.Title)
+		}
+	}
+	if live == "" {
+		live = h.getSessionRenderState(inst).paneTitle
+	}
 	if live == "" || live == inst.GetAutoNameDescription() {
 		return
 	}
@@ -14165,16 +14181,17 @@ func (h *Home) renderSessionItem(
 	if isMaestro {
 		displayTitle = "⬢ " + displayTitle
 	}
-	if inst.AutoName && instState.paneTitle != "" && h.width > 0 {
+	if inst.GetAutoName() && listWidth > 0 {
 		// Task descriptions can be long; truncate to the row's free width so the
 		// tool label and badges stay on-row. Keep the reserved terms below in
 		// sync with the row format that follows.
 		reserved := cellWidth(baseIndent) + cellWidth(selectionPrefix) +
 			cellWidth(treeStyle.Render(treeConnector)) + cellWidth(windowChevron) +
 			cellWidth(status) + 1 /* space before title */ + cellWidth(tool) +
-			cellWidth(yoloBadge) + cellWidth(worktreeBadge) + cellWidth(sandboxBadge) +
-			cellWidth(multiRepoBadge) + cellWidth(sshBadge)
-		budget := h.width - reserved - 1 // -1 trailing margin
+			cellWidth(maestroBadge) + cellWidth(yoloBadge) + cellWidth(worktreeBadge) +
+			cellWidth(sandboxBadge) + cellWidth(multiRepoBadge) + cellWidth(sshBadge) +
+			cellWidth(timestampBadge)
+		budget := listWidth - reserved - 1 // -1 trailing margin
 		if budget > 0 && cellWidth(displayTitle) > budget {
 			displayTitle = cellTruncate(displayTitle, budget, "…")
 		}
@@ -14208,7 +14225,7 @@ func (h *Home) renderSessionItem(
 	// so the prior measurement let the trailing pane-title text overflow
 	// the panel and shove subsequent rows down by one cell. See
 	// internal/ui/cellwidth.go for the upstream disagreement.
-	if (selected || h.showPaneTitles) && instState.paneTitle != "" && !inst.AutoName {
+	if (selected || h.showPaneTitles) && instState.paneTitle != "" && !inst.GetAutoName() {
 		// Dual layout: sidebar is narrower than h.width (#937). Using full
 		// terminal width here overflows the SESSIONS pane, then lipgloss
 		// truncation disagrees from terminal cells — wrapped lines duplicate

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -3083,6 +3083,20 @@ type sessionRenderState struct {
 	paneTitle string // Current task description from tmux pane title (stripped of spinner/done markers)
 }
 
+// displaySessionTitle returns the label to render for a session row. For an
+// auto-named quick session (AutoName) with a non-empty pane title, it returns
+// the live Claude task description; otherwise it returns the session's own
+// Title (the CLI handle or a user/Claude-chosen name).
+//
+// paneTitle must already be cleaned by cleanPaneTitle: an empty paneTitle means
+// idle/just-started, so the session falls back to its handle.
+func displaySessionTitle(inst *session.Instance, paneTitle string) string {
+	if inst.AutoName && paneTitle != "" {
+		return paneTitle
+	}
+	return inst.Title
+}
+
 // cleanPaneTitle strips spinner/done marker characters from a tmux pane title
 // and returns the task description. Returns "" for default/generic titles.
 func cleanPaneTitle(title string) string {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -10727,6 +10727,40 @@ func (h *Home) deleteSession(inst *session.Instance) tea.Cmd {
 	}
 }
 
+// captureAutoNameBeforeStop persists an auto-named session's live Claude task
+// description right before its process is stopped. Auto-named rows render the
+// live tmux pane title; once Kill() tears the process down that live title is
+// gone and displaySessionTitle falls back to the persisted auto-name
+// description. The background status tick is the only other writer, so a
+// session stopped before that tick fires would revert to its bare random
+// handle. Capturing here closes that window for archive (and any future stop
+// path that calls it).
+//
+// No-op unless the session is auto-named with a non-empty live title that
+// differs from what is already stored — an empty/idle pane must never clobber a
+// previously captured description (mirrors shouldPersistAutoNameDesc). Writes
+// the in-memory field (instance-locked) and the DB column via h.storage;
+// deliberately does NOT touch h.lastPersistedAutoNameDesc, which is owned by
+// the statusWorker goroutine — writing it from the UI goroutine would be a
+// data race.
+func (h *Home) captureAutoNameBeforeStop(inst *session.Instance) {
+	if inst == nil || !inst.AutoName {
+		return
+	}
+	live := h.getSessionRenderState(inst).paneTitle
+	if live == "" || live == inst.GetAutoNameDescription() {
+		return
+	}
+	inst.SetAutoNameDescription(live)
+	if h.storage == nil {
+		return
+	}
+	if err := h.storage.WriteAutoNameDescription(inst.ID, live); err != nil {
+		uiLog.Warn("autoname_capture_failed",
+			slog.String("id", inst.ID), slog.String("error", err.Error()))
+	}
+}
+
 // closeSession stops a session process but keeps metadata in list/storage.
 func (h *Home) closeSession(inst *session.Instance) tea.Cmd {
 	id := inst.ID
@@ -10738,6 +10772,9 @@ func (h *Home) closeSession(inst *session.Instance) tea.Cmd {
 
 // archiveSession stops a session and marks it archived.
 func (h *Home) archiveSession(inst *session.Instance) tea.Cmd {
+	// Snapshot the live Claude task description on the UI goroutine before the
+	// background Kill tears down the pane that title comes from.
+	h.captureAutoNameBeforeStop(inst)
 	id := inst.ID
 	return func() tea.Msg {
 		if killErr := inst.Kill(); killErr != nil {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -6152,6 +6152,7 @@ func (h *Home) handleNewDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			parentSessionID,
 			parentProjectPath,
 			tempID,
+			false, // not auto-named — user went through the full create dialog
 		)
 
 	case msg.String() == "esc":
@@ -8145,6 +8146,7 @@ func (h *Home) confirmCreateDirectory() tea.Cmd {
 		parentSessionID,
 		parentProjectPath,
 		"", // no placeholder — non-worktree sessions are fast
+		false, // not auto-named
 	)
 }
 
@@ -9350,6 +9352,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 	additionalPaths []string,
 	parentSessionID, parentProjectPath string,
 	tempID string,
+	autoName bool,
 ) tea.Cmd {
 	return func() tea.Msg {
 		uiLog.Info("create_session_start",
@@ -9398,6 +9401,7 @@ func (h *Home) createSessionInGroupWithWorktreeAndOptions(
 			inst = session.NewInstanceWithTool(name, path, tool)
 		}
 		inst.Command = command
+		inst.AutoName = autoName // quick-create paths pass true; see render substitution
 
 		// Set worktree fields if provided
 		if worktreePath != "" {
@@ -9860,7 +9864,8 @@ func (h *Home) quickCreateSession() tea.Cmd {
 		"",         // no explicit model override
 		false, nil, // no multi-repo
 		"", "", // no parent
-		"", // no placeholder
+		"",   // no placeholder
+		true, // quick-create → auto-named handle
 	)
 }
 
@@ -9943,6 +9948,7 @@ func (h *Home) quickCreateSessionAt(projectPath string) tea.Cmd {
 		false, nil,
 		"", "",
 		"",
+		true, // quick-create → auto-named handle
 	)
 }
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -13934,17 +13934,6 @@ func (h *Home) renderSessionItem(
 		}
 	}
 
-	// Pin marker (pin-sessions): a 📌 prefix flags any pinned row. Position in
-	// the list conveys top vs bottom; the emoji conveys "this is pinned".
-	displayTitle := inst.Title
-	if inst.Pin != session.PinNone {
-		displayTitle = "📌 " + displayTitle
-	}
-	// Maestro (fleet supervisor): ⬢ glyph leads the title.
-	if isMaestro {
-		displayTitle = "⬢ " + displayTitle
-	}
-	title := titleStyle.Render(displayTitle)
 	tool := toolStyle.Render(" " + instTool)
 
 	// Supervisor badge for the maestro row.
@@ -14066,6 +14055,38 @@ func (h *Home) renderSessionItem(
 		windowChevron = chevronStyle.Render(chevronChar)
 	}
 
+	// Auto-named quick sessions display Claude's live task description (the
+	// tmux pane title) in place of the random handle. instState.paneTitle is
+	// already cleaned by cleanPaneTitle, so an idle/just-started session (empty
+	// paneTitle) falls back to the handle automatically.
+	displayTitle := displaySessionTitle(inst, instState.paneTitle)
+	// Pin marker (pin-sessions): a 📌 prefix flags any pinned row. Position in
+	// the list conveys top vs bottom; the emoji conveys "this is pinned".
+	// Prepended before the AutoName truncation budget so width accounting below
+	// stays correct.
+	if inst.Pin != session.PinNone {
+		displayTitle = "📌 " + displayTitle
+	}
+	// Maestro (fleet supervisor): ⬢ glyph leads the title.
+	if isMaestro {
+		displayTitle = "⬢ " + displayTitle
+	}
+	if inst.AutoName && instState.paneTitle != "" && h.width > 0 {
+		// Task descriptions can be long; truncate to the row's free width so the
+		// tool label and badges stay on-row. Keep the reserved terms below in
+		// sync with the row format that follows.
+		reserved := cellWidth(baseIndent) + cellWidth(selectionPrefix) +
+			cellWidth(treeStyle.Render(treeConnector)) + cellWidth(windowChevron) +
+			cellWidth(status) + 1 /* space before title */ + cellWidth(tool) +
+			cellWidth(yoloBadge) + cellWidth(worktreeBadge) + cellWidth(sandboxBadge) +
+			cellWidth(multiRepoBadge) + cellWidth(sshBadge)
+		budget := h.width - reserved - 1 // -1 trailing margin
+		if budget > 0 && cellWidth(displayTitle) > budget {
+			displayTitle = cellTruncate(displayTitle, budget, "…")
+		}
+	}
+	title := titleStyle.Render(displayTitle)
+
 	// Build row: [baseIndent][selection][tree][chevron][status] [title] [tool] [badges]
 	row := fmt.Sprintf(
 		"%s%s%s%s%s %s%s%s%s%s%s%s%s%s",
@@ -14093,7 +14114,7 @@ func (h *Home) renderSessionItem(
 	// so the prior measurement let the trailing pane-title text overflow
 	// the panel and shove subsequent rows down by one cell. See
 	// internal/ui/cellwidth.go for the upstream disagreement.
-	if (selected || h.showPaneTitles) && instState.paneTitle != "" {
+	if (selected || h.showPaneTitles) && instState.paneTitle != "" && !inst.AutoName {
 		// Dual layout: sidebar is narrower than h.width (#937). Using full
 		// terminal width here overflows the SESSIONS pane, then lipgloss
 		// truncation disagrees from terminal cells — wrapped lines duplicate

--- a/internal/ui/home_test.go
+++ b/internal/ui/home_test.go
@@ -643,6 +643,49 @@ func TestHomeRenamePendingChangesSurviveReload(t *testing.T) {
 	}
 }
 
+func TestHomeRenamePendingChangeClearsAutoName(t *testing.T) {
+	home := NewHome()
+	home.width = 100
+	home.height = 30
+
+	// Create a quick-named session (AutoName=true with a machine-generated title)
+	inst := session.NewInstance("quick-adjective-noun", "/tmp/project")
+	inst.AutoName = true
+	home.instancesMu.Lock()
+	home.instances = []*session.Instance{inst}
+	home.instanceByID[inst.ID] = inst
+	home.instancesMu.Unlock()
+	home.groupTree = session.NewGroupTree(home.instances)
+	home.rebuildFlatItems()
+
+	// User renamed the session; the rename was stored as a pending change
+	// (save was skipped because isReloading=true at the time)
+	home.pendingTitleChanges[inst.ID] = "my-chosen-name"
+
+	// A reload replaces the instance with the stale disk version (AutoName=true, old title)
+	reloadInst := session.NewInstance("quick-adjective-noun", "/tmp/project")
+	reloadInst.ID = inst.ID
+	reloadInst.AutoName = true
+
+	reloadMsg := loadSessionsMsg{
+		instances:    []*session.Instance{reloadInst},
+		groups:       nil,
+		restoreState: &reloadState{cursorSessionID: inst.ID},
+	}
+
+	model, _ := home.Update(reloadMsg)
+	h := model.(*Home)
+
+	// The user-chosen title must be re-applied
+	if h.instances[0].Title != "my-chosen-name" {
+		t.Errorf("Session title = %q, want %q", h.instances[0].Title, "my-chosen-name")
+	}
+	// AutoName must be cleared so the TUI shows the user-chosen name, not the live pane title
+	if h.instances[0].AutoName {
+		t.Error("AutoName = true after pending-rename re-apply, want false (user-chosen name should stick)")
+	}
+}
+
 func TestHomeRenamePendingChangesNoop(t *testing.T) {
 	home := NewHome()
 	home.width = 100

--- a/internal/ui/session_title_test.go
+++ b/internal/ui/session_title_test.go
@@ -6,27 +6,34 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
-// TestDisplaySessionTitle pins the substitution rule: auto-named sessions show
-// the live (already-cleaned) pane title; everything else shows the handle.
+// TestDisplaySessionTitle pins the substitution rule for auto-named sessions:
+// live pane title → saved description → handle. Non-auto-named sessions always
+// show their handle. The saved-description fallback is what keeps a meaningful
+// name visible on reopen when the session is stopped/idle and no live pane
+// title is available.
 func TestDisplaySessionTitle(t *testing.T) {
 	cases := []struct {
 		name      string
 		autoName  bool
 		title     string
-		paneTitle string
+		savedDesc string // persisted AutoNameDescription
+		paneTitle string // live (already-cleaned) pane title
 		want      string
 	}{
-		{"auto-named with task", true, "lively-fjord", "Review SketchUp models", "Review SketchUp models"},
-		{"auto-named but idle (empty pane)", true, "lively-fjord", "", "lively-fjord"},
-		{"not auto-named ignores pane", false, "my-feature", "Some task", "my-feature"},
-		{"not auto-named, no pane", false, "Auth", "", "Auth"},
+		{"auto-named, live pane wins", true, "lively-fjord", "", "Review SketchUp models", "Review SketchUp models"},
+		{"auto-named, live pane beats saved desc", true, "lively-fjord", "Old task", "New task", "New task"},
+		{"auto-named, idle falls back to saved desc", true, "lively-fjord", "Review SketchUp models", "", "Review SketchUp models"},
+		{"auto-named, idle and no saved desc -> handle", true, "lively-fjord", "", "", "lively-fjord"},
+		{"not auto-named ignores pane and desc", false, "my-feature", "ignored", "Some task", "my-feature"},
+		{"not auto-named, no pane", false, "Auth", "", "", "Auth"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			inst := &session.Instance{Title: tc.title, AutoName: tc.autoName}
+			inst.SetAutoNameDescription(tc.savedDesc)
 			if got := displaySessionTitle(inst, tc.paneTitle); got != tc.want {
-				t.Errorf("displaySessionTitle(%+v, %q) = %q, want %q",
-					inst, tc.paneTitle, got, tc.want)
+				t.Errorf("displaySessionTitle(title=%q autoName=%v savedDesc=%q, pane=%q) = %q, want %q",
+					tc.title, tc.autoName, tc.savedDesc, tc.paneTitle, got, tc.want)
 			}
 		})
 	}

--- a/internal/ui/session_title_test.go
+++ b/internal/ui/session_title_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// TestDisplaySessionTitle pins the substitution rule: auto-named sessions show
+// the live (already-cleaned) pane title; everything else shows the handle.
+func TestDisplaySessionTitle(t *testing.T) {
+	cases := []struct {
+		name      string
+		autoName  bool
+		title     string
+		paneTitle string
+		want      string
+	}{
+		{"auto-named with task", true, "lively-fjord", "Review SketchUp models", "Review SketchUp models"},
+		{"auto-named but idle (empty pane)", true, "lively-fjord", "", "lively-fjord"},
+		{"not auto-named ignores pane", false, "my-feature", "Some task", "my-feature"},
+		{"not auto-named, no pane", false, "Auth", "", "Auth"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := &session.Instance{Title: tc.title, AutoName: tc.autoName}
+			if got := displaySessionTitle(inst, tc.paneTitle); got != tc.want {
+				t.Errorf("displaySessionTitle(%+v, %q) = %q, want %q",
+					inst, tc.paneTitle, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1416.

## What

Quick-created sessions (`N` quick-create, `agent-deck add --quick`) currently keep their random adjective-noun handle forever. This PR marks those machine-generated titles with an `AutoName` flag and renders Claude's live task description (the cleaned tmux pane title) in place of the handle — so a list of quick sessions reads as what each one is doing, not `brave-falcon` × 5.

## How

- **Flag lifecycle**: `Instance.AutoName` is set only on quick-created sessions with generated titles. Every explicit naming path clears it — `SetField` rename (TUI dialog + `session set title` + CLI rename all route through it), the Claude name-sync hook, and openclaw sync. A user-chosen name always wins.
- **Display**: `displaySessionTitle` swaps in the live pane title for AutoName rows only; long task descriptions truncate to the row's free width so badges stay on-row. The redundant pane-title trailer is suppressed for these rows.
- **Persistence** (schema **v12**, on top of v11 pin): `auto_name` + `auto_name_description` columns. The background status loop persists description changes via a targeted column write (mirrors `WriteStatus` — no whole-row save), so a stopped/reopened session shows its last meaningful name instead of reverting to the random handle.
- **Archive interplay** (#1325): `archiveSession` snapshots the live description on the UI goroutine before the background `Kill()` tears down the pane it comes from.
- `tmux.CleanPaneTitle` exported for shared cleaning of raw pane titles.

## Testing

- New: flag round-trip + clear-on-rename unit tests, `displaySessionTitle` render tests, capture-before-stop test, archive round-trip test, `CleanPaneTitle` tests (`go test ./internal/session/ ./internal/ui/ ./internal/tmux/ ./internal/statedb/ ./cmd/agent-deck/` green).
- `go build ./... && go vet ./...` clean; `internal/web` parity tests green (no API surface change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick-created sessions can auto-name using Claude’s live task description; UI shows the live description instead of a machine handle.
  * Live pane titles are cleaned and persisted so sessions retain meaningful names across reloads.

* **Bug Fixes**
  * User-initiated renames reliably clear auto-naming so chosen titles persist.
  * Auto-name display truncation/duplication suppressed for clearer session rows.

* **Tests**
  * Expanded tests for auto-name behavior, persistence, storage, and title cleaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->