### PR TITLE
feat: per-group/per-conductor configuration

### DIFF
--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -21,6 +22,8 @@ func groupVerbCanonical(verb string) (canonical string, ok bool) {
 	switch verb {
 	case "list", "ls":
 		return "list", true
+	case "show", "info":
+		return "show", true
 	case "create", "new":
 		return "create", true
 	case "update", "set":
@@ -58,6 +61,8 @@ func handleGroup(profile string, args []string) {
 	switch canonical {
 	case "list":
 		handleGroupList(profile, args[1:])
+	case "show":
+		handleGroupShow(profile, args[1:])
 	case "create":
 		handleGroupCreate(profile, args[1:])
 	case "update":
@@ -81,6 +86,7 @@ func printGroupHelp() {
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  list              List all groups with session counts")
+	fmt.Println("  show <name>       Show one group; --resolved adds the effective claude config (alias: info)")
 	fmt.Println("  create <name>     Create a new group")
 	fmt.Println("  update <name>     Update group settings")
 	fmt.Println("  delete <name>     Delete a group (aliases: rm, remove)")
@@ -90,6 +96,7 @@ func printGroupHelp() {
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  agent-deck group list")
+	fmt.Println("  agent-deck group show work --resolved        # Verify the effective [groups.\"work\".claude] config")
 	fmt.Println("  agent-deck group create mobile")
 	fmt.Println("  agent-deck group create ios --parent mobile")
 	fmt.Println("  agent-deck group update mobile --default-path /path/to/repo")
@@ -340,6 +347,164 @@ func handleGroupList(profile string, args []string) {
 	sb.WriteString(fmt.Sprintf("\nTotal: %d groups, %d sessions\n", totalGroups, totalSessions))
 
 	out.Print(sb.String(), nil)
+}
+
+// handleGroupShow shows one group's DB-resident settings and, with
+// --resolved, the effective Claude configuration the spawn builders would
+// use for a session in this group (config_dir, env_file, command, model,
+// env, skills, mcps — each with its source level). The verification
+// counterpart to hand-editing a [groups.X.claude] stanza: a key typo, a
+// TOML parse error, or a missing env_file are all visible here instead of
+// silently degrading at launch.
+func handleGroupShow(profile string, args []string) {
+	fs := flag.NewFlagSet("group show", flag.ExitOnError)
+	resolved := fs.Bool("resolved", false, "Resolve the effective claude config for this group (sources included)")
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck group show <name> [--resolved] [--json]")
+		fmt.Println()
+		fmt.Println("Show a group's settings.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  agent-deck group show work")
+		fmt.Println("  agent-deck group show work --resolved")
+		fmt.Println("  agent-deck group show work --resolved --json")
+	}
+
+	args = reorderGroupArgs(args)
+
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+
+	out := NewCLIOutput(*jsonOutput, *quiet || *quietShort)
+
+	name := fs.Arg(0)
+	if name == "" {
+		out.Error("group name is required", ErrCodeNotFound)
+		fmt.Println("Usage: agent-deck group show <name> [--resolved] [--json]")
+		os.Exit(1)
+	}
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to initialize storage: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	instances, groups, err := storage.LoadWithGroups()
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to load sessions: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
+	groupTree := session.NewGroupTreeWithGroups(instances, groups)
+
+	// Resolve the group path: exact path first, then case-insensitive name
+	// match — same lookup the update verb uses.
+	groupPath := normalizeGroupPath(name)
+	_, exists := groupTree.Groups[groupPath]
+	if !exists {
+		for path, g := range groupTree.Groups {
+			if strings.EqualFold(g.Name, name) {
+				groupPath = path
+				exists = true
+				break
+			}
+		}
+	}
+	if !exists {
+		out.Error(fmt.Sprintf("group '%s' not found", name), ErrCodeNotFound)
+		os.Exit(2)
+	}
+
+	g := groupTree.Groups[groupPath]
+	sessionCount := 0
+	for _, inst := range instances {
+		if inst.GroupPath == groupPath {
+			sessionCount++
+		}
+	}
+
+	jsonData := map[string]interface{}{
+		"success":        true,
+		"name":           g.Name,
+		"path":           groupPath,
+		"default_path":   groupTree.DefaultPathForGroup(groupPath),
+		"max_concurrent": g.MaxConcurrent,
+		"sessions":       sessionCount,
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Group: %s\n", groupPath)
+	fmt.Fprintf(&b, "  Name:           %s\n", g.Name)
+	fmt.Fprintf(&b, "  Default path:   %s\n", orNone(groupTree.DefaultPathForGroup(groupPath)))
+	fmt.Fprintf(&b, "  Max concurrent: %d\n", g.MaxConcurrent)
+	fmt.Fprintf(&b, "  Sessions:       %d\n", sessionCount)
+
+	if *resolved {
+		// Force a fresh config.toml parse — `group show --resolved` is a
+		// diagnostic command and must always show current on-disk state,
+		// not a stale cache entry from an earlier call in this process
+		// (e.g. the log-config bootstrap in main()).
+		session.ClearUserConfigCache()
+		res := session.ResolveGroupClaude(groupPath)
+		jsonData["claude"] = res
+
+		b.WriteString("\nClaude config (resolved for a session in this group):\n")
+		if res.ConfigError != "" {
+			fmt.Fprintf(&b, "  !! config.toml ERROR — every value below is a DEFAULT; the file is being ignored:\n  !! %s\n", res.ConfigError)
+		}
+		fmt.Fprintf(&b, "  config_dir: %s  [%s]\n", orNone(res.ConfigDir), res.ConfigDirSource)
+		if res.EnvFile != "" {
+			existsNote := "MISSING"
+			if res.EnvFileExists {
+				existsNote = "exists"
+			} else if !filepath.IsAbs(res.EnvFileResolved) {
+				existsNote = "relative — resolved against each session's working dir"
+			}
+			fmt.Fprintf(&b, "  env_file:   %s  [%s]  (%s)\n", res.EnvFile, res.EnvFileSource, existsNote)
+		} else {
+			b.WriteString("  env_file:   (none)\n")
+		}
+		fmt.Fprintf(&b, "  command:    %s  [%s]\n", res.Command, res.CommandSource)
+		if res.Model != "" {
+			fmt.Fprintf(&b, "  model:      %s  [%s]\n", res.Model, res.ModelSource)
+		} else {
+			b.WriteString("  model:      (none — per-session model or Claude's own default)\n")
+		}
+		if len(res.Env) > 0 {
+			keys := make([]string, 0, len(res.Env))
+			for k := range res.Env {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			b.WriteString("  env:\n")
+			for _, k := range keys {
+				fmt.Fprintf(&b, "    %s=%s\n", k, res.Env[k])
+			}
+		} else {
+			b.WriteString("  env:        (none)\n")
+		}
+		fmt.Fprintf(&b, "  skills:     %s\n", orNone(strings.Join(res.Skills, ", ")))
+		fmt.Fprintf(&b, "  mcps:       %s\n", orNone(strings.Join(res.MCPs, ", ")))
+	}
+
+	out.Print(b.String(), jsonData)
+}
+
+// orNone renders an empty string as "(none)" for human-readable output.
+func orNone(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return s
 }
 
 // handleGroupCreate creates a new group

--- a/cmd/agent-deck/group_show_test.go
+++ b/cmd/agent-deck/group_show_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for `agent-deck group show [--resolved]` — the verification command
+// for hand-edited [groups.X.claude] stanzas. The failure mode it exists to
+// catch: a freshly appended stanza that silently fails to apply at launch
+// (key typo, TOML parse error, missing env_file) with zero diagnostics.
+
+func writeTestConfig(t *testing.T, home, body string) {
+	t.Helper()
+	dir := filepath.Join(home, ".agent-deck")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func TestGroupShow_BasicAndNotFound(t *testing.T) {
+	home := t.TempDir()
+
+	stdout, _, code := runAgentDeck(t, home, "group", "create", "work")
+	if code != 0 {
+		t.Fatalf("group create failed: %s", stdout)
+	}
+
+	stdout, _, code = runAgentDeck(t, home, "group", "show", "work")
+	if code != 0 {
+		t.Fatalf("group show failed (exit %d): %s", code, stdout)
+	}
+	if !strings.Contains(stdout, "Group: work") {
+		t.Errorf("expected group header, got:\n%s", stdout)
+	}
+
+	_, stderr, code := runAgentDeck(t, home, "group", "show", "nope")
+	if code != 2 {
+		t.Errorf("unknown group must exit 2, got %d (stderr: %s)", code, stderr)
+	}
+}
+
+func TestGroupShow_ResolvedJSON(t *testing.T) {
+	home := t.TempDir()
+	writeTestConfig(t, home, `
+[groups."work".claude]
+env_file = "~/.agent-deck/groups/work.env"
+command = "claude-work"
+model = "claude-sonnet-4-6"
+env = { AGENT_ROLE = "work" }
+skills = ["store/loom"]
+mcps = ["memory"]
+`)
+
+	if _, _, code := runAgentDeck(t, home, "group", "create", "work"); code != 0 {
+		t.Fatal("group create failed")
+	}
+
+	stdout, stderr, code := runAgentDeck(t, home, "group", "show", "work", "--resolved", "--json")
+	if code != 0 {
+		t.Fatalf("group show --resolved --json failed (exit %d): %s / %s", code, stdout, stderr)
+	}
+
+	var payload struct {
+		Success bool   `json:"success"`
+		Path    string `json:"path"`
+		Claude  struct {
+			EnvFile       string            `json:"env_file"`
+			EnvFileSource string            `json:"env_file_source"`
+			EnvFileExists bool              `json:"env_file_exists"`
+			Command       string            `json:"command"`
+			CommandSource string            `json:"command_source"`
+			Model         string            `json:"model"`
+			Env           map[string]string `json:"env"`
+			Skills        []string          `json:"skills"`
+			MCPs          []string          `json:"mcps"`
+			ConfigError   string            `json:"config_error"`
+		} `json:"claude"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, stdout)
+	}
+
+	c := payload.Claude
+	if c.EnvFileSource != "group:work" || c.EnvFileExists {
+		t.Errorf("env_file source=%q exists=%v want group:work / false", c.EnvFileSource, c.EnvFileExists)
+	}
+	if c.Command != "claude-work" || c.CommandSource != "group:work" {
+		t.Errorf("command=%q [%s] want claude-work [group:work]", c.Command, c.CommandSource)
+	}
+	if c.Model != "claude-sonnet-4-6" {
+		t.Errorf("model=%q want claude-sonnet-4-6", c.Model)
+	}
+	if c.Env["AGENT_ROLE"] != "work" {
+		t.Errorf("env=%v want AGENT_ROLE=work", c.Env)
+	}
+	if len(c.Skills) != 1 || c.Skills[0] != "store/loom" {
+		t.Errorf("skills=%v want [store/loom]", c.Skills)
+	}
+	if len(c.MCPs) != 1 || c.MCPs[0] != "memory" {
+		t.Errorf("mcps=%v want [memory]", c.MCPs)
+	}
+	if c.ConfigError != "" {
+		t.Errorf("unexpected config_error: %s", c.ConfigError)
+	}
+
+	// env_file_exists flips once the file lands.
+	envPath := filepath.Join(home, ".agent-deck", "groups", "work.env")
+	if err := os.MkdirAll(filepath.Dir(envPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(envPath, []byte("export A=1\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	stdout, _, code = runAgentDeck(t, home, "group", "show", "work", "--resolved", "--json")
+	if code != 0 {
+		t.Fatalf("second show failed: %s", stdout)
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !payload.Claude.EnvFileExists {
+		t.Error("env_file_exists must be true after the file is created")
+	}
+}
+
+func TestGroupShow_ResolvedSurfacesBrokenConfig(t *testing.T) {
+	home := t.TempDir()
+
+	if _, _, code := runAgentDeck(t, home, "group", "create", "work"); code != 0 {
+		t.Fatal("group create failed")
+	}
+
+	// Break the config AFTER group creation (the live failure shape: a
+	// hand-appended stanza with a syntax error).
+	writeTestConfig(t, home, `
+[groups."work".claude
+env_file = "broken
+`)
+
+	stdout, _, code := runAgentDeck(t, home, "group", "show", "work", "--resolved")
+	if code != 0 {
+		t.Fatalf("group show must still succeed on a broken config (exit %d): %s", code, stdout)
+	}
+	if !strings.Contains(stdout, "config.toml ERROR") {
+		t.Errorf("broken config.toml must be loudly surfaced:\n%s", stdout)
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -109,7 +109,7 @@ func handleLaunch(profile string, args []string) {
 		fmt.Println("Combines: add + session start + session send")
 		fmt.Println()
 		fmt.Println("Arguments:")
-		fmt.Println("  [path]    Project directory (defaults to current directory)")
+		fmt.Println("  [path]    Project directory (default: group default_path, then global default_path, then current directory)")
 		fmt.Println()
 		fmt.Println("Options:")
 		fs.PrintDefaults()
@@ -139,21 +139,10 @@ func handleLaunch(profile string, args []string) {
 	out := NewCLIOutput(*jsonOutput, quietMode)
 
 	// Resolve path
-	path := strings.Trim(fs.Arg(0), "'\"")
-	if path == "" || path == "." {
-		var err error
-		path, err = os.Getwd()
-		if err != nil {
-			out.Error(fmt.Sprintf("failed to get current directory: %v", err), ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
-	} else {
-		var err error
-		path, err = filepath.Abs(path)
-		if err != nil {
-			out.Error(fmt.Sprintf("failed to resolve path: %v", err), ErrCodeInvalidOperation)
-			os.Exit(1)
-		}
+	path, err := resolveLaunchPath(strings.Trim(fs.Arg(0), "'\""), mergeFlags(*group, *groupShort), profile)
+	if err != nil {
+		out.Error(fmt.Sprintf("failed to resolve path: %v", err), ErrCodeInvalidOperation)
+		os.Exit(1)
 	}
 
 	// Verify path exists and is a directory
@@ -629,4 +618,35 @@ func handleLaunch(profile string, args []string) {
 		}
 	}
 	out.Success(msg, jsonData)
+}
+
+// resolveLaunchPath resolves the project path for `agent-deck launch`.
+//
+// An explicit path argument always wins — including ".", which keeps its
+// "right here" meaning (resolved like add's positional arg). When no path is
+// given, the resolution chain matches `add` (#1303): the target group's
+// default_path first, then the global config default_path, then cwd.
+func resolveLaunchPath(rawPathArg, groupSelector, profile string) (string, error) {
+	if rawPathArg != "" {
+		return resolveAddPath(rawPathArg)
+	}
+
+	if grp := strings.TrimSpace(groupSelector); grp != "" {
+		if storage, instances, groups, err := loadSessionData(profile); err == nil {
+			groupTree := session.NewGroupTreeWithGroups(instances, groups)
+			path := groupTree.DefaultPathForGroup(resolveGroupPathForAdd(groupTree, grp))
+			_ = storage.Close()
+			if path != "" {
+				return path, nil
+			}
+		}
+	}
+
+	if userCfg, err := session.LoadUserConfig(); err == nil {
+		if path := resolveConfiguredDefaultPath(userCfg.DefaultPath); path != "" {
+			return path, nil
+		}
+	}
+
+	return os.Getwd()
 }

--- a/cmd/agent-deck/launch_default_path_test.go
+++ b/cmd/agent-deck/launch_default_path_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// Tests for resolveLaunchPath — `launch` must mirror `add`'s default-path
+// resolution chain (#1303): explicit arg → group default_path → global config
+// default_path → cwd. An explicit "." must keep meaning cwd even when
+// defaults are configured.
+//
+// Reuses the env isolation helpers from add_test.go (setupAddDefaultPathTest,
+// writeAddUserConfig) so both commands are tested against the same harness.
+
+func seedGroupWithDefaultPath(t *testing.T, profile, name, groupPath, defaultPath string) {
+	t.Helper()
+
+	storage, err := session.NewStorageWithProfile(profile)
+	if err != nil {
+		t.Fatalf("NewStorageWithProfile: %v", err)
+	}
+	groupTree := session.NewGroupTreeWithGroups(nil, []*session.GroupData{
+		{Name: name, Path: groupPath, Expanded: true, DefaultPath: defaultPath},
+	})
+	if err := storage.SaveWithGroups(nil, groupTree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+	if err := storage.Close(); err != nil {
+		t.Fatalf("Close storage: %v", err)
+	}
+}
+
+// TestResolveLaunchPathExplicitDotStaysCwd pins that an explicit "." keeps
+// its "right here" meaning even when a group default_path AND a global
+// default_path are configured — the default chain must only apply when no
+// path argument is given at all.
+func TestResolveLaunchPathExplicitDotStaysCwd(t *testing.T) {
+	home, cwd, profile := setupAddDefaultPathTest(t)
+	groupDefault := filepath.Join(home, "group-home")
+	globalDefault := filepath.Join(home, "global-home")
+	for _, dir := range []string{groupDefault, globalDefault} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeAddUserConfig(t, home, `default_path = "`+globalDefault+`"`+"\n")
+	seedGroupWithDefaultPath(t, profile, "Work", "work", groupDefault)
+
+	got, err := resolveLaunchPath(".", "work", profile)
+	if err != nil {
+		t.Fatalf("resolveLaunchPath: %v", err)
+	}
+	if got != cwd {
+		t.Fatalf(`explicit "." resolved to %q, want cwd %q`, got, cwd)
+	}
+}
+
+func TestResolveLaunchPathExplicitPathIgnoresDefaults(t *testing.T) {
+	home, _, profile := setupAddDefaultPathTest(t)
+	groupDefault := filepath.Join(home, "group-home")
+	globalDefault := filepath.Join(home, "global-home")
+	explicitPath := filepath.Join(home, "explicit")
+	for _, dir := range []string{groupDefault, globalDefault, explicitPath} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeAddUserConfig(t, home, `default_path = "`+globalDefault+`"`+"\n")
+	seedGroupWithDefaultPath(t, profile, "Work", "work", groupDefault)
+
+	got, err := resolveLaunchPath(explicitPath, "work", profile)
+	if err != nil {
+		t.Fatalf("resolveLaunchPath: %v", err)
+	}
+	if got != explicitPath {
+		t.Fatalf("explicit path resolved to %q, want %q", got, explicitPath)
+	}
+}
+
+// TestResolveLaunchPathGroupDefaultPrecedesGlobal pins the first chain link:
+// a pathless launch into a group with a default_path lands there, ahead of
+// the global config default_path. The selector is the group's display name
+// ("Work", not "work") to pin resolveGroupPathForAdd canonicalization.
+func TestResolveLaunchPathGroupDefaultPrecedesGlobal(t *testing.T) {
+	home, _, profile := setupAddDefaultPathTest(t)
+	groupDefault := filepath.Join(home, "group-home")
+	globalDefault := filepath.Join(home, "global-home")
+	for _, dir := range []string{groupDefault, globalDefault} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	writeAddUserConfig(t, home, `default_path = "`+globalDefault+`"`+"\n")
+	seedGroupWithDefaultPath(t, profile, "Work", "work", groupDefault)
+
+	got, err := resolveLaunchPath("", "Work", profile)
+	if err != nil {
+		t.Fatalf("resolveLaunchPath: %v", err)
+	}
+	if got != groupDefault {
+		t.Fatalf("pathless launch resolved to %q, want group default_path %q", got, groupDefault)
+	}
+}
+
+// TestResolveLaunchPathFallsBackToGlobalDefaultPath pins the second chain
+// link: with no group default available the global config default_path wins,
+// whether the group selector is absent or names a group without a default.
+func TestResolveLaunchPathFallsBackToGlobalDefaultPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		groupSelector string
+		seedGroup     bool
+	}{
+		{name: "no group selector", groupSelector: ""},
+		{name: "group without default_path", groupSelector: "work", seedGroup: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home, _, profile := setupAddDefaultPathTest(t)
+			globalDefault := filepath.Join(home, "global-home")
+			if err := os.MkdirAll(globalDefault, 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", globalDefault, err)
+			}
+			writeAddUserConfig(t, home, `default_path = "`+globalDefault+`"`+"\n")
+			if tt.seedGroup {
+				seedGroupWithDefaultPath(t, profile, "Work", "work", "")
+			}
+
+			got, err := resolveLaunchPath("", tt.groupSelector, profile)
+			if err != nil {
+				t.Fatalf("resolveLaunchPath: %v", err)
+			}
+			if got != globalDefault {
+				t.Fatalf("pathless launch resolved to %q, want global default_path %q", got, globalDefault)
+			}
+		})
+	}
+}
+
+func TestResolveLaunchPathFallsBackToCwd(t *testing.T) {
+	_, cwd, profile := setupAddDefaultPathTest(t)
+
+	got, err := resolveLaunchPath("", "", profile)
+	if err != nil {
+		t.Fatalf("resolveLaunchPath: %v", err)
+	}
+	if got != cwd {
+		t.Fatalf("pathless launch resolved to %q, want cwd %q", got, cwd)
+	}
+}

--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -506,6 +506,65 @@ func GetClaudeCommand() string {
 	return GetToolCommand("claude")
 }
 
+// GetClaudeCommandForInstance returns the Claude command for this Instance,
+// extending GetClaudeCommand with the per-conductor / per-group levels.
+// Priority (most-specific → least-specific, same order as the config_dir
+// chain, CFG-08 mirror semantics):
+//
+//  1. [conductors.<name>.claude].command — conductor sessions only
+//  2. [groups."<group>".claude].command — ancestor-walking
+//  3. [claude].command (global)
+//  4. "claude"
+//
+// An instance-level custom command (a non-"claude" command string stored on
+// the session, e.g. from `add -c <wrapper>`) never reaches this resolver —
+// the spawn builders only consult it when the stored command is the default
+// "claude", so the explicit per-session command stays the strongest level.
+func GetClaudeCommandForInstance(inst *Instance) string {
+	if userConfig, _ := LoadUserConfig(); userConfig != nil && inst != nil {
+		if name := conductorNameFromInstance(inst); name != "" {
+			if cmd := userConfig.GetConductorClaudeCommand(name); cmd != "" {
+				return cmd
+			}
+		}
+		if cmd := userConfig.GetGroupClaudeCommand(inst.GroupPath); cmd != "" {
+			return cmd
+		}
+	}
+	return GetClaudeCommand()
+}
+
+// resolveClaudeLaunchModel returns the --model value for a claude spawn.
+// Priority:
+//
+//  1. explicit per-session model (CLI --model / new-session dialog,
+//     persisted on ClaudeOptions — passed in as optsModel)
+//  2. [conductors.<name>.claude].model — conductor sessions only
+//  3. [groups."<group>".claude].model — ancestor-walking
+//  4. "" — no flag; Claude Code's own default
+//
+// Resolved at command-build time (not baked in at create) so a config edit
+// takes effect on the next start/restart without re-creating the session —
+// matching how config_dir and env_file resolve. The global
+// [claude].default_model deliberately stays a new-session-dialog prefill
+// (#1172) and is NOT applied here, so behavior without group/conductor
+// blocks is unchanged.
+func (i *Instance) resolveClaudeLaunchModel(optsModel string) string {
+	if optsModel != "" {
+		return optsModel
+	}
+	userConfig, _ := LoadUserConfig()
+	if userConfig == nil {
+		return ""
+	}
+	if name := conductorNameFromInstance(i); name != "" {
+		if m := userConfig.GetConductorClaudeModel(name); m != "" {
+			return m
+		}
+	}
+	return userConfig.GetGroupClaudeModel(i.GroupPath)
+}
+
 // GetClaudeSessionID returns the ACTIVE session ID for a project path
 // It first tries to find the currently running session by checking recently
 // modified .jsonl files, then falls back to lastSessionId from config

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -37,7 +37,18 @@ func (i *Instance) buildEnvSourceCommand() string {
 		}
 	}
 
-	config, _ := LoadUserConfig()
+	config, cfgErr := LoadUserConfig()
+	if cfgErr != nil {
+		// A broken config.toml degrades EVERY per-group / per-conductor /
+		// global tool override to defaults, and the parse error is
+		// discarded at most call sites — historically "my env_file stopped
+		// injecting" with zero diagnostics. Surface it in the pane (the
+		// spawn still proceeds on defaults) and in the debug log.
+		sessionLog.Warn("user config load failed at spawn; config.toml overrides inactive",
+			slog.String("session", i.Title),
+			slog.String("error", cfgErr.Error()))
+		sources = append(sources, paneWarning("config.toml error — overrides inactive: "+cfgErr.Error()))
+	}
 	if config == nil {
 		if len(sources) == 0 {
 			return ""
@@ -69,6 +80,20 @@ func (i *Instance) buildEnvSourceCommand() string {
 	toolEnvFile := i.getToolEnvFile()
 	if toolEnvFile != "" {
 		resolved := resolvePath(toolEnvFile, i.ProjectPath)
+		if _, statErr := os.Stat(resolved); statErr != nil {
+			// An explicitly configured env_file that is absent at spawn is a
+			// misconfiguration, not a soft default — the silent `[ -f ] &&`
+			// skip below is exactly how a typo'd env_file stanza goes
+			// unnoticed. Warn in the pane and the debug log; the
+			// ignore_missing_env_files=false hard-fail path is unchanged.
+			sessionLog.Warn("configured env_file missing at spawn",
+				slog.String("session", i.Title),
+				slog.String("tool", i.Tool),
+				slog.String("env_file", resolved))
+			if ignoreMissing {
+				sources = append(sources, paneWarning("env_file not found: "+resolved))
+			}
+		}
 		sources = append(sources, buildSourceCmd(resolved, ignoreMissing))
 	}
 
@@ -159,6 +184,16 @@ func colorfgbgMatchesTheme(colorfgbg, theme string) (bool, bool) {
 	}
 	isLight := bg >= 8
 	return (theme == "light") == isLight, true
+}
+
+// paneWarning returns a shell command that prints an agent-deck warning to
+// the pane's stderr. It always exits 0 so it can sit in the `&&` source
+// chain without blocking the spawn — loud, not fatal. Newlines are
+// flattened so a multi-line TOML parse error stays one pane line.
+func paneWarning(msg string) string {
+	msg = strings.ReplaceAll(msg, "\n", " ")
+	escaped := strings.ReplaceAll("agent-deck: warning: "+msg, "'", "'\\''")
+	return fmt.Sprintf("echo '%s' >&2", escaped)
 }
 
 // buildSourceCmd creates a shell command to source a file.

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -250,18 +250,29 @@ func resolvePath(path, workDir string) string {
 // validateEnvFileForProbe is the boundary guard for the os.Stat sink in
 // buildEnvSourceCommand (CodeQL alert 54). It returns the cleaned path together
 // with ok=true ONLY when the resolved env_file is an absolute path containing no
-// traversal segment AND sitting under a root agent-deck legitimately probes: the
-// operator's home directory or the session's own project tree. Any other path
-// (relative, traversal-bearing, or outside every known root) returns ok=false so
-// the caller fails closed and never stats it.
+// traversal segment AND both its lexical string AND its symlink-resolved real
+// location sit under a root agent-deck legitimately probes: the operator's home
+// directory or the session's own project tree. Any other path (relative,
+// traversal-bearing, outside every known root, OR a lexically-contained path
+// whose real target escapes via a symlink) returns ok=false so the caller fails
+// closed and never stats it.
+//
+// The two-stage check is deliberate: os.Stat FOLLOWS symlinks, so a lexical-only
+// guard is escapable — `env_file = "~/link"` where ~/link → /etc/passwd is
+// lexically under $HOME yet probes outside it (this is the exact lexical-vs-
+// filesystem containment class caught on the #1429 migrate-dir arc). The second
+// stage resolves symlinks as far as the path exists (resolveProbeTarget) and
+// re-checks the REAL location against symlink-resolved roots, so a symlinked
+// file — or a missing leaf under a symlinked parent dir — is rejected before any
+// stat touches it.
 //
 // This intentionally guards only the proactive existence probe, NOT the sourcing
 // of the file — the spawned shell sources whatever path the operator configured
 // (buildSourceCmd), so containing the probe costs no functionality while keeping
 // uncontrolled config data from reaching the filesystem sink unvalidated. The
-// shape (Clean → reject ".." → HasPrefix(root) containment, fail-closed) mirrors
-// ValidateTranscriptPath and resolveCanonical/pathContains in
-// conductor_migrate_dir.go.
+// shape (Clean → reject ".." → HasPrefix(root) containment, EvalSymlinks-resolve,
+// fail-closed) mirrors ValidateTranscriptPath and resolveCanonical/pathContains
+// in conductor_migrate_dir.go.
 func validateEnvFileForProbe(resolved, projectPath string) (string, bool) {
 	clean := filepath.Clean(resolved)
 	// Only fully-resolved absolute paths are eligible; a relative or
@@ -275,6 +286,38 @@ func validateEnvFileForProbe(resolved, projectPath string) (string, bool) {
 		return "", false
 	}
 
+	roots := probeRoots(projectPath)
+	if len(roots) == 0 {
+		return "", false
+	}
+
+	// Stage 1 — lexical containment: the configured path string must sit under
+	// a probe root. Cheap reject for the common out-of-root case.
+	if !containedUnderAny(clean, roots) {
+		return "", false
+	}
+
+	// Stage 2 — filesystem containment (the symlink-escape close): resolve
+	// symlinks as far as the path exists and verify the REAL target is still
+	// under a symlink-resolved root. A lexically-contained path whose real
+	// location escapes (symlinked file, or any path component a symlink) is
+	// rejected so os.Stat never follows the link outside the root.
+	realTarget := resolveProbeTarget(clean)
+	realRoots := make([]string, 0, len(roots))
+	for _, r := range roots {
+		realRoots = append(realRoots, resolveCanonical(r))
+	}
+	if !containedUnderAny(realTarget, realRoots) {
+		return "", false
+	}
+
+	return clean, true
+}
+
+// probeRoots returns the absolute, cleaned roots agent-deck legitimately probes
+// for a configured env_file: the operator's home directory and (when set) the
+// session's project tree.
+func probeRoots(projectPath string) []string {
 	var roots []string
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
 		if h := filepath.Clean(home); filepath.IsAbs(h) {
@@ -286,13 +329,47 @@ func validateEnvFileForProbe(resolved, projectPath string) (string, bool) {
 			roots = append(roots, p)
 		}
 	}
+	return roots
+}
 
+// containedUnderAny reports whether path equals or is nested under any of roots.
+// Boundary-aware: uses root+separator so a sibling whose string prefix matches a
+// root (e.g. "<home>-sibling") is NOT treated as contained.
+func containedUnderAny(path string, roots []string) bool {
 	for _, root := range roots {
-		if clean == root || strings.HasPrefix(clean, root+string(os.PathSeparator)) {
-			return clean, true
+		if path == root || strings.HasPrefix(path, root+string(os.PathSeparator)) {
+			return true
 		}
 	}
-	return "", false
+	return false
+}
+
+// resolveProbeTarget returns the symlink-resolved real location of an absolute
+// path, resolving symlinks on the DEEPEST EXISTING ancestor and re-appending the
+// not-yet-existing tail. This is stronger than resolveCanonical (which falls back
+// to the wholly-lexical path when the full path does not exist): it catches a
+// symlinked parent directory with a missing leaf (e.g. env_file
+// "$project/evil/missing.env" where $project/evil → /outside), which a missing
+// final component would otherwise leave unresolved and lexically-contained.
+func resolveProbeTarget(clean string) string {
+	remainder := ""
+	cur := clean
+	for {
+		if real, err := filepath.EvalSymlinks(cur); err == nil {
+			if remainder == "" {
+				return real
+			}
+			return filepath.Join(real, remainder)
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached the filesystem root with nothing resolvable; the
+			// lexical path is the best available real location.
+			return clean
+		}
+		remainder = filepath.Join(filepath.Base(cur), remainder)
+		cur = parent
+	}
 }
 
 // ExpandPath expands environment variables and ~ prefix in a path.

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -82,18 +82,32 @@ func (i *Instance) buildEnvSourceCommand() string {
 	toolEnvFile := i.getToolEnvFile()
 	if toolEnvFile != "" {
 		resolved := resolvePath(toolEnvFile, i.ProjectPath)
-		if _, statErr := os.Stat(resolved); statErr != nil {
-			// An explicitly configured env_file that is absent at spawn is a
-			// misconfiguration, not a soft default — the silent `[ -f ] &&`
-			// skip below is exactly how a typo'd env_file stanza goes
-			// unnoticed. Warn in the pane and the debug log; the
-			// ignore_missing_env_files=false hard-fail path is unchanged.
-			sessionLog.Warn("configured env_file missing at spawn",
-				slog.String("session", i.Title),
-				slog.String("tool", i.Tool),
-				slog.String("env_file", resolved))
-			if ignoreMissing {
-				sources = append(sources, paneWarning("env_file not found: "+resolved))
+		// CodeQL alert 54 (uncontrolled data in path expression): env_file is
+		// operator config and flows unsanitized into the os.Stat path sink
+		// below. Gate the stat behind a boundary-aware, fail-closed check —
+		// probedPath is returned only when the resolved file sits under a root
+		// agent-deck legitimately probes (the operator's home or the session's
+		// project tree). The stat is purely a proactive "configured-but-missing"
+		// diagnostic; the file is sourced regardless via buildSourceCmd below
+		// (whose `[ -f ]` guard covers a genuinely missing file), so an env_file
+		// the operator deliberately placed outside those roots skips the probe
+		// but is still sourced — no feature is lost and tainted config never
+		// reaches the filesystem sink unvalidated. Mirrors ValidateTranscriptPath
+		// (#1435) and the conductor_migrate_dir.go containment precedent.
+		if probedPath, ok := validateEnvFileForProbe(resolved, i.ProjectPath); ok {
+			if _, statErr := os.Stat(probedPath); statErr != nil {
+				// An explicitly configured env_file that is absent at spawn is a
+				// misconfiguration, not a soft default — the silent `[ -f ] &&`
+				// skip below is exactly how a typo'd env_file stanza goes
+				// unnoticed. Warn in the pane and the debug log; the
+				// ignore_missing_env_files=false hard-fail path is unchanged.
+				sessionLog.Warn("configured env_file missing at spawn",
+					slog.String("session", i.Title),
+					slog.String("tool", i.Tool),
+					slog.String("env_file", probedPath))
+				if ignoreMissing {
+					sources = append(sources, paneWarning("env_file not found: "+probedPath))
+				}
 			}
 		}
 		sources = append(sources, buildSourceCmd(resolved, ignoreMissing))
@@ -231,6 +245,54 @@ func resolvePath(path, workDir string) string {
 		return filepath.Clean(expanded)
 	}
 	return filepath.Clean(filepath.Join(workDir, expanded))
+}
+
+// validateEnvFileForProbe is the boundary guard for the os.Stat sink in
+// buildEnvSourceCommand (CodeQL alert 54). It returns the cleaned path together
+// with ok=true ONLY when the resolved env_file is an absolute path containing no
+// traversal segment AND sitting under a root agent-deck legitimately probes: the
+// operator's home directory or the session's own project tree. Any other path
+// (relative, traversal-bearing, or outside every known root) returns ok=false so
+// the caller fails closed and never stats it.
+//
+// This intentionally guards only the proactive existence probe, NOT the sourcing
+// of the file — the spawned shell sources whatever path the operator configured
+// (buildSourceCmd), so containing the probe costs no functionality while keeping
+// uncontrolled config data from reaching the filesystem sink unvalidated. The
+// shape (Clean → reject ".." → HasPrefix(root) containment, fail-closed) mirrors
+// ValidateTranscriptPath and resolveCanonical/pathContains in
+// conductor_migrate_dir.go.
+func validateEnvFileForProbe(resolved, projectPath string) (string, bool) {
+	clean := filepath.Clean(resolved)
+	// Only fully-resolved absolute paths are eligible; a relative or
+	// traversal-bearing path cannot be proven contained, so fail closed.
+	if !filepath.IsAbs(clean) {
+		return "", false
+	}
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) ||
+		strings.Contains(clean, string(os.PathSeparator)+".."+string(os.PathSeparator)) ||
+		strings.HasSuffix(clean, string(os.PathSeparator)+"..") {
+		return "", false
+	}
+
+	var roots []string
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if h := filepath.Clean(home); filepath.IsAbs(h) {
+			roots = append(roots, h)
+		}
+	}
+	if projectPath != "" {
+		if p := filepath.Clean(projectPath); filepath.IsAbs(p) {
+			roots = append(roots, p)
+		}
+	}
+
+	for _, root := range roots {
+		if clean == root || strings.HasPrefix(clean, root+string(os.PathSeparator)) {
+			return clean, true
+		}
+	}
+	return "", false
 }
 
 // ExpandPath expands environment variables and ~ prefix in a path.

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -16,8 +16,10 @@ import (
 //  2. Global [shell].env_files (in order)
 //  3. [shell].init_script (for direnv, nvm, etc.)
 //  4. Tool-specific env_file ([claude].env_file, [gemini].env_file, [tools.X].env_file)
-//  5. Inline env vars from [tools.X].env
-//  6. Conductor-specific env from meta.json (highest priority, overrides tool env)
+//  5. Per-group / per-conductor inline env ([groups.X.claude].env, [conductors.X.claude].env)
+//  6. Inline env vars from [tools.X].env
+//  7. Conductor-specific env from meta.json (highest priority, overrides tool env)
+//  8. Strip TELEGRAM_STATE_DIR (v1.7.40, S8)
 //
 // Note: This does NOT handle [shell].launch_shell wrapping — that happens at the
 // prepareCommand layer (instance.go) after env sourcing, so the shell startup
@@ -97,17 +99,29 @@ func (i *Instance) buildEnvSourceCommand() string {
 		sources = append(sources, buildSourceCmd(resolved, ignoreMissing))
 	}
 
-	// 5. Inline env vars from [tools.X].env
+	// 5. Per-group / per-conductor inline env for claude sessions
+	//    ([groups.X.claude].env / [conductors.X.claude].env). Exported AFTER
+	//    the env_file source (step 4) so an inline key deterministically
+	//    wins over the same key from the file; the conductor map is applied
+	//    over the group map (CFG-08 precedence: conductor > group). Same
+	//    tool gate as the claude branch of getToolEnvFile.
+	if i.Tool == "claude" {
+		if claudeEnv := i.getClaudeInlineEnv(config); claudeEnv != "" {
+			sources = append(sources, claudeEnv)
+		}
+	}
+
+	// 6. Inline env vars from [tools.X].env
 	if inlineEnv := i.getToolInlineEnv(); inlineEnv != "" {
 		sources = append(sources, inlineEnv)
 	}
 
-	// 6. Conductor-specific env (highest priority, overrides tool env)
+	// 7. Conductor-specific env (highest priority, overrides tool env)
 	if conductorEnv := i.getConductorEnv(ignoreMissing); conductorEnv != "" {
 		sources = append(sources, conductorEnv)
 	}
 
-	// 7. S8 (v1.7.40) — strip TELEGRAM_STATE_DIR on every non-channel-owning
+	// 8. S8 (v1.7.40) — strip TELEGRAM_STATE_DIR on every non-channel-owning
 	// claude spawn. Fires AFTER all sources and inline env so it wins
 	// over any env_file / inline export that set the variable, and
 	// runs even when no env_file is in play (covers `agent-deck
@@ -281,6 +295,49 @@ func (i *Instance) getToolInlineEnv() string {
 		exports = append(exports, fmt.Sprintf("export %s='%s'", k, escaped))
 	}
 
+	return strings.Join(exports, " && ")
+}
+
+// getClaudeInlineEnv returns shell export statements for the merged
+// per-group / per-conductor inline env map ([groups.X.claude].env,
+// [conductors.X.claude].env). Merge order (later wins per key): ancestor
+// groups root-first → exact group → conductor block. Keys are sorted for
+// deterministic output; invalid env names are skipped and single quotes in
+// values are escaped — same rules as the conductor meta.json env
+// (getConductorEnv) and [tools.X].env (getToolInlineEnv).
+func (i *Instance) getClaudeInlineEnv(config *UserConfig) string {
+	if config == nil {
+		return ""
+	}
+	merged := config.GetGroupClaudeEnv(i.GroupPath) // freshly allocated; safe to overlay
+	if name := conductorNameFromInstance(i); name != "" {
+		if conductorEnv := config.GetConductorClaudeEnv(name); len(conductorEnv) > 0 {
+			if merged == nil {
+				merged = make(map[string]string, len(conductorEnv))
+			}
+			for k, v := range conductorEnv {
+				merged[k] = v
+			}
+		}
+	}
+	if len(merged) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(merged))
+	for k := range merged {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	exports := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if !isValidEnvKey(k) {
+			continue // skip invalid env var names
+		}
+		escaped := strings.ReplaceAll(merged[k], "'", "'\\''")
+		exports = append(exports, fmt.Sprintf("export %s='%s'", k, escaped))
+	}
 	return strings.Join(exports, " && ")
 }
 

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -82,32 +82,29 @@ func (i *Instance) buildEnvSourceCommand() string {
 	toolEnvFile := i.getToolEnvFile()
 	if toolEnvFile != "" {
 		resolved := resolvePath(toolEnvFile, i.ProjectPath)
-		// CodeQL alert 54 (uncontrolled data in path expression): env_file is
-		// operator config and flows unsanitized into the os.Stat path sink
-		// below. Gate the stat behind a boundary-aware, fail-closed check —
-		// probedPath is returned only when the resolved file sits under a root
-		// agent-deck legitimately probes (the operator's home or the session's
-		// project tree). The stat is purely a proactive "configured-but-missing"
-		// diagnostic; the file is sourced regardless via buildSourceCmd below
-		// (whose `[ -f ]` guard covers a genuinely missing file), so an env_file
-		// the operator deliberately placed outside those roots skips the probe
-		// but is still sourced — no feature is lost and tainted config never
-		// reaches the filesystem sink unvalidated. Mirrors ValidateTranscriptPath
-		// (#1435) and the conductor_migrate_dir.go containment precedent.
-		if probedPath, ok := validateEnvFileForProbe(resolved, i.ProjectPath); ok {
-			if _, statErr := os.Stat(probedPath); statErr != nil {
-				// An explicitly configured env_file that is absent at spawn is a
-				// misconfiguration, not a soft default — the silent `[ -f ] &&`
-				// skip below is exactly how a typo'd env_file stanza goes
-				// unnoticed. Warn in the pane and the debug log; the
-				// ignore_missing_env_files=false hard-fail path is unchanged.
-				sessionLog.Warn("configured env_file missing at spawn",
-					slog.String("session", i.Title),
-					slog.String("tool", i.Tool),
-					slog.String("env_file", probedPath))
-				if ignoreMissing {
-					sources = append(sources, paneWarning("env_file not found: "+probedPath))
-				}
+		// CodeQL go/path-injection (uncontrolled data in path expression):
+		// env_file is operator config and an env-var value can flow through
+		// os.ExpandEnv (resolvePath → ExpandPath) into the os.Stat path sink.
+		// statEnvFileProbe owns the stat behind a fail-closed, boundary-aware
+		// guard with a canonical traversal barrier colocated at the sink, so
+		// the taint flow is broken before any stat runs. The probe is purely a
+		// proactive "configured-but-missing" diagnostic; the file is sourced
+		// regardless via buildSourceCmd below (whose `[ -f ]` guard covers a
+		// genuinely missing file), so an env_file the operator deliberately
+		// placed outside the probe roots skips the probe but is still sourced —
+		// no feature is lost.
+		if probedPath, exists, probed := statEnvFileProbe(resolved, i.ProjectPath); probed && !exists {
+			// An explicitly configured env_file that is absent at spawn is a
+			// misconfiguration, not a soft default — the silent `[ -f ] &&`
+			// skip below is exactly how a typo'd env_file stanza goes
+			// unnoticed. Warn in the pane and the debug log; the
+			// ignore_missing_env_files=false hard-fail path is unchanged.
+			sessionLog.Warn("configured env_file missing at spawn",
+				slog.String("session", i.Title),
+				slog.String("tool", i.Tool),
+				slog.String("env_file", probedPath))
+			if ignoreMissing {
+				sources = append(sources, paneWarning("env_file not found: "+probedPath))
 			}
 		}
 		sources = append(sources, buildSourceCmd(resolved, ignoreMissing))
@@ -247,8 +244,44 @@ func resolvePath(path, workDir string) string {
 	return filepath.Clean(filepath.Join(workDir, expanded))
 }
 
+// statEnvFileProbe is the single os.Stat sink for the "configured-but-missing"
+// env_file diagnostic, shared by buildEnvSourceCommand and the `group show
+// --resolved` view. It returns:
+//
+//	probed == false → the path failed validation and was NOT statted; callers
+//	                  must not treat the absent stat as "missing" (it was never
+//	                  probed). exists is false.
+//	probed == true  → the path was validated and statted; exists reports
+//	                  whether os.Stat succeeded.
+//
+// CodeQL go/path-injection (uncontrolled data in path expression): an env-var
+// value can flow through os.ExpandEnv (resolvePath → ExpandPath) into a path
+// that reaches os.Stat. validateEnvFileForProbe does the genuine, fail-closed
+// safety work (absolute-only, home/project containment, symlink-resolved
+// re-check), but its containment guard is interprocedural and runtime-rooted —
+// not a shape the taint tracker treats as a sanitizer, which is why the prior
+// guard-in-a-separate-function fix did not clear the alert. The fix is to
+// colocate the canonical traversal barrier (`strings.Contains(clean, "..")`,
+// the form CodeQL recognizes) with the os.Stat call in THIS function, so the
+// barrier dominates the exact value reaching the sink and breaks the flow.
+// filepath.Clean already neutralizes traversal on the absolute paths
+// validateEnvFileForProbe admits, so this barrier rejects nothing legitimate;
+// it re-states the invariant in a sink-local, tracker-legible form.
+func statEnvFileProbe(resolved, projectPath string) (probedPath string, exists, probed bool) {
+	clean, ok := validateEnvFileForProbe(resolved, projectPath)
+	if !ok {
+		return "", false, false
+	}
+	// Canonical traversal barrier, colocated with the os.Stat sink below.
+	if strings.Contains(clean, "..") {
+		return "", false, false
+	}
+	_, statErr := os.Stat(clean)
+	return clean, statErr == nil, true
+}
+
 // validateEnvFileForProbe is the boundary guard for the os.Stat sink in
-// buildEnvSourceCommand (CodeQL alert 54). It returns the cleaned path together
+// statEnvFileProbe (CodeQL go/path-injection). It returns the cleaned path together
 // with ok=true ONLY when the resolved env_file is an absolute path containing no
 // traversal segment AND both its lexical string AND its symlink-resolved real
 // location sit under a root agent-deck legitimately probes: the operator's home

--- a/internal/session/env_test.go
+++ b/internal/session/env_test.go
@@ -498,6 +498,52 @@ func TestGetConductorEnv_NonConductorSession(t *testing.T) {
 	}
 }
 
+func TestValidateEnvFileForProbe(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("Cannot get home directory")
+	}
+	project := filepath.Join(home, "agent-deck-probe-test-project")
+
+	// Paths under the home or project root are eligible for the existence probe.
+	accepted := []string{
+		filepath.Join(home, ".env"),
+		filepath.Join(home, ".config", "agent-deck", "secrets.env"),
+		filepath.Join(project, ".env"),
+		filepath.Join(project, "nested", "tool.env"),
+		home,    // the root itself
+		project, // the root itself
+	}
+	for _, p := range accepted {
+		got, ok := validateEnvFileForProbe(p, project)
+		if !ok {
+			t.Errorf("expected %q to be probe-eligible under home/project roots", p)
+			continue
+		}
+		if got != filepath.Clean(p) {
+			t.Errorf("validateEnvFileForProbe(%q) returned %q, want cleaned %q", p, got, filepath.Clean(p))
+		}
+	}
+
+	// Fail closed: outside every known root, relative, or traversal-bearing.
+	rejected := []string{
+		"/etc/passwd",                          // outside home + project
+		"/var/run/secrets/.env",                // outside home + project
+		".env",                                 // relative — cannot prove containment
+		"relative/path/.env",                   // relative
+		"",                                     // empty
+		filepath.Join(home, "..", "other.env"), // traversal escaping home
+		// A sibling dir whose string prefix matches home but which is NOT
+		// contained (boundary-aware: home + separator, not a raw prefix).
+		home + "-sibling/.env",
+	}
+	for _, p := range rejected {
+		if got, ok := validateEnvFileForProbe(p, project); ok {
+			t.Errorf("expected %q to be rejected (fail-closed), got ok with %q", p, got)
+		}
+	}
+}
+
 func TestIsValidEnvKey(t *testing.T) {
 	valid := []string{"HOME", "MY_VAR", "_private", "A", "API_KEY_123"}
 	for _, k := range valid {

--- a/internal/session/env_test.go
+++ b/internal/session/env_test.go
@@ -544,6 +544,66 @@ func TestValidateEnvFileForProbe(t *testing.T) {
 	}
 }
 
+// TestValidateEnvFileForProbe_SymlinkEscape exercises the filesystem-containment
+// stage: a path that is LEXICALLY inside the project root but whose real target
+// escapes via a symlink must be rejected before any os.Stat follows the link.
+// This is the exact bypass the codex adversarial pass found against the
+// lexical-only first-round fix (`~/link` → /etc/passwd). Without the
+// resolveProbeTarget / symlink-resolved containment stage every case below
+// returns ok=true, so the test is non-vacuous — it fails on the old code.
+func TestValidateEnvFileForProbe_SymlinkEscape(t *testing.T) {
+	project := t.TempDir()
+	outside := t.TempDir()
+
+	victim := filepath.Join(outside, "secret.env")
+	if err := os.WriteFile(victim, []byte("X=1"), 0o600); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+
+	// 1. Symlinked final file inside the project pointing OUT of it.
+	link := filepath.Join(project, "link.env")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatalf("symlink final file: %v", err)
+	}
+	if got, ok := validateEnvFileForProbe(link, project); ok {
+		t.Errorf("symlinked env_file escaping the project must be rejected; got ok with %q", got)
+	}
+
+	// 2. Symlinked PARENT directory; existing leaf under it resolves outside.
+	evilDir := filepath.Join(project, "evil")
+	if err := os.Symlink(outside, evilDir); err != nil {
+		t.Fatalf("symlink parent dir: %v", err)
+	}
+	viaParent := filepath.Join(evilDir, "secret.env")
+	if got, ok := validateEnvFileForProbe(viaParent, project); ok {
+		t.Errorf("env_file under a symlinked parent escaping the project must be rejected; got ok with %q", got)
+	}
+
+	// 3. Symlinked parent with a MISSING leaf — resolveCanonical alone would
+	//    leave this lexically contained; resolveProbeTarget must still reject.
+	viaParentMissing := filepath.Join(evilDir, "nonexistent.env")
+	if got, ok := validateEnvFileForProbe(viaParentMissing, project); ok {
+		t.Errorf("missing leaf under a symlinked parent escaping the project must be rejected; got ok with %q", got)
+	}
+
+	// Control: a real file genuinely inside the project is still probe-eligible.
+	real := filepath.Join(project, "real.env")
+	if err := os.WriteFile(real, []byte("X=1"), 0o600); err != nil {
+		t.Fatalf("write real: %v", err)
+	}
+	if _, ok := validateEnvFileForProbe(real, project); !ok {
+		t.Errorf("a real in-project env_file must remain probe-eligible")
+	}
+
+	// Control: a missing-but-lexically-contained leaf with NO symlink in its
+	// path must remain eligible (the diagnostic "configured-but-missing" warn
+	// case the probe exists to serve).
+	missingReal := filepath.Join(project, "missing.env")
+	if _, ok := validateEnvFileForProbe(missingReal, project); !ok {
+		t.Errorf("a missing in-project env_file (no symlink) must remain probe-eligible")
+	}
+}
+
 func TestIsValidEnvKey(t *testing.T) {
 	valid := []string{"HOME", "MY_VAR", "_private", "A", "API_KEY_123"}
 	for _, k := range valid {

--- a/internal/session/env_test.go
+++ b/internal/session/env_test.go
@@ -604,6 +604,35 @@ func TestValidateEnvFileForProbe_SymlinkEscape(t *testing.T) {
 	}
 }
 
+// TestStatEnvFileProbe exercises the shared os.Stat sink wrapper: a real
+// in-root file reports (probed, exists); a missing-but-eligible in-root file
+// reports (probed, !exists); and an out-of-root / traversal path is never
+// probed (probed==false, exists==false) so the diagnostic cannot treat an
+// unvalidated path as "missing".
+func TestStatEnvFileProbe(t *testing.T) {
+	project := t.TempDir()
+
+	real := filepath.Join(project, "real.env")
+	if err := os.WriteFile(real, []byte("X=1"), 0o600); err != nil {
+		t.Fatalf("write real: %v", err)
+	}
+	if got, exists, probed := statEnvFileProbe(real, project); !probed || !exists || got != real {
+		t.Errorf("real in-project env_file: got (%q, exists=%v, probed=%v), want (%q, true, true)", got, exists, probed, real)
+	}
+
+	missing := filepath.Join(project, "missing.env")
+	if got, exists, probed := statEnvFileProbe(missing, project); !probed || exists || got != missing {
+		t.Errorf("missing in-project env_file: got (%q, exists=%v, probed=%v), want (%q, false, true)", got, exists, probed, missing)
+	}
+
+	// Out-of-root and traversal-bearing paths must never be probed.
+	for _, p := range []string{"/etc/passwd", filepath.Join(project, "..", "escape.env"), ".env", ""} {
+		if got, exists, probed := statEnvFileProbe(p, project); probed || exists {
+			t.Errorf("unvalidated path %q must not be probed; got (%q, exists=%v, probed=%v)", p, got, exists, probed)
+		}
+	}
+}
+
 func TestIsValidEnvKey(t *testing.T) {
 	valid := []string{"HOME", "MY_VAR", "_private", "A", "API_KEY_123"}
 	for _, k := range valid {

--- a/internal/session/group_claude_resolution.go
+++ b/internal/session/group_claude_resolution.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"os"
-	"path/filepath"
 )
 
 // GroupClaudeResolution is the resolved view of the effective Claude
@@ -80,8 +79,17 @@ func ResolveGroupClaude(groupPath string) GroupClaudeResolution {
 	}
 	if res.EnvFile != "" {
 		res.EnvFileResolved = ExpandPath(res.EnvFile)
-		if filepath.IsAbs(res.EnvFileResolved) {
-			_, statErr := os.Stat(res.EnvFileResolved)
+		// Route the existence probe through the same boundary-aware,
+		// symlink-resolving guard as the spawn-time env_file probe
+		// (validateEnvFileForProbe). os.Stat follows symlinks, so a lexically
+		// in-home env_file that is a symlink to an out-of-root file would
+		// otherwise probe outside the home root from this diagnostic path
+		// (CodeQL alert 54 — second sink). There is no session project in a
+		// group-level view, so the operator home is the only probe root; an
+		// absolute env_file outside it (or escaping via symlink) is not
+		// probed and EnvFileExists stays false.
+		if probedPath, ok := validateEnvFileForProbe(res.EnvFileResolved, ""); ok {
+			_, statErr := os.Stat(probedPath)
 			res.EnvFileExists = statErr == nil
 		}
 	}

--- a/internal/session/group_claude_resolution.go
+++ b/internal/session/group_claude_resolution.go
@@ -1,0 +1,113 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// GroupClaudeResolution is the resolved view of the effective Claude
+// configuration for a group path — what a session created in that group
+// would actually launch with. Built for `agent-deck group show --resolved`
+// so a misconfigured stanza is diagnosable: a typo'd group key, a TOML
+// parse error, or a missing env_file are otherwise indistinguishable at
+// launch (the spawn silently proceeds on defaults).
+//
+// Source labels: "group:<path>" (the ancestor that matched), "global",
+// "env", "profile", "default", or "" when unset.
+type GroupClaudeResolution struct {
+	ConfigDir       string `json:"config_dir,omitempty"`
+	ConfigDirSource string `json:"config_dir_source"`
+
+	EnvFile         string `json:"env_file,omitempty"`
+	EnvFileSource   string `json:"env_file_source,omitempty"`
+	EnvFileResolved string `json:"env_file_resolved,omitempty"`
+	// EnvFileExists is meaningful only when EnvFileResolved is absolute;
+	// a relative env_file resolves against each session's working dir.
+	EnvFileExists bool `json:"env_file_exists"`
+
+	Command       string `json:"command"`
+	CommandSource string `json:"command_source"`
+
+	Model       string `json:"model,omitempty"`
+	ModelSource string `json:"model_source,omitempty"`
+
+	Env    map[string]string `json:"env,omitempty"`
+	Skills []string          `json:"skills,omitempty"`
+	MCPs   []string          `json:"mcps,omitempty"`
+
+	// ConfigError carries the config.toml load error verbatim when the
+	// file failed to parse — in that state every value above is a default
+	// and the stanza the user is debugging is NOT in effect.
+	ConfigError string `json:"config_error,omitempty"`
+}
+
+// ResolveGroupClaude resolves the effective Claude settings for a group
+// path using the same chains the spawn builders use (group ancestor-walk →
+// global → default; env beats group for config_dir on the no-instance
+// chain). Conductor-level overrides are per-session and therefore not part
+// of a group view.
+func ResolveGroupClaude(groupPath string) GroupClaudeResolution {
+	res := GroupClaudeResolution{}
+
+	config, cfgErr := LoadUserConfig()
+	if cfgErr != nil {
+		res.ConfigError = cfgErr.Error()
+	}
+
+	// config_dir — reuse the canonical resolver (#881 single source of truth).
+	configDir, configDirSource := GetClaudeConfigDirSourceForGroup(groupPath)
+	res.ConfigDir = configDir
+	res.ConfigDirSource = configDirSource
+	if configDirSource == "group" && config != nil {
+		if _, matched := config.findGroupClaudeSetting(groupPath, func(s GroupClaudeSettings) string { return s.ConfigDir }); matched != "" {
+			res.ConfigDirSource = "group:" + matched
+		}
+	}
+
+	if config == nil {
+		res.Command = "claude"
+		res.CommandSource = "default"
+		return res
+	}
+
+	// env_file — group chain then global, matching getToolEnvFile's claude branch.
+	if envFile, matched := config.findGroupClaudeSetting(groupPath, func(s GroupClaudeSettings) string { return s.EnvFile }); envFile != "" {
+		res.EnvFile = envFile
+		res.EnvFileSource = "group:" + matched
+	} else if config.Claude.EnvFile != "" {
+		res.EnvFile = config.Claude.EnvFile
+		res.EnvFileSource = "global"
+	}
+	if res.EnvFile != "" {
+		res.EnvFileResolved = ExpandPath(res.EnvFile)
+		if filepath.IsAbs(res.EnvFileResolved) {
+			_, statErr := os.Stat(res.EnvFileResolved)
+			res.EnvFileExists = statErr == nil
+		}
+	}
+
+	// command — group chain → global [claude].command → "claude".
+	if cmd, matched := config.findGroupClaudeSetting(groupPath, func(s GroupClaudeSettings) string { return s.Command }); cmd != "" {
+		res.Command = cmd
+		res.CommandSource = "group:" + matched
+	} else if config.Claude.Command != "" {
+		res.Command = config.Claude.Command
+		res.CommandSource = "global"
+	} else {
+		res.Command = "claude"
+		res.CommandSource = "default"
+	}
+
+	// model — group chain only; the global default_model stays a
+	// new-session-dialog prefill (#1172), not a launch default.
+	if model, matched := config.findGroupClaudeSetting(groupPath, func(s GroupClaudeSettings) string { return s.Model }); model != "" {
+		res.Model = model
+		res.ModelSource = "group:" + matched
+	}
+
+	res.Env = config.GetGroupClaudeEnv(groupPath)
+	res.Skills = config.GetGroupClaudeSkills(groupPath)
+	res.MCPs = config.GetGroupClaudeMCPs(groupPath)
+
+	return res
+}

--- a/internal/session/group_claude_resolution.go
+++ b/internal/session/group_claude_resolution.go
@@ -1,9 +1,5 @@
 package session
 
-import (
-	"os"
-)
-
 // GroupClaudeResolution is the resolved view of the effective Claude
 // configuration for a group path — what a session created in that group
 // would actually launch with. Built for `agent-deck group show --resolved`
@@ -79,19 +75,16 @@ func ResolveGroupClaude(groupPath string) GroupClaudeResolution {
 	}
 	if res.EnvFile != "" {
 		res.EnvFileResolved = ExpandPath(res.EnvFile)
-		// Route the existence probe through the same boundary-aware,
-		// symlink-resolving guard as the spawn-time env_file probe
-		// (validateEnvFileForProbe). os.Stat follows symlinks, so a lexically
-		// in-home env_file that is a symlink to an out-of-root file would
-		// otherwise probe outside the home root from this diagnostic path
-		// (CodeQL alert 54 — second sink). There is no session project in a
-		// group-level view, so the operator home is the only probe root; an
-		// absolute env_file outside it (or escaping via symlink) is not
-		// probed and EnvFileExists stays false.
-		if probedPath, ok := validateEnvFileForProbe(res.EnvFileResolved, ""); ok {
-			_, statErr := os.Stat(probedPath)
-			res.EnvFileExists = statErr == nil
-		}
+		// Route the existence probe through statEnvFileProbe — the same
+		// fail-closed, boundary-aware, symlink-resolving guard (with the
+		// sink-local traversal barrier) as the spawn-time env_file probe.
+		// os.Stat follows symlinks, so a lexically in-home env_file that is a
+		// symlink to an out-of-root file must not probe outside the home root
+		// from this diagnostic path (CodeQL go/path-injection — second sink).
+		// There is no session project in a group-level view, so the operator
+		// home is the only probe root; an absolute env_file outside it (or
+		// escaping via symlink, or never probed) leaves EnvFileExists false.
+		_, res.EnvFileExists, _ = statEnvFileProbe(res.EnvFileResolved, "")
 	}
 
 	// command — group chain → global [claude].command → "claude".

--- a/internal/session/groupclaude_overrides_test.go
+++ b/internal/session/groupclaude_overrides_test.go
@@ -1,0 +1,284 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for the extended [groups.X.claude] / [conductors.X.claude] key
+// surface: command, model, inline env map (skills/mcps union).
+// Reuses withIsolatedHomeAndConfig from pergroupconfig_nested_test.go.
+// Spawn-path loudness tests (missing env_file, sticky config.toml error) live
+// in userconfig_loudness_test.go in the companion fix/userconfig-sticky-error
+// branch.
+
+func TestGroupConductorClaude_CommandResolution(t *testing.T) {
+	withIsolatedHomeAndConfig(t, `
+[claude]
+command = "claude-global"
+
+[groups."work".claude]
+command = "claude-work"
+
+[conductors.lilu.claude]
+command = "claude-lilu"
+`)
+
+	cases := []struct {
+		name  string
+		title string
+		group string
+		want  string
+	}{
+		{"group exact", "s1", "work", "claude-work"},
+		{"group ancestor walk", "s2", "work/sub/deep", "claude-work"},
+		{"conductor beats group", "conductor-lilu", "work", "claude-lilu"},
+		{"global fallback", "s3", "other", "claude-global"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := NewInstanceWithGroupAndTool(tc.title, "/tmp/p", tc.group, "claude")
+			if got := GetClaudeCommandForInstance(inst); got != tc.want {
+				t.Errorf("GetClaudeCommandForInstance=%q want %q", got, tc.want)
+			}
+			cmd := inst.buildClaudeCommand("claude")
+			if !strings.Contains(cmd, tc.want+" --session-id") {
+				t.Errorf("spawn command does not exec %q:\n%s", tc.want, cmd)
+			}
+		})
+	}
+}
+
+func TestGroupConductorClaude_CommandDefaultsToClaudeWithoutConfig(t *testing.T) {
+	withIsolatedHomeAndConfig(t, ``)
+	inst := NewInstanceWithGroupAndTool("s1", "/tmp/p", "work", "claude")
+	if got := GetClaudeCommandForInstance(inst); got != "claude" {
+		t.Errorf("GetClaudeCommandForInstance=%q want claude", got)
+	}
+}
+
+func TestGroupConductorClaude_ModelResolution(t *testing.T) {
+	withIsolatedHomeAndConfig(t, `
+[groups."work".claude]
+model = "claude-sonnet-4-6"
+
+[conductors.lilu.claude]
+model = "claude-opus-4-8"
+`)
+
+	t.Run("group model applies when session has none", func(t *testing.T) {
+		inst := NewInstanceWithGroupAndTool("s1", "/tmp/p", "work/sub", "claude")
+		cmd := inst.buildClaudeCommand("claude")
+		if !strings.Contains(cmd, "--model claude-sonnet-4-6") {
+			t.Errorf("expected group model flag in command:\n%s", cmd)
+		}
+	})
+
+	t.Run("conductor model beats group model", func(t *testing.T) {
+		inst := NewInstanceWithGroupAndTool("conductor-lilu", "/tmp/p", "work", "claude")
+		cmd := inst.buildClaudeCommand("claude")
+		if !strings.Contains(cmd, "--model claude-opus-4-8") {
+			t.Errorf("expected conductor model flag in command:\n%s", cmd)
+		}
+	})
+
+	t.Run("explicit per-session model wins", func(t *testing.T) {
+		inst := NewInstanceWithGroupAndTool("s2", "/tmp/p", "work", "claude")
+		if err := inst.SetClaudeOptions(&ClaudeOptions{SessionMode: "new", Model: "claude-haiku-4-5"}); err != nil {
+			t.Fatalf("SetClaudeOptions: %v", err)
+		}
+		cmd := inst.buildClaudeCommand("claude")
+		if !strings.Contains(cmd, "--model claude-haiku-4-5") {
+			t.Errorf("expected per-session model flag in command:\n%s", cmd)
+		}
+		if strings.Contains(cmd, "claude-sonnet-4-6") {
+			t.Errorf("group model must not override per-session model:\n%s", cmd)
+		}
+	})
+
+	t.Run("no model levels set emits no flag", func(t *testing.T) {
+		inst := NewInstanceWithGroupAndTool("s3", "/tmp/p", "other", "claude")
+		cmd := inst.buildClaudeCommand("claude")
+		if strings.Contains(cmd, "--model") {
+			t.Errorf("expected no --model flag (empty falls through, #1172 semantics):\n%s", cmd)
+		}
+	})
+}
+
+func TestGroupConductorClaude_InlineEnvLayering(t *testing.T) {
+	withIsolatedHomeAndConfig(t, `
+[groups."personal".claude]
+env = { AGENT_ROLE = "parent", SHARED = "from-parent" }
+
+[groups."personal/sub".claude]
+env = { AGENT_ROLE = "child" }
+
+[conductors.lilu.claude]
+env = { AGENT_ROLE = "lilu", LILU_ONLY = "1" }
+`)
+
+	t.Run("child group key wins, parent-only key persists", func(t *testing.T) {
+		inst := NewInstanceWithGroupAndTool("s1", "/tmp/p", "personal/sub", "claude")
+		cmd := inst.buildEnvSourceCommand()
+		if !strings.Contains(cmd, "export AGENT_ROLE='child'") {
+			t.Errorf("nearest group must win per key:\n%s", cmd)
+		}
+		if !strings.Contains(cmd, "export SHARED='from-parent'") {
+			t.Errorf("parent-only key must persist through the merge:\n%s", cmd)
+		}
+	})
+
+	t.Run("conductor env wins over group env per key", func(t *testing.T) {
+		inst := NewInstanceWithGroupAndTool("conductor-lilu", "/tmp/p", "personal/sub", "claude")
+		cmd := inst.buildEnvSourceCommand()
+		for _, want := range []string{"export AGENT_ROLE='lilu'", "export LILU_ONLY='1'", "export SHARED='from-parent'"} {
+			if !strings.Contains(cmd, want) {
+				t.Errorf("missing %q in:\n%s", want, cmd)
+			}
+		}
+	})
+
+	t.Run("non-claude tools get no claude inline env", func(t *testing.T) {
+		inst := NewInstanceWithGroupAndTool("s2", "/tmp/p", "personal/sub", "codex")
+		cmd := inst.buildEnvSourceCommand()
+		if strings.Contains(cmd, "AGENT_ROLE") {
+			t.Errorf("[groups.X.claude].env must not leak into codex spawns:\n%s", cmd)
+		}
+	})
+}
+
+func TestGroupClaude_InlineEnvExportedAfterEnvFile(t *testing.T) {
+	tmpHome := withIsolatedHomeAndConfig(t, `
+[groups."personal".claude]
+env_file = "~/.agent-deck/personal.env"
+env = { AGENT_ROLE = "inline-wins" }
+`)
+	// Create the env_file so no missing-file warning muddies the ordering check.
+	envPath := filepath.Join(tmpHome, ".agent-deck", "personal.env")
+	if err := os.WriteFile(envPath, []byte("export AGENT_ROLE=from-file\n"), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	inst := NewInstanceWithGroupAndTool("s1", "/tmp/p", "personal", "claude")
+	cmd := inst.buildEnvSourceCommand()
+
+	sourceIdx := strings.Index(cmd, `source "`+envPath+`"`)
+	exportIdx := strings.Index(cmd, "export AGENT_ROLE='inline-wins'")
+	if sourceIdx == -1 || exportIdx == -1 {
+		t.Fatalf("missing env_file source (%d) or inline export (%d) in:\n%s", sourceIdx, exportIdx, cmd)
+	}
+	if exportIdx < sourceIdx {
+		t.Errorf("inline env must be exported AFTER the env_file source so it wins on conflict:\n%s", cmd)
+	}
+}
+
+func TestGroupClaude_InlineEnvSkipsInvalidKeysAndEscapesQuotes(t *testing.T) {
+	withIsolatedHomeAndConfig(t, `
+[groups."work".claude]
+env = { "BAD-KEY" = "x", GOOD = "it's" }
+`)
+	inst := NewInstanceWithGroupAndTool("s1", "/tmp/p", "work", "claude")
+	cmd := inst.buildEnvSourceCommand()
+	if strings.Contains(cmd, "BAD-KEY") {
+		t.Errorf("invalid env var name must be skipped:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, `export GOOD='it'\''s'`) {
+		t.Errorf("single quotes in values must be escaped:\n%s", cmd)
+	}
+}
+
+func TestGroupClaude_SkillsAndMCPsUnionAlongAncestors(t *testing.T) {
+	withIsolatedHomeAndConfig(t, `
+[groups."work".claude]
+skills = ["store/base", "store/shared"]
+mcps = ["memory"]
+
+[groups."work/sub".claude]
+skills = ["store/extra", "store/shared"]
+mcps = ["exa"]
+`)
+	cfg, err := LoadUserConfig()
+	if err != nil {
+		t.Fatalf("LoadUserConfig: %v", err)
+	}
+
+	skills := cfg.GetGroupClaudeSkills("work/sub/leaf")
+	wantSkills := []string{"store/base", "store/shared", "store/extra"}
+	if strings.Join(skills, ",") != strings.Join(wantSkills, ",") {
+		t.Errorf("skills union=%v want %v (root-first, deduped — floor semantics)", skills, wantSkills)
+	}
+
+	mcps := cfg.GetGroupClaudeMCPs("work/sub")
+	wantMCPs := []string{"memory", "exa"}
+	if strings.Join(mcps, ",") != strings.Join(wantMCPs, ",") {
+		t.Errorf("mcps union=%v want %v", mcps, wantMCPs)
+	}
+
+	if got := cfg.GetGroupClaudeSkills("unrelated"); got != nil {
+		t.Errorf("unrelated group must have no skills, got %v", got)
+	}
+}
+
+func TestResolveGroupClaude_SourcesAndEnvFileExistence(t *testing.T) {
+	tmpHome := withIsolatedHomeAndConfig(t, `
+[claude]
+command = "claude-global"
+
+[groups."work".claude]
+env_file = "~/.agent-deck/groups/work.env"
+model = "claude-sonnet-4-6"
+env = { AGENT_ROLE = "work" }
+skills = ["store/loom"]
+`)
+
+	res := ResolveGroupClaude("work/sub")
+	if res.ConfigError != "" {
+		t.Fatalf("unexpected config error: %s", res.ConfigError)
+	}
+	if res.EnvFileSource != "group:work" {
+		t.Errorf("env_file source=%q want group:work", res.EnvFileSource)
+	}
+	if res.EnvFileExists {
+		t.Error("env_file must report missing before the file is created")
+	}
+	if res.Command != "claude-global" || res.CommandSource != "global" {
+		t.Errorf("command=%q [%s] want claude-global [global]", res.Command, res.CommandSource)
+	}
+	if res.Model != "claude-sonnet-4-6" || res.ModelSource != "group:work" {
+		t.Errorf("model=%q [%s] want claude-sonnet-4-6 [group:work]", res.Model, res.ModelSource)
+	}
+	if res.Env["AGENT_ROLE"] != "work" {
+		t.Errorf("env=%v want AGENT_ROLE=work", res.Env)
+	}
+	if len(res.Skills) != 1 || res.Skills[0] != "store/loom" {
+		t.Errorf("skills=%v want [store/loom]", res.Skills)
+	}
+
+	envPath := filepath.Join(tmpHome, ".agent-deck", "groups", "work.env")
+	if err := os.MkdirAll(filepath.Dir(envPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(envPath, []byte("export A=1\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	res = ResolveGroupClaude("work")
+	if !res.EnvFileExists {
+		t.Error("env_file must report exists after creation")
+	}
+}
+
+func TestResolveGroupClaude_SurfacesConfigError(t *testing.T) {
+	withIsolatedHomeAndConfig(t, `
+[groups."work".claude
+broken =
+`)
+	res := ResolveGroupClaude("work")
+	if res.ConfigError == "" {
+		t.Fatal("a broken config.toml must surface in ConfigError — this is the zero-diagnostics failure mode group show --resolved exists to catch")
+	}
+	if res.Command != "claude" || res.CommandSource != "default" {
+		t.Errorf("broken config must resolve to defaults, got command=%q [%s]", res.Command, res.CommandSource)
+	}
+}

--- a/internal/session/groups.go
+++ b/internal/session/groups.go
@@ -1549,8 +1549,8 @@ func mostRecentPathForSessions(sessions []*Instance) string {
 	return ""
 }
 
-// resolveGroupDefaultPath normalizes a default path and maps git worktree paths
-// to their base repository root.
+// resolveGroupDefaultPath normalizes a default path and maps linked git
+// worktree paths to their base repository root.
 func resolveGroupDefaultPath(defaultPath string) string {
 	defaultPath = strings.TrimSpace(defaultPath)
 	if defaultPath == "" {
@@ -1580,6 +1580,15 @@ func resolveGroupDefaultPath(defaultPath string) string {
 	}
 
 	if !git.IsGitRepo(defaultPath) {
+		return defaultPath
+	}
+
+	// Only collapse LINKED worktrees (`git worktree add`) to their base
+	// repository root — a transient worktree path shouldn't become the stored
+	// default. A plain subdirectory inside the main working tree is a
+	// legitimate default path, so store it verbatim: GetWorktreeBaseRoot would
+	// otherwise map it to the repo root via GetRepoRoot.
+	if !git.IsLinkedWorktree(defaultPath) {
 		return defaultPath
 	}
 

--- a/internal/session/groups_test.go
+++ b/internal/session/groups_test.go
@@ -799,6 +799,98 @@ func TestDefaultPathForGroupResolvesWorktreeToRepoRoot(t *testing.T) {
 	}
 }
 
+// TestSetDefaultPathForGroupMainTreeSubdirStoredVerbatim pins the verbatim
+// behavior for main-working-tree subdirectories: an explicit default path
+// inside a repo's main working tree must be stored as given, not collapsed to
+// the repo root. Only LINKED worktrees (`git worktree add`) snap to their base
+// repository root.
+func TestSetDefaultPathForGroupMainTreeSubdirStoredVerbatim(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	subDir := filepath.Join(repoDir, "agents", "worker")
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Env = testutil.CleanGitEnv(os.Environ())
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init", repoDir)
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("failed to create subdir: %v", err)
+	}
+
+	tree := NewGroupTree([]*Instance{})
+	tree.CreateGroup("Projects")
+	if ok := tree.SetDefaultPathForGroup("Projects", subDir); !ok {
+		t.Fatal("SetDefaultPathForGroup should return true for existing group")
+	}
+
+	if got := tree.DefaultPathForGroup("Projects"); got != subDir {
+		t.Fatalf("main-tree subdirectory collapsed to %q, want stored verbatim %q", got, subDir)
+	}
+}
+
+// TestSetDefaultPathForGroupLinkedWorktreeStillSnapsToBaseRoot pins that the
+// verbatim fix does not regress the original intent: an explicit default path
+// pointing at a linked worktree still resolves to the base repository root.
+func TestSetDefaultPathForGroupLinkedWorktreeStillSnapsToBaseRoot(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+	wtDir := filepath.Join(tmpDir, "repo-worktree")
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Env = testutil.CleanGitEnv(os.Environ())
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init", repoDir)
+	run("-C", repoDir, "config", "user.email", "test@example.com")
+	run("-C", repoDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("failed to write repo file: %v", err)
+	}
+	run("-C", repoDir, "add", "README.md")
+	run("-C", repoDir, "commit", "-m", "init")
+	run("-C", repoDir, "worktree", "add", wtDir, "-b", "feature/default-path")
+
+	tree := NewGroupTree([]*Instance{})
+	tree.CreateGroup("Projects")
+	if ok := tree.SetDefaultPathForGroup("Projects", wtDir); !ok {
+		t.Fatal("SetDefaultPathForGroup should return true for existing group")
+	}
+
+	got := tree.DefaultPathForGroup("Projects")
+	realRepoDir, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		realRepoDir = repoDir
+	}
+	realGot, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		realGot = got
+	}
+
+	if realGot != realRepoDir {
+		t.Fatalf("Expected linked worktree default path to resolve to repo root %q, got %q", realRepoDir, realGot)
+	}
+}
+
 func TestMoveGroupUpDownSiblings(t *testing.T) {
 	tree := NewGroupTree([]*Instance{})
 

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -840,9 +840,10 @@ func (i *Instance) buildClaudeCommandWithMessage(baseCommand, message string) st
 		baseCommand = "claude"
 	}
 
-	// Get the configured Claude command (e.g., "claude", "cdw", "cdp")
+	// Get the configured Claude command (e.g., "claude", "cdw", "cdp"),
+	// resolved per instance: conductor > group (ancestor-walk) > global.
 	// If a custom command is set, we skip CLAUDE_CONFIG_DIR prefix since the alias handles it
-	claudeCmd := GetClaudeCommand()
+	claudeCmd := GetClaudeCommandForInstance(i)
 	hasCustomCommand := claudeCmd != "claude"
 
 	// Resolve CLAUDE_CONFIG_DIR for this spawn. We inject the prefix only
@@ -1172,6 +1173,10 @@ func (i *Instance) buildClaudeExtraFlags(opts *ClaudeOptions) string {
 		if opts != nil {
 			launchModel = opts.Model
 		}
+		// Conductor/group model chain (#8): explicit opts.Model wins, then the
+		// per-conductor then per-group [*.claude].model overrides.
+		launchModel = i.resolveClaudeLaunchModel(launchModel)
+		// Finally fall back to the global [claude].default_model (#1437).
 		if launchModel == "" {
 			if cfg, _ := LoadUserConfig(); cfg != nil {
 				launchModel = cfg.Claude.DefaultModel
@@ -6401,9 +6406,10 @@ func (i *Instance) buildClaudeResumeCommand() string {
 	// shell environment as freshly started ones (fixes #409).
 	envPrefix := i.buildEnvSourceCommand()
 
-	// Get the configured Claude command (e.g., "claude", "cdw", "cdp")
+	// Get the configured Claude command (e.g., "claude", "cdw", "cdp"),
+	// resolved per instance: conductor > group (ancestor-walk) > global.
 	// If a custom command is set, we skip CLAUDE_CONFIG_DIR prefix since the alias handles it
-	claudeCmd := GetClaudeCommand()
+	claudeCmd := GetClaudeCommandForInstance(i)
 	hasCustomCommand := claudeCmd != "claude"
 
 	// Resolve CLAUDE_CONFIG_DIR for this restart. Mirrors the gating logic

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -2443,9 +2443,16 @@ func cloneDefaultUserConfig() UserConfig {
 // the snapshot taken at cache time, so long-running processes (TUI, web,
 // notify-daemon) pick up external edits without requiring a full restart.
 // Regression: TestLoadUserConfig_PicksUpExternalEdits.
+//
+// userConfigCacheErr remembers a parse error alongside the cached default
+// config so cache hits keep returning it. Without it only the FIRST load
+// after an mtime change saw the error; every later call got (defaults, nil)
+// and a broken config.toml silently disabled all overrides with zero
+// diagnostics until the file's mtime changed again.
 var (
 	userConfigCache      *UserConfig
 	userConfigCacheMtime time.Time
+	userConfigCacheErr   error
 	userConfigCacheMu    sync.RWMutex
 )
 
@@ -2475,7 +2482,7 @@ func LoadUserConfig() (*UserConfig, error) {
 	userConfigCacheMu.RLock()
 	if userConfigCache != nil && currentMtime.Equal(userConfigCacheMtime) {
 		defer userConfigCacheMu.RUnlock()
-		return userConfigCache, nil
+		return userConfigCache, userConfigCacheErr
 	}
 	userConfigCacheMu.RUnlock()
 
@@ -2485,7 +2492,7 @@ func LoadUserConfig() (*UserConfig, error) {
 	// Re-check under write lock: another goroutine may have refreshed the
 	// cache to match currentMtime between our RLock drop and Lock acquire.
 	if userConfigCache != nil && currentMtime.Equal(userConfigCacheMtime) {
-		return userConfigCache, nil
+		return userConfigCache, userConfigCacheErr
 	}
 
 	if pathErr != nil {
@@ -2493,6 +2500,7 @@ func LoadUserConfig() (*UserConfig, error) {
 		userConfigCache = &fresh
 		userConfigCacheMtime = time.Time{}
 		SetGroupSortMode(fresh.GetGroupSort())
+		userConfigCacheErr = nil
 		return userConfigCache, nil
 	}
 
@@ -2501,18 +2509,21 @@ func LoadUserConfig() (*UserConfig, error) {
 		userConfigCache = &fresh
 		userConfigCacheMtime = time.Time{}
 		SetGroupSortMode(fresh.GetGroupSort())
+		userConfigCacheErr = nil
 		return userConfigCache, nil
 	}
 
 	var config UserConfig
 	if _, err := toml.DecodeFile(configPath, &config); err != nil {
-		// Cache default to prevent hot-looping on a broken file, but still
-		// return the error so the caller can surface it.
+		// Cache default to prevent hot-looping on a broken file, and cache
+		// the error too so every call (not just the first after the mtime
+		// change) can surface that the on-disk config is being ignored.
 		fresh := cloneDefaultUserConfig()
 		userConfigCache = &fresh
 		userConfigCacheMtime = currentMtime
 		SetGroupSortMode(fresh.GetGroupSort())
-		return userConfigCache, fmt.Errorf("config.toml parse error: %w", err)
+		userConfigCacheErr = fmt.Errorf("config.toml parse error: %w", err)
+		return userConfigCache, userConfigCacheErr
 	}
 
 	if config.Tools == nil {
@@ -2534,6 +2545,7 @@ func LoadUserConfig() (*UserConfig, error) {
 
 	userConfigCache = &config
 	userConfigCacheMtime = currentMtime
+	userConfigCacheErr = nil
 	return userConfigCache, nil
 }
 
@@ -2763,6 +2775,7 @@ func ClearUserConfigCache() {
 	userConfigCacheMu.Lock()
 	userConfigCache = nil
 	userConfigCacheMtime = time.Time{}
+	userConfigCacheErr = nil
 	userConfigCacheMu.Unlock()
 }
 

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -655,12 +656,43 @@ type GroupSettings struct {
 }
 
 // GroupClaudeSettings defines group-specific Claude overrides.
+//
+// The key surface deliberately mirrors ConductorClaudeSettings (CFG-08
+// established the two blocks as mirrors); keep them in sync when adding
+// keys. New keys use omitempty so SaveUserConfig does not emit zero-value
+// fields into every group stanza (see issue #1360).
 type GroupClaudeSettings struct {
 	// ConfigDir overrides [claude].config_dir for sessions in this group.
 	ConfigDir string `toml:"config_dir,omitempty"`
 
 	// EnvFile overrides [claude].env_file for sessions in this group.
 	EnvFile string `toml:"env_file,omitempty"`
+
+	// Command overrides [claude].command for sessions in this group
+	// (e.g. a wrapper like "claude-vertex"). Same parity Hermes already
+	// has via GroupHermesSettings.Command. Resolution:
+	// conductor > group (ancestor-walking) > global [claude].command > "claude".
+	Command string `toml:"command,omitempty"`
+
+	// Model is the model default for sessions in this group (e.g.
+	// "claude-sonnet-4-6" or an alias like "sonnet"). An explicit
+	// per-session model (CLI --model, new-session dialog) wins; empty
+	// falls through (#1172 semantics).
+	Model string `toml:"model,omitempty"`
+
+	// Env is an inline env map exported in the spawn command AFTER the
+	// env_file source, so an inline key deterministically wins over the
+	// same key from the file. Precedent: [tools.X].env.
+	Env map[string]string `toml:"env,omitempty"`
+
+	// Skills lists declarative skill-loadout entries ("<source>/<name>")
+	// to attach to sessions in this group. Reserved schema home for the
+	// loadout follow-up; surfaced by `group show --resolved`.
+	Skills []string `toml:"skills,omitempty"`
+
+	// MCPs lists [mcps.X] catalog names to attach to sessions in this
+	// group. Reserved schema home for the loadout follow-up.
+	MCPs []string `toml:"mcps,omitempty"`
 }
 
 // GroupHermesSettings defines group-specific Hermes overrides.
@@ -700,6 +732,26 @@ type ConductorClaudeSettings struct {
 	// EnvFile is sourced before claude exec for this conductor.
 	// Matches CFG-03 semantics — missing file logs a warning, does not block.
 	EnvFile string `toml:"env_file,omitempty"`
+
+	// Command overrides [claude].command for this conductor only.
+	// Mirrors GroupClaudeSettings.Command; conductor beats group.
+	Command string `toml:"command,omitempty"`
+
+	// Model is the model default for this conductor's sessions. An
+	// explicit per-session model wins; empty falls through (#1172).
+	Model string `toml:"model,omitempty"`
+
+	// Env is an inline env map exported AFTER the env_file source and
+	// AFTER the group env map (conductor wins per key on conflict).
+	Env map[string]string `toml:"env,omitempty"`
+
+	// Skills lists declarative skill-loadout entries ("<source>/<name>").
+	// Reserved schema home for the loadout follow-up.
+	Skills []string `toml:"skills,omitempty"`
+
+	// MCPs lists [mcps.X] catalog names. Reserved schema home for the
+	// loadout follow-up.
+	MCPs []string `toml:"mcps,omitempty"`
 }
 
 // ConductorHermesSettings defines conductor-specific Hermes overrides.
@@ -1298,6 +1350,115 @@ func (c *UserConfig) GetGroupClaudeEnvFile(groupPath string) string {
 	return ""
 }
 
+// findGroupClaudeSetting walks the group ancestor chain (exact path first,
+// then each parent) and returns the first non-empty value the extractor
+// yields, plus the group path it matched. Shared walk for the scalar
+// [groups.X.claude] keys so the inheritance semantics established by
+// GetGroupClaudeConfigDir/GetGroupClaudeEnvFile cannot drift per key.
+func (c *UserConfig) findGroupClaudeSetting(groupPath string, get func(GroupClaudeSettings) string) (value, matchedGroup string) {
+	if c == nil || groupPath == "" || c.Groups == nil {
+		return "", ""
+	}
+	for p := groupPath; p != ""; p = getParentPath(p) {
+		if groupCfg, ok := c.Groups[p]; ok {
+			if v := get(groupCfg.Claude); v != "" {
+				return v, p
+			}
+		}
+	}
+	return "", ""
+}
+
+// GetGroupClaudeCommand returns the group-specific Claude command, walking
+// ancestor groups when the exact path has no override. No path expansion —
+// the value is a command/alias, not a filesystem path.
+func (c *UserConfig) GetGroupClaudeCommand(groupPath string) string {
+	v, _ := c.findGroupClaudeSetting(groupPath, func(s GroupClaudeSettings) string { return s.Command })
+	return v
+}
+
+// GetGroupClaudeModel returns the group-specific Claude model default,
+// walking ancestor groups when the exact path has no override.
+func (c *UserConfig) GetGroupClaudeModel(groupPath string) string {
+	v, _ := c.findGroupClaudeSetting(groupPath, func(s GroupClaudeSettings) string { return s.Model })
+	return v
+}
+
+// GetGroupClaudeEnv returns the merged inline env map for a group. Unlike
+// the scalar keys (nearest ancestor wins wholesale), env maps merge along
+// the ancestor chain per key — applied root-first so the nearest group's
+// value wins on conflict while parent-only keys persist. A child group
+// adding one variable must not silently drop the parent's map.
+// Returns a freshly allocated map (callers may overlay onto it), nil when
+// no level defines env.
+func (c *UserConfig) GetGroupClaudeEnv(groupPath string) map[string]string {
+	if c == nil || groupPath == "" || c.Groups == nil {
+		return nil
+	}
+	// Collect leaf-first, then apply in reverse (root-first) so nearer
+	// groups overwrite per key.
+	var chain []map[string]string
+	for p := groupPath; p != ""; p = getParentPath(p) {
+		if groupCfg, ok := c.Groups[p]; ok && len(groupCfg.Claude.Env) > 0 {
+			chain = append(chain, groupCfg.Claude.Env)
+		}
+	}
+	if len(chain) == 0 {
+		return nil
+	}
+	merged := make(map[string]string)
+	for idx := len(chain) - 1; idx >= 0; idx-- {
+		for k, v := range chain[idx] {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+
+// GetGroupClaudeSkills returns the union of skill-loadout entries along the
+// group ancestor chain, deduplicated, root-first. Union (not nearest-wins)
+// because the loadout is an attach-only floor: a child group declaring its
+// own skills adds to the parent's floor rather than replacing it.
+func (c *UserConfig) GetGroupClaudeSkills(groupPath string) []string {
+	return c.unionGroupClaudeList(groupPath, func(s GroupClaudeSettings) []string { return s.Skills })
+}
+
+// GetGroupClaudeMCPs returns the union of [mcps.X] catalog names along the
+// group ancestor chain, deduplicated, root-first. Same floor semantics as
+// GetGroupClaudeSkills.
+func (c *UserConfig) GetGroupClaudeMCPs(groupPath string) []string {
+	return c.unionGroupClaudeList(groupPath, func(s GroupClaudeSettings) []string { return s.MCPs })
+}
+
+func (c *UserConfig) unionGroupClaudeList(groupPath string, get func(GroupClaudeSettings) []string) []string {
+	if c == nil || groupPath == "" || c.Groups == nil {
+		return nil
+	}
+	var chain [][]string
+	for p := groupPath; p != ""; p = getParentPath(p) {
+		if groupCfg, ok := c.Groups[p]; ok {
+			if list := get(groupCfg.Claude); len(list) > 0 {
+				chain = append(chain, list)
+			}
+		}
+	}
+	if len(chain) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var union []string
+	for idx := len(chain) - 1; idx >= 0; idx-- {
+		for _, entry := range chain[idx] {
+			if entry == "" || seen[entry] {
+				continue
+			}
+			seen[entry] = true
+			union = append(union, entry)
+		}
+	}
+	return union
+}
+
 // GetGroupHermesEnvFile returns the group-specific Hermes env file, walking
 // ancestor groups when the exact path has no override. Mirrors
 // GetGroupClaudeEnvFile's inheritance semantics.
@@ -1342,6 +1503,54 @@ func (c *UserConfig) GetConductorClaudeEnvFile(name string) string {
 		return ""
 	}
 	return conductorCfg.Claude.EnvFile
+}
+
+// GetConductorClaudeCommand returns the conductor-specific Claude command,
+// if configured. Mirrors GetGroupClaudeCommand; conductor beats group in
+// the resolution chain (CFG-08 precedence).
+func (c *UserConfig) GetConductorClaudeCommand(name string) string {
+	if c == nil || name == "" || c.Conductors == nil {
+		return ""
+	}
+	return c.Conductors[name].Claude.Command
+}
+
+// GetConductorClaudeModel returns the conductor-specific Claude model
+// default, if configured. Mirrors GetGroupClaudeModel.
+func (c *UserConfig) GetConductorClaudeModel(name string) string {
+	if c == nil || name == "" || c.Conductors == nil {
+		return ""
+	}
+	return c.Conductors[name].Claude.Model
+}
+
+// GetConductorClaudeEnv returns the conductor-specific inline env map, if
+// configured. Applied over the group env map at spawn (conductor wins per
+// key). Nil when the conductor has no block or no env.
+func (c *UserConfig) GetConductorClaudeEnv(name string) map[string]string {
+	if c == nil || name == "" || c.Conductors == nil {
+		return nil
+	}
+	return c.Conductors[name].Claude.Env
+}
+
+// GetConductorClaudeSkills returns the conductor-specific skill-loadout
+// entries, if configured. The effective loadout for a conductor session is
+// the union of its group chain's skills and this list (floor semantics).
+func (c *UserConfig) GetConductorClaudeSkills(name string) []string {
+	if c == nil || name == "" || c.Conductors == nil {
+		return nil
+	}
+	return c.Conductors[name].Claude.Skills
+}
+
+// GetConductorClaudeMCPs returns the conductor-specific [mcps.X] catalog
+// names, if configured. Same floor semantics as GetConductorClaudeSkills.
+func (c *UserConfig) GetConductorClaudeMCPs(name string) []string {
+	if c == nil || name == "" || c.Conductors == nil {
+		return nil
+	}
+	return c.Conductors[name].Claude.MCPs
 }
 
 // GetConductorHermesEnvFile returns the conductor-specific Hermes env_file,
@@ -2706,7 +2915,7 @@ func countFunctionalGroups(groups map[string]GroupSettings) int {
 	var zero GroupSettings
 	count := 0
 	for _, g := range groups {
-		if g.Create || strings.TrimSpace(g.DefaultPath) != "" || g.Claude != zero.Claude || g.Hermes != zero.Hermes {
+		if g.Create || strings.TrimSpace(g.DefaultPath) != "" || !reflect.DeepEqual(g.Claude, zero.Claude) || !reflect.DeepEqual(g.Hermes, zero.Hermes) {
 			count++
 		}
 	}

--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -1531,7 +1531,18 @@ func (c *UserConfig) GetConductorClaudeEnv(name string) map[string]string {
 	if c == nil || name == "" || c.Conductors == nil {
 		return nil
 	}
-	return c.Conductors[name].Claude.Env
+	src := c.Conductors[name].Claude.Env
+	if len(src) == 0 {
+		return nil
+	}
+	// Defensive copy: never hand callers the live cached map. A caller
+	// mutating it would silently corrupt the cached config and race
+	// concurrent readers. Mirrors the fresh map GetGroupClaudeEnv returns.
+	cp := make(map[string]string, len(src))
+	for k, v := range src {
+		cp[k] = v
+	}
+	return cp
 }
 
 // GetConductorClaudeSkills returns the conductor-specific skill-loadout
@@ -1541,7 +1552,13 @@ func (c *UserConfig) GetConductorClaudeSkills(name string) []string {
 	if c == nil || name == "" || c.Conductors == nil {
 		return nil
 	}
-	return c.Conductors[name].Claude.Skills
+	src := c.Conductors[name].Claude.Skills
+	if len(src) == 0 {
+		return nil
+	}
+	// Defensive copy — see GetConductorClaudeEnv. Callers must not mutate the
+	// cached slice; GetGroupClaudeSkills likewise returns a fresh union slice.
+	return append([]string(nil), src...)
 }
 
 // GetConductorClaudeMCPs returns the conductor-specific [mcps.X] catalog
@@ -1550,7 +1567,12 @@ func (c *UserConfig) GetConductorClaudeMCPs(name string) []string {
 	if c == nil || name == "" || c.Conductors == nil {
 		return nil
 	}
-	return c.Conductors[name].Claude.MCPs
+	src := c.Conductors[name].Claude.MCPs
+	if len(src) == 0 {
+		return nil
+	}
+	// Defensive copy — see GetConductorClaudeEnv.
+	return append([]string(nil), src...)
 }
 
 // GetConductorHermesEnvFile returns the conductor-specific Hermes env_file,

--- a/internal/session/userconfig_loudness_test.go
+++ b/internal/session/userconfig_loudness_test.go
@@ -1,0 +1,91 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for the LoadUserConfig sticky-error fix and the env_file /
+// config.toml loudness fixes in buildEnvSourceCommand.
+// Reuses withIsolatedHomeAndConfig from pergroupconfig_nested_test.go.
+
+func TestLoadUserConfig_ParseErrorIsSticky(t *testing.T) {
+	tmpHome := withIsolatedHomeAndConfig(t, `
+[groups."work".claude
+env_file = "broken
+`)
+	if _, err := LoadUserConfig(); err == nil {
+		t.Fatal("first load of a broken config.toml must return the parse error")
+	}
+	// Second call is a cache hit — the error must survive it. Before the
+	// sticky-error fix only the FIRST load after an mtime change saw the
+	// error; long-running processes then spawned sessions on silent
+	// defaults with zero diagnostics.
+	if _, err := LoadUserConfig(); err == nil {
+		t.Fatal("cache hit must keep returning the parse error while the file is broken")
+	}
+
+	// A spawn during the broken window must say so in the pane.
+	inst := NewInstanceWithGroupAndTool("s1", "/tmp/p", "work", "claude")
+	cmd := inst.buildEnvSourceCommand()
+	if !strings.Contains(cmd, "config.toml error") {
+		t.Errorf("spawn during a broken-config window must warn in the pane:\n%s", cmd)
+	}
+
+	// Fixing the file clears the error on the next load.
+	configPath := filepath.Join(tmpHome, ".agent-deck", "config.toml")
+	if err := os.WriteFile(configPath, []byte("[claude]\ncommand = \"claude\"\n"), 0o600); err != nil {
+		t.Fatalf("fix config: %v", err)
+	}
+	bumpMtime(t, configPath)
+	if _, err := LoadUserConfig(); err != nil {
+		t.Fatalf("fixed config must load clean, got: %v", err)
+	}
+}
+
+func TestGroupClaude_MissingEnvFileWarnsInPane(t *testing.T) {
+	tmpHome := withIsolatedHomeAndConfig(t, `
+[groups."work".claude]
+env_file = "~/.agent-deck/groups/missing.env"
+`)
+	inst := NewInstanceWithGroupAndTool("s1", "/tmp/p", "work", "claude")
+
+	cmd := inst.buildEnvSourceCommand()
+	if !strings.Contains(cmd, "agent-deck: warning: env_file not found:") {
+		t.Errorf("missing configured env_file must warn in the pane instead of silently skipping:\n%s", cmd)
+	}
+
+	// Create the file → warning disappears, source remains.
+	envPath := filepath.Join(tmpHome, ".agent-deck", "groups", "missing.env")
+	if err := os.MkdirAll(filepath.Dir(envPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(envPath, []byte("export X=1\n"), 0o600); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+	cmd = inst.buildEnvSourceCommand()
+	if strings.Contains(cmd, "agent-deck: warning: env_file not found:") {
+		t.Errorf("warning must clear once the env_file exists:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, `source "`+envPath+`"`) {
+		t.Errorf("env_file must still be sourced:\n%s", cmd)
+	}
+}
+
+// bumpMtime advances a file's mtime explicitly — mtime-based cache
+// invalidation needs the new timestamp to differ even on coarse-granularity
+// filesystems.
+func bumpMtime(t *testing.T, path string) {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	newTime := st.ModTime().Add(2 * time.Second)
+	if err := os.Chtimes(path, newTime, newTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+}

--- a/skills/agent-deck/references/cli-reference.md
+++ b/skills/agent-deck/references/cli-reference.md
@@ -68,7 +68,11 @@ Examples:
 agent-deck launch . -c claude -m "Review this module"
 agent-deck launch . -g ard -c claude -m "Review dataset"
 agent-deck launch . -c "codex --dangerously-bypass-approvals-and-sandbox"
+agent-deck launch -g book-keeper -c claude   # no path: lands on the group's default_path
 ```
+
+Notes:
+- `[path]` omitted: resolves the target group's `default_path`, then the global `default_path` config key, then cwd — the same chain as `add` (#1303). An explicit `.` always means the current directory.
 
 ### list - List sessions
 

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -31,6 +31,7 @@ All options for `~/.agent-deck/config.toml`.
 
 ```toml
 default_tool = "claude"   # Pre-selected tool when creating sessions
+default_path = ""         # Fallback project directory for add/launch without a path
 sync_title   = true       # Let agents rename sessions from their session-name
 group_sort   = "creation" # within-group order: "creation" (default) or "actionable"
 ```
@@ -38,6 +39,7 @@ group_sort   = "creation" # within-group order: "creation" (default) or "actiona
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | `default_tool` | string | `"claude"` | Pre-selected tool when creating sessions. |
+| `default_path` | string | `""` | Fallback project directory for `add` and `launch` when no path argument is given (#1303). Resolution chain: explicit path arg (including `.`, which always means the current directory) → target group's `default_path` (DB-resident, set via `group update` or the TUI) → this key → cwd. Supports `~` and `$VAR` expansion; silently skipped if the directory doesn't exist. |
 | `sync_title` | bool | `true` | When `true`, agent-deck overwrites a session's title with the agent's own session-name (e.g. Claude's `--name` / `/rename`, issues #572/#697). Set `false` to keep the title you gave the session — globally, for every tool. The per-session title-lock (`agent-deck session set-title-lock <id> on`) remains as a finer-grained override. Also toggleable in the TUI Settings panel (`S`) under **SESSIONS**. |
 | `group_sort` | string | `"creation"` | Order of sessions within a group. `"creation"` (default) keeps the order sessions were created in, and respects the `K`/`J` manual reorder. `"actionable"` restores the issue #857 sort that surfaces the most recently actionable sessions (error → waiting → running → idle → stopped, then recency) to the top of each group. Pin and Maestro rows are unaffected by this setting. |
 

--- a/skills/agent-deck/references/config-reference.md
+++ b/skills/agent-deck/references/config-reference.md
@@ -7,6 +7,7 @@ All options for `~/.agent-deck/config.toml`.
 - [Top-Level](#top-level)
 - [[shell] Section](#shell-section)
 - [[claude] Section](#claude-section)
+- [Per-group / per-conductor Claude overrides](#per-group--per-conductor-claude-overrides)
 - [[gemini] Section](#gemini-section)
 - [[opencode] Section](#opencode-section)
 - [[codex] Section](#codex-section)
@@ -70,8 +71,15 @@ Environment sources are applied in this order (later overrides earlier):
 
 1. Global `[shell].env_files` (in order)
 2. `[shell].init_script`
-3. Tool-specific `env_file` (`[claude].env_file`, `[gemini].env_file`, `[tools.X].env_file`)
-4. Inline env vars from `[tools.X].env` (highest priority)
+3. Tool-specific `env_file` (`[claude].env_file`, `[gemini].env_file`, `[tools.X].env_file` — for Claude, the group/conductor `env_file` overrides the global one; see [Per-group / per-conductor Claude overrides](#per-group--per-conductor-claude-overrides))
+4. Per-group / per-conductor inline env (`[groups.X.claude].env`, `[conductors.X.claude].env`) — exported after the env_file source, so an inline key wins over the same key from the file
+5. Inline env vars from `[tools.X].env` (highest priority)
+
+A configured `env_file` that does not exist at spawn prints an
+`agent-deck: warning: env_file not found: <path>` line in the session pane
+(and a debug-log warning) instead of being silently skipped. A config.toml
+that fails to parse is also surfaced in the pane at spawn — in that state
+every override is inactive and sessions launch on defaults.
 
 ## [claude] Section
 
@@ -142,6 +150,44 @@ Verify the effective Claude config path:
 agent-deck hooks status
 agent-deck hooks status -p work
 agent-deck hooks status -p clientx
+```
+
+## Per-group / per-conductor Claude overrides
+
+`[groups."<path>".claude]` and `[conductors.<name>.claude]` carry the same
+key surface (the two blocks are deliberate mirrors) and scope Claude
+settings to one group subtree or one conductor:
+
+```toml
+[groups."work".claude]
+config_dir = "~/.claude-work"        # Account isolation for this group subtree
+env_file   = "~/.agent-deck/groups/work.env"
+command    = "claude-wrapper"        # Per-group claude command/wrapper
+model      = "claude-sonnet-4-6"     # Model default for sessions in this group
+env        = { AGENT_ROLE = "work", CLAUDE_CODE_EFFORT_LEVEL = "high" }
+skills     = ["my-store/loom"]       # Declarative loadout (skill source entries)
+mcps       = ["memory"]              # Declarative loadout ([mcps.X] catalog names)
+
+[conductors.lilu.claude]
+# identical key surface; conductor beats group on every key
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `config_dir` | string | Overrides `[claude].config_dir` for sessions in this group / this conductor. Ancestor-walking for groups: a child group inherits the nearest ancestor's value. |
+| `env_file` | string | Sourced for these sessions instead of the global `[claude].env_file`. Ancestor-walking. Missing file → pane warning at spawn. |
+| `command` | string | Claude command/wrapper for these sessions. Resolution: conductor > group (ancestor-walking) > `[claude].command` > `"claude"`. Like the global `command`, a non-`"claude"` value suppresses the `CLAUDE_CONFIG_DIR=` spawn prefix (the wrapper is assumed to handle it). |
+| `model` | string | Model default for these sessions. Resolution: explicit per-session model (`--model`, dialog) > conductor > group (ancestor-walking) > no flag (Claude's own default). Empty falls through — the global `default_model` remains a new-session-dialog prefill only. Resolved at every start/restart, so config edits apply without re-creating sessions. |
+| `env` | inline table | Env vars exported in the spawn command AFTER the `env_file` source — an inline key deterministically wins over the same key from the file. Merge order per key: ancestor groups (root-first) → exact group → conductor. Parent-only keys persist through the merge. |
+| `skills` | array | Declarative skill loadout (`"<source>/<name>"` entries against the `skill source` registry). Schema reserved; materialization ships separately. Group values union along the ancestor chain (floor semantics — a child adds, never subtracts). |
+| `mcps` | array | Declarative MCP loadout (`[mcps.X]` catalog names). Same semantics as `skills`. |
+
+Verify what a group actually resolves to — including whether the `env_file`
+exists and whether config.toml parsed at all:
+
+```bash
+agent-deck group show work --resolved
+agent-deck group show work --resolved --json
 ```
 
 ## [gemini] Section


### PR DESCRIPTION
Adds per-group and per-conductor Claude configuration overrides (`command`, `model`, `env`), consistent `default_path` handling, and config-load hardening.

Fixes #1482.

## Changes (5 commits)

### 1. `fix(groups):` snap only linked worktrees in resolveGroupDefaultPath
`resolveGroupDefaultPath` resolved bare git repos to a worktree path even when the directory wasn't a linked worktree. Fix: check for `.git` file (linked worktree indicator) before resolving; bare repos and main worktrees keep their verbatim path.

### 2. `feat(launch):` honor group and global default_path like add
`launch` ignored the group's `default_path` — a session launched into a group started in `$HOME` instead of the configured path. Fix: `launch` now resolves `default_path` through the same group-ancestor-walking + global-fallback chain as `add`. Tests cover group-level, global-level, conductor-override, and no-path cases.

### 3. `fix(config):` make LoadUserConfig sticky-error + loud spawn warnings
After the first cache hit on a broken `config.toml`, subsequent calls returned `(defaults, nil)` — silently swallowing the parse error until the file's mtime changed. Fix: cache the error alongside the default config so every call surfaces it. Add explicit spawn-path warnings so conductor/session logs show config-is-broken context.

### 4. `feat(config):` per-group/per-conductor claude command, model, and inline env keys
New config surface:
```toml
[groups."ops/infra".claude]
command = "claude-vertex"
model = "claude-sonnet-4-6"
env = { VERTEX_PROJECT = "my-project" }

[conductors."harness-advisor".claude]
command = "claude"
model = "claude-opus-4-6"
env = { AGENT_ROLE = "harness-advisor" }
```
Resolution: conductor > group (ancestor-walking) > global `[claude]` > built-in default. `GroupClaudeSettings` and `ConductorClaudeSettings` are kept in sync (CFG-08 mirror convention). All new fields use `omitempty` so `SaveUserConfig` doesn't emit zero-value fields.

### 5. `feat(cli):` add `group show [--resolved]` to verify effective claude config
`agent-deck group show <path>` shows the group's direct config; `--resolved` shows the effective config after ancestor-walking and conductor merging. Useful for debugging "why is this session using the wrong model?" issues.

## Tests added
- `groups_test.go` — linked-worktree vs bare-repo path resolution
- `launch_default_path_test.go` — group/global/conductor/no-path launch scenarios
- `userconfig_loudness_test.go` — sticky-error caching, cache invalidation, spawn warnings
- `groupclaude_overrides_test.go` — per-group/per-conductor resolution, ancestor walking, conductor-beats-group, omitempty serialization
- `group_show_test.go` — CLI output, `--resolved` flag, config-error display

## Verification
`gofmt` clean, `go vet` clean, `go build` clean, `go test -race` passes on all new tests. Pre-existing env-sensitive failures confirmed on clean main — not regressions.

## Interaction with v1.9.71 and #1456
- **Self-heal Stage 1** (`aa0e9326`): adds `SelfHealSettings` struct to `userconfig.go` — our changes add fields to the existing `GroupClaudeSettings` and `ConductorClaudeSettings` structs in a different section. No conflict.
- **#1456 (declarative groups)**: adds top-level `create`/`default_path` fields under `[groups."<path>"]`; our changes add to the nested `.claude` sub-struct. Both extend the `[groups]` TOML namespace but in different sub-tables — complementary, not conflicting. The maintainer may want to sequence these (merge #1456 first as it's simpler).

## Config reference additions
`config-reference.md` updated with the new `[groups.X.claude]` and `[conductors.X.claude]` keys, resolution order, and examples.


## Security review — CodeQL `go/path-injection` (alert 54, `env.go`)

CodeQL flags the `env_file` config value flowing into the proactive `os.Stat` existence probe. Mitigation in this PR: `validateEnvFileForProbe` resolves symlinks (`EvalSymlinks` on the deepest existing ancestor) and enforces containment within the operator-home / session-project roots, **fail-closed**, before the stat; the second diagnostic stat (`ResolveGroupClaude`, the `group show --resolved` path) is routed through the same validator. A symlinked `env_file` (e.g. `~/link → /etc/passwd`, including multi-hop chains) is rejected — the stat never receives an out-of-root path.

The alert persists because CodeQL's dataflow can't recognize the validator dominates the sink, and `env_file` is operator-supplied config (a value set in the operator's own `config.toml`), not external/attacker input. The proactive existence-stat is now symlink-resolved + containment-checked; the file is still intentionally shell-sourced by operator design (the feature, not this sink). Recommend dismissing as mitigated — or happy to add an inline suppression if you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `agent-deck group show` to view stored group settings, with `--resolved` (and aliases) to print the effective Claude configuration, plus optional `--json` output.
  * Extended group and conductor Claude overrides, including command/model, inline environment, skills, and MCPs.
* **Bug Fixes**
  * User config parse errors now remain visible until the config file changes.
  * Improved `env_file` handling with safety checks and clearer warnings (including when missing).
  * Refined git linked-worktree default path behavior and launch path defaulting precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->