### PR TITLE
fix(web): SSE streams accept query token for headless --token deployments

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -23,6 +23,17 @@ func (s *Server) authorizeWSRequest(r *http.Request) bool {
 	return s.authorize(r, true)
 }
 
+// authorizeStreamRequest authorizes an SSE stream request. Like the WebSocket
+// upgrade, an EventSource cannot set an Authorization header, so the token is
+// also accepted via the query string here. This mirrors authorizeWSRequest and
+// is the documented SSE exception to the header-only rule (report #5): the
+// affected pages set Referrer-Policy: no-referrer. JSON API endpoints stay on
+// header-only authorizeRequest. Loopback/no-token behavior is unchanged; a
+// bad or missing token still 401s.
+func (s *Server) authorizeStreamRequest(r *http.Request) bool {
+	return s.authorize(r, true)
+}
+
 func (s *Server) authorize(r *http.Request, allowQueryToken bool) bool {
 	if s.cfg.Token == "" {
 		return true

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -1,0 +1,103 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// SSE streams (EventSource) cannot set an Authorization header, so the menu and
+// command-center event streams must accept the token via the query string —
+// exactly like the WS upgrade. A bad or missing token still 401s, and the JSON
+// API endpoints stay header-only (query token rejected). Regression for the
+// v1.9.68/69 headless --token bug: header-only SSE handlers 401'd EventSource,
+// so the web menu + Command Center never loaded over Tailscale.
+//
+// For the *accepted* cases the handler passes the auth gate and then enters its
+// long-lived streaming loop (for { select { <-ctx.Done() ... } }). We give those
+// requests an already-cancelled context so the handler writes the initial
+// snapshot and returns immediately instead of blocking the test. The only thing
+// asserted for accepted cases is that the response is NOT 401.
+
+// cancelledRequest builds a GET request whose context is already cancelled, so
+// an authorized SSE handler exits its stream loop right after the first emit.
+func cancelledRequest(target string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	cancel()
+	return req.WithContext(ctx)
+}
+
+func TestSSE_QueryTokenAcceptedOnMenuEvents(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", Token: "secret"})
+
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, cancelledRequest("/events/menu?token=secret"))
+
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatalf("SSE /events/menu with query-string token should be authorized (not 401), got %d", rr.Code)
+	}
+}
+
+func TestSSE_QueryTokenAcceptedOnCommandCenterEvents(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", Token: "secret"})
+
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, cancelledRequest("/events/command-center?token=secret"))
+
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatalf("SSE /events/command-center with query-string token should be authorized (not 401), got %d", rr.Code)
+	}
+}
+
+func TestSSE_HeaderTokenAcceptedOnMenuEvents(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", Token: "secret"})
+
+	req := cancelledRequest("/events/menu")
+	req.Header.Set("Authorization", "Bearer secret")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatalf("SSE /events/menu with a valid header token should be authorized (not 401), got %d", rr.Code)
+	}
+}
+
+func TestSSE_BadQueryTokenRejectedOnMenuEvents(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", Token: "secret"})
+
+	req := httptest.NewRequest(http.MethodGet, "/events/menu?token=wrong", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("SSE /events/menu with a bad query token must be rejected (401), got %d", rr.Code)
+	}
+}
+
+func TestSSE_MissingTokenRejectedOnMenuEvents(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", Token: "secret"})
+
+	req := httptest.NewRequest(http.MethodGet, "/events/menu", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("SSE /events/menu with no token must be rejected (401), got %d", rr.Code)
+	}
+}
+
+// Guard: the SSE exception must NOT leak to the JSON API. The command-center
+// JSON status endpoint stays header-only — a query-string token is rejected.
+func TestSSE_CommandCenterJSONStaysHeaderOnly(t *testing.T) {
+	srv := NewServer(Config{ListenAddr: "127.0.0.1:0", Token: "secret"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/command-center/status?token=secret", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("JSON /api/command-center/status with query-string token should be rejected (401), got %d", rr.Code)
+	}
+}

--- a/internal/web/handlers_command_center.go
+++ b/internal/web/handlers_command_center.go
@@ -166,7 +166,7 @@ func (s *Server) handleCommandCenterEvents(w http.ResponseWriter, r *http.Reques
 		writeAPIError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
 		return
 	}
-	if !s.authorizeRequest(r) {
+	if !s.authorizeStreamRequest(r) {
 		writeAPIError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized")
 		return
 	}

--- a/internal/web/handlers_events.go
+++ b/internal/web/handlers_events.go
@@ -22,7 +22,7 @@ func (s *Server) handleMenuEvents(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
 		return
 	}
-	if !s.authorizeRequest(r) {
+	if !s.authorizeStreamRequest(r) {
 		writeAPIError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized")
 		return
 	}


### PR DESCRIPTION
## Problem

In headless `--token` mode (v1.9.68/69), the menu and Command Center SSE
streams were authorized header-only. EventSource cannot set an
`Authorization` header, so the browser's stream connection got a 401 and the
web menu + Command Center snapshot never loaded over Tailscale. The page
appeared blank/stuck for any non-loopback `--token` deployment.

## Fix

- Add `authorizeStreamRequest()` in `internal/web/auth.go` — accepts the token
  via query param **in addition** to header, mirroring the existing
  `authorizeWSRequest` (browsers can't set headers on WS/SSE either).
- `handleMenuEvents` (`/events/menu`) and `handleCommandCenterEvents`
  (`/events/command-center`) now use `authorizeStreamRequest`.
- JSON API endpoints stay on header-only `authorizeRequest`
  (`/api/command-center/status`, `/api/command-center/ask`, all `/api/*`):
  query-token secrets must not leak to logs/history/proxies on the API.

Loopback/no-token behavior is unchanged. A bad or missing token still 401s.

## Tests

`internal/web/auth_test.go` regression suite:
- query-token -> not 401 on both SSE streams
- header-token -> not 401 on SSE
- bad token / missing token -> 401 on SSE
- guard: `/api/command-center/status` with a query token -> 401 (JSON API
  stays header-only)

Verified fails-without / passes-with the fix. Existing `TestAuth_*` security
tests still pass (header-only API + WS query-token exception preserved).

This is the SSE auth fix only — no v2 command-center feature code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Server-Sent Events (SSE) authentication for menu and command-center event streams to properly support query string authentication, enabling reliable real-time event subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->