### PR TITLE
fix(claude): group config_dir must beat ambient CLAUDE_CONFIG_DIR (wrong-account grouped child)

### DIFF
--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -143,6 +143,35 @@ func resolveGroupSelection(currentGroup, cwdDerivedGroup, parentGroup string, ex
 	return parentGroup
 }
 
+// warnGroupAccountMismatch prints a stderr warning when a session's group
+// configures a Claude config_dir but the session will resolve to a DIFFERENT
+// config_dir (wrong-account-grouped-child). This catches the case where an
+// explicit account/conductor override — or the group block not being found at
+// resolution time — diverts a grouped child off its group's account before it
+// silently burns the wrong account's quota. No-op when the group has no
+// config_dir, or when the resolved dir already matches the group's.
+func warnGroupAccountMismatch(inst *session.Instance) {
+	if inst == nil || !session.IsClaudeCompatible(inst.Tool) || inst.GroupPath == "" {
+		return
+	}
+	userConfig, _ := session.LoadUserConfig()
+	if userConfig == nil {
+		return
+	}
+	groupDir := userConfig.GetGroupClaudeConfigDir(inst.GroupPath)
+	if groupDir == "" {
+		return
+	}
+	resolved, source := session.GetClaudeConfigDirSourceForInstance(inst)
+	if resolved == groupDir {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"warning: session %q in group %q will use CLAUDE_CONFIG_DIR=%s (source: %s), "+
+			"NOT the group's configured config_dir %s — it may run on the wrong account\n",
+		inst.Title, inst.GroupPath, resolved, source, groupDir)
+}
+
 // resolveAddPath resolves the user-provided positional path arg for `agent-deck add`.
 // Handles ".", "~", "~/foo", "$VAR/foo", and relative/absolute paths uniformly.
 // session.ExpandPath runs first so a literal tilde from a non-expanding shell

--- a/cmd/agent-deck/grouped_child_warn_test.go
+++ b/cmd/agent-deck/grouped_child_warn_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// captureStderr runs fn with os.Stderr redirected to a pipe and returns what
+// was written.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			b.WriteString(sc.Text())
+			b.WriteByte('\n')
+		}
+		done <- b.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stderr = orig
+	return <-done
+}
+
+// TestWarnGroupAccountMismatch covers the launch-time warn-guard: when a
+// grouped child will resolve to a config_dir that differs from its group's
+// configured one (e.g. an explicit account override diverts it), the operator
+// is warned before the wrong account's quota is burned. The healthy case
+// (child follows its group) stays silent.
+func TestWarnGroupAccountMismatch(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("AGENTDECK_PROFILE", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Cleanup(session.ClearUserConfigCache)
+
+	agentDeckDir := filepath.Join(tmpHome, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := `
+[profiles.work.claude]
+config_dir = "~/.claude-work"
+
+[profiles.buddii.claude]
+config_dir = "~/.claude-buddii"
+
+[groups.ryan.claude]
+config_dir = "~/.claude-buddii"
+`
+	if err := os.WriteFile(filepath.Join(agentDeckDir, "config.toml"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	session.ClearUserConfigCache()
+
+	// Healthy: grouped child, no override -> resolves to group's buddii -> silent.
+	healthy := session.NewInstanceWithGroupAndTool("ok-child", filepath.Join(tmpHome, "p"), "ryan", "claude")
+	if out := captureStderr(t, func() { warnGroupAccountMismatch(healthy) }); strings.TrimSpace(out) != "" {
+		t.Errorf("expected no warning for a child that follows its group, got: %q", out)
+	}
+
+	// Mismatch: explicit account "work" diverts the ryan child off buddii -> warn.
+	mismatch := session.NewInstanceWithGroupAndTool("bad-child", filepath.Join(tmpHome, "p"), "ryan", "claude")
+	mismatch.Account = "work"
+	out := captureStderr(t, func() { warnGroupAccountMismatch(mismatch) })
+	if !strings.Contains(out, "wrong account") || !strings.Contains(out, "ryan") {
+		t.Errorf("expected wrong-account warning naming the group, got: %q", out)
+	}
+	if !strings.Contains(out, filepath.Join(tmpHome, ".claude-work")) {
+		t.Errorf("warning should report the resolved (work) dir, got: %q", out)
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -436,6 +436,14 @@ func handleLaunch(profile string, args []string) {
 		_ = newInstance.SetClaudeOptions(opts)
 	}
 
+	// Warn when the child will NOT run on the account its group configures
+	// (wrong-account-grouped-child). With the resolver fix a grouped child
+	// pins its group's config_dir, so this only fires when an explicit
+	// account/conductor override (or a missing group block) diverts it —
+	// exactly the case an operator wants flagged before burning the wrong
+	// account's quota.
+	warnGroupAccountMismatch(newInstance)
+
 	// Add to instances list (in-memory only — used for downstream
 	// group cap math and the second SaveWithGroups after PostStartSync).
 	instances = append(instances, newInstance)

--- a/internal/session/claude.go
+++ b/internal/session/claude.go
@@ -293,11 +293,20 @@ func getMCPInfoUncached(projectPath string) *MCPInfo {
 }
 
 // resolveOpts selects which priority chain resolveClaudeConfigDir walks.
-//   - inst != nil  → instance chain: conductor > group > env > profile > global > default
-//   - inst == nil  → group chain:    env > group > profile > global > default
+//   - inst != nil  → instance chain: account > conductor > group > env > profile > global > default
+//   - inst == nil  → group chain:    group > env > profile > global > default
 //
 // groupPath is consulted in both chains; for the instance chain it falls
 // back to inst.GroupPath when not set explicitly.
+//
+// Both chains rank the group's config_dir ABOVE the ambient CLAUDE_CONFIG_DIR
+// env var. A [groups."<g>".claude].config_dir block is a config.toml-scoped
+// override (more specific than a shell-wide CLAUDE_CONFIG_DIR that dev shells
+// commonly export via aliases like cdp/cdw), so it must win — otherwise a
+// grouped child launched from inside a session whose ambient CLAUDE_CONFIG_DIR
+// points at the wrong account silently lands on that account instead of its
+// group's. The instance chain already did this (#881); the group chain was
+// fixed to match (wrong-account-grouped-child).
 type resolveOpts struct {
 	inst      *Instance
 	groupPath string
@@ -355,14 +364,18 @@ func resolveClaudeConfigDir(opts resolveOpts) (path, source string) {
 			return envDir, "env"
 		}
 	} else {
-		// Group chain: env wins.
-		if envDir := envClaudeConfigDirIgnoringScratchLeak(); envDir != "" {
-			return envDir, "env"
-		}
+		// Group chain: group config_dir beats ambient env (mirrors the
+		// instance chain). A config.toml [groups."<g>".claude].config_dir is
+		// a scoped override and is more specific than a shell-wide
+		// CLAUDE_CONFIG_DIR, so it must win — see resolveOpts doc
+		// (wrong-account-grouped-child).
 		if userConfig != nil {
 			if groupDir := userConfig.GetGroupClaudeConfigDir(groupPath); groupDir != "" {
 				return groupDir, "group"
 			}
+		}
+		if envDir := envClaudeConfigDirIgnoringScratchLeak(); envDir != "" {
+			return envDir, "env"
 		}
 	}
 
@@ -421,7 +434,8 @@ func IsClaudeConfigDirExplicit() bool {
 }
 
 // GetClaudeConfigDirForGroup returns the Claude config directory, walking
-// the group chain: env > group > profile > global > default.
+// the group chain: group > env > profile > global > default. The group's
+// config_dir beats ambient CLAUDE_CONFIG_DIR (wrong-account-grouped-child).
 func GetClaudeConfigDirForGroup(groupPath string) string {
 	path, _ := resolveClaudeConfigDir(resolveOpts{groupPath: groupPath})
 	return path

--- a/internal/session/claude_resolve_test.go
+++ b/internal/session/claude_resolve_test.go
@@ -69,7 +69,12 @@ config_dir = "~/.claude-coordinator"
 		groupPath   string
 		wantSource  string
 	}{
-		{"env wins", filepath.Join(tmpHome, ".claude-env"), "team-a", "env"},
+		// Group config_dir beats ambient env on the group chain too — mirrors
+		// the instance chain (#881), so a grouped child never inherits the
+		// caller's stale ambient account (wrong-account-grouped-child).
+		{"group beats env", filepath.Join(tmpHome, ".claude-env"), "team-a", "group"},
+		// env still wins when the group has no config_dir to assert.
+		{"env wins when no group match", filepath.Join(tmpHome, ".claude-env"), "unknown", "env"},
 		{"group beats profile (no env)", "", "team-a", "group"},
 		{"profile wins when no group match", "", "unknown", "profile"},
 		{"default when no profile", "", "", "profile"}, // profile=work matches

--- a/internal/session/claude_test.go
+++ b/internal/session/claude_test.go
@@ -754,11 +754,22 @@ config_dir = "~/.claude-team-a"
 		t.Errorf("GetClaudeConfigDirForGroup('') = %s, want %s", got, want)
 	}
 
-	// CLAUDE_CONFIG_DIR env var always wins
+	// A group's config_dir beats ambient CLAUDE_CONFIG_DIR — a scoped
+	// config.toml override is more specific than a shell-wide env var, so a
+	// grouped child can't silently inherit the caller's stale ambient account
+	// (wrong-account-grouped-child). Mirrors the instance chain (#881).
 	_ = os.Setenv("CLAUDE_CONFIG_DIR", "/env-override")
+	ClearUserConfigCache()
 	got = GetClaudeConfigDirForGroup("team-a")
+	wantGroup := filepath.Join(tmpHome, ".claude-team-a")
+	if got != wantGroup {
+		t.Errorf("GetClaudeConfigDirForGroup(team-a) with env set = %s, want %s (group beats ambient)", got, wantGroup)
+	}
+
+	// CLAUDE_CONFIG_DIR still wins when the group has no config_dir to assert.
+	got = GetClaudeConfigDirForGroup("unknown")
 	if got != "/env-override" {
-		t.Errorf("GetClaudeConfigDirForGroup with env = %s, want /env-override", got)
+		t.Errorf("GetClaudeConfigDirForGroup(unknown) with env = %s, want /env-override", got)
 	}
 }
 

--- a/internal/session/grouped_child_account_test.go
+++ b/internal/session/grouped_child_account_test.go
@@ -1,0 +1,134 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression tests for the wrong-account / group-config_dir-not-applied bug:
+// a child session launched with `-g <group>` from inside a running session
+// must pin its GROUP's Claude config_dir, NOT silently inherit the caller's
+// ambient (and possibly stale) CLAUDE_CONFIG_DIR.
+//
+// Root cause: resolveClaudeConfigDir's GROUP chain ranked the ambient env var
+// ABOVE the group's config_dir ("Group chain: env wins"), so whenever a
+// child's config_dir was resolved without a fully-populated *Instance the
+// stale ambient account silently won. The fix makes group beat env in the
+// group chain too, mirroring the instance chain (#881).
+//
+// Each test pairs:
+//   - a GROUP-chain assertion (RED before the fix, GREEN after) that proves
+//     the precedence change directly, and
+//   - an INSTANCE-chain bake assertion that locks the end-to-end spawn command
+//     so the contract can never regress.
+
+func writeGroupedChildConfig(t *testing.T, tmpHome, body string) {
+	t.Helper()
+	agentDeckDir := filepath.Join(tmpHome, ".agent-deck")
+	if err := os.MkdirAll(agentDeckDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDeckDir, "config.toml"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	ClearUserConfigCache()
+}
+
+// TestGroupedChild_ConfigDirBeatsAmbient is the repro test from the bug report:
+// a group with config_dir = ~/.claude-buddii, an ambient CLAUDE_CONFIG_DIR
+// pointing at ~/.claude-work, and a `-g <group>` child. The child must bake
+// the GROUP's dir (buddii), never the ambient one (work).
+func TestGroupedChild_ConfigDirBeatsAmbient(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("AGENTDECK_PROFILE", "")
+	t.Cleanup(ClearUserConfigCache)
+
+	buddiiDir := filepath.Join(tmpHome, ".claude-buddii")
+	workDir := filepath.Join(tmpHome, ".claude-work")
+	// Stale ambient = the WRONG account (work), exactly as inherited from a
+	// conductor pane whose CLAUDE_CONFIG_DIR points elsewhere.
+	t.Setenv("CLAUDE_CONFIG_DIR", workDir)
+
+	writeGroupedChildConfig(t, tmpHome, `
+[groups.ryan.claude]
+config_dir = "~/.claude-buddii"
+`)
+
+	// GROUP-chain assertion: RED before the fix (returned work/"env"),
+	// GREEN after (group beats ambient env).
+	path, source := GetClaudeConfigDirSourceForGroup("ryan")
+	if source != "group" {
+		t.Errorf("group chain source = %q, want %q (group config_dir must beat ambient CLAUDE_CONFIG_DIR)", source, "group")
+	}
+	if path != buddiiDir {
+		t.Errorf("group chain path = %q, want %q", path, buddiiDir)
+	}
+
+	// INSTANCE-chain bake assertion: the actual spawn command for a `-g ryan`
+	// child must export CLAUDE_CONFIG_DIR=<buddii> and never the ambient work.
+	inst := NewInstanceWithGroupAndTool("ab-triggers", filepath.Join(tmpHome, "proj"), "ryan", "claude")
+	cmd := inst.buildClaudeCommand("claude")
+	if !strings.Contains(cmd, "CLAUDE_CONFIG_DIR="+buddiiDir) {
+		t.Errorf("grouped child spawn missing CLAUDE_CONFIG_DIR=%s\ngot: %s", buddiiDir, cmd)
+	}
+	if strings.Contains(cmd, "CLAUDE_CONFIG_DIR="+workDir) {
+		t.Errorf("grouped child leaked the ambient (wrong-account) CLAUDE_CONFIG_DIR=%s\ngot: %s", workDir, cmd)
+	}
+}
+
+// TestGroupedChild_SwitchAccountSpawnUsesGroup proves switch-account keeps the
+// spawn-env consistent: after a parent session is switched A->B (so the live
+// pane's ambient CLAUDE_CONFIG_DIR points at B's dir), a grouped child it
+// spawns must still resolve to the GROUP's config_dir — not the parent's
+// switched account, and not the stale ambient.
+func TestGroupedChild_SwitchAccountSpawnUsesGroup(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("AGENTDECK_PROFILE", "")
+	t.Cleanup(ClearUserConfigCache)
+
+	buddiiDir := filepath.Join(tmpHome, ".claude-buddii")
+	workDir := filepath.Join(tmpHome, ".claude-work")
+
+	writeGroupedChildConfig(t, tmpHome, `
+[profiles.work.claude]
+config_dir = "~/.claude-work"
+
+[profiles.buddii.claude]
+config_dir = "~/.claude-buddii"
+
+[groups.ryan.claude]
+config_dir = "~/.claude-buddii"
+`)
+
+	// Model the parent AFTER `switch-account <parent> work`: the live pane's
+	// ambient CLAUDE_CONFIG_DIR now points at work — stale from the child's
+	// point of view (the child's group says buddii).
+	t.Setenv("CLAUDE_CONFIG_DIR", workDir)
+
+	// The child as launched via `agent-deck launch -g ryan` from inside that
+	// parent: GroupPath set, Account empty (launch never sets Account).
+	child := NewInstanceWithGroupAndTool("ab-test-fixes", filepath.Join(tmpHome, "proj"), "ryan", "claude")
+	if child.Account != "" {
+		t.Fatalf("precondition: launched child must have empty Account, got %q", child.Account)
+	}
+
+	// GROUP-chain assertion: RED before the fix (ambient work won), GREEN after.
+	gpath, gsource := GetClaudeConfigDirSourceForGroup("ryan")
+	if gsource != "group" || gpath != buddiiDir {
+		t.Errorf("group chain = (%q,%q), want (%q,%q): child must follow its group, not the parent's switched/stale ambient account",
+			gpath, gsource, buddiiDir, "group")
+	}
+
+	// INSTANCE-chain bake assertion: the child's spawn command pins buddii.
+	cmd := child.buildClaudeCommand("claude")
+	if !strings.Contains(cmd, "CLAUDE_CONFIG_DIR="+buddiiDir) {
+		t.Errorf("post-switch grouped child missing CLAUDE_CONFIG_DIR=%s\ngot: %s", buddiiDir, cmd)
+	}
+	if strings.Contains(cmd, "CLAUDE_CONFIG_DIR="+workDir) {
+		t.Errorf("post-switch grouped child inherited stale ambient CLAUDE_CONFIG_DIR=%s\ngot: %s", workDir, cmd)
+	}
+}

--- a/internal/session/pergroupconfig_test.go
+++ b/internal/session/pergroupconfig_test.go
@@ -489,7 +489,14 @@ func TestPerGroupConfig_ClaudeConfigDirSourceLabel(t *testing.T) {
 	}
 	_ = os.Setenv("HOME", tmpHome)
 
-	t.Run("env_var_wins", func(t *testing.T) {
+	// Group config_dir beats ambient CLAUDE_CONFIG_DIR on the group chain
+	// (wrong-account-grouped-child): a [groups."g".claude].config_dir is a
+	// config.toml-scoped override and is more specific than a shell-wide
+	// CLAUDE_CONFIG_DIR. Pre-fix this returned ("/tmp/env-dir","env"); the
+	// resolver now mirrors the instance chain where group already beat env
+	// (#881), so a grouped child can never silently inherit the caller's
+	// stale ambient account.
+	t.Run("group_beats_env", func(t *testing.T) {
 		_ = os.Setenv("CLAUDE_CONFIG_DIR", "/tmp/env-dir")
 		_ = os.Setenv("AGENTDECK_PROFILE", "p")
 		writeConfig(t, `
@@ -502,6 +509,31 @@ config_dir = "~/.claude-global"
 `)
 		ClearUserConfigCache()
 		path, source := GetClaudeConfigDirSourceForGroup("g")
+		if source != "group" {
+			t.Errorf("source=%q want %q", source, "group")
+		}
+		if want := filepath.Join(tmpHome, ".claude-g"); path != want {
+			t.Errorf("path=%q want %q", path, want)
+		}
+		_ = os.Unsetenv("CLAUDE_CONFIG_DIR")
+	})
+
+	// A bare CLAUDE_CONFIG_DIR with no matching group still resolves to env
+	// (env beats profile/global) — the group level only wins when the group
+	// actually has a config_dir.
+	t.Run("env_wins_when_no_group_match", func(t *testing.T) {
+		_ = os.Setenv("CLAUDE_CONFIG_DIR", "/tmp/env-dir")
+		_ = os.Setenv("AGENTDECK_PROFILE", "p")
+		writeConfig(t, `
+[groups."g".claude]
+config_dir = "~/.claude-g"
+[profiles.p.claude]
+config_dir = "~/.claude-p"
+[claude]
+config_dir = "~/.claude-global"
+`)
+		ClearUserConfigCache()
+		path, source := GetClaudeConfigDirSourceForGroup("unmatched-group")
 		if source != "env" {
 			t.Errorf("source=%q want %q", source, "env")
 		}


### PR DESCRIPTION
Closes #1508.

## Problem

A child session launched with `-g <group>` from inside a running session
could land on the **wrong Claude account** — it ignored the group's
configured `config_dir` and inherited the calling process's ambient
`CLAUDE_CONFIG_DIR` instead.

## Root cause

`resolveClaudeConfigDir` (`internal/session/claude.go`) has two precedence
chains. The **instance chain** correctly ranks `group` above ambient `env`,
but the **group chain** did the opposite ("Group chain: env wins"):

```
instance chain: account > conductor > group > env > profile > global > default
group chain:                            env > group > profile > global > default   ← env beat group
```

A `[groups."<g>".claude].config_dir` is a `config.toml`-scoped override and is
more specific than a shell-wide `CLAUDE_CONFIG_DIR` (dev shells set the latter
via aliases). So any resolution lacking a fully-populated `*Instance` — the
group chain — let a stale ambient account silently win over the group's
configured account. This is also the mechanism by which switching a parent's
account and then spawning a grouped child could leak the parent's stale
ambient account to the child.

## Change

- `internal/session/claude.go`: reorder the group chain to
  `group > env > profile > global > default`, mirroring the instance chain so
  both agree. `env` still wins when the group has no `config_dir`.
- `cmd/agent-deck` (`launch`): warn when a grouped child resolves to a
  `config_dir` different from its group's configured one — catches a
  wrong-account spawn (e.g. an explicit account override diverting it) before
  the wrong account's quota is burned.

## Tests

- `TestGroupedChild_ConfigDirBeatsAmbient` — repro: group `config_dir` beats a
  stale ambient `CLAUDE_CONFIG_DIR` for a `-g <group>` child (group-chain
  assertion is RED before the fix, GREEN after; instance-chain bake assertion
  locks the end-to-end spawn command).
- `TestGroupedChild_SwitchAccountSpawnUsesGroup` — a child spawned after a
  parent is switched A→B still follows its group, not the parent's
  switched/stale ambient account.
- `TestWarnGroupAccountMismatch` — warn-guard fires on mismatch, silent when
  the child follows its group.
- Updated `TestClaudeConfigDirResolveParity`, `TestGetClaudeConfigDirForGroup_GroupWins`,
  and `TestPerGroupConfig_ClaudeConfigDirSourceLabel` which previously locked
  the old env-beats-group group-chain ordering.

## Verification

Sandboxed (`HOME` + all XDG → temp dir, `CLAUDE_CONFIG_DIR` unset):

- new + updated config-resolution/account tests: all PASS.
- group-chain assertions confirmed RED on the pre-fix resolver, GREEN with it.
- `go vet ./internal/session/ ./cmd/agent-deck/`: clean.
- Two unrelated failures in the package (`TestPerf_Group_CreateDelete` timing
  budget, `TestCanRestartCursor` needs a live tmux) also fail on the pristine
  tree — pre-existing/environmental, not from this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added warning alerts when a session's resolved configuration directory differs from its group's expected directory.

* **Bug Fixes**
  * Corrected configuration directory resolution priority: group-level settings now take precedence over environment variables when determining Claude configuration directories.

* **Tests**
  * Added comprehensive test coverage for grouped child account configuration and mismatch warning validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->