### PR TITLE
feat(session): persist operator's per-session model across restart (#1436)

### DIFF
--- a/cmd/agent-deck/model_cmd_test.go
+++ b/cmd/agent-deck/model_cmd_test.go
@@ -181,8 +181,14 @@ func TestSessionSetModelPersists(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("re-set model failed (exit %d)\nstderr: %s", code, stderr)
 	}
-	stdout, _, _ = runAgentDeck(t, home, "session", "show", addResp.ID, "--json")
-	_ = json.Unmarshal([]byte(stdout), &showResp)
+	stdout, stderr, code = runAgentDeck(t, home, "session", "show", addResp.ID, "--json")
+	if code != 0 {
+		t.Fatalf("session show after re-set failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	showResp.ModelID = "<unparsed>"
+	if err := json.Unmarshal([]byte(stdout), &showResp); err != nil {
+		t.Fatalf("parse show response after re-set: %v\nstdout: %s", err, stdout)
+	}
 	if showResp.ModelID != "sonnet" {
 		t.Errorf("re-set model did not persist sonnet; model_id = %q", showResp.ModelID)
 	}
@@ -194,9 +200,19 @@ func TestSessionSetModelPersists(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("clear model failed (exit %d)\nstderr: %s", code, stderr)
 	}
-	stdout, _, _ = runAgentDeck(t, home, "session", "show", addResp.ID, "--json")
+	stdout, stderr, code = runAgentDeck(t, home, "session", "show", addResp.ID, "--json")
+	if code != 0 {
+		t.Fatalf("session show after clear failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	// Codex review of #1445: guard against a failed show / malformed response
+	// silently passing by asserting the show succeeded and the JSON parses
+	// (above + here). A cleared override surfaces as an empty/omitted model_id
+	// (omitempty), so "" is the cleared signal — pre-seed "" rather than a
+	// sentinel that an omitted field would not overwrite.
 	showResp.ModelID = ""
-	_ = json.Unmarshal([]byte(stdout), &showResp)
+	if err := json.Unmarshal([]byte(stdout), &showResp); err != nil {
+		t.Fatalf("parse show response after clear: %v\nstdout: %s", err, stdout)
+	}
 	if showResp.ModelID != "" {
 		t.Errorf("clear via \"\" did not reset model; model_id = %q", showResp.ModelID)
 	}

--- a/cmd/agent-deck/model_cmd_test.go
+++ b/cmd/agent-deck/model_cmd_test.go
@@ -111,3 +111,93 @@ func TestAddModelFlagPersistsAndSurfacesInStatus(t *testing.T) {
 		t.Fatalf("status --verbose missing model display; stdout: %s", stdout)
 	}
 }
+
+// TestSessionSetModelPersists asserts that `agent-deck session set <id> model <m>`
+// persists the operator's selected model into the session's tool_data so it
+// survives a restart (issue #1436, follow-up to #1431). The restart-side
+// consumption already prefers the persisted per-session model over
+// [claude].default_model (see buildClaudeExtraFlags); this verifies the
+// agent-deck-side persistence path that #1436 adds.
+//
+// Failure mode on main: `model` is not a valid mutable field, so the CLI
+// rejects the command with an "invalid field" error (non-zero exit).
+func TestSessionSetModelPersists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("subprocess CLI test skipped in short mode")
+	}
+	home := t.TempDir()
+	projectDir := filepath.Join(home, "proj")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home,
+		"add", "-t", "model-set-test", "-c", "claude", "--no-parent", "--json", projectDir,
+	)
+	if code != 0 {
+		t.Fatalf("agent-deck add failed (exit %d)\nstdout: %s\nstderr: %s", code, stdout, stderr)
+	}
+	var addResp struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &addResp); err != nil {
+		t.Fatalf("parse add response: %v\nstdout: %s", err, stdout)
+	}
+	if addResp.ID == "" {
+		t.Fatalf("add returned empty id; stdout: %s", stdout)
+	}
+
+	// Switch the model — the operator's choice we want to survive restart.
+	stdout, stderr, code = runAgentDeck(t, home,
+		"session", "set", "--json", addResp.ID, "model", "opus",
+	)
+	if code != 0 {
+		t.Fatalf(
+			"agent-deck session set <id> model failed (exit %d) — feature missing on main\n"+
+				"stdout: %s\nstderr: %s",
+			code, stdout, stderr,
+		)
+	}
+
+	// session show surfaces the persisted per-session model.
+	stdout, _, code = runAgentDeck(t, home, "session", "show", addResp.ID, "--json")
+	if code != 0 {
+		t.Fatalf("session show failed (exit %d)\nstdout: %s", code, stdout)
+	}
+	var showResp struct {
+		ModelID string `json:"model_id"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &showResp); err != nil {
+		t.Fatalf("parse show response: %v\nstdout: %s", err, stdout)
+	}
+	if showResp.ModelID != "opus" {
+		t.Errorf("session set model did not persist opus; model_id = %q\nshow: %s", showResp.ModelID, stdout)
+	}
+
+	// Re-set to a different model: the new choice must replace the old one.
+	_, stderr, code = runAgentDeck(t, home,
+		"session", "set", "--json", addResp.ID, "model", "sonnet",
+	)
+	if code != 0 {
+		t.Fatalf("re-set model failed (exit %d)\nstderr: %s", code, stderr)
+	}
+	stdout, _, _ = runAgentDeck(t, home, "session", "show", addResp.ID, "--json")
+	_ = json.Unmarshal([]byte(stdout), &showResp)
+	if showResp.ModelID != "sonnet" {
+		t.Errorf("re-set model did not persist sonnet; model_id = %q", showResp.ModelID)
+	}
+
+	// Clear via empty-string value: `model ""` must reset the override.
+	_, stderr, code = runAgentDeck(t, home,
+		"session", "set", "--json", addResp.ID, "model", "",
+	)
+	if code != 0 {
+		t.Fatalf("clear model failed (exit %d)\nstderr: %s", code, stderr)
+	}
+	stdout, _, _ = runAgentDeck(t, home, "session", "show", addResp.ID, "--json")
+	showResp.ModelID = ""
+	_ = json.Unmarshal([]byte(stdout), &showResp)
+	if showResp.ModelID != "" {
+		t.Errorf("clear via \"\" did not reset model; model_id = %q", showResp.ModelID)
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -1352,6 +1352,7 @@ func handleSessionSet(profile string, args []string) {
 		fmt.Println("  channels           Comma-separated plugin channel ids (claude only)")
 		fmt.Printf("  plugins            Comma-separated plugin catalog names (claude only) — see [plugins.<name>] in %s\n", effectiveUserConfigPathForHelp())
 		fmt.Println("  extra-args         Extra claude CLI tokens (claude only; use `-- --flag value` for tokens starting with -; persisted plaintext — no secrets)")
+		fmt.Println("  model              Per-session model override (e.g. opus/sonnet/haiku or a gemini model); persists across restart (#1436). Empty clears it.")
 		fmt.Println("  color              Optional TUI row tint: '#RRGGBB' or ANSI '0'..'255' or '' (issue #391)")
 		fmt.Println("  claude-session-id  Claude conversation ID")
 		fmt.Println("  gemini-session-id  Gemini conversation ID")

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -6426,6 +6426,44 @@ func (i *Instance) ApplyLaunchModel(model string) error {
 	}
 }
 
+// ClearLaunchModel removes any per-session model override so the session falls
+// back to the configured default ([claude].default_model, etc.) on the next
+// start/restart (#1436). Mirrors ApplyLaunchModel across tools; a no-op when
+// no override is set.
+func (i *Instance) ClearLaunchModel() error {
+	if i == nil {
+		return nil
+	}
+	switch {
+	case IsClaudeCompatible(i.Tool):
+		opts := i.GetClaudeOptions()
+		if opts == nil {
+			return nil
+		}
+		opts.Model = ""
+		return i.SetClaudeOptions(opts)
+	case i.Tool == "gemini":
+		i.GeminiModel = ""
+		return nil
+	case i.Tool == "opencode":
+		opts := i.GetOpenCodeOptions()
+		if opts == nil {
+			return nil
+		}
+		opts.Model = ""
+		return i.SetOpenCodeOptions(opts)
+	case IsCodexCompatible(i.Tool):
+		opts := i.GetCodexOptions()
+		if opts == nil {
+			return nil
+		}
+		opts.Model = ""
+		return i.SetCodexOptions(opts)
+	default:
+		return nil
+	}
+}
+
 // CanRestart returns true if the session can be restarted
 // For Claude sessions with known ID: can always restart (interrupt and resume)
 // For Gemini sessions with known ID: can always restart (interrupt and resume)

--- a/internal/session/model_persist_test.go
+++ b/internal/session/model_persist_test.go
@@ -1,0 +1,107 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSetFieldModelPersistsClaude asserts the tool-agnostic `model` field
+// (SetField) persists the operator's selected model into the Claude per-session
+// option store (ClaudeOptions.Model) so it survives a restart (#1436). The
+// restart-side consumption already prefers this over [claude].default_model
+// (#1431); this guards the agent-deck-side persistence.
+func TestSetFieldModelPersistsClaude(t *testing.T) {
+	extraArgsTestEnv(t)
+
+	inst := NewInstanceWithTool("model-claude", t.TempDir(), "claude")
+
+	old, postCommit, err := SetField(inst, FieldModel, "opus", nil)
+	if err != nil {
+		t.Fatalf("SetField(model) returned error: %v", err)
+	}
+	if postCommit != nil {
+		postCommit()
+	}
+	if old != "" {
+		t.Errorf("old model = %q, want empty (no prior override)", old)
+	}
+
+	if got := inst.LaunchModelID(); got != "opus" {
+		t.Fatalf("LaunchModelID() = %q after SetField(model, opus); want opus", got)
+	}
+
+	// The built command must carry the persisted model on start.
+	cmd := inst.buildClaudeCommand("claude")
+	if !strings.Contains(cmd, "--model") || !strings.Contains(cmd, "opus") {
+		t.Errorf("built command missing persisted --model opus, got:\n%s", cmd)
+	}
+
+	// Round-trip through JSON (the tool_data path) and re-check it survives.
+	data, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	revived := &Instance{}
+	if err := json.Unmarshal(data, revived); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := revived.LaunchModelID(); got != "opus" {
+		t.Errorf("revived LaunchModelID() = %q; want opus (model must survive JSON round-trip)", got)
+	}
+}
+
+// TestSetFieldModelClearsClaude asserts an empty value clears the override.
+func TestSetFieldModelClearsClaude(t *testing.T) {
+	extraArgsTestEnv(t)
+
+	inst := NewInstanceWithTool("model-clear", t.TempDir(), "claude")
+	if _, _, err := SetField(inst, FieldModel, "sonnet", nil); err != nil {
+		t.Fatalf("set sonnet: %v", err)
+	}
+	if got := inst.LaunchModelID(); got != "sonnet" {
+		t.Fatalf("precondition: LaunchModelID() = %q; want sonnet", got)
+	}
+	if _, _, err := SetField(inst, FieldModel, "", nil); err != nil {
+		t.Fatalf("clear model: %v", err)
+	}
+	if got := inst.LaunchModelID(); got != "" {
+		t.Errorf("LaunchModelID() = %q after clear; want empty", got)
+	}
+}
+
+// TestSetFieldModelGemini asserts the same field drives the gemini per-session
+// model, proving SetField is tool-agnostic and routes to each tool's store.
+func TestSetFieldModelGemini(t *testing.T) {
+	extraArgsTestEnv(t)
+
+	inst := NewInstanceWithTool("model-gemini", t.TempDir(), "gemini")
+	if _, _, err := SetField(inst, FieldModel, "gemini-2.5-pro", nil); err != nil {
+		t.Fatalf("set gemini model: %v", err)
+	}
+	if inst.GeminiModel != "gemini-2.5-pro" {
+		t.Errorf("GeminiModel = %q; want gemini-2.5-pro", inst.GeminiModel)
+	}
+	if got := inst.LaunchModelID(); got != "gemini-2.5-pro" {
+		t.Errorf("LaunchModelID() = %q; want gemini-2.5-pro", got)
+	}
+}
+
+// TestModelFieldRestartRequired asserts the model field forces a restart so the
+// new model is actually picked up (the running process keeps its launch model).
+func TestModelFieldRestartRequired(t *testing.T) {
+	if got := RestartPolicyFor(FieldModel); got != FieldRestartRequired {
+		t.Errorf("RestartPolicyFor(model) = %v; want FieldRestartRequired", got)
+	}
+}
+
+// TestModelFieldIsValidMutable asserts `model` is registered as a mutable field
+// so `agent-deck session set <id> model <m>` is accepted.
+func TestModelFieldIsValidMutable(t *testing.T) {
+	for _, f := range ValidMutableFields {
+		if f == FieldModel {
+			return
+		}
+	}
+	t.Errorf("FieldModel (%q) not in ValidMutableFields; CLI will reject `session set <id> model`", FieldModel)
+}

--- a/internal/session/mutators.go
+++ b/internal/session/mutators.go
@@ -35,6 +35,14 @@ const (
 	FieldAccount            = "account"      // #924 per-session named account slot
 	FieldIdleTimeout        = "idle-timeout" // #1143 auto-stop dormant sessions
 	FieldPin                = "pin"          // pin-sessions: anchor top/bottom of group
+	// FieldModel persists the operator's selected per-session model (#1436,
+	// follow-up to #1431). Tool-agnostic: routes to each tool's existing model
+	// store (ClaudeOptions.Model, GeminiModel, OpenCodeOptions.Model,
+	// CodexOptions.Model) via Instance.ApplyLaunchModel, so a model switched
+	// after launch survives `session restart` instead of reverting to the
+	// baked/default model. Restart-required (the running process keeps the
+	// model it launched with).
+	FieldModel = "model"
 )
 
 var ValidMutableFields = []string{
@@ -59,6 +67,7 @@ var ValidMutableFields = []string{
 	FieldAccount,
 	FieldIdleTimeout,
 	FieldPin,
+	FieldModel,
 }
 
 type FieldRestartPolicy int
@@ -71,7 +80,7 @@ const (
 func RestartPolicyFor(field string) FieldRestartPolicy {
 	switch field {
 	case FieldCommand, FieldWrapper, FieldTool, FieldChannels, FieldPlugins, FieldExtraArgs, FieldPath,
-		FieldSkipPermissions, FieldAutoMode, FieldAccount:
+		FieldSkipPermissions, FieldAutoMode, FieldAccount, FieldModel:
 		return FieldRestartRequired
 	default:
 		return FieldLive
@@ -357,6 +366,29 @@ func SetField(inst *Instance, field, value string, extraArgsTokens []string) (ol
 			return oldValue, nil, &MutationError{Field: field, Msg: perr.Error()}
 		}
 		inst.IdleTimeoutSecs = secs
+
+	case FieldModel:
+		// #1436: persist the operator's selected model into the tool-specific
+		// store each builder already reads on start/restart. The restart-side
+		// consumption already prefers this per-session model over
+		// [claude].default_model (#1431). Empty value clears the override (back
+		// to the configured default). Restart-required — the running process
+		// keeps the model it launched with.
+		if !SupportsLaunchModel(inst.Tool) {
+			return "", nil, &MutationError{
+				Field: field,
+				Msg:   fmt.Sprintf("model selection is not supported for tool %q", inst.Tool),
+			}
+		}
+		oldValue = inst.LaunchModelID()
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			if cerr := inst.ClearLaunchModel(); cerr != nil {
+				return oldValue, nil, &MutationError{Field: field, Msg: cerr.Error()}
+			}
+		} else if aerr := inst.ApplyLaunchModel(trimmed); aerr != nil {
+			return oldValue, nil, &MutationError{Field: field, Msg: aerr.Error()}
+		}
 
 	case FieldPin:
 		// pin-sessions: anchor the session to the top/bottom of its group,


### PR DESCRIPTION
Closes #1436.

Follow-up to #1431. #1431 made `[claude].default_model` honored at spawn and restart via the `buildClaudeExtraFlags` chokepoint, fixing children booting on Claude's built-in default. This PR handles the remaining case: when an operator switches model after launch, that choice should survive `session restart` instead of reverting to the baked/default model.

## What changed
- New tool-agnostic `model` mutable field. `agent-deck session set <id> model <m>` persists the selected model into the tool-specific store each command builder already reads on start/restart (`ClaudeOptions.Model`, `GeminiModel`, `OpenCodeOptions.Model`, `CodexOptions.Model`) via the existing `ApplyLaunchModel`. An empty value clears the override via the new `ClearLaunchModel`.
- Field is restart-required (a running process keeps the model it launched with).
- The restart-side consumption already prefers this per-session model over the configured default (#1431), so a restart relaunches on the operator's selection.
- CLI help for `session set` documents the field.

## Limitation (documented)
agent-deck cannot observe an in-pane `/model` switch typed into a running Claude session: Claude exposes no clean pane/analytics readback of the current model (noted in #1436). This implements the agent-deck-side persistence path, which is the documented fallback. An operator who wants a model change to survive restart sets it via `session set <id> model <m>`.

## Acceptance mapping
- Persist the selection (tool_data) so `restart` re-launches on the operator's current model — done.
- Restart-side consumption (explicit per-session model wins over default_model) — already shipped in #1431, verified here.

## Tests
- `internal/session`: SetField model persistence for claude/gemini, set/clear, JSON round-trip, restart-required policy, valid-field registration.
- `cmd/agent-deck`: `session set model` persist / re-set / clear, verified via `session show --json`.

All `internal/session` and `cmd/agent-deck` package tests pass in a sandboxed HOME/XDG.
