### PR TITLE
fix(status): printable field delimiter so tmux -F probes survive a non-UTF-8 locale

### DIFF
--- a/internal/tmux/no_client_field_sep_test.go
+++ b/internal/tmux/no_client_field_sep_test.go
@@ -1,0 +1,302 @@
+package tmux
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This file is the deterministic repro + regression guard for the 2026-06-18
+// wake-notification bug.
+//
+// Root cause (pinned empirically): the launchd notify-daemon and the
+// conductor-heartbeat run with a minimal environment — HOME and PATH only, no
+// UTF-8 locale. tmux invoked under a non-UTF-8 locale (LANG=C or unset)
+// sanitizes non-printable bytes in `-F` format output, rewriting TAB (0x09) to
+// "_". (Setting LANG/LC_CTYPE to a UTF-8 locale makes the TAB survive; so does
+// inheriting $TMUX, which borrows an attached client's UTF-8 context — that is
+// why the $TMUX plist stopgap masked the bug.) The status probes delimited
+// their fields with TAB, so under the daemon every line collapsed to one field,
+// parseListWindowsOutput skipped it, the session cache came back empty,
+// Session.Exists() reported false, and UpdateStatus stamped StatusError on every
+// live session. That error failed the idle/waiting gate on both the wake-nudge
+// and the heartbeat, so an idle conductor stopped being woken when a child
+// finished.
+//
+// The fix replaces the TAB delimiter with tmuxFieldSep ("|"), a printable ASCII
+// byte that survives the C-locale sanitization regardless of locale, $TMUX, or
+// client presence. These tests assert PASS (session resolves) vs FAIL (the old
+// TAB format is mangled and would resolve nothing) under the daemon's exact env.
+
+// daemonLikeEnv returns the minimal environment the launchd notify-daemon runs
+// under: HOME and PATH only, no UTF-8 locale and no $TMUX. This is what makes
+// tmux sanitize TAB to "_" in format output, so the spawned probe reproduces
+// the production condition regardless of how the test itself was launched.
+func daemonLikeEnv() []string {
+	return []string{"HOME=" + os.Getenv("HOME"), "PATH=" + os.Getenv("PATH")}
+}
+
+// makeIsolatedServerNamed starts a detached tmux server on a private -L socket
+// with a session named sessionName, and returns the socket. The server has no
+// attached client (detached), exactly like the conductor sessions the daemon
+// probes. Cleaned up via kill-server.
+func makeIsolatedServerNamed(t *testing.T, sessionName string) (socket string) {
+	t.Helper()
+	socket = fmt.Sprintf("ad%x", sha256.Sum256([]byte(t.Name())))[:14]
+	// All tmux calls for this server MUST share daemonLikeEnv: it omits
+	// TMUX_TMPDIR (which TestMain isolates), so create / kill / list all resolve
+	// `-L <socket>` to the same server under the default socket dir. Mixing envs
+	// points kill-server and new-session at different servers — a "duplicate
+	// session" flake when a prior run leaked a server.
+	kill := func() {
+		c := exec.Command("tmux", "-L", socket, "kill-server")
+		c.Env = daemonLikeEnv()
+		_ = c.Run()
+	}
+	// The socket name is deterministic per test, so a server leaked by a prior
+	// aborted run would collide; clear it before creating a fresh one.
+	kill()
+	cmd := exec.Command("tmux", "-L", socket, "new-session", "-d", "-x", "200", "-y", "50", "-s", sessionName, "bash")
+	cmd.Env = daemonLikeEnv()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create tmux session: %v: %s", err, out)
+	}
+	t.Cleanup(kill)
+	return socket
+}
+
+func listWindows(t *testing.T, socket, format string) string {
+	t.Helper()
+	cmd := exec.Command("tmux", "-L", socket, "list-windows", "-a", "-F", format)
+	cmd.Env = daemonLikeEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("list-windows: %v: %s", err, out)
+	}
+	return string(out)
+}
+
+func listPanes(t *testing.T, socket, format string) string {
+	t.Helper()
+	cmd := exec.Command("tmux", "-L", socket, "list-panes", "-a", "-F", format)
+	cmd.Env = daemonLikeEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("list-panes: %v: %s", err, out)
+	}
+	return string(out)
+}
+
+// TestNoClientMangling_RootCause documents the failure mode: under the daemon's
+// non-UTF-8 locale, tmux rewrites the TAB field separators in -F output to "_",
+// so the legacy tab-delimited probe resolves NO sessions. This is the bug; if
+// this test ever stops reproducing (tmux changes its sanitization), the fix's
+// rationale should be revisited.
+func TestNoClientMangling_RootCause(t *testing.T) {
+	requireTmux(t)
+	const sess = "agentdeck_conductor-rootcause_aabbccdd"
+	socket := makeIsolatedServerNamed(t, sess)
+
+	legacyFormat := "#{session_name}\t#{window_activity}\t#{window_index}\t#{window_name}"
+	out := listWindows(t, socket, legacyFormat)
+
+	if strings.Contains(out, "\t") {
+		t.Fatalf("expected TAB to be mangled by the no-client path, but output still has tabs: %q", out)
+	}
+	// The mangled line has no real delimiter, so the parser finds nothing.
+	sessions, _ := parseListWindowsOutput(out)
+	if _, ok := sessions[sess]; ok {
+		t.Fatalf("root-cause repro broke: parser unexpectedly resolved %q from mangled output %q", sess, out)
+	}
+}
+
+// TestNoClientFieldSep_FixResolvesSession is the PASS case: with the printable
+// tmuxFieldSep delimiter the same no-client probe resolves the live session, so
+// Exists() would return true and UpdateStatus would NOT misread it as error.
+func TestNoClientFieldSep_FixResolvesSession(t *testing.T) {
+	requireTmux(t)
+	const sess = "agentdeck_conductor-fixcase_aabbccdd"
+	socket := makeIsolatedServerNamed(t, sess)
+
+	format := tmuxFmt("#{session_name}", "#{window_activity}", "#{window_index}", "#{window_name}")
+	out := listWindows(t, socket, format)
+
+	if !strings.Contains(out, tmuxFieldSep) {
+		t.Fatalf("expected the printable field separator %q to survive the no-client path; got %q", tmuxFieldSep, out)
+	}
+	sessions, windows := parseListWindowsOutput(out)
+	if _, ok := sessions[sess]; !ok {
+		t.Fatalf("fix regressed: parser did not resolve %q from %q (sessions=%v)", sess, out, sessions)
+	}
+	if len(windows[sess]) == 0 {
+		t.Errorf("expected at least one window for %q; got none", sess)
+	}
+}
+
+// TestNoClientFieldSep_PaneInfoResolves is the PASS case for the pane-info
+// probe (feeds running/dead detection and the tool spinner) under the same
+// no-client condition.
+func TestNoClientFieldSep_PaneInfoResolves(t *testing.T) {
+	requireTmux(t)
+	const sess = "agentdeck_conductor-panecase_aabbccdd"
+	socket := makeIsolatedServerNamed(t, sess)
+
+	format := tmuxFmt("#{session_name}", "#{pane_current_command}", "#{pane_dead}", "#{window_index}", "#{pane_index}", "#{pane_title}")
+	out := listPanes(t, socket, format)
+
+	panes, _ := parseListPanesOutput(out)
+	info, ok := panes[sess]
+	if !ok {
+		t.Fatalf("fix regressed: pane parser did not resolve %q from %q", sess, out)
+	}
+	if info.Dead {
+		t.Errorf("freshly created pane reported Dead=true: %+v", info)
+	}
+}
+
+// TestDaemonPath_ExistsResolvesUnderCLocale is the end-to-end daemon-path
+// assertion. It drives the exact chain the launchd notify-daemon and the
+// heartbeat's `session show` run — RefreshSessionCache() populates the global
+// session cache from a real `tmux list-windows -a -F …` subprocess, and
+// Session.Exists() reads that cache — but under a forced C locale and no $TMUX,
+// the condition that made the daemon misread every session as StatusError. With
+// the tmuxFieldSep fix the cache resolves the live session and Exists() returns
+// true; before the fix the mangled TAB output left the cache empty and Exists()
+// returned false (→ StatusError → the idle/waiting wake gate failed).
+//
+// Note: the daemon and CLI never install a PipeManager (only the TUI does, via
+// internal/ui/home.go), so RefreshSessionCache deterministically takes the
+// subprocess branch this test exercises — not the control-mode pipe path.
+func TestDaemonPath_ExistsResolvesUnderCLocale(t *testing.T) {
+	requireTmux(t)
+	const sess = "agentdeck_conductor-daemonpath_aabbccdd"
+
+	// Reproduce the launchd daemon's environment in-process: a non-UTF-8 locale
+	// (the trigger for tmux's control-char sanitization) and no inherited $TMUX.
+	// Set BEFORE creating the server so both the create and RefreshSessionCache's
+	// in-process probe share one env — in particular the TMUX_TMPDIR that
+	// TestMain isolates, so `-L <socket>` resolves to the same server in both.
+	t.Setenv("LC_ALL", "C")
+	t.Setenv("LANG", "C")
+	t.Setenv("LC_CTYPE", "C")
+	t.Setenv("TMUX", "")
+
+	socket := fmt.Sprintf("ad%x", sha256.Sum256([]byte(t.Name())))[:14]
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	// No cmd.Env override: inherit the (now C-locale, isolated-TMUX_TMPDIR)
+	// process env so the server lands where RefreshSessionCache will look.
+	if out, err := exec.Command("tmux", "-L", socket, "new-session", "-d", "-x", "200", "-y", "50", "-s", sess, "bash").CombinedOutput(); err != nil {
+		t.Fatalf("create tmux session: %v: %s", err, out)
+	}
+	t.Cleanup(func() { _ = exec.Command("tmux", "-L", socket, "kill-server").Run() })
+
+	// Point the package-level default socket at our isolated test server so
+	// RefreshSessionCache probes it and Session.Exists() (SocketName == default)
+	// trusts the resulting cache.
+	prev := DefaultSocketName()
+	SetDefaultSocketName(socket)
+	t.Cleanup(func() {
+		SetDefaultSocketName(prev)
+		sessionCacheMu.Lock()
+		sessionCacheData = nil
+		sessionCacheTime = time.Time{}
+		sessionCacheMu.Unlock()
+	})
+
+	RefreshSessionCache()
+
+	if exists, valid := sessionExistsFromCache(sess); !valid || !exists {
+		t.Fatalf("daemon path regressed: sessionExistsFromCache(%q) = (exists=%v, valid=%v) under C locale; "+
+			"the status cache did not resolve the live session", sess, exists, valid)
+	}
+
+	s := &Session{Name: sess, SocketName: socket}
+	if !s.Exists() {
+		t.Fatalf("daemon path regressed: Session.Exists() returned false for live session %q under C locale "+
+			"(this is the exact StatusError misread that suppressed the idle wake-nudge)", sess)
+	}
+}
+
+// TestPipePath_FieldSepResolvesSessionAndPane closes the control-mode pipe
+// coverage gap. The pipe producers (RefreshAllActivities, RefreshAllPaneInfo)
+// share parseListWindowsOutput / parseListPanesOutput with the subprocess path,
+// so a producer↔parser delimiter or field-order drift would silently empty the
+// result and the daemon/TUI would fall back or misread. The existing
+// TestPipeManager_RefreshAllActivities silent-skips in CI/isolated envs
+// (skipIfNoTmuxServer needs a real external session); this uses the strict
+// helper so it RUNS wherever tmux exists, and asserts the session resolves
+// through BOTH pipe refreshers.
+func TestPipePath_FieldSepResolvesSessionAndPane(t *testing.T) {
+	name := createTestSessionStrict(t, "fieldsep")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pm := NewPipeManager(ctx, nil)
+	defer pm.Close()
+	if err := pm.Connect(name, ""); err != nil {
+		t.Fatalf("pipe connect: %v", err)
+	}
+
+	activities, _, err := pm.RefreshAllActivities()
+	if err != nil {
+		t.Fatalf("RefreshAllActivities: %v", err)
+	}
+	if _, ok := activities[name]; !ok {
+		t.Fatalf("pipe RefreshAllActivities did not resolve %q — producer/parser delimiter drift; got %v", name, activities)
+	}
+
+	panes, _, err := pm.RefreshAllPaneInfo()
+	if err != nil {
+		t.Fatalf("RefreshAllPaneInfo: %v", err)
+	}
+	if _, ok := panes[name]; !ok {
+		t.Fatalf("pipe RefreshAllPaneInfo did not resolve %q — producer/parser delimiter or field-order drift; got %v", name, panes)
+	}
+}
+
+// TestParseListWindowsOutput_FieldSepInWindowName proves collision-safety: a
+// tmuxFieldSep inside the trailing free-text field (window_name) is preserved
+// intact because it is parsed last with SplitN.
+func TestParseListWindowsOutput_FieldSepInWindowName(t *testing.T) {
+	const sess = "agentdeck_conductor-x_deadbeef"
+	weirdName := "my|weird|window"
+	line := tmuxFmt(sess, "1781842421", "0", weirdName)
+
+	sessions, windows := parseListWindowsOutput(line)
+	if _, ok := sessions[sess]; !ok {
+		t.Fatalf("session %q not parsed from %q", sess, line)
+	}
+	if len(windows[sess]) != 1 || windows[sess][0].Name != weirdName {
+		t.Fatalf("window_name with embedded %q not preserved: got %+v", tmuxFieldSep, windows[sess])
+	}
+}
+
+// TestParseListPanesOutput_FieldSepInPaneTitle proves the same collision-safety
+// for the pane probe: a tmuxFieldSep inside pane_title (the only free-text
+// field, placed last) does not corrupt the leading command/dead fields.
+func TestParseListPanesOutput_FieldSepInPaneTitle(t *testing.T) {
+	const sess = "agentdeck_conductor-y_cafebabe"
+	weirdTitle := "Claude | working | foo"
+	// session | command | dead | window_index | pane_index | title
+	line := tmuxFmt(sess, "node", "0", "0", "1", weirdTitle)
+
+	panes, _ := parseListPanesOutput(line)
+	info, ok := panes[sess]
+	if !ok {
+		t.Fatalf("session %q not parsed from %q", sess, line)
+	}
+	if info.CurrentCommand != "node" {
+		t.Errorf("CurrentCommand corrupted by delimiter in title: got %q want %q", info.CurrentCommand, "node")
+	}
+	if info.Dead {
+		t.Errorf("Dead corrupted by delimiter in title: got true")
+	}
+	if info.Title != weirdTitle {
+		t.Errorf("pane_title with embedded %q not preserved: got %q want %q", tmuxFieldSep, info.Title, weirdTitle)
+	}
+}

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -209,8 +209,11 @@ func (pm *PipeManager) RefreshAllActivities() (map[string]int64, map[string][]Wi
 		return nil, nil, fmt.Errorf("no alive pipes available")
 	}
 
-	// tmux control mode requires double-quoted format strings containing special chars
-	output, err := pipe.SendCommand(`list-windows -a -F "#{session_name}\t#{window_activity}\t#{window_index}\t#{window_name}"`)
+	// Must use the same tmuxFieldSep as parseListWindowsOutput (shared with the
+	// subprocess path). A control client negotiates UTF-8, so TAB would usually
+	// survive here, but the delimiter MUST still match what the parser splits on.
+	// tmux control mode requires the format string double-quoted.
+	output, err := pipe.SendCommand(`list-windows -a -F "` + tmuxFmt("#{session_name}", "#{window_activity}", "#{window_index}", "#{window_name}") + `"`)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list-windows via pipe: %w", err)
 	}
@@ -238,51 +241,15 @@ func (pm *PipeManager) RefreshAllPaneInfo() (map[string]PaneInfo, map[string]map
 		return nil, nil, fmt.Errorf("no alive pipes available")
 	}
 
-	output, err := pipe.SendCommand(`list-panes -a -F "#{session_name}\t#{pane_title}\t#{pane_current_command}\t#{pane_dead}\t#{window_index}\t#{pane_index}"`)
+	// Share the producer format AND parser with the subprocess path
+	// (parseListPanesOutput): pane_title last, tmuxFieldSep-delimited. Keeps the
+	// pipe and subprocess paths from drifting in field order or delimiter.
+	output, err := pipe.SendCommand(`list-panes -a -F "` + tmuxFmt("#{session_name}", "#{pane_current_command}", "#{pane_dead}", "#{window_index}", "#{pane_index}", "#{pane_title}") + `"`)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list-panes via pipe: %w", err)
 	}
 
-	result := make(map[string]PaneInfo)
-	windowTools := make(map[string]map[int]string)
-	seenWindowTool := make(map[string]bool) // "session\twinIdx" -> already processed
-	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, "\t", 6)
-		if len(parts) != 6 {
-			continue
-		}
-		name := parts[0]
-
-		// Collect tool info for the first pane of each window (handles any base-index).
-		windowKey := name + "\t" + parts[4]
-		if !seenWindowTool[windowKey] {
-			seenWindowTool[windowKey] = true
-			var winIdx int
-			_, _ = fmt.Sscanf(parts[4], "%d", &winIdx)
-			tool := detectToolFromCommand(parts[2])
-			if tool == "" {
-				tool = detectToolFromCommand(parts[1])
-			}
-			if tool != "" {
-				if windowTools[name] == nil {
-					windowTools[name] = make(map[int]string)
-				}
-				windowTools[name][winIdx] = tool
-			}
-		}
-
-		// Cache the first pane seen per session (primary window+pane).
-		if _, seen := result[name]; !seen {
-			result[name] = PaneInfo{
-				Title:          parts[1],
-				CurrentCommand: parts[2],
-				Dead:           parts[3] == "1",
-			}
-		}
-	}
+	result, windowTools := parseListPanesOutput(output)
 	return result, windowTools, nil
 }
 

--- a/internal/tmux/socket.go
+++ b/internal/tmux/socket.go
@@ -61,6 +61,39 @@ func DefaultSocketName() string {
 	return defaultSocketName
 }
 
+// tmuxFieldSep delimits the fields of the `-F` format strings that agent-deck
+// both emits and parses (the session / pane / client probes that feed status
+// detection). It MUST be a printable ASCII byte, and historically was a TAB —
+// which turned out to be a latent bug:
+//
+// A tmux command invoked with NO attached client sanitizes non-printable bytes
+// in its format output, rewriting TAB (0x09) — and every other control byte,
+// including newline and the C0/UTF-8 separators — to "_". The launchd
+// notify-daemon and conductor-heartbeat inherit no $TMUX, so every status probe
+// they ran hit this path: the TAB field separators collapsed to "_", SplitN
+// found a single field, parseListWindowsOutput skipped every line, the session
+// cache came back empty, Session.Exists() reported false, and UpdateStatus
+// stamped StatusError on every live session. That error then failed the
+// idle/waiting gate on BOTH the wake-nudge and the heartbeat, so an idle
+// conductor stopped being woken when a child finished (diagnosed 2026-06-18).
+//
+// "|" survives the no-client path. It can never collide with the non-trailing
+// fields these formats carry: tmux session names are sanitized to [A-Za-z0-9-]
+// (see sanitizeNameRe) and the rest are integers or a 0/1 flag. The genuinely
+// free-text fields (window_name, pane_title, client_name) are always placed
+// LAST and parsed with SplitN, so a stray "|" inside them is preserved intact.
+//
+// The control-mode pipe path (internal/tmux/pipemanager.go) is unaffected — a
+// control client IS attached there, so it keeps its TAB formats.
+const tmuxFieldSep = "|"
+
+// tmuxFmt joins tmux format fields with tmuxFieldSep. Producer and consumer
+// (strings.SplitN(line, tmuxFieldSep, n)) reference the same constant so the
+// delimiter can never drift between the two halves.
+func tmuxFmt(fields ...string) string {
+	return strings.Join(fields, tmuxFieldSep)
+}
+
 // tmuxArgs builds the full `tmux …` argv for a command, inserting the
 // `-L <name>` socket selector at the front when socketName is non-empty
 // and non-whitespace. An empty socket name is the pre-v1.7.50 default and

--- a/internal/tmux/title_detection.go
+++ b/internal/tmux/title_detection.go
@@ -125,9 +125,12 @@ func RefreshPaneInfoCache() {
 	// (#687 follow-up, v1.7.55).
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
+	// pane_title is free-text (apps set it via OSC) so it goes LAST; every
+	// other field is a sanitized name, integer, or 0/1 flag that cannot
+	// contain tmuxFieldSep. See tmuxFieldSep for why TAB is unusable here.
 	cmd := tmuxExecContext(ctx, DefaultSocketName(),
 		"list-panes", "-a", "-F",
-		"#{session_name}\t#{pane_title}\t#{pane_current_command}\t#{pane_dead}\t#{window_index}\t#{pane_index}")
+		tmuxFmt("#{session_name}", "#{pane_current_command}", "#{pane_dead}", "#{window_index}", "#{pane_index}", "#{pane_title}"))
 	output, err := cmd.Output()
 	if err != nil {
 		paneCacheMu.Lock()
@@ -137,31 +140,54 @@ func RefreshPaneInfoCache() {
 		return
 	}
 
+	newCache, windowTools := parseListPanesOutput(string(output))
+
+	paneCacheMu.Lock()
+	paneCacheData = newCache
+	paneCacheTime = time.Now()
+	paneCacheMu.Unlock()
+
+	updateWindowToolCache(windowTools)
+}
+
+// parseListPanesOutput parses `tmux list-panes -a` output in the format
+// tmuxFmt("#{session_name}", "#{pane_current_command}", "#{pane_dead}",
+// "#{window_index}", "#{pane_index}", "#{pane_title}"). pane_title is last so a
+// tmuxFieldSep inside it survives SplitN. Returns the per-session primary
+// PaneInfo and the session→windowIndex→tool map. Extracted from
+// RefreshPaneInfoCache so the no-client delimiter handling is unit-testable.
+func parseListPanesOutput(output string) (map[string]PaneInfo, map[string]map[int]string) {
 	newCache := make(map[string]PaneInfo)
 	windowTools := make(map[string]map[int]string) // session -> windowIndex -> tool
-	seenWindowTool := make(map[string]bool)        // "session\twinIdx" -> already processed
-	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+	seenWindowTool := make(map[string]bool)        // "session|winIdx" -> already processed
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "\t", 6)
+		// Field order: session_name | pane_current_command | pane_dead |
+		// window_index | pane_index | pane_title (pane_title last, free-text).
+		parts := strings.SplitN(line, tmuxFieldSep, 6)
 		if len(parts) != 6 {
 			continue
 		}
 		name := parts[0]
+		paneCommand := parts[1]
+		paneDead := parts[2]
+		windowIndex := parts[3]
+		paneTitle := parts[5]
 
 		// Collect tool info for the first pane of each window (handles any base-index).
 		// list-panes outputs panes sorted by window then pane index, so first hit = primary.
-		windowKey := name + "\t" + parts[4]
+		windowKey := name + tmuxFieldSep + windowIndex
 		if !seenWindowTool[windowKey] {
 			seenWindowTool[windowKey] = true
 			var winIdx int
-			_, _ = fmt.Sscanf(parts[4], "%d", &winIdx)
+			_, _ = fmt.Sscanf(windowIndex, "%d", &winIdx)
 			// Try pane_current_command first, then pane_title (Claude shows as "bash"
 			// in command but "Claude Code" in title via OSC escape sequences).
-			tool := detectToolFromCommand(parts[2])
+			tool := detectToolFromCommand(paneCommand)
 			if tool == "" {
-				tool = detectToolFromCommand(parts[1])
+				tool = detectToolFromCommand(paneTitle)
 			}
 			if tool != "" {
 				if windowTools[name] == nil {
@@ -175,19 +201,13 @@ func RefreshPaneInfoCache() {
 		// Handles any base-index config — first entry in sorted list-panes output is primary.
 		if _, seen := newCache[name]; !seen {
 			newCache[name] = PaneInfo{
-				Title:          parts[1],
-				CurrentCommand: parts[2],
-				Dead:           parts[3] == "1",
+				Title:          paneTitle,
+				CurrentCommand: paneCommand,
+				Dead:           paneDead == "1",
 			}
 		}
 	}
-
-	paneCacheMu.Lock()
-	paneCacheData = newCache
-	paneCacheTime = time.Now()
-	paneCacheMu.Unlock()
-
-	updateWindowToolCache(windowTools)
+	return newCache, windowTools
 }
 
 // GetCachedPaneInfo returns cached pane info for a session.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -272,7 +272,7 @@ func RefreshSessionCache() {
 	// Subprocess fallback: list-windows -a (3s timeout to prevent freeze when server is dead)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	cmd := tmuxExecContext(ctx, DefaultSocketName(), "list-windows", "-a", "-F", "#{session_name}\t#{window_activity}\t#{window_index}\t#{window_name}")
+	cmd := tmuxExecContext(ctx, DefaultSocketName(), "list-windows", "-a", "-F", tmuxFmt("#{session_name}", "#{window_activity}", "#{window_index}", "#{window_name}"))
 	output, err := cmd.Output()
 	if err != nil {
 		sessionCacheMu.Lock()
@@ -295,8 +295,10 @@ func RefreshSessionCache() {
 	windowCacheMu.Unlock()
 }
 
-// parseListWindowsOutput parses the output of `tmux list-windows -a` with the extended format
-// "#{session_name}\t#{window_activity}\t#{window_index}\t#{window_name}"
+// parseListWindowsOutput parses the output of `tmux list-windows -a` with the
+// extended format tmuxFmt("#{session_name}", "#{window_activity}",
+// "#{window_index}", "#{window_name}"). window_name is last so a tmuxFieldSep
+// inside it survives SplitN.
 // Returns session-level max activity and per-session window info.
 func parseListWindowsOutput(output string) (map[string]int64, map[string][]WindowInfo) {
 	sessionCache := make(map[string]int64)
@@ -306,7 +308,7 @@ func parseListWindowsOutput(output string) (map[string]int64, map[string][]Windo
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "\t", 4)
+		parts := strings.SplitN(line, tmuxFieldSep, 4)
 		if len(parts) < 2 {
 			continue
 		}
@@ -4972,22 +4974,24 @@ func InitializeStatusBarOptions() error {
 func RefreshStatusBarImmediate() error {
 	socket := DefaultSocketName()
 	// Get all connected clients, filtering out control mode clients
-	cmd := tmuxExec(socket, "list-clients", "-F", "#{client_name}\t#{client_control_mode}")
+	// client_name is free-text (a pts path) so it goes LAST, after the 0/1
+	// control-mode flag, to stay collision-safe under tmuxFieldSep.
+	cmd := tmuxExec(socket, "list-clients", "-F", tmuxFmt("#{client_control_mode}", "#{client_name}"))
 	output, err := cmd.Output()
 	if err != nil {
 		return nil
 	}
 
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		parts := strings.SplitN(line, "\t", 2)
-		if len(parts) != 2 || parts[0] == "" {
+		parts := strings.SplitN(line, tmuxFieldSep, 2)
+		if len(parts) != 2 || parts[1] == "" {
 			continue
 		}
 		// Skip control mode clients (PipeManager pipes)
-		if parts[1] == "1" {
+		if parts[0] == "1" {
 			continue
 		}
-		_ = tmuxExec(socket, "refresh-client", "-S", "-t", parts[0]).Run()
+		_ = tmuxExec(socket, "refresh-client", "-S", "-t", parts[1]).Run()
 	}
 	return nil
 }
@@ -5037,7 +5041,9 @@ func GetAttachedSessionsOnSockets(sockets ...string) []string {
 // attachedSessionsOnSocket lists the non-control-mode sessions with a client
 // attached on a single tmux socket ("" = default server).
 func attachedSessionsOnSocket(socket string) ([]string, error) {
-	cmd := tmuxExec(socket, "list-clients", "-F", "#{session_name}\t#{client_control_mode}")
+	// session_name is sanitized to [A-Za-z0-9-], so it never contains
+	// tmuxFieldSep; no reordering needed here.
+	cmd := tmuxExec(socket, "list-clients", "-F", tmuxFmt("#{session_name}", "#{client_control_mode}"))
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -5045,7 +5051,7 @@ func attachedSessionsOnSocket(socket string) ([]string, error) {
 
 	var sessions []string
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		parts := strings.SplitN(line, "\t", 2)
+		parts := strings.SplitN(line, tmuxFieldSep, 2)
 		if len(parts) != 2 || parts[0] == "" {
 			continue
 		}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2639,11 +2639,12 @@ func TestSplitIntoChunks_SplitsAtNewlineBoundary(t *testing.T) {
 }
 
 func TestParseWindowCacheFromListWindows(t *testing.T) {
-	// Simulate list-windows output with extended format
+	// Simulate list-windows output with extended format (tmuxFieldSep-delimited,
+	// session_name | window_activity | window_index | window_name).
 	lines := []string{
-		"agentdeck_proj_abc12345\t1704067200\t0\tmain",
-		"agentdeck_proj_abc12345\t1704067300\t1\ttests",
-		"agentdeck_other_def67890\t1704067100\t0\tbash",
+		tmuxFmt("agentdeck_proj_abc12345", "1704067200", "0", "main"),
+		tmuxFmt("agentdeck_proj_abc12345", "1704067300", "1", "tests"),
+		tmuxFmt("agentdeck_other_def67890", "1704067100", "0", "bash"),
 	}
 
 	sessionCache, windowCache := parseListWindowsOutput(strings.Join(lines, "\n"))


### PR DESCRIPTION
Fixes #1495.

## Problem

Under a non-UTF-8 locale (`LANG=C` or unset) tmux sanitizes non-printable bytes in `-F` format output, rewriting **TAB (0x09) → `_`**. The headless notify-daemon and conductor heartbeat installed by `conductor setup` inherit only `HOME`+`PATH` (no locale), so every TAB-delimited status probe collapses to one field → empty session cache → `Session.Exists()` false → `StatusError` on every live session → the `idle`/`waiting` gate fails on both the wake-nudge and the heartbeat → an idle conductor is never woken when a child finishes. An attached client negotiates UTF-8, so an interactive `$TMUX` session masks the bug.

**Repro**

```sh
tmux -L x new-session -d -s s
env -i PATH="$PATH" LANG=C           tmux -L x list-windows -F 'a	b' | cat -A   # => a_b   (mangled)
env -i PATH="$PATH" LANG=en_US.UTF-8 tmux -L x list-windows -F 'a	b' | cat -A   # => a^Ib  (preserved)
```

## Fix

Replace the TAB field delimiter with a printable ASCII delimiter (`tmuxFieldSep = "|"`) shared by every producer (`tmuxFmt`) and parser, so it survives the sanitization regardless of locale, `$TMUX`, or client.

### 1. `fix(status):` printable delimiter on the subprocess status probes

`RefreshSessionCache` (list-windows), `RefreshPaneInfoCache` (list-panes), and both `list-clients` probes now emit `tmuxFmt(...)` and split on `tmuxFieldSep`. Free-text fields (`window_name`, `pane_title`, `client_name`) are placed **last** and parsed with `SplitN`, so an embedded `|` is preserved; the other fields are sanitized session names (`[A-Za-z0-9-]`), integers, or a 0/1 flag and cannot collide.

**Before:** headless daemon reads every session as `error`. **After:** correct status independent of locale/`$TMUX`.

### 2. `fix(status):` same delimiter on the control-mode pipe path

The pipe producers (`RefreshAllActivities`, `RefreshAllPaneInfo`) share the same parsers as the subprocess path, so they're converted too and `pane_title` moved last (routed through the shared `parseListPanesOutput`). This keeps the two paths from drifting and removes a latent field-shift if a title ever contained the delimiter.

**Before:** pipe producer (TAB) drifted from the now-`|` shared parser → empty result → subprocess fallback every TUI tick. **After:** pipe path resolves directly; no drift.

*Intentionally unchanged:* `display-message` probes in `session_cmd.go` (interactive, require a current client → always UTF-8); `list-sessions -F "#{session_name}:#{pane_current_path}"` (already a printable `:` delimiter, session-name-first/path-last); `killStaleControlClients` (space-delimited integer fields). All noted for completeness.

## Tests added

`internal/tmux/no_client_field_sep_test.go`:

- `TestNoClientMangling_RootCause` — reproduces TAB→`_` against a real tmux server under a C locale and asserts the legacy format resolves nothing (the bug).
- `TestNoClientFieldSep_FixResolvesSession` / `_PaneInfoResolves` — the fix resolves the session/pane under that locale.
- `TestDaemonPath_ExistsResolvesUnderCLocale` — full daemon chain `RefreshSessionCache → cache → Session.Exists()` under a forced C locale.
- `TestPipePath_FieldSepResolvesSessionAndPane` — control-mode pipe path through both refreshers (non-vacuous: reverting a producer to TAB fails it).
- `TestParseList{Windows,Panes}Output_FieldSepIn…` — delimiter-collision safety on the free-text trailing field.

## Verification

`gofmt` clean, `golangci-lint` 0 issues, `go vet` clean, `go build ./...` clean, `go test ./internal/tmux/` passes. The pre-existing env-sensitive failures (issue1349 `GetJSONLPathChecked`, issue1400 output collision, issue1421 SSH socket path) are present on clean `main` — not regressions.

## Interaction with recent main

- `#1469` (`8f674dac`, keep live control pipes only for active sessions): touches pipe lifecycle, not format strings — independent; this PR is built on top of it.
- `#1457` Honest Status v2 (`1f9606eb`): adds `Substate` to `instance.go`; this PR touches only the tmux `-F` format/parse layer, a different region — no conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regression in tmux command output parsing affecting session, window, and pane resolution.
  * Improved field delimiter handling in list-windows and list-panes output parsing to prevent data corruption.

* **Tests**
  * Added comprehensive regression tests for tmux output parsing under various daemon and client environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->