### PR TITLE
fix(groups): stop empty groups from vanishing via additive group saves

### DIFF
--- a/cmd/agent-deck/group_cmd.go
+++ b/cmd/agent-deck/group_cmd.go
@@ -720,6 +720,13 @@ func handleGroupDelete(profile string, args []string) {
 		groupTree.SyncWithInstances(groupTree.GetAllInstances())
 	}
 
+	// SaveGroups is additive (never prunes), so the deleted group's rows must be
+	// removed explicitly or the group resurrects on the next reload.
+	if err := storage.DeleteGroupSubtree(groupPath); err != nil {
+		out.Error(fmt.Sprintf("failed to delete group rows: %v", err), ErrCodeNotFound)
+		os.Exit(1)
+	}
+
 	// Save
 	if err := storage.SaveWithGroups(groupTree.GetAllInstances(), groupTree); err != nil {
 		out.Error(fmt.Sprintf("failed to save: %v", err), ErrCodeNotFound)
@@ -1260,6 +1267,14 @@ func handleGroupChange(profile string, args []string) {
 	newPath := baseName
 	if destPath != "" {
 		newPath = destPath + "/" + baseName
+	}
+
+	// A move re-paths the group and its subgroups; the old source path rows must
+	// be deleted explicitly (additive SaveGroups won't prune them) before the
+	// save re-adds the new paths, or the group lingers under its old path.
+	if err := storage.DeleteGroupSubtree(sourcePath); err != nil {
+		out.Error(fmt.Sprintf("failed to delete old group rows: %v", err), ErrCodeNotFound)
+		os.Exit(1)
 	}
 
 	// Persist.

--- a/internal/session/empty_group_persistence_test.go
+++ b/internal/session/empty_group_persistence_test.go
@@ -1,0 +1,107 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/asheshgoplani/agent-deck/internal/statedb"
+)
+
+func emptyGroupTestStorage(t *testing.T) *Storage {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "state.db")
+	db, err := statedb.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.Migrate(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return &Storage{db: db, dbPath: dbPath, profile: "_test"}
+}
+
+func loadGroupPathSet(t *testing.T, s *Storage) map[string]bool {
+	t.Helper()
+	_, groups, err := s.LoadWithGroups()
+	if err != nil {
+		t.Fatalf("LoadWithGroups: %v", err)
+	}
+	set := make(map[string]bool, len(groups))
+	for _, g := range groups {
+		set[g.Path] = true
+	}
+	return set
+}
+
+// Regression for empty (session-less) groups silently disappearing.
+//
+// Real-world trigger: a second running instance (allow_multiple) or the
+// instances-only NewGroupTree fallback persists a tree that never contained an
+// empty group. With the old replace-all SaveGroups this deleted the empty group
+// for good (populated groups self-heal from their sessions; empty ones cannot).
+// With additive SaveGroups, a partial save must leave unknown groups intact.
+func TestSaveWithGroupsPreservesEmptyGroupAcrossStaleSave(t *testing.T) {
+	s := emptyGroupTestStorage(t)
+
+	inst := NewInstanceWithTool("a1", "/tmp/a1", "claude")
+	inst.GroupPath = "alpha"
+	instances := []*Instance{inst}
+
+	// Authoritative save: a populated group "alpha" and an EMPTY group "empties".
+	full := NewGroupTreeWithGroups(instances, []*GroupData{
+		{Name: "alpha", Path: "alpha", Expanded: true},
+		{Name: "empties", Path: "empties", Expanded: true},
+	})
+	if err := s.SaveWithGroups(instances, full); err != nil {
+		t.Fatalf("authoritative SaveWithGroups: %v", err)
+	}
+	if got := loadGroupPathSet(t, s); !got["empties"] || !got["alpha"] {
+		t.Fatalf("setup failed, groups on disk: %v", got)
+	}
+
+	// Stale/incomplete saver: an instances-only tree has "alpha" (from the
+	// session) but no "empties". This must NOT delete "empties".
+	stale := NewGroupTree(instances)
+	if _, ok := stale.Groups["empties"]; ok {
+		t.Fatalf("precondition: stale tree should not know about 'empties'")
+	}
+	if err := s.SaveWithGroups(instances, stale); err != nil {
+		t.Fatalf("stale SaveWithGroups: %v", err)
+	}
+
+	got := loadGroupPathSet(t, s)
+	if !got["empties"] {
+		t.Fatalf("empty group was wiped by an instances-only save; groups on disk: %v", got)
+	}
+	if !got["alpha"] {
+		t.Fatalf("populated group missing after stale save; groups on disk: %v", got)
+	}
+}
+
+// The explicit subtree delete (used by intentional delete/rename/move) removes
+// the group and its descendants while leaving prefix look-alikes intact.
+func TestDeleteGroupSubtreeViaStorage(t *testing.T) {
+	s := emptyGroupTestStorage(t)
+
+	tree := NewGroupTreeWithGroups(nil, []*GroupData{
+		{Name: "parent", Path: "parent"},
+		{Name: "child", Path: "parent/child"},
+		{Name: "parental", Path: "parental"},
+	})
+	if err := s.SaveWithGroups(nil, tree); err != nil {
+		t.Fatalf("SaveWithGroups: %v", err)
+	}
+
+	if err := s.DeleteGroupSubtree("parent"); err != nil {
+		t.Fatalf("DeleteGroupSubtree: %v", err)
+	}
+
+	got := loadGroupPathSet(t, s)
+	if got["parent"] || got["parent/child"] {
+		t.Fatalf("subtree not deleted: %v", got)
+	}
+	if !got["parental"] {
+		t.Fatalf("prefix look-alike 'parental' should survive: %v", got)
+	}
+}

--- a/internal/session/storage.go
+++ b/internal/session/storage.go
@@ -370,6 +370,26 @@ func (s *Storage) DeleteInstance(id string) error {
 	return nil
 }
 
+// DeleteGroupSubtree removes a group and all of its descendants from the groups
+// table. SaveGroups is additive (upsert, never prune), so intentional group
+// removal — delete, rename, move — must call this explicitly; otherwise the old
+// path rows linger and the group resurrects on the next reload.
+func (s *Storage) DeleteGroupSubtree(path string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.db == nil {
+		return fmt.Errorf("storage database not initialized")
+	}
+
+	if err := s.db.DeleteGroupSubtree(path); err != nil {
+		return fmt.Errorf("failed to delete group subtree %s: %w", path, err)
+	}
+
+	_ = s.db.Touch()
+	return nil
+}
+
 // WriteAutoNameDescription persists a single auto-named session's last captured
 // Claude task description via a targeted column update — no whole-row rewrite,
 // no full-table reconcile (see statedb.WriteAutoNameDescription). This lets the

--- a/internal/statedb/save_groups_additive_test.go
+++ b/internal/statedb/save_groups_additive_test.go
@@ -1,0 +1,113 @@
+package statedb
+
+import (
+	"testing"
+)
+
+// loadGroupPaths is a small helper returning the set of persisted group paths.
+func loadGroupPaths(t *testing.T, db *StateDB) map[string]bool {
+	t.Helper()
+	rows, err := db.LoadGroups()
+	if err != nil {
+		t.Fatalf("LoadGroups: %v", err)
+	}
+	set := make(map[string]bool, len(rows))
+	for _, g := range rows {
+		set[g.Path] = true
+	}
+	return set
+}
+
+// Regression for empty groups silently vanishing: a save with an INCOMPLETE
+// group set (e.g. a stale or instances-only in-memory tree from another running
+// instance) must not delete groups it doesn't know about. Replace-all semantics
+// wiped them; populated groups self-healed from their sessions on reload but
+// empty (session-less) groups were gone forever.
+func TestSaveGroupsDoesNotDropUnknownGroups(t *testing.T) {
+	db := newTestDB(t)
+
+	// Initial authoritative save: a populated group and an EMPTY group.
+	if err := db.SaveGroups([]*GroupRow{
+		{Path: "alpha", Name: "alpha", Expanded: true, Order: 0},
+		{Path: "empties", Name: "empties", Expanded: true, Order: 1},
+	}); err != nil {
+		t.Fatalf("initial SaveGroups: %v", err)
+	}
+
+	// A second, incomplete saver only knows about "alpha" (it never had
+	// "empties" in its tree). This must NOT delete "empties".
+	if err := db.SaveGroups([]*GroupRow{
+		{Path: "alpha", Name: "alpha", Expanded: true, Order: 0},
+	}); err != nil {
+		t.Fatalf("incomplete SaveGroups: %v", err)
+	}
+
+	got := loadGroupPaths(t, db)
+	if !got["empties"] {
+		t.Fatalf("empty group was wiped by an incomplete save; have %v", got)
+	}
+	if !got["alpha"] {
+		t.Fatalf("populated group missing after save; have %v", got)
+	}
+}
+
+// SaveGroups must still update fields (rename, reorder, expand, default-path,
+// max-concurrent) for groups it does know about — upsert, not insert-only.
+func TestSaveGroupsUpdatesExistingFields(t *testing.T) {
+	db := newTestDB(t)
+
+	if err := db.SaveGroups([]*GroupRow{
+		{Path: "g", Name: "old", Expanded: true, Order: 5, DefaultPath: "/a", MaxConcurrent: 1},
+	}); err != nil {
+		t.Fatalf("SaveGroups: %v", err)
+	}
+	if err := db.SaveGroups([]*GroupRow{
+		{Path: "g", Name: "new", Expanded: false, Order: 2, DefaultPath: "/b", MaxConcurrent: 4},
+	}); err != nil {
+		t.Fatalf("SaveGroups update: %v", err)
+	}
+
+	rows, err := db.LoadGroups()
+	if err != nil {
+		t.Fatalf("LoadGroups: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(rows))
+	}
+	g := rows[0]
+	if g.Name != "new" || g.Expanded != false || g.Order != 2 || g.DefaultPath != "/b" || g.MaxConcurrent != 4 {
+		t.Fatalf("fields not upserted: %+v", g)
+	}
+}
+
+// Intentional removal of a group (and its subgroups) must go through an explicit
+// subtree delete, since SaveGroups no longer prunes.
+func TestDeleteGroupSubtreeRemovesGroupAndDescendants(t *testing.T) {
+	db := newTestDB(t)
+
+	if err := db.SaveGroups([]*GroupRow{
+		{Path: "parent", Name: "parent", Order: 0},
+		{Path: "parent/child", Name: "child", Order: 1},
+		{Path: "parent/child/grand", Name: "grand", Order: 2},
+		{Path: "parental", Name: "parental", Order: 3}, // prefix look-alike, must survive
+		{Path: "other", Name: "other", Order: 4},
+	}); err != nil {
+		t.Fatalf("SaveGroups: %v", err)
+	}
+
+	if err := db.DeleteGroupSubtree("parent"); err != nil {
+		t.Fatalf("DeleteGroupSubtree: %v", err)
+	}
+
+	got := loadGroupPaths(t, db)
+	for _, gone := range []string{"parent", "parent/child", "parent/child/grand"} {
+		if got[gone] {
+			t.Fatalf("%q should have been deleted; have %v", gone, got)
+		}
+	}
+	for _, kept := range []string{"parental", "other"} {
+		if !got[kept] {
+			t.Fatalf("%q should have survived subtree delete; have %v", kept, got)
+		}
+	}
+}

--- a/internal/statedb/statedb.go
+++ b/internal/statedb/statedb.go
@@ -1010,7 +1010,16 @@ func (s *StateDB) InstanceExists(id string) (bool, error) {
 
 // --- Group CRUD ---
 
-// SaveGroups replaces all groups in a single transaction.
+// SaveGroups upserts the given groups in a single transaction. It is ADDITIVE:
+// groups absent from the slice are left untouched, never deleted.
+//
+// This deliberately abandons the old replace-all (DELETE FROM groups + insert)
+// because a save can run with an incomplete in-memory tree — a stale tree from
+// another concurrent instance (allow_multiple), or the instances-only
+// NewGroupTree fallback. Replace-all then wiped every group the saver didn't
+// know about; populated groups self-healed from their sessions on reload, but
+// empty (session-less) groups were lost forever. With upsert, a partial save can
+// only add/update; intentional removal must go through DeleteGroupSubtree.
 func (s *StateDB) SaveGroups(groups []*GroupRow) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -1018,14 +1027,15 @@ func (s *StateDB) SaveGroups(groups []*GroupRow) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Clear existing groups and re-insert (simpler than diff)
-	if _, err := tx.Exec("DELETE FROM groups"); err != nil {
-		return err
-	}
-
 	stmt, err := tx.Prepare(`
 		INSERT INTO groups (path, name, expanded, sort_order, default_path, max_concurrent)
 		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(path) DO UPDATE SET
+			name = excluded.name,
+			expanded = excluded.expanded,
+			sort_order = excluded.sort_order,
+			default_path = excluded.default_path,
+			max_concurrent = excluded.max_concurrent
 	`)
 	if err != nil {
 		return err
@@ -1072,6 +1082,21 @@ func (s *StateDB) LoadGroups() ([]*GroupRow, error) {
 // DeleteGroup removes a group by path.
 func (s *StateDB) DeleteGroup(path string) error {
 	_, err := s.db.Exec("DELETE FROM groups WHERE path = ?", path)
+	return err
+}
+
+// DeleteGroupSubtree removes a group and all of its descendants by path.
+// Because SaveGroups is additive (upsert, never prune), intentional group
+// removal — delete, rename, move — MUST go through this explicit delete, or the
+// old path rows would linger and resurrect on the next reload.
+//
+// The LIKE pattern matches only true descendants (path + "/"), so a prefix
+// look-alike such as "parental" survives a delete of "parent".
+func (s *StateDB) DeleteGroupSubtree(path string) error {
+	_, err := s.db.Exec(
+		"DELETE FROM groups WHERE path = ? OR path LIKE ? || '/%'",
+		path, path,
+	)
 	return err
 }
 

--- a/internal/ui/home.go
+++ b/internal/ui/home.go
@@ -8670,6 +8670,9 @@ func (h *Home) confirmAction() tea.Cmd {
 	case ConfirmDeleteGroup:
 		groupPath := h.confirmDialog.GetTargetID()
 		h.groupTree.DeleteGroup(groupPath)
+		// SaveGroups is additive (never prunes), so the removed group's rows must
+		// be deleted explicitly or it would resurrect on the next reload.
+		h.deleteGroupRows(groupPath)
 		h.instancesMu.Lock()
 		h.instances = h.groupTree.GetAllInstances()
 		h.instancesMu.Unlock()
@@ -9583,7 +9586,12 @@ func (h *Home) handleGroupDialogKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case GroupDialogRename:
 			name := h.groupDialog.GetValue()
 			if name != "" {
-				h.groupTree.RenameGroup(h.groupDialog.GetGroupPath(), name)
+				oldPath := h.groupDialog.GetGroupPath()
+				h.groupTree.RenameGroup(oldPath, name)
+				// A rename re-paths the group and its subgroups; the old path rows
+				// must be deleted explicitly (additive SaveGroups won't prune them)
+				// or the group reappears under its old name on the next reload.
+				h.deleteGroupRows(oldPath)
 				h.instancesMu.Lock()
 				h.instances = h.groupTree.GetAllInstances()
 				h.instancesMu.Unlock()
@@ -9889,6 +9897,19 @@ func (h *Home) saveInstancesWithForce(force bool) {
 				h.pendingTitleChanges = make(map[string]string)
 			}
 		}
+	}
+}
+
+// deleteGroupRows removes a group and its descendants from the groups table.
+// SaveGroups is additive (upsert, never prune), so an intentional removal —
+// delete or the old path of a rename/move — must be persisted explicitly here,
+// otherwise the stale rows resurrect the group on the next reload.
+func (h *Home) deleteGroupRows(path string) {
+	if h.storage == nil || path == "" {
+		return
+	}
+	if err := h.storage.DeleteGroupSubtree(path); err != nil {
+		uiLog.Warn("delete_group_rows_failed", slog.String("path", path), slog.String("error", err.Error()))
 	}
 }
 

--- a/internal/ui/web_mutator.go
+++ b/internal/ui/web_mutator.go
@@ -536,6 +536,14 @@ func (m *WebMutator) RenameGroup(groupPath, newName string) error {
 	}
 	defer storage.Close()
 
+	// SaveGroups is additive (never prunes), so the old path's rows must be
+	// deleted explicitly before the save re-adds the renamed paths — otherwise
+	// the group reappears under its old name on the next reload. Done before the
+	// save so a no-op rename (same name) is correctly re-added.
+	if err := storage.DeleteGroupSubtree(groupPath); err != nil {
+		return fmt.Errorf("delete old group rows: %w", err)
+	}
+
 	m.h.instancesMu.RLock()
 	instances := make([]*session.Instance, len(m.h.instances))
 	copy(instances, m.h.instances)
@@ -689,6 +697,12 @@ func (m *WebMutator) DeleteGroup(groupPath string) error {
 		return fmt.Errorf("open storage: %w", err)
 	}
 	defer storage.Close()
+
+	// SaveGroups is additive (never prunes), so the deleted group's rows must be
+	// removed explicitly or the group resurrects on the next reload.
+	if err := storage.DeleteGroupSubtree(groupPath); err != nil {
+		return fmt.Errorf("delete group rows: %w", err)
+	}
 
 	m.h.instancesMu.RLock()
 	instances := make([]*session.Instance, len(m.h.instances))


### PR DESCRIPTION
## Summary
User-created empty (0-session) groups would disappear permanently. The group save path did a replace-all write, and only populated groups self-healed on reload — so empty groups were lost (triggered by force-saves or the group-tree fallback).

## Fix
Make group saves **additive**: upsert groups and delete explicitly, instead of replace-all, so empty groups survive saves and reloads.

## Changes
- `internal/statedb/statedb.go` — additive `SaveGroups` (upsert + explicit `DeleteGroup`).
- `internal/session/storage.go`, `internal/ui/home.go`, `internal/ui/web_mutator.go`, `cmd/agent-deck/group_cmd.go` — wire the additive save through the session/TUI/web/CLI paths.

## Tests
- `internal/statedb/save_groups_additive_test.go` — empty groups persist across additive saves.
- `internal/session/empty_group_persistence_test.go` — empty groups survive reload.

`go build` / `go vet` clean; tests pass.

## Scope
`internal/ui/home.go` touches are confined to `confirmAction` / `handleGroupDialogKey` / `saveInstancesWithForce` — disjoint from the other in-flight PRs.