### PR TITLE
fix(config): stop selfheal section from bloating config.toml

### DIFF
--- a/internal/session/userconfig.go
+++ b/internal/session/userconfig.go
@@ -42,7 +42,12 @@ const UserConfigFileName = "config.toml"
 // allowSectionDrop=true so the destructive intent is explicit and greppable.
 var ErrRefusingConfigSectionDrop = fmt.Errorf("session: refusing to save config.toml that would drop a populated [mcps] or [groups] section to empty (use SaveUserConfigWithIntent to intentionally clear)")
 
-// UserConfig represents user-facing configuration in TOML format
+// UserConfig represents user-facing configuration in TOML format.
+//
+// TOML serialization: every field must use omitempty (string/bool/slice/map/pointer)
+// or omitzero (int/struct) so zero-value fields are not written to disk. Without
+// this, SaveUserConfig bloats the file with sections the user never configured.
+// TestSaveUserConfig_ZeroValueConfigProducesNoSections enforces this invariant.
 type UserConfig struct {
 	// DefaultTool is the pre-selected AI tool when creating new sessions
 	// Valid values: "claude", "gemini", "opencode", "codex", "pi", or any custom tool name
@@ -233,7 +238,7 @@ type SelfHealSettings struct {
 	// Enabled is the global kill switch (§3.7). When false (the default),
 	// self-heal does nothing at all — not even observe-mode logging. Set true to
 	// run the observe-only Stage 1.
-	Enabled bool `toml:"enabled"`
+	Enabled bool `toml:"enabled,omitempty"`
 
 	// Mode is the authority level: "observe" (default, the only acting mode in
 	// v1.9.67 — logs would_have, takes no action), "single_action" / "full"
@@ -250,11 +255,11 @@ type SelfHealSettings struct {
 	// PerSessionPerWindow overrides the per-session recovery cap (default 2 / 6h;
 	// auth_401 is always 1). 0 uses the default. Starting dial; tuned from
 	// observe data.
-	PerSessionPerWindow int `toml:"per_session_per_window,omitempty"`
+	PerSessionPerWindow int `toml:"per_session_per_window,omitzero"`
 
 	// GlobalPerHour overrides the fleet-wide hourly recovery cap (default 5 =
 	// TriageMaxPerHour). 0 uses the default.
-	GlobalPerHour int `toml:"global_per_hour,omitempty"`
+	GlobalPerHour int `toml:"global_per_hour,omitzero"`
 
 	// OptOutGroups lists group paths that opt OUT of self-heal entirely
 	// (deliberate long-waiting stream leads, sensitive scopes — §3.7). Checked

--- a/internal/session/userconfig_test.go
+++ b/internal/session/userconfig_test.go
@@ -2271,6 +2271,7 @@ func TestSaveUserConfig_OmitsZeroValueFields(t *testing.T) {
 		"[instances]",
 		"[shell]",
 		"[fork]",
+		"[selfheal]",
 	} {
 		if strings.Contains(content, absent) {
 			t.Errorf("config.toml should not contain zero-value section %q", absent)
@@ -2296,6 +2297,41 @@ func TestSaveUserConfig_OmitsZeroValueFields(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(content), "\n")
 	if len(lines) > 50 {
 		t.Errorf("config.toml is %d lines; expected under 50 for a minimal config.\nContent:\n%s", len(lines), content)
+	}
+}
+
+// TestSaveUserConfig_ZeroValueConfigProducesNoSections saves a completely empty
+// UserConfig and asserts NO section headers appear. This catches new struct fields
+// that lack omitempty/omitzero without needing to maintain a deny-list.
+func TestSaveUserConfig_ZeroValueConfigProducesNoSections(t *testing.T) {
+	tempDir := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", originalHome)
+	isolateConfigHomeXDG(t)
+
+	if err := SaveUserConfig(&UserConfig{}); err != nil {
+		t.Fatalf("SaveUserConfig: %v", err)
+	}
+
+	configPath, err := GetUserConfigPath()
+	if err != nil {
+		t.Fatalf("GetUserConfigPath: %v", err)
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+
+	content := strings.TrimSpace(string(raw))
+
+	// A zero-value UserConfig should produce at most the file header comment — no
+	// section headers. Any [section] means a field leaks its zero value.
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) > 0 && trimmed[0] == '[' {
+			t.Errorf("zero-value UserConfig produced section header: %s\nFull content:\n%s", trimmed, content)
+		}
 	}
 }
 


### PR DESCRIPTION
The selfheal feature (#1461) landed after the omitempty fix (#1383) and
introduced fields without proper omit tags: `Enabled bool` had no tag,
and the int fields used omitempty (which BurntSushi/toml ignores for
zero ints — only omitzero works).

Add a structural test that saves a zero-value UserConfig and asserts no
section headers appear — catches future regressions without maintaining
a deny-list.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files now omit empty sections and zero-value fields, resulting in cleaner saved configs.

* **Tests**
  * Enhanced test coverage for configuration serialization to prevent unintended default sections from appearing in config files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->