### PR TITLE
fix: preserve case in normalizeGroupPath; add ambiguous-delete guard

### DIFF
--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -642,14 +643,35 @@ func handleGroupDelete(profile string, args []string) {
 	groupPath := normalizeGroupPath(name)
 	group, exists := groupTree.Groups[groupPath]
 	if !exists {
-		// Try finding by name match
+		// Direct lookup missed: collect all case-insensitive name matches.
+		// Using a collect-all approach prevents silently deleting a random
+		// duplicate when the same leaf name exists under multiple parents.
+		type match struct {
+			path  string
+			group *session.Group
+		}
+		var matches []match
 		for path, g := range groupTree.Groups {
 			if strings.EqualFold(g.Name, name) {
-				groupPath = path
-				group = g
-				exists = true
-				break
+				matches = append(matches, match{path: path, group: g})
 			}
+		}
+		switch len(matches) {
+		case 0:
+			// not found — handled below
+		case 1:
+			groupPath = matches[0].path
+			group = matches[0].group
+			exists = true
+		default:
+			// Ambiguous: multiple groups share this leaf name.
+			paths := make([]string, len(matches))
+			for i, m := range matches {
+				paths[i] = m.path
+			}
+			sort.Strings(paths)
+			out.Error(fmt.Sprintf("group '%s' is ambiguous: %s - use the full path", name, strings.Join(paths, ", ")), ErrCodeInvalidOperation)
+			os.Exit(2)
 		}
 	}
 
@@ -1061,14 +1083,12 @@ func getParentGroupPath(path string) string {
 	return "" // root level
 }
 
-// normalizeGroupPath converts a group name/path to its normalized path form
+// normalizeGroupPath converts a group name/path to its normalized path form.
+// It replaces spaces with hyphens but preserves case, because GroupTree.Groups
+// is keyed by the raw stored path (case-preserving). Lowercasing here would make
+// any group whose path contains uppercase letters unreachable by direct lookup.
 func normalizeGroupPath(name string) string {
-	// Already looks like a path
-	if strings.Contains(name, "/") {
-		return strings.ToLower(strings.ReplaceAll(name, " ", "-"))
-	}
-	// Simple name
-	return strings.ToLower(strings.ReplaceAll(name, " ", "-"))
+	return strings.ReplaceAll(name, " ", "-")
 }
 
 // truncateGroupName shortens a group name for display

--- a/cmd/agent-deck/group_cmd_test.go
+++ b/cmd/agent-deck/group_cmd_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/asheshgoplani/agent-deck/internal/session"
@@ -138,4 +139,75 @@ func TestGroupReorderPositionClamp(t *testing.T) {
 	if paths[0] != "Beta" || paths[1] != "Gamma" || paths[2] != "Alpha" {
 		t.Errorf("expected [Beta Gamma Alpha], got %v", paths)
 	}
+}
+
+// TestNormalizeGroupPathCasePreserving verifies that normalizeGroupPath does not
+// lowercase its argument. GroupTree.Groups is keyed by the raw stored path, so
+// lowercasing here would make any group with uppercase letters unreachable.
+func TestNormalizeGroupPathCasePreserving(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"work", "work"},
+		{"Work", "Work"},
+		{"My Projects", "My-Projects"},
+		{"work/Frontend", "work/Frontend"},
+	}
+	for _, tc := range cases {
+		got := normalizeGroupPath(tc.input)
+		if got != tc.want {
+			t.Errorf("normalizeGroupPath(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestNormalizeGroupPathMatchesStoredKey verifies that after creating an uppercase
+// group via GroupTree.CreateGroup, the result of normalizeGroupPath on the same
+// name is a key that exists in GroupTree.Groups (regression guard for issue #1488).
+func TestNormalizeGroupPathMatchesStoredKey(t *testing.T) {
+	tree := session.NewGroupTreeWithGroups([]*session.Instance{}, nil)
+	tree.CreateGroup("Parent")
+
+	normalized := normalizeGroupPath("Parent")
+	if _, exists := tree.Groups[normalized]; !exists {
+		t.Errorf("normalizeGroupPath(%q) = %q, but Groups[%q] does not exist; stored keys: %v",
+			"Parent", normalized, normalized, groupKeys(tree))
+	}
+}
+
+// TestGroupDeleteAmbiguousNameError verifies that deleting by a bare leaf name
+// that matches multiple groups returns an error rather than silently deleting one.
+func TestGroupDeleteAmbiguousNameError(t *testing.T) {
+	tree := session.NewGroupTreeWithGroups([]*session.Instance{}, nil)
+	// Create pa, pb, then dup under each
+	tree.CreateGroup("pa")
+	tree.CreateGroup("pb")
+	tree.CreateSubgroup("pa", "dup")
+	tree.CreateSubgroup("pb", "dup")
+
+	// Simulate the ambiguous-lookup logic from handleGroupDelete.
+	name := "dup"
+	type match struct {
+		path  string
+		group *session.Group
+	}
+	var matches []match
+	for path, g := range tree.Groups {
+		if strings.EqualFold(g.Name, name) {
+			matches = append(matches, match{path: path, group: g})
+		}
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 ambiguous matches for %q, got %d: %v", name, len(matches), matches)
+	}
+}
+
+// groupKeys is a test helper that returns the keys of GroupTree.Groups.
+func groupKeys(tree *session.GroupTree) []string {
+	keys := make([]string, 0, len(tree.Groups))
+	for k := range tree.Groups {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/cmd/agent-deck/main_test.go
+++ b/cmd/agent-deck/main_test.go
@@ -252,9 +252,11 @@ func TestGroupScopeValidation(t *testing.T) {
 		input string
 		want  string
 	}{
+		// normalizeGroupPath replaces spaces with hyphens but preserves case,
+		// because GroupTree.Groups is keyed by the raw stored path.
 		{"work", "work"},
-		{"Work", "work"},
-		{"My Projects", "my-projects"},
+		{"Work", "Work"},
+		{"My Projects", "My-Projects"},
 		{"work/frontend", "work/frontend"},
 	}
 


### PR DESCRIPTION
## Summary

- Remove `strings.ToLower` from `normalizeGroupPath` so path lookups use the same case the group was stored with
- Fix the bare-name fallback in `handleGroupDelete` to collect all case-insensitive matches and error on ambiguity instead of silently deleting a random one

## Why this matters

`GroupTree.Groups` keys are the raw sanitized path produced by `CreateGroup` (spaces replaced with hyphens, case preserved). `normalizeGroupPath` was lowercasing the argument, so any group whose path contained an uppercase letter was unreachable by direct lookup.

Two concrete bugs from issue #1488:

1. `group create child --parent Parent` fails with "parent group 'Parent' not found" because the lookup key `"parent"` does not exist in the map (key is `"Parent"`).
2. `group delete dup` when `pa/dup` and `pb/dup` both exist silently deletes a non-deterministic one - Go map iteration is randomized, and the fallback broke on the first match.

Both problems share the same root: the lookup key does not match the stored key.

## Testing

- `TestNormalizeGroupPathCasePreserving` - verifies `normalizeGroupPath` no longer lowercases
- `TestNormalizeGroupPathMatchesStoredKey` - verifies a `normalizeGroupPath` result is a valid key in `GroupTree.Groups` after `CreateGroup("Parent")`
- `TestGroupDeleteAmbiguousNameError` - verifies the fallback collects both `pa/dup` and `pb/dup` as matches when deleting `"dup"`
- `TestGroupScopeValidation` in `main_test.go` updated to reflect the corrected (case-preserving) behavior

Fixes #1488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group deletion to detect name ambiguity: when multiple groups match a provided name, the system now requests the full path and shows sorted results for disambiguation
  * Group path normalization now preserves case, aligning with how group names are stored and accessed

* **Tests**
  * Added regression tests for case-preserving path normalization and ambiguous group name deletion scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->