### PR TITLE
feat(sandbox): pre-trust /workspace in the Claude home seed (fixes #1489)

### DIFF
--- a/internal/docker/config.go
+++ b/internal/docker/config.go
@@ -28,6 +28,22 @@ const (
 	defaultImage = "agent-deck-sandbox:latest"
 )
 
+// claudeHomeSeed is the ~/.claude.json seeded into sandbox containers.
+// Beyond global onboarding, it pre-trusts /workspace (the sandbox project
+// mount): Claude Code discovers project-scope plugins (.claude/skills
+// entries with .claude-plugin/plugin.json) only when the project dir is
+// trusted at session startup — trust accepted interactively mid-session
+// does not retroactively load plugins or register their hooks, and this
+// seed is rewritten on every session start, wiping any in-container
+// acceptance. Pre-trusting also lets sandbox sessions start unattended
+// (no trust prompt). hasTrustDialogAccepted is the load-bearing key — it
+// gates project-scope plugin discovery and the trust prompt, mirroring
+// PreAcceptClaudeTrust; the two onboarding flags additionally suppress the
+// first-run project-onboarding prompt for a fully unattended start.
+// Worktree sessions running in a /workspace subdirectory still key trust by
+// their own cwd and are not covered.
+const claudeHomeSeed = `{"hasCompletedOnboarding":true,"projects":{"/workspace":{"hasTrustDialogAccepted":true,"hasCompletedProjectOnboarding":true,"projectOnboardingSeenCount":1}}}`
+
 // agentConfigMounts defines all tool config directories and how they are handled.
 // Adding a new tool requires only a new entry here — no code changes needed.
 var agentConfigMounts = []AgentConfigMount{
@@ -36,7 +52,7 @@ var agentConfigMounts = []AgentConfigMount{
 		containerSuffix: ".claude",
 		skipEntries:     []string{"sandbox", "projects", ".home-seeds"},
 		copyDirs:        []string{"plugins", "skills"},
-		homeSeedFiles:   map[string]string{".claude.json": `{"hasCompletedOnboarding":true}`},
+		homeSeedFiles:   map[string]string{".claude.json": claudeHomeSeed},
 		preserveFiles:   []string{".credentials.json", "statsig_user_id"},
 		keychainCredential: &keychainEntry{
 			service:  "Claude Code-credentials",

--- a/internal/docker/sandbox_test.go
+++ b/internal/docker/sandbox_test.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -244,7 +245,7 @@ func TestRefreshAgentConfigs_ReturnsMounts(t *testing.T) {
 			require.Contains(t, m.hostPath, ".home-seeds")
 			data, err := os.ReadFile(m.hostPath)
 			require.NoError(t, err)
-			require.Equal(t, `{"hasCompletedOnboarding":true}`, string(data))
+			require.Equal(t, claudeHomeSeed, string(data))
 		}
 	}
 	require.True(t, found)
@@ -315,7 +316,28 @@ func TestRefreshAgentConfigs_HomeSeedFilesAlwaysRewritten(t *testing.T) {
 
 	data, err := os.ReadFile(seedPath)
 	require.NoError(t, err)
-	require.Equal(t, `{"hasCompletedOnboarding":true}`, string(data))
+	require.Equal(t, claudeHomeSeed, string(data))
+}
+
+// TestClaudeHomeSeed_PreTrustsWorkspace parses the seed and asserts it actually
+// pre-trusts the container workspace at startup, rather than relying on a
+// circular whole-string match against the const. Keyed on containerWorkDir so
+// the seed and the mount target cannot silently diverge.
+func TestClaudeHomeSeed_PreTrustsWorkspace(t *testing.T) {
+	t.Parallel()
+
+	var seed struct {
+		HasCompletedOnboarding bool `json:"hasCompletedOnboarding"`
+		Projects               map[string]struct {
+			HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
+		} `json:"projects"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(claudeHomeSeed), &seed))
+	require.True(t, seed.HasCompletedOnboarding, "seed must keep global onboarding")
+
+	ws, ok := seed.Projects[containerWorkDir]
+	require.True(t, ok, "seed must pre-trust the container workdir %q", containerWorkDir)
+	require.True(t, ws.HasTrustDialogAccepted, "%q must be trusted at startup for project-scope plugins to load", containerWorkDir)
 }
 
 func TestSyncAgentConfig_PreserveFiles(t *testing.T) {


### PR DESCRIPTION
## Problem
Claude Code discovers project-scope plugins/hooks only when the project dir is trusted **at session startup**. The Docker sandbox seeds `~/.claude.json` and rewrites it on every session start, wiping any in-container trust acceptance — so sandboxed sessions never load project-scope plugins/hooks, and the trust prompt blocks unattended starts. (fixes #1489)

## Fix
Extend the home seed (`internal/docker/config.go`) to pre-trust the `/workspace` project mount, replacing the minimal `{"hasCompletedOnboarding":true}` seed. This mirrors the auto-trust agent-deck already applies to its own managed directories — multi-repo worktree parents (#1149) and conductor dirs (#1359) — and is appropriate here because the user explicitly chose to mount this project into a hardened, cap-dropped sandbox container.

## Validation
- A no-pre-trust image variant failed to load project-scope plugins; with the seed trust, all loaded.
- `go build ./...`, `go test ./internal/docker/...`, `go vet ./internal/docker/...` all pass.
- The two existing seed assertions are updated, plus a new test asserts the seed actually pre-trusts the workspace (keyed on `containerWorkDir`, so the seed and mount target can't silently diverge).

## Known limitation
Worktree sandbox sessions run in `/workspace/<relativePath>` and Claude keys trust by cwd, so they're **not** covered by the `/workspace` entry — a natural follow-up (a per-session seed keyed to the actual working dir).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container initialization configuration to enhance onboarding completion tracking and workspace trust state management across container environments.
  * Added comprehensive validation tests ensuring correct onboarding state and workspace trust settings are properly initialized during container startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->