### PR TITLE
feat(mcp): add opencode mcp attach/detach support

### DIFF
--- a/internal/session/instance_mcp.go
+++ b/internal/session/instance_mcp.go
@@ -7,7 +7,7 @@ import (
 
 // ToolSupportsMCPManager reports whether the TUI/CLI MCP surfaces apply to this tool.
 func ToolSupportsMCPManager(toolName string) bool {
-	return IsClaudeCompatible(toolName) || toolName == "gemini" || toolName == "cursor"
+	return IsClaudeCompatible(toolName) || toolName == "gemini" || toolName == "cursor" || toolName == "opencode"
 }
 
 // MCPLocalConfigPathForTool returns the project-local MCP config path for display and writes.
@@ -21,6 +21,8 @@ func MCPLocalConfigPathForTool(toolName, projectPath string) string {
 		return filepath.Join(projectPath, ".mcp.json")
 	case toolName == "cursor":
 		return filepath.Join(projectPath, ".cursor", "mcp.json")
+	case toolName == "opencode":
+		return filepath.Join(projectPath, "opencode.json")
 	default:
 		return ""
 	}
@@ -35,6 +37,8 @@ func MCPGlobalConfigPathForTool(toolName string) string {
 		return filepath.Join(GetGeminiConfigDir(), "settings.json")
 	case toolName == "cursor":
 		return filepath.Join(GetCursorConfigDir(), "mcp.json")
+	case toolName == "opencode":
+		return filepath.Join(GetOpenCodeConfigDir(), "opencode.json")
 	default:
 		return ""
 	}
@@ -50,6 +54,8 @@ func MCPInfoForLocalAttach(toolName, projectPath string) *MCPInfo {
 	switch {
 	case toolName == "cursor":
 		return GetCursorMCPInfo(projectPath)
+	case toolName == "opencode":
+		return GetOpenCodeMCPInfo(projectPath)
 	case IsClaudeCompatible(toolName):
 		return GetMCPInfo(projectPath)
 	default:
@@ -62,6 +68,8 @@ func WriteLocalMCPConfigForTool(toolName, projectPath string, names []string) er
 	switch {
 	case toolName == "cursor":
 		return WriteCursorProjectMCP(projectPath, names)
+	case toolName == "opencode":
+		return WriteOpenCodeProjectMCP(projectPath, names)
 	case IsClaudeCompatible(toolName) || toolName == "gemini":
 		return WriteMCPJsonFromConfig(projectPath, names)
 	default:
@@ -78,15 +86,18 @@ func WriteGlobalMCPConfigForTool(toolName string, names []string) error {
 		return WriteGeminiMCPSettings(names)
 	case toolName == "cursor":
 		return WriteCursorGlobalMCP(names)
+	case toolName == "opencode":
+		return WriteOpenCodeGlobalMCP(names)
 	default:
 		return fmt.Errorf("global MCP: unsupported tool %q", toolName)
 	}
 }
 
-// InvalidateProjectMCPIntegrationsCache clears session caches used by Claude-style and Cursor MCP reads.
+// InvalidateProjectMCPIntegrationsCache clears session caches used by Claude-style, Cursor, and OpenCode MCP reads.
 func InvalidateProjectMCPIntegrationsCache(projectPath string) {
 	ClearMCPCache(projectPath)
 	ClearCursorMCPCache(projectPath)
+	ClearOpenCodeMCPCache(projectPath)
 }
 
 // MCPLocalConfigPath returns the project-local MCP file path for this instance's tool.

--- a/internal/session/instance_mcp_test.go
+++ b/internal/session/instance_mcp_test.go
@@ -17,6 +17,9 @@ func TestMCPLocalConfigPathForTool(t *testing.T) {
 	if p := MCPLocalConfigPathForTool("gemini", proj); p != "" {
 		t.Fatalf("gemini: want empty project-local path, got %q", p)
 	}
+	if p := MCPLocalConfigPathForTool("opencode", proj); p != filepath.Join(proj, "opencode.json") {
+		t.Fatalf("opencode: got %q", p)
+	}
 	if MCPLocalConfigPathForTool("claude", "") != "" {
 		t.Fatal("empty project path")
 	}
@@ -45,6 +48,9 @@ func TestMCPInfoForLocalAttach_GeminiUsesProjectMcpJsonWalker(t *testing.T) {
 func TestToolSupportsMCPManager(t *testing.T) {
 	if !ToolSupportsMCPManager("claude") || !ToolSupportsMCPManager("gemini") || !ToolSupportsMCPManager("cursor") {
 		t.Fatal("expected claude, gemini, cursor")
+	}
+	if !ToolSupportsMCPManager("opencode") {
+		t.Fatal("expected opencode")
 	}
 	if ToolSupportsMCPManager("shell") || ToolSupportsMCPManager("") {
 		t.Fatal("unexpected tool")

--- a/internal/session/opencode_mcp.go
+++ b/internal/session/opencode_mcp.go
@@ -1,0 +1,299 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
+)
+
+// opencodeMCPServer represents one server entry in opencode.json under "mcp".
+type opencodeMCPServer struct {
+	Type        string            `json:"type"`
+	Command     []string          `json:"command,omitempty"`
+	Environment map[string]string `json:"environment,omitempty"`
+	URL         string            `json:"url,omitempty"`
+}
+
+// opencodeConfig is the top-level shape of opencode.json (local or global).
+// Only the "mcp" key is relevant here; all other keys are preserved via rawConfig.
+type opencodeConfig struct {
+	MCP map[string]opencodeMCPServer `json:"mcp,omitempty"`
+}
+
+// opencodeMCPConfigDirOverride allows tests to override ~/.config/opencode.
+var opencodeMCPConfigDirOverride string
+
+// GetOpenCodeConfigDir returns ~/.config/opencode (OpenCode global config directory).
+func GetOpenCodeConfigDir() string {
+	if opencodeMCPConfigDirOverride != "" {
+		return opencodeMCPConfigDirOverride
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", "opencode")
+}
+
+// opencodeProjectMCPPath resolves <project>/opencode.json.
+// projectPath comes from agent-deck session metadata (local workspace), not remote input.
+func opencodeProjectMCPPath(projectPath string) (string, error) {
+	if projectPath == "" {
+		return "", fmt.Errorf("empty project path")
+	}
+	root, err := filepath.Abs(filepath.Clean(projectPath))
+	if err != nil {
+		return "", err
+	}
+	mcpFile := filepath.Join(root, "opencode.json")
+	rel, err := filepath.Rel(root, mcpFile)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("opencode mcp path outside project: %s", projectPath)
+	}
+	return mcpFile, nil
+}
+
+func opencodeGlobalMCPPath() string {
+	dir := GetOpenCodeConfigDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "opencode.json")
+}
+
+var (
+	opencodeMcpInfoCache   = make(map[string]*MCPInfo)
+	opencodeMcpInfoCacheMu sync.RWMutex
+	opencodeMcpCacheTimes  = make(map[string]time.Time)
+)
+
+// GetOpenCodeMCPInfo reads OpenCode MCP config: ~/.config/opencode/opencode.json (global)
+// and <project>/opencode.json (project-local). Returns merged MCPInfo for display.
+func GetOpenCodeMCPInfo(projectPath string) *MCPInfo {
+	opencodeMcpInfoCacheMu.RLock()
+	if cached, ok := opencodeMcpInfoCache[projectPath]; ok {
+		if time.Since(opencodeMcpCacheTimes[projectPath]) < mcpCacheExpiry {
+			opencodeMcpInfoCacheMu.RUnlock()
+			return cached
+		}
+	}
+	opencodeMcpInfoCacheMu.RUnlock()
+
+	info := getOpenCodeMCPInfoUncached(projectPath)
+
+	opencodeMcpInfoCacheMu.Lock()
+	opencodeMcpInfoCache[projectPath] = info
+	opencodeMcpCacheTimes[projectPath] = time.Now()
+	opencodeMcpInfoCacheMu.Unlock()
+
+	return info
+}
+
+func getOpenCodeMCPInfoUncached(projectPath string) *MCPInfo {
+	info := &MCPInfo{}
+
+	if gpath := opencodeGlobalMCPPath(); gpath != "" {
+		if data, err := os.ReadFile(gpath); err == nil {
+			var cfg opencodeConfig
+			if json.Unmarshal(data, &cfg) == nil {
+				for name := range cfg.MCP {
+					info.Global = append(info.Global, name)
+				}
+			}
+		}
+	}
+
+	if projectPath != "" {
+		p, err := opencodeProjectMCPPath(projectPath)
+		if err == nil {
+			if data, readErr := os.ReadFile(p); readErr == nil {
+				var cfg opencodeConfig
+				if json.Unmarshal(data, &cfg) == nil {
+					for name := range cfg.MCP {
+						info.LocalMCPs = append(info.LocalMCPs, LocalMCP{
+							Name:       name,
+							SourcePath: projectPath,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	sort.Strings(info.Global)
+	sort.Slice(info.LocalMCPs, func(i, j int) bool {
+		return info.LocalMCPs[i].Name < info.LocalMCPs[j].Name
+	})
+	return info
+}
+
+// ClearOpenCodeMCPCache invalidates cached OpenCode MCP info for a project path.
+func ClearOpenCodeMCPCache(projectPath string) {
+	opencodeMcpInfoCacheMu.Lock()
+	defer opencodeMcpInfoCacheMu.Unlock()
+	delete(opencodeMcpInfoCache, projectPath)
+	delete(opencodeMcpCacheTimes, projectPath)
+}
+
+// ClearAllOpenCodeMCPInfoCache clears all OpenCode MCP cache entries (needed after global writes).
+func ClearAllOpenCodeMCPInfoCache() {
+	opencodeMcpInfoCacheMu.Lock()
+	defer opencodeMcpInfoCacheMu.Unlock()
+	clear(opencodeMcpInfoCache)
+	clear(opencodeMcpCacheTimes)
+}
+
+// PruneOpenCodeMCPCache removes stale OpenCode MCP cache entries (TTL).
+func PruneOpenCodeMCPCache(maxAge time.Duration) {
+	opencodeMcpInfoCacheMu.Lock()
+	defer opencodeMcpInfoCacheMu.Unlock()
+	now := time.Now()
+	for path, t := range opencodeMcpCacheTimes {
+		if now.Sub(t) > maxAge {
+			delete(opencodeMcpInfoCache, path)
+			delete(opencodeMcpCacheTimes, path)
+		}
+	}
+}
+
+// buildOpenCodeMCPServers constructs the mcp map for an opencode.json write.
+func buildOpenCodeMCPServers(enabledNames []string) map[string]opencodeMCPServer {
+	availableMCPs := GetAvailableMCPs()
+	pool := GetGlobalPool()
+
+	servers := make(map[string]opencodeMCPServer)
+	for _, name := range enabledNames {
+		def, ok := availableMCPs[name]
+		if !ok {
+			continue
+		}
+
+		// HTTP / remote server
+		if def.URL != "" {
+			if def.HasAutoStartServer() {
+				if err := StartHTTPServer(name, &def); err != nil {
+					mcpCatLog.Warn("http_server_start_failed_opencode", "mcp", name, "error", err)
+				}
+			}
+			servers[name] = opencodeMCPServer{
+				Type: "remote",
+				URL:  def.URL,
+			}
+			continue
+		}
+
+		// Pool socket -> stdio via nc
+		if socketCfg, used := tryPoolSocket(pool, name, "opencode"); used {
+			cmd := []string{}
+			if socketCfg.Command != "" {
+				cmd = append([]string{socketCfg.Command}, socketCfg.Args...)
+			}
+			servers[name] = opencodeMCPServer{
+				Type:    "local",
+				Command: cmd,
+			}
+			continue
+		}
+
+		// stdio
+		args := def.Args
+		if args == nil {
+			args = []string{}
+		}
+		env := def.Env
+		if env == nil {
+			env = map[string]string{}
+		}
+		cmd := append([]string{def.Command}, args...)
+		servers[name] = opencodeMCPServer{
+			Type:        "local",
+			Command:     cmd,
+			Environment: env,
+		}
+	}
+	return servers
+}
+
+// WriteOpenCodeProjectMCP writes catalog MCPs to <project>/opencode.json.
+// OpenCode's local config uses {"mcp": {"name": {"type":"local","command":[...]}}} format.
+func WriteOpenCodeProjectMCP(projectPath string, enabledNames []string) error {
+	if !GetManageMCPJson() {
+		mcpCatLog.Debug("opencode_mcp_json_management_disabled", "path", projectPath)
+		return nil
+	}
+	if projectPath == "" {
+		return fmt.Errorf("opencode project MCP: empty project path")
+	}
+	mcpFile, err := opencodeProjectMCPPath(projectPath)
+	if err != nil {
+		return err
+	}
+
+	// Read existing file to preserve non-mcp keys.
+	var rawConfig map[string]interface{}
+	if data, readErr := os.ReadFile(mcpFile); readErr == nil {
+		if jsonErr := json.Unmarshal(data, &rawConfig); jsonErr != nil {
+			rawConfig = make(map[string]interface{})
+		}
+	} else {
+		rawConfig = make(map[string]interface{})
+	}
+
+	rawConfig["mcp"] = buildOpenCodeMCPServers(enabledNames)
+
+	newData, err := json.MarshalIndent(rawConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal opencode project mcp: %w", err)
+	}
+	if err := atomicfile.WriteFile(mcpFile, newData, 0o600); err != nil {
+		return fmt.Errorf("save opencode project mcp: %w", err)
+	}
+
+	ClearOpenCodeMCPCache(projectPath)
+	return nil
+}
+
+// WriteOpenCodeGlobalMCP writes catalog MCPs to ~/.config/opencode/opencode.json.
+// Preserves other JSON keys already present in the file.
+func WriteOpenCodeGlobalMCP(enabledNames []string) error {
+	if !GetManageMCPJson() {
+		mcpCatLog.Debug("opencode_mcp_json_management_disabled", "scope", "global")
+		return nil
+	}
+	configFile := opencodeGlobalMCPPath()
+	if configFile == "" {
+		return fmt.Errorf("cannot resolve ~/.config/opencode")
+	}
+	if err := os.MkdirAll(filepath.Dir(configFile), 0o755); err != nil {
+		return fmt.Errorf("create opencode config dir: %w", err)
+	}
+
+	var rawConfig map[string]interface{}
+	if data, err := os.ReadFile(configFile); err == nil {
+		if err := json.Unmarshal(data, &rawConfig); err != nil {
+			rawConfig = make(map[string]interface{})
+		}
+	} else {
+		rawConfig = make(map[string]interface{})
+	}
+
+	rawConfig["mcp"] = buildOpenCodeMCPServers(enabledNames)
+
+	newData, err := json.MarshalIndent(rawConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal opencode global mcp: %w", err)
+	}
+	if err := atomicfile.WriteFile(configFile, newData, 0o600); err != nil {
+		return fmt.Errorf("save opencode global mcp: %w", err)
+	}
+
+	ClearAllOpenCodeMCPInfoCache()
+	return nil
+}

--- a/internal/session/opencode_mcp.go
+++ b/internal/session/opencode_mcp.go
@@ -236,14 +236,22 @@ func WriteOpenCodeProjectMCP(projectPath string, enabledNames []string) error {
 		return err
 	}
 
-	// Read existing file to preserve non-mcp keys.
+	// Read existing file to preserve non-mcp keys. An existing-but-unparseable
+	// file must fail closed: resetting rawConfig to an empty map on an unmarshal
+	// error and writing it back would destroy every non-mcp key the user has
+	// (model, theme, keybinds, ...). A transient/partial write or a
+	// hand-edited-with-comments file (opencode tolerates JSONC in practice)
+	// would otherwise trigger total config loss. Only initialize an empty config
+	// when the file genuinely does not exist.
 	var rawConfig map[string]interface{}
 	if data, readErr := os.ReadFile(mcpFile); readErr == nil {
 		if jsonErr := json.Unmarshal(data, &rawConfig); jsonErr != nil {
-			rawConfig = make(map[string]interface{})
+			return fmt.Errorf("refusing to overwrite unparseable opencode project config %s: %w", mcpFile, jsonErr)
 		}
-	} else {
+	} else if os.IsNotExist(readErr) {
 		rawConfig = make(map[string]interface{})
+	} else {
+		return fmt.Errorf("read opencode project mcp %s: %w", mcpFile, readErr)
 	}
 
 	rawConfig["mcp"] = buildOpenCodeMCPServers(enabledNames)
@@ -275,13 +283,17 @@ func WriteOpenCodeGlobalMCP(enabledNames []string) error {
 		return fmt.Errorf("create opencode config dir: %w", err)
 	}
 
+	// Fail closed on an existing-but-unparseable file — see the rationale in
+	// WriteOpenCodeProjectMCP. Overwriting it would drop every non-mcp key.
 	var rawConfig map[string]interface{}
-	if data, err := os.ReadFile(configFile); err == nil {
-		if err := json.Unmarshal(data, &rawConfig); err != nil {
-			rawConfig = make(map[string]interface{})
+	if data, readErr := os.ReadFile(configFile); readErr == nil {
+		if jsonErr := json.Unmarshal(data, &rawConfig); jsonErr != nil {
+			return fmt.Errorf("refusing to overwrite unparseable opencode global config %s: %w", configFile, jsonErr)
 		}
-	} else {
+	} else if os.IsNotExist(readErr) {
 		rawConfig = make(map[string]interface{})
+	} else {
+		return fmt.Errorf("read opencode global mcp %s: %w", configFile, readErr)
 	}
 
 	rawConfig["mcp"] = buildOpenCodeMCPServers(enabledNames)

--- a/internal/session/opencode_mcp_test.go
+++ b/internal/session/opencode_mcp_test.go
@@ -260,6 +260,75 @@ func TestWriteOpenCodeGlobalMCP_PreservesOtherKeys(t *testing.T) {
 	}
 }
 
+// Regression: an existing-but-unparseable opencode.json must NOT be
+// overwritten. Earlier the parse-error branch reset rawConfig to an empty map
+// and wrote it back, destroying every non-mcp key (model, theme, keybinds). The
+// write must now fail closed and leave the file byte-for-byte untouched.
+func TestWriteOpenCodeProjectMCP_RefusesOverwriteOfUnparseableConfig(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	opencodeMCPConfigDirOverride = tmp
+	defer func() { opencodeMCPConfigDirOverride = "" }()
+
+	cfg := &UserConfig{MCPs: map[string]MCPDef{
+		"cat": {Command: "echo", Args: []string{"meow"}},
+	}}
+	restoreCfg := resetUserConfigCache(t, cfg)
+	t.Cleanup(restoreCfg)
+
+	// Garbage / partially-written JSON that still holds the user's real config.
+	garbage := []byte(`{"theme":"dark","model":"opus",`) // truncated, unparseable
+	mcpFile := filepath.Join(proj, "opencode.json")
+	if err := os.WriteFile(mcpFile, garbage, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteOpenCodeProjectMCP(proj, []string{"cat"}); err == nil {
+		t.Fatal("expected error when overwriting unparseable project config, got nil")
+	}
+
+	after, err := os.ReadFile(mcpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(garbage) {
+		t.Fatalf("unparseable project config was modified:\nbefore: %s\nafter:  %s", garbage, after)
+	}
+}
+
+func TestWriteOpenCodeGlobalMCP_RefusesOverwriteOfUnparseableConfig(t *testing.T) {
+	tmp := t.TempDir()
+	opencodeMCPConfigDirOverride = tmp
+	defer func() { opencodeMCPConfigDirOverride = "" }()
+
+	cfg := &UserConfig{MCPs: map[string]MCPDef{
+		"cat": {Command: "echo", Args: []string{"purr"}},
+	}}
+	restoreCfg := resetUserConfigCache(t, cfg)
+	t.Cleanup(restoreCfg)
+
+	path := filepath.Join(tmp, "opencode.json")
+	garbage := []byte(`{"foo":1, this is not json`)
+	if err := os.WriteFile(path, garbage, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteOpenCodeGlobalMCP([]string{"cat"}); err == nil {
+		t.Fatal("expected error when overwriting unparseable global config, got nil")
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(garbage) {
+		t.Fatalf("unparseable global config was modified:\nbefore: %s\nafter:  %s", garbage, after)
+	}
+}
+
 func TestOpenCodeRoundTrip(t *testing.T) {
 	tmp := t.TempDir()
 	proj := filepath.Join(tmp, "proj")

--- a/internal/session/opencode_mcp_test.go
+++ b/internal/session/opencode_mcp_test.go
@@ -1,0 +1,292 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetOpenCodeConfigDir(t *testing.T) {
+	opencodeMCPConfigDirOverride = ""
+	dir := GetOpenCodeConfigDir()
+	if dir == "" {
+		t.Fatal("GetOpenCodeConfigDir returned empty string")
+	}
+	// Should end with ".config/opencode"
+	if filepath.Base(dir) != "opencode" {
+		t.Fatalf("expected last component 'opencode', got %q", filepath.Base(dir))
+	}
+}
+
+func TestMCPLocalConfigPathForTool_Opencode(t *testing.T) {
+	proj := "/tmp/ocp"
+	got := MCPLocalConfigPathForTool("opencode", proj)
+	want := filepath.Join(proj, "opencode.json")
+	if got != want {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+	if MCPLocalConfigPathForTool("opencode", "") != "" {
+		t.Fatal("empty project path should return empty string")
+	}
+}
+
+func TestMCPGlobalConfigPathForTool_Opencode(t *testing.T) {
+	tmp := t.TempDir()
+	opencodeMCPConfigDirOverride = tmp
+	defer func() { opencodeMCPConfigDirOverride = "" }()
+
+	got := MCPGlobalConfigPathForTool("opencode")
+	want := filepath.Join(tmp, "opencode.json")
+	if got != want {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+}
+
+func TestToolSupportsMCPManager_Opencode(t *testing.T) {
+	if !ToolSupportsMCPManager("opencode") {
+		t.Fatal("expected ToolSupportsMCPManager(\"opencode\") == true")
+	}
+}
+
+func TestGetOpenCodeMCPInfo_GlobalAndLocal(t *testing.T) {
+	tmp := t.TempDir()
+	globalDir := filepath.Join(tmp, "config", "opencode")
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	opencodeMCPConfigDirOverride = globalDir
+	defer func() { opencodeMCPConfigDirOverride = "" }()
+
+	globalJSON := `{"mcp":{"g1":{"type":"local","command":["echo","g"]},"g2":{"type":"remote","url":"http://x"}}}`
+	if err := os.WriteFile(filepath.Join(globalDir, "opencode.json"), []byte(globalJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	localJSON := `{"mcp":{"l1":{"type":"local","command":["echo","l"]}}}`
+	if err := os.WriteFile(filepath.Join(proj, "opencode.json"), []byte(localJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ClearOpenCodeMCPCache(proj)
+	info := GetOpenCodeMCPInfo(proj)
+	if info == nil {
+		t.Fatal("nil info")
+	}
+	if len(info.Global) != 2 {
+		t.Fatalf("global count = %d, want 2: %v", len(info.Global), info.Global)
+	}
+	if len(info.LocalMCPs) != 1 || info.LocalMCPs[0].Name != "l1" {
+		t.Fatalf("local = %#v", info.LocalMCPs)
+	}
+}
+
+func TestGetOpenCodeMCPInfo_NoFiles(t *testing.T) {
+	tmp := t.TempDir()
+	opencodeMCPConfigDirOverride = tmp
+	defer func() { opencodeMCPConfigDirOverride = "" }()
+
+	info := GetOpenCodeMCPInfo("/nonexistent/project")
+	if info == nil {
+		t.Fatal("expected non-nil MCPInfo")
+	}
+	if len(info.Global) != 0 || len(info.LocalMCPs) != 0 {
+		t.Fatalf("expected empty info, got %+v", info)
+	}
+}
+
+func TestWriteOpenCodeProjectMCP_StdioFormat(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	opencodeMCPConfigDirOverride = tmp
+	defer func() { opencodeMCPConfigDirOverride = "" }()
+
+	cfg := &UserConfig{MCPs: map[string]MCPDef{
+		"mytool": {Command: "npx", Args: []string{"-y", "mytool-mcp"}},
+	}}
+	restoreCfg := resetUserConfigCache(t, cfg)
+	t.Cleanup(restoreCfg)
+
+	if err := WriteOpenCodeProjectMCP(proj, []string{"mytool"}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(proj, "opencode.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out opencodeConfig
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	srv, ok := out.MCP["mytool"]
+	if !ok {
+		t.Fatal("expected 'mytool' in mcp map")
+	}
+	if srv.Type != "local" {
+		t.Fatalf("type = %q, want 'local'", srv.Type)
+	}
+	if len(srv.Command) == 0 || srv.Command[0] != "npx" {
+		t.Fatalf("command = %v, want npx ...", srv.Command)
+	}
+}
+
+func TestWriteOpenCodeProjectMCP_HTTPFormat(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	opencodeMCPConfigDirOverride = tmp
+	defer func() { opencodeMCPConfigDirOverride = "" }()
+
+	cfg := &UserConfig{MCPs: map[string]MCPDef{
+		"remote-tool": {URL: "http://localhost:9999/mcp"},
+	}}
+	restoreCfg := resetUserConfigCache(t, cfg)
+	t.Cleanup(restoreCfg)
+
+	if err := WriteOpenCodeProjectMCP(proj, []string{"remote-tool"}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(proj, "opencode.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out opencodeConfig
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	srv, ok := out.MCP["remote-tool"]
+	if !ok {
+		t.Fatal("expected 'remote-tool' in mcp map")
+	}
+	if srv.Type != "remote" {
+		t.Fatalf("type = %q, want 'remote'", srv.Type)
+	}
+	if srv.URL != "http://localhost:9999/mcp" {
+		t.Fatalf("url = %q, want 'http://localhost:9999/mcp'", srv.URL)
+	}
+}
+
+func TestWriteOpenCodeProjectMCP_PreservesOtherKeys(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	opencodeMCPConfigDirOverride = tmp
+	defer func() { opencodeMCPConfigDirOverride = "" }()
+
+	cfg := &UserConfig{MCPs: map[string]MCPDef{
+		"cat": {Command: "echo", Args: []string{"meow"}},
+	}}
+	restoreCfg := resetUserConfigCache(t, cfg)
+	t.Cleanup(restoreCfg)
+
+	seed := `{"theme":"dark","mcp":{"orphan":{"type":"local","command":["true"]}}}`
+	mcpFile := filepath.Join(proj, "opencode.json")
+	if err := os.WriteFile(mcpFile, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteOpenCodeProjectMCP(proj, []string{"cat"}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(mcpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw["theme"] != "dark" {
+		t.Fatal("expected 'theme' key preserved")
+	}
+	mcpMap, ok := raw["mcp"].(map[string]interface{})
+	if !ok {
+		t.Fatal("mcp key missing or wrong type")
+	}
+	// cat should be present (from catalog), orphan is replaced
+	if _, hasCat := mcpMap["cat"]; !hasCat {
+		t.Fatal("expected 'cat' in mcp after write")
+	}
+}
+
+func TestWriteOpenCodeGlobalMCP_PreservesOtherKeys(t *testing.T) {
+	tmp := t.TempDir()
+	opencodeMCPConfigDirOverride = tmp
+	defer func() { opencodeMCPConfigDirOverride = "" }()
+
+	cfg := &UserConfig{MCPs: map[string]MCPDef{
+		"cat": {Command: "echo", Args: []string{"purr"}},
+	}}
+	restoreCfg := resetUserConfigCache(t, cfg)
+	t.Cleanup(restoreCfg)
+
+	path := filepath.Join(tmp, "opencode.json")
+	seed := []byte(`{"foo":1,"mcp":{}}`)
+	if err := os.WriteFile(path, seed, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteOpenCodeGlobalMCP([]string{"cat"}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw["foo"] == nil {
+		t.Fatal("expected 'foo' key preserved in global opencode.json")
+	}
+}
+
+func TestOpenCodeRoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	proj := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	opencodeMCPConfigDirOverride = tmp
+	defer func() { opencodeMCPConfigDirOverride = "" }()
+
+	cfg := &UserConfig{MCPs: map[string]MCPDef{
+		"alpha": {Command: "alpha-bin", Args: []string{"--flag"}},
+		"beta":  {Command: "beta-bin"},
+	}}
+	restoreCfg := resetUserConfigCache(t, cfg)
+	t.Cleanup(restoreCfg)
+
+	if err := WriteOpenCodeProjectMCP(proj, []string{"alpha", "beta"}); err != nil {
+		t.Fatal(err)
+	}
+
+	ClearOpenCodeMCPCache(proj)
+	info := GetOpenCodeMCPInfo(proj)
+	names := make(map[string]bool)
+	for _, lm := range info.LocalMCPs {
+		names[lm.Name] = true
+	}
+	if !names["alpha"] || !names["beta"] {
+		t.Fatalf("round-trip: got %v, want alpha and beta", info.LocalMCPs)
+	}
+}


### PR DESCRIPTION
## Summary

opencode sessions now support mcp attach/detach via a new adapter that follows the established Cursor/Gemini pattern.

- New `opencode_mcp.go`: implements `GetOpenCodeConfigDir` (returns `~/.config/opencode`), `GetOpenCodeMCPInfo` (reads project-local `opencode.json` and global config), `WriteOpenCodeProjectMCP` (writes `{"mcp": {"name": {"type":"local","command":[...]}}}` for stdio or `{"type":"remote","url":"..."}` for HTTP), `WriteOpenCodeGlobalMCP` (preserves existing non-MCP keys), and cache helpers (`ClearOpenCodeMCPCache`, `ClearAllOpenCodeMCPInfoCache`, `PruneOpenCodeMCPCache`).
- Updated `instance_mcp.go`: adds `"opencode"` case to all six switch statements (`ToolSupportsMCPManager`, `MCPLocalConfigPathForTool`, `MCPGlobalConfigPathForTool`, `MCPInfoForLocalAttach`, `WriteLocalMCPConfigForTool`, `WriteGlobalMCPConfigForTool`) and adds `ClearOpenCodeMCPCache` to `InvalidateProjectMCPIntegrationsCache`.

## Why this matters

Fixes #1288. When a session uses `default_tool = "opencode"`, `mcp attach` and `mcp detach` previously failed with "unsupported tool" errors, and the TUI MCP Manager (`m` key) was non-functional for OpenCode sessions.

## Changes

- `internal/session/opencode_mcp.go` (new): full OpenCode MCP adapter with local/global read and write, cache layer, and `opencode.json` format support (`mcp` key with `type/command/environment/url` fields matching the OpenCode spec).
- `internal/session/opencode_mcp_test.go` (new): 10 tests covering `ToolSupportsMCPManager`, config path resolution, read with global+local files, missing-file graceful return, stdio and HTTP write formats, key-preservation, and round-trip.
- `internal/session/instance_mcp.go`: wired opencode into all required switch statements and cache invalidation.
- `internal/session/instance_mcp_test.go`: updated `TestMCPLocalConfigPathForTool` and `TestToolSupportsMCPManager` to cover opencode.

Fixes #1288


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **OpenCode (opencode)** as a supported MCP tool with configuration management for both project-local and global settings.
  * Supports enabling/disabling MCP servers via remote HTTP, local socket-based, and stdio command formats.
  * Merges global + project-local MCP entries for runtime discovery, with caching for improved performance.

* **Bug Fixes**
  * Improved cache invalidation to ensure OpenCode MCP updates are reflected correctly.
  * Prevents overwriting `opencode.json` when it contains unparseable JSON, preserving file contents.

* **Tests**
  * Expanded test coverage for OpenCode MCP pathing, support detection, read/merge behavior, writing, and cache round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->