### PR TITLE
fix(web): headless --no-tui can mutate pre-existing sessions/groups (#1397)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -757,6 +757,15 @@ func main() {
 		liveMenuData := web.NewMemoryMenuData(fallbackMenuData)
 		homeModel.SetWebMenuData(liveMenuData)
 
+		// #1397: in headless mode no bubbletea loop ever populates the Home's
+		// in-memory registry, so the WebMutator must hydrate it from storage on
+		// each mutation. Flag the model so WebMutator.ensureHydrated activates;
+		// otherwise delete/restart/close/group-mutate on pre-existing sessions
+		// fail ("session not found" / empty-sweep guard).
+		if webHeadless {
+			homeModel.SetHeadless(true)
+		}
+
 		server, err := buildWebServer(effectiveProfile, webArgs, liveMenuData, ui.NewWebMutator(homeModel))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: web server setup failed: %v\n", err)

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -216,6 +216,13 @@ type Home struct {
 	groupTree    *session.GroupTree
 	flatItems    []session.Item // Flattened view for cursor navigation
 
+	// headless is true when running `web --no-tui`: no bubbletea loop ever
+	// boots, so the in-memory instances/groupTree are never populated by the
+	// TUI's loadSessions cycle. The WebMutator hydrates them from storage on
+	// each mutation instead (#1397). In live-TUI mode this stays false and the
+	// bubbletea loop owns this state.
+	headless bool
+
 	// Components
 	search               *Search
 	globalSearch         *GlobalSearch              // Global session search across all Claude conversations
@@ -2703,6 +2710,50 @@ func (h *Home) loadSessions() tea.Msg {
 	}
 
 	return msg
+}
+
+// SetHeadless marks this Home as backing a headless (`web --no-tui`) server.
+// In headless mode no bubbletea loop runs, so the WebMutator must hydrate the
+// in-memory registry from storage on each mutation (#1397).
+func (h *Home) SetHeadless(v bool) { h.headless = v }
+
+// IsHeadless reports whether this Home backs a headless web server.
+func (h *Home) IsHeadless() bool { return h.headless }
+
+// HydrateInstancesFromStorage reloads the in-memory instances, instanceByID
+// map, and groupTree from storage. It is the headless-mode equivalent of the
+// loadSessions/loadSessionsMsg cycle that the bubbletea loop runs in TUI mode:
+// without a running TUI, h.instances stays empty and every WebMutator lookup
+// fails with "session not found" while persistAllInstances ([]) trips the
+// empty-sweep guard (#1397). Safe to call repeatedly; it picks up out-of-band
+// changes (e.g. a concurrent CLI `add`/`rm`) so each web mutation operates on
+// the current registry.
+//
+// No-op (returns nil) when storage is unavailable so the caller can proceed
+// with whatever it already has rather than panicking.
+func (h *Home) HydrateInstancesFromStorage() error {
+	if h.storage == nil {
+		return nil
+	}
+	instances, groups, err := h.storage.LoadWithGroups()
+	if err != nil {
+		return fmt.Errorf("hydrate instances from storage: %w", err)
+	}
+
+	h.instancesMu.Lock()
+	h.instances = instances
+	h.instanceByID = make(map[string]*session.Instance, len(instances))
+	for _, inst := range instances {
+		h.instanceByID[inst.ID] = inst
+	}
+	h.instancesMu.Unlock()
+
+	if len(groups) > 0 {
+		h.groupTree = session.NewGroupTreeWithGroups(instances, groups)
+	} else {
+		h.groupTree = session.NewGroupTree(instances)
+	}
+	return nil
 }
 
 // tick returns a command that sends a tick message at regular intervals

--- a/internal/ui/issue1397_headless_mutator_test.go
+++ b/internal/ui/issue1397_headless_mutator_test.go
@@ -1,0 +1,236 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// newHeadlessHomeForTest builds a Home backed by a real (sandboxed, _test
+// profile) storage but WITHOUT booting bubbletea — exactly the `web --no-tui`
+// shape that issue #1397 is about. The in-memory instances/groupTree start
+// empty, mirroring a freshly-constructed headless server.
+func newHeadlessHomeForTest(t *testing.T, profile string) (*Home, *session.Storage) {
+	t.Helper()
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+
+	h := &Home{
+		profile:      storage.Profile(),
+		storage:      storage,
+		instanceByID: make(map[string]*session.Instance),
+		groupTree:    session.NewGroupTree(nil),
+		headless:     true,
+	}
+	return h, storage
+}
+
+func seedSession(t *testing.T, storage *session.Storage, existing []*session.Instance, id, title string) *session.Instance {
+	t.Helper()
+	inst := &session.Instance{
+		ID:          id,
+		Title:       title,
+		ProjectPath: "/tmp/issue1397-proj",
+		GroupPath:   session.DefaultGroupPath,
+		Command:     "bash",
+		Tool:        "bash",
+		Status:      session.StatusStopped,
+		CreatedAt:   time.Now(),
+	}
+	all := append(append([]*session.Instance{}, existing...), inst)
+	if err := storage.SaveWithGroups(all, session.NewGroupTree(all)); err != nil {
+		t.Fatalf("seed SaveWithGroups: %v", err)
+	}
+	return inst
+}
+
+// TestIssue1397_HeadlessDeleteFindsExistingSession verifies that a WebMutator
+// backed by a headless Home (empty in-memory list) can delete a session that
+// exists in storage. Pre-fix this returned "session not found" because the
+// mutator only consulted the never-populated h.instanceByID.
+func TestIssue1397_HeadlessDeleteFindsExistingSession(t *testing.T) {
+	h, storage := newHeadlessHomeForTest(t, "_test_1397_delete")
+	s1 := seedSession(t, storage, nil, "issue1397-del-001", "existing1")
+	_ = seedSession(t, storage, []*session.Instance{s1}, "issue1397-del-002", "existing2")
+
+	m := NewWebMutator(h)
+
+	// The Home's in-memory map is empty — this is the headless precondition.
+	if len(h.instanceByID) != 0 {
+		t.Fatalf("precondition: headless Home should start with empty instanceByID, got %d", len(h.instanceByID))
+	}
+
+	if err := m.DeleteSession("issue1397-del-001"); err != nil {
+		t.Fatalf("DeleteSession on existing session must succeed in headless mode, got: %v", err)
+	}
+
+	// Verify the row is actually gone from storage.
+	remaining, _, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	for _, r := range remaining {
+		if r.ID == "issue1397-del-001" {
+			t.Fatalf("deleted session still present in storage")
+		}
+	}
+	if len(remaining) != 1 {
+		t.Fatalf("expected 1 remaining session, got %d", len(remaining))
+	}
+}
+
+// TestIssue1397_HeadlessDeleteUnknownStillErrors guards the inverse: deleting a
+// genuinely non-existent id still fails (hydration must not paper over real
+// not-found errors).
+func TestIssue1397_HeadlessDeleteUnknownStillErrors(t *testing.T) {
+	h, storage := newHeadlessHomeForTest(t, "_test_1397_unknown")
+	_ = seedSession(t, storage, nil, "issue1397-keep-001", "keepme")
+
+	m := NewWebMutator(h)
+	if err := m.DeleteSession("does-not-exist"); err == nil {
+		t.Fatal("deleting a non-existent session must still error")
+	}
+}
+
+// TestIssue1397_HeadlessCreateGroupDoesNotTripGuard verifies that creating a
+// group while sessions exist in storage does not trip the empty-SaveInstances
+// data-loss guard. Pre-fix, persistAllInstances/SaveWithGroups ran with the
+// empty in-memory list and returned 500 from ErrRefusingEmptySweep.
+func TestIssue1397_HeadlessCreateGroupDoesNotTripGuard(t *testing.T) {
+	h, storage := newHeadlessHomeForTest(t, "_test_1397_group")
+	_ = seedSession(t, storage, nil, "issue1397-grp-001", "existing1")
+
+	m := NewWebMutator(h)
+	if _, err := m.CreateGroup("newgrp", ""); err != nil {
+		t.Fatalf("CreateGroup must succeed in headless mode with existing sessions, got: %v", err)
+	}
+
+	// The pre-existing session must survive the group creation (not wiped).
+	remaining, groups, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(remaining) != 1 {
+		t.Fatalf("existing session must survive group creation, got %d sessions", len(remaining))
+	}
+	found := false
+	for _, g := range groups {
+		if g.Name == "newgrp" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("created group not persisted; groups=%+v", groups)
+	}
+}
+
+// TestIssue1397_LiveModeDoesNotHydrate ensures the hydration path is gated on
+// headless: in live-TUI mode (headless=false) beginHeadlessTx must be a no-op so
+// it never races the bubbletea loop that owns the in-memory state.
+func TestIssue1397_LiveModeDoesNotHydrate(t *testing.T) {
+	storage, err := session.NewStorageWithProfile("_test_1397_live")
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+	_ = seedSession(t, storage, nil, "issue1397-live-001", "onlyondisk")
+
+	h := &Home{
+		profile:      storage.Profile(),
+		storage:      storage,
+		instanceByID: make(map[string]*session.Instance),
+		groupTree:    session.NewGroupTree(nil),
+		headless:     false, // live TUI mode
+	}
+	m := NewWebMutator(h)
+
+	// In live mode, beginHeadlessTx must NOT load from storage, so the on-disk
+	// session stays invisible to the (empty) in-memory map.
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		t.Fatalf("beginHeadlessTx should be a no-op in live mode, got: %v", err)
+	}
+	unlock()
+	if len(h.instanceByID) != 0 {
+		t.Fatalf("live mode must not hydrate; instanceByID has %d entries", len(h.instanceByID))
+	}
+}
+
+// TestIssue1397_HeadlessConcurrentMutationsNoRace fires concurrent headless
+// mutations (group creates + a delete) and asserts no data race and no lost
+// data: the pre-existing session survives and the deleted one is gone. Run with
+// -race to exercise the hydrate->mutate->persist serialization (#1397, Codex
+// review point on concurrency).
+func TestIssue1397_HeadlessConcurrentMutationsNoRace(t *testing.T) {
+	h, storage := newHeadlessHomeForTest(t, "_test_1397_concurrent")
+	keep := seedSession(t, storage, nil, "issue1397-keep-001", "keepme")
+	_ = seedSession(t, storage, []*session.Instance{keep}, "issue1397-doomed-001", "doomed")
+
+	m := NewWebMutator(h)
+
+	const groups = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, groups+1)
+
+	for i := 0; i < groups; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			if _, err := m.CreateGroup(fmt.Sprintf("g%d", n), ""); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := m.DeleteSession("issue1397-doomed-001"); err != nil {
+			errs <- err
+		}
+	}()
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent mutation error: %v", err)
+	}
+
+	remaining, grpList, err := storage.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	// The kept session must survive all the churn; the doomed one must be gone.
+	var sawKeep, sawDoomed bool
+	for _, r := range remaining {
+		switch r.ID {
+		case "issue1397-keep-001":
+			sawKeep = true
+		case "issue1397-doomed-001":
+			sawDoomed = true
+		}
+	}
+	if !sawKeep {
+		t.Error("kept session was lost under concurrent mutations")
+	}
+	if sawDoomed {
+		t.Error("doomed session should have been deleted")
+	}
+	// Serialization guarantees no lost updates: ALL concurrently-created groups
+	// must persist (a weaker >0 check would not catch a lost-update regression).
+	created := 0
+	for _, g := range grpList {
+		if strings.HasPrefix(g.Name, "g") {
+			created++
+		}
+	}
+	if created != groups {
+		t.Errorf("expected all %d concurrent groups to persist, got %d", groups, created)
+	}
+}

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -31,6 +31,14 @@ type WebMutator struct {
 	undoMu     sync.Mutex
 	undoStack  []webDeletedEntry
 	undoWindow time.Duration
+
+	// headlessTxMu serializes the full hydrate -> mutate -> persist transaction
+	// in headless (`web --no-tui`) mode (#1397). Without it, two concurrent HTTP
+	// handlers could each hydrate (replacing h.instances/instanceByID/groupTree),
+	// mutate a now-detached snapshot, and persist over each other — a lost
+	// update. Only contended in headless mode; in live-TUI mode the Tea loop
+	// owns that state and the mutator never hydrates, so this is uncontended.
+	headlessTxMu sync.Mutex
 }
 
 type webDeletedEntry struct {
@@ -51,8 +59,45 @@ func (m *WebMutator) WithUndoWindow(d time.Duration) *WebMutator {
 	return m
 }
 
+// beginHeadlessTx serializes and hydrates a headless mutation (#1397). It
+// returns an unlock function the caller MUST defer.
+//
+// In `web --no-tui` mode no bubbletea loop ever populates
+// h.instances/instanceByID/groupTree, so every lookup would miss pre-existing
+// sessions and persistAllInstances([]) would trip the empty-sweep guard. This
+// helper:
+//
+//  1. takes headlessTxMu so the whole hydrate -> mutate -> persist sequence runs
+//     as one critical section (no concurrent handler can replace the in-memory
+//     snapshot mid-mutation — prevents lost updates), and
+//  2. reloads the registry from storage so the mutation sees the current state,
+//     including out-of-band changes from a concurrent CLI add/rm.
+//
+// In live-TUI mode it is a pure no-op (returns a no-op unlock and does NOT
+// hydrate): the Tea loop owns that state and re-reading/locking here would
+// race it.
+//
+// Callers in live mode pay only a nil check and a closure; the mutex is never
+// contended because hydration never runs there.
+func (m *WebMutator) beginHeadlessTx() (unlock func(), err error) {
+	if m.h == nil || !m.h.IsHeadless() {
+		return func() {}, nil
+	}
+	m.headlessTxMu.Lock()
+	if hErr := m.h.HydrateInstancesFromStorage(); hErr != nil {
+		m.headlessTxMu.Unlock()
+		return func() {}, hErr
+	}
+	return m.headlessTxMu.Unlock, nil
+}
+
 // CreateSession creates and starts a new session, persisting it to storage.
 func (m *WebMutator) CreateSession(title, tool, projectPath, groupPath, modelID string) (string, error) {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
 	var inst *session.Instance
 	if groupPath != "" {
 		inst = session.NewInstanceWithGroupAndTool(title, projectPath, groupPath, tool)
@@ -93,6 +138,11 @@ func (m *WebMutator) CreateSession(title, tool, projectPath, groupPath, modelID 
 
 // StartSession starts a stopped/idle session by ID.
 func (m *WebMutator) StartSession(id string) error {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	m.h.instancesMu.RLock()
 	inst := m.h.instanceByID[id]
 	m.h.instancesMu.RUnlock()
@@ -104,6 +154,11 @@ func (m *WebMutator) StartSession(id string) error {
 
 // StopSession kills (stops) a running session by ID.
 func (m *WebMutator) StopSession(id string) error {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	m.h.instancesMu.RLock()
 	inst := m.h.instanceByID[id]
 	m.h.instancesMu.RUnlock()
@@ -115,6 +170,11 @@ func (m *WebMutator) StopSession(id string) error {
 
 // RestartSession restarts a session by ID.
 func (m *WebMutator) RestartSession(id string) error {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	m.h.instancesMu.RLock()
 	inst := m.h.instanceByID[id]
 	m.h.instancesMu.RUnlock()
@@ -128,6 +188,11 @@ func (m *WebMutator) RestartSession(id string) error {
 // Before removal, the instance is pushed onto the web undo stack so a
 // subsequent UndoDelete (POST /api/sessions/undelete) can restore it.
 func (m *WebMutator) DeleteSession(id string) error {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	m.h.instancesMu.RLock()
 	inst := m.h.instanceByID[id]
 	m.h.instancesMu.RUnlock()
@@ -158,6 +223,11 @@ func (m *WebMutator) DeleteSession(id string) error {
 // the front-end can express the user-visible intent ("close, but don't
 // delete").
 func (m *WebMutator) CloseSession(id string) error {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	m.h.instancesMu.RLock()
 	inst := m.h.instanceByID[id]
 	m.h.instancesMu.RUnlock()
@@ -170,6 +240,11 @@ func (m *WebMutator) CloseSession(id string) error {
 // ArchiveSession stops the session process and marks it archived so it
 // is hidden from active lists but retained in storage.
 func (m *WebMutator) ArchiveSession(id string) error {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	m.h.instancesMu.RLock()
 	inst := m.h.instanceByID[id]
 	m.h.instancesMu.RUnlock()
@@ -187,6 +262,11 @@ func (m *WebMutator) ArchiveSession(id string) error {
 
 // UnarchiveSession clears the archive flag without starting tmux.
 func (m *WebMutator) UnarchiveSession(id string) error {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	m.h.instancesMu.RLock()
 	inst := m.h.instanceByID[id]
 	m.h.instancesMu.RUnlock()
@@ -252,6 +332,16 @@ func (m *WebMutator) UndoDelete() (string, error) {
 		return "", fmt.Errorf("restart session: %w", err)
 	}
 
+	// #1397: hydrate + serialize before reading/persisting the in-memory list so
+	// the restored row is appended to the CURRENT registry (in headless mode the
+	// list would otherwise be empty, dropping every other session) and so this
+	// re-persist does not race a concurrent mutation.
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
+
 	storage, err := session.NewStorageWithProfile(m.h.profile)
 	if err != nil {
 		return "", fmt.Errorf("open storage: %w", err)
@@ -285,6 +375,11 @@ func (m *WebMutator) pushUndo(inst *session.Instance) {
 
 // ForkSession forks an existing session using the proper tool-specific fork command.
 func (m *WebMutator) ForkSession(id string) (string, error) {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
 	m.h.instancesMu.RLock()
 	parent := m.h.instanceByID[id]
 	m.h.instancesMu.RUnlock()
@@ -330,6 +425,11 @@ func (m *WebMutator) UpdateSession(id string, updates map[string]string) ([]stri
 	if len(updates) == 0 {
 		return nil, false, nil
 	}
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return nil, false, err
+	}
+	defer unlock()
 	m.h.instancesMu.RLock()
 	inst := m.h.instanceByID[id]
 	m.h.instancesMu.RUnlock()
@@ -389,6 +489,11 @@ func (m *WebMutator) UpdateSession(id string, updates map[string]string) ([]stri
 // CreateGroup creates a new group (or subgroup if parentPath is non-empty) and
 // persists the group tree to storage.
 func (m *WebMutator) CreateGroup(name, parentPath string) (string, error) {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return "", err
+	}
+	defer unlock()
 	var grp *session.Group
 	if parentPath != "" {
 		grp = m.h.groupTree.CreateSubgroup(parentPath, name)
@@ -418,6 +523,11 @@ func (m *WebMutator) CreateGroup(name, parentPath string) (string, error) {
 
 // RenameGroup renames a group identified by groupPath to newName and persists.
 func (m *WebMutator) RenameGroup(groupPath, newName string) error {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 	m.h.groupTree.RenameGroup(groupPath, newName)
 
 	storage, err := session.NewStorageWithProfile(m.h.profile)
@@ -441,6 +551,11 @@ func (m *WebMutator) RenameGroup(groupPath, newName string) error {
 // orchestration is duplicated rather than refactored to keep the
 // fix minimally invasive (issue #1126).
 func (m *WebMutator) FinishWorktree(id string, opts web.WorktreeFinishOptions) (web.WorktreeFinishResult, error) {
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return web.WorktreeFinishResult{}, err
+	}
+	defer unlock()
 	m.h.instancesMu.RLock()
 	inst := m.h.instanceByID[id]
 	m.h.instancesMu.RUnlock()
@@ -561,6 +676,11 @@ func (m *WebMutator) DeleteGroup(groupPath string) error {
 	if groupPath == session.DefaultGroupPath {
 		return fmt.Errorf("cannot delete default group")
 	}
+	unlock, err := m.beginHeadlessTx()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 
 	m.h.groupTree.DeleteGroup(groupPath)
 


### PR DESCRIPTION
Fixes #1397.

## The bug

In headless server mode (`agent-deck web --no-tui`) the web UI/REST API can **read** state correctly but **cannot mutate pre-existing state**: deleting an existing session returns 500 `session not found`, and creating a group returns 500 from the empty-`SaveInstances` data-loss guard.

Root cause: the `WebMutator` reads the TUI's in-memory instance list (`Home.instances` / `instanceByID` / `groupTree`), which is **never populated when no bubbletea loop runs**. So lookups miss sessions that exist in `state.db`, and `persistAllInstances` runs with an empty list (tripping the guard).

## The fix

- A `headless` flag on `Home`, set in the `--no-tui` boot path.
- `Home.HydrateInstancesFromStorage()` reloads instances + groups from storage into the in-memory registry.
- The `WebMutator` wraps every mutating method in `beginHeadlessTx()`: in headless mode it takes a per-mutator mutex **and** hydrates, returning an unlock the method defers — so the entire **hydrate → mutate → persist** sequence runs as one serialized critical section. No concurrent HTTP handler can replace the snapshot mid-mutation (no lost updates), and `UndoDelete` is covered too.
- In live-TUI mode `beginHeadlessTx()` is a pure no-op that never hydrates or locks, so the Tea loop keeps sole ownership of that state (no new races there).

## Tests

`internal/ui/issue1397_headless_mutator_test.go` (sandboxed, pass under `-race`):
- headless delete of an existing session succeeds and removes the row,
- an unknown id still errors (hydration does not mask real not-found),
- headless `CreateGroup` with existing sessions does not trip the guard and preserves the existing session,
- live mode does not hydrate,
- 8 concurrent `CreateGroup` + a `DeleteSession`: all groups persist, the kept session survives, the doomed one is deleted, no data race.

`gofmt -l` clean, `go vet` clean, `go build ./...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Web server now supports headless mode operation without the terminal interface
* Implemented automatic state synchronization from storage to maintain data consistency during concurrent operations
* Transaction-based locking ensures data integrity during simultaneous web requests in headless mode

## Tests
* Added comprehensive test coverage for headless mode functionality, including concurrent mutations, session management, and state persistence validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->