### PR TITLE
refactor(session): fork OpenCode via native --fork instead of export/import clone

### DIFF
--- a/internal/session/instance.go
+++ b/internal/session/instance.go
@@ -3115,10 +3115,11 @@ func (i *Instance) Start() error {
 		i.CopilotStartedAt = time.Now().UnixMilli()
 	case i.Tool == "opencode":
 		if i.IsForkAwaitingStart {
-			// Wrap the deferred fork script through buildOpenCodeCommand so the
-			// first-start command is byte-identical to the pre-deferred behavior
-			// (the script carries its own env prefix); restart falls through to the
-			// resume/fresh branch below via the stable "opencode" base Command.
+			// Wrap the deferred fork command through buildOpenCodeCommand so the
+			// env prefix is applied exactly once (the `--fork` command carries
+			// none); a later restart falls through to the resume/fresh branch
+			// below via the stable "opencode" base Command and the async-detected
+			// child session id (re-running `--fork` would re-fork the parent).
 			command = i.buildOpenCodeCommand(i.consumeForkStartCommand())
 			i.OpenCodeStartedAt = time.Now().UnixMilli()
 			sessionLog.Info("resume: none reason=fork_awaiting_start",
@@ -6940,20 +6941,37 @@ func (i *Instance) CreateForkedInstanceForTool(newTitle, newGroupPath string, op
 }
 
 // ForkOpenCode returns the command to create a forked OpenCode session.
-// Uses export/import to clone the session with a new ID, then launches
-// the forked session with opencode -s <new-id>.
+// Uses OpenCode's native `--fork` flag to branch the parent session into a new
+// session with its own id (discovered asynchronously after launch).
 // Deprecated: Use ForkOpenCodeWithOptions instead.
 func (i *Instance) ForkOpenCode(newTitle, newGroupPath string) (string, error) {
 	return i.ForkOpenCodeWithOptions(newTitle, newGroupPath, nil)
 }
 
-// ForkOpenCodeWithOptions returns the command to create a forked OpenCode session with custom options.
-// Uses export/import to clone the session with a new ID, then launches
-// the forked session with opencode -s <new-id> plus any model/agent flags.
+// ForkOpenCodeWithOptions returns the command to create a forked OpenCode session
+// with custom options. Uses OpenCode's native `opencode -s <parent-id> --fork`,
+// which branches the parent transcript into a fresh session while leaving the
+// parent intact, plus any model/agent flags.
 func (i *Instance) ForkOpenCodeWithOptions(newTitle, newGroupPath string, opts *OpenCodeOptions) (string, error) {
 	return i.forkOpenCodeWithOptionsInWorkDir(newTitle, newGroupPath, opts, i.ProjectPath)
 }
 
+// forkOpenCodeWithOptionsInWorkDir builds the one-time `cd <workDir> &&
+// opencode -s <parent-id> --fork` launch command for a forked OpenCode
+// instance. `--fork` is a newer OpenCode CLI flag that branches the session
+// named by -s/--continue; if the installed binary predates it the launched
+// command fails into a recoverable error state, mirroring how `codex fork` is
+// handled (CanForkCodex below).
+//
+// The launch is explicitly anchored to workDir with a `cd`: the multi-repo fork
+// path later repoints the tmux session WorkDir to the MultiRepoTempDir
+// container (internal/ui/home.go), yet async OpenCode session detection matches
+// by ProjectPath (DetectOpenCodeSession), so OpenCode must run in the requested
+// repo/worktree dir — not tmux's WorkDir — for the child session to be
+// discoverable. OpenCode mints the child session id, which that async detection
+// picks up; the previous export/import clone relied on the same path (and the
+// same `cd`), so no id is pre-assigned here. The env prefix is applied once by
+// buildOpenCodeCommand at start time.
 func (i *Instance) forkOpenCodeWithOptionsInWorkDir(newTitle, newGroupPath string, opts *OpenCodeOptions, workDir string) (string, error) {
 	if !i.CanForkOpenCode() {
 		return "", fmt.Errorf("cannot fork: no active OpenCode session")
@@ -6962,9 +6980,7 @@ func (i *Instance) forkOpenCodeWithOptionsInWorkDir(newTitle, newGroupPath strin
 		workDir = i.ProjectPath
 	}
 
-	envPrefix := i.buildEnvSourceCommand()
-
-	// Build extra flags from options (for fork, exclude session mode flags)
+	// Build extra flags from options (for fork, exclude session mode flags).
 	var extraFlags string
 	if opts != nil {
 		for _, arg := range opts.ToArgsForFork() {
@@ -6977,66 +6993,10 @@ func (i *Instance) forkOpenCodeWithOptionsInWorkDir(newTitle, newGroupPath strin
 		}
 	}
 
-	scriptPath, err := i.writeOpenCodeForkScript(workDir, envPrefix, extraFlags)
-	if err != nil {
-		return "", fmt.Errorf("failed to create fork script: %w", err)
-	}
-
-	return fmt.Sprintf("bash '%s'", scriptPath), nil
-}
-
-// writeOpenCodeForkScript writes a bash script that forks via export/import.
-// The script self-deletes after execution.
-func (i *Instance) writeOpenCodeForkScript(workDir, envPrefix, extraFlags string) (string, error) {
-	quotedWorkDir := shellescape.Quote(workDir)
-	quotedSessionID := shellescape.Quote(i.OpenCodeSessionID)
-	sedSessionID := strings.ReplaceAll(i.OpenCodeSessionID, ".", `\.`)
-	script := fmt.Sprintf(`#!/bin/bash
-cd %s || { printf 'cd failed to: %%s\n' %s; exit 1; }
-%s
-tmpfile=$(mktemp -t opencode-fork)
-trap "rm -f \"$tmpfile\" \"$0\"" EXIT
-
-opencode export %s 2>/dev/null > "$tmpfile"
-export_status=$?
-if [ $export_status -ne 0 ]; then
-  echo "Export failed (exit $export_status):"
-  cat "$tmpfile"
-  exit 1
-fi
-
-hash_cmd="md5sum"
-command -v md5sum >/dev/null 2>&1 || hash_cmd="md5"
-new_id="ses_$(date +%%s | $hash_cmd | head -c12)$(openssl rand -base64 20 | tr -dc a-zA-Z0-9 | head -c14)"
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i "" "s/%s/$new_id/g" "$tmpfile" || { echo "Sed failed"; exit 1; }
-else
-  sed -i "s/%s/$new_id/g" "$tmpfile" || { echo "Sed failed"; exit 1; }
-fi
-opencode import "$tmpfile" 2>&1 || { echo "Import failed"; exit 1; }
-# OPENCODE_SESSION_ID is propagated via host-side SetEnvironment after tmux start.
-echo "Forked to: $new_id"
-opencode -s "$new_id"%s
-`, quotedWorkDir, quotedWorkDir, envPrefix, quotedSessionID,
-		sedSessionID, sedSessionID, extraFlags)
-
-	f, err := os.CreateTemp("", "opencode-fork-*.sh")
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	if _, err := f.WriteString(script); err != nil {
-		os.Remove(f.Name())
-		return "", err
-	}
-
-	if err := f.Chmod(0o755); err != nil {
-		os.Remove(f.Name())
-		return "", err
-	}
-
-	return f.Name(), nil
+	// workDir and the session id are shell-quoted to keep the launch command
+	// injection-safe (the id is also charset-validated upstream by CanForkOpenCode).
+	return fmt.Sprintf("cd %s && opencode -s %s --fork%s",
+		shellescape.Quote(workDir), shellescape.Quote(i.OpenCodeSessionID), extraFlags), nil
 }
 
 // CreateForkedOpenCodeInstance creates a new Instance configured for forking an OpenCode session

--- a/internal/session/instance_opencode_fork_test.go
+++ b/internal/session/instance_opencode_fork_test.go
@@ -1,19 +1,21 @@
 package session
 
 import (
-	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"al.essio.dev/pkg/shellescape"
 )
 
-// TestCreateForkedOpenCode_DefersLaunchViaForkStartCommand guards a fork-restart
-// bug: the generated OpenCode fork script self-deletes after first run (trap …
-// EXIT). If it is stored as the persistent Command, a restart after the tmux
-// session dies (before async session-id detection completes) re-runs a missing
-// file and silently starts fresh. The fork must therefore use the Pi/Codex
-// deferred pattern — script in ForkStartCommand (transient), a stable base in
-// Command — so restart resumes via OpenCodeSessionID / bare opencode instead.
+// TestCreateForkedOpenCode_DefersLaunchViaForkStartCommand guards the fork-restart
+// invariant: the `opencode -s <parent> --fork` command must run exactly once. If
+// it were stored as the persistent Command, a restart after the tmux session dies
+// (before async session-id detection completes) would re-run `--fork` and fork the
+// parent *again* into yet another session. The fork therefore uses the Pi/Codex
+// deferred pattern — the one-shot command in ForkStartCommand (transient), a stable
+// base in Command — so restart resumes the child via OpenCodeSessionID / bare
+// opencode instead.
 func TestCreateForkedOpenCode_DefersLaunchViaForkStartCommand(t *testing.T) {
 	parent := NewInstanceWithTool("oc", t.TempDir(), "opencode")
 	parent.OpenCodeSessionID = "ses_parent_123"
@@ -23,27 +25,27 @@ func TestCreateForkedOpenCode_DefersLaunchViaForkStartCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateForkedOpenCodeInstanceWithOptions: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = os.Remove(strings.TrimPrefix(strings.TrimSuffix(cmd, "'"), "bash '"))
-	})
 
 	if forked.Command != "opencode" {
-		t.Fatalf("forked.Command = %q, want \"opencode\" (stable base survives the script's self-delete)", forked.Command)
+		t.Fatalf("forked.Command = %q, want \"opencode\" (stable base survives restart)", forked.Command)
 	}
 	if !forked.IsForkAwaitingStart || forked.ForkStartCommand != cmd {
 		t.Fatalf("opencode fork must defer launch via ForkStartCommand/IsForkAwaitingStart (Pi pattern); got awaiting=%v forkCmd=%q cmd=%q",
 			forked.IsForkAwaitingStart, forked.ForkStartCommand, cmd)
 	}
+	// The deferred command is the native one-shot fork, not a persistable resume.
+	if !strings.Contains(cmd, "opencode -s ses_parent_123 --fork") {
+		t.Fatalf("fork command should use native `opencode -s <parent> --fork`, got: %q", cmd)
+	}
 }
 
-// TestOpenCodeForkScriptQuotesWorkDir is the regression guard for the fork-review
-// command-safety finding: the generated OpenCode fork bash script must shell-quote
-// the working directory (and session id) rather than interpolate them raw, so a
-// project path containing shell metacharacters (here a literal double-quote) cannot
-// break out of the `cd`. The session id is validated to a safe charset upstream
-// (normalizeToolSessionID), so shellescape.Quote leaves it bare — the workDir
-// assertion is what proves the quoting is actually applied.
-func TestOpenCodeForkScriptQuotesWorkDir(t *testing.T) {
+// TestOpenCodeForkUsesNativeForkFlag verifies the OpenCode fork command uses
+// OpenCode's native `--fork` flag against the parent session id, rather than the
+// older `opencode export | sed | import` clone. The launch is still anchored to
+// the requested working dir with a `cd` (the multi-repo fork path depends on it
+// because async session detection matches by ProjectPath), so the workDir must
+// be shell-quoted to stay injection-safe.
+func TestOpenCodeForkUsesNativeForkFlag(t *testing.T) {
 	parent := NewInstanceWithTool("oc", `/tmp/project with "quote"`, "opencode")
 	parent.OpenCodeSessionID = "ses_parent_123"
 	parent.OpenCodeDetectedAt = time.Now()
@@ -53,25 +55,21 @@ func TestOpenCodeForkScriptQuotesWorkDir(t *testing.T) {
 		t.Fatalf("ForkOpenCodeWithOptions: %v", err)
 	}
 
-	// The command is `bash '<scriptPath>'`.
-	scriptPath := strings.TrimPrefix(strings.TrimSuffix(cmd, "'"), "bash '")
-	body, err := os.ReadFile(scriptPath)
-	if err != nil {
-		t.Fatalf("read fork script %q: %v", scriptPath, err)
+	if !strings.Contains(cmd, "opencode -s ses_parent_123 --fork") {
+		t.Fatalf("fork command should use native `opencode -s <parent> --fork`, got: %q", cmd)
 	}
-	t.Cleanup(func() { _ = os.Remove(scriptPath) })
-	script := string(body)
-
-	// Unsafe form: raw double-quoting would let the embedded `"` break out of cd.
-	if strings.Contains(script, `cd "/tmp/project with "quote""`) {
-		t.Fatalf("workDir is embedded unsafely (raw double-quoted):\n%s", script)
+	// The export/import clone path must be gone.
+	for _, gone := range []string{"opencode export", "opencode import", "sed "} {
+		if strings.Contains(cmd, gone) {
+			t.Fatalf("fork command should not reference the old clone path (%q): %q", gone, cmd)
+		}
 	}
-	// shellescape.Quote wraps a path containing a double-quote in single quotes.
-	if !strings.Contains(script, `cd '/tmp/project with "quote"'`) {
-		t.Fatalf("workDir should be shell-quoted via shellescape.Quote:\n%s", script)
+	// workDir is anchored via `cd`, but must be shell-quoted so a project path with
+	// shell metacharacters cannot break out of the cd.
+	if strings.Contains(cmd, `cd "/tmp/project with "quote""`) {
+		t.Fatalf("workDir must not be interpolated raw (double-quoted): %q", cmd)
 	}
-	// Validated safe session id flows through Quote unchanged (bare).
-	if !strings.Contains(script, `opencode export ses_parent_123`) {
-		t.Fatalf("opencode session id should flow through shellescape.Quote in the export command:\n%s", script)
+	if want := "cd " + shellescape.Quote(`/tmp/project with "quote"`); !strings.Contains(cmd, want) {
+		t.Fatalf("workDir should be shell-quoted in the cd anchor; want %q in %q", want, cmd)
 	}
 }

--- a/internal/session/instance_test.go
+++ b/internal/session/instance_test.go
@@ -2438,34 +2438,18 @@ func TestInstance_ForkOpenCode(t *testing.T) {
 		t.Errorf("ForkOpenCode() failed: %v", err)
 	}
 
-	// cmd is "bash '<script_path>'" - extract and read the script file
-	if !strings.HasPrefix(cmd, "bash '") {
-		t.Fatalf("ForkOpenCode() should return bash command, got: %s", cmd)
+	// Native fork: `opencode -s <parent-id> --fork`, no export/import clone script.
+	if !strings.Contains(cmd, "opencode -s ses_abc123def456ffe1234567890abcd --fork") {
+		t.Errorf("ForkOpenCode() should use native `opencode -s <parent> --fork`, got: %s", cmd)
 	}
-	scriptPath := strings.TrimPrefix(cmd, "bash '")
-	scriptPath = strings.TrimSuffix(scriptPath, "'")
-	scriptContent, err := os.ReadFile(scriptPath)
-	if err != nil {
-		t.Fatalf("Failed to read fork script at %s: %v", scriptPath, err)
-	}
-	script := string(scriptContent)
-
-	if !strings.Contains(script, "opencode export") {
-		t.Errorf("Fork script should use opencode export, got: %s", script)
-	}
-	if !strings.Contains(script, "opencode import") {
-		t.Errorf("Fork script should use opencode import, got: %s", script)
-	}
-	if !strings.Contains(script, "ses_abc123def456ffe1234567890abcd") {
-		t.Errorf("Fork script should include original session ID, got: %s", script)
-	}
-	// tmux set-environment removed: host-side SetEnvironment handles propagation
-	if strings.Contains(script, "tmux set-environment") {
-		t.Errorf("Fork script should NOT contain tmux set-environment (host-side handles it), got: %s", script)
+	for _, gone := range []string{"bash ", "opencode export", "opencode import", "tmux set-environment"} {
+		if strings.Contains(cmd, gone) {
+			t.Errorf("ForkOpenCode() should not reference the old clone path (%q), got: %s", gone, cmd)
+		}
 	}
 }
 
-func TestInstance_ForkOpenCode_QuotesScriptInputs(t *testing.T) {
+func TestInstance_ForkOpenCode_QuotesInputs(t *testing.T) {
 	workDir := filepath.Join(t.TempDir(), `project with "quote"`)
 	inst := NewInstanceWithTool("test", workDir, "opencode")
 	inst.OpenCodeSessionID = "ses_abc123"
@@ -2475,22 +2459,20 @@ func TestInstance_ForkOpenCode_QuotesScriptInputs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ForkOpenCode() failed: %v", err)
 	}
-	scriptPath := strings.TrimPrefix(cmd, "bash '")
-	scriptPath = strings.TrimSuffix(scriptPath, "'")
-	scriptContent, err := os.ReadFile(scriptPath)
-	if err != nil {
-		t.Fatalf("Failed to read fork script at %s: %v", scriptPath, err)
-	}
-	script := string(scriptContent)
 
-	if strings.Contains(script, fmt.Sprintf(`cd "%s"`, workDir)) {
-		t.Fatalf("workDir must not be interpolated inside double quotes: %s", script)
+	// The native fork command targets the parent session id via -s; the id is
+	// validated safe upstream (normalizeToolSessionID) so shellescape.Quote leaves
+	// it bare.
+	if want := "opencode -s " + shellescape.Quote(inst.OpenCodeSessionID) + " --fork"; !strings.Contains(cmd, want) {
+		t.Fatalf("fork command should target the quoted session id; want %q in %q", want, cmd)
 	}
-	if want := "cd " + shellescape.Quote(workDir); !strings.Contains(script, want) {
-		t.Fatalf("fork script should quote workDir with shellescape; want %q in %s", want, script)
+	// workDir is anchored into the command via `cd` (the multi-repo fork path needs
+	// it), but must be shell-quoted so a path with metacharacters can't break out.
+	if strings.Contains(cmd, fmt.Sprintf(`cd "%s"`, workDir)) {
+		t.Fatalf("workDir must not be interpolated raw (double-quoted): %q", cmd)
 	}
-	if want := "opencode export " + shellescape.Quote(inst.OpenCodeSessionID); !strings.Contains(script, want) {
-		t.Fatalf("fork script should quote OpenCode session ID; want %q in %s", want, script)
+	if want := "cd " + shellescape.Quote(workDir); !strings.Contains(cmd, want) {
+		t.Fatalf("workDir should be shell-quoted in the cd anchor; want %q in %q", want, cmd)
 	}
 }
 

--- a/internal/ui/fork_quick_test.go
+++ b/internal/ui/fork_quick_test.go
@@ -59,7 +59,7 @@ func TestForkInstanceDeps_OpenCodeUsesResolvedWorktreeDir(t *testing.T) {
 	// Exercise the deps.createInstance wiring directly — this is the exact seam
 	// Step 4 changes. Calling createInstance (not completeFork) keeps the test
 	// lean: no DetectOpenCodeSession goroutine and no start/multi-repo machinery.
-	// writeOpenCodeForkScript writes via os.CreateTemp, which works under any HOME.
+	// The OpenCode fork command is built in-process (no temp script), so this works under any HOME.
 	deps := defaultForkInstanceDeps()
 	inst, err := deps.createInstance(source, "oc parent (fork)", "", opts)
 	if err != nil {


### PR DESCRIPTION
## Summary

Replaces OpenCode's `export | sed-rewrite-id | import` clone with OpenCode's
native `--fork` flag for forked sessions. The launch command goes from a
generated self-deleting bash script to a direct:

```
cd <workDir> && opencode -s <parent-id> --fork
```

`--fork` branches the parent transcript into a fresh session while leaving the
parent intact. It has shipped since **opencode v1.1.54** (Feb 2026, PR
sst/opencode#11340); older binaries without it fail into the existing
recoverable error state, mirroring how `codex fork` is handled.

Net: **+87 / −147** across 4 files, deleting `writeOpenCodeForkScript` and its
temp-script machinery entirely.

## Behavior preserved

- **Deferred-launch pattern stays.** The one-shot fork command lives in
  `ForkStartCommand` (transient) while `Command` holds the stable `"opencode"`
  base, so a restart resumes the child via the async-detected session id rather
  than re-running `--fork` and re-forking the parent.
- **`cd <workDir>` anchor stays.** The multi-repo fork path repoints the tmux
  `WorkDir` to the `MultiRepoTempDir` container while async session detection
  matches by `ProjectPath` (`DetectOpenCodeSession`), so OpenCode must start in
  the requested repo/worktree dir for the child session to be discoverable.
- **Injection-safe.** `workDir` and the session id stay `shellescape.Quote`-wrapped
  (the id is also charset-validated upstream via `CanForkOpenCode`).
- **Env prefix applied once** by `buildOpenCodeCommand` at start time (the old
  script embedded its own, doubling it).

## Files

- `internal/session/instance.go` — rewrite `forkOpenCodeWithOptionsInWorkDir`
  to emit the native fork command; delete `writeOpenCodeForkScript`.
- `internal/session/instance_opencode_fork_test.go` — tests rewritten for the
  native fork shape (no temp script to read).
- `internal/session/instance_test.go` — `TestInstance_ForkOpenCode` and
  `TestInstance_ForkOpenCode_QuotesInputs` updated to the native command.
- `internal/ui/fork_quick_test.go` — stale comment fixed.

## Test plan

All green locally:

- [x] `go build ./...`
- [x] `gofmt -l internal/session/ internal/ui/` → empty
- [x] `go test ./internal/session/ -race -run 'ForkOpenCode|CreateForkedOpenCode|OpenCodeFork' -count=1` → 6 pass
- [x] `golangci-lint run ./internal/session/...` → 0 issues

> Pre-existing, unrelated: `TestUpdateStatus_ShellForegroundPromotion` fails
> identically on clean `main` (environment-sensitive tmux E2E reading the live
> tmux env); not touched by this change.

Draft pending a real-binary smoke test of the fork path against opencode ≥ v1.1.54.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined session forking through a more direct command execution approach, improving reliability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->