### PR TITLE
fix(tui): make in-attach session switcher opt-in (Ctrl+S collides with Claude Code)

### DIFF
--- a/docs/terminal-shortcuts.md
+++ b/docs/terminal-shortcuts.md
@@ -19,6 +19,22 @@ Alacritty, Ghostty, gnome-terminal, kitty, WezTerm, the Linux console).
 Cycle between sessions while staying attached — no detach-then-reattach
 round trip through the list.
 
+> **Opt-in — unbound by default.** Switching *while attached* requires
+> intercepting a control byte in the attach loop **before the attached
+> program sees it**, so the chord is taken from whatever runs inside the
+> session. There is no control byte that's safe to steal from every tool:
+> the previously-suggested `Ctrl-S` is Claude Code's "stash prompt" key and
+> the terminal XOFF flow-control freeze. The switcher therefore ships
+> **disabled**. Enable it by binding a `ctrl+<letter>` chord your attached
+> tools don't use:
+>
+> ```toml
+> [hotkeys]
+> switch_session = "ctrl+s"   # pick a key free in your inner tools
+> ```
+>
+> The examples below assume you've bound `Ctrl-S`.
+
 | Keystroke | What happens |
 | --------- | ------------ |
 | `Ctrl-S` | Open the session switcher, pre-highlighted on the session you're currently in. |
@@ -52,13 +68,20 @@ already in, so an immediate `Enter` is a no-op) and waits — it only starts
 the auto-attach countdown once you actually cycle inside it, so an
 accidental press never yanks you away.
 
-**Why `Ctrl-S` and not `Ctrl-Tab` / `Ctrl-Shift-Tab`?** Those chords only
-produce a distinct keystroke on terminals running an enhanced keyboard
-protocol (kitty / Ghostty / WezTerm / foot), and not reliably through an
-attach — everywhere else `Ctrl-Tab` is indistinguishable from a plain
-`Tab`. A `ctrl+<letter>` byte is the only portable trigger. (`Ctrl-S`'s
-legacy XON/XOFF flow-control meaning is moot: the attach runs the
-terminal in raw mode.)
+**Why a `ctrl+<letter>` chord and not `Ctrl-Tab` / `Ctrl-Shift-Tab`?**
+Those chords only produce a distinct keystroke on terminals running an
+enhanced keyboard protocol (kitty / Ghostty / WezTerm / foot), and not
+reliably through an attach — everywhere else `Ctrl-Tab` is indistinguishable
+from a plain `Tab`. A `ctrl+<letter>` byte is the only portable trigger.
+
+**Why is it opt-in, and why not a built-in default key?** Because the
+trigger is only useful if the attach loop grabs it *before* forwarding to
+the attached program — which means that program never receives the byte.
+Every `ctrl+<letter>` already means something to some tool: `Ctrl-S` is
+Claude Code's "stash prompt" (and XON/XOFF flow-control), readline binds
+`Ctrl-A`/`Ctrl-E`/`Ctrl-W`, and so on. There is no globally-safe choice, so
+the switcher ships unbound and you pick a key that's free in the tools you
+actually attach to.
 
 **Why does it auto-commit instead of switching on key release?**
 Terminals don't deliver key-*release* events without an enhanced
@@ -67,8 +90,9 @@ release Ctrl" can't be detected. The idle auto-commit (~1s) approximates
 it: tap to cycle, stop, and it lands. Press `Enter` to commit instantly
 or `Esc` to back out.
 
-The trigger is configurable under `[hotkeys]` as `switch_session` (must
-be a `ctrl+<letter>` chord); it never overrides the detach key.
+The trigger is configured under `[hotkeys]` as `switch_session` (must be a
+`ctrl+<letter>` chord); it is unbound by default and never overrides the
+detach key.
 
 ## Known terminal gotchas
 

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -3494,11 +3494,17 @@ func CreateExampleConfig() error {
 # restart = "R"
 # detach = "ctrl+d"   # PTY-attach detach key, default ctrl+q (issue #434).
                       # Alias [tmux].detach_key exists; [hotkeys].detach wins.
-# In-attach session switcher (cycle sessions without first detaching to the list):
-# switch_session = "ctrl+s"   # opens the switcher while attached. Tap again to cycle
-#                             # forward (Ctrl+A to go back); it auto-attaches
-#                             # ~1s after you stop, Enter attaches now, Esc cancels.
-#                             # Must be a "ctrl+<letter>" chord.
+# Session switcher (cycle sessions without first detaching to the list).
+# OPT-IN: unbound by default. Enabling it makes the attach loop intercept the
+# chord before the attached program sees it, so the key is taken from whatever
+# runs inside the session. The old default Ctrl+S is a poor choice — it is
+# Claude Code's "stash prompt" key and the terminal XOFF flow-control freeze.
+# No control byte is safe to steal from every tool, so pick one your attached
+# tools do not use. Must be a "ctrl+<letter>" chord.
+# switch_session = "ctrl+s"   # opens the switcher while attached. Tap again to
+#                             # cycle forward (Ctrl+A to go back); it auto-
+#                             # attaches ~1s after you stop, Enter attaches now,
+#                             # Esc cancels. Same key opens it from the list.
 
 # Instance behavior (optional)
 # [instances]

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -186,6 +186,8 @@ func (h *HelpOverlay) View() string {
 	skillsKey := h.key(hotkeySkillsManager, "s")
 	previewKey := h.key(hotkeyTogglePreview, "v")
 	groupViewKey := h.key(hotkeyCycleGroupView, "t")
+	// Opt-in: empty when switch_session is unbound, so the filter drops the row.
+	switchKey := h.key(hotkeySwitchSession, "")
 	unreadKey := h.key(hotkeyMarkUnread, "u")
 	quickApproveKey := h.key(hotkeyQuickApprove, "a")
 	promptSessionKey := h.key(hotkeyPromptSession, "o")
@@ -316,7 +318,7 @@ func (h *HelpOverlay) View() string {
 				{reloadKey, "Reload from disk"},
 				{importKey, "Import tmux sessions"},
 				{"Ctrl+Q", "Detach from session"},
-				{"Ctrl+S", "Switch session (here or attached)"},
+				{switchKey, "Switch session (here or attached)"},
 				{quitKey, "Quit"},
 				{helpKey, "This help"},
 			},

--- a/internal/ui/hotkeys.go
+++ b/internal/ui/hotkeys.go
@@ -51,7 +51,12 @@ const (
 	// Session switcher. While attached it is intercepted in the tmux attach
 	// loop (see internal/tmux/pty.go AttachOptions); on the home screen it is
 	// dispatched like any other hotkey. Must resolve to a "ctrl+<letter>" chord.
-	hotkeySwitchSession = "switch_session" // Ctrl+S
+	//
+	// Disabled by default (see defaultDisabledHotkeys): intercepting it while
+	// attached steals the control byte from the attached program, and the
+	// suggested Ctrl+S collides with Claude Code (stash prompt) and XOFF
+	// flow-control. Users opt in by binding [hotkeys].switch_session.
+	hotkeySwitchSession = "switch_session" // canonical "ctrl+s" (opt-in)
 )
 
 var hotkeyActionOrder = []string{
@@ -155,6 +160,18 @@ var renamedHotkeys = map[string]string{
 	"toggle_gemini_yolo": hotkeyToggleYolo,
 }
 
+// defaultDisabledHotkeys are actions that keep a canonical key in
+// defaultHotkeyBindings (so the home-screen dispatch case and help/status
+// labels resolve) but ship UNBOUND: resolveHotkeys drops them unless the user
+// binds them explicitly. switch_session is opt-in because enabling it
+// intercepts a control byte in the attach loop before the attached program
+// sees it — the suggested Ctrl+S collides with Claude Code's stash-prompt and
+// terminal XOFF flow-control, and no control byte is safe to steal from every
+// attached tool.
+var defaultDisabledHotkeys = map[string]bool{
+	hotkeySwitchSession: true,
+}
+
 func resolveHotkeys(overrides map[string]string) map[string]string {
 	bindings := make(map[string]string, len(defaultHotkeyBindings))
 	for action, key := range defaultHotkeyBindings {
@@ -196,6 +213,15 @@ func resolveHotkeys(overrides map[string]string) map[string]string {
 			continue
 		}
 		bindings[action] = key
+	}
+
+	// Opt-in actions ship unbound: drop them unless the user set them
+	// explicitly. The canonical default stays in defaultHotkeyBindings so the
+	// dispatch case and labels resolve once a user binds it.
+	for action := range defaultDisabledHotkeys {
+		if _, overridden := canonicalOverrides[action]; !overridden {
+			delete(bindings, action)
+		}
 	}
 
 	return bindings

--- a/internal/ui/switch_keys_test.go
+++ b/internal/ui/switch_keys_test.go
@@ -3,8 +3,48 @@ package ui
 import "testing"
 
 func TestResolvedSwitchByte_Default(t *testing.T) {
-	if got := ResolvedSwitchByte(nil); got != 0x13 {
-		t.Errorf("default switch byte = %#x, want Ctrl+S (0x13)", got)
+	// The in-attach switcher is opt-in: with no override it is unbound, so the
+	// attach loop never steals a control byte from the attached program.
+	if got := ResolvedSwitchByte(nil); got != 0 {
+		t.Errorf("default switch byte = %#x, want 0 (opt-in, unbound)", got)
+	}
+}
+
+func TestResolvedSwitchByte_OptInEnablesCtrlS(t *testing.T) {
+	// Binding the suggested Ctrl+S explicitly re-enables it (user accepts the
+	// collision with the attached program).
+	if got := ResolvedSwitchByte(map[string]string{"switch_session": "ctrl+s"}); got != 0x13 {
+		t.Errorf("opt-in ctrl+s switch byte = %#x, want 0x13", got)
+	}
+}
+
+func TestSwitchSessionUnboundByDefault(t *testing.T) {
+	bindings := resolveHotkeys(nil)
+	if key, ok := bindings[hotkeySwitchSession]; ok {
+		t.Errorf("switch_session bound to %q by default, want unbound", key)
+	}
+	// Pressing the canonical key must not normalize to the dispatch token when
+	// the action is unbound — otherwise the home-screen switcher would still
+	// open.
+	lookup, blocked := buildHotkeyLookup(bindings)
+	if _, ok := lookup["ctrl+s"]; ok {
+		t.Errorf("ctrl+s maps to a canonical action while switch_session is unbound")
+	}
+	if !blocked["ctrl+s"] {
+		t.Errorf("ctrl+s should be blocked while switch_session is unbound")
+	}
+}
+
+func TestSwitchSessionOptInDispatch(t *testing.T) {
+	// Once bound, the chord normalizes to the canonical dispatch token so the
+	// home-screen `case "ctrl+s"` arm fires.
+	bindings := resolveHotkeys(map[string]string{"switch_session": "ctrl+o"})
+	if bindings[hotkeySwitchSession] != "ctrl+o" {
+		t.Fatalf("switch_session = %q, want ctrl+o", bindings[hotkeySwitchSession])
+	}
+	lookup, _ := buildHotkeyLookup(bindings)
+	if got := lookup["ctrl+o"]; got != "ctrl+s" {
+		t.Errorf("ctrl+o canonical = %q, want ctrl+s dispatch token", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes the in-attach session switcher from #1411 **opt-in**. It currently binds **`Ctrl+S` by default**, and that collides badly with what runs *inside* a session.

## The conflict

To switch sessions *while attached*, the attach loop has to grab the trigger byte out of stdin **before forwarding to the inner PTY** (`internal/tmux/pty.go`, `indexSwitchKey` → the stdin reader stops at the switch byte and never writes it through). So the attached program never sees the key.

`Ctrl+S` is a particularly unfortunate default:

- **Claude Code uses `Ctrl+S` to stash the current prompt** — attached, that keystroke is swallowed by agent-deck and Claude Code never receives it.
- `Ctrl+S` is also the classic **XOFF flow-control freeze**, a long-standing terminal footgun.

And the deeper point: *any* `ctrl+<letter>` we intercept is stolen from the attached tool. There is no control byte that's safe to grab from every program (readline binds `Ctrl-A`/`Ctrl-E`/`Ctrl-W`, editors and REPLs bind others). So defaulting the switcher to *any* key is wrong — it should be the user's explicit choice, scoped to keys their own tools don't use.

## Change

- `switch_session` ships **unbound**. A new `defaultDisabledHotkeys` set keeps the canonical `"ctrl+s"` in `defaultHotkeyBindings` (so the home-screen dispatch `case` and the help/status labels still resolve once a key is bound), but `resolveHotkeys` drops the action unless the user binds it explicitly.
- Opt in via config:
  ```toml
  [hotkeys]
  switch_session = "ctrl+s"   # pick a chord free in your attached tools
  ```
- While unbound: nothing is intercepted during attach (the inner program gets every key), the overview `Ctrl+S` opener is inert, the help-overlay row is hidden, and the attached status bar shows no switch hint — all driven off the same resolved binding, so they can't drift.
- Docs (`docs/terminal-shortcuts.md`) and the `config.toml` template rewritten to explain the opt-in and the conflict.

## Why opt-in rather than "pick a better default key"

I considered just moving the default off `Ctrl+S`, but every candidate has the same problem — e.g. `Ctrl+O` is also used by Claude Code. Since the switcher must steal whatever byte it's bound to from the attached program, the only correct default is "none," with the user choosing a key safe for their stack.

## Testing

- `internal/ui` and `internal/tmux` suites pass.
- New/updated tests in `internal/ui/switch_keys_test.go`: default is now unbound (`ResolvedSwitchByte(nil) == 0`); explicit `ctrl+s` re-enables it; `switch_session` is absent from resolved bindings by default and its canonical key is blocked (so the overview opener is inert); an opt-in binding (`ctrl+o`) normalizes to the `ctrl+s` dispatch token.
- The byte-interception tests in `internal/tmux/switch_key_test.go` are unaffected (they exercise `AttachOptions` directly).

> Note: a few pre-existing `internal/session` tests fail in my sandbox (transcript-path / SSH-socket cases that touch real `$HOME` and aren't isolated here); they fail identically on unmodified `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * The session switcher hotkey is now opt-in and unbound by default. Users can enable it by configuring the binding in their configuration file.
  * Updated configuration documentation to describe the opt-in behavior and session switcher semantics.
  * Help overlay now dynamically displays the session switcher binding when configured, or omits it when unbound.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->