### PR TITLE
fix(ssh): sweep stale ControlMaster sockets to unblock remote fetch (#1421)

### DIFF
--- a/cmd/agent-deck/remote_cmd.go
+++ b/cmd/agent-deck/remote_cmd.go
@@ -269,6 +269,11 @@ func handleRemoteSessions(args []string) {
 		return
 	}
 
+	// #1421: sweep orphaned SSH ControlMaster sockets first so a stale socket
+	// (master died on a remote update / network drop) doesn't hang this command
+	// forever on the ControlMaster=auto reuse.
+	session.CleanStaleSSHSockets()
+
 	// Filter to specific remote if name provided
 	remoteName := ""
 	if len(fs.Args()) > 0 {

--- a/internal/session/issue1421_stale_ssh_socket_test.go
+++ b/internal/session/issue1421_stale_ssh_socket_test.go
@@ -1,0 +1,147 @@
+package session
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestIssue1421_CleanStaleSSHSockets verifies the orphaned-ControlMaster-socket
+// sweep: a stale socket (file present, no listener) is removed, while a live
+// socket (listener present) and a non-socket regular file are left untouched.
+//
+// This is the #1421 regression: when an SSH master dies (remote update /
+// network drop) the ControlPath socket is left behind, and the next
+// ControlMaster=auto connect hangs forever because ConnectTimeout does not
+// bound the Unix-socket dial. The sweep removes the dead socket so the next ssh
+// opens a fresh master instead of blocking.
+func TestIssue1421_CleanStaleSSHSockets(t *testing.T) {
+	dir := t.TempDir()
+
+	// (a) Stale socket: a leftover socket inode with no listener — exactly the
+	// on-disk state a crashed/killed SSH master leaves behind. SetUnlinkOnClose
+	// (false) keeps the socket file after Close so it becomes a true orphan.
+	stalePath := filepath.Join(dir, "stale@host:22")
+	recreateOrphanSocket(t, stalePath)
+
+	// (b) Live socket: a listener that stays open for the duration of the test.
+	livePath := filepath.Join(dir, "live@host:22")
+	liveLn, err := net.Listen("unix", livePath)
+	if err != nil {
+		t.Fatalf("create live socket: %v", err)
+	}
+	defer liveLn.Close()
+
+	// (c) Non-socket regular file: must never be touched.
+	regularPath := filepath.Join(dir, "not-a-socket.txt")
+	if err := os.WriteFile(regularPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write regular file: %v", err)
+	}
+
+	cleanStaleSSHSocketsIn(dir)
+
+	// Stale socket must be gone.
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Errorf("stale socket should have been removed, stat err=%v", err)
+	}
+	// Live socket must survive.
+	if _, err := os.Stat(livePath); err != nil {
+		t.Errorf("live socket should have been kept, stat err=%v", err)
+	}
+	// Regular file must survive.
+	if _, err := os.Stat(regularPath); err != nil {
+		t.Errorf("regular file should have been kept, stat err=%v", err)
+	}
+}
+
+// recreateOrphanSocket reproduces a leftover socket inode at path: bind a
+// listener to materialize the socket file, then close just the FD via
+// SyscallConn so the inode remains on disk with no process accepting on it
+// (mirrors a dead SSH master's ControlPath).
+func recreateOrphanSocket(t *testing.T, path string) {
+	t.Helper()
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: path, Net: "unix"})
+	if err != nil {
+		t.Fatalf("recreate orphan socket: %v", err)
+	}
+	// SetUnlinkOnClose(false) keeps the socket file on disk after Close so it
+	// becomes a true orphan inode with no listener.
+	ln.SetUnlinkOnClose(false)
+	_ = ln.Close()
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		t.Fatalf("orphan socket not created at %s", path)
+	}
+}
+
+// TestIssue1421_CleanStaleSSHSockets_MissingDir is a no-op when the control dir
+// does not exist (no remotes ever used). Must not panic or error.
+func TestIssue1421_CleanStaleSSHSockets_MissingDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	cleanStaleSSHSocketsIn(missing) // must not panic
+}
+
+// TestIssue1421_SSHConnOptsStillUseControlMaster guards that the fix did not
+// accidentally drop ControlMaster (the sweep is a complement to, not a
+// replacement for, connection multiplexing).
+func TestIssue1421_SSHConnOptsStillUseControlMaster(t *testing.T) {
+	r := &SSHRunner{Host: "user@host"}
+	opts := r.sshConnOpts()
+	joined := ""
+	for _, o := range opts {
+		joined += o + " "
+	}
+	for _, want := range []string{"ControlMaster=auto", "ControlPersist=600", "ConnectTimeout=10"} {
+		found := false
+		for _, o := range opts {
+			if o == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("sshConnOpts missing %q; got: %s", want, joined)
+		}
+	}
+}
+
+// timeoutErr is a net.Error that reports Timeout()==true, used to assert that
+// a probe timeout does NOT classify a socket as stale.
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "i/o timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+// TestIssue1421_IsStaleSocketDialErr_OnlyRemovesOnConfirmedDead verifies that
+// only an unambiguous "no listener" signal (ECONNREFUSED / ENOENT) marks a
+// socket stale. A timeout or a resource/permission error must NOT — removing on
+// those could tear down a LIVE master (#1421, Codex review).
+func TestIssue1421_IsStaleSocketDialErr_OnlyRemovesOnConfirmedDead(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"econnrefused", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, true},
+		{"enoent", &net.OpError{Op: "dial", Err: syscall.ENOENT}, true},
+		{"timeout", timeoutErr{}, false},
+		{"eacces", &net.OpError{Op: "dial", Err: syscall.EACCES}, false},
+		{"emfile", &net.OpError{Op: "dial", Err: syscall.EMFILE}, false},
+		{"generic", errorsNew("some other error"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStaleSocketDialErr(tc.err); got != tc.want {
+				t.Errorf("isStaleSocketDialErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func errorsNew(s string) error { return &simpleErr{s} }
+
+type simpleErr struct{ s string }
+
+func (e *simpleErr) Error() string { return e.s }

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"log/slog"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -29,6 +33,113 @@ const sshAttachReplyQuarantine = 500 * time.Millisecond
 
 // sshControlDir is the directory for SSH ControlMaster sockets.
 const sshControlDir = "/tmp/agent-deck-ssh"
+
+// staleSocketProbeTimeout bounds the per-socket liveness dial in
+// CleanStaleSSHSockets. It is deliberately short: a healthy master answers a
+// Unix-socket connect essentially instantly (the listener is local), so a dial
+// that does not connect within this window is treated as unreachable.
+const staleSocketProbeTimeout = 250 * time.Millisecond
+
+// CleanStaleSSHSockets removes orphaned SSH ControlMaster sockets from
+// sshControlDir (#1421). When an SSH master process dies unexpectedly (remote
+// agent-deck update restarts sshd, network drop, remote reboot), its
+// ControlPath socket file is left behind on disk with no process listening on
+// it. Because agent-deck uses ControlMaster=auto, the NEXT ssh invocation tries
+// to reuse that stale socket and hangs indefinitely — ConnectTimeout only
+// bounds the initial TCP dial, NOT the Unix-domain-socket connect to the mux.
+// The result: fetchRemoteSessions (and `agent-deck remote sessions`) block
+// forever and every remote session disappears from the TUI until restart.
+//
+// The cleanup probes each socket with a short net.DialTimeout. A live master
+// answers the connect immediately; a stale socket cannot be connected to
+// (connection refused — the listener is gone), so it is removed. Removing a
+// stale socket is safe: the next ssh invocation simply opens a fresh master.
+//
+// Best-effort and fully defensive: an unreadable directory, a transient stat
+// error, or a failed remove is swallowed (logged at debug), never fatal —
+// leaving a socket in place is strictly better than blocking the caller.
+// Non-socket files in the directory are ignored.
+func CleanStaleSSHSockets() {
+	cleanStaleSSHSocketsIn(sshControlDir)
+}
+
+// cleanStaleSSHSocketsIn is the dir-parameterized core of CleanStaleSSHSockets,
+// split out so tests can exercise the probe/remove logic against a temp dir
+// instead of the process-global /tmp/agent-deck-ssh (which a live agent-deck
+// shares).
+func cleanStaleSSHSocketsIn(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Directory missing (no remotes ever used) or unreadable: nothing to do.
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+
+		info, statErr := entry.Info()
+		if statErr != nil {
+			continue
+		}
+		// Only probe Unix sockets — skip regular files / anything unexpected.
+		if info.Mode()&os.ModeSocket == 0 {
+			continue
+		}
+
+		conn, dialErr := net.DialTimeout("unix", path, staleSocketProbeTimeout)
+		if dialErr == nil {
+			// A process is listening: the master is alive, keep the socket.
+			_ = conn.Close()
+			continue
+		}
+		// Only remove on a CONFIRMED-dead signal. A bare "dial failed" is not
+		// enough: a timeout (busy master with a full accept backlog), EMFILE /
+		// ENOMEM (local fd/memory exhaustion), or EACCES (transient permission)
+		// do NOT prove the master is gone, and unlinking on those would tear
+		// down a LIVE ControlMaster. ECONNREFUSED is the unambiguous "socket
+		// file exists but nothing is listening" signal a dead master leaves;
+		// ENOENT means it is already gone. Anything else: keep the socket and
+		// log (#1421, Codex review).
+		if !isStaleSocketDialErr(dialErr) {
+			slog.Debug("ssh: ControlMaster socket probe inconclusive, keeping socket",
+				slog.String("path", path), slog.String("err", dialErr.Error()))
+			continue
+		}
+		// The listening master is gone. Remove the orphan so the next ssh
+		// ControlMaster=auto opens a fresh master instead of hanging on it.
+		if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+			slog.Debug("ssh: failed to remove stale ControlMaster socket",
+				slog.String("path", path), slog.String("err", rmErr.Error()))
+		} else {
+			slog.Debug("ssh: removed stale ControlMaster socket", slog.String("path", path))
+		}
+	}
+}
+
+// isStaleSocketDialErr reports whether a net.DialTimeout error against a Unix
+// socket unambiguously means "the socket file exists but nothing is listening"
+// — i.e. the SSH master is dead and the socket is safe to remove. Only
+// ECONNREFUSED (no listener) and ENOENT (already gone) qualify. Timeouts and
+// resource errors (EMFILE/ENOMEM/EACCES) are deliberately excluded: they can
+// occur against a LIVE master, and removing on them would tear down a healthy
+// ControlMaster (#1421).
+func isStaleSocketDialErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ENOENT) {
+		return true
+	}
+	// A timeout is explicitly NOT stale: a busy master with a full accept
+	// backlog can time out. Be conservative — keep the socket.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return false
+	}
+	return false
+}
 
 // SSHRunner executes commands on a remote host via SSH.
 type SSHRunner struct {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2546,6 +2546,13 @@ func (h *Home) fetchRemoteSessions() tea.Msg {
 		return remoteSessionsFetchedMsg{sessions: nil}
 	}
 
+	// #1421: sweep orphaned SSH ControlMaster sockets before fetching. A stale
+	// socket (master died on a remote update / network drop) makes the next
+	// ControlMaster=auto connect hang forever — ConnectTimeout does not bound
+	// the Unix-socket dial — which would block this whole periodic fetch and
+	// make every remote session vanish until the TUI restarts.
+	session.CleanStaleSSHSockets()
+
 	results := make(map[string][]session.RemoteSessionInfo, len(config.Remotes))
 	// #1101: remote cost summaries piggy-back on the existing remote-fetch
 	// channel so the status-line cost segment doesn't lag behind the session


### PR DESCRIPTION
Fixes #1421.

## The bug

When an SSH master process dies unexpectedly (a remote agent-deck update restarts sshd, a network drop, a remote reboot), its `ControlPath` socket in `/tmp/agent-deck-ssh` is left on disk with no listener. Because agent-deck uses `ControlMaster=auto`, the next ssh invocation tries to reuse that stale socket and **hangs indefinitely** — `ConnectTimeout` only bounds the initial TCP dial, **not** the Unix-domain-socket connect to the mux. The TUI's periodic remote fetch (and `agent-deck remote sessions`) then block forever and every remote session disappears until restart.

## The fix

`CleanStaleSSHSockets()` probes each socket in the control dir with a short `net.DialTimeout`:
- a live master answers the connect instantly and is **kept**;
- a socket whose probe returns a **confirmed-dead** signal (`ECONNREFUSED` = no listener, or `ENOENT` = already gone) is **removed**, so the next `ControlMaster=auto` opens a fresh master.

Crucially, an **inconclusive** probe error — a timeout (busy master with a full accept backlog), `EMFILE` / `ENOMEM` / `EACCES` — does **not** remove the socket, so a live master is never torn down. Non-socket files and a missing dir are ignored; all failures are best-effort (logged at debug, never fatal).

Wired in before `fetchRemoteSessions` (covering both the TUI startup fetch and the periodic poll) and before the `remote sessions` CLI command.

## Tests

`internal/session/issue1421_stale_ssh_socket_test.go`:
- stale socket removed, live socket and a regular file kept,
- missing dir is a no-op,
- `ControlMaster`/`ControlPersist`/`ConnectTimeout` opts preserved,
- an error-classification matrix asserting only `ECONNREFUSED`/`ENOENT` mark a socket stale (timeout / `EACCES` / `EMFILE` / generic / nil all keep it).

`gofmt -l` clean, `go vet` clean, `go build ./...` clean.
