### PR TITLE
fix(notify): stale DB row must not veto a fresh terminal hook status (fixes #1424)

### DIFF
--- a/internal/session/stale_row_veto_test.go
+++ b/internal/session/stale_row_veto_test.go
@@ -1,0 +1,166 @@
+package session
+
+// Stale-row veto regression tests: under a live TUI heartbeat
+// (AliveInstanceCount > 0) syncProfile reads session statuses from DB rows.
+// A TUI that holds the heartbeat without refreshing its rows (orphaned tab,
+// or sessions created after it loaded its list) leaves rows frozen at
+// `running`, and emitHookTransitionCandidates let that stale row OVERRIDE a
+// FRESH terminal hook status — the candidate was then dropped as
+// non-terminal, so the child's completion vanished with no event and no log.
+//
+// Written test-first: TestSyncOnce_StaleRunningRowDoesNotVetoFreshTerminalHook
+// must FAIL on pre-fix main. The other two pin the boundaries of the fix:
+// a MORE-final row still wins, and the snapshot path still owns transitions
+// the rows actually reflect (no double delivery).
+//
+// NOTE: rename to issueNNNN_stale_row_veto_test.go once the upstream issue
+// is filed, per the regression-test naming convention.
+
+import (
+	"testing"
+	"time"
+)
+
+// seedStaleRowFixture saves a parent + claude child (status running) into the
+// profile's storage, registers a fresh TUI heartbeat on the profile DB (the
+// orphaned-TUI condition: heartbeat alive, rows not refreshed), and writes the
+// child's DB status row. Returns the parent and child.
+func seedStaleRowFixture(t *testing.T, storage *Storage, childID, parentID, rowStatus string) (*Instance, *Instance) {
+	t.Helper()
+	now := time.Now()
+	child := &Instance{
+		ID:              childID,
+		Title:           "worker",
+		ProjectPath:     "/tmp/" + childID,
+		GroupPath:       DefaultGroupPath,
+		ParentSessionID: parentID,
+		Tool:            "claude",
+		Status:          StatusRunning,
+		CreatedAt:       now,
+	}
+	parent := &Instance{
+		ID:          parentID,
+		Title:       "orchestrator",
+		ProjectPath: "/tmp/" + parentID,
+		GroupPath:   DefaultGroupPath,
+		Tool:        "claude",
+		Status:      StatusRunning,
+		CreatedAt:   now,
+	}
+	if err := storage.SaveWithGroups([]*Instance{child, parent}, nil); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	db := storage.GetDB()
+	if db == nil {
+		t.Fatal("storage has no state DB")
+	}
+	// The orphaned TUI: a fresh heartbeat keeps the daemon on the DB-row
+	// status source for this profile…
+	if err := db.RegisterInstance(false); err != nil {
+		t.Fatalf("RegisterInstance: %v", err)
+	}
+	// …while the child's row stays at whatever the TUI last wrote.
+	if err := db.WriteStatus(child.ID, rowStatus, child.Tool); err != nil {
+		t.Fatalf("WriteStatus: %v", err)
+	}
+	return parent, child
+}
+
+// TestSyncOnce_StaleRunningRowDoesNotVetoFreshTerminalHook is the PRIMARY
+// regression test. The child's own Stop hook asserts a fresh terminal status
+// (waiting) while the orphaned TUI's DB row still says running. The daemon
+// must emit the transition to the parent's inbox — the stale non-terminal row
+// must not veto the fresh hook status.
+func TestSyncOnce_StaleRunningRowDoesNotVetoFreshTerminalHook(t *testing.T) {
+	const profile = "_test_stalerow_veto"
+	d, storage := bootstrapDaemonProfile(t, profile)
+	ResetInboxFingerprintCacheForTest()
+	t.Cleanup(ResetInboxFingerprintCacheForTest)
+
+	parent, child := seedStaleRowFixture(t, storage, "stalerow-child-1", "stalerow-parent-1", "running")
+
+	// The child's own runtime asserts a FRESH terminal status via its Stop hook.
+	seedHookStatusFile(t, child.ID, "Stop", "55555555-5555-5555-5555-555555555555", "waiting")
+
+	d.syncProfile(profile)
+
+	inbox, err := DrainInboxForParent(parent.ID)
+	if err != nil {
+		t.Fatalf("DrainInboxForParent: %v", err)
+	}
+	if len(inbox) != 1 {
+		t.Fatalf("stale running row vetoed the fresh terminal hook status: parent inbox has %d events, want 1", len(inbox))
+	}
+	if inbox[0].ChildSessionID != child.ID || inbox[0].ToStatus != "waiting" {
+		t.Fatalf("wrong event committed: %+v", inbox[0])
+	}
+}
+
+// TestSyncOnce_MoreFinalRowStillWinsOverHookStatus guards the deliberately
+// preserved half of the override: when the DB row is itself notify-terminal
+// (and possibly MORE final than the hook status, e.g. error), the row still
+// wins and the emitted event carries the row's status.
+func TestSyncOnce_MoreFinalRowStillWinsOverHookStatus(t *testing.T) {
+	const profile = "_test_stalerow_morefinal"
+	d, storage := bootstrapDaemonProfile(t, profile)
+	ResetInboxFingerprintCacheForTest()
+	t.Cleanup(ResetInboxFingerprintCacheForTest)
+
+	parent, child := seedStaleRowFixture(t, storage, "stalerow-child-2", "stalerow-parent-2", "error")
+
+	seedHookStatusFile(t, child.ID, "Stop", "66666666-6666-6666-6666-666666666666", "waiting")
+
+	d.syncProfile(profile)
+
+	inbox, err := DrainInboxForParent(parent.ID)
+	if err != nil {
+		t.Fatalf("DrainInboxForParent: %v", err)
+	}
+	if len(inbox) != 1 {
+		t.Fatalf("parent inbox has %d events, want 1", len(inbox))
+	}
+	if inbox[0].ToStatus != "error" {
+		t.Fatalf("more-final row must win over the hook status: got to_status %q, want %q", inbox[0].ToStatus, "error")
+	}
+}
+
+// TestSyncOnce_SnapshotPathStillOwnsRefreshedRowTransition guards against the
+// fix introducing double delivery: when the rows ARE being refreshed (healthy
+// TUI) and both the row and the hook status report the same terminal
+// transition, the snapshot path emits it and the hook-candidate path stands
+// down — exactly one event reaches the parent.
+func TestSyncOnce_SnapshotPathStillOwnsRefreshedRowTransition(t *testing.T) {
+	const profile = "_test_stalerow_norefire"
+	d, storage := bootstrapDaemonProfile(t, profile)
+	ResetInboxFingerprintCacheForTest()
+	t.Cleanup(ResetInboxFingerprintCacheForTest)
+
+	parent, child := seedStaleRowFixture(t, storage, "stalerow-child-3", "stalerow-parent-3", "running")
+
+	// First poll observes the running snapshot (no hook file yet).
+	d.syncProfile(profile)
+	if events, err := DrainInboxForParent(parent.ID); err != nil || len(events) != 0 {
+		t.Fatalf("no event expected on the running snapshot, got %d (err=%v)", len(events), err)
+	}
+
+	// The TUI refreshes the row AND the child's Stop hook fires: both sources
+	// now agree on running→waiting.
+	if err := storage.GetDB().WriteStatus(child.ID, "waiting", child.Tool); err != nil {
+		t.Fatalf("WriteStatus: %v", err)
+	}
+	seedHookStatusFile(t, child.ID, "Stop", "77777777-7777-7777-7777-777777777777", "waiting")
+
+	d.syncProfile(profile)
+
+	inbox, err := DrainInboxForParent(parent.ID)
+	if err != nil {
+		t.Fatalf("DrainInboxForParent: %v", err)
+	}
+	if len(inbox) != 1 {
+		t.Fatalf("refreshed-row transition must be delivered exactly once, got %d events", len(inbox))
+	}
+	if inbox[0].ChildSessionID != child.ID || inbox[0].ToStatus != "waiting" {
+		t.Fatalf("wrong event committed: %+v", inbox[0])
+	}
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -502,7 +502,16 @@ func (d *TransitionDaemon) emitHookTransitionCandidates(
 		}
 
 		to := normalizeStatusString(candidate.ToStatus)
-		if curr := normalizeStatusString(current[id]); curr != "" {
+		// A live TUI heartbeat routes `current` through DB status rows. A TUI
+		// that holds the heartbeat without refreshing its rows (orphaned tab,
+		// or sessions created after it loaded its list) leaves rows frozen at
+		// `running`, and letting that stale row override a FRESH terminal hook
+		// status drops the child's completion entirely — no transition event,
+		// no log line. The hook file is the child's own runtime asserting its
+		// state; only defer to the row when the row itself is notify-terminal
+		// (it may be MORE final, e.g. error). A non-terminal row never vetoes
+		// a fresh terminal hook status.
+		if curr := normalizeStatusString(current[id]); curr != "" && isNotifyTerminalStatus(curr) {
 			to = curr
 		}
 		if !isNotifyTerminalStatus(to) {


### PR DESCRIPTION
### Root cause

Under a live TUI heartbeat (`AliveInstanceCount() > 0`, `statedb.go:1198`) the notify-daemon's `syncProfile` reads session statuses from DB status rows instead of self-probing (`transition_daemon.go:214-246`). A TUI that holds the heartbeat **without refreshing its rows** — an orphaned/idle tab, or sessions created after it loaded its list — leaves those rows frozen at `running`.

`emitHookTransitionCandidates` then let the stale row unconditionally override the fresh terminal hook status:

```go
to := normalizeStatusString(candidate.ToStatus)   // "waiting" — fresh, from the child's own Stop hook
if curr := normalizeStatusString(current[id]); curr != "" {
    to = curr                                      // "running" — stale DB row wins
}
if !isNotifyTerminalStatus(to) {
    continue                                       // candidate dropped, no event, no log
}
```

The child's completion vanishes silently: no transition event reaches the parent's inbox, no journal line is written. Observed in the field: five children of one conductor completed within a 7-minute window while an idle TUI (started hours earlier) held the profile's heartbeat — all five `running→waiting` transitions were dropped; sessions on a second profile with no orphaned TUI delivered normally throughout (full repro in the linked issue).

This is the same failure class #1349/#1352 fixed: **stale DB state must not clobber fresh hook truth.** The hook status file is the child's own runtime asserting its state; a row nobody is refreshing is not a better source.

### The fix

Only defer to the row when the row itself is notify-terminal — it may legitimately be *more* final than the hook status (e.g. `error`). A non-terminal row never vetoes a fresh terminal hook status (`internal/session/transition_daemon.go`, one condition):

```go
if curr := normalizeStatusString(current[id]); curr != "" && isNotifyTerminalStatus(curr) {
    to = curr
}
```

Boundaries deliberately preserved:

- **No double delivery.** When the rows *are* being refreshed (healthy TUI), the snapshot transition path emits the event and the candidate path still stands down via the existing `ShouldNotifyTransition(fromSnapshot, current[id])` guard — unchanged.
- **#1214 completion-wrapper gate untouched.** Task workers under the completion wrapper keep their owned done path; the `CompletionRecordExists` suppression runs before this code.
- **#1349/#1352 invariant respected.** Candidate *emission* stays unguarded (the liveness gate applies to session-id rebinding only); this change removes a wrong suppression, it adds none.
- **Fast-reprompt window.** A child that Stops while the parent immediately re-prompts within the same poll gap produces a fresh terminal hook status and a still-`running` DB row — the exact dropout scenario this PR fixes. New code emits the `running→waiting` event; the existing `isDuplicate`/`markNotified` dedup in the notifier prevents it reaching the parent's inbox twice if the row also transitions before the next sync. This is the correct behavior under #1352 (stale DB state must not clobber fresh hook truth): the transition genuinely happened, and the notifier's idempotency layer is the right place to absorb any transient duplication risk. Named here because `internal/session` gets a Codex adversarial review pass.

### Regression tests

`internal/session/stale_row_veto_test.go` — written fail-first, verified red on `main` @ `4541d10f` / green with the fix:

| test | pins | on pre-fix main |
|---|---|---|
| `TestSyncOnce_StaleRunningRowDoesNotVetoFreshTerminalHook` | stale `running` row + fresh terminal Stop hook → event committed to the parent inbox | **FAIL** (0 events — the dropout) |
| `TestSyncOnce_MoreFinalRowStillWinsOverHookStatus` | row `error` vs hook `waiting` → emitted event carries `error` | pass (guard against over-correcting) |
| `TestSyncOnce_SnapshotPathStillOwnsRefreshedRowTransition` | refreshed row + hook agreeing → exactly one delivery, via the snapshot path | pass (guard against double delivery) |

The tests reproduce the orphaned-TUI condition directly: a fresh heartbeat registered on the profile DB (`RegisterInstance`) with the child's status row pinned at `running` (`WriteStatus`), while a fresh `Stop`/`waiting` hook file is seeded for the child.

Local verification: `go vet` clean, `golangci-lint run ./internal/session/` 0 issues, transition/notifier/#1349 test subset green. (Two pre-existing env-sensitive failures in `issue1349_rebind_guard_test.go:369,420` — transcript-path resolution under the unsandboxed test HOME — fail identically with and without this change.)

### Links

- Fixes #1424 (issue text below; same silent-dropout family as the never-firing done-sentinel scan, reported separately)
- Same invariant as #1352 (*don't rebind stopped/removed sessions from stale SessionEnd hook*, merged) — stale DB state must not override fresh hook truth
- Composes with the #1186 → #1214 → #1225 notify arc: this fixes the poll-inference path; the owned done path (#1214) and durable outbox (#1225) are untouched
- Rebased onto v1.9.58 (`048bae91`) — verified orthogonal to #1394 (`99e3674e`, *reclaim dead primary in ElectPrimary*). #1394 changes only the `is_primary` flag selection during primary election; it does not touch `AliveInstanceCount()` (which counts heartbeat-fresh rows independent of `is_primary`) or `ReadAllStatuses()`. The `tuiAlive` gate (`AliveInstanceCount() > 0`) and the stale-`status`-row source this PR fixes are therefore unchanged by #1394 — no file conflict, no semantic interaction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where stale database entries could incorrectly override fresh instance status updates when transitioning to terminal states.
  * Ensured fresh status information from the daemon takes precedence over outdated database records during state synchronization.

* **Tests**
  * Added regression tests to verify correct behavior for stale row handling in instance state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->