### PR TITLE
feat(groups): declarative groups in config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ Attach/detach Claude skills per project with a managed pool workflow.
 - Apply writes project state to `.agent-deck/skills.toml` and materializes into `.claude/skills`
 - Type-to-jump is supported in the dialog (same pattern as MCP Manager)
 
+### Declarative groups
+
+Declare groups in `config.toml` so they exist on startup. Set `create = true` to ensure a group exists, and `default_path` to set the working directory for new sessions in it:
+
+```toml
+[groups."staging"]
+create = true                      # ensure the group exists
+
+[groups."projects/devops"]
+create = true
+default_path = "~/repos/devops"    # working directory for new sessions
+```
+
+On startup each group with `create = true` is created if missing (along with any parent groups). `default_path` is written to the state DB for any group that exists — including groups created from your sessions — so `create = true` is optional when the group is already there. Reconciliation is additive: removing a group from `config.toml` leaves the group and its sessions in place, and omitting `default_path` keeps any value already set. Clear a default with `agent-deck group update <name> --clear-default-path`.
+
 ### Per-group Claude config
 
 Agent Deck supports per-group `CLAUDE_CONFIG_DIR` and `env_file` overrides. Useful when a single profile hosts groups that should authenticate against different Claude accounts — for example, a personal profile hosting a `conductor` group pinned to `~/.claude-team` while other groups stay on `~/.claude`.

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -1249,7 +1249,7 @@ func handleAdd(profile string, args []string) {
 		fmt.Println("Add a new session to Agent Deck.")
 		fmt.Println()
 		fmt.Println("Arguments:")
-		fmt.Println("  [path]    Project directory (defaults to current directory)")
+		fmt.Println("  [path]    Project directory (defaults to the group or global default_path, else current directory)")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -1339,6 +1339,16 @@ func handleAdd(profile string, args []string) {
 	}
 
 	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+
+	// Seed groups declared in config.toml into the DB before resolving the
+	// new session's group and working directory.
+	if cfg, cfgErr := session.LoadUserConfig(); cfgErr == nil && cfg != nil {
+		if session.ReconcileDeclarativeGroups(groupTree, cfg) {
+			if err := storage.SaveGroupsOnly(groupTree); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to persist declarative groups: %v\n", err)
+			}
+		}
+	}
 
 	// Resolve parent session if specified
 	var parentInstance *session.Instance

--- a/internal/session/declarative_groups.go
+++ b/internal/session/declarative_groups.go
@@ -1,0 +1,59 @@
+package session
+
+import "strings"
+
+// canonicalGroupPath returns the stored path CreateGroupPath produces for the
+// given input.
+func canonicalGroupPath(path string) string {
+	segments := make([]string, 0)
+	for _, segment := range strings.Split(path, "/") {
+		if strings.TrimSpace(segment) == "" {
+			continue
+		}
+		clean := strings.ReplaceAll(sanitizeGroupName(segment), " ", "-")
+		segments = append(segments, clean)
+	}
+	return strings.Join(segments, "/")
+}
+
+// ReconcileDeclarativeGroups creates groups declared with create = true under
+// [groups."<path>"] in cfg, and applies default_path to declared or existing
+// groups. It never deletes a group and never clears a field config omits, and
+// returns true if the tree was modified.
+//
+// Callers must pass a tree loaded with the full stored group set.
+func ReconcileDeclarativeGroups(tree *GroupTree, cfg *UserConfig) bool {
+	if tree == nil || cfg == nil {
+		return false
+	}
+
+	changed := false
+	for key, settings := range cfg.Groups {
+		if !settings.Create && settings.DefaultPath == "" {
+			continue
+		}
+		path := canonicalGroupPath(key)
+		if path == "" {
+			continue
+		}
+
+		if settings.Create {
+			if _, exists := tree.Groups[path]; !exists {
+				if tree.CreateGroupPath(path) == nil {
+					continue
+				}
+				changed = true
+			}
+		}
+
+		if settings.DefaultPath == "" {
+			continue
+		}
+		resolved := resolveGroupDefaultPath(settings.DefaultPath)
+		if group := tree.Groups[path]; group != nil && group.DefaultPath != resolved {
+			tree.SetDefaultPathForGroup(path, settings.DefaultPath)
+			changed = true
+		}
+	}
+	return changed
+}

--- a/internal/session/declarative_groups_test.go
+++ b/internal/session/declarative_groups_test.go
@@ -1,0 +1,228 @@
+package session
+
+import "testing"
+
+func emptyTree() *GroupTree {
+	return NewGroupTree([]*Instance{})
+}
+
+// TestCanonicalGroupPathMatchesCreate verifies canonicalGroupPath predicts exactly the path CreateGroupPath stores.
+func TestCanonicalGroupPathMatchesCreate(t *testing.T) {
+	cases := []string{
+		"projects",
+		"Projects/DevOps",
+		"work/My Api.",
+		"a//b/",
+		"weird@@name",
+	}
+	for _, key := range cases {
+		tree := emptyTree()
+		leaf := tree.CreateGroupPath(key)
+		if leaf == nil {
+			t.Fatalf("CreateGroupPath(%q) returned nil", key)
+		}
+		if got := canonicalGroupPath(key); got != leaf.Path {
+			t.Errorf("canonicalGroupPath(%q) = %q, CreateGroupPath stored %q", key, got, leaf.Path)
+		}
+	}
+}
+
+// TestReconcileCreatesMissingGroupWithParents verifies a declared nested group is created along with its parents.
+func TestReconcileCreatesMissingGroupWithParents(t *testing.T) {
+	tree := emptyTree()
+	cfg := &UserConfig{Groups: map[string]GroupSettings{"work/api": {Create: true}}}
+
+	if !ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("expected changed=true creating a new nested group")
+	}
+	if _, ok := tree.Groups["work"]; !ok {
+		t.Error("parent group 'work' was not created")
+	}
+	if _, ok := tree.Groups["work/api"]; !ok {
+		t.Error("leaf group 'work/api' was not created")
+	}
+}
+
+// TestReconcileCreatesFlaggedGroupWithoutDefaultPath verifies create = true alone materializes a path-less group.
+func TestReconcileCreatesFlaggedGroupWithoutDefaultPath(t *testing.T) {
+	tree := emptyTree()
+	cfg := &UserConfig{Groups: map[string]GroupSettings{"staging": {Create: true}}}
+
+	if !ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("expected changed=true creating a flagged group")
+	}
+	g, ok := tree.Groups["staging"]
+	if !ok {
+		t.Fatal("group 'staging' was not created")
+	}
+	if g.DefaultPath != "" {
+		t.Errorf("DefaultPath = %q, want empty for a path-less group", g.DefaultPath)
+	}
+	if ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("second run should report changed=false")
+	}
+}
+
+// TestReconcileAppliesDefaultPath verifies a declared default_path is written to the created group.
+func TestReconcileAppliesDefaultPath(t *testing.T) {
+	dir := t.TempDir()
+	tree := emptyTree()
+	cfg := &UserConfig{Groups: map[string]GroupSettings{"proj": {Create: true, DefaultPath: dir}}}
+
+	if !ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("expected changed=true applying default_path")
+	}
+	if got := tree.Groups["proj"].DefaultPath; got != dir {
+		t.Errorf("DefaultPath = %q, want %q", got, dir)
+	}
+}
+
+// TestReconcileIsIdempotent verifies a second run with unchanged config reports no change.
+func TestReconcileIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	tree := emptyTree()
+	cfg := &UserConfig{Groups: map[string]GroupSettings{"proj": {Create: true, DefaultPath: dir}}}
+
+	if !ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("first run should report changed=true")
+	}
+	if ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("second run should report changed=false")
+	}
+	if got := tree.Groups["proj"].DefaultPath; got != dir {
+		t.Errorf("DefaultPath drifted to %q, want %q", got, dir)
+	}
+}
+
+// TestReconcileDefaultPathAppliesToExistingGroup verifies default_path applies to an existing group without create = true.
+func TestReconcileDefaultPathAppliesToExistingGroup(t *testing.T) {
+	dir := t.TempDir()
+	tree := emptyTree()
+	tree.CreateGroup("proj")
+
+	cfg := &UserConfig{Groups: map[string]GroupSettings{"proj": {DefaultPath: dir}}}
+	if !ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("expected changed=true applying default_path to an existing group")
+	}
+	if got := tree.Groups["proj"].DefaultPath; got != dir {
+		t.Errorf("DefaultPath = %q, want %q", got, dir)
+	}
+}
+
+// TestReconcileDefaultPathWithoutCreateSkipsMissingGroup verifies default_path without create = true does not create a missing group.
+func TestReconcileDefaultPathWithoutCreateSkipsMissingGroup(t *testing.T) {
+	dir := t.TempDir()
+	tree := emptyTree()
+
+	cfg := &UserConfig{Groups: map[string]GroupSettings{"ghost": {DefaultPath: dir}}}
+	if ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("expected changed=false: default_path alone must not create a group")
+	}
+	if _, ok := tree.Groups["ghost"]; ok {
+		t.Error("group 'ghost' must not be created without create = true")
+	}
+}
+
+// TestReconcileNoOpWhenMatching verifies no change is reported when the group and default_path already match.
+func TestReconcileNoOpWhenMatching(t *testing.T) {
+	dir := t.TempDir()
+	tree := emptyTree()
+	tree.CreateGroup("proj")
+	tree.SetDefaultPathForGroup("proj", dir)
+
+	cfg := &UserConfig{Groups: map[string]GroupSettings{"proj": {DefaultPath: dir}}}
+	if ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("expected changed=false when group and default_path already match")
+	}
+}
+
+// TestReconcileMutatesAuthoritatively verifies config's default_path overwrites a different stored value.
+func TestReconcileMutatesAuthoritatively(t *testing.T) {
+	old := t.TempDir()
+	want := t.TempDir()
+	tree := emptyTree()
+	tree.CreateGroup("proj")
+	tree.SetDefaultPathForGroup("proj", old)
+
+	cfg := &UserConfig{Groups: map[string]GroupSettings{"proj": {DefaultPath: want}}}
+	if !ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("expected changed=true overwriting an existing default_path")
+	}
+	if got := tree.Groups["proj"].DefaultPath; got != want {
+		t.Errorf("DefaultPath = %q, want %q (config should win)", got, want)
+	}
+}
+
+// TestReconcileDoesNotClearOmittedDefaultPath verifies an omitted default_path leaves the stored value intact.
+func TestReconcileDoesNotClearOmittedDefaultPath(t *testing.T) {
+	dir := t.TempDir()
+	tree := emptyTree()
+	tree.CreateGroup("proj")
+	tree.SetDefaultPathForGroup("proj", dir)
+
+	cfg := &UserConfig{Groups: map[string]GroupSettings{"proj": {}}}
+	if ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("expected changed=false: group exists and no default_path declared")
+	}
+	if got := tree.Groups["proj"].DefaultPath; got != dir {
+		t.Errorf("DefaultPath was cleared to %q, want it retained as %q", got, dir)
+	}
+}
+
+// TestReconcileNeverDeletes verifies a group absent from config is left in place.
+func TestReconcileNeverDeletes(t *testing.T) {
+	tree := emptyTree()
+	tree.CreateGroup("keep")
+
+	cfg := &UserConfig{Groups: map[string]GroupSettings{"proj": {Create: true}}}
+	ReconcileDeclarativeGroups(tree, cfg)
+
+	if _, ok := tree.Groups["keep"]; !ok {
+		t.Error("group 'keep' absent from config must not be deleted")
+	}
+	if _, ok := tree.Groups["proj"]; !ok {
+		t.Error("declared group 'proj' should have been created")
+	}
+}
+
+// TestReconcileIgnoresToolOnlyGroupBlock verifies a .claude/.hermes-only block with no create flag creates nothing.
+func TestReconcileIgnoresToolOnlyGroupBlock(t *testing.T) {
+	tree := emptyTree()
+	cfg := &UserConfig{Groups: map[string]GroupSettings{
+		"conductor": {Claude: GroupClaudeSettings{ConfigDir: "~/.claude-work"}},
+		"infra":     {Hermes: GroupHermesSettings{Command: "hermes"}},
+	}}
+
+	if ReconcileDeclarativeGroups(tree, cfg) {
+		t.Fatal("tool-only group blocks must not report a change")
+	}
+	if _, ok := tree.Groups["conductor"]; ok {
+		t.Error("claude-only block must not create the 'conductor' group")
+	}
+	if _, ok := tree.Groups["infra"]; ok {
+		t.Error("hermes-only block must not create the 'infra' group")
+	}
+}
+
+// TestReconcileNilSafe verifies nil tree or config inputs report no change.
+func TestReconcileNilSafe(t *testing.T) {
+	if ReconcileDeclarativeGroups(nil, &UserConfig{}) {
+		t.Error("nil tree should report changed=false")
+	}
+	if ReconcileDeclarativeGroups(emptyTree(), nil) {
+		t.Error("nil cfg should report changed=false")
+	}
+}
+
+// TestCountFunctionalGroupsCountsDeclarativeFields verifies create and default_path mark a group functional for the section-drop guard.
+func TestCountFunctionalGroupsCountsDeclarativeFields(t *testing.T) {
+	groups := map[string]GroupSettings{
+		"flagged":   {Create: true},
+		"pathed":    {DefaultPath: "/tmp/x"},
+		"tool-only": {Claude: GroupClaudeSettings{ConfigDir: "~/.c"}},
+		"empty":     {},
+	}
+	if got := countFunctionalGroups(groups); got != 3 {
+		t.Errorf("countFunctionalGroups = %d, want 3 (flagged, pathed, tool-only)", got)
+	}
+}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -644,6 +644,10 @@ type ProfileCodexSettings struct {
 
 // GroupSettings defines per-group configuration overrides.
 type GroupSettings struct {
+	// Create ensures the group exists on startup.
+	Create bool `toml:"create,omitempty"`
+	// DefaultPath sets the default working directory for new sessions in this group.
+	DefaultPath string `toml:"default_path,omitempty"`
 	// Claude defines Claude Code overrides for a specific group.
 	Claude GroupClaudeSettings `toml:"claude,omitempty"`
 	// Hermes defines Hermes overrides for a specific group.
@@ -2690,7 +2694,7 @@ func countFunctionalGroups(groups map[string]GroupSettings) int {
 	var zero GroupSettings
 	count := 0
 	for _, g := range groups {
-		if g.Claude != zero.Claude || g.Hermes != zero.Hermes {
+		if g.Create || strings.TrimSpace(g.DefaultPath) != "" || g.Claude != zero.Claude || g.Hermes != zero.Hermes {
 			count++
 		}
 	}

--- a/internal/session/userconfig_section_guard_test.go
+++ b/internal/session/userconfig_section_guard_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -301,5 +302,74 @@ func TestSaveUserConfig_AllZeroGroupEntry_DoesNotBlockSaves(t *testing.T) {
 	loaded.Theme = "light"
 	if err := SaveUserConfig(loaded); err != nil {
 		t.Fatalf("expected save to succeed when sole group entry is all-zero, got: %v", err)
+	}
+}
+
+// A config carrying [mcps], [profiles], a tool-only [groups] block, and a
+// declarative [groups] block survives a normal save with every section intact;
+// omitempty keeps create/default_path out of the tool-only block.
+func TestSaveUserConfig_PreservesSectionsWithDeclarativeGroups(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	isolateConfigHomeXDG(t)
+
+	cfg := cloneDefaultUserConfig()
+	cfg.MCPs = map[string]MCPDef{
+		"context7": {Command: "npx", Args: []string{"-y", "context7"}},
+	}
+	cfg.Profiles = map[string]ProfileSettings{
+		"work": {Codex: ProfileCodexSettings{ConfigDir: "~/.codex-work"}},
+	}
+	cfg.Groups = map[string]GroupSettings{
+		"tools":   {Claude: GroupClaudeSettings{ConfigDir: "~/.claude-work"}},
+		"staging": {Create: true, DefaultPath: "~/repos/staging"},
+	}
+	if err := SaveUserConfigWithIntent(&cfg, true); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	ReloadUserConfig()
+
+	loaded, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+	loaded.Theme = "light"
+	if err := SaveUserConfig(loaded); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	got, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if _, ok := got.MCPs["context7"]; !ok {
+		t.Error("[mcps] context7 not preserved")
+	}
+	if _, ok := got.Profiles["work"]; !ok {
+		t.Error("[profiles.work] not preserved")
+	}
+	if _, ok := got.Groups["tools"]; !ok {
+		t.Error("tool-only [groups.tools] not preserved")
+	}
+	g, ok := got.Groups["staging"]
+	if !ok {
+		t.Fatal("declarative [groups.staging] not preserved")
+	}
+	if !g.Create || g.DefaultPath == "" {
+		t.Errorf("declarative group fields lost: %+v", g)
+	}
+
+	configPath, err := GetUserConfigPath()
+	if err != nil {
+		t.Fatalf("GetUserConfigPath: %v", err)
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(raw), "create = false") {
+		t.Error("omitempty failed: 'create = false' written into a group block")
+	}
+	if strings.Contains(string(raw), `default_path = ""`) {
+		t.Error(`omitempty failed: 'default_path = "" written into a group block`)
 	}
 }

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -4627,6 +4627,17 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					h.groupTree = session.NewGroupTree(h.instances)
 				}
+				// Seed groups declared in config.toml into the DB, only after a
+				// successful load so a partial tree is never persisted.
+				if msg.err == nil {
+					if cfg, cfgErr := session.LoadUserConfig(); cfgErr == nil && cfg != nil {
+						if session.ReconcileDeclarativeGroups(h.groupTree, cfg) {
+							if err := h.storage.SaveGroupsOnly(h.groupTree); err != nil {
+								uiLog.Warn("declarative_groups_save_failed", slog.Any("error", err))
+							}
+						}
+					}
+				}
 			} else {
 				// Refresh - update existing tree with loaded sessions AND groups
 				// Preserve expanded state before recreating tree


### PR DESCRIPTION
Adds declarative group configuration to `config.toml`: groups can be created and given a default working directory up front, instead of only through `agent-deck group` at runtime. The group default-path mechanism itself is unchanged — this exposes it (and group creation) declaratively.

## What changed
- New `[groups."<path>"]` keys: `create` and `default_path`.
  - `create = true` ensures the group exists on startup, creating parents for nested paths.
  - `default_path` sets the working directory for new sessions in the group. It applies to any group that already exists, so `create` is only needed to bring a new group into being.
- `ReconcileDeclarativeGroups` (`internal/session/declarative_groups.go`) runs on the loaded group tree, creates declared groups via `CreateGroupPath`, and applies `default_path` via the existing `SetDefaultPathForGroup`. It reports whether the tree changed so callers persist only on change.
- Wired into the TUI initial load (`internal/ui/home.go`) and the CLI `add` path (`cmd/agent-deck/main.go`), persisting with `SaveGroupsOnly`.

## How
- Reconciliation is additive: a group dropped from config stays in place, and an omitted `default_path` keeps the stored value.
- Only `create = true` materializes a group, so existing `[groups."<path>".claude]` / `.hermes` per-group tool config resolves as before.
- Config keys canonicalize through the same `sanitizeGroupName` path `CreateGroupPath` uses, so a declared key matches the stored group path.
- `default_path` is authoritative for declared groups: a changed value in config overwrites the stored value on next startup.

## Tests
- `internal/session`: reconciler unit tests — create (incl. parents), path-less create via `create`, `default_path` applied to an existing group, `default_path` without `create` skips a missing group, tool-only blocks create nothing, authoritative overwrite, no-clear-on-omit, idempotency, never-delete, canonical-path parity, nil-safety.
- `go build ./...`, `go vet ./...`, and `golangci-lint run` clean; `TestPersistence_` and `TestPerGroupConfig_` pass with `-race`; new reconciler tests and the touched `internal/ui` / `cmd/agent-deck` suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative group settings in the configuration can now auto-create missing groups at startup (including required parent groups).
  * Groups can specify a `default_path` used as the working directory for new sessions, applied to existing groups too.
  * The `add` command help now correctly documents fallback when a path is omitted (group/global `default_path`, otherwise current directory).
* **Bug Fixes**
  * Configuration saving now preserves non-empty sections and avoids emitting empty `create`/`default_path` values where not set.
* **Tests**
  * Added coverage for group reconciliation, canonical path normalization, idempotency, default application rules, and “never delete” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->