### PR TITLE
feat(cursor): pre-seed workspace trust before session start

### DIFF
--- a/internal/session/cursor_trust.go
+++ b/internal/session/cursor_trust.go
@@ -1,0 +1,257 @@
+package session
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/docker"
+)
+
+// cursorSandboxHome and cursorSandboxWorkDir match internal/docker/config.go
+// containerHome and containerWorkDir.
+const (
+	cursorSandboxHome    = "/root"
+	cursorSandboxWorkDir = "/workspace"
+)
+
+// validateCursorProjectKey rejects project keys that could escape the projects/
+// subtree via path traversal. Cursor itself allows dots, spaces, and other
+// characters from the workspace path in the slug.
+func validateCursorProjectKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("cursor project key is empty")
+	}
+	if strings.Contains(key, "..") {
+		return fmt.Errorf("cursor project key %q contains ..", key)
+	}
+	if strings.ContainsAny(key, `/\`) {
+		return fmt.Errorf("cursor project key %q contains path separator", key)
+	}
+	return nil
+}
+
+// validateCursorTrustPathContained ensures trustPath stays under
+// cursorConfigDir/projects/ and names the expected trust file.
+func validateCursorTrustPathContained(cursorConfigDir, trustPath string) error {
+	cleanConfig, err := filepath.Abs(filepath.Clean(cursorConfigDir))
+	if err != nil {
+		return fmt.Errorf("abs cursor config dir: %w", err)
+	}
+	cleanTrust, err := filepath.Abs(filepath.Clean(trustPath))
+	if err != nil {
+		return fmt.Errorf("abs trust path: %w", err)
+	}
+	projectsRoot := filepath.Join(cleanConfig, "projects")
+	if cleanTrust != projectsRoot && !strings.HasPrefix(cleanTrust, projectsRoot+string(os.PathSeparator)) {
+		return fmt.Errorf("trust path %q escapes cursor config dir", trustPath)
+	}
+	if filepath.Base(cleanTrust) != ".workspace-trusted" {
+		return fmt.Errorf("trust path %q is not a .workspace-trusted file", trustPath)
+	}
+	return nil
+}
+
+// cursorWorkspaceProjectKey maps an absolute workspace path to the directory
+// name Cursor uses under ~/.cursor/projects/ (e.g.
+// /Users/me/proj → Users-me-proj).
+func cursorWorkspaceProjectKey(workspacePath string) (string, error) {
+	if workspacePath == "" {
+		return "", fmt.Errorf("workspacePath is empty")
+	}
+	abs, err := filepath.Abs(filepath.Clean(workspacePath))
+	if err != nil {
+		return "", fmt.Errorf("abs %s: %w", workspacePath, err)
+	}
+	abs = strings.TrimSuffix(abs, string(os.PathSeparator))
+	key := strings.TrimPrefix(abs, string(os.PathSeparator))
+	key = strings.ReplaceAll(key, string(os.PathSeparator), "-")
+	if key == "" {
+		return "", fmt.Errorf("workspacePath resolves to empty key: %s", workspacePath)
+	}
+	if err := validateCursorProjectKey(key); err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+// cursorWorkspaceTrustPath returns the ~/.cursor/projects/<key>/.workspace-trusted
+// path for workspacePath.
+func cursorWorkspaceTrustPath(cursorConfigDir, workspacePath string) (string, string, error) {
+	if cursorConfigDir == "" {
+		return "", "", fmt.Errorf("cursorConfigDir is empty")
+	}
+	key, err := cursorWorkspaceProjectKey(workspacePath)
+	if err != nil {
+		return "", "", err
+	}
+	abs, err := filepath.Abs(filepath.Clean(workspacePath))
+	if err != nil {
+		return "", "", fmt.Errorf("abs %s: %w", workspacePath, err)
+	}
+	projectDir := filepath.Join(cursorConfigDir, "projects", key)
+	trustPath := filepath.Join(projectDir, ".workspace-trusted")
+	if err := validateCursorTrustPathContained(cursorConfigDir, trustPath); err != nil {
+		return "", "", err
+	}
+	return trustPath, abs, nil
+}
+
+// cursorTrustEntryJSON returns the JSON bytes Cursor writes for workspace trust
+// and the absolute workspace path stored in the file.
+func cursorTrustEntryJSON(workspacePath string) ([]byte, string, error) {
+	abs, err := filepath.Abs(filepath.Clean(workspacePath))
+	if err != nil {
+		return nil, "", fmt.Errorf("abs %s: %w", workspacePath, err)
+	}
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	entry := map[string]string{
+		"trustedAt":     now.Format("2006-01-02T15:04:05.000Z"),
+		"workspacePath": abs,
+	}
+	out, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal cursor trust: %w", err)
+	}
+	out = append(out, '\n')
+	return out, abs, nil
+}
+
+// writeCursorTrustFileExclusive creates the trust file with O_EXCL so concurrent
+// seeders do not overwrite each other. An existing file is left unchanged.
+func writeCursorTrustFileExclusive(trustPath string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(trustPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir parent of %s: %w", trustPath, err)
+	}
+	// #nosec G304 -- trustPath is confined under cursorConfigDir/projects by
+	// validateCursorTrustPathContained before this write is attempted.
+	if err := writeFileIfAbsent(trustPath, content, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", trustPath, err)
+	}
+	return nil
+}
+
+// PreAcceptCursorTrust seeds ~/.cursor/projects/<key>/.workspace-trusted for
+// workspacePath so interactive `cursor agent` skips the workspace-trust prompt.
+//
+// Cursor keys trust by the literal workspace path (stored in the JSON file) and
+// a slugified directory under ~/.cursor/projects/. Pre-seeding matches what
+// accepting the prompt in the UI would write.
+//
+// If the trust file already exists it is left unchanged. Malformed existing
+// trust files are not overwritten.
+func PreAcceptCursorTrust(cursorConfigDir, workspacePath string) error {
+	trustPath, _, err := cursorWorkspaceTrustPath(cursorConfigDir, workspacePath)
+	if err != nil {
+		return err
+	}
+	content, _, err := cursorTrustEntryJSON(workspacePath)
+	if err != nil {
+		return err
+	}
+	return writeCursorTrustFileExclusive(trustPath, content)
+}
+
+// buildCursorTrustRemoteShellScript returns a POSIX shell script that writes
+// trust JSON to path using noclobber (set -C) so concurrent seeders do not
+// overwrite an existing file. pathSetup must set path= (and optionally key=)
+// before the write runs.
+func buildCursorTrustRemoteShellScript(pathSetup string, content []byte) string {
+	b64 := base64.StdEncoding.EncodeToString(content)
+	return fmt.Sprintf(`set -e
+%s
+mkdir -p "$(dirname "$path")"
+if (set -C; echo %s | base64 -d > "$path") 2>/dev/null; then
+  :
+fi
+`, pathSetup, shellQuote(b64))
+}
+
+// runCursorTrustRemoteScript executes a trust-seeding shell script on a remote
+// host over SSH. The script is passed on stdin to avoid embedding it in argv.
+func runCursorTrustRemoteScript(host, script string) error {
+	_ = os.MkdirAll(sshControlDir, 0o700)
+	args := append(sessionSSHConnOpts(), host, "sh", "-s")
+	// #nosec G204 -- host is validated by ValidateSSHHost; script is generated
+	// locally from a slugified key and base64 JSON, delivered via stdin.
+	cmd := exec.Command("ssh", args...)
+	cmd.Stdin = strings.NewReader(script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("ssh cursor trust seed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// runCursorTrustContainerScript executes a trust-seeding shell script inside a
+// managed sandbox container. The script is passed on stdin to docker exec.
+func runCursorTrustContainerScript(containerName, script string) error {
+	// #nosec G204 -- containerName is restricted to agent-deck-managed names;
+	// script is generated locally and delivered via stdin.
+	cmd := exec.Command("docker", "exec", "-i", containerName, "sh", "-s")
+	cmd.Stdin = strings.NewReader(script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("docker exec cursor trust seed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// PreAcceptCursorTrustSSH seeds Cursor workspace trust on a remote host via ssh.
+func PreAcceptCursorTrustSSH(host, workspacePath string) error {
+	if err := ValidateSSHHost(host); err != nil {
+		return err
+	}
+	content, absWorkspace, err := cursorTrustEntryJSON(workspacePath)
+	if err != nil {
+		return err
+	}
+	key, err := cursorWorkspaceProjectKey(absWorkspace)
+	if err != nil {
+		return err
+	}
+	pathSetup := fmt.Sprintf("key=%s\npath=\"$HOME/.cursor/projects/$key/.workspace-trusted\"", shellQuote(key))
+	script := buildCursorTrustRemoteShellScript(pathSetup, content)
+	return runCursorTrustRemoteScript(host, script)
+}
+
+// PreAcceptCursorTrustInContainer seeds Cursor workspace trust inside a sandbox
+// container via docker exec.
+func PreAcceptCursorTrustInContainer(containerName, workspacePath string) error {
+	if strings.TrimSpace(containerName) == "" {
+		return fmt.Errorf("containerName is empty")
+	}
+	if !docker.IsManagedContainer(containerName) {
+		return fmt.Errorf("container %q is not an agent-deck managed container", containerName)
+	}
+	if workspacePath != cursorSandboxWorkDir {
+		return fmt.Errorf("sandbox workspace path %q is not %q", workspacePath, cursorSandboxWorkDir)
+	}
+	content, absWorkspace, err := cursorTrustEntryJSON(workspacePath)
+	if err != nil {
+		return err
+	}
+	key, err := cursorWorkspaceProjectKey(absWorkspace)
+	if err != nil {
+		return err
+	}
+	trustPath := path.Join(cursorSandboxHome, ".cursor", "projects", key, ".workspace-trusted")
+	pathSetup := fmt.Sprintf("path=%s", shellQuote(trustPath))
+	script := buildCursorTrustRemoteShellScript(pathSetup, content)
+	return runCursorTrustContainerScript(containerName, script)
+}
+
+// sessionSSHConnOpts returns SSH connection options shared with SSHRunner paths.
+func sessionSSHConnOpts() []string {
+	return []string{
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=" + sshControlDir + "/%r@%h:%p",
+		"-o", "ControlPersist=600",
+		"-o", "ConnectTimeout=10",
+		"-o", "BatchMode=yes",
+	}
+}

--- a/internal/session/cursor_trust.go
+++ b/internal/session/cursor_trust.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -17,8 +18,9 @@ import (
 // cursorSandboxHome and cursorSandboxWorkDir match internal/docker/config.go
 // containerHome and containerWorkDir.
 const (
-	cursorSandboxHome    = "/root"
-	cursorSandboxWorkDir = "/workspace"
+	cursorSandboxHome         = "/root"
+	cursorSandboxWorkDir      = "/workspace"
+	cursorTrustCommandTimeout = 30 * time.Second
 )
 
 // validateCursorProjectKey rejects project keys that could escape the projects/
@@ -142,7 +144,9 @@ func writeCursorTrustFileExclusive(trustPath string, content []byte) error {
 //
 // Cursor keys trust by the literal workspace path (stored in the JSON file) and
 // a slugified directory under ~/.cursor/projects/. Pre-seeding matches what
-// accepting the prompt in the UI would write.
+// accepting the prompt in the UI would write. This mirrors Cursor's observed
+// trust format as of 2026-06; if Cursor changes that schema, seeding may become
+// a harmless no-op until this mapping is updated.
 //
 // If the trust file already exists it is left unchanged. Malformed existing
 // trust files are not overwritten.
@@ -159,16 +163,25 @@ func PreAcceptCursorTrust(cursorConfigDir, workspacePath string) error {
 }
 
 // buildCursorTrustRemoteShellScript returns a POSIX shell script that writes
-// trust JSON to path using noclobber (set -C) so concurrent seeders do not
-// overwrite an existing file. pathSetup must set path= (and optionally key=)
-// before the write runs.
+// trust JSON to path through a same-directory temp file and exclusive hard link
+// so concurrent seeders do not overwrite an existing file. pathSetup must set
+// path= (and optionally key=) before the write runs.
 func buildCursorTrustRemoteShellScript(pathSetup string, content []byte) string {
 	b64 := base64.StdEncoding.EncodeToString(content)
 	return fmt.Sprintf(`set -e
 %s
-mkdir -p "$(dirname "$path")"
-if (set -C; echo %s | base64 -d > "$path") 2>/dev/null; then
-  :
+if [ -e "$path" ] || [ -L "$path" ]; then
+  exit 0
+fi
+dir="$(dirname "$path")"
+mkdir -p "$dir"
+tmp="$(mktemp "$dir/.workspace-trusted.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT HUP INT TERM
+echo %s | base64 -d > "$tmp"
+if ln "$tmp" "$path" 2>/dev/null; then
+  rm -f "$tmp"
+elif [ ! -e "$path" ] && [ ! -L "$path" ]; then
+  exit 1
 fi
 `, pathSetup, shellQuote(b64))
 }
@@ -178,11 +191,16 @@ fi
 func runCursorTrustRemoteScript(host, script string) error {
 	_ = os.MkdirAll(sshControlDir, 0o700)
 	args := append(sessionSSHConnOpts(), host, "sh", "-s")
+	ctx, cancel := context.WithTimeout(context.Background(), cursorTrustCommandTimeout)
+	defer cancel()
 	// #nosec G204 -- host is validated by ValidateSSHHost; script is generated
 	// locally from a slugified key and base64 JSON, delivered via stdin.
-	cmd := exec.Command("ssh", args...)
+	cmd := exec.CommandContext(ctx, "ssh", args...)
 	cmd.Stdin = strings.NewReader(script)
 	if out, err := cmd.CombinedOutput(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("ssh cursor trust seed: %w: %s", ctxErr, strings.TrimSpace(string(out)))
+		}
 		return fmt.Errorf("ssh cursor trust seed: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
@@ -191,17 +209,23 @@ func runCursorTrustRemoteScript(host, script string) error {
 // runCursorTrustContainerScript executes a trust-seeding shell script inside a
 // managed sandbox container. The script is passed on stdin to docker exec.
 func runCursorTrustContainerScript(containerName, script string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), cursorTrustCommandTimeout)
+	defer cancel()
 	// #nosec G204 -- containerName is restricted to agent-deck-managed names;
 	// script is generated locally and delivered via stdin.
-	cmd := exec.Command("docker", "exec", "-i", containerName, "sh", "-s")
+	cmd := exec.CommandContext(ctx, "docker", "exec", "-i", containerName, "sh", "-s")
 	cmd.Stdin = strings.NewReader(script)
 	if out, err := cmd.CombinedOutput(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("docker exec cursor trust seed: %w: %s", ctxErr, strings.TrimSpace(string(out)))
+		}
 		return fmt.Errorf("docker exec cursor trust seed: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }
 
-// PreAcceptCursorTrustSSH seeds Cursor workspace trust on a remote host via ssh.
+// PreAcceptCursorTrustSSH seeds Cursor workspace trust on a POSIX remote host
+// via ssh. Project-key generation assumes matching POSIX path semantics locally.
 func PreAcceptCursorTrustSSH(host, workspacePath string) error {
 	if err := ValidateSSHHost(host); err != nil {
 		return err

--- a/internal/session/cursor_trust_test.go
+++ b/internal/session/cursor_trust_test.go
@@ -1,0 +1,292 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestCursorWorkspaceProjectKey(t *testing.T) {
+	workspace := filepath.Join("/Users", "me", "dev", "agent-deck")
+	key, err := cursorWorkspaceProjectKey(workspace)
+	if err != nil {
+		t.Fatalf("cursorWorkspaceProjectKey: %v", err)
+	}
+	want := "Users-me-dev-agent-deck"
+	if key != want {
+		t.Fatalf("key = %q, want %q", key, want)
+	}
+}
+
+func TestCursorWorkspaceProjectKey_AllowsDotsAndSpaces(t *testing.T) {
+	workspace := filepath.Join("/Users", "me", "my.repo", "My Project")
+	key, err := cursorWorkspaceProjectKey(workspace)
+	if err != nil {
+		t.Fatalf("cursorWorkspaceProjectKey: %v", err)
+	}
+	if !strings.Contains(key, ".") {
+		t.Fatalf("key %q should preserve dots from workspace path", key)
+	}
+	if !strings.Contains(key, " ") {
+		t.Fatalf("key %q should preserve spaces from workspace path", key)
+	}
+}
+
+func TestPreAcceptCursorTrust_CreatesTrustFile(t *testing.T) {
+	tmpHome := t.TempDir()
+	cursorDir := filepath.Join(tmpHome, ".cursor")
+	workspace := filepath.Join(tmpHome, "worktrees", "feature-x")
+
+	if err := PreAcceptCursorTrust(cursorDir, workspace); err != nil {
+		t.Fatalf("PreAcceptCursorTrust: %v", err)
+	}
+
+	trustPath, absWorkspace, err := cursorWorkspaceTrustPath(cursorDir, workspace)
+	if err != nil {
+		t.Fatalf("cursorWorkspaceTrustPath: %v", err)
+	}
+	data, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read trust file: %v", err)
+	}
+	var entry map[string]string
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("unmarshal trust file: %v", err)
+	}
+	if entry["workspacePath"] != absWorkspace {
+		t.Fatalf("workspacePath = %q, want %q", entry["workspacePath"], absWorkspace)
+	}
+	if entry["trustedAt"] == "" {
+		t.Fatal("trustedAt is empty")
+	}
+	if !strings.HasSuffix(entry["trustedAt"], "Z") {
+		t.Fatalf("trustedAt = %q, want UTC Z suffix", entry["trustedAt"])
+	}
+}
+
+func TestPreAcceptCursorTrust_Idempotent(t *testing.T) {
+	tmpHome := t.TempDir()
+	cursorDir := filepath.Join(tmpHome, ".cursor")
+	workspace := filepath.Join(tmpHome, "repo")
+
+	if err := PreAcceptCursorTrust(cursorDir, workspace); err != nil {
+		t.Fatalf("first PreAcceptCursorTrust: %v", err)
+	}
+	trustPath, _, err := cursorWorkspaceTrustPath(cursorDir, workspace)
+	if err != nil {
+		t.Fatalf("cursorWorkspaceTrustPath: %v", err)
+	}
+	before, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read trust file: %v", err)
+	}
+
+	if err := PreAcceptCursorTrust(cursorDir, workspace); err != nil {
+		t.Fatalf("second PreAcceptCursorTrust: %v", err)
+	}
+	after, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read trust file after second call: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatalf("trust file changed on second call:\nbefore: %s\nafter: %s", before, after)
+	}
+}
+
+func TestPreAcceptCursorTrust_EmptyInputs(t *testing.T) {
+	if err := PreAcceptCursorTrust("", "/tmp"); err == nil {
+		t.Fatal("expected error for empty cursorConfigDir")
+	}
+	if err := PreAcceptCursorTrust("/tmp/.cursor", ""); err == nil {
+		t.Fatal("expected error for empty workspacePath")
+	}
+}
+
+func TestWriteCursorTrustFileExclusive_ExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	trustPath := filepath.Join(dir, "projects", "key", ".workspace-trusted")
+	content := []byte("original\n")
+
+	if err := writeCursorTrustFileExclusive(trustPath, content); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := writeCursorTrustFileExclusive(trustPath, []byte("overwrite\n")); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	got, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("content = %q, want %q", got, content)
+	}
+}
+
+func TestWriteCursorTrustFileExclusive_Concurrent(t *testing.T) {
+	dir := t.TempDir()
+	trustPath := filepath.Join(dir, ".workspace-trusted")
+	workspace := filepath.Join(dir, "proj")
+	content, _, err := cursorTrustEntryJSON(workspace)
+	if err != nil {
+		t.Fatalf("cursorTrustEntryJSON: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = writeCursorTrustFileExclusive(trustPath, content)
+		}()
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read trust file: %v", err)
+	}
+	if string(data) != string(content) {
+		t.Fatalf("unexpected content: %s", data)
+	}
+}
+
+func TestInstance_preAcceptCursorWorkspaceTrust_Local(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	workspace := filepath.Join(tmpHome, "proj")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	inst := NewInstanceWithTool("cursor-trust", workspace, "cursor")
+	inst.preAcceptCursorWorkspaceTrust()
+
+	trustPath, absWorkspace, err := cursorWorkspaceTrustPath(GetCursorConfigDir(), workspace)
+	if err != nil {
+		t.Fatalf("cursorWorkspaceTrustPath: %v", err)
+	}
+	if _, err := os.Stat(trustPath); err != nil {
+		t.Fatalf("trust file missing: %v", err)
+	}
+	if absWorkspace != workspace {
+		t.Fatalf("abs workspace = %q, want %q", absWorkspace, workspace)
+	}
+}
+
+func TestInstance_cursorTrustWorkspacePath(t *testing.T) {
+	inst := NewInstanceWithTool("x", "/host/proj", "cursor")
+	inst.SSHHost = "user@remote"
+	inst.SSHRemotePath = "/remote/proj"
+	if got := inst.cursorTrustWorkspacePath(); got != "/remote/proj" {
+		t.Fatalf("ssh path = %q, want /remote/proj", got)
+	}
+
+	inst.SSHHost = ""
+	inst.Sandbox = NewSandboxConfig("")
+	if got := inst.cursorTrustWorkspacePath(); got != cursorSandboxWorkDir {
+		t.Fatalf("sandbox path = %q, want %s", got, cursorSandboxWorkDir)
+	}
+}
+
+func TestBuildCursorTrustRemoteShellScript_ExpandsHome(t *testing.T) {
+	pathSetup := "key='foo'\npath=\"$HOME/.cursor/projects/$key/.workspace-trusted\""
+	script := buildCursorTrustRemoteShellScript(pathSetup, []byte("data\n"))
+	if !strings.Contains(script, `path="$HOME/.cursor/projects/$key/.workspace-trusted"`) {
+		t.Fatalf("script missing HOME path expansion: %s", script)
+	}
+	if !strings.Contains(script, "set -C") {
+		t.Fatalf("script missing noclobber exclusive write: %s", script)
+	}
+	if !strings.Contains(script, "base64 -d") {
+		t.Fatalf("script missing base64 decode: %s", script)
+	}
+}
+
+func TestValidateCursorProjectKey_RejectsTraversal(t *testing.T) {
+	if err := validateCursorProjectKey("Users-me-my.repo"); err != nil {
+		t.Fatalf("dots in key should be allowed: %v", err)
+	}
+	if err := validateCursorProjectKey("Users-me-My Project"); err != nil {
+		t.Fatalf("spaces in key should be allowed: %v", err)
+	}
+	if err := validateCursorProjectKey(".."); err == nil {
+		t.Fatal("expected .. to be rejected")
+	}
+	if err := validateCursorProjectKey("foo/bar"); err == nil {
+		t.Fatal("expected path separators to be rejected")
+	}
+}
+
+func TestValidateCursorTrustPathContained(t *testing.T) {
+	configDir := filepath.Join(t.TempDir(), ".cursor")
+	trustPath := filepath.Join(configDir, "projects", "Users-me-proj", ".workspace-trusted")
+	if err := validateCursorTrustPathContained(configDir, trustPath); err != nil {
+		t.Fatalf("expected contained path to pass: %v", err)
+	}
+	outside := filepath.Join(t.TempDir(), "outside", ".workspace-trusted")
+	if err := validateCursorTrustPathContained(configDir, outside); err == nil {
+		t.Fatal("expected path outside cursor config dir to be rejected")
+	}
+}
+
+func TestPreAcceptCursorTrustInContainer_RejectsUnmanagedName(t *testing.T) {
+	err := PreAcceptCursorTrustInContainer("evil-container", cursorSandboxWorkDir)
+	if err == nil {
+		t.Fatal("expected unmanaged container name to be rejected")
+	}
+}
+
+func TestPreAcceptCursorTrustInContainer_RejectsWrongWorkspace(t *testing.T) {
+	err := PreAcceptCursorTrustInContainer("agent-deck-test-12345678", "/host/path")
+	if err == nil {
+		t.Fatal("expected non-sandbox workspace path to be rejected")
+	}
+}
+
+func TestCursorTrustContainerScript_UsesPOSIXPath(t *testing.T) {
+	content, absWorkspace, err := cursorTrustEntryJSON(cursorSandboxWorkDir)
+	if err != nil {
+		t.Fatalf("cursorTrustEntryJSON: %v", err)
+	}
+	key, err := cursorWorkspaceProjectKey(absWorkspace)
+	if err != nil {
+		t.Fatalf("cursorWorkspaceProjectKey: %v", err)
+	}
+	trustPath := cursorSandboxHome + "/.cursor/projects/" + key + "/.workspace-trusted"
+	script := buildCursorTrustRemoteShellScript("path="+shellQuote(trustPath), content)
+	if !strings.Contains(script, "path='"+trustPath+"'") {
+		t.Fatalf("script missing POSIX container trust path %q:\n%s", trustPath, script)
+	}
+	if strings.Contains(script, `\`) {
+		t.Fatalf("container script must not use host path separators:\n%s", script)
+	}
+}
+
+func TestInstance_Start_CursorSeedsWorkspaceTrust(t *testing.T) {
+	skipIfNoTmuxServer(t)
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	workspace := filepath.Join(tmpHome, "my.repo")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	inst := NewInstanceWithTool("cursor-start-trust", workspace, "cursor")
+	inst.Command = "/bin/true"
+	if err := inst.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = inst.Kill() }()
+
+	trustPath, _, err := cursorWorkspaceTrustPath(GetCursorConfigDir(), workspace)
+	if err != nil {
+		t.Fatalf("cursorWorkspaceTrustPath: %v", err)
+	}
+	if _, err := os.Stat(trustPath); err != nil {
+		t.Fatalf("trust file missing after Start: %v", err)
+	}
+}

--- a/internal/session/cursor_trust_test.go
+++ b/internal/session/cursor_trust_test.go
@@ -3,11 +3,19 @@ package session
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 )
+
+func runShellScriptForTest(script string) (string, error) {
+	cmd := exec.Command("sh", "-s")
+	cmd.Stdin = strings.NewReader(script)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
 
 func TestCursorWorkspaceProjectKey(t *testing.T) {
 	workspace := filepath.Join("/Users", "me", "dev", "agent-deck")
@@ -191,17 +199,210 @@ func TestInstance_cursorTrustWorkspacePath(t *testing.T) {
 	}
 }
 
+func TestInstance_cursorTrustWorkspacePath_SandboxTakesPrecedenceOverSSH(t *testing.T) {
+	inst := NewInstanceWithTool("x", "/host/proj", "cursor")
+	inst.SSHHost = "user@remote"
+	inst.SSHRemotePath = "/remote/proj"
+	inst.Sandbox = NewSandboxConfig("")
+	inst.SandboxContainer = "agent-deck-test-12345678"
+
+	if got := inst.cursorTrustWorkspacePath(); got != cursorSandboxWorkDir {
+		t.Fatalf("workspace path = %q, want sandbox %s", got, cursorSandboxWorkDir)
+	}
+}
+
+func TestInstance_preAcceptCursorWorkspaceTrust_SandboxTakesPrecedenceOverSSH(t *testing.T) {
+	fakeBin := t.TempDir()
+	capturedDockerScript := filepath.Join(t.TempDir(), "docker-script.sh")
+	sshMarker := filepath.Join(t.TempDir(), "ssh-called")
+
+	if err := os.WriteFile(filepath.Join(fakeBin, "docker"), []byte(`#!/bin/sh
+set -eu
+if [ "$1" != "exec" ] || [ "$2" != "-i" ]; then
+  echo "unexpected docker args: $*" >&2
+  exit 20
+fi
+cat > "$FAKE_DOCKER_SCRIPT"
+`), 0o755); err != nil {
+		t.Fatalf("write fake docker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fakeBin, "ssh"), []byte(`#!/bin/sh
+echo called > "$FAKE_SSH_MARKER"
+exit 99
+`), 0o755); err != nil {
+		t.Fatalf("write fake ssh: %v", err)
+	}
+
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_DOCKER_SCRIPT", capturedDockerScript)
+	t.Setenv("FAKE_SSH_MARKER", sshMarker)
+
+	inst := NewInstanceWithTool("x", "/host/proj", "cursor")
+	inst.SSHHost = "user@remote"
+	inst.SSHRemotePath = "/remote/proj"
+	inst.Sandbox = NewSandboxConfig("")
+	inst.SandboxContainer = "agent-deck-test-12345678"
+
+	inst.preAcceptCursorWorkspaceTrust()
+
+	script, err := os.ReadFile(capturedDockerScript)
+	if err != nil {
+		t.Fatalf("docker script was not captured: %v", err)
+	}
+	if !strings.Contains(string(script), cursorSandboxHome+"/.cursor/projects/") {
+		t.Fatalf("docker script did not target sandbox cursor home:\n%s", script)
+	}
+	if _, err := os.Stat(sshMarker); !os.IsNotExist(err) {
+		t.Fatalf("ssh path was invoked for sandboxed session; stat marker err=%v", err)
+	}
+}
+
 func TestBuildCursorTrustRemoteShellScript_ExpandsHome(t *testing.T) {
 	pathSetup := "key='foo'\npath=\"$HOME/.cursor/projects/$key/.workspace-trusted\""
 	script := buildCursorTrustRemoteShellScript(pathSetup, []byte("data\n"))
 	if !strings.Contains(script, `path="$HOME/.cursor/projects/$key/.workspace-trusted"`) {
 		t.Fatalf("script missing HOME path expansion: %s", script)
 	}
-	if !strings.Contains(script, "set -C") {
-		t.Fatalf("script missing noclobber exclusive write: %s", script)
+	if !strings.Contains(script, "mktemp") || !strings.Contains(script, `ln "$tmp" "$path"`) {
+		t.Fatalf("script missing temp-file exclusive link: %s", script)
 	}
 	if !strings.Contains(script, "base64 -d") {
 		t.Fatalf("script missing base64 decode: %s", script)
+	}
+}
+
+func TestBuildCursorTrustRemoteShellScript_WritesWithoutClobber(t *testing.T) {
+	remoteHome := t.TempDir()
+	trustPath := filepath.Join(remoteHome, ".cursor", "projects", "foo", ".workspace-trusted")
+	script := buildCursorTrustRemoteShellScript("path="+shellQuote(trustPath), []byte("created\n"))
+
+	if out, err := runShellScriptForTest(script); err != nil {
+		t.Fatalf("script failed: %v: %s", err, out)
+	}
+	data, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read trust file: %v", err)
+	}
+	if string(data) != "created\n" {
+		t.Fatalf("trust content = %q, want created", data)
+	}
+
+	if out, err := runShellScriptForTest(buildCursorTrustRemoteShellScript("path="+shellQuote(trustPath), []byte("overwrite\n"))); err != nil {
+		t.Fatalf("second script failed: %v: %s", err, out)
+	}
+	after, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read trust file after second script: %v", err)
+	}
+	if string(after) != "created\n" {
+		t.Fatalf("trust content after second script = %q, want original", after)
+	}
+}
+
+func TestBuildCursorTrustRemoteShellScript_PropagatesRealWriteErrors(t *testing.T) {
+	parentFile := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(parentFile, []byte("file\n"), 0o644); err != nil {
+		t.Fatalf("write parent file: %v", err)
+	}
+	trustPath := filepath.Join(parentFile, ".workspace-trusted")
+	script := buildCursorTrustRemoteShellScript("path="+shellQuote(trustPath), []byte("data\n"))
+
+	if out, err := runShellScriptForTest(script); err == nil {
+		t.Fatalf("script succeeded unexpectedly: %s", out)
+	}
+}
+
+func TestPreAcceptCursorTrustSSH_UsesRemoteHomeAndWorkspace(t *testing.T) {
+	fakeBin := t.TempDir()
+	remoteHome := t.TempDir()
+	workspace := "/remote/My Project"
+	fakeSSH := filepath.Join(fakeBin, "ssh")
+	if err := os.WriteFile(fakeSSH, []byte(`#!/bin/sh
+set -eu
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+host="$1"
+shift
+if [ "$host" != "user@remote" ]; then
+  echo "unexpected host: $host" >&2
+  exit 20
+fi
+if [ "$1" != "sh" ] || [ "$2" != "-s" ]; then
+  echo "unexpected remote command: $*" >&2
+  exit 21
+fi
+export HOME="$FAKE_REMOTE_HOME"
+exec sh -s
+`), 0o755); err != nil {
+		t.Fatalf("write fake ssh: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_REMOTE_HOME", remoteHome)
+
+	if err := PreAcceptCursorTrustSSH("user@remote", workspace); err != nil {
+		t.Fatalf("PreAcceptCursorTrustSSH: %v", err)
+	}
+
+	key, err := cursorWorkspaceProjectKey(workspace)
+	if err != nil {
+		t.Fatalf("cursorWorkspaceProjectKey: %v", err)
+	}
+	trustPath := filepath.Join(remoteHome, ".cursor", "projects", key, ".workspace-trusted")
+	data, err := os.ReadFile(trustPath)
+	if err != nil {
+		t.Fatalf("read remote trust file: %v", err)
+	}
+	var entry map[string]string
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("unmarshal remote trust file: %v", err)
+	}
+	if entry["workspacePath"] != workspace {
+		t.Fatalf("workspacePath = %q, want %q", entry["workspacePath"], workspace)
+	}
+}
+
+func TestPreAcceptCursorTrustSSH_PropagatesRemoteWriteError(t *testing.T) {
+	fakeBin := t.TempDir()
+	remoteHome := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(remoteHome, []byte("file\n"), 0o644); err != nil {
+		t.Fatalf("write fake remote home: %v", err)
+	}
+	fakeSSH := filepath.Join(fakeBin, "ssh")
+	if err := os.WriteFile(fakeSSH, []byte(`#!/bin/sh
+set -eu
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+shift
+if [ "$1" != "sh" ] || [ "$2" != "-s" ]; then
+  echo "unexpected remote command: $*" >&2
+  exit 21
+fi
+export HOME="$FAKE_REMOTE_HOME"
+exec sh -s
+`), 0o755); err != nil {
+		t.Fatalf("write fake ssh: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FAKE_REMOTE_HOME", remoteHome)
+
+	if err := PreAcceptCursorTrustSSH("user@remote", "/remote/project"); err == nil {
+		t.Fatal("PreAcceptCursorTrustSSH succeeded despite remote write error")
 	}
 }
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1636,6 +1636,48 @@ func (i *Instance) consumeForkStartCommand() string {
 	return command
 }
 
+// cursorTrustWorkspacePath returns the workspace path Cursor should trust for
+// this instance: container /workspace for sandboxes, SSHRemotePath for remote
+// sessions, otherwise the effective local working directory.
+func (i *Instance) cursorTrustWorkspacePath() string {
+	if i.IsSandboxed() {
+		return cursorSandboxWorkDir
+	}
+	if i.IsSSH() && i.SSHRemotePath != "" {
+		return i.SSHRemotePath
+	}
+	return i.EffectiveWorkingDir()
+}
+
+// preAcceptCursorWorkspaceTrust seeds Cursor workspace trust for the session's
+// workspace so interactive launches skip the trust prompt. Local, SSH, and
+// sandbox sessions each write trust where Cursor will read it. Failures are
+// logged and non-fatal.
+func (i *Instance) preAcceptCursorWorkspaceTrust() {
+	if i.Tool != "cursor" {
+		return
+	}
+	dir := i.cursorTrustWorkspacePath()
+	if dir == "" {
+		return
+	}
+	var err error
+	switch {
+	case i.IsSSH():
+		err = PreAcceptCursorTrustSSH(i.SSHHost, dir)
+	case i.IsSandboxed() && i.SandboxContainer != "":
+		err = PreAcceptCursorTrustInContainer(i.SandboxContainer, dir)
+	default:
+		err = PreAcceptCursorTrust(GetCursorConfigDir(), dir)
+	}
+	if err != nil {
+		sessionLog.Warn("cursor_preaccept_trust_failed",
+			slog.String("instance_id", i.ID),
+			slog.String("dir", dir),
+			slog.String("error", err.Error()))
+	}
+}
+
 // buildCursorCommand builds the command for the Cursor CLI (`cursor agent`).
 // continuePrev adds --continue so Restart resumes the previous chat in the workspace.
 // Env files from [shell].env_files are applied via buildEnvSourceCommand.
@@ -3196,6 +3238,8 @@ func (i *Instance) Start() error {
 	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
 	i.applyLaunchSettingsFromConfig()
 
+	i.preAcceptCursorWorkspaceTrust()
+
 	// Start the tmux session
 	if err := i.tmuxSession.Start(command); err != nil {
 		return fmt.Errorf("failed to start tmux session: %w", err)
@@ -3436,6 +3480,8 @@ func (i *Instance) StartWithMessage(message string) error {
 	i.tmuxSession.OptionOverrides = i.buildTmuxOptionOverrides()
 	i.tmuxSession.RunCommandAsInitialProcess = i.IsSandboxed() || i.Tool != "shell"
 	i.applyLaunchSettingsFromConfig()
+
+	i.preAcceptCursorWorkspaceTrust()
 
 	// Start the tmux session
 	if err := i.tmuxSession.Start(command); err != nil {

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -1663,10 +1663,10 @@ func (i *Instance) preAcceptCursorWorkspaceTrust() {
 	}
 	var err error
 	switch {
-	case i.IsSSH():
-		err = PreAcceptCursorTrustSSH(i.SSHHost, dir)
 	case i.IsSandboxed() && i.SandboxContainer != "":
 		err = PreAcceptCursorTrustInContainer(i.SandboxContainer, dir)
+	case i.IsSSH():
+		err = PreAcceptCursorTrustSSH(i.SSHHost, dir)
 	default:
 		err = PreAcceptCursorTrust(GetCursorConfigDir(), dir)
 	}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -769,13 +769,7 @@ func (r *SSHRunner) InstallBinary(ctx context.Context, binaryData []byte, expect
 //
 // See the README "Remote Instances" section for the documented assumption.
 func (r *SSHRunner) sshConnOpts() []string {
-	return []string{
-		"-o", "ControlMaster=auto",
-		"-o", "ControlPath=" + sshControlDir + "/%r@%h:%p",
-		"-o", "ControlPersist=600",
-		"-o", "ConnectTimeout=10",
-		"-o", "BatchMode=yes",
-	}
+	return sessionSSHConnOpts()
 }
 
 // ValidateSSHHost rejects host strings ssh would misinterpret as options rather


### PR DESCRIPTION
Cursor stores trust in ~/.cursor/projects/<key>/.workspace-trusted. Seed that file from EffectiveWorkingDir() before tmux launch so conductor-spawned interactive sessions skip the trust prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Cursor “workspace trust” pre-configuration during session startup for local workspaces, SSH targets, and managed container environments to reduce first-time trust prompts.
  * Implemented deterministic trust key generation, trust-file creation, and exclusive remote/container writing behavior to avoid clobbering.
  * Pre-accept trust seeding runs just before session start and failures are logged as warnings without blocking startup.
* **Tests**
  * Added extensive coverage for key/path normalization, validation, idempotency, exclusive/concurrent writes, and remote/container script behavior.
* **Refactor**
  * Centralized shared SSH connection options for consistent SSH behavior across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->