### PR TITLE
fix(tui): address session-switcher review feedback (follow-up to #1411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Session switcher review-feedback fixes** ([#1426](https://github.com/asheshgoplani/agent-deck/pull/1426), follow-up to [#1411](https://github.com/asheshgoplani/agent-deck/pull/1411)). Restores `SIGINT` handling on the attach raw-mode setup failure paths — a failure there could otherwise leave the process permanently ignoring `Ctrl+C`. Opens the in-attach switcher on the session actually in view after a notification-bar switch (`Ctrl+b 1-6`) rather than the original attach target, fixing pre-highlight / `Esc`-reattach / follow-CWD. The attached status-bar hint now reflects the configured `[hotkeys]` detach/switch bindings instead of hardcoded `ctrl+q`/`ctrl+s` (and is omitted when the switch key is unbound or collides with detach). The switcher resizes with the window; `Show` clears stale picker state when fewer than two sessions remain; and the footer `Esc` hint is context-sensitive ("back" while attached vs "close" from the overview). Documents the switcher as local-only (remote/SSH sessions use a separate attach path).
+
 ## [1.9.58] - 2026-06-13
 
 ### Added

--- a/docs/terminal-shortcuts.md
+++ b/docs/terminal-shortcuts.md
@@ -44,6 +44,9 @@ The same `Ctrl-S` also works **from the overview list** — it opens the
 switcher pre-highlighted on the session under the cursor, so you can hop
 to a recent session without scrolling the grouped list.
 
+> The switcher currently lists **local sessions only**. Remote (SSH) sessions
+> use a separate attach path and aren't yet included in the picker.
+
 A single `Ctrl-S` just opens the switcher (highlighting the session you're
 already in, so an immediate `Enter` is a no-op) and waits — it only starts
 the auto-attach countdown once you actually cycle inside it, so an

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -3270,7 +3270,7 @@ func CreateExampleConfig() error {
                       # Alias [tmux].detach_key exists; [hotkeys].detach wins.
 # In-attach session switcher (cycle sessions without first detaching to the list):
 # switch_session = "ctrl+s"   # opens the switcher while attached. Tap again to cycle
-#                             # forward (Shift+Tab / Up to go back); it auto-attaches
+#                             # forward (Ctrl+A to go back); it auto-attaches
 #                             # ~1s after you stop, Enter attaches now, Esc cancels.
 #                             # Must be a "ctrl+<letter>" chord.
 

--- a/internal/tmux/pty.go
+++ b/internal/tmux/pty.go
@@ -253,12 +253,17 @@ func (s *Session) AttachWithOptions(ctx context.Context, opts AttachOptions) (Sw
 	// restoring the terminal and Attach() calling term.MakeRaw().
 	// SIGINT is restored in cleanupAttach() via signal.Reset(syscall.SIGINT).
 	signal.Ignore(syscall.SIGINT)
+	// Safety net: restore SIGINT on every return path. cleanupAttach() resets it
+	// first thing on the normal teardown, but the raw-mode setup failures below
+	// return before cleanupAttach runs — without this defer they would leave the
+	// process permanently ignoring Ctrl+C. signal.Reset is idempotent, so the
+	// extra call on the happy path is harmless.
+	defer signal.Reset(syscall.SIGINT)
 
 	// Start command with PTY, pre-sized to the controlling terminal so the
 	// tmux client connects full-width from frame one (#1167).
 	ptmx, err := StartAttachPTY(cmd, os.Stdin)
 	if err != nil {
-		signal.Reset(syscall.SIGINT)
 		return SwitchNone, fmt.Errorf("failed to start pty: %w", err)
 	}
 	defer ptmx.Close()

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -115,8 +115,45 @@ func currentTmuxThemeStyle() tmuxThemeStyle {
 	}
 }
 
+// Status-bar hint labels. The attach loop's detach/switch keys are configurable
+// ([hotkeys].detach / [hotkeys].switch_session), so the status-right hint must
+// follow the resolved bindings instead of hardcoding them. The UI layer pushes
+// the resolved labels here via SetStatusHints whenever hotkeys are (re)resolved;
+// the defaults keep the hint correct for the default config before that first
+// call. switchHintEnabled is false when the switch key is unbound or collides
+// with detach (the attach loop drops it in those cases), so the hint then omits
+// the switch segment.
+var (
+	statusHintMu      sync.RWMutex
+	detachHintLabel   = "ctrl+q"
+	switchHintLabel   = "ctrl+s"
+	switchHintEnabled = true
+)
+
+// SetStatusHints updates the detach/switch key labels shown in the tmux
+// status-right bar. Empty labels are ignored (the existing value is kept).
+func SetStatusHints(detach, switchKey string, switchEnabled bool) {
+	statusHintMu.Lock()
+	defer statusHintMu.Unlock()
+	if detach != "" {
+		detachHintLabel = detach
+	}
+	if switchKey != "" {
+		switchHintLabel = switchKey
+	}
+	switchHintEnabled = switchEnabled
+}
+
 func (s *Session) themedStatusRight(themeStyle tmuxThemeStyle) string {
-	return fmt.Sprintf("#[fg=%s]ctrl+q detach#[default] · #[fg=%s]ctrl+s switch#[default] │ 📁 %s | %s ", themeStyle.hintColor, themeStyle.hintColor, s.DisplayName, s.projectDisplayName())
+	statusHintMu.RLock()
+	detach, switchKey, switchOn := detachHintLabel, switchHintLabel, switchHintEnabled
+	statusHintMu.RUnlock()
+
+	hints := fmt.Sprintf("#[fg=%s]%s detach#[default]", themeStyle.hintColor, detach)
+	if switchOn {
+		hints += fmt.Sprintf(" · #[fg=%s]%s switch#[default]", themeStyle.hintColor, switchKey)
+	}
+	return fmt.Sprintf("%s │ 📁 %s | %s ", hints, s.DisplayName, s.projectDisplayName())
 }
 
 func (s *Session) projectDisplayName() string {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -679,6 +679,23 @@ func (h *Home) setHotkeys(bindings map[string]string) {
 	if h.helpOverlay != nil {
 		h.helpOverlay.SetHotkeys(bindings)
 	}
+	h.syncStatusHints(bindings)
+}
+
+// syncStatusHints pushes the resolved detach/switch key labels into the tmux
+// package so the attached status bar reflects the user's [hotkeys] config
+// instead of the hardcoded "ctrl+q"/"ctrl+s". The switch hint mirrors
+// attachOptions: it is suppressed when the switch key has no portable control
+// byte or collides with detach, since the attach loop drops it in those cases.
+func (h *Home) syncStatusHints(bindings map[string]string) {
+	detachByte := DetachByteFromBinding(actionHotkey(bindings, hotkeyDetach))
+	switchByte := ctrlByteFromBinding(actionHotkey(bindings, hotkeySwitchSession))
+	switchEnabled := switchByte != 0 && switchByte != detachByte
+	tmux.SetStatusHints(
+		strings.ToLower(DetachByteLabel(detachByte)),
+		strings.ToLower(DetachByteLabel(switchByte)),
+		switchEnabled,
+	)
 }
 
 // openInNewWindow dispatches the Shift+Enter new-window launch through an
@@ -11204,9 +11221,31 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 		// The user pressed the session-switch key while attached: surface the
 		// in-attach switcher instead of just returning to the list.
 		if res.intent != tmux.SwitchNone {
+			// While attached the user may have switched the tmux client to
+			// another session via the notification bar (Ctrl+b 1-6), recorded
+			// in lastNotifSwitchID. Open the switcher on the session actually in
+			// view — not the one we first attached to — so the pre-highlight,
+			// Esc-reattach, and follow-CWD all target the right session.
+			fromID, fromWorkDir := inst.ID, currentWorkDir
+			h.lastNotifSwitchMu.Lock()
+			switchedID := h.lastNotifSwitchID
+			h.lastNotifSwitchMu.Unlock()
+			if switchedID != "" && switchedID != inst.ID {
+				h.instancesMu.RLock()
+				switched := h.instanceByID[switchedID]
+				h.instancesMu.RUnlock()
+				if switched != nil {
+					fromID = switched.ID
+					if ts := switched.GetTmuxSession(); ts != nil {
+						if wd := strings.TrimSpace(ts.GetWorkDir()); wd != "" {
+							fromWorkDir = wd
+						}
+					}
+				}
+			}
 			return openSwitcherMsg{
-				fromSessionID:   inst.ID,
-				attachedWorkDir: currentWorkDir,
+				fromSessionID:   fromID,
+				attachedWorkDir: fromWorkDir,
 			}
 		}
 
@@ -11681,6 +11720,12 @@ func (h *Home) updateSizes() {
 	h.groupDialog.SetSize(h.width, h.height)
 	h.confirmDialog.SetSize(h.width, h.height)
 	h.geminiModelDialog.SetSize(h.width, h.height)
+	if h.sessionSwitcher != nil {
+		// The switcher is a centered full-screen overlay; keep it sized so a
+		// resize while it is open (notably from the overview, where it can stay
+		// up) re-centers it instead of leaving it on stale dimensions.
+		h.sessionSwitcher.SetSize(h.width, h.height)
+	}
 	h.worktreeFinishDialog.SetSize(h.width, h.height)
 	if h.feedbackDialog != nil {
 		h.feedbackDialog.SetSize(h.width, h.height)
@@ -16812,6 +16857,11 @@ func (h *Home) handleSessionPickerDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 // only once the user cycles (Ctrl+S/Ctrl+A) at least once inside the picker
 // (see handleSessionSwitcherKey). When fewer than two switchable sessions exist
 // the picker stays closed.
+//
+// Local-only by design: this feeds local h.instances and re-attaches via the
+// local tmux attach loop. Remote (ItemTypeRemoteSession) rows are intentionally
+// excluded for now — see SessionSwitcher.Show and
+// TestSessionSwitcher_RemoteSessionsUnsupported.
 func (h *Home) openSessionSwitcher(fromID string, reattachOnCancel bool) {
 	h.instancesMu.RLock()
 	instances := make([]*session.Instance, len(h.instances))

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -11227,8 +11227,13 @@ func (h *Home) attachSession(inst *session.Instance) tea.Cmd {
 			// view — not the one we first attached to — so the pre-highlight,
 			// Esc-reattach, and follow-CWD all target the right session.
 			fromID, fromWorkDir := inst.ID, currentWorkDir
+			// Consume the value: clear it so a switcher exit that bypasses the
+			// statusUpdateMsg path (e.g. Ctrl+Q out of the switcher) can't leave
+			// a stale ID to pre-highlight the wrong session on a later attach.
+			// The commit/Esc-reattach paths re-set it via attachToSwitchTarget.
 			h.lastNotifSwitchMu.Lock()
 			switchedID := h.lastNotifSwitchID
+			h.lastNotifSwitchID = ""
 			h.lastNotifSwitchMu.Unlock()
 			if switchedID != "" && switchedID != inst.ID {
 				h.instancesMu.RLock()

--- a/internal/ui/session_switcher.go
+++ b/internal/ui/session_switcher.go
@@ -83,6 +83,13 @@ func NewSessionSwitcher() *SessionSwitcher { return &SessionSwitcher{} }
 // the overview shows next to an entry); a nil map renders no subtitles. It
 // returns false (and stays hidden) when fewer than two sessions are available —
 // there is nothing to switch between, so the caller falls back to a normal detach.
+//
+// Scope: the switcher is local-only by design — it takes local
+// *session.Instance rows and re-attaches via the local tmux attach loop. Remote
+// (SSH) sessions reach a session over a different attach path, so they are
+// intentionally excluded from the picker for now (see
+// TestSessionSwitcher_RemoteSessionsUnsupported); supporting them needs a remote
+// re-attach path and is tracked as a follow-up.
 func (s *SessionSwitcher) Show(fromID string, allInstances []*session.Instance, subtitles map[string]string) bool {
 	list := make([]*session.Instance, 0, len(allInstances))
 	for _, inst := range allInstances {
@@ -97,6 +104,10 @@ func (s *SessionSwitcher) Show(fromID string, allInstances []*session.Instance, 
 		list = append(list, inst)
 	}
 	if len(list) < 2 {
+		// Nothing to switch between. Clear any prior selection so a switcher that
+		// was already open (e.g. live-session count just dropped below two) does
+		// not linger on stale state — Show's contract is "stays hidden" here.
+		s.Hide()
 		return false
 	}
 
@@ -229,8 +240,17 @@ func (s *SessionSwitcher) View() string {
 	}
 
 	lines = append(lines, "")
+	// The forward/back cycle keys are fixed (the attach loop and
+	// handleSessionSwitcherKey both match Ctrl+S / Ctrl+A regardless of the
+	// configurable open binding), so the labels stay literal. Esc, however,
+	// re-attaches to the origin only when the picker was opened while attached;
+	// from the overview it just closes, so the hint reflects that.
+	escHint := "Esc close"
+	if s.reattachOnCancel {
+		escHint = "Esc back"
+	}
 	lines = append(lines, footerStyle.Render("Ctrl+S next · Ctrl+A prev"))
-	lines = append(lines, footerStyle.Render("↑/↓ browse · Enter attach · Esc back"))
+	lines = append(lines, footerStyle.Render("↑/↓ browse · Enter attach · "+escHint))
 
 	content := strings.Join(lines, "\n")
 

--- a/internal/ui/session_switcher_test.go
+++ b/internal/ui/session_switcher_test.go
@@ -242,3 +242,68 @@ func TestSessionSwitcher_ViewRendersTitlesAndFooter(t *testing.T) {
 		t.Error("view should render the session's conversation subtitle")
 	}
 }
+
+// TestSessionSwitcher_FooterEscReflectsContext pins the Esc hint: it says
+// "Esc back" only when the picker was opened while attached (Esc re-attaches),
+// and "Esc close" when opened from the overview (Esc just closes).
+func TestSessionSwitcher_FooterEscReflectsContext(t *testing.T) {
+	InitTheme("dark")
+	sw := NewSessionSwitcher()
+	sw.SetSize(80, 24)
+
+	sw.Show("a", mruThree(), nil) // reattachOnCancel defaults to false (overview)
+	if v := sw.View(); !strings.Contains(v, "Esc close") || strings.Contains(v, "Esc back") {
+		t.Errorf("overview-opened footer should say 'Esc close', got:\n%s", v)
+	}
+
+	sw.reattachOnCancel = true // opened while attached
+	if v := sw.View(); !strings.Contains(v, "Esc back") {
+		t.Errorf("attached-opened footer should say 'Esc back', got:\n%s", v)
+	}
+}
+
+// TestSessionSwitcher_RemoteSessionsUnsupported documents a deliberate scope
+// decision flagged by the Remote_parity check: the in-attach switcher operates
+// on local *session.Instance rows and re-attaches via the local tmux attach
+// loop only. Remote (SSH) sessions use a separate attach path, so they are
+// intentionally excluded from the picker for now — mirroring them would require
+// a remote re-attach path that is out of scope for this feature. Tracked as a
+// follow-up. See SessionSwitcher.Show / Home.openSessionSwitcher.
+func TestSessionSwitcher_RemoteSessionsUnsupported(t *testing.T) {
+	t.Skip("by design: the session switcher is local-only; remote (SSH) sessions use a separate attach path — follow-up tracked")
+}
+
+// TestCtrlS_NewDialogOpen_DoesNotOpenSwitcher guards the binding collision the
+// maintainer flagged: as of v1.9.57 the new-session dialog uses Ctrl+S as its
+// submit key, so the overview Ctrl+S switcher must never fire while that dialog
+// is open. The protection is the modal-dispatch order in Update (newDialog is
+// checked before handleMainKey, where the overview Ctrl+S lives); this pins
+// that contract end-to-end through Update.
+func TestCtrlS_NewDialogOpen_DoesNotOpenSwitcher(t *testing.T) {
+	h := &Home{
+		setupWizard:     NewSetupWizard(),
+		watcherPanel:    NewWatcherPanel(),
+		settingsPanel:   NewSettingsPanel(),
+		helpOverlay:     NewHelpOverlay(),
+		search:          NewSearch(),
+		globalSearch:    NewGlobalSearch(),
+		newDialog:       NewNewDialog(),
+		sessionSwitcher: NewSessionSwitcher(),
+	}
+	// Two live sessions, so the switcher *could* open if routing were wrong.
+	h.instances = []*session.Instance{
+		{ID: "a", Status: session.StatusRunning, LastAccessedAt: time.Unix(1000, 0)},
+		{ID: "b", Status: session.StatusRunning, LastAccessedAt: time.Unix(900, 0)},
+	}
+	h.instanceByID = map[string]*session.Instance{"a": h.instances[0], "b": h.instances[1]}
+	h.newDialog.Show() // the new-session dialog is now the active modal
+
+	if _, _ = h.Update(tea.KeyMsg{Type: tea.KeyCtrlS}); h.sessionSwitcher.IsVisible() {
+		t.Fatal("Ctrl+S while the new-session dialog is open must NOT open the session switcher (dialog submit takes precedence)")
+	}
+	// The dialog stays open: an empty-name submit is a validation no-op, proving
+	// Ctrl+S was routed to the dialog rather than the switcher.
+	if !h.newDialog.IsVisible() {
+		t.Fatal("the new-session dialog should remain open after an empty-name Ctrl+S submit")
+	}
+}


### PR DESCRIPTION
Follow-up to #1411, which merged (and shipped in v1.9.58) before the preliminary review fixes landed. This applies them on top of `main`.

## Changes

- **`pty.go`** — restore SIGINT on all attach early-return paths via a single `defer`, so a raw-mode setup failure can't leave the process permanently ignoring Ctrl+C.
- **`session_switcher.go`** — clear picker state when fewer than two sessions remain (`Show` no longer leaves a stale overlay visible); footer Esc hint is now context-sensitive ("Esc back" while attached vs "Esc close" from the overview).
- **`tmux.go` + `home.go`** — the attached status-bar hint follows the resolved `[hotkeys]` bindings (both detach and switch) instead of hardcoding `ctrl+q`/`ctrl+s`, and omits the switch segment when it's unbound or collides with detach.
- **`home.go`** — resize the switcher on `WindowSizeMsg`; open the in-attach switcher on the session actually in view (`lastNotifSwitchID`) rather than the original attach target, fixing pre-highlight / Esc-reattach / follow-CWD when the user switched via the notification bar mid-attach.
- **`userconfig.go`** — fix the `switch_session` example comment (Ctrl+A to go back, not Shift+Tab).
- Document that the switcher is **local-only** (remote/SSH sessions use a separate attach path) in code, docs, and a `t.Skip` test for the `Remote_parity` check.
- Tests: add the `Ctrl+S` / new-session-dialog collision guard and the context-sensitive footer test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status bar hotkey hints now update dynamically when hotkeys are reconfigured
  * Session switcher highlights the currently viewed session after switching clients

* **Bug Fixes**
  * Restored SIGINT handling during session attachment
  * Session switcher clears stale state when too few sessions remain
  * Prevented modal interruption by Ctrl+S while a dialog is open
  * Updated session navigation hotkey instruction to reference Ctrl+A

* **Tests**
  * Added tests covering switcher footer hints, exclusion of remote sessions, and Ctrl+S behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->