### PR TITLE
refactor(tui): consolidate dialog width clamp into fitDialogWidth (fixes narrow-terminal overflow)

### DIFF
--- a/internal/ui/cellwidth.go
+++ b/internal/ui/cellwidth.go
@@ -130,3 +130,51 @@ func keycapCount(s string) int {
 	}
 	return n
 }
+
+// Chrome of the shared dialog box (DialogBoxStyle: RoundedBorder + Padding(1,2)).
+const (
+	// dialogBorderWidth is the rounded border's horizontal cost — 1 cell each
+	// side. lipgloss draws it OUTSIDE the value passed to .Width(), so the
+	// rendered box is .Width() + dialogBorderWidth wide.
+	dialogBorderWidth = 2
+	// dialogScreenMargin is how far a dialog's .Width() stays below the terminal
+	// width on a narrow screen, leaving a comfortable gutter around the box.
+	dialogScreenMargin = 10
+)
+
+// fitDialogWidth returns the value to pass to a dialog's lipgloss .Width(),
+// clamped so the rendered box (this width + the rounded border) always fits
+// within termWidth. preferred is the width the dialog wants on a roomy screen;
+// minWidth is the smallest it should use before the terminal forces it smaller.
+// On a narrow terminal the dialog shrinks toward termWidth-dialogScreenMargin
+// but not below minWidth, then a final hard cap (termWidth-dialogBorderWidth)
+// guarantees it never overflows even when minWidth alone would. termWidth <= 0
+// (unknown) disables clamping.
+//
+// This consolidates the width-clamp every DialogBoxStyle dialog used to
+// hand-roll. Routing them all through one function removes the class of bug
+// where a fixed minimum overflowed a very narrow terminal — e.g. a floor of 56
+// rendered a 58-cell box on a 57-cell split pane (only codeblock had guarded
+// against it). It reproduces the old `min(preferred, max(minWidth, width-10))`
+// for every non-overflowing terminal; only the overflow case changes.
+func fitDialogWidth(preferred, minWidth, termWidth int) int {
+	w := preferred
+	if w < minWidth {
+		w = minWidth
+	}
+	if termWidth > 0 {
+		if shrunk := termWidth - dialogScreenMargin; shrunk < w {
+			w = shrunk
+		}
+		if w < minWidth {
+			w = minWidth
+		}
+		if hardCap := termWidth - dialogBorderWidth; w > hardCap {
+			w = hardCap
+		}
+	}
+	if w < 1 {
+		w = 1
+	}
+	return w
+}

--- a/internal/ui/codeblock.go
+++ b/internal/ui/codeblock.go
@@ -225,24 +225,12 @@ func (d *CodeBlockDialog) View() string {
 	dimStyle := lipgloss.NewStyle().Foreground(ColorComment)
 	footerStyle := lipgloss.NewStyle().Foreground(ColorComment).Italic(true)
 
-	dialogWidth := 60
-	if d.width > 0 && d.width < dialogWidth+10 {
-		dialogWidth = d.width - 10
-		if dialogWidth < 36 {
-			dialogWidth = 36
-		}
-	}
-	// On a genuinely tiny terminal, never let the box (content + RoundedBorder's
-	// 2 cols) exceed the screen — that would wrap the whole dialog and break the
-	// height accounting. Clamp to the available width as a last resort, all the
-	// way down to a minimal box, so the box+border invariant holds even on a
-	// pathologically narrow terminal (#1412, Codex review).
-	if d.width > 0 && dialogWidth > d.width-2 {
-		dialogWidth = d.width - 2
-	}
-	if dialogWidth < 1 {
-		dialogWidth = 1
-	}
+	// fitDialogWidth clamps to the terminal so the box (content + RoundedBorder's
+	// 2 cols) can never exceed the screen — that would wrap the whole dialog and
+	// break the one-row-per-block height accounting (#1412, Codex review). The
+	// shared helper folds in the last-resort narrow-terminal cap this dialog used
+	// to apply by hand.
+	dialogWidth := fitDialogWidth(60, 36, d.width)
 
 	// innerWidth is the content width INSIDE DialogBoxStyle's Padding(1,2):
 	// dialogWidth minus 2 columns of padding on each side. EVERY rendered row is

--- a/internal/ui/dialog_width_test.go
+++ b/internal/ui/dialog_width_test.go
@@ -1,0 +1,63 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFitDialogWidth pins the shared dialog width clamp: it reproduces the old
+// per-dialog behavior on roomy/narrow terminals and, crucially, never lets the
+// rendered box (width + border) exceed the terminal — the class of bug where a
+// fixed floor (e.g. skill_dialog's 56) overflowed a narrow split pane.
+func TestFitDialogWidth(t *testing.T) {
+	cases := []struct {
+		name                      string
+		preferred, minWidth, term int
+		want                      int
+	}{
+		{"roomy uses preferred", 44, 30, 80, 44},
+		{"wide caps at preferred", 60, 36, 200, 60},
+		{"narrowish shrinks with margin", 44, 30, 50, 40}, // 50-10=40, above the floor
+		{"narrow floors at minWidth", 44, 30, 35, 30},     // 35-10=25 -> floor 30 (box 32 fits)
+		{"hard cap prevents overflow", 86, 56, 57, 55},    // skill floor 56 would render 58 > 57
+		{"tiny terminal", 44, 30, 24, 22},                 // 24-2: box exactly fills the screen
+		{"unknown width returns preferred", 44, 30, 0, 44},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := fitDialogWidth(c.preferred, c.minWidth, c.term); got != c.want {
+				t.Errorf("fitDialogWidth(%d, %d, %d) = %d, want %d", c.preferred, c.minWidth, c.term, got, c.want)
+			}
+		})
+	}
+
+	// Invariant: across every real dialog's (preferred, minWidth) pair and every
+	// plausible terminal width, the bordered box must fit on screen. This is the
+	// guarantee the hand-rolled per-dialog floors used to violate.
+	pairs := [][2]int{{44, 30}, {60, 36}, {64, 50}, {70, 35}, {70, 40}, {86, 56}, {80, 35}}
+	for _, p := range pairs {
+		for term := 14; term <= 240; term++ {
+			got := fitDialogWidth(p[0], p[1], term)
+			if got+dialogBorderWidth > term {
+				t.Fatalf("overflow: fitDialogWidth(%d, %d, %d) = %d, box %d > term %d",
+					p[0], p[1], term, got, got+dialogBorderWidth, term)
+			}
+		}
+	}
+}
+
+// TestCenterInScreen_MeasuresDisplayCellsNotBytes guards the centering fix:
+// content is centered by its display width (cellWidth), not its byte length.
+// "日本語" is 6 cells but 9 bytes, so byte-based centering would under-pad it.
+func TestCenterInScreen_MeasuresDisplayCellsNotBytes(t *testing.T) {
+	const content = "日本語" // 3 wide glyphs => 6 cells, 9 bytes
+	if cellWidth(content) != 6 || len(content) != 9 {
+		t.Fatalf("precondition failed: cellWidth=%d len=%d", cellWidth(content), len(content))
+	}
+	out := centerInScreen(content, 20, 1)
+	line := strings.Split(out, "\n")[0]
+	leading := len(line) - len(strings.TrimLeft(line, " "))
+	if want := (20 - 6) / 2; leading != want {
+		t.Errorf("leading pad = %d, want %d (centered by cell width, not bytes)", leading, want)
+	}
+}

--- a/internal/ui/dialog_width_test.go
+++ b/internal/ui/dialog_width_test.go
@@ -46,6 +46,16 @@ func TestFitDialogWidth(t *testing.T) {
 	}
 }
 
+// TestDialogWidth_RemoteSessionsNotApplicable documents, per the internal/ui
+// RemoteSession coverage guideline, that nothing here needs a RemoteSession
+// case: fitDialogWidth and centerInScreen are pure layout geometry — they take
+// a terminal width and string content and never branch on session type, so
+// local vs. remote (SSH) sessions are indistinguishable to them. Mirrors
+// TestSessionSwitcher_RemoteSessionsUnsupported's documented-skip convention.
+func TestDialogWidth_RemoteSessionsNotApplicable(t *testing.T) {
+	t.Skip("not applicable: fitDialogWidth/centerInScreen are session-agnostic geometry helpers")
+}
+
 // TestCenterInScreen_MeasuresDisplayCellsNotBytes guards the centering fix:
 // content is centered by its display width (cellWidth), not its byte length.
 // "日本語" is 6 cells but 9 bytes, so byte-based centering would under-pad it.

--- a/internal/ui/group_dialog.go
+++ b/internal/ui/group_dialog.go
@@ -438,13 +438,7 @@ func (g *GroupDialog) View() string {
 	}
 
 	// Responsive dialog width
-	dialogWidth := 44
-	if g.width > 0 && g.width < dialogWidth+10 {
-		dialogWidth = g.width - 10
-		if dialogWidth < 30 {
-			dialogWidth = 30
-		}
-	}
+	dialogWidth := fitDialogWidth(44, 30, g.width)
 	titleWidth := dialogWidth - 4
 
 	titleStyle := DialogTitleStyle.Width(titleWidth)

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -351,19 +351,14 @@ func (h *HelpOverlay) View() string {
 		Bold(true)
 
 	// Responsive dialog width: prefer wider so descriptions don't wrap
-	// awkwardly. Default 70, scale up to ~80 when the terminal allows,
-	// shrink only on narrow terminals.
-	dialogWidth := 70
-	if h.width > 0 {
-		if h.width-10 < dialogWidth {
-			dialogWidth = h.width - 10
-			if dialogWidth < 35 {
-				dialogWidth = 35
-			}
-		} else if h.width >= 100 {
-			dialogWidth = 80
-		}
+	// awkwardly. Default 70, scale up to ~80 when the terminal is roomy; the
+	// shared helper handles shrinking (and the never-overflow clamp) on narrow
+	// terminals.
+	preferred := 70
+	if h.width >= 100 {
+		preferred = 80
 	}
+	dialogWidth := fitDialogWidth(preferred, 35, h.width)
 	keyWidth := 14
 	if dialogWidth < 45 {
 		keyWidth = 10 // Compact key column for small screens

--- a/internal/ui/mcp_dialog.go
+++ b/internal/ui/mcp_dialog.go
@@ -935,13 +935,7 @@ func (m *MCPDialog) View() string {
 		"[S]=stdio  [H]=http  [E]=sse  ●=running  ○=external  ✗=stopped")
 
 	// Responsive dialog width
-	dialogWidth := 64
-	if m.width > 0 && m.width < dialogWidth+10 {
-		dialogWidth = m.width - 10
-		if dialogWidth < 50 {
-			dialogWidth = 50
-		}
-	}
+	dialogWidth := fitDialogWidth(64, 50, m.width)
 	titleWidth := dialogWidth - 4
 
 	// Assemble dialog

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -279,8 +279,10 @@ func centerInScreen(content string, screenWidth, screenHeight int) string {
 	contentHeight := len(lines)
 	contentWidth := 0
 	for _, line := range lines {
-		if len(line) > contentWidth {
-			contentWidth = len(line)
+		// cellWidth (not len): the box lines carry ANSI styling, so byte length
+		// over-counts and the dialog ends up shifted left of true center.
+		if w := cellWidth(line); w > contentWidth {
+			contentWidth = w
 		}
 	}
 

--- a/internal/ui/session_picker_dialog.go
+++ b/internal/ui/session_picker_dialog.go
@@ -163,13 +163,7 @@ func (d *SessionPickerDialog) View() string {
 	content := strings.Join(lines, "\n")
 
 	// Dialog box
-	dialogWidth := 44
-	if d.width > 0 && d.width < dialogWidth+10 {
-		dialogWidth = d.width - 10
-		if dialogWidth < 30 {
-			dialogWidth = 30
-		}
-	}
+	dialogWidth := fitDialogWidth(44, 30, d.width)
 
 	box := DialogBoxStyle.
 		Width(dialogWidth).

--- a/internal/ui/skill_dialog.go
+++ b/internal/ui/skill_dialog.go
@@ -521,13 +521,7 @@ func (d *SkillDialog) View() string {
 		hint += lipgloss.NewStyle().Foreground(ColorTextDim).Render("  (" + d.typeJumpBuf + ")")
 	}
 
-	dialogWidth := 86
-	if d.width > 0 && d.width < dialogWidth+10 {
-		dialogWidth = d.width - 10
-		if dialogWidth < 56 {
-			dialogWidth = 56
-		}
-	}
+	dialogWidth := fitDialogWidth(86, 56, d.width)
 	titleWidth := dialogWidth - 4
 
 	parts := []string{

--- a/internal/ui/zoxide_picker.go
+++ b/internal/ui/zoxide_picker.go
@@ -231,13 +231,5 @@ func (z *ZoxidePicker) renderResults() string {
 }
 
 func (z *ZoxidePicker) dialogWidth() int {
-	const preferred = 70
-	if z.width > 0 && z.width < preferred+10 {
-		w := z.width - 10
-		if w < 40 {
-			w = 40
-		}
-		return w
-	}
-	return preferred
+	return fitDialogWidth(70, 40, z.width)
 }


### PR DESCRIPTION
## Summary

Every `DialogBoxStyle` dialog hand-rolled the same width clamp — `min(preferred, max(floor, width-10))` — but most omitted the never-overflow guard that only `codeblock` carried. As a result a fixed floor overflows a narrow terminal: `skill_dialog`'s floor of 56 renders a 58-cell box on a 57-cell split pane, `mcp_dialog`'s 50 overflows at ≤51, `group`/`session_picker`'s 30 at ≤31, and so on. (This is the same class of bug CodeRabbit flagged on the session switcher in #1475.)

This extracts a single helper and routes the family through it:

- **`fitDialogWidth(preferred, minWidth, termWidth)`** in `cellwidth.go`, with named chrome constants (`dialogBorderWidth`, `dialogScreenMargin`) and the hard terminal cap (`termWidth - border`) baked in. It reproduces the old `min(preferred, max(minWidth, width-10))` for every terminal that didn't overflow; **only the overflow case changes**.
- Migrated `session_picker`, `codeblock`, `help`, `mcp`, `zoxide`, `skill`, and `group` to it, deleting their copy-pasted clamps (including `codeblock`'s bespoke last-resort guard, now folded into the helper).
- Fixed **`centerInScreen`** to measure with `cellWidth` instead of `len` (byte length), so styled/multibyte dialogs center on their true display width instead of drifting left.

A table-driven test asserts the never-overflow invariant across the real dialogs' `(preferred, minWidth)` pairs for every terminal width 14–240, plus a `centerInScreen` cell-width regression.

## Motivation

The narrow-terminal overflow was duplicated across ~7 dialogs because each re-implemented the clamp. Consolidating into one helper fixes the whole class at once and gives future dialogs a correct default. The session switcher (#1475) keeps its bespoke auto-expand width logic for now to avoid a merge conflict; adopting `fitDialogWidth` there is a small follow-up once that lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed dialog centering when titles contain multi-byte characters.
  * Improved responsive dialog width calculations for narrow terminal windows.

* **Tests**
  * Added tests for dialog width constraints and character display handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->