### PR TITLE
fix(tui): sink empty/archived-only groups below the view-mode divider

### DIFF
--- a/internal/session/group_view_mode.go
+++ b/internal/session/group_view_mode.go
@@ -59,9 +59,14 @@ type GroupActivity struct {
 	HasActive bool // group (or a descendant) has at least one active session
 }
 
-// GroupActivityMap returns per-group-path activity aggregated over all sessions
-// in the tree (collapse-agnostic), propagated to ancestor paths.
-func (t *GroupTree) GroupActivityMap() map[string]GroupActivity {
+// GroupActivityMap returns per-group-path activity aggregated over the sessions
+// in the tree (collapse-agnostic), propagated to ancestor paths. Only sessions
+// matching the current archive view are counted: with viewArchived=false
+// (the normal active view) archived sessions are ignored, so a group whose
+// sessions are ALL archived reports HasAny=false and is treated as empty for
+// view-mode placement — it sinks below the divider with the other empty groups
+// rather than masquerading as a collapsed-but-populated group on top.
+func (t *GroupTree) GroupActivityMap(viewArchived bool) map[string]GroupActivity {
 	m := make(map[string]GroupActivity)
 	mark := func(path string, active bool) {
 		if path == "" {
@@ -80,6 +85,9 @@ func (t *GroupTree) GroupActivityMap() map[string]GroupActivity {
 	}
 	for _, g := range t.Groups {
 		for _, s := range g.Sessions {
+			if s.IsArchived() != viewArchived {
+				continue
+			}
 			mark(g.Path, isActiveStatus(s.Status))
 		}
 	}

--- a/internal/ui/group_view_mode_wiring_test.go
+++ b/internal/ui/group_view_mode_wiring_test.go
@@ -7,6 +7,7 @@ package ui
 
 import (
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -115,6 +116,45 @@ func TestPopulatedTopWiringSinksEmptyGroup(t *testing.T) {
 	}
 	if !emptyBelow {
 		t.Fatal("empty group 'empties' must appear below the divider")
+	}
+}
+
+// Regression: once ANY session is archived, hasArchivedSessions() flips true and
+// the archive-partition pass in rebuildFlatItems engages. That pass previously
+// dropped every group not in archiveGroupsWithMatches — including empty groups and
+// groups holding only active sessions in a parent that also had matches — so the
+// empty "empties" group vanished entirely instead of sinking below the divider.
+func TestPopulatedTopWiringSinksEmptyGroupWithArchivedSession(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+
+	// Archive one real session so hasArchivedSessions() returns true and the
+	// archive-partition pass runs (mirrors the user having archived something).
+	home.instancesMu.Lock()
+	for _, inst := range home.instances {
+		if inst.Title == "b2" {
+			inst.ArchivedAt = time.Now().UTC()
+		}
+	}
+	home.instancesMu.Unlock()
+
+	// Add an empty group with no sessions.
+	home.groupTree.CreateGroup("empties")
+	home.groupViewMode = session.GroupViewPopulatedTop
+	home.rebuildFlatItems()
+
+	div := dividerIndex(home)
+	if div < 0 {
+		t.Fatalf("expected a divider when an empty group exists alongside populated ones")
+	}
+	// The empty group header must still appear, below the divider.
+	emptyBelow := false
+	for i := div + 1; i < len(home.flatItems); i++ {
+		if home.flatItems[i].Type == session.ItemTypeGroup && home.flatItems[i].Path == "empties" {
+			emptyBelow = true
+		}
+	}
+	if !emptyBelow {
+		t.Fatalf("empty group 'empties' must appear below the divider even when a session is archived; flatItems=%d divider=%d", len(home.flatItems), div)
 	}
 }
 

--- a/internal/ui/group_view_mode_wiring_test.go
+++ b/internal/ui/group_view_mode_wiring_test.go
@@ -158,6 +158,53 @@ func TestPopulatedTopWiringSinksEmptyGroupWithArchivedSession(t *testing.T) {
 	}
 }
 
+// In populated-on-top view, a group whose sessions are ALL archived is empty
+// from the active view's perspective, so it must sink below the divider with the
+// other empty groups — not stay on top as if populated. The placement is driven
+// by GroupActivityMap, which must therefore ignore archived sessions in the
+// active view.
+func TestPopulatedTopWiringSinksFullyArchivedGroup(t *testing.T) {
+	home, _ := buildTwoGroupHome(t)
+
+	// Archive every session in beta (b1, b2). alpha (a1..a3) stays active.
+	home.instancesMu.Lock()
+	for _, inst := range home.instances {
+		if inst.Title == "b1" || inst.Title == "b2" {
+			inst.ArchivedAt = time.Now().UTC()
+		}
+	}
+	home.instancesMu.Unlock()
+
+	home.groupViewMode = session.GroupViewPopulatedTop
+	home.rebuildFlatItems()
+
+	div := dividerIndex(home)
+	if div < 0 {
+		t.Fatalf("expected a divider: alpha is populated, beta is fully archived (empty in active view)")
+	}
+	// alpha's active sessions stay above the divider.
+	for _, title := range []string{"a1", "a2", "a3"} {
+		if idx := sessionIndexByTitle(home, title); idx < 0 || idx >= div {
+			t.Fatalf("active session %q must be above the divider: idx=%d divider=%d", title, idx, div)
+		}
+	}
+	// The fully-archived beta group header must appear below the divider.
+	betaBelow := false
+	betaAbove := false
+	for i, it := range home.flatItems {
+		if it.Type == session.ItemTypeGroup && it.Path == "beta" {
+			if i > div {
+				betaBelow = true
+			} else {
+				betaAbove = true
+			}
+		}
+	}
+	if betaAbove || !betaBelow {
+		t.Fatalf("fully-archived group 'beta' must appear only below the divider: above=%v below=%v divider=%d", betaAbove, betaBelow, div)
+	}
+}
+
 func TestActiveTopWiringCollapsedRunningGroupStaysTop(t *testing.T) {
 	home, _ := buildTwoGroupHome(t)
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1868,7 +1868,13 @@ func (h *Home) rebuildFlatItems() {
 		partitioned := make([]session.Item, 0, len(allItems))
 		for _, item := range allItems {
 			if item.Type == session.ItemTypeGroup {
-				if groupsWithMatches[item.Path] {
+				// Archived view: only show groups that actually contain archived
+				// sessions. Active view: keep every group header — groups are never
+				// themselves archived, so empty groups and groups whose sessions are
+				// all archived remain part of the active list (they render as empty
+				// groups, same as before anything was archived) and can sink under
+				// the view-mode divider instead of vanishing.
+				if !viewArchived || groupsWithMatches[item.Path] {
 					partitioned = append(partitioned, item)
 				}
 			} else if item.Type == session.ItemTypeSession && item.Session != nil {

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -1949,8 +1949,10 @@ func (h *Home) rebuildFlatItems() {
 	if h.groupViewMode != session.GroupViewNormal {
 		// Activity is computed from the full tree (collapse-agnostic) so a
 		// collapsed-but-populated group's header is placed by its real contents,
-		// not by the (absent) session rows under a collapsed header.
-		activity := h.groupTree.GroupActivityMap()
+		// not by the (absent) session rows under a collapsed header. It honors the
+		// archive view so a group whose sessions are all archived counts as empty
+		// in the active view and sinks below the divider.
+		activity := h.groupTree.GroupActivityMap(viewArchived)
 		h.flatItems = session.PartitionByViewMode(h.flatItems, h.groupViewMode, activity)
 	}
 


### PR DESCRIPTION
## Summary
In the populated-on-top view mode, empty and fully-archived groups were not being placed correctly relative to the view-mode divider. This keeps them in the active view and sinks them below the divider so they don't disappear or float above populated groups.

## Changes
- `internal/session/group_view_mode.go` — partition logic sinks fully-archived/empty groups below the divider.
- `internal/ui/home.go` — `rebuildFlatItems` keeps empty/archived-only groups in the active view.

## Tests
- `internal/ui/group_view_mode_wiring_test.go` — empty/archived-only groups stay visible and sink under the divider.

`go build` / `go vet` clean; tests pass.

## Scope
The `internal/ui/home.go` touches are confined to `rebuildFlatItems` — disjoint from other in-flight changes.