### PR TITLE
fix(session): honor explicit --session-id on the Start path (closes #1465)

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -2877,6 +2877,34 @@ func (i *Instance) buildTmuxOptionOverrides() map[string]string {
 	return overrides
 }
 
+// adoptExplicitClaudeSessionID adopts an explicit `--session-id <uuid>` baked
+// into i.Command as the authoritative conversation id, correcting any stale or
+// disk-hijacked value, and returns true when an explicit id was present (the
+// caller must then skip mtime-based disk discovery). An explicit id is the
+// user's declaration of WHICH conversation this session owns; honoring it
+// before disk discovery is what stops sibling sessions in a shared cwd from
+// converging on the newest transcript. Shared by both session-id preludes —
+// ensureClaudeSessionIDFromDiskForRestart (#1147) and
+// ensureClaudeSessionIDFromDisk (#1465). The reason label distinguishes the
+// Start path from the Restart path in the resume log line.
+func (i *Instance) adoptExplicitClaudeSessionID(reason string) bool {
+	explicit, ok := extractExplicitClaudeSessionID(i.Command)
+	if !ok {
+		return false
+	}
+	if i.ClaudeSessionID != explicit {
+		i.ClaudeSessionID = explicit
+		sessionLog.Info("resume: id="+explicit+" reason="+reason,
+			slog.String("instance_id", i.ID),
+			slog.String("claude_session_id", explicit),
+			slog.String("reason", reason))
+	}
+	if i.ClaudeDetectedAt.IsZero() {
+		i.ClaudeDetectedAt = time.Now()
+	}
+	return true
+}
+
 // ensureClaudeSessionIDFromDisk is the Phase 5 / REQ-7 prelude invoked by
 // Start() and StartWithMessage() when an IsClaudeCompatible Instance has an
 // empty ClaudeSessionID. It attempts to discover the latest UUID-named
@@ -2905,6 +2933,15 @@ func (i *Instance) buildTmuxOptionOverrides() map[string]string {
 // two grep-stable lines for a Phase 5 discovery start, distinguishable
 // by the `reason=` attr.
 func (i *Instance) ensureClaudeSessionIDFromDisk() {
+	// Issue #1465: an explicit `--session-id <uuid>` baked into i.Command is
+	// the authoritative conversation id. Adopt it before the #608 gate and
+	// disk discovery so a Start-path session sharing a cwd with newer sibling
+	// transcripts (e.g. a removed-then-recreated review session) cannot hijack
+	// a sibling's conversation. The Restart prelude already does this for
+	// #1147; this closes the same gap on the Start path.
+	if i.adoptExplicitClaudeSessionID("session_id_flag_explicit") {
+		return
+	}
 	if i.ClaudeSessionID != "" {
 		return
 	}
@@ -2962,17 +2999,7 @@ func (i *Instance) ensureClaudeSessionIDFromDiskForRestart() {
 	// sharing a CLAUDE_SESSION_ID. Adopting the explicit id BEFORE the
 	// non-empty short-circuit ensures it also corrects a previously-
 	// hijacked id from an earlier buggy run.
-	if explicit, ok := extractExplicitClaudeSessionID(i.Command); ok {
-		if i.ClaudeSessionID != explicit {
-			i.ClaudeSessionID = explicit
-			sessionLog.Info("resume: id="+explicit+" reason=session_id_flag_explicit_restart",
-				slog.String("instance_id", i.ID),
-				slog.String("claude_session_id", explicit),
-				slog.String("reason", "session_id_flag_explicit_restart"))
-		}
-		if i.ClaudeDetectedAt.IsZero() {
-			i.ClaudeDetectedAt = time.Now()
-		}
+	if i.adoptExplicitClaudeSessionID("session_id_flag_explicit_restart") {
 		return
 	}
 	if i.ClaudeSessionID != "" {

--- a/internal/session/issue1465_session_isolation_test.go
+++ b/internal/session/issue1465_session_isolation_test.go
@@ -1,0 +1,129 @@
+package session
+
+// Issue #1465 — sequential Claude review sessions in the same project dir
+// inherit a prior session's conversation ("stale context").
+//
+// Reporter (@lantzbuilds) scenario: a conductor launches PR-333-claude in
+// repo dir X, removes it, then launches PR-335-claude in the SAME dir X — and
+// the second session resumes the PR-333 conversation instead of starting
+// fresh, ignoring its launch prompt.
+//
+// Root cause: the Start()-path prelude ensureClaudeSessionIDFromDisk did NOT
+// honor an explicit `--session-id <uuid>` baked into i.Command before falling
+// into mtime-based disk discovery. The Restart()-path prelude already adopts
+// the explicit id first (issue #1147, commit 5333dfb4), so the two preludes
+// were asymmetric: a Start-path session that lost its ClaudeSessionID (custom
+// wrapper, no hook capture) but carries an explicit --session-id in its
+// Command could still hijack a newer sibling transcript from the shared cwd.
+//
+// The reporter's literal evidence (`... --continue --session-dir ...`) is the
+// Pi builder's template (buildPiCommand), not Claude's — Claude's "new" mode
+// has used a fresh `--session-id <uuid>` (never `-c`) for many releases, so a
+// plain fresh `add` is already isolated by the #608 gate. These tests pin the
+// remaining contract on the Start path:
+//
+//   1. Explicit --session-id wins over a newer sibling JSONL (the fix).
+//   2. No explicit id + prior conversation: disk discovery still recovers it.
+//   3. A brand-new session (ClaudeDetectedAt zero) never inherits a sibling's
+//      conversation — the reporter's exact remove-then-recreate scenario.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssue1465_StartPrelude_ExplicitIDWinsOverSiblingDiskDiscovery is the core
+// regression. A Start-path session in a shared cwd, with its own explicit
+// --session-id in Command, a lost ClaudeSessionID, and a non-zero
+// ClaudeDetectedAt (so the #608 gate does NOT early-return), must adopt its
+// OWN id — not the newest sibling JSONL.
+//
+// RED before fix: ensureClaudeSessionIDFromDisk skips the explicit id, passes
+// the #608 gate, disk-discovers the newest sibling UUID, and hijacks it.
+// GREEN after fix: the explicit-id extractor adopts the Command's UUID and
+// skips disk discovery.
+func TestIssue1465_StartPrelude_ExplicitIDWinsOverSiblingDiskDiscovery(t *testing.T) {
+	home := isolatedHomeDir(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+
+	const (
+		uuidOwn     = "12345678-1465-1465-1465-121212121212"
+		uuidSibling = "99999999-1465-1465-1465-999999999999"
+	)
+
+	inst := newClaudeInstanceForExplicitID(t, home,
+		"env REVIEW=PR-335 claude --session-id "+uuidOwn+" --dangerously-skip-permissions")
+
+	// A newer sibling transcript (a prior PR-333 review removed and left on
+	// disk) sits in the shared cwd, newest by mtime.
+	now := time.Now()
+	stageJSONL(t, home, inst.ProjectPath, uuidOwn, now.Add(-1*time.Minute))
+	stageJSONL(t, home, inst.ProjectPath, uuidSibling, now)
+
+	inst.ensureClaudeSessionIDFromDisk()
+
+	require.Equal(t, uuidOwn, inst.ClaudeSessionID,
+		"Issue #1465: a Start-path session with `--session-id %s` in its Command must adopt that UUID, not the newest sibling JSONL %s. Got %q — the session would resume the prior review's conversation.",
+		uuidOwn, uuidSibling, inst.ClaudeSessionID)
+}
+
+// TestIssue1465_StartPrelude_NoExplicitID_DiskDiscoveryPreserved pins parity:
+// the fix must NOT regress legitimate Start-path recovery. A session with NO
+// explicit --session-id but a prior conversation (ClaudeDetectedAt non-zero)
+// must still bind the on-disk JSONL.
+func TestIssue1465_StartPrelude_NoExplicitID_DiskDiscoveryPreserved(t *testing.T) {
+	home := isolatedHomeDir(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+
+	inst := newClaudeInstanceForExplicitID(t, home, "/usr/local/bin/claude-wrapper.sh")
+
+	const jsonlUUID = "14650000-1465-1465-1465-146500001465"
+	stageJSONL(t, home, inst.ProjectPath, jsonlUUID, time.Now())
+
+	inst.ensureClaudeSessionIDFromDisk()
+
+	require.Equal(t, jsonlUUID, inst.ClaudeSessionID,
+		"Issue #1465 fix must NOT regress Start-path recovery: a session with no explicit --session-id and a prior conversation must still auto-bind the newest JSONL. Got %q.",
+		inst.ClaudeSessionID)
+}
+
+// TestIssue1465_FreshSession_DoesNotInheritSiblingHistory pins the reporter's
+// exact remove-then-recreate scenario: a brand-new session (ClaudeDetectedAt
+// zero, no explicit id) launched in a cwd that previously hosted another
+// Claude session must NOT inherit that session's conversation. The #608 gate
+// already guarantees this; this test locks it in so the guarantee can't
+// silently regress.
+func TestIssue1465_FreshSession_DoesNotInheritSiblingHistory(t *testing.T) {
+	home := isolatedHomeDir(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	ClearUserConfigCache()
+
+	// A prior review (PR-333) left a transcript in the shared cwd.
+	priorProject := filepath.Join(home, "ui-library")
+	require.NoError(t, os.MkdirAll(priorProject, 0o755))
+	const priorUUID = "33333333-0333-0333-0333-033303330333"
+	stageJSONL(t, home, priorProject, priorUUID, time.Now())
+
+	// PR-335 is a freshly added session in the SAME cwd: no explicit id, and
+	// ClaudeDetectedAt zero (never started before).
+	fresh := &Instance{
+		ID:               "test-1465-fresh",
+		Tool:             "claude",
+		ProjectPath:      priorProject,
+		Command:          "claude",
+		ClaudeSessionID:  "",
+		ClaudeDetectedAt: time.Time{}, // zero — brand-new spawn
+	}
+
+	fresh.ensureClaudeSessionIDFromDisk()
+
+	require.Empty(t, fresh.ClaudeSessionID,
+		"Issue #1465: a brand-new session (ClaudeDetectedAt zero) in a cwd that previously hosted another Claude session must NOT adopt the prior session's transcript %s. Got %q — that is the stale-context bug.",
+		priorUUID, fresh.ClaudeSessionID)
+}


### PR DESCRIPTION
## Summary

Fixes #1465 — sequential Claude sessions in the same project dir could inherit a prior session's conversation ("stale context").

## Root cause

Two preludes resolve a Claude session's conversation id when it isn't already known:

- **Restart path** — `ensureClaudeSessionIDFromDiskForRestart` — already honors an explicit `--session-id <uuid>` baked into the launch command *before* falling back to mtime-based JSONL discovery (the #1147 fix).
- **Start path** — `ensureClaudeSessionIDFromDisk` — did **not**. When a session had lost its `ClaudeSessionID` (e.g. a custom wrapper where no hook ever captured it) but carried an explicit `--session-id` in its command, and it shared a project dir with a newer sibling transcript, the Start prelude picked the newest sibling JSONL by mtime and **hijacked the sibling's conversation** — resuming stale context.

This is the same class of bug #1147 closed on the Restart path, left open on the Start path.

### About the reporter's evidence

The literal `... --continue --session-dir "$session_dir"` string in the binary is the **Pi** builder's template (`buildPiCommand`), not Claude's. Claude's `new` session mode has launched with a fresh `--session-id <uuid>` (never `-c`/`--continue`) for many releases, so the originally-reported "fresh launch resumes prior conversation" symptom no longer reproduces on a plain fresh `add` (the #608 `ClaudeDetectedAt` gate protects it). This PR hardens the remaining real path — explicit-id sessions sharing a cwd — and locks the behavior in with tests.

## Fix

Extract the explicit-id adoption that the Restart prelude already performs into a shared `adoptExplicitClaudeSessionID(reason)` helper, and call it first in `ensureClaudeSessionIDFromDisk` — before the #608 gate and disk discovery. Both preludes now share one code path, so they can't drift again.

- Fresh sessions (no explicit `--session-id`, `ClaudeDetectedAt` zero) are unchanged — still protected by the #608 gate.
- Legitimate single-session disk recovery (no explicit id, prior conversation) is preserved.

## Tests (regression-first)

Added `internal/session/issue1465_session_isolation_test.go`:

1. `TestIssue1465_StartPrelude_ExplicitIDWinsOverSiblingDiskDiscovery` — **RED before the fix** (adopts the newer sibling UUID), GREEN after (adopts its own).
2. `TestIssue1465_StartPrelude_NoExplicitID_DiskDiscoveryPreserved` — parity guard: legitimate recovery still works.
3. `TestIssue1465_FreshSession_DoesNotInheritSiblingHistory` — the reporter's exact remove-then-recreate scenario stays isolated via the #608 gate.

All four existing #1147 tests still pass (they guard the shared-helper refactor on the Restart path).

## Verification

- `go test ./internal/session/` — pass (sandboxed HOME/XDG)
- `go build ./...` — pass
- `go vet ./internal/session/` — pass
- `golangci-lint run ./internal/session/` — 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session management to properly prioritize explicit session IDs and prevent incorrect adoption of previous conversation transcripts when running multiple sequential sessions within the same project directory.

* **Tests**
  * Added comprehensive regression test coverage for session isolation behavior, including explicit session ID precedence and fresh session scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->