### PR TITLE
fix(web): invalidate memory menu cache after mutations in headless mode

### DIFF
--- a/internal/web/memory_menu_data.go
+++ b/internal/web/memory_menu_data.go
@@ -64,6 +64,19 @@ func (m *MemoryMenuData) LoadArchivedMenuSnapshot() (*MenuSnapshot, error) {
 	return nil, fmt.Errorf("archived session list is not available")
 }
 
+// InvalidateCache clears the cached snapshot so the next call to
+// LoadMenuSnapshot reloads from the fallback storage-backed loader.
+// Used after mutations in headless (--no-tui) mode to ensure the menu
+// reflects the current persisted state on the next fetch.
+func (m *MemoryMenuData) InvalidateCache() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.snapshot = nil
+	m.mu.Unlock()
+}
+
 // SetSnapshot replaces the stored menu snapshot.
 func (m *MemoryMenuData) SetSnapshot(snapshot *MenuSnapshot) {
 	if m == nil {

--- a/internal/web/memory_menu_data_test.go
+++ b/internal/web/memory_menu_data_test.go
@@ -61,6 +61,67 @@ func TestMemoryMenuData_LoadMenuSnapshotFallbackAndCache(t *testing.T) {
 	}
 }
 
+func TestMemoryMenuData_InvalidateCacheForcesReload(t *testing.T) {
+	loader := &staticMenuLoader{
+		snapshot: &MenuSnapshot{
+			Profile:       "default",
+			GeneratedAt:   time.Now().UTC(),
+			TotalGroups:   1,
+			TotalSessions: 1,
+			Items: []MenuItem{
+				{
+					Type: MenuItemTypeSession,
+					Session: &MenuSession{
+						ID: "sess-1", Title: "Original",
+					},
+				},
+			},
+		},
+	}
+	store := NewMemoryMenuData(loader)
+
+	// First load populates the cache from the fallback loader.
+	first, err := store.LoadMenuSnapshot()
+	if err != nil {
+		t.Fatalf("first LoadMenuSnapshot() error = %v", err)
+	}
+	if loader.calls != 1 {
+		t.Fatalf("fallback calls after first load = %d, want 1", loader.calls)
+	}
+
+	// Second load returns the cached snapshot without calling the fallback.
+	_, err = store.LoadMenuSnapshot()
+	if err != nil {
+		t.Fatalf("second LoadMenuSnapshot() error = %v", err)
+	}
+	if loader.calls != 1 {
+		t.Fatalf("cached load triggered fallback: calls = %d, want 1", loader.calls)
+	}
+
+	// Verify the first snapshot content is correct
+	if got := first.Items[0].Session.Title; got != "Original" {
+		t.Fatalf("first load title = %q, want %q", got, "Original")
+	}
+
+	// Mutate the fallback data to simulate a storage-side change.
+	loader.snapshot.Items[0].Session.Title = "Updated"
+
+	// Invalidate the cache — next LoadMenuSnapshot must go back to fallback.
+	store.InvalidateCache()
+
+	// Third load must call the fallback and get the updated title.
+	third, err := store.LoadMenuSnapshot()
+	if err != nil {
+		t.Fatalf("third LoadMenuSnapshot() error = %v", err)
+	}
+	if loader.calls != 2 {
+		t.Fatalf("fallback calls after invalidate = %d, want 2", loader.calls)
+	}
+	if got := third.Items[0].Session.Title; got != "Updated" {
+		t.Fatalf("after invalidation title = %q, want %q", got, "Updated")
+	}
+}
+
 func TestMemoryMenuData_UpdateSessionStates(t *testing.T) {
 	store := NewMemoryMenuData(nil)
 	store.SetSnapshot(&MenuSnapshot{

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -429,6 +429,15 @@ func (s *Server) notifyMenuChanged() {
 		}
 	}
 	s.menuSubscribersMu.Unlock()
+
+	// Invalidate the MemoryMenuData cache so the next LoadMenuSnapshot()
+	// reloads from the storage-backed fallback. In headless (--no-tui) mode
+	// there is no TUI loop to call publishWebMenuSnapshot(), so without this
+	// the menu snapshot would remain frozen at its first-load state and new
+	// sessions created via the API would never appear until server restart.
+	if mmd, ok := s.menuData.(*MemoryMenuData); ok {
+		mmd.InvalidateCache()
+	}
 }
 
 // checkMutationsAllowed writes a 403 response and returns false when web mutations are disabled.


### PR DESCRIPTION
## Problem
In headless (`--no-tui`) web mode, `MemoryMenuData.LoadMenuSnapshot()` caches the menu snapshot indefinitely after the first call. Since there is no TUI loop to call `publishWebMenuSnapshot()` after mutations, new sessions created via the web API never appear in the menu until a server restart. Attempting to connect to one of these new sessions via WebSocket returns `TMUX_SESSION_NOT_FOUND` because the stale snapshot references a nonexistent tmux session.

## Root Cause
`MemoryMenuData.LoadMenuSnapshot()` returns the cached `m.snapshot` unconditionally once populated (line 39-41 in memory_menu_data.go). The storage-backed fallback is only queried on the very first call. In headless mode, `publishWebMenuSnapshot()` (which lives on `Home`) is never called because the bubbletea loop doesn't run.

## Fix
1. **`MemoryMenuData.InvalidateCache()`** — clears the cached snapshot so the next `LoadMenuSnapshot()` reloads from the storage-backed fallback.
2. **`Server.notifyMenuChanged()`** — calls `InvalidateCache()` on the `*MemoryMenuData` after sending SSE notifications. Every mutation handler already calls `notifyMenuChanged()`, so this ensures the cache is invalidated on every mutation.
3. **Test** — verifies that `InvalidateCache()` forces a subsequent `LoadMenuSnapshot()` to call the fallback and return fresh data.

## Testing
- `TestMemoryMenuData_InvalidateCacheForcesReload` — new test
- All existing `MemoryMenuData` tests pass (3/3)
- `TestCSRF*` and `TestHandleSessions*` pass (10/10) — no regressions from the `notifyMenuChanged()` change (test servers use `fakeMenuDataLoader`, not `*MemoryMenuData`, so the type assertion is a no-op)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where menu updates weren't immediately visible in headless/no-TUI mode by ensuring the menu cache is refreshed when changes occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->