### PR TITLE
feat(cursor): add hook-based status for conductor notifications

### DIFF
--- a/cmd/agent-deck/cursor_hooks_cmd.go
+++ b/cmd/agent-deck/cursor_hooks_cmd.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func handleCursorHooks(args []string) {
+	if len(args) == 0 {
+		printCursorHooksUsage(os.Stderr)
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "help", "--help", "-h":
+		printCursorHooksUsage(os.Stdout)
+	case "install":
+		handleCursorHooksInstall()
+	case "uninstall":
+		handleCursorHooksUninstall()
+	case "status":
+		handleCursorHooksStatus()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown cursor-hooks subcommand: %s\n", args[0])
+		printCursorHooksUsage(os.Stderr)
+		os.Exit(1)
+	}
+}
+
+func printCursorHooksUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage: agent-deck cursor-hooks <command>")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Manage Cursor Agent CLI hook integration.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Commands:")
+	fmt.Fprintln(w, "  install      Install agent-deck Cursor hooks")
+	fmt.Fprintln(w, "  uninstall    Remove agent-deck Cursor hooks")
+	fmt.Fprintln(w, "  status       Show Cursor hooks install status")
+}
+
+func handleCursorHooksInstall() {
+	configDir := getCursorConfigDirForHooks()
+	installed, err := session.InjectCursorHooks(configDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error installing Cursor hooks: %v\n", err)
+		os.Exit(1)
+	}
+	if installed {
+		fmt.Println("Cursor hooks installed successfully.")
+		fmt.Printf("Config: %s/hooks.json\n", configDir)
+	} else {
+		fmt.Println("Cursor hooks are already installed.")
+	}
+}
+
+func handleCursorHooksUninstall() {
+	configDir := getCursorConfigDirForHooks()
+	removed, err := session.RemoveCursorHooks(configDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error removing Cursor hooks: %v\n", err)
+		os.Exit(1)
+	}
+	if removed {
+		fmt.Println("Cursor hooks removed successfully.")
+	} else {
+		fmt.Println("No agent-deck Cursor hooks found to remove.")
+	}
+}
+
+func handleCursorHooksStatus() {
+	configDir := getCursorConfigDirForHooks()
+	installed := session.CheckCursorHooksInstalled(configDir)
+	configPath := filepath.Join(configDir, "hooks.json")
+
+	if installed {
+		fmt.Println("Status: INSTALLED")
+		fmt.Printf("Config: %s\n", configPath)
+	} else {
+		fmt.Println("Status: NOT INSTALLED")
+		fmt.Println("Run 'agent-deck cursor-hooks install' to install.")
+	}
+}
+
+func getCursorConfigDirForHooks() string {
+	return session.GetCursorConfigDir()
+}

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -29,11 +29,11 @@ var validInstanceID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
 // hookPayload represents the JSON payload Claude Code sends to hooks via stdin.
 // Only the fields we need are decoded; unknown fields are ignored.
 type hookPayload struct {
-	HookEventName string          `json:"hook_event_name"`
-	SessionID     string          `json:"session_id"`
-	ConversationID string         `json:"conversation_id"`
-	Source        string          `json:"source"`
-	Matcher       json.RawMessage `json:"matcher,omitempty"`
+	HookEventName  string          `json:"hook_event_name"`
+	SessionID      string          `json:"session_id"`
+	ConversationID string          `json:"conversation_id"`
+	Source         string          `json:"source"`
+	Matcher        json.RawMessage `json:"matcher,omitempty"`
 	// Cwd is the session's working directory (PROJECT_DIR) as reported by
 	// Claude Code on each hook event. Issue #1233: when a running session's
 	// registered worktree is renamed/removed, this points at a path that no

--- a/cmd/agent-deck/hook_handler.go
+++ b/cmd/agent-deck/hook_handler.go
@@ -31,6 +31,7 @@ var validInstanceID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
 type hookPayload struct {
 	HookEventName string          `json:"hook_event_name"`
 	SessionID     string          `json:"session_id"`
+	ConversationID string         `json:"conversation_id"`
 	Source        string          `json:"source"`
 	Matcher       json.RawMessage `json:"matcher,omitempty"`
 	// Cwd is the session's working directory (PROJECT_DIR) as reported by
@@ -79,46 +80,52 @@ type hookStatusFile struct {
 	TranscriptPath string `json:"transcript_path,omitempty"`
 }
 
-// mapEventToStatus maps a Claude Code hook event to an agent-deck status string.
+// normalizeHookEventKey folds hook event names from Claude (PascalCase), Cursor
+// (camelCase), Hermes (snake_case), and Codex into a single lookup key.
+func normalizeHookEventKey(event string) string {
+	s := strings.ToLower(strings.TrimSpace(event))
+	return strings.NewReplacer("_", "", "-", "", " ", "").Replace(s)
+}
+
+func isStopHookEvent(event string) bool {
+	return normalizeHookEventKey(event) == "stop"
+}
+
+// mapEventToStatus maps a hook event to an agent-deck status string.
 // Status semantics in agent-deck:
-//   - "running" = Claude is actively processing (green)
-//   - "waiting" = Claude is at the prompt, waiting for user input (orange)
+//   - "running" = agent is actively processing (green)
+//   - "waiting" = agent is at the prompt, waiting for user input (orange)
 //   - "dead"    = Session ended
-//
-// Gemini mappings:
-//   - "BeforeAgent" = running
-//   - "AfterAgent"  = waiting
 func mapEventToStatus(event string) string {
-	switch event {
-	case "SessionStart":
-		return "waiting" // Claude at initial prompt, waiting for user input
-	case "BeforeAgent":
+	switch normalizeHookEventKey(event) {
+	case "sessionstart":
+		return "waiting" // at initial prompt, waiting for user input
+	case "beforeagent":
 		return "running" // Gemini received user input and is processing
-	case "AfterAgent":
+	case "afteragent":
 		return "waiting" // Gemini completed response, back to waiting
-	// Hermes shell hook events
-	case "pre_tool_call":
-		return "running" // Hermes is executing a tool call
-	case "post_tool_call":
-		return "waiting" // Hermes finished a tool call, back at prompt
-	case "on_session_start":
+	case "pretoolcall", "pretooluse":
+		return "running" // executing a tool call
+	case "posttoolcall", "posttooluse", "posttoolusefailure":
+		return "waiting" // finished a tool call, back at prompt
+	case "onsessionstart":
 		return "waiting" // Hermes session started, waiting for first prompt
-	case "on_session_end":
+	case "onsessionend":
 		return "dead" // Hermes session ended
-	case "UserPromptSubmit":
-		return "running" // User sent prompt, Claude is processing
-	case "Stop":
-		return "waiting" // Claude finished, back at prompt waiting for user
-	case "PermissionRequest":
-		return "waiting" // Claude needs permission approval
-	case "Notification":
+	case "userpromptsubmit", "beforesubmitprompt":
+		return "running" // user sent prompt, agent is processing
+	case "stop":
+		return "waiting" // agent finished, back at prompt waiting for user
+	case "permissionrequest":
+		return "waiting" // agent needs permission approval
+	case "notification":
 		// Notification events with permission_prompt|elicitation_dialog matcher
 		// are mapped to "waiting" by the caller after checking the matcher.
 		// Default notification is informational, treat as no status change.
 		return ""
-	case "SessionEnd":
+	case "sessionend":
 		return "dead"
-	case "PreCompact":
+	case "precompact":
 		return "" // Observability only; context-% monitoring handles /clear proactively
 	default:
 		return ""
@@ -168,7 +175,7 @@ func handleHookHandler() {
 
 	// Special handling for Notification events: only map to "waiting" if
 	// the matcher indicates a permission prompt or elicitation dialog
-	if payload.HookEventName == "Notification" && payload.Matcher != nil {
+	if normalizeHookEventKey(payload.HookEventName) == "notification" && payload.Matcher != nil {
 		var matcher string
 		if err := json.Unmarshal(payload.Matcher, &matcher); err == nil {
 			if matcher == "permission_prompt" || matcher == "elicitation_dialog" {
@@ -192,17 +199,22 @@ func handleHookHandler() {
 	// SYNCHRONOUSLY (#1225), so waiting out the flush here would add turn-end
 	// latency to every managed session. Absent on ordinary mid-task Stops, so
 	// the existing "waiting" behavior is unchanged.
-	if payload.HookEventName == "Stop" {
-		writeHookStatusWithScan(instanceID, status, payload.SessionID, payload.HookEventName, detectDoneSentinel(data))
+	sessionID := strings.TrimSpace(payload.SessionID)
+	if sessionID == "" {
+		sessionID = strings.TrimSpace(payload.ConversationID)
+	}
+
+	if isStopHookEvent(payload.HookEventName) {
+		writeHookStatusWithScan(instanceID, status, sessionID, payload.HookEventName, detectDoneSentinel(data))
 	} else {
-		writeHookStatus(instanceID, status, payload.SessionID, payload.HookEventName)
+		writeHookStatus(instanceID, status, sessionID, payload.HookEventName)
 	}
 
 	// #572: Sync agent-deck title from Claude Code's --name / /rename value.
 	// Event-driven so user-facing rename lands within one hook tick; silent
 	// no-op when no name is set (sessions started without --name keep the
 	// existing agent-deck adjective-noun title).
-	applyClaudeTitleSync(instanceID, payload.SessionID)
+	applyClaudeTitleSync(instanceID, sessionID)
 
 	// Write cost event if this hook contains usage data
 	logCostDebug("hook event=%s instance=%s status=%s", payload.HookEventName, instanceID, status)
@@ -216,7 +228,7 @@ func handleHookHandler() {
 	// that exits with no decision falls through to Claude Code's default,
 	// which denies in UI-less contexts. Status-tracking behavior above is
 	// unchanged.
-	if payload.HookEventName == "PermissionRequest" && parentIsDSP() {
+	if normalizeHookEventKey(payload.HookEventName) == "permissionrequest" && parentIsDSP() {
 		fmt.Println(`{"hookSpecificOutput":{"hookEventName":"PermissionRequest","permissionDecision":"allow"}}`)
 	}
 
@@ -231,7 +243,7 @@ func handleHookHandler() {
 	// SYNCHRONOUSLY. The install flips the conductor's Stop hook to sync — see
 	// the maintainer note in the PR. Emitting here is harmless under the legacy
 	// async install (Claude ignores stdout) and activates once sync lands.
-	if payload.HookEventName == "Stop" {
+	if isStopHookEvent(payload.HookEventName) {
 		if dec, blocked, derr := session.DrainForStopHook(instanceID, resolveStopHookActive(payload)); derr == nil && blocked {
 			if out, mErr := json.Marshal(dec); mErr == nil {
 				fmt.Println(string(out))
@@ -562,7 +574,7 @@ func writeCostEvent(instanceID string, rawPayload []byte) {
 		logCostDebug("payload parse error: %v", err)
 		return
 	}
-	if stop.HookEventName != "Stop" {
+	if !isStopHookEvent(stop.HookEventName) {
 		logCostDebug("not a Stop event, skipping")
 		return
 	}

--- a/cmd/agent-deck/hook_handler_test.go
+++ b/cmd/agent-deck/hook_handler_test.go
@@ -31,6 +31,14 @@ func TestMapEventToStatus(t *testing.T) {
 		{"on_session_start", "waiting"},
 		{"on_session_end", "dead"},
 		{"subagent_stop", ""},
+		// Cursor Agent CLI hook events (camelCase)
+		{"sessionStart", "waiting"},
+		{"beforeSubmitPrompt", "running"},
+		{"preToolUse", "running"},
+		{"postToolUse", "waiting"},
+		{"postToolUseFailure", "waiting"},
+		{"stop", "waiting"},
+		{"sessionEnd", "dead"},
 	}
 
 	for _, tt := range tests {
@@ -156,6 +164,12 @@ func TestHookPayload_Unmarshal(t *testing.T) {
 			input:   `{"hook_event_name":"UserPromptSubmit","session_id":"ghi-789","extra":"ignored"}`,
 			event:   "UserPromptSubmit",
 			session: "ghi-789",
+		},
+		{
+			name:    "Cursor stop with conversation_id",
+			input:   `{"hook_event_name":"stop","conversation_id":"conv-123"}`,
+			event:   "stop",
+			session: "",
 		},
 	}
 

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -347,6 +347,9 @@ func main() {
 		case "hermes-hooks":
 			handleHermesHooks(args[1:])
 			return
+		case "cursor-hooks":
+			handleCursorHooks(args[1:])
+			return
 		case "notify-daemon":
 			handleNotifyDaemon(args[1:])
 			return
@@ -3037,6 +3040,7 @@ func printHelp() {
 	fmt.Println("  codex-hooks      Manage Codex notify hook integration")
 	fmt.Println("  gemini-hooks     Manage Gemini hook integration")
 	fmt.Println("  hermes-hooks     Manage Hermes Agent hook integration")
+	fmt.Println("  cursor-hooks     Manage Cursor Agent CLI hook integration")
 	fmt.Println("  group            Manage groups")
 	fmt.Println("  worktree, wt     Manage git worktrees")
 	fmt.Println("  web              Start TUI with web UI server running alongside")
@@ -3082,6 +3086,9 @@ func printHelp() {
 	fmt.Println("  hermes-hooks install      Install Hermes Agent hooks")
 	fmt.Println("  hermes-hooks uninstall    Remove Hermes Agent hooks")
 	fmt.Println("  hermes-hooks status       Show Hermes hooks install status")
+	fmt.Println("  cursor-hooks install      Install Cursor hooks")
+	fmt.Println("  cursor-hooks uninstall    Remove Cursor hooks")
+	fmt.Println("  cursor-hooks status       Show Cursor hooks install status")
 	fmt.Println()
 	fmt.Println("Group Commands:")
 	fmt.Println("  group list                List all groups")

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -76,7 +76,7 @@ func TestNestedSessionAllowsCLICommands(t *testing.T) {
 		subcommands := []string{
 			"add", "list", "ls", "remove", "rm", "status",
 			"session", "mcp", "skill", "group", "try", "worktree", "wt",
-			"profile", "update", "mcp-proxy", "web", "uninstall", "migrate-paths", "hooks", "codex-hooks", "codex-notify", "gemini-hooks",
+			"profile", "update", "mcp-proxy", "web", "uninstall", "migrate-paths", "hooks", "codex-hooks", "codex-notify", "gemini-hooks", "cursor-hooks",
 			"version", "--version", "-v",
 			"help", "--help", "-h",
 		}

--- a/internal/session/cursor_hooks.go
+++ b/internal/session/cursor_hooks.go
@@ -1,0 +1,189 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/atomicfile"
+)
+
+const agentDeckCursorHookCommand = "agent-deck hook-handler"
+
+type cursorHookDef struct {
+	Command string `json:"command"`
+	Matcher string `json:"matcher,omitempty"`
+}
+
+type cursorHooksConfig struct {
+	Version int                        `json:"version"`
+	Hooks   map[string][]cursorHookDef `json:"hooks"`
+}
+
+var cursorHookEventNames = []string{
+	"sessionStart",
+	"sessionEnd",
+	"beforeSubmitPrompt",
+	"preToolUse",
+	"postToolUse",
+	"stop",
+}
+
+// InjectCursorHooks injects agent-deck hook entries into ~/.cursor/hooks.json.
+// Uses read-preserve-modify-write to keep existing user hooks.
+// Returns true if hooks were newly installed, false if already present.
+func InjectCursorHooks(configDir string) (bool, error) {
+	hooksPath := filepath.Join(configDir, "hooks.json")
+
+	var cfg cursorHooksConfig
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("read hooks.json: %w", err)
+		}
+		cfg = cursorHooksConfig{
+			Version: 1,
+			Hooks:     make(map[string][]cursorHookDef),
+		}
+	} else {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return false, fmt.Errorf("parse hooks.json: %w", err)
+		}
+		if cfg.Version == 0 {
+			cfg.Version = 1
+		}
+		if cfg.Hooks == nil {
+			cfg.Hooks = make(map[string][]cursorHookDef)
+		}
+	}
+
+	if cursorHooksAlreadyInstalled(cfg.Hooks) {
+		return false, nil
+	}
+
+	for _, event := range cursorHookEventNames {
+		cfg.Hooks[event] = mergeCursorHookEvent(cfg.Hooks[event])
+	}
+
+	finalData, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal hooks.json: %w", err)
+	}
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return false, fmt.Errorf("create config dir: %w", err)
+	}
+	if err := atomicfile.WriteFile(hooksPath, finalData, 0644); err != nil {
+		return false, fmt.Errorf("write hooks.json: %w", err)
+	}
+
+	sessionLog.Info("cursor_hooks_installed", slog.String("config_dir", configDir))
+	return true, nil
+}
+
+// RemoveCursorHooks removes agent-deck hook entries from ~/.cursor/hooks.json.
+// Returns true if hooks were removed, false if none found.
+func RemoveCursorHooks(configDir string) (bool, error) {
+	hooksPath := filepath.Join(configDir, "hooks.json")
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read hooks.json: %w", err)
+	}
+
+	var cfg cursorHooksConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return false, fmt.Errorf("parse hooks.json: %w", err)
+	}
+	if cfg.Hooks == nil {
+		return false, nil
+	}
+
+	removed := false
+	for _, event := range cursorHookEventNames {
+		cleaned, didRemove := removeAgentDeckFromCursorEvent(cfg.Hooks[event])
+		if didRemove {
+			removed = true
+			if len(cleaned) == 0 {
+				delete(cfg.Hooks, event)
+			} else {
+				cfg.Hooks[event] = cleaned
+			}
+		}
+	}
+
+	if !removed {
+		return false, nil
+	}
+
+	finalData, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal hooks.json: %w", err)
+	}
+	if err := atomicfile.WriteFile(hooksPath, finalData, 0644); err != nil {
+		return false, fmt.Errorf("write hooks.json: %w", err)
+	}
+
+	sessionLog.Info("cursor_hooks_removed", slog.String("config_dir", configDir))
+	return true, nil
+}
+
+// CheckCursorHooksInstalled reports whether required agent-deck Cursor hooks are installed.
+func CheckCursorHooksInstalled(configDir string) bool {
+	hooksPath := filepath.Join(configDir, "hooks.json")
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		return false
+	}
+
+	var cfg cursorHooksConfig
+	if err := json.Unmarshal(data, &cfg); err != nil || cfg.Hooks == nil {
+		return false
+	}
+	return cursorHooksAlreadyInstalled(cfg.Hooks)
+}
+
+func cursorHooksAlreadyInstalled(hooks map[string][]cursorHookDef) bool {
+	for _, event := range cursorHookEventNames {
+		if !cursorEventHasAgentDeckHook(hooks[event]) {
+			return false
+		}
+	}
+	return true
+}
+
+func cursorEventHasAgentDeckHook(defs []cursorHookDef) bool {
+	for _, d := range defs {
+		if strings.Contains(d.Command, agentDeckCursorHookCommand) {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeCursorHookEvent(existing []cursorHookDef) []cursorHookDef {
+	for _, d := range existing {
+		if strings.Contains(d.Command, agentDeckCursorHookCommand) {
+			return existing
+		}
+	}
+	return append(existing, cursorHookDef{Command: agentDeckCursorHookCommand})
+}
+
+func removeAgentDeckFromCursorEvent(defs []cursorHookDef) ([]cursorHookDef, bool) {
+	removed := false
+	var cleaned []cursorHookDef
+	for _, d := range defs {
+		if strings.Contains(d.Command, agentDeckCursorHookCommand) {
+			removed = true
+			continue
+		}
+		cleaned = append(cleaned, d)
+	}
+	return cleaned, removed
+}

--- a/internal/session/cursor_hooks.go
+++ b/internal/session/cursor_hooks.go
@@ -46,7 +46,7 @@ func InjectCursorHooks(configDir string) (bool, error) {
 		}
 		cfg = cursorHooksConfig{
 			Version: 1,
-			Hooks:     make(map[string][]cursorHookDef),
+			Hooks:   make(map[string][]cursorHookDef),
 		}
 	} else {
 		if err := json.Unmarshal(data, &cfg); err != nil {

--- a/internal/session/cursor_hooks_test.go
+++ b/internal/session/cursor_hooks_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInjectCursorHooks_Fresh(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	installed, err := InjectCursorHooks(tmpDir)
+	if err != nil {
+		t.Fatalf("InjectCursorHooks failed: %v", err)
+	}
+	if !installed {
+		t.Fatal("expected hooks to be newly installed")
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "hooks.json"))
+	if err != nil {
+		t.Fatalf("read hooks.json: %v", err)
+	}
+	var cfg cursorHooksConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse hooks.json: %v", err)
+	}
+	if cfg.Version != 1 {
+		t.Fatalf("version = %d, want 1", cfg.Version)
+	}
+	for _, event := range cursorHookEventNames {
+		if !cursorEventHasAgentDeckHook(cfg.Hooks[event]) {
+			t.Fatalf("event %s missing agent-deck hook", event)
+		}
+	}
+}
+
+func TestInjectCursorHooks_PreservesExistingHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	orig := `{
+  "version": 1,
+  "hooks": {
+    "stop": [{ "command": "./my-stop.sh" }]
+  }
+}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "hooks.json"), []byte(orig), 0644); err != nil {
+		t.Fatalf("seed hooks.json: %v", err)
+	}
+
+	installed, err := InjectCursorHooks(tmpDir)
+	if err != nil {
+		t.Fatalf("InjectCursorHooks failed: %v", err)
+	}
+	if !installed {
+		t.Fatal("expected hooks to be installed")
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "hooks.json"))
+	if err != nil {
+		t.Fatalf("read hooks.json: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "./my-stop.sh") {
+		t.Fatal("expected existing stop hook preserved")
+	}
+	if !strings.Contains(text, agentDeckCursorHookCommand) {
+		t.Fatal("expected agent-deck hook appended")
+	}
+}
+
+func TestInjectCursorHooks_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	if _, err := InjectCursorHooks(tmpDir); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	installed, err := InjectCursorHooks(tmpDir)
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if installed {
+		t.Fatal("expected idempotent install to return false")
+	}
+}
+
+func TestRemoveCursorHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	if _, err := InjectCursorHooks(tmpDir); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	removed, err := RemoveCursorHooks(tmpDir)
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if !removed {
+		t.Fatal("expected hooks removed")
+	}
+	if CheckCursorHooksInstalled(tmpDir) {
+		t.Fatal("hooks should not be installed after remove")
+	}
+}
+
+func TestCheckCursorHooksInstalled(t *testing.T) {
+	tmpDir := t.TempDir()
+	if CheckCursorHooksInstalled(tmpDir) {
+		t.Fatal("expected not installed on empty dir")
+	}
+	if _, err := InjectCursorHooks(tmpDir); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !CheckCursorHooksInstalled(tmpDir) {
+		t.Fatal("expected installed after inject")
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3790,7 +3790,7 @@ func (i *Instance) UpdateStatus() error {
 
 	// COLD LOAD: CLI doesn't run StatusFileWatcher, so hookStatus is always empty.
 	// Read the hook file from disk once to give CLI the same fast path as the TUI.
-	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini" || i.Tool == "hermes") {
+	if i.hookStatus == "" && (IsClaudeCompatible(i.Tool) || i.Tool == "codex" || i.Tool == "gemini" || i.Tool == "hermes" || i.Tool == "cursor") {
 		if hs := readHookStatusFile(i.ID); hs != nil {
 			i.hookStatus = hs.Status
 			i.hookEvent = hs.Event
@@ -3809,7 +3809,7 @@ func (i *Instance) UpdateStatus() error {
 	// Freshness is tool- and state-specific (e.g. Codex running vs waiting).
 	// When this path is stale/missing, control naturally falls through to tmux
 	// polling and tool-specific session sync (tmux env/process-files/disk).
-	if (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini" || i.Tool == "hermes") &&
+	if (IsClaudeCompatible(i.Tool) || IsCodexCompatible(i.Tool) || i.Tool == "gemini" || i.Tool == "hermes" || i.Tool == "cursor") &&
 		i.hookStatus != "" &&
 		time.Since(i.hookLastUpdate) < hookFastPathFreshnessForTool(i.Tool, i.hookStatus) {
 		switch i.hookStatus {

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -199,7 +199,7 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 	hookStatuses := make(map[string]*HookStatus, len(instances))
 	for _, inst := range instances {
 		byID[inst.ID] = inst
-		if IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" {
+		if IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" || inst.Tool == "cursor" {
 			if hs := d.hookStatusForInstance(inst.ID); hs != nil {
 				// Issue #1349: only let a hook status rebind the session id when
 				// the instance is actually LIVE (running/waiting/idle with a real
@@ -645,6 +645,11 @@ func terminalHookTransitionCandidate(tool string, hs *HookStatus) (hookTransitio
 		}
 	case "codex":
 		if isCodexTerminalHookEvent(event) {
+			return hookTransitionCandidate{ToStatus: to, Timestamp: hs.UpdatedAt}, true
+		}
+	case "cursor":
+		// sessionStart is intentionally excluded (initial prompt isn't task completion).
+		if event == "stop" {
 			return hookTransitionCandidate{ToStatus: to, Timestamp: hs.UpdatedAt}, true
 		}
 	}

--- a/internal/sessionstatus/sessionstatus.go
+++ b/internal/sessionstatus/sessionstatus.go
@@ -94,7 +94,7 @@ func IsHookEmittingTool(tool string) bool {
 	if session.IsClaudeCompatible(tool) {
 		return true
 	}
-	return tool == "codex" || tool == "gemini" || tool == "hermes"
+	return tool == "codex" || tool == "gemini" || tool == "hermes" || tool == "cursor"
 }
 
 // freshnessFor returns the freshness window for a (tool, hookStatus) pair.

--- a/internal/tmux/patterns.go
+++ b/internal/tmux/patterns.go
@@ -120,6 +120,9 @@ func DefaultRawPatterns(toolName string) *RawPatterns {
 			PromptPatterns: []string{
 				"How can I help",
 				`re:(?m)^\s*›\s`,
+				"Ask questions",
+				"Plan mode",
+				"Switch modes",
 			},
 		}
 	case "shell":

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1387,6 +1387,29 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 		}
 	}
 
+	// Cursor Agent CLI hooks: auto-inject silently when the cursor binary is available.
+	if cursorCmd := strings.TrimSpace(session.GetToolCommand("cursor")); cursorCmd != "" {
+		if cursorFields := strings.Fields(cursorCmd); len(cursorFields) > 0 {
+			cursorBin := cursorFields[0]
+			if _, err := exec.LookPath(cursorBin); err == nil {
+				cursorConfigDir := session.GetCursorConfigDir()
+				if !session.CheckCursorHooksInstalled(cursorConfigDir) {
+					if _, err := session.InjectCursorHooks(cursorConfigDir); err != nil {
+						uiLog.Warn("cursor_hooks_inject_failed", slog.String("error", err.Error()))
+					} else {
+						uiLog.Info("cursor_hooks_installed", slog.String("config_dir", cursorConfigDir))
+					}
+				}
+				if h.hookWatcher == nil {
+					if hookWatcher, err := session.NewStatusFileWatcher(nil); err == nil {
+						h.hookWatcher = hookWatcher
+						go hookWatcher.Start()
+					}
+				}
+			}
+		}
+	}
+
 	// Start system theme watcher if configured
 	if session.GetTheme() == "system" {
 		h.themeWatcher = NewThemeWatcher(ctx)
@@ -3670,7 +3693,7 @@ func (h *Home) backgroundStatusUpdate() {
 	// Feed hook statuses from watcher to instances (enables hook fast path in UpdateStatus)
 	if h.hookWatcher != nil {
 		for _, inst := range instances {
-			if session.IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" || inst.Tool == "hermes" {
+			if session.IsClaudeCompatible(inst.Tool) || inst.Tool == "codex" || inst.Tool == "gemini" || inst.Tool == "hermes" || inst.Tool == "cursor" {
 				if hs := h.hookWatcher.GetHookStatus(inst.ID); hs != nil {
 					inst.UpdateHookStatus(hs)
 				}


### PR DESCRIPTION
Wire Cursor Agent CLI lifecycle hooks into agent-deck so running→waiting transitions are detected reliably and conductors receive inbox events.