### PR TITLE
feat(selfheal): Stage 1 observe-only detection (v1.9.67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.67] - 2026-06-15
+
+### Added
+
+- **Self-heal supervision Stage 1: observe-only detection, no recovery actions.** A deterministic policy module (`internal/selfheal`) that consumes the Honest Status v2 substate layer and, for every session each poll cycle, evaluates a conservative "truly stuck" predicate and **logs what it would do — taking zero action**. A session is a candidate only when ALL hold: its substate is a known-stuck class (`model-unavailable` / `auth-401` / `idle-at-empty-prompt`), it is not actively busy, not mid-turn, has dwelled past a cause-specific threshold, is not stopped, and is not opted out — confirmed across two independent reads. The safety state-machine (per-session and global rate caps, backoff, circuit breaker, and flicker-detector subscription) is fully exercised and logged, but in observe mode it never executes a recovery: the observe engine holds no action executor at all, so "no recovery primitive is ever called" is a structural guarantee. Modes `single_action` / `full` are defined but guarded (they refuse to act) until the next stages are re-approved. Every detection emits one structured NDJSON audit record (substate, dwell, the two confirming read signatures, decision, caps state, and the `would_have` action) to a durable per-profile sink under `runtime/selfheal/`, for review over the observe window. Configured via `[selfheal]` (`enabled` kill-switch, `mode`, per-session/group opt-out, cap dials); disabled by default. Runs inside the existing transition/state daemon — no new watchdog process.
+- **`instances.last_sent_at` column (schema v13).** The keysender send path now stamps a durable "we last sent it something" timestamp on every delivered send, via a targeted single-column write (never a whole-row rewrite). The self-heal predicate measures the `idle-at-empty-prompt` dwell from this clock, so a session is only ever considered stuck at an empty prompt if we actually sent it something and nothing happened — a long-deliberately-idle session (no send) is never a candidate. Additive migration; legacy rows default to "never sent".
+
 ## [1.9.66] - 2026-06-15
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -37,7 +37,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.9.66" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.9.67" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/profile"
 	"github.com/asheshgoplani/agent-deck/internal/send"
 	"github.com/asheshgoplani/agent-deck/internal/session"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
 	"github.com/asheshgoplani/agent-deck/internal/tmux"
 	"github.com/asheshgoplani/agent-deck/internal/ui"
 	"github.com/asheshgoplani/agent-deck/internal/vcs"
@@ -2252,6 +2253,15 @@ func handleSessionSend(profile string, args []string) {
 			out.ErrorWithData(fmt.Sprintf("failed to send message: %v", sendErr), ErrCodeInvalidOperation, extra)
 		}
 		os.Exit(1)
+	}
+
+	// Self-heal Stage 1: stamp the "we talked to it" clock. A delivered send is
+	// exactly the event the idle_at_empty_prompt dwell is measured from — a
+	// session is only stuck at an empty prompt if WE sent it something and
+	// nothing happened. Targeted single-column write (never SaveInstances);
+	// best-effort, never blocks or fails the send.
+	if db := statedb.GetGlobal(); db != nil {
+		_ = db.WriteLastSentAt(inst.ID, sentAt.Unix())
 	}
 
 	// Delivery succeeded, but if an operator draft was cleared and could not

--- a/internal/selfheal/candidate.go
+++ b/internal/selfheal/candidate.go
@@ -1,0 +1,146 @@
+package selfheal
+
+import (
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Candidate is a pure snapshot of one session's self-heal-relevant state for a
+// single evaluation cycle. It is assembled by the daemon adapter from the data
+// the poll loop already read (status, substate, hook freshness, output
+// signatures, the dwell anchors). The policy never reaches back into tmux or the
+// DB; everything it needs to decide is in here. This is what makes the predicate
+// deterministic and the observe-only invariant structural.
+type Candidate struct {
+	// Identity (carried into the audit event).
+	SessionID string
+	Title     string
+	Group     string
+	Profile   string
+	Account   string
+
+	// Coarse status + additive substate (Honest Status v2, v1.9.66).
+	Status   string
+	Substate tmux.Substate
+
+	// Busy is the canonical busy-first signal (tmux.go busy-first ordering). A
+	// live busy indicator is AUTHORITATIVE and disqualifying (§1.3 #2 / §3.1).
+	Busy bool
+
+	// HookRunningFresh is true when a hook-status "running" was seen within the
+	// freshness window (sessionstatus freshnessFor). Mid-turn → never act
+	// (§1.3 #3 / §3.2).
+	HookRunningFresh bool
+
+	// OutputSig is a stable signature (hash) of the recent pane/output content
+	// THIS read. OutputMoved is true when it differs from the previous read's
+	// signature — token/output movement means mid-turn, disqualifying (§1.3 #3).
+	OutputSig   string
+	OutputMoved bool
+
+	// Stopped marks a user-intentional stopped session (highest precedence,
+	// §1.3 #5). Such a session is never a candidate.
+	Stopped bool
+
+	// OptedOut is the per-session or group-level "never self-heal me" flag,
+	// checked as a quick disqualifier in the predicate (§3.7).
+	OptedOut bool
+
+	// StatusChangedAt anchors the dwell clock: when the current status/substate
+	// was entered. Zero means unknown (treated as not-yet-dwelled).
+	StatusChangedAt time.Time
+
+	// LastSentAt is when self-heal/the keysender last delivered input to this
+	// session. idle_at_empty_prompt only counts as stuck AFTER a send (§1.3 #4,
+	// §1.4): the dwell for that class is measured from LastSentAt. Zero means
+	// "we never sent it anything" → a long-waiting deliberate-idle session,
+	// never a candidate.
+	LastSentAt time.Time
+}
+
+// dwellAnchor returns the timestamp the dwell window is measured from for this
+// candidate's substate, and whether an anchor exists at all.
+//
+//   - idle_at_empty_prompt is anchored on LastSentAt: it is only stuck if WE sent
+//     something and nothing happened. No send → not a candidate (§1.4).
+//   - every other stuck class is anchored on StatusChangedAt (when the banner /
+//     stuck state was entered).
+func (c Candidate) dwellAnchor() (time.Time, bool) {
+	if c.Substate == tmux.SubstateIdleAtEmptyPrompt {
+		if c.LastSentAt.IsZero() {
+			return time.Time{}, false
+		}
+		return c.LastSentAt, true
+	}
+	if c.StatusChangedAt.IsZero() {
+		return time.Time{}, false
+	}
+	return c.StatusChangedAt, true
+}
+
+// Dwell returns how long the candidate has dwelled in its stuck state as of now,
+// and whether a dwell anchor exists.
+func (c Candidate) Dwell(now time.Time) (time.Duration, bool) {
+	anchor, ok := c.dwellAnchor()
+	if !ok {
+		return 0, false
+	}
+	return now.Sub(anchor), true
+}
+
+// PredicateResult is the outcome of evaluating the §1.3 stuck predicate against a
+// single read of a candidate. It is intentionally verbose so the audit event can
+// record exactly which condition decided the verdict.
+type PredicateResult struct {
+	// Candidate is true only when ALL §1.3 conditions hold for this read. The
+	// two-read confirm is layered ON TOP by the Engine (one read is never enough,
+	// §1.3 #4 / PLAYBOOK F5).
+	Candidate bool
+	// Decision is the most-precise reason the predicate reached its verdict. For
+	// a true candidate it is DecisionAct (pending the 2-read confirm); for a
+	// false one it names the disqualifier.
+	Decision Decision
+	// Dwell is the measured dwell at evaluation time (0 if no anchor).
+	Dwell time.Duration
+}
+
+// Evaluate runs the §1.3 stuck predicate for ONE read. It is pure: same inputs →
+// same verdict. The disqualifier ordering mirrors the design's precedence —
+// stopped (user intent) and opt-out first as cheap exits, then the authoritative
+// busy / mid-turn signals, then substate class, then dwell.
+//
+// A true result means "candidate for THIS read". The caller (Engine) must
+// require two independent confirming reads before acting (§1.3 #4).
+func Evaluate(c Candidate, now time.Time) PredicateResult {
+	// 5 (precedence, cheap exits first): stopped = user-intentional, highest.
+	if c.Stopped {
+		return PredicateResult{Decision: DecisionSkipStopped}
+	}
+	// 5: opt-out is a quick disqualifier (§3.7).
+	if c.OptedOut {
+		return PredicateResult{Decision: DecisionSkipOptOut}
+	}
+	// 2: a live busy indicator is authoritative and disqualifying. An actively
+	// running session is never stuck, full stop (§3.1).
+	if c.Busy {
+		return PredicateResult{Decision: DecisionSkipBusy}
+	}
+	// 3: mid-turn — a fresh hook-running or output movement between reads means
+	// in-flight work. Never act mid-turn (§3.2).
+	if c.HookRunningFresh || c.OutputMoved {
+		return PredicateResult{Decision: DecisionSkipMidTurn}
+	}
+	// 1: substate must be a known-stuck class, never healthy.
+	if !IsStuckSubstate(c.Substate) {
+		return PredicateResult{Decision: DecisionSkipHealthy}
+	}
+	// 4: dwell past the cause-specific threshold, anchored on status_changed_at
+	// or (for idle_at_empty_prompt) last_sent_at.
+	threshold, _ := DwellThreshold(c.Substate)
+	dwell, ok := c.Dwell(now)
+	if !ok || dwell < threshold {
+		return PredicateResult{Decision: DecisionSkipDwell, Dwell: dwell}
+	}
+	return PredicateResult{Candidate: true, Decision: DecisionAct, Dwell: dwell}
+}

--- a/internal/selfheal/engine.go
+++ b/internal/selfheal/engine.go
@@ -87,10 +87,10 @@ type Config struct {
 // constructor the daemon uses in v1.9.67.
 func NewObserveEngine(caps Caps, sink EventSink) *Engine {
 	return &Engine{
-		mode:      ModeObserve,
-		caps:      caps,
-		policy:    NewPolicyMachine(caps),
-		sink:      sink,
+		mode:         ModeObserve,
+		caps:         caps,
+		policy:       NewPolicyMachine(caps),
+		sink:         sink,
 		exec:         nil,
 		prevSig:      map[string]string{},
 		confirmed:    map[string]confirmState{},

--- a/internal/selfheal/engine.go
+++ b/internal/selfheal/engine.go
@@ -1,0 +1,296 @@
+package selfheal
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// ErrActionInGuardedMode is returned if an action executor is ever invoked while
+// the engine is in a guarded mode (single_action / full). Stages 2-3 are HELD
+// pending Ashesh re-approval + the three §9 gap-fixes, so those modes refuse to
+// act. observe never reaches an executor at all.
+var ErrActionInGuardedMode = errors.New("selfheal: actions are HELD (Stages 2-3 not re-approved)")
+
+// ActionExecutor performs a real recovery. STAGE 1 NEVER CONSTRUCTS ONE — the
+// observe-mode engine has a nil executor and a guarded mode refuses to call it.
+// The interface exists so the wiring is in place for Stage 2 without reshaping
+// the engine, but every method is unreachable in v1.9.67.
+type ActionExecutor interface {
+	// Execute applies the action to the candidate and reports the immediate
+	// outcome string. Only ever called in single_action/full AFTER the §9 gaps
+	// close and Ashesh re-approves.
+	Execute(c Candidate, a Action) (outcome string, err error)
+}
+
+// Engine is the per-process self-heal policy. It owns the safety machine, the
+// audit sink, and (for non-observe stages only) the action executor. In observe
+// mode exec is nil and stage gating refuses any execution path, so "no recovery
+// primitive is ever called" is structural.
+type Engine struct {
+	mode   Mode
+	caps   Caps
+	policy *PolicyMachine
+	sink   EventSink
+	// exec is nil in observe mode. Even when set, ProcessRead refuses to call it
+	// unless the mode is single_action/full (guarded) — and those are HELD.
+	exec ActionExecutor
+
+	// mu guards the per-session bookkeeping maps below. Today ProcessRead is only
+	// called from the single transition-daemon poll goroutine, but the lock makes
+	// the engine safe if a future stage ever evaluates profiles in parallel
+	// (defense-in-depth; the hot path is tiny so the lock is free).
+	mu sync.Mutex
+
+	// prevSig tracks the previous read's output signature per session, so the
+	// engine can detect output movement (mid-turn) and require the two-read
+	// confirm without the caller having to thread it.
+	prevSig map[string]string
+	// confirmed tracks the FIRST qualifying read per session (its signature +
+	// the substate it was diagnosed as), so the current read can be the §1.3 #4
+	// second confirming read AND we can require the diagnosis to MATCH across the
+	// two reads (a model_unavailable read followed by an auth_401 read must NOT
+	// confirm — they are different incidents).
+	confirmed map[string]confirmState
+	// substateSeen records, per session, when the engine FIRST observed the
+	// current stuck substate (and which substate). This is the authoritative
+	// dwell anchor: it is the moment the stuck condition began, reset the instant
+	// the substate changes, the session goes healthy/busy/mid-turn, or output
+	// moves. It fixes anchoring the dwell on a stale waiting timestamp and an
+	// old send timestamp surviving a legitimate later idle.
+	substateSeen map[string]substateEntry
+}
+
+// confirmState is the first qualifying read recorded for the two-read confirm.
+type confirmState struct {
+	read     ReadSig
+	substate tmux.Substate
+}
+
+// substateEntry records when a stuck substate was first observed by the engine.
+type substateEntry struct {
+	substate tmux.Substate
+	since    time.Time
+}
+
+// Config configures a new Engine.
+type Config struct {
+	Mode Mode
+	Caps Caps
+	Sink EventSink
+}
+
+// NewObserveEngine builds the Stage-1 observe-only engine. It has NO action
+// executor — by construction it cannot take a recovery action. This is the only
+// constructor the daemon uses in v1.9.67.
+func NewObserveEngine(caps Caps, sink EventSink) *Engine {
+	return &Engine{
+		mode:      ModeObserve,
+		caps:      caps,
+		policy:    NewPolicyMachine(caps),
+		sink:      sink,
+		exec:         nil,
+		prevSig:      map[string]string{},
+		confirmed:    map[string]confirmState{},
+		substateSeen: map[string]substateEntry{},
+	}
+}
+
+// Policy exposes the safety machine (for the flicker subscription wiring).
+func (e *Engine) Policy() *PolicyMachine { return e.policy }
+
+// Mode returns the engine's current authority level.
+func (e *Engine) Mode() Mode { return e.mode }
+
+// ProcessRead evaluates ONE read of one candidate, advances the two-read confirm
+// state-machine, exercises the safety machine, and emits exactly one audit event
+// describing what self-heal would do. In observe mode it returns having taken
+// NO action — guaranteed because:
+//   - the executor is nil, and
+//   - executeIfAuthorized refuses any non-observe mode (Stages 2-3 HELD).
+//
+// now must be a date-u-anchored monotonic-ish UTC time (the daemon anchors it).
+// outputMoved/hookRunningFresh come from the caller's existing reads; the engine
+// also folds in its own prevSig comparison so a caller that doesn't compute
+// movement still gets it.
+func (e *Engine) ProcessRead(c Candidate, now time.Time) Event {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	// Subscribe-derived movement: if the caller didn't flag movement, derive it
+	// from the prior signature this engine saw.
+	if !c.OutputMoved {
+		if prev, ok := e.prevSig[c.SessionID]; ok && prev != "" && c.OutputSig != "" && prev != c.OutputSig {
+			c.OutputMoved = true
+		}
+	}
+	e.prevSig[c.SessionID] = c.OutputSig
+
+	// Track when the current STUCK substate began and use that as the dwell
+	// anchor — it is the authoritative "the stuck condition started here" time,
+	// independent of any stale waiting/send timestamp. The anchor resets the
+	// instant the substate changes, the session leaves the stuck class, or output
+	// moves. This is what stops (a) a months-old waiting timestamp from instantly
+	// satisfying a freshly-observed model_unavailable dwell, and (b) an old
+	// last_sent_at from re-flagging a session that legitimately went idle long
+	// after its send. The caller's StatusChangedAt/LastSentAt are used only as a
+	// floor so a real, persistent stuck condition is not under-counted.
+	anchor := e.updateSubstateAnchor(c, now)
+	if !anchor.IsZero() {
+		c.StatusChangedAt = anchor
+		// For idle_at_empty_prompt the dwell is measured from the LATER of the
+		// send and the substate-entry: a session is only stuck if it has been at
+		// the empty prompt (no output movement) since AND after we last sent it
+		// something. If it produced output after the send, the anchor moved past
+		// last_sent_at and the idle is fresh (not a stale send).
+		if c.Substate == tmux.SubstateIdleAtEmptyPrompt && !c.LastSentAt.IsZero() && anchor.After(c.LastSentAt) {
+			c.LastSentAt = anchor
+		}
+	}
+
+	res := Evaluate(c, now)
+
+	ev := Event{
+		TS:        formatTS(now),
+		SessionID: c.SessionID,
+		Title:     c.Title,
+		Group:     c.Group,
+		Profile:   c.Profile,
+		Account:   c.Account,
+		Substate:  string(c.Substate),
+		Dwell:     res.Dwell.Seconds(),
+		Decision:  res.Decision,
+		Stage:     e.mode,
+	}
+
+	if !res.Candidate {
+		// Not a candidate this read → the confirm chain resets.
+		delete(e.confirmed, c.SessionID)
+		ev.Reads = []ReadSig{{T: formatTS(now), Sig: c.OutputSig}}
+		_ = e.sink.Append(ev)
+		return ev
+	}
+
+	// Candidate THIS read. Require a prior confirming read (§1.3 #4): one read is
+	// never enough. The first qualifying read is recorded and we stand down; the
+	// second confirming read is what proceeds to the gate — but ONLY if it is the
+	// SAME diagnosis. A model_unavailable read followed by an auth_401 read is two
+	// different incidents, not a confirmation: the second read replaces the first
+	// and we re-confirm.
+	first, hadFirst := e.confirmed[c.SessionID]
+	thisRead := ReadSig{T: formatTS(now), Sig: c.OutputSig}
+	if !hadFirst || first.substate != c.Substate {
+		e.confirmed[c.SessionID] = confirmState{read: thisRead, substate: c.Substate}
+		ev.Decision = DecisionSkipConfirm
+		ev.Reads = []ReadSig{thisRead}
+		_ = e.sink.Append(ev)
+		return ev
+	}
+
+	// Two confirming reads of the SAME substate. Record both signatures.
+	second := thisRead
+	ev.Reads = []ReadSig{first.read, second}
+
+	// Safety machine: caps / backoff / breaker / flicker.
+	gate, capsState := e.policy.Gate(c, now)
+	ev.Caps = capsState
+	if gate != DecisionAct {
+		// Blocked by a guard — escalate-only, take no recovery. Reset the confirm
+		// chain so we re-confirm before the next would-be attempt.
+		delete(e.confirmed, c.SessionID)
+		ev.Decision = gate
+		ev.WouldHave = ActionEscalate
+		_ = e.sink.Append(ev)
+		return ev
+	}
+
+	// Gate allowed: this is a confirmed, in-budget candidate. The safety machine
+	// records the would-be attempt so caps/backoff advance and the next cycle
+	// reflects it (Stage-1 brief item 4: the machine is exercised + logged).
+	e.policy.RecordAttempt(c, now)
+	delete(e.confirmed, c.SessionID)
+
+	would := WouldHaveAction(c.Substate)
+	ev.Decision = DecisionAct
+	ev.WouldHave = would
+	ev.ActionParams = actionParams(c.Substate)
+
+	// OBSERVE: log would_have and STOP. No executor, no action. This is the whole
+	// point of Stage 1.
+	if e.mode == ModeObserve {
+		ev.Outcome = "observe_noop"
+		_ = e.sink.Append(ev)
+		return ev
+	}
+
+	// Non-observe modes are HELD. The executor is refused even if one were set.
+	outcome, action := e.executeIfAuthorized(c, would)
+	ev.Action = action
+	ev.Outcome = outcome
+	_ = e.sink.Append(ev)
+	return ev
+}
+
+// updateSubstateAnchor tracks when the current stuck substate was first observed
+// for a session and returns that "since" time (zero when there is no stuck
+// substate to anchor). The anchor RESETS whenever:
+//   - the substate changes (a different incident starts its own clock),
+//   - the session is busy / mid-turn (output moved) — it is actively working, not
+//     stuck, so any prior stuck observation is void,
+//   - the substate is not a stuck class.
+//
+// This is the engine's authoritative dwell anchor, independent of the caller's
+// possibly-stale StatusChangedAt/LastSentAt.
+func (e *Engine) updateSubstateAnchor(c Candidate, now time.Time) time.Time {
+	// Any sign of life — or any disqualifying state — voids a stuck observation
+	// outright. Stopped/OptedOut are included so a session cannot silently accrue
+	// dwell while it is stopped or opted out and then instantly confirm the moment
+	// it is reactivated / un-opted-out (Codex review). Output movement, busy, and
+	// mid-turn are the active-work signals; a non-stuck substate has nothing to
+	// anchor.
+	if c.Busy || c.HookRunningFresh || c.OutputMoved || c.Stopped || c.OptedOut || !IsStuckSubstate(c.Substate) {
+		delete(e.substateSeen, c.SessionID)
+		return time.Time{}
+	}
+	prev, ok := e.substateSeen[c.SessionID]
+	if !ok || prev.substate != c.Substate {
+		// First observation of this stuck substate → start its clock now.
+		e.substateSeen[c.SessionID] = substateEntry{substate: c.Substate, since: now}
+		return now
+	}
+	return prev.since
+}
+
+// executeIfAuthorized is the single chokepoint where a real action could ever
+// run. It REFUSES in every mode that ships in v1.9.67: observe (no executor) and
+// the HELD single_action/full. Returns the outcome string and the action
+// actually taken (ActionNone when refused).
+func (e *Engine) executeIfAuthorized(c Candidate, would Action) (string, Action) {
+	// Stages 2-3 are HELD pending re-approval + the three §9 gap-fixes. Until
+	// then, even single_action/full refuse to act.
+	if e.mode != ModeObserve { // both guarded modes land here
+		return "held_stage_2_3", ActionNone
+	}
+	// Unreachable in observe (handled by the caller), but defensive: never act.
+	if e.exec == nil {
+		return "no_executor", ActionNone
+	}
+	outcome, err := e.exec.Execute(c, would)
+	if err != nil {
+		return "error:" + err.Error(), ActionNone
+	}
+	return outcome, would
+}
+
+// actionParams records the would-be action's parameters for the audit (§5).
+func actionParams(s tmux.Substate) map[string]any {
+	switch s {
+	case tmux.SubstateModelUnavailable:
+		return map[string]any{"model": "opus", "reissue": true}
+	case tmux.SubstateAuth401:
+		return map[string]any{"reassert_creds": true}
+	default:
+		return nil
+	}
+}

--- a/internal/selfheal/engine_test.go
+++ b/internal/selfheal/engine_test.go
@@ -119,7 +119,7 @@ func TestObserve_ConfirmRequiresSameSubstate(t *testing.T) {
 	mk := func(sub tmux.Substate) Candidate {
 		return Candidate{SessionID: sid, Substate: sub, OutputSig: "x"}
 	}
-	_ = e.ProcessRead(mk(tmux.SubstateModelUnavailable), now)               // anchor
+	_ = e.ProcessRead(mk(tmux.SubstateModelUnavailable), now)                    // anchor
 	_ = e.ProcessRead(mk(tmux.SubstateModelUnavailable), now.Add(2*time.Minute)) // dwelled → first confirm
 	// Now the substate FLIPS to auth_401 on the would-be confirming read. Because
 	// auth_401's anchor just started, it is not dwelled AND the diagnosis differs,
@@ -217,7 +217,7 @@ func TestObserve_TwoReadDrop_OnMovement(t *testing.T) {
 
 	c := dwelledModelCand(now)
 	c.OutputSig = "sigA"
-	_ = e.ProcessRead(c, now)                    // anchor (dwell 0)
+	_ = e.ProcessRead(c, now)                       // anchor (dwell 0)
 	ev2 := e.ProcessRead(c, now.Add(2*time.Minute)) // dwelled → first confirm
 	if ev2.Decision != DecisionSkipConfirm {
 		t.Fatalf("read2 (dwelled, first candidate): want skip_confirm, got %s", ev2.Decision)

--- a/internal/selfheal/engine_test.go
+++ b/internal/selfheal/engine_test.go
@@ -1,0 +1,314 @@
+package selfheal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// spyExecutor records every Execute call. In observe mode it must NEVER be
+// called — that is the load-bearing proof of the observe-only invariant.
+type spyExecutor struct {
+	calls []Action
+}
+
+func (s *spyExecutor) Execute(c Candidate, a Action) (string, error) {
+	s.calls = append(s.calls, a)
+	return "executed", nil
+}
+
+func dwelledModelCand(now time.Time) Candidate {
+	return Candidate{
+		SessionID: "s1-1780000000",
+		Title:     "exec-fix",
+		Profile:   "personal",
+		Substate:  tmux.SubstateModelUnavailable,
+		OutputSig: "sigA", // stable across reads → no movement
+	}
+}
+
+// driveToAct feeds the same candidate at a fixed cadence (default 1 min apart)
+// up to a bound and returns the first "act" event plus how many reads it took.
+// The engine anchors dwell on the FIRST observation of the stuck substate, so a
+// candidate becomes actionable only after it has been observed across enough
+// polls to (a) pass the dwell threshold AND (b) confirm over two same-substate
+// reads — exactly the conservative behavior we want.
+func driveToAct(t *testing.T, e *Engine, c Candidate, start time.Time, step time.Duration, max int) (Event, int) {
+	t.Helper()
+	now := start
+	for i := 1; i <= max; i++ {
+		ev := e.ProcessRead(c, now)
+		if ev.Action != ActionNone {
+			t.Fatalf("read %d emitted an action %q (observe must never act)", i, ev.Action)
+		}
+		if ev.Decision == DecisionAct {
+			return ev, i
+		}
+		now = now.Add(step)
+	}
+	t.Fatalf("candidate never reached 'act' within %d reads", max)
+	return Event{}, 0
+}
+
+// The headline guarantee: in observe mode, a fully-confirmed stuck candidate
+// eventually emits an "act" decision with would_have set, observe_noop outcome,
+// NO action field; and the engine holds NO executor.
+func TestObserve_ConfirmedCandidate_LogsWouldHave_NoAction(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	sink := &MemorySink{}
+	e := NewObserveEngine(DefaultCaps(), sink)
+
+	if e.exec != nil {
+		t.Fatal("observe engine must hold NO action executor")
+	}
+
+	// First read starts the dwell clock (anchor = now), so it cannot be a
+	// candidate yet — proving we never fire on a single observation.
+	ev1 := e.ProcessRead(dwelledModelCand(now), now)
+	if ev1.Decision == DecisionAct {
+		t.Fatalf("first observation must never act, got %s", ev1.Decision)
+	}
+
+	act, reads := driveToAct(t, e, dwelledModelCand(now), now, time.Minute, 10)
+	if reads < 3 {
+		t.Fatalf("model_unavailable should need >=3 reads (dwell 90s + 2-read confirm), took %d", reads)
+	}
+	if act.WouldHave != ActionRestartModelSwitch {
+		t.Fatalf("would_have: want restart_model_switch, got %q", act.WouldHave)
+	}
+	if act.Action != ActionNone {
+		t.Fatalf("OBSERVE MUST TAKE NO ACTION: action field = %q", act.Action)
+	}
+	if act.Outcome != "observe_noop" {
+		t.Fatalf("outcome: want observe_noop, got %q", act.Outcome)
+	}
+	if act.Stage != ModeObserve {
+		t.Fatalf("stage must be observe, got %q", act.Stage)
+	}
+	if len(act.Reads) != 2 {
+		t.Fatalf("act event must record both confirming reads, got %d", len(act.Reads))
+	}
+}
+
+// First observation of a freshly-stuck substate never fires, even if the
+// caller's StatusChangedAt is ancient — the engine anchors dwell on when IT
+// first saw the substate (Codex finding #4: no instant-fire on a stale anchor).
+func TestObserve_FreshSubstate_StaleAnchor_NoInstantFire(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	e := NewObserveEngine(DefaultCaps(), &MemorySink{})
+	c := dwelledModelCand(now)
+	c.StatusChangedAt = now.Add(-30 * 24 * time.Hour) // month-old waiting ts
+	ev := e.ProcessRead(c, now)
+	if ev.Decision == DecisionAct {
+		t.Fatal("a freshly-observed stuck substate with a stale anchor must NOT instantly fire")
+	}
+	if ev.Dwell > 1 {
+		t.Fatalf("dwell must be measured from first observation (~0), got %.0fs", ev.Dwell)
+	}
+}
+
+// Codex finding #2: two reads of DIFFERENT substates must not confirm. A
+// model_unavailable read followed by an auth_401 read is two incidents.
+func TestObserve_ConfirmRequiresSameSubstate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	e := NewObserveEngine(DefaultCaps(), &MemorySink{})
+	sid := "s1"
+
+	// Drive model_unavailable past its dwell so it would be a candidate...
+	mk := func(sub tmux.Substate) Candidate {
+		return Candidate{SessionID: sid, Substate: sub, OutputSig: "x"}
+	}
+	_ = e.ProcessRead(mk(tmux.SubstateModelUnavailable), now)               // anchor
+	_ = e.ProcessRead(mk(tmux.SubstateModelUnavailable), now.Add(2*time.Minute)) // dwelled → first confirm
+	// Now the substate FLIPS to auth_401 on the would-be confirming read. Because
+	// auth_401's anchor just started, it is not dwelled AND the diagnosis differs,
+	// so it must NOT act.
+	ev := e.ProcessRead(mk(tmux.SubstateAuth401), now.Add(3*time.Minute))
+	if ev.Decision == DecisionAct {
+		t.Fatalf("a substate change must reset the confirm, got act")
+	}
+}
+
+// Even if a candidate confirms many times, observe mode never calls any executor.
+// We can't inject one into NewObserveEngine (by design), so we assert the
+// chokepoint refuses in observe and that processing emits no action over a long
+// run including a cap-hit.
+func TestObserve_NeverCallsExecutor_OverManyCycles(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	sink := &MemorySink{}
+	e := NewObserveEngine(DefaultCaps(), sink)
+	c := dwelledModelCand(now)
+
+	for i := 0; i < 20; i++ {
+		ev := e.ProcessRead(c, now)
+		if ev.Action != ActionNone {
+			t.Fatalf("cycle %d: observe emitted an action %q", i, ev.Action)
+		}
+		now = now.Add(2 * time.Minute)
+	}
+	// Some events must have been "act" (would_have), and at least one cap_hit
+	// after the per-session cap (2) was exhausted — proving the safety machine
+	// was exercised AND logged, all while taking no action.
+	var sawAct, sawCap bool
+	for _, ev := range sink.Snapshot() {
+		if ev.Decision == DecisionAct {
+			sawAct = true
+		}
+		if ev.Decision == DecisionCapHit {
+			sawCap = true
+		}
+		if ev.Action != ActionNone {
+			t.Fatalf("audit shows an action taken in observe: %q", ev.Action)
+		}
+	}
+	if !sawAct {
+		t.Fatal("expected at least one would-act event")
+	}
+	if !sawCap {
+		t.Fatal("expected the per-session cap to fire and be logged (machine exercised)")
+	}
+}
+
+// The chokepoint refuses even when a guarded mode somehow has an executor: Stages
+// 2-3 are HELD. This guards against a future mis-wire shipping actions early.
+func TestExecuteIfAuthorized_GuardedModes_Refuse(t *testing.T) {
+	c := Candidate{SessionID: "s1", Substate: tmux.SubstateModelUnavailable}
+	for _, m := range []Mode{ModeSingleAction, ModeFull} {
+		spy := &spyExecutor{}
+		e := &Engine{mode: m, caps: DefaultCaps(), policy: NewPolicyMachine(DefaultCaps()), sink: &MemorySink{}, exec: spy, prevSig: map[string]string{}, confirmed: map[string]confirmState{}, substateSeen: map[string]substateEntry{}}
+		outcome, action := e.executeIfAuthorized(c, ActionRestartModelSwitch)
+		if action != ActionNone {
+			t.Fatalf("mode %q: HELD modes must take no action, got %q", m, action)
+		}
+		if outcome != "held_stage_2_3" {
+			t.Fatalf("mode %q: want held_stage_2_3 outcome, got %q", m, outcome)
+		}
+		if len(spy.calls) != 0 {
+			t.Fatalf("mode %q: executor must NOT be called (Stages 2-3 HELD), got %d calls", m, len(spy.calls))
+		}
+	}
+}
+
+// A busy session over two reads never reaches act, even confirmed-looking.
+func TestObserve_BusySession_NeverActs(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	sink := &MemorySink{}
+	e := NewObserveEngine(DefaultCaps(), sink)
+	c := dwelledModelCand(now)
+	c.Busy = true
+	for i := 0; i < 5; i++ {
+		ev := e.ProcessRead(c, now.Add(time.Duration(i)*time.Minute))
+		if ev.Decision != DecisionSkipBusy {
+			t.Fatalf("busy session must skip_busy, got %s", ev.Decision)
+		}
+		if ev.WouldHave != ActionNone {
+			t.Fatalf("busy session must have no would_have, got %q", ev.WouldHave)
+		}
+	}
+}
+
+// The two-read drop: once dwelled and on its first confirming read, if the
+// session then shows output movement (mid-turn), it must NOT act (§1.3 #4).
+func TestObserve_TwoReadDrop_OnMovement(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	sink := &MemorySink{}
+	e := NewObserveEngine(DefaultCaps(), sink)
+
+	c := dwelledModelCand(now)
+	c.OutputSig = "sigA"
+	_ = e.ProcessRead(c, now)                    // anchor (dwell 0)
+	ev2 := e.ProcessRead(c, now.Add(2*time.Minute)) // dwelled → first confirm
+	if ev2.Decision != DecisionSkipConfirm {
+		t.Fatalf("read2 (dwelled, first candidate): want skip_confirm, got %s", ev2.Decision)
+	}
+	// read3: output moved → mid-turn → not a candidate, confirm chain resets.
+	c3 := c
+	c3.OutputSig = "sigB" // movement detected by engine's prevSig diff
+	ev3 := e.ProcessRead(c3, now.Add(4*time.Minute))
+	if ev3.Decision != DecisionSkipMidTurn {
+		t.Fatalf("read3 with movement: want skip_midturn, got %s", ev3.Decision)
+	}
+	if ev3.WouldHave != ActionNone {
+		t.Fatalf("dropped read must not set would_have, got %q", ev3.WouldHave)
+	}
+}
+
+// Each substate yields the correct would_have over the confirm flow.
+func TestObserve_PerSubstate_WouldHave(t *testing.T) {
+	cases := []struct {
+		sub  tmux.Substate
+		want Action
+		mk   func() Candidate
+	}{
+		{tmux.SubstateModelUnavailable, ActionRestartModelSwitch, func() Candidate {
+			return Candidate{SessionID: "m", Substate: tmux.SubstateModelUnavailable, OutputSig: "x"}
+		}},
+		{tmux.SubstateAuth401, ActionRestartReassertCreds, func() Candidate {
+			return Candidate{SessionID: "a", Substate: tmux.SubstateAuth401, OutputSig: "x"}
+		}},
+		{tmux.SubstateIdleAtEmptyPrompt, ActionResend, func() Candidate {
+			// idle dwell is from last_sent_at; the engine anchors substate-entry at
+			// first observation, so a recent send + accruing reads reach act.
+			return Candidate{SessionID: "i", Substate: tmux.SubstateIdleAtEmptyPrompt, LastSentAt: time.Unix(1780000000, 0).Add(-1 * time.Minute), OutputSig: "x"}
+		}},
+	}
+	for _, tc := range cases {
+		now := time.Unix(1780000000, 0).UTC()
+		e := NewObserveEngine(DefaultCaps(), &MemorySink{})
+		ev, _ := driveToAct(t, e, tc.mk(), now, time.Minute, 12)
+		if ev.WouldHave != tc.want {
+			t.Fatalf("%s: would_have = %q, want %q", tc.sub, ev.WouldHave, tc.want)
+		}
+		if ev.Action != ActionNone {
+			t.Fatalf("%s: observe took an action %q", tc.sub, ev.Action)
+		}
+	}
+}
+
+// A stopped (or opted-out) session must not accrue dwell while disqualified and
+// then instantly confirm on reactivation — the anchor resets while stopped.
+func TestObserve_StoppedAccruesNoDwell(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	e := NewObserveEngine(DefaultCaps(), &MemorySink{})
+	sid := "s1"
+	stuck := func(stopped bool) Candidate {
+		return Candidate{SessionID: sid, Substate: tmux.SubstateModelUnavailable, Stopped: stopped, OutputSig: "x"}
+	}
+	// Many reads while STOPPED — must accrue no dwell.
+	for i := 0; i < 10; i++ {
+		ev := e.ProcessRead(stuck(true), now.Add(time.Duration(i)*time.Minute))
+		if ev.Decision == DecisionAct || ev.Decision == DecisionSkipConfirm {
+			t.Fatalf("stopped session must never accrue toward act, got %s", ev.Decision)
+		}
+	}
+	// Reactivated: the FIRST live read starts the clock fresh (dwell ~0), so it
+	// cannot instantly confirm.
+	ev := e.ProcessRead(stuck(false), now.Add(20*time.Minute))
+	if ev.Decision == DecisionAct {
+		t.Fatal("a just-reactivated session must not instantly fire on dwell accrued while stopped")
+	}
+}
+
+// Codex finding #1: a session that got a send, produced output (moving past the
+// send), and only LATER went idle must NOT be flagged off the stale send. The
+// output movement resets the substate anchor, so the idle dwell restarts from
+// the fresh idle, not the old send.
+func TestObserve_IdleAfterOutputMoved_NotStaleSendCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	e := NewObserveEngine(DefaultCaps(), &MemorySink{})
+	sid := "i1"
+	oldSend := now.Add(-30 * time.Minute) // a long-ago send
+
+	// The session produced output (still working) AFTER the send — output moved.
+	working := Candidate{SessionID: sid, Substate: tmux.SubstateIdleAtEmptyPrompt, LastSentAt: oldSend, OutputSig: "a", OutputMoved: true}
+	_ = e.ProcessRead(working, now)
+
+	// Now it goes idle. The idle clock must start from HERE, not the 30-min-old
+	// send — so a single fresh idle read is not instantly a >5-min-stale candidate.
+	idle := Candidate{SessionID: sid, Substate: tmux.SubstateIdleAtEmptyPrompt, LastSentAt: oldSend, OutputSig: "a"}
+	ev := e.ProcessRead(idle, now.Add(1*time.Second))
+	if ev.Decision == DecisionAct {
+		t.Fatal("a freshly-idle session must not fire off a 30-min-old send (anchor reset on output movement)")
+	}
+}

--- a/internal/selfheal/event.go
+++ b/internal/selfheal/event.go
@@ -1,0 +1,124 @@
+package selfheal
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// ReadSig is one of the two confirming reads recorded in an event (§5). It pairs
+// the read time with the stable output signature so a reviewer can verify the
+// two reads agreed (the §1.3 #4 two-read confirm).
+type ReadSig struct {
+	T   string `json:"t"`
+	Sig string `json:"sig"`
+}
+
+// Event is the single structured record emitted per detection cycle, whether or
+// not it acts (§5). It is the observability hook for the future OGDB
+// operational-KG (we emit the record; we do NOT build the sink). In observe mode
+// Stage is "observe" and WouldHave carries the action that WOULD have run.
+type Event struct {
+	TS        string  `json:"ts"`
+	SessionID string  `json:"session_id"`
+	Title     string  `json:"title"`
+	Conductor string  `json:"conductor,omitempty"`
+	Group     string  `json:"group,omitempty"`
+	Profile   string  `json:"profile"`
+	Account   string  `json:"account,omitempty"`
+	Substate  string  `json:"substate"`
+	Dwell     float64 `json:"dwell_seconds"`
+
+	Reads []ReadSig `json:"reads"`
+
+	Decision Decision `json:"decision"`
+	// Action is the action TAKEN (null/empty on skip and in observe mode — observe
+	// never takes an action). WouldHave carries the observe-mode would-be action.
+	Action       Action            `json:"action,omitempty"`
+	ActionParams map[string]any    `json:"action_params,omitempty"`
+	Caps         CapsState         `json:"caps"`
+	Outcome      string            `json:"outcome,omitempty"`
+	Stage        Mode              `json:"stage"`
+	// WouldHave is present in observe mode: the action self-heal WOULD have taken
+	// had it been authorized. Empty when the decision was a skip.
+	WouldHave Action `json:"would_have,omitempty"`
+}
+
+// EventSink is the durable audit destination. The default is an append-only
+// NDJSON file; the operational-KG ingestion path can subscribe to the same
+// records later (§5). Append must be safe for concurrent callers.
+type EventSink interface {
+	Append(Event) error
+}
+
+// NDJSONSink is an append-only newline-delimited-JSON file sink. It uses a
+// targeted append (O_APPEND create), NEVER a full-file rewrite and NEVER
+// SaveInstances — it cannot wipe or truncate existing audit history (§3.5: no
+// destructive write primitive). The parent directory is created 0o700.
+type NDJSONSink struct {
+	path string
+	mu   sync.Mutex
+}
+
+// NewNDJSONSink returns a sink appending to path. The directory is created if
+// absent. The file itself is created lazily on first Append.
+func NewNDJSONSink(path string) (*NDJSONSink, error) {
+	if path == "" {
+		return nil, fmt.Errorf("selfheal: empty audit path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("selfheal: mkdir audit dir: %w", err)
+	}
+	return &NDJSONSink{path: path}, nil
+}
+
+// Path returns the audit file path (so callers/tests can report where it lands).
+func (s *NDJSONSink) Path() string { return s.path }
+
+// Append writes one event as a single JSON line. O_APPEND guarantees the write
+// only ever extends the file; it never truncates or overwrites prior records.
+func (s *NDJSONSink) Append(e Event) error {
+	line, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("selfheal: marshal event: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	f, err := os.OpenFile(s.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("selfheal: open audit file: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("selfheal: append audit line: %w", err)
+	}
+	return nil
+}
+
+// MemorySink collects events in memory (tests, and any in-process subscriber).
+type MemorySink struct {
+	mu     sync.Mutex
+	Events []Event
+}
+
+// Append records the event.
+func (m *MemorySink) Append(e Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Events = append(m.Events, e)
+	return nil
+}
+
+// Snapshot returns a copy of the recorded events.
+func (m *MemorySink) Snapshot() []Event {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Event, len(m.Events))
+	copy(out, m.Events)
+	return out
+}
+
+func formatTS(t time.Time) string { return t.UTC().Format(time.RFC3339) }

--- a/internal/selfheal/event.go
+++ b/internal/selfheal/event.go
@@ -37,11 +37,11 @@ type Event struct {
 	Decision Decision `json:"decision"`
 	// Action is the action TAKEN (null/empty on skip and in observe mode — observe
 	// never takes an action). WouldHave carries the observe-mode would-be action.
-	Action       Action            `json:"action,omitempty"`
-	ActionParams map[string]any    `json:"action_params,omitempty"`
-	Caps         CapsState         `json:"caps"`
-	Outcome      string            `json:"outcome,omitempty"`
-	Stage        Mode              `json:"stage"`
+	Action       Action         `json:"action,omitempty"`
+	ActionParams map[string]any `json:"action_params,omitempty"`
+	Caps         CapsState      `json:"caps"`
+	Outcome      string         `json:"outcome,omitempty"`
+	Stage        Mode           `json:"stage"`
 	// WouldHave is present in observe mode: the action self-heal WOULD have taken
 	// had it been authorized. Empty when the decision was a skip.
 	WouldHave Action `json:"would_have,omitempty"`

--- a/internal/selfheal/event_test.go
+++ b/internal/selfheal/event_test.go
@@ -1,0 +1,140 @@
+package selfheal
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+func TestNDJSONSink_AppendOnly_NeverTruncates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "selfheal-audit.ndjson")
+	sink, err := NewNDJSONSink(path)
+	if err != nil {
+		t.Fatalf("NewNDJSONSink: %v", err)
+	}
+	if sink.Path() != path {
+		t.Fatalf("Path() = %q, want %q", sink.Path(), path)
+	}
+
+	for i := 0; i < 3; i++ {
+		ev := Event{
+			TS:        formatTS(time.Unix(int64(1780000000+i), 0)),
+			SessionID: "s1",
+			Substate:  string(tmux.SubstateModelUnavailable),
+			Decision:  DecisionAct,
+			WouldHave: ActionRestartModelSwitch,
+			Stage:     ModeObserve,
+		}
+		if err := sink.Append(ev); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+
+	// A new sink to the same path must EXTEND, not truncate (durability across
+	// process restarts — the ≥1-week observe window spans restarts).
+	sink2, err := NewNDJSONSink(path)
+	if err != nil {
+		t.Fatalf("re-open sink: %v", err)
+	}
+	if err := sink2.Append(Event{SessionID: "s2", Stage: ModeObserve, Decision: DecisionSkipBusy}); err != nil {
+		t.Fatalf("Append after re-open: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	var lines []Event
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var e Event
+		if err := json.Unmarshal(sc.Bytes(), &e); err != nil {
+			t.Fatalf("bad NDJSON line %q: %v", sc.Text(), err)
+		}
+		lines = append(lines, e)
+	}
+	if len(lines) != 4 {
+		t.Fatalf("want 4 durable records (3 + 1 after re-open), got %d", len(lines))
+	}
+	if lines[0].SessionID != "s1" || lines[3].SessionID != "s2" {
+		t.Fatalf("append order/durability broken: %q ... %q", lines[0].SessionID, lines[3].SessionID)
+	}
+}
+
+func TestNDJSONSink_EmptyPath_Errors(t *testing.T) {
+	if _, err := NewNDJSONSink(""); err == nil {
+		t.Fatal("empty path must error")
+	}
+}
+
+func TestNDJSONSink_Concurrent(t *testing.T) {
+	dir := t.TempDir()
+	sink, err := NewNDJSONSink(filepath.Join(dir, "a.ndjson"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 50
+	done := make(chan struct{}, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			_ = sink.Append(Event{SessionID: "x", Stage: ModeObserve})
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < n; i++ {
+		<-done
+	}
+	f, _ := os.Open(sink.Path())
+	defer f.Close()
+	count := 0
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		count++
+	}
+	if count != n {
+		t.Fatalf("concurrent appends: want %d lines, got %d", n, count)
+	}
+}
+
+func TestEvent_JSONShape_MatchesSpec(t *testing.T) {
+	ev := Event{
+		TS:           "2026-06-15T11:00:00Z",
+		SessionID:    "ab12-1780000000",
+		Title:        "exec-fix-1414",
+		Group:        "agent-deck",
+		Profile:      "personal",
+		Substate:     string(tmux.SubstateModelUnavailable),
+		Dwell:        95,
+		Reads:        []ReadSig{{T: "t1", Sig: "h1"}, {T: "t2", Sig: "h1"}},
+		Decision:     DecisionAct,
+		Caps:         CapsState{Session6h: 1, GlobalHour: 2},
+		Outcome:      "observe_noop",
+		Stage:        ModeObserve,
+		WouldHave:    ActionRestartModelSwitch,
+		ActionParams: map[string]any{"model": "opus", "reissue": true},
+	}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	// Spec §5 required keys present; "action" absent (observe takes none).
+	for _, k := range []string{"ts", "session_id", "substate", "dwell_seconds", "reads", "decision", "caps", "stage", "would_have"} {
+		if _, ok := m[k]; !ok {
+			t.Errorf("event JSON missing required key %q", k)
+		}
+	}
+	if _, ok := m["action"]; ok {
+		t.Errorf("observe event must omit the taken-action field")
+	}
+}

--- a/internal/selfheal/policy.go
+++ b/internal/selfheal/policy.go
@@ -1,0 +1,227 @@
+package selfheal
+
+import (
+	"sync"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Caps holds the §3.3 rate limits. Defaults mirror the rails agent-deck already
+// trusts: the global hourly cap is the TriageMaxPerHour=5 precedent.
+type Caps struct {
+	// PerSession6h is the max recoveries per session per rolling 6h window
+	// (default 2). auth_401 is special-cased to 1 (PerSessionAuth401).
+	PerSession6h int
+	// PerSessionAuth401 is the per-session cap for the auth_401 class (default 1):
+	// a 401 that survives one restart trips the breaker immediately (§2.2/§3.4).
+	PerSessionAuth401 int
+	// GlobalPerHour is the max recoveries across the WHOLE fleet per hour
+	// (default 5 = TriageMaxPerHour). On hitting it → escalate-only, one
+	// consolidated incident (§3.3).
+	GlobalPerHour int
+	// BreakerK is the consecutive-failed-recovery count that opens the per-session
+	// circuit breaker (default 2; 1 for auth_401, BreakerKAuth401) (§3.4).
+	BreakerK         int
+	BreakerKAuth401  int
+}
+
+// DefaultCaps returns the §3.3/§7 starting dials (tuned later from observe data).
+func DefaultCaps() Caps {
+	return Caps{
+		PerSession6h:      2,
+		PerSessionAuth401: 1,
+		GlobalPerHour:     5,
+		BreakerK:          2,
+		BreakerKAuth401:   1,
+	}
+}
+
+// CapsState is a read-only view of the cap counters for one decision, recorded in
+// the audit event's "caps" field.
+type CapsState struct {
+	Session6h   int `json:"session_6h"`
+	GlobalHour  int `json:"global_hour"`
+	BreakerFails int `json:"breaker_fails"`
+	BreakerOpen bool `json:"breaker_open"`
+}
+
+// recovery is a single recorded would-be recovery attempt (timestamped for the
+// rolling windows). In observe mode no real recovery executes, but the
+// state-machine still RECORDS would-be attempts so caps/backoff/breaker are
+// exercised and their decisions are logged (§ Stage 1 brief item 4).
+type recovery struct {
+	at      time.Time
+	substate tmux.Substate
+}
+
+// PolicyMachine is the deterministic safety state-machine (§3): caps, backoff,
+// circuit breaker, and FlickerDetector subscription. It is the SAME machine in
+// every stage; in observe mode it is exercised and logged but never gates a real
+// action (because no action runs). Safe for concurrent use.
+type PolicyMachine struct {
+	caps Caps
+
+	mu sync.Mutex
+	// perSession holds recent would-be recoveries per session id (for the rolling
+	// per-session window + backoff anchor).
+	perSession map[string][]recovery
+	// global holds recent would-be recoveries across the fleet (rolling hour).
+	global []recovery
+	// consecutiveFails counts consecutive FAILED recoveries per session (breaker).
+	consecutiveFails map[string]int
+	// quarantined marks sessions whose breaker is open (manual clear / self-heal).
+	quarantined map[string]bool
+	// flickering is the set of session ids the FlickerDetector flagged (>3
+	// transitions / 60s) — a flapping session is by definition not safely
+	// healable, so it is quarantine-equivalent (§3.4).
+	flickering map[string]bool
+}
+
+// NewPolicyMachine builds a machine with the given caps (use DefaultCaps()).
+func NewPolicyMachine(caps Caps) *PolicyMachine {
+	return &PolicyMachine{
+		caps:             caps,
+		perSession:       map[string][]recovery{},
+		consecutiveFails: map[string]int{},
+		quarantined:      map[string]bool{},
+		flickering:       map[string]bool{},
+	}
+}
+
+// rolling windows for the two caps.
+const (
+	perSessionWindow = 6 * time.Hour
+	globalWindow     = 1 * time.Hour
+)
+
+// SetFlickering records the FlickerDetector verdict for a session. A flapping
+// session is quarantine-equivalent: self-heal must never restart into a flap
+// (the #1349 / duplicate-killer family, §3.4/§3.5).
+func (p *PolicyMachine) SetFlickering(sessionID string, flickering bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if flickering {
+		p.flickering[sessionID] = true
+	} else {
+		delete(p.flickering, sessionID)
+	}
+}
+
+// breakerLimit returns the breaker K for the given substate.
+func (p *PolicyMachine) breakerLimit(s tmux.Substate) int {
+	if s == tmux.SubstateAuth401 {
+		return p.caps.BreakerKAuth401
+	}
+	return p.caps.BreakerK
+}
+
+// perSessionLimit returns the per-session recovery cap for the given substate.
+func (p *PolicyMachine) perSessionLimit(s tmux.Substate) int {
+	if s == tmux.SubstateAuth401 {
+		return p.caps.PerSessionAuth401
+	}
+	return p.caps.PerSession6h
+}
+
+// prune drops recoveries outside their rolling window. Caller holds the lock.
+func prune(recs []recovery, now time.Time, window time.Duration) []recovery {
+	cutoff := now.Add(-window)
+	out := recs[:0]
+	for _, r := range recs {
+		if r.at.After(cutoff) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// Gate decides whether the safety machine would ALLOW a recovery for a confirmed
+// candidate right now, and returns the cap snapshot + the gating decision. It is
+// pure w.r.t. recorded state (no side effects); RecordAttempt commits a would-be
+// attempt. The returned Decision is DecisionAct when allowed, or the specific
+// guard that blocked it (cap_hit / breaker_open).
+//
+// Ordering (most-protective first): breaker / flicker quarantine, then global
+// fleet cap, then per-session cap. Backoff is folded into the per-session cap
+// check via the most-recent attempt time.
+func (p *PolicyMachine) Gate(c Candidate, now time.Time) (Decision, CapsState) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	sess := prune(p.perSession[c.SessionID], now, perSessionWindow)
+	p.perSession[c.SessionID] = sess
+	p.global = prune(p.global, now, globalWindow)
+
+	state := CapsState{
+		Session6h:    len(sess),
+		GlobalHour:   len(p.global),
+		BreakerFails: p.consecutiveFails[c.SessionID],
+		BreakerOpen:  p.quarantined[c.SessionID] || p.flickering[c.SessionID],
+	}
+
+	// Circuit breaker / flicker quarantine: a session that flapped or already
+	// failed K consecutive recoveries must not be acted on — escalate only.
+	if state.BreakerOpen || p.consecutiveFails[c.SessionID] >= p.breakerLimit(c.Substate) {
+		state.BreakerOpen = true
+		return DecisionBreakerOpen, state
+	}
+
+	// Global fleet rate cap (TriageMaxPerHour precedent): a fleet-wide outage
+	// can never become a fleet-wide restart storm.
+	if len(p.global) >= p.caps.GlobalPerHour {
+		return DecisionCapHit, state
+	}
+
+	// Per-session cap (folds in backoff: once the cap is hit, stop).
+	if len(sess) >= p.perSessionLimit(c.Substate) {
+		return DecisionCapHit, state
+	}
+
+	return DecisionAct, state
+}
+
+// RecordAttempt commits a would-be recovery attempt to the rolling windows. In
+// observe mode this is what exercises the caps/backoff machine without any real
+// action: the engine records the attempt it WOULD have made so the next cycle's
+// Gate reflects it and the audit shows caps advancing.
+func (p *PolicyMachine) RecordAttempt(c Candidate, now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	rec := recovery{at: now, substate: c.Substate}
+	p.perSession[c.SessionID] = append(prune(p.perSession[c.SessionID], now, perSessionWindow), rec)
+	p.global = append(prune(p.global, now, globalWindow), rec)
+}
+
+// RecordOutcome updates the circuit breaker after a recovery's outcome is known.
+// healthy=true resets the consecutive-fail counter; healthy=false increments it
+// and, on reaching K, opens the breaker (quarantine). Used by Stages 2-3; in
+// observe mode there is no real outcome, so it is exercised only in tests.
+func (p *PolicyMachine) RecordOutcome(c Candidate, healthy bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if healthy {
+		delete(p.consecutiveFails, c.SessionID)
+		return
+	}
+	p.consecutiveFails[c.SessionID]++
+	if p.consecutiveFails[c.SessionID] >= p.breakerLimit(c.Substate) {
+		p.quarantined[c.SessionID] = true
+	}
+}
+
+// IsQuarantined reports whether the session's breaker is open (manual clear or a
+// return to healthy is required). flicker is treated as quarantine-equivalent.
+func (p *PolicyMachine) IsQuarantined(sessionID string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.quarantined[sessionID] || p.flickering[sessionID]
+}
+
+// ClearQuarantine releases a session's breaker (human/Maestro action, §3.4).
+func (p *PolicyMachine) ClearQuarantine(sessionID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.quarantined, sessionID)
+	delete(p.consecutiveFails, sessionID)
+}

--- a/internal/selfheal/policy.go
+++ b/internal/selfheal/policy.go
@@ -22,8 +22,8 @@ type Caps struct {
 	GlobalPerHour int
 	// BreakerK is the consecutive-failed-recovery count that opens the per-session
 	// circuit breaker (default 2; 1 for auth_401, BreakerKAuth401) (§3.4).
-	BreakerK         int
-	BreakerKAuth401  int
+	BreakerK        int
+	BreakerKAuth401 int
 }
 
 // DefaultCaps returns the §3.3/§7 starting dials (tuned later from observe data).
@@ -40,10 +40,10 @@ func DefaultCaps() Caps {
 // CapsState is a read-only view of the cap counters for one decision, recorded in
 // the audit event's "caps" field.
 type CapsState struct {
-	Session6h   int `json:"session_6h"`
-	GlobalHour  int `json:"global_hour"`
-	BreakerFails int `json:"breaker_fails"`
-	BreakerOpen bool `json:"breaker_open"`
+	Session6h    int  `json:"session_6h"`
+	GlobalHour   int  `json:"global_hour"`
+	BreakerFails int  `json:"breaker_fails"`
+	BreakerOpen  bool `json:"breaker_open"`
 }
 
 // recovery is a single recorded would-be recovery attempt (timestamped for the
@@ -51,7 +51,7 @@ type CapsState struct {
 // state-machine still RECORDS would-be attempts so caps/backoff/breaker are
 // exercised and their decisions are logged (§ Stage 1 brief item 4).
 type recovery struct {
-	at      time.Time
+	at       time.Time
 	substate tmux.Substate
 }
 

--- a/internal/selfheal/policy_test.go
+++ b/internal/selfheal/policy_test.go
@@ -1,0 +1,141 @@
+package selfheal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+func cand(id string, s tmux.Substate) Candidate {
+	return Candidate{SessionID: id, Substate: s}
+}
+
+func TestGate_PerSessionCap_TwoThenBlocked(t *testing.T) {
+	p := NewPolicyMachine(DefaultCaps()) // PerSession6h=2
+	now := time.Unix(1780000000, 0).UTC()
+	c := cand("s1", tmux.SubstateModelUnavailable)
+
+	// 1st and 2nd attempts allowed.
+	for i := 0; i < 2; i++ {
+		if d, _ := p.Gate(c, now); d != DecisionAct {
+			t.Fatalf("attempt %d: want act, got %s", i+1, d)
+		}
+		p.RecordAttempt(c, now)
+		now = now.Add(time.Minute)
+	}
+	// 3rd within the 6h window is capped.
+	if d, st := p.Gate(c, now); d != DecisionCapHit {
+		t.Fatalf("3rd attempt: want cap_hit, got %s (session6h=%d)", d, st.Session6h)
+	}
+}
+
+func TestGate_PerSessionCap_RollsOffAfterWindow(t *testing.T) {
+	p := NewPolicyMachine(DefaultCaps())
+	now := time.Unix(1780000000, 0).UTC()
+	c := cand("s1", tmux.SubstateModelUnavailable)
+	p.RecordAttempt(c, now)
+	p.RecordAttempt(c, now.Add(time.Minute))
+	// 7h later both attempts have rolled off the 6h window.
+	later := now.Add(7 * time.Hour)
+	if d, st := p.Gate(c, later); d != DecisionAct || st.Session6h != 0 {
+		t.Fatalf("after window: want act/0, got %s/%d", d, st.Session6h)
+	}
+}
+
+func TestGate_Auth401_CapIsOne(t *testing.T) {
+	p := NewPolicyMachine(DefaultCaps()) // PerSessionAuth401=1
+	now := time.Unix(1780000000, 0).UTC()
+	c := cand("s1", tmux.SubstateAuth401)
+	if d, _ := p.Gate(c, now); d != DecisionAct {
+		t.Fatalf("1st 401: want act, got %s", d)
+	}
+	p.RecordAttempt(c, now)
+	if d, _ := p.Gate(c, now.Add(time.Minute)); d != DecisionCapHit {
+		t.Fatalf("2nd 401: want cap_hit (K=1), got %s", d)
+	}
+}
+
+func TestGate_GlobalFleetCap(t *testing.T) {
+	p := NewPolicyMachine(DefaultCaps()) // GlobalPerHour=5
+	now := time.Unix(1780000000, 0).UTC()
+	// 5 distinct sessions each record one attempt → global window full.
+	for i := 0; i < 5; i++ {
+		c := cand(string(rune('a'+i)), tmux.SubstateModelUnavailable)
+		if d, _ := p.Gate(c, now); d != DecisionAct {
+			t.Fatalf("session %d: want act, got %s", i, d)
+		}
+		p.RecordAttempt(c, now)
+	}
+	// 6th distinct session is blocked by the GLOBAL cap even though its own
+	// per-session count is 0.
+	c6 := cand("z", tmux.SubstateModelUnavailable)
+	if d, st := p.Gate(c6, now); d != DecisionCapHit {
+		t.Fatalf("6th session: want global cap_hit, got %s (global=%d)", d, st.GlobalHour)
+	}
+}
+
+func TestBreaker_OpensAfterKFails(t *testing.T) {
+	p := NewPolicyMachine(DefaultCaps()) // BreakerK=2
+	c := cand("s1", tmux.SubstateModelUnavailable)
+	now := time.Unix(1780000000, 0).UTC()
+	p.RecordOutcome(c, false) // 1st fail
+	if p.IsQuarantined("s1") {
+		t.Fatal("breaker opened too early (after 1 fail, K=2)")
+	}
+	p.RecordOutcome(c, false) // 2nd fail → open
+	if !p.IsQuarantined("s1") {
+		t.Fatal("breaker must open after K=2 consecutive fails")
+	}
+	if d, st := p.Gate(c, now); d != DecisionBreakerOpen || !st.BreakerOpen {
+		t.Fatalf("quarantined session: want breaker_open, got %s", d)
+	}
+}
+
+func TestBreaker_Auth401_OpensAfterOneFail(t *testing.T) {
+	p := NewPolicyMachine(DefaultCaps()) // BreakerKAuth401=1
+	c := cand("s1", tmux.SubstateAuth401)
+	p.RecordOutcome(c, false)
+	if !p.IsQuarantined("s1") {
+		t.Fatal("401 breaker must open after a single fail (K=1)")
+	}
+}
+
+func TestBreaker_HealthyResetsFails(t *testing.T) {
+	p := NewPolicyMachine(DefaultCaps())
+	c := cand("s1", tmux.SubstateModelUnavailable)
+	p.RecordOutcome(c, false)
+	p.RecordOutcome(c, true) // healthy resets
+	p.RecordOutcome(c, false)
+	if p.IsQuarantined("s1") {
+		t.Fatal("healthy outcome must reset the consecutive-fail counter")
+	}
+}
+
+func TestFlicker_QuarantineEquivalent(t *testing.T) {
+	p := NewPolicyMachine(DefaultCaps())
+	c := cand("s1", tmux.SubstateModelUnavailable)
+	now := time.Unix(1780000000, 0).UTC()
+	p.SetFlickering("s1", true)
+	if d, st := p.Gate(c, now); d != DecisionBreakerOpen || !st.BreakerOpen {
+		t.Fatalf("flapping session must be breaker_open (never restart a flap), got %s", d)
+	}
+	// clearing the flicker re-allows.
+	p.SetFlickering("s1", false)
+	if d, _ := p.Gate(c, now); d != DecisionAct {
+		t.Fatalf("after flicker cleared: want act, got %s", d)
+	}
+}
+
+func TestClearQuarantine(t *testing.T) {
+	p := NewPolicyMachine(DefaultCaps())
+	c := cand("s1", tmux.SubstateAuth401)
+	p.RecordOutcome(c, false) // opens (K=1)
+	if !p.IsQuarantined("s1") {
+		t.Fatal("expected quarantine")
+	}
+	p.ClearQuarantine("s1")
+	if p.IsQuarantined("s1") {
+		t.Fatal("ClearQuarantine must release the breaker")
+	}
+}

--- a/internal/selfheal/predicate_test.go
+++ b/internal/selfheal/predicate_test.go
@@ -1,0 +1,178 @@
+package selfheal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// base returns a candidate that, with a dwelled anchor, IS a candidate. Tests
+// flip one field to assert each disqualifier in isolation.
+func base(now time.Time) Candidate {
+	return Candidate{
+		SessionID:       "s1-1780000000",
+		Title:           "exec-fix",
+		Group:           "agent-deck",
+		Profile:         "personal",
+		Status:          "error",
+		Substate:        tmux.SubstateModelUnavailable,
+		Busy:            false,
+		HookRunningFresh: false,
+		OutputMoved:     false,
+		Stopped:         false,
+		OptedOut:        false,
+		StatusChangedAt: now.Add(-5 * time.Minute), // well past 90s
+	}
+}
+
+func TestEvaluate_ModelUnavailable_Dwelled_IsCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	res := Evaluate(base(now), now)
+	if !res.Candidate || res.Decision != DecisionAct {
+		t.Fatalf("want candidate/act, got candidate=%v decision=%s", res.Candidate, res.Decision)
+	}
+}
+
+func TestEvaluate_Busy_NeverCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	c := base(now)
+	c.Busy = true // authoritative disqualifier (§3.1)
+	res := Evaluate(c, now)
+	if res.Candidate || res.Decision != DecisionSkipBusy {
+		t.Fatalf("busy must never be a candidate, got candidate=%v decision=%s", res.Candidate, res.Decision)
+	}
+}
+
+func TestEvaluate_MidTurn_HookRunning_NeverCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	c := base(now)
+	c.HookRunningFresh = true
+	res := Evaluate(c, now)
+	if res.Candidate || res.Decision != DecisionSkipMidTurn {
+		t.Fatalf("mid-turn (hook running) must never be a candidate, got %v/%s", res.Candidate, res.Decision)
+	}
+}
+
+func TestEvaluate_MidTurn_OutputMoved_NeverCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	c := base(now)
+	c.OutputMoved = true
+	res := Evaluate(c, now)
+	if res.Candidate || res.Decision != DecisionSkipMidTurn {
+		t.Fatalf("mid-turn (output moved) must never be a candidate, got %v/%s", res.Candidate, res.Decision)
+	}
+}
+
+func TestEvaluate_Healthy_NeverCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	for _, s := range []tmux.Substate{tmux.SubstateNone, tmux.SubstateRunning} {
+		c := base(now)
+		c.Substate = s
+		res := Evaluate(c, now)
+		if res.Candidate || res.Decision != DecisionSkipHealthy {
+			t.Fatalf("substate %q must never be a candidate, got %v/%s", s, res.Candidate, res.Decision)
+		}
+	}
+}
+
+func TestEvaluate_NotDwelled_NeverCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	c := base(now)
+	c.StatusChangedAt = now.Add(-30 * time.Second) // < 90s threshold
+	res := Evaluate(c, now)
+	if res.Candidate || res.Decision != DecisionSkipDwell {
+		t.Fatalf("not dwelled must skip_dwell, got %v/%s", res.Candidate, res.Decision)
+	}
+}
+
+func TestEvaluate_Stopped_NeverCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	c := base(now)
+	c.Stopped = true
+	res := Evaluate(c, now)
+	if res.Candidate || res.Decision != DecisionSkipStopped {
+		t.Fatalf("stopped must never be a candidate, got %v/%s", res.Candidate, res.Decision)
+	}
+}
+
+func TestEvaluate_OptedOut_NeverCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	c := base(now)
+	c.OptedOut = true
+	res := Evaluate(c, now)
+	if res.Candidate || res.Decision != DecisionSkipOptOut {
+		t.Fatalf("opted-out must never be a candidate, got %v/%s", res.Candidate, res.Decision)
+	}
+}
+
+// §1.4: a long-waiting session with NO send is deliberate idle, never a
+// candidate — idle_at_empty_prompt is only stuck AFTER a send.
+func TestEvaluate_IdleNoSend_NeverCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	c := base(now)
+	c.Substate = tmux.SubstateIdleAtEmptyPrompt
+	c.Status = "waiting"
+	c.StatusChangedAt = now.Add(-3 * time.Hour) // waiting for ages
+	c.LastSentAt = time.Time{}                   // but we never sent anything
+	res := Evaluate(c, now)
+	if res.Candidate || res.Decision != DecisionSkipDwell {
+		t.Fatalf("deliberate idle (no send) must never be a candidate, got %v/%s", res.Candidate, res.Decision)
+	}
+}
+
+// idle_at_empty_prompt IS a candidate only once it has dwelled past 5m AFTER a
+// send.
+func TestEvaluate_IdleAfterSend_Dwelled_IsCandidate(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	c := base(now)
+	c.Substate = tmux.SubstateIdleAtEmptyPrompt
+	c.Status = "waiting"
+	c.LastSentAt = now.Add(-6 * time.Minute) // sent, no response for 6m > 5m
+	res := Evaluate(c, now)
+	if !res.Candidate || res.Decision != DecisionAct {
+		t.Fatalf("idle 6m after send must be a candidate, got %v/%s", res.Candidate, res.Decision)
+	}
+}
+
+func TestEvaluate_IdleAfterSend_NotDwelled_Skips(t *testing.T) {
+	now := time.Unix(1780000000, 0).UTC()
+	c := base(now)
+	c.Substate = tmux.SubstateIdleAtEmptyPrompt
+	c.LastSentAt = now.Add(-2 * time.Minute) // < 5m
+	res := Evaluate(c, now)
+	if res.Candidate || res.Decision != DecisionSkipDwell {
+		t.Fatalf("idle 2m after send must skip_dwell, got %v/%s", res.Candidate, res.Decision)
+	}
+}
+
+// Each stuck substate maps to the correct would_have action (§2.4).
+func TestWouldHaveAction_PerSubstate(t *testing.T) {
+	cases := map[tmux.Substate]Action{
+		tmux.SubstateModelUnavailable:  ActionRestartModelSwitch,
+		tmux.SubstateAuth401:           ActionRestartReassertCreds,
+		tmux.SubstateIdleAtEmptyPrompt: ActionResend,
+	}
+	for s, want := range cases {
+		if got := WouldHaveAction(s); got != want {
+			t.Errorf("WouldHaveAction(%q) = %q, want %q", s, got, want)
+		}
+	}
+	// a non-stuck class falls back to escalate (defensive).
+	if got := WouldHaveAction(tmux.SubstateNone); got != ActionEscalate {
+		t.Errorf("WouldHaveAction(none) = %q, want escalate", got)
+	}
+}
+
+func TestDwellThresholds(t *testing.T) {
+	if d, ok := DwellThreshold(tmux.SubstateModelUnavailable); !ok || d != 90*time.Second {
+		t.Errorf("model_unavailable dwell = %v ok=%v, want 90s", d, ok)
+	}
+	if d, ok := DwellThreshold(tmux.SubstateAuth401); !ok || d != 60*time.Second {
+		t.Errorf("auth_401 dwell = %v ok=%v, want 60s", d, ok)
+	}
+	// usage_limit / running / none are not stuck classes.
+	if _, ok := DwellThreshold(tmux.SubstateRunning); ok {
+		t.Errorf("running must not be a stuck class")
+	}
+}

--- a/internal/selfheal/predicate_test.go
+++ b/internal/selfheal/predicate_test.go
@@ -11,18 +11,18 @@ import (
 // flip one field to assert each disqualifier in isolation.
 func base(now time.Time) Candidate {
 	return Candidate{
-		SessionID:       "s1-1780000000",
-		Title:           "exec-fix",
-		Group:           "agent-deck",
-		Profile:         "personal",
-		Status:          "error",
-		Substate:        tmux.SubstateModelUnavailable,
-		Busy:            false,
+		SessionID:        "s1-1780000000",
+		Title:            "exec-fix",
+		Group:            "agent-deck",
+		Profile:          "personal",
+		Status:           "error",
+		Substate:         tmux.SubstateModelUnavailable,
+		Busy:             false,
 		HookRunningFresh: false,
-		OutputMoved:     false,
-		Stopped:         false,
-		OptedOut:        false,
-		StatusChangedAt: now.Add(-5 * time.Minute), // well past 90s
+		OutputMoved:      false,
+		Stopped:          false,
+		OptedOut:         false,
+		StatusChangedAt:  now.Add(-5 * time.Minute), // well past 90s
 	}
 }
 
@@ -114,7 +114,7 @@ func TestEvaluate_IdleNoSend_NeverCandidate(t *testing.T) {
 	c.Substate = tmux.SubstateIdleAtEmptyPrompt
 	c.Status = "waiting"
 	c.StatusChangedAt = now.Add(-3 * time.Hour) // waiting for ages
-	c.LastSentAt = time.Time{}                   // but we never sent anything
+	c.LastSentAt = time.Time{}                  // but we never sent anything
 	res := Evaluate(c, now)
 	if res.Candidate || res.Decision != DecisionSkipDwell {
 		t.Fatalf("deliberate idle (no send) must never be a candidate, got %v/%s", res.Candidate, res.Decision)

--- a/internal/selfheal/selfheal.go
+++ b/internal/selfheal/selfheal.go
@@ -64,16 +64,16 @@ const (
 type Decision string
 
 const (
-	DecisionAct          Decision = "act"          // would act (observe: would_have set)
-	DecisionSkipHealthy  Decision = "skip_healthy"  // substate not a stuck class
-	DecisionSkipBusy     Decision = "skip_busy"     // live busy indicator (authoritative)
-	DecisionSkipMidTurn  Decision = "skip_midturn"  // fresh hook-running / output moved
-	DecisionSkipDwell    Decision = "skip_dwell"    // not dwelled past threshold yet
-	DecisionSkipConfirm  Decision = "skip_confirm"  // second read disagreed (2-read drop)
-	DecisionSkipStopped  Decision = "skip_stopped"  // session stopped (user-intentional)
-	DecisionSkipOptOut   Decision = "skip_optout"   // per-session/group opt-out
-	DecisionCapHit       Decision = "cap_hit"       // per-session or global cap exceeded
-	DecisionBreakerOpen  Decision = "breaker_open"  // circuit breaker / flicker quarantine
+	DecisionAct         Decision = "act"          // would act (observe: would_have set)
+	DecisionSkipHealthy Decision = "skip_healthy" // substate not a stuck class
+	DecisionSkipBusy    Decision = "skip_busy"    // live busy indicator (authoritative)
+	DecisionSkipMidTurn Decision = "skip_midturn" // fresh hook-running / output moved
+	DecisionSkipDwell   Decision = "skip_dwell"   // not dwelled past threshold yet
+	DecisionSkipConfirm Decision = "skip_confirm" // second read disagreed (2-read drop)
+	DecisionSkipStopped Decision = "skip_stopped" // session stopped (user-intentional)
+	DecisionSkipOptOut  Decision = "skip_optout"  // per-session/group opt-out
+	DecisionCapHit      Decision = "cap_hit"      // per-session or global cap exceeded
+	DecisionBreakerOpen Decision = "breaker_open" // circuit breaker / flicker quarantine
 )
 
 // stuckDwellThresholds are the §1.3 cause-specific dwell windows. usage_limit is

--- a/internal/selfheal/selfheal.go
+++ b/internal/selfheal/selfheal.go
@@ -1,0 +1,117 @@
+// Package selfheal is the deterministic "Go floor" of the self-heal supervision
+// design (SELF-HEAL-DESIGN.md §4.3). It detects a TRULY stuck session, classifies
+// the cause, and — gated by a release stage — decides on a bounded, idempotent,
+// fully-logged recovery.
+//
+// STAGE 1 (this release, v1.9.67) is OBSERVE-ONLY. The engine evaluates the §1.3
+// stuck predicate, exercises the caps / backoff / circuit-breaker / flicker
+// state-machine, and LOGS what it WOULD do — but takes ZERO action. Observe mode
+// holds no action executor at all, so "no recovery primitive is ever called" is a
+// structural property, not a runtime check (see Engine.Observe and the
+// no-action test). Modes single_action / full are DEFINED but GUARDED: they
+// refuse to act until Stages 2-3 are re-approved (the three §9 gap-fixes).
+//
+// The module is pure: it consumes a Candidate snapshot (already-read data) and a
+// monotonic clock, and emits a structured Event to an EventSink. It never reaches
+// into tmux, never calls SaveInstances, never touches the rebind path. That
+// keeps the predicate and the safety machine fully unit-testable and guarantees
+// the observe-only invariant.
+package selfheal
+
+import (
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// Mode is the global self-heal authority level (config [selfheal] mode).
+type Mode string
+
+const (
+	// ModeObserve logs would_have for every candidate and takes NO action. The
+	// default and the only mode that does anything in v1.9.67.
+	ModeObserve Mode = "observe"
+	// ModeSingleAction is Stage 2 (model_unavailable restart+Opus only). DEFINED
+	// but GUARDED — refuses to act until Ashesh re-approves + the §9 gaps close.
+	ModeSingleAction Mode = "single_action"
+	// ModeFull is Stage 3 (all classes, auto within caps). DEFINED but GUARDED.
+	ModeFull Mode = "full"
+)
+
+// Action is what self-heal would do for a candidate. It is recorded in the audit
+// event; in observe mode it is the would_have value and is never executed.
+type Action string
+
+const (
+	ActionNone Action = ""
+	// ActionRestartModelSwitch — restart pinned to a safe model + re-issue last
+	// intent once (model_unavailable, §2.1).
+	ActionRestartModelSwitch Action = "restart_model_switch"
+	// ActionRestart — one bounded restart via the resume path (wedged_pane, §2.3).
+	ActionRestart Action = "restart"
+	// ActionResend — re-send the last intent once before any restart
+	// (idle_at_empty_prompt, §2.3).
+	ActionResend Action = "resend"
+	// ActionRestartReassertCreds — one restart that reasserts the credential
+	// symlink, the known fix for the scratch-clobber 401 class (auth_401, §2.2).
+	ActionRestartReassertCreds Action = "restart_reassert_creds"
+	// ActionEscalate — surface one consolidated alert, take no recovery
+	// (cap hit, breaker open, 401 that survived a restart).
+	ActionEscalate Action = "escalate"
+)
+
+// Decision is the verdict the policy reached for a candidate this cycle.
+type Decision string
+
+const (
+	DecisionAct          Decision = "act"          // would act (observe: would_have set)
+	DecisionSkipHealthy  Decision = "skip_healthy"  // substate not a stuck class
+	DecisionSkipBusy     Decision = "skip_busy"     // live busy indicator (authoritative)
+	DecisionSkipMidTurn  Decision = "skip_midturn"  // fresh hook-running / output moved
+	DecisionSkipDwell    Decision = "skip_dwell"    // not dwelled past threshold yet
+	DecisionSkipConfirm  Decision = "skip_confirm"  // second read disagreed (2-read drop)
+	DecisionSkipStopped  Decision = "skip_stopped"  // session stopped (user-intentional)
+	DecisionSkipOptOut   Decision = "skip_optout"   // per-session/group opt-out
+	DecisionCapHit       Decision = "cap_hit"       // per-session or global cap exceeded
+	DecisionBreakerOpen  Decision = "breaker_open"  // circuit breaker / flicker quarantine
+)
+
+// stuckDwellThresholds are the §1.3 cause-specific dwell windows. usage_limit is
+// intentionally absent (never auto-restart, §2). A substate not present here is
+// not a self-heal-actionable stuck class.
+var stuckDwellThresholds = map[tmux.Substate]time.Duration{
+	tmux.SubstateModelUnavailable:  90 * time.Second,
+	tmux.SubstateAuth401:           60 * time.Second,
+	tmux.SubstateIdleAtEmptyPrompt: 5 * time.Minute,
+}
+
+// actionForSubstate maps a confirmed stuck substate to the action self-heal
+// would take FIRST (§2.4). Observe mode records this as would_have.
+var actionForSubstate = map[tmux.Substate]Action{
+	tmux.SubstateModelUnavailable:  ActionRestartModelSwitch,
+	tmux.SubstateAuth401:           ActionRestartReassertCreds,
+	tmux.SubstateIdleAtEmptyPrompt: ActionResend,
+}
+
+// IsStuckSubstate reports whether a substate is a self-heal-actionable stuck
+// class (§1.3 condition 1). SubstateRunning / SubstateNone are never stuck.
+func IsStuckSubstate(s tmux.Substate) bool {
+	_, ok := stuckDwellThresholds[s]
+	return ok
+}
+
+// DwellThreshold returns the cause-specific dwell window for a stuck substate,
+// or 0 (and ok=false) for a non-stuck class.
+func DwellThreshold(s tmux.Substate) (time.Duration, bool) {
+	d, ok := stuckDwellThresholds[s]
+	return d, ok
+}
+
+// WouldHaveAction returns the action self-heal would take for a confirmed stuck
+// candidate (used to populate would_have in observe mode).
+func WouldHaveAction(s tmux.Substate) Action {
+	if a, ok := actionForSubstate[s]; ok {
+		return a
+	}
+	return ActionEscalate
+}

--- a/internal/session/flicker_detector.go
+++ b/internal/session/flicker_detector.go
@@ -71,6 +71,27 @@ func (d *FlickerDetector) Observe(sessionID, status string) {
 	d.observeAt(sessionID, status, time.Now())
 }
 
+// IsFlickering reports whether a session currently has more than flickerThreshold
+// transitions within the sliding window — i.e. it is flapping. Read-only (it
+// prunes against the wall clock but records no new transition). Used by self-heal
+// to treat a flapping session as quarantine-equivalent: a flicker is by
+// definition not safely healable by restart (SELF-HEAL-DESIGN.md §3.4).
+func (d *FlickerDetector) IsFlickering(sessionID string) bool {
+	if sessionID == "" {
+		return false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	cutoff := time.Now().Add(-flickerWindow)
+	count := 0
+	for _, ts := range d.transitions[sessionID] {
+		if ts.After(cutoff) {
+			count++
+		}
+	}
+	return count > flickerThreshold
+}
+
 // observeAt is the testable form of Observe.
 func (d *FlickerDetector) observeAt(sessionID, status string, now time.Time) {
 	if sessionID == "" {

--- a/internal/session/flicker_detector_test.go
+++ b/internal/session/flicker_detector_test.go
@@ -10,6 +10,28 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/logging"
 )
 
+// TestFlickerDetector_IsFlickering reports flapping for self-heal's quarantine
+// signal. Uses fresh Observe (wall-clock) since IsFlickering prunes against now.
+func TestFlickerDetector_IsFlickering(t *testing.T) {
+	d := NewFlickerDetector()
+	if d.IsFlickering("inst-A") {
+		t.Fatal("no transitions: must not be flickering")
+	}
+	// >flickerThreshold (3) transitions in the window → flapping.
+	for i := 0; i < 5; i++ {
+		d.Observe("inst-A", "running")
+	}
+	if !d.IsFlickering("inst-A") {
+		t.Fatal("5 fresh transitions must read as flickering")
+	}
+	if d.IsFlickering("other") {
+		t.Fatal("unrelated session must not be flickering")
+	}
+	if d.IsFlickering("") {
+		t.Fatal("empty id must not be flickering")
+	}
+}
+
 // TestFlickerDetector_BelowThreshold_NoWarn verifies that a small number of
 // transitions within the window does NOT emit a flicker_detected log.
 func TestFlickerDetector_BelowThreshold_NoWarn(t *testing.T) {

--- a/internal/session/selfheal_pass.go
+++ b/internal/session/selfheal_pass.go
@@ -1,0 +1,150 @@
+package session
+
+import (
+	"sync"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/selfheal"
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+// selfHealRegistry holds one observe-only self-heal Engine per profile, lazily
+// created. The Engine must persist across poll cycles so the two-read confirm
+// and the caps/backoff/breaker windows accumulate. It is owned by the transition
+// daemon and never spawns its own goroutine (F3: no new watchdog layer — the
+// existing poll loop drives it). Safe for concurrent use.
+type selfHealRegistry struct {
+	mu      sync.Mutex
+	engines map[string]*selfheal.Engine
+	sinks   map[string]selfheal.EventSink
+}
+
+func newSelfHealRegistry() *selfHealRegistry {
+	return &selfHealRegistry{
+		engines: map[string]*selfheal.Engine{},
+		sinks:   map[string]selfheal.EventSink{},
+	}
+}
+
+// engineFor returns the observe-only engine for a profile, creating it on first
+// use with the configured caps + the durable NDJSON audit sink. Returns nil when
+// the audit sink can't be opened (self-heal then stands down for that profile,
+// rather than failing the whole poll — observe-only must never destabilize the
+// daemon).
+func (r *selfHealRegistry) engineFor(profile string, caps selfheal.Caps) *selfheal.Engine {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.engines[profile]; ok {
+		return e
+	}
+	path, err := SelfHealAuditPath(profile)
+	if err != nil {
+		return nil
+	}
+	sink, err := selfheal.NewNDJSONSink(path)
+	if err != nil {
+		return nil
+	}
+	e := selfheal.NewObserveEngine(caps, sink)
+	r.engines[profile] = e
+	r.sinks[profile] = sink
+	return e
+}
+
+// capsFromSettings maps the config dials onto selfheal.Caps, falling back to the
+// trusted defaults for any unset field.
+func capsFromSettings(s SelfHealSettings) selfheal.Caps {
+	caps := selfheal.DefaultCaps()
+	if s.PerSessionPerWindow > 0 {
+		caps.PerSession6h = s.PerSessionPerWindow
+	}
+	if s.GlobalPerHour > 0 {
+		caps.GlobalPerHour = s.GlobalPerHour
+	}
+	return caps
+}
+
+// buildSelfHealCandidate assembles the pure Candidate snapshot for one instance
+// from data the daemon already read this cycle. It does NO new tmux capture and
+// NO DB mutation — it reuses the cached substate, the canonical status, the hook
+// freshness, and the content signal the transition path already computes. This
+// is what keeps the observe pass cheap and side-effect-free.
+//
+// hs is the instance's hook status (may be nil). lastSentAt is the last_sent_at
+// clock read from the DB (zero if never sent). optedOut folds the per-session and
+// group opt-out config.
+func buildSelfHealCandidate(inst *Instance, status string, hs *HookStatus, lastSentAt time.Time, optedOut bool) selfheal.Candidate {
+	sub := inst.CachedSubstate()
+	busy := sub == SubstateRunning
+	hookRunningFresh := hs != nil &&
+		normalizeStatusString(hs.Status) == "running" &&
+		(hs.UpdatedAt.IsZero() || time.Since(hs.UpdatedAt) <= hookFreshWindow)
+
+	return selfheal.Candidate{
+		SessionID:        inst.ID,
+		Title:            inst.Title,
+		Group:            inst.GroupPath,
+		Profile:          "", // stamped by the caller (it knows the profile)
+		Account:          inst.Account,
+		Status:           status,
+		Substate:         sub,
+		Busy:             busy,
+		HookRunningFresh: hookRunningFresh,
+		OutputSig:        transitionEventOutputHash(inst),
+		Stopped:          normalizeStatusString(status) == "stopped",
+		OptedOut:         optedOut,
+		StatusChangedAt:  inst.GetWaitingSince(), // best-available durable dwell anchor
+		LastSentAt:       lastSentAt,
+	}
+}
+
+// runSelfHealObservePass evaluates every instance through the profile's observe
+// engine, emitting one audit record per detection. It takes ZERO action — the
+// engine is observe-only by construction (no executor). It is called from the
+// daemon's syncProfile AFTER statuses are computed, reusing the already-loaded
+// instances/hookStatuses (no extra poll). Disabled-by-config → no-op.
+//
+// now is date-u anchored by the caller (time.Now().UTC()). db is the profile's
+// state DB for the read-only last_sent_at lookup.
+func (d *TransitionDaemon) runSelfHealObservePass(profile string, instances []*Instance, statuses map[string]string, hookStatuses map[string]*HookStatus, db *statedb.StateDB, now time.Time) {
+	settings := GetSelfHealSettings()
+	if !settings.Enabled {
+		return // global kill switch (default): self-heal does nothing.
+	}
+	if d.selfheal == nil {
+		d.selfheal = newSelfHealRegistry()
+	}
+	engine := d.selfheal.engineFor(profile, capsFromSettings(settings))
+	if engine == nil {
+		return // audit sink unavailable — stand down for this profile.
+	}
+
+	// Subscribe to the global FlickerDetector (the same one the TUI feeds): a
+	// flapping session is by definition not safely healable, so self-heal treats
+	// it as quarantine-equivalent (SELF-HEAL-DESIGN.md §3.4). We update the policy
+	// machine's flicker view each pass so the gate reflects current flapping.
+	flicker := GlobalFlickerDetector()
+
+	for _, inst := range instances {
+		if inst == nil {
+			continue
+		}
+		var lastSent time.Time
+		if db != nil {
+			if ts, err := db.ReadLastSentAt(inst.ID); err == nil && ts > 0 {
+				lastSent = time.Unix(ts, 0)
+			}
+		}
+		optedOut := settings.IsSessionOptedOut(inst.ID, inst.Title) ||
+			settings.IsGroupOptedOut(inst.GroupPath)
+
+		engine.Policy().SetFlickering(inst.ID, flicker.IsFlickering(inst.ID))
+
+		c := buildSelfHealCandidate(inst, statuses[inst.ID], hookStatuses[inst.ID], lastSent, optedOut)
+		c.Profile = profile
+		// Observe-only: ProcessRead logs would_have and returns having taken NO
+		// action (the engine holds no executor). We deliberately ignore the
+		// returned event here — the audit sink already persisted it.
+		_ = engine.ProcessRead(c, now)
+	}
+}

--- a/internal/session/selfheal_pass_test.go
+++ b/internal/session/selfheal_pass_test.go
@@ -1,0 +1,112 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/selfheal"
+)
+
+func TestBuildSelfHealCandidate_FoldsSignals(t *testing.T) {
+	inst := &Instance{
+		ID:        "s1-1780000000",
+		Title:     "exec-fix",
+		GroupPath: "agent-deck",
+		Account:   "personal",
+		Status:    StatusError,
+	}
+	// hook freshness is compared against the wall clock (time.Since), so use a
+	// fresh "now" here, not a fixed-epoch timestamp.
+	hs := &HookStatus{Status: "running", UpdatedAt: time.Now()}
+
+	c := buildSelfHealCandidate(inst, "error", hs, time.Unix(1779999000, 0), true)
+	if c.SessionID != "s1-1780000000" || c.Title != "exec-fix" || c.Group != "agent-deck" {
+		t.Fatalf("identity not folded: %+v", c)
+	}
+	if !c.HookRunningFresh {
+		t.Error("fresh hook-running must set HookRunningFresh (mid-turn signal)")
+	}
+	if !c.OptedOut {
+		t.Error("optedOut must be carried into the candidate")
+	}
+	if c.LastSentAt.IsZero() {
+		t.Error("LastSentAt must be carried")
+	}
+}
+
+func TestBuildSelfHealCandidate_StaleHookNotFresh(t *testing.T) {
+	inst := &Instance{ID: "s1", Title: "t", Status: StatusError}
+	stale := time.Now().Add(-10 * time.Minute)
+	c := buildSelfHealCandidate(inst, "error", &HookStatus{Status: "running", UpdatedAt: stale}, time.Time{}, false)
+	if c.HookRunningFresh {
+		t.Error("a stale hook-running (past freshness window) must NOT count as mid-turn")
+	}
+}
+
+func TestBuildSelfHealCandidate_StoppedDetected(t *testing.T) {
+	inst := &Instance{ID: "s1", Title: "t", Status: StatusStopped}
+	c := buildSelfHealCandidate(inst, "stopped", nil, time.Time{}, false)
+	if !c.Stopped {
+		t.Error("stopped status must set Stopped (highest-precedence disqualifier)")
+	}
+}
+
+func TestCapsFromSettings_DefaultsAndOverrides(t *testing.T) {
+	def := capsFromSettings(SelfHealSettings{})
+	if def != selfheal.DefaultCaps() {
+		t.Fatalf("empty settings must yield default caps, got %+v", def)
+	}
+	over := capsFromSettings(SelfHealSettings{PerSessionPerWindow: 9, GlobalPerHour: 11})
+	if over.PerSession6h != 9 || over.GlobalPerHour != 11 {
+		t.Fatalf("overrides not applied: %+v", over)
+	}
+	// auth401 cap stays at the safe default even when per-session is widened.
+	if over.PerSessionAuth401 != 1 {
+		t.Fatalf("auth401 cap must stay 1, got %d", over.PerSessionAuth401)
+	}
+}
+
+func TestSelfHealSettings_OptOut(t *testing.T) {
+	s := SelfHealSettings{
+		OptOutGroups:   []string{"stream-leads"},
+		OptOutSessions: []string{"keep-warm", "id-123"},
+	}
+	if !s.IsGroupOptedOut("stream-leads") {
+		t.Error("group opt-out not honored")
+	}
+	if s.IsGroupOptedOut("agent-deck") {
+		t.Error("unrelated group must not be opted out")
+	}
+	if !s.IsSessionOptedOut("id-123", "any") || !s.IsSessionOptedOut("x", "keep-warm") {
+		t.Error("session opt-out (by id or title) not honored")
+	}
+	if s.IsSessionOptedOut("nope", "nope") {
+		t.Error("unrelated session must not be opted out")
+	}
+}
+
+func TestSelfHealMode_Normalizes(t *testing.T) {
+	cases := map[string]string{
+		"":              "observe",
+		"observe":       "observe",
+		"garbage":       "observe",
+		"single_action": "single_action",
+		"full":          "full",
+	}
+	for in, want := range cases {
+		if got := (SelfHealSettings{Mode: in}).SelfHealMode(); got != want {
+			t.Errorf("SelfHealMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The registry exposes an observe-only engine: it must never hold an executor.
+func TestSelfHealRegistry_ObserveEngineOnly(t *testing.T) {
+	r := newSelfHealRegistry()
+	// Inject a memory-backed engine so we don't depend on the filesystem path.
+	r.engines["p"] = selfheal.NewObserveEngine(selfheal.DefaultCaps(), &selfheal.MemorySink{})
+	e := r.engines["p"]
+	if e.Mode() != selfheal.ModeObserve {
+		t.Fatalf("registry engine must be observe mode, got %q", e.Mode())
+	}
+}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -58,6 +58,11 @@ type TransitionDaemon struct {
 	// the daemon runs it at most once per inboxTTLSweepInterval. Zero
 	// means "never run" — the first SyncOnce pass will perform it.
 	lastInboxTTLSweep time.Time
+
+	// selfheal holds the per-profile observe-only self-heal engines (lazily
+	// created). Driven by this poll loop — NOT a new daemon (F3: no watchdog
+	// stacking). nil until the first enabled pass.
+	selfheal *selfHealRegistry
 }
 
 func NewTransitionDaemon() *TransitionDaemon {
@@ -254,6 +259,13 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 			}
 		}
 	}
+
+	// Self-heal Stage 1 (observe-only): evaluate every instance through the
+	// profile's observe engine, logging what it WOULD do and taking ZERO action.
+	// Runs every poll (including the first) so the dwell/confirm clocks start
+	// immediately. Reuses the instances/hookStatuses already loaded above — no
+	// extra capture, no new goroutine (F3). Disabled-by-config → cheap no-op.
+	d.runSelfHealObservePass(profile, instances, statuses, hookStatuses, db, time.Now().UTC())
 
 	if !d.initialized[profile] {
 		// Cover fast transitions that completed before we observed a running snapshot.

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -216,6 +216,88 @@ type UserConfig struct {
 
 	// UI defines TUI layout settings (split ratios, etc).
 	UI UISettings `toml:"ui,omitempty"`
+
+	// SelfHeal defines self-heal supervision settings (SELF-HEAL-DESIGN.md).
+	// Stage 1 (v1.9.67) is observe-only: it logs what it WOULD do, takes no
+	// action. See SelfHealSettings.
+	SelfHeal SelfHealSettings `toml:"selfheal,omitempty"`
+}
+
+// SelfHealSettings controls the self-heal supervision policy (SELF-HEAL-DESIGN.md
+// §3.7, §6). The shipped default is fully observe-only: it detects truly-stuck
+// sessions, exercises the safety state-machine, and LOGS what it would do —
+// taking ZERO recovery action. Modes single_action / full are DEFINED but GUARDED
+// (they refuse to act) until Stages 2-3 are re-approved by Ashesh + the three §9
+// gap-fixes land.
+type SelfHealSettings struct {
+	// Enabled is the global kill switch (§3.7). When false (the default),
+	// self-heal does nothing at all — not even observe-mode logging. Set true to
+	// run the observe-only Stage 1.
+	Enabled bool `toml:"enabled"`
+
+	// Mode is the authority level: "observe" (default, the only acting mode in
+	// v1.9.67 — logs would_have, takes no action), "single_action" / "full"
+	// (Stages 2-3, DEFINED but GUARDED, refuse to act). An unknown/empty value
+	// is normalized to "observe".
+	Mode string `toml:"mode,omitempty"`
+
+	// AuditPath overrides where the durable NDJSON audit log lands. Empty uses
+	// the per-profile default under the agent-deck data dir (see
+	// SelfHealAuditPath). The audit is the dataset reviewed over the ≥1-week
+	// observe window before any Stage-2 re-approval.
+	AuditPath string `toml:"audit_path,omitempty"`
+
+	// PerSessionPerWindow overrides the per-session recovery cap (default 2 / 6h;
+	// auth_401 is always 1). 0 uses the default. Starting dial; tuned from
+	// observe data.
+	PerSessionPerWindow int `toml:"per_session_per_window,omitempty"`
+
+	// GlobalPerHour overrides the fleet-wide hourly recovery cap (default 5 =
+	// TriageMaxPerHour). 0 uses the default.
+	GlobalPerHour int `toml:"global_per_hour,omitempty"`
+
+	// OptOutGroups lists group paths that opt OUT of self-heal entirely
+	// (deliberate long-waiting stream leads, sensitive scopes — §3.7). Checked
+	// in the stuck predicate as a quick disqualifier.
+	OptOutGroups []string `toml:"opt_out_groups,omitempty"`
+
+	// OptOutSessions lists session ids/titles that opt OUT of self-heal.
+	OptOutSessions []string `toml:"opt_out_sessions,omitempty"`
+}
+
+// SelfHealMode normalizes the configured mode to a known value. Empty / unknown
+// → "observe" (the safe default). Used by the daemon when constructing the
+// engine. The string return matches selfheal.Mode values.
+func (s SelfHealSettings) SelfHealMode() string {
+	switch s.Mode {
+	case "single_action", "full":
+		return s.Mode
+	default:
+		return "observe"
+	}
+}
+
+// IsGroupOptedOut reports whether a group path opts out of self-heal.
+func (s SelfHealSettings) IsGroupOptedOut(groupPath string) bool {
+	for _, g := range s.OptOutGroups {
+		if g != "" && g == groupPath {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSessionOptedOut reports whether a session (by id or title) opts out.
+func (s SelfHealSettings) IsSessionOptedOut(id, title string) bool {
+	for _, sn := range s.OptOutSessions {
+		if sn == "" {
+			continue
+		}
+		if sn == id || sn == title {
+			return true
+		}
+	}
+	return false
 }
 
 // UISettings controls TUI layout proportions.
@@ -3196,6 +3278,44 @@ func GetNotificationsSettings() NotificationsConfig {
 	}
 
 	return settings
+}
+
+// GetSelfHealSettings returns self-heal settings from config. The zero value
+// (Enabled=false) is the safe default: self-heal does nothing unless explicitly
+// enabled. Mode is normalized to a known value by SelfHealMode().
+func GetSelfHealSettings() SelfHealSettings {
+	config, err := LoadUserConfig()
+	if err != nil || config == nil {
+		return SelfHealSettings{}
+	}
+	return config.SelfHeal
+}
+
+// SelfHealAuditPath returns the durable NDJSON audit path for a profile. It uses
+// the configured AuditPath override when set, else a per-profile default under
+// the agent-deck data dir (so the ≥1-week observe window's records survive
+// restarts and are easy to locate for review). profile may be "" (default).
+func SelfHealAuditPath(profile string) (string, error) {
+	s := GetSelfHealSettings()
+	if s.AuditPath != "" {
+		// Keep an explicit override profile-scoped too, so multiple profiles do
+		// not interleave their records into one file (they run in separate
+		// processes but could point at the same override). Insert the profile
+		// before the extension: /x/audit.ndjson -> /x/audit-<profile>.ndjson.
+		if profile == "" {
+			return s.AuditPath, nil
+		}
+		ext := filepath.Ext(s.AuditPath)
+		base := strings.TrimSuffix(s.AuditPath, ext)
+		return base + "-" + profile + ext, nil
+	}
+	name := "selfheal-audit.ndjson"
+	if profile != "" {
+		name = "selfheal-audit-" + profile + ".ndjson"
+	}
+	// Lands under <data-dir>/runtime/selfheal/ so the ≥1-week observe-window
+	// records survive restarts and are easy to locate for review.
+	return runtimeDataPath(filepath.Join("selfheal", name))
 }
 
 // GetMaintenanceSettings returns maintenance settings from config

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -96,7 +96,7 @@ func withBusyRetry(op func() error) error {
 
 // SchemaVersion tracks the current database schema version.
 // Bump this when adding migrations.
-const SchemaVersion = 12
+const SchemaVersion = 13
 
 // StateDB wraps a SQLite database for session/group persistence.
 // Thread-safe for concurrent use from multiple goroutines within one process.
@@ -380,6 +380,7 @@ func (s *StateDB) Migrate() error {
 			auto_name              INTEGER NOT NULL DEFAULT 0,
 			auto_name_description  TEXT NOT NULL DEFAULT '',
 			pin             TEXT NOT NULL DEFAULT '',
+			last_sent_at    INTEGER NOT NULL DEFAULT 0,
 			tool_data       TEXT NOT NULL DEFAULT '{}',
 			acknowledged    INTEGER NOT NULL DEFAULT 0
 		)
@@ -543,6 +544,14 @@ func (s *StateDB) Migrate() error {
 		// their handle until they are recreated as quick sessions.
 		"ALTER TABLE instances ADD COLUMN auto_name INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE instances ADD COLUMN auto_name_description TEXT NOT NULL DEFAULT ''",
+		// v13 (self-heal Stage 1, #1457-followup): the "we talked to it" clock.
+		// Set by the keysender on every delivered injection. The self-heal stuck
+		// predicate measures the idle_at_empty_prompt dwell from this timestamp:
+		// a session is only stuck at an empty prompt if WE sent it something and
+		// nothing happened. Default 0 ("never sent") preserves legacy rows as
+		// deliberate-idle (never a self-heal candidate). Additive + targeted-write
+		// only (WriteLastSentAt); never part of a whole-row REPLACE/SaveInstances.
+		"ALTER TABLE instances ADD COLUMN last_sent_at INTEGER NOT NULL DEFAULT 0",
 	}
 	for _, stmt := range alterMigrations {
 		if _, err := tx.Exec(stmt); err != nil {
@@ -626,6 +635,16 @@ func (s *StateDB) Migrate() error {
 			if _, err := tx.Exec(`ALTER TABLE instances ADD COLUMN auto_name_description TEXT NOT NULL DEFAULT ''`); err != nil {
 				if !strings.Contains(err.Error(), "duplicate column") {
 					return fmt.Errorf("statedb: migrate v12 auto_name_description: %w", err)
+				}
+			}
+		}
+		if oldVer < 13 {
+			// Self-heal Stage 1: the last_sent_at clock. Default 0 = "never sent",
+			// so every legacy row reads as deliberate-idle (never a self-heal
+			// candidate) until the keysender stamps it.
+			if _, err := tx.Exec(`ALTER TABLE instances ADD COLUMN last_sent_at INTEGER NOT NULL DEFAULT 0`); err != nil {
+				if !strings.Contains(err.Error(), "duplicate column") {
+					return fmt.Errorf("statedb: migrate v13 last_sent_at: %w", err)
 				}
 			}
 		}
@@ -1095,6 +1114,36 @@ func (s *StateDB) WriteAutoNameDescription(id, description string) error {
 		)
 		return err
 	})
+}
+
+// WriteLastSentAt persists the "we talked to it" clock (Unix seconds) for a
+// session into the last_sent_at column with a targeted single-column UPDATE —
+// never a whole-row INSERT OR REPLACE and never SaveInstances. The keysender
+// stamps this on every delivered injection; the self-heal predicate reads it to
+// measure the idle_at_empty_prompt dwell (#1457-followup, self-heal Stage 1).
+//
+// Like WriteAutoNameDescription this touches ONLY its own column, so a concurrent
+// writer's edits to any other field of the same row are preserved (no data-loss
+// surface), and it is wrapped in withBusyRetry for the same SQLITE_BUSY reason.
+func (s *StateDB) WriteLastSentAt(id string, unixSeconds int64) error {
+	return withBusyRetry(func() error {
+		_, err := s.db.Exec(
+			`UPDATE instances SET last_sent_at = ? WHERE id = ?`,
+			unixSeconds, id,
+		)
+		return err
+	})
+}
+
+// ReadLastSentAt returns the last_sent_at clock (Unix seconds, 0 if never sent)
+// for a session. Read-only; used by the self-heal detection pass.
+func (s *StateDB) ReadLastSentAt(id string) (int64, error) {
+	var ts int64
+	err := s.db.QueryRow(`SELECT last_sent_at FROM instances WHERE id = ?`, id).Scan(&ts)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return ts, err
 }
 
 // InstanceStatusUpdate is one targeted status mutation for

--- a/internal/statedb/statedb_test.go
+++ b/internal/statedb/statedb_test.go
@@ -932,6 +932,54 @@ func TestMigrate_OldSchema_AcknowledgedColumn(t *testing.T) {
 	}
 }
 
+// TestMigrate_OldSchema_LastSentAtColumn verifies the v13 self-heal migration:
+// upgrading a pre-last_sent_at DB adds the column, defaults legacy rows to 0
+// ("never sent" → deliberate-idle, never a self-heal candidate), preserves the
+// existing row, and the targeted Write/ReadLastSentAt helpers work without
+// touching any other column.
+func TestMigrate_OldSchema_LastSentAtColumn(t *testing.T) {
+	db := createV1SchemaDB(t)
+
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("Migrate() on v1 schema failed: %v", err)
+	}
+
+	// Legacy row survives, and last_sent_at defaults to 0.
+	insts, err := db.LoadInstances()
+	if err != nil {
+		t.Fatalf("LoadInstances after migrate: %v", err)
+	}
+	if len(insts) != 1 || insts[0].ID != "existing-1" {
+		t.Fatalf("legacy row not preserved: %+v", insts)
+	}
+	ts, err := db.ReadLastSentAt("existing-1")
+	if err != nil {
+		t.Fatalf("ReadLastSentAt: %v", err)
+	}
+	if ts != 0 {
+		t.Fatalf("legacy row last_sent_at must default to 0, got %d", ts)
+	}
+
+	// Targeted write round-trips and does not disturb the title/status.
+	const sent = int64(1780000123)
+	if err := db.WriteLastSentAt("existing-1", sent); err != nil {
+		t.Fatalf("WriteLastSentAt: %v", err)
+	}
+	ts, _ = db.ReadLastSentAt("existing-1")
+	if ts != sent {
+		t.Fatalf("ReadLastSentAt = %d, want %d", ts, sent)
+	}
+	insts2, _ := db.LoadInstances()
+	if insts2[0].Title != "My Session" {
+		t.Fatalf("WriteLastSentAt disturbed another column: title=%q", insts2[0].Title)
+	}
+
+	// Unknown id reads 0, not an error (no row).
+	if v, err := db.ReadLastSentAt("nope"); err != nil || v != 0 {
+		t.Fatalf("ReadLastSentAt(unknown) = %d, %v; want 0, nil", v, err)
+	}
+}
+
 // TestMigrate_OldSchema_NewTablesCreated verifies that new tables (recent_sessions,
 // cost_events) are created when migrating from v1 schema.
 func TestMigrate_OldSchema_NewTablesCreated(t *testing.T) {


### PR DESCRIPTION
## Self-heal supervision Stage 1 — OBSERVE-ONLY

Adds a deterministic self-heal policy module (`internal/selfheal`) that **detects truly-stuck sessions and logs what it would do, taking zero recovery action.** It runs inside the existing transition/state daemon (no new watchdog process).

### What it does
- Consumes the Honest Status v2 substate layer (`model-unavailable` / `auth-401` / `idle-at-empty-prompt`).
- Evaluates a conservative "truly stuck" predicate: known-stuck substate AND not actively busy AND not mid-turn AND dwelled past a cause-specific threshold AND not stopped AND not opted out — confirmed across two independent reads of the **same** substate.
- Exercises the full safety state-machine (per-session + global rate caps, backoff, circuit breaker, flicker-detector subscription) and **logs its decisions** — but never executes a recovery in observe mode.
- Emits one structured NDJSON audit record per detection (substate, dwell, the two confirming read signatures, decision, caps state, `would_have` action) to a durable per-profile sink under `runtime/selfheal/`.

### Observe-only is structural
The observe engine holds **no** action executor, and the single execution chokepoint refuses any non-observe mode. Modes `single_action` / `full` are defined but guarded (they refuse to act) pending re-approval. A dedicated test asserts no recovery primitive is ever called in observe mode.

### Supporting changes
- `instances.last_sent_at` column (schema v13, additive, targeted single-column write from the send path) — the `idle-at-empty-prompt` dwell is measured from this clock, so a deliberately-idle session with no send is never a candidate. Legacy rows default to "never sent".
- `FlickerDetector.IsFlickering` read-only query, wired so a flapping session is treated as quarantine-equivalent.

### Config
`[selfheal]` with `enabled` kill-switch (off by default), `mode` (observe default), per-session/group opt-out, and cap dials.

### Testing
- New `internal/selfheal` package: predicate true/false cases, the two-read drop, same-substate confirm, caps/backoff/breaker transitions, flicker quarantine, NDJSON append-only durability, and the observe-takes-no-action proof. `-race` clean.
- Schema v13 migration upgrade-path test (sandboxed HOME/XDG), targeted-write isolation test.
- Session-level candidate-builder, opt-out, and flicker tests.