### PR TITLE
fix(creds-refresh): derive keep-warm defaults from config.toml profiles (#1414)

### DIFF
--- a/cmd/agent-deck/creds_refresh_cmd.go
+++ b/cmd/agent-deck/creds_refresh_cmd.go
@@ -19,8 +19,12 @@
 //	agent-deck creds-refresh --config-dir ~/.claude --config-dir ~/.claude-work
 //	agent-deck creds-refresh --interval 25m --threshold 20m
 //
-// Default config dirs (when none given): ~/.claude and ~/.claude-work, whichever
-// has a .credentials.json present.
+// Default config dirs (when none given): the legacy ~/.claude + ~/.claude-work
+// pair PLUS every Claude config_dir declared in config.toml ([claude],
+// [profiles.*.claude], [groups.*.claude], [conductors.*.claude]) — whichever
+// of those has a .credentials.json present, deduplicated by canonical path.
+// Issue #1414: extra account profiles (e.g. ~/.claude-seminno) used to be
+// silently excluded from keep-warm coverage.
 //
 // NOTE: not started automatically anywhere. Enable it deliberately via the
 // systemd --user unit in scripts/systemd/ (see that file's header).
@@ -34,6 +38,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -58,12 +63,19 @@ func handleCredsRefresh(args []string) {
 	threshold := fs.Duration("threshold", credrefresh.DefaultThreshold, "refresh when the access token expires within this window")
 	endpoint := fs.String("endpoint", credrefresh.DefaultTokenEndpoint, "OAuth token endpoint (override for testing only)")
 	var configDirs stringSliceFlag
-	fs.Var(&configDirs, "config-dir", "profile config dir to keep warm (repeatable); defaults to ~/.claude and ~/.claude-work")
+	fs.Var(&configDirs, "config-dir", "profile config dir to keep warm (repeatable); defaults to ~/.claude, ~/.claude-work and every config_dir declared in config.toml")
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)
 	}
 
-	dirs := resolveCredConfigDirs(configDirs)
+	// Only consult config.toml when the operator did not pin the set. The
+	// load is read-only (LoadUserConfig never writes a default file); on
+	// error the returned default config simply yields the legacy pair.
+	var userCfg *session.UserConfig
+	if len(configDirs) == 0 {
+		userCfg, _ = session.LoadUserConfig()
+	}
+	dirs := resolveCredConfigDirs(configDirs, userCfg)
 	if len(dirs) == 0 {
 		fmt.Fprintln(os.Stderr, "creds-refresh: no profile config dir with a .credentials.json found; pass --config-dir explicitly")
 		os.Exit(1)
@@ -94,28 +106,87 @@ func handleCredsRefresh(args []string) {
 	credrefresh.Run(ctx, cfg)
 }
 
-// resolveCredConfigDirs expands the explicit --config-dir flags, or falls back
-// to the standard dual-profile pair, keeping only dirs that actually hold a
-// .credentials.json (so a single-profile host doesn't error on the other).
-func resolveCredConfigDirs(explicit stringSliceFlag) []string {
-	candidates := explicit
+// resolveCredConfigDirs expands the explicit --config-dir flags, or derives
+// the default keep-warm set from the agent-deck user config plus the legacy
+// dual-profile pair. Only dirs that actually hold a .credentials.json survive
+// (so a declared-but-never-logged-in profile doesn't error every tick), and
+// aliases of one canonical (symlinked profile dirs) are deduplicated so each
+// canonical is refreshed exactly once per tick.
+//
+// Issue #1414: the defaults were hardcoded to ~/.claude + ~/.claude-work, so
+// hosts with extra account profiles in config.toml (e.g. ~/.claude-seminno)
+// silently left those canonicals un-warmed — their concurrent sessions kept
+// racing the single-use rotating refresh token (mid-turn 401 → "/login").
+func resolveCredConfigDirs(explicit stringSliceFlag, cfg *session.UserConfig) []string {
+	candidates := []string(explicit)
 	if len(candidates) == 0 {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			candidates = stringSliceFlag{
-				filepath.Join(home, ".claude"),
-				filepath.Join(home, ".claude-work"),
-			}
-		}
+		candidates = credConfigDirCandidates(cfg)
 	}
 	out := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
 	for _, d := range candidates {
 		dir := session.ExpandPath(d)
-		if _, err := os.Stat(credrefresh.CanonicalCredPath(dir)); err == nil {
-			out = append(out, dir)
+		if _, err := os.Stat(credrefresh.CanonicalCredPath(dir)); err != nil {
+			continue
 		}
+		key := dir
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			key = resolved
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, dir)
 	}
 	return out
+}
+
+// credConfigDirCandidates lists every Claude config dir agent-deck could
+// spawn a session into: the legacy ~/.claude + ~/.claude-work pair, the
+// global [claude].config_dir, and every [profiles.*.claude],
+// [groups.*.claude] and [conductors.*.claude] config_dir override. Map keys
+// are walked in sorted order so the daemon's startup log is deterministic.
+func credConfigDirCandidates(cfg *session.UserConfig) []string {
+	var candidates []string
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".claude"),
+			filepath.Join(home, ".claude-work"),
+		)
+	}
+	if cfg == nil {
+		return candidates
+	}
+	if cfg.Claude.ConfigDir != "" {
+		candidates = append(candidates, cfg.Claude.ConfigDir)
+	}
+	for _, name := range sortedKeys(cfg.Profiles) {
+		if d := cfg.Profiles[name].Claude.ConfigDir; d != "" {
+			candidates = append(candidates, d)
+		}
+	}
+	for _, name := range sortedKeys(cfg.Groups) {
+		if d := cfg.Groups[name].Claude.ConfigDir; d != "" {
+			candidates = append(candidates, d)
+		}
+	}
+	for _, name := range sortedKeys(cfg.Conductors) {
+		if d := cfg.Conductors[name].Claude.ConfigDir; d != "" {
+			candidates = append(candidates, d)
+		}
+	}
+	return candidates
+}
+
+// sortedKeys returns the map's keys in ascending order.
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func logCredsRefreshResult(credPath string, res credrefresh.RefreshResult, err error) {

--- a/cmd/agent-deck/creds_refresh_cmd_test.go
+++ b/cmd/agent-deck/creds_refresh_cmd_test.go
@@ -1,0 +1,198 @@
+// Tests for `agent-deck creds-refresh` config-dir resolution (issue #1414).
+//
+// The keep-warm daemon's default coverage was hardcoded to ~/.claude and
+// ~/.claude-work. Hosts with additional account profiles declared in
+// config.toml ([profiles.<name>.claude].config_dir, e.g. ~/.claude-seminno)
+// silently left those canonicals UN-warmed, so their concurrent sessions kept
+// racing Anthropic's single-use rotating refresh token — the exact mid-turn
+// 401 signature of #1414. Defaults must derive from the user config.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// writeCreds creates dir with a placeholder .credentials.json so the dir
+// passes resolveCredConfigDirs's "has credentials" filter. The content is
+// never parsed by resolution — a stub is sufficient and no real token is
+// ever written.
+func writeCreds(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(`{"claudeAiOauth":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func containsDir(dirs []string, want string) bool {
+	for _, d := range dirs {
+		if d == want {
+			return true
+		}
+	}
+	return false
+}
+
+// The #1414 regression: a profile declared in config.toml with its own
+// config_dir must be part of the default keep-warm set.
+func TestResolveCredConfigDirs_DefaultsIncludeConfiguredProfiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	legacy := filepath.Join(home, ".claude")
+	seminno := filepath.Join(home, ".claude-seminno")
+	writeCreds(t, legacy)
+	writeCreds(t, seminno)
+
+	cfg := &session.UserConfig{
+		Profiles: map[string]session.ProfileSettings{
+			"seminno": {Claude: session.ProfileClaudeSettings{ConfigDir: "~/.claude-seminno"}},
+		},
+	}
+
+	dirs := resolveCredConfigDirs(nil, cfg)
+	if !containsDir(dirs, legacy) {
+		t.Errorf("legacy default %s missing from %v", legacy, dirs)
+	}
+	if !containsDir(dirs, seminno) {
+		t.Errorf("profile config dir %s missing from %v — #1414 keep-warm coverage gap", seminno, dirs)
+	}
+}
+
+// Group- and conductor-scoped config_dir overrides are also spawnable account
+// canonicals and must be kept warm.
+func TestResolveCredConfigDirs_DefaultsIncludeGroupAndConductorDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	groupDir := filepath.Join(home, ".claude-group")
+	condDir := filepath.Join(home, ".claude-cond")
+	globalDir := filepath.Join(home, ".claude-global")
+	writeCreds(t, groupDir)
+	writeCreds(t, condDir)
+	writeCreds(t, globalDir)
+
+	cfg := &session.UserConfig{
+		Claude: session.ClaudeSettings{ConfigDir: "~/.claude-global"},
+		Groups: map[string]session.GroupSettings{
+			"g": {Claude: session.GroupClaudeSettings{ConfigDir: "~/.claude-group"}},
+		},
+		Conductors: map[string]session.ConductorOverrides{
+			"c": {Claude: session.ConductorClaudeSettings{ConfigDir: "~/.claude-cond"}},
+		},
+	}
+
+	dirs := resolveCredConfigDirs(nil, cfg)
+	for _, want := range []string{groupDir, condDir, globalDir} {
+		if !containsDir(dirs, want) {
+			t.Errorf("config-declared dir %s missing from %v", want, dirs)
+		}
+	}
+}
+
+// Two declarations aliasing ONE canonical (e.g. a symlinked profile dir) must
+// resolve to a single keep-warm entry — refreshing one canonical twice per
+// tick is wasted lock traffic against Claude's own refresh lock.
+func TestResolveCredConfigDirs_DedupesSymlinkAliases(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical := filepath.Join(home, ".claude-real")
+	writeCreds(t, canonical)
+	alias := filepath.Join(home, ".claude-alias")
+	if err := os.Symlink(canonical, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &session.UserConfig{
+		Profiles: map[string]session.ProfileSettings{
+			"real":  {Claude: session.ProfileClaudeSettings{ConfigDir: "~/.claude-real"}},
+			"alias": {Claude: session.ProfileClaudeSettings{ConfigDir: "~/.claude-alias"}},
+		},
+	}
+
+	dirs := resolveCredConfigDirs(nil, cfg)
+	matches := 0
+	for _, d := range dirs {
+		resolved, err := filepath.EvalSymlinks(d)
+		if err != nil {
+			continue
+		}
+		canonResolved, err := filepath.EvalSymlinks(canonical)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resolved == canonResolved {
+			matches++
+		}
+	}
+	if matches != 1 {
+		t.Errorf("canonical %s appears %d times in %v; want exactly 1", canonical, matches, dirs)
+	}
+}
+
+// Explicit --config-dir flags pin the set exactly: config-derived candidates
+// must NOT be appended (operator intent wins, matching prior behavior).
+func TestResolveCredConfigDirs_ExplicitFlagsBypassConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	pinned := filepath.Join(home, ".claude-pinned")
+	other := filepath.Join(home, ".claude-other")
+	writeCreds(t, pinned)
+	writeCreds(t, other)
+
+	cfg := &session.UserConfig{
+		Profiles: map[string]session.ProfileSettings{
+			"other": {Claude: session.ProfileClaudeSettings{ConfigDir: "~/.claude-other"}},
+		},
+	}
+
+	dirs := resolveCredConfigDirs(stringSliceFlag{pinned}, cfg)
+	if len(dirs) != 1 || dirs[0] != pinned {
+		t.Errorf("explicit flags must pin the set; got %v, want [%s]", dirs, pinned)
+	}
+}
+
+// Dirs without a .credentials.json are filtered out (pre-existing semantics:
+// a declared-but-never-logged-in profile must not error every tick).
+func TestResolveCredConfigDirs_SkipsDirsWithoutCredentials(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	empty := filepath.Join(home, ".claude-empty")
+	if err := os.MkdirAll(empty, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &session.UserConfig{
+		Profiles: map[string]session.ProfileSettings{
+			"empty": {Claude: session.ProfileClaudeSettings{ConfigDir: "~/.claude-empty"}},
+		},
+	}
+
+	dirs := resolveCredConfigDirs(nil, cfg)
+	if containsDir(dirs, empty) {
+		t.Errorf("dir without credentials %s must be filtered; got %v", empty, dirs)
+	}
+}
+
+// A nil config (load failure) must degrade to the legacy pair, never panic.
+func TestResolveCredConfigDirs_NilConfigFallsBackToLegacyPair(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	legacy := filepath.Join(home, ".claude")
+	writeCreds(t, legacy)
+
+	dirs := resolveCredConfigDirs(nil, nil)
+	if !containsDir(dirs, legacy) {
+		t.Errorf("nil config must still cover legacy %s; got %v", legacy, dirs)
+	}
+}

--- a/scripts/systemd/agent-deck-creds-refresh.service
+++ b/scripts/systemd/agent-deck-creds-refresh.service
@@ -28,9 +28,12 @@
 # To keep it running after logout (so it warms tokens while you are away):
 #   loginctl enable-linger "$USER"
 #
-# By default it keeps ~/.claude and ~/.claude-work warm (whichever has a
-# .credentials.json). To pin specific profiles, add repeated --config-dir flags
-# to ExecStart, e.g.:
+# By default it keeps ~/.claude, ~/.claude-work AND every Claude config_dir
+# declared in ~/.agent-deck/config.toml ([profiles.*.claude], [groups.*.claude],
+# [conductors.*.claude]) warm — whichever has a .credentials.json (issue #1414:
+# extra account profiles like ~/.claude-seminno used to be silently excluded).
+# Prefer the defaults; explicit --config-dir flags PIN the set and disable the
+# config.toml derivation, so a profile added later would be missed:
 #   ExecStart=%h/.local/bin/agent-deck creds-refresh --config-dir %h/.claude
 # ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem (#1414)

Two concurrent sessions sharing one Claude config_dir (`~/.claude-<profile>`, the spare profile) — one 401'd MID-TURN ("socket connection closed", "Please run /login") while the other kept working on the same account. Same signature as a project profile's incident of 2026-06-11/12.

## Root cause split (investigation-first)

**Upstream mechanism (claude CLI, cannot be fixed here):** single-use rotating refresh tokens + concurrent holders. The claude CLI's expiry-refresh path re-reads disk and serializes via a proper-lockfile lock on `realpath(CONFIG_DIR)+".lock"` (verified by disassembly during #1384), but the **on-401 retry path** and **server-side early revocation** remain exposed — tracked upstream as anthropics/claude-code#54443 (open, has repro, exact same two-sessions-one-store timeline). Related: #52202, #24317.

**Our gap (this PR):** agent-deck's defense-in-depth for this class is the keep-warm refresh daemon (`agent-deck creds-refresh`, `internal/credrefresh`) — it proactively rotates each canonical under Claude's own lock so live sessions essentially never hit the refresh race at all. But its **default coverage was hardcoded to a fixed pair of legacy config dirs** (`~/.claude` + one `~/.claude-<profile>`). Profiles added later via config.toml (`[profiles.<profile>.claude].config_dir = "~/.claude-<profile>"`, others likewise) were **silently excluded** from keep-warm coverage.

Forensic confirmation: the two hardcoded-default config dirs' credential mtimes advance in lockstep (daemon ticks), while the config.toml-added profiles rotate on their own session-driven schedule. Both 401 incidents are on exactly the two uncovered profiles.

## Fix

`resolveCredConfigDirs` now derives the default keep-warm set from the agent-deck user config when no `--config-dir` flags are given:

- legacy `~/.claude` + `~/.claude-<profile>` pair (unchanged)
- global `[claude].config_dir`
- every `[profiles.*.claude].config_dir`, `[groups.*.claude].config_dir`, `[conductors.*.claude].config_dir`

filtered to dirs that actually hold a `.credentials.json`, **deduplicated by symlink-resolved canonical path** (two aliases of one canonical are refreshed once per tick — no extra lock traffic against Claude's own refresh lock).

Explicit `--config-dir` flags still pin the set exactly (operator intent wins; config derivation is skipped). `LoadUserConfig` is read-only — a missing/broken config.toml degrades to the legacy pair.

The systemd unit docs are updated to state the new defaults and warn that pinned `--config-dir` flags disable the config.toml derivation.

## Tests (TDD — written first, watched fail with the old signature/behavior)

`cmd/agent-deck/creds_refresh_cmd_test.go`:
- `TestResolveCredConfigDirs_DefaultsIncludeConfiguredProfiles` — the #1414 regression (config.toml-added profile included)
- `TestResolveCredConfigDirs_DefaultsIncludeGroupAndConductorDirs` — global/group/conductor config_dirs included
- `TestResolveCredConfigDirs_DedupesSymlinkAliases` — one canonical, two aliases → one entry
- `TestResolveCredConfigDirs_ExplicitFlagsBypassConfig` — explicit flags pin the set
- `TestResolveCredConfigDirs_SkipsDirsWithoutCredentials` — never-logged-in profile filtered (pre-existing semantics)
- `TestResolveCredConfigDirs_NilConfigFallsBackToLegacyPair` — load failure degrades gracefully

All run sandboxed (`HOME=$(mktemp -d)`, XDG cleared, `CLAUDE_CONFIG_DIR` unset). No real token is ever written or read; no network.

## Ops note

If an installed unit pins explicit `--config-dir` flags (e.g. `--config-dir ~/.claude --config-dir ~/.claude-<profile>`), they **disable** the new derivation. After merge+deploy: drop the pinned flags from ExecStart (the shipped unit file has none), then `systemctl --user daemon-reload && systemctl --user restart agent-deck-creds-refresh`.

## What this does NOT fix (honest residual, see issue comment)

Mid-turn 401s from server-side early revocation and the claude CLI's on-401 retry path are upstream (anthropics/claude-code#54443). The on-401 shared-config_dir correlation *hint* in status detection is deferred until the #1400 pane-banner classification PR lands (avoiding a detector.go collision).

Do not merge — opened for dual review per the investigation hand-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `agent-deck creds-refresh` to automatically discover credential directories from configuration file, including profiles, groups, and conductors, while preserving legacy defaults.
  * Deduplicates directories resolved via symlinks to prevent redundant refreshes.

* **Tests**
  * Added comprehensive test coverage for credential directory resolution behavior.

* **Documentation**
  * Updated command help text and systemd unit documentation to reflect expanded credential directory discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
