### PR TITLE
feat(session): default within-group session order to creation order (group_sort toggle) + fix orphan sub-session shuffle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`group_sort` config option to choose within-group session ordering.** Sessions inside a group now display in **creation order by default** (honoring the `K`/`J` manual reorder), instead of the status/recency "actionable" sort. Set `group_sort = "actionable"` in `config.toml` to restore the issue [#857](https://github.com/asheshgoplani/agent-deck/issues/857) most-recently-actionable-first behavior. Pin-top/pin-bottom and the Maestro supervisor still surface as before in both modes.
+
+### Fixed
+
+- **Orphaned sub-sessions no longer shuffle position between renders.** Sub-sessions whose parent session lives in a different group were emitted in Go's randomized map-iteration order, so they jumped around on each redraw. They now render in a stable order (by persisted `Order`).
+
 ## [1.9.71] - 2026-06-17
 
 ### Fixed
@@ -102,13 +110,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **An operator's per-session model choice now survives `session restart`** ([#1445](https://github.com/asheshgoplani/agent-deck/pull/1445), closes [#1436](https://github.com/asheshgoplani/agent-deck/issues/1436)). Follow-up to [#1431](https://github.com/asheshgoplani/agent-deck/issues/1431), which made `[claude].default_model` honored at spawn and restart. A new tool-agnostic `model` field — `agent-deck session set <id> model <m>` — persists the selected model into the per-session store each command builder already reads on start/restart (Claude/Gemini/OpenCode/Codex), so a model switched after launch is relaunched on the operator's selection instead of reverting to the baked/default model; an empty value clears the override. The field is restart-required. Note: agent-deck cannot observe an in-pane `/model` switch typed into a running Claude session (Claude exposes no clean model readback), so the documented path is `session set <id> model <m>`.
-
 ## [1.9.61] - 2026-06-14
 
 ### Fixed
 
 - **`SaveUserConfig` no longer bloats `config.toml` with zero-value fields, and default-true settings survive an explicit `false`** ([#1383](https://github.com/asheshgoplani/agent-deck/pull/1383)). Saving the config previously rewrote every struct field, including unset zero values, so a minimal hand-written `config.toml` ballooned with defaulted keys on the first save. The serializer now omits zero-value scalars (`omitzero`) and empty collections (`omitempty`), and `stripEmptyTOMLSections` removes the orphan section headers the encoder leaves behind, keeping the on-disk file minimal. Critically, the six default-`true` booleans (e.g. global-search enabled, update checks, MCP-pool stdio fallback) were converted to `*bool` so an explicit `false` is encoded and round-trips losslessly instead of being silently dropped and reverting to its `true` default; the heartbeat interval default (15) is likewise preserved across save/reload. The populated `[mcps]`/`[groups]` sections remain protected by the existing section-drop guard and the `config.toml.bak` backup taken before every save.
-
 ## [1.9.60] - 2026-06-14
 
 ### Added
@@ -156,7 +162,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A stale DB row no longer vetoes a fresh terminal hook status** ([#1425](https://github.com/asheshgoplani/agent-deck/pull/1425), fixes [#1424](https://github.com/asheshgoplani/agent-deck/issues/1424)). The notify daemon could let a session row frozen at `running` (from a missed update, or a session created after the daemon loaded its list) override a fresh terminal status from the child's own Stop/done hook — dropping the completion entirely (no transition event, no log line). A non-terminal row now never vetoes a fresh terminal hook; the row only wins when it is itself notify-terminal (where it may be more final, e.g. `error`).
 - **Done-sentinel detection works on current Claude Code transcript formats** ([#1423](https://github.com/asheshgoplani/agent-deck/pull/1423), fixes [#1422](https://github.com/asheshgoplani/agent-deck/issues/1422)). The Stop-edge tail scan that detects a worker-printed completion sentinel had drifted from Claude Code's current transcript shape, so real completions were missed. Detection now matches the current formats, with guards that avoid reporting a PREVIOUS turn's sentinel as the current one.
 - **Session switcher review-feedback fixes** ([#1426](https://github.com/asheshgoplani/agent-deck/pull/1426), follow-up to [#1411](https://github.com/asheshgoplani/agent-deck/pull/1411)). Restores `SIGINT` handling on the attach raw-mode setup failure paths — a failure there could otherwise leave the process permanently ignoring `Ctrl+C`. Opens the in-attach switcher on the session actually in view after a notification-bar switch (`Ctrl+b 1-6`) rather than the original attach target, fixing pre-highlight / `Esc`-reattach / follow-CWD. The attached status-bar hint now reflects the configured `[hotkeys]` detach/switch bindings instead of hardcoded `ctrl+q`/`ctrl+s` (and is omitted when the switch key is unbound or collides with detach). The switcher resizes with the window; `Show` clears stale picker state when fewer than two sessions remain; and the footer `Esc` hint is context-sensitive ("back" while attached vs "close" from the overview). Documents the switcher as local-only (remote/SSH sessions use a separate attach path).
-
 ## [1.9.57] - 2026-06-12
 
 ### Fixed

--- a/docs/superpowers/plans/2026-06-13-group-creation-order-sort.md
+++ b/docs/superpowers/plans/2026-06-13-group-creation-order-sort.md
@@ -1,0 +1,616 @@
+# Group Creation-Order Sort Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make sessions within a group display in creation order by default (honoring the existing K/J manual reorder), with the issue-#857 status/recency sort kept available behind a `group_sort` config toggle, and fix the genuine non-deterministic shuffling of orphaned sub-sessions.
+
+**Architecture:** Add a `group_sort` field to `UserConfig` (`"creation"` default | `"actionable"`). A concurrency-safe package-level cache in `internal/session` holds the active mode; it is refreshed from `LoadUserConfig` (single funnel — covers TUI, web, CLI, and reloads). `SortInstancesByActionable` reads the cached mode once per call: in creation mode the normal band sorts by `Order` only; in actionable mode the existing status→recency→Order chain runs. Pin/Maestro bands are unchanged. Separately, `Flatten()` is made deterministic by sorting orphaned sub-sessions by `Order` instead of emitting them in Go map-iteration order.
+
+**Tech Stack:** Go 1.24, BurntSushi/toml, `sync/atomic`, standard `testing`. Build/test via `make build` / `go test -race -count=1 ./...`.
+
+> **Refinement over spec §2:** `SetGroupSortMode` is invoked once inside `LoadUserConfig` (the single config funnel) rather than at the `home.go`/`menu_snapshot_builder.go` call sites. This is simpler and uniformly covers reload, CLI, and web. Default mode is `"creation"`, which also covers the no-config / parse-error fallback paths.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `internal/session/userconfig.go` | User TOML config | Add `GroupSort` field + `GetGroupSort()`; call `SetGroupSortMode` in `LoadUserConfig` |
+| `internal/session/groups.go` | Group tree, in-group sort, flatten | Add cached mode (`groupSortMode`, `SetGroupSortMode`, `currentGroupSortMode`); gate normal-band sort; deterministic orphan emission |
+| `internal/session/userconfig_test.go` | Config tests | `GetGroupSort` normalization + `LoadUserConfig` sets mode |
+| `internal/session/groups_test.go` | Group/sort tests | Cached-mode tests; creation-order default test; orphan-determinism test |
+| `internal/ui/issue857_sort_actionable_test.go` | #857 regression | Pin both tests to `actionable` mode |
+| `internal/session/maestro_test.go` | Maestro band | Pin `TestSortInstancesByActionable_MaestroFirst` to `actionable` mode |
+| `CHANGELOG.md` | Release notes | `## [Unreleased]` Added + Fixed bullets |
+| `skills/agent-deck/references/config-reference.md` | Config docs | Document `group_sort` in Top-Level table |
+
+---
+
+## Task 1: Config field + accessor
+
+**Files:**
+- Modify: `internal/session/userconfig.go` (struct near `SyncTitle` ~line 75; accessor near `GetSyncTitle` ~line 1015)
+- Test: `internal/session/userconfig_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/session/userconfig_test.go`:
+
+```go
+func TestUserConfig_GetGroupSort(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", "creation"},
+		{"creation", "creation"},
+		{"actionable", "actionable"},
+		{"garbage", "creation"},
+		{"ACTIONABLE", "creation"}, // case-sensitive; only exact "actionable" opts in
+	}
+	for _, c := range cases {
+		cfg := &UserConfig{GroupSort: c.in}
+		if got := cfg.GetGroupSort(); got != c.want {
+			t.Errorf("GetGroupSort(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/session/ -run TestUserConfig_GetGroupSort`
+Expected: FAIL — `cfg.GroupSort` undefined / `GetGroupSort` undefined.
+
+- [ ] **Step 3: Add the field**
+
+In the `UserConfig` struct, after the `SyncTitle *bool` field, add:
+
+```go
+	// GroupSort controls the order of sessions within a group.
+	//   "creation"   (default) — fixed creation order; honors K/J manual reorder.
+	//   "actionable"           — issue #857 status→recency→Order surfacing.
+	// Empty or unrecognized values normalize to "creation".
+	GroupSort string `toml:"group_sort"`
+```
+
+- [ ] **Step 4: Add the accessor**
+
+After `GetSyncTitle` (~line 1020), add:
+
+```go
+// GetGroupSort returns the normalized within-group sort mode: "actionable" only
+// when explicitly set, otherwise "creation" (the default).
+func (c *UserConfig) GetGroupSort() string {
+	if c.GroupSort == "actionable" {
+		return "actionable"
+	}
+	return "creation"
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/session/ -run TestUserConfig_GetGroupSort`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/session/userconfig.go internal/session/userconfig_test.go
+git commit -m "feat(session): add group_sort config field + GetGroupSort accessor"
+```
+
+---
+
+## Task 2: Cached group-sort mode
+
+**Files:**
+- Modify: `internal/session/groups.go` (imports block lines 3-12; new code after `SortInstancesByActionable`, ~line 200)
+- Test: `internal/session/groups_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/session/groups_test.go`:
+
+```go
+func TestGroupSortMode_DefaultAndSet(t *testing.T) {
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+
+	SetGroupSortMode("creation") // normalize starting point
+	if got := currentGroupSortMode(); got != "creation" {
+		t.Fatalf("default/creation mode = %q, want creation", got)
+	}
+	SetGroupSortMode("actionable")
+	if got := currentGroupSortMode(); got != "actionable" {
+		t.Fatalf("after set actionable = %q, want actionable", got)
+	}
+	SetGroupSortMode("garbage")
+	if got := currentGroupSortMode(); got != "creation" {
+		t.Fatalf("garbage normalizes to %q, want creation", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/session/ -run TestGroupSortMode_DefaultAndSet`
+Expected: FAIL — `SetGroupSortMode` / `currentGroupSortMode` undefined.
+
+- [ ] **Step 3: Add `sync/atomic` to the imports**
+
+Change the import block in `internal/session/groups.go` to:
+
+```go
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"unicode"
+
+	"github.com/asheshgoplani/agent-deck/internal/git"
+)
+```
+
+- [ ] **Step 4: Add the cached mode**
+
+Immediately after the `SortInstancesByActionable` function (after its closing `}` at ~line 200), add:
+
+```go
+// groupSortMode caches the active within-group sort mode ("creation" or
+// "actionable"). It is refreshed from LoadUserConfig on every config (re)load,
+// so SortInstancesByActionable can read it without a disk hit and without
+// threading a parameter through the tree constructors. Defaults to "creation"
+// until SetGroupSortMode is first called.
+var groupSortMode atomic.Value // holds string
+
+// SetGroupSortMode updates the cached within-group sort mode. Any value other
+// than "actionable" normalizes to "creation".
+func SetGroupSortMode(mode string) {
+	if mode != "actionable" {
+		mode = "creation"
+	}
+	groupSortMode.Store(mode)
+}
+
+// currentGroupSortMode returns the cached mode, defaulting to "creation" when
+// it has never been set.
+func currentGroupSortMode() string {
+	if v, ok := groupSortMode.Load().(string); ok && v != "" {
+		return v
+	}
+	return "creation"
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/session/ -run TestGroupSortMode_DefaultAndSet`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/session/groups.go internal/session/groups_test.go
+git commit -m "feat(session): cached group-sort mode (SetGroupSortMode/currentGroupSortMode)"
+```
+
+---
+
+## Task 3: Wire mode into LoadUserConfig
+
+**Files:**
+- Modify: `internal/session/userconfig.go` (`LoadUserConfig` success path, just before `userConfigCache = &config`, ~line 2357)
+- Test: `internal/session/userconfig_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/session/userconfig_test.go`:
+
+```go
+func TestLoadUserConfig_SetsGroupSortMode(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+	defer ClearUserConfigCache()
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configPath := filepath.Join(agentDeckDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte("group_sort = \"actionable\"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := LoadUserConfig(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := currentGroupSortMode(); got != "actionable" {
+		t.Fatalf("LoadUserConfig did not apply group_sort: mode = %q, want actionable", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/session/ -run TestLoadUserConfig_SetsGroupSortMode`
+Expected: FAIL — mode stays `"creation"` because `LoadUserConfig` does not call `SetGroupSortMode`.
+
+- [ ] **Step 3: Apply the mode on the success path**
+
+In `LoadUserConfig`, the success path currently ends with:
+
+```go
+	normalizeUIHiddenTools(&config.UI, config.Tools)
+
+	userConfigCache = &config
+	userConfigCacheMtime = currentMtime
+	return userConfigCache, nil
+}
+```
+
+Insert the `SetGroupSortMode` call so it becomes:
+
+```go
+	normalizeUIHiddenTools(&config.UI, config.Tools)
+
+	// Keep the in-group sort mode in lockstep with the loaded config. This is
+	// the single funnel for TUI, web, and CLI; ReloadUserConfig routes through
+	// here too, so an external edit to group_sort takes effect on next load.
+	SetGroupSortMode(config.GetGroupSort())
+
+	userConfigCache = &config
+	userConfigCacheMtime = currentMtime
+	return userConfigCache, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/session/ -run TestLoadUserConfig_SetsGroupSortMode`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/session/userconfig.go internal/session/userconfig_test.go
+git commit -m "feat(session): apply group_sort mode from LoadUserConfig"
+```
+
+---
+
+## Task 4: Gate the normal-band sort (flip default to creation order)
+
+**Files:**
+- Modify: `internal/session/groups.go` (`SortInstancesByActionable`, lines 175-200)
+- Test: `internal/session/groups_test.go` (new creation-order test)
+- Modify (pin to actionable): `internal/ui/issue857_sort_actionable_test.go`, `internal/session/maestro_test.go`
+
+- [ ] **Step 1: Write the failing creation-order test**
+
+Add to `internal/session/groups_test.go`:
+
+```go
+func TestSortInstancesByActionable_CreationOrderDefault(t *testing.T) {
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+	SetGroupSortMode("creation")
+	now := time.Now()
+
+	// Statuses + recency are arranged so an actionable sort would reorder these,
+	// but creation mode must keep strict Order ascending.
+	instances := []*Instance{
+		{ID: "a", GroupPath: "g", Order: 0, Status: StatusStopped, LastAccessedAt: now.Add(-5 * time.Hour)},
+		{ID: "b", GroupPath: "g", Order: 1, Status: StatusError, LastAccessedAt: now},
+		{ID: "c", GroupPath: "g", Order: 2, Status: StatusWaiting, LastAccessedAt: now.Add(-1 * time.Minute)},
+	}
+	tree := NewGroupTree(instances)
+	got := []string{}
+	for _, s := range tree.Groups["g"].Sessions {
+		got = append(got, s.ID)
+	}
+	want := []string{"a", "b", "c"}
+	if !equalStrings(got, want) {
+		t.Fatalf("creation mode must order by Order asc; got %v want %v", got, want)
+	}
+}
+```
+
+> Note: `equalStrings` and the `time` import already exist in this package's tests (used by `pin_test.go`). If `time` is not yet imported in `groups_test.go`, add it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/session/ -run TestSortInstancesByActionable_CreationOrderDefault`
+Expected: FAIL — current code always runs the actionable chain, producing `[b, c, a]`.
+
+- [ ] **Step 3: Gate the normal band on the mode**
+
+Replace the body of `SortInstancesByActionable` (lines 175-200) with:
+
+```go
+func SortInstancesByActionable(insts []*Instance) {
+	mode := currentGroupSortMode()
+	sort.SliceStable(insts, func(i, j int) bool {
+		// Outermost key is the band: maestro (-1), pin-top (0), normal (1),
+		// pin-bottom (2) — see pinZone.
+		zi, zj := pinZone(insts[i]), pinZone(insts[j])
+		if zi != zj {
+			return zi < zj
+		}
+		// Maestro, pin-top and pin-bottom bands are fully fixed: Order only.
+		if zi != 1 {
+			return insts[i].Order < insts[j].Order
+		}
+		// Normal band. In actionable mode (issue #857) the status→recency tiers
+		// apply before Order; in creation mode (default) Order alone decides, so
+		// sessions keep their creation order (or K/J manual order).
+		if mode == "actionable" {
+			pi, pj := actionablePriority(insts[i].Status), actionablePriority(insts[j].Status)
+			if pi != pj {
+				return pi < pj
+			}
+			ai, aj := insts[i].LastAccessedAt, insts[j].LastAccessedAt
+			if !ai.Equal(aj) {
+				return ai.After(aj)
+			}
+		}
+		return insts[i].Order < insts[j].Order
+	})
+}
+```
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run: `go test ./internal/session/ -run TestSortInstancesByActionable_CreationOrderDefault`
+Expected: PASS
+
+- [ ] **Step 5: Pin the #857 UI regression tests to actionable mode**
+
+In `internal/ui/issue857_sort_actionable_test.go`, at the very start of the body of BOTH `TestSessionList_SortByActionable_RegressionFor857` and `TestSessionList_SortByActionable_TimestampTieBreak`, add:
+
+```go
+	session.SetGroupSortMode("actionable")
+	t.Cleanup(func() { session.SetGroupSortMode("creation") })
+```
+
+(Insert directly after the opening `{` of each function, before `now := time.Now()`.)
+
+- [ ] **Step 6: Pin the maestro actionable test**
+
+In `internal/session/maestro_test.go`, at the start of `TestSortInstancesByActionable_MaestroFirst` (which asserts non-maestro rows keep actionable order), add:
+
+```go
+	SetGroupSortMode("actionable")
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+```
+
+(Insert directly after the opening `{`, before `now := time.Now()`.)
+
+- [ ] **Step 7: Run the full suite and pin any remaining actionable-order failures**
+
+Run: `go test -count=1 ./internal/session/... ./internal/ui/...`
+Expected: PASS. If any *other* test fails because it asserts status/recency normal-band order (it will show a reordered `got` vs `want`), add the same two lines at the start of that test:
+
+```go
+	SetGroupSortMode("actionable")              // session package
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+```
+
+or, in the `ui` package, the `session.`-qualified form from Step 5. Do **not** add these to tests that pass — most pin/timestamp tests are unaffected.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/session/groups.go internal/session/groups_test.go \
+        internal/ui/issue857_sort_actionable_test.go internal/session/maestro_test.go
+git commit -m "feat(session): default within-group sort to creation order (group_sort toggle)"
+```
+
+---
+
+## Task 5: Deterministic orphan sub-session ordering in Flatten
+
+**Files:**
+- Modify: `internal/session/groups.go` (`Flatten`, orphan tail at lines 617-630)
+- Test: `internal/session/groups_test.go`
+
+- [ ] **Step 1: Write the failing determinism test**
+
+Add to `internal/session/groups_test.go`:
+
+```go
+func TestFlatten_OrphanSubSessionsDeterministic(t *testing.T) {
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+	SetGroupSortMode("creation")
+
+	// Three sub-sessions whose parent lives in a DIFFERENT group than they do,
+	// so they render as orphaned top-level rows in group "g". Their Order
+	// values fix the expected display order.
+	mk := func(id string, order int) *Instance {
+		return &Instance{ID: id, Title: id, GroupPath: "g", Order: order, ParentSessionID: "absent-parent"}
+	}
+	instances := []*Instance{mk("s0", 0), mk("s1", 1), mk("s2", 2)}
+
+	tree := NewGroupTree(instances)
+
+	var first []string
+	for _, it := range tree.Flatten() {
+		if it.Type == ItemTypeSession {
+			first = append(first, it.Session.ID)
+		}
+	}
+	if !equalStrings(first, []string{"s0", "s1", "s2"}) {
+		t.Fatalf("orphan order = %v, want [s0 s1 s2]", first)
+	}
+	// Repeat many times — map-iteration nondeterminism would surface a
+	// different order on some iteration.
+	for i := 0; i < 50; i++ {
+		var got []string
+		for _, it := range tree.Flatten() {
+			if it.Type == ItemTypeSession {
+				got = append(got, it.Session.ID)
+			}
+		}
+		if !equalStrings(got, first) {
+			t.Fatalf("Flatten order not stable across calls: iter %d got %v, want %v", i, got, first)
+		}
+	}
+}
+```
+
+> Note: `IsSubSession()` returns true when `ParentSessionID != ""`. Since `"absent-parent"` is not present in group `g`, these rows take the orphan path in `Flatten`.
+
+- [ ] **Step 2: Run test to verify it fails (or flakes)**
+
+Run: `go test ./internal/session/ -run TestFlatten_OrphanSubSessionsDeterministic -count=20`
+Expected: FAIL on at least one run — orphans are emitted in random Go map order.
+
+- [ ] **Step 3: Make orphan emission deterministic**
+
+In `Flatten`, replace the orphan tail (currently):
+
+```go
+			// Add any orphaned sub-sessions (parent not in this group)
+			for _, subs := range subSessionsByParent {
+				for _, sub := range subs {
+					topLevelIndex++
+					items = append(items, Item{
+						Type:          ItemTypeSession,
+						Session:       sub,
+						Level:         groupLevel + 1,
+						Path:          group.Path,
+						IsLastInGroup: topLevelIndex == topLevelCount,
+						IsSubSession:  true, // Still a sub-session, just orphaned in this group
+					})
+				}
+			}
+```
+
+with a version that flattens the remaining map into a slice and sorts by `Order`
+before emitting, so the order is independent of Go's randomized map iteration:
+
+```go
+			// Add any orphaned sub-sessions (parent not in this group). Collect
+			// the remaining map entries into a slice and sort by Order so the
+			// emission order is deterministic — iterating subSessionsByParent
+			// directly would use Go's randomized map order and shuffle these
+			// rows between renders.
+			orphans := make([]*Instance, 0, len(subSessionsByParent))
+			for _, subs := range subSessionsByParent {
+				orphans = append(orphans, subs...)
+			}
+			sort.SliceStable(orphans, func(i, j int) bool {
+				return orphans[i].Order < orphans[j].Order
+			})
+			for _, sub := range orphans {
+				topLevelIndex++
+				items = append(items, Item{
+					Type:          ItemTypeSession,
+					Session:       sub,
+					Level:         groupLevel + 1,
+					Path:          group.Path,
+					IsLastInGroup: topLevelIndex == topLevelCount,
+					IsSubSession:  true, // Still a sub-session, just orphaned in this group
+				})
+			}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/session/ -run TestFlatten_OrphanSubSessionsDeterministic -count=50`
+Expected: PASS on every iteration.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/session/groups.go internal/session/groups_test.go
+git commit -m "fix(session): deterministic orphan sub-session order in Flatten"
+```
+
+---
+
+## Task 6: Documentation (CHANGELOG + config reference)
+
+**Files:**
+- Modify: `CHANGELOG.md` (`## [Unreleased]` section, top of file ~line 8)
+- Modify: `skills/agent-deck/references/config-reference.md` (Top-Level section ~lines 29-39)
+
+- [ ] **Step 1: Add the CHANGELOG entry**
+
+Under `## [Unreleased]` (replace the empty section), add:
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- **`group_sort` config option to choose within-group session ordering.** Sessions inside a group now display in **creation order by default** (honoring the `K`/`J` manual reorder), instead of the status/recency "actionable" sort. Set `group_sort = "actionable"` in `config.toml` to restore the issue [#857](https://github.com/asheshgoplani/agent-deck/issues/857) most-recently-actionable-first behavior. Pin-top/pin-bottom and the Maestro supervisor still surface as before in both modes.
+
+### Fixed
+
+- **Orphaned sub-sessions no longer shuffle position between renders.** Sub-sessions whose parent session lives in a different group were emitted in Go's randomized map-iteration order, so they jumped around on each redraw. They now render in a stable order (by persisted `Order`).
+```
+
+- [ ] **Step 2: Document `group_sort` in the config reference**
+
+In `skills/agent-deck/references/config-reference.md`, in the Top-Level example block (~line 32) add a line:
+
+```toml
+group_sort   = "creation"  # within-group order: "creation" (default) or "actionable"
+```
+
+and add a row to the Top-Level table (after the `sync_title` row, ~line 39):
+
+```markdown
+| `group_sort` | string | `"creation"` | Order of sessions within a group. `"creation"` (default) keeps the order sessions were created in, and respects the `K`/`J` manual reorder. `"actionable"` restores the issue #857 sort that surfaces the most recently actionable sessions (error → waiting → running → idle → stopped, then recency) to the top of each group. Pin and Maestro rows are unaffected by this setting. |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md skills/agent-deck/references/config-reference.md
+git commit -m "docs: document group_sort config and orphan-order fix"
+```
+
+---
+
+## Task 7: Full local CI gate (definition of done)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format and vet**
+
+Run: `go fmt ./... && go vet ./internal/session/... ./internal/ui/... ./internal/web/...`
+Expected: no diff from `go fmt`, no vet errors.
+
+- [ ] **Step 2: Lint**
+
+Run: `golangci-lint run`
+Expected: no findings in the changed files.
+
+- [ ] **Step 3: Race-enabled test suite**
+
+Run: `go test -race -count=1 ./...`
+Expected: PASS (the global `groupSortMode` is exercised by serial order tests with `t.Cleanup` resets; no test in these packages uses `t.Parallel`).
+
+- [ ] **Step 4: Build**
+
+Run: `go build -o /dev/null ./cmd/agent-deck/`
+Expected: success.
+
+- [ ] **Step 5 (optional): Full local CI**
+
+Run: `make ci`
+Expected: all lefthook `pre-push` commands pass (css-verify, lint, build, test, release-tests YAML lint).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** config field (Task 1), cached mode (Task 2), wiring (Task 3), normal-band creation-order default + actionable toggle (Task 4), orphan determinism (Task 5), CHANGELOG + docs (Task 6), `make ci` DoD (Task 7). Pins/Maestro left untouched per spec.
+- **Known actionable-order tests pinned:** the two `issue857_sort_actionable_test.go` tests and `TestSortInstancesByActionable_MaestroFirst`; Task 4 Step 7 sweeps any other suite failures via the same one-liner.
+- **Global-state safety:** every test that sets the mode also registers `t.Cleanup(func(){ SetGroupSortMode("creation") })`; none of the affected files use `t.Parallel`.

--- a/docs/superpowers/specs/2026-06-13-group-creation-order-sort-design.md
+++ b/docs/superpowers/specs/2026-06-13-group-creation-order-sort-design.md
@@ -158,6 +158,13 @@ orphans, so `IsLastInGroup` math is unaffected.
 | `internal/session/groups.go` | cached mode (`SetGroupSortMode`/`currentGroupSortMode`); normal-band sort branch; deterministic orphan emission in `Flatten` |
 | `internal/ui/home.go` | call `SetGroupSortMode` on config load/reload |
 | `internal/web/menu_snapshot_builder.go` | call `SetGroupSortMode` before building tree |
+| `CHANGELOG.md` | `## [Unreleased]` entry: **Added** `group_sort` config; **Fixed** orphan sub-session shuffle |
+| `README.md` | document `group_sort` in the config-options reference |
+
+> **CODEOWNERS note:** `internal/session/` is a protected hot path owned by
+> `@asheshgoplani`; this PR edits it, so maintainer review is mandatory. New
+> exported symbols (`SetGroupSortMode`, `UserConfig.GetGroupSort`) carry Go doc
+> comments (CodeRabbit nudges for docstrings + unit tests).
 
 ## Testing
 
@@ -173,6 +180,23 @@ orphans, so `IsLastInGroup` math is unaffected.
 - **K/J survives:** after a manual reorder (which rewrites `Order`), creation
   mode renders in the new manual order, and it persists across a tree rebuild.
 - **Pins/Maestro:** pin-top/pin-bottom/maestro still surface in creation mode.
+
+## Definition of done (agent-deck PR requirements)
+
+- **Local CI green** via `make ci` (lefthook): `gofmt` clean, `go vet ./...`,
+  `make css-verify`, `golangci-lint run`, `go build ./cmd/agent-deck/`,
+  `go test -race -count=1 ./...`, release-tests YAML lint. Tests are
+  deterministic and depend on no external state (orphan-determinism test
+  satisfies this explicitly).
+- **CHANGELOG.md** updated under `## [Unreleased]` (Added + Fixed bullets, with
+  the PR link once opened).
+- **Docs**: `group_sort` documented in the README config reference; doc comments
+  on new exported symbols.
+- **Conventional-commit** messages (`feat:` for the toggle, `fix:` for the
+  orphan determinism, or a single squashed `feat:` referencing both); branch
+  `feature/group-creation-order-sort` off `main`.
+- **PR**: clear description, reference the related issue, maintainer
+  (`@asheshgoplani`) review for the `internal/session/` change.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-13-group-creation-order-sort-design.md
+++ b/docs/superpowers/specs/2026-06-13-group-creation-order-sort-design.md
@@ -1,0 +1,181 @@
+# Group Creation-Order Sort — Design
+
+**Date:** 2026-06-13
+**Status:** Approved (pending spec review)
+**Branch:** `feature/group-creation-order-sort`
+
+## Problem
+
+Sessions displayed inside a group do not preserve their creation order. They
+"randomly reorganize." Two distinct mechanisms cause this:
+
+1. **Intentional automatic reordering (issue #857).** Within a group's *normal*
+   band, `SortInstancesByActionable` (`internal/session/groups.go:175`) sorts by
+   status priority, then `LastAccessedAt` (recency), using `Order` only as a
+   final tie-breaker. So a session jumps position whenever its status changes or
+   it is touched. To the user this reads as random shuffling.
+
+2. **A genuine non-determinism bug.** In `Flatten()`
+   (`internal/session/groups.go:619`), *orphaned* sub-sessions (sub-sessions
+   whose parent session lives in a different group) are bucketed into a Go
+   `map[string][]*Instance` and emitted in **map iteration order**, which Go
+   randomizes on every render. Those rows genuinely shuffle between renders even
+   with no state change.
+
+## Goal
+
+Sessions inside a group display in **creation order by default**, with the
+existing K/J manual reorder still able to override and persist that order. Make
+the automatic actionable sort opt-in via config. Eliminate the orphan
+sub-session non-determinism entirely.
+
+## Key facts (verified)
+
+- `Order` **is** creation order. New sessions get `inst.Order = len(group.Sessions)`
+  at insertion (`groups.go:923`, `groups.go:1345`) — a monotonic position.
+- K/J manual reorder rewrites `Order` (`groups.go:766,813,831,891`) and it
+  persists through the `sort_order` column (`statedb` `LoadInstances ... ORDER BY
+  sort_order`). So **sorting the normal band by `Order` alone yields creation
+  order by default and the user's manual order after K/J.**
+- `SortInstancesByActionable` is called only at tree construction, in two places:
+  `NewGroupTree` (`groups.go:242`) and `NewGroupTreeWithGroups` (`groups.go:312`).
+- Pin zones (pin-top / pin-bottom) and Maestro are an outer sort band
+  (`pinZone`, `groups.go:119`) applied in both the load-time sort and the live
+  `stablePinPartition` in `Flatten()`. These are explicit user actions and are
+  **out of scope** — they keep surfacing in both modes.
+
+## Decisions
+
+- **Config toggle, default creation order.** Keep the actionable sort available
+  for users who prefer it (preserves the #857 feature). Default is creation order.
+- **Cached package-level mode** for wiring (not an explicit constructor
+  parameter), to avoid churning the ~6 constructor call sites and their tests.
+- **Pins / Maestro keep surfacing** in both modes.
+
+## Design
+
+### 1. Config field
+
+Add to `UserConfig` (`internal/session/userconfig.go`):
+
+```go
+// GroupSort controls the order of sessions within a group.
+//   "creation"   (default) — fixed creation order; honors K/J manual reorder.
+//   "actionable"           — issue #857 status→recency→Order surfacing.
+// Empty or unrecognized values normalize to "creation".
+GroupSort string `toml:"group_sort"`
+```
+
+Accessor:
+
+```go
+func (c *UserConfig) GetGroupSort() string {
+    switch c.GroupSort {
+    case "actionable":
+        return "actionable"
+    default:
+        return "creation"
+    }
+}
+```
+
+`config.toml` example documentation: `group_sort = "creation"  # or "actionable"`.
+
+### 2. Cached mode in the `session` package
+
+A package-level, concurrency-safe cache so the sort can read the mode without a
+disk hit and without changing constructor signatures:
+
+```go
+// groupSortMode caches the active group-sort mode ("creation"|"actionable").
+// Defaults to "creation" until SetGroupSortMode is called.
+var groupSortMode atomic.Value // string
+
+func SetGroupSortMode(mode string) {
+    if mode != "actionable" {
+        mode = "creation"
+    }
+    groupSortMode.Store(mode)
+}
+
+func currentGroupSortMode() string {
+    if v, ok := groupSortMode.Load().(string); ok && v != "" {
+        return v
+    }
+    return "creation"
+}
+```
+
+Callers of `SetGroupSortMode(cfg.GetGroupSort())`:
+- UI on config load **and** on reload (`internal/ui/home.go`, where the tree is
+  rebuilt at `~4223`/`4236` and wherever config is (re)loaded).
+- Web snapshot builder before it builds the tree
+  (`internal/web/menu_snapshot_builder.go:15`).
+
+Tests set the mode directly via `SetGroupSortMode`.
+
+### 3. Normal-band sort change
+
+Refactor the normal-band branch of `SortInstancesByActionable`
+(`groups.go:189-198`). Outer keys (pin zone, and Order within
+maestro/pin-top/pin-bottom bands) are unchanged. Only the *normal* band differs:
+
+```go
+// Normal (1) band:
+if currentGroupSortMode() == "actionable" {
+    pi, pj := actionablePriority(insts[i].Status), actionablePriority(insts[j].Status)
+    if pi != pj {
+        return pi < pj
+    }
+    ai, aj := insts[i].LastAccessedAt, insts[j].LastAccessedAt
+    if !ai.Equal(aj) {
+        return ai.After(aj)
+    }
+}
+// creation mode (default) and actionable tie-breaker: Order only.
+return insts[i].Order < insts[j].Order
+```
+
+`stablePinPartition` (used live in `Flatten`) is unchanged — it already leaves
+the normal band in its load-time order, which is now creation order.
+
+### 4. Orphan sub-session determinism fix (both modes)
+
+In `Flatten()`, replace the random map-iteration tail
+(`for _, subs := range subSessionsByParent { ... }`, `groups.go:618-630`) with a
+deterministic pass: collect the remaining orphan sub-sessions into a single
+slice and `sort.SliceStable` by `Order` before appending them as top-level
+items. This is a strict bug fix and applies regardless of `group_sort` mode.
+
+The `topLevelCount` pre-count loop earlier in `Flatten` already counts these
+orphans, so `IsLastInGroup` math is unaffected.
+
+## Components touched
+
+| File | Change |
+|------|--------|
+| `internal/session/userconfig.go` | `GroupSort` field + `GetGroupSort()` |
+| `internal/session/groups.go` | cached mode (`SetGroupSortMode`/`currentGroupSortMode`); normal-band sort branch; deterministic orphan emission in `Flatten` |
+| `internal/ui/home.go` | call `SetGroupSortMode` on config load/reload |
+| `internal/web/menu_snapshot_builder.go` | call `SetGroupSortMode` before building tree |
+
+## Testing
+
+- **Default → creation order:** with no config (mode unset/`creation`), a group
+  of sessions with shuffled statuses and `LastAccessedAt` renders strictly by
+  `Order`.
+- **Orphan determinism:** a group containing orphaned sub-sessions returns the
+  same `Flatten()` order across many repeated calls (guards against map-order
+  regression); assert in both modes.
+- **Actionable preserved:** existing `internal/ui/issue857_sort_actionable_test.go`
+  and related tests set `SetGroupSortMode("actionable")` in setup and continue to
+  pass unchanged.
+- **K/J survives:** after a manual reorder (which rewrites `Order`), creation
+  mode renders in the new manual order, and it persists across a tree rebuild.
+- **Pins/Maestro:** pin-top/pin-bottom/maestro still surface in creation mode.
+
+## Out of scope
+
+- The K/J manual reorder mechanism itself (already implemented; only relied upon).
+- Pin and Maestro behavior (unchanged).
+- Group-level ordering (`GroupList`) — only *within-group* session ordering changes.

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -664,7 +664,13 @@ func (t *GroupTree) Flatten() []Item {
 				orphans = append(orphans, subs...)
 			}
 			sort.SliceStable(orphans, func(i, j int) bool {
-				return orphans[i].Order < orphans[j].Order
+				if orphans[i].Order != orphans[j].Order {
+					return orphans[i].Order < orphans[j].Order
+				}
+				// Tie-break on ID so equal-Order orphans (collected from the
+				// randomized subSessionsByParent map) still emit in a stable,
+				// run-independent order rather than leaking map-iteration order.
+				return orphans[i].ID < orphans[j].ID
 			})
 			for _, sub := range orphans {
 				topLevelIndex++

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -651,19 +651,28 @@ func (t *GroupTree) Flatten() []Item {
 				topLevelIndex++
 			}
 
-			// Add any orphaned sub-sessions (parent not in this group)
+			// Add any orphaned sub-sessions (parent not in this group). Collect
+			// the remaining map entries into a slice and sort by Order so the
+			// emission order is deterministic — iterating subSessionsByParent
+			// directly would use Go's randomized map order and shuffle these
+			// rows between renders.
+			orphans := make([]*Instance, 0, len(subSessionsByParent))
 			for _, subs := range subSessionsByParent {
-				for _, sub := range subs {
-					topLevelIndex++
-					items = append(items, Item{
-						Type:          ItemTypeSession,
-						Session:       sub,
-						Level:         groupLevel + 1,
-						Path:          group.Path,
-						IsLastInGroup: topLevelIndex == topLevelCount,
-						IsSubSession:  true, // Still a sub-session, just orphaned in this group
-					})
-				}
+				orphans = append(orphans, subs...)
+			}
+			sort.SliceStable(orphans, func(i, j int) bool {
+				return orphans[i].Order < orphans[j].Order
+			})
+			for _, sub := range orphans {
+				topLevelIndex++
+				items = append(items, Item{
+					Type:          ItemTypeSession,
+					Session:       sub,
+					Level:         groupLevel + 1,
+					Path:          group.Path,
+					IsLastInGroup: topLevelIndex == topLevelCount,
+					IsSubSession:  true, // Still a sub-session, just orphaned in this group
+				})
 			}
 		}
 	}

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -159,15 +159,21 @@ func stablePinPartition(insts []*Instance) {
 	})
 }
 
-// SortInstancesByActionable sorts the given slice in place so the most
-// recently actionable sessions surface first within a group (issue #857),
-// while honoring per-session pins (pin-sessions feature). The outermost key is
-// the pin zone (see pinZone); within the normal zone the existing actionable
-// tiers apply, and within the pin-top/pin-bottom bands sessions are ordered by
-// Order alone (fully fixed — status and recency are ignored, so K/J reordering
-// still works inside a band).
+// SortInstancesByActionable sorts the given slice in place according to the
+// active within-group sort mode (see SetGroupSortMode), while honoring
+// per-session pins (pin-sessions feature). The outermost key is the pin zone
+// (see pinZone); within the normal zone the sort depends on mode:
 //
-// Normal zone key precedence:
+//   - "creation" (default): Order asc only — sessions keep their creation /
+//     K/J manual order unchanged.
+//   - "actionable" (issue #857): status→recency tiers apply before Order so
+//     the most recently actionable sessions surface first.
+//
+// Pin-top and pin-bottom bands are always ordered by Order alone (fully fixed
+// — status and recency are ignored, so K/J reordering still works inside a
+// band).
+//
+// Actionable-mode normal-zone key precedence:
 //
 //  1. actionablePriority(Status)   asc  — error/waiting/running first
 //  2. LastAccessedAt              desc  — recent attention first
@@ -176,6 +182,7 @@ func stablePinPartition(insts []*Instance) {
 //     (TestSessionOrderPersistence,
 //     TestSessionOrderMigration)
 func SortInstancesByActionable(insts []*Instance) {
+	mode := currentGroupSortMode()
 	sort.SliceStable(insts, func(i, j int) bool {
 		// The outermost key is the band: maestro (the fleet supervisor, a fixed
 		// point of reference that surfaces first regardless of status), then
@@ -189,14 +196,18 @@ func SortInstancesByActionable(insts []*Instance) {
 		if zi != 1 {
 			return insts[i].Order < insts[j].Order
 		}
-		// Normal (1) band keeps the actionable tiers.
-		pi, pj := actionablePriority(insts[i].Status), actionablePriority(insts[j].Status)
-		if pi != pj {
-			return pi < pj
-		}
-		ai, aj := insts[i].LastAccessedAt, insts[j].LastAccessedAt
-		if !ai.Equal(aj) {
-			return ai.After(aj)
+		// Normal band. In actionable mode (issue #857) the status→recency tiers
+		// apply before Order; in creation mode (default) Order alone decides, so
+		// sessions keep their creation order (or K/J manual order).
+		if mode == "actionable" {
+			pi, pj := actionablePriority(insts[i].Status), actionablePriority(insts[j].Status)
+			if pi != pj {
+				return pi < pj
+			}
+			ai, aj := insts[i].LastAccessedAt, insts[j].LastAccessedAt
+			if !ai.Equal(aj) {
+				return ai.After(aj)
+			}
 		}
 		return insts[i].Order < insts[j].Order
 	})

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"unicode"
 
 	"github.com/asheshgoplani/agent-deck/internal/git"
@@ -199,6 +200,31 @@ func SortInstancesByActionable(insts []*Instance) {
 		}
 		return insts[i].Order < insts[j].Order
 	})
+}
+
+// groupSortMode caches the active within-group sort mode ("creation" or
+// "actionable"). It is refreshed from LoadUserConfig on every config (re)load,
+// so SortInstancesByActionable can read it without a disk hit and without
+// threading a parameter through the tree constructors. Defaults to "creation"
+// until SetGroupSortMode is first called.
+var groupSortMode atomic.Value // holds string
+
+// SetGroupSortMode updates the cached within-group sort mode. Any value other
+// than "actionable" normalizes to "creation".
+func SetGroupSortMode(mode string) {
+	if mode != "actionable" {
+		mode = "creation"
+	}
+	groupSortMode.Store(mode)
+}
+
+// currentGroupSortMode returns the cached mode, defaulting to "creation" when
+// it has never been set.
+func currentGroupSortMode() string {
+	if v, ok := groupSortMode.Load().(string); ok && v != "" {
+		return v
+	}
+	return "creation"
 }
 
 // NewGroupTree creates a new group tree from instances

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -117,7 +117,8 @@ func actionablePriority(s Status) int {
 //	-1 maestro      the fleet supervisor — a fixed point of reference that
 //	                surfaces above everything, including pin-top
 //	0  pin-top      fixed at the top, exempt from status/recency
-//	1  normal       the existing actionable sort (status → recency → Order)
+//	1  normal       the within-group sort (creation Order, or actionable
+//	                status → recency → Order — see group_sort config)
 //	2  pin-bottom   fixed at the bottom, exempt from status/recency
 func pinZone(inst *Instance) int {
 	if inst.IsMaestro() {
@@ -137,9 +138,10 @@ func pinZone(inst *Instance) int {
 // pin-bottom bands (pinZone), preserving the relative order of sessions within
 // each band. Unlike SortInstancesByActionable it never reorders by
 // status/recency, so it is safe to run on every render (Flatten): it moves only
-// pinned rows, leaving the load-time actionable order — and any live K/J manual
-// order — of the normal band untouched. This is what makes a pin edit take
-// effect live instead of only after a restart.
+// pinned rows, leaving the load-time order (creation or actionable, per the
+// group_sort config) — and any live K/J manual order — of the normal band
+// untouched. This is what makes a pin edit take effect live instead of only
+// after a restart.
 func stablePinPartition(insts []*Instance) {
 	sort.SliceStable(insts, func(i, j int) bool {
 		zi, zj := pinZone(insts[i]), pinZone(insts[j])
@@ -153,8 +155,9 @@ func stablePinPartition(insts []*Instance) {
 		if zi != 1 {
 			return insts[i].Order < insts[j].Order
 		}
-		// Normal (1) band is already actionable-sorted at load; return false so
-		// SliceStable leaves its relative order untouched.
+		// Normal (1) band is already sorted at load (creation Order, or actionable
+		// per group_sort); return false so SliceStable leaves its relative order
+		// untouched.
 		return false
 	})
 }

--- a/internal/session/groups_test.go
+++ b/internal/session/groups_test.go
@@ -2099,3 +2099,20 @@ func TestDemoteSession_WithChildrenNoOp(t *testing.T) {
 		t.Errorf("p2's children should be unchanged; got %v, want %v", gotKids, wantKids)
 	}
 }
+
+func TestGroupSortMode_DefaultAndSet(t *testing.T) {
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+
+	SetGroupSortMode("creation") // normalize starting point
+	if got := currentGroupSortMode(); got != "creation" {
+		t.Fatalf("default/creation mode = %q, want creation", got)
+	}
+	SetGroupSortMode("actionable")
+	if got := currentGroupSortMode(); got != "actionable" {
+		t.Fatalf("after set actionable = %q, want actionable", got)
+	}
+	SetGroupSortMode("garbage")
+	if got := currentGroupSortMode(); got != "creation" {
+		t.Fatalf("garbage normalizes to %q, want creation", got)
+	}
+}

--- a/internal/session/groups_test.go
+++ b/internal/session/groups_test.go
@@ -2116,3 +2116,26 @@ func TestGroupSortMode_DefaultAndSet(t *testing.T) {
 		t.Fatalf("garbage normalizes to %q, want creation", got)
 	}
 }
+
+func TestSortInstancesByActionable_CreationOrderDefault(t *testing.T) {
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+	SetGroupSortMode("creation")
+	now := time.Now()
+
+	// Statuses + recency are arranged so an actionable sort would reorder these,
+	// but creation mode must keep strict Order ascending.
+	instances := []*Instance{
+		{ID: "a", GroupPath: "g", Order: 0, Status: StatusStopped, LastAccessedAt: now.Add(-5 * time.Hour)},
+		{ID: "b", GroupPath: "g", Order: 1, Status: StatusError, LastAccessedAt: now},
+		{ID: "c", GroupPath: "g", Order: 2, Status: StatusWaiting, LastAccessedAt: now.Add(-1 * time.Minute)},
+	}
+	tree := NewGroupTree(instances)
+	got := []string{}
+	for _, s := range tree.Groups["g"].Sessions {
+		got = append(got, s.ID)
+	}
+	want := []string{"a", "b", "c"}
+	if !equalStrings(got, want) {
+		t.Fatalf("creation mode must order by Order asc; got %v want %v", got, want)
+	}
+}

--- a/internal/session/groups_test.go
+++ b/internal/session/groups_test.go
@@ -2139,3 +2139,45 @@ func TestSortInstancesByActionable_CreationOrderDefault(t *testing.T) {
 		t.Fatalf("creation mode must order by Order asc; got %v want %v", got, want)
 	}
 }
+
+func TestFlatten_OrphanSubSessionsDeterministic(t *testing.T) {
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+	SetGroupSortMode("creation")
+
+	// Three sub-sessions whose parent lives in a DIFFERENT group than they do,
+	// so they render as orphaned top-level rows in group "g". Their Order
+	// values fix the expected display order.
+	mk := func(id string, order int, parent string) *Instance {
+		return &Instance{ID: id, Title: id, GroupPath: "g", Order: order, ParentSessionID: parent}
+	}
+	instances := []*Instance{
+		mk("s0", 0, "absent-p0"),
+		mk("s1", 1, "absent-p1"),
+		mk("s2", 2, "absent-p2"),
+	}
+
+	tree := NewGroupTree(instances)
+
+	var first []string
+	for _, it := range tree.Flatten() {
+		if it.Type == ItemTypeSession {
+			first = append(first, it.Session.ID)
+		}
+	}
+	if !equalStrings(first, []string{"s0", "s1", "s2"}) {
+		t.Fatalf("orphan order = %v, want [s0 s1 s2]", first)
+	}
+	// Repeat many times — map-iteration nondeterminism would surface a
+	// different order on some iteration.
+	for i := 0; i < 50; i++ {
+		var got []string
+		for _, it := range tree.Flatten() {
+			if it.Type == ItemTypeSession {
+				got = append(got, it.Session.ID)
+			}
+		}
+		if !equalStrings(got, first) {
+			t.Fatalf("Flatten order not stable across calls: iter %d got %v, want %v", i, got, first)
+		}
+	}
+}

--- a/internal/session/groups_test.go
+++ b/internal/session/groups_test.go
@@ -2181,3 +2181,42 @@ func TestFlatten_OrphanSubSessionsDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// When orphaned sub-sessions share the same Order, the sort must still be
+// deterministic: without an ID tie-break, SliceStable would preserve the
+// randomized map-iteration order of subSessionsByParent and the rows could
+// drift between renders. They must emit in ID order.
+func TestFlatten_OrphanSubSessionsDeterministic_TiedOrder(t *testing.T) {
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+	SetGroupSortMode("creation")
+
+	// All orphans share Order 0 and live in distinct parent buckets, so the only
+	// stable discriminator is ID.
+	mk := func(id, parent string) *Instance {
+		return &Instance{ID: id, Title: id, GroupPath: "g", Order: 0, ParentSessionID: parent}
+	}
+	instances := []*Instance{
+		mk("s2", "absent-p2"),
+		mk("s0", "absent-p0"),
+		mk("s1", "absent-p1"),
+	}
+
+	tree := NewGroupTree(instances)
+
+	collect := func() []string {
+		var got []string
+		for _, it := range tree.Flatten() {
+			if it.Type == ItemTypeSession {
+				got = append(got, it.Session.ID)
+			}
+		}
+		return got
+	}
+
+	want := []string{"s0", "s1", "s2"} // ID order, independent of input/map order
+	for i := 0; i < 50; i++ {
+		if got := collect(); !equalStrings(got, want) {
+			t.Fatalf("tied-Order orphans not deterministic: iter %d got %v, want %v", i, got, want)
+		}
+	}
+}

--- a/internal/session/maestro_test.go
+++ b/internal/session/maestro_test.go
@@ -38,6 +38,8 @@ func TestIsMaestro_ExactTitleOnly(t *testing.T) {
 // a stopped supervisor still outranks a running worker, because the row is
 // a fixed point of reference (the fleet supervisor), not an activity item.
 func TestSortInstancesByActionable_MaestroFirst(t *testing.T) {
+	SetGroupSortMode("actionable")
+	t.Cleanup(func() { SetGroupSortMode("creation") })
 	now := time.Now()
 	maestro := &Instance{Title: "conductor-maestro", Status: StatusStopped, LastAccessedAt: now.Add(-24 * time.Hour), Order: 5}
 	worker := &Instance{Title: "busy-worker", Status: StatusRunning, LastAccessedAt: now, Order: 0}

--- a/internal/session/maestro_test.go
+++ b/internal/session/maestro_test.go
@@ -60,6 +60,33 @@ func TestSortInstancesByActionable_MaestroFirst(t *testing.T) {
 	}
 }
 
+// In the default "creation" mode the maestro still surfaces first within its
+// group (it is band -1, exempt from the normal-band sort), and the non-maestro
+// rows follow in creation Order — not status/recency. Guards the pin/Maestro
+// invariant for the group_sort default.
+func TestSortInstancesByActionable_MaestroFirst_CreationMode(t *testing.T) {
+	SetGroupSortMode("creation")
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+	now := time.Now()
+	maestro := &Instance{Title: "conductor-maestro", Status: StatusStopped, LastAccessedAt: now.Add(-24 * time.Hour), Order: 5}
+	worker := &Instance{Title: "busy-worker", Status: StatusRunning, LastAccessedAt: now, Order: 0}
+	conductor := &Instance{Title: "conductor-agent-deck", Status: StatusWaiting, LastAccessedAt: now, Order: 1}
+
+	insts := []*Instance{worker, conductor, maestro}
+	SortInstancesByActionable(insts)
+
+	if insts[0].Title != "conductor-maestro" {
+		t.Fatalf("maestro must sort first even in creation mode; got: %s, %s, %s",
+			insts[0].Title, insts[1].Title, insts[2].Title)
+	}
+	// Non-maestro rows follow by creation Order (worker=0 before conductor=1),
+	// NOT by actionable status (which would put the waiting conductor first).
+	if insts[1].Title != "busy-worker" || insts[2].Title != "conductor-agent-deck" {
+		t.Fatalf("non-maestro rows must order by creation Order; got: %s, %s",
+			insts[1].Title, insts[2].Title)
+	}
+}
+
 // The group containing the maestro must be pinned to the very top of the
 // group list — above even the legacy "conductor" group pin (Order=-1).
 func TestGroupTree_MaestroGroupPinnedFirst(t *testing.T) {

--- a/internal/session/pin_test.go
+++ b/internal/session/pin_test.go
@@ -9,6 +9,8 @@ import (
 // sessions first, then normal (status/recency), then pin-bottom — regardless
 // of each session's status. The pin bands are "fully fixed".
 func TestSortInstancesByActionable_PinZones(t *testing.T) {
+	SetGroupSortMode("actionable")
+	t.Cleanup(func() { SetGroupSortMode("creation") })
 	now := time.Now()
 	// A pin-bottom session in error state would, under the plain status sort,
 	// jump to the very top. It must instead sink to the pin-bottom band.

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2515,6 +2515,11 @@ func LoadUserConfig() (*UserConfig, error) {
 
 	normalizeUIHiddenTools(&config.UI, config.Tools)
 
+	// Keep the in-group sort mode in lockstep with the loaded config. This is
+	// the single funnel for TUI, web, and CLI; ReloadUserConfig routes through
+	// here too, so an external edit to group_sort takes effect on next load.
+	SetGroupSortMode(config.GetGroupSort())
+
 	userConfigCache = &config
 	userConfigCacheMtime = currentMtime
 	return userConfigCache, nil

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2483,6 +2483,7 @@ func LoadUserConfig() (*UserConfig, error) {
 		fresh := cloneDefaultUserConfig()
 		userConfigCache = &fresh
 		userConfigCacheMtime = time.Time{}
+		SetGroupSortMode(fresh.GetGroupSort())
 		return userConfigCache, nil
 	}
 
@@ -2490,6 +2491,7 @@ func LoadUserConfig() (*UserConfig, error) {
 		fresh := cloneDefaultUserConfig()
 		userConfigCache = &fresh
 		userConfigCacheMtime = time.Time{}
+		SetGroupSortMode(fresh.GetGroupSort())
 		return userConfigCache, nil
 	}
 
@@ -2500,6 +2502,7 @@ func LoadUserConfig() (*UserConfig, error) {
 		fresh := cloneDefaultUserConfig()
 		userConfigCache = &fresh
 		userConfigCacheMtime = currentMtime
+		SetGroupSortMode(fresh.GetGroupSort())
 		return userConfigCache, fmt.Errorf("config.toml parse error: %w", err)
 	}
 

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -85,7 +85,7 @@ type UserConfig struct {
 	//   "creation"   (default) — fixed creation order; honors K/J manual reorder.
 	//   "actionable"           — issue #857 status→recency→Order surfacing.
 	// Empty or unrecognized values normalize to "creation".
-	GroupSort string `toml:"group_sort"`
+	GroupSort string `toml:"group_sort,omitempty"`
 
 	// MCPs defines available MCP servers for the MCP Manager
 	// These can be attached/detached per-project via the MCP Manager (M key)

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -81,6 +81,12 @@ type UserConfig struct {
 	// Default: true (nil = true)
 	SyncTitle *bool `toml:"sync_title,omitempty"`
 
+	// GroupSort controls the order of sessions within a group.
+	//   "creation"   (default) — fixed creation order; honors K/J manual reorder.
+	//   "actionable"           — issue #857 status→recency→Order surfacing.
+	// Empty or unrecognized values normalize to "creation".
+	GroupSort string `toml:"group_sort"`
+
 	// MCPs defines available MCP servers for the MCP Manager
 	// These can be attached/detached per-project via the MCP Manager (M key)
 	MCPs map[string]MCPDef `toml:"mcps,omitempty"`
@@ -1144,6 +1150,15 @@ func (c *UserConfig) GetSyncTitle() bool {
 		return true
 	}
 	return *c.SyncTitle
+}
+
+// GetGroupSort returns the normalized within-group sort mode: "actionable" only
+// when explicitly set, otherwise "creation" (the default).
+func (c *UserConfig) GetGroupSort() string {
+	if c.GroupSort == "actionable" {
+		return "actionable"
+	}
+	return "creation"
 }
 
 // ClaudeSettings defines Claude Code configuration

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -2486,3 +2486,19 @@ func TestSaveUserConfig_PreservesDefaultTrueBoolsSetToFalse(t *testing.T) {
 		t.Error("GlobalSearch.Enabled: expected false after round-trip, got true")
 	}
 }
+
+func TestUserConfig_GetGroupSort(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", "creation"},
+		{"creation", "creation"},
+		{"actionable", "actionable"},
+		{"garbage", "creation"},
+		{"ACTIONABLE", "creation"}, // case-sensitive; only exact "actionable" opts in
+	}
+	for _, c := range cases {
+		cfg := &UserConfig{GroupSort: c.in}
+		if got := cfg.GetGroupSort(); got != c.want {
+			t.Errorf("GetGroupSort(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -2502,3 +2502,29 @@ func TestUserConfig_GetGroupSort(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadUserConfig_SetsGroupSortMode(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	ClearUserConfigCache()
+	defer ClearUserConfigCache()
+	t.Cleanup(func() { SetGroupSortMode("creation") })
+
+	agentDeckDir := filepath.Join(tempDir, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configPath := filepath.Join(agentDeckDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte("group_sort = \"actionable\"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := LoadUserConfig(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := currentGroupSortMode(); got != "actionable" {
+		t.Fatalf("LoadUserConfig did not apply group_sort: mode = %q, want actionable", got)
+	}
+}

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -2528,3 +2528,44 @@ func TestLoadUserConfig_SetsGroupSortMode(t *testing.T) {
 		t.Fatalf("LoadUserConfig did not apply group_sort: mode = %q, want actionable", got)
 	}
 }
+
+// TestSaveUserConfig_OmitsUnsetGroupSort guards the minimal-config guarantee
+// (issue #1383 / #1360): an unset GroupSort must NOT be written, so a
+// load→mutate→save round-trip never injects group_sort = "" into a
+// previously-minimal config. A set value must still survive the round-trip.
+func TestSaveUserConfig_OmitsUnsetGroupSort(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
+
+	configPath, err := GetUserConfigPath()
+	if err != nil {
+		t.Fatalf("GetUserConfigPath: %v", err)
+	}
+
+	// Unset GroupSort must be omitted entirely.
+	if err := SaveUserConfig(&UserConfig{DefaultTool: "claude"}); err != nil {
+		t.Fatalf("SaveUserConfig (unset): %v", err)
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	if strings.Contains(string(raw), "group_sort") {
+		t.Errorf("config.toml must not contain group_sort when unset; got:\n%s", raw)
+	}
+
+	// A set GroupSort must round-trip back out.
+	if err := SaveUserConfig(&UserConfig{DefaultTool: "claude", GroupSort: "actionable"}); err != nil {
+		t.Fatalf("SaveUserConfig (set): %v", err)
+	}
+	raw, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	if !strings.Contains(string(raw), `group_sort = "actionable"`) {
+		t.Errorf("config.toml must contain a set group_sort; got:\n%s", raw)
+	}
+}

--- a/internal/ui/issue857_sort_actionable_test.go
+++ b/internal/ui/issue857_sort_actionable_test.go
@@ -31,6 +31,8 @@ import (
 // `Order` values intentionally invert the desired output so a regression to
 // the old Order-based sort flips at least four positions.
 func TestSessionList_SortByActionable_RegressionFor857(t *testing.T) {
+	session.SetGroupSortMode("actionable")
+	t.Cleanup(func() { session.SetGroupSortMode("creation") })
 	now := time.Now()
 
 	// Order values are reversed vs. the desired actionable order; the
@@ -73,6 +75,8 @@ func TestSessionList_SortByActionable_RegressionFor857(t *testing.T) {
 // the actionable session you just left should stay above one you parked
 // hours ago.
 func TestSessionList_SortByActionable_TimestampTieBreak(t *testing.T) {
+	session.SetGroupSortMode("actionable")
+	t.Cleanup(func() { session.SetGroupSortMode("creation") })
 	now := time.Now()
 
 	instances := []*session.Instance{

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -32,12 +32,14 @@ All options for `~/.agent-deck/config.toml`.
 ```toml
 default_tool = "claude"   # Pre-selected tool when creating sessions
 sync_title   = true       # Let agents rename sessions from their session-name
+group_sort   = "creation" # within-group order: "creation" (default) or "actionable"
 ```
 
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | `default_tool` | string | `"claude"` | Pre-selected tool when creating sessions. |
 | `sync_title` | bool | `true` | When `true`, agent-deck overwrites a session's title with the agent's own session-name (e.g. Claude's `--name` / `/rename`, issues #572/#697). Set `false` to keep the title you gave the session — globally, for every tool. The per-session title-lock (`agent-deck session set-title-lock <id> on`) remains as a finer-grained override. Also toggleable in the TUI Settings panel (`S`) under **SESSIONS**. |
+| `group_sort` | string | `"creation"` | Order of sessions within a group. `"creation"` (default) keeps the order sessions were created in, and respects the `K`/`J` manual reorder. `"actionable"` restores the issue #857 sort that surfaces the most recently actionable sessions (error → waiting → running → idle → stopped, then recency) to the top of each group. Pin and Maestro rows are unaffected by this setting. |
 
 ## [shell] Section
 


### PR DESCRIPTION
## Summary

Sessions inside a group could appear to "randomly reorganize." This makes within-group ordering **creation order by default**, keeps the previous status/recency sort available via config, and fixes a genuine non-determinism bug.

- **`group_sort` config option** (`"creation"` default | `"actionable"`). In creation mode the normal band sorts by persisted `Order` only, so sessions keep the order they were created in and honor the existing `K`/`J` manual reorder. `group_sort = "actionable"` restores the issue #857 most-recently-actionable-first behavior (status → recency → Order).
- **Single config funnel:** the active mode is cached in `internal/session` and refreshed from `LoadUserConfig` (covers TUI, web, CLI, and live reload). Pin-top/pin-bottom and the Maestro supervisor still surface in both modes — the gate only affects the normal band.
- **Bug fix:** orphaned sub-sessions (whose parent lives in a different group) were emitted in Go's randomized map-iteration order in `GroupTree.Flatten()`, so they shuffled between renders. They now emit in a stable order (sorted by `Order`), in both modes.

Docs updated: `CHANGELOG.md` (Unreleased) and the config reference.

## Test Plan

- [x] `go build ./...`, `gofmt`, `go vet` clean on touched packages
- [x] New unit tests: creation-order default; orphan-sub-session determinism (50-iteration stability with distinct parent buckets, verified red→green); `LoadUserConfig` applies `group_sort`; `GetGroupSort` normalization; Maestro-first preserved in creation mode
- [x] Existing issue-#857 actionable-order tests preserved by pinning them to `actionable` mode (behavior unchanged when opted in)
- [x] `go test ./internal/session/... ./internal/ui/... ./internal/web/...` — all sort/group/config tests pass

> Note: any `TestPersistence_TmuxDiesWithoutUserScope` / `TestForkDialog_Show_*` failures in a sandbox are pre-existing environment issues (cgroup features; `git init -b` needs git ≥2.28) unrelated to this change.

Makes the issue #857 actionable sort opt-in; default is now creation order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-configurable **group_sort** preference to switch unpinned in-group session ordering between **creation** and **actionable** modes.
* **Bug Fixes**
  * Updated sorting to reflect the selected mode immediately (including pin zone ordering and normal sessions).
  * Made orphan sub-session flattening deterministic across repeated views, with stable ordering even when sort values tie.
* **Tests**
  * Expanded coverage for mode switching and normalization, config load/save integration, maestro prioritization, and deterministic orphan ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->