### PR TITLE
fix(hooks): done-sentinel detection on current Claude Code transcript formats (fixes #1422)

### DIFF
--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -655,13 +655,20 @@ func writeCostEvent(instanceID string, rawPayload []byte) {
 }
 
 // transcriptContentMessage extracts the assistant message content blocks from
-// the last transcript line, for completion-sentinel detection (issue #1186).
+// a transcript line, for completion-sentinel detection (issue #1186).
 type transcriptContentMessage struct {
-	Type    string `json:"type"`
-	Message struct {
+	Type        string `json:"type"`
+	IsSidechain bool   `json:"isSidechain"`
+	Message     struct {
 		Content json.RawMessage `json:"content"`
 	} `json:"message"`
 }
+
+// doneScanTailLines bounds the backward walk over transcript records when
+// looking for the just-finished assistant turn. Post-assistant noise observed
+// in the wild is 1-4 records (system/attachment); 25 leaves generous margin
+// without rescanning history.
+const doneScanTailLines = 25
 
 // detectDoneSentinel parses transcript_path out of a Stop hook payload and
 // scans the transcript tail for a worker-printed completion sentinel. It
@@ -687,24 +694,34 @@ func detectDoneSentinel(rawPayload []byte) (session.DoneSignal, bool) {
 	return scanTranscriptForDone(cleanPath)
 }
 
-// scanTranscriptForDone reads the last transcript line, and if it is an
-// assistant turn, scans its text content for a completion sentinel. The path
-// is the injectable source: tests point it at a temp file, no live agent
-// required. A missing/unreadable file or a non-assistant tail yields no
-// sentinel rather than an error.
+// scanTranscriptForDone scans the transcript tail for a completion sentinel
+// in the most recent MAIN-CHAIN assistant turn. The sentinel-bearing assistant
+// record is NOT reliably the literal last line: Claude Code appends system /
+// attachment records after the assistant turn (observed: `..., assistant,
+// system, system` — a last-line-only scan made issue-#1186 finished events
+// never fire at all on current transcript formats). Walk backwards over a
+// bounded tail window, skip non-assistant records and sidechain (subagent)
+// traffic, and scan the first assistant record found — that IS the turn that
+// just stopped; earlier turns are never reached. The path is the injectable
+// source: tests point it at a temp file, no live agent required. A
+// missing/unreadable file or no assistant in the window yields no sentinel
+// rather than an error.
 func scanTranscriptForDone(path string) (session.DoneSignal, bool) {
-	lastLine, err := readLastLine(path)
+	lines, err := readLastLines(path, doneScanTailLines)
 	if err != nil {
 		return session.DoneSignal{}, false
 	}
-	var msg transcriptContentMessage
-	if err := json.Unmarshal([]byte(lastLine), &msg); err != nil {
-		return session.DoneSignal{}, false
+	for i := len(lines) - 1; i >= 0; i-- {
+		var msg transcriptContentMessage
+		if err := json.Unmarshal([]byte(lines[i]), &msg); err != nil {
+			continue
+		}
+		if msg.IsSidechain || msg.Type != "assistant" {
+			continue
+		}
+		return session.ScanDoneSentinel(transcriptText(msg.Message.Content))
 	}
-	if msg.Type != "assistant" {
-		return session.DoneSignal{}, false
-	}
-	return session.ScanDoneSentinel(transcriptText(msg.Message.Content))
+	return session.DoneSignal{}, false
 }
 
 // transcriptText flattens an assistant message's content into plain text.
@@ -735,52 +752,63 @@ func transcriptText(content json.RawMessage) string {
 	return sb.String()
 }
 
-// readLastLine reads the last non-empty line from a file.
-func readLastLine(path string) (string, error) {
+// readLastLines returns up to n trailing non-empty lines of the file, oldest
+// first. It reads at most the trailing 512KB — transcript records are single
+// JSONL lines comfortably under that; a line truncated by the byte cut is
+// discarded rather than half-parsed.
+func readLastLines(path string, n int) ([]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer f.Close()
 
 	stat, err := f.Stat()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-
 	size := stat.Size()
 	if size == 0 {
-		return "", fmt.Errorf("empty file")
+		return nil, fmt.Errorf("empty file")
 	}
 
-	// Read backwards in chunks to find the last complete line
-	buf := make([]byte, 0, 16384)
-	offset := size
-
-	for offset > 0 {
-		readSize := int64(16384)
-		if readSize > offset {
-			readSize = offset
-		}
-		offset -= readSize
-
-		chunk := make([]byte, readSize)
-		if _, err := f.ReadAt(chunk, offset); err != nil {
-			return "", err
-		}
-		buf = append(chunk, buf...)
-
-		// Strip trailing whitespace/newlines for consistent handling
-		trimmed := strings.TrimRight(string(buf), "\n\r ")
-		// Find the last newline in the trimmed content
-		lastNL := strings.LastIndexByte(trimmed, '\n')
-		if lastNL >= 0 {
-			return trimmed[lastNL+1:], nil
-		}
+	const maxTailBytes = int64(512 * 1024)
+	offset := int64(0)
+	if size > maxTailBytes {
+		offset = size - maxTailBytes
+	}
+	buf := make([]byte, size-offset)
+	if _, err := f.ReadAt(buf, offset); err != nil {
+		return nil, err
 	}
 
-	// Entire file is one line
-	return strings.TrimSpace(string(buf)), nil
+	rawLines := strings.Split(strings.TrimRight(string(buf), "\n\r "), "\n")
+	if offset > 0 && len(rawLines) > 0 {
+		rawLines = rawLines[1:] // first line may be cut mid-record by the offset
+	}
+	start := 0
+	if len(rawLines) > n {
+		start = len(rawLines) - n
+	}
+	lines := make([]string, 0, n)
+	for _, raw := range rawLines[start:] {
+		if s := strings.TrimSpace(raw); s != "" {
+			lines = append(lines, s)
+		}
+	}
+	return lines, nil
+}
+
+// readLastLine reads the last non-empty line from a file.
+func readLastLine(path string) (string, error) {
+	lines, err := readLastLines(path, 1)
+	if err != nil {
+		return "", err
+	}
+	if len(lines) == 0 {
+		return "", fmt.Errorf("no non-empty line")
+	}
+	return lines[0], nil
 }
 
 // logCostDebug writes debug messages to the XDG cache cost-debug.log.

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -72,6 +72,11 @@ type hookStatusFile struct {
 	// "no finished event to emit."
 	DoneStatus  string `json:"done_status,omitempty"`
 	DoneSummary string `json:"done_summary,omitempty"`
+	// TranscriptPath is persisted ONLY when the Stop-edge sentinel scan was
+	// inconclusive because the turn's assistant record had not flushed yet
+	// (issue #1186 flush race). The daemon re-scans this path on its poll
+	// loop; the synchronous Stop hook (#1225) must not wait out the flush.
+	TranscriptPath string `json:"transcript_path,omitempty"`
 }
 
 // mapEventToStatus maps a Claude Code hook event to an agent-deck status string.
@@ -181,14 +186,14 @@ func handleHookHandler() {
 	// tail for a worker-printed completion sentinel. When present, persist the
 	// parsed outcome into the hook status file so the daemon can emit a
 	// distinct "finished" event to the parent instead of the conductor having
-	// to poll artifacts. Absent on ordinary mid-task Stops, so the existing
-	// "waiting" behavior is unchanged.
+	// to poll artifacts. When the turn's assistant record has not flushed yet
+	// (Claude Code can fire Stop before appending it), persist the transcript
+	// path instead and let the daemon finish the scan — the Stop hook runs
+	// SYNCHRONOUSLY (#1225), so waiting out the flush here would add turn-end
+	// latency to every managed session. Absent on ordinary mid-task Stops, so
+	// the existing "waiting" behavior is unchanged.
 	if payload.HookEventName == "Stop" {
-		if sig, ok := detectDoneSentinel(data); ok {
-			writeHookStatus(instanceID, status, payload.SessionID, payload.HookEventName, sig)
-		} else {
-			writeHookStatus(instanceID, status, payload.SessionID, payload.HookEventName)
-		}
+		writeHookStatusWithScan(instanceID, status, payload.SessionID, payload.HookEventName, detectDoneSentinel(data))
 	} else {
 		writeHookStatus(instanceID, status, payload.SessionID, payload.HookEventName)
 	}
@@ -257,6 +262,18 @@ func parentIsDSP() bool {
 // The optional done argument carries a completion sentinel (issue #1186);
 // when supplied its status/summary are persisted alongside the hook status.
 func writeHookStatus(instanceID, status, sessionID, event string, done ...session.DoneSignal) {
+	scan := doneScanResult{}
+	if len(done) > 0 {
+		scan.signal = &done[0]
+	}
+	writeHookStatusWithScan(instanceID, status, sessionID, event, scan)
+}
+
+// writeHookStatusWithScan is writeHookStatus plus the full Stop-edge scan
+// outcome: a parsed sentinel persists as done_status/done_summary; an
+// unflushed tail persists as transcript_path so the daemon can finish the
+// scan (issue #1186 flush race).
+func writeHookStatusWithScan(instanceID, status, sessionID, event string, scan doneScanResult) {
 	if instanceID == "" || status == "" {
 		return
 	}
@@ -284,10 +301,11 @@ func writeHookStatus(instanceID, status, sessionID, event string, done ...sessio
 		Event:     event,
 		Timestamp: time.Now().Unix(),
 	}
-	if len(done) > 0 {
-		statusFile.DoneStatus = done[0].Status
-		statusFile.DoneSummary = done[0].Summary
+	if scan.signal != nil {
+		statusFile.DoneStatus = scan.signal.Status
+		statusFile.DoneSummary = scan.signal.Summary
 	}
+	statusFile.TranscriptPath = scan.pendingTranscript
 
 	jsonData, err := json.Marshal(statusFile)
 	if err != nil {
@@ -654,154 +672,46 @@ func writeCostEvent(instanceID string, rawPayload []byte) {
 	logCostDebug("wrote cost event: %s model=%s in=%d out=%d", finalPath, cf.Model, cf.InputTokens, cf.OutputTokens)
 }
 
-// transcriptContentMessage extracts the assistant message content blocks from
-// a transcript line, for completion-sentinel detection (issue #1186).
-type transcriptContentMessage struct {
-	Type        string `json:"type"`
-	IsSidechain bool   `json:"isSidechain"`
-	Message     struct {
-		Content json.RawMessage `json:"content"`
-	} `json:"message"`
+// doneScanResult carries the Stop-edge sentinel-scan outcome into the hook
+// status file. At most one field is set: signal when a sentinel was parsed
+// from the flushed assistant turn; pendingTranscript (the validated
+// transcript path) when the tail was unflushed at hook time — issue #1186
+// flush race — so the daemon can finish the scan on its poll loop. The zero
+// value is an ordinary Stop with nothing extra to persist.
+type doneScanResult struct {
+	signal            *session.DoneSignal
+	pendingTranscript string
 }
-
-// doneScanTailLines bounds the backward walk over transcript records when
-// looking for the just-finished assistant turn. Post-assistant noise observed
-// in the wild is 1-4 records (system/attachment); 25 leaves generous margin
-// without rescanning history.
-const doneScanTailLines = 25
 
 // detectDoneSentinel parses transcript_path out of a Stop hook payload and
-// scans the transcript tail for a worker-printed completion sentinel. It
-// applies the same path-traversal / ~/.claude containment guards as the cost
-// path so a crafted payload can't read arbitrary files.
-func detectDoneSentinel(rawPayload []byte) (session.DoneSignal, bool) {
+// scans the transcript tail for a worker-printed completion sentinel
+// (issue #1186). Path-traversal / ~/.claude containment guards mirror the
+// cost path so a crafted payload can't read arbitrary files. The scan itself
+// lives in internal/session, shared with the transition daemon's flush-race
+// rescan.
+func detectDoneSentinel(rawPayload []byte) doneScanResult {
 	var stop stopHookPayload
 	if err := json.Unmarshal(rawPayload, &stop); err != nil {
-		return session.DoneSignal{}, false
+		return doneScanResult{}
 	}
-	if stop.TranscriptPath == "" {
-		return session.DoneSignal{}, false
+	cleanPath, ok := session.ValidateTranscriptPath(stop.TranscriptPath)
+	if !ok {
+		return doneScanResult{}
 	}
-	cleanPath := filepath.Clean(stop.TranscriptPath)
-	if strings.Contains(cleanPath, "..") {
-		return session.DoneSignal{}, false
+	sig, found, pending := session.ScanTranscriptTailForDone(cleanPath)
+	switch {
+	case pending:
+		return doneScanResult{pendingTranscript: cleanPath}
+	case found:
+		return doneScanResult{signal: &sig}
+	default:
+		return doneScanResult{}
 	}
-	if home, err := os.UserHomeDir(); err == nil {
-		if !strings.HasPrefix(cleanPath, filepath.Join(home, ".claude")) {
-			return session.DoneSignal{}, false
-		}
-	}
-	return scanTranscriptForDone(cleanPath)
-}
-
-// scanTranscriptForDone scans the transcript tail for a completion sentinel
-// in the most recent MAIN-CHAIN assistant turn. The sentinel-bearing assistant
-// record is NOT reliably the literal last line: Claude Code appends system /
-// attachment records after the assistant turn (observed: `..., assistant,
-// system, system` — a last-line-only scan made issue-#1186 finished events
-// never fire at all on current transcript formats). Walk backwards over a
-// bounded tail window, skip non-assistant records and sidechain (subagent)
-// traffic, and scan the first assistant record found — that IS the turn that
-// just stopped; earlier turns are never reached. The path is the injectable
-// source: tests point it at a temp file, no live agent required. A
-// missing/unreadable file or no assistant in the window yields no sentinel
-// rather than an error.
-func scanTranscriptForDone(path string) (session.DoneSignal, bool) {
-	lines, err := readLastLines(path, doneScanTailLines)
-	if err != nil {
-		return session.DoneSignal{}, false
-	}
-	for i := len(lines) - 1; i >= 0; i-- {
-		var msg transcriptContentMessage
-		if err := json.Unmarshal([]byte(lines[i]), &msg); err != nil {
-			continue
-		}
-		if msg.IsSidechain || msg.Type != "assistant" {
-			continue
-		}
-		return session.ScanDoneSentinel(transcriptText(msg.Message.Content))
-	}
-	return session.DoneSignal{}, false
-}
-
-// transcriptText flattens an assistant message's content into plain text.
-// Claude transcripts encode content either as a string or as an array of
-// typed blocks ({"type":"text","text":"..."}); only text blocks contribute.
-func transcriptText(content json.RawMessage) string {
-	if len(content) == 0 {
-		return ""
-	}
-	var asString string
-	if err := json.Unmarshal(content, &asString); err == nil {
-		return asString
-	}
-	var blocks []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
-	}
-	if err := json.Unmarshal(content, &blocks); err != nil {
-		return ""
-	}
-	var sb strings.Builder
-	for _, b := range blocks {
-		if b.Type == "text" {
-			sb.WriteString(b.Text)
-			sb.WriteByte('\n')
-		}
-	}
-	return sb.String()
-}
-
-// readLastLines returns up to n trailing non-empty lines of the file, oldest
-// first. It reads at most the trailing 512KB — transcript records are single
-// JSONL lines comfortably under that; a line truncated by the byte cut is
-// discarded rather than half-parsed.
-func readLastLines(path string, n int) ([]string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	stat, err := f.Stat()
-	if err != nil {
-		return nil, err
-	}
-	size := stat.Size()
-	if size == 0 {
-		return nil, fmt.Errorf("empty file")
-	}
-
-	const maxTailBytes = int64(512 * 1024)
-	offset := int64(0)
-	if size > maxTailBytes {
-		offset = size - maxTailBytes
-	}
-	buf := make([]byte, size-offset)
-	if _, err := f.ReadAt(buf, offset); err != nil {
-		return nil, err
-	}
-
-	rawLines := strings.Split(strings.TrimRight(string(buf), "\n\r "), "\n")
-	if offset > 0 && len(rawLines) > 0 {
-		rawLines = rawLines[1:] // first line may be cut mid-record by the offset
-	}
-	start := 0
-	if len(rawLines) > n {
-		start = len(rawLines) - n
-	}
-	lines := make([]string, 0, n)
-	for _, raw := range rawLines[start:] {
-		if s := strings.TrimSpace(raw); s != "" {
-			lines = append(lines, s)
-		}
-	}
-	return lines, nil
 }
 
 // readLastLine reads the last non-empty line from a file.
 func readLastLine(path string) (string, error) {
-	lines, err := readLastLines(path, 1)
+	lines, err := session.TranscriptTailLines(path, 1)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/agent-deck/issue1186_done_signal_test.go
+++ b/cmd/agent-deck/issue1186_done_signal_test.go
@@ -13,14 +13,23 @@ import (
 // sentinel. On the Stop hook edge, agent-deck scans the transcript tail for
 // that sentinel and persists the parsed outcome into the hook status file so
 // the daemon can emit a distinct "finished" event to the parent. These tests
-// cover the cmd-side detection + persistence; the daemon-side emit lives in
-// internal/session. The transcript source is injectable (a file path) so the
-// tests don't need a live agent.
+// cover the cmd-side detection + persistence; the scan itself lives in
+// internal/session (transcript_done_scan_test.go), shared with the daemon's
+// flush-race rescan, and the daemon-side emit lives in internal/session too.
 
-// writeTranscript writes JSONL lines to a temp file and returns its path.
-func writeTranscript(t *testing.T, lines ...string) string {
+// writeClaudeTranscript writes JSONL lines to a transcript file under the
+// test HOME's ~/.claude (so detectDoneSentinel's containment guard passes)
+// and returns its path. Callers must have pointed HOME at a temp dir.
+func writeClaudeTranscript(t *testing.T, lines ...string) string {
 	t.Helper()
-	dir := t.TempDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("user home: %v", err)
+	}
+	dir := filepath.Join(home, ".claude", "projects", "p")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir transcript dir: %v", err)
+	}
 	path := filepath.Join(dir, "transcript.jsonl")
 	content := ""
 	for _, l := range lines {
@@ -50,113 +59,70 @@ func assistantLine(t *testing.T, body string) string {
 	return string(b)
 }
 
-func TestScanTranscriptForDone_OK(t *testing.T) {
-	path := writeTranscript(t,
-		assistantLine(t, "doing work"),
-		assistantLine(t, "all set.\n===AGENTDECK_DONE=== status=ok summary=feature shipped"),
-	)
-	sig, ok := scanTranscriptForDone(path)
-	if !ok {
-		t.Fatalf("expected sentinel detected in transcript")
+// stopPayload builds a Stop hook payload pointing at the given transcript.
+func stopPayload(t *testing.T, transcriptPath string) []byte {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"hook_event_name": "Stop",
+		"transcript_path": transcriptPath,
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
 	}
-	if sig.Status != "ok" || sig.Summary != "feature shipped" {
-		t.Errorf("got status=%q summary=%q", sig.Status, sig.Summary)
-	}
+	return b
 }
 
-func TestScanTranscriptForDone_Fail(t *testing.T) {
-	path := writeTranscript(t,
-		assistantLine(t, "===AGENTDECK_DONE=== status=fail summary=could not build"),
-	)
-	sig, ok := scanTranscriptForDone(path)
-	if !ok {
-		t.Fatalf("expected sentinel detected")
-	}
-	if sig.Status != "fail" || sig.Summary != "could not build" {
-		t.Errorf("got status=%q summary=%q", sig.Status, sig.Summary)
-	}
-}
-
-func TestScanTranscriptForDone_NoSentinel(t *testing.T) {
-	path := writeTranscript(t,
-		assistantLine(t, "just an ordinary mid-task turn, no sentinel here"),
-	)
-	if _, ok := scanTranscriptForDone(path); ok {
-		t.Errorf("expected no sentinel for ordinary turn")
-	}
-}
-
-func TestScanTranscriptForDone_MalformedIgnored(t *testing.T) {
-	path := writeTranscript(t,
-		assistantLine(t, "===AGENTDECK_DONE=== status=maybe summary=garbage"),
-	)
-	if _, ok := scanTranscriptForDone(path); ok {
-		t.Errorf("expected malformed sentinel to be ignored")
-	}
-}
-
-func TestScanTranscriptForDone_NonAssistantLastLine(t *testing.T) {
-	// A user/tool line as the tail must not be mined for a sentinel.
-	userLine := `{"type":"user","message":{"role":"user","content":"===AGENTDECK_DONE=== status=ok summary=spoofed"}}`
-	path := writeTranscript(t, userLine)
-	if _, ok := scanTranscriptForDone(path); ok {
-		t.Errorf("expected non-assistant tail to yield no sentinel")
-	}
-}
-
-func TestScanTranscriptForDone_MissingFile(t *testing.T) {
-	if _, ok := scanTranscriptForDone(filepath.Join(t.TempDir(), "nope.jsonl")); ok {
-		t.Errorf("expected missing transcript to yield no sentinel, not a crash")
-	}
-}
-
-// Regression: Claude Code appends system / attachment records after the
-// assistant turn (observed tail: `..., assistant, system, system`), so the
-// sentinel-bearing assistant record is not the literal last transcript line.
-// On a last-line-only scan, finished events never fire at all on current
-// transcript formats. The scan must walk back through that noise.
-func TestScanTranscriptForDone_TrailingSystemRecords(t *testing.T) {
-	path := writeTranscript(t,
+func TestDetectDoneSentinel_FlushedSentinel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path := writeClaudeTranscript(t,
 		`{"type":"user","message":{"role":"user","content":"do the thing"}}`,
 		assistantLine(t, "all done\n===AGENTDECK_DONE=== status=ok summary=fix landed"),
 		`{"type":"system","subtype":"hook_result"}`,
-		`{"type":"system","subtype":"turn_duration"}`,
 	)
-	sig, ok := scanTranscriptForDone(path)
-	if !ok {
-		t.Fatalf("expected sentinel detection through trailing system records")
+	res := detectDoneSentinel(stopPayload(t, path))
+	if res.signal == nil {
+		t.Fatalf("expected parsed sentinel, got %+v", res)
 	}
-	if sig.Status != "ok" || sig.Summary != "fix landed" {
-		t.Fatalf("wrong signal parsed: %+v", sig)
+	if res.signal.Status != "ok" || res.signal.Summary != "fix landed" {
+		t.Errorf("got status=%q summary=%q", res.signal.Status, res.signal.Summary)
+	}
+	if res.pendingTranscript != "" {
+		t.Errorf("flushed tail must not report pending, got %q", res.pendingTranscript)
 	}
 }
 
-// Regression: sidechain (subagent) assistant records interleave with the main
-// chain and must never be mined for a sentinel — a subagent quoting the
-// sentinel marker is not the session asserting completion.
-func TestScanTranscriptForDone_SidechainAssistantIgnored(t *testing.T) {
-	path := writeTranscript(t,
-		assistantLine(t, "main turn done\n===AGENTDECK_DONE=== status=ok summary=real"),
-		`{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"===AGENTDECK_DONE=== status=fail summary=sidechain must be ignored"}]}}`,
-		`{"type":"system","subtype":"hook_result"}`,
+// Regression for the flush race (one-turn lag): Claude Code can fire the Stop
+// hook BEFORE appending the turn's final assistant record, leaving a user
+// record as the newest main-chain line. Scanning past it would deliver the
+// PREVIOUS turn's sentinel. The hook must instead report the transcript as
+// pending — and not sleep, because the Stop hook runs synchronously (#1225).
+func TestDetectDoneSentinel_UnflushedTailReportsPending(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path := writeClaudeTranscript(t,
+		assistantLine(t, "previous turn\n===AGENTDECK_DONE=== status=fail summary=stale previous sentinel"),
+		`{"type":"user","message":{"role":"user","content":"next prompt"}}`,
 	)
-	sig, ok := scanTranscriptForDone(path)
-	if !ok {
-		t.Fatalf("expected main-chain sentinel behind sidechain noise")
+	res := detectDoneSentinel(stopPayload(t, path))
+	if res.signal != nil {
+		t.Fatalf("previous turn's sentinel leaked through the unflushed tail: %+v", *res.signal)
 	}
-	if sig.Status != "ok" || sig.Summary != "real" {
-		t.Fatalf("sidechain record leaked into detection: %+v", sig)
+	if res.pendingTranscript != path {
+		t.Fatalf("expected pending transcript %q, got %q", path, res.pendingTranscript)
 	}
 }
 
-// A tail window containing no main-chain assistant record yields no sentinel.
-func TestScanTranscriptForDone_NoAssistantInTail(t *testing.T) {
-	path := writeTranscript(t,
-		`{"type":"user","message":{"role":"user","content":"prompt"}}`,
-		`{"type":"system","subtype":"hook_result"}`,
-	)
-	if _, ok := scanTranscriptForDone(path); ok {
-		t.Fatalf("expected no sentinel without a main-chain assistant record")
+func TestDetectDoneSentinel_RejectsPathOutsideClaudeDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// Sentinel-bearing transcript OUTSIDE ~/.claude: containment guard must
+	// reject it without reading.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	if err := os.WriteFile(path, []byte(assistantLine(t, "===AGENTDECK_DONE=== status=ok summary=spoof")+"\n"), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	res := detectDoneSentinel(stopPayload(t, path))
+	if res.signal != nil || res.pendingTranscript != "" {
+		t.Fatalf("path outside ~/.claude must yield a zero result, got %+v", res)
 	}
 }
 
@@ -201,5 +167,34 @@ func TestWriteHookStatus_NoDoneFieldsWhenAbsent(t *testing.T) {
 	}
 	if _, present := parsed["done_status"]; present {
 		t.Errorf("done_status should be omitted for ordinary Stop, got %v", parsed["done_status"])
+	}
+	if _, present := parsed["transcript_path"]; present {
+		t.Errorf("transcript_path should be omitted for ordinary Stop, got %v", parsed["transcript_path"])
+	}
+}
+
+// An unflushed tail at Stop time persists the transcript path (and no done
+// fields) so the daemon can finish the scan on its poll loop.
+func TestWriteHookStatusWithScan_PersistsPendingTranscript(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	instanceID := "inst-pending"
+
+	pendingPath := filepath.Join(tmpHome, ".claude", "projects", "p", "transcript.jsonl")
+	writeHookStatusWithScan(instanceID, "waiting", "sess-3", "Stop", doneScanResult{pendingTranscript: pendingPath})
+
+	data, err := os.ReadFile(filepath.Join(getHooksDir(), instanceID+".json"))
+	if err != nil {
+		t.Fatalf("read hook file: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal hook file: %v", err)
+	}
+	if parsed["transcript_path"] != pendingPath {
+		t.Errorf("transcript_path = %v, want %q", parsed["transcript_path"], pendingPath)
+	}
+	if _, present := parsed["done_status"]; present {
+		t.Errorf("done_status should be absent on a pending scan, got %v", parsed["done_status"])
 	}
 }

--- a/cmd/agent-deck/issue1186_done_signal_test.go
+++ b/cmd/agent-deck/issue1186_done_signal_test.go
@@ -110,6 +110,56 @@ func TestScanTranscriptForDone_MissingFile(t *testing.T) {
 	}
 }
 
+// Regression: Claude Code appends system / attachment records after the
+// assistant turn (observed tail: `..., assistant, system, system`), so the
+// sentinel-bearing assistant record is not the literal last transcript line.
+// On a last-line-only scan, finished events never fire at all on current
+// transcript formats. The scan must walk back through that noise.
+func TestScanTranscriptForDone_TrailingSystemRecords(t *testing.T) {
+	path := writeTranscript(t,
+		`{"type":"user","message":{"role":"user","content":"do the thing"}}`,
+		assistantLine(t, "all done\n===AGENTDECK_DONE=== status=ok summary=fix landed"),
+		`{"type":"system","subtype":"hook_result"}`,
+		`{"type":"system","subtype":"turn_duration"}`,
+	)
+	sig, ok := scanTranscriptForDone(path)
+	if !ok {
+		t.Fatalf("expected sentinel detection through trailing system records")
+	}
+	if sig.Status != "ok" || sig.Summary != "fix landed" {
+		t.Fatalf("wrong signal parsed: %+v", sig)
+	}
+}
+
+// Regression: sidechain (subagent) assistant records interleave with the main
+// chain and must never be mined for a sentinel — a subagent quoting the
+// sentinel marker is not the session asserting completion.
+func TestScanTranscriptForDone_SidechainAssistantIgnored(t *testing.T) {
+	path := writeTranscript(t,
+		assistantLine(t, "main turn done\n===AGENTDECK_DONE=== status=ok summary=real"),
+		`{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"===AGENTDECK_DONE=== status=fail summary=sidechain must be ignored"}]}}`,
+		`{"type":"system","subtype":"hook_result"}`,
+	)
+	sig, ok := scanTranscriptForDone(path)
+	if !ok {
+		t.Fatalf("expected main-chain sentinel behind sidechain noise")
+	}
+	if sig.Status != "ok" || sig.Summary != "real" {
+		t.Fatalf("sidechain record leaked into detection: %+v", sig)
+	}
+}
+
+// A tail window containing no main-chain assistant record yields no sentinel.
+func TestScanTranscriptForDone_NoAssistantInTail(t *testing.T) {
+	path := writeTranscript(t,
+		`{"type":"user","message":{"role":"user","content":"prompt"}}`,
+		`{"type":"system","subtype":"hook_result"}`,
+	)
+	if _, ok := scanTranscriptForDone(path); ok {
+		t.Fatalf("expected no sentinel without a main-chain assistant record")
+	}
+}
+
 func TestWriteHookStatus_PersistsDoneFields(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -28,6 +28,10 @@ type HookStatus struct {
 	// detected on the Stop edge (issue #1186). Empty for ordinary turns.
 	DoneStatus  string // "ok" or "fail" when a completion sentinel was seen
 	DoneSummary string // free-text completion summary
+	// TranscriptPath is set when the Stop-edge sentinel scan was inconclusive
+	// because the turn's assistant record had not flushed yet (issue #1186
+	// flush race). The transition daemon re-scans this path on its poll loop.
+	TranscriptPath string
 }
 
 // StatusFileWatcher watches ~/.agent-deck/hooks/ for status file changes
@@ -192,24 +196,26 @@ func (w *StatusFileWatcher) scanDisk() map[string]*HookStatus {
 			continue
 		}
 		var raw struct {
-			Status      string `json:"status"`
-			SessionID   string `json:"session_id"`
-			Event       string `json:"event"`
-			Timestamp   int64  `json:"ts"`
-			DoneStatus  string `json:"done_status"`
-			DoneSummary string `json:"done_summary"`
+			Status         string `json:"status"`
+			SessionID      string `json:"session_id"`
+			Event          string `json:"event"`
+			Timestamp      int64  `json:"ts"`
+			DoneStatus     string `json:"done_status"`
+			DoneSummary    string `json:"done_summary"`
+			TranscriptPath string `json:"transcript_path"`
 		}
 		if uerr := json.Unmarshal(data, &raw); uerr != nil {
 			continue
 		}
 		instanceID := strings.TrimSuffix(entry.Name(), ".json")
 		out[instanceID] = &HookStatus{
-			Status:      raw.Status,
-			SessionID:   raw.SessionID,
-			Event:       raw.Event,
-			UpdatedAt:   time.Unix(raw.Timestamp, 0),
-			DoneStatus:  raw.DoneStatus,
-			DoneSummary: raw.DoneSummary,
+			Status:         raw.Status,
+			SessionID:      raw.SessionID,
+			Event:          raw.Event,
+			UpdatedAt:      time.Unix(raw.Timestamp, 0),
+			DoneStatus:     raw.DoneStatus,
+			DoneSummary:    raw.DoneSummary,
+			TranscriptPath: raw.TranscriptPath,
 		}
 	}
 	return out
@@ -277,12 +283,13 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 	}
 
 	var status struct {
-		Status      string `json:"status"`
-		SessionID   string `json:"session_id"`
-		Event       string `json:"event"`
-		Timestamp   int64  `json:"ts"`
-		DoneStatus  string `json:"done_status"`
-		DoneSummary string `json:"done_summary"`
+		Status         string `json:"status"`
+		SessionID      string `json:"session_id"`
+		Event          string `json:"event"`
+		Timestamp      int64  `json:"ts"`
+		DoneStatus     string `json:"done_status"`
+		DoneSummary    string `json:"done_summary"`
+		TranscriptPath string `json:"transcript_path"`
 	}
 	if err := json.Unmarshal(data, &status); err != nil {
 		hookLog.Warn("hook_file_corrupt",
@@ -299,12 +306,13 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 	instanceID := strings.TrimSuffix(base, ".json")
 
 	hookStatus := &HookStatus{
-		Status:      status.Status,
-		SessionID:   status.SessionID,
-		Event:       status.Event,
-		UpdatedAt:   time.Unix(status.Timestamp, 0),
-		DoneStatus:  status.DoneStatus,
-		DoneSummary: status.DoneSummary,
+		Status:         status.Status,
+		SessionID:      status.SessionID,
+		Event:          status.Event,
+		UpdatedAt:      time.Unix(status.Timestamp, 0),
+		DoneStatus:     status.DoneStatus,
+		DoneSummary:    status.DoneSummary,
+		TranscriptPath: status.TranscriptPath,
 	}
 
 	w.mu.Lock()

--- a/internal/session/issue1186_done_emit_test.go
+++ b/internal/session/issue1186_done_emit_test.go
@@ -241,3 +241,210 @@ func TestDaemon_EmitDoneSignals_NoSentinelNoEmit(t *testing.T) {
 	}
 	_ = strings.TrimSpace // keep imports stable across edits
 }
+
+// --- Flush-race rescan (issue #1186, Stop hook outrunning the transcript flush) ---
+//
+// Claude Code can fire the Stop hook before appending the turn's final
+// assistant record. The hook is synchronous (#1225) so it must not wait out
+// the flush; it persists the transcript path into the hook status file and
+// the daemon finishes the scan on its poll loop. These tests pin that retry:
+// pending tail -> no emit (and no resolved marker, so the next poll retries);
+// flushed sentinel -> exactly-once emit; stale or unsafe paths -> ignored.
+
+// writePendingTranscript writes JSONL lines under the test HOME's ~/.claude
+// (so the daemon's containment guard passes) and returns the path.
+func writePendingTranscript(t *testing.T, lines ...string) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("user home: %v", err)
+	}
+	dir := home + "/.claude/projects/p"
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := dir + "/transcript.jsonl"
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+func appendTranscriptLine(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open transcript for append: %v", err)
+	}
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	_ = f.Close()
+}
+
+func loadInstancesByID(t *testing.T, profile string) map[string]*Instance {
+	t.Helper()
+	storage, err := NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+	defer storage.Close()
+	instances, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	byID := map[string]*Instance{}
+	for _, inst := range instances {
+		byID[inst.ID] = inst
+	}
+	return byID
+}
+
+// TestDaemon_FlushRaceRescan_EmitsAfterFlush: a pending hook status emits
+// nothing while the tail is unflushed (and stays retryable), then emits the
+// finished event exactly once after the sentinel turn lands in the file.
+func TestDaemon_FlushRaceRescan_EmitsAfterFlush(t *testing.T) {
+	profile := "_test-1186-rescan-flush"
+	parentID, childID := seedDoneParentChild(t, profile)
+
+	d := NewTransitionDaemon()
+	t.Cleanup(d.notifier.Close)
+	byID := loadInstancesByID(t, profile)
+
+	path := writePendingTranscript(t,
+		scanAssistantLine(t, "previous turn, no sentinel"),
+		scanUserLine,
+	)
+	hs := &HookStatus{
+		Status:         "waiting",
+		Event:          "Stop",
+		TranscriptPath: path,
+		UpdatedAt:      time.Now(),
+	}
+	hookStatuses := map[string]*HookStatus{childID: hs}
+
+	// Unflushed: no emit, and the scan must NOT be marked resolved so the
+	// next poll retries.
+	d.emitDoneSignals(profile, byID, hookStatuses)
+	d.notifier.Flush()
+	if got := readInboxLines(t, parentID); len(got) != 0 {
+		t.Fatalf("pending tail must not emit; inbox has %d records", len(got))
+	}
+	if _, resolved := d.lastDoneScan[profile][childID]; resolved {
+		t.Fatalf("unresolved scan must not be marked resolved (it would never retry)")
+	}
+
+	// The flush lands; the next poll emits exactly once.
+	appendTranscriptLine(t, path, scanAssistantLine(t, "wrapped up\n===AGENTDECK_DONE=== status=ok summary=after the flush"))
+	d.emitDoneSignals(profile, byID, hookStatuses)
+	d.notifier.Flush()
+	got := readInboxLines(t, parentID)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 finished record after flush, got %d", len(got))
+	}
+	if got[0].Kind != transitionKindFinished || got[0].DoneStatus != "ok" || got[0].DoneSummary != "after the flush" {
+		t.Fatalf("wrong record: %+v", got[0])
+	}
+
+	// Re-poll: resolved marker + lastDone dedup keep it at one record.
+	d.emitDoneSignals(profile, byID, hookStatuses)
+	d.notifier.Flush()
+	if got := readInboxLines(t, parentID); len(got) != 1 {
+		t.Fatalf("re-poll after resolution must not duplicate; inbox has %d records", len(got))
+	}
+}
+
+// TestDaemon_FlushRaceRescan_NoSentinelResolvesQuiet: an ordinary turn (no
+// sentinel) that flushes resolves the pending scan with no emission, and the
+// resolved marker stops further transcript reads for that Stop edge.
+func TestDaemon_FlushRaceRescan_NoSentinelResolvesQuiet(t *testing.T) {
+	profile := "_test-1186-rescan-quiet"
+	parentID, childID := seedDoneParentChild(t, profile)
+
+	d := NewTransitionDaemon()
+	t.Cleanup(d.notifier.Close)
+	byID := loadInstancesByID(t, profile)
+
+	path := writePendingTranscript(t,
+		scanAssistantLine(t, "previous turn"),
+		scanUserLine,
+		scanAssistantLine(t, "just a normal answer, nothing to report"),
+	)
+	hs := &HookStatus{
+		Status:         "waiting",
+		Event:          "Stop",
+		TranscriptPath: path,
+		UpdatedAt:      time.Now(),
+	}
+	d.emitDoneSignals(profile, byID, map[string]*HookStatus{childID: hs})
+	d.notifier.Flush()
+	if got := readInboxLines(t, parentID); len(got) != 0 {
+		t.Fatalf("sentinel-less turn must not emit; inbox has %d records", len(got))
+	}
+	resolved, ok := d.lastDoneScan[profile][childID]
+	if !ok || !resolved.Equal(hs.UpdatedAt) {
+		t.Fatalf("conclusive no-sentinel scan must be marked resolved at the hook timestamp; got %v ok=%v", resolved, ok)
+	}
+}
+
+// TestDaemon_FlushRaceRescan_StaleHookIgnored: a pending hook status older
+// than hookFreshWindow is never rescanned — the freshness window is the
+// retry bound, same as the pre-existing done-fields path.
+func TestDaemon_FlushRaceRescan_StaleHookIgnored(t *testing.T) {
+	profile := "_test-1186-rescan-stale"
+	parentID, childID := seedDoneParentChild(t, profile)
+
+	d := NewTransitionDaemon()
+	t.Cleanup(d.notifier.Close)
+	byID := loadInstancesByID(t, profile)
+
+	path := writePendingTranscript(t,
+		scanAssistantLine(t, "late turn\n===AGENTDECK_DONE=== status=ok summary=too late"),
+	)
+	hs := &HookStatus{
+		Status:         "waiting",
+		Event:          "Stop",
+		TranscriptPath: path,
+		UpdatedAt:      time.Now().Add(-2 * hookFreshWindow),
+	}
+	d.emitDoneSignals(profile, byID, map[string]*HookStatus{childID: hs})
+	d.notifier.Flush()
+	if got := readInboxLines(t, parentID); len(got) != 0 {
+		t.Fatalf("stale pending hook must not emit; inbox has %d records", len(got))
+	}
+}
+
+// TestDaemon_FlushRaceRescan_PathOutsideClaudeRejected: the daemon re-applies
+// the ~/.claude containment guard before reading a path it found in a hook
+// status file — a sentinel-bearing file elsewhere on disk must not emit.
+func TestDaemon_FlushRaceRescan_PathOutsideClaudeRejected(t *testing.T) {
+	profile := "_test-1186-rescan-guard"
+	parentID, childID := seedDoneParentChild(t, profile)
+
+	d := NewTransitionDaemon()
+	t.Cleanup(d.notifier.Close)
+	byID := loadInstancesByID(t, profile)
+
+	outside := t.TempDir() + "/transcript.jsonl"
+	if err := os.WriteFile(outside, []byte(scanAssistantLine(t, "===AGENTDECK_DONE=== status=ok summary=spoof")+"\n"), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	hs := &HookStatus{
+		Status:         "waiting",
+		Event:          "Stop",
+		TranscriptPath: outside,
+		UpdatedAt:      time.Now(),
+	}
+	d.emitDoneSignals(profile, byID, map[string]*HookStatus{childID: hs})
+	d.notifier.Flush()
+	if got := readInboxLines(t, parentID); len(got) != 0 {
+		t.Fatalf("out-of-containment path must not emit; inbox has %d records", len(got))
+	}
+	if _, resolved := d.lastDoneScan[profile][childID]; !resolved {
+		t.Fatalf("rejected path should be marked resolved so the daemon does not retry it")
+	}
+}

--- a/internal/session/transcript_done_scan.go
+++ b/internal/session/transcript_done_scan.go
@@ -1,0 +1,174 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// This file holds the transcript-tail scan behind completion-sentinel
+// detection (issue #1186). It lives in internal/session because TWO callers
+// need it: the Stop-hook handler (cmd/agent-deck) for the immediate scan, and
+// the transition daemon for the flush-race rescan — Claude Code can fire the
+// Stop hook BEFORE appending the turn's final assistant record, and the hook,
+// synchronous since issue #1225, must not sleep waiting for the flush. The
+// hook persists the transcript path into the hook status file instead, and
+// the daemon's poll loop becomes the retry.
+
+// transcriptContentMessage extracts the assistant message content blocks from
+// a transcript line, for completion-sentinel detection.
+type transcriptContentMessage struct {
+	Type        string `json:"type"`
+	IsSidechain bool   `json:"isSidechain"`
+	Message     struct {
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+// doneScanTailLines bounds the backward walk over transcript records when
+// looking for the just-finished assistant turn. Post-assistant noise observed
+// in the wild is 1-4 records (system/attachment); 25 leaves generous margin
+// without rescanning history.
+const doneScanTailLines = 25
+
+// ValidateTranscriptPath cleans a Claude Code transcript path and applies the
+// same traversal / containment guards as the hook cost path: no "..", and the
+// path must live under ~/.claude (where Claude Code keeps transcripts). Both
+// the hook handler (payload-supplied path) and the daemon (path re-read from
+// a hook status file) gate on this before opening the file.
+func ValidateTranscriptPath(path string) (string, bool) {
+	if strings.TrimSpace(path) == "" {
+		return "", false
+	}
+	cleanPath := filepath.Clean(path)
+	if strings.Contains(cleanPath, "..") {
+		return "", false
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if !strings.HasPrefix(cleanPath, filepath.Join(home, ".claude")) {
+			return "", false
+		}
+	}
+	return cleanPath, true
+}
+
+// ScanTranscriptTailForDone scans the transcript tail for a completion
+// sentinel in the just-stopped MAIN-CHAIN assistant turn. The sentinel-bearing
+// assistant record is NOT reliably the literal last line: Claude Code appends
+// system / attachment records after the assistant turn, and sidechain
+// (subagent) records interleave freely. Walk backwards over a bounded tail
+// window, skipping sidechain traffic and non-turn records, until the first
+// main-chain assistant or user record:
+//
+//   - assistant: this IS the turn that just stopped — scan it for the
+//     sentinel. pending=false.
+//   - user: the just-stopped turn's reply has not been appended yet (the Stop
+//     hook outran the transcript flush). Scanning past it would re-read the
+//     PREVIOUS turn's sentinel — the observed deterministic one-turn lag — so
+//     report pending=true and let the caller retry once the record lands.
+//   - window exhausted: nothing conclusive in the tail; also pending=true
+//     (the flushed record, once appended, lands at the very end and the next
+//     scan sees it immediately).
+//
+// A missing/unreadable file yields pending=false so callers never spin on a
+// path that will not resolve.
+func ScanTranscriptTailForDone(path string) (sig DoneSignal, found bool, pending bool) {
+	lines, err := TranscriptTailLines(path, doneScanTailLines)
+	if err != nil {
+		return DoneSignal{}, false, false
+	}
+	for i := len(lines) - 1; i >= 0; i-- {
+		var msg transcriptContentMessage
+		if err := json.Unmarshal([]byte(lines[i]), &msg); err != nil {
+			continue
+		}
+		if msg.IsSidechain {
+			continue
+		}
+		switch msg.Type {
+		case "assistant":
+			sig, found = ScanDoneSentinel(transcriptText(msg.Message.Content))
+			return sig, found, false
+		case "user":
+			return DoneSignal{}, false, true
+		}
+	}
+	return DoneSignal{}, false, true
+}
+
+// transcriptText flattens an assistant message's content into plain text.
+// Claude transcripts encode content either as a string or as an array of
+// typed blocks ({"type":"text","text":"..."}); only text blocks contribute.
+func transcriptText(content json.RawMessage) string {
+	if len(content) == 0 {
+		return ""
+	}
+	var asString string
+	if err := json.Unmarshal(content, &asString); err == nil {
+		return asString
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, b := range blocks {
+		if b.Type == "text" {
+			sb.WriteString(b.Text)
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+// TranscriptTailLines returns up to n trailing non-empty lines of the file,
+// oldest first. It reads at most the trailing 512KB — transcript records are
+// single JSONL lines comfortably under that; a line truncated by the byte cut
+// is discarded rather than half-parsed.
+func TranscriptTailLines(path string, n int) ([]string, error) {
+	f, err := os.Open(path) // #nosec G304 -- callers validate via ValidateTranscriptPath or supply test paths
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := stat.Size()
+	if size == 0 {
+		return nil, fmt.Errorf("empty file")
+	}
+
+	const maxTailBytes = int64(512 * 1024)
+	offset := int64(0)
+	if size > maxTailBytes {
+		offset = size - maxTailBytes
+	}
+	buf := make([]byte, size-offset)
+	if _, err := f.ReadAt(buf, offset); err != nil {
+		return nil, err
+	}
+
+	rawLines := strings.Split(strings.TrimRight(string(buf), "\n\r "), "\n")
+	if offset > 0 && len(rawLines) > 0 {
+		rawLines = rawLines[1:] // first line may be cut mid-record by the offset
+	}
+	start := 0
+	if len(rawLines) > n {
+		start = len(rawLines) - n
+	}
+	lines := make([]string, 0, n)
+	for _, raw := range rawLines[start:] {
+		if s := strings.TrimSpace(raw); s != "" {
+			lines = append(lines, s)
+		}
+	}
+	return lines, nil
+}

--- a/internal/session/transcript_done_scan_test.go
+++ b/internal/session/transcript_done_scan_test.go
@@ -1,0 +1,259 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #1186: the transcript-tail scan behind completion-sentinel detection.
+// Shared by the Stop-hook handler (immediate scan) and the transition daemon
+// (flush-race rescan). The path is the injectable source: tests point it at a
+// temp file, no live agent required.
+
+// writeScanTranscript writes JSONL lines to a temp file and returns its path.
+func writeScanTranscript(t *testing.T, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	content := ""
+	for _, l := range lines {
+		content += l + "\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// scanAssistantLine builds a transcript assistant message whose text content
+// holds the supplied body.
+func scanAssistantLine(t *testing.T, body string) string {
+	t.Helper()
+	msg := map[string]any{
+		"type": "assistant",
+		"message": map[string]any{
+			"role":    "assistant",
+			"content": []map[string]any{{"type": "text", "text": body}},
+		},
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal assistant line: %v", err)
+	}
+	return string(b)
+}
+
+const scanUserLine = `{"type":"user","message":{"role":"user","content":"next prompt"}}`
+
+func TestScanTranscriptTailForDone_OK(t *testing.T) {
+	path := writeScanTranscript(t,
+		scanAssistantLine(t, "doing work"),
+		scanAssistantLine(t, "all set.\n===AGENTDECK_DONE=== status=ok summary=feature shipped"),
+	)
+	sig, found, pending := ScanTranscriptTailForDone(path)
+	if !found || pending {
+		t.Fatalf("expected conclusive sentinel, got found=%v pending=%v", found, pending)
+	}
+	if sig.Status != "ok" || sig.Summary != "feature shipped" {
+		t.Errorf("got status=%q summary=%q", sig.Status, sig.Summary)
+	}
+}
+
+func TestScanTranscriptTailForDone_Fail(t *testing.T) {
+	path := writeScanTranscript(t,
+		scanAssistantLine(t, "===AGENTDECK_DONE=== status=fail summary=could not build"),
+	)
+	sig, found, pending := ScanTranscriptTailForDone(path)
+	if !found || pending {
+		t.Fatalf("expected conclusive sentinel, got found=%v pending=%v", found, pending)
+	}
+	if sig.Status != "fail" || sig.Summary != "could not build" {
+		t.Errorf("got status=%q summary=%q", sig.Status, sig.Summary)
+	}
+}
+
+func TestScanTranscriptTailForDone_NoSentinel(t *testing.T) {
+	path := writeScanTranscript(t,
+		scanAssistantLine(t, "just an ordinary mid-task turn, no sentinel here"),
+	)
+	if _, found, pending := ScanTranscriptTailForDone(path); found || pending {
+		t.Errorf("ordinary flushed turn: want found=false pending=false, got found=%v pending=%v", found, pending)
+	}
+}
+
+func TestScanTranscriptTailForDone_MalformedIgnored(t *testing.T) {
+	path := writeScanTranscript(t,
+		scanAssistantLine(t, "===AGENTDECK_DONE=== status=maybe summary=garbage"),
+	)
+	if _, found, _ := ScanTranscriptTailForDone(path); found {
+		t.Errorf("expected malformed sentinel to be ignored")
+	}
+}
+
+func TestScanTranscriptTailForDone_MissingFile(t *testing.T) {
+	_, found, pending := ScanTranscriptTailForDone(filepath.Join(t.TempDir(), "nope.jsonl"))
+	if found {
+		t.Errorf("expected missing transcript to yield no sentinel, not a crash")
+	}
+	if pending {
+		t.Errorf("missing transcript must not report pending — callers would spin on it")
+	}
+}
+
+// Regression: Claude Code appends system / attachment records after the
+// assistant turn (observed tail: `..., assistant, system, system`), so the
+// sentinel-bearing assistant record is not the literal last transcript line.
+// On a last-line-only scan, finished events never fire at all on current
+// transcript formats. The scan must walk back through that noise.
+func TestScanTranscriptTailForDone_TrailingSystemRecords(t *testing.T) {
+	path := writeScanTranscript(t,
+		`{"type":"user","message":{"role":"user","content":"do the thing"}}`,
+		scanAssistantLine(t, "all done\n===AGENTDECK_DONE=== status=ok summary=fix landed"),
+		`{"type":"system","subtype":"hook_result"}`,
+		`{"type":"system","subtype":"turn_duration"}`,
+	)
+	sig, found, pending := ScanTranscriptTailForDone(path)
+	if !found || pending {
+		t.Fatalf("expected sentinel through trailing system records, got found=%v pending=%v", found, pending)
+	}
+	if sig.Status != "ok" || sig.Summary != "fix landed" {
+		t.Fatalf("wrong signal parsed: %+v", sig)
+	}
+}
+
+// Regression: sidechain (subagent) assistant records interleave with the main
+// chain and must never be mined for a sentinel — a subagent quoting the
+// sentinel marker is not the session asserting completion.
+func TestScanTranscriptTailForDone_SidechainAssistantIgnored(t *testing.T) {
+	path := writeScanTranscript(t,
+		scanAssistantLine(t, "main turn done\n===AGENTDECK_DONE=== status=ok summary=real"),
+		`{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"===AGENTDECK_DONE=== status=fail summary=sidechain must be ignored"}]}}`,
+		`{"type":"system","subtype":"hook_result"}`,
+	)
+	sig, found, pending := ScanTranscriptTailForDone(path)
+	if !found || pending {
+		t.Fatalf("expected main-chain sentinel behind sidechain noise, got found=%v pending=%v", found, pending)
+	}
+	if sig.Status != "ok" || sig.Summary != "real" {
+		t.Fatalf("sidechain record leaked into detection: %+v", sig)
+	}
+}
+
+// Regression for the flush race (one-turn lag): when the newest main-chain
+// record is a user record, the just-stopped turn's assistant reply has not
+// been appended yet. Scanning past it would return the PREVIOUS turn's
+// sentinel — observed live as a deterministic one-turn delivery lag, which
+// means a worker's final (sentinel) turn never delivers. The scan must stop
+// at the user record and report pending.
+func TestScanTranscriptTailForDone_UnflushedTailPending(t *testing.T) {
+	path := writeScanTranscript(t,
+		scanAssistantLine(t, "previous turn\n===AGENTDECK_DONE=== status=fail summary=stale previous sentinel"),
+		scanUserLine,
+	)
+	sig, found, pending := ScanTranscriptTailForDone(path)
+	if found {
+		t.Fatalf("previous turn's sentinel leaked through the unflushed tail: %+v", sig)
+	}
+	if !pending {
+		t.Fatalf("unflushed tail must report pending so the daemon retries")
+	}
+}
+
+// Sidechain noise appended after the user prompt (subagents streaming while
+// the main assistant reply is still unflushed) must not mask the pending
+// state — and must not be mined for a sentinel either.
+func TestScanTranscriptTailForDone_SidechainAfterUserStillPending(t *testing.T) {
+	path := writeScanTranscript(t,
+		scanAssistantLine(t, "previous turn"),
+		scanUserLine,
+		`{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"===AGENTDECK_DONE=== status=ok summary=sidechain spoof"}]}}`,
+	)
+	sig, found, pending := ScanTranscriptTailForDone(path)
+	if found {
+		t.Fatalf("sidechain sentinel leaked: %+v", sig)
+	}
+	if !pending {
+		t.Fatalf("expected pending while the main-chain reply is unflushed")
+	}
+}
+
+// A window with no main-chain turn record at all is treated as pending: the
+// flushed record, once appended, lands at the very end of the file and the
+// next scan sees it immediately.
+func TestScanTranscriptTailForDone_NoMainChainInWindow(t *testing.T) {
+	path := writeScanTranscript(t,
+		`{"type":"system","subtype":"hook_result"}`,
+		`{"type":"system","subtype":"turn_duration"}`,
+	)
+	if _, found, pending := ScanTranscriptTailForDone(path); found || !pending {
+		t.Fatalf("want found=false pending=true for a window without main-chain records, got found=%v pending=%v", found, pending)
+	}
+}
+
+// The pending sentinel turn flushing to the file resolves the scan — the
+// daemon-side retry sequence in miniature.
+func TestScanTranscriptTailForDone_FlushResolvesPending(t *testing.T) {
+	path := writeScanTranscript(t,
+		scanAssistantLine(t, "previous turn"),
+		scanUserLine,
+	)
+	if _, found, pending := ScanTranscriptTailForDone(path); found || !pending {
+		t.Fatalf("precondition: want pending before flush, got found=%v pending=%v", found, pending)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open transcript for append: %v", err)
+	}
+	if _, err := f.WriteString(scanAssistantLine(t, "done now\n===AGENTDECK_DONE=== status=ok summary=landed after flush") + "\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	_ = f.Close()
+
+	sig, found, pending := ScanTranscriptTailForDone(path)
+	if !found || pending {
+		t.Fatalf("flushed sentinel not picked up: found=%v pending=%v", found, pending)
+	}
+	if sig.Status != "ok" || sig.Summary != "landed after flush" {
+		t.Fatalf("wrong signal after flush: %+v", sig)
+	}
+}
+
+func TestValidateTranscriptPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	good := filepath.Join(home, ".claude", "projects", "p", "t.jsonl")
+	if cleaned, ok := ValidateTranscriptPath(good); !ok || cleaned != good {
+		t.Errorf("expected %q accepted, got ok=%v cleaned=%q", good, ok, cleaned)
+	}
+	if _, ok := ValidateTranscriptPath(""); ok {
+		t.Errorf("empty path must be rejected")
+	}
+	if _, ok := ValidateTranscriptPath("../../etc/passwd"); ok {
+		t.Errorf("traversal path must be rejected")
+	}
+	if _, ok := ValidateTranscriptPath(filepath.Join(home, "elsewhere", "t.jsonl")); ok {
+		t.Errorf("path outside ~/.claude must be rejected")
+	}
+}
+
+func TestTranscriptTailLines_BoundsAndOrder(t *testing.T) {
+	var lines []string
+	for i := 0; i < 40; i++ {
+		lines = append(lines, scanAssistantLine(t, strings.Repeat("x", 10)))
+	}
+	path := writeScanTranscript(t, lines...)
+	got, err := TranscriptTailLines(path, 25)
+	if err != nil {
+		t.Fatalf("TranscriptTailLines: %v", err)
+	}
+	if len(got) != 25 {
+		t.Fatalf("want 25 trailing lines, got %d", len(got))
+	}
+	if got[len(got)-1] != lines[len(lines)-1] {
+		t.Errorf("last returned line is not the file's last line")
+	}
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -45,6 +45,15 @@ type TransitionDaemon struct {
 	// across polls — or a later identical Stop — does not re-fire.
 	lastDone map[string]map[string]DoneSignal
 
+	// lastDoneScan tracks, per (profile, instance), the hook-status timestamp
+	// whose pending transcript rescan (issue #1186 flush race) reached a
+	// conclusive answer — assistant record flushed, sentinel present or not.
+	// It stops the daemon from re-reading the transcript tail every poll for
+	// the rest of the freshness window once the scan has resolved; an
+	// UNRESOLVED (still-unflushed) scan is deliberately not recorded so the
+	// next poll retries.
+	lastDoneScan map[string]map[string]time.Time
+
 	// lastInboxTTLSweep tracks the most recent SweepInboxByTTL call so
 	// the daemon runs it at most once per inboxTTLSweepInterval. Zero
 	// means "never run" — the first SyncOnce pass will perform it.
@@ -53,11 +62,12 @@ type TransitionDaemon struct {
 
 func NewTransitionDaemon() *TransitionDaemon {
 	return &TransitionDaemon{
-		notifier:    NewTransitionNotifier(),
-		storages:    map[string]*Storage{},
-		lastStatus:  map[string]map[string]string{},
-		initialized: map[string]bool{},
-		lastDone:    map[string]map[string]DoneSignal{},
+		notifier:     NewTransitionNotifier(),
+		storages:     map[string]*Storage{},
+		lastStatus:   map[string]map[string]string{},
+		initialized:  map[string]bool{},
+		lastDone:     map[string]map[string]DoneSignal{},
+		lastDoneScan: map[string]map[string]time.Time{},
 	}
 }
 
@@ -290,33 +300,21 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 // later identical Stop — fires at most once. A genuinely new completion
 // (different status/summary) fires again. Stale hook files (older than
 // hookFreshWindow) are ignored so a daemon restart doesn't replay a long-dead
-// completion.
+// completion. When the hook's own scan was inconclusive (transcript not
+// flushed at Stop time), the hook file carries the transcript path instead of
+// done fields and the daemon finishes the scan here — see doneSignalFor.
 func (d *TransitionDaemon) emitDoneSignals(profile string, byID map[string]*Instance, hookStatuses map[string]*HookStatus) {
 	if len(hookStatuses) == 0 {
 		return
 	}
 	notifyEnabled := GetNotificationsSettings().GetTransitionEventsEnabled()
 	for id, hs := range hookStatuses {
-		if hs == nil || strings.TrimSpace(hs.DoneStatus) == "" {
+		if hs == nil {
 			continue
 		}
-		// Issue #1214: a task worker run one-shot under the completion wrapper
-		// owns its own done signal via the kernel-exit path (cmd.Wait ->
-		// durable record -> active wake). Stand down from poll-inference for it
-		// — the freshness window + lastDone dedup that simulate exactly-once
-		// over a polled file are exactly what the kernel exit replaces. The
-		// claim record exists for the whole run, so this also wins the race
-		// against the worker's own Stop hook. Interactive sessions (no record)
-		// keep the path below unchanged.
-		if CompletionRecordExists(profile, id) {
+		sig, ok := d.doneSignalFor(profile, id, hs)
+		if !ok {
 			continue
-		}
-		if !hs.UpdatedAt.IsZero() && time.Since(hs.UpdatedAt) > hookFreshWindow {
-			continue
-		}
-		sig := DoneSignal{
-			Status:  strings.ToLower(strings.TrimSpace(hs.DoneStatus)),
-			Summary: strings.TrimSpace(hs.DoneSummary),
 		}
 		if prev, ok := d.lastDone[profile][id]; ok && prev == sig {
 			continue // already emitted this exact completion
@@ -342,6 +340,84 @@ func (d *TransitionDaemon) emitDoneSignals(profile string, byID map[string]*Inst
 		}
 		d.lastDone[profile][id] = sig
 	}
+}
+
+// doneSignalFor resolves a hook status into a completion sentinel, or reports
+// none (ok=false). Two sources, in order:
+//
+//  1. Done fields persisted by the Stop hook's own scan — the common path.
+//  2. A pending transcript rescan (issue #1186 flush race): Claude Code can
+//     fire the Stop hook BEFORE appending the turn's final assistant record,
+//     and the hook — synchronous since #1225, Claude blocks on its exit —
+//     must not sleep waiting for the flush. The hook persists the validated
+//     transcript path instead, and the daemon's poll loop is the retry: each
+//     pass re-scans the tail until the record lands (typically the very next
+//     poll) or the hook file ages out of hookFreshWindow.
+//
+// Both sources respect the #1214 completion-wrapper ownership gate and the
+// freshness window exactly like the pre-existing done-fields path.
+func (d *TransitionDaemon) doneSignalFor(profile, id string, hs *HookStatus) (DoneSignal, bool) {
+	fresh := hs.UpdatedAt.IsZero() || time.Since(hs.UpdatedAt) <= hookFreshWindow
+
+	if strings.TrimSpace(hs.DoneStatus) != "" {
+		// Issue #1214: a task worker run one-shot under the completion wrapper
+		// owns its own done signal via the kernel-exit path (cmd.Wait ->
+		// durable record -> active wake). Stand down from poll-inference for it
+		// — the freshness window + lastDone dedup that simulate exactly-once
+		// over a polled file are exactly what the kernel exit replaces. The
+		// claim record exists for the whole run, so this also wins the race
+		// against the worker's own Stop hook. Interactive sessions (no record)
+		// keep the path below unchanged.
+		if CompletionRecordExists(profile, id) {
+			return DoneSignal{}, false
+		}
+		if !fresh {
+			return DoneSignal{}, false
+		}
+		return DoneSignal{
+			Status:  strings.ToLower(strings.TrimSpace(hs.DoneStatus)),
+			Summary: strings.TrimSpace(hs.DoneSummary),
+		}, true
+	}
+
+	// Pending rescan path. Freshness uses a hard zero-check here (unlike the
+	// done-fields path, which tolerates a zero UpdatedAt for legacy files):
+	// the window is the only bound on the retry loop.
+	if strings.TrimSpace(hs.TranscriptPath) == "" {
+		return DoneSignal{}, false
+	}
+	if hs.UpdatedAt.IsZero() || !fresh {
+		return DoneSignal{}, false
+	}
+	// Already reached a conclusive scan for this Stop edge — don't re-read
+	// the transcript every poll for the rest of the freshness window. (Hook
+	// timestamps have second granularity; two Stop edges inside the same
+	// second could collide here, which degrades to the pre-#1186 waiting
+	// transition — turns take seconds, so this is acceptable.)
+	if resolved, ok := d.lastDoneScan[profile][id]; ok && !hs.UpdatedAt.After(resolved) {
+		return DoneSignal{}, false
+	}
+	if CompletionRecordExists(profile, id) {
+		return DoneSignal{}, false
+	}
+	cleanPath, ok := ValidateTranscriptPath(hs.TranscriptPath)
+	if !ok {
+		d.markDoneScanResolved(profile, id, hs.UpdatedAt)
+		return DoneSignal{}, false
+	}
+	sig, found, pending := ScanTranscriptTailForDone(cleanPath)
+	if pending {
+		return DoneSignal{}, false // record still unflushed: retry next poll
+	}
+	d.markDoneScanResolved(profile, id, hs.UpdatedAt)
+	return sig, found
+}
+
+func (d *TransitionDaemon) markDoneScanResolved(profile, id string, at time.Time) {
+	if d.lastDoneScan[profile] == nil {
+		d.lastDoneScan[profile] = map[string]time.Time{}
+	}
+	d.lastDoneScan[profile][id] = at
 }
 
 func (d *TransitionDaemon) getStorage(profile string) *Storage {
@@ -451,12 +527,13 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		return nil
 	}
 	var raw struct {
-		Status      string `json:"status"`
-		SessionID   string `json:"session_id"`
-		Event       string `json:"event"`
-		Timestamp   int64  `json:"ts"`
-		DoneStatus  string `json:"done_status"`
-		DoneSummary string `json:"done_summary"`
+		Status         string `json:"status"`
+		SessionID      string `json:"session_id"`
+		Event          string `json:"event"`
+		Timestamp      int64  `json:"ts"`
+		DoneStatus     string `json:"done_status"`
+		DoneSummary    string `json:"done_summary"`
+		TranscriptPath string `json:"transcript_path"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil
@@ -469,12 +546,13 @@ func readHookStatusFile(instanceID string) *HookStatus {
 		updatedAt = time.Unix(raw.Timestamp, 0)
 	}
 	return &HookStatus{
-		Status:      raw.Status,
-		SessionID:   raw.SessionID,
-		Event:       raw.Event,
-		UpdatedAt:   updatedAt,
-		DoneStatus:  raw.DoneStatus,
-		DoneSummary: raw.DoneSummary,
+		Status:         raw.Status,
+		SessionID:      raw.SessionID,
+		Event:          raw.Event,
+		UpdatedAt:      updatedAt,
+		DoneStatus:     raw.DoneStatus,
+		DoneSummary:    raw.DoneSummary,
+		TranscriptPath: raw.TranscriptPath,
 	}
 }
 


### PR DESCRIPTION
## Root cause

Two bugs, one feature surface (#1186 / #1188 done-sentinel → `finished`
events). Details and live evidence in #1422.

1. `scanTranscriptForDone` reads only the literal **last** transcript line
   and requires `type == "assistant"`. Current Claude Code appends system /
   attachment records after the assistant turn (observed tail:
   `..., assistant, system, system`), so detection never succeeds — zero
   `kind=finished` events ever, on two independent long-running deployments.
2. Claude Code can fire the Stop hook **before** the turn's final assistant
   record is flushed to the JSONL. A backward scan alone then reads the
   PREVIOUS turn's sentinel (observed live: deterministic one-turn lag), so a
   worker's final — sentinel-bearing — turn never delivers. The Stop hook is
   synchronous since #1225 (Claude blocks on its exit to read the
   `decision:block` drain response), so the hook must not sleep out the
   flush: any in-process retry adds turn-end latency to every managed
   session.

## The fix

Commit 1 — bounded backward tail scan (`cmd/agent-deck/hook_handler.go`):

- Walk up to 25 trailing transcript lines backwards; skip system /
  attachment records and sidechain (`isSidechain`, subagent) records; scan
  the first **main-chain assistant** record found — the turn that just
  stopped. Earlier turns are never reached.
- `readLastLine` (cost path) is rebuilt on the shared tail reader instead of
  duplicating the backward-read logic.

Commit 2 — flush race handed to the daemon (zero added hook latency):

- The scan moves to `internal/session/transcript_done_scan.go`, shared by
  both callers, with one new outcome: if the newest main-chain record in the
  window is a **user** record, the just-stopped turn's reply is not flushed
  yet → `pending`.
- On `pending`, the hook persists the validated transcript path into the
  hook status file (`transcript_path`, omitempty) — no done fields, no
  sleeping — and exits.
- The transition daemon's existing poll loop finishes the scan
  (`doneSignalFor` in `transition_daemon.go`): re-scan on each pass until the
  record lands (typically the next poll), bounded by the existing 45s
  `hookFreshWindow`, deduped by the existing `lastDone` map, gated by the
  same #1214 completion-record ownership check as the done-fields path, and
  memoized per Stop edge (`lastDoneScan`) so a resolved scan stops re-reading
  the transcript for the rest of the window.
- The daemon re-applies the `~/.claude` containment / path-traversal guard
  (`ValidateTranscriptPath`, shared with the hook) before opening any path it
  read from a status file.

Behavioral invariants preserved: #1214 wrapper-owned completions stay
suppressed on the poll path; #1225's synchronous Stop drain is untouched (the
hook still exits immediately); ordinary no-sentinel Stops write the same
status files as before, plus `transcript_path` only when the tail was
unflushed.

## Regression tests

Fail-first on main (verified):

- `internal/session/transcript_done_scan_test.go` — trailing-system-records
  detection, sidechain-spoof rejection (incl. sidechain noise after the user
  prompt), **unflushed tail must not leak the previous turn's sentinel**,
  flush-resolves-pending, no-main-chain window, missing file must not report
  pending (no retry spin), path validation, tail-window bounds.
- `cmd/agent-deck/issue1186_done_signal_test.go` — payload-level detection
  (flushed sentinel / unflushed-pending / containment rejection) and hook
  status persistence (done fields, pending `transcript_path`, omitted-when-
  absent).
- `internal/session/issue1186_done_emit_test.go` — daemon rescan: no emit +
  retryable while unflushed, exactly-once emit after the flush lands, quiet
  resolution without a sentinel, stale hook files ignored, containment guard
  on daemon-read paths.

`go test ./cmd/... ./internal/session/...` — green except two pre-existing
environment-sensitive failures in `internal/session`
(`issue1349_rebind_guard_test.go:369,420`), which fail identically on
unmodified `main` in this environment. `golangci-lint run` on both touched
packages: 0 issues.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Resolved race condition** where transcript completion could be missed when transcript flush occurs simultaneously with hook emission
* **Enhanced transcript validation** with support for deferred rescanning to ensure completion detection reliably succeeds even when transcript state is initially unclear

<!-- end of auto-generated comment: release notes by coderabbit.ai -->