### PR TITLE
fix(worktree): don't strand siblings when finishing a shared worktree (#1449) + TUI help/idle fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Worktree finish on a shared worktree no longer strands sibling sessions** ([#1449](https://github.com/asheshgoplani/agent-deck/issues/1449)). Finishing (or deleting) one of several sessions that share a single git worktree used to remove the shared worktree directory and delete the branch, leaving the remaining sessions pointing at a missing worktree. Both teardown paths now count other live sessions whose worktree path resolves (via `EvalSymlinks`) to the same directory; while any sibling remains, the destructive `git worktree remove` + branch delete are skipped and only the finished session's record is dropped. The last sharer cleans up as before, and the existing "never delete the original repo" guard is preserved.
+- **Help overlay documents the archive shortcuts.** The `?` help overlay now lists the archive family — `A` (archive), `Shift+U` (unarchive), and `^` (toggle archived view) — which were reachable in the TUI and shown in the top filter bar but missing from help.
+- **A session that was added but never started shows idle, not error.** A freshly added session with no running tmux is now classified as idle (`○`) instead of error (`✕`); a session that was started and then lost its tmux still surfaces as error.
+
 ## [1.9.64] - 2026-06-14
 
 ### Changed

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -395,6 +395,16 @@ type Instance struct {
 	// Not serialized - only relevant for current TUI session
 	lastStartTime time.Time
 
+	// addedThisProcess is true only for instances built by a NewInstance*
+	// constructor in the current process (i.e. just `add`ed), and false for
+	// instances reloaded from storage (built as struct literals). Combined with
+	// a zero lastStartTime it identifies a session that was added but never
+	// started, whose absent tmux is expected (idle), not a fault (error).
+	// Not serialized — a reloaded "never started" row that genuinely ran would
+	// surface a stored non-idle status; a brand-new row reloads as idle and
+	// re-derives correctly once the user starts it.
+	addedThisProcess bool
+
 	// Rate-limits expensive session metadata sync work (Claude/Gemini/Codex)
 	// that runs from UpdateStatus while this instance lock is held.
 	lastSessionMetaSync time.Time
@@ -643,15 +653,16 @@ func NewInstance(title, projectPath string) *Instance {
 	tmuxSess.SetTerminalChromeEnabled(GetTerminalSettings().GetITermBadge())
 
 	inst := &Instance{
-		ID:             id,
-		Title:          title,
-		ProjectPath:    projectPath,
-		GroupPath:      extractGroupPath(projectPath), // Auto-assign group from path
-		Tool:           "shell",
-		Status:         StatusIdle,
-		CreatedAt:      time.Now(),
-		TmuxSocketName: socket,
-		tmuxSession:    tmuxSess,
+		ID:               id,
+		Title:            title,
+		ProjectPath:      projectPath,
+		GroupPath:        extractGroupPath(projectPath), // Auto-assign group from path
+		Tool:             "shell",
+		Status:           StatusIdle,
+		CreatedAt:        time.Now(),
+		TmuxSocketName:   socket,
+		tmuxSession:      tmuxSess,
+		addedThisProcess: true,
 	}
 	logSessionCreated(inst)
 	return inst
@@ -721,15 +732,16 @@ func NewInstanceWithTool(title, projectPath, tool string) *Instance {
 	tmuxSess.SetTerminalChromeEnabled(GetTerminalSettings().GetITermBadge())
 
 	inst := &Instance{
-		ID:             id,
-		Title:          title,
-		ProjectPath:    projectPath,
-		GroupPath:      extractGroupPath(projectPath),
-		Tool:           tool,
-		Status:         StatusIdle,
-		CreatedAt:      time.Now(),
-		TmuxSocketName: socket,
-		tmuxSession:    tmuxSess,
+		ID:               id,
+		Title:            title,
+		ProjectPath:      projectPath,
+		GroupPath:        extractGroupPath(projectPath),
+		Tool:             tool,
+		Status:           StatusIdle,
+		CreatedAt:        time.Now(),
+		TmuxSocketName:   socket,
+		tmuxSession:      tmuxSess,
+		addedThisProcess: true,
 	}
 
 	// Claude session ID will be detected from files Claude creates
@@ -3682,6 +3694,23 @@ func (i *Instance) shellForegroundRunning() bool {
 	return true
 }
 
+// neverStarted reports whether this session was added but never started, so an
+// absent tmux session is expected rather than a fault. Two conditions must both
+// hold (caller holds i.mu):
+//
+//  1. The instance was added in THIS process (addedThisProcess), not reloaded
+//     from storage. A reloaded session whose tmux later dies is a genuine error
+//     (instance_cli_parity_test.go TestUpdateStatus_CLIvsTUIParity_Error builds
+//     a reloaded struct literal, so addedThisProcess is false there).
+//  2. Start() was never called (lastStartTime is zero). A started-then-killed
+//     session has a non-zero lastStartTime and must surface as error
+//     (lifecycle_regression_test.go phase5).
+//  3. The status is still the pristine post-add state (idle or starting).
+func (i *Instance) neverStarted() bool {
+	return i.addedThisProcess && i.lastStartTime.IsZero() &&
+		(i.Status == StatusIdle || i.Status == StatusStarting)
+}
+
 // UpdateStatus updates the session status by checking tmux.
 // Thread-safe: acquires write lock to protect Status, Tool, and internal cache fields.
 func (i *Instance) UpdateStatus() error {
@@ -3708,7 +3737,11 @@ func (i *Instance) UpdateStatus() error {
 	}
 
 	if i.tmuxSession == nil {
-		if i.Status != StatusStopped {
+		if i.neverStarted() {
+			// A session that was added but never started has no tmux yet; it is
+			// not an error, just not-yet-running. Keep it idle (✕ → ○).
+			i.Status = StatusIdle
+		} else if i.Status != StatusStopped {
 			i.Status = StatusError
 		}
 		return nil
@@ -3724,7 +3757,11 @@ func (i *Instance) UpdateStatus() error {
 
 	// Check if tmux session exists
 	if !i.tmuxSession.Exists() {
-		if i.Status != StatusStopped {
+		if i.neverStarted() {
+			// Added but never started: no tmux session was ever created, so an
+			// absent tmux is expected — classify as idle, not error (✕ → ○).
+			i.Status = StatusIdle
+		} else if i.Status != StatusStopped {
 			i.Status = StatusError
 		}
 		i.lastErrorCheck = time.Now() // Record when we confirmed error/stopped

--- a/internal/session/never_started_status_test.go
+++ b/internal/session/never_started_status_test.go
@@ -1,0 +1,55 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A session that was `add`ed but never started has a tmux session object that
+// does not yet exist (Start() was never called, so no tmux session was created)
+// and is still in its pristine StatusIdle state. UpdateStatus must classify it
+// as idle (not-yet-started), NOT error — rendering it with the ✕ error glyph is
+// the TUI-verification finding.
+//
+// The contract that MUST stay intact: a session that WAS started (lastStartTime
+// set) and then lost its tmux session is a genuine error (see
+// lifecycle_regression_test.go phase5). Only the never-started case is exempt.
+func TestUpdateStatus_NeverStartedSessionIsIdleNotError(t *testing.T) {
+	inst := NewInstanceWithTool("never-started", t.TempDir(), "bash")
+	require.Equal(t, StatusIdle, inst.GetStatusThreadSafe(), "fresh session starts idle")
+	require.True(t, inst.lastStartTime.IsZero(), "a never-started session has no lastStartTime")
+	require.False(t, inst.Exists(), "a never-started session has no live tmux")
+
+	// Age past the 1.5s tmux-init grace period so we exercise the real
+	// classification (not the StatusStarting shortcut).
+	inst.CreatedAt = time.Now().Add(-5 * time.Second)
+	inst.ForceNextStatusCheck()
+
+	require.NoError(t, inst.UpdateStatus())
+
+	got := inst.GetStatusThreadSafe()
+	assert.NotEqual(t, StatusError, got,
+		"a session that was added but never started must not show error")
+	assert.Equal(t, StatusIdle, got,
+		"a never-started session should remain idle")
+}
+
+// A started-then-lost session must still surface as error: gating on
+// lastStartTime must not regress the externally-killed contract.
+func TestUpdateStatus_StartedThenLostTmuxIsStillError(t *testing.T) {
+	inst := NewInstanceWithTool("was-started", t.TempDir(), "bash")
+	// Simulate a session that WAS started but whose tmux session is now gone:
+	// non-zero lastStartTime + a non-existent tmux session, aged past grace.
+	inst.lastStartTime = time.Now().Add(-5 * time.Second)
+	inst.CreatedAt = inst.lastStartTime
+	inst.Status = StatusRunning // it had been running before tmux died
+	inst.ForceNextStatusCheck()
+
+	require.NoError(t, inst.UpdateStatus())
+
+	assert.Equal(t, StatusError, inst.GetStatusThreadSafe(),
+		"a session that was started and then lost its tmux must show error")
+}

--- a/internal/session/worktree_removal.go
+++ b/internal/session/worktree_removal.go
@@ -38,6 +38,39 @@ func IsRemovableWorktree(inst *Instance) bool {
 	return git.IsLinkedWorktree(wt)
 }
 
+// OtherSessionsShareWorktree reports whether any instance in others (other than
+// target itself) still references target's worktree directory. Paths are
+// compared canonically (EvalSymlinks), so a symlinked alias to the same
+// directory counts as a sharer. nil entries, target's own ID, and non-worktree
+// instances are skipped.
+//
+// This is the missing guard behind issue #1449: finishing one of several
+// sessions that share a single worktree must not remove the shared directory or
+// delete the branch while a sibling session still uses it.
+func OtherSessionsShareWorktree(target *Instance, others []*Instance) bool {
+	if target == nil {
+		return false
+	}
+	wt := strings.TrimSpace(target.WorktreePath)
+	if wt == "" {
+		return false
+	}
+	targetCanon := canonicalPath(wt)
+	for _, o := range others {
+		if o == nil || o.ID == target.ID {
+			continue
+		}
+		owt := strings.TrimSpace(o.WorktreePath)
+		if owt == "" {
+			continue
+		}
+		if canonicalPath(owt) == targetCanon {
+			return true
+		}
+	}
+	return false
+}
+
 // RemoveSessionWorktree removes the session's worktree directory if and only if
 // IsRemovableWorktree permits it. It returns whether a removal was performed.
 // A reused original repo (or any non-linked-worktree path) is left untouched —
@@ -52,6 +85,19 @@ func RemoveSessionWorktree(inst *Instance) (removed bool, err error) {
 	// Best-effort: drop the now-stale worktree administrative reference.
 	_ = git.PruneWorktrees(inst.WorktreeRepoRoot)
 	return true, nil
+}
+
+// RemoveSessionWorktreeUnlessShared is the shared-worktree-safe entry point
+// (issue #1449). It removes the session's worktree directory only when no OTHER
+// live session still references that worktree; otherwise it skips the
+// destructive git steps and reports removed=false so the caller merely detaches
+// this session from the registry. When this is the last sharer, behaviour is
+// identical to RemoveSessionWorktree (including the #1200 reuse guard).
+func RemoveSessionWorktreeUnlessShared(inst *Instance, others []*Instance) (removed bool, err error) {
+	if OtherSessionsShareWorktree(inst, others) {
+		return false, nil
+	}
+	return RemoveSessionWorktree(inst)
 }
 
 // canonicalPath resolves symlinks and cleans a path for equality comparison so

--- a/internal/session/worktree_removal.go
+++ b/internal/session/worktree_removal.go
@@ -108,5 +108,14 @@ func canonicalPath(p string) string {
 	if resolved, err := filepath.EvalSymlinks(p); err == nil {
 		return filepath.Clean(resolved)
 	}
+	// EvalSymlinks failed (e.g. the path no longer exists, or a broken/
+	// inaccessible symlink alias). Fall back to an absolute lexical clean so a
+	// relative vs absolute spelling of the same path still compares equal. For
+	// the shared-worktree check this matters: a false negative here would let a
+	// still-shared worktree reach destructive cleanup, so normalize before the
+	// lexical compare rather than trusting the raw input.
+	if abs, err := filepath.Abs(p); err == nil {
+		return filepath.Clean(abs)
+	}
 	return filepath.Clean(p)
 }

--- a/internal/session/worktree_removal_shared_test.go
+++ b/internal/session/worktree_removal_shared_test.go
@@ -1,0 +1,153 @@
+package session
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// Issue #1449: finishing ONE of several sessions that share a single worktree
+// removed the shared worktree directory AND deleted the branch, stranding the
+// remaining sessions (their `worktree info` flipped to MISSING).
+//
+// RemoveSessionWorktree had the #1200 "don't delete the original repo" guard
+// but NO "another live session still references this worktree" guard. The fix
+// adds a shared-use check: when other live instances resolve (via EvalSymlinks)
+// to the same worktree directory, the destructive git steps (worktree dir
+// removal + branch delete) are skipped and only THIS session's record is
+// dropped (detach). When the LAST sharer is finished, normal cleanup runs.
+
+func sharedWtBranchExists(t *testing.T, repo, branch string) bool {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+	return cmd.Run() == nil
+}
+
+// TestOtherSessionsShareWorktree reports the shared-use predicate directly.
+func TestOtherSessionsShareWorktree(t *testing.T) {
+	repo := issue1200InitRepo(t)
+	wt := issue1200AddWorktree(t, repo, "shared-feat")
+	otherWt := issue1200AddWorktree(t, repo, "lonely-feat")
+
+	target := &Instance{ID: "a", WorktreePath: wt, WorktreeRepoRoot: repo}
+	sameWt := &Instance{ID: "b", WorktreePath: wt, WorktreeRepoRoot: repo}
+	diffWt := &Instance{ID: "c", WorktreePath: otherWt, WorktreeRepoRoot: repo}
+
+	cases := []struct {
+		name   string
+		others []*Instance
+		want   bool
+	}{
+		{"no others", nil, false},
+		{"only itself in others (same ID excluded)", []*Instance{target}, false},
+		{"another session on the same worktree", []*Instance{sameWt}, true},
+		{"another session on a different worktree", []*Instance{diffWt}, false},
+		{"mixed: one shares, one does not", []*Instance{diffWt, sameWt}, true},
+		{"nil entries are skipped", []*Instance{nil, diffWt}, false},
+		{"non-worktree entries are skipped", []*Instance{{ID: "d"}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := OtherSessionsShareWorktree(target, tc.others); got != tc.want {
+				t.Errorf("OtherSessionsShareWorktree = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOtherSessionsShareWorktree_SymlinkAlias proves the EvalSymlinks resolve:
+// an alias path pointing at the same worktree dir counts as a sharer, so a
+// symlinked sibling is not silently treated as unrelated and then stranded.
+func TestOtherSessionsShareWorktree_SymlinkAlias(t *testing.T) {
+	repo := issue1200InitRepo(t)
+	wt := issue1200AddWorktree(t, repo, "alias-feat")
+
+	aliasDir := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(wt, aliasDir); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	target := &Instance{ID: "a", WorktreePath: wt, WorktreeRepoRoot: repo}
+	aliased := &Instance{ID: "b", WorktreePath: aliasDir, WorktreeRepoRoot: repo}
+
+	if !OtherSessionsShareWorktree(target, []*Instance{aliased}) {
+		t.Fatalf("a symlink alias to the same worktree must count as a sharer")
+	}
+}
+
+// TestRemoveSessionWorktreeUnlessShared_NonLastDetaches is THE #1449 regression:
+// finishing a non-last session sharing a worktree must NOT remove the worktree
+// dir nor delete the branch — the remaining sibling stays intact.
+func TestRemoveSessionWorktreeUnlessShared_NonLastDetaches(t *testing.T) {
+	repo := issue1200InitRepo(t)
+	wt := issue1200AddWorktree(t, repo, "shared")
+
+	target := &Instance{ID: "a", WorktreePath: wt, WorktreeRepoRoot: repo, WorktreeBranch: "shared"}
+	sibling := &Instance{ID: "b", WorktreePath: wt, WorktreeRepoRoot: repo, WorktreeBranch: "shared"}
+
+	removed, err := RemoveSessionWorktreeUnlessShared(target, []*Instance{sibling})
+	if err != nil {
+		t.Fatalf("RemoveSessionWorktreeUnlessShared (non-last) error: %v", err)
+	}
+	if removed {
+		t.Fatalf("non-last sharer must NOT remove the shared worktree (got removed=true)")
+	}
+	if _, statErr := os.Stat(wt); os.IsNotExist(statErr) {
+		t.Fatalf("DATA LOSS (#1449): shared worktree dir deleted while a sibling session still uses it")
+	}
+	if !sharedWtBranchExists(t, repo, "shared") {
+		t.Fatalf("DATA LOSS (#1449): branch deleted while a sibling session still uses the worktree")
+	}
+}
+
+// TestRemoveSessionWorktreeUnlessShared_LastCleansUp proves the cleanup still
+// runs for the final sharer: once no other session references the worktree,
+// finishing it removes the dir as before.
+func TestRemoveSessionWorktreeUnlessShared_LastCleansUp(t *testing.T) {
+	repo := issue1200InitRepo(t)
+	wt := issue1200AddWorktree(t, repo, "lastone")
+	sentinel := filepath.Join(repo, "PRECIOUS.txt")
+	if err := os.WriteFile(sentinel, []byte("main repo work"), 0o644); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+
+	target := &Instance{ID: "a", WorktreePath: wt, WorktreeRepoRoot: repo, WorktreeBranch: "lastone"}
+
+	removed, err := RemoveSessionWorktreeUnlessShared(target, nil)
+	if err != nil {
+		t.Fatalf("RemoveSessionWorktreeUnlessShared (last) error: %v", err)
+	}
+	if !removed {
+		t.Fatalf("last sharer must remove its dedicated worktree (got removed=false)")
+	}
+	if _, statErr := os.Stat(wt); !os.IsNotExist(statErr) {
+		t.Fatalf("expected the dedicated worktree %s to be removed for the last sharer", wt)
+	}
+	if _, statErr := os.Stat(sentinel); os.IsNotExist(statErr) {
+		t.Fatalf("DATA LOSS: original repo removed during last-sharer cleanup")
+	}
+}
+
+// TestRemoveSessionWorktreeUnlessShared_ReuseStillGuarded keeps the #1200
+// guarantee intact under the new entry point: a reused repo is never removed,
+// regardless of other sessions.
+func TestRemoveSessionWorktreeUnlessShared_ReuseStillGuarded(t *testing.T) {
+	repo := issue1200InitRepo(t)
+	sentinel := filepath.Join(repo, "PRECIOUS_USER_WORK.txt")
+	if err := os.WriteFile(sentinel, []byte("uncommitted work"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	inst := &Instance{ID: "a", WorktreePath: repo, WorktreeRepoRoot: repo}
+	removed, err := RemoveSessionWorktreeUnlessShared(inst, nil)
+	if err != nil {
+		t.Fatalf("RemoveSessionWorktreeUnlessShared (reuse) error: %v", err)
+	}
+	if removed {
+		t.Fatalf("reused repo must NOT be removed (#1200)")
+	}
+	if _, statErr := os.Stat(sentinel); os.IsNotExist(statErr) {
+		t.Fatalf("DATA LOSS (#1200): reused repo deleted")
+	}
+}

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -203,6 +203,9 @@ func (h *HelpOverlay) View() string {
 	watcherPanelKey := h.key(hotkeyWatcherPanel, "w")
 	groupKey := h.key(hotkeyCreateGroup, "g")
 	undoKey := h.key(hotkeyUndoDelete, "Ctrl+Z")
+	archiveKey := h.key(hotkeyArchiveSession, "A")
+	unarchiveKey := h.key(hotkeyUnarchiveSession, "Shift+U")
+	viewArchivedKey := h.key(hotkeyViewArchived, "^")
 
 	sections := []struct {
 		title string
@@ -245,6 +248,9 @@ func (h *HelpOverlay) View() string {
 				{deleteKey, "Delete session"},
 				{closeKey, "Close session process"},
 				{undoKey, "Undo delete"},
+				{archiveKey, "Archive session"},
+				{unarchiveKey, "Unarchive session"},
+				{viewArchivedKey, "Toggle archived view"},
 				{moveKey, "Move to group"},
 				{mcpKey, "MCP Manager (Claude/Gemini/Cursor)"},
 				{pluginKey, "Plugin Manager (Claude — RFC PLUGIN_ATTACH.md)"},

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -47,6 +47,29 @@ func TestHelpOverlayShowsNotesShortcutWhenEnabled(t *testing.T) {
 	}
 }
 
+// TestHelpOverlayShowsArchiveKeys is the regression for the #1325 help gap: the
+// archive family (A / Shift+U / ^) was reachable in the TUI and shown in the
+// top filter bar but missing from the `?` help overlay.
+func TestHelpOverlayShowsArchiveKeys(t *testing.T) {
+	overlay := NewHelpOverlay()
+	overlay.SetSize(100, 120) // tall enough to render the full SESSIONS section
+	overlay.Show()
+
+	view := overlay.View()
+	for _, want := range []string{"Archive session", "Unarchive session", "Toggle archived view"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("help overlay should document archive key %q (#1325), got %q", want, view)
+		}
+	}
+	// The archive default keybindings must surface too. Keys render exactly as
+	// stored in the keymap (lowercase chord names, matching ctrl+z / ctrl+r).
+	for _, key := range []string{"shift+u", "^"} {
+		if !strings.Contains(view, key) {
+			t.Fatalf("help overlay should show archive keybinding %q, got %q", key, view)
+		}
+	}
+}
+
 func TestWrapWithHangingIndent_ShortText_NoWrap(t *testing.T) {
 	got := wrapWithHangingIndent("Short text", 40, "    ")
 	want := "Short text"

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -11138,15 +11138,33 @@ func (h *Home) deleteSession(inst *session.Instance) tea.Cmd {
 	isMultiRepo := inst.IsMultiRepo()
 	multiRepoTempDir := inst.MultiRepoTempDir
 	multiRepoWorktrees := inst.MultiRepoWorktrees
+	// #1449: snapshot whether another live session still shares this worktree,
+	// under the lock, before the async closure runs (which must not touch
+	// h.instances). When shared, the worktree dir + branch are left intact and
+	// only this session's record is dropped.
+	sharedWorktree := false
+	if isWorktree {
+		h.instancesMu.RLock()
+		sharedWorktree = session.OtherSessionsShareWorktree(
+			&session.Instance{ID: id, WorktreePath: worktreePath, WorktreeRepoRoot: worktreeRepoRoot},
+			h.instances,
+		)
+		h.instancesMu.RUnlock()
+	}
 	return func() tea.Msg {
 		killErr := inst.Kill()
-		if isWorktree {
+		if isWorktree && sharedWorktree {
+			// #1449: another live session still references this worktree; skip
+			// the destructive removal + branch delete and merely drop this
+			// session's record so the siblings are not stranded.
+			uiLog.Info("worktree_remove_skipped", slog.String("path", worktreePath), slog.String("repo", worktreeRepoRoot), slog.String("reason", "another live session still references this worktree (#1449)"))
+		} else if isWorktree {
 			// #1200: route worktree teardown through the session guard so a
 			// worktree_reuse session (WorktreePath == the user's original repo)
 			// is never os.RemoveAll'd. Only genuine agent-deck-created linked
 			// worktrees are removed; a reused repo is left intact and merely
 			// dropped from the registry.
-			snap := &session.Instance{WorktreePath: worktreePath, WorktreeRepoRoot: worktreeRepoRoot}
+			snap := &session.Instance{ID: id, WorktreePath: worktreePath, WorktreeRepoRoot: worktreeRepoRoot}
 			switch removed, err := session.RemoveSessionWorktree(snap); {
 			case err != nil:
 				uiLog.Warn("worktree_remove_err", slog.String("path", worktreePath), slog.String("err", err.Error()))
@@ -17384,12 +17402,18 @@ func (h *Home) handleWorktreeFinishDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		repoRoot := h.worktreeFinishDialog.repoRoot
 		wtPath := h.worktreeFinishDialog.worktreePath
 
-		// Find the instance for kill/remove
+		// Find the instance for kill/remove, and snapshot whether any OTHER
+		// live session still shares this worktree (#1449). Computed here under
+		// the lock so the async finishWorktree closure never touches h.instances.
 		h.instancesMu.RLock()
 		inst := h.instanceByID[sid]
+		shared := session.OtherSessionsShareWorktree(
+			&session.Instance{ID: sid, WorktreePath: wtPath, WorktreeRepoRoot: repoRoot},
+			h.instances,
+		)
 		h.instancesMu.RUnlock()
 
-		return h, h.finishWorktree(inst, sid, sTitle, branch, repoRoot, wtPath, mergeEnabled, targetBranch, keepBranch)
+		return h, h.finishWorktree(inst, sid, sTitle, branch, repoRoot, wtPath, mergeEnabled, targetBranch, keepBranch, shared)
 
 	case "input":
 		// Pass through to text input
@@ -17427,7 +17451,7 @@ func (h *Home) runWorktreeSetup(inst *session.Instance) tea.Cmd {
 
 // finishWorktree performs the worktree finish operation asynchronously:
 // merge branch, remove worktree, delete branch, kill session, remove from storage
-func (h *Home) finishWorktree(inst *session.Instance, sessionID, sessionTitle, branchName, repoRoot, worktreePath string, mergeEnabled bool, targetBranch string, keepBranch bool) tea.Cmd {
+func (h *Home) finishWorktree(inst *session.Instance, sessionID, sessionTitle, branchName, repoRoot, worktreePath string, mergeEnabled bool, targetBranch string, keepBranch bool, sharedWorktree bool) tea.Cmd {
 	return func() tea.Msg {
 		merged := false
 
@@ -17444,16 +17468,29 @@ func (h *Home) finishWorktree(inst *session.Instance, sessionID, sessionTitle, b
 			merged = true
 		}
 
-		// Step 2: Remove worktree
-		if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
-			_ = git.RemoveWorktree(repoRoot, worktreePath, false)
-		}
-		_ = git.PruneWorktrees(repoRoot)
+		// #1449: when other live sessions still share this worktree, the
+		// destructive git steps (remove the shared dir + delete the branch)
+		// would strand those siblings (their `worktree info` → MISSING). Skip
+		// them and merely detach THIS session; the last sharer to finish runs
+		// the real cleanup. sharedWorktree is snapshotted by the caller under
+		// instancesMu so this async closure never touches h.instances.
+		if sharedWorktree {
+			uiLog.Info("worktree_finish_skipped_shared",
+				slog.String("id", sessionID),
+				slog.String("path", worktreePath),
+				slog.String("reason", "another live session still references this worktree (#1449)"))
+		} else {
+			// Step 2: Remove worktree
+			if _, statErr := os.Stat(worktreePath); !os.IsNotExist(statErr) {
+				_ = git.RemoveWorktree(repoRoot, worktreePath, false)
+			}
+			_ = git.PruneWorktrees(repoRoot)
 
-		// Step 3: Delete branch (if not keeping)
-		if !keepBranch {
-			// Use force delete if we merged (branch is fully merged), regular delete otherwise
-			_ = git.DeleteBranch(repoRoot, branchName, merged)
+			// Step 3: Delete branch (if not keeping)
+			if !keepBranch {
+				// Use force delete if we merged (branch is fully merged), regular delete otherwise
+				_ = git.DeleteBranch(repoRoot, branchName, merged)
+			}
 		}
 
 		// Step 4: Kill tmux session


### PR DESCRIPTION
## Summary

Fixes one data-loss-adjacent worktree bug plus two minor TUI findings surfaced by a TUI-verification pass.

### Fix 1 (priority) — #1449: finishing a non-last shared-worktree session orphans siblings

When several sessions share a single git worktree, finishing (or deleting) one of them removed the shared worktree directory and deleted the branch, leaving the remaining sessions pointing at a missing worktree (`worktree info` → MISSING).

Root cause: `RemoveSessionWorktree` (and the TUI `W` finish flow) had the #1200 "don't delete the original repo" guard but no "another live session still references this worktree" guard.

Fix: a new `OtherSessionsShareWorktree` predicate counts other live sessions whose worktree path resolves (via `EvalSymlinks`) to the same directory. Both teardown paths skip the destructive `git worktree remove` + branch delete while any sibling remains, dropping only the finished session's record. The last sharer cleans up exactly as before, and the #1200 reuse guard is unchanged. The shared-use check is snapshotted under `instancesMu` before the async closure, so the goroutine never touches `h.instances`.

### Fix 2 — minor TUI findings

- **Help overlay (#1325):** the `?` overlay now documents the archive family — `A` (archive), `Shift+U` (unarchive), `^` (toggle archived view) — which were reachable in the TUI and shown in the top filter bar but missing from help.
- **Never-started status:** a session added but never started is now classified as idle (`○`) instead of error (`✕`). A new `addedThisProcess` marker distinguishes a freshly-added in-process session from a reloaded one, so a session that was started and then lost its tmux still surfaces as error (CLI/TUI parity contract preserved).

## Tests

New regression tests (all `-race` clean):

- `TestOtherSessionsShareWorktree` (+ symlink-alias variant)
- `TestRemoveSessionWorktreeUnlessShared_NonLastDetaches` / `_LastCleansUp` / `_ReuseStillGuarded`
- `TestUpdateStatus_NeverStartedSessionIsIdleNotError` / `TestUpdateStatus_StartedThenLostTmuxIsStillError`
- `TestHelpOverlayShowsArchiveKeys`

Full `internal/session` (`-race`) and `internal/ui` suites pass; the existing `TestUpdateStatus_CLIvsTUIParity_Error` and all #1200 / #1396 worktree tests still pass.

Closes #1449.
