### PR TITLE
fix(worktree): finish last session via targeted delete (#1396)

### DIFF
--- a/cmd/agent-deck/worktree_cmd.go
+++ b/cmd/agent-deck/worktree_cmd.go
@@ -666,14 +666,20 @@ func handleWorktreeFinish(profile string, args []string) {
 		}
 	}
 
-	// Step 5: Remove session from agent-deck
-	var remaining []*session.Instance
-	for _, i := range instances {
-		if i.ID != inst.ID {
-			remaining = append(remaining, i)
-		}
-	}
-	if err := saveSessionData(storage, remaining, groups); err != nil {
+	// Step 5: Remove session from agent-deck.
+	//
+	// #1396: this must use the targeted RemoveSessionAndVerify path (the same
+	// one `session remove` uses), NOT saveSessionData/SaveWithGroups. When the
+	// finished worktree is the LAST session in the registry, `remaining` is
+	// empty and SaveWithGroups → SaveInstances([]) trips the S1 empty-sweep
+	// data-loss guard (ErrRefusingEmptySweep) — but only AFTER the irreversible
+	// merge/remove-worktree/delete-branch steps have already run, leaving an
+	// orphaned row pointing at a deleted worktree. RemoveSessionAndVerify
+	// issues a targeted DELETE + SaveGroupsOnly, so the last-session delete
+	// succeeds without ever calling SaveInstances([]).
+	remaining := dropInstance(instances, inst.ID)
+	groupTree := session.NewGroupTreeWithGroups(remaining, groups)
+	if err := storage.RemoveSessionAndVerify(inst.ID, remaining, groupTree); err != nil {
 		out.Error(fmt.Sprintf("failed to save session data: %v", err), ErrCodeInvalidOperation)
 		os.Exit(1)
 	}

--- a/internal/session/issue1396_worktree_finish_last_test.go
+++ b/internal/session/issue1396_worktree_finish_last_test.go
@@ -1,0 +1,80 @@
+package session
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssue1396_FinishLastWorktreeDoesNotTripEmptySweepGuard is the regression
+// test for issue #1396.
+//
+// `agent-deck worktree finish <session>`, when that session is the ONLY one in
+// the registry, used to persist the row removal via SaveWithGroups([]) which
+// flows into SaveInstances([]) and trips the S1 empty-sweep data-loss guard
+// (ErrRefusingEmptySweep). The guard rejection fired only AFTER the
+// irreversible git steps (merge / remove-worktree / delete-branch) had already
+// run, leaving an orphaned session row pointing at a deleted worktree.
+//
+// The fix routes the last-session removal through the targeted
+// RemoveSessionAndVerify path (DELETE + SaveGroupsOnly) instead, which removes
+// the row without ever calling SaveInstances([]).
+func TestIssue1396_FinishLastWorktreeDoesNotTripEmptySweepGuard(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "state.db")
+
+	// Seed a SINGLE worktree session — exactly the "only session in registry"
+	// condition that triggers the bug.
+	seed := rmTestStorage(t, dbPath)
+	only := &Instance{
+		ID:               "wt-finish-last-001",
+		Title:            "wtsess",
+		ProjectPath:      "/tmp/issue1396-repo",
+		GroupPath:        DefaultGroupPath,
+		Command:          "bash",
+		Tool:             "bash",
+		Status:           StatusStopped,
+		CreatedAt:        time.Now(),
+		WorktreeRepoRoot: "/tmp/issue1396-repo",
+		WorktreePath:     "/tmp/issue1396-repo/.worktrees/feat1",
+		WorktreeBranch:   "feature/feat1",
+	}
+	require.NoError(t, seed.SaveWithGroups([]*Instance{only}, NewGroupTree([]*Instance{only})))
+	require.True(t, only.IsWorktree(), "seed instance must be a worktree session")
+
+	// Sanity: the OLD persistence path (the pre-fix bug) trips the guard when
+	// removing the last session. This locks in WHY the targeted path is needed.
+	t.Run("old SaveWithGroups path trips the empty-sweep guard", func(t *testing.T) {
+		s := rmTestStorage(t, dbPath)
+		var remaining []*Instance // empty: the finished session was the only one
+		err := s.SaveWithGroups(remaining, NewGroupTreeWithGroups(remaining, nil))
+		require.Error(t, err, "SaveWithGroups([]) on a populated table must be refused")
+		require.True(t, errors.Is(err, statedb.ErrRefusingEmptySweep),
+			"expected ErrRefusingEmptySweep, got: %v", err)
+
+		// And the row is still present — proving the orphan in the bug report.
+		exists, exErr := s.InstanceExists(only.ID)
+		require.NoError(t, exErr)
+		require.True(t, exists, "row must still exist after the guard rejection (the orphan)")
+	})
+
+	// The FIX: RemoveSessionAndVerify cleanly removes the last session's row
+	// without tripping the guard, leaving an empty registry.
+	t.Run("RemoveSessionAndVerify removes the last session cleanly", func(t *testing.T) {
+		s := rmTestStorage(t, dbPath)
+		var remaining []*Instance // empty: the finished session was the only one
+		require.Empty(t, remaining, "after dropping the only session, remaining must be empty")
+
+		groupTree := NewGroupTreeWithGroups(remaining, nil)
+		err := s.RemoveSessionAndVerify(only.ID, remaining, groupTree)
+		require.NoError(t, err, "finishing the last worktree session must not trip the guard")
+
+		exists, exErr := s.InstanceExists(only.ID)
+		require.NoError(t, exErr)
+		require.False(t, exists, "the finished session's row must be gone (no orphan)")
+	})
+}

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -532,7 +532,13 @@ func (m *WebMutator) FinishWorktree(id string, opts web.WorktreeFinishOptions) (
 		}
 	}
 	m.h.instancesMu.RUnlock()
-	if sErr := storage.SaveWithGroups(existing, m.h.groupTree); sErr != nil {
+	// #1396: use the targeted RemoveSessionAndVerify path, NOT
+	// SaveWithGroups(existing, ...). When the finished worktree is the LAST
+	// session, `existing` is empty and SaveWithGroups → SaveInstances([]) trips
+	// the S1 empty-sweep data-loss guard AFTER the irreversible git steps,
+	// orphaning the row. The targeted DELETE + SaveGroupsOnly path persists the
+	// last-session removal without ever calling SaveInstances([]).
+	if sErr := storage.RemoveSessionAndVerify(id, existing, m.h.groupTree); sErr != nil {
 		return web.WorktreeFinishResult{}, fmt.Errorf("save session data: %w", sErr)
 	}
 


### PR DESCRIPTION
Fixes #1396.

## The bug

`agent-deck worktree finish <session>`, when that session is the **only** session in the registry, performs all the irreversible git steps (merge branch -> remove worktree -> delete branch) and **then** fails at the persistence step. The empty `remaining` list flows into `SaveWithGroups` -> `SaveInstances([])`, which trips the S1 empty-sweep data-loss guard (`ErrRefusingEmptySweep`). The command exits 1, misleading the user, and leaves an **orphaned session row** pointing at a worktree that no longer exists.

## The fix

Route the row removal through the targeted `RemoveSessionAndVerify` path (the same one `session remove` uses): a single-row `DELETE` + `SaveGroupsOnly`, which never calls `SaveInstances([])` and therefore cleanly removes the last session without tripping the guard.

Both call sites that shared the bug are fixed:
- `cmd/agent-deck/worktree_cmd.go` (`handleWorktreeFinish`, the CLI path the issue reproduced)
- `internal/ui/web_mutator.go` (`WebMutator.FinishWorktree`, the headless web/REST path — same `SaveWithGroups([])` bug)

## Tests

`internal/session/issue1396_worktree_finish_last_test.go` seeds a single worktree session and asserts:
1. the old `SaveWithGroups([])` path trips `ErrRefusingEmptySweep` and leaves the orphan row (locks in the root cause), and
2. `RemoveSessionAndVerify` removes the row cleanly with an empty registry.

`gofmt -l` clean, `go vet` clean, `go build ./...` clean. Test passes under sandboxed HOME+XDG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session removal logic to prevent data protection guards from being triggered when finishing the last worktree session.

* **Tests**
  * Added regression test to ensure proper cleanup when removing the final worktree session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->