### PR TITLE
fix(security): boundary-aware, fail-closed transcript-path containment (fixes #1434)

### DIFF
--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -571,20 +571,14 @@ func writeCostEvent(instanceID string, rawPayload []byte) {
 		return
 	}
 
-	// Validate transcript path to prevent path traversal.
-	// Claude stores transcripts under ~/.claude/projects/{hash}/{session}.jsonl
-	cleanPath := filepath.Clean(stop.TranscriptPath)
-	if strings.Contains(cleanPath, "..") {
-		logCostDebug("rejected transcript_path with path traversal: %s", stop.TranscriptPath)
+	// Validate transcript path through the shared fail-closed, boundary-aware
+	// containment guard (same check the done-sentinel reader uses) so a crafted
+	// payload can't coax this reader into opening an arbitrary file. Claude
+	// stores transcripts under ~/.claude/projects/{hash}/{session}.jsonl.
+	cleanPath, ok := session.ValidateTranscriptPath(stop.TranscriptPath)
+	if !ok {
+		logCostDebug("rejected transcript_path outside ~/.claude or traversal: %s", stop.TranscriptPath)
 		return
-	}
-	home, homeErr := os.UserHomeDir()
-	if homeErr == nil {
-		claudeDir := filepath.Join(home, ".claude")
-		if !strings.HasPrefix(cleanPath, claudeDir) {
-			logCostDebug("rejected transcript_path outside ~/.claude: %s", stop.TranscriptPath)
-			return
-		}
 	}
 	logCostDebug("transcript_path: %s", cleanPath)
 

--- a/internal/session/transcript_done_scan.go
+++ b/internal/session/transcript_done_scan.go
@@ -38,6 +38,14 @@ const doneScanTailLines = 25
 // path must live under ~/.claude (where Claude Code keeps transcripts). Both
 // the hook handler (payload-supplied path) and the daemon (path re-read from
 // a hook status file) gate on this before opening the file.
+//
+// Containment is fail-closed and boundary-aware. A raw HasPrefix against
+// ~/.claude wrongly accepts sibling directories (e.g. ~/.claude-spoof/x.jsonl,
+// whose string prefix matches but which lives outside the transcript root), so
+// the path must equal the root exactly OR begin with root + path separator. If
+// the home directory cannot be resolved we cannot establish the containment
+// root, so we REJECT rather than fall through (a missing root must never
+// disable containment for a payload-supplied path).
 func ValidateTranscriptPath(path string) (string, bool) {
 	if strings.TrimSpace(path) == "" {
 		return "", false
@@ -46,10 +54,13 @@ func ValidateTranscriptPath(path string) (string, bool) {
 	if strings.Contains(cleanPath, "..") {
 		return "", false
 	}
-	if home, err := os.UserHomeDir(); err == nil {
-		if !strings.HasPrefix(cleanPath, filepath.Join(home, ".claude")) {
-			return "", false
-		}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	root := filepath.Join(home, ".claude")
+	if cleanPath != root && !strings.HasPrefix(cleanPath, root+string(os.PathSeparator)) {
+		return "", false
 	}
 	return cleanPath, true
 }

--- a/internal/session/transcript_done_scan_test.go
+++ b/internal/session/transcript_done_scan_test.go
@@ -238,6 +238,35 @@ func TestValidateTranscriptPath(t *testing.T) {
 	if _, ok := ValidateTranscriptPath(filepath.Join(home, "elsewhere", "t.jsonl")); ok {
 		t.Errorf("path outside ~/.claude must be rejected")
 	}
+
+	// Boundary bypass: a SIBLING directory whose name has ~/.claude as a string
+	// prefix (e.g. ~/.claude-spoof) lives OUTSIDE the transcript root and must
+	// be rejected. A raw HasPrefix(cleanPath, "$HOME/.claude") wrongly accepts
+	// it — this case fails against that logic and passes with the boundary-aware
+	// check.
+	for _, sibling := range []string{".claude-spoof", ".claude-backup", ".claudex"} {
+		spoof := filepath.Join(home, sibling, "transcript.jsonl")
+		if _, ok := ValidateTranscriptPath(spoof); ok {
+			t.Errorf("sibling-prefix path %q must be rejected", spoof)
+		}
+	}
+
+	// The transcript root itself is contained.
+	root := filepath.Join(home, ".claude")
+	if cleaned, ok := ValidateTranscriptPath(root); !ok || cleaned != root {
+		t.Errorf("transcript root %q must be accepted, got ok=%v cleaned=%q", root, ok, cleaned)
+	}
+
+	// Fail-closed: when the home directory cannot be resolved we cannot
+	// establish the containment root, so even a ~/.claude-shaped path is
+	// rejected rather than falling through to acceptance. On Unix os.UserHomeDir
+	// resolves HOME; clearing it makes resolution fail.
+	t.Run("home_unresolvable_fails_closed", func(t *testing.T) {
+		t.Setenv("HOME", "")
+		if _, ok := ValidateTranscriptPath(filepath.Join(home, ".claude", "projects", "p", "t.jsonl")); ok {
+			t.Errorf("path must be rejected when home dir cannot be resolved")
+		}
+	})
 }
 
 func TestTranscriptTailLines_BoundsAndOrder(t *testing.T) {


### PR DESCRIPTION
Fixes #1434.

Hardens the transcript-path containment used by the Stop hook's done-sentinel detection and the notify-daemon (follow-up to #1423/#1422).

## The change

- **`ValidateTranscriptPath` is now boundary-aware and fail-closed** (`internal/session/transcript_done_scan.go`):
  - Containment requires the cleaned path to equal the `~/.claude` root exactly, or begin with `root + os.PathSeparator` — so siblings like `~/.claude-spoof/x.jsonl` / `~/.claude-backup/...` are rejected (a raw `HasPrefix` accepted them).
  - If `os.UserHomeDir()` errors, the path is **rejected** rather than falling through to acceptance.
- **`writeCostEvent` now routes through `session.ValidateTranscriptPath`** (`cmd/agent-deck/hook_handler.go`) instead of its own inline `HasPrefix` guard, so both readers share the hardened check and there's no remaining weak path.

## Tests

`internal/session/transcript_done_scan_test.go` adds regression coverage: sibling prefixes (`.claude-spoof`, `.claude-backup`, `.claudex`) are rejected, the exact root and legitimate `~/.claude/projects/.../*.jsonl` paths are accepted, and the home-resolution-failure case fails closed.

`gofmt -l .` clean; `go build ./...` clean; `go test ./internal/session/ ./cmd/agent-deck/` pass; `go test -race ./internal/session/` clean (0 data races). The two pre-existing env-sensitive `issue1349_rebind_guard_test.go` failures are unrelated and present on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript path validation with stricter containment rules to prevent unauthorized file access.
  * Enhanced fail-closed behavior for invalid or inaccessible paths.

* **Tests**
  * Added comprehensive test coverage for transcript path validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->