### PR TITLE
fix(session): allow restarting live Cursor sessions

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -6082,6 +6082,28 @@ func (i *Instance) Restart() error {
 		return nil
 	}
 
+	// If Cursor session AND tmux session exists, use respawn-pane.
+	if i.Tool == "cursor" && i.tmuxSession != nil && i.tmuxSession.Exists() {
+		resumeCmd, containerName, err := i.prepareCommand(i.buildCursorCommand(i.Command, true))
+		if err != nil {
+			return err
+		}
+		if containerName != "" {
+			i.SandboxContainer = containerName
+		}
+		sessionLog.Info("restart_cursor_respawn", slog.String("command", resumeCmd))
+
+		if err := i.tmuxSession.RespawnPane(resumeCmd); err != nil {
+			sessionLog.Info("restart_cursor_respawn_failed", slog.String("error", err.Error()))
+			return fmt.Errorf("failed to restart Cursor session: %w", err)
+		}
+
+		sessionLog.Info("restart_cursor_respawn_succeeded")
+		i.ensureProfileEnv()
+		i.Status = StatusWaiting
+		return nil
+	}
+
 	// If custom tool with session resume support AND tmux session exists, use respawn-pane.
 	if i.CanRestartGeneric() && i.tmuxSession != nil && i.tmuxSession.Exists() {
 		toolDef := GetToolDef(i.Tool)
@@ -6556,6 +6578,11 @@ func (i *Instance) CanRestart() bool {
 	// Pi sessions are scoped to an Agent Deck instance-specific session dir and
 	// can always be relaunched with --continue.
 	if i.Tool == "pi" {
+		return true
+	}
+
+	// Cursor sessions resume via --continue on restart (workspace-scoped chat).
+	if i.Tool == "cursor" {
 		return true
 	}
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -6100,6 +6100,8 @@ func (i *Instance) Restart() error {
 
 		sessionLog.Info("restart_cursor_respawn_succeeded")
 		i.ensureProfileEnv()
+		i.sweepDuplicateToolSessions()
+		i.CaptureLoadedMCPs()
 		i.Status = StatusWaiting
 		return nil
 	}

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -1743,6 +1743,38 @@ func TestBuildCodexCommand_InlineCodexHomeDropsStaleID(t *testing.T) {
 	}
 }
 
+func TestCanRestartCursor(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+
+	inst := NewInstanceWithTool("cursor-restart-test", "/tmp", "cursor")
+	inst.Command = "sleep 60"
+	err := inst.Start()
+	if err != nil {
+		t.Fatalf("Failed to start session: %v", err)
+	}
+	defer func() { _ = inst.Kill() }()
+
+	inst.Status = StatusRunning
+
+	if !inst.CanRestart() {
+		t.Fatal("CanRestart() should return true for a running Cursor session with live tmux pane")
+	}
+
+	// Simulate persisted command from a real Cursor session before restart.
+	inst.Command = "cursor agent"
+
+	if err := inst.Restart(); err != nil {
+		t.Fatalf("Restart failed: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if inst.tmuxSession == nil || !inst.tmuxSession.Exists() {
+		t.Fatal("tmux session should exist after Restart")
+	}
+	if inst.Status == StatusError {
+		t.Fatalf("after Restart, Status = %s; want != error", inst.Status)
+	}
+}
+
 func TestBuildCursorCommand(t *testing.T) {
 	inst := NewInstanceWithTool("c1", "/tmp/c1", "cursor")
 	inst.Command = ""


### PR DESCRIPTION
CanRestart() omitted cursor, so pressing R on a running session was a no-op. Add a respawn-pane restart path with --continue, matching other agent tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cursor session restart behavior to properly resume workspaces when existing tmux sessions are present.
  * Cursor sessions are now eligible for restart in additional scenarios.

* **Tests**
  * Added integration test coverage for Cursor session restart functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->