### PR TITLE
fix(session): honor [claude].default_model at spawn+restart; guard --extra-arg footgun (closes #1431)

### DIFF
--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -83,6 +83,9 @@ func handleLaunch(profile string, args []string) {
 	// Persisted plaintext in state.db — do NOT pass secrets like API keys.
 	var extraArgFlags []string
 	fs.Func("extra-arg", "Extra claude CLI token (can specify multiple times); requires -c claude; persisted plaintext — no secrets", func(s string) error {
+		if err := session.ValidateClaudeExtraArgToken(s); err != nil {
+			return err
+		}
 		extraArgFlags = append(extraArgFlags, s)
 		return nil
 	})

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1195,6 +1195,9 @@ func handleAdd(profile string, args []string) {
 	// buildClaudeExtraFlags.
 	var extraArgFlags []string
 	fs.Func("extra-arg", "Extra claude CLI token (can specify multiple times); requires -c claude; persisted plaintext — no secrets", func(s string) error {
+		if err := session.ValidateClaudeExtraArgToken(s); err != nil {
+			return err
+		}
 		extraArgFlags = append(extraArgFlags, s)
 		return nil
 	})

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1047,6 +1047,25 @@ func (i *Instance) logClaudeConfigResolution() {
 	)
 }
 
+// ValidateClaudeExtraArgToken rejects a single --extra-arg token that looks
+// like a flag mashed together with its value (issue #1431b). Each --extra-arg
+// is shell-quoted as ONE argument, so `--extra-arg "--model opus"` reaches
+// claude as the literal single arg '--model opus' (embedded space) — an
+// unknown flag that makes claude exit on startup and leaves a dead pane the
+// registry still reports as running. A token that starts with '-' AND contains
+// whitespace is almost always two tokens the user meant to pass separately;
+// surfacing it as an error at spawn time beats the silent tmux death. Clean
+// flags ("--model") and clean values ("opus", "be concise") pass.
+func ValidateClaudeExtraArgToken(token string) error {
+	if strings.HasPrefix(token, "-") && strings.ContainsAny(token, " \t\n\r") {
+		return fmt.Errorf(
+			"--extra-arg %q looks like a flag and its value combined; pass them as separate --extra-arg tokens (e.g. --extra-arg \"--model\" --extra-arg \"opus\"), or use the first-class --model flag",
+			token,
+		)
+	}
+	return nil
+}
+
 // buildClaudeExtraFlags builds extra command-line flags string from ClaudeOptions
 // Also handles instance-level flags like --add-dir for subagent access
 func (i *Instance) buildClaudeExtraFlags(opts *ClaudeOptions) string {
@@ -1078,11 +1097,32 @@ func (i *Instance) buildClaudeExtraFlags(opts *ClaudeOptions) string {
 		}
 	}
 
+	// Launch model resolution (#1431). An explicit per-session opts.Model
+	// wins; otherwise fall back to [claude].default_model. The fallback is the
+	// load-bearing fix: a session that persisted ANY other Claude option
+	// (skip-permissions / chrome / teammate-mode) has a non-nil ClaudeOptions
+	// with an empty Model, which bypasses the NewClaudeOptions default_model
+	// fallback in the callers. Without resolving the default here, both spawn
+	// and restart dropped --model entirely and the child silently booted on
+	// Claude's built-in default (Fable, unavailable account-wide) while the
+	// registry still showed it running. Because every start/restart/resume
+	// command delegates flag assembly here, this single point keeps them all
+	// in lockstep.
+	launchModel := ""
+	if opts != nil {
+		launchModel = opts.Model
+	}
+	if launchModel == "" {
+		if cfg, _ := LoadUserConfig(); cfg != nil {
+			launchModel = cfg.Claude.DefaultModel
+		}
+	}
+	if launchModel != "" {
+		flags = append(flags, "--model "+shellescape.Quote(launchModel))
+	}
+
 	// Options-level flags
 	if opts != nil {
-		if opts.Model != "" {
-			flags = append(flags, "--model "+shellescape.Quote(opts.Model))
-		}
 		if opts.SkipPermissions {
 			flags = append(flags, "--dangerously-skip-permissions")
 		} else if opts.AutoMode {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1066,6 +1066,20 @@ func ValidateClaudeExtraArgToken(token string) error {
 	return nil
 }
 
+// extraArgsSupplyModel reports whether the persisted --extra-arg tokens already
+// carry a `--model` override. ValidateClaudeExtraArgToken forces flag and value
+// into separate tokens, so a user-supplied model appears as a bare "--model"
+// (or "--model=..." form) token. When present we must NOT also inject
+// [claude].default_model, or the launch command would carry two --model flags.
+func extraArgsSupplyModel(extraArgs []string) bool {
+	for _, tok := range extraArgs {
+		if tok == "--model" || strings.HasPrefix(tok, "--model=") {
+			return true
+		}
+	}
+	return false
+}
+
 // buildClaudeExtraFlags builds extra command-line flags string from ClaudeOptions
 // Also handles instance-level flags like --add-dir for subagent access
 func (i *Instance) buildClaudeExtraFlags(opts *ClaudeOptions) string {
@@ -1108,17 +1122,28 @@ func (i *Instance) buildClaudeExtraFlags(opts *ClaudeOptions) string {
 	// registry still showed it running. Because every start/restart/resume
 	// command delegates flag assembly here, this single point keeps them all
 	// in lockstep.
-	launchModel := ""
-	if opts != nil {
-		launchModel = opts.Model
-	}
-	if launchModel == "" {
-		if cfg, _ := LoadUserConfig(); cfg != nil {
-			launchModel = cfg.Claude.DefaultModel
+	// A user-supplied --model via --extra-arg (the form the
+	// ValidateClaudeExtraArgToken error message recommends) is an explicit
+	// override that must stand alone: the extra-arg tokens are appended verbatim
+	// below, so emitting any resolved --model here too would produce a duplicate
+	// --model on the command line. claude is last-wins so it would be harmless,
+	// but it is confusing and the operator's intent is unambiguous. Suppress the
+	// resolved model entirely (whether it came from opts.Model, the
+	// NewClaudeOptions default, or [claude].default_model) when extra-args carry
+	// their own.
+	if !extraArgsSupplyModel(i.ExtraArgs) {
+		launchModel := ""
+		if opts != nil {
+			launchModel = opts.Model
 		}
-	}
-	if launchModel != "" {
-		flags = append(flags, "--model "+shellescape.Quote(launchModel))
+		if launchModel == "" {
+			if cfg, _ := LoadUserConfig(); cfg != nil {
+				launchModel = cfg.Claude.DefaultModel
+			}
+		}
+		if launchModel != "" {
+			flags = append(flags, "--model "+shellescape.Quote(launchModel))
+		}
 	}
 
 	// Options-level flags

--- a/internal/session/issue1431_default_model_command_test.go
+++ b/internal/session/issue1431_default_model_command_test.go
@@ -1,0 +1,119 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #1431: conductors spawn children that silently run on Claude's
+// built-in default (Fable) instead of the configured [claude].default_model
+// (Opus). #1390 wired default_model into NewClaudeOptions, which is only
+// consulted when an Instance has *no* persisted ToolOptionsJSON. A session
+// that carries any other persisted Claude option (skip-permissions, chrome,
+// teammate-mode, etc.) but no explicit model has a NON-NIL ClaudeOptions with
+// Model=="", so GetClaudeOptions() short-circuits the NewClaudeOptions
+// fallback and the launch command omits --model entirely. The session boots
+// on Fable and silently no-ops account-wide.
+//
+// The contract these tests pin: when [claude].default_model is configured and
+// the session has no explicit per-session model, the built launch command
+// MUST carry `--model <default>` — regardless of whether ToolOptionsJSON is
+// nil or a non-nil options struct with an empty Model.
+
+// issue1431ConfigEnv points LoadUserConfig at a temp HOME holding a
+// config.toml with the given [claude].default_model, isolated from the host.
+func issue1431ConfigEnv(t *testing.T, defaultModel string) {
+	t.Helper()
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	origProfile := os.Getenv("AGENTDECK_PROFILE")
+	origClaudeDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+		if origProfile != "" {
+			_ = os.Setenv("AGENTDECK_PROFILE", origProfile)
+		} else {
+			_ = os.Unsetenv("AGENTDECK_PROFILE")
+		}
+		if origClaudeDir != "" {
+			_ = os.Setenv("CLAUDE_CONFIG_DIR", origClaudeDir)
+		} else {
+			_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+		}
+		ClearUserConfigCache()
+	})
+
+	_ = os.Setenv("HOME", tmpHome)
+	_ = os.Unsetenv("AGENTDECK_PROFILE")
+	_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+
+	agentDeckDir := filepath.Join(tmpHome, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configContent := "[claude]\ndefault_model = \"" + defaultModel + "\"\n"
+	if err := os.WriteFile(filepath.Join(agentDeckDir, "config.toml"), []byte(configContent), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	ClearUserConfigCache()
+}
+
+// Baseline: a fresh claude session with no persisted options must pick up
+// [claude].default_model at command-build time (the #1390 nil-fallback path).
+func TestIssue1431_DefaultModelApplied_NilOptions(t *testing.T) {
+	issue1431ConfigEnv(t, "claude-opus-4-8")
+
+	inst := NewInstanceWithTool("dm-nil", t.TempDir(), "claude")
+	if inst.GetClaudeOptions() != nil {
+		t.Fatalf("precondition: expected nil ClaudeOptions on a fresh instance")
+	}
+
+	cmd := inst.buildClaudeCommand("claude")
+	if !strings.Contains(cmd, "--model claude-opus-4-8") {
+		t.Fatalf("nil-options spawn dropped [claude].default_model; command missing --model claude-opus-4-8:\n%s", cmd)
+	}
+}
+
+// The #1431 gap: a session carrying a non-model Claude option (here
+// skip-permissions) has a non-nil ClaudeOptions with Model=="". The
+// NewClaudeOptions fallback is skipped, so without a final default_model
+// resolution the command omits --model and the child runs on Fable.
+func TestIssue1431_DefaultModelApplied_NonNilEmptyModelOptions(t *testing.T) {
+	issue1431ConfigEnv(t, "claude-opus-4-8")
+
+	inst := NewInstanceWithTool("dm-nonnil", t.TempDir(), "claude")
+	// Persist options WITHOUT a model — mimics any session that set another
+	// Claude option (skip-permissions/chrome/teammate-mode) at create time.
+	if err := inst.SetClaudeOptions(&ClaudeOptions{SessionMode: "new", SkipPermissions: true}); err != nil {
+		t.Fatalf("SetClaudeOptions: %v", err)
+	}
+	if opts := inst.GetClaudeOptions(); opts == nil || opts.Model != "" {
+		t.Fatalf("precondition: expected non-nil options with empty Model")
+	}
+
+	cmd := inst.buildClaudeCommand("claude")
+	if !strings.Contains(cmd, "--model claude-opus-4-8") {
+		t.Fatalf("non-nil/empty-model spawn dropped [claude].default_model; command missing --model claude-opus-4-8:\n%s", cmd)
+	}
+}
+
+// Guard: an explicit per-session model must win over [claude].default_model —
+// the default is a fallback, never an override.
+func TestIssue1431_ExplicitModelBeatsDefault(t *testing.T) {
+	issue1431ConfigEnv(t, "claude-opus-4-8")
+
+	inst := NewInstanceWithTool("dm-explicit", t.TempDir(), "claude")
+	if err := inst.SetClaudeOptions(&ClaudeOptions{SessionMode: "new", Model: "claude-haiku-4-5"}); err != nil {
+		t.Fatalf("SetClaudeOptions: %v", err)
+	}
+
+	cmd := inst.buildClaudeCommand("claude")
+	if !strings.Contains(cmd, "--model claude-haiku-4-5") {
+		t.Fatalf("explicit per-session model lost; command:\n%s", cmd)
+	}
+	if strings.Contains(cmd, "claude-opus-4-8") {
+		t.Fatalf("default_model wrongly overrode explicit per-session model:\n%s", cmd)
+	}
+}

--- a/internal/session/issue1431_default_model_command_test.go
+++ b/internal/session/issue1431_default_model_command_test.go
@@ -117,3 +117,23 @@ func TestIssue1431_ExplicitModelBeatsDefault(t *testing.T) {
 		t.Fatalf("default_model wrongly overrode explicit per-session model:\n%s", cmd)
 	}
 }
+
+// Guard: when the operator supplies --model through --extra-arg (the form the
+// ValidateClaudeExtraArgToken error message recommends), the default_model
+// fallback must NOT also inject a second --model. claude is last-wins so the
+// duplicate is harmless, but the command must carry exactly one --model and it
+// must be the user's, not the default.
+func TestIssue1431_ExtraArgModelSuppressesDefault(t *testing.T) {
+	issue1431ConfigEnv(t, "claude-opus-4-8")
+
+	inst := NewInstanceWithTool("dm-extraarg", t.TempDir(), "claude")
+	inst.ExtraArgs = []string{"--model", "claude-haiku-4-5"}
+
+	cmd := inst.buildClaudeCommand("claude")
+	if strings.Contains(cmd, "claude-opus-4-8") {
+		t.Fatalf("default_model injected alongside user --extra-arg --model:\n%s", cmd)
+	}
+	if strings.Count(cmd, "--model") != 1 {
+		t.Fatalf("expected exactly one --model, got %d:\n%s", strings.Count(cmd, "--model"), cmd)
+	}
+}

--- a/internal/session/issue1431_extraarg_guard_test.go
+++ b/internal/session/issue1431_extraarg_guard_test.go
@@ -1,0 +1,44 @@
+package session
+
+import "testing"
+
+// Issue #1431(b): `agent-deck launch --extra-arg "--model opus"` silently
+// broke tmux bringup. A single --extra-arg token is shell-quoted as ONE
+// argument, so "--model opus" reaches claude as the literal single arg
+// '--model opus' (with an embedded space) — an unknown flag that makes claude
+// exit immediately, leaving a dead pane the registry still reports as running.
+//
+// ValidateClaudeExtraArgToken turns that silent failure into an actionable
+// error at spawn time: a token that looks like a flag (starts with '-') AND
+// contains whitespace is almost always a flag mashed together with its value
+// that the user meant as two separate --extra-arg tokens.
+
+func TestValidateClaudeExtraArgToken_RejectsFlagMashedWithValue(t *testing.T) {
+	bad := []string{
+		"--model opus",
+		"--model claude-opus-4-8",
+		"-c something",
+		"--permission-mode auto",
+	}
+	for _, tok := range bad {
+		if err := ValidateClaudeExtraArgToken(tok); err == nil {
+			t.Errorf("ValidateClaudeExtraArgToken(%q) = nil, want error (flag mashed with value)", tok)
+		}
+	}
+}
+
+func TestValidateClaudeExtraArgToken_AllowsCleanTokens(t *testing.T) {
+	good := []string{
+		"--model",                 // bare flag
+		"opus",                    // bare value
+		"--dangerously-skip-permissions", // bare flag, no value
+		"claude-opus-4-8",         // value with dashes but no space
+		"be concise please",       // a value with spaces that is NOT a flag
+		"",                        // empty (handled elsewhere; not a footgun)
+	}
+	for _, tok := range good {
+		if err := ValidateClaudeExtraArgToken(tok); err != nil {
+			t.Errorf("ValidateClaudeExtraArgToken(%q) = %v, want nil", tok, err)
+		}
+	}
+}

--- a/internal/session/issue1431_extraarg_guard_test.go
+++ b/internal/session/issue1431_extraarg_guard_test.go
@@ -29,12 +29,12 @@ func TestValidateClaudeExtraArgToken_RejectsFlagMashedWithValue(t *testing.T) {
 
 func TestValidateClaudeExtraArgToken_AllowsCleanTokens(t *testing.T) {
 	good := []string{
-		"--model",                 // bare flag
-		"opus",                    // bare value
+		"--model",                        // bare flag
+		"opus",                           // bare value
 		"--dangerously-skip-permissions", // bare flag, no value
-		"claude-opus-4-8",         // value with dashes but no space
-		"be concise please",       // a value with spaces that is NOT a flag
-		"",                        // empty (handled elsewhere; not a footgun)
+		"claude-opus-4-8",                // value with dashes but no space
+		"be concise please",              // a value with spaces that is NOT a flag
+		"",                               // empty (handled elsewhere; not a footgun)
 	}
 	for _, tok := range good {
 		if err := ValidateClaudeExtraArgToken(tok); err != nil {


### PR DESCRIPTION
## Summary

Fixes #1431: conductor-spawned children silently booted on Claude's built-in default model (Fable, currently unavailable account-wide) instead of the configured `[claude].default_model` (Opus), no-op'ing every turn while the registry still showed them **running**. Two root causes, two fixes.

### (a) `default_model` dropped at spawn+restart for any session with persisted options

`#1390` wired `default_model` into `NewClaudeOptions`, which callers only consult when an `Instance` has **no** persisted `ToolOptionsJSON`. A session carrying any other Claude option (skip-permissions, chrome, teammate-mode) has a non-nil `ClaudeOptions` with `Model==""`, so `GetClaudeOptions()` short-circuits that fallback and the launch command omits `--model` entirely.

`buildClaudeExtraFlags` — the single chokepoint every start/restart/resume command delegates flag assembly to — now resolves the launch model: explicit `opts.Model` wins, else `[claude].default_model`. Because restart routes through the same point, this also fixes the **restart re-bakes original model** symptom from the issue title.

### (b) `--extra-arg "--model opus"` silently killed tmux bringup

Each `--extra-arg` is shell-quoted as ONE argument, so the mashed token reached `claude` as the single bogus arg `'--model opus'` (embedded space). `claude` exited on startup, leaving a dead pane the registry still reported as running. `ValidateClaudeExtraArgToken` now rejects a token that starts with `-` AND contains whitespace at spawn time, with an actionable message pointing to separate tokens or the first-class `--model` flag. Wired into both `add` and `launch`.

The first-class per-launch `--model` flag (from #1023) already provides a supported override and is verified by the new command-level tests.

### Cross-conductor impact

This is the single biggest fleet-babysitting cost (Maestro finding, 2026-06-13: cost hours across the fleet). With this fix, every conductor-spawned child honors the configured Opus default at both spawn and restart instead of silently falling to an unavailable model.

### Out of scope (split to follow-up #1436)

Persisting an operator's in-pane `/model` switch across restart needs new Claude model-detection infra; tracked separately.

## Tests

- `TestIssue1431_DefaultModelApplied_NilOptions` — fresh session picks up default_model (the #1390 nil-fallback path)
- `TestIssue1431_DefaultModelApplied_NonNilEmptyModelOptions` — the gap: non-nil options with empty Model still get `--model <default>`
- `TestIssue1431_ExplicitModelBeatsDefault` — explicit per-session model wins; default never overrides
- `TestValidateClaudeExtraArgToken_RejectsFlagMashedWithValue` / `_AllowsCleanTokens` — the extra-arg footgun guard

Full `internal/session` + `cmd/agent-deck` suites green (sandboxed HOME+XDG).

Closes #1431


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of `--extra-arg` tokens to reject malformed flag/value combinations before launching a session.
  * Prevents incorrect or duplicate `--model` arguments by suppressing default model injection when `--model` is already provided in per-session extra arguments.
* **New Features**
  * Added default model behavior from configured `default_model`, applied automatically unless explicitly overridden.
* **Tests**
  * Expanded coverage for extra-arg validation and default/override model command behavior across session scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
