### PR TITLE
feat(ui): copy a code block from session output with Y (#1412)

### DIFF
--- a/internal/ui/codeblock.go
+++ b/internal/ui/codeblock.go
@@ -1,0 +1,426 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/asheshgoplani/agent-deck/internal/clipboard"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// CodeBlock is a single fenced code block extracted from a session's output.
+// Lang is the info-string after the opening fence (may be empty); Content is
+// the block body with the fences stripped and no trailing newline.
+type CodeBlock struct {
+	Lang    string
+	Content string
+}
+
+// FirstLine returns the first non-empty line of the block, trimmed — used as
+// the picker label so the user can tell blocks apart at a glance.
+func (b CodeBlock) FirstLine() string {
+	for _, ln := range strings.Split(b.Content, "\n") {
+		if t := strings.TrimSpace(ln); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// LineCount returns the number of lines in the block.
+func (b CodeBlock) LineCount() int {
+	if b.Content == "" {
+		return 0
+	}
+	return strings.Count(b.Content, "\n") + 1
+}
+
+// extractCodeBlocks pulls fenced code blocks (``` … ```) out of text, newest
+// last (in source order). This is the #1412 "Run this SQL / run this command"
+// extractor: agents constantly emit runnable snippets inside fences, and the
+// pain point is getting them out of a tmux pane cleanly.
+//
+// Rules (deliberately lenient, matching how agents format output):
+//   - A fence opens on a line whose first non-space run is ``` (3+ backticks).
+//   - The optional info-string after the backticks becomes Lang.
+//   - The block closes on the next line whose trimmed content is only
+//     backticks. An unterminated fence (still streaming) is closed at EOF so
+//     the latest, half-finished command is still copyable.
+//   - Empty blocks (no content) are skipped.
+func extractCodeBlocks(text string) []CodeBlock {
+	if text == "" {
+		return nil
+	}
+
+	var blocks []CodeBlock
+	var (
+		inBlock bool
+		lang    string
+		openLen int // backtick count of the opening fence (CommonMark: closer must be >=)
+		body    []string
+	)
+
+	flush := func() {
+		content := strings.TrimRight(strings.Join(body, "\n"), "\n")
+		if strings.TrimSpace(content) != "" {
+			blocks = append(blocks, CodeBlock{Lang: lang, Content: content})
+		}
+		inBlock = false
+		lang = ""
+		openLen = 0
+		body = nil
+	}
+
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		ticks, info, isFence := parseFence(trimmed)
+
+		if !inBlock {
+			// Only an OPENING fence may carry an info string (the language).
+			if isFence {
+				inBlock = true
+				lang = info
+				openLen = ticks
+				body = nil
+			}
+			continue
+		}
+
+		// Inside a block: a CLOSER is a bare fence (no info string) of at least
+		// the opening length (CommonMark). Anything else — including a longer
+		// or info-bearing fence — is block content, so nested ``` fences and
+		// "```foo" lines do not prematurely close an outer block.
+		if isFence && info == "" && ticks >= openLen {
+			flush()
+			continue
+		}
+		body = append(body, line)
+	}
+	// Unterminated fence at EOF: keep the partial block so a streaming command
+	// is still copyable.
+	if inBlock {
+		flush()
+	}
+
+	return blocks
+}
+
+// parseFence inspects a trimmed line and reports whether it is a code-fence
+// delimiter. A fence is a run of >=3 backticks optionally followed by an
+// info string. It returns the backtick count, the trimmed info string, and
+// whether the line is a fence at all. An inline-code line like `foo` (a single
+// backtick run that is not >=3) or a line whose info string contains a backtick
+// (e.g. ``` `inline` ```) is NOT a fence.
+func parseFence(trimmed string) (ticks int, info string, ok bool) {
+	n := 0
+	for n < len(trimmed) && trimmed[n] == '`' {
+		n++
+	}
+	if n < 3 {
+		return 0, "", false
+	}
+	rest := strings.TrimSpace(trimmed[n:])
+	// An info string containing a backtick means this is not a clean fence
+	// (CommonMark forbids backticks in an info string).
+	if strings.Contains(rest, "`") {
+		return 0, "", false
+	}
+	return n, rest, true
+}
+
+// CodeBlockDialog presents the fenced code blocks extracted from a session's
+// recent output so the user can pick one and copy it (OSC52, SSH-safe). It is
+// the #1412 copy/paste extractor. Mirrors SessionPickerDialog's shape.
+type CodeBlockDialog struct {
+	visible       bool
+	width, height int
+	blocks        []CodeBlock
+	cursor        int
+	sessionTitle  string
+}
+
+// NewCodeBlockDialog creates an empty code-block picker dialog.
+func NewCodeBlockDialog() *CodeBlockDialog {
+	return &CodeBlockDialog{}
+}
+
+// Show opens the picker with the given blocks for sessionTitle. Returns false
+// (and does not open) when there are no blocks to pick.
+func (d *CodeBlockDialog) Show(sessionTitle string, blocks []CodeBlock) bool {
+	if len(blocks) == 0 {
+		return false
+	}
+	d.visible = true
+	d.sessionTitle = sessionTitle
+	d.blocks = blocks
+	d.cursor = 0
+	return true
+}
+
+// Hide closes the dialog and clears its state.
+func (d *CodeBlockDialog) Hide() {
+	d.visible = false
+	d.cursor = 0
+	d.blocks = nil
+	d.sessionTitle = ""
+}
+
+// IsVisible reports whether the dialog is shown.
+func (d *CodeBlockDialog) IsVisible() bool { return d.visible }
+
+// SetSize updates the dialog dimensions for centering.
+func (d *CodeBlockDialog) SetSize(w, h int) {
+	d.width = w
+	d.height = h
+}
+
+// GetSelected returns the block at the cursor, or nil when none.
+func (d *CodeBlockDialog) GetSelected() *CodeBlock {
+	if d.cursor < 0 || d.cursor >= len(d.blocks) {
+		return nil
+	}
+	return &d.blocks[d.cursor]
+}
+
+// Update handles navigation keys (j/k/up/down). enter/esc are handled by the
+// parent so it can act on the selection (mirrors SessionPickerDialog).
+func (d *CodeBlockDialog) Update(msg tea.KeyMsg) (*CodeBlockDialog, tea.Cmd) {
+	if !d.visible {
+		return d, nil
+	}
+	switch msg.String() {
+	case "j", "down":
+		if len(d.blocks) > 0 {
+			d.cursor = (d.cursor + 1) % len(d.blocks)
+		}
+	case "k", "up":
+		if len(d.blocks) > 0 {
+			d.cursor = (d.cursor - 1 + len(d.blocks)) % len(d.blocks)
+		}
+	case "esc":
+		d.Hide()
+	}
+	return d, nil
+}
+
+// View renders the code-block picker.
+func (d *CodeBlockDialog) View() string {
+	if !d.visible {
+		return ""
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorAccent)
+	// No MarginBottom here: the explicit blank line below provides the single
+	// header gap, so chrome row counting in visibleRows stays deterministic.
+	sourceStyle := lipgloss.NewStyle().Foreground(ColorTextDim)
+	selectedStyle := lipgloss.NewStyle().Foreground(ColorAccent).Bold(true)
+	normalStyle := lipgloss.NewStyle().Foreground(ColorText)
+	dimStyle := lipgloss.NewStyle().Foreground(ColorComment)
+	footerStyle := lipgloss.NewStyle().Foreground(ColorComment).Italic(true)
+
+	dialogWidth := 60
+	if d.width > 0 && d.width < dialogWidth+10 {
+		dialogWidth = d.width - 10
+		if dialogWidth < 36 {
+			dialogWidth = 36
+		}
+	}
+	// On a genuinely tiny terminal, never let the box (content + RoundedBorder's
+	// 2 cols) exceed the screen — that would wrap the whole dialog and break the
+	// height accounting. Clamp to the available width as a last resort, all the
+	// way down to a minimal box, so the box+border invariant holds even on a
+	// pathologically narrow terminal (#1412, Codex review).
+	if d.width > 0 && dialogWidth > d.width-2 {
+		dialogWidth = d.width - 2
+	}
+	if dialogWidth < 1 {
+		dialogWidth = 1
+	}
+
+	// innerWidth is the content width INSIDE DialogBoxStyle's Padding(1,2):
+	// dialogWidth minus 2 columns of padding on each side. EVERY rendered row is
+	// hard-truncated to innerWidth (cell-width-aware) so nothing wraps onto a
+	// second terminal line, which would break the one-row-per-block height
+	// accounting in visibleRows (#1412, Codex review). cellTruncate is keycap /
+	// CJK / emoji aware, so multibyte content can't overflow the budget either.
+	// The floor is derived from dialogWidth (never a fixed 12) so it can never
+	// exceed the box interior on a tiny terminal.
+	innerWidth := dialogWidth - 4
+	if innerWidth < 1 {
+		innerWidth = 1
+	}
+	// fit truncates a (possibly styled) line to exactly innerWidth cells.
+	fit := func(s string) string { return cellTruncate(s, innerWidth, "…") }
+
+	var lines []string
+	lines = append(lines, fit(titleStyle.Render("Copy Code Block")))
+	if d.sessionTitle != "" {
+		lines = append(lines, fit(sourceStyle.Render(fmt.Sprintf("Session: %q", d.sessionTitle))))
+	}
+	lines = append(lines, "")
+
+	// Windowed rendering: a session with many code blocks would otherwise
+	// produce a dialog taller than the terminal, pushing the selection and
+	// footer off-screen. Show at most maxVisible rows scrolled around the
+	// cursor, with ↑/↓ overflow markers (#1412, Codex review).
+	maxVisible := d.visibleRows()
+	start, end := windowBounds(d.cursor, len(d.blocks), maxVisible)
+
+	if start > 0 {
+		lines = append(lines, fit(dimStyle.Render(fmt.Sprintf("  ↑ %d more", start))))
+	}
+	for i := start; i < end; i++ {
+		b := d.blocks[i]
+		lang := b.Lang
+		if lang == "" {
+			lang = "text"
+		}
+		meta := dimStyle.Render(fmt.Sprintf("[%s, %d line(s)]", lang, b.LineCount()))
+		label := fmt.Sprintf("%s  %s", b.FirstLine(), meta)
+		if i == d.cursor {
+			lines = append(lines, fit("> "+selectedStyle.Render(label)))
+		} else {
+			lines = append(lines, fit("  "+normalStyle.Render(label)))
+		}
+	}
+	if end < len(d.blocks) {
+		lines = append(lines, fit(dimStyle.Render(fmt.Sprintf("  ↓ %d more", len(d.blocks)-end))))
+	}
+
+	lines = append(lines, "")
+	// Footer: compact form when the full hint would not fit, then a final
+	// cell-width truncation as a backstop so it is always exactly one row.
+	footer := "Enter copy | Esc cancel | j/k navigate"
+	if cellWidth(footer) > innerWidth {
+		footer = "Enter copy | Esc | j/k"
+	}
+	lines = append(lines, fit(footerStyle.Render(footer)))
+
+	box := DialogBoxStyle.Width(dialogWidth).Render(strings.Join(lines, "\n"))
+	return centerInScreen(box, d.width, d.height)
+}
+
+// codeBlockDialogChrome is the number of non-block rows the rendered dialog
+// occupies, so the windowed block list never overflows the terminal:
+//
+//	DialogBoxStyle border top+bottom ......... 2
+//	DialogBoxStyle padding top+bottom (1,2) .. 2
+//	title line ............................... 1
+//	session line ............................. 1
+//	blank after header ....................... 1
+//	"↑ N more" overflow marker (worst case) .. 1
+//	"↓ N more" overflow marker (worst case) .. 1
+//	blank before footer ...................... 1
+//	footer line .............................. 1
+//
+// Total = 11. Kept slightly conservative on purpose; underestimating chrome is
+// what lets the picker spill off-screen (#1412, Codex review).
+const codeBlockDialogChrome = 11
+
+// visibleRows returns how many block rows fit given the screen height. It
+// subtracts the full rendered chrome (border + padding + header/footer +
+// overflow markers) so the dialog stays within the terminal even when many
+// blocks exist. Falls back to a small default when height is unknown, and never
+// returns fewer than one row (on a terminal too short to fit even one block
+// the dialog cannot help being clipped, but it must still render a row).
+func (d *CodeBlockDialog) visibleRows() int {
+	const def = 12
+	if d.height <= 0 {
+		return def
+	}
+	rows := d.height - codeBlockDialogChrome
+	if rows < 1 {
+		return 1
+	}
+	if rows > def {
+		return def
+	}
+	return rows
+}
+
+// windowBounds returns the [start, end) slice of indices to render so that
+// cursor stays visible within a window of at most size rows.
+func windowBounds(cursor, total, size int) (int, int) {
+	if total <= size {
+		return 0, total
+	}
+	start := cursor - size/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + size
+	if end > total {
+		end = total
+		start = end - size
+	}
+	return start, end
+}
+
+// copyCodeBlock returns a tea.Cmd that copies the given code block's content to
+// the clipboard, reusing the same OSC52-aware fallback chain as the other copy
+// actions so it works over SSH.
+func (h *Home) copyCodeBlock(block CodeBlock, sessionTitle string) tea.Cmd {
+	return func() tea.Msg {
+		if strings.TrimSpace(block.Content) == "" {
+			return copyResultMsg{err: fmt.Errorf("empty code block")}
+		}
+		termInfo := tmux.GetTerminalInfo()
+		result, err := clipboard.Copy(block.Content, termInfo.SupportsOSC52)
+		if err != nil {
+			return copyResultMsg{err: fmt.Errorf("clipboard: %w", err)}
+		}
+		return copyResultMsg{
+			sessionTitle: sessionTitle,
+			lineCount:    result.LineCount,
+		}
+	}
+}
+
+// openCodeBlockPicker reads the selected session's recent output, extracts
+// fenced code blocks, and either copies the single block directly or opens the
+// picker for the user to choose. It is the entry point for the #1412 `Y`
+// hotkey. sessionContent is injected so the core is testable without tmux.
+func (h *Home) startCodeBlockCopy(inst *session.Instance) tea.Cmd {
+	content, err := getSessionContent(inst)
+	if err != nil {
+		h.setError(fmt.Errorf("no output to extract code from: %w", err))
+		return nil
+	}
+	blocks := extractCodeBlocks(content)
+	switch len(blocks) {
+	case 0:
+		h.setError(fmt.Errorf("no code blocks found in this session's output"))
+		return nil
+	case 1:
+		return h.copyCodeBlock(blocks[0], inst.Title)
+	default:
+		h.codeBlockDialog.SetSize(h.width, h.height)
+		h.codeBlockDialog.Show(inst.Title, blocks)
+		return nil
+	}
+}
+
+// handleCodeBlockDialogKey handles key events while the code-block picker is
+// visible. Mirrors handleSessionPickerDialogKey.
+func (h *Home) handleCodeBlockDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		selected := h.codeBlockDialog.GetSelected()
+		title := h.codeBlockDialog.sessionTitle
+		h.codeBlockDialog.Hide()
+		if selected != nil {
+			return h, h.copyCodeBlock(*selected, title)
+		}
+		return h, nil
+	case "esc":
+		h.codeBlockDialog.Hide()
+		return h, nil
+	default:
+		h.codeBlockDialog.Update(msg)
+		return h, nil
+	}
+}

--- a/internal/ui/codeblock.go
+++ b/internal/ui/codeblock.go
@@ -169,8 +169,11 @@ func (d *CodeBlockDialog) Hide() {
 	d.sessionTitle = ""
 }
 
-// IsVisible reports whether the dialog is shown.
-func (d *CodeBlockDialog) IsVisible() bool { return d.visible }
+// IsVisible reports whether the dialog is shown. Nil-safe: partially
+// constructed Home values in tests (and any future construction path that does
+// not initialize this dialog) call this from updateInner's key dispatch, so a
+// nil receiver must report "not visible" rather than panic.
+func (d *CodeBlockDialog) IsVisible() bool { return d != nil && d.visible }
 
 // SetSize updates the dialog dimensions for centering.
 func (d *CodeBlockDialog) SetSize(w, h int) {

--- a/internal/ui/codeblock_test.go
+++ b/internal/ui/codeblock_test.go
@@ -1,0 +1,247 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestExtractCodeBlocks_Basic(t *testing.T) {
+	text := "Here is the fix:\n\n```sql\nSELECT * FROM users WHERE id = 1;\n```\n\nAnd run this:\n\n```bash\nls -la\nrm tmp.txt\n```\n"
+	blocks := extractCodeBlocks(text)
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d: %+v", len(blocks), blocks)
+	}
+	if blocks[0].Lang != "sql" {
+		t.Errorf("block 0 lang: want sql, got %q", blocks[0].Lang)
+	}
+	if blocks[0].Content != "SELECT * FROM users WHERE id = 1;" {
+		t.Errorf("block 0 content: %q", blocks[0].Content)
+	}
+	if blocks[1].Lang != "bash" {
+		t.Errorf("block 1 lang: want bash, got %q", blocks[1].Lang)
+	}
+	if blocks[1].Content != "ls -la\nrm tmp.txt" {
+		t.Errorf("block 1 content: %q", blocks[1].Content)
+	}
+	if blocks[1].LineCount() != 2 {
+		t.Errorf("block 1 line count: want 2, got %d", blocks[1].LineCount())
+	}
+}
+
+func TestExtractCodeBlocks_NoFences(t *testing.T) {
+	if got := extractCodeBlocks("just some prose, no code at all"); got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+	if got := extractCodeBlocks(""); got != nil {
+		t.Errorf("expected nil for empty, got %+v", got)
+	}
+}
+
+func TestExtractCodeBlocks_NoLang(t *testing.T) {
+	blocks := extractCodeBlocks("```\nplain command\n```")
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].Lang != "" {
+		t.Errorf("expected empty lang, got %q", blocks[0].Lang)
+	}
+	if blocks[0].Content != "plain command" {
+		t.Errorf("content: %q", blocks[0].Content)
+	}
+}
+
+func TestExtractCodeBlocks_SkipsEmptyBlocks(t *testing.T) {
+	// An empty fenced block (no body) should be skipped.
+	blocks := extractCodeBlocks("```\n```\n\n```sh\necho hi\n```")
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 non-empty block, got %d: %+v", len(blocks), blocks)
+	}
+	if blocks[0].Content != "echo hi" {
+		t.Errorf("content: %q", blocks[0].Content)
+	}
+}
+
+func TestExtractCodeBlocks_UnterminatedFenceClosesAtEOF(t *testing.T) {
+	// A streaming/half-finished block (no closing fence) must still be copyable.
+	blocks := extractCodeBlocks("```bash\ngit push origin main")
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block from unterminated fence, got %d", len(blocks))
+	}
+	if blocks[0].Content != "git push origin main" {
+		t.Errorf("content: %q", blocks[0].Content)
+	}
+}
+
+func TestExtractCodeBlocks_IgnoresInlineBackticks(t *testing.T) {
+	// Inline code like `run foo` must NOT be treated as a fence.
+	blocks := extractCodeBlocks("Use the `foo` command, then:\n```\nfoo --bar\n```")
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d: %+v", len(blocks), blocks)
+	}
+	if blocks[0].Content != "foo --bar" {
+		t.Errorf("content: %q", blocks[0].Content)
+	}
+}
+
+func TestExtractCodeBlocks_IndentedFence(t *testing.T) {
+	// Agents sometimes emit fences with leading indentation (list items).
+	blocks := extractCodeBlocks("  ```\n  some cmd\n  ```")
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+}
+
+func TestCodeBlock_FirstLine(t *testing.T) {
+	b := CodeBlock{Content: "\n\n  SELECT 1;\nSELECT 2;"}
+	if got := b.FirstLine(); got != "SELECT 1;" {
+		t.Errorf("FirstLine: want %q, got %q", "SELECT 1;", got)
+	}
+	if got := (CodeBlock{}).FirstLine(); got != "" {
+		t.Errorf("empty FirstLine should be empty, got %q", got)
+	}
+}
+
+func TestCodeBlockDialog_ShowEmptyReturnsFalse(t *testing.T) {
+	d := NewCodeBlockDialog()
+	if d.Show("sess", nil) {
+		t.Error("Show with no blocks should return false")
+	}
+	if d.IsVisible() {
+		t.Error("dialog should not be visible with no blocks")
+	}
+}
+
+func TestCodeBlockDialog_NavigationAndSelection(t *testing.T) {
+	d := NewCodeBlockDialog()
+	blocks := []CodeBlock{
+		{Lang: "sql", Content: "SELECT 1;"},
+		{Lang: "bash", Content: "ls"},
+		{Lang: "", Content: "third"},
+	}
+	if !d.Show("mysession", blocks) {
+		t.Fatal("Show with blocks should return true")
+	}
+	if !d.IsVisible() {
+		t.Fatal("dialog should be visible")
+	}
+	if got := d.GetSelected(); got == nil || got.Content != "SELECT 1;" {
+		t.Fatalf("initial selection should be first block, got %+v", got)
+	}
+
+	// Down twice -> third block.
+	d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if got := d.GetSelected(); got == nil || got.Content != "third" {
+		t.Fatalf("after 2x down, selection should be third, got %+v", got)
+	}
+
+	// Down again wraps to first.
+	d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if got := d.GetSelected(); got == nil || got.Content != "SELECT 1;" {
+		t.Fatalf("down should wrap to first, got %+v", got)
+	}
+
+	// Up wraps to last.
+	d.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if got := d.GetSelected(); got == nil || got.Content != "third" {
+		t.Fatalf("up should wrap to last, got %+v", got)
+	}
+
+	// Esc hides.
+	d.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if d.IsVisible() {
+		t.Error("esc should hide the dialog")
+	}
+}
+
+func TestCodeBlockDialog_View(t *testing.T) {
+	d := NewCodeBlockDialog()
+	d.SetSize(120, 40)
+	d.Show("mysession", []CodeBlock{{Lang: "sql", Content: "SELECT 1;"}})
+	view := d.View()
+	if view == "" {
+		t.Fatal("visible dialog should render a non-empty view")
+	}
+	// Hidden dialog renders nothing.
+	d.Hide()
+	if d.View() != "" {
+		t.Error("hidden dialog should render empty view")
+	}
+}
+
+func TestExtractCodeBlocks_NestedFenceNotClosedByInner(t *testing.T) {
+	// An outer 4-backtick fence wrapping an inner ``` fence: the inner triple
+	// backticks are content, not a closer (CommonMark: closer must be >= opener
+	// length and bare). The whole inner markdown is one block.
+	text := "````md\n```sh\necho hi\n```\n````"
+	blocks := extractCodeBlocks(text)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d: %+v", len(blocks), blocks)
+	}
+	if blocks[0].Lang != "md" {
+		t.Errorf("lang: want md, got %q", blocks[0].Lang)
+	}
+	want := "```sh\necho hi\n```"
+	if blocks[0].Content != want {
+		t.Errorf("content: want %q, got %q", want, blocks[0].Content)
+	}
+}
+
+func TestExtractCodeBlocks_InfoStringDoesNotClose(t *testing.T) {
+	// A "```lang" line inside an open block must NOT close it (closers are bare).
+	text := "```\nline1\n```python\nline2\n```"
+	blocks := extractCodeBlocks(text)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block (info-bearing fence is content), got %d: %+v", len(blocks), blocks)
+	}
+	want := "line1\n```python\nline2"
+	if blocks[0].Content != want {
+		t.Errorf("content: want %q, got %q", want, blocks[0].Content)
+	}
+}
+
+func TestExtractCodeBlocks_LongerCloserAccepted(t *testing.T) {
+	// Opening with 3, closing with 4 backticks: a bare closer >= opener closes.
+	blocks := extractCodeBlocks("```\necho hi\n````")
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].Content != "echo hi" {
+		t.Errorf("content: %q", blocks[0].Content)
+	}
+}
+
+func TestWindowBounds(t *testing.T) {
+	if s, e := windowBounds(0, 3, 10); s != 0 || e != 3 {
+		t.Errorf("all-fit: got [%d,%d), want [0,3)", s, e)
+	}
+	if s, e := windowBounds(0, 100, 10); s != 0 || e != 10 {
+		t.Errorf("top: got [%d,%d), want [0,10)", s, e)
+	}
+	if s, e := windowBounds(50, 100, 10); s != 45 || e != 55 {
+		t.Errorf("middle: got [%d,%d), want [45,55)", s, e)
+	}
+	if s, e := windowBounds(99, 100, 10); s != 90 || e != 100 {
+		t.Errorf("end: got [%d,%d), want [90,100)", s, e)
+	}
+}
+
+func TestCodeBlockDialog_ViewWithManyBlocksFitsHeight(t *testing.T) {
+	d := NewCodeBlockDialog()
+	d.SetSize(120, 20) // small height forces windowing
+	blocks := make([]CodeBlock, 50)
+	for i := range blocks {
+		blocks[i] = CodeBlock{Lang: "sh", Content: "cmd"}
+	}
+	d.Show("sess", blocks)
+	view := d.View()
+	if view == "" {
+		t.Fatal("view should be non-empty")
+	}
+	rows := strings.Count(view, "\n") + 1
+	if rows > 20 {
+		t.Errorf("windowed view should fit in height 20, got %d rows", rows)
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -259,6 +259,7 @@ func (h *HelpOverlay) View() string {
 				{forkKeys, "Fork session (Claude/Pi)"},
 				{copyKey, "Copy output to clipboard"},
 				{"C", "Copy preview info (Repo / Path / Branch)"},
+				{"Y", "Copy a code block from output"},
 				{sendKey, "Send output to session"},
 				{execShellKey, "Exec shell in sandbox container"},
 				{editPathsKey, "Edit multi-repo paths"},

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -236,6 +236,7 @@ type Home struct {
 	analyticsPanel       *AnalyticsPanel       // For displaying session analytics
 	geminiModelDialog    *GeminiModelDialog    // For selecting Gemini model
 	sessionPickerDialog  *SessionPickerDialog  // For sending output to another session
+	codeBlockDialog      *CodeBlockDialog      // For copying a fenced code block from session output (#1412)
 	sessionSwitcher      *SessionSwitcher      // In-attach session switcher (Ctrl+Tab / Ctrl+S)
 	worktreeFinishDialog *WorktreeFinishDialog // For finishing worktree sessions (merge + cleanup)
 	feedbackDialog       *FeedbackDialog       // For in-app feedback popup (Phase 2)
@@ -1071,6 +1072,7 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		analyticsPanel:            NewAnalyticsPanel(),
 		geminiModelDialog:         NewGeminiModelDialog(),
 		sessionPickerDialog:       NewSessionPickerDialog(),
+		codeBlockDialog:           NewCodeBlockDialog(),
 		sessionSwitcher:           NewSessionSwitcher(),
 		worktreeFinishDialog:      NewWorktreeFinishDialog(),
 		feedbackDialog:            NewFeedbackDialog(),
@@ -5981,6 +5983,9 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if h.sessionPickerDialog.IsVisible() {
 			return h.handleSessionPickerDialogKey(msg)
 		}
+		if h.codeBlockDialog.IsVisible() {
+			return h.handleCodeBlockDialogKey(msg)
+		}
 		if h.worktreeFinishDialog.IsVisible() {
 			return h.handleWorktreeFinishDialogKey(msg)
 		}
@@ -6687,6 +6692,7 @@ func (h *Home) hasModalVisible() bool {
 		h.newDialog.IsVisible() || h.groupDialog.IsVisible() || h.forkDialog.IsVisible() ||
 		h.confirmDialog.IsVisible() || h.mcpDialog.IsVisible() || h.pluginDialog.IsVisible() || h.skillDialog.IsVisible() ||
 		h.geminiModelDialog.IsVisible() || h.sessionPickerDialog.IsVisible() ||
+		h.codeBlockDialog.IsVisible() ||
 		h.sessionSwitcher.IsVisible() ||
 		h.worktreeFinishDialog.IsVisible() || h.editPathsDialog.IsVisible() ||
 		h.editSessionDialog.IsVisible() ||
@@ -8071,6 +8077,19 @@ func (h *Home) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			item := h.flatItems[h.cursor]
 			if item.Type == session.ItemTypeSession && item.Session != nil {
 				return h, h.copySessionInfo(item.Session)
+			}
+		}
+		return h, nil
+
+	case "Y", "shift+y":
+		// Extract fenced code blocks from this session's recent output and
+		// copy one (OSC52, SSH-safe). Single block -> copy directly; multiple
+		// -> open the picker. Pairs with `c`/`C` in the copy family (#1412).
+		// `y` (lowercase) is the YOLO toggle, so this uses the shift variant.
+		if h.cursor < len(h.flatItems) {
+			item := h.flatItems[h.cursor]
+			if item.Type == session.ItemTypeSession && item.Session != nil {
+				return h, h.startCodeBlockCopy(item.Session)
 			}
 		}
 		return h, nil
@@ -12027,6 +12046,9 @@ func (h *Home) View() string {
 	}
 	if h.sessionPickerDialog.IsVisible() {
 		return h.sessionPickerDialog.View()
+	}
+	if h.codeBlockDialog.IsVisible() {
+		return h.codeBlockDialog.View()
 	}
 	if h.worktreeFinishDialog.IsVisible() {
 		return h.worktreeFinishDialog.View()

--- a/internal/ui/tui_eval_seam_a_test.go
+++ b/internal/ui/tui_eval_seam_a_test.go
@@ -105,6 +105,7 @@ func newSeamATestHome() *Home {
 		analyticsPanel:       NewAnalyticsPanel(),
 		geminiModelDialog:    NewGeminiModelDialog(),
 		sessionPickerDialog:  NewSessionPickerDialog(),
+		codeBlockDialog:      NewCodeBlockDialog(),
 		worktreeFinishDialog: NewWorktreeFinishDialog(),
 		feedbackDialog:       NewFeedbackDialog(),
 		zoxidePicker:         NewZoxidePicker(),

--- a/internal/ui/tui_eval_seam_b_test.go
+++ b/internal/ui/tui_eval_seam_b_test.go
@@ -156,6 +156,7 @@ func seamBNewHome() *Home {
 		analyticsPanel:       NewAnalyticsPanel(),
 		geminiModelDialog:    NewGeminiModelDialog(),
 		sessionPickerDialog:  NewSessionPickerDialog(),
+		codeBlockDialog:      NewCodeBlockDialog(),
 		worktreeFinishDialog: NewWorktreeFinishDialog(),
 		feedbackDialog:       NewFeedbackDialog(),
 		zoxidePicker:         NewZoxidePicker(),


### PR DESCRIPTION
Fixes #1412.

## The pain

Agents constantly emit runnable snippets ("Run this SQL...", "run this in a terminal: ...") and getting them out of a tmux-hosted session into the clipboard is high-friction: mouse selection in tmux panes, line-wrap mangling, no structured extraction. A Feedback Hub reporter said this single feature decides 100% daily-driver adoption.

## The feature

A new `Y` hotkey on a highlighted session:
1. Reads the session's recent output (the existing `getSessionContent` path).
2. Extracts the fenced code blocks (``` ... ```).
3. If there is exactly one block, copies it directly; if several, opens a picker to choose one.
4. Copies via the existing OSC52-aware `internal/clipboard` path, so it works over SSH.

`y` (lowercase) remains the YOLO toggle, so `Y` (the shift variant) is used — it sits in the `c` (copy output) / `C` (copy info) copy family. Documented in the help overlay.

## Correctness details

- **Parser** follows CommonMark closing-fence rules: a closer must be a *bare* fence of at least the opening backtick length, so nested ``` fences and `\`\`\`lang` lines inside a block are content, not premature closers. Unterminated (streaming) fences are closed at EOF so a half-finished command is still copyable. Inline backticks (`foo`) are never mistaken for fences.
- **Picker** windows its list around the cursor (with up/down overflow markers) and hard-truncates every rendered row to the box interior using the repo's cell-width-aware truncator (keycap / CJK / emoji safe), so the dialog never overflows the terminal height or wraps a row regardless of long language tags, long session titles, or multibyte content.

## Tests

`internal/ui/codeblock_test.go` covers the parser (basic, no-lang, empty-skip, unterminated, inline backticks, nested fences, info-bearing and longer closers), picker navigation/selection/visibility, windowing bounds, and bounded render height.

`gofmt -l` clean, `go vet` clean, `go build ./...` clean. Tests pass under sandboxed HOME+XDG.
