### PR TITLE
fix(conductor): default HeartbeatInterval to 15 for fresh conductors

### DIFF
--- a/internal/session/conductor.go
+++ b/internal/session/conductor.go
@@ -773,6 +773,8 @@ func SetupConductorWithAgent(name, profile, agent string, heartbeatEnabled bool,
 			meta.EnvFile = existing.EnvFile
 		}
 		meta.HeartbeatInterval = existing.HeartbeatInterval
+	} else if heartbeatEnabled {
+		meta.HeartbeatInterval = 15
 	}
 	if !clearOnCompact {
 		meta.ClearOnCompact = &clearOnCompact

--- a/internal/session/conductor_test.go
+++ b/internal/session/conductor_test.go
@@ -991,6 +991,42 @@ func TestSetupConductorWithAgent_Codex(t *testing.T) {
 	}
 }
 
+func TestSetupConductorWithAgent_DefaultsHeartbeatInterval(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "hb-default"
+	if err := SetupConductorWithAgent(name, "default", ConductorAgentClaude, true, true, "", "", "", "", nil, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	meta, err := LoadConductorMeta(name)
+	if err != nil {
+		t.Fatalf("failed to load meta: %v", err)
+	}
+	if meta.HeartbeatInterval != 15 {
+		t.Fatalf("HeartbeatInterval = %d, want 15 (fresh conductor with heartbeat enabled)", meta.HeartbeatInterval)
+	}
+}
+
+func TestSetupConductorWithAgent_HeartbeatDisabledKeepsZeroInterval(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "hb-off"
+	if err := SetupConductorWithAgent(name, "default", ConductorAgentClaude, false, true, "", "", "", "", nil, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	meta, err := LoadConductorMeta(name)
+	if err != nil {
+		t.Fatalf("failed to load meta: %v", err)
+	}
+	if meta.HeartbeatInterval != 0 {
+		t.Fatalf("HeartbeatInterval = %d, want 0 (heartbeat disabled)", meta.HeartbeatInterval)
+	}
+}
+
 func TestSetupConductorWithAgent_RemovesStaleInstructionsFile(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)


### PR DESCRIPTION
Fresh conductors with heartbeat enabled got HeartbeatInterval=0 in
meta.json because the value was only copied from an existing conductor
on re-runs. The heartbeat daemon worked (it reads the global config)
but meta.json was inconsistent and conductor list could misreport.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed heartbeat functionality for new session setups. The heartbeat interval now properly defaults to 15 seconds when enabled, preventing unintended disablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->