### PR TITLE
refactor(conductor): remove [conductor].enabled, derive from filesystem presence (#1361)

### DIFF
--- a/cmd/agent-deck/conductor_cmd.go
+++ b/cmd/agent-deck/conductor_cmd.go
@@ -271,8 +271,11 @@ func handleConductorSetup(profile string, args []string) {
 		}
 	}
 
-	// Step 2: If conductor system not enabled, run first-time setup
-	if !settings.Enabled {
+	// Step 2: If no conductors exist yet, run first-time channel setup.
+	// "Enabled" is no longer a config flag (#1361); the conductor system is
+	// active whenever a conductor exists on disk. First-time setup is therefore
+	// gated on "no conductors yet" rather than a stored flag.
+	if !session.ConductorSystemActive() {
 		fmt.Println("Conductor Setup")
 		fmt.Println("===============")
 		fmt.Println()
@@ -414,10 +417,11 @@ func handleConductorSetup(profile string, args []string) {
 			discordConfigured = true
 		}
 
-		// Update config (no longer stores profiles list, conductors are on disk)
+		// Update config (no longer stores profiles list or an enabled flag;
+		// conductors are discovered on disk and enabled-state is derived from
+		// their presence — #1361). Channel tokens are still legitimate config.
 		heartbeatDefault := 15
 		settings = session.ConductorSettings{
-			Enabled:           true,
 			HeartbeatInterval: &heartbeatDefault,
 			Telegram:          telegram,
 			Slack:             slack,
@@ -910,8 +914,11 @@ func handleConductorStatus(_ string, args []string) {
 	// when conductors are globally disabled in config.
 	runAutoMigration(*jsonOutput)
 
-	settings := session.GetConductorSettings()
-	if !settings.Enabled {
+	// Enabled-state is derived from conductor presence (#1361), not a config
+	// flag. When no conductors exist, report disabled exactly as before so the
+	// generated heartbeat.sh (which greps for `"enabled".*true`) and any other
+	// consumers keep the same byte-stable contract.
+	if !session.ConductorSystemActive() {
 		if *jsonOutput {
 			fmt.Println(`{"enabled": false}`)
 		} else {

--- a/conductor/setup.sh
+++ b/conductor/setup.sh
@@ -105,7 +105,8 @@ else
 # sessions per profile, auto-respond when possible, and escalate via Telegram.
 
 [conductor]
-enabled = true
+# The conductor system is active whenever a conductor exists on disk; there is
+# no longer an `enabled` flag (#1361).
 heartbeat_interval = 15
 profiles = ["default", "work"]
 

--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -65,7 +65,12 @@ var conductorAgentSpecs = map[string]ConductorAgentSpec{
 
 // ConductorSettings defines conductor (meta-agent orchestration) configuration
 type ConductorSettings struct {
-	// Enabled activates the conductor system
+	// Deprecated: Enabled is retained only so pre-#1361 configs that still carry
+	// `enabled = true/false` continue to load without error. The flag is no
+	// longer read anywhere — the conductor system's active state is derived from
+	// filesystem presence via ConductorSystemActive(). Setup no longer writes
+	// this field. TOML decoding ignores unknown keys, but keeping the field
+	// avoids a "field not found" surprise for anyone round-tripping old configs.
 	Enabled bool `toml:"enabled,omitempty"`
 
 	// HeartbeatInterval is the interval in minutes between heartbeat checks
@@ -523,6 +528,26 @@ func ListConductors() ([]ConductorMeta, error) {
 		conductors = append(conductors, *meta)
 	}
 	return conductors, nil
+}
+
+// ConductorSystemActive reports whether the conductor system is active by
+// deriving the answer from filesystem/registry state instead of a config flag.
+// The system is "active" exactly when at least one conductor exists on disk
+// (a directory under ConductorDir containing a valid meta.json).
+//
+// This replaces the former [conductor].enabled config flag (issue #1361),
+// which was write-once-true and whose only reachable "off" value silently
+// broke the heartbeat. Deriving from presence means enabled-state cannot drift
+// from reality: it is true iff there is something to conduct.
+func ConductorSystemActive() bool {
+	conductors, err := ListConductors()
+	if err != nil {
+		// A read error is not a license to silently disable. Treat the system
+		// as active so the failure surfaces downstream rather than masquerading
+		// as "no conductors configured".
+		return true
+	}
+	return len(conductors) > 0
 }
 
 // ListConductorsForProfile returns conductors belonging to a specific profile

--- a/internal/session/conductor_bridge.py
+++ b/internal/session/conductor_bridge.py
@@ -209,8 +209,17 @@ def load_config() -> dict:
     config = toml.load(CONFIG_PATH)
     conductor_cfg = config.get("conductor", {})
 
-    if not conductor_cfg.get("enabled", False):
-        log.error("[conductor] section missing or not enabled in config.toml")
+    # The conductor system is "active" when at least one conductor exists on
+    # disk (meta.json under CONDUCTOR_DIR), mirroring ConductorSystemActive()
+    # on the Go side. The legacy [conductor].enabled flag has been removed
+    # (#1361); it was write-once-true and its only reachable "off" value
+    # silently killed the bridge daemon. Old configs that still carry
+    # `enabled = false` no longer disable the bridge.
+    if not discover_conductors():
+        log.error(
+            "No conductors found under %s; run 'agent-deck conductor setup <name>'",
+            CONDUCTOR_DIR,
+        )
         sys.exit(1)
 
     # Telegram config

--- a/internal/session/conductor_enabled_derive_test.go
+++ b/internal/session/conductor_enabled_derive_test.go
@@ -1,0 +1,90 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Regression tests for issue #1361: the [conductor].enabled config flag is
+// removed and the conductor system's active state is derived from filesystem
+// presence (a conductor dir with a valid meta.json) instead.
+
+// TestConductorSystemActive_DerivesFromPresence verifies that a conductor with
+// no `enabled` flag anywhere is correctly reported active once it exists on
+// disk, and inactive when none exist.
+func TestConductorSystemActive_DerivesFromPresence(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg-data"))
+
+	// No conductors yet -> system is not active. There is no `enabled = true`
+	// flag anywhere; presence alone is the source of truth.
+	if ConductorSystemActive() {
+		t.Fatalf("expected ConductorSystemActive()=false with zero conductors on disk")
+	}
+
+	// Create a conductor on disk without ever touching any enabled flag.
+	if err := SaveConductorMeta(&ConductorMeta{
+		Name:             "alpha",
+		Profile:          "default",
+		HeartbeatEnabled: true,
+		CreatedAt:        "2026-06-14T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("SaveConductorMeta: %v", err)
+	}
+
+	if !ConductorSystemActive() {
+		t.Fatalf("expected ConductorSystemActive()=true once a conductor exists on disk (no enabled flag required)")
+	}
+}
+
+// TestConductorSettings_LegacyEnabledFlagStillLoads verifies graceful
+// migration: a pre-#1361 config that still carries `enabled = true` (or
+// `enabled = false`) decodes without error. The flag is simply ignored.
+func TestConductorSettings_LegacyEnabledFlagStillLoads(t *testing.T) {
+	for _, legacy := range []string{
+		"[conductor]\nenabled = true\nheartbeat_interval = 15\n",
+		"[conductor]\nenabled = false\nheartbeat_interval = 15\n",
+	} {
+		var cfg struct {
+			Conductor ConductorSettings `toml:"conductor"`
+		}
+		if _, err := toml.Decode(legacy, &cfg); err != nil {
+			t.Fatalf("legacy config with enabled flag must still decode, got error: %v\nconfig:\n%s", err, legacy)
+		}
+		if cfg.Conductor.HeartbeatInterval == nil || *cfg.Conductor.HeartbeatInterval != 15 {
+			t.Fatalf("expected heartbeat_interval=15 to survive decode of legacy config:\n%s", legacy)
+		}
+	}
+}
+
+// TestConductorSystemActive_LegacyEnabledFalseIgnored is the key safety case:
+// a config that still says `enabled = false` must NOT disable a conductor that
+// actually exists on disk. The flag is dead; presence wins.
+func TestConductorSystemActive_LegacyEnabledFalseIgnored(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "xdg-data"))
+
+	if err := SaveConductorMeta(&ConductorMeta{
+		Name:      "legacy",
+		Profile:   "default",
+		CreatedAt: "2026-06-14T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("SaveConductorMeta: %v", err)
+	}
+
+	// Even with a stale enabled=false flag decoded into settings, the derived
+	// active-state ignores it entirely.
+	var cfg struct {
+		Conductor ConductorSettings `toml:"conductor"`
+	}
+	if _, err := toml.Decode("[conductor]\nenabled = false\n", &cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !ConductorSystemActive() {
+		t.Fatalf("a live conductor on disk must be active regardless of a stale enabled=false flag")
+	}
+}


### PR DESCRIPTION
Closes #1361.

## What

Removes the `[conductor].enabled` config flag and derives the conductor system's active state from filesystem/registry presence instead.

## Why

`conductor.enabled` was redundant and a footgun:
- write-once-true; the app never legitimately set it false
- its only reachable "off" value silently broke things: `heartbeat.sh` exits 0 (success, no log) when `enabled != true`, and the bridge daemon `sys.exit(1)` on the same condition
- legacy-migrated / dotfile-synced / config-reset paths could leave live conductors on disk with `enabled=false`

## How

New helper `ConductorSystemActive()` returns `len(ListConductors()) > 0`, reusing the meta.json scan that `conductor status` already performs. The system is active exactly when a conductor exists on disk.

All four former gate sites converted:
1. setup wizard gate (run first-time channel setup when no conductors exist)
2. `conductor status` early-exit + `--json` `enabled` field (kept byte-stable: true exactly when conductors exist, so the generated `heartbeat.sh` is unchanged)
3. python bridge daemon (`conductor_bridge.py`) gates on `discover_conductors()` presence
4. `setup.sh` template drops the `enabled = true` line

## Migration

Graceful: the `Enabled` struct field is retained (deprecated, ignored) so pre-#1361 configs carrying `enabled = true/false` still decode without error. A stale `enabled = false` no longer disables a conductor that exists on disk.

## Tests

`internal/session/conductor_enabled_derive_test.go`:
- a conductor with no `enabled` flag anywhere is correctly active once on disk
- legacy config with `enabled = true/false` still loads
- a stale `enabled = false` is ignored when a conductor exists on disk
