### PR TITLE
fix: status & daemon reliability hardening

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -2193,14 +2193,58 @@ func InstallTransitionNotifierDaemon() (string, error) {
 	}
 }
 
-func installTransitionNotifierLaunchd() (string, error) {
-	plistContent, err := GenerateTransitionNotifierLaunchdPlist()
+// Seams for the Background-domain eviction guard (testable without touching the
+// real launchd registration). Production points them at the real impls.
+var (
+	transitionNotifierManagerName = launchctlManagerName
+	transitionNotifierIsRunning   = IsTransitionNotifierDaemonRunning
+	runLaunchctl                  = func(args ...string) error { return exec.Command("launchctl", args...).Run() }
+)
+
+// launchctlManagerName returns the current launchd domain's manager name —
+// "Aqua" for a login GUI session, "Background" for a process running under a
+// launchd-managed daemon (e.g. a tmux pane spawned by the agent-deck web
+// daemon, which is where a conductor session runs). Empty if launchctl is
+// unavailable or errors.
+func launchctlManagerName() string {
+	out, err := exec.Command("launchctl", "managername").Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to generate notifier plist: %w", err)
+		return ""
 	}
+	return strings.TrimSpace(string(out))
+}
+
+// inBackgroundLaunchdDomain reports whether we are in the launchd "Background"
+// domain — i.e. inside a daemon-spawned process tree (a conductor pane), not a
+// login shell. A user/GUI-domain `launchctl unload` issued from here reaches the
+// live notify-daemon CROSS-DOMAIN and evicts it, and the paired `load` registers
+// into the wrong (Background) domain — killing completion delivery fleet-wide.
+func inBackgroundLaunchdDomain() bool {
+	return transitionNotifierManagerName() == "Background"
+}
+
+func installTransitionNotifierLaunchd() (string, error) {
 	plistPath, err := TransitionNotifierLaunchdPlistPath()
 	if err != nil {
 		return "", fmt.Errorf("failed to get notifier plist path: %w", err)
+	}
+
+	// Background-domain eviction guard. `conductor setup` run from inside a
+	// conductor pane executes in the launchd "Background" domain. The unload
+	// below would reach the live notify-daemon cross-domain and evict it, and the
+	// load would re-register it into the wrong domain — completion delivery dies
+	// fleet-wide. When the daemon already runs and we're in Background, leave its
+	// registration completely untouched (conductor setup proceeds otherwise).
+	if inBackgroundLaunchdDomain() && transitionNotifierIsRunning() {
+		fmt.Fprintln(os.Stderr, "notify-daemon install skipped — Background launchd domain, "+
+			"existing daemon left intact (an unload here would evict it cross-domain). "+
+			"Re-run `agent-deck conductor setup` from a login shell to (re)install.")
+		return plistPath, nil
+	}
+
+	plistContent, err := GenerateTransitionNotifierLaunchdPlist()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate notifier plist: %w", err)
 	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -2209,11 +2253,11 @@ func installTransitionNotifierLaunchd() (string, error) {
 	if err := os.MkdirAll(filepath.Join(homeDir, "Library", "LaunchAgents"), 0o755); err != nil {
 		return "", fmt.Errorf("failed to create LaunchAgents dir: %w", err)
 	}
-	_ = exec.Command("launchctl", "unload", plistPath).Run()
+	_ = runLaunchctl("unload", plistPath)
 	if err := os.WriteFile(plistPath, []byte(plistContent), 0o644); err != nil {
 		return "", fmt.Errorf("failed to write notifier plist: %w", err)
 	}
-	if err := exec.Command("launchctl", "load", plistPath).Run(); err != nil {
+	if err := runLaunchctl("load", plistPath); err != nil {
 		return plistPath, fmt.Errorf("plist written but failed to load notifier daemon: %w", err)
 	}
 	return plistPath, nil

--- a/internal/session/conductor_bg_guard_test.go
+++ b/internal/session/conductor_bg_guard_test.go
@@ -1,0 +1,109 @@
+package session
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The Background-domain eviction guard: `conductor setup` run from inside a
+// conductor pane (launchd "Background" domain) must NOT unload/load the live
+// notify-daemon — that cross-domain unload evicts it fleet-wide. These tests
+// drive installTransitionNotifierLaunchd through its seams (no real launchctl,
+// HOME pointed at a temp dir) and assert which launchctl verbs are issued.
+
+func withGuardSeams(t *testing.T, managerName string, running bool) *[]string {
+	t.Helper()
+	// Isolate the plist path so the proceed-path WriteFile lands in a temp dir,
+	// never the real ~/Library/LaunchAgents.
+	t.Setenv("HOME", t.TempDir())
+
+	var calls []string
+	origMgr := transitionNotifierManagerName
+	origRun := transitionNotifierIsRunning
+	origExec := runLaunchctl
+	transitionNotifierManagerName = func() string { return managerName }
+	transitionNotifierIsRunning = func() bool { return running }
+	runLaunchctl = func(args ...string) error {
+		calls = append(calls, strings.Join(args, " "))
+		return nil
+	}
+	t.Cleanup(func() {
+		transitionNotifierManagerName = origMgr
+		transitionNotifierIsRunning = origRun
+		runLaunchctl = origExec
+	})
+	return &calls
+}
+
+func containsPrefix(calls []string, prefix string) bool {
+	for _, c := range calls {
+		if strings.HasPrefix(c, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// SAFE-AFTER: Background domain + daemon running → guard skips, ZERO launchctl
+// verbs issued (no unload = no eviction), and the existing plist is not rewritten.
+func TestInstallTransitionNotifierLaunchd_BackgroundRunning_SkipsUnload(t *testing.T) {
+	calls := withGuardSeams(t, "Background", true)
+
+	path, err := installTransitionNotifierLaunchd()
+	if err != nil {
+		t.Fatalf("guarded skip must not error; got %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("guard must issue NO launchctl verbs in Background w/ running daemon "+
+			"(an unload would evict it cross-domain); got %v", *calls)
+	}
+	if path == "" {
+		t.Fatalf("guard should still return the plist path for the caller's message")
+	}
+}
+
+// EVICTS-BEFORE (the bug, modeled): without the guard condition (Aqua login
+// domain), the install proceeds and DOES issue unload + load — the exact verbs
+// that, in the Background domain, evict the live daemon. Pins that the guard is
+// the only thing standing between Background and that unload.
+func TestInstallTransitionNotifierLaunchd_LoginDomain_ProceedsWithUnloadLoad(t *testing.T) {
+	calls := withGuardSeams(t, "Aqua", false)
+
+	if _, err := installTransitionNotifierLaunchd(); err != nil {
+		t.Fatalf("login-domain install must proceed cleanly; got %v", err)
+	}
+	if !containsPrefix(*calls, "unload ") {
+		t.Fatalf("login-domain install must issue the unload (the evicting verb); got %v", *calls)
+	}
+	if !containsPrefix(*calls, "load ") {
+		t.Fatalf("login-domain install must issue the load; got %v", *calls)
+	}
+}
+
+// Background but daemon NOT running: nothing to protect → proceed (first install
+// from a conductor pane when no daemon exists must still work).
+func TestInstallTransitionNotifierLaunchd_BackgroundNotRunning_Proceeds(t *testing.T) {
+	calls := withGuardSeams(t, "Background", false)
+
+	if _, err := installTransitionNotifierLaunchd(); err != nil {
+		t.Fatalf("background-but-not-running install must proceed; got %v", err)
+	}
+	if !containsPrefix(*calls, "unload ") || !containsPrefix(*calls, "load ") {
+		t.Fatalf("with no live daemon to protect, install must proceed (unload+load); got %v", *calls)
+	}
+}
+
+// The plist path the guard returns must be the real notifier path (sanity that
+// the early return didn't fabricate a path).
+func TestInstallTransitionNotifierLaunchd_SkipReturnsNotifierPath(t *testing.T) {
+	withGuardSeams(t, "Background", true)
+	path, err := installTransitionNotifierLaunchd()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want, _ := TransitionNotifierLaunchdPlistPath()
+	if filepath.Base(path) != filepath.Base(want) {
+		t.Fatalf("skip returned %q, want notifier plist %q", path, want)
+	}
+}

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4084,6 +4084,16 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
+	// Snapshot the prior hook-status fields so a candidate that fails the
+	// ownership check below can RESTORE them rather than leaving its status
+	// applied. This closes the `claude -p` env-pollution flip: a foreign
+	// ephemeral session (a `claude -p` child that inherited our
+	// AGENTDECK_INSTANCE_ID and fired hooks under our id) has no conversation
+	// data, so the bind is rejected — but previously the running/waiting status
+	// it carried had already been written here and stuck, flipping this
+	// instance's status. See the candidate_has_no_conversation_data branch.
+	prevHookStatus, prevHookEvent, prevHookLastUpdate := i.hookStatus, i.hookEvent, i.hookLastUpdate
+
 	// Detect whether this is genuinely new data (newer timestamp than last seen).
 	// Only reset acknowledgment on new events — not on re-application of the same
 	// stale hook file, which would undo the user's intentional acknowledge.
@@ -4144,6 +4154,13 @@ func (i *Instance) UpdateHookStatus(status *HookStatus) {
 		}
 		// v1.7.7 guard: candidate must have any conversation data at all.
 		if !sessionHasConversationData(i, sessionID) {
+			// A different session id with NO conversation data on an established
+			// instance is a foreign ephemeral (a `claude -p` child that inherited
+			// our AGENTDECK_INSTANCE_ID) — it doesn't own this instance, so its
+			// status must not stick either. Restore the pre-event status so the
+			// foreign hook is a no-op, not a flip. (A real /clear or fork carries
+			// conversation data and never reaches this branch.)
+			i.hookStatus, i.hookEvent, i.hookLastUpdate = prevHookStatus, prevHookEvent, prevHookLastUpdate
 			_ = WriteSessionIDLifecycleEvent(SessionIDLifecycleEvent{
 				InstanceID: i.ID, Tool: i.Tool, Action: "reject",
 				Source: hookSource, OldID: i.ClaudeSessionID, Candidate: sessionID,

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -410,6 +410,15 @@ type Instance struct {
 	// Not serialized - only relevant for current TUI session
 	lastStartTime time.Time
 
+	// tmuxFlipFromRunningPending debounces a purely tmux-inferred flip AWAY from
+	// running (→ waiting/error). A long single tool-call (past the hook freshness
+	// window) or transient subprocess churn can momentarily present the pane as a
+	// shell prompt or a capture error, then recover; without a confirming second
+	// sample that single transient read fires a false completion/error to the
+	// conductor. Set when we hold the first such sample at running; cleared on any
+	// settled (running/idle) outcome or once the flip is confirmed. Not serialized.
+	tmuxFlipFromRunningPending bool
+
 	// addedThisProcess is true only for instances built by a NewInstance*
 	// constructor in the current process (i.e. just `add`ed), and false for
 	// instances reloaded from storage (built as struct literals). Combined with
@@ -3656,6 +3665,26 @@ func (i *Instance) neverStarted() bool {
 
 // UpdateStatus updates the session status by checking tmux.
 // Thread-safe: acquires write lock to protect Status, Tool, and internal cache fields.
+// debounceFlipFromRunning decides whether a tmux-derived status that flips AWAY
+// from running should be held for one confirming sample. It returns the status
+// to apply, the next value for the pending marker, and whether the flip was
+// HELD (the caller applies `apply` and returns early when held is true).
+//
+// Held only on the FIRST tmux-inferred running→{waiting,error} sample (pending
+// was false): a long single tool-call past the hook freshness window, or a
+// transient CapturePane failure during subprocess churn, can present that flip
+// for one tick and then recover. A genuinely dead pane (tmux raw "inactive")
+// and a "dead" hook are real terminal signals and are never debounced. Pure for
+// testability.
+func debounceFlipFromRunning(prev, derived Status, tmuxRaw, hookStatus string, pending bool) (apply Status, nextPending bool, held bool) {
+	flipAwayFromRunning := (derived == StatusWaiting || derived == StatusError) &&
+		tmuxRaw != "inactive" && hookStatus != "dead"
+	if prev == StatusRunning && flipAwayFromRunning && !pending {
+		return StatusRunning, true, true
+	}
+	return derived, false, false
+}
+
 func (i *Instance) UpdateStatus() error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -3849,7 +3878,20 @@ func (i *Instance) UpdateStatus() error {
 		return nil
 	}
 
+	// Prior status, captured before this tmux-derived sample overwrites it, so the
+	// debounce below can tell a flip AWAY from running from a steady state.
+	prevStatus := i.Status
+
 	if err != nil {
+		// Debounce a transient capture failure: subprocess churn can make a single
+		// CapturePane fail, then recover. Hold at running for one sample rather than
+		// firing a false error. Modeled as a derived error with no tmux raw status.
+		if apply, nextPending, held := debounceFlipFromRunning(prevStatus, StatusError, "", i.hookStatus, i.tmuxFlipFromRunningPending); held {
+			i.tmuxFlipFromRunningPending = nextPending
+			i.Status = apply
+			return nil
+		}
+		i.tmuxFlipFromRunningPending = false
 		i.Status = StatusError
 		return err
 	}
@@ -3892,6 +3934,21 @@ func (i *Instance) UpdateStatus() error {
 	default:
 		i.Status = StatusError
 	}
+
+	// Debounce a purely tmux-inferred flip away from running (see
+	// tmuxFlipFromRunningPending). A long single tool-call past the hook freshness
+	// window can momentarily present the pane as a shell prompt ("waiting") or a
+	// transient error, then recover; one confirming sample prevents a false
+	// completion/error to the conductor. A genuinely dead pane (tmux "inactive")
+	// and a "dead" hook are NOT debounced — those are real terminal signals.
+	if apply, nextPending, held := debounceFlipFromRunning(prevStatus, i.Status, status, i.hookStatus, i.tmuxFlipFromRunningPending); held {
+		i.tmuxFlipFromRunningPending = nextPending
+		i.Status = apply
+		return nil
+	}
+	// Confirmed flip (second consecutive sample) or a non-debounceable outcome:
+	// clear the marker so a later genuine flip starts a fresh debounce.
+	i.tmuxFlipFromRunningPending = false
 
 	// Hermes: augment status with gateway health when a gateway URL is resolvable.
 	// Check is throttled to 30s to avoid 1.5s HTTP delays on every status tick.

--- a/internal/session/instance_foreign_session_guard_test.go
+++ b/internal/session/instance_foreign_session_guard_test.go
@@ -118,7 +118,7 @@ func TestUpdateHookStatus_LegitRebindWithData_NotSuppressed(t *testing.T) {
 	newPath := seedClaudeJSONL(t, inst, newID, 1, 8) // smaller-but-fresh: the /clear shape
 
 	now := time.Now()
-	oldMtime := now.Add(-clearRebindMtimeGrace)
+	oldMtime := now.Add(-clearRebindMtimeGrace - time.Second)
 	if err := os.Chtimes(oldPath, oldMtime, oldMtime); err != nil {
 		t.Fatalf("chtimes old: %v", err)
 	}

--- a/internal/session/instance_foreign_session_guard_test.go
+++ b/internal/session/instance_foreign_session_guard_test.go
@@ -1,0 +1,143 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Regression coverage for the `claude -p` env-pollution class: a foreign
+// ephemeral Claude session (a `claude -p` child that inherited this instance's
+// AGENTDECK_INSTANCE_ID via env and fired its own hooks under our id) must not
+// flip THIS instance's status. The bind path already rejected the foreign
+// session id (candidate_has_no_conversation_data); these tests pin that the
+// STATUS application is now gated by the same ownership check.
+//
+// Setup mirrors instance_clear_rebind_boundary_test.go (seedClaudeJSONL +
+// isolated HOME/CLAUDE_CONFIG_DIR).
+
+func newGuardTestInstance(t *testing.T, title string) *Instance {
+	t.Helper()
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(tmpHome, ".claude"))
+	ClearUserConfigCache()
+	t.Cleanup(ClearUserConfigCache)
+
+	projectPath := filepath.Join(tmpHome, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	return NewInstanceWithTool(title, projectPath, "claude")
+}
+
+// Foreign ephemeral (different id, NO conversation data) on an ESTABLISHED
+// instance: status must NOT be applied, bind must NOT change, and a reject is
+// logged with the foreign-session reason.
+func TestUpdateHookStatus_ForeignEphemeral_StatusSuppressed(t *testing.T) {
+	inst := newGuardTestInstance(t, "foreign-guard-suppress")
+
+	ownID := "5ea244ce-0000-0000-0000-0000000000a0"
+	foreignID := "2266314c-0000-0000-0000-0000000000b0" // no jsonl seeded → no conversation data
+	seedClaudeJSONL(t, inst, ownID, 50, 512)            // our real session has history
+	inst.ClaudeSessionID = ownID
+
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: foreignID,
+		Event:     "UserPromptSubmit",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.hookStatus == "running" {
+		t.Fatalf("foreign ephemeral claude -p hook flipped our hookStatus to %q; "+
+			"the ownership guard must suppress a no-conversation-data foreign session", inst.hookStatus)
+	}
+	if inst.ClaudeSessionID != ownID {
+		t.Fatalf("foreign session must not rebind; got %q want %q", inst.ClaudeSessionID, ownID)
+	}
+	events := readLifecycleEvents(t)
+	if !hasRejectReason(events, "candidate_has_no_conversation_data") {
+		t.Fatalf("expected reject reason=candidate_has_no_conversation_data; events=%+v", events)
+	}
+}
+
+// The owning session's own hook (SessionID == bound id) must apply normally.
+func TestUpdateHookStatus_OwningSession_StatusApplied(t *testing.T) {
+	inst := newGuardTestInstance(t, "foreign-guard-owning")
+
+	ownID := "5ea244ce-0000-0000-0000-0000000000a1"
+	seedClaudeJSONL(t, inst, ownID, 50, 512)
+	inst.ClaudeSessionID = ownID
+
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: ownID,
+		Event:     "UserPromptSubmit",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.hookStatus != "running" {
+		t.Fatalf("owning session hook must apply status; got hookStatus=%q want running", inst.hookStatus)
+	}
+}
+
+// Cold start (no bound id yet) must NOT be suppressed — the first real session
+// has to be free to bind and report status.
+func TestUpdateHookStatus_ColdStart_NotSuppressed(t *testing.T) {
+	inst := newGuardTestInstance(t, "foreign-guard-coldstart")
+
+	firstID := "2266314c-0000-0000-0000-0000000000c0" // no jsonl needed: cold start binds unconditionally
+	inst.ClaudeSessionID = ""
+
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: firstID,
+		Event:     "UserPromptSubmit",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.hookStatus != "running" {
+		t.Fatalf("cold-start hook must apply status; got hookStatus=%q want running", inst.hookStatus)
+	}
+	if inst.ClaudeSessionID != firstID {
+		t.Fatalf("cold-start must bind first candidate; got %q want %q", inst.ClaudeSessionID, firstID)
+	}
+}
+
+// A LEGITIMATE rebind (different id but WITH conversation data, /clear shape)
+// must NOT be flagged as foreign — status applies and the rebind proceeds. This
+// pins that the guard never starves a real session change.
+func TestUpdateHookStatus_LegitRebindWithData_NotSuppressed(t *testing.T) {
+	inst := newGuardTestInstance(t, "foreign-guard-rebind")
+
+	oldID := "5ea244ce-0000-0000-0000-0000000000a2"
+	newID := "2266314c-0000-0000-0000-0000000000d0"
+	oldPath := seedClaudeJSONL(t, inst, oldID, 200, 1024)
+	newPath := seedClaudeJSONL(t, inst, newID, 1, 8) // smaller-but-fresh: the /clear shape
+
+	now := time.Now()
+	oldMtime := now.Add(-clearRebindMtimeGrace)
+	if err := os.Chtimes(oldPath, oldMtime, oldMtime); err != nil {
+		t.Fatalf("chtimes old: %v", err)
+	}
+	if err := os.Chtimes(newPath, now, now); err != nil {
+		t.Fatalf("chtimes new: %v", err)
+	}
+
+	inst.ClaudeSessionID = oldID
+	inst.UpdateHookStatus(&HookStatus{
+		Status:    "running",
+		SessionID: newID,
+		Event:     "UserPromptSubmit",
+		UpdatedAt: time.Now(),
+	})
+
+	if inst.hookStatus != "running" {
+		t.Fatalf("legit rebind (candidate has conversation data) must apply status; got %q", inst.hookStatus)
+	}
+	if inst.ClaudeSessionID != newID {
+		t.Fatalf("legit /clear rebind must proceed; got ClaudeSessionID=%q want %q", inst.ClaudeSessionID, newID)
+	}
+}

--- a/internal/session/instance_status_debounce_test.go
+++ b/internal/session/instance_status_debounce_test.go
@@ -1,0 +1,109 @@
+package session
+
+import "testing"
+
+// debounceFlipFromRunning gates a purely tmux-inferred flip away from running so
+// a single transient sample (long tool-call past the hook freshness window, or a
+// CapturePane failure during subprocess churn) does not fire a false
+// completion/error to the conductor. These pin the one-tick-hold-then-flip
+// behavior and the non-debounceable terminal signals.
+func TestDebounceFlipFromRunning(t *testing.T) {
+	cases := []struct {
+		name        string
+		prev        Status
+		derived     Status
+		tmuxRaw     string
+		hookStatus  string
+		pending     bool
+		wantApply   Status
+		wantPending bool
+		wantHeld    bool
+	}{
+		{
+			name: "first running->waiting sample is HELD at running",
+			prev: StatusRunning, derived: StatusWaiting, tmuxRaw: "waiting", pending: false,
+			wantApply: StatusRunning, wantPending: true, wantHeld: true,
+		},
+		{
+			name: "second consecutive running->waiting sample FLIPS",
+			prev: StatusRunning, derived: StatusWaiting, tmuxRaw: "waiting", pending: true,
+			wantApply: StatusWaiting, wantPending: false, wantHeld: false,
+		},
+		{
+			name: "first running->error (banner) sample is HELD",
+			prev: StatusRunning, derived: StatusError, tmuxRaw: "error", pending: false,
+			wantApply: StatusRunning, wantPending: true, wantHeld: true,
+		},
+		{
+			name: "transient capture error (no raw) is HELD on first sample",
+			prev: StatusRunning, derived: StatusError, tmuxRaw: "", pending: false,
+			wantApply: StatusRunning, wantPending: true, wantHeld: true,
+		},
+		{
+			name: "genuinely dead pane (inactive) is NEVER debounced",
+			prev: StatusRunning, derived: StatusError, tmuxRaw: "inactive", pending: false,
+			wantApply: StatusError, wantPending: false, wantHeld: false,
+		},
+		{
+			name: "dead hook is NEVER debounced",
+			prev: StatusRunning, derived: StatusError, tmuxRaw: "error", hookStatus: "dead", pending: false,
+			wantApply: StatusError, wantPending: false, wantHeld: false,
+		},
+		{
+			name: "flip not FROM running is not debounced",
+			prev: StatusWaiting, derived: StatusError, tmuxRaw: "error", pending: false,
+			wantApply: StatusError, wantPending: false, wantHeld: false,
+		},
+		{
+			name: "running->running (recovered) clears, not held",
+			prev: StatusRunning, derived: StatusRunning, tmuxRaw: "active", pending: true,
+			wantApply: StatusRunning, wantPending: false, wantHeld: false,
+		},
+		{
+			name: "running->idle is not a debounceable flip",
+			prev: StatusRunning, derived: StatusIdle, tmuxRaw: "idle", pending: false,
+			wantApply: StatusIdle, wantPending: false, wantHeld: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			apply, nextPending, held := debounceFlipFromRunning(tc.prev, tc.derived, tc.tmuxRaw, tc.hookStatus, tc.pending)
+			if apply != tc.wantApply || nextPending != tc.wantPending || held != tc.wantHeld {
+				t.Fatalf("debounceFlipFromRunning(prev=%s derived=%s raw=%q hook=%q pending=%v) = (%s,%v,%v); want (%s,%v,%v)",
+					tc.prev, tc.derived, tc.tmuxRaw, tc.hookStatus, tc.pending,
+					apply, nextPending, held, tc.wantApply, tc.wantPending, tc.wantHeld)
+			}
+		})
+	}
+}
+
+// The canonical long-bash sequence: running, then two consecutive tmux "waiting"
+// reads. The first is held at running (no false completion), the second flips.
+func TestDebounceFlipFromRunning_LongBashSequence(t *testing.T) {
+	pending := false
+	// Tick 1: long tool-call, hook window lapsed, pane shows a prompt.
+	apply, pending, held := debounceFlipFromRunning(StatusRunning, StatusWaiting, "waiting", "", pending)
+	if !held || apply != StatusRunning {
+		t.Fatalf("tick 1 must hold at running; got apply=%s held=%v", apply, held)
+	}
+	// Tick 2: still waiting → confirmed flip.
+	apply, pending, held = debounceFlipFromRunning(StatusRunning, StatusWaiting, "waiting", "", pending)
+	if held || apply != StatusWaiting || pending {
+		t.Fatalf("tick 2 must flip to waiting; got apply=%s held=%v pending=%v", apply, held, pending)
+	}
+}
+
+// If the pane recovers on the second sample, no false flip ever surfaced.
+func TestDebounceFlipFromRunning_RecoversAfterHold(t *testing.T) {
+	// Tick 1: transient waiting → held.
+	_, pending, held := debounceFlipFromRunning(StatusRunning, StatusWaiting, "waiting", "", false)
+	if !held || !pending {
+		t.Fatalf("tick 1 must hold; held=%v pending=%v", held, pending)
+	}
+	// Tick 2: back to active → cleared, never flipped.
+	apply, pending, held := debounceFlipFromRunning(StatusRunning, StatusRunning, "active", "", pending)
+	if held || apply != StatusRunning || pending {
+		t.Fatalf("tick 2 recovery must clear without flip; apply=%s held=%v pending=%v", apply, held, pending)
+	}
+}

--- a/internal/session/notify_hang_guard_test.go
+++ b/internal/session/notify_hang_guard_test.go
@@ -1,0 +1,236 @@
+package session
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// These tests pin the notify-daemon runtime-hang fix. The daemon's Run loop is
+// single-threaded (SyncOnce → syncProfile → UpdateStatus per instance, in the
+// no-live-TUI branch). Before the fix a status probe that blocks — a wedged
+// tmux pane, a stuck tmux server, a query that never returns, or lock
+// contention on inst.mu — froze the entire delivery loop and muted every
+// profile until launchctl kickstart. The fix bounds each probe
+// (statusProbeBudget) and the whole pass (syncPassBudget) so one hung probe is
+// skipped and the loop keeps delivering.
+//
+// The status probe is exercised through the updateInstanceStatus seam so the
+// block is deterministic (a channel, not a real hung tmux that would be
+// timing-flaky).
+
+// withBlockingProbe installs an updateInstanceStatus seam where instances whose
+// IDs are in blockIDs hang on the returned channel, while all other instances
+// record that they were probed. The returned release() unblocks the hung probes
+// and restores the original seam. It also shrinks the budgets so the test runs
+// fast. blockedProbed counts how many distinct non-blocked instances were
+// probed.
+func withBlockingProbe(t *testing.T, blockIDs ...string) (block chan struct{}, otherProbed *atomic.Int32, release func()) {
+	t.Helper()
+	block = make(chan struct{})
+	otherProbed = &atomic.Int32{}
+	blocked := map[string]bool{}
+	for _, id := range blockIDs {
+		blocked[id] = true
+	}
+
+	origSeam := updateInstanceStatus.Load().(statusProbeFunc)
+	updateInstanceStatus.Store(statusProbeFunc(func(inst *Instance) error {
+		if blocked[inst.ID] {
+			<-block // model a status probe that never returns
+			return nil
+		}
+		otherProbed.Add(1)
+		return nil
+	}))
+
+	origBudget := statusProbeBudget
+	origPass := syncPassBudget
+	statusProbeBudget = 200 * time.Millisecond
+	syncPassBudget = 5 * time.Second
+
+	var released atomic.Bool
+	release = func() {
+		if released.Swap(true) {
+			return
+		}
+		updateInstanceStatus.Store(origSeam)
+		statusProbeBudget = origBudget
+		syncPassBudget = origPass
+		close(block) // let any detached probe goroutines exit
+	}
+	t.Cleanup(release)
+	return block, otherProbed, release
+}
+
+// saveInstances persists bare instances (no tmux session attached) for a
+// daemon-backed profile.
+func saveInstances(t *testing.T, storage *Storage, ids ...string) {
+	t.Helper()
+	insts := make([]*Instance, 0, len(ids))
+	for _, id := range ids {
+		pp := filepath.Join(os.Getenv("HOME"), "proj-"+id)
+		if err := os.MkdirAll(pp, 0o755); err != nil {
+			t.Fatalf("mkdir project %s: %v", id, err)
+		}
+		insts = append(insts, &Instance{
+			ID:          id,
+			Title:       id,
+			ProjectPath: pp,
+			GroupPath:   DefaultGroupPath,
+			Tool:        "claude",
+			Status:      StatusRunning,
+			CreatedAt:   time.Now().Add(-time.Hour), // past the tmux init grace window
+		})
+	}
+	if err := storage.SaveWithGroups(insts, nil); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+}
+
+// runSyncProfileWithDeadline runs d.syncProfile(profile) in a goroutine and
+// fails the test if it does not return within deadline. This is the
+// reproduction assertion: on the unbounded (pre-fix) loop, a blocked probe
+// makes syncProfile never return and this fatals — the freeze. With the fix it
+// returns promptly.
+func runSyncProfileWithDeadline(t *testing.T, d *TransitionDaemon, profile string, deadline time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		d.syncProfile(profile)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(deadline):
+		t.Fatalf("syncProfile did not return within %s: a hung status probe froze the whole pass (the notify-daemon runtime hang)", deadline)
+	}
+}
+
+// TestSyncProfile_HungProbeDoesNotFreezeLoop is the primary reproduction +
+// regression test. One instance's status probe blocks forever; the pass must
+// still complete within the budget and the healthy instance must still be
+// probed. On the pre-fix unbounded loop syncProfile never returns and this
+// test fatals via the deadline.
+func TestSyncProfile_HungProbeDoesNotFreezeLoop(t *testing.T) {
+	const profile = "_test_notify_hang_primary"
+	d, storage := bootstrapDaemonProfile(t, profile)
+
+	_, otherProbed, _ := withBlockingProbe(t, "hung")
+	saveInstances(t, storage, "hung", "healthy")
+
+	// Prime baseline (initialized=true) so the second pass exercises the full
+	// transition-detection path, not just the init shortcut.
+	runSyncProfileWithDeadline(t, d, profile, 3*time.Second)
+	runSyncProfileWithDeadline(t, d, profile, 3*time.Second)
+
+	if otherProbed.Load() == 0 {
+		t.Fatal("the healthy instance was never probed — the hung probe blocked the loop")
+	}
+}
+
+// TestSyncProfile_TimedOutProbeIsSkippedOthersProcessed asserts the timeout
+// path: a probe that exceeds statusProbeBudget is skipped (the instance keeps
+// its last-known status, taken without touching inst.mu) while every other
+// instance is processed normally and its real transition is observed.
+func TestSyncProfile_TimedOutProbeIsSkippedOthersProcessed(t *testing.T) {
+	const profile = "_test_notify_hang_skip"
+	d, storage := bootstrapDaemonProfile(t, profile)
+
+	block, otherProbed, _ := withBlockingProbe(t, "hung")
+	saveInstances(t, storage, "hung", "h1", "h2", "h3")
+
+	runSyncProfileWithDeadline(t, d, profile, 3*time.Second)
+
+	// All three healthy instances were probed despite "hung" never returning.
+	if got := otherProbed.Load(); got != 3 {
+		t.Fatalf("expected 3 healthy instances probed, got %d (hung probe leaked back-pressure onto the loop)", got)
+	}
+
+	// The hung instance kept its last-known status (running), recorded without
+	// blocking on its held lock.
+	if got := d.lastStatus[profile]["hung"]; got != string(StatusRunning) {
+		t.Fatalf("hung instance status: want %q (last-known), got %q", StatusRunning, got)
+	}
+
+	// Sanity: the loop never read the hung instance's lock-guarded state.
+	select {
+	case <-block:
+		t.Fatal("block channel was closed early")
+	default:
+	}
+}
+
+// TestSyncProfile_ProbeStallBreadcrumb asserts the watchdog breadcrumb: a
+// timed-out probe writes a diagnostic line to notifier-probe-stalls.log so a
+// future hang is visible and the self-recovery is auditable.
+func TestSyncProfile_ProbeStallBreadcrumb(t *testing.T) {
+	const profile = "_test_notify_hang_breadcrumb"
+	d, storage := bootstrapDaemonProfile(t, profile)
+
+	withBlockingProbe(t, "hung")
+	saveInstances(t, storage, "hung", "healthy")
+
+	runSyncProfileWithDeadline(t, d, profile, 3*time.Second)
+
+	path := notifierProbeStallLogPath()
+	entries := readProbeStallLog(t, path)
+	if len(entries) == 0 {
+		t.Fatalf("no probe-stall breadcrumb written to %s", path)
+	}
+	var found bool
+	for _, e := range entries {
+		if e["instance"] == "hung" && e["reason"] == "probe_budget" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a probe_budget breadcrumb for instance \"hung\", got %+v", entries)
+	}
+}
+
+// TestLogProbeStall_RateLimited asserts the breadcrumb is rate-limited per
+// (profile,instance,reason) so a permanently wedged instance — which times out
+// every poll — logs at most once per probeStallLogInterval instead of flooding.
+func TestLogProbeStall_RateLimited(t *testing.T) {
+	const profile = "_test_notify_hang_ratelimit"
+	d, _ := bootstrapDaemonProfile(t, profile)
+
+	path := notifierProbeStallLogPath()
+	for i := 0; i < 5; i++ {
+		d.logProbeStall(profile, "hung", "probe_budget")
+	}
+	if got := len(readProbeStallLog(t, path)); got != 1 {
+		t.Fatalf("expected 1 rate-limited breadcrumb, got %d", got)
+	}
+}
+
+func readProbeStallLog(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("open probe-stall log: %v", err)
+	}
+	defer f.Close()
+	var out []map[string]any
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var e map[string]any
+		if err := json.Unmarshal(line, &e); err != nil {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}

--- a/internal/session/notify_hang_guard_test.go
+++ b/internal/session/notify_hang_guard_test.go
@@ -201,6 +201,10 @@ func TestLogProbeStall_RateLimited(t *testing.T) {
 	d, _ := bootstrapDaemonProfile(t, profile)
 
 	path := notifierProbeStallLogPath()
+	// Truncate before writing so entries from earlier tests don't inflate the count.
+	if err := os.Truncate(path, 0); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("truncate probe-stall log: %v", err)
+	}
 	for i := 0; i < 5; i++ {
 		d.logProbeStall(profile, "hung", "probe_budget")
 	}

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -63,16 +64,23 @@ type TransitionDaemon struct {
 	// created). Driven by this poll loop — NOT a new daemon (F3: no watchdog
 	// stacking). nil until the first enabled pass.
 	selfheal *selfHealRegistry
+
+	// lastProbeStall rate-limits the probe-stall breadcrumb per (profile|key)
+	// so a permanently wedged instance — which times out again on every poll —
+	// logs at most once per probeStallLogInterval instead of flooding the log
+	// every few seconds. Accessed only from the single-threaded Run loop.
+	lastProbeStall map[string]time.Time
 }
 
 func NewTransitionDaemon() *TransitionDaemon {
 	return &TransitionDaemon{
-		notifier:     NewTransitionNotifier(),
-		storages:     map[string]*Storage{},
-		lastStatus:   map[string]map[string]string{},
-		initialized:  map[string]bool{},
-		lastDone:     map[string]map[string]DoneSignal{},
-		lastDoneScan: map[string]map[string]time.Time{},
+		notifier:       NewTransitionNotifier(),
+		storages:       map[string]*Storage{},
+		lastStatus:     map[string]map[string]string{},
+		initialized:    map[string]bool{},
+		lastDone:       map[string]map[string]DoneSignal{},
+		lastDoneScan:   map[string]map[string]time.Time{},
+		lastProbeStall: map[string]time.Time{},
 	}
 }
 
@@ -179,6 +187,121 @@ func (d *TransitionDaemon) maybeSweepInboxTTL() {
 	_, _ = SweepInboxByTTL(InboxTTL())
 }
 
+// statusProbeBudget bounds a single instance's status refresh in the
+// no-live-TUI sync path. The notify-daemon recurring-freeze bug: Run is a
+// single-threaded poll loop, so a status probe that never returns — a wedged
+// tmux pane, a stuck tmux server, a session whose query hangs, or lock
+// contention on inst.mu behind an earlier hung probe — froze the entire
+// delivery loop and muted every profile until launchctl kickstart. The
+// underlying tmux subprocesses are individually context-bounded (CapturePane
+// 3s, Exists 2s, IsPaneDead 2s, WaitDelay 2s); this budget is the loop-level
+// backstop that keeps the daemon alive even if some future call site is added
+// without its own timeout, or several probes pile up at once.
+var statusProbeBudget = 6 * time.Second
+
+// syncPassBudget bounds the cumulative time one no-live-TUI pass spends probing
+// instance status. Past it the remaining instances keep their last-known status
+// for this pass and are retried next pass, so a burst of simultaneously wedged
+// tmux servers can't stretch a single pass without bound (worst case otherwise
+// is instanceCount × statusProbeBudget).
+var syncPassBudget = 30 * time.Second
+
+// probeStallLogInterval rate-limits the per-(profile,instance) probe-stall
+// breadcrumb so a permanently wedged instance doesn't flood the log.
+const probeStallLogInterval = time.Minute
+
+// statusProbeFunc is the signature of the swappable status-probe seam.
+type statusProbeFunc = func(inst *Instance) error
+
+// updateInstanceStatus is the swappable status-probe seam used by the
+// no-live-TUI sync path, held in an atomic.Value so the production read at
+// probe-spawn time stays race-free against tests that swap it (a detached probe
+// goroutine may still be parked when a test restores the seam). Production
+// points it at (*Instance).UpdateStatus, set once in init; tests Store a
+// controllable blocking probe to prove a hung tmux call can't freeze the loop.
+var updateInstanceStatus atomic.Value
+
+func init() {
+	updateInstanceStatus.Store(statusProbeFunc(func(inst *Instance) error { return inst.UpdateStatus() }))
+}
+
+// refreshInstanceStatusBounded runs the status probe for inst under
+// statusProbeBudget. It returns timedOut=true when the probe didn't finish in
+// time, in which case a detached goroutine is still inside UpdateStatus —
+// possibly holding inst.mu — and the caller must NOT read lock-guarded instance
+// state (it would block on that same lock and re-freeze the loop).
+//
+// Why a goroutine budget and not only the per-subprocess timeouts: the tmux
+// execs already use exec.CommandContext, but UpdateStatus also takes inst.mu and
+// can serialize behind a previous hung probe on the same instance, and not every
+// reachable call site (e.g. a future helper) is guaranteed to carry its own
+// deadline. We deliberately accept a possibly-leaked goroutine over a leaked
+// lock: we never block the loop waiting on inst.mu, a still-hung instance simply
+// times out again next pass instead of wedging the daemon, and the leak is
+// bounded in practice because the subprocess context timeouts let the detached
+// probe return within a few seconds.
+func (d *TransitionDaemon) refreshInstanceStatusBounded(profile string, inst *Instance) (timedOut bool) {
+	probe := updateInstanceStatus.Load().(statusProbeFunc)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = probe(inst)
+	}()
+	select {
+	case <-done:
+		return false
+	case <-time.After(statusProbeBudget):
+		d.logProbeStall(profile, inst.ID, "probe_budget")
+		return true
+	}
+}
+
+// logProbeStall appends a breadcrumb to notifier-probe-stalls.log when a status
+// probe (or a whole pass) exceeds its budget, mirroring the notifier-missed.log
+// diagnostic idiom so a future hang is visible and the daemon's self-recovery is
+// auditable. Rate-limited per (profile|key) to probeStallLogInterval.
+func (d *TransitionDaemon) logProbeStall(profile, instanceID, reason string) {
+	dedupKey := profile + "|" + instanceID + "|" + reason
+	now := time.Now()
+	if d.lastProbeStall == nil {
+		d.lastProbeStall = map[string]time.Time{}
+	}
+	if last, ok := d.lastProbeStall[dedupKey]; ok && now.Sub(last) < probeStallLogInterval {
+		return
+	}
+	d.lastProbeStall[dedupKey] = now
+
+	path := notifierProbeStallLogPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	entry := map[string]any{
+		"ts":       now.Format(time.RFC3339Nano),
+		"profile":  profile,
+		"instance": instanceID,
+		"reason":   reason,
+		"budget":   statusProbeBudget.String(),
+	}
+	line, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(append(line, '\n'))
+}
+
+func notifierProbeStallLogPath() string {
+	path, err := logDataPath("notifier-probe-stalls.log")
+	if err != nil {
+		return tempAgentDeckPath("logs", "notifier-probe-stalls.log")
+	}
+	return path
+}
+
 func profilesForTransitionDaemon() []string {
 	profiles, err := ListProfiles()
 	if err != nil || len(profiles) == 0 {
@@ -249,9 +372,38 @@ func (d *TransitionDaemon) syncProfile(profile string) time.Duration {
 			}
 		}
 	} else {
+		// No live TUI: the daemon is the only thing refreshing status, so it
+		// must probe each instance via tmux itself. This loop is the freeze
+		// surface — Run is single-threaded (SyncOnce → syncProfile →
+		// UpdateStatus per instance), so any probe that blocks here mutes the
+		// whole daemon for every profile until launchctl kickstart. Bound each
+		// probe (statusProbeBudget) and the cumulative pass (syncPassBudget) so
+		// one wedged tmux call — or a burst of them during a busy sprint — can't
+		// wedge delivery. See refreshInstanceStatusBounded for the lock
+		// reasoning.
+		passStart := time.Now()
+		passBudgetSpent := false
 		for _, inst := range instances {
 			previousStatus := normalizeStatusString(string(inst.Status))
-			_ = inst.UpdateStatus()
+			if passBudgetSpent || time.Since(passStart) > syncPassBudget {
+				if !passBudgetSpent {
+					passBudgetSpent = true
+					d.logProbeStall(profile, "", "pass_budget")
+				}
+				// Out of pass budget: keep last-known status for the remaining
+				// instances and retry them next pass rather than stretching this
+				// one without bound.
+				statuses[inst.ID] = previousStatus
+				continue
+			}
+			if d.refreshInstanceStatusBounded(profile, inst) {
+				// Probe exceeded its per-instance budget. A detached goroutine is
+				// still inside UpdateStatus and may hold inst.mu, so reading
+				// GetStatusThreadSafe would block on that same lock — fall back to
+				// the last-known status and keep the loop delivering.
+				statuses[inst.ID] = previousStatus
+				continue
+			}
 			status := normalizeStatusString(string(inst.GetStatusThreadSafe()))
 			statuses[inst.ID] = status
 			if db != nil && status != previousStatus {

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -275,12 +276,16 @@ func (d *TransitionDaemon) logProbeStall(profile, instanceID, reason string) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return
 	}
+	budget := statusProbeBudget
+	if reason == "pass_budget" {
+		budget = syncPassBudget
+	}
 	entry := map[string]any{
 		"ts":       now.Format(time.RFC3339Nano),
 		"profile":  profile,
 		"instance": instanceID,
 		"reason":   reason,
-		"budget":   statusProbeBudget.String(),
+		"budget":   budget.String(),
 	}
 	line, err := json.Marshal(entry)
 	if err != nil {
@@ -290,8 +295,10 @@ func (d *TransitionDaemon) logProbeStall(profile, instanceID, reason string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
 	_, _ = f.Write(append(line, '\n'))
+	if err := f.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "logProbeStall: close %s: %v\n", path, err)
+	}
 }
 
 func notifierProbeStallLogPath() string {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2153,8 +2153,15 @@ func (s *Session) IsPaneDead() bool {
 	if info, ok := GetCachedPaneInfo(s.Name); ok {
 		return info.Dead
 	}
-	// Cache miss: direct tmux check targeting the primary pane.
-	out, err := s.tmuxCmd("list-panes", "-t", s.Name+":0.0", "-F", "#{pane_dead}").Output()
+	// Cache miss: direct tmux check targeting the primary pane. Bound it the
+	// same way Exists() bounds has-session — a wedged tmux server must not hang
+	// this probe, since it runs under the notify-daemon's single-threaded poll
+	// loop (via UpdateStatus → GetStatus) where a stall freezes all delivery.
+	// A timed-out (indeterminate) probe is treated as "not dead": reporting a
+	// live pane as dead would flip the session to an error state.
+	ctx, cancel := context.WithTimeout(context.Background(), hasSessionProbeTimeout)
+	defer cancel()
+	out, err := s.tmuxCmdContext(ctx, "list-panes", "-t", s.Name+":0.0", "-F", "#{pane_dead}").Output()
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Four independent defensive guards against transient or foreign signals corrupting daemon/session state. Each fix addresses a distinct failure mode; all are pure bugfixes with no feature dependencies.

Fixes #1480.

## Changes

### 1. `fix(status):` suppress foreign `claude -p` hook status from flipping the parent
A `claude -p` one-shot child inherits `AGENTDECK_INSTANCE_ID` and fires hooks under the parent's ID. The session-ID bind is rejected (no conversation data), but the child's status had already been written — flipping the parent out of `running`. Fix: snapshot the pre-event hook status fields; on bind rejection, restore them so the foreign hook is a complete no-op.

**Before:** Parent session flips to `waiting`/`idle` despite actively running.
**After:** Bind rejection restores the prior status; foreign hook is invisible.

### 2. `fix(status):` debounce a tmux-inferred flip away from running
A long tool call past the hook freshness window, or a transient `CapturePane` failure during subprocess churn, produces a single false running→{waiting,error} sample. Without debounce, one transient read fires a false completion event to the conductor. Fix: hold the first such sample at `running` for one confirming tick. Genuine dead-pane (`inactive`) and dead-hook signals are never debounced.

**Before:** One transient tmux read fires a false completion.
**After:** Requires a confirming second sample; transients are absorbed.

### 3. `fix(conductor):` guard notify-daemon install against Background-domain eviction
`conductor setup` from a non-login context (claude -p child, SSH, daemon-spawned process) resolves to the macOS Background launchd domain. The preceding `launchctl bootout` evicts the daemon from the active Aqua domain. Fix: detect Background domain membership before the unload/reload cycle and skip it, logging a warning with recovery instructions.

**Before:** Daemon evicted from Aqua domain, re-registered under Background where it can't deliver.
**After:** Setup detects Background domain and leaves the existing daemon intact.

### 4. `fix(notify):` bound status probes so a hung tmux call can't mute the daemon
The notify-daemon `Run` loop is single-threaded. A hung status probe (wedged tmux, lock contention) blocks the entire delivery loop. Fix: each probe runs in a bounded goroutine (6s per-instance budget via `atomic.Value` seam, 30s per-pass budget). A timed-out instance keeps its last-known status and retries next pass. Rate-limited breadcrumbs (1/min per stalled instance) prevent log flooding.

**Before:** One hung probe freezes the daemon until process kill.
**After:** Daemon stays alive; stalled instance retries next pass.

## Tests added
- `instance_foreign_session_guard_test.go` — verifies status restoration on bind rejection
- `instance_status_debounce_test.go` — verifies one-sample hold, confirmation, inactive/dead bypass
- `conductor_bg_guard_test.go` — verifies Background-domain detection and skip
- `notify_hang_guard_test.go` — verifies per-instance budget, per-pass budget, log rate-limiting, atomic probe seam under `-race`

## Verification
`gofmt` clean, `go vet` clean, `go build` clean, `go test -race` passes on all new tests. Pre-existing env-sensitive failures (issue1349 `GetJSONLPathChecked`, issue1400 output collision, issue1421 SSH socket path, issue956 chat history) confirmed present on clean main — not regressions.

## Interaction with v1.9.71
- **Honest Status v2** (`1f9606eb`): adds `Substate` enrichment to `instance.go` — our foreign-hook guard and debounce operate on the coarse `Status` path, different code regions, no conflict.
- **Self-heal Stage 1** (`aa0e9326`): adds `selfheal` field to `TransitionDaemon` — our notify-hang-guard adds `lastProbeStall` field and bounded probe logic; both extend the daemon struct independently. Self-heal's `runSelfHealObservePass` reuses the instances already loaded by the probe loop, so bounded probes protect the self-heal pass too.
- **Cursor hooks** (`31a35742`, `83076bbd`): refactored `instance.go` readiness detection and added cursor hook handling — our changes touch separate code paths (status restoration, debounce logic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session status stability by debouncing transient tmux-derived flips and handling transient tmux failures more safely.
  * Prevented session hook/status changes from foreign ephemeral processes, keeping ownership-based updates consistent.
  * Fixed potential notifier daemon freeze by adding budgeted, timeout-bounded status probing with stall diagnostics.
  * Added a timeout to the tmux pane-dead check to avoid hangs when tmux is unresponsive.
  * Hardened background launchd notifier installation to avoid disruptive unload/reload when already running.
* **Tests**
  * Added regression and behavior tests covering launchd guarding, debouncing, foreign-session suppression, and probe-stall handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->