### PR TITLE
fix(launch): detect cursor readiness during tmux starting window

### DIFF
--- a/cmd/agent-deck/issue957_send_timeout_test.go
+++ b/cmd/agent-deck/issue957_send_timeout_test.go
@@ -5,10 +5,12 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/send"
 )
 
 // neverReadyChecker simulates a busy agent that never reaches "waiting"/"idle".
-// GetStatus always returns "active" (the loading state), so waitForAgentReady
+// GetStatus always returns "active" (the loading state), so WaitForAgentReady
 // can never satisfy its readiness predicate and must hit the timeout.
 type neverReadyChecker struct {
 	calls atomic.Int64
@@ -26,39 +28,28 @@ func (m *neverReadyChecker) CapturePaneFresh() (string, error) {
 // TestSessionSend_RespectsTimeoutFlag_RegressionFor957 is the regression test
 // for issue #957: `session send --timeout <duration>` must bound the
 // agent-ready wait, not just the post-ready completion wait.
-//
-// Before the fix, waitForAgentReady ignored its caller's timeout and used a
-// hardcoded 80s (400 attempts × 200ms). With a 1s caller-supplied timeout
-// against a never-ready mock, the call took ~80s instead of ~1s.
-//
-// After the fix, the function returns within a small multiple of the
-// requested timeout.
 func TestSessionSend_RespectsTimeoutFlag_RegressionFor957(t *testing.T) {
 	mock := &neverReadyChecker{}
 
 	requested := 1 * time.Second
 	start := time.Now()
-	err := waitForAgentReady(mock, "shell", requested)
+	err := send.WaitForAgentReady(mock, "shell", requested, send.PromptGates{})
 	elapsed := time.Since(start)
 
 	if err == nil {
 		t.Fatalf("expected timeout error for never-ready agent, got nil (elapsed=%v)", elapsed)
 	}
 
-	// Must not have run anywhere near the legacy hardcoded 80s gate.
-	// Allow generous headroom for CI scheduling jitter (3× the requested).
 	upper := 3 * requested
 	if elapsed > upper {
-		t.Fatalf("waitForAgentReady ignored --timeout: elapsed=%v, requested=%v, upper bound=%v (legacy hardcoded gate was ~80s — looks unfixed)", elapsed, requested, upper)
+		t.Fatalf("WaitForAgentReady ignored --timeout: elapsed=%v, requested=%v, upper bound=%v", elapsed, requested, upper)
 	}
 
-	// Must not have returned instantly (would mean the wait loop is broken).
 	lower := requested / 2
 	if elapsed < lower {
-		t.Fatalf("waitForAgentReady returned too quickly: elapsed=%v, requested=%v, lower bound=%v", elapsed, requested, lower)
+		t.Fatalf("WaitForAgentReady returned too quickly: elapsed=%v, requested=%v, lower bound=%v", elapsed, requested, lower)
 	}
 
-	// Error message should reference the timeout so operators can diagnose.
 	if !strings.Contains(err.Error(), "not ready") {
 		t.Errorf("expected error to mention readiness, got: %v", err)
 	}
@@ -69,14 +60,13 @@ func TestSessionSend_RespectsTimeoutFlag_RegressionFor957(t *testing.T) {
 }
 
 // TestWaitForAgentReady_ShorterTimeout_ReturnsFaster asserts the wait actually
-// scales with --timeout (not just "anything <80s passes"). Catches regressions
-// where someone might cap the timeout silently.
+// scales with --timeout (not just "anything <80s passes").
 func TestWaitForAgentReady_ShorterTimeout_ReturnsFaster(t *testing.T) {
 	mock := &neverReadyChecker{}
 
 	requested := 500 * time.Millisecond
 	start := time.Now()
-	err := waitForAgentReady(mock, "shell", requested)
+	err := send.WaitForAgentReady(mock, "shell", requested, send.PromptGates{})
 	elapsed := time.Since(start)
 
 	if err == nil {

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2190,7 +2190,10 @@ func handleSessionSend(profile string, args []string) {
 	// post-ready completion wait. Otherwise --timeout 5m against a busy
 	// recipient silently fails at ~80s.
 	if !*noWait {
-		if err := waitForAgentReady(tmuxSess, inst.Tool, *timeout); err != nil {
+		if err := send.WaitForAgentReady(tmuxSess, inst.Tool, *timeout, send.PromptGates{
+			ClaudeComposer: inst.Tool == "claude",
+			CodexPrompt:    inst.Tool == "codex",
+		}); err != nil {
 			out.Error(fmt.Sprintf("timeout waiting for agent: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
@@ -2883,87 +2886,6 @@ func messageDeliveryToken(message string) string {
 	return trimmed
 }
 
-// agentReadyChecker abstracts the tmux surface that waitForAgentReady needs.
-// Lets tests exercise the readiness/timeout loop without a real tmux session.
-// *tmux.Session satisfies this interface naturally.
-type agentReadyChecker interface {
-	GetStatus() (string, error)
-	CapturePaneFresh() (string, error)
-}
-
-// waitForAgentReady waits for Claude/Gemini/other agents to be ready for input
-// Uses status detection: waits for "active" → "waiting" transition.
-//
-// Issue #957: before v1.9.x this loop was hardcoded to 80s and silently
-// overrode the caller's --timeout. `--timeout` now bounds the agent-ready
-// phase too, so `session send --timeout 5m` against a busy recipient actually
-// waits up to 5m for readiness before giving up.
-func waitForAgentReady(target agentReadyChecker, tool string, timeout time.Duration) error {
-	const pollInterval = 200 * time.Millisecond
-	if timeout <= 0 {
-		timeout = 80 * time.Second // preserve historical default if caller passes zero
-	}
-	maxAttempts := int(timeout / pollInterval)
-	if maxAttempts < 1 {
-		maxAttempts = 1
-	}
-
-	sawActive := false
-	readyCount := 0
-
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		time.Sleep(pollInterval)
-
-		status, err := target.GetStatus()
-		if err != nil {
-			readyCount = 0
-			continue
-		}
-
-		if status == "active" {
-			sawActive = true
-			readyCount = 0
-			continue
-		}
-
-		if status == "waiting" || status == "idle" {
-			readyCount++
-		} else {
-			readyCount = 0
-		}
-
-		// Agent is ready when:
-		// 1. We've seen "active" (loading) and now see "waiting" (ready)
-		// 2. We've seen stable waiting/idle 10+ times (already ready)
-		alreadyReady := readyCount >= 10 && attempt >= 15 // At least 3s elapsed
-		if (sawActive && (status == "waiting" || status == "idle")) || alreadyReady {
-			if tool == "claude" {
-				if rawContent, captureErr := target.CapturePaneFresh(); captureErr == nil && !send.HasCurrentComposerPrompt(tmux.StripANSI(rawContent)) {
-					// Claude can report waiting before the interactive prompt is visible.
-					// Keep polling until the prompt line is present.
-					continue
-				}
-			}
-			// Gate Codex sends on prompt readiness: wait for "codex>" or
-			// "Continue?" to be visible before considering the agent ready.
-			if tool == "codex" {
-				if rawContent, captureErr := target.CapturePaneFresh(); captureErr == nil {
-					content := tmux.StripANSI(rawContent)
-					detector := tmux.NewPromptDetector("codex")
-					if !detector.HasPrompt(content) {
-						// Codex hasn't shown its prompt yet; keep polling.
-						continue
-					}
-				}
-			}
-			time.Sleep(300 * time.Millisecond) // Small delay for UI to render
-			return nil
-		}
-	}
-
-	return fmt.Errorf("agent not ready after %s", timeout)
-}
-
 // shouldGateSlashRegistration reports whether a send needs to wait for
 // Claude's slash-command parser to finish registering before relaying.
 //
@@ -2985,13 +2907,13 @@ func shouldGateSlashRegistration(tool, message string) bool {
 
 // waitForSlashCommandReady polls the pane until the composer prompt has been
 // continuously visible for the slash-registration settle window, then returns.
-// Callers must have already passed waitForAgentReady; this is an additional
+// Callers must have already passed send.WaitForAgentReady; this is an additional
 // hold-back specifically for the #966 race.
 //
 // The function probes (rather than blind-sleeps) so a long-already-ready
 // Claude returns near-immediately on retries, while a freshly restarted
 // Claude pays the full settle window.
-func waitForSlashCommandReady(target agentReadyChecker, tool string, timeout time.Duration) error {
+func waitForSlashCommandReady(target send.AgentReadyChecker, tool string, timeout time.Duration) error {
 	const pollInterval = 100 * time.Millisecond
 	// Eight stable composer observations (~800ms) is the empirical floor
 	// for Claude to finish registering its slash-command parser after the

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -2191,8 +2191,8 @@ func handleSessionSend(profile string, args []string) {
 	// recipient silently fails at ~80s.
 	if !*noWait {
 		if err := send.WaitForAgentReady(tmuxSess, inst.Tool, *timeout, send.PromptGates{
-			ClaudeComposer: inst.Tool == "claude",
-			CodexPrompt:    inst.Tool == "codex",
+			ClaudeComposer: session.IsClaudeCompatible(inst.Tool),
+			CodexPrompt:    session.IsCodexCompatible(inst.Tool),
 		}); err != nil {
 			out.Error(fmt.Sprintf("timeout waiting for agent: %v", err), ErrCodeInvalidOperation)
 			os.Exit(1)

--- a/internal/send/ready.go
+++ b/internal/send/ready.go
@@ -1,0 +1,139 @@
+package send
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+// DefaultAgentReadyTimeout is the readiness budget for launch / StartWithMessage.
+// Matches `session send --timeout` default so cold-start TUIs (Cursor, Claude+MCP)
+// are not cut off early.
+const DefaultAgentReadyTimeout = 10 * time.Minute
+
+// AgentReadyChecker abstracts the tmux surface readiness polling needs.
+// *tmux.Session satisfies this interface.
+type AgentReadyChecker interface {
+	GetStatus() (string, error)
+	CapturePaneFresh() (string, error)
+}
+
+// PromptGates enables tool-specific prompt visibility checks once GetStatus
+// reports waiting/idle (or during the startup-window prompt probe below).
+type PromptGates struct {
+	ClaudeComposer bool // IsClaudeCompatible tools: require ❯ composer line
+	CodexPrompt    bool // IsCodexCompatible tools: require codex>/› prompt
+}
+
+// WaitForAgentReady waits until the agent accepts keyboard input.
+//
+// Primary path: GetStatus active → waiting/idle transition (same as the TUI).
+// Secondary path (#cursor-launch): during tmux's startup window GetStatus can
+// return "starting" without re-capturing the pane when window_activity is flat,
+// even though the tool prompt is already on screen and the user can type.
+// When status is "starting", probe CapturePaneFresh directly for a tool prompt.
+func WaitForAgentReady(target AgentReadyChecker, tool string, timeout time.Duration, gates PromptGates) error {
+	const pollInterval = 200 * time.Millisecond
+	if timeout <= 0 {
+		timeout = 80 * time.Second
+	}
+	maxAttempts := int(timeout / pollInterval)
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
+	sawActive := false
+	readyCount := 0
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		time.Sleep(pollInterval)
+
+		status, err := target.GetStatus()
+		if err != nil {
+			readyCount = 0
+			continue
+		}
+
+		// Startup-window bypass: prompt visible in pane but GetStatus still
+		// "starting" because prompt detection only runs on activity changes.
+		if status == "starting" {
+			if paneShowsReadyPrompt(target, tool, gates) {
+				time.Sleep(300 * time.Millisecond)
+				return nil
+			}
+			readyCount = 0
+			continue
+		}
+
+		if status == "active" {
+			sawActive = true
+			readyCount = 0
+			continue
+		}
+
+		if status == "waiting" || status == "idle" {
+			readyCount++
+		} else {
+			readyCount = 0
+		}
+
+		alreadyReady := readyCount >= 10 && attempt >= 15
+		if (sawActive && (status == "waiting" || status == "idle")) || alreadyReady {
+			if gates.ClaudeComposer {
+				if rawContent, captureErr := target.CapturePaneFresh(); captureErr == nil && !HasCurrentComposerPrompt(tmux.StripANSI(rawContent)) {
+					continue
+				}
+			}
+			if gates.CodexPrompt {
+				if rawContent, captureErr := target.CapturePaneFresh(); captureErr == nil {
+					content := tmux.StripANSI(rawContent)
+					detector := tmux.NewPromptDetector("codex")
+					if !detector.HasPrompt(content) {
+						continue
+					}
+				}
+			}
+			if tool == "cursor" {
+				if rawContent, captureErr := target.CapturePaneFresh(); captureErr == nil {
+					content := tmux.StripANSI(rawContent)
+					detector := tmux.NewPromptDetector("cursor")
+					if !detector.HasPrompt(content) {
+						continue
+					}
+				}
+			}
+			time.Sleep(300 * time.Millisecond)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("agent not ready after %s", timeout)
+}
+
+func paneShowsReadyPrompt(target AgentReadyChecker, tool string, gates PromptGates) bool {
+	raw, err := target.CapturePaneFresh()
+	if err != nil {
+		return false
+	}
+	content := tmux.StripANSI(raw)
+	if paneLooksBusy(content) {
+		return false
+	}
+	if gates.ClaudeComposer && HasCurrentComposerPrompt(content) {
+		return true
+	}
+	if gates.CodexPrompt {
+		if tmux.NewPromptDetector("codex").HasPrompt(content) {
+			return true
+		}
+	}
+	return tmux.NewPromptDetector(tool).HasPrompt(content)
+}
+
+func paneLooksBusy(content string) bool {
+	lower := strings.ToLower(content)
+	return strings.Contains(lower, "ctrl+c to interrupt") ||
+		strings.Contains(lower, "esc to interrupt")
+}

--- a/internal/send/ready.go
+++ b/internal/send/ready.go
@@ -37,7 +37,7 @@ type PromptGates struct {
 func WaitForAgentReady(target AgentReadyChecker, tool string, timeout time.Duration, gates PromptGates) error {
 	const pollInterval = 200 * time.Millisecond
 	if timeout <= 0 {
-		timeout = 80 * time.Second
+		timeout = DefaultAgentReadyTimeout
 	}
 	maxAttempts := int(timeout / pollInterval)
 	if maxAttempts < 1 {
@@ -121,13 +121,11 @@ func paneShowsReadyPrompt(target AgentReadyChecker, tool string, gates PromptGat
 	if paneLooksBusy(content) {
 		return false
 	}
-	if gates.ClaudeComposer && HasCurrentComposerPrompt(content) {
-		return true
+	if gates.ClaudeComposer {
+		return HasCurrentComposerPrompt(content)
 	}
 	if gates.CodexPrompt {
-		if tmux.NewPromptDetector("codex").HasPrompt(content) {
-			return true
-		}
+		return tmux.NewPromptDetector("codex").HasPrompt(content)
 	}
 	return tmux.NewPromptDetector(tool).HasPrompt(content)
 }

--- a/internal/send/ready_test.go
+++ b/internal/send/ready_test.go
@@ -92,6 +92,10 @@ func TestWaitForAgentReady_RespectsTimeout(t *testing.T) {
 	if elapsed > 3*requested {
 		t.Fatalf("timeout ignored: elapsed=%v requested=%v", elapsed, requested)
 	}
+	lower := requested / 2
+	if elapsed < lower {
+		t.Fatalf("returned too quickly: elapsed=%v requested=%v lower=%v", elapsed, requested, lower)
+	}
 	if mock.calls.Load() == 0 {
 		t.Error("expected GetStatus to be polled")
 	}

--- a/internal/send/ready_test.go
+++ b/internal/send/ready_test.go
@@ -1,0 +1,98 @@
+package send
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/tmux"
+)
+
+type mockReadyChecker struct {
+	statuses []string
+	statusIx atomic.Int64
+	pane     string
+}
+
+func (m *mockReadyChecker) GetStatus() (string, error) {
+	i := int(m.statusIx.Add(1)) - 1
+	if i >= len(m.statuses) {
+		return m.statuses[len(m.statuses)-1], nil
+	}
+	return m.statuses[i], nil
+}
+
+func (m *mockReadyChecker) CapturePaneFresh() (string, error) {
+	return m.pane, nil
+}
+
+// Cursor can be interactive while GetStatus still returns "starting" during
+// the tmux startup window (no activity-timestamp change → no prompt re-check).
+func TestWaitForAgentReady_StartingWithCursorPrompt(t *testing.T) {
+	mock := &mockReadyChecker{
+		statuses: []string{"starting"},
+		pane: strings.Join([]string{
+			"Cursor Agent",
+			"How can I help you today?",
+			"› implement the feature",
+			"Plan mode · Switch modes",
+		}, "\n"),
+	}
+
+	err := WaitForAgentReady(mock, "cursor", 2*time.Second, PromptGates{})
+	if err != nil {
+		t.Fatalf("expected ready via startup prompt probe, got: %v", err)
+	}
+}
+
+func TestWaitForAgentReady_StartingWithoutPromptTimesOut(t *testing.T) {
+	mock := &mockReadyChecker{
+		statuses: []string{"starting"},
+		pane:     "Loading...\n",
+	}
+
+	err := WaitForAgentReady(mock, "cursor", 400*time.Millisecond, PromptGates{})
+	if err == nil {
+		t.Fatal("expected timeout when starting with no prompt")
+	}
+}
+
+func TestWaitForAgentReady_CursorPromptDetector(t *testing.T) {
+	content := "› ask anything\nPlan mode"
+	d := tmux.NewPromptDetector("cursor")
+	if !d.HasPrompt(content) {
+		t.Fatalf("cursor detector should match › prompt, content:\n%s", content)
+	}
+}
+
+type neverReadyChecker struct {
+	calls atomic.Int64
+}
+
+func (m *neverReadyChecker) GetStatus() (string, error) {
+	m.calls.Add(1)
+	return "active", nil
+}
+
+func (m *neverReadyChecker) CapturePaneFresh() (string, error) {
+	return "", nil
+}
+
+func TestWaitForAgentReady_RespectsTimeout(t *testing.T) {
+	mock := &neverReadyChecker{}
+	requested := 1 * time.Second
+	start := time.Now()
+	err := WaitForAgentReady(mock, "shell", requested, PromptGates{})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil (elapsed=%v)", elapsed)
+	}
+	if elapsed > 3*requested {
+		t.Fatalf("timeout ignored: elapsed=%v requested=%v", elapsed, requested)
+	}
+	if mock.calls.Load() == 0 {
+		t.Error("expected GetStatus to be polled")
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3469,164 +3469,92 @@ func (i *Instance) StartWithMessage(message string) error {
 	return nil
 }
 
-// sendMessageWhenReady waits for the agent to be ready and sends the message
-// Uses the existing status detection system which is robust and works for all tools
-//
-// The status flow for a new session:
-//  1. Initial "waiting" (session just started, hash set)
-//  2. "active" (content changing as agent loads)
-//  3. "waiting" (content stable, agent ready for input)
-//
-// We wait for this full cycle: initial → active → waiting
-// Exception: If Claude already finished processing "." from session capture,
-// we may see "waiting" immediately - detect this by checking for input prompt
+// sendMessageWhenReady waits for the agent to be ready and sends the message.
+// Uses the shared WaitForAgentReady helper (same semantics as `session send`).
 func (i *Instance) sendMessageWhenReady(message string) error {
 	if i.tmuxSession == nil {
 		return fmt.Errorf("tmux session not initialized")
 	}
 
-	// Track state transitions: we need to see "active" before accepting "waiting"
-	// This ensures we don't send the message during initial startup (false "waiting")
-	sawActive := false
-	readyCount := 0    // Track consecutive waiting/idle states to detect already-ready sessions
-	maxAttempts := 300 // 60 seconds max (300 * 200ms) - Claude with MCPs can take 40-60s
+	if err := send.WaitForAgentReady(i.tmuxSession, i.Tool, send.DefaultAgentReadyTimeout, send.PromptGates{
+		ClaudeComposer: IsClaudeCompatible(i.Tool),
+		CodexPrompt:    IsCodexCompatible(i.Tool),
+	}); err != nil {
+		return fmt.Errorf("timeout waiting for agent to be ready")
+	}
 
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		time.Sleep(200 * time.Millisecond)
+	if err := i.tmuxSession.SendKeysAndEnter(message); err != nil {
+		return fmt.Errorf("failed to send message: %w", err)
+	}
 
-		// Use the existing robust status detection
-		status, err := i.tmuxSession.GetStatus()
-		if err != nil {
-			readyCount = 0 // Reset on error
+	// The verify loop below keys off Claude-specific signals (an
+	// "active" transition, composer glyph, unsent-paste markers). Non-
+	// Claude tools never surface those, so the loop false-negatives a
+	// delivered message and Enter-spams the composer; skip it for every
+	// non-Claude tool (#1238 — generalizes #1228's codex-only skip).
+	if !UsesClaudeDeliveryVerify(i.Tool) {
+		return nil
+	}
+
+	// Verify the agent accepted Enter and began processing.
+	const verifyRetries = 50
+	const verifyDelay = 300 * time.Millisecond
+	const activeSuccessThreshold = 2
+	const waitingAfterActiveThreshold = 2
+	waitingNoMarkerChecks := 0
+	activeChecks := 0
+	sawActiveAfterSend := false
+
+	for retry := 0; retry < verifyRetries; retry++ {
+		time.Sleep(verifyDelay)
+
+		unsentPromptDetected := false
+		if rawContent, captureErr := i.tmuxSession.CapturePaneFresh(); captureErr == nil {
+			content := tmux.StripANSI(rawContent)
+			unsentPromptDetected = send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message)
+		}
+		verifiedStatus, statusErr := i.tmuxSession.GetStatus()
+
+		if unsentPromptDetected {
+			waitingNoMarkerChecks = 0
+			activeChecks = 0
+			_ = i.tmuxSession.SendEnter()
 			continue
 		}
 
-		if status == "active" {
-			sawActive = true
-			readyCount = 0
-			continue
-		}
-
-		if status == "waiting" || status == "idle" {
-			readyCount++
-		} else {
-			readyCount = 0
-		}
-
-		// Agent is ready when either:
-		// 1. We've seen "active" (loading) and now see "waiting" (ready)
-		// 2. We've seen waiting/idle 10+ times consecutively (already processed initial ".")
-		//    This handles the race where Claude finishes before we start checking
-		alreadyReady := readyCount >= 10 && attempt >= 15 // At least 3s elapsed
-		if (sawActive && (status == "waiting" || status == "idle")) || alreadyReady {
-			if IsClaudeCompatible(i.Tool) {
-				if rawContent, captureErr := i.tmuxSession.CapturePaneFresh(); captureErr == nil && !send.HasCurrentComposerPrompt(tmux.StripANSI(rawContent)) {
-					// Claude can report waiting before the interactive prompt is visible.
-					// Keep polling until the prompt line is present.
-					continue
-				}
-			}
-			// Gate Codex sends on prompt readiness: wait for "codex>" or
-			// "Continue?" to be visible before considering the agent ready.
-			if IsCodexCompatible(i.Tool) {
-				if rawContent, captureErr := i.tmuxSession.CapturePaneFresh(); captureErr == nil {
-					content := tmux.StripANSI(rawContent)
-					detector := tmux.NewPromptDetector("codex")
-					if !detector.HasPrompt(content) {
-						continue
-					}
-				}
-			}
-			// Small delay to ensure UI is fully rendered
-			time.Sleep(300 * time.Millisecond)
-
-			// Send message atomically (text + Enter in single tmux invocation)
-			if err := i.tmuxSession.SendKeysAndEnter(message); err != nil {
-				return fmt.Errorf("failed to send message: %w", err)
-			}
-
-			// The verify loop below keys off Claude-specific signals (an
-			// "active" transition, composer glyph, unsent-paste markers). Non-
-			// Claude tools never surface those, so the loop false-negatives a
-			// delivered message and Enter-spams the composer; skip it for every
-			// non-Claude tool (#1238 — generalizes #1228's codex-only skip).
-			if !UsesClaudeDeliveryVerify(i.Tool) {
+		if statusErr == nil && verifiedStatus == "active" {
+			sawActiveAfterSend = true
+			waitingNoMarkerChecks = 0
+			activeChecks++
+			if activeChecks >= activeSuccessThreshold {
 				return nil
 			}
+			continue
+		}
+		activeChecks = 0
 
-			// Verify the agent accepted Enter and began processing.
-			// Strategy:
-			// - If unsent prompt is visible, press Enter again immediately.
-			// - Consider success only after sustained post-send activity ("active").
-			// - If we never observe active and remain in waiting/idle, keep a
-			//   periodic fallback Enter cadence instead of returning early.
-			const verifyRetries = 50
-			const verifyDelay = 300 * time.Millisecond
-			const activeSuccessThreshold = 2
-			const waitingAfterActiveThreshold = 2
-			waitingNoMarkerChecks := 0
-			activeChecks := 0
-			sawActiveAfterSend := false
-
-			for retry := 0; retry < verifyRetries; retry++ {
-				time.Sleep(verifyDelay)
-
-				unsentPromptDetected := false
-				if rawContent, captureErr := i.tmuxSession.CapturePaneFresh(); captureErr == nil {
-					content := tmux.StripANSI(rawContent)
-					unsentPromptDetected = send.HasUnsentPastedPrompt(content) || send.HasUnsentComposerPrompt(content, message)
+		if statusErr == nil && (verifiedStatus == "waiting" || verifiedStatus == "idle") {
+			if sawActiveAfterSend {
+				waitingNoMarkerChecks++
+				if waitingNoMarkerChecks >= waitingAfterActiveThreshold {
+					return nil
 				}
-				verifiedStatus, statusErr := i.tmuxSession.GetStatus()
-
-				if unsentPromptDetected {
-					waitingNoMarkerChecks = 0
-					activeChecks = 0
-					_ = i.tmuxSession.SendEnter()
-					continue
-				}
-
-				if statusErr == nil && verifiedStatus == "active" {
-					sawActiveAfterSend = true
-					waitingNoMarkerChecks = 0
-					activeChecks++
-					if activeChecks >= activeSuccessThreshold {
-						return nil
-					}
-					continue
-				}
-				activeChecks = 0
-
-				if statusErr == nil && (verifiedStatus == "waiting" || verifiedStatus == "idle") {
-					if sawActiveAfterSend {
-						waitingNoMarkerChecks++
-						if waitingNoMarkerChecks >= waitingAfterActiveThreshold {
-							return nil
-						}
-					} else {
-						waitingNoMarkerChecks = 0
-						// We haven't observed any post-send activity yet.
-						// Nudge Enter aggressively in the early window (every
-						// iteration for first 5 retries) then every 2nd iteration.
-						if retry < 5 || retry%2 == 0 {
-							_ = i.tmuxSession.SendEnter()
-						}
-					}
-					continue
-				}
-
+			} else {
 				waitingNoMarkerChecks = 0
-				// Increased from 2 to 4 for TUI frameworks needing more time.
-				if retry < 4 {
+				if retry < 5 || retry%2 == 0 {
 					_ = i.tmuxSession.SendEnter()
 				}
 			}
+			continue
+		}
 
-			// Best effort: don't fail if verification remains inconclusive.
-			return nil
+		waitingNoMarkerChecks = 0
+		if retry < 4 {
+			_ = i.tmuxSession.SendEnter()
 		}
 	}
 
-	return fmt.Errorf("timeout waiting for agent to be ready")
+	return nil
 }
 
 // errorRecheckInterval - how often to recheck sessions that don't exist

--- a/internal/tmux/detector.go
+++ b/internal/tmux/detector.go
@@ -81,6 +81,9 @@ func (d *PromptDetector) HasPrompt(content string) bool {
 		// with a status bar (model · path · branch · usage) below it.
 		return d.hasCodexPromptMarker(content)
 
+	case "cursor":
+		return d.hasCursorPrompt(content)
+
 	default:
 		// Generic shell - check for common prompts
 		return d.hasShellPrompt(content)
@@ -480,6 +483,23 @@ func (d *PromptDetector) hasCodexPromptMarker(content string) bool {
 		}
 	}
 	return false
+}
+
+// hasCursorPrompt detects when the Cursor Agent CLI is waiting for input.
+// Patterns mirror internal/tmux/patterns.go (cursor tool defaults).
+func (d *PromptDetector) hasCursorPrompt(content string) bool {
+	lower := strings.ToLower(content)
+	if strings.Contains(lower, "esc to interrupt") ||
+		strings.Contains(lower, "ctrl+c to interrupt") {
+		return false
+	}
+	if strings.Contains(content, "How can I help") ||
+		strings.Contains(content, "Ask questions") ||
+		strings.Contains(content, "Plan mode") ||
+		strings.Contains(content, "Switch modes") {
+		return true
+	}
+	return d.hasCodexPromptMarker(content)
 }
 
 // hasGeminiPrompt detects if Gemini CLI is waiting for input.


### PR DESCRIPTION
Launch with -m timed out because sendMessageWhenReady ignored the "starting" status even when the pane already showed a Cursor prompt. Share readiness polling with session send and probe the pane directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting Cursor agent readiness alongside existing Claude Composer and Codex tools
  * Enhanced prompt detection and readiness checks to confirm agents are truly ready to accept input
* **Bug Fixes**
  * Improved timeout handling to better respect requested timeouts and return clearer “not ready” errors
  * Tightened readiness timing and polling behavior for more reliable send-timeout outcomes
* **Tests**
  * Added unit tests for agent readiness (including Cursor prompt detection) and updated regression coverage for timeout behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->