### PR TITLE
feat(conductor): inject AGENTDECK_PROFILE into spawned session env (fixes #1428)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -989,6 +989,24 @@ func sessionProfileEnvValue() string {
 	return GetEffectiveProfile("")
 }
 
+// ensureProfileEnv sets AGENTDECK_PROFILE host-side on the instance's tmux
+// session so a bare `agent-deck` command run inside the session resolves the
+// session's own profile rather than falling back to "default". It is the
+// tool-agnostic safety net complementing the inline command-prefix injection in
+// the spawn-command builders (which only some tools carry — e.g. gemini/opencode/
+// generic respawn rebuild a bare resume command with no AGENTDECK_PROFILE prefix).
+// Must run on every spawn/respawn success path, including the Restart()
+// respawn-pane branches that return early before reaching the fallback recreate
+// path. Best-effort: a failure is logged, not fatal.
+func (i *Instance) ensureProfileEnv() {
+	if i.tmuxSession == nil {
+		return
+	}
+	if err := i.tmuxSession.SetEnvironment("AGENTDECK_PROFILE", sessionProfileEnvValue()); err != nil {
+		sessionLog.Warn("set_profile_failed", slog.String("error", err.Error()))
+	}
+}
+
 // logClaudeConfigResolution emits the CFG-07 observability line documenting
 // which priority level resolved CLAUDE_CONFIG_DIR for this session.
 // Owns the single CFG-07 slog message literal for this package.
@@ -3048,9 +3066,7 @@ func (i *Instance) Start() error {
 	// command run inside this session resolves the session's own profile rather
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
-	if err := i.tmuxSession.SetEnvironment("AGENTDECK_PROFILE", sessionProfileEnvValue()); err != nil {
-		sessionLog.Warn("set_profile_failed", slog.String("error", err.Error()))
-	}
+	i.ensureProfileEnv()
 
 	// Propagate tool session IDs into the tmux environment (host-side, works for both
 	// sandbox and non-sandbox sessions). This replaces the previous approach of embedding
@@ -3291,9 +3307,7 @@ func (i *Instance) StartWithMessage(message string) error {
 	// command run inside this session resolves the session's own profile rather
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
-	if err := i.tmuxSession.SetEnvironment("AGENTDECK_PROFILE", sessionProfileEnvValue()); err != nil {
-		sessionLog.Warn("set_profile_failed", slog.String("error", err.Error()))
-	}
+	i.ensureProfileEnv()
 
 	// Propagate tool session IDs into the tmux environment (host-side, works for both
 	// sandbox and non-sandbox sessions).
@@ -5701,6 +5715,10 @@ func (i *Instance) Restart() error {
 
 		mcpLog.Debug("respawn_pane_claude_succeeded")
 
+		// Re-assert AGENTDECK_PROFILE host-side: this respawn branch returns
+		// before the fallback recreate path that would otherwise set it.
+		i.ensureProfileEnv()
+
 		// Persist .sid sidecar so hook events after restart can be correlated
 		WriteHookSessionAnchor(i.ID, i.ClaudeSessionID)
 
@@ -5740,6 +5758,11 @@ func (i *Instance) Restart() error {
 		}
 
 		sessionLog.Info("restart_gemini_respawn_succeeded")
+
+		// Re-assert AGENTDECK_PROFILE host-side: gemini's rebuilt resume command
+		// carries no inline AGENTDECK_PROFILE prefix, and this branch returns
+		// before the fallback recreate path that would otherwise set it.
+		i.ensureProfileEnv()
 
 		// Persist .sid sidecar so hook events after restart can be correlated
 		WriteHookSessionAnchor(i.ID, i.GeminiSessionID)
@@ -5794,6 +5817,11 @@ func (i *Instance) Restart() error {
 		}
 
 		sessionLog.Info("restart_opencode_respawn_succeeded")
+
+		// Re-assert AGENTDECK_PROFILE host-side: opencode's rebuilt resume command
+		// carries no inline AGENTDECK_PROFILE prefix, and this branch returns
+		// before the fallback recreate path that would otherwise set it.
+		i.ensureProfileEnv()
 
 		// Persist .sid sidecar so hook events after restart can be correlated
 		if i.OpenCodeSessionID != "" {
@@ -5859,6 +5887,11 @@ func (i *Instance) Restart() error {
 
 		sessionLog.Info("restart_codex_respawn_succeeded")
 
+		// Re-assert AGENTDECK_PROFILE host-side as a belt-and-suspenders to the
+		// inline prefix buildCodexCommand already injects; this branch returns
+		// before the fallback recreate path that would otherwise set it.
+		i.ensureProfileEnv()
+
 		// Persist .sid sidecar so hook events after restart can be correlated
 		WriteHookSessionAnchor(i.ID, i.CodexSessionID)
 
@@ -5903,6 +5936,12 @@ func (i *Instance) Restart() error {
 		}
 
 		sessionLog.Info("restart_generic_respawn_succeeded", slog.String("tool", i.Tool))
+
+		// Re-assert AGENTDECK_PROFILE host-side: the generic resume command is a
+		// bare `<cmd> <resumeFlag> <sid>` with no inline AGENTDECK_PROFILE prefix,
+		// and this branch returns before the fallback recreate path.
+		i.ensureProfileEnv()
+
 		i.loadCustomPatternsFromConfig() // Reload custom patterns
 		i.Status = StatusWaiting
 		return nil
@@ -6011,9 +6050,7 @@ func (i *Instance) Restart() error {
 	// command run inside this session resolves the session's own profile rather
 	// than falling back to "default". Covers shells/OpenCode/etc. that have no
 	// inline env-prefix injection of their own.
-	if err := i.tmuxSession.SetEnvironment("AGENTDECK_PROFILE", sessionProfileEnvValue()); err != nil {
-		sessionLog.Warn("set_profile_failed", slog.String("error", err.Error()))
-	}
+	i.ensureProfileEnv()
 
 	// Propagate all known tool session IDs to the tmux environment (host-side).
 	// This covers Restart() which uses buildClaudeResumeCommand() and similar

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -813,8 +813,10 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 	}
 
 	// AGENTDECK_INSTANCE_ID is set as an inline env var so Claude's hook subprocesses
-	// can identify which agent-deck session they belong to.
-	instanceIDPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s ", i.ID)
+	// can identify which agent-deck session they belong to. AGENTDECK_PROFILE is
+	// injected alongside it so an in-session `agent-deck` command resolves this
+	// session's own profile instead of falling back to "default".
+	instanceIDPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s ", i.ID, shellescape.Quote(sessionProfileEnvValue()))
 	configDirPrefix = instanceIDPrefix + configDirPrefix
 
 	// Get options - either from instance or create defaults from config
@@ -938,7 +940,7 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 // and buildClaudeResumeCommand. See the comment there (issue #949) for
 // why the gate is required.
 func (i *Instance) buildBashExportPrefix() string {
-	prefix := fmt.Sprintf("export AGENTDECK_INSTANCE_ID=%s; ", i.ID)
+	prefix := fmt.Sprintf("export AGENTDECK_INSTANCE_ID=%s; export AGENTDECK_PROFILE=%s; ", i.ID, shellescape.Quote(sessionProfileEnvValue()))
 	if IsClaudeConfigDirExplicitForInstance(i) {
 		// Issue #922 (reporter @bautrey): see applyWorkerScratchOverride.
 		configDir := i.applyWorkerScratchOverride(GetClaudeConfigDirForInstance(i))
@@ -969,6 +971,22 @@ func (i *Instance) buildResolvedAccountHintExports() string {
 		shellescape.Quote(i.GroupPath),
 		shellescape.Quote(source),
 	)
+}
+
+// sessionProfileEnvValue returns the effective profile name to inject as
+// AGENTDECK_PROFILE into a spawned session's environment, alongside
+// AGENTDECK_INSTANCE_ID. Without it, a bare `agent-deck` command run *inside* a
+// non-default-profile session has no AGENTDECK_PROFILE in its shell, so
+// GetEffectiveProfile falls through to "default" — resolving the wrong profile
+// and silently orphaning auto-parent routing (resolveAutoParentInstance looks
+// up the caller's instance against the wrong profile's session list). The deck
+// process is single-profile (one Storage, one state.db), so GetEffectiveProfile("")
+// is authoritative here and matches storage.Profile() for every session it
+// manages. We inject it explicitly at each spawn site (rather than relying on
+// shell inheritance) so a child spawned from a child carries its own profile and
+// not a stale inherited one.
+func sessionProfileEnvValue() string {
+	return GetEffectiveProfile("")
 }
 
 // logClaudeConfigResolution emits the CFG-07 observability line documenting
@@ -1343,8 +1361,8 @@ func (i *Instance) buildCodexCommand(baseCommand string) string {
 	// injected BEFORE the custom-command passthrough early-return below.
 	// Dropping it on custom-command sessions was the design regression flagged
 	// on #951 review — keep AGENTDECK_* on every codex-flavoured launch.
-	agentdeckEnvPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_TITLE=%q AGENTDECK_TOOL=%s ",
-		i.ID, i.Title, i.Tool)
+	agentdeckEnvPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_TITLE=%q AGENTDECK_TOOL=%s AGENTDECK_PROFILE=%s ",
+		i.ID, i.Title, i.Tool, shellescape.Quote(sessionProfileEnvValue()))
 	envPrefix += agentdeckEnvPrefix
 
 	// Passthrough: if the tool is literally "codex" and user gave a custom command
@@ -1425,11 +1443,13 @@ func (i *Instance) buildPiCommand(baseCommand string) string {
 
 	sessionDir := piAgentDeckSessionDirExpr(i.ID)
 	quotedInstanceID := shellescape.Quote(i.ID)
+	quotedProfile := shellescape.Quote(sessionProfileEnvValue())
 
 	return envPrefix + fmt.Sprintf(
-		"session_dir=%s; mkdir -p \"$session_dir\" && AGENTDECK_INSTANCE_ID=%s %s --continue --session-dir \"$session_dir\"",
+		"session_dir=%s; mkdir -p \"$session_dir\" && AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s %s --continue --session-dir \"$session_dir\"",
 		sessionDir,
 		quotedInstanceID,
+		quotedProfile,
 		cmd,
 	)
 }
@@ -1451,12 +1471,14 @@ func (i *Instance) buildPiForkCommandForTarget(target *Instance, baseCommand str
 	parentSessionDir := piAgentDeckSessionDirExpr(i.ID)
 	sessionDir := piAgentDeckSessionDirExpr(target.ID)
 	quotedInstanceID := shellescape.Quote(target.ID)
+	quotedProfile := shellescape.Quote(sessionProfileEnvValue())
 
 	return envPrefix + fmt.Sprintf(
-		"parent_session_dir=%s; session_dir=%s; mkdir -p \"$session_dir\" && source_file=$(find \"$parent_session_dir\" -type f -name '*.jsonl' -exec ls -t {} + 2>/dev/null | head -n 1); if [ -z \"$source_file\" ]; then echo \"No Pi session file found in $parent_session_dir\" >&2; exit 1; fi; AGENTDECK_INSTANCE_ID=%s %s --fork \"$source_file\" --session-dir \"$session_dir\"",
+		"parent_session_dir=%s; session_dir=%s; mkdir -p \"$session_dir\" && source_file=$(find \"$parent_session_dir\" -type f -name '*.jsonl' -exec ls -t {} + 2>/dev/null | head -n 1); if [ -z \"$source_file\" ]; then echo \"No Pi session file found in $parent_session_dir\" >&2; exit 1; fi; AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s %s --fork \"$source_file\" --session-dir \"$session_dir\"",
 		parentSessionDir,
 		sessionDir,
 		quotedInstanceID,
+		quotedProfile,
 		cmd,
 	), nil
 }
@@ -3022,6 +3044,14 @@ func (i *Instance) Start() error {
 		sessionLog.Warn("set_instance_id_failed", slog.String("error", err.Error()))
 	}
 
+	// Set AGENTDECK_PROFILE (host-side, tool-agnostic) so a bare `agent-deck`
+	// command run inside this session resolves the session's own profile rather
+	// than falling back to "default". Covers shells/OpenCode/etc. that have no
+	// inline env-prefix injection of their own.
+	if err := i.tmuxSession.SetEnvironment("AGENTDECK_PROFILE", sessionProfileEnvValue()); err != nil {
+		sessionLog.Warn("set_profile_failed", slog.String("error", err.Error()))
+	}
+
 	// Propagate tool session IDs into the tmux environment (host-side, works for both
 	// sandbox and non-sandbox sessions). This replaces the previous approach of embedding
 	// "tmux set-environment" calls in the shell command string, which silently failed
@@ -3255,6 +3285,14 @@ func (i *Instance) StartWithMessage(message string) error {
 	// This enables real-time status updates via Stop/SessionStart hooks
 	if err := i.tmuxSession.SetEnvironment("AGENTDECK_INSTANCE_ID", i.ID); err != nil {
 		sessionLog.Warn("set_instance_id_failed", slog.String("error", err.Error()))
+	}
+
+	// Set AGENTDECK_PROFILE (host-side, tool-agnostic) so a bare `agent-deck`
+	// command run inside this session resolves the session's own profile rather
+	// than falling back to "default". Covers shells/OpenCode/etc. that have no
+	// inline env-prefix injection of their own.
+	if err := i.tmuxSession.SetEnvironment("AGENTDECK_PROFILE", sessionProfileEnvValue()); err != nil {
+		sessionLog.Warn("set_profile_failed", slog.String("error", err.Error()))
 	}
 
 	// Propagate tool session IDs into the tmux environment (host-side, works for both
@@ -5969,6 +6007,14 @@ func (i *Instance) Restart() error {
 		sessionLog.Warn("set_instance_id_failed", slog.String("error", err.Error()))
 	}
 
+	// Set AGENTDECK_PROFILE (host-side, tool-agnostic) so a bare `agent-deck`
+	// command run inside this session resolves the session's own profile rather
+	// than falling back to "default". Covers shells/OpenCode/etc. that have no
+	// inline env-prefix injection of their own.
+	if err := i.tmuxSession.SetEnvironment("AGENTDECK_PROFILE", sessionProfileEnvValue()); err != nil {
+		sessionLog.Warn("set_profile_failed", slog.String("error", err.Error()))
+	}
+
 	// Propagate all known tool session IDs to the tmux environment (host-side).
 	// This covers Restart() which uses buildClaudeResumeCommand() and similar
 	// builders that no longer embed "tmux set-environment" in the shell string.
@@ -6056,8 +6102,10 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	}
 
 	// AGENTDECK_INSTANCE_ID is set as an inline env var so hook subprocesses
-	// can identify which agent-deck session they belong to.
-	instanceIDPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s ", i.ID)
+	// can identify which agent-deck session they belong to. AGENTDECK_PROFILE is
+	// injected alongside it so an in-session `agent-deck` command resolves this
+	// session's own profile instead of falling back to "default".
+	instanceIDPrefix := fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_PROFILE=%s ", i.ID, shellescape.Quote(sessionProfileEnvValue()))
 	configDirPrefix = instanceIDPrefix + configDirPrefix
 
 	// Get per-session permission settings (falls back to config if not persisted)
@@ -6758,8 +6806,8 @@ func (i *Instance) buildCodexForkCommandForTarget(target *Instance, baseCommand 
 	// Shell-quote the injected env values: target.Title is user-editable and could
 	// contain shell metacharacters (e.g. $(...) or backticks), and custom Codex-tool
 	// identities are config-defined — keep the generated fork command injection-safe.
-	envPrefix += fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_TITLE=%s AGENTDECK_TOOL=%s ",
-		shellescape.Quote(target.ID), shellescape.Quote(target.Title), shellescape.Quote(target.Tool))
+	envPrefix += fmt.Sprintf("AGENTDECK_INSTANCE_ID=%s AGENTDECK_TITLE=%s AGENTDECK_TOOL=%s AGENTDECK_PROFILE=%s ",
+		shellescape.Quote(target.ID), shellescape.Quote(target.Title), shellescape.Quote(target.Tool), shellescape.Quote(sessionProfileEnvValue()))
 	yoloFlag := target.resolveCodexYoloFlag()
 	modelFlag := target.resolveCodexModelFlag()
 	command := target.resolveCodexCommand(baseCommand)

--- a/internal/session/profile_env_injection_test.go
+++ b/internal/session/profile_env_injection_test.go
@@ -1,0 +1,93 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// Profile env injection (AGENTDECK_PROFILE) at spawn time.
+//
+// agent-deck injects AGENTDECK_INSTANCE_ID into every spawned session so hook
+// subprocesses can find their session. These tests pin the sibling injection of
+// AGENTDECK_PROFILE: without it, a bare `agent-deck` command run *inside* a
+// non-default-profile session has no AGENTDECK_PROFILE in its shell, so
+// GetEffectiveProfile falls back to "default" — resolving the wrong profile and
+// silently orphaning auto-parent routing. The value injected must be the
+// session's OWN resolved profile, set explicitly as a command-prefix assignment
+// so it overrides (not inherits) any stale parent value at exec.
+
+// withProfileEnv pins AGENTDECK_PROFILE so GetEffectiveProfile("") resolves
+// deterministically to profile (priority #2, ahead of CLAUDE_CONFIG_DIR/config).
+// t.Setenv restores the previous value at test end.
+func withProfileEnv(t *testing.T, profile string) {
+	t.Helper()
+	t.Setenv("AGENTDECK_PROFILE", profile)
+}
+
+func TestBuildClaudeCommand_ExportsProfile(t *testing.T) {
+	withProfileEnv(t, "work")
+
+	inst := NewInstanceWithTool("test", "/tmp/test", "claude")
+	cmd := inst.buildClaudeCommand("claude")
+
+	if !strings.Contains(cmd, "AGENTDECK_PROFILE=work") {
+		t.Errorf("claude command should inject AGENTDECK_PROFILE=work, got: %s", cmd)
+	}
+}
+
+func TestBuildClaudeResumeCommand_ExportsProfile(t *testing.T) {
+	withProfileEnv(t, "work")
+
+	inst := NewInstanceWithTool("test", "/tmp/test", "claude")
+	inst.ClaudeSessionID = "abc-123-def"
+	cmd := inst.buildClaudeResumeCommand()
+
+	if !strings.Contains(cmd, "AGENTDECK_PROFILE=work") {
+		t.Errorf("claude resume command should inject AGENTDECK_PROFILE=work, got: %s", cmd)
+	}
+}
+
+func TestBuildCodexCommand_ExportsProfile(t *testing.T) {
+	withProfileEnv(t, "work")
+
+	inst := NewInstanceWithTool("test", "/tmp/test", "codex")
+	cmd := inst.buildCodexCommand("codex")
+
+	if !strings.Contains(cmd, "AGENTDECK_PROFILE=work") {
+		t.Errorf("codex command should inject AGENTDECK_PROFILE=work, got: %s", cmd)
+	}
+}
+
+// TestBuildBashExportPrefix_ExportsProfile covers the custom-command / conductor
+// wrapper path, which exports the per-session vars via `export VAR=...;`.
+func TestBuildBashExportPrefix_ExportsProfile(t *testing.T) {
+	withProfileEnv(t, "work")
+
+	inst := NewInstanceWithTool("test", "/tmp/test", "claude")
+	prefix := inst.buildBashExportPrefix()
+
+	if !strings.Contains(prefix, "export AGENTDECK_PROFILE=work;") {
+		t.Errorf("bash export prefix should export AGENTDECK_PROFILE=work, got: %s", prefix)
+	}
+}
+
+// TestSpawnProfile_IsExplicitResolvedNotDefault verifies the injected value is
+// the session's RESOLVED profile placed as an explicit command-prefix
+// assignment (which overrides any inherited AGENTDECK_PROFILE at exec), not the
+// hardcoded "default" fallback. This is the non-inherit property: a child
+// spawned from a non-default-profile session carries that session's own profile.
+func TestSpawnProfile_IsExplicitResolvedNotDefault(t *testing.T) {
+	withProfileEnv(t, "personal")
+
+	inst := NewInstanceWithTool("test", "/tmp/test", "claude")
+	cmd := inst.buildClaudeCommand("claude")
+
+	// The resolved profile ("personal") is injected explicitly...
+	if !strings.Contains(cmd, "AGENTDECK_PROFILE=personal") {
+		t.Fatalf("expected explicit AGENTDECK_PROFILE=personal, got: %s", cmd)
+	}
+	// ...and the "default" fallback is NOT what gets injected.
+	if strings.Contains(cmd, "AGENTDECK_PROFILE=default") {
+		t.Errorf("must not inject the default fallback when a real profile resolves, got: %s", cmd)
+	}
+}

--- a/internal/session/profile_env_injection_test.go
+++ b/internal/session/profile_env_injection_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // Profile env injection (AGENTDECK_PROFILE) at spawn time.
@@ -68,6 +69,98 @@ func TestBuildBashExportPrefix_ExportsProfile(t *testing.T) {
 
 	if !strings.Contains(prefix, "export AGENTDECK_PROFILE=work;") {
 		t.Errorf("bash export prefix should export AGENTDECK_PROFILE=work, got: %s", prefix)
+	}
+}
+
+// --- Host-side (tool-agnostic) profile injection ---
+//
+// Some respawn-pane branches in Restart() rebuild a bare resume command that
+// carries NO inline AGENTDECK_PROFILE prefix (gemini, opencode, generic), and
+// every respawn branch returns before reaching the fallback recreate path that
+// sets it host-side. ensureProfileEnv() is the shared safety net those branches
+// (and the spawn paths) call so the tmux session always carries the var.
+
+// TestEnsureProfileEnv_SetsHostSideEnv pins that ensureProfileEnv writes
+// AGENTDECK_PROFILE into the live tmux session environment as the session's own
+// resolved profile. This is the exact call every Restart() respawn-pane branch
+// now makes, so it stands in for the tmux-dependent respawn paths (gemini/
+// opencode/codex/generic) that CI cannot launch (no tool binary).
+func TestEnsureProfileEnv_SetsHostSideEnv(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	isolateUserHomeForShellRestart(t)
+	withProfileEnv(t, "work")
+
+	title := uniqueShellTestTitle("EnsureProfileEnv")
+	inst := NewInstance(title, t.TempDir())
+	inst.Command = ""
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	t.Cleanup(func() { cleanupShellSessions(title) })
+
+	if !waitForTmuxSession(inst.tmuxSession.Name, 1*time.Second) {
+		t.Fatalf("tmux session %q never appeared after Start", inst.tmuxSession.Name)
+	}
+
+	// Clear it first so we prove ensureProfileEnv is what sets it (Start also
+	// sets it, but we want to isolate the helper the respawn branches call).
+	if err := inst.tmuxSession.SetEnvironment("AGENTDECK_PROFILE", "stale"); err != nil {
+		t.Fatalf("seed SetEnvironment failed: %v", err)
+	}
+
+	inst.ensureProfileEnv()
+
+	got, err := inst.tmuxSession.GetEnvironment("AGENTDECK_PROFILE")
+	if err != nil {
+		t.Fatalf("GetEnvironment(AGENTDECK_PROFILE) failed: %v", err)
+	}
+	if got != "work" {
+		t.Errorf("AGENTDECK_PROFILE in tmux env = %q, want %q", got, "work")
+	}
+}
+
+// TestEnsureProfileEnv_NilTmuxSession_NoPanic pins the nil guard: a respawn
+// branch must never panic if the instance has no tmux session.
+func TestEnsureProfileEnv_NilTmuxSession_NoPanic(t *testing.T) {
+	inst := NewInstanceWithTool("test", "/tmp/test", "claude")
+	inst.tmuxSession = nil
+	inst.ensureProfileEnv() // must not panic
+}
+
+// TestRestart_ShellSession_CarriesProfileEnv is the end-to-end contract: after
+// Restart(), the session's tmux environment carries AGENTDECK_PROFILE set to the
+// session's own resolved profile. Shell sessions take the fallback recreate path
+// (no resume support), but this proves ensureProfileEnv is wired through Restart.
+func TestRestart_ShellSession_CarriesProfileEnv(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	isolateUserHomeForShellRestart(t)
+	withProfileEnv(t, "personal")
+
+	title := uniqueShellTestTitle("RestartProfileEnv")
+	inst := NewInstance(title, t.TempDir())
+	inst.Command = ""
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	t.Cleanup(func() { cleanupShellSessions(title) })
+
+	if !waitForTmuxSession(inst.tmuxSession.Name, 1*time.Second) {
+		t.Fatalf("tmux session %q never appeared after Start", inst.tmuxSession.Name)
+	}
+
+	if err := inst.Restart(); err != nil {
+		t.Fatalf("Restart returned error: %v", err)
+	}
+	if !waitForTmuxSession(inst.tmuxSession.Name, 1*time.Second) {
+		t.Fatalf("tmux session %q does not exist after Restart", inst.tmuxSession.Name)
+	}
+
+	got, err := inst.tmuxSession.GetEnvironment("AGENTDECK_PROFILE")
+	if err != nil {
+		t.Fatalf("GetEnvironment(AGENTDECK_PROFILE) after Restart failed: %v", err)
+	}
+	if got != "personal" {
+		t.Errorf("after Restart, AGENTDECK_PROFILE = %q, want %q", got, "personal")
 	}
 }
 


### PR DESCRIPTION
Fixes #1428.

## Motivation

agent-deck injects `AGENTDECK_INSTANCE_ID` into every spawned session's environment (so an in-session `agent-deck` command knows which session it belongs to) but never injected `AGENTDECK_PROFILE`.

`session.GetEffectiveProfile` precedence is `AGENTDECK_PROFILE` → `CLAUDE_CONFIG_DIR` → config `default_profile` → `"default"`. Because a spawned session's shell carries no `AGENTDECK_PROFILE`, a bare `agent-deck` command run *from inside* a non-default-profile session resolves to the wrong profile (`default`). Downstream, auto-parent (`resolveAutoParentInstance`) finds the caller via `AGENTDECK_INSTANCE_ID` but resolves it against the *resolved (wrong) profile's* instance list → silent orphan (dropped `[DONE]` routing). Both symptoms trace to this one missing env var.

## The change

Inject `AGENTDECK_PROFILE=<the session's own resolved profile>` alongside `AGENTDECK_INSTANCE_ID` at **every** spawn site, mirroring the existing idiom exactly:

- **Claude** start (`buildClaudeCommandWithMessage`) + resume (`buildClaudeResumeCommand`)
- **Codex** start (`buildCodexCommand`) + fork (`buildCodexForkCommandForTarget`)
- **Pi** continue (`buildPiCommand`) + fork (`buildPiForkCommandForTarget`)
- **custom-command / conductor wrapper** path (`buildBashExportPrefix`)
- **tool-agnostic host-side** tmux `SetEnvironment` in `Start` / `StartWithMessage` / `Restart`

The value comes from a small helper `sessionProfileEnvValue()` → `GetEffectiveProfile("")`. It is set **explicitly per-session** (command-prefix assignment for the shell paths; tmux `set-environment` host-side), never inherited — so a child spawned from a child carries its **own** profile, not a stale grandparent value. Shell-prefix values are `shellescape.Quote`-wrapped to match the file's existing injection-safety discipline.

## Implications (profile resolution is load-bearing — audited before implementing)

- **Coverage:** all 10 `AGENTDECK_INSTANCE_ID` write sites (all in `internal/session/instance.go`) now also set `AGENTDECK_PROFILE`; no spawn path sets the id without the profile.
- **`childenv`:** `childenv.ForLaunch` builds the launch environment for child processes (Claude workers, pooled MCP servers); it does **not** set the per-session `AGENTDECK_INSTANCE_ID`, so it is not one of the paired injection sites — and the deck process already exports `AGENTDECK_PROFILE` in its own environment, so anything it does launch resolves correctly. No gap.
- **`_test` sentinel** (`group_nav.go`): only suppresses a cosmetic one-time hint; a real profile name can't equal the reserved `_test` value.
- **`watcher/engine.go`:** moves from a lossy `"default"` fallback to the correct resolved profile — a fix, not a regression.
- **Account / `CLAUDE_CONFIG_DIR` (#924):** this chain *does* consult `AGENTDECK_PROFILE` via `GetEffectiveProfile`, but it is resolved **deck-side from the deck's own environment** (and `Instance.Account` is a separate, higher-priority dimension). The per-session value injected into a *child's* shell never feeds back into the deck's config-dir/account selection, so there's no precedence inversion.
- **Inheritance/override:** the explicit per-session set (command-prefix assignment / tmux `set-environment` replace) overrides any inherited `AGENTDECK_PROFILE`, so no grandparent leak. The deck process is single-profile (one `Storage`, one `state.db`) and every `Start`/`StartWithMessage`/`Restart` caller lives in that process, so `GetEffectiveProfile("")` is authoritative and equals `storage.Profile()` for every session it manages — the same idiom the spawn flow already trusts for codex-home resolution.

## Tests

New `internal/session/profile_env_injection_test.go` (mirrors the existing `*_ExportsInstanceID` tests): `TestBuildClaudeCommand_ExportsProfile`, `TestBuildClaudeResumeCommand_ExportsProfile`, `TestBuildCodexCommand_ExportsProfile`, `TestBuildBashExportPrefix_ExportsProfile`, and `TestSpawnProfile_IsExplicitResolvedNotDefault` (asserts the injected value is the resolved profile, not the `"default"` fallback — the non-inherit property).

`gofmt -l .` clean; `go build ./...` clean; `go vet ./internal/session/ ./cmd/agent-deck/` clean; the suites pass except the pre-existing env-sensitive `issue1349_rebind_guard_test.go` failures (unrelated — they resolve transcript paths against the real `$HOME`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly injects the active profile via `AGENTDECK_PROFILE` (alongside the existing instance id), ensuring spawned tool commands and tmux session commands reliably resolve the correct profile on start and restart.
* **Tests**
  * Adds coverage to verify `AGENTDECK_PROFILE` is included in generated command/prefix flows and persists in tmux after restart, including safe handling when tmux isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->