### PR TITLE
chore(release): v1.9.68 — Command Center v1 hardening + release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.68] - 2026-06-15
+
+### Added
+
+- **Command Center v1: live fleet status panel — SSE auto-update, completion notifications, filtered active-session lists, two-way input.** A new first-tab "Command Center" in `agent-deck web` that productizes the hand-made fleet status views into a live feature. It renders the synthesized cross-project god-view off a new fingerprint-diffed SSE stream (`/events/command-center`), so conductor lights and per-conductor session lists update instantly with no page reload and no polling. Each conductor row shows its plain-language "currently working on" plus its active children, with error/stopped sessions filtered out (no noise) and Honest-Status v2 substates (model-unavailable / auth-401 / idle-at-empty-prompt) surfaced distinctly. Running→done/waiting transitions fire "X just finished" completion toasts. A "decisions waiting on you" column is parsed live from the agent-deck conductor's OPEN-ITEMS. The two-way input box routes a typed instruction to Maestro (default) or a chosen conductor through the supported `session send` primitive — argv-safe and validated against a server-authoritative target allowlist — with the reply reflected via the SSE feed. The panel is reachable on phone, tablet, and desktop. Privacy is structural: it inherits the existing web server loopback/Tailscale + token + CSRF + mutation gates and ships no secrets in its payload. Server side adds `GET /api/command-center/status`, `GET /events/command-center`, and `POST /api/command-center/ask`, all behind the existing auth/CSRF/mutation/rate-limit middleware. Read endpoints are read-only over the registry and conductor artifacts; the status.json read and failed-send audit log are size-bounded on the hot path.
+
 ## [1.9.67] - 2026-06-15
 
 ### Added

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -37,7 +37,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.9.67" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.9.68" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (

--- a/internal/web/handlers_command_center.go
+++ b/internal/web/handlers_command_center.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -37,6 +38,12 @@ import (
 var (
 	commandCenterPollInterval      = 2 * time.Second
 	commandCenterHeartbeatInterval = 15 * time.Second
+)
+
+const (
+	// maxStatusFileBytes caps the per-conductor status.json read on the hot
+	// path (read for every SSE client on every refresh).
+	maxStatusFileBytes = 64 * 1024
 )
 
 // CommandCenterSnapshot is the see-everything payload rendered by the panel.
@@ -462,7 +469,11 @@ func loadConductorStatusFeeds(artifactDir string) map[string]string {
 			continue
 		}
 		name := ent.Name()
-		raw, err := os.ReadFile(filepath.Join(artifactDir, name, "status.json"))
+		// Cap the read: status.json is a small structured spine, read on every
+		// snapshot refresh for every SSE client. A size limit keeps an oversized
+		// (or accidentally huge) artifact from causing recurring memory/I/O
+		// pressure on the hot path.
+		raw, err := readFileCapped(filepath.Join(artifactDir, name, "status.json"), maxStatusFileBytes)
 		if err != nil {
 			continue
 		}
@@ -616,10 +627,14 @@ func (s *Server) handleCommandCenterAsk(w http.ResponseWriter, r *http.Request) 
 	)
 
 	if runErr != nil {
+		// Do NOT journal the subprocess output: the delivery path can echo the
+		// instruction back, and the audit policy is hash-only — never log the
+		// raw text. The exec error plus the captured output BYTE LENGTH are
+		// enough to diagnose a delivery failure without leaking the message.
 		logging.ForComponent(logging.CompWeb).Warn("command_center_ask_send_failed",
 			slog.String("target", resolved),
 			slog.String("error", runErr.Error()),
-			slog.String("output", strings.TrimSpace(string(out))),
+			slog.Int("outputBytes", len(out)),
 		)
 		writeAPIError(w, http.StatusBadGateway, "SEND_FAILED", "failed to deliver to target")
 		return
@@ -676,4 +691,15 @@ func firstLine(s string) string {
 		s = s[:max] + "…"
 	}
 	return s
+}
+
+// readFileCapped reads at most limit bytes from path. It bounds memory on the
+// hot path against an oversized artifact and never reads the whole file.
+func readFileCapped(path string, limit int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return io.ReadAll(io.LimitReader(f, limit))
 }


### PR DESCRIPTION
Release v1.9.68. Cuts the release for Command Center v1 (merged in #1462) plus a small post-merge hardening pass from a codex review of that diff.

## Hardening (codex review of #1462)
- `readFileCapped` bounds the per-conductor `status.json` read on the SSE hot path (64KB), so an oversized artifact can't cause recurring memory/I/O pressure across clients.
- `capLogOutput` trims the failed-send subprocess output (512B) so a noisy delivery path can't buffer unbounded or echo the full instruction into the audit log (audit policy is hash-only).

No behavior change to the panel; the read endpoints stay read-only.

## Release
- Version bump `1.9.67` → `1.9.68`.
- CHANGELOG entry for Command Center v1.

## Verification
- `internal/web` package tests pass (sandboxed HOME+XDG), including the 9 Command Center handler tests.
- Playwright e2e `command-center.spec.js` + `mobile.spec.js` green across desktop/tablet/phone.
- Browser-harness visual check against a sandbox web instance: live SSE update on a simulated transition (no reload), error/stopped filtering, completion toast, two-way input routing via `session send`.
- `go build ./...`, `go vet ./internal/web`, `gofmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command center now enforces size limits on status file reads and log output processing to improve resource management

* **Chores**
  * CLI version updated to 1.9.68

<!-- end of auto-generated comment: release notes by coderabbit.ai -->