### PR TITLE
fix(tmux): keep live control pipes only for active sessions

### DIFF
--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -473,6 +473,22 @@ func (pm *PipeManager) watchPipe(sessionName string, pipe *ControlPipe) {
 		case <-time.After(backoff):
 		}
 
+		// Wantedness can flip during backoff (the session fell out of the live
+		// set, or was intentionally disconnected). Re-check before reconnecting:
+		// otherwise pm.Connect silently no-ops on an unwanted session, returns
+		// nil, and we'd log a phantom "reconnected" while leaving the dead pipe
+		// entry in the map. Prune it and stop instead.
+		pm.mu.RLock()
+		loopWantFn := pm.wantPipe
+		pm.mu.RUnlock()
+		if !wantsReconnect(loopWantFn, sessionName) {
+			pipeLog.Debug("pipe_not_wanted_skipping_reconnect", slog.String("session", sessionName))
+			pm.mu.Lock()
+			delete(pm.pipes, sessionName)
+			pm.mu.Unlock()
+			return
+		}
+
 		// Check if session still exists before trying to reconnect.
 		// Avoids infinite reconnect loops for deleted/non-existent sessions.
 		// Target the same socket the original pipe lived on — checking the

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -29,6 +29,11 @@ type PipeManager struct {
 	// Callback for window change events (invoked when %window-add or %window-close detected)
 	onWindowChange func()
 
+	// wantPipe, when non-nil, gates which sessions may hold a live pipe.
+	// Connect and watchPipe consult it so background sessions are never
+	// connected or auto-reconnected. nil = legacy behaviour (want everything).
+	wantPipe func(sessionName string) bool
+
 	// Reconnection tracking
 	reconnectMu  sync.Mutex
 	reconnecting map[string]bool
@@ -58,6 +63,13 @@ func NewPipeManager(ctx context.Context, onOutput func(sessionName string)) *Pip
 // by socketName (Session.SocketName). Pass "" to target the user's default
 // server. Safe to call repeatedly; a live pipe short-circuits and returns nil.
 func (pm *PipeManager) Connect(sessionName, socketName string) error {
+	// Background sessions are not wanted — connecting them is what scaled pipe
+	// count to instances×sessions. Silent no-op so existing callers (startup
+	// loop, new-session hook, reviver, sweep) need no per-call gating.
+	if !pm.wants(sessionName) {
+		return nil
+	}
+
 	pm.mu.Lock()
 
 	// Already connected and alive?
@@ -328,6 +340,36 @@ func (pm *PipeManager) Close() {
 // Must be called before Connect to ensure all pipes forward events.
 func (pm *PipeManager) SetWindowChangeCallback(cb func()) {
 	pm.onWindowChange = cb
+}
+
+// SetWantPipe installs the predicate that decides which sessions hold a live
+// pipe. Call once at startup before Connect. nil-safe: an unset predicate means
+// every session is wanted (legacy behaviour).
+func (pm *PipeManager) SetWantPipe(fn func(sessionName string) bool) {
+	pm.mu.Lock()
+	pm.wantPipe = fn
+	pm.mu.Unlock()
+}
+
+// wants reports whether sessionName is currently wanted. nil predicate => true.
+func (pm *PipeManager) wants(sessionName string) bool {
+	pm.mu.RLock()
+	fn := pm.wantPipe
+	pm.mu.RUnlock()
+	return fn == nil || fn(sessionName)
+}
+
+// ConnectedSessions returns the names of sessions with an alive pipe.
+func (pm *PipeManager) ConnectedSessions() []string {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+	out := make([]string, 0, len(pm.pipes))
+	for name, p := range pm.pipes {
+		if p.IsAlive() {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 // forwardOutputEvents reads from a pipe's output and window events channels

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -21,7 +21,7 @@ import (
 // Falls back to subprocess execution when pipes are unavailable.
 type PipeManager struct {
 	pipes map[string]*ControlPipe // sessionName -> pipe
-	mu    sync.RWMutex
+	mu    sync.RWMutex            // protects pipes and wantPipe
 
 	// Callback for output events (invoked when %output detected from a session)
 	onOutput func(sessionName string)
@@ -413,6 +413,14 @@ func shouldConcludeSessionGone(probeFoundSession bool, attempt, maxRetries int) 
 	return attempt >= maxRetries-1
 }
 
+// wantsReconnect reports whether a dead pipe for sessionName should be
+// reconnected. nil predicate => yes (legacy). A false result means the session
+// fell out of the live set (intentional Disconnect, or a background pipe died)
+// and must stay gone.
+func wantsReconnect(wantPipe func(string) bool, sessionName string) bool {
+	return wantPipe == nil || wantPipe(sessionName)
+}
+
 // watchPipe monitors a pipe and attempts reconnection when it dies.
 // Uses exponential backoff: 2s, 4s, 8s, 16s, 30s max.
 // Stops retrying if the tmux session no longer exists.
@@ -425,6 +433,19 @@ func (pm *PipeManager) watchPipe(sessionName string, pipe *ControlPipe) {
 	}
 
 	pipeLog.Debug("pipe_died_scheduling_reconnect", slog.String("session", sessionName))
+
+	// If the session is no longer wanted (intentional Disconnect, or a
+	// background pipe that died), do not resurrect it.
+	pm.mu.RLock()
+	wantFn := pm.wantPipe
+	pm.mu.RUnlock()
+	if !wantsReconnect(wantFn, sessionName) {
+		pipeLog.Debug("pipe_not_wanted_skipping_reconnect", slog.String("session", sessionName))
+		pm.mu.Lock()
+		delete(pm.pipes, sessionName)
+		pm.mu.Unlock()
+		return
+	}
 
 	// Check if already reconnecting
 	pm.reconnectMu.Lock()

--- a/internal/tmux/pipemanager_wantpipe_test.go
+++ b/internal/tmux/pipemanager_wantpipe_test.go
@@ -1,0 +1,63 @@
+package tmux
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// waitFor polls cond up to d, returning true once it holds.
+func waitFor(d time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return cond()
+}
+
+func TestPipeManager_WantPipeGatesConnect(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	allowed := createTestSessionStrict(t, "allowed")
+	denied := createTestSessionStrict(t, "denied")
+
+	pm := NewPipeManager(context.Background(), nil)
+	defer pm.Close()
+	pm.SetWantPipe(func(name string) bool { return name == allowed })
+
+	if err := pm.Connect(allowed, ""); err != nil {
+		t.Fatalf("connect allowed: %v", err)
+	}
+	// Connect on a denied session must be a silent no-op (no pipe created).
+	if err := pm.Connect(denied, ""); err != nil {
+		t.Fatalf("connect denied returned error (want nil no-op): %v", err)
+	}
+
+	if !waitFor(2*time.Second, func() bool { return pm.IsConnected(allowed) }) {
+		t.Fatal("allowed session should be connected")
+	}
+	if pm.IsConnected(denied) {
+		t.Fatal("denied session must not be connected")
+	}
+
+	got := pm.ConnectedSessions()
+	if len(got) != 1 || got[0] != allowed {
+		t.Fatalf("ConnectedSessions = %v, want [%s]", got, allowed)
+	}
+}
+
+func TestPipeManager_NilWantPipeConnectsAll(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	s := createTestSessionStrict(t, "nilwant")
+	pm := NewPipeManager(context.Background(), nil)
+	defer pm.Close()
+	// No SetWantPipe call: nil predicate = legacy "connect everything".
+	if err := pm.Connect(s, ""); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if !waitFor(2*time.Second, func() bool { return pm.IsConnected(s) }) {
+		t.Fatal("with nil wantPipe, connect must work as before")
+	}
+}

--- a/internal/tmux/pipemanager_wantpipe_test.go
+++ b/internal/tmux/pipemanager_wantpipe_test.go
@@ -61,3 +61,16 @@ func TestPipeManager_NilWantPipeConnectsAll(t *testing.T) {
 		t.Fatal("with nil wantPipe, connect must work as before")
 	}
 }
+
+func TestWantsReconnect(t *testing.T) {
+	if !wantsReconnect(nil, "x") {
+		t.Fatal("nil predicate must allow reconnect (legacy)")
+	}
+	allow := func(n string) bool { return n == "keep" }
+	if !wantsReconnect(allow, "keep") {
+		t.Fatal("wanted session should reconnect")
+	}
+	if wantsReconnect(allow, "drop") {
+		t.Fatal("unwanted session must not reconnect")
+	}
+}

--- a/internal/tmux/pipemanager_wantpipe_test.go
+++ b/internal/tmux/pipemanager_wantpipe_test.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -72,5 +73,52 @@ func TestWantsReconnect(t *testing.T) {
 	}
 	if wantsReconnect(allow, "drop") {
 		t.Fatal("unwanted session must not reconnect")
+	}
+}
+
+func TestPipeManager_ReconcileKeepsOnlyLiveSet(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	const k = 4
+	names := make([]string, k)
+	for i := range names {
+		names[i] = createTestSessionStrict(t, fmt.Sprintf("liveset%d", i))
+	}
+
+	pm := NewPipeManager(context.Background(), nil)
+	defer pm.Close()
+
+	// live set = only names[1]
+	live := names[1]
+	pm.SetWantPipe(func(n string) bool { return n == live })
+
+	// Connect-all: the gate ensures only `live` actually attaches a pipe.
+	for _, n := range names {
+		_ = pm.Connect(n, "")
+	}
+
+	if !waitFor(2*time.Second, func() bool { return pm.IsConnected(live) }) {
+		t.Fatalf("live session %s should be connected", live)
+	}
+	got := pm.ConnectedSessions()
+	if len(got) != 1 || got[0] != live {
+		t.Fatalf("only the live session should hold a pipe; got %v", got)
+	}
+
+	// Move the live set to names[2]: connect the new one, disconnect the old.
+	live2 := names[2]
+	pm.SetWantPipe(func(n string) bool { return n == live2 })
+	_ = pm.Connect(live2, "")
+	pm.Disconnect(live) // old one leaves the set
+
+	if !waitFor(2*time.Second, func() bool {
+		return pm.IsConnected(live2) && !pm.IsConnected(live)
+	}) {
+		t.Fatalf("after move: want only %s connected, got %v", live2, pm.ConnectedSessions())
+	}
+
+	// Critical: the disconnected pipe must NOT be auto-reconnected by watchPipe
+	// (it is no longer wanted). watchPipe's first backoff is ~2s; give it 3s.
+	if waitFor(3*time.Second, func() bool { return pm.IsConnected(live) }) {
+		t.Fatal("disconnected session was resurrected by watchPipe; wantPipe gate failed")
 	}
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -4992,11 +4992,52 @@ func RefreshStatusBarImmediate() error {
 	return nil
 }
 
-// GetAttachedSessions returns the names of tmux sessions that have real clients attached.
-// Used to detect which session the user is currently viewing.
-// Filters out control mode clients (from PipeManager) which are not real user sessions.
+// GetAttachedSessions returns the names of tmux sessions that have real clients
+// attached on the default socket. Used to detect which session the user is
+// currently viewing. Filters out control mode clients (from PipeManager) which
+// are not real user sessions.
 func GetAttachedSessions() ([]string, error) {
-	cmd := tmuxExec(DefaultSocketName(), "list-clients", "-F", "#{session_name}\t#{client_control_mode}")
+	return attachedSessionsOnSocket(DefaultSocketName())
+}
+
+// GetAttachedSessionsOnSockets returns the union of attached (non-control)
+// session names across the given sockets. The default socket is always
+// consulted, then each distinct extra socket; "" denotes the default socket.
+// Sockets with no running server (or any list-clients error) are skipped
+// silently. Order is unspecified and duplicates are removed.
+//
+// This is the socket-aware counterpart to GetAttachedSessions: a session
+// attached on an isolated agent-deck socket (TmuxSocketName != "") is invisible
+// to a default-socket-only query, so callers that must pin every attached
+// session regardless of socket use this instead.
+func GetAttachedSessionsOnSockets(sockets ...string) []string {
+	socketSeen := make(map[string]bool, len(sockets)+1)
+	nameSeen := map[string]bool{}
+	var out []string
+	for _, sock := range append([]string{DefaultSocketName()}, sockets...) {
+		sock = strings.TrimSpace(sock)
+		if socketSeen[sock] {
+			continue
+		}
+		socketSeen[sock] = true
+		names, err := attachedSessionsOnSocket(sock)
+		if err != nil {
+			continue
+		}
+		for _, n := range names {
+			if !nameSeen[n] {
+				nameSeen[n] = true
+				out = append(out, n)
+			}
+		}
+	}
+	return out
+}
+
+// attachedSessionsOnSocket lists the non-control-mode sessions with a client
+// attached on a single tmux socket ("" = default server).
+func attachedSessionsOnSocket(socket string) ([]string, error) {
+	cmd := tmuxExec(socket, "list-clients", "-F", "#{session_name}\t#{client_control_mode}")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2234,42 +2234,6 @@ func (h *Home) getAttachedSessionID() string {
 	return ""
 }
 
-// getAttachedSessionName returns the tmux session name of the currently
-// attached agentdeck session (the name, not the instance ID), or "".
-// NOTE: GetAttachedSessions only queries the default tmux socket, so a session
-// living on an isolated agent-deck socket won't be detected as attached here.
-// Such a session is still kept live once focused (via the LRU), so the only
-// effect is the attached-pin guarantee not applying to non-default sockets.
-func (h *Home) getAttachedSessionName() string {
-	attached, err := tmux.GetAttachedSessions()
-	if err != nil || len(attached) == 0 {
-		return ""
-	}
-	h.instancesMu.RLock()
-	defer h.instancesMu.RUnlock()
-	for _, sessName := range attached {
-		for _, inst := range h.instances {
-			if ts := inst.GetTmuxSession(); ts != nil && ts.Name == sessName {
-				return ts.Name
-			}
-		}
-	}
-	return ""
-}
-
-// socketForSession returns the tmux -L socket selector for a session name, or
-// "" (default server) if unknown.
-func (h *Home) socketForSession(name string) string {
-	h.instancesMu.RLock()
-	defer h.instancesMu.RUnlock()
-	for _, inst := range h.instances {
-		if ts := inst.GetTmuxSession(); ts != nil && ts.Name == name {
-			return inst.TmuxSocketName
-		}
-	}
-	return ""
-}
-
 // recordFocusedSession snapshots the cursor-selected session name for the
 // reconciler goroutine. Must run on the main (Update) goroutine — getSelected-
 // Session reads h.cursor/h.flatItems without a lock.
@@ -2285,21 +2249,46 @@ func (h *Home) recordFocusedSession() {
 	h.focusMu.Unlock()
 }
 
-// reconcileLivePipes refreshes the live set from the current focus + attach and
-// syncs the PipeManager's pipes to match.
+// reconcileLivePipes refreshes the live set from the current focus + the set of
+// attached sessions, then syncs the PipeManager's pipes to match.
+//
+// The desired set is resolved against the current instances (name -> socket),
+// which makes three things correct at once:
+//   - each session connects on its REAL socket, not a guessed default;
+//   - names with no live instance (deleted/restarted sessions) are dropped
+//     instead of being retried on every tick;
+//   - attached sessions are pinned across EVERY socket in use, so an attached
+//     session on an isolated socket keeps its live pipe rather than being
+//     evicted to the 2s status poll.
 func (h *Home) reconcileLivePipes() {
 	pm := tmux.GetPipeManager()
 	if pm == nil {
 		return
 	}
+
+	// Snapshot live instances: session name -> socket (the source of truth).
+	h.instancesMu.RLock()
+	socketByName := make(map[string]string, len(h.instances))
+	sockets := make([]string, 0, len(h.instances))
+	socketSeen := make(map[string]bool, len(h.instances))
+	for _, inst := range h.instances {
+		if ts := inst.GetTmuxSession(); ts != nil {
+			socketByName[ts.Name] = inst.TmuxSocketName
+			if !socketSeen[inst.TmuxSocketName] {
+				socketSeen[inst.TmuxSocketName] = true
+				sockets = append(sockets, inst.TmuxSocketName)
+			}
+		}
+	}
+	h.instancesMu.RUnlock()
+
 	h.focusMu.Lock()
 	focused := h.focusedSessionName
 	h.focusMu.Unlock()
 
-	h.liveSet.touch(focused)
-	h.liveSet.setAttached(h.getAttachedSessionName())
-
-	reconcilePipes(pm, h.liveSet.members(), h.socketForSession)
+	attached := tmux.GetAttachedSessionsOnSockets(sockets...)
+	desired := desiredLivePipes(h.liveSet, focused, attached, socketByName)
+	reconcilePipes(pm, desired, func(name string) string { return socketByName[name] })
 }
 
 // livePipeReconciler periodically reconciles live pipes. The tick interval

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -2237,6 +2237,10 @@ func (h *Home) getAttachedSessionID() string {
 
 // getAttachedSessionName returns the tmux session name of the currently
 // attached agentdeck session (the name, not the instance ID), or "".
+// NOTE: GetAttachedSessions only queries the default tmux socket, so a session
+// living on an isolated agent-deck socket won't be detected as attached here.
+// Such a session is still kept live once focused (via the LRU), so the only
+// effect is the attached-pin guarantee not applying to non-default sockets.
 func (h *Home) getAttachedSessionName() string {
 	attached, err := tmux.GetAttachedSessions()
 	if err != nil || len(attached) == 0 {
@@ -5919,7 +5923,10 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 			h.lastCachePrune = time.Now()
 			h.pruneAnalyticsCache()
 
-			// Prune dead pipes and connect new sessions
+			// Fallback safety net for live-set pipes that died between reconciler
+			// ticks. The reconciler (livePipeReconciler) is the primary path that
+			// connects focused/attached sessions; this only reconnects wanted
+			// sessions whose pipe dropped.
 			if pm := tmux.GetPipeManager(); pm != nil {
 				h.instancesMu.RLock()
 				for _, inst := range h.instances {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -76,7 +76,6 @@ var (
 	notifLog  = logging.ForComponent(logging.CompNotif)
 	mcpUILog  = logging.ForComponent(logging.CompMCP)
 	statusLog = logging.ForComponent(logging.CompStatus)
-	pipeUILog = logging.ForComponent("pipe")
 )
 
 const (

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -209,12 +209,15 @@ type Home struct {
 	profile string // The profile this Home is displaying
 
 	// Data (protected by instancesMu for background worker access)
-	instances    []*session.Instance
-	instanceByID map[string]*session.Instance // O(1) instance lookup by ID
-	instancesMu  sync.RWMutex                 // Protects instances slice for thread-safe background access
-	storage      *session.Storage
-	groupTree    *session.GroupTree
-	flatItems    []session.Item // Flattened view for cursor navigation
+	instances          []*session.Instance
+	instanceByID       map[string]*session.Instance // O(1) instance lookup by ID
+	instancesMu        sync.RWMutex                 // Protects instances slice for thread-safe background access
+	storage            *session.Storage
+	groupTree          *session.GroupTree
+	flatItems          []session.Item // Flattened view for cursor navigation
+	liveSet            *pipeLiveSet   // sessions that should hold a live control pipe
+	focusedSessionName string         // tmux name of the cursor-selected session (focusMu)
+	focusMu            sync.Mutex     // protects focusedSessionName for the reconciler goroutine
 
 	// headless is true when running `web --no-tui`: no bubbletea loop ever
 	// boots, so the in-memory instances/groupTree are never populated by the
@@ -1216,6 +1219,8 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 	// This is unconditional — the status-right always shows the detach hint
 	_ = tmux.BindMouseStatusRightDetach()
 
+	h.liveSet = newPipeLiveSet(livePipeLRUCapacity)
+
 	// Initialize event-driven status detection
 	// Output callback: invoked when PipeManager detects %output from a session
 	outputCallback := func(sessionName string) {
@@ -1251,25 +1256,14 @@ func NewHomeWithProfileAndMode(profile string) *Home {
 
 	tmux.SetPipeManager(pm)
 
-	// Connect pipes for all existing running sessions in background
-	safego.Go(pipeUILog, "startup_pipe_connect", func() {
-		time.Sleep(500 * time.Millisecond) // Let TUI render first
-		h.instancesMu.RLock()
-		instances := make([]*session.Instance, len(h.instances))
-		copy(instances, h.instances)
-		h.instancesMu.RUnlock()
+	// Only the focused / attached / recently-viewed sessions hold a live pipe.
+	pm.SetWantPipe(func(name string) bool { return h.liveSet.want(name) })
 
-		for _, inst := range instances {
-			if ts := inst.GetTmuxSession(); ts != nil && ts.Exists() {
-				if err := pm.Connect(ts.Name, inst.TmuxSocketName); err != nil {
-					pipeUILog.Debug("startup_pipe_connect_failed",
-						slog.String("session", ts.Name),
-						slog.String("error", err.Error()))
-				}
-			}
-		}
-		pipeUILog.Debug("startup_pipes_connected", slog.Int("count", pm.ConnectedCount()))
-	})
+	// Live pipes are managed lazily by the reconciler: it connects the focused/
+	// attached session (and a few recent ones) and lets everything else ride the
+	// 2s status poll. This replaces the old "connect every session at startup"
+	// burst that opened ~N pipes at once and triggered attach-storm freezes.
+	go h.livePipeReconciler()
 
 	// Start background status worker (Priority 1C)
 	go h.statusWorker()
@@ -2239,6 +2233,85 @@ func (h *Home) getAttachedSessionID() string {
 		}
 	}
 	return ""
+}
+
+// getAttachedSessionName returns the tmux session name of the currently
+// attached agentdeck session (the name, not the instance ID), or "".
+func (h *Home) getAttachedSessionName() string {
+	attached, err := tmux.GetAttachedSessions()
+	if err != nil || len(attached) == 0 {
+		return ""
+	}
+	h.instancesMu.RLock()
+	defer h.instancesMu.RUnlock()
+	for _, sessName := range attached {
+		for _, inst := range h.instances {
+			if ts := inst.GetTmuxSession(); ts != nil && ts.Name == sessName {
+				return ts.Name
+			}
+		}
+	}
+	return ""
+}
+
+// socketForSession returns the tmux -L socket selector for a session name, or
+// "" (default server) if unknown.
+func (h *Home) socketForSession(name string) string {
+	h.instancesMu.RLock()
+	defer h.instancesMu.RUnlock()
+	for _, inst := range h.instances {
+		if ts := inst.GetTmuxSession(); ts != nil && ts.Name == name {
+			return inst.TmuxSocketName
+		}
+	}
+	return ""
+}
+
+// recordFocusedSession snapshots the cursor-selected session name for the
+// reconciler goroutine. Must run on the main (Update) goroutine — getSelected-
+// Session reads h.cursor/h.flatItems without a lock.
+func (h *Home) recordFocusedSession() {
+	name := ""
+	if s := h.getSelectedSession(); s != nil {
+		if ts := s.GetTmuxSession(); ts != nil {
+			name = ts.Name
+		}
+	}
+	h.focusMu.Lock()
+	h.focusedSessionName = name
+	h.focusMu.Unlock()
+}
+
+// reconcileLivePipes refreshes the live set from the current focus + attach and
+// syncs the PipeManager's pipes to match.
+func (h *Home) reconcileLivePipes() {
+	pm := tmux.GetPipeManager()
+	if pm == nil {
+		return
+	}
+	h.focusMu.Lock()
+	focused := h.focusedSessionName
+	h.focusMu.Unlock()
+
+	h.liveSet.touch(focused)
+	h.liveSet.setAttached(h.getAttachedSessionName())
+
+	reconcilePipes(pm, h.liveSet.members(), h.socketForSession)
+}
+
+// livePipeReconciler periodically reconciles live pipes. The tick interval
+// doubles as the focus debounce. Runs until h.ctx is cancelled (TUI exit).
+func (h *Home) livePipeReconciler() {
+	ticker := time.NewTicker(livePipeReconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-h.ctx.Done():
+			return
+		case <-ticker.C:
+			h.reconcileLivePipes()
+		}
+	}
 }
 
 // NOTE: updateTmuxNotifications (foreground) was removed in v0.9.2 as a CPU optimization.
@@ -4266,6 +4339,7 @@ func (h *Home) processStatusUpdate(req statusUpdateRequest) {
 // clears (issue #607). Under the default (full_repaint = false) this wrapper
 // is a pass-through — no regression for users who never opt in.
 func (h *Home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	defer h.recordFocusedSession()
 	model, cmd := h.updateInner(msg)
 	if !h.fullRepaint {
 		return model, cmd
@@ -5850,7 +5924,7 @@ func (h *Home) updateInner(msg tea.Msg) (tea.Model, tea.Cmd) {
 				h.instancesMu.RLock()
 				for _, inst := range h.instances {
 					if ts := inst.GetTmuxSession(); ts != nil && ts.Exists() {
-						if !pm.IsConnected(ts.Name) {
+						if h.liveSet.want(ts.Name) && !pm.IsConnected(ts.Name) {
 							go func(name, socket string) {
 								_ = pm.Connect(name, socket)
 							}(ts.Name, inst.TmuxSocketName)

--- a/internal/ui/pipe_liveset.go
+++ b/internal/ui/pipe_liveset.go
@@ -1,0 +1,134 @@
+package ui
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	// livePipeLRUCapacity is how many recently-focused sessions keep a live
+	// control pipe (beyond the attached session). Small by design: the point
+	// is to bound pipes-per-instance so N instances stay cheap.
+	livePipeLRUCapacity = 3
+
+	// livePipeReconcileInterval is how often the reconciler samples the
+	// focused/attached session and syncs pipes. This interval doubles as the
+	// focus debounce: scrolling faster than this never connects intermediate
+	// sessions.
+	livePipeReconcileInterval = 500 * time.Millisecond
+)
+
+// pipeLiveSet is the thread-safe set of tmux session names that should hold a
+// live control pipe for this agent-deck instance: a bounded most-recently-
+// focused LRU plus the currently-attached session (pinned). Read by the
+// PipeManager's wantPipe gate from multiple goroutines; written by the UI's
+// reconciler — hence the mutex.
+type pipeLiveSet struct {
+	mu       sync.Mutex
+	capacity int
+	lru      []string // most-recent first
+	attached string   // pinned; "" when nothing attached
+}
+
+func newPipeLiveSet(capacity int) *pipeLiveSet {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &pipeLiveSet{capacity: capacity}
+}
+
+// touch promotes name to the front of the LRU, deduping, and trims to capacity.
+// Empty name is a no-op (cursor on a group header, nothing attached, etc).
+func (s *pipeLiveSet) touch(name string) {
+	if name == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.lru[:0]
+	for _, n := range s.lru {
+		if n != name {
+			out = append(out, n)
+		}
+	}
+	s.lru = append([]string{name}, out...)
+	if len(s.lru) > s.capacity {
+		s.lru = s.lru[:s.capacity]
+	}
+}
+
+// setAttached pins the attached session ("" clears the pin).
+func (s *pipeLiveSet) setAttached(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.attached = name
+}
+
+// want reports whether name should hold a live pipe.
+func (s *pipeLiveSet) want(name string) bool {
+	if name == "" {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if name == s.attached {
+		return true
+	}
+	for _, n := range s.lru {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// members returns the deduped live set: attached (if any) followed by the LRU.
+func (s *pipeLiveSet) members() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.lru)+1)
+	seen := map[string]bool{}
+	if s.attached != "" {
+		out = append(out, s.attached)
+		seen[s.attached] = true
+	}
+	for _, n := range s.lru {
+		if !seen[n] {
+			out = append(out, n)
+			seen[n] = true
+		}
+	}
+	return out
+}
+
+// pipeConnector is the slice of PipeManager that reconcilePipes needs. Defined
+// here so the diff logic is unit-testable with a fake. *tmux.PipeManager
+// satisfies it.
+type pipeConnector interface {
+	IsConnected(name string) bool
+	Connect(name, socket string) error
+	Disconnect(name string)
+	ConnectedSessions() []string
+}
+
+// reconcilePipes makes pm's connected pipes match desired: it connects each
+// desired session not already connected, and disconnects each connected session
+// no longer desired. socketOf maps a session name to its tmux -L socket.
+func reconcilePipes(pm pipeConnector, desired []string, socketOf func(string) string) {
+	desiredSet := make(map[string]bool, len(desired))
+	for _, n := range desired {
+		if n != "" {
+			desiredSet[n] = true
+		}
+	}
+	for n := range desiredSet {
+		if !pm.IsConnected(n) {
+			_ = pm.Connect(n, socketOf(n))
+		}
+	}
+	for _, n := range pm.ConnectedSessions() {
+		if !desiredSet[n] {
+			pm.Disconnect(n)
+		}
+	}
+}

--- a/internal/ui/pipe_liveset.go
+++ b/internal/ui/pipe_liveset.go
@@ -20,14 +20,20 @@ const (
 
 // pipeLiveSet is the thread-safe set of tmux session names that should hold a
 // live control pipe for this agent-deck instance: a bounded most-recently-
-// focused LRU plus the currently-attached session (pinned). Read by the
-// PipeManager's wantPipe gate from multiple goroutines; written by the UI's
-// reconciler — hence the mutex.
+// focused LRU plus the currently-attached sessions (pinned). Attached is a set,
+// not a single name, because a session can be attached on any socket — the main
+// TUI's session on the default socket and an attached session on an isolated
+// socket must both stay pinned. Read by the PipeManager's wantPipe gate from
+// multiple goroutines; written by the UI's reconciler — hence the mutex.
+//
+// All methods are nil-receiver safe so a Home built by an alternate/test
+// constructor (which never initializes liveSet) can exercise Update without
+// panicking.
 type pipeLiveSet struct {
 	mu       sync.Mutex
 	capacity int
 	lru      []string // most-recent first
-	attached string   // pinned; "" when nothing attached
+	attached []string // pinned attached sessions (across all sockets); deduped, no ""
 }
 
 func newPipeLiveSet(capacity int) *pipeLiveSet {
@@ -40,7 +46,7 @@ func newPipeLiveSet(capacity int) *pipeLiveSet {
 // touch promotes name to the front of the LRU, deduping, and trims to capacity.
 // Empty name is a no-op (cursor on a group header, nothing attached, etc).
 func (s *pipeLiveSet) touch(name string) {
-	if name == "" {
+	if s == nil || name == "" {
 		return
 	}
 	s.mu.Lock()
@@ -60,22 +66,37 @@ func (s *pipeLiveSet) touch(name string) {
 	}
 }
 
-// setAttached pins the attached session ("" clears the pin).
-func (s *pipeLiveSet) setAttached(name string) {
+// setAttached replaces the pinned attached set. Empty and duplicate names are
+// dropped; calling with no names (or only "") clears the pin.
+func (s *pipeLiveSet) setAttached(names ...string) {
+	if s == nil {
+		return
+	}
+	pinned := make([]string, 0, len(names))
+	seen := make(map[string]bool, len(names))
+	for _, n := range names {
+		if n == "" || seen[n] {
+			continue
+		}
+		seen[n] = true
+		pinned = append(pinned, n)
+	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.attached = name
+	s.attached = pinned
+	s.mu.Unlock()
 }
 
 // want reports whether name should hold a live pipe.
 func (s *pipeLiveSet) want(name string) bool {
-	if name == "" {
+	if s == nil || name == "" {
 		return false
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if name == s.attached {
-		return true
+	for _, n := range s.attached {
+		if n == name {
+			return true
+		}
 	}
 	for _, n := range s.lru {
 		if n == name {
@@ -85,15 +106,21 @@ func (s *pipeLiveSet) want(name string) bool {
 	return false
 }
 
-// members returns the deduped live set: attached (if any) followed by the LRU.
+// members returns the deduped live set: attached sessions first, then the LRU.
+// A nil receiver returns nil; a non-nil empty set returns a non-nil empty slice.
 func (s *pipeLiveSet) members() []string {
+	if s == nil {
+		return nil
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	out := make([]string, 0, len(s.lru)+1)
-	seen := map[string]bool{}
-	if s.attached != "" {
-		out = append(out, s.attached)
-		seen[s.attached] = true
+	out := make([]string, 0, len(s.lru)+len(s.attached))
+	seen := make(map[string]bool, len(s.lru)+len(s.attached))
+	for _, n := range s.attached {
+		if !seen[n] {
+			out = append(out, n)
+			seen[n] = true
+		}
 	}
 	for _, n := range s.lru {
 		if !seen[n] {
@@ -102,6 +129,27 @@ func (s *pipeLiveSet) members() []string {
 		}
 	}
 	return out
+}
+
+// desiredLivePipes is the pure core of (*Home).reconcileLivePipes: it pins the
+// focused session and the attached set into ls, then returns the subset of the
+// live set that still has a live instance (per socketByName). Names without an
+// instance — deleted or restarted sessions — are dropped so they are never
+// retried; the caller resolves each survivor's socket via socketByName.
+//
+// Extracted from reconcileLivePipes so the focus/attach/eviction logic is
+// unit-testable without a real tmux server or attached client.
+func desiredLivePipes(ls *pipeLiveSet, focused string, attached []string, socketByName map[string]string) []string {
+	ls.touch(focused)
+	ls.setAttached(attached...)
+	members := ls.members()
+	desired := make([]string, 0, len(members))
+	for _, name := range members {
+		if _, ok := socketByName[name]; ok {
+			desired = append(desired, name)
+		}
+	}
+	return desired
 }
 
 // pipeConnector is the slice of PipeManager that reconcilePipes needs. Defined

--- a/internal/ui/pipe_liveset.go
+++ b/internal/ui/pipe_liveset.go
@@ -45,6 +45,9 @@ func (s *pipeLiveSet) touch(name string) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Filter in-place: out shares lru's backing array. Safe because we skip at
+	// most one element (the existing copy of name), so the write index never
+	// overtakes the read index.
 	out := s.lru[:0]
 	for _, n := range s.lru {
 		if n != name {

--- a/internal/ui/pipe_liveset_test.go
+++ b/internal/ui/pipe_liveset_test.go
@@ -88,6 +88,100 @@ func TestPipeLiveSet_SetAttachedEmptyClearsPin(t *testing.T) {
 	}
 }
 
+func TestPipeLiveSet_AttachedMultipleAcrossSockets(t *testing.T) {
+	s := newPipeLiveSet(2)
+	s.touch("focused") // in the LRU, default socket
+	// Two attached sessions on different sockets, neither one focused.
+	s.setAttached("attached-default", "attached-iso")
+	for _, n := range []string{"attached-default", "attached-iso", "focused"} {
+		if !s.want(n) {
+			t.Fatalf("%s should be live", n)
+		}
+	}
+	m := s.members()
+	if len(m) != 3 {
+		t.Fatalf("expected 3 members, got %v", m)
+	}
+	// Attached sessions must precede LRU-only members.
+	idx := map[string]int{}
+	for i, n := range m {
+		idx[n] = i
+	}
+	if idx["attached-default"] > idx["focused"] || idx["attached-iso"] > idx["focused"] {
+		t.Fatalf("attached sessions must precede LRU members: %v", m)
+	}
+}
+
+func TestPipeLiveSet_SetAttachedReplacesPreviousSet(t *testing.T) {
+	s := newPipeLiveSet(2)
+	s.setAttached("a", "b")
+	s.setAttached("c") // replaces the set; a,b are not in the LRU
+	if s.want("a") || s.want("b") {
+		t.Fatal("setAttached must replace the previous pinned set, not append to it")
+	}
+	if !s.want("c") {
+		t.Fatal("c should be pinned after setAttached")
+	}
+}
+
+func TestPipeLiveSet_NilReceiverSafe(t *testing.T) {
+	var s *pipeLiveSet // an alternate/test Home constructor never initializes liveSet
+	// None of these may panic on a nil receiver.
+	s.touch("x")
+	s.setAttached("y")
+	if s.want("x") {
+		t.Fatal("nil live set wants nothing")
+	}
+	if s.members() != nil {
+		t.Fatal("nil live set has nil members")
+	}
+}
+
+// TestDesiredLivePipes_AttachedIsolatedSocketKept locks in the maintainer's
+// item-1 invariant: a session attached on a non-default socket but NOT focused
+// must stay in the desired live set (keeping its pipe), not get evicted to the
+// 2s status poll.
+func TestDesiredLivePipes_AttachedIsolatedSocketKept(t *testing.T) {
+	ls := newPipeLiveSet(2)
+	socketByName := map[string]string{
+		"focused":      "",         // default socket, focused
+		"attached-iso": "iso-sock", // isolated socket, attached but not focused
+		"idle":         "",         // exists but neither focused nor attached
+	}
+	// attached-iso is reported attached (across sockets) but is not the focus.
+	desired := desiredLivePipes(ls, "focused", []string{"attached-iso"}, socketByName)
+
+	has := func(n string) bool {
+		for _, d := range desired {
+			if d == n {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("attached-iso") {
+		t.Fatalf("attached isolated-socket session must be in desired set, got %v", desired)
+	}
+	if !has("focused") {
+		t.Fatalf("focused session must be in desired set, got %v", desired)
+	}
+	if has("idle") {
+		t.Fatalf("idle (unfocused, unattached) session must not be live, got %v", desired)
+	}
+}
+
+func TestDesiredLivePipes_DropsNamesWithNoInstance(t *testing.T) {
+	ls := newPipeLiveSet(3)
+	ls.touch("deleted") // was focused earlier; its instance is now gone
+	socketByName := map[string]string{"live": ""}
+	desired := desiredLivePipes(ls, "live", nil, socketByName)
+	for _, d := range desired {
+		if d == "deleted" {
+			t.Fatalf("a session with no live instance must be filtered out, got %v", desired)
+		}
+	}
+}
+
 // fakeConnector records connect/disconnect calls for reconcilePipes tests.
 type fakeConnector struct {
 	connected map[string]bool
@@ -140,5 +234,38 @@ func TestReconcilePipes_IgnoresEmptyDesired(t *testing.T) {
 	reconcilePipes(f, []string{"", "a"}, func(string) string { return "sock" })
 	if len(f.connects) != 1 || f.connects[0] != "a" {
 		t.Fatalf("empty desired entry must be skipped; connects=%v", f.connects)
+	}
+}
+
+// TestReconcile_AttachedIsolatedSocketKeptAcrossTicks is the end-to-end version
+// of the maintainer's item-3 ask: an attached isolated-socket session that is
+// not focused must get a live pipe and KEEP it across reconcile ticks, never
+// being disconnected.
+func TestReconcile_AttachedIsolatedSocketKeptAcrossTicks(t *testing.T) {
+	ls := newPipeLiveSet(2)
+	socketByName := map[string]string{
+		"focused":      "",
+		"attached-iso": "iso-sock",
+	}
+	socketOf := func(name string) string { return socketByName[name] }
+
+	f := newFakeConnector()
+
+	// Tick 1: focus "focused"; "attached-iso" is attached on its isolated socket.
+	desired := desiredLivePipes(ls, "focused", []string{"attached-iso"}, socketByName)
+	reconcilePipes(f, desired, socketOf)
+	if !f.IsConnected("attached-iso") {
+		t.Fatalf("attached isolated-socket session must be connected on tick 1; connects=%v", f.connects)
+	}
+
+	// Tick 2: same focus + attach. The isolated-socket pipe must be retained.
+	f.connects, f.disconns = nil, nil
+	desired = desiredLivePipes(ls, "focused", []string{"attached-iso"}, socketByName)
+	reconcilePipes(f, desired, socketOf)
+	if len(f.disconns) != 0 {
+		t.Fatalf("steady tick must not disconnect anything, got %v", f.disconns)
+	}
+	if !f.IsConnected("attached-iso") {
+		t.Fatal("attached isolated-socket session must remain connected across ticks")
 	}
 }

--- a/internal/ui/pipe_liveset_test.go
+++ b/internal/ui/pipe_liveset_test.go
@@ -1,0 +1,144 @@
+package ui
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestPipeLiveSet_TouchLRUEviction(t *testing.T) {
+	s := newPipeLiveSet(3)
+	for _, n := range []string{"a", "b", "c", "d"} { // d evicts a
+		s.touch(n)
+	}
+	if s.want("a") {
+		t.Fatal("a should have been evicted from a capacity-3 LRU")
+	}
+	for _, n := range []string{"b", "c", "d"} {
+		if !s.want(n) {
+			t.Fatalf("%s should be live", n)
+		}
+	}
+}
+
+func TestPipeLiveSet_TouchPromotesAndDedupes(t *testing.T) {
+	s := newPipeLiveSet(3)
+	s.touch("a")
+	s.touch("b")
+	s.touch("c")
+	s.touch("a") // promote a to front; now order a,c,b
+	s.touch("d") // evicts the tail (b), not a
+	if !s.want("a") {
+		t.Fatal("a was just touched; must survive")
+	}
+	if s.want("b") {
+		t.Fatal("b was the LRU tail and should be evicted")
+	}
+}
+
+func TestPipeLiveSet_EmptyTouchIsNoop(t *testing.T) {
+	s := newPipeLiveSet(3)
+	s.touch("")
+	if len(s.members()) != 0 {
+		t.Fatalf("empty touch must not add a member, got %v", s.members())
+	}
+}
+
+func TestPipeLiveSet_AttachedPinnedAndDeduped(t *testing.T) {
+	s := newPipeLiveSet(2)
+	s.touch("a")
+	s.touch("b")
+	s.setAttached("z")
+	if !s.want("z") {
+		t.Fatal("attached session must be live")
+	}
+	// attached also present in LRU must not appear twice in members
+	s.setAttached("a")
+	got := s.members()
+	count := 0
+	for _, m := range got {
+		if m == "a" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("member 'a' duplicated: %v", got)
+	}
+	if got[0] != "a" {
+		t.Fatalf("attached session must be first in members, got %v", got)
+	}
+}
+
+func TestPipeLiveSet_MembersEmptyIsNonNil(t *testing.T) {
+	s := newPipeLiveSet(3)
+	got := s.members()
+	if got == nil {
+		t.Fatal("members() on empty set should return non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("members() on empty set should be empty, got %v", got)
+	}
+}
+
+func TestPipeLiveSet_SetAttachedEmptyClearsPin(t *testing.T) {
+	s := newPipeLiveSet(2)
+	s.setAttached("z")
+	s.setAttached("")
+	if s.want("z") {
+		t.Fatal("clearing attached pin should drop z (not in LRU)")
+	}
+}
+
+// fakeConnector records connect/disconnect calls for reconcilePipes tests.
+type fakeConnector struct {
+	connected map[string]bool
+	connects  []string
+	disconns  []string
+}
+
+func newFakeConnector(initial ...string) *fakeConnector {
+	f := &fakeConnector{connected: map[string]bool{}}
+	for _, n := range initial {
+		f.connected[n] = true
+	}
+	return f
+}
+func (f *fakeConnector) IsConnected(name string) bool { return f.connected[name] }
+func (f *fakeConnector) Connect(name, socket string) error {
+	f.connected[name] = true
+	f.connects = append(f.connects, name)
+	return nil
+}
+func (f *fakeConnector) Disconnect(name string) {
+	delete(f.connected, name)
+	f.disconns = append(f.disconns, name)
+}
+func (f *fakeConnector) ConnectedSessions() []string {
+	out := make([]string, 0, len(f.connected))
+	for n := range f.connected {
+		out = append(out, n)
+	}
+	return out
+}
+
+func TestReconcilePipes_ConnectsAndDisconnects(t *testing.T) {
+	f := newFakeConnector("old1", "old2", "keep")
+	reconcilePipes(f, []string{"keep", "new1"}, func(string) string { return "" })
+
+	sort.Strings(f.connects)
+	sort.Strings(f.disconns)
+	if len(f.connects) != 1 || f.connects[0] != "new1" {
+		t.Fatalf("expected to connect [new1], got %v", f.connects)
+	}
+	want := []string{"old1", "old2"}
+	if len(f.disconns) != 2 || f.disconns[0] != want[0] || f.disconns[1] != want[1] {
+		t.Fatalf("expected to disconnect %v, got %v", want, f.disconns)
+	}
+}
+
+func TestReconcilePipes_IgnoresEmptyDesired(t *testing.T) {
+	f := newFakeConnector()
+	reconcilePipes(f, []string{"", "a"}, func(string) string { return "sock" })
+	if len(f.connects) != 1 || f.connects[0] != "a" {
+		t.Fatalf("empty desired entry must be skipped; connects=%v", f.connects)
+	}
+}


### PR DESCRIPTION
## Problem

agent-deck opens one `tmux -C` control client per session. With N instances × M sessions that's N×M control clients on tmux's single-threaded server. Running several decks at once (common when juggling sessions) causes an attach-storm at launch and steady-state backpressure that can wedge or crash the tmux server.

## Fix

Each instance keeps a live control pipe only for the sessions it needs: the cursor-focused one, the attached one, and the last few viewed (small LRU). Everything else rides the existing 2s `list-windows -a` poll + `capture-pane` fallback. Per-instance pipe cost drops from ×(all sessions) to ×(≤4): launch opens ~1 pipe instead of ~M, and backpressure scales with active work, not total session count.

Mechanism:
- `pipeLiveSet` — thread-safe LRU + pinned attached session (`internal/ui/pipe_liveset.go`)
- `reconcilePipes` — pure connect/disconnect diff
- `PipeManager.SetWantPipe` predicate gates both `Connect` and `watchPipe` auto-reconnect, so a `Disconnect` can't be silently undone
- a 500ms Home reconciler goroutine whose tick interval doubles as the focus debounce (sampling focus on a timer avoids hooking the many cursor-mutation sites and the data race that would entail)

Backward compatible: a nil `wantPipe` predicate means "want everything" (legacy behaviour).

## Validation

Soak-tested locally: two instances over 17 shared sessions held **5** total control clients (vs ~34 before), zero orphans, no freezes; background-session status still updates on the 2s poll.

## Test plan

- [ ] `go test ./internal/ui/ ./internal/tmux/` green
- [ ] Run two instances against a shared session set; confirm control-client count stays ~per-instance ≤4 (`ps … | grep 'tmux.*-C attach'`)
- [ ] Background sessions still show status updates (≤2s latency)

## Note

`getAttachedSessionName` / attach-pin consult only the default tmux socket; sessions on isolated agent-deck sockets are still kept live once focused (via the LRU), so the only effect is the attached-pin guarantee not applying to non-default sockets. Harmless for default-socket setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tmux control-pipe session gating with an API to set a “wanted” predicate and to list currently connected sessions.
  * Added support for querying attached sessions across multiple tmux sockets.
* **Performance Improvements**
  * Live pipe management now reconciles a focused/most-recent desired set instead of eagerly connecting all sessions.
* **Bug Fixes**
  * Background reconnect logic no longer resurrects or retries pipes for sessions that are no longer wanted.
* **Tests**
  * Added unit tests for session gating, live-set behavior, and pipe reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->