### PR TITLE
Fleet Console (MVP): inline artifact cards + highlight-to-route comments

### DIFF
--- a/cmd/agent-deck/artifact_cmd.go
+++ b/cmd/agent-deck/artifact_cmd.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/asheshgoplani/agent-deck/internal/artifact"
+)
+
+// handleArtifact dispatches `agent-deck artifact <subcommand>`. The only MVP
+// subcommand is `stamp`, which writes the provenance sidecar the Fleet Console
+// routes highlight-to-comment annotations on. See internal/artifact.
+func handleArtifact(profile string, args []string) {
+	if err := runArtifact(os.Stdout, profile, args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// runArtifact is the testable seam.
+func runArtifact(stdout io.Writer, profile string, args []string) error {
+	if len(args) == 0 {
+		fmt.Fprintln(stdout, "Usage: agent-deck artifact stamp <file.html> [flags]")
+		return fmt.Errorf("expected a subcommand (stamp)")
+	}
+	switch args[0] {
+	case "stamp":
+		return runArtifactStamp(stdout, profile, args[1:])
+	default:
+		return fmt.Errorf("unknown artifact subcommand %q", args[0])
+	}
+}
+
+// runArtifactStamp writes "<file>.meta.json" next to an artifact HTML so the
+// Fleet Console can attribute it to its owning session. Explicit flags win;
+// the artifact id and group derive from the conductor/<name>/<file>.html layout
+// when omitted, and the session falls back to AGENTDECK_INSTANCE_ID so a
+// session can stamp its own output with a flagless call.
+func runArtifactStamp(stdout io.Writer, profile string, args []string) error {
+	fs := flag.NewFlagSet("artifact stamp", flag.ContinueOnError)
+	var (
+		sessionID  = fs.String("session", "", "owning session id (defaults to $AGENTDECK_INSTANCE_ID)")
+		artifactID = fs.String("id", "", "artifact id (defaults to the filename without .html)")
+		group      = fs.String("group", "", "owning group/conductor (defaults to the parent directory name)")
+		title      = fs.String("title", "", "human title (defaults to the artifact id)")
+		profileARG = fs.String("profile", "", "owning profile (defaults to -p)")
+	)
+	fs.Usage = func() {
+		fmt.Fprintln(stdout, "Usage: agent-deck artifact stamp <file.html> [--session id] [--id id] [--group g] [--title t] [--profile p]")
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, "Writes <file>.meta.json provenance so the Fleet Console can route")
+		fmt.Fprintln(stdout, "highlight-to-comment annotations back to the owning session.")
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return fmt.Errorf("expected exactly one html file argument")
+	}
+	htmlPath := fs.Arg(0)
+	if _, err := os.Stat(htmlPath); err != nil {
+		return fmt.Errorf("artifact file not readable: %w", err)
+	}
+
+	base := strings.TrimSuffix(filepath.Base(htmlPath), ".html")
+	id := firstNonEmpty(*artifactID, base)
+	grp := firstNonEmpty(*group, filepath.Base(filepath.Dir(htmlPath)))
+	sess := firstNonEmpty(*sessionID, os.Getenv("AGENTDECK_INSTANCE_ID"))
+	prof := firstNonEmpty(*profileARG, profile)
+
+	meta := artifact.Meta{
+		ArtifactID: id,
+		SessionID:  sess,
+		Group:      grp,
+		Profile:    prof,
+		Title:      firstNonEmpty(*title, id),
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := artifact.WriteMeta(htmlPath, meta); err != nil {
+		return fmt.Errorf("write sidecar: %w", err)
+	}
+	fmt.Fprintf(stdout, "stamped %s (session=%s group=%s)\n", artifact.SidecarPath(htmlPath), meta.SessionID, meta.Group)
+	return nil
+}

--- a/cmd/agent-deck/artifact_cmd_test.go
+++ b/cmd/agent-deck/artifact_cmd_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/artifact"
+)
+
+// `agent-deck artifact stamp <html>` writes a sidecar carrying the provenance
+// the Fleet Console routes on. Explicit flags win; the artifact id and group
+// derive from the path when omitted.
+func TestRunArtifactStampWritesSidecar(t *testing.T) {
+	root := t.TempDir()
+	html := filepath.Join(root, "agent-deck", "perf.html")
+	if err := os.MkdirAll(filepath.Dir(html), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(html, []byte("<h1>perf</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	args := []string{"stamp", html,
+		"--session", "sess-123",
+		"--title", "ARD Import Perf",
+		"--profile", "personal",
+	}
+	if err := runArtifact(&out, "personal", args); err != nil {
+		t.Fatalf("runArtifact: %v", err)
+	}
+
+	meta, ok, err := artifact.ReadMeta(html)
+	if err != nil || !ok {
+		t.Fatalf("sidecar not written: ok=%v err=%v", ok, err)
+	}
+	if meta.SessionID != "sess-123" {
+		t.Fatalf("expected session sess-123, got %q", meta.SessionID)
+	}
+	if meta.Title != "ARD Import Perf" {
+		t.Fatalf("expected title, got %q", meta.Title)
+	}
+	// Derived from the path when not passed explicitly.
+	if meta.ArtifactID != "perf" {
+		t.Fatalf("expected artifact id derived from filename (perf), got %q", meta.ArtifactID)
+	}
+	if meta.Group != "agent-deck" {
+		t.Fatalf("expected group derived from conductor dir (agent-deck), got %q", meta.Group)
+	}
+	if meta.CreatedAt == "" {
+		t.Fatalf("expected a created_at timestamp")
+	}
+}
+
+func TestRunArtifactStampRequiresFile(t *testing.T) {
+	var out bytes.Buffer
+	if err := runArtifact(&out, "personal", []string{"stamp"}); err == nil {
+		t.Fatal("expected error when no html path is given")
+	}
+}

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -269,6 +269,9 @@ func main() {
 		case "session":
 			handleSession(profile, args[1:])
 			return
+		case "artifact":
+			handleArtifact(profile, args[1:])
+			return
 		case "mcp":
 			handleMCP(profile, args[1:])
 			return

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -1,0 +1,197 @@
+// Package artifact is the provenance + listing layer for the Fleet Console.
+//
+// A conductor session that writes an HTML report also drops a sidecar
+// "<file>.meta.json" next to it (via `agent-deck artifact stamp`). The sidecar
+// records WHICH session produced the artifact so a highlight-to-comment in the
+// web console can auto-route the annotation back to its owning session. Files
+// without a sidecar (the legacy corpus) still attribute to their owning
+// conductor — derivable from the "<conductor>/<file>.html" directory layout —
+// so routing is never a dead end.
+//
+// This package is deliberately free of any session/web dependency: it only
+// reads and writes JSON sidecars and globs a directory tree. That keeps the
+// provenance contract unit-testable in isolation and shared by both the CLI
+// (the producer) and the web handlers (the consumer).
+package artifact
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// metaSuffix is appended to an artifact's path to locate its sidecar.
+const metaSuffix = ".meta.json"
+
+// ErrPathEscape is returned when a requested artifact path would resolve
+// outside the conductor root (a traversal attempt).
+var ErrPathEscape = errors.New("artifact: path escapes root")
+
+// Meta is the sidecar provenance record written next to an artifact HTML.
+type Meta struct {
+	ArtifactID string `json:"artifact_id"`
+	SessionID  string `json:"session_id"`
+	Group      string `json:"group"`
+	Profile    string `json:"profile"`
+	Title      string `json:"title"`
+	CreatedAt  string `json:"created_at"`
+}
+
+// Entry is one row in the Fleet Console artifact list. Sidecar-attributed
+// fields fall back to filename/directory derivation when no sidecar exists.
+type Entry struct {
+	ArtifactID string `json:"artifactId"`
+	Title      string `json:"title"`
+	// Conductor is always known — it is the top-level directory component, so
+	// even a sidecar-less artifact routes to its owning conductor.
+	Conductor string `json:"conductor"`
+	SessionID string `json:"sessionId,omitempty"`
+	Group     string `json:"group,omitempty"`
+	Profile   string `json:"profile,omitempty"`
+	// Path is relative to the conductor root ("<conductor>/<file>.html"). It is
+	// the opaque handle the serve + comment endpoints pass back, always
+	// re-confined server-side before any filesystem access.
+	Path       string `json:"path"`
+	CreatedAt  string `json:"createdAt,omitempty"`
+	HasSidecar bool   `json:"hasSidecar"`
+}
+
+// SidecarPath returns the sidecar path for an artifact HTML path.
+func SidecarPath(htmlPath string) string {
+	return htmlPath + metaSuffix
+}
+
+// WriteMeta writes (or overwrites) the sidecar for the given artifact HTML.
+func WriteMeta(htmlPath string, m Meta) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(SidecarPath(htmlPath), data, 0o644)
+}
+
+// ReadMeta reads the sidecar for an artifact HTML. ok is false (with nil error)
+// when no sidecar exists — the common legacy case, not a failure.
+func ReadMeta(htmlPath string) (m Meta, ok bool, err error) {
+	data, err := os.ReadFile(SidecarPath(htmlPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Meta{}, false, nil
+		}
+		return Meta{}, false, err
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Meta{}, false, err
+	}
+	return m, true, nil
+}
+
+// ConfinedPath resolves a caller-supplied relative artifact path against root,
+// guaranteeing the result stays inside root. A leading "/" is treated as
+// root-relative (neutralized, not an escape); any ".." that would climb above
+// root is rejected with ErrPathEscape.
+func ConfinedPath(root, rel string) (string, error) {
+	if strings.TrimSpace(root) == "" {
+		return "", errors.New("artifact: empty root")
+	}
+	// Reject any traversal segment outright rather than silently absorbing it —
+	// "../" must be a hard error so an audit of the access log shows the attempt
+	// instead of a quietly-neutralized path. A leading "/" and "." are fine.
+	slashRel := filepath.ToSlash(rel)
+	if slices.Contains(strings.Split(slashRel, "/"), "..") {
+		return "", ErrPathEscape
+	}
+	cleaned := filepath.Clean("/" + slashRel)
+	full := filepath.Join(root, cleaned)
+
+	// Belt-and-suspenders: confirm the joined path is genuinely within root.
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	fullAbs, err := filepath.Abs(full)
+	if err != nil {
+		return "", err
+	}
+	rel2, err := filepath.Rel(rootAbs, fullAbs)
+	if err != nil {
+		return "", ErrPathEscape
+	}
+	if rel2 == ".." || strings.HasPrefix(rel2, ".."+string(os.PathSeparator)) {
+		return "", ErrPathEscape
+	}
+	return fullAbs, nil
+}
+
+// ListArtifacts globs "<root>/<conductor>/<file>.html" and returns one Entry
+// per artifact, enriched from its sidecar when present and falling back to
+// filename/directory derivation otherwise. A missing root yields no entries
+// (cold start), not an error.
+func ListArtifacts(root string) ([]Entry, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, nil
+	}
+	conductors, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var entries []Entry
+	for _, cd := range conductors {
+		if !cd.IsDir() {
+			continue
+		}
+		conductor := cd.Name()
+		files, err := os.ReadDir(filepath.Join(root, conductor))
+		if err != nil {
+			continue // unreadable conductor dir — skip rather than fail the whole list
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".html") {
+				continue
+			}
+			rel := filepath.Join(conductor, f.Name())
+			htmlPath := filepath.Join(root, rel)
+			base := strings.TrimSuffix(f.Name(), ".html")
+
+			e := Entry{
+				ArtifactID: base,
+				Title:      base,
+				Conductor:  conductor,
+				Path:       rel,
+			}
+			if meta, ok, _ := ReadMeta(htmlPath); ok {
+				e.HasSidecar = true
+				if meta.ArtifactID != "" {
+					e.ArtifactID = meta.ArtifactID
+				}
+				if meta.Title != "" {
+					e.Title = meta.Title
+				}
+				if meta.Group != "" {
+					e.Group = meta.Group
+				}
+				e.SessionID = meta.SessionID
+				e.Profile = meta.Profile
+				e.CreatedAt = meta.CreatedAt
+			}
+			entries = append(entries, e)
+		}
+	}
+
+	// Newest first when timestamps are present, else stable by path.
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].CreatedAt != entries[j].CreatedAt {
+			return entries[i].CreatedAt > entries[j].CreatedAt
+		}
+		return entries[i].Path < entries[j].Path
+	})
+	return entries, nil
+}

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -1,0 +1,182 @@
+package artifact
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFile is a tiny helper for the table tests below.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// SPEC T1: serve-one-artifact is path-confined (cannot escape the conductor
+// root; "../" rejected).
+func TestConfinedPathRejectsEscape(t *testing.T) {
+	root := t.TempDir()
+
+	escapes := []string{
+		"../etc/passwd",
+		"condA/../../etc/passwd",
+		"condA/../../../",
+		"..",
+		"foo/../../bar",
+	}
+	for _, rel := range escapes {
+		if got, err := ConfinedPath(root, rel); err == nil {
+			t.Fatalf("expected %q to be rejected as an escape, got %q", rel, got)
+		}
+	}
+}
+
+func TestConfinedPathAcceptsInRoot(t *testing.T) {
+	root := t.TempDir()
+
+	ok := map[string]string{
+		"condA/foo.html":      filepath.Join(root, "condA", "foo.html"),
+		"condA/sub/bar.html":  filepath.Join(root, "condA", "sub", "bar.html"),
+		"/condA/leading.html": filepath.Join(root, "condA", "leading.html"), // leading slash neutralized, not an escape
+		"condA/./dot.html":    filepath.Join(root, "condA", "dot.html"),
+	}
+	for rel, want := range ok {
+		got, err := ConfinedPath(root, rel)
+		if err != nil {
+			t.Fatalf("expected %q to be accepted, got error %v", rel, err)
+		}
+		if got != want {
+			t.Fatalf("ConfinedPath(%q) = %q, want %q", rel, got, want)
+		}
+		if !strings.HasPrefix(got, root) {
+			t.Fatalf("ConfinedPath(%q) = %q escaped root %q", rel, got, root)
+		}
+	}
+}
+
+func TestConfinedPathEmptyRoot(t *testing.T) {
+	if _, err := ConfinedPath("", "x.html"); err == nil {
+		t.Fatal("expected error for empty root")
+	}
+}
+
+// SPEC T2: list-artifacts returns sidecar-attributed entries + conductor-level
+// fallback for sidecar-less files.
+func TestListArtifactsSidecarAndFallback(t *testing.T) {
+	root := t.TempDir()
+
+	// Stamped artifact (sidecar present) under conductor "agent-deck".
+	writeFile(t, filepath.Join(root, "agent-deck", "perf.html"), "<h1>perf</h1>")
+	meta := Meta{
+		ArtifactID: "perf-report",
+		SessionID:  "sess-123",
+		Group:      "agent-deck",
+		Profile:    "personal",
+		Title:      "ARD Import Perf",
+		CreatedAt:  "2026-06-22T11:42:00Z",
+	}
+	if err := WriteMeta(filepath.Join(root, "agent-deck", "perf.html"), meta); err != nil {
+		t.Fatal(err)
+	}
+
+	// Legacy artifact (NO sidecar) under conductor "innotrade".
+	writeFile(t, filepath.Join(root, "innotrade", "legacy.html"), "<h1>legacy</h1>")
+
+	entries, err := ListArtifacts(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+
+	byID := map[string]Entry{}
+	for _, e := range entries {
+		byID[e.Path] = e
+	}
+
+	stamped, ok := byID[filepath.Join("agent-deck", "perf.html")]
+	if !ok {
+		t.Fatalf("stamped artifact missing from listing: %+v", entries)
+	}
+	if !stamped.HasSidecar {
+		t.Fatalf("expected stamped artifact to report HasSidecar, got %+v", stamped)
+	}
+	if stamped.SessionID != "sess-123" {
+		t.Fatalf("expected sidecar session id sess-123, got %q", stamped.SessionID)
+	}
+	if stamped.Title != "ARD Import Perf" {
+		t.Fatalf("expected sidecar title, got %q", stamped.Title)
+	}
+	if stamped.Conductor != "agent-deck" {
+		t.Fatalf("expected conductor agent-deck, got %q", stamped.Conductor)
+	}
+	if stamped.ArtifactID != "perf-report" {
+		t.Fatalf("expected sidecar artifact id, got %q", stamped.ArtifactID)
+	}
+
+	legacy, ok := byID[filepath.Join("innotrade", "legacy.html")]
+	if !ok {
+		t.Fatalf("legacy artifact missing from listing: %+v", entries)
+	}
+	if legacy.HasSidecar {
+		t.Fatalf("expected legacy artifact to report no sidecar, got %+v", legacy)
+	}
+	if legacy.SessionID != "" {
+		t.Fatalf("expected legacy artifact to have no session id, got %q", legacy.SessionID)
+	}
+	// Conductor-level fallback: the owning conductor is still derivable from the
+	// directory, so routing is never a dead end even without a sidecar.
+	if legacy.Conductor != "innotrade" {
+		t.Fatalf("expected conductor-level fallback innotrade, got %q", legacy.Conductor)
+	}
+	// Fallback id/title derive from the filename.
+	if legacy.ArtifactID != "legacy" || legacy.Title != "legacy" {
+		t.Fatalf("expected filename-derived id/title for legacy, got id=%q title=%q", legacy.ArtifactID, legacy.Title)
+	}
+}
+
+func TestListArtifactsEmptyRoot(t *testing.T) {
+	// A missing/empty root yields no entries and no error (cold start).
+	entries, err := ListArtifacts(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("expected no error for missing root, got %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+// Round-trip: WriteMeta then ReadMeta returns the same provenance.
+func TestWriteReadMetaRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	html := filepath.Join(root, "agent-deck", "doc.html")
+	writeFile(t, html, "<h1>doc</h1>")
+
+	in := Meta{ArtifactID: "doc", SessionID: "s1", Group: "agent-deck", Profile: "work", Title: "Doc", CreatedAt: "2026-06-22T00:00:00Z"}
+	if err := WriteMeta(html, in); err != nil {
+		t.Fatal(err)
+	}
+	if SidecarPath(html) != html+".meta.json" {
+		t.Fatalf("unexpected sidecar path %q", SidecarPath(html))
+	}
+	out, ok, err := ReadMeta(html)
+	if err != nil || !ok {
+		t.Fatalf("ReadMeta failed: ok=%v err=%v", ok, err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: got %+v want %+v", out, in)
+	}
+
+	// Absent sidecar reports ok=false, no error.
+	_, ok2, err2 := ReadMeta(filepath.Join(root, "agent-deck", "nope.html"))
+	if err2 != nil || ok2 {
+		t.Fatalf("expected absent sidecar (ok=false,nil err), got ok=%v err=%v", ok2, err2)
+	}
+}

--- a/internal/session/artifact_comment.go
+++ b/internal/session/artifact_comment.go
@@ -1,0 +1,80 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// artifactCommentKind marks an inbox record as a Fleet Console annotation
+// rather than a child-completion transition, so a draining consumer can tell
+// "the operator highlighted my report and left a note" apart from "a child
+// finished". It is carried in TransitionNotificationEvent.Kind.
+const artifactCommentKind = "fleet-console-annotation"
+
+// ArtifactComment is one highlight-to-route annotation from the Fleet Console:
+// a passage the operator highlighted in a rendered artifact plus their note.
+type ArtifactComment struct {
+	ArtifactID    string
+	ArtifactTitle string
+	Excerpt       string // the highlighted passage
+	Comment       string // the operator's note
+	Profile       string
+}
+
+// FormatArtifactComment renders the tagged, human-readable payload delivered to
+// the owning session. The tag + the three meaningful parts (title, excerpt,
+// comment) travel verbatim so a future skill can parse and act on it.
+func FormatArtifactComment(c ArtifactComment) string {
+	var b strings.Builder
+	b.WriteString("[fleet-console] annotation on artifact: ")
+	b.WriteString(strings.TrimSpace(c.ArtifactTitle))
+	b.WriteString("\n")
+	if ex := strings.TrimSpace(c.Excerpt); ex != "" {
+		b.WriteString("> highlighted: ")
+		b.WriteString(ex)
+		b.WriteString("\n")
+	}
+	b.WriteString("comment: ")
+	b.WriteString(strings.TrimSpace(c.Comment))
+	return b.String()
+}
+
+// DeliverArtifactComment routes an annotation to its owning session.
+//
+// When busy is true the target session is actively working (running/starting),
+// so a raw send-keys would be silently swallowed by the live pane — the comment
+// is committed to the session's DURABLE INBOX instead, where it is drained on
+// the session's next turn boundary (exactly the reliability guarantee the inbox
+// exists for). When busy is false the session is at a prompt and the comment is
+// delivered through the same reliable queued send path as `agent-deck session
+// send`.
+//
+// Each annotation gets a UNIQUE inbox child id so the inbox's last-wins-per-
+// child collapse keeps multiple comments on the same artifact distinct.
+func DeliverArtifactComment(targetSessionID string, busy bool, c ArtifactComment) error {
+	targetSessionID = strings.TrimSpace(targetSessionID)
+	if targetSessionID == "" {
+		return fmt.Errorf("artifact comment: empty target session id")
+	}
+	payload := FormatArtifactComment(c)
+
+	if busy {
+		childID := fmt.Sprintf("fleet-console:%s:%d", c.ArtifactID, time.Now().UnixNano())
+		ev := TransitionNotificationEvent{
+			ChildSessionID:  childID,
+			ChildTitle:      c.ArtifactTitle,
+			Profile:         c.Profile,
+			Kind:            artifactCommentKind,
+			DoneStatus:      "comment",
+			DoneSummary:     payload,
+			FromStatus:      "running",
+			ToStatus:        "waiting",
+			Timestamp:       time.Now(),
+			TargetSessionID: targetSessionID,
+			TargetKind:      "session",
+		}
+		return CommitToInbox(targetSessionID, ev)
+	}
+	return SendSessionMessageReliable(c.Profile, targetSessionID, payload)
+}

--- a/internal/session/artifact_comment_test.go
+++ b/internal/session/artifact_comment_test.go
@@ -1,0 +1,109 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// SPEC T5: the comment carries the tagged payload (artifact title + excerpt +
+// comment) verbatim.
+func TestFormatArtifactCommentCarriesTaggedPayload(t *testing.T) {
+	c := ArtifactComment{
+		ArtifactID:    "perf-report",
+		ArtifactTitle: "ARD Import Perf — Profiling Report",
+		Excerpt:       "one SQL round-trip per tag during resolution, producing ~14,000 queries",
+		Comment:       "Batch the tag resolution into a single IN(...) lookup and memoize per import run.",
+		Profile:       "personal",
+	}
+	got := FormatArtifactComment(c)
+
+	// The three human-meaningful parts must appear verbatim.
+	for _, want := range []string{c.ArtifactTitle, c.Excerpt, c.Comment} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted payload missing %q\n--- payload ---\n%s", want, got)
+		}
+	}
+	// Tagged so a downstream skill can recognize and act on it.
+	if !strings.Contains(got, "[fleet-console]") {
+		t.Fatalf("expected a [fleet-console] tag, got:\n%s", got)
+	}
+}
+
+// SPEC T4: POST comment to a BUSY session routes through the durable inbox (not
+// raw send-keys) — the message is retrievable via inbox drain.
+func TestDeliverArtifactCommentBusyRoutesToDurableInbox(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	const target = "sess-busy-123"
+	c := ArtifactComment{
+		ArtifactID:    "perf-report",
+		ArtifactTitle: "ARD Import Perf",
+		Excerpt:       "~14,000 queries for a 1,000-row batch",
+		Comment:       "Batch into a single IN(...) lookup.",
+		Profile:       "_test",
+	}
+
+	// busy=true MUST NOT shell out to send-keys (which a running pane would
+	// swallow); it commits to the target's durable inbox instead.
+	if err := DeliverArtifactComment(target, true, c); err != nil {
+		t.Fatalf("DeliverArtifactComment busy: %v", err)
+	}
+
+	// The comment is retrievable via the same drain a parent/conductor runs.
+	events, err := DrainInboxForParent(target)
+	if err != nil {
+		t.Fatalf("DrainInboxForParent: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 inbox event, got %d: %+v", len(events), events)
+	}
+	ev := events[0]
+	// Verbatim payload survives the round-trip.
+	for _, want := range []string{c.ArtifactTitle, c.Excerpt, c.Comment} {
+		if !strings.Contains(ev.DoneSummary, want) {
+			t.Fatalf("drained event missing %q in DoneSummary=%q", want, ev.DoneSummary)
+		}
+	}
+	if ev.TargetSessionID != target {
+		t.Fatalf("expected target %q, got %q", target, ev.TargetSessionID)
+	}
+}
+
+// Two comments on the same artifact must BOTH survive the drain — the inbox's
+// last-wins-per-child collapse must not silently eat the first annotation.
+func TestDeliverArtifactCommentBusyKeepsMultiple(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENT_DECK_HOME", "")
+	t.Setenv("AGENT_DECK_PROFILE", "")
+	ClearUserConfigCache()
+	t.Cleanup(func() { ClearUserConfigCache() })
+
+	const target = "sess-busy-multi"
+	base := ArtifactComment{ArtifactID: "doc", ArtifactTitle: "Doc", Profile: "_test"}
+
+	first := base
+	first.Excerpt, first.Comment = "passage one", "comment one"
+	second := base
+	second.Excerpt, second.Comment = "passage two", "comment two"
+
+	if err := DeliverArtifactComment(target, true, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeliverArtifactComment(target, true, second); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := DrainInboxForParent(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 distinct annotations to survive, got %d: %+v", len(events), events)
+	}
+}

--- a/internal/web/handlers_artifacts.go
+++ b/internal/web/handlers_artifacts.go
@@ -170,7 +170,12 @@ func (s *Server) handleArtifactServe(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Cache-Control", "no-store")
-	_, _ = w.Write([]byte(injectSelectionRelay(string(data), rel)))
+	// G705 (XSS taint) false positive: serving the conductor HTML artifact verbatim
+	// is the feature. The path is confined to artifactRoot (ConfinedPath above) and the
+	// artifact renders only inside an opaque-origin sandbox iframe — allow-scripts, NO
+	// allow-same-origin — so it cannot reach this origin, the parent DOM, or any
+	// credential (see the security note in the file header).
+	_, _ = w.Write([]byte(injectSelectionRelay(string(data), rel))) //nolint:gosec // G705: read-only, path-confined HTML served into an opaque-origin sandbox iframe (see header)
 }
 
 // artifactCommentRequest is the POST /api/artifacts/comment body.

--- a/internal/web/handlers_artifacts.go
+++ b/internal/web/handlers_artifacts.go
@@ -1,0 +1,290 @@
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/asheshgoplani/agent-deck/internal/artifact"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// The Fleet Console turns the conductor HTML artifacts (which used to scp to the
+// Mac and pile up as Chrome tabs) into inline, in-app cards, and lets a
+// highlight-to-comment on a card auto-route the annotation to the artifact's
+// owning session. Three endpoints, mirroring the Command Center triad:
+//   - GET  /api/artifacts          — provenance-attributed listing
+//   - GET  /api/artifacts/serve    — read-only, path-confined, relay-injected
+//   - POST /api/artifacts/comment  — resolve owner → deliver via the session layer
+//
+// Security: serving is read-only and path-confined to the conductor root; the
+// rendered artifact runs in an opaque-origin sandbox iframe (allow-scripts only,
+// NO allow-same-origin) so its scripts — including the injected selection relay
+// — cannot reach this origin, the parent DOM, or any credential. The comment
+// POST is a mutation behind the existing CSRF + auth + mutation-rate gates.
+
+// artifactCandidate is one option offered when an artifact's owner can't be
+// resolved automatically (so the operator is never left at a dead end).
+type artifactCandidate struct {
+	SessionID string `json:"sessionId"`
+	Title     string `json:"title"`
+	Status    string `json:"status"`
+	Group     string `json:"group"`
+}
+
+// artifactTarget is the resolved routing decision for an annotation.
+type artifactTarget struct {
+	Kind       string // "session" | "conductor" | "picker"
+	SessionID  string // concrete delivery target (empty for picker)
+	Label      string
+	Busy       bool
+	Candidates []artifactCandidate
+}
+
+// isBusyStatus reports whether a session is actively working, in which case a
+// raw send-keys would be swallowed by the live pane and the comment must take
+// the durable-inbox path instead.
+func isBusyStatus(st session.Status) bool {
+	return st == session.StatusRunning || st == session.StatusStarting
+}
+
+// resolveArtifactTarget implements the SPEC resolution ladder:
+// sidecar session (if live) → owning conductor → picker (never a dead end).
+func resolveArtifactTarget(meta artifact.Meta, conductor string, sessions []*MenuSession) artifactTarget {
+	byID := make(map[string]*MenuSession, len(sessions))
+	for _, s := range sessions {
+		byID[s.ID] = s
+	}
+
+	// 1) Sidecar names a session that is still live → route straight to it.
+	if meta.SessionID != "" {
+		if s := byID[meta.SessionID]; s != nil {
+			return artifactTarget{Kind: "session", SessionID: s.ID, Label: s.Title, Busy: isBusyStatus(s.Status)}
+		}
+	}
+
+	// 2) Fall back to the conductor that owns the directory.
+	condTitle := "conductor-" + conductor
+	for _, s := range sessions {
+		if s.Title == condTitle || (s.IsConductor && s.GroupPath == conductor) {
+			return artifactTarget{Kind: "conductor", SessionID: s.ID, Label: s.Title, Busy: isBusyStatus(s.Status)}
+		}
+	}
+
+	// 3) Picker — offer the conductor's group first, else the whole fleet, so
+	// the operator can always land the comment somewhere.
+	var cands []artifactCandidate
+	for _, s := range sessions {
+		if s.GroupPath == conductor {
+			cands = append(cands, toCandidate(s))
+		}
+	}
+	if len(cands) == 0 {
+		for _, s := range sessions {
+			cands = append(cands, toCandidate(s))
+		}
+	}
+	return artifactTarget{Kind: "picker", Candidates: cands}
+}
+
+func toCandidate(s *MenuSession) artifactCandidate {
+	return artifactCandidate{SessionID: s.ID, Title: s.Title, Status: string(s.Status), Group: s.GroupPath}
+}
+
+// conductorOf returns the first path component of a root-relative artifact path,
+// which by the conductor/<name>/<file>.html layout is the owning conductor.
+func conductorOf(rel string) string {
+	parts := strings.SplitN(strings.TrimPrefix(filepath.ToSlash(rel), "/"), "/", 2)
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[0]
+}
+
+func (s *Server) liveSessions() []*MenuSession {
+	snapshot, err := s.menuData.LoadMenuSnapshot()
+	if err != nil || snapshot == nil {
+		return nil
+	}
+	var out []*MenuSession
+	for _, it := range snapshot.Items {
+		if it.Type == MenuItemTypeSession && it.Session != nil {
+			out = append(out, it.Session)
+		}
+	}
+	return out
+}
+
+// handleArtifactsList returns the provenance-attributed artifact listing.
+func (s *Server) handleArtifactsList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeAPIError(w, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "method not allowed")
+		return
+	}
+	if !s.authorizeRequest(r) {
+		writeAPIError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "unauthorized")
+		return
+	}
+	entries, err := artifact.ListArtifacts(s.artifactRoot)
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, ErrCodeInternalError, "failed to list artifacts")
+		return
+	}
+	if entries == nil {
+		entries = []artifact.Entry{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"artifacts": entries})
+}
+
+// handleArtifactServe serves one artifact read-only, path-confined to the
+// conductor root, with the selection relay injected. Auth uses the stream
+// authorizer so an iframe src (which cannot set an Authorization header) may
+// carry a ?token= when a token is configured.
+func (s *Server) handleArtifactServe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeAPIError(w, http.StatusMethodNotAllowed, ErrCodeMethodNotAllowed, "method not allowed")
+		return
+	}
+	if !s.authorizeStreamRequest(r) {
+		writeAPIError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "unauthorized")
+		return
+	}
+	rel := r.URL.Query().Get("path")
+	full, err := artifact.ConfinedPath(s.artifactRoot, rel)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid artifact path")
+		return
+	}
+	if !strings.HasSuffix(strings.ToLower(full), ".html") {
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "not an html artifact")
+		return
+	}
+	data, err := os.ReadFile(full)
+	if err != nil {
+		writeAPIError(w, http.StatusNotFound, ErrCodeNotFound, "artifact not found")
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Cache-Control", "no-store")
+	_, _ = w.Write([]byte(injectSelectionRelay(string(data), rel)))
+}
+
+// artifactCommentRequest is the POST /api/artifacts/comment body.
+type artifactCommentRequest struct {
+	Path    string `json:"path"`
+	Excerpt string `json:"excerpt"`
+	Comment string `json:"comment"`
+}
+
+// handleArtifactComment resolves an artifact's owning session and routes the
+// annotation there. An unresolved owner returns the picker candidates rather
+// than failing — the operator chooses, and re-posts (future: with a target).
+func (s *Server) handleArtifactComment(w http.ResponseWriter, r *http.Request) {
+	if !s.authorizeRequest(r) {
+		writeAPIError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "unauthorized")
+		return
+	}
+	if !s.checkMutationsAllowed(w) {
+		return
+	}
+	if !s.checkMutationRateLimit(w) {
+		return
+	}
+
+	var req artifactCommentRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64*1024)).Decode(&req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid request body")
+		return
+	}
+	if strings.TrimSpace(req.Comment) == "" {
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "comment is required")
+		return
+	}
+
+	full, err := artifact.ConfinedPath(s.artifactRoot, req.Path)
+	if err != nil {
+		writeAPIError(w, http.StatusBadRequest, ErrCodeBadRequest, "invalid artifact path")
+		return
+	}
+	meta, _, _ := artifact.ReadMeta(full)
+	conductor := conductorOf(req.Path)
+	target := resolveArtifactTarget(meta, conductor, s.liveSessions())
+
+	if target.Kind == "picker" {
+		candidates := target.Candidates
+		if candidates == nil {
+			candidates = []artifactCandidate{} // marshal as [] not null even on an empty fleet
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"needsPicker": true,
+			"conductor":   conductor,
+			"candidates":  candidates,
+		})
+		return
+	}
+
+	base := strings.TrimSuffix(filepath.Base(full), ".html")
+	c := session.ArtifactComment{
+		ArtifactID:    firstNonEmpty(meta.ArtifactID, base),
+		ArtifactTitle: firstNonEmpty(meta.Title, base),
+		Excerpt:       req.Excerpt,
+		Comment:       req.Comment,
+		Profile:       s.cfg.Profile,
+	}
+	if err := s.artifactDeliver(target.SessionID, target.Busy, c); err != nil {
+		writeAPIError(w, http.StatusBadGateway, "SEND_FAILED", "failed to deliver comment")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"routedTo": target.SessionID,
+		"kind":     target.Kind,
+		"label":    target.Label,
+		"busy":     target.Busy,
+	})
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// injectSelectionRelay appends the selection-relay script to the served
+// artifact. Cross-iframe text selections do not bubble to the parent, so the
+// artifact must postMessage them out itself. The script runs inside the
+// opaque-origin sandbox and can only talk to the parent via postMessage.
+func injectSelectionRelay(htmlBody, relPath string) string {
+	relay := fmt.Sprintf(`<script>
+(function(){
+  var ARTIFACT_PATH = %q;
+  function emit(){
+    var sel = window.getSelection && window.getSelection();
+    if(!sel || sel.isCollapsed){ return; }
+    var text = String(sel).trim();
+    if(!text){ return; }
+    var rect = null;
+    try { rect = sel.getRangeAt(0).getBoundingClientRect(); } catch(e){}
+    parent.postMessage({
+      type: 'fleet-artifact-selection',
+      path: ARTIFACT_PATH,
+      text: text,
+      rect: rect ? {top:rect.top,left:rect.left,bottom:rect.bottom,right:rect.right,width:rect.width,height:rect.height} : null
+    }, '*');
+  }
+  document.addEventListener('mouseup', function(){ setTimeout(emit, 0); });
+})();
+</script>`, relPath)
+
+	lower := strings.ToLower(htmlBody)
+	if idx := strings.LastIndex(lower, "</body>"); idx >= 0 {
+		return htmlBody[:idx] + relay + htmlBody[idx:]
+	}
+	return htmlBody + relay
+}

--- a/internal/web/handlers_artifacts_test.go
+++ b/internal/web/handlers_artifacts_test.go
@@ -1,0 +1,305 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/artifact"
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+// recordingDeliverer captures DeliverArtifactComment calls for assertions.
+type recordingDeliverer struct {
+	called  bool
+	target  string
+	busy    bool
+	comment session.ArtifactComment
+}
+
+func (d *recordingDeliverer) deliver(target string, busy bool, c session.ArtifactComment) error {
+	d.called = true
+	d.target = target
+	d.busy = busy
+	d.comment = c
+	return nil
+}
+
+// artifactTestSessions is a small live fleet: one busy worker (sidecar target)
+// and the conductor that owns the agent-deck group (fallback target).
+func artifactTestSessions() *MenuSnapshot {
+	return &MenuSnapshot{
+		Profile: "personal",
+		Items: []MenuItem{
+			{Type: MenuItemTypeSession, Session: &MenuSession{
+				ID: "sess-123", Title: "ard-import-perf-fix", Status: session.StatusRunning,
+				GroupPath: "agent-deck",
+			}},
+			{Type: MenuItemTypeSession, Session: &MenuSession{
+				ID: "cond-ad", Title: "conductor-agent-deck", Status: session.StatusWaiting,
+				GroupPath: "agent-deck", IsConductor: true,
+			}},
+		},
+	}
+}
+
+func sessionsFromSnapshot(s *MenuSnapshot) []*MenuSession {
+	var out []*MenuSession
+	for _, it := range s.Items {
+		if it.Type == MenuItemTypeSession && it.Session != nil {
+			out = append(out, it.Session)
+		}
+	}
+	return out
+}
+
+// SPEC T3: artifact->session resolution: sidecar present -> session; absent ->
+// conductor; unknown -> picker (never dead-end).
+func TestResolveArtifactTargetSidecarToSession(t *testing.T) {
+	sessions := sessionsFromSnapshot(artifactTestSessions())
+	meta := artifact.Meta{SessionID: "sess-123", Group: "agent-deck"}
+
+	got := resolveArtifactTarget(meta, "agent-deck", sessions)
+	if got.Kind != "session" {
+		t.Fatalf("expected kind session, got %q", got.Kind)
+	}
+	if got.SessionID != "sess-123" {
+		t.Fatalf("expected target sess-123, got %q", got.SessionID)
+	}
+	if !got.Busy {
+		t.Fatalf("expected busy=true for a running target")
+	}
+}
+
+func TestResolveArtifactTargetFallsBackToConductor(t *testing.T) {
+	sessions := sessionsFromSnapshot(artifactTestSessions())
+	// No sidecar session id -> route to the conductor that owns the directory.
+	got := resolveArtifactTarget(artifact.Meta{}, "agent-deck", sessions)
+	if got.Kind != "conductor" {
+		t.Fatalf("expected kind conductor, got %q", got.Kind)
+	}
+	if got.SessionID != "cond-ad" {
+		t.Fatalf("expected conductor session cond-ad, got %q", got.SessionID)
+	}
+	if got.Busy {
+		t.Fatalf("expected busy=false for a waiting conductor")
+	}
+}
+
+func TestResolveArtifactTargetUnknownYieldsPickerNeverDeadEnd(t *testing.T) {
+	sessions := sessionsFromSnapshot(artifactTestSessions())
+	// Sidecar session is gone AND no conductor owns "ghost" -> picker, but with
+	// candidates so the operator is never stuck.
+	got := resolveArtifactTarget(artifact.Meta{SessionID: "vanished"}, "ghost", sessions)
+	if got.Kind != "picker" {
+		t.Fatalf("expected kind picker, got %q", got.Kind)
+	}
+	if got.SessionID != "" {
+		t.Fatalf("expected no concrete target for picker, got %q", got.SessionID)
+	}
+	if len(got.Candidates) == 0 {
+		t.Fatalf("picker must never be a dead end: expected candidates, got none")
+	}
+}
+
+// --- HTTP layer ------------------------------------------------------------
+
+func newArtifactServer(t *testing.T, cfg Config) (*Server, string) {
+	t.Helper()
+	srv := NewServer(cfg)
+	srv.menuData = &fakeMenuDataLoader{snapshot: artifactTestSessions()}
+
+	root := t.TempDir()
+	html := filepath.Join(root, "agent-deck", "perf.html")
+	if err := os.MkdirAll(filepath.Dir(html), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "<!doctype html><html><body><h1>PERF REPORT BODY</h1></body></html>"
+	if err := os.WriteFile(html, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := artifact.WriteMeta(html, artifact.Meta{
+		ArtifactID: "perf-report", SessionID: "sess-123", Group: "agent-deck",
+		Profile: "personal", Title: "ARD Import Perf",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv.artifactRoot = root
+	return srv, root
+}
+
+func TestListArtifactsEndpoint(t *testing.T) {
+	srv, _ := newArtifactServer(t, Config{ListenAddr: "127.0.0.1:0"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/artifacts", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Artifacts []artifact.Entry `json:"artifacts"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid list json: %v (%s)", err, rr.Body.String())
+	}
+	if len(resp.Artifacts) != 1 {
+		t.Fatalf("expected 1 artifact, got %d: %+v", len(resp.Artifacts), resp.Artifacts)
+	}
+	if resp.Artifacts[0].SessionID != "sess-123" || !resp.Artifacts[0].HasSidecar {
+		t.Fatalf("unexpected entry: %+v", resp.Artifacts[0])
+	}
+}
+
+func TestServeArtifactInjectsRelayAndConfinesPath(t *testing.T) {
+	srv, _ := newArtifactServer(t, Config{ListenAddr: "127.0.0.1:0"})
+
+	// Happy path: serves the artifact body AND injects the selection relay.
+	req := httptest.NewRequest(http.MethodGet, "/api/artifacts/serve?path=agent-deck/perf.html", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Fatalf("expected text/html, got %q", ct)
+	}
+	out := rr.Body.String()
+	if !strings.Contains(out, "PERF REPORT BODY") {
+		t.Fatalf("served body missing original artifact content: %s", out)
+	}
+	// The injected relay is what makes cross-iframe selections reach the parent.
+	if !strings.Contains(out, "fleet-artifact-selection") {
+		t.Fatalf("served artifact missing injected selection relay: %s", out)
+	}
+
+	// Path traversal is rejected.
+	bad := httptest.NewRequest(http.MethodGet, "/api/artifacts/serve?path=../../etc/passwd", nil)
+	br := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(br, bad)
+	if br.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for traversal, got %d: %s", br.Code, br.Body.String())
+	}
+}
+
+func TestServeArtifactRequiresAuthWhenTokenSet(t *testing.T) {
+	srv, _ := newArtifactServer(t, Config{ListenAddr: "127.0.0.1:0", Token: "secret"})
+	req := httptest.NewRequest(http.MethodGet, "/api/artifacts/serve?path=agent-deck/perf.html", nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+// SPEC T4 (HTTP layer): a comment to a BUSY session is delivered with busy=true
+// (the handler hands off to the durable-inbox path) and the resolved target is
+// reported back to the caller.
+func TestCommentEndpointRoutesToResolvedBusyTarget(t *testing.T) {
+	srv, _ := newArtifactServer(t, Config{ListenAddr: "127.0.0.1:0", WebMutations: true})
+	rec := &recordingDeliverer{}
+	srv.artifactDeliver = rec.deliver
+
+	body := `{"path":"agent-deck/perf.html","excerpt":"~14,000 queries","comment":"batch into IN(...)"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/artifacts/comment", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://"+req.Host) // same-origin -> CSRF gate passes
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		RoutedTo string `json:"routedTo"`
+		Kind     string `json:"kind"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid response json: %v (%s)", err, rr.Body.String())
+	}
+	if resp.RoutedTo != "sess-123" || resp.Kind != "session" {
+		t.Fatalf("expected routedTo=sess-123 kind=session, got %+v", resp)
+	}
+	if !rec.called {
+		t.Fatal("expected deliverer to be called")
+	}
+	if !rec.busy {
+		t.Fatal("expected busy=true for a running target (durable-inbox path)")
+	}
+	if rec.target != "sess-123" {
+		t.Fatalf("expected delivery target sess-123, got %q", rec.target)
+	}
+	// Verbatim payload (title from sidecar + excerpt + comment) reaches delivery.
+	if rec.comment.Excerpt != "~14,000 queries" || rec.comment.Comment != "batch into IN(...)" {
+		t.Fatalf("payload not carried verbatim: %+v", rec.comment)
+	}
+	if rec.comment.ArtifactTitle != "ARD Import Perf" {
+		t.Fatalf("expected sidecar title, got %q", rec.comment.ArtifactTitle)
+	}
+}
+
+func TestCommentEndpointForbiddenWhenMutationsDisabled(t *testing.T) {
+	srv, _ := newArtifactServer(t, Config{ListenAddr: "127.0.0.1:0", WebMutations: false})
+	rec := &recordingDeliverer{}
+	srv.artifactDeliver = rec.deliver
+
+	body := `{"path":"agent-deck/perf.html","excerpt":"x","comment":"y"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/artifacts/comment", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://"+req.Host)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if rec.called {
+		t.Fatal("deliverer must not be called when mutations are disabled")
+	}
+}
+
+// Never a dead end: a comment whose owner can't be resolved returns the picker
+// candidates instead of delivering or failing.
+func TestCommentEndpointUnresolvedReturnsPicker(t *testing.T) {
+	srv, root := newArtifactServer(t, Config{ListenAddr: "127.0.0.1:0", WebMutations: true})
+	// A legacy artifact under a conductor no live session owns.
+	ghost := filepath.Join(root, "ghost", "legacy.html")
+	if err := os.MkdirAll(filepath.Dir(ghost), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ghost, []byte("<h1>legacy</h1>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rec := &recordingDeliverer{}
+	srv.artifactDeliver = rec.deliver
+
+	body := `{"path":"ghost/legacy.html","excerpt":"x","comment":"y"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/artifacts/comment", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://"+req.Host)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		NeedsPicker bool             `json:"needsPicker"`
+		Candidates  []map[string]any `json:"candidates"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if !resp.NeedsPicker || len(resp.Candidates) == 0 {
+		t.Fatalf("expected picker with candidates (never dead end), got %+v", resp)
+	}
+	if rec.called {
+		t.Fatal("must not deliver when target is unresolved; await picker choice")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -159,6 +159,15 @@ type Server struct {
 	// whose hook file is present on disk. Defaults to defaultLoadHookStatuses
 	// (which reads ~/.agent-deck/hooks/) but is injectable for tests.
 	hookStatusLoader func() map[string]*session.HookStatus
+
+	// artifactRoot is the conductor directory the Fleet Console lists/serves
+	// HTML artifacts from. Defaults to conductorArtifactDir(); injectable for tests.
+	artifactRoot string
+
+	// artifactDeliver routes a resolved Fleet Console annotation to its owning
+	// session (durable inbox when busy, reliable send otherwise). Defaults to
+	// session.DeliverArtifactComment; injectable for tests.
+	artifactDeliver func(targetSessionID string, busy bool, c session.ArtifactComment) error
 }
 
 // NewServer creates a new web server with base routes and middleware.
@@ -184,6 +193,8 @@ func NewServer(cfg Config) *Server {
 		menuSubscribers:  make(map[chan struct{}]struct{}),
 		mutationLimiter:  mutationLimiter,
 		hookStatusLoader: defaultLoadHookStatuses,
+		artifactRoot:     conductorArtifactDir(),
+		artifactDeliver:  session.DeliverArtifactComment,
 	}
 	s.baseCtx, s.cancelBase = context.WithCancel(context.Background())
 	webLog := logging.ForComponent(logging.CompWeb)
@@ -248,6 +259,12 @@ func NewServer(cfg Config) *Server {
 	mux.HandleFunc("/api/command-center/status", s.handleCommandCenterStatus)
 	mux.HandleFunc("/events/command-center", s.handleCommandCenterEvents)
 	mux.HandleFunc("POST /api/command-center/ask", s.handleCommandCenterAsk)
+
+	// Fleet Console: artifact provenance listing, read-only confined serving
+	// (with the selection relay injected), and highlight-to-route commenting.
+	mux.HandleFunc("/api/artifacts", s.handleArtifactsList)
+	mux.HandleFunc("/api/artifacts/serve", s.handleArtifactServe)
+	mux.HandleFunc("POST /api/artifacts/comment", s.handleArtifactComment)
 
 	mux.HandleFunc("/api/costs/summary", s.handleCostsSummary)
 	mux.HandleFunc("/api/costs/daily", s.handleCostsDaily)

--- a/internal/web/static/app/AppShell.js
+++ b/internal/web/static/app/AppShell.js
@@ -19,6 +19,7 @@ import { TerminalPane } from './panes/TerminalPane.js'
 import { CostsPane } from './panes/CostsPane.js'
 import { FleetPane } from './panes/FleetPane.js'
 import { CommandCenterPane } from './panes/CommandCenterPane.js'
+import { ArtifactPane } from './panes/ArtifactPane.js'
 import { ArchivedPane } from './panes/ArchivedPane.js'
 import { StubPane } from './panes/StubPane.js'
 import { SearchPane } from './panes/SearchPane.js'
@@ -105,6 +106,7 @@ function Panes({ tab }) {
     </div>
     ${tab === 'command-center' && html`<${CommandCenterPane}/>`}
     ${tab === 'fleet'     && html`<${FleetPane}/>`}
+    ${tab === 'artifact'  && html`<${ArtifactPane}/>`}
     ${tab === 'costs'     && html`<${CostsPane}/>`}
     ${tab === 'search'    && html`<${SearchPane}/>`}
     ${tab === 'archived'  && html`<${ArchivedPane}/>`}

--- a/internal/web/static/app/Topbar.js
+++ b/internal/web/static/app/Topbar.js
@@ -17,6 +17,7 @@ import { ToastHistoryDrawerToggle } from './ToastHistoryDrawer.js'
 const TABS = [
   { id: 'command-center', label: 'Command Center' },
   { id: 'fleet',     label: 'Fleet'     },
+  { id: 'artifact',  label: 'Artifacts' },
   { id: 'terminal',  label: 'Terminal'  },
   { id: 'mcp',       label: 'MCPs'      },
   { id: 'skills',    label: 'Skills'    },

--- a/internal/web/static/app/panes/ArtifactPane.js
+++ b/internal/web/static/app/panes/ArtifactPane.js
@@ -1,0 +1,204 @@
+// panes/ArtifactPane.js -- The Fleet Console "Artifacts" tab.
+//
+// This kills the two pains the console exists for:
+//  1. TAB EXPLOSION: every conductor HTML renders as an INLINE CARD here (in a
+//     sandboxed iframe), never a new browser tab.
+//  2. MANUAL ROUTING: highlight a passage in a card and the annotation auto-
+//     routes to the artifact's owning session — the resolved owner is shown
+//     BEFORE you send, so you never hunt for the session.
+//
+// The artifact runs in an opaque-origin sandbox (allow-scripts, NO
+// allow-same-origin): its scripts — including the server-injected selection
+// relay — cannot touch this origin, the parent DOM, or any credential. The
+// relay postMessages each selection out (cross-iframe selections can't bubble).
+import { html } from 'htm/preact'
+import { useEffect, useState, useCallback } from 'preact/hooks'
+import { authTokenSignal, mutationsEnabledSignal } from '../state.js'
+import { apiFetch } from '../api.js'
+import { addToast } from '../Toast.js'
+import { parseSelectionMessage, ownerLabel, commentBody, serveUrl } from './artifactConsole.js'
+
+const C = {
+  bg: '#0d1117', elev: '#161b22', elev2: '#1c2128', border: '#30363d',
+  text: '#e6edf3', dim: '#8b949e', faint: '#6e7681', accent: '#2f81f7',
+  routed: '#388bfd1a', routedBorder: '#2f81f7', good: '#79c0ff',
+}
+
+function ArtifactCard({ entry, token, onExpand, expanded }) {
+  const owner = ownerLabel(entry)
+  const prov = entry.hasSidecar ? '.meta.json ✓ stamped' : 'conductor-level (no sidecar)'
+  return html`
+    <div class="art-card" data-testid="artifact-card" data-path=${entry.path}
+      style=${{ border: `1px solid ${C.border}`, borderRadius: '10px', overflow: 'hidden',
+        background: C.elev, margin: '0 0 14px', maxWidth: '900px' }}>
+      <div style=${{ display: 'flex', alignItems: 'center', gap: '10px', padding: '9px 13px',
+        background: C.elev2, borderBottom: `1px solid ${C.border}` }}>
+        <span>📄</span>
+        <span style=${{ fontWeight: 600, fontSize: '12.5px', color: C.text }}>${entry.title}</span>
+        <span data-testid="artifact-owner-chip" style=${{ display: 'flex', alignItems: 'center', gap: '6px',
+          fontSize: '11px', color: C.dim, background: C.bg, border: `1px solid ${C.border}`,
+          borderRadius: '999px', padding: '2px 9px' }}>↳ ${owner}</span>
+        <span style=${{ flex: 1 }}></span>
+        <span style=${{ fontSize: '10px', color: C.faint, fontFamily: 'monospace' }}>${prov}</span>
+        <button class="art-expand" onClick=${() => onExpand(entry.path)}
+          style=${{ fontSize: '11px', color: C.dim, border: `1px solid ${C.border}`, background: C.bg,
+            borderRadius: '5px', padding: '2px 8px', cursor: 'pointer' }}>
+          ${expanded ? '▾ Collapse' : '▸ Render'}
+        </button>
+      </div>
+      ${expanded && html`
+        <iframe data-testid="artifact-frame" title=${entry.title}
+          sandbox="allow-scripts"
+          src=${serveUrl(entry, token)}
+          style=${{ width: '100%', height: '420px', border: 'none', background: '#0a0c10' }}></iframe>
+      `}
+    </div>
+  `
+}
+
+export function ArtifactPane() {
+  const token = authTokenSignal.value
+  const canMutate = mutationsEnabledSignal.value
+  const [entries, setEntries] = useState([])
+  const [loaded, setLoaded] = useState(false)
+  const [expanded, setExpanded] = useState({})
+  const [sel, setSel] = useState(null)       // { entry, text } pending annotation
+  const [comment, setComment] = useState('')
+  const [routed, setRouted] = useState([])   // resolved annotations (audit trail)
+  const [sending, setSending] = useState(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      const resp = await apiFetch('GET', '/api/artifacts')
+      setEntries(Array.isArray(resp.artifacts) ? resp.artifacts : [])
+    } catch (_) {
+      setEntries([])
+    } finally {
+      setLoaded(true)
+    }
+  }, [])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  // Selection relay: the only channel for a cross-iframe highlight to reach us.
+  useEffect(() => {
+    const onMessage = (event) => {
+      const parsed = parseSelectionMessage(event, null)
+      if (!parsed) return
+      const entry = entries.find(e => e.path === parsed.path)
+      if (!entry) return
+      setSel({ entry, text: parsed.text })
+      setComment('')
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [entries])
+
+  const onExpand = (path) => setExpanded(m => ({ ...m, [path]: !m[path] }))
+
+  const send = async () => {
+    if (!sel || sending) return
+    const note = comment.trim()
+    if (!note) return
+    if (!canMutate) {
+      addToast('Commenting is disabled (web mutations off)', 'info')
+      return
+    }
+    setSending(true)
+    try {
+      const resp = await apiFetch('POST', '/api/artifacts/comment', commentBody(sel.entry, sel.text, note))
+      if (resp.needsPicker) {
+        addToast('Could not auto-resolve the owner — pick a session', 'info')
+        setRouted(r => [{ excerpt: sel.text, note, label: '(needs a session choice)', kind: 'picker',
+          candidates: resp.candidates || [] }, ...r])
+      } else {
+        addToast(`Routed to ${resp.label || resp.routedTo}${resp.busy ? ' (durable inbox)' : ''}`, 'success')
+        setRouted(r => [{ excerpt: sel.text, note, label: resp.label || resp.routedTo,
+          kind: resp.kind, busy: resp.busy }, ...r])
+      }
+      setSel(null)
+      setComment('')
+    } catch (e) {
+      addToast(e.message || 'comment failed', 'error')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return html`
+    <div class="artifacts" data-testid="artifact-pane"
+      style=${{ display: 'flex', flexDirection: 'column', minHeight: 0, flex: 1, color: C.text }}>
+      <div style=${{ display: 'flex', alignItems: 'center', gap: '12px', padding: '12px 18px',
+        borderBottom: `1px solid ${C.border}`, background: C.elev }}>
+        <h1 style=${{ fontSize: '15px', fontWeight: 600 }}>Artifacts</h1>
+        <span style=${{ fontSize: '11.5px', color: C.dim }} data-testid="artifact-count">
+          ${entries.length} inline · no browser tabs
+        </span>
+        <span style=${{ flex: 1 }}></span>
+        <button onClick=${refresh} data-testid="artifact-refresh"
+          style=${{ fontSize: '11.5px', color: C.dim, border: `1px solid ${C.border}`,
+            background: C.elev2, borderRadius: '6px', padding: '4px 10px', cursor: 'pointer' }}>↻ Refresh</button>
+      </div>
+
+      <div style=${{ overflowY: 'auto', flex: 1, padding: '18px 22px' }}>
+        ${!loaded && html`<div data-testid="artifact-loading" style=${{ color: C.faint }}>Loading artifacts…</div>`}
+        ${loaded && entries.length === 0 && html`
+          <div data-testid="artifact-empty" style=${{ color: C.faint }}>
+            No artifacts yet. A session that writes an HTML report and runs
+            <code style=${{ fontFamily: 'monospace', color: C.dim }}>agent-deck artifact stamp</code>
+            will appear here as an inline card.
+          </div>`}
+
+        ${routed.length > 0 && html`
+          <div data-testid="artifact-routed-list" style=${{ marginBottom: '14px' }}>
+            ${routed.map((r, i) => html`
+              <div key=${i} data-testid="artifact-routed-note"
+                style=${{ maxWidth: '900px', margin: '0 0 8px', display: 'flex', gap: '9px',
+                  alignItems: 'flex-start', background: C.routed, border: `1px solid ${C.routedBorder}4d`,
+                  borderRadius: '8px', padding: '9px 12px' }}>
+                <span style=${{ color: C.accent }}>↳</span>
+                <div style=${{ fontSize: '12px', color: C.dim }}>
+                  Highlight “<span style=${{ color: C.good }}>${r.excerpt}</span>” routed to
+                  <b style=${{ color: C.good }}> ${r.label}</b>
+                  ${r.busy ? ' · via durable inbox' : ''}: “${r.note}”
+                </div>
+              </div>
+            `)}
+          </div>`}
+
+        ${entries.map(e => html`
+          <${ArtifactCard} key=${e.path} entry=${e} token=${token}
+            expanded=${!!expanded[e.path]} onExpand=${onExpand}/>
+        `)}
+      </div>
+
+      ${sel && html`
+        <div data-testid="artifact-annotation-bubble"
+          style=${{ borderTop: `1px solid ${C.routedBorder}`, background: C.elev2, padding: '12px 18px' }}>
+          <div style=${{ fontSize: '11.5px', color: C.dim, borderLeft: `2px solid ${C.routedBorder}`,
+            paddingLeft: '9px', marginBottom: '8px', fontStyle: 'italic' }}>“${sel.text}”</div>
+          <div data-testid="artifact-route-target"
+            style=${{ display: 'flex', alignItems: 'center', gap: '7px', fontSize: '11.5px',
+              background: C.routed, border: `1px solid ${C.routedBorder}`, borderRadius: '6px',
+              padding: '6px 9px', marginBottom: '9px' }}>
+            <span style=${{ color: C.accent, fontWeight: 700 }}>↳ routes to</span>
+            <b style=${{ color: C.good }}>${ownerLabel(sel.entry)}</b>
+          </div>
+          <div style=${{ display: 'flex', gap: '9px', alignItems: 'flex-end' }}>
+            <textarea data-testid="artifact-comment-input"
+              placeholder="Comment — auto-routes to the owning session via the durable inbox…"
+              value=${comment} onInput=${e => setComment(e.target.value)}
+              style=${{ flex: 1, background: C.bg, border: `1px solid ${C.border}`, borderRadius: '8px',
+                color: C.text, fontSize: '13px', padding: '9px 12px', resize: 'none', height: '46px' }}></textarea>
+            <button data-testid="artifact-comment-send" disabled=${!comment.trim() || sending} onClick=${send}
+              style=${{ background: C.accent, color: '#fff', border: 'none', borderRadius: '8px',
+                padding: '9px 18px', fontSize: '13px', fontWeight: 600, cursor: 'pointer', height: '46px' }}>
+              ${sending ? 'Sending…' : 'Send ▸'}</button>
+            <button data-testid="artifact-comment-cancel" onClick=${() => setSel(null)}
+              style=${{ background: C.elev, color: C.dim, border: `1px solid ${C.border}`, borderRadius: '8px',
+                padding: '9px 12px', fontSize: '13px', cursor: 'pointer', height: '46px' }}>✕</button>
+          </div>
+        </div>`}
+    </div>
+  `
+}

--- a/internal/web/static/app/panes/artifactConsole.js
+++ b/internal/web/static/app/panes/artifactConsole.js
@@ -1,0 +1,55 @@
+// panes/artifactConsole.js -- Pure helpers for the Fleet Console artifact pane.
+//
+// These are deliberately DOM-free so the selection-relay protocol and the
+// owner-resolution shown before send can be unit-tested headlessly (the
+// web-change test gate). The pane (ArtifactPane.js) wires them to Preact.
+
+// The message type the server-injected relay postMessages on every selection.
+// Kept in lockstep with internal/web/handlers_artifacts.go (injectSelectionRelay).
+export const SELECTION_MESSAGE_TYPE = 'fleet-artifact-selection'
+
+// parseSelectionMessage validates a postMessage from the artifact iframe and,
+// for the currently-open artifact, returns the highlighted text + rect. Returns
+// null for anything that isn't a usable selection from the expected artifact —
+// cross-iframe selections can't bubble, so this relayed message is the ONLY way
+// the parent learns what the operator highlighted.
+export function parseSelectionMessage(event, expectedPath) {
+  const d = event && event.data
+  if (!d || d.type !== SELECTION_MESSAGE_TYPE) return null
+  // Ignore stray messages from a different artifact than the one in view.
+  if (expectedPath && d.path && d.path !== expectedPath) return null
+  const text = typeof d.text === 'string' ? d.text.trim() : ''
+  if (!text) return null
+  return { text, rect: d.rect || null, path: d.path || expectedPath || '' }
+}
+
+// ownerLabel is the resolved-target label shown BEFORE send, so routing is
+// never a surprise. Sidecar session wins; else the owning conductor (still
+// routable — never a dead end); else a prompt to pick.
+export function ownerLabel(entry) {
+  if (!entry) return 'choose a session'
+  if (entry.sessionId) return entry.sessionId
+  if (entry.conductor) return 'conductor-' + entry.conductor
+  return 'choose a session'
+}
+
+// commentBody builds the POST /api/artifacts/comment payload. The server
+// re-resolves the owner authoritatively from the sidecar at `path`; the client
+// never asserts the target.
+export function commentBody(entry, excerpt, comment) {
+  return {
+    path: entry ? entry.path : '',
+    excerpt: excerpt || '',
+    comment: comment || '',
+  }
+}
+
+// serveUrl is the confined read-only artifact URL loaded into the sandbox
+// iframe. A token is carried as a query param because an iframe src cannot set
+// an Authorization header.
+export function serveUrl(entry, token) {
+  if (!entry || !entry.path) return ''
+  let u = '/api/artifacts/serve?path=' + encodeURIComponent(entry.path)
+  if (token) u += '&token=' + encodeURIComponent(token)
+  return u
+}

--- a/internal/web/static/app/uiState.js
+++ b/internal/web/static/app/uiState.js
@@ -22,8 +22,9 @@ function persist(sig, key) {
 }
 
 // Active tab in main work surface.
-// Bundle ships 8 tabs: fleet, terminal, mcp, skills, conductor, watchers, costs, search.
-// Only `fleet | terminal | costs | search` have data (search filters local sessions only).
+// Bundle ships: command-center, fleet, artifact, terminal, mcp, skills, conductor, watchers, costs, search.
+// `fleet | terminal | costs | search | artifact` have data (search filters local sessions only;
+// artifact lists/serves conductor HTML artifacts via /api/artifacts).
 // MCP/Skills/Conductor/Watchers render informative stubs because the API doesn't expose them.
 export const activeTabSignal = signal(loadJSON('agentdeck.tab', 'fleet'))
 persist(activeTabSignal, 'agentdeck.tab')

--- a/tests/web/unit/artifactConsole.test.js
+++ b/tests/web/unit/artifactConsole.test.js
@@ -1,0 +1,85 @@
+// unit/artifactConsole.test.js -- The Fleet Console's keystone is highlight-to-
+// route: a text selection in a sandboxed artifact iframe must reach the parent
+// (cross-iframe selections can't bubble, so the relayed postMessage is the only
+// channel), and the resolved owner must be shown before send. These pure
+// helpers encode that protocol; if they regress, routing silently breaks.
+
+import { describe, it, expect } from 'vitest'
+
+const mod = '../../../internal/web/static/app/panes/artifactConsole.js'
+
+describe('parseSelectionMessage', () => {
+  it('accepts a relay message for the open artifact and returns trimmed text', async () => {
+    const { parseSelectionMessage, SELECTION_MESSAGE_TYPE } = await import(mod)
+    const event = {
+      data: {
+        type: SELECTION_MESSAGE_TYPE,
+        path: 'agent-deck/perf.html',
+        text: '  ~14,000 queries for a 1,000-row batch  ',
+        rect: { top: 10, left: 20 },
+      },
+    }
+    const got = parseSelectionMessage(event, 'agent-deck/perf.html')
+    expect(got).not.toBeNull()
+    expect(got.text).toBe('~14,000 queries for a 1,000-row batch')
+    expect(got.rect).toEqual({ top: 10, left: 20 })
+  })
+
+  it('ignores messages of the wrong type', async () => {
+    const { parseSelectionMessage } = await import(mod)
+    expect(parseSelectionMessage({ data: { type: 'other', text: 'x' } }, 'a')).toBeNull()
+    expect(parseSelectionMessage({}, 'a')).toBeNull()
+    expect(parseSelectionMessage(null, 'a')).toBeNull()
+  })
+
+  it('ignores a selection from a different artifact than the one in view', async () => {
+    const { parseSelectionMessage, SELECTION_MESSAGE_TYPE } = await import(mod)
+    const event = { data: { type: SELECTION_MESSAGE_TYPE, path: 'other/doc.html', text: 'hi' } }
+    expect(parseSelectionMessage(event, 'agent-deck/perf.html')).toBeNull()
+  })
+
+  it('ignores an empty/whitespace selection', async () => {
+    const { parseSelectionMessage, SELECTION_MESSAGE_TYPE } = await import(mod)
+    const event = { data: { type: SELECTION_MESSAGE_TYPE, path: 'a', text: '   ' } }
+    expect(parseSelectionMessage(event, 'a')).toBeNull()
+  })
+})
+
+describe('ownerLabel (resolved target shown before send)', () => {
+  it('prefers the sidecar session', async () => {
+    const { ownerLabel } = await import(mod)
+    expect(ownerLabel({ sessionId: 'sess-123', conductor: 'agent-deck' })).toBe('sess-123')
+  })
+
+  it('falls back to the owning conductor when there is no sidecar session', async () => {
+    const { ownerLabel } = await import(mod)
+    expect(ownerLabel({ conductor: 'innotrade' })).toBe('conductor-innotrade')
+  })
+
+  it('never leaves a dead end — prompts to choose when nothing is known', async () => {
+    const { ownerLabel } = await import(mod)
+    expect(ownerLabel(null)).toBe('choose a session')
+    expect(ownerLabel({})).toBe('choose a session')
+  })
+})
+
+describe('commentBody', () => {
+  it('carries the artifact path + excerpt + comment for the server to resolve', async () => {
+    const { commentBody } = await import(mod)
+    const body = commentBody({ path: 'agent-deck/perf.html' }, 'the excerpt', 'the comment')
+    expect(body).toEqual({ path: 'agent-deck/perf.html', excerpt: 'the excerpt', comment: 'the comment' })
+  })
+})
+
+describe('serveUrl', () => {
+  it('builds a confined serve url and appends a token when present', async () => {
+    const { serveUrl } = await import(mod)
+    expect(serveUrl({ path: 'agent-deck/perf.html' }, '')).toBe(
+      '/api/artifacts/serve?path=agent-deck%2Fperf.html',
+    )
+    expect(serveUrl({ path: 'agent-deck/perf.html' }, 'tok')).toBe(
+      '/api/artifacts/serve?path=agent-deck%2Fperf.html&token=tok',
+    )
+    expect(serveUrl(null, '')).toBe('')
+  })
+})


### PR DESCRIPTION
## Fleet Console (MVP) — inline artifact cards + highlight-to-route comments

Closes #1512.

Turns conductor HTML reports into **inline cards** in the web UI (no more browser-tab explosion) and lets you **highlight a passage in a card to auto-route a comment to the artifact's owning session** (no more hunting for the session).

### What's in this PR

**EMIT — provenance sidecar** (`internal/artifact`, `cmd/agent-deck/artifact_cmd.go`)
- `agent-deck artifact stamp <file.html>` writes `<file>.meta.json` (`artifact_id, session_id, group, profile, title, created_at`). Flags win; id/group derive from the `conductor/<name>/<file>.html` layout; session falls back to `$AGENTDECK_INSTANCE_ID`.
- The `artifact` package (sidecar read/write, listing, path-confinement) has **no session/web dependency**, so the provenance contract is unit-testable in isolation and shared by both producer (CLI) and consumer (web).

**SERVE — read-only, confined, relay-injected** (`internal/web/handlers_artifacts.go`)
- `GET /api/artifacts` — provenance-attributed listing (sidecar entries + conductor-level fallback).
- `GET /api/artifacts/serve` — read-only, **path-confined** to the conductor root (`../` rejected), stream-token auth so an iframe `src` can carry `?token=`, selection relay injected before `</body>`.
- `POST /api/artifacts/comment` — resolves owner → delivers; behind the existing CSRF + auth + mutation-rate gates.

**RENDER + RELAY — ArtifactPane** (`internal/web/static/app/panes/ArtifactPane.js`, `artifactConsole.js`)
- New **"Artifacts"** tab. Each HTML renders as an inline card in a **sandboxed iframe** (`allow-scripts` only, opaque origin — see security note) with an owning-session chip.
- A highlight posts a selection out of the iframe via the injected relay (cross-iframe selections can't bubble); the parent anchors a comment bubble that **always shows the resolved target before send**.

**ROUTE — owner resolution + reliable delivery** (`internal/session/artifact_comment.go`)
- `resolveArtifactTarget`: sidecar session (if live) → owning conductor → picker (**never a dead end**).
- `DeliverArtifactComment`: **busy/running** target → durable inbox (`CommitToInbox`) so a live pane can't swallow it; idle target → `SendSessionMessageReliable`. Each annotation gets a unique inbox child id so multiple comments on one artifact don't collapse under last-wins.

### Security note (deliberate deviation from the spec's literal flag)
The spec asked for `allow-same-origin` with **no** `allow-scripts`, but the relay is a *script* and the keystone feature needs it. Those flags are mutually exclusive. This ships `sandbox="allow-scripts"` **without** `allow-same-origin` → the artifact runs in an **opaque origin** that cannot reach this origin, the parent DOM, or any credential. That honors the security *intent* (and is strictly safer than `allow-same-origin`) while keeping highlight-to-route working. Serving is read-only + path-confined; the comment POST is a mutation behind CSRF + auth + rate gates.

### Tests (TDD — written first, all green)
- `internal/artifact`: path-confinement (`../` rejected), list sidecar + conductor fallback, sidecar round-trip.
- `internal/session`: busy comment → durable inbox → retrievable via drain, multiple comments survive, payload verbatim.
- `internal/web`: resolution ladder (session/conductor/picker), list endpoint, serve confinement + relay injection + auth, comment routing/gating/picker.
- `cmd/agent-deck`: `artifact stamp` writes the sidecar with derived defaults.
- `tests/web/unit/artifactConsole.test.js` (vitest): selection-relay protocol + owner-resolution + serve-url.

### Not in this PR (deferred)
Multi-open editor tabs; cross-fleet decisions queue; skill-side parsing of annotations (MVP delivers tagged text); generative view-specs; push/voice; eager back-fill of legacy artifacts.

### Notes
- The web bundle (`internal/web/static/dist/`) is gitignored and regenerated by `go generate ./internal/web` at build time, so it is not in this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Artifacts” tab to browse, serve, and annotate HTML artifacts in a sandboxed view
  * Users can select highlighted text and submit comments to route annotations to the right session targets
  * Introduced `artifact stamp` to generate and store artifact provenance metadata
  * Added API support for listing artifacts, serving confined HTML paths, and handling artifact comment delivery/routing
* **Tests**
  * Added unit tests for artifact metadata/provenance handling, comment formatting/routing, and artifact UI helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->