### PR TITLE
fix(web): make headless --no-tui web daemon work under a process supervisor (fixes #1452)

### DIFF
--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -458,9 +458,13 @@ func main() {
 		}
 	}
 
-	// Check if multiple instances are allowed (uses primary election as single-instance gate)
+	// Check if multiple instances are allowed (uses primary election as single-instance gate).
+	// In headless web mode (--no-tui), skip the gate — a headless HTTP server is meant to
+	// coexist with an interactive TUI for the same profile (the whole point of --no-tui), and
+	// the sibling TUI-launch guards above skip the same way. Without this, restarting the web
+	// daemon while a TUI holds the profile primary makes it lose ElectPrimary and exit.
 	instanceSettings := session.GetInstanceSettings()
-	if !instanceSettings.GetAllowMultiple() {
+	if !webHeadless && !instanceSettings.GetAllowMultiple() {
 		if db := statedb.GetGlobal(); db != nil {
 			isFirst, electErr := db.ElectPrimary(30 * time.Second)
 			if electErr == nil && !isFirst {

--- a/internal/web/terminal_bridge.go
+++ b/internal/web/terminal_bridge.go
@@ -283,7 +283,39 @@ func tmuxAttachCommand(sessionName, socketName string) *exec.Cmd {
 	// for ALL attached clients (Ghostty, iTerm) — the dots-in-window symptom.
 	// With largest in effect, every client sees content sized to the biggest
 	// viewer; smaller clients see a clipped portion rather than dot-filled void.
-	return tmuxCommand(socketName, "attach-session", "-t", sessionName)
+	cmd := tmuxCommand(socketName, "attach-session", "-t", sessionName)
+	// Guarantee a usable TERM for the attach client. When the web daemon runs
+	// under launchd/systemd its environment carries no TERM, and a tmux attach
+	// client with an empty/unset TERM aborts with "open terminal failed:
+	// terminal does not support clear" — the web terminal then never renders
+	// and the browser's resize message races the dying bridge into
+	// RESIZE_FAILED. The browser side is xterm.js, so xterm-256color is the
+	// correct client terminal type. A TERM the daemon legitimately inherited
+	// (e.g. `agent-deck web` launched from an interactive shell) is preserved.
+	cmd.Env = ensureTERM(cmd.Env)
+	return cmd
+}
+
+// ensureTERM returns env with a non-empty TERM guaranteed. A nil env (the
+// inherit-parent default) is materialized from os.Environ() first so the
+// appended TERM is not dropped. An existing non-empty TERM is left untouched;
+// an existing but empty TERM (`TERM=`) is replaced in place rather than
+// shadowed by a duplicate entry — execve passes the slice verbatim and getenv
+// resolution order for duplicate keys is unspecified, so a trailing append
+// could leave the empty value winning and tmux would still abort.
+func ensureTERM(env []string) []string {
+	if env == nil {
+		env = os.Environ()
+	}
+	for i, kv := range env {
+		if strings.HasPrefix(kv, "TERM=") {
+			if strings.TrimSpace(kv[len("TERM="):]) == "" {
+				env[i] = "TERM=xterm-256color"
+			}
+			return env
+		}
+	}
+	return append(env, "TERM=xterm-256color")
 }
 
 func tmuxSocketFromEnv() (string, bool) {

--- a/internal/web/terminal_bridge_test.go
+++ b/internal/web/terminal_bridge_test.go
@@ -127,6 +127,105 @@ func TestResize_AcceptsReasonableDimensions(t *testing.T) {
 	}
 }
 
+// TestEnsureTERM exercises the launchd/systemd failure mode directly: a web
+// daemon spawned by a supervisor inherits an environment with no TERM, and a
+// tmux attach client with an unset/empty TERM aborts with "open terminal
+// failed: terminal does not support clear". ensureTERM must guarantee a usable
+// TERM without clobbering one the daemon legitimately inherited.
+func TestEnsureTERM(t *testing.T) {
+	const fallback = "TERM=xterm-256color"
+
+	countTERM := func(env []string) (n int, last string) {
+		for _, kv := range env {
+			if strings.HasPrefix(kv, "TERM=") {
+				n++
+				last = kv
+			}
+		}
+		return n, last
+	}
+
+	t.Run("unset TERM gets the fallback appended", func(t *testing.T) {
+		env := []string{"PATH=/usr/bin", "HOME=/home/x"}
+		got := ensureTERM(env)
+		n, last := countTERM(got)
+		if n != 1 || last != fallback {
+			t.Fatalf("want exactly one %q, got n=%d last=%q (env=%v)", fallback, n, last, got)
+		}
+	})
+
+	t.Run("empty TERM is replaced in place, not duplicated", func(t *testing.T) {
+		env := []string{"TERM=", "PATH=/usr/bin"}
+		got := ensureTERM(env)
+		n, last := countTERM(got)
+		if n != 1 {
+			t.Fatalf("empty TERM must be replaced, not shadowed: got %d TERM entries (env=%v)", n, got)
+		}
+		if last != fallback {
+			t.Fatalf("want TERM replaced with %q, got %q", fallback, last)
+		}
+	})
+
+	t.Run("whitespace-only TERM is treated as empty and replaced", func(t *testing.T) {
+		env := []string{"TERM=   ", "PATH=/usr/bin"}
+		got := ensureTERM(env)
+		n, last := countTERM(got)
+		if n != 1 || last != fallback {
+			t.Fatalf("whitespace TERM must be replaced: got n=%d last=%q (env=%v)", n, last, got)
+		}
+	})
+
+	t.Run("inherited non-empty TERM is preserved untouched", func(t *testing.T) {
+		env := []string{"TERM=screen-256color", "PATH=/usr/bin"}
+		got := ensureTERM(env)
+		n, last := countTERM(got)
+		if n != 1 || last != "TERM=screen-256color" {
+			t.Fatalf("inherited TERM must be preserved: got n=%d last=%q", n, last)
+		}
+	})
+
+	t.Run("nil env is materialized and gets a TERM", func(t *testing.T) {
+		got := ensureTERM(nil)
+		if got == nil {
+			t.Fatal("nil env must be materialized, got nil")
+		}
+		if n, _ := countTERM(got); n == 0 {
+			t.Fatalf("materialized env must contain a TERM, got none (len=%d)", len(got))
+		}
+	})
+}
+
+// TestTmuxAttachCommand_InjectsTERM guards the wiring: the attach command's
+// environment must always carry a non-empty TERM regardless of socket path, so
+// the bridge renders under a TERM-less supervisor.
+func TestTmuxAttachCommand_InjectsTERM(t *testing.T) {
+	t.Setenv("TERM", "") // simulate a launchd-spawned daemon with no TERM
+
+	for _, tc := range []struct {
+		name       string
+		socketName string
+		tmuxEnv    string
+	}{
+		{"default server", "", ""},
+		{"socket from TMUX env", "", "/tmp/tmux-test.sock,1,0"},
+		{"explicit socket name", "agent-deck", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TMUX", tc.tmuxEnv)
+			cmd := tmuxAttachCommand("sess", tc.socketName)
+			found := false
+			for _, kv := range cmd.Env {
+				if strings.HasPrefix(kv, "TERM=") && strings.TrimSpace(kv[len("TERM="):]) != "" {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("attach command env must carry a non-empty TERM, got %v", cmd.Env)
+			}
+		})
+	}
+}
+
 // TestTmuxAttachCommand_WhitespaceSocketNameFallsBackToEnv: the same
 // defensive trim we use elsewhere. A typo like `socket_name = "   "` in
 // config must not send the web bridge to a phantom server named "   " —


### PR DESCRIPTION
Fixes #1452.

## Summary
Two independent but related bugs make `agent-deck web --no-tui` unusable when the
web server runs under a process supervisor (launchd on macOS, systemd on Linux)
rather than from an interactive shell. Together they mean a supervised headless
web daemon (1) won't stay up next to a TUI and (2) when it does, its session
terminal won't render. Both reproduce on a clean `main` (v1.9.63) — neither is a
downstream regression.

### 1. `--no-tui` crash-loops on the single-instance gate
The single-instance guard (`ElectPrimary`, `cmd/agent-deck/main.go`) exists to stop
two *interactive TUIs* fighting over a profile. The three adjacent TUI-only guards
(nested-session, outer-tmux, update-prompt) already exempt headless mode with
`!webHeadless`, but the primary-election gate was missed. So when a headless web
daemon restarts while a TUI holds the profile primary, it loses the election and
exits "already running" — and under `KeepAlive`/`Restart=always` it crash-loops.

Fix: add the same `!webHeadless` exemption. A headless HTTP server is meant to
coexist with an interactive TUI for the same profile (the point of `--no-tui`); it
registers as a non-primary instance and never needs primary status (it reads
storage-backed session data). Correctly scoped: `webHeadless` is set only for
`web --no-tui`, so plain TUI and `agent-deck web` (TUI+web) still go through the gate.

### 2. tmux attach fails with "terminal does not support clear" under a TERM-less supervisor
The web terminal bridge spawns `tmux attach-session` in a PTY and streams it to
xterm.js. The attach inherits the daemon's environment, and a supervisor-spawned
process has no `TERM`. A tmux client with an unset/empty `TERM` aborts immediately:

    open terminal failed: terminal does not support clear

The attach process dies, its error text is streamed to the browser, and the
browser's resize message then races the dying bridge into a repeating
`[error:RESIZE_FAILED]`. From a shell (`TERM=xterm-256color`) it works; under
launchd/systemd it never renders.

Fix: `ensureTERM` guarantees a non-empty `TERM` on the attach env. The browser
client is always xterm.js, so `xterm-256color` is the correct type. A `TERM` the
daemon legitimately inherited is preserved; an empty `TERM=` is replaced in place
(not shadowed by a duplicate entry, whose getenv resolution order is unspecified).

## Reproduction
- Run `agent-deck web --no-tui` from launchd/systemd (no TERM in the unit env) with
  a TUI already attached to the same profile.
- Before: daemon exits "already running" and crash-loops; if forced up, the web
  terminal shows `open terminal failed: terminal does not support clear` + repeating
  `[error:RESIZE_FAILED]`.
- After: daemon coexists with the TUI; the web terminal renders normally.

Empirically confirmed: attaching tmux in a PTY with TERM unset reproduces the exact
error; with `TERM=xterm-256color` it renders.

## Tests
- `TestEnsureTERM` — unset / empty / whitespace / inherited / nil-env cases,
  including the no-duplicate-on-empty guarantee.
- `TestTmuxAttachCommand_InjectsTERM` — the attach command carries a non-empty TERM
  across all three socket paths (default server, `$TMUX` env, explicit `-L` socket).
- The single-instance exemption mirrors three already-untested sibling guards in
  `func main()`; the `--no-tui` parsing it depends on is covered by the existing
  `extractNoTuiFlag` test.

## Verification
`gofmt` clean · `go vet ./...` clean · `go build ./...` OK · `golangci-lint` 0 issues ·
`go test -race ./internal/web/ ./internal/statedb/` pass · `go test ./cmd/agent-deck/`
(no-tui) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed headless web server incorrectly exiting when another instance holds primary ownership.
  * Fixed terminal environment configuration in tmux sessions by ensuring a valid terminal type is always set.

* **Tests**
  * Added test coverage for terminal environment variable handling and tmux session attachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->