### PR TITLE
feat(conductor): auto-allow read-only/safe CLI commands in .claude/settings.json (#1358)

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -698,6 +698,21 @@ func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool,
 		}
 	}
 
+	// Write the conductor's .claude/settings.json permission allowlist (#1358).
+	// Claude-only (codex/hermes don't use this file). Auto-allows read-only and
+	// safe CLI commands plus scoped data-file writes so the conductor's heartbeat
+	// read loop doesn't drown the user in permission prompts, while keeping
+	// lifecycle/mutating commands and executable/config writes behind prompts.
+	// Non-fatal: setup still succeeds if this fails.
+	if spec.Agent == ConductorAgentClaude {
+		if err := writeConductorClaudeSettingsAt(dir); err != nil {
+			sessionLog.Warn("conductor_claude_settings_failed",
+				slog.String("conductor", name),
+				slog.String("dir", dir),
+				slog.String("error", err.Error()))
+		}
+	}
+
 	return nil
 }
 

--- a/internal/session/conductor_claude_settings.go
+++ b/internal/session/conductor_claude_settings.go
@@ -1,0 +1,205 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Conductor .claude/settings.json permission allowlist (issue #1358).
+//
+// A Claude conductor's core read loop (status -> list -> session output) fires
+// on every heartbeat and at startup. With dangerous_mode=false this produces a
+// wall of permission prompts. We auto-allow genuinely read-only and safe
+// lifecycle CLI commands, and scope file writes to the conductor's own data
+// files — deliberately NOT the executable/config files in its directory.
+//
+// Security tightenings applied (maintainer ruling on #1358):
+//   - session start/stop/restart are NOT silently auto-allowed. They replay the
+//     session's stored command (which can be a permission-skipping wrapper) and
+//     start/restart accept -m/--message prompt injection. They go to the ask
+//     list so the user still confirms.
+//   - The write-allow is NOT a recursive /** over the conductor dir. A conductor
+//     dir holds executables/config that run on spawn/hook (.claude/settings.json
+//     = arbitrary hooks, .mcp.json = arbitrary stdio servers, .envrc = injected
+//     env, *.sh = scripts). A recursive write-allow would let the conductor
+//     silently rewrite any of these for arbitrary code execution on the next
+//     hook/spawn, defeating dangerous_mode=false. Writes are scoped to data
+//     files (*.md, state.json), and explicit deny rules guard the executable/
+//     config paths (deny takes precedence over any broader glob).
+
+// conductorAutoAllowCommands are the read-only / safe CLI commands a conductor
+// may run without a prompt. Pure reads plus restart (replays the stored command
+// but has no -m injection flag — acceptable per the ruling).
+//
+// Shell commands must be wrapped in Bash(...) — Claude Code interprets a bare
+// string as a tool name, not a command, so an unwrapped entry would silently
+// fail to match and the policy would not apply.
+var conductorAutoAllowCommands = []string{
+	"Bash(agent-deck status *)",
+	"Bash(agent-deck list *)",
+	"Bash(agent-deck session output *)",
+	"Bash(agent-deck session show *)",
+	"Bash(agent-deck session current)",
+	"Bash(agent-deck inbox *)",
+	"Bash(agent-deck mcp list)",
+	"Bash(agent-deck version)",
+	"Bash(agent-deck session restart *)",
+}
+
+// conductorAskCommands are mutating / lifecycle / replay-risk commands that must
+// still prompt. Listed explicitly so the policy is auditable and so the user is
+// asked rather than silently denied. Wrapped in Bash(...) for the same reason as
+// the allow list.
+var conductorAskCommands = []string{
+	"Bash(agent-deck session start *)",
+	"Bash(agent-deck session stop *)",
+	"Bash(agent-deck session send *)",
+	"Bash(agent-deck launch *)",
+	"Bash(agent-deck add *)",
+	"Bash(agent-deck mcp attach *)",
+	"Bash(agent-deck mcp detach *)",
+	"Bash(agent-deck session set *)",
+	"Bash(agent-deck session move *)",
+	"Bash(agent-deck session switch-account *)",
+	"Bash(agent-deck session fork *)",
+	"Bash(agent-deck session remove *)",
+}
+
+// conductorWriteAllowPatterns builds the scoped file-write allowlist for a
+// conductor directory. Narrow on purpose: only the conductor's data files, never
+// a recursive /** over the dir.
+func conductorWriteAllowPatterns(dir string) []string {
+	return []string{
+		"Edit(//" + dir + "/*.md)",
+		"Write(//" + dir + "/*.md)",
+		"Write(//" + dir + "/state.json)",
+		"Write(//" + dir + "/task-log.md)",
+	}
+}
+
+// conductorWriteDenyPatterns builds deny rules for the executable/config paths
+// inside a conductor directory. Deny takes precedence over allow, so even if a
+// broader allow glob is ever introduced these stay protected from
+// self-escalation.
+func conductorWriteDenyPatterns(dir string) []string {
+	return []string{
+		"Write(//" + dir + "/.claude/**)",
+		"Edit(//" + dir + "/.claude/**)",
+		"Write(//" + dir + "/.mcp.json)",
+		"Edit(//" + dir + "/.mcp.json)",
+		"Write(//" + dir + "/.envrc)",
+		"Edit(//" + dir + "/.envrc)",
+		"Write(//" + dir + "/*.sh)",
+		"Edit(//" + dir + "/*.sh)",
+	}
+}
+
+// WriteConductorClaudeSettings writes (or merges into) the conductor's
+// .claude/settings.json with the auto-allow/ask/deny permission policy from
+// #1358. Claude-only; other agents don't use this file.
+//
+// Existing unmanaged keys in settings.json are preserved. Managed permission
+// entries are merged in idempotently: re-running setup keeps the policy current
+// without duplicating entries or discarding user-added permissions.
+func WriteConductorClaudeSettings(name string) error {
+	dir, err := ConductorNameDir(name)
+	if err != nil {
+		return fmt.Errorf("failed to get conductor dir: %w", err)
+	}
+	return writeConductorClaudeSettingsAt(dir)
+}
+
+func writeConductorClaudeSettingsAt(dir string) error {
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", claudeDir, err)
+	}
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	// Preserve any existing top-level keys (and any user-added permissions).
+	root := map[string]json.RawMessage{}
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		if uErr := json.Unmarshal(data, &root); uErr != nil {
+			// Don't clobber a file we can't parse — surface the error instead.
+			return fmt.Errorf("existing %s is not valid JSON: %w", settingsPath, uErr)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", settingsPath, err)
+	}
+
+	// Preserve every nested permissions key (defaultMode, additionalDirectories,
+	// disableBypassPermissionsMode, etc.). We only touch the three string arrays
+	// we manage — allow, deny, ask — and write the rest back untouched.
+	permsObj := map[string]json.RawMessage{}
+	if raw, ok := root["permissions"]; ok {
+		if err := json.Unmarshal(raw, &permsObj); err != nil {
+			return fmt.Errorf("existing permissions in %s is not valid JSON: %w", settingsPath, err)
+		}
+	}
+
+	allow, err := mergeUniqueRaw(permsObj["allow"], conductorAutoAllowCommands, conductorWriteAllowPatterns(dir))
+	if err != nil {
+		return fmt.Errorf("merge permissions.allow in %s: %w", settingsPath, err)
+	}
+	ask, err := mergeUniqueRaw(permsObj["ask"], conductorAskCommands)
+	if err != nil {
+		return fmt.Errorf("merge permissions.ask in %s: %w", settingsPath, err)
+	}
+	deny, err := mergeUniqueRaw(permsObj["deny"], conductorWriteDenyPatterns(dir))
+	if err != nil {
+		return fmt.Errorf("merge permissions.deny in %s: %w", settingsPath, err)
+	}
+	permsObj["allow"] = allow
+	permsObj["ask"] = ask
+	permsObj["deny"] = deny
+
+	permsJSON, err := json.Marshal(permsObj)
+	if err != nil {
+		return fmt.Errorf("marshal permissions: %w", err)
+	}
+	root["permissions"] = permsJSON
+
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+	out = append(out, '\n')
+	if err := os.WriteFile(settingsPath, out, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", settingsPath, err)
+	}
+	return nil
+}
+
+// mergeUniqueRaw decodes an existing JSON string array (which may be nil/absent,
+// preserving any user-added entries), appends the managed additions skipping
+// duplicates, and returns a sorted JSON array for deterministic output. Returns
+// an error if the existing value is present but not a JSON string array.
+func mergeUniqueRaw(existing json.RawMessage, additions ...[]string) (json.RawMessage, error) {
+	var base []string
+	if len(existing) > 0 {
+		if err := json.Unmarshal(existing, &base); err != nil {
+			return nil, fmt.Errorf("not a JSON string array: %w", err)
+		}
+	}
+	seen := map[string]bool{}
+	merged := []string{}
+	appendUnique := func(s string) {
+		if !seen[s] {
+			seen[s] = true
+			merged = append(merged, s)
+		}
+	}
+	for _, b := range base {
+		appendUnique(b)
+	}
+	for _, add := range additions {
+		for _, a := range add {
+			appendUnique(a)
+		}
+	}
+	sort.Strings(merged)
+	return json.Marshal(merged)
+}

--- a/internal/session/conductor_claude_settings_test.go
+++ b/internal/session/conductor_claude_settings_test.go
@@ -1,0 +1,271 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression tests for issue #1358: conductor .claude/settings.json auto-allow
+// policy with maintainer tightenings (read-only auto-allowed; lifecycle/mutating
+// commands prompted; conductor-dir executable/config writes NOT blanket-allowed).
+
+type conductorPermissions struct {
+	Allow []string `json:"allow,omitempty"`
+	Deny  []string `json:"deny,omitempty"`
+	Ask   []string `json:"ask,omitempty"`
+}
+
+func loadConductorPerms(t *testing.T, dir string) conductorPermissions {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("settings.json not valid JSON: %v\n%s", err, data)
+	}
+	raw, ok := root["permissions"]
+	if !ok {
+		t.Fatalf("settings.json missing permissions key:\n%s", data)
+	}
+	var perms conductorPermissions
+	if err := json.Unmarshal(raw, &perms); err != nil {
+		t.Fatalf("permissions not valid JSON: %v", err)
+	}
+	return perms
+}
+
+func permContains(list []string, want string) bool {
+	for _, e := range list {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}
+
+func anyHasPrefix(list []string, prefix string) bool {
+	for _, e := range list {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestConductorClaudeSettings_ReadOnlyAutoAllowed verifies genuinely read-only
+// commands are in the allow list with no prompt.
+func TestConductorClaudeSettings_ReadOnlyAutoAllowed(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeConductorClaudeSettingsAt(dir); err != nil {
+		t.Fatalf("writeConductorClaudeSettingsAt: %v", err)
+	}
+	perms := loadConductorPerms(t, dir)
+
+	for _, cmd := range []string{
+		"Bash(agent-deck status *)",
+		"Bash(agent-deck list *)",
+		"Bash(agent-deck session output *)",
+		"Bash(agent-deck session show *)",
+		"Bash(agent-deck inbox *)",
+		"Bash(agent-deck session restart *)",
+	} {
+		if !permContains(perms.Allow, cmd) {
+			t.Errorf("expected read-only/safe command auto-allowed: %q\nallow=%v", cmd, perms.Allow)
+		}
+	}
+	// Shell commands must be Bash(...)-wrapped — a bare command string is read by
+	// Claude Code as a tool name and silently never matches.
+	for _, bare := range []string{"agent-deck status *", "agent-deck list *"} {
+		if permContains(perms.Allow, bare) {
+			t.Errorf("command must be Bash(...)-wrapped, found bare entry: %q", bare)
+		}
+	}
+}
+
+// TestConductorClaudeSettings_LifecycleAndMutatingPrompt verifies the dangerous
+// command-replay / injection surfaces are NOT silently auto-allowed and instead
+// go to the ask (prompt) list.
+func TestConductorClaudeSettings_LifecycleAndMutatingPrompt(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeConductorClaudeSettingsAt(dir); err != nil {
+		t.Fatalf("writeConductorClaudeSettingsAt: %v", err)
+	}
+	perms := loadConductorPerms(t, dir)
+
+	for _, cmd := range []string{
+		"Bash(agent-deck session start *)",
+		"Bash(agent-deck session stop *)",
+		"Bash(agent-deck session send *)",
+		"Bash(agent-deck launch *)",
+	} {
+		if permContains(perms.Allow, cmd) {
+			t.Errorf("mutating/lifecycle command must NOT be auto-allowed: %q\nallow=%v", cmd, perms.Allow)
+		}
+		if !permContains(perms.Ask, cmd) {
+			t.Errorf("mutating/lifecycle command must be in ask list: %q\nask=%v", cmd, perms.Ask)
+		}
+	}
+}
+
+// TestConductorClaudeSettings_NoBlanketDirWrite is the core security guarantee:
+// writes are NOT blanket-allowed over the conductor dir, and the executable/
+// config paths are explicitly denied (deny takes precedence).
+func TestConductorClaudeSettings_NoBlanketDirWrite(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeConductorClaudeSettingsAt(dir); err != nil {
+		t.Fatalf("writeConductorClaudeSettingsAt: %v", err)
+	}
+	perms := loadConductorPerms(t, dir)
+
+	// No recursive write/edit over the whole conductor dir.
+	for _, bad := range []string{
+		"Write(//" + dir + "/**)",
+		"Edit(//" + dir + "/**)",
+	} {
+		if permContains(perms.Allow, bad) {
+			t.Errorf("must NOT blanket write-allow the conductor dir: %q", bad)
+		}
+	}
+	if anyHasPrefix(perms.Allow, "Write(//"+dir+"/**") || anyHasPrefix(perms.Allow, "Edit(//"+dir+"/**") {
+		t.Errorf("must NOT have a recursive write-allow glob over the conductor dir\nallow=%v", perms.Allow)
+	}
+
+	// The executable/config paths must be explicitly denied.
+	for _, deny := range []string{
+		"Write(//" + dir + "/.claude/**)",
+		"Write(//" + dir + "/.mcp.json)",
+		"Write(//" + dir + "/.envrc)",
+		"Write(//" + dir + "/*.sh)",
+	} {
+		if !permContains(perms.Deny, deny) {
+			t.Errorf("expected deny rule for self-escalation path: %q\ndeny=%v", deny, perms.Deny)
+		}
+	}
+
+	// Scoped data-file writes ARE allowed.
+	for _, allow := range []string{
+		"Write(//" + dir + "/state.json)",
+		"Write(//" + dir + "/task-log.md)",
+	} {
+		if !permContains(perms.Allow, allow) {
+			t.Errorf("expected scoped data-file write allowed: %q\nallow=%v", allow, perms.Allow)
+		}
+	}
+}
+
+// TestConductorClaudeSettings_Idempotent verifies re-running setup does not
+// duplicate entries and preserves unmanaged top-level keys plus user-added
+// permissions.
+func TestConductorClaudeSettings_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Pre-seed with an unmanaged key and a user-added permission.
+	seed := `{"model":"opus","permissions":{"allow":["Bash(ls *)"]}}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	if err := writeConductorClaudeSettingsAt(dir); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := writeConductorClaudeSettingsAt(dir); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+	// Unmanaged key preserved.
+	if string(root["model"]) != `"opus"` {
+		t.Errorf("unmanaged top-level key must be preserved, got model=%s", root["model"])
+	}
+	perms := loadConductorPerms(t, dir)
+	// User-added permission preserved.
+	if !permContains(perms.Allow, "Bash(ls *)") {
+		t.Errorf("user-added permission must be preserved\nallow=%v", perms.Allow)
+	}
+	// No duplicate of a managed entry.
+	count := 0
+	for _, e := range perms.Allow {
+		if e == "Bash(agent-deck status *)" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("managed entry duplicated after re-run: count=%d\nallow=%v", count, perms.Allow)
+	}
+}
+
+// TestConductorClaudeSettings_PreservesNestedPermissionKeys verifies that
+// unmanaged nested keys inside the permissions object (defaultMode,
+// additionalDirectories, security-sensitive disableBypassPermissionsMode) are
+// preserved across a merge — we only touch allow/ask/deny.
+func TestConductorClaudeSettings_PreservesNestedPermissionKeys(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seed := `{"permissions":{"defaultMode":"acceptEdits","disableBypassPermissionsMode":"disable","additionalDirectories":["/tmp/extra"],"allow":["Bash(ls *)"]}}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	if err := writeConductorClaudeSettingsAt(dir); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("not valid JSON: %v", err)
+	}
+	var permsObj map[string]json.RawMessage
+	if err := json.Unmarshal(root["permissions"], &permsObj); err != nil {
+		t.Fatalf("permissions not valid JSON: %v", err)
+	}
+	// Compare semantically (re-marshal to canonical form) since MarshalIndent
+	// reformats whitespace in preserved raw values.
+	canon := func(raw json.RawMessage) string {
+		var v any
+		if err := json.Unmarshal(raw, &v); err != nil {
+			t.Fatalf("re-unmarshal preserved value: %v", err)
+		}
+		b, _ := json.Marshal(v)
+		return string(b)
+	}
+	for key, want := range map[string]string{
+		"defaultMode":                  `"acceptEdits"`,
+		"disableBypassPermissionsMode": `"disable"`,
+		"additionalDirectories":        `["/tmp/extra"]`,
+	} {
+		got := canon(permsObj[key])
+		if got != want {
+			t.Errorf("nested permissions key %q must be preserved: want %s, got %s", key, want, got)
+		}
+	}
+	// And the user-added allow entry survives alongside the managed ones.
+	perms := loadConductorPerms(t, dir)
+	if !permContains(perms.Allow, "Bash(ls *)") {
+		t.Errorf("user-added allow entry must survive\nallow=%v", perms.Allow)
+	}
+	if !permContains(perms.Allow, "Bash(agent-deck status *)") {
+		t.Errorf("managed allow entry must be present\nallow=%v", perms.Allow)
+	}
+}


### PR DESCRIPTION
Closes #1358.

## What

`conductor setup` now writes (or merges into) the conductor's `.claude/settings.json` with a scoped permission policy so a Claude conductor's heartbeat read loop no longer drowns the user in permission prompts under `dangerous_mode = false`. Claude-only (codex/hermes don't use this file).

## Policy (implements the maintainer ruling's tightenings)

**Auto-allow (no prompt)** — genuinely read-only plus safe lifecycle:
- `status`, `list`, `session output`, `session show`, `session current`, `inbox`, `mcp list`, `version`
- `session restart` — replays the stored command but has no `-m` injection flag (acceptable per the ruling)

**Ask (still prompts)** — command-replay / injection / spawn risk:
- `session start` (replays stored command AND accepts `-m` prompt injection — NOT auto-allowed)
- `session stop`, `session send` (types raw keystrokes into the target pane; can approve a child's pending prompt)
- `launch`, `add` (accept arbitrary permission-skipping tool commands via `-c`/`--wrapper`)
- `mcp attach/detach`, `session set/move/switch-account/fork/remove`

**Scoped file writes** — only the conductor's own data files:
- `Edit/Write(<dir>/*.md)`, `Write(<dir>/state.json)`, `Write(<dir>/task-log.md)`
- Deliberately NOT a recursive `/**` over the conductor dir

**Deny (precedence over any broader glob)** — self-escalation guard:
- `Write/Edit` of `<dir>/.claude/**`, `.mcp.json`, `.envrc`, `*.sh` — these run on spawn/hook; a blanket write-allow would let the conductor rewrite them for arbitrary code execution, defeating `dangerous_mode = false`

## Implementation notes

- Shell command rules are `Bash(...)`-wrapped. A bare command string is interpreted by Claude Code as a tool name and silently never matches, so the policy would otherwise not apply.
- The merge preserves all unmanaged top-level keys and all unmanaged nested `permissions` keys (`defaultMode`, `additionalDirectories`, `disableBypassPermissionsMode`, user-added allow/ask/deny entries). Only the three managed arrays are updated, idempotently, with no duplicates.
- Non-fatal: setup still succeeds if writing the file fails (logged warning).

## Tests

`internal/session/conductor_claude_settings_test.go`:
- read-only/safe commands are auto-allowed and are `Bash(...)`-wrapped (no bare entries)
- mutating/lifecycle commands (`start`/`stop`/`send`/`launch`) are NOT auto-allowed and are in the ask list
- no recursive write-allow over the conductor dir; executable/config paths are denied; data-file writes are allowed
- idempotent re-run preserves unmanaged top-level keys and user-added permissions, no duplicates
- nested permissions keys (`defaultMode`, `additionalDirectories`, `disableBypassPermissionsMode`) are preserved across merge

## Review note

Codex flagged auto-allowing `session restart` as a residual replay risk. This matches the maintainer ruling on #1358 (restart kept auto-allowed because it has no `-m` injection flag; only `start` was moved to prompt). Left as-ruled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Claude conductor setup with automatic permission management configuration
  * Granular access controls distinguishing read-only agent commands from commands requiring user approval
  * File write protections preventing modifications to sensitive configuration files

* **Tests**
  * Added comprehensive test coverage for conductor permission policies and idempotent setup behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->