### PR TITLE
feat(sandbox): per-instance-scoped hook status bridge (closes #1499)

### DIFF
--- a/internal/docker/config.go
+++ b/internal/docker/config.go
@@ -244,6 +244,51 @@ func WithGitConfig(path string) ContainerConfigOption {
 	}
 }
 
+// WithHooksDir mounts a PER-INSTANCE host hooks directory at the container's
+// default agent-deck hooks path (read-write). hostDir must be the scoped
+// per-instance subdir (…/hooks/sandbox/<instanceID>), NOT the global fleet-wide
+// hooks dir.
+//
+// The in-container `agent-deck hook-handler` resolves its hooks dir under $HOME,
+// which sits on the read-only sandbox rootfs — without this bridge its status
+// writes fail silently and the host watcher/notifier stays blind to sandboxed
+// sessions.
+//
+// Security rests on THREE independent properties, not just the mount scope:
+//   - Scope-bound WRITE (here): only this instance's own subdir is mounted, so a
+//     compromised container can read/write files ONLY inside …/hooks/sandbox/
+//     <instanceID>/. The global fleet-wide hooks dir — holding every sibling
+//     session's and the conductor's <id>.json — is NEVER mounted, so siblings'
+//     status, IDs, summaries and transcript paths are unreadable.
+//   - Scope-bound ATTRIBUTION (host StatusFileWatcher): a container can still
+//     NAME a file inside its own subdir after a victim (…/sandbox/<self>/
+//     <victim>.json). The host watcher therefore keys a scoped file by its
+//     OWNING SUBDIR and ingests only <subdir>.json, ignoring any foreign-named
+//     file — so a container cannot forge a sibling's terminal transition or
+//     inject a done_summary into the conductor by mis-naming a file it writes.
+//   - No-follow + size-bounded READ (host StatusFileWatcher / transition daemon):
+//     because the subdir is container-writable, a container could make its own
+//     <id>.json a SYMLINK (its legit name, so attribution passes) pointing at a
+//     sibling/host file or /dev/zero, or write a huge real <id>.json. All host
+//     reads use O_NOFOLLOW + a size cap (and Lstat the scoped path), so a
+//     symlinked status file is neither followed (no host-file disclosure) nor a
+//     DoS vector, and a giant file cannot OOM the shared notify-daemon.
+//
+// Read-write is safe under this scoping: the only status file the container can
+// both write AND have attributed back to it is its own <instanceID>.json, and
+// even that is read no-follow and size-bounded.
+func WithHooksDir(hostDir string) ContainerConfigOption {
+	return func(cfg *ContainerConfig) {
+		if hostDir == "" {
+			return
+		}
+		cfg.volumes = append(cfg.volumes, VolumeMount{
+			hostPath:      hostDir,
+			containerPath: cfg.containerHome + "/.local/share/agent-deck/hooks",
+		})
+	}
+}
+
 // WithSSH mounts the host ~/.ssh directory read-only inside the container.
 func WithSSH(path string) ContainerConfigOption {
 	return func(cfg *ContainerConfig) {

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -268,6 +268,49 @@ func TestNewContainerConfig_SSH(t *testing.T) {
 	require.True(t, cfg.volumes[1].readOnly)
 }
 
+func TestNewContainerConfig_HooksDir(t *testing.T) {
+	t.Parallel()
+
+	// hostDir is the PER-INSTANCE scoped subdir, not the global hooks dir.
+	perInstance := "/home/user/.local/share/agent-deck/hooks/sandbox/inst-123"
+	cfg := NewContainerConfig("/project",
+		WithHooksDir(perInstance),
+	)
+
+	// Project mount + hooks mount.
+	require.Len(t, cfg.volumes, 2)
+	require.Equal(t, perInstance, cfg.volumes[1].hostPath)
+	require.Equal(t, containerHome+"/.local/share/agent-deck/hooks", cfg.volumes[1].containerPath)
+	// Must be read-write: the container writes its own status file. RW is safe
+	// because the mount is scoped to this instance's own subdir.
+	require.False(t, cfg.volumes[1].readOnly)
+
+	// SECURITY: the global fleet-wide hooks dir (…/hooks) and its sandbox parent
+	// (…/hooks/sandbox) must NEVER be mounted — only the per-instance subdir.
+	// Mounting the global dir would expose every sibling session's and the
+	// conductor's status file to a compromised container. perInstance is
+	// …/hooks/sandbox/<id>; its grandparent is the global hooks dir.
+	sandboxParent := filepath.Dir(perInstance)    // …/hooks/sandbox
+	globalHooksDir := filepath.Dir(sandboxParent) // …/hooks
+	for _, v := range cfg.volumes {
+		require.NotEqual(t, globalHooksDir, v.hostPath,
+			"global hooks dir must never be a container mount source")
+		require.NotEqual(t, sandboxParent, v.hostPath,
+			"the sandbox parent dir must never be a container mount source")
+	}
+}
+
+func TestNewContainerConfig_HooksDir_Empty(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewContainerConfig("/project",
+		WithHooksDir(""),
+	)
+
+	// Only the project mount when the per-instance dir is empty (no-op).
+	require.Len(t, cfg.volumes, 1)
+}
+
 func TestNewContainerConfig_VolumeIgnores(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/hook_scoped_test.go
+++ b/internal/session/hook_scoped_test.go
@@ -1,0 +1,343 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeHookStatusAt writes a minimal hook status file at an explicit path
+// (scoped or flat), creating parent dirs as needed.
+func writeHookStatusAt(t *testing.T, path, status, sessionID string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	data := fmt.Sprintf(`{"status":%q,"session_id":%q,"event":"Stop","ts":%d}`,
+		status, sessionID, time.Now().Unix())
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o644))
+}
+
+// TestReadHookStatusFile_ResolvesScopedPath verifies that a sandboxed session's
+// status file in the per-instance scoped subdir (…/hooks/sandbox/<id>/<id>.json)
+// is resolved by readHookStatusFile.
+func TestReadHookStatusFile_ResolvesScopedPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	instanceID := "scoped-inst-1"
+	scopedPath := filepath.Join(GetHooksDir(), "sandbox", instanceID, instanceID+".json")
+	writeHookStatusAt(t, scopedPath, "waiting", "scoped-sess")
+
+	hs := readHookStatusFile(instanceID)
+	require.NotNil(t, hs, "scoped status file should be resolved")
+	assert.Equal(t, "waiting", hs.Status)
+	assert.Equal(t, "scoped-sess", hs.SessionID)
+}
+
+// TestReadHookStatusFile_FallsBackToFlat verifies that a non-sandbox session's
+// flat status file (…/hooks/<id>.json) is still resolved when no scoped subdir
+// exists — preserving existing behavior.
+func TestReadHookStatusFile_FallsBackToFlat(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	instanceID := "flat-inst-1"
+	flatPath := filepath.Join(GetHooksDir(), instanceID+".json")
+	writeHookStatusAt(t, flatPath, "running", "flat-sess")
+
+	hs := readHookStatusFile(instanceID)
+	require.NotNil(t, hs, "flat status file should be resolved when no scoped dir exists")
+	assert.Equal(t, "running", hs.Status)
+	assert.Equal(t, "flat-sess", hs.SessionID)
+}
+
+// TestReadHookStatusFile_PrefersScopedOverFlat verifies that when both a scoped
+// and a flat file exist for the same instance, the scoped (container-bridged)
+// file wins.
+func TestReadHookStatusFile_PrefersScopedOverFlat(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	instanceID := "both-inst-1"
+	writeHookStatusAt(t, filepath.Join(GetHooksDir(), instanceID+".json"), "running", "flat-sess")
+	writeHookStatusAt(t, filepath.Join(GetHooksDir(), "sandbox", instanceID, instanceID+".json"), "waiting", "scoped-sess")
+
+	hs := readHookStatusFile(instanceID)
+	require.NotNil(t, hs)
+	assert.Equal(t, "waiting", hs.Status, "scoped path should take precedence over flat")
+	assert.Equal(t, "scoped-sess", hs.SessionID)
+}
+
+// newTestWatcher constructs a StatusFileWatcher wired to a real fsnotify watcher
+// rooted at the given hooksDir, suitable for live Start() tests.
+func newTestWatcher(t *testing.T, hooksDir string) *StatusFileWatcher {
+	t.Helper()
+	fsw, err := fsnotify.NewWatcher()
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	return &StatusFileWatcher{
+		hooksDir:   hooksDir,
+		sandboxDir: filepath.Join(hooksDir, "sandbox"),
+		watcher:    fsw,
+		statuses:   make(map[string]*HookStatus),
+		ctx:        ctx,
+		cancel:     cancel,
+	}
+}
+
+// TestStatusFileWatcher_ObservesScopedWrite verifies that a live write into a
+// per-instance scoped subdir that exists at startup is picked up by the watcher.
+func TestStatusFileWatcher_ObservesScopedWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	hooksDir := filepath.Join(tmpDir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+	instanceID := "scoped-live-1"
+	scopedDir := filepath.Join(hooksDir, "sandbox", instanceID)
+	// Subdir exists before Start → exercises addExistingScopedWatches.
+	require.NoError(t, os.MkdirAll(scopedDir, 0o700))
+
+	w := newTestWatcher(t, hooksDir)
+	go w.Start()
+	defer w.Stop()
+
+	// The status file is written AFTER the watcher is running → exercises the
+	// live fsnotify path on the scoped subdir.
+	writeHookStatusAt(t, filepath.Join(scopedDir, instanceID+".json"), "waiting", "live-sess")
+
+	require.Eventually(t, func() bool {
+		return w.GetHookStatus(instanceID) != nil
+	}, 3*time.Second, 20*time.Millisecond, "watcher should observe scoped status write")
+	assert.Equal(t, "waiting", w.GetHookStatus(instanceID).Status)
+}
+
+// TestStatusFileWatcher_ObservesNewScopedSubdir verifies that a per-instance
+// scoped subdir created AFTER the watcher starts is dynamically watched and its
+// status write observed — exercising the live Create-event handler that adds a
+// watch on the new subdir and the loadDir backstop.
+//
+// The status file is written EXACTLY ONCE. An earlier version re-wrote it on
+// every require.Eventually poll (25ms); because that interval is shorter than
+// the watcher's 100ms event-debounce, each rewrite reset the debounce timer so
+// it never fired, starving the live processFile path and leaving the assertion
+// to race the one-shot loadDir in the create handler (~20-25% flake on macOS
+// kqueue). A single write lets the debounce settle deterministically, and the
+// loadDir-on-create backstop covers the write-before-watch ordering. The
+// require.Eventually window is widened to suit kqueue create-event + debounce
+// latency. (The transition daemon does not depend on this live watch at all —
+// it reads the file directly via the poll/disk path — so this is the only path
+// that needs the watcher to be live.)
+func TestStatusFileWatcher_ObservesNewScopedSubdir(t *testing.T) {
+	tmpDir := t.TempDir()
+	hooksDir := filepath.Join(tmpDir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+	w := newTestWatcher(t, hooksDir)
+	go w.Start()
+	defer w.Stop()
+
+	instanceID := "scoped-dyn-1"
+	scopedDir := filepath.Join(hooksDir, "sandbox", instanceID)
+	// Subdir is created AFTER Start → exercises the dynamic create-event handler
+	// (watcher.Add on the new subdir + loadDir), distinct from the pre-created
+	// sibling test TestStatusFileWatcher_ObservesScopedWrite.
+	require.NoError(t, os.MkdirAll(scopedDir, 0o700))
+	scopedFile := filepath.Join(scopedDir, instanceID+".json")
+	writeHookStatusAt(t, scopedFile, "idle", "dyn-sess")
+
+	require.Eventually(t, func() bool {
+		return w.GetHookStatus(instanceID) != nil
+	}, 10*time.Second, 50*time.Millisecond, "watcher should observe a write in a newly-created scoped subdir")
+	assert.Equal(t, "idle", w.GetHookStatus(instanceID).Status)
+}
+
+// writeForgedHookStatusAt writes a status file carrying a forged terminal
+// transition and an injected done_summary, at an explicit path.
+func writeForgedHookStatusAt(t *testing.T, path, status, doneStatus, doneSummary string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	// Future timestamp so a forged entry would look fresher than any legitimate
+	// one and win the freshness/recency checks downstream.
+	data := fmt.Sprintf(
+		`{"status":%q,"session_id":"forged","event":"Stop","ts":%d,"done_status":%q,"done_summary":%q}`,
+		status, time.Now().Add(time.Hour).Unix(), doneStatus, doneSummary)
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o644))
+}
+
+// TestStatusFileWatcher_RejectsForeignNamedScopedFile is the PoC for the
+// forge-sibling / inject-into-conductor vectors. A compromised container can
+// write ANYWHERE inside its OWN per-instance subdir (…/hooks/sandbox/<id>/) and
+// can name the file anything — including after a victim. The watcher must bind
+// the instance ID to the OWNING SUBDIR, accept only <subdir>.json, and ignore
+// any foreign-named file. This test fails on the pre-fix (filename-keyed) code,
+// where statuses["victim-bbbb-222"] would be populated from the attacker's file.
+func TestStatusFileWatcher_RejectsForeignNamedScopedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	hooksDir := filepath.Join(tmpDir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+	const (
+		attackerID = "attacker-aaaa-111"
+		victimID   = "victim-bbbb-222"
+	)
+	attackerDir := filepath.Join(hooksDir, "sandbox", attackerID)
+
+	// (1) The attacker's own legitimate status file — allowed.
+	writeHookStatusAt(t, filepath.Join(attackerDir, attackerID+".json"), "running", "attacker-sess")
+	// (2) A forged file NAMED AFTER THE VICTIM, planted inside the attacker's
+	//     own writable subdir. This is the exploit payload.
+	writeForgedHookStatusAt(t, filepath.Join(attackerDir, victimID+".json"), "dead", "fail", "INJECTED")
+
+	w := newTestWatcher(t, hooksDir)
+
+	// Exercise the startup load path (loadExisting → loadScopedDirs → loadDir →
+	// processFile).
+	w.loadExisting()
+	assert.Nil(t, w.GetHookStatus(victimID),
+		"forged file named after a victim, inside the attacker's own subdir, must NOT be attributed to the victim (loadExisting)")
+	require.NotNil(t, w.GetHookStatus(attackerID), "attacker's own status file should be ingested")
+	assert.Equal(t, "running", w.GetHookStatus(attackerID).Status,
+		"attacker's status must come ONLY from its own <id>.json, not the forged sibling file")
+
+	// Exercise the overflow-recovery path (scanDisk → scanDirEntriesInto), which
+	// rebuilds the whole map from disk.
+	rebuilt := w.scanDisk()
+	assert.Nil(t, rebuilt[victimID],
+		"forged file must NOT appear in the scanDisk-rebuilt map (overflow recovery path)")
+	require.NotNil(t, rebuilt[attackerID], "attacker's own status should appear in the rebuilt map")
+	assert.Equal(t, "running", rebuilt[attackerID].Status)
+}
+
+// TestStatusFileWatcher_RejectsSymlinkedScopedFile is the PoC for the
+// symlink-follow exfiltration/DoS vector. The per-instance subdir is
+// container-writable, so a compromised container can make its OWN <id>.json a
+// SYMLINK (its legit, attribution-passing name) pointing at a sibling/host file
+// or /dev/zero. The host read path uses O_NOFOLLOW, so the symlink is refused
+// rather than followed — the target's contents are never disclosed and the
+// daemon never reads through to a device file. This test fails on the pre-fix
+// (os.ReadFile, which follows symlinks) code, where statuses["<id>"] would be
+// populated from the symlink target.
+func TestStatusFileWatcher_RejectsSymlinkedScopedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	hooksDir := filepath.Join(tmpDir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+	const attackerID = "attacker-sym-111"
+	attackerDir := filepath.Join(hooksDir, "sandbox", attackerID)
+	require.NoError(t, os.MkdirAll(attackerDir, 0o700))
+
+	// A "secret" host/sibling file the container should never be able to read
+	// through. It carries a valid, fresh status so a successful follow WOULD be
+	// ingested (proving the no-follow guard is what blocks it).
+	secret := filepath.Join(tmpDir, "secret-host-file.json")
+	require.NoError(t, os.WriteFile(secret,
+		[]byte(`{"status":"dead","session_id":"leaked","event":"Stop","ts":9999999999}`), 0o644))
+
+	// The container symlinks its OWN legit-named <id>.json at the secret file.
+	link := filepath.Join(attackerDir, attackerID+".json")
+	require.NoError(t, os.Symlink(secret, link))
+
+	w := newTestWatcher(t, hooksDir)
+
+	// Startup load path (loadExisting → loadScopedDirs → loadDir → processFile).
+	w.loadExisting()
+	assert.Nil(t, w.GetHookStatus(attackerID),
+		"a symlinked <id>.json must NOT be followed (no host-file disclosure) on loadExisting")
+
+	// Overflow-recovery path (scanDisk → scanDirEntriesInto).
+	rebuilt := w.scanDisk()
+	assert.Nil(t, rebuilt[attackerID],
+		"a symlinked <id>.json must NOT be followed in the scanDisk-rebuilt map")
+
+	// Direct: the no-follow reader itself refuses the symlink.
+	_, err := readStatusFileNoFollow(link)
+	require.Error(t, err, "readStatusFileNoFollow must error on a symlinked final component (O_NOFOLLOW)")
+}
+
+// TestStatusFileWatcher_RejectsOversizedScopedFile asserts the size bound: a
+// huge real <id>.json (the OOM-the-notify-daemon DoS) is read bounded, not
+// whole, and a status that only parses beyond the bound is therefore not
+// ingested. Deterministic: the JSON's done_summary string is padded past the
+// bound, so truncation cuts it mid-string and the parse fails.
+func TestStatusFileWatcher_RejectsOversizedScopedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	hooksDir := filepath.Join(tmpDir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+	const instanceID = "oversized-222"
+	scopedDir := filepath.Join(hooksDir, "sandbox", instanceID)
+	require.NoError(t, os.MkdirAll(scopedDir, 0o700))
+
+	// Valid JSON whose trailing string value runs well past maxHookStatusFileSize,
+	// so a bounded read truncates mid-string → unterminated → unparseable.
+	pad := strings.Repeat("A", maxHookStatusFileSize*2)
+	huge := fmt.Sprintf(`{"status":"running","session_id":"s","event":"Stop","ts":1,"done_summary":%q}`, pad)
+	scopedFile := filepath.Join(scopedDir, instanceID+".json")
+	require.NoError(t, os.WriteFile(scopedFile, []byte(huge), 0o644))
+	require.Greater(t, len(huge), maxHookStatusFileSize, "test fixture must exceed the bound")
+
+	// The bounded reader returns at most maxHookStatusFileSize bytes, never the
+	// whole file.
+	data, err := readStatusFileNoFollow(scopedFile)
+	require.NoError(t, err)
+	assert.Len(t, data, maxHookStatusFileSize,
+		"read must be capped at the bound, not read whole")
+	assert.Less(t, len(data), len(huge), "bounded read must be shorter than the oversized file")
+
+	// End to end: the truncated (now-invalid) JSON is not ingested.
+	w := newTestWatcher(t, hooksDir)
+	w.loadExisting()
+	assert.Nil(t, w.GetHookStatus(instanceID),
+		"an oversized status file whose payload only completes past the bound must not be ingested")
+}
+
+// TestHookStatusFilePath_IgnoresSymlinkedScopedPath asserts the read-side
+// resolver does not PREFER (nor follow) a symlinked scoped path: hookStatusFilePath
+// Lstats the scoped path, so a symlink there is skipped in favour of the flat
+// path, and readStatusFileNoFollow would refuse to follow it anyway.
+func TestHookStatusFilePath_IgnoresSymlinkedScopedPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const instanceID = "sym-resolve-1"
+	// Legitimate flat status for this id.
+	flatPath := filepath.Join(GetHooksDir(), instanceID+".json")
+	writeHookStatusAt(t, flatPath, "running", "flat-sess")
+
+	// A secret file the container would like disclosed via a scoped symlink.
+	secret := filepath.Join(t.TempDir(), "secret.json")
+	writeHookStatusAt(t, secret, "waiting", "leaked-sess")
+
+	scopedDir := filepath.Join(GetHooksDir(), "sandbox", instanceID)
+	require.NoError(t, os.MkdirAll(scopedDir, 0o700))
+	require.NoError(t, os.Symlink(secret, filepath.Join(scopedDir, instanceID+".json")))
+
+	// Scoped path is a symlink → not preferred; flat path wins and the symlink
+	// target ("waiting"/"leaked-sess") is never read.
+	assert.Equal(t, flatPath, hookStatusFilePath(instanceID),
+		"a symlinked scoped path must not be preferred over the flat path")
+	hs := readHookStatusFile(instanceID)
+	require.NotNil(t, hs)
+	assert.Equal(t, "running", hs.Status, "must read the flat file, not the symlink target")
+	assert.NotEqual(t, "leaked-sess", hs.SessionID, "symlink target must not be disclosed")
+}
+
+// TestStatusFileWatcher_FlatDirStillFilenameKeyed verifies the non-sandbox flat
+// top-level dir keeps its existing filename-keying so ordinary (non-sandbox)
+// sessions are unaffected by the scope-binding fix.
+func TestStatusFileWatcher_FlatDirStillFilenameKeyed(t *testing.T) {
+	tmpDir := t.TempDir()
+	hooksDir := filepath.Join(tmpDir, "hooks")
+	require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+	writeHookStatusAt(t, filepath.Join(hooksDir, "flat-inst-9.json"), "waiting", "flat-sess")
+
+	w := newTestWatcher(t, hooksDir)
+	w.loadExisting()
+
+	require.NotNil(t, w.GetHookStatus("flat-inst-9"), "flat top-level status file should be ingested by filename")
+	assert.Equal(t, "waiting", w.GetHookStatus("flat-inst-9").Status)
+}

--- a/internal/session/hook_watcher.go
+++ b/internal/session/hook_watcher.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -17,6 +19,21 @@ import (
 )
 
 var hookLog = logging.ForComponent(logging.CompSession)
+
+const maxHookStatusFileSize = 64 << 10 // status files are a few hundred bytes
+
+// readStatusFileNoFollow reads a hook status file without following a
+// final-component symlink (O_NOFOLLOW) and bounded in size, so a compromised
+// sandbox cannot symlink <id>.json at a sibling/host/device file to exfiltrate
+// or DoS the shared notify-daemon, nor OOM it with a huge real <id>.json.
+func readStatusFileNoFollow(path string) ([]byte, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(io.LimitReader(f, maxHookStatusFileSize))
+}
 
 // HookStatus holds the decoded status from a hook status file.
 type HookStatus struct {
@@ -38,7 +55,13 @@ type HookStatus struct {
 // and updates instance hook status in real time.
 type StatusFileWatcher struct {
 	hooksDir string
-	watcher  *fsnotify.Watcher
+	// sandboxDir is hooksDir/sandbox — the parent of the per-instance scoped
+	// subdirs that sandboxed sessions bridge from their containers. Each
+	// sandbox session writes …/hooks/sandbox/<id>/<id>.json; the watcher
+	// observes these by watching this dir for subdir-create events and adding
+	// a watch on each per-instance subdir.
+	sandboxDir string
+	watcher    *fsnotify.Watcher
 
 	mu       sync.RWMutex
 	statuses map[string]*HookStatus // instance_id -> latest hook status
@@ -68,12 +91,13 @@ func NewStatusFileWatcher(onChange func()) (*StatusFileWatcher, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return &StatusFileWatcher{
-		hooksDir: hooksDir,
-		watcher:  watcher,
-		statuses: make(map[string]*HookStatus),
-		ctx:      ctx,
-		cancel:   cancel,
-		onChange: onChange,
+		hooksDir:   hooksDir,
+		sandboxDir: filepath.Join(hooksDir, "sandbox"),
+		watcher:    watcher,
+		statuses:   make(map[string]*HookStatus),
+		ctx:        ctx,
+		cancel:     cancel,
+		onChange:   onChange,
 	}, nil
 }
 
@@ -84,7 +108,20 @@ func (w *StatusFileWatcher) Start() {
 		return
 	}
 
-	// Load any existing status files on startup
+	// Also watch the per-instance sandbox subtree so sandboxed sessions' scoped
+	// status writes are observed live. We watch the parent (sandboxDir) for
+	// subdir-create events and add a watch on each per-instance subdir (fsnotify
+	// is non-recursive, so each dir must be registered explicitly). A failure
+	// here is non-fatal: flat-dir (non-sandbox) sessions keep working.
+	if err := os.MkdirAll(w.sandboxDir, 0o700); err != nil {
+		hookLog.Warn("hook_watcher_sandbox_mkdir_failed", slog.String("dir", w.sandboxDir), slog.String("error", err.Error()))
+	} else if err := w.watcher.Add(w.sandboxDir); err != nil {
+		hookLog.Warn("hook_watcher_add_failed", slog.String("dir", w.sandboxDir), slog.String("error", err.Error()))
+	} else {
+		w.addExistingScopedWatches()
+	}
+
+	// Load any existing status files on startup (flat + scoped)
 	w.loadExisting()
 
 	// Debounce timer: coalesce rapid file events
@@ -100,6 +137,21 @@ func (w *StatusFileWatcher) Start() {
 		case event, ok := <-w.watcher.Events:
 			if !ok {
 				return
+			}
+
+			// A new per-instance sandbox subdir appeared — register a watch on
+			// it so its status-file writes are observed (fsnotify only reports
+			// events for explicitly-added dirs). Then scan it once in case the
+			// status file was written before the watch was added.
+			if event.Op&fsnotify.Create != 0 && filepath.Dir(event.Name) == w.sandboxDir {
+				if info, statErr := os.Stat(event.Name); statErr == nil && info.IsDir() {
+					if addErr := w.watcher.Add(event.Name); addErr != nil {
+						hookLog.Warn("hook_watcher_add_scoped_failed", slog.String("dir", event.Name), slog.String("error", addErr.Error()))
+					} else {
+						w.loadDir(event.Name)
+					}
+					continue
+				}
 			}
 
 			// Only process .json file writes/creates
@@ -178,20 +230,90 @@ func (w *StatusFileWatcher) handleOverflow(err error) {
 // mid-write or corrupt; the next event will retry).
 func (w *StatusFileWatcher) scanDisk() map[string]*HookStatus {
 	out := make(map[string]*HookStatus)
-	entries, err := os.ReadDir(w.hooksDir)
-	if err != nil {
+	// Flat top-level files (non-sandbox sessions). A read error here is logged
+	// because the flat dir is expected to exist.
+	if entries, err := os.ReadDir(w.hooksDir); err != nil {
 		hookLog.Warn("hook_watcher_scan_read_dir_failed",
 			slog.String("dir", w.hooksDir),
 			slog.String("error", err.Error()),
 		)
-		return out
+	} else {
+		w.scanDirEntriesInto(out, w.hooksDir, entries)
 	}
+	// Per-instance scoped subdirs (sandbox sessions). Missing/absent is benign.
+	if subdirs, err := os.ReadDir(w.sandboxDir); err == nil {
+		for _, sub := range subdirs {
+			if !sub.IsDir() {
+				continue
+			}
+			dir := filepath.Join(w.sandboxDir, sub.Name())
+			if entries, rerr := os.ReadDir(dir); rerr == nil {
+				w.scanDirEntriesInto(out, dir, entries)
+			}
+		}
+	}
+	return out
+}
+
+// instanceIDForStatusFile derives the instance ID that OWNS the status file at
+// filePath, binding identity to the file's LOCATION — not just its name:
+//
+//   - Flat top-level file …/hooks/<id>.json (non-sandbox sessions): keyed by
+//     filename, as before.
+//   - Per-instance scoped file …/hooks/sandbox/<id>/<id>.json (sandbox
+//     sessions): keyed by the OWNING SUBDIR name, and accepted ONLY when the
+//     basename equals "<subdir>.json".
+//
+// A sandboxed container can write anywhere inside its OWN …/hooks/sandbox/<id>/
+// subdir, but it controls the filename — including naming a file after a victim
+// session. Keying purely by filename (the pre-fix behaviour) let such a file
+// land at statuses["<victim>"], forging the victim's terminal transition and
+// injecting an attacker-chosen done_summary into the conductor's turn. Binding
+// the ID to the owning subdir and rejecting any non-matching basename closes
+// the forge-sibling and inject-into-conductor vectors. ok=false means the file
+// is foreign (or sits in an unrecognized location) and must NOT be stored.
+func (w *StatusFileWatcher) instanceIDForStatusFile(filePath string) (string, bool) {
+	if filepath.Ext(filePath) != ".json" {
+		return "", false
+	}
+	dir := filepath.Dir(filePath)
+	base := filepath.Base(filePath)
+	// Per-instance scoped subdir: …/hooks/sandbox/<id>/…  (parent-of-dir is the
+	// sandbox root, so dir itself is the per-instance subdir named <id>).
+	if w.sandboxDir != "" && filepath.Dir(dir) == w.sandboxDir {
+		owner := filepath.Base(dir)
+		if base != owner+".json" {
+			return "", false // foreign-named file inside someone else's subdir
+		}
+		return owner, true
+	}
+	// Flat top-level file: …/hooks/<id>.json (non-sandbox sessions).
+	if dir == w.hooksDir {
+		return strings.TrimSuffix(base, ".json"), true
+	}
+	// A file directly under …/hooks/sandbox/ (not in a per-instance subdir), or
+	// any deeper/unexpected location, is not an authoritative status file.
+	return "", false
+}
+
+// scanDirEntriesInto parses every .json status file in dir and writes the
+// decoded HookStatus into out keyed by its scope-bound instance ID. Files whose
+// name does not match their owning sandbox subdir are foreign and skipped.
+func (w *StatusFileWatcher) scanDirEntriesInto(out map[string]*HookStatus, dir string, entries []os.DirEntry) {
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
 			continue
 		}
-		path := filepath.Join(w.hooksDir, entry.Name())
-		data, rerr := os.ReadFile(path)
+		path := filepath.Join(dir, entry.Name())
+		instanceID, ok := w.instanceIDForStatusFile(path)
+		if !ok {
+			continue // foreign-named file in a scoped subdir, or unexpected path
+		}
+		// No-follow + size-bounded: a compromised sandbox could symlink its
+		// <id>.json at a sibling/host/device file, or write a huge real file, to
+		// exfiltrate or DoS the daemon. O_NOFOLLOW errors out on a symlink; the
+		// bound caps the read.
+		data, rerr := readStatusFileNoFollow(path)
 		if rerr != nil {
 			continue
 		}
@@ -207,7 +329,6 @@ func (w *StatusFileWatcher) scanDisk() map[string]*HookStatus {
 		if uerr := json.Unmarshal(data, &raw); uerr != nil {
 			continue
 		}
-		instanceID := strings.TrimSuffix(entry.Name(), ".json")
 		out[instanceID] = &HookStatus{
 			Status:         raw.Status,
 			SessionID:      raw.SessionID,
@@ -218,7 +339,6 @@ func (w *StatusFileWatcher) scanDisk() map[string]*HookStatus {
 			TranscriptPath: raw.TranscriptPath,
 		}
 	}
-	return out
 }
 
 func errString(err error) string {
@@ -248,18 +368,58 @@ func (w *StatusFileWatcher) ClearHookStatus(instanceID string) {
 	delete(w.statuses, instanceID)
 }
 
-// loadExisting reads all current status files on startup.
+// loadExisting reads all current status files on startup — both the flat
+// top-level files (non-sandbox sessions) and the per-instance scoped subdir
+// files (sandbox sessions under …/hooks/sandbox/<id>/).
 func (w *StatusFileWatcher) loadExisting() {
-	entries, err := os.ReadDir(w.hooksDir)
+	w.loadDir(w.hooksDir)
+	w.loadScopedDirs()
+}
+
+// loadDir processes every .json status file directly inside dir (non-recursive).
+func (w *StatusFileWatcher) loadDir(dir string) {
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return
 	}
-
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
 			continue
 		}
-		w.processFile(filepath.Join(w.hooksDir, entry.Name()))
+		w.processFile(filepath.Join(dir, entry.Name()))
+	}
+}
+
+// loadScopedDirs processes the status file inside each per-instance sandbox
+// subdir under sandboxDir.
+func (w *StatusFileWatcher) loadScopedDirs() {
+	entries, err := os.ReadDir(w.sandboxDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		w.loadDir(filepath.Join(w.sandboxDir, entry.Name()))
+	}
+}
+
+// addExistingScopedWatches registers an fsnotify watch on each per-instance
+// sandbox subdir that already exists when the watcher starts.
+func (w *StatusFileWatcher) addExistingScopedWatches() {
+	entries, err := os.ReadDir(w.sandboxDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := filepath.Join(w.sandboxDir, entry.Name())
+		if err := w.watcher.Add(dir); err != nil {
+			hookLog.Warn("hook_watcher_add_scoped_failed", slog.String("dir", dir), slog.String("error", err.Error()))
+		}
 	}
 }
 
@@ -268,10 +428,25 @@ func (w *StatusFileWatcher) loadExisting() {
 // fail-open silently; success-path logs at INFO with file path so a hook
 // audit can be done without opening SQLite.
 func (w *StatusFileWatcher) processFile(filePath string) {
-	data, err := os.ReadFile(filePath)
+	// Bind identity to the file's LOCATION before reading it. A scoped sandbox
+	// file is authoritative ONLY for the instance that owns its subdir; a
+	// foreign-named file planted inside another instance's writable subdir is
+	// rejected here so a compromised container cannot forge a sibling's status
+	// (or inject a done_summary into the conductor via a victim-named file).
+	instanceID, ok := w.instanceIDForStatusFile(filePath)
+	if !ok {
+		hookLog.Warn("hook_file_foreign_scope_rejected", slog.String("path", filePath))
+		return
+	}
+
+	// No-follow + size-bounded read (see readStatusFileNoFollow): O_NOFOLLOW
+	// makes a symlinked <id>.json error out here rather than disclose the
+	// symlink target, and the bound caps a huge real file so a compromised
+	// sandbox cannot OOM the shared notify-daemon.
+	data, err := readStatusFileNoFollow(filePath)
 	if err != nil {
 		// Not-exist is benign (file was deleted between event and read).
-		// Anything else is real corruption.
+		// Anything else (incl. ELOOP on a symlinked path) is real corruption.
 		if !os.IsNotExist(err) {
 			hookLog.Warn("hook_file_corrupt",
 				slog.String("path", filePath),
@@ -300,10 +475,6 @@ func (w *StatusFileWatcher) processFile(filePath string) {
 		)
 		return
 	}
-
-	// Extract instance ID from filename (remove .json extension)
-	base := filepath.Base(filePath)
-	instanceID := strings.TrimSuffix(base, ".json")
 
 	hookStatus := &HookStatus{
 		Status:         status.Status,

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -4441,9 +4441,23 @@ func (i *Instance) ClearHookStatus() {
 	i.hookLastUpdate = time.Time{}
 	i.mu.Unlock()
 
-	if err := os.Remove(filepath.Join(GetHooksDir(), i.ID+".json")); err != nil && !os.IsNotExist(err) {
+	// Remove the persisted status file. Sandbox sessions bridge a PER-INSTANCE
+	// scoped subdir (…/hooks/sandbox/<id>/<id>.json) from the container, and the
+	// watcher attributes that file to this instance by its OWNING SUBDIR, so the
+	// scoped file is the one to clear. Non-sandbox sessions write the flat
+	// …/hooks/<id>.json. We remove only the FILE here (not the subdir): this can
+	// fire mid-session (attach-return / unacknowledge) while the container still
+	// has the subdir bind-mounted, and unlinking the mount source would orphan
+	// the live bridge. The subdir + its fsnotify watch are torn down at session
+	// end (see killInternal).
+	hookPath := filepath.Join(GetHooksDir(), i.ID+".json")
+	if i.IsSandboxed() {
+		hookPath = filepath.Join(GetHooksDir(), "sandbox", i.ID, i.ID+".json")
+	}
+	if err := os.Remove(hookPath); err != nil && !os.IsNotExist(err) {
 		sessionLog.Debug("clear_hook_status_file_failed",
 			slog.String("instance", i.ID),
+			slog.String("path", hookPath),
 			slog.String("error", err.Error()),
 		)
 	}
@@ -5842,6 +5856,26 @@ func (i *Instance) killInternal(sync bool) error {
 	if i.IsSandboxed() {
 		if homeDir, err := os.UserHomeDir(); err == nil {
 			docker.CleanupKeychainCredentials(homeDir)
+		}
+
+		// Tear down the per-instance scoped hook bridge dir (…/hooks/sandbox/<id>).
+		// Each ended sandbox session otherwise leaks a directory AND (on Linux) an
+		// fsnotify inotify watch held by the notify-daemon's StatusFileWatcher →
+		// watch exhaustion on long-lived hosts. Removing the dir on disk also makes
+		// the kernel auto-drop that watch (IN_IGNORED). Skip when the container is
+		// intentionally kept (auto-cleanup off): it still has the dir bind-mounted.
+		// Follow-up: an explicit watcher.Remove() from here would require threading
+		// the daemon's StatusFileWatcher into the session-end lifecycle (it is not
+		// reachable from this layer), so we rely on the on-delete auto-drop.
+		if i.ID != "" && GetDockerSettings().GetAutoCleanup() {
+			scopedDir := filepath.Join(GetHooksDir(), "sandbox", i.ID)
+			if err := os.RemoveAll(scopedDir); err != nil {
+				sessionLog.Debug("sandbox_hook_dir_cleanup_failed",
+					slog.String("instance", i.ID),
+					slog.String("dir", scopedDir),
+					slog.String("error", err.Error()),
+				)
+			}
 		}
 	}
 
@@ -8352,6 +8386,30 @@ func buildSandboxConfig(
 		docker.WithCPULimit(cpuLimit),
 		docker.WithMemoryLimit(memLimit),
 		docker.WithAgentConfigs(bindMounts, homeMounts),
+	}
+
+	// Bridge in-container hook-handler status writes to a PER-INSTANCE host dir.
+	// The container's own hooks path sits on the read-only rootfs, so without
+	// this mount Stop/transition events from sandboxed sessions are lost. The
+	// dir is scoped to this instance (…/hooks/sandbox/<id>) rather than the
+	// global fleet-wide hooks dir. Three properties keep this safe: (1) only this
+	// instance's subdir is mounted, so a compromised container can read/write
+	// files ONLY inside its own subdir — it can never see siblings' or the
+	// conductor's status; (2) the host StatusFileWatcher keys a scoped file
+	// by its OWNING SUBDIR and ingests only <id>.json, so a container cannot
+	// forge a sibling's transition (or inject a done_summary into the conductor)
+	// by naming a file after a victim inside its own subdir; and (3) every host
+	// read of a status file is no-follow (O_NOFOLLOW, plus Lstat on the scoped
+	// path) and size-bounded, so the container cannot symlink its own <id>.json
+	// at a sibling/host file or /dev/zero, nor write a huge <id>.json, to read
+	// host files or DoS the shared notify-daemon. The host read path
+	// (readHookStatusFile / hookStatusFilePath) also builds the path from the
+	// requested <id>, so it cannot be cross-attributed either.
+	if hooksDir := GetHooksDir(); hooksDir != "" {
+		perInstanceDir := filepath.Join(hooksDir, "sandbox", inst.ID)
+		if mkErr := os.MkdirAll(perInstanceDir, 0o700); mkErr == nil {
+			configOpts = append(configOpts, docker.WithHooksDir(perInstanceDir))
+		}
 	}
 
 	// Note: Docker.Environment names (e.g. TERM) are NOT forwarded at create time.

--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -8409,6 +8409,14 @@ func buildSandboxConfig(
 		perInstanceDir := filepath.Join(hooksDir, "sandbox", inst.ID)
 		if mkErr := os.MkdirAll(perInstanceDir, 0o700); mkErr == nil {
 			configOpts = append(configOpts, docker.WithHooksDir(perInstanceDir))
+		} else {
+			// Don't fail the spawn, but surface it: without the scoped hooks dir
+			// the bridge mount is silently skipped, leaving the host watcher blind
+			// to this sandboxed session — the exact problem this bridge solves.
+			sessionLog.Warn("scoped_hooks_dir_create_failed",
+				slog.String("instance_id", inst.ID),
+				slog.String("dir", perInstanceDir),
+				slog.String("error", mkErr.Error()))
 		}
 	}
 

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -695,11 +695,35 @@ func (d *TransitionDaemon) hookStatusForInstance(instanceID string) *HookStatus 
 	return best
 }
 
+// hookStatusFilePath resolves the on-disk status file for an instance.
+// Sandboxed sessions bridge a PER-INSTANCE scoped subdir from the container, so
+// their status lands at …/hooks/sandbox/<id>/<id>.json; non-sandbox sessions
+// write the flat …/hooks/<id>.json. Prefer the scoped path when it exists, else
+// fall back to flat. Robust to a missing sandbox subtree (Lstat just errors and
+// we fall through to flat).
+//
+// We Lstat (not Stat) the scoped path so a container-planted SYMLINK at
+// <id>.json is NOT preferred: Lstat reports the link itself, and the subsequent
+// no-follow read (readStatusFileNoFollow) refuses to follow it. A symlinked
+// scoped path therefore neither gets selected over the flat path nor gets read
+// through, closing the exfiltration/DoS vector at the read site too.
+func hookStatusFilePath(instanceID string) string {
+	hooksDir := GetHooksDir()
+	scoped := filepath.Join(hooksDir, "sandbox", instanceID, instanceID+".json")
+	if info, err := os.Lstat(scoped); err == nil && info.Mode()&os.ModeSymlink == 0 {
+		return scoped
+	}
+	return filepath.Join(hooksDir, instanceID+".json")
+}
+
 func readHookStatusFile(instanceID string) *HookStatus {
 	if strings.TrimSpace(instanceID) == "" {
 		return nil
 	}
-	data, err := os.ReadFile(filepath.Join(GetHooksDir(), instanceID+".json"))
+	// No-follow + size-bounded read for both the scoped (sandbox) and flat
+	// (non-sandbox) paths: a container could symlink or oversize its <id>.json
+	// to read a host file or OOM the shared notify-daemon that polls this.
+	data, err := readStatusFileNoFollow(hookStatusFilePath(instanceID))
 	if err != nil || len(data) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Problem
Sandboxed (Docker) sessions resolve the in-container `agent-deck hook-handler` status path under `$HOME`, which sits on the **read-only** sandbox rootfs. Status writes fail silently, so the host `StatusFileWatcher` / transition notifier is blind to sandboxed sessions — Stop/transition events and done-summaries never reach the conductor.

## Fix
Bridge each sandboxed session's in-container hooks dir to a **per-instance** host subdir, `…/hooks/sandbox/<id>/`, bind-mounted RW at the container's hooks path (`WithHooksDir`). The host watcher and transition daemon read the scoped path, preferring it over the flat `…/hooks/<id>.json` and falling back to flat for non-sandbox sessions.

## Security rationale (the untrusted container is the threat boundary)
The sandbox is a hardened containment boundary (`--cap-drop=ALL`, `--read-only`, …). Three enforced properties:

1. **Scope-bound write** — only the instance's own subdir is mounted; the global fleet-wide hooks dir (every sibling's + the conductor's status) is never mounted. A container can read/write only inside its own `…/sandbox/<id>/`.
2. **Scope-bound attribution** — a container controls filenames inside its subdir, so the watcher keys a scoped file by its **owning subdir** (not its filename) and ingests only `<subdir>.json`, ignoring foreign-named files. A container cannot forge a sibling's transition or inject a `done_summary` into the conductor. Every map-populating path routes through this check. Regression test: `TestStatusFileWatcher_RejectsForeignNamedScopedFile`.
3. **Symlink-safe, bounded reads** — since the subdir is container-writable, a container could symlink `<id>.json` at a sibling/host/device file (`os.ReadFile` follows symlinks and is unbounded → host-file disclosure + a crash-loop DoS of the shared notify-daemon, e.g. via `/dev/zero` or a huge real file). Scoped/flat reads now use `O_NOFOLLOW` + a 64 KiB bound (`readStatusFileNoFollow`), and `Lstat` ensures a symlinked scoped path isn't preferred.

## Cleanup
`killInternal` removes the scoped subdir on session end (gated on auto-cleanup; the container is force-removed first, so the bind mount is gone before the unlink) — the kernel auto-drops the watch, preventing dir/inotify leaks. `ClearHookStatus` clears only the scoped file mid-session, never orphaning the live mount.

## Validation
`go build ./...`, `go vet`, `gofmt`, and the docker tests are clean; the session package shows only its known pre-existing local-env failures (zsh-rc / JSONL-path / SSH-socket). New tests cover scoped resolution, flat fallback, scoped-over-flat precedence, live + dynamic-subdir observation, and the negatives (foreign-named forge, symlink-follow, oversize bound).

## Scope
Bridges hook-status *visibility* to the host watcher/conductor. Durable-inbox delivery of those transitions downstream is out of scope for this PR.

closes #1499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hook status cleanup and sandbox hook bridging for sandboxed sessions to prevent stale artifacts
  * Enhanced security for hook status file handling with symlink rejection and size limits
  * Fixed per-instance hook directory mounting to prevent cross-instance interference

* **Tests**
  * Added comprehensive tests for hook status file resolution and sandbox subdirectory behavior
  * Added security validation tests for hook status file handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->