### PR TITLE
feat(cli): fleet fan-out — launch parented children & track completions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,8 @@
       "strict": false,
       "skills": [
         "./skills/agent-deck",
-        "./skills/session-share"
+        "./skills/session-share",
+        "./skills/fleet"
       ]
     }
   ]

--- a/cmd/agent-deck/cli_utils.go
+++ b/cmd/agent-deck/cli_utils.go
@@ -127,20 +127,58 @@ func splitFirstWord(raw string) (string, string) {
 // resolveGroupSelection picks the group for a new session using a fixed
 // priority order. Priority (issue #972):
 //  1. Explicit -g/--group always wins.
-//  2. Otherwise the cwd-derived project group wins.
-//  3. Parent-session group is the fallback only when no cwd-derived group is
+//  2. inheritGroup (launch --inherit-group): the parent-session group wins
+//     over the cwd-derived group. This keeps a fanned-out fleet co-located
+//     with its parent even when each child runs in its own worktree
+//     (e.g. .worktrees/<branch>, whose leaf folder would otherwise derive a
+//     junk per-branch group). Opt-in so it never regresses #972's conductor
+//     case, which relies on the cwd-derived group winning by default.
+//  3. Otherwise the cwd-derived project group wins.
+//  4. Parent-session group is the fallback only when no cwd-derived group is
 //     available (e.g. an empty project path mapping).
 //
-// Prior to #972 step 2 did not exist, so every conductor-spawned child
+// Prior to #972 step 3 did not exist, so every conductor-spawned child
 // silently inherited the conductor's `conductor` group.
-func resolveGroupSelection(currentGroup, cwdDerivedGroup, parentGroup string, explicitGroupProvided bool) string {
+func resolveGroupSelection(currentGroup, cwdDerivedGroup, parentGroup string, explicitGroupProvided, inheritGroup bool) string {
 	if explicitGroupProvided {
 		return currentGroup
+	}
+	if inheritGroup && parentGroup != "" {
+		return parentGroup
 	}
 	if cwdDerivedGroup != "" {
 		return cwdDerivedGroup
 	}
 	return parentGroup
+}
+
+// shouldInheritParentGroup decides whether a parented `launch` with no explicit
+// -g should adopt the parent's group (i.e. behave as if --inherit-group was
+// passed). It is the auto-default that makes a fanned-out fleet land with its
+// parent without anyone remembering the flag.
+//
+// Priority:
+//  1. An explicit -g always wins — never auto-inherit over a deliberate group.
+//  2. --inherit-group set → inherit.
+//  3. Otherwise inherit when the child path is a git LINKED worktree. A
+//     worktree's path-derived group is junk (the branch leaf, or `worktrees`),
+//     so a worktree child almost always belongs with its parent. This is the
+//     load-bearing fix: fleets fan out into worktrees, and they should stay
+//     co-located by default.
+//
+// pathIsLinkedWorktree is a thunk so the (process-spawning) git probe runs only
+// when steps 1–2 didn't already decide — and stays trivially unit-testable.
+// #972 is preserved: conductor children launch into separate REAL repos (main
+// working trees, not linked worktrees), so this returns false for them and the
+// cwd-derived project group still wins.
+func shouldInheritParentGroup(explicitGroupProvided, inheritGroupFlag bool, pathIsLinkedWorktree func() bool) bool {
+	if explicitGroupProvided {
+		return false
+	}
+	if inheritGroupFlag {
+		return true
+	}
+	return pathIsLinkedWorktree()
 }
 
 // resolveAddPath resolves the user-provided positional path arg for `agent-deck add`.

--- a/cmd/agent-deck/cli_utils_test.go
+++ b/cmd/agent-deck/cli_utils_test.go
@@ -334,6 +334,7 @@ func TestResolveGroupSelection(t *testing.T) {
 		cwdDerivedGroup       string
 		parentGroup           string
 		explicitGroupProvided bool
+		inheritGroup          bool
 		want                  string
 	}{
 		{
@@ -359,10 +360,65 @@ func TestResolveGroupSelection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveGroupSelection(tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided)
+			got := resolveGroupSelection(tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided, tt.inheritGroup)
 			if got != tt.want {
-				t.Fatalf("resolveGroupSelection(%q, %q, %q, %v) = %q, want %q",
-					tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided, got, tt.want)
+				t.Fatalf("resolveGroupSelection(%q, %q, %q, %v, %v) = %q, want %q",
+					tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided, tt.inheritGroup, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldInheritParentGroup(t *testing.T) {
+	tests := []struct {
+		name                  string
+		explicitGroupProvided bool
+		inheritGroupFlag      bool
+		isLinkedWorktree      bool
+		want                  bool
+		wantProbe             bool // whether the git worktree thunk should be consulted
+	}{
+		{
+			name:                  "explicit -g never auto-inherits, and skips the git probe",
+			explicitGroupProvided: true,
+			isLinkedWorktree:      true,
+			want:                  false,
+			wantProbe:             false,
+		},
+		{
+			name:             "--inherit-group inherits without probing git",
+			inheritGroupFlag: true,
+			isLinkedWorktree: false,
+			want:             true,
+			wantProbe:        false,
+		},
+		{
+			name:             "worktree child auto-inherits (the fleet default)",
+			isLinkedWorktree: true,
+			want:             true,
+			wantProbe:        true,
+		},
+		{
+			name:             "non-worktree child keeps cwd-derived group (e.g. conductor)",
+			isLinkedWorktree: false,
+			want:             false,
+			wantProbe:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probed := false
+			got := shouldInheritParentGroup(tt.explicitGroupProvided, tt.inheritGroupFlag, func() bool {
+				probed = true
+				return tt.isLinkedWorktree
+			})
+			if got != tt.want {
+				t.Fatalf("shouldInheritParentGroup(explicit=%v, flag=%v, worktree=%v) = %v, want %v",
+					tt.explicitGroupProvided, tt.inheritGroupFlag, tt.isLinkedWorktree, got, tt.want)
+			}
+			if probed != tt.wantProbe {
+				t.Fatalf("git worktree probe called = %v, want %v (lazy thunk must not run when steps 1-2 decide)", probed, tt.wantProbe)
 			}
 		})
 	}

--- a/cmd/agent-deck/issue972_launch_group_test.go
+++ b/cmd/agent-deck/issue972_launch_group_test.go
@@ -27,6 +27,7 @@ func TestLaunch_DerivesGroupFromCwdNotParent_RegressionFor972(t *testing.T) {
 		cwdDerivedGroup       string
 		parentGroup           string
 		explicitGroupProvided bool
+		inheritGroup          bool
 		want                  string
 	}{
 		{
@@ -35,6 +36,31 @@ func TestLaunch_DerivesGroupFromCwdNotParent_RegressionFor972(t *testing.T) {
 			cwdDerivedGroup: "agent-deck",
 			parentGroup:     "conductor",
 			want:            "agent-deck",
+		},
+		{
+			name:            "inherit-group: parent group wins over worktree cwd-derived group",
+			currentGroup:    "",
+			cwdDerivedGroup: "feat-profile",
+			parentGroup:     "doozyx/voice-chat",
+			inheritGroup:    true,
+			want:            "doozyx/voice-chat",
+		},
+		{
+			name:                  "inherit-group never overrides explicit -g",
+			currentGroup:          "ard",
+			cwdDerivedGroup:       "feat-profile",
+			parentGroup:           "doozyx/voice-chat",
+			explicitGroupProvided: true,
+			inheritGroup:          true,
+			want:                  "ard",
+		},
+		{
+			name:            "inherit-group with empty parent falls back to cwd-derived",
+			currentGroup:    "",
+			cwdDerivedGroup: "feat-profile",
+			parentGroup:     "",
+			inheritGroup:    true,
+			want:            "feat-profile",
 		},
 		{
 			name:                  "explicit -g still wins over both cwd-derived and parent",
@@ -62,10 +88,10 @@ func TestLaunch_DerivesGroupFromCwdNotParent_RegressionFor972(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := resolveGroupSelection(tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided)
+			got := resolveGroupSelection(tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided, tt.inheritGroup)
 			if got != tt.want {
-				t.Fatalf("resolveGroupSelection(curr=%q, cwd=%q, parent=%q, explicit=%v) = %q, want %q",
-					tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided, got, tt.want)
+				t.Fatalf("resolveGroupSelection(curr=%q, cwd=%q, parent=%q, explicit=%v, inherit=%v) = %q, want %q",
+					tt.currentGroup, tt.cwdDerivedGroup, tt.parentGroup, tt.explicitGroupProvided, tt.inheritGroup, got, tt.want)
 			}
 		})
 	}

--- a/cmd/agent-deck/launch_assert_done_test.go
+++ b/cmd/agent-deck/launch_assert_done_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyAssertDoneAppendsSentinel(t *testing.T) {
+	got := applyAssertDone("do the thing", true)
+	if !strings.Contains(got, "===AGENTDECK_DONE===") {
+		t.Fatalf("expected sentinel instruction appended, got: %q", got)
+	}
+	if !strings.HasPrefix(got, "do the thing") {
+		t.Fatalf("expected original message preserved, got: %q", got)
+	}
+}
+
+func TestApplyAssertDoneDisabledIsNoop(t *testing.T) {
+	if got := applyAssertDone("msg", false); got != "msg" {
+		t.Fatalf("expected no-op when disabled, got: %q", got)
+	}
+}
+
+func TestApplyAssertDoneEmptyMessageStaysEmpty(t *testing.T) {
+	if got := applyAssertDone("", true); got != "" {
+		t.Fatalf("expected empty message untouched (nothing to attach to), got: %q", got)
+	}
+}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -13,6 +13,24 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/vcs"
 )
 
+// assertDoneInstruction is appended to a child's initial message so it ends its
+// final turn with the #1186 completion sentinel. The completion ledger and the
+// parent inbox both key off this line; without it "done" is never trustworthy.
+const assertDoneInstruction = "\n\n## Final step — assert completion\n" +
+	"When the task is fully done, print exactly this as the last line of your final message:\n" +
+	"  ===AGENTDECK_DONE=== status=ok summary=<what you accomplished, one line>\n" +
+	"Use status=fail if you could not complete it; put the blocker in the summary."
+
+// applyAssertDone appends the completion-sentinel instruction when enabled and
+// there is an initial message to attach it to. A no-op for an empty message
+// (nothing to append to) or when disabled.
+func applyAssertDone(message string, enabled bool) string {
+	if !enabled || strings.TrimSpace(message) == "" {
+		return message
+	}
+	return message + assertDoneInstruction
+}
+
 // handleLaunch combines add + start + optional send into a single command.
 // It creates a new session, starts it, and optionally sends an initial message.
 func handleLaunch(profile string, args []string) {
@@ -27,9 +45,17 @@ func handleLaunch(profile string, args []string) {
 	message := fs.String("message", "", "Initial message to send once agent is ready")
 	messageShort := fs.String("m", "", "Initial message to send (short)")
 	noWait := fs.Bool("no-wait", false, "Don't wait for agent to be ready before sending message")
+	assertDone := fs.Bool("assert-done", false, "Append a completion-sentinel instruction to the message (default on for -c claude)")
+	noAssertDone := fs.Bool("no-assert-done", false, "Disable the completion-sentinel instruction")
 	parent := fs.String("parent", "", "Parent session (creates sub-session, inherits group)")
 	parentShort := fs.String("p", "", "Parent session (short)")
 	noParent := fs.Bool("no-parent", false, "Disable automatic parent linking")
+	// Keep a fanned-out child in the parent's group instead of the cwd-derived
+	// group. Without this, a child launched into a worktree (.worktrees/<branch>)
+	// derives its group from that leaf folder and lands in a per-branch group
+	// detached from the parent. Opt-in so #972 (conductor children -> project
+	// group) is preserved by default. Used by the fleet skill.
+	inheritGroup := fs.Bool("inherit-group", false, "Place the child in the parent session's group instead of the cwd-derived group (auto-applied for git worktree children; use this to force it for non-worktree paths)")
 	noTransitionNotify := fs.Bool("no-transition-notify", false, "Suppress transition event notifications to parent session")
 	// #697: conductor-friendly title lock. Prevents Claude's session name
 	// from overwriting the agent-deck title.
@@ -123,6 +149,7 @@ func handleLaunch(profile string, args []string) {
 		fmt.Println("  agent-deck launch . -c claude --mcp memory -m \"Research topic X\"")
 		fmt.Println("  agent-deck launch . -c claude --channel plugin:telegram@user/repo -m \"Listen for messages\"")
 		fmt.Println("  agent-deck launch . -c claude -m \"Fix bug\" --no-wait")
+		fmt.Println("  agent-deck launch . -c claude -m \"Refactor X\"   # auto-appends completion sentinel (see session children)")
 		fmt.Println("  agent-deck launch . -c \"codex --dangerously-bypass-approvals-and-sandbox\"")
 		fmt.Println("  agent-deck launch . -g ard --no-parent -c claude -m \"Run review\"")
 		fmt.Println("  agent-deck launch . -c claude -w feature/new -b -m \"Start work\"")
@@ -168,6 +195,20 @@ func handleLaunch(profile string, args []string) {
 		os.Exit(1)
 	}
 	initialMessage := mergeFlags(*message, *messageShort)
+
+	// --assert-done: append the completion-sentinel instruction so the child
+	// reliably reports back via the ledger / parent inbox. Default-on for
+	// Claude children (a completion signal nobody requests is useless);
+	// --no-assert-done always wins.
+	assertDoneTool := firstNonEmpty(sessionCommandTool, detectTool(sessionCommandInput))
+	assertDoneOn := *assertDone
+	if !*assertDone && !*noAssertDone && session.IsClaudeCompatible(assertDoneTool) {
+		assertDoneOn = true
+	}
+	if *noAssertDone {
+		assertDoneOn = false
+	}
+	initialMessage = applyAssertDone(initialMessage, assertDoneOn)
 
 	// Resolve worktree flags
 	wtBranch := *worktreeBranch
@@ -266,6 +307,16 @@ func handleLaunch(profile string, args []string) {
 	// conductor's own group (`conductor`). The parent group is now a
 	// fallback for path mappings that produce no group.
 	cwdDerivedGroup := session.GroupPathForProject(path)
+	// A worktree child auto-inherits its parent's group (issue: fleets fanned
+	// into worktrees scattered into junk per-branch / `worktrees` groups, or
+	// a deliberately-named group, detached from the parent). `path` is already
+	// the final worktree path here (the -w branch above reassigns it before
+	// this point). git.IsLinkedWorktree returns false for main working trees,
+	// so #972's conductor children (separate real repos) keep cwd-derived group.
+	// The thunk defers the git probe until shouldInheritParentGroup needs it.
+	inheritParentGroup := shouldInheritParentGroup(explicitGroupProvided, *inheritGroup, func() bool {
+		return git.IsLinkedWorktree(path)
+	})
 	var parentInstance *session.Instance
 	if sessionParent != "" {
 		var errMsg string
@@ -278,11 +329,11 @@ func handleLaunch(profile string, args []string) {
 			out.Error("cannot create sub-session of a sub-session (single level only)", ErrCodeInvalidOperation)
 			os.Exit(1)
 		}
-		sessionGroup = resolveGroupSelection(sessionGroup, cwdDerivedGroup, parentInstance.GroupPath, explicitGroupProvided)
+		sessionGroup = resolveGroupSelection(sessionGroup, cwdDerivedGroup, parentInstance.GroupPath, explicitGroupProvided, inheritParentGroup)
 	} else if !*noParent {
 		parentInstance = resolveAutoParentInstance(instances)
 		if parentInstance != nil && !parentInstance.IsSubSession() {
-			sessionGroup = resolveGroupSelection(sessionGroup, cwdDerivedGroup, parentInstance.GroupPath, explicitGroupProvided)
+			sessionGroup = resolveGroupSelection(sessionGroup, cwdDerivedGroup, parentInstance.GroupPath, explicitGroupProvided, inheritParentGroup)
 		} else {
 			parentInstance = nil
 		}

--- a/cmd/agent-deck/launch_cmd.go
+++ b/cmd/agent-deck/launch_cmd.go
@@ -47,7 +47,7 @@ func handleLaunch(profile string, args []string) {
 	noWait := fs.Bool("no-wait", false, "Don't wait for agent to be ready before sending message")
 	assertDone := fs.Bool("assert-done", false, "Append a completion-sentinel instruction to the message (default on for -c claude)")
 	noAssertDone := fs.Bool("no-assert-done", false, "Disable the completion-sentinel instruction")
-	parent := fs.String("parent", "", "Parent session (creates sub-session, inherits group)")
+	parent := fs.String("parent", "", "Parent session (creates sub-session; group is cwd-derived by default — auto-inherits the parent's group for git worktree children or with --inherit-group)")
 	parentShort := fs.String("p", "", "Parent session (short)")
 	noParent := fs.Bool("no-parent", false, "Disable automatic parent linking")
 	// Keep a fanned-out child in the parent's group instead of the cwd-derived

--- a/cmd/agent-deck/main.go
+++ b/cmd/agent-deck/main.go
@@ -37,7 +37,7 @@ import (
 	"github.com/asheshgoplani/agent-deck/internal/web"
 )
 
-var Version = "1.9.77" // overridden at build time via -ldflags "-X main.Version=..."
+var Version = "1.10.4" // overridden at build time via -ldflags "-X main.Version=..."
 
 // Table column widths for list command output
 const (
@@ -1369,11 +1369,11 @@ func handleAdd(profile string, args []string) {
 		// cwd-derived group is not available here. Passing "" preserves
 		// handleAdd's existing behavior; the #972 cwd-over-parent priority
 		// is wired into `launch` where path is already known at this point.
-		sessionGroup = resolveGroupSelection(sessionGroup, "", parentInstance.GroupPath, explicitGroupProvided)
+		sessionGroup = resolveGroupSelection(sessionGroup, "", parentInstance.GroupPath, explicitGroupProvided, false)
 	} else if !*noParent {
 		parentInstance = resolveAutoParentInstance(instances)
 		if parentInstance != nil && !parentInstance.IsSubSession() {
-			sessionGroup = resolveGroupSelection(sessionGroup, "", parentInstance.GroupPath, explicitGroupProvided)
+			sessionGroup = resolveGroupSelection(sessionGroup, "", parentInstance.GroupPath, explicitGroupProvided, false)
 		} else {
 			parentInstance = nil
 		}

--- a/cmd/agent-deck/session_children_test.go
+++ b/cmd/agent-deck/session_children_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/session"
+)
+
+func TestChildrenOfFiltersByParent(t *testing.T) {
+	a := &session.Instance{ID: "p"}
+	b := &session.Instance{ID: "c1", ParentSessionID: "p"}
+	c := &session.Instance{ID: "c2", ParentSessionID: "other"}
+	d := &session.Instance{ID: "c3", ParentSessionID: "p"}
+	got := childrenOf("p", []*session.Instance{a, b, c, d})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(got))
+	}
+	if got[0].ID != "c1" || got[1].ID != "c3" {
+		t.Fatalf("unexpected children: %v %v", got[0].ID, got[1].ID)
+	}
+}

--- a/cmd/agent-deck/session_cmd.go
+++ b/cmd/agent-deck/session_cmd.go
@@ -78,6 +78,8 @@ func handleSession(profile string, args []string) {
 		handleSessionSendKeys(profile, args[1:])
 	case "output":
 		handleSessionOutput(profile, args[1:])
+	case "children":
+		handleSessionChildren(profile, args[1:])
 	case "search":
 		handleSessionSearch(profile, args[1:])
 	case "help", "--help", "-h":
@@ -110,6 +112,7 @@ func printSessionHelp() {
 	fmt.Println("  move <id> <path>        Move session to a new path (migrates Claude history)")
 	fmt.Println("  send <id> <message>     Send a message to a running session")
 	fmt.Println("  output <id>             Get the last response from a session")
+	fmt.Println("  children [id]           List sub-sessions with status + last completion")
 	fmt.Println("  search <query>          Search message content across Claude sessions")
 	fmt.Println("  set-parent <id> <parent>  Link session as sub-session of parent")
 	fmt.Println("  unset-parent <id>       Remove sub-session link")
@@ -3506,6 +3509,103 @@ func matchInstanceDataByTmuxName(instances []*session.InstanceData, tmuxSessionN
 // TestIsValidSessionColor table in session_color_test.go keep working.
 func isValidSessionColor(v string) bool {
 	return session.IsValidSessionColor(v)
+}
+
+// childrenOf returns the direct sub-sessions of parentID, preserving the input
+// order. Pure helper so the filtering is unit-testable without a live registry.
+func childrenOf(parentID string, instances []*session.Instance) []*session.Instance {
+	var out []*session.Instance
+	for _, inst := range instances {
+		if inst != nil && inst.ParentSessionID == parentID {
+			out = append(out, inst)
+		}
+	}
+	return out
+}
+
+// handleSessionChildren implements `session children [id]` — a read-only fleet
+// view that lists a session's sub-sessions with live status and each child's
+// last asserted completion (from the non-destructive completion ledger). It
+// defaults to the current session and never clears the inbox, so a parent can
+// poll it from any chat without disturbing delivery.
+func handleSessionChildren(profile string, args []string) {
+	fs := flag.NewFlagSet("session children", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session children [id|title] [options]")
+		fmt.Println()
+		fmt.Println("List a session's sub-sessions with live status and last completion.")
+		fmt.Println("Defaults to the current session. Read-only; does not clear the inbox.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+	identifier := fs.Arg(0)
+	quietMode := *quiet || *quietShort
+	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	_, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+	// Default to the caller's own session. resolveSelfSessionID prefers
+	// AGENTDECK_INSTANCE_ID (the authoritative full id) over the tmux session
+	// name, whose suffix is only a short hash and won't resolve.
+	if strings.TrimSpace(identifier) == "" {
+		self, err := resolveSelfSessionID()
+		if err != nil {
+			out.Error(err.Error(), ErrCodeNotFound)
+			os.Exit(2)
+		}
+		identifier = self
+	}
+	parent, errMsg, errCode := ResolveSession(identifier, instances)
+	if parent == nil {
+		out.Error(errMsg, errCode)
+		os.Exit(2)
+	}
+
+	kids := childrenOf(parent.ID, instances)
+	session.RefreshInstancesForCLIStatus(kids)
+
+	type childRow struct {
+		ID          string `json:"id"`
+		Title       string `json:"title"`
+		Status      string `json:"status"`
+		DoneStatus  string `json:"done_status,omitempty"`
+		DoneSummary string `json:"done_summary,omitempty"`
+		DoneAt      string `json:"done_at,omitempty"`
+	}
+	rows := make([]childRow, 0, len(kids))
+	var human strings.Builder
+	fmt.Fprintf(&human, "Children of %s (%s):\n", parent.Title, parent.ID)
+	for _, k := range kids {
+		_ = k.UpdateStatus()
+		row := childRow{ID: k.ID, Title: k.Title, Status: StatusString(k.Status)}
+		if e, ok := session.ReadLedgerEntry(k.ID); ok {
+			row.DoneStatus = e.Status
+			row.DoneSummary = e.Summary
+			if !e.FinishedAt.IsZero() {
+				row.DoneAt = e.FinishedAt.Format(time.RFC3339)
+			}
+		}
+		rows = append(rows, row)
+		done := row.DoneStatus
+		if done == "" {
+			done = "-"
+		}
+		fmt.Fprintf(&human, "  %s  %-20s  %-8s  done=%s  %s\n", k.ID, k.Title, row.Status, done, row.DoneSummary)
+	}
+	if len(kids) == 0 {
+		human.WriteString("  (no sub-sessions)\n")
+	}
+	out.Print(human.String(), map[string]interface{}{"parent": parent.ID, "children": rows})
 }
 
 // handleSessionSearch implements issue #483 — search across Claude session

--- a/docs/plans/2026-06-13-fleet-fanout-cli-design.md
+++ b/docs/plans/2026-06-13-fleet-fanout-cli-design.md
@@ -1,0 +1,177 @@
+# Fleet fan-out CLI — design
+
+**Date:** 2026-06-13
+**Status:** Approved (design); implementation plan pending
+**Branch:** `feat/fleet-fanout-cli`
+
+## Problem
+
+From inside a Claude session running under agent-deck, a user wants to fan out
+several child sessions (e.g. "launch 5 sessions"), let them work independently,
+and later — from any chat in the parent session, or from the TUI — check which
+children are done and read their results. The check must be **non-blocking**:
+inspecting progress from the parent must never freeze the parent's other work,
+and must not consume/destroy events that another chat or the conductor relies on.
+
+### What already works (verified)
+
+- `agent-deck launch <path> -c claude -m "<task>"` creates a real, registered
+  session in its own detached tmux process. It **auto-parents** the child to the
+  launching session by default (`launch_cmd.go` — the `!*noParent` path), so
+  children become sub-sessions of the parent and appear nested under it in the
+  TUI session list with live status dots.
+- Children run fully independently (separate tmux processes / context windows);
+  closing the parent does not stop them.
+- `agent-deck list --json` shows all sessions; `agent-deck session output <id>
+  [--json]` returns a child's latest response.
+- A completion sentinel exists: a worker ending its final turn with
+  `===AGENTDECK_DONE=== status=<ok|fail> summary=<one line>` is detected on the
+  `Stop` edge (`internal/session/done_sentinel.go`,
+  `internal/session/hook_watcher.go`) and delivered to the parent as a `[DONE]`
+  event carrying `done_status` / `done_summary`
+  (`internal/session/taskworker.go:DeliverCompletion`).
+
+### The gap
+
+Completion (`done_status` / `done_summary`) currently lives **only** as a
+transient event in the parent's durable outbox. The only way to read it is
+`agent-deck inbox drain <session-id>`, which is **destructive** ("reading clears
+the inbox") and last-wins per child. Consequences:
+
+1. A parent cannot peek "which of my fleet is done" repeatedly without stealing
+   those events from another chat / the conductor heartbeat.
+2. Completion is not a queryable property of a session — `list --json` does not
+   expose it, so the TUI / CLI cannot show it as state.
+3. Children only emit the sentinel if the operator remembers to append the
+   "assert completion" instruction to every launch message; otherwise completion
+   is never trustworthy.
+
+## Goals
+
+- Fan out N children from the parent session; they appear in the TUI list nested
+  under the parent and run independently.
+- From the parent (any chat) or the TUI, read each child's status + last
+  completion (ok/fail + summary) on demand, **non-blocking and non-destructive**.
+- Make the completion signal reliable by default for Claude children.
+
+## Non-goals
+
+- **No blocking `session wait`.** Explicitly excluded — it would freeze the
+  parent's other chats. The peek-and-collect loop replaces it.
+- **No multi-spec / manifest `launch`.** Launch stays one-session-per-call;
+  callers loop it. A manifest format is scope creep.
+- The consumer-facing skill that documents the loop is a **follow-up**, not part
+  of this spec.
+
+## Design
+
+Three changes, all within the existing CLI; no new top-level noun.
+
+### 1. Persist last completion on the session record (core enabler)
+
+When the Stop-hook completion sentinel is detected, in addition to delivering the
+existing outbox event, persist onto the child's `Instance` record:
+
+- `done_status` — `ok` | `fail`
+- `done_summary` — the one-line summary (already capped via `capDoneSummary`)
+- `done_at` — timestamp of detection
+
+Semantics:
+
+- **Last-wins per child**, mirroring current outbox behavior. A genuinely new
+  completion (different summary) overwrites; re-reading the same sentinel does
+  not change it.
+- This makes completion a **queryable property**, independent of the destructive
+  outbox. The outbox path is unchanged — conductor heartbeats still
+  `inbox drain` as before.
+- `list --json` gains `done_status` / `done_summary` / `done_at` fields
+  (omitempty), so the TUI and any CLI consumer can render completion as state.
+
+### 2. Non-destructive fleet view: `agent-deck session children [<id>] --json`
+
+New read-only subcommand. `<id>` defaults to the current session (auto-detected,
+same as `session current`). Lists the session's direct sub-sessions with, per
+child:
+
+- `id`, `title`
+- live `status` (running / waiting / idle / error)
+- persisted `done_status` / `done_summary` / `done_at` (from change 1)
+
+Read-only — it **never** clears the inbox. This is the parent's on-demand "who's
+done" call; safe to run from any chat, as often as wanted. To read a finished
+child's full transcript, the existing `session output <id> --json` is used.
+
+Human-readable default output; `--json` for programmatic use.
+
+### 3. Reliable signaling: `launch --assert-done`
+
+`launch` gains `--assert-done` (and `--no-assert-done`). When on, it appends the
+standard completion-sentinel instruction to the child's initial `-m` message:
+
+```
+## Final step — assert completion
+When the task is fully done, print exactly this as the last line of your final message:
+  ===AGENTDECK_DONE=== status=ok summary=<what you accomplished, one line>
+Use status=fail if you could not complete it; put the blocker in the summary.
+```
+
+**Default-on for `-c claude` children** (opt out with `--no-assert-done`).
+Rationale: a completion signal nobody remembers to request is useless; the whole
+non-blocking-check story depends on children reliably asserting done. Non-Claude
+tools are unaffected unless explicitly enabled.
+
+## End-to-end flow
+
+```
+# Parent session fans out 5 children (looped from inside the parent):
+for i in 1..5: agent-deck launch <path_i> -c claude --assert-done -m "<task_i>"
+#   → 5 detached sessions, auto-parented to this session, visible nested in TUI.
+
+# Parent keeps working. Whenever convenient, from any chat:
+agent-deck session children --json
+#   → [{id, title, status, done_status, done_summary, done_at}, ...]  (non-destructive)
+
+# For any child showing done_status, pull its full result:
+agent-deck session output <child-id> --json
+```
+
+No step blocks the parent; nothing is consumed by checking.
+
+## Components touched
+
+- `internal/session/` — completion persistence on the `Instance` record at the
+  sentinel-detection site (near `hook_watcher.go` / `taskworker.go`); JSON
+  serialization fields; `list --json` surfacing.
+- `cmd/agent-deck/session_cmd.go` — new `children` subcommand.
+- `cmd/agent-deck/launch_cmd.go` — `--assert-done` / `--no-assert-done` flag and
+  message-append logic; default-on gating for `-c claude`.
+- Help text / examples for the above.
+
+## Error handling
+
+- `session children` on a session with no sub-sessions → empty list (not an
+  error).
+- `session children <id>` for an unknown/ambiguous id → existing
+  `ResolveSession` error path.
+- Malformed completion sentinels remain ignored (current behavior); persistence
+  only happens for a valid `status`.
+- `--assert-done` with no `-m` message → append nothing and warn (there is no
+  initial message to attach the instruction to), or document that the instruction
+  is only injected when an initial message is present. (Decide in plan.)
+
+## Testing
+
+- Unit: sentinel detection persists `done_status`/`done_summary`/`done_at` on the
+  record; last-wins on re-detection; malformed sentinel does not persist.
+- Unit: `launch --assert-done` appends the instruction to the message; default-on
+  for `-c claude`, off for other tools; `--no-assert-done` suppresses it.
+- CLI: `session children --json` returns parented children with completion fields
+  and does **not** clear the inbox (assert outbox still drainable afterward).
+- Regression: `inbox drain` behavior unchanged; non-parented (`--no-parent`)
+  children do not appear under `session children`.
+
+## Packaging (follow-up, out of scope here)
+
+A thin skill in the user's claude-setup repo documenting the loop:
+`launch --assert-done` ×N → keep working → `session children --json` →
+`session output <id>`. Authored after the CLI changes land.

--- a/docs/plans/2026-06-13-fleet-fanout-cli-plan.md
+++ b/docs/plans/2026-06-13-fleet-fanout-cli-plan.md
@@ -1,0 +1,530 @@
+# Fleet fan-out CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a parent agent-deck session fan out N child sessions and, non-blockingly, read each child's status + last completion (ok/fail + summary) on demand from any chat.
+
+**Architecture:** Three changes in the existing Go CLI. (1) A new durable, non-destructive **completion ledger** file-store (mirroring the proven `CompletionRecord` pattern but in its own directory, so it does not collide with the task-worker claim-guard semantics) written at both the interactive done-signal emit site and the task-worker path. (2) A read-only `session children` subcommand that merges live status with ledger entries. (3) A `launch --assert-done` flag (default-on for Claude) that appends the completion-sentinel instruction to the child's initial message.
+
+**Tech Stack:** Go 1.24, standard library only. Tests via `go test`. Spec: `docs/superpowers/specs/2026-06-13-fleet-fanout-cli-design.md`.
+
+**Design refinement vs spec:** The spec said "persist completion on the session record." Implementation uses a dedicated ledger file-store instead of new `Instance` SQLite columns — lower risk (no schema migration) and avoids overloading the existing `completions/` claim store, whose presence makes the daemon stand down (`transition_daemon.go:311`). Same observable behavior: completion becomes a non-destructively queryable property.
+
+---
+
+## File Structure
+
+- Create: `internal/session/completion_ledger.go` — ledger entry type + atomic write / non-destructive read / profile load.
+- Create: `internal/session/completion_ledger_test.go` — ledger unit tests.
+- Modify: `internal/session/transition_daemon.go:340-344` — write ledger entry at the interactive emit site.
+- Modify: `internal/session/taskworker.go:246-250` — write ledger entry for the task-worker path.
+- Modify: `cmd/agent-deck/session_cmd.go` — add `children` subcommand + dispatch + help.
+- Create: `cmd/agent-deck/session_children_test.go` — children-command filtering test.
+- Modify: `cmd/agent-deck/launch_cmd.go` — `--assert-done` / `--no-assert-done` flag + message append.
+- Create: `cmd/agent-deck/launch_assert_done_test.go` — assert-done append unit test.
+
+---
+
+### Task 1: Completion ledger store
+
+**Files:**
+- Create: `internal/session/completion_ledger.go`
+- Test: `internal/session/completion_ledger_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package session
+
+import "testing"
+
+func TestCompletionLedgerWriteReadLastWins(t *testing.T) {
+	t.Setenv("AGENT_DECK_TEST_PROFILE", "ledgertest")
+	if _, ok := ReadLedgerEntry("child-1"); ok {
+		t.Fatalf("expected no entry before write")
+	}
+	if err := WriteLedgerEntry(CompletionLedgerEntry{ChildID: "child-1", Profile: "p", Title: "T", Status: "ok", Summary: "first"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := WriteLedgerEntry(CompletionLedgerEntry{ChildID: "child-1", Profile: "p", Title: "T", Status: "fail", Summary: "second"}); err != nil {
+		t.Fatalf("write 2: %v", err)
+	}
+	got, ok := ReadLedgerEntry("child-1")
+	if !ok {
+		t.Fatalf("expected entry after write")
+	}
+	if got.Status != "fail" || got.Summary != "second" {
+		t.Fatalf("last-wins failed: got %+v", got)
+	}
+}
+
+func TestCompletionLedgerWriteRejectsEmptyID(t *testing.T) {
+	if err := WriteLedgerEntry(CompletionLedgerEntry{ChildID: "  "}); err == nil {
+		t.Fatalf("expected error on empty child id")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/doozyx/DoozyX/Adaptam/ui/agent-deck && go test ./internal/session/ -run TestCompletionLedger -v`
+Expected: FAIL — undefined `CompletionLedgerEntry`, `WriteLedgerEntry`, `ReadLedgerEntry`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Mirror the existing `taskworker.go` record store. Reuse `safeRecordName` (same package) and `runtimeDataPath`.
+
+```go
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CompletionLedgerEntry is the durable, non-destructive last-known completion
+// for a child session. Unlike the task-worker CompletionRecord (whose presence
+// makes the daemon stand down from poll-inference), the ledger is purely
+// informational: it records the most recent asserted completion so a parent can
+// query "which of my fleet finished" without consuming any delivery event.
+// Last-wins per child.
+type CompletionLedgerEntry struct {
+	ChildID    string    `json:"child_id"`
+	Profile    string    `json:"profile"`
+	Title      string    `json:"title,omitempty"`
+	Status     string    `json:"status"` // "ok" | "fail"
+	Summary    string    `json:"summary,omitempty"`
+	FinishedAt time.Time `json:"finished_at"`
+}
+
+func completionLedgerDir() (string, error) {
+	return runtimeDataPath("completion-ledger")
+}
+
+func completionLedgerPath(childID string) (string, error) {
+	dir, err := completionLedgerDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, safeRecordName(childID)+".json"), nil
+}
+
+// WriteLedgerEntry persists an entry atomically (tmp + rename), last-wins.
+func WriteLedgerEntry(e CompletionLedgerEntry) error {
+	if strings.TrimSpace(e.ChildID) == "" {
+		return errors.New("completion ledger: empty child id")
+	}
+	if e.FinishedAt.IsZero() {
+		e.FinishedAt = time.Now()
+	}
+	path, err := completionLedgerPath(e.ChildID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// ReadLedgerEntry returns the last-known completion for a child, if any. Read
+// is non-destructive.
+func ReadLedgerEntry(childID string) (CompletionLedgerEntry, bool) {
+	path, err := completionLedgerPath(childID)
+	if err != nil {
+		return CompletionLedgerEntry{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return CompletionLedgerEntry{}, false
+	}
+	var e CompletionLedgerEntry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return CompletionLedgerEntry{}, false
+	}
+	return e, true
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/doozyx/DoozyX/Adaptam/ui/agent-deck && go test ./internal/session/ -run TestCompletionLedger -v`
+Expected: PASS. (If `runtimeDataPath` is not isolated by `AGENT_DECK_TEST_PROFILE`, the test still passes because it writes/reads the same real dir; the assertions are self-contained for `child-1`. Verify it does not error.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/session/completion_ledger.go internal/session/completion_ledger_test.go
+git commit -m "feat(session): add non-destructive completion ledger store"
+```
+
+---
+
+### Task 2: Write ledger at the interactive emit site
+
+**Files:**
+- Modify: `internal/session/transition_daemon.go` (inside `emitDoneSignals`, right after `d.lastDone[profile][id] = sig`)
+
+- [ ] **Step 1: Add the ledger write**
+
+After the existing line `d.lastDone[profile][id] = sig` (around line 343), append:
+
+```go
+		_ = WriteLedgerEntry(CompletionLedgerEntry{
+			ChildID:    id,
+			Profile:    profile,
+			Title:      inst.Title,
+			Status:     sig.Status,
+			Summary:    sig.Summary,
+			FinishedAt: hs.UpdatedAt,
+		})
+```
+
+Rationale: this is the interactive (persistent-session) done path. The write is best-effort (`_ =`) — a ledger failure must never block the existing notification.
+
+- [ ] **Step 2: Build**
+
+Run: `cd /Users/doozyx/DoozyX/Adaptam/ui/agent-deck && go build ./...`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/session/transition_daemon.go
+git commit -m "feat(session): record interactive completions to the ledger"
+```
+
+---
+
+### Task 3: Write ledger for the task-worker path
+
+**Files:**
+- Modify: `internal/session/taskworker.go` (inside `RunTaskWorker`, after the finalized record is written ~line 247)
+
+- [ ] **Step 1: Add the ledger write**
+
+In `RunTaskWorker`, after `if err := WriteCompletionRecord(rec); err != nil { return rec, err }` and before `return rec, nil`, add:
+
+```go
+	if strings.TrimSpace(rec.Status) != "" {
+		_ = WriteLedgerEntry(CompletionLedgerEntry{
+			ChildID:    rec.ChildID,
+			Profile:    rec.Profile,
+			Title:      rec.Title,
+			Status:     rec.Status,
+			Summary:    rec.Summary,
+			FinishedAt: rec.FinishedAt,
+		})
+	}
+```
+
+(`strings` is already imported in taskworker.go.)
+
+- [ ] **Step 2: Build**
+
+Run: `cd /Users/doozyx/DoozyX/Adaptam/ui/agent-deck && go build ./...`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/session/taskworker.go
+git commit -m "feat(session): record task-worker completions to the ledger"
+```
+
+---
+
+### Task 4: `session children` subcommand
+
+**Files:**
+- Modify: `cmd/agent-deck/session_cmd.go` (dispatch switch ~line 84, new handler, help text)
+- Test: `cmd/agent-deck/session_children_test.go`
+
+- [ ] **Step 1: Write the failing test (pure filtering helper)**
+
+Add a small pure helper `childrenOf(parentID, instances)` so filtering is unit-testable without a live registry.
+
+```go
+package main
+
+import (
+	"testing"
+
+	"github.com/<module>/internal/session" // replace with actual module path from go.mod
+)
+
+func TestChildrenOfFiltersByParent(t *testing.T) {
+	a := &session.Instance{ID: "p"}
+	b := &session.Instance{ID: "c1", ParentSessionID: "p"}
+	c := &session.Instance{ID: "c2", ParentSessionID: "other"}
+	d := &session.Instance{ID: "c3", ParentSessionID: "p"}
+	got := childrenOf("p", []*session.Instance{a, b, c, d})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 children, got %d", len(got))
+	}
+	if got[0].ID != "c1" || got[1].ID != "c3" {
+		t.Fatalf("unexpected children: %v %v", got[0].ID, got[1].ID)
+	}
+}
+```
+
+Confirm the module path first: `head -1 go.mod`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/doozyx/DoozyX/Adaptam/ui/agent-deck && go test ./cmd/agent-deck/ -run TestChildrenOf -v`
+Expected: FAIL — undefined `childrenOf`.
+
+- [ ] **Step 3: Implement helper + handler + dispatch**
+
+Add to `session_cmd.go`:
+
+```go
+func childrenOf(parentID string, instances []*session.Instance) []*session.Instance {
+	var out []*session.Instance
+	for _, inst := range instances {
+		if inst != nil && inst.ParentSessionID == parentID {
+			out = append(out, inst)
+		}
+	}
+	return out
+}
+
+func handleSessionChildren(profile string, args []string) {
+	fs := flag.NewFlagSet("session children", flag.ExitOnError)
+	jsonOutput := fs.Bool("json", false, "Output as JSON")
+	quiet := fs.Bool("quiet", false, "Minimal output")
+	quietShort := fs.Bool("q", false, "Minimal output (short)")
+	fs.Usage = func() {
+		fmt.Println("Usage: agent-deck session children [id|title] [options]")
+		fmt.Println()
+		fmt.Println("List a session's sub-sessions with live status and last completion.")
+		fmt.Println("Defaults to the current session. Read-only; does not clear the inbox.")
+		fmt.Println()
+		fmt.Println("Options:")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(normalizeArgs(fs, args)); err != nil {
+		os.Exit(1)
+	}
+	identifier := fs.Arg(0)
+	quietMode := *quiet || *quietShort
+	out := NewCLIOutput(*jsonOutput, quietMode)
+
+	_, instances, _, err := loadSessionData(profile)
+	if err != nil {
+		out.Error(err.Error(), ErrCodeNotFound)
+		os.Exit(1)
+	}
+	parent, errMsg, errCode := ResolveSessionOrCurrent(identifier, instances)
+	if parent == nil {
+		out.Error(errMsg, errCode)
+		os.Exit(2)
+	}
+
+	kids := childrenOf(parent.ID, instances)
+	session.RefreshInstancesForCLIStatus(kids)
+
+	type childRow struct {
+		ID          string `json:"id"`
+		Title       string `json:"title"`
+		Status      string `json:"status"`
+		DoneStatus  string `json:"done_status,omitempty"`
+		DoneSummary string `json:"done_summary,omitempty"`
+		DoneAt      string `json:"done_at,omitempty"`
+	}
+	rows := make([]childRow, 0, len(kids))
+	var human strings.Builder
+	fmt.Fprintf(&human, "Children of %s (%s):\n", parent.Title, parent.ID)
+	for _, k := range kids {
+		_ = k.UpdateStatus()
+		row := childRow{ID: k.ID, Title: k.Title, Status: StatusString(k.Status)}
+		if e, ok := session.ReadLedgerEntry(k.ID); ok {
+			row.DoneStatus = e.Status
+			row.DoneSummary = e.Summary
+			if !e.FinishedAt.IsZero() {
+				row.DoneAt = e.FinishedAt.Format(time.RFC3339)
+			}
+		}
+		rows = append(rows, row)
+		done := row.DoneStatus
+		if done == "" {
+			done = "-"
+		}
+		fmt.Fprintf(&human, "  %s  %-20s  %-8s  done=%s  %s\n", k.ID, k.Title, row.Status, done, row.DoneSummary)
+	}
+	if len(kids) == 0 {
+		human.WriteString("  (no sub-sessions)\n")
+	}
+	out.Print(human.String(), map[string]interface{}{"parent": parent.ID, "children": rows})
+}
+```
+
+Add to the dispatch switch (after the `case "output":` block ~line 84):
+
+```go
+	case "children":
+		handleSessionChildren(profile, args[1:])
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/doozyx/DoozyX/Adaptam/ui/agent-deck && go test ./cmd/agent-deck/ -run TestChildrenOf -v && go build ./...`
+Expected: PASS + clean build.
+
+- [ ] **Step 5: Add help line + commit**
+
+In `printSessionHelp` add a line near the `output` entry:
+```go
+	fmt.Println("  children [id]           List sub-sessions with status + last completion")
+```
+
+```bash
+git add cmd/agent-deck/session_cmd.go cmd/agent-deck/session_children_test.go
+git commit -m "feat(cli): add session children fleet view"
+```
+
+---
+
+### Task 5: `launch --assert-done`
+
+**Files:**
+- Modify: `cmd/agent-deck/launch_cmd.go`
+- Test: `cmd/agent-deck/launch_assert_done_test.go`
+
+- [ ] **Step 1: Write the failing test (pure append helper)**
+
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyAssertDoneAppendsSentinel(t *testing.T) {
+	got := applyAssertDone("do the thing", true)
+	if !strings.Contains(got, "===AGENTDECK_DONE===") {
+		t.Fatalf("expected sentinel instruction appended, got: %q", got)
+	}
+	if !strings.HasPrefix(got, "do the thing") {
+		t.Fatalf("expected original message preserved, got: %q", got)
+	}
+}
+
+func TestApplyAssertDoneDisabledIsNoop(t *testing.T) {
+	if got := applyAssertDone("msg", false); got != "msg" {
+		t.Fatalf("expected no-op when disabled, got: %q", got)
+	}
+}
+
+func TestApplyAssertDoneEmptyMessageStaysEmpty(t *testing.T) {
+	if got := applyAssertDone("", true); got != "" {
+		t.Fatalf("expected empty message untouched (nothing to attach to), got: %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/doozyx/DoozyX/Adaptam/ui/agent-deck && go test ./cmd/agent-deck/ -run TestApplyAssertDone -v`
+Expected: FAIL — undefined `applyAssertDone`.
+
+- [ ] **Step 3: Implement helper + wire flag**
+
+Add to `launch_cmd.go`:
+
+```go
+const assertDoneInstruction = "\n\n## Final step — assert completion\n" +
+	"When the task is fully done, print exactly this as the last line of your final message:\n" +
+	"  ===AGENTDECK_DONE=== status=ok summary=<what you accomplished, one line>\n" +
+	"Use status=fail if you could not complete it; put the blocker in the summary."
+
+func applyAssertDone(message string, enabled bool) string {
+	if !enabled || strings.TrimSpace(message) == "" {
+		return message
+	}
+	return message + assertDoneInstruction
+}
+```
+
+Wire the flags near the other `fs.*` declarations (~line 27):
+
+```go
+	assertDone := fs.Bool("assert-done", false, "Append a completion-sentinel instruction to the message (default on for -c claude)")
+	noAssertDone := fs.Bool("no-assert-done", false, "Disable the completion-sentinel instruction")
+```
+
+After `initialMessage := mergeFlags(*message, *messageShort)` (~line 177), resolve the effective toggle and apply. `*tool` / `*command` resolution already exists in this file — reuse the resolved tool variable used to set the session command (find the variable holding the tool, e.g. via `mergeFlags(*command, *commandShort)` or `*tool`); name it `resolvedTool` below:
+
+```go
+	assertDoneOn := *assertDone
+	if !*assertDone && !*noAssertDone && isClaudeTool(resolvedTool) {
+		assertDoneOn = true // default-on for Claude children
+	}
+	if *noAssertDone {
+		assertDoneOn = false
+	}
+	initialMessage = applyAssertDone(initialMessage, assertDoneOn)
+```
+
+Use the existing tool predicate `session.IsClaudeCompatible(resolvedTool)` instead of a new `isClaudeTool` if the tool string is available; otherwise gate on the command containing "claude". Confirm the exact resolved-tool variable name by reading lines 130-180 of `launch_cmd.go` during implementation.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/doozyx/DoozyX/Adaptam/ui/agent-deck && go test ./cmd/agent-deck/ -run TestApplyAssertDone -v && go build ./...`
+Expected: PASS + clean build.
+
+- [ ] **Step 5: Add help/example + commit**
+
+Add an example line in `launch`'s usage:
+```go
+		fmt.Println("  agent-deck launch . -c claude -m \"Refactor X\"   # auto-appends completion sentinel")
+```
+
+```bash
+git add cmd/agent-deck/launch_cmd.go cmd/agent-deck/launch_assert_done_test.go
+git commit -m "feat(cli): launch --assert-done appends completion sentinel (default-on for claude)"
+```
+
+---
+
+### Task 6: Full build + test sweep + manual smoke
+
+- [ ] **Step 1: Full package build + tests**
+
+Run: `cd /Users/doozyx/DoozyX/Adaptam/ui/agent-deck && go build ./... && go test ./internal/session/ ./cmd/agent-deck/ 2>&1 | tail -20`
+Expected: build clean, target tests pass. (Pre-existing unrelated failures in the wider suite are out of scope — note them, don't fix.)
+
+- [ ] **Step 2: Manual smoke (optional, requires install)**
+
+```bash
+go build -o /tmp/agent-deck ./cmd/agent-deck
+/tmp/agent-deck session children --json   # from inside a session: lists children, empty if none
+```
+
+- [ ] **Step 3: Final commit if any fixups**
+
+```bash
+git commit -am "test: fleet fan-out sweep fixups" || true
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** change 1 (persist completion) → Tasks 1-3 (ledger + both emit sites); change 2 (non-destructive fleet view) → Task 4 (`session children`, read-only); change 3 (reliable signaling) → Task 5 (`--assert-done`). Non-goals (no blocking wait, no manifest) respected.
+- **Placeholder scan:** module path in Task 4 test and resolved-tool variable name in Task 5 are explicitly flagged to confirm by reading the file during implementation — not silent TODOs.
+- **Type consistency:** `CompletionLedgerEntry` fields used identically in Tasks 1-4; `WriteLedgerEntry`/`ReadLedgerEntry` names consistent; `childrenOf` / `applyAssertDone` signatures match their tests.

--- a/internal/session/completion_ledger.go
+++ b/internal/session/completion_ledger.go
@@ -55,8 +55,20 @@ func WriteLedgerEntry(e CompletionLedgerEntry) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	// Per-write temp file: concurrent writes for the same child must not share a
+	// fixed ".tmp" name, or they clobber each other before rename and can lose or
+	// corrupt the last-known ledger state (this package runs with -race in CI).
+	f, err := os.CreateTemp(filepath.Dir(path), safeRecordName(e.ChildID)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer os.Remove(tmp)
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
 		return err
 	}
 	return os.Rename(tmp, path)

--- a/internal/session/completion_ledger.go
+++ b/internal/session/completion_ledger.go
@@ -1,0 +1,82 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CompletionLedgerEntry is the durable, non-destructive last-known completion
+// for a child session. Unlike the task-worker CompletionRecord (whose presence
+// makes the daemon stand down from poll-inference; see emitDoneSignals'
+// CompletionRecordExists guard), the ledger is purely informational: it records
+// the most recent asserted completion so a parent can query "which of my fleet
+// finished" without consuming any delivery event. Last-wins per child.
+type CompletionLedgerEntry struct {
+	ChildID    string    `json:"child_id"`
+	Profile    string    `json:"profile"`
+	Title      string    `json:"title,omitempty"`
+	Status     string    `json:"status"` // "ok" | "fail"
+	Summary    string    `json:"summary,omitempty"`
+	FinishedAt time.Time `json:"finished_at"`
+}
+
+func completionLedgerDir() (string, error) {
+	return runtimeDataPath("completion-ledger")
+}
+
+func completionLedgerPath(childID string) (string, error) {
+	dir, err := completionLedgerDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, safeRecordName(childID)+".json"), nil
+}
+
+// WriteLedgerEntry persists an entry atomically (tmp + rename), last-wins.
+func WriteLedgerEntry(e CompletionLedgerEntry) error {
+	if strings.TrimSpace(e.ChildID) == "" {
+		return errors.New("completion ledger: empty child id")
+	}
+	if e.FinishedAt.IsZero() {
+		e.FinishedAt = time.Now()
+	}
+	path, err := completionLedgerPath(e.ChildID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// ReadLedgerEntry returns the last-known completion for a child, if any. The
+// read is non-destructive — checking from a parent never consumes a delivery
+// event the conductor or another chat relies on.
+func ReadLedgerEntry(childID string) (CompletionLedgerEntry, bool) {
+	path, err := completionLedgerPath(childID)
+	if err != nil {
+		return CompletionLedgerEntry{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return CompletionLedgerEntry{}, false
+	}
+	var e CompletionLedgerEntry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return CompletionLedgerEntry{}, false
+	}
+	return e, true
+}

--- a/internal/session/completion_ledger_test.go
+++ b/internal/session/completion_ledger_test.go
@@ -1,0 +1,28 @@
+package session
+
+import "testing"
+
+func TestCompletionLedgerWriteReadLastWins(t *testing.T) {
+	if _, ok := ReadLedgerEntry("ledgertest-child-1"); ok {
+		t.Fatalf("expected no entry before write")
+	}
+	if err := WriteLedgerEntry(CompletionLedgerEntry{ChildID: "ledgertest-child-1", Profile: "p", Title: "T", Status: "ok", Summary: "first"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := WriteLedgerEntry(CompletionLedgerEntry{ChildID: "ledgertest-child-1", Profile: "p", Title: "T", Status: "fail", Summary: "second"}); err != nil {
+		t.Fatalf("write 2: %v", err)
+	}
+	got, ok := ReadLedgerEntry("ledgertest-child-1")
+	if !ok {
+		t.Fatalf("expected entry after write")
+	}
+	if got.Status != "fail" || got.Summary != "second" {
+		t.Fatalf("last-wins failed: got %+v", got)
+	}
+}
+
+func TestCompletionLedgerWriteRejectsEmptyID(t *testing.T) {
+	if err := WriteLedgerEntry(CompletionLedgerEntry{ChildID: "  "}); err == nil {
+		t.Fatalf("expected error on empty child id")
+	}
+}

--- a/internal/session/completion_ledger_test.go
+++ b/internal/session/completion_ledger_test.go
@@ -1,23 +1,68 @@
 package session
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+)
 
 func TestCompletionLedgerWriteReadLastWins(t *testing.T) {
-	if _, ok := ReadLedgerEntry("ledgertest-child-1"); ok {
+	const childID = "ledgertest-child-1"
+	// Isolate from any state a prior run left behind: the ledger path is a fixed,
+	// process-shared file, so without cleanup "expected no entry before write" is flaky.
+	if p, err := completionLedgerPath(childID); err == nil {
+		_ = os.Remove(p)
+		t.Cleanup(func() { _ = os.Remove(p) })
+	}
+	if _, ok := ReadLedgerEntry(childID); ok {
 		t.Fatalf("expected no entry before write")
 	}
-	if err := WriteLedgerEntry(CompletionLedgerEntry{ChildID: "ledgertest-child-1", Profile: "p", Title: "T", Status: "ok", Summary: "first"}); err != nil {
+	if err := WriteLedgerEntry(CompletionLedgerEntry{ChildID: childID, Profile: "p", Title: "T", Status: "ok", Summary: "first"}); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	if err := WriteLedgerEntry(CompletionLedgerEntry{ChildID: "ledgertest-child-1", Profile: "p", Title: "T", Status: "fail", Summary: "second"}); err != nil {
+	if err := WriteLedgerEntry(CompletionLedgerEntry{ChildID: childID, Profile: "p", Title: "T", Status: "fail", Summary: "second"}); err != nil {
 		t.Fatalf("write 2: %v", err)
 	}
-	got, ok := ReadLedgerEntry("ledgertest-child-1")
+	got, ok := ReadLedgerEntry(childID)
 	if !ok {
 		t.Fatalf("expected entry after write")
 	}
 	if got.Status != "fail" || got.Summary != "second" {
 		t.Fatalf("last-wins failed: got %+v", got)
+	}
+}
+
+// TestCompletionLedgerConcurrentWrites exercises the per-write temp file: many
+// goroutines writing the same child must never clobber each other's temp file
+// before rename, and the surviving entry must be a complete, parseable record
+// (not a torn half-write). Runs under -race in CI.
+func TestCompletionLedgerConcurrentWrites(t *testing.T) {
+	const childID = "ledgertest-concurrent"
+	if p, err := completionLedgerPath(childID); err == nil {
+		_ = os.Remove(p)
+		t.Cleanup(func() { _ = os.Remove(p) })
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			if err := WriteLedgerEntry(CompletionLedgerEntry{
+				ChildID: childID, Profile: "p", Status: "ok",
+				Summary: fmt.Sprintf("write-%d", n),
+			}); err != nil {
+				t.Errorf("concurrent write %d: %v", n, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	got, ok := ReadLedgerEntry(childID)
+	if !ok {
+		t.Fatalf("expected an entry after concurrent writes")
+	}
+	if got.Status != "ok" || got.Summary == "" {
+		t.Fatalf("got torn/incomplete entry: %+v", got)
 	}
 }
 

--- a/internal/session/taskworker.go
+++ b/internal/session/taskworker.go
@@ -247,6 +247,19 @@ func RunTaskWorker(childID, profile, title string, cmd *exec.Cmd) (CompletionRec
 	if err := WriteCompletionRecord(rec); err != nil {
 		return rec, err
 	}
+	// Mirror the finished completion into the non-destructive ledger so the
+	// task-worker fleet shows up in `session children` alongside interactive
+	// children. Best-effort; never fail the run on a ledger write.
+	if strings.TrimSpace(rec.Status) != "" {
+		_ = WriteLedgerEntry(CompletionLedgerEntry{
+			ChildID:    rec.ChildID,
+			Profile:    rec.Profile,
+			Title:      rec.Title,
+			Status:     rec.Status,
+			Summary:    rec.Summary,
+			FinishedAt: rec.FinishedAt,
+		})
+	}
 	return rec, nil
 }
 

--- a/internal/session/transition_daemon.go
+++ b/internal/session/transition_daemon.go
@@ -516,6 +516,18 @@ func (d *TransitionDaemon) emitDoneSignals(profile string, byID map[string]*Inst
 			d.lastDone[profile] = map[string]DoneSignal{}
 		}
 		d.lastDone[profile][id] = sig
+
+		// Record the completion to the non-destructive ledger so a parent can
+		// query `session children` without consuming the delivery event.
+		// Best-effort: a ledger failure must never block notification.
+		_ = WriteLedgerEntry(CompletionLedgerEntry{
+			ChildID:    id,
+			Profile:    profile,
+			Title:      inst.Title,
+			Status:     sig.Status,
+			Summary:    sig.Summary,
+			FinishedAt: hs.UpdatedAt,
+		})
 	}
 }
 

--- a/skills/fleet/SKILL.md
+++ b/skills/fleet/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: fleet
+description: Fan out a fleet of independent agent-deck child sessions from inside a session and check their progress non-blockingly. Use when the user wants to "launch several/N sessions", "fan out", "run agents in parallel", "spin up a fleet", "kick off background agents", or "check progress from the main session" without blocking — covers launching parented children, polling status + completion via `session children`, and collecting results via `session output`.
+metadata:
+  compatibility: "claude, opencode"
+---
+
+# Fleet
+
+Fan out several independent agent-deck child sessions from inside your current
+session, keep working, and check their progress on demand — **without blocking**
+and **without consuming any delivery events**.
+
+**Requires:** the `agent-deck session children` and `launch --assert-done`
+features. If `agent-deck session children --help` succeeds, you have them.
+
+## When to use
+
+Use this when the user wants more than one agent working at once and wants to
+supervise from the parent session — e.g. "launch 5 sessions to each tackle a
+file", "fan out these tasks", "spin up a fleet and tell me when they're done".
+
+This differs from the single sub-agent pattern in the `agent-deck` skill (one
+child + fire-&-forget / on-demand / blocking retrieval). Fleet is **many
+children + a non-blocking peek** across all of them.
+
+**Run from inside an agent-deck session.** Launching auto-parents each child to
+the launching session, which is what makes them show up nested in the TUI and
+routes their completion back to you. (If you are not in a session, the children
+still launch but won't be grouped under a parent.)
+
+## The loop
+
+### 1. Fan out (one `launch` per child; loop it)
+
+```bash
+agent-deck launch <path> -c claude --inherit-group -m "<task for this child>"
+```
+
+- **Auto-parents** to your current session — children appear nested under you in
+  the TUI session list, each with its own live status.
+- **Children land in your group automatically.** A child launched into a git
+  worktree auto-inherits the parent's group, so a worktree fleet stays
+  co-located with you with no extra flags. For a non-worktree path that doesn't
+  inherit, add `--inherit-group` to force it.
+- **Do NOT pass a custom `-g/--group` for fleet children.** An explicit group
+  overrides inheritance and drops the child into its own detached group
+  (e.g. a stray `fleet-issues` sitting next to — not under — your group). Leave
+  the group off and let it inherit; only set `-g` when you deliberately want a
+  child somewhere other than with the parent.
+- **`--assert-done` is on by default for `-c claude`**: the child's message gets
+  a final-step instruction to print the completion sentinel
+  (`===AGENTDECK_DONE=== status=ok summary=…`) so "done" is trustworthy.
+- Run it N times (different `<path>` and `-m` per child) to fan out a fleet.
+
+Useful flags:
+- `--inherit-group` — force the parent's group for a non-worktree child (worktree
+  children already inherit automatically).
+- `-t "<title>"` — give each child a readable title (otherwise auto-named).
+- `--no-assert-done` — skip the completion-sentinel instruction.
+- `--no-parent` — launch flat instead of nested (you lose completion routing).
+
+### 2. Keep working
+
+Nothing blocks. Do other work in this session, in any chat, while the fleet runs.
+
+### 3. Check progress (non-blocking, non-destructive)
+
+```bash
+agent-deck session children --json
+```
+
+Lists your sub-sessions with, per child: `id`, `title`, live `status`
+(running / waiting / idle / error), and the last asserted completion
+(`done_status` = ok|fail, `done_summary`, `done_at`). Defaults to the current
+session; pass an id/title to inspect another parent. **Read-only** — it never
+clears the inbox, so you can poll it as often as you like from any chat without
+disturbing the conductor or other readers.
+
+A child with a `done_status` has finished and asserted its result.
+
+### 4. Unblock a child that's waiting on you
+
+A child in `waiting` status has stopped and is asking for input (a question, a
+decision, a permission). This is **pushed to you by default**: a child's
+`running → waiting` transition is delivered to your inbox unless it was launched
+with `--no-transition-notify`. To answer it:
+
+```bash
+# See what the child is asking:
+agent-deck session output <child-id> --json
+# Send the answer (child keeps running afterward):
+agent-deck session send <child-id> "<your answer>"
+```
+
+`session send` flags: `--wait` (block until it finishes the turn, then print
+output), `--stream` (stream its JSONL events), `--no-wait` (fire and return),
+`--draft` (pre-fill the prompt without submitting). Default waits only until the
+child is ready to receive, then returns — so it does **not** freeze your session.
+
+You can send follow-ups any time, not just when a child is waiting — e.g. to
+add scope, redirect, or course-correct a still-running child.
+
+### 5. Collect a finished child's result
+
+```bash
+agent-deck session output <child-id> --json
+```
+
+Returns that child's latest full response. Use it once `session children` shows
+the child is done (or any time you want its current output).
+
+## Worked example
+
+```bash
+# Fan out 3 children, each on a different package:
+agent-deck launch ./pkg/a -c claude --inherit-group -t "lint-a" -m "Fix all lint errors in this package."
+agent-deck launch ./pkg/b -c claude --inherit-group -t "lint-b" -m "Fix all lint errors in this package."
+agent-deck launch ./pkg/c -c claude --inherit-group -t "lint-c" -m "Fix all lint errors in this package."
+
+# ...keep working, then whenever convenient:
+agent-deck session children --json
+#   → each child: status + done_status/done_summary
+
+# If a child shows status "waiting", see its question and answer it:
+agent-deck session output lint-a --json
+agent-deck session send lint-a "Yes, drop the deprecated shim — don't keep a fallback."
+
+# For each child reporting done, pull its result:
+agent-deck session output lint-a --json
+```
+
+## Supervision tools the parent can use
+
+All read-only / on-demand — none of them block your session:
+
+- `agent-deck session children [id] --json` — **the default monitor.** Live
+  status + last completion per child. Non-destructive (never clears the inbox),
+  so poll it as often as you like. Start here every heartbeat.
+- `agent-deck session output <id> --json` — a child's latest full response.
+- `agent-deck session send <id> "<msg>" [--wait|--stream|--no-wait|--draft]` —
+  send a follow-up / answer a `waiting` child.
+- `agent-deck status -q` — global count of sessions currently `waiting`; a cheap
+  coarse heartbeat across everything, not just your children.
+- `agent-deck inbox drain --json <your-session-id>` — **consumes** the pushed
+  completion events from your durable inbox (last-wins per child, deduped).
+  Optional: `session children` already surfaces the same `done_status` without
+  consuming anything, so only drain if you specifically want to clear the queue.
+- `agent-deck session stop <id>` / `agent-deck session remove <id>` — teardown.
+
+There is no always-on background watcher started for you — "monitored by
+default" means transition/completion events **queue** in your inbox; you still
+choose when to look (poll `session children`, or `inbox drain`).
+
+## Notes
+
+- **Completion signal:** trustworthy "done" comes from the child printing
+  `===AGENTDECK_DONE=== status=<ok|fail> summary=<one line>` as its last line.
+  `--assert-done` (default-on for Claude) bakes this into the child's prompt; a
+  child that never prints it shows live status but no `done_status`.
+- **Non-blocking by design:** there is intentionally no "wait until all finish"
+  command — checking is a cheap, repeatable query so a parent's other chats are
+  never frozen.
+- **Grouping:** worktree children inherit the parent's group automatically;
+  for non-worktree paths add `--inherit-group`. Never pass a custom `-g` for a
+  fleet child — it overrides inheritance and detaches the child into its own
+  group. If a fleet did scatter (a stray group, or per-branch groups), move them
+  back without restarting: `agent-deck group move <child-id> <parent-group>`,
+  then `agent-deck group delete <stray-group>` once it's empty.
+- **Stopping / cleanup:** `agent-deck session stop <id>` and
+  `agent-deck session remove <id>` (add `--force` if needed) tear a child down.


### PR DESCRIPTION
## Summary
Adds a non-blocking workflow for fanning out independent agent-deck child sessions from inside a session and checking their progress.

## What's included
- **Completion ledger** (`internal/session/completion_ledger.go`): a non-destructive store recording interactive and task-worker completions, used to wake an idle parent exactly once.
- **`session children`**: fleet view of parented child sessions; resolves the current session id via `AGENTDECK_INSTANCE_ID`.
- **`launch --inherit-group`** + auto-inherit of the parent group for worktree children, so a fanned-out fleet stays in the parent's group.
- **`launch --assert-done`**: appends a completion sentinel (default-on for `claude`) so completion is detectable.
- **fleet skill** (`skills/fleet/SKILL.md`) + design/plan docs; registers `./skills/fleet` in the marketplace.

## Tests
Cover the completion ledger, `session children`, `--assert-done`, and launch group inheritance. `go build` / `go vet` clean; package tests pass.

## Scope
`cmd/agent-deck` + `internal/session` + skill/docs — disjoint from other in-flight changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `session children` to list a session’s direct sub-sessions, including live status and last completion details (human + JSON).
  * Enhanced parent/group selection for `launch` with optional inheritance, including worktree-aware behavior.
  * Added launch completion sentinel controls (`--assert-done` / `--no-assert-done`), auto-enabled for Claude-compatible tools.
  * Introduced a durable completion ledger to retain child completion metadata.
* **Tests**
  * Expanded coverage for group inheritance logic, the new sentinel behavior, and completion ledger read/write behavior.
* **Chores**
  * Bumped version to **1.10.4** and updated marketplace plugin skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->