### PR TITLE
fix(tmux): idempotent kill + socket-complete existence cache

### DIFF
--- a/internal/tmux/ensure_pids_dead.go
+++ b/internal/tmux/ensure_pids_dead.go
@@ -175,5 +175,12 @@ func (s *Session) KillAndWait() error {
 		EnsurePIDsDead(oldPIDs, 3*time.Second)
 	}
 
+	// Killing an already-dead session is success (see Session.Kill): tmux
+	// `kill-session` exits non-zero for a session that no longer exists. CLI
+	// callers (`agent-deck remove` of a stopped session) must not fail on that.
+	if killErr != nil && !s.Exists() {
+		return nil
+	}
+
 	return killErr
 }

--- a/internal/tmux/kill_idempotent_test.go
+++ b/internal/tmux/kill_idempotent_test.go
@@ -1,0 +1,49 @@
+package tmux
+
+import "testing"
+
+// TestKill_NonexistentSessionReturnsNil pins that killing a tmux session that
+// no longer exists is treated as success, not failure.
+//
+// tmux `kill-session` exits non-zero ("can't find session") for an
+// already-dead session. Surfacing that as an error made the TUI's
+// archiveSession (and WebMutator.ArchiveSession) abort and silently fail to
+// persist the archive when re-archiving a session whose tmux was already gone
+// — the exact path hit after Unarchive, which clears the flag without
+// restarting tmux. See archiveSession in internal/ui/home.go.
+func TestKill_NonexistentSessionReturnsNil(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	s := NewSession("agent-deck-kill-idempotent-absent", t.TempDir())
+	if err := s.Kill(); err != nil {
+		t.Fatalf("Kill() on a nonexistent session should return nil, got: %v", err)
+	}
+}
+
+// TestKillAndWait_NonexistentSessionReturnsNil mirrors the above for the
+// synchronous CLI path (`agent-deck remove`), which also must not fail just
+// because the session was already stopped.
+func TestKillAndWait_NonexistentSessionReturnsNil(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	s := NewSession("agent-deck-killandwait-idempotent-absent", t.TempDir())
+	if err := s.KillAndWait(); err != nil {
+		t.Fatalf("KillAndWait() on a nonexistent session should return nil, got: %v", err)
+	}
+}
+
+// TestKill_LiveSessionThenSecondKillBothSucceed verifies the first kill of a
+// live session still works (returns nil) and that an immediately-repeated kill
+// of the now-dead session is also nil — the idempotency the archive flow relies
+// on.
+func TestKill_LiveSessionThenSecondKillBothSucceed(t *testing.T) {
+	skipIfNoTmuxBinary(t)
+	s := NewSession("agent-deck-kill-idempotent-live", t.TempDir())
+	if err := s.Start(""); err != nil {
+		t.Skipf("could not start tmux session in this environment: %v", err)
+	}
+	if err := s.Kill(); err != nil {
+		t.Fatalf("first Kill() of a live session should return nil, got: %v", err)
+	}
+	if err := s.Kill(); err != nil {
+		t.Fatalf("second Kill() of an already-dead session should return nil, got: %v", err)
+	}
+}

--- a/internal/tmux/multisocket_cache_test.go
+++ b/internal/tmux/multisocket_cache_test.go
@@ -1,0 +1,90 @@
+package tmux
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestSelectPipesPerSocket_OnePerDistinctAliveSocket pins the fix for the
+// multi-socket cache aliasing bug: RefreshAllActivities must probe one pipe per
+// distinct socket (each tmux server) rather than a single arbitrary pipe, which
+// only ever sees one server's sessions. Sessions on the other socket would
+// otherwise be absent from the cache and reported as tmux_missing.
+func TestSelectPipesPerSocket_OnePerDistinctAliveSocket(t *testing.T) {
+	pipes := map[string]*ControlPipe{
+		"a1": {sessionName: "a1", socketName: "agent-deck", alive: true},
+		"a2": {sessionName: "a2", socketName: "agent-deck", alive: true},
+		"d1": {sessionName: "d1", socketName: "", alive: true},
+		"x1": {sessionName: "x1", socketName: "other", alive: false}, // dead → skipped
+	}
+
+	got := selectPipesPerSocket(pipes)
+
+	sockets := map[string]int{}
+	for _, p := range got {
+		sockets[p.socketName]++
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected exactly one pipe per distinct alive socket (2), got %d: %v", len(got), sockets)
+	}
+	if sockets["agent-deck"] != 1 {
+		t.Fatalf("expected one pipe for socket 'agent-deck', got %d", sockets["agent-deck"])
+	}
+	if sockets[""] != 1 {
+		t.Fatalf("expected one pipe for the default socket, got %d", sockets[""])
+	}
+	if _, ok := sockets["other"]; ok {
+		t.Fatal("a dead pipe's socket must not be selected")
+	}
+}
+
+// TestSessionExists_NegativeCacheHitNotTrusted pins the core of the multi-socket
+// fix: a fresh cache that does NOT contain a session must not, by itself, declare
+// that session dead. The cache can transiently omit a live session whose socket
+// differs from the one the last refresh was sourced from. Exists() must fall
+// through to the live pipe / direct probe instead of trusting the negative.
+//
+// Deterministic without a real tmux server: prime a fresh cache that omits the
+// session, then register a live control pipe for it. Old behavior returned the
+// cached false immediately; the fix falls through and the live pipe answers true.
+func TestSessionExists_NegativeCacheHitNotTrusted(t *testing.T) {
+	oldPM := GetPipeManager()
+	defer SetPipeManager(oldPM)
+
+	// Default socket matches the session's socket so the cache guard applies —
+	// this is exactly the case that regressed (session's socket == default, yet
+	// the cache was built from a different socket and omits it).
+	SetDefaultSocketName("")
+	defer SetDefaultSocketName("")
+
+	const name = "agentdeck_live_but_uncached_9f1c"
+
+	// Fresh cache that contains some OTHER session but not `name` → a valid
+	// negative hit for `name`.
+	sessionCacheMu.Lock()
+	sessionCacheData = map[string]int64{"agentdeck_someone_else_0001": time.Now().Unix()}
+	sessionCacheTime = time.Now()
+	sessionCacheMu.Unlock()
+	defer func() {
+		sessionCacheMu.Lock()
+		sessionCacheData = nil
+		sessionCacheTime = time.Time{}
+		sessionCacheMu.Unlock()
+	}()
+
+	// A live control pipe proves the session is actually alive.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pm := NewPipeManager(ctx, nil)
+	pm.mu.Lock()
+	pm.pipes[name] = &ControlPipe{sessionName: name, socketName: "", alive: true}
+	pm.mu.Unlock()
+	SetPipeManager(pm)
+
+	s := &Session{Name: name, SocketName: ""}
+
+	if !s.Exists() {
+		t.Fatal("Exists() trusted a negative cache hit and declared a live session dead (multi-socket aliasing false negative)")
+	}
+}

--- a/internal/tmux/pipemanager.go
+++ b/internal/tmux/pipemanager.go
@@ -190,35 +190,71 @@ func (pm *PipeManager) GetWindowActivity(sessionName string) (int64, error) {
 	return ts, nil
 }
 
-// RefreshAllActivities sends a single list-windows command through any available
-// pipe to get activity timestamps for ALL sessions. This replaces the subprocess
-// call in RefreshSessionCache.
+// selectPipesPerSocket returns one alive pipe for each distinct socket among
+// the given pipes. `list-windows -a` only reports sessions on the server its
+// pipe is attached to, so a single arbitrary pipe misses every session living
+// on another socket. When agent-deck sessions are split across more than one
+// tmux server (e.g. some on the default socket, some under [tmux] socket_name),
+// querying just one pipe makes the others' sessions look gone — they flip to
+// StatusError/tmux_missing and can then be killed by restart machinery. Probing
+// one pipe per socket and merging keeps the cache complete. Dead pipes are
+// skipped. See the multi-socket cache aliasing note.
+func selectPipesPerSocket(pipes map[string]*ControlPipe) []*ControlPipe {
+	seen := make(map[string]bool)
+	var selected []*ControlPipe
+	for _, p := range pipes {
+		if p == nil || !p.IsAlive() {
+			continue
+		}
+		if seen[p.socketName] {
+			continue
+		}
+		seen[p.socketName] = true
+		selected = append(selected, p)
+	}
+	return selected
+}
+
+// RefreshAllActivities sends a list-windows command through one pipe per distinct
+// socket to get activity timestamps for ALL sessions across every tmux server we
+// have a live pipe to. This replaces the subprocess call in RefreshSessionCache.
+// Session names carry random suffixes, so cross-socket name collisions are
+// effectively impossible and merging by name is safe.
 func (pm *PipeManager) RefreshAllActivities() (map[string]int64, map[string][]WindowInfo, error) {
 	pm.mu.RLock()
-	// Find any alive pipe to send the command through
-	var pipe *ControlPipe
-	for _, p := range pm.pipes {
-		if p.IsAlive() {
-			pipe = p
-			break
-		}
-	}
+	pipes := selectPipesPerSocket(pm.pipes)
 	pm.mu.RUnlock()
 
-	if pipe == nil {
+	if len(pipes) == 0 {
 		return nil, nil, fmt.Errorf("no alive pipes available")
 	}
 
-	// Must use the same tmuxFieldSep as parseListWindowsOutput (shared with the
-	// subprocess path). A control client negotiates UTF-8, so TAB would usually
-	// survive here, but the delimiter MUST still match what the parser splits on.
-	// tmux control mode requires the format string double-quoted.
-	output, err := pipe.SendCommand(`list-windows -a -F "` + tmuxFmt("#{session_name}", "#{window_activity}", "#{window_index}", "#{window_name}") + `"`)
-	if err != nil {
-		return nil, nil, fmt.Errorf("list-windows via pipe: %w", err)
+	sessionCache := make(map[string]int64)
+	windowCache := make(map[string][]WindowInfo)
+	var firstErr error
+	gotAny := false
+	for _, pipe := range pipes {
+		// Must use the same tmuxFieldSep as parseListWindowsOutput (shared with the
+		// subprocess path). A control client negotiates UTF-8, so TAB would usually
+		// survive here, but the delimiter MUST still match what the parser splits on.
+		// tmux control mode requires the format string double-quoted.
+		output, err := pipe.SendCommand(`list-windows -a -F "` + tmuxFmt("#{session_name}", "#{window_activity}", "#{window_index}", "#{window_name}") + `"`)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		gotAny = true
+		sc, wc := parseListWindowsOutput(output)
+		maps.Copy(sessionCache, sc)
+		maps.Copy(windowCache, wc)
 	}
 
-	sessionCache, windowCache := parseListWindowsOutput(output)
+	if !gotAny {
+		return nil, nil, fmt.Errorf("list-windows via pipe: %w", firstErr)
+	}
+
 	return sessionCache, windowCache, nil
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2115,13 +2115,23 @@ var hasSessionProbeTimeout = 2 * time.Second
 // Uses cached session list when available (refreshed by RefreshExistingSessions)
 // Falls back to direct tmux call if cache is stale
 func (s *Session) Exists() bool {
-	// The session cache is populated by RefreshSessionCache against
-	// DefaultSocketName() only — entries describe the default tmux server
-	// alone. Sessions on isolated sockets must skip the cache, otherwise
-	// UpdateStatus would stamp StatusError on every poll for them (#755).
+	// #755: the cache describes the DefaultSocketName() server, so a session on
+	// a different socket must not be answered from it (a same-named entry is not
+	// the same session). Keep that guard.
+	//
+	// Within the guard, trust only a POSITIVE hit. A NEGATIVE/stale result is
+	// NOT trusted: the cache can transiently miss a live session when
+	// agent-deck sessions span multiple sockets (RefreshAllActivities merges one
+	// pipe per socket, and the subprocess fallback covers only DefaultSocketName,
+	// so a refresh sourced from the "wrong" socket omits this one). Confirm a
+	// "not in cache" reading with the live pipe / a direct probe on the
+	// session's OWN socket before declaring it dead. Trusting a negative cache
+	// hit flipped live sessions on a second socket to StatusError/tmux_missing
+	// (multi-socket cache aliasing), after which restart machinery could kill
+	// the still-running pane.
 	if strings.TrimSpace(s.SocketName) == DefaultSocketName() {
-		if exists, cacheValid := sessionExistsFromCache(s.Name); cacheValid {
-			return exists
+		if exists, cacheValid := sessionExistsFromCache(s.Name); cacheValid && exists {
+			return true
 		}
 	}
 
@@ -2367,6 +2377,17 @@ func (s *Session) Kill() error {
 	// Verify old processes are dead; escalate to SIGKILL if needed
 	if len(oldPIDs) > 0 {
 		go s.ensureProcessesDead(oldPIDs, 0)
+	}
+
+	// Killing a session that no longer exists is success, not failure: tmux
+	// `kill-session` exits non-zero ("can't find session") for an already-dead
+	// session. Treating that as fatal made archiveSession abort and silently
+	// fail to persist the archive when re-archiving a session whose tmux was
+	// already gone (the post-Unarchive path — Unarchive clears the flag without
+	// restarting tmux). Only surface the error if the session is genuinely
+	// still alive after the kill attempt.
+	if err != nil && !s.Exists() {
+		return nil
 	}
 
 	return err


### PR DESCRIPTION
## Summary
Two independent tmux session-management reliability fixes, isolated to the `internal/tmux` package.

### 1. Idempotent `Kill()`
Re-archiving an already-dead tmux session aborted with a fatal error because `Kill()` returned an error when the session no longer existed. `Kill()` now returns `nil` when the session is already gone after the kill, making the operation idempotent.

### 2. Socket-complete existence cache
The existence cache was built from a single arbitrary tmux pipe. When sessions were split across two tmux servers (sockets), live sessions on the *second* socket were flagged as missing — causing false "error" status and restart/duplicate-kill of a live session. The cache is now built from **all** sockets.

## Tests
- `kill_idempotent_test.go` — idempotent kill of an already-dead session.
- `multisocket_cache_test.go` — live sessions on a second socket are not flagged missing.

Both pass; `go build` / `go vet` clean.

## Scope
Touches only `internal/tmux/` (5 files) — no overlap with other in-flight changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Killing already-stopped sessions no longer returns errors.
  * Session detection across multiple tmux servers is now more reliable and properly validates cache state.

* **Tests**
  * Added tests for idempotent kill operations on nonexistent and live sessions.
  * Added tests for multi-socket session cache correctness and existence verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->