### PR TITLE
fix(fork): preserve tool identity for Claude-compatible forks

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -6736,6 +6736,10 @@ func (i *Instance) CreateForkedInstanceWithOptions(
 		forked.GroupPath = i.GroupPath
 	}
 	forked.Tool = "claude"
+	if IsClaudeCompatible(i.Tool) {
+		forked.Tool = i.Tool
+	}
+	forked.Wrapper = i.Wrapper
 
 	// #1407: persist the parent's ExtraArgs onto the fork record. The baked
 	// one-shot fork command below inherits them implicitly via the builder

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -299,6 +299,43 @@ func TestInstance_CreateForkedInstance(t *testing.T) {
 	}
 }
 
+func TestInstance_CreateForkedInstance_PreservesCompatibleToolIdentity(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	cfg := &UserConfig{
+		Tools: map[string]ToolDef{
+			"my-claude": {
+				Command:        "claude-wrapper",
+				CompatibleWith: "claude",
+			},
+		},
+	}
+	if err := SaveUserConfig(cfg); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+	ClearUserConfigCache()
+
+	parent := NewInstanceWithTool("cl parent", "/tmp/original", "my-claude")
+	parent.Wrapper = "wrap {command}"
+	parent.ClaudeSessionID = "abc-123"
+	parent.ClaudeDetectedAt = time.Now()
+
+	forked, _, err := parent.CreateForkedInstanceWithOptions("cl parent (fork)", "", nil)
+	if err != nil {
+		t.Fatalf("CreateForkedInstanceWithOptions: %v", err)
+	}
+	if forked.Tool != "my-claude" {
+		t.Fatalf("forked Tool = %q, want custom Claude-compatible tool identity", forked.Tool)
+	}
+	if forked.Wrapper != parent.Wrapper {
+		t.Fatalf("forked Wrapper = %q, want %q", forked.Wrapper, parent.Wrapper)
+	}
+}
+
 // TestInstance_CreateForkedInstance_ExplicitConfig tests CreateForkedInstance with explicit config
 func TestInstance_CreateForkedInstance_ExplicitConfig(t *testing.T) {
 	// Isolate from user's environment (don't pick up their config.toml)


### PR DESCRIPTION
## Problem

`CreateForkedInstanceWithOptions` hardcoded `forked.Tool = "claude"`, so forking a session of a **custom Claude-compatible tool** (a `[tools.X]` entry with `compatible_with = "claude"`) dropped its configured identity and reverted to the generic `claude` tool — losing the custom command, wrapper, and model defaults.

The Codex, Pi, and OpenCode fork paths already preserve the parent tool; the Claude/default path did not.

## Fix

Inherit `i.Tool` when the parent is Claude-compatible, and copy the parent's `Wrapper`:

```go
forked.Tool = "claude"
if IsClaudeCompatible(i.Tool) {
    forked.Tool = i.Tool
}
forked.Wrapper = i.Wrapper
```

The copy is gated on `IsClaudeCompatible` because this is the dispatcher's catch-all branch — unlike the Codex path it has no compatibility guarantee, so non-Claude parents (e.g. a synthetic `shell` instance) still fall back to `claude`. A plain `claude` parent is unchanged.

## Testing

- Added `TestInstance_CreateForkedInstance_PreservesCompatibleToolIdentity` (forks a custom `compatible_with = "claude"` tool, asserts `Tool` and `Wrapper` are preserved).
- All existing `Fork` tests pass; `gofmt`/`go build`/`go vet` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Forked instances now preserve the source tool identity when the tool is Claude-compatible, ensuring consistency across instance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->