### PR TITLE
fix(notify): initialize daemon logging and bound the session-id lifecycle log

### DIFF
--- a/cmd/agent-deck/notify_daemon_cmd.go
+++ b/cmd/agent-deck/notify_daemon_cmd.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/asheshgoplani/agent-deck/internal/logging"
 	"github.com/asheshgoplani/agent-deck/internal/session"
 )
 
@@ -32,6 +33,24 @@ func handleNotifyDaemon(args []string) {
 	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
 		os.Exit(1)
 	}
+
+	// handleNotifyDaemon is dispatched from main()'s early command switch and
+	// returns before main() runs logging.Init, so without this the daemon's
+	// globalLogger stays nil and every commsLog record — including
+	// wake_nudge_send_failed / wake_nudge_dispatch_failed — goes to io.Discard.
+	// That blind spot is exactly why the 2026-06-18 wake regression could not be
+	// diagnosed from the logs. See initDaemonLogging.
+	defer initDaemonLogging()()
+
+	// One unconditional startup line so an operator can confirm the daemon is
+	// alive AND that its logging pipeline works (the absence of which hid the
+	// 2026-06-18 regression). Subsequent comms records share this CompNotif
+	// stream in ~/.cache/agent-deck/debug.log.
+	logging.ForComponent(logging.CompNotif).Info("notify_daemon_started",
+		"once", *once,
+		"version", Version,
+		"debug", os.Getenv("AGENTDECK_DEBUG") != "",
+	)
 
 	daemon := session.NewTransitionDaemon()
 	if *once {
@@ -58,6 +77,59 @@ func handleNotifyDaemon(args []string) {
 		fmt.Fprintf(os.Stderr, "notify-daemon error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// initDaemonLogging wires up structured file logging for the always-on daemon
+// and returns a shutdown func for the caller to defer. Unlike the TUI/CLI, the
+// daemon has no terminal to corrupt, so it always logs to the XDG cache
+// debug.log at info level (bumped to debug under AGENTDECK_DEBUG) — capturing
+// the Warn-level comms failures that previously vanished into io.Discard.
+// lumberjack rotation (size/backup/age) bounds growth. On cache-dir failure it
+// degrades to a no-op so the daemon still runs.
+func initDaemonLogging() func() {
+	cacheDir, err := ensureEffectiveCacheDir()
+	if err != nil {
+		return func() {}
+	}
+	level := "info"
+	if os.Getenv("AGENTDECK_DEBUG") != "" {
+		level = "debug"
+	}
+	logCfg := logging.Config{
+		Debug:                 true, // daemon has no TUI to interfere with; always write
+		LogDir:                cacheDir,
+		Level:                 level,
+		Format:                "json",
+		MaxSizeMB:             10,
+		MaxBackups:            5,
+		MaxAgeDays:            10,
+		Compress:              true,
+		RingBufferSize:        10 * 1024 * 1024,
+		AggregateIntervalSecs: 30,
+	}
+	// Honor the same user-config log overrides main() applies, so an operator
+	// who tuned rotation/format in config.toml gets it for the daemon too.
+	if userCfg, err := session.LoadUserConfig(); err == nil {
+		ls := userCfg.Logs
+		if os.Getenv("AGENTDECK_DEBUG") != "" && ls.DebugLevel != "" {
+			logCfg.Level = ls.DebugLevel
+		}
+		if ls.DebugFormat != "" {
+			logCfg.Format = ls.DebugFormat
+		}
+		if ls.DebugMaxMB > 0 {
+			logCfg.MaxSizeMB = ls.DebugMaxMB
+		}
+		if ls.DebugBackups > 0 {
+			logCfg.MaxBackups = ls.DebugBackups
+		}
+		if ls.DebugRetentionDays > 0 {
+			logCfg.MaxAgeDays = ls.DebugRetentionDays
+		}
+		logCfg.Compress = ls.GetDebugCompress()
+	}
+	logging.Init(logCfg)
+	return logging.Shutdown
 }
 
 // watchBinaryVersion periodically compares the running binary's compiled-in

--- a/internal/session/session_id_event_log.go
+++ b/internal/session/session_id_event_log.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // SessionIDLifecycleEvent captures every session-ID bind/rebind/reject decision.
@@ -24,7 +26,15 @@ type SessionIDLifecycleEvent struct {
 	Timestamp  int64  `json:"ts"`
 }
 
-var sessionIDLifecycleLogMu sync.Mutex
+var (
+	sessionIDLifecycleLogMu sync.Mutex
+	// sessionIDLifecycleWriter is a lazily-initialised rotating writer. Before
+	// this, WriteSessionIDLifecycleEvent was a raw O_APPEND with no cap and had
+	// grown to ~22MB / 92K lines on the live mac-studio. lumberjack bounds it the
+	// same way debug.log is bounded (size + backups + age). Guarded by
+	// sessionIDLifecycleLogMu.
+	sessionIDLifecycleWriter *lumberjack.Logger
+)
 
 // GetSessionIDLifecycleLogPath returns ~/.agent-deck/logs/session-id-lifecycle.jsonl.
 func GetSessionIDLifecycleLogPath() string {
@@ -55,13 +65,23 @@ func WriteSessionIDLifecycleEvent(event SessionIDLifecycleEvent) error {
 	sessionIDLifecycleLogMu.Lock()
 	defer sessionIDLifecycleLogMu.Unlock()
 
-	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("open lifecycle log: %w", err)
+	// Lazily bind the rotating writer to the resolved path. lumberjack creates
+	// the file and rotates it in place (5MB × 3 backups, 30-day retention) so
+	// this postmortem log can never grow unbounded again.
+	if sessionIDLifecycleWriter == nil || sessionIDLifecycleWriter.Filename != logPath {
+		if sessionIDLifecycleWriter != nil {
+			_ = sessionIDLifecycleWriter.Close()
+		}
+		sessionIDLifecycleWriter = &lumberjack.Logger{
+			Filename:   logPath,
+			MaxSize:    5, // MB
+			MaxBackups: 3,
+			MaxAge:     30, // days
+			Compress:   true,
+		}
 	}
-	defer f.Close()
 
-	if _, err := f.Write(line); err != nil {
+	if _, err := sessionIDLifecycleWriter.Write(line); err != nil {
 		return fmt.Errorf("write lifecycle event: %w", err)
 	}
 	return nil

--- a/internal/session/session_id_event_log_test.go
+++ b/internal/session/session_id_event_log_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -55,5 +56,67 @@ func TestWriteSessionIDLifecycleEvent_AppendsJSONL(t *testing.T) {
 	}
 	if gotFirst.Timestamp == 0 || gotSecond.Timestamp == 0 {
 		t.Fatal("timestamps should be auto-populated")
+	}
+}
+
+// TestWriteSessionIDLifecycleEvent_RotatesUnderCap verifies the log can no
+// longer grow unbounded: before this fix it was a raw O_APPEND that reached
+// ~22MB / 92K lines on the live host. With the lumberjack writer (5MB cap), once
+// total writes exceed the cap the active file rotates, so the active file stays
+// well under the total bytes written and at least one backup appears.
+func TestWriteSessionIDLifecycleEvent_RotatesUnderCap(t *testing.T) {
+	// Reset the lazily-bound global writer so this test's HOME path takes effect.
+	sessionIDLifecycleLogMu.Lock()
+	if sessionIDLifecycleWriter != nil {
+		_ = sessionIDLifecycleWriter.Close()
+		sessionIDLifecycleWriter = nil
+	}
+	sessionIDLifecycleLogMu.Unlock()
+
+	t.Setenv("HOME", t.TempDir())
+
+	// ~1KB per event so we cross the 5MB cap in a few thousand cheap writes.
+	pad := strings.Repeat("x", 1024)
+	const totalBytesTarget = 7 * 1024 * 1024 // 7MB > 5MB cap, forces ≥1 rotation
+	written := 0
+	for written < totalBytesTarget {
+		ev := SessionIDLifecycleEvent{
+			InstanceID: "inst-rotate",
+			Tool:       "claude",
+			Action:     "bind",
+			Source:     "tmux_env",
+			NewID:      "session",
+			Reason:     pad,
+		}
+		if err := WriteSessionIDLifecycleEvent(ev); err != nil {
+			t.Fatalf("write event: %v", err)
+		}
+		written += len(pad) + 128
+	}
+
+	logPath := GetSessionIDLifecycleLogPath()
+	fi, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("stat active log: %v", err)
+	}
+	const cap = 5 * 1024 * 1024
+	// Active file must be bounded near the cap, not the full ~7MB written.
+	if fi.Size() > cap+512*1024 {
+		t.Fatalf("active log %d bytes exceeds cap+slack; rotation did not bound it", fi.Size())
+	}
+	// At least one rotated backup must exist alongside the active file.
+	entries, err := os.ReadDir(filepath.Dir(logPath))
+	if err != nil {
+		t.Fatalf("read log dir: %v", err)
+	}
+	base := filepath.Base(logPath)
+	backups := 0
+	for _, e := range entries {
+		if e.Name() != base && strings.HasPrefix(e.Name(), "session-id-lifecycle") {
+			backups++
+		}
+	}
+	if backups == 0 {
+		t.Fatalf("expected ≥1 rotated backup in %s; got none (entries=%v)", filepath.Dir(logPath), entries)
 	}
 }


### PR DESCRIPTION
Fixes #1497.

## Changes

### 1. `fix(notify):` initialize structured logging in the notify-daemon

`handleNotifyDaemon` is dispatched from `main()`'s early command switch and returns before `main()` calls `logging.Init`, so the daemon ran with a nil `globalLogger` and every `commsLog` record (incl. `wake_nudge_send_failed`) went to `io.Discard`. Initialize logging at the top of `handleNotifyDaemon` — always at info (debug under `AGENTDECK_DEBUG`; the daemon has no TUI to corrupt) — with one `notify_daemon_started` heartbeat line. lumberjack rotation bounds growth.

**Before:** daemon logs are silently discarded. **After:** `~/.cache/agent-deck/debug.log` carries the daemon's comms records.

### 2. `fix(session):` bound the session-id lifecycle log with rotation

`WriteSessionIDLifecycleEvent` was a raw uncapped `O_APPEND` (observed ~22 MB / 90k+ lines). Route it through a lumberjack writer (5 MB × 3 backups, 30 d, compressed), like the debug log. Safe to truncate the existing file (only tests read it).

**Before:** unbounded growth. **After:** capped + rotated.

## Tests added

- `session_id_event_log_test.go`: `TestWriteSessionIDLifecycleEvent_RotatesUnderCap` (writes past the cap, asserts the active file is bounded and ≥1 rotated backup exists). Existing append test still passes through the rotating writer.

## Verification

`gofmt` clean, `golangci-lint` 0 issues, `go vet` clean, `go build ./...` clean, daemon logging confirmed end-to-end (`notify-daemon --once` writes `notify_daemon_started` at info).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Structured logging now initializes earlier for the notify daemon, with debug mode support via environment flag.
  * Session logs now rotate automatically to manage disk space and prevent unbounded growth.

* **Tests**
  * Added test to verify session log rotation stays within configured limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->