### PR TITLE
feat(web): Command Center — live two-way fleet god-view tab (v1)

### DIFF
--- a/docs/COMMAND-CENTER.md
+++ b/docs/COMMAND-CENTER.md
@@ -1,0 +1,135 @@
+# Command Center
+
+The Command Center is the embedded, live, two-way **fleet god-view** inside
+`agent-deck web`. It productizes the hand-made conductor status HTMLs into a real
+feature: a first-class tab that renders cross-project status live off an SSE feed,
+surfaces the decisions waiting on you, and routes typed instructions to Maestro or
+a chosen conductor through the supported `session send` path.
+
+It is private by construction — loopback by default, token-gated for any
+non-loopback bind, never public — inheriting the web server's existing security
+model (`auth.go`, `bind.go`, `csrf.go`, the mutation gate + rate limiter). It adds
+no new server, no new daemon, and no new auth surface.
+
+## v1 (shipped)
+
+A "Command Center" tab (positioned first) in the existing Preact SPA, backed by
+three additive endpoints registered on the existing mux behind the existing gates.
+
+### Endpoints (`internal/web/handlers_command_center.go`)
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/command-center/status` | GET | One-shot synthesized cross-project snapshot |
+| `/events/command-center` | GET (SSE) | Live push of the snapshot, fingerprint-diffed + heartbeat (same pattern as `/events/menu`) |
+| `/api/command-center/ask` | POST | Two-way input: route an instruction to Maestro / a conductor via `session send`; mutation-gated, CSRF fail-closed, target-allowlisted, argv-safe |
+
+### What it does
+
+- **Live, no polling.** `/events/command-center` subscribes to the same menu
+  change channel the menu SSE uses, so a session transition pushes a new snapshot
+  instantly. The page never polls; it re-renders off a Preact signal.
+- **Completion notifications.** The stream diffs each session's status between
+  consecutive snapshots server-side; a `running → done/waiting` transition is
+  emitted in `recentlyCompleted`, and the panel fires a "✅ X just finished"
+  toast (de-duplicated by completion id so reconnects don't re-fire).
+- **See-everything, noise filtered.** Per-conductor rows show each conductor's
+  health plus its active child sessions and what each is working on (from the
+  session's latest activity). **Error and stopped sessions are filtered out** by
+  construction. Honest-status v2 substates (`model-unavailable`, `auth-401`,
+  `idle-at-empty-prompt`) are surfaced distinctly rather than hidden as "running".
+- **Decisions waiting on you.** Parsed live from the agent-deck conductor's
+  `OPEN-ITEMS.md` §D, each with a 💬 comment affordance that prefills the input.
+- **Two-way input.** An input box (with a Maestro/conductor target picker) POSTs
+  to `/api/command-center/ask`, which delivers via `agent-deck -p <profile>
+  session send <target> "[command-center] <text>" --no-wait`. The text is passed
+  as a single argv element (never interpolated into a shell string), the target
+  is validated against a server-authoritative allowlist (Maestro + live
+  `conductor-*` sessions), and every ask is journaled (correlation id + target +
+  text-hash, never the raw text). Replies reflect back through the SSE feed as the
+  fleet moves.
+
+### Frontend (`internal/web/static/app/`)
+
+- `panes/CommandCenterPane.js` — the panel.
+- `Topbar.js` — the "Command Center" tab (first) with a decisions-waiting badge.
+- `main.js` — `startCommandCenterSSE()` subscribes to `/events/command-center`,
+  updates `commandCenterSignal`, and fires completion toasts.
+- `state.js` — `commandCenterSignal`.
+- `app.css` — the `.cc-*` styles (reuse the existing design tokens).
+
+### Snapshot shape
+
+```jsonc
+{
+  "profile": "personal",
+  "generatedAt": "2026-06-15T...",
+  "conductors": [
+    { "name": "agent-deck", "target": "conductor-agent-deck",
+      "status": "running", "substate": "",
+      "currentlyWorkingOn": "v1.9.67 release wave",
+      "sessions": [ { "id": "...", "title": "fix-1431", "status": "running",
+                      "substate": "", "workingOn": "investigating spawn race" } ],
+      "counts": { "running": 1, "waiting": 0, "idle": 0 } }
+  ],
+  "totals": { "running": 1, "waiting": 0, "idle": 0 },
+  "decisionsWaiting": [ { "id": "#1361", "question": "...", "route": "conductor-agent-deck" } ],
+  "recentlyCompleted": [ { "id": "...", "title": "X", "status": "waiting", "at": "..." } ],
+  "askTargets": [ "maestro", "conductor-agent-deck" ]
+}
+```
+
+No secret-shaped field (token/key/credential) is ever in the payload — only which
+account/conductor, never the credential. (Asserted in
+`handlers_command_center_test.go`.)
+
+### Tests
+
+- `internal/web/handlers_command_center_test.go` — synthesis (grouping, noise
+  filtering, substate surfacing, completion diff), `OPEN-ITEMS.md` §D parsing, the
+  status endpoint, SSE initial+change, `/ask` target allowlist + mutation gate +
+  empty-text rejection, target resolution.
+- `tests/web/e2e/command-center.spec.js` — Playwright: live render, conductor
+  rows + input bar, **live SSE update without reload**, **error/stopped
+  filtering**, two-way input routing (the web-UI TDD gate).
+
+## v2 (planned — follow-on PR)
+
+v2 deepens interactivity and per-project depth. It is additive to the v1 surface
+and ships as its own review-gated PR.
+
+1. **Connected per-project detail pages.** Navigable, in-app explain/detail views
+   per project (the ryan/poster/opengraphdb-style pages from the prototype):
+   click a conductor row → a detail panel with its roadmap, recent releases, what
+   each session is doing in depth, and a back affordance. Rendered from the same
+   snapshot plus the conductor's richer status artifacts.
+2. **Comment-on-anything.** A 💬 on every entity (conductor, session, decision,
+   recently-completed) that prefills the input with that entity's context
+   (`re <id>: …`) and, on send, attaches a `context` object to `/ask` so the
+   receiving conductor knows exactly what is being commented on. (v1 already
+   prefills for decisions; v2 generalizes it to all rows and wires `context`.)
+3. **Correlated reply read-back.** `/ask` records the correlation id + target; a
+   follow-up SSE event reads the target's latest response via the existing
+   `session output` path and shows it inline under the input — the chat-style
+   "you asked X, conductor replied Y" (design §5.3 fidelity tier 2). v1 reflects
+   replies via the live fleet-state SSE (tier 1); v2 adds the explicit read-back.
+4. **Keyboard navigation.** Arrows move row focus, Enter opens/expands, Esc backs
+   out / blurs the input, digit-jump (1–9) to a row, `/` to focus the input —
+   matching the prototype's nav model.
+5. **Compact plain-language layout.** A density toggle + a one-paragraph
+   plain-language fleet summary (an optional, debounced, Maestro-routed LLM
+   synthesis — never on the hot path), for the "tell me what's going on" glance.
+6. **Structured per-conductor `status.json` contract.** v1 already reads an
+   optional `conductor/<name>/status.json` `{headline}` when present (falling back
+   to the live latest-prompt). v2 formalizes the full contract
+   (`{headline, inProgress[], recentlyDone[], decisionsWaiting[], updatedAt}`) and
+   has conductors write it on their heartbeat, replacing free-text parsing with
+   structured signal.
+
+## v3 (gated on OpenGraphDB — not in scope here)
+
+Swap the interim local synthesis for an OGDB operational-knowledge-graph backend
+behind a single `StatusSource` interface (the renderer is unchanged), adding a
+free-form "ask anything about everything" query. Gated on OGDB R5/R6/R7/R10 + an
+agreed operational-KG schema co-designed with conductor-opengraphdb. See the full
+design doc (`conductor/agent-deck/COMMAND-CENTER-DESIGN.md` §7) for the seam.

--- a/internal/web/handlers_command_center.go
+++ b/internal/web/handlers_command_center.go
@@ -1,0 +1,679 @@
+package web
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/agentpaths"
+	"github.com/asheshgoplani/agent-deck/internal/logging"
+)
+
+// The Command Center is the embedded, live, two-way fleet god-view (see
+// conductor/agent-deck/COMMAND-CENTER-DESIGN.md). v1 productizes the hand-made
+// status HTMLs into a real agent-deck web panel:
+//   - GET  /api/command-center/status  — synthesized cross-project snapshot
+//   - GET  /events/command-center      — fingerprint-diffed SSE live push
+//   - POST /api/command-center/ask     — two-way input routed via `session send`
+//
+// It composes the existing plumbing: it reads the same MenuSnapshot the menu
+// handlers read (so it inherits the hook overlay + the menu change
+// subscription that drives live updates), folds in each conductor's plain-
+// language status artifacts from disk, and parses OPEN-ITEMS.md §D for the
+// "decisions waiting on you" surface. No new daemon, no new auth — every
+// endpoint is behind the existing authorize/CSRF/mutation/rate-limit gates.
+
+var (
+	commandCenterPollInterval      = 2 * time.Second
+	commandCenterHeartbeatInterval = 15 * time.Second
+)
+
+// CommandCenterSnapshot is the see-everything payload rendered by the panel.
+// Deliberately the same shape family as MenuSnapshot (profile + generatedAt +
+// typed items) so the frontend's data conventions and SSE plumbing carry over.
+type CommandCenterSnapshot struct {
+	Profile     string `json:"profile"`
+	GeneratedAt string `json:"generatedAt"`
+
+	Conductors []CommandCenterConductor `json:"conductors"`
+	Totals     CommandCenterTotals      `json:"totals"`
+
+	// DecisionsWaiting is the ⭐ surface: rulings/reviews waiting on Ashesh,
+	// parsed from OPEN-ITEMS.md §D. Empty when the file is absent.
+	DecisionsWaiting []CommandCenterDecision `json:"decisionsWaiting"`
+
+	// RecentlyCompleted carries the running→done/waiting transitions detected
+	// since the previous snapshot, so the panel can fire "✅ X just finished"
+	// notifications. It is diff-derived server-side and may be empty.
+	RecentlyCompleted []CommandCenterCompletion `json:"recentlyCompleted"`
+
+	// AskTargets is the server-authoritative allowlist of two-way input
+	// targets (maestro + live conductor-* sessions). The panel populates its
+	// target picker from this; the /ask handler re-validates against it.
+	AskTargets []string `json:"askTargets"`
+}
+
+// CommandCenterConductor is one project/domain row: a conductor plus the live
+// session list it manages, filtered to active work only.
+type CommandCenterConductor struct {
+	Name   string `json:"name"`   // short name, e.g. "agent-deck"
+	Target string `json:"target"` // routing target, e.g. "conductor-agent-deck"
+	// Status mirrors the conductor session's own status (running|waiting|idle
+	// |error|...). "absent" when no conductor session exists for the group.
+	Status string `json:"status"`
+	// Substate is the honest-status v2 refinement of the conductor session.
+	Substate string `json:"substate,omitempty"`
+	// CurrentlyWorkingOn is plain-language, sourced from the conductor's
+	// disk status artifact (status.json headline) or its latest prompt.
+	CurrentlyWorkingOn string `json:"currentlyWorkingOn,omitempty"`
+	// Sessions are the conductor's active children, error/stopped filtered out.
+	Sessions []CommandCenterSession `json:"sessions"`
+	Counts   CommandCenterCounts    `json:"counts"`
+}
+
+// CommandCenterSession is one active child session in a conductor's group.
+type CommandCenterSession struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Status   string `json:"status"`
+	Substate string `json:"substate,omitempty"`
+	// WorkingOn is the latest prompt/activity hint, when available.
+	WorkingOn string `json:"workingOn,omitempty"`
+}
+
+// CommandCenterCounts is the per-conductor active-session tally (the noise the
+// user explicitly does NOT want — error/stopped — is excluded by construction).
+type CommandCenterCounts struct {
+	Running int `json:"running"`
+	Waiting int `json:"waiting"`
+	Idle    int `json:"idle"`
+}
+
+// CommandCenterTotals is the fleet-wide active tally.
+type CommandCenterTotals struct {
+	Running int `json:"running"`
+	Waiting int `json:"waiting"`
+	Idle    int `json:"idle"`
+}
+
+// CommandCenterDecision is one item from OPEN-ITEMS.md §D.
+type CommandCenterDecision struct {
+	ID       string `json:"id"`       // e.g. "#1361"
+	Question string `json:"question"` // the plain-language ask
+	// Route is the conductor that owns the decision (best-effort; defaults to
+	// the agent-deck conductor). Wires the two-way "answer the card" path.
+	Route string `json:"route"`
+}
+
+// CommandCenterCompletion is a running→done/waiting transition for a session.
+type CommandCenterCompletion struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Status string `json:"status"` // the new status (waiting|idle)
+	At     string `json:"at"`
+}
+
+// askRequest is the POST /api/command-center/ask body.
+type askRequest struct {
+	Target  string `json:"target"` // "maestro" | "conductor-<name>" | "auto"
+	Text    string `json:"text"`   // the instruction
+	Context struct {
+		DecisionID string `json:"decisionId"`
+	} `json:"context,omitempty"`
+}
+
+// ccPrevStatuses tracks the last observed status per session id, per profile,
+// so the SSE stream can diff running→done/waiting and emit completions. Guarded
+// by the menu subscription serialization in the stream loop (one goroutine per
+// connection); kept on the connection's stack, not shared, so no extra lock.
+type ccStatusTracker map[string]string
+
+// handleCommandCenterStatus serves a one-shot synthesized snapshot.
+func (s *Server) handleCommandCenterStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeAPIError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+	if !s.authorizeRequest(r) {
+		writeAPIError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized")
+		return
+	}
+	snapshot, err := s.loadCommandCenterSnapshot(nil)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to build command center snapshot")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(snapshot)
+}
+
+// handleCommandCenterEvents streams the synthesized snapshot live, copying the
+// proven /events/menu fingerprint-diff + heartbeat pattern. It subscribes to
+// the same menu change channel so a session transition pushes instantly.
+func (s *Server) handleCommandCenterEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeAPIError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+	if !s.authorizeRequest(r) {
+		writeAPIError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized")
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeAPIError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "stream unavailable")
+		return
+	}
+
+	tracker := ccStatusTracker{}
+	snapshot, err := s.loadCommandCenterSnapshot(tracker)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to build command center snapshot")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	lastFingerprint := commandCenterFingerprint(snapshot)
+	if err := writeSSEEvent(w, flusher, "command-center", snapshot); err != nil {
+		return
+	}
+
+	menuChanges := s.subscribeMenuChanges()
+	defer s.unsubscribeMenuChanges(menuChanges)
+
+	pollTicker := time.NewTicker(commandCenterPollInterval)
+	defer pollTicker.Stop()
+	heartbeatTicker := time.NewTicker(commandCenterHeartbeatInterval)
+	defer heartbeatTicker.Stop()
+
+	ctx := r.Context()
+	emitIfChanged := func() error {
+		next, err := s.loadCommandCenterSnapshot(tracker)
+		if err != nil {
+			logging.ForComponent(logging.CompWeb).Error("command_center_stream_refresh_failed",
+				slog.String("error", err.Error()))
+			return nil
+		}
+		nextFingerprint := commandCenterFingerprint(next)
+		// Always emit when a completion fired (the notification is the point),
+		// even if the steady-state fingerprint (which excludes RecentlyCompleted)
+		// is unchanged.
+		if nextFingerprint == lastFingerprint && len(next.RecentlyCompleted) == 0 {
+			return nil
+		}
+		if err := writeSSEEvent(w, flusher, "command-center", next); err != nil {
+			return err
+		}
+		lastFingerprint = nextFingerprint
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-heartbeatTicker.C:
+			if err := writeSSEComment(w, flusher, "keepalive"); err != nil {
+				return
+			}
+		case _, ok := <-menuChanges:
+			if !ok {
+				// Subscription closed (server shutting down) — stop rather
+				// than spin on a perpetually-ready closed channel.
+				return
+			}
+			if err := emitIfChanged(); err != nil {
+				return
+			}
+		case <-pollTicker.C:
+			if err := emitIfChanged(); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// loadCommandCenterSnapshot reads the menu snapshot (with hook overlay) and
+// synthesizes the cross-project view. When tracker is non-nil it is updated
+// with the latest per-session statuses and RecentlyCompleted is populated from
+// the running→done/waiting diff.
+func (s *Server) loadCommandCenterSnapshot(tracker ccStatusTracker) (*CommandCenterSnapshot, error) {
+	menu, err := s.menuData.LoadMenuSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	refreshSnapshotHookStatuses(menu, s.hookStatusLoader)
+	return buildCommandCenterSnapshot(menu, s.cfg.Profile, conductorArtifactDir(), tracker), nil
+}
+
+// buildCommandCenterSnapshot is the pure synthesis function (no I/O beyond the
+// optional artifactDir read), kept separate so it is unit-testable with fixed
+// inputs. menu must already have the hook overlay applied.
+func buildCommandCenterSnapshot(menu *MenuSnapshot, profile, artifactDir string, tracker ccStatusTracker) *CommandCenterSnapshot {
+	snap := &CommandCenterSnapshot{
+		Profile:           profile,
+		GeneratedAt:       time.Now().UTC().Format(time.RFC3339),
+		Conductors:        []CommandCenterConductor{},
+		DecisionsWaiting:  []CommandCenterDecision{},
+		RecentlyCompleted: []CommandCenterCompletion{},
+		AskTargets:        []string{"maestro"},
+	}
+	if menu == nil {
+		return snap
+	}
+
+	// Collect sessions, split conductors from children, group children by group.
+	type sess struct {
+		id, title, status, substate, group, prompt string
+		isConductor                                bool
+	}
+	var all []sess
+	conductorByGroup := map[string]sess{}
+	for _, item := range menu.Items {
+		if item.Type != "session" || item.Session == nil {
+			continue
+		}
+		ms := item.Session
+		e := sess{
+			id:          ms.ID,
+			title:       ms.Title,
+			status:      string(ms.Status),
+			substate:    ms.Substate,
+			group:       ms.GroupPath,
+			prompt:      firstLine(ms.LatestPrompt),
+			isConductor: ms.IsConductor || strings.HasPrefix(ms.Title, "conductor-"),
+		}
+		all = append(all, e)
+		if e.isConductor {
+			// Map a conductor to the group it manages. Conductors named
+			// "conductor-<name>" manage the "<name>" group by convention.
+			managed := strings.TrimPrefix(e.title, "conductor-")
+			conductorByGroup[managed] = e
+		}
+	}
+
+	// Completion diff: running→(waiting|idle) since last snapshot. The tracker
+	// is rebuilt each pass (not just upserted) so a session id that vanishes
+	// from the registry is dropped — otherwise a later id reuse could compare
+	// against a stale "running" and fire a false completion.
+	if tracker != nil {
+		next := make(map[string]string, len(all))
+		for _, e := range all {
+			if tracker[e.id] == "running" && (e.status == "waiting" || e.status == "idle") {
+				snap.RecentlyCompleted = append(snap.RecentlyCompleted, CommandCenterCompletion{
+					ID:     e.id,
+					Title:  e.title,
+					Status: e.status,
+					At:     snap.GeneratedAt,
+				})
+			}
+			next[e.id] = e.status
+		}
+		// Replace the tracker contents in place (the caller holds the map).
+		for k := range tracker {
+			delete(tracker, k)
+		}
+		for k, v := range next {
+			tracker[k] = v
+		}
+	}
+
+	// Build a conductor row per managed group. A group is a "conductor scope"
+	// if there's a conductor-<group> session for it OR it simply has sessions.
+	groupNames := map[string]bool{}
+	for _, e := range all {
+		if e.isConductor {
+			groupNames[strings.TrimPrefix(e.title, "conductor-")] = true
+		} else if e.group != "" {
+			groupNames[e.group] = true
+		}
+	}
+	names := make([]string, 0, len(groupNames))
+	for n := range groupNames {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	statusFeeds := loadConductorStatusFeeds(artifactDir)
+
+	for _, name := range names {
+		cd := CommandCenterConductor{
+			Name:     name,
+			Target:   "conductor-" + name,
+			Status:   "absent",
+			Sessions: []CommandCenterSession{},
+		}
+		if c, ok := conductorByGroup[name]; ok {
+			cd.Status = c.status
+			cd.Substate = c.substate
+			snap.AskTargets = append(snap.AskTargets, c.title)
+		}
+		// plain-language "currently working on": disk status feed wins, else
+		// the conductor's own latest prompt.
+		if feed, ok := statusFeeds[name]; ok && feed != "" {
+			cd.CurrentlyWorkingOn = feed
+		} else if c, ok := conductorByGroup[name]; ok {
+			cd.CurrentlyWorkingOn = c.prompt
+		}
+
+		for _, e := range all {
+			if e.isConductor || e.group != name {
+				continue
+			}
+			// SEE-EVERYTHING but filter OUT the noise the user rejected.
+			if e.status == "error" || e.status == "stopped" {
+				continue
+			}
+			cd.Sessions = append(cd.Sessions, CommandCenterSession{
+				ID:        e.id,
+				Title:     e.title,
+				Status:    e.status,
+				Substate:  e.substate,
+				WorkingOn: e.prompt,
+			})
+			switch e.status {
+			case "running":
+				cd.Counts.Running++
+				snap.Totals.Running++
+			case "waiting":
+				cd.Counts.Waiting++
+				snap.Totals.Waiting++
+			case "idle":
+				cd.Counts.Idle++
+				snap.Totals.Idle++
+			}
+		}
+		snap.Conductors = append(snap.Conductors, cd)
+	}
+
+	snap.DecisionsWaiting = parseDecisionsWaiting(artifactDir)
+	return snap
+}
+
+// commandCenterFingerprint is the SSE diff key. It deliberately excludes
+// RecentlyCompleted (a transient event list) and GeneratedAt (always changes)
+// so the stream only re-emits on real fleet/decision state change.
+func commandCenterFingerprint(snap *CommandCenterSnapshot) string {
+	if snap == nil {
+		return "nil"
+	}
+	payload := struct {
+		Profile          string                   `json:"profile"`
+		Conductors       []CommandCenterConductor `json:"conductors"`
+		Totals           CommandCenterTotals      `json:"totals"`
+		DecisionsWaiting []CommandCenterDecision  `json:"decisionsWaiting"`
+	}{
+		Profile:          snap.Profile,
+		Conductors:       snap.Conductors,
+		Totals:           snap.Totals,
+		DecisionsWaiting: snap.DecisionsWaiting,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "marshal-error"
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// conductorArtifactDir resolves the on-disk conductor/ directory (where each
+// conductor keeps state.json / status.json / OPEN-ITEMS.md). Returns "" if it
+// can't be resolved, in which case the synthesis falls back to live-only data.
+func conductorArtifactDir() string {
+	dir, err := agentpaths.EffectiveDataPath("conductor", "conductor")
+	if err != nil {
+		return ""
+	}
+	return dir
+}
+
+// loadConductorStatusFeeds reads each conductor's optional structured
+// status.json (the v1.x hardening contract) for a plain-language headline,
+// keyed by conductor short name. Free-text fallback (state.json) is omitted in
+// v1 to avoid brittle parsing; conductors that haven't adopted status.json
+// simply fall back to the live latest-prompt.
+func loadConductorStatusFeeds(artifactDir string) map[string]string {
+	feeds := map[string]string{}
+	if artifactDir == "" {
+		return feeds
+	}
+	entries, err := os.ReadDir(artifactDir)
+	if err != nil {
+		return feeds
+	}
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		name := ent.Name()
+		raw, err := os.ReadFile(filepath.Join(artifactDir, name, "status.json"))
+		if err != nil {
+			continue
+		}
+		var parsed struct {
+			Headline string `json:"headline"`
+		}
+		if json.Unmarshal(raw, &parsed) == nil && parsed.Headline != "" {
+			feeds[name] = firstLine(parsed.Headline)
+		}
+	}
+	return feeds
+}
+
+// parseDecisionsWaiting reads conductor/agent-deck/OPEN-ITEMS.md and extracts
+// the §D "DECISIONS — waiting on Ashesh" items. It handles both shapes seen in
+// practice: a single "· "-separated line, and a normal multi-line Markdown list
+// ("- item" / "* item"). Every non-empty line until the next "## " section is
+// consumed; list markers are stripped; each line is further split on "·".
+// Best-effort: returns empty on any failure.
+func parseDecisionsWaiting(artifactDir string) []CommandCenterDecision {
+	out := []CommandCenterDecision{}
+	if artifactDir == "" {
+		return out
+	}
+	f, err := os.Open(filepath.Join(artifactDir, "agent-deck", "OPEN-ITEMS.md"))
+	if err != nil {
+		return out
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	inSection := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "## ") {
+			// Section D begins with "## D. DECISIONS"; any later "## " ends it.
+			inSection = strings.HasPrefix(line, "## D.")
+			continue
+		}
+		if !inSection || line == "" {
+			continue
+		}
+		// Strip a leading Markdown list marker ("- " / "* ") if present.
+		line = strings.TrimSpace(strings.TrimLeft(line, "-*"))
+		for _, raw := range strings.Split(line, "·") {
+			item := strings.TrimSpace(raw)
+			if item == "" {
+				continue
+			}
+			id := ""
+			if strings.HasPrefix(item, "#") {
+				if sp := strings.IndexByte(item, ' '); sp > 0 {
+					id = item[:sp]
+				}
+			}
+			out = append(out, CommandCenterDecision{
+				ID:       id,
+				Question: item,
+				Route:    "conductor-agent-deck",
+			})
+		}
+	}
+	return out
+}
+
+// handleCommandCenterAsk routes a typed instruction to Maestro or a chosen
+// conductor through the supported `session send` primitive — the same safe,
+// non-invasive inbound path bridge.py and the voice receiver use. It does NOT
+// type into tmux directly and does NOT touch the bridge.
+func (s *Server) handleCommandCenterAsk(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeAPIError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+	if !s.authorizeRequest(r) {
+		writeAPIError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized")
+		return
+	}
+	// /ask can move the fleet — gate it as a mutation (403 in --read-only or
+	// when web mutations are disabled) and rate-limit it like every WebMutator.
+	if !s.checkMutationsAllowed(w) {
+		return
+	}
+	if !s.checkMutationRateLimit(w) {
+		return
+	}
+
+	var req askRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64*1024)).Decode(&req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	text := strings.TrimSpace(req.Text)
+	if text == "" {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_BODY", "text is required")
+		return
+	}
+
+	// Resolve and validate the target against the server-authoritative
+	// allowlist (maestro + live conductor-* sessions). No arbitrary injection.
+	snapshot, err := s.loadCommandCenterSnapshot(nil)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to resolve targets")
+		return
+	}
+	target := strings.TrimSpace(req.Target)
+	if target == "" || target == "auto" {
+		// Default to Maestro (classify+delegate) when present, else the
+		// agent-deck conductor.
+		target = "maestro"
+		if !targetAllowed(snapshot.AskTargets, "maestro") {
+			target = "conductor-agent-deck"
+		}
+	}
+	resolved := resolveAskTarget(target, snapshot.AskTargets)
+	if resolved == "" {
+		writeAPIError(w, http.StatusBadRequest, "INVALID_TARGET", "unknown target")
+		return
+	}
+
+	// Tag the message like every other inbound channel so the receiving
+	// conductor knows the source. text is passed as a single argv element to
+	// `session send` — never interpolated into a shell string — closing the
+	// multiline / metacharacter footgun.
+	msg := "[command-center] " + text
+
+	exe, err := os.Executable()
+	if err != nil || exe == "" {
+		exe = "agent-deck"
+	}
+	// --no-wait so the HTTP request returns promptly (the reply reflects back
+	// via the SSE feed as the fleet moves); -p <profile> so it works headless.
+	// Bound the child with a context timeout so a stalled `session send` (e.g.
+	// a wedged tmux) can't pile up orphaned processes if many asks fire.
+	args := []string{"-p", s.cfg.Profile, "session", "send", resolved, msg, "--no-wait"}
+	cmdCtx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(cmdCtx, exe, args...)
+	cmd.Env = os.Environ()
+	out, runErr := cmd.CombinedOutput()
+
+	// Audit: journal the routing decision (correlationId + target + text-hash,
+	// never the raw text) — mirrors Maestro's outbox audit pattern.
+	correlationID := fmt.Sprintf("cc-%d", time.Now().UnixNano())
+	textHash := sha256.Sum256([]byte(text))
+	logging.ForComponent(logging.CompWeb).Info("command_center_ask",
+		slog.String("correlationId", correlationID),
+		slog.String("target", resolved),
+		slog.String("textHash", hex.EncodeToString(textHash[:8])),
+	)
+
+	if runErr != nil {
+		logging.ForComponent(logging.CompWeb).Warn("command_center_ask_send_failed",
+			slog.String("target", resolved),
+			slog.String("error", runErr.Error()),
+			slog.String("output", strings.TrimSpace(string(out))),
+		)
+		writeAPIError(w, http.StatusBadGateway, "SEND_FAILED", "failed to deliver to target")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"correlationId": correlationID,
+		"routedTo":      resolved,
+	})
+}
+
+// resolveAskTarget maps a requested target to the concrete allowlisted session
+// title, returning "" if it is not allowed. "maestro" resolves to the live
+// "conductor-maestro" session when present (else bare "maestro").
+func resolveAskTarget(target string, allow []string) string {
+	if target == "maestro" {
+		if targetAllowed(allow, "conductor-maestro") {
+			return "conductor-maestro"
+		}
+		if targetAllowed(allow, "maestro") {
+			return "maestro"
+		}
+		return ""
+	}
+	if targetAllowed(allow, target) {
+		return target
+	}
+	return ""
+}
+
+func targetAllowed(allow []string, target string) bool {
+	for _, a := range allow {
+		if a == target {
+			return true
+		}
+	}
+	return false
+}
+
+// firstLine returns the first non-empty line of s, trimmed and length-capped,
+// for compact plain-language display.
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		s = strings.TrimSpace(s[:idx])
+	}
+	const max = 160
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
+}

--- a/internal/web/handlers_command_center_test.go
+++ b/internal/web/handlers_command_center_test.go
@@ -1,0 +1,331 @@
+package web
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ccTestMenu builds a MenuSnapshot with a conductor session plus active and
+// noise (error/stopped) children, used across the command-center tests.
+func ccTestMenu() *MenuSnapshot {
+	return &MenuSnapshot{
+		Profile:       "personal",
+		TotalSessions: 4,
+		Items: []MenuItem{
+			{Type: MenuItemTypeSession, Session: &MenuSession{
+				ID: "cond-ad", Title: "conductor-agent-deck", IsConductor: true,
+				Status: "running", GroupPath: "agent-deck", LatestPrompt: "v1.9.67 release wave",
+			}},
+			{Type: MenuItemTypeSession, Session: &MenuSession{
+				ID: "child-1", Title: "fix-1431", Status: "running",
+				GroupPath: "agent-deck", LatestPrompt: "investigating spawn race",
+			}},
+			{Type: MenuItemTypeSession, Session: &MenuSession{
+				ID: "child-err", Title: "broken", Status: "error", GroupPath: "agent-deck",
+			}},
+			{Type: MenuItemTypeSession, Session: &MenuSession{
+				ID: "child-stop", Title: "old", Status: "stopped", GroupPath: "agent-deck",
+			}},
+		},
+	}
+}
+
+func TestCommandCenterStatusFiltersNoiseAndGroupsByConductor(t *testing.T) {
+	snap := buildCommandCenterSnapshot(ccTestMenu(), "personal", "", nil)
+
+	if len(snap.Conductors) != 1 {
+		t.Fatalf("expected 1 conductor row, got %d: %+v", len(snap.Conductors), snap.Conductors)
+	}
+	cd := snap.Conductors[0]
+	if cd.Name != "agent-deck" {
+		t.Fatalf("expected conductor name agent-deck, got %q", cd.Name)
+	}
+	if cd.Target != "conductor-agent-deck" {
+		t.Fatalf("expected target conductor-agent-deck, got %q", cd.Target)
+	}
+	if cd.Status != "running" {
+		t.Fatalf("expected conductor status running, got %q", cd.Status)
+	}
+	if cd.CurrentlyWorkingOn != "v1.9.67 release wave" {
+		t.Fatalf("expected currentlyWorkingOn from latest prompt, got %q", cd.CurrentlyWorkingOn)
+	}
+	// error + stopped children must be filtered OUT (the rejected noise).
+	if len(cd.Sessions) != 1 {
+		t.Fatalf("expected 1 active session (error/stopped filtered), got %d: %+v", len(cd.Sessions), cd.Sessions)
+	}
+	if cd.Sessions[0].ID != "child-1" {
+		t.Fatalf("expected active child-1, got %q", cd.Sessions[0].ID)
+	}
+	for _, s := range cd.Sessions {
+		if s.Status == "error" || s.Status == "stopped" {
+			t.Fatalf("noise session leaked into output: %+v", s)
+		}
+	}
+	if snap.Totals.Running != 1 {
+		t.Fatalf("expected totals.running 1, got %d", snap.Totals.Running)
+	}
+	// maestro is always an allowed ask target; the conductor session adds itself.
+	if !targetAllowed(snap.AskTargets, "maestro") {
+		t.Fatalf("expected maestro in askTargets, got %v", snap.AskTargets)
+	}
+	if !targetAllowed(snap.AskTargets, "conductor-agent-deck") {
+		t.Fatalf("expected conductor-agent-deck in askTargets, got %v", snap.AskTargets)
+	}
+}
+
+func TestCommandCenterSurfacesHonestStatusSubstate(t *testing.T) {
+	menu := ccTestMenu()
+	menu.Items[1].Session.Substate = "model-unavailable"
+	snap := buildCommandCenterSnapshot(menu, "personal", "", nil)
+	if snap.Conductors[0].Sessions[0].Substate != "model-unavailable" {
+		t.Fatalf("expected substate surfaced, got %q", snap.Conductors[0].Sessions[0].Substate)
+	}
+}
+
+func TestCommandCenterDetectsCompletions(t *testing.T) {
+	tracker := ccStatusTracker{}
+	// First pass: child-1 running, no completions, tracker seeded.
+	first := buildCommandCenterSnapshot(ccTestMenu(), "personal", "", tracker)
+	if len(first.RecentlyCompleted) != 0 {
+		t.Fatalf("expected no completions on first pass, got %+v", first.RecentlyCompleted)
+	}
+	// Second pass: child-1 transitions running -> waiting => one completion.
+	menu2 := ccTestMenu()
+	menu2.Items[1].Session.Status = "waiting"
+	second := buildCommandCenterSnapshot(menu2, "personal", "", tracker)
+	if len(second.RecentlyCompleted) != 1 {
+		t.Fatalf("expected 1 completion, got %+v", second.RecentlyCompleted)
+	}
+	if second.RecentlyCompleted[0].ID != "child-1" || second.RecentlyCompleted[0].Status != "waiting" {
+		t.Fatalf("unexpected completion: %+v", second.RecentlyCompleted[0])
+	}
+}
+
+func TestParseDecisionsWaiting(t *testing.T) {
+	dir := t.TempDir()
+	adDir := filepath.Join(dir, "agent-deck")
+	if err := os.MkdirAll(adDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "# Open Items\n\n## D. DECISIONS — waiting on Ashesh (not work, rulings)\n" +
+		"#1361 is conductor.enabled necessary? · #1358 auto-allow read-only cmds · self-heal approve\n\n" +
+		"## E. HOUSEKEEPING\nroutine\n"
+	if err := os.WriteFile(filepath.Join(adDir, "OPEN-ITEMS.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	decisions := parseDecisionsWaiting(dir)
+	if len(decisions) != 3 {
+		t.Fatalf("expected 3 decisions, got %d: %+v", len(decisions), decisions)
+	}
+	if decisions[0].ID != "#1361" {
+		t.Fatalf("expected first id #1361, got %q", decisions[0].ID)
+	}
+	if decisions[0].Route != "conductor-agent-deck" {
+		t.Fatalf("expected route conductor-agent-deck, got %q", decisions[0].Route)
+	}
+	// The non-#-prefixed item still parses with empty id.
+	if decisions[2].ID != "" || !strings.Contains(decisions[2].Question, "self-heal") {
+		t.Fatalf("unexpected third decision: %+v", decisions[2])
+	}
+}
+
+func TestParseDecisionsWaitingMultilineList(t *testing.T) {
+	dir := t.TempDir()
+	adDir := filepath.Join(dir, "agent-deck")
+	if err := os.MkdirAll(adDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Markdown-list shape (the other common form): each decision on its own
+	// line with a list marker. Subsequent items must NOT be lost, and the
+	// list marker must be stripped while the #id is preserved.
+	content := "# Open Items\n\n## D. DECISIONS — waiting on Ashesh\n" +
+		"- #1361 is conductor.enabled necessary?\n" +
+		"- #1399 docs revamp (PR)\n" +
+		"* self-heal: approve\n\n" +
+		"## E. HOUSEKEEPING\nroutine\n"
+	if err := os.WriteFile(filepath.Join(adDir, "OPEN-ITEMS.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	decisions := parseDecisionsWaiting(dir)
+	if len(decisions) != 3 {
+		t.Fatalf("expected 3 decisions from multiline list, got %d: %+v", len(decisions), decisions)
+	}
+	if decisions[0].ID != "#1361" {
+		t.Fatalf("expected #1361 with marker stripped, got %q (q=%q)", decisions[0].ID, decisions[0].Question)
+	}
+	if decisions[1].ID != "#1399" {
+		t.Fatalf("expected #1399, got %q", decisions[1].ID)
+	}
+	if strings.HasPrefix(decisions[2].Question, "*") || !strings.Contains(decisions[2].Question, "self-heal") {
+		t.Fatalf("list marker not stripped on third item: %+v", decisions[2])
+	}
+}
+
+func TestCommandCenterStatusEndpointJSON(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0"})
+	srv.menuData = &fakeMenuDataLoader{snapshot: ccTestMenu()}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/command-center/status", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var snap CommandCenterSnapshot
+	if err := json.Unmarshal(rr.Body.Bytes(), &snap); err != nil {
+		t.Fatalf("invalid snapshot json: %v", err)
+	}
+	if len(snap.Conductors) != 1 {
+		t.Fatalf("expected 1 conductor, got %d", len(snap.Conductors))
+	}
+	// Privacy: snapshot must carry no secret-shaped fields.
+	body := rr.Body.String()
+	for _, banned := range []string{"token", "Token", "apiKey", "api_key", "secret", "password", "credential"} {
+		if strings.Contains(body, banned) {
+			t.Fatalf("snapshot leaked a secret-shaped field %q: %s", banned, body)
+		}
+	}
+}
+
+func TestCommandCenterEventsUnauthorizedWhenTokenEnabled(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", Token: "secret-token"})
+	srv.menuData = &fakeMenuDataLoader{snapshot: ccTestMenu()}
+
+	req := httptest.NewRequest(http.MethodGet, "/events/command-center", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestCommandCenterEventsStreamInitialAndChange(t *testing.T) {
+	origPoll := commandCenterPollInterval
+	commandCenterPollInterval = 30 * time.Millisecond
+	defer func() { commandCenterPollInterval = origPoll }()
+	origHB := commandCenterHeartbeatInterval
+	commandCenterHeartbeatInterval = 2 * time.Second
+	defer func() { commandCenterHeartbeatInterval = origHB }()
+
+	first := ccTestMenu()
+	second := ccTestMenu()
+	second.Items[1].Session.Status = "waiting" // child-1 completes
+
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0"})
+	srv.menuData = &rotatingMenuDataLoader{snapshots: []*MenuSnapshot{first, second}}
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/events/command-center", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Fatalf("expected event-stream, got %q", ct)
+	}
+	reader := bufio.NewReader(resp.Body)
+
+	event, payload1, err := readSSEEvent(reader)
+	if err != nil {
+		t.Fatalf("read first event: %v", err)
+	}
+	if event != "command-center" {
+		t.Fatalf("expected event command-center, got %q", event)
+	}
+	if !strings.Contains(payload1, `"name":"agent-deck"`) {
+		t.Fatalf("first payload missing conductor: %s", payload1)
+	}
+
+	// Next emit should reflect the change and carry the completion.
+	_, payload2, err := readSSEEvent(reader)
+	if err != nil {
+		t.Fatalf("read second event: %v", err)
+	}
+	if !strings.Contains(payload2, `"recentlyCompleted"`) || !strings.Contains(payload2, `"child-1"`) {
+		t.Fatalf("second payload missing completion: %s", payload2)
+	}
+}
+
+func TestCommandCenterAskRejectsUnknownTarget(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", WebMutations: true})
+	srv.menuData = &fakeMenuDataLoader{snapshot: ccTestMenu()}
+
+	body := strings.NewReader(`{"target":"conductor-evil","text":"do bad things"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/command-center/ask", body)
+	req.Header.Set("Content-Type", "application/json")
+	// Same-origin so the CSRF gate (no token configured here) passes.
+	req.Header.Set("Origin", "http://"+req.Host)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown target, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "INVALID_TARGET") {
+		t.Fatalf("expected INVALID_TARGET, got: %s", rr.Body.String())
+	}
+}
+
+func TestCommandCenterAskForbiddenWhenMutationsDisabled(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", WebMutations: false})
+	srv.menuData = &fakeMenuDataLoader{snapshot: ccTestMenu()}
+
+	body := strings.NewReader(`{"target":"maestro","text":"hi"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/command-center/ask", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://"+req.Host)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 when mutations disabled, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCommandCenterAskRequiresText(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", WebMutations: true})
+	srv.menuData = &fakeMenuDataLoader{snapshot: ccTestMenu()}
+
+	body := strings.NewReader(`{"target":"maestro","text":"   "}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/command-center/ask", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://"+req.Host)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty text, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestResolveAskTarget(t *testing.T) {
+	allow := []string{"maestro", "conductor-agent-deck", "conductor-maestro"}
+	if got := resolveAskTarget("maestro", allow); got != "conductor-maestro" {
+		t.Fatalf("maestro should resolve to conductor-maestro when present, got %q", got)
+	}
+	if got := resolveAskTarget("maestro", []string{"maestro"}); got != "maestro" {
+		t.Fatalf("maestro should fall back to bare maestro, got %q", got)
+	}
+	if got := resolveAskTarget("conductor-agent-deck", allow); got != "conductor-agent-deck" {
+		t.Fatalf("explicit allowed target should resolve, got %q", got)
+	}
+	if got := resolveAskTarget("conductor-evil", allow); got != "" {
+		t.Fatalf("disallowed target should return empty, got %q", got)
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -242,6 +242,13 @@ func NewServer(cfg Config) *Server {
 	mux.HandleFunc("/events/menu", s.handleMenuEvents)
 	mux.HandleFunc("/ws/session/", s.handleSessionWS)
 
+	// Command Center (the embedded live fleet god-view — see
+	// conductor/agent-deck/COMMAND-CENTER-DESIGN.md). Two read endpoints and
+	// one write endpoint, all behind the existing authorize/CSRF/mutation gates.
+	mux.HandleFunc("/api/command-center/status", s.handleCommandCenterStatus)
+	mux.HandleFunc("/events/command-center", s.handleCommandCenterEvents)
+	mux.HandleFunc("POST /api/command-center/ask", s.handleCommandCenterAsk)
+
 	mux.HandleFunc("/api/costs/summary", s.handleCostsSummary)
 	mux.HandleFunc("/api/costs/daily", s.handleCostsDaily)
 	mux.HandleFunc("/api/costs/sessions", s.handleCostsSessions)

--- a/internal/web/session_data_service.go
+++ b/internal/web/session_data_service.go
@@ -56,19 +56,25 @@ type MenuGroup struct {
 
 // MenuSession contains metadata for a session item.
 type MenuSession struct {
-	ID              string         `json:"id"`
-	Title           string         `json:"title"`
-	Tool            string         `json:"tool"`
-	ModelID         string         `json:"modelId,omitempty"`
-	Model           string         `json:"model,omitempty"`
-	ModelVersion    string         `json:"modelVersion,omitempty"`
-	CanFork         bool           `json:"canFork"`
-	Status          session.Status `json:"status"`
-	GroupPath       string         `json:"groupPath"`
-	ProjectPath     string         `json:"projectPath"`
-	ParentSessionID string         `json:"parentSessionId,omitempty"`
-	Order           int            `json:"order"`
-	TmuxSession     string         `json:"tmuxSession,omitempty"`
+	ID           string         `json:"id"`
+	Title        string         `json:"title"`
+	Tool         string         `json:"tool"`
+	ModelID      string         `json:"modelId,omitempty"`
+	Model        string         `json:"model,omitempty"`
+	ModelVersion string         `json:"modelVersion,omitempty"`
+	CanFork      bool           `json:"canFork"`
+	Status       session.Status `json:"status"`
+	// Substate is the additive Honest-Status-v2 refinement of Status
+	// (e.g. "model-unavailable", "auth-401", "idle-at-empty-prompt"). It
+	// explains WHY a session is in its coarse status so consumers like the
+	// Command Center can surface model-unavailable/401 distinctly instead of
+	// hiding them as plain "running". Empty when there is no refinement.
+	Substate        string `json:"substate,omitempty"`
+	GroupPath       string `json:"groupPath"`
+	ProjectPath     string `json:"projectPath"`
+	ParentSessionID string `json:"parentSessionId,omitempty"`
+	Order           int    `json:"order"`
+	TmuxSession     string `json:"tmuxSession,omitempty"`
 	// TmuxSocketName is the tmux -L selector captured at session creation
 	// (Instance.TmuxSocketName). Surfaced so the web PTY bridge can reach
 	// sessions running on an isolated socket (issue #687, v1.7.50).
@@ -234,6 +240,7 @@ func toMenuSession(inst *session.Instance) *MenuSession {
 		ModelVersion:       modelInfo.Version,
 		CanFork:            inst.CanFork(),
 		Status:             inst.GetStatusThreadSafe(),
+		Substate:           string(inst.CachedSubstate()),
 		GroupPath:          inst.GroupPath,
 		ProjectPath:        inst.ProjectPath,
 		ParentSessionID:    inst.ParentSessionID,

--- a/internal/web/static/app/AppShell.js
+++ b/internal/web/static/app/AppShell.js
@@ -18,6 +18,7 @@ import { TweaksPanel } from './TweaksPanel.js'
 import { TerminalPane } from './panes/TerminalPane.js'
 import { CostsPane } from './panes/CostsPane.js'
 import { FleetPane } from './panes/FleetPane.js'
+import { CommandCenterPane } from './panes/CommandCenterPane.js'
 import { ArchivedPane } from './panes/ArchivedPane.js'
 import { StubPane } from './panes/StubPane.js'
 import { SearchPane } from './panes/SearchPane.js'
@@ -102,6 +103,7 @@ function Panes({ tab }) {
     <div style=${{ display: tab === 'terminal' ? 'flex' : 'none', flex: 1, minHeight: 0, flexDirection: 'column' }}>
       <${TerminalPane}/>
     </div>
+    ${tab === 'command-center' && html`<${CommandCenterPane}/>`}
     ${tab === 'fleet'     && html`<${FleetPane}/>`}
     ${tab === 'costs'     && html`<${CostsPane}/>`}
     ${tab === 'search'    && html`<${SearchPane}/>`}

--- a/internal/web/static/app/MobileTabs.js
+++ b/internal/web/static/app/MobileTabs.js
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { activeTabSignal } from './uiState.js'
 
 const MOBILE_TABS = [
+  { id: 'command-center', label: 'Command', icon: '★' },
   { id: 'fleet',     label: 'Fleet',    icon: '▦' },
   { id: 'terminal',  label: 'Session',  icon: '›_' },
   { id: 'watchers',  label: 'Watchers', icon: '◇' },

--- a/internal/web/static/app/Topbar.js
+++ b/internal/web/static/app/Topbar.js
@@ -7,7 +7,7 @@
 import { html } from 'htm/preact'
 import { Logo, Icon, ICONS } from './icons.js'
 import { menuModelSignal } from './dataModel.js'
-import { connectionSignal, profilesSignal } from './state.js'
+import { connectionSignal, profilesSignal, commandCenterSignal } from './state.js'
 import {
   activeTabSignal, paletteOpenSignal, tweaksOpenSignal,
   railSignal, profileSignal,
@@ -15,6 +15,7 @@ import {
 import { ToastHistoryDrawerToggle } from './ToastHistoryDrawer.js'
 
 const TABS = [
+  { id: 'command-center', label: 'Command Center' },
   { id: 'fleet',     label: 'Fleet'     },
   { id: 'terminal',  label: 'Terminal'  },
   { id: 'mcp',       label: 'MCPs'      },
@@ -33,6 +34,8 @@ export function Topbar() {
   const { sessions } = menuModelSignal.value
   const sessionsBadge = sessions.filter(s => s.status === 'waiting' || s.status === 'error').length
   const pendingNeeds = sessions.reduce((n, s) => n + (s.pendingNeeds || 0), 0)
+  const cc = commandCenterSignal.value
+  const decisionsBadge = cc && Array.isArray(cc.decisionsWaiting) ? cc.decisionsWaiting.length : 0
 
   const connClass = conn === 'connected' ? '' : 'off'
   const connDotStyle = conn === 'connected'
@@ -59,6 +62,7 @@ export function Topbar() {
               ${t.label}
               ${t.id === 'conductor' && pendingNeeds > 0 && html`<span class="badge">${pendingNeeds}</span>`}
               ${t.id === 'fleet' && sessionsBadge > 0 && html`<span class="badge">${sessionsBadge}</span>`}
+              ${t.id === 'command-center' && decisionsBadge > 0 && html`<span class="badge">${decisionsBadge}</span>`}
             </button>
           `)}
         </div>

--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -942,7 +942,7 @@ body[data-rail="hidden"] .rightrail { display: none; }
 
   /* mobile bottom tabs */
   .mob-tabs {
-    display: grid; grid-template-columns: repeat(4, 1fr);
+    display: grid; grid-template-columns: repeat(5, 1fr);
     grid-area: foot;
     background: var(--panel);
     border-top: 1px solid var(--border);
@@ -1110,3 +1110,11 @@ body[data-rail="hidden"] .rightrail { display: none; }
 .cc-st { font-size: 11px; flex: none; color: var(--muted); min-width: 120px; }
 .cc-st.ok { color: var(--tn-green); }
 .cc-st.err { color: var(--tn-red); }
+
+/* Command Center on phone: lift the fixed input bar above the bottom mob-tabs
+   (56px) so they don't overlap, and give the scroll area room for both. */
+@media (max-width: 720px) {
+  .cc-input { bottom: 56px; }
+  .cc { padding-bottom: 150px; }
+  .cc-input select { max-width: 120px; }
+}

--- a/internal/web/static/app/app.css
+++ b/internal/web/static/app/app.css
@@ -1023,3 +1023,90 @@ body[data-rail="hidden"] .rightrail { display: none; }
   margin-top: 8px; padding-top: 10px; border-top: 1px solid var(--border);
   font-family: var(--mono); font-size: 11px; color: var(--muted);
 }
+
+/* ── Command Center (the embedded live fleet god-view) ───────────────────── */
+.cc {
+  display: flex; flex-direction: column; min-height: 0; flex: 1;
+  padding: 18px 20px 92px; overflow-y: auto;
+}
+.cc-top { display: flex; align-items: baseline; gap: 12px; margin-bottom: 14px; }
+.cc-top h1 { font-size: 18px; margin: 0; color: var(--text-hi); }
+.cc-live { font-size: 11.5px; color: var(--tn-green); }
+.cc-live.stale { color: var(--tn-yellow); }
+.cc-totals { font-size: 11.5px; color: var(--muted); margin-left: auto; font-family: var(--mono); }
+.cc-empty { color: var(--muted); font-size: 13px; padding: 24px 0; }
+.cc h2 {
+  font-size: 10.5px; text-transform: uppercase; letter-spacing: 1.2px;
+  color: var(--muted-2); margin: 4px 0 8px; font-weight: 700;
+}
+.cc-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; align-items: start; }
+@media (max-width: 760px) { .cc-cols { grid-template-columns: 1fr; } }
+.cc-col { min-width: 0; }
+
+/* decisions */
+.cc-ask {
+  display: flex; align-items: center; gap: 8px;
+  background: var(--card); border: 1px solid var(--border);
+  border-radius: 9px; padding: 7px 10px; margin-bottom: 6px;
+}
+.cc-ask-id { color: var(--tn-yellow); font-weight: 700; flex: none; font-family: var(--mono); font-size: 11.5px; }
+.cc-ask-text { flex: 1; min-width: 0; font-size: 12.5px; color: var(--text); }
+.cc-cmt {
+  flex: none; cursor: pointer; color: var(--muted); font-size: 13px;
+  border: 0; background: none; padding: 2px 4px;
+}
+.cc-cmt:hover { color: var(--accent); }
+
+/* conductor rows */
+.cc-cd {
+  border: 1px solid var(--border); border-radius: 9px;
+  margin-bottom: 6px; background: var(--panel); overflow: hidden;
+}
+.cc-cd.open { border-color: var(--border-hi, var(--border)); }
+.cc-cd-head {
+  width: 100%; display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px; background: none; border: 0; cursor: pointer;
+  color: var(--text); font: inherit; text-align: left;
+}
+.cc-cd-head:hover { background: var(--card); }
+.cc-dot { flex: none; }
+.cc-nm { font-weight: 600; flex: none; width: 96px; color: var(--text-hi); }
+.cc-ac {
+  color: var(--muted); font-size: 11.5px; flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cc-lc { flex: none; font-size: 10.5px; color: var(--muted-2); font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.cc-cd-body { padding: 6px 12px 10px 30px; border-top: 1px solid var(--border); }
+.cc-srow { display: flex; gap: 7px; align-items: center; font-size: 11.5px; color: var(--text-dim); padding: 2px 0; }
+.cc-sd { flex: none; font-size: 9px; }
+.cc-stt { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
+.cc-sub {
+  flex: none; font-size: 10px; color: var(--tn-red);
+  border: 1px solid var(--tn-red); border-radius: 5px; padding: 0 5px;
+  font-family: var(--mono);
+}
+.cc-sdone { font-size: 11px; color: var(--muted-2); padding: 3px 0; }
+
+/* two-way input bar */
+.cc-input {
+  position: fixed; left: 0; right: 0; bottom: 0;
+  background: var(--panel); border-top: 1px solid var(--border);
+  padding: 9px 16px; display: flex; gap: 9px; align-items: center; z-index: 5;
+}
+.cc-input select {
+  background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
+  color: var(--text); font: inherit; font-size: 12px; padding: 7px 8px; flex: none; max-width: 200px;
+}
+.cc-input textarea {
+  flex: 1; background: var(--bg); border: 1px solid var(--border); border-radius: 9px;
+  color: var(--text); font: inherit; font-size: 13px; padding: 8px 11px; resize: none; height: 38px;
+}
+.cc-input textarea:focus { outline: none; border-color: var(--accent); height: 56px; }
+.cc-send {
+  font: inherit; font-weight: 600; color: var(--bg); background: var(--accent);
+  border: 0; padding: 8px 15px; border-radius: 9px; cursor: pointer; flex: none;
+}
+.cc-send:disabled { opacity: .5; cursor: default; }
+.cc-st { font-size: 11px; flex: none; color: var(--muted); min-width: 120px; }
+.cc-st.ok { color: var(--tn-green); }
+.cc-st.err { color: var(--tn-red); }

--- a/internal/web/static/app/main.js
+++ b/internal/web/static/app/main.js
@@ -9,7 +9,9 @@ import {
   selectedIdSignal,
   connectionSignal,
   authTokenSignal,
+  commandCenterSignal,
 } from './state.js'
+import { addToast } from './Toast.js'
 
 // ---------- Auth token extraction ----------
 
@@ -79,6 +81,60 @@ export function stopSSE() {
     _menuSource.close()
     _menuSource = null
   }
+  if (_ccSource) {
+    _ccSource.close()
+    _ccSource = null
+  }
+}
+
+// ---------- Command Center SSE ----------
+// A second stream alongside the menu SSE, carrying the synthesized cross-
+// project god-view snapshot. Live by construction (fingerprint-diffed
+// server-side), so the panel never polls. recentlyCompleted entries drive
+// "✅ X just finished" notifications.
+
+let _ccSource = null
+// Track which completion ids we've already toasted so a steady-state re-emit
+// of the same snapshot (or a reconnect) doesn't re-fire notifications.
+const _ccSeenCompletions = new Set()
+
+export function startCommandCenterSSE() {
+  if (_ccSource) return
+
+  const token = authTokenSignal.value
+  const url = token
+    ? '/events/command-center?token=' + encodeURIComponent(token)
+    : '/events/command-center'
+
+  const source = new EventSource(url)
+  _ccSource = source
+
+  // CRITICAL: the Go server emits this event with type "command-center"
+  // (handlers_command_center.go: writeSSEEvent(w, flusher, "command-center", snapshot)).
+  source.addEventListener('command-center', (event) => {
+    try {
+      const snapshot = JSON.parse(event.data)
+      if (snapshot && typeof snapshot === 'object') {
+        commandCenterSignal.value = snapshot
+        const done = Array.isArray(snapshot.recentlyCompleted) ? snapshot.recentlyCompleted : []
+        for (const c of done) {
+          const key = (c && (c.id || '')) + ':' + (c && (c.at || ''))
+          if (_ccSeenCompletions.has(key)) continue
+          _ccSeenCompletions.add(key)
+          if (c && c.title) addToast(`✅ ${c.title} just finished`, 'success')
+        }
+        // Bound the seen-set so it can't grow unbounded over a long session.
+        if (_ccSeenCompletions.size > 200) {
+          _ccSeenCompletions.clear()
+        }
+      }
+    } catch (_) {
+      // malformed JSON; ignore
+    }
+  })
+
+  // The command-center stream shares the connection-state signal via the menu
+  // stream; we don't flip it here to avoid fighting the menu reconnect logic.
 }
 
 // ---------- Initial menu load + SSE kick-off ----------
@@ -92,10 +148,12 @@ export async function loadMenu() {
     // we're offline.
     sessionsLoadedSignal.value = true
     startSSE()
+    startCommandCenterSSE()
   } catch (_) {
     connectionSignal.value = 'disconnected'
     // Still start SSE so it can reconnect when server comes back
     startSSE()
+    startCommandCenterSSE()
   }
 }
 

--- a/internal/web/static/app/panes/CommandCenterPane.js
+++ b/internal/web/static/app/panes/CommandCenterPane.js
@@ -1,0 +1,200 @@
+// panes/CommandCenterPane.js -- The Command Center: a live, two-way fleet
+// god-view embedded in the agent-deck web UI (see
+// conductor/agent-deck/COMMAND-CENTER-DESIGN.md). v1 productizes the hand-made
+// status HTMLs:
+//   - LIVE via the /events/command-center SSE feed (no polling) — conductor
+//     lights + session lists update instantly.
+//   - SEE-EVERYTHING: per-conductor status + active session lists (error/
+//     stopped filtered OUT, the noise the user rejected), each showing what
+//     it's working on. Honest-status v2 substates surfaced distinctly.
+//   - DECISIONS WAITING ON YOU parsed from OPEN-ITEMS.md §D, with 💬 prefill.
+//   - COMPLETION NOTIFICATIONS fire as toasts (wired in main.js).
+//   - TWO-WAY input box routing to Maestro / a chosen conductor via the
+//     supported `session send` primitive (POST /api/command-center/ask).
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import { commandCenterSignal, connectionSignal, mutationsEnabledSignal } from '../state.js'
+import { apiFetch } from '../api.js'
+import { addToast } from '../Toast.js'
+
+const STATUS_DOT = {
+  running: '🟢',
+  waiting: '🟡',
+  idle: '⚪',
+  error: '🔴',
+  stopped: '⚫',
+  absent: '⚫',
+}
+
+// Honest-status v2: surface model-unavailable / auth-401 distinctly rather than
+// hiding them as plain "running".
+const SUBSTATE_LABEL = {
+  'model-unavailable': 'model unavailable',
+  'auth-401': 'auth error (401)',
+  'idle-at-empty-prompt': 'idle (empty prompt)',
+}
+
+function dotFor(name, status) {
+  if (name === 'maestro' && status === 'running') return '🔵'
+  return STATUS_DOT[status] || '⚪'
+}
+
+function liveCounts(counts) {
+  if (!counts) return ''
+  const order = ['running', 'waiting', 'idle']
+  return order.filter(k => counts[k]).map(k => `${counts[k]} ${k}`).join(' · ')
+}
+
+function DecisionCard({ decision, onComment }) {
+  return html`
+    <div class="cc-ask">
+      ${decision.id && html`<span class="cc-ask-id">${decision.id}</span>`}
+      <span class="cc-ask-text">${decision.question}</span>
+      <button class="cc-cmt" title="Comment / answer this"
+        onClick=${() => onComment(decision)}>💬</button>
+    </div>
+  `
+}
+
+function SessionRow({ sess }) {
+  const sub = sess.substate && SUBSTATE_LABEL[sess.substate]
+  return html`
+    <div class="cc-srow" data-testid="cc-session" data-status=${sess.status}>
+      <span class="cc-sd">${STATUS_DOT[sess.status] || '⚪'}</span>
+      <span class="cc-stt" title=${sess.workingOn || sess.title}>${sess.title}</span>
+      ${sub && html`<span class="cc-sub" title=${'honest-status: ' + sess.substate}>${sub}</span>`}
+    </div>
+  `
+}
+
+function ConductorRow({ cd }) {
+  const [open, setOpen] = useState(false)
+  const sub = cd.substate && SUBSTATE_LABEL[cd.substate]
+  return html`
+    <div class=${`cc-cd ${open ? 'open' : ''}`} data-testid="cc-conductor" data-name=${cd.name}>
+      <button class="cc-cd-head" onClick=${() => setOpen(o => !o)}>
+        <span class="cc-dot">${dotFor(cd.name, cd.status)}</span>
+        <span class="cc-nm">${cd.name}</span>
+        <span class="cc-ac" title=${cd.currentlyWorkingOn || ''}>
+          ${cd.currentlyWorkingOn || (cd.status === 'absent' ? 'no conductor session' : cd.status)}
+          ${sub && html` · ${sub}`}
+        </span>
+        <span class="cc-lc">${liveCounts(cd.counts)}</span>
+      </button>
+      ${open && html`
+        <div class="cc-cd-body">
+          ${cd.sessions && cd.sessions.length
+            ? cd.sessions.map(s => html`<${SessionRow} key=${s.id} sess=${s}/>`)
+            : html`<div class="cc-sdone">no active sessions</div>`}
+        </div>
+      `}
+    </div>
+  `
+}
+
+export function CommandCenterPane() {
+  const snap = commandCenterSignal.value
+  const conn = connectionSignal.value
+  const canMutate = mutationsEnabledSignal.value
+  const [text, setText] = useState('')
+  const [target, setTarget] = useState('maestro')
+  const [sending, setSending] = useState(false)
+  const [status, setStatus] = useState('ready')
+
+  const onComment = (decision) => {
+    const label = decision.id || decision.question.slice(0, 24)
+    setText(`re ${label}: `)
+    document.querySelector('.cc-input textarea')?.focus()
+  }
+
+  const send = async () => {
+    const msg = text.trim()
+    if (!msg || sending) return
+    if (!canMutate) {
+      addToast('Two-way input is disabled (web mutations off)', 'info')
+      return
+    }
+    setSending(true); setStatus('sending…')
+    try {
+      const resp = await apiFetch('POST', '/api/command-center/ask', { target, text: msg })
+      setStatus(`✓ routed to ${resp.routedTo || target}`)
+      setText('')
+    } catch (e) {
+      setStatus('✗ ' + (e.message || 'send failed'))
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const onKey = (e) => {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault()
+      send()
+    }
+  }
+
+  const targets = (snap && Array.isArray(snap.askTargets) ? snap.askTargets : ['maestro'])
+
+  if (!snap) {
+    return html`
+      <div class="cc" data-testid="command-center-pane">
+        <div class="cc-top">
+          <h1>Command Center</h1>
+          <span class=${`cc-live ${conn === 'connected' ? '' : 'stale'}`}>
+            ${conn === 'connected' ? '● connecting…' : '● offline'}
+          </span>
+        </div>
+        <div class="cc-empty" data-testid="cc-loading">Waiting for the first fleet snapshot…</div>
+      </div>
+    `
+  }
+
+  const decisions = Array.isArray(snap.decisionsWaiting) ? snap.decisionsWaiting : []
+  const conductors = Array.isArray(snap.conductors) ? snap.conductors : []
+  const totals = snap.totals || {}
+
+  return html`
+    <div class="cc" data-testid="command-center-pane">
+      <div class="cc-top">
+        <h1>Command Center</h1>
+        <span class=${`cc-live ${conn === 'connected' ? '' : 'stale'}`} data-testid="cc-live">
+          ${conn === 'connected' ? '● live' : '● offline'}
+        </span>
+        <span class="cc-totals" data-testid="cc-totals">
+          ${totals.running || 0} running · ${totals.waiting || 0} waiting · ${totals.idle || 0} idle
+        </span>
+      </div>
+
+      <div class="cc-cols">
+        <div class="cc-col">
+          <h2>👉 Needs you</h2>
+          ${decisions.length
+            ? decisions.map((d, i) => html`<${DecisionCard} key=${d.id || i} decision=${d} onComment=${onComment}/>`)
+            : html`<div class="cc-sdone" data-testid="cc-no-decisions">nothing waiting on you 🎉</div>`}
+        </div>
+
+        <div class="cc-col">
+          <h2>🛰️ The fleet — what each is doing</h2>
+          ${conductors.length
+            ? conductors.map(cd => html`<${ConductorRow} key=${cd.name} cd=${cd}/>`)
+            : html`<div class="cc-sdone" data-testid="cc-no-conductors">no conductors detected</div>`}
+        </div>
+      </div>
+
+      <div class="cc-input" data-testid="cc-input">
+        <select value=${target} onChange=${e => setTarget(e.target.value)} title="Route to" data-testid="cc-target">
+          ${targets.map(t => html`<option key=${t} value=${t === 'conductor-maestro' ? 'maestro' : t}>
+            ${t === 'conductor-maestro' || t === 'maestro' ? 'Maestro (default)' : t}
+          </option>`)}
+        </select>
+        <textarea
+          placeholder="answer a decision, comment, or instruct… ⌘/Ctrl+Enter to send"
+          value=${text}
+          onInput=${e => setText(e.target.value)}
+          onKeyDown=${onKey}></textarea>
+        <button class="cc-send" disabled=${!text.trim() || sending} onClick=${send} data-testid="cc-send">➤ Send</button>
+        <span class=${`cc-st ${status.startsWith('✓') ? 'ok' : status.startsWith('✗') ? 'err' : ''}`} data-testid="cc-status">${status}</span>
+      </div>
+    </div>
+  `
+}

--- a/internal/web/static/app/state.js
+++ b/internal/web/static/app/state.js
@@ -174,6 +174,13 @@ export const profilesSignal = signal(null)
 // the first poll lands; consumers handle the null case.
 export const systemStatsSignal = signal(null)
 
+// Command Center snapshot from the /events/command-center SSE feed (the
+// embedded live fleet god-view — see COMMAND-CENTER-DESIGN.md). Shape:
+// { profile, generatedAt, conductors[], totals, decisionsWaiting[],
+//   recentlyCompleted[], askTargets[] }. Defaults to null until the first
+// SSE snapshot lands; the pane handles the null case with a skeleton.
+export const commandCenterSignal = signal(null)
+
 export async function loadArchivedSessions() {
   try {
     const data = await apiFetch('GET', '/api/sessions/archived')

--- a/tests/web/e2e/command-center.spec.js
+++ b/tests/web/e2e/command-center.spec.js
@@ -1,0 +1,103 @@
+// e2e/command-center.spec.js -- Command Center pane end-to-end coverage.
+//
+// The Command Center (internal/web/static/app/panes/CommandCenterPane.js) is the
+// embedded, live, two-way fleet god-view. It renders the synthesized snapshot
+// from GET /events/command-center (SSE), groups sessions per conductor, filters
+// OUT error/stopped sessions (the noise the user explicitly rejected), surfaces
+// honest-status substates, and routes typed instructions via POST
+// /api/command-center/ask. See conductor/agent-deck/COMMAND-CENTER-DESIGN.md.
+//
+// Grounded in the fixture seed (tests/web/fixtures/cmd/web-fixture/main.go):
+//   sess-001 "agent-deck"     status=idle    group=work           (IsConductor)
+//   sess-002 "frontend"       status=running group=work
+//   sess-003 "innotrade-api"  status=idle    group=work/innotrade
+//   sess-004 "scratch"        status=idle    group=personal
+// → active CHILD totals at cold load (the conductor row itself is excluded from
+//   the per-child tally): running=1 (sess-002), waiting=0, idle=2 (sess-003/004).
+import { test, expect } from '@playwright/test'
+
+async function openCommandCenter(page) {
+  await page.goto('/')
+  // Click the first tab ("Command Center").
+  await page.locator('.top-tab', { hasText: 'Command Center' }).click()
+  await expect(page.locator('[data-testid="command-center-pane"]')).toBeVisible({ timeout: 5000 })
+}
+
+test.describe('command center pane', () => {
+  test.beforeEach(async ({ request }) => {
+    await request.post('/__fixture/reset')
+  })
+
+  test('renders live with totals derived from the fixture seed', async ({ page }) => {
+    await openCommandCenter(page)
+    // The live indicator and totals hydrate from the first SSE snapshot.
+    await expect(page.locator('[data-testid="cc-live"]')).toContainText('live', { timeout: 5000 })
+    // Seed (child sessions only; the conductor row is tallied separately):
+    // sess-002 running; sess-003/004 idle; nothing waiting. toContainText
+    // retries through the initial empty render before the SSE snapshot lands.
+    await expect(page.locator('[data-testid="cc-totals"]')).toContainText('1 running', { timeout: 5000 })
+    await expect(page.locator('[data-testid="cc-totals"]')).toContainText('0 waiting')
+    await expect(page.locator('[data-testid="cc-totals"]')).toContainText('2 idle')
+  })
+
+  test('shows conductor rows and the two-way input bar', async ({ page }) => {
+    await openCommandCenter(page)
+    // At least one conductor row renders (groups: work, work/innotrade, personal).
+    await expect(page.locator('[data-testid="cc-conductor"]').first()).toBeVisible({ timeout: 5000 })
+    // The two-way input bar and target picker are present.
+    await expect(page.locator('[data-testid="cc-input"]')).toBeVisible()
+    await expect(page.locator('[data-testid="cc-target"]')).toBeVisible()
+    // Maestro is the default routing target.
+    await expect(page.locator('[data-testid="cc-target"]')).toContainText('Maestro')
+  })
+
+  test('updates live via SSE without a reload', async ({ page, request }) => {
+    await openCommandCenter(page)
+    await expect(page.locator('[data-testid="cc-totals"]')).toContainText('1 running', { timeout: 5000 })
+
+    // Drive a TUI-side transition: sess-002 running -> waiting. This must flow
+    // through /events/command-center and re-render the panel WITHOUT a reload.
+    await request.post('/__fixture/session/sess-002/status?to=waiting')
+
+    await expect(page.locator('[data-testid="cc-totals"]')).toContainText('0 running', { timeout: 6000 })
+    await expect(page.locator('[data-testid="cc-totals"]')).toContainText('1 waiting')
+    // We never called page.goto/reload — the SSE feed alone drove the change.
+  })
+
+  test('filters OUT error/stopped sessions (the rejected noise)', async ({ page, request }) => {
+    await openCommandCenter(page)
+    await expect(page.locator('[data-testid="command-center-pane"]')).toBeVisible({ timeout: 5000 })
+
+    // Force sess-002 to error. It must NOT appear in any conductor's session
+    // list — error is filtered by construction.
+    await request.post('/__fixture/session/sess-002/status?to=error')
+
+    // Give the SSE feed a moment to push the change.
+    await expect(page.locator('[data-testid="cc-totals"]')).toContainText('0 running', { timeout: 6000 })
+
+    // Expand every conductor row, then assert no rendered session row is error/stopped.
+    const heads = page.locator('.cc-cd-head')
+    const n = await heads.count()
+    for (let i = 0; i < n; i++) await heads.nth(i).click()
+
+    const errorRows = page.locator('[data-testid="cc-session"][data-status="error"]')
+    const stoppedRows = page.locator('[data-testid="cc-session"][data-status="stopped"]')
+    await expect(errorRows).toHaveCount(0)
+    await expect(stoppedRows).toHaveCount(0)
+  })
+
+  test('typing routes through the ask endpoint and reflects status', async ({ page }) => {
+    await openCommandCenter(page)
+    await expect(page.locator('[data-testid="cc-input"]')).toBeVisible({ timeout: 5000 })
+
+    await page.locator('[data-testid="cc-input"] textarea').fill('approve #1361 — keep conductor.enabled')
+    await page.locator('[data-testid="cc-send"]').click()
+
+    // The status line reflects the routing outcome. In the fixture there is no
+    // live agent behind the target, so the supported `session send` path can't
+    // deliver and the handler returns an honest error — the point is that the
+    // request went through the /ask endpoint and the UI reflected a result,
+    // not a silent no-op. Either ✓ routed or ✗ deliver is a valid reflection.
+    await expect(page.locator('[data-testid="cc-status"]')).not.toHaveText('ready', { timeout: 6000 })
+  })
+})

--- a/tests/web/e2e/command-center.spec.js
+++ b/tests/web/e2e/command-center.spec.js
@@ -18,8 +18,15 @@ import { test, expect } from '@playwright/test'
 
 async function openCommandCenter(page) {
   await page.goto('/')
-  // Click the first tab ("Command Center").
-  await page.locator('.top-tab', { hasText: 'Command Center' }).click()
+  // The top tab strip is hidden on phone-class viewports (≤720px), which use
+  // the bottom MobileTabs bar instead. Click whichever control is visible so
+  // the flagship view is reachable on every viewport.
+  const viewport = page.viewportSize()
+  if (viewport && viewport.width < 768) {
+    await page.locator('[data-testid="mobile-tab-command-center"]').click()
+  } else {
+    await page.locator('.top-tab', { hasText: 'Command Center' }).click()
+  }
   await expect(page.locator('[data-testid="command-center-pane"]')).toBeVisible({ timeout: 5000 })
 }
 

--- a/tests/web/e2e/mobile.spec.js
+++ b/tests/web/e2e/mobile.spec.js
@@ -44,11 +44,12 @@ test.describe('mobile phone layout', () => {
     await waitForPhoneMount(page)
   })
 
-  test('bottom tab bar is visible with the Fleet/Session/Watchers/Costs set', async ({ page }) => {
+  test('bottom tab bar is visible with the Command/Fleet/Session/Watchers/Costs set', async ({ page }) => {
     const bar = page.locator('[data-testid="mobile-tabs"]')
     await expect(bar).toBeVisible()
     // Exact tab set + labels from MOBILE_TABS in MobileTabs.js.
-    await expect(bar.locator('.mob-tab')).toHaveCount(4)
+    await expect(bar.locator('.mob-tab')).toHaveCount(5)
+    await expect(page.locator('[data-testid="mobile-tab-command-center"]')).toContainText('Command')
     await expect(page.locator('[data-testid="mobile-tab-fleet"]')).toContainText('Fleet')
     await expect(page.locator('[data-testid="mobile-tab-terminal"]')).toContainText('Session')
     await expect(page.locator('[data-testid="mobile-tab-watchers"]')).toContainText('Watchers')


### PR DESCRIPTION
## Summary

Adds the **Command Center**: an embedded, live, two-way fleet status panel as a new first tab in the agent-deck web UI. It composes the existing web-server plumbing (SSE feed, WebMutator security model, profile model, the supported `session send` inbound path) — no new server, no new daemon, no new auth surface.

## What it does (v1)

- **Live, no polling.** A new `GET /events/command-center` SSE stream (fingerprint-diffed + heartbeat, subscribed to the same menu change channel as `/events/menu`) pushes a synthesized cross-project snapshot the instant fleet state changes. The panel re-renders off a signal — no reload.
- **Completion notifications.** The stream diffs each session's status between snapshots server-side; a `running → done/waiting` transition fires a "✅ X just finished" toast (de-duplicated).
- **See-everything, noise filtered.** Per-conductor rows show health + active child sessions and what each is working on. **Error/stopped sessions are filtered out** by construction. Honest-status v2 substates (`model-unavailable` / `auth-401`) are surfaced distinctly instead of hidden as "running".
- **Decisions waiting on you.** Parsed live from the agent-deck conductor's open-items list, each with a 💬 comment affordance that prefills the input.
- **Two-way input.** An input box (with a Maestro / conductor target picker) POSTs to `POST /api/command-center/ask`, which delivers via the supported `session send` path (`--no-wait -p <profile>`, text passed as a single argv element, target validated against a server-authoritative allowlist, every ask journaled by correlation id + target + text-hash). Replies reflect back through the SSE feed.

## Endpoints (`internal/web/handlers_command_center.go`)

| Endpoint | Method | Purpose |
|---|---|---|
| `/api/command-center/status` | GET | One-shot synthesized snapshot |
| `/events/command-center` | GET (SSE) | Live push, fingerprint-diffed |
| `/api/command-center/ask` | POST | Two-way input via `session send` (mutation-gated, CSRF fail-closed, target-allowlisted) |

Also adds a `substate` field to `MenuSession` (populated from `CachedSubstate`).

## Frontend (`internal/web/static/app/`)

`panes/CommandCenterPane.js` + a Topbar tab with a decisions-waiting badge; `main.js` SSE subscription + completion toasts; `state.js` signal; `app.css` styles (reuse the existing design tokens).

## Privacy

Inherits the web server's loopback-default / token / CSRF / mutation gates. No secret-shaped field is ever in the payload (asserted in tests) — only which conductor/account, never the credential.

## Tests

- **Go** (`internal/web/handlers_command_center_test.go`): synthesis (grouping, error/stopped filtering, substate surfacing, completion diff), open-items section-D parsing (single-line **and** multi-line list), status endpoint, SSE initial+change, `/ask` target allowlist + mutation gate + empty-text rejection, target resolution.
- **Playwright** (`tests/web/e2e/command-center.spec.js`, the web-UI TDD gate): live render, conductor rows + input bar, **live SSE update without reload**, **error/stopped filtering**, two-way input routing.

Verified visually with a headless browser against a sandbox `agent-deck web`: live SSE update, filtering, the completion toast, and input routing all confirmed.

## Docs

`docs/COMMAND-CENTER.md` documents v1 plus the v2 increment plan (connected per-project detail pages, comment-on-anything with context, correlated reply read-back, keyboard nav, compact layout, the structured `status.json` contract). v3 (knowledge-graph-backed) stays gated behind a stable `StatusSource` seam.

## Review

Dual-reviewed; addressed all findings: bounded the `session send` child with a context timeout, made the open-items parser handle multi-line Markdown lists, guarded the SSE loop against a closed subscription channel, and made the completion tracker prune vanished session ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)